### PR TITLE
feat(acp): add session-scoped runtime MCP

### DIFF
--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -11826,6 +11826,110 @@ describe('createAcpSessionBridge', () => {
     });
   });
 
+  describe('session-scoped runtime MCP servers', () => {
+    it('routes add and remove to the selected live session only', async () => {
+      const calls: Array<{
+        method: string;
+        params: Record<string, unknown>;
+      }> = [];
+      const factory: ChannelFactory = async () => {
+        const { clientStream, agentStream } = createInMemoryChannel();
+        const agent = new FakeAgent({
+          extMethodImpl: (method, params) => {
+            calls.push({ method, params });
+            if (method === SERVE_CONTROL_EXT_METHODS.sessionMcpRuntimeAdd) {
+              return Promise.resolve({
+                name: params['name'],
+                transport: 'sdk',
+                replaced: false,
+                shadowedSettings: false,
+                toolCount: 1,
+                originatorClientId: params['originatorClientId'],
+              });
+            }
+            if (method === SERVE_CONTROL_EXT_METHODS.sessionMcpRuntimeRemove) {
+              return Promise.resolve({
+                name: params['name'],
+                removed: true,
+                wasShadowingSettings: false,
+                originatorClientId: params['originatorClientId'],
+              });
+            }
+            return Promise.resolve({});
+          },
+        });
+        new AgentSideConnection(() => agent as Agent, agentStream);
+        return {
+          stream: clientStream,
+          exited: new Promise<
+            | { exitCode: number | null; signalCode: NodeJS.Signals | null }
+            | undefined
+          >(() => {}),
+          kill: async () => {},
+          killSync: () => {},
+        };
+      };
+      const bridge = makeBridge({
+        sessionScope: 'thread',
+        channelFactory: factory,
+      });
+      await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const target = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+
+      await bridge.addSessionRuntimeMcpServer(
+        target.sessionId,
+        'channel-loop',
+        { type: 'sdk' },
+        'daemon-channel',
+      );
+      await bridge.removeSessionRuntimeMcpServer(
+        target.sessionId,
+        'channel-loop',
+        'daemon-channel',
+      );
+
+      expect(calls.slice(-2)).toEqual([
+        {
+          method: SERVE_CONTROL_EXT_METHODS.sessionMcpRuntimeAdd,
+          params: {
+            sessionId: target.sessionId,
+            name: 'channel-loop',
+            config: { type: 'sdk' },
+            originatorClientId: 'daemon-channel',
+          },
+        },
+        {
+          method: SERVE_CONTROL_EXT_METHODS.sessionMcpRuntimeRemove,
+          params: {
+            sessionId: target.sessionId,
+            name: 'channel-loop',
+            originatorClientId: 'daemon-channel',
+          },
+        },
+      ]);
+      await bridge.shutdown();
+    });
+
+    it('rejects an unknown session without falling back to a live channel', async () => {
+      const extMethodImpl = vi.fn().mockResolvedValue({});
+      const bridge = makeBridge({
+        channelFactory: async () => makeChannel({ extMethodImpl }).channel,
+      });
+      await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+
+      await expect(
+        bridge.addSessionRuntimeMcpServer('missing-session', 'channel-loop', {
+          type: 'sdk',
+        }),
+      ).rejects.toBeInstanceOf(SessionNotFoundError);
+      expect(extMethodImpl).not.toHaveBeenCalledWith(
+        SERVE_CONTROL_EXT_METHODS.sessionMcpRuntimeAdd,
+        expect.anything(),
+      );
+      await bridge.shutdown();
+    });
+  });
+
   describe('removeRuntimeMcpServer (T2.8 #4514)', () => {
     /**
      * Build a channel factory whose ACP `extMethod` handler returns a

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -133,6 +133,8 @@ import type {
   BridgeSessionTranscriptPageRequest,
   BridgeGenerationStreamEvent,
   BridgeWorkspaceGenerationStreamEvent,
+  RuntimeMcpServerAddResult,
+  RuntimeMcpServerRemoveResult,
 } from './bridgeTypes.js';
 import type {
   BridgeFreshSessionAdmissionContext,
@@ -8167,6 +8169,27 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         });
       }
       return response;
+    },
+
+    async addSessionRuntimeMcpServer(
+      sessionId,
+      name,
+      config,
+      originatorClientId,
+    ) {
+      return requestSessionStatus<RuntimeMcpServerAddResult>(
+        sessionId,
+        SERVE_CONTROL_EXT_METHODS.sessionMcpRuntimeAdd,
+        { name, config, originatorClientId },
+      );
+    },
+
+    async removeSessionRuntimeMcpServer(sessionId, name, originatorClientId) {
+      return requestSessionStatus<RuntimeMcpServerRemoveResult>(
+        sessionId,
+        SERVE_CONTROL_EXT_METHODS.sessionMcpRuntimeRemove,
+        { name, originatorClientId },
+      );
     },
 
     async killSession(sessionId, opts) {

--- a/packages/acp-bridge/src/bridgeClient.test.ts
+++ b/packages/acp-bridge/src/bridgeClient.test.ts
@@ -2834,6 +2834,90 @@ describe('BridgeClient — reverse tool channel (qwen/control/client_mcp/message
     expect((result as { payload?: unknown }).payload).toBeDefined();
   });
 
+  it('forwards the originating session id to the client MCP sender', async () => {
+    const contexts: unknown[] = [];
+    const sender: ClientMcpMessageSender = () => async (_payload, context) => {
+      contexts.push(context);
+      return { jsonrpc: '2.0', id: 1, result: {} };
+    };
+    const client = new BridgeClient(
+      (() => undefined) as never,
+      (() => undefined) as never,
+      { request: thrower } as never,
+      0,
+      Infinity,
+      undefined,
+      undefined,
+      undefined,
+      sender,
+    );
+
+    await client.extMethod('qwen/control/client_mcp/message', {
+      server: 'channel-loop',
+      sessionId: 'session-channel-1',
+      payload: { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+    });
+
+    expect(contexts).toEqual([{ sessionId: 'session-channel-1' }]);
+  });
+
+  it('rejects a malformed optional session id', async () => {
+    const sender: ClientMcpMessageSender = () => async () => ({
+      jsonrpc: '2.0',
+      id: 1,
+      result: {},
+    });
+    const client = new BridgeClient(
+      (() => undefined) as never,
+      (() => undefined) as never,
+      { request: thrower } as never,
+      0,
+      Infinity,
+      undefined,
+      undefined,
+      undefined,
+      sender,
+    );
+
+    await expect(
+      client.extMethod('qwen/control/client_mcp/message', {
+        server: 'channel-loop',
+        sessionId: '',
+        payload: { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+      }),
+    ).rejects.toMatchObject({ code: -32602 });
+  });
+
+  it('rejects a session id owned by another ACP channel', async () => {
+    const send = vi.fn().mockResolvedValue({
+      jsonrpc: '2.0',
+      id: 1,
+      result: {},
+    });
+    const sender: ClientMcpMessageSender = () => send;
+    const client = new BridgeClient(
+      (() => undefined) as never,
+      (() => undefined) as never,
+      { request: thrower } as never,
+      0,
+      Infinity,
+      undefined,
+      undefined,
+      undefined,
+      sender,
+      () => false,
+    );
+
+    await expect(
+      client.extMethod('qwen/control/client_mcp/message', {
+        server: 'channel-loop',
+        sessionId: 'foreign-session',
+        payload: { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+      }),
+    ).rejects.toMatchObject({ code: -32602 });
+    expect(send).not.toHaveBeenCalled();
+  });
+
   it('rejects (invalidParams) when the named server is not connected', async () => {
     const registrar = new ClientMcpRegistrar({ sendFrame: () => {} });
     // No registerServer call — the lookup returns undefined.

--- a/packages/acp-bridge/src/bridgeClient.ts
+++ b/packages/acp-bridge/src/bridgeClient.ts
@@ -1300,7 +1300,26 @@ export class BridgeClient implements Client {
         `client-hosted MCP server '${server}' is not currently connected`,
       );
     }
-    const response = await send(payload);
+    const sessionId = params['sessionId'];
+    if (
+      sessionId !== undefined &&
+      (typeof sessionId !== 'string' || sessionId.length === 0)
+    ) {
+      throw RequestError.invalidParams(
+        undefined,
+        '`sessionId` must be a non-empty string when provided',
+      );
+    }
+    if (typeof sessionId === 'string' && !this.ownsSession(sessionId)) {
+      throw RequestError.invalidParams(
+        undefined,
+        `Session not owned by this channel: ${sessionId}`,
+      );
+    }
+    const response = await send(
+      payload,
+      typeof sessionId === 'string' ? { sessionId } : undefined,
+    );
     return { payload: response as Record<string, unknown> };
   }
 

--- a/packages/acp-bridge/src/bridgeOptions.ts
+++ b/packages/acp-bridge/src/bridgeOptions.ts
@@ -464,9 +464,15 @@ export interface BridgeOptions {
  * package free of an MCP-SDK dependency; the serve layer passes a
  * `JSONRPCMessage`.
  */
+export interface ClientMcpMessageContext {
+  sessionId?: string;
+}
+
 export type ClientMcpMessageSender = (
   serverName: string,
-) => ((payload: unknown) => Promise<unknown>) | undefined;
+) =>
+  | ((payload: unknown, context?: ClientMcpMessageContext) => Promise<unknown>)
+  | undefined;
 
 /** Ceiling on a sub-session prompt arriving over `extMethod`. The child is a
  * separate process, so this is a trust boundary — mirrors the scheduled-task

--- a/packages/acp-bridge/src/bridgeTypes.ts
+++ b/packages/acp-bridge/src/bridgeTypes.ts
@@ -774,6 +774,30 @@ export type BridgeWorkspaceGenerationNotificationEvent = Exclude<
   { type: 'done' }
 >;
 
+export type RuntimeMcpServerAddResult =
+  | {
+      name: string;
+      transport: string;
+      replaced: boolean;
+      shadowedSettings: boolean;
+      toolCount: number;
+      originatorClientId: string;
+    }
+  | {
+      name: string;
+      skipped: true;
+      reason: 'budget_warning_only' | 'runtime_name_conflict';
+    };
+
+export type RuntimeMcpServerRemoveResult =
+  | {
+      name: string;
+      removed: true;
+      wasShadowingSettings: boolean;
+      originatorClientId: string;
+    }
+  | { name: string; skipped: true; reason: 'not_present' };
+
 export interface AcpSessionBridge {
   /** Read-only daemon diagnostics for status endpoints. */
   getDaemonStatusSnapshot(): BridgeDaemonStatusSnapshot;
@@ -1392,21 +1416,7 @@ export interface AcpSessionBridge {
     name: string,
     config: Record<string, unknown>,
     originatorClientId?: string,
-  ): Promise<
-    | {
-        name: string;
-        transport: string;
-        replaced: boolean;
-        shadowedSettings: boolean;
-        toolCount: number;
-        originatorClientId: string;
-      }
-    | {
-        name: string;
-        skipped: true;
-        reason: 'budget_warning_only' | 'runtime_name_conflict';
-      }
-  >;
+  ): Promise<RuntimeMcpServerAddResult>;
 
   /**
    * Remove a runtime MCP server through the ACP child's
@@ -1419,15 +1429,26 @@ export interface AcpSessionBridge {
   removeRuntimeMcpServer(
     name: string,
     originatorClientId?: string,
-  ): Promise<
-    | {
-        name: string;
-        removed: true;
-        wasShadowingSettings: boolean;
-        originatorClientId: string;
-      }
-    | { name: string; skipped: true; reason: 'not_present' }
-  >;
+  ): Promise<RuntimeMcpServerRemoveResult>;
+
+  /**
+   * Add a runtime MCP server to one live session only. This does not mutate
+   * workspace bootstrap state, affect sibling sessions, or emit a workspace
+   * event.
+   */
+  addSessionRuntimeMcpServer(
+    sessionId: string,
+    name: string,
+    config: Record<string, unknown>,
+    originatorClientId?: string,
+  ): Promise<RuntimeMcpServerAddResult>;
+
+  /** Remove a runtime MCP server from one live session only. */
+  removeSessionRuntimeMcpServer(
+    sessionId: string,
+    name: string,
+    originatorClientId?: string,
+  ): Promise<RuntimeMcpServerRemoveResult>;
 
   manageMcpServer(
     serverName: string,

--- a/packages/acp-bridge/src/status.ts
+++ b/packages/acp-bridge/src/status.ts
@@ -166,6 +166,8 @@ export const SERVE_CONTROL_EXT_METHODS = {
    * `{ sessionId }`; result: `{ active: ActiveGoalView | null }`.
    */
   sessionGoalGet: 'qwen/control/session/goal/get',
+  sessionMcpRuntimeAdd: 'qwen/control/session/mcp/runtime-add',
+  sessionMcpRuntimeRemove: 'qwen/control/session/mcp/runtime-remove',
   workspaceMcpRuntimeAdd: 'qwen/control/workspace/mcp/runtime-add',
   workspaceMcpRuntimeRemove: 'qwen/control/workspace/mcp/runtime-remove',
   workspaceReload: 'qwen/control/workspace/reload',

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -10076,6 +10076,85 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
+  it('mutates runtime MCP state on only the selected live session', async () => {
+    const firstConfig = await setupSessionMocks('session-mcp-a');
+    const firstManager = {
+      addRuntimeMcpServer: vi.fn(),
+      removeRuntimeMcpServer: vi.fn(),
+    };
+    Object.assign(firstConfig, {
+      getToolRegistry: vi.fn().mockReturnValue({
+        getMcpClientManager: vi.fn().mockReturnValue(firstManager),
+      }),
+    });
+    const secondManager = {
+      addRuntimeMcpServer: vi.fn().mockResolvedValue({
+        name: 'channel-loop',
+        transport: 'sdk',
+        replaced: false,
+        shadowedSettings: false,
+        toolCount: 1,
+        originatorClientId: 'daemon-channel',
+      }),
+      removeRuntimeMcpServer: vi.fn().mockResolvedValue({
+        name: 'channel-loop',
+        removed: true,
+        wasShadowingSettings: false,
+        originatorClientId: 'daemon-channel',
+      }),
+    };
+    const secondConfig = {
+      ...firstConfig,
+      getSessionId: vi.fn().mockReturnValue('session-mcp-b'),
+      getToolRegistry: vi.fn().mockReturnValue({
+        getMcpClientManager: vi.fn().mockReturnValue(secondManager),
+      }),
+    };
+    vi.mocked(loadCliConfig)
+      .mockResolvedValueOnce(firstConfig as unknown as Config)
+      .mockResolvedValueOnce(secondConfig as unknown as Config);
+
+    const { agent, agentPromise } = await bootAcpAgent();
+    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+
+    await expect(
+      agent.extMethod(SERVE_CONTROL_EXT_METHODS.sessionMcpRuntimeAdd, {
+        sessionId: 'session-mcp-b',
+        name: 'channel-loop',
+        config: {
+          type: 'sdk',
+          __clientMcpOverWs: true,
+          trust: true,
+          cwd: '/untrusted',
+        },
+        originatorClientId: 'daemon-channel',
+      }),
+    ).resolves.toMatchObject({ name: 'channel-loop', transport: 'sdk' });
+    await expect(
+      agent.extMethod(SERVE_CONTROL_EXT_METHODS.sessionMcpRuntimeRemove, {
+        sessionId: 'session-mcp-b',
+        name: 'channel-loop',
+        originatorClientId: 'daemon-channel',
+      }),
+    ).resolves.toMatchObject({ name: 'channel-loop', removed: true });
+
+    expect(firstManager.addRuntimeMcpServer).not.toHaveBeenCalled();
+    expect(firstManager.removeRuntimeMcpServer).not.toHaveBeenCalled();
+    expect(secondManager.addRuntimeMcpServer).toHaveBeenCalledWith(
+      'channel-loop',
+      { type: 'sdk' },
+      'daemon-channel',
+    );
+    expect(secondManager.removeRuntimeMcpServer).toHaveBeenCalledWith(
+      'channel-loop',
+      'daemon-channel',
+    );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
   it('first ACP session fires SessionStart only from the real session initialize path', async () => {
     const innerConfig = await setupSessionMocks(
       'session-no-direct-session-start',

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -101,6 +101,7 @@ import {
   type HookConfig,
   type McpBudgetEvent,
   type McpBudgetMode,
+  type McpClientManager,
   type McpTransportKind,
   type ProviderConfig,
   type ProviderModelConfig,
@@ -2642,6 +2643,116 @@ export async function deliverClientMcpMessage(
     );
   }
   return payload as JSONRPCMessage;
+}
+
+interface RuntimeMcpRequest {
+  name: string;
+  runtimeClientId: string;
+}
+
+interface RuntimeMcpAddRequest extends RuntimeMcpRequest {
+  config: MCPServerConfig;
+}
+
+function readRuntimeMcpRequest(
+  params: Record<string, unknown>,
+): RuntimeMcpRequest {
+  const name = params['name'];
+  if (typeof name !== 'string' || name.length === 0) {
+    throw RequestError.invalidParams(undefined, 'Invalid or missing name');
+  }
+  if (!isValidServerName(name)) {
+    throw RequestError.invalidParams(
+      undefined,
+      'Server name must be ≤256 chars, alphanumeric + underscore/hyphen, and not a reserved JS property name',
+    );
+  }
+  const originatorClientId = params['originatorClientId'];
+  return {
+    name,
+    runtimeClientId:
+      typeof originatorClientId === 'string' && originatorClientId.length > 0
+        ? originatorClientId
+        : 'daemon',
+  };
+}
+
+function readRuntimeMcpAddRequest(
+  params: Record<string, unknown>,
+): RuntimeMcpAddRequest {
+  const request = readRuntimeMcpRequest(params);
+  const config = params['config'];
+  if (!config || typeof config !== 'object' || Array.isArray(config)) {
+    throw RequestError.invalidParams(undefined, 'Invalid or missing config');
+  }
+  // Runtime callers cannot grant trust, inject credentials, change tool
+  // filters, or choose a process working directory.
+  const {
+    trust: _trust,
+    authProviderType: _auth,
+    includeTools: _inc,
+    excludeTools: _exc,
+    cwd: _cwd,
+    env: _env,
+    oauth: _oauth,
+    headers: _headers,
+    type: _type,
+    [CLIENT_MCP_OVER_WS_CONFIG_FLAG]: clientMcpOverWs,
+    ...safeConfig
+  } = config as ClientMcpOverWsRuntimeConfig;
+  if (clientMcpOverWs === true) {
+    (safeConfig as Record<string, unknown>)['type'] = 'sdk';
+  }
+  return {
+    ...request,
+    config: safeConfig as MCPServerConfig,
+  };
+}
+
+function getRuntimeMcpManager(config: Config): McpClientManager {
+  const manager = config.getToolRegistry()?.getMcpClientManager();
+  if (!manager) {
+    throw RequestError.internalError(
+      undefined,
+      'McpClientManager unavailable on this Config',
+    );
+  }
+  return manager;
+}
+
+async function addRuntimeMcpServer(
+  manager: McpClientManager,
+  request: RuntimeMcpAddRequest,
+): Promise<Record<string, unknown>> {
+  try {
+    return (await manager.addRuntimeMcpServer(
+      request.name,
+      request.config,
+      request.runtimeClientId,
+    )) as unknown as Record<string, unknown>;
+  } catch (err) {
+    if (err instanceof McpBudgetWouldExceedError) {
+      throw new RequestError(-32099, err.message, {
+        errorKind: err.code,
+        serverName: err.serverName,
+      });
+    }
+    if (err instanceof McpServerSpawnFailedError) {
+      throw new RequestError(-32099, err.message, {
+        errorKind: err.code,
+        serverName: err.serverName,
+        ...err.details,
+      });
+    }
+    if (err instanceof InvalidMcpConfigError) {
+      throw new RequestError(-32099, err.message, {
+        errorKind: err.code,
+        serverName: err.serverName,
+        reason: err.reason,
+      });
+    }
+    throw err;
+  }
 }
 
 export async function runAcpAgent(
@@ -9083,174 +9194,44 @@ class QwenAgent implements Agent {
         return result;
       }
       case SERVE_CONTROL_EXT_METHODS.workspaceMcpRuntimeAdd: {
-        const name = params['name'];
-        const config = params['config'];
-        const originatorClientId = params['originatorClientId'];
-        if (typeof name !== 'string' || name.length === 0) {
-          throw RequestError.invalidParams(
-            undefined,
-            'Invalid or missing name',
-          );
-        }
-        if (!isValidServerName(name)) {
-          throw RequestError.invalidParams(
-            undefined,
-            'Server name must be ≤256 chars, alphanumeric + underscore/hyphen, and not a reserved JS property name',
-          );
-        }
-        if (!config || typeof config !== 'object' || Array.isArray(config)) {
-          throw RequestError.invalidParams(
-            undefined,
-            'Invalid or missing config',
-          );
-        }
-        const runtimeClientId =
-          typeof originatorClientId === 'string' &&
-          originatorClientId.length > 0
-            ? originatorClientId
-            : 'daemon';
-        const manager = this.config.getToolRegistry()?.getMcpClientManager();
-        if (!manager) {
-          throw RequestError.internalError(
-            undefined,
-            'McpClientManager unavailable on this Config',
-          );
-        }
-        try {
-          // Strip security-sensitive fields — runtime-added servers must
-          // not bypass permission gates via trust:true, leak cloud creds
-          // via authProviderType, manipulate tool filtering, or spawn in
-          // arbitrary directories
-          const {
-            trust: _trust,
-            authProviderType: _auth,
-            includeTools: _inc,
-            excludeTools: _exc,
-            cwd: _cwd,
-            env: _env,
-            oauth: _oauth,
-            headers: _headers,
-            type: _type,
-            // Reverse tool channel marker (issue #5626, Phase 2). The parent
-            // serve process stamps this on a client-hosted (extension) MCP
-            // server's runtime config; it never reaches the transport itself.
-            [CLIENT_MCP_OVER_WS_CONFIG_FLAG]: clientMcpOverWs,
-            ...safeConfig
-          } = config as ClientMcpOverWsRuntimeConfig;
-          // Client-hosted MCP servers (#5626) MUST keep `type: 'sdk'` so the
-          // manager binds an `SdkControlClientTransport` whose `sendMcpMessage`
-          // routes back over the daemon WS via `sendSdkMcpMessage` — which the
-          // session manager wires to the `client_mcp/message` ext-method. For
-          // every other runtime server the type stays stripped (no SDK process
-          // backs them). Trust/creds/filters/cwd remain stripped regardless.
-          if (clientMcpOverWs === true) {
-            (safeConfig as Record<string, unknown>)['type'] = 'sdk';
-          }
-          const result = await manager.addRuntimeMcpServer(
-            name,
-            safeConfig as MCPServerConfig,
-            runtimeClientId,
-          );
-          // Reverse tool channel (issue #5626, Phase 2). The add above lands
-          // the server in the BOOTSTRAP/workspace Config — which is what
-          // discovery and `GET /workspace/mcp/<server>/tools` read, and what a
-          // session created LATER inherits (see `newSessionConfig`). But a
-          // prompt runs against a PER-SESSION Config whose tool registry +
-          // `sendSdkMcpMessage` are independent: an ALREADY-ACTIVE session would
-          // not see the server and a model-driven `tools/call` for a
-          // client-hosted tool would fail with "not found in registry", never
-          // reaching the WS client. Fan the add out to each live session's
-          // manager so the tool lands in that session's registry AND binds that
-          // session's `sendSdkMcpMessage` (the `__clientMcpOverWs` reverse
-          // path). Best-effort + additive: a per-session failure is logged but
-          // does not fail the registration (the bootstrap add already
-          // succeeded and is the result we return); no active sessions ⇒ no-op.
-          await Promise.all(
-            this.getActiveSessions().map(async (session) => {
-              const sessionManager = session
-                .getConfig()
-                .getToolRegistry()
-                ?.getMcpClientManager();
-              if (!sessionManager) return;
-              // `addRuntimeMcpServer` is idempotent on an identical fingerprint
-              // (same name + config) — it updates the overlay without transport
-              // churn — so a session that already inherited this server at
-              // creation re-adds harmlessly.
-              try {
-                await sessionManager.addRuntimeMcpServer(
-                  name,
-                  safeConfig as MCPServerConfig,
-                  runtimeClientId,
-                );
-              } catch (sessionErr) {
-                debugLogger.warn(
-                  `workspaceMcpRuntimeAdd: failed to add runtime MCP server ` +
-                    `'${name}' to active session ${session.getConfig().getSessionId()}: ` +
-                    `${
-                      sessionErr instanceof Error
-                        ? sessionErr.message
-                        : String(sessionErr)
-                    }`,
-                );
-              }
-            }),
-          );
-          return result as unknown as Record<string, unknown>;
-        } catch (err) {
-          if (err instanceof McpBudgetWouldExceedError) {
-            throw new RequestError(-32099, err.message, {
-              errorKind: err.code,
-              serverName: err.serverName,
-            });
-          }
-          if (err instanceof McpServerSpawnFailedError) {
-            throw new RequestError(-32099, err.message, {
-              errorKind: err.code,
-              serverName: err.serverName,
-              ...err.details,
-            });
-          }
-          if (err instanceof InvalidMcpConfigError) {
-            throw new RequestError(-32099, err.message, {
-              errorKind: err.code,
-              serverName: err.serverName,
-              reason: err.reason,
-            });
-          }
-          throw err;
-        }
+        const request = readRuntimeMcpAddRequest(params);
+        const result = await addRuntimeMcpServer(
+          getRuntimeMcpManager(this.config),
+          request,
+        );
+        await Promise.all(
+          this.getActiveSessions().map(async (session) => {
+            const sessionManager = session
+              .getConfig()
+              .getToolRegistry()
+              ?.getMcpClientManager();
+            if (!sessionManager) return;
+            try {
+              await sessionManager.addRuntimeMcpServer(
+                request.name,
+                request.config,
+                request.runtimeClientId,
+              );
+            } catch (sessionErr) {
+              debugLogger.warn(
+                `workspaceMcpRuntimeAdd: failed to add runtime MCP server ` +
+                  `'${request.name}' to active session ${session.getConfig().getSessionId()}: ` +
+                  `${
+                    sessionErr instanceof Error
+                      ? sessionErr.message
+                      : String(sessionErr)
+                  }`,
+              );
+            }
+          }),
+        );
+        return result;
       }
       case SERVE_CONTROL_EXT_METHODS.workspaceMcpRuntimeRemove: {
-        const name = params['name'];
-        const originatorClientId = params['originatorClientId'];
-        if (typeof name !== 'string' || name.length === 0) {
-          throw RequestError.invalidParams(
-            undefined,
-            'Invalid or missing name',
-          );
-        }
-        if (!isValidServerName(name)) {
-          throw RequestError.invalidParams(
-            undefined,
-            'Server name must be ≤256 chars, alphanumeric + underscore/hyphen, and not a reserved JS property name',
-          );
-        }
-        const runtimeClientId =
-          typeof originatorClientId === 'string' &&
-          originatorClientId.length > 0
-            ? originatorClientId
-            : 'daemon';
-        const manager = this.config.getToolRegistry()?.getMcpClientManager();
-        if (!manager) {
-          throw RequestError.internalError(
-            undefined,
-            'McpClientManager unavailable on this Config',
-          );
-        }
-        const result = await manager.removeRuntimeMcpServer(
-          name,
-          runtimeClientId,
-        );
+        const request = readRuntimeMcpRequest(params);
+        const result = await getRuntimeMcpManager(
+          this.config,
+        ).removeRuntimeMcpServer(request.name, request.runtimeClientId);
         // Mirror of the add fan-out (#5626): the runtime server was also
         // registered on each active session's manager, so deregistering it
         // must tear it down there too — otherwise an active session keeps a
@@ -9267,13 +9248,13 @@ class QwenAgent implements Agent {
             if (!sessionManager) return;
             try {
               await sessionManager.removeRuntimeMcpServer(
-                name,
-                runtimeClientId,
+                request.name,
+                request.runtimeClientId,
               );
             } catch (sessionErr) {
               debugLogger.warn(
                 `workspaceMcpRuntimeRemove: failed to remove runtime MCP server ` +
-                  `'${name}' from active session ${session.getConfig().getSessionId()}: ` +
+                  `'${request.name}' from active session ${session.getConfig().getSessionId()}: ` +
                   `${
                     sessionErr instanceof Error
                       ? sessionErr.message
@@ -9283,6 +9264,35 @@ class QwenAgent implements Agent {
             }
           }),
         );
+        return result as unknown as Record<string, unknown>;
+      }
+      case SERVE_CONTROL_EXT_METHODS.sessionMcpRuntimeAdd: {
+        const sessionId = params['sessionId'];
+        if (typeof sessionId !== 'string' || sessionId.length === 0) {
+          throw RequestError.invalidParams(
+            undefined,
+            'Invalid or missing sessionId',
+          );
+        }
+        const session = this.sessionOrThrow(sessionId);
+        return addRuntimeMcpServer(
+          getRuntimeMcpManager(session.getConfig()),
+          readRuntimeMcpAddRequest(params),
+        );
+      }
+      case SERVE_CONTROL_EXT_METHODS.sessionMcpRuntimeRemove: {
+        const sessionId = params['sessionId'];
+        if (typeof sessionId !== 'string' || sessionId.length === 0) {
+          throw RequestError.invalidParams(
+            undefined,
+            'Invalid or missing sessionId',
+          );
+        }
+        const session = this.sessionOrThrow(sessionId);
+        const request = readRuntimeMcpRequest(params);
+        const result = await getRuntimeMcpManager(
+          session.getConfig(),
+        ).removeRuntimeMcpServer(request.name, request.runtimeClientId);
         return result as unknown as Record<string, unknown>;
       }
       case SERVE_CONTROL_EXT_METHODS.workspaceExtensionsRefresh: {


### PR DESCRIPTION
## What this PR does

Adds a session-owned runtime MCP route alongside the existing workspace-owned route. A daemon host can now add or remove an SDK MCP server for one selected live session without mutating bootstrap state, fanning out to siblings, or publishing workspace-wide events.

Carries the originating session identity through reverse MCP messages and verifies that the claimed session belongs to the ACP channel before forwarding it to the host-side sender.

## Why it's needed

Daemon-managed channels need private agent tools that belong to the channel's live session. Reusing the workspace route would expose those tools to unrelated terminal and web sessions in the same runtime. This provides the generic isolation boundary required by the later channel-loop integration while remaining independent of channel behavior.

## Reviewer Test Plan

### How to verify

- Create two thread-scoped sessions on one live ACP channel, add and remove a runtime MCP server for the second session, and confirm both requests carry only that session identity.
- Request a session-scoped add for an unknown session and confirm it fails instead of falling back to the live workspace channel.
- In the ACP child, register managers for two sessions and confirm only the selected manager receives the add and remove calls; security-sensitive runtime configuration remains stripped.
- Send a reverse MCP frame with a valid session identity and confirm the host sender receives it; malformed or foreign session identities must fail before the sender runs.
- Run `cd packages/acp-bridge && npx vitest run src/bridgeClient.test.ts src/bridge.test.ts`.
- Run `cd packages/cli && npx vitest run src/acp-integration/acpAgent.test.ts`.
- Run `npm run build`, `npm run typecheck`, and `npm run lint`.

### Evidence (Before & After)

N/A — protocol and routing infrastructure only; no UI changes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Node.js 22 workspace install; package-level Vitest suites and repository build/type/lint checks.

## Risk & Scope

- Main risk or tradeoff: The new route is intentionally live-session scoped; callers must recreate the runtime server after that session is replaced or restored.
- Not validated / out of scope: No channel loop server is registered here, and no browser or TUI behavior changes in this PR.
- Breaking changes / migration notes: None. Existing workspace-scoped runtime MCP registration and senders that ignore the optional context remain compatible.

## Linked Issues

Related to #7628 and #7641.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在现有 workspace 归属的运行时 MCP 路由之外，新增 session 归属的运行时 MCP 路由。daemon host 现在可以只为一个指定的 live session 添加或移除 SDK MCP server，不会修改 bootstrap 状态、扩散到兄弟 session，也不会发布 workspace 级事件。

反向 MCP 消息会携带来源 session 身份；在转交给 host 侧 sender 之前，还会校验该 session 确实归当前 ACP channel 所有。

## 为什么需要

daemon-managed channel 需要只属于其 live session 的私有 agent tools。如果复用 workspace 路由，这些工具会暴露给同一 runtime 中无关的终端和 Web session。这个 PR 提供后续 channel-loop 集成所需的通用隔离边界，同时不包含任何 channel 业务。

## Reviewer 测试计划

### 如何验证

- 在同一个 live ACP channel 上创建两个 thread-scoped session，只为第二个 session 添加并移除运行时 MCP server，确认两个请求都只携带该 session 身份。
- 对不存在的 session 发起 session-scoped add，确认请求失败而不是回退到 live workspace channel。
- 在 ACP child 中为两个 session 注册 manager，确认只有目标 manager 收到 add/remove；安全敏感的运行时配置仍会被剥离。
- 发送带合法 session 身份的反向 MCP frame，确认 host sender 收到该身份；畸形或属于其他 channel 的 session 身份必须在 sender 执行前失败。
- 运行 `cd packages/acp-bridge && npx vitest run src/bridgeClient.test.ts src/bridge.test.ts`。
- 运行 `cd packages/cli && npx vitest run src/acp-integration/acpAgent.test.ts`。
- 运行 `npm run build`、`npm run typecheck` 和 `npm run lint`。

### 证据（前后对比）

N/A——仅协议和路由基础设施，没有 UI 变化。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

Node.js 22 workspace 安装；执行 package 级 Vitest suite 与仓库 build/type/lint 检查。

## 风险与范围

- 主要风险或取舍：新路由刻意绑定 live session；该 session 被替换或恢复后，调用方必须重新创建运行时 server。
- 未验证 / 范围外：本 PR 不注册 channel loop server，也不改变浏览器或 TUI 行为。
- 破坏性变更 / 迁移说明：无。现有 workspace-scoped 运行时 MCP 注册，以及忽略可选 context 的 sender，保持兼容。

## 关联 Issue

关联 #7628 和 #7641。

</details>
