### PR TITLE
fix(triage): actually restrict the CI review agent's tools

### DIFF
--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -178,14 +178,22 @@ jobs:
              startsWith(github.event.comment.body, '@qwen-code /triage'))) &&
            needs.authorize.outputs.should_run == 'true')
         }}
-    # Triage is the read-only analysis agent (same security profile as
-    # review-pr in qwen-code-pr-review.yml): it checks out the trusted base
-    # repo, never executes PR code, and reaches the PR/issue only via the API.
-    # In the canonical repo, run it on the self-hosted ECS pool like review-pr
-    # so it stops queueing behind the hosted CI/e2e/macOS/Windows concurrency
-    # cap while the ECS pool sits idle. Forks fall back to ubuntu-latest unless
-    # they deliberately change this workflow in their own repo.
-    runs-on: "${{ (github.repository == 'QwenLM/qwen-code' && vars.MAINTAINER_ECS_RUNNER_DISABLED != 'true') && fromJSON('[\"self-hosted\", \"linux\", \"x64\", \"ecs-qwen\"]') || fromJSON('[\"ubuntu-latest\"]') }}"
+    # Triage is a static-analysis agent: it checks out the trusted base repo,
+    # reaches the PR/issue only via the API, and must NEVER execute PR-derived
+    # code — its step env carries a write PAT that executed code could read.
+    # This is defended in layers, none of which is a hard boundary on its own
+    # (see the long note on the Qwen step for why a `--yolo` command denylist
+    # cannot be): the skill forbids executing PR code
+    # (.qwen/skills/triage/SKILL.md Rules), the `settings` deny rules block the
+    # direct interpreter/build/network invocations, and the routing below keeps
+    # foreign code off the persistent pool.
+    # Runner routing: the persistent ECS pool is reserved for events whose
+    # payload carries no foreign code — issue triage and same-repo PR events.
+    # Fork PRs, and comment/dispatch-triggered reruns (which may target fork
+    # PRs), go to ephemeral hosted runners so a steered agent cannot persist
+    # anything across runs. Forks of this repo fall back to ubuntu-latest as
+    # before.
+    runs-on: "${{ (github.repository == 'QwenLM/qwen-code' && vars.MAINTAINER_ECS_RUNNER_DISABLED != 'true' && (github.event_name == 'issues' || (github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository))) && fromJSON('[\"self-hosted\", \"linux\", \"x64\", \"ecs-qwen\"]') || fromJSON('[\"ubuntu-latest\"]') }}"
     # startsWith (not contains) prevents false triggers from comments that
     # mention the phrase in quoted text or mid-sentence descriptions.
     # always() so the job still evaluates when the upstream `authorize` job is
@@ -239,6 +247,30 @@ jobs:
             echo "no prior workspace; nothing to clean"
             exit 0
           fi
+          # Neutralize git exec vectors a prior run could have planted in the
+          # persistent workspace: local config knobs that make a later git
+          # invocation run a command, and hook scripts. The knobs span several
+          # families — hooksPath/fsmonitor, the pager/editor/diff.external/
+          # sshCommand that fire on the plain `git log`/`diff`/`show` triage
+          # runs, filter.*.{clean,smudge,process} (run on checkout via
+          # .gitattributes), credential.helper, url.*.insteadOf, init.templateDir,
+          # aliases, and include/includeIf which pull any of them back in from an
+          # arbitrary file. Enumerate the actual keys and --unset-all each:
+          # --remove-section cannot target an includeIf subsection like
+          # [includeIf "gitdir:…"] (it errors "no such section" and the `|| true`
+          # hides it), but unsetting the resolved key removes it. This is a
+          # best-effort denylist for defense-in-depth (the `run_shell_command(git
+          # config)` deny rule already stops the current run from planting these);
+          # a keep-known-safe config allowlist is the exhaustive end-state, tracked
+          # with the workflow-test-harness follow-up since it needs a checkout test.
+          git config --local --name-only --list 2>/dev/null \
+            | grep -iE '^(core\.(hookspath|fsmonitor|pager|editor|sshcommand)|sequence\.editor|diff\.external|filter\.|credential\.|url\.|init\.templatedir|pager\.|alias\.|include\.|includeif\.)' \
+            | while IFS= read -r key; do git config --local --unset-all "$key" 2>/dev/null || true; done
+          HOOKS_DIR="$(git rev-parse --git-path hooks 2>/dev/null || echo .git/hooks)"
+          # Match -type f OR -type l: a symlinked hook (e.g. post-checkout ->
+          # ../payload) survives a bare `-type f` sweep and still fires on the
+          # next actions/checkout. Parenthesize so ! -name binds to both.
+          find "$HOOKS_DIR" \( -type f -o -type l \) ! -name '*.sample' -delete 2>/dev/null || true
           rm -rf .qwen/tmp/* 2>/dev/null || true
           git worktree prune -v || true
           echo "stale agent state cleaned"
@@ -284,19 +316,180 @@ jobs:
           OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
           OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'
           OPENAI_MODEL: '${{ vars.QWEN_TRIAGE_MODEL || vars.QWEN_PR_REVIEW_MODEL }}'
-          settings_json: |-
+          # The input name is `settings` — this action version has no
+          # `settings_json` input. The old `settings_json:` block was silently
+          # dropped ("Unexpected input(s) 'settings_json'" in the run log), so
+          # the agent ran with the full default toolset. Do not rename it back.
+          #
+          # ── What these settings are, and are NOT ────────────────────────────
+          # The action runs `qwen --yolo`, so every permission resolves to
+          # auto-approve EXCEPT a `permissions.deny` match, which the scheduler
+          # errors out before approval mode is consulted (verified in
+          # coreToolScheduler L5 + permissionFlow.needsConfirmation). `tools.core`
+          # additionally filters which tools register at all (fail-safe: an
+          # unlisted tool like web_fetch/web_search/save_memory never loads, so
+          # those network/persistence tool channels are gone). No `sandbox` key:
+          # the ECS pool ships no container runtime.
+          #
+          # ⚠️ A command denylist is NOT a security boundary under --yolo, and
+          # is not treated as one here. It is defense-in-depth against the
+          # NORMAL failure (the agent running `npm test`/`npx`/a build because a
+          # prompt implied it) and low-effort injection. It does NOT stop a
+          # determined prompt-injection: `$(...)` substitution is not reliably
+          # deny-matchable (parser-dependent), and even with it blocked, exec
+          # can hide in `sed s///e`, env-var interpreters, etc. — an unwinnable
+          # denylist game. Backtick and `<(` ARE hard-blocked below (verified,
+          # they were free); `$(` and `>(` are not reliably matchable and are
+          # left to the layers below, not papered over with a rule that no-ops.
+          #
+          # The REAL controls, in order of strength:
+          #   1. No PR code is ever executed (skill Rules; every legit triage
+          #      command is a gh-API call, a read-only git command, or text
+          #      processing — none touch the PR's tree in an executable way).
+          #   2. Fork PRs run on ephemeral hosted runners (see the triage job
+          #      `runs-on`), bounding persistence/lateral movement.
+          #   3. Stale git exec vectors (hooks/config/aliases) are wiped each
+          #      run (see "Clean stale agent state").
+          # RESIDUAL RISK: the agent still holds a write PAT (GH_TOKEN above),
+          # and under a successful injection it could exfiltrate it or forge bot
+          # writes — it even has a legitimate comment-posting capability. The
+          # structural fix is token isolation (agent runs read-only; a separate
+          # PR-code-free step publishes its drafted output with the PAT, as
+          # publish-tmux already does). Tracked as a follow-up; not yet wired.
+          #
+          # The deny list below therefore backs the skill's no-PR-code rule as
+          # a speed bump: interpreters/build tools, shells, exec wrappers,
+          # network binaries, path execution, and the git/gh subcommands that
+          # execute configured commands or materialize PR code. Prefix match is
+          # word-boundary ("npm" blocks `npm test`, not `npmx`); shell redirects
+          # are also checked against the write_file path rules.
+          settings: |-
             {
-              "coreTools": [
-                "run_shell_command",
-                "write_file",
-                "read_file",
-                "grep_search",
-                "glob",
-                "agent",
-                "enter_worktree",
-                "exit_worktree"
-              ],
-              "sandbox": false
+              "tools": {
+                "core": [
+                  "run_shell_command",
+                  "write_file",
+                  "read_file",
+                  "read_many_files",
+                  "list_directory",
+                  "grep_search",
+                  "glob",
+                  "todo_write",
+                  "agent",
+                  "enter_worktree",
+                  "exit_worktree"
+                ]
+              },
+              "permissions": {
+                "deny": [
+                  "run_shell_command(node)",
+                  "run_shell_command(npm)",
+                  "run_shell_command(npx)",
+                  "run_shell_command(pnpm)",
+                  "run_shell_command(yarn)",
+                  "run_shell_command(bun)",
+                  "run_shell_command(corepack)",
+                  "run_shell_command(tsx)",
+                  "run_shell_command(ts-node)",
+                  "run_shell_command(deno)",
+                  "run_shell_command(python)",
+                  "run_shell_command(python3)",
+                  "run_shell_command(pip)",
+                  "run_shell_command(pip3)",
+                  "run_shell_command(perl)",
+                  "run_shell_command(ruby)",
+                  "run_shell_command(php)",
+                  "run_shell_command(java)",
+                  "run_shell_command(go)",
+                  "run_shell_command(cargo)",
+                  "run_shell_command(make)",
+                  "run_shell_command(cmake)",
+                  "run_shell_command(sh)",
+                  "run_shell_command(bash)",
+                  "run_shell_command(zsh)",
+                  "run_shell_command(dash)",
+                  "run_shell_command(ksh)",
+                  "run_shell_command(su)",
+                  "run_shell_command(sudo)",
+                  "run_shell_command(env)",
+                  "run_shell_command(eval)",
+                  "run_shell_command(exec)",
+                  "run_shell_command(command)",
+                  "run_shell_command(xargs)",
+                  "run_shell_command(find)",
+                  "run_shell_command(awk)",
+                  "run_shell_command(nohup)",
+                  "run_shell_command(setsid)",
+                  "run_shell_command(timeout)",
+                  "run_shell_command(curl)",
+                  "run_shell_command(wget)",
+                  "run_shell_command(nc)",
+                  "run_shell_command(ncat)",
+                  "run_shell_command(socat)",
+                  "run_shell_command(ssh)",
+                  "run_shell_command(scp)",
+                  "run_shell_command(rsync)",
+                  "run_shell_command(docker)",
+                  "run_shell_command(podman)",
+                  "run_shell_command(apt)",
+                  "run_shell_command(apt-get)",
+                  "run_shell_command(chmod)",
+                  "run_shell_command(chown)",
+                  "run_shell_command(crontab)",
+                  "run_shell_command(systemctl)",
+                  "run_shell_command(tmux)",
+                  "run_shell_command(screen)",
+                  "run_shell_command(qwen)",
+                  "run_shell_command(./*)",
+                  "run_shell_command(/tmp/*)",
+                  "run_shell_command(/var/tmp/*)",
+                  "run_shell_command(/dev/shm/*)",
+                  "run_shell_command(/home/*)",
+                  "run_shell_command(~/*)",
+                  "run_shell_command(git config)",
+                  "run_shell_command(git rebase)",
+                  "run_shell_command(git filter-branch)",
+                  "run_shell_command(git bisect)",
+                  "run_shell_command(git am)",
+                  "run_shell_command(git apply)",
+                  "run_shell_command(git fetch)",
+                  "run_shell_command(git pull)",
+                  "run_shell_command(git checkout)",
+                  "run_shell_command(git clone)",
+                  "run_shell_command(git submodule)",
+                  "run_shell_command(git merge)",
+                  "run_shell_command(git push)",
+                  "run_shell_command(patch)",
+                  "run_shell_command(git -c)",
+                  "run_shell_command(*`*)",
+                  "run_shell_command(*<(*)",
+                  "run_shell_command(gh pr checkout)",
+                  "run_shell_command(gh repo clone)",
+                  "run_shell_command(gh alias)",
+                  "run_shell_command(gh extension)",
+                  "run_shell_command(gh auth)",
+                  "run_shell_command(gh secret)",
+                  "run_shell_command(gh codespace)",
+                  "write_file(/.git/hooks/**)",
+                  "write_file(/.git/config)",
+                  "write_file(**/.git/hooks/**)",
+                  "write_file(**/.git/config)",
+                  "write_file(**/.npmrc)",
+                  "write_file(**/.qwen/settings.json)",
+                  "write_file(~/.gitconfig)",
+                  "write_file(~/.config/git/**)",
+                  "write_file(~/.bashrc)",
+                  "write_file(~/.bash_profile)",
+                  "write_file(~/.bash_login)",
+                  "write_file(~/.profile)",
+                  "write_file(~/.bash_logout)",
+                  "write_file(~/.npmrc)",
+                  "write_file(~/.ssh/**)",
+                  "write_file(~/.config/gh/**)",
+                  "write_file(~/.local/bin/**)",
+                  "write_file(//etc/**)"
+                ]
+              }
             }
           prompt: '/triage ${{ steps.resolve.outputs.number }} --repo ${{ github.repository }}'
 


### PR DESCRIPTION
## The bug

The `settings_json:` input on the `QwenLM/qwen-code-action` step **does not exist** — the action reads `settings:`. The block was silently dropped (the run logs show `Unexpected input(s) 'settings_json'`), so the triage agent has been running with the **full default toolset and no restrictions** — in a job whose environment carries a write PAT.

## Change

- **Rename to `settings:`** and express it in the current schema (`tools.core` + `permissions.deny`). Verified to load through the real settings pipeline: 11 tools registered, 106 deny rules active.
- **Deny** interpreters, build tools, shells, network binaries, path execution, and the `git`/`gh` write subcommands that execute configured commands or materialize PR code.
- **Route fork PRs** (and comment/dispatch reruns, which may target fork PRs) to ephemeral hosted runners, so a steered agent cannot persist on the shared ECS pool. Issue triage and same-repo PRs keep the ECS pool.
- **Wipe stale git exec vectors** (hooks / `core.hooksPath` / `core.fsmonitor` / aliases) each run before checkout.

## What this is — and is not

A command denylist is **not** a security boundary under the action's `--yolo`, and this PR does not treat it as one. `$(...)` substitution is not reliably deny-matchable, and even with it blocked, exec can hide elsewhere. The denylist is **defense-in-depth** against the normal failure (the agent running `npm`/`node` because a prompt implied it) and low-effort injection.

The **real** controls are, in order:
1. the skill's no-PR-code rule (#7646),
2. ephemeral runners for fork PRs (this PR),
3. the per-run git exec-vector cleanup (this PR).

**Residual risk** is documented inline: the agent still holds a write PAT, so a successful prompt-injection could still exfiltrate it. The structural fix is token isolation (agent runs read-only; a separate PR-code-free step publishes its drafts, as `publish-tmux` already does) — flagged as a follow-up, not wired here.

## Verification

- The exact `settings` JSON was fed through the real `PermissionManager`: 38/38 attack-shaped commands hard-denied, 34/34 legitimate triage commands allowed, write-path rules correct (`git -c` denied, `git -C` allowed).
- Confirmed the installed CLI enforces it: a smoke run had `echo` execute and `node -e …` hard-denied.
- Two full real-model triage runs against #7632 (write-blocked) hit **zero** false denials and executed no PR code.

## Depends on #7646

#7646 switches test evidence to the CI API and the CHANGELOG fetch to `gh api`. **Merge #7646 first** so the `npm`/`curl` denials introduced here are harmless.

<details>
<summary>中文说明</summary>

## Bug

`QwenLM/qwen-code-action` step 上的 `settings_json:` 输入**根本不存在** —— action 读的是 `settings:`。这个块被静默丢弃了(运行日志里能看到 `Unexpected input(s) 'settings_json'`),所以 triage agent 一直在用**全量默认工具集、零限制**运行 —— 而该 job 的环境里带着有写权限的 PAT。

## 改动

- **改名为 `settings:`**,并用当前 schema 表达(`tools.core` + `permissions.deny`)。已验证能通过真实设置加载链路生效:注册 11 个工具,106 条 deny 规则激活。
- **Deny** 解释器、构建工具、shell、网络二进制、路径执行,以及会执行配置命令或落地 PR 代码的 `git`/`gh` 写子命令。
- **把 fork PR**(以及可能指向 fork PR 的 comment/dispatch 重跑)**路由到临时 hosted runner**,使被操纵的 agent 无法在共享 ECS 池上持久化。issue triage 和同仓 PR 仍用 ECS 池。
- 每次运行在 checkout 前**清除陈旧的 git 执行向量**(hooks / `core.hooksPath` / `core.fsmonitor` / alias)。

## 它是什么,不是什么

在 action 的 `--yolo` 下,命令 denylist **不是**安全边界,本 PR 也没把它当边界。`$(...)` 替换无法可靠地被 deny 匹配,即便挡住,执行也能藏在别处。denylist 是针对**常见失误**(agent 因为 prompt 暗示就去跑 `npm`/`node`)和低成本注入的**纵深防御**。

**真正的**控制,按强度排序:
1. skill 的"不执行 PR 代码"规则(#7646);
2. fork PR 用临时 runner(本 PR);
3. 每次运行清 git 执行向量(本 PR)。

**残余风险**已在文件内注明:agent 仍持有写权限 PAT,成功的 prompt 注入仍可能把它外带。结构性修复是 token 隔离(agent 用只读 token,由单独的、不接触 PR 代码的步骤发布其草稿,正如 `publish-tmux` 已经在做的)—— 已标为后续项,本 PR 未接线。

## 验证

- 把确切的 `settings` JSON 喂进真实 `PermissionManager`:38/38 攻击形态命令被硬拒,34/34 合法 triage 命令放行,写路径规则正确(`git -c` 拒、`git -C` 放)。
- 确认装机 CLI 会强制执行:smoke 运行中 `echo` 执行、`node -e …` 被硬拒。
- 两轮完整真实模型 triage(写被拦)对 #7632:**零**误拒,零 PR 代码执行。

## 依赖 #7646

#7646 把测试证据切到 CI API、CHANGELOG 拉取切到 `gh api`。**请先合并 #7646**,这样本 PR 引入的 `npm`/`curl` deny 才不会造成困扰。

</details>
