### PR TITLE
fix(core): Preserve usage after empty OpenAI stream frames

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
@@ -2181,6 +2181,14 @@ describe('ContentGenerationPipeline', () => {
       } as OpenAI.Chat.ChatCompletionChunk;
       const mockChunk2 = {
         id: 'chunk-2',
+        choices: [],
+      } as unknown as OpenAI.Chat.ChatCompletionChunk;
+      const mockChunk3 = {
+        id: 'chunk-3',
+        choices: [],
+      } as unknown as OpenAI.Chat.ChatCompletionChunk;
+      const mockChunk4 = {
+        id: 'chunk-4',
         choices: [
           { delta: { content: 'Hello response' }, finish_reason: 'stop' },
         ],
@@ -2190,13 +2198,18 @@ describe('ContentGenerationPipeline', () => {
         async *[Symbol.asyncIterator]() {
           yield mockChunk1;
           yield mockChunk2;
+          yield mockChunk3;
+          yield mockChunk4;
         },
       };
 
-      const mockEmptyResponse = new GenerateContentResponse();
-      mockEmptyResponse.candidates = [
+      const mockEmptyCandidateResponse = new GenerateContentResponse();
+      mockEmptyCandidateResponse.candidates = [
         { content: { parts: [], role: 'model' } },
       ];
+      const mockEmptyChoicesResponse = new GenerateContentResponse();
+      mockEmptyChoicesResponse.candidates = [];
+      const mockMissingCandidatesResponse = new GenerateContentResponse();
 
       const mockValidResponse = new GenerateContentResponse();
       mockValidResponse.candidates = [
@@ -2205,7 +2218,9 @@ describe('ContentGenerationPipeline', () => {
 
       (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([]);
       (mockConverter.convertOpenAIChunkToGemini as Mock)
-        .mockReturnValueOnce(mockEmptyResponse)
+        .mockReturnValueOnce(mockEmptyCandidateResponse)
+        .mockReturnValueOnce(mockEmptyChoicesResponse)
+        .mockReturnValueOnce(mockMissingCandidatesResponse)
         .mockReturnValueOnce(mockValidResponse);
       (mockClient.chat.completions.create as Mock).mockResolvedValue(
         mockStream,
@@ -3446,10 +3461,10 @@ describe('ContentGenerationPipeline', () => {
       expect(capturedSignal!.aborted).toBe(true);
     });
 
-    it('should merge finishReason and usageMetadata from separate chunks', async () => {
+    it('should ignore empty choices while merging finishReason and usageMetadata', async () => {
       // Arrange
       const request: GenerateContentParameters = {
-        model: 'test-model',
+        model: 'GLM-5.2-FP8',
         contents: [{ parts: [{ text: 'Hello' }], role: 'user' }],
       };
       const userPromptId = 'test-prompt-id';
@@ -3466,14 +3481,25 @@ describe('ContentGenerationPipeline', () => {
       const mockChunk2 = {
         id: 'chunk-2',
         choices: [{ delta: { content: '' }, finish_reason: 'stop' }],
+        usage: null,
       } as OpenAI.Chat.ChatCompletionChunk;
 
-      // Usage metadata chunk (empty candidates, has usage)
+      // Empty choices chunk between finish and usage
       const mockChunk3 = {
         id: 'chunk-3',
         object: 'chat.completion.chunk',
-        created: Date.now(),
-        model: 'test-model',
+        created: 0,
+        model: 'GLM-5.2-FP8',
+        choices: [],
+        usage: null,
+      } as OpenAI.Chat.ChatCompletionChunk;
+
+      // Usage metadata chunk (empty candidates, has usage)
+      const mockChunk4 = {
+        id: 'chunk-4',
+        object: 'chat.completion.chunk',
+        created: 0,
+        model: 'GLM-5.2-FP8',
         choices: [],
         usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
       } as OpenAI.Chat.ChatCompletionChunk;
@@ -3483,6 +3509,7 @@ describe('ContentGenerationPipeline', () => {
           yield mockChunk1;
           yield mockChunk2;
           yield mockChunk3;
+          yield mockChunk4;
         },
       };
 
@@ -3501,6 +3528,9 @@ describe('ContentGenerationPipeline', () => {
         },
       ];
 
+      const mockEmptyResponse = new GenerateContentResponse();
+      mockEmptyResponse.candidates = [];
+
       const mockUsageResponse = new GenerateContentResponse();
       mockUsageResponse.candidates = [];
       mockUsageResponse.usageMetadata = {
@@ -3512,54 +3542,47 @@ describe('ContentGenerationPipeline', () => {
         cachedInputTokensReported: false,
       });
 
-      // Expected merged response (finishReason + usageMetadata combined)
-      const mockMergedResponse = new GenerateContentResponse();
-      mockMergedResponse.candidates = [
-        {
-          content: { parts: [], role: 'model' },
-          finishReason: FinishReason.STOP,
-        },
-      ];
-      mockMergedResponse.usageMetadata = {
-        promptTokenCount: 10,
-        candidatesTokenCount: 20,
-        totalTokenCount: 30,
-      };
-
       (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([]);
       (mockConverter.convertOpenAIChunkToGemini as Mock)
         .mockReturnValueOnce(mockContentResponse)
         .mockReturnValueOnce(mockFinishResponse)
+        .mockReturnValueOnce(mockEmptyResponse)
         .mockReturnValueOnce(mockUsageResponse);
       (mockClient.chat.completions.create as Mock).mockResolvedValue(
         mockStream,
       );
 
-      // Act
       const resultGenerator = await pipeline.executeStream(
         request,
         userPromptId,
       );
-      const results = [];
-      for await (const result of resultGenerator) {
-        results.push(result);
-      }
+      const iterator = resultGenerator[Symbol.asyncIterator]();
 
-      // Assert
-      expect(results).toHaveLength(2); // Content chunk + merged finish/usage chunk
-      expect(results[0]).toBe(mockContentResponse);
+      const contentResult = await iterator.next();
+      if (contentResult.done) throw new Error('Expected a content response.');
+      expect(contentResult.value).toBe(mockContentResponse);
 
-      // The last result should have both finishReason and usageMetadata
-      const lastResult = results[1];
-      expect(lastResult.candidates?.[0]?.finishReason).toBe(FinishReason.STOP);
-      expect(lastResult.usageMetadata).toEqual({
+      const finishResult = await iterator.next();
+      if (finishResult.done) throw new Error('Expected a finish response.');
+      // Check before resuming: a later chunk can mutate the yielded object.
+      expect(finishResult.value.candidates?.[0]?.finishReason).toBe(
+        FinishReason.STOP,
+      );
+      expect(finishResult.value.usageMetadata).toEqual({
         promptTokenCount: 10,
         candidatesTokenCount: 20,
         totalTokenCount: 30,
       });
-      expect(lastResult.modelVersion).toBe('actual-provider-model');
-      expect(getGenAiUsageProvenance(lastResult.usageMetadata)).toEqual({
-        cachedInputTokensReported: false,
+      expect(finishResult.value.modelVersion).toBe('actual-provider-model');
+      expect(getGenAiUsageProvenance(finishResult.value.usageMetadata)).toEqual(
+        {
+          cachedInputTokensReported: false,
+        },
+      );
+
+      await expect(iterator.next()).resolves.toEqual({
+        value: undefined,
+        done: true,
       });
     });
 

--- a/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
@@ -3464,7 +3464,7 @@ describe('ContentGenerationPipeline', () => {
     it('should ignore empty choices while merging finishReason and usageMetadata', async () => {
       // Arrange
       const request: GenerateContentParameters = {
-        model: 'GLM-5.2-FP8',
+        model: 'test-model',
         contents: [{ parts: [{ text: 'Hello' }], role: 'user' }],
       };
       const userPromptId = 'test-prompt-id';
@@ -3481,25 +3481,20 @@ describe('ContentGenerationPipeline', () => {
       const mockChunk2 = {
         id: 'chunk-2',
         choices: [{ delta: { content: '' }, finish_reason: 'stop' }],
-        usage: null,
       } as OpenAI.Chat.ChatCompletionChunk;
 
       // Empty choices chunk between finish and usage
       const mockChunk3 = {
         id: 'chunk-3',
-        object: 'chat.completion.chunk',
-        created: 0,
-        model: 'GLM-5.2-FP8',
         choices: [],
-        usage: null,
-      } as OpenAI.Chat.ChatCompletionChunk;
+      } as unknown as OpenAI.Chat.ChatCompletionChunk;
 
       // Usage metadata chunk (empty candidates, has usage)
       const mockChunk4 = {
         id: 'chunk-4',
         object: 'chat.completion.chunk',
-        created: 0,
-        model: 'GLM-5.2-FP8',
+        created: Date.now(),
+        model: 'test-model',
         choices: [],
         usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
       } as OpenAI.Chat.ChatCompletionChunk;
@@ -3552,38 +3547,47 @@ describe('ContentGenerationPipeline', () => {
         mockStream,
       );
 
+      // Act
       const resultGenerator = await pipeline.executeStream(
         request,
         userPromptId,
       );
       const iterator = resultGenerator[Symbol.asyncIterator]();
 
-      const contentResult = await iterator.next();
-      if (contentResult.done) throw new Error('Expected a content response.');
-      expect(contentResult.value).toBe(mockContentResponse);
+      // Assert
+      try {
+        const contentResult = await iterator.next();
+        if (contentResult.done) throw new Error('Expected a content response.');
+        expect(contentResult.value).toBe(mockContentResponse);
 
-      const finishResult = await iterator.next();
-      if (finishResult.done) throw new Error('Expected a finish response.');
-      // Check before resuming: a later chunk can mutate the yielded object.
-      expect(finishResult.value.candidates?.[0]?.finishReason).toBe(
-        FinishReason.STOP,
-      );
-      expect(finishResult.value.usageMetadata).toEqual({
-        promptTokenCount: 10,
-        candidatesTokenCount: 20,
-        totalTokenCount: 30,
-      });
-      expect(finishResult.value.modelVersion).toBe('actual-provider-model');
-      expect(getGenAiUsageProvenance(finishResult.value.usageMetadata)).toEqual(
-        {
+        const finishResult = await iterator.next();
+        if (finishResult.done) throw new Error('Expected a finish response.');
+        // Check before resuming: a later chunk can mutate the yielded object.
+        expect(finishResult.value.candidates?.[0]?.finishReason).toBe(
+          FinishReason.STOP,
+        );
+        expect(finishResult.value.usageMetadata).toEqual({
+          promptTokenCount: 10,
+          candidatesTokenCount: 20,
+          totalTokenCount: 30,
+        });
+        expect(finishResult.value.modelVersion).toBe('actual-provider-model');
+        expect(
+          getGenAiUsageProvenance(finishResult.value.usageMetadata),
+        ).toEqual({
           cachedInputTokensReported: false,
-        },
-      );
+        });
 
-      await expect(iterator.next()).resolves.toEqual({
-        value: undefined,
-        done: true,
-      });
+        await expect(iterator.next()).resolves.toEqual({
+          value: undefined,
+          done: true,
+        });
+      } finally {
+        let result = await iterator.next();
+        while (!result.done) {
+          result = await iterator.next();
+        }
+      }
     });
 
     it('should handle ideal case where last chunk has both finishReason and usageMetadata', async () => {

--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -547,7 +547,7 @@ export class ContentGenerationPipeline {
 
         // Stage 2b: Filter empty responses to avoid downstream issues
         if (
-          response.candidates?.[0]?.content?.parts?.length === 0 &&
+          (response.candidates?.[0]?.content?.parts?.length ?? 0) === 0 &&
           !response.candidates?.[0]?.finishReason &&
           !response.usageMetadata &&
           // Preparation-only responses must reach ACP before arguments complete.


### PR DESCRIPTION
<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item as one long line.
-->

## What this PR does

This change treats OpenAI-compatible stream frames with no candidate parts as empty whether candidates are present, empty, or missing. It keeps finish-only, usage-only, and tool-call preparation frames valid, allowing an earlier finish response to remain buffered until request-level usage arrives or the stream reaches EOF.

The regression coverage reproduces the provider ordering content → finish without usage → empty choices without usage → usage-only → EOF. It asserts the finish response at the moment it is yielded so later in-place mutation cannot hide an early flush.

## Why it's needed

Some OpenAI-compatible providers emit an empty choices frame between `finish_reason` and the final usage-only frame. The previous empty-frame check only recognized an explicit empty parts array, so the no-candidate frame prematurely flushed the pending finish response. Transcript and telemetry consumers capture usage at yield time, leaving request-level token details missing even though the provider returned them.

## Reviewer Test Plan

Confirm that the reproduced four-frame sequence yields content followed by one finish response containing usage, with no extra response. Confirm that empty candidates and missing candidates are filtered while finish-only, usage-only, zero-usage, duplicate-finish, trailing-empty, and tool-preparation behavior remains unchanged.

### How to verify

Run the focused OpenAI pipeline, logging content generator, and base LLM client tests. Then build and type-check the repository. With an OpenAI-compatible endpoint that emits the reproduced ordering, confirm that the persisted API response and assistant transcript usage match the provider's input, output, total, and cached token counts, and that a tool call executes only once.

### Evidence (Before & After)

Before: the intermediate empty choices frame flushed a finish response without usage; the final usage frame only mutated the already-yielded object, so transcript token details were missing.

After: the empty frame is ignored, the finish response is yielded once with the final usage attached, and request-level transcript token details match the provider response.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested     |
| 🪟 Windows |   ⚠️ not tested     |
|  🐧 Linux  |   ⚠️ not tested     |

### Environment (optional)

macOS, Node.js 22.22.3, Qwen Code 0.20.1 local build, OpenAI-compatible streaming endpoint.

## Risk & Scope

- Main risk or tradeoff: Frames with no candidate parts, finish reason, usage, or tool-call preparation are now consistently dropped when candidates are empty or missing; this matches the existing empty-parts behavior.
- Not validated / out of scope: Historical transcript backfill, trace-side usage aggregation fallback, and release backports are not included.
- Breaking changes / migration notes: None. Public APIs, interfaces, telemetry schemas, and persisted formats are unchanged.

## Linked Issues

Fixes #7649

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本改动将没有 candidate parts 的 OpenAI 兼容流帧统一视为空帧，无论 candidates 存在、为空还是缺失。finish-only、usage-only 和工具调用 preparation 帧仍保持有效，使此前缓存的 finish 响应能够等待请求级 usage 到达或流结束后再输出。

回归测试复现了 content → 无 usage 的 finish → 无 usage 的空 choices → usage-only → EOF 的 provider 时序，并在 finish 响应实际 yield 的当下断言，避免后续原地修改掩盖提前输出问题。

## 为什么需要

部分 OpenAI 兼容 provider 会在 `finish_reason` 与最终 usage-only 帧之间发送一个空 choices 帧。旧的空帧判断只能识别显式空 parts 数组，因此无 candidate 的帧会提前输出待合并的 finish 响应。transcript 和 telemetry 消费者在 yield 时记录 usage，导致 provider 已返回 token 数据但请求级 token 明细仍然缺失。

## Reviewer 测试计划

确认复现的四帧顺序只输出 content 和一个已包含 usage 的 finish 响应，且没有额外响应。确认空 candidates 和缺失 candidates 会被过滤，同时 finish-only、usage-only、零 usage、重复 finish、尾空帧和工具 preparation 行为保持不变。

### 如何验证

运行 OpenAI pipeline、LoggingContentGenerator 和 BaseLlmClient 的定向测试，然后执行全量构建和类型检查。使用会产生该时序的 OpenAI 兼容 endpoint，确认持久化的 API response 与 assistant transcript usage 和 provider 返回的 input、output、total、cached token 完全一致，并确认工具调用只执行一次。

### 证据（修复前后）

修复前：中间空 choices 帧提前输出不含 usage 的 finish 响应；最终 usage 帧只修改已输出对象，因此 transcript token 明细缺失。

修复后：空帧被忽略，finish 响应只输出一次且已经附带最终 usage，请求级 transcript token 明细与 provider 响应一致。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅ 已测试     |
| 🪟 Windows |   ⚠️ 未测试     |
|  🐧 Linux  |   ⚠️ 未测试     |

### 环境（可选）

macOS、Node.js 22.22.3、Qwen Code 0.20.1 本地构建、OpenAI 兼容流式 endpoint。

## 风险与范围

- 主要风险或权衡：当 candidates 为空或缺失时，没有 candidate parts、finish reason、usage 或工具调用 preparation 的帧现在会被一致丢弃；这与既有空 parts 行为一致。
- 未验证或范围外：不包含历史 transcript 回填、trace 侧 usage 聚合回退和发布分支回补。
- 破坏性变更或迁移说明：无。公共 API、接口、telemetry schema 和持久化格式均未改变。

## 关联 Issue

Fixes #7649

</details>
