### PR TITLE
ci(triage): surface live progress via an early status comment

### DIFF
--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -259,6 +259,43 @@ jobs:
             echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
           fi
 
+      # The agent runs as one long step, but its output streams live to the
+      # Actions log. Post a status comment up front carrying that run link so a
+      # maintainer can watch progress instead of waiting silently until the
+      # first stage comment lands; "Finalize triage status comment" flips it to
+      # a terminal state at the end. Upsert by marker so a re-run reuses the one
+      # comment (no clutter). Best-effort: never fail the job over a status post.
+      - name: 'Post triage status comment'
+        if: "steps.resolve.outputs.number != ''"
+        shell: 'bash'
+        env:
+          GH_TOKEN: '${{ secrets.QWEN_CODE_BOT_TOKEN || secrets.CI_BOT_PAT }}'
+          NUMBER: '${{ steps.resolve.outputs.number }}'
+          RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+        run: |-
+          set -uo pipefail
+          MARKER='<!-- qwen-triage stage=status -->'
+          printf -v BODY '%s\n\n%s\n\n%s' \
+            "$MARKER" \
+            "🔄 **Qwen Triage is running** — [watch live progress]($RUN_URL). Stage results will post in this thread as they complete." \
+            "🔄 **Qwen Triage 正在运行** —— [查看实时进度]($RUN_URL)。各阶段结果完成后会更新在本线程。"
+          EXISTING_ID="$(
+            gh api "repos/$GITHUB_REPOSITORY/issues/$NUMBER/comments" \
+              --method GET --paginate -F per_page=100 |
+              jq -rs --arg m "$MARKER" \
+                '[.[][] | select(.body | contains($m))] | last | .id // empty'
+          )" || EXISTING_ID=''
+          if [ -n "$EXISTING_ID" ]; then
+            gh api --method PATCH \
+              "repos/$GITHUB_REPOSITORY/issues/comments/$EXISTING_ID" \
+              -f body="$BODY" >/dev/null ||
+              echo "::warning::Failed to update triage status comment; continuing." >&2
+          else
+            gh api "repos/$GITHUB_REPOSITORY/issues/$NUMBER/comments" \
+              -f body="$BODY" >/dev/null ||
+              echo "::warning::Failed to post triage status comment; continuing." >&2
+          fi
+
       - name: 'Inject model name into triage signature'
         shell: 'bash'
         env:
@@ -373,6 +410,47 @@ jobs:
             "The stage comments above were updated with the latest result. [View workflow run]($RUN_URL)."
           gh api "repos/$GITHUB_REPOSITORY/issues/$NUMBER/comments" \
             -f body="$BODY" >/dev/null
+
+      # Flip the early status comment to a terminal state so a lingering
+      # "running" line doesn't outlive the run. Neutral wording — the verdict
+      # lives in the stage comments above; this only records that the run ended
+      # and keeps the run link. Same marker → edits the one comment, no second
+      # post. Best-effort, on both success and failure.
+      - name: 'Finalize triage status comment'
+        if: "(success() || failure()) && steps.resolve.outputs.number != ''"
+        shell: 'bash'
+        env:
+          GH_TOKEN: '${{ secrets.QWEN_CODE_BOT_TOKEN || secrets.CI_BOT_PAT }}'
+          NUMBER: '${{ steps.resolve.outputs.number }}'
+          RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+          TRIAGE_OUTCOME: '${{ steps.triage.outcome }}'
+        run: |-
+          set -uo pipefail
+          MARKER='<!-- qwen-triage stage=status -->'
+          if [ "${TRIAGE_OUTCOME:-}" = 'success' ]; then
+            EN="✅ **Qwen Triage finished** — [view run]($RUN_URL). See the stage comments above for the result."
+            ZH="✅ **Qwen Triage 已完成** —— [查看运行]($RUN_URL)。结果见上方各阶段评论。"
+          else
+            EN="⚠️ **Qwen Triage ended early** — [view run]($RUN_URL). It stopped before finishing; check the run log."
+            ZH="⚠️ **Qwen Triage 提前结束** —— [查看运行]($RUN_URL)。未跑完,请查看运行日志。"
+          fi
+          printf -v BODY '%s\n\n%s\n\n%s' "$MARKER" "$EN" "$ZH"
+          EXISTING_ID="$(
+            gh api "repos/$GITHUB_REPOSITORY/issues/$NUMBER/comments" \
+              --method GET --paginate -F per_page=100 |
+              jq -rs --arg m "$MARKER" \
+                '[.[][] | select(.body | contains($m))] | last | .id // empty'
+          )" || EXISTING_ID=''
+          if [ -n "$EXISTING_ID" ]; then
+            gh api --method PATCH \
+              "repos/$GITHUB_REPOSITORY/issues/comments/$EXISTING_ID" \
+              -f body="$BODY" >/dev/null ||
+              echo "::warning::Failed to finalize triage status comment; continuing." >&2
+          else
+            gh api "repos/$GITHUB_REPOSITORY/issues/$NUMBER/comments" \
+              -f body="$BODY" >/dev/null ||
+              echo "::warning::Failed to post final triage status comment; continuing." >&2
+          fi
 
   # On-demand real-user testing: a write-permission user comments
   # `@qwen-code /tmux` on a PR to launch the changed app in a tmux TUI and

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -198,6 +198,29 @@ describe('qwen-triage tmux workflow', () => {
     expect(notifyStep).not.toContain('-X PATCH');
   });
 
+  it('posts an early live-progress status comment and finalizes the same one', () => {
+    const statusStep = step('Post triage status comment');
+    // Announced up front (before the long agent step) with the live run link.
+    expect(statusStep).toContain('<!-- qwen-triage stage=status -->');
+    expect(statusStep).toContain('actions/runs/${{ github.run_id }}');
+    expect(statusStep).toContain('watch live progress');
+    // Upsert by marker so a re-run reuses the one comment instead of stacking.
+    expect(statusStep).toContain('contains($m)');
+    expect(statusStep).toContain('--method PATCH');
+    // Best-effort: a failed status post warns and continues, never fails triage.
+    expect(statusStep).toContain('set -uo pipefail');
+    expect(statusStep).toContain('continuing.');
+
+    const finalizeStep = step('Finalize triage status comment');
+    // Runs on both outcomes and edits the SAME marker comment (no second post).
+    expect(finalizeStep).toContain('<!-- qwen-triage stage=status -->');
+    expect(finalizeStep).toContain('success() || failure()');
+    expect(finalizeStep).toContain('steps.triage.outcome');
+    expect(finalizeStep).toContain('--method PATCH');
+    expect(finalizeStep).toContain('Qwen Triage finished');
+    expect(finalizeStep).toContain('ended early');
+  });
+
   it('reports timeout and infra-error without claiming the flow was exercised', () => {
     const postStep = step('Post tmux result comment');
 


### PR DESCRIPTION
## What this PR does

Gives `@qwen-code /triage` an early, in-thread **progress signal**. The moment triage starts it posts a status comment carrying a link to the **live Actions run**, and finalizes that same comment when the run ends.

## Why

Triage runs the agent as **one long workflow step**. Today the only immediate acknowledgement is a 👀 reaction (and only on comment triggers) — after that the PR thread is silent until the first stage comment lands (agent boot → Stage 1 → the long Stage 2 code-review + tmux testing). A maintainer can't tell whether it started or how far along it is. The agent's output **already streams live to the Actions log**, but that run link was only surfaced at the very end (in one silent-re-run edge case), so nobody could watch during the run. `pull_request_target` auto-triage had no acknowledgement at all.

The fix is to surface the existing live log **early** — the Actions log is far more granular (every tool call, every `capture-pane`, the model's reasoning) than any status text we could synthesize.

## How

Two small workflow steps in the `triage` job, no agent/skill dependency:

- **`Post triage status comment`** (right after the number resolves, before the agent) — posts `<!-- qwen-triage stage=status -->` → `🔄 Qwen Triage is running — [watch live progress](run)`. Covers manual, `pull_request_target`, and `workflow_dispatch` triage.
- **`Finalize triage status comment`** (`success() || failure()`) — edits the **same** comment to a terminal `✅ finished` / `⚠️ ended early` (from `steps.triage.outcome`), keeping the run link. Neutral wording — the verdict lives in the stage comments.

Both **upsert by marker**, so a re-run reuses the one comment (no clutter/stacking), and both are **best-effort** (`set -uo pipefail` + warn-and-continue) — a failed status post never fails triage.

**Deliberately not done:** an agent-maintained per-stage status line. It would be less reliable exactly where it's most needed (mid-Stage-2, when the agent is busy), cost agent turns, and risk drift from the real stage comments — and the live log already does that job better. If the live link doesn't close the Stage-2 gap, a targeted "posting Stage 2b test now" line is the cheaper next step.

## Reviewer Test Plan

- `scripts/tests/qwen-triage-workflow.test.js` — **13 passed** (adds one test pinning: early status carries the `run_id` link + marker; both steps upsert via `--method PATCH`; best-effort). Mutation-verified: removing `watch live progress`, or breaking the finalize `PATCH`, turns exactly that test red.
- **yamllint** (`quote-type: single, allow-quoted-quotes`) — clean (the `if:` values are double-quoted only because they contain `''`).
- **shellcheck 0.11.0** (CI's pinned version) on both run blocks — no findings; **`bash -n`** — clean.
- Diff is additions-only (+78 workflow / +23 test); the pre-existing `SC2016` note at line ~1009 (`publish-tmux`) is untouched.

## Risk & Scope

- Adds **one** comment per triaged item (upserted + edited in place, not per-run spam). That's the cost of the visibility.
- No behavior change to the agent, the review verdict, or the tmux path. Best-effort and independent of agent reliability.
- Uses the same bot token as the agent's stage comments, so the finalize edit is same-identity. Breaking changes / migration: none.

## Linked Issues

Follow-up to the triage-verification work (#7648) — same goal of making `/triage` legible to maintainers, here for *progress* rather than *evidence depth*.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

给 `@qwen-code /triage` 一个**早期、线程内的进度信号**:triage 一开始就发一条带**实时 Actions 运行**链接的状态评论,运行结束时把**同一条**评论定稿。

## 为什么

triage 把 agent 跑在**单个 workflow step** 里。现在唯一的即时反馈是 👀 reaction(还仅限评论触发),之后 PR 线程一直静默,直到首个 stage 评论落地(agent 启动 → Stage 1 → 最长的 Stage 2 代码评审+tmux 测试)。维护者看不出它开没开、跑到哪。agent 输出**本就实时流进 Actions 日志**,但那个运行链接只在最后(某个静默 re-run 边角分支)才露出,运行中没人能看;`pull_request_target` 自动 triage 更是**完全没有**任何反馈。

修法是把已有的实时日志**早点**露出来 —— Actions 日志的粒度(每个工具调用、每次 `capture-pane`、模型推理)远比我们能拼出的状态文本细。

## 怎么做

`triage` job 里两个小步骤,不依赖 agent/skill:

- **`Post triage status comment`**(number 解析后、agent 之前)—— 发 `<!-- qwen-triage stage=status -->` → `🔄 正在运行 — [查看实时进度](run)`。覆盖手动、`pull_request_target`、`workflow_dispatch`。
- **`Finalize triage status comment`**(`success() || failure()`)—— 把**同一条**评论改为终态 `✅ 已完成` / `⚠️ 提前结束`(依据 `steps.triage.outcome`),保留运行链接。措辞中性 —— 裁决在各阶段评论里。

两者都**按 marker upsert**,re-run 复用同一条评论(不刷屏/不堆叠);都是**尽力而为**(`set -uo pipefail` + 告警后继续)—— 状态评论失败绝不拖垮 triage。

**特意没做:**由 agent 维护的逐阶段状态行。它在最需要的地方(Stage 2 中段、agent 正忙时)最不可靠,耗 agent turn,还会和真实 stage 评论漂移 —— 而实时日志已经把这活干得更好。若实时链接堵不住 Stage 2 那段空窗,更便宜的下一步是一行靶向的"正在测 Stage 2b"。

## 评审验证

- `qwen-triage-workflow.test.js` —— **13 通过**(新增一条:早期状态带 `run_id` 链接+marker;两步都用 `--method PATCH` upsert;尽力而为)。变异验证:删 `watch live progress` 或破坏 finalize 的 `PATCH`,恰好该测试变红。
- **yamllint**(`quote-type: single, allow-quoted-quotes`)—— 干净(`if:` 用双引号仅因含 `''`)。
- **shellcheck 0.11.0**(CI 固定版本)两个 run 块 —— 无发现;**`bash -n`** —— 干净。
- diff 纯新增(+78 workflow / +23 test);第 ~1009 行(`publish-tmux`)预存的 `SC2016` 未触碰。

## 风险与范围

- 每个被 triage 的条目多**一条**评论(就地 upsert+编辑,非逐 run 刷屏)—— 这是可见性的代价。
- 不改 agent、裁决、tmux 路径的任何行为。尽力而为,不依赖 agent 可靠性。
- 用与 agent stage 评论相同的 bot token,finalize 编辑是同身份。破坏性变更:无。

## 关联 Issue

triage 验证工作(#7648)的跟进 —— 同样是让 `/triage` 对维护者更透明,这次针对*进度*而非*证据深度*。

</details>
