### PR TITLE
test(web-shell): cover restored-history pagination retries

### DIFF
--- a/packages/sdk-typescript/test/unit/DaemonClient.test.ts
+++ b/packages/sdk-typescript/test/unit/DaemonClient.test.ts
@@ -1340,6 +1340,27 @@ describe('DaemonClient', () => {
       });
     });
 
+    it('encodes a before-record transcript boundary', async () => {
+      const { fetch, calls } = recordingFetch(() =>
+        jsonResponse(200, {
+          v: 1,
+          sessionId: 'with/slash',
+          events: [],
+          hasMore: false,
+        }),
+      );
+      const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+
+      await client.getSessionTranscriptPage('with/slash', {
+        beforeRecordId: 'record/1',
+        limit: 2,
+      });
+
+      expect(calls[0]?.url).toBe(
+        'http://daemon/session/with%2Fslash/transcript?beforeRecordId=record%2F1&limit=2',
+      );
+    });
+
     it('uses direct REST fetch even when an ACP transport is configured', async () => {
       const { fetch, calls } = recordingFetch(() =>
         jsonResponse(200, {

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -9096,6 +9096,24 @@ describe('DaemonSessionProvider', () => {
     });
 
     expect(sdkMocks.getSessionTranscriptPage).toHaveBeenCalledTimes(2);
+    expect(sdkMocks.getSessionTranscriptPage).toHaveBeenNthCalledWith(
+      1,
+      session.sessionId,
+      {
+        beforeRecordId: 'record-2',
+        limit: 25,
+        clientId: session.clientId,
+      },
+    );
+    expect(sdkMocks.getSessionTranscriptPage).toHaveBeenNthCalledWith(
+      2,
+      session.sessionId,
+      {
+        beforeRecordId: 'record-2',
+        limit: 25,
+        clientId: session.clientId,
+      },
+    );
     expect(
       blocks.map((block) => ('text' in block ? block.text : undefined)),
     ).toEqual(['older prompt', 'recent prompt']);


### PR DESCRIPTION
## What this PR does

Adds regression coverage for restored-session transcript pagination. It verifies that a `beforeRecordId` boundary is URL-encoded when requesting a transcript page and that retrying a transient initial-page failure preserves that boundary and the session client identifier.

## Why it's needed

Restored sessions with truncated replay use their first persisted record as the boundary for loading older transcript history. A regression in query encoding or retry state could request the wrong page, skip history, or make the retry inconsistent. These tests preserve the pagination contract introduced by #7064.

## Reviewer Test Plan

### How to verify

Run the focused SDK and WebUI transcript-pagination tests. Confirm that `record/1` is encoded as `record%2F1` in the daemon request URL, then simulate a transient first-page failure and confirm that both the failed request and its retry send `beforeRecordId: 'record-2'`, `limit: 25`, and the active session client identifier.

### Evidence (Before & After)

N/A - this PR adds non-user-visible regression coverage.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS     | ⚠️ not tested |
|  Windows   | ✅ tested |
|  Linux     | ⚠️ not tested |

### Environment (optional)

Windows 11, Node.js v22.11.0, npm 11.12.0.

## Risk & Scope

- Main risk or tradeoff: Test-only change; no production behavior changes.
- Not validated / out of scope: Manual TUI verification is not applicable; macOS and Linux were not tested locally.
- Breaking changes / migration notes: None.

## Linked Issues

Refs #7084

<details>
<summary>中文说明</summary>

## 此 PR 的内容

为已恢复会话的转录分页添加回归覆盖。它验证请求转录页时会对 `beforeRecordId` 边界进行 URL 编码，并验证首次页面请求发生瞬态失败后的重试会保留该边界和会话客户端标识符。

## 为什么需要它

回放被截断的已恢复会话会使用其第一条持久化记录作为加载较旧转录历史的边界。查询编码或重试状态的回归可能请求错误页面、跳过历史记录，或使重试不一致。这些测试保护由 #7064 引入的分页契约。

## 审阅者测试计划

### 如何验证

运行聚焦的 SDK 和 WebUI 转录分页测试。确认 daemon 请求 URL 中的 `record/1` 被编码为 `record%2F1`，然后模拟一次瞬态的首页面失败，并确认失败请求及其重试均发送 `beforeRecordId: 'record-2'`、`limit: 25` 和活动会话客户端标识符。

### 证据（前后对比）

不适用 - 此 PR 添加非用户可见的回归覆盖。

### 测试环境

|     操作系统     | 状态 |
| :--------------: | :--: |
|      macOS       | ⚠️ 未测试 |
|     Windows      | ✅ 已测试 |
|      Linux       | ⚠️ 未测试 |

### 环境（可选）

Windows 11、Node.js v22.11.0、npm 11.12.0。

## 风险与范围

- 主要风险或取舍：仅测试改动；不改变生产行为。
- 未验证 / 范围外：不适用手动 TUI 验证；未在本地测试 macOS 和 Linux。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Refs #7084

</details>
