### PR TITLE
fix(core): avoid required tools in DashScope thinking

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
@@ -713,6 +713,28 @@ describe('ContentGenerationPipeline', () => {
         expectedToolChoice: undefined,
       },
       {
+        name: 'remove required tool selection when thinking is enabled on the wire',
+        baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+        model: 'qwen3.7-max',
+        extraBody: { enable_thinking: true },
+        thinkingMandatory: undefined,
+        reasoning: undefined,
+        includeThoughts: true,
+        expectedThinking: true,
+        expectedToolChoice: undefined,
+      },
+      {
+        name: 'preserve required tool selection when thinking is not enabled',
+        baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+        model: 'qwen3.7-max',
+        extraBody: undefined,
+        thinkingMandatory: undefined,
+        reasoning: undefined,
+        includeThoughts: true,
+        expectedThinking: undefined,
+        expectedToolChoice: 'required',
+      },
+      {
         name: 'never emit the disable even under the reasoning opt-out',
         baseUrl:
           'https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1',

--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -946,10 +946,16 @@ export class ContentGenerationPipeline {
           delete typed['chat_template_kwargs'];
         }
       }
-      // DashScope rejects forced tool selection while thinking is enabled.
-      if (isDashScope && typed['tool_choice'] === 'required') {
-        delete typed['tool_choice'];
-      }
+    }
+
+    const typed = providerRequest as unknown as Record<string, unknown>;
+    // DashScope rejects forced tool selection while thinking is enabled.
+    if (
+      isDashScope &&
+      typed['tool_choice'] === 'required' &&
+      (thinkingMandatory || typed['enable_thinking'] === true)
+    ) {
+      delete typed['tool_choice'];
     }
 
     return providerRequest;


### PR DESCRIPTION
## What this PR does

When a DashScope request has thinking enabled, it no longer sends a forced `tool_choice: "required"`. Forced tool selection stays unchanged when thinking is off and for non-DashScope providers.

## Why it's needed

Structured side queries such as memory recall use forced tool selection. DashScope rejects that setting while thinking is active, so users who enable thinking without also setting the separate mandatory-thinking option receive a 400 response. The previous safeguard only recognized the mandatory-thinking option instead of the final request state.

## Reviewer Test Plan

### How to verify

Configure a DashScope model with thinking enabled but without mandatory thinking, then issue a structured side query using forced function calling. The outgoing request should keep thinking enabled and omit forced tool selection. Repeat without thinking enabled and confirm that forced tool selection is still present.

### Evidence (Before & After)

Before, the reproduced wire shape contained `{ enable_thinking: true, tool_choice: "required" }`, which DashScope rejects. After, the focused pipeline suite confirms that the same thinking request omits `tool_choice`, while the non-thinking control keeps it. The focused suite passes 122/122 tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Node.js 22.22.1 and npm 10.9.4.

## Risk & Scope

- Main risk or tradeoff: accidentally removing forced tool selection from requests where it remains valid; regression coverage protects the thinking and non-thinking branches.
- Not validated / out of scope: no live DashScope request was sent; runtime learning for other OpenAI-compatible providers remains separate follow-up work.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #7659

<details>
<summary>中文说明</summary>

## 本 PR 的改动

当 DashScope 请求已启用思考时，不再发送强制的 `tool_choice: "required"`。未启用思考时，以及非 DashScope 提供商的行为保持不变。

## 为什么需要此改动

记忆召回等结构化侧查询会使用强制工具选择。DashScope 在启用思考时会拒绝该设置，因此只启用思考、但没有另外设置强制思考选项的用户会收到 400 响应。之前的保护逻辑只识别强制思考选项，而没有检查最终请求的实际状态。

## 审查者测试计划

### 如何验证

配置一个启用思考但未启用强制思考的 DashScope 模型，然后使用强制函数调用发起结构化侧查询。发出的请求应保留思考设置，并省略强制工具选择。随后在未启用思考的情况下重复测试，确认强制工具选择仍然存在。

### 证据（改动前后）

改动前，复现出的请求包含 `{ enable_thinking: true, tool_choice: "required" }`，DashScope 会拒绝该组合。改动后，针对性的 pipeline 测试确认相同的思考请求会省略 `tool_choice`，而非思考对照请求仍然保留该字段。针对性测试共 122 项，全部通过。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|    🍏 macOS      |  ⚠️  |
|   🪟 Windows     |  ⚠️  |
|     🐧 Linux     |  ✅  |

### 环境（可选）

Node.js 22.22.1 和 npm 10.9.4。

## 风险与范围

- 主要风险或权衡：可能误删仍然有效的强制工具选择；回归测试覆盖了思考与非思考两个分支。
- 未验证或范围之外：没有发送真实的 DashScope 请求；其他 OpenAI 兼容提供商的运行时学习仍属于后续独立工作。
- 破坏性变更或迁移说明：无。

## 关联 Issue

Fixes #7659

</details>
