### PR TITLE
fix(web-shell): show full session names on hover

### DIFF
--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.collapse-persist.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.collapse-persist.test.tsx
@@ -244,6 +244,35 @@ describe('WebShellSidebar collapsed session group persistence', () => {
     expect(sessionName?.textContent).toContain('API review');
   });
 
+  it('shows the complete archived session name in a native tooltip', async () => {
+    connection.capabilities = {
+      qwenCodeVersion: '1.2.3',
+      features: ['session_organization', 'session_archive'],
+    };
+    archived.sessions = [
+      makeSession('session-archived', {
+        displayName: 'Archived task',
+        isArchived: true,
+      }),
+    ];
+    archived.data = archived.sessions;
+
+    renderSidebar();
+    await flushSidebar();
+
+    const archivedHeader = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('button[aria-expanded]'),
+    ).find((btn) => btn.textContent?.includes('Archived'));
+    expect(archivedHeader).not.toBeNull();
+    act(() => click(archivedHeader!));
+    await flushSidebar();
+
+    const sessionName = container.querySelector<HTMLElement>(
+      '[title="Archived task"]',
+    );
+    expect(sessionName?.textContent).toContain('Archived task');
+  });
+
   it('writes collapsed section ids with the qwen-code-web-shell-* key', async () => {
     renderSidebar();
     await flushSidebar();

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.collapse-persist.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.collapse-persist.test.tsx
@@ -234,6 +234,16 @@ afterEach(() => {
 });
 
 describe('WebShellSidebar collapsed session group persistence', () => {
+  it('shows the complete session name in a native tooltip', async () => {
+    renderSidebar();
+    await flushSidebar();
+
+    const sessionName = container.querySelector<HTMLElement>(
+      '[title="API review"]',
+    );
+    expect(sessionName?.textContent).toContain('API review');
+  });
+
   it('writes collapsed section ids with the qwen-code-web-shell-* key', async () => {
     renderSidebar();
     await flushSidebar();

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -2808,7 +2808,9 @@ export function WebShellSidebar({
               busy && styles.busySession,
             )}
           >
-            <span className={styles.sessionText}>{label}</span>
+            <span className={styles.sessionText} title={label}>
+              {label}
+            </span>
             <div className={styles.sessionMetaSlot}>
               <span className={styles.sessionTime}>{time}</span>
               {hasArchivedActions && (
@@ -2966,7 +2968,7 @@ export function WebShellSidebar({
                 </form>
               ) : (
                 <>
-                  <span className={styles.sessionText}>
+                  <span className={styles.sessionText} title={label}>
                     {session.worktree && (
                       <GitForkIcon
                         size={11}

--- a/packages/web-shell/client/components/sidebar/WorkspaceSection.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WorkspaceSection.test.tsx
@@ -70,6 +70,7 @@ function renderSection(
     onOpenGitDiff: (cwd: string) => void;
     client: DaemonClient;
     reloadToken: number;
+    expanded: boolean;
   }> = {},
 ): void {
   act(() => {
@@ -79,6 +80,7 @@ function renderSection(
           workspace={overrides.workspace ?? trustedWorkspace}
           client={overrides.client ?? makeClient()}
           reloadToken={overrides.reloadToken ?? 0}
+          expanded={overrides.expanded}
           untrustedLabel="Untrusted"
           readOnlyLabel="Read-only"
           trustToOpenLabel="Trust to open"
@@ -131,6 +133,34 @@ describe('WorkspaceSection label', () => {
 
     expect(container.textContent).toContain('Payments API');
     expect(container.textContent).not.toContain('project');
+  });
+
+  it('shows the complete read-only session name in a native tooltip', async () => {
+    const listWorkspaceSessions = vi.fn().mockResolvedValue([
+      {
+        sessionId: 'session-1',
+        displayName: 'A very long session name',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      } as DaemonSessionSummary,
+    ]);
+    const client = {
+      workspaceByCwd: vi.fn(() => ({
+        workspaceGit,
+        listWorkspaceSessions,
+        listSessionGroups: vi.fn().mockResolvedValue({ groups: [] }),
+      })),
+    } as unknown as DaemonClient;
+
+    renderSection({
+      workspace: untrustedWorkspace,
+      client,
+      expanded: true,
+    });
+    await flush();
+
+    expect(
+      container.querySelector('[title="A very long session name"]'),
+    ).not.toBeNull();
   });
 });
 

--- a/packages/web-shell/client/components/sidebar/WorkspaceSection.tsx
+++ b/packages/web-shell/client/components/sidebar/WorkspaceSection.tsx
@@ -444,7 +444,9 @@ export function WorkspaceSection({
                     role="note"
                     aria-label={`${label}${time ? `, ${time}` : ''}. ${trustToOpenLabel}`}
                   >
-                    <span className={styles.sessionName}>{label}</span>
+                    <span className={styles.sessionName} title={label}>
+                      {label}
+                    </span>
                     {time && <span className={styles.sessionTime}>{time}</span>}
                   </div>
                 );


### PR DESCRIPTION
## What this PR does

Adds a lightweight native tooltip to session names in the Web Shell sidebar, including active, archived, and read-only workspace session rows. Existing single-line truncation remains unchanged, while hovering the name exposes the complete label.

## Why it's needed

Long session names are truncated to preserve the sidebar layout, but users currently have no direct way to read the complete name from the session row. A native tooltip provides that information without adding custom overlay state, positioning logic, or visual noise.

## Reviewer Test Plan

### How to verify

Open the Web Shell with a session whose display name is wider than the sidebar. Confirm the row remains truncated with an ellipsis, then hover the session name and verify the browser displays the complete label. Repeat for an archived session and a read-only session under an untrusted workspace. The focused unit tests passed with 19 tests, and the Web Shell TypeScript typecheck and Prettier checks passed.

### Evidence (Before & After)

Before: Truncated session names could not be read in full directly from the sidebar row.

After: Hovering a session name displays its complete label through the browser's native tooltip while preserving the existing truncated layout.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local Vitest and TypeScript checks on macOS.

## Risk & Scope

- Main risk or tradeoff: Native tooltip appearance and delay are controlled by the browser and operating system.
- Not validated / out of scope: Custom tooltip styling, touch-only discovery, and changes to session name generation are out of scope.
- Breaking changes / migration notes: None.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

为 Web Shell 左侧栏中的会话名称增加轻量的浏览器原生 tooltip，覆盖活跃会话、归档会话和只读工作区会话。现有单行截断行为保持不变，鼠标悬停在名称上时可以查看完整标签。

## 为什么需要

较长的会话名称会被截断，以保持侧边栏布局稳定，但用户目前无法直接从会话行查看完整名称。使用浏览器原生 tooltip 可以补充完整信息，同时无需增加自定义浮层状态、定位逻辑或额外视觉干扰。

## Reviewer 测试计划

### 如何验证

打开 Web Shell，并准备一个显示名称宽度超过侧边栏的会话。确认会话行仍使用省略号截断，然后将鼠标悬停在会话名称上，验证浏览器显示完整标签。对归档会话和未信任工作区下的只读会话重复验证。相关单元测试共 19 项均通过，Web Shell TypeScript 类型检查和 Prettier 检查也已通过。

### 前后效果证据

修改前：侧边栏中被截断的会话名称无法直接查看完整内容。

修改后：悬停会话名称时，浏览器原生 tooltip 会显示完整标签，同时保留现有的截断布局。

### 测试系统

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

在 macOS 上运行本地 Vitest 和 TypeScript 检查。

## 风险与范围

- 主要风险或取舍：原生 tooltip 的外观和显示延迟由浏览器及操作系统控制。
- 未验证 / 范围外：自定义 tooltip 样式、纯触屏设备上的发现性，以及会话名称生成逻辑的修改均不在本次范围内。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
