### PR TITLE
fix: silence xterm.js parser diagnostics leaking from headless shell terminals

### DIFF
--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -444,6 +444,32 @@ describe('ShellExecutionService', () => {
       );
     });
 
+    it('suppresses parser diagnostics for malformed PTY output', async () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      try {
+        const { result } = await simulateExecution(
+          'malformed-output',
+          (pty) => {
+            pty.onData.mock.calls[0][0]('\u001b\xb0');
+            pty.onData.mock.calls[0][0]('recovered');
+            pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+          },
+        );
+
+        expect(
+          consoleErrorSpy.mock.calls.some((args) =>
+            args.some((arg) => String(arg).includes('Parsing error')),
+          ),
+        ).toBe(false);
+        expect(result.output).toContain('recovered');
+      } finally {
+        consoleErrorSpy.mockRestore();
+      }
+    });
+
     it('should correctly decode multi-byte characters split across chunks', async () => {
       const { result } = await simulateExecution('echo "你好"', (pty) => {
         const multiByteChar = '你好';

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -395,6 +395,8 @@ const replayTerminalOutput = async (
     rows,
     scrollback: 10000,
     convertEol: true,
+    // This headless terminal only captures output, so suppress parser diagnostics.
+    logLevel: 'off',
   });
 
   try {
@@ -1486,6 +1488,8 @@ export class ShellExecutionService {
           cols,
           rows,
           scrollback: MAX_LIVE_TERMINAL_SCROLLBACK_LINES,
+          // This headless terminal only captures output, so suppress parser diagnostics.
+          logLevel: 'off',
         });
         headlessTerminal.scrollToTop();
 


### PR DESCRIPTION
## What this PR does

Sets `logLevel: 'off'` on the two headless `@xterm/headless` `Terminal` instances in `packages/core/src/services/shellExecutionService.ts` — the replay terminal used to reserialize captured output and the live PTY terminal used during shell execution — and adds a regression test. A brief inline comment at each construction site records why the log level is disabled so it is not dropped in a later edit.

## Why it's needed

When a shell command emits an incomplete or invalid ANSI escape sequence — for example an `ESC` byte followed by `0xB0`, which is common with GBK/GB2312 (non‑UTF‑8) output — xterm.js's default `LogService` writes an `xterm.js: Parsing error: {...}` line to `console.error`. The parser recovers gracefully with no data loss and continues processing subsequent bytes, so the message is purely diagnostic. Because these two terminals run inside the shell execution service only to capture and serialize output, that benign diagnostic escapes to stderr and surfaces as alarming, repeated noise for anything that forwards child‑process stderr verbatim (the case reported in #7631). In a normal interactive TUI the same message is swallowed and never seen. These terminals never render diagnostics to a user, so turning their internal logging off is the appropriate scope for silencing the noise without changing any captured output.

## Reviewer Test Plan

This is a small, non‑user‑visible change (it suppresses an internal stderr diagnostic), so the plan below is a focused unit test plus a direct before/after probe of the library behavior rather than a TUI screenshot.

### How to verify

Run the focused unit tests:

```
cd packages/core && npx vitest run src/services/shellExecutionService.test.ts
```

All tests pass, including the new case `suppresses parser diagnostics for malformed PTY output`, which feeds an `ESC` + `0xB0` sequence followed by normal text through the shell execution path with a `console.error` spy, then asserts that no `Parsing error` line is emitted while the captured output still contains the trailing text (proving the parser still recovers).

The underlying behavior can also be confirmed directly against `@xterm/headless`: constructing a `Terminal` and writing `"\xb0recovered"` emits one `console.error` containing `Parsing error` by default and zero once `logLevel: 'off'` is set; in both cases the buffer still reads `recovered`.

### Evidence (Before & After)

Not user‑visible (this suppresses an internal stderr diagnostic, not TUI output). Verified via the new unit test and a direct `@xterm/headless` probe:

- Before (`{ allowProposedApi: true }`): writing `\xb0recovered` → 1 `console.error` call containing `Parsing error`; buffer line = `recovered`.
- After (`{ allowProposedApi: true, logLevel: 'off' }`): same write → 0 `console.error` calls; buffer line = `recovered`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

Unit tests only (`vitest`); no runtime sandbox needed.

## Risk & Scope

- Main risk or tradeoff: internal xterm.js log output from these two headless terminals is now suppressed entirely. They are used only for output capture and serialization and never surface diagnostics to the user, so this removes noise without hiding anything a user would otherwise see.
- Not validated / out of scope: does not change encoding/charset detection and does not touch AcpBridge stderr forwarding; it only sets the log level on the two headless terminals.
- Breaking changes / migration notes: none.

## Linked Issues

Closes #7631

<details>
<summary>中文说明</summary>

在 `packages/core/src/services/shellExecutionService.ts` 中的两个 `@xterm/headless` 无头 `Terminal` 实例上设置 `logLevel: 'off'`——一个是用于重新序列化已捕获输出的 replay 终端，另一个是 shell 执行期间使用的实时 PTY 终端——并新增一个回归测试。每个构造处都加了一行简短注释，说明为何关闭日志级别，以免日后被误删。

当 shell 命令输出不完整或无效的 ANSI 转义序列时（例如 `ESC` 字节后跟 `0xB0`，这在 GBK/GB2312 等非 UTF‑8 输出中很常见），xterm.js 默认的 `LogService` 会向 `console.error` 写入一行 `xterm.js: Parsing error: {...}`。解析器会自动恢复且不丢失数据，因此该信息纯属诊断性质。由于这两个终端仅用于在 shell 执行服务内部捕获和序列化输出，该诊断信息会外泄到 stderr，对任何原样转发子进程 stderr 的场景（即 #7631 报告的情况）表现为反复出现、令人担忧的噪声；而在正常的交互式 TUI 中同样的信息会被吞掉、从不显示。这些终端从不向用户呈现诊断信息，因此关闭其内部日志是在不改变任何已捕获输出的前提下消除该噪声的恰当范围。

验证：`cd packages/core && npx vitest run src/services/shellExecutionService.test.ts`，全部测试通过，包括新增用例 `suppresses parser diagnostics for malformed PTY output`。修复前：写入 `\xb0recovered` 会产生一次包含 `Parsing error` 的 `console.error`；修复后：不再产生该调用，且缓冲区仍为 `recovered`。仅在 macOS 上本地验证（单元测试）。

</details>

AI was used for assistance.
