### PR TITLE
feat(core): add Goal v3 runtime orchestration

### DIFF
--- a/packages/core/src/goals/goal-runtime.integration.test.ts
+++ b/packages/core/src/goals/goal-runtime.integration.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  GoalStateRecordPayloadV2,
+  GoalTurnPermit,
+  TranscriptCursor,
+} from './goal-protocol.js';
+import {
+  createGoalRuntime,
+  type GoalJournal,
+  type GoalTurnHost,
+} from './goal-runtime.js';
+
+function journal(): GoalJournal {
+  let cursor: TranscriptCursor = { recordId: null };
+  return {
+    getTranscriptCursor: () => ({ ...cursor }),
+    async recordGoalState(
+      recordUuid: string,
+      _payload: GoalStateRecordPayloadV2,
+    ): Promise<void> {
+      cursor = { recordId: recordUuid };
+    },
+  };
+}
+
+describe('Goal runtime host integration', () => {
+  it('keeps 150 sequential automatic admissions independent', async () => {
+    const started: GoalTurnPermit[] = [];
+    const host: GoalTurnHost = {
+      startGoalTurn: vi.fn(async ({ permit }) => {
+        started.push(structuredClone(permit));
+      }),
+      preemptGoalTurn: vi.fn(),
+    };
+    const runtime = createGoalRuntime({ journal: journal() });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+
+    for (let turn = 0; turn < 150; turn += 1) {
+      const permit = started[turn];
+      expect(permit).toBeDefined();
+      await runtime.finishTurn(permit!);
+    }
+
+    expect(started).toHaveLength(151);
+    expect(new Set(started.map(({ turnId }) => turnId)).size).toBe(151);
+    expect(runtime.getSnapshot()).toMatchObject({
+      activity: 'running',
+      goal: { status: 'active', turnCount: 150 },
+    });
+  });
+
+  it('gives queued user input priority over automatic continuation', async () => {
+    const started: GoalTurnPermit[] = [];
+    const runtime = createGoalRuntime({ journal: journal() });
+    runtime.bindHost({
+      async startGoalTurn({ permit }) {
+        started.push(structuredClone(permit));
+      },
+      preemptGoalTurn: vi.fn(),
+    });
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+    const automaticPermit = started[0]!;
+
+    expect(runtime.beginTurn('real-user-key')).toBeUndefined();
+    await runtime.finishTurn(automaticPermit);
+
+    const userPermit = runtime.permitForTurn('real-user-key');
+    expect(userPermit).toBeDefined();
+    expect(started).toHaveLength(1);
+    await runtime.finishTurn(userPermit!);
+    expect(started).toHaveLength(2);
+  });
+});

--- a/packages/core/src/goals/goal-runtime.test.ts
+++ b/packages/core/src/goals/goal-runtime.test.ts
@@ -1,0 +1,2212 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { GoalEvidenceRecord } from './goal-evidence.js';
+import type { GoalRecoveryRecord } from './goal-persistence.js';
+import type {
+  GoalSnapshotV2,
+  GoalStateCause,
+  GoalStateRecordPayloadV2,
+  GoalTurnPermit,
+  TranscriptCursor,
+} from './goal-protocol.js';
+import {
+  createGoalRuntime,
+  type GoalEvidenceSource,
+  type GoalJournal,
+  type GoalTurnHost,
+} from './goal-runtime.js';
+import { GoalConflictError } from './goal-reducer.js';
+import type { GoalVerifier } from './goal-verifier.js';
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function fakeGoalJournal(
+  options: {
+    appendError?: Error;
+    appendErrors?: Array<Error | undefined>;
+    beforeAppend?: () => Promise<void>;
+  } = {},
+): GoalJournal & {
+  appended: GoalStateRecordPayloadV2[];
+} {
+  const appended: GoalStateRecordPayloadV2[] = [];
+  return {
+    appended,
+    getTranscriptCursor(): TranscriptCursor {
+      return { recordId: null };
+    },
+    async recordGoalState(
+      recordUuid: string,
+      payload: GoalStateRecordPayloadV2,
+    ): Promise<RuntimeRecord> {
+      await options.beforeAppend?.();
+      const appendError = options.appendErrors?.shift() ?? options.appendError;
+      if (appendError) throw appendError;
+      appended.push(structuredClone(payload));
+      return {
+        uuid: recordUuid,
+        parentUuid: null,
+        sessionId: 's-1',
+        timestamp: new Date(0).toISOString(),
+        type: 'system',
+        subtype: 'goal_state',
+        cwd: '/tmp',
+        version: 'test',
+        systemPayload: payload,
+      };
+    },
+  };
+}
+
+function goalStateRecord(snapshot: GoalSnapshotV2): RuntimeRecord {
+  return {
+    uuid: 'restore-record',
+    parentUuid: null,
+    sessionId: 's-1',
+    timestamp: new Date(0).toISOString(),
+    type: 'system',
+    subtype: 'goal_state',
+    provenance: 'goal_control',
+    cwd: '/tmp',
+    version: 'test',
+    systemPayload: { v: 2, cause: 'pause', snapshot },
+  };
+}
+
+function legacyGoalRecord(): RuntimeRecord {
+  return {
+    uuid: 'legacy-record',
+    parentUuid: null,
+    sessionId: 's-1',
+    timestamp: new Date(0).toISOString(),
+    type: 'system',
+    subtype: 'slash_command',
+    cwd: '/tmp',
+    version: 'test',
+    systemPayload: {
+      phase: 'result',
+      rawCommand: '/goal ship it',
+      outputHistoryItems: [
+        { type: 'goal_status', kind: 'set', condition: 'ship it' },
+      ],
+    },
+  };
+}
+
+function fakeGoalTurnHost(): GoalTurnHost & {
+  started: GoalTurnPermit[];
+  inputs: Array<Parameters<GoalTurnHost['startGoalTurn']>[0]>;
+} {
+  const started: GoalTurnPermit[] = [];
+  const inputs: Array<Parameters<GoalTurnHost['startGoalTurn']>[0]> = [];
+  return {
+    started,
+    inputs,
+    async startGoalTurn(input) {
+      const { permit } = input;
+      started.push(structuredClone(permit));
+      inputs.push(structuredClone(input));
+    },
+    preemptGoalTurn: vi.fn(),
+  };
+}
+
+function verifierEvidenceRecords(
+  permit: GoalTurnPermit,
+  cursorId: string,
+  evidenceId = 'assistant-evidence',
+): RuntimeRecord[] {
+  return [
+    {
+      uuid: cursorId,
+      parentUuid: null,
+      sessionId: 's-1',
+      timestamp: new Date(0).toISOString(),
+      type: 'system',
+      subtype: 'goal_state',
+      provenance: 'goal_control',
+      cwd: '/tmp',
+      version: 'test',
+    },
+    {
+      uuid: evidenceId,
+      parentUuid: cursorId,
+      sessionId: 's-1',
+      timestamp: new Date(1).toISOString(),
+      type: 'assistant',
+      provenance: 'assistant_output',
+      goalContext: permit,
+      cwd: '/tmp',
+      version: 'test',
+      message: { role: 'model', parts: [{ text: 'Delivered result' }] },
+    },
+  ];
+}
+
+function verifierUserEvidenceRecords(
+  permit: GoalTurnPermit,
+  cursorId: string,
+  evidenceId = 'user-evidence',
+): RuntimeRecord[] {
+  const records = verifierEvidenceRecords(permit, cursorId, evidenceId);
+  records[1] = {
+    ...records[1]!,
+    type: 'user',
+    provenance: 'real_user',
+    message: { role: 'user', parts: [{ text: 'No deployment authority' }] },
+  };
+  return records;
+}
+
+function fakeEvidenceSource(
+  read: () => readonly RuntimeRecord[],
+): GoalEvidenceSource & {
+  flush: ReturnType<typeof vi.fn>;
+  readActiveTranscriptChain: ReturnType<typeof vi.fn>;
+} {
+  return {
+    flush: vi.fn(async () => undefined),
+    readActiveTranscriptChain: vi.fn(async () => read()),
+  };
+}
+
+type RuntimeRecord = GoalEvidenceRecord &
+  GoalRecoveryRecord & {
+    parentUuid: string | null;
+    sessionId: string;
+    timestamp: string;
+    cwd: string;
+    version: string;
+    message?: GoalEvidenceRecord['message'] & { role?: string };
+  };
+
+describe('goal runtime', () => {
+  it('requires evidence source and verifier dependencies as a pair', () => {
+    const journal = fakeGoalJournal();
+    const evidenceSource = fakeEvidenceSource(() => []);
+    const verifier: GoalVerifier = vi.fn();
+
+    expect(() => createGoalRuntime({ journal, evidenceSource })).toThrow(
+      'must be configured together',
+    );
+    expect(() => createGoalRuntime({ journal, verifier })).toThrow(
+      'must be configured together',
+    );
+  });
+
+  it('does not activate a control after disposal during persistence', async () => {
+    const appendStarted = deferred<void>();
+    const appendGate = deferred<void>();
+    const journal = fakeGoalJournal({
+      beforeAppend: async () => {
+        appendStarted.resolve();
+        await appendGate.promise;
+      },
+    });
+    const runtime = createGoalRuntime({ journal });
+
+    const creating = runtime.dispatch({ action: 'create', objective: 'ship' });
+    await appendStarted.promise;
+    runtime.dispose();
+    appendGate.resolve();
+
+    await expect(creating).rejects.toThrow('disposed');
+    expect(runtime.getSnapshot()).toEqual({
+      v: 2,
+      goal: null,
+      activity: 'idle',
+    });
+  });
+
+  it('persists verifier acceptance before completing a verified proposal', async () => {
+    const journal = fakeGoalJournal();
+    let records: readonly RuntimeRecord[] = [];
+    const evidenceSource = fakeEvidenceSource(() => records);
+    const verifier: GoalVerifier = vi.fn(async () => ({
+      decision: 'accept' as const,
+      reason: 'Evidence satisfies the objective',
+    }));
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal, evidenceSource, verifier });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'deliver result' });
+    const permit = host.started[0];
+    const cursorId = runtime.getSnapshot().goal!.evidenceCursor.recordId!;
+    records = verifierEvidenceRecords(permit, cursorId);
+    runtime.recordTerminalProposal(permit, {
+      status: 'complete',
+      reason: 'Delivered',
+      evidenceRefs: ['assistant-evidence'],
+    });
+    const causes: Array<GoalStateCause | undefined> = [];
+    runtime.subscribe((_snapshot, cause) => causes.push(cause));
+
+    await runtime.finishTurn(permit);
+
+    expect(evidenceSource.flush).toHaveBeenCalledOnce();
+    expect(verifier).toHaveBeenCalledOnce();
+    expect(journal.appended.map((payload) => payload.cause)).toEqual([
+      'create',
+      'turn_finished',
+      'verifier_accept',
+      'complete',
+    ]);
+    expect(causes).toEqual(['turn_finished', 'complete']);
+    expect(runtime.getSnapshot()).toMatchObject({
+      activity: 'idle',
+      goal: {
+        status: 'complete',
+        lastReason: 'Evidence satisfies the objective',
+      },
+    });
+    expect(host.started).toHaveLength(1);
+  });
+
+  it('accepts a verified blocker as a resumable terminal state', async () => {
+    const journal = fakeGoalJournal();
+    let records: readonly RuntimeRecord[] = [];
+    const evidenceSource = fakeEvidenceSource(() => records);
+    const verifier: GoalVerifier = vi.fn(async () => ({
+      decision: 'accept' as const,
+      reason: 'User authority is required',
+    }));
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal, evidenceSource, verifier });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'deploy' });
+    const permit = host.started[0];
+    records = verifierUserEvidenceRecords(
+      permit,
+      runtime.getSnapshot().goal!.evidenceCursor.recordId!,
+    );
+    runtime.recordTerminalProposal(permit, {
+      status: 'blocked',
+      blockerKind: 'authority',
+      reason: 'Need deployment approval',
+      evidenceRefs: ['user-evidence'],
+    });
+    const causes: Array<GoalStateCause | undefined> = [];
+    runtime.subscribe((_snapshot, cause) => causes.push(cause));
+
+    await runtime.finishTurn(permit);
+
+    expect(journal.appended.map((payload) => payload.cause)).toEqual([
+      'create',
+      'turn_finished',
+      'verifier_accept',
+      'blocked',
+    ]);
+    expect(causes).toEqual(['turn_finished', 'blocked']);
+    expect(runtime.getSnapshot()).toMatchObject({
+      activity: 'idle',
+      goal: { status: 'blocked', lastReason: 'User authority is required' },
+    });
+    expect(verifier).toHaveBeenCalledWith(
+      expect.objectContaining({
+        blockedPolicy: expect.stringContaining(
+          'Difficulty, uncertainty, incomplete work',
+        ),
+      }),
+      expect.any(AbortSignal),
+    );
+  });
+
+  it('rejects an invalid evidence reference without calling the verifier', async () => {
+    const journal = fakeGoalJournal();
+    let records: readonly RuntimeRecord[] = [];
+    const evidenceSource = fakeEvidenceSource(() => records);
+    const verifier: GoalVerifier = vi.fn();
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal, evidenceSource, verifier });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'deliver result' });
+    const permit = host.started[0];
+    records = verifierEvidenceRecords(
+      permit,
+      runtime.getSnapshot().goal!.evidenceCursor.recordId!,
+    );
+    runtime.recordTerminalProposal(permit, {
+      status: 'complete',
+      reason: 'Delivered',
+      evidenceRefs: ['missing-evidence'],
+    });
+    const causes: Array<GoalStateCause | undefined> = [];
+    runtime.subscribe((_snapshot, cause) => causes.push(cause));
+
+    await runtime.finishTurn(permit);
+
+    expect(verifier).not.toHaveBeenCalled();
+    expect(journal.appended.map((payload) => payload.cause)).toEqual([
+      'create',
+      'turn_finished',
+      'verifier_reject',
+    ]);
+    expect(causes).toEqual(['turn_finished', 'verifier_reject']);
+    expect(runtime.getSnapshot()).toMatchObject({
+      activity: 'running',
+      goal: { status: 'active' },
+    });
+    expect(host.started).toHaveLength(2);
+  });
+
+  it.each([
+    ['flush', new Error('flush failed')],
+    ['read', new Error('read failed')],
+    ['cursor', new Error('not in the active transcript chain')],
+    ['provider', new Error('provider failed')],
+  ] as const)(
+    'moves to usage_limited when verification %s fails',
+    async (failurePoint, failure) => {
+      const journal = fakeGoalJournal();
+      let records: readonly RuntimeRecord[] = [];
+      const evidenceSource = fakeEvidenceSource(() => records);
+      if (failurePoint === 'flush') {
+        evidenceSource.flush.mockRejectedValueOnce(failure);
+      } else if (failurePoint === 'read') {
+        evidenceSource.readActiveTranscriptChain.mockRejectedValueOnce(failure);
+      }
+      const verifier: GoalVerifier =
+        failurePoint === 'provider'
+          ? vi.fn(async () => {
+              throw failure;
+            })
+          : vi.fn(async () => ({ decision: 'accept', reason: 'ok' }));
+      const host = fakeGoalTurnHost();
+      const runtime = createGoalRuntime({ journal, evidenceSource, verifier });
+      runtime.bindHost(host);
+      await runtime.dispatch({ action: 'create', objective: 'deliver result' });
+      const permit = host.started[0];
+      records = verifierEvidenceRecords(
+        permit,
+        runtime.getSnapshot().goal!.evidenceCursor.recordId!,
+      );
+      if (failurePoint === 'cursor') records = records.slice(1);
+      runtime.recordTerminalProposal(permit, {
+        status: 'complete',
+        reason: 'Delivered',
+        evidenceRefs: ['assistant-evidence'],
+      });
+      const causes: Array<GoalStateCause | undefined> = [];
+      runtime.subscribe((_snapshot, cause) => causes.push(cause));
+
+      await runtime.finishTurn(permit);
+
+      expect(runtime.getSnapshot()).toMatchObject({
+        activity: 'idle',
+        goal: {
+          status: 'usage_limited',
+          lastReason: expect.stringContaining(failure.message),
+        },
+      });
+      expect(journal.appended.at(-1)?.cause).toBe('usage_limited');
+      expect(causes).toEqual(['turn_finished', 'usage_limited']);
+      expect(host.started).toHaveLength(1);
+      await runtime.dispatch({
+        action: 'resume',
+        expectedGoalId: permit.goalId,
+        expectedRevision: permit.revision,
+      });
+      expect(runtime.getSnapshot().goal?.status).toBe('active');
+      expect(host.started).toHaveLength(2);
+    },
+  );
+
+  it('promotes queued user input with exact verifier feedback after rejection', async () => {
+    const result = deferred<Awaited<ReturnType<GoalVerifier>>>();
+    const journal = fakeGoalJournal();
+    let records: readonly RuntimeRecord[] = [];
+    const evidenceSource = fakeEvidenceSource(() => records);
+    const verifier: GoalVerifier = vi.fn(() => result.promise);
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal, evidenceSource, verifier });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'deliver result' });
+    const permit = host.started[0];
+    records = verifierEvidenceRecords(
+      permit,
+      runtime.getSnapshot().goal!.evidenceCursor.recordId!,
+    );
+    runtime.recordTerminalProposal(permit, {
+      status: 'complete',
+      reason: 'Delivered',
+      evidenceRefs: ['assistant-evidence'],
+    });
+    const finishing = runtime.finishTurn(permit);
+    await vi.waitFor(() => expect(verifier).toHaveBeenCalledOnce());
+    expect(runtime.beginTurn('real-user')).toBeUndefined();
+
+    result.resolve({ decision: 'reject', reason: 'Add the missing example' });
+    await finishing;
+
+    const userPermit = runtime.permitForTurn('real-user')!;
+    expect(userPermit).toBeDefined();
+    expect(runtime.getVerifierFeedback(userPermit)).toBe(
+      'Add the missing example',
+    );
+    expect(host.started).toHaveLength(1);
+    expect(runtime.getSnapshot().activity).toBe('running');
+  });
+
+  it.each(['blocked', 'usage_limited'] as const)(
+    'preserves queued user priority when verification stops as %s',
+    async (terminalStatus) => {
+      const result = deferred<Awaited<ReturnType<GoalVerifier>>>();
+      const journal = fakeGoalJournal();
+      let records: readonly RuntimeRecord[] = [];
+      const evidenceSource = fakeEvidenceSource(() => records);
+      const verifier: GoalVerifier = vi.fn(() => result.promise);
+      const host = fakeGoalTurnHost();
+      const runtime = createGoalRuntime({ journal, evidenceSource, verifier });
+      runtime.bindHost(host);
+      await runtime.dispatch({ action: 'create', objective: 'deploy' });
+      const permit = host.started[0];
+      records =
+        terminalStatus === 'blocked'
+          ? verifierUserEvidenceRecords(
+              permit,
+              runtime.getSnapshot().goal!.evidenceCursor.recordId!,
+            )
+          : verifierEvidenceRecords(
+              permit,
+              runtime.getSnapshot().goal!.evidenceCursor.recordId!,
+            );
+      runtime.recordTerminalProposal(
+        permit,
+        terminalStatus === 'blocked'
+          ? {
+              status: 'blocked',
+              blockerKind: 'authority',
+              reason: 'Need approval',
+              evidenceRefs: ['user-evidence'],
+            }
+          : {
+              status: 'complete',
+              reason: 'Done',
+              evidenceRefs: ['assistant-evidence'],
+            },
+      );
+      const finishing = runtime.finishTurn(permit);
+      await vi.waitFor(() => expect(verifier).toHaveBeenCalledOnce());
+      expect(runtime.beginTurn('real-user')).toBeUndefined();
+
+      if (terminalStatus === 'blocked') {
+        result.resolve({ decision: 'accept', reason: 'approval required' });
+      } else {
+        result.reject(new Error('provider unavailable'));
+      }
+      await finishing;
+      expect(runtime.getSnapshot().goal?.status).toBe(terminalStatus);
+      await runtime.dispatch({
+        action: 'resume',
+        expectedGoalId: permit.goalId,
+        expectedRevision: permit.revision,
+      });
+
+      expect(runtime.permitForTurn('real-user')).toBeDefined();
+      expect(host.started).toHaveLength(1);
+      expect(runtime.getSnapshot().activity).toBe('running');
+    },
+  );
+
+  it('releases a queued user reservation before it is promoted', async () => {
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal: fakeGoalJournal() });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+    const initialPermit = host.started[0];
+
+    expect(runtime.beginTurn('queued-user')).toBeUndefined();
+    await expect(runtime.releaseTurn('queued-user')).resolves.toBe(true);
+    await runtime.finishTurn(initialPermit);
+
+    expect(runtime.permitForTurn('queued-user')).toBeUndefined();
+    expect(host.started).toHaveLength(2);
+    expect(runtime.getSnapshot()).toMatchObject({
+      activity: 'running',
+      goal: { status: 'active', turnCount: 1 },
+    });
+  });
+
+  it('releases a promoted user reservation and resumes autonomously', async () => {
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal: fakeGoalJournal() });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+    const initialPermit = host.started[0];
+
+    expect(runtime.beginTurn('queued-user')).toBeUndefined();
+    await runtime.finishTurn(initialPermit);
+    expect(runtime.permitForTurn('queued-user')).toBeDefined();
+
+    await expect(runtime.releaseTurn('queued-user')).resolves.toBe(true);
+
+    expect(runtime.permitForTurn('queued-user')).toBeUndefined();
+    expect(host.started).toHaveLength(2);
+    expect(runtime.getSnapshot()).toMatchObject({
+      activity: 'running',
+      goal: { status: 'active', turnCount: 1 },
+    });
+  });
+
+  it('serializes reservation release behind an in-flight turn commit', async () => {
+    const appendReached = deferred<void>();
+    const appendGate = deferred<void>();
+    let blockTurnFinish = false;
+    const journal = fakeGoalJournal({
+      beforeAppend: async () => {
+        if (!blockTurnFinish) return;
+        appendReached.resolve();
+        await appendGate.promise;
+      },
+    });
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+    const initialPermit = host.started[0];
+    expect(runtime.beginTurn('queued-user')).toBeUndefined();
+
+    blockTurnFinish = true;
+    const finishing = runtime.finishTurn(initialPermit);
+    await appendReached.promise;
+    const releasing = runtime.releaseTurn('queued-user');
+    appendGate.resolve();
+    await Promise.all([finishing, releasing]);
+
+    expect(runtime.permitForTurn('queued-user')).toBeUndefined();
+    expect(host.started).toHaveLength(2);
+    expect(runtime.getSnapshot()).toMatchObject({
+      activity: 'running',
+      goal: { status: 'active', turnCount: 1 },
+    });
+  });
+
+  it('ignores an in-flight accept after edit changes the revision', async () => {
+    const result = deferred<Awaited<ReturnType<GoalVerifier>>>();
+    const journal = fakeGoalJournal();
+    let records: readonly RuntimeRecord[] = [];
+    const evidenceSource = fakeEvidenceSource(() => records);
+    const verifier: GoalVerifier = vi.fn(() => result.promise);
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal, evidenceSource, verifier });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'first' });
+    const permit = host.started[0];
+    records = verifierEvidenceRecords(
+      permit,
+      runtime.getSnapshot().goal!.evidenceCursor.recordId!,
+    );
+    runtime.recordTerminalProposal(permit, {
+      status: 'complete',
+      reason: 'Done',
+      evidenceRefs: ['assistant-evidence'],
+    });
+    const finishing = runtime.finishTurn(permit);
+    await vi.waitFor(() => expect(verifier).toHaveBeenCalledOnce());
+
+    await runtime.dispatch({
+      action: 'edit',
+      objective: 'second',
+      expectedGoalId: permit.goalId,
+      expectedRevision: permit.revision,
+    });
+    result.resolve({ decision: 'accept', reason: 'Old evidence' });
+    await finishing;
+
+    expect(runtime.getSnapshot()).toMatchObject({
+      goal: { goalId: permit.goalId, revision: 2, status: 'active' },
+    });
+    expect(journal.appended.map((payload) => payload.cause)).toEqual([
+      'create',
+      'turn_finished',
+      'edit',
+    ]);
+  });
+
+  it('does not revive an aborted verifier result after pause and resume', async () => {
+    const result = deferred<Awaited<ReturnType<GoalVerifier>>>();
+    const journal = fakeGoalJournal();
+    let records: readonly RuntimeRecord[] = [];
+    const evidenceSource = fakeEvidenceSource(() => records);
+    const verifier: GoalVerifier = vi.fn(() => result.promise);
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal, evidenceSource, verifier });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+    const permit = host.started[0];
+    records = verifierEvidenceRecords(
+      permit,
+      runtime.getSnapshot().goal!.evidenceCursor.recordId!,
+    );
+    runtime.recordTerminalProposal(permit, {
+      status: 'complete',
+      reason: 'Done',
+      evidenceRefs: ['assistant-evidence'],
+    });
+    const finishing = runtime.finishTurn(permit);
+    await vi.waitFor(() => expect(verifier).toHaveBeenCalledOnce());
+
+    await runtime.dispatch({
+      action: 'pause',
+      expectedGoalId: permit.goalId,
+      expectedRevision: permit.revision,
+    });
+    await runtime.dispatch({
+      action: 'resume',
+      expectedGoalId: permit.goalId,
+      expectedRevision: permit.revision,
+    });
+    result.reject(new Error('late provider failure'));
+    await finishing;
+
+    expect(runtime.getSnapshot()).toMatchObject({
+      activity: 'running',
+      goal: { revision: permit.revision, status: 'active' },
+    });
+    expect(journal.appended.map((payload) => payload.cause)).toEqual([
+      'create',
+      'turn_finished',
+      'pause',
+      'resume',
+    ]);
+    expect(host.started).toHaveLength(2);
+  });
+
+  it('does not commit a verifier result after disposal during outcome persistence', async () => {
+    const outcomeAppend = deferred<void>();
+    let appendCount = 0;
+    const journal = fakeGoalJournal({
+      beforeAppend: async () => {
+        appendCount += 1;
+        if (appendCount === 3) await outcomeAppend.promise;
+      },
+    });
+    let records: readonly RuntimeRecord[] = [];
+    const evidenceSource = fakeEvidenceSource(() => records);
+    const verifier: GoalVerifier = vi.fn(async () => ({
+      decision: 'accept' as const,
+      reason: 'verified',
+    }));
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal, evidenceSource, verifier });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+    const permit = host.started[0];
+    records = verifierEvidenceRecords(
+      permit,
+      runtime.getSnapshot().goal!.evidenceCursor.recordId!,
+    );
+    runtime.recordTerminalProposal(permit, {
+      status: 'complete',
+      reason: 'Done',
+      evidenceRefs: ['assistant-evidence'],
+    });
+
+    const finishing = runtime.finishTurn(permit);
+    await vi.waitFor(() => expect(appendCount).toBe(3));
+    runtime.dispose();
+    outcomeAppend.resolve();
+    await finishing;
+
+    expect(journal.appended.map((payload) => payload.cause)).toEqual([
+      'create',
+      'turn_finished',
+      'verifier_accept',
+    ]);
+    expect(journal.appended.at(-1)?.snapshot.goal?.status).toBe('active');
+    expect(runtime.getSnapshot()).toMatchObject({
+      activity: 'verifying',
+      goal: { status: 'active' },
+    });
+  });
+
+  it.each([
+    ['verifier_accept', 2, 'accept'],
+    ['complete', 3, 'accept'],
+    ['verifier_reject', 2, 'reject'],
+    ['usage_limited', 2, 'usage'],
+  ] as const)(
+    'keeps verifying and does not continue when %s persistence fails',
+    async (_cause, failingAppendIndex, outcome) => {
+      const appendErrors: Array<Error | undefined> = [
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+      ];
+      appendErrors[failingAppendIndex] = new Error('outcome write failed');
+      const journal = fakeGoalJournal({ appendErrors });
+      let records: readonly RuntimeRecord[] = [];
+      const evidenceSource = fakeEvidenceSource(() => records);
+      if (outcome === 'usage') {
+        evidenceSource.flush.mockRejectedValueOnce(new Error('source failed'));
+      }
+      const verifier: GoalVerifier = vi.fn(async () => {
+        if (outcome === 'reject') {
+          return {
+            decision: 'reject' as const,
+            reason: 'not enough evidence',
+          };
+        }
+        return { decision: 'accept' as const, reason: 'verified' };
+      });
+      const host = fakeGoalTurnHost();
+      const runtime = createGoalRuntime({ journal, evidenceSource, verifier });
+      runtime.bindHost(host);
+      await runtime.dispatch({ action: 'create', objective: 'ship' });
+      const permit = host.started[0];
+      records = verifierEvidenceRecords(
+        permit,
+        runtime.getSnapshot().goal!.evidenceCursor.recordId!,
+      );
+      runtime.recordTerminalProposal(permit, {
+        status: 'complete',
+        reason: 'Done',
+        evidenceRefs: ['assistant-evidence'],
+      });
+
+      await expect(runtime.finishTurn(permit)).rejects.toThrow(
+        'outcome write failed',
+      );
+
+      expect(runtime.getSnapshot()).toMatchObject({
+        activity: 'verifying',
+        goal: { status: 'active' },
+      });
+      expect(host.started).toHaveLength(1);
+    },
+  );
+
+  it('returns only a bounded evidence catalog and rejects it after stale I/O', async () => {
+    const flushGate = deferred<void>();
+    const journal = fakeGoalJournal();
+    let records: readonly RuntimeRecord[] = [];
+    const evidenceSource = fakeEvidenceSource(() => records);
+    evidenceSource.flush.mockImplementationOnce(() => flushGate.promise);
+    const verifier: GoalVerifier = vi.fn();
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal, evidenceSource, verifier });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+    const permit = host.started[0];
+    records = verifierEvidenceRecords(
+      permit,
+      runtime.getSnapshot().goal!.evidenceCursor.recordId!,
+    );
+
+    const reading = runtime.getGoalForWorker(permit);
+    await vi.waitFor(() => expect(evidenceSource.flush).toHaveBeenCalledOnce());
+    const editing = runtime.dispatch({
+      action: 'edit',
+      objective: 'ship revised',
+      expectedGoalId: permit.goalId,
+      expectedRevision: permit.revision,
+    });
+    await expect(editing).resolves.toBeDefined();
+    flushGate.resolve();
+
+    await expect(reading).rejects.toThrow(
+      'Goal turn permit is no longer valid',
+    );
+  });
+
+  it.each(['accept', 'reject', 'usage_limited'] as const)(
+    'counts active verifier time before committing %s',
+    async (outcome) => {
+      vi.useFakeTimers({ toFake: ['Date'] });
+      try {
+        vi.setSystemTime(1_000);
+        const flushGate = deferred<void>();
+        const journal = fakeGoalJournal();
+        let records: readonly RuntimeRecord[] = [];
+        const evidenceSource = fakeEvidenceSource(() => records);
+        evidenceSource.flush.mockImplementationOnce(() => flushGate.promise);
+        const verifier: GoalVerifier = vi.fn(async () =>
+          outcome === 'reject'
+            ? { decision: 'reject' as const, reason: 'retry' }
+            : { decision: 'accept' as const, reason: 'verified' },
+        );
+        const host = fakeGoalTurnHost();
+        const runtime = createGoalRuntime({
+          journal,
+          evidenceSource,
+          verifier,
+        });
+        runtime.bindHost(host);
+        await runtime.dispatch({ action: 'create', objective: 'ship' });
+        const permit = host.started[0];
+        records = verifierEvidenceRecords(
+          permit,
+          runtime.getSnapshot().goal!.evidenceCursor.recordId!,
+        );
+        runtime.recordTerminalProposal(permit, {
+          status: 'complete',
+          reason: 'Done',
+          evidenceRefs: ['assistant-evidence'],
+        });
+
+        vi.setSystemTime(2_000);
+        const finishing = runtime.finishTurn(permit);
+        await new Promise((resolve) => setImmediate(resolve));
+        expect(runtime.getSnapshot().goal?.activeTimeMs).toBe(1_000);
+        vi.setSystemTime(5_000);
+        if (outcome === 'usage_limited') {
+          flushGate.reject(new Error('source unavailable'));
+        } else {
+          flushGate.resolve();
+        }
+        await finishing;
+
+        expect(runtime.getSnapshot().goal?.activeTimeMs).toBe(4_000);
+        expect(journal.appended.at(-1)?.snapshot.goal?.activeTimeMs).toBe(
+          4_000,
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it('publishes one continuation snapshot after verifier rejection', async () => {
+    const result = deferred<Awaited<ReturnType<GoalVerifier>>>();
+    const journal = fakeGoalJournal();
+    let records: readonly RuntimeRecord[] = [];
+    const evidenceSource = fakeEvidenceSource(() => records);
+    const verifier: GoalVerifier = vi.fn(() => result.promise);
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal, evidenceSource, verifier });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+    const permit = host.started[0];
+    records = verifierEvidenceRecords(
+      permit,
+      runtime.getSnapshot().goal!.evidenceCursor.recordId!,
+    );
+    runtime.recordTerminalProposal(permit, {
+      status: 'complete',
+      reason: 'Done',
+      evidenceRefs: ['assistant-evidence'],
+    });
+    const observed: GoalSnapshotV2[] = [];
+    runtime.subscribe((value) => observed.push(value));
+    const finishing = runtime.finishTurn(permit);
+    await vi.waitFor(() => expect(verifier).toHaveBeenCalledOnce());
+    observed.length = 0;
+
+    result.resolve({ decision: 'reject', reason: 'retry' });
+    await finishing;
+
+    expect(host.started).toHaveLength(2);
+    expect(host.inputs[1]?.verifierFeedback).toBe('retry');
+    expect(observed).toHaveLength(1);
+    expect(observed[0]?.activity).toBe('running');
+  });
+
+  it('returns a bounded catalog without exposing full evidence content', async () => {
+    const journal = fakeGoalJournal();
+    let records: readonly RuntimeRecord[] = [];
+    const evidenceSource = fakeEvidenceSource(() => records);
+    const verifier: GoalVerifier = vi.fn();
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal, evidenceSource, verifier });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+    const permit = host.started[0];
+    records = verifierEvidenceRecords(
+      permit,
+      runtime.getSnapshot().goal!.evidenceCursor.recordId!,
+    );
+
+    const view = await runtime.getGoalForWorker(permit);
+
+    expect(view.evidenceCatalog).toEqual({
+      entries: [
+        {
+          uuid: 'assistant-evidence',
+          provenance: 'assistant_output',
+          turnId: permit.turnId,
+          preview: 'Delivered result',
+          proofKind: 'delivered_output',
+        },
+      ],
+      lineageTurnIds: [permit.turnId],
+      truncated: false,
+    });
+    expect(view.evidenceCatalog?.entries[0]).not.toHaveProperty('content');
+  });
+
+  it('keeps verification live when a pausing lifecycle append fails', async () => {
+    const result = deferred<Awaited<ReturnType<GoalVerifier>>>();
+    const journal = fakeGoalJournal({
+      appendErrors: [undefined, undefined, new Error('pause write failed')],
+    });
+    let records: readonly RuntimeRecord[] = [];
+    const evidenceSource = fakeEvidenceSource(() => records);
+    const verifier: GoalVerifier = vi.fn(() => result.promise);
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal, evidenceSource, verifier });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+    const permit = host.started[0];
+    records = verifierEvidenceRecords(
+      permit,
+      runtime.getSnapshot().goal!.evidenceCursor.recordId!,
+    );
+    runtime.recordTerminalProposal(permit, {
+      status: 'complete',
+      reason: 'Done',
+      evidenceRefs: ['assistant-evidence'],
+    });
+    const finishing = runtime.finishTurn(permit);
+    await vi.waitFor(() => expect(verifier).toHaveBeenCalledOnce());
+
+    await expect(
+      runtime.dispatch({
+        action: 'pause',
+        expectedGoalId: permit.goalId,
+        expectedRevision: permit.revision,
+      }),
+    ).rejects.toThrow('pause write failed');
+    expect(runtime.getSnapshot().activity).toBe('verifying');
+    result.resolve({ decision: 'accept', reason: 'verified' });
+    await finishing;
+
+    expect(runtime.getSnapshot().goal?.status).toBe('complete');
+  });
+
+  it('does not mutate or broadcast when lifecycle persistence fails', async () => {
+    const journal = fakeGoalJournal({
+      appendError: new Error('disk full'),
+    });
+    const runtime = createGoalRuntime({ journal });
+    const observed: GoalSnapshotV2[] = [];
+    runtime.subscribe((snapshot) => observed.push(snapshot));
+
+    await expect(
+      runtime.dispatch({ action: 'create', objective: 'ship it' }),
+    ).rejects.toThrow('disk full');
+
+    expect(runtime.getSnapshot()).toEqual({
+      v: 2,
+      goal: null,
+      activity: 'idle',
+    });
+    expect(observed).toEqual([]);
+    expect(vi.isMockFunction(journal.recordGoalState)).toBe(false);
+  });
+
+  it('publishes a lifecycle cause only after its append commits', async () => {
+    const appendGate = deferred<void>();
+    const journal = fakeGoalJournal({ beforeAppend: () => appendGate.promise });
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal });
+    const observed: Array<{
+      snapshot: GoalSnapshotV2;
+      cause: GoalStateCause | undefined;
+    }> = [];
+    runtime.subscribe((snapshot, cause) => observed.push({ snapshot, cause }));
+    runtime.bindHost(host);
+
+    const creating = runtime.dispatch({ action: 'create', objective: 'ship' });
+    await Promise.resolve();
+
+    expect(observed).toEqual([]);
+    appendGate.resolve();
+    await creating;
+
+    expect(observed.map(({ cause }) => cause)).toEqual(['create', undefined]);
+    expect(observed.map(({ snapshot }) => snapshot.activity)).toEqual([
+      'idle',
+      'running',
+    ]);
+  });
+
+  it('publishes the recovered record cause after restore commits', async () => {
+    const runtime = createGoalRuntime({ journal: fakeGoalJournal() });
+    const observed: Array<GoalStateCause | undefined> = [];
+    runtime.subscribe((_snapshot, cause) => observed.push(cause));
+
+    await runtime.restore([
+      goalStateRecord({
+        v: 2,
+        activity: 'idle',
+        goal: {
+          goalId: 'g-1',
+          revision: 1,
+          objective: 'ship it',
+          status: 'paused',
+          evidenceCursor: { recordId: 'create-record' },
+          turnCount: 2,
+          activeTimeMs: 10,
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      }),
+    ]);
+
+    expect(observed).toEqual(['pause']);
+  });
+
+  it('resumes an idle stopped goal exactly once', async () => {
+    const journal = fakeGoalJournal();
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal });
+    await runtime.restore([
+      goalStateRecord({
+        v: 2,
+        activity: 'idle',
+        goal: {
+          goalId: 'g-1',
+          revision: 1,
+          objective: 'ship it',
+          status: 'paused',
+          evidenceCursor: { recordId: 'create-record' },
+          turnCount: 2,
+          activeTimeMs: 10,
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      }),
+    ]);
+    runtime.bindHost(host);
+
+    await runtime.dispatch({
+      action: 'resume',
+      expectedGoalId: 'g-1',
+      expectedRevision: 1,
+    });
+
+    expect(host.started).toHaveLength(1);
+  });
+
+  it('broadcasts a restored v2 snapshot to existing subscribers', async () => {
+    const runtime = createGoalRuntime({ journal: fakeGoalJournal() });
+    const observed: GoalSnapshotV2[] = [];
+    runtime.subscribe((snapshot) => observed.push(snapshot));
+    const restoredSnapshot: GoalSnapshotV2 = {
+      v: 2,
+      activity: 'idle',
+      goal: {
+        goalId: 'g-1',
+        revision: 1,
+        objective: 'ship it',
+        status: 'paused',
+        evidenceCursor: { recordId: 'create-record' },
+        turnCount: 2,
+        activeTimeMs: 10,
+        createdAt: 1,
+        updatedAt: 2,
+      },
+    };
+
+    await runtime.restore([goalStateRecord(restoredSnapshot)]);
+
+    expect(observed).toEqual([restoredSnapshot]);
+  });
+
+  it('preempts and admits an active create only after persistence commits', async () => {
+    const appendGate = deferred<void>();
+    const journal = fakeGoalJournal({ beforeAppend: () => appendGate.promise });
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal });
+    runtime.bindHost(host);
+
+    const creating = runtime.dispatch({ action: 'create', objective: 'ship' });
+    await Promise.resolve();
+
+    expect(host.preemptGoalTurn).not.toHaveBeenCalled();
+    expect(host.started).toEqual([]);
+
+    appendGate.resolve();
+    await creating;
+
+    expect(host.preemptGoalTurn).toHaveBeenCalledOnce();
+    expect(host.started).toHaveLength(1);
+  });
+
+  it('preempts and invalidates an in-flight turn when paused', async () => {
+    const journal = fakeGoalJournal();
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+    const permit = host.started[0];
+    const evidenceCursor = runtime.getSnapshot().goal?.evidenceCursor;
+    vi.mocked(host.preemptGoalTurn).mockClear();
+
+    await runtime.dispatch({
+      action: 'pause',
+      expectedGoalId: permit.goalId,
+      expectedRevision: permit.revision,
+    });
+    await expect(runtime.finishTurn(permit)).rejects.toThrow(
+      'Goal turn permit is no longer valid',
+    );
+
+    expect(host.preemptGoalTurn).toHaveBeenCalledOnce();
+    expect(host.started).toHaveLength(1);
+    expect(runtime.getSnapshot()).toMatchObject({
+      activity: 'idle',
+      goal: {
+        status: 'paused',
+        revision: 1,
+        turnCount: 0,
+        evidenceCursor,
+      },
+    });
+    expect(journal.appended.map((payload) => payload.cause)).toEqual([
+      'create',
+      'pause',
+    ]);
+  });
+
+  it('resumes with a new permit after pause invalidates the running turn', async () => {
+    const journal = fakeGoalJournal();
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal });
+    const observed: GoalSnapshotV2[] = [];
+    runtime.subscribe((value) => observed.push(value));
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+    const permit = host.started[0];
+
+    expect(
+      runtime.recordTerminalProposal(permit, {
+        status: 'complete',
+        reason: 'done',
+        evidenceRefs: ['e-1'],
+      }),
+    ).toMatchObject({ recorded: true });
+    expect(
+      runtime.recordTerminalProposal(permit, {
+        status: 'blocked',
+        reason: 'duplicate',
+        evidenceRefs: [],
+      }),
+    ).toMatchObject({ recorded: false });
+
+    await runtime.dispatch({
+      action: 'pause',
+      expectedGoalId: permit.goalId,
+      expectedRevision: permit.revision,
+    });
+    expect(runtime.getSnapshot().activity).toBe('idle');
+    await runtime.dispatch({
+      action: 'resume',
+      expectedGoalId: permit.goalId,
+      expectedRevision: permit.revision,
+    });
+    expect(runtime.getSnapshot().activity).toBe('running');
+    expect(host.started).toHaveLength(2);
+    const resumedPermit = host.started[1];
+    expect(resumedPermit).not.toEqual(permit);
+    await runtime.dispatch({
+      action: 'pause',
+      expectedGoalId: resumedPermit.goalId,
+      expectedRevision: resumedPermit.revision,
+    });
+
+    expect(host.started).toHaveLength(2);
+    expect(runtime.getSnapshot().activity).toBe('idle');
+    expect(observed.at(-1)?.activity).toBe('idle');
+    expect(observed.some((value) => value.activity === 'verifying')).toBe(
+      false,
+    );
+  });
+
+  it('lets ordinary user input claim the queued slot before continuation and reuses its permit', async () => {
+    const journal = fakeGoalJournal();
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+    const automaticPermit = host.started[0];
+
+    expect(runtime.beginTurn('real-user-1')).toBeUndefined();
+    await runtime.finishTurn(automaticPermit);
+
+    expect(host.started).toHaveLength(1);
+    const userPermit = runtime.permitForTurn('real-user-1');
+    expect(userPermit).toEqual(
+      expect.objectContaining({
+        goalId: automaticPermit.goalId,
+        revision: automaticPermit.revision,
+        turnId: expect.any(String),
+      }),
+    );
+    expect(userPermit?.turnId).not.toBe(automaticPermit.turnId);
+    expect(runtime.beginTurn('real-user-1')).toEqual(userPermit);
+    expect(runtime.getSnapshot().activity).toBe('running');
+  });
+
+  it('invalidates an old permit before broadcasting an objective change', async () => {
+    const journal = fakeGoalJournal();
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'first' });
+    const oldPermit = host.started[0];
+    let listenerError: unknown;
+    let lateAccepted = false;
+    runtime.subscribe((value) => {
+      if (value.goal?.revision !== 2) return;
+      try {
+        lateAccepted = runtime.recordTerminalProposal(oldPermit, {
+          status: 'complete',
+          reason: 'late',
+          evidenceRefs: [],
+        }).recorded;
+      } catch (error) {
+        listenerError = error;
+      }
+    });
+
+    await runtime.dispatch({
+      action: 'edit',
+      objective: 'second',
+      expectedGoalId: oldPermit.goalId,
+      expectedRevision: oldPermit.revision,
+    });
+
+    expect(listenerError).toEqual(
+      expect.objectContaining({
+        message: 'Goal turn permit is no longer valid',
+      }),
+    );
+    expect(lateAccepted).toBe(false);
+    expect(host.started).toHaveLength(2);
+  });
+
+  it('preempts the permit-owning host when a subscriber rebinds during broadcast', async () => {
+    const oldHost = fakeGoalTurnHost();
+    const newHost = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal: fakeGoalJournal() });
+    runtime.bindHost(oldHost);
+    const created = await runtime.dispatch({
+      action: 'create',
+      objective: 'first',
+    });
+    vi.mocked(oldHost.preemptGoalTurn).mockClear();
+    runtime.subscribe((snapshot) => {
+      if (snapshot.goal?.revision === 2) runtime.bindHost(newHost);
+    });
+
+    await runtime.dispatch({
+      action: 'edit',
+      objective: 'second',
+      expectedGoalId: created.snapshot.goal!.goalId,
+      expectedRevision: 1,
+    });
+
+    expect(oldHost.preemptGoalTurn).toHaveBeenCalledOnce();
+    expect(newHost.preemptGoalTurn).not.toHaveBeenCalled();
+    expect(newHost.started).toHaveLength(1);
+  });
+
+  it('preempts the bound host that owns a directly admitted user turn', async () => {
+    const oldHost = fakeGoalTurnHost();
+    const newHost = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal: fakeGoalJournal() });
+    await runtime.restore([
+      goalStateRecord({
+        v: 2,
+        activity: 'idle',
+        goal: {
+          goalId: 'g-1',
+          revision: 1,
+          objective: 'first',
+          status: 'paused',
+          evidenceCursor: { recordId: 'create-record' },
+          turnCount: 0,
+          activeTimeMs: 0,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      }),
+    ]);
+    runtime.bindHost(oldHost);
+    let userPermit: GoalTurnPermit | undefined;
+    runtime.subscribe((snapshot) => {
+      if (snapshot.goal?.status === 'active' && !userPermit) {
+        userPermit = runtime.beginTurn('real-user');
+      }
+    });
+    await runtime.dispatch({
+      action: 'resume',
+      expectedGoalId: 'g-1',
+      expectedRevision: 1,
+    });
+    expect(userPermit).toBeDefined();
+    runtime.bindHost(newHost);
+
+    await runtime.dispatch({
+      action: 'edit',
+      objective: 'second',
+      expectedGoalId: 'g-1',
+      expectedRevision: 1,
+    });
+
+    expect(oldHost.preemptGoalTurn).toHaveBeenCalledOnce();
+    expect(newHost.preemptGoalTurn).not.toHaveBeenCalled();
+  });
+
+  it('preempts the bound host that owns a promoted queued user turn', async () => {
+    const oldHost = fakeGoalTurnHost();
+    const newHost = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal: fakeGoalJournal() });
+    runtime.bindHost(oldHost);
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+    const automaticPermit = oldHost.started[0];
+    expect(runtime.beginTurn('real-user')).toBeUndefined();
+
+    await runtime.finishTurn(automaticPermit);
+    expect(runtime.permitForTurn('real-user')).toBeDefined();
+    vi.mocked(oldHost.preemptGoalTurn).mockClear();
+    runtime.bindHost(newHost);
+    await runtime.dispatch({
+      action: 'clear',
+      expectedGoalId: automaticPermit.goalId,
+      expectedRevision: automaticPermit.revision,
+    });
+
+    expect(oldHost.preemptGoalTurn).toHaveBeenCalledOnce();
+    expect(newHost.preemptGoalTurn).not.toHaveBeenCalled();
+  });
+
+  it('migrates a legacy active goal once before making it schedulable', async () => {
+    const journal = fakeGoalJournal();
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal });
+
+    await runtime.restore([legacyGoalRecord()]);
+    await runtime.restore([legacyGoalRecord()]);
+
+    expect(journal.appended).toHaveLength(1);
+    expect(journal.appended[0]).toMatchObject({
+      cause: 'migrated',
+      snapshot: {
+        activity: 'idle',
+        goal: {
+          objective: 'ship it',
+          revision: 1,
+          status: 'active',
+          evidenceCursor: { recordId: expect.any(String) },
+        },
+      },
+    });
+    expect(host.started).toEqual([]);
+    runtime.bindHost(host);
+    await vi.waitFor(() => expect(host.started).toHaveLength(1));
+  });
+
+  it('releases a rejected host start without an unhandled rejection', async () => {
+    const journal = fakeGoalJournal();
+    const runtime = createGoalRuntime({ journal });
+    await runtime.restore([
+      goalStateRecord({
+        v: 2,
+        activity: 'idle',
+        goal: {
+          goalId: 'g-1',
+          revision: 1,
+          objective: 'ship',
+          status: 'active',
+          evidenceCursor: { recordId: 'create-record' },
+          turnCount: 0,
+          activeTimeMs: 0,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      }),
+    ]);
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      runtime.bindHost({
+        startGoalTurn: vi.fn().mockRejectedValue(new Error('host rejected')),
+        preemptGoalTurn: vi.fn(),
+      });
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(runtime.getSnapshot().activity).toBe('idle');
+      expect(unhandled).toEqual([]);
+
+      const replacement = fakeGoalTurnHost();
+      runtime.bindHost(replacement);
+      await vi.waitFor(() => expect(replacement.started).toHaveLength(1));
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+  });
+
+  it('hands a queued continuation to a replacement host after start failure', async () => {
+    const failedStart = deferred<void>();
+    const runtime = createGoalRuntime({ journal: fakeGoalJournal() });
+    const failingHost: GoalTurnHost = {
+      startGoalTurn: () => failedStart.promise,
+      preemptGoalTurn: vi.fn(),
+    };
+    runtime.bindHost(failingHost);
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+    const replacement = fakeGoalTurnHost();
+    runtime.bindHost(replacement);
+
+    failedStart.reject(new Error('host rejected'));
+
+    await vi.waitFor(() => expect(replacement.started).toHaveLength(1));
+    expect(runtime.getSnapshot().activity).toBe('running');
+  });
+
+  it('promotes queued user input before automatic retry after start failure', async () => {
+    const failedStart = deferred<void>();
+    const runtime = createGoalRuntime({ journal: fakeGoalJournal() });
+    runtime.bindHost({
+      startGoalTurn: () => failedStart.promise,
+      preemptGoalTurn: vi.fn(),
+    });
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+    expect(runtime.beginTurn('real-user')).toBeUndefined();
+    const replacement = fakeGoalTurnHost();
+    runtime.bindHost(replacement);
+
+    failedStart.reject(new Error('host rejected'));
+
+    await vi.waitFor(() =>
+      expect(runtime.permitForTurn('real-user')).toBeDefined(),
+    );
+    expect(replacement.started).toEqual([]);
+    expect(runtime.getSnapshot().activity).toBe('running');
+  });
+
+  it('discards the rejected permit proposal before promoting queued user input', async () => {
+    const failedStart = deferred<void>();
+    const started: GoalTurnPermit[] = [];
+    const runtime = createGoalRuntime({ journal: fakeGoalJournal() });
+    runtime.bindHost({
+      async startGoalTurn({ permit }) {
+        started.push(permit);
+        await failedStart.promise;
+      },
+      preemptGoalTurn: vi.fn(),
+    });
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+    const rejectedPermit = started[0];
+    expect(
+      runtime.recordTerminalProposal(rejectedPermit, {
+        status: 'complete',
+        reason: 'stale proposal',
+        evidenceRefs: ['stale'],
+      }),
+    ).toEqual({ recorded: true, readyForVerification: true });
+    expect(runtime.beginTurn('real-user')).toBeUndefined();
+
+    failedStart.reject(new Error('host rejected'));
+    await vi.waitFor(() =>
+      expect(runtime.permitForTurn('real-user')).toBeDefined(),
+    );
+    const promotedPermit = runtime.permitForTurn('real-user')!;
+
+    expect(
+      runtime.recordTerminalProposal(promotedPermit, {
+        status: 'complete',
+        reason: 'fresh proposal',
+        evidenceRefs: ['fresh'],
+      }),
+    ).toEqual({ recorded: true, readyForVerification: true });
+    await runtime.finishTurn(promotedPermit);
+    expect(runtime.takePendingTerminalProposal()).toEqual({
+      permit: promotedPermit,
+      proposal: {
+        status: 'complete',
+        reason: 'fresh proposal',
+        evidenceRefs: ['fresh'],
+      },
+    });
+  });
+
+  it('returns a defensive worker view and rejects it after permit invalidation', async () => {
+    const journal = fakeGoalJournal();
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+    const permit = host.started[0];
+
+    const view = await runtime.getGoalForWorker(permit);
+    view.objective = 'mutated';
+    view.evidenceCursor.recordId = 'mutated';
+    expect(runtime.getSnapshot().goal).toMatchObject({
+      objective: 'ship',
+      evidenceCursor: { recordId: expect.not.stringContaining('mutated') },
+    });
+
+    await runtime.dispatch({
+      action: 'edit',
+      objective: 'ship better',
+      expectedGoalId: permit.goalId,
+      expectedRevision: permit.revision,
+    });
+    await expect(runtime.getGoalForWorker(permit)).rejects.toThrow(
+      'Goal turn permit is no longer valid',
+    );
+  });
+
+  it('requires three repeated blocked turns and resets that audit on resume', async () => {
+    const journal = fakeGoalJournal();
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+
+    for (let index = 0; index < 2; index += 1) {
+      const permit = host.started.at(-1)!;
+      expect(
+        runtime.recordTerminalProposal(permit, {
+          status: 'blocked',
+          reason: 'waiting for access',
+          evidenceRefs: [],
+          blockerKind: 'repeated',
+        }),
+      ).toEqual({ recorded: true, readyForVerification: false });
+      await runtime.finishTurn(permit);
+    }
+
+    const thirdPermit = host.started.at(-1)!;
+    expect(
+      runtime.recordTerminalProposal(thirdPermit, {
+        status: 'blocked',
+        reason: 'waiting for access',
+        evidenceRefs: [],
+        blockerKind: 'repeated',
+      }),
+    ).toEqual({ recorded: true, readyForVerification: true });
+    await runtime.dispatch({
+      action: 'pause',
+      expectedGoalId: thirdPermit.goalId,
+      expectedRevision: thirdPermit.revision,
+    });
+    await runtime.dispatch({
+      action: 'resume',
+      expectedGoalId: thirdPermit.goalId,
+      expectedRevision: thirdPermit.revision,
+    });
+
+    const afterResume = host.started.at(-1)!;
+    expect(
+      runtime.recordTerminalProposal(afterResume, {
+        status: 'blocked',
+        reason: 'waiting for access',
+        evidenceRefs: [],
+        blockerKind: 'repeated',
+      }),
+    ).toEqual({ recorded: true, readyForVerification: false });
+  });
+
+  it('restores the repeated blocker audit from the durable Goal state', async () => {
+    const journal = fakeGoalJournal();
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+
+    for (let index = 0; index < 2; index += 1) {
+      const permit = host.started.at(-1)!;
+      runtime.recordTerminalProposal(permit, {
+        status: 'blocked',
+        reason: 'waiting for access',
+        evidenceRefs: [],
+        blockerKind: 'repeated',
+      });
+      await runtime.finishTurn(permit);
+    }
+
+    const restoredHost = fakeGoalTurnHost();
+    const restored = createGoalRuntime({ journal: fakeGoalJournal() });
+    await restored.restore([
+      {
+        ...goalStateRecord(journal.appended.at(-1)!.snapshot),
+        systemPayload: journal.appended.at(-1)!,
+      },
+    ]);
+    restored.bindHost(restoredHost);
+    await vi.waitFor(() => expect(restoredHost.started).toHaveLength(1));
+
+    expect(
+      restored.recordTerminalProposal(restoredHost.started[0], {
+        status: 'blocked',
+        reason: 'waiting for access',
+        evidenceRefs: [],
+        blockerKind: 'repeated',
+      }),
+    ).toEqual({ recorded: true, readyForVerification: true });
+  });
+
+  it('restores and bounds a repeated blocker audit after verifier rejection', async () => {
+    const activeSnapshot: GoalSnapshotV2 = {
+      v: 2,
+      activity: 'idle',
+      goal: {
+        goalId: 'g-rejected',
+        revision: 1,
+        objective: 'ship',
+        status: 'active',
+        evidenceCursor: { recordId: 'create-record' },
+        turnCount: 3,
+        activeTimeMs: 0,
+        createdAt: 1,
+        updatedAt: 2,
+      },
+    };
+    const record = goalStateRecord(activeSnapshot);
+    record.systemPayload = {
+      v: 2,
+      cause: 'verifier_reject',
+      snapshot: activeSnapshot,
+      blockedAudit: {
+        fingerprint: 'repeated\nwaiting for access',
+        count: 3,
+        turnIds: ['turn-1', 'turn-2', 'turn-3'],
+      },
+    };
+    const journal = fakeGoalJournal();
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal });
+    await runtime.restore([record]);
+    runtime.bindHost(host);
+    await vi.waitFor(() => expect(host.started).toHaveLength(1));
+
+    expect(
+      runtime.recordTerminalProposal(host.started[0], {
+        status: 'blocked',
+        reason: 'waiting for access',
+        evidenceRefs: [],
+        blockerKind: 'repeated',
+      }),
+    ).toEqual({ recorded: true, readyForVerification: true });
+    await runtime.finishTurn(host.started[0]);
+
+    expect(journal.appended.at(-1)?.blockedAudit).toMatchObject({
+      count: 3,
+      turnIds: ['turn-2', 'turn-3', host.started[0].turnId],
+    });
+  });
+
+  it('does not count a repeated proposal recorded before pause and resume', async () => {
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal: fakeGoalJournal() });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+    const beforeResume = host.started[0];
+    runtime.recordTerminalProposal(beforeResume, {
+      status: 'blocked',
+      reason: 'same blocker',
+      evidenceRefs: [],
+      blockerKind: 'repeated',
+    });
+    await runtime.dispatch({
+      action: 'pause',
+      expectedGoalId: beforeResume.goalId,
+      expectedRevision: beforeResume.revision,
+    });
+    await runtime.dispatch({
+      action: 'resume',
+      expectedGoalId: beforeResume.goalId,
+      expectedRevision: beforeResume.revision,
+    });
+    expect(() =>
+      runtime.recordTerminalProposal(beforeResume, {
+        status: 'complete',
+        reason: 'second proposal from same permit',
+        evidenceRefs: [],
+      }),
+    ).toThrow('Goal turn permit is no longer valid');
+    await expect(runtime.finishTurn(beforeResume)).rejects.toThrow(
+      'Goal turn permit is no longer valid',
+    );
+    expect(runtime.takePendingTerminalProposal()).toBeUndefined();
+
+    for (let index = 0; index < 2; index += 1) {
+      const permit = host.started.at(-1)!;
+      expect(
+        runtime.recordTerminalProposal(permit, {
+          status: 'blocked',
+          reason: 'same blocker',
+          evidenceRefs: [],
+          blockerKind: 'repeated',
+        }),
+      ).toEqual({ recorded: true, readyForVerification: false });
+      await runtime.finishTurn(permit);
+    }
+
+    const thirdPermit = host.started.at(-1)!;
+    expect(
+      runtime.recordTerminalProposal(thirdPermit, {
+        status: 'blocked',
+        reason: 'same blocker',
+        evidenceRefs: [],
+        blockerKind: 'repeated',
+      }),
+    ).toEqual({ recorded: true, readyForVerification: true });
+  });
+
+  it('retains an active terminal proposal for verifier handoff without continuing', async () => {
+    const journal = fakeGoalJournal();
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+    const permit = host.started[0];
+    runtime.recordTerminalProposal(permit, {
+      status: 'complete',
+      reason: 'done',
+      evidenceRefs: ['e-1'],
+    });
+
+    await runtime.finishTurn(permit);
+
+    expect(runtime.getSnapshot().activity).toBe('verifying');
+    expect(host.started).toHaveLength(1);
+    const pending = runtime.takePendingTerminalProposal();
+    expect(pending).toEqual({
+      permit,
+      proposal: {
+        status: 'complete',
+        reason: 'done',
+        evidenceRefs: ['e-1'],
+      },
+    });
+    expect(runtime.takePendingTerminalProposal()).toBeUndefined();
+  });
+
+  it.each(['authority', 'external'] as const)(
+    'admits %s blockers for verification immediately',
+    async (blockerKind) => {
+      const journal = fakeGoalJournal();
+      const runtime = createGoalRuntime({ journal });
+      const permit = runtime.beginTurn('not-active');
+      expect(permit).toBeUndefined();
+
+      const host = fakeGoalTurnHost();
+      runtime.bindHost(host);
+      await runtime.dispatch({ action: 'create', objective: 'ship' });
+      expect(
+        runtime.recordTerminalProposal(host.started[0], {
+          status: 'blocked',
+          reason: 'maintainer decision required',
+          evidenceRefs: [],
+          blockerKind,
+        }),
+      ).toEqual({ recorded: true, readyForVerification: true });
+    },
+  );
+
+  it('requires repeated blocker observations to be consecutive active finishes', async () => {
+    const journal = fakeGoalJournal();
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+    const propose = (permit: GoalTurnPermit) =>
+      runtime.recordTerminalProposal(permit, {
+        status: 'blocked',
+        reason: 'same blocker',
+        evidenceRefs: [],
+        blockerKind: 'repeated',
+      });
+
+    let permit = host.started.at(-1)!;
+    expect(propose(permit).readyForVerification).toBe(false);
+    await runtime.finishTurn(permit);
+    permit = host.started.at(-1)!;
+    await runtime.finishTurn(permit);
+
+    permit = host.started.at(-1)!;
+    expect(propose(permit).readyForVerification).toBe(false);
+    await runtime.finishTurn(permit);
+    permit = host.started.at(-1)!;
+    expect(propose(permit).readyForVerification).toBe(false);
+  });
+
+  it('serializes concurrent controls and reports the committed snapshot on conflict', async () => {
+    const appendGate = deferred<void>();
+    const journal = fakeGoalJournal({ beforeAppend: () => appendGate.promise });
+    const runtime = createGoalRuntime({ journal });
+
+    const first = runtime.dispatch({ action: 'create', objective: 'first' });
+    const second = runtime.dispatch({ action: 'create', objective: 'second' });
+    appendGate.resolve();
+    const created = await first;
+    const conflict = await second.catch((error: unknown) => error);
+
+    expect(conflict).toBeInstanceOf(GoalConflictError);
+    expect((conflict as GoalConflictError).current).toEqual(created.snapshot);
+    expect(journal.appended).toHaveLength(1);
+  });
+
+  it('keeps turn state and the dispatch mutex usable when turn persistence fails', async () => {
+    const journal = fakeGoalJournal({
+      appendErrors: [undefined, new Error('turn write failed')],
+    });
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+    const permit = host.started[0];
+    runtime.recordTerminalProposal(permit, {
+      status: 'complete',
+      reason: 'done',
+      evidenceRefs: [],
+    });
+
+    await expect(runtime.finishTurn(permit)).rejects.toThrow(
+      'turn write failed',
+    );
+
+    expect(runtime.getSnapshot().activity).toBe('running');
+    expect(runtime.permitForTurn(`goal-runtime:${permit.turnId}`)).toEqual(
+      permit,
+    );
+    expect(
+      runtime.recordTerminalProposal(permit, {
+        status: 'complete',
+        reason: 'duplicate',
+        evidenceRefs: [],
+      }).recorded,
+    ).toBe(false);
+    expect(host.started).toHaveLength(1);
+
+    await runtime.finishTurn(permit);
+    expect(runtime.getSnapshot()).toMatchObject({
+      activity: 'verifying',
+      goal: { turnCount: 1 },
+    });
+  });
+
+  it('restores active state once while stopped state remains display-only', async () => {
+    const activeHost = fakeGoalTurnHost();
+    const active = createGoalRuntime({ journal: fakeGoalJournal() });
+    await active.restore([
+      goalStateRecord({
+        v: 2,
+        activity: 'idle',
+        goal: {
+          goalId: 'g-active',
+          revision: 1,
+          objective: 'ship',
+          status: 'active',
+          evidenceCursor: { recordId: 'create-record' },
+          turnCount: 0,
+          activeTimeMs: 0,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      }),
+    ]);
+    active.bindHost(activeHost);
+    active.bindHost(fakeGoalTurnHost());
+    await vi.waitFor(() => expect(activeHost.started).toHaveLength(1));
+
+    const stoppedHost = fakeGoalTurnHost();
+    const stopped = createGoalRuntime({ journal: fakeGoalJournal() });
+    await stopped.restore([
+      goalStateRecord({
+        v: 2,
+        activity: 'idle',
+        goal: {
+          goalId: 'g-complete',
+          revision: 1,
+          objective: 'ship',
+          status: 'complete',
+          evidenceCursor: { recordId: 'create-record' },
+          turnCount: 1,
+          activeTimeMs: 1,
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      }),
+    ]);
+    stopped.bindHost(stoppedHost);
+    await Promise.resolve();
+    expect(stoppedHost.started).toEqual([]);
+    expect(stopped.getSnapshot().goal?.status).toBe('complete');
+  });
+
+  it('surfaces unsupported recovery without scheduling or fallback', async () => {
+    const malformed = goalStateRecord({ v: 2, activity: 'idle', goal: null });
+    malformed.systemPayload = {
+      v: 99,
+    } as unknown as RuntimeRecord['systemPayload'];
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal: fakeGoalJournal() });
+    runtime.bindHost(host);
+
+    await expect(runtime.restore([malformed])).rejects.toThrow(
+      'malformed or uses an unsupported version',
+    );
+    await expect(
+      runtime.dispatch({ action: 'create', objective: 'must not overwrite' }),
+    ).rejects.toThrow('malformed or uses an unsupported version');
+    expect(runtime.getSnapshot().goal).toBeNull();
+    expect(host.started).toEqual([]);
+  });
+
+  it('blocks writes after failed legacy migration until restore succeeds', async () => {
+    const journal = fakeGoalJournal({
+      appendErrors: [new Error('migration write failed'), undefined],
+    });
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal });
+    runtime.bindHost(host);
+
+    await expect(runtime.restore([legacyGoalRecord()])).rejects.toThrow(
+      'migration write failed',
+    );
+    await expect(
+      runtime.dispatch({ action: 'create', objective: 'must not overwrite' }),
+    ).rejects.toThrow('migration write failed');
+    expect(host.started).toEqual([]);
+
+    await runtime.restore([legacyGoalRecord()]);
+    expect(runtime.getSnapshot().goal).toMatchObject({
+      objective: 'ship it',
+      status: 'active',
+    });
+  });
+
+  it('commits successful legacy recovery before reentrant subscribers run', async () => {
+    const journal = fakeGoalJournal({
+      appendErrors: [new Error('migration write failed'), undefined],
+    });
+    const runtime = createGoalRuntime({ journal });
+    await expect(runtime.restore([legacyGoalRecord()])).rejects.toThrow(
+      'migration write failed',
+    );
+    const host = fakeGoalTurnHost();
+    let bindError: unknown;
+    let reentrantDispatch: Promise<unknown> | undefined;
+    let reentered = false;
+    runtime.subscribe((snapshot) => {
+      if (reentered || snapshot.goal?.status !== 'active') return;
+      reentered = true;
+      try {
+        runtime.bindHost(host);
+      } catch (error) {
+        bindError = error;
+      }
+      reentrantDispatch = runtime.dispatch({
+        action: 'pause',
+        expectedGoalId: snapshot.goal.goalId,
+        expectedRevision: snapshot.goal.revision,
+      });
+    });
+
+    await runtime.restore([legacyGoalRecord()]);
+    await reentrantDispatch;
+
+    expect(bindError).toBeUndefined();
+    expect(host.started).toHaveLength(1);
+    expect(runtime.getSnapshot().goal?.status).toBe('paused');
+  });
+
+  it('preempts replace and clear after commit and admits only active replacements', async () => {
+    const journal = fakeGoalJournal();
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal });
+    runtime.bindHost(host);
+    const created = await runtime.dispatch({
+      action: 'create',
+      objective: 'a',
+    });
+    vi.mocked(host.preemptGoalTurn).mockClear();
+    const replaced = await runtime.dispatch({
+      action: 'replace',
+      objective: 'b',
+      expectedGoalId: created.snapshot.goal!.goalId,
+      expectedRevision: 1,
+    });
+    expect(replaced.snapshot.goal).toMatchObject({
+      revision: 1,
+      objective: 'b',
+    });
+    expect(host.preemptGoalTurn).toHaveBeenCalledOnce();
+    expect(host.started).toHaveLength(2);
+
+    vi.mocked(host.preemptGoalTurn).mockClear();
+    await runtime.dispatch({
+      action: 'clear',
+      expectedGoalId: replaced.snapshot.goal!.goalId,
+      expectedRevision: 1,
+    });
+    expect(host.preemptGoalTurn).toHaveBeenCalledOnce();
+    expect(host.started).toHaveLength(2);
+    expect(runtime.getSnapshot().goal).toBeNull();
+  });
+
+  it('defensively copies response, subscriber, and getter snapshots', async () => {
+    const runtime = createGoalRuntime({ journal: fakeGoalJournal() });
+    runtime.subscribe((value) => {
+      if (value.goal) {
+        value.goal.objective = 'listener mutation';
+        value.goal.evidenceCursor.recordId = 'listener mutation';
+      }
+    });
+
+    const response = await runtime.dispatch({
+      action: 'create',
+      objective: 'original',
+    });
+    response.snapshot.goal!.objective = 'response mutation';
+    response.snapshot.goal!.evidenceCursor.recordId = 'response mutation';
+    const firstRead = runtime.getSnapshot();
+    firstRead.goal!.objective = 'getter mutation';
+
+    expect(runtime.getSnapshot().goal).toMatchObject({
+      objective: 'original',
+      evidenceCursor: { recordId: expect.any(String) },
+    });
+  });
+
+  it('does not let a subscriber failure block committed host admission', async () => {
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal: fakeGoalJournal() });
+    runtime.subscribe(() => {
+      throw new Error('listener failed');
+    });
+    runtime.bindHost(host);
+
+    await expect(
+      runtime.dispatch({ action: 'create', objective: 'ship' }),
+    ).resolves.toBeDefined();
+    expect(host.started).toHaveLength(1);
+  });
+
+  it('does not hold the writer mutex while the host owns a running turn', async () => {
+    const hostTurn = deferred<void>();
+    const started: GoalTurnPermit[] = [];
+    const runtime = createGoalRuntime({ journal: fakeGoalJournal() });
+    runtime.bindHost({
+      async startGoalTurn({ permit }) {
+        started.push(permit);
+        await hostTurn.promise;
+      },
+      preemptGoalTurn: vi.fn(),
+    });
+    let dispatchSettled = false;
+    const creating = runtime
+      .dispatch({ action: 'create', objective: 'ship' })
+      .then(() => {
+        dispatchSettled = true;
+      });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(started).toHaveLength(1);
+    expect(dispatchSettled).toBe(true);
+
+    hostTurn.resolve();
+    await creating;
+  });
+
+  it('keeps real user input queued while a terminal proposal is verifying', async () => {
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal: fakeGoalJournal() });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+    const permit = host.started[0];
+    runtime.recordTerminalProposal(permit, {
+      status: 'complete',
+      reason: 'done',
+      evidenceRefs: [],
+    });
+    await runtime.finishTurn(permit);
+
+    expect(runtime.beginTurn('real-user-during-verification')).toBeUndefined();
+    expect(runtime.getSnapshot().activity).toBe('verifying');
+    const replacementHost = fakeGoalTurnHost();
+    runtime.bindHost(replacementHost);
+    await Promise.resolve();
+    expect(replacementHost.started).toEqual([]);
+    expect(runtime.takePendingTerminalProposal()).toBeDefined();
+    expect(runtime.takePendingTerminalProposal()).toBeUndefined();
+  });
+
+  it('cancels pending verification on pause and resumes exactly once', async () => {
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal: fakeGoalJournal() });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+    const permit = host.started[0];
+    runtime.recordTerminalProposal(permit, {
+      status: 'complete',
+      reason: 'done',
+      evidenceRefs: [],
+    });
+    await runtime.finishTurn(permit);
+
+    await runtime.dispatch({
+      action: 'pause',
+      expectedGoalId: permit.goalId,
+      expectedRevision: permit.revision,
+    });
+    expect(runtime.getSnapshot()).toMatchObject({
+      activity: 'idle',
+      goal: { status: 'paused' },
+    });
+    expect(runtime.takePendingTerminalProposal()).toBeUndefined();
+
+    await runtime.dispatch({
+      action: 'resume',
+      expectedGoalId: permit.goalId,
+      expectedRevision: permit.revision,
+    });
+    expect(host.started).toHaveLength(2);
+  });
+
+  it('does not let host preemption failures break committed lifecycle state', async () => {
+    const started: GoalTurnPermit[] = [];
+    const runtime = createGoalRuntime({ journal: fakeGoalJournal() });
+    runtime.bindHost({
+      async startGoalTurn({ permit }) {
+        started.push(permit);
+      },
+      preemptGoalTurn() {
+        throw new Error('preempt failed');
+      },
+    });
+
+    await expect(
+      runtime.dispatch({ action: 'create', objective: 'ship' }),
+    ).resolves.toBeDefined();
+    expect(started).toHaveLength(1);
+    expect(() => runtime.dispose()).not.toThrow();
+  });
+
+  it('recovers when a host start throws synchronously', async () => {
+    const runtime = createGoalRuntime({ journal: fakeGoalJournal() });
+    runtime.bindHost({
+      startGoalTurn(): Promise<void> {
+        throw new Error('synchronous host failure');
+      },
+      preemptGoalTurn: vi.fn(),
+    });
+
+    await expect(
+      runtime.dispatch({ action: 'create', objective: 'ship' }),
+    ).resolves.toBeDefined();
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(runtime.getSnapshot().activity).toBe('idle');
+  });
+});

--- a/packages/core/src/goals/goal-runtime.ts
+++ b/packages/core/src/goals/goal-runtime.ts
@@ -59,13 +59,6 @@ export interface GoalEvidenceSource {
   readActiveTranscriptChain(): Promise<readonly GoalEvidenceRecord[]>;
 }
 
-export class GoalPersistenceUnavailableError extends Error {
-  constructor() {
-    super('Goal persistence is unavailable for this session');
-    this.name = 'GoalPersistenceUnavailableError';
-  }
-}
-
 export interface GoalTurnHost {
   startGoalTurn(input: {
     permit: GoalTurnPermit;
@@ -893,12 +886,6 @@ export function createGoalRuntime(
           continuationQueued = false;
         } else if (request.action === 'resume') {
           blockedAudit = undefined;
-          if (currentProposal?.blockedAuditCandidate) {
-            currentProposal = {
-              proposal: currentProposal.proposal,
-              readyForVerification: false,
-            };
-          }
         }
         snapshot = {
           ...structuredClone(nextSnapshot),

--- a/packages/core/src/goals/goal-runtime.ts
+++ b/packages/core/src/goals/goal-runtime.ts
@@ -1,0 +1,944 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { randomUUID } from 'node:crypto';
+import {
+  buildGoalEvidenceCatalog,
+  EvidenceSourceUnavailableError,
+  InvalidGoalEvidenceReferenceError,
+  validateGoalEvidenceReferences,
+  type GoalEvidenceCatalog,
+  type GoalEvidenceRecord,
+} from './goal-evidence.js';
+import {
+  GOAL_STATE_VERSION,
+  type GoalControlRequest,
+  type GoalSnapshotV2,
+  type GoalStateCause,
+  type GoalStateRecordPayloadV2,
+  type GoalStateResponse,
+  type GoalTerminalProposal,
+  type GoalTurnPermit,
+  type TranscriptCursor,
+} from './goal-protocol.js';
+import {
+  elapsedActiveTime,
+  reduceGoalControl,
+  reduceGoalTurnFinished,
+} from './goal-reducer.js';
+import type {
+  GoalVerificationResult,
+  GoalVerifier,
+  GoalVerifierInput,
+} from './goal-verifier.js';
+import {
+  createMigratedGoalState,
+  recoverGoalFromRecords,
+  type GoalRecoveryRecord,
+} from './goal-persistence.js';
+
+export interface GoalJournal {
+  getTranscriptCursor(): TranscriptCursor;
+  recordGoalState(
+    recordUuid: string,
+    payload: GoalStateRecordPayloadV2,
+  ): Promise<unknown>;
+}
+
+export interface CreateGoalRuntimeOptions {
+  journal: GoalJournal;
+  evidenceSource?: GoalEvidenceSource;
+  verifier?: GoalVerifier;
+}
+
+export interface GoalEvidenceSource {
+  flush(): Promise<void>;
+  readActiveTranscriptChain(): Promise<readonly GoalEvidenceRecord[]>;
+}
+
+export class GoalPersistenceUnavailableError extends Error {
+  constructor() {
+    super('Goal persistence is unavailable for this session');
+    this.name = 'GoalPersistenceUnavailableError';
+  }
+}
+
+export interface GoalTurnHost {
+  startGoalTurn(input: {
+    permit: GoalTurnPermit;
+    continuationContext: string;
+    verifierFeedback?: string;
+  }): Promise<void>;
+  preemptGoalTurn(reason: string): void;
+}
+
+export interface GoalProposalReceipt {
+  recorded: boolean;
+  readyForVerification: boolean;
+}
+
+export interface GoalWorkerView {
+  goalId: string;
+  revision: number;
+  objective: string;
+  evidenceCursor: TranscriptCursor;
+  evidenceCatalog?: GoalEvidenceCatalog;
+  verifierFeedback?: string;
+}
+
+export interface GoalPendingProposal {
+  permit: GoalTurnPermit;
+  proposal: GoalTerminalProposal;
+}
+
+export interface GoalRuntime {
+  getSnapshot(): GoalSnapshotV2;
+  subscribe(
+    listener: (snapshot: GoalSnapshotV2, cause?: GoalStateCause) => void,
+  ): () => void;
+  restore(records: readonly GoalRecoveryRecord[]): Promise<void>;
+  dispatch(request: GoalControlRequest): Promise<GoalStateResponse>;
+  bindHost(host: GoalTurnHost): () => void;
+  beginTurn(turnKey: string): GoalTurnPermit | undefined;
+  releaseTurn(turnKey: string): Promise<boolean>;
+  permitForTurn(turnKey: string): GoalTurnPermit | undefined;
+  getVerifierFeedback(permit: GoalTurnPermit): string | undefined;
+  finishTurn(permit: GoalTurnPermit): Promise<void>;
+  getGoalForWorker(permit: GoalTurnPermit): Promise<GoalWorkerView>;
+  recordTerminalProposal(
+    permit: GoalTurnPermit,
+    proposal: GoalTerminalProposal,
+  ): GoalProposalReceipt;
+  takePendingTerminalProposal(): GoalPendingProposal | undefined;
+  dispose(): void;
+}
+
+export function createGoalRuntime(
+  options: CreateGoalRuntimeOptions,
+): GoalRuntime {
+  if (Boolean(options.evidenceSource) !== Boolean(options.verifier)) {
+    throw new Error(
+      'Goal evidence source and verifier must be configured together',
+    );
+  }
+
+  let snapshot: GoalSnapshotV2 = {
+    v: GOAL_STATE_VERSION,
+    goal: null,
+    activity: 'idle',
+  };
+  const listeners = new Set<
+    (value: GoalSnapshotV2, cause?: GoalStateCause) => void
+  >();
+  let dispatchTail = Promise.resolve();
+  let host: GoalTurnHost | undefined;
+  let currentPermit: GoalTurnPermit | undefined;
+  let currentPermitHost: GoalTurnHost | undefined;
+  let currentTurnKey: string | undefined;
+  let queuedTurnKey: string | undefined;
+  let continuationQueued = false;
+  let currentProposal:
+    | {
+        proposal: GoalTerminalProposal;
+        readyForVerification: boolean;
+        blockedAuditCandidate?: {
+          fingerprint: string;
+          count: number;
+          turnIds: string[];
+        };
+      }
+    | undefined;
+  let pendingProposal: GoalPendingProposal | undefined;
+  let verificationAttempt:
+    | {
+        permit: GoalTurnPermit;
+        proposal: GoalTerminalProposal;
+        goal: NonNullable<GoalSnapshotV2['goal']>;
+        controller: AbortController;
+      }
+    | undefined;
+  let blockedAudit: GoalStateRecordPayloadV2['blockedAudit'];
+  let nextVerifierFeedback: string | undefined;
+  let currentTurnFeedback: string | undefined;
+  let restored = false;
+  let disposed = false;
+  let recoveryError: Error | undefined;
+  type VerificationAttempt = NonNullable<typeof verificationAttempt>;
+
+  const assertAvailable = () => {
+    if (disposed) throw new Error('Goal runtime has been disposed');
+  };
+
+  const assertOperational = () => {
+    assertAvailable();
+    if (recoveryError) throw recoveryError;
+  };
+
+  const getSnapshot = (): GoalSnapshotV2 => structuredClone(snapshot);
+
+  const broadcast = (cause?: GoalStateCause) => {
+    for (const listener of listeners) {
+      try {
+        listener(getSnapshot(), cause);
+      } catch {
+        // Subscribers cannot roll back a committed runtime transition.
+      }
+    }
+  };
+
+  const preemptHost = (reason: string, target = host) => {
+    try {
+      target?.preemptGoalTurn(reason);
+    } catch {
+      // The lifecycle is already committed before host preemption begins.
+    }
+  };
+
+  const flushContinuation = (cause?: GoalStateCause) => {
+    if (
+      !continuationQueued ||
+      !host ||
+      currentPermit ||
+      pendingProposal ||
+      verificationAttempt ||
+      snapshot.activity !== 'idle' ||
+      snapshot.goal?.status !== 'active'
+    ) {
+      return;
+    }
+    continuationQueued = false;
+    const scheduledHost = host;
+    const continuationContext = snapshot.goal.objective;
+    const verifierFeedback = nextVerifierFeedback;
+    nextVerifierFeedback = undefined;
+    currentTurnFeedback = verifierFeedback;
+    currentPermit = {
+      goalId: snapshot.goal.goalId,
+      revision: snapshot.goal.revision,
+      turnId: randomUUID(),
+    };
+    currentPermitHost = scheduledHost;
+    currentTurnKey = `goal-runtime:${currentPermit.turnId}`;
+    const startedPermit = structuredClone(currentPermit);
+    snapshot = { ...snapshot, activity: 'running' };
+    broadcast(cause);
+    const handleStartFailure = () => {
+      void enqueue(async () => {
+        if (isCurrentPermit(startedPermit)) {
+          const nextTurnKey = queuedTurnKey;
+          currentPermit = undefined;
+          currentPermitHost = undefined;
+          currentTurnKey = undefined;
+          currentProposal = undefined;
+          if (currentTurnFeedback !== undefined) {
+            nextVerifierFeedback ??= currentTurnFeedback;
+          }
+          currentTurnFeedback = undefined;
+          if (host === scheduledHost) host = undefined;
+          if (nextTurnKey && snapshot.goal?.status === 'active') {
+            currentPermit = {
+              goalId: snapshot.goal.goalId,
+              revision: snapshot.goal.revision,
+              turnId: randomUUID(),
+            };
+            currentPermitHost = host;
+            currentTurnKey = nextTurnKey;
+            currentTurnFeedback = nextVerifierFeedback;
+            nextVerifierFeedback = undefined;
+            queuedTurnKey = undefined;
+            continuationQueued = false;
+            snapshot = { ...snapshot, activity: 'running' };
+          } else {
+            snapshot = { ...snapshot, activity: 'idle' };
+          }
+          broadcast();
+          if (!currentPermit) queueContinuation();
+        }
+      }).catch(() => undefined);
+    };
+    let started: Promise<void>;
+    try {
+      started = scheduledHost.startGoalTurn({
+        permit: startedPermit,
+        continuationContext,
+        ...(verifierFeedback ? { verifierFeedback } : {}),
+      });
+    } catch {
+      handleStartFailure();
+      return;
+    }
+    void started.catch(handleStartFailure);
+  };
+
+  const queueContinuation = (cause?: GoalStateCause) => {
+    if (
+      snapshot.goal?.status !== 'active' ||
+      currentPermit ||
+      pendingProposal ||
+      verificationAttempt
+    ) {
+      return;
+    }
+    continuationQueued = true;
+    flushContinuation(cause);
+  };
+
+  const enqueue = <T>(operation: () => Promise<T>): Promise<T> => {
+    const result = dispatchTail.then(operation, operation);
+    dispatchTail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
+
+  const isCurrentPermit = (permit: GoalTurnPermit) =>
+    snapshot.goal?.goalId === permit.goalId &&
+    snapshot.goal.revision === permit.revision &&
+    currentPermit?.goalId === permit.goalId &&
+    currentPermit.revision === permit.revision &&
+    currentPermit.turnId === permit.turnId;
+
+  const isCurrentVerificationAttempt = (attempt: VerificationAttempt) =>
+    verificationAttempt === attempt &&
+    snapshot.goal?.goalId === attempt.permit.goalId &&
+    snapshot.goal.revision === attempt.permit.revision &&
+    snapshot.goal.status === 'active' &&
+    snapshot.activity === 'verifying';
+
+  const invalidateVerification = (reason: string) => {
+    const attempt = verificationAttempt;
+    verificationAttempt = undefined;
+    pendingProposal = undefined;
+    if (attempt && !attempt.controller.signal.aborted) {
+      attempt.controller.abort(new Error(reason));
+    }
+  };
+
+  const verifierInput = (
+    attempt: VerificationAttempt,
+    evidence: ReturnType<typeof validateGoalEvidenceReferences>,
+  ): GoalVerifierInput => {
+    const currentDeliveredOutput = evidence.citedRecords
+      .filter(
+        (record) =>
+          record.proofKind === 'delivered_output' &&
+          record.turnId === attempt.permit.turnId,
+      )
+      .map((record) => record.content);
+    const base = {
+      goal: {
+        goalId: attempt.goal.goalId,
+        revision: attempt.goal.revision,
+        objective: attempt.goal.objective,
+      },
+      evidence: evidence.citedRecords,
+      ...(currentDeliveredOutput.length > 0 ? { currentDeliveredOutput } : {}),
+    };
+    if (attempt.proposal.status === 'complete') {
+      return {
+        ...base,
+        proposal: { ...attempt.proposal, status: 'complete' },
+      };
+    }
+    return {
+      ...base,
+      proposal: { ...attempt.proposal, status: 'blocked' },
+      blockedPolicy:
+        'A blocked Goal is resumable. It may be accepted immediately only when the evidence shows that new user authority or a material user choice is required, or that an external state change is required, and no meaningful in-scope work remains. An ordinary technical blocker requires evidence of the same cause from the current and two immediately preceding Goal turns. Difficulty, uncertainty, incomplete work, or a preference for clarification do not by themselves justify blocked.',
+    };
+  };
+
+  const promoteQueuedUserTurn = (): boolean => {
+    const nextTurnKey = queuedTurnKey;
+    if (!nextTurnKey || currentPermit || snapshot.goal?.status !== 'active') {
+      return false;
+    }
+    queuedTurnKey = undefined;
+    continuationQueued = false;
+    currentPermit = {
+      goalId: snapshot.goal.goalId,
+      revision: snapshot.goal.revision,
+      turnId: randomUUID(),
+    };
+    currentPermitHost = host;
+    currentTurnKey = nextTurnKey;
+    currentTurnFeedback = nextVerifierFeedback;
+    nextVerifierFeedback = undefined;
+    snapshot = { ...snapshot, activity: 'running' };
+    return true;
+  };
+
+  const admitAfterRejection = (): boolean => {
+    continuationQueued = false;
+    if (promoteQueuedUserTurn()) return false;
+    const activityBefore = snapshot.activity;
+    queueContinuation('verifier_reject');
+    return activityBefore !== snapshot.activity;
+  };
+
+  const recordVerificationOutcome = async (
+    attempt: VerificationAttempt,
+    outcome:
+      | { kind: 'decision'; result: GoalVerificationResult }
+      | { kind: 'usage_limited'; reason: string },
+  ): Promise<void> => {
+    await enqueue(async () => {
+      if (!isCurrentVerificationAttempt(attempt) || !snapshot.goal) return;
+
+      const now = Date.now();
+      if (outcome.kind === 'decision' && outcome.result.decision === 'accept') {
+        const acceptedGoal = {
+          ...snapshot.goal,
+          activeTimeMs: elapsedActiveTime(snapshot.goal, now),
+          updatedAt: now,
+          lastReason: outcome.result.reason,
+        };
+        const acceptedSnapshot: GoalSnapshotV2 = {
+          v: GOAL_STATE_VERSION,
+          goal: acceptedGoal,
+          activity: 'idle',
+        };
+        const terminalSnapshot: GoalSnapshotV2 = {
+          v: GOAL_STATE_VERSION,
+          goal: {
+            ...acceptedGoal,
+            status: attempt.proposal.status,
+          },
+          activity: 'idle',
+        };
+        await options.journal.recordGoalState(randomUUID(), {
+          v: GOAL_STATE_VERSION,
+          cause: 'verifier_accept',
+          snapshot: acceptedSnapshot,
+        });
+        if (!isCurrentVerificationAttempt(attempt) || !snapshot.goal) return;
+        await options.journal.recordGoalState(randomUUID(), {
+          v: GOAL_STATE_VERSION,
+          cause: attempt.proposal.status,
+          snapshot: terminalSnapshot,
+        });
+        if (!isCurrentVerificationAttempt(attempt) || !snapshot.goal) return;
+        verificationAttempt = undefined;
+        pendingProposal = undefined;
+        if (attempt.proposal.status === 'complete') queuedTurnKey = undefined;
+        continuationQueued = false;
+        nextVerifierFeedback = undefined;
+        currentTurnFeedback = undefined;
+        snapshot = structuredClone(terminalSnapshot);
+        broadcast(attempt.proposal.status);
+        return;
+      }
+
+      if (outcome.kind === 'usage_limited') {
+        const limitedSnapshot: GoalSnapshotV2 = {
+          v: GOAL_STATE_VERSION,
+          goal: {
+            ...snapshot.goal,
+            status: 'usage_limited',
+            activeTimeMs: elapsedActiveTime(snapshot.goal, now),
+            updatedAt: now,
+            lastReason: outcome.reason,
+          },
+          activity: 'idle',
+        };
+        await options.journal.recordGoalState(randomUUID(), {
+          v: GOAL_STATE_VERSION,
+          cause: 'usage_limited',
+          snapshot: limitedSnapshot,
+        });
+        if (!isCurrentVerificationAttempt(attempt) || !snapshot.goal) return;
+        verificationAttempt = undefined;
+        pendingProposal = undefined;
+        continuationQueued = false;
+        nextVerifierFeedback = undefined;
+        currentTurnFeedback = undefined;
+        snapshot = structuredClone(limitedSnapshot);
+        broadcast('usage_limited');
+        return;
+      }
+
+      const rejectedSnapshot: GoalSnapshotV2 = {
+        v: GOAL_STATE_VERSION,
+        goal: {
+          ...snapshot.goal,
+          activeTimeMs: elapsedActiveTime(snapshot.goal, now),
+          updatedAt: now,
+          lastReason: outcome.result.reason,
+        },
+        activity: 'idle',
+      };
+      await options.journal.recordGoalState(randomUUID(), {
+        v: GOAL_STATE_VERSION,
+        cause: 'verifier_reject',
+        snapshot: rejectedSnapshot,
+        ...(blockedAudit
+          ? { blockedAudit: structuredClone(blockedAudit) }
+          : {}),
+      });
+      if (!isCurrentVerificationAttempt(attempt) || !snapshot.goal) return;
+      verificationAttempt = undefined;
+      pendingProposal = undefined;
+      snapshot = structuredClone(rejectedSnapshot);
+      nextVerifierFeedback = outcome.result.reason;
+      const continuationBroadcast = admitAfterRejection();
+      if (!continuationBroadcast) broadcast('verifier_reject');
+    });
+  };
+
+  const runVerification = async (
+    attempt: VerificationAttempt,
+  ): Promise<void> => {
+    const evidenceSource = options.evidenceSource;
+    const verifier = options.verifier;
+    if (!evidenceSource || !verifier) return;
+
+    let outcome:
+      | { kind: 'decision'; result: GoalVerificationResult }
+      | { kind: 'usage_limited'; reason: string };
+    try {
+      await evidenceSource.flush();
+      if (attempt.controller.signal.aborted) return;
+      const records = await evidenceSource.readActiveTranscriptChain();
+      if (attempt.controller.signal.aborted) return;
+      const evidence = validateGoalEvidenceReferences({
+        records,
+        goal: attempt.goal,
+        permit: attempt.permit,
+        proposal: attempt.proposal,
+      });
+      const result = await verifier(
+        verifierInput(attempt, evidence),
+        attempt.controller.signal,
+      );
+      if (attempt.controller.signal.aborted) return;
+      outcome = { kind: 'decision', result };
+    } catch (error) {
+      if (attempt.controller.signal.aborted) return;
+      if (error instanceof InvalidGoalEvidenceReferenceError) {
+        outcome = {
+          kind: 'decision',
+          result: { decision: 'reject', reason: error.message },
+        };
+      } else {
+        const reason =
+          error instanceof EvidenceSourceUnavailableError
+            ? error.message
+            : error instanceof Error
+              ? error.message
+              : String(error);
+        outcome = { kind: 'usage_limited', reason };
+      }
+    }
+    await recordVerificationOutcome(attempt, outcome);
+  };
+
+  return {
+    getSnapshot,
+    subscribe(
+      listener: (value: GoalSnapshotV2, cause?: GoalStateCause) => void,
+    ): () => void {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    restore(records: readonly GoalRecoveryRecord[]): Promise<void> {
+      return enqueue(async () => {
+        assertAvailable();
+        if (restored) return;
+        const recovery = recoverGoalFromRecords(records);
+        if (recovery.kind === 'unsupported') {
+          recoveryError = new Error(recovery.reason);
+          throw recoveryError;
+        }
+        try {
+          let recoveredSnapshot: GoalSnapshotV2 | undefined;
+          let recoveredCause: GoalStateCause | undefined;
+          if (recovery.kind === 'v2') {
+            recoveredSnapshot = {
+              ...structuredClone(recovery.payload.snapshot),
+              activity: 'idle',
+            };
+            blockedAudit = recovery.payload.blockedAudit
+              ? structuredClone(recovery.payload.blockedAudit)
+              : undefined;
+            recoveredCause = recovery.payload.cause;
+          } else if (recovery.kind === 'legacy') {
+            const recordUuid = randomUUID();
+            const payload = createMigratedGoalState({
+              objective: recovery.objective,
+              goalId: randomUUID(),
+              recordUuid,
+              now: Date.now(),
+            });
+            await options.journal.recordGoalState(recordUuid, payload);
+            assertAvailable();
+            recoveredSnapshot = structuredClone(payload.snapshot);
+            recoveredCause = payload.cause;
+          }
+          if (recoveredSnapshot) snapshot = recoveredSnapshot;
+          recoveryError = undefined;
+          restored = true;
+          if (recoveredSnapshot) broadcast(recoveredCause);
+          queueContinuation();
+        } catch (error) {
+          if (!disposed) {
+            recoveryError =
+              error instanceof Error ? error : new Error(String(error));
+          }
+          throw error;
+        }
+      });
+    },
+    bindHost(nextHost: GoalTurnHost): () => void {
+      assertOperational();
+      host = nextHost;
+      queueContinuation();
+      return () => {
+        if (host === nextHost) host = undefined;
+      };
+    },
+    beginTurn(turnKey: string): GoalTurnPermit | undefined {
+      assertOperational();
+      if (snapshot.goal?.status !== 'active') return undefined;
+      if (
+        snapshot.activity === 'verifying' ||
+        pendingProposal ||
+        verificationAttempt
+      ) {
+        queuedTurnKey ??= turnKey;
+        continuationQueued = false;
+        return undefined;
+      }
+      if (currentPermit) {
+        if (currentTurnKey === turnKey) return structuredClone(currentPermit);
+        queuedTurnKey ??= turnKey;
+        continuationQueued = false;
+        return undefined;
+      }
+      continuationQueued = false;
+      currentPermit = {
+        goalId: snapshot.goal.goalId,
+        revision: snapshot.goal.revision,
+        turnId: randomUUID(),
+      };
+      currentPermitHost = host;
+      currentTurnKey = turnKey;
+      currentTurnFeedback = nextVerifierFeedback;
+      nextVerifierFeedback = undefined;
+      snapshot = { ...snapshot, activity: 'running' };
+      broadcast();
+      return structuredClone(currentPermit);
+    },
+    releaseTurn(turnKey: string): Promise<boolean> {
+      return enqueue(async () => {
+        assertOperational();
+        let released = false;
+        if (queuedTurnKey === turnKey) {
+          queuedTurnKey = undefined;
+          released = true;
+        }
+        if (currentPermit && currentTurnKey === turnKey) {
+          if (currentTurnFeedback !== undefined) {
+            nextVerifierFeedback ??= currentTurnFeedback;
+          }
+          currentPermit = undefined;
+          currentPermitHost = undefined;
+          currentTurnKey = undefined;
+          currentTurnFeedback = undefined;
+          currentProposal = undefined;
+          snapshot = { ...snapshot, activity: 'idle' };
+          broadcast();
+          released = true;
+        }
+        if (released) queueContinuation();
+        return released;
+      });
+    },
+    permitForTurn(turnKey: string): GoalTurnPermit | undefined {
+      assertOperational();
+      return currentPermit && currentTurnKey === turnKey
+        ? structuredClone(currentPermit)
+        : undefined;
+    },
+    getVerifierFeedback(permit: GoalTurnPermit): string | undefined {
+      assertOperational();
+      if (!isCurrentPermit(permit)) {
+        throw new Error('Goal turn permit is no longer valid');
+      }
+      return currentTurnFeedback;
+    },
+    finishTurn(permit: GoalTurnPermit): Promise<void> {
+      const finish = enqueue(
+        async (): Promise<VerificationAttempt | undefined> => {
+          assertOperational();
+          if (!isCurrentPermit(permit) || !snapshot.goal) {
+            throw new Error('Goal turn permit is no longer valid');
+          }
+          const recordUuid = randomUUID();
+          const nextGoal = reduceGoalTurnFinished(snapshot.goal, {
+            now: Date.now(),
+          });
+          const persistedSnapshot: GoalSnapshotV2 = {
+            v: GOAL_STATE_VERSION,
+            goal: nextGoal,
+            activity: 'idle',
+          };
+          const persistedBlockedAudit = currentProposal?.blockedAuditCandidate;
+          await options.journal.recordGoalState(recordUuid, {
+            v: GOAL_STATE_VERSION,
+            cause: 'turn_finished',
+            snapshot: persistedSnapshot,
+            ...(persistedBlockedAudit
+              ? { blockedAudit: structuredClone(persistedBlockedAudit) }
+              : {}),
+          });
+          assertAvailable();
+          const nextTurnKey = queuedTurnKey;
+          const proposal = currentProposal;
+          const activeProposal =
+            proposal && persistedSnapshot.goal?.status === 'active'
+              ? proposal
+              : undefined;
+          if (activeProposal?.blockedAuditCandidate) {
+            blockedAudit = activeProposal.blockedAuditCandidate;
+          } else if (persistedSnapshot.goal?.status === 'active') {
+            blockedAudit = undefined;
+          }
+          pendingProposal =
+            activeProposal?.readyForVerification && !options.verifier
+              ? {
+                  permit: structuredClone(permit),
+                  proposal: structuredClone(activeProposal.proposal),
+                }
+              : undefined;
+          verificationAttempt =
+            activeProposal?.readyForVerification && options.verifier
+              ? {
+                  permit: structuredClone(permit),
+                  proposal: structuredClone(activeProposal.proposal),
+                  goal: structuredClone(nextGoal),
+                  controller: new AbortController(),
+                }
+              : undefined;
+          const verifying = Boolean(pendingProposal || verificationAttempt);
+          snapshot = {
+            ...structuredClone(persistedSnapshot),
+            activity: verifying ? 'verifying' : 'idle',
+          };
+          currentPermit = undefined;
+          currentPermitHost = undefined;
+          currentTurnKey = undefined;
+          currentTurnFeedback = undefined;
+          queuedTurnKey = verifying ? nextTurnKey : undefined;
+          continuationQueued = false;
+          currentProposal = undefined;
+          if (!verifying && nextTurnKey && snapshot.goal?.status === 'active') {
+            currentPermit = {
+              goalId: snapshot.goal.goalId,
+              revision: snapshot.goal.revision,
+              turnId: randomUUID(),
+            };
+            currentPermitHost = host;
+            currentTurnKey = nextTurnKey;
+            currentTurnFeedback = nextVerifierFeedback;
+            nextVerifierFeedback = undefined;
+            snapshot = { ...snapshot, activity: 'running' };
+          }
+          broadcast('turn_finished');
+          if (!verifying && !currentPermit) {
+            queueContinuation();
+          }
+          return verificationAttempt;
+        },
+      );
+      return finish.then(async (attempt) => {
+        if (attempt) await runVerification(attempt);
+      });
+    },
+    async getGoalForWorker(permit: GoalTurnPermit): Promise<GoalWorkerView> {
+      assertOperational();
+      if (!isCurrentPermit(permit) || !snapshot.goal) {
+        throw new Error('Goal turn permit is no longer valid');
+      }
+      const goal = structuredClone(snapshot.goal);
+      const verifierFeedback = currentTurnFeedback;
+      const evidenceSource = options.evidenceSource;
+      if (!evidenceSource) {
+        return {
+          goalId: goal.goalId,
+          revision: goal.revision,
+          objective: goal.objective,
+          evidenceCursor: structuredClone(goal.evidenceCursor),
+          ...(verifierFeedback ? { verifierFeedback } : {}),
+        };
+      }
+      await evidenceSource.flush();
+      const records = await evidenceSource.readActiveTranscriptChain();
+      const evidenceCatalog = buildGoalEvidenceCatalog({
+        records,
+        goal,
+        permit,
+      });
+      if (!isCurrentPermit(permit) || !snapshot.goal) {
+        throw new Error('Goal turn permit is no longer valid');
+      }
+      return {
+        goalId: goal.goalId,
+        revision: goal.revision,
+        objective: goal.objective,
+        evidenceCursor: structuredClone(goal.evidenceCursor),
+        evidenceCatalog,
+        ...(verifierFeedback ? { verifierFeedback } : {}),
+      };
+    },
+    recordTerminalProposal(
+      permit: GoalTurnPermit,
+      proposal: GoalTerminalProposal,
+    ): GoalProposalReceipt {
+      assertOperational();
+      if (!isCurrentPermit(permit)) {
+        throw new Error('Goal turn permit is no longer valid');
+      }
+      if (currentProposal) {
+        return {
+          recorded: false,
+          readyForVerification: currentProposal.readyForVerification,
+        };
+      }
+      let readyForVerification = true;
+      let blockedAuditCandidate:
+        | { fingerprint: string; count: number; turnIds: string[] }
+        | undefined;
+      if (
+        proposal.status === 'blocked' &&
+        proposal.blockerKind !== 'authority' &&
+        proposal.blockerKind !== 'external'
+      ) {
+        const fingerprint = `${proposal.blockerKind ?? ''}\n${proposal.reason}`;
+        blockedAuditCandidate = {
+          fingerprint,
+          count:
+            blockedAudit?.fingerprint === fingerprint
+              ? Math.min(blockedAudit.count + 1, 3)
+              : 1,
+          turnIds:
+            blockedAudit?.fingerprint === fingerprint
+              ? [...blockedAudit.turnIds, permit.turnId].slice(-3)
+              : [permit.turnId],
+        };
+        readyForVerification = blockedAuditCandidate.count >= 3;
+      }
+      currentProposal = {
+        proposal: structuredClone(proposal),
+        readyForVerification,
+        ...(blockedAuditCandidate ? { blockedAuditCandidate } : {}),
+      };
+      return { recorded: true, readyForVerification };
+    },
+    takePendingTerminalProposal(): GoalPendingProposal | undefined {
+      assertOperational();
+      const proposal = pendingProposal;
+      pendingProposal = undefined;
+      return proposal ? structuredClone(proposal) : undefined;
+    },
+    dispatch(request: GoalControlRequest): Promise<GoalStateResponse> {
+      const execute = async (): Promise<GoalStateResponse> => {
+        assertOperational();
+        const recordUuid = randomUUID();
+        const nextGoal = reduceGoalControl(snapshot.goal, {
+          request,
+          now: Date.now(),
+          nextGoalId: randomUUID(),
+          cursor:
+            request.action === 'create' ||
+            request.action === 'replace' ||
+            request.action === 'edit'
+              ? { recordId: recordUuid }
+              : options.journal.getTranscriptCursor(),
+        });
+        const nextSnapshot: GoalSnapshotV2 = {
+          v: GOAL_STATE_VERSION,
+          goal: nextGoal,
+          activity: 'idle',
+        };
+        await options.journal.recordGoalState(recordUuid, {
+          v: GOAL_STATE_VERSION,
+          cause: request.action,
+          snapshot: nextSnapshot,
+        });
+        assertAvailable();
+        const invalidatesPermit =
+          request.action === 'create' ||
+          request.action === 'replace' ||
+          request.action === 'edit' ||
+          request.action === 'pause' ||
+          request.action === 'clear';
+        const invalidatedHost = currentPermitHost ?? host;
+        if (invalidatesPermit) {
+          invalidateVerification(`Goal ${request.action}`);
+        }
+        if (invalidatesPermit) {
+          currentPermit = undefined;
+          currentPermitHost = undefined;
+          currentTurnKey = undefined;
+          queuedTurnKey = undefined;
+          currentProposal = undefined;
+          pendingProposal = undefined;
+          blockedAudit = undefined;
+          nextVerifierFeedback = undefined;
+          currentTurnFeedback = undefined;
+          continuationQueued = false;
+        } else if (request.action === 'resume') {
+          blockedAudit = undefined;
+          if (currentProposal?.blockedAuditCandidate) {
+            currentProposal = {
+              proposal: currentProposal.proposal,
+              readyForVerification: false,
+            };
+          }
+        }
+        snapshot = {
+          ...structuredClone(nextSnapshot),
+          activity:
+            currentPermit && request.action === 'resume' ? 'running' : 'idle',
+        };
+        if (request.action === 'resume') promoteQueuedUserTurn();
+        broadcast(request.action);
+        if (invalidatesPermit) {
+          preemptHost(`Goal ${request.action}`, invalidatedHost);
+        }
+        if (
+          request.action === 'resume' ||
+          (request.action !== 'clear' && snapshot.goal?.status === 'active')
+        ) {
+          queueContinuation();
+        }
+        return { snapshot: getSnapshot() };
+      };
+
+      return enqueue(execute);
+    },
+    dispose(): void {
+      if (disposed) return;
+      disposed = true;
+      const invalidatedHost = currentPermitHost ?? host;
+      currentPermit = undefined;
+      currentPermitHost = undefined;
+      currentTurnKey = undefined;
+      queuedTurnKey = undefined;
+      continuationQueued = false;
+      currentProposal = undefined;
+      pendingProposal = undefined;
+      invalidateVerification('Goal runtime disposed');
+      blockedAudit = undefined;
+      nextVerifierFeedback = undefined;
+      currentTurnFeedback = undefined;
+      preemptHost('Goal runtime disposed', invalidatedHost);
+      host = undefined;
+      listeners.clear();
+    },
+  };
+}

--- a/packages/core/src/goals/index.ts
+++ b/packages/core/src/goals/index.ts
@@ -61,3 +61,4 @@ export type {
 } from './goal-legacy-projection.js';
 export * from './goal-evidence.js';
 export * from './goal-verifier.js';
+export * from './goal-runtime.js';


### PR DESCRIPTION
## What this PR does

Adds the session-owned Goal v3 runtime that serializes lifecycle controls, persists every committed transition before publishing it, grants one exact version-bound turn permit at a time, and schedules automatic continuation without a fixed turn cap.

It gives queued real-user input priority over automatic continuation, invalidates stale permits on pause, edit, replace, clear, or disposal, and safely transfers ownership when a host is replaced or fails to start.

It also orchestrates bounded evidence collection and independent terminal verification. Completion and blocked proposals remain non-terminal until verification is durably accepted; repeated technical blockers require three consecutive Goal turns, while authority and external blockers can be verified immediately.

## Why it's needed

Goal execution previously mixed lifecycle state, model-loop continuation, and client queue behavior. A single session-owned runtime is required so TUI, non-interactive, ACP, Web Shell, and Desktop integrations can share the same ordering and stale-turn guarantees without reimplementing them.

This is the third focused slice of the Goal v3 rollout. The state protocol and bounded evidence verifier are already merged; tool and client integrations intentionally remain outside this PR.

## Reviewer Test Plan

### How to verify

Create an active Goal with a fake host and confirm exactly one automatic turn starts with a permit matching the Goal identity and revision. Queue a real-user turn while it runs, finish the automatic turn, and confirm the queued user turn is admitted before another automatic continuation.

Run 150 sequential automatic turns and confirm every turn receives a unique permit, the Goal remains active, and the turn count reaches 150 without a fixed 50-turn stop.

Pause, edit, replace, or clear an active Goal and confirm the previous permit becomes invalid only after the lifecycle write commits. Resume and confirm exactly one new turn is admitted.

Submit completion and blocker proposals with bounded evidence. Confirm verifier rejection returns feedback to the next permitted turn, verification failures move the Goal to a resumable usage-limited state, and an accepted proposal becomes terminal only after both acceptance and terminal lifecycle writes succeed.

### Evidence (Before & After)

N/A — this PR adds the shared runtime contract and has no user-visible UI changes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22 workspace, no sandbox.

## Risk & Scope

- Main risk or tradeoff: The runtime coordinates persistence, host ownership, user-turn priority, and asynchronous verification; focused concurrency and persistence-failure tests cover these boundaries.
- Not validated / out of scope: Tool registration, model-loop wiring, transcript recording and rewind, TUI, non-interactive, ACP, SDK, Web Shell, and Desktop integration are intentionally deferred to subsequent focused PRs.
- Breaking changes / migration notes: None. The new runtime is exported but is not wired into existing clients in this PR.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

新增会话级 Goal v3 runtime：串行化生命周期控制，在对外发布前持久化每次已提交转换，每次只签发一个与目标版本精确绑定的 turn permit，并在没有固定轮数上限的情况下调度自动续跑。

真实用户排队消息优先于自动续跑；暂停、编辑、替换、清除或销毁会使旧 permit 失效；host 被替换或启动失败时会安全转移所有权。

同时编排有界证据采集和独立终态验证。完成或阻塞提案在验证被持久化接受前不会改变终态；普通技术阻塞必须在连续三个 Goal 轮次中重复出现，权限或外部状态阻塞则可立即进入验证。

## 为什么需要

此前 Goal 执行把生命周期状态、模型循环续跑和客户端排队行为混在一起。需要一个会话级统一 runtime，让 TUI、非交互、ACP、Web Shell 和 Desktop 共享相同的时序与过期轮次保护，不再各自重写。

这是 Goal v3 拆分合入的第三个聚焦切片。状态协议和有界证据 verifier 已经合入；工具和客户端集成明确不属于本 PR。

## Reviewer 测试计划

### 如何验证

使用 fake host 创建 active Goal，确认只启动一个自动轮次，且 permit 与 Goal 标识和 revision 匹配。在自动轮次运行时排入真实用户轮次，结束自动轮次后确认用户轮次先于下一次自动续跑被接纳。

连续运行 150 个自动轮次，确认每轮 permit 唯一、Goal 保持 active、turn count 达到 150，且不存在固定 50 轮停止。

对 active Goal 执行暂停、编辑、替换或清除，确认只有生命周期写入成功后旧 permit 才失效；恢复后只接纳一个新轮次。

用有界证据提交完成和阻塞提案。确认 verifier 拒绝会把反馈交给下一个获准轮次，验证基础设施失败会进入可恢复的 usage-limited 状态，接受的提案只有在接受记录和终态记录都成功写入后才进入终态。

### 证据（前后对比）

不适用——本 PR 只新增共享 runtime 契约，没有用户可见 UI 改动。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Node.js 22 工作区，无 sandbox。

## 风险与范围

- 主要风险或取舍：runtime 同时协调持久化、host 所有权、用户轮次优先级和异步验证；已用聚焦的并发与持久化失败测试覆盖这些边界。
- 未验证或不在范围内：工具注册、模型循环接线、对话录制与 rewind、TUI、非交互、ACP、SDK、Web Shell 和 Desktop 集成将由后续聚焦 PR 完成。
- 破坏性变更或迁移说明：无。新 runtime 已导出，但本 PR 不接入现有客户端。

## 关联问题

不适用

</details>
