### PR TITLE
fix(web-shell): keep git mode popover open when picking branch/worktree

### DIFF
--- a/packages/web-shell/client/components/GitModePopover.tsx
+++ b/packages/web-shell/client/components/GitModePopover.tsx
@@ -160,6 +160,13 @@ export function GitModePopover({
           align="end"
           sideOffset={8}
           className={styles.popover}
+          // The content is portaled out of the composer, but React synthetic
+          // clicks still bubble through the React tree to the composer
+          // surface's onClick, which calls core.focus() and steals focus out of
+          // the popover — Radix then dismisses it via focus-outside. Stop the
+          // bubble so option clicks keep focus inside (mirrors the composer
+          // ToolbarPopover pattern in ChatEditor).
+          onClick={(e) => e.stopPropagation()}
           onOpenAutoFocus={(e) => e.preventDefault()}
           onInteractOutside={(e) => {
             // The portal container fools Radix's dismissable-layer into

--- a/packages/web-shell/client/e2e/web-shell.git-mode.spec.ts
+++ b/packages/web-shell/client/e2e/web-shell.git-mode.spec.ts
@@ -83,13 +83,20 @@ test('git mode chip shows popover with three modes and captures screenshots', as
     animations: 'disabled',
   });
 
-  // Click "New branch" option
-  const branchOption = popover.getByText('New branch', { exact: false });
-  await branchOption.click();
+  // Click "New branch" option (match by role: the option's text is split
+  // across a name + description span, so getByText('New branch') is ambiguous)
+  await popover.getByRole('radio', { name: /New branch/ }).click();
 
   // Wait for the branch input to appear
   const branchInput = page.locator('[data-testid="git-mode-branch-input"]');
   await expect(branchInput).toBeVisible({ timeout: 5_000 });
+  // Regression guard: clicking an option used to steal focus to the composer
+  // (via the surface onClick bubbling through the portal), dismissing the
+  // popover ~100ms after the input flashed visible. Assert it stays open.
+  await expect(branchInput).toBeVisible();
+  await page.waitForTimeout(300);
+  await expect(popover).toBeVisible();
+  await expect(branchInput).toBeVisible();
 
   // Type a branch name
   await branchInput.fill('feat/git-mode-selector');
@@ -145,12 +152,17 @@ test('git mode chip worktree mode sends worktree intent', async ({
   const popover = page.locator('[data-slot="popover-content"]');
   await expect(popover).toBeVisible({ timeout: 5_000 });
 
-  // Click "Worktree" option
-  const worktreeOption = popover.getByText('Worktree', { exact: false });
-  await worktreeOption.click();
+  // Click "Worktree" option (match by role; see the branch test above)
+  await popover.getByRole('radio', { name: /Worktree/ }).click();
 
   // Confirm worktree selection
   const confirmBtn = page.locator('[data-testid="git-mode-confirm-worktree"]');
+  await expect(confirmBtn).toBeVisible();
+  // Regression guard: same focus-steal dismissal as the branch test — the
+  // confirm button flashed visible, then the popover closed before it could
+  // be clicked. Assert the popover survives the click.
+  await page.waitForTimeout(300);
+  await expect(popover).toBeVisible();
   await expect(confirmBtn).toBeVisible();
   await confirmBtn.click();
 
@@ -209,8 +221,8 @@ test('git mode chip clear button resets to current branch', async ({
   const popover = page.locator('[data-slot="popover-content"]');
   await expect(popover).toBeVisible({ timeout: 5_000 });
 
-  // Select branch mode
-  await popover.getByText('New branch', { exact: false }).click();
+  // Select branch mode (match by role; see the first branch test)
+  await popover.getByRole('radio', { name: /New branch/ }).click();
   const branchInput = page.locator('[data-testid="git-mode-branch-input"]');
   await branchInput.fill('feat/temp');
   await page.locator('[data-testid="git-mode-confirm-branch"]').click();


### PR DESCRIPTION
## What this PR does

On the new-conversation screen, clicking the "New branch" or "Worktree" option in the git mode popover dismissed the popover instead of revealing the branch-name input or the worktree confirm button, so the git mode could never be switched away from the current branch. This makes those option clicks keep the popover open so the follow-up UI shows and the selection can be confirmed.

## Why it's needed

The git mode popover renders its content through a portal, but an option click still bubbles through the React tree up to the composer surface, whose click handler moves focus into the editor. That focus jump lands outside the popover and trips Radix's focus-outside dismissal, closing the popover about 100ms after the option's own UI flashes visible — so the branch input / confirm button appears for an instant and then vanishes, and the chip stays on the current branch. The popover already guarded the pointer-outside path (`onInteractOutside`) but not this focus-outside path. The other composer toolbar popovers already avoid this by stopping click propagation; this applies the same treatment to the git mode popover.

## Reviewer Test Plan

### How to verify

Run the web shell against a daemon bound to a trusted git workspace and open the new-conversation screen. Click the branch chip in the composer toolbar to open the git mode popover. Click "New branch": the branch-name input should appear and stay open (previously the popover closed); type a name and confirm, and the chip switches to the new branch. Click "Worktree": the "Create worktree" confirm button should appear and stay open; confirm, and the chip switches to worktree mode. "Current branch" and clicking outside still dismiss the popover as before.

E2E: `cd packages/web-shell && npx playwright test --config playwright.config.ts web-shell.git-mode.spec.ts --project=chromium` — 5 pass. The branch/worktree tests now wait 300ms and assert the popover is still open; with the fix reverted they fail at that assertion (verified both directions).

### Evidence (Before & After)

Before: clicking "New branch" / "Worktree" flashes the input / confirm for ~100ms, then the popover closes and the chip stays on the current branch. After: the input / confirm stays visible and the selection can be confirmed, switching the chip to the new branch / worktree mode.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`npm run dev` and `qwen serve` against a local daemon with a trusted git workspace; Playwright e2e (chromium).

## Risk & Scope

- Main risk or tradeoff: clicks inside the git mode popover no longer bubble to the composer surface, so they no longer trigger that surface's focus-the-editor / close-other-dropdowns side effects. This matches the existing toolbar popover behavior; genuine outside-click and Escape dismissal are unaffected because they rely on native document listeners, not React click bubbling.
- Not validated / out of scope: Windows/Linux local runs (left to CI).
- Breaking changes / migration notes: none.

## Linked Issues

Reported directly by a maintainer; no tracking issue.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在新建对话页面，点击 git 模式弹层里的“新建分支”或“Worktree 隔离”选项时，弹层会直接关闭，而不是展开分支名输入框或 Worktree 确认按钮，导致 git 模式永远无法从当前分支切换出去。本 PR 让这些选项的点击保持弹层打开，从而显示后续 UI 并完成确认。

## 为什么需要

git 模式弹层的内容通过 portal 渲染，但选项的点击仍会沿 React 树冒泡到 composer 表面容器，而该容器的点击处理会把焦点移回编辑器。这次焦点跳转落到弹层之外，触发了 Radix 的 focus-outside 关闭逻辑——大约在选项自身 UI 闪现 100ms 后弹层就被关闭，于是分支输入框/确认按钮只出现一瞬间就消失，chip 仍停在当前分支。该弹层原本只防了 pointer-outside 路径（`onInteractOutside`），没防这条 focus-outside 路径。composer 里其它工具栏弹层早已通过阻止点击冒泡规避了这个问题；本 PR 对 git 模式弹层做同样处理。

## 评审测试计划

### 如何验证

把 web shell 连接到一个绑定了可信 git 仓库的 daemon，打开新建对话页面。点击 composer 工具栏里的分支 chip 打开 git 模式弹层。点“新建分支”：分支名输入框应出现并保持打开（此前弹层会关闭）；输入名称并确认，chip 切换到新分支。点“Worktree 隔离”：“创建 Worktree”确认按钮应出现并保持打开；确认后 chip 切换到 worktree 模式。“当前分支”以及点击外部仍像以前一样关闭弹层。

E2E：`cd packages/web-shell && npx playwright test --config playwright.config.ts web-shell.git-mode.spec.ts --project=chromium` —— 5 个通过。branch/worktree 用例现在会等待 300ms 并断言弹层仍然打开；撤掉修复后会在该断言处失败（已双向验证）。

### 证据（修改前后）

修改前：点击“新建分支”/“Worktree 隔离”会让输入框/确认按钮闪现约 100ms，随后弹层关闭，chip 停在当前分支。修改后：输入框/确认按钮保持可见，可以完成确认，chip 切换到新分支 / worktree 模式。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 运行环境（可选）

`npm run dev` 和 `qwen serve`，连接带可信 git 仓库的本地 daemon；Playwright e2e（chromium）。

## 风险与范围

- 主要风险或取舍：git 模式弹层内部的点击不再冒泡到 composer 表面容器，因此不再触发该容器“聚焦编辑器/关闭其它下拉”的副作用。这与现有工具栏弹层的行为一致；真正的外部点击和 Escape 关闭不受影响，因为它们依赖原生 document 监听器，而非 React 点击冒泡。
- 未验证 / 范围之外：Windows/Linux 本地运行（交给 CI）。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

由 maintainer 直接反馈，无对应 issue。

</details>
