### PR TITLE
test(web-shell): capture the git-mode new-branch sub-state in the visuals suite

### DIFF
--- a/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
+++ b/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
@@ -423,16 +423,31 @@ for (const theme of THEMES) {
       // Open: the three-mode popover (current / new branch / worktree). Assert
       // an option is visible (not just the chip's aria-label) so a regression
       // that fails to open the popover fails here, not only in the visually
-      // reviewed screenshot. The branch-name sub-state is intentionally not
-      // captured: its input autoFocuses, and the popover then dismisses on the
-      // idle frame captureScreenshot waits for — so it can't be shot stably
-      // through this pipeline (the functional web-shell.git-mode.spec.ts drives
-      // that path). The chip + open popover already show the new UI head-only.
+      // reviewed screenshot.
       await chip.click();
       await expect(
         page.getByText('Current branch', { exact: true }),
       ).toBeVisible();
       await captureScreenshot(page, `git-mode-popover-${theme}`);
+
+      // New-branch mode: reveals the branch-name input (validated ✓) and the
+      // Create-branch affordance. Selecting an option once dismissed the popover
+      // — the click bubbled through the React tree (portaled content) to the
+      // composer surface's onClick → core.focus() → Radix focus-outside close —
+      // until #7668 stopped that propagation on PopoverContent. So this capture
+      // both shows the sub-state the previous revision couldn't and stands as a
+      // visual regression guard: if that dismissal ever returns, the input goes
+      // missing and this assertion fails here, not just in the screenshot.
+      // Match the option by role — its label is split across a name + a
+      // description span, so getByText('New branch') is ambiguous (#7668).
+      await page.getByRole('radio', { name: /New branch/ }).click();
+      const branchInput = page.locator('[data-testid="git-mode-branch-input"]');
+      await expect(branchInput).toBeVisible();
+      await branchInput.fill('feat/my-feature');
+      await expect(
+        page.locator('[data-testid="git-mode-confirm-branch"]'),
+      ).toBeVisible();
+      await captureScreenshot(page, `git-mode-branch-${theme}`);
     });
 
     test(`slash menu`, async ({ page }, testInfo) => {

--- a/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
+++ b/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
@@ -430,12 +430,20 @@ for (const theme of THEMES) {
       ).toBeVisible();
       await captureScreenshot(page, `git-mode-popover-${theme}`);
 
-      // #7668 keeps this sub-state open; its input is the visual regression guard.
-      // Match by role — the label spans multiple elements, so getByText is ambiguous.
-      await page.getByRole('radio', { name: /New branch/ }).click();
+      // #7668 keeps this sub-state open. Match the option by role — its label
+      // spans a name + description span, so getByText is ambiguous.
+      const popover = page.locator('[data-slot="popover-content"]');
+      await popover.getByRole('radio', { name: /New branch/ }).click();
       const branchInput = page.locator('[data-testid="git-mode-branch-input"]');
       await expect(branchInput).toBeVisible();
       await branchInput.fill('feat/my-feature');
+      // Regression guard for #7668: the input flashes visible on click, but the
+      // pre-fix dismissal landed ~100ms later, so an immediate assertion still
+      // passed. Settle past that window and re-assert, so a re-dismissal hard-fails
+      // here — mirroring the functional web-shell.git-mode.spec.ts.
+      await page.waitForTimeout(300);
+      await expect(popover).toBeVisible();
+      await expect(branchInput).toBeVisible();
       await expect(
         page.locator('[data-testid="git-mode-confirm-branch"]'),
       ).toBeEnabled();

--- a/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
+++ b/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
@@ -430,23 +430,15 @@ for (const theme of THEMES) {
       ).toBeVisible();
       await captureScreenshot(page, `git-mode-popover-${theme}`);
 
-      // New-branch mode: reveals the branch-name input (validated ✓) and the
-      // Create-branch affordance. Selecting an option once dismissed the popover
-      // — the click bubbled through the React tree (portaled content) to the
-      // composer surface's onClick → core.focus() → Radix focus-outside close —
-      // until #7668 stopped that propagation on PopoverContent. So this capture
-      // both shows the sub-state the previous revision couldn't and stands as a
-      // visual regression guard: if that dismissal ever returns, the input goes
-      // missing and this assertion fails here, not just in the screenshot.
-      // Match the option by role — its label is split across a name + a
-      // description span, so getByText('New branch') is ambiguous (#7668).
+      // #7668 keeps this sub-state open; its input is the visual regression guard.
+      // Match by role — the label spans multiple elements, so getByText is ambiguous.
       await page.getByRole('radio', { name: /New branch/ }).click();
       const branchInput = page.locator('[data-testid="git-mode-branch-input"]');
       await expect(branchInput).toBeVisible();
       await branchInput.fill('feat/my-feature');
       await expect(
         page.locator('[data-testid="git-mode-confirm-branch"]'),
-      ).toBeVisible();
+      ).toBeEnabled();
       await captureScreenshot(page, `git-mode-branch-${theme}`);
     });
 


### PR DESCRIPTION
## What this PR does

Extends the `git mode selector` visuals scenario to capture the **new-branch sub-state** of the git-mode popover — the branch-name input (validated) plus the Create-branch affordance — in both themes. The scenario already captured the composer chip and the opened three-mode popover; this adds the state a reviewer actually looks at when judging the branch-creation UI.

## Why it's needed

Selecting an option in the popover used to dismiss it ~100ms later: the click bubbled through the **React component tree** (synthetic events don't follow the DOM tree, so the portaled popover content still reached the composer surface's `onClick`) → `core.focus()` → Radix focus-outside close. So the branch-name sub-state flashed and vanished, and couldn't be shot stably through the capture pipeline — it was deliberately left out when the scenario landed (#7471).

**#7668 fixed that dismissal** (`onClick={(e) => e.stopPropagation()}` on `PopoverContent`), so the sub-state is now stable and capturable. This PR captures it. Neatly, the state that demonstrates #7668's fix is exactly the one #7668 made shootable — so beyond filling the coverage gap, this capture doubles as a **visual regression guard**: if the popover ever dismisses on option-click again, the branch input goes missing and the assertion fails here, not only in the (eyeballed) screenshot.

The option is matched by role (`getByRole('radio', { name: /New branch/ })`) rather than text — its label is split across a name and a description span, so `getByText('New branch')` is ambiguous (also fixed in #7668).

## Reviewer Test Plan

### How to verify

```
cd packages/web-shell
npx playwright test --config playwright.visuals.config.ts -g "git mode selector" --project=chromium
# 2 passed → git-mode-{chip,popover,branch}-{dark,light}.png
```

Determinism (the point — proving the once-flaky branch state is now stable): render twice and pixel-diff. All six captures are `0.0000%` (`|ΔR|+|ΔG|+|ΔB| > 30` per pixel, over the full frame). Full visuals suite stays green (`26 passed`), and prettier/eslint/scoped-tsc are clean.

To confirm the capture is load-bearing on #7668's fix, revert only the `stopPropagation` line in `GitModePopover.tsx` and re-run this scenario: the popover dismisses after the New-branch click, `expect(branchInput).toBeVisible()` fails, and the `git-mode-branch-*` capture never happens.

### Evidence (Before & After)

The new capture — the popover stays open, "New branch" is selected (✓), the branch input holds a validated `feat/my-feature`, and the `$ git checkout -b …` preview + **Create branch** button are shown:

`git-mode-branch-dark.png` / `git-mode-branch-light.png` (head-only NEW in the preview bot).

Before this PR: no capture of this state at all — the scenario stopped at the opened popover.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Playwright against the visuals mock daemon (Vite dev server, Chromium). No real backend. Determinism measured with a canvas pixel-diff matching the visuals bot's own metric.

## Risk & Scope

- **Main risk or tradeoff:** none functional — a test-only addition. The one dependency is #7668 already being on `main` (it is): without its `stopPropagation` fix this capture would be flaky. That's intentional — the capture guards exactly that fix.
- **Not validated / out of scope:** the worktree and clear sub-states are not captured (the branch input is the representative option sub-state; worktree/clear are covered by the functional `web-shell.git-mode.spec.ts`).
- **Breaking changes / migration notes:** none.

## Linked Issues

Follow-up to #7471 (added the scenario) and #7668 (fixed the dismissal that made this sub-state capturable).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

扩展 `git mode selector` 视觉场景,补拍 git-mode popover 的**新建分支子态**——branch 输入框(已校验)+ Create-branch 按钮,双主题。场景原本只拍了 composer chip 和打开态的三模式 popover;这一步补上了 reviewer 真正会看的那个"创建分支 UI"的状态。

## 为什么需要

在 popover 里点选项以前会在 ~100ms 后把它关掉:点击沿 **React 组件树**冒泡(合成事件不走 DOM 树,所以 portal 出去的 popover 内容仍冒泡到 composer 表面的 `onClick`)→ `core.focus()` → 触发 Radix 的 focus-outside 关闭。于是 branch 输入子态一闪即逝,在截图管线里拍不稳,场景落地时(#7471)就故意没拍它。

**#7668 修好了这个关闭**(给 `PopoverContent` 加 `onClick={(e) => e.stopPropagation()}`),这个子态现在稳定可拍,本 PR 就把它拍下来。巧妙之处:能展示 #7668 修复的那个状态,恰恰是 #7668 让它可拍的——所以除了补齐覆盖缺口,这个捕获还兼作**视觉回归守卫**:以后谁再让 popover 在点选项时关闭,branch 输入就会消失、断言在这里就挂,而不是只体现在(需人眼看的)截图里。

选项用 role 定位(`getByRole('radio', { name: /New branch/ })`)而非文字——它的 label 分在 name span 和 description span 两处,`getByText('New branch')` 有歧义(这点 #7668 也修了)。

## 如何验证

见上文英文命令。确定性(重点——证明曾经不稳的 branch 态现在稳了):双跑像素比对,6 张全部 `0.0000%`。全套件保持 `26 passed`,prettier/eslint/tsc 干净。想确认这个捕获对 #7668 的修复是承重的:只回退 `GitModePopover.tsx` 里那行 `stopPropagation` 再跑本场景,popover 在点 New branch 后关闭,`expect(branchInput).toBeVisible()` 失败,`git-mode-branch-*` 根本拍不出来。

## 风险与范围

- **主要取舍:** 无功能风险——纯测试新增。唯一依赖是 #7668 已在 `main`(已在):没有它的 `stopPropagation` 修复,这个捕获会 flaky。这是有意的——捕获守的正是那个修复。
- **不在范围内:** worktree 和 clear 子态未拍(branch 输入作为选项子态的代表;worktree/clear 由功能测试 `web-shell.git-mode.spec.ts` 覆盖)。
- **破坏性改动:** 无。

</details>
