### PR TITLE
fix(core): give plugins from the same repository distinct extension ids

### DIFF
--- a/packages/core/src/extension/extension-store.test.ts
+++ b/packages/core/src/extension/extension-store.test.ts
@@ -102,6 +102,62 @@ describe('ExtensionStore', () => {
     ).toMatchObject({ effective: 'enabled', source: 'workspace_override' });
   });
 
+  it('re-keys a policy to a new id for the same name after an id-formula change', async () => {
+    const store = makeStore();
+    const oldId = 'a'.repeat(64);
+    const newId = 'b'.repeat(64);
+    await store.ensureInitialized([{ id: oldId, name: 'dotnet' }]);
+    await store.setDefaultActivation({ id: oldId, name: 'dotnet' }, 'disabled');
+    await store.setWorkspaceActivation(
+      { id: oldId, name: 'dotnet' },
+      '/workspace/a',
+      'enabled',
+    );
+
+    const snapshot = await store.ensureInitialized([
+      { id: newId, name: 'dotnet' },
+    ]);
+
+    expect(snapshot.extensions[oldId]).toBeUndefined();
+    expect(snapshot.extensions[newId]).toMatchObject({
+      name: 'dotnet',
+      defaultActivation: 'disabled',
+      workspaceOverrides: { '/workspace/a': 'enabled' },
+    });
+  });
+
+  it('re-keys only the orphaned policy when a sibling plugin installs fresh', async () => {
+    const store = makeStore();
+    const repoOnlyId = 'a'.repeat(64);
+    const dotnetId = 'b'.repeat(64);
+    const dotnetTestId = 'c'.repeat(64);
+    await store.ensureInitialized([{ id: repoOnlyId, name: 'dotnet' }]);
+
+    const snapshot = await store.ensureInitialized([
+      { id: dotnetId, name: 'dotnet' },
+      { id: dotnetTestId, name: 'dotnet-test' },
+    ]);
+
+    expect(snapshot.extensions[repoOnlyId]).toBeUndefined();
+    expect(snapshot.extensions[dotnetId]?.name).toBe('dotnet');
+    expect(snapshot.extensions[dotnetTestId]?.name).toBe('dotnet-test');
+  });
+
+  it('does not re-key a policy still owned by another loaded extension', async () => {
+    const store = makeStore();
+    const demoId = 'a'.repeat(64);
+    const otherId = 'b'.repeat(64);
+    await store.ensureInitialized([{ id: demoId, name: 'demo' }]);
+
+    const snapshot = await store.ensureInitialized([
+      { id: demoId, name: 'demo' },
+      { id: otherId, name: 'other' },
+    ]);
+
+    expect(snapshot.extensions[demoId]?.name).toBe('demo');
+    expect(snapshot.extensions[otherId]?.name).toBe('other');
+  });
+
   it('uses an inherit mask when clearing an override matched by a legacy rule', async () => {
     await fsp.writeFile(
       enablementPath,

--- a/packages/core/src/extension/extension-store.test.ts
+++ b/packages/core/src/extension/extension-store.test.ts
@@ -126,6 +126,24 @@ describe('ExtensionStore', () => {
     });
   });
 
+  it('re-keys across a case mismatch and normalizes the stored name', async () => {
+    const store = makeStore();
+    const oldId = 'a'.repeat(64);
+    const newId = 'b'.repeat(64);
+    await store.ensureInitialized([{ id: oldId, name: 'DotNet' }]);
+    await store.setDefaultActivation({ id: oldId, name: 'DotNet' }, 'disabled');
+
+    const snapshot = await store.ensureInitialized([
+      { id: newId, name: 'dotnet' },
+    ]);
+
+    expect(snapshot.extensions[oldId]).toBeUndefined();
+    expect(snapshot.extensions[newId]).toMatchObject({
+      name: 'dotnet',
+      defaultActivation: 'disabled',
+    });
+  });
+
   it('re-keys only the orphaned policy when a sibling plugin installs fresh', async () => {
     const store = makeStore();
     const repoOnlyId = 'a'.repeat(64);

--- a/packages/core/src/extension/extension-store.ts
+++ b/packages/core/src/extension/extension-store.ts
@@ -273,6 +273,32 @@ export class ExtensionStore {
     const legacy = await this.readLegacyProjection();
     if (existing) {
       let changed = false;
+      // An id-formula change (e.g. #7568 added the plugin name to the hash)
+      // leaves installed extensions pointing at ids the store has never
+      // seen. Without this re-key, the blocks below would mint a fresh
+      // default policy under the new id — resetting activation state — and
+      // strand the old policy as an orphan that later trips the
+      // name-conflict guard on update/uninstall. Names are unique in the
+      // store (enforced case-insensitively on every commit), so a loaded
+      // identity whose id is unknown safely claims the policy stored under
+      // its name, provided no loaded extension still owns that entry.
+      const loadedIds = new Set(extensions.map((identity) => identity.id));
+      for (const identity of extensions) {
+        assertIdentity(identity);
+        if (existing.extensions[identity.id]) continue;
+        const staleEntry = Object.entries(existing.extensions).find(
+          ([id, policy]) =>
+            !loadedIds.has(id) &&
+            policy.name.toLowerCase() === identity.name.toLowerCase(),
+        );
+        if (staleEntry) {
+          const [staleId, policy] = staleEntry;
+          delete existing.extensions[staleId];
+          policy.name = identity.name;
+          existing.extensions[identity.id] = policy;
+          changed = true;
+        }
+      }
       if (existing.legacyProjectionHash !== projectionHash(legacy)) {
         if (!(await this.legacyProjectionIsNewerThanState())) {
           try {

--- a/packages/core/src/extension/extensionManager.test.ts
+++ b/packages/core/src/extension/extensionManager.test.ts
@@ -2780,6 +2780,41 @@ describe('extension tests', () => {
           hashValue('https://gitlab.company.com/team/extension-repo'),
         );
       });
+
+      it('gives plugins from the same repository distinct ids (#7568)', () => {
+        const metadataFor = (pluginName: string) => ({
+          type: 'git' as const,
+          source: 'https://github.com/dotnet/skills',
+          pluginName,
+        });
+        const dotnetId = getExtensionId(
+          { name: 'dotnet', version: '1.0.0' },
+          metadataFor('dotnet'),
+        );
+        const dotnetTestId = getExtensionId(
+          { name: 'dotnet-test', version: '1.0.0' },
+          metadataFor('dotnet-test'),
+        );
+
+        expect(dotnetId).toBe(
+          hashValue('https://github.com/dotnet/skills:dotnet'),
+        );
+        expect(dotnetTestId).toBe(
+          hashValue('https://github.com/dotnet/skills:dotnet-test'),
+        );
+        expect(dotnetId).not.toBe(dotnetTestId);
+      });
+
+      it('keeps the repo-only id when no plugin name is recorded', () => {
+        const config: ExtensionConfig = { name: 'solo-ext', version: '1.0.0' };
+        const metadata = {
+          type: 'git' as const,
+          source: 'https://github.com/owner/solo',
+        };
+        expect(getExtensionId(config, metadata)).toBe(
+          hashValue('https://github.com/owner/solo'),
+        );
+      });
     });
   });
 

--- a/packages/core/src/extension/extensionManager.ts
+++ b/packages/core/src/extension/extensionManager.ts
@@ -2624,6 +2624,14 @@ export function getExtensionId(
   } else {
     idValue = installMetadata?.source ?? config.name;
   }
+  // A marketplace repo can host several plugins; hashing only the repo URL
+  // collapses them into one id and the second install trips the store's
+  // id-ownership check (#7568). Suffix the plugin name so each plugin from
+  // the same source gets its own id. Installs recorded under the old
+  // repo-only id are re-keyed by ExtensionStore.ensureInitialized.
+  if (installMetadata?.pluginName) {
+    idValue += `:${installMetadata.pluginName}`;
+  }
   return hashValue(idValue);
 }
 


### PR DESCRIPTION
## What this PR does

Makes extensions installed from the same repository get distinct ids: `getExtensionId()` now appends `installMetadata.pluginName` to the hash input when it is present, so `dotnet` and `dotnet-test` from `https://github.com/dotnet/skills` no longer collide. Because an id-formula change would otherwise strand every existing install — on the next load the store would mint a fresh default policy under the new id (silently resetting the user's activation state) and the orphaned old policy would then trip the name-conflict guard on any update or uninstall — `ExtensionStore.ensureInitialized()` gains a re-key step: a loaded identity whose id is unknown to the store claims the policy stored under its unique name, provided no other loaded extension still owns that entry. Activation state, workspace overrides, and artifact generation all move with the policy; the store's existing case-insensitive name-uniqueness guarantee is what makes the name-based claim safe.

## Why it's needed

#7568: installing a second plugin from a multi-plugin marketplace repo fails with `Extension id belongs to "dotnet", not "dotnet-test".` — `getExtensionId()` hashed only the normalized repo URL, so every plugin from one repo produced the same id and the store's id-ownership check rejected the second install. The triage confirmed the root cause and maintainer doudouOUC endorsed exactly this fix shape (append `pluginName` to the hash input), explicitly calling out that a migration path or backward-compatible lookup must accompany the id change for users who already have one plugin installed from such a repo — that is the re-key step above.

## Reviewer Test Plan

### How to verify

1. `/extensions install https://github.com/dotnet/skills` → choose `dotnet`; repeat and choose `dotnet-test`. Before this PR the second install fails with the id-ownership error; after, both install and coexist.
2. Upgrade path: with a plugin installed by a pre-fix build (policy keyed by the repo-only hash, e.g. globally disabled), run any command on this branch — the policy is re-keyed to the new id with activation state intact, and update/uninstall work.
3. `npx vitest run src/extension/` in `packages/core` (573/573).

### Evidence (Before & After)

E2E drives the compiled `getExtensionId` + real `ExtensionStore` (temp dirs on disk, real install/uninstall commits), before/after via `git stash` + rebuild:

![before/after E2E + tests](https://raw.githubusercontent.com/zjunothing/qwen-code/pr-assets-7568/verify-7568.png)

| check | unpatched (origin/main) | patched |
| --- | --- | --- |
| ids differ for two plugins of one repo | ❌ (identical hash) | ✅ |
| second plugin install commit | ❌ `Extension id belongs to "dotnet", not "dotnet-test".` | ✅ |
| store holds both plugins side by side | ❌ | ✅ |
| legacy repo-only-id policy re-keys on load; activation state (disabled) survives; uninstall under new id works | ❌ (no re-key) | ✅ |
| new unit tests (distinct ids, re-key, orphan-only re-key, no-theft guard) | 3 of 4 fail | ✅ 4/4 |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS (Darwin 24.6), Node v22.23.1; vitest. `npm run typecheck`, `eslint --max-warnings 0`, `prettier --check` all clean.

## Risk & Scope

- Main risk or tradeoff: the re-key matches by extension name when the id is unknown. Names are already enforced unique (case-insensitively) on every store commit, and the claim is further restricted to entries no loaded extension owns, so a wrong-target re-key would require two different extensions sharing a name — a state the store itself rejects. Local/link installs without `pluginName` are byte-for-byte unaffected.
- Not validated / out of scope: the `<repo>:<pluginName>` install-source shorthand parsing (`marketplace.ts`) is untouched; Claude-marketplace conversions keep their own plugin hashing (`claude-converter.ts`).
- Breaking changes / migration notes: extension ids for plugin installs change formula, but the store self-heals on first load — no user action needed.

## Linked Issues

Fixes #7568

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让同一仓库安装的多个扩展获得不同 id：`getExtensionId()` 在 `installMetadata.pluginName` 存在时把它追加进哈希输入，`dotnet` 与 `dotnet-test` 不再碰撞。由于 id 公式变更会孤立所有既有安装——下次加载时 store 会在新 id 下铸造全新默认 policy（静默重置用户的启用状态），而旧 policy 变成孤儿、在 update/uninstall 时触发名字冲突守卫——`ExtensionStore.ensureInitialized()` 新增重挂步骤：store 不认识其 id 的已加载 identity，可认领以其唯一名字存储的 policy（前提是没有其它已加载扩展仍持有该条目）。启用状态、workspace 覆盖、artifact generation 随 policy 一起迁移；store 既有的大小写不敏感名字唯一性保证了按名认领的安全性。

## 为什么需要

#7568：从多插件市场仓库安装第二个插件时报 `Extension id belongs to "dotnet", not "dotnet-test".`——`getExtensionId()` 只哈希规范化仓库 URL，同仓库所有插件产生相同 id，store 的 id 归属检查拒绝第二次安装。triage 已确认根因，维护者 doudouOUC 背书了正是本 PR 的修复形状（哈希输入追加 `pluginName`），并明确指出 id 变更必须配迁移路径或向后兼容查找——即上述重挂步骤。

## 审阅测试计划

### 如何验证

1. `/extensions install https://github.com/dotnet/skills` 选 `dotnet`，再来一次选 `dotnet-test`：本 PR 之前第二次安装报 id 归属错误；之后两者共存。
2. 升级路径：旧版本安装的插件（policy 键为仓库哈希，如全局禁用），在本分支运行任意命令——policy 重挂到新 id、启用状态保留、update/uninstall 正常。
3. `packages/core` 下 `npx vitest run src/extension/`（573/573）。

### 证据（Before & After）

E2E 驱动编译产物 `getExtensionId` + 真实 `ExtensionStore`（磁盘临时目录、真实 install/uninstall 提交），`git stash` + 重建对照：未修复时两插件同 id、第二次安装报 issue 原始错误、无重挂；修复后全部通过。4 条新单测中 3 条在未修复源码上失败。

### 测试平台

macOS 已本地验证（✅）；Windows / Linux 依赖 CI（⚠️）。

### 环境

macOS（Darwin 24.6）、Node v22.23.1；vitest；typecheck / eslint / prettier 全绿。

## 风险与范围

- 主要风险/权衡：重挂在 id 未知时按扩展名匹配。名字在每次 store 提交时已强制唯一（大小写不敏感），且认领仅限没有任何已加载扩展持有的条目，错误重挂需要两个不同扩展同名——store 本身拒绝这种状态。无 `pluginName` 的 local/link 安装完全不受影响。
- 未验证/超出范围：`<repo>:<pluginName>` 安装源简写解析（`marketplace.ts`）未改动；Claude marketplace 转换保留自己的插件哈希（`claude-converter.ts`）。
- 破坏性变更/迁移说明：插件安装的扩展 id 公式变更，但 store 首次加载自愈——用户无需任何操作。

## 关联 Issue

Fixes #7568

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
