### PR TITLE
fix(core): allow reading saved plan files without a confirmation prompt

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -2497,6 +2497,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       getSessionService: vi.fn(() => new SessionService('/tmp')),
       hasSessionWriteOwnership: vi.fn().mockReturnValue(false),
       getSessionRuntimeBaseDir: vi.fn().mockReturnValue('/runtime-a'),
+      getPlansDir: vi.fn().mockReturnValue('/home/test/.qwen/plans'),
       setFileSystemService: vi.fn(),
       getHookSystem: vi.fn().mockReturnValue(undefined),
       getDisableAllHooks: vi.fn().mockReturnValue(true),
@@ -2515,6 +2516,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       '/tmp/user-memory',
       '/home/test/.qwen/skills',
       '/tmp/qwen-extensions',
+      '/home/test/.qwen/plans',
       ...(process.platform === 'win32' ? [] : ['/tmp']),
     ];
   }

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -542,6 +542,9 @@ function buildAcpLocalReadRoots(config: Config): string[] {
     getUserAutoMemoryRoot(),
     ...config.storage.getUserSkillsDirs(),
     Storage.getUserExtensionsDir(),
+    // Saved plan files (see ReadFileTool.getDefaultPermission for why the
+    // plans dir must be readable without a confirmation prompt).
+    config.getPlansDir(),
     ...defaultAcpOnlyLocalReadRoots(),
     ...parseAcpLocalReadRootsEnv(),
   ];

--- a/packages/core/src/tools/read-file.test.ts
+++ b/packages/core/src/tools/read-file.test.ts
@@ -104,6 +104,7 @@ describe('ReadFileTool', () => {
         getProjectDir: () => path.join(tempRootDir, '.project'),
         getUserSkillsDirs: () => [path.join(os.homedir(), '.qwen', 'skills')],
       },
+      getPlansDir: () => path.join(os.homedir(), '.qwen', 'plans'),
       getTruncateToolOutputThreshold: () => 2500,
       getTruncateToolOutputLines: () => 500,
       getContentGeneratorConfig: () => ({
@@ -322,6 +323,24 @@ describe('ReadFileTool', () => {
       const invocation = tool.build(params);
       const permission = await invocation.getDefaultPermission();
       expect(permission).toBe('allow');
+    });
+
+    it('should return allow for saved plan files under the plans directory', async () => {
+      const params: ReadFileToolParams = {
+        file_path: path.join(os.homedir(), '.qwen', 'plans', 'session-1.md'),
+      };
+      const invocation = tool.build(params);
+      const permission = await invocation.getDefaultPermission();
+      expect(permission).toBe('allow');
+    });
+
+    it('should still return ask for ~/.qwen files outside the plans directory', async () => {
+      const params: ReadFileToolParams = {
+        file_path: path.join(os.homedir(), '.qwen', 'settings.json'),
+      };
+      const invocation = tool.build(params);
+      const permission = await invocation.getDefaultPermission();
+      expect(permission).toBe('ask');
     });
 
     it('should return ask for paths directly under the OS temp directory', async () => {

--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -135,6 +135,12 @@ class ReadFileToolInvocation extends BaseToolInvocation<
       Storage.getGlobalTempDir(),
       ...this.config.storage.getUserSkillsDirs(),
       Storage.getUserExtensionsDir(),
+      // Approved plans are persisted here (default ~/.qwen/plans, outside
+      // the workspace) and after approval nothing re-injects the plan text,
+      // so the saved file is the model's only recovery route — reading it
+      // back must not stall on a confirmation prompt. The dir holds only
+      // session plan files, never credentials or settings.
+      this.config.getPlansDir(),
     ];
 
     if (


### PR DESCRIPTION
## What this PR does

Adds the plans directory (`config.getPlansDir()`, default `~/.qwen/plans`) to the two mirrored permission-free read-root lists: `ReadFileTool.getDefaultPermission()`'s `allowedRoots` and `AcpAgent.buildAcpLocalReadRoots()` (per the SYNC comment binding the two). Reading a saved plan file no longer lands on an `ask` confirmation; everything else under `~/.qwen` (settings.json, credentials) stays confirmation-gated, pinned by a new test.

## Why it's needed

This is finding #3 from the #7197 review ([review comment](https://github.com/QwenLM/qwen-code/pull/7197#issuecomment-5062089806)), which asked for exactly this change and noted it "should land before this trade is considered complete": the approved-plan pointer replaces the in-history plan text with a reference to the saved file, but the default plans dir sits outside the workspace and in none of `ReadFileTool`'s permission-free roots — so the pointer's own instruction ("read that file if you need to consult it again") stalls on an `ask` prompt, popped at exactly the moment the user just approved the plan and told the agent to start coding; in non-interactive/ACP flows an `ask` can resolve to a denial. Since nothing re-injects the plan after approval, the saved file is the model's only recovery route for the plan text. The change is independently safe to land: plan files are already written today by `savePlan` at approval, and reading them back should never have required a prompt.

## Reviewer Test Plan

### How to verify

1. In a session with an approved plan (plan file saved under `~/.qwen/plans`), have the model `read_file` that path. Before: an ask confirmation pops (or the read is denied in ACP). After: the read proceeds directly. Reading `~/.qwen/settings.json` still prompts.
2. `npx vitest run src/tools/read-file.test.ts` (packages/core, 87/87) and `npx vitest run src/acp-integration/acpAgent.test.ts` (packages/cli, 317/317).

### Evidence (Before & After)

E2E drives the compiled `Config` + `ReadFileTool` with a real plan file written to `config.getPlanFilePath()` under a temp `QWEN_HOME`, before/after via `git stash` + rebuild:

![before/after E2E + tests](https://raw.githubusercontent.com/zjunothing/qwen-code/pr-assets-plansdir/verify-plansdir.png)

| check | unpatched (origin/main) | patched |
| --- | --- | --- |
| saved plan file permission | ❌ `ask` | ✅ `allow` |
| `~/.qwen/settings.json` stays gated (`ask`) | ✅ | ✅ (unchanged, now pinned) |
| workspace file stays `allow` | ✅ | ✅ (unchanged) |
| new unit test: allow for plan files | ❌ | ✅ |
| ACP fallback read roots include the plans dir (3 existing tests re-pinned) | ❌ | ✅ |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS (Darwin 24.6), Node v22.23.1; vitest. `npm run typecheck`, `eslint --max-warnings 0`, `prettier --check` all clean.

## Risk & Scope

- Main risk or tradeoff: this widens the permission-free read surface by one directory. The plans dir contains only session plan files the user has already seen and approved (filenames are sanitized session ids); when `plansDirectory` is configured it must resolve within the project root (already workspace-readable), so the widening is effectively the default `~/.qwen/plans` only. The new settings.json test pins that no sibling `~/.qwen` path is exposed.
- Not validated / out of scope: no change to write permissions or to the plan pointer text itself (#7197); the remaining #7197 review follow-ups (test pins, import cycle) are separate.
- Breaking changes / migration notes: none.

## Linked Issues

Refs #6237 (follow-up to the #7197 review, finding #3)

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

把 plans 目录（`config.getPlansDir()`，默认 `~/.qwen/plans`）加入两处互为镜像的免确认读根列表：`ReadFileTool.getDefaultPermission()` 的 `allowedRoots` 与 `AcpAgent.buildAcpLocalReadRoots()`（两处由 SYNC 注释绑定）。读取已保存的 plan 文件不再弹 `ask` 确认；`~/.qwen` 下的其它文件（settings.json、凭据）仍保持确认门控，并由新测试钉住。

## 为什么需要

这是 #7197 review 的 finding #3（review 明确要求本改动并指出"应在认定该取舍完成之前落地"）：approved-plan pointer 把历史中的 plan 原文换成对已保存文件的引用，但默认 plans 目录在工作区之外、也不在任何免确认读根里——pointer 自带的"需要时可重读该文件"指令会撞上 `ask` 确认框，恰好出现在用户刚批准 plan、让 agent 开始写码的时刻；非交互/ACP 流程中 `ask` 还可能解析为拒绝。批准后没有任何机制重新注入 plan，已保存文件是模型找回 plan 文本的唯一途径。本改动可独立安全落地：plan 文件今天就由批准时的 `savePlan` 写入，读回它本不该需要确认。

## 审阅测试计划

### 如何验证

1. 在有已批准 plan 的会话中让模型 `read_file` 该路径：之前弹确认（ACP 下可能被拒）；之后直接读取。读 `~/.qwen/settings.json` 仍会弹确认。
2. `packages/core` 下 read-file 87/87；`packages/cli` 下 acpAgent 317/317。

### 证据（Before & After）

E2E 驱动编译产物 `Config` + `ReadFileTool`，在临时 `QWEN_HOME` 下用 `config.getPlanFilePath()` 写真实 plan 文件，`git stash` + 重建对照：未修复时 plan 文件是 `ask`；修复后 `allow`，settings.json 与工作区文件行为不变。新单测在未修复源码上失败；ACP 读根 3 条既有测试重新钉住。

### 测试平台

macOS 已本地验证（✅）；Windows / Linux 依赖 CI（⚠️）。

### 环境

macOS（Darwin 24.6）、Node v22.23.1；vitest；typecheck / eslint / prettier 全绿。

## 风险与范围

- 主要风险/权衡：免确认读面扩大一个目录。plans 目录只含用户已看过并批准的会话 plan 文件（文件名为净化后的会话 id）；配置 `plansDirectory` 时必须解析在项目根内（本就工作区可读），所以实际扩大的只有默认 `~/.qwen/plans`。新增 settings.json 测试钉住不暴露 `~/.qwen` 其它路径。
- 未验证/超出范围：不改写权限、不改 plan pointer 文案（#7197）；#7197 review 其余 follow-up（测试钉、导入环）另行处理。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Refs #6237（#7197 review finding #3 的 follow-up）

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
