### PR TITLE
perf(web-shell): paint the composer git chip before git status completes

### DIFF
--- a/docs/design/2026-07-24-webshell-git-status-fast-path.md
+++ b/docs/design/2026-07-24-webshell-git-status-fast-path.md
@@ -1,0 +1,192 @@
+# Web Shell git chip 快速显示：branch 先行 + status 缓存/推送
+
+日期：2026-07-24
+状态：待确认
+
+## 背景与问题
+
+Web Shell 新建会话时，composer 工具条里的 git chip 出现得慢。根因（已逐行确认）：
+
+1. **daemon 端 branch 被 `git status` 子进程拖住**——`WorkspaceGitState.getStatus()`
+   （`packages/cli/src/serve/workspace-git-state.ts`）里 branch 有毫秒级快路径
+   （`resolveBranchName` 读 `HEAD` 文件 + reflog watcher），但 HTTP 响应必须等
+   `getGitWorkingTreeStatus()` 完成——每次请求同步 spawn
+   `git status --porcelain=v1 --branch -z`（`gitDiff.ts` runGit，5s 超时，零缓存）。
+2. **前端 chip 渲染被全量 status 门控**——新建会话时 chip 文本只认
+   `selectedWorkspaceGitStatus?.branch`（App.tsx 7860–7871），它要等整个
+   HTTP + git status 往返（App.tsx 1480–1520 的 effect）才 setState。
+3. **同一路由并发打两次**——`DaemonSessionProvider` 的 metadata 拉取
+   （`DaemonSessionProvider.tsx:1320`，只用 `.branch`）与 App.tsx 的 git-status
+   effect 几乎同时发 `GET /workspaces/:ws/git`，daemon 端 spawn 两个相同子进程。
+4. 串行门控：`activeWorkspaceCwd` 依赖 `GET /capabilities` 先完成。
+
+## 目标与非目标
+
+目标：
+
+- 新建会话 / 首屏时 git chip 以 branch 文本**立即出现**（一个本地 HTTP RTT，毫秒级），
+  dirty/ahead/behind/stash 等计数器在 daemon 算完即补齐（`wait: true` fresh 请求；
+  有会话时另有 SSE 实时推送）。
+- 消除重复 `git status` 子进程（并发去重 + stale-while-revalidate）。
+- 不回归：侧栏 workspace chip（要计数器）、worktree 会话 chip、detached HEAD、
+  非 git workspace、git 失败降级。
+
+非目标：
+
+- worktree `?cwd=` 路径不引入 watcher/缓存（维持现状：直接计算，避免每 worktree
+  泄漏一个 fs watcher）。worktree chip 延迟不变。
+- 不做 daemon 启动预热（capabilities 后前端立即就会来请求，预热收益小）。
+- 不改 `git_branch_changed` 现有语义。
+
+## 方案总览
+
+三层改动：daemon 缓存 + 后台刷新 + SSE 推送（P0），响应两阶段化（P1），
+前端消费 SSE 并保留慢路径给需要的调用方（P2 重评估后见下文）。
+
+### P0+P1：daemon——`WorkspaceGitState` 缓存、去重、后台刷新、SSE 推送
+
+`WorkspaceGitEntry` 扩展：
+
+```ts
+interface WorkspaceGitEntry {
+  branch: string | undefined; // watcher 保持新鲜（现状）
+  dispose: () => void; // 现状
+  status?: GitWorkingTreeStatus; // 上次计算的原始 working-tree summary
+  statusComputedAt?: number; // epoch ms
+  statusPromise?: Promise<void>; // in-flight 去重
+  disposed?: boolean; // dispose 后禁止 publish
+}
+```
+
+`getStatus(cwd, bridge, opts?: { wait?: boolean })` 语义改为：
+
+- **默认（fast path）**：确保 entry 存在（branch 秒回）；按
+  stale-while-revalidate 踢一次后台刷新（见下）；**立即返回**上次缓存的
+  status（materialize：overlay `entry.branch ?? status.branch`，v2 形状 +
+  `computedAt`）；从未计算过时返回 branch-only `{ v, workspaceCwd, branch }`
+  （无 `computedAt`，前端据此区分"未计算"与"clean"）。
+- **`wait: true`**：等待（或发起并等待，in-flight 复用）一次新鲜计算，
+  返回全量 status。计算失败降级 branch-only（现状语义）。
+
+后台刷新 `refreshStatus(entry)`：
+
+- in-flight 复用：`statusPromise` 存在则直接返回它。
+- 节流：距上次发起 < 2s 则跳过（防 focus 风暴串行排队 git 子进程）。
+- 计算成功且与缓存的 enriched 字段有差异 → 更新缓存 + 通过
+  `bridge.publishWorkspaceEvent({ type: 'git_status_changed', data })` 推送
+  materialized 全量 status（data 即 `DaemonWorkspaceGitStatus`，含 workspaceCwd）。
+  首次计算（缓存为空）视为有差异，必推送——这是冷启动 chip 补齐计数器的通道。
+- 无差异 → 只更新缓存，不推送（避免 30s 轮询每次都引起前端 setState/re-render）。
+- 计算失败/非 git 目录 → 保留旧缓存，不推送。
+- entry 已 disposed → 不推送。
+
+**无 TTL**。last-known + 每次 GET 触发后台刷新 + SSE 纠偏已足够；
+节流 2s 承担" TTL 防爆"职责。`wait: true` 调用方总是拿到新鲜计算（in-flight 复用）。
+
+路由（`packages/cli/src/serve/routes/workspace-git.ts`）：
+
+- `/workspace/git` 与 `/workspaces/:workspace/git` 解析 `?wait=1`，透传给
+  `getStatus`。默认 fast。
+- worktree `?cwd=` 分支维持现状（直接 `getGitWorkingTreeStatus`，不进缓存）。
+
+### SDK（`packages/sdk-typescript`）
+
+- `events.ts`：`DAEMON_KNOWN_EVENT_TYPE_VALUES` 增加 `'git_status_changed'`
+  （紧跟 `'git_branch_changed'`）。旧 SDK 经 `asKnownDaemonEvent` 静默丢弃——
+  向后兼容，无需协议 bump（与 `followup_suggestion` 同模式）。
+- `ui/normalizer.ts`：`case 'git_status_changed': return [];`（与
+  `git_branch_changed` 一样由 session mappers 处理，不进 UI 归一化流）。
+- `DaemonClient.workspaceGit` 签名改为 options 对象：
+  `workspaceGit(opts?: { cwd?: string; wait?: boolean })`，拼 query
+  （`cwd` 与 `wait=1` 可组合）。迁移全部 4 个调用点（App.tsx、WorkspaceSection、
+  DaemonSessionProvider ×2 处）与 SDK 单测。
+
+### webui（`packages/webui`）
+
+- `session/types.ts`：`DaemonConnectionState` 增加
+  `gitStatus?: DaemonWorkspaceGitStatus`（仅当前 workspace 的全量 status，
+  由 SSE 维护）。
+- `session/mappers.ts`：`updateConnectionFromDaemonEvent` 增加
+  `case 'git_status_changed'`——`data.workspaceCwd` 与
+  `current.workspaceCwd` 不匹配则忽略（镜像 `git_branch_changed` 的守卫），
+  否则 `setConnection({ ...current, gitStatus: data })`。
+
+### web-shell（`packages/web-shell`）
+
+- `App.tsx` git-status effect：composer 用**客户端 stale-while-revalidate**——
+  每次触发并发两个请求（worktree 会话除外，见下）：
+  1. `workspaceGit({ cwd: sessionWorktree?.path })`（fast）：last-known 秒回，
+     立即渲染（冷缓存 branch-only）；
+  2. `workspaceGit({ wait: true })`（fresh）：daemon 后台算完即返回全量 status，
+     补齐计数器。两个请求在 daemon 端共享同一次计算（in-flight 去重），
+     不增加 git 子进程数。
+- **为什么 fresh 请求必须存在（反向审计发现）**：SSE `git_status_changed` 走
+  每会话事件流（`GET /session/:id/events`），**新建会话态（deferred connect，
+  无 sessionId）没有 SSE 订阅**——只发 fast GET 时计数器要等 30s 轮询或
+  focus 才补上。fresh 请求不依赖会话存在，保证"branch 立即、计数器算完即得"
+  在所有会话态成立。（`git_branch_changed` 今天就有同样的无会话盲区，非回归。）
+- `App.tsx` 另保留 SSE 同步 effect：`connection.gitStatus` 变化且
+  `workspaceCwd` 匹配、无 `sessionWorktree` 时写入 `selectedWorkspaceGitStatus`——
+  覆盖**有会话时**两次轮询之间的实时推送（另一客户端/CLI 触发的后台刷新
+  推送过来）。
+- worktree 会话只发 fast 请求：`?cwd=` 路径本就绕过缓存直接计算
+  （fast 与 wait 等价），行为不变。
+- `sidebar/WorkspaceSection.tsx`：`workspaceGit({ wait: true })`——侧栏 chip
+  要计数器且没有 SSE/fresh 双发通道，保留阻塞语义（现状行为不变；非活跃
+  workspace 没有 SSE 通道）。
+
+### P2 重评估（按价值裁剪）
+
+原 P2（前端去重：provider 首拉存全量 status 给 App 复用）**降格为不做**：
+P0 的 daemon 端 in-flight 去重已消除重复 `git status` 子进程（原问题的实质），
+剩下的只是一次毫秒级本地 HTTP 往返。把全量 status 存进 provider 再让 App
+复用会引入跨层耦合（provider→App 初始值协议），收益约等于零。
+provider 两处 `workspaceGit()` 调用只取 `.branch`，走默认 fast path 即可，零改动。
+
+## 兼容性
+
+- 路由响应形状不变（v2，enriched 字段本就 optional）；新增 `?wait=1` query 为可选。
+- 默认 fast path 语义变化：调用方可能收到 last-known（旧缓存）而非新鲜计算。
+  全部现存调用方逐一核对：
+  - `DaemonSessionProvider`（×2）：只读 `.branch`——branch 始终新鲜（watcher），无影响。
+  - App.tsx composer chip：正是本设计的服务对象。
+  - WorkspaceSection：显式改 `wait: true`，语义不变。
+- 新 SSE 事件旧客户端静默丢弃（SDK known-list 机制）。
+- `git status_changed` 仅 publish 给该 workspace 的 session SSE bus
+  （`publishWorkspaceEvent` 现有机制，含多 workspace 隔离）。
+
+## 风险与缓解
+
+| 风险                                            | 缓解                                                                                             |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| chip 先显示 branch 后出现计数器，工具条宽度抖动 | 已有隐藏测量副本（ChatEditor toolbar-measure）处理 re-measure；接受轻微 shift                    |
+| branch-only 响应被误读为 "clean"                | branch-only 不携带 `computedAt`；GitBranchIndicator 现有逻辑在 `computedAt` 缺失时不显示 "clean" |
+| 缓存 status 与 watcher branch 不一致            | materialize 时 overlay `entry.branch ?? status.branch`（现状逻辑保留）                           |
+| 后台刷新泄漏（dispose 后 publish）              | `disposed` flag 守卫                                                                             |
+| focus 风暴触发串行 git spawn                    | 2s 节流 + in-flight 复用                                                                         |
+
+## 测试计划
+
+单测：
+
+- `workspace-git-state.test.ts`（扩展）：fast path 立即返回 last-known；
+  冷缓存返回 branch-only 且无 `computedAt`；后台刷新有差异才 publish
+  `git_status_changed`；首次计算必 publish；并发 getStatus 只触发一次
+  `getGitWorkingTreeStatus`；2s 节流；`wait: true` 等待新鲜计算；
+  计算失败保留旧缓存不 publish；dispose 后不 publish。
+- `routes/workspace-git.test.ts`（扩展）：`?wait=1` 透传；worktree `?cwd=`
+  路径不进缓存（维持直接计算）。
+- SDK `DaemonClient.test.ts`：options 对象 query 拼接（cwd / wait / 组合）。
+- webui `mappers.test.ts`：`git_status_changed` 匹配/不匹配 workspaceCwd
+  两种分支。
+
+E2E（`.qwen/e2e-tests/2026-07-24-git-chip-fast-branch.md`，验证阶段补）：
+真 daemon + web shell，大工作区新建会话——chip（branch）在编辑器就绪后立刻出现，
+计数器随后补齐；侧栏 chip 行为不变；focus/30s 轮询仍刷新；worktree 会话 chip 不变。
+
+## 被否决的备选
+
+- **TTL 缓存（无后台刷新/SSE）**：只能加速重复请求，冷启动仍需等 git status——
+  不解决"新建会话 chip 慢"的主诉。
+- **capabilities 后 daemon 预热**：首 GET 与预热几乎同时，in-flight 去重后收益≈0。
+- **前端只做去重/合并请求**：不消除 git status 子进程等待，治标。

--- a/docs/plans/2026-07-24-webshell-git-status-fast-path.md
+++ b/docs/plans/2026-07-24-webshell-git-status-fast-path.md
@@ -1,0 +1,57 @@
+# 实施计划：Web Shell git chip 快速显示
+
+日期：2026-07-24
+设计文档：`docs/design/2026-07-24-webshell-git-status-fast-path.md`
+
+## Goal
+
+新建会话/首屏时 composer git chip 以 branch 立即出现，计数器经 SSE 补齐；
+daemon 端消除重复 `git status` 子进程（缓存 + in-flight 去重 + 2s 节流）。
+
+## Architecture
+
+daemon `WorkspaceGitState` 增加 per-workspace status 缓存与后台刷新
+（stale-while-revalidate），路由默认 fast、`?wait=1` 阻塞；SDK 新增
+`git_status_changed` 事件与 `workspaceGit({cwd, wait})` options；
+webui 把 SSE status 存入 connection.gitStatus；web-shell App 消费它补齐 chip，
+侧栏显式走 `wait: true` 保持现状语义。
+
+## Tech Stack
+
+TypeScript ESM monorepo（cli / sdk-typescript / webui / web-shell），vitest。
+
+## File Structure
+
+| 包        | 文件                                             | 改动                                                                              |
+| --------- | ------------------------------------------------ | --------------------------------------------------------------------------------- |
+| cli       | `src/serve/workspace-git-state.ts`               | 缓存 + 去重 + 节流 + 后台刷新 + SSE publish + `getStatus` opts                    |
+| cli       | `src/serve/routes/workspace-git.ts`              | 解析 `?wait=1` 透传（两条路由；worktree `?cwd=` 不变）                            |
+| cli       | `src/serve/workspace-git-state.test.ts`          | 新增 fast/cache/dedup/throttle/wait/dispose 用例                                  |
+| cli       | `src/serve/routes/workspace-git.test.ts`         | `?wait=1` 透传、worktree 不进缓存                                                 |
+| sdk       | `src/daemon/events.ts`                           | known types 增加 `git_status_changed`                                             |
+| sdk       | `src/daemon/ui/normalizer.ts`                    | case → `return []`                                                                |
+| sdk       | `src/daemon/DaemonClient.ts`                     | `workspaceGit(opts?: {cwd?, wait?})` options 对象                                 |
+| sdk       | `test/unit/DaemonClient.test.ts`                 | query 拼接用例                                                                    |
+| webui     | `src/daemon/session/types.ts`                    | `DaemonConnectionState.gitStatus?`                                                |
+| webui     | `src/daemon/session/mappers.ts`                  | `case 'git_status_changed'`（workspaceCwd 守卫）                                  |
+| webui     | `src/daemon/session/mappers.test.ts`             | 匹配/不匹配两分支                                                                 |
+| web-shell | `client/App.tsx`                                 | options 迁移 + fast/fresh 双发（fresh 不依赖 SSE，覆盖无会话态）+ SSE 同步 effect |
+| web-shell | `client/components/sidebar/WorkspaceSection.tsx` | `workspaceGit({ wait: true })`                                                    |
+
+## Tasks
+
+- [x] 1. daemon：`WorkspaceGitState` 缓存/去重/节流/后台刷新/SSE + `getStatus` opts
+- [x] 2. daemon：路由 `?wait=1` 透传
+- [x] 3. daemon：单测（state + route）
+- [x] 4. sdk：事件类型 + normalizer + `workspaceGit` options 对象 + 单测
+- [x] 5. webui：connection.gitStatus + mapper + 单测
+- [x] 6. web-shell：App.tsx（options 迁移 + fast/fresh 双发 + SSE 同步 effect）+ WorkspaceSection `wait: true`
+- [x] 7. `npm run build && npm run typecheck` + 各包目标单测全绿
+- [x] 8. E2E 测试计划写入 `.qwen/e2e-tests/`，test-engineer 实测验证（协议级 6/6 通过，记录见计划文件）
+- [x] 9. 自审 diff（两轮）+ `/review`（medium local：无遗留发现；评审中补了 2 个 App 用例）
+
+## 备注
+
+- P2（前端请求去重）经价值重评估后不做——daemon 去重已消除重复子进程，
+  前端再合并只剩一次毫秒级本地 HTTP，不抵跨层耦合成本。设计文档已记录。
+- worktree `?cwd=` 路径维持直接计算，不进缓存（避免 watcher 泄漏）。

--- a/packages/cli/src/serve/routes/workspace-git.test.ts
+++ b/packages/cli/src/serve/routes/workspace-git.test.ts
@@ -62,7 +62,32 @@ describe('workspace Git routes', () => {
       workspaceCwd: '/work/main',
       branch: 'main',
     });
-    expect(getStatus).toHaveBeenCalledWith('/work/main', bridge);
+    expect(getStatus).toHaveBeenCalledWith('/work/main', bridge, {
+      wait: false,
+    });
+  });
+
+  it('passes wait:true through to the bound workspace git state', async () => {
+    const app = express();
+    const bridge = runtime('primary', '/work/main', true).bridge;
+    const getStatus = vi.fn(async () => ({
+      v: 1 as const,
+      workspaceCwd: '/work/main',
+      branch: 'main',
+    }));
+    registerWorkspaceGitRoutes(app, {
+      boundWorkspace: '/work/main',
+      bridge,
+      gitState: { getStatus } as unknown as WorkspaceGitState,
+      sendBridgeError,
+    });
+
+    const response = await request(app).get('/workspace/git?wait=1');
+
+    expect(response.status).toBe(200);
+    expect(getStatus).toHaveBeenCalledWith('/work/main', bridge, {
+      wait: true,
+    });
   });
 
   it('returns a structured error when bound Git status fails', async () => {
@@ -111,6 +136,33 @@ describe('workspace Git routes', () => {
     expect(getStatus).toHaveBeenCalledWith(
       secondary.workspaceCwd,
       secondary.bridge,
+      { wait: false },
+    );
+  });
+
+  it('passes wait:true through to the qualified workspace git state', async () => {
+    const app = express();
+    const primary = runtime('primary', '/work/main', true);
+    const getStatus = vi.fn(async () => ({
+      v: 1 as const,
+      workspaceCwd: primary.workspaceCwd,
+      branch: 'main',
+    }));
+    registerWorkspaceQualifiedGitRoutes(app, {
+      workspaceRegistry: registry([primary]),
+      gitState: { getStatus } as unknown as WorkspaceGitState,
+      sendBridgeError,
+    });
+
+    const response = await request(app).get('/workspaces/primary/git?wait=1');
+
+    expect(response.status).toBe(200);
+    expect(getStatus).toHaveBeenCalledWith(
+      primary.workspaceCwd,
+      primary.bridge,
+      {
+        wait: true,
+      },
     );
   });
 

--- a/packages/cli/src/serve/routes/workspace-git.ts
+++ b/packages/cli/src/serve/routes/workspace-git.ts
@@ -29,11 +29,14 @@ export function registerWorkspaceGitRoutes(
     sendBridgeError: SendBridgeError;
   },
 ): void {
-  app.get('/workspace/git', async (_req, res) => {
+  app.get('/workspace/git', async (req, res) => {
     try {
-      res
-        .status(200)
-        .json(await deps.gitState.getStatus(deps.boundWorkspace, deps.bridge));
+      const wait = req.query['wait'] === '1';
+      res.status(200).json(
+        await deps.gitState.getStatus(deps.boundWorkspace, deps.bridge, {
+          wait,
+        }),
+      );
     } catch (err) {
       deps.sendBridgeError(res, err, { route: 'GET /workspace/git' });
     }
@@ -106,9 +109,12 @@ export function registerWorkspaceQualifiedGitRoutes(
             : { v: 2, workspaceCwd: gitCwd, branch: null },
         );
       } else {
+        const wait = req.query['wait'] === '1';
         res
           .status(200)
-          .json(await deps.gitState.getStatus(gitCwd, runtime.bridge));
+          .json(
+            await deps.gitState.getStatus(gitCwd, runtime.bridge, { wait }),
+          );
       }
     } catch (err) {
       deps.sendBridgeError(res, err, { route });

--- a/packages/cli/src/serve/workspace-git-state.test.ts
+++ b/packages/cli/src/serve/workspace-git-state.test.ts
@@ -9,6 +9,7 @@ import {
   getGitWorkingTreeStatus,
   resolveBranchName,
   watchRepoBranch,
+  type GitWorkingTreeStatus,
 } from '@qwen-code/qwen-code-core';
 import type { AcpSessionBridge } from './acp-session-bridge.js';
 import { WorkspaceGitState } from './workspace-git-state.js';
@@ -22,6 +23,31 @@ vi.mock('@qwen-code/qwen-code-core', () => ({
 const getGitWorkingTreeStatusMock = vi.mocked(getGitWorkingTreeStatus);
 const resolveBranchNameMock = vi.mocked(resolveBranchName);
 const watchRepoBranchMock = vi.mocked(watchRepoBranch);
+
+function summary(
+  overrides: Partial<GitWorkingTreeStatus> = {},
+): GitWorkingTreeStatus {
+  return {
+    branch: 'main',
+    detached: false,
+    hasUpstream: true,
+    ahead: 0,
+    behind: 0,
+    staged: 0,
+    unstaged: 0,
+    untracked: 0,
+    conflicted: 0,
+    stashCount: 0,
+    ...overrides,
+  };
+}
+
+function bridgeWith(publishWorkspaceEvent = vi.fn()) {
+  return {
+    bridge: { publishWorkspaceEvent } as unknown as AcpSessionBridge,
+    publishWorkspaceEvent,
+  };
+}
 
 describe('WorkspaceGitState', () => {
   beforeEach(() => {
@@ -86,9 +112,13 @@ describe('WorkspaceGitState', () => {
     const state = new WorkspaceGitState();
 
     await expect(
-      state.getStatus('/workspace', {
-        publishWorkspaceEvent: vi.fn(),
-      } as unknown as AcpSessionBridge),
+      state.getStatus(
+        '/workspace',
+        {
+          publishWorkspaceEvent: vi.fn(),
+        } as unknown as AcpSessionBridge,
+        { wait: true },
+      ),
     ).resolves.toEqual({
       v: 2,
       workspaceCwd: '/workspace',
@@ -158,7 +188,7 @@ describe('WorkspaceGitState', () => {
       publishWorkspaceEvent: vi.fn(),
     } as unknown as AcpSessionBridge;
 
-    const status = await state.getStatus('/workspace', bridge);
+    const status = await state.getStatus('/workspace', bridge, { wait: true });
     expect(status).toMatchObject({
       v: 2,
       workspaceCwd: '/workspace',
@@ -197,7 +227,7 @@ describe('WorkspaceGitState', () => {
       publishWorkspaceEvent: vi.fn(),
     } as unknown as AcpSessionBridge;
 
-    const status = await state.getStatus('/workspace', bridge);
+    const status = await state.getStatus('/workspace', bridge, { wait: true });
     expect(status).not.toHaveProperty('operation');
   });
 
@@ -223,7 +253,9 @@ describe('WorkspaceGitState', () => {
       publishWorkspaceEvent: vi.fn(),
     } as unknown as AcpSessionBridge;
 
-    await expect(state.getStatus('/workspace', bridge)).resolves.toMatchObject({
+    await expect(
+      state.getStatus('/workspace', bridge, { wait: true }),
+    ).resolves.toMatchObject({
       branch: 'a1b2c3d',
       detached: true,
     });
@@ -278,5 +310,181 @@ describe('WorkspaceGitState', () => {
     });
     expect(resolveBranchNameMock).toHaveBeenCalledTimes(2);
     state.dispose();
+  });
+
+  it('serves branch-only on a cold cache, then publishes the computed summary', async () => {
+    resolveBranchNameMock.mockResolvedValue('main');
+    watchRepoBranchMock.mockResolvedValue(() => {});
+    getGitWorkingTreeStatusMock.mockResolvedValue(summary({ staged: 2 }));
+    const state = new WorkspaceGitState();
+    const { bridge, publishWorkspaceEvent } = bridgeWith();
+
+    // Fast path: last-known (nothing yet) without waiting for `git status`.
+    await expect(state.getStatus('/workspace', bridge)).resolves.toEqual({
+      v: 2,
+      workspaceCwd: '/workspace',
+      branch: 'main',
+    });
+
+    await vi.waitFor(() =>
+      expect(publishWorkspaceEvent).toHaveBeenCalledWith({
+        type: 'git_status_changed',
+        data: expect.objectContaining({
+          workspaceCwd: '/workspace',
+          branch: 'main',
+          staged: 2,
+        }),
+      }),
+    );
+
+    // Warm cache: the fast path now returns the enriched last-known status.
+    const warm = await state.getStatus('/workspace', bridge);
+    expect(warm).toMatchObject({ staged: 2 });
+    expect(typeof warm.computedAt).toBe('number');
+    state.dispose();
+  });
+
+  it('publishes a follow-up event only when the summary changes', async () => {
+    resolveBranchNameMock.mockResolvedValue('main');
+    watchRepoBranchMock.mockResolvedValue(() => {});
+    getGitWorkingTreeStatusMock.mockResolvedValue(summary({ staged: 1 }));
+    const state = new WorkspaceGitState();
+    const { bridge, publishWorkspaceEvent } = bridgeWith();
+
+    await state.getStatus('/workspace', bridge);
+    await vi.waitFor(() =>
+      expect(publishWorkspaceEvent).toHaveBeenCalledTimes(1),
+    );
+
+    vi.useFakeTimers({ toFake: ['Date'] });
+    try {
+      // Past the throttle window: a refresh runs but an unchanged summary
+      // must not re-publish (clients poll on a 30s cadence; a per-poll event
+      // would needlessly re-render).
+      vi.setSystemTime(Date.now() + 2_000);
+      await state.getStatus('/workspace', bridge);
+      await vi.waitFor(() =>
+        expect(getGitWorkingTreeStatusMock).toHaveBeenCalledTimes(2),
+      );
+      expect(publishWorkspaceEvent).toHaveBeenCalledTimes(1);
+
+      getGitWorkingTreeStatusMock.mockResolvedValue(summary({ staged: 3 }));
+      vi.setSystemTime(Date.now() + 2_000);
+      await state.getStatus('/workspace', bridge);
+      await vi.waitFor(() =>
+        expect(publishWorkspaceEvent).toHaveBeenCalledTimes(2),
+      );
+      expect(publishWorkspaceEvent).toHaveBeenLastCalledWith({
+        type: 'git_status_changed',
+        data: expect.objectContaining({ staged: 3 }),
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+    state.dispose();
+  });
+
+  it('shares one in-flight computation across concurrent fast callers', async () => {
+    resolveBranchNameMock.mockResolvedValue('main');
+    watchRepoBranchMock.mockResolvedValue(() => {});
+    getGitWorkingTreeStatusMock.mockResolvedValue(summary());
+    const state = new WorkspaceGitState();
+    const { bridge } = bridgeWith();
+
+    await Promise.all([
+      state.getStatus('/workspace', bridge),
+      state.getStatus('/workspace', bridge),
+      state.getStatus('/workspace', bridge),
+    ]);
+    await vi.waitFor(() =>
+      expect(getGitWorkingTreeStatusMock).toHaveBeenCalledTimes(1),
+    );
+
+    // Within the throttle window another fast call does not refresh again.
+    await state.getStatus('/workspace', bridge);
+    expect(getGitWorkingTreeStatusMock).toHaveBeenCalledTimes(1);
+    state.dispose();
+  });
+
+  it('wait:true awaits a fresh computation and bypasses the throttle', async () => {
+    let resolveGit!: (value: GitWorkingTreeStatus | null) => void;
+    getGitWorkingTreeStatusMock.mockImplementation(
+      () =>
+        new Promise<GitWorkingTreeStatus | null>((resolve) => {
+          resolveGit = resolve;
+        }),
+    );
+    resolveBranchNameMock.mockResolvedValue('main');
+    watchRepoBranchMock.mockResolvedValue(() => {});
+    const state = new WorkspaceGitState();
+    const { bridge } = bridgeWith();
+
+    let settled = false;
+    const pending = state
+      .getStatus('/workspace', bridge, { wait: true })
+      .then((status) => {
+        settled = true;
+        return status;
+      });
+    await vi.waitFor(() =>
+      expect(getGitWorkingTreeStatusMock).toHaveBeenCalled(),
+    );
+    expect(settled).toBe(false);
+
+    resolveGit(summary({ ahead: 4 }));
+    await expect(pending).resolves.toMatchObject({ ahead: 4 });
+
+    // A second wait:true right after still forces a fresh computation.
+    getGitWorkingTreeStatusMock.mockResolvedValue(summary({ ahead: 5 }));
+    await expect(
+      state.getStatus('/workspace', bridge, { wait: true }),
+    ).resolves.toMatchObject({ ahead: 5 });
+    expect(getGitWorkingTreeStatusMock).toHaveBeenCalledTimes(2);
+    state.dispose();
+  });
+
+  it('keeps the cached summary and stays silent when a refresh fails', async () => {
+    resolveBranchNameMock.mockResolvedValue('main');
+    watchRepoBranchMock.mockResolvedValue(() => {});
+    getGitWorkingTreeStatusMock.mockResolvedValueOnce(summary({ staged: 1 }));
+    const state = new WorkspaceGitState();
+    const { bridge, publishWorkspaceEvent } = bridgeWith();
+
+    await expect(
+      state.getStatus('/workspace', bridge, { wait: true }),
+    ).resolves.toMatchObject({ staged: 1 });
+    expect(publishWorkspaceEvent).toHaveBeenCalledTimes(1);
+
+    getGitWorkingTreeStatusMock.mockRejectedValueOnce(
+      new Error('git exploded'),
+    );
+    await expect(
+      state.getStatus('/workspace', bridge, { wait: true }),
+    ).resolves.toMatchObject({ staged: 1 });
+    expect(publishWorkspaceEvent).toHaveBeenCalledTimes(1);
+    state.dispose();
+  });
+
+  it('does not publish when a refresh finishes after dispose', async () => {
+    let resolveGit!: (value: GitWorkingTreeStatus | null) => void;
+    getGitWorkingTreeStatusMock.mockImplementation(
+      () =>
+        new Promise<GitWorkingTreeStatus | null>((resolve) => {
+          resolveGit = resolve;
+        }),
+    );
+    resolveBranchNameMock.mockResolvedValue('main');
+    watchRepoBranchMock.mockResolvedValue(() => {});
+    const state = new WorkspaceGitState();
+    const { bridge, publishWorkspaceEvent } = bridgeWith();
+
+    const pending = state.getStatus('/workspace', bridge, { wait: true });
+    await vi.waitFor(() =>
+      expect(getGitWorkingTreeStatusMock).toHaveBeenCalled(),
+    );
+    state.dispose();
+    resolveGit(summary({ staged: 5 }));
+    await pending;
+    expect(publishWorkspaceEvent).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/serve/workspace-git-state.test.ts
+++ b/packages/cli/src/serve/workspace-git-state.test.ts
@@ -524,6 +524,30 @@ describe('WorkspaceGitState', () => {
     expect(publishWorkspaceEvent).not.toHaveBeenCalled();
   });
 
+  it('does not publish git_branch_changed when the watcher fires after dispose', async () => {
+    let onChange: (() => void) | undefined;
+    const dispose = vi.fn();
+    resolveBranchNameMock
+      .mockResolvedValueOnce('main')
+      .mockResolvedValueOnce('feature');
+    watchRepoBranchMock.mockImplementation(async (_cwd, callback) => {
+      onChange = callback;
+      return dispose;
+    });
+    const state = new WorkspaceGitState();
+    const { bridge, publishWorkspaceEvent } = bridgeWith();
+
+    await state.getStatus('/workspace', bridge);
+    state.dispose();
+    await vi.waitFor(() => expect(dispose).toHaveBeenCalledOnce());
+
+    onChange?.();
+    await vi.waitFor(() =>
+      expect(resolveBranchNameMock).toHaveBeenCalledTimes(2),
+    );
+    expect(publishWorkspaceEvent).not.toHaveBeenCalled();
+  });
+
   it('keeps the cache and resolves wait:true when publishWorkspaceEvent throws', async () => {
     resolveBranchNameMock.mockResolvedValue('main');
     watchRepoBranchMock.mockResolvedValue(() => {});

--- a/packages/cli/src/serve/workspace-git-state.test.ts
+++ b/packages/cli/src/serve/workspace-git-state.test.ts
@@ -12,6 +12,7 @@ import {
   type GitWorkingTreeStatus,
 } from '@qwen-code/qwen-code-core';
 import type { AcpSessionBridge } from './acp-session-bridge.js';
+import { writeStderrLineSafe } from '../utils/stdioHelpers.js';
 import { WorkspaceGitState } from './workspace-git-state.js';
 
 vi.mock('@qwen-code/qwen-code-core', () => ({
@@ -28,6 +29,7 @@ vi.mock('../utils/stdioHelpers.js', () => ({
 const getGitWorkingTreeStatusMock = vi.mocked(getGitWorkingTreeStatus);
 const resolveBranchNameMock = vi.mocked(resolveBranchName);
 const watchRepoBranchMock = vi.mocked(watchRepoBranch);
+const writeStderrLineSafeMock = vi.mocked(writeStderrLineSafe);
 
 function summary(
   overrides: Partial<GitWorkingTreeStatus> = {},
@@ -498,6 +500,9 @@ describe('WorkspaceGitState', () => {
       state.getStatus('/workspace', bridge, { wait: true }),
     ).resolves.toMatchObject({ staged: 1 });
     expect(publishWorkspaceEvent).toHaveBeenCalledTimes(1);
+    expect(writeStderrLineSafeMock).toHaveBeenCalledWith(
+      expect.stringContaining('git status failed'),
+    );
     state.dispose();
   });
 

--- a/packages/cli/src/serve/workspace-git-state.test.ts
+++ b/packages/cli/src/serve/workspace-git-state.test.ts
@@ -487,4 +487,23 @@ describe('WorkspaceGitState', () => {
     await pending;
     expect(publishWorkspaceEvent).not.toHaveBeenCalled();
   });
+
+  it('keeps the cache and resolves wait:true when publishWorkspaceEvent throws', async () => {
+    resolveBranchNameMock.mockResolvedValue('main');
+    watchRepoBranchMock.mockResolvedValue(() => {});
+    getGitWorkingTreeStatusMock.mockResolvedValue(summary({ staged: 2 }));
+    const state = new WorkspaceGitState();
+    const { bridge, publishWorkspaceEvent } = bridgeWith();
+    publishWorkspaceEvent.mockImplementationOnce(() => {
+      throw new Error('sse down');
+    });
+
+    await expect(
+      state.getStatus('/workspace', bridge, { wait: true }),
+    ).resolves.toMatchObject({ staged: 2 });
+
+    const fast = await state.getStatus('/workspace', bridge);
+    expect(fast.computedAt).toBeDefined();
+    state.dispose();
+  });
 });

--- a/packages/cli/src/serve/workspace-git-state.test.ts
+++ b/packages/cli/src/serve/workspace-git-state.test.ts
@@ -406,6 +406,37 @@ describe('WorkspaceGitState', () => {
     state.dispose();
   });
 
+  it('wait:true joins an already in-flight fast-path refresh', async () => {
+    let resolveGit!: (value: GitWorkingTreeStatus | null) => void;
+    getGitWorkingTreeStatusMock.mockImplementation(
+      () =>
+        new Promise<GitWorkingTreeStatus | null>((resolve) => {
+          resolveGit = resolve;
+        }),
+    );
+    resolveBranchNameMock.mockResolvedValue('main');
+    watchRepoBranchMock.mockResolvedValue(() => {});
+    const state = new WorkspaceGitState();
+    const { bridge } = bridgeWith();
+
+    // Fast path kicks a background refresh, setting statusPromise.
+    const fastPromise = state.getStatus('/workspace', bridge);
+    await vi.waitFor(() =>
+      expect(getGitWorkingTreeStatusMock).toHaveBeenCalledTimes(1),
+    );
+
+    // wait:true should join the in-flight computation, not spawn a second one.
+    const waitPromise = state.getStatus('/workspace', bridge, { wait: true });
+
+    resolveGit(summary({ staged: 3 }));
+
+    const [fast, wait] = await Promise.all([fastPromise, waitPromise]);
+    expect(getGitWorkingTreeStatusMock).toHaveBeenCalledTimes(1);
+    expect(fast.branch).toBe('main');
+    expect(wait.staged).toBe(3);
+    state.dispose();
+  });
+
   it('wait:true awaits a fresh computation and bypasses the throttle', async () => {
     let resolveGit!: (value: GitWorkingTreeStatus | null) => void;
     getGitWorkingTreeStatusMock.mockImplementation(

--- a/packages/cli/src/serve/workspace-git-state.test.ts
+++ b/packages/cli/src/serve/workspace-git-state.test.ts
@@ -20,6 +20,11 @@ vi.mock('@qwen-code/qwen-code-core', () => ({
   watchRepoBranch: vi.fn(),
 }));
 
+vi.mock('../utils/stdioHelpers.js', () => ({
+  writeStderrLine: vi.fn(),
+  writeStderrLineSafe: vi.fn(),
+}));
+
 const getGitWorkingTreeStatusMock = vi.mocked(getGitWorkingTreeStatus);
 const resolveBranchNameMock = vi.mocked(resolveBranchName);
 const watchRepoBranchMock = vi.mocked(watchRepoBranch);

--- a/packages/cli/src/serve/workspace-git-state.ts
+++ b/packages/cli/src/serve/workspace-git-state.ts
@@ -9,6 +9,7 @@ import {
   resolveBranchName,
   watchRepoBranch,
   type GitOperation,
+  type GitWorkingTreeStatus,
 } from '@qwen-code/qwen-code-core';
 import type { AcpSessionBridge } from './acp-session-bridge.js';
 
@@ -35,23 +36,102 @@ export interface WorkspaceGitStatus {
 interface WorkspaceGitEntry {
   branch: string | undefined;
   dispose: () => void;
+  /** Last computed working-tree summary; served as last-known on fast paths. */
+  status?: GitWorkingTreeStatus;
+  statusComputedAt?: number;
+  /** In-flight working-tree computation, shared by all callers. */
+  statusPromise?: Promise<void>;
+  /** Last time a computation was kicked, for background-refresh throttling. */
+  refreshStartedAt?: number;
+  /** Set on dispose: a late-finishing refresh must not publish. */
+  disposed?: boolean;
+}
+
+/**
+ * Minimum interval between background working-tree refreshes. `wait: true`
+ * callers bypass it — only reactive kicks (one per fast `getStatus`) are
+ * throttled, so a focus/poll burst can't queue a train of `git status`
+ * subprocesses.
+ */
+const BACKGROUND_REFRESH_THROTTLE_MS = 2_000;
+
+function sameWorkingTreeStatus(
+  a: GitWorkingTreeStatus,
+  b: GitWorkingTreeStatus,
+): boolean {
+  return (
+    a.branch === b.branch &&
+    a.detached === b.detached &&
+    a.hasUpstream === b.hasUpstream &&
+    a.ahead === b.ahead &&
+    a.behind === b.behind &&
+    a.staged === b.staged &&
+    a.unstaged === b.unstaged &&
+    a.untracked === b.untracked &&
+    a.conflicted === b.conflicted &&
+    a.stashCount === b.stashCount &&
+    a.operation === b.operation
+  );
 }
 
 export class WorkspaceGitState {
   private readonly entries = new Map<string, Promise<WorkspaceGitEntry>>();
 
+  /**
+   * Default (fast) path: return the last-known status immediately — branch-only
+   * when the working-tree summary has never been computed — and kick a
+   * throttled background refresh that publishes `git_status_changed` when it
+   * finds a delta. `wait: true` awaits a fresh computation and returns the
+   * full status (in-flight refreshes are shared), matching the pre-cache
+   * blocking semantics.
+   */
   async getStatus(
     workspaceCwd: string,
     bridge: AcpSessionBridge,
+    opts?: { wait?: boolean },
   ): Promise<WorkspaceGitStatus> {
     const entry = await this.getOrCreateEntry(workspaceCwd, bridge);
-    // The watcher keeps `entry.branch` live between refreshes; the heavier
-    // working-tree summary is computed fresh per call (the client bounds how
-    // often it asks). A non-repo / git failure yields null → branch-only; a
-    // transient state (merge/rebase/…) still returns a summary with `operation`.
-    const status = await getGitWorkingTreeStatus(workspaceCwd).catch(
-      () => null,
-    );
+    if (opts?.wait) {
+      await this.startRefresh(workspaceCwd, entry, bridge, true);
+    } else {
+      void this.startRefresh(workspaceCwd, entry, bridge, false);
+    }
+    return this.materialize(workspaceCwd, entry);
+  }
+
+  dispose(): void {
+    for (const pending of this.entries.values()) {
+      void pending
+        .then((entry) => {
+          entry.disposed = true;
+          entry.dispose();
+        })
+        .catch(() => {});
+    }
+    this.entries.clear();
+  }
+
+  disposeWorkspace(workspaceCwd: string): void {
+    const pending = this.entries.get(workspaceCwd);
+    if (!pending) return;
+    this.entries.delete(workspaceCwd);
+    void pending
+      .then((entry) => {
+        entry.disposed = true;
+        entry.dispose();
+      })
+      .catch(() => {});
+  }
+
+  private materialize(
+    workspaceCwd: string,
+    entry: WorkspaceGitEntry,
+  ): WorkspaceGitStatus {
+    const status = entry.status;
+    // The watcher keeps `entry.branch` live between refreshes; prefer it over
+    // the (possibly stale) summary branch. A missing summary yields the
+    // branch-only shape with no `computedAt`, which clients distinguish from
+    // "computed and clean".
     if (!status) {
       return { v: 2, workspaceCwd, branch: entry.branch ?? null };
     }
@@ -69,22 +149,60 @@ export class WorkspaceGitState {
       behind: status.behind,
       stashCount: status.stashCount,
       ...(status.operation ? { operation: status.operation } : {}),
-      computedAt: Date.now(),
+      computedAt: entry.statusComputedAt ?? Date.now(),
     };
   }
 
-  dispose(): void {
-    for (const pending of this.entries.values()) {
-      void pending.then((entry) => entry.dispose()).catch(() => {});
+  /**
+   * Start a working-tree computation unless one is already in flight (shared)
+   * or a non-forced kick lands within the throttle window. Returns the
+   * in-flight promise, or undefined when throttled. A failed computation keeps
+   * the previous cache and stays silent; a successful one publishes
+   * `git_status_changed` only when the summary actually changed.
+   */
+  private startRefresh(
+    workspaceCwd: string,
+    entry: WorkspaceGitEntry,
+    bridge: AcpSessionBridge,
+    force: boolean,
+  ): Promise<void> | undefined {
+    if (entry.statusPromise) return entry.statusPromise;
+    if (
+      !force &&
+      entry.refreshStartedAt !== undefined &&
+      Date.now() - entry.refreshStartedAt < BACKGROUND_REFRESH_THROTTLE_MS
+    ) {
+      return undefined;
     }
-    this.entries.clear();
-  }
-
-  disposeWorkspace(workspaceCwd: string): void {
-    const pending = this.entries.get(workspaceCwd);
-    if (!pending) return;
-    this.entries.delete(workspaceCwd);
-    void pending.then((entry) => entry.dispose()).catch(() => {});
+    entry.refreshStartedAt = Date.now();
+    const run = (async () => {
+      const status = await getGitWorkingTreeStatus(workspaceCwd).catch(
+        () => null,
+      );
+      if (!status) return;
+      const changed =
+        !entry.status || !sameWorkingTreeStatus(entry.status, status);
+      entry.status = status;
+      entry.statusComputedAt = Date.now();
+      if (changed && !entry.disposed) {
+        try {
+          bridge.publishWorkspaceEvent({
+            type: 'git_status_changed',
+            data: this.materialize(workspaceCwd, entry),
+          });
+        } catch {
+          // SSE fan-out is a side effect — it must not reject the refresh
+          // (an awaited wait:true call would 500 the route) or drop the cache.
+        }
+      }
+    })();
+    entry.statusPromise = run;
+    void run.finally(() => {
+      if (entry.statusPromise === run) {
+        entry.statusPromise = undefined;
+      }
+    });
+    return run;
   }
 
   private getOrCreateEntry(
@@ -116,6 +234,7 @@ export class WorkspaceGitState {
       const branch = await resolveBranchName(workspaceCwd);
       if (branch === entry.branch) return;
       entry.branch = branch;
+      if (entry.disposed) return;
       bridge.publishWorkspaceEvent({
         type: 'git_branch_changed',
         data: { workspaceCwd, branch: branch ?? null },

--- a/packages/cli/src/serve/workspace-git-state.ts
+++ b/packages/cli/src/serve/workspace-git-state.ts
@@ -12,7 +12,7 @@ import {
   type GitWorkingTreeStatus,
 } from '@qwen-code/qwen-code-core';
 import type { AcpSessionBridge } from './acp-session-bridge.js';
-import { writeStderrLine } from '../utils/stdioHelpers.js';
+import { writeStderrLineSafe } from '../utils/stdioHelpers.js';
 
 export interface WorkspaceGitStatus {
   v: 2;
@@ -198,7 +198,7 @@ export class WorkspaceGitState {
     const run = (async () => {
       const status = await getGitWorkingTreeStatus(workspaceCwd).catch(
         (err) => {
-          writeStderrLine(
+          writeStderrLineSafe(
             `qwen serve: git status failed for ${workspaceCwd}: ${err instanceof Error ? err.message : String(err)}`,
           );
           return null;

--- a/packages/cli/src/serve/workspace-git-state.ts
+++ b/packages/cli/src/serve/workspace-git-state.ts
@@ -12,6 +12,7 @@ import {
   type GitWorkingTreeStatus,
 } from '@qwen-code/qwen-code-core';
 import type { AcpSessionBridge } from './acp-session-bridge.js';
+import { writeStderrLine } from '../utils/stdioHelpers.js';
 
 export interface WorkspaceGitStatus {
   v: 2;
@@ -196,7 +197,12 @@ export class WorkspaceGitState {
     entry.refreshStartedAt = Date.now();
     const run = (async () => {
       const status = await getGitWorkingTreeStatus(workspaceCwd).catch(
-        () => null,
+        (err) => {
+          writeStderrLine(
+            `qwen serve: git status failed for ${workspaceCwd}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+          return null;
+        },
       );
       if (!status) return;
       const changed =

--- a/packages/cli/src/serve/workspace-git-state.ts
+++ b/packages/cli/src/serve/workspace-git-state.ts
@@ -59,6 +59,22 @@ function sameWorkingTreeStatus(
   a: GitWorkingTreeStatus,
   b: GitWorkingTreeStatus,
 ): boolean {
+  // Exhaustiveness guard: if a field is added to GitWorkingTreeStatus,
+  // this line will fail to compile until the field is added below.
+  const _exhaustive: Record<keyof GitWorkingTreeStatus, true> = {
+    branch: true,
+    detached: true,
+    hasUpstream: true,
+    ahead: true,
+    behind: true,
+    staged: true,
+    unstaged: true,
+    untracked: true,
+    conflicted: true,
+    stashCount: true,
+    operation: true,
+  };
+  void _exhaustive;
   return (
     a.branch === b.branch &&
     a.detached === b.detached &&

--- a/packages/cli/src/serve/workspace-git-state.ts
+++ b/packages/cli/src/serve/workspace-git-state.ts
@@ -75,6 +75,9 @@ function sameWorkingTreeStatus(
     operation: true,
   };
   void _exhaustive;
+  // branch is compared even though materialize() overlays the watcher branch:
+  // a status.branch delta is the first signal of a checkout the watcher has
+  // not yet seen — publishing is intentionally conservative.
   return (
     a.branch === b.branch &&
     a.detached === b.detached &&

--- a/packages/sdk-typescript/src/daemon/DaemonClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonClient.ts
@@ -1089,9 +1089,11 @@ export class DaemonClient {
     );
   }
 
-  async workspaceGit(): Promise<DaemonWorkspaceGitStatus> {
+  async workspaceGit(opts?: {
+    wait?: boolean;
+  }): Promise<DaemonWorkspaceGitStatus> {
     return await this.jsonRequest<DaemonWorkspaceGitStatus>(
-      '/workspace/git',
+      `/workspace/git${opts?.wait ? '?wait=1' : ''}`,
       'GET /workspace/git',
       { mode: 'rest' },
     );
@@ -4433,8 +4435,15 @@ export class WorkspaceDaemonClient {
     );
   }
 
-  workspaceGit(cwd?: string): Promise<DaemonWorkspaceGitStatus> {
-    const suffix = cwd ? `/git?cwd=${encodeURIComponent(cwd)}` : '/git';
+  workspaceGit(opts?: {
+    cwd?: string;
+    wait?: boolean;
+  }): Promise<DaemonWorkspaceGitStatus> {
+    const params = new URLSearchParams();
+    if (opts?.cwd) params.set('cwd', opts.cwd);
+    if (opts?.wait) params.set('wait', '1');
+    const query = params.toString();
+    const suffix = query ? `/git?${query}` : '/git';
     return this.client.workspaceJsonRequest<DaemonWorkspaceGitStatus>(
       this.workspaceSelector,
       suffix,

--- a/packages/sdk-typescript/src/daemon/events.ts
+++ b/packages/sdk-typescript/src/daemon/events.ts
@@ -157,6 +157,11 @@ export const DAEMON_KNOWN_EVENT_TYPE_VALUES = [
   // clients can seed their reducer without an extra round-trip.
   'session_snapshot',
   'git_branch_changed',
+  // Enriched working-tree summary push: the daemon recomputes `git status`
+  // in the background (stale-while-revalidate on `GET …/git`) and publishes
+  // this only when the summary changed. `data` is a DaemonWorkspaceGitStatus.
+  // Old SDK consumers silently drop it via `asKnownDaemonEvent`.
+  'git_status_changed',
 ] as const;
 
 const DAEMON_KNOWN_EVENT_TYPES: ReadonlySet<string> = new Set<string>(

--- a/packages/sdk-typescript/src/daemon/ui/normalizer.ts
+++ b/packages/sdk-typescript/src/daemon/ui/normalizer.ts
@@ -310,6 +310,9 @@ export function normalizeDaemonEvent(
     case 'git_branch_changed':
       return [];
 
+    case 'git_status_changed':
+      return [];
+
     case 'memory_changed':
       return normalizeMemoryChanged(event, base);
 

--- a/packages/sdk-typescript/test/unit/DaemonClient.test.ts
+++ b/packages/sdk-typescript/test/unit/DaemonClient.test.ts
@@ -872,6 +872,36 @@ describe('DaemonClient', () => {
       expect(transportFetch).not.toHaveBeenCalled();
     });
 
+    it('builds Git status query strings from cwd/wait options', async () => {
+      const status = {
+        v: 1 as const,
+        workspaceCwd: '/work/main',
+        branch: 'main',
+      };
+      const { fetch, calls } = recordingFetch(() => jsonResponse(200, status));
+      const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+
+      await client.workspaceGit({ wait: true });
+      await client
+        .workspaceByCwd('/work/secondary')
+        .workspaceGit({ cwd: '/work/secondary/wt-1' });
+      await client
+        .workspaceByCwd('/work/secondary')
+        .workspaceGit({ cwd: '/work/secondary/wt-1', wait: true });
+
+      expect(calls.map((call) => [call.method, call.url])).toEqual([
+        ['GET', 'http://daemon/workspace/git?wait=1'],
+        [
+          'GET',
+          'http://daemon/workspaces/%2Fwork%2Fsecondary/git?cwd=%2Fwork%2Fsecondary%2Fwt-1',
+        ],
+        [
+          'GET',
+          'http://daemon/workspaces/%2Fwork%2Fsecondary/git?cwd=%2Fwork%2Fsecondary%2Fwt-1&wait=1',
+        ],
+      ]);
+    });
+
     it('reads Git diff list and per-file hunks (incl. rename oldPath) over REST', async () => {
       const diffList = {
         v: 1 as const,

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -2,7 +2,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, createRef, type CSSProperties } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import type { DaemonInputAnnotation } from '@qwen-code/sdk/daemon';
+import type {
+  DaemonInputAnnotation,
+  DaemonWorkspaceGitStatus,
+} from '@qwen-code/sdk/daemon';
 import type { WebShellApi } from './App';
 import type { Message } from './adapters/types';
 import { loadSplitSessions, saveSplitSessions } from './utils/splitUrl';
@@ -26,6 +29,8 @@ type MockConnection = {
   error?: string;
   errorStatus?: number;
   missingSession?: boolean;
+  gitBranch?: string;
+  gitStatus?: DaemonWorkspaceGitStatus;
 };
 
 type ChatEditorTestProps = {
@@ -57,6 +62,8 @@ type ChatEditorTestProps = {
     name?: string;
     slug?: string;
   }) => void;
+  gitBranch?: string;
+  gitStatus?: DaemonWorkspaceGitStatus;
 };
 
 type AddWorkspaceDialogTestProps = {
@@ -1011,6 +1018,8 @@ beforeEach(() => {
   mockConnection.skills = [];
   mockConnection.loadingTranscript = false;
   mockConnection.catchingUp = false;
+  mockConnection.gitBranch = undefined;
+  mockConnection.gitStatus = undefined;
   mockWorkspace.capabilities = {
     workspaces: [{ id: 'primary', cwd: '/workspace', primary: true }],
   };
@@ -1948,6 +1957,78 @@ describe('App session callbacks', () => {
     expect(
       testState.latestChatEditorProps?.onGitModeIntentChange,
     ).toBeUndefined();
+  });
+
+  it('fetches the composer git status on both the fast and the wait:true fresh path', async () => {
+    mockConnection.sessionId = undefined;
+    mockWorkspace.capabilities = {
+      workspaces: [
+        { id: 'primary', cwd: '/workspace', primary: true, trusted: true },
+      ],
+    };
+    const workspaceGit = vi.fn().mockResolvedValue({ branch: 'main' });
+    mockWorkspace.client.workspaceByCwd.mockImplementation(() => ({
+      workspaceGit,
+      workspaceSkills: mockWorkspaceActions.loadSkillsStatus,
+    }));
+    renderApp();
+    await flush();
+    await flush();
+
+    // Fast path paints the chip from the daemon's last-known cache; the
+    // wait:true fresh path fills in the enriched counters once the daemon's
+    // background recomputation lands (no SSE exists before the first
+    // prompt). Both share one daemon-side `git status` computation.
+    await vi.waitFor(() => {
+      expect(workspaceGit).toHaveBeenCalledWith({ cwd: undefined });
+      expect(workspaceGit).toHaveBeenCalledWith({ wait: true });
+    });
+  });
+
+  it('mirrors connection.gitStatus into the composer git chip', async () => {
+    mockConnection.sessionId = undefined;
+    mockWorkspace.capabilities = {
+      workspaces: [
+        { id: 'primary', cwd: '/workspace', primary: true, trusted: true },
+      ],
+    };
+    mockWorkspace.client.workspaceByCwd.mockImplementation(() => ({
+      workspaceGit: vi.fn().mockResolvedValue({ branch: 'main' }),
+      workspaceSkills: mockWorkspaceActions.loadSkillsStatus,
+    }));
+    renderApp();
+    await flush();
+    await flush();
+
+    // Fast GET applied the branch-only last-known status.
+    await vi.waitFor(() => {
+      expect(testState.latestChatEditorProps?.gitStatus).toEqual({
+        branch: 'main',
+      });
+    });
+
+    // The daemon's `git_status_changed` push lands as connection.gitStatus
+    // (a provider state update in production; simulated here by mutating the
+    // connection object and forcing a re-render).
+    act(() => {
+      mockConnection.gitStatus = {
+        v: 2,
+        workspaceCwd: '/workspace',
+        branch: 'main',
+        staged: 2,
+        computedAt: 1_700_000_000_000,
+      };
+      testState.latestChatEditorProps?.onInputTextChange?.('x');
+    });
+    await flush();
+
+    await vi.waitFor(() => {
+      expect(testState.latestChatEditorProps?.gitStatus).toMatchObject({
+        workspaceCwd: '/workspace',
+        branch: 'main',
+        staged: 2,
+      });
+    });
   });
 
   it('forwards the branch intent to createSession when submitting a prompt', async () => {

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -2031,6 +2031,43 @@ describe('App session callbacks', () => {
     });
   });
 
+  it('skips the wait:true fresh path for worktree sessions', async () => {
+    const worktreePath = '/workspace/.worktrees/feat-a';
+    mockWorkspace.client.sessionStatus.mockResolvedValue({
+      worktree: { slug: 'feat-a', path: worktreePath, branch: 'feat-a' },
+    });
+    mockWorkspace.capabilities = {
+      workspaces: [
+        { id: 'primary', cwd: '/workspace', primary: true, trusted: true },
+      ],
+    };
+    const workspaceGit = vi.fn().mockResolvedValue({ branch: 'feat-a' });
+    mockWorkspace.client.workspaceByCwd.mockImplementation(() => ({
+      workspaceGit,
+      workspaceSkills: mockWorkspaceActions.loadSkillsStatus,
+    }));
+    renderApp();
+    await flush();
+    await flush();
+
+    // The worktree session status lands and the git effect re-runs with the
+    // worktree path.
+    await vi.waitFor(() => {
+      expect(workspaceGit).toHaveBeenCalledWith({ cwd: worktreePath });
+    });
+
+    // After the worktree cwd call, no wait:true call should follow — worktree
+    // ?cwd= reads compute directly, so a second request would be a duplicate.
+    const calls = workspaceGit.mock.calls.map(([arg]) => arg);
+    const cwdIndex = calls.findIndex(
+      (arg: Record<string, unknown>) => arg?.cwd === worktreePath,
+    );
+    const waitAfter = calls
+      .slice(cwdIndex + 1)
+      .filter((arg: Record<string, unknown>) => arg?.wait === true);
+    expect(waitAfter).toHaveLength(0);
+  });
+
   it('forwards the branch intent to createSession when submitting a prompt', async () => {
     mockConnection.sessionId = undefined;
     mockWorkspace.capabilities = {

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -1492,20 +1492,39 @@ export function App({
     }
     let cancelled = false;
     const fetchStatus = () => {
-      void workspace.client
-        .workspaceByCwd(activeWorkspaceCwd)
-        .workspaceGit(sessionWorktree?.path)
-        .then((git) => {
-          if (!cancelled) setSelectedWorkspaceGitStatus(git);
+      const git = workspace.client.workspaceByCwd(activeWorkspaceCwd);
+      // Fast path: last-known cache (branch-only on a cold start) paints the
+      // chip immediately.
+      void git
+        .workspaceGit({ cwd: sessionWorktree?.path })
+        .then((status) => {
+          if (!cancelled) setSelectedWorkspaceGitStatus(status);
         })
         .catch(() => {
           if (!cancelled) setSelectedWorkspaceGitStatus(undefined);
         });
+      // Fresh path: resolves when the daemon's recomputation lands, so the
+      // enriched counters fill in without depending on SSE — the
+      // `git_status_changed` push only flows on a per-session event stream,
+      // which doesn't exist before the first prompt (deferred connect).
+      // Daemon-side in-flight dedup shares one `git status` computation
+      // across both requests. Worktree `?cwd=` reads always compute
+      // directly, so a second request would be a duplicate there.
+      if (!sessionWorktree) {
+        void git
+          .workspaceGit({ wait: true })
+          .then((status) => {
+            if (!cancelled) setSelectedWorkspaceGitStatus(status);
+          })
+          .catch(() => {});
+      }
     };
     fetchStatus();
-    // The enriched working-tree summary isn't pushed over SSE, so refresh it on
-    // focus and on a slow poll for the active workspace only. A live branch
-    // change re-runs this effect via the connection.gitBranch dependency.
+    // Refresh triggers stay on focus and on a slow poll for the active
+    // workspace only. A live branch change re-runs this effect via the
+    // connection.gitBranch dependency. With an active session the daemon's
+    // `git_status_changed` push (mirrored by the effect below) additionally
+    // covers realtime updates between polls.
     const onFocus = () => fetchStatus();
     window.addEventListener('focus', onFocus);
     const poll = window.setInterval(() => {
@@ -1522,6 +1541,17 @@ export function App({
     workspace.client,
     sessionWorktree,
   ]);
+  // Mirror the daemon's `git_status_changed` push (surfaced as
+  // connection.gitStatus by the session provider) into the chip state so the
+  // enriched counters fill in right after the branch-only first paint.
+  // Worktree sessions bypass the daemon cache/SSE path — their status comes
+  // from the ?cwd= fetch above.
+  useEffect(() => {
+    const status = connection.gitStatus;
+    if (!status || sessionWorktree) return;
+    if (status.workspaceCwd !== activeWorkspaceCwd) return;
+    setSelectedWorkspaceGitStatus(status);
+  }, [connection.gitStatus, activeWorkspaceCwd, sessionWorktree]);
   const onToastRef = useRef(onToast);
   onToastRef.current = onToast;
   const toastIdRef = useRef(0);

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -1516,7 +1516,9 @@ export function App({
           .then((status) => {
             if (!cancelled) setSelectedWorkspaceGitStatus(status);
           })
-          .catch(() => {});
+          .catch((err) => {
+            console.warn('[web-shell] git status fresh path failed:', err);
+          });
       }
     };
     fetchStatus();

--- a/packages/web-shell/client/components/sidebar/WorkspaceSection.tsx
+++ b/packages/web-shell/client/components/sidebar/WorkspaceSection.tsx
@@ -231,7 +231,12 @@ export function WorkspaceSection({
   const loadGitStatus = useCallback(async () => {
     if (!gitStatusEnabled || !workspace.trusted || !gitPollCwd) return;
     try {
-      const status = await client.workspaceByCwd(gitPollCwd).workspaceGit();
+      // wait: the sidebar chip shows the enriched counters and has no SSE
+      // fill-in path, so it keeps the blocking semantics instead of the
+      // composer's last-known fast path.
+      const status = await client
+        .workspaceByCwd(gitPollCwd)
+        .workspaceGit({ wait: true });
       gitPollFailed.current = false;
       setGitStatus(status);
     } catch (err) {

--- a/packages/webui/src/daemon/session/mappers.test.ts
+++ b/packages/webui/src/daemon/session/mappers.test.ts
@@ -285,6 +285,49 @@ describe('updateConnectionFromDaemonEvent', () => {
     expect(next).toBe(current);
   });
 
+  it('stores the enriched git status pushed for the current workspace', () => {
+    const next = applyEvent(
+      { status: 'connected', workspaceCwd: '/workspace' },
+      {
+        v: 1,
+        type: 'git_status_changed',
+        data: {
+          v: 2,
+          workspaceCwd: '/workspace',
+          branch: 'main',
+          staged: 2,
+          computedAt: 1_700_000_000_000,
+        },
+      },
+    );
+
+    expect(next.gitStatus).toMatchObject({
+      workspaceCwd: '/workspace',
+      branch: 'main',
+      staged: 2,
+    });
+  });
+
+  it('ignores git status pushes from a previous workspace', () => {
+    const current = {
+      status: 'connected' as const,
+      workspaceCwd: '/workspace/current',
+    };
+
+    const next = applyEvent(current, {
+      v: 1,
+      type: 'git_status_changed',
+      data: {
+        v: 2,
+        workspaceCwd: '/workspace/previous',
+        branch: 'stale-branch',
+        staged: 9,
+      },
+    });
+
+    expect(next).toBe(current);
+  });
+
   it('replaces commands and skills from an available_commands_update', () => {
     const next = applyEvent(
       { status: 'connected', workspaceCwd: '/workspace' },

--- a/packages/webui/src/daemon/session/mappers.ts
+++ b/packages/webui/src/daemon/session/mappers.ts
@@ -10,6 +10,7 @@ import type {
   DaemonEvent,
   DaemonSessionContextStatus,
   DaemonSessionSupportedCommandsStatus,
+  DaemonWorkspaceGitStatus,
   DaemonWorkspaceProvidersStatus,
   DaemonWorkspaceSkillsStatus,
 } from '@qwen-code/sdk/daemon';
@@ -265,6 +266,19 @@ export function updateConnectionFromDaemonEvent(
         workspaceCwd && workspaceCwd !== current.workspaceCwd
           ? current
           : { ...current, gitBranch: branch },
+      );
+      break;
+    }
+    case 'git_status_changed': {
+      const data = getRecord(event.data);
+      const workspaceCwd = getString(data, 'workspaceCwd');
+      setConnection((current) =>
+        workspaceCwd && workspaceCwd !== current.workspaceCwd
+          ? current
+          : {
+              ...current,
+              gitStatus: data as unknown as DaemonWorkspaceGitStatus,
+            },
       );
       break;
     }

--- a/packages/webui/src/daemon/session/types.ts
+++ b/packages/webui/src/daemon/session/types.ts
@@ -33,6 +33,7 @@ import type {
   DaemonShellCommandResult,
   DaemonTranscriptBlock,
   DaemonTranscriptStore,
+  DaemonWorkspaceGitStatus,
   DaemonWorkspaceProvidersStatus,
   HeartbeatResult,
   PermissionResponse,
@@ -62,6 +63,12 @@ export interface DaemonConnectionState {
   workspaceCwd?: string;
   /** Current Git branch, short detached-HEAD hash, or undefined outside Git. */
   gitBranch?: string;
+  /**
+   * Last enriched working-tree summary for the current workspace, pushed by
+   * the daemon via `git_status_changed` (only set when the event's
+   * workspaceCwd matches this connection's workspace).
+   */
+  gitStatus?: DaemonWorkspaceGitStatus;
   commands?: DaemonCommandInfo[];
   skills?: string[];
   models?: DaemonModelInfo[];


### PR DESCRIPTION
## What this PR does

Makes the git branch chip in the Web Shell composer appear almost instantly when opening a new session. The daemon's git-status route now answers from a per-workspace cached summary — recomputed in the background with in-flight dedup and a short throttle, and pushed to clients over SSE only when the summary actually changes — while a new opt-in `wait` query flag preserves the previous blocking behavior for callers that need it. The composer issues both a fast (cached) and a fresh (blocking) request on each refresh; the two share a single daemon-side `git status` computation, so the branch name paints in single-digit milliseconds and the dirty/ahead/behind counters land as soon as the working-tree scan finishes. The fresh request also covers the no-session state (before the first prompt), where no per-session event stream exists and an SSE push alone would never arrive. Sidebar workspace chips explicitly opt into the blocking behavior, and worktree sessions keep their direct, uncached computation.

## Why it's needed

Previously, creating a new session left the composer without a git chip for hundreds of milliseconds to several seconds: every status request synchronously spawned `git status --porcelain` behind the HTTP response (no caching, no dedup), and the chip rendered nothing until the full round trip completed. The branch name alone is available in milliseconds from a lightweight HEAD read with a live reflog watcher, but the response held it hostage to the heavy working-tree computation. On top of that, the same route was hit twice concurrently on connect (session metadata prefetch and the composer effect), spawning two identical git subprocesses.

## Reviewer Test Plan

### How to verify

- Unit tests: daemon git state (cache hit/miss, in-flight dedup, throttle, publish-only-on-change, `wait` semantics, failure keeps cache, dispose suppresses publish), route `wait` flag passthrough, SDK query-string building, webui event mapping (workspace guard), and web-shell composer fast+fresh double fetch plus SSE mirror — all added or updated and green. `npm run build` and `npm run typecheck` are clean.
- Protocol-level E2E against a real daemon (numbers in the E2E comment below): with a cold cache the fast request returns a branch-only body in ~3ms vs ~25ms for the blocking one; a `git_status_changed` event follows on the session event stream; a second fast request serves the enriched cache immediately; touching an untracked file triggers one new push, and a quiet period triggers none.
- Manual: open the Web Shell and start a new session — the branch chip should render immediately with the branch name, with counters appearing shortly after (most visible in a large repository). Sidebar folder chips should still show their counters. Switching branches should still update the chip via the existing live branch event.

### Evidence (Before & After)

Before: new-session composer shows no git chip until a full `git status --porcelain` round trip completes (hundreds of ms on real repositories; up to the 5s subprocess timeout in the worst case). After (protocol timings, clean small repo): fast request returns `{v: 2, workspaceCwd, branch: "main"}` with no enriched fields in 3.3ms, vs 25.5ms for the same request with the blocking flag — and the enriched summary follows via the fresh request / SSE push. In the target scenario (new session in a large working tree) the perceived chip latency drops from the full `git status` duration to one local HTTP round trip.

### Tested on

|     OS     |      Status       |
| :--------: | :---------------: |
|  🍏 macOS  |     ✅ tested     |
| 🪟 Windows | ⚠️ not tested (CI) |
|  🐧 Linux  | ⚠️ not tested (CI) |

### Environment (optional)

Local daemon from the built bundle (`node packages/cli/dist/index.js serve --workspace <repo> --no-web --safe-mode`) with curl timing and a raw SSE subscription; unit tests via per-package vitest runs.

## Risk & Scope

- Main risk or tradeoff: the default (no-flag) route can now return last-known data — branch-only on a cold cache, or a summary that is one background-refresh behind — instead of always blocking for a fresh computation. Every existing caller was audited: the session provider only reads the branch (kept live by the reflog watcher, so it is never stale), the composer is the intended beneficiary, and the sidebar was moved to the blocking flag explicitly. A summary computed while `git status` fails keeps the previous cache and stays silent.
- Not validated / out of scope: browser-level visual assertions (covered by protocol E2E timings plus unit tests instead); worktree sessions intentionally keep the uncached direct computation to avoid leaking one fs watcher per worktree; no daemon warm-up at startup.
- Breaking changes / migration notes: none — the response shape is unchanged (enriched fields were already optional), the `wait` query flag and the `git_status_changed` event are purely additive, and older SDK clients silently drop the unknown event.

## Linked Issues

N/A — raised from direct usage feedback.

<details>
<summary>中文说明</summary>

让 Web Shell 输入框里的 git 分支 chip 在新建会话时几乎立即出现。daemon 的 git status 路由改为从每个工作区的缓存摘要直接应答——后台异步重算（带 in-flight 去重和短节流），且仅在摘要真正变化时通过 SSE 推送给客户端；同时新增可选的 `wait` 查询参数，为需要的调用方保留原来的阻塞语义。composer 每次刷新时并发发出 fast（读缓存）和 fresh（阻塞等新鲜结果）两个请求，二者在 daemon 端共享同一次 `git status` 计算，因此分支名在几毫秒内渲染出来，dirty/ahead/behind 等计数器在工作区扫描完成后立即补齐。fresh 请求还覆盖了无会话状态（首个 prompt 之前）——此时不存在按会话的事件流，仅靠 SSE 推送永远到不了。侧栏工作区 chip 显式选择保留阻塞语义；worktree 会话保持直接计算、不进缓存。

此前，新建会话后 composer 的 git chip 要等几百毫秒到数秒才出现：每个 status 请求都在 HTTP 响应前同步 spawn `git status --porcelain`（无缓存、无去重），chip 在整个往返完成前完全不渲染。分支名本身通过轻量的 HEAD 读取加 reflog watcher 毫秒级可得，却被重量的工作区计算拖住。此外，连接建立时同一路由会被并发打两次（会话元数据预取和 composer effect），spawn 两个相同的 git 子进程。

验证方式：单测覆盖 daemon git state（缓存命中/未命中、in-flight 去重、节流、仅变化才推送、wait 语义、失败保留缓存、dispose 后不再推送）、路由 wait 参数透传、SDK query 拼接、webui 事件映射（workspace 守卫）、web-shell composer 双发与 SSE 镜像，全部新增或更新并通过；`npm run build` 与 `npm run typecheck` 干净。协议级 E2E（真实 daemon，数据见下方 E2E 评论）：冷缓存 fast 请求约 3ms 返回 branch-only，阻塞请求约 25ms；会话事件流随后收到 `git_status_changed`；第二次 fast 请求立即返回 enrich 后的缓存；新增未跟踪文件触发一次新推送，静置期不推送。手动验证：打开 Web Shell 新建会话，chip 应立即显示分支名，计数器随后补齐（大仓库更明显）；侧栏文件夹 chip 计数器不变；切换分支仍能通过既有的分支事件更新 chip。

主要风险：默认（不带参数）路由现在可能返回 last-known 数据（冷缓存时 branch-only，或落后一次后台刷新的摘要），而非总是阻塞等待新鲜计算。已逐一审计所有现存调用方：session provider 只读分支（由 reflog watcher 保持实时，不会过期），composer 是本次优化的服务对象，侧栏已显式改用阻塞参数。`git status` 失败时保留旧缓存且不发事件。未验证/范围外：浏览器级视觉断言（由协议级 E2E 计时和单测覆盖）；worktree 会话有意保持无缓存直接计算（避免每个 worktree 泄漏一个 fs watcher）；无 daemon 启动预热。无破坏性变更：响应形状不变（enriched 字段本就可选），`wait` 参数与 `git_status_changed` 事件均为纯新增，旧版 SDK 客户端会静默丢弃未知事件。

</details>
