### PR TITLE
fix(core): tell the model when the user manually exits plan mode

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -6460,6 +6460,51 @@ describe('setApprovalMode with folder trust', () => {
       expect(config.getApprovalModeRevision()).toBe(initialRevision + 2);
     });
 
+    it('queues a one-shot manual plan-exit notice on a manual exit', () => {
+      const config = new Config(baseParams);
+      vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
+
+      config.setApprovalMode(ApprovalMode.PLAN);
+      config.setApprovalMode(ApprovalMode.DEFAULT);
+
+      expect(config.consumePendingManualPlanExitNotice()).toBe(true);
+      // One-shot: consumed on first read.
+      expect(config.consumePendingManualPlanExitNotice()).toBe(false);
+    });
+
+    it('does not queue the exit notice for an approved plan exit', () => {
+      const config = new Config(baseParams);
+      vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
+
+      config.setApprovalMode(ApprovalMode.PLAN);
+      config.setApprovalMode(ApprovalMode.DEFAULT, {
+        fromApprovedPlanExit: true,
+      });
+
+      expect(config.consumePendingManualPlanExitNotice()).toBe(false);
+    });
+
+    it('clears a stale exit notice when plan mode is re-entered', () => {
+      const config = new Config(baseParams);
+      vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
+
+      config.setApprovalMode(ApprovalMode.PLAN);
+      config.setApprovalMode(ApprovalMode.DEFAULT);
+      config.setApprovalMode(ApprovalMode.PLAN);
+
+      expect(config.consumePendingManualPlanExitNotice()).toBe(false);
+    });
+
+    it('does not queue the exit notice for non-plan mode changes', () => {
+      const config = new Config(baseParams);
+      vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
+
+      config.setApprovalMode(ApprovalMode.AUTO_EDIT);
+      config.setApprovalMode(ApprovalMode.DEFAULT);
+
+      expect(config.consumePendingManualPlanExitNotice()).toBe(false);
+    });
+
     it('records prePlanMode=yolo for a Shift+Tab cycle into plan mode', () => {
       const config = new Config(baseParams);
       vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1761,6 +1761,7 @@ export class Config {
   private approvalMode: ApprovalMode;
   private prePlanMode?: ApprovalMode;
   private approvalModeRevision = 0;
+  private pendingManualPlanExitNotice = false;
   private autoModeDenialState: AutoModeDenialState = createDenialState();
   private readonly accessibility: AccessibilitySettings;
   private readonly showResponseTokensPerSecond: boolean;
@@ -5403,10 +5404,18 @@ export class Config {
 
   setApprovalMode(
     mode: ApprovalMode,
-    /** @deprecated Model origin no longer changes plan-exit approval. */
-    options?: { enteredByModel?: boolean },
+    options?: {
+      /** @deprecated Model origin no longer changes plan-exit approval. */
+      enteredByModel?: boolean;
+      /**
+       * Set by ExitPlanModeTool for user/leader-approved plan exits. Every
+       * other PLAN → non-PLAN transition (Shift+Tab, /approval-mode, /plan,
+       * ACP setSessionMode, confirm-and-switch) is a manual exit the model
+       * was never told about, and queues a one-shot system reminder.
+       */
+      fromApprovedPlanExit?: boolean;
+    },
   ): void {
-    void options;
     if (
       !this.isTrustedFolder() &&
       mode !== ApprovalMode.DEFAULT &&
@@ -5435,8 +5444,18 @@ export class Config {
     // succeeded, so callers never observe a partially applied mode change.
     if (mode === ApprovalMode.PLAN && fromMode !== ApprovalMode.PLAN) {
       this.prePlanMode = fromMode;
+      // A stale exit notice must not survive a re-entry: the plan-mode
+      // reminder takes over again on the next turn.
+      this.pendingManualPlanExitNotice = false;
     } else if (mode !== ApprovalMode.PLAN && fromMode === ApprovalMode.PLAN) {
       this.prePlanMode = undefined;
+      if (!options?.fromApprovedPlanExit) {
+        // While in plan mode the model is told "plan mode is active" on
+        // every turn; on a manual exit that reminder just stops appearing,
+        // which models do not reliably notice (#7671). Queue an explicit
+        // one-shot exit notice for the next turn's reminder assembly.
+        this.pendingManualPlanExitNotice = true;
+      }
     }
     // Any deliberate mode change invalidates the AUTO denialTracking signal.
     if (fromMode !== mode) {
@@ -5446,6 +5465,17 @@ export class Config {
     if (fromMode !== mode) {
       this.approvalModeRevision++;
     }
+  }
+
+  /**
+   * One-shot: returns whether a manual (non-approved) plan-mode exit is
+   * pending model notification, and clears the flag. Consumed by the
+   * system-reminder assembly in `GeminiClient` on the next model-bound turn.
+   */
+  consumePendingManualPlanExitNotice(): boolean {
+    const pending = this.pendingManualPlanExitNotice;
+    this.pendingManualPlanExitNotice = false;
+    return pending;
   }
 
   /**

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -566,6 +566,7 @@ describe('Gemini Client (client.ts)', () => {
       getNoBrowser: vi.fn().mockReturnValue(false),
       getUsageStatisticsEnabled: vi.fn().mockReturnValue(true),
       getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
+      consumePendingManualPlanExitNotice: vi.fn().mockReturnValue(false),
       getSdkMode: vi.fn().mockReturnValue(false),
       getExperimentalZedIntegration: vi.fn().mockReturnValue(false),
       isInteractive: vi.fn().mockReturnValue(false),
@@ -5962,6 +5963,74 @@ hello
         ],
         expect.any(AbortSignal),
       );
+    });
+
+    it('injects a one-shot exit notice after a manual plan-mode exit', async () => {
+      vi.mocked(mockConfig.getApprovalMode).mockReturnValue(
+        ApprovalMode.DEFAULT,
+      );
+      vi.mocked(
+        mockConfig.consumePendingManualPlanExitNotice,
+      ).mockReturnValueOnce(true);
+      const mockStream = (async function* () {
+        yield { type: 'content', value: 'Continuing' };
+      })();
+      mockTurnRunFn.mockReturnValue(mockStream);
+      client['chat'] = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+      } as unknown as GeminiChat;
+
+      const stream = client.sendMessageStream(
+        [{ text: 'Now implement it' }],
+        new AbortController().signal,
+        'prompt-id-manual-plan-exit',
+      );
+      for await (const _ of stream) {
+        // consume stream
+      }
+
+      expect(mockTurnRunFn).toHaveBeenCalledWith(
+        'test-model',
+        expect.arrayContaining([
+          expect.stringContaining(
+            'The user has manually switched out of plan mode',
+          ),
+        ]),
+        expect.any(AbortSignal),
+      );
+    });
+
+    it('does not inject the exit notice when none is pending', async () => {
+      vi.mocked(mockConfig.getApprovalMode).mockReturnValue(
+        ApprovalMode.DEFAULT,
+      );
+      const mockStream = (async function* () {
+        yield { type: 'content', value: 'Reply' };
+      })();
+      mockTurnRunFn.mockReturnValue(mockStream);
+      client['chat'] = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+      } as unknown as GeminiChat;
+
+      const stream = client.sendMessageStream(
+        [{ text: 'Hello' }],
+        new AbortController().signal,
+        'prompt-id-no-plan-exit-notice',
+      );
+      for await (const _ of stream) {
+        // consume stream
+      }
+
+      const requestArg = mockTurnRunFn.mock.calls.at(-1)![1] as string[];
+      expect(
+        requestArg.some(
+          (part) =>
+            typeof part === 'string' &&
+            part.includes('manually switched out of plan mode'),
+        ),
+      ).toBe(false);
     });
 
     it('uses the subagent plan reminder when a subagent inherits PLAN mode', async () => {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -52,6 +52,7 @@ import {
   getArenaSystemReminder,
   getCoreSystemPrompt,
   getCustomSystemPrompt,
+  getManualPlanExitSystemReminder,
   getPlanModeSystemReminder,
   resolveInteractionMode,
 } from './prompts.js';
@@ -2451,6 +2452,15 @@ export class GeminiClient {
               shouldUsePlanOnlyReminderInSubagentContext() ||
                 this.config.getSdkMode(),
             ),
+          );
+        } else if (this.config.consumePendingManualPlanExitNotice()) {
+          // One-shot counterpart to the reminder above: the model was told
+          // "plan mode is active" on every turn, so a manual exit
+          // (Shift+Tab, /approval-mode, /plan) needs an explicit signal —
+          // the reminder silently disappearing goes unnoticed and the
+          // model keeps calling exit_plan_mode (#7671).
+          systemReminders.push(
+            getManualPlanExitSystemReminder(this.config.getApprovalMode()),
           );
         }
 

--- a/packages/core/src/core/prompts.test.ts
+++ b/packages/core/src/core/prompts.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   getCoreSystemPrompt,
   getCustomSystemPrompt,
+  getManualPlanExitSystemReminder,
   getPlanModeSystemReminder,
   resolvePathFromEnv,
   getCompressionPrompt,
@@ -783,6 +784,27 @@ describe('getPlanModeSystemReminder', () => {
     const result2 = getPlanModeSystemReminder();
 
     expect(result1).toBe(result2);
+  });
+});
+
+describe('getManualPlanExitSystemReminder', () => {
+  it('should name the new mode and forbid exit_plan_mode', () => {
+    const result = getManualPlanExitSystemReminder('default');
+
+    expect(result).toMatch(/^<system-reminder>[\s\S]*<\/system-reminder>$/);
+    expect(result).toContain('manually switched out of plan mode');
+    expect(result).toContain('current approval mode: default');
+    expect(result).toContain('Do NOT call exit_plan_mode');
+    expect(result).toContain('no longer apply');
+  });
+
+  it('should render whichever mode the user switched to', () => {
+    expect(getManualPlanExitSystemReminder('yolo')).toContain(
+      'current approval mode: yolo',
+    );
+    expect(getManualPlanExitSystemReminder('auto-edit')).toContain(
+      'current approval mode: auto-edit',
+    );
   });
 });
 

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -1099,6 +1099,22 @@ Your plan is ready when you have addressed all ambiguities and it covers: what t
 }
 
 /**
+ * One-shot reminder injected on the first model-bound turn after the user
+ * manually exits plan mode (Shift+Tab, `/approval-mode`, `/plan`, ACP mode
+ * switch). While plan mode is active {@link getPlanModeSystemReminder} is
+ * re-injected every turn, so on a manual exit the model's most recent
+ * context still says "plan mode is active" — the reminder silently
+ * disappearing is not a signal models reliably notice (#7671).
+ *
+ * @param currentMode - The approval mode the user switched to
+ */
+export function getManualPlanExitSystemReminder(currentMode: string): string {
+  return `<system-reminder>
+The user has manually switched out of plan mode (current approval mode: ${currentMode}). You are no longer in plan mode. Do NOT call ${ToolNames.EXIT_PLAN_MODE} — there is no plan approval pending. Continue working in the current mode; previous plan-mode restrictions on edits and state-modifying tools no longer apply.
+</system-reminder>`;
+}
+
+/**
  * Generates a system reminder about an active Arena session.
  *
  * @param configFilePath - Absolute path to the arena session's `config.json`

--- a/packages/core/src/tools/exitPlanMode.test.ts
+++ b/packages/core/src/tools/exitPlanMode.test.ts
@@ -115,7 +115,9 @@ describe('ExitPlanModeTool', () => {
 
       expect(result.error).toBeUndefined();
       expect(approvalMode).toBe(targetMode);
-      expect(config.setApprovalMode).toHaveBeenCalledWith(targetMode);
+      expect(config.setApprovalMode).toHaveBeenCalledWith(targetMode, {
+        fromApprovedPlanExit: true,
+      });
       expect(config.savePlan).toHaveBeenCalledWith('Approved plan');
     },
   );

--- a/packages/core/src/tools/exitPlanMode.test.ts
+++ b/packages/core/src/tools/exitPlanMode.test.ts
@@ -373,6 +373,35 @@ describe('ExitPlanModeTool', () => {
     expect(config.setApprovalMode).not.toHaveBeenCalled();
   });
 
+  it('marks a successful leader-approved exit as an approved plan exit', async () => {
+    vi.mocked(config.getTeamManager).mockReturnValue({
+      requestPlanApproval: vi.fn(async () => ({
+        action: 'approve',
+        targetMode: ApprovalMode.DEFAULT,
+      })),
+    } as never);
+    const invocation = tool.build({ plan: 'Teammate plan' });
+
+    const result = await runWithTeammateIdentity(
+      {
+        agentId: 'planner@test',
+        agentName: 'planner',
+        teamName: 'test',
+        isTeamLead: false,
+        planModeRequired: true,
+      },
+      () => invocation.execute(new AbortController().signal),
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(approvalMode).toBe(ApprovalMode.DEFAULT);
+    // Must mirror the regular approval call site: without the option, a
+    // leader-approved exit would queue the manual plan-exit reminder.
+    expect(config.setApprovalMode).toHaveBeenCalledWith(ApprovalMode.DEFAULT, {
+      fromApprovedPlanExit: true,
+    });
+  });
+
   it('saves a leader-approved plan when the teammate transition fails', async () => {
     transitionError = new Error('mode locked');
     vi.mocked(config.getTeamManager).mockReturnValue({

--- a/packages/core/src/tools/exitPlanMode.ts
+++ b/packages/core/src/tools/exitPlanMode.ts
@@ -234,7 +234,9 @@ class ExitPlanModeToolInvocation extends BaseToolInvocation<
 
     this.savePlanBestEffort(snapshot.plan);
     try {
-      this.config.setApprovalMode(targetMode);
+      this.config.setApprovalMode(targetMode, {
+        fromApprovedPlanExit: true,
+      });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       debugLogger.error(
@@ -331,7 +333,9 @@ class ExitPlanModeToolInvocation extends BaseToolInvocation<
 
     this.savePlanBestEffort(plan);
     try {
-      this.config.setApprovalMode(decision.targetMode);
+      this.config.setApprovalMode(decision.targetMode, {
+        fromApprovedPlanExit: true,
+      });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       return this.errorResult(


### PR DESCRIPTION
## What this PR does

Tells the model — exactly once — when the user manually exits plan mode. `Config.setApprovalMode()` now queues a one-shot notice on every PLAN → non-PLAN transition except the approved `exit_plan_mode` flow (the tool passes a new `fromApprovedPlanExit` option at its two exit sites); re-entering plan mode clears a stale notice so it can never lie. `GeminiClient`'s per-turn system-reminder assembly consumes the flag in the `else` branch of the existing plan-reminder injection and adds an explicit reminder: "The user has manually switched out of plan mode (current approval mode: …). Do NOT call exit_plan_mode … previous plan-mode restrictions no longer apply." The change stays entirely in core, exactly where the plan-mode reminder itself lives.

## Why it's needed

#7671 (problem 1): the plan-mode reminder is re-injected on **every** model-bound turn while plan mode is active, so after a manual exit (Shift+Tab, `/approval-mode`, `/plan`, ACP mode switch) the reminder just silently stops appearing — a non-signal models don't reliably notice, as doudouOUC's triage note spelled out. The model's most recent context still says plan mode is active, so it keeps calling `exit_plan_mode` and gets stuck. This PR implements the one-shot-flag design from that triage note. It is complementary to #7673, which handles the other half (the unhelpful deny error when `exit_plan_mode` is called anyway) in different files — the two merge independently.

## Reviewer Test Plan

### How to verify

1. Start `qwen --approval-mode plan`, chat once, press Shift+Tab (or `/approval-mode default`), chat again. Before: the next request to the provider carries no signal about the mode change (and the model typically tries `exit_plan_mode`). After: that request carries the one-shot exit reminder naming the new mode, and the following request does not repeat it.
2. Normal plan flow is unchanged: an `exit_plan_mode` approved via the confirmation dialog does not inject the manual-exit reminder.
3. `npx vitest run src/config/config.test.ts src/core/client.test.ts src/tools/exitPlanMode.test.ts` in `packages/core` (744/744).

### Evidence (Before & After)

E2E drives the real compiled CLI in a scripted PTY against a fake OpenAI-compatible server and inspects the actual wire requests; the mode switch is a real Shift+Tab keypress in the TUI. Before/after via `git stash` + rebuild:

![before/after E2E + tests](https://raw.githubusercontent.com/zjunothing/qwen-code/pr-assets-7671/verify-7671.png)

| check (on captured wire requests) | unpatched (origin/main) | patched |
| --- | --- | --- |
| turn in plan mode carries the plan-mode reminder | ✅ | ✅ (unchanged) |
| first turn after Shift+Tab carries the manual-exit notice naming the new mode | ❌ (nothing — reminder just disappears) | ✅ |
| notice is one-shot: not re-injected on the following turn | ❌ (n/a) | ✅ |
| no new plan-mode reminder after the exit | ✅ | ✅ (unchanged) |
| new unit tests (queue on manual exit / suppress on approved exit / clear on re-entry / client injection + negative pin) | fail | ✅ |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS (Darwin 24.6), Node v22.23.1; vitest; scripted PTY + fake OpenAI SSE server for the E2E. `npm run typecheck`, `eslint --max-warnings 0`, `prettier --check` all clean.

## Risk & Scope

- Main risk or tradeoff: `ProceedOnceAndSwitchToDefault` (the "proceed once and switch to default" confirmation choice) also queues the notice when it fires inside plan mode — intentional, since that too is a user-driven exit the model wasn't told about. The notice consumes on the next UserQuery/Cron turn even if that request later fails; worst case the model misses one notice, which is today's behavior on every exit.
- Not validated / out of scope: the context-aware deny message for calling `exit_plan_mode` outside plan mode is #7673; no CLI/UI-layer changes.
- Breaking changes / migration notes: `setApprovalMode`'s options gain an optional `fromApprovedPlanExit` field — additive, existing callers unaffected.

## Linked Issues

Refs #7671 (problem 1; problem 2 is addressed by #7673)

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在用户手动退出 plan mode 时明确告知模型——且只告知一次。`Config.setApprovalMode()` 在每次 PLAN → 非 PLAN 转换时排队一个一次性通知，唯批准的 `exit_plan_mode` 流程除外（该工具在两处退出点传入新的 `fromApprovedPlanExit` 选项）；重新进入 plan mode 会清除过期通知，保证它不会说谎。`GeminiClient` 逐轮的 system-reminder 装配在既有 plan reminder 注入的 `else` 分支消费该标志，注入明确提醒："用户已手动退出 plan mode（当前审批模式：…）。不要调用 exit_plan_mode……此前的 plan mode 限制不再适用。"改动完全在 core 内——正是 plan-mode reminder 本身所在之处。

## 为什么需要

#7671（问题 1）：plan mode 激活期间，plan reminder 在**每一轮**模型请求中重复注入；手动退出（Shift+Tab、`/approval-mode`、`/plan`、ACP 模式切换）后 reminder 只是静默消失——如 doudouOUC 的 triage 笔记所说，这种"无信号"模型不可靠感知。模型最近的上下文仍写着 plan mode 激活，于是反复调用 `exit_plan_mode` 卡死。本 PR 实现了该笔记中的一次性标志设计。与 #7673 互补（后者处理另一半：调用被拒时的无用错误信息），两者改动文件不同、可独立合并。

## 审阅测试计划

### 如何验证

1. `qwen --approval-mode plan` 启动，对话一轮，按 Shift+Tab（或 `/approval-mode default`），再对话：之前下一次请求对模式变更毫无信号（模型通常会尝试 `exit_plan_mode`）；之后该请求携带注明新模式的一次性退出提醒，再下一轮不重复。
2. 正常 plan 流程不变：经确认框批准的 `exit_plan_mode` 不注入手动退出提醒。
3. `packages/core` 下三个测试文件 744/744。

### 证据（Before & After）

E2E 用脚本化 PTY 驱动真实编译 CLI 对接 fake OpenAI 服务器、检查真实 wire 请求；模式切换是真实的 TUI Shift+Tab 按键。`git stash` + 重建对照：未修复时退出后请求无任何信号；修复后一次性注入、后续轮不重复、批准退出不触发。新单测在未修复源码上失败。

### 测试平台

macOS 已本地验证（✅）；Windows / Linux 依赖 CI（⚠️）。

### 环境

macOS（Darwin 24.6）、Node v22.23.1；vitest；E2E 用脚本化 PTY + fake OpenAI SSE server；typecheck / eslint / prettier 全绿。

## 风险与范围

- 主要风险/权衡：plan mode 内触发的 `ProceedOnceAndSwitchToDefault`（"仅此一次并切换到默认模式"）同样排队通知——这是有意的，它也是模型未被告知的用户驱动退出。通知在下一次 UserQuery/Cron 轮消费，即使该请求随后失败也不重放；最坏情况模型错过一次通知，即今天每次退出的现状。
- 未验证/超出范围：plan mode 外调用 `exit_plan_mode` 的上下文化拒绝信息由 #7673 处理；无 CLI/UI 层改动。
- 破坏性变更/迁移说明：`setApprovalMode` 的 options 新增可选 `fromApprovedPlanExit` 字段——纯新增，既有调用方不受影响。

## 关联 Issue

Refs #7671（问题 1；问题 2 由 #7673 处理）

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
