### PR TITLE
fix(ci): don't fail triage cleanup when there is nothing to clean

### DIFF
--- a/.github/scripts/qwen-triage-workflow.test.mjs
+++ b/.github/scripts/qwen-triage-workflow.test.mjs
@@ -122,6 +122,52 @@ describe('qwen-triage: git exec-vector cleanup', () => {
     );
   });
 
+  // Steady-state regression: on a reused runner this step has already
+  // sanitized the config, so the next run's grep matches nothing and exits 1.
+  // Under the Actions default `bash -e` shell plus the script's own
+  // `set -o pipefail`, an unguarded grep killed the whole step exactly when
+  // there was nothing to clean (run 30095456731). The allowlist test below
+  // can't catch this: it re-assembles the pipeline without the shell flags
+  // and always plants non-allowlisted keys. So run the *actual* step script
+  // under the actual flags against the nothing-to-clean state.
+  describe('steady state: nothing to clean (real step script, bash -e)', () => {
+    // The stage-draft cleanup touches a literal /tmp glob; neuter that one
+    // line so the test never deletes files outside its scratch dir.
+    const hermetic = cleanStep.run.replace(/^rm -f \/tmp\/stage-[^\n]*$/m, ':');
+    let dir;
+
+    before(() => {
+      assert.notEqual(hermetic, cleanStep.run, 'stage-draft rm line not found');
+      dir = mkdtempSync(join(tmpdir(), 'triage-steady-'));
+      spawnSync('git', ['-C', dir, 'init', '-q']);
+    });
+
+    after(() => dir && rmSync(dir, { recursive: true, force: true }));
+
+    const runStep = (script) =>
+      spawnSync('bash', ['-e', '-c', script], {
+        cwd: dir,
+        encoding: 'utf8',
+        env: { ...process.env, RUNNER_TEMP: join(dir, 'rt') },
+      });
+
+    it('succeeds when every config key is already allowlisted', () => {
+      const res = runStep(hermetic);
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.match(res.stdout, /stale agent state cleaned/);
+    });
+
+    it('negative control: without the grep guard the same state kills the step', () => {
+      const unguarded = hermetic.replace(' || true; }', '; }');
+      assert.notEqual(
+        unguarded,
+        hermetic,
+        'grep guard (`|| true`) not found in clean step',
+      );
+      assert.notEqual(runStep(unguarded).status, 0);
+    });
+  });
+
   // Behavioral test: run the workflow's *actual* allowlist pattern (extracted
   // from the step) against a scratch repo. Proves the regex both unsets exec
   // vectors and preserves the plumbing actions/checkout needs — a broken

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -264,8 +264,12 @@ jobs:
           # overwrites remote.origin.url, so a planted `ext::` transport URL kept
           # here is replaced before any fetch. --unset-all handles resolved
           # includeIf subsections that --remove-section cannot target.
+          # `|| true` on the grep: no non-allowlisted keys (the steady state
+          # on a reused runner this step already sanitized) means grep exits
+          # 1, and with the default `bash -e` plus pipefail above that would
+          # kill the whole step exactly when there is nothing to clean.
           git config --local --name-only --list 2>/dev/null \
-            | grep -ivE '^(core\.(repositoryformatversion|bare|filemode|symlinks|ignorecase|precomposeunicode|logallrefupdates|worktree|hidedotfiles|protecthfs|protectntfs)|remote\.|branch\.|extensions\.|gc\.|pack\.|fetch\.|index\.|safe\.|submodule\.[^.]+\.(url|active|branch))' \
+            | { grep -ivE '^(core\.(repositoryformatversion|bare|filemode|symlinks|ignorecase|precomposeunicode|logallrefupdates|worktree|hidedotfiles|protecthfs|protectntfs)|remote\.|branch\.|extensions\.|gc\.|pack\.|fetch\.|index\.|safe\.|submodule\.[^.]+\.(url|active|branch))' || true; } \
             | while IFS= read -r key; do git config --local --unset-all "$key" 2>/dev/null || true; done
           HOOKS_DIR="$(git rev-parse --git-path hooks 2>/dev/null || echo .git/hooks)"
           # Match -type f OR -type l: a symlinked hook (e.g. post-checkout ->


### PR DESCRIPTION
## Problem

The triage job on [run 30095456731](https://github.com/QwenLM/qwen-code/actions/runs/30095456731/job/89488379440) (PR #7672) failed in **Clean stale agent state** with exit 1 and no output, before checkout ever ran. The failure has nothing to do with the PR being triaged.

The step sanitizes the persistent workspace's local git config through:

```bash
git config --local --name-only --list 2>/dev/null \
  | grep -ivE '<allowlist>' \
  | while IFS= read -r key; do git config --local --unset-all "$key" ...; done
```

When the config holds **only allowlisted keys**, `grep` matches nothing and exits 1. The step runs under the Actions default `bash -e` shell, and the script's own `set -o pipefail` propagates grep's status through the pipeline — so the step dies silently.

That empty-match state is not an edge case; it is the steady state on a reused runner: a previous run of this very step already stripped everything non-allowlisted, and `actions/checkout`'s post step removes its auth extraheader at job end, leaving only allowlisted plumbing keys (`core.*`, `remote.*`, `branch.*`). In other words, the step fails exactly when there is nothing to clean. Downstream, "Check triage response" then reports the misleading "global CLI install" error, and a re-run landing on the same runner fails the same way.

Reproduction (fresh repo, config = allowlisted keys only):

```
$ bash -e step.sh   # before: exit 1, no output
$ bash -e step.sh   # after:  exit 0, "stale agent state cleaned"
```

## Fix

Guard the grep with `|| true` so an empty match feeds an empty loop instead of failing the job.

Verified that sanitization is unchanged: with `core.pager`, `include.path`, and a `!`-command alias planted, the fixed step still strips all three and exits 0.

## Regression test

The workflow test harness (`qwen-triage-workflow.test.mjs`) missed this because its allowlist test re-assembles the pipeline without the step's shell flags and always plants non-allowlisted keys first. Added a steady-state test that runs the step's **actual script** under `bash -e` against a config holding only allowlisted keys, plus a negative control that strips the guard and demands the step die — red on the unfixed workflow (26/28), green with the fix (28/28).

<details><summary>中文说明</summary>

## 问题

[run 30095456731](https://github.com/QwenLM/qwen-code/actions/runs/30095456731/job/89488379440)(PR #7672)的 triage job 在 **Clean stale agent state** 步骤以 exit 1 失败,无任何输出,checkout 尚未执行。失败与被 triage 的 PR 本身无关。

该步骤通过如下管道清理持久 workspace 的本地 git config:

```bash
git config --local --name-only --list 2>/dev/null \
  | grep -ivE '<allowlist>' \
  | while IFS= read -r key; do git config --local --unset-all "$key" ...; done
```

当 config 中**只剩 allowlist 内的键**时,`grep` 匹配不到任何行,退出码为 1。该步骤运行在 Actions 默认的 `bash -e` shell 下,脚本自身的 `set -o pipefail` 又把 grep 的退出码传播到整条管道——于是步骤静默死亡。

这个"空匹配"并非罕见边界,而是复用 runner 上的稳态:上一次运行的同一步骤已把非 allowlist 键清理干净,`actions/checkout` 的 post 步骤也会在 job 结束时移除 auth extraheader,只剩下 allowlist 内的键(`core.*`、`remote.*`、`branch.*`)。也就是说,**恰恰在没有东西可清理时步骤反而失败**。下游 "Check triage response" 随后报出误导性的 "global CLI install" 错误;re-run 若调度到同一台处于稳态的 runner 会以同样方式再次失败。

复现(全新仓库,config 仅含 allowlist 键):

```
$ bash -e step.sh   # 修复前: exit 1,无输出
$ bash -e step.sh   # 修复后: exit 0,输出 "stale agent state cleaned"
```

## 修复

给 grep 加 `|| true` 兜底,空匹配时向 while 循环输入空内容,而不是让整个 job 失败。

已验证清理行为不变:植入 `core.pager`、`include.path` 和 `!` 命令 alias 后,修复后的步骤仍会全部清除并以 exit 0 结束。

## 回归测试

workflow 测试 harness(`qwen-triage-workflow.test.mjs`)之前没抓到这个 bug:其 allowlist 测试自行重组管道(不带步骤的 shell 标志),且总是先植入非 allowlist 键。本 PR 新增稳态回归测试:在只含 allowlist 键的 config 上以 `bash -e` 运行步骤的**真实脚本**,并附带一个去掉兜底后必须失败的负向对照——未修复的 workflow 下 26/28 红,修复后 28/28 绿。

</details>
