### PR TITLE
feat(triage): stop in-agent CI polling, finalize evidence and approval after CI completes

### DIFF
--- a/.github/workflows/qwen-triage-finalize.yml
+++ b/.github/workflows/qwen-triage-finalize.yml
@@ -61,7 +61,11 @@ jobs:
     name: 'finalize-triage-ci'
     # Only PR-caused CI runs can have triage comments to finalize; push and
     # merge-queue runs are filtered here rather than discovered-empty later.
-    if: "github.event.workflow_run.event == 'pull_request'"
+    # The repository guard is the house convention for bot workflows: a fork
+    # that configured its own CI_BOT_PAT should opt in by editing this line.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.repository == 'QwenLM/qwen-code'
     runs-on: 'ubuntu-latest'
     timeout-minutes: 10
     steps:
@@ -113,6 +117,12 @@ jobs:
           # reviewed-commit footer. Fixed-string matching via index(), never
           # regex.
           replace_region() { # $1 body-in  $2 region-file  $3 body-out
+            # An empty or unreadable region file would delete the region AND
+            # its markers (getline just returns 0), leaving nothing for a
+            # later run to repair — refuse it up front.
+            if [ ! -s "$2" ]; then
+              return 1
+            fi
             if ! grep -qF "$CI_BEGIN" "$1" || ! grep -qF "$CI_END" "$1"; then
               return 1
             fi
@@ -153,15 +163,25 @@ jobs:
                 | @tsv' "$1"
           }
 
-          # Table rows from check-runs: one row per check NAME (latest run
-          # wins — the API default filter=latest only dedups within one check
-          # suite, and every bot event mints a new suite with the same job
-          # names), skipped rows dropped (noise in a table, though still green
-          # for the gate), and still-running + non-green rows sorted FIRST so
-          # the row cap can never truncate a failure into invisibility.
-          table_rows() { # $1 checks-file → TSV: name status conclusion
-            jq -r --arg self "$SELF_CHECK_NAME" '
-              map(select(.name != $self))
+          # Table rows from check-runs, restricted to the SAME universe the
+          # approval gate trusts: only checks whose suite belongs to a deduped
+          # event == "pull_request" workflow run. Without that filter the
+          # table renders bot-orchestration plumbing (route, label, precheck)
+          # as CI evidence and disagrees with the gate about what "CI" means.
+          # Then: one row per check NAME (latest run wins — filter=latest only
+          # dedups within one check suite), skipped rows dropped (noise in a
+          # table, though still green for the gate), and still-running +
+          # non-green rows sorted FIRST so the row cap can never truncate a
+          # failure into invisibility. A check with no readable suite id is
+          # excluded (fail closed toward showing less, never toward blanking —
+          # the caller skips the rewrite entirely when zero rows survive).
+          table_rows() { # $1 checks-file  $2 runs-file → TSV: name status conclusion
+            jq -r --arg self "$SELF_CHECK_NAME" --slurpfile runs "$2" '
+              ([$runs[0][] | select(.event == "pull_request")]
+                 | group_by(.workflow_id) | map(max_by(.id))
+                 | map(.check_suite_id)) as $ok
+                | map(select(.name != $self))
+                | map(select((.check_suite.id // null) as $s | $ok | index($s)))
                 | group_by(.name) | map(max_by(.id))
                 | map(select(.conclusion != "skipped"))
                 | sort_by([ (.status == "completed"),
@@ -220,9 +240,17 @@ jobs:
           # comment limit alongside the rest of the Stage 2 comment; because
           # table_rows sorts running/non-green first, the cap can only ever
           # cut green rows.
-          table_rows /tmp/checks.json > /tmp/rows.tsv
+          table_rows /tmp/checks.json /tmp/runs.json > /tmp/rows.tsv
           ROWS=$(grep -c '' /tmp/rows.tsv || true)
           MAX_ROWS=60
+          REGION_OK=true
+          if [ "${ROWS:-0}" -eq 0 ]; then
+            # Zero surviving rows means "could not read the PR's CI" (failed
+            # runs fetch, missing suite ids), not "there is no CI" — leave the
+            # agent's hand-written table untouched rather than blanking it.
+            echo "::warning::No PR CI table rows for $SHORT_SHA; leaving existing tables untouched."
+            REGION_OK=false
+          fi
           {
             printf '%s\n\n' "$CI_BEGIN"
             if [ "$GATE_OK" = true ] && [ "$PENDING" -eq 0 ]; then
@@ -230,7 +258,7 @@ jobs:
             else
               printf 'CI results for `%s` — this table auto-updates as CI workflows complete:\n\n' "$SHORT_SHA"
             fi
-            printf '| Check | Result |\n| ----- | ------ |\n'
+            printf '| Check | Conclusion |\n| ----- | ---------- |\n'
             head -n "$MAX_ROWS" /tmp/rows.tsv |
               while IFS=$'\t' read -r name status conclusion; do
                 safe_name="$(printf '%s' "$name" | tr -d '\r\n\000' | cut -c1-120 | html_escape)"
@@ -257,9 +285,13 @@ jobs:
 
           # Flip the triage status comment when the deferred approval resolves,
           # so its outcome is visible without opening the Stage 2 table.
-          update_status() { # $1 pr-number  $2 approved|red|stale|deferred
+          update_status() { # $1 pr-number  $2 approved|red|stale|deferred|guarded
             local pr="$1" kind="$2" en zh sid
             case "$kind" in
+              guarded)
+                en="🛡️ **Deferred approval blocked by the fork-refactor guardrail** — a cross-repository refactor PR needs a human maintainer's approval regardless of CI. CI results are in the Stage 2 table. [finalize run](${RUN_URL})"
+                zh="🛡️ **延迟审批被 fork-refactor 护栏拦截** —— 跨仓库的 refactor PR 无论 CI 结果如何都需要人类维护者审批。CI 结果见 Stage 2 表格。[查看 finalize 运行](${RUN_URL})"
+                ;;
               approved)
                 en="✅ **Qwen Triage finished** — CI landed green on \`${SHORT_SHA}\` and the deferred approval was posted. [finalize run](${RUN_URL})"
                 zh="✅ **Qwen Triage 已完成** —— \`${SHORT_SHA}\` 的 CI 全绿，延迟审批已提交。[查看 finalize 运行](${RUN_URL})"
@@ -302,7 +334,9 @@ jobs:
             CID="$(jq -r --arg bot "$BOT_LOGIN" --arg m "$CI_BEGIN" \
               '[.[] | select(.user.login == $bot) | select(.body | contains($m))] | last | .id // empty' \
               "/tmp/comments-$PR.json")"
-            if [ -n "$CID" ]; then
+            if [ -n "$CID" ] && [ "$REGION_OK" != true ]; then
+              echo "PR #$PR: table rewrite skipped (no readable CI rows)."
+            elif [ -n "$CID" ]; then
               jq -r --argjson id "$CID" '.[] | select(.id == $id) | .body' \
                 "/tmp/comments-$PR.json" > /tmp/body-in.md
               if replace_region /tmp/body-in.md /tmp/region.md /tmp/body-out.md; then
@@ -364,6 +398,19 @@ jobs:
               echo "PR #$PR: closed or draft; approval stays withheld."
               continue
             fi
+            # Structural re-assertion of the skill's fork-refactor approval
+            # guardrail. The marker's emission is a prompt-ordering property;
+            # this is not — even a marker that slipped out on a
+            # cross-repository refactor PR never becomes an approval. A
+            # deleted fork repo yields a null head.repo → treated as fork →
+            # blocked (fail closed).
+            IS_FORK="$(jq -r '(.head.repo.full_name // "") != .base.repo.full_name' <<<"$PR_STATE_JSON")"
+            PR_TITLE="$(jq -r '.title // ""' <<<"$PR_STATE_JSON")"
+            if [ "$IS_FORK" != false ] && printf '%s' "$PR_TITLE" | grep -qiE '^[[:space:]]*refactor'; then
+              echo "PR #$PR: fork refactor — approval guardrail blocks the deferred approval."
+              update_status "$PR" guarded
+              continue
+            fi
             # An unavailable gate or an empty run list is "cannot attest", not
             # "nothing failed" — skip without approving.
             if [ "$GATE_OK" != true ] || [ "$TOTAL" -eq 0 ]; then
@@ -386,7 +433,12 @@ jobs:
                 'any(.[][]; .user.login == $bot and .state == "APPROVED" and .commit_id == $sha)')" ||
               ALREADY='false'
             if [ "$ALREADY" = 'true' ]; then
+              # Repair the status comment too: a later firing that saw
+              # PENDING > 0 (a job re-run, a labeled-triggered workflow) may
+              # have flipped it back to "deferred" after the approval landed,
+              # and nothing else would ever set it right again.
               echo "PR #$PR: already approved at $SHORT_SHA."
+              update_status "$PR" approved
               continue
             fi
             gh api "repos/$GITHUB_REPOSITORY/pulls/$PR/reviews" \

--- a/.github/workflows/qwen-triage-finalize.yml
+++ b/.github/workflows/qwen-triage-finalize.yml
@@ -342,9 +342,26 @@ jobs:
             CURRENT_HEAD="$(jq -r '.head.sha' <<<"$PR_STATE_JSON")"
             PR_STATE="$(jq -r '.state' <<<"$PR_STATE_JSON")"
             PR_DRAFT="$(jq -r '.draft' <<<"$PR_STATE_JSON")"
-            if [ "$CURRENT_HEAD" != "$HEAD_SHA" ] || [ "$PR_STATE" != "open" ] || [ "$PR_DRAFT" = "true" ]; then
-              echo "PR #$PR: head moved or PR closed/draft since the review; failing closed."
-              update_status "$PR" stale
+            if [ "$CURRENT_HEAD" != "$HEAD_SHA" ]; then
+              # The status comment is deliberately NOT SHA-scoped (the triage
+              # workflow creates it unscoped, and scoping only this side would
+              # orphan the pairing), so a late firing for an old SHA must not
+              # overwrite the comment once a newer review owns it. Proxy for
+              # ownership: the new head's re-review leaves sha= markers in
+              # bot-authored comments; if they exist, stay silent.
+              NEW_HEAD_MARKED="$(jq -r --arg bot "$BOT_LOGIN" --arg m "sha=${CURRENT_HEAD}" \
+                '[.[] | select(.user.login == $bot) | select(.body | contains($m))] | length' \
+                "/tmp/comments-$PR.json")"
+              if [ "${NEW_HEAD_MARKED:-0}" -gt 0 ] 2>/dev/null; then
+                echo "PR #$PR: head moved to a re-reviewed commit; leaving the status comment to the newer review."
+              else
+                echo "PR #$PR: head moved since the review with no re-review yet; posting the stale note."
+                update_status "$PR" stale
+              fi
+              continue
+            fi
+            if [ "$PR_STATE" != "open" ] || [ "$PR_DRAFT" = "true" ]; then
+              echo "PR #$PR: closed or draft; approval stays withheld."
               continue
             fi
             # An unavailable gate or an empty run list is "cannot attest", not

--- a/.github/workflows/qwen-triage-finalize.yml
+++ b/.github/workflows/qwen-triage-finalize.yml
@@ -1,0 +1,294 @@
+name: 'Qwen Triage Finalize'
+
+# Completes the triage's CI-evidence story after the fact. The triage agent
+# (qwen-triage.yml) reads check-runs ONCE and never sleep-polls: this repo's
+# unit suite alone outlives any reasonable in-agent wait (observed ~32 min vs
+# the old 10-minute poll cap, which therefore always gave up — and once even
+# preceded an approval posted 12 minutes before the suite finished). Instead
+# the Stage 2 comment carries a machine-readable `qwen-triage-ci` region and,
+# when the verdict was approve with checks still pending, an
+# `approve-on-green` marker; this workflow — deterministic bash over the API,
+# no model, no checkout — fires when a CI workflow completes and:
+#   1. rewrites the Stage 2 CI table region in place with the settled results,
+#   2. posts the deferred, commit-pinned approval only when every check on the
+#      reviewed SHA landed green (fail-closed on red checks, a moved head, or
+#      a closed/draft PR), updating the triage status comment either way.
+#
+# Security profile: this run never checks out or executes any code — PR code
+# least of all — and treats every marker as forgeable text: markers are only
+# honored inside comments authored by the bot identity behind the PAT. Check
+# NAMES are attacker-influenced on fork PRs (a PR can add or rename workflows
+# that run on pull_request), so they pass through the same HTML-escape
+# discipline the triage skill mandates for file paths before entering a table.
+on:
+  workflow_run:
+    # The long pole is 'Qwen Code CI' (its Test job is the ~30-minute suite);
+    # 'E2E Tests' is listed so a late E2E finish also converges the table. On
+    # every firing the job re-reads ALL check-runs for the SHA, so multiple
+    # triggers are idempotent — each just renders the then-current state.
+    workflows: ['Qwen Code CI', 'E2E Tests']
+    types: ['completed']
+
+# Writes go through the bot PAT below; the default token stays read-only.
+permissions:
+  contents: 'read'
+
+concurrency:
+  # One finalize at a time per head SHA: concurrent completions (CI + E2E)
+  # would read-modify-write the same comment. cancel-in-progress: false — the
+  # queued run re-reads fresh state, so the last one always converges.
+  group: 'qwen-triage-finalize-${{ github.event.workflow_run.head_sha }}'
+  cancel-in-progress: false
+
+jobs:
+  finalize:
+    # This job's own check-run attaches to the SAME head SHA as the triggering
+    # workflow, so every green/pending computation below excludes this exact
+    # name — otherwise the run could never observe itself "complete".
+    name: 'finalize-triage-ci'
+    # Only PR-caused CI runs can have triage comments to finalize; push and
+    # merge-queue runs are filtered here rather than discovered-empty later.
+    if: "github.event.workflow_run.event == 'pull_request'"
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 10
+    steps:
+      - name: 'Finalize CI evidence and deferred approval'
+        shell: 'bash'
+        env:
+          GH_TOKEN: '${{ secrets.QWEN_CODE_BOT_TOKEN || secrets.CI_BOT_PAT }}'
+          HEAD_SHA: '${{ github.event.workflow_run.head_sha }}'
+          RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+          SELF_CHECK_NAME: 'finalize-triage-ci'
+        run: |-
+          set -uo pipefail
+
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::notice::No bot token configured (fork?); skipping triage finalize."
+            exit 0
+          fi
+          SHORT_SHA="${HEAD_SHA:0:7}"
+
+          # Markers are matched as FIXED STRINGS everywhere (grep -F, awk
+          # index(), jq contains) — never as regex over untrusted text. The
+          # sha= binding is what stops this run from touching a table or
+          # honoring an approval that belongs to a commit its CI didn't cover.
+          CI_BEGIN="<!-- qwen-triage-ci sha=${HEAD_SHA} -->"
+          CI_END='<!-- /qwen-triage-ci -->'
+          APPROVE_MARKER="<!-- qwen-triage approve-on-green sha=${HEAD_SHA} -->"
+          STATUS_MARKER='<!-- qwen-triage stage=status -->'
+
+          if ! BOT_LOGIN="$(gh api user --jq '.login')" || [ -z "$BOT_LOGIN" ]; then
+            echo "::warning::Cannot resolve the bot identity; skipping (markers cannot be author-verified)."
+            exit 0
+          fi
+
+          # Same escape chain as the triage skill's sanitize_path: & FIRST
+          # (later escapes would double-encode), then everything that could
+          # break out of a <code> cell or fire Markdown/@mentions.
+          html_escape() {
+            sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' \
+              -e 's/`/\&#96;/g' -e 's/|/\&#124;/g' -e 's/@/\&#64;/g' \
+              -e 's/\[/\&#91;/g' -e 's/\]/\&#93;/g' -e 's/(/\&#40;/g' -e 's/)/\&#41;/g' -e 's/\*/\&#42;/g'
+          }
+
+          # Replace everything between (and including) the region markers with
+          # the contents of the region file. Fail-closed: if either marker is
+          # missing the body is left untouched — never blank a comment this
+          # run cannot parse. Fixed-string matching via index(), not regex.
+          replace_region() { # $1 body-in  $2 region-file  $3 body-out
+            if ! grep -qF "$CI_BEGIN" "$1" || ! grep -qF "$CI_END" "$1"; then
+              return 1
+            fi
+            awk -v begin="$CI_BEGIN" -v end="$CI_END" -v rfile="$2" '
+              index($0, begin) && !inr {
+                inr = 1
+                while ((getline line < rfile) > 0) print line
+                close(rfile)
+                next
+              }
+              inr && index($0, end) { inr = 0; next }
+              inr { next }
+              { print }
+            ' "$1" > "$3"
+          }
+          # --- end triage-finalize helpers ---
+
+          # Open PRs whose current head is this SHA. (workflow_run carries
+          # pull_requests only for same-repo PRs; the commits/:sha/pulls
+          # association works for fork PRs too.)
+          PR_NUMBERS="$(
+            gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/pulls?per_page=100" --paginate \
+              --jq '.[] | select(.state == "open") | .number'
+          )" || PR_NUMBERS=''
+          if [ -z "$PR_NUMBERS" ]; then
+            echo "No open PR for $SHORT_SHA; nothing to finalize."
+            exit 0
+          fi
+
+          # One check-runs fetch for the SHA. filter=latest (the API default)
+          # collapses re-runs to the newest attempt per check name; --paginate
+          # emits one array per page, so jq -s 'add' flattens them (this repo
+          # has hit 500+ checks on a commit). Then drop our own check.
+          if ! gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/check-runs?per_page=100" --paginate \
+            --jq '.check_runs' | jq -s 'add // []' > /tmp/checks-raw.json; then
+            echo "::warning::check-runs fetch failed; skipping."
+            exit 0
+          fi
+          jq --arg self "$SELF_CHECK_NAME" '[ .[] | select(.name != $self) ]' \
+            /tmp/checks-raw.json > /tmp/checks.json
+
+          TOTAL=$(jq 'length' /tmp/checks.json)
+          PENDING=$(jq '[.[] | select(.status != "completed")] | length' /tmp/checks.json)
+          # Green means success, neutral, or skipped. failure / timed_out /
+          # cancelled / action_required / anything unknown is NOT green — the
+          # deferred approval fails closed on all of them.
+          RED=$(jq '[.[] | select(.status == "completed")
+            | select(["success","neutral","skipped"] | index(.conclusion // "") | not)] | length' /tmp/checks.json)
+          echo "Checks for $SHORT_SHA: total=$TOTAL pending=$PENDING non-green=$RED"
+          # Render the replacement region once; it is identical for every PR
+          # carrying this SHA. Row cap keeps the table inside GitHub's ~65 KB
+          # comment limit alongside the rest of the Stage 2 comment.
+          MAX_ROWS=60
+          {
+            printf '%s\n\n' "$CI_BEGIN"
+            if [ "$PENDING" -eq 0 ]; then
+              printf 'Final CI results for `%s` — auto-updated after CI completed ([finalize run](%s)):\n\n' "$SHORT_SHA" "$RUN_URL"
+            else
+              printf 'CI results for `%s` — %s check(s) still running; this table auto-updates as CI workflows complete ([finalize run](%s)):\n\n' "$SHORT_SHA" "$PENDING" "$RUN_URL"
+            fi
+            printf '| Check | Result |\n| ----- | ------ |\n'
+            jq -r '.[] | [.name, .status, (.conclusion // "")] | @tsv' /tmp/checks.json |
+              sort -f | head -n "$MAX_ROWS" |
+              while IFS=$'\t' read -r name status conclusion; do
+                safe_name="$(printf '%s' "$name" | tr -d '\r\n\000' | cut -c1-120 | html_escape)"
+                if [ "$status" != "completed" ]; then
+                  result='⏳ running'
+                else
+                  case "$conclusion" in
+                    success) result='✅ success' ;;
+                    skipped) result='⏭️ skipped' ;;
+                    neutral) result='◽ neutral' ;;
+                    failure) result='❌ failure' ;;
+                    cancelled) result='🚫 cancelled' ;;
+                    timed_out) result='⏱️ timed out' ;;
+                    *) result="⚠️ $(printf '%s' "$conclusion" | tr -d '\r\n\000' | cut -c1-40 | html_escape)" ;;
+                  esac
+                fi
+                printf '| <code>%s</code> | %s |\n' "$safe_name" "$result"
+              done
+            if [ "$TOTAL" -gt "$MAX_ROWS" ]; then
+              printf '| …and %s more checks | see the Checks tab |\n' "$((TOTAL - MAX_ROWS))"
+            fi
+            printf '\n<sub>Auto-updated by the triage finalize job after CI completion. / 此表由 finalize 任务在 CI 完成后自动更新。</sub>\n\n'
+            printf '%s\n' "$CI_END"
+          } > /tmp/region.md
+
+          # Flip the triage status comment when the deferred approval resolves,
+          # so its outcome is visible without opening the Stage 2 table.
+          update_status() { # $1 pr-number  $2 approved|red|stale
+            local pr="$1" kind="$2" en zh sid
+            case "$kind" in
+              approved)
+                en="✅ **Qwen Triage finished** — CI landed green on \`${SHORT_SHA}\` and the deferred approval was posted. [finalize run](${RUN_URL})"
+                zh="✅ **Qwen Triage 已完成** —— \`${SHORT_SHA}\` 的 CI 全绿，延迟审批已提交。[查看 finalize 运行](${RUN_URL})"
+                ;;
+              red)
+                en="⚠️ **Deferred approval withheld** — CI finished with ${RED} non-green check(s) on \`${SHORT_SHA}\`; see the updated table in the Stage 2 comment. Re-run \`@qwen-code /triage\` after fixes. [finalize run](${RUN_URL})"
+                zh="⚠️ **延迟审批已搁置** —— \`${SHORT_SHA}\` 的 CI 有 ${RED} 项检查未通过，详见 Stage 2 评论中已更新的表格。修复后可重新运行 \`@qwen-code /triage\`。[查看 finalize 运行](${RUN_URL})"
+                ;;
+              stale)
+                en="⚠️ **Deferred approval not posted** — the PR head moved (or the PR closed) after the review of \`${SHORT_SHA}\`; approving now would attest to unreviewed code. Re-run \`@qwen-code /triage\` on the new head. [finalize run](${RUN_URL})"
+                zh="⚠️ **延迟审批未提交** —— 审查 \`${SHORT_SHA}\` 之后 PR head 已变更（或 PR 已关闭），此时审批会为未审查的代码背书。请在新 head 上重新运行 \`@qwen-code /triage\`。[查看 finalize 运行](${RUN_URL})"
+                ;;
+              *) return 0 ;;
+            esac
+            sid="$(jq -r --arg bot "$BOT_LOGIN" --arg m "$STATUS_MARKER" \
+              '[.[] | select(.user.login == $bot) | select(.body | contains($m))] | last | .id // empty' \
+              "/tmp/comments-$pr.json")"
+            [ -n "$sid" ] || return 0
+            printf '%s\n\n%s\n\n%s' "$STATUS_MARKER" "$en" "$zh" > /tmp/status-body.md
+            gh api --method PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$sid" \
+              -F body=@/tmp/status-body.md >/dev/null ||
+              echo "::warning::Failed to update the status comment on PR #$pr."
+          }
+
+          for PR in $PR_NUMBERS; do
+            if ! gh api "repos/$GITHUB_REPOSITORY/issues/$PR/comments" \
+              --method GET --paginate -F per_page=100 |
+              jq -s '[.[][]]' > "/tmp/comments-$PR.json"; then
+              echo "::warning::Comment listing failed for PR #$PR; skipping it."
+              continue
+            fi
+
+            # 1. CI table upsert — only in a comment the BOT authored that
+            # carries the region for THIS sha (a forged marker in a
+            # third-party comment is ignored by the author filter).
+            CID="$(jq -r --arg bot "$BOT_LOGIN" --arg m "$CI_BEGIN" \
+              '[.[] | select(.user.login == $bot) | select(.body | contains($m))] | last | .id // empty' \
+              "/tmp/comments-$PR.json")"
+            if [ -n "$CID" ]; then
+              jq -r --argjson id "$CID" '.[] | select(.id == $id) | .body' \
+                "/tmp/comments-$PR.json" > /tmp/body-in.md
+              if replace_region /tmp/body-in.md /tmp/region.md /tmp/body-out.md; then
+                if cmp -s /tmp/body-in.md /tmp/body-out.md; then
+                  echo "PR #$PR: CI table already current."
+                else
+                  gh api --method PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$CID" \
+                    -F body=@/tmp/body-out.md >/dev/null &&
+                    echo "PR #$PR: CI table updated (comment $CID)." ||
+                    echo "::warning::Failed to update the CI table on PR #$PR."
+                fi
+              else
+                echo "::warning::CI region end marker missing in comment $CID; leaving it untouched."
+              fi
+            else
+              echo "PR #$PR: no bot CI region for $SHORT_SHA."
+            fi
+
+            # 2. Deferred approval — marker must sit in a BOT-authored comment
+            # and bind this exact sha.
+            HAS_MARKER="$(jq -r --arg bot "$BOT_LOGIN" --arg m "$APPROVE_MARKER" \
+              '[.[] | select(.user.login == $bot) | select(.body | contains($m))] | length' \
+              "/tmp/comments-$PR.json")"
+            [ "$HAS_MARKER" -gt 0 ] || continue
+            if [ "$PENDING" -gt 0 ]; then
+              echo "PR #$PR: $PENDING check(s) still running; approval stays deferred."
+              continue
+            fi
+            if [ "$RED" -gt 0 ]; then
+              echo "PR #$PR: $RED non-green check(s); approval withheld."
+              update_status "$PR" red
+              continue
+            fi
+            # All green — re-verify head and state at the last moment. The
+            # approval is pinned to HEAD_SHA either way (branch protection
+            # ignores an approval whose commit is no longer the head), but a
+            # moved head means the review is stale, so say so instead of
+            # silently doing nothing.
+            if ! PR_STATE_JSON="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR")"; then
+              echo "::warning::Cannot read PR #$PR state; approval stays deferred."
+              continue
+            fi
+            CURRENT_HEAD="$(jq -r '.head.sha' <<<"$PR_STATE_JSON")"
+            PR_STATE="$(jq -r '.state' <<<"$PR_STATE_JSON")"
+            PR_DRAFT="$(jq -r '.draft' <<<"$PR_STATE_JSON")"
+            if [ "$CURRENT_HEAD" != "$HEAD_SHA" ] || [ "$PR_STATE" != "open" ] || [ "$PR_DRAFT" = "true" ]; then
+              echo "PR #$PR: head moved or PR closed/draft since the review; failing closed."
+              update_status "$PR" stale
+              continue
+            fi
+            ALREADY="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR/reviews" \
+              --method GET --paginate -F per_page=100 |
+              jq -s --arg bot "$BOT_LOGIN" --arg sha "$HEAD_SHA" \
+                'any(.[][]; .user.login == $bot and .state == "APPROVED" and .commit_id == $sha)')" ||
+              ALREADY='false'
+            if [ "$ALREADY" = 'true' ]; then
+              echo "PR #$PR: already approved at $SHORT_SHA."
+              continue
+            fi
+            gh api "repos/$GITHUB_REPOSITORY/pulls/$PR/reviews" \
+              -f commit_id="$HEAD_SHA" -f event=APPROVE \
+              -f body='LGTM, looks ready to ship — CI landed green after the review. ✅' >/dev/null &&
+              { echo "PR #$PR: deferred approval posted at $SHORT_SHA."; update_status "$PR" approved; } ||
+              echo "::warning::Deferred approval failed for PR #$PR."
+          done

--- a/.github/workflows/qwen-triage-finalize.yml
+++ b/.github/workflows/qwen-triage-finalize.yml
@@ -22,11 +22,21 @@ name: 'Qwen Triage Finalize'
 # discipline the triage skill mandates for file paths before entering a table.
 on:
   workflow_run:
-    # The long pole is 'Qwen Code CI' (its Test job is the ~30-minute suite);
-    # 'E2E Tests' is listed so a late E2E finish also converges the table. On
-    # every firing the job re-reads ALL check-runs for the SHA, so multiple
-    # triggers are idempotent — each just renders the then-current state.
-    workflows: ['Qwen Code CI', 'E2E Tests']
+    # Every workflow with a `pull_request` trigger must be listed: the deferred
+    # approval can only land on a firing that happens AFTER the last PR CI run
+    # completes, so whichever workflow finishes last has to be in this list.
+    # The long pole is 'Qwen Code CI' (its Test job is the ~30-minute suite),
+    # but path-filtered PRs can make any of the others the final finisher.
+    # E2E Tests is deliberately absent — it has no pull_request trigger (push /
+    # schedule / dispatch only), so listing it would only add dead firings.
+    # Every firing re-reads current state, so multiple triggers are idempotent.
+    workflows:
+      - 'Qwen Code CI'
+      - 'Qwen Autofix'
+      - 'SDK Java'
+      - 'SDK Python'
+      - 'Serve A/B'
+      - 'Web-shell Visuals'
     types: ['completed']
 
 # Writes go through the bot PAT below; the default token stays read-only.
@@ -42,9 +52,12 @@ concurrency:
 
 jobs:
   finalize:
-    # This job's own check-run attaches to the SAME head SHA as the triggering
-    # workflow, so every green/pending computation below excludes this exact
-    # name — otherwise the run could never observe itself "complete".
+    # workflow_run jobs are attributed to the default branch, so this job's
+    # check-run does not normally land on the PR head SHA (verified: other
+    # workflow_run jobs in this repo never appear in head-SHA check lists).
+    # The name is still excluded from the rendered table as belt-and-braces,
+    # and the approval gate reads workflow runs filtered to
+    # event == pull_request, which excludes this job structurally.
     name: 'finalize-triage-ci'
     # Only PR-caused CI runs can have triage comments to finalize; push and
     # merge-queue runs are filtered here rather than discovered-empty later.
@@ -63,7 +76,7 @@ jobs:
           set -uo pipefail
 
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::notice::No bot token configured (fork?); skipping triage finalize."
+            echo "::notice::No bot token configured; skipping triage finalize."
             exit 0
           fi
           SHORT_SHA="${HEAD_SHA:0:7}"
@@ -93,8 +106,12 @@ jobs:
 
           # Replace everything between (and including) the region markers with
           # the contents of the region file. Fail-closed: if either marker is
-          # missing the body is left untouched — never blank a comment this
-          # run cannot parse. Fixed-string matching via index(), not regex.
+          # missing — or the region never closes because the "end" text only
+          # appears BEFORE the begin marker (grep proves existence, not order)
+          # — the exit code is non-zero and the caller leaves the comment
+          # untouched; a truncated PATCH would eat the signature and the
+          # reviewed-commit footer. Fixed-string matching via index(), never
+          # regex.
           replace_region() { # $1 body-in  $2 region-file  $3 body-out
             if ! grep -qF "$CI_BEGIN" "$1" || ! grep -qF "$CI_END" "$1"; then
               return 1
@@ -109,7 +126,48 @@ jobs:
               inr && index($0, end) { inr = 0; next }
               inr { next }
               { print }
+              END { if (inr) exit 1 }
             ' "$1" > "$3"
+          }
+
+          # Approval-gate counts, computed over WORKFLOW RUNS for the head SHA
+          # filtered to event == "pull_request" — the PR's own CI, nothing
+          # else. Bot orchestration runs (pull_request_target / issue_comment
+          # jobs like triage or review-pr) also attach check-runs to the head
+          # SHA and can run long after CI finishes; counting those would hold
+          # PENDING above zero at the moment the last CI workflow completes,
+          # after which no listed workflow ever fires again and the deferred
+          # approval would be dropped silently. Re-runs dedup per workflow
+          # (latest run wins, mirroring branch-protection semantics). A jq
+          # failure yields empty output, which the numeric validation at the
+          # call site turns into "skip approval", never "approve".
+          gate_counts() { # $1 runs-file → TSV: total pending red
+            jq -r '
+              [ .[] | select(.event == "pull_request") ]
+                | group_by(.workflow_id) | map(max_by(.id))
+                | [ length,
+                    (map(select(.status != "completed")) | length),
+                    (map(select(.status == "completed")
+                       | select((.conclusion // "") | IN("success","neutral","skipped") | not))
+                     | length) ]
+                | @tsv' "$1"
+          }
+
+          # Table rows from check-runs: one row per check NAME (latest run
+          # wins — the API default filter=latest only dedups within one check
+          # suite, and every bot event mints a new suite with the same job
+          # names), skipped rows dropped (noise in a table, though still green
+          # for the gate), and still-running + non-green rows sorted FIRST so
+          # the row cap can never truncate a failure into invisibility.
+          table_rows() { # $1 checks-file → TSV: name status conclusion
+            jq -r --arg self "$SELF_CHECK_NAME" '
+              map(select(.name != $self))
+                | group_by(.name) | map(max_by(.id))
+                | map(select(.conclusion != "skipped"))
+                | sort_by([ (.status == "completed"),
+                            ((.conclusion // "") | IN("success","neutral")),
+                            (.name | ascii_downcase) ])
+                | .[] | [.name, .status, (.conclusion // "")] | @tsv' "$1"
           }
           # --- end triage-finalize helpers ---
 
@@ -125,40 +183,55 @@ jobs:
             exit 0
           fi
 
-          # One check-runs fetch for the SHA. filter=latest (the API default)
-          # collapses re-runs to the newest attempt per check name; --paginate
-          # emits one array per page, so jq -s 'add' flattens them (this repo
-          # has hit 500+ checks on a commit). Then drop our own check.
+          # Check-runs power the TABLE only; the approval gate reads workflow
+          # runs below. --paginate emits one array per page, so jq -s 'add'
+          # flattens them (this repo has hit 500+ checks on a commit).
           if ! gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/check-runs?per_page=100" --paginate \
-            --jq '.check_runs' | jq -s 'add // []' > /tmp/checks-raw.json; then
+            --jq '.check_runs' | jq -s 'add // []' > /tmp/checks.json; then
             echo "::warning::check-runs fetch failed; skipping."
             exit 0
           fi
-          jq --arg self "$SELF_CHECK_NAME" '[ .[] | select(.name != $self) ]' \
-            /tmp/checks-raw.json > /tmp/checks.json
 
-          TOTAL=$(jq 'length' /tmp/checks.json)
-          PENDING=$(jq '[.[] | select(.status != "completed")] | length' /tmp/checks.json)
-          # Green means success, neutral, or skipped. failure / timed_out /
+          # Workflow runs for the head SHA — the approval gate's data source.
+          # Green means success, neutral, or skipped; failure / timed_out /
           # cancelled / action_required / anything unknown is NOT green — the
           # deferred approval fails closed on all of them.
-          RED=$(jq '[.[] | select(.status == "completed")
-            | select(["success","neutral","skipped"] | index(.conclusion // "") | not)] | length' /tmp/checks.json)
-          echo "Checks for $SHORT_SHA: total=$TOTAL pending=$PENDING non-green=$RED"
+          if ! gh api "repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$HEAD_SHA&per_page=100" --paginate \
+            --jq '.workflow_runs' | jq -s 'add // []' > /tmp/runs.json; then
+            echo "::warning::workflow-runs fetch failed; tables may still update, approval is skipped."
+            printf '[]' > /tmp/runs.json
+          fi
+          GATE_OK=true
+          IFS=$'\t' read -r TOTAL PENDING RED < <(gate_counts /tmp/runs.json) || true
+          # A jq failure (or an API shape change) must read as "cannot attest",
+          # never as "nothing is red": non-numeric counters skip the approval.
+          case "${TOTAL:-}${PENDING:-}${RED:-}" in
+            '' | *[!0-9]*)
+              echo "::warning::Gate counts unavailable (total='${TOTAL:-}' pending='${PENDING:-}' red='${RED:-}'); approval is skipped."
+              GATE_OK=false
+              TOTAL=0 PENDING=0 RED=0
+              ;;
+          esac
+          echo "PR CI workflow runs for $SHORT_SHA: total=$TOTAL pending=$PENDING non-green=$RED gate_ok=$GATE_OK"
           # Render the replacement region once; it is identical for every PR
-          # carrying this SHA. Row cap keeps the table inside GitHub's ~65 KB
-          # comment limit alongside the rest of the Stage 2 comment.
+          # carrying this SHA, and deterministic for a given check state (no
+          # run links or timestamps inside), so the cmp below really can skip
+          # no-op PATCHes. Row cap keeps the table inside GitHub's ~65 KB
+          # comment limit alongside the rest of the Stage 2 comment; because
+          # table_rows sorts running/non-green first, the cap can only ever
+          # cut green rows.
+          table_rows /tmp/checks.json > /tmp/rows.tsv
+          ROWS=$(grep -c '' /tmp/rows.tsv || true)
           MAX_ROWS=60
           {
             printf '%s\n\n' "$CI_BEGIN"
-            if [ "$PENDING" -eq 0 ]; then
-              printf 'Final CI results for `%s` — auto-updated after CI completed ([finalize run](%s)):\n\n' "$SHORT_SHA" "$RUN_URL"
+            if [ "$GATE_OK" = true ] && [ "$PENDING" -eq 0 ]; then
+              printf 'Final CI results for `%s` (auto-updated by the triage finalize job after CI completed):\n\n' "$SHORT_SHA"
             else
-              printf 'CI results for `%s` — %s check(s) still running; this table auto-updates as CI workflows complete ([finalize run](%s)):\n\n' "$SHORT_SHA" "$PENDING" "$RUN_URL"
+              printf 'CI results for `%s` — this table auto-updates as CI workflows complete:\n\n' "$SHORT_SHA"
             fi
             printf '| Check | Result |\n| ----- | ------ |\n'
-            jq -r '.[] | [.name, .status, (.conclusion // "")] | @tsv' /tmp/checks.json |
-              sort -f | head -n "$MAX_ROWS" |
+            head -n "$MAX_ROWS" /tmp/rows.tsv |
               while IFS=$'\t' read -r name status conclusion; do
                 safe_name="$(printf '%s' "$name" | tr -d '\r\n\000' | cut -c1-120 | html_escape)"
                 if [ "$status" != "completed" ]; then
@@ -166,7 +239,6 @@ jobs:
                 else
                   case "$conclusion" in
                     success) result='✅ success' ;;
-                    skipped) result='⏭️ skipped' ;;
                     neutral) result='◽ neutral' ;;
                     failure) result='❌ failure' ;;
                     cancelled) result='🚫 cancelled' ;;
@@ -176,16 +248,16 @@ jobs:
                 fi
                 printf '| <code>%s</code> | %s |\n' "$safe_name" "$result"
               done
-            if [ "$TOTAL" -gt "$MAX_ROWS" ]; then
-              printf '| …and %s more checks | see the Checks tab |\n' "$((TOTAL - MAX_ROWS))"
+            if [ "$ROWS" -gt "$MAX_ROWS" ]; then
+              printf '| …and %s more checks | see the Checks tab |\n' "$((ROWS - MAX_ROWS))"
             fi
-            printf '\n<sub>Auto-updated by the triage finalize job after CI completion. / 此表由 finalize 任务在 CI 完成后自动更新。</sub>\n\n'
+            printf '\n<sub>One row per check name (latest run); skipped checks omitted; failures sort first. / 每个检查名一行（取最新一次运行），省略 skipped，失败项排在最前。</sub>\n\n'
             printf '%s\n' "$CI_END"
           } > /tmp/region.md
 
           # Flip the triage status comment when the deferred approval resolves,
           # so its outcome is visible without opening the Stage 2 table.
-          update_status() { # $1 pr-number  $2 approved|red|stale
+          update_status() { # $1 pr-number  $2 approved|red|stale|deferred
             local pr="$1" kind="$2" en zh sid
             case "$kind" in
               approved)
@@ -193,8 +265,12 @@ jobs:
                 zh="✅ **Qwen Triage 已完成** —— \`${SHORT_SHA}\` 的 CI 全绿，延迟审批已提交。[查看 finalize 运行](${RUN_URL})"
                 ;;
               red)
-                en="⚠️ **Deferred approval withheld** — CI finished with ${RED} non-green check(s) on \`${SHORT_SHA}\`; see the updated table in the Stage 2 comment. Re-run \`@qwen-code /triage\` after fixes. [finalize run](${RUN_URL})"
-                zh="⚠️ **延迟审批已搁置** —— \`${SHORT_SHA}\` 的 CI 有 ${RED} 项检查未通过，详见 Stage 2 评论中已更新的表格。修复后可重新运行 \`@qwen-code /triage\`。[查看 finalize 运行](${RUN_URL})"
+                en="⚠️ **Deferred approval withheld** — ${RED} PR CI workflow run(s) on \`${SHORT_SHA}\` did not finish green; see the updated table in the Stage 2 comment. Re-run \`@qwen-code /triage\` after fixes. [finalize run](${RUN_URL})"
+                zh="⚠️ **延迟审批已搁置** —— \`${SHORT_SHA}\` 有 ${RED} 个 PR CI workflow 未以绿色完成，详见 Stage 2 评论中已更新的表格。修复后可重新运行 \`@qwen-code /triage\`。[查看 finalize 运行](${RUN_URL})"
+                ;;
+              deferred)
+                en="⏳ **Approval still deferred** — ${PENDING} PR CI workflow run(s) still in progress for \`${SHORT_SHA}\`; the finalize job approves automatically once every run lands green. [finalize run](${RUN_URL})"
+                zh="⏳ **审批仍在延迟中** —— \`${SHORT_SHA}\` 还有 ${PENDING} 个 PR CI workflow 在运行，全部通过后 finalize 任务会自动提交审批。[查看 finalize 运行](${RUN_URL})"
                 ;;
               stale)
                 en="⚠️ **Deferred approval not posted** — the PR head moved (or the PR closed) after the review of \`${SHORT_SHA}\`; approving now would attest to unreviewed code. Re-run \`@qwen-code /triage\` on the new head. [finalize run](${RUN_URL})"
@@ -251,20 +327,14 @@ jobs:
               '[.[] | select(.user.login == $bot) | select(.body | contains($m))] | length' \
               "/tmp/comments-$PR.json")"
             [ "$HAS_MARKER" -gt 0 ] || continue
-            if [ "$PENDING" -gt 0 ]; then
-              echo "PR #$PR: $PENDING check(s) still running; approval stays deferred."
-              continue
-            fi
-            if [ "$RED" -gt 0 ]; then
-              echo "PR #$PR: $RED non-green check(s); approval withheld."
-              update_status "$PR" red
-              continue
-            fi
-            # All green — re-verify head and state at the last moment. The
-            # approval is pinned to HEAD_SHA either way (branch protection
-            # ignores an approval whose commit is no longer the head), but a
-            # moved head means the review is stale, so say so instead of
-            # silently doing nothing.
+            # Head/state re-check comes BEFORE any red/deferred verdict: CI's
+            # cancel-in-progress means a force-push fires this job on the
+            # now-stale SHA with a `cancelled` (non-green) run, and the status
+            # comment is not SHA-scoped — deciding red first would stamp a
+            # stale verdict over the comment that now belongs to the new
+            # head's review. The approval is pinned to HEAD_SHA either way
+            # (branch protection ignores an approval whose commit is no longer
+            # the head); the stale note keeps the outcome visible.
             if ! PR_STATE_JSON="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR")"; then
               echo "::warning::Cannot read PR #$PR state; approval stays deferred."
               continue
@@ -275,6 +345,22 @@ jobs:
             if [ "$CURRENT_HEAD" != "$HEAD_SHA" ] || [ "$PR_STATE" != "open" ] || [ "$PR_DRAFT" = "true" ]; then
               echo "PR #$PR: head moved or PR closed/draft since the review; failing closed."
               update_status "$PR" stale
+              continue
+            fi
+            # An unavailable gate or an empty run list is "cannot attest", not
+            # "nothing failed" — skip without approving.
+            if [ "$GATE_OK" != true ] || [ "$TOTAL" -eq 0 ]; then
+              echo "PR #$PR: gate unavailable or no PR CI runs (total=$TOTAL); approval stays deferred."
+              continue
+            fi
+            if [ "$PENDING" -gt 0 ]; then
+              echo "PR #$PR: $PENDING PR CI workflow run(s) still in progress; approval stays deferred."
+              update_status "$PR" deferred
+              continue
+            fi
+            if [ "$RED" -gt 0 ]; then
+              echo "PR #$PR: $RED non-green PR CI workflow run(s); approval withheld."
+              update_status "$PR" red
               continue
             fi
             ALREADY="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR/reviews" \

--- a/.qwen/skills/triage/references/pr-workflow.md
+++ b/.qwen/skills/triage/references/pr-workflow.md
@@ -536,11 +536,13 @@ A fork `refactor` that hits the approval guardrail below, **or a PR that Stage 0
 
 Then write what you're actually thinking. "Looks good, ships the feature cleanly, the before/after shows it works" — not a five-bullet summary of the stages. If you have reservations, say them plainly. If you're approving with mild concerns, name them. Sign with `— _Qwen Code · qwen3.7-max_`, add the reviewed-commit footer (empty `HEAD_SHA` → fail closed, as above — don't blank a prior footer), and save this comment's ID.
 
-**Approve verdict while CI is still running → say so in this comment, before posting it.** Reuse the Stage 2b fetch — no new API call, and **no polling**. Staleness is safe in this direction only: a check that completed after the fetch is merely treated as still pending, which defers the approval; it can never approve early. The `finalize-triage-ci` exclusion is the finalize workflow's own in-flight check on the same SHA:
+**Approve verdict while CI is still running → say so in this comment, before posting it.** Count pending **workflow runs with `event == "pull_request"`** — the PR's own CI — not check-runs. Check-runs on the head SHA also include bot orchestration jobs (`pull_request_target` / `issue_comment` runs like triage itself and review-pr) that can stay in flight long after CI finishes; counting those would defer an approval that nothing will ever un-defer, because the finalize workflow only fires on PR CI workflow completions. One extra cheap API call, still **no polling**; staleness is safe in this direction only (a run that completed after the fetch is merely treated as pending → defers, never mis-approves):
 
 ```bash
-PENDING=$(jq '[.[] | select(.name != "finalize-triage-ci")
-  | select(.status != "completed")] | length' /tmp/triage-checks.json)
+PENDING=$(gh api "repos/$REPO/actions/runs?head_sha=$HEAD_SHA&per_page=100" --paginate \
+  --jq '.workflow_runs' | jq -s 'add // []
+    | [ .[] | select(.event == "pull_request") | select(.status != "completed") ] | length')
+case "$PENDING" in '' | *[!0-9]*) PENDING=1 ;; esac   # unreadable → treat as pending (defer, fail closed)
 ```
 
 If the verdict is approve and `PENDING` is greater than 0, state it plainly in the comment — "approval deferred until CI lands green on `<HEAD_SHA>`" — and include this machine marker on its own line (full OID, the same one the footer attests):

--- a/.qwen/skills/triage/references/pr-workflow.md
+++ b/.qwen/skills/triage/references/pr-workflow.md
@@ -545,7 +545,16 @@ PENDING=$(gh api "repos/$REPO/actions/runs?head_sha=$HEAD_SHA&per_page=100" --pa
 case "$PENDING" in '' | *[!0-9]*) PENDING=1 ;; esac   # unreadable → treat as pending (defer, fail closed)
 ```
 
-If the verdict is approve and `PENDING` is greater than 0, state it plainly in the comment — "approval deferred until CI lands green on `<HEAD_SHA>`" — and include this machine marker on its own line (full OID, the same one the footer attests):
+**Compute the approval guardrail HERE, before the marker.** The marker is an approval with a CI precondition attached, so everything that would block an immediate approval must block the marker too — evaluating the guardrail only in Step 2, after the comment is posted, would leave a standing approval instruction that Step 2 cannot cleanly withdraw:
+
+```bash
+GUARD=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json isCrossRepository,title \
+  --jq 'if (.isCrossRepository and (.title | test("^\\s*refactor"; "i"))) then "block" else "ok" end')
+```
+
+Emit the marker only when ALL of these hold: the verdict is approve, `PENDING` is greater than 0, `GUARD` is `ok`, and Stage 0 raised no maintainer escalation. A fork `refactor` or an escalated PR never carries the marker — those cap at 3/5 and take the defer path, with or without CI. (The finalize workflow independently re-asserts the fork-refactor guardrail before approving, but that is a backstop, not the mechanism.)
+
+When the marker is warranted, state it plainly in the comment — "approval deferred until CI lands green on `<HEAD_SHA>`" — and include it on its own line (full OID, the same one the footer attests):
 
 ```
 <!-- qwen-triage approve-on-green sha=<HEAD_SHA> -->
@@ -555,12 +564,7 @@ The finalize workflow honors the marker only in comments authored by the bot its
 
 **Step 2: Act on the verdict.**
 
-**⛔ Approval guardrail — check this BEFORE approving.** A cross-repository (fork) `refactor` PR must never be auto-approved: refactors touch structure broadly and a fork author is not a trusted committer, so these always need a human maintainer's eye (this rule exists because such a PR was wrongly auto-approved and merged). Decide it deterministically — do not eyeball it:
-
-```bash
-GUARD=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json isCrossRepository,title \
-  --jq 'if (.isCrossRepository and (.title | test("^\\s*refactor"; "i"))) then "block" else "ok" end')
-```
+**⛔ Approval guardrail — check this BEFORE approving.** A cross-repository (fork) `refactor` PR must never be auto-approved: refactors touch structure broadly and a fork author is not a trusted committer, so these always need a human maintainer's eye (this rule exists because such a PR was wrongly auto-approved and merged). Decide it deterministically — do not eyeball it. `GUARD` was already computed in Step 1 (where it also gates the `approve-on-green` marker, for the same reason); reuse that value here.
 
 If `GUARD` is `block`: do **not** run `gh pr review --approve` no matter how clean every stage looked. Escalate to the maintainer instead (the "Genuinely unsure" path below, using `$QWEN_MAINTAINER_HANDLE` if set), and only `--request-changes` if you actually found blocking issues. This overrides the "approve" path.
 

--- a/.qwen/skills/triage/references/pr-workflow.md
+++ b/.qwen/skills/triage/references/pr-workflow.md
@@ -364,14 +364,43 @@ JOB_ID=$(jq -r '[.[] | select(.conclusion == "failure") | select(.details_url | 
 [ -n "$JOB_ID" ] && gh api "repos/$REPO/actions/jobs/$JOB_ID/logs" | tail -c 15000
 ```
 
-If checks that matter are still running, poll briefly (`sleep 60`, up to ~10
-minutes). Still pending after that → write "CI still running at review time"
-with the pending check names and move on — do not guess the outcome.
+**Never poll or sleep-wait on pending checks.** This repo's unit suite alone
+runs ~30 minutes — longer than any in-agent waiting budget, so a poll loop
+burns runner minutes and still gives up before the result exists (measured: a
+10-minute poll cap surrendered 13 minutes before the suite finished). Fetch
+once, report what is there. Checks still running → list them as pending in the
+table and move on — do not guess the outcome. The `Qwen Triage Finalize`
+workflow (a deterministic `workflow_run` job, no model, no checkout) rewrites
+the table region below in place once CI settles, and performs any deferred
+approval (see Stage 3).
 
 Quote real check names, real conclusions, and the failing excerpt in the
 Stage 2 comment — never a bare "tests pass". A red check that the PR
 plausibly caused is a finding; a red check that is clearly pre-existing infra
 noise should be named as such, with the evidence for that call.
+
+**Wrap the CI table in machine-readable region markers** so the finalize
+workflow can update it in place after CI completes. Each marker sits on its own
+line; `sha=` carries the full reviewed `HEAD_SHA` — the same OID the footer
+attests, which is what lets the finalize job refuse to touch a table belonging
+to a commit its CI run didn't cover:
+
+```markdown
+<!-- qwen-triage-ci sha=<HEAD_SHA> -->
+
+| Check | Conclusion |
+| ----- | ---------- |
+| …     | …          |
+
+<!-- /qwen-triage-ci -->
+```
+
+Everything between the markers is replaced wholesale by the finalize job, so
+keep your prose about the CI signal — pre-existing-failure calls,
+pending-check notes, log excerpts — **outside** the region; only the table and
+its caption live inside. Emit the marker pair exactly once, and do not quote
+the marker text elsewhere in the comment (the Chinese `<details>` summarizes
+the table in prose instead of duplicating it).
 
 ⚠️ **Trust boundary in the CI signal.** Check **names** and **conclusions** are
 GitHub-set metadata — trust them. The log **body** text is stdout from code the
@@ -452,7 +481,7 @@ so the maintainer can trust and reproduce it.
 
 Post a single Stage 2 comment (must include `<!-- qwen-triage stage=2 -->` at the top), in this order: code review findings → optional sequence diagram (2a-bis) → optional changed-files overview (2a-bis) → CI test evidence (2b) → real-scenario testing result when one was driven locally (2c) → the bilingual `<details>` Chinese summary → signature + footer last (the same tail order as the Stage 1 template). Include the two enrichments only when 2a-bis says they earn their place; a small, focused PR is just findings + testing.
 
-**⛔ BEFORE POSTING: verify the testing section carries real evidence.** Read back through your draft. In CI: does it quote actual check names and conclusions (and the failing job's log excerpt when red)? On a local run: does it have a fenced code block with the actual terminal capture (or the `N/A` substitution for docs/types/refactor PRs with nothing user-visible)? Does the evidence depth match the PR type per “Scale the evidence” above — screenshots for UI changes, measurements for performance claims, clean-state numbers for build/test claims? If not, fix that now — and never paper over a gap with the author's self-reported results. The maintainer cannot approve without seeing what actually happened.
+**⛔ BEFORE POSTING: verify the testing section carries real evidence.** Read back through your draft. In CI: does it quote actual check names and conclusions (and the failing job's log excerpt when red), and is the CI table wrapped in the `qwen-triage-ci` region markers so the finalize workflow can update it? On a local run: does it have a fenced code block with the actual terminal capture (or the `N/A` substitution for docs/types/refactor PRs with nothing user-visible)? Does the evidence depth match the PR type per “Scale the evidence” above — screenshots for UI changes, measurements for performance claims, clean-state numbers for build/test claims? If not, fix that now — and never paper over a gap with the author's self-reported results. The maintainer cannot approve without seeing what actually happened.
 
 ````markdown
 ## Before (installed build)
@@ -507,6 +536,21 @@ A fork `refactor` that hits the approval guardrail below, **or a PR that Stage 0
 
 Then write what you're actually thinking. "Looks good, ships the feature cleanly, the before/after shows it works" — not a five-bullet summary of the stages. If you have reservations, say them plainly. If you're approving with mild concerns, name them. Sign with `— _Qwen Code · qwen3.7-max_`, add the reviewed-commit footer (empty `HEAD_SHA` → fail closed, as above — don't blank a prior footer), and save this comment's ID.
 
+**Approve verdict while CI is still running → say so in this comment, before posting it.** Reuse the Stage 2b fetch — no new API call, and **no polling**. Staleness is safe in this direction only: a check that completed after the fetch is merely treated as still pending, which defers the approval; it can never approve early. The `finalize-triage-ci` exclusion is the finalize workflow's own in-flight check on the same SHA:
+
+```bash
+PENDING=$(jq '[.[] | select(.name != "finalize-triage-ci")
+  | select(.status != "completed")] | length' /tmp/triage-checks.json)
+```
+
+If the verdict is approve and `PENDING` is greater than 0, state it plainly in the comment — "approval deferred until CI lands green on `<HEAD_SHA>`" — and include this machine marker on its own line (full OID, the same one the footer attests):
+
+```
+<!-- qwen-triage approve-on-green sha=<HEAD_SHA> -->
+```
+
+The finalize workflow honors the marker only in comments authored by the bot itself, but still: emit it exactly once, and never quote the marker text in prose or the Chinese translation.
+
 **Step 2: Act on the verdict.**
 
 **⛔ Approval guardrail — check this BEFORE approving.** A cross-repository (fork) `refactor` PR must never be auto-approved: refactors touch structure broadly and a fork author is not a trusted committer, so these always need a human maintainer's eye (this rule exists because such a PR was wrongly auto-approved and merged). Decide it deterministically — do not eyeball it:
@@ -522,13 +566,16 @@ If Stage 0 escalated the PR for maintainer awareness, do **not** approve automat
 
 **Re-runs (manually triggered via `@qwen-code /triage`):** hygiene concerns (scope mismatch, undocumented changes, naming) that don't block the PR are not a valid reason to defer. Note them in the comment and approve. Only defer if you have genuine blocking uncertainty — something you cannot resolve from the diff, tests, and PR description.
 
-All stages genuinely clean, `GUARD` is `ok`, and no Stage 0 maintainer escalation remains — approve:
+All stages genuinely clean, `GUARD` is `ok`, and no Stage 0 maintainer escalation remains — how you approve depends on the `PENDING` count computed in Step 1:
 
-```bash
-# Approve pinned to the reviewed commit (see the Approval note above) — never `gh pr review --approve`, which binds to no SHA.
-gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
-  -f commit_id="$HEAD_SHA" -f event=APPROVE -f body='LGTM, looks ready to ship. ✅'
-```
+- `PENDING` = 0 → approve now, pinned to the reviewed commit (see the Approval note above) — never `gh pr review --approve`, which binds to no SHA:
+
+  ```bash
+  gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+    -f commit_id="$HEAD_SHA" -f event=APPROVE -f body='LGTM, looks ready to ship. ✅'
+  ```
+
+- `PENDING` > 0 → **post no approval in this run.** The Stage 3 comment already carries the `approve-on-green` marker (Step 1); the finalize workflow posts the same commit-pinned approval only after every check on `HEAD_SHA` completes green, and withholds it — flagging the status comment — if anything lands red or the head moves. Approving while the unit suite is still running would attest to a result that does not exist yet; that gap is exactly what the deferred path closes.
 
 Reflection shows it shouldn't merge — request changes immediately, citing the specific concerns from the comment:
 

--- a/scripts/tests/qwen-triage-finalize-workflow.test.js
+++ b/scripts/tests/qwen-triage-finalize-workflow.test.js
@@ -97,6 +97,13 @@ describe('qwen-triage-finalize workflow', () => {
     expect(script.indexOf('update_status "$PR" stale')).toBeLessThan(
       script.indexOf('update_status "$PR" red'),
     );
+    // The status comment is not SHA-scoped, so a late firing for an old SHA
+    // must not overwrite it once the new head's re-review (whose sha= markers
+    // sit in bot comments) owns it.
+    expect(script).toContain('sha=${CURRENT_HEAD}');
+    expect(script.indexOf('sha=${CURRENT_HEAD}')).toBeLessThan(
+      script.indexOf('update_status "$PR" stale'),
+    );
     // Still-pending is visible, not silent.
     expect(script).toContain('update_status "$PR" deferred');
     // Re-running finalize must not stack approvals.

--- a/scripts/tests/qwen-triage-finalize-workflow.test.js
+++ b/scripts/tests/qwen-triage-finalize-workflow.test.js
@@ -1,0 +1,231 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+const workflowText = readFileSync(
+  '.github/workflows/qwen-triage-finalize.yml',
+  'utf8',
+);
+const workflow = parse(workflowText);
+const script = workflow.jobs.finalize.steps[0].run;
+
+describe('qwen-triage-finalize workflow', () => {
+  it('fires on CI completion only for PR-caused runs', () => {
+    expect(workflow.on.workflow_run.workflows).toEqual([
+      'Qwen Code CI',
+      'E2E Tests',
+    ]);
+    expect(workflow.on.workflow_run.types).toEqual(['completed']);
+    expect(workflow.jobs.finalize.if).toBe(
+      "github.event.workflow_run.event == 'pull_request'",
+    );
+  });
+
+  it('never checks out or executes repository code', () => {
+    // The whole point of the split: the agent job reads, this job writes, and
+    // neither ever runs PR code. A checkout here would put PR-controlled files
+    // next to a write PAT.
+    expect(workflowText).not.toContain('actions/checkout');
+    expect(workflowText).not.toContain('npm ');
+    expect(workflow.jobs.finalize.steps).toHaveLength(1);
+  });
+
+  it('serializes concurrent finalize runs per head SHA without cancelling', () => {
+    // CI and E2E can complete near-simultaneously; a cancelled run would drop
+    // its read-modify-write, so queue instead of cancel.
+    expect(workflowText).toContain(
+      "group: 'qwen-triage-finalize-${{ github.event.workflow_run.head_sha }}'",
+    );
+    expect(workflowText).toContain('cancel-in-progress: false');
+  });
+
+  it('excludes its own check-run from the green computation', () => {
+    // This job is itself a check on the same SHA and is in_progress while it
+    // runs — without the exclusion it could never see the SHA "complete".
+    expect(workflow.jobs.finalize.name).toBe('finalize-triage-ci');
+    expect(workflow.jobs.finalize.steps[0].env.SELF_CHECK_NAME).toBe(
+      'finalize-triage-ci',
+    );
+    expect(script).toContain('select(.name != $self)');
+  });
+
+  it('treats markers as forgeable and only honors bot-authored comments', () => {
+    // Marker text is public: anyone can paste it into a PR comment. Every
+    // lookup that acts on a marker must filter on the bot identity first.
+    const markerLookups = script
+      .split('\n')
+      .filter((line) => line.includes('--arg m'));
+    expect(markerLookups.length).toBeGreaterThan(0);
+    expect(script).toContain("gh api user --jq '.login'");
+    const authorFiltered = script.match(
+      /select\(\.user\.login == \$bot\) \| select\(\.body \| contains\(\$m\)\)/g,
+    );
+    // CI-region lookup, approve-marker lookup, and status-comment lookup.
+    expect(authorFiltered?.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('pins the deferred approval to the reviewed SHA and fails closed', () => {
+    expect(script).toContain('-f commit_id="$HEAD_SHA" -f event=APPROVE');
+    // Head moved / closed / draft → no approval, explicit stale note.
+    expect(script).toContain('"$CURRENT_HEAD" != "$HEAD_SHA"');
+    expect(script).toContain('update_status "$PR" stale');
+    // Red checks → withheld, not approved.
+    expect(script).toContain('update_status "$PR" red');
+    // Green is a closed set; anything unknown is not green.
+    expect(script).toContain('["success","neutral","skipped"]');
+    // Re-running finalize must not stack approvals.
+    expect(script).toContain('.state == "APPROVED" and .commit_id == $sha');
+  });
+
+  it('binds every marker to the full head SHA of the triggering run', () => {
+    expect(script).toContain(
+      'CI_BEGIN="<!-- qwen-triage-ci sha=${HEAD_SHA} -->"',
+    );
+    expect(script).toContain(
+      'APPROVE_MARKER="<!-- qwen-triage approve-on-green sha=${HEAD_SHA} -->"',
+    );
+    expect(workflowText).toContain(
+      "HEAD_SHA: '${{ github.event.workflow_run.head_sha }}'",
+    );
+  });
+
+  it('sanitizes attacker-influenced check names before the table', () => {
+    // Fork PRs can add or rename workflows that run on pull_request, so check
+    // names are untrusted. Same discipline as the triage skill: & first,
+    // control characters stripped, bounded, rendered in <code>.
+    expect(script).toContain("sed -e 's/&/\\&amp;/g'");
+    expect(script).toContain("tr -d '\\r\\n\\000'");
+    expect(script).toContain('cut -c1-120');
+    expect(script).toContain('<code>%s</code>');
+    expect(script).toContain('MAX_ROWS=60');
+  });
+
+  it('exits quietly when no bot token or no matching PR exists', () => {
+    expect(script).toContain('if [ -z "${GH_TOKEN:-}" ]');
+    expect(script).toContain('No open PR for $SHORT_SHA; nothing to finalize.');
+  });
+});
+
+describe('qwen-triage-finalize helpers', () => {
+  const helpers = script.slice(
+    script.indexOf('html_escape() {'),
+    script.indexOf('# --- end triage-finalize helpers ---'),
+  );
+
+  const runHelpers = (driver) => {
+    const full = [
+      'set -uo pipefail',
+      'CI_BEGIN="<!-- qwen-triage-ci sha=abc123 -->"',
+      "CI_END='<!-- /qwen-triage-ci -->'",
+      helpers,
+      driver,
+    ].join('\n');
+    const proc = spawnSync('bash', ['-c', full], { encoding: 'utf8' });
+    return { status: proc.status, stdout: proc.stdout };
+  };
+
+  it('extracted both helper functions', () => {
+    expect(helpers).toContain('html_escape() {');
+    expect(helpers).toContain('replace_region() {');
+  });
+
+  it('escapes ampersand first so entities are not double-encoded', () => {
+    const { status, stdout } = runHelpers(
+      `printf '%s' 'a&<>|@[]()*\`b' | html_escape`,
+    );
+    expect(status).toBe(0);
+    expect(stdout).toBe(
+      'a&amp;&lt;&gt;&#124;&#64;&#91;&#93;&#40;&#41;&#42;&#96;b',
+    );
+  });
+
+  it('replaces exactly the marked region and preserves the rest', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'triage-finalize-io-'));
+    try {
+      writeFileSync(
+        join(dir, 'body.md'),
+        [
+          'findings prose stays',
+          '<!-- qwen-triage-ci sha=abc123 -->',
+          '| old | table |',
+          '<!-- /qwen-triage-ci -->',
+          'footer stays',
+        ].join('\n'),
+      );
+      writeFileSync(
+        join(dir, 'region.md'),
+        [
+          '<!-- qwen-triage-ci sha=abc123 -->',
+          '| new | table |',
+          '<!-- /qwen-triage-ci -->',
+        ].join('\n'),
+      );
+      const proc = spawnSync(
+        'bash',
+        [
+          '-c',
+          [
+            'set -uo pipefail',
+            'CI_BEGIN="<!-- qwen-triage-ci sha=abc123 -->"',
+            "CI_END='<!-- /qwen-triage-ci -->'",
+            helpers,
+            `replace_region '${join(dir, 'body.md')}' '${join(dir, 'region.md')}' '${join(dir, 'out.md')}'`,
+          ].join('\n'),
+        ],
+        { encoding: 'utf8' },
+      );
+      expect(proc.status).toBe(0);
+      const out = readFileSync(join(dir, 'out.md'), 'utf8');
+      expect(out).toContain('findings prose stays');
+      expect(out).toContain('footer stays');
+      expect(out).toContain('| new | table |');
+      expect(out).not.toContain('| old | table |');
+      // Markers survive so the NEXT finalize run can update again.
+      expect(out).toContain('<!-- qwen-triage-ci sha=abc123 -->');
+      expect(out).toContain('<!-- /qwen-triage-ci -->');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed when the end marker is missing', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'triage-finalize-noend-'));
+    try {
+      writeFileSync(
+        join(dir, 'body.md'),
+        ['<!-- qwen-triage-ci sha=abc123 -->', 'unterminated'].join('\n'),
+      );
+      writeFileSync(join(dir, 'region.md'), 'replacement');
+      const proc = spawnSync(
+        'bash',
+        [
+          '-c',
+          [
+            'set -uo pipefail',
+            'CI_BEGIN="<!-- qwen-triage-ci sha=abc123 -->"',
+            "CI_END='<!-- /qwen-triage-ci -->'",
+            helpers,
+            `replace_region '${join(dir, 'body.md')}' '${join(dir, 'region.md')}' '${join(dir, 'out.md')}'`,
+            'echo "exit=$?"',
+          ].join('\n'),
+        ],
+        { encoding: 'utf8' },
+      );
+      // Non-zero return from replace_region, and no output file written: the
+      // caller leaves the comment untouched rather than truncating it.
+      expect(proc.stdout).toContain('exit=1');
+      expect(() => readFileSync(join(dir, 'out.md'), 'utf8')).toThrow();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/tests/qwen-triage-finalize-workflow.test.js
+++ b/scripts/tests/qwen-triage-finalize-workflow.test.js
@@ -19,11 +19,20 @@ const workflow = parse(workflowText);
 const script = workflow.jobs.finalize.steps[0].run;
 
 describe('qwen-triage-finalize workflow', () => {
-  it('fires on CI completion only for PR-caused runs', () => {
+  it('fires on every pull_request-triggered workflow, only for PR-caused runs', () => {
+    // The deferred approval can only land on a firing that happens AFTER the
+    // last PR CI run completes, so every workflow with a pull_request trigger
+    // must be listed — and none without one (a dead entry just adds skipped
+    // firings; E2E Tests has no pull_request trigger).
     expect(workflow.on.workflow_run.workflows).toEqual([
       'Qwen Code CI',
-      'E2E Tests',
+      'Qwen Autofix',
+      'SDK Java',
+      'SDK Python',
+      'Serve A/B',
+      'Web-shell Visuals',
     ]);
+    expect(workflow.on.workflow_run.workflows).not.toContain('E2E Tests');
     expect(workflow.on.workflow_run.types).toEqual(['completed']);
     expect(workflow.jobs.finalize.if).toBe(
       "github.event.workflow_run.event == 'pull_request'",
@@ -32,39 +41,44 @@ describe('qwen-triage-finalize workflow', () => {
 
   it('never checks out or executes repository code', () => {
     // The whole point of the split: the agent job reads, this job writes, and
-    // neither ever runs PR code. A checkout here would put PR-controlled files
-    // next to a write PAT.
-    expect(workflowText).not.toContain('actions/checkout');
-    expect(workflowText).not.toContain('npm ');
+    // neither ever runs PR code. No `uses:` at all — a single API-only bash
+    // step, so no action can ever put PR-controlled files next to the PAT.
+    expect(workflowText).not.toContain('uses:');
     expect(workflow.jobs.finalize.steps).toHaveLength(1);
   });
 
   it('serializes concurrent finalize runs per head SHA without cancelling', () => {
-    // CI and E2E can complete near-simultaneously; a cancelled run would drop
-    // its read-modify-write, so queue instead of cancel.
+    // Two listed workflows can complete near-simultaneously; a cancelled run
+    // would drop its read-modify-write, so queue instead of cancel.
     expect(workflowText).toContain(
       "group: 'qwen-triage-finalize-${{ github.event.workflow_run.head_sha }}'",
     );
     expect(workflowText).toContain('cancel-in-progress: false');
   });
 
-  it('excludes its own check-run from the green computation', () => {
-    // This job is itself a check on the same SHA and is in_progress while it
-    // runs — without the exclusion it could never see the SHA "complete".
-    expect(workflow.jobs.finalize.name).toBe('finalize-triage-ci');
-    expect(workflow.jobs.finalize.steps[0].env.SELF_CHECK_NAME).toBe(
-      'finalize-triage-ci',
+  it('gates approval on pull_request workflow runs, not head-SHA check-runs', () => {
+    // Check-runs on the head SHA include bot orchestration jobs
+    // (pull_request_target / issue_comment) that can outlive CI; counting
+    // them would silently drop the deferred approval forever, since only the
+    // listed PR CI workflows re-fire this job.
+    expect(script).toContain('actions/runs?head_sha=$HEAD_SHA');
+    expect(script).toContain('select(.event == "pull_request")');
+    expect(script).toContain('group_by(.workflow_id) | map(max_by(.id))');
+    // Green is a closed set bound to the conclusion BEFORE the membership
+    // test (jq `|` rebinds `.`, so the array-first form raises an error).
+    expect(script).toContain(
+      '(.conclusion // "") | IN("success","neutral","skipped") | not',
     );
-    expect(script).toContain('select(.name != $self)');
+    // A jq failure must read as "cannot attest": non-numeric counters are
+    // caught and flip GATE_OK off instead of falling through to approve.
+    expect(script).toContain("'' | *[!0-9]*");
+    expect(script).toContain('GATE_OK=false');
+    expect(script).toContain('[ "$GATE_OK" != true ] || [ "$TOTAL" -eq 0 ]');
   });
 
   it('treats markers as forgeable and only honors bot-authored comments', () => {
     // Marker text is public: anyone can paste it into a PR comment. Every
     // lookup that acts on a marker must filter on the bot identity first.
-    const markerLookups = script
-      .split('\n')
-      .filter((line) => line.includes('--arg m'));
-    expect(markerLookups.length).toBeGreaterThan(0);
     expect(script).toContain("gh api user --jq '.login'");
     const authorFiltered = script.match(
       /select\(\.user\.login == \$bot\) \| select\(\.body \| contains\(\$m\)\)/g,
@@ -75,13 +89,16 @@ describe('qwen-triage-finalize workflow', () => {
 
   it('pins the deferred approval to the reviewed SHA and fails closed', () => {
     expect(script).toContain('-f commit_id="$HEAD_SHA" -f event=APPROVE');
-    // Head moved / closed / draft → no approval, explicit stale note.
+    // Head moved / closed / draft → no approval, explicit stale note — and
+    // this re-check runs BEFORE the red/deferred verdicts, so a
+    // cancel-in-progress firing on a stale SHA cannot stamp a red status
+    // over the new head's comment.
     expect(script).toContain('"$CURRENT_HEAD" != "$HEAD_SHA"');
-    expect(script).toContain('update_status "$PR" stale');
-    // Red checks → withheld, not approved.
-    expect(script).toContain('update_status "$PR" red');
-    // Green is a closed set; anything unknown is not green.
-    expect(script).toContain('["success","neutral","skipped"]');
+    expect(script.indexOf('update_status "$PR" stale')).toBeLessThan(
+      script.indexOf('update_status "$PR" red'),
+    );
+    // Still-pending is visible, not silent.
+    expect(script).toContain('update_status "$PR" deferred');
     // Re-running finalize must not stack approvals.
     expect(script).toContain('.state == "APPROVED" and .commit_id == $sha');
   });
@@ -107,6 +124,19 @@ describe('qwen-triage-finalize workflow', () => {
     expect(script).toContain('cut -c1-120');
     expect(script).toContain('<code>%s</code>');
     expect(script).toContain('MAX_ROWS=60');
+    // Belt-and-braces: this job's own check name stays out of the table.
+    expect(script).toContain('map(select(.name != $self))');
+  });
+
+  it('keeps the region deterministic so no-op PATCHes are skipped', () => {
+    // RUN_URL carries the run id and would differ on every firing; inside the
+    // region it would make the cmp always miss and every trigger PATCH.
+    const region = script.slice(
+      script.indexOf('table_rows /tmp/checks.json > /tmp/rows.tsv'),
+      script.indexOf('} > /tmp/region.md'),
+    );
+    expect(region).not.toContain('RUN_URL');
+    expect(script).toContain('cmp -s /tmp/body-in.md /tmp/body-out.md');
   });
 
   it('exits quietly when no bot token or no matching PR exists', () => {
@@ -121,21 +151,27 @@ describe('qwen-triage-finalize helpers', () => {
     script.indexOf('# --- end triage-finalize helpers ---'),
   );
 
+  const preamble = [
+    'set -uo pipefail',
+    'CI_BEGIN="<!-- qwen-triage-ci sha=abc123 -->"',
+    "CI_END='<!-- /qwen-triage-ci -->'",
+    'SELF_CHECK_NAME=finalize-triage-ci',
+  ];
+
   const runHelpers = (driver) => {
-    const full = [
-      'set -uo pipefail',
-      'CI_BEGIN="<!-- qwen-triage-ci sha=abc123 -->"',
-      "CI_END='<!-- /qwen-triage-ci -->'",
-      helpers,
-      driver,
-    ].join('\n');
-    const proc = spawnSync('bash', ['-c', full], { encoding: 'utf8' });
-    return { status: proc.status, stdout: proc.stdout };
+    const proc = spawnSync(
+      'bash',
+      ['-c', [...preamble, helpers, driver].join('\n')],
+      { encoding: 'utf8' },
+    );
+    return { status: proc.status, stdout: proc.stdout, stderr: proc.stderr };
   };
 
-  it('extracted both helper functions', () => {
+  it('extracted all helper functions', () => {
     expect(helpers).toContain('html_escape() {');
     expect(helpers).toContain('replace_region() {');
+    expect(helpers).toContain('gate_counts() {');
+    expect(helpers).toContain('table_rows() {');
   });
 
   it('escapes ampersand first so entities are not double-encoded', () => {
@@ -146,6 +182,157 @@ describe('qwen-triage-finalize helpers', () => {
     expect(stdout).toBe(
       'a&amp;&lt;&gt;&#124;&#64;&#91;&#93;&#40;&#41;&#42;&#96;b',
     );
+  });
+
+  it('gate_counts: event-filtered, deduped, closed green set, no jq errors', () => {
+    // Covers every conclusion class plus the two poison shapes: non-PR events
+    // that must be ignored, and a re-run pair where only the latest counts.
+    const runs = [
+      {
+        event: 'pull_request',
+        workflow_id: 1,
+        id: 10,
+        status: 'completed',
+        conclusion: 'success',
+      },
+      {
+        event: 'pull_request',
+        workflow_id: 2,
+        id: 11,
+        status: 'completed',
+        conclusion: 'failure',
+      },
+      {
+        event: 'pull_request',
+        workflow_id: 3,
+        id: 12,
+        status: 'in_progress',
+        conclusion: null,
+      },
+      {
+        event: 'pull_request',
+        workflow_id: 4,
+        id: 13,
+        status: 'completed',
+        conclusion: 'cancelled',
+      },
+      {
+        event: 'pull_request',
+        workflow_id: 5,
+        id: 14,
+        status: 'completed',
+        conclusion: 'skipped',
+      },
+      {
+        event: 'pull_request',
+        workflow_id: 6,
+        id: 15,
+        status: 'completed',
+        conclusion: 'timed_out',
+      },
+      {
+        event: 'pull_request',
+        workflow_id: 7,
+        id: 16,
+        status: 'completed',
+        conclusion: 'action_required',
+      },
+      {
+        event: 'pull_request',
+        workflow_id: 8,
+        id: 17,
+        status: 'queued',
+        conclusion: null,
+      },
+      {
+        event: 'pull_request_target',
+        workflow_id: 9,
+        id: 18,
+        status: 'completed',
+        conclusion: 'failure',
+      },
+      {
+        event: 'workflow_run',
+        workflow_id: 10,
+        id: 19,
+        status: 'in_progress',
+        conclusion: null,
+      },
+      {
+        event: 'pull_request',
+        workflow_id: 11,
+        id: 20,
+        status: 'completed',
+        conclusion: 'failure',
+      },
+      {
+        event: 'pull_request',
+        workflow_id: 11,
+        id: 21,
+        status: 'completed',
+        conclusion: 'success',
+      },
+    ];
+    const dir = mkdtempSync(join(tmpdir(), 'triage-finalize-gate-'));
+    try {
+      writeFileSync(join(dir, 'runs.json'), JSON.stringify(runs));
+      const { status, stdout, stderr } = runHelpers(
+        `gate_counts '${join(dir, 'runs.json')}'`,
+      );
+      expect(stderr).toBe('');
+      expect(status).toBe(0);
+      // 9 deduped pull_request runs; 2 pending (in_progress + queued); red =
+      // failure + cancelled + timed_out + action_required (the deduped
+      // workflow 11 resolves to success; skipped and the non-PR failure are
+      // not red).
+      expect(stdout.trim()).toBe('9\t2\t4');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('table_rows: dedups by name, drops skipped, sorts failures first', () => {
+    const checks = [
+      {
+        name: 'Test (ubuntu-latest)',
+        id: 2,
+        status: 'completed',
+        conclusion: 'success',
+      },
+      {
+        name: 'Test (ubuntu-latest)',
+        id: 1,
+        status: 'completed',
+        conclusion: 'failure',
+      },
+      { name: 'authorize', id: 3, status: 'completed', conclusion: 'skipped' },
+      { name: 'Serve A/B', id: 4, status: 'completed', conclusion: 'failure' },
+      { name: 'visuals', id: 5, status: 'in_progress', conclusion: null },
+      {
+        name: 'finalize-triage-ci',
+        id: 6,
+        status: 'in_progress',
+        conclusion: null,
+      },
+      { name: 'alpha', id: 7, status: 'completed', conclusion: 'success' },
+    ];
+    const dir = mkdtempSync(join(tmpdir(), 'triage-finalize-table-'));
+    try {
+      writeFileSync(join(dir, 'checks.json'), JSON.stringify(checks));
+      const { status, stdout, stderr } = runHelpers(
+        `table_rows '${join(dir, 'checks.json')}'`,
+      );
+      expect(stderr).toBe('');
+      expect(status).toBe(0);
+      expect(stdout.trimEnd().split('\n')).toEqual([
+        'visuals\tin_progress\t',
+        'Serve A/B\tcompleted\tfailure',
+        'alpha\tcompleted\tsuccess',
+        'Test (ubuntu-latest)\tcompleted\tsuccess',
+      ]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('replaces exactly the marked region and preserves the rest', () => {
@@ -169,21 +356,10 @@ describe('qwen-triage-finalize helpers', () => {
           '<!-- /qwen-triage-ci -->',
         ].join('\n'),
       );
-      const proc = spawnSync(
-        'bash',
-        [
-          '-c',
-          [
-            'set -uo pipefail',
-            'CI_BEGIN="<!-- qwen-triage-ci sha=abc123 -->"',
-            "CI_END='<!-- /qwen-triage-ci -->'",
-            helpers,
-            `replace_region '${join(dir, 'body.md')}' '${join(dir, 'region.md')}' '${join(dir, 'out.md')}'`,
-          ].join('\n'),
-        ],
-        { encoding: 'utf8' },
+      const { status } = runHelpers(
+        `replace_region '${join(dir, 'body.md')}' '${join(dir, 'region.md')}' '${join(dir, 'out.md')}'`,
       );
-      expect(proc.status).toBe(0);
+      expect(status).toBe(0);
       const out = readFileSync(join(dir, 'out.md'), 'utf8');
       expect(out).toContain('findings prose stays');
       expect(out).toContain('footer stays');
@@ -205,25 +381,45 @@ describe('qwen-triage-finalize helpers', () => {
         ['<!-- qwen-triage-ci sha=abc123 -->', 'unterminated'].join('\n'),
       );
       writeFileSync(join(dir, 'region.md'), 'replacement');
-      const proc = spawnSync(
-        'bash',
+      const { stdout } = runHelpers(
         [
-          '-c',
-          [
-            'set -uo pipefail',
-            'CI_BEGIN="<!-- qwen-triage-ci sha=abc123 -->"',
-            "CI_END='<!-- /qwen-triage-ci -->'",
-            helpers,
-            `replace_region '${join(dir, 'body.md')}' '${join(dir, 'region.md')}' '${join(dir, 'out.md')}'`,
-            'echo "exit=$?"',
-          ].join('\n'),
-        ],
-        { encoding: 'utf8' },
+          `replace_region '${join(dir, 'body.md')}' '${join(dir, 'region.md')}' '${join(dir, 'out.md')}'`,
+          'echo "exit=$?"',
+        ].join('\n'),
       );
-      // Non-zero return from replace_region, and no output file written: the
-      // caller leaves the comment untouched rather than truncating it.
-      expect(proc.stdout).toContain('exit=1');
+      // Non-zero return, and no output file written: the caller leaves the
+      // comment untouched rather than truncating it.
+      expect(stdout).toContain('exit=1');
       expect(() => readFileSync(join(dir, 'out.md'), 'utf8')).toThrow();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed when the end marker only appears before the begin marker', () => {
+    // grep -qF proves both markers EXIST, not their order. Without the awk
+    // END guard this shape opens the region at the begin marker, eats to
+    // EOF (losing the signature and reviewed-commit footer), and exits 0.
+    const dir = mkdtempSync(join(tmpdir(), 'triage-finalize-order-'));
+    try {
+      writeFileSync(
+        join(dir, 'body.md'),
+        [
+          'quoted example: <!-- /qwen-triage-ci -->',
+          'prose',
+          '<!-- qwen-triage-ci sha=abc123 -->',
+          '| old | table |',
+          'FOOTER reviewed commit',
+        ].join('\n'),
+      );
+      writeFileSync(join(dir, 'region.md'), 'replacement');
+      const { stdout } = runHelpers(
+        [
+          `replace_region '${join(dir, 'body.md')}' '${join(dir, 'region.md')}' '${join(dir, 'out.md')}'`,
+          'echo "exit=$?"',
+        ].join('\n'),
+      );
+      expect(stdout).toContain('exit=1');
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/scripts/tests/qwen-triage-finalize-workflow.test.js
+++ b/scripts/tests/qwen-triage-finalize-workflow.test.js
@@ -34,8 +34,12 @@ describe('qwen-triage-finalize workflow', () => {
     ]);
     expect(workflow.on.workflow_run.workflows).not.toContain('E2E Tests');
     expect(workflow.on.workflow_run.types).toEqual(['completed']);
-    expect(workflow.jobs.finalize.if).toBe(
+    expect(workflow.jobs.finalize.if).toContain(
       "github.event.workflow_run.event == 'pull_request'",
+    );
+    // House convention for bot workflows: forks opt in by editing the guard.
+    expect(workflow.jobs.finalize.if).toContain(
+      "github.repository == 'QwenLM/qwen-code'",
     );
   });
 
@@ -106,8 +110,23 @@ describe('qwen-triage-finalize workflow', () => {
     );
     // Still-pending is visible, not silent.
     expect(script).toContain('update_status "$PR" deferred');
-    // Re-running finalize must not stack approvals.
+    // Re-running finalize must not stack approvals — and the already-approved
+    // branch repairs a status comment that a later PENDING>0 firing flipped
+    // back to "deferred" after the approval landed.
     expect(script).toContain('.state == "APPROVED" and .commit_id == $sha');
+    expect(script).toMatch(
+      /already approved at \$SHORT_SHA\."\n\s*update_status "\$PR" approved/,
+    );
+    // The fork-refactor guardrail is re-asserted structurally: even a marker
+    // that slipped out on a cross-repository refactor PR never becomes an
+    // approval, and a deleted fork (null head.repo) is treated as a fork.
+    expect(script).toContain(
+      `(.head.repo.full_name // "") != .base.repo.full_name`,
+    );
+    expect(script).toContain("grep -qiE '^[[:space:]]*refactor'");
+    expect(script.indexOf('update_status "$PR" guarded')).toBeLessThan(
+      script.indexOf('update_status "$PR" deferred'),
+    );
   });
 
   it('binds every marker to the full head SHA of the triggering run', () => {
@@ -138,12 +157,22 @@ describe('qwen-triage-finalize workflow', () => {
   it('keeps the region deterministic so no-op PATCHes are skipped', () => {
     // RUN_URL carries the run id and would differ on every firing; inside the
     // region it would make the cmp always miss and every trigger PATCH.
-    const region = script.slice(
-      script.indexOf('table_rows /tmp/checks.json > /tmp/rows.tsv'),
-      script.indexOf('} > /tmp/region.md'),
+    const start = script.indexOf(
+      'table_rows /tmp/checks.json /tmp/runs.json > /tmp/rows.tsv',
     );
+    expect(start).toBeGreaterThan(-1);
+    const region = script.slice(start, script.indexOf('} > /tmp/region.md'));
     expect(region).not.toContain('RUN_URL');
     expect(script).toContain('cmp -s /tmp/body-in.md /tmp/body-out.md');
+  });
+
+  it('never blanks a table it cannot rebuild', () => {
+    // Zero surviving rows (failed runs fetch, missing suite ids) skips the
+    // rewrite instead of overwriting the agent's table with an empty one,
+    // and replace_region refuses an empty region file outright.
+    expect(script).toContain('REGION_OK=false');
+    expect(script).toContain('[ -n "$CID" ] && [ "$REGION_OK" != true ]');
+    expect(script).toContain('if [ ! -s "$2" ]; then');
   });
 
   it('exits quietly when no bot token or no matching PR exists', () => {
@@ -298,43 +327,103 @@ describe('qwen-triage-finalize helpers', () => {
     }
   });
 
-  it('table_rows: dedups by name, drops skipped, sorts failures first', () => {
+  it('table_rows: suite-filtered, deduped by name, skipped dropped, failures first', () => {
+    // Suite 1000 belongs to the latest pull_request run; suite 900 to a
+    // superseded run of the same workflow; suite 2000 to a bot
+    // (pull_request_target) run. Only suite-1000 checks may render.
+    const runs = [
+      {
+        event: 'pull_request',
+        workflow_id: 1,
+        id: 100,
+        check_suite_id: 1000,
+      },
+      { event: 'pull_request', workflow_id: 1, id: 90, check_suite_id: 900 },
+      {
+        event: 'pull_request_target',
+        workflow_id: 2,
+        id: 101,
+        check_suite_id: 2000,
+      },
+    ];
     const checks = [
       {
         name: 'Test (ubuntu-latest)',
         id: 2,
         status: 'completed',
         conclusion: 'success',
+        check_suite: { id: 1000 },
       },
       {
         name: 'Test (ubuntu-latest)',
         id: 1,
         status: 'completed',
         conclusion: 'failure',
+        check_suite: { id: 1000 },
       },
-      { name: 'authorize', id: 3, status: 'completed', conclusion: 'skipped' },
-      { name: 'Serve A/B', id: 4, status: 'completed', conclusion: 'failure' },
-      { name: 'visuals', id: 5, status: 'in_progress', conclusion: null },
       {
-        name: 'finalize-triage-ci',
+        name: 'old-run-check',
+        id: 3,
+        status: 'completed',
+        conclusion: 'failure',
+        check_suite: { id: 900 },
+      },
+      {
+        name: 'triage',
+        id: 4,
+        status: 'completed',
+        conclusion: 'failure',
+        check_suite: { id: 2000 },
+      },
+      {
+        name: 'skippy',
+        id: 5,
+        status: 'completed',
+        conclusion: 'skipped',
+        check_suite: { id: 1000 },
+      },
+      {
+        name: 'running',
         id: 6,
         status: 'in_progress',
         conclusion: null,
+        check_suite: { id: 1000 },
       },
-      { name: 'alpha', id: 7, status: 'completed', conclusion: 'success' },
+      {
+        name: 'finalize-triage-ci',
+        id: 7,
+        status: 'in_progress',
+        conclusion: null,
+        check_suite: { id: 1000 },
+      },
+      {
+        name: 'redcheck',
+        id: 8,
+        status: 'completed',
+        conclusion: 'cancelled',
+        check_suite: { id: 1000 },
+      },
+      {
+        name: 'beta',
+        id: 9,
+        status: 'completed',
+        conclusion: 'success',
+        check_suite: { id: 1000 },
+      },
     ];
     const dir = mkdtempSync(join(tmpdir(), 'triage-finalize-table-'));
     try {
       writeFileSync(join(dir, 'checks.json'), JSON.stringify(checks));
+      writeFileSync(join(dir, 'runs.json'), JSON.stringify(runs));
       const { status, stdout, stderr } = runHelpers(
-        `table_rows '${join(dir, 'checks.json')}'`,
+        `table_rows '${join(dir, 'checks.json')}' '${join(dir, 'runs.json')}'`,
       );
       expect(stderr).toBe('');
       expect(status).toBe(0);
       expect(stdout.trimEnd().split('\n')).toEqual([
-        'visuals\tin_progress\t',
-        'Serve A/B\tcompleted\tfailure',
-        'alpha\tcompleted\tsuccess',
+        'running\tin_progress\t',
+        'redcheck\tcompleted\tcancelled',
+        'beta\tcompleted\tsuccess',
         'Test (ubuntu-latest)\tcompleted\tsuccess',
       ]);
     } finally {


### PR DESCRIPTION
## What this PR does

Removes the triage agent's in-agent CI polling and moves the "wait for CI" half of the review to a new deterministic finalize workflow. Stage 2b now fetches check-runs exactly once, reports pending checks honestly, and wraps the CI table in `qwen-triage-ci` region markers keyed to the reviewed SHA. When Stage 3 reaches a clean approve verdict while checks are still running, it no longer approves immediately — the comment carries an `approve-on-green` marker instead. A new `qwen-triage-finalize.yml` workflow fires on `workflow_run` completion of `Qwen Code CI` / `E2E Tests` and, in plain bash over the API (no model, no checkout), rewrites the marked table region with the settled results and posts the commit-pinned approval only when every check on that SHA landed green — failing closed on red checks, a moved head, or a closed/draft PR, and flipping the triage status comment to say which way it resolved.

## Why it's needed

The Stage 2b poll loop (`sleep 60`, up to ~10 minutes) can never catch this repo's unit suite, which takes ~30 minutes: the agent starts polling around minute 9 of a 32-minute check, waits its full budget, and always gives up with "CI still running at review time". Concretely on #7680: PR opened 14:42, triage burned 14:51→15:01 polling, Stage 3 **approved at 15:02:10**, and `Test (ubuntu-latest)` finished at **15:14:17** — the approval attested to a result that did not exist yet, and 10 minutes of ECS runner time plus per-poll model turns were spent to obtain nothing. With this change the stage comments land ~10 minutes sooner (roughly halving the triage job), and the deferred approval lands at CI completion — the theoretical minimum for a review that includes the unit-test signal — with full evidence instead of before it.

## Reviewer Test Plan

### How to verify

- `npx vitest run --config ./scripts/tests/vitest.config.ts qwen-triage-finalize-workflow qwen-triage-workflow` — 26 tests pass (13 new). The new suite asserts the security-relevant structure (no checkout, bot-author filter before honoring any marker, SHA-pinned approval, closed green set, self-check exclusion, per-SHA serialized concurrency) and executes the extracted `html_escape` / `replace_region` bash helpers against crafted bodies (region replaced in place, prose preserved, missing end marker → fail closed, escape order `&` first).
- Read `.qwen/skills/triage/references/pr-workflow.md` Stage 2b/Stage 3: polling is now forbidden, the table template carries the region markers, and the approve path branches on the `PENDING` count computed from the existing single fetch (staleness in that direction can only defer, never approve early).
- Marker forgery: the finalize job looks up markers only in comments whose author is the bot identity behind the PAT (`gh api user`), so a third party pasting `approve-on-green` into a PR comment is ignored.
- Head movement: approval is pinned via `commit_id` and additionally re-checks `head.sha`/state/draft at the last moment; any mismatch posts a "stale" status note instead of approving.

### Evidence (Before & After)

Before (#7680, run 30102148473): triage job 14:43→15:02 (~19.7 min, of which ~10 min was the poll loop), Stage 2 comment says "still running after ~10 minutes of polling", approval posted 15:02:10, unit suite finished 15:14:17.

After: the agent posts Stage 2/3 with the once-fetched table (pending rows marked) and no sleep loops; `finalize-triage-ci` updates the table and resolves the deferred approval when the last CI workflow completes. New-workflow behavior is covered by the structural/functional test suite above; it activates on merge (workflow_run listens on the default branch).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

vitest via `scripts/tests/vitest.config.ts`; YAML validated with the repo's `yaml` package and the embedded script with `bash -n`.

## Risk & Scope

- Main risk or tradeoff: the deferred approval depends on a `workflow_run` firing after the marker is posted. The long pole (`Qwen Code CI`, ~30 min) always completes well after Stage 3 (~10 min), so the ordering holds in practice; if every listed workflow somehow finished before the marker landed, the approval simply stays deferred (visible in the status comment) until the next `/triage` re-run — fail-closed, never fail-open.
- Not validated / out of scope: the live `workflow_run` path can only be exercised after merge (GitHub runs the default-branch version); the CI table region renders identically to the current hand-written table but row texts become mechanical (`✅ success` etc.) after the first finalize pass. Shortening the 30-minute unit suite itself (the real lower bound) is out of scope.
- Breaking changes / migration notes: none. Old-format Stage 2 comments without region markers are left untouched by the finalize job; re-runs regenerate comments in the new format.

## Linked Issues

None — follows up on the triage-latency discussion around #7646 / #7648 (static unattended review) using #7680 as the measured example.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

移除 triage agent 的 CI 轮询，把"等待 CI"这一半职责移交给新的确定性 finalize workflow。Stage 2b 现在只拉取一次 check-runs，如实报告 pending 状态，并用绑定被审 SHA 的 `qwen-triage-ci` 定界符包裹 CI 表格。Stage 3 得出干净的 approve 结论但检查仍在运行时，不再立即审批——评论中改为携带 `approve-on-green` 标记。新增的 `qwen-triage-finalize.yml` 在 `Qwen Code CI` / `E2E Tests` 完成时经 `workflow_run` 触发，以纯 bash 调 API（无模型、无 checkout）原地重写定界区内的表格，并且只有当该 SHA 上所有检查全绿时才提交 pin 到该 commit 的审批——红色检查、head 变更、PR 关闭/草稿一律 fail-closed，并同步更新 triage status 评论说明结果。

## 为什么需要

Stage 2b 的轮询循环（`sleep 60`，上限约 10 分钟）永远等不到本仓库约 30 分钟的单测套件：agent 在一个 32 分钟检查的第 9 分钟左右开始轮询，耗尽全部预算后必然以"CI still running at review time"放弃。以 #7680 为例：PR 14:42 打开，triage 在 14:51→15:01 空转轮询，Stage 3 于 **15:02:10 审批**，而 `Test (ubuntu-latest)` **15:14:17** 才跑完——审批为一个尚不存在的结果背了书，10 分钟 ECS runner 时间和每轮轮询的模型调用一无所获。本改动使阶段评论提前约 10 分钟落地（triage job 时长约减半），延迟审批则在 CI 完成时（这是包含单测信号的审查的理论下界）带着完整证据落地。

## 审查者验证方案

- `npx vitest run --config ./scripts/tests/vitest.config.ts qwen-triage-finalize-workflow qwen-triage-workflow` —— 26 个测试通过（新增 13 个）。新测试断言安全关键结构（无 checkout、先验证评论作者是 bot 才认标记、审批 pin SHA、绿色集合封闭、排除自身 check、按 SHA 串行并发），并实际执行抽取出的 `html_escape` / `replace_region` bash 函数（区域原地替换、正文保留、缺失结束标记则 fail-closed、`&` 最先转义）。
- 阅读 `.qwen/skills/triage/references/pr-workflow.md` Stage 2b/Stage 3：禁止轮询，表格模板带定界符，approve 路径按既有单次拉取算出的 `PENDING` 分支（该方向的数据陈旧只会推迟审批，绝不会提前审批）。
- 标记伪造：finalize 只在作者为 bot 本人（`gh api user`）的评论中查找标记，第三方粘贴 `approve-on-green` 无效。
- Head 变更：审批经 `commit_id` pin 定，且在最后时刻复核 `head.sha`/状态/草稿；任何不一致都改为发布 "stale" 状态说明而非审批。

## 证据（Before & After）

Before（#7680，run 30102148473）：triage job 14:43→15:02（约 19.7 分钟，其中约 10 分钟为轮询），Stage 2 评论写着 "still running after ~10 minutes of polling"，15:02:10 审批，单测 15:14:17 完成。

After：agent 以单次拉取的表格（pending 行如实标注）发布 Stage 2/3，无任何 sleep；`finalize-triage-ci` 在最后一个 CI workflow 完成时更新表格并落定延迟审批。新 workflow 行为由上述结构/功能测试覆盖；合并后生效（`workflow_run` 监听默认分支版本）。

## 风险与范围

- 主要风险/权衡：延迟审批依赖标记发布后仍有 `workflow_run` 触发。长尾检查（约 30 分钟的 `Qwen Code CI`）总是远晚于 Stage 3（约 10 分钟）完成，顺序在实践中成立；若所列 workflow 都在标记落地前完成，审批只会保持延迟（status 评论可见），等下次 `/triage` 重跑——只会 fail-closed，不会 fail-open。
- 未验证/范围外：`workflow_run` 实链路只能在合并后验证（GitHub 运行默认分支版本）；首次 finalize 后表格行文变为机械格式（`✅ success` 等）。缩短 30 分钟单测本身（真正的下界）不在本 PR 范围。
- 破坏性变更/迁移说明：无。旧格式（无定界符）的 Stage 2 评论 finalize 不会触碰；重跑会以新格式重写评论。

## 关联 Issue

无——是 #7646 / #7648（无人值守静态审查）之后关于 triage 延迟的后续，以 #7680 为实测样本。

</details>
