### PR TITLE
fix(acp): sweep review worktree leases at the end of each prompt turn

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.review-lease.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.review-lease.test.ts
@@ -1,0 +1,245 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * ACP prompt turns and the /review worktree lease.
+ *
+ * Coverage:
+ *   RL1: the turn body runs inside promptIdContext, so shell subprocesses
+ *        (via getShellContextEnvVars) see QWEN_CODE_PROMPT_ID and
+ *        `qwen review fetch-pr` can record its worktree lease.
+ *   RL2: a completed prompt sweeps this prompt's review-worktree leases
+ *        (no-op when the review's own cleanup step already cleared them).
+ *   RL3: the sweep still runs when the model stream throws — the
+ *        interrupted-/review case the lease mechanism exists for.
+ *   RL4: consecutive prompts sweep under their own prompt IDs.
+ *
+ * Mirrors the harness in Session.worktree.test.ts: real Session, no
+ * module-level mock of @qwen-code/qwen-code-core.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Session } from './Session.js';
+import type { Config, GeminiChat } from '@qwen-code/qwen-code-core';
+import {
+  ApprovalMode,
+  AuthType,
+  Storage,
+  promptIdContext,
+} from '@qwen-code/qwen-code-core';
+import * as core from '@qwen-code/qwen-code-core';
+import type {
+  AgentSideConnection,
+  PromptRequest,
+} from '@agentclientprotocol/sdk';
+import type { LoadedSettings } from '../../config/settings.js';
+
+vi.mock('../../nonInteractiveCliCommands.js', () => ({
+  ALLOWED_BUILTIN_COMMANDS_NON_INTERACTIVE: [],
+  getAvailableCommands: vi.fn().mockResolvedValue([]),
+  handleSlashCommand: vi.fn(),
+}));
+
+const cleanupReviewWorktreeLeases = vi.hoisted(() => vi.fn());
+vi.mock('../../services/review-worktree-lease.js', () => ({
+  cleanupReviewWorktreeLeases,
+}));
+
+function createEmptyStream() {
+  return (async function* () {})();
+}
+
+function makePromptRequest(text = 'hello'): PromptRequest {
+  return {
+    sessionId: 'lease-test-session',
+    prompt: [{ type: 'text', text }],
+  };
+}
+
+describe('Session review-worktree lease sweep', () => {
+  const SESSION_ID = 'lease-test-session';
+  const PROJECT_ROOT = '/repo';
+
+  /** promptIdContext store observed inside each model send. */
+  let observedPromptIds: Array<string | undefined>;
+  let mockChat: GeminiChat;
+  let mockConfig: Config;
+  let mockClient: AgentSideConnection;
+  let mockSettings: LoadedSettings;
+
+  beforeEach(() => {
+    cleanupReviewWorktreeLeases.mockClear();
+    observedPromptIds = [];
+
+    mockChat = {
+      sendMessageStream: vi.fn().mockImplementation(async () => {
+        observedPromptIds.push(promptIdContext.getStore());
+        return createEmptyStream();
+      }),
+      addHistory: vi.fn(),
+      getHistory: vi.fn().mockReturnValue([]),
+      setHistory: vi.fn(),
+      truncateHistory: vi.fn(),
+      stripThoughtsFromHistory: vi.fn(),
+    } as unknown as GeminiChat;
+
+    const mockGeminiClient = {
+      getChat: vi.fn().mockReturnValue(mockChat),
+      tryCompressChat: vi.fn().mockResolvedValue({
+        originalTokenCount: 0,
+        newTokenCount: 0,
+        compressionStatus: core.CompressionStatus.NOOP,
+      }),
+    };
+
+    mockConfig = {
+      storage: {
+        getRuntimeBaseDir: vi.fn(() => Storage.getRuntimeBaseDir()),
+      },
+      setApprovalMode: vi.fn(),
+      getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
+      switchModel: vi.fn(),
+      getModel: vi.fn().mockReturnValue('qwen3'),
+      getSessionId: vi.fn().mockReturnValue(SESSION_ID),
+      assertCanStartTurn: vi.fn().mockResolvedValue(undefined),
+      getWorkingDir: vi.fn().mockReturnValue('/tmp'),
+      getTelemetryLogPromptsEnabled: vi.fn().mockReturnValue(false),
+      getUsageStatisticsEnabled: vi.fn().mockReturnValue(false),
+      getContentGeneratorConfig: vi.fn().mockReturnValue(undefined),
+      getChatRecordingService: vi.fn().mockReturnValue({
+        recordUserMessage: vi.fn(),
+        recordUiTelemetryEvent: vi.fn(),
+        recordToolResult: vi.fn(),
+        recordSlashCommand: vi.fn(),
+        rewindRecording: vi.fn(),
+        setTitleRecordedCallback: vi.fn(),
+      }),
+      getToolRegistry: vi.fn().mockReturnValue({
+        getTool: vi.fn(),
+        ensureTool: vi.fn().mockResolvedValue(true),
+      }),
+      getFileService: vi.fn().mockReturnValue({
+        shouldGitIgnoreFile: vi.fn().mockReturnValue(false),
+      }),
+      getFileFilteringRespectGitIgnore: vi.fn().mockReturnValue(true),
+      getEnableRecursiveFileSearch: vi.fn().mockReturnValue(false),
+      getTargetDir: vi.fn().mockReturnValue('/tmp'),
+      getProjectRoot: vi.fn().mockReturnValue(PROJECT_ROOT),
+      getDebugMode: vi.fn().mockReturnValue(false),
+      getAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+      isCronEnabled: vi.fn().mockReturnValue(false),
+      getSessionTokenLimit: vi.fn().mockReturnValue(0),
+      getGeminiClient: vi.fn().mockReturnValue(mockGeminiClient),
+      getDisableAllHooks: vi.fn().mockReturnValue(true),
+      hasHooksForEvent: vi.fn().mockReturnValue(false),
+      getMessageBus: vi.fn().mockReturnValue(undefined),
+      getStopHookBlockingCap: vi.fn().mockReturnValue(0),
+      getBackgroundTaskRegistry: vi.fn().mockReturnValue({
+        setNotificationCallback: vi.fn(),
+      }),
+      getMonitorRegistry: vi.fn().mockReturnValue({
+        setNotificationCallback: vi.fn(),
+      }),
+      getBackgroundShellRegistry: vi.fn().mockReturnValue({
+        setNotificationCallback: vi.fn(),
+      }),
+      setSubSessionSpawner: vi.fn(),
+      getSubSessionSpawner: vi.fn(),
+    } as unknown as Config;
+
+    mockClient = {
+      sessionUpdate: vi.fn().mockResolvedValue(undefined),
+      requestPermission: vi.fn().mockResolvedValue({
+        outcome: { outcome: 'selected', optionId: 'proceed_once' },
+      }),
+      extNotification: vi.fn().mockResolvedValue(undefined),
+    } as unknown as AgentSideConnection;
+
+    mockSettings = {
+      merged: {},
+      isTrusted: false,
+      user: { settings: {} },
+      workspace: { settings: {} },
+      setValue: vi.fn(),
+    } as unknown as LoadedSettings;
+  });
+
+  afterEach(() => {
+    Storage.setRuntimeBaseDir(null);
+    vi.restoreAllMocks();
+    vi.clearAllTimers();
+  });
+
+  it('RL1: the turn body observes this prompt in promptIdContext', async () => {
+    const session = new Session(
+      SESSION_ID,
+      mockConfig,
+      mockClient,
+      mockSettings,
+    );
+
+    await session.prompt(makePromptRequest());
+
+    expect(observedPromptIds).toEqual([`${SESSION_ID}########1`]);
+  });
+
+  it('RL2: a completed prompt sweeps its review-worktree leases', async () => {
+    const session = new Session(
+      SESSION_ID,
+      mockConfig,
+      mockClient,
+      mockSettings,
+    );
+
+    await session.prompt(makePromptRequest());
+
+    expect(cleanupReviewWorktreeLeases).toHaveBeenCalledTimes(1);
+    expect(cleanupReviewWorktreeLeases).toHaveBeenCalledWith({
+      sessionId: SESSION_ID,
+      promptId: `${SESSION_ID}########1`,
+      repositoryRoot: PROJECT_ROOT,
+    });
+  });
+
+  it('RL3: the sweep still runs when the model stream throws', async () => {
+    (
+      mockChat.sendMessageStream as ReturnType<typeof vi.fn>
+    ).mockRejectedValueOnce(new Error('stream exploded'));
+    const session = new Session(
+      SESSION_ID,
+      mockConfig,
+      mockClient,
+      mockSettings,
+    );
+
+    await session.prompt(makePromptRequest()).catch(() => {});
+
+    expect(cleanupReviewWorktreeLeases).toHaveBeenCalledTimes(1);
+    expect(cleanupReviewWorktreeLeases).toHaveBeenCalledWith(
+      expect.objectContaining({ promptId: `${SESSION_ID}########1` }),
+    );
+  });
+
+  it('RL4: consecutive prompts sweep under their own prompt IDs', async () => {
+    const session = new Session(
+      SESSION_ID,
+      mockConfig,
+      mockClient,
+      mockSettings,
+    );
+
+    await session.prompt(makePromptRequest('first'));
+    await session.prompt(makePromptRequest('second'));
+
+    expect(cleanupReviewWorktreeLeases).toHaveBeenCalledTimes(2);
+    expect(cleanupReviewWorktreeLeases).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ promptId: `${SESSION_ID}########1` }),
+    );
+    expect(cleanupReviewWorktreeLeases).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ promptId: `${SESSION_ID}########2` }),
+    );
+  });
+});

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -143,6 +143,7 @@ import {
   clearGoalTerminalObserver,
   setGoalTerminalObserver,
   sessionIdContext,
+  promptIdContext,
   dedupeToolCallsById,
   getProviderToolCallId,
   parsePositiveIntegerEnv,
@@ -168,6 +169,7 @@ import {
 } from '@qwen-code/acp-bridge/bridgeTypes';
 import { SERVE_CONTROL_EXT_METHODS } from '@qwen-code/acp-bridge/status';
 import { getCommandSubcommandNames } from '../../services/commandMetadata.js';
+import { cleanupReviewWorktreeLeases } from '../../services/review-worktree-lease.js';
 import { getEffectiveSupportedModes } from '../../services/commandUtils.js';
 import { normalizeChannelDeliveryText } from '../../serve/channel-delivery.js';
 import { readVoiceModel } from '../../services/voice-settings.js';
@@ -2425,6 +2427,16 @@ export class Session implements SessionContext {
         this.turn += 1;
 
         const promptId = this.config.getSessionId() + '########' + this.turn;
+        // Bind the prompt ID for the remainder of this turn, mirroring the
+        // sessionIdContext.run wrapper in #executePrompt. Shell subprocesses
+        // read it via getShellContextEnvVars (QWEN_CODE_PROMPT_ID) — without
+        // it, `qwen review fetch-pr` cannot record its worktree lease and an
+        // interrupted /review leaves the review worktree behind. TUI and
+        // headless enter this context at their prompt entry points
+        // (useGeminiStream.ts / nonInteractiveCli.ts); ACP had no equivalent.
+        // enterWith (not run) so the 500-line turn body below stays unnested;
+        // the binding dies with this async scope.
+        promptIdContext.enterWith(promptId);
         const parentContext = extractDaemonTraceContext(params);
 
         return await withInteractionSpan(
@@ -3009,6 +3021,19 @@ export class Session implements SessionContext {
                   turnCount,
                 ),
               );
+              // Remove review worktrees leased during this prompt and not
+              // released by the skill's own cleanup step — a cancelled or
+              // errored /review otherwise leaves `.qwen/tmp/review-pr-<n>`
+              // and its branch behind. Unconditional like the headless
+              // finally (nonInteractiveCli.ts): the ACP turn loop runs
+              // whole turns, so unlike the TUI's per-continuation
+              // submitQuery this can never fire mid-review. No-op when the
+              // lease was already cleared by `qwen review cleanup`.
+              cleanupReviewWorktreeLeases({
+                sessionId: this.config.getSessionId(),
+                promptId,
+                repositoryRoot: this.config.getProjectRoot(),
+              });
             }
           },
           (result: { stopReason: PromptResponse['stopReason'] }) =>

--- a/packages/cli/src/acp-integration/session/Session.worktree.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.worktree.test.ts
@@ -131,6 +131,9 @@ describe('Session.pendingWorktreeNotice', () => {
       getFileFilteringRespectGitIgnore: vi.fn().mockReturnValue(true),
       getEnableRecursiveFileSearch: vi.fn().mockReturnValue(false),
       getTargetDir: vi.fn().mockReturnValue('/tmp'),
+      // The prompt turn's finally sweeps review-worktree leases against the
+      // project root (see Session.review-lease.test.ts).
+      getProjectRoot: vi.fn().mockReturnValue('/tmp'),
       getDebugMode: vi.fn().mockReturnValue(false),
       getAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
       isCronEnabled: vi.fn().mockReturnValue(false),


### PR DESCRIPTION
## Problem

Cancelling (or crashing out of) a `/review` in a Web Shell / daemon session leaves the review worktree `.qwen/tmp/review-pr-<n>` and the `qwen-review/pr-<n>` branch behind. They stay on disk until the next review of the same PR runs its stale-state cleanup, or someone runs `qwen review cleanup pr-<n>` by hand.

The root cause is one level below the missing cleanup call: the ACP prompt path never enters `promptIdContext`. Only the TUI (`useGeminiStream.ts`) and headless (`nonInteractiveCli.ts`) entry points wrap the turn in `promptIdContext.run`, so in daemon sessions `getShellContextEnvVars` emits an empty `QWEN_CODE_PROMPT_ID`, and `createReviewWorktreeLease` (called by `qwen review fetch-pr`) silently no-ops — the lease that interruption cleanup depends on is never recorded in the first place.

## Fix

Two small changes in `Session.ts`, mirroring the existing surfaces:

- **Bind the prompt ID** in `#executePromptInner` right after it is computed, via `promptIdContext.enterWith(promptId)` — the analogue of the `sessionIdContext.run` wrapper in `#executePrompt`. `enterWith` (rather than `run`) keeps the ~500-line turn body unnested; the binding dies with the turn's async scope. Shell subprocesses now see the real prompt ID and the lease gets recorded.
- **Sweep the leases** in the turn-wide `finally` (the one that already emits `ConversationFinishedEvent`, which runs on every terminal path: end_turn, cancelled, thrown). Unconditional like the headless `finally` in `nonInteractiveCli.ts` — the ACP loop runs whole turns, so unlike the TUI's per-continuation `submitQuery` this can never fire mid-review. When the review completed normally, its own cleanup step already released the lease and the sweep is a no-op.

`config.getProjectRoot()` is the correct lease root even for worktree-isolated sessions: `relocateWorkingDirectory` updates `targetDir` when the daemon relocates a session into its worktree, matching the `process.cwd()` that `fetch-pr` records.

## Tests

New `Session.review-lease.test.ts` (reuses the `Session.worktree.test.ts` harness — real `Session`, no module-level core mock):

- RL1: the turn body observes the prompt ID in `promptIdContext` (the binding shell subprocesses inherit).
- RL2: a completed prompt sweeps its leases with the exact `{sessionId, promptId, repositoryRoot}` triple.
- RL3: the sweep still runs when the model stream throws — the interrupted-review case this exists for.
- RL4: consecutive prompts sweep under their own prompt IDs.

The `Session.worktree.test.ts` mock config gains `getProjectRoot` (the new `finally` calls it on every turn; `Session.test.ts` and `acpAgent.test.ts` mocks already had it).

Full `src/acp-integration` suite: 1064/1064 passing.

## Not covered (intentionally)

- Cron/notification turns still don't enter `promptIdContext`; they don't run `/review`, so kept out of scope.
- A SIGKILL of the daemon child mid-review still can't run the `finally`; the next same-PR review's stale-state cleanup remains the backstop, as before.

<details>
<summary>中文版</summary>

## 问题

在 Web Shell / daemon 会话中取消(或异常中断)一次 `/review`,会把 review worktree `.qwen/tmp/review-pr-<n>` 和分支 `qwen-review/pr-<n>` 留在磁盘上,直到下次审同一个 PR 时的陈旧状态清理兜底,或者手动执行 `qwen review cleanup pr-<n>`。

根因比"少了一处清理调用"更深一层:ACP prompt 通路从未进入 `promptIdContext`。只有 TUI(`useGeminiStream.ts`)和 headless(`nonInteractiveCli.ts`)入口用 `promptIdContext.run` 包裹整个 turn,因此 daemon 会话里 `getShellContextEnvVars` 注入的 `QWEN_CODE_PROMPT_ID` 是空串,`qwen review fetch-pr` 调用的 `createReviewWorktreeLease` 静默 no-op —— 中断清理所依赖的 lease 从一开始就没有被记录。

## 修复

`Session.ts` 里两处小改动,与既有通路对齐:

- **绑定 prompt ID**:在 `#executePromptInner` 计算出 `promptId` 后立即 `promptIdContext.enterWith(promptId)`,对应 `#executePrompt` 里已有的 `sessionIdContext.run` 包裹。用 `enterWith`(而非 `run`)是为了不给约 500 行的 turn 主体增加一层嵌套;绑定随 turn 的 async 作用域消亡。此后 shell 子进程能看到真实的 prompt ID,lease 得以记录。
- **清扫 lease**:放在 turn 级 `finally`(即已发出 `ConversationFinishedEvent` 的那个,覆盖 end_turn / cancelled / 抛错所有终止路径)。与 headless 的 `nonInteractiveCli.ts` 一样无条件执行 —— ACP 循环一次跑完整个 turn,不像 TUI 的 `submitQuery` 按 tool-result continuation 分次调用,因此绝不会在 review 进行中途触发。review 正常完成时其自身的 cleanup 步骤已释放 lease,这里的清扫是 no-op。

对 worktree 隔离会话,`config.getProjectRoot()` 也是正确的 lease 根:daemon 把会话迁入 worktree 时 `relocateWorkingDirectory` 会更新 `targetDir`,与 `fetch-pr` 记录的 `process.cwd()` 一致。

## 测试

新增 `Session.review-lease.test.ts`(复用 `Session.worktree.test.ts` 的 harness —— 真实 `Session`,不做模块级 core mock):

- RL1:turn 主体内能观测到 `promptIdContext` 中的 prompt ID(即 shell 子进程继承的绑定)。
- RL2:prompt 正常完成后按精确的 `{sessionId, promptId, repositoryRoot}` 三元组清扫 lease。
- RL3:模型流抛错时清扫仍会执行 —— 正是本机制针对的"review 被中断"场景。
- RL4:连续多个 prompt 各自用自己的 prompt ID 清扫。

`Session.worktree.test.ts` 的 mock config 补充了 `getProjectRoot`(新的 `finally` 每个 turn 都会调用它;`Session.test.ts` 和 `acpAgent.test.ts` 的 mock 原本就有)。

`src/acp-integration` 全套:1064/1064 通过。

## 有意不覆盖

- cron/notification turn 仍未进入 `promptIdContext`;它们不会运行 `/review`,故不在本次范围内。
- review 进行中 daemon 子进程被 SIGKILL 时 `finally` 依然无法执行;和之前一样,由下次审同一 PR 的陈旧状态清理兜底。

</details>
