### PR TITLE
fix(triage): resolve stage comment ids by marker at patch time, harden model injection

### DIFF
--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -71,7 +71,7 @@ jobs:
     # Canonical same-repo guard: this job loads CI_BOT_PAT, so fork-triggered
     # runs stay on hosted (ephemeral); only in-repo PR events on QwenLM/qwen-code
     # use the persistent ECS runner.
-    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
+    runs-on: "${{ (github.repository == 'QwenLM/qwen-code' && vars.MAINTAINER_ECS_RUNNER_DISABLED != 'true' && github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('[\"self-hosted\", \"linux\", \"x64\", \"ecs-qwen\"]') || fromJSON('[\"ubuntu-latest\"]') }}"
     timeout-minutes: 5
     permissions:
       contents: 'read'
@@ -193,7 +193,7 @@ jobs:
     # PRs), go to ephemeral hosted runners so a steered agent cannot persist
     # anything across runs. Forks of this repo fall back to ubuntu-latest as
     # before.
-    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event_name == ''issues'' || (github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository))) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
+    runs-on: "${{ (github.repository == 'QwenLM/qwen-code' && vars.MAINTAINER_ECS_RUNNER_DISABLED != 'true' && (github.event_name == 'issues' || (github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository))) && fromJSON('[\"self-hosted\", \"linux\", \"x64\", \"ecs-qwen\"]') || fromJSON('[\"ubuntu-latest\"]') }}"
     # startsWith (not contains) prevents false triggers from comments that
     # mention the phrase in quoted text or mid-sentence descriptions.
     # always() so the job still evaluates when the upstream `authorize` job is
@@ -281,7 +281,7 @@ jobs:
           echo "stale agent state cleaned"
 
       - name: 'Checkout repo'
-        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
+        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10'  # v6.0.3
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
 
@@ -816,7 +816,7 @@ jobs:
 
       - name: 'Checkout PR merge ref'
         if: "steps.pr.outputs.decision == 'run'"
-        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
+        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10'  # v6.0.3
         with:
           # Untrusted PR code — keep the token out of .git/config.
           persist-credentials: false

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -71,7 +71,7 @@ jobs:
     # Canonical same-repo guard: this job loads CI_BOT_PAT, so fork-triggered
     # runs stay on hosted (ephemeral); only in-repo PR events on QwenLM/qwen-code
     # use the persistent ECS runner.
-    runs-on: "${{ (github.repository == 'QwenLM/qwen-code' && vars.MAINTAINER_ECS_RUNNER_DISABLED != 'true' && github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('[\"self-hosted\", \"linux\", \"x64\", \"ecs-qwen\"]') || fromJSON('[\"ubuntu-latest\"]') }}"
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     timeout-minutes: 5
     permissions:
       contents: 'read'
@@ -193,7 +193,7 @@ jobs:
     # PRs), go to ephemeral hosted runners so a steered agent cannot persist
     # anything across runs. Forks of this repo fall back to ubuntu-latest as
     # before.
-    runs-on: "${{ (github.repository == 'QwenLM/qwen-code' && vars.MAINTAINER_ECS_RUNNER_DISABLED != 'true' && (github.event_name == 'issues' || (github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository))) && fromJSON('[\"self-hosted\", \"linux\", \"x64\", \"ecs-qwen\"]') || fromJSON('[\"ubuntu-latest\"]') }}"
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event_name == ''issues'' || (github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository))) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     # startsWith (not contains) prevents false triggers from comments that
     # mention the phrase in quoted text or mid-sentence descriptions.
     # always() so the job still evaluates when the upstream `authorize` job is
@@ -281,7 +281,7 @@ jobs:
           echo "stale agent state cleaned"
 
       - name: 'Checkout repo'
-        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10'  # v6.0.3
+        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
 
@@ -339,9 +339,22 @@ jobs:
           OPENAI_MODEL: '${{ vars.QWEN_TRIAGE_MODEL || vars.QWEN_PR_REVIEW_MODEL }}'
         run: |-
           set -euo pipefail
-          if [ -n "${OPENAI_MODEL:-}" ]; then
-            sed -i "s/qwen3\.7-max/${OPENAI_MODEL}/g" .qwen/skills/triage/references/pr-workflow.md
+          if [ -z "${OPENAI_MODEL:-}" ]; then
+            exit 0
           fi
+          TARGET=.qwen/skills/triage/references/pr-workflow.md
+          # The default signature literal must still exist in the skill, or
+          # this injection silently no-ops and every staged comment ships the
+          # wrong model name. Fail loudly so a skill edit that renames the
+          # default surfaces here instead of in production comments.
+          if ! grep -q 'qwen3\.7-max' "$TARGET"; then
+            echo "::error::Signature literal 'qwen3.7-max' not found in $TARGET — update this step's sed target to match the skill."
+            exit 1
+          fi
+          # Escape sed replacement metacharacters (& / \) so a model name
+          # containing them cannot corrupt the skill text.
+          ESCAPED=$(printf '%s' "$OPENAI_MODEL" | sed -e 's/[&/\]/\\&/g')
+          sed -i "s/qwen3\.7-max/${ESCAPED}/g" "$TARGET"
 
       - name: 'Run Qwen Triage'
         id: 'triage'
@@ -626,8 +639,8 @@ jobs:
           set -uo pipefail
           MARKER='<!-- qwen-triage stage=status -->'
           if [ "${TRIAGE_OUTCOME:-}" = 'success' ]; then
-            EN="✅ **Qwen Triage finished** — [view run]($RUN_URL). See the stage comments above for the result."
-            ZH="✅ **Qwen Triage 已完成** —— [查看运行]($RUN_URL)。结果见上方各阶段评论。"
+            EN="✅ **Qwen Triage finished** — [view run]($RUN_URL). See the stage comments in this thread for the result."
+            ZH="✅ **Qwen Triage 已完成** —— [查看运行]($RUN_URL)。结果见本线程中的各阶段评论。"
           else
             EN="⚠️ **Qwen Triage ended early** — [view run]($RUN_URL). It stopped before finishing; check the run log."
             ZH="⚠️ **Qwen Triage 提前结束** —— [查看运行]($RUN_URL)。未跑完,请查看运行日志。"
@@ -803,7 +816,7 @@ jobs:
 
       - name: 'Checkout PR merge ref'
         if: "steps.pr.outputs.decision == 'run'"
-        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10'  # v6.0.3
+        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
         with:
           # Untrusted PR code — keep the token out of .git/config.
           persist-credentials: false

--- a/.qwen/skills/triage/references/pr-workflow.md
+++ b/.qwen/skills/triage/references/pr-workflow.md
@@ -25,11 +25,20 @@ or Stage 1c direction escalation), submit exactly one `CHANGES_REQUESTED`
 review and stop. Do not also post or update a Stage 1 issue comment, and do not
 continue to Stage 2, Stage 3, or approval.
 
-**Re-runs:** if the triage runs again on the same PR, update each comment in place:
+**Re-runs:** if the triage runs again on the same PR, update each comment in place. **Resolve the comment id by its stage marker AT PATCH TIME — never from memory, list position, or an earlier stage's bookkeeping.** On a re-run the thread holds four or more bot comments whose list order is not the stage order, and a wrong id silently overwrites another stage's comment (observed on a real re-run: the stage=3 comment clobbered with stage=1 content mid-run). The author filter matters too — the marker is public text anyone can paste into a comment, and the bot PAT may be able to edit other users' comments:
 
 ```bash
-gh api -X PATCH "/repos/$REPO/issues/comments/$COMMENT_ID" -F body=@/tmp/stage-N-updated.md
+BOT_LOGIN=$(gh api user --jq '.login')
+stage_comment_id() { # $1 = stage number (1, 2, 3) or "status"
+  gh api "repos/$REPO/issues/$PR_NUMBER/comments" --method GET --paginate -F per_page=100 |
+    jq -rs --arg bot "$BOT_LOGIN" --arg m "<!-- qwen-triage stage=$1 -->" \
+      '[.[][] | select(.user.login == $bot) | select(.body | startswith($m))] | last | .id // empty'
+}
+CID=$(stage_comment_id 2)   # re-resolve immediately before EACH patch
+[ -n "$CID" ] && gh api -X PATCH "/repos/$REPO/issues/comments/$CID" -F body=@/tmp/stage-2-updated.md
 ```
+
+`startswith`, not `contains`: stage comments carry their marker as the first line, and a substring match would also hit a comment that merely quotes the marker. An empty `CID` means that stage has no comment yet — POST a new one instead of patching.
 
 Never create duplicates. For terminal-exit reviews (submitted via
 `gh pr review --request-changes`), the GitHub API does not support editing PR

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -17,6 +17,10 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const workflow = readFileSync('.github/workflows/qwen-triage.yml', 'utf8');
+const prSkill = readFileSync(
+  '.qwen/skills/triage/references/pr-workflow.md',
+  'utf8',
+);
 
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -359,5 +363,23 @@ describe('qwen-triage tmux workflow', () => {
     const empty = run('', 'sig: qwen3.7-max end');
     expect(empty.status).toBe(0);
     expect(empty.out).toBe('sig: qwen3.7-max end');
+  });
+
+  it('pins the re-run comment-id recipe to startswith and the bot-author filter', () => {
+    // The skill's stage_comment_id() exists because a re-run once PATCHed the
+    // stage=3 comment with stage=1 content (#7693). Its two load-bearing
+    // constraints must not silently regress: `startswith` (a `contains` match
+    // would also hit a comment that merely quotes a marker) and the
+    // bot-author filter (markers are public text; the PAT may be able to
+    // edit other users' comments).
+    const section = prSkill.slice(
+      prSkill.indexOf('**Re-runs:**'),
+      prSkill.indexOf('Never create duplicates'),
+    );
+    expect(section).toContain('stage_comment_id()');
+    expect(section).toContain('select(.user.login == $bot)');
+    expect(section).toContain('startswith($m)');
+    expect(section).not.toContain('contains($m)');
+    expect(section).toContain('re-resolve immediately before EACH patch');
   });
 });

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -324,6 +324,16 @@ describe('qwen-triage tmux workflow', () => {
     const body = injectStep.match(/run: \|-\n([\s\S]*)$/)?.[1];
     expect(body).toBeTruthy();
     const script = body.replace(/^ {10}/gm, '');
+    // The workflow step only ever executes on ubuntu runners (GNU sed), but
+    // this suite also runs in the macOS merge-queue job, where BSD sed
+    // requires an extension argument after -i. Shim ONLY on darwin: on GNU
+    // sed a separated '' is parsed as the sed script (not the -i suffix), so
+    // an unconditional rewrite would break the Linux runs that actually
+    // mirror production.
+    const portableScript =
+      process.platform === 'darwin'
+        ? script.replace(/sed -i /g, "sed -i '' ")
+        : script;
 
     const run = (model, content) => {
       const dir = mkdtempSync(join(tmpdir(), 'triage-inject-'));
@@ -331,7 +341,7 @@ describe('qwen-triage tmux workflow', () => {
         const target = join(dir, '.qwen/skills/triage/references');
         mkdirSync(target, { recursive: true });
         writeFileSync(join(target, 'pr-workflow.md'), content);
-        const proc = spawnSync('bash', ['-c', script], {
+        const proc = spawnSync('bash', ['-c', portableScript], {
           cwd: dir,
           env: { ...process.env, OPENAI_MODEL: model },
           encoding: 'utf8',

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -5,7 +5,15 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const workflow = readFileSync('.github/workflows/qwen-triage.yml', 'utf8');
@@ -305,5 +313,51 @@ describe('qwen-triage tmux workflow', () => {
     expect(
       workflow.indexOf("- name: 'Install tmux runner tools'"),
     ).toBeLessThan(workflow.indexOf("- name: 'Checkout PR merge ref'"));
+  });
+
+  it('escapes injected model names and fails loudly when the signature literal is gone', () => {
+    const injectStep = step('Inject model name into triage signature');
+    const body = injectStep.match(/run: \|-\n([\s\S]*)$/)?.[1];
+    expect(body).toBeTruthy();
+    const script = body.replace(/^ {10}/gm, '');
+
+    const run = (model, content) => {
+      const dir = mkdtempSync(join(tmpdir(), 'triage-inject-'));
+      try {
+        const target = join(dir, '.qwen/skills/triage/references');
+        mkdirSync(target, { recursive: true });
+        writeFileSync(join(target, 'pr-workflow.md'), content);
+        const proc = spawnSync('bash', ['-c', script], {
+          cwd: dir,
+          env: { ...process.env, OPENAI_MODEL: model },
+          encoding: 'utf8',
+        });
+        return {
+          status: proc.status,
+          out: readFileSync(join(target, 'pr-workflow.md'), 'utf8'),
+          log: `${proc.stdout}${proc.stderr}`,
+        };
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    };
+
+    // A model name carrying every sed replacement metacharacter (/ & \) must
+    // land verbatim — the old unescaped sed corrupted the skill text on these.
+    const meta = run('m1/pre&post\\x', 'sig: qwen3.7-max end');
+    expect(meta.status).toBe(0);
+    expect(meta.out).toBe('sig: m1/pre&post\\x end');
+
+    // The signature literal disappearing from the skill must fail the step —
+    // the old silent no-op shipped the wrong model name in every comment.
+    const missing = run('m2', 'sig: some-other-model end');
+    expect(missing.status).not.toBe(0);
+    expect(missing.log).toContain('Signature literal');
+    expect(missing.out).toBe('sig: some-other-model end');
+
+    // No model configured → file untouched, step succeeds.
+    const empty = run('', 'sig: qwen3.7-max end');
+    expect(empty.status).toBe(0);
+    expect(empty.out).toBe('sig: qwen3.7-max end');
   });
 });


### PR DESCRIPTION
## What this PR does

Hardens two fragile spots in the triage pipeline that surfaced while shepherding #7693, and fixes one wording error. First, re-run comment updates in the triage skill now resolve the target comment id **by its stage marker at PATCH time** — bot-author-filtered, `startswith` match, re-resolved immediately before each PATCH — instead of trusting ids the agent remembered from earlier in the run. Second, the model-name injection step in `qwen-triage.yml` now fails the job loudly when the `qwen3.7-max` signature literal is missing from the skill (previously a silent no-op that would ship the wrong model name in every comment) and escapes sed replacement metacharacters in the model name (previously `/`, `&`, or `\` in a configured model corrupted the skill text). Third, the terminal status comment said "see the stage comments **above**", but the status comment is created before the stage comments, so they are below it — now "in this thread".

## Why it's needed

Observed on a real `/triage` re-run of #7693: with four bot comments in the thread (status + stages 1–3), the agent PATCHed the **stage=3 comment with stage=1 content** mid-run before later self-correcting. Remembered-id bookkeeping is fragile exactly when re-runs matter most — the thread's list order is not the stage order, and one wrong id silently destroys another stage's record. The marker-resolution recipe makes the correct id a lookup, not a memory. The injection hardening closes the two standing failure modes of a raw `sed -i "s/…/${OPENAI_MODEL}/g"`: a renamed literal degrades silently, and an unusual model name writes garbage into the prompt the agent is about to execute.

## Reviewer Test Plan

### How to verify

- `npx vitest run --config ./scripts/tests/vitest.config.ts qwen-triage-workflow qwen-triage-finalize-workflow` — 32 tests pass (1 new). The new test extracts the actual injection step script and runs it against fixture files: a model name carrying `/ & \` lands verbatim in the skill text, a missing signature literal fails the step with the `Signature literal` error (file untouched), and an empty model leaves the file untouched with success.
- Read the **Re-runs** section of `.qwen/skills/triage/references/pr-workflow.md`: the `stage_comment_id` recipe filters on the bot's own login (markers are public text; the PAT may be able to edit others' comments) and uses `startswith` so a comment merely quoting a marker can't be targeted.

### Evidence (Before & After)

Before: on #7693's second `/triage` re-run, comment 5073149611 (stage=3) was PATCHed to stage=1 content at 21:06:48 UTC before the agent self-corrected at 21:08:37 — visible in that comment's edit history. Injection step: `sed -i "s/qwen3\.7-max/${OPENAI_MODEL}/g"` with no existence check and no escaping.

After: id resolution is a marker lookup at PATCH time (skill instruction), and the injection behavior is pinned by the new behavioral test. N/A for UI.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

vitest via `scripts/tests/vitest.config.ts`; workflow YAML re-parsed with the repo's `yaml` package.

## Risk & Scope

- Main risk or tradeoff: the skill change is prompt guidance — the agent must follow it (the deterministic backstop for approvals already lives in the finalize workflow from #7693). The injection step can now fail the triage job when the literal is renamed without updating the step; that is the intended loud failure, and the test pins the pairing.
- Not validated / out of scope: no live re-run was driven against a production PR for this change; consolidating stage-comment bookkeeping into a deterministic workflow step (rather than agent-followed instructions) is a possible future step.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #7693 (observations from its shepherding).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

加固在护航 #7693 时暴露的两个脆弱点，并修正一处文案。其一，triage skill 的 re-run 评论更新改为**在 PATCH 时按 stage 标记现场解析评论 id**——过滤 bot 本人作者、`startswith` 匹配、每次 PATCH 前重新解析——不再信任 agent 在运行早期记住的 id。其二，`qwen-triage.yml` 的模型名注入步骤在 skill 中找不到 `qwen3.7-max` 签名字面量时会大声失败（此前是静默 no-op，会让每条评论都带错误模型名），并对模型名中的 sed 替换元字符转义（此前配置的模型名含 `/`、`&` 或 `\` 会写坏 skill 文本）。其三，终态 status 评论写"见**上方**各阶段评论"，但 status 评论创建在最前、各阶段评论在其下方——改为"本线程中"。

## 为什么需要

在 #7693 的一次真实 `/triage` 重跑中观察到：线程里有四条 bot 评论（status + stage 1–3）时，agent 中途把 **stage=3 评论 PATCH 成了 stage=1 内容**，稍后才自行纠正。记忆式 id 簿记恰恰在最需要 re-run 的场景下最脆弱——线程列表顺序不等于 stage 顺序，一个错误 id 就会静默摧毁另一个 stage 的记录。标记解析法把"正确的 id"变成一次查找而非一段记忆。注入加固则堵住裸 `sed -i` 的两个既有失败模式：字面量改名后静默退化；特殊模型名向 agent 即将执行的提示词里写入垃圾。

## 审查者验证方案

- `npx vitest run --config ./scripts/tests/vitest.config.ts qwen-triage-workflow qwen-triage-finalize-workflow` —— 32 个测试通过（新增 1 个）。新测试抽取真实注入步骤脚本并对 fixture 文件执行：含 `/ & \` 的模型名原样落入 skill 文本；签名字面量缺失时步骤以 `Signature literal` 错误失败（文件不动）；模型名为空时文件不动、步骤成功。
- 阅读 `.qwen/skills/triage/references/pr-workflow.md` 的 **Re-runs** 一节：`stage_comment_id` 过滤 bot 本人登录名（标记是任何人都能粘贴的公开文本，且 PAT 可能有权编辑他人评论），并用 `startswith` 防止仅引用标记的评论被误定位。

## 证据（Before & After）

Before：#7693 第二次 `/triage` 重跑中，评论 5073149611（stage=3）于 21:06:48 UTC 被 PATCH 成 stage=1 内容，21:08:37 才被 agent 自行纠正——该评论的编辑历史可见。注入步骤为无存在性检查、无转义的裸 `sed -i`。

After：id 解析改为 PATCH 时的标记查找（skill 指令），注入行为由新的行为测试固定。无 UI 变化。

## 风险与范围

- 主要风险/权衡：skill 改动属于提示词指导——依赖 agent 遵循（审批的确定性兜底已由 #7693 的 finalize workflow 承担）。字面量改名而未同步更新注入步骤时 triage job 会失败——这是有意的大声失败，测试固定了这一配对。
- 未验证/范围外：未针对生产 PR 驱动真实重跑验证本改动；将 stage 评论簿记整体下沉为确定性 workflow 步骤（而非 agent 遵循的指令）是可能的后续方向。
- 破坏性变更/迁移说明：无。

## 关联 Issue

#7693 的后续（护航过程中的观察）。

</details>
