### PR TITLE
fix(web-shell): add :focus-visible outline to GitHub PR list rows

### DIFF
--- a/packages/web-shell/client/components/dialogs/GitHubPrsDialog.module.css
+++ b/packages/web-shell/client/components/dialogs/GitHubPrsDialog.module.css
@@ -35,6 +35,11 @@
   background: var(--subtle-bg, rgba(128, 128, 128, 0.06));
 }
 
+.prRow:focus-visible {
+  outline: 2px solid var(--agent-blue-500);
+  outline-offset: 2px;
+}
+
 .prLine {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## What this PR does

Adds a `:focus-visible` outline to the pull-request list rows in the Web Shell Git dialog. The row is a `<button>`, but unlike its sibling dialog rows it shipped without a focus indicator, so keyboard users tabbing through the list had no visible cue about which PR was focused. The outline matches the style already used by the other dialog rows.

## Why it's needed

Follow-up to #7683. An external review flagged the missing focus indicator; every other interactive row/button in the dialog family defines `:focus-visible`, so this brings the PR list in line with the established accessibility convention.

## Reviewer Test Plan

### How to verify

Open the Web Shell Git dialog on a workspace with open pull requests (or run `/prs`), then press Tab to move focus into the PR list. The focused row should show a 2px blue outline offset from the row, matching the focus style of rows in the other dialogs. Mouse users see no change (the outline only appears for keyboard focus).

### Evidence (Before & After)

Before: tabbing through the PR list showed no focus indicator. After: the focused row shows the standard 2px `--agent-blue-500` outline.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

CSS-only change; verified formatting and the existing PR-panel unit tests still pass.

## Risk & Scope

- Main risk or tradeoff: none — additive CSS scoped to the PR row, no behavior change for mouse users.
- Not validated / out of scope: the other items raised in the external review were triaged and declined (one cited a non-existent lint rule; one suggested misclassifying completed CI states as pending; the rest were style preferences or impossible-scenario handling).
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

为 Web Shell Git 对话框中的拉取请求列表行补上 `:focus-visible` 焦点轮廓。该行是一个 `<button>`，但与其它兄弟对话框的行不同，它缺少焦点指示器，键盘用户用 Tab 遍历列表时看不到当前聚焦在哪条 PR 上。轮廓样式与其它对话框行保持一致。

## 为什么需要

#7683 的后续。外部 review 指出缺少焦点指示器；对话框家族里其它所有可交互行/按钮都定义了 `:focus-visible`，本 PR 让 PR 列表对齐既有的可访问性约定。

## 评审验证计划

### 如何验证

在有开放 PR 的工作区打开 Web Shell Git 对话框（或执行 `/prs`），按 Tab 把焦点移入 PR 列表。聚焦的行应显示一圈 2px 蓝色轮廓（与行有偏移），与其它对话框行的焦点样式一致。鼠标用户无变化（轮廓仅在键盘焦点时出现）。

### 前后对照

Before：Tab 遍历 PR 列表无焦点指示。After：聚焦行显示标准 2px `--agent-blue-500` 轮廓。

### 测试平台

macOS 已测试；Windows、Linux 未单独验证（由 CI 覆盖）。

### 环境（可选）

纯 CSS 改动；已验证格式与现有 PR 面板单测仍通过。

## 风险与范围

- 主要风险或取舍：无——仅是作用于 PR 行的增量 CSS，鼠标用户行为不变。
- 未验证/范围之外：外部 review 的其它条目已逐条核验并拒绝（一条引用了不存在的 lint 规则；一条建议把已完成的 CI 态误判为进行中；其余为风格偏好或不可能场景的防御处理）。
- 破坏性变更/迁移说明：无。

## 关联 Issue

无

</details>
