### PR TITLE
perf(cli): cache GitHub PR list in the daemon route with a 60s TTL

### DIFF
--- a/docs/design/web-shell-github-prs.md
+++ b/docs/design/web-shell-github-prs.md
@@ -148,6 +148,23 @@ pullRequests: DaemonGitHubPullRequest[] }`(`pullRequests` 恒在,不可用时为
 | `packages/web-shell/client/components/dialogs/GitDialog.tsx`                    | 第三 tab    |
 | `packages/web-shell/client/App.tsx` / `constants/localCommands.ts` / `i18n.tsx` | 入口 + 文案 |
 
+## 性能优化:daemon 侧 TTL 缓存
+
+`gh pr list --json …,statusCheckRollup` 是慢点——为 30 个 PR 各拉 CI rollup
+要多秒级 GitHub 往返(实测本仓库冷启动 ~8s,CPU 时间仅 ~0.07s,纯网络
+I/O)。面板是"瞟一眼"性质,数据 stale 一分钟完全可接受,故在 daemon 路由
+加闭包级、按 workspaceCwd 分键的短 TTL 缓存(默认 60s,`cacheTtlMs` 可注入,
+对齐 `usage-stats.ts` 的既有约定):
+
+- **单飞合并**:进行中的 load 无论新旧都复用,并发打开共享一次 `gh` 拉起
+  (即使它超过 TTL);TTL 窗口从 load 落定后开始计。
+- **仅缓存 `ok`**:`cli_unavailable`/`failed`/`not_a_repo` 落定即清条目,
+  下次打开重试(用户可能刚装好/登录 gh,或工作区刚变成仓库)。
+- 实测:冷启动 8.0s → 缓存命中 ~2ms(约 2500 倍)。
+
+首次打开仍慢(~8s)是 `gh` 本身的延迟;如需改善首屏,后续可做两阶段加载
+(先不带 `statusCheckRollup` 快速渲染列表,再异步补 CI 图标),不在本次范围。
+
 ## 开放问题
 
 - 无。`gh` 缺失/未登录、非 git 仓库、旧 daemon 三条降级路径均有明确

--- a/packages/cli/src/serve/routes/workspace-github-prs.test.ts
+++ b/packages/cli/src/serve/routes/workspace-github-prs.test.ts
@@ -42,6 +42,16 @@ function registry(runtimes: WorkspaceRuntime[]): WorkspaceRegistry {
   return createWorkspaceRegistry(runtimes);
 }
 
+function mount(deps: { cacheTtlMs?: number } = {}) {
+  const app = express();
+  registerWorkspaceQualifiedGitHubPrsRoutes(app, {
+    workspaceRegistry: registry([runtime('primary', '/work/main', true)]),
+    sendBridgeError,
+    ...deps,
+  });
+  return app;
+}
+
 const PR = {
   number: 42,
   title: 'Add a thing',
@@ -208,5 +218,96 @@ describe('workspace GitHub PR routes', () => {
 
     expect(response.status).toBe(500);
     expect(response.body.error).toBe('boom');
+  });
+});
+
+describe('workspace GitHub PR routes — caching', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('serves a cached ok result within the TTL without re-running gh', async () => {
+    fetchGitHubPullRequestsMock.mockResolvedValue({
+      kind: 'ok',
+      pullRequests: [PR],
+    });
+    const app = mount({ cacheTtlMs: 60_000 });
+
+    const first = await request(app).get('/workspaces/primary/github/prs');
+    const second = await request(app).get('/workspaces/primary/github/prs');
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(second.body.pullRequests).toEqual([PR]);
+    expect(fetchGitHubPullRequestsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('reloads on every request when the TTL is 0', async () => {
+    fetchGitHubPullRequestsMock.mockResolvedValue({
+      kind: 'ok',
+      pullRequests: [PR],
+    });
+    const app = mount({ cacheTtlMs: 0 });
+
+    await request(app).get('/workspaces/primary/github/prs');
+    await request(app).get('/workspaces/primary/github/prs');
+
+    expect(fetchGitHubPullRequestsMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache a failed result (the next open retries gh)', async () => {
+    fetchGitHubPullRequestsMock
+      .mockResolvedValueOnce({
+        kind: 'failed',
+        message: 'gh: not logged in',
+        gitRoot: '/work/main',
+      })
+      .mockResolvedValueOnce({ kind: 'ok', pullRequests: [PR] });
+    const app = mount({ cacheTtlMs: 60_000 });
+
+    const first = await request(app).get('/workspaces/primary/github/prs');
+    expect(first.status).toBe(502);
+    expect(first.body.code).toBe('github_prs_failed');
+
+    const second = await request(app).get('/workspaces/primary/github/prs');
+    expect(second.status).toBe(200);
+    expect(second.body.pullRequests).toEqual([PR]);
+    expect(fetchGitHubPullRequestsMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('coalesces concurrent opens onto a single in-flight gh load', async () => {
+    let calls = 0;
+    let resolveLoad: (r: {
+      kind: 'ok';
+      pullRequests: Array<typeof PR>;
+    }) => void = () => {};
+    const gate = new Promise<{ kind: 'ok'; pullRequests: Array<typeof PR> }>(
+      (r) => {
+        resolveLoad = r;
+      },
+    );
+    fetchGitHubPullRequestsMock.mockImplementation(() => {
+      calls++;
+      return gate;
+    });
+    // TTL 0 would normally reload each request; the pending load must still be
+    // shared so two concurrent opens spawn gh once. `.then` forces supertest to
+    // send now (it is otherwise lazy), so both handlers reach getPullRequests
+    // while the single load is still pending.
+    const app = mount({ cacheTtlMs: 0 });
+
+    const p1 = request(app)
+      .get('/workspaces/primary/github/prs')
+      .then((r) => r);
+    const p2 = request(app)
+      .get('/workspaces/primary/github/prs')
+      .then((r) => r);
+    await new Promise((r) => setTimeout(r, 50));
+    resolveLoad({ kind: 'ok', pullRequests: [PR] });
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    expect(calls).toBe(1);
   });
 });

--- a/packages/cli/src/serve/routes/workspace-github-prs.ts
+++ b/packages/cli/src/serve/routes/workspace-github-prs.ts
@@ -8,6 +8,7 @@ import type { Application } from 'express';
 import {
   GITHUB_PR_ERROR_MESSAGE_MAX,
   fetchGitHubPullRequests,
+  type FetchGitHubPullRequestsResult,
 } from '@qwen-code/qwen-code-core';
 import type { SendBridgeError } from '../server/error-response.js';
 import type { WorkspaceRegistry } from '../workspace-registry.js';
@@ -16,6 +17,8 @@ import {
   resolveWorkspaceRuntimeFromParam,
 } from '../workspace-route-runtime.js';
 import { applyReadHeaders } from './workspace-file-read.js';
+
+const DEFAULT_CACHE_TTL_MS = 60_000;
 
 function sanitizeMessage(message: string, workspaceCwd: string): string {
   return message.split(workspaceCwd).join('<workspace>');
@@ -26,8 +29,54 @@ export function registerWorkspaceQualifiedGitHubPrsRoutes(
   deps: {
     workspaceRegistry: WorkspaceRegistry;
     sendBridgeError: SendBridgeError;
+    /** Coalescing/refresh window for the cached PR list. Defaults to 60s. */
+    cacheTtlMs?: number;
   },
 ): void {
+  const ttlMs = deps.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+
+  // Closure-scoped, per-workspace PR cache (one daemon per process). `gh pr
+  // list` with CI rollup is the slow part (multi-second GitHub round-trips),
+  // and the panel is glanceable, so a short TTL turns repeat opens instant.
+  // A pending load is reused regardless of age, so concurrent opens share one
+  // `gh` spawn even when it outlives the TTL; the window starts once the load
+  // settles. Only `ok` results are cached — `cli_unavailable` / `failed` /
+  // `not_a_repo` clear the entry so the next open retries (gh may since have
+  // been installed or authed, or the workspace may have become a repo).
+  interface PrsCacheEntry {
+    promise: Promise<FetchGitHubPullRequestsResult>;
+    settledAt: number | null;
+  }
+  const cache = new Map<string, PrsCacheEntry>();
+
+  const getPullRequests = (
+    workspaceCwd: string,
+  ): Promise<FetchGitHubPullRequestsResult> => {
+    const now = Date.now();
+    const existing = cache.get(workspaceCwd);
+    const fresh =
+      existing !== undefined &&
+      (existing.settledAt === null || now - existing.settledAt < ttlMs);
+    if (!fresh) {
+      const entry: PrsCacheEntry = {
+        promise: fetchGitHubPullRequests(workspaceCwd),
+        settledAt: null,
+      };
+      cache.set(workspaceCwd, entry);
+      entry.promise.then(
+        (result) => {
+          if (cache.get(workspaceCwd) !== entry) return;
+          if (result.kind === 'ok') entry.settledAt = Date.now();
+          else cache.delete(workspaceCwd);
+        },
+        () => {
+          if (cache.get(workspaceCwd) === entry) cache.delete(workspaceCwd);
+        },
+      );
+    }
+    return cache.get(workspaceCwd)!.promise;
+  };
+
   app.get('/workspaces/:workspace/github/prs', async (req, res) => {
     const route = 'GET /workspaces/:workspace/github/prs';
     const runtime = resolveWorkspaceRuntimeFromParam(
@@ -40,7 +89,7 @@ export function registerWorkspaceQualifiedGitHubPrsRoutes(
 
     applyReadHeaders(res);
     try {
-      const result = await fetchGitHubPullRequests(runtime.workspaceCwd);
+      const result = await getPullRequests(runtime.workspaceCwd);
       switch (result.kind) {
         case 'ok':
           res.status(200).json({


### PR DESCRIPTION
## What this PR does

Adds a short-lived (60s) daemon-side cache for the Web Shell GitHub pull-request list. Opening the PR panel shells out to `gh pr list` with CI rollup, which makes multi-second GitHub round-trips — measured at ~8s cold for this repository, almost entirely network I/O. The panel is a glanceable surface, so a minute-old snapshot is perfectly acceptable. The cache is closure-scoped per workspace, coalesces concurrent opens onto a single in-flight `gh` spawn, and only caches successful results: `gh`-missing / failure / not-a-repo responses clear the entry so the next open retries. The TTL is dependency-injected, following the existing usage-dashboard route's caching convention.

## Why it's needed

The PR panel from #7683 was slow to open: every open re-ran `gh pr list --json …,statusCheckRollup`, fetching CI status for 30 PRs over the network (~8s). With the cache, repeat opens within the TTL are effectively instant, which matches how the panel is actually used (opened repeatedly while working).

## Reviewer Test Plan

### How to verify

Start the daemon on a GitHub-backed repository and open the Web Shell PR panel (`/prs`). The first open takes a few seconds (the `gh` call); close and reopen within a minute — the second open should be near-instant. Wait past 60s (or restart) and the next open re-fetches. If `gh` is missing or fails, the panel still shows the appropriate error and the next open retries rather than serving a cached failure.

### Evidence (Before & After)

Measured against this repository via the daemon route:

| Request | Before | After |
| --- | --- | --- |
| 1st (cold, runs `gh`) | ~8.0s | ~8.0s |
| 2nd (cached) | ~8.0s | ~0.003s |
| 3rd (cached) | ~8.0s | ~0.001s |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Real daemon + real `gh` against this repository for the timing evidence; four new route unit tests cover cache-hit, TTL-0 reload, no-cache-on-failure, and concurrent-coalescing.

## Risk & Scope

- Main risk or tradeoff: the list can be up to 60s stale. Acceptable for a glanceable panel; the TTL is a single constant and injectable.
- Not validated / out of scope: first-open latency is unchanged (it is `gh`'s own network time). A two-phase load (render the list fast, enrich CI icons asynchronously) would improve first open and is left as a follow-up.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

为 Web Shell 的 GitHub 拉取请求列表加一个短时效（60s）的 daemon 侧缓存。打开 PR 面板会 shell 出 `gh pr list` 并带 CI rollup，需要多秒级 GitHub 往返——本仓库实测冷启动约 8s，几乎全是网络 I/O。面板是"瞟一眼"性质，一分钟内的快照完全可接受。缓存按 workspace 闭包级存放，并发打开合并到一次在飞的 `gh` 拉起，且只缓存成功结果：gh 缺失/失败/非仓库的响应会清掉条目，下次打开重试。TTL 依赖注入，对齐现有 usage-dashboard 路由的缓存约定。

## 为什么需要

#7683 的 PR 面板打开慢：每次打开都重跑 `gh pr list --json …,statusCheckRollup`，为 30 个 PR 拉 CI 状态（约 8s）。加缓存后，TTL 内的重复打开几乎瞬时，符合面板的实际使用方式（工作中反复打开）。

## 评审验证计划

### 如何验证

在 GitHub 仓库上启动 daemon，打开 Web Shell PR 面板（`/prs`）。首次打开需几秒（gh 调用）；一分钟内关闭再打开——第二次应几乎瞬时。等过 60s（或重启）后下次打开会重新拉取。若 gh 缺失或失败，面板仍显示对应错误，且下次打开会重试而非返回缓存的失败。

### 前后对照

本仓库经 daemon 路由实测：第 1 次（冷，走 gh）约 8.0s（前后相同）；第 2 次（缓存）从约 8.0s 降到约 0.003s；第 3 次约 0.001s。

### 测试平台

macOS 已测试；Windows、Linux 未单独验证（由 CI 覆盖）。

### 环境（可选）

真实 daemon + 真实 gh 指向本仓库做计时证据；新增 4 个路由单测覆盖缓存命中、TTL=0 重载、失败不缓存、并发合并。

## 风险与范围

- 主要风险或取舍：列表最多 stale 60s。对一瞥面板可接受；TTL 是单一常量且可注入。
- 未验证/范围之外：首次打开延迟不变（是 gh 自身的网络时间）。两阶段加载（先快速渲染列表、再异步补 CI 图标）可改善首屏，留作后续。
- 破坏性变更/迁移说明：无。

## 关联 Issue

无

</details>
