### PR TITLE
fix(triage): resolve finalize PRs from the open-PR list, not the commit association

### DIFF
--- a/.github/workflows/qwen-triage-finalize.yml
+++ b/.github/workflows/qwen-triage-finalize.yml
@@ -191,13 +191,23 @@ jobs:
           }
           # --- end triage-finalize helpers ---
 
-          # Open PRs whose current head is this SHA. (workflow_run carries
-          # pull_requests only for same-repo PRs; the commits/:sha/pulls
-          # association works for fork PRs too.)
+          # Open PRs for this SHA. Primary source: the open-PR list filtered
+          # by current head — the commits/:sha/pulls association is NOT
+          # reliable for fork-branch commits (observed live: it returned
+          # empty for the current head of an open fork PR, which silently
+          # dropped that PR's deferred approval; workflow_run.pull_requests
+          # is likewise empty for forks). The association endpoint is still
+          # consulted second: when it works it also surfaces PRs whose head
+          # has moved past this SHA, which is what powers the stale note.
           PR_NUMBERS="$(
-            gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/pulls?per_page=100" --paginate \
-              --jq '.[] | select(.state == "open") | .number'
-          )" || PR_NUMBERS=''
+            {
+              gh api "repos/$GITHUB_REPOSITORY/pulls?state=open&per_page=100" --paginate \
+                --jq '.' | jq -rs --arg sha "$HEAD_SHA" \
+                'add // [] | .[] | select(.head.sha == $sha) | .number' || true
+              gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/pulls?per_page=100" --paginate \
+                --jq '.[] | select(.state == "open") | .number' 2>/dev/null || true
+            } | sort -un
+          )"
           if [ -z "$PR_NUMBERS" ]; then
             echo "No open PR for $SHORT_SHA; nothing to finalize."
             exit 0

--- a/scripts/tests/qwen-triage-finalize-workflow.test.js
+++ b/scripts/tests/qwen-triage-finalize-workflow.test.js
@@ -179,6 +179,21 @@ describe('qwen-triage-finalize workflow', () => {
     expect(script).toContain('if [ -z "${GH_TOKEN:-}" ]');
     expect(script).toContain('No open PR for $SHORT_SHA; nothing to finalize.');
   });
+
+  it('resolves PRs from the open-PR list by head sha, not only the commit association', () => {
+    // commits/:sha/pulls returns empty for fork-branch commits (observed
+    // live on the current head of an open fork PR), and
+    // workflow_run.pull_requests is empty for forks too — filtering the
+    // open-PR list by head.sha is the source that cannot miss the PR the
+    // deferred approval belongs to. The association endpoint stays as the
+    // second source (it powers the stale note when it works).
+    expect(script).toContain('pulls?state=open&per_page=100');
+    expect(script).toContain('select(.head.sha == $sha)');
+    expect(script.indexOf('pulls?state=open')).toBeLessThan(
+      script.indexOf('commits/$HEAD_SHA/pulls'),
+    );
+    expect(script).toContain('sort -un');
+  });
 });
 
 describe('qwen-triage-finalize helpers', () => {


### PR DESCRIPTION
## What this PR does

Changes how `qwen-triage-finalize.yml` resolves which PRs a firing belongs to. The primary source is now the open-PR list filtered by `head.sha` — a lookup that cannot miss the PR a current-head firing acts on — with the previous `commits/{sha}/pulls` association kept as a second, unioned source (when it works, it also surfaces PRs whose head has moved past the SHA, which is what powers the stale note). A structural test pins the new resolution order.

## Why it's needed

Live verification of the #7693 finalize loop on its first real fork PR (#7703) caught the deferred approval being silently dropped. The sequence: triage deferred the approval with an `approve-on-green` marker for the head SHA; `Qwen Code CI` landed green; the finalize run fired for that exact SHA — and logged `No open PR for 3800f25; nothing to finalize`, because `commits/{sha}/pulls` returned an empty list **for the current head of an open PR**. The association endpoint is not reliable for fork-branch commits (`workflow_run.pull_requests` is likewise documented-empty for forks, which is why it was not used). Verified side by side at the time of failure: the association endpoint returned `0` results for the SHA while the open-PR list filtered by `head.sha` returned exactly `[7703]`. Every fork PR — the common case for this repo — would hit this, making the deferred-approval half of #7693 dead on arrival.

## Reviewer Test Plan

### How to verify

- `npx vitest run --config ./scripts/tests/vitest.config.ts qwen-triage-finalize-workflow` — 19 tests pass (1 new: asserts the open-PR `head.sha` filter exists, precedes the association lookup, and the two sources are unioned with `sort -un`).
- Reproduce the underlying API behavior on any open fork PR: `gh api "repos/QwenLM/qwen-code/commits/<fork-pr-head-sha>/pulls" --jq length` → `0`, while `gh api "repos/QwenLM/qwen-code/pulls?state=open&per_page=100" --paginate --jq '.' | jq -s --arg sha <sha> 'add|[.[]|select(.head.sha==$sha)|.number]'` → the PR number.
- The fix is inside the single bash step; no trigger, permission, or concurrency changes.

### Evidence (Before & After)

Before: finalize run 30145481498 (05:16:34Z, HEAD_SHA `3800f257b…`) logged `No open PR for 3800f25; nothing to finalize` while #7703 was open at exactly that head with a valid `approve-on-green` marker — the deferred approval never posted.

After: the head.sha filter resolves `[7703]` for that same SHA (verified against the live API at the failure moment). N/A for UI.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

vitest via `scripts/tests/vitest.config.ts`; YAML re-parsed with the repo's `yaml` package; embedded script `bash -n` clean.

## Risk & Scope

- Main risk or tradeoff: the open-PR listing costs one paginated call per firing (~1–2 pages at this repo's open-PR count). The union keeps the association endpoint's stale-note coverage intact.
- Not validated / out of scope: the live path can only be exercised after merge (workflow_run runs the default-branch version); #7703 remains the natural first verification target once this lands.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #7693 (bug found during its live verification, on #7703).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修改 `qwen-triage-finalize.yml` 解析"本次触发属于哪些 PR"的方式。主数据源改为按 `head.sha` 过滤开放 PR 列表——对现任 head 的触发不可能漏掉所属 PR——原来的 `commits/{sha}/pulls` 关联端点保留为第二来源并做并集（它正常工作时还能带出 head 已前移的 PR，即 stale 提示的数据来源）。新增结构测试固定解析顺序。

## 为什么需要

对 #7693 finalize 闭环在首个真实 fork PR（#7703）上的实链路验证抓到了延迟审批被静默丢弃：triage 已为 head SHA 留下 `approve-on-green` 标记；`Qwen Code CI` 全绿；finalize 针对该 SHA 触发——却记录 `No open PR for 3800f25; nothing to finalize`，因为 `commits/{sha}/pulls` 对**开放 PR 的现任 head** 返回了空列表。该关联端点对 fork 分支 commit 不可靠（`workflow_run.pull_requests` 对 fork 也是文档明确的空值，因此当初没有使用）。故障当时的并排验证：关联端点对该 SHA 返回 `0` 条，而按 `head.sha` 过滤开放 PR 列表恰好返回 `[7703]`。每个 fork PR——本仓库的常态——都会命中此问题，#7693 的延迟审批一半功能等于胎死腹中。

## 审查者验证方案

- `npx vitest run --config ./scripts/tests/vitest.config.ts qwen-triage-finalize-workflow` —— 19 个测试通过（新增 1 个：断言存在开放 PR 的 `head.sha` 过滤、其位于关联查询之前、两个来源经 `sort -un` 并集）。
- 在任一开放 fork PR 上复现底层 API 行为：`commits/<fork-pr-head-sha>/pulls` 返回 `0`，而按 `head.sha` 过滤开放 PR 列表返回该 PR 号。
- 修改仅在单个 bash step 内部；触发器、权限、并发均无变化。

## 证据（Before & After）

Before：finalize run 30145481498（05:16:34Z，HEAD_SHA `3800f257b…`）记录 `No open PR for 3800f25; nothing to finalize`，而 #7703 恰以该 head 开放、且带有效 `approve-on-green` 标记——延迟审批从未发布。

After：同一 SHA 上 head.sha 过滤解析出 `[7703]`（故障当时对线上 API 的实测）。无 UI 变化。

## 风险与范围

- 主要风险/权衡：每次触发多一次分页的开放 PR 列表调用（按本仓库规模约 1–2 页）。并集保留了关联端点的 stale 提示覆盖。
- 未验证/范围外：实链路只能在合并后验证（workflow_run 运行默认分支版本）；#7703 是落地后的天然首个验证对象。
- 破坏性变更/迁移说明：无。

## 关联 Issue

#7693 的后续（在 #7703 实链路验证中发现的 bug）。

</details>
