### PR TITLE
feat(web-shell): persist terminal history pagination errors

### DIFF
--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -234,6 +234,7 @@ vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
     hasMore: false,
     loading: false,
     capacityReached: false,
+    paginationError: false,
     loadMore: vi.fn(),
     release: vi.fn(),
   }),

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -7635,6 +7635,8 @@ export function App({
                                 historyCapacityReached={
                                   transcriptHistory.capacityReached
                                 }
+                                historyPaginationError={
+                                  transcriptHistory.paginationError}
                                 onLoadOlderHistory={transcriptHistory.loadMore}
                                 transcriptBlockCount={blocks.length}
                                 transcriptActivity={store}

--- a/packages/web-shell/client/components/ChatPane.test.tsx
+++ b/packages/web-shell/client/components/ChatPane.test.tsx
@@ -72,6 +72,7 @@ vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
     hasMore: false,
     loading: false,
     capacityReached: false,
+    paginationError: false,
     loadMore: vi.fn(),
     release: vi.fn(),
   }),

--- a/packages/web-shell/client/components/ChatPane.tsx
+++ b/packages/web-shell/client/components/ChatPane.tsx
@@ -590,6 +590,7 @@ export function ChatPane({
             hasOlderHistory={transcriptHistory.hasMore}
             loadingOlderHistory={transcriptHistory.loading}
             historyCapacityReached={transcriptHistory.capacityReached}
+            historyPaginationError={transcriptHistory.paginationError}
             onLoadOlderHistory={transcriptHistory.loadMore}
             transcriptBlockCount={blocks.length}
             transcriptActivity={store}

--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -203,6 +203,7 @@ function mount(
     hasOlderHistory?: boolean;
     loadingOlderHistory?: boolean;
     historyCapacityReached?: boolean;
+    historyPaginationError?: boolean;
     onLoadOlderHistory?: () => Promise<void>;
     transcriptBlockCount?: number;
     transcriptActivity?: {
@@ -243,6 +244,7 @@ function mount(
             hasOlderHistory={opts.hasOlderHistory}
             loadingOlderHistory={opts.loadingOlderHistory}
             historyCapacityReached={opts.historyCapacityReached}
+            historyPaginationError={opts.historyPaginationError}
             onLoadOlderHistory={opts.onLoadOlderHistory}
             transcriptBlockCount={opts.transcriptBlockCount}
             transcriptActivity={opts.transcriptActivity}
@@ -1582,8 +1584,8 @@ describe('MessageList — turn collapse (DOM)', () => {
     const c = mount([userMsg('u1')], undefined, {
       historyPaginationError: true,
     });
-    expect(c.querySelector('[role="alert"]')?.textContent).toBe(
-      'Failed to load earlier history. Some older messages may be unavailable.',
+    expect(c.querySelector('[role="status"]')?.textContent).toBe(
+      'Earlier history could not be loaded.',
     );
   });
 

--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -1578,6 +1578,50 @@ describe('MessageList — turn collapse (DOM)', () => {
     );
   });
 
+  it('shows a persistent error when history pagination fails', () => {
+    const c = mount([userMsg('u1')], undefined, {
+      historyPaginationError: true,
+    });
+    expect(c.querySelector('[role="alert"]')?.textContent).toBe(
+      'Failed to load earlier history. Some older messages may be unavailable.',
+    );
+  });
+
+  it('does not auto-load older history when a pagination error is present', async () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 300,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    const onLoadOlderHistory = vi.fn().mockResolvedValue(undefined);
+    // historyPaginationError is true, hasOlderHistory is true
+    const c = mount([userMsg('u1')], undefined, {
+      hasOlderHistory: true,
+      historyPaginationError: true,
+      onLoadOlderHistory,
+    });
+
+    const list = c.querySelector(
+      '[data-web-shell-message-list]',
+    ) as HTMLElement;
+    Object.defineProperty(list, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+
+    await act(async () => {
+      list.dispatchEvent(new Event('scroll'));
+      await Promise.resolve();
+    });
+
+    // It should NOT call loadMore because paginationError blocks it
+    expect(onLoadOlderHistory).not.toHaveBeenCalled();
+  });
+
   it('does not smooth-scroll when existing session history loads after an empty render', () => {
     const scrollTo = vi.fn();
     let scrollTop = 0;

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -63,6 +63,7 @@ interface MessageListProps {
   hasOlderHistory?: boolean;
   loadingOlderHistory?: boolean;
   historyCapacityReached?: boolean;
+  historyPaginationError?: boolean;
   onLoadOlderHistory?: () => Promise<void>;
   transcriptBlockCount?: number;
   transcriptActivity?: {
@@ -2184,6 +2185,7 @@ export const MessageList = memo(
       hasOlderHistory = false,
       loadingOlderHistory = false,
       historyCapacityReached = false,
+      historyPaginationError = false,
       onLoadOlderHistory,
       transcriptBlockCount = 0,
       transcriptActivity,
@@ -3171,6 +3173,7 @@ export const MessageList = memo(
           !onLoadOlderHistory ||
           loadingOlderHistory ||
           olderHistoryLoadInFlight.current ||
+          historyPaginationError ||
           (olderHistoryRetryBlocked.current && !allowRetry)
         ) {
           return;
@@ -3194,7 +3197,7 @@ export const MessageList = memo(
           setSuppressOlderHistoryLoadingStatus(false);
         }
       },
-      [loadingOlderHistory, onLoadOlderHistory],
+      [loadingOlderHistory, onLoadOlderHistory, historyPaginationError],
     );
 
     // Rules 2 & 3: detect scroll direction to toggle follow mode.
@@ -3811,6 +3814,13 @@ export const MessageList = memo(
             {t('history.capacityReached')}
           </div>
         )}
+        {historyPaginationError &&
+          !showLoadingSkeleton &&
+          !historyCapacityReached && (
+            <div className={styles.historyStatus} role="alert">
+              {t('history.paginationError')}
+            </div>
+          )}
         <SessionTimeline
           entries={sessionTimelineEntries}
           currentTurnId={currentTimelineTurnId}

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -3817,7 +3817,7 @@ export const MessageList = memo(
         {historyPaginationError &&
           !showLoadingSkeleton &&
           !historyCapacityReached && (
-            <div className={styles.historyStatus} role="alert">
+            <div className={styles.historyStatus} role="status">
               {t('history.paginationError')}
             </div>
           )}

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -790,8 +790,7 @@ const EN: Messages = {
   'history.loadingEarlier': 'Loading earlier messages…',
   'history.capacityReached':
     'History display limit reached. Earlier messages remain saved.',
-  'history.paginationError':
-    'Failed to load earlier history. Some older messages may be unavailable.',
+  'history.paginationError': 'Earlier history could not be loaded.',
   'editor.shellPlaceholder': 'Enter terminal command',
   'editor.send': 'Send message',
   'editor.connectionDisconnected':
@@ -3057,8 +3056,7 @@ const ZH: Messages = {
   'editor.placeholder': '输入消息或 @ 文件路径',
   'history.loadingEarlier': '正在加载更早消息…',
   'history.capacityReached': '已达到历史显示上限，更早消息仍保存在会话中。',
-  'history.paginationError':
-    '加载更早历史记录失败。部分更早的消息可能无法显示。',
+  'history.paginationError': '无法加载更早的历史记录。',
   'editor.shellPlaceholder': '请输入终端命令',
   'editor.send': '发送消息',
   'editor.connectionDisconnected': '连接已中断，请在恢复后重试。',

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -790,6 +790,8 @@ const EN: Messages = {
   'history.loadingEarlier': 'Loading earlier messages…',
   'history.capacityReached':
     'History display limit reached. Earlier messages remain saved.',
+  'history.paginationError':
+    'Failed to load earlier history. Some older messages may be unavailable.',
   'editor.shellPlaceholder': 'Enter terminal command',
   'editor.send': 'Send message',
   'editor.connectionDisconnected':
@@ -3055,6 +3057,8 @@ const ZH: Messages = {
   'editor.placeholder': '输入消息或 @ 文件路径',
   'history.loadingEarlier': '正在加载更早消息…',
   'history.capacityReached': '已达到历史显示上限，更早消息仍保存在会话中。',
+  'history.paginationError':
+    '加载更早历史记录失败。部分更早的消息可能无法显示。',
   'editor.shellPlaceholder': '请输入终端命令',
   'editor.send': '发送消息',
   'editor.connectionDisconnected': '连接已中断，请在恢复后重试。',

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -17,6 +17,7 @@ import type {
   DaemonUiSessionActions,
   PromptResult,
 } from '@qwen-code/sdk/daemon';
+import { DaemonHttpError } from '@qwen-code/sdk/daemon';
 import {
   DaemonSessionProvider,
   useDaemonActions,
@@ -9102,6 +9103,60 @@ describe('DaemonSessionProvider', () => {
     expect(history?.hasMore).toBe(false);
   });
 
+  it('latches a non-retryable transcript page failure', async () => {
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['session_transcript_pagination'],
+    });
+    const replayEvent = (id: number, text: string): DaemonEvent => ({
+      id,
+      v: 1,
+      type: 'session_update',
+      data: {
+        update: {
+          sessionUpdate: 'user_message_chunk',
+          content: { type: 'text', text },
+          _meta: { 'qwen.session.recordId': `record-${id}` },
+        },
+      },
+    });
+    const session = createMockSession({
+      sessionId: 'session-forbidden-history-page',
+      historyHasMore: true,
+      replaySnapshot: {
+        compactedReplay: [replayEvent(2, 'recent prompt')],
+        liveJournal: [],
+      },
+    });
+    sdkMocks.sessions.push(session);
+    sdkMocks.getSessionTranscriptPage.mockRejectedValue(
+      new DaemonHttpError(403, undefined, 'Forbidden'),
+    );
+    let history: ReturnType<typeof useDaemonTranscriptHistory> | undefined;
+    function Harness() {
+      history = useDaemonTranscriptHistory();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      historyPageSize: 25,
+    });
+    await act(async () => {
+      await expect(history?.loadMore()).rejects.toThrow('Forbidden');
+      await flushPromises();
+    });
+
+    expect(history?.paginationError).toBe(true);
+    expect(history?.hasMore).toBe(false);
+
+    await act(async () => {
+      await history?.loadMore();
+      await flushPromises();
+    });
+    expect(sdkMocks.getSessionTranscriptPage).toHaveBeenCalledTimes(1);
+  });
+
   it('skips malformed older-page events and advances the cursor', async () => {
     sdkMocks.capabilities.mockResolvedValue({
       workspaceCwd: '/mock-workspace',
@@ -9265,11 +9320,8 @@ describe('DaemonSessionProvider', () => {
       blocks.map((block) => ('text' in block ? block.text : undefined)),
     ).toEqual(['recent prompt']);
     expect(history?.hasMore).toBe(false);
-    expect(notices.at(-1)).toMatchObject({
-      code: 'daemon.transcript_history.failed',
-      message: 'Failed to load earlier session history',
-      debugMessage: 'Replay conversion failed for this page',
-    });
+    expect(history?.paginationError).toBe(true);
+    expect(notices.at(-1)).toBeUndefined();
   });
 
   it('keeps an oversized initial replay intact and stops older pagination', async () => {

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -119,6 +119,7 @@ export interface DaemonTranscriptHistory {
   hasMore: boolean;
   loading: boolean;
   capacityReached: boolean;
+  paginationError: boolean;
   loadMore(): Promise<void>;
 }
 
@@ -443,11 +444,18 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
     hasMore: boolean;
     loading: boolean;
     capacityReached: boolean;
-  }>({ hasMore: false, loading: false, capacityReached: false });
+    paginationError: boolean;
+  }>({
+    hasMore: false,
+    loading: false,
+    capacityReached: false,
+    paginationError: false,
+  });
   const [transcriptHistoryState, setTranscriptHistoryState] = useState({
     hasMore: false,
     loading: false,
     capacityReached: false,
+    paginationError: false,
   });
   const eventStreamRef = useRef<
     | {
@@ -1150,11 +1158,13 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
             hasMore: historyHasMore,
             loading: false,
             capacityReached: false,
+            paginationError: false,
           };
           setTranscriptHistoryState({
             hasMore: historyHasMore,
             loading: false,
             capacityReached: false,
+            paginationError: false,
           });
           const replayInjected =
             shouldInjectReplaySnapshot && replayEvents.length > 0;
@@ -2342,6 +2352,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
     if (
       !history.hasMore ||
       history.loading ||
+      history.paginationError ||
       !activeSession ||
       activeSession.sessionId !== history.sessionId
     ) {
@@ -2353,6 +2364,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
       hasMore: true,
       loading: true,
       capacityReached: false,
+      paginationError: false,
     });
     let terminalFailure = false;
     try {
@@ -2434,6 +2446,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           hasMore: false,
           loading: false,
           capacityReached: true,
+          paginationError: false,
         });
         return;
       }
@@ -2464,10 +2477,12 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
       history.hasMore = retryable;
       history.loading = false;
       history.capacityReached = false;
+      history.paginationError = !retryable;
       setTranscriptHistoryState({
         hasMore: retryable,
         loading: false,
         capacityReached: false,
+        paginationError: !retryable,
       });
       addNotice({
         severity: 'warning',
@@ -2489,6 +2504,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
       hasMore: active && transcriptHistoryState.hasMore,
       loading: active && transcriptHistoryState.loading,
       capacityReached: active && transcriptHistoryState.capacityReached,
+      paginationError: active && transcriptHistoryState.paginationError,
       loadMore: loadMoreTranscript,
     };
   }, [connection.sessionId, loadMoreTranscript, transcriptHistoryState]);

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -1257,6 +1257,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                 hasMore: false,
                 loading: false,
                 capacityReached: true,
+                paginationError: false,
               });
             }
             for (const replayEvent of replayEvents) {
@@ -2460,6 +2461,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
         hasMore: history.hasMore,
         loading: false,
         capacityReached: history.capacityReached,
+        paginationError: false,
       });
     } catch (error) {
       if (
@@ -2484,15 +2486,17 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
         capacityReached: false,
         paginationError: !retryable,
       });
-      addNotice({
-        severity: 'warning',
-        category: 'user_action',
-        operation: 'load_session',
-        code: 'daemon.transcript_history.failed',
-        message: 'Failed to load earlier session history',
-        debugMessage: error instanceof Error ? error.message : String(error),
-        recoverable: retryable,
-      });
+      if (retryable) {
+        addNotice({
+          severity: 'warning',
+          category: 'user_action',
+          operation: 'load_session',
+          code: 'daemon.transcript_history.failed',
+          message: 'Failed to load earlier session history',
+          debugMessage: error instanceof Error ? error.message : String(error),
+          recoverable: retryable,
+        });
+      }
       throw error;
     }
   }, [addNotice, dismissNotice, maxBlocks, store]);


### PR DESCRIPTION
## What this PR does

Introduces a persistent error state for terminal history pagination failures (e.g., 403 or 404) in the Web Shell. When loading older history fails non-retryably, it stops further pagination attempts and renders a dedicated, persistent status message near the transcript history controls, completely separate from the existing `capacityReached` display limit state.

## Why it's needed

When loading earlier restored-session history failed with a non-retryable response, Web Shell previously only emitted a transient warning notice that disappeared, leaving no explanation for why earlier history was unavailable. Reusing the `capacityReached` UI was misleading because its text states that the display limit was reached and earlier messages remain saved, which is false for authorization, missing-session, or invalid-request failures. This provides accurate, persistent feedback to the user.

## Reviewer Test Plan

### How to verify

Reviewers can run the unit tests for `MessageList.dom.test.tsx` to verify that the persistent error UI renders and that auto-loading is blocked when `historyPaginationError` is true. To verify end-to-end, mock the daemon's transcript pagination endpoint to return a 403 or 404, scroll to the top of the Web Shell transcript, and confirm that the persistent "Failed to load earlier history" status appears and no further pagination requests are made.

### Evidence (Before & After)

N/A (Verified via unit tests and React component state logic)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |   N/A  |

### Environment (optional)

N/A (unit tests and UI components only)

## Risk & Scope

- Main risk or tradeoff: All non-retryable pagination failures will now persistently block older history loading until the session is reloaded, which is the desired behavior for clear user feedback but means users must reload to retry.
- Not validated / out of scope: Live daemon integration testing for specific 403/404 payloads was not performed; verified via React component tests and state logic.
- Breaking changes / migration notes: None.

## Linked Issues

Closes #7117

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

为 Web Shell 中终端历史记录分页失败（例如 403 或 404）引入了持久化的错误状态。当加载较早历史记录发生不可重试的失败时，它会停止后续的分页尝试，并在转录历史记录控件附近渲染一个专用的、持久的状态消息，与现有的 `capacityReached` 显示限制状态完全分离。

## 为什么需要它

当加载较早的恢复会话历史记录因不可重试的响应而失败时，Web Shell 以前只发出一个短暂的警告通知，通知消失后没有任何解释说明为什么较早的历史记录不可用。重用 `capacityReached` UI 会产生误导，因为它的文本声称已达到显示限制且较早的消息仍保存着，这对于授权、缺失会话或无效请求失败来说是不真实的。这为用户提供了准确、持久的反馈。

## 审查者测试计划

### 如何验证

审查者可以运行 `MessageList.dom.test.tsx` 的单元测试，验证当 `historyPaginationError` 为 true 时，持久化错误 UI 会渲染且自动加载被阻止。要进行端到端验证，可以模拟守护进程的转录分页端点返回 403 或 404，滚动到 Web Shell 转录的顶部，确认出现持久的“Failed to load earlier history”状态，并且没有发出后续的分页请求。

### 证据（前后对比）

N/A（通过单元测试和 React 组件状态逻辑验证）

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  N/A |
| 🪟 Windows |  ✅  |
|  🐧 Linux  |  N/A |

### 环境（可选）

N/A（仅限单元测试和 UI 组件）

## 风险与范围

- 主要风险或权衡：所有不可重试的分页失败现在都会持久地阻止加载较早的历史记录，直到会话重新加载，这是为了提供清晰的用户反馈而期望的行为，但也意味着用户必须重新加载才能重试。
- 未验证/超出范围：未对特定的 403/404 有效负载进行实时守护进程集成测试；通过 React 组件测试和状态逻辑进行了验证。
- 破坏性更改/迁移说明：无。

## 关联的 Issues

Closes #7117

</details>