### PR TITLE
fix(web-shell): allow pin and group for secondary workspace sessions

### DIFF
--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -856,6 +856,16 @@ export function WebShellSidebar({
       (scope.kind === 'locked' && workspaceQualifiedRestCoreEnabled),
     [workspaceQualifiedRestCoreEnabled],
   );
+  // Organization (pin/group) is safe for any trusted workspace — not just
+  // locked ones — because it only mutates display metadata, never executes
+  // code or touches the filesystem.
+  const canUseOrganizationActions = useCallback(
+    (scope: SessionWorkspaceScope) => {
+      if (scope.kind === 'unknown' || scope.kind === 'untrusted') return false;
+      return scope.kind === 'primary' || workspaceQualifiedRestCoreEnabled;
+    },
+    [workspaceQualifiedRestCoreEnabled],
+  );
   const isActiveSessionReadOnly = useCallback(
     (session: DaemonSessionSummary) =>
       !isMutableSessionScope(resolveSessionWorkspaceScope(session)),
@@ -865,7 +875,7 @@ export function WebShellSidebar({
     (session: DaemonSessionSummary) => {
       const scope = resolveSessionWorkspaceScope(session);
       if (scope.kind === 'primary') return workspaceActions;
-      if (scope.kind === 'locked') {
+      if (scope.kind === 'locked' || scope.kind === 'restricted') {
         return workspace.client.workspaceByCwd(scope.cwd);
       }
       return undefined;
@@ -913,9 +923,9 @@ export function WebShellSidebar({
     (session: DaemonSessionSummary, item: 'pin' | 'group') =>
       organizationEnabled &&
       sessionActionItems.has(item) &&
-      canUseWorkspaceQualifiedActions(resolveSessionWorkspaceScope(session)),
+      canUseOrganizationActions(resolveSessionWorkspaceScope(session)),
     [
-      canUseWorkspaceQualifiedActions,
+      canUseOrganizationActions,
       organizationEnabled,
       resolveSessionWorkspaceScope,
       sessionActionItems,
@@ -933,9 +943,9 @@ export function WebShellSidebar({
     (workspaceCwd?: string) =>
       organizationEnabled &&
       sessionActionItems.has('group') &&
-      canUseWorkspaceQualifiedActions(resolveWorkspaceScope(workspaceCwd)),
+      canUseOrganizationActions(resolveWorkspaceScope(workspaceCwd)),
     [
-      canUseWorkspaceQualifiedActions,
+      canUseOrganizationActions,
       organizationEnabled,
       resolveWorkspaceScope,
       sessionActionItems,
@@ -2011,7 +2021,7 @@ export function WebShellSidebar({
         const groupActions =
           scope.kind === 'primary'
             ? workspaceActions
-            : scope.kind === 'locked'
+            : scope.kind === 'locked' || scope.kind === 'restricted'
               ? workspace.client.workspaceByCwd(scope.cwd)
               : undefined;
         if (!groupActions) return;
@@ -2127,7 +2137,7 @@ export function WebShellSidebar({
     const groupActions =
       scope.kind === 'primary'
         ? workspaceActions
-        : scope.kind === 'locked'
+        : scope.kind === 'locked' || scope.kind === 'restricted'
           ? workspace.client.workspaceByCwd(scope.cwd)
           : undefined;
     if (!groupActions) {
@@ -3072,7 +3082,7 @@ export function WebShellSidebar({
                         )}
                       </div>
                     )}
-                    {!readOnly && (
+                    {(!readOnly || showPin) && (
                       <div
                         className={styles.sessionActions}
                         onClick={(event) => event.stopPropagation()}

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
@@ -2010,7 +2010,7 @@ describe('WebShellSidebar workspace removal', () => {
     expect(sessionActions.renameSession).not.toHaveBeenCalled();
   });
 
-  it('keeps a pinned secondary row restricted until that workspace is locked', async () => {
+  it('allows pin on an unlocked secondary workspace but keeps destructive actions restricted', async () => {
     connection.capabilities = {
       ...capabilities,
       features: [...capabilities.features, 'session_organization'],
@@ -2033,8 +2033,9 @@ describe('WebShellSidebar workspace removal', () => {
       await Promise.resolve();
       await Promise.resolve();
     });
-    expect(inlineSessionAction('Pinned secondary', 'Unpin')).toBeUndefined();
-    expect(sessionAction('Pinned secondary')).toBeUndefined();
+    expect(inlineSessionAction('Pinned secondary', 'Unpin')).toBeDefined();
+    expect(inlineSessionAction('Pinned secondary', 'Delete')).toBeUndefined();
+    expect(inlineSessionAction('Pinned secondary', 'Rename')).toBeUndefined();
 
     renderSidebar({ lockedWorkspaceCwd: '/tmp/other' });
     await act(async () => {
@@ -2045,7 +2046,7 @@ describe('WebShellSidebar workspace removal', () => {
     expect(sessionAction('Pinned secondary')).toBeDefined();
   });
 
-  it('keeps unlocked secondary actions conservative across every sidebar surface', async () => {
+  it('allows organization but keeps destructive actions conservative for unlocked secondary sessions', async () => {
     connection.capabilities = {
       ...capabilities,
       features: [
@@ -2122,13 +2123,11 @@ describe('WebShellSidebar workspace removal', () => {
     });
 
     expect(archiveButtonFor('Unlocked normal')?.disabled).toBe(false);
-    expect(sessionAction('Unlocked normal')).toBeUndefined();
-    expect(inlineSessionAction('Unlocked normal', 'Pin')).toBeUndefined();
+    expect(inlineSessionAction('Unlocked normal', 'Pin')).toBeDefined();
     expect(inlineSessionAction('Unlocked normal', 'Delete')).toBeUndefined();
 
     expect(archiveButtonFor('Unlocked pinned')?.disabled).toBe(false);
-    expect(sessionAction('Unlocked pinned')).toBeUndefined();
-    expect(inlineSessionAction('Unlocked pinned', 'Unpin')).toBeUndefined();
+    expect(inlineSessionAction('Unlocked pinned', 'Unpin')).toBeDefined();
 
     const archivedItems = await openSessionMenuItems('Unlocked archived');
     expect(archivedItems).toEqual([
@@ -2149,13 +2148,13 @@ describe('WebShellSidebar workspace removal', () => {
         .closest<HTMLElement>('[class*="headerRow"]')
         ?.textContent?.includes('other'),
     );
-    expect(secondaryCreateGroup).toBeUndefined();
+    expect(secondaryCreateGroup).toBeDefined();
     expect(
       container.querySelector('button[aria-label="Rename group"]'),
-    ).toBeNull();
+    ).not.toBeNull();
     expect(
       container.querySelector('button[aria-label="Delete group"]'),
-    ).toBeNull();
+    ).not.toBeNull();
   });
 
   it('does not carry an active rename edit across equal session ids in another workspace', async () => {


### PR DESCRIPTION
## What this PR does

Secondary (non-primary) workspace sessions in the Web Shell sidebar can now be pinned and grouped without first locking the workspace. Previously these organization actions were gated behind the same trust check as destructive operations (rename, delete, export), requiring the workspace to be explicitly locked. This change introduces a separate, more permissive gate for organization actions that allows any trusted workspace — primary, locked, or restricted — while keeping destructive actions behind the original locked-or-primary requirement.

## Why it's needed

Pinning and grouping only mutate display metadata (sort order, visual grouping) — they never execute code, touch the filesystem, or change workspace trust state. Requiring a workspace lock for these operations was overly conservative and made multi-workspace sidebar management unnecessarily frictionful: users had to lock a secondary workspace just to pin a session they wanted to keep visible.

## Reviewer Test Plan

### How to verify

1. Connect a Web Shell to a multi-workspace daemon with at least one secondary workspace.
2. Without locking the secondary workspace, hover over one of its sessions in the sidebar.
3. Confirm the pin button appears and clicking it pins/unpins the session.
4. Confirm the group menu (color dots, create group) is available for the secondary workspace.
5. Confirm rename and delete buttons do NOT appear for the unlocked secondary session.
6. Lock the secondary workspace and confirm all actions (rename, delete, export) become available as before.

### Evidence (Before & After)

Before: secondary workspace sessions showed no action buttons (pin, group, rename, delete all hidden) until the workspace was locked.
After: pin and group are immediately available; rename/delete/export still require locking.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

Unit tests: `npx vitest run client/components/sidebar/` in `packages/web-shell` — 81/81 pass.

## Risk & Scope

- Main risk or tradeoff: archive actions also become visible for restricted sessions (they were already gated correctly by their own `canMutateSessionArchive` check but were hidden by the outer `readOnly` wrapper). This is consistent with the existing archive gate, not a new permission.
- Not validated / out of scope: untrusted and unknown workspaces remain fully locked down. Daemon-side trust validation (`requireTrustedRuntimeForWorkspaceRoute`) is unchanged.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

Web Shell 侧边栏中的次级（非主）workspace session 现在无需锁定 workspace 即可置顶和分组。此前这些组织操作与破坏性操作（重命名、删除、导出）共用同一个信任检查，要求 workspace 必须被显式锁定。本次改动为组织操作引入了一个更宽松的独立门控，允许所有受信任的 workspace（primary、locked、restricted），同时破坏性操作仍保持原有的 locked-or-primary 要求。

## 为什么需要

置顶和分组仅修改展示元数据（排序、视觉分组），不会执行代码、访问文件系统或更改 workspace 信任状态。对这些操作要求 workspace 锁定过于保守，增加了多 workspace 侧边栏管理的不必要摩擦：用户仅仅为了置顶一个想保持可见的 session 就必须先锁定次级 workspace。

## 审阅者测试计划

### 如何验证

1. 将 Web Shell 连接到至少有一个次级 workspace 的多 workspace daemon。
2. 不锁定次级 workspace，将鼠标悬停在其某个 session 上。
3. 确认置顶按钮出现，点击可以置顶/取消置顶。
4. 确认分组菜单（颜色点、创建分组）对次级 workspace 可用。
5. 确认重命名和删除按钮不会出现在未锁定的次级 session 上。
6. 锁定次级 workspace，确认所有操作（重命名、删除、导出）恢复可用。

### 证据（前后对比）

之前：次级 workspace 的 session 在锁定前不显示任何操作按钮。
之后：置顶和分组立即可用；重命名/删除/导出仍需锁定。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

单元测试：在 `packages/web-shell` 中运行 `npx vitest run client/components/sidebar/` — 81/81 通过。

## 风险与范围

- 主要风险或权衡：archive 操作也会对 restricted session 可见（它们已被自身的 `canMutateSessionArchive` 检查正确门控，只是被外层 `readOnly` 包裹隐藏了）。这与现有 archive 门控一致，不是新权限。
- 未验证 / 超出范围：untrusted 和 unknown workspace 仍完全锁定。Daemon 侧信任校验（`requireTrustedRuntimeForWorkspaceRoute`）未更改。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无

</details>
