### PR TITLE
fix(qqbot): restore AcpBridge session loading — return input sessionId, patch catch path

### DIFF
--- a/packages/channels/base/src/AcpBridge.ts
+++ b/packages/channels/base/src/AcpBridge.ts
@@ -203,12 +203,12 @@ export class AcpBridge extends EventEmitter implements ChannelAgentBridge {
   async loadSession(sessionId: string, cwd: string): Promise<string> {
     const conn = this.ensureConnection();
     await this.registerChannelLoopMcpServer();
-    const response = await conn.loadSession({
+    await conn.loadSession({
       sessionId,
       cwd,
       mcpServers: [],
     });
-    return response.sessionId;
+    return sessionId;
   }
 
   async prompt(

--- a/packages/channels/qqbot/src/QQChannel.ts
+++ b/packages/channels/qqbot/src/QQChannel.ts
@@ -1973,6 +1973,7 @@ export class QQChannel extends ChannelBase {
                 onReady();
               })
               .catch(() => {
+                this.fixRestoredSessions();
                 process.stderr.write(
                   `[QQ:${this.name}] WARNING: router session restore failed — cron messages will be dropped until sessions re-establish\n`,
                 );


### PR DESCRIPTION
## What this PR does

Two changes to fix QQ Bot session restore after WebSocket reconnect:

1. **AcpBridge.loadSession()** returns the input `sessionId` instead of `response.sessionId` — ACP's `LoadSessionResponse` schema deliberately omits `sessionId` (the client already knows it), so `response.sessionId` is always `undefined`.

2. **QQChannel READY catch handler** now calls `fixRestoredSessions()` — the existing workaround that reads the raw `sessions.json` persist file and patches the router maps with correct session IDs. Previously it only ran in the `.then()` path, which was never reached after PR #5978 added validation in `restoreSessions()`.

## Why it's needed

The QQ Bot loses all session routing after every WebSocket reconnect when QQ sends 4009 (session timeout). Logs show `[SessionRouter] Failed to restore session X: Invalid restored session ID` and `Ready (0 sessions)` on every reconnect. All conversation context is lost until a new message creates a fresh session.

## Reviewer Test Plan

### How to verify

1. Start `qwen channel start` with a QQ Bot channel configured
2. Send a message to the bot — a session is created
3. Kill and restart the `qwen channel start` process (or trigger a QQ WebSocket 4009 reconnect)
4. Verify the bot resumes with the restored session context

### Evidence (Before & After)

**Before:** After reconnect, logs show:
```
[SessionRouter] Failed to restore session b1f3a8df-... for key qq-bot:__single__: Invalid restored session ID
[QQ:qq-bot] Ready (0 sessions)
```

**After:** The session is restored from the persist file via `fixRestoredSessions()`, and `Ready (N sessions)` shows the count of restored sessions.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested on local env |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment

`qwen channel start` mode (not `qwen serve --channel`).

## Risk & Scope

- Main risk or tradeoff: `fixRestoredSessions()` uses type coercion to access private SessionRouter fields — it's already labeled as fragile in the existing JSDoc. But this is the same workaround that was working in PR #5202, only now also triggered from the catch path.
- Not validated / out of scope: `qwen serve --channel` mode uses `DaemonChannelBridge` which has a separate loadSession implementation and is unaffected.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #7721

<details>
<summary>中文说明</summary>

修复 QQ Bot session 在 WebSocket 重连后丢失的问题。两个改动：
1. **AcpBridge.loadSession()** 直接返回输入的 sessionId 而非 `response.sessionId`——ACP 协议的 `LoadSessionResponse` 设计上不含 sessionId，所以 `response.sessionId` 一直是 undefined。
2. **QQChannel READY catch handler** 新增调用 `fixRestoredSessions()`——原有的 workaround 会从 `sessions.json` 文件直接读取正确 sessionId 并修复路由映射。之前它只在 `.then()` 路径执行，但 PR #5978 后 `restoreSessions()` 走 `.catch()` 路径了。

关联 Issue #7721
</details>
