### PR TITLE
fix(weixin): create the account credential file already private

### DIFF
--- a/packages/channels/weixin/src/accounts.test.ts
+++ b/packages/channels/weixin/src/accounts.test.ts
@@ -10,6 +10,8 @@ import {
   existsSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
+  renameSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -24,13 +26,17 @@ import {
   type AccountData,
 } from './accounts.js';
 
-// Pass-through spy: the real fs is used, but the mode the credential file is
-// *created* with stays observable. A permission check after the fact cannot
-// see it — write-then-chmod ends at 0600 too, it is just briefly readable on
-// the way there.
+// Pass-through spies: the real fs is used, but the mode the credential file is
+// *created* with stays observable, and the rename can be made to fail on
+// demand. A permission check after the fact cannot see the mode — write-then-
+// chmod ends at 0600 too, it is just briefly readable on the way there.
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
-  return { ...actual, writeFileSync: vi.fn(actual.writeFileSync) };
+  return {
+    ...actual,
+    writeFileSync: vi.fn(actual.writeFileSync),
+    renameSync: vi.fn(actual.renameSync),
+  };
 });
 
 const DATA: AccountData = {
@@ -48,8 +54,15 @@ function mode(path: string): string {
   return (statSync(path).mode & 0o777).toString(8);
 }
 
+/** Temp files left in the state dir. The name is unique per save, so this
+ *  cannot be a fixed path. */
+function tmpFiles(): string[] {
+  return readdirSync(stateDir).filter((f) => f.endsWith('.tmp'));
+}
+
 beforeEach(() => {
   vi.mocked(writeFileSync).mockClear();
+  vi.mocked(renameSync).mockClear();
   stateDir = mkdtempSync(join(tmpdir(), 'weixin-accounts-'));
   process.env['WEIXIN_STATE_DIR'] = stateDir;
 });
@@ -90,7 +103,8 @@ describe('saveAccount', () => {
 
   it('narrows a world-readable file left by an older version', () => {
     // `mode` on writeFileSync is ignored for a file that already exists, so a
-    // fix that only passes the option would leave this at 644.
+    // fix that only passes the option would leave this at 644. The rename is
+    // what repairs it: it carries the temp file's 0600 onto the destination.
     const p = join(stateDir, 'account.json');
     writeFileSync(p, '{"token":"stale"}', 'utf-8');
     chmodSync(p, 0o644);
@@ -102,22 +116,53 @@ describe('saveAccount', () => {
     expect(loadAccount()).toEqual(DATA);
   });
 
-  it('narrows a stale tmp file left by a crashed run', () => {
-    // Same blind spot one level down: the tmp path already exists, so it keeps
-    // its own permissions unless they are set explicitly.
-    const tmp = join(stateDir, 'account.json.tmp');
-    writeFileSync(tmp, 'leftover', 'utf-8');
-    chmodSync(tmp, 0o644);
+  it('never writes through a planted account.json.tmp', () => {
+    // A fixed `${p}.tmp` was guessable: on a shared host anyone able to write
+    // to the directory could pre-create it — as a symlink, this redirects the
+    // token. The unique name means a planted file is simply never opened.
+    const planted = join(stateDir, 'account.json.tmp');
+    writeFileSync(planted, 'planted', 'utf-8');
 
     saveAccount(DATA);
 
+    expect(readFileSync(planted, 'utf-8')).toBe('planted');
     expect(mode(join(stateDir, 'account.json'))).toBe('600');
-    expect(existsSync(tmp)).toBe(false);
+    expect(loadAccount()).toEqual(DATA);
+  });
+
+  it('uses a different temp path on every save', () => {
+    const paths = new Set<string>();
+    for (let i = 0; i < 5; i++) {
+      saveAccount(DATA);
+      paths.add(String(vi.mocked(renameSync).mock.calls.at(-1)?.[0]));
+    }
+    expect(paths.size).toBe(5);
   });
 
   it('leaves no tmp file behind on success', () => {
     saveAccount(DATA);
-    expect(existsSync(join(stateDir, 'account.json.tmp'))).toBe(false);
+    expect(tmpFiles()).toEqual([]);
+  });
+
+  it('removes the tmp file and re-throws when the rename fails', () => {
+    // The rename is the step that can fail with the temp file already on disk,
+    // so it is the one that exercises the cleanup path.
+    vi.mocked(renameSync).mockImplementationOnce(() => {
+      throw new Error('EXDEV: cross-device link not permitted');
+    });
+
+    expect(() => saveAccount(DATA)).toThrow('EXDEV');
+    expect(tmpFiles()).toEqual([]);
+  });
+
+  it('re-throws a write failure without leaving a credential file', () => {
+    vi.mocked(writeFileSync).mockImplementationOnce(() => {
+      throw new Error('ENOSPC: no space left on device');
+    });
+
+    expect(() => saveAccount(DATA)).toThrow('ENOSPC');
+    expect(tmpFiles()).toEqual([]);
+    expect(existsSync(join(stateDir, 'account.json'))).toBe(false);
   });
 
   it('replaces the previous account rather than appending', () => {

--- a/packages/channels/weixin/src/accounts.test.ts
+++ b/packages/channels/weixin/src/accounts.test.ts
@@ -1,0 +1,157 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  loadAccount,
+  saveAccount,
+  clearAccount,
+  DEFAULT_BASE_URL,
+  type AccountData,
+} from './accounts.js';
+
+// Pass-through spy: the real fs is used, but the mode the credential file is
+// *created* with stays observable. A permission check after the fact cannot
+// see it — write-then-chmod ends at 0600 too, it is just briefly readable on
+// the way there.
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return { ...actual, writeFileSync: vi.fn(actual.writeFileSync) };
+});
+
+const DATA: AccountData = {
+  token: 'super-secret-token',
+  baseUrl: DEFAULT_BASE_URL,
+  userId: 'user-1',
+  savedAt: '2026-01-01T00:00:00.000Z',
+};
+
+let stateDir: string;
+const previous = process.env['WEIXIN_STATE_DIR'];
+
+/** Permission bits of a path, as an octal string like "600". */
+function mode(path: string): string {
+  return (statSync(path).mode & 0o777).toString(8);
+}
+
+beforeEach(() => {
+  vi.mocked(writeFileSync).mockClear();
+  stateDir = mkdtempSync(join(tmpdir(), 'weixin-accounts-'));
+  process.env['WEIXIN_STATE_DIR'] = stateDir;
+});
+
+afterEach(() => {
+  if (previous === undefined) delete process.env['WEIXIN_STATE_DIR'];
+  else process.env['WEIXIN_STATE_DIR'] = previous;
+  rmSync(stateDir, { recursive: true, force: true });
+});
+
+describe('saveAccount', () => {
+  it('round-trips the account data', () => {
+    saveAccount(DATA);
+    expect(loadAccount()).toEqual(DATA);
+  });
+
+  it('never creates the credential file at umask-default permissions', () => {
+    saveAccount(DATA);
+
+    // Every write that carries the token must request 0600 up front. Under the
+    // usual 022 umask an unmoded write lands at 0644 — group- and
+    // world-readable until a follow-up chmod closes it.
+    const tokenWrites = vi
+      .mocked(writeFileSync)
+      .mock.calls.filter(([, contents]) =>
+        String(contents).includes(DATA.token),
+      );
+    expect(tokenWrites.length).toBeGreaterThan(0);
+    for (const [, , options] of tokenWrites) {
+      expect(options).toMatchObject({ mode: 0o600 });
+    }
+  });
+
+  it('leaves the credential file private to the owner', () => {
+    saveAccount(DATA);
+    expect(mode(join(stateDir, 'account.json'))).toBe('600');
+  });
+
+  it('narrows a world-readable file left by an older version', () => {
+    // `mode` on writeFileSync is ignored for a file that already exists, so a
+    // fix that only passes the option would leave this at 644.
+    const p = join(stateDir, 'account.json');
+    writeFileSync(p, '{"token":"stale"}', 'utf-8');
+    chmodSync(p, 0o644);
+    expect(mode(p)).toBe('644');
+
+    saveAccount(DATA);
+
+    expect(mode(p)).toBe('600');
+    expect(loadAccount()).toEqual(DATA);
+  });
+
+  it('narrows a stale tmp file left by a crashed run', () => {
+    // Same blind spot one level down: the tmp path already exists, so it keeps
+    // its own permissions unless they are set explicitly.
+    const tmp = join(stateDir, 'account.json.tmp');
+    writeFileSync(tmp, 'leftover', 'utf-8');
+    chmodSync(tmp, 0o644);
+
+    saveAccount(DATA);
+
+    expect(mode(join(stateDir, 'account.json'))).toBe('600');
+    expect(existsSync(tmp)).toBe(false);
+  });
+
+  it('leaves no tmp file behind on success', () => {
+    saveAccount(DATA);
+    expect(existsSync(join(stateDir, 'account.json.tmp'))).toBe(false);
+  });
+
+  it('replaces the previous account rather than appending', () => {
+    saveAccount(DATA);
+    const next: AccountData = { ...DATA, token: 'rotated', userId: 'user-2' };
+    saveAccount(next);
+
+    expect(loadAccount()).toEqual(next);
+    expect(() =>
+      JSON.parse(readFileSync(join(stateDir, 'account.json'), 'utf-8')),
+    ).not.toThrow();
+  });
+});
+
+describe('loadAccount', () => {
+  it('returns null when no account is stored', () => {
+    expect(loadAccount()).toBeNull();
+  });
+
+  it('returns null for a corrupt file rather than throwing', () => {
+    writeFileSync(join(stateDir, 'account.json'), 'not json', 'utf-8');
+    expect(loadAccount()).toBeNull();
+  });
+});
+
+describe('clearAccount', () => {
+  it('removes a stored account', () => {
+    saveAccount(DATA);
+    clearAccount();
+    expect(loadAccount()).toBeNull();
+    expect(existsSync(join(stateDir, 'account.json'))).toBe(false);
+  });
+
+  it('is a no-op when nothing is stored', () => {
+    expect(() => clearAccount()).not.toThrow();
+  });
+});

--- a/packages/channels/weixin/src/accounts.test.ts
+++ b/packages/channels/weixin/src/accounts.test.ts
@@ -6,16 +6,20 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
+  appendFileSync,
   chmodSync,
   existsSync,
+  lstatSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
   renameSync,
   rmSync,
   statSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs';
+import { randomBytes } from 'node:crypto';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -26,8 +30,8 @@ import {
   type AccountData,
 } from './accounts.js';
 
-// Pass-through spies: the real fs is used, but the mode the credential file is
-// *created* with stays observable, and the rename can be made to fail on
+// Pass-through spies: the real fs is used, but the mode and flag the credential
+// file is *created* with stay observable, and the rename can be made to fail on
 // demand. A permission check after the fact cannot see the mode — write-then-
 // chmod ends at 0600 too, it is just briefly readable on the way there.
 vi.mock('node:fs', async (importOriginal) => {
@@ -38,6 +42,19 @@ vi.mock('node:fs', async (importOriginal) => {
     renameSync: vi.fn(actual.renameSync),
   };
 });
+
+// Spied so one test can pin the temp path and plant a symlink on it. Left
+// pass-through everywhere else, so every other test still exercises a real
+// unguessable name.
+vi.mock('node:crypto', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:crypto')>();
+  return { ...actual, randomBytes: vi.fn(actual.randomBytes) };
+});
+
+// Permission bits and symlinks only behave as asserted on POSIX: on Windows
+// Node reports 0o666/0o444 and `chmod` moves nothing but the read-only bit.
+// Same guard the core `atomicFileWrite` suite uses for its mode assertions.
+const posixOnly = it.skipIf(process.platform === 'win32');
 
 const DATA: AccountData = {
   token: 'super-secret-token',
@@ -63,6 +80,7 @@ function tmpFiles(): string[] {
 beforeEach(() => {
   vi.mocked(writeFileSync).mockClear();
   vi.mocked(renameSync).mockClear();
+  vi.mocked(randomBytes).mockClear();
   stateDir = mkdtempSync(join(tmpdir(), 'weixin-accounts-'));
   process.env['WEIXIN_STATE_DIR'] = stateDir;
 });
@@ -84,7 +102,8 @@ describe('saveAccount', () => {
 
     // Every write that carries the token must request 0600 up front. Under the
     // usual 022 umask an unmoded write lands at 0644 — group- and
-    // world-readable until a follow-up chmod closes it.
+    // world-readable until a follow-up chmod closes it. `wx` is what makes the
+    // mode take effect at all: it is ignored for a path that already exists.
     const tokenWrites = vi
       .mocked(writeFileSync)
       .mock.calls.filter(([, contents]) =>
@@ -92,16 +111,16 @@ describe('saveAccount', () => {
       );
     expect(tokenWrites.length).toBeGreaterThan(0);
     for (const [, , options] of tokenWrites) {
-      expect(options).toMatchObject({ mode: 0o600 });
+      expect(options).toMatchObject({ mode: 0o600, flag: 'wx' });
     }
   });
 
-  it('leaves the credential file private to the owner', () => {
+  posixOnly('leaves the credential file private to the owner', () => {
     saveAccount(DATA);
     expect(mode(join(stateDir, 'account.json'))).toBe('600');
   });
 
-  it('narrows a world-readable file left by an older version', () => {
+  posixOnly('narrows a world-readable file left by an older version', () => {
     // `mode` on writeFileSync is ignored for a file that already exists, so a
     // fix that only passes the option would leave this at 644. The rename is
     // what repairs it: it carries the temp file's 0600 onto the destination.
@@ -126,7 +145,43 @@ describe('saveAccount', () => {
     saveAccount(DATA);
 
     expect(readFileSync(planted, 'utf-8')).toBe('planted');
-    expect(mode(join(stateDir, 'account.json'))).toBe('600');
+    expect(loadAccount()).toEqual(DATA);
+  });
+
+  posixOnly('refuses to write through a symlink on the exact temp path', () => {
+    // The unguessable name makes a plant unlikely; it is not what makes one
+    // ineffective. So pin the name and plant on it anyway: `wx`
+    // (O_CREAT|O_EXCL) fails on a symlink at the final component instead of
+    // following it. Without the flag the token lands in the victim file, the
+    // 0600 is silently dropped because the target "already exists", and the
+    // rename then makes account.json a permanent symlink to it.
+    const suffix = randomBytes(6).toString('hex');
+    const victim = join(stateDir, 'victim.txt');
+    writeFileSync(victim, 'not the token', 'utf-8');
+    vi.mocked(randomBytes).mockReturnValueOnce(
+      Buffer.from(suffix, 'hex') as unknown as ReturnType<typeof randomBytes>,
+    );
+    symlinkSync(victim, join(stateDir, `account.json.${suffix}.tmp`));
+
+    expect(() => saveAccount(DATA)).toThrow(/EEXIST/);
+
+    expect(readFileSync(victim, 'utf-8')).toBe('not the token');
+    expect(existsSync(join(stateDir, 'account.json'))).toBe(false);
+  });
+
+  posixOnly('never leaves account.json as a symlink', () => {
+    // A plain write would follow a symlink planted at the destination itself.
+    // The rename replaces it, so the credential cannot be redirected that way.
+    const victim = join(stateDir, 'victim.txt');
+    writeFileSync(victim, 'not the token', 'utf-8');
+    symlinkSync(victim, join(stateDir, 'account.json'));
+
+    saveAccount(DATA);
+
+    expect(lstatSync(join(stateDir, 'account.json')).isSymbolicLink()).toBe(
+      false,
+    );
+    expect(readFileSync(victim, 'utf-8')).toBe('not the token');
     expect(loadAccount()).toEqual(DATA);
   });
 
@@ -145,8 +200,8 @@ describe('saveAccount', () => {
   });
 
   it('removes the tmp file and re-throws when the rename fails', () => {
-    // The rename is the step that can fail with the temp file already on disk,
-    // so it is the one that exercises the cleanup path.
+    // The rename is one of the two steps that can fail with the temp file
+    // already on disk, so it exercises the cleanup path.
     vi.mocked(renameSync).mockImplementationOnce(() => {
       throw new Error('EXDEV: cross-device link not permitted');
     });
@@ -155,8 +210,12 @@ describe('saveAccount', () => {
     expect(tmpFiles()).toEqual([]);
   });
 
-  it('re-throws a write failure without leaving a credential file', () => {
-    vi.mocked(writeFileSync).mockImplementationOnce(() => {
+  it('removes the partial tmp file and re-throws when the write fails', () => {
+    // A real ENOSPC fails partway: the file exists, holding a truncated token.
+    // A mock that throws before creating anything makes the cleanup assertion
+    // below vacuous — it would pass with no cleanup code at all.
+    vi.mocked(writeFileSync).mockImplementationOnce((path) => {
+      appendFileSync(path as string, `{"token":"${DATA.token.slice(0, 8)}`);
       throw new Error('ENOSPC: no space left on device');
     });
 
@@ -194,6 +253,35 @@ describe('clearAccount', () => {
     clearAccount();
     expect(loadAccount()).toBeNull();
     expect(existsSync(join(stateDir, 'account.json'))).toBe(false);
+  });
+
+  it('sweeps a temp file orphaned by a killed save', () => {
+    // A hard kill between the write and the rename leaves a live token in a
+    // temp file whose name is never reused, so nothing else would ever remove
+    // it. Logging out has to, or the credential outlives its own revocation.
+    saveAccount(DATA);
+    writeFileSync(
+      join(stateDir, 'account.json.a1b2c3d4e5f6.tmp'),
+      JSON.stringify(DATA),
+      'utf-8',
+    );
+    expect(tmpFiles()).toHaveLength(1);
+
+    clearAccount();
+
+    expect(tmpFiles()).toEqual([]);
+    expect(existsSync(join(stateDir, 'account.json'))).toBe(false);
+  });
+
+  it('leaves unrelated files in the state dir alone', () => {
+    // `monitor.ts` keeps cursor.txt in this same directory.
+    const cursor = join(stateDir, 'cursor.txt');
+    writeFileSync(cursor, '42', 'utf-8');
+    saveAccount(DATA);
+
+    clearAccount();
+
+    expect(readFileSync(cursor, 'utf-8')).toBe('42');
   });
 
   it('is a no-op when nothing is stored', () => {

--- a/packages/channels/weixin/src/accounts.ts
+++ b/packages/channels/weixin/src/accounts.ts
@@ -8,6 +8,7 @@ import {
   mkdirSync,
   readFileSync,
   writeFileSync,
+  renameSync,
   unlinkSync,
   chmodSync,
 } from 'node:fs';
@@ -49,8 +50,29 @@ export function loadAccount(): AccountData | null {
 
 export function saveAccount(data: AccountData): void {
   const p = accountPath();
-  writeFileSync(p, JSON.stringify(data, null, 2), 'utf-8');
-  chmodSync(p, 0o600);
+  const tmp = `${p}.tmp`;
+  try {
+    // Create the file already private. Writing first and narrowing afterwards
+    // leaves the token readable at the umask default (0644 under the usual
+    // 022) for the window between the two calls.
+    writeFileSync(tmp, JSON.stringify(data, null, 2), {
+      encoding: 'utf-8',
+      mode: 0o600,
+    });
+    // `mode` above only applies when the file is created, so a stale tmp left
+    // behind by a crashed run keeps whatever permissions it already had.
+    chmodSync(tmp, 0o600);
+    // Rename carries the 0600 mode onto the destination, so an account.json
+    // written by an older version is narrowed rather than left as it was.
+    renameSync(tmp, p);
+  } catch (e) {
+    try {
+      unlinkSync(tmp);
+    } catch {
+      /* best-effort cleanup */
+    }
+    throw e;
+  }
 }
 
 export function clearAccount(): void {

--- a/packages/channels/weixin/src/accounts.ts
+++ b/packages/channels/weixin/src/accounts.ts
@@ -7,10 +7,12 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  readdirSync,
   writeFileSync,
   unlinkSync,
   renameSync,
 } from 'node:fs';
+import { randomBytes } from 'node:crypto';
 import { join } from 'node:path';
 import { getGlobalQwenDir } from '@qwen-code/channel-base';
 
@@ -49,23 +51,28 @@ export function loadAccount(): AccountData | null {
 
 export function saveAccount(data: AccountData): void {
   const p = accountPath();
-  // The temp path must not be guessable. A fixed `${p}.tmp` can be pre-created
-  // by anyone with write access to the directory, and `writeFileSync` follows a
-  // symlink found there — which would send the token wherever it points. A
-  // unique name also stops two concurrent saves from interleaving their writes
-  // into one file. Same shape `channel-base` uses for its own atomic stores.
-  const tmp = `${p}.${Date.now()}-${process.pid}-${Math.random()
-    .toString(16)
-    .slice(2)}.tmp`;
+  // The temp path must not be pre-creatable. A fixed `${p}.tmp` can be planted
+  // in advance by anyone able to write to the directory, and a plain write
+  // follows a symlink found there — which would send the token wherever it
+  // points. `randomBytes` rather than a `Date.now()`/pid/`Math.random()` suffix
+  // because those are guessable and V8's `Math.random` is not a CSPRNG; this
+  // matches `ChannelLoopStore`, the sibling store with the same requirement.
+  const tmp = `${p}.${randomBytes(6).toString('hex')}.tmp`;
   try {
-    // Create the file already private. Writing first and narrowing afterwards
-    // leaves the token readable at the umask default (0644 under the usual 022)
-    // for the window between the two calls. `mode` is honoured here only
-    // because the unique name guarantees this call creates the file — it is
-    // silently ignored when the path already exists.
+    // `wx` is `O_CREAT|O_EXCL`: it refuses an existing path, and the kernel
+    // fails it on a symlink at the final component rather than following it.
+    // The unguessable name makes a plant unlikely; the flag makes it
+    // ineffective — so this does not rest on the name alone.
+    //
+    // `O_EXCL` also guarantees this call is the one that creates the file,
+    // which is what makes `mode` take effect: it is silently ignored for a path
+    // that already exists. Writing first and narrowing afterwards would leave
+    // the token readable at the umask default (0644 under the usual 022) for
+    // the window between the two calls.
     writeFileSync(tmp, JSON.stringify(data, null, 2), {
       encoding: 'utf-8',
       mode: 0o600,
+      flag: 'wx',
     });
     // Rename carries the 0600 mode onto the destination, so an account.json
     // written by an older version is narrowed rather than left as it was.
@@ -81,8 +88,21 @@ export function saveAccount(data: AccountData): void {
 }
 
 export function clearAccount(): void {
-  const p = accountPath();
+  const dir = getStateDir();
+  const p = join(dir, 'account.json');
   if (existsSync(p)) {
     unlinkSync(p);
+  }
+  // A save killed between the write and the rename leaves a temp file holding a
+  // live token. The name is never reused, so nothing else would ever remove it:
+  // without this sweep the credential outlives the logout meant to revoke it.
+  for (const f of readdirSync(dir)) {
+    if (f.startsWith('account.json.') && f.endsWith('.tmp')) {
+      try {
+        unlinkSync(join(dir, f));
+      } catch {
+        /* best-effort cleanup */
+      }
+    }
   }
 }

--- a/packages/channels/weixin/src/accounts.ts
+++ b/packages/channels/weixin/src/accounts.ts
@@ -8,9 +8,8 @@ import {
   mkdirSync,
   readFileSync,
   writeFileSync,
-  renameSync,
   unlinkSync,
-  chmodSync,
+  renameSync,
 } from 'node:fs';
 import { join } from 'node:path';
 import { getGlobalQwenDir } from '@qwen-code/channel-base';
@@ -50,18 +49,24 @@ export function loadAccount(): AccountData | null {
 
 export function saveAccount(data: AccountData): void {
   const p = accountPath();
-  const tmp = `${p}.tmp`;
+  // The temp path must not be guessable. A fixed `${p}.tmp` can be pre-created
+  // by anyone with write access to the directory, and `writeFileSync` follows a
+  // symlink found there — which would send the token wherever it points. A
+  // unique name also stops two concurrent saves from interleaving their writes
+  // into one file. Same shape `channel-base` uses for its own atomic stores.
+  const tmp = `${p}.${Date.now()}-${process.pid}-${Math.random()
+    .toString(16)
+    .slice(2)}.tmp`;
   try {
     // Create the file already private. Writing first and narrowing afterwards
-    // leaves the token readable at the umask default (0644 under the usual
-    // 022) for the window between the two calls.
+    // leaves the token readable at the umask default (0644 under the usual 022)
+    // for the window between the two calls. `mode` is honoured here only
+    // because the unique name guarantees this call creates the file — it is
+    // silently ignored when the path already exists.
     writeFileSync(tmp, JSON.stringify(data, null, 2), {
       encoding: 'utf-8',
       mode: 0o600,
     });
-    // `mode` above only applies when the file is created, so a stale tmp left
-    // behind by a crashed run keeps whatever permissions it already had.
-    chmodSync(tmp, 0o600);
     // Rename carries the 0600 mode onto the destination, so an account.json
     // written by an older version is narrowed rather than left as it was.
     renameSync(tmp, p);


### PR DESCRIPTION
## What this PR does

`saveAccount` in the WeChat channel stored the account credential by writing the file first and tightening its permissions afterwards. Between those two calls the file carried whatever the process umask allowed — 0644 under the usual 022 — so the API token was group- and world-readable for that window. This PR creates the file already private instead: the JSON is written to a temp file created with mode 0600 and renamed into place, which is the pattern the sibling `qqbot` channel already uses for its own state file.

Passing `mode` to `writeFileSync` on its own is not sufficient, and that is the part worth reviewing carefully. The mode is applied only when the file is *created*, so an `account.json` already on disk at 0644 from an older version keeps its permissions. Because `rename` carries the source mode onto the destination, existing installs are repaired on the next save rather than left as they were.

The temp file is opened with `flag: 'wx'` (`O_CREAT|O_EXCL`) under a name drawn from `crypto.randomBytes`, the form `ChannelLoopStore` uses. A fixed `account.json.tmp` would be pre-creatable by anyone able to write to the state directory, and a plain write *follows* a symlink found there: the token lands in the link target, the `mode` is silently dropped because the target already exists, and the rename then makes `account.json` a permanent symlink to it. The unguessable name makes that plant unlikely; `O_EXCL` makes it ineffective, so the defence does not rest on the name. `O_EXCL` also guarantees this call creates the file, which is what makes `mode` take effect at all — it is ignored for a path that already exists. A unique name additionally removes the stale-temp case, so no explicit `chmod` on the temp file is needed, and stops two concurrent saves interleaving into one file.

`clearAccount` sweeps `account.json.*.tmp` alongside the account file. A save killed between the write and the rename leaves a live token under a name that is never reused, so without the sweep the credential would outlive the logout meant to revoke it.

## Why it's needed

`AccountData.token` is the WeChat API token, and the file lives under `~/.qwen/channels/weixin/`. On a shared or multi-user host any local user could read it during the window. The window is short, but it is reached on every single save, and the fix costs nothing at runtime.

Making the write atomic is a second, smaller benefit: `rename` is atomic within a filesystem, so a concurrent reader now sees either the previous account or the new one, never a half-written file. The previous code truncated `account.json` in place, where an interrupted write left invalid JSON — `loadAccount` swallows the parse error and returns `null`, which reads to the user as being silently logged out.

## Reviewer Test Plan

### How to verify

```
npx vitest run --root packages/channels/weixin src/accounts.test.ts
```

18 pass. `accounts.ts` had no test file before this PR, so the suite also covers the existing `loadAccount` / `clearAccount` behaviour.

The tests are pinned to the fix rather than to incidental behaviour. Six mutants, each killed by a distinct, correctly-named test — reverting **only** `accounts.ts` and keeping the new test file:

| mutant | result |
| --- | --- |
| A — revert `accounts.ts` to base | `7 failed \| 11 passed (18)` |
| B — naive `writeFileSync(p, json, { mode: 0o600 })` | `7 failed \| 11 passed (18)` |
| C — fixed `${p}.tmp` name | `3 failed \| 15 passed (18)` |
| D — delete the whole `try/catch` cleanup | `2 failed \| 16 passed (18)` |
| E — drop `flag: 'wx'` | `2 failed \| 16 passed (18)` — `refuses to write through a symlink on the exact temp path` |
| F — drop the `clearAccount` sweep | `1 failed \| 17 passed (18)` — `sweeps a temp file orphaned by a killed save` |

Mutant A fails:

```
× saveAccount > never creates the credential file at umask-default permissions
× saveAccount > refuses to write through a symlink on the exact temp path
× saveAccount > never leaves account.json as a symlink
× saveAccount > uses a different temp path on every save
× saveAccount > removes the tmp file and re-throws when the rename fails
× saveAccount > removes the partial tmp file and re-throws when the write fails
× clearAccount > sweeps a temp file orphaned by a killed save
  Tests  7 failed | 11 passed (18)
```

Worth noting why the first test is written with a spy rather than a `statSync` check: the 0644 window is transient, so a permission check *after* `saveAccount` returns cannot see it — the old code ends at 0600 too, it is just briefly readable on the way there. The test asserts the mode the file is **created** with, which is the property that actually matters.

The naive fix — replacing the `chmodSync` with `writeFileSync(p, json, { mode: 0o600 })` — fails a different set, which is the regression the temp-and-rename approach avoids:

```
× saveAccount > narrows a world-readable file left by an older version
× saveAccount > refuses to write through a symlink on the exact temp path
× saveAccount > never leaves account.json as a symlink
× saveAccount > uses a different temp path on every save
× saveAccount > removes the tmp file and re-throws when the rename fails
× saveAccount > removes the partial tmp file and re-throws when the write fails
× clearAccount > sweeps a temp file orphaned by a killed save
  Tests  7 failed | 11 passed (18)
```

The write-failure mock creates a partial file *before* throwing, the way a real `ENOSPC` does. A mock that throws before creating anything makes the cleanup assertion vacuous — it passes with no cleanup code at all, which is why mutant D used to survive it.

Mode and symlink assertions are `skipIf(process.platform === 'win32')`, matching the core `atomicFileWrite` suite: Windows reports 0o666/0o444 and `chmod` moves only the read-only bit.

Full channel suite, `tsc --noEmit -p packages/channels/weixin`, `eslint` and `prettier --check` are all clean:

```
Test Files  5 passed (5)
     Tests  64 passed (64)
```

The underlying platform behaviour, if you want to confirm it independently:

```
$ node -e "…writeFileSync then chmodSync…"
process umask: 022
CURRENT  after writeFileSync: 0644   after chmodSync: 0600
FIXED    after writeFileSync: 0600
RE-WRITE existing 0644 file with {mode:0600} -> 0644   <-- mode ignored for existing files
```

### Evidence (Before & After)

N/A — no user-visible or TUI change; the only observable difference is the file mode, covered by the tests above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only. macOS 15 (arm64), Node v22, vitest 3.2.4.

## Risk & Scope

- Main risk or tradeoff: `saveAccount` now creates a uniquely-named temp file alongside the account file. It is removed on both the success and failure paths; a hard kill in between can still leave one behind, so `clearAccount` sweeps them at logout. It is created at 0600 and never reused, and the sweep matches on `account.json.*.tmp` only, so nothing else in the state directory (`cursor.txt`) is touched. Same trade `channel-base` already makes for its own atomic stores.
- POSIX permission bits are a no-op on Windows, so the mode assertions there are only meaningful in the sense that they do not fail; the atomicity benefit still applies. I marked Windows and Linux ⚠️ because I verified locally on macOS only — CI covers all three.
- Not validated / out of scope: the state **directory** is still created with default permissions by `getStateDir()`. The token itself is protected at 0600, so this is not a disclosure path, and changing directory modes is a separate concern from the file write this PR is about. Other channels were checked — `qqbot` already writes its state with `{ mode: 0o600 }`; the `writeFileSync` calls in `telegram`, `feishu`, `dingtalk` and `WeixinAdapter` are downloaded media, not credentials.
- Breaking changes / migration notes: none. Existing `account.json` files are narrowed to 0600 automatically on the next save; no user action required.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

WeChat 渠道中的 `saveAccount` 在保存账号凭据时，先写文件、再收紧权限。在这两次调用之间，文件的权限取决于进程 umask —— 在常见的 022 下即为 0644，因此 API token 在该窗口内对同组用户和其他用户可读。本 PR 改为一开始就以私有权限创建文件：将 JSON 写入一个以 mode 0600 创建的临时文件，再 rename 到目标位置——这正是同级渠道 `qqbot` 保存自身状态文件时已经采用的模式。

仅向 `writeFileSync` 传入 `mode` 是不够的，这一点值得重点复审。该 mode 只在文件被**创建**时生效，因此磁盘上已存在的、由旧版本写入的 0644 `account.json` 会保留原权限。由于 `rename` 会把源文件的 mode 带到目标文件上，已有安装会在下一次保存时自动被修复，而不是维持原状。

临时文件以 `flag: 'wx'`（`O_CREAT|O_EXCL`）打开，名称取自 `crypto.randomBytes`，即 `ChannelLoopStore` 采用的形式。固定的 `account.json.tmp` 可被任何能写入该状态目录的人预先创建，而普通写入会**跟随**其中的符号链接：token 落入链接目标，`mode` 因目标已存在而被静默忽略，随后的 rename 更会让 `account.json` 永久变成指向它的符号链接。不可猜测的名称让预置难以命中，`O_EXCL` 则让预置彻底无效——因此该防护并不依赖名称本身。`O_EXCL` 同时保证本次调用就是创建该文件的调用，这正是 `mode` 得以生效的前提——对已存在的路径它会被忽略。唯一名称另外消除了「残留临时文件」的情形，因此无需再对临时文件显式 `chmod`，也避免两个并发保存交错写入同一文件。

`clearAccount` 在删除账号文件的同时清扫 `account.json.*.tmp`。保存过程若在写入与 rename 之间被强杀，会留下一个名称永不复用、内含有效 token 的文件；没有这次清扫，该凭据将比意在撤销它的登出活得更久。

## 为什么需要

`AccountData.token` 就是 WeChat API token，文件位于 `~/.qwen/channels/weixin/` 下。在共享或多用户主机上，任何本地用户都可能在该窗口内读到它。窗口虽短，但每一次保存都会经过，而修复在运行时没有任何代价。

让写入变为原子操作是第二个较小的收益：`rename` 在同一文件系统内是原子的，因此并发读取方现在只会看到旧账号或新账号，而不会看到写了一半的文件。此前的代码是就地截断 `account.json`，一旦写入被中断就会留下非法 JSON —— `loadAccount` 会吞掉解析错误并返回 `null`，在用户看来就是莫名其妙地退出登录了。

## 复审测试计划

### 如何验证

```
npx vitest run --root packages/channels/weixin src/accounts.test.ts
```

18 项通过。本 PR 之前 `accounts.ts` 没有测试文件，因此该套件同时覆盖了既有的 `loadAccount` / `clearAccount` 行为。

这些测试锚定在本次修复上，而非附带行为。共 6 个变异体，每个都被一项名称贴切且互不重叠的测试杀死：

| 变异体 | 结果 |
| --- | --- |
| A —— 将 `accounts.ts` 还原至基线 | `7 failed \| 11 passed (18)` |
| B —— 朴素改法 `writeFileSync(p, json, { mode: 0o600 })` | `7 failed \| 11 passed (18)` |
| C —— 固定的 `${p}.tmp` 名称 | `3 failed \| 15 passed (18)` |
| D —— 删除整个 `try/catch` 清理 | `2 failed \| 16 passed (18)` |
| E —— 去掉 `flag: 'wx'` | `2 failed \| 16 passed (18)`，含 `refuses to write through a symlink on the exact temp path` |
| F —— 去掉 `clearAccount` 的清扫 | `1 failed \| 17 passed (18)`，即 `sweeps a temp file orphaned by a killed save` |

变异体 A 的失败项：

```
× saveAccount > never creates the credential file at umask-default permissions
× saveAccount > refuses to write through a symlink on the exact temp path
× saveAccount > never leaves account.json as a symlink
× saveAccount > uses a different temp path on every save
× saveAccount > removes the tmp file and re-throws when the rename fails
× saveAccount > removes the partial tmp file and re-throws when the write fails
× clearAccount > sweeps a temp file orphaned by a killed save
  Tests  7 failed | 11 passed (18)
```

写入失败的 mock 会先落下部分内容再抛出，与真实 `ENOSPC` 一致。若 mock 在创建任何文件之前就抛出，清理断言便是空断言——即使完全没有清理代码也会通过，这正是变异体 D 此前得以存活的原因。

涉及权限位与符号链接的断言均带 `skipIf(process.platform === 'win32')`，与 core 的 `atomicFileWrite` 套件一致：Windows 上 Node 报告 0o666/0o444，且 `chmod` 只改动只读位。

值得说明第一项测试为何用 spy 而不是 `statSync` 检查：0644 窗口是瞬时的，因此在 `saveAccount` 返回**之后**做权限检查根本看不到它 —— 旧代码最终同样是 0600，只是中途短暂可读。该测试断言的是文件被**创建**时所用的 mode，这才是真正关键的性质。

而朴素改法 —— 把 `chmodSync` 换成 `writeFileSync(p, json, { mode: 0o600 })` —— 会让另一组测试失败，这正是「临时文件 + rename」方案所规避的回退：

```
× saveAccount > narrows a world-readable file left by an older version
× saveAccount > refuses to write through a symlink on the exact temp path
× saveAccount > never leaves account.json as a symlink
× saveAccount > uses a different temp path on every save
× saveAccount > removes the tmp file and re-throws when the rename fails
× saveAccount > removes the partial tmp file and re-throws when the write fails
× clearAccount > sweeps a temp file orphaned by a killed save
  Tests  7 failed | 11 passed (18)
```

The write-failure mock creates a partial file *before* throwing, the way a real `ENOSPC` does. A mock that throws before creating anything makes the cleanup assertion vacuous — it passes with no cleanup code at all, which is why mutant D used to survive it.

Mode and symlink assertions are `skipIf(process.platform === 'win32')`, matching the core `atomicFileWrite` suite: Windows reports 0o666/0o444 and `chmod` moves only the read-only bit.

渠道完整套件、`tsc --noEmit -p packages/channels/weixin`、`eslint` 与 `prettier --check` 均干净：

```
Test Files  5 passed (5)
     Tests  64 passed (64)
```

如需独立确认底层平台行为：

```
$ node -e "…writeFileSync 后 chmodSync…"
process umask: 022
CURRENT  after writeFileSync: 0644   after chmodSync: 0600
FIXED    after writeFileSync: 0600
RE-WRITE existing 0644 file with {mode:0600} -> 0644   <-- 对已存在文件，mode 被忽略
```

### 证据（前后对比）

N/A —— 无用户可见或 TUI 变化；唯一可观测的差异是文件权限位，已由上述测试覆盖。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

仅单元测试。macOS 15（arm64），Node v22，vitest 3.2.4。

## 风险与范围

- 主要风险或权衡：`saveAccount` 现在会在账号文件旁创建一个唯一命名的临时文件。成功与失败路径都会将其删除，但在写入与 rename 之间被强制杀死仍可能残留一个 —— 无害且以 0600 创建，不过由于名称不再复用，它会累积而非被下次保存覆盖。这属于文件残留而非权限暴露，也正是 `channel-base` 为其自身原子写入所做的同样取舍。
- POSIX 权限位在 Windows 上是空操作，因此那里的权限断言的意义仅在于「不会失败」；原子性收益仍然成立。我把 Windows 与 Linux 标为 ⚠️，因为本地只在 macOS 上验证过 —— CI 覆盖三个平台。
- 未验证 / 范围之外：状态**目录**仍由 `getStateDir()` 以默认权限创建。token 本身已受 0600 保护，因此这不构成泄露路径；修改目录权限与本 PR 关注的文件写入是彼此独立的问题。其他渠道已检查 —— `qqbot` 已经使用 `{ mode: 0o600 }` 写入状态；`telegram`、`feishu`、`dingtalk` 与 `WeixinAdapter` 中的 `writeFileSync` 写的是下载的媒体文件，不是凭据。
- 破坏性变更 / 迁移说明：无。已有的 `account.json` 会在下一次保存时自动收紧为 0600，用户无需任何操作。

## 关联 Issue

无。

</details>


