### PR TITLE
fix(channels): use username as senderId in GitHub adapter to fix allowlist gate

### DIFF
--- a/docs/users/features/channels/github.md
+++ b/docs/users/features/channels/github.md
@@ -72,6 +72,8 @@ On a **public repository**, setting `senderPolicy: "open"` allows **any GitHub u
 
 Always use `senderPolicy: "allowlist"` with explicit `allowedUsers` on public repos.
 
+Allowlist and pairing entries follow the **username**, not the immutable account ID. If an allowlisted user renames their GitHub account, remove the stale entry — GitHub releases the old username for anyone else to claim, and the new holder would inherit the allowlist/pairing authorization.
+
 ## Mention Detection
 
 The adapter detects mentions by scanning the **comment body** for `@bot-username` using a case-insensitive regex. It does NOT rely on GitHub's notification `reason` field, which is a sticky thread-level value that doesn't reflect per-comment mentions.

--- a/packages/channels/github/src/GithubAdapter.test.ts
+++ b/packages/channels/github/src/GithubAdapter.test.ts
@@ -13,7 +13,6 @@ vi.mock('@octokit/rest', () => {
     rest: {
       users: {
         getAuthenticated: vi.fn(),
-        getByUsername: vi.fn(),
       },
       activity: {
         listNotificationsForAuthenticatedUser: vi.fn(),
@@ -51,7 +50,6 @@ const mockOctokit = (
   rest: {
     users: {
       getAuthenticated: ReturnType<typeof vi.fn>;
-      getByUsername: ReturnType<typeof vi.fn>;
     };
     activity: {
       listNotificationsForAuthenticatedUser: ReturnType<typeof vi.fn>;
@@ -195,81 +193,23 @@ describe('GithubChannel', () => {
       );
     });
 
-    it('resolves allowedUsers logins to numeric IDs for the gate without mutating config', async () => {
+    it('passes allowedUsers logins directly to the gate', async () => {
       const config = makeConfig({
         senderPolicy: 'allowlist',
         allowedUsers: ['alice'],
       });
       channel = new TestableGithubChannel('test-github', config, makeBridge());
-      mockOctokit.rest.users.getByUsername.mockResolvedValue({
-        data: { id: 10001, login: 'alice' },
-      });
       mockOctokit.paginate.mockResolvedValue([]);
       await channel.connect();
 
-      expect(mockOctokit.rest.users.getByUsername).toHaveBeenCalledWith({
-        username: 'alice',
-      });
-      // config keeps the original logins so reconnect can re-resolve them.
-      expect(
-        (channel as unknown as { config: { allowedUsers: string[] } }).config
-          .allowedUsers,
-      ).toEqual(['alice']);
       const gate = (
         channel as unknown as {
           gate: { isAllowed: (senderId: string) => boolean };
         }
       ).gate;
-      expect(gate.isAllowed('10001')).toBe(true);
-      expect(gate.isAllowed('alice')).toBe(false);
+      expect(gate.isAllowed('alice')).toBe(true);
+      expect(gate.isAllowed('bob')).toBe(false);
       channel.disconnect();
-    });
-
-    it('connect() is idempotent across reconnects (does not re-resolve numeric IDs)', async () => {
-      const config = makeConfig({
-        senderPolicy: 'allowlist',
-        allowedUsers: ['alice'],
-      });
-      channel = new TestableGithubChannel('test-github', config, makeBridge());
-      // Resolve the login, but 404 on a numeric ID — as GitHub does for
-      // GET /users/{username} when given an ID instead of a login.
-      mockOctokit.rest.users.getByUsername.mockImplementation(
-        async ({ username }: { username: string }) => {
-          if (username === 'alice') {
-            return { data: { id: 10001, login: 'alice' } };
-          }
-          throw new Error(`Not Found: ${username}`);
-        },
-      );
-      mockOctokit.paginate.mockResolvedValue([]);
-
-      await channel.connect();
-      channel.disconnect();
-      // Daemon bridge-crash restart calls disconnect() + connect() on the same
-      // instance; this must not attempt to resolve the already-numeric ID.
-      await expect(channel.connect()).resolves.toBeUndefined();
-      channel.disconnect();
-
-      expect(config.allowedUsers).toEqual(['alice']);
-      expect(mockOctokit.rest.users.getByUsername).toHaveBeenCalledWith({
-        username: 'alice',
-      });
-    });
-
-    it('throws when allowedUser resolution fails', async () => {
-      channel = new TestableGithubChannel(
-        'test-github',
-        makeConfig({ senderPolicy: 'allowlist', allowedUsers: ['alice'] }),
-        makeBridge(),
-      );
-      mockOctokit.rest.users.getByUsername.mockRejectedValue(
-        new Error('transient 502'),
-      );
-      mockOctokit.paginate.mockResolvedValue([]);
-
-      await expect(channel.connect()).rejects.toThrow(
-        'could not resolve allowedUser "alice"',
-      );
     });
   });
 
@@ -284,7 +224,7 @@ describe('GithubChannel', () => {
       expect(channel.inboundEnvelopes).toHaveLength(1);
       const env = channel.inboundEnvelopes[0]!;
       expect(env.text).toBe(' please fix this');
-      expect(env.senderId).toBe('10001');
+      expect(env.senderId).toBe('alice');
       expect(env.senderName).toBe('alice');
       expect(env.chatId).toBe('owner/repo');
       expect(env.threadId).toBe('issue:42');
@@ -601,7 +541,7 @@ describe('GithubChannel', () => {
       expect(channel.inboundEnvelopes).toHaveLength(1);
       const env = channel.inboundEnvelopes[0]!;
       expect(env.text).toBe(' implement this feature');
-      expect(env.senderId).toBe('10002');
+      expect(env.senderId).toBe('bob');
     });
 
     it('dispatches issue body without mention as isMentioned false', async () => {
@@ -651,7 +591,7 @@ describe('GithubChannel', () => {
       expect(channel.inboundEnvelopes).toHaveLength(1);
       const env = channel.inboundEnvelopes[0]!;
       expect(env.text).toBe(' review this PR');
-      expect(env.senderId).toBe('10003');
+      expect(env.senderId).toBe('carol');
       expect(env.threadId).toBe('pr:99');
       expect(env.metadata).toContain('Pull Request');
     });
@@ -767,9 +707,6 @@ describe('GithubChannel', () => {
         makeConfig({ senderPolicy: 'allowlist', allowedUsers: ['bob'] }),
         makeBridge(),
       );
-      mockOctokit.rest.users.getByUsername.mockResolvedValue({
-        data: { id: 10002, login: 'bob' },
-      });
       mockOctokit.paginate.mockResolvedValueOnce([]);
       await channel.connect();
       channel.disconnect();
@@ -797,7 +734,7 @@ describe('GithubChannel', () => {
         e.messageId.startsWith('issue-body-'),
       );
       expect(bodyEnvelope).toBeDefined();
-      expect(bodyEnvelope!.senderId).toBe('10002');
+      expect(bodyEnvelope!.senderId).toBe('bob');
     });
   });
 

--- a/packages/channels/github/src/GithubAdapter.test.ts
+++ b/packages/channels/github/src/GithubAdapter.test.ts
@@ -193,10 +193,10 @@ describe('GithubChannel', () => {
       );
     });
 
-    it('passes allowedUsers logins directly to the gate', async () => {
+    it('normalizes allowedUsers to lowercase for case-insensitive matching', async () => {
       const config = makeConfig({
         senderPolicy: 'allowlist',
-        allowedUsers: ['alice'],
+        allowedUsers: ['Alice'],
       });
       channel = new TestableGithubChannel('test-github', config, makeBridge());
       mockOctokit.paginate.mockResolvedValue([]);
@@ -209,7 +209,23 @@ describe('GithubChannel', () => {
       ).gate;
       expect(gate.isAllowed('alice')).toBe(true);
       expect(gate.isAllowed('bob')).toBe(false);
+      // config is normalized too — ChannelBase reads it directly
+      expect(config.allowedUsers).toEqual(['alice']);
       channel.disconnect();
+    });
+
+    it('connect() is idempotent across reconnects', async () => {
+      const config = makeConfig({
+        senderPolicy: 'allowlist',
+        allowedUsers: ['Alice'],
+      });
+      channel = new TestableGithubChannel('test-github', config, makeBridge());
+      mockOctokit.paginate.mockResolvedValue([]);
+      await channel.connect();
+      channel.disconnect();
+      await expect(channel.connect()).resolves.toBeUndefined();
+      channel.disconnect();
+      expect(config.allowedUsers).toEqual(['alice']);
     });
   });
 
@@ -231,6 +247,13 @@ describe('GithubChannel', () => {
       expect(env.isMentioned).toBe(true);
       expect(env.isGroup).toBe(true);
       expect(env.metadata).toContain('Test Issue');
+      // senderId must be comparable to config.allowedUsers — ChannelBase
+      // compares them directly in isAuthorizedForSharedSessionTarget.
+      const cfg = channel as unknown as {
+        config: { allowedUsers: string[] };
+      };
+      cfg.config.allowedUsers = ['alice'];
+      expect(cfg.config.allowedUsers).toContain(env.senderId);
     });
 
     it('skips bot own comments', async () => {

--- a/packages/channels/github/src/GithubAdapter.ts
+++ b/packages/channels/github/src/GithubAdapter.ts
@@ -30,7 +30,6 @@ const MAX_DISPATCHED_BODIES = 500;
 
 export class GithubChannel extends PollingChannelBase<GithubCursor> {
   private octokit!: Octokit;
-  private botUserId: number | null = null;
   private botUsername: string | null = null;
   private webOrigin = 'https://github.com';
 
@@ -75,32 +74,13 @@ export class GithubChannel extends PollingChannelBase<GithubCursor> {
     });
     try {
       const { data } = await this.octokit.rest.users.getAuthenticated();
-      this.botUserId = data.id;
       this.botUsername = data.login;
     } catch (err) {
       throw new Error(
         `[Channel:${this.name}] failed to resolve bot identity: ${err}`,
       );
     }
-    // Resolve allowedUsers logins to immutable numeric IDs
-    const resolved: string[] = [];
-    for (const login of this.config.allowedUsers ?? []) {
-      try {
-        const { data: u } = await this.octokit.rest.users.getByUsername({
-          username: login,
-        });
-        resolved.push(String(u.id));
-      } catch (err) {
-        throw new Error(
-          `[Channel:${this.name}] could not resolve allowedUser "${login}" to a numeric ID: ${err}`,
-        );
-      }
-    }
-    // Only the gate consumes the resolved IDs. Keep this.config.allowedUsers as
-    // the original logins so connect() stays idempotent — the daemon reconnect
-    // path calls disconnect() + connect() on the same instance, and re-resolving
-    // already-numeric IDs would 404 (GET /users/{username} expects a login).
-    this.gate.replaceAllowedUsers(resolved);
+    this.gate.replaceAllowedUsers(this.config.allowedUsers ?? []);
     this.startPollLoop();
   }
 
@@ -202,7 +182,7 @@ export class GithubChannel extends PollingChannelBase<GithubCursor> {
         );
 
         const newComments = comments.filter((c) => {
-          if (c.user?.id != null && c.user.id === this.botUserId) {
+          if (c.user?.login != null && c.user.login === this.botUsername) {
             return false;
           }
           if (c.created_at && c.created_at > maxUpdatedAt) {
@@ -228,7 +208,7 @@ export class GithubChannel extends PollingChannelBase<GithubCursor> {
 
           const envelope: Envelope = {
             channelName: this.name,
-            senderId: String(comment.user?.id ?? 'unknown'),
+            senderId: comment.user?.login || 'unknown',
             senderName: comment.user?.login || 'unknown',
             chatId,
             threadId,
@@ -298,7 +278,7 @@ export class GithubChannel extends PollingChannelBase<GithubCursor> {
 
       const body = issue.body || '';
 
-      if (issue.user?.id === this.botUserId) return;
+      if (issue.user?.login === this.botUsername) return;
 
       const isMentioned = this.botUsername
         ? testBotMention(body, this.botUsername)
@@ -310,7 +290,7 @@ export class GithubChannel extends PollingChannelBase<GithubCursor> {
 
       const envelope: Envelope = {
         channelName: this.name,
-        senderId: String(issue.user?.id ?? 'unknown'),
+        senderId: issue.user?.login || 'unknown',
         senderName: issue.user?.login || 'unknown',
         chatId,
         threadId,

--- a/packages/channels/github/src/GithubAdapter.ts
+++ b/packages/channels/github/src/GithubAdapter.ts
@@ -80,7 +80,14 @@ export class GithubChannel extends PollingChannelBase<GithubCursor> {
         `[Channel:${this.name}] failed to resolve bot identity: ${err}`,
       );
     }
-    this.gate.replaceAllowedUsers(this.config.allowedUsers ?? []);
+    // GitHub logins are case-insensitive; normalize both sides so the
+    // allowlist gate and ChannelBase's shared-session authorization match
+    // regardless of how the operator typed the config entry.
+    const allowed = (this.config.allowedUsers ?? []).map((u) =>
+      u.toLowerCase(),
+    );
+    this.config.allowedUsers = allowed;
+    this.gate.replaceAllowedUsers(allowed);
     this.startPollLoop();
   }
 
@@ -182,7 +189,7 @@ export class GithubChannel extends PollingChannelBase<GithubCursor> {
         );
 
         const newComments = comments.filter((c) => {
-          if (c.user?.login != null && c.user.login === this.botUsername) {
+          if (c.user?.login === this.botUsername) {
             return false;
           }
           if (c.created_at && c.created_at > maxUpdatedAt) {
@@ -208,7 +215,7 @@ export class GithubChannel extends PollingChannelBase<GithubCursor> {
 
           const envelope: Envelope = {
             channelName: this.name,
-            senderId: comment.user?.login || 'unknown',
+            senderId: (comment.user?.login || 'unknown').toLowerCase(),
             senderName: comment.user?.login || 'unknown',
             chatId,
             threadId,
@@ -290,7 +297,7 @@ export class GithubChannel extends PollingChannelBase<GithubCursor> {
 
       const envelope: Envelope = {
         channelName: this.name,
-        senderId: issue.user?.login || 'unknown',
+        senderId: (issue.user?.login || 'unknown').toLowerCase(),
         senderName: issue.user?.login || 'unknown',
         chatId,
         threadId,


### PR DESCRIPTION
## What this PR does

Changes the GitHub channel adapter to use the commenter's username (login) as the sender identity throughout, instead of resolving it to a numeric user ID via an extra API call. The allowlist gate, pairing store, bot self-comment filtering, and envelope sender field now all operate on usernames directly. Both sides are normalized to lowercase so matching is case-insensitive, matching GitHub's own login semantics.

## Why it's needed

As identified in https://github.com/QwenLM/qwen-code/pull/7632#pullrequestreview-4779068826:

> **[Critical]** isAuthorizedForSharedSessionTarget (ChannelBase.ts:4016) compares config.allowedUsers (logins like 'alice') against envelope.senderId (numeric IDs like '10001') — the GithubAdapter resolves logins to numeric IDs for the SenderGate but deliberately leaves config.allowedUsers as original logins. With senderPolicy: 'allowlist' and the default chat_thread scope (always shared), every allowlisted user is rejected from /who, /clear, /status, /loop, and channel memory commands.

The numeric ID resolution also made `connect()` non-idempotent: on daemon reconnect, re-resolving an already-numeric ID via `GET /users/{username}` returns 404, crashing the channel.

Using usernames directly eliminates both issues. This assumes GitHub users don't change usernames, which is a reasonable tradeoff for the simplicity and correctness gain.

## Reviewer Test Plan

### How to verify

1. Configure a GitHub channel with `senderPolicy: "allowlist"` and `allowedUsers: ["<your-username>"]` (any casing works)
2. Start the channel, create an issue mentioning the bot
3. Confirm the bot replies (previously it would reply to the mention but reject all shared-session commands)
4. Wait 3+ poll cycles — confirm no repeat replies

Unit tests: `cd packages/channels/github && npx vitest run src/GithubAdapter.test.ts` (54 tests pass)

### Evidence (Before & After)

E2E validated with real GitHub API ([OrbitZore/channel-e2e-0726](https://github.com/OrbitZore/channel-e2e-0726), bot `@orbitzorex`, pollInterval 15s, model qwen3.6-flash):

**Pairing flow** (`senderPolicy: "pairing"`):

| Step | Action | Result |
|------|--------|--------|
| P1 | Create issue `@orbitzorex what is fib(10)?` | Bot replied pairing code `5B2VU5LD` |
| P2 | `qwen channel pairing approve e2e-0726-pair 5B2VU5LD` | `Approved: OrbitZore` (username stored, not numeric ID) |
| P3 | Comment `@orbitzorex what is fib(10)?` | Bot replied `fib(10) = 55` |
| P4 | Wait 3 poll cycles (50s) | 3 comments total — no repeat |
| P5 | Comment `@orbitzorex is 17 a prime number?` | Bot replied "Yes, 17 is a prime number" |
| P6 | Wait 3 poll cycles (50s) | 5 comments total — no repeat |

**Allowlist gate** (`senderPolicy: "allowlist"`, `allowedUsers: ["OrbitZore"]`):

| Step | Action | Result |
|------|--------|--------|
| A1 | Create issue `@orbitzorex what is fib(10)?` | Bot replied `55` (allowed, no pairing code) |
| A2 | Wait 3 poll cycles (50s) | 1 comment — no repeat |
| A3 | Comment `@orbitzorex is 17 prime?` | Bot replied "Yes" |
| A4 | Wait 3 poll cycles (50s) | 3 comments — no repeat |
| A5 | Create new issue `@orbitzorex what is fib(20)?` | Bot replied `6765` (new thread works) |
| A6 | Wait 3 poll cycles (50s) | Issue 2: 3 comments, Issue 3: 1 comment — no repeat |

**Case-insensitive matching** (`allowedUsers: ["ORBITZORE"]` — deliberately wrong casing):

| Step | Action | Result |
|------|--------|--------|
| C1 | Create issue `@orbitzorex what is fib(5)?` | Bot replied `5` — config `ORBITZORE` matched API login `OrbitZore` via lowercase normalization |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

`node dist/cli.js channel start` with real GitHub token, bundle built from this branch.

## Risk & Scope

- Main risk or tradeoff: Allowlist/pairing entries follow the **username**, not the immutable account ID. If an allowlisted user renames their GitHub account, the old username becomes available for anyone else to claim — and the new holder inherits the allowlist/pairing authorization (fail-open). Mitigation: remove stale entries after a rename; documented in the security section of the GitHub channel docs.
- Not validated / out of scope: N/A
- Breaking changes / migration notes: Existing `allowedUsers` configs already use logins — no migration needed. Persisted state keyed by the old numeric senderId format is invalidated on upgrade: (1) PairingStore allowlist entries — affected users re-pair once; (2) ChannelLoopStore job targets — pre-upgrade `/loop` jobs cannot be stopped/replaced by the same user, a fresh `/loop` creates a duplicate; (3) observed delivery contacts — stale numeric entries remain in the proactive-target list. All are one-time and minor.

## Linked Issues

Addresses the Critical finding in https://github.com/QwenLM/qwen-code/pull/7632#pullrequestreview-4779068826

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

将 GitHub channel 适配器的发送者标识从数字用户 ID 改为用户名（login）。允许列表门禁、配对存储、bot 自评论过滤和消息信封的 sender 字段全部直接使用用户名，不再通过额外 API 调用解析数字 ID。两侧统一归一化为小写，匹配 GitHub 登录名大小写不敏感的语义。

## 为什么需要

如 https://github.com/QwenLM/qwen-code/pull/7632#pullrequestreview-4779068826 中指出：

> **[Critical]** isAuthorizedForSharedSessionTarget (ChannelBase.ts:4016) 将 config.allowedUsers（login 如 'alice'）与 envelope.senderId（数字 ID 如 '10001'）比较——GithubAdapter 将 login 解析为数字 ID 传给 SenderGate，但 config.allowedUsers 保留原始 login。在 senderPolicy: 'allowlist' + 默认 chat_thread 范围（始终共享）下，所有允许列表用户被 /who、/clear、/status、/loop 和 channel memory 命令拒绝。

数字 ID 解析还导致 connect() 不幂等：daemon 重连时重新解析已是数字的 ID，GET /users/{username} 返回 404，channel 崩溃。

直接使用用户名同时消除了这两个问题。假设 GitHub 用户不会随便换用户名，这是合理取舍。

## 验证方式

1. 配置 GitHub channel，设置 `senderPolicy: "allowlist"`，`allowedUsers: ["<你的用户名>"]`（大小写均可）
2. 启动 channel，创建 issue 并 mention bot
3. 确认 bot 回复（之前会回复 mention 但拒绝所有共享会话命令）
4. 等待 3 个以上轮询周期——确认无重复回复

单元测试：`cd packages/channels/github && npx vitest run src/GithubAdapter.test.ts`（54 项全部通过）

## E2E 证据

使用真实 GitHub API 验证（[OrbitZore/channel-e2e-0726](https://github.com/OrbitZore/channel-e2e-0726)，bot `@orbitzorex`，pollInterval 15s，model qwen3.6-flash）：

**配对流程**（`senderPolicy: "pairing"`）：

| 步骤 | 操作 | 结果 |
|------|------|------|
| P1 | 创建 issue `@orbitzorex what is fib(10)?` | Bot 回复配对码 `5B2VU5LD` |
| P2 | `qwen channel pairing approve e2e-0726-pair 5B2VU5LD` | `Approved: OrbitZore`（存储的是用户名，非数字 ID） |
| P3 | 评论 `@orbitzorex what is fib(10)?` | Bot 回复 `fib(10) = 55` |
| P4 | 等待 3 个轮询周期（50s） | 共 3 条评论——无重复 |
| P5 | 评论 `@orbitzorex is 17 a prime number?` | Bot 回复 "Yes, 17 is a prime number" |
| P6 | 等待 3 个轮询周期（50s） | 共 5 条评论——无重复 |

**允许列表门禁**（`senderPolicy: "allowlist"`，`allowedUsers: ["OrbitZore"]`）：

| 步骤 | 操作 | 结果 |
|------|------|------|
| A1 | 创建 issue `@orbitzorex what is fib(10)?` | Bot 回复 `55`（已授权，无配对码） |
| A2 | 等待 3 个轮询周期（50s） | 1 条评论——无重复 |
| A3 | 评论 `@orbitzorex is 17 prime?` | Bot 回复 "Yes" |
| A4 | 等待 3 个轮询周期（50s） | 3 条评论——无重复 |
| A5 | 创建新 issue `@orbitzorex what is fib(20)?` | Bot 回复 `6765`（新线程正常） |
| A6 | 等待 3 个轮询周期（50s） | Issue 2: 3 条评论，Issue 3: 1 条评论——无重复 |

**大小写不敏感匹配**（`allowedUsers: ["ORBITZORE"]`——故意使用错误大小写）：

| 步骤 | 操作 | 结果 |
|------|------|------|
| C1 | 创建 issue `@orbitzorex what is fib(5)?` | Bot 回复 `5`——配置中的 `ORBITZORE` 通过小写归一化匹配了 API 返回的 `OrbitZore` |

## 风险与范围

- 主要风险：允许列表/配对条目跟随**用户名**而非不可变账号 ID。若允许列表中的用户改名，旧用户名会被 GitHub 释放供他人注册——新持有者将继承允许列表/配对授权（fail-open）。缓解措施：改名后删除旧条目；已在 GitHub channel 文档安全警示部分说明。
- 未验证/不在范围内：N/A
- 破坏性变更：现有 allowedUsers 配置本身就是 login，无需迁移。升级后以旧数字 senderId 格式持久化的状态失效：(1) PairingStore 允许列表条目——受影响用户重新配对一次；(2) ChannelLoopStore 任务目标——升级前排定的 /loop 无法被同一用户 stop/replace，新 /loop 产生重复；(3) 观测到的投递联系人——旧数字条目残留在主动投递目标列表中。均为一次性小问题。

</details>
