### PR TITLE
fix(cli): probe sandbox runtime before selecting it

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -160,6 +160,40 @@ vi.mock('command-exists', () => ({
   },
 }));
 
+// #7734 added a sandbox runtime probe that spawns a real `docker version`
+// subprocess during sandbox selection. These tests enable the sandbox to assert
+// image precedence, not which runtime is chosen, so left unmocked the probe runs
+// for real and the suite fails on any non-macOS host without a running daemon
+// (macOS is masked because the sandbox-exec branch returns before probing).
+// Report the runtime probe healthy; leave every other spawnSync call real.
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  const spawnSync = vi.fn(
+    (command: string, args?: readonly string[], options?: unknown) => {
+      if (
+        (command === 'docker' || command === 'podman') &&
+        args?.[0] === 'version'
+      ) {
+        return {
+          status: 0,
+          stdout: '',
+          stderr: '',
+          signal: null,
+          pid: 0,
+          output: [],
+          error: undefined,
+        };
+      }
+      return (actual.spawnSync as unknown as (...a: unknown[]) => unknown)(
+        command,
+        args,
+        options,
+      );
+    },
+  );
+  return { ...actual, default: { ...actual, spawnSync }, spawnSync };
+});
+
 vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
   const actualServer = await importOriginal<typeof ServerConfig>();
   const SkillManagerMock = vi.fn();

--- a/packages/cli/src/config/sandboxConfig.test.ts
+++ b/packages/cli/src/config/sandboxConfig.test.ts
@@ -1,0 +1,160 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SpawnSyncReturns } from 'node:child_process';
+
+const { commandExistsSync, spawnSync, platform } = vi.hoisted(() => ({
+  commandExistsSync: vi.fn<(cmd: string) => boolean>(),
+  spawnSync: vi.fn(),
+  platform: vi.fn<() => string>(),
+}));
+
+vi.mock('command-exists', () => ({
+  default: { sync: commandExistsSync },
+}));
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  // `default` has to carry the stub too: Node builtins are CJS, so Vite's
+  // interop can resolve a named import through the default export.
+  return { ...actual, default: { ...actual, spawnSync }, spawnSync };
+});
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return { ...actual, platform };
+});
+
+vi.mock('../utils/package.js', () => ({
+  getPackageJson: vi.fn(async () => ({
+    config: { sandboxImageUri: 'test-image' },
+  })),
+}));
+
+const { loadSandboxConfig } = await import('./sandboxConfig.js');
+
+/** A `spawnSync` result standing in for a runtime that answers `version`. */
+function healthy(): Partial<SpawnSyncReturns<string>> {
+  return { status: 0, stdout: 'Version: 99.0.0\n', stderr: '' };
+}
+
+/**
+ * A runtime whose CLI is installed but cannot reach its daemon — Docker
+ * Desktop stopped, or the user not in the `docker` group.
+ */
+function daemonDown(): Partial<SpawnSyncReturns<string>> {
+  return {
+    status: 1,
+    stdout: '',
+    stderr:
+      'Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?\n',
+  };
+}
+
+/** Route probe results per command so a test can mix healthy and broken. */
+function probes(byCommand: Record<string, Partial<SpawnSyncReturns<string>>>) {
+  spawnSync.mockImplementation((cmd: string) => {
+    const result = byCommand[cmd];
+    if (!result) throw new Error(`unexpected probe of '${cmd}'`);
+    return result;
+  });
+}
+
+function installed(...commands: string[]) {
+  commandExistsSync.mockImplementation((cmd: string) => commands.includes(cmd));
+}
+
+describe('loadSandboxConfig sandbox command selection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    platform.mockReturnValue('linux');
+    delete process.env['SANDBOX'];
+    delete process.env['QWEN_SANDBOX'];
+  });
+
+  afterEach(() => {
+    delete process.env['SANDBOX'];
+    delete process.env['QWEN_SANDBOX'];
+  });
+
+  it('falls back to podman when docker is installed but its daemon is unreachable', async () => {
+    installed('docker', 'podman');
+    probes({ docker: daemonDown(), podman: healthy() });
+
+    const config = await loadSandboxConfig({}, { sandbox: true });
+
+    expect(config?.command).toBe('podman');
+  });
+
+  it('still prefers docker when it is usable', async () => {
+    installed('docker', 'podman');
+    probes({ docker: healthy(), podman: healthy() });
+
+    const config = await loadSandboxConfig({}, { sandbox: true });
+
+    expect(config?.command).toBe('docker');
+  });
+
+  it('names the runtime that broke when no installed runtime can run', async () => {
+    installed('docker');
+    probes({ docker: daemonDown() });
+
+    await expect(loadSandboxConfig({}, { sandbox: true })).rejects.toThrow(
+      /docker.*cannot run.*Cannot connect to the Docker daemon/s,
+    );
+  });
+
+  it('keeps the generic message when nothing is installed at all', async () => {
+    installed();
+    probes({});
+
+    await expect(loadSandboxConfig({}, { sandbox: true })).rejects.toThrow(
+      /failed to determine command for sandbox/,
+    );
+  });
+
+  it('does not silently override an explicit QWEN_SANDBOX choice', async () => {
+    process.env['QWEN_SANDBOX'] = 'docker';
+    installed('docker', 'podman');
+    probes({ docker: daemonDown(), podman: healthy() });
+
+    await expect(loadSandboxConfig({}, {})).rejects.toThrow(
+      /'docker' \(from QWEN_SANDBOX\) is installed but cannot run/,
+    );
+  });
+
+  it('accepts an explicit choice that is usable', async () => {
+    process.env['QWEN_SANDBOX'] = 'podman';
+    installed('podman');
+    probes({ podman: healthy() });
+
+    const config = await loadSandboxConfig({}, {});
+
+    expect(config?.command).toBe('podman');
+  });
+
+  it('selects seatbelt on darwin without probing a daemon', async () => {
+    platform.mockReturnValue('darwin');
+    installed('sandbox-exec', 'docker');
+    probes({});
+
+    const config = await loadSandboxConfig({}, { sandbox: true });
+
+    expect(config?.command).toBe('sandbox-exec');
+    expect(spawnSync).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when the sandbox is disabled', async () => {
+    installed('docker');
+    probes({});
+
+    const config = await loadSandboxConfig({}, { sandbox: false });
+
+    expect(config).toBeUndefined();
+    expect(spawnSync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/config/sandboxConfig.test.ts
+++ b/packages/cli/src/config/sandboxConfig.test.ts
@@ -108,6 +108,29 @@ describe('loadSandboxConfig sandbox command selection', () => {
     );
   });
 
+  it('does not blame QWEN_SANDBOX when --sandbox enabled the auto-detect path', async () => {
+    installed('docker');
+    probes({ docker: daemonDown() });
+
+    const failure = await loadSandboxConfig({}, { sandbox: true }).catch(
+      (error: Error) => error,
+    );
+
+    expect((failure as Error).message).toContain("'docker' is installed");
+    expect((failure as Error).message).toContain('--sandbox');
+    expect((failure as Error).message).not.toContain('QWEN_SANDBOX is true');
+  });
+
+  it('says QWEN_SANDBOX is true when the env var enabled the sandbox', async () => {
+    process.env['QWEN_SANDBOX'] = 'true';
+    installed('docker');
+    probes({ docker: daemonDown() });
+
+    await expect(loadSandboxConfig({}, {})).rejects.toThrow(
+      /QWEN_SANDBOX is true and 'docker' is installed but cannot run/,
+    );
+  });
+
   it('keeps the generic message when nothing is installed at all', async () => {
     installed();
     probes({});

--- a/packages/cli/src/config/sandboxConfig.test.ts
+++ b/packages/cli/src/config/sandboxConfig.test.ts
@@ -35,7 +35,9 @@ vi.mock('../utils/package.js', () => ({
   })),
 }));
 
-const { loadSandboxConfig } = await import('./sandboxConfig.js');
+const { loadSandboxConfig, resetSandboxProbeCacheForTest } = await import(
+  './sandboxConfig.js'
+);
 
 /** A `spawnSync` result standing in for a runtime that answers `version`. */
 function healthy(): Partial<SpawnSyncReturns<string>> {
@@ -109,6 +111,7 @@ function installed(...commands: string[]) {
 describe('loadSandboxConfig sandbox command selection', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetSandboxProbeCacheForTest();
     platform.mockReturnValue('linux');
     delete process.env['SANDBOX'];
     delete process.env['QWEN_SANDBOX'];
@@ -148,6 +151,22 @@ describe('loadSandboxConfig sandbox command selection', () => {
     expect(config?.command).toBe('podman');
   });
 
+  it('probes each runtime once and reuses the result across calls', async () => {
+    // Selection runs more than once per startup (the sandbox hop, then again
+    // inside loadCliConfig), so without the cache a wedged runtime pays the
+    // timeout on every pass. Two selections must probe docker only once.
+    installed('docker', 'podman');
+    probes({ docker: healthy() });
+
+    await loadSandboxConfig({}, { sandbox: true });
+    await loadSandboxConfig({}, { sandbox: true });
+
+    const dockerProbes = spawnSync.mock.calls.filter(
+      ([cmd]) => cmd === 'docker',
+    ).length;
+    expect(dockerProbes).toBe(1);
+  });
+
   it('still prefers docker when it is usable', async () => {
     installed('docker', 'podman');
     probes({ docker: healthy(), podman: healthy() });
@@ -164,6 +183,27 @@ describe('loadSandboxConfig sandbox command selection', () => {
     await expect(loadSandboxConfig({}, { sandbox: true })).rejects.toThrow(
       /docker.*cannot run.*Cannot connect to the Docker daemon/s,
     );
+  });
+
+  it('strips ANSI and control characters from the runtime failure', async () => {
+    // The runtime's stderr is interpolated into a FatalSandboxError that
+    // reaches the terminal, so its escape and control bytes must not survive.
+    process.env['QWEN_SANDBOX'] = 'docker';
+    installed('docker');
+    probes({
+      docker: {
+        status: 1,
+        stdout: '',
+        stderr: '\x1b[31mCannot connect to the daemon\x1b[0m\x07\n',
+      },
+    });
+
+    const error = await loadSandboxConfig({}, {}).catch((e: Error) => e);
+    const message = (error as Error).message;
+
+    expect(message).toContain('Cannot connect to the daemon');
+    expect(message).not.toContain('\x1b');
+    expect(message).not.toContain('\x07');
   });
 
   it('surfaces the timeout error when a probe is killed at the cap', async () => {

--- a/packages/cli/src/config/sandboxConfig.test.ts
+++ b/packages/cli/src/config/sandboxConfig.test.ts
@@ -56,6 +56,30 @@ function daemonDown(): Partial<SpawnSyncReturns<string>> {
 }
 
 /**
+ * A runtime that exits non-zero but prints nothing — a wrapper that swallows
+ * output, or a silent permission failure. The empty output is the point: it is
+ * what makes the `?? synthesized message` fallback in `probeSandboxCommand`
+ * load-bearing. Without that fallback the probe would return `undefined` here
+ * and the broken runtime would be declared usable.
+ */
+function brokenSilently(): Partial<SpawnSyncReturns<string>> {
+  return { status: 1, stdout: '', stderr: '' };
+}
+
+/**
+ * A wedged daemon killed at the timeout: `spawnSync` reports an `error` and a
+ * null status. This is the path `SANDBOX_PROBE_TIMEOUT_MS` exists for.
+ */
+function timedOut(): Partial<SpawnSyncReturns<string>> {
+  return {
+    error: new Error('spawnSync docker ETIMEDOUT'),
+    status: null,
+    stdout: '',
+    stderr: '',
+  };
+}
+
+/**
  * Route probe results per command so a test can mix healthy and broken.
  *
  * The stub validates argv and the timeout, not just the command name. Both are
@@ -111,6 +135,19 @@ describe('loadSandboxConfig sandbox command selection', () => {
     );
   });
 
+  it('treats a non-zero exit with no output as broken and falls through', async () => {
+    // Pins the `?? synthesized message` fallback: with empty output the probe
+    // must still report a failure so selection moves on. Drop the fallback and
+    // probeSandboxCommand returns undefined here, docker is called usable, and
+    // the original bug returns with every selection assertion still green.
+    installed('docker', 'podman');
+    probes({ docker: brokenSilently(), podman: healthy() });
+
+    const config = await loadSandboxConfig({}, { sandbox: true });
+
+    expect(config?.command).toBe('podman');
+  });
+
   it('still prefers docker when it is usable', async () => {
     installed('docker', 'podman');
     probes({ docker: healthy(), podman: healthy() });
@@ -127,6 +164,17 @@ describe('loadSandboxConfig sandbox command selection', () => {
     await expect(loadSandboxConfig({}, { sandbox: true })).rejects.toThrow(
       /docker.*cannot run.*Cannot connect to the Docker daemon/s,
     );
+  });
+
+  it('surfaces the timeout error when a probe is killed at the cap', async () => {
+    // Pins the `result.error` branch — the wedged-daemon path the timeout
+    // exists for. Delete that branch and the throw degrades from the ETIMEDOUT
+    // text to "exited with null" with the suite still green.
+    process.env['QWEN_SANDBOX'] = 'docker';
+    installed('docker');
+    probes({ docker: timedOut() });
+
+    await expect(loadSandboxConfig({}, {})).rejects.toThrow(/ETIMEDOUT/);
   });
 
   it('does not blame QWEN_SANDBOX when --sandbox enabled the auto-detect path', async () => {

--- a/packages/cli/src/config/sandboxConfig.test.ts
+++ b/packages/cli/src/config/sandboxConfig.test.ts
@@ -55,13 +55,27 @@ function daemonDown(): Partial<SpawnSyncReturns<string>> {
   };
 }
 
-/** Route probe results per command so a test can mix healthy and broken. */
+/**
+ * Route probe results per command so a test can mix healthy and broken.
+ *
+ * The stub validates argv and the timeout, not just the command name. Both are
+ * load-bearing and neither is observable from the selection result: `version`
+ * contacts the daemon while `--version` only prints the client build, so a
+ * probe that drifted to `--version` would call every broken runtime healthy and
+ * silently restore the original bug with the selection assertions still green.
+ * The timeout is the only bound on a wedged daemon that accepts connections and
+ * never answers.
+ */
 function probes(byCommand: Record<string, Partial<SpawnSyncReturns<string>>>) {
-  spawnSync.mockImplementation((cmd: string) => {
-    const result = byCommand[cmd];
-    if (!result) throw new Error(`unexpected probe of '${cmd}'`);
-    return result;
-  });
+  spawnSync.mockImplementation(
+    (cmd: string, args: string[], options: { timeout?: number }) => {
+      const result = byCommand[cmd];
+      if (!result) throw new Error(`unexpected probe of '${cmd}'`);
+      expect(args).toEqual(['version']);
+      expect(options?.timeout).toBeGreaterThan(0);
+      return result;
+    },
+  );
 }
 
 function installed(...commands: string[]) {
@@ -88,6 +102,13 @@ describe('loadSandboxConfig sandbox command selection', () => {
     const config = await loadSandboxConfig({}, { sandbox: true });
 
     expect(config?.command).toBe('podman');
+    // Pin the probe argument at the call site as well: `docker version` is what
+    // reaches the daemon, and it is the reason the fallback fires at all.
+    expect(spawnSync).toHaveBeenCalledWith(
+      'docker',
+      ['version'],
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
   });
 
   it('still prefers docker when it is usable', async () => {

--- a/packages/cli/src/config/sandboxConfig.test.ts
+++ b/packages/cli/src/config/sandboxConfig.test.ts
@@ -127,6 +127,30 @@ describe('loadSandboxConfig sandbox command selection', () => {
     );
   });
 
+  it('does not blame QWEN_SANDBOX for a command that came from --sandbox', async () => {
+    installed('docker', 'podman');
+    probes({ docker: daemonDown(), podman: healthy() });
+
+    // `--sandbox docker` / `tools.sandbox` reach the same code path, so the
+    // error must not point at an env var the user never set.
+    const failure = await loadSandboxConfig({}, { sandbox: 'docker' }).catch(
+      (error: Error) => error,
+    );
+
+    expect((failure as Error).message).toContain("'docker' is installed");
+    expect((failure as Error).message).not.toContain('QWEN_SANDBOX');
+  });
+
+  it('names QWEN_SANDBOX when a missing command really did come from it', async () => {
+    process.env['QWEN_SANDBOX'] = 'podman';
+    installed('docker');
+    probes({});
+
+    await expect(loadSandboxConfig({}, {})).rejects.toThrow(
+      /Missing sandbox command 'podman' \(from QWEN_SANDBOX\)/,
+    );
+  });
+
   it('accepts an explicit choice that is usable', async () => {
     process.env['QWEN_SANDBOX'] = 'podman';
     installed('podman');

--- a/packages/cli/src/config/sandboxConfig.test.ts
+++ b/packages/cli/src/config/sandboxConfig.test.ts
@@ -185,6 +185,38 @@ describe('loadSandboxConfig sandbox command selection', () => {
     );
   });
 
+  it('names the first broken runtime when every installed runtime fails', async () => {
+    // Pins that the error reports docker (tried first), not podman (tried
+    // last). Flip `firstFailure ??=` to `=` and it would name podman with the
+    // suite otherwise green, sending the user to debug the wrong daemon.
+    installed('docker', 'podman');
+    probes({ docker: daemonDown(), podman: daemonDown() });
+
+    const error = await loadSandboxConfig({}, { sandbox: true }).catch(
+      (e: Error) => e,
+    );
+    const message = (error as Error).message;
+
+    expect(message).toContain("'docker'");
+    expect(message).not.toContain("'podman'");
+  });
+
+  it('treats a failure of only control characters as broken, not usable', async () => {
+    // The runtime exits non-zero but its output is nothing but escape/control
+    // bytes, which strip to ''. That empty string must not read as "no
+    // failure" — otherwise the broken runtime is selected, reintroducing the
+    // presence-vs-liveness bug through the sanitizer.
+    installed('docker', 'podman');
+    probes({
+      docker: { status: 1, stdout: '', stderr: '\x1b[0m\x07\n' },
+      podman: healthy(),
+    });
+
+    const config = await loadSandboxConfig({}, { sandbox: true });
+
+    expect(config?.command).toBe('podman');
+  });
+
   it('strips ANSI and control characters from the runtime failure', async () => {
     // The runtime's stderr is interpolated into a FatalSandboxError that
     // reaches the terminal, so its escape and control bytes must not survive.

--- a/packages/cli/src/config/sandboxConfig.ts
+++ b/packages/cli/src/config/sandboxConfig.ts
@@ -7,6 +7,7 @@
 import type { SandboxConfig } from '@qwen-code/qwen-code-core';
 import { FatalSandboxError } from '@qwen-code/qwen-code-core';
 import commandExists from 'command-exists';
+import { spawnSync } from 'node:child_process';
 import * as os from 'node:os';
 import { getPackageJson } from '../utils/package.js';
 import type { Settings } from './settings.js';
@@ -26,6 +27,51 @@ const VALID_SANDBOX_COMMANDS: ReadonlyArray<SandboxConfig['command']> = [
 
 function isSandboxCommand(value: string): value is SandboxConfig['command'] {
   return (VALID_SANDBOX_COMMANDS as readonly string[]).includes(value);
+}
+
+const SANDBOX_PROBE_TIMEOUT_MS = 10_000;
+
+/**
+ * Confirms that a sandbox command can actually run, not merely that it is on
+ * PATH. A present container CLI is not a usable one: Docker Desktop may be
+ * stopped, the daemon may be unreachable, or the user may not be in the
+ * `docker` group. `version` is the cheapest command that still contacts the
+ * daemon, so it fails exactly when the runtime would fail later.
+ *
+ * `sandbox-exec` is a kernel facility rather than a daemon-backed client, so
+ * its presence on PATH is already sufficient.
+ *
+ * @returns The first line of the failure output when the command cannot run,
+ *          or undefined when it is usable.
+ */
+function probeSandboxCommand(
+  command: SandboxConfig['command'],
+): string | undefined {
+  if (command === 'sandbox-exec') {
+    return undefined;
+  }
+
+  try {
+    const result = spawnSync(command, ['version'], {
+      encoding: 'utf8',
+      stdio: 'pipe',
+      timeout: SANDBOX_PROBE_TIMEOUT_MS,
+    });
+    if (result.error) {
+      return result.error.message;
+    }
+    if (result.status === 0) {
+      return undefined;
+    }
+    const output = `${result.stderr ?? ''}\n${result.stdout ?? ''}`;
+    const firstLine = output
+      .split('\n')
+      .map((line) => line.trim())
+      .find((line) => line.length > 0);
+    return firstLine ?? `'${command} version' exited with ${result.status}`;
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
 }
 
 function getSandboxCommand(
@@ -60,6 +106,15 @@ function getSandboxCommand(
     }
     // confirm that specified command exists
     if (commandExists.sync(sandbox)) {
+      // An explicit choice is never silently overridden — but it is still
+      // probed, so the failure names the runtime instead of surfacing later as
+      // an opaque container error.
+      const failure = probeSandboxCommand(sandbox);
+      if (failure) {
+        throw new FatalSandboxError(
+          `Sandbox command '${sandbox}' (from QWEN_SANDBOX) is installed but cannot run: ${failure}`,
+        );
+      }
       return sandbox;
     }
     throw new FatalSandboxError(
@@ -69,16 +124,39 @@ function getSandboxCommand(
 
   // look for seatbelt, docker, or podman, in that order
   // for container-based sandboxing, require sandbox to be enabled explicitly
+  const candidates: Array<SandboxConfig['command']> = [];
   if (os.platform() === 'darwin' && commandExists.sync('sandbox-exec')) {
-    return 'sandbox-exec';
-  } else if (commandExists.sync('docker') && sandbox === true) {
-    return 'docker';
-  } else if (commandExists.sync('podman') && sandbox === true) {
-    return 'podman';
+    candidates.push('sandbox-exec');
+  }
+  if (sandbox === true) {
+    candidates.push('docker', 'podman');
+  }
+
+  // Selecting on presence alone would stop at an installed-but-unusable
+  // runtime and leave a working one below it unreachable, so each candidate is
+  // probed and the first one that actually runs wins.
+  let firstFailure: { command: string; detail: string } | undefined;
+  for (const candidate of candidates) {
+    if (candidate !== 'sandbox-exec' && !commandExists.sync(candidate)) {
+      continue;
+    }
+    const failure = probeSandboxCommand(candidate);
+    if (!failure) {
+      return candidate;
+    }
+    firstFailure ??= { command: candidate, detail: failure };
   }
 
   // throw an error if user requested sandbox but no command was found
   if (sandbox === true) {
+    // Report the runtime that actually broke rather than a generic
+    // "nothing installed", which would send the user down the wrong path.
+    if (firstFailure) {
+      throw new FatalSandboxError(
+        `QWEN_SANDBOX is true and '${firstFailure.command}' is installed but cannot run: ` +
+          `${firstFailure.detail}; start it, install another runtime, or specify command in QWEN_SANDBOX`,
+      );
+    }
     throw new FatalSandboxError(
       'QWEN_SANDBOX is true but failed to determine command for sandbox; ' +
         'install docker or podman or specify command in QWEN_SANDBOX',

--- a/packages/cli/src/config/sandboxConfig.ts
+++ b/packages/cli/src/config/sandboxConfig.ts
@@ -99,10 +99,11 @@ function runSandboxProbe(
       .find((line) => line.length > 0);
     // The runtime's own output reaches a FatalSandboxError message, so strip
     // ANSI/control characters from that untrusted string before it hits the
-    // terminal.
-    return firstLine
-      ? stripAnsiAndControl(firstLine)
-      : `'${command} version' exited with ${result.status}`;
+    // terminal. Check for emptiness AFTER stripping: a line that is only
+    // control characters strips to '', which is falsy — return that and the
+    // caller reads the broken runtime as usable, the very bug this guards.
+    const stripped = firstLine ? stripAnsiAndControl(firstLine).trim() : '';
+    return stripped || `'${command} version' exited with ${result.status}`;
   } catch (error) {
     return error instanceof Error ? error.message : String(error);
   }
@@ -177,7 +178,7 @@ function getSandboxCommand(
   // probed and the first one that actually runs wins.
   let firstFailure: { command: string; detail: string } | undefined;
   for (const candidate of candidates) {
-    if (candidate !== 'sandbox-exec' && !commandExists.sync(candidate)) {
+    if (!commandExists.sync(candidate)) {
       continue;
     }
     const failure = probeSandboxCommand(candidate);
@@ -203,7 +204,7 @@ function getSandboxCommand(
     if (firstFailure) {
       throw new FatalSandboxError(
         `${enabledLabel} and '${firstFailure.command}' is installed but cannot run: ` +
-          `${firstFailure.detail}; start it, install another runtime, or ${specifyHint}`,
+          `${firstFailure.detail}; start it, try another installed runtime, or ${specifyHint}`,
       );
     }
     throw new FatalSandboxError(

--- a/packages/cli/src/config/sandboxConfig.ts
+++ b/packages/cli/src/config/sandboxConfig.ts
@@ -96,6 +96,12 @@ function getSandboxCommand(
     return '';
   }
 
+  // An explicitly named command can come from QWEN_SANDBOX, --sandbox, or
+  // tools.sandbox in settings. Naming the wrong one sends the user looking in
+  // a place they never configured, so only claim the env var when it won.
+  const sandboxSource =
+    environmentConfiguredSandbox.length > 0 ? ' (from QWEN_SANDBOX)' : '';
+
   if (typeof sandbox === 'string' && sandbox) {
     if (!isSandboxCommand(sandbox)) {
       throw new FatalSandboxError(
@@ -112,13 +118,13 @@ function getSandboxCommand(
       const failure = probeSandboxCommand(sandbox);
       if (failure) {
         throw new FatalSandboxError(
-          `Sandbox command '${sandbox}' (from QWEN_SANDBOX) is installed but cannot run: ${failure}`,
+          `Sandbox command '${sandbox}'${sandboxSource} is installed but cannot run: ${failure}`,
         );
       }
       return sandbox;
     }
     throw new FatalSandboxError(
-      `Missing sandbox command '${sandbox}' (from QWEN_SANDBOX)`,
+      `Missing sandbox command '${sandbox}'${sandboxSource}`,
     );
   }
 

--- a/packages/cli/src/config/sandboxConfig.ts
+++ b/packages/cli/src/config/sandboxConfig.ts
@@ -29,7 +29,10 @@ function isSandboxCommand(value: string): value is SandboxConfig['command'] {
   return (VALID_SANDBOX_COMMANDS as readonly string[]).includes(value);
 }
 
-const SANDBOX_PROBE_TIMEOUT_MS = 10_000;
+// A healthy `docker version` answers in roughly 200-500ms, so this is already
+// an order of magnitude of headroom. Probes run sequentially, so the ceiling is
+// paid once per wedged runtime — keeping it tight matters for startup.
+const SANDBOX_PROBE_TIMEOUT_MS = 5_000;
 
 /**
  * Confirms that a sandbox command can actually run, not merely that it is on
@@ -155,17 +158,26 @@ function getSandboxCommand(
 
   // throw an error if user requested sandbox but no command was found
   if (sandbox === true) {
+    // Sandboxing can be switched on by the env var, by --sandbox, or by
+    // settings, so these messages name the env var only when it was the one
+    // that enabled it — same reasoning as sandboxSource above.
+    const enabledLabel = sandboxSource
+      ? 'QWEN_SANDBOX is true'
+      : 'Sandbox is enabled';
+    const specifyHint = sandboxSource
+      ? 'specify command in QWEN_SANDBOX'
+      : 'specify command via --sandbox or QWEN_SANDBOX';
     // Report the runtime that actually broke rather than a generic
     // "nothing installed", which would send the user down the wrong path.
     if (firstFailure) {
       throw new FatalSandboxError(
-        `QWEN_SANDBOX is true and '${firstFailure.command}' is installed but cannot run: ` +
-          `${firstFailure.detail}; start it, install another runtime, or specify command in QWEN_SANDBOX`,
+        `${enabledLabel} and '${firstFailure.command}' is installed but cannot run: ` +
+          `${firstFailure.detail}; start it, install another runtime, or ${specifyHint}`,
       );
     }
     throw new FatalSandboxError(
-      'QWEN_SANDBOX is true but failed to determine command for sandbox; ' +
-        'install docker or podman or specify command in QWEN_SANDBOX',
+      `${enabledLabel} but failed to determine command for sandbox; ` +
+        `install docker or podman or ${specifyHint}`,
     );
   }
 

--- a/packages/cli/src/config/sandboxConfig.ts
+++ b/packages/cli/src/config/sandboxConfig.ts
@@ -5,7 +5,10 @@
  */
 
 import type { SandboxConfig } from '@qwen-code/qwen-code-core';
-import { FatalSandboxError } from '@qwen-code/qwen-code-core';
+import {
+  FatalSandboxError,
+  stripAnsiAndControl,
+} from '@qwen-code/qwen-code-core';
 import commandExists from 'command-exists';
 import { spawnSync } from 'node:child_process';
 import * as os from 'node:os';
@@ -30,9 +33,22 @@ function isSandboxCommand(value: string): value is SandboxConfig['command'] {
 }
 
 // A healthy `docker version` answers in roughly 200-500ms, so this is already
-// an order of magnitude of headroom. Probes run sequentially, so the ceiling is
-// paid once per wedged runtime — keeping it tight matters for startup.
+// an order of magnitude of headroom. Keeping it tight matters because a wedged
+// daemon blocks startup for the full cap.
 const SANDBOX_PROBE_TIMEOUT_MS = 5_000;
+
+// `loadSandboxConfig` runs twice on a sandboxed startup — once for the sandbox
+// hop and once inside loadCliConfig — so selection is entered more than once
+// per process. Cache each command's probe outcome so a runtime is contacted at
+// most once; otherwise the wedged-daemon-then-fallback case pays the timeout
+// twice. Daemon state changing mid-startup is not worth serving. Mirrors the
+// ripgrep health cache (`ripgrepUtils.ts`).
+const probeCache = new Map<SandboxConfig['command'], string | undefined>();
+
+/** Clears the per-process probe cache so tests stay hermetic. */
+export function resetSandboxProbeCacheForTest(): void {
+  probeCache.clear();
+}
 
 /**
  * Confirms that a sandbox command can actually run, not merely that it is on
@@ -44,8 +60,8 @@ const SANDBOX_PROBE_TIMEOUT_MS = 5_000;
  * `sandbox-exec` is a kernel facility rather than a daemon-backed client, so
  * its presence on PATH is already sufficient.
  *
- * @returns The first line of the failure output when the command cannot run,
- *          or undefined when it is usable.
+ * @returns The failure output when the command cannot run, or undefined when it
+ *          is usable. The result is cached per command for the process.
  */
 function probeSandboxCommand(
   command: SandboxConfig['command'],
@@ -53,7 +69,17 @@ function probeSandboxCommand(
   if (command === 'sandbox-exec') {
     return undefined;
   }
+  if (probeCache.has(command)) {
+    return probeCache.get(command);
+  }
+  const failure = runSandboxProbe(command);
+  probeCache.set(command, failure);
+  return failure;
+}
 
+function runSandboxProbe(
+  command: SandboxConfig['command'],
+): string | undefined {
   try {
     const result = spawnSync(command, ['version'], {
       encoding: 'utf8',
@@ -71,7 +97,12 @@ function probeSandboxCommand(
       .split('\n')
       .map((line) => line.trim())
       .find((line) => line.length > 0);
-    return firstLine ?? `'${command} version' exited with ${result.status}`;
+    // The runtime's own output reaches a FatalSandboxError message, so strip
+    // ANSI/control characters from that untrusted string before it hits the
+    // terminal.
+    return firstLine
+      ? stripAnsiAndControl(firstLine)
+      : `'${command} version' exited with ${result.status}`;
   } catch (error) {
     return error instanceof Error ? error.message : String(error);
   }


### PR DESCRIPTION
## What this PR does

Sandbox runtime selection now confirms the runtime can actually run before committing to it, instead of assuming it works because the command is on PATH. Each candidate is probed with `version` — the cheapest command that still contacts the daemon — and the first one that actually runs is selected, so auto-selection falls through a broken runtime to a working one.

When no installed runtime can run, the error names the runtime that actually broke and quotes its failure, rather than reporting that nothing is installed. An explicit `QWEN_SANDBOX` choice is never silently redirected to a different runtime: it still fails, but with the daemon error attached so the cause is immediate. `sandbox-exec` is not probed, since seatbelt is a kernel facility rather than a daemon-backed client.

## Why it's needed

`commandExists.sync` answers a PATH question, not a liveness question. A container CLI can be installed and still be unusable — Docker Desktop stopped, the daemon socket unreachable, or the user not in the `docker` group. In that state selection returns `docker` anyway, and because the chain short-circuits, the `podman` branch directly below it is unreachable even when a working podman is installed. The existing ordered fallback could only ever handle a *missing* runtime, never a *broken* one.

The result is a hard startup failure with a working runtime sitting unused, and a diagnosis that points the wrong way: a user whose Docker daemon is stopped is told `install docker or podman`. That is #7732.

This is the same presence-vs-capability gap that #7203 fixed for the bundled ripgrep, where the binary was chosen on file existence alone and the system-`rg` fallback below it became unreachable. Same shape, same remedy: verify the selected thing runs, and report the real failure when it does not.

## Reviewer Test Plan

### How to verify

The real trigger is a stopped or unreachable container daemon. What matters for this code path is not why the daemon is down but the failure *shape*: a runtime CLI that exists, is executable, runs, and exits non-zero. That is reproducible anywhere with stubs.

Put a broken `docker` and a working `podman` on PATH, with `sandbox-exec` out of PATH so the container branch is exercised:

```sh
mkdir -p /tmp/probe-bin
printf '#!/bin/sh\necho "Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?" >&2\nexit 1\n' > /tmp/probe-bin/docker
printf '#!/bin/sh\necho "podman version 5.0.0"\nexit 0\n' > /tmp/probe-bin/podman
chmod +x /tmp/probe-bin/docker /tmp/probe-bin/podman
```

Then drive `loadSandboxConfig({}, { sandbox: true })` with `PATH=/tmp/probe-bin`, and again with `QWEN_SANDBOX=docker`.

Expected on `main`: auto-selection returns `docker`, and the explicit choice is accepted, both against a dead daemon. Expected with this PR: auto-selection returns `podman`, and the explicit choice fails naming docker and quoting the daemon error.

Also worth confirming the non-regressions: docker is still preferred when it is healthy, `sandbox-exec` is still chosen first on darwin without any probe, and the generic "failed to determine command" message is unchanged when genuinely nothing is installed.

Unit tests: `cd packages/cli && npx vitest run src/config/sandboxConfig.test.ts`. Sixteen tests were added — the file had no test coverage before. Several pin probe branches that no selection assertion observes — the `version` argv and timeout, the empty-output / timeout-error fallbacks, the per-process probe cache, and control-character stripping — each verified to fail against a mutant of the branch it covers.

### Evidence (Before & After)

Not a TUI change, so this is captured output from driving the real `loadSandboxConfig` path with the stubs above rather than screenshots.

**Before** — docker installed but daemon unreachable, working podman available:

```
PATH has: docker (daemon down), podman (working)

auto-selection -> "docker"
QWEN_SANDBOX=docker -> "docker"
```

**After** — same conditions:

```
PATH has: docker (daemon down), podman (working)

auto-selection -> "podman"
QWEN_SANDBOX=docker THREW -> Sandbox command 'docker' (from QWEN_SANDBOX) is installed but cannot run: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS 25.5.0 arm64, Node v22.22.3, vitest 3.2.4. Verified with stubbed runtimes; no real docker or podman installed on the test machine, so the daemon-down behavior was reproduced by failure shape rather than by stopping a real daemon.

`npm run preflight` was run in full. Everything passes except `src/ui/auth/AuthDialog.test.tsx`, which is flaky here independently of this change: it fails the same way with this PR's changes fully reverted to `origin/main` (13 failures under full parallel preflight load, 1 when the file is run on its own — all `vi.waitFor` timeouts). Flagging it rather than claiming a clean run; happy to re-run if CI disagrees.

Error attribution: sandboxing can be named or enabled via `QWEN_SANDBOX`, `--sandbox`, or `tools.sandbox` in settings, so every message names the env var only when it was actually the source. That also corrects two pre-existing messages — `Missing sandbox command '...' (from QWEN_SANDBOX)` and `QWEN_SANDBOX is true but failed to determine command` — which claim the env var unconditionally on `main` today.

## Risk & Scope

- Main risk or tradeoff: selection spends one `version` call per candidate at startup. It only runs when sandboxing is already enabled, and `sandbox-exec` — the default on darwin — is never probed, so the common paths are unaffected. The probe is capped by a 5s timeout so a wedged daemon cannot hang startup indefinitely, and the outcome is cached per command for the process — `loadSandboxConfig` runs twice on a sandboxed startup, so without the cache the wedged-then-fallback case would pay the cap twice. With it, each runtime is contacted at most once.
- Not validated / out of scope: I verified locally with stubbed runtimes, not a real stopped daemon, and could not test Windows at all. Correcting an earlier overstatement here: the `Test (macos-latest)` and `Test (windows-latest)` jobs are `merge_group`-gated, so they are skipped on this PR — the green checks here are ubuntu-only, not full-matrix. Reviewers have since closed the other gaps with real-binary runs (Linux and macOS); Windows remains unverified by anyone. Behavior of the container runtime *after* selection is unchanged — this PR only decides which runtime is chosen.
- Breaking changes / migration notes: none. A previously "successful" selection of an unusable runtime becomes either a working alternative or an earlier, clearer error; a genuinely working setup selects exactly what it did before.

## Linked Issues

Fixes #7732

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

沙箱运行时选择现在会先确认该运行时确实可用，而不是仅凭命令存在于 PATH 就认为可用。每个候选项都用 `version` 探测（这是仍会联系守护进程的最廉价命令），第一个真正能运行的才被选中，因此自动选择会越过已损坏的运行时，落到可用的那个。

当没有任何已安装的运行时可用时，错误信息会指出真正失败的运行时并引用其失败原因，而不是声称什么都没装。显式的 `QWEN_SANDBOX` 选择绝不会被静默改写：它仍然失败，但会附上守护进程的错误，便于立即定位。`sandbox-exec` 不做探测，因为 seatbelt 是内核设施而非守护进程客户端。

## 为什么需要

`commandExists.sync` 回答的是 PATH 问题，而不是存活性问题。容器 CLI 可以已安装却不可用——Docker Desktop 已停止、守护进程套接字不可达，或用户不在 `docker` 组中。此时选择仍返回 `docker`，且由于短路求值，紧随其后的 `podman` 分支即使装有可用的 podman 也永远不可达。原有的顺序回退只能处理*缺失*的运行时，无法处理*损坏*的运行时。

结果是：可用的运行时闲置不用，启动直接失败，而且诊断方向错误——守护进程已停止的用户被告知去 `install docker or podman`。即 #7732。

这与 #7203 为内置 ripgrep 修复的问题属于同一类：二进制文件仅凭存在即被选中，导致其下方的系统 `rg` 回退不可达。形状相同，处理方式相同：验证所选对象确实能运行，不能运行时报告真实失败原因。

</details>

<sub>AI-assisted: the fix, tests, and the captured before/after output above were produced with agent assistance and verified by real local runs.</sub>


