### PR TITLE
fix(triage): only the bot's own approval counts as already approved

### DIFF
--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -591,6 +591,9 @@ jobs:
         run: |-
           set -euo pipefail
           HAS_REVIEW=false
+          HEAD_SHA=''
+          # unknown until both the review list and the head SHA are readable
+          STANDING=unknown
           if BOT_LOGIN="$(gh api user --jq '.login')" &&
              REVIEWS="$(
                gh api "repos/$GITHUB_REPOSITORY/pulls/$NUMBER/reviews" \
@@ -608,6 +611,26 @@ jobs:
               echo "::warning::Failed to inspect triage reviews; posting a summary comment."
               HAS_REVIEW=false
             fi
+            # Adding no review is benign only when the bot's OWN verdict already
+            # stands on the current head. Pin the lookup to login, state, AND
+            # commit: another account's approval is a different vote (main needs
+            # two), and `dismiss_stale_reviews` voids the bot's own on every
+            # push. Observed: the agent read a maintainer's approval on the head
+            # commit as its own, skipped approving, and reported success — the
+            # PR sat at 1 of 2 approvals with nothing in the log marked wrong.
+            if HEAD_SHA="$(
+                 gh api "repos/$GITHUB_REPOSITORY/pulls/$NUMBER" --jq '.head.sha'
+               )" && [ -n "$HEAD_SHA" ]; then
+              STANDING="$(
+                printf '%s' "$REVIEWS" |
+                  jq -rs \
+                    --arg bot "$BOT_LOGIN" \
+                    --arg sha "$HEAD_SHA" \
+                    '[.[][] | select(.user.login == $bot and .commit_id == $sha)
+                            | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED")]
+                     | if length > 0 then "own" else "none" end'
+              )" || STANDING=unknown
+            fi
           else
             echo "::warning::Failed to fetch triage reviews; posting a summary comment."
           fi
@@ -615,9 +638,22 @@ jobs:
             echo "Triage re-run posted a review; no summary comment needed."
             exit 0
           fi
-          printf -v BODY '%s\n\n%s\n\n%s' \
+          case "$STANDING" in
+            own)
+              NOTE="The bot already has a review of its own on \`$HEAD_SHA\`, which still stands."
+              ;;
+            none)
+              NOTE="⚠️ The bot has **no review of its own** on \`$HEAD_SHA\`. If this re-run was meant to approve, it did not — an approval left by another account is a separate vote and does not count as the bot's own."
+              echo "::warning title=Triage re-run left no bot review::The bot has no APPROVED or CHANGES_REQUESTED review on $HEAD_SHA and this re-run added none."
+              ;;
+            *)
+              NOTE="The bot's review state on the head commit could not be read."
+              ;;
+          esac
+          printf -v BODY '%s\n\n%s\n\n%s\n\n%s' \
             '<!-- qwen-triage stage=rerun-summary -->' \
             'Triage re-run completed without a new review.' \
+            "$NOTE" \
             "The stage comments above were updated with the latest result. [View workflow run]($RUN_URL)."
           gh api "repos/$GITHUB_REPOSITORY/issues/$NUMBER/comments" \
             -f body="$BODY" >/dev/null

--- a/.qwen/skills/triage/references/pr-workflow.md
+++ b/.qwen/skills/triage/references/pr-workflow.md
@@ -47,9 +47,12 @@ exists — if it does, skip re-submitting (the existing review already gates the
 PR). Only update issue comments, not PR reviews.
 
 ```bash
-# Check for existing terminal-exit review before re-submitting
-EXISTING=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
-  --jq '[.[] | select(.user.login=="qwen-code-ci-bot" and .state=="CHANGES_REQUESTED")] | length')
+# Check for existing terminal-exit review before re-submitting. Paginate: a
+# heavily-reviewed PR is exactly where re-runs happen, and an unpaginated read
+# sees only the first page — missing the gating review and duplicating it.
+EXISTING=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --method GET --paginate -F per_page=100 |
+  jq -s --arg bot "$BOT_LOGIN" \
+    '[.[][] | select(.user.login == $bot and .state == "CHANGES_REQUESTED")] | length')
 # Only submit if no existing terminal review
 if [ "$EXISTING" -eq 0 ]; then gh pr review ... ; fi
 ```
@@ -80,6 +83,25 @@ Every staged comment (Stage 1 gate-pass, Stage 2, Stage 3) ends with the signatu
 gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
   -f commit_id="$HEAD_SHA" -f event=APPROVE -f body='LGTM, looks ready to ship. ✅'
 ```
+
+**Approve once per commit — and only your OWN approval counts as already done.** Re-running triage three times must not stack three approvals, so check before posting. But "already approved" means **this bot's** `APPROVED` review on **this exact** `HEAD_SHA`, and nothing else:
+
+- **Another account's approval is not yours.** `main` requires two approving reviews, so a maintainer's approval is a *different* vote — the whole reason the bot's is still needed. Never read it as "already approved".
+- **A `DISMISSED` review is not an approval.** Branch protection runs with `dismiss_stale_reviews: true`, so every push dismisses the bot's prior approval. That is precisely when a fresh one is required.
+- **An approval on an earlier commit does not carry over**, for the same reason.
+
+Decide it with the query, not by scanning the review list — the failure mode is silent, and the run still reports ✅:
+
+```bash
+# Does the bot's OWN approval already stand on the commit under review?
+BOT_LOGIN=$(gh api user --jq '.login')   # re-resolve if this is a fresh shell
+MINE=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --method GET --paginate -F per_page=100 |
+  jq -s --arg bot "$BOT_LOGIN" --arg sha "$HEAD_SHA" \
+    '[.[][] | select(.user.login == $bot and .state == "APPROVED" and .commit_id == $sha)] | length')
+if [ "$MINE" -eq 0 ]; then gh api ... -f event=APPROVE ... ; fi
+```
+
+This rule exists because a maintainer approved a PR three minutes before re-triggering `/triage`; the run read that human approval as "existing approval from prior run still valid, head SHA unchanged", skipped its own approve, and reported ✅ Approved (5/5) — leaving the PR at 1 of 2 required approvals with nothing in the run log marked wrong.
 
 Only approve when you're genuinely confident.
 

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -198,7 +198,12 @@ describe('qwen-triage tmux workflow', () => {
     expect(notifyStep).toContain('.user.login == $bot');
     expect(notifyStep).toContain('.submitted_at != null');
     expect(notifyStep).toContain('.submitted_at >= $since');
-    expect(notifyStep).not.toContain('.state == "APPROVED"');
+    // "Did this re-run post anything?" must stay state-agnostic: a re-posted
+    // CHANGES_REQUESTED counts as a review just as much as an approval. The
+    // separate head-commit probe below is the one that filters on state.
+    const sinceQuery = notifyStep.match(/any\(\.\[\]\[\];[^\n]*\$since\)/)?.[0];
+    expect(sinceQuery).toBeTruthy();
+    expect(sinceQuery).not.toContain('.state');
     expect(notifyStep).toContain('HAS_REVIEW=false');
     expect(notifyStep).toContain(
       'gh api "repos/$GITHUB_REPOSITORY/issues/$NUMBER/comments"',
@@ -392,4 +397,151 @@ describe('qwen-triage tmux workflow', () => {
     expect(section).not.toContain('contains($m)');
     expect(section).toContain('re-resolve immediately before EACH patch');
   });
+
+  it('scopes the approve-skip check to the bot own approval on the reviewed commit', () => {
+    // A maintainer approved a PR three minutes before re-triggering /triage.
+    // The agent read that human approval as "existing approval from prior run
+    // still valid", skipped its own approve, and reported 5/5 Approved — the
+    // PR sat at 1 of the 2 required approvals with nothing marked wrong. The
+    // skip is worth keeping (three re-runs must not stack three approvals),
+    // but all three filters are load-bearing: login (another account's vote is
+    // not the bot's), state (a DISMISSED review is not an approval), and
+    // commit (dismiss_stale_reviews voids the bot's own on every push).
+    const section = prSkill.slice(
+      prSkill.indexOf('**Approve once per commit'),
+      prSkill.indexOf("Only approve when you're genuinely confident"),
+    );
+    expect(section).toContain('.user.login == $bot');
+    expect(section).toContain('.state == "APPROVED"');
+    expect(section).toContain('.commit_id == $sha');
+    expect(section).toContain('--paginate');
+    expect(section).toContain('DISMISSED');
+
+    // The terminal-gate probe shares the same failure mode: an unpaginated
+    // read sees only the first 30 reviews, and re-runs land on exactly the
+    // heavily-reviewed PRs where the gating review sits on a later page.
+    const terminalGate = prSkill.slice(
+      prSkill.indexOf('Never create duplicates'),
+      prSkill.indexOf('**Signature & footer:**'),
+    );
+    expect(terminalGate).toContain('--paginate');
+    expect(terminalGate).toContain('.state == "CHANGES_REQUESTED"');
+    expect(terminalGate).not.toContain("--jq '[.[] | select");
+  });
+
+  it.skipIf(spawnSync('jq', ['--version']).status !== 0)(
+    'warns when a triage re-run leaves the bot with no review on the head commit',
+    () => {
+      const notifyStep = step('Notify silent triage re-run');
+      const body = notifyStep.match(/run: \|-\n([\s\S]*)$/)?.[1];
+      expect(body).toBeTruthy();
+      const script = body.replace(/^ {10}/gm, '');
+
+      const REVIEWS = {
+        // The observed case: the bot's approval was dismissed by a push, its
+        // only review on the head commit is a /review downgrade to COMMENTED,
+        // and the sole APPROVED on that commit belongs to a maintainer.
+        humanOnly: [
+          { user: { login: 'bot' }, state: 'DISMISSED', commit_id: 'old' },
+          { user: { login: 'bot' }, state: 'COMMENTED', commit_id: 'head' },
+          {
+            user: { login: 'human' },
+            state: 'APPROVED',
+            submitted_at: '2026-01-01T00:00:00Z',
+            commit_id: 'head',
+          },
+        ],
+        ownApproval: [
+          { user: { login: 'bot' }, state: 'APPROVED', commit_id: 'head' },
+          { user: { login: 'human' }, state: 'APPROVED', commit_id: 'head' },
+        ],
+        postedNow: [
+          {
+            user: { login: 'bot' },
+            state: 'CHANGES_REQUESTED',
+            submitted_at: '2030-01-01T00:00:00Z',
+            commit_id: 'head',
+          },
+        ],
+      };
+
+      const run = (reviews, head) => {
+        const dir = mkdtempSync(join(tmpdir(), 'triage-notify-'));
+        try {
+          const bin = join(dir, 'bin');
+          mkdirSync(bin, { recursive: true });
+          writeFileSync(join(dir, 'reviews.json'), JSON.stringify(reviews));
+          // Stand-in for `gh`: serves the review list and head SHA, and
+          // captures the comment body the step would have posted.
+          writeFileSync(
+            join(bin, 'gh'),
+            [
+              '#!/usr/bin/env bash',
+              'case "$*" in',
+              `  "api user --jq .login") echo bot ;;`,
+              `  *"/pulls/1/reviews"*) cat "${join(dir, 'reviews.json')}" ;;`,
+              `  *"/pulls/1 --jq .head.sha") [ -n "$FAKE_HEAD" ] && echo "$FAKE_HEAD" || exit 1 ;;`,
+              `  *"/issues/1/comments"*)`,
+              `    for a in "$@"; do case "$a" in body=*) printf '%s' "\${a#body=}" > "${join(dir, 'comment.txt')}" ;; esac; done`,
+              `    echo '{}' ;;`,
+              '  *) echo "unexpected gh call: $*" >&2; exit 1 ;;',
+              'esac',
+            ].join('\n'),
+            { mode: 0o755 },
+          );
+          const proc = spawnSync('bash', ['-c', script], {
+            env: {
+              ...process.env,
+              PATH: `${bin}:${process.env.PATH}`,
+              GITHUB_REPOSITORY: 'QwenLM/qwen-code',
+              NUMBER: '1',
+              TRIGGERED_AT: '2026-01-02T00:00:00Z',
+              RUN_URL: 'https://example.invalid/run',
+              FAKE_HEAD: head,
+            },
+            encoding: 'utf8',
+          });
+          let comment = '';
+          try {
+            comment = readFileSync(join(dir, 'comment.txt'), 'utf8');
+          } catch {
+            comment = '';
+          }
+          return {
+            status: proc.status,
+            log: `${proc.stdout}${proc.stderr}`,
+            comment,
+          };
+        } finally {
+          rmSync(dir, { recursive: true, force: true });
+        }
+      };
+
+      // The silent skip must surface as a warning AND in the posted comment.
+      const humanOnly = run(REVIEWS.humanOnly, 'head');
+      expect(humanOnly.status).toBe(0);
+      expect(humanOnly.log).toContain('Triage re-run left no bot review');
+      expect(humanOnly.comment).toContain('no review of its own');
+      expect(humanOnly.comment).toContain('does not count as the bot');
+
+      // The bot's own approval standing on the head commit is the benign case.
+      const ownApproval = run(REVIEWS.ownApproval, 'head');
+      expect(ownApproval.status).toBe(0);
+      expect(ownApproval.log).not.toContain('Triage re-run left no bot review');
+      expect(ownApproval.comment).toContain('review of its own');
+      expect(ownApproval.comment).toContain('still stands');
+
+      // A review posted by this very re-run short-circuits before commenting.
+      const postedNow = run(REVIEWS.postedNow, 'head');
+      expect(postedNow.status).toBe(0);
+      expect(postedNow.log).toContain('no summary comment needed');
+      expect(postedNow.comment).toBe('');
+
+      // An unreadable head SHA must not masquerade as either verdict.
+      const noHead = run(REVIEWS.humanOnly, '');
+      expect(noHead.status).toBe(0);
+      expect(noHead.log).not.toContain('Triage re-run left no bot review');
+      expect(noHead.comment).toContain('could not be read');
+    },
+  );
 });


### PR DESCRIPTION
## What this PR does

Makes the triage agent's "this PR is already approved, nothing to do" check mean what it says: the bot's **own** `APPROVED` review, pinned to the **exact commit under review**. Another account's approval, a dismissed review, and an approval on an earlier commit no longer satisfy it. The skip itself stays — three re-runs still must not stack three approvals.

Three changes:

1. **`.qwen/skills/triage/references/pr-workflow.md`** — the approval section now states the check explicitly and gives the query, instead of leaving the agent to infer one from the neighbouring `CHANGES_REQUESTED` rule.
2. **`.github/workflows/qwen-triage.yml`** — the "Notify silent triage re-run" step now reports whether the bot has a review of its own on the head commit, and emits a workflow warning when it does not. It already knew no review had been added; it just phrased that as a normal ending.
3. **`.qwen/skills/triage/references/pr-workflow.md`** — the `CHANGES_REQUESTED` probe gets `--paginate`. An unpaginated `gh api` returns the first page only, and re-runs happen on exactly the heavily-reviewed PRs where the gating review has scrolled past it.

## Why it's needed

On [#7620](https://github.com/QwenLM/qwen-code/pull/7620), a maintainer approved the PR at 00:47:02 and re-triggered `@qwen-code /triage` at 00:50:36. The run ([30181861786](https://github.com/QwenLM/qwen-code/actions/runs/30181861786)) reviewed the PR, scored it 5/5, updated all three stage comments — and then returned:

> **Verdict:** ✅ Approved (5/5) — existing approval from prior run still valid, head SHA unchanged

It never called the approve API. The approval it read was the maintainer's, on the same head commit. The bot's own state on that commit was a `/review` downgrade to `COMMENTED`, and its earlier approval had been dismissed by a push (`dismiss_stale_reviews: true`). `main` requires two approving reviews, so the PR sat at 1 of 2 with the run reporting success and nothing in the log marked wrong.

The skill documented an "already exists, skip re-submitting" rule for `CHANGES_REQUESTED` only, and that snippet correctly filters on the bot's login. Nothing covered approvals, so the rule was generalized to them with the author filter dropped along the way. This is not a one-off: approving first and then asking triage for the second vote is the normal maintainer flow, so any re-run in that order reproduces it.

## Reviewer Test Plan

### How to verify

The `Notify silent triage re-run` step's script is executed directly by the test suite against a stubbed `gh`, so the four branches are checked as behaviour rather than as string matches:

```
npm run test:scripts -- qwen-triage-workflow
```

| Fixture | Expected |
| --- | --- |
| Bot review dismissed + `COMMENTED` at head, human `APPROVED` at head (the observed case) | `::warning title=Triage re-run left no bot review`, comment says "no review of its own" |
| Bot's own `APPROVED` at head | no warning, comment says the existing review "still stands" |
| Bot review submitted after the trigger | early exit, no comment posted |
| Head SHA unreadable | neither verdict claimed, comment says "could not be read" |

Negative control: reverting both source files and re-running the suite fails exactly the two new tests (`scopes the approve-skip check…`, `warns when a triage re-run leaves…`) and leaves the other 15 green.

The `.state == "APPROVED"` assertion that previously guarded the whole step is now scoped to the `$since` sub-query, which must stay state-agnostic — a re-posted `CHANGES_REQUESTED` counts as "this re-run added a review" just as much as an approval does. The new head-commit probe is the one that filters on state.

### Evidence (Before & After)

N/A — CI automation, nothing user-visible in the app. The behaviour change is the workflow warning and comment text covered by the table above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 triage agent 的「这个 PR 已经批过了，无需重复」判定名副其实：只有 **bot 自己的** `APPROVED` review、且 **pin 在当前被审查的那个 commit 上**，才算已批准。其他账号的 approve、已被 dismiss 的 review、以及更早 commit 上的 approve，都不再满足该条件。跳过逻辑本身保留——连跑三次 re-run 仍然不该叠出三条 approve。

三处改动：

1. **`.qwen/skills/triage/references/pr-workflow.md`** —— approval 一节现在显式写明判定条件并给出查询语句，而不是让 agent 从相邻的 `CHANGES_REQUESTED` 规则去推断。
2. **`.github/workflows/qwen-triage.yml`** —— "Notify silent triage re-run" 步骤现在会报告 bot 在 head commit 上是否有自己的 review，没有时发出 workflow warning。它原本就已经检测到「本次没有新增 review」，只是措辞读起来像正常结束。
3. **`.qwen/skills/triage/references/pr-workflow.md`** —— `CHANGES_REQUESTED` 探测补上 `--paginate`。未分页的 `gh api` 只返回第一页，而 re-run 恰恰发生在 review 数量多、gating review 已经翻页的 PR 上。

## 为什么需要

在 [#7620](https://github.com/QwenLM/qwen-code/pull/7620) 上，maintainer 于 00:47:02 approve，并在 00:50:36 重新触发 `@qwen-code /triage`。该次运行（[30181861786](https://github.com/QwenLM/qwen-code/actions/runs/30181861786)）完整审查了 PR、给出 5/5、更新了三条 stage 评论，然后返回：

> **Verdict:** ✅ Approved (5/5) — existing approval from prior run still valid, head SHA unchanged

但它从未调用 approve API。它读到的那条 approve 是 maintainer 的，位于同一个 head commit 上。bot 自己在该 commit 上的状态是一条被 `/review` 降级成 `COMMENTED` 的 review，而它更早的 approve 已因 push 被自动 dismiss（`dismiss_stale_reviews: true`）。`main` 要求两条 approving review，于是 PR 停在 1/2，运行状态却是成功，日志里没有任何地方标记异常。

skill 中只为 `CHANGES_REQUESTED` 定义了「已存在则跳过重复提交」的规则，且那段代码正确地按 bot login 过滤。approve 没有对应规则，于是该规则被外推到 approve 上，外推过程中把作者过滤条件丢掉了。这不是偶发：先手动 approve、再让 triage 补第二票，是 maintainer 的常规操作顺序，因此任何按此顺序进行的 re-run 都会复现。

## 验证方式

测试直接执行 `Notify silent triage re-run` 步骤的脚本（`gh` 用桩替代），因此四个分支是按行为验证的，而非字符串匹配：

```
npm run test:scripts -- qwen-triage-workflow
```

| 用例 | 预期 |
| --- | --- |
| bot 的 review 已 dismiss + head 上为 `COMMENTED`，head 上有人类 `APPROVED`（实际发生的情况） | 输出 `::warning title=Triage re-run left no bot review`，评论提示「no review of its own」 |
| bot 自己的 `APPROVED` 在 head 上 | 无 warning，评论说明既有 review「still stands」 |
| 本次触发之后 bot 提交了 review | 提前退出，不发评论 |
| head SHA 读取失败 | 不声称任何一种结论，评论说明「could not be read」 |

反向验证：还原两个源文件后重跑测试，恰好只有两条新增测试失败（`scopes the approve-skip check…`、`warns when a triage re-run leaves…`），其余 15 条保持通过。

原本作用于整个步骤的 `.state == "APPROVED"` 断言，现在收窄到 `$since` 子查询上——该子查询必须与 state 无关，因为重新提交的 `CHANGES_REQUESTED` 同样算「本次 re-run 新增了 review」。按 state 过滤的是新增的 head-commit 探测。

## 证据（Before & After）

不适用 —— 属于 CI 自动化，应用中没有用户可见变化。行为变化即上表覆盖的 workflow warning 与评论文案。

</details>
