### PR TITLE
ci(autofix): show a live-progress status comment while a round runs

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2955,6 +2955,7 @@ jobs:
       # never announces a round it will not run. Best-effort: a status post that
       # fails warns and continues — it must never cost the round.
       - name: 'Post autofix status comment'
+        id: 'post_status'
         if: |-
           ${{ steps.prepare.outputs.stale != 'true' && needs.route.outputs.dry_run != 'true' }}
         env:
@@ -2978,9 +2979,15 @@ jobs:
               -f body="${BODY}" > /dev/null ||
               echo "::warning::Failed to update the autofix status comment on PR #${PR}; continuing."
           else
-            gh api "repos/${REPO}/issues/${PR}/comments" -f body="${BODY}" > /dev/null ||
-              echo "::warning::Failed to post the autofix status comment on PR #${PR}; continuing."
+            STATUS_ID="$(gh api "repos/${REPO}/issues/${PR}/comments" \
+              -f body="${BODY}" --jq '.id')" ||
+              {
+                STATUS_ID=''
+                echo "::warning::Failed to post the autofix status comment on PR #${PR}; continuing."
+              }
           fi
+          # Hand the id to the finalize step so it does not repeat this scan.
+          echo "comment_id=${STATUS_ID}" >> "${GITHUB_OUTPUT}"
 
       - name: 'Triage and address'
         id: 'address'
@@ -3726,16 +3733,17 @@ jobs:
           EFFECTIVE_ROUND: '${{ steps.prepare.outputs.effective_round }}'
           OUTCOME: '${{ steps.verify.outputs.outcome }}'
           RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+          # The id the announcement wrote. Empty means this round never
+          # announced (its step was skipped, or the post itself failed) — then
+          # no comment claims this round is working, so there is nothing to
+          # flip and no reason to scan for one. A previous round's comment is
+          # already terminal, and the next round's announcement re-PATCHes it.
+          STATUS_ID: '${{ steps.post_status.outputs.comment_id }}'
         run: |-
           set -uo pipefail
           MARKER='<!-- autofix-status -->'
-          STATUS_ID="$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate |
-            jq -rs --arg m "${MARKER}" --arg ab "${AUTOFIX_BOT}" \
-              '[ .[][] | select((.user.login // "") == $ab)
-                 | select((.body // "") | contains($m)) ] | last | .id // empty')" ||
-            STATUS_ID=''
           if [[ -z "${STATUS_ID}" ]]; then
-            echo "No autofix status comment on PR #${PR}; nothing to finalize."
+            echo "This round posted no status comment on PR #${PR}; nothing to finalize."
             exit 0
           fi
           ROUND_DISPLAY="${EFFECTIVE_ROUND:-${ROUND}}"

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2944,6 +2944,44 @@ jobs:
           echo '--- feedback.md ---'
           cat "${WORKDIR}/feedback.md"
 
+      # The agent below runs for up to 80 minutes and the verification gate adds
+      # more, but nothing reaches the PR thread until "Push and report" at the
+      # very end: a maintainer who just engaged takeover sees silence and cannot
+      # tell a working round from a stuck one. The agent's output already
+      # streams live to the Actions log, so publish that link up front.
+      # Upserted by marker so one status comment per PR is EDITED each round
+      # (edits notify nobody) rather than stacking a new comment against a
+      # 100-round cap. Runs after prepare so a revalidated-away stale duplicate
+      # never announces a round it will not run. Best-effort: a status post that
+      # fails warns and continues — it must never cost the round.
+      - name: 'Post autofix status comment'
+        if: |-
+          ${{ steps.prepare.outputs.stale != 'true' && needs.route.outputs.dry_run != 'true' }}
+        env:
+          GITHUB_TOKEN: '${{ secrets.CI_DEV_BOT_PAT }}'
+          EFFECTIVE_ROUND: '${{ steps.prepare.outputs.effective_round }}'
+          RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+        run: |-
+          set -uo pipefail
+          MARKER='<!-- autofix-status -->'
+          ROUND_DISPLAY="${EFFECTIVE_ROUND:-${ROUND}}"
+          BODY="$(printf '%s\n\n🔄 **AutoFix is working on this PR** — round %s/%s. [Watch live progress](%s); this round posts its report here when it finishes.\n\n<details>\n<summary>中文说明</summary>\n\n🔄 **AutoFix 正在处理此 PR** —— 第 %s/%s 轮。[查看实时进度](%s)；本轮结束后会在此发布报告。\n\n</details>' \
+            "${MARKER}" "${ROUND_DISPLAY}" "${MAX_ROUNDS}" "${RUN_URL}" \
+            "${ROUND_DISPLAY}" "${MAX_ROUNDS}" "${RUN_URL}")"
+          STATUS_ID="$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate |
+            jq -rs --arg m "${MARKER}" --arg ab "${AUTOFIX_BOT}" \
+              '[ .[][] | select((.user.login // "") == $ab)
+                 | select((.body // "") | contains($m)) ] | last | .id // empty')" ||
+            STATUS_ID=''
+          if [[ -n "${STATUS_ID}" ]]; then
+            gh api --method PATCH "repos/${REPO}/issues/comments/${STATUS_ID}" \
+              -f body="${BODY}" > /dev/null ||
+              echo "::warning::Failed to update the autofix status comment on PR #${PR}; continuing."
+          else
+            gh api "repos/${REPO}/issues/${PR}/comments" -f body="${BODY}" > /dev/null ||
+              echo "::warning::Failed to post the autofix status comment on PR #${PR}; continuing."
+          fi
+
       - name: 'Triage and address'
         id: 'address'
         # Skipped entirely for a stale duplicate target (see the live-watermark
@@ -3667,3 +3705,51 @@ jobs:
             } > "${WORKDIR}/report.md"
             gh pr comment "${PR}" --repo "${REPO}" --body-file "${WORKDIR}/report.md" || echo "::warning::Failed to post handoff comment on PR #${PR}"
           fi
+
+      # Flip the status comment out of "working" so a finished round never
+      # leaves a live-looking line behind. PATCH-only on purpose: a round that
+      # never posted a status (stale duplicate, dry run) must not gain one here.
+      # The verdict stays in the round report this job already posts; this only
+      # records that the round ended, and keeps the run link reachable.
+      # Gated on 'stale' for the same reason the announcement is: the per-PR
+      # concurrency group serialises duplicate address jobs, so the discarded
+      # one runs AFTER the real round already finalised. Ungated, it would
+      # overwrite that round's "finished" with its own "ended without
+      # publishing" and report a successful round as a failed one. An empty
+      # 'stale' (prepare itself crashed) still finalises — that IS this job's
+      # round, and it is exactly the case that must not stay "working".
+      - name: 'Finalize autofix status comment'
+        if: |-
+          ${{ always() && steps.prepare.outputs.stale != 'true' && needs.route.outputs.dry_run != 'true' }}
+        env:
+          GITHUB_TOKEN: '${{ secrets.CI_DEV_BOT_PAT }}'
+          EFFECTIVE_ROUND: '${{ steps.prepare.outputs.effective_round }}'
+          OUTCOME: '${{ steps.verify.outputs.outcome }}'
+          RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+        run: |-
+          set -uo pipefail
+          MARKER='<!-- autofix-status -->'
+          STATUS_ID="$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate |
+            jq -rs --arg m "${MARKER}" --arg ab "${AUTOFIX_BOT}" \
+              '[ .[][] | select((.user.login // "") == $ab)
+                 | select((.body // "") | contains($m)) ] | last | .id // empty')" ||
+            STATUS_ID=''
+          if [[ -z "${STATUS_ID}" ]]; then
+            echo "No autofix status comment on PR #${PR}; nothing to finalize."
+            exit 0
+          fi
+          ROUND_DISPLAY="${EFFECTIVE_ROUND:-${ROUND}}"
+          # 'fixed'/'noop' are the two outcomes that published a round report;
+          # anything else means the round stopped before publishing one.
+          if [[ "${OUTCOME:-}" == 'fixed' || "${OUTCOME:-}" == 'noop' ]]; then
+            EN="$(printf '✅ **AutoFix round %s finished** — [view run](%s). See this round'"'"'s report below.' "${ROUND_DISPLAY}" "${RUN_URL}")"
+            ZH="$(printf '✅ **AutoFix 第 %s 轮已完成** —— [查看运行](%s)。本轮报告见下方。' "${ROUND_DISPLAY}" "${RUN_URL}")"
+          else
+            EN="$(printf '⚠️ **AutoFix round %s ended without publishing a report** — [view run](%s).' "${ROUND_DISPLAY}" "${RUN_URL}")"
+            ZH="$(printf '⚠️ **AutoFix 第 %s 轮结束但未发布报告** —— [查看运行](%s)。' "${ROUND_DISPLAY}" "${RUN_URL}")"
+          fi
+          BODY="$(printf '%s\n\n%s\n\n<details>\n<summary>中文说明</summary>\n\n%s\n\n</details>' \
+            "${MARKER}" "${EN}" "${ZH}")"
+          gh api --method PATCH "repos/${REPO}/issues/comments/${STATUS_ID}" \
+            -f body="${BODY}" > /dev/null ||
+            echo "::warning::Failed to finalize the autofix status comment on PR #${PR}; continuing."

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -4868,6 +4868,18 @@ describe('qwen-autofix workflow', () => {
     expect(finalizeStatusCommentStep).not.toContain(
       'gh api "repos/${REPO}/issues/${PR}/comments" -f body=',
     );
+    // The announcement hands over the id it just wrote (both branches), so the
+    // finalize never repeats the paginated comment scan — one scan per round,
+    // not two, on a PR that can accumulate hundreds of comments over 100 rounds.
+    expect(postStatusCommentStep).toContain("id: 'post_status'");
+    expect(postStatusCommentStep).toContain(
+      'echo "comment_id=${STATUS_ID}" >> "${GITHUB_OUTPUT}"',
+    );
+    expect(postStatusCommentStep).toContain("--jq '.id'");
+    expect(finalizeStatusCommentStep).toContain(
+      "STATUS_ID: '${{ steps.post_status.outputs.comment_id }}'",
+    );
+    expect(finalizeStatusCommentStep).not.toContain('--paginate');
     // Tells a round that published a report from one that died before it.
     expect(finalizeStatusCommentStep).toContain("== 'fixed'");
     expect(finalizeStatusCommentStep).toContain(

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -4845,6 +4845,8 @@ describe('qwen-autofix workflow', () => {
     // Best-effort — a failed status post warns and continues, never costs a round.
     expect(postStatusCommentStep).toContain('set -uo pipefail');
     expect(postStatusCommentStep).toContain('continuing.');
+    expect(finalizeStatusCommentStep).toContain('set -uo pipefail');
+    expect(finalizeStatusCommentStep).toContain('continuing.');
     // Repository convention for anything posted verbatim as a PR comment.
     expect(postStatusCommentStep).toContain('<summary>中文说明</summary>');
 
@@ -4858,6 +4860,9 @@ describe('qwen-autofix workflow', () => {
     // publishing" — reporting a successful round as a failed one.
     expect(finalizeStatusCommentStep).toContain(
       "steps.prepare.outputs.stale != 'true'",
+    );
+    expect(finalizeStatusCommentStep).toContain(
+      "needs.route.outputs.dry_run != 'true'",
     );
     expect(finalizeStatusCommentStep).toContain('<!-- autofix-status -->');
     expect(finalizeStatusCommentStep).toContain('--method PATCH');

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -102,7 +102,15 @@ const triageAndAddressStep =
   )?.[0] ?? '';
 const prepareBranchAndFeedbackStep =
   workflow.match(
-    /- name: 'Prepare branch and feedback'[\s\S]*?(?=\n[ ]{6}- name: 'Triage and address')/,
+    /- name: 'Prepare branch and feedback'[\s\S]*?(?=\n[ ]{6}- name: 'Post autofix status comment')/,
+  )?.[0] ?? '';
+const postStatusCommentStep =
+  workflow.match(
+    /- name: 'Post autofix status comment'[\s\S]*?(?=\n[ ]{6}- name: 'Triage and address')/,
+  )?.[0] ?? '';
+const finalizeStatusCommentStep =
+  workflow.match(
+    /- name: 'Finalize autofix status comment'[\s\S]*?(?=\n[ ]{6}- name: '|$)/,
   )?.[0] ?? '';
 const resetAutofixWorkspaceSteps =
   workflow.match(
@@ -293,9 +301,12 @@ describe('qwen-autofix workflow', () => {
     // discards itself — no agent run, no marker, no comment.
     expect(prepareBranchAndFeedbackStep).toContain('LIVE_EVAL_WM');
     expect(prepareBranchAndFeedbackStep).toContain('stale duplicate target');
+    // Four gates, and both status-comment steps are among them: a discarded
+    // duplicate must neither announce a round it will never run nor rewrite
+    // the status the real round already finalised.
     expect(
       workflow.split("steps.prepare.outputs.stale != 'true'").length - 1,
-    ).toBe(2);
+    ).toBe(4);
     expect(reviewScanJob).toContain(
       'capture("^review-address \\\\((?<pr>[0-9]+),")',
     );
@@ -4807,6 +4818,61 @@ describe('qwen-autofix workflow', () => {
         ),
       ),
     ).toBe(0);
+  });
+
+  it('announces a working round up front and closes the same status comment', () => {
+    // The whole point: the live run link reaches the thread BEFORE the
+    // 80-minute agent step, not after it. Without this the PR is silent from
+    // takeover until "Push and report", so a working round and a stuck one
+    // look identical.
+    expect(postStatusCommentStep.length).toBeGreaterThan(0);
+    expect(postStatusCommentStep).toContain('<!-- autofix-status -->');
+    expect(postStatusCommentStep).toContain(
+      'actions/runs/${{ github.run_id }}',
+    );
+    expect(postStatusCommentStep).toContain('Watch live progress');
+    // Announced only for a round that will really run, and never on a dry run.
+    expect(postStatusCommentStep).toContain(
+      "steps.prepare.outputs.stale != 'true'",
+    );
+    expect(postStatusCommentStep).toContain(
+      "needs.route.outputs.dry_run != 'true'",
+    );
+    // One comment per PR, EDITED each round: a new comment per round would
+    // stack up to MAX_ROUNDS of them on a managed PR.
+    expect(postStatusCommentStep).toContain('--method PATCH');
+    expect(postStatusCommentStep).toContain('contains($m)');
+    // Best-effort — a failed status post warns and continues, never costs a round.
+    expect(postStatusCommentStep).toContain('set -uo pipefail');
+    expect(postStatusCommentStep).toContain('continuing.');
+    // Repository convention for anything posted verbatim as a PR comment.
+    expect(postStatusCommentStep).toContain('<summary>中文说明</summary>');
+
+    // Runs on every ending (including a crashed agent) so no finished round
+    // leaves a live-looking "working" line behind.
+    expect(finalizeStatusCommentStep.length).toBeGreaterThan(0);
+    expect(finalizeStatusCommentStep).toContain('always()');
+    // ...but NOT for a discarded duplicate. The per-PR concurrency group runs
+    // it after the real round already finalised, so an ungated finalize would
+    // overwrite that round's "finished" with its own "ended without
+    // publishing" — reporting a successful round as a failed one.
+    expect(finalizeStatusCommentStep).toContain(
+      "steps.prepare.outputs.stale != 'true'",
+    );
+    expect(finalizeStatusCommentStep).toContain('<!-- autofix-status -->');
+    expect(finalizeStatusCommentStep).toContain('--method PATCH');
+    expect(finalizeStatusCommentStep).toContain('<summary>中文说明</summary>');
+    // PATCH-ONLY: a round that never announced (stale duplicate, dry run) must
+    // not gain a status comment at the end.
+    expect(finalizeStatusCommentStep).toContain('nothing to finalize');
+    expect(finalizeStatusCommentStep).not.toContain(
+      'gh api "repos/${REPO}/issues/${PR}/comments" -f body=',
+    );
+    // Tells a round that published a report from one that died before it.
+    expect(finalizeStatusCommentStep).toContain("== 'fixed'");
+    expect(finalizeStatusCommentStep).toContain(
+      'ended without publishing a report',
+    );
   });
 
   it('renders the whole managed fleet into the run summary', () => {


### PR DESCRIPTION
## What this PR does

Makes an in-flight AutoFix round **visible in the PR thread**. When a round starts, it posts a status comment carrying a link to the **live Actions run**; when the round ends, it flips that same comment to a terminal state.

## Why

Takeover engages — and then the thread goes quiet. `review-address` runs the agent for up to **80 minutes** (`timeout-minutes: 80`) plus a verification gate (build/typecheck/lint/tests), but **nothing reaches the PR until `Push and report` at the very end**. The `takeover-ack` comment says "engaged" and carries no run link, and every `autofix-*` marker (`eval`, `rearm`, `redcheck`) is end-of-round bookkeeping.

Measured on **#7731**: takeover engaged `01:55`, `review-address` started `01:55:59`, and at `02:39` it was still running — **43 minutes of silence**, with no way to tell a working round from a stuck one. The job cap is 120 minutes, so it can be worse.

The agent's output **already streams live to the Actions log**. Only the link was missing.

## How

Two steps in `review-address`, no agent/skill dependency:

- **`Post autofix status comment`** — after `Prepare branch and feedback`, before the agent → `<!-- autofix-status -->` `🔄 AutoFix is working on this PR — round N/M. [Watch live progress](run)`.
- **`Finalize autofix status comment`** (`always()`) — edits the **same** comment to `✅ round N finished` / `⚠️ ended without publishing a report` (from `steps.verify.outputs.outcome`), keeping the run link. The verdict itself stays in the round report this job already posts.

Three properties that are load-bearing rather than incidental:

1. **Upsert by marker** — one status comment per PR, **edited** each round. A new comment per round would stack up to `TAKEOVER_MAX_ROUNDS` (100) of them; edits also notify nobody, so a long round-trip stays quiet.
2. **Both steps gated on the stale-duplicate flag.** The per-PR concurrency group (`qwen-pr-head-write-<pr>`) serialises duplicate address jobs, so a discarded duplicate runs **after** the real round already finalised. Ungated, its finalize would overwrite that round's `✅ finished` with its own `⚠️ ended without publishing` — **reporting a successful round as a failed one**. (Found in self-audit, not by a test; a regression test now pins it.)
3. **Finalize is PATCH-only** — a round that never announced (stale duplicate, dry run) must not gain a status comment at the end.

Best-effort throughout (`set -uo pipefail` + warn-and-continue): a failed status post never costs a round.

**Deliberately not done:** a per-phase status line driven by the agent. The live Actions log is finer-grained than anything we could synthesise, needs no agent cooperation, and a mid-round agent is exactly when an agent-maintained line is least reliable.

## Reviewer Test Plan

- `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` — **103/103**, three consecutive clean runs. (This suite has known load-flakes — `eligibility recheck`, `permanent API failures terminal` — which appeared in some runs and are unrelated.)
- **Mutation-verified**, each killing exactly the intended test: removing `Watch live progress`; breaking finalize's PATCH-only exit; adding a POST fallback to finalize (proves PATCH-only is genuinely pinned, not a string coincidence); removing finalize's stale guard (kills both the new test and the `stale`-gate count assertion).
- **yamllint** clean (`quote-type: single, allow-quoted-quotes`). **prettier** clean.
- **actionlint**: `16` findings on this branch vs `16` on `main` — byte-identical rule counts, so **no new lint findings**; the reported lines are all pre-existing steps, none of them the two added here. `bash -n` clean on both run blocks.

## Risk & Scope

- Adds **one** comment per managed PR (upserted + edited in place, never one per round). That is the cost of the visibility.
- No change to routing, round accounting, the verification gate, the eval markers, or what the agent does. Both steps are additive and best-effort.
- Uses the same `CI_DEV_BOT_PAT` as the round report, so the status edit is same-identity.
- **Known limitation:** GitHub orders comments by creation time, so on a PR that runs many rounds the status comment stays where it was first posted and gets buried up-thread. It is exactly where it is needed in the case this targets (just after takeover engages). Making it always-last would mean delete-and-repost each round — a notification per round — so it is deliberately **not** done here.
- Residual gap: the announcement lands after `npm ci` + build (a few minutes), not at second zero. That is the price of announcing only rounds that will actually run.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #7654, which did the same for `/triage`; this is the takeover-loop counterpart. Motivated by the silence observed on #7731.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让**正在进行的 AutoFix 轮次在 PR 线程里可见**:轮次开始时发一条带**实时 Actions 运行**链接的状态评论,轮次结束时把**同一条**改为终态。

## 为什么

接管之后线程就安静了。`review-address` 跑 agent 最长 **80 分钟**(`timeout-minutes: 80`),外加验证门禁(build/typecheck/lint/测试),但**直到最后一步 `Push and report` 才有内容进入 PR**。`takeover-ack` 只说"已接管"且不带运行链接,而所有 `autofix-*` 标记(`eval`/`rearm`/`redcheck`)都是轮次结束后的记账。

在 **#7731** 上实测:`01:55` 接管,`review-address` `01:55:59` 启动,到 `02:39` 仍在运行 —— **静默 43 分钟**,无法区分"正在干活"与"卡住了"。job 上限是 120 分钟,还可能更久。

agent 的输出**本就实时流进 Actions 日志**,缺的只是那个链接。

## 怎么做

`review-address` 中两个步骤,不依赖 agent/skill:

- **`Post autofix status comment`** —— 在 `Prepare branch and feedback` 之后、agent 之前 → `<!-- autofix-status -->` `🔄 正在处理此 PR —— 第 N/M 轮。[查看实时进度](run)`。
- **`Finalize autofix status comment`**(`always()`)—— 把**同一条**改为 `✅ 第 N 轮已完成` / `⚠️ 结束但未发布报告`(依据 `steps.verify.outputs.outcome`),保留运行链接。裁决本身仍在本 job 已有的轮次报告里。

三个承重性质(而非可有可无):

1. **按 marker upsert** —— 每个 PR 一条状态评论,每轮**编辑**。每轮新发一条会在 100 轮上限下堆积;而编辑不发通知,长轮次也保持安静。
2. **两个步骤都 gate 了 stale 标志。** 每 PR 并发组(`qwen-pr-head-write-<pr>`)会串行化重复的 address job,因此被丢弃的那个在真实轮次**定稿之后**才运行。若不 gate,它的 finalize 会把该轮的 `✅ 已完成` 覆写成自己的 `⚠️ 未发布报告` —— **把成功的一轮报成失败**。(自审发现,非测试发现;现已有回归测试钉住。)
3. **finalize 仅 PATCH** —— 从未发过状态的轮次(重复丢弃、dry run)不应在结束时凭空多出一条。

全程尽力而为(`set -uo pipefail` + 告警后继续):状态评论失败绝不拖垮轮次。

**特意没做:**由 agent 维护的逐阶段状态行。实时 Actions 日志比我们能合成的任何文本都细,且不依赖 agent 配合;而轮次中段正是 agent 最忙、这种状态行最不可靠的时候。

## 评审验证

- `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` —— **103/103**,连续三次干净。(该 suite 有已知负载 flake:`eligibility recheck`、`permanent API failures terminal`,与本 PR 无关。)
- **变异验证**,每个都恰好杀死目标测试:删 `Watch live progress`;破坏 finalize 的 PATCH-only 出口;给 finalize 加 POST 兜底(证明 PATCH-only 是真被钉住,而非字符串巧合);删掉 finalize 的 stale 守卫(同时杀死新测试与 `stale` 计数断言)。
- **yamllint** 干净;**prettier** 干净。
- **actionlint**:本分支 `16` 条 vs `main` `16` 条 —— 规则计数完全一致,**无新增**;报告行全是既有步骤,不含新加的两个。两个 run 块 `bash -n` 干净。

## 风险与范围

- 每个被管理的 PR 多**一条**评论(就地 upsert + 编辑,绝非每轮一条)。这是可见性的代价。
- 不改路由、轮次计数、验证门禁、eval 标记,也不改 agent 的行为。两步均为新增且尽力而为。
- 使用与轮次报告相同的 `CI_DEV_BOT_PAT`,故状态编辑是同身份。
- **已知局限**:GitHub 按创建时间排序评论,因此在跑很多轮的 PR 上,状态评论会停留在最初位置、被埋在上游。在本 PR 针对的场景(刚接管那会儿)它正好在需要的位置。要让它永远置底就得每轮删除重发 —— 每轮多一次通知 —— 故**特意不做**。
- 残留缺口:公告落在 `npm ci` + build 之后(几分钟),而非第 0 秒。这是"只公告真正会运行的轮次"的代价。
- 破坏性变更:无。

## 关联 Issue

#7654 的跟进(那个针对 `/triage`),本 PR 是接管循环的对应件。起因是 #7731 上观察到的静默。

</details>
