### PR TITLE
fix(cli): handle escaped dollars around inline math

### DIFF
--- a/integration-tests/terminal-capture/scenarios/inline-math-escaped-dollar.ts
+++ b/integration-tests/terminal-capture/scenarios/inline-math-escaped-dollar.ts
@@ -1,0 +1,32 @@
+import type { ScenarioConfig } from '../scenario-runner.js';
+
+const prompt = String.raw`请只输出以下 7 行测试文本，不要解释，不要编号，不要使用代码块，也不要改变任何字符。尤其要原样保留所有美元符号和反斜杠：
+$x^2$ is valid math
+it costs $5 and $10
+$5-$10
+literal \$x$
+formula $x + \$5$
+literal then math: \$$x^2$
+math then literal: $x^2\$$`;
+
+export default {
+  name: 'inline-math-escaped-dollar',
+  spawn: ['node', 'dist/cli.js', '--yolo', '--model', 'qwen3.7-max-2026-06-08'],
+  terminal: {
+    title: 'qwen-code inline math',
+    cwd: '../../..',
+    cols: 120,
+    rows: 32,
+  },
+  flow: [
+    {
+      type: prompt,
+      capture: 'inline-math-escaped-dollar.png',
+    },
+    {
+      sleep: 20000,
+      capture: 'inline-math-escaped-dollar-settled.png',
+    },
+  ],
+  gif: false,
+} satisfies ScenarioConfig;

--- a/integration-tests/terminal-capture/scenarios/markdown-rendering.ts
+++ b/integration-tests/terminal-capture/scenarios/markdown-rendering.ts
@@ -8,7 +8,7 @@ const markdownPrompt = `Output a compact Markdown rendering verification sample 
 4. Inline math $x$ and $y = \\\\frac{-b \\\\pm \\\\sqrt{b^2 - 4ac}}{2a}$.
 5. One display math block using $$ fences.
 6. One checked and one unchecked task list item.
-7. Literal inline code \`$zz$\` and escaped math source \\\\$xy$.
+7. Literal inline code \`$zz$\`, escaped prose \\\\$xy$, formula $x + \\\\$5$, and the boundaries \\\\$$x^2$ and $x^2\\\\$$.
 
 Do not explain the sample.`;
 

--- a/packages/cli/src/ui/commands/copyCommand.test.ts
+++ b/packages/cli/src/ui/commands/copyCommand.test.ts
@@ -573,6 +573,31 @@ describe('copyCommand', () => {
     });
   });
 
+  it('should copy formulas containing or adjacent to escaped dollars', async () => {
+    if (!copyCommand.action) throw new Error('Command has no action');
+
+    mockGetHistoryShallow.mockReturnValue([
+      {
+        role: 'model',
+        parts: [
+          {
+            text: String.raw`literal \$x$
+formula $x + \$5$
+literal then math: \$$x^2$
+math then literal: $x^2\$$`,
+          },
+        ],
+      },
+    ]);
+    mockCopyToClipboard.mockResolvedValue(undefined);
+
+    const expected = [String.raw`x + \$5`, 'x^2', String.raw`x^2\$`];
+    for (const [offset, expression] of expected.entries()) {
+      await copyCommand.action(mockContext, `inline-latex ${offset + 1}`);
+      expect(mockCopyToClipboard).toHaveBeenLastCalledWith(expression);
+    }
+  });
+
   it('should copy a numbered inline LaTeX expression with /copy latex inline 1', async () => {
     if (!copyCommand.action) throw new Error('Command has no action');
 

--- a/packages/cli/src/ui/utils/InlineMarkdownRenderer.test.tsx
+++ b/packages/cli/src/ui/utils/InlineMarkdownRenderer.test.tsx
@@ -67,14 +67,42 @@ describe('<RenderInline />', () => {
     expect(output).not.toContain('$x$');
   });
 
-  it('preserves escaped inline math and inline code', () => {
+  it('renders escaped dollars as prose while keeping inline code verbatim', () => {
     const { lastFrame } = renderWithProviders(
-      <RenderInline text={'Literal \\$xy$ and code `$xy$`'} enableInlineMath />,
+      <RenderInline
+        text={'Literal \\$xy$ and code `$xy$ and \\$xy$`'}
+        enableInlineMath
+      />,
     );
 
     expect((lastFrame() ?? '').replace(/\n/g, '')).toContain(
-      'Literal \\$xy$ and code$xy$',
+      'Literal $xy$ and code$xy$ and \\$xy$',
     );
+  });
+
+  it('renders escaped dollars inside and next to inline math', () => {
+    const text = String.raw`$x^2$ is valid math
+it costs $5 and $10
+$5-$10
+literal \$x$
+formula $x + \$5$
+literal then math: \$$x^2$
+math then literal: $x^2\$$`;
+    const { lastFrame } = renderWithProviders(
+      <RenderInline text={text} enableInlineMath />,
+    );
+
+    const output = (lastFrame() ?? '').replace(/\n/g, '');
+    expect(output).toContain('x² is valid math');
+    expect(output).toContain('it costs $5 and $10');
+    expect(output).toContain('$5-$10');
+    expect(output).toContain('literal $x$');
+    expect(output).toContain('x + $5');
+    expect(output).toContain('literal then math:');
+    expect(output).toContain('$x²');
+    expect(output).toContain('math then literal:');
+    expect(output).toContain('x²$');
+    expect(output).not.toContain('\\$');
   });
 
   it('keeps math literal inside multi-backtick code spans', () => {
@@ -100,6 +128,15 @@ describe('<RenderInline />', () => {
     expect(getPlainTextLength('code `$xy$`', true)).toBe('code $xy$'.length);
     expect(getPlainTextLength('code ``a `$xy$` b``', true)).toBe(
       'code a `$xy$` b'.length,
+    );
+    expect(getPlainTextLength(String.raw`literal \$x$`, true)).toBe(
+      'literal $x$'.length,
+    );
+    expect(getPlainTextLength(String.raw`formula $x + \$5$`, true)).toBe(
+      'formula x + $5'.length,
+    );
+    expect(getPlainTextLength(String.raw`even \\$x$`, true)).toBe(
+      'even \\x'.length,
     );
   });
 

--- a/packages/cli/src/ui/utils/InlineMarkdownRenderer.tsx
+++ b/packages/cli/src/ui/utils/InlineMarkdownRenderer.tsx
@@ -24,7 +24,9 @@ import {
 } from './osc8.js';
 import {
   INLINE_CODE_SPAN_PATTERN_SOURCE,
-  INLINE_MATH_PATTERN_SOURCE,
+  mergeInlineMathMatches,
+  unescapeMarkdownBeforeMath,
+  unescapeMarkdownDollars,
 } from './inline-math.js';
 
 // Constants for Markdown parsing
@@ -34,15 +36,9 @@ const STRIKETHROUGH_MARKER_LENGTH = 2; // For "~~")
 const INLINE_CODE_MARKER_LENGTH = 1; // For "`"
 const UNDERLINE_TAG_START_LENGTH = 3; // For "<u>"
 const UNDERLINE_TAG_END_LENGTH = 4; // For "</u>"
-const INLINE_MATH_MARKER_LENGTH = 1; // For "$"
 const INLINE_MARKDOWN_REGEX = new RegExp(
   String.raw`(\*\*.*?\*\*|\*.*?\*|_.*?_|~~.*?~~|${MD_LINK_PATTERN}|` +
     String.raw`${INLINE_CODE_SPAN_PATTERN_SOURCE}|<u>.*?<\/u>|https?:\/\/\S+)`,
-  'g',
-);
-const INLINE_MARKDOWN_WITH_MATH_REGEX = new RegExp(
-  String.raw`(\*\*.*?\*\*|\*.*?\*|_.*?_|~~.*?~~|${MD_LINK_PATTERN}|` +
-    String.raw`${INLINE_CODE_SPAN_PATTERN_SOURCE}|${INLINE_MATH_PATTERN_SOURCE}|<u>.*?<\/u>|https?:\/\/\S+)`,
   'g',
 );
 
@@ -62,7 +58,8 @@ const RenderInlineInternal: React.FC<RenderInlineProps> = ({
   // Early return for plain text without markdown or URLs
   if (
     !/[*_~`<[]|https?:/.test(text) &&
-    !(enableInlineMath && text.includes('$'))
+    !(enableInlineMath && text.includes('$')) &&
+    !text.includes('\\$')
   ) {
     return <Text color={textColor}>{text}</Text>;
   }
@@ -72,24 +69,39 @@ const RenderInlineInternal: React.FC<RenderInlineProps> = ({
   // Capability is stable for the duration of a single render — read it once
   // here so each matched link/URL doesn't re-walk the env-var table.
   const canHyperlink = supportsHyperlinks();
-  const inlineRegex = enableInlineMath
-    ? INLINE_MARKDOWN_WITH_MATH_REGEX
-    : INLINE_MARKDOWN_REGEX;
-  inlineRegex.lastIndex = 0;
-  let match;
+  for (const token of mergeInlineMathMatches(
+    text,
+    INLINE_MARKDOWN_REGEX,
+    enableInlineMath,
+  )) {
+    const index =
+      token.kind === 'math' ? token.span.index : (token.match.index ?? 0);
 
-  while ((match = inlineRegex.exec(text)) !== null) {
-    if (match.index > lastIndex) {
+    if (index > lastIndex) {
+      const prose = text.slice(lastIndex, index);
       nodes.push(
         <Text key={`t-${lastIndex}`}>
-          {text.slice(lastIndex, match.index)}
+          {token.kind === 'math'
+            ? unescapeMarkdownBeforeMath(prose)
+            : unescapeMarkdownDollars(prose)}
         </Text>,
       );
     }
 
+    if (token.kind === 'math') {
+      nodes.push(
+        <Text key={`m-${index}`} color={theme.text.accent}>
+          {renderInlineLatex(unescapeMarkdownDollars(token.span.content))}
+        </Text>,
+      );
+      lastIndex = index + token.span.raw.length;
+      continue;
+    }
+
+    const match = token.match;
     const fullMatch = match[0];
     let renderedNode: React.ReactNode = null;
-    const key = `m-${match.index}`;
+    const key = `m-${index}`;
 
     try {
       if (
@@ -99,25 +111,35 @@ const RenderInlineInternal: React.FC<RenderInlineProps> = ({
       ) {
         renderedNode = (
           <Text key={key} bold>
-            {fullMatch.slice(BOLD_MARKER_LENGTH, -BOLD_MARKER_LENGTH)}
+            {unescapeMarkdownDollars(
+              fullMatch.slice(BOLD_MARKER_LENGTH, -BOLD_MARKER_LENGTH),
+            )}
           </Text>
         );
       } else if (
         fullMatch.length > ITALIC_MARKER_LENGTH * 2 &&
         ((fullMatch.startsWith('*') && fullMatch.endsWith('*')) ||
           (fullMatch.startsWith('_') && fullMatch.endsWith('_'))) &&
-        !/\w/.test(text.substring(match.index - 1, match.index)) &&
+        !/\w/.test(text.substring(index - 1, index)) &&
         !/\w/.test(
-          text.substring(inlineRegex.lastIndex, inlineRegex.lastIndex + 1),
+          text.substring(
+            index + fullMatch.length,
+            index + fullMatch.length + 1,
+          ),
         ) &&
-        !/\S[./\\]/.test(text.substring(match.index - 2, match.index)) &&
+        !/\S[./\\]/.test(text.substring(index - 2, index)) &&
         !/[./\\]\S/.test(
-          text.substring(inlineRegex.lastIndex, inlineRegex.lastIndex + 2),
+          text.substring(
+            index + fullMatch.length,
+            index + fullMatch.length + 2,
+          ),
         )
       ) {
         renderedNode = (
           <Text key={key} italic>
-            {fullMatch.slice(ITALIC_MARKER_LENGTH, -ITALIC_MARKER_LENGTH)}
+            {unescapeMarkdownDollars(
+              fullMatch.slice(ITALIC_MARKER_LENGTH, -ITALIC_MARKER_LENGTH),
+            )}
           </Text>
         );
       } else if (
@@ -127,9 +149,11 @@ const RenderInlineInternal: React.FC<RenderInlineProps> = ({
       ) {
         renderedNode = (
           <Text key={key} strikethrough>
-            {fullMatch.slice(
-              STRIKETHROUGH_MARKER_LENGTH,
-              -STRIKETHROUGH_MARKER_LENGTH,
+            {unescapeMarkdownDollars(
+              fullMatch.slice(
+                STRIKETHROUGH_MARKER_LENGTH,
+                -STRIKETHROUGH_MARKER_LENGTH,
+              ),
             )}
           </Text>
         );
@@ -173,7 +197,10 @@ const RenderInlineInternal: React.FC<RenderInlineProps> = ({
           // `(url)` suffix) when OSC 8 is active. The legacy `label (url)`
           // branch leaves both intact so today's unsupported-terminal
           // output stays byte-identical.
-          const safeLabel = wrapOsc8 ? sanitizeForOsc(linkText) : linkText;
+          const renderedLinkText = unescapeMarkdownDollars(linkText);
+          const safeLabel = wrapOsc8
+            ? sanitizeForOsc(renderedLinkText)
+            : renderedLinkText;
           const safeUrl = wrapOsc8 ? sanitizeForOsc(url) : url;
           // Keep the `(url)` suffix visible when the label itself looks
           // like a (mismatched) URL — pre-OSC-8 rendering always showed the
@@ -193,7 +220,7 @@ const RenderInlineInternal: React.FC<RenderInlineProps> = ({
             </Text>
           ) : (
             <Text key={key}>
-              {linkText}
+              {renderedLinkText}
               <Text color={theme.text.link}> ({url})</Text>
             </Text>
           );
@@ -206,24 +233,10 @@ const RenderInlineInternal: React.FC<RenderInlineProps> = ({
       ) {
         renderedNode = (
           <Text key={key} underline>
-            {fullMatch.slice(
-              UNDERLINE_TAG_START_LENGTH,
-              -UNDERLINE_TAG_END_LENGTH,
-            )}
-          </Text>
-        );
-      } else if (
-        enableInlineMath &&
-        fullMatch.startsWith('$') &&
-        fullMatch.endsWith('$') &&
-        fullMatch.length > INLINE_MATH_MARKER_LENGTH * 2
-      ) {
-        renderedNode = (
-          <Text key={key} color={theme.text.accent}>
-            {renderInlineLatex(
+            {unescapeMarkdownDollars(
               fullMatch.slice(
-                INLINE_MATH_MARKER_LENGTH,
-                -INLINE_MATH_MARKER_LENGTH,
+                UNDERLINE_TAG_START_LENGTH,
+                -UNDERLINE_TAG_END_LENGTH,
               ),
             )}
           </Text>
@@ -252,12 +265,20 @@ const RenderInlineInternal: React.FC<RenderInlineProps> = ({
       renderedNode = null;
     }
 
-    nodes.push(renderedNode ?? <Text key={key}>{fullMatch}</Text>);
-    lastIndex = inlineRegex.lastIndex;
+    nodes.push(
+      renderedNode ?? (
+        <Text key={key}>{unescapeMarkdownDollars(fullMatch)}</Text>
+      ),
+    );
+    lastIndex = index + fullMatch.length;
   }
 
   if (lastIndex < text.length) {
-    nodes.push(<Text key={`t-${lastIndex}`}>{text.slice(lastIndex)}</Text>);
+    nodes.push(
+      <Text key={`t-${lastIndex}`}>
+        {unescapeMarkdownDollars(text.slice(lastIndex))}
+      </Text>,
+    );
   }
 
   return <>{nodes.filter((node) => node !== null)}</>;
@@ -273,35 +294,42 @@ export const getPlainTextLength = (
   text: string,
   enableInlineMath = false,
 ): number => {
-  const inlineRegex = enableInlineMath
-    ? INLINE_MARKDOWN_WITH_MATH_REGEX
-    : INLINE_MARKDOWN_REGEX;
-  inlineRegex.lastIndex = 0;
   let normalizedText = '';
   let lastIndex = 0;
-  let match;
 
-  while ((match = inlineRegex.exec(text)) !== null) {
-    normalizedText += text.slice(lastIndex, match.index);
+  for (const token of mergeInlineMathMatches(
+    text,
+    INLINE_MARKDOWN_REGEX,
+    enableInlineMath,
+  )) {
+    const index =
+      token.kind === 'math' ? token.span.index : (token.match.index ?? 0);
+    const prose = text.slice(lastIndex, index);
+    normalizedText +=
+      token.kind === 'math'
+        ? unescapeMarkdownBeforeMath(prose)
+        : unescapeMarkdownDollars(prose);
+
+    if (token.kind === 'math') {
+      normalizedText += renderInlineLatex(
+        unescapeMarkdownDollars(token.span.content),
+      );
+      lastIndex = index + token.span.raw.length;
+      continue;
+    }
+
+    const match = token.match;
     const fullMatch = match[0];
     const codeMatch = fullMatch.match(/^(`+)(.+?)\1$/s);
 
     if (codeMatch?.[2]) {
       normalizedText += codeMatch[2];
-    } else if (
-      enableInlineMath &&
-      fullMatch.startsWith('$') &&
-      fullMatch.endsWith('$')
-    ) {
-      normalizedText += renderInlineLatex(
-        fullMatch.slice(INLINE_MATH_MARKER_LENGTH, -INLINE_MATH_MARKER_LENGTH),
-      );
     } else {
-      normalizedText += fullMatch;
+      normalizedText += unescapeMarkdownDollars(fullMatch);
     }
-    lastIndex = inlineRegex.lastIndex;
+    lastIndex = index + fullMatch.length;
   }
-  normalizedText += text.slice(lastIndex);
+  normalizedText += unescapeMarkdownDollars(text.slice(lastIndex));
 
   const cleanText = normalizedText
     .replace(/\*\*(.*?)\*\*/g, '$1')

--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -1134,11 +1134,11 @@ Another paragraph.
       expect(output).not.toContain('$\\alpha$');
     });
 
-    it('renders table math while preserving escaped and code-span math', () => {
+    it('renders escaped dollars in table prose and keeps code spans verbatim', () => {
       const text = `
-| Formula | Literal | Code |
-|---------|---------|------|
-| $x$ | \\$xy$ | \`\`a \`$zz$\` b\`\` |
+| Formula | Literal | Code | Mixed |
+|---------|---------|------|-------|
+| $x$ | \\$xy$ | \`\`a \`$zz$\` b\`\` | $x + \\$5$ |
 `.replace(/\n/g, eol);
       const { lastFrame } = renderWithProviders(
         <MarkdownDisplay {...baseProps} text={text} />,
@@ -1146,8 +1146,10 @@ Another paragraph.
       const output = stripAnsi(lastFrame() ?? '');
 
       expect(output).toContain('│ x');
-      expect(output).toContain('\\$xy$');
+      expect(output).toContain('$xy$');
+      expect(output).not.toContain('\\$xy$');
       expect(output).toContain('a `$zz$` b');
+      expect(output).toContain('x + $5');
       expect(output).not.toContain('$x$');
     });
 

--- a/packages/cli/src/ui/utils/TableRenderer.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.tsx
@@ -14,7 +14,9 @@ import { theme } from '../semantic-colors.js';
 import { renderInlineLatex } from './latexRenderer.js';
 import {
   INLINE_CODE_SPAN_PATTERN_SOURCE,
-  INLINE_MATH_PATTERN_SOURCE,
+  mergeInlineMathMatches,
+  unescapeMarkdownBeforeMath,
+  unescapeMarkdownDollars,
 } from './inline-math.js';
 import {
   MD_LINK_CAPTURE,
@@ -49,11 +51,6 @@ const SAFETY_MARGIN = 4;
 const INLINE_MARKDOWN_REGEX = new RegExp(
   String.raw`(\*\*.*?\*\*|\*.*?\*|_.*?_|~~.*?~~|${MD_LINK_PATTERN}|` +
     String.raw`${INLINE_CODE_SPAN_PATTERN_SOURCE}|<u>.*?<\/u>|https?:\/\/\S+)`,
-  'g',
-);
-const INLINE_MARKDOWN_WITH_MATH_REGEX = new RegExp(
-  String.raw`(\*\*.*?\*\*|\*.*?\*|_.*?_|~~.*?~~|${MD_LINK_PATTERN}|` +
-    String.raw`${INLINE_CODE_SPAN_PATTERN_SOURCE}|${INLINE_MATH_PATTERN_SOURCE}|<u>.*?<\/u>|https?:\/\/\S+)`,
   'g',
 );
 
@@ -253,21 +250,36 @@ const ansiFmt = {
  * Mirrors RenderInline's behavior but outputs strings instead of React nodes.
  */
 function renderMarkdownToAnsi(text: string, enableInlineMath = false): string {
-  const inlineRegex = enableInlineMath
-    ? INLINE_MARKDOWN_WITH_MATH_REGEX
-    : INLINE_MARKDOWN_REGEX;
-  inlineRegex.lastIndex = 0;
-
   // Capability is stable for the duration of one cell render — read it once
   // here instead of per matched token.
   const canHyperlink = supportsHyperlinks();
 
   let result = '';
   let lastIndex = 0;
-  let match;
 
-  while ((match = inlineRegex.exec(text)) !== null) {
-    result += text.slice(lastIndex, match.index);
+  for (const token of mergeInlineMathMatches(
+    text,
+    INLINE_MARKDOWN_REGEX,
+    enableInlineMath,
+  )) {
+    const index =
+      token.kind === 'math' ? token.span.index : (token.match.index ?? 0);
+    const prose = text.slice(lastIndex, index);
+    result +=
+      token.kind === 'math'
+        ? unescapeMarkdownBeforeMath(prose)
+        : unescapeMarkdownDollars(prose);
+
+    if (token.kind === 'math') {
+      result += applyColor(
+        renderInlineLatex(unescapeMarkdownDollars(token.span.content)),
+        theme.text.accent,
+      );
+      lastIndex = index + token.span.raw.length;
+      continue;
+    }
+
+    const match = token.match;
     const fullMatch = match[0]!;
     let rendered: string | null = null;
 
@@ -276,27 +288,31 @@ function renderMarkdownToAnsi(text: string, enableInlineMath = false): string {
       fullMatch.endsWith('**') &&
       fullMatch.length > 4
     ) {
-      rendered = ansiFmt.bold(fullMatch.slice(2, -2));
+      rendered = ansiFmt.bold(unescapeMarkdownDollars(fullMatch.slice(2, -2)));
     } else if (
       fullMatch.length > 2 &&
       ((fullMatch.startsWith('*') && fullMatch.endsWith('*')) ||
         (fullMatch.startsWith('_') && fullMatch.endsWith('_'))) &&
-      !/\w/.test(text.substring(match.index - 1, match.index)) &&
+      !/\w/.test(text.substring(index - 1, index)) &&
       !/\w/.test(
-        text.substring(inlineRegex.lastIndex, inlineRegex.lastIndex + 1),
+        text.substring(index + fullMatch.length, index + fullMatch.length + 1),
       ) &&
-      !/\S[./\\]/.test(text.substring(match.index - 2, match.index)) &&
+      !/\S[./\\]/.test(text.substring(index - 2, index)) &&
       !/[./\\]\S/.test(
-        text.substring(inlineRegex.lastIndex, inlineRegex.lastIndex + 2),
+        text.substring(index + fullMatch.length, index + fullMatch.length + 2),
       )
     ) {
-      rendered = ansiFmt.italic(fullMatch.slice(1, -1));
+      rendered = ansiFmt.italic(
+        unescapeMarkdownDollars(fullMatch.slice(1, -1)),
+      );
     } else if (
       fullMatch.startsWith('~~') &&
       fullMatch.endsWith('~~') &&
       fullMatch.length > 4
     ) {
-      rendered = ansiFmt.strikethrough(fullMatch.slice(2, -2));
+      rendered = ansiFmt.strikethrough(
+        unescapeMarkdownDollars(fullMatch.slice(2, -2)),
+      );
     } else if (
       fullMatch.startsWith('`') &&
       fullMatch.endsWith('`') &&
@@ -313,7 +329,7 @@ function renderMarkdownToAnsi(text: string, enableInlineMath = false): string {
     ) {
       const linkMatch = fullMatch.match(MD_LINK_CAPTURE);
       if (linkMatch) {
-        const labelText = linkMatch[1] ?? '';
+        const labelText = unescapeMarkdownDollars(linkMatch[1] ?? '');
         const url = linkMatch[2] ?? '';
         // When OSC 8 wraps, show only the label — long URLs in narrow
         // table cells were the worst offender for layout cluttering, so
@@ -345,21 +361,13 @@ function renderMarkdownToAnsi(text: string, enableInlineMath = false): string {
         }
       }
     } else if (
-      enableInlineMath &&
-      fullMatch.startsWith('$') &&
-      fullMatch.endsWith('$') &&
-      fullMatch.length > 2
-    ) {
-      rendered = applyColor(
-        renderInlineLatex(fullMatch.slice(1, -1)),
-        theme.text.accent,
-      );
-    } else if (
       fullMatch.startsWith('<u>') &&
       fullMatch.endsWith('</u>') &&
       fullMatch.length > 7
     ) {
-      rendered = ansiFmt.underline(fullMatch.slice(3, -4));
+      rendered = ansiFmt.underline(
+        unescapeMarkdownDollars(fullMatch.slice(3, -4)),
+      );
     } else if (/^https?:\/\//.test(fullMatch)) {
       const visible = applyColor(fullMatch, theme.text.link);
       if (canHyperlink) {
@@ -372,11 +380,11 @@ function renderMarkdownToAnsi(text: string, enableInlineMath = false): string {
       }
     }
 
-    result += rendered ?? fullMatch;
-    lastIndex = inlineRegex.lastIndex;
+    result += rendered ?? unescapeMarkdownDollars(fullMatch);
+    lastIndex = index + fullMatch.length;
   }
 
-  result += text.slice(lastIndex);
+  result += unescapeMarkdownDollars(text.slice(lastIndex));
   return result;
 }
 

--- a/packages/cli/src/ui/utils/inline-math.test.ts
+++ b/packages/cli/src/ui/utils/inline-math.test.ts
@@ -9,6 +9,8 @@ import {
   findInlineMathExpressions,
   INLINE_MATH_MAX_CHARS,
   readInlineMathSpanAt,
+  unescapeMarkdownBeforeMath,
+  unescapeMarkdownDollars,
 } from './inline-math.js';
 
 describe('inline math recognition', () => {
@@ -28,6 +30,27 @@ describe('inline math recognition', () => {
   it('rejects formulas whose closing dollar is escaped', () => {
     expect(findInlineMathExpressions(String.raw`A $x\$ B`)).toEqual([]);
     expect(findInlineMathExpressions(String.raw`Total $a b\$ end`)).toEqual([]);
+  });
+
+  it('recognizes literal dollars inside and next to formulas', () => {
+    expect(findInlineMathExpressions(String.raw`Formula $x + \$5$`)).toEqual([
+      String.raw`x + \$5`,
+    ]);
+    expect(
+      findInlineMathExpressions(String.raw`Literal then math: \$$x^2$`),
+    ).toEqual(['x^2']);
+    expect(
+      findInlineMathExpressions(String.raw`Math then literal: $x^2\$$`),
+    ).toEqual([String.raw`x^2\$`]);
+  });
+
+  it('uses the full backslash-run parity around delimiters', () => {
+    expect(findInlineMathExpressions(String.raw`Odd \$x$; even \\$y$`)).toEqual(
+      ['y'],
+    );
+    expect(findInlineMathExpressions(String.raw`Odd $x\$; even $y\\$`)).toEqual(
+      [String.raw`y\\`],
+    );
   });
 
   it('ignores inline code spans and unclosed formulas', () => {
@@ -53,5 +76,13 @@ describe('inline math recognition', () => {
   it('reads a span only at the requested offset', () => {
     expect(readInlineMathSpanAt('A $x$ B', 2)).toBe('$x$');
     expect(readInlineMathSpanAt(String.raw`A \$x$ B`, 3)).toBeNull();
+    expect(readInlineMathSpanAt(String.raw`\$$x$`, 2)).toBe('$x$');
+  });
+
+  it('removes Markdown escaping from literal dollars by parity', () => {
+    expect(unescapeMarkdownDollars(String.raw`\$ \\$ \\\$`)).toBe(
+      String.raw`$ \$ \$`,
+    );
+    expect(unescapeMarkdownBeforeMath(String.raw`prefix \\`)).toBe('prefix \\');
   });
 });

--- a/packages/cli/src/ui/utils/inline-math.ts
+++ b/packages/cli/src/ui/utils/inline-math.ts
@@ -6,39 +6,166 @@
 
 export const INLINE_MATH_MAX_CHARS = 1024;
 
-export const INLINE_MATH_PATTERN_SOURCE = String.raw`(?<![\\\w$])\$(?![\s\d$])[^$\n]{0,${INLINE_MATH_MAX_CHARS - 1}}[^$\s](?<!\\)\$(?![\w$])`;
-
 export const INLINE_CODE_SPAN_PATTERN_SOURCE = String.raw`(?<!\`)(?<inlineCodeFence>\`+)(?!\`).+?(?<!\`)\k<inlineCodeFence>(?!\`)`;
 
 const INLINE_CODE_SPAN_RE = new RegExp(INLINE_CODE_SPAN_PATTERN_SOURCE, 'g');
 
+export interface InlineMathSpan {
+  content: string;
+  index: number;
+  raw: string;
+}
+
+export type InlineToken =
+  | { kind: 'markup'; match: RegExpMatchArray }
+  | { kind: 'math'; span: InlineMathSpan };
+
+function isEscapedAt(text: string, index: number): boolean {
+  let slashCount = 0;
+  for (
+    let cursor = index - 1;
+    cursor >= 0 && text[cursor] === '\\';
+    cursor -= 1
+  ) {
+    slashCount += 1;
+  }
+  return slashCount % 2 === 1;
+}
+
+function isUnescapedDollarAt(text: string, index: number): boolean {
+  return text[index] === '$' && !isEscapedAt(text, index);
+}
+
+export function unescapeMarkdownDollars(text: string): string {
+  return text.replace(
+    /(\\+)\$/g,
+    (_match, slashes: string) =>
+      `${'\\'.repeat(Math.floor(slashes.length / 2))}$`,
+  );
+}
+
+export function unescapeMarkdownBeforeMath(text: string): string {
+  return unescapeMarkdownDollars(`${text}$`).slice(0, -1);
+}
+
+// Escape state depends on the parity of the complete backslash run, and an
+// escaped dollar inside math must be skipped while looking for the real closer.
+function readInlineMathSpan(
+  text: string,
+  index: number,
+): InlineMathSpan | null {
+  if (!isUnescapedDollarAt(text, index)) {
+    return null;
+  }
+
+  const previous = text[index - 1] ?? '';
+  const next = text[index + 1] ?? '';
+  if (
+    /\w/.test(previous) ||
+    isUnescapedDollarAt(text, index - 1) ||
+    !next ||
+    /[\s\d$]/.test(next)
+  ) {
+    return null;
+  }
+
+  let closingIndex = index + 1;
+  while (
+    closingIndex < text.length &&
+    text[closingIndex] !== '\n' &&
+    closingIndex - index - 1 <= INLINE_MATH_MAX_CHARS &&
+    !isUnescapedDollarAt(text, closingIndex)
+  ) {
+    closingIndex += 1;
+  }
+
+  if (!isUnescapedDollarAt(text, closingIndex)) {
+    return null;
+  }
+
+  const content = text.slice(index + 1, closingIndex);
+  const following = text[closingIndex + 1] ?? '';
+  if (
+    content.length > INLINE_MATH_MAX_CHARS ||
+    /\s$/.test(content) ||
+    /[\w$]/.test(following)
+  ) {
+    return null;
+  }
+
+  return {
+    content,
+    index,
+    raw: text.slice(index, closingIndex + 1),
+  };
+}
+
+export function findNextInlineMath(
+  text: string,
+  fromIndex = 0,
+): InlineMathSpan | null {
+  for (let index = fromIndex; index < text.length; index += 1) {
+    const span = readInlineMathSpan(text, index);
+    if (span) {
+      return span;
+    }
+  }
+  return null;
+}
+
+export function* mergeInlineMathMatches(
+  text: string,
+  markupRegex: RegExp,
+  enableInlineMath = true,
+): Generator<InlineToken> {
+  markupRegex.lastIndex = 0;
+  const markupMatches = text.matchAll(markupRegex);
+  let nextMarkup = markupMatches.next();
+  let nextMath = enableInlineMath ? findNextInlineMath(text) : null;
+  let cursor = 0;
+
+  while (!nextMarkup.done || nextMath) {
+    while (!nextMarkup.done && (nextMarkup.value.index ?? 0) < cursor) {
+      nextMarkup = markupMatches.next();
+    }
+
+    if (nextMath && nextMath.index < cursor) {
+      nextMath = findNextInlineMath(text, cursor);
+    }
+
+    const markupIndex = nextMarkup.done
+      ? Number.POSITIVE_INFINITY
+      : (nextMarkup.value.index ?? 0);
+    const mathIndex = nextMath?.index ?? Number.POSITIVE_INFINITY;
+
+    if (!nextMarkup.done && markupIndex <= mathIndex) {
+      const match = nextMarkup.value;
+      yield { kind: 'markup', match };
+      cursor = markupIndex + match[0].length;
+      nextMarkup = markupMatches.next();
+    } else if (nextMath) {
+      yield { kind: 'math', span: nextMath };
+      cursor = mathIndex + nextMath.raw.length;
+      nextMath = findNextInlineMath(text, cursor);
+    }
+  }
+}
+
 export function findInlineMathExpressions(text: string): string[] {
-  const codeRanges = [...text.matchAll(INLINE_CODE_SPAN_RE)].map((match) => ({
-    start: match.index,
-    end: match.index + match[0].length,
-  }));
-  const mathRegex = new RegExp(INLINE_MATH_PATTERN_SOURCE, 'g');
   const expressions: string[] = [];
 
-  for (const match of text.matchAll(mathRegex)) {
-    const start = match.index;
-    const raw = match[0];
-    const end = start + raw.length;
-    if (codeRanges.some((range) => start >= range.start && end <= range.end)) {
-      continue;
+  for (const token of mergeInlineMathMatches(text, INLINE_CODE_SPAN_RE)) {
+    if (token.kind === 'math') {
+      expressions.push(token.span.content);
     }
-    expressions.push(raw.slice(1, -1));
   }
 
   return expressions;
 }
 
-const INLINE_MATH_AT_RE = new RegExp(INLINE_MATH_PATTERN_SOURCE, 'y');
-
 export function readInlineMathSpanAt(
   text: string,
   index: number,
 ): string | null {
-  INLINE_MATH_AT_RE.lastIndex = index;
-  return INLINE_MATH_AT_RE.exec(text)?.[0] ?? null;
+  return readInlineMathSpan(text, index)?.raw ?? null;
 }

--- a/packages/cli/src/ui/utils/pending-rendered-height.test.ts
+++ b/packages/cli/src/ui/utils/pending-rendered-height.test.ts
@@ -42,6 +42,13 @@ describe('splitMarkdownTableRow', () => {
       'c',
     ]);
   });
+
+  it('keeps pipes inside math that contains an escaped dollar', () => {
+    expect(splitMarkdownTableRow(String.raw`$x + \$5|y$ | c`)).toEqual([
+      String.raw`$x + \$5|y$`,
+      'c',
+    ]);
+  });
 });
 
 describe('estimateWrappedRows', () => {


### PR DESCRIPTION
## What this PR does

This PR completes the CLI's escaped-dollar inline-math contract with a bounded, parity-aware delimiter scanner. Escaped dollars can now appear inside formulas or immediately beside a formula boundary, while Markdown escapes in visible prose are removed and inline code remains byte-preserving.

Rendering, table rendering, `/copy inline-latex`, table splitting, and rendered-width measurement continue to share the same recognition result. The existing 1024-character bound and the currency, shell-variable, adjacent-span, and exact-backtick guards remain in place.

## Why it's needed

The recognizer merged in #7701 correctly stopped an escaped opener from becoming math, but its regex still excluded every dollar from a formula body and inspected only one preceding backslash. As a result, a literal dollar inside math, a formula next to an escaped dollar, and even-vs-odd backslash runs could not be represented correctly. The prose renderer also exposed `\` from a Markdown escape instead of displaying the intended literal dollar.

This is the narrow follow-up confirmed in #7740. It does not change delimiters or broaden TeX support.

## Reviewer Test Plan

### How to verify

Enable inline math and render these seven lines exactly:

```text
$x^2$ is valid math
it costs $5 and $10
$5-$10
literal \$x$
formula $x + \$5$
literal then math: \$$x^2$
math then literal: $x^2\$$
```

Confirm that the first formula renders as `x²`, currency and the compact range remain prose, the prose escape displays as `literal $x$`, the mixed formula displays as `x + $5`, and the two boundary cases display as `$x²` and `x²$`. Inline code containing `\$` must retain the backslash.

Run `/copy inline-latex` against the same output. The four formula sources should be selected in document order, preserving `\$` in the copied TeX source where present.

### Evidence (Before & After)

**Before — merge-base `7959fdb27`:**

![Before: escaped dollars remain raw](https://raw.githubusercontent.com/CubeLander/formulas-workspace/0f4dca6981d968277585acc09415e72f291426fe/evidence/qwen-cli-escaped-dollar-before.png)

**After — patched TUI:**

![After: escaped dollars render correctly](https://raw.githubusercontent.com/CubeLander/formulas-workspace/0f4dca6981d968277585acc09415e72f291426fe/evidence/qwen-cli-escaped-dollar-after.png)

| Case | Before | After |
| --- | --- | --- |
| `literal \$x$` | Backslash visible | Displays `literal $x$` |
| `$x + \$5$` | Entire source left raw | Renders `x + $5`; copy retains `x + \$5` |
| `\$$x^2$` | Entire source left raw | Displays literal `$` followed by rendered `x²` |
| `$x^2\$$` | Entire source left raw | Renders `x²$` |
| Inline code containing `\$` | Literal | Still literal and byte-preserving |

The baseline was reproduced through the real React/Ink inline renderer and shared copy recognizer on current `main`: only the first expression was recognized. On this branch, five focused suites exercise prose rendering, table rendering, source copy, table splitting, width measurement, code-span isolation, backslash parity, currency, and the complete seven-line corpus: **300/300 tests passed**.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS 26.5.2 with Node.js v26.4.0. A clean `npm ci` completed the repository build and bundle. The CLI package build, typecheck, lint, and five focused suites (300 tests) passed on the rebased head.

## Risk & Scope

- Main risk or tradeoff: the delimiter implementation changes from one regex to a small bounded scanner so it can model backslash parity; the scanner retains the previous length and context guards and is exercised through every CLI consumer.
- Not validated / out of scope: Web Shell, new delimiter forms, broader TeX rendering, Windows, and Linux runtime validation.
- Breaking changes / migration notes: escaped dollars in rendered Markdown prose now follow normal Markdown escape semantics and display without the escape backslash; inline code and copied TeX source remain unchanged.

## Linked Issues

Fixes #7740

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本 PR 用一个有长度边界、能够判断反斜杠奇偶性的定界符扫描器，补全 CLI 对转义美元符号与行内公式的处理契约。转义美元符号现在可以出现在公式内部或紧贴公式边界；可见普通文本中的 Markdown 转义会被去除，而行内代码仍逐字节保留。

普通文本渲染、表格渲染、`/copy inline-latex`、表格拆分和渲染宽度测量继续共享同一份识别结果。原有的 1024 字符上限、货币、shell 变量、相邻 span 和精确反引号守卫均保持不变。

## 为什么需要

#7701 合入的识别器已经能阻止转义 opener 被误认成公式，但其正则仍禁止公式主体出现任何美元符号，并且只检查紧邻的一个反斜杠。因此，公式内的字面美元、紧邻转义美元的公式以及奇偶反斜杠 run 都无法正确表达；普通文本渲染器还会把 Markdown 转义中的 `\` 直接显示出来，而不是只显示目标美元符号。

这是 #7740 中已确认的窄范围后续修复，不改变定界符，也不扩大 TeX 支持。

## Reviewer 测试计划

### 如何验证

启用行内公式，并原样渲染上方七行语料。确认第一行显示为 `x²`，货币与紧凑价格区间仍是普通文本，普通文本转义显示为 `literal $x$`，混合公式显示为 `x + $5`，两种边界分别显示为 `$x²` 与 `x²$`。行内代码中的 `\$` 必须保留反斜杠。

对同一输出执行 `/copy inline-latex`。四个公式源码应按文档顺序参与选择，并在适用位置保留复制出的 TeX 源码中的 `\$`。

### 证据（修复前后）

| 情况 | 修复前 | 修复后 |
| --- | --- | --- |
| `literal \$x$` | 反斜杠可见 | 显示 `literal $x$` |
| `$x + \$5$` | 整段源码保持原样 | 渲染为 `x + $5`；复制仍得到 `x + \$5` |
| `\$$x^2$` | 整段源码保持原样 | 显示字面 `$`，随后是渲染后的 `x²` |
| `$x^2\$$` | 整段源码保持原样 | 渲染为 `x²$` |
| 含 `\$` 的行内代码 | 保持字面形式 | 仍保持字面形式且逐字节不变 |

基线已通过当前 `main` 的真实 React/Ink 行内渲染器与共享复制识别器复现：只有第一个公式被识别。本分支的五组聚焦测试覆盖普通文本渲染、表格渲染、源码复制、表格拆分、宽度测量、代码段隔离、反斜杠奇偶性、货币和完整七行语料，共 **300/300 项通过**。

### 已测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS 26.5.2、Node.js v26.4.0。全新 `npm ci` 已完成仓库 build 与 bundle；在 rebase 后的 head 上，CLI package 的 build、typecheck、lint 以及五组聚焦测试（300 项）全部通过。

## 风险与范围

- 主要风险或取舍：定界符实现从单一正则改为小型有界扫描器，以便表达反斜杠奇偶性；扫描器保留旧有长度与上下文守卫，并通过全部 CLI 消费路径测试。
- 未验证或范围外：Web Shell、新定界符、更广泛的 TeX 渲染、Windows 和 Linux 运行时验证。
- Breaking changes / 迁移说明：渲染后的 Markdown 普通文本中的转义美元现在遵循正常 Markdown 转义语义，不再显示转义反斜杠；行内代码与复制出的 TeX 源码保持不变。

## 关联 Issue

Fixes #7740

</details>

