### PR TITLE
fix(ci): handle compressed npm audit responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "lint:ci": "eslint . --ext .ts,.tsx --max-warnings 0 && eslint integration-tests --max-warnings 0",
     "lint:sdk:python": "python3 -m ruff check --config packages/sdk-python/pyproject.toml packages/sdk-python",
     "lint:all": "node scripts/lint.js",
-    "audit:runtime:critical": "npm audit --omit=dev --audit-level=critical",
+    "audit:runtime:critical": "node scripts/audit-runtime-critical.js",
     "format": "prettier --experimental-cli --write .",
     "typecheck": "npm run typecheck --workspaces --if-present",
     "typecheck:sdk:python": "python3 -m mypy --config-file packages/sdk-python/pyproject.toml packages/sdk-python/src",

--- a/scripts/audit-runtime-critical.js
+++ b/scripts/audit-runtime-critical.js
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync } from 'node:fs';
+import https from 'node:https';
+import { fileURLToPath } from 'node:url';
+import { gunzipSync } from 'node:zlib';
+
+const AUDIT_URL =
+  'https://registry.npmjs.org/-/npm/v1/security/advisories/bulk';
+
+export function createAuditPayload(lock) {
+  const versions = new Map();
+
+  for (const [path, pkg] of Object.entries(lock.packages)) {
+    if (!path || pkg.link || pkg.dev || !pkg.version) continue;
+    const name = pkg.name ?? path.slice(path.lastIndexOf('node_modules/') + 13);
+    const values = versions.get(name) ?? new Set();
+    values.add(pkg.version);
+    versions.set(name, values);
+  }
+
+  return Object.fromEntries(
+    [...versions].map(([name, values]) => [name, [...values]]),
+  );
+}
+
+export function decodeAuditResponse(body) {
+  // The registry can omit Content-Encoding even when returning gzip.
+  return body[0] === 0x1f && body[1] === 0x8b ? gunzipSync(body) : body;
+}
+
+export function findCriticalAdvisories(report) {
+  return Object.entries(report).flatMap(([name, advisories]) => {
+    if (!Array.isArray(advisories)) {
+      throw new Error(`Invalid audit response for ${name}`);
+    }
+    return advisories
+      .filter(({ severity }) => severity === 'critical')
+      .map((advisory) => ({ name, ...advisory }));
+  });
+}
+
+function requestAudit(payload) {
+  const body = JSON.stringify(payload);
+  return new Promise((resolve, reject) => {
+    const request = https.request(
+      AUDIT_URL,
+      {
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          'accept-encoding': 'identity',
+          'content-length': Buffer.byteLength(body),
+          'content-type': 'application/json',
+        },
+      },
+      (response) => {
+        const chunks = [];
+        response.on('error', reject);
+        response.on('data', (chunk) => chunks.push(chunk));
+        response.on('end', () => {
+          const result = Buffer.concat(chunks);
+          if (response.statusCode !== 200) {
+            reject(
+              new Error(
+                `Audit endpoint returned ${response.statusCode}: ${result}`,
+              ),
+            );
+            return;
+          }
+          resolve(JSON.parse(decodeAuditResponse(result)));
+        });
+      },
+    );
+    request.on('error', reject);
+    request.end(body);
+  });
+}
+
+async function main() {
+  const lock = JSON.parse(readFileSync('package-lock.json', 'utf8'));
+  const critical = findCriticalAdvisories(
+    await requestAudit(createAuditPayload(lock)),
+  );
+
+  if (critical.length === 0) {
+    console.log('No critical runtime vulnerabilities found.');
+    return;
+  }
+
+  for (const { name, title, url } of critical) {
+    console.error(`${name}: ${title} (${url})`);
+  }
+  process.exitCode = 1;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/scripts/tests/audit-runtime-critical.test.js
+++ b/scripts/tests/audit-runtime-critical.test.js
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { gzipSync } from 'node:zlib';
+import { describe, expect, it } from 'vitest';
+import {
+  createAuditPayload,
+  decodeAuditResponse,
+  findCriticalAdvisories,
+} from '../audit-runtime-critical.js';
+
+describe('runtime dependency audit', () => {
+  it('collects installed production package versions', () => {
+    expect(
+      createAuditPayload({
+        packages: {
+          '': { name: 'root', version: '1.0.0' },
+          'packages/core': { name: '@qwen-code/core', version: '1.0.0' },
+          'node_modules/foo': { version: '1.0.0' },
+          'packages/core/node_modules/foo': { version: '2.0.0' },
+          'node_modules/@scope/bar': { version: '3.0.0' },
+          'node_modules/dev-only': { version: '1.0.0', dev: true },
+          'node_modules/workspace': { link: true },
+        },
+      }),
+    ).toEqual({
+      '@qwen-code/core': ['1.0.0'],
+      foo: ['1.0.0', '2.0.0'],
+      '@scope/bar': ['3.0.0'],
+    });
+  });
+
+  it('decodes plain and gzip responses', () => {
+    const body = Buffer.from('{"foo":[]}');
+    expect(decodeAuditResponse(body)).toEqual(body);
+    expect(decodeAuditResponse(gzipSync(body))).toEqual(body);
+  });
+
+  it('returns only critical advisories', () => {
+    expect(
+      findCriticalAdvisories({
+        foo: [
+          { severity: 'high', title: 'high' },
+          { severity: 'critical', title: 'critical' },
+        ],
+      }),
+    ).toEqual([{ name: 'foo', severity: 'critical', title: 'critical' }]);
+  });
+});


### PR DESCRIPTION
## What this PR does

Keeps the critical runtime dependency audit on the supported bulk advisory endpoint and decodes both plain and gzip responses.

## Why it's needed

The npm registry currently returns gzip bytes for the repository's bulk audit request without a `Content-Encoding` response header. npm 10, 11, and 12 therefore parse compressed bytes as JSON; npm 10 then falls back to the retired quick-audit endpoint and reports the misleading error `Invalid package tree`. This is failing every full CI run before project checks begin.

## Reviewer Test Plan

### How to verify

Run `npm run audit:runtime:critical`. It should query the official npm bulk advisory endpoint, print `No critical runtime vulnerabilities found.` for the current lockfile, and exit successfully. The generated 799-package production payload was also compared exactly with npm Arborist's `--omit=dev` inventory.

### Evidence (Before & After)

N/A

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22.22.0; npm 10.9.4. Focused helper tests: 3/3 passed.

## Risk & Scope

- Main risk or tradeoff: the audit payload is derived from package-lock metadata instead of npm's failing network client; a focused test and an exact Arborist comparison cover the production/development filtering contract.
- Not validated / out of scope: non-critical advisories remain informational, matching the existing `--audit-level=critical` gate.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让 critical 级运行时依赖审计继续使用受支持的 bulk advisory endpoint，并同时兼容纯 JSON 与 gzip 响应。

## 为什么需要

npm registry 当前会对本仓库较大的 bulk audit 请求返回 gzip 字节，但响应头缺失 `Content-Encoding`。npm 10、11、12 因此都会把压缩字节当作 JSON 解析；npm 10 随后回退到已退役的 quick-audit endpoint，并给出误导性的 `Invalid package tree`。这导致所有 full CI 在项目检查开始前失败。

## Reviewer 测试计划

### 如何验证

运行 `npm run audit:runtime:critical`。它应调用 npm 官方 bulk advisory endpoint；当前 lockfile 没有 critical 漏洞时打印 `No critical runtime vulnerabilities found.` 并成功退出。生成的 799 个生产依赖 payload 也已与 npm Arborist 的 `--omit=dev` inventory 逐项比对一致。

### 前后证据

N/A

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

Node.js 22.22.0；npm 10.9.4。定点 helper 测试 3/3 通过。

## 风险与范围

- 主要风险或取舍：审计 payload 改为从 package-lock 元数据生成，不再依赖当前失败的 npm 网络客户端；定点测试及与 Arborist 的逐项比对覆盖了生产/开发依赖过滤契约。
- 未验证/范围外：非 critical advisory 仍只作为信息，不阻断 CI，与原有 `--audit-level=critical` 门禁一致。
- 破坏性变更/迁移：无。

## 关联 Issue

N/A

</details>
