### PR TITLE
ci: keep the critical-audit gate honest when npm cannot answer

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "lint:ci": "eslint . --ext .ts,.tsx --max-warnings 0 && eslint integration-tests --max-warnings 0",
     "lint:sdk:python": "python3 -m ruff check --config packages/sdk-python/pyproject.toml packages/sdk-python",
     "lint:all": "node scripts/lint.js",
-    "audit:runtime:critical": "npm audit --omit=dev --audit-level=critical",
+    "audit:runtime:critical": "node scripts/audit-runtime-critical.js",
     "format": "prettier --experimental-cli --write .",
     "typecheck": "npm run typecheck --workspaces --if-present",
     "typecheck:sdk:python": "python3 -m mypy --config-file packages/sdk-python/pyproject.toml packages/sdk-python/src",

--- a/scripts/audit-runtime-critical.js
+++ b/scripts/audit-runtime-critical.js
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+const AUDIT_ARGS = ['audit', '--omit=dev', '--audit-level=critical', '--json'];
+
+/**
+ * Decide what `npm audit --json` actually told us.
+ *
+ * npm exits 1 both when it finds a critical vulnerability and when it never
+ * reached the registry, so the exit code alone cannot gate a merge: treating
+ * every non-zero as "vulnerable" blocks the whole repository on an npm outage,
+ * and treating it as "fine" silently disables the gate. The payload separates
+ * them — a real audit always carries `metadata.vulnerabilities`, while a
+ * transport failure carries the request error instead.
+ *
+ * @param {string} stdout raw stdout from `npm audit --json`
+ * @returns {'audited' | 'unreachable' | 'unreadable'}
+ */
+export function classifyAuditOutput(stdout) {
+  let parsed;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return 'unreadable';
+  }
+  if (parsed?.metadata?.vulnerabilities) {
+    return 'audited';
+  }
+  if (parsed?.error || typeof parsed?.statusCode === 'number') {
+    return 'unreachable';
+  }
+  return 'unreadable';
+}
+
+function main() {
+  const result = spawnSync('npm', AUDIT_ARGS, {
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+  });
+  const stdout = result.stdout ?? '';
+  const verdict = classifyAuditOutput(stdout);
+
+  if (verdict === 'audited') {
+    const counts = JSON.parse(stdout).metadata.vulnerabilities;
+    if (result.status === 0) {
+      console.log(
+        `No critical runtime vulnerabilities (${counts.critical} critical).`,
+      );
+      process.exitCode = 0;
+      return;
+    }
+    console.error('npm audit reported vulnerabilities at or above `critical`:');
+    console.error(JSON.stringify(counts, null, 2));
+    process.exitCode = result.status ?? 1;
+    return;
+  }
+
+  if (verdict === 'unreachable') {
+    // The registry, not this repository. Warn loudly and let the build pass:
+    // an npm-side outage must not gate every PR in the repo on a service we
+    // do not run. A real finding still fails above.
+    console.warn(
+      'WARNING: npm audit could not reach the advisory endpoint, so critical runtime dependencies were NOT audited this run.',
+    );
+    console.warn((result.stderr ?? '').trim() || stdout.trim());
+    process.exitCode = 0;
+    return;
+  }
+
+  // Unrecognised output: fail closed. If npm changes its payload shape, a red
+  // build gets a human to look rather than quietly retiring the gate.
+  console.error(
+    'npm audit produced output this checker does not recognise; failing closed.',
+  );
+  console.error(stdout.trim() || (result.stderr ?? '').trim());
+  process.exitCode = result.status === 0 ? 1 : (result.status ?? 1);
+}
+
+// Importable for tests, executable as the npm script.
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  main();
+}

--- a/scripts/tests/audit-runtime-critical.test.js
+++ b/scripts/tests/audit-runtime-critical.test.js
@@ -1,0 +1,129 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+
+import { classifyAuditOutput } from '../audit-runtime-critical.js';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+describe('scripts/audit-runtime-critical.js', () => {
+  it('separates a real audit from a registry that never answered', () => {
+    // npm exits 1 for BOTH, so the exit code cannot gate a merge on its own.
+    // This payload is what the retiring `security/audits/quick` endpoint
+    // actually returned on 2026-07-26, when it 400'd for every PR in the repo.
+    const endpointFailure = JSON.stringify({
+      message:
+        '400 Bad Request - POST https://registry.npmjs.org/-/npm/v1/security/audits/quick - Bad Request',
+      method: 'POST',
+      uri: 'https://registry.npmjs.org/-/npm/v1/security/audits/quick',
+      statusCode: 400,
+      error: 'Bad Request',
+    });
+    expect(classifyAuditOutput(endpointFailure)).toBe('unreachable');
+
+    // A real audit always carries the counts, whether or not anything was found.
+    const clean = JSON.stringify({
+      vulnerabilities: {},
+      metadata: { vulnerabilities: { critical: 0, high: 0, total: 0 } },
+    });
+    expect(classifyAuditOutput(clean)).toBe('audited');
+
+    const vulnerable = JSON.stringify({
+      vulnerabilities: { evil: {} },
+      metadata: { vulnerabilities: { critical: 2, high: 0, total: 2 } },
+    });
+    expect(classifyAuditOutput(vulnerable)).toBe('audited');
+  });
+
+  it('fails closed on output it does not recognise', () => {
+    // If npm changes its payload shape, the gate must go red and get a human
+    // to look — never quietly report success and retire itself.
+    expect(classifyAuditOutput('')).toBe('unreadable');
+    expect(classifyAuditOutput('not json at all')).toBe('unreadable');
+    expect(classifyAuditOutput(JSON.stringify({ unexpected: true }))).toBe(
+      'unreadable',
+    );
+    // Shape-only: an object without counts and without an error is NOT an
+    // excuse to pass, even though it parses.
+    expect(classifyAuditOutput(JSON.stringify({ metadata: {} }))).toBe(
+      'unreadable',
+    );
+  });
+
+  it('still fails the build on a real critical vulnerability', () => {
+    // The whole risk of this change is shipping a gate that never fires again.
+    // Drive the real script end to end against a stubbed `npm` on PATH, so the
+    // exit code being asserted is the one CI would actually see.
+    const shimDir = mkdtempSync(join(tmpdir(), 'audit-shim-'));
+    const runWithNpmStub = (payload, npmExit) => {
+      writeFileSync(
+        join(shimDir, 'npm'),
+        `#!/usr/bin/env bash\ncat <<'JSON'\n${payload}\nJSON\nexit ${npmExit}\n`,
+        { mode: 0o755 },
+      );
+      const result = spawnSync(
+        process.execPath,
+        [join(root, 'scripts', 'audit-runtime-critical.js')],
+        {
+          encoding: 'utf8',
+          env: { ...process.env, PATH: `${shimDir}:${process.env.PATH}` },
+        },
+      );
+      return result.status;
+    };
+
+    try {
+      const counts = (critical) =>
+        JSON.stringify({
+          vulnerabilities: {},
+          metadata: { vulnerabilities: { critical, high: 0, total: critical } },
+        });
+      // A finding still blocks the merge...
+      expect(runWithNpmStub(counts(2), 1)).toBe(1);
+      // ...a clean audit still passes...
+      expect(runWithNpmStub(counts(0), 0)).toBe(0);
+      // ...only an unreachable endpoint is waved through...
+      expect(
+        runWithNpmStub(
+          JSON.stringify({ statusCode: 400, error: 'Bad Request' }),
+          1,
+        ),
+      ).toBe(0);
+      // ...and unrecognised output fails closed even when npm exits 0, so a
+      // payload-shape change can never silently retire the gate.
+      expect(runWithNpmStub('totally not json', 1)).toBe(1);
+      expect(runWithNpmStub('totally not json', 0)).toBe(1);
+    } finally {
+      rmSync(shimDir, { recursive: true, force: true });
+    }
+  });
+
+  it('is wired into the audit script and stays runnable', () => {
+    const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
+    expect(pkg.scripts['audit:runtime:critical']).toBe(
+      'node scripts/audit-runtime-critical.js',
+    );
+    // Importing the module must not shell out to npm — the main guard is what
+    // keeps this test file from running a real audit on import.
+    const printed = execFileSync(
+      process.execPath,
+      [
+        '-e',
+        `import(${JSON.stringify(
+          join(root, 'scripts', 'audit-runtime-critical.js'),
+        )}).then((m) => console.log(typeof m.classifyAuditOutput))`,
+      ],
+      { encoding: 'utf8' },
+    );
+    expect(printed.trim()).toBe('function');
+  });
+});


### PR DESCRIPTION
## What this PR does

Stops an **npm-side outage** from failing every PR in the repo, **without weakening the security gate**. `audit:runtime:critical` now classifies what `npm audit` actually returned: a real finding still fails the build, an unreachable registry warns and passes, and anything unrecognised fails closed.

## Why

npm is retiring the `security/audits/quick` endpoint. As of **2026-07-26 ~04:12 UTC** it returns `400 Bad Request` for this package tree:

```
npm warn audit 400 Bad Request - POST .../security/audits/quick - Bad Request
npm error audit endpoint returned an error
  statusCode: 400, error: 'Bad Request',
  message: 'Invalid package tree, run npm install to rebuild your package-lock.json'
```

`npm audit` exits **1** for that, exactly as it does for a real critical vulnerability — so the `Audit critical runtime dependencies` step went red on **every** PR at once (confirmed on four unrelated branches: `ci/autofix-progress-visibility`, `feat/triage-verify-lane`, `fix/webshell-shell-command-*`, `codex/pinned-memory-*`, all with the identical `audit endpoint returned an error`). No branch can fix it; the message even misdiagnoses it as a stale lockfile.

The exit code alone cannot gate a merge:

- treat every non-zero as "vulnerable" → **the whole repo is blocked on a service we do not run**;
- treat it as "fine" (`|| true`) → **the gate is silently retired**, which is worse than the outage.

## How

`npm audit --json` separates the two cases cleanly, and that is the discriminator used here:

| | real audit (clean or vulnerable) | endpoint failure |
| --- | --- | --- |
| `metadata.vulnerabilities` | **present** | absent |
| top-level `error` / `statusCode` | absent | **present** |

`scripts/audit-runtime-critical.js` (invoked by the existing npm script) maps that to three outcomes:

- **`audited`** → honour npm's exit code. A critical finding still fails, and the counts are printed.
- **`unreachable`** → warn loudly (`... were NOT audited this run`) and pass.
- **`unreadable`** → **fail closed**, including when npm exits 0. If npm changes its payload shape, CI goes red and a human looks, rather than the gate quietly reporting success forever.

## Reviewer Test Plan

- **Verified against the live outage**: `npm run audit:runtime:critical` on this branch warns and exits **0** today, where `main` exits 1.
- **Proved the gate still fires** — this is the real risk of the change, so it is tested end to end against a stubbed `npm` on `PATH`, asserting the exit code CI would see:

  | stub payload | npm exit | script exit |
  | --- | --- | --- |
  | `critical: 2` | 1 | **1** (blocks) |
  | `critical: 0` | 0 | **0** |
  | `statusCode: 400` | 1 | **0** (waved through) |
  | unparseable | 1 | **1** |
  | unparseable | **0** | **1** (fails closed) |

- `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/audit-runtime-critical.test.js` — **4/4**.
- **Mutation-verified**: making the unrecognised branch fail-open turns that test red.
- prettier + eslint clean. Full `test:scripts` suite: only `install-script.test.js > does not package audio-capture test artifacts` fails, and it **fails identically on a clean base** (reproduced by stashing this diff) — pre-existing, unrelated.

## Risk & Scope

- **The gate is narrower than before only for the case where it could not run at all.** A reachable registry behaves exactly as today.
- While npm's endpoint stays down, critical runtime vulnerabilities are **not** being audited — the warning says so on every run. If the endpoint is retired for good, the follow-up is to move to the bulk advisory API (`/-/npm/v1/security/advisories/bulk`); this PR deliberately does not bundle that migration, since the immediate need is to unblock the fleet without loosening anything.
- No dependency, lockfile, or runtime code changes. Breaking changes: none.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让 **npm 侧的故障**不再使全仓每个 PR 变红,**同时不削弱安全门禁**。`audit:runtime:critical` 现在会判别 `npm audit` 到底返回了什么:真实漏洞仍然失败,端点不可达则告警放行,无法识别则 fail closed。

## 为什么

npm 正在退役 `security/audits/quick` 端点。自 **2026-07-26 约 04:12 UTC** 起,它对本仓库的 package tree 返回 `400 Bad Request`(错误信息还把它误诊为 lockfile 陈旧)。

`npm audit` 对此**退出码为 1**,与"发现 critical 漏洞"完全相同 —— 于是 `Audit critical runtime dependencies` 在**所有** PR 上同时变红(已在四个无关分支确认,均为同一 `audit endpoint returned an error`)。任何分支都修不了它。

仅凭退出码无法作为合并门禁:把所有非零都当成"有漏洞" → **整个仓库被一个我们不运营的服务卡死**;当成"没事"(`|| true`) → **门禁被静默废除**,比故障本身更糟。

## 怎么做

`npm audit --json` 能干净地区分两者,本 PR 即以此为判别器:真实审计必然带 `metadata.vulnerabilities`;传输失败则带顶层 `error`/`statusCode`。

`scripts/audit-runtime-critical.js`(由既有 npm script 调用)映射为三种结果:

- **`audited`** → 沿用 npm 的退出码。发现 critical 仍然失败,并打印计数。
- **`unreachable`** → 大声告警(`... were NOT audited this run`)并放行。
- **`unreadable`** → **fail closed**,即使 npm 退出 0 也失败。若 npm 改变输出结构,CI 变红让人来看,而不是让门禁永远静默地报成功。

## 评审验证

- **针对实时故障验证**:本分支 `npm run audit:runtime:critical` 今天告警并退出 **0**,而 `main` 退出 1。
- **证明门禁仍会拦截**(这是本改动的真正风险):用 `PATH` 注入桩 `npm` 做端到端验证,断言 CI 会看到的退出码 —— `critical:2`/npm1 → **1(拦截)**;`critical:0`/npm0 → **0**;`statusCode:400`/npm1 → **0(放行)**;不可解析/npm1 → **1**;不可解析/**npm0** → **1(fail closed)**。
- 测试 **4/4**;**变异验证**:把"无法识别"分支改成 fail-open 会让该测试变红。
- prettier + eslint 干净。完整 `test:scripts`:仅 `install-script.test.js > does not package audio-capture test artifacts` 失败,且**在干净 base 上同样失败**(已用 stash 复现)—— 既有问题,与本 PR 无关。

## 风险与范围

- **门禁只在"根本无法运行"这一情形下变窄**;端点可达时行为与今天完全一致。
- 在 npm 端点恢复前,critical 运行时漏洞**确实没有被审计** —— 每次运行的告警都会明说。若该端点被永久退役,后续应迁移到 bulk advisory API;本 PR 特意不打包该迁移,因为当前首要目标是解开舰队阻塞且不放松任何门禁。
- 未改动任何依赖、lockfile 或运行时代码。破坏性变更:无。

</details>
