### PR TITLE
ci(autofix): number the status comment like every other round message

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2966,6 +2966,12 @@ jobs:
           set -uo pipefail
           MARKER='<!-- autofix-status -->'
           ROUND_DISPLAY="${EFFECTIVE_ROUND:-${ROUND}}"
+          # ROUND counts rounds already DONE; every other message numbers the
+          # round being performed (the report posts ROUND + 1). Match it, or
+          # the same round carries two different numbers in one thread.
+          if [[ "${ROUND_DISPLAY}" =~ ^[0-9]+$ ]]; then
+            ROUND_DISPLAY="$((ROUND_DISPLAY + 1))"
+          fi
           BODY="$(printf '%s\n\n🔄 **AutoFix is working on this PR** — round %s/%s. [Watch live progress](%s); this round posts its report here when it finishes.\n\n<details>\n<summary>中文说明</summary>\n\n🔄 **AutoFix 正在处理此 PR** —— 第 %s/%s 轮。[查看实时进度](%s)；本轮结束后会在此发布报告。\n\n</details>' \
             "${MARKER}" "${ROUND_DISPLAY}" "${MAX_ROUNDS}" "${RUN_URL}" \
             "${ROUND_DISPLAY}" "${MAX_ROUNDS}" "${RUN_URL}")"
@@ -3747,6 +3753,12 @@ jobs:
             exit 0
           fi
           ROUND_DISPLAY="${EFFECTIVE_ROUND:-${ROUND}}"
+          # ROUND counts rounds already DONE; every other message numbers the
+          # round being performed (the report posts ROUND + 1). Match it, or
+          # the same round carries two different numbers in one thread.
+          if [[ "${ROUND_DISPLAY}" =~ ^[0-9]+$ ]]; then
+            ROUND_DISPLAY="$((ROUND_DISPLAY + 1))"
+          fi
           # 'fixed'/'noop' are the two outcomes that published a round report;
           # anything else means the round stopped before publishing one.
           if [[ "${OUTCOME:-}" == 'fixed' || "${OUTCOME:-}" == 'noop' ]]; then

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -4885,6 +4885,18 @@ describe('qwen-autofix workflow', () => {
       "STATUS_ID: '${{ steps.post_status.outputs.comment_id }}'",
     );
     expect(finalizeStatusCommentStep).not.toContain('--paginate');
+    // Both status messages number the round being PERFORMED, like every other
+    // message the loop posts. `effective_round` counts rounds already done and
+    // "Push and report" prints ROUND + 1, so using it raw made the status say
+    // "round 5 finished" in the same thread where the report said "round 6/100"
+    // — observed on #7724. Same round must not carry two numbers.
+    for (const statusStep of [
+      postStatusCommentStep,
+      finalizeStatusCommentStep,
+    ]) {
+      expect(statusStep).toContain('ROUND_DISPLAY="$((ROUND_DISPLAY + 1))"');
+      expect(statusStep).toContain('^[0-9]+$');
+    }
     // Tells a round that published a report from one that died before it.
     expect(finalizeStatusCommentStep).toContain("== 'fixed'");
     expect(finalizeStatusCommentStep).toContain(


### PR DESCRIPTION
## What this PR does

Fixes an off-by-one in the AutoFix status comment (#7738): it now numbers the round **being performed**, like every other message the loop posts.

## Why

`effective_round` counts rounds already **finished**, and `Push and report` posts `ROUND + 1` as the round it just performed. The status comment used the raw value, so the **same round carried two different numbers in one thread**.

Observed live on **#7724** at `10:10 UTC` — both written by the bot, minutes apart, about the same round:

| | text |
| --- | --- |
| round report | `🤖 Addressed the latest review feedback (round **6**/100)` |
| status comment | `✅ AutoFix round **5** finished` |

That is exactly the confusion the status comment exists to remove, so it is worth a follow-up rather than leaving it.

## How

Display `ROUND + 1` in both status steps, guarded by a numeric check so a missing or non-numeric round degrades to the raw value instead of failing the step (it is a best-effort step — it must never cost a round).

## Reviewer Test Plan

- Behaviour, exercised directly: `effective_round=5` → shows **6** (matches the report's `round 6/100`); empty `effective_round` falls back to `ROUND=3` → shows **4**; a non-numeric value stays as-is and does not crash.
- `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` — **103/103** (two consecutive clean runs; the suite's known load-flakes appeared in one earlier run and are unrelated).
- **Mutation-verified**: reverting either site to the raw value turns the pinning test red.
- yamllint clean, prettier clean, `bash -n` clean on both run blocks, actionlint **16 vs main 16** (no new findings).

## Risk & Scope

- Display-only: no change to round accounting, the cap, the markers, or any control flow. `ROUND` itself is untouched — only what the status comment prints.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #7738. Defect observed on #7724.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修复 AutoFix 状态评论(#7738)的 off-by-one:现在按**正在执行的轮次**编号,与循环发布的其它消息一致。

## 为什么

`effective_round` 统计的是**已完成**的轮数,而 `Push and report` 发布的是 `ROUND + 1`(它刚执行的那一轮)。状态评论直接用了原始值,导致**同一轮在同一线程里出现两个编号**。

在 **#7724** 于 `10:10 UTC` 实测到 —— 两条都由 bot 发出、相隔几分钟、指同一轮:轮次报告写 `（第 **6**/100 轮）`,状态评论写 `✅ AutoFix round **5** finished`。

这恰恰是状态评论本该消除的困惑,因此值得一个跟进修复。

## 怎么做

两个状态步骤都显示 `ROUND + 1`,并加数字校验:若轮次值缺失或非数字,则退回原始值而不是让步骤失败(它是尽力而为的步骤,绝不能拖垮一轮)。

## 评审验证

- 直接跑行为:`effective_round=5` → 显示 **6**(与报告的 `round 6/100` 一致);`effective_round` 为空 → 回退 `ROUND=3` → 显示 **4**;非数字值原样保留且不崩溃。
- `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` —— **103/103**(连续两次干净;该 suite 的已知负载 flake 在更早一次出现,与本 PR 无关)。
- **变异验证**:任一处改回原始值都会让钉住该行为的测试变红。
- yamllint 干净、prettier 干净、两个 run 块 `bash -n` 干净、actionlint **16 vs main 16**(无新增)。

## 风险与范围

- 仅显示层:不改轮次计数、上限、标记或任何控制流。`ROUND` 本身未动,只改状态评论打印的内容。
- 破坏性变更:无。

## 关联 Issue

#7738 的跟进;缺陷在 #7724 上观察到。

</details>
