### PR TITLE
feat(web-shell): Scope voice to composer workspace

### DIFF
--- a/docs/design/web-shell-secondary-workspace-voice.md
+++ b/docs/design/web-shell-secondary-workspace-voice.md
@@ -32,7 +32,7 @@ The composer already has the correct source data. In the main view, `activeWorks
 
 The merged protocol is authoritative: `workspace_qualified_voice` alone advertises all workspace-qualified Voice modalities. The legacy `workspace_voice`, `workspace_voice_transcription`, and `voice_transcribe` tags describe primary-bound routes and are not prerequisites for a secondary runtime.
 
-Issue #6972 originally asked for an intersection between `workspace_qualified_voice` and a legacy Voice capability. That would incorrectly hide a valid secondary configuration when the primary runtime has no Voice model or primary-only capability. The implementation and tests follow the merged protocol, and the issue wording must reflect that separation before implementation review.
+Issue #6972 originally asked for an intersection between `workspace_qualified_voice` and a legacy Voice capability. That would incorrectly hide a valid secondary configuration when the primary runtime has no Voice model or primary-only capability. The issue now reflects that separation, and the implementation and tests follow the merged protocol.
 
 The related model and Settings UI use core routes, not Voice routes, so their capability intersection is operation-specific:
 

--- a/docs/design/web-shell-secondary-workspace-voice.md
+++ b/docs/design/web-shell-secondary-workspace-voice.md
@@ -1,0 +1,402 @@
+# Web Shell Secondary-workspace Voice
+
+## Summary
+
+Web Shell Voice must use the same workspace owner as the composer that exposes the control. The main composer, a locked embed, and each split-view composer can therefore use either the legacy primary Voice routes or the workspace-qualified Voice routes, but a single capture must never change owners after it starts.
+
+The implementation should add a small Voice-specific target resolver and route adapter rather than retargeting the global `DaemonWorkspaceProvider` or general Settings state. The resolver feeds all existing Voice behavior: button visibility, Voice status, model discovery, the `voiceModel` setting, the streaming WebSocket, and stale-result rejection.
+
+This design implements issue #6972 on top of the daemon and SDK support merged in #6839. It does not change the daemon protocol, SDK public API, Voice schema, or the existing Voice UX.
+
+## Current state and failure
+
+The daemon and TypeScript SDK already expose trusted workspace-qualified Voice:
+
+- `GET` and `POST /workspaces/:workspace/voice`
+- `POST /workspaces/:workspace/voice/transcribe`
+- `WS /workspaces/:workspace/voice/stream`
+- `WorkspaceDaemonClient.workspaceVoice()`, `workspaceProviders()`, `workspaceSettings()`, and workspace-scoped `setWorkspaceSetting()`
+
+Web Shell does not use those surfaces for Voice today:
+
+- `VoiceButton` reads `workspace.client.workspaceVoice()`, so its enabled state is always primary.
+- `useVoiceCapture` always builds `<base>/voice/stream`, so audio always reaches the primary runtime.
+- `/model --voice`, the Voice model picker, and the Settings `voiceModel` row load and mutate the root workspace state.
+- `ChatEditor` creates `VoiceButton` without a workspace or session owner. Split-view panes therefore also use primary Voice regardless of their session workspace.
+- `useVoiceCapture` keeps the latest `onFinal` callback. A final frame from an old capture can consequently call a composer callback installed after a workspace/session change unless the old capture has already been aborted.
+- The Vite development proxy's `/workspace` prefix already carries qualified REST requests, but no matching qualified Voice rule opts the WebSocket upgrade into proxying.
+
+The composer already has the correct source data. In the main view, `activeWorkspaceCwd` resolves the active session owner, otherwise the locked workspace, selected workspace, or primary workspace. Each split pane also knows its session id and workspace cwd. Voice should consume those values instead of inventing a second selection state.
+
+## Protocol correction
+
+The merged protocol is authoritative: `workspace_qualified_voice` alone advertises all workspace-qualified Voice modalities. The legacy `workspace_voice`, `workspace_voice_transcription`, and `voice_transcribe` tags describe primary-bound routes and are not prerequisites for a secondary runtime.
+
+Issue #6972 originally asked for an intersection between `workspace_qualified_voice` and a legacy Voice capability. That would incorrectly hide a valid secondary configuration when the primary runtime has no Voice model or primary-only capability. The implementation and tests follow the merged protocol, and the issue wording must reflect that separation before implementation review.
+
+The related model and Settings UI use core routes, not Voice routes, so their capability intersection is operation-specific:
+
+| Secondary operation                                           | Required capability                                      |
+| ------------------------------------------------------------- | -------------------------------------------------------- |
+| Voice status/update, batch transcription, streaming WebSocket | `workspace_qualified_voice`                              |
+| Provider discovery                                            | `workspace_qualified_rest_core`                          |
+| Qualified Settings read/write                                 | `workspace_qualified_rest_core` and `workspace_settings` |
+| Shared user-scope setting write                               | `workspace_settings`                                     |
+
+These extra tags gate only their matching model/Settings controls. A secondary composer with `workspace_qualified_voice` but without Settings persistence can still dictate; it must not be hidden merely because model selection is unavailable. Conversely, model/Settings controls must not infer core-route or persistence support from `workspace_qualified_voice`, and they must never substitute primary data when their own gate is absent.
+
+## Goals
+
+- Bind every existing Web Shell Voice operation to the composer owner.
+- Keep legacy primary and old single-workspace behavior unchanged.
+- Prefer a stable workspace id and use a correctly encoded absolute cwd only as a fallback.
+- Fail closed for missing, unknown, untrusted, removed, draining, or unsupported secondary workspaces.
+- Preserve the existing User/Workspace scope behavior of `voiceModel`.
+- Abort microphone, audio graph, timers, WebSocket, and callbacks when the target or owning session changes.
+- Never retry a qualified failure against a primary route.
+- Keep the change Voice-specific and small.
+
+## Non-goals
+
+- New Voice controls, settings, modes, or model schema.
+- A general multi-workspace rewrite of the Web Shell Settings panel.
+- Changes to daemon routes, ACP methods, SDK public methods, quotas, or admission policy.
+- Voice access for untrusted workspaces.
+- Per-workspace quotas or fairness.
+- Batch transcription UI.
+- Retargeting a running capture to a new workspace or session.
+
+## Ownership model
+
+Voice crosses several scopes. Each value must stay in its existing owner:
+
+| Concern                                                                | Owner                                   |
+| ---------------------------------------------------------------------- | --------------------------------------- |
+| Composer text and capture identity                                     | One main or split-view composer/session |
+| Voice status, effective model, provider environment, workspace setting | Resolved workspace runtime              |
+| User-scoped `voiceModel` write                                         | Existing process/user settings surface  |
+| Primary compatibility routes                                           | Legacy primary runtime                  |
+| Secondary Voice routes                                                 | Trusted registered selected runtime     |
+| Eight-operation Voice admission limit                                  | Daemon process                          |
+| Microphone, AudioContext, timers, WebSocket                            | One browser capture generation          |
+
+The process-global admission coordinator remains entirely server-side. The Web Shell should surface its errors but must not add a client-side quota.
+
+## Target resolution
+
+Add a pure Voice target resolver under `packages/web-shell/client/voice`. Its input is the intended composer workspace cwd, the daemon primary cwd, the merged registered-workspace list, and the composer session id. Its output is either no target or an immutable route descriptor:
+
+```ts
+type VoiceWorkspaceTarget =
+  | {
+      route: 'legacy-primary';
+      workspaceKey: string;
+      ownerKey: string;
+      cwd?: string;
+      streamPath: 'voice/stream';
+    }
+  | {
+      route: 'workspace-qualified';
+      workspaceKey: string;
+      ownerKey: string;
+      cwd: string;
+      selector: {
+        kind: 'id' | 'cwd';
+        value: string;
+      };
+      streamPath: string;
+    };
+```
+
+The descriptor contains data, not an SDK client. Small helpers choose `DaemonClient` or `WorkspaceDaemonClient` for each operation. This keeps construction and encoding in one place without adding a new provider or mutable service.
+
+Resolution order for the main composer remains:
+
+1. Active session `connection.workspaceCwd`.
+2. Embedder-locked workspace.
+3. Workspace selected for the next session.
+4. Registered primary workspace, falling back to `capabilities.workspaceCwd` for older single-workspace daemons.
+
+A split pane resolves from its own `connection.sessionId` and authoritative `connection.workspaceCwd`. Its explicit pane workspace cwd is a consistency check and a pre-connection hint, not an override: while a session id exists, a missing connection cwd or a mismatch between the connection and pane prop yields no Voice target. This prevents stale split-layout metadata from routing a live session's audio.
+
+Ownership resolution and operation support remain separate. The resolver applies only these ownership/trust gates:
+
+| Owner             | Required state                                           |
+| ----------------- | -------------------------------------------------------- |
+| Primary           | Cwd is the registered/compatibility primary              |
+| Secondary         | Exact unique registered cwd match and `trusted === true` |
+| Missing/ambiguous | No Voice workspace owner                                 |
+
+Small capability helpers then decide which operations the resolved owner supports:
+
+| Owner     | Dictation status/stream     | Model/Settings management                                                              |
+| --------- | --------------------------- | -------------------------------------------------------------------------------------- |
+| Primary   | `voice_transcribe`          | Preserve the existing legacy provider/Settings behavior                                |
+| Secondary | `workspace_qualified_voice` | `workspace_qualified_voice`, `workspace_qualified_rest_core`, and `workspace_settings` |
+
+Separating the owner from the operation gate preserves the current ability to configure a primary Voice model even on an older daemon where the streaming capability is absent. It also lets a qualified secondary dictate when Settings persistence is absent without exposing a non-functional model picker.
+
+An older daemon without `workspaces[]` may use only its compatibility primary cwd and legacy routes. Because it supplies no per-workspace trust projection, preserve the existing primary behavior rather than inventing an untrusted state. A very old daemon that exposes neither `workspaces[]` nor `workspaceCwd` may keep the opaque legacy-primary target only when it advertises no modern workspace feature; a modern session with no authoritative cwd fails closed. Neither form can synthesize a secondary target.
+
+For a qualified target, use a non-empty registered id first. If an id is unavailable, retain the raw absolute cwd as the selector. Encode the raw selector exactly once when constructing the path. SDK calls use `workspaceById(id)` or `workspaceByCwd(cwd)`, both of which own their own encoding.
+
+`workspaceKey` includes route kind, selector identity, and cwd. Re-registering the same cwd under a different runtime id therefore invalidates the old target. `ownerKey` additionally includes `session:<id>` or `draft:<workspaceKey>`. Replacing a session in the same workspace still invalidates a capture, while a pre-session composer remains stable until its selected workspace changes or a session is attached.
+
+## Main and split-view propagation
+
+`App` resolves the main target from the existing `activeWorkspaceCwd` and its merged workspace list, which includes an embedder-locked capability that may not yet be present in the first capabilities snapshot. It passes the descriptor through `ChatEditor` to `VoiceButton`.
+
+`App` also passes the same merged workspace list and Voice revision state through `SplitView` when the daemon supplied a workspace list or a locked runtime was registered locally. It leaves that prop absent for an old single-workspace daemon so `ChatPane` can retain the compatibility `workspaceCwd` fallback instead of having it shadowed by an empty list. `ChatPane` combines the applicable list with its pane connection, resolves a descriptor, and passes it through its own `ChatEditor`. This matters for a just-registered locked runtime that exists in the local merged list even if the subsequent global capabilities refresh failed. `ChatEditor` remains a presentational pass-through and does not query daemon ownership itself.
+
+Passing the resolved descriptor is preferable to resolving inside `VoiceButton`: the main App owns the locked/selected precedence and is the only layer with the merged locked capability. It also makes target resolution independently testable.
+
+## Status and button gate
+
+`VoiceButton` always receives the resolved owner while the composer owns it, independently of temporary status revalidation. It applies the owner's dictation capability and keeps its existing fail-closed status gate, keyed by:
+
+- `target.workspaceKey`
+- `target.ownerKey`
+- the current session provider's `settingsVersion` only when that session's cwd equals the target cwd
+- the target-relevant App-owned Voice revisions incremented after local Voice model writes and propagated to the main and split-view buttons
+- a local revalidation revision used after unexpected socket closure
+
+For a primary target it calls legacy `client.workspaceVoice()`. For a qualified target it calls the corresponding `WorkspaceDaemonClient.workspaceVoice()`. Each request captures a monotonically increasing status-request generation in addition to the target keys. The request starts from a hidden state, and only the latest generation may update the gate; this covers both a simple target switch and an A → B → A sequence.
+
+The button appears only after the selected route reports `enabled: true`. A qualified response must also echo the target's canonical `workspaceCwd`; a mismatched response is treated as stale/invalid. A missing target, pending request, request error, feature loss, trust loss, owner change, or mismatched response hides the control. The capture hook keeps the same resolved target during same-owner status revalidation so a retryable connection error is not mistaken for an owner change and erased; a real owner or stream-path change still clears target-local state. If any invalid gate affects connecting, recording, or transcribing, the capture is aborted.
+
+No qualified status error may trigger a legacy request. HTTP `400 workspace_mismatch`, `403 untrusted_workspace`, and `503 workspace_draining` remain terminal for that revalidation.
+
+The App-owned revision state has one user-settings counter and a counter per `workspaceKey`. User-scope Voice writes increment the shared counter because they affect every runtime; workspace-scope writes increment only the captured target's counter. A button keys on the shared counter plus its own workspace counter, so changing workspace A does not abort an unrelated capture in workspace B.
+
+An active main or split session also receives its runtime's `settingsVersion` from that session event stream. Ignore an outer/provider signal whose connection cwd does not match the resolved owner, which can occur for a draft selected for another workspace. A draft/locked secondary composer has no workspace event stream before session creation, so it refreshes on target/capability changes and the App-owned revision after local writes. This design does not add polling or a second hidden session solely to observe out-of-process settings edits; a later target change, explicit Settings reload, capture revalidation, or page refresh reconciles those edits.
+
+## Voice model discovery and setting scope
+
+The existing Voice model UI is retained, but its data access becomes target-aware and independently capability-gated. Ownership resolution does not reject a valid dictation target because a core REST or Settings capability is absent.
+
+### Model candidates
+
+When opening `/model --voice` or the Voice model picker:
+
+- Primary preserves the existing behavior and loads legacy `/workspace/providers`.
+- Secondary first requires `workspace_qualified_voice`, `workspace_qualified_rest_core`, and `workspace_settings`, then loads `/workspaces/:workspace/providers` through the same qualified target.
+- The existing `extractVoiceModels()` and `ModelDialog` continue to render the result.
+
+The picker is a setting mutation surface, so a read-only provider list without `workspace_settings` is not useful enough to justify a new disabled-picker state. If any secondary gate is absent, do not issue the provider request; report an unsupported-capability error through the existing `model.setVoice` error path for a command entry point, and omit or disable the Settings entry point.
+
+The async request captures the target owner key and a monotonically increasing picker-intent generation; both success and error completion require both values before changing current UI. A new Voice request supersedes the previous one. Owner/capability changes, leaving the request's originating surface (chat for a command, Settings for a Settings click), opening any competing model/fallback/auth surface, explicit dismissal, and unmount also invalidate the pending intent, so a slow provider response cannot reopen a surface the user has already left. The generation changes as soon as a committed owner or capability transition occurs, which also rejects an old A response after an A → B → A sequence. For a qualified response, additionally require `workspaceCwd` to equal the target's canonical cwd before consuming it. If the response is no longer current or names a different runtime, discard it and do not open the picker. If a Voice picker is already open when its owner or capability gate changes, close it without applying a selection.
+
+The qualified Voice status also contains `availableVoiceModels`; it remains useful evidence that the runtime resolved its Voice transports, but it should not replace the provider response in the picker because the current UI preserves provider labels and metadata.
+
+### Settings read
+
+For a secondary main target with `workspace_qualified_voice`, `workspace_qualified_rest_core`, and `workspace_settings`, load qualified `/workspaces/:workspace/settings` and replace only the `voiceModel` descriptor in the Settings state passed to `SettingsMessage`. Reload that descriptor on target key, matching target-session `settingsVersion`, and target-relevant local Voice revisions. Derive the Voice picker's `currentModel` from that same overlaid descriptor; leaving the existing `currentVoiceModel` calculation on the root settings would still highlight the primary value. Other setting descriptors keep their current behavior and are outside this issue.
+
+Until the qualified descriptor loads, or when any required capability is absent, omit or disable the secondary `voiceModel` row rather than displaying the primary value. If there is no valid trusted workspace owner, do the same for all Voice model entry points instead of leaving a primary-backed control visible. The primary row and picker keep their current legacy availability even when primary dictation is unsupported. A settings-request generation rejects late successes and failures even after an A → B → A target sequence. The qualified response already contains effective, user, and workspace values, so it can preserve the current scope-specific selection display.
+
+### Settings write
+
+Use the existing scope semantics:
+
+| Target    | Scope     | Write                                                                                                                       |
+| --------- | --------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Primary   | User      | Legacy `setWorkspaceSetting('user', 'voiceModel', value)`                                                                   |
+| Primary   | Workspace | Legacy `setWorkspaceSetting('workspace', 'voiceModel', value)`                                                              |
+| Secondary | User      | Legacy user-scoped setting write, because user settings are shared and the qualified route intentionally forbids user scope |
+| Secondary | Workspace | Qualified `WorkspaceDaemonClient.setWorkspaceSetting('workspace', 'voiceModel', value)`                                     |
+
+Every secondary model-management entry point requires `workspace_qualified_voice`, `workspace_qualified_rest_core`, and `workspace_settings`. The user-scope write itself still goes through the shared legacy route, but that does not bypass the entry point's qualified provider/Settings gates. The picker rechecks the gates at selection time rather than trusting the state from when it opened.
+
+After a successful local Voice model write, increment the shared user revision for user scope or the captured target's workspace revision for workspace scope. Pass the relevant pair to every main and split-view `VoiceButton`. For a secondary target, also explicitly reload the target Voice settings. `VoiceButton` includes those revisions in its status key and therefore reloads the target Voice status. A user-scoped write is broadcast on the primary bridge and a pre-session secondary composer may have no target event stream, so relying only on `settingsVersion` would leave the secondary UI stale.
+
+The main composer's locally handled `/model --voice <id>` uses the same adapter. It snapshots the invocation target. A concurrent removal is rejected by the runtime generation guard; the client never retries another route. Split panes continue sending their session-scoped daemon command through their own `DaemonSessionProvider`; this design does not reroute that command through the outer App.
+
+The Voice picker stores its opening target and scope together. Selection is refused if the current owner no longer matches, preventing a picker opened for workspace A from writing workspace B.
+
+## Streaming capture
+
+Change `useVoiceCapture` to accept an immutable capture target containing `ownerKey` and `streamPath`, in addition to base URL and token.
+
+URL construction becomes:
+
+- Primary: `<base>/voice/stream`
+- Qualified id: `<base>/workspaces/<encoded-id>/voice/stream`
+- Qualified cwd fallback: `<base>/workspaces/<encodeURIComponent(absolute-cwd)>/voice/stream`
+
+Reverse-proxy base paths remain preserved. Bearer authentication continues to offer `qwen-ws` plus `qwen-bearer.<base64url-token>` and never puts the token in a URL.
+
+At `start()`, the hook snapshots:
+
+- capture generation
+- owner key
+- stream path
+- final/error callbacks
+
+Every microphone continuation, audio callback, WebSocket callback, timer, and final delivery checks that snapshot. A layout-timed owner/route change aborts the generation before browser events can run for the newly committed composer, even when the old generation is already in an error/notice state. It also clears target-local error, notice, interim, level, and timer state so workspace B never displays workspace A's result. The hook must not use a newly rendered `onFinal` callback for an older capture.
+
+Abort remains idempotent and performs all cleanup:
+
+- stop every media track, including a track returned after a pending `getUserMedia`
+- disconnect ScriptProcessor/source/sink nodes
+- close the AudioContext
+- clear response/finalization timers
+- send `abort` when the socket is open
+- detach socket handlers and close the socket
+- clear interim text and audio level
+- invalidate the generation before any asynchronous completion can publish
+
+A final transcript is inserted only when generation and owner still match. Empty final text keeps the existing no-speech notice.
+
+## Socket closure and lifecycle changes
+
+The backend already closes runtime leases with `1012` for workspace removal, trust reconfiguration, or daemon shutdown, and uses an error frame plus `1013` for capacity.
+
+Add an optional structured unexpected-close callback from `useVoiceCapture` to `VoiceButton`. A close before a final result and without a preceding terminal `error` frame is classified by close code. Ownership-ambiguous closes such as `1012`, `1006`, or an unexpected application failure invalidate the status gate and start a route revalidation; while it is pending, the button is hidden and cannot restart microphone work. Capacity `1013` is the one close-only exception because it is process-scoped and says nothing about target validity. A terminal `error` frame already owns cleanup and user-visible retry state; its later close is detached during cleanup and must not trigger a second generic failure or gate invalidation.
+
+- `1012`: also refresh daemon capabilities. A removed or untrusted target then disappears. If refresh fails, keep the local gate invalid instead of exposing Retry.
+- `1013`: the preceding capacity error frame remains the user-facing retry message and the target gate stays valid, so Retry remains visible. If a malformed peer sends `1013` without an error frame, show the generic capacity message without crossing routes.
+- `1006` or another unexpected close: re-read the exact target status. A concurrent 400/403/503 stays hidden; a still-valid enabled target may return as a retry control.
+- `1000` after final/abort: normal cleanup, no revalidation.
+
+This client revalidation improves UX but is not the security boundary. The daemon still resolves trust/generation after authentication and never falls back to primary.
+
+## Development proxy
+
+Add a narrow qualified Voice WebSocket rule next to, preferably before, the existing `/workspace` prefix:
+
+```ts
+'^/workspaces/[^/]+/voice/stream/?$': { ...daemonProxy, ws: true },
+'/workspace': daemonProxy,
+```
+
+Vite treats a proxy key beginning with `^` as a regular expression. Its upgrade loop ignores matching contexts that do not opt into WebSockets, so declaration order is not a correctness dependency in the current Vite version; keeping the specific upgrade rule before the broad REST prefix nevertheless makes the overlap explicit. The narrow suffix does not match client-side `/voice/*` TypeScript modules. Qualified REST continues through the existing `/workspace` prefix.
+
+Keep the existing exact `/voice/stream` rule for primary compatibility.
+
+## Error behavior
+
+| Failure                                           | UI behavior                                                                                          | Fallback |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | -------- |
+| Target unknown/unregistered                       | Voice hidden                                                                                         | None     |
+| Target known untrusted                            | Voice hidden before status or mic                                                                    | None     |
+| Primary `voice_transcribe` absent                 | Primary dictation hidden; existing primary model configuration remains available                     | None     |
+| Secondary `workspace_qualified_voice` absent      | Secondary dictation and model configuration hidden                                                   | None     |
+| Qualified core REST or Settings capability absent | Secondary model/Settings control hidden or command reported unsupported; dictation remains available | None     |
+| Status/settings/providers 400, 403, or 503        | Relevant control hidden/closed; report model action error where already expected                     | None     |
+| Status/provider response names another cwd        | Discard response and keep relevant control hidden                                                    | None     |
+| Voice disabled                                    | Voice hidden                                                                                         | None     |
+| Model missing/invalid                             | Existing server error message and retry behavior                                                     | None     |
+| Capacity                                          | Existing “try again shortly” error; retry remains available                                          | None     |
+| Removal/trust change during capture               | Abort resources, discard callbacks, hide while capabilities/status revalidate                        | None     |
+| Session/workspace switch                          | Abort resources, close open Voice picker, discard stale responses/transcript                         | None     |
+| Network/socket interruption                       | Release mic immediately, revalidate exact target, then allow retry only if still valid               | None     |
+
+## Implementation slices
+
+1. Add the pure ownership resolver, per-operation capability helpers, route helpers, and focused tests.
+2. Pass resolved targets through the main and split-view `ChatEditor` paths.
+3. Make `VoiceButton` status reads and `useVoiceCapture` URLs/ownership target-aware.
+4. Make Voice model provider loading and only the `voiceModel` setting descriptor/mutation target-aware.
+5. Add the narrow Vite qualified Voice WebSocket proxy rule.
+6. Add focused unit/component tests, then the E2E coverage and evidence described below.
+
+This ordering keeps each step reviewable and allows the capture safety work to be tested independently of the model/settings integration.
+
+## Test strategy
+
+### Pure/unit tests
+
+- Primary, selected secondary, active-session, locked, split-pane, old single-workspace (including split propagation), unknown, removed, and untrusted target resolution.
+- A session id with a missing workspace cwd, or a split pane whose explicit cwd disagrees with its connection, resolves to no target.
+- Split resolution consumes the App's merged workspace list, including a locally registered locked capability not yet present in global capabilities.
+- Ownership resolution is independent of capability; the capture gate requires only `workspace_qualified_voice` for secondary and `voice_transcribe` for primary.
+- Secondary dictation remains available with only `workspace_qualified_voice`; model/Settings entry points separately require `workspace_qualified_rest_core` and `workspace_settings`.
+- Primary model configuration remains available when the primary capture gate is absent.
+- Stable id preference, cwd fallback, POSIX/Windows-drive/UNC paths, spaces/non-ASCII cwd encoding, reverse-proxy base paths, and no double encoding.
+- Qualified status/providers/settings calls never call a legacy alternative after failure.
+- Qualified status and provider responses with a mismatched `workspaceCwd` are rejected.
+- User/workspace Voice model scope routing matches the table above.
+- A workspace-scope write revalidates only buttons for that workspace; a user-scope write revalidates all Voice targets.
+- A settings-version signal from a different workspace does not revalidate or abort the current target.
+- Stale status, settings, provider, and picker successes or failures cannot affect UI after owner changes, including A → B → A.
+- Pending Voice picker loads cannot reopen after their Settings panel closes or another model/auth surface supersedes them.
+- Target/session changes in connecting, recording, and transcribing abort once and discard final/interim/error callbacks.
+- Target changes from idle, error, and no-speech states also clear the old target's error/notice state.
+- Pending microphone acquisition is stopped after target invalidation.
+- Qualified `1012`/`1006` invalidation, error-frame/`1013` retry preservation, normal final, timeout, and unmount cleanup.
+- Main and split `ChatEditor` pass the intended Voice target.
+
+### Integration/E2E
+
+- Real daemon with primary plus trusted secondary, Voice enabled/model configuration isolated between them.
+- Main pre-session workspace selection, active secondary session, locked secondary embed, primary, and split pane.
+- Qualified status/provider/settings requests and qualified Voice WebSocket upgrade by id.
+- Cwd fallback encoding in a focused browser/hook integration fixture.
+- Mid-capture workspace switch, session replacement, removal, and trust/capability loss.
+- Primary token/no-token bearer-subprotocol compatibility.
+- Development Vite proxy upgrades both legacy and qualified Voice sockets without proxying `/voice/voiceModels.ts`.
+
+The detailed execution plan lives in `.qwen/e2e-tests/web-shell-secondary-workspace-voice.md`.
+
+## Compatibility and rollout
+
+- No protocol or SDK version change.
+- Primary continues to use only the legacy status/settings/providers/stream routes.
+- Primary model configuration keeps its existing availability even when primary dictation is unsupported.
+- Older daemons without `workspace_qualified_voice` retain primary Voice and hide secondary Voice.
+- A secondary with qualified Voice but no Settings persistence can dictate while its model/Settings mutation controls stay unavailable.
+- Host `visibleToolbarActions` remains the outer Voice gate.
+- Existing button labels, waveform, timers, empty-speech notice, model dialog, and setting scopes remain unchanged.
+- No automatic fallback or retry crosses workspace ownership.
+
+## Risks and mitigations
+
+### A broad Settings refactor expands the issue
+
+Only the `voiceModel` descriptor and mutation are overlaid for a secondary target. Other Settings ownership remains out of scope.
+
+### A late final reaches a different composer
+
+The capture snapshots its callback and owner, target changes invalidate the generation in layout timing, and final delivery rechecks both.
+
+### Same-cwd runtime replacement looks unchanged
+
+The target key includes the preferred runtime id, not only cwd.
+
+### A Voice picker writes after navigation
+
+The picker stores its opening owner and closes/refuses selection after an owner change.
+
+### The dev proxy has overlapping REST and WebSocket contexts
+
+The qualified rule is limited to the Voice stream suffix and explicitly enables WebSockets. It is kept next to and before `/workspace` so future proxy changes do not obscure the overlap.
+
+### User-scope writes appear primary-bound
+
+That is the intended settings ownership: user scope is shared and qualified settings writes are workspace-only. Target status/settings are explicitly reloaded after the global write.
+
+## Alternatives rejected
+
+### Retarget the global `DaemonWorkspaceProvider`
+
+The provider owns process/global discovery and many primary compatibility surfaces. Retargeting it would change unrelated settings, extensions, auth, and sidebar behavior and would not work for simultaneous split panes.
+
+### Always use qualified routes, including primary
+
+This would unnecessarily drop compatibility with older daemons and violate the explicit legacy-primary contract.
+
+### Resolve the target inside `VoiceButton`
+
+The button cannot reconstruct locked-workspace merging or main selection precedence, and it would duplicate split/main ownership logic.
+
+### Keep the latest final callback and rely on effect cleanup
+
+WebSocket events can race a committed owner change before passive cleanup. Snapshotting the owner/callback and invalidating in layout timing closes that window.
+
+### Use `availableVoiceModels` alone for the picker
+
+It proves runtime Voice availability but lacks the labels and provider metadata the existing picker already renders.
+
+### Retry a failed secondary request on legacy primary
+
+This is an ownership and trust violation and is forbidden by the protocol.

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -55,7 +55,11 @@ type ChatEditorTestProps = {
   skills?: Array<{ name: string; description: string }>;
   commands?: Array<{ name: string }>;
   isPreparing?: boolean;
+  disabled?: boolean;
   dialogOpen?: boolean;
+  onToggleShortcuts?: () => void;
+  voiceTarget?: VoiceWorkspaceTarget;
+  voiceStatusRevision?: VoiceStatusRevision;
   placeholderText?: string;
   workspaces?: Array<{ id: string; cwd: string }>;
   atWorkspaceCwd?: string;
@@ -7710,9 +7714,17 @@ describe('App session callbacks', () => {
     // flips false. Unless dialogOpen also keys off the pending approval,
     // useComposerCore refocuses the composer and ToolApproval — which ignores
     // keys from editable targets — stops responding to its approval shortcuts.
+    mockWorkspace.capabilities = {
+      workspaceCwd: '/tmp/project',
+      features: ['voice_transcribe'],
+    } as typeof mockWorkspace.capabilities;
     const { rerender } = renderApp();
     await flush();
     expect(testState.latestChatEditorProps?.dialogOpen).toBe(false);
+    const voiceTarget = testState.latestChatEditorProps?.voiceTarget;
+    const voiceStatusRevision =
+      testState.latestChatEditorProps?.voiceStatusRevision;
+    expect(voiceTarget).toBeDefined();
 
     await act(async () => {
       testState.blocks = [makePendingPermissionBlock()];
@@ -7721,6 +7733,33 @@ describe('App session callbacks', () => {
     });
 
     expect(testState.latestChatEditorProps?.dialogOpen).toBe(true);
+    expect(testState.latestChatEditorProps?.disabled).toBe(true);
+    expect(testState.latestChatEditorProps?.voiceTarget).toBe(voiceTarget);
+    expect(testState.latestChatEditorProps?.voiceStatusRevision).toBe(
+      voiceStatusRevision,
+    );
+  });
+
+  it('keeps an active Voice owner stable while a normal dialog is open', async () => {
+    mockWorkspace.capabilities = {
+      workspaceCwd: '/tmp/project',
+      features: ['voice_transcribe'],
+    } as typeof mockWorkspace.capabilities;
+    const { container } = renderApp();
+    await flush();
+    const voiceTarget = testState.latestChatEditorProps?.voiceTarget;
+    expect(voiceTarget).toBeDefined();
+
+    act(() => {
+      testState.latestChatEditorProps?.onToggleShortcuts?.();
+    });
+    await flush();
+
+    expect(
+      container.querySelector('[data-testid="dialog-shell"]'),
+    ).not.toBeNull();
+    expect(testState.latestChatEditorProps?.disabled).toBe(true);
+    expect(testState.latestChatEditorProps?.voiceTarget).toBe(voiceTarget);
   });
 
   it('dismisses an open sub-dialog (model picker) when an approval becomes pending', async () => {

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -5,10 +5,15 @@ import { createRoot, type Root } from 'react-dom/client';
 import type {
   DaemonInputAnnotation,
   DaemonSessionMonitorTaskStatus,
+  DaemonSettingDescriptor,
   DaemonWorkspaceGitStatus,
 } from '@qwen-code/sdk/daemon';
 import type { WebShellApi } from './App';
 import type { Message } from './adapters/types';
+import type {
+  VoiceStatusRevision,
+  VoiceWorkspaceTarget,
+} from './voice/voice-workspace-target';
 import { loadSplitSessions, saveSplitSessions } from './utils/splitUrl';
 
 type StreamingState = 'idle' | 'responding';
@@ -32,6 +37,8 @@ type MockConnection = {
   missingSession?: boolean;
   gitBranch?: string;
   gitStatus?: DaemonWorkspaceGitStatus;
+  voiceTarget?: VoiceWorkspaceTarget;
+  voiceStatusRevision?: VoiceStatusRevision;
 };
 
 type ChatEditorTestProps = {
@@ -75,6 +82,18 @@ type AddWorkspaceDialogTestProps = {
   persistenceSupported?: boolean;
 };
 
+function voiceSetting(effective: string): DaemonSettingDescriptor {
+  return {
+    key: 'voiceModel',
+    type: 'string',
+    label: 'Voice model',
+    category: 'model',
+    requiresRestart: false,
+    default: '',
+    values: { effective, workspace: effective },
+  };
+}
+
 const {
   mockConnection,
   mockSessionActions,
@@ -91,6 +110,11 @@ const {
   editorFocus,
   editorInsertText,
   settingsReload,
+  settingsSetValue,
+  qualifiedWorkspaceSettings,
+  rootWorkspaceProviders,
+  qualifiedWorkspaceProviders,
+  qualifiedSetWorkspaceSetting,
 } = vi.hoisted(() => {
   const connection: MockConnection = {
     status: 'connected',
@@ -108,6 +132,10 @@ const {
     catchingUp: false,
   };
   const loadSkillsStatus = vi.fn().mockResolvedValue({ skills: [] });
+  const qualifiedWorkspaceSettings = vi.fn();
+  const rootWorkspaceProviders = vi.fn();
+  const qualifiedWorkspaceProviders = vi.fn();
+  const qualifiedSetWorkspaceSetting = vi.fn();
   const workspaceClient = {
     workspaceByCwd: vi.fn(() => ({
       workspaceGit: vi.fn().mockResolvedValue({ branch: 'main' }),
@@ -119,8 +147,15 @@ const {
         pullRequests: [],
       }),
     })),
+    workspaceProviders: rootWorkspaceProviders,
+    workspaceById: vi.fn(() => ({
+      workspaceSettings: qualifiedWorkspaceSettings,
+      workspaceProviders: qualifiedWorkspaceProviders,
+      setWorkspaceSetting: qualifiedSetWorkspaceSetting,
+    })),
     sessionStatus: vi.fn(() => Promise.resolve({})),
   };
+  const settingsSetValue = vi.fn().mockResolvedValue(undefined);
   return {
     mockConnection: connection,
     mockSessionActions: {
@@ -219,6 +254,10 @@ const {
       latestTasksStatusProps: null as {
         onOpenMonitor?: (task: DaemonSessionMonitorTaskStatus) => void;
       } | null,
+      settings: [] as DaemonSettingDescriptor[],
+      latestSettingsState: null as {
+        settings: DaemonSettingDescriptor[];
+      } | null,
       latestScheduledTasksProps: null as {
         onRunPrompt?: (
           prompt: string,
@@ -240,6 +279,11 @@ const {
     editorFocus: vi.fn(),
     editorInsertText: vi.fn(),
     settingsReload: vi.fn().mockResolvedValue(undefined),
+    settingsSetValue,
+    qualifiedWorkspaceSettings,
+    rootWorkspaceProviders,
+    qualifiedWorkspaceProviders,
+    qualifiedSetWorkspaceSetting,
   };
 });
 
@@ -256,8 +300,8 @@ vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
   useSessionNotices: () => ({ notices: [], dismissNotice: vi.fn() }),
   usePromptStatus: () => 'idle',
   useSettings: () => ({
-    settings: [],
-    setValue: vi.fn().mockResolvedValue(undefined),
+    settings: testState.settings,
+    setValue: settingsSetValue,
     reload: settingsReload,
     loading: false,
   }),
@@ -473,13 +517,17 @@ vi.mock('./components/messages/SettingsMessage', async () => {
   const React = await import('react');
   return {
     SettingsMessage: (props: {
+      settingsState: {
+        settings: DaemonSettingDescriptor[];
+      };
       onSubDialog?: (key: string, scope: 'user' | 'workspace') => void;
       onLanguageChange?: (
         language: string,
         scope: 'user' | 'workspace',
       ) => void;
-    }) =>
-      React.createElement(
+    }) => {
+      testState.latestSettingsState = props.settingsState;
+      return React.createElement(
         'div',
         { 'data-testid': 'settings-message' },
         React.createElement(
@@ -506,6 +554,24 @@ vi.mock('./components/messages/SettingsMessage', async () => {
         React.createElement(
           'button',
           {
+            'data-testid': 'open-voice-model',
+            type: 'button',
+            onClick: () => props.onSubDialog?.('voiceModel', 'workspace'),
+          },
+          'voice model',
+        ),
+        React.createElement(
+          'button',
+          {
+            'data-testid': 'open-voice-model-user',
+            type: 'button',
+            onClick: () => props.onSubDialog?.('voiceModel', 'user'),
+          },
+          'voice model (user)',
+        ),
+        React.createElement(
+          'button',
+          {
             'data-testid': 'change-language-workspace',
             type: 'button',
             // Workspace tab language change → /language ui en --project.
@@ -513,7 +579,8 @@ vi.mock('./components/messages/SettingsMessage', async () => {
           },
           'language (workspace)',
         ),
-      ),
+      );
+    },
   };
 });
 
@@ -697,6 +764,7 @@ vi.doMock('./components/SplitView', async () => {
         workspaceActions: unknown,
       ) => void;
       onRightPanelOpen?: (request: unknown) => void;
+      voiceWorkspaces?: readonly unknown[];
     }) => {
       const paneActions = {
         readWorkspaceFile: vi.fn().mockResolvedValue('<p>pane</p>'),
@@ -725,6 +793,13 @@ vi.doMock('./components/SplitView', async () => {
           'span',
           { 'data-testid': 'split-initial' },
           (props.sessionIds ?? []).join(','),
+        ),
+        React.createElement(
+          'span',
+          { 'data-testid': 'split-voice-workspaces' },
+          props.voiceWorkspaces === undefined
+            ? 'legacy'
+            : String(props.voiceWorkspaces.length),
         ),
         // Simulate the real SplitView reporting its live pane set up to the App.
         React.createElement(
@@ -1409,6 +1484,7 @@ beforeEach(() => {
     mockWorkspace.capabilities,
   );
   mockWorkspace.client.workspaceByCwd.mockClear();
+  mockWorkspace.client.workspaceById.mockClear();
   testState.prompt = 'hello';
   testState.inputAnnotations = undefined;
   testState.promptImages = undefined;
@@ -1423,6 +1499,8 @@ beforeEach(() => {
   testState.backgroundTasks = [];
   testState.latestMonitorDetailsOnOpen = null;
   testState.latestTasksStatusProps = null;
+  testState.settings = [];
+  testState.latestSettingsState = null;
   testState.latestScheduledTasksProps = null;
   testState.latestGoalsProps = null;
   sidebarTokens.length = 0;
@@ -1433,6 +1511,34 @@ beforeEach(() => {
   editorInsertText.mockClear();
   settingsReload.mockClear();
   settingsReload.mockResolvedValue(undefined);
+  settingsSetValue.mockReset();
+  settingsSetValue.mockResolvedValue(undefined);
+  qualifiedWorkspaceSettings.mockReset();
+  qualifiedWorkspaceSettings.mockResolvedValue({
+    v: 1,
+    settings: [],
+  });
+  rootWorkspaceProviders.mockReset();
+  rootWorkspaceProviders.mockResolvedValue({
+    v: 1,
+    workspaceCwd: '/work/primary',
+    initialized: true,
+    providers: [],
+  });
+  qualifiedWorkspaceProviders.mockReset();
+  qualifiedWorkspaceProviders.mockResolvedValue({
+    v: 1,
+    workspaceCwd: '/work/secondary',
+    initialized: true,
+    providers: [],
+  });
+  qualifiedSetWorkspaceSetting.mockReset();
+  qualifiedSetWorkspaceSetting.mockResolvedValue({
+    key: 'voiceModel',
+    scope: 'workspace',
+    value: 'fast-model-x',
+    requiresRestart: false,
+  });
   mockFollowup.clear.mockClear();
   for (const value of Object.values(mockSessionActions)) {
     if (typeof value === 'function' && 'mockClear' in value) value.mockClear();
@@ -2693,6 +2799,509 @@ describe('App shell command queueing', () => {
 });
 
 describe('App session callbacks', () => {
+  it('binds the main composer Voice target to its active secondary session', async () => {
+    mockConnection.workspaceCwd = '/work/secondary';
+    mockWorkspace.capabilities = {
+      workspaceCwd: '/work/primary',
+      features: ['workspace_qualified_voice'],
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/work/primary',
+          primary: true,
+          trusted: true,
+        },
+        {
+          id: 'secondary',
+          cwd: '/work/secondary',
+          primary: false,
+          trusted: true,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+
+    renderApp();
+    await flush();
+
+    expect(testState.latestChatEditorProps?.voiceTarget).toMatchObject({
+      route: 'workspace-qualified',
+      cwd: '/work/secondary',
+      selector: { kind: 'id', value: 'secondary' },
+      sessionId: 'session-1',
+      streamPath: 'workspaces/secondary/voice/stream',
+    });
+    expect(testState.latestChatEditorProps?.voiceStatusRevision).toEqual({
+      user: 0,
+      workspace: 0,
+    });
+  });
+
+  it('keeps primary Voice model reads and writes on legacy routes', async () => {
+    mockConnection.workspaceCwd = '/work/primary';
+    mockWorkspace.capabilities = {
+      workspaceCwd: '/work/primary',
+      features: [],
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/work/primary',
+          primary: true,
+          trusted: false,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+    const { container } = renderApp();
+    await flush();
+
+    act(() => {
+      testState.latestChatEditorProps?.onSubmit('/model --voice');
+    });
+    await flush();
+
+    expect(rootWorkspaceProviders).toHaveBeenCalledOnce();
+    expect(qualifiedWorkspaceProviders).not.toHaveBeenCalled();
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="model-select"]')
+        ?.click();
+      await Promise.resolve();
+    });
+
+    expect(settingsSetValue).toHaveBeenCalledWith(
+      'workspace',
+      'voiceModel',
+      'fast-model-x',
+    );
+    expect(qualifiedSetWorkspaceSetting).not.toHaveBeenCalled();
+  });
+
+  it('uses qualified providers and workspace settings for secondary Voice models', async () => {
+    mockConnection.workspaceCwd = '/work/secondary';
+    mockWorkspace.capabilities = {
+      workspaceCwd: '/work/primary',
+      features: [
+        'workspace_qualified_voice',
+        'workspace_qualified_rest_core',
+        'workspace_settings',
+      ],
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/work/primary',
+          primary: true,
+          trusted: true,
+        },
+        {
+          id: 'secondary',
+          cwd: '/work/secondary',
+          primary: false,
+          trusted: true,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+    const { container } = renderApp();
+    await flush();
+
+    await act(async () => {
+      testState.latestChatEditorProps?.onSubmit('/model --voice');
+      await Promise.resolve();
+    });
+
+    expect(qualifiedWorkspaceProviders).toHaveBeenCalledOnce();
+    expect(mockWorkspaceActions.loadProviders).not.toHaveBeenCalled();
+    const select = container.querySelector<HTMLButtonElement>(
+      '[data-testid="model-select"]',
+    );
+    expect(select).not.toBeNull();
+    await act(async () => {
+      select?.click();
+      await Promise.resolve();
+    });
+
+    expect(qualifiedSetWorkspaceSetting).toHaveBeenCalledWith(
+      'workspace',
+      'voiceModel',
+      'fast-model-x',
+    );
+    expect(settingsSetValue).not.toHaveBeenCalled();
+  });
+
+  it('never exposes the primary Voice setting while secondary settings load', async () => {
+    mockConnection.workspaceCwd = '/work/secondary';
+    mockWorkspace.capabilities = {
+      workspaceCwd: '/work/primary',
+      features: [
+        'workspace_qualified_voice',
+        'workspace_qualified_rest_core',
+        'workspace_settings',
+      ],
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/work/primary',
+          primary: true,
+          trusted: true,
+        },
+        {
+          id: 'secondary',
+          cwd: '/work/secondary',
+          primary: false,
+          trusted: true,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+    testState.settings = [voiceSetting('primary-voice')];
+    let resolveSettings: (status: {
+      v: 1;
+      settings: DaemonSettingDescriptor[];
+    }) => void = () => undefined;
+    qualifiedWorkspaceSettings.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSettings = resolve;
+      }),
+    );
+    const { container } = renderApp();
+    await flush();
+    testState.prompt = '/settings';
+    await clickSubmit(container);
+    await flush();
+
+    expect(
+      testState.latestSettingsState?.settings.find(
+        (setting) => setting.key === 'voiceModel',
+      ),
+    ).toBeUndefined();
+
+    await act(async () => {
+      resolveSettings({
+        v: 1,
+        settings: [voiceSetting('secondary-voice')],
+      });
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(
+      testState.latestSettingsState?.settings.find(
+        (setting) => setting.key === 'voiceModel',
+      )?.values.effective,
+    ).toBe('secondary-voice');
+  });
+
+  it('drops a provider failure after the Voice workspace changes', async () => {
+    mockConnection.workspaceCwd = '/work/secondary-a';
+    mockWorkspace.capabilities = {
+      workspaceCwd: '/work/primary',
+      features: [
+        'workspace_qualified_voice',
+        'workspace_qualified_rest_core',
+        'workspace_settings',
+      ],
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/work/primary',
+          primary: true,
+          trusted: true,
+        },
+        {
+          id: 'secondary-a',
+          cwd: '/work/secondary-a',
+          primary: false,
+          trusted: true,
+        },
+        {
+          id: 'secondary-b',
+          cwd: '/work/secondary-b',
+          primary: false,
+          trusted: true,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+    const providersResult = deferred();
+    qualifiedWorkspaceProviders.mockReturnValue(providersResult.promise);
+    const onToast = vi.fn();
+    const { container, rerender } = renderApp({ onToast });
+    await flush();
+
+    await act(async () => {
+      testState.latestChatEditorProps?.onSubmit('/model --voice');
+      await Promise.resolve();
+    });
+    expect(qualifiedWorkspaceProviders).toHaveBeenCalledOnce();
+
+    mockConnection.workspaceCwd = '/work/secondary-b';
+    rerender();
+    await flush();
+    await act(async () => {
+      providersResult.reject(new Error('old workspace failed'));
+      await Promise.resolve();
+    });
+
+    expect(onToast).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-testid="model-select"]')).toBeNull();
+  });
+
+  it('drops a stale provider success after an A to B to A workspace change', async () => {
+    mockConnection.workspaceCwd = '/work/secondary-a';
+    mockWorkspace.capabilities = {
+      workspaceCwd: '/work/primary',
+      features: [
+        'workspace_qualified_voice',
+        'workspace_qualified_rest_core',
+        'workspace_settings',
+      ],
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/work/primary',
+          primary: true,
+          trusted: true,
+        },
+        {
+          id: 'secondary-a',
+          cwd: '/work/secondary-a',
+          primary: false,
+          trusted: true,
+        },
+        {
+          id: 'secondary-b',
+          cwd: '/work/secondary-b',
+          primary: false,
+          trusted: true,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+    const providersResult = deferred<{
+      v: 1;
+      workspaceCwd: string;
+      initialized: boolean;
+      providers: never[];
+    }>();
+    qualifiedWorkspaceProviders.mockReturnValue(providersResult.promise);
+    const { container, rerender } = renderApp();
+    await flush();
+
+    act(() => {
+      testState.latestChatEditorProps?.onSubmit('/model --voice');
+    });
+    mockConnection.workspaceCwd = '/work/secondary-b';
+    rerender();
+    await flush();
+    mockConnection.workspaceCwd = '/work/secondary-a';
+    rerender();
+    await flush();
+
+    await act(async () => {
+      providersResult.resolve({
+        v: 1,
+        workspaceCwd: '/work/secondary-a',
+        initialized: true,
+        providers: [],
+      });
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(container.querySelector('[data-testid="model-select"]')).toBeNull();
+  });
+
+  it('drops a provider failure after the Web Shell unmounts', async () => {
+    mockConnection.workspaceCwd = '/work/secondary';
+    mockWorkspace.capabilities = {
+      workspaceCwd: '/work/primary',
+      features: [
+        'workspace_qualified_voice',
+        'workspace_qualified_rest_core',
+        'workspace_settings',
+      ],
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/work/primary',
+          primary: true,
+          trusted: true,
+        },
+        {
+          id: 'secondary',
+          cwd: '/work/secondary',
+          primary: false,
+          trusted: true,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+    const providersResult = deferred();
+    qualifiedWorkspaceProviders.mockReturnValue(providersResult.promise);
+    const onToast = vi.fn();
+    const { unmount } = renderApp({ onToast });
+    await flush();
+
+    act(() => {
+      testState.latestChatEditorProps?.onSubmit('/model --voice');
+    });
+    unmount();
+    await act(async () => {
+      providersResult.reject(new Error('late provider failure'));
+      await Promise.resolve();
+    });
+
+    expect(onToast).not.toHaveBeenCalled();
+  });
+
+  it('closes an open Voice picker when its capability gate is lost', async () => {
+    mockConnection.workspaceCwd = '/work/secondary';
+    mockWorkspace.capabilities = {
+      workspaceCwd: '/work/primary',
+      features: [
+        'workspace_qualified_voice',
+        'workspace_qualified_rest_core',
+        'workspace_settings',
+      ],
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/work/primary',
+          primary: true,
+          trusted: true,
+        },
+        {
+          id: 'secondary',
+          cwd: '/work/secondary',
+          primary: false,
+          trusted: true,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+    const { container, rerender } = renderApp();
+    await flush();
+
+    await act(async () => {
+      testState.latestChatEditorProps?.onSubmit('/model --voice');
+      await Promise.resolve();
+    });
+    expect(
+      container.querySelector('[data-testid="model-select"]'),
+    ).not.toBeNull();
+
+    mockWorkspace.capabilities = {
+      ...mockWorkspace.capabilities,
+      features: ['workspace_qualified_voice', 'workspace_qualified_rest_core'],
+    };
+    rerender();
+    await flush();
+
+    expect(container.querySelector('[data-testid="model-select"]')).toBeNull();
+  });
+
+  it('does not open a pending Voice picker after entering split view', async () => {
+    mockConnection.workspaceCwd = '/work/secondary';
+    mockWorkspace.capabilities = {
+      workspaceCwd: '/work/primary',
+      features: [
+        'workspace_qualified_voice',
+        'workspace_qualified_rest_core',
+        'workspace_settings',
+      ],
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/work/primary',
+          primary: true,
+          trusted: true,
+        },
+        {
+          id: 'secondary',
+          cwd: '/work/secondary',
+          primary: false,
+          trusted: true,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+    const providerStatus = {
+      v: 1 as const,
+      workspaceCwd: '/work/secondary',
+      initialized: true,
+      providers: [],
+    };
+    const providersResult = deferred<typeof providerStatus>();
+    qualifiedWorkspaceProviders.mockReturnValue(providersResult.promise);
+    const { container } = renderApp();
+    await flush();
+
+    await act(async () => {
+      testState.latestChatEditorProps?.onSubmit('/model --voice');
+      await Promise.resolve();
+    });
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="open-split-view"]')
+        ?.click();
+    });
+    await act(async () => {
+      providersResult.resolve(providerStatus);
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(container.querySelector('[data-testid="model-select"]')).toBeNull();
+  });
+
+  it('does not open a pending command Voice picker after entering Settings', async () => {
+    mockConnection.workspaceCwd = '/work/secondary';
+    mockWorkspace.capabilities = {
+      workspaceCwd: '/work/primary',
+      features: [
+        'workspace_qualified_voice',
+        'workspace_qualified_rest_core',
+        'workspace_settings',
+      ],
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/work/primary',
+          primary: true,
+          trusted: true,
+        },
+        {
+          id: 'secondary',
+          cwd: '/work/secondary',
+          primary: false,
+          trusted: true,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+    const providerStatus = {
+      v: 1 as const,
+      workspaceCwd: '/work/secondary',
+      initialized: true,
+      providers: [],
+    };
+    const providersResult = deferred<typeof providerStatus>();
+    qualifiedWorkspaceProviders.mockReturnValue(providersResult.promise);
+    const { container } = renderApp();
+    await flush();
+
+    act(() => {
+      testState.latestChatEditorProps?.onSubmit('/model --voice');
+      testState.latestChatEditorProps?.onSubmit('/settings');
+    });
+    expect(qualifiedWorkspaceProviders).toHaveBeenCalledOnce();
+    expect(
+      container.querySelector('[data-testid="inline-panel"]'),
+    ).not.toBeNull();
+
+    await act(async () => {
+      providersResult.resolve(providerStatus);
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(container.querySelector('[data-testid="model-select"]')).toBeNull();
+    expect(
+      container.querySelector('[data-testid="inline-panel"]'),
+    ).not.toBeNull();
+  });
+
   it('submits through a disconnected session when prompt SSE restart is enabled', async () => {
     mockConnection.status = 'disconnected';
     renderApp({ restartSseOnPrompt: true });
@@ -5729,6 +6338,22 @@ describe('App session callbacks', () => {
     expect(messages?.closest('[aria-hidden="true"]')).not.toBeNull();
   });
 
+  it('preserves the legacy split Voice workspace fallback', async () => {
+    mockWorkspace.capabilities = {
+      features: ['voice_transcribe'],
+      workspaceCwd: '/workspace',
+    } as typeof mockWorkspace.capabilities;
+    saveSplitSessions(['s1']);
+
+    const { container } = renderApp();
+    await flush();
+
+    expect(
+      container.querySelector('[data-testid="split-voice-workspaces"]')
+        ?.textContent,
+    ).toBe('legacy');
+  });
+
   it('restores a persisted split on load (survives a refresh)', async () => {
     // Simulate the storage left behind by a split that was open before a refresh.
     saveSplitSessions(['s1', 's2']);
@@ -7385,6 +8010,60 @@ describe('App session callbacks', () => {
         (c) => c[0] === '/model --fast fast-model-x --global',
       ),
     ).toBe(true);
+  });
+
+  it('keeps a secondary Voice user-scope write on the shared legacy setting route', async () => {
+    mockConnection.workspaceCwd = '/work/secondary';
+    mockWorkspace.capabilities = {
+      workspaceCwd: '/work/primary',
+      features: [
+        'workspace_qualified_voice',
+        'workspace_qualified_rest_core',
+        'workspace_settings',
+      ],
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/work/primary',
+          primary: true,
+          trusted: true,
+        },
+        {
+          id: 'secondary',
+          cwd: '/work/secondary',
+          primary: false,
+          trusted: true,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+    const { container } = renderApp();
+    await flush();
+    testState.prompt = '/settings';
+    await clickSubmit(container);
+    await flush();
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="open-voice-model-user"]',
+        )
+        ?.click();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="model-select"]')
+        ?.click();
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(settingsSetValue).toHaveBeenCalledWith(
+      'user',
+      'voiceModel',
+      'fast-model-x',
+    );
+    expect(qualifiedSetWorkspaceSetting).not.toHaveBeenCalled();
   });
 
   it('sends /language ui --project for a workspace-scoped language change from Settings', async () => {

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -2875,6 +2875,29 @@ describe('App session callbacks', () => {
     expect(qualifiedSetWorkspaceSetting).not.toHaveBeenCalled();
   });
 
+  it('keeps the legacy pre-session Voice fallback out of git status', async () => {
+    mockConnection.sessionId = undefined;
+    mockWorkspace.capabilities = {
+      workspaceCwd: '/workspace',
+      features: ['voice_transcribe'],
+    } as typeof mockWorkspace.capabilities;
+    const workspaceGit = vi.fn().mockResolvedValue({ branch: 'main' });
+    mockWorkspace.client.workspaceByCwd.mockImplementation(() => ({
+      workspaceGit,
+      workspaceSkills: mockWorkspaceActions.loadSkillsStatus,
+    }));
+
+    renderApp();
+    await flush();
+
+    expect(testState.latestChatEditorProps?.voiceTarget).toMatchObject({
+      route: 'legacy-primary',
+      cwd: '/workspace',
+      streamPath: 'voice/stream',
+    });
+    expect(workspaceGit).not.toHaveBeenCalled();
+  });
+
   it('uses qualified providers and workspace settings for secondary Voice models', async () => {
     mockConnection.workspaceCwd = '/work/secondary';
     mockWorkspace.capabilities = {

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -53,6 +53,14 @@ import { MonitorDetailsProvider } from './monitorDetailsContext';
 import { findMonitorTaskForTool } from './utils/monitorTasks';
 import { extractVoiceModels, type VoiceModelOption } from './voice/voiceModels';
 import {
+  loadVoiceProviders,
+  resolveVoiceWorkspaceTarget,
+  setVoiceModelSetting,
+  supportsVoiceModelSettings,
+  type VoiceStatusRevision,
+} from './voice/voice-workspace-target';
+import { useVoiceWorkspaceSettings } from './voice/use-voice-workspace-settings';
+import {
   ChatEditor,
   type ComposerToolbarAction,
 } from './components/ChatEditor';
@@ -1491,12 +1499,14 @@ export function App({
         ? connection.workspaceCwd
         : (lockedWorkspaceCwd ??
           selectedWorkspaceCwd ??
-          workspaces.find((entry) => entry.primary)?.cwd),
+          workspaces.find((entry) => entry.primary)?.cwd ??
+          workspace.capabilities?.workspaceCwd),
     [
       connection.sessionId,
       connection.workspaceCwd,
       lockedWorkspaceCwd,
       selectedWorkspaceCwd,
+      workspace.capabilities?.workspaceCwd,
       workspaces,
     ],
   );
@@ -2614,6 +2624,8 @@ export function App({
   >('workspace');
   const [showFallbacksDialog, setShowFallbacksDialog] = useState(false);
   const showFallbacksDialogRef = useRef(showFallbacksDialog);
+  modelDialogModeRef.current = modelDialogMode;
+  showFallbacksDialogRef.current = showFallbacksDialog;
   const [voiceModels, setVoiceModels] = useState<VoiceModelOption[]>([]);
   const [showApprovalModeDialog, setShowApprovalModeDialog] = useState(false);
   const [showResumeDialog, setShowResumeDialog] = useState(false);
@@ -2636,6 +2648,8 @@ export function App({
   const [mainView, setMainView] = useState<
     'chat' | 'scheduledTasks' | 'goals' | 'split'
   >('chat');
+  const mainViewRef = useRef(mainView);
+  mainViewRef.current = mainView;
   const useFloatingArtifactPanel =
     !canDockArtifactPanel || mainView === 'split';
   // Sessions to seed the split view with (e.g. the selection from the overview).
@@ -2660,6 +2674,8 @@ export function App({
     | 'agents'
     | null
   >(null);
+  const activePanelRef = useRef(activePanel);
+  activePanelRef.current = activePanel;
   const closePanel = useCallback(() => setActivePanel(null), []);
   const handleUseSkill = useCallback(
     (name: string) => {
@@ -3009,6 +3025,7 @@ export function App({
   const [showMemoryDialog, setShowMemoryDialog] = useState(false);
   const [showAuthDialog, setShowAuthDialog] = useState(false);
   const showAuthDialogRef = useRef(showAuthDialog);
+  showAuthDialogRef.current = showAuthDialog;
   const [memoryRefreshSignal, setMemoryRefreshSignal] = useState(0);
   const [memoryAddSignal, setMemoryAddSignal] = useState(0);
   const [externalInteractionBlockCount, setExternalInteractionBlockCount] =
@@ -3447,6 +3464,57 @@ export function App({
   // while a full-pane view (the Scheduled Tasks page) covers the chat, so
   // keystrokes/Escape can't reach the hidden composer underneath.
   const interactionBlocked = dialogOpen || mainView !== 'chat';
+  const mainVoiceTarget = useMemo(
+    () =>
+      resolveVoiceWorkspaceTarget({
+        capabilities: workspace.capabilities,
+        intendedCwd: activeWorkspaceCwd,
+        sessionId: connection.sessionId,
+        workspaces:
+          workspace.capabilities?.workspaces || lockedWorkspaceCapability
+            ? workspaces
+            : undefined,
+      }),
+    [
+      activeWorkspaceCwd,
+      connection.sessionId,
+      lockedWorkspaceCapability,
+      workspace.capabilities,
+      workspaces,
+    ],
+  );
+  const [voiceUserRevision, setVoiceUserRevision] = useState(0);
+  const [voiceWorkspaceRevisions, setVoiceWorkspaceRevisions] = useState<
+    Record<string, number>
+  >({});
+  const mainVoiceStatusRevision: VoiceStatusRevision = {
+    user: voiceUserRevision,
+    workspace: mainVoiceTarget
+      ? (voiceWorkspaceRevisions[mainVoiceTarget.workspaceKey] ?? 0)
+      : 0,
+  };
+  const voiceModelSettingsSupported = supportsVoiceModelSettings(
+    mainVoiceTarget,
+    workspace.capabilities?.features ?? [],
+  );
+  const matchingVoiceSettingsVersion =
+    mainVoiceTarget?.sessionId === connection.sessionId &&
+    (!mainVoiceTarget?.cwd || mainVoiceTarget.cwd === connection.workspaceCwd)
+      ? workspaceEventSignals?.settingsVersion
+      : undefined;
+  const {
+    descriptor: qualifiedVoiceSetting,
+    reload: reloadQualifiedVoiceSettings,
+  } = useVoiceWorkspaceSettings(
+    workspace.client,
+    mainVoiceTarget,
+    voiceModelSettingsSupported && mainView !== 'split',
+    JSON.stringify([
+      voiceUserRevision,
+      mainVoiceStatusRevision.workspace,
+      matchingVoiceSettingsVersion ?? null,
+    ]),
+  );
 
   const reportError = useCallback(
     (error: unknown, fallback: string) => {
@@ -3792,6 +3860,50 @@ export function App({
     setValue: setWorkspaceSetting,
     reload: reloadWorkspaceSettings,
   } = workspaceSettingsState;
+  const reloadTargetedWorkspaceSettings = useCallback(async () => {
+    const status = await reloadWorkspaceSettings();
+    if (mainVoiceTarget?.route === 'workspace-qualified') {
+      await reloadQualifiedVoiceSettings();
+    }
+    return status;
+  }, [
+    mainVoiceTarget?.route,
+    reloadQualifiedVoiceSettings,
+    reloadWorkspaceSettings,
+  ]);
+  const targetedWorkspaceSettings = useMemo(() => {
+    if (mainVoiceTarget?.route === 'legacy-primary') return workspaceSettings;
+    const withoutVoice = workspaceSettings.filter(
+      (setting) => setting.key !== 'voiceModel',
+    );
+    if (
+      !voiceModelSettingsSupported ||
+      !qualifiedVoiceSetting ||
+      mainView === 'split'
+    ) {
+      return withoutVoice;
+    }
+    const voiceIndex = workspaceSettings.findIndex(
+      (setting) => setting.key === 'voiceModel',
+    );
+    if (voiceIndex < 0) {
+      return [...withoutVoice, qualifiedVoiceSetting];
+    }
+    return workspaceSettings.map((setting) =>
+      setting.key === 'voiceModel' ? qualifiedVoiceSetting : setting,
+    );
+  }, [
+    mainView,
+    mainVoiceTarget?.route,
+    qualifiedVoiceSetting,
+    voiceModelSettingsSupported,
+    workspaceSettings,
+  ]);
+  const targetedWorkspaceSettingsState = {
+    ...workspaceSettingsState,
+    settings: targetedWorkspaceSettings,
+    reload: reloadTargetedWorkspaceSettings,
+  };
   const themeSetting = workspaceSettings.find(
     (setting) => setting.key === THEME_SETTING_KEY,
   );
@@ -3803,7 +3915,7 @@ export function App({
   );
   const currentVoiceModel = (() => {
     const value = readScopedModelSetting(
-      workspaceSettings,
+      targetedWorkspaceSettings,
       modelSettingScope,
       'voiceModel',
     );
@@ -3839,6 +3951,192 @@ export function App({
           .filter(Boolean)
       : [];
   }, [workspaceSettings, modelSettingScope]);
+  const bumpVoiceRevision = useCallback(
+    (target: typeof mainVoiceTarget, scope: 'workspace' | 'user') => {
+      if (!target) return;
+      if (scope === 'user') {
+        setVoiceUserRevision((revision) => revision + 1);
+        return;
+      }
+      setVoiceWorkspaceRevisions((revisions) => ({
+        ...revisions,
+        [target.workspaceKey]: (revisions[target.workspaceKey] ?? 0) + 1,
+      }));
+    },
+    [],
+  );
+  const writeVoiceModelForTarget = useCallback(
+    async (
+      value: string,
+      scope: 'workspace' | 'user',
+      target = mainVoiceTarget,
+    ) => {
+      if (
+        !target ||
+        !supportsVoiceModelSettings(
+          target,
+          workspace.capabilities?.features ?? [],
+        )
+      ) {
+        throw new Error(
+          'Voice model settings are unavailable for this workspace.',
+        );
+      }
+      try {
+        if (target.route === 'legacy-primary' || scope === 'user') {
+          await setWorkspaceSetting(scope, 'voiceModel', value);
+        } else {
+          await setVoiceModelSetting(workspace.client, target, scope, value);
+        }
+      } catch (error) {
+        bumpVoiceRevision(target, scope);
+        if (target.route === 'legacy-primary') {
+          await reloadWorkspaceSettings().catch(() => undefined);
+        } else {
+          await reloadQualifiedVoiceSettings().catch(() => undefined);
+        }
+        throw error;
+      }
+      bumpVoiceRevision(target, scope);
+      if (target.route === 'legacy-primary') {
+        await reloadWorkspaceSettings().catch(() => undefined);
+      } else {
+        await reloadQualifiedVoiceSettings().catch(() => undefined);
+      }
+    },
+    [
+      bumpVoiceRevision,
+      mainVoiceTarget,
+      reloadQualifiedVoiceSettings,
+      reloadWorkspaceSettings,
+      setWorkspaceSetting,
+      workspace.capabilities?.features,
+      workspace.client,
+    ],
+  );
+  const mainVoiceTargetRef = useRef(mainVoiceTarget);
+  mainVoiceTargetRef.current = mainVoiceTarget;
+  const voiceFeaturesRef = useRef(workspace.capabilities?.features ?? []);
+  voiceFeaturesRef.current = workspace.capabilities?.features ?? [];
+  const voicePickerRequestRef = useRef(0);
+  const pendingVoicePickerSourceRef = useRef<
+    'command' | 'settings' | undefined
+  >(undefined);
+  const pendingVoicePickerOwnerRef = useRef<string | undefined>(undefined);
+  const voicePickerTargetRef = useRef(mainVoiceTarget);
+  useEffect(
+    () => () => {
+      voicePickerRequestRef.current++;
+      pendingVoicePickerSourceRef.current = undefined;
+    },
+    [],
+  );
+  const openVoiceModelPicker = useCallback(
+    async (scope: 'workspace' | 'user', source: 'command' | 'settings') => {
+      const target = mainVoiceTargetRef.current;
+      if (
+        !target ||
+        !supportsVoiceModelSettings(
+          target,
+          workspace.capabilities?.features ?? [],
+        )
+      ) {
+        reportError(
+          new Error('Voice model settings are unavailable for this workspace.'),
+          t('model.setVoice'),
+        );
+        return;
+      }
+      const request = ++voicePickerRequestRef.current;
+      pendingVoicePickerSourceRef.current = source;
+      pendingVoicePickerOwnerRef.current = target.ownerKey;
+      const intentIsCurrent = () =>
+        request === voicePickerRequestRef.current &&
+        mainVoiceTargetRef.current?.ownerKey === target.ownerKey &&
+        supportsVoiceModelSettings(
+          mainVoiceTargetRef.current,
+          voiceFeaturesRef.current,
+        ) &&
+        (source === 'settings'
+          ? activePanelRef.current === 'settings'
+          : activePanelRef.current === null) &&
+        mainViewRef.current === 'chat' &&
+        modelDialogModeRef.current === null &&
+        !showFallbacksDialogRef.current &&
+        !showAuthDialogRef.current;
+      try {
+        const status = await loadVoiceProviders(workspace.client, target);
+        if (!intentIsCurrent()) {
+          if (request === voicePickerRequestRef.current) {
+            pendingVoicePickerSourceRef.current = undefined;
+          }
+          return;
+        }
+        pendingVoicePickerSourceRef.current = undefined;
+        voicePickerTargetRef.current = target;
+        setVoiceModels(extractVoiceModels(status));
+        setModelSettingScope(scope);
+        setModelDialogMode('voice');
+      } catch (error) {
+        if (!intentIsCurrent()) {
+          if (request === voicePickerRequestRef.current) {
+            pendingVoicePickerSourceRef.current = undefined;
+          }
+          return;
+        }
+        pendingVoicePickerSourceRef.current = undefined;
+        reportError(error, t('model.setVoice'));
+      }
+    },
+    [reportError, t, workspace.capabilities?.features, workspace.client],
+  );
+  useEffect(() => {
+    if (
+      pendingVoicePickerSourceRef.current &&
+      (pendingVoicePickerOwnerRef.current !== mainVoiceTarget?.ownerKey ||
+        !voiceModelSettingsSupported)
+    ) {
+      voicePickerRequestRef.current++;
+      pendingVoicePickerSourceRef.current = undefined;
+    }
+  }, [mainVoiceTarget?.ownerKey, voiceModelSettingsSupported]);
+  useEffect(() => {
+    const source = pendingVoicePickerSourceRef.current;
+    const sourceSurfaceIsCurrent =
+      source === 'settings' ? activePanel === 'settings' : activePanel === null;
+    if (source && !sourceSurfaceIsCurrent) {
+      voicePickerRequestRef.current++;
+      pendingVoicePickerSourceRef.current = undefined;
+    }
+  }, [activePanel]);
+  useEffect(() => {
+    if (
+      pendingVoicePickerSourceRef.current &&
+      (mainView !== 'chat' ||
+        modelDialogMode !== null ||
+        showFallbacksDialog ||
+        showAuthDialog)
+    ) {
+      voicePickerRequestRef.current++;
+      pendingVoicePickerSourceRef.current = undefined;
+    }
+  }, [mainView, modelDialogMode, showAuthDialog, showFallbacksDialog]);
+  useEffect(() => {
+    const pickerTarget = voicePickerTargetRef.current;
+    if (
+      modelDialogMode === 'voice' &&
+      (pickerTarget?.ownerKey !== mainVoiceTarget?.ownerKey ||
+        !voiceModelSettingsSupported ||
+        mainView !== 'chat')
+    ) {
+      setModelDialogMode(null);
+    }
+  }, [
+    mainView,
+    mainVoiceTarget?.ownerKey,
+    modelDialogMode,
+    voiceModelSettingsSupported,
+  ]);
   // Fallback candidates are the selectable (non-runtime) models, keyed by their
   // base id — the same value shape the modelFallbacks setting stores.
   const fallbackModelOptions = useMemo(() => {
@@ -4093,12 +4391,6 @@ export function App({
       }
     })();
   }, [streamingState, sessionActions, reportError, pushToast, t]);
-
-  useEffect(() => {
-    modelDialogModeRef.current = modelDialogMode;
-    showFallbacksDialogRef.current = showFallbacksDialog;
-    showAuthDialogRef.current = showAuthDialog;
-  }, [modelDialogMode, showFallbacksDialog, showAuthDialog]);
 
   useEffect(() => {
     let retryableTurnErrorId: string | null = null;
@@ -5513,25 +5805,13 @@ export function App({
             }
             if (modelArg === '--voice') {
               if (echoOrDeferLocalCommand(text, images)) return true;
-              workspaceActions
-                .loadProviders()
-                .then((status) => {
-                  setVoiceModels(extractVoiceModels(status));
-                  setModelDialogMode('voice');
-                })
-                .catch((error: unknown) =>
-                  reportError(error, t('model.setVoice')),
-                );
+              void openVoiceModelPicker('workspace', 'command');
               return true;
             }
             if (modelArg.startsWith('--voice ')) {
               const voiceModelId = modelArg.replace(/^--voice\s+/, '');
-              setWorkspaceSetting(
-                'workspace',
-                'voiceModel',
-                voiceModelId,
-              ).catch((error: unknown) =>
-                reportError(error, t('model.setVoice')),
+              void writeVoiceModelForTarget(voiceModelId, 'workspace').catch(
+                (error: unknown) => reportError(error, t('model.setVoice')),
               );
               return true;
             }
@@ -6184,6 +6464,8 @@ export function App({
       setPendingModel,
       setPendingMode,
       setWorkspaceSetting,
+      openVoiceModelPicker,
+      writeVoiceModelForTarget,
       showContextUsage,
       t,
       workspaceActions,
@@ -6644,11 +6926,23 @@ export function App({
       // Model IDs from the voice picker arrive as bare model IDs (baseModelId),
       // not ACP format. extractVoiceModels() sets id to the baseModelId.
       const bareModelId = extractBareModelId(modelId);
-      setWorkspaceSetting(modelSettingScope, 'voiceModel', bareModelId).catch(
-        (error: unknown) => reportError(error, t('model.setVoice')),
-      );
+      const target = voicePickerTargetRef.current;
+      if (!target || target.ownerKey !== mainVoiceTargetRef.current?.ownerKey) {
+        reportError(
+          new Error(
+            'The Voice workspace changed before the selection applied.',
+          ),
+          t('model.setVoice'),
+        );
+        return;
+      }
+      void writeVoiceModelForTarget(
+        bareModelId,
+        modelSettingScope,
+        target,
+      ).catch((error: unknown) => reportError(error, t('model.setVoice')));
     },
-    [modelSettingScope, reportError, setWorkspaceSetting, t],
+    [modelSettingScope, reportError, t, writeVoiceModelForTarget],
   );
 
   const handleVisionModelSelect = useCallback(
@@ -7473,7 +7767,7 @@ export function App({
                     >
                       {activePanel === 'settings' ? (
                       <SettingsMessage
-                        settingsState={workspaceSettingsState}
+                        settingsState={targetedWorkspaceSettingsState}
                         embedded
                         onLanguageChange={handleSettingsLanguageChange}
                         onThemeChange={handleThemeChange}
@@ -7502,33 +7796,7 @@ export function App({
                             setModelSettingScope(scope);
                             setModelDialogMode('vision');
                           } else if (key === 'voiceModel') {
-                            // The voice picker opens asynchronously (after
-                            // loadProviders), so DON'T record the scope up front:
-                            // if the user opens and closes another picker while
-                            // loading, the reset effect would clobber it and the
-                            // voice model would persist to the wrong scope. Set
-                            // the scope together with the open, from this click's
-                            // captured `scope`, and only when no other surface
-                            // opened meanwhile.
-                            workspaceActions
-                              .loadProviders()
-                              .then((status) => {
-                                setVoiceModels(extractVoiceModels(status));
-                                // "No other surface opened meanwhile" — mirror the
-                                // reset effect's condition so the voice picker
-                                // never opens on top of a fallbacks/auth dialog.
-                                if (
-                                  modelDialogModeRef.current === null &&
-                                  !showFallbacksDialogRef.current &&
-                                  !showAuthDialogRef.current
-                                ) {
-                                  setModelSettingScope(scope);
-                                  setModelDialogMode('voice');
-                                }
-                              })
-                              .catch((error: unknown) =>
-                                reportError(error, t('model.setVoice')),
-                              );
+                            void openVoiceModelPicker(scope, 'settings');
                           } else if (key === 'modelFallbacks') {
                             setModelSettingScope(scope);
                             setShowFallbacksDialog(true);
@@ -7823,6 +8091,14 @@ export function App({
                         messageTurnOutputs={messageTurnOutputs}
                         restartSseOnPrompt={restartSseOnPrompt}
                         historyPageSize={historyPageSize}
+                        voiceUserRevision={voiceUserRevision}
+                        voiceWorkspaceRevisions={voiceWorkspaceRevisions}
+                        voiceWorkspaces={
+                          workspace.capabilities?.workspaces ||
+                          lockedWorkspaceCapability
+                            ? workspaces
+                            : undefined
+                        }
                       />
                     </CompactModeContext.Provider>
                   </WebShellCustomizationProvider>
@@ -8197,6 +8473,12 @@ export function App({
                           builtinAtProviders={builtinAtProviders}
                           atProviders={atProviders}
                           composerTagIcons={composerTagIcons}
+                          voiceTarget={
+                            interactionBlocked || approvalOverlayActive
+                              ? undefined
+                              : mainVoiceTarget
+                          }
+                          voiceStatusRevision={mainVoiceStatusRevision}
                           queuedMessages={queuedTexts}
                           onFocusFooter={handleFocusTaskPill}
                           onPopQueuedMessages={editLastQueuedPrompt}

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -1499,14 +1499,12 @@ export function App({
         ? connection.workspaceCwd
         : (lockedWorkspaceCwd ??
           selectedWorkspaceCwd ??
-          workspaces.find((entry) => entry.primary)?.cwd ??
-          workspace.capabilities?.workspaceCwd),
+          workspaces.find((entry) => entry.primary)?.cwd),
     [
       connection.sessionId,
       connection.workspaceCwd,
       lockedWorkspaceCwd,
       selectedWorkspaceCwd,
-      workspace.capabilities?.workspaceCwd,
       workspaces,
     ],
   );

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -2622,8 +2622,6 @@ export function App({
   >('workspace');
   const [showFallbacksDialog, setShowFallbacksDialog] = useState(false);
   const showFallbacksDialogRef = useRef(showFallbacksDialog);
-  modelDialogModeRef.current = modelDialogMode;
-  showFallbacksDialogRef.current = showFallbacksDialog;
   const [voiceModels, setVoiceModels] = useState<VoiceModelOption[]>([]);
   const [showApprovalModeDialog, setShowApprovalModeDialog] = useState(false);
   const [showResumeDialog, setShowResumeDialog] = useState(false);
@@ -2647,7 +2645,6 @@ export function App({
     'chat' | 'scheduledTasks' | 'goals' | 'split'
   >('chat');
   const mainViewRef = useRef(mainView);
-  mainViewRef.current = mainView;
   const useFloatingArtifactPanel =
     !canDockArtifactPanel || mainView === 'split';
   // Sessions to seed the split view with (e.g. the selection from the overview).
@@ -2673,7 +2670,6 @@ export function App({
     | null
   >(null);
   const activePanelRef = useRef(activePanel);
-  activePanelRef.current = activePanel;
   const closePanel = useCallback(() => setActivePanel(null), []);
   const handleUseSkill = useCallback(
     (name: string) => {
@@ -3023,7 +3019,6 @@ export function App({
   const [showMemoryDialog, setShowMemoryDialog] = useState(false);
   const [showAuthDialog, setShowAuthDialog] = useState(false);
   const showAuthDialogRef = useRef(showAuthDialog);
-  showAuthDialogRef.current = showAuthDialog;
   const [memoryRefreshSignal, setMemoryRefreshSignal] = useState(0);
   const [memoryAddSignal, setMemoryAddSignal] = useState(0);
   const [externalInteractionBlockCount, setExternalInteractionBlockCount] =
@@ -3485,12 +3480,15 @@ export function App({
   const [voiceWorkspaceRevisions, setVoiceWorkspaceRevisions] = useState<
     Record<string, number>
   >({});
-  const mainVoiceStatusRevision: VoiceStatusRevision = {
-    user: voiceUserRevision,
-    workspace: mainVoiceTarget
-      ? (voiceWorkspaceRevisions[mainVoiceTarget.workspaceKey] ?? 0)
-      : 0,
-  };
+  const mainVoiceStatusRevision: VoiceStatusRevision = useMemo(
+    () => ({
+      user: voiceUserRevision,
+      workspace: mainVoiceTarget
+        ? (voiceWorkspaceRevisions[mainVoiceTarget.workspaceKey] ?? 0)
+        : 0,
+    }),
+    [mainVoiceTarget, voiceUserRevision, voiceWorkspaceRevisions],
+  );
   const voiceModelSettingsSupported = supportsVoiceModelSettings(
     mainVoiceTarget,
     workspace.capabilities?.features ?? [],
@@ -3870,15 +3868,12 @@ export function App({
     reloadWorkspaceSettings,
   ]);
   const targetedWorkspaceSettings = useMemo(() => {
-    if (mainVoiceTarget?.route === 'legacy-primary') return workspaceSettings;
     const withoutVoice = workspaceSettings.filter(
       (setting) => setting.key !== 'voiceModel',
     );
-    if (
-      !voiceModelSettingsSupported ||
-      !qualifiedVoiceSetting ||
-      mainView === 'split'
-    ) {
+    if (mainView === 'split') return withoutVoice;
+    if (mainVoiceTarget?.route === 'legacy-primary') return workspaceSettings;
+    if (!voiceModelSettingsSupported || !qualifiedVoiceSetting) {
       return withoutVoice;
     }
     const voiceIndex = workspaceSettings.findIndex(
@@ -4013,9 +4008,24 @@ export function App({
     ],
   );
   const mainVoiceTargetRef = useRef(mainVoiceTarget);
-  mainVoiceTargetRef.current = mainVoiceTarget;
   const voiceFeaturesRef = useRef(workspace.capabilities?.features ?? []);
-  voiceFeaturesRef.current = workspace.capabilities?.features ?? [];
+  useLayoutEffect(() => {
+    modelDialogModeRef.current = modelDialogMode;
+    showFallbacksDialogRef.current = showFallbacksDialog;
+    mainViewRef.current = mainView;
+    activePanelRef.current = activePanel;
+    showAuthDialogRef.current = showAuthDialog;
+    mainVoiceTargetRef.current = mainVoiceTarget;
+    voiceFeaturesRef.current = workspace.capabilities?.features ?? [];
+  }, [
+    activePanel,
+    mainView,
+    mainVoiceTarget,
+    modelDialogMode,
+    showAuthDialog,
+    showFallbacksDialog,
+    workspace.capabilities?.features,
+  ]);
   const voicePickerRequestRef = useRef(0);
   const pendingVoicePickerSourceRef = useRef<
     'command' | 'settings' | undefined
@@ -8463,7 +8473,10 @@ export function App({
                           }
                           cancelArmed={cancelArmed}
                           disabled={
-                            isDisabled || isStartingNewSessionSuggestion
+                            isDisabled ||
+                            isStartingNewSessionSuggestion ||
+                            interactionBlocked ||
+                            approvalOverlayActive
                           }
                           commands={commands}
                           skills={loadedSkills}
@@ -8472,7 +8485,7 @@ export function App({
                           atProviders={atProviders}
                           composerTagIcons={composerTagIcons}
                           voiceTarget={
-                            interactionBlocked || approvalOverlayActive
+                            activePanel !== null || mainView !== 'chat'
                               ? undefined
                               : mainVoiceTarget
                           }

--- a/packages/web-shell/client/components/ChatEditor.tsx
+++ b/packages/web-shell/client/components/ChatEditor.tsx
@@ -50,6 +50,10 @@ import { ModeIcon } from './ModeIcon';
 import { planSlashSectionRows } from '../utils/slashSectionPlan';
 import { getModelDisplayName } from '../utils/modelDisplay';
 import { VoiceButton } from '../voice/VoiceButton';
+import type {
+  VoiceStatusRevision,
+  VoiceWorkspaceTarget,
+} from '../voice/voice-workspace-target';
 import { GitBranchChipContent, GitBranchIndicator } from './GitBranchIndicator';
 import { GitModePopover, type SessionGitIntent } from './GitModePopover';
 import { WorkspaceIndicator } from './WorkspaceIndicator';
@@ -179,6 +183,8 @@ interface ChatEditorProps {
   builtinAtProviders?: WebShellBuiltinAtProvidersConfig;
   atProviders?: readonly WebShellAtProvider[];
   composerTagIcons?: WebShellComposerTagIconMap;
+  voiceTarget?: VoiceWorkspaceTarget;
+  voiceStatusRevision?: VoiceStatusRevision;
 }
 
 const CHAT_EDITOR_THEME = {
@@ -1198,6 +1204,8 @@ export const ChatEditor = memo(
       builtinAtProviders,
       atProviders,
       composerTagIcons,
+      voiceTarget,
+      voiceStatusRevision,
     } = props;
 
     const {
@@ -2329,6 +2337,8 @@ export const ChatEditor = memo(
                   <VoiceButton
                     disabled={disabled}
                     onActiveChange={setVoiceActive}
+                    target={voiceTarget}
+                    statusRevision={voiceStatusRevision}
                     onInsert={(text) => {
                       const existing = core.getText();
                       const sep = existing && !/\s$/.test(existing) ? ' ' : '';

--- a/packages/web-shell/client/components/ChatPane.test.tsx
+++ b/packages/web-shell/client/components/ChatPane.test.tsx
@@ -373,6 +373,31 @@ describe('ChatPane', () => {
     });
   });
 
+  it('keeps an active split Voice owner stable while approval is pending', () => {
+    connectionState.capabilities = {
+      features: ['voice_transcribe'],
+      workspaceCwd: '/w',
+    };
+    render({ workspaceCwd: '/w' });
+    const voiceTarget = latestChatEditorProps.voiceTarget;
+    const voiceStatusRevision = latestChatEditorProps.voiceStatusRevision;
+    expect(voiceTarget).toBeDefined();
+
+    pendingPermission = { id: 'perm-1', toolName: 'write_file', rawInput: {} };
+    act(() => {
+      root?.render(
+        <I18nProvider language="en">
+          <ChatPane workspaceCwd="/w" />
+        </I18nProvider>,
+      );
+    });
+
+    expect(latestChatEditorProps.dialogOpen).toBe(true);
+    expect(latestChatEditorProps.disabled).toBe(true);
+    expect(latestChatEditorProps.voiceTarget).toBe(voiceTarget);
+    expect(latestChatEditorProps.voiceStatusRevision).toBe(voiceStatusRevision);
+  });
+
   it('uses the merged registered workspace list for split Voice', () => {
     connectionState.workspaceCwd = '/work/locked';
     connectionState.capabilities = {

--- a/packages/web-shell/client/components/ChatPane.test.tsx
+++ b/packages/web-shell/client/components/ChatPane.test.tsx
@@ -325,6 +325,109 @@ describe('ChatPane', () => {
     expect(latestChatEditorProps.workspaceColor).toBe('green');
   });
 
+  it('binds split Voice to the connected secondary workspace and revision', () => {
+    connectionState.workspaceCwd = '/work/api';
+    connectionState.capabilities = {
+      features: ['workspace_qualified_voice'],
+      workspaceCwd: '/work/web-shell',
+      workspaces: [
+        { id: 'w0', cwd: '/work/web-shell', primary: true, trusted: true },
+        { id: 'w1', cwd: '/work/api', primary: false, trusted: true },
+      ],
+    };
+
+    render({
+      workspaceCwd: '/work/api',
+      voiceUserRevision: 3,
+      voiceWorkspaceRevisions: {
+        '["workspace-qualified","id","w1","/work/api"]': 5,
+      },
+    });
+
+    expect(latestChatEditorProps.voiceTarget).toMatchObject({
+      route: 'workspace-qualified',
+      cwd: '/work/api',
+      selector: { kind: 'id', value: 'w1' },
+      sessionId: 'sess-1',
+      streamPath: 'workspaces/w1/voice/stream',
+    });
+    expect(latestChatEditorProps.voiceStatusRevision).toEqual({
+      user: 3,
+      workspace: 5,
+    });
+  });
+
+  it('binds split Voice to the legacy primary workspace without a workspace list', () => {
+    connectionState.capabilities = {
+      features: ['voice_transcribe'],
+      workspaceCwd: '/w',
+    };
+
+    render({ workspaceCwd: '/w' });
+
+    expect(latestChatEditorProps.voiceTarget).toMatchObject({
+      route: 'legacy-primary',
+      cwd: '/w',
+      sessionId: 'sess-1',
+      streamPath: 'voice/stream',
+    });
+  });
+
+  it('uses the merged registered workspace list for split Voice', () => {
+    connectionState.workspaceCwd = '/work/locked';
+    connectionState.capabilities = {
+      features: ['workspace_qualified_voice'],
+      workspaceCwd: '/work/web-shell',
+      workspaces: [
+        { id: 'w0', cwd: '/work/web-shell', primary: true, trusted: true },
+      ],
+    };
+
+    render({
+      workspaceCwd: '/work/locked',
+      voiceWorkspaces: [
+        { id: 'w0', cwd: '/work/web-shell', primary: true, trusted: true },
+        {
+          id: 'locked',
+          cwd: '/work/locked',
+          primary: false,
+          trusted: true,
+        },
+      ],
+    });
+
+    expect(latestChatEditorProps.voiceTarget).toMatchObject({
+      route: 'workspace-qualified',
+      cwd: '/work/locked',
+      selector: { kind: 'id', value: 'locked' },
+      streamPath: 'workspaces/locked/voice/stream',
+    });
+  });
+
+  it('fails closed on split workspace mismatch and while hidden', () => {
+    connectionState.workspaceCwd = '/work/api';
+    connectionState.capabilities = {
+      features: ['workspace_qualified_voice'],
+      workspaceCwd: '/work/web-shell',
+      workspaces: [
+        { id: 'w0', cwd: '/work/web-shell', primary: true, trusted: true },
+        { id: 'w1', cwd: '/work/api', primary: false, trusted: true },
+      ],
+    };
+
+    render({ workspaceCwd: '/work/other' });
+    expect(latestChatEditorProps.voiceTarget).toBeUndefined();
+
+    act(() => {
+      root?.render(
+        <I18nProvider language="en">
+          <ChatPane workspaceCwd="/work/api" hidden />
+        </I18nProvider>,
+      );
+    });
+    expect(latestChatEditorProps.voiceTarget).toBeUndefined();
+  });
+
   it('surfaces the workspace in the pane header on a multi-workspace daemon', () => {
     connectionState.capabilities = {
       features: [],

--- a/packages/web-shell/client/components/ChatPane.tsx
+++ b/packages/web-shell/client/components/ChatPane.tsx
@@ -86,6 +86,7 @@ const PANE_TOOLBAR_ACTIONS: readonly ComposerToolbarAction[] = [
   'model',
   'voice',
 ];
+const EMPTY_VOICE_WORKSPACE_REVISIONS: Readonly<Record<string, number>> = {};
 
 export interface ChatPaneProps {
   /** Header label; falls back to the session's own display name / id. */
@@ -144,7 +145,7 @@ export function ChatPane({
   restartSseOnPrompt = false,
   hidden = false,
   voiceUserRevision = 0,
-  voiceWorkspaceRevisions = {},
+  voiceWorkspaceRevisions = EMPTY_VOICE_WORKSPACE_REVISIONS,
   voiceWorkspaces,
 }: ChatPaneProps) {
   const { t } = useI18n();
@@ -279,12 +280,15 @@ export function ChatPane({
       workspace.capabilities,
     ],
   );
-  const voiceStatusRevision: VoiceStatusRevision = {
-    user: voiceUserRevision,
-    workspace: voiceTarget
-      ? (voiceWorkspaceRevisions[voiceTarget.workspaceKey] ?? 0)
-      : 0,
-  };
+  const voiceStatusRevision: VoiceStatusRevision = useMemo(
+    () => ({
+      user: voiceUserRevision,
+      workspace: voiceTarget
+        ? (voiceWorkspaceRevisions[voiceTarget.workspaceKey] ?? 0)
+        : 0,
+    }),
+    [voiceTarget, voiceUserRevision, voiceWorkspaceRevisions],
+  );
   const isResponding = streamingState !== 'idle';
   const artifactsByTurn = useMemo(
     () =>
@@ -719,7 +723,8 @@ export function ChatPane({
           onSelectMode={handleSelectMode}
           onSelectModel={handleSelectModel}
           dialogOpen={approvalActive}
-          voiceTarget={hidden || approvalActive ? undefined : voiceTarget}
+          disabled={approvalActive}
+          voiceTarget={hidden ? undefined : voiceTarget}
           voiceStatusRevision={voiceStatusRevision}
           followupState={followupState}
           onAcceptFollowup={onAcceptFollowup}

--- a/packages/web-shell/client/components/ChatPane.tsx
+++ b/packages/web-shell/client/components/ChatPane.tsx
@@ -18,7 +18,10 @@ import {
   useWorkspaceActions,
   type DaemonWorkspaceActions,
 } from '@qwen-code/webui/daemon-react-sdk';
-import type { DaemonSessionArtifact } from '@qwen-code/sdk/daemon';
+import type {
+  DaemonSessionArtifact,
+  DaemonWorkspaceCapability,
+} from '@qwen-code/sdk/daemon';
 import type { ACPToolCall } from '../adapters/types';
 import { SubagentDetailsProvider } from '../subagentDetailsContext';
 import { useI18n } from '../i18n';
@@ -45,6 +48,10 @@ import {
   workspaceLabelForCwd,
 } from '../utils/workspace';
 import { workspaceAccentColor } from '../utils/workspaceColor';
+import {
+  resolveVoiceWorkspaceTarget,
+  type VoiceStatusRevision,
+} from '../voice/voice-workspace-target';
 import {
   getLocalCommands,
   localizeBuiltinDescriptions,
@@ -110,6 +117,10 @@ export interface ChatPaneProps {
   messageTurnOutputs?: readonly TurnOutputKind[];
   /** Allow prompt admission to recover a disconnected SSE stream. */
   restartSseOnPrompt?: boolean;
+  hidden?: boolean;
+  voiceUserRevision?: number;
+  voiceWorkspaceRevisions?: Readonly<Record<string, number>>;
+  voiceWorkspaces?: readonly DaemonWorkspaceCapability[];
 }
 
 /**
@@ -131,6 +142,10 @@ export function ChatPane({
   onPaneArtifactsChange,
   messageTurnOutputs,
   restartSseOnPrompt = false,
+  hidden = false,
+  voiceUserRevision = 0,
+  voiceWorkspaceRevisions = {},
+  voiceWorkspaces,
 }: ChatPaneProps) {
   const { t } = useI18n();
   const connection = useConnection();
@@ -243,6 +258,33 @@ export function ChatPane({
   pendingToolApprovalRef.current = pendingToolApproval;
   const approvalActive =
     pendingToolApproval !== null || pendingAskUserApproval !== null;
+  const paneVoiceCwd =
+    connection.sessionId &&
+    connection.workspaceCwd &&
+    (!workspaceCwd || workspaceCwd === connection.workspaceCwd)
+      ? connection.workspaceCwd
+      : undefined;
+  const voiceTarget = useMemo(
+    () =>
+      resolveVoiceWorkspaceTarget({
+        capabilities: workspace.capabilities,
+        intendedCwd: paneVoiceCwd,
+        sessionId: connection.sessionId,
+        workspaces: voiceWorkspaces,
+      }),
+    [
+      connection.sessionId,
+      paneVoiceCwd,
+      voiceWorkspaces,
+      workspace.capabilities,
+    ],
+  );
+  const voiceStatusRevision: VoiceStatusRevision = {
+    user: voiceUserRevision,
+    workspace: voiceTarget
+      ? (voiceWorkspaceRevisions[voiceTarget.workspaceKey] ?? 0)
+      : 0,
+  };
   const isResponding = streamingState !== 'idle';
   const artifactsByTurn = useMemo(
     () =>
@@ -677,6 +719,8 @@ export function ChatPane({
           onSelectMode={handleSelectMode}
           onSelectModel={handleSelectModel}
           dialogOpen={approvalActive}
+          voiceTarget={hidden || approvalActive ? undefined : voiceTarget}
+          voiceStatusRevision={voiceStatusRevision}
           followupState={followupState}
           onAcceptFollowup={onAcceptFollowup}
           onDismissFollowup={onDismissFollowup}

--- a/packages/web-shell/client/components/SplitView.test.tsx
+++ b/packages/web-shell/client/components/SplitView.test.tsx
@@ -73,6 +73,9 @@ vi.mock('./ChatPane', () => ({
         data-maximized={props.isMaximized ? 'true' : 'false'}
         data-pane-restart-sse={props.restartSseOnPrompt ? 'true' : 'false'}
         data-slash-handler={props.onSlashCommand ? 'true' : 'false'}
+        data-hidden={props.hidden ? 'true' : 'false'}
+        data-voice-user-revision={String(props.voiceUserRevision ?? 0)}
+        data-voice-workspace-count={String(props.voiceWorkspaces?.length ?? 0)}
       >
         <span data-testid="pane-title">{props.title}</span>
         {props.onToggleMaximize && (
@@ -447,11 +450,38 @@ describe('SplitView', () => {
     expect(panes()).toHaveLength(3);
     // …but the two non-maximized slots are hidden, leaving one visible.
     expect(hiddenSlots()).toHaveLength(2);
+    expect(container!.querySelectorAll('[data-hidden="true"]')).toHaveLength(2);
     // The maximized pane reflects its state down to ChatPane.
     const maximized = container!.querySelector('[data-maximized="true"]');
     expect(
       maximized?.querySelector('[data-testid="pane-title"]')?.textContent,
     ).toBe('One');
+  });
+
+  it('forwards Voice revision state to every pane', () => {
+    render({
+      sessionIds: ['s1', 's2'],
+      voiceUserRevision: 4,
+      voiceWorkspaceRevisions: { workspace: 7 },
+    });
+
+    expect(
+      container!.querySelectorAll('[data-voice-user-revision="4"]'),
+    ).toHaveLength(2);
+  });
+
+  it('forwards the merged Voice workspace list to every pane', () => {
+    render({
+      sessionIds: ['s1', 's2'],
+      voiceWorkspaces: [
+        { id: 'primary', cwd: '/w', primary: true },
+        { id: 'secondary', cwd: '/other', primary: false, trusted: true },
+      ],
+    });
+
+    expect(
+      container!.querySelectorAll('[data-voice-workspace-count="2"]'),
+    ).toHaveLength(2);
   });
 
   it('toggles back to the tiled layout when the maximized pane’s button is clicked again', () => {

--- a/packages/web-shell/client/components/SplitView.tsx
+++ b/packages/web-shell/client/components/SplitView.tsx
@@ -10,7 +10,10 @@ import {
   useConnection,
   type DaemonWorkspaceActions,
 } from '@qwen-code/webui/daemon-react-sdk';
-import type { DaemonSessionArtifact } from '@qwen-code/sdk/daemon';
+import type {
+  DaemonSessionArtifact,
+  DaemonWorkspaceCapability,
+} from '@qwen-code/sdk/daemon';
 import type { WebShellSlashCommandHandler } from '../App';
 import { useI18n } from '../i18n';
 import { ChatPane } from './ChatPane';
@@ -73,6 +76,9 @@ export interface SplitViewProps {
   restartSseOnPrompt?: boolean;
   /** Persisted transcript records requested per page by each pane. */
   historyPageSize?: number;
+  voiceUserRevision?: number;
+  voiceWorkspaceRevisions?: Readonly<Record<string, number>>;
+  voiceWorkspaces?: readonly DaemonWorkspaceCapability[];
 }
 
 /**
@@ -96,6 +102,9 @@ export function SplitView({
   workspaceCwd,
   restartSseOnPrompt,
   historyPageSize = WEB_SHELL_HISTORY_PAGE_SIZE,
+  voiceUserRevision = 0,
+  voiceWorkspaceRevisions = {},
+  voiceWorkspaces,
 }: SplitViewProps) {
   const { t } = useI18n();
   const connection = useConnection();
@@ -490,6 +499,10 @@ export function SplitView({
                     <ChatPane
                       title={titleById.get(sessionId)}
                       workspaceCwd={paneWorkspaceCwd}
+                      hidden={isHidden}
+                      voiceUserRevision={voiceUserRevision}
+                      voiceWorkspaceRevisions={voiceWorkspaceRevisions}
+                      voiceWorkspaces={voiceWorkspaces}
                       onClose={() => removePane(sessionId)}
                       onToggleMaximize={
                         canMaximize

--- a/packages/web-shell/client/e2e/utils/mockDaemon.ts
+++ b/packages/web-shell/client/e2e/utils/mockDaemon.ts
@@ -510,6 +510,7 @@ function isDaemonPath(path: string): boolean {
     path === '/workspace/extensions/check-updates' ||
     path === '/workspace/mcp' ||
     path === '/workspace/voice' ||
+    /^\/workspaces\/[^/]+\/(voice|providers|settings)\/?$/.test(path) ||
     /^\/workspace\/mcp\/[^/]+\/tools\/?$/.test(path) ||
     /^\/workspace\/mcp\/[^/]+\/resources\/?$/.test(path) ||
     /^\/workspace\/.+\/sessions\/?$/.test(path) ||
@@ -547,6 +548,18 @@ function isDaemonRoute(method: string, path: string): boolean {
   }
   if (method === 'GET' && path === '/workspace/mcp') return true;
   if (method === 'GET' && path === '/workspace/voice') return true;
+  if (
+    (method === 'GET' || method === 'POST') &&
+    /^\/workspaces\/[^/]+\/settings\/?$/.test(path)
+  ) {
+    return true;
+  }
+  if (
+    method === 'GET' &&
+    /^\/workspaces\/[^/]+\/(voice|providers)\/?$/.test(path)
+  ) {
+    return true;
+  }
   if (method === 'GET' && /^\/workspace\/mcp\/[^/]+\/tools\/?$/.test(path)) {
     return true;
   }
@@ -661,6 +674,27 @@ async function handleDaemonRoute(
   }
   if (method === 'GET' && path === '/workspace/voice') {
     await json(route, workspaceVoice(scenario));
+    return;
+  }
+  if (method === 'GET' && /^\/workspaces\/[^/]+\/voice\/?$/.test(path)) {
+    await json(route, workspaceVoice(scenario));
+    return;
+  }
+  if (method === 'GET' && /^\/workspaces\/[^/]+\/providers\/?$/.test(path)) {
+    await json(route, scenario.providers);
+    return;
+  }
+  if (method === 'GET' && /^\/workspaces\/[^/]+\/settings\/?$/.test(path)) {
+    await json(route, scenario.settings);
+    return;
+  }
+  if (method === 'POST' && /^\/workspaces\/[^/]+\/settings\/?$/.test(path)) {
+    await json(route, {
+      key: getRecordValue(body, 'key') ?? 'unknown',
+      scope: getRecordValue(body, 'scope') ?? 'workspace',
+      value: getRecordValue(body, 'value'),
+      requiresRestart: false,
+    });
     return;
   }
   if (method === 'GET' && /^\/workspace\/mcp\/[^/]+\/tools\/?$/.test(path)) {

--- a/packages/web-shell/client/e2e/web-shell.smoke.spec.ts
+++ b/packages/web-shell/client/e2e/web-shell.smoke.spec.ts
@@ -380,6 +380,61 @@ test('gates voice dictation on the workspace voice setting @smoke', async ({
   await expect(voiceButton).toBeVisible();
 });
 
+test('loads Voice status from the active secondary workspace @smoke', async ({
+  page,
+}, testInfo) => {
+  const secondaryCwd = '/work/secondary';
+  const scenario = createWebShellDaemonScenario({
+    workspaceCwd: secondaryCwd,
+    capabilities: {
+      workspaceCwd: '/work/primary',
+      features: [
+        'session_events',
+        'workspace_qualified_voice',
+        'workspace_qualified_rest_core',
+        'workspace_settings',
+      ],
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/work/primary',
+          primary: true,
+          trusted: true,
+        },
+        {
+          id: 'secondary',
+          cwd: secondaryCwd,
+          primary: false,
+          trusted: true,
+        },
+      ],
+    },
+    voice: { enabled: true, workspaceCwd: secondaryCwd },
+  });
+  const daemon = await installScenario(page, scenario, testInfo);
+
+  await gotoSession(page, scenario, daemon);
+  await expect(
+    page.getByRole('button', { name: 'Start voice dictation' }),
+  ).toBeVisible();
+  await expect
+    .poll(
+      () =>
+        daemon.requests.filter(
+          (request) =>
+            request.method === 'GET' &&
+            request.path === '/workspaces/secondary/voice',
+        ).length,
+    )
+    .toBeGreaterThan(0);
+  expect(
+    daemon.requests.some(
+      (request) =>
+        request.method === 'GET' && request.path === '/workspace/voice',
+    ),
+  ).toBe(false);
+});
+
 for (const viewportHeight of COMPOSER_VIEWPORT_HEIGHTS) {
   test(`grows long text to the responsive composer cap at ${viewportHeight}px @smoke`, async ({
     page,

--- a/packages/web-shell/client/vite-config.test.ts
+++ b/packages/web-shell/client/vite-config.test.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { ConfigEnv, UserConfig } from 'vite';
+import viteConfig, { QUALIFIED_VOICE_STREAM_PROXY } from '../vite.config';
+
+describe('Web Shell Voice development proxy', () => {
+  it('proxies only qualified Voice stream upgrades', () => {
+    const factory = viteConfig as (env: ConfigEnv) => UserConfig;
+    const config = factory({
+      command: 'serve',
+      mode: 'test',
+      isSsrBuild: false,
+      isPreview: false,
+    });
+    const proxy = config.server?.proxy;
+    const qualified = proxy?.[QUALIFIED_VOICE_STREAM_PROXY];
+
+    expect(qualified).not.toBeTypeOf('string');
+    expect(
+      qualified && typeof qualified !== 'string' ? qualified.ws : false,
+    ).toBe(true);
+    expect(
+      new RegExp(QUALIFIED_VOICE_STREAM_PROXY).test(
+        '/workspaces/id/voice/stream',
+      ),
+    ).toBe(true);
+    expect(
+      new RegExp(QUALIFIED_VOICE_STREAM_PROXY).test('/voice/voiceModels.ts'),
+    ).toBe(false);
+  });
+});

--- a/packages/web-shell/client/voice/VoiceButton.test.tsx
+++ b/packages/web-shell/client/voice/VoiceButton.test.tsx
@@ -179,6 +179,7 @@ describe('VoiceButton', () => {
   });
 
   it('stays hidden while the workspace voice request is pending or fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     let rejectVoice: (reason?: unknown) => void = () => undefined;
     mocks.workspaceVoice.mockReturnValue(
       new Promise((_, reject) => {
@@ -194,6 +195,11 @@ describe('VoiceButton', () => {
       await Promise.resolve();
     });
     expect(container.querySelector('button')).toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      '[web-shell] Voice status probe failed:',
+      expect.any(Error),
+    );
+    warn.mockRestore();
   });
 
   it('does not request workspace voice without the daemon capability', async () => {
@@ -532,13 +538,17 @@ describe('VoiceButton', () => {
     expect(container.querySelector('button')).toBeNull();
   });
 
-  it('keeps the same-owner gate closed when a 1012 refresh fails', async () => {
+  it('revalidates the same owner when a 1012 refresh fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     mocks.workspace.refreshCapabilities.mockRejectedValue(
       new Error('refresh failed'),
     );
-    const { container } = mount(false);
+    const { root, container } = mount(false);
     await flush();
     expect(container.querySelector('button')).not.toBeNull();
+    mocks.workspaceVoice.mockRejectedValueOnce(
+      new Error('voice status still unavailable'),
+    );
 
     act(() => {
       mocks.captureOptions?.onUnexpectedClose?.({
@@ -549,12 +559,28 @@ describe('VoiceButton', () => {
     await flush();
 
     expect(mocks.workspace.refreshCapabilities).toHaveBeenCalledOnce();
-    expect(mocks.workspaceVoice).toHaveBeenCalledOnce();
+    expect(mocks.workspaceVoice).toHaveBeenCalledTimes(2);
     expect(container.querySelector('button')).toBeNull();
+
+    mocks.settingsVersion += 1;
+    act(() => {
+      root.render(
+        <VoiceButton
+          disabled={false}
+          onInsert={() => {}}
+          target={legacyTarget}
+        />,
+      );
+    });
+    await flush();
+
+    expect(mocks.workspaceVoice).toHaveBeenCalledTimes(3);
+    expect(container.querySelector('button')).not.toBeNull();
     expect(mocks.captureOptions?.target).toEqual({
       ownerKey: legacyTarget.ownerKey,
       streamPath: legacyTarget.streamPath,
     });
+    warn.mockRestore();
   });
 
   it('lets a disabled composer stop active dictation', async () => {

--- a/packages/web-shell/client/voice/VoiceButton.test.tsx
+++ b/packages/web-shell/client/voice/VoiceButton.test.tsx
@@ -8,6 +8,7 @@ import type {
   UseVoiceCaptureOptions,
   UseVoiceCaptureReturn,
 } from './useVoiceCapture';
+import type { VoiceWorkspaceTarget } from './voice-workspace-target';
 
 (
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -15,14 +16,23 @@ import type {
 
 const mocks = vi.hoisted(() => ({
   settingsVersion: 0,
+  connection: {
+    sessionId: 'session-1',
+    workspaceCwd: '/tmp/workspace',
+  },
   workspaceVoice: vi.fn(),
   onFinal: undefined as UseVoiceCaptureOptions['onFinal'] | undefined,
+  qualifiedWorkspaceVoice: vi.fn(),
+  workspaceById: vi.fn(),
+  captureOptions: undefined as UseVoiceCaptureOptions | undefined,
   workspace: {
     baseUrl: 'http://127.0.0.1:1234',
     token: undefined as string | undefined,
     capabilities: { features: ['voice_transcribe'] },
+    refreshCapabilities: vi.fn(),
     client: {
       workspaceVoice: vi.fn(),
+      workspaceById: vi.fn(),
     },
   },
   capture: {
@@ -37,6 +47,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
+  useConnection: () => mocks.connection,
   useWorkspace: () => mocks.workspace,
   useWorkspaceEventSignals: () => ({
     settingsVersion: mocks.settingsVersion,
@@ -46,16 +57,17 @@ vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
 vi.mock('./useVoiceCapture', () => ({
   useVoiceCapture: (options: UseVoiceCaptureOptions): UseVoiceCaptureReturn => {
     mocks.onFinal = options.onFinal;
+    mocks.captureOptions = options;
     return mocks.capture as unknown as UseVoiceCaptureReturn;
   },
 }));
 
 const mounted: Array<{ root: Root; container: HTMLElement }> = [];
 
-function voiceStatus(enabled: boolean) {
+function voiceStatus(enabled: boolean, workspaceCwd = '/tmp/workspace') {
   return {
     v: 1 as const,
-    workspaceCwd: '/tmp/workspace',
+    workspaceCwd,
     enabled,
     mode: 'hold' as const,
     language: 'en',
@@ -64,7 +76,11 @@ function voiceStatus(enabled: boolean) {
   };
 }
 
-function mount(disabled: boolean, onActiveChange?: (active: boolean) => void) {
+function mount(
+  disabled: boolean,
+  target: VoiceWorkspaceTarget | undefined = legacyTarget,
+  onActiveChange?: (active: boolean) => void,
+) {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
@@ -73,6 +89,7 @@ function mount(disabled: boolean, onActiveChange?: (active: boolean) => void) {
       <VoiceButton
         disabled={disabled}
         onInsert={() => {}}
+        target={target}
         onActiveChange={onActiveChange}
       />,
     );
@@ -80,6 +97,15 @@ function mount(disabled: boolean, onActiveChange?: (active: boolean) => void) {
   mounted.push({ root, container });
   return { root, container };
 }
+
+const legacyTarget = {
+  route: 'legacy-primary' as const,
+  cwd: '/tmp/workspace',
+  workspaceKey: 'primary',
+  ownerKey: 'primary:session-1',
+  sessionId: 'session-1',
+  streamPath: 'voice/stream' as const,
+};
 
 async function flush(): Promise<void> {
   await act(async () => {
@@ -103,13 +129,27 @@ const click = (button: HTMLButtonElement) => {
 
 beforeEach(() => {
   mocks.settingsVersion = 0;
+  mocks.connection.sessionId = 'session-1';
+  mocks.connection.workspaceCwd = '/tmp/workspace';
   mocks.workspace.capabilities.features = ['voice_transcribe'];
+  mocks.workspace.refreshCapabilities.mockReset();
+  mocks.workspace.refreshCapabilities.mockResolvedValue(undefined);
   mocks.workspace.client = {
     workspaceVoice: mocks.workspaceVoice,
+    workspaceById: mocks.workspaceById,
   };
   mocks.workspaceVoice.mockReset();
   mocks.workspaceVoice.mockResolvedValue(voiceStatus(true));
   mocks.onFinal = undefined;
+  mocks.qualifiedWorkspaceVoice.mockReset();
+  mocks.qualifiedWorkspaceVoice.mockResolvedValue(
+    voiceStatus(true, '/tmp/secondary'),
+  );
+  mocks.workspaceById.mockReset();
+  mocks.workspaceById.mockReturnValue({
+    workspaceVoice: mocks.qualifiedWorkspaceVoice,
+  });
+  mocks.captureOptions = undefined;
   mocks.capture.status = 'idle';
   mocks.capture.interimText = '';
   mocks.capture.audioLevel = 0;
@@ -165,6 +205,33 @@ describe('VoiceButton', () => {
     expect(mocks.workspaceVoice).not.toHaveBeenCalled();
   });
 
+  it('uses the qualified status and stream path without legacy capability tags', async () => {
+    mocks.workspace.capabilities.features = ['workspace_qualified_voice'];
+    const target: VoiceWorkspaceTarget = {
+      route: 'workspace-qualified',
+      cwd: '/tmp/secondary',
+      workspaceKey: 'secondary',
+      ownerKey: 'secondary:session-2',
+      sessionId: 'session-2',
+      selector: { kind: 'id', value: 'secondary-id' },
+      streamPath: 'workspaces/secondary-id/voice/stream',
+    };
+    mocks.connection.sessionId = 'session-2';
+    mocks.connection.workspaceCwd = '/tmp/secondary';
+
+    const { container } = mount(false, target);
+    await flush();
+
+    expect(container.querySelector('button')).not.toBeNull();
+    expect(mocks.workspaceById).toHaveBeenCalledWith('secondary-id');
+    expect(mocks.qualifiedWorkspaceVoice).toHaveBeenCalledOnce();
+    expect(mocks.workspaceVoice).not.toHaveBeenCalled();
+    expect(mocks.captureOptions?.target).toEqual({
+      ownerKey: target.ownerKey,
+      streamPath: target.streamPath,
+    });
+  });
+
   it('reloads workspace voice when settings change', async () => {
     mocks.workspaceVoice.mockResolvedValue(voiceStatus(false));
     const { root, container } = mount(false);
@@ -174,7 +241,13 @@ describe('VoiceButton', () => {
     mocks.settingsVersion = 1;
     mocks.workspaceVoice.mockResolvedValue(voiceStatus(true));
     act(() => {
-      root.render(<VoiceButton disabled={false} onInsert={() => {}} />);
+      root.render(
+        <VoiceButton
+          disabled={false}
+          onInsert={() => {}}
+          target={legacyTarget}
+        />,
+      );
     });
     expect(container.querySelector('button')).toBeNull();
     await flush();
@@ -183,7 +256,13 @@ describe('VoiceButton', () => {
     mocks.settingsVersion = 2;
     mocks.workspaceVoice.mockResolvedValue(voiceStatus(false));
     act(() => {
-      root.render(<VoiceButton disabled={false} onInsert={() => {}} />);
+      root.render(
+        <VoiceButton
+          disabled={false}
+          onInsert={() => {}}
+          target={legacyTarget}
+        />,
+      );
     });
     expect(container.querySelector('button')).toBeNull();
     await flush();
@@ -203,7 +282,13 @@ describe('VoiceButton', () => {
     mocks.settingsVersion = 1;
     mocks.workspaceVoice.mockResolvedValueOnce(voiceStatus(false));
     act(() => {
-      root.render(<VoiceButton disabled={false} onInsert={() => {}} />);
+      root.render(
+        <VoiceButton
+          disabled={false}
+          onInsert={() => {}}
+          target={legacyTarget}
+        />,
+      );
     });
     await flush();
 
@@ -229,7 +314,13 @@ describe('VoiceButton', () => {
     );
     mocks.workspace.client = { workspaceVoice };
     act(() => {
-      root.render(<VoiceButton disabled={false} onInsert={() => {}} />);
+      root.render(
+        <VoiceButton
+          disabled={false}
+          onInsert={() => {}}
+          target={legacyTarget}
+        />,
+      );
     });
 
     expect(container.querySelector('button')).toBeNull();
@@ -249,18 +340,221 @@ describe('VoiceButton', () => {
 
     mocks.capture.status = 'recording';
     act(() => {
-      root.render(<VoiceButton disabled={false} onInsert={() => {}} />);
+      root.render(
+        <VoiceButton
+          disabled={false}
+          onInsert={() => {}}
+          target={legacyTarget}
+        />,
+      );
     });
     expect(mocks.capture.abort).not.toHaveBeenCalled();
 
     mocks.settingsVersion = 1;
     mocks.workspaceVoice.mockReturnValue(new Promise(() => undefined));
     act(() => {
-      root.render(<VoiceButton disabled={false} onInsert={() => {}} />);
+      root.render(
+        <VoiceButton
+          disabled={false}
+          onInsert={() => {}}
+          target={legacyTarget}
+        />,
+      );
     });
 
     expect(container.querySelector('button')).toBeNull();
     expect(mocks.capture.abort).toHaveBeenCalledOnce();
+    expect(mocks.captureOptions?.target).toEqual({
+      ownerKey: legacyTarget.ownerKey,
+      streamPath: legacyTarget.streamPath,
+    });
+  });
+
+  it('keeps recording when an equivalent target object is rebuilt', async () => {
+    const { root, container } = mount(false);
+    await flush();
+    expect(container.querySelector('button')).not.toBeNull();
+
+    mocks.capture.status = 'recording';
+    act(() => {
+      root.render(
+        <VoiceButton
+          disabled={false}
+          onInsert={() => {}}
+          target={{ ...legacyTarget }}
+        />,
+      );
+    });
+
+    expect(container.querySelector('button')).not.toBeNull();
+    expect(mocks.workspaceVoice).toHaveBeenCalledOnce();
+    expect(mocks.capture.abort).not.toHaveBeenCalled();
+  });
+
+  it('keeps the capture owner while an unexpected close revalidates status', async () => {
+    const { container } = mount(false);
+    await flush();
+    expect(container.querySelector('button')).not.toBeNull();
+    mocks.workspaceVoice.mockReturnValue(new Promise(() => undefined));
+
+    act(() => {
+      mocks.captureOptions?.onUnexpectedClose?.({
+        code: 1006,
+        reason: 'network',
+      });
+    });
+
+    expect(container.querySelector('button')).toBeNull();
+    expect(mocks.captureOptions?.target).toEqual({
+      ownerKey: legacyTarget.ownerKey,
+      streamPath: legacyTarget.streamPath,
+    });
+  });
+
+  it('keeps the status gate and retry visible after a capacity close', async () => {
+    mocks.capture.status = 'error';
+    mocks.capture.errorMessage = 'Voice is busy';
+    const { container } = mount(false);
+    await flush();
+    expect(container.querySelector('button')).not.toBeNull();
+    expect(mocks.workspaceVoice).toHaveBeenCalledOnce();
+
+    act(() => {
+      mocks.captureOptions?.onUnexpectedClose?.({
+        code: 1013,
+        reason: 'capacity',
+      });
+    });
+
+    expect(container.querySelector('button')).not.toBeNull();
+    expect(mocks.workspaceVoice).toHaveBeenCalledOnce();
+    expect(mocks.captureOptions?.target).toEqual({
+      ownerKey: legacyTarget.ownerKey,
+      streamPath: legacyTarget.streamPath,
+    });
+  });
+
+  it('ignores a completed capability refresh from a previous owner', async () => {
+    mocks.workspace.capabilities.features = ['workspace_qualified_voice'];
+    mocks.qualifiedWorkspaceVoice.mockResolvedValue(
+      voiceStatus(true, '/tmp/secondary-a'),
+    );
+    let resolveRefresh: () => void = () => undefined;
+    mocks.workspace.refreshCapabilities.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveRefresh = resolve;
+      }),
+    );
+    const targetA: VoiceWorkspaceTarget = {
+      route: 'workspace-qualified',
+      cwd: '/tmp/secondary-a',
+      workspaceKey: 'secondary-a',
+      ownerKey: 'secondary-a:session-a',
+      sessionId: 'session-a',
+      selector: { kind: 'id', value: 'secondary-a' },
+      streamPath: 'workspaces/secondary-a/voice/stream',
+    };
+    const targetB: VoiceWorkspaceTarget = {
+      route: 'workspace-qualified',
+      cwd: '/tmp/secondary-b',
+      workspaceKey: 'secondary-b',
+      ownerKey: 'secondary-b:session-b',
+      sessionId: 'session-b',
+      selector: { kind: 'id', value: 'secondary-b' },
+      streamPath: 'workspaces/secondary-b/voice/stream',
+    };
+    const { root, container } = mount(false, targetA);
+    await flush();
+    expect(container.querySelector('button')).not.toBeNull();
+
+    act(() => {
+      mocks.captureOptions?.onUnexpectedClose?.({
+        code: 1012,
+        reason: 'workspace removed',
+      });
+    });
+    expect(mocks.workspace.refreshCapabilities).toHaveBeenCalledOnce();
+
+    mocks.connection.sessionId = 'session-b';
+    mocks.connection.workspaceCwd = '/tmp/secondary-b';
+    mocks.qualifiedWorkspaceVoice.mockResolvedValue(
+      voiceStatus(true, '/tmp/secondary-b'),
+    );
+    act(() => {
+      root.render(
+        <VoiceButton disabled={false} onInsert={() => {}} target={targetB} />,
+      );
+    });
+    await flush();
+    expect(container.querySelector('button')).not.toBeNull();
+
+    mocks.capture.status = 'recording';
+    act(() => {
+      root.render(
+        <VoiceButton disabled={false} onInsert={() => {}} target={targetB} />,
+      );
+    });
+    mocks.capture.abort.mockClear();
+    const statusRequestCount = mocks.qualifiedWorkspaceVoice.mock.calls.length;
+
+    await act(async () => {
+      resolveRefresh();
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('button')).not.toBeNull();
+    expect(mocks.capture.abort).not.toHaveBeenCalled();
+    expect(mocks.qualifiedWorkspaceVoice).toHaveBeenCalledTimes(
+      statusRequestCount,
+    );
+    expect(mocks.captureOptions?.target).toEqual({
+      ownerKey: targetB.ownerKey,
+      streamPath: targetB.streamPath,
+    });
+  });
+
+  it('revalidates the same owner after a successful 1012 refresh', async () => {
+    const { container } = mount(false);
+    await flush();
+    expect(container.querySelector('button')).not.toBeNull();
+    mocks.workspaceVoice.mockResolvedValue(voiceStatus(false));
+
+    act(() => {
+      mocks.captureOptions?.onUnexpectedClose?.({
+        code: 1012,
+        reason: 'daemon restart',
+      });
+    });
+    await flush();
+
+    expect(mocks.workspace.refreshCapabilities).toHaveBeenCalledOnce();
+    expect(mocks.workspaceVoice).toHaveBeenCalledTimes(2);
+    expect(container.querySelector('button')).toBeNull();
+  });
+
+  it('keeps the same-owner gate closed when a 1012 refresh fails', async () => {
+    mocks.workspace.refreshCapabilities.mockRejectedValue(
+      new Error('refresh failed'),
+    );
+    const { container } = mount(false);
+    await flush();
+    expect(container.querySelector('button')).not.toBeNull();
+
+    act(() => {
+      mocks.captureOptions?.onUnexpectedClose?.({
+        code: 1012,
+        reason: 'workspace removed',
+      });
+    });
+    await flush();
+
+    expect(mocks.workspace.refreshCapabilities).toHaveBeenCalledOnce();
+    expect(mocks.workspaceVoice).toHaveBeenCalledOnce();
+    expect(container.querySelector('button')).toBeNull();
+    expect(mocks.captureOptions?.target).toEqual({
+      ownerKey: legacyTarget.ownerKey,
+      streamPath: legacyTarget.streamPath,
+    });
   });
 
   it('lets a disabled composer stop active dictation', async () => {
@@ -276,6 +570,7 @@ describe('VoiceButton', () => {
   it('lets a disabled composer abort a connecting dictation', async () => {
     mocks.capture.status = 'connecting';
     const button = await render(true);
+    mocks.capture.abort.mockClear();
 
     expect(button.disabled).toBe(false);
     click(button);
@@ -285,7 +580,7 @@ describe('VoiceButton', () => {
 
   it('reports whether voice capture is active', async () => {
     const onActiveChange = vi.fn();
-    const { root } = mount(false, onActiveChange);
+    const { root } = mount(false, legacyTarget, onActiveChange);
     await flush();
     expect(onActiveChange).toHaveBeenLastCalledWith(false);
 
@@ -295,6 +590,7 @@ describe('VoiceButton', () => {
         <VoiceButton
           disabled={false}
           onInsert={() => {}}
+          target={legacyTarget}
           onActiveChange={onActiveChange}
         />,
       );
@@ -307,6 +603,7 @@ describe('VoiceButton', () => {
         <VoiceButton
           disabled={false}
           onInsert={() => {}}
+          target={legacyTarget}
           onActiveChange={onActiveChange}
         />,
       );

--- a/packages/web-shell/client/voice/VoiceButton.tsx
+++ b/packages/web-shell/client/voice/VoiceButton.tsx
@@ -5,17 +5,22 @@
  */
 
 import type React from 'react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
+  useConnection,
   useWorkspace,
   useWorkspaceEventSignals,
 } from '@qwen-code/webui/daemon-react-sdk';
 import { useI18n } from '../i18n';
 import { useVoiceCapture } from './useVoiceCapture';
+import {
+  loadVoiceStatus,
+  supportsVoiceCapture,
+  type VoiceStatusRevision,
+  type VoiceWorkspaceTarget,
+} from './voice-workspace-target';
 import styles from './VoiceButton.module.css';
 
-/** Daemon capability tag gating the mic (see serve/capabilities.ts). */
-const VOICE_FEATURE = 'voice_transcribe';
 /** Live waveform bar count in the recording pill. */
 const BAR_COUNT = 16;
 const NOTICE_TIMEOUT_MS = 2_000;
@@ -25,6 +30,8 @@ export interface VoiceButtonProps {
   onInsert: (text: string) => void;
   onActiveChange?: (active: boolean) => void;
   disabled?: boolean;
+  target: VoiceWorkspaceTarget | undefined;
+  statusRevision?: VoiceStatusRevision;
 }
 
 const MicIcon = (): React.JSX.Element => (
@@ -63,38 +70,86 @@ export function VoiceButton({
   onInsert,
   onActiveChange,
   disabled,
+  target,
+  statusRevision = { user: 0, workspace: 0 },
 }: VoiceButtonProps): React.JSX.Element | null {
   const workspace = useWorkspace();
-  const settingsVersion = useWorkspaceEventSignals()?.settingsVersion;
+  const connection = useConnection();
+  const signals = useWorkspaceEventSignals();
   const { t } = useI18n();
   const features = workspace.capabilities?.features ?? [];
-  const hasVoiceCapability = features.includes(VOICE_FEATURE);
+  const captureSupported = supportsVoiceCapture(target, features);
+  const settingsVersion =
+    target?.sessionId &&
+    target.sessionId === connection.sessionId &&
+    (!target.cwd || target.cwd === connection.workspaceCwd)
+      ? signals?.settingsVersion
+      : undefined;
+  const [localRevision, setLocalRevision] = useState(0);
+  const [capabilityRefreshFailed, setCapabilityRefreshFailed] = useState(false);
+  const queryKey = useMemo(
+    () =>
+      target
+        ? JSON.stringify([
+            target.workspaceKey,
+            target.ownerKey,
+            settingsVersion ?? null,
+            statusRevision.user,
+            statusRevision.workspace,
+            localRevision,
+          ])
+        : undefined,
+    [
+      localRevision,
+      settingsVersion,
+      statusRevision.user,
+      statusRevision.workspace,
+      target,
+    ],
+  );
   const [voiceGate, setVoiceGate] = useState<{
-    client: typeof workspace.client;
-    settingsVersion: number | undefined;
+    queryKey: string | undefined;
     enabled: boolean;
   }>(() => ({
-    client: workspace.client,
-    settingsVersion,
+    queryKey,
     enabled: false,
   }));
+  const targetRef = useRef(target);
+  targetRef.current = target;
+  const requestGenerationRef = useRef(0);
+  const capabilityRefreshGenerationRef = useRef(0);
+  const mountedRef = useRef(false);
 
   useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      capabilityRefreshGenerationRef.current += 1;
+    };
+  }, []);
+
+  useEffect(() => {
+    const generation = ++requestGenerationRef.current;
+    const requestTarget = targetRef.current;
     let current = true;
     setVoiceGate({
-      client: workspace.client,
-      settingsVersion,
+      queryKey,
       enabled: false,
     });
-    if (!hasVoiceCapability) return undefined;
+    if (
+      !requestTarget ||
+      !queryKey ||
+      !captureSupported ||
+      capabilityRefreshFailed
+    ) {
+      return undefined;
+    }
 
-    void workspace.client
-      .workspaceVoice()
+    void loadVoiceStatus(workspace.client, requestTarget)
       .then((voice) => {
-        if (current) {
+        if (current && requestGenerationRef.current === generation) {
           setVoiceGate({
-            client: workspace.client,
-            settingsVersion,
+            queryKey,
             enabled: voice.enabled === true,
           });
         }
@@ -104,12 +159,12 @@ export function VoiceButton({
     return () => {
       current = false;
     };
-  }, [hasVoiceCapability, settingsVersion, workspace.client]);
+  }, [capabilityRefreshFailed, captureSupported, queryKey, workspace.client]);
 
   const voiceEnabled =
-    hasVoiceCapability &&
-    voiceGate.client === workspace.client &&
-    voiceGate.settingsVersion === settingsVersion &&
+    captureSupported &&
+    !capabilityRefreshFailed &&
+    voiceGate.queryKey === queryKey &&
     voiceGate.enabled;
   // Surfaced when a recording finalizes with no transcript (e.g. silence).
   const [noticeMessage, setNoticeMessage] = useState<string | undefined>(
@@ -128,6 +183,9 @@ export function VoiceButton({
     useVoiceCapture({
       baseUrl: workspace.baseUrl,
       token: workspace.token,
+      target: target
+        ? { ownerKey: target.ownerKey, streamPath: target.streamPath }
+        : undefined,
       onFinal: (text) => {
         const trimmed = text.trim();
         if (trimmed) {
@@ -136,6 +194,28 @@ export function VoiceButton({
         } else {
           setNoticeMessage(t('voice.noSpeech'));
         }
+      },
+      onUnexpectedClose: ({ code }) => {
+        if (code === 1013) return;
+        setLocalRevision((revision) => revision + 1);
+        if (code !== 1012) return;
+        const refreshOwnerKey = targetRef.current?.ownerKey;
+        const refreshGeneration = ++capabilityRefreshGenerationRef.current;
+        setCapabilityRefreshFailed(true);
+        void workspace
+          .refreshCapabilities?.()
+          .then(() => {
+            if (
+              !mountedRef.current ||
+              capabilityRefreshGenerationRef.current !== refreshGeneration ||
+              targetRef.current?.ownerKey !== refreshOwnerKey
+            ) {
+              return;
+            }
+            setCapabilityRefreshFailed(false);
+            setLocalRevision((revision) => revision + 1);
+          })
+          .catch(() => undefined);
       },
     });
 
@@ -184,12 +264,8 @@ export function VoiceButton({
     return () => clearInterval(id);
   }, [isRecording]);
 
-  const voiceWasEnabled = useRef(voiceEnabled);
-  useEffect(() => {
-    const wasEnabled = voiceWasEnabled.current;
-    voiceWasEnabled.current = voiceEnabled;
+  useLayoutEffect(() => {
     if (
-      wasEnabled &&
       !voiceEnabled &&
       (status === 'recording' ||
         status === 'connecting' ||
@@ -198,6 +274,15 @@ export function VoiceButton({
       abort();
     }
   }, [abort, status, voiceEnabled]);
+
+  const previousOwnerRef = useRef(target?.ownerKey);
+  useLayoutEffect(() => {
+    if (previousOwnerRef.current === target?.ownerKey) return;
+    previousOwnerRef.current = target?.ownerKey;
+    capabilityRefreshGenerationRef.current += 1;
+    setNoticeMessage(undefined);
+    setCapabilityRefreshFailed(false);
+  }, [target?.ownerKey]);
 
   if (!voiceEnabled) return null;
 

--- a/packages/web-shell/client/voice/VoiceButton.tsx
+++ b/packages/web-shell/client/voice/VoiceButton.tsx
@@ -154,7 +154,9 @@ export function VoiceButton({
           });
         }
       })
-      .catch(() => undefined);
+      .catch((error: unknown) => {
+        console.warn('[web-shell] Voice status probe failed:', error);
+      });
 
     return () => {
       current = false;
@@ -202,20 +204,27 @@ export function VoiceButton({
         const refreshOwnerKey = targetRef.current?.ownerKey;
         const refreshGeneration = ++capabilityRefreshGenerationRef.current;
         setCapabilityRefreshFailed(true);
-        void workspace
-          .refreshCapabilities?.()
-          .then(() => {
-            if (
-              !mountedRef.current ||
-              capabilityRefreshGenerationRef.current !== refreshGeneration ||
-              targetRef.current?.ownerKey !== refreshOwnerKey
-            ) {
-              return;
-            }
-            setCapabilityRefreshFailed(false);
-            setLocalRevision((revision) => revision + 1);
-          })
-          .catch(() => undefined);
+        const settleRefresh = () => {
+          if (
+            !mountedRef.current ||
+            capabilityRefreshGenerationRef.current !== refreshGeneration ||
+            targetRef.current?.ownerKey !== refreshOwnerKey
+          ) {
+            return;
+          }
+          setCapabilityRefreshFailed(false);
+          setLocalRevision((revision) => revision + 1);
+        };
+        try {
+          const refresh = workspace.refreshCapabilities?.();
+          if (refresh) {
+            void refresh.then(settleRefresh, settleRefresh);
+          } else {
+            settleRefresh();
+          }
+        } catch {
+          settleRefresh();
+        }
       },
     });
 

--- a/packages/web-shell/client/voice/use-voice-workspace-settings.test.tsx
+++ b/packages/web-shell/client/voice/use-voice-workspace-settings.test.tsx
@@ -109,6 +109,30 @@ describe('useVoiceWorkspaceSettings', () => {
     expect(workspaceSettingsA).toHaveBeenCalledOnce();
   });
 
+  it('keeps the current descriptor visible during a same-owner refresh', async () => {
+    workspaceSettingsA.mockResolvedValueOnce(settings('voice-a'));
+    currentTarget = targetA;
+    await render();
+    expect(result?.descriptor?.values.effective).toBe('voice-a');
+
+    let resolveRefresh: (value: ReturnType<typeof settings>) => void = () =>
+      undefined;
+    workspaceSettingsA.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveRefresh = resolve;
+      }),
+    );
+    currentRevision = '1';
+    await render();
+    expect(result?.descriptor?.values.effective).toBe('voice-a');
+
+    await act(async () => {
+      resolveRefresh(settings('new-a'));
+      await Promise.resolve();
+    });
+    expect(result?.descriptor?.values.effective).toBe('new-a');
+  });
+
   it('rejects stale A to B to A responses by request generation', async () => {
     let resolveFirstA: (value: ReturnType<typeof settings>) => void = () =>
       undefined;

--- a/packages/web-shell/client/voice/use-voice-workspace-settings.test.tsx
+++ b/packages/web-shell/client/voice/use-voice-workspace-settings.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { DaemonClient } from '@qwen-code/sdk/daemon';
+import { useVoiceWorkspaceSettings } from './use-voice-workspace-settings';
+import type { VoiceWorkspaceTarget } from './voice-workspace-target';
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+const targetA: VoiceWorkspaceTarget = {
+  route: 'workspace-qualified',
+  cwd: '/a',
+  workspaceKey: 'a',
+  ownerKey: 'a:session',
+  sessionId: 'session-a',
+  selector: { kind: 'id', value: 'a' },
+  streamPath: 'workspaces/a/voice/stream',
+};
+const targetB: VoiceWorkspaceTarget = {
+  route: 'workspace-qualified',
+  cwd: '/b',
+  workspaceKey: 'b',
+  ownerKey: 'b:session',
+  sessionId: 'session-b',
+  selector: { kind: 'id', value: 'b' },
+  streamPath: 'workspaces/b/voice/stream',
+};
+
+function settings(value: string) {
+  return {
+    v: 1 as const,
+    settings: [
+      {
+        key: 'voiceModel',
+        type: 'string',
+        label: 'Voice model',
+        category: 'model',
+        requiresRestart: false,
+        default: '',
+        values: { effective: value, workspace: value },
+      },
+    ],
+  };
+}
+
+let root: Root | undefined;
+let container: HTMLDivElement | undefined;
+let currentTarget: VoiceWorkspaceTarget | undefined;
+let currentRevision = '0';
+let result: ReturnType<typeof useVoiceWorkspaceSettings> | undefined;
+const workspaceSettingsA = vi.fn();
+const workspaceSettingsB = vi.fn();
+const client = {
+  workspaceById: vi.fn((id: string) => ({
+    workspaceSettings: id === 'a' ? workspaceSettingsA : workspaceSettingsB,
+  })),
+} as unknown as DaemonClient;
+
+function Host() {
+  result = useVoiceWorkspaceSettings(
+    client,
+    currentTarget,
+    true,
+    currentRevision,
+  );
+  return null;
+}
+
+async function render() {
+  if (!container) {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  }
+  await act(async () => {
+    root?.render(<Host />);
+    await Promise.resolve();
+  });
+}
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = undefined;
+  container = undefined;
+  result = undefined;
+  currentTarget = undefined;
+  currentRevision = '0';
+  workspaceSettingsA.mockReset();
+  workspaceSettingsB.mockReset();
+});
+
+describe('useVoiceWorkspaceSettings', () => {
+  it('loads only the qualified Voice descriptor', async () => {
+    currentTarget = targetA;
+    workspaceSettingsA.mockResolvedValue(settings('voice-a'));
+
+    await render();
+
+    expect(result?.descriptor?.values.effective).toBe('voice-a');
+    expect(workspaceSettingsA).toHaveBeenCalledOnce();
+  });
+
+  it('rejects stale A to B to A responses by request generation', async () => {
+    let resolveFirstA: (value: ReturnType<typeof settings>) => void = () =>
+      undefined;
+    workspaceSettingsA
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFirstA = resolve;
+        }),
+      )
+      .mockResolvedValueOnce(settings('new-a'));
+    workspaceSettingsB.mockResolvedValue(settings('voice-b'));
+    currentTarget = targetA;
+    await render();
+
+    currentTarget = targetB;
+    await render();
+    expect(result?.descriptor?.values.effective).toBe('voice-b');
+
+    currentTarget = targetA;
+    currentRevision = '1';
+    await render();
+    expect(result?.descriptor?.values.effective).toBe('new-a');
+
+    await act(async () => {
+      resolveFirstA(settings('stale-a'));
+      await Promise.resolve();
+    });
+    expect(result?.descriptor?.values.effective).toBe('new-a');
+  });
+
+  it('does not let an old target reload invalidate the current target', async () => {
+    currentTarget = targetA;
+    workspaceSettingsA.mockResolvedValue(settings('voice-a'));
+    await render();
+    const reloadA = result?.reload;
+    if (!reloadA) throw new Error('target A reload was not available');
+
+    workspaceSettingsB.mockResolvedValue(settings('voice-b'));
+    currentTarget = targetB;
+    await render();
+    expect(result?.descriptor?.values.effective).toBe('voice-b');
+
+    await act(async () => {
+      await reloadA();
+    });
+
+    expect(workspaceSettingsA).toHaveBeenCalledOnce();
+    expect(result?.descriptor?.values.effective).toBe('voice-b');
+  });
+});

--- a/packages/web-shell/client/voice/use-voice-workspace-settings.ts
+++ b/packages/web-shell/client/voice/use-voice-workspace-settings.ts
@@ -27,52 +27,61 @@ export function useVoiceWorkspaceSettings(
   revisionKey: string,
 ): VoiceWorkspaceSettingsState {
   const requestRef = useRef(0);
-  const targetKey =
+  const ownerKey =
     enabled && target?.route === 'workspace-qualified'
-      ? JSON.stringify([target.ownerKey, revisionKey])
+      ? target.ownerKey
       : undefined;
-  const currentKeyRef = useRef(targetKey);
-  currentKeyRef.current = targetKey;
+  const requestKey = ownerKey
+    ? JSON.stringify([ownerKey, revisionKey])
+    : undefined;
+  const currentRequestKeyRef = useRef(requestKey);
+  currentRequestKeyRef.current = requestKey;
   const [state, setState] = useState<{
-    key: string | undefined;
+    ownerKey: string | undefined;
     status: DaemonWorkspaceSettingsStatus | undefined;
   }>({
-    key: targetKey,
+    ownerKey,
     status: undefined,
   });
 
   const reload = useCallback(async () => {
-    const key = targetKey;
-    if (currentKeyRef.current !== key) return undefined;
+    const key = requestKey;
+    if (currentRequestKeyRef.current !== key) return undefined;
     const request = ++requestRef.current;
-    if (!key || !target || target.route !== 'workspace-qualified') {
+    if (
+      !key ||
+      !ownerKey ||
+      !target ||
+      target.route !== 'workspace-qualified'
+    ) {
       setState({
-        key,
+        ownerKey,
         status: undefined,
       });
       return undefined;
     }
 
-    setState({
-      key,
-      status: undefined,
-    });
+    setState((current) =>
+      current.ownerKey === ownerKey
+        ? current
+        : {
+            ownerKey,
+            status: undefined,
+          },
+    );
     try {
       const status = await loadVoiceSettings(client, target);
-      if (request === requestRef.current && currentKeyRef.current === key) {
-        setState({ key, status });
+      if (
+        request === requestRef.current &&
+        currentRequestKeyRef.current === key
+      ) {
+        setState({ ownerKey, status });
       }
       return status;
     } catch {
-      if (request === requestRef.current && currentKeyRef.current === key) {
-        setState({
-          key,
-          status: undefined,
-        });
-      }
       return undefined;
     }
-  }, [client, target, targetKey]);
+  }, [client, ownerKey, requestKey, target]);
   const invalidate = useCallback(() => {
     requestRef.current++;
   }, []);
@@ -82,7 +91,7 @@ export function useVoiceWorkspaceSettings(
     return invalidate;
   }, [invalidate, reload]);
 
-  const current = state.key === targetKey ? state : undefined;
+  const current = state.ownerKey === ownerKey ? state : undefined;
   return {
     descriptor: current?.status?.settings.find(
       (setting) => setting.key === 'voiceModel',

--- a/packages/web-shell/client/voice/use-voice-workspace-settings.ts
+++ b/packages/web-shell/client/voice/use-voice-workspace-settings.ts
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type {
+  DaemonClient,
+  DaemonSettingDescriptor,
+  DaemonWorkspaceSettingsStatus,
+} from '@qwen-code/sdk/daemon';
+import {
+  loadVoiceSettings,
+  type VoiceWorkspaceTarget,
+} from './voice-workspace-target';
+
+interface VoiceWorkspaceSettingsState {
+  descriptor: DaemonSettingDescriptor | undefined;
+  reload: () => Promise<DaemonWorkspaceSettingsStatus | undefined>;
+}
+
+export function useVoiceWorkspaceSettings(
+  client: DaemonClient,
+  target: VoiceWorkspaceTarget | undefined,
+  enabled: boolean,
+  revisionKey: string,
+): VoiceWorkspaceSettingsState {
+  const requestRef = useRef(0);
+  const targetKey =
+    enabled && target?.route === 'workspace-qualified'
+      ? JSON.stringify([target.ownerKey, revisionKey])
+      : undefined;
+  const currentKeyRef = useRef(targetKey);
+  currentKeyRef.current = targetKey;
+  const [state, setState] = useState<{
+    key: string | undefined;
+    status: DaemonWorkspaceSettingsStatus | undefined;
+  }>({
+    key: targetKey,
+    status: undefined,
+  });
+
+  const reload = useCallback(async () => {
+    const key = targetKey;
+    if (currentKeyRef.current !== key) return undefined;
+    const request = ++requestRef.current;
+    if (!key || !target || target.route !== 'workspace-qualified') {
+      setState({
+        key,
+        status: undefined,
+      });
+      return undefined;
+    }
+
+    setState({
+      key,
+      status: undefined,
+    });
+    try {
+      const status = await loadVoiceSettings(client, target);
+      if (request === requestRef.current && currentKeyRef.current === key) {
+        setState({ key, status });
+      }
+      return status;
+    } catch {
+      if (request === requestRef.current && currentKeyRef.current === key) {
+        setState({
+          key,
+          status: undefined,
+        });
+      }
+      return undefined;
+    }
+  }, [client, target, targetKey]);
+  const invalidate = useCallback(() => {
+    requestRef.current++;
+  }, []);
+
+  useEffect(() => {
+    void reload();
+    return invalidate;
+  }, [invalidate, reload]);
+
+  const current = state.key === targetKey ? state : undefined;
+  return {
+    descriptor: current?.status?.settings.find(
+      (setting) => setting.key === 'voiceModel',
+    ),
+    reload,
+  };
+}

--- a/packages/web-shell/client/voice/useVoiceCapture.test.tsx
+++ b/packages/web-shell/client/voice/useVoiceCapture.test.tsx
@@ -622,6 +622,8 @@ describe('useVoiceCapture', () => {
     await act(async () => {
       result.start();
     });
+    const context = MockAudioContext.latest;
+    if (!context) throw new Error('audio context was not created');
     await act(async () => {
       root?.unmount();
     });
@@ -633,7 +635,7 @@ describe('useVoiceCapture', () => {
 
     expect(track.stop).toHaveBeenCalledTimes(1);
     expect(MockWebSocket.latest).toBeUndefined();
-    expect(MockAudioContext.latest).toBeUndefined();
+    expect(context.close).toHaveBeenCalledOnce();
     expect(onFinal).not.toHaveBeenCalled();
     expect(onError).not.toHaveBeenCalled();
   });

--- a/packages/web-shell/client/voice/useVoiceCapture.test.tsx
+++ b/packages/web-shell/client/voice/useVoiceCapture.test.tsx
@@ -49,6 +49,8 @@ function node() {
 }
 
 class MockAudioContext {
+  static latest: MockAudioContext | undefined;
+
   state = 'running';
   sampleRate = 16_000;
   readonly destination = {};
@@ -59,6 +61,10 @@ class MockAudioContext {
   close = vi.fn(async () => {
     this.state = 'closed';
   });
+
+  constructor() {
+    MockAudioContext.latest = this;
+  }
 }
 
 let root: Root | null = null;
@@ -66,9 +72,12 @@ let container: HTMLDivElement | null = null;
 let capture: UseVoiceCaptureReturn | undefined;
 const onFinal = vi.fn();
 const onError = vi.fn();
+const onUnexpectedClose = vi.fn();
 const track = { stop: vi.fn() };
 let baseUrl = 'http://127.0.0.1:1234';
 let token: string | undefined;
+let ownerKey = 'workspace-a:session-a';
+let streamPath = 'voice/stream';
 
 /** Decode a `qwen-bearer.<base64url>` subprotocol back to the raw token. */
 function decodeBearerSubprotocol(proto: string): string {
@@ -85,8 +94,10 @@ function TestHost() {
   capture = useVoiceCapture({
     baseUrl,
     token,
+    target: { ownerKey, streamPath },
     onFinal,
     onError,
+    onUnexpectedClose,
   });
   return null;
 }
@@ -106,10 +117,14 @@ beforeEach(() => {
   capture = undefined;
   onFinal.mockReset();
   onError.mockReset();
+  onUnexpectedClose.mockReset();
   track.stop.mockReset();
   baseUrl = 'http://127.0.0.1:1234';
   token = undefined;
+  ownerKey = 'workspace-a:session-a';
+  streamPath = 'voice/stream';
   MockWebSocket.latest = undefined;
+  MockAudioContext.latest = undefined;
   Object.defineProperty(globalThis, 'WebSocket', {
     value: MockWebSocket,
     configurable: true,
@@ -151,6 +166,20 @@ describe('useVoiceCapture', () => {
 
     expect(MockWebSocket.latest?.url).toBe(
       'wss://example.test/qwen/voice/stream',
+    );
+  });
+
+  it('uses a workspace-qualified stream path without double encoding', async () => {
+    baseUrl = 'https://example.test/qwen/';
+    streamPath = 'workspaces/%2Frepo%2F%E4%BA%8C%20%E6%AC%A1/voice/stream';
+    const result = await renderHookHost();
+
+    await act(async () => {
+      result.start();
+    });
+
+    expect(MockWebSocket.latest?.url).toBe(
+      'wss://example.test/qwen/workspaces/%2Frepo%2F%E4%BA%8C%20%E6%AC%A1/voice/stream',
     );
   });
 
@@ -336,6 +365,36 @@ describe('useVoiceCapture', () => {
     expect(capture?.status).toBe('error');
   });
 
+  it('cleans up when the unexpected-close callback throws', async () => {
+    onUnexpectedClose.mockImplementation(() => {
+      throw new Error('close callback failed');
+    });
+    const result = await renderHookHost();
+
+    await act(async () => {
+      result.start();
+    });
+    const ws = MockWebSocket.latest;
+    const context = MockAudioContext.latest;
+    if (!ws || !context) throw new Error('capture resources were not created');
+
+    await act(async () => {
+      ws.onopen?.();
+    });
+    await act(async () => {
+      ws.onclose?.({ code: 1006, reason: '' } as CloseEvent);
+    });
+
+    expect(onUnexpectedClose).toHaveBeenCalledWith({
+      code: 1006,
+      reason: 'none',
+    });
+    expect(capture?.status).toBe('error');
+    expect(track.stop).toHaveBeenCalledOnce();
+    expect(context.close).toHaveBeenCalledOnce();
+    expect(ws.readyState).toBe(3);
+  });
+
   it('does not leak a transcription timer when stop is called twice', async () => {
     vi.useFakeTimers();
     const result = await renderHookHost();
@@ -417,5 +476,165 @@ describe('useVoiceCapture', () => {
     expect(capture?.status).toBe('connecting');
     expect(secondWs.readyState).toBe(MockWebSocket.OPEN);
     expect(onFinal).not.toHaveBeenCalled();
+  });
+
+  it('aborts and drops an old final when the owner changes', async () => {
+    const result = await renderHookHost();
+    await act(async () => {
+      result.start();
+    });
+    const firstWs = MockWebSocket.latest;
+    const staleMessage = firstWs?.onmessage;
+    if (!firstWs || !staleMessage) throw new Error('socket was not ready');
+
+    ownerKey = 'workspace-b:session-b';
+    await act(async () => {
+      root?.render(React.createElement(TestHost));
+    });
+
+    expect(firstWs.sent).toContain(JSON.stringify({ type: 'abort' }));
+    expect(track.stop).toHaveBeenCalled();
+    expect(capture?.status).toBe('idle');
+
+    await act(async () => {
+      staleMessage({
+        data: JSON.stringify({ type: 'final', text: 'wrong owner' }),
+      } as MessageEvent);
+    });
+    expect(onFinal).not.toHaveBeenCalled();
+  });
+
+  it('clears an old owner error before the new owner can retry', async () => {
+    const result = await renderHookHost();
+    await act(async () => {
+      result.start();
+    });
+    const firstWs = MockWebSocket.latest;
+    if (!firstWs) throw new Error('socket was not ready');
+    await act(async () => {
+      firstWs.onmessage?.({
+        data: JSON.stringify({ type: 'error', message: 'owner A failed' }),
+      } as MessageEvent);
+    });
+    expect(capture?.status).toBe('error');
+
+    ownerKey = 'workspace-b:session-b';
+    await act(async () => {
+      root?.render(React.createElement(TestHost));
+    });
+
+    expect(capture?.status).toBe('idle');
+    expect(capture?.errorMessage).toBeUndefined();
+  });
+
+  it('stops a pending microphone stream after the owner changes', async () => {
+    let resolveStream:
+      | ((stream: { getTracks: () => Array<typeof track> }) => void)
+      | undefined;
+    Object.defineProperty(navigator, 'mediaDevices', {
+      value: {
+        getUserMedia: vi.fn(
+          () =>
+            new Promise<{ getTracks: () => Array<typeof track> }>((resolve) => {
+              resolveStream = resolve;
+            }),
+        ),
+      },
+      configurable: true,
+    });
+    const result = await renderHookHost();
+    await act(async () => {
+      result.start();
+    });
+
+    ownerKey = 'workspace-b:session-b';
+    await act(async () => {
+      root?.render(React.createElement(TestHost));
+    });
+    await act(async () => {
+      resolveStream?.({ getTracks: () => [track] });
+    });
+
+    expect(track.stop).toHaveBeenCalledTimes(1);
+    expect(MockWebSocket.latest).toBeUndefined();
+    expect(onFinal).not.toHaveBeenCalled();
+  });
+
+  it('releases an active capture when the hook unmounts', async () => {
+    vi.useFakeTimers();
+    const result = await renderHookHost();
+    await act(async () => {
+      result.start();
+    });
+    const ws = MockWebSocket.latest;
+    const context = MockAudioContext.latest;
+    if (!ws || !context) throw new Error('capture resources were not created');
+    const staleMessage = ws.onmessage;
+    const source = context.createMediaStreamSource.mock.results[0]?.value;
+    const processor = context.createScriptProcessor.mock.results[0]?.value;
+    const sink = context.createGain.mock.results[0]?.value;
+
+    await act(async () => {
+      ws.onopen?.();
+    });
+    expect(capture?.status).toBe('recording');
+    expect(vi.getTimerCount()).toBe(1);
+
+    await act(async () => {
+      root?.unmount();
+    });
+    root = null;
+
+    expect(track.stop).toHaveBeenCalledTimes(1);
+    expect(source?.disconnect).toHaveBeenCalledOnce();
+    expect(processor?.disconnect).toHaveBeenCalledOnce();
+    expect(sink?.disconnect).toHaveBeenCalledOnce();
+    expect(context.close).toHaveBeenCalledOnce();
+    expect(ws.readyState).toBe(3);
+    expect(ws.onmessage).toBeNull();
+    expect(ws.onerror).toBeNull();
+    expect(ws.onclose).toBeNull();
+    expect(vi.getTimerCount()).toBe(0);
+
+    staleMessage?.({
+      data: JSON.stringify({ type: 'final', text: 'after unmount' }),
+    } as MessageEvent);
+    expect(onFinal).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('stops a microphone stream that resolves after unmount', async () => {
+    let resolveStream:
+      | ((stream: { getTracks: () => Array<typeof track> }) => void)
+      | undefined;
+    Object.defineProperty(navigator, 'mediaDevices', {
+      value: {
+        getUserMedia: vi.fn(
+          () =>
+            new Promise<{ getTracks: () => Array<typeof track> }>((resolve) => {
+              resolveStream = resolve;
+            }),
+        ),
+      },
+      configurable: true,
+    });
+    const result = await renderHookHost();
+    await act(async () => {
+      result.start();
+    });
+    await act(async () => {
+      root?.unmount();
+    });
+    root = null;
+
+    await act(async () => {
+      resolveStream?.({ getTracks: () => [track] });
+    });
+
+    expect(track.stop).toHaveBeenCalledTimes(1);
+    expect(MockWebSocket.latest).toBeUndefined();
+    expect(MockAudioContext.latest).toBeUndefined();
+    expect(onFinal).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
   });
 });

--- a/packages/web-shell/client/voice/useVoiceCapture.ts
+++ b/packages/web-shell/client/voice/useVoiceCapture.ts
@@ -4,20 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 
 /**
- * Browser-side voice capture for the Web Shell. Captures the microphone via
- * `getUserMedia`, downsamples to 16 kHz mono s16le PCM in an AudioWorklet, and
- * streams the raw frames to the daemon's `/voice/stream` WebSocket. The daemon
- * transcribes server-side (credentials never reach the browser) and returns
- * interim/final transcripts.
- *
- * Note: browsers cannot set an `Authorization` header on a WebSocket. When a
- * bearer token is configured it rides in the `Sec-WebSocket-Protocol`
- * subprotocol as `qwen-bearer.<base64url(token)>` (see `bearerSubprotocol`),
- * which the daemon's ACP upgrade listener verifies — so this works against both
- * no-token loopback and token-required deployments.
+ * Captures 16 kHz mono PCM in the browser and streams it to the immutable
+ * workspace owner selected when recording starts. Credentials remain in the
+ * browser-to-daemon transport; transcription stays server-side.
  */
 export type VoiceCaptureStatus =
   | 'idle'
@@ -26,12 +24,24 @@ export type VoiceCaptureStatus =
   | 'transcribing'
   | 'error';
 
+export interface VoiceCaptureTarget {
+  ownerKey: string;
+  streamPath: string;
+}
+
+export interface VoiceUnexpectedClose {
+  code: number;
+  reason: string;
+}
+
 export interface UseVoiceCaptureOptions {
   baseUrl: string;
   token?: string;
+  target: VoiceCaptureTarget | undefined;
   /** Called with the final transcript (may be empty). */
   onFinal: (text: string) => void;
   onError?: (message: string) => void;
+  onUnexpectedClose?: (event: VoiceUnexpectedClose) => void;
 }
 
 export interface UseVoiceCaptureReturn {
@@ -50,25 +60,24 @@ const FRAME_SIZE = 4096;
 const START_TIMEOUT_MS = 60_000;
 const TRANSCRIPTION_TIMEOUT_MS = 60_000;
 
-function toWebSocketUrl(baseUrl: string): string {
+export function toVoiceWebSocketUrl(
+  baseUrl: string,
+  streamPath: string,
+): string {
   const base = new URL(baseUrl);
   const basePath = base.pathname.replace(/\/?$/, '/');
-  const url = new URL('voice/stream', `${base.origin}${basePath}`);
+  const url = new URL(
+    streamPath.replace(/^\/+/, ''),
+    `${base.origin}${basePath}`,
+  );
   url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
   return url.toString();
 }
 
-/**
- * Browsers can't set an `Authorization` header on a WebSocket, so the bearer
- * token rides in `Sec-WebSocket-Protocol` as `qwen-bearer.<base64url(token)>`.
- * The daemon's ACP upgrade listener decodes it (serve/acp-http/index.ts) — keep
- * this prefix in sync with `WS_BEARER_SUBPROTOCOL_PREFIX` there.
- */
+// Browsers cannot set Authorization on a WebSocket. The daemon decodes this
+// bearer subprotocol during the upgrade; keep the prefix in sync with it.
 const WS_BEARER_SUBPROTOCOL_PREFIX = 'qwen-bearer.';
-// Non-secret marker offered alongside the bearer subprotocol. The daemon
-// completes the handshake by selecting THIS (never echoing the secret), which
-// also satisfies WS clients that require the server to pick an offered
-// subprotocol when any were requested. Must not start with the bearer prefix.
+// The daemon selects this non-secret marker instead of echoing the bearer.
 const WS_AUTH_SUBPROTOCOL = 'qwen-ws';
 
 function bearerSubprotocol(token: string): string {
@@ -84,7 +93,6 @@ function bearerSubprotocol(token: string): string {
   return `${WS_BEARER_SUBPROTOCOL_PREFIX}${b64}`;
 }
 
-/** Turn a getUserMedia rejection into an actionable, human message. */
 function describeMicError(err: unknown): string {
   const name = (err as { name?: string } | undefined)?.name;
   switch (name) {
@@ -103,7 +111,7 @@ function describeMicError(err: unknown): string {
   }
 }
 
-/** Float32 [-1,1] frame → Int16 PCM + RMS level. */
+/** Float32 [-1, 1] frame to Int16 PCM plus an RMS level for the meter. */
 function floatToPcm16(input: Float32Array): {
   pcm: ArrayBuffer;
   level: number;
@@ -111,11 +119,11 @@ function floatToPcm16(input: Float32Array): {
   const pcm = new Int16Array(input.length);
   let sumSquares = 0;
   for (let i = 0; i < input.length; i++) {
-    let s = input[i];
-    if (s > 1) s = 1;
-    else if (s < -1) s = -1;
-    pcm[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
-    sumSquares += s * s;
+    let sample = input[i];
+    if (sample > 1) sample = 1;
+    else if (sample < -1) sample = -1;
+    pcm[i] = sample < 0 ? sample * 0x8000 : sample * 0x7fff;
+    sumSquares += sample * sample;
   }
   return {
     pcm: pcm.buffer,
@@ -128,37 +136,40 @@ interface CaptureResources {
   stream?: MediaStream;
   context?: AudioContext;
   source?: MediaStreamAudioSourceNode;
-  // ScriptProcessorNode (not AudioWorklet): the Web Shell CSP `script-src`
-  // omits `blob:`, which blocks a Blob-URL worklet module. ScriptProcessor
-  // needs no module load, so it sidesteps CSP entirely.
+  // The Web Shell CSP omits blob:, so a Blob-URL AudioWorklet cannot load.
+  // ScriptProcessor needs no module URL and therefore works under that CSP.
   processor?: ScriptProcessorNode;
   sink?: GainNode;
   transcribeTimeout?: ReturnType<typeof setTimeout>;
 }
 
-export function useVoiceCapture(
-  options: UseVoiceCaptureOptions,
-): UseVoiceCaptureReturn {
-  const { baseUrl, token, onFinal, onError } = options;
+interface CaptureSnapshot {
+  generation: number;
+  ownerKey: string;
+  streamPath: string;
+  onFinal: (text: string) => void;
+  onError?: (message: string) => void;
+  onUnexpectedClose?: (event: VoiceUnexpectedClose) => void;
+}
 
+export function useVoiceCapture({
+  baseUrl,
+  token,
+  target,
+  onFinal,
+  onError,
+  onUnexpectedClose,
+}: UseVoiceCaptureOptions): UseVoiceCaptureReturn {
   const [status, setStatus] = useState<VoiceCaptureStatus>('idle');
   const [interimText, setInterimText] = useState('');
   const [audioLevel, setAudioLevel] = useState(0);
-  const [errorMessage, setErrorMessage] = useState<string | undefined>(
-    undefined,
-  );
+  const [errorMessage, setErrorMessage] = useState<string>();
 
   const resourcesRef = useRef<CaptureResources>({});
   const mountedRef = useRef(true);
-  const captureGenerationRef = useRef(0);
-  // Live status for async WS/worklet callbacks, which would otherwise read a
-  // stale closure copy of `status`.
+  const generationRef = useRef(0);
   const statusRef = useRef<VoiceCaptureStatus>('idle');
-  // Latest callbacks without re-binding the capture lifecycle.
-  const onFinalRef = useRef(onFinal);
-  onFinalRef.current = onFinal;
-  const onErrorRef = useRef(onError);
-  onErrorRef.current = onError;
+  const snapshotRef = useRef<CaptureSnapshot | undefined>(undefined);
 
   const applyStatus = useCallback((next: VoiceCaptureStatus) => {
     statusRef.current = next;
@@ -166,104 +177,151 @@ export function useVoiceCapture(
   }, []);
 
   const clearTranscribeTimeout = useCallback(() => {
-    const res = resourcesRef.current;
-    if (res.transcribeTimeout) {
-      clearTimeout(res.transcribeTimeout);
-      res.transcribeTimeout = undefined;
-    }
+    const resources = resourcesRef.current;
+    if (!resources.transcribeTimeout) return;
+    clearTimeout(resources.transcribeTimeout);
+    resources.transcribeTimeout = undefined;
   }, []);
 
   const teardownAudio = useCallback(() => {
-    const res = resourcesRef.current;
-    if (res.processor) res.processor.onaudioprocess = null;
-    for (const node of [res.processor, res.source, res.sink]) {
+    const resources = resourcesRef.current;
+    if (resources.processor) resources.processor.onaudioprocess = null;
+    for (const node of [
+      resources.processor,
+      resources.source,
+      resources.sink,
+    ]) {
       try {
         node?.disconnect();
       } catch {
-        /* ignore */
+        // Best-effort browser resource cleanup.
       }
     }
-    res.stream?.getTracks().forEach((track) => track.stop());
-    if (res.context && res.context.state !== 'closed') {
-      void res.context.close().catch(() => {});
+    resources.stream?.getTracks().forEach((track) => track.stop());
+    if (resources.context && resources.context.state !== 'closed') {
+      void resources.context.close().catch(() => {});
     }
-    res.processor = undefined;
-    res.sink = undefined;
-    res.source = undefined;
-    res.stream = undefined;
-    res.context = undefined;
+    resources.processor = undefined;
+    resources.source = undefined;
+    resources.sink = undefined;
+    resources.stream = undefined;
+    resources.context = undefined;
   }, []);
 
   const cleanup = useCallback(() => {
-    captureGenerationRef.current++;
+    generationRef.current++;
+    snapshotRef.current = undefined;
     teardownAudio();
-    const res = resourcesRef.current;
     clearTranscribeTimeout();
-    if (res.ws) {
+    const resources = resourcesRef.current;
+    if (resources.ws) {
       try {
-        res.ws.onmessage = null;
-        res.ws.onerror = null;
-        res.ws.onclose = null;
-        res.ws.close();
+        resources.ws.onmessage = null;
+        resources.ws.onerror = null;
+        resources.ws.onclose = null;
+        resources.ws.close();
       } catch {
-        /* ignore */
+        // Best-effort browser resource cleanup.
       }
-      res.ws = undefined;
+      resources.ws = undefined;
     }
-  }, [teardownAudio, clearTranscribeTimeout]);
+  }, [clearTranscribeTimeout, teardownAudio]);
+
+  const snapshotIsCurrent = useCallback(
+    (snapshot: CaptureSnapshot): boolean =>
+      mountedRef.current &&
+      generationRef.current === snapshot.generation &&
+      snapshotRef.current === snapshot,
+    [],
+  );
 
   const fail = useCallback(
-    (message: string, generation?: number) => {
-      if (
-        !mountedRef.current ||
-        (generation !== undefined &&
-          captureGenerationRef.current !== generation)
-      ) {
-        return;
-      }
+    (message: string, snapshot: CaptureSnapshot) => {
+      if (!snapshotIsCurrent(snapshot)) return;
       cleanup();
+      if (!mountedRef.current) return;
       applyStatus('error');
       setInterimText('');
       setAudioLevel(0);
       setErrorMessage(message);
-      onErrorRef.current?.(message);
+      snapshot.onError?.(message);
     },
-    [cleanup, applyStatus],
+    [applyStatus, cleanup, snapshotIsCurrent],
   );
 
   const finishWith = useCallback(
-    (text: string, generation?: number) => {
-      if (
-        generation !== undefined &&
-        captureGenerationRef.current !== generation
-      ) {
-        return;
-      }
+    (text: string, snapshot: CaptureSnapshot) => {
+      if (!snapshotIsCurrent(snapshot)) return;
       cleanup();
       if (!mountedRef.current) return;
       applyStatus('idle');
       setInterimText('');
       setAudioLevel(0);
-      onFinalRef.current(text);
+      snapshot.onFinal(text);
     },
-    [cleanup, applyStatus],
+    [applyStatus, cleanup, snapshotIsCurrent],
   );
 
+  const abort = useCallback(() => {
+    const resources = resourcesRef.current;
+    if (resources.ws?.readyState === WebSocket.OPEN) {
+      try {
+        resources.ws.send(JSON.stringify({ type: 'abort' }));
+      } catch {
+        // The socket may have closed between the readyState check and send.
+      }
+    }
+    cleanup();
+    if (!mountedRef.current) return;
+    applyStatus('idle');
+    setInterimText('');
+    setAudioLevel(0);
+    setErrorMessage(undefined);
+  }, [applyStatus, cleanup]);
+
+  const targetIdentity = target
+    ? JSON.stringify([target.ownerKey, target.streamPath])
+    : undefined;
+  const previousTargetIdentityRef = useRef(targetIdentity);
+  useLayoutEffect(() => {
+    if (previousTargetIdentityRef.current === targetIdentity) return;
+    previousTargetIdentityRef.current = targetIdentity;
+    if (snapshotRef.current) abort();
+    else {
+      applyStatus('idle');
+      setInterimText('');
+      setAudioLevel(0);
+      setErrorMessage(undefined);
+    }
+  }, [abort, applyStatus, targetIdentity]);
+
   const start = useCallback(() => {
-    if (statusRef.current !== 'idle' && statusRef.current !== 'error') return;
+    if (
+      !target ||
+      (statusRef.current !== 'idle' && statusRef.current !== 'error')
+    ) {
+      return;
+    }
+
     setErrorMessage(undefined);
     setInterimText('');
     applyStatus('connecting');
-    const generation = ++captureGenerationRef.current;
-    const isStale = () =>
-      !mountedRef.current || captureGenerationRef.current !== generation;
+    const snapshot: CaptureSnapshot = {
+      generation: ++generationRef.current,
+      ownerKey: target.ownerKey,
+      streamPath: target.streamPath,
+      onFinal,
+      ...(onError ? { onError } : {}),
+      ...(onUnexpectedClose ? { onUnexpectedClose } : {}),
+    };
+    snapshotRef.current = snapshot;
 
     if (!navigator.mediaDevices?.getUserMedia) {
       fail(
         window.isSecureContext
           ? 'Microphone capture is not supported in this browser.'
           : 'Microphone needs a secure context — open the Web Shell via localhost/127.0.0.1 or https.',
-        generation,
+        snapshot,
       );
       return;
     }
@@ -281,14 +339,17 @@ export function useVoiceCapture(
       contextReady =
         context.state === 'suspended' ? context.resume() : Promise.resolve();
     } catch (error) {
-      fail(error instanceof Error ? error.message : String(error), generation);
+      fail(error instanceof Error ? error.message : String(error), snapshot);
       return;
     }
 
     clearTranscribeTimeout();
     resourcesRef.current.transcribeTimeout = setTimeout(() => {
-      if (statusRef.current === 'connecting') {
-        fail('Voice capture timed out while starting.', generation);
+      if (
+        snapshotIsCurrent(snapshot) &&
+        statusRef.current === 'connecting'
+      ) {
+        fail('Voice capture timed out while starting.', snapshot);
       }
     }, START_TIMEOUT_MS);
 
@@ -304,7 +365,7 @@ export function useVoiceCapture(
           })
           .then(
             (stream) => {
-              if (isStale()) {
+              if (!snapshotIsCurrent(snapshot)) {
                 stream.getTracks().forEach((track) => track.stop());
               } else {
                 resourcesRef.current.stream = stream;
@@ -316,12 +377,12 @@ export function useVoiceCapture(
             },
           );
         const [stream] = await Promise.all([streamPromise, contextReady]);
-        if (isStale()) return;
+        if (!snapshotIsCurrent(snapshot)) return;
 
         const source = context.createMediaStreamSource(stream);
         const processor = context.createScriptProcessor(FRAME_SIZE, 1, 1);
-        // Silent sink: a ScriptProcessorNode only fires `onaudioprocess` while
-        // connected to the destination; gain 0 avoids routing mic to speakers.
+        // ScriptProcessor fires only while connected to a destination. A muted
+        // gain node keeps the microphone out of the speakers.
         const sink = context.createGain();
         sink.gain.value = 0;
         resourcesRef.current.source = source;
@@ -329,45 +390,27 @@ export function useVoiceCapture(
         resourcesRef.current.sink = sink;
 
         const ws = new WebSocket(
-          toWebSocketUrl(baseUrl),
+          toVoiceWebSocketUrl(baseUrl, snapshot.streamPath),
           token ? [WS_AUTH_SUBPROTOCOL, bearerSubprotocol(token)] : undefined,
         );
         ws.binaryType = 'arraybuffer';
         resourcesRef.current.ws = ws;
 
         processor.onaudioprocess = (event: AudioProcessingEvent) => {
+          if (!snapshotIsCurrent(snapshot)) return;
           const { pcm, level } = floatToPcm16(
             event.inputBuffer.getChannelData(0),
           );
-          if (mountedRef.current) setAudioLevel(level);
+          setAudioLevel(level);
           if (ws.readyState === WebSocket.OPEN) ws.send(pcm);
         };
 
         ws.onopen = () => {
-          if (isStale()) {
-            processor.onaudioprocess = null;
-            for (const node of [processor, source, sink]) {
-              try {
-                node.disconnect();
-              } catch {
-                /* ignore */
-              }
-            }
-            stream.getTracks().forEach((track) => track.stop());
-            if (context.state !== 'closed') {
-              void context.close().catch(() => {});
-            }
-            const res = resourcesRef.current;
-            if (res.ws === ws) res.ws = undefined;
-            if (res.processor === processor) res.processor = undefined;
-            if (res.source === source) res.source = undefined;
-            if (res.sink === sink) res.sink = undefined;
-            if (res.stream === stream) res.stream = undefined;
-            if (res.context === context) res.context = undefined;
+          if (!snapshotIsCurrent(snapshot)) {
             try {
               ws.close();
             } catch {
-              /* ignore */
+              // The stale socket may already be closed.
             }
             return;
           }
@@ -377,110 +420,128 @@ export function useVoiceCapture(
           sink.connect(context.destination);
           clearTranscribeTimeout();
           resourcesRef.current.transcribeTimeout = setTimeout(() => {
-            if (statusRef.current === 'recording') {
+            if (
+              snapshotIsCurrent(snapshot) &&
+              statusRef.current === 'recording'
+            ) {
               fail(
                 'No response from server. Check that the voice model is running.',
-                generation,
+                snapshot,
               );
             }
           }, TRANSCRIPTION_TIMEOUT_MS);
-          if (mountedRef.current) applyStatus('recording');
+          applyStatus('recording');
         };
 
         ws.onmessage = (event: MessageEvent) => {
+          if (!snapshotIsCurrent(snapshot)) return;
           if (
             statusRef.current === 'connecting' ||
             statusRef.current === 'recording'
           ) {
             clearTranscribeTimeout();
           }
-          let msg: { type?: string; text?: string; message?: string };
+          let message: { type?: string; text?: string; message?: string };
           try {
-            msg = JSON.parse(String(event.data));
+            message = JSON.parse(String(event.data));
           } catch {
             return;
           }
-          if (msg.type === 'interim') {
-            if (mountedRef.current) setInterimText(msg.text ?? '');
-          } else if (msg.type === 'final') {
-            finishWith(msg.text ?? '', generation);
-          } else if (msg.type === 'error') {
+          if (message.type === 'interim') {
+            setInterimText(message.text ?? '');
+          } else if (message.type === 'final') {
+            finishWith(message.text ?? '', snapshot);
+          } else if (message.type === 'error') {
             fail(
-              msg.message ?? msg.text ?? 'Voice transcription failed.',
-              generation,
+              message.message ?? message.text ?? 'Voice transcription failed.',
+              snapshot,
             );
           }
         };
 
         ws.onerror = () => {
-          // The following close event carries the useful code/reason.
+          // The close event carries the useful code and reason.
         };
         ws.onclose = (event) => {
-          // A close before a final result (and not during normal teardown)
-          // surfaces as an error so the user isn't left stuck.
+          // A close before a final result is never successful completion.
           if (
-            mountedRef.current &&
-            (statusRef.current === 'recording' ||
+            !snapshotIsCurrent(snapshot) ||
+            !(
+              statusRef.current === 'recording' ||
               statusRef.current === 'connecting' ||
-              statusRef.current === 'transcribing')
+              statusRef.current === 'transcribing'
+            )
           ) {
-            const code = event.code || 1006;
-            const reason = event.reason || 'none';
-            fail(
-              `Voice connection closed (code=${code}, reason=${reason}).`,
-              generation,
-            );
+            return;
           }
+          const code = event.code || 1006;
+          const reason = event.reason || 'none';
+          try {
+            snapshot.onUnexpectedClose?.({ code, reason });
+          } catch {
+            // An observer must not prevent capture cleanup.
+          }
+          fail(
+            code === 1013
+              ? reason === 'none'
+                ? 'Voice capacity is temporarily unavailable. Retry shortly.'
+                : reason
+              : `Voice connection closed (code=${code}, reason=${reason}).`,
+            snapshot,
+          );
         };
       } catch (error) {
-        fail(
-          error instanceof Error ? error.message : String(error),
-          generation,
-        );
+        fail(error instanceof Error ? error.message : String(error), snapshot);
       }
     })();
-  }, [baseUrl, token, fail, finishWith, applyStatus, clearTranscribeTimeout]);
+  }, [
+    applyStatus,
+    baseUrl,
+    clearTranscribeTimeout,
+    fail,
+    finishWith,
+    onError,
+    onFinal,
+    onUnexpectedClose,
+    snapshotIsCurrent,
+    target,
+    token,
+  ]);
 
   const stop = useCallback(() => {
+    const snapshot = snapshotRef.current;
     const ws = resourcesRef.current.ws;
-    if (!ws || ws.readyState !== WebSocket.OPEN) {
-      cleanup();
-      applyStatus('idle');
+    if (!snapshot || !ws || ws.readyState !== WebSocket.OPEN) {
+      abort();
       return;
     }
-    // Stop feeding audio, then ask the daemon to finalize. The 'final' frame
-    // resolves the transcript; teardownAudio releases the mic immediately.
+    if (statusRef.current === 'transcribing') return;
+    // Release the microphone immediately; the final frame completes teardown.
     teardownAudio();
     setAudioLevel(0);
     applyStatus('transcribing');
-    const generation = captureGenerationRef.current;
     try {
       ws.send(JSON.stringify({ type: 'stop' }));
       clearTranscribeTimeout();
       resourcesRef.current.transcribeTimeout = setTimeout(() => {
-        if (statusRef.current === 'transcribing') {
-          fail('Transcription timed out.', generation);
+        if (
+          snapshotIsCurrent(snapshot) &&
+          statusRef.current === 'transcribing'
+        ) {
+          fail('Transcription timed out.', snapshot);
         }
       }, TRANSCRIPTION_TIMEOUT_MS);
     } catch {
-      fail('Failed to finalize voice transcription.', generation);
+      fail('Failed to finalize voice transcription.', snapshot);
     }
-  }, [cleanup, teardownAudio, fail, applyStatus, clearTranscribeTimeout]);
-
-  const abort = useCallback(() => {
-    const ws = resourcesRef.current.ws;
-    if (ws && ws.readyState === WebSocket.OPEN) {
-      try {
-        ws.send(JSON.stringify({ type: 'abort' }));
-      } catch {
-        /* ignore */
-      }
-    }
-    cleanup();
-    applyStatus('idle');
-    setInterimText('');
-    setAudioLevel(0);
-  }, [cleanup, applyStatus]);
+  }, [
+    abort,
+    applyStatus,
+    clearTranscribeTimeout,
+    fail,
+    snapshotIsCurrent,
+    teardownAudio,
+  ]);
 
   useEffect(() => {
     mountedRef.current = true;

--- a/packages/web-shell/client/voice/useVoiceCapture.ts
+++ b/packages/web-shell/client/voice/useVoiceCapture.ts
@@ -15,7 +15,9 @@ import {
 /**
  * Captures 16 kHz mono PCM in the browser and streams it to the immutable
  * workspace owner selected when recording starts. Credentials remain in the
- * browser-to-daemon transport; transcription stays server-side.
+ * browser-to-daemon transport; transcription stays server-side. The bearer
+ * subprotocol is verified by the daemon's ACP upgrade listener in
+ * `serve/acp-http/index.ts`.
  */
 export type VoiceCaptureStatus =
   | 'idle'
@@ -77,7 +79,10 @@ export function toVoiceWebSocketUrl(
 // Browsers cannot set Authorization on a WebSocket. The daemon decodes this
 // bearer subprotocol during the upgrade; keep the prefix in sync with it.
 const WS_BEARER_SUBPROTOCOL_PREFIX = 'qwen-bearer.';
-// The daemon selects this non-secret marker instead of echoing the bearer.
+// Non-secret marker offered alongside the bearer subprotocol. The daemon
+// completes the handshake by selecting THIS (never echoing the secret), which
+// also satisfies WS clients that require the server to pick an offered
+// subprotocol when any were requested. Must not start with the bearer prefix.
 const WS_AUTH_SUBPROTOCOL = 'qwen-ws';
 
 function bearerSubprotocol(token: string): string {
@@ -111,7 +116,7 @@ function describeMicError(err: unknown): string {
   }
 }
 
-/** Float32 [-1, 1] frame to Int16 PCM plus an RMS level for the meter. */
+/** Float32 [-1,1] frame → Int16 PCM + RMS level. */
 function floatToPcm16(input: Float32Array): {
   pcm: ArrayBuffer;
   level: number;
@@ -119,11 +124,11 @@ function floatToPcm16(input: Float32Array): {
   const pcm = new Int16Array(input.length);
   let sumSquares = 0;
   for (let i = 0; i < input.length; i++) {
-    let sample = input[i];
-    if (sample > 1) sample = 1;
-    else if (sample < -1) sample = -1;
-    pcm[i] = sample < 0 ? sample * 0x8000 : sample * 0x7fff;
-    sumSquares += sample * sample;
+    let s = input[i];
+    if (s > 1) s = 1;
+    else if (s < -1) s = -1;
+    pcm[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
+    sumSquares += s * s;
   }
   return {
     pcm: pcm.buffer,
@@ -136,8 +141,9 @@ interface CaptureResources {
   stream?: MediaStream;
   context?: AudioContext;
   source?: MediaStreamAudioSourceNode;
-  // The Web Shell CSP omits blob:, so a Blob-URL AudioWorklet cannot load.
-  // ScriptProcessor needs no module URL and therefore works under that CSP.
+  // ScriptProcessorNode (not AudioWorklet): the Web Shell CSP `script-src`
+  // omits `blob:`, which blocks a Blob-URL worklet module. ScriptProcessor
+  // needs no module load, so it sidesteps CSP entirely.
   processor?: ScriptProcessorNode;
   sink?: GainNode;
   transcribeTimeout?: ReturnType<typeof setTimeout>;
@@ -345,10 +351,7 @@ export function useVoiceCapture({
 
     clearTranscribeTimeout();
     resourcesRef.current.transcribeTimeout = setTimeout(() => {
-      if (
-        snapshotIsCurrent(snapshot) &&
-        statusRef.current === 'connecting'
-      ) {
+      if (snapshotIsCurrent(snapshot) && statusRef.current === 'connecting') {
         fail('Voice capture timed out while starting.', snapshot);
       }
     }, START_TIMEOUT_MS);

--- a/packages/web-shell/client/voice/voice-workspace-target.test.ts
+++ b/packages/web-shell/client/voice/voice-workspace-target.test.ts
@@ -1,0 +1,321 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  DaemonCapabilities,
+  DaemonWorkspaceCapability,
+} from '@qwen-code/sdk/daemon';
+import {
+  loadVoiceProviders,
+  loadVoiceStatus,
+  resolveVoiceWorkspaceTarget,
+  setVoiceModelSetting,
+  supportsVoiceCapture,
+  supportsVoiceModelSettings,
+} from './voice-workspace-target';
+
+function capabilities(
+  overrides: Partial<DaemonCapabilities> = {},
+): DaemonCapabilities {
+  return {
+    v: 1,
+    mode: 'http-bridge',
+    features: [],
+    modelServices: [],
+    ...overrides,
+  };
+}
+
+const primary: DaemonWorkspaceCapability = {
+  id: 'primary',
+  cwd: '/repo/primary',
+  primary: true,
+  trusted: false,
+};
+const secondary: DaemonWorkspaceCapability = {
+  id: 'secondary id',
+  cwd: '/repo/secondary',
+  primary: false,
+  trusted: true,
+};
+
+describe('resolveVoiceWorkspaceTarget', () => {
+  it('keeps a registered primary on legacy routes without a new trust gate', () => {
+    const target = resolveVoiceWorkspaceTarget({
+      capabilities: capabilities({ workspaces: [primary, secondary] }),
+      intendedCwd: primary.cwd,
+    });
+
+    expect(target).toMatchObject({
+      route: 'legacy-primary',
+      cwd: primary.cwd,
+      streamPath: 'voice/stream',
+    });
+  });
+
+  it('uses a unique secondary id and encodes it once', () => {
+    const target = resolveVoiceWorkspaceTarget({
+      capabilities: capabilities({ workspaces: [primary, secondary] }),
+      intendedCwd: secondary.cwd,
+      sessionId: 'session-1',
+    });
+
+    expect(target).toMatchObject({
+      route: 'workspace-qualified',
+      cwd: secondary.cwd,
+      selector: { kind: 'id', value: secondary.id },
+      streamPath: 'workspaces/secondary%20id/voice/stream',
+      sessionId: 'session-1',
+    });
+    expect(target?.ownerKey).toContain('session-1');
+  });
+
+  it('falls back to an encoded cwd for duplicate or empty ids', () => {
+    const target = resolveVoiceWorkspaceTarget({
+      capabilities: capabilities({
+        workspaces: [primary, { ...secondary, id: '', cwd: '/repo/二 次' }],
+      }),
+      intendedCwd: '/repo/二 次',
+    });
+
+    expect(target).toMatchObject({
+      route: 'workspace-qualified',
+      selector: { kind: 'cwd', value: '/repo/二 次' },
+      streamPath: 'workspaces/%2Frepo%2F%E4%BA%8C%20%E6%AC%A1/voice/stream',
+    });
+  });
+
+  it('falls back to cwd when a non-empty id is duplicated', () => {
+    const target = resolveVoiceWorkspaceTarget({
+      capabilities: capabilities({
+        workspaces: [primary, secondary, { ...secondary, cwd: '/repo/other' }],
+      }),
+      intendedCwd: secondary.cwd,
+    });
+
+    expect(target).toMatchObject({
+      route: 'workspace-qualified',
+      selector: { kind: 'cwd', value: secondary.cwd },
+      streamPath: 'workspaces/%2Frepo%2Fsecondary/voice/stream',
+    });
+  });
+
+  it.each([
+    [
+      'Windows drive',
+      'C:\\repo\\voice',
+      'workspaces/C%3A%5Crepo%5Cvoice/voice/stream',
+    ],
+    [
+      'UNC',
+      '\\\\server\\share\\voice',
+      'workspaces/%5C%5Cserver%5Cshare%5Cvoice/voice/stream',
+    ],
+  ])('encodes a %s cwd selector once', (_label, cwd, streamPath) => {
+    const target = resolveVoiceWorkspaceTarget({
+      capabilities: capabilities({
+        workspaces: [primary, { ...secondary, id: '', cwd, trusted: true }],
+      }),
+      intendedCwd: cwd,
+    });
+
+    expect(target).toMatchObject({
+      route: 'workspace-qualified',
+      selector: { kind: 'cwd', value: cwd },
+      streamPath,
+    });
+  });
+
+  it('fails closed for unknown, ambiguous, and untrusted secondary targets', () => {
+    const untrusted = { ...secondary, trusted: false };
+    const duplicate = { ...secondary, id: 'other' };
+    const caps = capabilities({
+      workspaces: [primary, untrusted, duplicate],
+    });
+
+    expect(
+      resolveVoiceWorkspaceTarget({
+        capabilities: caps,
+        intendedCwd: secondary.cwd,
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveVoiceWorkspaceTarget({
+        capabilities: caps,
+        intendedCwd: '/repo/missing',
+      }),
+    ).toBeUndefined();
+  });
+
+  it('requires a live modern session to report its workspace cwd', () => {
+    expect(
+      resolveVoiceWorkspaceTarget({
+        capabilities: capabilities({ workspaces: [primary, secondary] }),
+        intendedCwd: undefined,
+        sessionId: 'session-1',
+      }),
+    ).toBeUndefined();
+  });
+
+  it('preserves old single-workspace and opaque legacy daemons', () => {
+    expect(
+      resolveVoiceWorkspaceTarget({
+        capabilities: capabilities({ workspaceCwd: '/legacy' }),
+        intendedCwd: '/legacy',
+      }),
+    ).toMatchObject({ route: 'legacy-primary', cwd: '/legacy' });
+    const opaque = resolveVoiceWorkspaceTarget({
+      capabilities: capabilities(),
+      intendedCwd: undefined,
+    });
+    expect(opaque).toMatchObject({ route: 'legacy-primary' });
+    expect(opaque?.cwd).toBeUndefined();
+  });
+
+  it.each([
+    'dynamic_workspace_registration',
+    'persistent_workspace_registration',
+    'scratch_workspace_registration',
+    'workspace_display_name',
+    'workspace_runtime_removal',
+    'multi_workspace_sessions',
+    'multi_workspace_session_shell',
+    'workspace_qualified_rest_core',
+    'workspace_qualified_voice',
+  ])('does not synthesize opaque legacy ownership with %s', (feature) => {
+    expect(
+      resolveVoiceWorkspaceTarget({
+        capabilities: capabilities({
+          features: [feature],
+        }),
+        intendedCwd: undefined,
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe('Voice target operation gates', () => {
+  const legacy = resolveVoiceWorkspaceTarget({
+    capabilities: capabilities({ workspaces: [primary] }),
+    intendedCwd: primary.cwd,
+  });
+  const qualified = resolveVoiceWorkspaceTarget({
+    capabilities: capabilities({ workspaces: [primary, secondary] }),
+    intendedCwd: secondary.cwd,
+  });
+
+  it('separates dictation from secondary model/settings support', () => {
+    expect(supportsVoiceCapture(legacy, ['voice_transcribe'])).toBe(true);
+    expect(supportsVoiceCapture(qualified, ['workspace_qualified_voice'])).toBe(
+      true,
+    );
+    expect(
+      supportsVoiceModelSettings(qualified, ['workspace_qualified_voice']),
+    ).toBe(false);
+    expect(
+      supportsVoiceModelSettings(qualified, [
+        'workspace_qualified_voice',
+        'workspace_qualified_rest_core',
+        'workspace_settings',
+      ]),
+    ).toBe(true);
+  });
+
+  it('keeps legacy model settings available without dictation', () => {
+    expect(supportsVoiceCapture(legacy, [])).toBe(false);
+    expect(supportsVoiceModelSettings(legacy, [])).toBe(true);
+  });
+});
+
+describe('Voice target route adapters', () => {
+  it('uses qualified reads and workspace writes without primary fallback', async () => {
+    const workspaceVoice = vi.fn().mockResolvedValue({
+      v: 1,
+      workspaceCwd: secondary.cwd,
+      enabled: true,
+      mode: 'tap',
+      language: 'en',
+      voiceModel: null,
+      availableVoiceModels: [],
+    });
+    const workspaceProviders = vi.fn().mockResolvedValue({
+      v: 1,
+      workspaceCwd: secondary.cwd,
+      initialized: true,
+      providers: [],
+    });
+    const setWorkspaceSetting = vi.fn().mockResolvedValue({
+      key: 'voiceModel',
+      scope: 'workspace',
+      value: 'voice-1',
+      requiresRestart: false,
+    });
+    const rootVoice = vi.fn();
+    const rootProviders = vi.fn();
+    const rootSet = vi.fn();
+    const client = {
+      workspaceVoice: rootVoice,
+      workspaceProviders: rootProviders,
+      setWorkspaceSetting: rootSet,
+      workspaceById: vi.fn(() => ({
+        workspaceVoice,
+        workspaceProviders,
+        setWorkspaceSetting,
+      })),
+    };
+    const target = resolveVoiceWorkspaceTarget({
+      capabilities: capabilities({ workspaces: [primary, secondary] }),
+      intendedCwd: secondary.cwd,
+    });
+    if (!target) throw new Error('expected qualified target');
+
+    await expect(
+      loadVoiceStatus(client as never, target),
+    ).resolves.toMatchObject({ workspaceCwd: secondary.cwd });
+    await expect(
+      loadVoiceProviders(client as never, target),
+    ).resolves.toMatchObject({ workspaceCwd: secondary.cwd });
+    await setVoiceModelSetting(client as never, target, 'workspace', 'voice-1');
+
+    expect(client.workspaceById).toHaveBeenCalledWith(secondary.id);
+    expect(workspaceVoice).toHaveBeenCalledTimes(1);
+    expect(workspaceProviders).toHaveBeenCalledTimes(1);
+    expect(setWorkspaceSetting).toHaveBeenCalledWith(
+      'workspace',
+      'voiceModel',
+      'voice-1',
+    );
+    expect(rootVoice).not.toHaveBeenCalled();
+    expect(rootProviders).not.toHaveBeenCalled();
+    expect(rootSet).not.toHaveBeenCalled();
+  });
+
+  it('rejects a response for the wrong workspace', async () => {
+    const client = {
+      workspaceById: vi.fn(() => ({
+        workspaceVoice: vi.fn().mockResolvedValue({
+          v: 1,
+          workspaceCwd: '/wrong',
+          enabled: true,
+          mode: 'tap',
+          language: 'en',
+          voiceModel: null,
+          availableVoiceModels: [],
+        }),
+      })),
+    };
+    const target = resolveVoiceWorkspaceTarget({
+      capabilities: capabilities({ workspaces: [primary, secondary] }),
+      intendedCwd: secondary.cwd,
+    });
+    if (!target) throw new Error('expected qualified target');
+
+    await expect(loadVoiceStatus(client as never, target)).rejects.toThrow(
+      'does not match',
+    );
+  });
+});

--- a/packages/web-shell/client/voice/voice-workspace-target.test.ts
+++ b/packages/web-shell/client/voice/voice-workspace-target.test.ts
@@ -130,11 +130,21 @@ describe('resolveVoiceWorkspaceTarget', () => {
     });
   });
 
-  it('fails closed for unknown, ambiguous, and untrusted secondary targets', () => {
-    const untrusted = { ...secondary, trusted: false };
+  it('fails closed for an untrusted secondary target', () => {
+    expect(
+      resolveVoiceWorkspaceTarget({
+        capabilities: capabilities({
+          workspaces: [primary, { ...secondary, trusted: false }],
+        }),
+        intendedCwd: secondary.cwd,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('fails closed for unknown and ambiguous secondary targets', () => {
     const duplicate = { ...secondary, id: 'other' };
     const caps = capabilities({
-      workspaces: [primary, untrusted, duplicate],
+      workspaces: [primary, secondary, duplicate],
     });
 
     expect(

--- a/packages/web-shell/client/voice/voice-workspace-target.ts
+++ b/packages/web-shell/client/voice/voice-workspace-target.ts
@@ -1,0 +1,274 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  DaemonCapabilities,
+  DaemonClient,
+  DaemonSettingUpdateResult,
+  DaemonWorkspaceCapability,
+  DaemonWorkspaceProvidersStatus,
+  DaemonWorkspaceSettingsStatus,
+  DaemonWorkspaceVoiceStatus,
+} from '@qwen-code/sdk/daemon';
+
+const PRIMARY_VOICE_FEATURE = 'voice_transcribe';
+const QUALIFIED_VOICE_FEATURE = 'workspace_qualified_voice';
+const QUALIFIED_CORE_FEATURE = 'workspace_qualified_rest_core';
+const WORKSPACE_SETTINGS_FEATURE = 'workspace_settings';
+
+const MODERN_WORKSPACE_FEATURES = new Set([
+  'dynamic_workspace_registration',
+  'persistent_workspace_registration',
+  'scratch_workspace_registration',
+  'workspace_display_name',
+  'workspace_runtime_removal',
+]);
+
+interface VoiceTargetBase {
+  cwd?: string;
+  workspaceKey: string;
+  ownerKey: string;
+  sessionId?: string;
+}
+
+export type VoiceWorkspaceTarget =
+  | (VoiceTargetBase & {
+      route: 'legacy-primary';
+      streamPath: 'voice/stream';
+    })
+  | (VoiceTargetBase & {
+      route: 'workspace-qualified';
+      cwd: string;
+      selector: {
+        kind: 'id' | 'cwd';
+        value: string;
+      };
+      streamPath: string;
+    });
+
+export interface VoiceStatusRevision {
+  user: number;
+  workspace: number;
+}
+
+export interface ResolveVoiceWorkspaceTargetOptions {
+  capabilities: DaemonCapabilities | undefined;
+  intendedCwd: string | undefined;
+  sessionId?: string;
+  /**
+   * Pass App's merged list when a locked workspace has been registered before
+   * the next capabilities snapshot arrives.
+   */
+  workspaces?: readonly DaemonWorkspaceCapability[];
+}
+
+type VoiceTargetWithoutOwner =
+  | {
+      route: 'legacy-primary';
+      cwd?: string;
+      workspaceKey: string;
+      streamPath: 'voice/stream';
+    }
+  | {
+      route: 'workspace-qualified';
+      cwd: string;
+      workspaceKey: string;
+      selector: {
+        kind: 'id' | 'cwd';
+        value: string;
+      };
+      streamPath: string;
+    };
+
+function key(parts: readonly unknown[]): string {
+  return JSON.stringify(parts);
+}
+
+function hasModernWorkspaceFeature(features: readonly string[]): boolean {
+  return features.some(
+    (feature) =>
+      MODERN_WORKSPACE_FEATURES.has(feature) ||
+      feature.startsWith('multi_workspace_') ||
+      feature.startsWith('workspace_qualified_'),
+  );
+}
+
+function withOwner(
+  target: VoiceTargetWithoutOwner,
+  sessionId: string | undefined,
+): VoiceWorkspaceTarget {
+  return {
+    ...target,
+    ...(sessionId ? { sessionId } : {}),
+    ownerKey: key([
+      target.workspaceKey,
+      sessionId ? ['session', sessionId] : ['draft'],
+    ]),
+  } as VoiceWorkspaceTarget;
+}
+
+function legacyTarget(
+  cwd: string | undefined,
+  sessionId: string | undefined,
+): VoiceWorkspaceTarget {
+  return withOwner(
+    {
+      route: 'legacy-primary',
+      ...(cwd ? { cwd } : {}),
+      workspaceKey: key(['legacy-primary', cwd ?? null]),
+      streamPath: 'voice/stream',
+    },
+    sessionId,
+  );
+}
+
+export function resolveVoiceWorkspaceTarget({
+  capabilities,
+  intendedCwd,
+  sessionId,
+  workspaces,
+}: ResolveVoiceWorkspaceTargetOptions): VoiceWorkspaceTarget | undefined {
+  if (!capabilities) return undefined;
+
+  const registered = workspaces ?? capabilities.workspaces;
+  const primaryCwd =
+    registered?.find((workspace) => workspace.primary)?.cwd ??
+    capabilities.workspaceCwd;
+  const cwd = intendedCwd ?? (sessionId ? undefined : primaryCwd);
+
+  if (registered) {
+    if (!cwd) return undefined;
+    const matches = registered.filter((workspace) => workspace.cwd === cwd);
+    if (matches.length !== 1) return undefined;
+    const workspace = matches[0];
+    if (workspace.primary) return legacyTarget(workspace.cwd, sessionId);
+    if (!workspace.trusted) return undefined;
+
+    const usableId = workspace.id.trim() ? workspace.id : undefined;
+    const idIsUnique =
+      usableId !== undefined &&
+      registered.filter((entry) => entry.id === usableId).length === 1;
+    const selector = idIsUnique
+      ? ({ kind: 'id', value: usableId } as const)
+      : ({ kind: 'cwd', value: workspace.cwd } as const);
+    const workspaceKey = key([
+      'workspace-qualified',
+      selector.kind,
+      selector.value,
+      workspace.cwd,
+    ]);
+    return withOwner(
+      {
+        route: 'workspace-qualified',
+        cwd: workspace.cwd,
+        workspaceKey,
+        selector,
+        streamPath: `workspaces/${encodeURIComponent(selector.value)}/voice/stream`,
+      },
+      sessionId,
+    );
+  }
+
+  if (capabilities.workspaceCwd) {
+    if (cwd !== capabilities.workspaceCwd) return undefined;
+    return legacyTarget(capabilities.workspaceCwd, sessionId);
+  }
+
+  if (!intendedCwd && !hasModernWorkspaceFeature(capabilities.features)) {
+    return legacyTarget(undefined, sessionId);
+  }
+
+  return undefined;
+}
+
+export function supportsVoiceCapture(
+  target: VoiceWorkspaceTarget | undefined,
+  features: readonly string[],
+): boolean {
+  if (!target) return false;
+  return features.includes(
+    target.route === 'legacy-primary'
+      ? PRIMARY_VOICE_FEATURE
+      : QUALIFIED_VOICE_FEATURE,
+  );
+}
+
+export function supportsVoiceModelSettings(
+  target: VoiceWorkspaceTarget | undefined,
+  features: readonly string[],
+): boolean {
+  if (!target) return false;
+  if (target.route === 'legacy-primary') return true;
+  return [
+    QUALIFIED_VOICE_FEATURE,
+    QUALIFIED_CORE_FEATURE,
+    WORKSPACE_SETTINGS_FEATURE,
+  ].every((feature) => features.includes(feature));
+}
+
+function qualifiedClient(client: DaemonClient, target: VoiceWorkspaceTarget) {
+  if (target.route !== 'workspace-qualified') return undefined;
+  return target.selector.kind === 'id'
+    ? client.workspaceById(target.selector.value)
+    : client.workspaceByCwd(target.selector.value);
+}
+
+export async function loadVoiceStatus(
+  client: DaemonClient,
+  target: VoiceWorkspaceTarget,
+): Promise<DaemonWorkspaceVoiceStatus> {
+  const status =
+    target.route === 'legacy-primary'
+      ? await client.workspaceVoice()
+      : await qualifiedClient(client, target)!.workspaceVoice();
+  if (target.cwd && status.workspaceCwd !== target.cwd) {
+    throw new Error(
+      'Voice status workspace does not match the selected target.',
+    );
+  }
+  return status;
+}
+
+export async function loadVoiceProviders(
+  client: DaemonClient,
+  target: VoiceWorkspaceTarget,
+): Promise<DaemonWorkspaceProvidersStatus> {
+  const status =
+    target.route === 'legacy-primary'
+      ? await client.workspaceProviders()
+      : await qualifiedClient(client, target)!.workspaceProviders();
+  if (target.cwd && status.workspaceCwd !== target.cwd) {
+    throw new Error(
+      'Voice provider workspace does not match the selected target.',
+    );
+  }
+  return status;
+}
+
+export async function loadVoiceSettings(
+  client: DaemonClient,
+  target: VoiceWorkspaceTarget,
+): Promise<DaemonWorkspaceSettingsStatus> {
+  return target.route === 'legacy-primary'
+    ? await client.workspaceSettings()
+    : await qualifiedClient(client, target)!.workspaceSettings();
+}
+
+export async function setVoiceModelSetting(
+  client: DaemonClient,
+  target: VoiceWorkspaceTarget,
+  scope: 'workspace' | 'user',
+  value: string,
+): Promise<DaemonSettingUpdateResult> {
+  if (target.route === 'workspace-qualified' && scope === 'workspace') {
+    return await qualifiedClient(client, target)!.setWorkspaceSetting(
+      'workspace',
+      'voiceModel',
+      value,
+    );
+  }
+  return await client.setWorkspaceSetting(scope, 'voiceModel', value);
+}

--- a/packages/web-shell/vite.config.ts
+++ b/packages/web-shell/vite.config.ts
@@ -42,6 +42,9 @@ const daemonProxy: ProxyOptions = {
   },
 };
 
+export const QUALIFIED_VOICE_STREAM_PROXY =
+  '^/workspaces/[^/]+/voice/stream/?$';
+
 export default defineConfig(({ command }) => ({
   root: 'client',
   plugins: [react(), tailwindcss()],
@@ -88,6 +91,7 @@ export default defineConfig(({ command }) => ({
       '/daemon/status': daemonProxy,
       '/session': daemonProxy,
       '/permission': daemonProxy,
+      [QUALIFIED_VOICE_STREAM_PROXY]: { ...daemonProxy, ws: true },
       '/workspace': daemonProxy,
       '/extensions': daemonProxy,
       '/file': daemonProxy,


### PR DESCRIPTION
## What this PR does

Routes the existing Web Shell Voice experience through the workspace that owns each composer. Main, locked, and split-view composers now resolve a fail-closed Voice target; trusted secondary workspaces use workspace-qualified status, provider, settings, model, and streaming routes, while primary and older single-workspace daemons retain the legacy routes. Each capture generation snapshots its owner and cleans up microphone, audio, timers, sockets, and stale callbacks when ownership changes. The development proxy now forwards only qualified Voice stream upgrades.

## Why it's needed

Web Shell sessions can run in secondary workspaces, but Voice previously continued to use the primary workspace daemon. This could expose primary-workspace Voice configuration in a secondary composer and insert a transcript produced by the wrong runtime. Scoping Voice to the composer owner preserves workspace isolation and makes split-view behavior predictable.

## Reviewer Test Plan

### How to verify

1. Start Web Shell with a primary workspace and a trusted secondary workspace, then confirm that Voice in the primary composer uses the legacy routes while Voice in the secondary composer uses routes qualified with that workspace's exact canonical path.
2. Open both workspaces in split view and confirm each composer independently reports Voice availability, loads its own provider and model settings, and streams to its owning runtime.
3. Start capture and then switch, remove, untrust, or drain the owning workspace. Confirm the capture is stopped, resources are released, and no late transcript or error from the old owner is inserted into the current composer.
4. Confirm user-scoped Voice settings remain shared while workspace-scoped settings and model discovery are loaded and saved only through the resolved workspace.
5. Confirm an older single-workspace daemon still supports Voice through the legacy endpoints, while an unknown, ambiguous, untrusted, bootstrapping, draining, or removed secondary workspace fails closed instead of falling back to primary.

Expected result: every Voice request and callback stays bound to the composer workspace that initiated it, with legacy compatibility limited to the primary single-workspace path.

### Evidence (Before & After)

Before: Voice controls in a secondary-workspace composer queried and streamed through the primary runtime, so availability, settings, models, and transcripts could belong to the wrong workspace.

After: each composer resolves one exact Voice owner; trusted secondary workspaces use qualified routes, primary keeps legacy compatibility, and unresolved or unsafe secondary states disable Voice without primary fallback.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS with the repository's Node.js 22+ toolchain. Verified with 359 focused Vitest tests, the Web Shell production and library builds, Web Shell typecheck, repository lint, and whitespace validation. Physical microphone browser E2E was not run because Playwright Chromium is not installed in the local environment.

## Risk & Scope

- Main risk or tradeoff: Voice target lifetime and stale asynchronous results are more explicit; capture generations and exact canonical workspace identity are used to prevent callbacks from crossing owners.
- Not validated / out of scope: Physical microphone behavior in a real browser, provider credentials, Windows, and Linux were not validated locally. This change does not alter daemon or SDK route schemas.
- Breaking changes / migration notes: None. Primary and older single-workspace daemons retain the existing Voice routes.

## Linked Issues

Closes #6972

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

将现有 Web Shell Voice 体验路由到拥有各个输入框的工作区。主工作区、锁定工作区和分屏输入框现在都会以失败关闭方式解析 Voice 目标；可信的次工作区使用带工作区限定的状态、提供商、设置、模型和流式路由，而主工作区及旧版单工作区 daemon 继续使用兼容的旧路由。每一代录音都会快照其所有者，并在所有权变化时清理麦克风、音频、定时器、套接字和过期回调。开发代理现在只转发带工作区限定的 Voice 流式升级请求。

## 为什么需要

Web Shell 会话可以运行在次工作区中，但 Voice 之前仍然使用主工作区 daemon。这可能在次工作区输入框中暴露主工作区的 Voice 配置，并插入由错误运行时生成的转录。将 Voice 限定到输入框所有者可以保持工作区隔离，并使分屏行为可预测。

## Reviewer 测试计划

### 如何验证

1. 使用一个主工作区和一个可信次工作区启动 Web Shell，确认主工作区输入框中的 Voice 使用旧路由，而次工作区输入框中的 Voice 使用包含该工作区精确规范路径的限定路由。
2. 在分屏中打开两个工作区，确认每个输入框都独立报告 Voice 可用性、加载各自的提供商和模型设置，并流式连接到其所属运行时。
3. 启动录音后切换、移除、不信任或排空所属工作区。确认录音停止、资源释放，并且旧所有者的延迟转录或错误不会插入当前输入框。
4. 确认用户级 Voice 设置继续共享，而工作区级设置和模型发现只通过已解析的工作区加载和保存。
5. 确认旧版单工作区 daemon 仍可通过旧端点支持 Voice；未知、歧义、不可信、启动中、排空中或已移除的次工作区应失败关闭，而不是回退到主工作区。

预期结果：每个 Voice 请求和回调都始终绑定到发起操作的输入框工作区，旧版兼容性仅限于主工作区的单工作区路径。

### 证据（之前与之后）

之前：次工作区输入框中的 Voice 控件通过主运行时查询和流式通信，因此可用性、设置、模型和转录可能属于错误的工作区。

之后：每个输入框解析到唯一且精确的 Voice 所有者；可信次工作区使用限定路由，主工作区保留旧版兼容性，无法解析或不安全的次工作区状态会禁用 Voice，且不会回退到主工作区。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|     🍏 macOS     |  ✅  |
|    🪟 Windows    |  ⚠️  |
|     🐧 Linux     |  ⚠️  |

### 环境（可选）

macOS，使用仓库要求的 Node.js 22+ 工具链。已通过 359 个定向 Vitest 测试、Web Shell 生产构建和库构建、Web Shell 类型检查、仓库 lint 以及空白检查。由于本地环境未安装 Playwright Chromium，未执行真实麦克风浏览器 E2E。

## 风险与范围

- 主要风险或权衡：Voice 目标生命周期和过期异步结果变得更明确；实现通过录音代次和精确的规范工作区身份防止回调跨越所有者。
- 未验证或范围外：未在本地验证真实浏览器中的物理麦克风行为、提供商凭据、Windows 和 Linux。本变更不修改 daemon 或 SDK 路由 schema。
- 破坏性变更或迁移说明：无。主工作区和旧版单工作区 daemon 保留现有 Voice 路由。

## 关联 Issue

Closes #6972

</details>
