### PR TITLE
fix(core): treat properties as a name map in toOpenAPI30

### DIFF
--- a/packages/core/src/utils/schemaConverter.test.ts
+++ b/packages/core/src/utils/schemaConverter.test.ts
@@ -160,6 +160,79 @@ describe('convertSchema', () => {
       const expected = { type: 'string' };
       expect(convertSchema(input, 'openapi_30')).toEqual(expected);
     });
+
+    it('never treats property names as schema keywords', () => {
+      // `properties` keys are names, not keywords. Walking the map as if it
+      // were a schema node makes each step misfire on a colliding name: the
+      // const step replaces a property called `const` with a bogus `enum`,
+      // the skip list drops one called `default`, and one called `type` is
+      // copied verbatim instead of being converted.
+      const input = {
+        type: 'object',
+        properties: {
+          type: { type: ['string', 'null'], description: 'a prop named type' },
+          const: { type: 'string', enum: [1, 2] },
+          default: { type: 'boolean' },
+          enum: { type: ['integer', 'null'] },
+          items: { type: 'string' },
+          $schema: { type: 'string' },
+          dependencies: { type: 'string' },
+          patternProperties: { type: 'string' },
+        },
+        required: ['type'],
+      };
+      const expected = {
+        type: 'object',
+        properties: {
+          // Converted as a schema, not read as a `type` keyword.
+          type: {
+            type: 'string',
+            nullable: true,
+            description: 'a prop named type',
+          },
+          const: { type: 'string', enum: ['1', '2'] },
+          default: { type: 'boolean' },
+          enum: { type: 'integer', nullable: true },
+          items: { type: 'string' },
+          $schema: { type: 'string' },
+          dependencies: { type: 'string' },
+          patternProperties: { type: 'string' },
+        },
+        required: ['type'],
+      };
+      expect(convertSchema(input, 'openapi_30')).toEqual(expected);
+    });
+
+    it('converts $defs and definitions as name maps too', () => {
+      const input = {
+        type: 'object',
+        $defs: { const: { type: ['string', 'null'] } },
+        definitions: { default: { type: ['number', 'null'] } },
+      };
+      const expected = {
+        type: 'object',
+        $defs: { const: { type: 'string', nullable: true } },
+        definitions: { default: { type: 'number', nullable: true } },
+      };
+      expect(convertSchema(input, 'openapi_30')).toEqual(expected);
+    });
+
+    it('still removes keyword-level unsupported fields beside a map', () => {
+      // The map guard must not become an escape hatch for the real keywords:
+      // a top-level `$schema` is still dropped even when a property shares
+      // its name.
+      const input = {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        $id: '#foo',
+        type: 'object',
+        properties: { $schema: { type: 'string' } },
+      };
+      const expected = {
+        type: 'object',
+        properties: { $schema: { type: 'string' } },
+      };
+      expect(convertSchema(input, 'openapi_30')).toEqual(expected);
+    });
   });
 });
 

--- a/packages/core/src/utils/schemaConverter.ts
+++ b/packages/core/src/utils/schemaConverter.ts
@@ -110,6 +110,29 @@ function toOpenAPI30(schema: Record<string, unknown>): Record<string, unknown> {
 
     // 6. Recursively process other properties
     for (const [key, value] of Object.entries(source)) {
+      // `properties` / `$defs` / `definitions` are name->schema MAPS: their
+      // keys are property/definition names, not JSON Schema keywords. Walking
+      // one as if it were a schema node makes every step above misfire on a
+      // property whose name collides with a keyword — a property called
+      // `const` is replaced by a bogus `enum`, one called `default` is
+      // dropped by the skip list below, and one called `type` is copied
+      // verbatim instead of being converted. Only the VALUES are schemas.
+      if (
+        (key === 'properties' || key === '$defs' || key === 'definitions') &&
+        typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value)
+      ) {
+        const map: Record<string, unknown> = {};
+        for (const [mapKey, mapValue] of Object.entries(
+          value as Record<string, unknown>,
+        )) {
+          map[mapKey] = convert(mapValue);
+        }
+        target[key] = map;
+        continue;
+      }
+
       // Skip fields we've already handled or want to remove
       if (
         key === 'type' ||


### PR DESCRIPTION
## What this PR does

`toOpenAPI30` walked the `properties` map as if it were a JSON Schema node. The keys of that map are property *names*, not schema keywords, so every conversion step misfired on any property whose name happens to collide with one — and a tool schema is exactly where such names show up, because they are drawn from a tool's own parameter list.

Three separate corruptions came from that one mistake. A property named `const` was **deleted** and a literal `"enum": ["[object Object]"]` injected beside its siblings, because the const-to-enum step read the map itself as a const-carrying schema. A property named `default`, `$schema`, `$id`, `dependencies` or `patternProperties` was **dropped entirely**, because the skip list at the end of the walk treats those keys as unsupported keywords to remove. A property named `type` was **copied verbatim** rather than converted, so its `["string", "null"]` union was never downgraded to `nullable: true` — which is the entire purpose of this function, and produces a schema Gemini rejects.

The fix handles `properties` / `$defs` / `definitions` as name→schema maps, recursing into the values only. That is not a new idea in this file: the sibling function `relaxSchemaForFunctionCalling`, forty lines below, already does exactly this and documents why.

## Why it's needed

This conversion is what tool schemas pass through on the way to the model. `convertSchema(schema, 'openapi_30')` is called from both `anthropicContentGenerator/converter.ts:240` and `openaiContentGenerator/converter.ts:373`, driven by the user-facing `schemaCompliance` setting whose own description points at Gemini compatibility. So the failure is silent and lands on the wire: a tool declares a parameter, and the model is handed a schema in which that parameter has vanished, or has been replaced by a nonsense `enum`, or still carries a type union the target API refuses.

The same bug class has been fixed twice already in this repository — once in `openaiContentGenerator/converter.ts` by `0a17239` ("convert subschemas of properties named after schema keywords"), and once in this file's other function. This is the third site, and the last one in `schemaConverter.ts`.

Actual output before this change, for a schema with properties named `type`, `const`, `default` and a normal `age`:

```json
{"type":"object","properties":{
   "type":{"type":["string","null"],"description":"a prop named type"},
   "enum":["[object Object]"],
   "age":{"type":"integer","minimum":0}},
 "required":["type"]}
```

`const` and `default` are gone, `enum` is not a property at all, and `type` was never converted.

## Reviewer Test Plan

### How to verify

- From the repo root: `npx vitest run --root packages/core src/utils/schemaConverter.test.ts` → 26/26.
- Reverting **only** `schemaConverter.ts` and keeping the new tests fails exactly the three added cases, and nothing else: `3 failed | 23 passed (26)`.
  - `never treats property names as schema keywords`
  - `converts $defs and definitions as name maps too`
  - `still removes keyword-level unsupported fields beside a map`
- No regression in the callers: `npx vitest run --root packages/core src/utils/schemaConverter.test.ts src/core/openaiContentGenerator src/core/anthropicContentGenerator` → **905 passed (21 files)**.
- The third test is the guard against over-correcting. The map handling must not become an escape hatch for the real keywords, so it pins that a top-level `$schema` is still dropped even when a property shares that name — the keyword and the property name are distinguished by position, not by spelling.
- `$defs` and `definitions` are covered separately from `properties` because a fix that handled only `properties` would look correct against a flat schema and still corrupt every schema using definitions.

### Evidence (Before & After)

N/A — not user-visible. The change alters the schema sent to the model, covered by the unit tests above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only; pure function with no I/O or platform-dependent behaviour. CI covers Windows and Linux.

## Risk & Scope

- Main risk or tradeoff: schemas that were previously mangled now convert, so the payload sent to the model changes for any schema containing a property named after a schema keyword. That is the intent, and it moves toward what the function documents. Schemas without such property names are byte-identical before and after — the 905 passing caller tests are the evidence.
- Not validated / out of scope: `toOpenAPI30` also drops a Draft-4 boolean `exclusiveMinimum` / `exclusiveMaximum` (`{minimum: 0, exclusiveMinimum: true}` comes out as `{minimum: 0}`, turning an exclusive bound into an inclusive one). That survives this fix, because it is a different mechanism — step 3 handles only the Draft-6 numeric form and the skip list then removes the boolean. It needs its own change and its own test, so it is deliberately left for a separate PR rather than folded in here.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

`toOpenAPI30` 把 `properties` 映射当作 JSON Schema 节点来遍历。该映射的键是属性**名称**而非 schema 关键字，因此只要属性名恰好与某个关键字重名，上游的每一个转换步骤都会误触发——而工具 schema 正是这类名称的高发地，因为它们直接取自工具自身的参数列表。

这一个错误导致了三种各自独立的破坏。名为 `const` 的属性被**删除**，并在其兄弟节点旁注入一个字面量 `"enum": ["[object Object]"]`，因为「const 转 enum」这一步把映射本身读成了带 const 的 schema。名为 `default`、`$schema`、`$id`、`dependencies` 或 `patternProperties` 的属性被**整个丢弃**，因为遍历末尾的跳过列表把这些键视为需要移除的不受支持关键字。名为 `type` 的属性则被**原样复制**而未经转换，其 `["string", "null"]` 联合类型从未被降级为 `nullable: true`——而这恰是本函数的全部意义所在，其产物会被 Gemini 拒绝。

修复方式是把 `properties` / `$defs` / `definitions` 作为「名称→schema」映射处理，只对其值递归。这在本文件中并非新思路：四十行之下的同级函数 `relaxSchemaForFunctionCalling` 已经这样做了，并且写明了原因。

## 为什么需要

这段转换正是工具 schema 发往模型途中必经的一环。`convertSchema(schema, 'openapi_30')` 由 `anthropicContentGenerator/converter.ts:240` 与 `openaiContentGenerator/converter.ts:373` 两处调用，并由面向用户的 `schemaCompliance` 设置驱动，而该设置的说明本身就指向 Gemini 兼容性。因此这个故障是静默的，且会直接落到线上：工具声明了一个参数，模型收到的 schema 里该参数却已消失、或被替换成无意义的 `enum`、或仍带着目标 API 拒收的类型联合。

同一类 bug 在本仓库已被修过两次——一次是 `openaiContentGenerator/converter.ts` 的 `0a17239`（“convert subschemas of properties named after schema keywords”），一次是本文件的另一个函数。这是第三处，也是 `schemaConverter.ts` 中的最后一处。

对于包含 `type`、`const`、`default` 与普通 `age` 属性的 schema，改动前的实际输出为：

```json
{"type":"object","properties":{
   "type":{"type":["string","null"],"description":"a prop named type"},
   "enum":["[object Object]"],
   "age":{"type":"integer","minimum":0}},
 "required":["type"]}
```

`const` 与 `default` 已消失，`enum` 根本不是一个属性，而 `type` 从未被转换。

## 复核测试计划

### 如何验证

- 在仓库根目录：`npx vitest run --root packages/core src/utils/schemaConverter.test.ts` → 26/26 通过。
- **仅**还原 `schemaConverter.ts`、保留新增测试时，恰好是新增的三项失败，且无其他失败：`3 failed | 23 passed (26)`。
  - `never treats property names as schema keywords`
  - `converts $defs and definitions as name maps too`
  - `still removes keyword-level unsupported fields beside a map`
- 调用方无回归：`npx vitest run --root packages/core src/utils/schemaConverter.test.ts src/core/openaiContentGenerator src/core/anthropicContentGenerator` → **905 通过（21 个文件）**。
- 第三项测试是防止「矫枉过正」的保险。映射处理不得成为真正关键字的逃生通道，因此它锚定了：即便某个属性与之同名，顶层的 `$schema` 依然会被丢弃——关键字与属性名是靠位置而非拼写来区分的。
- `$defs` 与 `definitions` 与 `properties` 分开覆盖，因为只处理 `properties` 的修复在扁平 schema 上看起来完全正确，却仍会破坏每一个使用 definitions 的 schema。

### 证据（修复前后对比）

N/A —— 非用户可见。该改动影响的是发送给模型的 schema，已由上述单元测试覆盖。

### 测试环境

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

仅单元测试；纯函数，无 I/O，无平台相关行为。Windows 与 Linux 由 CI 覆盖。

## 风险与范围

- 主要风险或权衡：此前被破坏的 schema 现在能正确转换，因此凡是含有与 schema 关键字同名属性的 schema，发送给模型的载荷都会改变。这正是本次改动的目的，且使其向该函数所声明的行为靠拢。不含此类属性名的 schema 在改动前后逐字节一致——905 项通过的调用方测试即为证据。
- 未验证 / 不在范围内：`toOpenAPI30` 还会丢弃 Draft-4 布尔形式的 `exclusiveMinimum` / `exclusiveMaximum`（`{minimum: 0, exclusiveMinimum: true}` 会变成 `{minimum: 0}`，把排他边界变成包含边界）。该问题在本次修复后依然存在，因为它的成因不同——第 3 步只处理 Draft-6 的数值形式，随后跳过列表移除了布尔形式。它需要独立的改动与独立的测试，因此有意留给单独的 PR，而不并入本 PR。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
