### PR TITLE
test(serve): Add first-output latency benchmark

### DIFF
--- a/docs/design/daemon-first-output-latency.md
+++ b/docs/design/daemon-first-output-latency.md
@@ -1,0 +1,241 @@
+# Daemon first-output latency
+
+- **Tracking**: #7757
+- **Background**: #7264
+- **Scope**: daemon/ACP client-observable latency
+- **Status**: Phase 1 measurement design
+
+## Decision and scope
+
+The first PR is measurement-only: an opt-in benchmark, pure classification/statistics helpers, tests, and versioned artifacts. It does not change production startup behavior.
+
+A separate Provider-preparation prototype is allowed only if the single-bundle baseline passes its gate. Publishing that prototype then requires distinct control and candidate bundles to pass every latency, resource, functional, and cleanup gate in this document. A valid negative result ends the work.
+
+The benchmark measures process spawn through first model-derived output while keeping local preparation, Provider request arrival, first output, first answer text, and terminal completion separate. The existing production `ttft_ms` remains unchanged: it still measures Provider dispatch to first visible content and does not absorb lazy loading or local prompt preparation.
+
+Out of scope are TUI/Web Shell/editor rendering, prompt caching, compression, model thought/tool behavior, network preconnection, real-model latency optimization, production telemetry changes, public lifecycle APIs, protocol fields, configuration, and feature flags.
+
+## Repository and runner contract
+
+| Path                                                               | Responsibility                                                                                             |
+| ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| `integration-tests/cli/qwen-daemon-first-output-benchmark.test.ts` | Opt-in runner, fake Provider, isolated process lifecycle, baseline/compare protocols, and artifact writing |
+| `integration-tests/cli/_first-output-benchmark.ts`                 | Pure event tracking, classification, percentiles, paired bootstrap, and decision inputs                    |
+| `integration-tests/cli/_first-output-benchmark.test.ts`            | Deterministic tests for the pure contract                                                                  |
+| `integration-tests/fake-openai-server.ts`                          | Existing fake Provider with opt-in connection closing for unbiased cold/warm measurements                  |
+
+The runner is disabled unless `QWEN_FIRST_OUTPUT_BENCHMARK=1`. Its two input modes are mutually exclusive:
+
+- **Baseline**: `BENCHMARK_CLI_PATH`.
+- **Comparison**: both `BENCHMARK_CONTROL_CLI_PATH` and `BENCHMARK_CANDIDATE_CLI_PATH`.
+
+`BENCHMARK_POST_SESSION_DWELL_MS` is comparison-only, accepts exactly `0`, `100`, or `500`, and defaults to `0`. `BENCHMARK_MEASURED_PAIRS` is also comparison-only and accepts exactly `10` or `30`; it defaults to `10` for the 500 ms diagnostic and `30` otherwise. A 500 ms run requires 10 pairs and the 0/100 ms runs require 30, so a diagnostic cannot be mislabeled as decision-bearing. Formal Phase 2 runs invoke the runner separately for the three dwell scenarios; samples from different dwell values are never pooled. Missing or mixed modes, identical comparison bundles, unreadable paths, unsupported dwell or pair counts, and mismatched dwell/sample plans fail as `invalid_configuration` before sampling.
+
+Artifacts are written below `.qwen/investigations/daemon-first-output-benchmark/`, outside the integration harness's disposable run directory. This keeps successful, failed, and negative-result runs after global teardown without requiring `KEEP_OUTPUT`.
+
+## Measurement contract
+
+### One clock
+
+All latency timestamps use `performance.now()` in the parent harness. No duration combines daemon, ACP-child, Provider, or wall clocks.
+
+| Timestamp                  | Client-observable definition                                                       |
+| -------------------------- | ---------------------------------------------------------------------------------- |
+| `processSpawnAt`           | Immediately before daemon `spawn`                                                  |
+| `sessionReadyAt`           | Successful session response fully read and validated                               |
+| `promptStartedAt`          | Immediately before starting the non-blocking prompt request                        |
+| `promptAcceptedAt`         | HTTP `202` body validated, including top-level `promptId` and replay cursor        |
+| `providerRequestArrivalAt` | Fake Provider accepts the measured request, before its fixed delay                 |
+| `providerReadyAt`          | Fixed 50 ms delay has elapsed, immediately before the response stream is available |
+| `firstModelOutputAt`       | First qualifying SSE event for the accepted top-level `promptId` parsed            |
+| `firstAnswerTextAt`        | First qualifying answer-text event parsed; nullable                                |
+| `terminalAt`               | Matching `turn_complete` or `turn_error` parsed                                    |
+
+The raw timestamps produce these exact metrics:
+
+| Metric                              | Calculation                                     |
+| ----------------------------------- | ----------------------------------------------- |
+| `processToSessionReadyMs`           | `sessionReadyAt - processSpawnAt`               |
+| `promptToProviderRequestArrivalMs`  | `providerRequestArrivalAt - promptStartedAt`    |
+| `promptToFirstModelOutputMs`        | `firstModelOutputAt - promptStartedAt`          |
+| `promptToFirstAnswerTextMs`         | `firstAnswerTextAt - promptStartedAt`, nullable |
+| `providerReadyToFirstModelOutputMs` | `firstModelOutputAt - providerReadyAt`          |
+| `promptToTerminalMs`                | `terminalAt - promptStartedAt`                  |
+| `processToFirstModelOutputMs`       | `firstModelOutputAt - processSpawnAt`           |
+
+`promptAcceptedAt` is diagnostic, not a latency origin: a Provider request or event may precede receipt of the HTTP `202`. Missing required timestamps, non-finite values, or negative durations invalidate the sample. The harness owns the 30-second SSE-readiness deadline; the SDK connect timeout is recorded and set five seconds later so timer ordering cannot change `sse_connect_timeout` into another failure code.
+
+### Prompt and event correlation
+
+The SSE collector is active before the prompt, or resumes from the cursor preceding it, and buffers a fixed number of events until the `202` yields the accepted top-level `promptId`. The acceptance envelope must contain a non-empty `promptId` and a non-negative integer `lastEventId`; a legacy synchronous result is recognized only by its `stopReason`, while any other malformed response is rejected. A prompt acceptance timeout aborts the underlying request before sample teardown. The collector then evaluates buffered and live events in original arrival order and accepts only an exact top-level ID match. Earlier, absent-ID, and unrelated prompt events are ignored; buffer overflow fails rather than dropping events.
+
+Provider requests do not carry the daemon `promptId`. Each isolated fake Provider therefore permits only one expected measured request at a time and matches its unique fixed-length prompt sentinel. Its timestamp can be buffered before the `202`; an extra, missing, early, or concurrent request fails the sample.
+
+The first qualifying event determines `firstOutputAt`:
+
+| Event                                | Kind                                     |
+| ------------------------------------ | ---------------------------------------- |
+| Non-empty `agent_message_chunk` text | `answer_text`, and first-answer boundary |
+| Non-empty `agent_thought_chunk` text | `thought_text`                           |
+| Well-formed initial `tool_call`      | `tool_call`                              |
+
+Non-empty means decoded text length is greater than zero; text is not trimmed or rewritten. Replay/status frames, local discrete messages (including slash-command and background-notification output), user echo, role- or usage-only chunks, compression diagnostics, malformed updates, and `tool_call_update` do not count. `turn_error` always fails. `turn_complete` before qualifying output also fails. The pure tracker allows valid thought- or tool-first turns with a null answer metric, while the live fake Provider must produce its known answer sentinel.
+
+## Fake Provider and isolation
+
+The loopback-only OpenAI-compatible fake Provider records request arrival, validates the request/model, waits for a configured 50 ms timer, records the actual elapsed delay and `providerReadyAt`, emits one streamed answer sentinel, and completes normally. Benchmark responses explicitly use `Connection: close`, so the warm turn cannot gain from a TCP connection opened by the cold turn; network preconnection remains outside the measured optimization. The delay separates local pre-request work from response/event propagation; it does not model a real latency distribution. Pure tests cover thought- and tool-first fixtures without adding nondeterminism to live runs.
+
+Every baseline process and every comparison arm gets a fresh daemon/ACP process tree, workspace, home and `QWEN_HOME`, ephemeral daemon/Provider ports, event collector, and request ledger. Samples run serially.
+
+Node compile caches are empty at formal-run start, isolated by bundle and mode, populated only by excluded warmups, and then reused only by that same bundle. Control and candidate never share them. Warmup observations remain in the artifact with `measured: false`.
+
+The child starts from a minimal environment allowlist. It uses fixed locale/timezone, isolated writable paths, disabled telemetry/update checks, dummy Provider configuration, and cleared real credentials and proxy variables. The artifact records only deliberately supplied non-secret values.
+
+Formal comparisons use release bundles built from the same lockfile on the same idle 2-vCPU Linux host. The artifact records resolved paths, SHA-256 hashes, source revisions when available, Node/OS/CPU/memory, and load metadata. Filesystem page cache and scheduler noise cannot be flushed reliably, so AB/BA ordering and the order-sensitivity gate are mandatory.
+
+## Phase 1: single-bundle cold/warm baseline
+
+Run 2 excluded warmup processes, then 50 measured processes. Each measured process:
+
+1. creates a fresh `sessionScope: thread` session and sends one immediate fixed-length prompt (`cold`);
+2. waits for its validated terminal;
+3. keeps the first session open, creates a distinct `sessionScope: thread` session on the same ACP child process; and
+4. sends one same-length prompt with a distinct sentinel (`warm`).
+
+The runner records the ACP child PID after both turns and invalidates the sample unless exactly one unchanged child served them. Only after the second turn does it close both sessions. The second session therefore has a fresh per-session lazy Provider wrapper but warm ACP process-wide ESM/runtime caches. The pair estimates cold process-level Provider loading without conversation-history confounding. Both sessions still construct their own Provider on prompt, so work the prototype may move into the dwell is not credited; the gate is conservative. Second-session process-to metrics are diagnostic.
+
+The baseline expects exactly two Provider requests per process. All 50 cold/warm pairs must be valid. With:
+
+```text
+providerDelta =
+  P50(cold promptToProviderRequestArrivalMs) -
+  P50(warm promptToProviderRequestArrivalMs)
+```
+
+Phase 1 passes when either:
+
+```text
+providerDelta >= 25 ms
+```
+
+or:
+
+```text
+providerDelta >= 10% * P50(cold promptToFirstModelOutputMs)
+```
+
+Otherwise the artifact is retained and production work stops.
+
+## Comparison and statistics
+
+Each comparison dwell uses 2 excluded warmup pairs followed by 30 measured pairs, except the explicitly diagnostic 500 ms scenario, which uses 10 and always reports an inconclusive top-level outcome. Odd pairs run control then candidate (AB); even pairs run candidate then control (BA). Each arm has fresh state, and every recorded delta is `candidate - control`, so negative latency is faster.
+
+Failed arms remain in raw output and invalidate their pairs. They are not replaced. Sampling stops after the first invalid process or completed pair. The outer Vitest deadline is derived conservatively from the largest legal sample plan and every fixed lifecycle timeout, with scheduler margin, so even legal near-deadline samples cannot preempt artifact writing. Emergency teardown has its own fixed hook deadline. There is no outlier deletion, winsorization, subset selection, or Vitest retry. Any invalid primary pair invalidates the formal run.
+
+For each metric, report nearest-rank P50/P90/P99 and mean for each arm, paired median delta, wins/ties, and AB/BA subgroup medians. P90/P99 are descriptive only at 30 pairs; no P95 or tail-latency conclusion is made without at least 100 pairs.
+
+The paired-median 95% confidence interval uses 10,000 seeded bootstrap resamples of valid pair deltas with replacement; seed and iteration count are stored. Its bounds are the nearest-rank 2.5th and 97.5th percentiles. `orderSensitive` is true when AB and BA median deltas have opposite signs and either absolute median is at least 10 ms. Order sensitivity makes the run inconclusive rather than being averaged away.
+
+A paired artifact's top-level outcome describes only its primary metric in that one scenario. It does not evaluate the cross-scenario, resource, functional, or publication gates and cannot by itself authorize a Phase 2 pull request.
+
+## Failures, artifacts, and cleanup
+
+Every classified lifecycle or sample failure is retained and has one primary code:
+
+| Code                              | Trigger                                                          |
+| --------------------------------- | ---------------------------------------------------------------- |
+| `invalid_configuration`           | Invalid mode, path, dwell, environment, or bundle identity       |
+| `daemon_boot_timeout`             | No listening endpoint before deadline                            |
+| `daemon_exited_before_listen`     | Daemon exited before readiness                                   |
+| `session_create_failed`           | Error or malformed session response                              |
+| `sse_connect_timeout`             | SSE not established before deadline                              |
+| `sse_stream_ended`                | SSE ended before matching terminal                               |
+| `prompt_accept_timeout`           | Prompt request did not finish before deadline                    |
+| `prompt_rejected`                 | Error or malformed `202` response                                |
+| `legacy_prompt_response`          | Endpoint completed synchronously instead of returning `promptId` |
+| `event_buffer_overflow`           | Fixed pre-acceptance buffer exceeded                             |
+| `provider_request_count_mismatch` | Extra, missing, early, or concurrent fake request                |
+| `unexpected_output_kind`          | Answer-only live benchmark first emitted another output kind     |
+| `first_output_timeout`            | No qualifying output before deadline                             |
+| `terminal_before_first_output`    | Clean terminal without qualifying output                         |
+| `turn_error`                      | Matching error terminal                                          |
+| `terminal_timeout`                | No terminal after output before deadline                         |
+| `wrong_final_text`                | Answer differs from sentinel                                     |
+| `cleanup_timeout`                 | Owned resources did not stop by deadline                         |
+| `residual_process`                | Tracked daemon/ACP descendant survived cleanup                   |
+| `harness_error`                   | Unclassified harness invariant or I/O failure                    |
+
+The first causal lifecycle failure stays primary; SSE/session and process cleanup failures are recorded separately and still invalidate the pair. Non-finite or negative timings are retained as a harness failure but normalized to `null` before aggregation, and failed runs never contribute to percentile or gate calculations. Fixed timeouts, request limits, and buffer capacity are serialized. Diagnostic messages and bounded stdout/stderr tails do not affect decisions.
+
+Each invocation writes schema-version-1 `daemon-first-output` JSON plus Markdown derived only from that JSON. It contains run/platform/bundle identity, sanitized configuration, warmups, every raw relative timestamp and metric, latched first-output/answer/terminal event types and correlation counts, Provider request counts, invalid samples and pairs, failures, cleanup results, statistics/bootstrap/order summaries, and gate inputs with explicit decision reasons. Phase 2 resource runs extend their validation evidence with RSS measurements. Classified sample failures stay in their fixed sample slots; invalid configuration or an unclassified harness failure produces a fatal artifact. Artifacts exclude credentials, tokens, and prompt content beyond the non-secret benchmark sentinel.
+
+Cleanup always aborts and awaits SSE, closes live sessions, captures ACP/MCP descendant PIDs, sends `SIGTERM` to the owned process group while its leader is still known live, and escalates the group only if that same leader survives the fixed grace period. Captured descendants and an enumeration-completeness latch stay attached to the active resource through emergency cleanup. Once the leader exits, cleanup never probes or signals its numeric process-group ID again because POSIX may reuse it; it only verifies the retained descendant set and fails safely if a descendant survives or enumeration was incomplete. Provider sockets close only after process teardown, and temporary state is removed only after both are verified. Cleanup never uses process-name-wide killing. Any invalid process or completed pair stops sampling immediately while retaining the failure. If an owned process or listener cannot be verified as stopped, the runner records the temp root deferred to emergency cleanup, marks a not-started counterpart when needed to preserve an invalid pair, and makes emergency teardown failure visible rather than silently dropping its tracked resource. Emergency teardown retries tracked processes and Providers before deleting deferred temp roots or compile caches.
+
+## Phase 2: best-effort Provider preparation
+
+### Behavior and boundary
+
+The current lazy generator memoizes one loader promise across generation, streaming, token count, and embedding. Preparation may start that same promise early; it must not add another loader/Provider, make any model/token/embed request, refresh credentials, or change eager validation and Qwen OAuth credential timing. An immediate prompt must join the same promise.
+
+A rejected preparation promise remains memoized so the first prompt observes the same failure. The detached caller may attach a rejection observer only to prevent an unhandled rejection; it must not clear or replace the stored promise. The capability stays internal to Core and does not extend the public `ContentGenerator` contract.
+
+The earliest allowed trigger is the ACP child's successful write of a `session/new` result:
+
+1. observe the received request ID;
+2. observe a sent response with the same ID and `result`;
+3. rely on the existing observation occurring only after `writer.write(frame)` resolves; and
+4. schedule one unref'ed `setImmediate` that starts, but does not await, preparation.
+
+Failed responses, authentication, `session/load`, `session/resume`, and other RPCs do not trigger it. No sleep is used to guess response delivery. ESM import is not cancellable, so a closed session may allow an already-started import to finish; it must still issue no request, retain no external resource, and produce no unhandled rejection.
+
+This boundary is only best-effort. The daemon still performs session ownership/config/source persistence work and serializes the outer HTTP response after the child write. Provider import can contend on a 2-vCPU host and regress `processToSessionReadyMs`; `setImmediate` creates no cross-process happens-before relation. Session non-inferiority is therefore blocking. If it fails, stop rather than tune a timer. An exact outer-response-finished signal would cross HTTP transport, daemon bridge, and ACP child and needs a separate design only if the measured value justifies that complexity.
+
+### Publication gates
+
+Use distinct release bundles on the reference host:
+
+| Scenario                     | Required result                                                                                                     |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Fake, 0 ms dwell, 30 pairs   | 95% paired-median CI upper bound for both `processToSessionReadyMs` and `promptToFirstModelOutputMs` is `<= +10 ms` |
+| Fake, 100 ms dwell, 30 pairs | `processToFirstModelOutputMs` paired median is `<= -10 ms` and its 95% CI upper bound is `< 0`                      |
+| Fake, 500 ms dwell, 10 pairs | Diagnostic upper bound only; cannot compensate for another failed gate or independently justify merge               |
+
+Across the 0 and 100 ms fake runs, all 60/60 pairs must be valid, with zero preload-window Provider requests, zero residual processes, and no order sensitivity.
+
+Measure whole-process-tree RSS for 1, 4, and 16 idle sessions after Provider preparation has settled and before any prompt. Both gates must pass:
+
+- single-session candidate-minus-control P50 RSS `<= +10 MiB`;
+- candidate-minus-control incremental growth from 1 to 16 live sessions `<= +0.5 MiB` per additional session:
+
+```text
+((candidateRss16 - candidateRss1) -
+ (controlRss16 - controlRss1)) / 15
+```
+
+Each idle-session probe creates sessions serially, waits for preparation to settle, and sends no prompt before RSS measurement; any Provider request fails it. Pair count and ordering are fixed in the Phase 2 validation artifact before formal measurement.
+
+Only after all fake/resource gates pass, run real-Provider external validity on the same host: 30 AB/BA pairs at 100 ms plus a 10-pair immediate smoke. Functional/auth/streaming/answer failures block. Network uncertainty is reported but cannot override fake-local conclusions in either direction.
+
+## Validation and decision
+
+Phase 1 pure tests cover answer/thought/tool classification; local/replay/diagnostic exclusions; exact and pre-`202` correlation; buffer overflow; terminal/error paths; nullable answer metrics; nearest-rank percentiles; deterministic bootstrap; delta sign; invalid-pair retention; order sensitivity; representative fatal artifacts; and JSON-to-Markdown rendering. An opt-in release-bundle smoke validates Provider wiring, lifecycle, artifact schema, and cleanup. Formal benchmarks are not default CI.
+
+A Phase 2 candidate additionally tests trigger timing and RPC filtering, single-flight with an immediate prompt, zero Provider requests/credential refresh, memoized rejection, non-blocking response write, and safe shutdown. It must pass build, typecheck, affected unit/integration tests, and the full artifact gates.
+
+```text
+50-process cold/warm baseline valid and threshold met?
+├─ no  → retain artifact; stop
+└─ yes → prototype separately
+         └─ fake 0 ms non-inferior?
+            ├─ no  → retain artifact; stop
+            └─ yes
+               └─ fake 100 ms materially faster with CI < 0?
+                  ├─ no  → retain artifact; stop
+                  └─ yes
+                     └─ 60/60 valid + request/cleanup/order/RSS gates pass?
+                        ├─ no  → retain artifact; stop
+                        └─ yes
+                           └─ real-Provider runs functionally pass?
+                              ├─ no  → retain artifact; stop
+                              └─ yes → optimization PR may be published
+```

--- a/integration-tests/cli/_first-output-benchmark.test.ts
+++ b/integration-tests/cli/_first-output-benchmark.test.ts
@@ -1,0 +1,806 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_BOOTSTRAP_ITERATIONS,
+  FIRST_OUTPUT_BENCHMARK_VERSION,
+  FirstOutputTracker,
+  classifyFirstOutputEvent,
+  evaluateSingleBundlePrototypeGate,
+  measuredPairCountForDwell,
+  nullablePercentiles,
+  parseBenchmarkPostSessionDwell,
+  pairedCandidateControlStats,
+  percentiles,
+  renderFirstOutputBenchmarkMarkdown,
+  validateExpectedFinalText,
+  validatePromptAcceptance,
+  type BenchmarkDaemonEvent,
+  type FirstOutputBenchmarkArtifactV1,
+  type PairedMetricSample,
+} from './_first-output-benchmark.js';
+
+describe('measuredPairCountForDwell', () => {
+  it('uses 30 decision pairs except for the 500ms diagnostic', () => {
+    expect(measuredPairCountForDwell(0)).toBe(30);
+    expect(measuredPairCountForDwell(100)).toBe(30);
+    expect(measuredPairCountForDwell(500)).toBe(10);
+  });
+
+  it('rejects sample counts that could mislabel a diagnostic or decision run', () => {
+    expect(() => measuredPairCountForDwell(0, '10')).toThrow(
+      '0ms dwell requires exactly 30 measured pairs',
+    );
+    expect(() => measuredPairCountForDwell(500, '30')).toThrow(
+      '500ms dwell requires exactly 10 measured pairs',
+    );
+    expect(() => measuredPairCountForDwell(100, '20')).toThrow(
+      'expected exactly 10 or 30',
+    );
+  });
+});
+
+describe('parseBenchmarkPostSessionDwell', () => {
+  it('accepts only the three benchmark scenarios', () => {
+    expect(parseBenchmarkPostSessionDwell()).toBe(0);
+    expect(parseBenchmarkPostSessionDwell('0')).toBe(0);
+    expect(parseBenchmarkPostSessionDwell('100')).toBe(100);
+    expect(parseBenchmarkPostSessionDwell('500')).toBe(500);
+  });
+
+  it('rejects unsupported and timer-overflow dwell values', () => {
+    expect(() => parseBenchmarkPostSessionDwell('1')).toThrow(
+      'expected exactly 0, 100, or 500',
+    );
+    expect(() => parseBenchmarkPostSessionDwell('2147483648')).toThrow(
+      'expected exactly 0, 100, or 500',
+    );
+  });
+});
+
+function sessionUpdate(
+  promptId: string,
+  update: Record<string, unknown>,
+  id = 1,
+  meta?: Record<string, unknown>,
+): BenchmarkDaemonEvent {
+  return {
+    id,
+    v: 1,
+    type: 'session_update',
+    promptId,
+    data: { sessionId: 'session-1', update },
+    ...(meta ? { _meta: meta } : {}),
+  };
+}
+
+function answer(promptId: string, text: string, id = 1): BenchmarkDaemonEvent {
+  return sessionUpdate(
+    promptId,
+    {
+      sessionUpdate: 'agent_message_chunk',
+      content: { type: 'text', text },
+    },
+    id,
+  );
+}
+
+function thought(promptId: string, text: string, id = 1): BenchmarkDaemonEvent {
+  return sessionUpdate(
+    promptId,
+    {
+      sessionUpdate: 'agent_thought_chunk',
+      content: { type: 'text', text },
+    },
+    id,
+  );
+}
+
+function toolCall(promptId: string, id = 1): BenchmarkDaemonEvent {
+  return sessionUpdate(
+    promptId,
+    {
+      sessionUpdate: 'tool_call',
+      toolCallId: 'call-1',
+      title: 'Read file',
+    },
+    id,
+  );
+}
+
+function turnComplete(promptId: string, id = 10): BenchmarkDaemonEvent {
+  return {
+    id,
+    v: 1,
+    type: 'turn_complete',
+    promptId,
+    data: {
+      sessionId: 'session-1',
+      promptId,
+      stopReason: 'end_turn',
+    },
+  };
+}
+
+function turnError(
+  promptId: string,
+  message: string,
+  id = 10,
+): BenchmarkDaemonEvent {
+  return {
+    id,
+    v: 1,
+    type: 'turn_error',
+    promptId,
+    data: {
+      sessionId: 'session-1',
+      promptId,
+      code: 'provider_error',
+      message,
+    },
+  };
+}
+
+describe('classifyFirstOutputEvent', () => {
+  it('classifies non-empty answer text and preserves the receive-independent server timestamp', () => {
+    const event = answer('prompt-1', 'hello');
+    event._meta = { serverTimestamp: '2026-07-27T00:00:00.000Z' };
+
+    expect(classifyFirstOutputEvent(event, 'prompt-1')).toEqual({
+      type: 'output',
+      kind: 'answer_text',
+      text: 'hello',
+      toolCallId: null,
+      serverTimestampMs: Date.parse('2026-07-27T00:00:00.000Z'),
+    });
+  });
+
+  it('classifies thought text and an initial tool call as output', () => {
+    expect(
+      classifyFirstOutputEvent(thought('prompt-1', 'thinking'), 'prompt-1'),
+    ).toMatchObject({
+      type: 'output',
+      kind: 'thought_text',
+      text: 'thinking',
+    });
+    expect(
+      classifyFirstOutputEvent(toolCall('prompt-1'), 'prompt-1'),
+    ).toMatchObject({
+      type: 'output',
+      kind: 'tool_call',
+      toolCallId: 'call-1',
+    });
+  });
+
+  it('excludes empty, replayed, diagnostic, user, and update-only frames', () => {
+    const excluded = [
+      sessionUpdate('prompt-1', {
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: '' },
+        _meta: { usage: { totalTokens: 1 } },
+      }),
+      sessionUpdate('prompt-1', {
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: 'old answer' },
+        _meta: { qwenTranscript: { sourceRecordIds: ['record-1'] } },
+      }),
+      sessionUpdate('prompt-1', {
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: 'status' },
+        _meta: {
+          source: 'todo_stop_guard',
+          qwenDiscreteMessage: true,
+        },
+      }),
+      sessionUpdate('prompt-1', {
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: 'future local status' },
+        _meta: {
+          source: 'future_local_status',
+          qwenDiscreteMessage: true,
+        },
+      }),
+      sessionUpdate('prompt-1', {
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: 'background task finished' },
+        _meta: { source: 'background_notification' },
+      }),
+      sessionUpdate('prompt-1', {
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: 'local command output' },
+        _meta: { source: 'slash_command' },
+      }),
+      answer(
+        'prompt-1',
+        'IMPORTANT: This conversation approached the input token limit. ' +
+          'A compressed context will be sent for future messages.',
+      ),
+      sessionUpdate('prompt-1', {
+        sessionUpdate: 'user_message_chunk',
+        content: { type: 'text', text: 'echo' },
+      }),
+      sessionUpdate('prompt-1', {
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'call-1',
+        status: 'completed',
+      }),
+      sessionUpdate('prompt-1', {
+        sessionUpdate: 'tool_call',
+        toolCallId: '',
+        title: 'Malformed tool call',
+      }),
+      sessionUpdate('prompt-1', {
+        sessionUpdate: 'tool_call',
+        toolCallId: 'call-without-title',
+      }),
+      {
+        v: 1,
+        type: 'replay_complete',
+        promptId: 'prompt-1',
+        data: {},
+      },
+    ];
+
+    for (const event of excluded) {
+      expect(classifyFirstOutputEvent(event, 'prompt-1').type).toBe('ignore');
+    }
+  });
+
+  it('requires exact prompt correlation for output and terminal events', () => {
+    expect(
+      classifyFirstOutputEvent(answer('other-prompt', 'wrong'), 'prompt-1'),
+    ).toEqual({ type: 'ignore', reason: 'wrong_prompt_id' });
+
+    const wrongNestedPrompt = turnComplete('prompt-1');
+    (wrongNestedPrompt.data as Record<string, unknown>)['promptId'] =
+      'other-prompt';
+    expect(classifyFirstOutputEvent(wrongNestedPrompt, 'prompt-1')).toEqual({
+      type: 'ignore',
+      reason: 'wrong_prompt_id',
+    });
+
+    const missingEnvelopePrompt = turnComplete('prompt-1');
+    delete missingEnvelopePrompt.promptId;
+    expect(classifyFirstOutputEvent(missingEnvelopePrompt, 'prompt-1')).toEqual(
+      {
+        type: 'ignore',
+        reason: 'wrong_prompt_id',
+      },
+    );
+  });
+});
+
+describe('FirstOutputTracker', () => {
+  it('tracks thought as first output and later answer separately', () => {
+    const tracker = new FirstOutputTracker();
+    tracker.acceptPrompt('prompt-1');
+    tracker.push(thought('prompt-1', 'thinking', 1), 20);
+    tracker.push(answer('prompt-1', 'final ', 2), 30);
+    tracker.push(answer('prompt-1', 'answer', 3), 40);
+    tracker.push(turnComplete('prompt-1', 4), 50);
+
+    expect(tracker.snapshot()).toMatchObject({
+      firstOutput: {
+        kind: 'thought_text',
+        receivedAtMs: 20,
+        text: 'thinking',
+      },
+      firstAnswer: {
+        kind: 'answer_text',
+        receivedAtMs: 30,
+        text: 'final ',
+      },
+      finalAnswerText: 'final answer',
+      runEligible: true,
+      answerMetricEligible: true,
+      failureCode: null,
+    });
+  });
+
+  it('buffers events that precede HTTP acceptance and filters by the accepted promptId once', () => {
+    const tracker = new FirstOutputTracker();
+    tracker.push(answer('other-prompt', 'wrong', 1), 10);
+    tracker.push(answer('prompt-1', 'right', 2), 11);
+    tracker.push(turnComplete('prompt-1', 3), 12);
+
+    expect(tracker.snapshot().firstOutput).toBeNull();
+    tracker.acceptPrompt('prompt-1');
+    tracker.acceptPrompt('prompt-1');
+
+    expect(tracker.snapshot()).toMatchObject({
+      bufferedEventCount: 0,
+      bufferedBeforeAcceptanceCount: 3,
+      matchingEventCount: 2,
+      matchingTerminalCount: 1,
+      firstOutput: {
+        eventId: 2,
+        text: 'right',
+        receivedAtMs: 11,
+      },
+      finalAnswerText: 'right',
+      runEligible: true,
+    });
+  });
+
+  it('fails a clean terminal that arrives before qualifying output', () => {
+    const tracker = new FirstOutputTracker();
+    tracker.acceptPrompt('prompt-1');
+    tracker.push(turnComplete('prompt-1'), 25);
+    tracker.push(answer('prompt-1', 'too late'), 30);
+
+    expect(tracker.snapshot()).toMatchObject({
+      firstOutput: null,
+      finalAnswerText: null,
+      terminal: { kind: 'complete', receivedAtMs: 25 },
+      failureCode: 'terminal_before_first_output',
+      runEligible: false,
+    });
+  });
+
+  it('preserves partial final answer text when turn_error terminates the run', () => {
+    const tracker = new FirstOutputTracker();
+    tracker.acceptPrompt('prompt-1');
+    tracker.push(answer('prompt-1', 'partial ', 1), 10);
+    tracker.push(answer('prompt-1', 'answer', 2), 11);
+    tracker.push(turnError('prompt-1', 'provider unavailable', 3), 12);
+
+    expect(tracker.snapshot()).toMatchObject({
+      finalAnswerText: 'partial answer',
+      terminal: {
+        kind: 'error',
+        code: 'provider_error',
+        message: 'provider unavailable',
+      },
+      failureCode: 'turn_error',
+      failureMessage: 'provider unavailable',
+      runEligible: false,
+    });
+  });
+
+  it('keeps a successful tool-call-only run eligible while excluding its null answer metric', () => {
+    const tracker = new FirstOutputTracker();
+    tracker.acceptPrompt('prompt-1');
+    tracker.push(toolCall('prompt-1'), 10);
+    tracker.push(turnComplete('prompt-1'), 20);
+
+    expect(tracker.snapshot()).toMatchObject({
+      firstOutput: { kind: 'tool_call' },
+      firstAnswer: null,
+      finalAnswerText: null,
+      runEligible: true,
+      answerMetricEligible: false,
+    });
+    expect(nullablePercentiles([12, null, 18])).toEqual({
+      totalCount: 3,
+      eligibleCount: 2,
+      missingCount: 1,
+      distribution: {
+        count: 2,
+        p50: 12,
+        p90: 18,
+        p99: 18,
+        mean: 15,
+        min: 12,
+        max: 18,
+      },
+    });
+  });
+
+  it('reports bounded pre-acceptance buffering overflow', () => {
+    const tracker = new FirstOutputTracker({ maxBufferedEvents: 1 });
+    tracker.push(answer('prompt-1', 'first'), 10);
+    tracker.push(answer('prompt-1', 'overflow'), 11);
+    tracker.acceptPrompt('prompt-1');
+
+    expect(tracker.snapshot()).toMatchObject({
+      firstOutput: { text: 'first' },
+      failureCode: 'event_buffer_overflow',
+      runEligible: false,
+    });
+  });
+
+  it('preserves the first causal tracker failure', () => {
+    const tracker = new FirstOutputTracker({ maxBufferedEvents: 1 });
+    tracker.push(answer('prompt-1', 'first'), 10);
+    tracker.push(answer('prompt-1', 'overflow'), 11);
+    tracker.acceptPrompt('prompt-1');
+    tracker.push(turnError('prompt-1', 'later failure'), 12);
+
+    expect(tracker.snapshot()).toMatchObject({
+      failureCode: 'event_buffer_overflow',
+      failureMessage: 'More than 1 events arrived before prompt acceptance',
+      terminal: { kind: 'error' },
+    });
+  });
+});
+
+describe('statistics', () => {
+  it('calculates predictable nearest-rank percentiles', () => {
+    expect(percentiles([5, 1, 4, 2, 3])).toEqual({
+      count: 5,
+      p50: 3,
+      p90: 5,
+      p99: 5,
+      mean: 3,
+      min: 1,
+      max: 5,
+    });
+    expect(percentiles([])).toBeNull();
+  });
+
+  it('produces deterministic seeded 10,000-iteration bootstrap statistics', () => {
+    const samples: PairedMetricSample[] = [
+      {
+        order: 'AB',
+        valid: true,
+        controlMs: 120,
+        candidateMs: 90,
+      },
+      {
+        order: 'BA',
+        valid: true,
+        controlMs: 125,
+        candidateMs: 92,
+      },
+      {
+        order: 'AB',
+        valid: true,
+        controlMs: 115,
+        candidateMs: 91,
+      },
+      {
+        order: 'BA',
+        valid: true,
+        controlMs: 130,
+        candidateMs: 95,
+      },
+    ];
+
+    const first = pairedCandidateControlStats(samples, { seed: 7264 });
+    const second = pairedCandidateControlStats(samples, { seed: 7264 });
+
+    expect(first).toEqual(second);
+    expect(first.bootstrapMedianCi95).toMatchObject({
+      lowMs: -35,
+      highMs: -24,
+      iterations: DEFAULT_BOOTSTRAP_ITERATIONS,
+      seed: 7264,
+    });
+    expect(first).toMatchObject({
+      control: { p50: 120, p90: 130, p99: 130, mean: 122.5 },
+      candidate: { p50: 91, p90: 95, p99: 95, mean: 92 },
+      medianDeltaMs: -31.5,
+      meanDeltaMs: -30.5,
+      candidateWins: 4,
+      controlWins: 0,
+      ties: 0,
+      orderSensitivity: {
+        abMedianDeltaMs: -27,
+        baMedianDeltaMs: -34,
+      },
+      decision: 'improved',
+    });
+  });
+
+  it('detects material AB/BA direction reversal and makes the decision inconclusive', () => {
+    const stats = pairedCandidateControlStats(
+      [
+        {
+          order: 'AB',
+          valid: true,
+          controlMs: 100,
+          candidateMs: 80,
+        },
+        {
+          order: 'AB',
+          valid: true,
+          controlMs: 100,
+          candidateMs: 82,
+        },
+        {
+          order: 'BA',
+          valid: true,
+          controlMs: 100,
+          candidateMs: 101,
+        },
+        {
+          order: 'BA',
+          valid: true,
+          controlMs: 100,
+          candidateMs: 102,
+        },
+      ],
+      { seed: 5 },
+    );
+
+    expect(stats.orderSensitivity).toEqual({
+      abEligiblePairs: 2,
+      baEligiblePairs: 2,
+      abMedianDeltaMs: -19,
+      baMedianDeltaMs: 1.5,
+      thresholdMs: 10,
+      orderSensitive: true,
+    });
+    expect(stats.decision).toBe('inconclusive');
+  });
+
+  it('preserves invalid pairs and omits valid pairs missing a nullable metric', () => {
+    const stats = pairedCandidateControlStats(
+      [
+        {
+          order: 'AB',
+          valid: false,
+          controlMs: 100,
+          candidateMs: 90,
+        },
+        {
+          order: 'BA',
+          valid: true,
+          controlMs: 100,
+          candidateMs: null,
+        },
+      ],
+      { seed: 1 },
+    );
+
+    expect(stats).toMatchObject({
+      totalPairs: 2,
+      validPairs: 1,
+      invalidPairs: 1,
+      eligiblePairs: 0,
+      missingMetricPairs: 1,
+      decision: 'invalid',
+    });
+  });
+
+  it('never promotes a partial comparison when any pair is invalid', () => {
+    const stats = pairedCandidateControlStats(
+      [
+        {
+          order: 'AB',
+          valid: false,
+          controlMs: 100,
+          candidateMs: 80,
+        },
+        {
+          order: 'AB',
+          valid: true,
+          controlMs: 100,
+          candidateMs: 70,
+        },
+        {
+          order: 'BA',
+          valid: true,
+          controlMs: 100,
+          candidateMs: 70,
+        },
+      ],
+      { seed: 1 },
+    );
+
+    expect(stats).toMatchObject({
+      validPairs: 2,
+      invalidPairs: 1,
+      medianDeltaMs: -30,
+      decision: 'invalid',
+      decisionReason: 'At least one pair is invalid',
+    });
+  });
+});
+
+describe('runner decision contracts', () => {
+  it('distinguishes accepted, legacy, and malformed prompt responses', () => {
+    expect(
+      validatePromptAcceptance({ promptId: 'prompt-1', lastEventId: 0 }),
+    ).toEqual({
+      kind: 'accepted',
+      promptId: 'prompt-1',
+      lastEventId: 0,
+    });
+    expect(validatePromptAcceptance({ stopReason: 'end_turn' })).toMatchObject({
+      kind: 'failure',
+      failure: { code: 'legacy_prompt_response' },
+    });
+    for (const malformed of [
+      null,
+      {},
+      { promptId: '', lastEventId: 0 },
+      { promptId: 'prompt-1', lastEventId: -1 },
+      { promptId: 'prompt-1', lastEventId: 1.5 },
+      { promptId: 'prompt-1', lastEventId: Number.NaN },
+      { stopReason: 'end_turn', promptId: '' },
+    ]) {
+      expect(validatePromptAcceptance(malformed)).toMatchObject({
+        kind: 'failure',
+        failure: { code: 'prompt_rejected' },
+      });
+    }
+  });
+
+  it('applies the absolute and relative prototype gates only to complete baselines', () => {
+    expect(
+      evaluateSingleBundlePrototypeGate({
+        complete: true,
+        coldPromptToProviderRequestP50Ms: 125,
+        warmPromptToProviderRequestP50Ms: 100,
+        coldPromptToFirstModelOutputP50Ms: 400,
+      }),
+    ).toMatchObject({ passed: true, providerDeltaMs: 25 });
+    expect(
+      evaluateSingleBundlePrototypeGate({
+        complete: true,
+        coldPromptToProviderRequestP50Ms: 110,
+        warmPromptToProviderRequestP50Ms: 100,
+        coldPromptToFirstModelOutputP50Ms: 100,
+      }),
+    ).toMatchObject({ passed: true, providerDeltaMs: 10 });
+    expect(
+      evaluateSingleBundlePrototypeGate({
+        complete: true,
+        coldPromptToProviderRequestP50Ms: 109,
+        warmPromptToProviderRequestP50Ms: 100,
+        coldPromptToFirstModelOutputP50Ms: 100,
+      }),
+    ).toMatchObject({ passed: false, providerDeltaMs: 9 });
+    expect(
+      evaluateSingleBundlePrototypeGate({
+        complete: false,
+        coldPromptToProviderRequestP50Ms: 130,
+        warmPromptToProviderRequestP50Ms: 100,
+        coldPromptToFirstModelOutputP50Ms: 100,
+      }),
+    ).toMatchObject({ passed: false });
+  });
+
+  it('maps a mismatched final answer to the stable failure code', () => {
+    expect(validateExpectedFinalText('expected', 'expected')).toBeNull();
+    expect(validateExpectedFinalText('actual', 'expected')).toEqual({
+      code: 'wrong_final_text',
+      message: 'Unexpected final answer: "actual".',
+    });
+  });
+});
+
+describe('artifact rendering', () => {
+  it('renders v1 metric and failure summaries without mutating the artifact', () => {
+    const stats = pairedCandidateControlStats(
+      [
+        {
+          order: 'AB',
+          valid: true,
+          controlMs: 100,
+          candidateMs: 80,
+        },
+      ],
+      { seed: 1 },
+    );
+    const artifact = {
+      version: FIRST_OUTPUT_BENCHMARK_VERSION,
+      benchmark: 'daemon-first-output',
+      mode: 'paired',
+      capturedAt: '2026-07-27T00:00:00.000Z',
+      harnessGitCommit: null,
+      platform: {
+        os: 'darwin',
+        arch: 'arm64',
+        nodeVersion: 'v22.0.0',
+        cpuModel: 'test',
+        logicalCpuCount: 8,
+        availableCpuCount: 8,
+        totalMemoryBytes: 1,
+        loadAverage: [0, 0, 0],
+      },
+      config: {
+        seed: 1,
+        warmupPairs: 0,
+        measuredPairs: 1,
+        bootstrapIterations: DEFAULT_BOOTSTRAP_ITERATIONS,
+        materialThresholdMs: 10,
+        orderSensitivityThresholdMs: 10,
+        providerDelayMs: 50,
+        providerConnection: 'close-per-response',
+        postSessionDwellMs: 0,
+        prompt: 'reply',
+        expectedAnswer: 'ok',
+        maxBufferedEvents: 256,
+        providerRequestsPerSession: 1,
+        timeoutsMs: {},
+        variants: {
+          control: {
+            cliPath: '/control',
+            realpath: '/control',
+            sha256: 'control-hash',
+            gitCommit: null,
+            compileCache: {
+              policy: 'fixed-private-per-variant-warmed',
+              directory: '/cache/control',
+            },
+          },
+          candidate: {
+            cliPath: '/candidate',
+            realpath: '/candidate',
+            sha256: 'candidate-hash',
+            gitCommit: null,
+            compileCache: {
+              policy: 'fixed-private-per-variant-warmed',
+              directory: '/cache/candidate',
+            },
+          },
+        },
+      },
+      warmups: [],
+      pairs: [],
+      summary: {
+        expectedPairs: 1,
+        validPairs: 1,
+        invalidPairs: 0,
+        failuresByCode: { turn_error: 1 },
+        metrics: {
+          promptToFirstModelOutputMs: {
+            all: null,
+            bySession: { session_1: stats },
+          },
+        },
+        decision: {
+          outcome: 'improved',
+          scope: 'primary_metric_only',
+          publicationGateEvaluated: false,
+          primaryMetric: 'processToFirstModelOutputMs',
+          primarySession: 1,
+          reasons: ['Candidate is faster'],
+        },
+      },
+    } satisfies FirstOutputBenchmarkArtifactV1;
+    const before = JSON.stringify(artifact);
+
+    const markdown = renderFirstOutputBenchmarkMarkdown(artifact);
+
+    expect(markdown).toContain('Primary metric decision: **improved**');
+    expect(markdown).toContain('| promptToFirstModelOutputMs |');
+    expect(markdown).toContain('Control p50/p90/p99/mean');
+    expect(markdown).toContain('Wins candidate/control/ties');
+    expect(markdown).toContain('80.0/80.0/80.0/80.0');
+    expect(markdown).toContain('- turn_error: 1');
+    expect(JSON.stringify(artifact)).toBe(before);
+  });
+
+  it('renders a fatal configuration artifact', () => {
+    const artifact = {
+      version: FIRST_OUTPUT_BENCHMARK_VERSION,
+      benchmark: 'daemon-first-output',
+      mode: 'failed',
+      capturedAt: '2026-07-27T00:00:00.000Z',
+      harnessGitCommit: null,
+      platform: {
+        os: 'linux',
+        arch: 'x64',
+        nodeVersion: 'v22.0.0',
+        cpuModel: 'test',
+        logicalCpuCount: 2,
+        availableCpuCount: 2,
+        totalMemoryBytes: 1,
+        loadAverage: [0, 0, 0],
+      },
+      config: { requestedMode: 'unknown' },
+      failure: {
+        code: 'invalid_configuration',
+        message: 'bundle path is missing',
+      },
+      summary: {
+        failuresByCode: { invalid_configuration: 1 },
+        decision: {
+          outcome: 'invalid',
+          reasons: ['bundle path is missing'],
+        },
+      },
+    } satisfies FirstOutputBenchmarkArtifactV1;
+
+    expect(renderFirstOutputBenchmarkMarkdown(artifact)).toContain(
+      'Failure: invalid_configuration',
+    );
+  });
+});

--- a/integration-tests/cli/_first-output-benchmark.ts
+++ b/integration-tests/cli/_first-output-benchmark.ts
@@ -1,0 +1,1181 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const FIRST_OUTPUT_BENCHMARK_VERSION = 1 as const;
+export const DEFAULT_BOOTSTRAP_ITERATIONS = 10_000;
+export const DEFAULT_MATERIAL_THRESHOLD_MS = 10;
+export const DEFAULT_ORDER_SENSITIVITY_THRESHOLD_MS = 10;
+export const DEFAULT_FIRST_OUTPUT_EVENT_BUFFER_LIMIT = 256;
+
+export type BenchmarkVariant = 'single' | 'control' | 'candidate';
+export type PairOrder = 'AB' | 'BA';
+export type FirstOutputKind = 'answer_text' | 'thought_text' | 'tool_call';
+export type BenchmarkDecision =
+  | 'improved'
+  | 'regressed'
+  | 'inconclusive'
+  | 'invalid';
+
+export function parseBenchmarkPostSessionDwell(
+  configuredValue?: string,
+): 0 | 100 | 500 {
+  const raw = configuredValue?.trim() ?? '0';
+  if (raw === '0' || raw === '100' || raw === '500') {
+    return Number(raw) as 0 | 100 | 500;
+  }
+  throw new Error(
+    'Invalid BENCHMARK_POST_SESSION_DWELL_MS: expected exactly 0, 100, or 500.',
+  );
+}
+
+export function measuredPairCountForDwell(
+  postSessionDwellMs: number,
+  configuredValue?: string,
+): 10 | 30 {
+  const expected = postSessionDwellMs === 500 ? 10 : 30;
+  const raw = configuredValue?.trim() ?? String(expected);
+  if (raw !== '10' && raw !== '30') {
+    throw new Error(
+      'Invalid BENCHMARK_MEASURED_PAIRS: expected exactly 10 or 30.',
+    );
+  }
+  const configured = Number(raw) as 10 | 30;
+  if (configured !== expected) {
+    throw new Error(
+      `Invalid comparison sample plan: ${postSessionDwellMs}ms dwell ` +
+        `requires exactly ${expected} measured pairs.`,
+    );
+  }
+  return configured;
+}
+
+export interface BenchmarkDaemonEvent {
+  id?: number;
+  v?: number;
+  type: string;
+  data?: unknown;
+  promptId?: string;
+  _meta?: Record<string, unknown>;
+}
+
+export interface TimedDaemonEvent {
+  event: BenchmarkDaemonEvent;
+  receivedAtMs: number;
+}
+
+export interface ClassifiedFirstOutput {
+  type: 'output';
+  kind: FirstOutputKind;
+  text: string | null;
+  toolCallId: string | null;
+  serverTimestampMs: number | null;
+}
+
+export interface ClassifiedTerminal {
+  type: 'terminal';
+  kind: 'complete' | 'error';
+  stopReason: string | null;
+  code: string | null;
+  message: string | null;
+}
+
+export type IgnoredEventReason =
+  | 'wrong_prompt_id'
+  | 'unrelated_event'
+  | 'malformed_update'
+  | 'replay'
+  | 'diagnostic'
+  | 'non_output_update'
+  | 'empty_content';
+
+export interface IgnoredFirstOutputEvent {
+  type: 'ignore';
+  reason: IgnoredEventReason;
+}
+
+export type ClassifiedPromptEvent =
+  | ClassifiedFirstOutput
+  | ClassifiedTerminal
+  | IgnoredFirstOutputEvent;
+
+export interface FirstOutputObservation {
+  kind: FirstOutputKind;
+  receivedAtMs: number;
+  eventId: number | null;
+  text: string | null;
+  toolCallId: string | null;
+  serverTimestampMs: number | null;
+}
+
+export interface FirstOutputTerminal {
+  kind: 'complete' | 'error';
+  receivedAtMs: number;
+  eventId: number | null;
+  stopReason: string | null;
+  code: string | null;
+  message: string | null;
+}
+
+export type TrackerFailureCode =
+  | 'event_buffer_overflow'
+  | 'terminal_before_first_output'
+  | 'turn_error';
+
+export interface FirstOutputTrackerSnapshot {
+  promptId: string | null;
+  bufferedEventCount: number;
+  bufferedBeforeAcceptanceCount: number;
+  matchingEventCount: number;
+  matchingTerminalCount: number;
+  firstOutput: FirstOutputObservation | null;
+  firstAnswer: FirstOutputObservation | null;
+  finalAnswerText: string | null;
+  terminal: FirstOutputTerminal | null;
+  failureCode: TrackerFailureCode | null;
+  failureMessage: string | null;
+  runEligible: boolean;
+  answerMetricEligible: boolean;
+}
+
+export interface FirstOutputTrackerOptions {
+  maxBufferedEvents?: number;
+}
+
+const COMPRESSION_DIAGNOSTIC_PREFIX = 'IMPORTANT: This conversation ';
+const COMPRESSION_DIAGNOSTIC_MARKER =
+  'A compressed context will be sent for future messages';
+const NON_MODEL_OUTPUT_SOURCES = new Set([
+  'background_notification',
+  'background_notification_response',
+  'slash_command',
+  'todo_stop_guard',
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function numberOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function parseTimestamp(value: unknown): number | null {
+  const number = numberOrNull(value);
+  if (number !== null) return number;
+  if (typeof value !== 'string') return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function eventServerTimestampMs(event: BenchmarkDaemonEvent): number | null {
+  return parseTimestamp(event._meta?.['serverTimestamp']);
+}
+
+function isReplayMeta(meta: Record<string, unknown> | undefined): boolean {
+  if (!meta) return false;
+  return (
+    isRecord(meta['qwenTranscript']) ||
+    typeof meta['qwen.session.recordId'] === 'string'
+  );
+}
+
+function isDiagnosticUpdate(
+  update: Record<string, unknown>,
+  text: string | null,
+): boolean {
+  const meta = isRecord(update['_meta']) ? update['_meta'] : undefined;
+  if (
+    meta?.['qwenDiscreteMessage'] === true ||
+    NON_MODEL_OUTPUT_SOURCES.has(String(meta?.['source']))
+  ) {
+    return true;
+  }
+  return (
+    text !== null &&
+    text.startsWith(COMPRESSION_DIAGNOSTIC_PREFIX) &&
+    text.includes(COMPRESSION_DIAGNOSTIC_MARKER)
+  );
+}
+
+function classifyTerminal(
+  event: BenchmarkDaemonEvent,
+  promptId: string,
+): ClassifiedPromptEvent {
+  if (!isRecord(event.data)) {
+    return { type: 'ignore', reason: 'unrelated_event' };
+  }
+  if (event.promptId !== promptId || event.data['promptId'] !== promptId) {
+    return { type: 'ignore', reason: 'wrong_prompt_id' };
+  }
+  if (event.type === 'turn_complete') {
+    return {
+      type: 'terminal',
+      kind: 'complete',
+      stopReason: stringOrNull(event.data['stopReason']),
+      code: null,
+      message: null,
+    };
+  }
+  return {
+    type: 'terminal',
+    kind: 'error',
+    stopReason: null,
+    code: stringOrNull(event.data['code']),
+    message: stringOrNull(event.data['message']),
+  };
+}
+
+export function classifyFirstOutputEvent(
+  event: BenchmarkDaemonEvent,
+  promptId: string,
+): ClassifiedPromptEvent {
+  if (event.type === 'turn_complete' || event.type === 'turn_error') {
+    return classifyTerminal(event, promptId);
+  }
+  if (event.type !== 'session_update') {
+    return { type: 'ignore', reason: 'unrelated_event' };
+  }
+  if (event.promptId !== promptId) {
+    return { type: 'ignore', reason: 'wrong_prompt_id' };
+  }
+  if (!isRecord(event.data) || !isRecord(event.data['update'])) {
+    return { type: 'ignore', reason: 'malformed_update' };
+  }
+
+  const update = event.data['update'];
+  const meta = isRecord(update['_meta']) ? update['_meta'] : undefined;
+  if (isReplayMeta(event._meta) || isReplayMeta(meta)) {
+    return { type: 'ignore', reason: 'replay' };
+  }
+
+  const updateType = update['sessionUpdate'];
+  if (
+    updateType === 'agent_message_chunk' ||
+    updateType === 'agent_thought_chunk'
+  ) {
+    const content = isRecord(update['content']) ? update['content'] : undefined;
+    const text =
+      content?.['type'] === 'text' ? stringOrNull(content['text']) : null;
+    if (isDiagnosticUpdate(update, text)) {
+      return { type: 'ignore', reason: 'diagnostic' };
+    }
+    if (text === null || text.length === 0) {
+      return { type: 'ignore', reason: 'empty_content' };
+    }
+    return {
+      type: 'output',
+      kind:
+        updateType === 'agent_message_chunk' ? 'answer_text' : 'thought_text',
+      text,
+      toolCallId: null,
+      serverTimestampMs: eventServerTimestampMs(event),
+    };
+  }
+
+  if (updateType === 'tool_call') {
+    if (isDiagnosticUpdate(update, null)) {
+      return { type: 'ignore', reason: 'diagnostic' };
+    }
+    const toolCallId = stringOrNull(update['toolCallId']);
+    const title = stringOrNull(update['title']);
+    if (!toolCallId || title === null) {
+      return { type: 'ignore', reason: 'malformed_update' };
+    }
+    return {
+      type: 'output',
+      kind: 'tool_call',
+      text: null,
+      toolCallId,
+      serverTimestampMs: eventServerTimestampMs(event),
+    };
+  }
+
+  return { type: 'ignore', reason: 'non_output_update' };
+}
+
+export class FirstOutputTracker {
+  readonly #maxBufferedEvents: number;
+  readonly #buffer: TimedDaemonEvent[] = [];
+  #promptId: string | null = null;
+  #bufferedBeforeAcceptanceCount = 0;
+  #matchingEventCount = 0;
+  #matchingTerminalCount = 0;
+  #firstOutput: FirstOutputObservation | null = null;
+  #firstAnswer: FirstOutputObservation | null = null;
+  #answerChunks: string[] = [];
+  #terminal: FirstOutputTerminal | null = null;
+  #failureCode: TrackerFailureCode | null = null;
+  #failureMessage: string | null = null;
+
+  constructor(options: FirstOutputTrackerOptions = {}) {
+    const maxBufferedEvents =
+      options.maxBufferedEvents ?? DEFAULT_FIRST_OUTPUT_EVENT_BUFFER_LIMIT;
+    if (!Number.isInteger(maxBufferedEvents) || maxBufferedEvents < 1) {
+      throw new TypeError('maxBufferedEvents must be a positive integer');
+    }
+    this.#maxBufferedEvents = maxBufferedEvents;
+  }
+
+  push(event: BenchmarkDaemonEvent, receivedAtMs: number): void {
+    if (!Number.isFinite(receivedAtMs)) {
+      throw new TypeError('receivedAtMs must be finite');
+    }
+    if (this.#promptId === null) {
+      if (this.#buffer.length >= this.#maxBufferedEvents) {
+        this.#setFailure(
+          'event_buffer_overflow',
+          `More than ${this.#maxBufferedEvents} events arrived before prompt acceptance`,
+        );
+        return;
+      }
+      this.#buffer.push({ event, receivedAtMs });
+      return;
+    }
+    this.#process(event, receivedAtMs);
+  }
+
+  acceptPrompt(promptId: string): void {
+    if (promptId.length === 0) {
+      throw new TypeError('promptId must not be empty');
+    }
+    if (this.#promptId !== null) {
+      if (this.#promptId !== promptId) {
+        throw new Error(
+          `Tracker already accepted prompt ${this.#promptId}, not ${promptId}`,
+        );
+      }
+      return;
+    }
+    this.#promptId = promptId;
+    this.#bufferedBeforeAcceptanceCount = this.#buffer.length;
+    const buffered = this.#buffer.splice(0);
+    for (const { event, receivedAtMs } of buffered) {
+      this.#process(event, receivedAtMs);
+    }
+  }
+
+  snapshot(): FirstOutputTrackerSnapshot {
+    const runEligible =
+      this.#failureCode === null && this.#terminal?.kind === 'complete';
+    return {
+      promptId: this.#promptId,
+      bufferedEventCount: this.#buffer.length,
+      bufferedBeforeAcceptanceCount: this.#bufferedBeforeAcceptanceCount,
+      matchingEventCount: this.#matchingEventCount,
+      matchingTerminalCount: this.#matchingTerminalCount,
+      firstOutput: this.#firstOutput ? { ...this.#firstOutput } : null,
+      firstAnswer: this.#firstAnswer ? { ...this.#firstAnswer } : null,
+      finalAnswerText:
+        this.#answerChunks.length > 0 ? this.#answerChunks.join('') : null,
+      terminal: this.#terminal ? { ...this.#terminal } : null,
+      failureCode: this.#failureCode,
+      failureMessage: this.#failureMessage,
+      runEligible,
+      answerMetricEligible: runEligible && this.#firstAnswer !== null,
+    };
+  }
+
+  #process(event: BenchmarkDaemonEvent, receivedAtMs: number): void {
+    if (this.#terminal !== null) return;
+    const classified = classifyFirstOutputEvent(event, this.#promptId!);
+    if (classified.type === 'ignore') return;
+    this.#matchingEventCount += 1;
+
+    if (classified.type === 'output') {
+      const observation: FirstOutputObservation = {
+        kind: classified.kind,
+        receivedAtMs,
+        eventId: numberOrNull(event.id),
+        text: classified.text,
+        toolCallId: classified.toolCallId,
+        serverTimestampMs: classified.serverTimestampMs,
+      };
+      this.#firstOutput ??= observation;
+      if (classified.kind === 'answer_text') {
+        this.#firstAnswer ??= observation;
+        this.#answerChunks.push(classified.text!);
+      }
+      return;
+    }
+
+    this.#matchingTerminalCount += 1;
+    this.#terminal = {
+      kind: classified.kind,
+      receivedAtMs,
+      eventId: numberOrNull(event.id),
+      stopReason: classified.stopReason,
+      code: classified.code,
+      message: classified.message,
+    };
+    if (classified.kind === 'error') {
+      this.#setFailure(
+        'turn_error',
+        classified.message ?? classified.code ?? 'Prompt ended with turn_error',
+      );
+    } else if (this.#firstOutput === null) {
+      this.#setFailure(
+        'terminal_before_first_output',
+        'Prompt completed before producing a qualifying output event',
+      );
+    }
+  }
+
+  #setFailure(code: TrackerFailureCode, message: string): void {
+    if (this.#failureCode !== null) return;
+    this.#failureCode = code;
+    this.#failureMessage = message;
+  }
+}
+
+export interface PercentileSummary {
+  count: number;
+  p50: number;
+  p90: number;
+  p99: number;
+  mean: number;
+  min: number;
+  max: number;
+}
+
+export interface NullablePercentileSummary {
+  totalCount: number;
+  eligibleCount: number;
+  missingCount: number;
+  distribution: PercentileSummary | null;
+}
+
+function assertFiniteValues(values: readonly number[]): void {
+  if (values.some((value) => !Number.isFinite(value))) {
+    throw new TypeError('Percentile inputs must all be finite');
+  }
+}
+
+function nearestRank(sorted: readonly number[], percentile: number): number {
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil(percentile * sorted.length) - 1),
+  );
+  return sorted[index];
+}
+
+export function percentiles(
+  values: readonly number[],
+): PercentileSummary | null {
+  if (values.length === 0) return null;
+  assertFiniteValues(values);
+  const sorted = [...values].sort((left, right) => left - right);
+  const sum = sorted.reduce((total, value) => total + value, 0);
+  return {
+    count: sorted.length,
+    p50: nearestRank(sorted, 0.5),
+    p90: nearestRank(sorted, 0.9),
+    p99: nearestRank(sorted, 0.99),
+    mean: sum / sorted.length,
+    min: sorted[0],
+    max: sorted[sorted.length - 1],
+  };
+}
+
+export function nullablePercentiles(
+  values: readonly (number | null)[],
+): NullablePercentileSummary {
+  const eligible = values.filter((value): value is number => value !== null);
+  return {
+    totalCount: values.length,
+    eligibleCount: eligible.length,
+    missingCount: values.length - eligible.length,
+    distribution: percentiles(eligible),
+  };
+}
+
+export interface PairedMetricSample {
+  order: PairOrder;
+  valid: boolean;
+  controlMs: number | null;
+  candidateMs: number | null;
+}
+
+export interface BootstrapMedianConfidenceInterval {
+  lowMs: number;
+  highMs: number;
+  iterations: number;
+  seed: number;
+}
+
+export interface OrderSensitivitySummary {
+  abEligiblePairs: number;
+  baEligiblePairs: number;
+  abMedianDeltaMs: number | null;
+  baMedianDeltaMs: number | null;
+  thresholdMs: number;
+  orderSensitive: boolean;
+}
+
+export interface PairedCandidateControlStats {
+  totalPairs: number;
+  validPairs: number;
+  invalidPairs: number;
+  eligiblePairs: number;
+  missingMetricPairs: number;
+  control: PercentileSummary | null;
+  candidate: PercentileSummary | null;
+  deltaCandidateMinusControl: PercentileSummary | null;
+  medianDeltaMs: number | null;
+  meanDeltaMs: number | null;
+  candidateWins: number;
+  controlWins: number;
+  ties: number;
+  bootstrapMedianCi95: BootstrapMedianConfidenceInterval | null;
+  orderSensitivity: OrderSensitivitySummary;
+  decision: BenchmarkDecision;
+  decisionReason: string;
+}
+
+export interface PairedStatsOptions {
+  seed: number;
+  bootstrapIterations?: number;
+  materialThresholdMs?: number;
+  orderSensitivityThresholdMs?: number;
+}
+
+function median(values: readonly number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1] + sorted[middle]) / 2
+    : sorted[middle];
+}
+
+function createSeededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  if (state === 0) state = 0x6d2b79f5;
+  return () => {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    return (state >>> 0) / 0x1_0000_0000;
+  };
+}
+
+function bootstrapMedianCi95(
+  values: readonly number[],
+  iterations: number,
+  seed: number,
+): BootstrapMedianConfidenceInterval | null {
+  if (values.length === 0) return null;
+  const random = createSeededRandom(seed);
+  const medians: number[] = [];
+  for (let iteration = 0; iteration < iterations; iteration += 1) {
+    const sample: number[] = [];
+    for (let index = 0; index < values.length; index += 1) {
+      sample.push(values[Math.floor(random() * values.length)]);
+    }
+    medians.push(median(sample)!);
+  }
+  medians.sort((left, right) => left - right);
+  return {
+    lowMs: nearestRank(medians, 0.025),
+    highMs: nearestRank(medians, 0.975),
+    iterations,
+    seed: seed >>> 0,
+  };
+}
+
+export function pairedCandidateControlStats(
+  samples: readonly PairedMetricSample[],
+  options: PairedStatsOptions,
+): PairedCandidateControlStats {
+  const iterations =
+    options.bootstrapIterations ?? DEFAULT_BOOTSTRAP_ITERATIONS;
+  const materialThresholdMs =
+    options.materialThresholdMs ?? DEFAULT_MATERIAL_THRESHOLD_MS;
+  const orderThresholdMs =
+    options.orderSensitivityThresholdMs ??
+    DEFAULT_ORDER_SENSITIVITY_THRESHOLD_MS;
+  if (!Number.isInteger(iterations) || iterations < 1) {
+    throw new TypeError('bootstrapIterations must be a positive integer');
+  }
+  if (!Number.isFinite(options.seed)) {
+    throw new TypeError('seed must be finite');
+  }
+  if (
+    !Number.isFinite(materialThresholdMs) ||
+    materialThresholdMs < 0 ||
+    !Number.isFinite(orderThresholdMs) ||
+    orderThresholdMs < 0
+  ) {
+    throw new TypeError('thresholds must be finite and non-negative');
+  }
+
+  const valid = samples.filter((sample) => sample.valid);
+  const eligible = valid.filter(
+    (
+      sample,
+    ): sample is PairedMetricSample & {
+      controlMs: number;
+      candidateMs: number;
+    } => sample.controlMs !== null && sample.candidateMs !== null,
+  );
+  for (const sample of eligible) {
+    assertFiniteValues([sample.controlMs, sample.candidateMs]);
+  }
+
+  const control = eligible.map((sample) => sample.controlMs);
+  const candidate = eligible.map((sample) => sample.candidateMs);
+  const deltas = eligible.map(
+    (sample) => sample.candidateMs - sample.controlMs,
+  );
+  const abDeltas = eligible
+    .filter((sample) => sample.order === 'AB')
+    .map((sample) => sample.candidateMs - sample.controlMs);
+  const baDeltas = eligible
+    .filter((sample) => sample.order === 'BA')
+    .map((sample) => sample.candidateMs - sample.controlMs);
+  const abMedian = median(abDeltas);
+  const baMedian = median(baDeltas);
+  const orderSensitive =
+    abMedian !== null &&
+    baMedian !== null &&
+    abMedian * baMedian < 0 &&
+    Math.max(Math.abs(abMedian), Math.abs(baMedian)) >= orderThresholdMs;
+  const medianDeltaMs = median(deltas);
+  const ci = bootstrapMedianCi95(deltas, iterations, options.seed);
+
+  let decision: BenchmarkDecision = 'inconclusive';
+  let decisionReason = 'The confidence interval crosses zero or is immaterial';
+  if (valid.length !== samples.length) {
+    decision = 'invalid';
+    decisionReason = 'At least one pair is invalid';
+  } else if (eligible.length === 0) {
+    decision = 'invalid';
+    decisionReason = 'No valid pair has both candidate and control values';
+  } else if (orderSensitive) {
+    decisionReason = 'AB and BA medians indicate material order sensitivity';
+  } else if (
+    ci !== null &&
+    medianDeltaMs !== null &&
+    ci.highMs < 0 &&
+    medianDeltaMs <= -materialThresholdMs
+  ) {
+    decision = 'improved';
+    decisionReason =
+      'The candidate is materially faster and the 95% median CI is below zero';
+  } else if (
+    ci !== null &&
+    medianDeltaMs !== null &&
+    ci.lowMs > 0 &&
+    medianDeltaMs >= materialThresholdMs
+  ) {
+    decision = 'regressed';
+    decisionReason =
+      'The candidate is materially slower and the 95% median CI is above zero';
+  }
+
+  return {
+    totalPairs: samples.length,
+    validPairs: valid.length,
+    invalidPairs: samples.length - valid.length,
+    eligiblePairs: eligible.length,
+    missingMetricPairs: valid.length - eligible.length,
+    control: percentiles(control),
+    candidate: percentiles(candidate),
+    deltaCandidateMinusControl: percentiles(deltas),
+    medianDeltaMs,
+    meanDeltaMs:
+      deltas.length === 0
+        ? null
+        : deltas.reduce((sum, value) => sum + value, 0) / deltas.length,
+    candidateWins: deltas.filter((delta) => delta < 0).length,
+    controlWins: deltas.filter((delta) => delta > 0).length,
+    ties: deltas.filter((delta) => delta === 0).length,
+    bootstrapMedianCi95: ci,
+    orderSensitivity: {
+      abEligiblePairs: abDeltas.length,
+      baEligiblePairs: baDeltas.length,
+      abMedianDeltaMs: abMedian,
+      baMedianDeltaMs: baMedian,
+      thresholdMs: orderThresholdMs,
+      orderSensitive,
+    },
+    decision,
+    decisionReason,
+  };
+}
+
+export const FIRST_OUTPUT_FAILURE_CODES = [
+  'invalid_configuration',
+  'daemon_boot_timeout',
+  'daemon_exited_before_listen',
+  'session_create_failed',
+  'sse_connect_timeout',
+  'sse_stream_ended',
+  'prompt_accept_timeout',
+  'prompt_rejected',
+  'legacy_prompt_response',
+  'event_buffer_overflow',
+  'provider_request_count_mismatch',
+  'unexpected_output_kind',
+  'first_output_timeout',
+  'terminal_before_first_output',
+  'turn_error',
+  'terminal_timeout',
+  'wrong_final_text',
+  'cleanup_timeout',
+  'residual_process',
+  'harness_error',
+] as const;
+
+export type FirstOutputFailureCode =
+  (typeof FIRST_OUTPUT_FAILURE_CODES)[number];
+
+export interface FirstOutputFailure {
+  code: FirstOutputFailureCode;
+  message: string;
+}
+
+export type PromptAcceptanceValidation =
+  | {
+      kind: 'accepted';
+      promptId: string;
+      lastEventId: number;
+    }
+  | {
+      kind: 'failure';
+      failure: FirstOutputFailure;
+    };
+
+export function validatePromptAcceptance(
+  value: unknown,
+): PromptAcceptanceValidation {
+  if (!isRecord(value)) {
+    return {
+      kind: 'failure',
+      failure: {
+        code: 'prompt_rejected',
+        message: 'Prompt acceptance returned a non-object response.',
+      },
+    };
+  }
+
+  const hasAcceptanceField =
+    'promptId' in value || 'lastEventId' in value || 'eventEpoch' in value;
+  if (!hasAcceptanceField && typeof value['stopReason'] === 'string') {
+    return {
+      kind: 'failure',
+      failure: {
+        code: 'legacy_prompt_response',
+        message:
+          'Benchmark requires the daemon non-blocking prompt protocol (202 with promptId).',
+      },
+    };
+  }
+
+  const promptId = value['promptId'];
+  const lastEventId = value['lastEventId'];
+  if (
+    typeof promptId !== 'string' ||
+    promptId.length === 0 ||
+    !Number.isInteger(lastEventId) ||
+    (lastEventId as number) < 0
+  ) {
+    return {
+      kind: 'failure',
+      failure: {
+        code: 'prompt_rejected',
+        message:
+          'Prompt acceptance must contain a non-empty promptId and a non-negative integer lastEventId.',
+      },
+    };
+  }
+
+  return { kind: 'accepted', promptId, lastEventId: lastEventId as number };
+}
+
+export function validateExpectedFinalText(
+  actual: string | null,
+  expected: string,
+): FirstOutputFailure | null {
+  return actual === expected
+    ? null
+    : {
+        code: 'wrong_final_text',
+        message: `Unexpected final answer: ${JSON.stringify(actual)}.`,
+      };
+}
+
+export interface SingleBundlePrototypeGateInput {
+  complete: boolean;
+  coldPromptToProviderRequestP50Ms: number | null;
+  warmPromptToProviderRequestP50Ms: number | null;
+  coldPromptToFirstModelOutputP50Ms: number | null;
+  absoluteThresholdMs?: number;
+  relativeThresholdRatio?: number;
+}
+
+export interface SingleBundlePrototypeGateResult {
+  passed: boolean;
+  providerDeltaMs: number | null;
+  absoluteThresholdMs: number;
+  relativeThresholdRatio: number;
+}
+
+export function evaluateSingleBundlePrototypeGate(
+  input: SingleBundlePrototypeGateInput,
+): SingleBundlePrototypeGateResult {
+  const absoluteThresholdMs = input.absoluteThresholdMs ?? 25;
+  const relativeThresholdRatio = input.relativeThresholdRatio ?? 0.1;
+  if (
+    !Number.isFinite(absoluteThresholdMs) ||
+    absoluteThresholdMs < 0 ||
+    !Number.isFinite(relativeThresholdRatio) ||
+    relativeThresholdRatio < 0
+  ) {
+    throw new TypeError('gate thresholds must be finite and non-negative');
+  }
+  const providerDeltaMs =
+    input.coldPromptToProviderRequestP50Ms === null ||
+    input.warmPromptToProviderRequestP50Ms === null
+      ? null
+      : input.coldPromptToProviderRequestP50Ms -
+        input.warmPromptToProviderRequestP50Ms;
+  const passed =
+    input.complete &&
+    providerDeltaMs !== null &&
+    input.coldPromptToFirstModelOutputP50Ms !== null &&
+    (providerDeltaMs >= absoluteThresholdMs ||
+      providerDeltaMs >=
+        relativeThresholdRatio * input.coldPromptToFirstModelOutputP50Ms);
+  return {
+    passed,
+    providerDeltaMs,
+    absoluteThresholdMs,
+    relativeThresholdRatio,
+  };
+}
+
+export interface FirstOutputSessionTimestamps {
+  sessionCreateStart: number;
+  sessionReady: number | null;
+  sseReady: number | null;
+  promptStart: number | null;
+  promptAccepted: number | null;
+  providerRequestArrival: number | null;
+  providerReady: number | null;
+  firstModelOutput: number | null;
+  firstAnswerText: number | null;
+  terminal: number | null;
+}
+
+export interface FirstOutputSessionTimings {
+  processToSessionReadyMs: number | null;
+  promptToProviderRequestArrivalMs: number | null;
+  promptToFirstModelOutputMs: number | null;
+  promptToFirstAnswerTextMs: number | null;
+  providerReadyToFirstModelOutputMs: number | null;
+  processToFirstModelOutputMs: number | null;
+  promptToTerminalMs: number | null;
+}
+
+export interface FirstOutputSessionRunResult {
+  ordinal: number;
+  sessionId: string | null;
+  promptId: string | null;
+  timestamps: FirstOutputSessionTimestamps;
+  timings: FirstOutputSessionTimings;
+  firstOutput: FirstOutputObservation | null;
+  firstAnswer: FirstOutputObservation | null;
+  finalAnswerText: string | null;
+  terminal: FirstOutputTerminal | null;
+  providerRequestCount: number;
+  runEligible: boolean;
+  answerMetricEligible: boolean;
+  failure: FirstOutputFailure | null;
+  cleanupFailure: FirstOutputFailure | null;
+  diagnostics?: Record<string, unknown>;
+}
+
+export interface FirstOutputCleanupResult {
+  completed: boolean;
+  daemonExited: boolean;
+  residualProcessCount: number;
+  failure: FirstOutputFailure | null;
+}
+
+export interface FirstOutputProcessRunResult {
+  variant: BenchmarkVariant;
+  sampleIndex: number;
+  pairIndex: number | null;
+  orderPosition: 1 | 2 | null;
+  measured: boolean;
+  pid: number | null;
+  timestamps: {
+    processStart: number | null;
+    daemonReady: number | null;
+  };
+  processToListenMs: number | null;
+  sessions: FirstOutputSessionRunResult[];
+  failure: FirstOutputFailure | null;
+  cleanup: FirstOutputCleanupResult;
+  stdout: string;
+  stderr: string;
+  diagnostics?: Record<string, unknown>;
+}
+
+export interface FirstOutputPairResult {
+  pairIndex: number;
+  order: PairOrder;
+  control: FirstOutputProcessRunResult;
+  candidate: FirstOutputProcessRunResult;
+  valid: boolean;
+  invalidReason: string | null;
+}
+
+export interface FirstOutputVariantDescriptor {
+  cliPath: string;
+  realpath: string;
+  sha256: string;
+  gitCommit: string | null;
+  compileCache: {
+    policy: 'fixed-private-per-variant-warmed';
+    directory: string;
+  };
+}
+
+export type FirstOutputMetricName =
+  | 'processToListenMs'
+  | 'processToSessionReadyMs'
+  | 'promptToProviderRequestArrivalMs'
+  | 'promptToFirstModelOutputMs'
+  | 'promptToFirstAnswerTextMs'
+  | 'providerReadyToFirstModelOutputMs'
+  | 'processToFirstModelOutputMs'
+  | 'promptToTerminalMs';
+
+export interface FirstOutputSingleMetricSummary {
+  all: NullablePercentileSummary | null;
+  bySession: Record<string, NullablePercentileSummary>;
+}
+
+export interface FirstOutputPairedMetricSummary {
+  all: PairedCandidateControlStats | null;
+  bySession: Record<string, PairedCandidateControlStats>;
+}
+
+interface FirstOutputBenchmarkArtifactBaseV1 {
+  version: typeof FIRST_OUTPUT_BENCHMARK_VERSION;
+  benchmark: 'daemon-first-output';
+  capturedAt: string;
+  harnessGitCommit: string | null;
+  platform: {
+    os: string;
+    arch: string;
+    nodeVersion: string;
+    cpuModel: string;
+    logicalCpuCount: number;
+    availableCpuCount: number;
+    totalMemoryBytes: number;
+    loadAverage: [number, number, number];
+  };
+}
+
+interface FirstOutputBenchmarkCommonConfig {
+  seed: number;
+  providerDelayMs: number;
+  providerConnection: 'close-per-response';
+  postSessionDwellMs: number;
+  prompt: string;
+  expectedAnswer: string;
+  maxBufferedEvents: number;
+  providerRequestsPerSession: number;
+  timeoutsMs: Record<string, number>;
+}
+
+export interface FirstOutputSingleBenchmarkArtifactV1
+  extends FirstOutputBenchmarkArtifactBaseV1 {
+  mode: 'single';
+  config: FirstOutputBenchmarkCommonConfig & {
+    warmupRuns: number;
+    measuredRuns: number;
+    variant: FirstOutputVariantDescriptor;
+  };
+  warmupRuns: FirstOutputProcessRunResult[];
+  runs: FirstOutputProcessRunResult[];
+  summary: {
+    expectedRuns: number;
+    successfulRuns: number;
+    failedRuns: number;
+    failuresByCode: Partial<Record<FirstOutputFailureCode, number>>;
+    metrics: Partial<
+      Record<FirstOutputMetricName, FirstOutputSingleMetricSummary>
+    >;
+    decision: {
+      outcome: 'prototype_allowed' | 'stop' | 'invalid';
+      reasons: string[];
+      gate: {
+        coldPromptToProviderRequestP50Ms: number | null;
+        warmPromptToProviderRequestP50Ms: number | null;
+        providerDeltaMs: number | null;
+        coldPromptToFirstModelOutputP50Ms: number | null;
+        absoluteThresholdMs: number;
+        relativeThresholdRatio: number;
+        passed: boolean;
+      };
+    };
+  };
+}
+
+export interface FirstOutputPairedBenchmarkArtifactV1
+  extends FirstOutputBenchmarkArtifactBaseV1 {
+  mode: 'paired';
+  config: FirstOutputBenchmarkCommonConfig & {
+    warmupPairs: number;
+    measuredPairs: number;
+    bootstrapIterations: number;
+    materialThresholdMs: number;
+    orderSensitivityThresholdMs: number;
+    variants: Record<
+      Exclude<BenchmarkVariant, 'single'>,
+      FirstOutputVariantDescriptor
+    >;
+  };
+  warmups: FirstOutputPairResult[];
+  pairs: FirstOutputPairResult[];
+  summary: {
+    expectedPairs: number;
+    validPairs: number;
+    invalidPairs: number;
+    failuresByCode: Partial<Record<FirstOutputFailureCode, number>>;
+    metrics: Partial<
+      Record<FirstOutputMetricName, FirstOutputPairedMetricSummary>
+    >;
+    decision: {
+      outcome: BenchmarkDecision;
+      scope: 'primary_metric_only';
+      publicationGateEvaluated: false;
+      primaryMetric: FirstOutputMetricName;
+      primarySession: 1;
+      reasons: string[];
+    };
+  };
+}
+
+export interface FirstOutputFailedBenchmarkArtifactV1
+  extends FirstOutputBenchmarkArtifactBaseV1 {
+  mode: 'failed';
+  config: {
+    requestedMode: 'single' | 'paired' | 'unknown';
+  };
+  failure: FirstOutputFailure;
+  summary: {
+    failuresByCode: Partial<Record<FirstOutputFailureCode, number>>;
+    decision: {
+      outcome: 'invalid';
+      reasons: string[];
+    };
+  };
+}
+
+export type FirstOutputBenchmarkArtifactV1 =
+  | FirstOutputSingleBenchmarkArtifactV1
+  | FirstOutputPairedBenchmarkArtifactV1
+  | FirstOutputFailedBenchmarkArtifactV1;
+
+function formatMilliseconds(value: number | null): string {
+  return value === null ? 'n/a' : value.toFixed(1);
+}
+
+function formatConfidenceInterval(
+  interval: BootstrapMedianConfidenceInterval | null,
+): string {
+  return interval === null
+    ? 'n/a'
+    : `[${interval.lowMs.toFixed(1)}, ${interval.highMs.toFixed(1)}]`;
+}
+
+function formatDistribution(distribution: PercentileSummary | null): string {
+  return distribution === null
+    ? 'n/a'
+    : [distribution.p50, distribution.p90, distribution.p99, distribution.mean]
+        .map((value) => value.toFixed(1))
+        .join('/');
+}
+
+export function renderFirstOutputBenchmarkMarkdown(
+  artifact: FirstOutputBenchmarkArtifactV1,
+): string {
+  const decisionLabel =
+    artifact.mode === 'paired' ? 'Primary metric decision' : 'Decision';
+  const lines = [
+    '# Daemon first-output benchmark',
+    '',
+    `Captured: ${artifact.capturedAt}`,
+    '',
+    `${decisionLabel}: **${artifact.summary.decision.outcome}**`,
+    '',
+    ...artifact.summary.decision.reasons.map((reason) => `- ${reason}`),
+    '',
+  ];
+
+  if (artifact.mode === 'failed') {
+    lines.push(
+      `Failure: ${artifact.failure.code}`,
+      '',
+      artifact.failure.message,
+    );
+  } else if (artifact.mode === 'single') {
+    lines.push(
+      `Runs: ${artifact.summary.successfulRuns}/${artifact.summary.expectedRuns} successful`,
+      '',
+      '| Metric | Scope | p50 (ms) | p90 (ms) | p99 (ms) | Mean (ms) | Eligible samples |',
+      '| --- | --- | ---: | ---: | ---: | ---: | ---: |',
+    );
+    for (const [metric, summary] of Object.entries(artifact.summary.metrics)) {
+      if (!summary) continue;
+      const scopes = [
+        ...(summary.all ? [['all', summary.all] as const] : []),
+        ...Object.entries(summary.bySession),
+      ];
+      for (const [scope, stats] of scopes) {
+        lines.push(
+          `| ${metric} | ${scope} | ${formatMilliseconds(stats.distribution?.p50 ?? null)} | ${formatMilliseconds(stats.distribution?.p90 ?? null)} | ${formatMilliseconds(stats.distribution?.p99 ?? null)} | ${formatMilliseconds(stats.distribution?.mean ?? null)} | ${stats.eligibleCount} |`,
+        );
+      }
+    }
+  } else {
+    lines.push(
+      `Pairs: ${artifact.summary.validPairs}/${artifact.summary.expectedPairs} valid`,
+      '',
+      '| Metric | Scope | Control p50/p90/p99/mean (ms) | Candidate p50/p90/p99/mean (ms) | Δ p50/p90/p99/mean (ms) | Median Δ (ms) | 95% bootstrap CI (ms) | Wins candidate/control/ties | AB/BA median Δ (ms) | Eligible pairs | Decision |',
+      '| --- | --- | --- | --- | --- | ---: | --- | --- | --- | ---: | --- |',
+    );
+    for (const [metric, summary] of Object.entries(artifact.summary.metrics)) {
+      if (!summary) continue;
+      const scopes = [
+        ...(summary.all ? [['all', summary.all] as const] : []),
+        ...Object.entries(summary.bySession),
+      ];
+      for (const [scope, stats] of scopes) {
+        lines.push(
+          `| ${metric} | ${scope} | ${formatDistribution(stats.control)} | ${formatDistribution(stats.candidate)} | ${formatDistribution(stats.deltaCandidateMinusControl)} | ${formatMilliseconds(stats.medianDeltaMs)} | ${formatConfidenceInterval(stats.bootstrapMedianCi95)} | ${stats.candidateWins}/${stats.controlWins}/${stats.ties} | ${formatMilliseconds(stats.orderSensitivity.abMedianDeltaMs)}/${formatMilliseconds(stats.orderSensitivity.baMedianDeltaMs)} | ${stats.eligiblePairs} | ${stats.decision} |`,
+        );
+      }
+    }
+  }
+
+  const failures = Object.entries(artifact.summary.failuresByCode);
+  if (failures.length > 0) {
+    lines.push('', '## Failures', '');
+    for (const [code, count] of failures) {
+      lines.push(`- ${code}: ${count}`);
+    }
+  }
+  return `${lines.join('\n')}\n`;
+}

--- a/integration-tests/cli/qwen-daemon-first-output-benchmark.test.ts
+++ b/integration-tests/cli/qwen-daemon-first-output-benchmark.test.ts
@@ -1,0 +1,2324 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Opt-in daemon first-output benchmark.
+ *
+ * The single-bundle mode records a cold/warm two-session baseline. The
+ * comparison mode runs paired control/candidate processes in balanced AB/BA
+ * order. Every process, workspace, home, qwen home, and listener is isolated.
+ *
+ * Enable with QWEN_FIRST_OUTPUT_BENCHMARK=1. See readBenchmarkConfig() for the
+ * intentionally strict bundle-path contract.
+ */
+
+import { execFileSync, spawn, type ChildProcess } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { fileURLToPath } from 'node:url';
+import { afterAll, describe, it } from 'vitest';
+
+import {
+  DaemonClient,
+  type DaemonEvent,
+  type DaemonSession,
+} from '@qwen-code/sdk';
+import {
+  DEFAULT_BOOTSTRAP_ITERATIONS,
+  DEFAULT_FIRST_OUTPUT_EVENT_BUFFER_LIMIT,
+  DEFAULT_MATERIAL_THRESHOLD_MS,
+  DEFAULT_ORDER_SENSITIVITY_THRESHOLD_MS,
+  FirstOutputTracker,
+  evaluateSingleBundlePrototypeGate,
+  measuredPairCountForDwell,
+  nullablePercentiles,
+  pairedCandidateControlStats,
+  parseBenchmarkPostSessionDwell,
+  renderFirstOutputBenchmarkMarkdown,
+  validateExpectedFinalText,
+  validatePromptAcceptance,
+  type FirstOutputBenchmarkArtifactV1,
+  type FirstOutputFailure,
+  type FirstOutputFailureCode,
+  type FirstOutputMetricName,
+  type FirstOutputPairResult,
+  type FirstOutputPairedMetricSummary,
+  type FirstOutputProcessRunResult,
+  type FirstOutputSessionRunResult,
+  type FirstOutputSingleMetricSummary,
+} from './_first-output-benchmark.js';
+import {
+  countDescendants,
+  LISTENING_LINE_RE,
+  sleep,
+} from './_daemon-harness.js';
+import { writeSnapshotArtifacts } from './_daemon-perf-report.js';
+import {
+  startFakeOpenAIServer,
+  type FakeOpenAIServer,
+} from '../fake-openai-server.js';
+
+const ENABLED = process.env['QWEN_FIRST_OUTPUT_BENCHMARK'] === '1';
+const SANDBOX_DISABLED = process.env['QWEN_SANDBOX'] === 'false';
+const SKIP = !ENABLED || process.platform === 'win32';
+
+const SINGLE_WARMUPS = 2;
+const SINGLE_MEASURED = 50;
+const COMPARE_WARMUP_PAIRS = 2;
+const SINGLE_SESSIONS_PER_PROCESS = 2;
+const COMPARE_SESSIONS_PER_PROCESS = 1;
+const PROVIDER_DELAY_MS = 50;
+const BOOT_TIMEOUT_MS = 35_000;
+const TURN_TIMEOUT_MS = 30_000;
+const SDK_FETCH_TIMEOUT_MS = TURN_TIMEOUT_MS + 5_000;
+const PROCESS_EXIT_TIMEOUT_MS = 5_000;
+const DESCENDANT_EXIT_TIMEOUT_MS = 5_000;
+const EMERGENCY_CLEANUP_TIMEOUT_MS = 60_000;
+const MAX_POST_SESSION_DWELL_MS = 500;
+const SESSION_TIMEOUT_BUDGET_MS =
+  SDK_FETCH_TIMEOUT_MS * 2 +
+  TURN_TIMEOUT_MS * 3 +
+  PROCESS_EXIT_TIMEOUT_MS +
+  MAX_POST_SESSION_DWELL_MS;
+const PROCESS_TIMEOUT_BUDGET_MS = (sessionCount: 1 | 2) =>
+  BOOT_TIMEOUT_MS +
+  sessionCount * SESSION_TIMEOUT_BUDGET_MS +
+  PROCESS_EXIT_TIMEOUT_MS * 3 +
+  DESCENDANT_EXIT_TIMEOUT_MS * 2;
+const SINGLE_RUN_TIMEOUT_BUDGET_MS =
+  (SINGLE_WARMUPS + SINGLE_MEASURED) *
+  PROCESS_TIMEOUT_BUDGET_MS(SINGLE_SESSIONS_PER_PROCESS);
+const COMPARE_RUN_TIMEOUT_BUDGET_MS =
+  (COMPARE_WARMUP_PAIRS + 30) *
+  2 *
+  PROCESS_TIMEOUT_BUDGET_MS(COMPARE_SESSIONS_PER_PROCESS);
+const BENCHMARK_TEST_TIMEOUT_MS =
+  Math.ceil(
+    Math.max(SINGLE_RUN_TIMEOUT_BUDGET_MS, COMPARE_RUN_TIMEOUT_BUDGET_MS) *
+      1.25,
+  ) +
+  5 * 60_000;
+const PROMPT_LENGTH = 128;
+const TOKEN = 'daemon-first-output-benchmark-token';
+const EXPECTED_ANSWER = 'benchmark response complete';
+const REPOSITORY_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+const OUTPUT_DIR = path.join(
+  REPOSITORY_ROOT,
+  '.qwen',
+  'investigations',
+  'daemon-first-output-benchmark',
+  new Date().toISOString().replace(/[:.]/g, '').replace(/Z$/, ''),
+);
+const BOOTSTRAP_SEED = 0x51f02026;
+const activeDaemons = new Set<BenchmarkDaemon>();
+const activeProcessGroups = new Set<ActiveProcessGroup>();
+const activeFakeProviders = new Set<FakeOpenAIServer>();
+const activeTempDirs = new Set<string>();
+const activeCompileCacheDirs = new Set<string>();
+let promptSequence = 0;
+
+type BundleRole = 'single' | 'control' | 'candidate';
+type PairOrder = 'AB' | 'BA';
+
+interface ResolvedBundle {
+  role: BundleRole;
+  configuredPath: string;
+  realPath: string;
+  sha256: string;
+  gitCommit: string | null;
+  compileCacheDir: string;
+}
+
+interface SingleBenchmarkConfig {
+  mode: 'single';
+  bundle: ResolvedBundle;
+  postSessionDwellMs: 0;
+}
+
+interface CompareBenchmarkConfig {
+  mode: 'compare';
+  control: ResolvedBundle;
+  candidate: ResolvedBundle;
+  postSessionDwellMs: 0 | 100 | 500;
+  measuredPairs: 10 | 30;
+}
+
+type BenchmarkConfig = SingleBenchmarkConfig | CompareBenchmarkConfig;
+
+interface BenchmarkDaemon {
+  client: DaemonClient;
+  child: ChildProcess;
+  pid: number;
+  processStartedAtMs: number;
+  daemonReadyAtMs: number;
+  port: number;
+  stdout: { value: string };
+  stderr: { value: string };
+  processGroup: ActiveProcessGroup;
+}
+
+interface ActiveProcessGroup {
+  child: ChildProcess;
+  pid: number;
+  descendantPids: Set<number>;
+  descendantSnapshotComplete: boolean;
+}
+
+interface ProviderTiming {
+  prompt: string;
+  requestAtMs: number;
+  readyAtMs: number;
+}
+
+interface ProcessSample {
+  sampleId: string;
+  role: BundleRole;
+  bundleRealPath: string;
+  bundleSha256: string;
+  order: PairOrder | null;
+  pairIndex: number | null;
+  warmup: boolean;
+  pid: number | null;
+  processStartedAtMs: number | null;
+  daemonReadyAtMs: number | null;
+  daemonPort: number | null;
+  fakeProviderPort: number | null;
+  sessions: FirstOutputSessionRunResult[];
+  failure: FirstOutputFailure | null;
+  safeToContinue: boolean;
+  stdout: string;
+  stderr: string;
+  cleanup: {
+    completed: boolean;
+    daemonExited: boolean;
+    residualProcessCount: number;
+    failure: FirstOutputFailure | null;
+  };
+  deferredTempRoot: string | null;
+}
+
+interface ExpectedRequest {
+  prompt: string;
+  count: number;
+  timing?: ProviderTiming;
+}
+
+interface ProviderFailureState {
+  value: FirstOutputFailure | null;
+}
+
+class BenchmarkFailure extends Error {
+  constructor(
+    readonly code: FirstOutputFailureCode,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = 'BenchmarkFailure';
+  }
+}
+
+class BenchmarkSpawnFailure extends BenchmarkFailure {
+  constructor(
+    primary: FirstOutputFailure,
+    readonly pid: number,
+    readonly stdout: string,
+    readonly stderr: string,
+    readonly processStartedAtMs: number,
+    readonly cleanupFailure: FirstOutputFailure | null,
+    readonly residualProcessCount: number,
+    readonly safeToContinue: boolean,
+    readonly daemonExited: boolean,
+  ) {
+    super(primary.code, primary.message);
+    this.name = 'BenchmarkSpawnFailure';
+  }
+}
+
+class ResidualProcessFailure extends BenchmarkFailure {
+  constructor(
+    message: string,
+    readonly residualProcessCount: number,
+  ) {
+    super('residual_process', message);
+    this.name = 'ResidualProcessFailure';
+  }
+}
+
+class BenchmarkTimeoutError extends Error {
+  constructor(label: string, timeoutMs: number) {
+    super(`${label} timed out after ${timeoutMs}ms.`);
+    this.name = 'BenchmarkTimeoutError';
+  }
+}
+
+function firstOutputFailure(
+  error: unknown,
+  fallback: FirstOutputFailureCode = 'harness_error',
+): FirstOutputFailure {
+  return error instanceof BenchmarkFailure
+    ? { code: error.code, message: error.message }
+    : { code: fallback, message: errorMessage(error) };
+}
+
+function readBenchmarkConfig(): BenchmarkConfig {
+  if (!SANDBOX_DISABLED) {
+    throw new Error(
+      'Invalid first-output benchmark config: QWEN_SANDBOX must be exactly false.',
+    );
+  }
+  const singlePath = process.env['BENCHMARK_CLI_PATH']?.trim();
+  const controlPath = process.env['BENCHMARK_CONTROL_CLI_PATH']?.trim();
+  const candidatePath = process.env['BENCHMARK_CANDIDATE_CLI_PATH']?.trim();
+  const hasSingle = Boolean(singlePath);
+  const hasControl = Boolean(controlPath);
+  const hasCandidate = Boolean(candidatePath);
+
+  if (hasSingle && (hasControl || hasCandidate)) {
+    throw new Error(
+      'Invalid first-output benchmark config: BENCHMARK_CLI_PATH cannot be ' +
+        'combined with BENCHMARK_CONTROL_CLI_PATH or ' +
+        'BENCHMARK_CANDIDATE_CLI_PATH.',
+    );
+  }
+  if (hasControl !== hasCandidate) {
+    throw new Error(
+      'Invalid first-output benchmark config: compare mode requires both ' +
+        'BENCHMARK_CONTROL_CLI_PATH and BENCHMARK_CANDIDATE_CLI_PATH.',
+    );
+  }
+  if (!hasSingle && !hasControl) {
+    throw new Error(
+      'Invalid first-output benchmark config: set BENCHMARK_CLI_PATH for ' +
+        'single mode, or set both BENCHMARK_CONTROL_CLI_PATH and ' +
+        'BENCHMARK_CANDIDATE_CLI_PATH for compare mode.',
+    );
+  }
+
+  const dwell = parseBenchmarkPostSessionDwell(
+    process.env['BENCHMARK_POST_SESSION_DWELL_MS'],
+  );
+  if (hasSingle) {
+    if (process.env['BENCHMARK_POST_SESSION_DWELL_MS'] !== undefined) {
+      throw new Error(
+        'Invalid first-output benchmark config: ' +
+          'BENCHMARK_POST_SESSION_DWELL_MS is compare-only.',
+      );
+    }
+    if (process.env['BENCHMARK_MEASURED_PAIRS'] !== undefined) {
+      throw new Error(
+        'Invalid first-output benchmark config: ' +
+          'BENCHMARK_MEASURED_PAIRS is compare-only.',
+      );
+    }
+    return {
+      mode: 'single',
+      bundle: resolveBundle(singlePath!, 'single'),
+      postSessionDwellMs: 0,
+    };
+  }
+
+  const control = resolveBundle(controlPath!, 'control');
+  const candidate = resolveBundle(candidatePath!, 'candidate');
+  if (control.realPath === candidate.realPath) {
+    throw new Error(
+      'Invalid first-output benchmark config: control and candidate resolve ' +
+        `to the same bundle (${control.realPath}).`,
+    );
+  }
+  if (control.sha256 === candidate.sha256) {
+    throw new Error(
+      'Invalid first-output benchmark config: control and candidate bundle ' +
+        `hashes are identical (${control.sha256}).`,
+    );
+  }
+  return {
+    mode: 'compare',
+    control,
+    candidate,
+    postSessionDwellMs: dwell,
+    measuredPairs: measuredPairCountForDwell(
+      dwell,
+      process.env['BENCHMARK_MEASURED_PAIRS'],
+    ),
+  };
+}
+
+function resolveBundle(input: string, role: BundleRole): ResolvedBundle {
+  const configuredPath = path.resolve(input);
+  let realPath: string;
+  try {
+    realPath = fs.realpathSync(configuredPath);
+  } catch (error) {
+    throw new Error(
+      `Invalid ${role} bundle path ${JSON.stringify(input)}: ${errorMessage(error)}`,
+    );
+  }
+  const stat = fs.statSync(realPath);
+  if (!stat.isFile()) {
+    throw new Error(
+      `Invalid ${role} bundle path ${JSON.stringify(input)}: expected a file.`,
+    );
+  }
+  const compileCacheDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), `qwen-first-output-cache-${role}-`),
+  );
+  activeCompileCacheDirs.add(compileCacheDir);
+  return {
+    role,
+    configuredPath,
+    realPath,
+    sha256: createHash('sha256')
+      .update(fs.readFileSync(realPath))
+      .digest('hex'),
+    gitCommit: gitCommitForPath(realPath),
+    compileCacheDir,
+  };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function gitCommitForPath(filePath: string): string | null {
+  try {
+    return execFileSync(
+      'git',
+      ['-C', path.dirname(filePath), 'rev-parse', 'HEAD'],
+      {
+        encoding: 'utf8',
+        timeout: 5_000,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      },
+    ).trim();
+  } catch {
+    return null;
+  }
+}
+
+async function spawnBenchmarkDaemon(
+  bundle: ResolvedBundle,
+  workspace: string,
+  env: NodeJS.ProcessEnv,
+): Promise<BenchmarkDaemon> {
+  const processStartedAtMs = performance.now();
+  const child = spawn(
+    process.execPath,
+    [
+      bundle.realPath,
+      'serve',
+      '--port',
+      '0',
+      '--token',
+      TOKEN,
+      '--hostname',
+      '127.0.0.1',
+      '--workspace',
+      workspace,
+      '--max-sessions',
+      '0',
+    ],
+    {
+      cwd: workspace,
+      detached: true,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+  const pid = child.pid;
+  if (!pid) {
+    throw new Error(`Failed to spawn ${bundle.role} daemon: no child pid.`);
+  }
+  const processGroup: ActiveProcessGroup = {
+    child,
+    pid,
+    descendantPids: new Set(),
+    descendantSnapshotComplete: false,
+  };
+  activeProcessGroups.add(processGroup);
+
+  const stdout = { value: '' };
+  const stderr = { value: '' };
+  child.stdout?.on('data', (chunk: Buffer) => {
+    stdout.value += chunk.toString();
+  });
+  child.stderr?.on('data', (chunk: Buffer) => {
+    stderr.value += chunk.toString();
+  });
+
+  let port: number;
+  try {
+    port = await waitForListening(child, stdout, stderr);
+  } catch (error) {
+    const primary = firstOutputFailure(error);
+    let cleanupFailure: FirstOutputFailure | null = null;
+    let residualProcessCount = 0;
+    let safeToContinue = true;
+    try {
+      await terminateTrackedProcessGroup(processGroup);
+      activeProcessGroups.delete(processGroup);
+    } catch (cleanupError) {
+      safeToContinue = false;
+      cleanupFailure ??= firstOutputFailure(cleanupError, 'cleanup_timeout');
+      residualProcessCount =
+        cleanupError instanceof ResidualProcessFailure
+          ? cleanupError.residualProcessCount
+          : 0;
+    }
+    throw new BenchmarkSpawnFailure(
+      primary,
+      pid,
+      tailUtf8(stdout.value),
+      tailUtf8(stderr.value),
+      processStartedAtMs,
+      cleanupFailure,
+      residualProcessCount,
+      safeToContinue,
+      hasChildExited(child),
+    );
+  }
+
+  const daemon: BenchmarkDaemon = {
+    client: new DaemonClient({
+      baseUrl: `http://127.0.0.1:${port}`,
+      token: TOKEN,
+      fetchTimeoutMs: SDK_FETCH_TIMEOUT_MS,
+    }),
+    child,
+    pid,
+    processStartedAtMs,
+    daemonReadyAtMs: performance.now(),
+    port,
+    stdout,
+    stderr,
+    processGroup,
+  };
+  activeDaemons.add(daemon);
+  return daemon;
+}
+
+function waitForListening(
+  child: ChildProcess,
+  stdout: { value: string },
+  stderr: { value: string },
+): Promise<number> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const cleanup = () => {
+      child.stdout?.off('data', onData);
+      child.off('exit', onExit);
+      child.off('error', onError);
+      clearTimeout(timer);
+    };
+    const fail = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const onData = () => {
+      const port = stdout.value.match(LISTENING_LINE_RE)?.groups?.['port'];
+      if (!port || settled) return;
+      settled = true;
+      cleanup();
+      resolve(Number(port));
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      fail(
+        new BenchmarkFailure(
+          'daemon_exited_before_listen',
+          `Daemon exited before listening (code=${code}, signal=${signal}).\n` +
+            `stdout:\n${tailUtf8(stdout.value)}\nstderr:\n${tailUtf8(stderr.value)}`,
+        ),
+      );
+    };
+    const onError = (error: Error) => {
+      fail(
+        new BenchmarkFailure(
+          'daemon_exited_before_listen',
+          `Daemon spawn failed: ${error.message}`,
+          { cause: error },
+        ),
+      );
+    };
+    const timer = setTimeout(() => {
+      fail(
+        new BenchmarkFailure(
+          'daemon_boot_timeout',
+          `Daemon did not listen within ${BOOT_TIMEOUT_MS}ms.\n` +
+            `stdout:\n${tailUtf8(stdout.value)}\nstderr:\n${tailUtf8(stderr.value)}`,
+        ),
+      );
+    }, BOOT_TIMEOUT_MS);
+    child.stdout?.on('data', onData);
+    child.once('exit', onExit);
+    child.once('error', onError);
+  });
+}
+
+async function terminateBenchmarkDaemon(
+  daemon: BenchmarkDaemon,
+): Promise<null> {
+  await terminateTrackedProcessGroup(daemon.processGroup);
+  activeDaemons.delete(daemon);
+  activeProcessGroups.delete(daemon.processGroup);
+  return null;
+}
+
+function benchmarkDescendantPids(pid: number): number[] {
+  const descendants = benchmarkDescendants(pid);
+  return [
+    ...new Set([...descendants.acpChildren, ...descendants.mcpGrandchildren]),
+  ];
+}
+
+function benchmarkDescendants(pid: number) {
+  return countDescendants(pid, {
+    acpFilter: '(^|[[:space:]])--acp([[:space:]]|$)',
+  });
+}
+
+function rememberDescendantPids(
+  processGroup: ActiveProcessGroup,
+  descendantPids: readonly number[],
+): void {
+  for (const descendantPid of descendantPids) {
+    processGroup.descendantPids.add(descendantPid);
+  }
+}
+
+async function terminateTrackedProcessGroup(
+  processGroup: ActiveProcessGroup,
+): Promise<void> {
+  let enumerationFailure: FirstOutputFailure | null = null;
+  if (!hasChildExited(processGroup.child)) {
+    try {
+      rememberDescendantPids(
+        processGroup,
+        benchmarkDescendantPids(processGroup.pid),
+      );
+      processGroup.descendantSnapshotComplete = true;
+    } catch (error) {
+      processGroup.descendantSnapshotComplete = false;
+      enumerationFailure = firstOutputFailure(error, 'cleanup_timeout');
+    }
+  }
+
+  const trackedPids = [...processGroup.descendantPids];
+  const remainingPids = await terminateProcessGroup(
+    processGroup.child,
+    trackedPids,
+  );
+  for (const trackedPid of trackedPids) {
+    if (!remainingPids.includes(trackedPid)) {
+      processGroup.descendantPids.delete(trackedPid);
+    }
+  }
+  if (remainingPids.length > 0) {
+    throw new ResidualProcessFailure(
+      `Tracked descendants survived teardown: ${remainingPids.join(', ')}.`,
+      remainingPids.length,
+    );
+  }
+  if (!processGroup.descendantSnapshotComplete) {
+    throw new BenchmarkFailure(
+      'cleanup_timeout',
+      enumerationFailure?.message ??
+        'Descendant enumeration did not complete before the process-group leader exited.',
+    );
+  }
+}
+
+async function terminateProcessGroup(
+  child: ChildProcess,
+  descendantPids: number[],
+): Promise<number[]> {
+  const pid = child.pid;
+  if (!pid) return descendantPids;
+
+  if (!hasChildExited(child)) {
+    signalProcessGroup(pid, 'SIGTERM');
+  }
+  await waitForChildExit(child, PROCESS_EXIT_TIMEOUT_MS);
+  let remaining = await waitForDescendantsExit(
+    descendantPids,
+    DESCENDANT_EXIT_TIMEOUT_MS,
+  );
+
+  if (!hasChildExited(child)) {
+    signalProcessGroup(pid, 'SIGKILL');
+    await waitForChildExit(child, PROCESS_EXIT_TIMEOUT_MS);
+    remaining = await waitForDescendantsExit(
+      remaining,
+      DESCENDANT_EXIT_TIMEOUT_MS,
+    );
+  }
+  if (!hasChildExited(child)) {
+    throw new BenchmarkFailure(
+      'cleanup_timeout',
+      `Daemon process group ${pid} did not exit after SIGKILL.`,
+    );
+  }
+
+  return remaining;
+}
+
+async function waitForDescendantsExit(
+  descendantPids: readonly number[],
+  timeoutMs: number,
+): Promise<number[]> {
+  const deadline = performance.now() + timeoutMs;
+  let remaining = descendantPids.filter(isProcessAlive);
+  while (remaining.length > 0 && performance.now() < deadline) {
+    await sleep(25);
+    remaining = remaining.filter(isProcessAlive);
+  }
+  return remaining;
+}
+
+function signalProcessGroup(pid: number, signal: NodeJS.Signals): void {
+  try {
+    process.kill(-pid, signal);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== 'ESRCH') throw error;
+  }
+}
+
+function hasChildExited(child: ChildProcess): boolean {
+  return child.exitCode !== null || child.signalCode !== null;
+}
+
+function waitForChildExit(
+  child: ChildProcess,
+  timeoutMs: number,
+): Promise<boolean> {
+  if (hasChildExited(child)) {
+    return Promise.resolve(true);
+  }
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      child.off('exit', onExit);
+      resolve(false);
+    }, timeoutMs);
+    const onExit = () => {
+      clearTimeout(timer);
+      resolve(true);
+    };
+    child.once('exit', onExit);
+  });
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ESRCH') return false;
+    if (code === 'EPERM') return true;
+    throw error;
+  }
+}
+
+function fakeProviderPort(server: FakeOpenAIServer): number {
+  const port = Number(new URL(server.baseUrl).port);
+  if (!Number.isSafeInteger(port) || port <= 0) {
+    throw new Error(
+      `Fake provider returned an invalid base URL: ${server.baseUrl}`,
+    );
+  }
+  return port;
+}
+
+function isolatedDaemonEnv(
+  home: string,
+  qwenHome: string,
+  tempDir: string,
+  workspace: string,
+  fakeServer: FakeOpenAIServer,
+  bundle: ResolvedBundle,
+): NodeJS.ProcessEnv {
+  const inherited: NodeJS.ProcessEnv = {};
+  if (process.env['PATH']) inherited['PATH'] = process.env['PATH'];
+  const trustedFoldersPath = path.join(qwenHome, 'trustedFolders.json');
+  fs.writeFileSync(
+    trustedFoldersPath,
+    JSON.stringify({ [fs.realpathSync(workspace)]: 'TRUST_FOLDER' }),
+  );
+  return {
+    ...inherited,
+    HOME: home,
+    QWEN_HOME: qwenHome,
+    TMPDIR: tempDir,
+    XDG_CACHE_HOME: path.join(home, '.cache'),
+    XDG_CONFIG_HOME: path.join(home, '.config'),
+    XDG_DATA_HOME: path.join(home, '.local', 'share'),
+    NODE_COMPILE_CACHE: bundle.compileCacheDir,
+    QWEN_SANDBOX: 'false',
+    QWEN_CODE_INTEGRATION_TEST: 'true',
+    QWEN_CODE_SKIP_UPDATE_CHECK_ONCE: 'true',
+    QWEN_TELEMETRY_ENABLED: 'false',
+    QWEN_CODE_TRUSTED_FOLDERS_PATH: trustedFoldersPath,
+    CI: 'true',
+    TERM: 'dumb',
+    LANG: 'C.UTF-8',
+    LC_ALL: 'C.UTF-8',
+    TZ: 'UTC',
+    NO_COLOR: '1',
+    NO_PROXY: '127.0.0.1,localhost',
+    no_proxy: '127.0.0.1,localhost',
+    OPENAI_API_KEY: 'fake-key',
+    OPENAI_BASE_URL: fakeServer.baseUrl,
+    OPENAI_MODEL: 'fake-model',
+    QWEN_MODEL: 'fake-model',
+  };
+}
+
+function prepareIsolatedDirectories(sampleId: string): {
+  root: string;
+  workspace: string;
+  home: string;
+  qwenHome: string;
+  tempDir: string;
+} {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), `qwen-first-output-${sampleId}-`),
+  );
+  activeTempDirs.add(root);
+  const workspace = path.join(root, 'workspace');
+  const home = path.join(root, 'home');
+  const qwenHome = path.join(home, '.qwen');
+  const tempDir = path.join(root, 'tmp');
+  fs.mkdirSync(workspace, { recursive: true });
+  fs.mkdirSync(qwenHome, { recursive: true });
+  fs.mkdirSync(tempDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(qwenHome, 'settings.json'),
+    JSON.stringify({
+      ui: { enableFollowupSuggestions: false },
+    }),
+  );
+  return { root, workspace, home, qwenHome, tempDir };
+}
+
+function makePrompt(): string {
+  promptSequence++;
+  const marker = `first-output-${String(promptSequence).padStart(6, '0')}`;
+  const prefix = `Reply with one short sentence. Benchmark marker: ${marker}. `;
+  if (prefix.length > PROMPT_LENGTH) {
+    throw new Error('Benchmark prompt prefix exceeded its fixed width.');
+  }
+  return prefix.padEnd(PROMPT_LENGTH, 'x');
+}
+
+function startTimedFakeProvider(
+  expectedRequests: Map<string, ExpectedRequest>,
+  failureState: ProviderFailureState,
+): Promise<FakeOpenAIServer> {
+  return startFakeOpenAIServer(
+    async ({ body }) => {
+      if (body['stream'] !== true || body['model'] !== 'fake-model') {
+        const message =
+          'Benchmark Provider requires stream=true and model=fake-model.';
+        failureState.value ??= {
+          code: 'harness_error',
+          message,
+        };
+        throw new Error(message);
+      }
+      const messages = JSON.stringify(body['messages'] ?? []);
+      const matches = [...expectedRequests.values()].filter(({ prompt }) =>
+        messages.includes(prompt),
+      );
+      if (matches.length !== 1) {
+        const message = `Expected exactly one benchmark prompt in provider request, found ${matches.length}.`;
+        failureState.value ??= {
+          code: 'provider_request_count_mismatch',
+          message,
+        };
+        throw new Error(message);
+      }
+      const expected = matches[0];
+      expected.count++;
+      if (expected.count !== 1) {
+        const message = `Benchmark prompt reached the provider ${expected.count} times.`;
+        failureState.value ??= {
+          code: 'provider_request_count_mismatch',
+          message,
+        };
+        throw new Error(message);
+      }
+      const requestAtMs = performance.now();
+      await sleep(PROVIDER_DELAY_MS);
+      const readyAtMs = performance.now();
+      expected.timing = {
+        prompt: expected.prompt,
+        requestAtMs,
+        readyAtMs,
+      };
+      return { content: EXPECTED_ANSWER };
+    },
+    { keepAlive: false },
+  );
+}
+
+async function runSession(
+  daemon: BenchmarkDaemon,
+  workspace: string,
+  ordinal: 1 | 2,
+  postSessionDwellMs: number,
+  expectedRequests: Map<string, ExpectedRequest>,
+): Promise<FirstOutputSessionRunResult> {
+  const prompt = makePrompt();
+  const expectedRequest: ExpectedRequest = { prompt, count: 0 };
+  expectedRequests.set(prompt, expectedRequest);
+
+  const sessionCreateStart = performance.now();
+  let session: DaemonSession | undefined;
+  let promptId: string | null = null;
+  let abort: AbortController | undefined;
+  let promptAbort: AbortController | undefined;
+  let streamTask: Promise<void> | undefined;
+  let failure: FirstOutputFailure | null = null;
+  let cleanupFailure: FirstOutputFailure | null = null;
+  const tracker = new FirstOutputTracker();
+  const timestamps: FirstOutputSessionRunResult['timestamps'] = {
+    sessionCreateStart,
+    sessionReady: null,
+    sseReady: null,
+    promptStart: null,
+    promptAccepted: null,
+    providerRequestArrival: null,
+    providerReady: null,
+    firstModelOutput: null,
+    firstAnswerText: null,
+    terminal: null,
+  };
+
+  try {
+    try {
+      session = await daemon.client.createOrAttachSession({
+        workspaceCwd: workspace,
+        sessionScope: 'thread',
+      });
+    } catch (error) {
+      throw new BenchmarkFailure(
+        'session_create_failed',
+        `Session creation failed: ${errorMessage(error)}`,
+        { cause: error },
+      );
+    }
+    if (!session.sessionId || !session.clientId) {
+      throw new BenchmarkFailure(
+        'session_create_failed',
+        'Session creation returned a malformed response.',
+      );
+    }
+    timestamps.sessionReady = performance.now();
+
+    abort = new AbortController();
+    const epochReady = deferred<void>();
+    const terminalReady = deferred<void>();
+    void terminalReady.promise.catch(() => undefined);
+    streamTask = (async () => {
+      try {
+        for await (const event of daemon.client.subscribeEvents(
+          session!.sessionId,
+          {
+            signal: abort!.signal,
+            onEpoch: () => {
+              if (timestamps.sseReady === null) {
+                timestamps.sseReady = performance.now();
+                epochReady.resolve();
+              }
+            },
+          },
+        )) {
+          tracker.push(event as DaemonEvent, performance.now());
+          if (tracker.snapshot().terminal !== null) {
+            terminalReady.resolve();
+            return;
+          }
+        }
+        const streamEnded = new BenchmarkFailure(
+          'sse_stream_ended',
+          'SSE stream ended before the matching prompt terminal.',
+        );
+        epochReady.reject(streamEnded);
+        terminalReady.reject(streamEnded);
+      } catch (error) {
+        if (!abort!.signal.aborted) {
+          epochReady.reject(error);
+          terminalReady.reject(
+            new BenchmarkFailure(
+              'sse_stream_ended',
+              `SSE stream failed: ${errorMessage(error)}`,
+              { cause: error },
+            ),
+          );
+        }
+      }
+    })();
+
+    try {
+      await withTimeout(
+        epochReady.promise,
+        TURN_TIMEOUT_MS,
+        'SSE epoch readiness',
+      );
+    } catch (error) {
+      throw new BenchmarkFailure(
+        error instanceof BenchmarkTimeoutError
+          ? 'sse_connect_timeout'
+          : 'sse_stream_ended',
+        `SSE connection failed: ${errorMessage(error)}`,
+        { cause: error },
+      );
+    }
+    const promptNotBefore = timestamps.sessionReady + postSessionDwellMs;
+    if (performance.now() < promptNotBefore) {
+      await sleep(promptNotBefore - performance.now());
+    }
+
+    timestamps.promptStart = performance.now();
+    promptAbort = new AbortController();
+    let accepted: Awaited<ReturnType<DaemonClient['promptNonBlocking']>>;
+    try {
+      accepted = await withTimeout(
+        daemon.client.promptNonBlocking(
+          session.sessionId,
+          {
+            prompt: [{ type: 'text', text: prompt }],
+          },
+          promptAbort.signal,
+          session.clientId,
+        ),
+        TURN_TIMEOUT_MS,
+        'prompt acceptance',
+      );
+    } catch (error) {
+      promptAbort.abort();
+      const snapshot = tracker.snapshot();
+      if (snapshot.failureCode !== null) {
+        throw new BenchmarkFailure(
+          snapshot.failureCode,
+          snapshot.failureMessage ?? snapshot.failureCode,
+        );
+      }
+      throw new BenchmarkFailure(
+        error instanceof BenchmarkTimeoutError
+          ? 'prompt_accept_timeout'
+          : 'prompt_rejected',
+        `Prompt acceptance failed: ${errorMessage(error)}`,
+        { cause: error },
+      );
+    }
+    const acceptance = validatePromptAcceptance(accepted);
+    if (acceptance.kind === 'failure') {
+      throw new BenchmarkFailure(
+        acceptance.failure.code,
+        acceptance.failure.message,
+      );
+    }
+    timestamps.promptAccepted = performance.now();
+    promptId = acceptance.promptId;
+    tracker.acceptPrompt(promptId);
+    const acceptedSnapshot = tracker.snapshot();
+    if (
+      acceptedSnapshot.terminal !== null ||
+      acceptedSnapshot.failureCode !== null
+    ) {
+      terminalReady.resolve();
+    }
+
+    try {
+      await withTimeout(
+        terminalReady.promise,
+        TURN_TIMEOUT_MS,
+        'matching prompt terminal',
+      );
+    } catch (error) {
+      const snapshot = tracker.snapshot();
+      if (snapshot.failureCode !== null) {
+        throw new BenchmarkFailure(
+          snapshot.failureCode,
+          snapshot.failureMessage ?? snapshot.failureCode,
+        );
+      }
+      if (error instanceof BenchmarkFailure) throw error;
+      throw new BenchmarkFailure(
+        snapshot.firstOutput === null
+          ? 'first_output_timeout'
+          : 'terminal_timeout',
+        errorMessage(error),
+        { cause: error },
+      );
+    }
+    const tracked = tracker.snapshot();
+    if (tracked.failureCode !== null) {
+      throw new BenchmarkFailure(
+        tracked.failureCode,
+        tracked.failureMessage ?? tracked.failureCode,
+      );
+    }
+    if (!tracked.runEligible || !tracked.firstOutput || !tracked.terminal) {
+      throw new BenchmarkFailure(
+        'harness_error',
+        `Prompt ${promptId} completed without an eligible output and terminal.`,
+      );
+    }
+    if (tracked.firstOutput.kind !== 'answer_text') {
+      throw new BenchmarkFailure(
+        'unexpected_output_kind',
+        `Expected answer_text as first output, received ${tracked.firstOutput.kind}.`,
+      );
+    }
+    const finalTextFailure = validateExpectedFinalText(
+      tracked.finalAnswerText,
+      EXPECTED_ANSWER,
+    );
+    if (finalTextFailure) {
+      throw new BenchmarkFailure(
+        finalTextFailure.code,
+        finalTextFailure.message,
+      );
+    }
+    if (expectedRequest.count !== 1 || !expectedRequest.timing) {
+      throw new BenchmarkFailure(
+        'provider_request_count_mismatch',
+        `Expected exactly one target generation request, observed ${expectedRequest.count}.`,
+      );
+    }
+  } catch (error) {
+    failure = firstOutputFailure(error);
+  } finally {
+    promptAbort?.abort();
+    abort?.abort();
+    if (streamTask) {
+      try {
+        await withTimeout(streamTask, PROCESS_EXIT_TIMEOUT_MS, 'SSE shutdown');
+      } catch (error) {
+        cleanupFailure ??= firstOutputFailure(error, 'cleanup_timeout');
+      }
+    }
+  }
+
+  const tracked = tracker.snapshot();
+  if (expectedRequest.timing) {
+    timestamps.providerRequestArrival = expectedRequest.timing.requestAtMs;
+    timestamps.providerReady = expectedRequest.timing.readyAtMs;
+  }
+  timestamps.firstModelOutput = tracked.firstOutput?.receivedAtMs ?? null;
+  timestamps.firstAnswerText = tracked.firstAnswer?.receivedAtMs ?? null;
+  timestamps.terminal = tracked.terminal?.receivedAtMs ?? null;
+  const timings = computeSessionTimings(timestamps, daemon.processStartedAtMs);
+  const invalidMetric = findInvalidTiming(timings);
+  if (invalidMetric) {
+    failure ??= {
+      code: 'harness_error',
+      message: `Invalid ${invalidMetric[0]} duration: ${invalidMetric[1]}`,
+    };
+    timings[invalidMetric[0]] = null;
+  }
+
+  return {
+    ordinal,
+    sessionId: session?.sessionId ?? null,
+    promptId,
+    timestamps,
+    timings,
+    firstOutput: tracked.firstOutput,
+    firstAnswer: tracked.firstAnswer,
+    finalAnswerText: tracked.finalAnswerText,
+    terminal: tracked.terminal,
+    providerRequestCount: expectedRequest.count,
+    runEligible: failure === null && tracked.runEligible,
+    answerMetricEligible: failure === null && tracked.answerMetricEligible,
+    failure,
+    cleanupFailure,
+    diagnostics: {
+      promptLength: prompt.length,
+      promptSha256: createHash('sha256').update(prompt).digest('hex'),
+      bufferedBeforeAcceptanceCount: tracked.bufferedBeforeAcceptanceCount,
+      matchingEventCount: tracked.matchingEventCount,
+      matchingTerminalCount: tracked.matchingTerminalCount,
+      sseReadyBeforePrompt:
+        timestamps.sseReady !== null &&
+        timestamps.promptStart !== null &&
+        timestamps.sseReady <= timestamps.promptStart,
+      actualProviderDelayMs: duration(
+        timestamps.providerReady,
+        timestamps.providerRequestArrival,
+      ),
+    },
+  };
+}
+
+function findInvalidTiming(
+  timings: FirstOutputSessionRunResult['timings'],
+): [keyof FirstOutputSessionRunResult['timings'], number] | null {
+  for (const key of Object.keys(timings) as Array<
+    keyof FirstOutputSessionRunResult['timings']
+  >) {
+    const value = timings[key];
+    if (value !== null && (!Number.isFinite(value) || value < 0)) {
+      return [key, value];
+    }
+  }
+  return null;
+}
+
+function computeSessionTimings(
+  timestamps: FirstOutputSessionRunResult['timestamps'],
+  processStartedAtMs: number,
+): FirstOutputSessionRunResult['timings'] {
+  return {
+    processToSessionReadyMs: duration(
+      timestamps.sessionReady,
+      processStartedAtMs,
+    ),
+    promptToProviderRequestArrivalMs: duration(
+      timestamps.providerRequestArrival,
+      timestamps.promptStart,
+    ),
+    promptToFirstModelOutputMs: duration(
+      timestamps.firstModelOutput,
+      timestamps.promptStart,
+    ),
+    promptToFirstAnswerTextMs: duration(
+      timestamps.firstAnswerText,
+      timestamps.promptStart,
+    ),
+    providerReadyToFirstModelOutputMs: duration(
+      timestamps.firstModelOutput,
+      timestamps.providerReady,
+    ),
+    processToFirstModelOutputMs: duration(
+      timestamps.firstModelOutput,
+      processStartedAtMs,
+    ),
+    promptToTerminalMs: duration(timestamps.terminal, timestamps.promptStart),
+  };
+}
+
+function duration(end: number | null, start: number | null): number | null {
+  return end === null || start === null ? null : end - start;
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: unknown): void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new BenchmarkTimeoutError(label, timeoutMs));
+    }, timeoutMs);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+async function runProcessSample(options: {
+  sampleId: string;
+  bundle: ResolvedBundle;
+  order: PairOrder | null;
+  pairIndex: number | null;
+  warmup: boolean;
+  postSessionDwellMs: number;
+  sessionCount: 1 | 2;
+}): Promise<ProcessSample> {
+  let dirs: ReturnType<typeof prepareIsolatedDirectories> | undefined;
+  const expectedRequests = new Map<string, ExpectedRequest>();
+  const providerFailureState: ProviderFailureState = { value: null };
+  let fakeServer: FakeOpenAIServer | undefined;
+  let daemon: BenchmarkDaemon | undefined;
+  let spawnFailure: BenchmarkSpawnFailure | undefined;
+  const sessions: FirstOutputSessionRunResult[] = [];
+  let failure: FirstOutputFailure | null = null;
+  let cleanupFailure: FirstOutputFailure | null = null;
+  let residualProcessCount = 0;
+  let firstSessionAcpPids: number[] | null = null;
+  let safeToContinue = true;
+
+  try {
+    dirs = prepareIsolatedDirectories(options.sampleId);
+    fakeServer = await startTimedFakeProvider(
+      expectedRequests,
+      providerFailureState,
+    );
+    activeFakeProviders.add(fakeServer);
+    daemon = await spawnBenchmarkDaemon(
+      options.bundle,
+      dirs.workspace,
+      isolatedDaemonEnv(
+        dirs.home,
+        dirs.qwenHome,
+        dirs.tempDir,
+        dirs.workspace,
+        fakeServer,
+        options.bundle,
+      ),
+    );
+
+    for (let ordinal = 1; ordinal <= options.sessionCount; ordinal += 1) {
+      const session = await runSession(
+        daemon,
+        dirs.workspace,
+        ordinal as 1 | 2,
+        options.postSessionDwellMs,
+        expectedRequests,
+      );
+      sessions.push(session);
+      cleanupFailure ??= session.cleanupFailure;
+      if (options.sessionCount === 2 && session.failure === null) {
+        const descendants = benchmarkDescendants(daemon.pid);
+        rememberDescendantPids(daemon.processGroup, [
+          ...descendants.acpChildren,
+          ...descendants.mcpGrandchildren,
+        ]);
+        const acpPids = descendants.acpChildren.sort(
+          (left, right) => left - right,
+        );
+        session.diagnostics = { ...session.diagnostics, acpPids };
+        if (ordinal === 1) {
+          firstSessionAcpPids = acpPids;
+        } else if (
+          firstSessionAcpPids === null ||
+          firstSessionAcpPids.length !== 1 ||
+          acpPids.length !== 1 ||
+          firstSessionAcpPids[0] !== acpPids[0]
+        ) {
+          failure = {
+            code: 'harness_error',
+            message:
+              'Cold and warm sessions did not use the same single ACP child process.',
+          };
+        }
+      }
+      if (session.failure !== null || session.cleanupFailure !== null) {
+        failure ??= providerFailureState.value ?? session.failure;
+        break;
+      }
+    }
+
+    for (const session of sessions) {
+      if (!session.sessionId) continue;
+      try {
+        await daemon.client.closeSession(session.sessionId, undefined);
+      } catch (error) {
+        cleanupFailure ??= {
+          code: 'cleanup_timeout',
+          message: `Session close failed: ${errorMessage(error)}`,
+        };
+      }
+    }
+
+    if (
+      failure === null &&
+      cleanupFailure === null &&
+      options.sessionCount === 2
+    ) {
+      const [first, second] = sessions;
+      if (
+        !first ||
+        !second ||
+        first.sessionId === second.sessionId ||
+        first.promptId === second.promptId
+      ) {
+        failure = {
+          code: 'harness_error',
+          message:
+            'The two sessionScope=thread benchmark turns did not retain distinct session and prompt ids.',
+        };
+      }
+    }
+  } catch (error) {
+    if (error instanceof BenchmarkSpawnFailure) {
+      spawnFailure = error;
+      cleanupFailure ??= error.cleanupFailure;
+      residualProcessCount = error.residualProcessCount;
+      safeToContinue = error.safeToContinue;
+    }
+    failure ??= firstOutputFailure(error);
+  } finally {
+    if (daemon && activeDaemons.has(daemon)) {
+      try {
+        const processCleanupFailure = await terminateBenchmarkDaemon(daemon);
+        cleanupFailure ??= processCleanupFailure;
+      } catch (error) {
+        safeToContinue = false;
+        cleanupFailure ??= firstOutputFailure(error, 'cleanup_timeout');
+        residualProcessCount =
+          error instanceof ResidualProcessFailure
+            ? error.residualProcessCount
+            : residualProcessCount;
+      }
+    }
+    failure ??= providerFailureState.value;
+    if (
+      fakeServer &&
+      failure === null &&
+      cleanupFailure === null &&
+      (expectedRequests.size !== options.sessionCount ||
+        fakeServer.requests.length !== options.sessionCount ||
+        [...expectedRequests.values()].some((request) => request.count !== 1))
+    ) {
+      failure = {
+        code: 'provider_request_count_mismatch',
+        message:
+          'Provider request-count invariant failed after daemon exit: ' +
+          `expected exactly one generation for each of ${options.sessionCount} ` +
+          `sessions, saw ${fakeServer.requests.length} total request(s).`,
+      };
+    }
+    if (fakeServer) {
+      try {
+        await withTimeout(
+          fakeServer.close(),
+          PROCESS_EXIT_TIMEOUT_MS,
+          'Fake Provider shutdown',
+        );
+        activeFakeProviders.delete(fakeServer);
+      } catch (error) {
+        safeToContinue = false;
+        cleanupFailure ??= {
+          code: 'cleanup_timeout',
+          message: `Fake Provider close failed: ${errorMessage(error)}`,
+        };
+      }
+    }
+    if (dirs && safeToContinue) {
+      try {
+        fs.rmSync(dirs.root, { recursive: true, force: true });
+        activeTempDirs.delete(dirs.root);
+      } catch (error) {
+        cleanupFailure ??= {
+          code: 'cleanup_timeout',
+          message: `Temporary-state cleanup failed: ${errorMessage(error)}`,
+        };
+      }
+    }
+  }
+
+  const failed = failure !== null || cleanupFailure !== null;
+  return {
+    sampleId: options.sampleId,
+    role: options.bundle.role,
+    bundleRealPath: options.bundle.realPath,
+    bundleSha256: options.bundle.sha256,
+    order: options.order,
+    pairIndex: options.pairIndex,
+    warmup: options.warmup,
+    pid: daemon?.pid ?? spawnFailure?.pid ?? null,
+    processStartedAtMs:
+      daemon?.processStartedAtMs ?? spawnFailure?.processStartedAtMs ?? null,
+    daemonReadyAtMs: daemon?.daemonReadyAtMs ?? null,
+    daemonPort: daemon?.port ?? null,
+    fakeProviderPort: fakeServer ? fakeProviderPort(fakeServer) : null,
+    sessions,
+    failure,
+    safeToContinue,
+    stdout: failed
+      ? tailUtf8(daemon?.stdout.value ?? spawnFailure?.stdout ?? '')
+      : '',
+    stderr: failed
+      ? tailUtf8(daemon?.stderr.value ?? spawnFailure?.stderr ?? '')
+      : '',
+    cleanup: {
+      completed: cleanupFailure === null,
+      daemonExited:
+        daemon !== undefined
+          ? hasChildExited(daemon.child)
+          : spawnFailure !== undefined
+            ? spawnFailure.daemonExited
+            : true,
+      residualProcessCount,
+      failure: cleanupFailure,
+    },
+    deferredTempRoot: dirs && activeTempDirs.has(dirs.root) ? dirs.root : null,
+  };
+}
+
+function tailUtf8(value: string): string {
+  const bytes = Buffer.from(value);
+  return bytes.subarray(Math.max(0, bytes.length - 4_096)).toString();
+}
+
+async function runSingleSamples(config: SingleBenchmarkConfig): Promise<{
+  warmups: ProcessSample[];
+  measured: ProcessSample[];
+}> {
+  const warmups: ProcessSample[] = [];
+  const measured: ProcessSample[] = [];
+  for (let index = 1; index <= SINGLE_WARMUPS; index++) {
+    logProgress(`single warmup ${index}/${SINGLE_WARMUPS}`);
+    const sample = await runProcessSample({
+      sampleId: `single-warmup-${index}`,
+      bundle: config.bundle,
+      order: null,
+      pairIndex: null,
+      warmup: true,
+      postSessionDwellMs: 0,
+      sessionCount: SINGLE_SESSIONS_PER_PROCESS,
+    });
+    warmups.push(sample);
+    if (!isSuccessfulProcessSample(sample, SINGLE_SESSIONS_PER_PROCESS)) {
+      return { warmups, measured };
+    }
+  }
+  for (let index = 1; index <= SINGLE_MEASURED; index++) {
+    logProgress(`single measured ${index}/${SINGLE_MEASURED}`);
+    const sample = await runProcessSample({
+      sampleId: `single-measured-${index}`,
+      bundle: config.bundle,
+      order: null,
+      pairIndex: null,
+      warmup: false,
+      postSessionDwellMs: 0,
+      sessionCount: SINGLE_SESSIONS_PER_PROCESS,
+    });
+    measured.push(sample);
+    if (!isSuccessfulProcessSample(sample, SINGLE_SESSIONS_PER_PROCESS)) {
+      return { warmups, measured };
+    }
+  }
+  return { warmups, measured };
+}
+
+interface RawPair {
+  pairIndex: number;
+  order: PairOrder;
+  warmup: boolean;
+  control: ProcessSample;
+  candidate: ProcessSample;
+  safeToContinue: boolean;
+}
+
+async function runComparisonPairs(
+  config: CompareBenchmarkConfig,
+): Promise<{ warmups: RawPair[]; measured: RawPair[] }> {
+  const warmups: RawPair[] = [];
+  const measured: RawPair[] = [];
+  const warmupOrders: PairOrder[] = ['AB', 'BA'];
+  for (let index = 1; index <= COMPARE_WARMUP_PAIRS; index++) {
+    const order = warmupOrders[index - 1];
+    logProgress(
+      `compare warmup pair ${index}/${COMPARE_WARMUP_PAIRS} (${order})`,
+    );
+    const pair = await runComparisonPair(config, index, order, true);
+    warmups.push(pair);
+    if (!isSuccessfulRawPair(pair)) return { warmups, measured };
+  }
+  for (let index = 1; index <= config.measuredPairs; index++) {
+    const order: PairOrder = index % 2 === 1 ? 'AB' : 'BA';
+    logProgress(
+      `compare measured pair ${index}/${config.measuredPairs} (${order})`,
+    );
+    const pair = await runComparisonPair(config, index, order, false);
+    measured.push(pair);
+    if (!isSuccessfulRawPair(pair)) return { warmups, measured };
+  }
+  const abCount = measured.filter((pair) => pair.order === 'AB').length;
+  const baCount = measured.filter((pair) => pair.order === 'BA').length;
+  const expectedPerOrder = config.measuredPairs / 2;
+  if (abCount !== expectedPerOrder || baCount !== expectedPerOrder) {
+    throw new Error(
+      'Internal AB/BA balance error: expected ' +
+        `${expectedPerOrder}/${expectedPerOrder}, received ${abCount}/${baCount}.`,
+    );
+  }
+  return { warmups, measured };
+}
+
+async function runComparisonPair(
+  config: CompareBenchmarkConfig,
+  pairIndex: number,
+  order: PairOrder,
+  warmup: boolean,
+): Promise<RawPair> {
+  const sequence =
+    order === 'AB'
+      ? ([config.control, config.candidate] as const)
+      : ([config.candidate, config.control] as const);
+  const samples: ProcessSample[] = [];
+  for (const [position, bundle] of sequence.entries()) {
+    const sampleId =
+      `${warmup ? 'warmup' : 'measured'}-pair-${pairIndex}-` +
+      `${position + 1}-${bundle.role}`;
+    const sample = await runProcessSample({
+      sampleId,
+      bundle,
+      order,
+      pairIndex,
+      warmup,
+      postSessionDwellMs: config.postSessionDwellMs,
+      sessionCount: COMPARE_SESSIONS_PER_PROCESS,
+    });
+    samples.push(sample);
+    if (!sample.safeToContinue && position === 0) {
+      const skippedBundle = sequence[1];
+      samples.push(
+        skippedProcessSample(
+          `${warmup ? 'warmup' : 'measured'}-pair-${pairIndex}-2-${skippedBundle.role}`,
+          skippedBundle,
+          order,
+          pairIndex,
+          warmup,
+        ),
+      );
+      break;
+    }
+  }
+  const control = samples.find((sample) => sample.role === 'control');
+  const candidate = samples.find((sample) => sample.role === 'candidate');
+  if (!control || !candidate) {
+    throw new Error(`Comparison pair ${pairIndex} lost a variant result.`);
+  }
+  return {
+    pairIndex,
+    order,
+    warmup,
+    control,
+    candidate,
+    safeToContinue: samples.every((sample) => sample.safeToContinue),
+  };
+}
+
+function isSuccessfulProcessSample(
+  sample: ProcessSample,
+  expectedSessions: 1 | 2,
+): boolean {
+  return (
+    sample.failure === null &&
+    sample.cleanup.failure === null &&
+    sample.sessions.length === expectedSessions &&
+    sample.sessions.every((session) => session.runEligible)
+  );
+}
+
+function isSuccessfulRawPair(pair: RawPair): boolean {
+  return (
+    pair.safeToContinue &&
+    isSuccessfulProcessSample(pair.control, COMPARE_SESSIONS_PER_PROCESS) &&
+    isSuccessfulProcessSample(pair.candidate, COMPARE_SESSIONS_PER_PROCESS)
+  );
+}
+
+function skippedProcessSample(
+  sampleId: string,
+  bundle: ResolvedBundle,
+  order: PairOrder,
+  pairIndex: number,
+  warmup: boolean,
+): ProcessSample {
+  return {
+    sampleId,
+    role: bundle.role,
+    bundleRealPath: bundle.realPath,
+    bundleSha256: bundle.sha256,
+    order,
+    pairIndex,
+    warmup,
+    pid: null,
+    processStartedAtMs: null,
+    daemonReadyAtMs: null,
+    daemonPort: null,
+    fakeProviderPort: null,
+    sessions: [],
+    failure: {
+      code: 'harness_error',
+      message:
+        "Arm was not started because the preceding arm's owned resources could not be verified as stopped.",
+    },
+    safeToContinue: false,
+    stdout: '',
+    stderr: '',
+    cleanup: {
+      completed: true,
+      daemonExited: true,
+      residualProcessCount: 0,
+      failure: null,
+    },
+    deferredTempRoot: null,
+  };
+}
+
+function logProgress(message: string): void {
+  console.log(`[first-output-benchmark] ${message}`);
+}
+
+const METRICS: readonly FirstOutputMetricName[] = [
+  'processToListenMs',
+  'processToSessionReadyMs',
+  'promptToProviderRequestArrivalMs',
+  'promptToFirstModelOutputMs',
+  'promptToFirstAnswerTextMs',
+  'providerReadyToFirstModelOutputMs',
+  'processToFirstModelOutputMs',
+  'promptToTerminalMs',
+];
+
+function toProcessRun(
+  sample: ProcessSample,
+  sampleIndex: number,
+  orderPosition: 1 | 2 | null,
+): FirstOutputProcessRunResult {
+  return {
+    variant: sample.role,
+    sampleIndex,
+    pairIndex: sample.pairIndex,
+    orderPosition,
+    measured: !sample.warmup,
+    pid: sample.pid,
+    timestamps: {
+      processStart: sample.processStartedAtMs,
+      daemonReady: sample.daemonReadyAtMs,
+    },
+    processToListenMs: duration(
+      sample.daemonReadyAtMs,
+      sample.processStartedAtMs,
+    ),
+    sessions: sample.sessions,
+    failure: sample.failure,
+    cleanup: sample.cleanup,
+    stdout: sample.stdout,
+    stderr: sample.stderr,
+    diagnostics: {
+      sampleId: sample.sampleId,
+      bundleRealPath: sample.bundleRealPath,
+      bundleSha256: sample.bundleSha256,
+      daemonPort: sample.daemonPort,
+      fakeProviderPort: sample.fakeProviderPort,
+      deferredTempRoot: sample.deferredTempRoot,
+    },
+  };
+}
+
+function toPairResult(
+  pair: RawPair,
+  sampleIndex: number,
+): FirstOutputPairResult {
+  const controlPosition: 1 | 2 = pair.order === 'AB' ? 1 : 2;
+  const candidatePosition: 1 | 2 = pair.order === 'AB' ? 2 : 1;
+  const control = toProcessRun(pair.control, sampleIndex, controlPosition);
+  const candidate = toProcessRun(
+    pair.candidate,
+    sampleIndex,
+    candidatePosition,
+  );
+  const invalidReasons = [control, candidate].flatMap((run) => {
+    const reasons: string[] = [];
+    if (run.failure) reasons.push(`${run.variant}:${run.failure.code}`);
+    if (run.cleanup.failure) {
+      reasons.push(`${run.variant}:cleanup:${run.cleanup.failure.code}`);
+    }
+    if (run.sessions.some((session) => !session.runEligible)) {
+      reasons.push(`${run.variant}:ineligible_session`);
+    }
+    return reasons;
+  });
+  return {
+    pairIndex: pair.pairIndex,
+    order: pair.order,
+    control,
+    candidate,
+    valid: invalidReasons.length === 0,
+    invalidReason:
+      invalidReasons.length === 0 ? null : invalidReasons.join(', '),
+  };
+}
+
+function sessionMetric(
+  session: FirstOutputSessionRunResult,
+  metric: FirstOutputMetricName,
+): number | null {
+  switch (metric) {
+    case 'processToSessionReadyMs':
+      return session.timings.processToSessionReadyMs;
+    case 'promptToProviderRequestArrivalMs':
+      return session.timings.promptToProviderRequestArrivalMs;
+    case 'promptToFirstModelOutputMs':
+      return session.timings.promptToFirstModelOutputMs;
+    case 'promptToFirstAnswerTextMs':
+      return session.timings.promptToFirstAnswerTextMs;
+    case 'providerReadyToFirstModelOutputMs':
+      return session.timings.providerReadyToFirstModelOutputMs;
+    case 'processToFirstModelOutputMs':
+      return session.timings.processToFirstModelOutputMs;
+    case 'promptToTerminalMs':
+      return session.timings.promptToTerminalMs;
+    case 'processToListenMs':
+      return null;
+  }
+}
+
+function buildSingleMetricSummary(
+  runs: readonly FirstOutputProcessRunResult[],
+  metric: FirstOutputMetricName,
+): FirstOutputSingleMetricSummary {
+  if (metric === 'processToListenMs') {
+    return {
+      all: nullablePercentiles(
+        runs.map((run) =>
+          isSuccessfulRun(run) ? run.processToListenMs : null,
+        ),
+      ),
+      bySession: {},
+    };
+  }
+  const bySession: Record<string, ReturnType<typeof nullablePercentiles>> = {};
+  for (const ordinal of [1, 2] as const) {
+    bySession[`session_${ordinal}`] = nullablePercentiles(
+      runs.map((run) => {
+        if (!isSuccessfulRun(run)) return null;
+        const session = run.sessions.find(
+          (candidate) => candidate.ordinal === ordinal,
+        );
+        return session ? sessionMetric(session, metric) : null;
+      }),
+    );
+  }
+  return {
+    all: null,
+    bySession,
+  };
+}
+
+function buildPairedMetricSummary(
+  pairs: readonly FirstOutputPairResult[],
+  metric: FirstOutputMetricName,
+  seedOffset: number,
+): FirstOutputPairedMetricSummary {
+  if (metric === 'processToListenMs') {
+    return {
+      all: pairedCandidateControlStats(
+        pairs.map((pair) => ({
+          order: pair.order,
+          valid: pair.valid,
+          controlMs: pair.control.processToListenMs,
+          candidateMs: pair.candidate.processToListenMs,
+        })),
+        pairedOptions(seedOffset),
+      ),
+      bySession: {},
+    };
+  }
+
+  const sessionStats = pairedCandidateControlStats(
+    pairs.map((pair) => ({
+      order: pair.order,
+      valid: pair.valid,
+      controlMs: metricForOrdinal(pair.control, 1, metric),
+      candidateMs: metricForOrdinal(pair.candidate, 1, metric),
+    })),
+    pairedOptions(seedOffset),
+  );
+  return {
+    all: null,
+    bySession: { session_1: sessionStats },
+  };
+}
+
+function metricForOrdinal(
+  run: FirstOutputProcessRunResult,
+  ordinal: number,
+  metric: FirstOutputMetricName,
+): number | null {
+  const session = run.sessions.find(
+    (candidate) => candidate.ordinal === ordinal,
+  );
+  return session ? sessionMetric(session, metric) : null;
+}
+
+function pairedOptions(seedOffset: number): {
+  seed: number;
+  bootstrapIterations: number;
+  materialThresholdMs: number;
+  orderSensitivityThresholdMs: number;
+} {
+  return {
+    seed: BOOTSTRAP_SEED + seedOffset,
+    bootstrapIterations: DEFAULT_BOOTSTRAP_ITERATIONS,
+    materialThresholdMs: DEFAULT_MATERIAL_THRESHOLD_MS,
+    orderSensitivityThresholdMs: DEFAULT_ORDER_SENSITIVITY_THRESHOLD_MS,
+  };
+}
+
+function commonArtifactFields(): Pick<
+  FirstOutputBenchmarkArtifactV1,
+  'version' | 'benchmark' | 'capturedAt' | 'harnessGitCommit' | 'platform'
+> {
+  const cpus = os.cpus();
+  const loadAverage = os.loadavg() as [number, number, number];
+  return {
+    version: 1,
+    benchmark: 'daemon-first-output',
+    capturedAt: new Date().toISOString(),
+    harnessGitCommit: gitHead(),
+    platform: {
+      os: process.platform,
+      arch: process.arch,
+      nodeVersion: process.version,
+      cpuModel: cpus[0]?.model ?? 'unknown',
+      logicalCpuCount: cpus.length,
+      availableCpuCount: os.availableParallelism(),
+      totalMemoryBytes: os.totalmem(),
+      loadAverage,
+    },
+  };
+}
+
+function commonConfig(postSessionDwellMs: number): {
+  seed: number;
+  providerDelayMs: number;
+  providerConnection: 'close-per-response';
+  postSessionDwellMs: number;
+  prompt: string;
+  expectedAnswer: string;
+  maxBufferedEvents: number;
+  providerRequestsPerSession: number;
+  timeoutsMs: Record<string, number>;
+} {
+  return {
+    seed: BOOTSTRAP_SEED,
+    providerDelayMs: PROVIDER_DELAY_MS,
+    providerConnection: 'close-per-response',
+    postSessionDwellMs,
+    prompt:
+      `Unique fixed-width ${PROMPT_LENGTH}-character prompt with a ` +
+      'zero-padded per-session marker',
+    expectedAnswer: EXPECTED_ANSWER,
+    maxBufferedEvents: DEFAULT_FIRST_OUTPUT_EVENT_BUFFER_LIMIT,
+    providerRequestsPerSession: 1,
+    timeoutsMs: {
+      daemonBoot: BOOT_TIMEOUT_MS,
+      sdkFetch: SDK_FETCH_TIMEOUT_MS,
+      promptTurn: TURN_TIMEOUT_MS,
+      streamShutdown: PROCESS_EXIT_TIMEOUT_MS,
+      providerShutdown: PROCESS_EXIT_TIMEOUT_MS,
+      processExit: PROCESS_EXIT_TIMEOUT_MS,
+      descendantExit: DESCENDANT_EXIT_TIMEOUT_MS,
+      emergencyCleanup: EMERGENCY_CLEANUP_TIMEOUT_MS,
+      outerTest: BENCHMARK_TEST_TIMEOUT_MS,
+    },
+  };
+}
+
+function variantDescriptor(bundle: ResolvedBundle): {
+  cliPath: string;
+  realpath: string;
+  sha256: string;
+  gitCommit: string | null;
+  compileCache: {
+    policy: 'fixed-private-per-variant-warmed';
+    directory: string;
+  };
+} {
+  return {
+    cliPath: bundle.configuredPath,
+    realpath: bundle.realPath,
+    sha256: bundle.sha256,
+    gitCommit: bundle.gitCommit,
+    compileCache: {
+      policy: 'fixed-private-per-variant-warmed',
+      directory: bundle.compileCacheDir,
+    },
+  };
+}
+
+function buildSingleArtifact(
+  config: SingleBenchmarkConfig,
+  raw: Awaited<ReturnType<typeof runSingleSamples>>,
+): FirstOutputBenchmarkArtifactV1 {
+  const warmupRuns = raw.warmups.map((sample, index) =>
+    toProcessRun(sample, index + 1, null),
+  );
+  const runs = raw.measured.map((sample, index) =>
+    toProcessRun(sample, index + 1, null),
+  );
+  const metrics: Partial<
+    Record<FirstOutputMetricName, FirstOutputSingleMetricSummary>
+  > = {};
+  for (const metric of METRICS) {
+    metrics[metric] = buildSingleMetricSummary(runs, metric);
+  }
+  const successfulRuns = runs.filter(isSuccessfulRun).length;
+  const measuredComplete = runs.length === SINGLE_MEASURED;
+  const measuredValid = measuredComplete && successfulRuns === SINGLE_MEASURED;
+  const warmupsComplete = warmupRuns.length === SINGLE_WARMUPS;
+  const validWarmups = warmupRuns.filter(isSuccessfulRun).length;
+  const warmupsValid = warmupsComplete && validWarmups === SINGLE_WARMUPS;
+  const coldProviderP50 =
+    metrics['promptToProviderRequestArrivalMs']?.bySession['session_1']
+      ?.distribution?.p50 ?? null;
+  const warmProviderP50 =
+    metrics['promptToProviderRequestArrivalMs']?.bySession['session_2']
+      ?.distribution?.p50 ?? null;
+  const coldFirstOutputP50 =
+    metrics['promptToFirstModelOutputMs']?.bySession['session_1']?.distribution
+      ?.p50 ?? null;
+  const complete = warmupsValid && measuredValid;
+  const gate = evaluateSingleBundlePrototypeGate({
+    complete,
+    coldPromptToProviderRequestP50Ms: coldProviderP50,
+    warmPromptToProviderRequestP50Ms: warmProviderP50,
+    coldPromptToFirstModelOutputP50Ms: coldFirstOutputP50,
+  });
+  const providerDeltaMs = gate.providerDeltaMs;
+  const gatePassed = gate.passed;
+  const outcome = !complete
+    ? 'invalid'
+    : gatePassed
+      ? 'prototype_allowed'
+      : 'stop';
+  return {
+    ...commonArtifactFields(),
+    mode: 'single',
+    config: {
+      ...commonConfig(0),
+      warmupRuns: SINGLE_WARMUPS,
+      measuredRuns: SINGLE_MEASURED,
+      variant: variantDescriptor(config.bundle),
+    },
+    warmupRuns,
+    runs,
+    summary: {
+      expectedRuns: SINGLE_MEASURED,
+      successfulRuns,
+      failedRuns: runs.length - successfulRuns,
+      failuresByCode: countRunFailures([...warmupRuns, ...runs]),
+      metrics,
+      decision: {
+        outcome,
+        reasons: [
+          measuredComplete
+            ? `All ${SINGLE_MEASURED} measured processes ran.`
+            : `Only ${runs.length}/${SINGLE_MEASURED} measured processes ran before the first invalid process stopped sampling.`,
+          measuredValid
+            ? `Cold-minus-warm Provider-arrival P50: ${
+                providerDeltaMs === null
+                  ? 'n/a'
+                  : `${providerDeltaMs.toFixed(1)}ms`
+              }.`
+            : `Only ${successfulRuns}/${SINGLE_MEASURED} measured processes were valid.`,
+          warmupsComplete
+            ? `Both compile-cache warmup processes ran.`
+            : `Only ${warmupRuns.length}/${SINGLE_WARMUPS} compile-cache warmup processes ran before the first invalid process stopped sampling.`,
+          warmupsValid
+            ? 'Both compile-cache warmup processes were valid.'
+            : `Only ${validWarmups}/${SINGLE_WARMUPS} compile-cache warmup processes were valid.`,
+          gatePassed
+            ? 'The baseline permits a separate Provider-preparation prototype.'
+            : 'The baseline does not permit production Provider-preparation changes.',
+          'Single-bundle measurements do not claim an optimization.',
+        ],
+        gate: {
+          coldPromptToProviderRequestP50Ms: coldProviderP50,
+          warmPromptToProviderRequestP50Ms: warmProviderP50,
+          providerDeltaMs,
+          coldPromptToFirstModelOutputP50Ms: coldFirstOutputP50,
+          absoluteThresholdMs: gate.absoluteThresholdMs,
+          relativeThresholdRatio: gate.relativeThresholdRatio,
+          passed: gatePassed,
+        },
+      },
+    },
+  };
+}
+
+function buildPairedArtifact(
+  config: CompareBenchmarkConfig,
+  raw: Awaited<ReturnType<typeof runComparisonPairs>>,
+): FirstOutputBenchmarkArtifactV1 {
+  const warmups = raw.warmups.map((pair, index) =>
+    toPairResult(pair, index + 1),
+  );
+  const pairs = raw.measured.map((pair, index) =>
+    toPairResult(pair, index + 1),
+  );
+  const metrics: Partial<
+    Record<FirstOutputMetricName, FirstOutputPairedMetricSummary>
+  > = {};
+  for (const [index, metric] of METRICS.entries()) {
+    metrics[metric] = buildPairedMetricSummary(pairs, metric, index * 10);
+  }
+  const primary =
+    metrics['processToFirstModelOutputMs']?.bySession['session_1'];
+  if (!primary) {
+    throw new Error('Primary paired metric summary was not produced.');
+  }
+  const validPairs = pairs.filter((pair) => pair.valid).length;
+  const measuredComplete = pairs.length === config.measuredPairs;
+  const measuredValid = measuredComplete && validPairs === config.measuredPairs;
+  const warmupsValid =
+    warmups.length === COMPARE_WARMUP_PAIRS &&
+    warmups.every((pair) => pair.valid);
+  const diagnosticOnly = config.measuredPairs === 10;
+  const comparisonOutcome =
+    measuredValid && warmupsValid
+      ? diagnosticOnly
+        ? 'inconclusive'
+        : primary.decision
+      : 'invalid';
+  return {
+    ...commonArtifactFields(),
+    mode: 'paired',
+    config: {
+      ...commonConfig(config.postSessionDwellMs),
+      warmupPairs: COMPARE_WARMUP_PAIRS,
+      measuredPairs: config.measuredPairs,
+      bootstrapIterations: DEFAULT_BOOTSTRAP_ITERATIONS,
+      materialThresholdMs: DEFAULT_MATERIAL_THRESHOLD_MS,
+      orderSensitivityThresholdMs: DEFAULT_ORDER_SENSITIVITY_THRESHOLD_MS,
+      variants: {
+        control: variantDescriptor(config.control),
+        candidate: variantDescriptor(config.candidate),
+      },
+    },
+    warmups,
+    pairs,
+    summary: {
+      expectedPairs: config.measuredPairs,
+      validPairs,
+      invalidPairs: pairs.length - validPairs,
+      failuresByCode: countPairFailures([...warmups, ...pairs]),
+      metrics,
+      decision: {
+        outcome: comparisonOutcome,
+        scope: 'primary_metric_only',
+        publicationGateEvaluated: false,
+        primaryMetric: 'processToFirstModelOutputMs',
+        primarySession: 1,
+        reasons: [
+          ...(diagnosticOnly
+            ? [
+                'The 10-pair 500ms scenario is diagnostic-only and cannot produce a decision-bearing outcome.',
+              ]
+            : []),
+          primary.decisionReason,
+          warmupsValid
+            ? 'Both compile-cache warmup pairs were valid.'
+            : 'At least one compile-cache warmup pair failed.',
+          measuredComplete
+            ? `All ${config.measuredPairs} measured pairs ran.`
+            : `Only ${pairs.length}/${config.measuredPairs} measured pairs ran before the first invalid pair stopped sampling.`,
+          measuredValid
+            ? `All ${config.measuredPairs} measured pairs were valid.`
+            : `Only ${validPairs}/${config.measuredPairs} measured pairs were valid.`,
+          `Session 1 median candidate-control delta: ${
+            primary.medianDeltaMs === null
+              ? 'n/a'
+              : `${primary.medianDeltaMs.toFixed(1)}ms`
+          }.`,
+          'Each comparison arm measures one cold thread session.',
+          'This artifact does not evaluate cross-scenario, resource, or publication gates.',
+        ],
+      },
+    },
+  };
+}
+
+function isSuccessfulRun(run: FirstOutputProcessRunResult): boolean {
+  return (
+    run.failure === null &&
+    run.cleanup.failure === null &&
+    run.sessions.length === SINGLE_SESSIONS_PER_PROCESS &&
+    run.sessions.every((session) => session.runEligible)
+  );
+}
+
+function countRunFailures(
+  runs: readonly FirstOutputProcessRunResult[],
+): Partial<Record<FirstOutputFailureCode, number>> {
+  const counts: Partial<Record<FirstOutputFailureCode, number>> = {};
+  for (const run of runs) {
+    for (const failure of [run.failure, run.cleanup.failure]) {
+      if (!failure) continue;
+      counts[failure.code] = (counts[failure.code] ?? 0) + 1;
+    }
+  }
+  return counts;
+}
+
+function countPairFailures(
+  pairs: readonly FirstOutputPairResult[],
+): Partial<Record<FirstOutputFailureCode, number>> {
+  return countRunFailures(
+    pairs.flatMap((pair) => [pair.control, pair.candidate]),
+  );
+}
+
+function buildFatalArtifact(
+  failure: FirstOutputFailure,
+): FirstOutputBenchmarkArtifactV1 {
+  const hasSingle = Boolean(process.env['BENCHMARK_CLI_PATH']?.trim());
+  const hasPaired = Boolean(
+    process.env['BENCHMARK_CONTROL_CLI_PATH']?.trim() ||
+      process.env['BENCHMARK_CANDIDATE_CLI_PATH']?.trim(),
+  );
+  return {
+    ...commonArtifactFields(),
+    mode: 'failed',
+    config: {
+      requestedMode:
+        hasSingle === hasPaired ? 'unknown' : hasSingle ? 'single' : 'paired',
+    },
+    failure,
+    summary: {
+      failuresByCode: { [failure.code]: 1 },
+      decision: {
+        outcome: 'invalid',
+        reasons: [failure.message],
+      },
+    },
+  };
+}
+
+function gitHead(): string | null {
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+      timeout: 5_000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+async function cleanupActiveResources(): Promise<void> {
+  const failures: unknown[] = [];
+  for (const processGroup of [...activeProcessGroups]) {
+    try {
+      await terminateTrackedProcessGroup(processGroup);
+      activeProcessGroups.delete(processGroup);
+      for (const daemon of activeDaemons) {
+        if (daemon.processGroup === processGroup) {
+          activeDaemons.delete(daemon);
+        }
+      }
+    } catch (error) {
+      failures.push(error);
+    }
+  }
+  for (const fakeProvider of [...activeFakeProviders]) {
+    try {
+      await withTimeout(
+        fakeProvider.close(),
+        PROCESS_EXIT_TIMEOUT_MS,
+        'Fake Provider emergency shutdown',
+      );
+      activeFakeProviders.delete(fakeProvider);
+    } catch (error) {
+      failures.push(error);
+    }
+  }
+  if (failures.length === 0) {
+    for (const tempDir of [...activeTempDirs]) {
+      try {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+        activeTempDirs.delete(tempDir);
+      } catch (error) {
+        failures.push(error);
+      }
+    }
+    for (const cacheDir of [...activeCompileCacheDirs]) {
+      try {
+        fs.rmSync(cacheDir, { recursive: true, force: true });
+        activeCompileCacheDirs.delete(cacheDir);
+      } catch (error) {
+        failures.push(error);
+      }
+    }
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures,
+      'One or more benchmark-owned resources survived emergency cleanup.',
+    );
+  }
+}
+
+(SKIP ? describe.skip : describe).sequential(
+  'daemon first-output benchmark (opt-in, POSIX-only)',
+  { retry: 0 },
+  () => {
+    afterAll(cleanupActiveResources, EMERGENCY_CLEANUP_TIMEOUT_MS);
+
+    it(
+      'records a single baseline or balanced paired comparison',
+      async () => {
+        let artifact: FirstOutputBenchmarkArtifactV1 | undefined;
+        let runError: unknown;
+        let configResolved = false;
+        try {
+          const config = readBenchmarkConfig();
+          configResolved = true;
+          artifact =
+            config.mode === 'single'
+              ? buildSingleArtifact(config, await runSingleSamples(config))
+              : buildPairedArtifact(config, await runComparisonPairs(config));
+        } catch (error) {
+          runError = error;
+          artifact = buildFatalArtifact(
+            firstOutputFailure(
+              error,
+              configResolved ? 'harness_error' : 'invalid_configuration',
+            ),
+          );
+        } finally {
+          if (artifact) {
+            writeSnapshotArtifacts(
+              OUTPUT_DIR,
+              'daemon-first-output-benchmark-v1',
+              artifact,
+              renderFirstOutputBenchmarkMarkdown(artifact),
+              'first-output-benchmark',
+            );
+          }
+        }
+
+        if (runError !== undefined) throw runError;
+        if (
+          artifact.mode === 'failed' ||
+          artifact.summary.decision.outcome === 'invalid'
+        ) {
+          throw new Error(
+            'First-output benchmark produced an invalid artifact.',
+          );
+        }
+      },
+      BENCHMARK_TEST_TIMEOUT_MS,
+    );
+  },
+);

--- a/integration-tests/fake-openai-server.test.ts
+++ b/integration-tests/fake-openai-server.test.ts
@@ -89,6 +89,58 @@ describe('fake OpenAI server', () => {
     expect(server.requests).toHaveLength(2);
   });
 
+  it('can close response connections for isolated latency measurements', async () => {
+    server = await startFakeOpenAIServer(
+      () => ({ content: 'no connection reuse' }),
+      { keepAlive: false },
+    );
+
+    const response = await fetch(`${server.baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        model: 'fake-model',
+        stream: true,
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('connection')).toBe('close');
+    await response.text();
+  });
+
+  it('preserves a caller-requested close for default non-streaming responses', async () => {
+    server = await startFakeOpenAIServer(() => ({ content: 'closed' }));
+
+    const response = await fetch(`${server.baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        connection: 'close',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'fake-model',
+        stream: false,
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('connection')).toBe('close');
+    await response.text();
+  });
+
+  it('closes idempotently', async () => {
+    server = await startFakeOpenAIServer(() => ({ content: 'unused' }));
+
+    const firstClose = server.close();
+    const secondClose = server.close();
+
+    expect(secondClose).toBe(firstClose);
+    await Promise.all([firstClose, secondClose]);
+  });
+
   it('serves non-streaming tool calls with null content', async () => {
     server = await startFakeOpenAIServer(() => ({
       toolCalls: [

--- a/integration-tests/fake-openai-server.ts
+++ b/integration-tests/fake-openai-server.ts
@@ -60,9 +60,12 @@ export type FakeOpenAIServer = {
   close: () => Promise<void>;
 };
 
-export type FakeOpenAIServerOptions =
+export type FakeOpenAIServerOptions = (
   | { listenHost?: undefined; baseUrlHost?: undefined }
-  | { listenHost: string; baseUrlHost: string };
+  | { listenHost: string; baseUrlHost: string }
+) & {
+  keepAlive?: boolean;
+};
 
 export type FakeOpenAIHandler = (ctx: {
   body: JsonObject;
@@ -118,9 +121,19 @@ export async function startFakeOpenAIServer(
 
       const response = await handler({ body, requestIndex });
       if (body['stream'] === true) {
-        writeStreamed(res, getModel(body), response);
+        writeStreamed(
+          res,
+          getModel(body),
+          response,
+          options.keepAlive !== false,
+        );
       } else {
-        writeNonStreamed(res, getModel(body), response);
+        writeNonStreamed(
+          res,
+          getModel(body),
+          response,
+          options.keepAlive !== false,
+        );
       }
     } catch (error) {
       if (error instanceof RequestBodyTooLargeError) {
@@ -167,12 +180,13 @@ export async function startFakeOpenAIServer(
     throw new Error('failed to start fake OpenAI server');
   }
 
+  let closePromise: Promise<void> | undefined;
   return {
     baseUrl: `http://${options.baseUrlHost ?? '127.0.0.1'}:${
       (address as AddressInfo).port
     }/v1`,
     requests,
-    close: () => closeServer(server),
+    close: () => (closePromise ??= closeServer(server)),
   };
 }
 
@@ -219,8 +233,14 @@ function writeNonStreamed(
   res: ServerResponse,
   model: string,
   message: FakeOpenAIResponse,
+  keepAlive: boolean,
 ): void {
-  res.writeHead(200, { 'content-type': 'application/json' });
+  res.writeHead(
+    200,
+    keepAlive
+      ? { 'content-type': 'application/json' }
+      : { connection: 'close', 'content-type': 'application/json' },
+  );
   res.end(
     JSON.stringify({
       id: chatCompletionId(),
@@ -245,10 +265,11 @@ function writeStreamed(
   res: ServerResponse,
   model: string,
   message: FakeOpenAIResponse,
+  keepAlive: boolean,
 ): void {
   res.writeHead(200, {
     'cache-control': 'no-cache',
-    connection: 'keep-alive',
+    connection: keepAlive ? 'keep-alive' : 'close',
     'content-type': 'text/event-stream',
   });
 


### PR DESCRIPTION
## What this PR does

This PR adds an opt-in, measurement-only benchmark for the daemon/ACP path from a fresh process spawn to the first model-derived output. It records process-to-session-ready, prompt-to-Provider-request-arrival, prompt-to-first-model-output, prompt-to-first-answer-text, Provider-ready-to-first-output, and prompt-to-terminal boundaries while leaving production behavior and the existing `ttft_ms` contract unchanged.

The benchmark supports a single-bundle cold-versus-warm baseline and a distinct-bundle paired comparison with balanced AB/BA ordering. Each measured arm uses an isolated process, workspace, home, Qwen home, port set, and warmed per-variant compile cache. Event correlation handles output received before prompt acceptance, locks onto the accepted top-level `promptId`, and distinguishes message, thought, and initial tool-call output from replay, status, usage, role-only, user echo, compression diagnostics, and tool-call updates.

Versioned JSON and Markdown artifacts retain every sample, deterministic failure codes, raw relative timestamps, request counts, cleanup evidence, percentile summaries, seeded paired-median bootstrap confidence intervals, order-sensitivity checks, and the decision gate for a future Provider preload prototype. The fake OpenAI server also closes each benchmark response connection deterministically so a fresh daemon process cannot inherit pooled-connection effects from the harness.

## Why it's needed

The completed cold-session work in #7264 improved session creation, but session timing alone can hide work that moved into the first prompt. A trustworthy end-to-end benchmark is required before changing Core or ACP lifecycle behavior, so any proposed Provider preload is justified by measured local preparation cost rather than network or model latency.

This PR deliberately stops at measurement. A local macOS 2-warmup-plus-50-sample exploratory run completed without invalid samples or residual processes and observed a 26.66 ms cold-versus-warm P50 difference in prompt-to-Provider-request arrival. The formal run on the designated 2-vCPU Linux reference host also completed 50/50 valid measured processes with no residual processes and observed a 56.36 ms cold-versus-warm P50 difference, so Phase 1 permits a separate Provider-preload prototype. Neither single-bundle result claims an optimization.

## Reviewer Test Plan

### How to verify

Reviewers should first run the pure helper and fake-server tests and confirm all 36 cases pass, including text, thought-to-answer, tool-call-only, pre-202 event buffering, exact prompt correlation, error outcomes, deterministic statistics, configuration validation, and idempotent server cleanup. Build and typecheck should then complete without errors.

With a release bundle supplied through `BENCHMARK_CLI_PATH`, enable `QWEN_FIRST_OUTPUT_BENCHMARK=1` and run the benchmark in its default single-bundle mode. It should execute two warmup processes followed by 50 measured fresh processes, measure two independent sessions per process, emit version 1 JSON and Markdown artifacts, report exactly one generation request for every target session, and report no residual daemon/ACP processes or deferred temporary roots. The macOS exploratory run produced 50/50 valid measured processes, cold/warm prompt-to-Provider-request P50 values of 51.66/25.00 ms, and a 26.66 ms gate delta.

The paired compare mode should reject identical bundle realpaths or hashes, require exactly 30 balanced pairs for 0 ms and 100 ms dwell or 10 diagnostic pairs for 500 ms dwell, invalidate rather than replace any failed pair, and mark opposing material AB/BA medians as order-sensitive and inconclusive.

### Evidence (Before & After)

N/A — this PR changes opt-in measurement and test infrastructure only; it has no user-visible or TUI behavior.

### Tested on

|     OS     |        Status         |
| :--------: | :-------------------: |
|  🍏 macOS  |       ✅ tested       |
| 🪟 Windows | N/A — POSIX-only test |
|  🐧 Linux  |       ✅ tested       |

### Environment (optional)

macOS 26.4.1 arm64 with Node.js 22.22.3, plus 2-vCPU Linux x64 with Node.js 22.23.1. Both used a release bundle, `QWEN_SANDBOX=false`, a fixed 50 ms fake-Provider response delay, two warmup processes, 50 measured processes, and isolated warmed compile caches.

## Risk & Scope

- Main risk or tradeoff: The main risk is drawing a performance conclusion from incorrectly correlated events or incomplete process cleanup; the benchmark therefore preserves raw timing and failure evidence, validates exact prompt/request cardinality, and fails closed when descendant enumeration or cleanup cannot be confirmed.
- Not validated / out of scope: Production Provider preload and its paired performance/resource gates belong to a separate PR. Real-Provider performance, TUI/Web Shell paint, prompt cache, compression, network preconnection, model thought/tool behavior, production telemetry, and ACP protocol changes are out of scope.
- Breaking changes / migration notes: None. The benchmark is opt-in, disabled by default, and does not modify production behavior or the existing `ttft_ms` definition.

## Linked Issues

Relates to #7757.

Relates to #7264.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 新增一个按需启用、仅用于测量的 daemon/ACP 基准，从全新进程启动一直记录到首个模型派生输出。它记录进程到 session ready、prompt 到 Provider 请求到达、prompt 到首个模型输出、prompt 到首个回答文本、Provider ready 到首个输出以及 prompt 到 terminal 等边界，同时保持生产行为和现有 `ttft_ms` 契约不变。

基准支持单 bundle 的冷/热 baseline，以及两个不同 bundle 的配对比较，并采用平衡的 AB/BA 顺序。每个测量 arm 都使用隔离的进程、workspace、HOME、QWEN_HOME、端口集合和按 variant 预热的固定编译缓存。事件关联能够处理 prompt 接受响应之前到达的输出，锁定准确的顶层 `promptId`，并将 message、thought 和初始 tool call 输出与 replay、状态、usage、仅 role、user echo、压缩诊断和 tool-call update 区分开。

版本化 JSON 和 Markdown artifact 会保留每个样本、确定性失败码、原始相对时间戳、请求计数、清理证据、百分位汇总、带 seed 的配对中位数 bootstrap 置信区间、顺序敏感性检查，以及未来 Provider 预加载原型的决策门槛。fake OpenAI server 还会确定性关闭每个 benchmark 响应连接，避免新 daemon 进程受到 harness 连接池复用的影响。

## 为什么需要

#7264 中已经完成的冷 session 工作改善了 session 创建时间，但只观察 session 时间可能掩盖被移动到首 prompt 的工作。在修改 Core 或 ACP 生命周期行为前，需要一个可信的端到端 benchmark，确保任何 Provider 预加载提案依据的是本地准备成本，而不是网络或模型延迟。

本 PR 有意止步于测量。本地 macOS 的 2 次 warmup 加 50 个样本探索性运行没有无效样本或残留进程，并观测到 prompt 到 Provider 请求到达的冷/热 P50 差值为 26.66 ms。指定 2-vCPU Linux 参考机上的正式运行同样完成了 50/50 个有效测量进程，没有残留进程，并观测到 56.36 ms 的冷/热 P50 差值，因此 Phase 1 允许制作独立的 Provider 预加载原型。两个单 bundle 结果都不宣称已经取得优化。

## Reviewer 测试计划

### 如何验证

Reviewer 应先运行纯 helper 和 fake-server 测试，确认全部 36 个 case 通过，包括文本、thought 到 answer、仅 tool call、202 前事件缓存、准确 prompt 关联、错误结果、确定性统计、配置校验和幂等 server 清理。随后 build 和 typecheck 应无错误完成。

通过 `BENCHMARK_CLI_PATH` 提供 release bundle，设置 `QWEN_FIRST_OUTPUT_BENCHMARK=1`，并以默认单 bundle 模式运行 benchmark。它应执行 2 个 warmup 进程和 50 个全新测量进程，在每个进程中测量两个独立 session，输出 version 1 JSON 和 Markdown artifact，为每个目标 session 报告恰好一次生成请求，并且不报告残留 daemon/ACP 进程或延迟清理的临时目录。macOS 探索性运行得到 50/50 个有效测量进程，冷/热 prompt 到 Provider 请求 P50 分别为 51.66/25.00 ms，门槛差值为 26.66 ms。

配对 compare 模式应拒绝 realpath 或 hash 相同的 bundle，在 0 ms 和 100 ms dwell 下严格要求 30 个平衡 pair，在 500 ms dwell 下要求 10 个诊断 pair；任何失败 pair 都应被标记为无效而不是被替换；AB/BA 中位数方向相反且达到 material 阈值时，应标记为 order-sensitive 和 inconclusive。

### 证据（Before & After）

N/A — 本 PR 只改变按需启用的测量和测试基础设施，不包含用户可见或 TUI 行为变化。

### 测试平台

|     OS     |          状态           |
| :--------: | :---------------------: |
|  🍏 macOS  |        ✅ 已测试         |
| 🪟 Windows | N/A — 仅支持 POSIX 的测试 |
|  🐧 Linux  |        ✅ 已测试         |

### 环境（可选）

macOS 26.4.1 arm64（Node.js 22.22.3）和 2-vCPU Linux x64（Node.js 22.23.1）。两者均使用 release bundle、`QWEN_SANDBOX=false`、固定 50 ms fake Provider 响应延迟、2 个 warmup 进程、50 个测量进程，以及隔离且已预热的编译缓存。

## 风险与范围

- 主要风险或权衡：主要风险是根据错误关联的事件或不完整的进程清理得出性能结论；因此 benchmark 会保留原始时间和失败证据，校验准确的 prompt/请求基数，并在无法确认后代枚举或清理时 fail closed。
- 未验证/范围外：生产 Provider 预加载及其配对性能/资源门禁属于独立 PR。真实 Provider 性能、TUI/Web Shell paint、prompt cache、压缩、网络预连接、模型 thought/tool 行为、生产 telemetry 和 ACP 协议变更均不在范围内。
- 破坏性变更/迁移说明：无。benchmark 为按需启用且默认关闭，不修改生产行为或现有 `ttft_ms` 定义。

## 关联 Issue

Relates to #7757。

Relates to #7264。

</details>
