### PR TITLE
feat(hooks): Add submitted prompt provenance

### DIFF
--- a/docs/design/submitted-prompt-provenance.md
+++ b/docs/design/submitted-prompt-provenance.md
@@ -83,18 +83,32 @@ while deleting another.
 
 ## Eligibility
 
-| Path                                                                     | `prompt`                   | `submitted_prompt`                               | Rule                                            |
-| ------------------------------------------------------------------------ | -------------------------- | ------------------------------------------------ | ----------------------------------------------- |
-| Fresh interactive TUI submission sent as `UserQuery`                     | Existing model-bound value | Present                                          | Capture the trimmed projection before expansion |
-| Deferred TUI submission that later becomes a fresh turn                  | Existing model-bound value | Present only with complete provenance            | Preserve the sidecar while queued               |
-| Exact cancellation or queue restoration followed by resubmission         | Existing model-bound value | Present only when the restored text is unchanged | Reuse the sidecar only for an exact restoration |
-| Edited or partially known restored input                                 | Existing model-bound value | Absent                                           | Do not guess provenance                         |
-| Same-turn steering input                                                 | Existing behavior          | Absent                                           | Steering is not a fresh supported submission    |
-| Tool result or hook continuation                                         | Existing behavior          | Absent                                           | Preserve legacy continuation behavior           |
-| Retry, cron, notification, or teammate traffic                           | Existing behavior          | Absent                                           | Preserve existing trigger behavior              |
-| Configured `--prompt-interactive` initial prompt                         | Existing model-bound value | Absent                                           | It did not cross the interactive input boundary |
-| Vim NORMAL-mode direct submission                                        | Existing model-bound value | Absent                                           | It bypasses the canonical InputPrompt producer  |
-| ACP, headless, `serve`, SDK, remote input, or accepted speculative input | Existing behavior          | Absent                                           | No producer is added in this change             |
+| Path                                                                               | `prompt`                   | `submitted_prompt`                               | Rule                                            |
+| ---------------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------ | ----------------------------------------------- |
+| Fresh interactive TUI submission sent as `UserQuery`                               | Existing model-bound value | Present                                          | Capture the trimmed projection before expansion |
+| Deferred TUI submission that later becomes a fresh turn                            | Existing model-bound value | Present only with complete provenance            | Preserve the sidecar while queued               |
+| Exact cancellation or queue restoration followed by resubmission                   | Existing model-bound value | Present only when the restored text is unchanged | Reuse the sidecar only for an exact restoration |
+| Edited or partially known restored input                                           | Existing model-bound value | Absent                                           | Do not guess provenance                         |
+| Prompt, command, or shell-history navigation or selected search match              | Existing model-bound value | Absent                                           | History can contain generated expansions        |
+| Prompt restored from the cross-restart stash                                       | Existing model-bound value | Absent                                           | The stash stores text without provenance        |
+| Prompt restored by conversation rewind                                             | Existing model-bound value | Absent                                           | Rewind history stores model-bound text only     |
+| Same-turn steering input                                                           | Existing behavior          | Absent                                           | Steering is not a fresh supported submission    |
+| Tool result or hook continuation                                                   | Existing behavior          | Absent                                           | Preserve legacy continuation behavior           |
+| Retry, cron, notification, or teammate traffic                                     | Existing behavior          | Absent                                           | Preserve existing trigger behavior              |
+| Configured `--prompt-interactive` initial prompt                                   | Existing model-bound value | Absent                                           | It did not cross the interactive input boundary |
+| Non-empty input present while Vim mode is enabled, including after Vim is disabled | Existing model-bound value | Absent                                           | Vim registers do not carry provenance           |
+| ACP, headless, `serve`, SDK, remote input, or accepted speculative input           | Existing behavior          | Absent                                           | No producer is added in this change             |
+
+When restored or provenance-unavailable model-bound input is cleared or
+submitted, the TUI discards its text-buffer undo and redo history before a
+later input can become eligible. This prevents undo from restoring model-bound
+text after its provenance marker or sidecar has been consumed.
+
+Any non-empty input present while Vim is enabled remains ineligible after Vim
+is disabled until the composer is cleared. This conservative rule also covers
+drafts entered before enabling Vim. Vim registers can retain model-bound text
+across buffer clears, so changing modes cannot restore provenance for existing
+content.
 
 The table defines provenance only. Existing event triggering remains unchanged,
 including paths that do not fire `UserPromptSubmit`.
@@ -153,18 +167,19 @@ access controls must match the submitted data. A hook can also copy its input
 into its own output, error, logs, or downstream systems; those destinations are
 outside this field's guarantees.
 
+When both fields are present, prompt-hook payloads contain overlapping text and
+can consume additional model input tokens. This contract does not provide
+per-hook field suppression.
+
 Hook-call telemetry currently exports hook metadata rather than the full input,
 but that implementation detail is not a privacy boundary and consumers should
 not rely on it.
 
 ## Why this differs from Claude Code
 
-In the reviewed Claude Code source, `UserPromptSubmit` runs inside
-`src/utils/processUserInput/processUserInput.ts`, after user-input processing
-decides a request should be queried and before control enters the model query
-loop. Tool-result recursion remains inside `src/query.ts` and does not cross
-that user-input boundary. Consequently, Claude Code's existing `prompt`
-naturally represents the input at its user-submission boundary.
+Claude Code runs `UserPromptSubmit` at its user-submission boundary, before
+control enters the model query loop. Tool-result recursion does not cross that
+boundary, so its existing `prompt` naturally represents submitted input.
 
 Qwen Code runs the hook closer to its shared model-send pipeline and preserves
 legacy behavior across more send paths. Moving the event would be a broader,

--- a/docs/design/submitted-prompt-provenance.md
+++ b/docs/design/submitted-prompt-provenance.md
@@ -5,8 +5,8 @@
 `UserPromptSubmit.prompt` is the prompt for the current model invocation. It can
 contain Qwen-generated reminders, expanded files and resources, slash-command
 output, extension output, or context added by an earlier hook. It therefore
-cannot reliably answer a different question: what text did a person submit at
-the interactive input boundary?
+cannot reliably answer a different question: what text projection crossed a
+supported interactive input boundary?
 
 This change adds an optional `submitted_prompt` field:
 
@@ -50,7 +50,7 @@ Non-goals:
 
 ```mermaid
 flowchart LR
-  U["Interactive TUI submission"] --> C["Capture trimmed submitted text"]
+  U["Interactive TUI submission"] --> C["Capture trimmed text projection"]
   C --> E["Qwen expansion and reminders"]
   C -. "defer or restore" .-> Q["Queue or restore with provenance sidecar"]
   Q --> E["Qwen expansion and reminders"]
@@ -69,19 +69,32 @@ an internal sidecar and is consumed only when the queued text becomes a fresh
 turn. Any ambiguous transformation, partial batch, or edited restoration fails
 closed by omitting `submitted_prompt`.
 
+Large-paste placeholders remain compact in `submitted_prompt`; their full
+content is expanded only into the model-bound `prompt`. This preserves the TUI
+projection and avoids duplicating multi-megabyte pasted content in every hook
+payload.
+
+Cancellation restoration retains ownership of the main turn when a concurrent
+`/btw` side question runs. Because that side question can write a newer user
+entry to disk history, cancellation removes the latest logged entry only when
+the main turn still exclusively owns it. This coupling keeps the restored
+provenance sidecar and persistent history aligned instead of restoring one turn
+while deleting another.
+
 ## Eligibility
 
-| Path                                                                     | `prompt`                   | `submitted_prompt`                               | Rule                                                     |
-| ------------------------------------------------------------------------ | -------------------------- | ------------------------------------------------ | -------------------------------------------------------- |
-| Fresh interactive TUI submission sent as `UserQuery`                     | Existing model-bound value | Present                                          | Capture the trimmed input before reminders and expansion |
-| Deferred TUI submission that later becomes a fresh turn                  | Existing model-bound value | Present only with complete provenance            | Preserve the sidecar while queued                        |
-| Exact cancellation or queue restoration followed by resubmission         | Existing model-bound value | Present only when the restored text is unchanged | Reuse the sidecar only for an exact restoration          |
-| Edited or partially known restored input                                 | Existing model-bound value | Absent                                           | Do not guess provenance                                  |
-| Same-turn steering input                                                 | Existing behavior          | Absent                                           | Steering is not a fresh supported submission             |
-| Tool result or hook continuation                                         | Existing behavior          | Absent                                           | Preserve legacy continuation behavior                    |
-| Retry, cron, notification, or teammate traffic                           | Existing behavior          | Absent                                           | Preserve existing trigger behavior                       |
-| Configured `--prompt-interactive` initial prompt                         | Existing model-bound value | Absent                                           | It did not cross the interactive input boundary          |
-| ACP, headless, `serve`, SDK, remote input, or accepted speculative input | Existing behavior          | Absent                                           | No producer is added in this change                      |
+| Path                                                                     | `prompt`                   | `submitted_prompt`                               | Rule                                            |
+| ------------------------------------------------------------------------ | -------------------------- | ------------------------------------------------ | ----------------------------------------------- |
+| Fresh interactive TUI submission sent as `UserQuery`                     | Existing model-bound value | Present                                          | Capture the trimmed projection before expansion |
+| Deferred TUI submission that later becomes a fresh turn                  | Existing model-bound value | Present only with complete provenance            | Preserve the sidecar while queued               |
+| Exact cancellation or queue restoration followed by resubmission         | Existing model-bound value | Present only when the restored text is unchanged | Reuse the sidecar only for an exact restoration |
+| Edited or partially known restored input                                 | Existing model-bound value | Absent                                           | Do not guess provenance                         |
+| Same-turn steering input                                                 | Existing behavior          | Absent                                           | Steering is not a fresh supported submission    |
+| Tool result or hook continuation                                         | Existing behavior          | Absent                                           | Preserve legacy continuation behavior           |
+| Retry, cron, notification, or teammate traffic                           | Existing behavior          | Absent                                           | Preserve existing trigger behavior              |
+| Configured `--prompt-interactive` initial prompt                         | Existing model-bound value | Absent                                           | It did not cross the interactive input boundary |
+| Vim NORMAL-mode direct submission                                        | Existing model-bound value | Absent                                           | It bypasses the canonical InputPrompt producer  |
+| ACP, headless, `serve`, SDK, remote input, or accepted speculative input | Existing behavior          | Absent                                           | No producer is added in this change             |
 
 The table defines provenance only. Existing event triggering remains unchanged,
 including paths that do not fire `UserPromptSubmit`.
@@ -161,7 +174,8 @@ callers the missing boundary signal while preserving existing integrations.
 ## Verification
 
 Unit tests cover the Core serialization gate, hook chaining, TUI capture,
-deferred queues, exact and edited restoration, provenance clearing, and
-incomplete batches. Interactive E2E coverage captures a real command-hook
-payload and confirms that expansion can change `prompt` without changing
-`submitted_prompt` and that a tool-result continuation omits the field.
+large-paste projection, deferred queues, exact and edited restoration,
+provenance clearing, and incomplete batches. Interactive E2E coverage captures
+a real command-hook payload and confirms that expansion can change `prompt`
+without changing `submitted_prompt` and that a tool-result continuation omits
+the field.

--- a/docs/design/submitted-prompt-provenance.md
+++ b/docs/design/submitted-prompt-provenance.md
@@ -1,0 +1,167 @@
+# Submitted Prompt Provenance for `UserPromptSubmit`
+
+## Summary
+
+`UserPromptSubmit.prompt` is the prompt for the current model invocation. It can
+contain Qwen-generated reminders, expanded files and resources, slash-command
+output, extension output, or context added by an earlier hook. It therefore
+cannot reliably answer a different question: what text did a person submit at
+the interactive input boundary?
+
+This change adds an optional `submitted_prompt` field:
+
+```ts
+interface UserPromptSubmitInput {
+  prompt: string;
+  submitted_prompt?: string;
+}
+```
+
+The field is populated only when Qwen can carry provenance from a supported
+interactive TUI submission to a fresh `UserQuery`. Consumers that require
+user-submitted text must treat a missing field as unavailable and must not fall
+back to `prompt`.
+
+The change does not alter when `UserPromptSubmit` fires, the existing `prompt`
+value, hook ordering or blocking, or `additionalContext` behavior.
+
+## Goals and non-goals
+
+Goals:
+
+- Preserve the text submitted through the supported interactive TUI before
+  Qwen expands it.
+- Carry that text through deferred and restored submissions without associating
+  it with the wrong model request.
+- Add the field without breaking consumers that accept forward-compatible JSON.
+- Make all data recipients and trust boundaries explicit.
+
+Non-goals:
+
+- Changing `UserPromptSubmit` trigger semantics.
+- Inferring an original prompt from model-bound content.
+- Supporting ACP, headless, remote, SDK, or other input producers in this
+  change.
+- Providing authentication, tenant identity, DLP, or an immutable security
+  label.
+- Implementing external-context recall.
+
+## Data flow
+
+```mermaid
+flowchart LR
+  U["Interactive TUI submission"] --> C["Capture trimmed submitted text"]
+  C --> E["Qwen expansion and reminders"]
+  C -. "defer or restore" .-> Q["Queue or restore with provenance sidecar"]
+  Q --> E["Qwen expansion and reminders"]
+  E --> S["Fresh UserQuery send"]
+  C -. "submitted_prompt" .-> H["UserPromptSubmit payload"]
+  S -- "prompt" --> H
+  H --> X["Command, HTTP, function, or prompt hook"]
+  X -- "optional additionalContext" --> S
+
+  N["Tool result, retry, steer, cron, notification, teammate, ACP, headless, or remote input"] --> M["No supported provenance"]
+  M -. "omit submitted_prompt" .-> H
+```
+
+The queue remains text-oriented for rendering. Provenance is associated through
+an internal sidecar and is consumed only when the queued text becomes a fresh
+turn. Any ambiguous transformation, partial batch, or edited restoration fails
+closed by omitting `submitted_prompt`.
+
+## Eligibility
+
+| Path                                                                     | `prompt`                   | `submitted_prompt`                               | Rule                                                     |
+| ------------------------------------------------------------------------ | -------------------------- | ------------------------------------------------ | -------------------------------------------------------- |
+| Fresh interactive TUI submission sent as `UserQuery`                     | Existing model-bound value | Present                                          | Capture the trimmed input before reminders and expansion |
+| Deferred TUI submission that later becomes a fresh turn                  | Existing model-bound value | Present only with complete provenance            | Preserve the sidecar while queued                        |
+| Exact cancellation or queue restoration followed by resubmission         | Existing model-bound value | Present only when the restored text is unchanged | Reuse the sidecar only for an exact restoration          |
+| Edited or partially known restored input                                 | Existing model-bound value | Absent                                           | Do not guess provenance                                  |
+| Same-turn steering input                                                 | Existing behavior          | Absent                                           | Steering is not a fresh supported submission             |
+| Tool result or hook continuation                                         | Existing behavior          | Absent                                           | Preserve legacy continuation behavior                    |
+| Retry, cron, notification, or teammate traffic                           | Existing behavior          | Absent                                           | Preserve existing trigger behavior                       |
+| Configured `--prompt-interactive` initial prompt                         | Existing model-bound value | Absent                                           | It did not cross the interactive input boundary          |
+| ACP, headless, `serve`, SDK, remote input, or accepted speculative input | Existing behavior          | Absent                                           | No producer is added in this change                      |
+
+The table defines provenance only. Existing event triggering remains unchanged,
+including paths that do not fire `UserPromptSubmit`.
+
+## Invariants
+
+1. Core serializes `submitted_prompt` only for a fresh `UserQuery` carrying a
+   non-empty string from a supported producer.
+2. The value is preserved as received by Core; Core does not trim, reconstruct,
+   or derive it from `prompt`.
+3. Sequential `additionalContext` updates may extend `prompt` but do not rewrite
+   `submitted_prompt`.
+4. Recursive and machine-driven sends clear provenance.
+5. A queued batch is attributed only when every included item has compatible
+   provenance. Otherwise the batch omits the field.
+6. A restored sidecar is single-use and applies only to an exact resubmission.
+7. Missing provenance is a normal state, not an error.
+
+## Compatibility and migration
+
+The hook JSON contract is forward-extensible. Decoders should ignore unknown
+fields. Consumers that intentionally reject unknown fields, for example a JSON
+Schema with `additionalProperties: false`, must explicitly allow the optional
+`submitted_prompt` property before upgrading. For a security-sensitive hook,
+strict-decoder failure can change whether an invocation fails open or closed,
+so administrators must test the upgraded payload with the deployed hook before
+rollout.
+
+Existing consumers that read only `prompt` retain their current behavior.
+Source-sensitive consumers should read `submitted_prompt` and skip, ask the
+user, or apply a documented fallback policy when it is absent. Silently using
+`prompt` as the original user text is not a safe fallback.
+
+## Trust and data boundaries
+
+`submitted_prompt` is caller-supplied provenance. It is not an authenticated
+identity, authorization decision, repository binding, or DLP result. It
+inherits trust from the local Qwen process and supported TUI producer; it does
+not establish a new trust boundary. In particular, a function hook receives an
+in-process object and must be treated as trusted code; this design does not
+claim runtime immutability against such a hook.
+
+All configured hook executors receive the event payload:
+
+| Hook type | Recipient                                                 |
+| --------- | --------------------------------------------------------- |
+| Command   | Child process through standard input                      |
+| HTTP      | Configured endpoint through the POST body                 |
+| Function  | Trusted in-process callback                               |
+| Prompt    | Configured model provider after `$ARGUMENTS` substitution |
+
+Operators must treat both `prompt` and `submitted_prompt` as potentially
+sensitive. Prompt hooks send the payload to a model provider. File-backed debug
+logging records the fully expanded prompt-hook request, so its retention and
+access controls must match the submitted data. A hook can also copy its input
+into its own output, error, logs, or downstream systems; those destinations are
+outside this field's guarantees.
+
+Hook-call telemetry currently exports hook metadata rather than the full input,
+but that implementation detail is not a privacy boundary and consumers should
+not rely on it.
+
+## Why this differs from Claude Code
+
+In the reviewed Claude Code source, `UserPromptSubmit` runs inside
+`src/utils/processUserInput/processUserInput.ts`, after user-input processing
+decides a request should be queried and before control enters the model query
+loop. Tool-result recursion remains inside `src/query.ts` and does not cross
+that user-input boundary. Consequently, Claude Code's existing `prompt`
+naturally represents the input at its user-submission boundary.
+
+Qwen Code runs the hook closer to its shared model-send pipeline and preserves
+legacy behavior across more send paths. Moving the event would be a broader,
+breaking semantic change. An additive provenance field gives supported TUI
+callers the missing boundary signal while preserving existing integrations.
+
+## Verification
+
+Unit tests cover the Core serialization gate, hook chaining, TUI capture,
+deferred queues, exact and edited restoration, provenance clearing, and
+incomplete batches. Interactive E2E coverage captures a real command-hook
+payload and confirms that expansion can change `prompt` without changing
+`submitted_prompt` and that a tool-result continuation omits the field.

--- a/docs/users/features/hooks.md
+++ b/docs/users/features/hooks.md
@@ -139,6 +139,8 @@ Function hooks directly call registered JavaScript/TypeScript functions. They ar
 
 Prompt hooks use an LLM to evaluate hook input and return a decision. This is useful for making intelligent decisions based on context, such as determining whether to allow or block an operation.
 
+> **Data handling:** A prompt hook sends its event input to the configured model provider. When file-backed debug logging is enabled, the fully expanded prompt-hook request is also written to the session debug log. Treat hook input and debug logs as potentially sensitive.
+
 **How it works:**
 
 1. The hook input JSON is injected into your prompt using the `$ARGUMENTS` placeholder
@@ -184,7 +186,7 @@ Prompt hooks can be used with most hook events, including:
 - `PostToolUse` - Evaluate tool results and potentially inject context
 - `Stop` - Determine whether to continue or stop
 - `SubagentStop` - Evaluate subagent results
-- `UserPromptSubmit` - Evaluate or enrich user prompts
+- `UserPromptSubmit` - Evaluate or enrich eligible model-bound prompts
 
 **Example: Stop Hook**
 
@@ -235,24 +237,24 @@ When `ok` is `false`, Qwen Code will continue working and use the `reason` as co
 
 Hooks fire at specific points during a Qwen Code session. Different events support different matchers to filter trigger conditions.
 
-| Event                | Triggered When                            | Matcher Target                                                 |
-| :------------------- | :---------------------------------------- | :------------------------------------------------------------- |
-| `PreToolUse`         | Before tool execution                     | Tool id (`write_file`, `read_file`, `run_shell_command`, etc.) |
-| `PostToolUse`        | After successful tool execution           | Tool id                                                        |
-| `PostToolUseFailure` | After tool execution fails                | Tool id                                                        |
-| `UserPromptSubmit`   | After user submits prompt                 | None (always fires)                                            |
-| `SessionStart`       | When session starts or resumes            | Source (`startup`, `resume`, `clear`, `compact`)               |
-| `SessionEnd`         | When session ends                         | Reason (`clear`, `logout`, `prompt_input_exit`, etc.)          |
-| `MessageDisplay`     | Repeatedly, as the reply streams          | None (always fires)                                            |
-| `Stop`               | When Claude prepares to conclude response | None (always fires)                                            |
-| `SubagentStart`      | When subagent starts                      | Agent type (`Bash`, `Explorer`, `Plan`, etc.)                  |
-| `SubagentStop`       | When subagent stops                       | Agent type                                                     |
-| `PreCompact`         | Before conversation compaction            | Trigger (`manual`, `auto`)                                     |
-| `Notification`       | When notifications are sent               | Type (`permission_prompt`, `idle_prompt`, `auth_success`)      |
-| `PermissionRequest`  | When permission dialog is shown           | Tool id                                                        |
-| `PermissionDenied`   | When tool permission is denied            | Tool id                                                        |
-| `TodoCreated`        | When a new todo item is created           | None (always fires)                                            |
-| `TodoCompleted`      | When a todo item is marked as completed   | None (always fires)                                            |
+| Event                | Triggered When                              | Matcher Target                                                 |
+| :------------------- | :------------------------------------------ | :------------------------------------------------------------- |
+| `PreToolUse`         | Before tool execution                       | Tool id (`write_file`, `read_file`, `run_shell_command`, etc.) |
+| `PostToolUse`        | After successful tool execution             | Tool id                                                        |
+| `PostToolUseFailure` | After tool execution fails                  | Tool id                                                        |
+| `UserPromptSubmit`   | Before an eligible prompt reaches the model | None (when emitted)                                            |
+| `SessionStart`       | When session starts or resumes              | Source (`startup`, `resume`, `clear`, `compact`)               |
+| `SessionEnd`         | When session ends                           | Reason (`clear`, `logout`, `prompt_input_exit`, etc.)          |
+| `MessageDisplay`     | Repeatedly, as the reply streams            | None (always fires)                                            |
+| `Stop`               | When Claude prepares to conclude response   | None (always fires)                                            |
+| `SubagentStart`      | When subagent starts                        | Agent type (`Bash`, `Explorer`, `Plan`, etc.)                  |
+| `SubagentStop`       | When subagent stops                         | Agent type                                                     |
+| `PreCompact`         | Before conversation compaction              | Trigger (`manual`, `auto`)                                     |
+| `Notification`       | When notifications are sent                 | Type (`permission_prompt`, `idle_prompt`, `auth_success`)      |
+| `PermissionRequest`  | When permission dialog is shown             | Tool id                                                        |
+| `PermissionDenied`   | When tool permission is denied              | Tool id                                                        |
+| `TodoCreated`        | When a new todo item is created             | None (always fires)                                            |
+| `TodoCompleted`      | When a todo item is marked as completed     | None (always fires)                                            |
 
 ### Matcher Patterns
 
@@ -327,7 +329,18 @@ Hooks fire at specific points during a Qwen Code session. Different events suppo
 
 ### Hook Input Structure
 
-All hooks receive standardized input in JSON format through stdin (command) or POST body (http).
+All hook executors receive the standardized event input. The delivery boundary depends on the executor:
+
+| Hook type  | Input recipient                                                 |
+| :--------- | :-------------------------------------------------------------- |
+| `command`  | Child process through JSON on `stdin`                           |
+| `http`     | Configured endpoint through a JSON `POST` body                  |
+| `function` | Trusted in-process callback                                     |
+| `prompt`   | Configured model provider after the input replaces `$ARGUMENTS` |
+
+Function hooks are trusted code running in the Qwen process. They receive an in-process object, so fields must not be treated as immutable against a function hook.
+
+Qwen does not control whether a hook process, endpoint, callback, or model provider retains or forwards its input. Review each configured executor's data-handling policy.
 
 **Common Fields:**
 
@@ -342,6 +355,8 @@ All hooks receive standardized input in JSON format through stdin (command) or P
 ```
 
 Event-specific fields are added based on the hook type. When running in a subagent, `agent_id` and `agent_type` are additionally included.
+
+Hook input is a forward-extensible JSON contract: new optional fields can be added to existing events. Consumers should ignore unknown fields. A strict decoder that rejects unknown properties must be updated to explicitly allow each new optional field before upgrading Qwen Code. For security-sensitive hooks, a decoder failure can change fail-open or fail-closed behavior, so administrators must validate the upgraded payload against the deployed hook before rollout.
 
 ### Hook Output Structure
 
@@ -491,15 +506,24 @@ The `permissionDecision` value controls whether the tool runs:
 
 #### UserPromptSubmit
 
-**Purpose**: Executed when the user submits a prompt to modify, validate, or enrich the input.
+**Purpose**: Executed before an eligible prompt reaches the model to validate, block, or enrich the current model invocation. The existing event can also occur on continuation paths, so `prompt` must not be assumed to be raw user input.
 
 **Event-specific fields**:
 
 ```json
 {
-  "prompt": "the user's submitted prompt text"
+  "prompt": "current model-bound prompt for this hook invocation",
+  "submitted_prompt": "optional user text captured at a supported interactive TUI submission boundary"
 }
 ```
+
+`submitted_prompt` is optional. It is present only when Qwen can carry provenance from a supported interactive TUI submission to a fresh `UserQuery`. It is omitted for unsupported producers and machine-driven paths such as same-turn steering, tool-result continuations, retries, cron, notifications, and teammate traffic. ACP, headless, `serve`, SDK, and remote-input paths do not produce it in this version.
+
+Deferred input can retain the field when its provenance remains complete. A combined batch retains provenance only when every constituent item has it; edited, partially known, or otherwise ambiguous input omits the field. Consumers that require user-submitted text should treat absence as unavailable rather than falling back to `prompt`.
+
+This field is provenance, not authentication, tenant identity, authorization, or DLP. It is caller-supplied data. Every executor configured for this event receives it; in particular, HTTP hooks send it to their endpoint and prompt hooks send it to their model provider.
+
+Sequential UserPromptSubmit hooks can append `additionalContext` to `prompt`; `submitted_prompt` continues to represent the captured submission. Function hooks are trusted same-process code and are not constrained by an immutability guarantee.
 
 **Output Options**:
 
@@ -1291,7 +1315,7 @@ A PostToolUse HTTP hook that sends all tool execution records to a remote audit 
 
 ### Example 3: User Prompt Validation Hook
 
-A UserPromptSubmit hook that validates user prompts for sensitive information and provides context for long prompts:
+A UserPromptSubmit hook that validates supported interactive TUI submissions for sensitive information and provides context for long prompts. It skips invocations where source provenance is unavailable. The keyword check is illustrative and is not a complete DLP policy:
 
 **prompt_validator.py**
 
@@ -1305,9 +1329,12 @@ try:
     input_data = json.load(sys.stdin)
 except json.JSONDecodeError as e:
     print(f"Error: Invalid JSON input: {e}", file=sys.stderr)
-    exit(1)
+    sys.exit(1)
 
-user_prompt = input_data.get("prompt", "")
+user_prompt = input_data.get("submitted_prompt")
+if user_prompt is None:
+    # Do not mistake model-bound or machine-generated content for raw input.
+    sys.exit(0)
 
 # Sensitive words list
 sensitive_words = ["password", "secret", "token", "api_key"]
@@ -1324,7 +1351,7 @@ for word in sensitive_words:
             }
         }
         print(json.dumps(output))
-        exit(0)
+        sys.exit(0)
 
 # Check prompt length and add warning context if too long
 if len(user_prompt) > 1000:
@@ -1335,10 +1362,10 @@ if len(user_prompt) > 1000:
         }
     }
     print(json.dumps(output))
-    exit(0)
+    sys.exit(0)
 
 # No processing needed for normal cases
-exit(0)
+sys.exit(0)
 ```
 
 ## Troubleshooting
@@ -1347,5 +1374,5 @@ exit(0)
 - Verify hook script permissions and executability
 - Ensure proper JSON formatting in hook outputs
 - Use specific matcher patterns to avoid unintended hook execution
-- Use `--debug` mode to see detailed hook matching and execution information
+- Use `--debug` mode to see detailed hook matching and execution information. Prompt-hook inputs can be written to the session debug log, so apply appropriate access and retention controls.
 - Temporarily disable all hooks: add `"disableAllHooks": true` in settings

--- a/docs/users/features/hooks.md
+++ b/docs/users/features/hooks.md
@@ -237,24 +237,24 @@ When `ok` is `false`, Qwen Code will continue working and use the `reason` as co
 
 Hooks fire at specific points during a Qwen Code session. Different events support different matchers to filter trigger conditions.
 
-| Event                | Triggered When                              | Matcher Target                                                 |
-| :------------------- | :------------------------------------------ | :------------------------------------------------------------- |
-| `PreToolUse`         | Before tool execution                       | Tool id (`write_file`, `read_file`, `run_shell_command`, etc.) |
-| `PostToolUse`        | After successful tool execution             | Tool id                                                        |
-| `PostToolUseFailure` | After tool execution fails                  | Tool id                                                        |
-| `UserPromptSubmit`   | Before an eligible prompt reaches the model | None (when emitted)                                            |
-| `SessionStart`       | When session starts or resumes              | Source (`startup`, `resume`, `clear`, `compact`)               |
-| `SessionEnd`         | When session ends                           | Reason (`clear`, `logout`, `prompt_input_exit`, etc.)          |
-| `MessageDisplay`     | Repeatedly, as the reply streams            | None (always fires)                                            |
-| `Stop`               | When Claude prepares to conclude response   | None (always fires)                                            |
-| `SubagentStart`      | When subagent starts                        | Agent type (`Bash`, `Explorer`, `Plan`, etc.)                  |
-| `SubagentStop`       | When subagent stops                         | Agent type                                                     |
-| `PreCompact`         | Before conversation compaction              | Trigger (`manual`, `auto`)                                     |
-| `Notification`       | When notifications are sent                 | Type (`permission_prompt`, `idle_prompt`, `auth_success`)      |
-| `PermissionRequest`  | When permission dialog is shown             | Tool id                                                        |
-| `PermissionDenied`   | When tool permission is denied              | Tool id                                                        |
-| `TodoCreated`        | When a new todo item is created             | None (always fires)                                            |
-| `TodoCompleted`      | When a todo item is marked as completed     | None (always fires)                                            |
+| Event                | Triggered When                            | Matcher Target                                                 |
+| :------------------- | :---------------------------------------- | :------------------------------------------------------------- |
+| `PreToolUse`         | Before tool execution                     | Tool id (`write_file`, `read_file`, `run_shell_command`, etc.) |
+| `PostToolUse`        | After successful tool execution           | Tool id                                                        |
+| `PostToolUseFailure` | After tool execution fails                | Tool id                                                        |
+| `UserPromptSubmit`   | Before supported model invocations        | None                                                           |
+| `SessionStart`       | When session starts or resumes            | Source (`startup`, `resume`, `clear`, `compact`)               |
+| `SessionEnd`         | When session ends                         | Reason (`clear`, `logout`, `prompt_input_exit`, etc.)          |
+| `MessageDisplay`     | Repeatedly, as the reply streams          | None (always fires)                                            |
+| `Stop`               | When Claude prepares to conclude response | None (always fires)                                            |
+| `SubagentStart`      | When subagent starts                      | Agent type (`Bash`, `Explorer`, `Plan`, etc.)                  |
+| `SubagentStop`       | When subagent stops                       | Agent type                                                     |
+| `PreCompact`         | Before conversation compaction            | Trigger (`manual`, `auto`)                                     |
+| `Notification`       | When notifications are sent               | Type (`permission_prompt`, `idle_prompt`, `auth_success`)      |
+| `PermissionRequest`  | When permission dialog is shown           | Tool id                                                        |
+| `PermissionDenied`   | When tool permission is denied            | Tool id                                                        |
+| `TodoCreated`        | When a new todo item is created           | None (always fires)                                            |
+| `TodoCompleted`      | When a todo item is marked as completed   | None (always fires)                                            |
 
 ### Matcher Patterns
 
@@ -506,7 +506,7 @@ The `permissionDecision` value controls whether the tool runs:
 
 #### UserPromptSubmit
 
-**Purpose**: Executed before an eligible prompt reaches the model to validate, block, or enrich the current model invocation. The existing event can also occur on continuation paths, so `prompt` must not be assumed to be raw user input.
+**Purpose**: Executed before supported model invocations to validate, block, or enrich the current model-bound prompt. The event currently covers `UserQuery`, `ToolResult`, and `Hook` sends, while `Retry`, `Steer`, `Cron`, `Notification`, and `Teammate` sends are skipped. It can therefore occur on continuation paths, and `prompt` must not be assumed to be raw user input.
 
 **Event-specific fields**:
 
@@ -520,6 +520,10 @@ The `permissionDecision` value controls whether the tool runs:
 `submitted_prompt` is optional. It is present only when Qwen can carry provenance from a supported interactive TUI submission to a fresh `UserQuery`. It is omitted for unsupported producers and machine-driven paths such as same-turn steering, tool-result continuations, retries, cron, notifications, and teammate traffic. ACP, headless, `serve`, SDK, and remote-input paths do not produce it in this version.
 
 Deferred input can retain the field when its provenance remains complete. A combined batch retains provenance only when every constituent item has it; edited, partially known, or otherwise ambiguous input omits the field. Consumers that require user-submitted text should treat absence as unavailable rather than falling back to `prompt`.
+
+Large-paste placeholders remain compact in `submitted_prompt`; the expanded pasted content appears only in `prompt`. Consumers should treat the field as a TUI text projection rather than a byte-for-byte record of clipboard input.
+
+Vim NORMAL-mode currently submits through a direct path that bypasses the canonical InputPrompt preparation, so that path omits `submitted_prompt`. Vim INSERT-mode Enter falls through to InputPrompt and remains eligible.
 
 This field is provenance, not authentication, tenant identity, authorization, or DLP. It is caller-supplied data. Every executor configured for this event receives it; in particular, HTTP hooks send it to their endpoint and prompt hooks send it to their model provider.
 
@@ -1313,9 +1317,11 @@ A PostToolUse HTTP hook that sends all tool execution records to a remote audit 
 }
 ```
 
-### Example 3: User Prompt Validation Hook
+### Example 3: Interactive TUI Submitted Prompt Validation Hook
 
 A UserPromptSubmit hook that validates supported interactive TUI submissions for sensitive information and provides context for long prompts. It skips invocations where source provenance is unavailable. The keyword check is illustrative and is not a complete DLP policy:
+
+To inspect the current model-bound content instead, read `prompt`. That field can include generated or expanded content, is not the original user input, and does not imply that `UserPromptSubmit` covers every model send. Do not silently fall back from `submitted_prompt` to `prompt` when source provenance is required.
 
 **prompt_validator.py**
 

--- a/docs/users/features/hooks.md
+++ b/docs/users/features/hooks.md
@@ -519,13 +519,17 @@ The `permissionDecision` value controls whether the tool runs:
 
 `submitted_prompt` is optional. It is present only when Qwen can carry provenance from a supported interactive TUI submission to a fresh `UserQuery`. It is omitted for unsupported producers and machine-driven paths such as same-turn steering, tool-result continuations, retries, cron, notifications, and teammate traffic. ACP, headless, `serve`, SDK, and remote-input paths do not produce it in this version.
 
-Deferred input can retain the field when its provenance remains complete. A combined batch retains provenance only when every constituent item has it; edited, partially known, or otherwise ambiguous input omits the field. Consumers that require user-submitted text should treat absence as unavailable rather than falling back to `prompt`.
+Deferred input can retain the field when its provenance remains complete. A combined batch retains provenance only when every constituent item has it; edited, partially known, or otherwise ambiguous input omits the field. Prompt, command, and shell-history navigation or selected search matches, cross-restart stash restores, and conversation rewind restores also omit it because those paths can surface model-bound text without its original provenance. Consumers that require user-submitted text should treat absence as unavailable rather than falling back to `prompt`.
+
+After restored or provenance-unavailable model-bound input is cleared or submitted, the composer also clears its undo and redo history. This prevents undo from restoring expanded text after its marker or sidecar has been consumed.
 
 Large-paste placeholders remain compact in `submitted_prompt`; the expanded pasted content appears only in `prompt`. Consumers should treat the field as a TUI text projection rather than a byte-for-byte record of clipboard input.
 
-Vim NORMAL-mode currently submits through a direct path that bypasses the canonical InputPrompt preparation, so that path omits `submitted_prompt`. Vim INSERT-mode Enter falls through to InputPrompt and remains eligible.
+Any non-empty input present while Vim mode is enabled omits `submitted_prompt`, including after Vim is disabled, because Vim registers do not carry provenance in this version. This conservative rule also covers drafts entered before enabling Vim. Clearing the composer starts a new eligible input.
 
 This field is provenance, not authentication, tenant identity, authorization, or DLP. It is caller-supplied data. Every executor configured for this event receives it; in particular, HTTP hooks send it to their endpoint and prompt hooks send it to their model provider.
+
+When both fields are present, prompt-hook payloads contain overlapping text and can consume additional model input tokens. There is no per-hook field suppression in this version.
 
 Sequential UserPromptSubmit hooks can append `additionalContext` to `prompt`; `submitted_prompt` continues to represent the captured submission. Function hooks are trusted same-process code and are not constrained by an immutability guarantee.
 
@@ -1319,9 +1323,9 @@ A PostToolUse HTTP hook that sends all tool execution records to a remote audit 
 
 ### Example 3: Interactive TUI Submitted Prompt Validation Hook
 
-A UserPromptSubmit hook that validates supported interactive TUI submissions for sensitive information and provides context for long prompts. It skips invocations where source provenance is unavailable. The keyword check is illustrative and is not a complete DLP policy:
-
 To inspect the current model-bound content instead, read `prompt`. That field can include generated or expanded content, is not the original user input, and does not imply that `UserPromptSubmit` covers every model send. Do not silently fall back from `submitted_prompt` to `prompt` when source provenance is required.
+
+A UserPromptSubmit hook that validates supported interactive TUI submissions for sensitive information and provides context for long prompts. It skips invocations where source provenance is unavailable. The keyword check is illustrative and is not a complete DLP policy:
 
 **prompt_validator.py**
 

--- a/integration-tests/interactive/submitted-prompt-provenance.test.ts
+++ b/integration-tests/interactive/submitted-prompt-provenance.test.ts
@@ -1,0 +1,187 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { join } from 'node:path';
+import {
+  fakeToolCall,
+  startFakeOpenAIServer,
+  type FakeOpenAIServer,
+} from '../fake-openai-server.js';
+import { TestRig, type } from '../test-helper.js';
+
+interface CapturedHookInput {
+  hook_event_name?: unknown;
+  prompt?: unknown;
+  submitted_prompt?: unknown;
+}
+
+describe('submitted prompt provenance', () => {
+  let fakeServer: FakeOpenAIServer | undefined;
+  let rig: TestRig;
+  let savedQwenHome: string | undefined;
+  let savedTrustedFoldersPath: string | undefined;
+
+  beforeEach(() => {
+    rig = new TestRig();
+    savedQwenHome = process.env['QWEN_HOME'];
+    savedTrustedFoldersPath = process.env['QWEN_CODE_TRUSTED_FOLDERS_PATH'];
+  });
+
+  afterEach(async () => {
+    await fakeServer?.close();
+    fakeServer = undefined;
+    await rig.cleanup();
+    if (savedQwenHome === undefined) {
+      delete process.env['QWEN_HOME'];
+    } else {
+      process.env['QWEN_HOME'] = savedQwenHome;
+    }
+    if (savedTrustedFoldersPath === undefined) {
+      delete process.env['QWEN_CODE_TRUSTED_FOLDERS_PATH'];
+    } else {
+      process.env['QWEN_CODE_TRUSTED_FOLDERS_PATH'] = savedTrustedFoldersPath;
+    }
+  });
+
+  it('keeps expanded file content out of submitted_prompt and omits it on tool continuation', async () => {
+    const submittedPrompt = '@context.txt Inspect this context.';
+    const fileCanary = 'EXPANDED_FILE_CANARY_7585';
+
+    await rig.setup('submitted-prompt-provenance', {
+      settings: {
+        memory: {
+          enableManagedAutoMemory: false,
+          enableManagedAutoDream: false,
+        },
+        security: {
+          auth: {
+            selectedType: 'openai',
+          },
+        },
+      },
+    });
+    const qwenHome = join(rig.testDir!, '.qwen-home');
+    const trustedFoldersPath = join(qwenHome, 'trustedFolders.json');
+    rig.mkdir('.qwen-home');
+    rig.createFile(
+      '.qwen-home/settings.json',
+      JSON.stringify({
+        hooks: {
+          UserPromptSubmit: [
+            {
+              hooks: [
+                {
+                  type: 'command',
+                  command: 'node capture-hook-input.mjs',
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+    rig.createFile(
+      '.qwen-home/trustedFolders.json',
+      JSON.stringify({ [rig.testDir!]: 'TRUST_FOLDER' }),
+    );
+    process.env['QWEN_HOME'] = qwenHome;
+    process.env['QWEN_CODE_TRUSTED_FOLDERS_PATH'] = trustedFoldersPath;
+    rig.createFile('context.txt', fileCanary);
+    const toolFile = rig.createFile('tool-result.txt', 'tool result');
+    rig.createFile(
+      'capture-hook-input.mjs',
+      [
+        "import { appendFileSync } from 'node:fs';",
+        "let input = '';",
+        "process.stdin.setEncoding('utf8');",
+        'for await (const chunk of process.stdin) input += chunk;',
+        "appendFileSync('hook-inputs.jsonl', `${input.trimEnd()}\\n`);",
+        "process.stdout.write('{}');",
+      ].join('\n'),
+    );
+
+    fakeServer = await startFakeOpenAIServer(({ requestIndex }) =>
+      requestIndex === 0
+        ? {
+            toolCalls: [
+              fakeToolCall(
+                'read_file',
+                { file_path: toolFile },
+                'call_submitted_prompt_e2e',
+              ),
+            ],
+          }
+        : { content: 'PROVENANCE_E2E_DONE' },
+    );
+
+    const { ptyProcess, promise } = rig.runInteractive(
+      '--auth-type',
+      'openai',
+      '--openai-api-key',
+      'fake-key',
+      '--openai-base-url',
+      fakeServer.baseUrl,
+      '--model',
+      'fake-model',
+    );
+
+    try {
+      const isReady = await rig.waitForText('Type your message', 30_000);
+      expect(isReady, 'CLI did not start in interactive mode').toBe(true);
+
+      await type(ptyProcess, submittedPrompt);
+      await type(ptyProcess, '\r');
+
+      const completed = await rig.waitForText('PROVENANCE_E2E_DONE', 30_000);
+      expect(completed, 'Fake model turn did not complete').toBe(true);
+
+      const capturedBothEvents = await rig.poll(
+        () => {
+          try {
+            return (
+              rig
+                .readFile('hook-inputs.jsonl')
+                .trim()
+                .split('\n')
+                .filter(Boolean).length >= 2
+            );
+          } catch {
+            return false;
+          }
+        },
+        15_000,
+        200,
+      );
+      expect(capturedBothEvents, 'Expected two hook invocations').toBe(true);
+
+      const inputs = rig
+        .readFile('hook-inputs.jsonl')
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as CapturedHookInput);
+
+      expect(inputs).toHaveLength(2);
+      expect(inputs[0]).toMatchObject({
+        hook_event_name: 'UserPromptSubmit',
+        submitted_prompt: submittedPrompt,
+      });
+      expect(inputs[0]?.prompt).toEqual(expect.stringContaining(fileCanary));
+      expect(inputs[0]?.submitted_prompt).not.toEqual(
+        expect.stringContaining(fileCanary),
+      );
+
+      expect(inputs[1]).toMatchObject({
+        hook_event_name: 'UserPromptSubmit',
+      });
+      expect(inputs[1]).not.toHaveProperty('submitted_prompt');
+    } finally {
+      ptyProcess.kill();
+      await promise;
+    }
+  });
+});

--- a/packages/cli/src/i18n/locales/ca.js
+++ b/packages/cli/src/i18n/locales/ca.js
@@ -853,8 +853,8 @@ export default {
     "L'entrada a l'ordre és JSON amb tool_name, tool_input, tool_use_id, error, error_type, is_interrupt i is_timeout.",
   'Input to command is JSON with notification message and type.':
     "L'entrada a l'ordre és JSON amb el missatge de notificació i el tipus.",
-  'Input to command is JSON with original user prompt text.':
-    "L'entrada a l'ordre és JSON amb el text original del missatge de l'usuari.",
+  'Input to command is JSON with "prompt" (the current model-bound prompt) and optional "submitted_prompt" (the supported interactive TUI text projection).':
+    'L’entrada de l’ordre és JSON amb "prompt" (el prompt actual vinculat al model) i el camp opcional "submitted_prompt" (la projecció de text de la TUI interactiva compatible).',
   'Input to command is JSON with command_name, command_args, and expanded prompt text.':
     "L'entrada a l'ordre és JSON amb command_name, command_args i el text del missatge expandit.",
   'Input to command is JSON with session start source.':

--- a/packages/cli/src/i18n/locales/de.js
+++ b/packages/cli/src/i18n/locales/de.js
@@ -799,8 +799,8 @@ export default {
     'Die Eingabe an den Befehl ist JSON mit tool_name, tool_input, tool_use_id, error, error_type, is_interrupt und is_timeout.',
   'Input to command is JSON with notification message and type.':
     'Die Eingabe an den Befehl ist JSON mit Benachrichtigungsnachricht und -typ.',
-  'Input to command is JSON with original user prompt text.':
-    'Die Eingabe an den Befehl ist JSON mit dem ursprünglichen Benutzer-Prompt-Text.',
+  'Input to command is JSON with "prompt" (the current model-bound prompt) and optional "submitted_prompt" (the supported interactive TUI text projection).':
+    'Die Eingabe für den Befehl ist JSON mit "prompt" (dem aktuellen modellgebundenen Prompt) und optional "submitted_prompt" (der Textprojektion der unterstützten interaktiven TUI).',
   'Input to command is JSON with command_name, command_args, and expanded prompt text.':
     'Die Eingabe an den Befehl ist JSON mit command_name, command_args und erweitertem Prompt-Text.',
   'Input to command is JSON with session start source.':

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -1148,8 +1148,8 @@ export default {
     'Input to command is JSON with tool_name, tool_input, tool_use_id, error, error_type, is_interrupt, and is_timeout.',
   'Input to command is JSON with notification message and type.':
     'Input to command is JSON with notification message and type.',
-  'Input to command is JSON with original user prompt text.':
-    'Input to command is JSON with original user prompt text.',
+  'Input to command is JSON with "prompt" (the current model-bound prompt) and optional "submitted_prompt" (the supported interactive TUI text projection).':
+    'Input to command is JSON with "prompt" (the current model-bound prompt) and optional "submitted_prompt" (the supported interactive TUI text projection).',
   'Input to command is JSON with command_name, command_args, and expanded prompt text.':
     'Input to command is JSON with command_name, command_args, and expanded prompt text.',
   'Input to command is JSON with session start source.':

--- a/packages/cli/src/i18n/locales/fr.js
+++ b/packages/cli/src/i18n/locales/fr.js
@@ -868,8 +868,8 @@ export default {
     "L'entrée de la commande est du JSON avec tool_name, tool_input, tool_use_id, error, error_type, is_interrupt et is_timeout.",
   'Input to command is JSON with notification message and type.':
     "L'entrée de la commande est du JSON avec le message et le type de notification.",
-  'Input to command is JSON with original user prompt text.':
-    "L'entrée de la commande est du JSON avec le texte d'invite original de l'utilisateur.",
+  'Input to command is JSON with "prompt" (the current model-bound prompt) and optional "submitted_prompt" (the supported interactive TUI text projection).':
+    'L’entrée de la commande est un JSON avec "prompt" (l’invite actuelle liée au modèle) et, facultativement, "submitted_prompt" (la projection textuelle de l’interface TUI interactive prise en charge).',
   'Input to command is JSON with command_name, command_args, and expanded prompt text.':
     "L'entrée de la commande est du JSON avec command_name, command_args et le texte d'invite développé.",
   'Input to command is JSON with session start source.':

--- a/packages/cli/src/i18n/locales/ja.js
+++ b/packages/cli/src/i18n/locales/ja.js
@@ -584,8 +584,8 @@ export default {
     'コマンドへの入力は tool_name、tool_input、tool_use_id、error、error_type、is_interrupt、is_timeout を持つ JSON です。',
   'Input to command is JSON with notification message and type.':
     'コマンドへの入力は通知メッセージとタイプを持つ JSON です。',
-  'Input to command is JSON with original user prompt text.':
-    'コマンドへの入力は元のユーザープロンプトテキストを持つ JSON です。',
+  'Input to command is JSON with "prompt" (the current model-bound prompt) and optional "submitted_prompt" (the supported interactive TUI text projection).':
+    'コマンド入力は、"prompt"（現在のモデル向けプロンプト）と、オプションの "submitted_prompt"（サポート対象の対話型 TUI で入力されたテキストの投影）を含む JSON です。',
   'Input to command is JSON with command_name, command_args, and expanded prompt text.':
     'コマンドへの入力は command_name、command_args、展開後のプロンプトテキストを持つ JSON です。',
   'Input to command is JSON with session start source.':

--- a/packages/cli/src/i18n/locales/pt.js
+++ b/packages/cli/src/i18n/locales/pt.js
@@ -805,8 +805,8 @@ export default {
     'A entrada para o comando é JSON com tool_name, tool_input, tool_use_id, error, error_type, is_interrupt e is_timeout.',
   'Input to command is JSON with notification message and type.':
     'A entrada para o comando é JSON com mensagem e tipo de notificação.',
-  'Input to command is JSON with original user prompt text.':
-    'A entrada para o comando é JSON com o texto original do prompt do usuário.',
+  'Input to command is JSON with "prompt" (the current model-bound prompt) and optional "submitted_prompt" (the supported interactive TUI text projection).':
+    'A entrada para o comando é JSON com "prompt" (o prompt atual vinculado ao modelo) e o campo opcional "submitted_prompt" (a projeção de texto da TUI interativa compatível).',
   'Input to command is JSON with command_name, command_args, and expanded prompt text.':
     'A entrada para o comando é JSON com command_name, command_args e o texto do prompt expandido.',
   'Input to command is JSON with session start source.':

--- a/packages/cli/src/i18n/locales/ru.js
+++ b/packages/cli/src/i18n/locales/ru.js
@@ -812,8 +812,8 @@ export default {
     'Ввод в команду — это JSON с tool_name, tool_input, tool_use_id, error, error_type, is_interrupt и is_timeout.',
   'Input to command is JSON with notification message and type.':
     'Ввод в команду — это JSON с сообщением уведомления и типом.',
-  'Input to command is JSON with original user prompt text.':
-    'Ввод в команду — это JSON с исходным текстом промпта пользователя.',
+  'Input to command is JSON with "prompt" (the current model-bound prompt) and optional "submitted_prompt" (the supported interactive TUI text projection).':
+    'Ввод команды — JSON с полем "prompt" (текущий промпт, отправляемый модели) и необязательным "submitted_prompt" (текстовая проекция поддерживаемого интерактивного TUI).',
   'Input to command is JSON with command_name, command_args, and expanded prompt text.':
     'Ввод в команду — это JSON с command_name, command_args и развернутым текстом промпта.',
   'Input to command is JSON with session start source.':

--- a/packages/cli/src/i18n/locales/zh-TW.js
+++ b/packages/cli/src/i18n/locales/zh-TW.js
@@ -1057,8 +1057,8 @@ export default {
     '命令輸入為包含 tool_name、tool_input、tool_use_id、error、error_type、is_interrupt 和 is_timeout 的 JSON。',
   'Input to command is JSON with notification message and type.':
     '命令輸入為包含通知消息和類型的 JSON。',
-  'Input to command is JSON with original user prompt text.':
-    '命令輸入為包含原始用戶提示文本的 JSON。',
+  'Input to command is JSON with "prompt" (the current model-bound prompt) and optional "submitted_prompt" (the supported interactive TUI text projection).':
+    '命令輸入為 JSON，其中包含 "prompt"（目前模型側提示）以及選用的 "submitted_prompt"（受支援互動式 TUI 的提交文字投影）。',
   'Input to command is JSON with command_name, command_args, and expanded prompt text.':
     '命令輸入為包含 command_name、command_args 和展開後提示文本的 JSON。',
   'Input to command is JSON with session start source.':

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -1117,8 +1117,8 @@ export default {
     '命令输入为包含 tool_name、tool_input、tool_use_id、error、error_type、is_interrupt 和 is_timeout 的 JSON。',
   'Input to command is JSON with notification message and type.':
     '命令输入为包含通知消息和类型的 JSON。',
-  'Input to command is JSON with original user prompt text.':
-    '命令输入为包含原始用户提示文本的 JSON。',
+  'Input to command is JSON with "prompt" (the current model-bound prompt) and optional "submitted_prompt" (the supported interactive TUI text projection).':
+    '命令输入为 JSON，其中包含 "prompt"（当前模型侧提示）以及可选的 "submitted_prompt"（受支持交互式 TUI 的提交文本投影）。',
   'Input to command is JSON with command_name, command_args, and expanded prompt text.':
     '命令输入为包含 command_name、command_args 和展开后提示文本的 JSON。',
   'Input to command is JSON with session start source.':

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -52,6 +52,7 @@ import ansiEscapes from 'ansi-escapes';
 import {
   type Config,
   makeFakeConfig,
+  SendMessageType,
   type GeminiClient,
   type SubagentManager,
 } from '@qwen-code/qwen-code-core';
@@ -332,7 +333,7 @@ describe('AppContainer State Management', () => {
       getQueuedMessagesText: vi.fn().mockReturnValue(''),
       popAllMessages: vi.fn().mockReturnValue(null),
       drainQueue: vi.fn().mockReturnValue([]),
-      popNextSegment: vi.fn().mockReturnValue(null),
+      popNextTurn: vi.fn().mockReturnValue(null),
     });
     mockedUseAutoAcceptIndicator.mockReturnValue(false);
     mockedUseGitBranchName.mockReturnValue('main');
@@ -1045,7 +1046,7 @@ describe('AppContainer State Management', () => {
         getQueuedMessagesText: vi.fn().mockReturnValue(''),
         popAllMessages: vi.fn().mockReturnValue(null),
         drainQueue: vi.fn().mockReturnValue([]),
-        popNextSegment: vi.fn().mockReturnValue(null),
+        popNextTurn: vi.fn().mockReturnValue(null),
       });
 
       render(
@@ -1061,7 +1062,11 @@ describe('AppContainer State Management', () => {
         deferUntilIdle: true,
       });
 
-      expect(mockQueueMessage).toHaveBeenCalledWith('/btw next turn', true);
+      expect(mockQueueMessage).toHaveBeenCalledWith(
+        '/btw next turn',
+        true,
+        '/btw next turn',
+      );
       expect(mockSubmitQuery).not.toHaveBeenCalled();
     });
 
@@ -1087,7 +1092,7 @@ describe('AppContainer State Management', () => {
         getQueuedMessagesText: vi.fn().mockReturnValue(''),
         popAllMessages: vi.fn().mockReturnValue(null),
         drainQueue: vi.fn().mockReturnValue([]),
-        popNextSegment: vi.fn().mockReturnValue(null),
+        popNextTurn: vi.fn().mockReturnValue(null),
       });
 
       render(
@@ -1101,7 +1106,12 @@ describe('AppContainer State Management', () => {
 
       capturedUIActions.handleFinalSubmit('/btw quick side question');
 
-      expect(mockSubmitQuery).toHaveBeenCalledWith('/btw quick side question');
+      expect(mockSubmitQuery).toHaveBeenCalledWith(
+        '/btw quick side question',
+        SendMessageType.UserQuery,
+        undefined,
+        { submittedPrompt: '/btw quick side question' },
+      );
       expect(mockQueueMessage).not.toHaveBeenCalled();
     });
 
@@ -1127,7 +1137,7 @@ describe('AppContainer State Management', () => {
         getQueuedMessagesText: vi.fn().mockReturnValue(''),
         popAllMessages: vi.fn().mockReturnValue(null),
         drainQueue: vi.fn().mockReturnValue([]),
-        popNextSegment: vi.fn().mockReturnValue(null),
+        popNextTurn: vi.fn().mockReturnValue(null),
       });
 
       render(
@@ -1141,7 +1151,12 @@ describe('AppContainer State Management', () => {
 
       capturedUIActions.handleFinalSubmit('/model');
 
-      expect(mockSubmitQuery).toHaveBeenCalledWith('/model');
+      expect(mockSubmitQuery).toHaveBeenCalledWith(
+        '/model',
+        SendMessageType.UserQuery,
+        undefined,
+        { submittedPrompt: '/model' },
+      );
       expect(mockQueueMessage).not.toHaveBeenCalled();
     });
 
@@ -1168,7 +1183,7 @@ describe('AppContainer State Management', () => {
         getQueuedMessagesText: vi.fn().mockReturnValue(''),
         popAllMessages: vi.fn().mockReturnValue(null),
         drainQueue: vi.fn().mockReturnValue([]),
-        popNextSegment: vi.fn().mockReturnValue(null),
+        popNextTurn: vi.fn().mockReturnValue(null),
       });
 
       render(
@@ -1187,8 +1202,280 @@ describe('AppContainer State Management', () => {
         1,
         '<system-reminder>\nUse list_agents to inspect restored agents.\n' +
           '</system-reminder>\n\ncontinue the review',
+        false,
+        'continue the review',
       );
-      expect(mockQueueMessage).toHaveBeenNthCalledWith(2, 'one more check');
+      expect(mockQueueMessage).toHaveBeenNthCalledWith(
+        2,
+        'one more check',
+        false,
+        'one more check',
+      );
+    });
+
+    it('preserves unchanged queue provenance across the input clear before submit', () => {
+      const modelText =
+        '<system-reminder>\nmanaged context\n</system-reminder>\n\nreview this';
+      const mockQueueMessage = vi.fn();
+      let onBufferChange: ((text: string) => void) | undefined;
+      mockedUseTextBuffer.mockImplementation((options) => {
+        onBufferChange = options.onChange;
+        return {
+          text: '',
+          setText: vi.fn(),
+        };
+      });
+      mockedUseMessageQueue.mockReturnValue({
+        messageQueue: [modelText],
+        addMessage: mockQueueMessage,
+        clearQueue: vi.fn(),
+        getQueuedMessagesText: vi.fn().mockReturnValue(modelText),
+        popAllMessages: vi.fn().mockReturnValue({
+          modelText,
+          submittedPrompt: 'review this',
+        }),
+        drainQueue: vi.fn().mockReturnValue([]),
+        popNextTurn: vi.fn().mockReturnValue(null),
+      });
+
+      render(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+
+      expect(capturedUIActions.popAllQueuedMessages()).toBe(modelText);
+      capturedUIActions.prepareInputSubmission?.(modelText);
+      capturedUIActions.handleFinalSubmit(modelText);
+      act(() => {
+        onBufferChange?.('');
+      });
+
+      expect(mockQueueMessage).toHaveBeenCalledWith(
+        modelText,
+        false,
+        'review this',
+      );
+    });
+
+    it('separates edited restores from same-text history resubmissions', () => {
+      const modelText =
+        '<system-reminder>\nmanaged context\n</system-reminder>\n\nreview this';
+      const mockQueueMessage = vi.fn();
+      let onBufferChange: ((text: string) => void) | undefined;
+      mockedUseTextBuffer.mockImplementation((options) => {
+        onBufferChange = options.onChange;
+        return {
+          text: '',
+          setText: vi.fn(),
+        };
+      });
+      mockedUseMessageQueue.mockReturnValue({
+        messageQueue: [modelText],
+        addMessage: mockQueueMessage,
+        clearQueue: vi.fn(),
+        getQueuedMessagesText: vi.fn().mockReturnValue(modelText),
+        popAllMessages: vi.fn().mockReturnValue({
+          modelText,
+          submittedPrompt: 'review this',
+        }),
+        drainQueue: vi.fn().mockReturnValue([]),
+        popNextTurn: vi.fn().mockReturnValue(null),
+      });
+
+      render(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+
+      expect(capturedUIActions.popAllQueuedMessages()).toBe(modelText);
+      act(() => {
+        onBufferChange?.(`${modelText} with edits`);
+        onBufferChange?.(modelText);
+      });
+      capturedUIActions.handleFinalSubmit(modelText);
+
+      expect(mockQueueMessage).toHaveBeenCalledWith(
+        modelText,
+        false,
+        undefined,
+      );
+
+      mockQueueMessage.mockClear();
+      expect(capturedUIActions.popAllQueuedMessages()).toBe(modelText);
+      capturedUIActions.prepareInputSubmission?.(`${modelText} with edits`);
+      capturedUIActions.handleFinalSubmit(`${modelText} with edits`);
+
+      expect(mockQueueMessage).toHaveBeenCalledWith(
+        `${modelText} with edits`,
+        false,
+        undefined,
+      );
+
+      mockQueueMessage.mockClear();
+      expect(capturedUIActions.popAllQueuedMessages()).toBe(modelText);
+      capturedUIActions.prepareInputSubmission?.(`${modelText} `);
+      capturedUIActions.handleFinalSubmit(`${modelText} `);
+
+      expect(mockQueueMessage).toHaveBeenCalledWith(
+        `${modelText} `,
+        false,
+        undefined,
+      );
+
+      mockQueueMessage.mockClear();
+      expect(capturedUIActions.popAllQueuedMessages()).toBe(modelText);
+      act(() => {
+        onBufferChange?.(`${modelText} with edits`);
+        onBufferChange?.('');
+        onBufferChange?.('fresh prompt');
+      });
+      capturedUIActions.handleFinalSubmit('fresh prompt');
+
+      expect(mockQueueMessage).toHaveBeenCalledWith(
+        'fresh prompt',
+        false,
+        'fresh prompt',
+      );
+
+      mockQueueMessage.mockClear();
+      expect(capturedUIActions.popAllQueuedMessages()).toBe(modelText);
+      capturedUIActions.clearRestoredSubmission?.();
+      capturedUIActions.handleFinalSubmit(modelText);
+
+      expect(mockQueueMessage).toHaveBeenCalledWith(
+        modelText,
+        false,
+        modelText,
+      );
+    });
+
+    it('does not create provenance for a whitespace-only submission', () => {
+      const mockQueueMessage = vi.fn();
+      mockedUseMessageQueue.mockReturnValue({
+        messageQueue: [],
+        addMessage: mockQueueMessage,
+        clearQueue: vi.fn(),
+        getQueuedMessagesText: vi.fn().mockReturnValue(''),
+        popAllMessages: vi.fn().mockReturnValue(null),
+        drainQueue: vi.fn().mockReturnValue([]),
+        popNextTurn: vi.fn().mockReturnValue(null),
+      });
+
+      render(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+
+      capturedUIActions.handleFinalSubmit('   ');
+
+      expect(mockQueueMessage).toHaveBeenCalledWith('   ', false, undefined);
+    });
+
+    it('captures trimmed multiline Unicode input as provenance', () => {
+      const mockQueueMessage = vi.fn();
+      mockedUseMessageQueue.mockReturnValue({
+        messageQueue: [],
+        addMessage: mockQueueMessage,
+        clearQueue: vi.fn(),
+        getQueuedMessagesText: vi.fn().mockReturnValue(''),
+        popAllMessages: vi.fn().mockReturnValue(null),
+        drainQueue: vi.fn().mockReturnValue([]),
+        popNextTurn: vi.fn().mockReturnValue(null),
+      });
+
+      render(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+
+      capturedUIActions.handleFinalSubmit(' \n你好 🌏\nsecond line \n ');
+
+      expect(mockQueueMessage).toHaveBeenCalledWith(
+        ' \n你好 🌏\nsecond line \n ',
+        false,
+        '你好 🌏\nsecond line',
+      );
+    });
+
+    it('uses the explicit pre-attachment text as provenance', () => {
+      const mockQueueMessage = vi.fn();
+      mockedUseMessageQueue.mockReturnValue({
+        messageQueue: [],
+        addMessage: mockQueueMessage,
+        clearQueue: vi.fn(),
+        getQueuedMessagesText: vi.fn().mockReturnValue(''),
+        popAllMessages: vi.fn().mockReturnValue(null),
+        drainQueue: vi.fn().mockReturnValue([]),
+        popNextTurn: vi.fn().mockReturnValue(null),
+      });
+
+      render(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+
+      capturedUIActions.handleFinalSubmit(
+        '@.qwen/tmp/clipboard.png\n\ndescribe this image',
+        { submittedPrompt: 'describe this image' },
+      );
+
+      expect(mockQueueMessage).toHaveBeenCalledWith(
+        '@.qwen/tmp/clipboard.png\n\ndescribe this image',
+        false,
+        'describe this image',
+      );
+    });
+
+    it('omits provenance when a programmatic caller explicitly has none', () => {
+      const mockQueueMessage = vi.fn();
+      mockedUseMessageQueue.mockReturnValue({
+        messageQueue: [],
+        addMessage: mockQueueMessage,
+        clearQueue: vi.fn(),
+        getQueuedMessagesText: vi.fn().mockReturnValue(''),
+        popAllMessages: vi.fn().mockReturnValue(null),
+        drainQueue: vi.fn().mockReturnValue([]),
+        popNextTurn: vi.fn().mockReturnValue(null),
+      });
+
+      render(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+
+      capturedUIActions.handleFinalSubmit('configured initial prompt', {
+        submittedPrompt: undefined,
+      });
+
+      expect(mockQueueMessage).toHaveBeenCalledWith(
+        'configured initial prompt',
+        false,
+        undefined,
+      );
     });
 
     it.each(['exit', 'quit', ':q', ':q!', ':wq', ':wq!'])(
@@ -1212,7 +1499,7 @@ describe('AppContainer State Management', () => {
           getQueuedMessagesText: vi.fn().mockReturnValue(''),
           popAllMessages: vi.fn().mockReturnValue(null),
           drainQueue: vi.fn().mockReturnValue([]),
-          popNextSegment: vi.fn().mockReturnValue(null),
+          popNextTurn: vi.fn().mockReturnValue(null),
         });
 
         render(
@@ -1262,7 +1549,7 @@ describe('AppContainer State Management', () => {
           getQueuedMessagesText: vi.fn().mockReturnValue(''),
           popAllMessages: vi.fn().mockReturnValue(null),
           drainQueue: vi.fn().mockReturnValue([]),
-          popNextSegment: vi.fn().mockReturnValue(null),
+          popNextTurn: vi.fn().mockReturnValue(null),
         });
 
         render(
@@ -1291,7 +1578,12 @@ describe('AppContainer State Management', () => {
     const ON_CANCEL_SUBMIT_ARG_INDEX = 15;
     type CapturedCancelSubmit = (info?: {
       pendingItem: HistoryItemWithoutId | null;
-      lastTurnUserItem: { id: number; text: string } | null;
+      lastTurnUserItem: {
+        id: number;
+        text: string;
+        submittedPrompt?: string;
+      } | null;
+      canUndoLastLoggedUserMessage: boolean;
       turnProducedMeaningfulContent: boolean;
     }) => void;
     let capturedOnCancelSubmit: CapturedCancelSubmit | null = null;
@@ -1302,10 +1594,15 @@ describe('AppContainer State Management', () => {
     // common case (the cancelled turn added the user prompt in the
     // history fixture). Defaults to the fixture's id=1 so the tests
     // that use single-USER history fixtures work without parameterizing.
-    const cancelInfoFor = (text: string, id = 1) =>
+    const cancelInfoFor = (text: string, id = 1, submittedPrompt?: string) =>
       ({
         pendingItem: null,
-        lastTurnUserItem: { id, text },
+        lastTurnUserItem: {
+          id,
+          text,
+          ...(submittedPrompt === undefined ? {} : { submittedPrompt }),
+        },
+        canUndoLastLoggedUserMessage: true,
         turnProducedMeaningfulContent: false,
       }) as const;
 
@@ -1361,7 +1658,7 @@ describe('AppContainer State Management', () => {
         getQueuedMessagesText: vi.fn().mockReturnValue(''),
         popAllMessages: vi.fn().mockReturnValue(null),
         drainQueue: vi.fn().mockReturnValue([]),
-        popNextSegment: vi.fn().mockReturnValue(null),
+        popNextTurn: vi.fn().mockReturnValue(null),
       });
 
       render(
@@ -1430,7 +1727,7 @@ describe('AppContainer State Management', () => {
         getQueuedMessagesText: vi.fn().mockReturnValue(''),
         popAllMessages: vi.fn().mockReturnValue(null),
         drainQueue: vi.fn().mockReturnValue([]),
-        popNextSegment: vi.fn().mockReturnValue(null),
+        popNextTurn: vi.fn().mockReturnValue(null),
       });
 
       render(
@@ -1458,7 +1755,9 @@ describe('AppContainer State Management', () => {
 
     it('moves queued follow-up messages into an empty buffer on cancel', async () => {
       const mockSetText = vi.fn();
-      const mockPopAllMessages = vi.fn().mockReturnValue('queued follow-up');
+      const mockPopAllMessages = vi
+        .fn()
+        .mockReturnValue({ modelText: 'queued follow-up' });
       const mockClearQueue = vi.fn();
       mockedUseTextBuffer.mockReturnValue({
         text: '',
@@ -1485,7 +1784,7 @@ describe('AppContainer State Management', () => {
         getQueuedMessagesText: vi.fn().mockReturnValue('queued follow-up'),
         popAllMessages: mockPopAllMessages,
         drainQueue: vi.fn().mockReturnValue(['queued follow-up']),
-        popNextSegment: vi.fn().mockReturnValue('queued follow-up'),
+        popNextTurn: vi.fn().mockReturnValue({ modelText: 'queued follow-up' }),
       });
 
       render(
@@ -1568,7 +1867,7 @@ describe('AppContainer State Management', () => {
         getQueuedMessagesText: vi.fn().mockReturnValue(''),
         popAllMessages: vi.fn().mockReturnValue(null),
         drainQueue: vi.fn().mockReturnValue([]),
-        popNextSegment: vi.fn().mockReturnValue(null),
+        popNextTurn: vi.fn().mockReturnValue(null),
       });
 
       render(
@@ -1601,6 +1900,144 @@ describe('AppContainer State Management', () => {
       // escape so the cancelled `> prompt` actually disappears from
       // scrollback rather than appearing twice (transcript + input box).
       expect(mockStdout.write).toHaveBeenCalledWith(ansiEscapes.clearTerminal);
+    });
+
+    it('does not remove a newer BTW entry when restoring a cancelled main turn', async () => {
+      const mockSetText = vi.fn();
+      const mockTruncateToItem = vi.fn();
+      const mockRemoveLastUserMessage = vi.fn().mockResolvedValue(true);
+      const mockStripOrphans = vi.fn();
+      mockedUseTextBuffer.mockReturnValue({
+        text: '',
+        setText: mockSetText,
+      });
+      mockedUseHistory.mockReturnValue({
+        history: [
+          { id: 1, type: 'user', text: 'main prompt' },
+          { id: 2, type: 'info', text: 'Request cancelled.' },
+        ],
+        addItem: vi.fn(),
+        updateItem: vi.fn(),
+        clearItems: vi.fn(),
+        loadHistory: vi.fn(),
+        truncateToItem: mockTruncateToItem,
+      });
+      mockedUseLogger.mockReturnValue({
+        getPreviousUserMessages: vi.fn().mockResolvedValue([]),
+        removeLastUserMessage: mockRemoveLastUserMessage,
+      });
+      vi.spyOn(mockConfig, 'getGeminiClient').mockReturnValue({
+        initialize: vi.fn().mockResolvedValue(undefined),
+        setTools: vi.fn().mockResolvedValue(undefined),
+        isInitialized: vi.fn().mockReturnValue(false),
+        stripOrphanedUserEntriesFromHistory: mockStripOrphans,
+      } as unknown as GeminiClient);
+      installCancelCapture({
+        streamingState: 'responding',
+        submitQuery: vi.fn(),
+        initError: null,
+        pendingHistoryItems: [],
+        thought: null,
+        cancelOngoingRequest: vi.fn(),
+        retryLastPrompt: vi.fn(),
+      });
+      mockedUseMessageQueue.mockReturnValue({
+        messageQueue: [],
+        addMessage: vi.fn(),
+        clearQueue: vi.fn(),
+        getQueuedMessagesText: vi.fn().mockReturnValue(''),
+        popAllMessages: vi.fn().mockReturnValue(null),
+        drainQueue: vi.fn().mockReturnValue([]),
+        popNextTurn: vi.fn().mockReturnValue(null),
+      });
+
+      render(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      triggerCancel({
+        ...cancelInfoFor('main prompt'),
+        canUndoLastLoggedUserMessage: false,
+      });
+
+      expect(mockTruncateToItem).toHaveBeenCalledWith(1);
+      expect(mockSetText).toHaveBeenCalledWith('main prompt');
+      expect(mockStripOrphans).toHaveBeenCalled();
+      expect(mockRemoveLastUserMessage).not.toHaveBeenCalled();
+    });
+
+    it('reuses the cancelled turn provenance on an unchanged resubmit', async () => {
+      const modelText =
+        '<system-reminder>\nmanaged context\n</system-reminder>\n\nreview this';
+      const mockSetText = vi.fn();
+      const mockQueueMessage = vi.fn();
+      mockedUseTextBuffer.mockReturnValue({
+        text: '',
+        setText: mockSetText,
+      });
+      mockedUseHistory.mockReturnValue({
+        history: [
+          { id: 1, type: 'user', text: modelText },
+          { id: 2, type: 'info', text: 'Request cancelled.' },
+        ],
+        addItem: vi.fn(),
+        updateItem: vi.fn(),
+        clearItems: vi.fn(),
+        loadHistory: vi.fn(),
+        truncateToItem: vi.fn(),
+      });
+      mockedUseLogger.mockReturnValue({
+        getPreviousUserMessages: vi.fn().mockResolvedValue([]),
+        removeLastUserMessage: vi.fn().mockResolvedValue(true),
+      });
+      installCancelCapture({
+        streamingState: 'responding',
+        submitQuery: vi.fn(),
+        initError: null,
+        pendingHistoryItems: [],
+        thought: null,
+        cancelOngoingRequest: vi.fn(),
+        retryLastPrompt: vi.fn(),
+      });
+      mockedUseMessageQueue.mockReturnValue({
+        messageQueue: [],
+        addMessage: mockQueueMessage,
+        clearQueue: vi.fn(),
+        getQueuedMessagesText: vi.fn().mockReturnValue(''),
+        popAllMessages: vi.fn().mockReturnValue(null),
+        drainQueue: vi.fn().mockReturnValue([]),
+        popNextTurn: vi.fn().mockReturnValue(null),
+      });
+
+      render(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      triggerCancel(cancelInfoFor(modelText, 1, 'review this'));
+      capturedUIActions.handleFinalSubmit(modelText);
+
+      expect(mockSetText).toHaveBeenCalledWith(modelText);
+      expect(mockQueueMessage).toHaveBeenCalledWith(
+        modelText,
+        false,
+        'review this',
+      );
     });
 
     it('does not auto-restore when the cancelled turn did not add a user item (e.g. Cron / slash submit_prompt)', async () => {
@@ -1649,7 +2086,7 @@ describe('AppContainer State Management', () => {
         getQueuedMessagesText: vi.fn().mockReturnValue(''),
         popAllMessages: vi.fn().mockReturnValue(null),
         drainQueue: vi.fn().mockReturnValue([]),
-        popNextSegment: vi.fn().mockReturnValue(null),
+        popNextTurn: vi.fn().mockReturnValue(null),
       });
 
       render(
@@ -1669,6 +2106,7 @@ describe('AppContainer State Management', () => {
       triggerCancel({
         pendingItem: null,
         lastTurnUserItem: null,
+        canUndoLastLoggedUserMessage: false,
         turnProducedMeaningfulContent: false,
       });
 
@@ -1716,7 +2154,7 @@ describe('AppContainer State Management', () => {
         getQueuedMessagesText: vi.fn().mockReturnValue(''),
         popAllMessages: vi.fn().mockReturnValue(null),
         drainQueue: vi.fn().mockReturnValue([]),
-        popNextSegment: vi.fn().mockReturnValue(null),
+        popNextTurn: vi.fn().mockReturnValue(null),
       });
 
       render(
@@ -1735,6 +2173,7 @@ describe('AppContainer State Management', () => {
       triggerCancel({
         pendingItem: null,
         lastTurnUserItem: { id: 1, text: 'a different text' },
+        canUndoLastLoggedUserMessage: true,
         turnProducedMeaningfulContent: false,
       });
 
@@ -1778,7 +2217,7 @@ describe('AppContainer State Management', () => {
         getQueuedMessagesText: vi.fn().mockReturnValue(''),
         popAllMessages: vi.fn().mockReturnValue(null),
         drainQueue: vi.fn().mockReturnValue([]),
-        popNextSegment: vi.fn().mockReturnValue(null),
+        popNextTurn: vi.fn().mockReturnValue(null),
       });
 
       render(
@@ -1843,7 +2282,7 @@ describe('AppContainer State Management', () => {
         getQueuedMessagesText: vi.fn().mockReturnValue(''),
         popAllMessages: vi.fn().mockReturnValue(null),
         drainQueue: vi.fn().mockReturnValue([]),
-        popNextSegment: vi.fn().mockReturnValue(null),
+        popNextTurn: vi.fn().mockReturnValue(null),
       });
 
       render(
@@ -1866,6 +2305,7 @@ describe('AppContainer State Management', () => {
           text: 'partial reply…',
         },
         lastTurnUserItem: { id: 1, text: 'what time is it?' },
+        canUndoLastLoggedUserMessage: true,
         turnProducedMeaningfulContent: false,
       });
 
@@ -1917,7 +2357,7 @@ describe('AppContainer State Management', () => {
         getQueuedMessagesText: vi.fn().mockReturnValue(''),
         popAllMessages: vi.fn().mockReturnValue(null),
         drainQueue: vi.fn().mockReturnValue([]),
-        popNextSegment: vi.fn().mockReturnValue(null),
+        popNextTurn: vi.fn().mockReturnValue(null),
       });
 
       render(
@@ -1937,6 +2377,7 @@ describe('AppContainer State Management', () => {
       triggerCancel({
         pendingItem: { type: 'gemini_thought', text: 'thinking…' },
         lastTurnUserItem: { id: 1, text: 'what time is it?' },
+        canUndoLastLoggedUserMessage: true,
         turnProducedMeaningfulContent: true,
       });
 
@@ -1989,7 +2430,7 @@ describe('AppContainer State Management', () => {
         getQueuedMessagesText: vi.fn().mockReturnValue(''),
         popAllMessages: vi.fn().mockReturnValue(null),
         drainQueue: vi.fn().mockReturnValue([]),
-        popNextSegment: vi.fn().mockReturnValue(null),
+        popNextTurn: vi.fn().mockReturnValue(null),
       });
 
       render(
@@ -2011,6 +2452,7 @@ describe('AppContainer State Management', () => {
       triggerCancel({
         pendingItem: null,
         lastTurnUserItem: { id: 999, text: 'foo' },
+        canUndoLastLoggedUserMessage: true,
         turnProducedMeaningfulContent: false,
       });
 
@@ -2058,7 +2500,7 @@ describe('AppContainer State Management', () => {
         getQueuedMessagesText: vi.fn().mockReturnValue(''),
         popAllMessages: vi.fn().mockReturnValue(null),
         drainQueue: vi.fn().mockReturnValue([]),
-        popNextSegment: vi.fn().mockReturnValue(null),
+        popNextTurn: vi.fn().mockReturnValue(null),
       });
 
       render(
@@ -2119,9 +2561,11 @@ describe('AppContainer State Management', () => {
         addMessage: vi.fn(),
         clearQueue: vi.fn(),
         getQueuedMessagesText: vi.fn().mockReturnValue('queued thought'),
-        popAllMessages: vi.fn().mockReturnValue('queued thought'),
+        popAllMessages: vi
+          .fn()
+          .mockReturnValue({ modelText: 'queued thought' }),
         drainQueue: vi.fn().mockReturnValue([]),
-        popNextSegment: vi.fn().mockReturnValue('queued thought'),
+        popNextTurn: vi.fn().mockReturnValue({ modelText: 'queued thought' }),
       });
 
       render(
@@ -2198,7 +2642,7 @@ describe('AppContainer State Management', () => {
         getQueuedMessagesText: vi.fn().mockReturnValue(''),
         popAllMessages: vi.fn().mockReturnValue(null),
         drainQueue: vi.fn().mockReturnValue([]),
-        popNextSegment: vi.fn().mockReturnValue(null),
+        popNextTurn: vi.fn().mockReturnValue(null),
       });
 
       render(
@@ -2235,7 +2679,9 @@ describe('AppContainer State Management', () => {
       // Mirrors claude-code's popAllEditable behaviour.
       const mockSetText = vi.fn();
       const mockClearQueue = vi.fn();
-      const mockPopAllMessages = vi.fn().mockReturnValue('/model\n\nhi');
+      const mockPopAllMessages = vi
+        .fn()
+        .mockReturnValue({ modelText: '/model\n\nhi' });
       mockedUseTextBuffer.mockReturnValue({
         text: '',
         setText: mockSetText,
@@ -2271,7 +2717,7 @@ describe('AppContainer State Management', () => {
         getQueuedMessagesText: vi.fn().mockReturnValue('/model\n\nhi'),
         popAllMessages: mockPopAllMessages,
         drainQueue: vi.fn().mockReturnValue([]),
-        popNextSegment: vi.fn().mockReturnValue('/model'),
+        popNextTurn: vi.fn().mockReturnValue({ modelText: '/model' }),
       });
 
       render(
@@ -2319,9 +2765,11 @@ describe('AppContainer State Management', () => {
         addMessage: vi.fn(),
         clearQueue: vi.fn(),
         getQueuedMessagesText: vi.fn().mockReturnValue('queued follow-up'),
-        popAllMessages: vi.fn().mockReturnValue('queued follow-up'),
+        popAllMessages: vi
+          .fn()
+          .mockReturnValue({ modelText: 'queued follow-up' }),
         drainQueue: vi.fn().mockReturnValue(['queued follow-up']),
-        popNextSegment: vi.fn().mockReturnValue('queued follow-up'),
+        popNextTurn: vi.fn().mockReturnValue({ modelText: 'queued follow-up' }),
       });
 
       render(

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -1060,6 +1060,7 @@ describe('AppContainer State Management', () => {
 
       capturedUIActions.handleFinalSubmit('/btw next turn', {
         deferUntilIdle: true,
+        submittedPrompt: '/btw next turn',
       });
 
       expect(mockQueueMessage).toHaveBeenCalledWith(
@@ -1104,7 +1105,9 @@ describe('AppContainer State Management', () => {
         />,
       );
 
-      capturedUIActions.handleFinalSubmit('/btw quick side question');
+      capturedUIActions.handleFinalSubmit('/btw quick side question', {
+        submittedPrompt: '/btw quick side question',
+      });
 
       expect(mockSubmitQuery).toHaveBeenCalledWith(
         '/btw quick side question',
@@ -1149,7 +1152,9 @@ describe('AppContainer State Management', () => {
         />,
       );
 
-      capturedUIActions.handleFinalSubmit('/model');
+      capturedUIActions.handleFinalSubmit('/model', {
+        submittedPrompt: '/model',
+      });
 
       expect(mockSubmitQuery).toHaveBeenCalledWith(
         '/model',
@@ -1195,8 +1200,12 @@ describe('AppContainer State Management', () => {
         />,
       );
 
-      capturedUIActions.handleFinalSubmit('continue the review');
-      capturedUIActions.handleFinalSubmit('one more check');
+      capturedUIActions.handleFinalSubmit('continue the review', {
+        submittedPrompt: 'continue the review',
+      });
+      capturedUIActions.handleFinalSubmit('one more check', {
+        submittedPrompt: 'one more check',
+      });
 
       expect(mockQueueMessage).toHaveBeenNthCalledWith(
         1,
@@ -1248,8 +1257,9 @@ describe('AppContainer State Management', () => {
       );
 
       expect(capturedUIActions.popAllQueuedMessages()).toBe(modelText);
-      capturedUIActions.prepareInputSubmission?.(modelText);
-      capturedUIActions.handleFinalSubmit(modelText);
+      capturedUIActions.handleFinalSubmit(modelText, {
+        submittedPrompt: modelText,
+      });
       act(() => {
         onBufferChange?.('');
       });
@@ -1300,7 +1310,9 @@ describe('AppContainer State Management', () => {
         onBufferChange?.(`${modelText} with edits`);
         onBufferChange?.(modelText);
       });
-      capturedUIActions.handleFinalSubmit(modelText);
+      capturedUIActions.handleFinalSubmit(modelText, {
+        submittedPrompt: modelText,
+      });
 
       expect(mockQueueMessage).toHaveBeenCalledWith(
         modelText,
@@ -1310,8 +1322,9 @@ describe('AppContainer State Management', () => {
 
       mockQueueMessage.mockClear();
       expect(capturedUIActions.popAllQueuedMessages()).toBe(modelText);
-      capturedUIActions.prepareInputSubmission?.(`${modelText} with edits`);
-      capturedUIActions.handleFinalSubmit(`${modelText} with edits`);
+      capturedUIActions.handleFinalSubmit(`${modelText} with edits`, {
+        submittedPrompt: `${modelText} with edits`,
+      });
 
       expect(mockQueueMessage).toHaveBeenCalledWith(
         `${modelText} with edits`,
@@ -1321,8 +1334,9 @@ describe('AppContainer State Management', () => {
 
       mockQueueMessage.mockClear();
       expect(capturedUIActions.popAllQueuedMessages()).toBe(modelText);
-      capturedUIActions.prepareInputSubmission?.(`${modelText} `);
-      capturedUIActions.handleFinalSubmit(`${modelText} `);
+      capturedUIActions.handleFinalSubmit(`${modelText} `, {
+        submittedPrompt: `${modelText} `,
+      });
 
       expect(mockQueueMessage).toHaveBeenCalledWith(
         `${modelText} `,
@@ -1337,7 +1351,9 @@ describe('AppContainer State Management', () => {
         onBufferChange?.('');
         onBufferChange?.('fresh prompt');
       });
-      capturedUIActions.handleFinalSubmit('fresh prompt');
+      capturedUIActions.handleFinalSubmit('fresh prompt', {
+        submittedPrompt: 'fresh prompt',
+      });
 
       expect(mockQueueMessage).toHaveBeenCalledWith(
         'fresh prompt',
@@ -1347,8 +1363,10 @@ describe('AppContainer State Management', () => {
 
       mockQueueMessage.mockClear();
       expect(capturedUIActions.popAllQueuedMessages()).toBe(modelText);
-      capturedUIActions.clearRestoredSubmission?.();
-      capturedUIActions.handleFinalSubmit(modelText);
+      capturedUIActions.clearRestoredSubmission();
+      capturedUIActions.handleFinalSubmit(modelText, {
+        submittedPrompt: modelText,
+      });
 
       expect(mockQueueMessage).toHaveBeenCalledWith(
         modelText,
@@ -1378,7 +1396,9 @@ describe('AppContainer State Management', () => {
         />,
       );
 
-      capturedUIActions.handleFinalSubmit('   ');
+      capturedUIActions.handleFinalSubmit('   ', {
+        submittedPrompt: '   ',
+      });
 
       expect(mockQueueMessage).toHaveBeenCalledWith('   ', false, undefined);
     });
@@ -1404,7 +1424,9 @@ describe('AppContainer State Management', () => {
         />,
       );
 
-      capturedUIActions.handleFinalSubmit(' \n你好 🌏\nsecond line \n ');
+      capturedUIActions.handleFinalSubmit(' \n你好 🌏\nsecond line \n ', {
+        submittedPrompt: ' \n你好 🌏\nsecond line \n ',
+      });
 
       expect(mockQueueMessage).toHaveBeenCalledWith(
         ' \n你好 🌏\nsecond line \n ',
@@ -1446,7 +1468,7 @@ describe('AppContainer State Management', () => {
       );
     });
 
-    it('omits provenance when a programmatic caller explicitly has none', () => {
+    it('omits provenance when a programmatic caller does not opt in', () => {
       const mockQueueMessage = vi.fn();
       mockedUseMessageQueue.mockReturnValue({
         messageQueue: [],
@@ -1467,12 +1489,50 @@ describe('AppContainer State Management', () => {
         />,
       );
 
-      capturedUIActions.handleFinalSubmit('configured initial prompt', {
-        submittedPrompt: undefined,
-      });
+      capturedUIActions.handleFinalSubmit('configured initial prompt');
 
       expect(mockQueueMessage).toHaveBeenCalledWith(
         'configured initial prompt',
+        false,
+        undefined,
+      );
+    });
+
+    it('keeps restored direct Vim submissions fail closed', () => {
+      const modelText =
+        '<system-reminder>\nmanaged context\n</system-reminder>\n\nvim prompt';
+      const mockQueueMessage = vi.fn();
+      mockedUseMessageQueue.mockReturnValue({
+        messageQueue: [modelText],
+        addMessage: mockQueueMessage,
+        clearQueue: vi.fn(),
+        getQueuedMessagesText: vi.fn().mockReturnValue(modelText),
+        popAllMessages: vi.fn().mockReturnValue({
+          modelText,
+          submittedPrompt: 'vim prompt',
+        }),
+        drainQueue: vi.fn().mockReturnValue([]),
+        popNextTurn: vi.fn().mockReturnValue(null),
+      });
+
+      render(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+
+      expect(capturedUIActions.popAllQueuedMessages()).toBe(modelText);
+      const vimSubmit = mockedUseVim.mock.calls.at(-1)?.[1];
+      if (typeof vimSubmit !== 'function') {
+        throw new Error('useVim did not receive its submit callback');
+      }
+      vimSubmit(modelText);
+
+      expect(mockQueueMessage).toHaveBeenCalledWith(
+        modelText,
         false,
         undefined,
       );
@@ -2030,7 +2090,9 @@ describe('AppContainer State Management', () => {
       await Promise.resolve();
 
       triggerCancel(cancelInfoFor(modelText, 1, 'review this'));
-      capturedUIActions.handleFinalSubmit(modelText);
+      capturedUIActions.handleFinalSubmit(modelText, {
+        submittedPrompt: modelText,
+      });
 
       expect(mockSetText).toHaveBeenCalledWith(modelText);
       expect(mockQueueMessage).toHaveBeenCalledWith(

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -32,7 +32,7 @@ import {
   type Mock,
 } from 'vitest';
 import { render, cleanup } from 'ink-testing-library';
-import { useContext, act } from 'react';
+import { useContext, useState, act } from 'react';
 import {
   AppContainer,
   dedupeNewestFirst,
@@ -152,6 +152,7 @@ vi.mock('./contexts/AgentViewContext.js', () => ({
 }));
 vi.mock('./components/shared/text-buffer.js');
 vi.mock('./hooks/useLogger.js');
+vi.mock('../services/prompt-stash.js');
 
 // Mock external utilities
 vi.mock('../utils/events.js');
@@ -185,6 +186,7 @@ import { useLoadingIndicator } from './hooks/useLoadingIndicator.js';
 import { useTerminalSize } from './hooks/useTerminalSize.js';
 import { useKeypress, type Key } from './hooks/useKeypress.js';
 import { ShellExecutionService } from '@qwen-code/qwen-code-core';
+import { restorePromptStash } from '../services/prompt-stash.js';
 
 describe('AppContainer State Management', () => {
   let mockConfig: Config;
@@ -216,6 +218,7 @@ describe('AppContainer State Management', () => {
   const mockedUseLoadingIndicator = useLoadingIndicator as Mock;
   const mockedUseTerminalSize = useTerminalSize as Mock;
   const mockedUseKeypress = useKeypress as Mock;
+  const mockedRestorePromptStash = vi.mocked(restorePromptStash);
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -362,6 +365,7 @@ describe('AppContainer State Management', () => {
       getPreviousUserMessages: vi.fn().mockResolvedValue([]),
       removeLastUserMessage: vi.fn().mockResolvedValue(false),
     });
+    mockedRestorePromptStash.mockReturnValue(false);
     mockedUseLoadingIndicator.mockReturnValue({
       elapsedTime: '0.0s',
       currentLoadingPhrase: '',
@@ -500,6 +504,16 @@ describe('AppContainer State Management', () => {
       text: '',
       setText,
     });
+    const addMessage = vi.fn();
+    mockedUseMessageQueue.mockReturnValue({
+      messageQueue: [],
+      addMessage,
+      clearQueue: vi.fn(),
+      getQueuedMessagesText: vi.fn().mockReturnValue(''),
+      popAllMessages: vi.fn().mockReturnValue(null),
+      drainQueue: vi.fn().mockReturnValue([]),
+      popNextTurn: vi.fn().mockReturnValue(null),
+    });
 
     const apiHistory = options.apiHistory ?? [
       apiUser('first prompt'),
@@ -561,6 +575,7 @@ describe('AppContainer State Management', () => {
       addItem,
       loadHistory,
       setText,
+      addMessage,
       rewind,
       getHistoryShallow,
       truncateHistory,
@@ -1363,7 +1378,7 @@ describe('AppContainer State Management', () => {
 
       mockQueueMessage.mockClear();
       expect(capturedUIActions.popAllQueuedMessages()).toBe(modelText);
-      capturedUIActions.clearRestoredSubmission();
+      capturedUIActions.invalidateSubmittedPromptProvenance();
       capturedUIActions.handleFinalSubmit(modelText, {
         submittedPrompt: modelText,
       });
@@ -1371,7 +1386,120 @@ describe('AppContainer State Management', () => {
       expect(mockQueueMessage).toHaveBeenCalledWith(
         modelText,
         false,
-        modelText,
+        undefined,
+      );
+    });
+
+    it('treats a restored prompt stash as provenance unavailable', () => {
+      const stashedText =
+        '<system-reminder>\ngenerated context\n</system-reminder>\n\nuser text';
+      const mockQueueMessage = vi.fn();
+      const setText = vi.fn();
+      mockedUseTextBuffer.mockImplementation(() => ({
+        text: '',
+        setText,
+      }));
+      mockedRestorePromptStash.mockImplementation(
+        (_targetDir, _currentText, onRestore) => {
+          onRestore(stashedText);
+          return true;
+        },
+      );
+      mockedUseMessageQueue.mockReturnValue({
+        messageQueue: [],
+        addMessage: mockQueueMessage,
+        clearQueue: vi.fn(),
+        getQueuedMessagesText: vi.fn().mockReturnValue(''),
+        popAllMessages: vi.fn().mockReturnValue(null),
+        drainQueue: vi.fn().mockReturnValue([]),
+        popNextTurn: vi.fn().mockReturnValue(null),
+      });
+
+      render(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+
+      expect(setText).toHaveBeenCalledWith(stashedText);
+      capturedUIActions.handleFinalSubmit(stashedText, {
+        submittedPrompt: stashedText,
+      });
+
+      expect(mockQueueMessage).toHaveBeenCalledWith(
+        stashedText,
+        false,
+        undefined,
+      );
+      expect(setText).toHaveBeenLastCalledWith('', {
+        clearUndoHistory: true,
+      });
+      expect(setText).toHaveBeenCalledWith(stashedText);
+      expect(setText).toHaveBeenCalledTimes(2);
+    });
+
+    it('clears restored prompt undo history after a manual clear', () => {
+      const stashedText =
+        '<system-reminder>\ngenerated context\n</system-reminder>\n\nuser text';
+      const addMessage = vi.fn();
+      let currentText = '';
+      let onBufferChange: ((text: string) => void) | undefined;
+      const setText = vi.fn((text: string) => {
+        currentText = text;
+      });
+      mockedUseTextBuffer.mockImplementation((options) => {
+        onBufferChange = options.onChange;
+        return {
+          get text() {
+            return currentText;
+          },
+          setText,
+        };
+      });
+      mockedRestorePromptStash.mockImplementation(
+        (_targetDir, _currentText, onRestore) => {
+          onRestore(stashedText);
+          return true;
+        },
+      );
+      mockedUseMessageQueue.mockReturnValue({
+        messageQueue: [],
+        addMessage,
+        clearQueue: vi.fn(),
+        getQueuedMessagesText: vi.fn().mockReturnValue(''),
+        popAllMessages: vi.fn().mockReturnValue(null),
+        drainQueue: vi.fn().mockReturnValue([]),
+        popNextTurn: vi.fn().mockReturnValue(null),
+      });
+
+      render(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+
+      act(() => {
+        currentText = '';
+        onBufferChange?.('');
+      });
+
+      expect(setText).toHaveBeenLastCalledWith('', {
+        clearUndoHistory: true,
+      });
+
+      capturedUIActions.handleFinalSubmit('fresh prompt', {
+        submittedPrompt: 'fresh prompt',
+      });
+      expect(addMessage).toHaveBeenCalledWith(
+        'fresh prompt',
+        false,
+        'fresh prompt',
       );
     });
 
@@ -1468,8 +1596,21 @@ describe('AppContainer State Management', () => {
       );
     });
 
-    it('omits provenance when a programmatic caller does not opt in', () => {
+    it('does not consume composer provenance for a programmatic submission', () => {
+      const stashedText =
+        '<system-reminder>\ngenerated context\n</system-reminder>\n\nuser text';
       const mockQueueMessage = vi.fn();
+      const setText = vi.fn();
+      mockedUseTextBuffer.mockImplementation(() => ({
+        text: '',
+        setText,
+      }));
+      mockedRestorePromptStash.mockImplementation(
+        (_targetDir, _currentText, onRestore) => {
+          onRestore(stashedText);
+          return true;
+        },
+      );
       mockedUseMessageQueue.mockReturnValue({
         messageQueue: [],
         addMessage: mockQueueMessage,
@@ -1489,6 +1630,7 @@ describe('AppContainer State Management', () => {
         />,
       );
 
+      expect(setText).toHaveBeenCalledWith(stashedText);
       capturedUIActions.handleFinalSubmit('configured initial prompt');
 
       expect(mockQueueMessage).toHaveBeenCalledWith(
@@ -1496,21 +1638,33 @@ describe('AppContainer State Management', () => {
         false,
         undefined,
       );
+      expect(setText).toHaveBeenCalledTimes(1);
+
+      capturedUIActions.handleFinalSubmit(stashedText, {
+        submittedPrompt: stashedText,
+      });
+      expect(mockQueueMessage).toHaveBeenLastCalledWith(
+        stashedText,
+        false,
+        undefined,
+      );
+      expect(setText).toHaveBeenCalledWith('', {
+        clearUndoHistory: true,
+      });
     });
 
-    it('keeps restored direct Vim submissions fail closed', () => {
-      const modelText =
-        '<system-reminder>\nmanaged context\n</system-reminder>\n\nvim prompt';
+    it('omits provenance while Vim mode is enabled', () => {
       const mockQueueMessage = vi.fn();
+      mockedUseVimModeState.mockReturnValue({
+        vimEnabled: true,
+        vimMode: 'INSERT',
+      });
       mockedUseMessageQueue.mockReturnValue({
-        messageQueue: [modelText],
+        messageQueue: [],
         addMessage: mockQueueMessage,
         clearQueue: vi.fn(),
-        getQueuedMessagesText: vi.fn().mockReturnValue(modelText),
-        popAllMessages: vi.fn().mockReturnValue({
-          modelText,
-          submittedPrompt: 'vim prompt',
-        }),
+        getQueuedMessagesText: vi.fn().mockReturnValue(''),
+        popAllMessages: vi.fn().mockReturnValue(null),
         drainQueue: vi.fn().mockReturnValue([]),
         popNextTurn: vi.fn().mockReturnValue(null),
       });
@@ -1524,15 +1678,62 @@ describe('AppContainer State Management', () => {
         />,
       );
 
-      expect(capturedUIActions.popAllQueuedMessages()).toBe(modelText);
-      const vimSubmit = mockedUseVim.mock.calls.at(-1)?.[1];
-      if (typeof vimSubmit !== 'function') {
-        throw new Error('useVim did not receive its submit callback');
-      }
-      vimSubmit(modelText);
+      capturedUIActions.handleFinalSubmit('vim prompt', {
+        submittedPrompt: 'vim prompt',
+      });
 
       expect(mockQueueMessage).toHaveBeenCalledWith(
-        modelText,
+        'vim prompt',
+        false,
+        undefined,
+      );
+    });
+
+    it('keeps Vim-modified composer text ineligible after Vim is disabled', () => {
+      const mockQueueMessage = vi.fn();
+      let setVimEnabled: ((enabled: boolean) => void) | undefined;
+      mockedUseTextBuffer.mockImplementation(() => ({
+        text: 'register contents',
+        setText: vi.fn(),
+      }));
+      const useMockVimModeState = () => {
+        const [vimEnabled, setEnabled] = useState(true);
+        setVimEnabled = setEnabled;
+        return {
+          vimEnabled,
+          vimMode: 'NORMAL',
+        };
+      };
+      mockedUseVimModeState.mockImplementation(useMockVimModeState);
+      mockedUseMessageQueue.mockReturnValue({
+        messageQueue: [],
+        addMessage: mockQueueMessage,
+        clearQueue: vi.fn(),
+        getQueuedMessagesText: vi.fn().mockReturnValue(''),
+        popAllMessages: vi.fn().mockReturnValue(null),
+        drainQueue: vi.fn().mockReturnValue([]),
+        popNextTurn: vi.fn().mockReturnValue(null),
+      });
+
+      render(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+
+      act(() => {
+        setVimEnabled?.(false);
+      });
+
+      capturedUIActions.handleFinalSubmit('register contents', {
+        submittedPrompt: 'register contents',
+      });
+
+      expect(mockQueueMessage).toHaveBeenCalledWith(
+        'register contents',
         false,
         undefined,
       );
@@ -4800,6 +5001,18 @@ describe('AppContainer State Management', () => {
         { truncatedCount: 2 },
         harness.snapshots.slice(0, 2),
       );
+
+      capturedUIActions.handleFinalSubmit('second prompt', {
+        submittedPrompt: 'second prompt',
+      });
+      expect(harness.addMessage).toHaveBeenCalledWith(
+        'second prompt',
+        false,
+        undefined,
+      );
+      expect(harness.setText).toHaveBeenLastCalledWith('', {
+        clearUndoHistory: true,
+      });
     });
 
     it('shows an error and returns for conversation-only rewind with no client', async () => {

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1067,17 +1067,6 @@ export const AppContainer = (props: AppContainerProps) => {
     restoredSubmissionRef.current = null;
     restoredSubmissionEditedRef.current = false;
   }, []);
-  const prepareInputSubmission = useCallback((value: string) => {
-    const restoredSubmission = restoredSubmissionRef.current;
-    if (
-      restoredSubmission !== null &&
-      (restoredSubmissionEditedRef.current ||
-        restoredSubmission.modelText !== value)
-    ) {
-      restoredSubmissionRef.current = null;
-      restoredSubmissionEditedRef.current = true;
-    }
-  }, []);
   const handleBufferChange = useCallback((text: string) => {
     if (text.length === 0) {
       restoredSubmissionRef.current = null;
@@ -2226,16 +2215,14 @@ export const AppContainer = (props: AppContainerProps) => {
       restoredSubmissionRef.current = null;
       const restoredSubmissionWasEdited = restoredSubmissionEditedRef.current;
       restoredSubmissionEditedRef.current = false;
-      const submittedPromptCandidate =
-        options !== undefined && 'submittedPrompt' in options
-          ? options.submittedPrompt
-          : submittedValue;
+      const submittedPromptCandidate = options?.submittedPrompt;
+      const provenanceEnabled = submittedPromptCandidate !== undefined;
       const trimmedSubmittedPrompt = submittedPromptCandidate?.trim();
       const submittedPrompt = restoredSubmissionWasEdited
         ? undefined
         : restoredSubmission === null
           ? trimmedSubmittedPrompt || undefined
-          : restoredSubmission.modelText === submittedValue
+          : provenanceEnabled && restoredSubmission.modelText === submittedValue
             ? restoredSubmission.submittedPrompt
             : undefined;
 
@@ -2801,7 +2788,7 @@ export const AppContainer = (props: AppContainerProps) => {
       welcomeBackChoice !== 'restart' &&
       geminiClient?.isInitialized?.()
     ) {
-      handleFinalSubmit(initialPrompt, { submittedPrompt: undefined });
+      handleFinalSubmit(initialPrompt);
       initialPromptSubmitted.current = true;
     }
   }, [
@@ -4482,7 +4469,6 @@ export const AppContainer = (props: AppContainerProps) => {
       handleClearScreen,
       popAllQueuedMessages,
       clearRestoredSubmission,
-      prepareInputSubmission,
       // Welcome back dialog
       handleWelcomeBackSelection,
       handleWelcomeBackClose,
@@ -4574,7 +4560,6 @@ export const AppContainer = (props: AppContainerProps) => {
       handleClearScreen,
       popAllQueuedMessages,
       clearRestoredSubmission,
-      prepareInputSubmission,
       handleWelcomeBackSelection,
       handleWelcomeBackClose,
       handleWorktreeExit,

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1062,15 +1062,24 @@ export const AppContainer = (props: AppContainerProps) => {
 
   const preferredEditor = usePreferredEditor();
   const restoredSubmissionRef = useRef<QueuedSubmission | null>(null);
-  const restoredSubmissionEditedRef = useRef(false);
-  const clearRestoredSubmission = useCallback(() => {
+  const submittedPromptProvenanceUnavailableRef = useRef(false);
+  const setBufferTextRef = useRef<
+    ReturnType<typeof useTextBuffer>['setText'] | null
+  >(null);
+  const invalidateSubmittedPromptProvenance = useCallback(() => {
     restoredSubmissionRef.current = null;
-    restoredSubmissionEditedRef.current = false;
+    submittedPromptProvenanceUnavailableRef.current = true;
   }, []);
   const handleBufferChange = useCallback((text: string) => {
     if (text.length === 0) {
+      if (
+        restoredSubmissionRef.current !== null ||
+        submittedPromptProvenanceUnavailableRef.current
+      ) {
+        setBufferTextRef.current?.('', { clearUndoHistory: true });
+      }
       restoredSubmissionRef.current = null;
-      restoredSubmissionEditedRef.current = false;
+      submittedPromptProvenanceUnavailableRef.current = false;
       return;
     }
     if (
@@ -1078,7 +1087,7 @@ export const AppContainer = (props: AppContainerProps) => {
       restoredSubmissionRef.current.modelText !== text
     ) {
       restoredSubmissionRef.current = null;
-      restoredSubmissionEditedRef.current = true;
+      submittedPromptProvenanceUnavailableRef.current = true;
     }
   }, []);
 
@@ -1092,6 +1101,8 @@ export const AppContainer = (props: AppContainerProps) => {
     preferredEditor,
     onChange: handleBufferChange,
   });
+  const setBufferText = buffer.setText;
+  setBufferTextRef.current = setBufferText;
   const restoredPromptStashTargetsRef = useRef(new Set<string>());
   const promptStashTargetDir = config.getTargetDir();
   useEffect(() => {
@@ -1099,9 +1110,11 @@ export const AppContainer = (props: AppContainerProps) => {
       return;
     }
     restoredPromptStashTargetsRef.current.add(promptStashTargetDir);
-    restorePromptStash(promptStashTargetDir, buffer.text, (text) =>
-      buffer.setText(text),
-    );
+    restorePromptStash(promptStashTargetDir, buffer.text, (text) => {
+      restoredSubmissionRef.current = null;
+      submittedPromptProvenanceUnavailableRef.current = true;
+      buffer.setText(text);
+    });
   }, [buffer, promptStashTargetDir]);
 
   useEffect(() => {
@@ -1429,6 +1442,14 @@ export const AppContainer = (props: AppContainerProps) => {
 
   const { vimEnabled, vimMode } = useVimModeState();
   const { toggleVimEnabled } = useVimModeActions();
+
+  useLayoutEffect(() => {
+    if (vimEnabled && buffer.text.length > 0) {
+      // Vim registers outlive buffer clears, so provenance cannot be recovered
+      // by pasting register contents and then disabling Vim.
+      invalidateSubmittedPromptProvenance();
+    }
+  }, [buffer.text, invalidateSubmittedPromptProvenance, vimEnabled]);
 
   const {
     isSubagentCreateDialogOpen,
@@ -2064,7 +2085,7 @@ export const AppContainer = (props: AppContainerProps) => {
     const submission = popAllMessages();
     if (submission === null) return null;
     restoredSubmissionRef.current = submission;
-    restoredSubmissionEditedRef.current = false;
+    submittedPromptProvenanceUnavailableRef.current = false;
     return submission.modelText;
   }, [popAllMessages]);
 
@@ -2211,20 +2232,32 @@ export const AppContainer = (props: AppContainerProps) => {
         submittedPrompt?: string;
       },
     ) => {
-      const restoredSubmission = restoredSubmissionRef.current;
-      restoredSubmissionRef.current = null;
-      const restoredSubmissionWasEdited = restoredSubmissionEditedRef.current;
-      restoredSubmissionEditedRef.current = false;
+      const consumesComposerState = options !== undefined;
+      const restoredSubmission = consumesComposerState
+        ? restoredSubmissionRef.current
+        : null;
+      const submittedPromptProvenanceUnavailable =
+        consumesComposerState &&
+        submittedPromptProvenanceUnavailableRef.current;
+      if (consumesComposerState) {
+        restoredSubmissionRef.current = null;
+        submittedPromptProvenanceUnavailableRef.current = false;
+      }
       const submittedPromptCandidate = options?.submittedPrompt;
-      const provenanceEnabled = submittedPromptCandidate !== undefined;
+      const provenanceEnabled =
+        !vimEnabled && submittedPromptCandidate !== undefined;
       const trimmedSubmittedPrompt = submittedPromptCandidate?.trim();
-      const submittedPrompt = restoredSubmissionWasEdited
-        ? undefined
-        : restoredSubmission === null
-          ? trimmedSubmittedPrompt || undefined
-          : provenanceEnabled && restoredSubmission.modelText === submittedValue
-            ? restoredSubmission.submittedPrompt
-            : undefined;
+      const submittedPrompt =
+        submittedPromptProvenanceUnavailable || !provenanceEnabled
+          ? undefined
+          : restoredSubmission === null
+            ? trimmedSubmittedPrompt || undefined
+            : restoredSubmission.modelText === submittedValue
+              ? restoredSubmission.submittedPrompt
+              : undefined;
+      if (restoredSubmission !== null || submittedPromptProvenanceUnavailable) {
+        setBufferText('', { clearUndoHistory: true });
+      }
 
       // Route to active in-process agent if viewing a sub-agent tab.
       if (agentViewState.activeView !== 'main') {
@@ -2446,6 +2479,8 @@ export const AppContainer = (props: AppContainerProps) => {
       geminiClient,
       historyManager,
       settings.merged.ui?.disableWorkflowKeywordTrigger,
+      setBufferText,
+      vimEnabled,
     ],
   );
 
@@ -2546,7 +2581,7 @@ export const AppContainer = (props: AppContainerProps) => {
       const popped = popAllMessages();
       if (popped) {
         restoredSubmissionRef.current = popped;
-        restoredSubmissionEditedRef.current = false;
+        submittedPromptProvenanceUnavailableRef.current = false;
         const currentText = buffer.text;
         buffer.setText(
           currentText
@@ -2606,7 +2641,7 @@ export const AppContainer = (props: AppContainerProps) => {
             ? {}
             : { submittedPrompt: cancelledTurnUserItem.submittedPrompt }),
         };
-        restoredSubmissionEditedRef.current = false;
+        submittedPromptProvenanceUnavailableRef.current = false;
         buffer.setText(cancelledTurnUserItem.text);
       };
 
@@ -3394,6 +3429,8 @@ export const AppContainer = (props: AppContainerProps) => {
           refreshStatic();
 
           if (userItem.type === 'user' && userItem.text) {
+            restoredSubmissionRef.current = null;
+            submittedPromptProvenanceUnavailableRef.current = true;
             buffer.setText(userItem.text);
           }
 
@@ -4468,7 +4505,7 @@ export const AppContainer = (props: AppContainerProps) => {
       handleRetryLastPrompt: retryLastPrompt,
       handleClearScreen,
       popAllQueuedMessages,
-      clearRestoredSubmission,
+      invalidateSubmittedPromptProvenance,
       // Welcome back dialog
       handleWelcomeBackSelection,
       handleWelcomeBackClose,
@@ -4559,7 +4596,7 @@ export const AppContainer = (props: AppContainerProps) => {
       retryLastPrompt,
       handleClearScreen,
       popAllQueuedMessages,
-      clearRestoredSubmission,
+      invalidateSubmittedPromptProvenance,
       handleWelcomeBackSelection,
       handleWelcomeBackClose,
       handleWorktreeExit,

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -67,6 +67,7 @@ import {
   ToolConfirmationOutcome,
   type WaitingToolCall,
   ToolNames,
+  SendMessageType,
   clearWorktreeSession,
   restoreWorktreeContext,
   GitWorktreeService,
@@ -189,7 +190,10 @@ import { sendNotification } from '../services/notificationService.js';
 import { type UpdateObject } from './utils/updateCheck.js';
 import { setUpdateHandler } from '../utils/handleAutoUpdate.js';
 import { registerCleanup, runExitCleanup } from '../utils/cleanup.js';
-import { useMessageQueue } from './hooks/useMessageQueue.js';
+import {
+  useMessageQueue,
+  type QueuedSubmission,
+} from './hooks/useMessageQueue.js';
 import { useAutoAcceptIndicator } from './hooks/useAutoAcceptIndicator.js';
 import { useSessionStats } from './contexts/SessionContext.js';
 import { useGitBranchName } from './hooks/useGitBranchName.js';
@@ -1057,6 +1061,37 @@ export const AppContainer = (props: AppContainerProps) => {
   }, []);
 
   const preferredEditor = usePreferredEditor();
+  const restoredSubmissionRef = useRef<QueuedSubmission | null>(null);
+  const restoredSubmissionEditedRef = useRef(false);
+  const clearRestoredSubmission = useCallback(() => {
+    restoredSubmissionRef.current = null;
+    restoredSubmissionEditedRef.current = false;
+  }, []);
+  const prepareInputSubmission = useCallback((value: string) => {
+    const restoredSubmission = restoredSubmissionRef.current;
+    if (
+      restoredSubmission !== null &&
+      (restoredSubmissionEditedRef.current ||
+        restoredSubmission.modelText !== value)
+    ) {
+      restoredSubmissionRef.current = null;
+      restoredSubmissionEditedRef.current = true;
+    }
+  }, []);
+  const handleBufferChange = useCallback((text: string) => {
+    if (text.length === 0) {
+      restoredSubmissionRef.current = null;
+      restoredSubmissionEditedRef.current = false;
+      return;
+    }
+    if (
+      restoredSubmissionRef.current !== null &&
+      restoredSubmissionRef.current.modelText !== text
+    ) {
+      restoredSubmissionRef.current = null;
+      restoredSubmissionEditedRef.current = true;
+    }
+  }, []);
 
   const buffer = useTextBuffer({
     initialText: '',
@@ -1066,6 +1101,7 @@ export const AppContainer = (props: AppContainerProps) => {
     isValidPath,
     shellModeActive,
     preferredEditor,
+    onChange: handleBufferChange,
   });
   const restoredPromptStashTargetsRef = useRef(new Set<string>());
   const promptStashTargetDir = config.getTargetDir();
@@ -2019,12 +2055,33 @@ export const AppContainer = (props: AppContainerProps) => {
     popAllMessages,
     restoreMessages,
     drainQueue,
-    popNextSegment,
+    popNextTurn,
   } = useMessageQueue();
+
+  const submitUserQuery = useCallback(
+    (submission: QueuedSubmission) =>
+      submitQuery(
+        submission.modelText,
+        SendMessageType.UserQuery,
+        undefined,
+        submission.submittedPrompt === undefined
+          ? undefined
+          : { submittedPrompt: submission.submittedPrompt },
+      ),
+    [submitQuery],
+  );
+
+  const popAllQueuedMessages = useCallback((): string | null => {
+    const submission = popAllMessages();
+    if (submission === null) return null;
+    restoredSubmissionRef.current = submission;
+    restoredSubmissionEditedRef.current = false;
+    return submission.modelText;
+  }, [popAllMessages]);
 
   // Bridge message queue to mid-turn drain via ref.
   // drainQueue reads the synchronous queueRef inside the hook, so it
-  // stays consistent with popNextSegment even before React re-renders.
+  // stays consistent with popNextTurn even before React re-renders.
   midTurnDrainRef.current = drainQueue;
   midTurnRestoreRef.current = restoreMessages;
 
@@ -2158,7 +2215,30 @@ export const AppContainer = (props: AppContainerProps) => {
 
   // Callback for handling final submit (must be after addMessage from useMessageQueue)
   const handleFinalSubmit = useCallback(
-    (submittedValue: string, options?: { deferUntilIdle?: boolean }) => {
+    (
+      submittedValue: string,
+      options?: {
+        deferUntilIdle?: boolean;
+        submittedPrompt?: string;
+      },
+    ) => {
+      const restoredSubmission = restoredSubmissionRef.current;
+      restoredSubmissionRef.current = null;
+      const restoredSubmissionWasEdited = restoredSubmissionEditedRef.current;
+      restoredSubmissionEditedRef.current = false;
+      const submittedPromptCandidate =
+        options !== undefined && 'submittedPrompt' in options
+          ? options.submittedPrompt
+          : submittedValue;
+      const trimmedSubmittedPrompt = submittedPromptCandidate?.trim();
+      const submittedPrompt = restoredSubmissionWasEdited
+        ? undefined
+        : restoredSubmission === null
+          ? trimmedSubmittedPrompt || undefined
+          : restoredSubmission.modelText === submittedValue
+            ? restoredSubmission.submittedPrompt
+            : undefined;
+
       // Route to active in-process agent if viewing a sub-agent tab.
       if (agentViewState.activeView !== 'main') {
         const agent = agentViewState.agents.get(agentViewState.activeView);
@@ -2226,14 +2306,17 @@ export const AppContainer = (props: AppContainerProps) => {
           submittedValue;
       }
       if (options?.deferUntilIdle) {
-        addMessage(submittedValue, true);
+        addMessage(submittedValue, true, submittedPrompt);
         return;
       }
       if (
         streamingState === StreamingState.Responding &&
         isBtwCommand(submittedValue)
       ) {
-        void submitQuery(submittedValue);
+        void submitUserQuery({
+          modelText: submittedValue,
+          submittedPrompt,
+        });
         return;
       }
 
@@ -2339,7 +2422,7 @@ export const AppContainer = (props: AppContainerProps) => {
           })
           .catch(() => {
             // Fallback: submit normally
-            addMessage(submittedValue);
+            addMessage(submittedValue, false, submittedPrompt);
           });
         speculationRef.current = IDLE_SPECULATION;
         return;
@@ -2356,18 +2439,21 @@ export const AppContainer = (props: AppContainerProps) => {
         !isProcessing &&
         isSlashCommand(submittedValue)
       ) {
-        void submitQuery(submittedValue);
+        void submitUserQuery({
+          modelText: submittedValue,
+          submittedPrompt,
+        });
         return;
       }
 
-      addMessage(submittedValue);
+      addMessage(submittedValue, false, submittedPrompt);
     },
     [
       addMessage,
       agentViewState,
       streamingState,
       isProcessing,
-      submitQuery,
+      submitUserQuery,
       handleSlashCommand,
       config,
       geminiClient,
@@ -2472,8 +2558,14 @@ export const AppContainer = (props: AppContainerProps) => {
       // tool-execution cancels — never silently drop the user's queued work).
       const popped = popAllMessages();
       if (popped) {
+        restoredSubmissionRef.current = popped;
+        restoredSubmissionEditedRef.current = false;
         const currentText = buffer.text;
-        buffer.setText(currentText ? `${popped}\n${currentText}` : popped);
+        buffer.setText(
+          currentText
+            ? `${popped.modelText}\n${currentText}`
+            : popped.modelText,
+        );
       }
 
       // Restore-on-cancel: pull the just-submitted prompt back into the input
@@ -2520,6 +2612,16 @@ export const AppContainer = (props: AppContainerProps) => {
         );
         return;
       }
+      const restoreCancelledPrompt = () => {
+        restoredSubmissionRef.current = {
+          modelText: cancelledTurnUserItem.text,
+          ...(cancelledTurnUserItem.submittedPrompt === undefined
+            ? {}
+            : { submittedPrompt: cancelledTurnUserItem.submittedPrompt }),
+        };
+        restoredSubmissionEditedRef.current = false;
+        buffer.setText(cancelledTurnUserItem.text);
+      };
 
       if (pendingHistoryItems.some((item) => item.type === 'tool_group')) {
         debugLogger.debug(
@@ -2539,7 +2641,7 @@ export const AppContainer = (props: AppContainerProps) => {
         debugLogger.debug(
           'auto-restore: preserving streamed output and restoring prompt text',
         );
-        buffer.setText(cancelledTurnUserItem.text);
+        restoreCancelledPrompt();
         return;
       }
       if (pendingHistoryItems.some((item) => !isSyntheticHistoryItem(item))) {
@@ -2559,7 +2661,7 @@ export const AppContainer = (props: AppContainerProps) => {
         debugLogger.debug(
           'auto-restore: preserving committed output and restoring prompt text',
         );
-        buffer.setText(cancelledTurnUserItem.text);
+        restoreCancelledPrompt();
         return;
       }
 
@@ -2600,7 +2702,7 @@ export const AppContainer = (props: AppContainerProps) => {
       // cancelled prompt twice — once in scrollback and once pre-filled
       // in the input buffer.
       refreshStatic();
-      buffer.setText(lastUserItem.text);
+      restoreCancelledPrompt();
       // Third cleanup leg: the in-memory chat history. `GeminiChat`
       // appends the user content before the stream generator runs, and
       // the abort path doesn't pop it. Without this strip, the NEXT
@@ -2618,9 +2720,11 @@ export const AppContainer = (props: AppContainerProps) => {
       // errors and returns false, but attach a .catch as defence so a
       // future code path that throws doesn't surface as an
       // UnhandledPromiseRejection.
-      void logger?.removeLastUserMessage().catch((err: unknown) => {
-        debugLogger.debug('Failed to undo cancelled prompt from log:', err);
-      });
+      if (info?.canUndoLastLoggedUserMessage) {
+        void logger?.removeLastUserMessage().catch((err: unknown) => {
+          debugLogger.debug('Failed to undo cancelled prompt from log:', err);
+        });
+      }
     },
     [
       buffer,
@@ -2697,7 +2801,7 @@ export const AppContainer = (props: AppContainerProps) => {
       welcomeBackChoice !== 'restart' &&
       geminiClient?.isInitialized?.()
     ) {
-      handleFinalSubmit(initialPrompt);
+      handleFinalSubmit(initialPrompt, { submittedPrompt: undefined });
       initialPromptSubmitted.current = true;
     }
   }, [
@@ -4018,13 +4122,11 @@ export const AppContainer = (props: AppContainerProps) => {
     if (isTranscriptOpenRef.current) return;
 
     // Two-phase: batch plain prompts as one turn, else pop next slash command.
-    const plainPrompts = drainQueue(true);
-    const submission =
-      plainPrompts.length > 0 ? plainPrompts.join('\n\n') : popNextSegment();
+    const submission = popNextTurn();
     if (submission === null) return;
 
     queueDrainingRef.current = true;
-    Promise.resolve(submitQuery(submission)).finally(() => {
+    Promise.resolve(submitUserQuery(submission)).finally(() => {
       queueDrainingRef.current = false;
       setQueueDrainNonce((n) => n + 1);
     });
@@ -4036,9 +4138,8 @@ export const AppContainer = (props: AppContainerProps) => {
     // Re-run the drain when the transcript closes so queued messages resume.
     isTranscriptOpen,
     messageQueue,
-    drainQueue,
-    popNextSegment,
-    submitQuery,
+    popNextTurn,
+    submitUserQuery,
     queueDrainNonce,
   ]);
 
@@ -4379,7 +4480,9 @@ export const AppContainer = (props: AppContainerProps) => {
       handleFinalSubmit,
       handleRetryLastPrompt: retryLastPrompt,
       handleClearScreen,
-      popAllQueuedMessages: popAllMessages,
+      popAllQueuedMessages,
+      clearRestoredSubmission,
+      prepareInputSubmission,
       // Welcome back dialog
       handleWelcomeBackSelection,
       handleWelcomeBackClose,
@@ -4469,7 +4572,9 @@ export const AppContainer = (props: AppContainerProps) => {
       handleFinalSubmit,
       retryLastPrompt,
       handleClearScreen,
-      popAllMessages,
+      popAllQueuedMessages,
+      clearRestoredSubmission,
+      prepareInputSubmission,
       handleWelcomeBackSelection,
       handleWelcomeBackClose,
       handleWorktreeExit,

--- a/packages/cli/src/ui/components/InputPrompt.suggestionMouse.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.suggestionMouse.test.tsx
@@ -56,7 +56,7 @@ vi.mock('../contexts/UIActionsContext.js', () => ({
     handleRetryLastPrompt: vi.fn(),
     temporaryCloseFeedbackDialog: vi.fn(),
     popAllQueuedMessages: vi.fn(() => null),
-    clearRestoredSubmission: vi.fn(),
+    invalidateSubmittedPromptProvenance: vi.fn(),
   })),
 }));
 vi.mock('../contexts/AgentViewContext.js', () => ({

--- a/packages/cli/src/ui/components/InputPrompt.suggestionMouse.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.suggestionMouse.test.tsx
@@ -56,6 +56,7 @@ vi.mock('../contexts/UIActionsContext.js', () => ({
     handleRetryLastPrompt: vi.fn(),
     temporaryCloseFeedbackDialog: vi.fn(),
     popAllQueuedMessages: vi.fn(() => null),
+    clearRestoredSubmission: vi.fn(),
   })),
 }));
 vi.mock('../contexts/AgentViewContext.js', () => ({
@@ -233,7 +234,10 @@ describe('InputPrompt suggestion mouse routing', () => {
       (captured.props!['onSelectIndex'] as (i: number) => void)(0);
     });
     expect(mockCommandCompletion.handleAutocomplete).toHaveBeenCalledWith(0);
-    expect(props.onSubmit).toHaveBeenCalledWith('/skills');
+    expect(props.onSubmit).toHaveBeenCalledWith('/skills', {
+      deferUntilIdle: false,
+      submittedPrompt: '/skills',
+    });
     unmount();
   });
 

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -75,7 +75,7 @@ vi.mock('../contexts/UIActionsContext.js', () => ({
     handleRetryLastPrompt: vi.fn(),
     temporaryCloseFeedbackDialog: vi.fn(),
     popAllQueuedMessages: vi.fn(() => null),
-    clearRestoredSubmission: vi.fn(),
+    invalidateSubmittedPromptProvenance: vi.fn(),
   })),
 }));
 vi.mock('../contexts/AgentViewContext.js', () => ({
@@ -221,7 +221,7 @@ describe('InputPrompt', () => {
       handleRetryLastPrompt: vi.fn(),
       temporaryCloseFeedbackDialog: vi.fn(),
       popAllQueuedMessages: vi.fn(() => null),
-      clearRestoredSubmission: vi.fn(),
+      invalidateSubmittedPromptProvenance: vi.fn(),
     } as unknown as ReturnType<typeof useUIActions>);
     mockedUseAgentViewState.mockReturnValue({
       activeView: 'main',
@@ -442,12 +442,12 @@ describe('InputPrompt', () => {
   });
 
   it('clears restored provenance before applying same-text history', async () => {
-    const clearRestoredSubmission = vi.fn();
+    const invalidateSubmittedPromptProvenance = vi.fn();
     mockedUseUIActions.mockReturnValue({
       handleRetryLastPrompt: vi.fn(),
       temporaryCloseFeedbackDialog: vi.fn(),
       popAllQueuedMessages: vi.fn(() => null),
-      clearRestoredSubmission,
+      invalidateSubmittedPromptProvenance,
     } as unknown as ReturnType<typeof useUIActions>);
     props.buffer.setText('repeat prompt');
     vi.mocked(props.buffer.setText).mockClear();
@@ -462,11 +462,11 @@ describe('InputPrompt', () => {
       historyArgs.onChange('repeat prompt');
     });
 
-    expect(clearRestoredSubmission).toHaveBeenCalledOnce();
+    expect(invalidateSubmittedPromptProvenance).toHaveBeenCalledOnce();
     expect(props.buffer.setText).toHaveBeenCalledWith('repeat prompt');
-    expect(clearRestoredSubmission.mock.invocationCallOrder[0]).toBeLessThan(
-      vi.mocked(props.buffer.setText).mock.invocationCallOrder[0],
-    );
+    expect(
+      invalidateSubmittedPromptProvenance.mock.invocationCallOrder[0],
+    ).toBeLessThan(vi.mocked(props.buffer.setText).mock.invocationCallOrder[0]);
     unmount();
   });
 
@@ -1260,6 +1260,13 @@ describe('InputPrompt', () => {
 
   it('should set the buffer text when a shell history command is retrieved', async () => {
     props.shellModeActive = true;
+    const invalidateSubmittedPromptProvenance = vi.fn();
+    mockedUseUIActions.mockReturnValue({
+      handleRetryLastPrompt: vi.fn(),
+      temporaryCloseFeedbackDialog: vi.fn(),
+      popAllQueuedMessages: vi.fn(() => null),
+      invalidateSubmittedPromptProvenance,
+    } as unknown as ReturnType<typeof useUIActions>);
     vi.mocked(mockShellHistory.getPreviousCommand).mockReturnValue(
       'previous command',
     );
@@ -1270,6 +1277,10 @@ describe('InputPrompt', () => {
     await wait();
 
     expect(mockShellHistory.getPreviousCommand).toHaveBeenCalled();
+    expect(invalidateSubmittedPromptProvenance).toHaveBeenCalledOnce();
+    expect(
+      invalidateSubmittedPromptProvenance.mock.invocationCallOrder[0],
+    ).toBeLessThan(vi.mocked(props.buffer.setText).mock.invocationCallOrder[0]);
     expect(props.buffer.setText).toHaveBeenCalledWith('previous command');
     unmount();
   });
@@ -3982,6 +3993,13 @@ describe('InputPrompt', () => {
     });
 
     it('completes the highlighted entry on Tab and exits reverse-search', async () => {
+      const invalidateSubmittedPromptProvenance = vi.fn();
+      mockedUseUIActions.mockReturnValue({
+        handleRetryLastPrompt: vi.fn(),
+        temporaryCloseFeedbackDialog: vi.fn(),
+        popAllQueuedMessages: vi.fn(() => null),
+        invalidateSubmittedPromptProvenance,
+      } as unknown as ReturnType<typeof useUIActions>);
       // Mock the reverse search completion
       const mockHandleAutocomplete = vi.fn(() => {
         props.buffer.setText('echo hello');
@@ -4023,11 +4041,22 @@ describe('InputPrompt', () => {
       await wait();
 
       expect(mockHandleAutocomplete).toHaveBeenCalledWith(0);
+      expect(invalidateSubmittedPromptProvenance).toHaveBeenCalledOnce();
+      expect(
+        invalidateSubmittedPromptProvenance.mock.invocationCallOrder[0],
+      ).toBeLessThan(mockHandleAutocomplete.mock.invocationCallOrder[0]);
       expect(props.buffer.setText).toHaveBeenCalledWith('echo hello');
       unmount();
     }, 15000);
 
     it('submits the highlighted entry on Enter and exits reverse-search', async () => {
+      const invalidateSubmittedPromptProvenance = vi.fn();
+      mockedUseUIActions.mockReturnValue({
+        handleRetryLastPrompt: vi.fn(),
+        temporaryCloseFeedbackDialog: vi.fn(),
+        popAllQueuedMessages: vi.fn(() => null),
+        invalidateSubmittedPromptProvenance,
+      } as unknown as ReturnType<typeof useUIActions>);
       // Mock the reverse search completion to return suggestions
       mockedUseReverseSearchCompletion.mockReturnValue({
         ...mockReverseSearchCompletion,
@@ -4063,6 +4092,10 @@ describe('InputPrompt', () => {
         deferUntilIdle: false,
         submittedPrompt: 'echo hello',
       });
+      expect(invalidateSubmittedPromptProvenance).toHaveBeenCalledOnce();
+      expect(
+        invalidateSubmittedPromptProvenance.mock.invocationCallOrder[0],
+      ).toBeLessThan(vi.mocked(props.onSubmit).mock.invocationCallOrder[0]);
       unmount();
     });
 
@@ -4207,6 +4240,59 @@ describe('InputPrompt', () => {
       expect(frame).toContain('(r:)');
       expect(frame).toContain('git commit');
       expect(frame).toContain('git push');
+      unmount();
+    });
+
+    it('invalidates provenance before submitting a command-history match', async () => {
+      props.shellModeActive = false;
+      const invalidateSubmittedPromptProvenance = vi.fn();
+      mockedUseUIActions.mockReturnValue({
+        handleRetryLastPrompt: vi.fn(),
+        temporaryCloseFeedbackDialog: vi.fn(),
+        popAllQueuedMessages: vi.fn(() => null),
+        invalidateSubmittedPromptProvenance,
+      } as unknown as ReturnType<typeof useUIActions>);
+      vi.mocked(useReverseSearchCompletion).mockImplementation(
+        (_buffer, _data, isActive) => ({
+          ...mockReverseSearchCompletion,
+          suggestions: isActive
+            ? [
+                {
+                  label:
+                    '<system-reminder>generated</system-reminder>\nuser text',
+                  value:
+                    '<system-reminder>generated</system-reminder>\nuser text',
+                },
+              ]
+            : [],
+          showSuggestions: !!isActive,
+          activeSuggestionIndex: isActive ? 0 : -1,
+        }),
+      );
+
+      const { stdin, unmount } = renderWithProviders(
+        <InputPrompt {...props} />,
+      );
+      await wait();
+
+      stdin.write('\x12');
+      await wait();
+      stdin.write('\r');
+
+      await waitFor(() => {
+        expect(props.onSubmit).toHaveBeenCalledWith(
+          '<system-reminder>generated</system-reminder>\nuser text',
+          {
+            deferUntilIdle: false,
+            submittedPrompt:
+              '<system-reminder>generated</system-reminder>\nuser text',
+          },
+        );
+      });
+      expect(invalidateSubmittedPromptProvenance).toHaveBeenCalledOnce();
+      expect(
+        invalidateSubmittedPromptProvenance.mock.invocationCallOrder[0],
+      ).toBeLessThan(vi.mocked(props.onSubmit).mock.invocationCallOrder[0]);
       unmount();
     });
 

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -75,6 +75,7 @@ vi.mock('../contexts/UIActionsContext.js', () => ({
     handleRetryLastPrompt: vi.fn(),
     temporaryCloseFeedbackDialog: vi.fn(),
     popAllQueuedMessages: vi.fn(() => null),
+    clearRestoredSubmission: vi.fn(),
   })),
 }));
 vi.mock('../contexts/AgentViewContext.js', () => ({
@@ -220,6 +221,7 @@ describe('InputPrompt', () => {
       handleRetryLastPrompt: vi.fn(),
       temporaryCloseFeedbackDialog: vi.fn(),
       popAllQueuedMessages: vi.fn(() => null),
+      clearRestoredSubmission: vi.fn(),
     } as unknown as ReturnType<typeof useUIActions>);
     mockedUseAgentViewState.mockReturnValue({
       activeView: 'main',
@@ -408,19 +410,15 @@ describe('InputPrompt', () => {
       expect(mockedClearPromptStash).toHaveBeenCalledWith(
         path.join('test', 'project', 'src'),
       );
-      expect(props.onSubmit).toHaveBeenCalledWith('send this');
+      expect(props.onSubmit).toHaveBeenCalledWith('send this', {
+        deferUntilIdle: false,
+        submittedPrompt: 'send this',
+      });
     });
     unmount();
   });
 
-  it('prepares submission provenance before clearing the input buffer', async () => {
-    const prepareInputSubmission = vi.fn();
-    mockedUseUIActions.mockReturnValue({
-      handleRetryLastPrompt: vi.fn(),
-      temporaryCloseFeedbackDialog: vi.fn(),
-      popAllQueuedMessages: vi.fn(() => null),
-      prepareInputSubmission,
-    } as unknown as ReturnType<typeof useUIActions>);
+  it('captures explicit provenance before clearing the input buffer', async () => {
     props.buffer.setText('restored prompt');
     vi.mocked(props.buffer.setText).mockClear();
 
@@ -431,13 +429,12 @@ describe('InputPrompt', () => {
     });
 
     await waitFor(() => {
-      expect(prepareInputSubmission).toHaveBeenCalledWith('restored prompt');
       expect(props.buffer.setText).toHaveBeenCalledWith('');
-      expect(props.onSubmit).toHaveBeenCalledWith('restored prompt');
+      expect(props.onSubmit).toHaveBeenCalledWith('restored prompt', {
+        deferUntilIdle: false,
+        submittedPrompt: 'restored prompt',
+      });
     });
-    expect(prepareInputSubmission.mock.invocationCallOrder[0]).toBeLessThan(
-      vi.mocked(props.buffer.setText).mock.invocationCallOrder[0],
-    );
     expect(
       vi.mocked(props.buffer.setText).mock.invocationCallOrder[0],
     ).toBeLessThan(vi.mocked(props.onSubmit).mock.invocationCallOrder[0]);
@@ -484,6 +481,7 @@ describe('InputPrompt', () => {
     await waitFor(() => {
       expect(props.onSubmit).toHaveBeenCalledWith('send this later', {
         deferUntilIdle: true,
+        submittedPrompt: 'send this later',
       });
     });
     expect(props.buffer.setText).toHaveBeenCalledWith('');
@@ -971,7 +969,10 @@ describe('InputPrompt', () => {
 
           // Submitting a non-empty buffer clears the stale suggestion too, so a
           // synchronous slash command (/clear, /help) can't leave a ghost.
-          expect(props.onSubmit).toHaveBeenCalledWith('ship it');
+          expect(props.onSubmit).toHaveBeenCalledWith('ship it', {
+            deferUntilIdle: false,
+            submittedPrompt: 'ship it',
+          });
           expect(onPromptSuggestionDismiss).toHaveBeenCalled();
         } finally {
           vi.useRealTimers();
@@ -1283,7 +1284,10 @@ describe('InputPrompt', () => {
     await wait();
 
     expect(mockShellHistory.addCommandToHistory).toHaveBeenCalledWith('ls -l');
-    expect(props.onSubmit).toHaveBeenCalledWith('ls -l');
+    expect(props.onSubmit).toHaveBeenCalledWith('ls -l', {
+      deferUntilIdle: false,
+      submittedPrompt: 'ls -l',
+    });
     unmount();
   });
 
@@ -1309,7 +1313,10 @@ describe('InputPrompt', () => {
 
     expect(mockInputHistory.navigateUp).toHaveBeenCalled();
     expect(mockInputHistory.navigateDown).toHaveBeenCalled();
-    expect(props.onSubmit).toHaveBeenCalledWith('some text');
+    expect(props.onSubmit).toHaveBeenCalledWith('some text', {
+      deferUntilIdle: false,
+      submittedPrompt: 'some text',
+    });
     unmount();
   });
 
@@ -1488,7 +1495,10 @@ describe('InputPrompt', () => {
       await waitFor(() => {
         expect(props.onSubmit).toHaveBeenCalledWith(
           '@.qwen/tmp/clipboard.png\n\ndescribe this image',
-          { submittedPrompt: 'describe this image' },
+          {
+            deferUntilIdle: false,
+            submittedPrompt: 'describe this image',
+          },
         );
       });
       unmount();
@@ -1794,7 +1804,10 @@ describe('InputPrompt', () => {
     stdin.write('\r');
     await wait();
 
-    expect(props.onSubmit).toHaveBeenCalledWith('/clear');
+    expect(props.onSubmit).toHaveBeenCalledWith('/clear', {
+      deferUntilIdle: false,
+      submittedPrompt: '/clear',
+    });
     unmount();
   });
 
@@ -1819,7 +1832,10 @@ describe('InputPrompt', () => {
     stdin.write('\r');
     await wait();
 
-    expect(props.onSubmit).toHaveBeenCalledWith('/export');
+    expect(props.onSubmit).toHaveBeenCalledWith('/export', {
+      deferUntilIdle: false,
+      submittedPrompt: '/export',
+    });
     expect(mockCommandCompletion.handleAutocomplete).not.toHaveBeenCalled();
     unmount();
   });
@@ -1852,7 +1868,10 @@ describe('InputPrompt', () => {
     stdin.write('\r');
     await wait();
 
-    expect(props.onSubmit).toHaveBeenCalledWith('/export md');
+    expect(props.onSubmit).toHaveBeenCalledWith('/export md', {
+      deferUntilIdle: false,
+      submittedPrompt: '/export md',
+    });
     unmount();
   });
 
@@ -2547,7 +2566,10 @@ describe('InputPrompt', () => {
     stdinFinal.write('\r');
     await wait();
 
-    expect(props.onSubmit).toHaveBeenCalledWith('/memory');
+    expect(props.onSubmit).toHaveBeenCalledWith('/memory', {
+      deferUntilIdle: false,
+      submittedPrompt: '/memory',
+    });
     expect(mockCommandCompletion.handleAutocomplete).not.toHaveBeenCalled();
     unmountFinal();
   });
@@ -2572,7 +2594,10 @@ describe('InputPrompt', () => {
     stdin.write('\r');
     await wait();
 
-    expect(props.onSubmit).toHaveBeenCalledWith('/memory');
+    expect(props.onSubmit).toHaveBeenCalledWith('/memory', {
+      deferUntilIdle: false,
+      submittedPrompt: '/memory',
+    });
     expect(mockCommandCompletion.handleAutocomplete).not.toHaveBeenCalled();
     unmount();
   });
@@ -2777,7 +2802,10 @@ describe('InputPrompt', () => {
     stdin.write('\r');
     await wait();
 
-    expect(props.onSubmit).toHaveBeenCalledWith('a prompt from history');
+    expect(props.onSubmit).toHaveBeenCalledWith('a prompt from history', {
+      deferUntilIdle: false,
+      submittedPrompt: 'a prompt from history',
+    });
     expect(mockInputHistory.resetHistoryNav).toHaveBeenCalled();
     unmount();
   });
@@ -2796,7 +2824,10 @@ describe('InputPrompt', () => {
     stdin.write('\r');
     await wait();
 
-    expect(props.onSubmit).toHaveBeenCalledWith('/clear');
+    expect(props.onSubmit).toHaveBeenCalledWith('/clear', {
+      deferUntilIdle: false,
+      submittedPrompt: '/clear',
+    });
     unmount();
   });
 
@@ -3733,7 +3764,10 @@ describe('InputPrompt', () => {
         await flush();
 
         // Verify that onSubmit was called after the timeout
-        expect(props.onSubmit).toHaveBeenCalledWith('test command');
+        expect(props.onSubmit).toHaveBeenCalledWith('test command', {
+          deferUntilIdle: false,
+          submittedPrompt: 'test command',
+        });
       } finally {
         vi.useRealTimers();
         unmount();
@@ -3754,7 +3788,10 @@ describe('InputPrompt', () => {
       await wait();
 
       // Verify that onSubmit was called normally
-      expect(props.onSubmit).toHaveBeenCalledWith('normal command');
+      expect(props.onSubmit).toHaveBeenCalledWith('normal command', {
+        deferUntilIdle: false,
+        submittedPrompt: 'normal command',
+      });
 
       unmount();
     });
@@ -4022,7 +4059,10 @@ describe('InputPrompt', () => {
         expect(stdout.lastFrame()).not.toContain('(r:)');
       });
 
-      expect(props.onSubmit).toHaveBeenCalledWith('echo hello');
+      expect(props.onSubmit).toHaveBeenCalledWith('echo hello', {
+        deferUntilIdle: false,
+        submittedPrompt: 'echo hello',
+      });
       unmount();
     });
 
@@ -4498,7 +4538,10 @@ describe('InputPrompt', () => {
         await flush();
 
         // Verify onSubmit was called with expanded content
-        expect(props.onSubmit).toHaveBeenCalledWith(largeContent);
+        expect(props.onSubmit).toHaveBeenCalledWith(largeContent, {
+          deferUntilIdle: false,
+          submittedPrompt: '[Pasted Content 1001 chars]',
+        });
       } finally {
         vi.useRealTimers();
         unmount();
@@ -4540,6 +4583,11 @@ describe('InputPrompt', () => {
 
         expect(props.onSubmit).toHaveBeenCalledWith(
           `${secondPaste}\n${firstPaste}`,
+          {
+            deferUntilIdle: false,
+            submittedPrompt:
+              '[Pasted Content 1001 chars] #2\n[Pasted Content 1001 chars]',
+          },
         );
       } finally {
         vi.useRealTimers();
@@ -4577,7 +4625,10 @@ describe('InputPrompt', () => {
         expect(mockShellHistory.addCommandToHistory).toHaveBeenCalledWith(
           largeContent,
         );
-        expect(props.onSubmit).toHaveBeenCalledWith(largeContent);
+        expect(props.onSubmit).toHaveBeenCalledWith(largeContent, {
+          deferUntilIdle: false,
+          submittedPrompt: '[Pasted Content 1001 chars]',
+        });
       } finally {
         vi.useRealTimers();
         unmount();

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -413,6 +413,66 @@ describe('InputPrompt', () => {
     unmount();
   });
 
+  it('prepares submission provenance before clearing the input buffer', async () => {
+    const prepareInputSubmission = vi.fn();
+    mockedUseUIActions.mockReturnValue({
+      handleRetryLastPrompt: vi.fn(),
+      temporaryCloseFeedbackDialog: vi.fn(),
+      popAllQueuedMessages: vi.fn(() => null),
+      prepareInputSubmission,
+    } as unknown as ReturnType<typeof useUIActions>);
+    props.buffer.setText('restored prompt');
+    vi.mocked(props.buffer.setText).mockClear();
+
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+
+    act(() => {
+      stdin.write('\r');
+    });
+
+    await waitFor(() => {
+      expect(prepareInputSubmission).toHaveBeenCalledWith('restored prompt');
+      expect(props.buffer.setText).toHaveBeenCalledWith('');
+      expect(props.onSubmit).toHaveBeenCalledWith('restored prompt');
+    });
+    expect(prepareInputSubmission.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(props.buffer.setText).mock.invocationCallOrder[0],
+    );
+    expect(
+      vi.mocked(props.buffer.setText).mock.invocationCallOrder[0],
+    ).toBeLessThan(vi.mocked(props.onSubmit).mock.invocationCallOrder[0]);
+    unmount();
+  });
+
+  it('clears restored provenance before applying same-text history', async () => {
+    const clearRestoredSubmission = vi.fn();
+    mockedUseUIActions.mockReturnValue({
+      handleRetryLastPrompt: vi.fn(),
+      temporaryCloseFeedbackDialog: vi.fn(),
+      popAllQueuedMessages: vi.fn(() => null),
+      clearRestoredSubmission,
+    } as unknown as ReturnType<typeof useUIActions>);
+    props.buffer.setText('repeat prompt');
+    vi.mocked(props.buffer.setText).mockClear();
+
+    const { unmount } = renderWithProviders(<InputPrompt {...props} />);
+    const historyArgs = mockedUseInputHistory.mock.calls.at(-1)?.[0];
+    if (!historyArgs) {
+      throw new Error('useInputHistory was not called');
+    }
+
+    act(() => {
+      historyArgs.onChange('repeat prompt');
+    });
+
+    expect(clearRestoredSubmission).toHaveBeenCalledOnce();
+    expect(props.buffer.setText).toHaveBeenCalledWith('repeat prompt');
+    expect(clearRestoredSubmission.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(props.buffer.setText).mock.invocationCallOrder[0],
+    );
+    unmount();
+  });
+
   it('queues the prompt for the next turn on Ctrl+Q', async () => {
     props.buffer.setText('send this later');
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
@@ -1400,6 +1460,37 @@ describe('InputPrompt', () => {
       expect(clipboardUtils.saveClipboardImage).toHaveBeenCalled();
       expect(clipboardUtils.cleanupOldClipboardImages).toHaveBeenCalled();
       // Note: The new implementation adds images as attachments rather than inserting into buffer
+      unmount();
+    });
+
+    it('keeps generated attachment references out of submitted provenance', async () => {
+      const imagePath = path.join(
+        'test',
+        'project',
+        'src',
+        '.qwen',
+        'tmp',
+        'clipboard.png',
+      );
+      vi.mocked(clipboardUtils.clipboardHasImage).mockResolvedValue(true);
+      vi.mocked(clipboardUtils.saveClipboardImage).mockResolvedValue(imagePath);
+      props.buffer.setText('describe this image');
+
+      const { stdin, unmount } = renderWithProviders(
+        <InputPrompt {...props} />,
+      );
+      await wait();
+
+      stdin.write(isWindows ? '\x1Bv' : '\x16');
+      await wait();
+      stdin.write('\r');
+
+      await waitFor(() => {
+        expect(props.onSubmit).toHaveBeenCalledWith(
+          '@.qwen/tmp/clipboard.png\n\ndescribe this image',
+          { submittedPrompt: 'describe this image' },
+        );
+      });
       unmount();
     });
 

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -601,6 +601,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     (submittedValue: string, deferUntilIdle = false) => {
       exportCompletion.reset();
       // Expand any large paste placeholders to their full content before submitting
+      const submittedPrompt = submittedValue;
       let finalValue = submittedValue;
       if (pendingPastes.size > 0) {
         finalValue = expandPendingPastePlaceholders(finalValue, pendingPastes);
@@ -611,8 +612,6 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         shellHistory.addCommandToHistory(finalValue);
       }
 
-      const submittedPrompt = finalValue;
-
       // Convert attachments to @references and prepend to the message
       if (attachments.length > 0) {
         const attachmentRefs = attachments
@@ -621,21 +620,11 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         finalValue = `${attachmentRefs}\n\n${finalValue.trim()}`;
       }
 
-      uiActions.prepareInputSubmission?.(finalValue);
       // Clear the buffer *before* calling onSubmit to prevent potential re-submission
       // if onSubmit triggers a re-render while the buffer still holds the old value.
       buffer.setText('');
       clearPromptStash(targetDir);
-      if (deferUntilIdle) {
-        onSubmit(finalValue, {
-          deferUntilIdle: true,
-          ...(attachments.length > 0 ? { submittedPrompt } : {}),
-        });
-      } else if (attachments.length > 0) {
-        onSubmit(finalValue, { submittedPrompt });
-      } else {
-        onSubmit(finalValue);
-      }
+      onSubmit(finalValue, { deferUntilIdle, submittedPrompt });
 
       // Reset history navigation so the next Up-arrow starts from the newest
       // entry rather than advancing from whatever index the user picked.
@@ -671,7 +660,6 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       pendingPastes,
       followup,
       onPromptSuggestionDismiss,
-      uiActions,
     ],
   );
 
@@ -680,7 +668,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
   const customSetTextAndResetCompletionSignal = useCallback(
     (newText: string) => {
-      uiActions.clearRestoredSubmission?.();
+      uiActions.clearRestoredSubmission();
       buffer.setText(newText);
       setHistoryRestoredText(newText);
     },

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -668,7 +668,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
   const customSetTextAndResetCompletionSignal = useCallback(
     (newText: string) => {
-      uiActions.clearRestoredSubmission();
+      uiActions.invalidateSubmittedPromptProvenance();
       buffer.setText(newText);
       setHistoryRestoredText(newText);
     },
@@ -1288,6 +1288,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
             }
           }
           if (keyMatchers[Command.ACCEPT_SUGGESTION_REVERSE_SEARCH](key)) {
+            uiActions.invalidateSubmittedPromptProvenance();
             sc.handleAutocomplete(activeSuggestionIndex);
             resetState();
             setActive(false);
@@ -1300,6 +1301,9 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
             showSuggestions && activeSuggestionIndex > -1
               ? suggestions[activeSuggestionIndex].value
               : buffer.text;
+          if (showSuggestions && activeSuggestionIndex > -1) {
+            uiActions.invalidateSubmittedPromptProvenance();
+          }
           handleSubmitAndClear(textToSubmit);
           resetState();
           setActive(false);
@@ -1650,12 +1654,18 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         // Shell History Navigation
         if (keyMatchers[Command.NAVIGATION_UP](key)) {
           const prevCommand = shellHistory.getPreviousCommand();
-          if (prevCommand !== null) buffer.setText(prevCommand);
+          if (prevCommand !== null) {
+            uiActions.invalidateSubmittedPromptProvenance();
+            buffer.setText(prevCommand);
+          }
           return true;
         }
         if (keyMatchers[Command.NAVIGATION_DOWN](key)) {
           const nextCommand = shellHistory.getNextCommand();
-          if (nextCommand !== null) buffer.setText(nextCommand);
+          if (nextCommand !== null) {
+            uiActions.invalidateSubmittedPromptProvenance();
+            buffer.setText(nextCommand);
+          }
           return true;
         }
       }
@@ -2033,6 +2043,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         const sc = isCommandSearch
           ? commandSearchCompletion
           : reverseSearchCompletion;
+        uiActions.invalidateSubmittedPromptProvenance();
         sc.handleAutocomplete(index);
         sc.resetCompletionState();
         (isCommandSearch ? setCommandSearchActive : setReverseSearchActive)(
@@ -2080,6 +2091,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       setExpandedSuggestionIndex,
       setCommandSearchActive,
       setReverseSearchActive,
+      uiActions,
     ],
   );
 

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -166,7 +166,13 @@ export function expandPendingPastePlaceholders(
 
 export interface InputPromptProps {
   buffer: TextBuffer;
-  onSubmit: (value: string, options?: { deferUntilIdle?: boolean }) => void;
+  onSubmit: (
+    value: string,
+    options?: {
+      deferUntilIdle?: boolean;
+      submittedPrompt?: string;
+    },
+  ) => void;
   userMessages: readonly string[];
   onClearScreen: () => void;
   config: Config;
@@ -605,6 +611,8 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         shellHistory.addCommandToHistory(finalValue);
       }
 
+      const submittedPrompt = finalValue;
+
       // Convert attachments to @references and prepend to the message
       if (attachments.length > 0) {
         const attachmentRefs = attachments
@@ -613,12 +621,18 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         finalValue = `${attachmentRefs}\n\n${finalValue.trim()}`;
       }
 
+      uiActions.prepareInputSubmission?.(finalValue);
       // Clear the buffer *before* calling onSubmit to prevent potential re-submission
       // if onSubmit triggers a re-render while the buffer still holds the old value.
       buffer.setText('');
       clearPromptStash(targetDir);
       if (deferUntilIdle) {
-        onSubmit(finalValue, { deferUntilIdle: true });
+        onSubmit(finalValue, {
+          deferUntilIdle: true,
+          ...(attachments.length > 0 ? { submittedPrompt } : {}),
+        });
+      } else if (attachments.length > 0) {
+        onSubmit(finalValue, { submittedPrompt });
       } else {
         onSubmit(finalValue);
       }
@@ -657,6 +671,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       pendingPastes,
       followup,
       onPromptSuggestionDismiss,
+      uiActions,
     ],
   );
 
@@ -665,10 +680,11 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
   const customSetTextAndResetCompletionSignal = useCallback(
     (newText: string) => {
+      uiActions.clearRestoredSubmission?.();
       buffer.setText(newText);
       setHistoryRestoredText(newText);
     },
-    [buffer],
+    [buffer, uiActions],
   );
 
   const inputHistory = useInputHistory({

--- a/packages/cli/src/ui/components/hooks/constants.test.ts
+++ b/packages/cli/src/ui/components/hooks/constants.test.ts
@@ -212,6 +212,14 @@ describe('hooks constants', () => {
       expect(desc).toContain('load_reason');
     });
 
+    it('should distinguish model-bound and submitted prompts', () => {
+      const desc = getHookDescription(HookEventName.UserPromptSubmit);
+      expect(desc).toContain('"prompt"');
+      expect(desc).toContain('model-bound');
+      expect(desc).toContain('"submitted_prompt"');
+      expect(desc).toContain('interactive TUI');
+    });
+
     it('should return description for PostCompact', () => {
       const desc = getHookDescription(HookEventName.PostCompact);
       expect(desc).toContain('trigger');

--- a/packages/cli/src/ui/components/hooks/constants.ts
+++ b/packages/cli/src/ui/components/hooks/constants.ts
@@ -234,7 +234,7 @@ export function getHookDescription(eventName: string): string {
       'Input to command is JSON with file_path, memory_type, load_reason, and optional trigger_file_path and parent_file_path.',
     ),
     [HookEventName.UserPromptSubmit]: t(
-      'Input to command is JSON with original user prompt text.',
+      'Input to command is JSON with "prompt" (the current model-bound prompt) and optional "submitted_prompt" (the supported interactive TUI text projection).',
     ),
     [HookEventName.UserPromptExpansion]: t(
       'Input to command is JSON with command_name, command_args, and expanded prompt text.',

--- a/packages/cli/src/ui/components/shared/text-buffer.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.test.ts
@@ -73,6 +73,26 @@ describe('textBufferReducer', () => {
       expect(state.lines).toEqual(['no undo']);
       expect(state.undoStack.length).toBe(0);
     });
+
+    it('should clear undo and redo history when requested', () => {
+      const stateWithHistory: TextBufferState = {
+        ...initialState,
+        lines: ['history-derived'],
+        undoStack: [{ lines: ['draft'], cursorRow: 0, cursorCol: 5 }],
+        redoStack: [{ lines: ['other'], cursorRow: 0, cursorCol: 5 }],
+      };
+      const state = textBufferReducer(stateWithHistory, {
+        type: 'set_text',
+        payload: '',
+        clearUndoHistory: true,
+      });
+
+      expect(state.lines).toEqual(['']);
+      expect(state.undoStack).toEqual([]);
+      expect(state.redoStack).toEqual([]);
+      expect(textBufferReducer(state, { type: 'undo' }).lines).toEqual(['']);
+      expect(textBufferReducer(state, { type: 'redo' }).lines).toEqual(['']);
+    });
   });
 
   describe('insert action', () => {

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -1168,7 +1168,12 @@ export const pushUndo = (currentState: TextBufferState): TextBufferState => {
 };
 
 export type TextBufferAction =
-  | { type: 'set_text'; payload: string; pushToUndo?: boolean }
+  | {
+      type: 'set_text';
+      payload: string;
+      pushToUndo?: boolean;
+      clearUndoHistory?: boolean;
+    }
   | { type: 'insert'; payload: string }
   | { type: 'backspace' }
   | {
@@ -1257,8 +1262,10 @@ function textBufferReducerLogic(
 
   switch (action.type) {
     case 'set_text': {
-      let nextState = state;
-      if (action.pushToUndo !== false) {
+      let nextState = action.clearUndoHistory
+        ? { ...state, undoStack: [], redoStack: [] }
+        : state;
+      if (!action.clearUndoHistory && action.pushToUndo !== false) {
         nextState = pushUndoLocal(state);
       }
       const newContentLines = action.payload
@@ -2165,6 +2172,8 @@ export function useTextBuffer({
   const [visualScrollRow, setVisualScrollRow] = useState<number>(0);
 
   useEffect(() => {
+    // Keep change notification post-render: InputPrompt clears this buffer
+    // before its synchronous submit callback consumes restored provenance.
     if (onChange) {
       onChange(text);
     }
@@ -2277,8 +2286,12 @@ export function useTextBuffer({
   }, [dispatch]);
 
   const setText = useCallback(
-    (newText: string): void => {
-      dispatch({ type: 'set_text', payload: newText });
+    (newText: string, options?: { clearUndoHistory?: boolean }): void => {
+      dispatch({
+        type: 'set_text',
+        payload: newText,
+        clearUndoHistory: options?.clearUndoHistory,
+      });
     },
     [dispatch],
   );
@@ -2919,9 +2932,9 @@ export interface TextBuffer {
 
   /**
    * Replaces the entire buffer content with the provided text.
-   * The operation is undoable.
+   * The operation is undoable unless `clearUndoHistory` is set.
    */
-  setText: (text: string) => void;
+  setText: (text: string, options?: { clearUndoHistory?: boolean }) => void;
   /**
    * Insert a single character or string without newlines.
    */

--- a/packages/cli/src/ui/contexts/UIActionsContext.tsx
+++ b/packages/cli/src/ui/contexts/UIActionsContext.tsx
@@ -85,8 +85,7 @@ export interface UIActions {
   handleRetryLastPrompt: () => void;
   handleClearScreen: () => void;
   popAllQueuedMessages: () => string | null;
-  clearRestoredSubmission?: () => void;
-  prepareInputSubmission?: (value: string) => void;
+  clearRestoredSubmission: () => void;
   // Welcome back dialog
   handleWelcomeBackSelection: (choice: 'continue' | 'restart') => void;
   handleWelcomeBackClose: () => void;

--- a/packages/cli/src/ui/contexts/UIActionsContext.tsx
+++ b/packages/cli/src/ui/contexts/UIActionsContext.tsx
@@ -77,11 +77,16 @@ export interface UIActions {
   refreshStatic: () => void;
   handleFinalSubmit: (
     value: string,
-    options?: { deferUntilIdle?: boolean },
+    options?: {
+      deferUntilIdle?: boolean;
+      submittedPrompt?: string;
+    },
   ) => void;
   handleRetryLastPrompt: () => void;
   handleClearScreen: () => void;
   popAllQueuedMessages: () => string | null;
+  clearRestoredSubmission?: () => void;
+  prepareInputSubmission?: (value: string) => void;
   // Welcome back dialog
   handleWelcomeBackSelection: (choice: 'continue' | 'restart') => void;
   handleWelcomeBackClose: () => void;

--- a/packages/cli/src/ui/contexts/UIActionsContext.tsx
+++ b/packages/cli/src/ui/contexts/UIActionsContext.tsx
@@ -85,7 +85,7 @@ export interface UIActions {
   handleRetryLastPrompt: () => void;
   handleClearScreen: () => void;
   popAllQueuedMessages: () => string | null;
-  clearRestoredSubmission: () => void;
+  invalidateSubmittedPromptProvenance: () => void;
   // Welcome back dialog
   handleWelcomeBackSelection: (choice: 'continue' | 'restart') => void;
   handleWelcomeBackClose: () => void;

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -30,6 +30,7 @@ import {
   AUTONOMOUS_SENTINEL_DYNAMIC,
   AuthType,
   GeminiEventType as ServerGeminiEventType,
+  MessageSenderType,
   SendMessageType,
   ToolErrorType,
   ToolConfirmationOutcome,
@@ -348,6 +349,8 @@ describe('useGeminiStream', () => {
     initialToolCalls: TrackedToolCall[] = [],
     geminiClient?: any,
     availableTerminalHeightRef?: { current: number },
+    onCancelSubmit: Parameters<typeof useGeminiStream>[15] = () => {},
+    logger?: Parameters<typeof useGeminiStream>[20],
   ) => {
     let currentToolCalls = initialToolCalls;
     const setToolCalls = (newToolCalls: TrackedToolCall[]) => {
@@ -397,12 +400,12 @@ describe('useGeminiStream', () => {
           false,
           () => {},
           () => {},
-          () => {},
+          onCancelSubmit,
           () => {},
           80,
           24,
           undefined, // midTurnDrainRef
-          undefined, // logger
+          logger,
           availableTerminalHeightRef,
         );
       },
@@ -469,6 +472,54 @@ describe('useGeminiStream', () => {
     });
   });
 
+  it('forwards submitted prompt provenance only for UserQuery', async () => {
+    const { result, mockSendMessageStream } = renderTestHook();
+
+    await act(async () => {
+      await result.current.submitQuery(
+        '<system-reminder>managed</system-reminder>\n\nreview this',
+        SendMessageType.UserQuery,
+        undefined,
+        { submittedPrompt: 'review this' },
+      );
+    });
+
+    expect(mockSendMessageStream.mock.calls[0]?.[3]).toEqual(
+      expect.objectContaining({
+        type: SendMessageType.UserQuery,
+        submittedPrompt: 'review this',
+      }),
+    );
+
+    mockSendMessageStream.mockClear();
+    await act(async () => {
+      await result.current.submitQuery(
+        'retry payload',
+        SendMessageType.Retry,
+        undefined,
+        { submittedPrompt: 'must not escape' },
+      );
+    });
+
+    expect(mockSendMessageStream.mock.calls[0]?.[3]).not.toHaveProperty(
+      'submittedPrompt',
+    );
+
+    mockSendMessageStream.mockClear();
+    await act(async () => {
+      await result.current.submitQuery(
+        'tool result payload',
+        SendMessageType.ToolResult,
+        undefined,
+        { submittedPrompt: 'must not escape' },
+      );
+    });
+
+    expect(mockSendMessageStream.mock.calls[0]?.[3]).not.toHaveProperty(
+      'submittedPrompt',
+    );
+  });
+
   describe('vision bridge gate', () => {
     const imagePart = { inlineData: { mimeType: 'image/png', data: 'abc123' } };
     const enableBridge = (primaryAcceptsImages = false) => {
@@ -499,13 +550,23 @@ describe('useGeminiStream', () => {
       });
       const { result, mockSendMessageStream } = renderTestHook();
       await act(async () => {
-        await result.current.submitQuery('@img.png describe');
+        await result.current.submitQuery(
+          '@img.png describe',
+          SendMessageType.UserQuery,
+          undefined,
+          { submittedPrompt: '@img.png describe' },
+        );
       });
       await waitFor(() => expect(mockRunVisionBridge).toHaveBeenCalledTimes(1));
       await waitFor(() => expect(mockSendMessageStream).toHaveBeenCalled());
       const sent = JSON.stringify(mockSendMessageStream.mock.calls[0][0]);
       expect(sent).toContain('[transcribed image]');
       expect(sent).not.toContain('inlineData');
+      expect(mockSendMessageStream.mock.calls[0]?.[3]).toEqual(
+        expect.objectContaining({
+          submittedPrompt: '@img.png describe',
+        }),
+      );
       expect(mockAddItem).toHaveBeenCalledWith(
         expect.objectContaining({
           type: MessageType.VISION_NOTICE,
@@ -6010,11 +6071,18 @@ describe('useGeminiStream', () => {
           () => {},
           80,
           24,
+          undefined,
+          { logMessage: vi.fn() } as any,
         ),
       );
 
       await act(async () => {
-        result.current.submitQuery('what time is it?');
+        result.current.submitQuery(
+          '<system-reminder>managed</system-reminder>\n\nwhat time is it?',
+          SendMessageType.UserQuery,
+          undefined,
+          { submittedPrompt: 'what time is it?' },
+        );
       });
 
       act(() => {
@@ -6030,8 +6098,10 @@ describe('useGeminiStream', () => {
       // content before cancel; that's covered by a separate test below.)
       expect(info?.lastTurnUserItem).toEqual({
         id: expect.any(Number),
-        text: 'what time is it?',
+        text: '<system-reminder>managed</system-reminder>\n\nwhat time is it?',
+        submittedPrompt: 'what time is it?',
       });
+      expect(info?.canUndoLastLoggedUserMessage).toBe(true);
     });
 
     it('emits lastTurnUserItem: null for paths that do NOT add a user history item (Notification)', async () => {
@@ -6702,7 +6772,12 @@ describe('useGeminiStream', () => {
         renderTestHook();
 
       await act(async () => {
-        await result.current.submitQuery('/my-custom-command');
+        await result.current.submitQuery(
+          '/my-custom-command',
+          SendMessageType.UserQuery,
+          undefined,
+          { submittedPrompt: '/my-custom-command' },
+        );
       });
 
       await waitFor(() => {
@@ -6720,7 +6795,10 @@ describe('useGeminiStream', () => {
           'This is the actual prompt from the command file.',
           expect.any(AbortSignal),
           expect.any(String),
-          { type: SendMessageType.UserQuery },
+          expect.objectContaining({
+            type: SendMessageType.UserQuery,
+            submittedPrompt: '/my-custom-command',
+          }),
         );
 
         expect(mockScheduleToolCalls).not.toHaveBeenCalled();
@@ -8238,7 +8316,12 @@ describe('useGeminiStream', () => {
     );
 
     await act(async () => {
-      await result.current.submitQuery(rawQuery);
+      await result.current.submitQuery(
+        rawQuery,
+        SendMessageType.UserQuery,
+        undefined,
+        { submittedPrompt: rawQuery },
+      );
     });
 
     expect(handleAtCommandSpy).toHaveBeenCalledWith(
@@ -8261,7 +8344,10 @@ describe('useGeminiStream', () => {
       processedQueryParts, // Argument 1: The parts array directly
       expect.any(AbortSignal), // Argument 2: An AbortSignal
       expect.any(String), // Argument 3: The prompt_id string
-      { type: SendMessageType.UserQuery }, // Argument 4: The options
+      expect.objectContaining({
+        type: SendMessageType.UserQuery,
+        submittedPrompt: rawQuery,
+      }), // Argument 4: The options
     );
   });
 
@@ -9600,7 +9686,8 @@ describe('useGeminiStream', () => {
   });
 
   describe('Concurrent Execution Prevention', () => {
-    it('should allow /btw slash commands while a main response is in progress', async () => {
+    it('should handle /btw as a UI-only command while a main response is in progress', async () => {
+      const btwQuery = '/btw quick side question';
       let resolveFirstCall!: () => void;
 
       const firstCallPromise = new Promise<void>((resolve) => {
@@ -9617,7 +9704,7 @@ describe('useGeminiStream', () => {
 
       mockSendMessageStream.mockImplementation(() => firstStream);
       mockHandleSlashCommand.mockImplementation(async (command) => {
-        if (command === '/btw quick side question') {
+        if (command === btwQuery) {
           return { type: 'handled' };
         }
         return false;
@@ -9637,12 +9724,10 @@ describe('useGeminiStream', () => {
         });
 
         await act(async () => {
-          await result.current.submitQuery('/btw quick side question');
+          await result.current.submitQuery(btwQuery);
         });
 
-        expect(mockHandleSlashCommand).toHaveBeenCalledWith(
-          '/btw quick side question',
-        );
+        expect(mockHandleSlashCommand).toHaveBeenCalledWith(btwQuery);
         expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
       } finally {
         resolveFirstCall();
@@ -9651,6 +9736,7 @@ describe('useGeminiStream', () => {
     });
 
     it('should keep the main request cancellable after submitting /btw in parallel', async () => {
+      const btwQuery = '/btw quick side question';
       let resolveFirstCall!: () => void;
       let mainAbortSignal: AbortSignal | undefined;
 
@@ -9669,17 +9755,30 @@ describe('useGeminiStream', () => {
         })();
       });
       mockHandleSlashCommand.mockImplementation(async (command) => {
-        if (command === '/btw quick side question') {
+        if (command === btwQuery) {
           return { type: 'handled' };
         }
         return false;
       });
 
-      const { result } = renderTestHook();
+      const cancelSubmitSpy = vi.fn();
+      const mockLogMessage = vi.fn();
+      const { result } = renderTestHook(
+        [],
+        undefined,
+        undefined,
+        cancelSubmitSpy,
+        { logMessage: mockLogMessage } as any,
+      );
 
       let mainRequest!: Promise<void>;
       await act(async () => {
-        mainRequest = result.current.submitQuery('First query');
+        mainRequest = result.current.submitQuery(
+          '<system-reminder>managed</system-reminder>\n\nFirst query',
+          SendMessageType.UserQuery,
+          undefined,
+          { submittedPrompt: 'First query' },
+        );
       });
 
       try {
@@ -9689,7 +9788,12 @@ describe('useGeminiStream', () => {
         });
 
         await act(async () => {
-          await result.current.submitQuery('/btw quick side question');
+          await result.current.submitQuery(
+            btwQuery,
+            SendMessageType.UserQuery,
+            undefined,
+            { submittedPrompt: btwQuery },
+          );
         });
 
         act(() => {
@@ -9704,6 +9808,107 @@ describe('useGeminiStream', () => {
           expect.any(Number),
         );
         expect(mainAbortSignal?.aborted).toBe(true);
+        expect(
+          cancelSubmitSpy.mock.calls.at(-1)?.[0]?.lastTurnUserItem,
+        ).toEqual({
+          id: expect.any(Number),
+          text: '<system-reminder>managed</system-reminder>\n\nFirst query',
+          submittedPrompt: 'First query',
+        });
+        expect(
+          cancelSubmitSpy.mock.calls.at(-1)?.[0]?.canUndoLastLoggedUserMessage,
+        ).toBe(false);
+        expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
+        expect(mockLogMessage).toHaveBeenNthCalledWith(
+          2,
+          MessageSenderType.USER,
+          btwQuery,
+        );
+      } finally {
+        resolveFirstCall();
+        await mainRequest;
+      }
+    });
+
+    it('should preserve the legacy model path for ?btw during a main response', async () => {
+      const btwQuery = '?btw quick side question';
+      let resolveFirstCall!: () => void;
+      let mainAbortSignal: AbortSignal | undefined;
+      let callCount = 0;
+
+      const firstCallPromise = new Promise<void>((resolve) => {
+        resolveFirstCall = resolve;
+      });
+
+      mockSendMessageStream.mockImplementation((_query, signal) => {
+        callCount += 1;
+        if (callCount === 1) {
+          mainAbortSignal = signal;
+          return (async function* () {
+            yield {
+              type: ServerGeminiEventType.Content,
+              value: 'First call content',
+            };
+            await firstCallPromise;
+          })();
+        }
+        return (async function* () {})();
+      });
+
+      const cancelSubmitSpy = vi.fn();
+      const { result } = renderTestHook(
+        [],
+        undefined,
+        undefined,
+        cancelSubmitSpy,
+      );
+
+      let mainRequest!: Promise<void>;
+      await act(async () => {
+        mainRequest = result.current.submitQuery(
+          '<system-reminder>managed</system-reminder>\n\nFirst query',
+          SendMessageType.UserQuery,
+          undefined,
+          { submittedPrompt: 'First query' },
+        );
+      });
+
+      try {
+        await waitFor(() => {
+          expect(mainAbortSignal).toBeDefined();
+          expect(result.current.streamingState).toBe(StreamingState.Responding);
+        });
+
+        await act(async () => {
+          await result.current.submitQuery(
+            btwQuery,
+            SendMessageType.UserQuery,
+            undefined,
+            { submittedPrompt: btwQuery },
+          );
+        });
+
+        expect(mockHandleSlashCommand).not.toHaveBeenCalledWith(btwQuery);
+        expect(mockSendMessageStream).toHaveBeenCalledTimes(2);
+        expect(mockSendMessageStream.mock.calls[1]?.[3]).toEqual(
+          expect.objectContaining({
+            type: SendMessageType.UserQuery,
+            submittedPrompt: btwQuery,
+          }),
+        );
+
+        act(() => {
+          result.current.cancelOngoingRequest();
+        });
+
+        expect(mainAbortSignal?.aborted).toBe(true);
+        expect(
+          cancelSubmitSpy.mock.calls.at(-1)?.[0]?.lastTurnUserItem,
+        ).toEqual({
+          id: expect.any(Number),
+          text: '<system-reminder>managed</system-reminder>\n\nFirst query',
+          submittedPrompt: 'First query',
+        });
       } finally {
         resolveFirstCall();
         await mainRequest;

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -385,7 +385,18 @@ export interface CancelSubmitInfo {
    * consecutive-duplicate user message (text alone would wrongly match
    * the older row).
    */
-  lastTurnUserItem: { id: number; text: string } | null;
+  lastTurnUserItem: {
+    id: number;
+    text: string;
+    submittedPrompt?: string;
+  } | null;
+  /**
+   * Whether removing the Logger's latest USER entry can only target
+   * `lastTurnUserItem`. A concurrent BTW command writes a newer USER entry,
+   * so the cancel handler must keep the log intact rather than remove the
+   * side-question by mistake.
+   */
+  canUndoLastLoggedUserMessage: boolean;
   /**
    * True if a content event landed during this turn, including during
    * the pre-cancel flush of throttle-buffered events. Lets the
@@ -454,7 +465,12 @@ export const useGeminiStream = (
   // messages while still returning a freshly-generated id — text alone
   // would let the auto-restore guard wrongly match an older USER row
   // when the user re-submits the same prompt.
-  const lastTurnUserItemRef = useRef<{ id: number; text: string } | null>(null);
+  const lastTurnUserItemRef = useRef<{
+    id: number;
+    text: string;
+    submittedPrompt?: string;
+  } | null>(null);
+  const canUndoLastLoggedUserMessageRef = useRef(false);
   // Set to true the first time a content event lands this turn — even
   // during the pre-cancel flush. AppContainer's auto-restore guard
   // can't otherwise see content that was just addItem'd inside flush
@@ -863,6 +879,7 @@ export const useGeminiStream = (
       onCancelSubmit({
         pendingItem: pendingItemAtCancel,
         lastTurnUserItem: lastTurnUserItemRef.current,
+        canUndoLastLoggedUserMessage: canUndoLastLoggedUserMessageRef.current,
         turnProducedMeaningfulContent: turnSawContentEventRef.current,
       });
     } finally {
@@ -974,6 +991,8 @@ export const useGeminiStream = (
       abortSignal: AbortSignal,
       prompt_id: string,
       submitType: SendMessageType,
+      submittedPrompt: string | undefined,
+      preserveTurnOwnership: boolean,
     ): Promise<{
       queryToSend: PartListUnion | null;
       shouldProceed: boolean;
@@ -989,7 +1008,9 @@ export const useGeminiStream = (
       // this — paths that don't add a USER history item (Cron /
       // Notification / slash submit_prompt) leave it null so cancel
       // never wrongly targets an older user item.
-      lastTurnUserItemRef.current = null;
+      if (!preserveTurnOwnership) {
+        lastTurnUserItemRef.current = null;
+      }
 
       let localQueryToSendToGemini: PartListUnion | null = null;
 
@@ -1024,6 +1045,8 @@ export const useGeminiStream = (
 
         onDebugMessage(`Received user query (${trimmedQuery.length} chars)`);
         await logger?.logMessage(MessageSenderType.USER, trimmedQuery);
+        canUndoLastLoggedUserMessageRef.current =
+          !preserveTurnOwnership && logger != null;
 
         // Handle UI-only commands first
         const slashCommandResult = isSlashCommand(trimmedQuery)
@@ -1128,10 +1151,13 @@ export const useGeminiStream = (
           // skipped insertion (consecutive-duplicate user); the older
           // matching USER in history carries a DIFFERENT id, so the
           // mismatch makes auto-restore bail correctly in that case.
-          lastTurnUserItemRef.current = {
-            id: insertedId,
-            text: trimmedQuery,
-          };
+          if (!preserveTurnOwnership) {
+            lastTurnUserItemRef.current = {
+              id: insertedId,
+              text: trimmedQuery,
+              ...(submittedPrompt === undefined ? {} : { submittedPrompt }),
+            };
+          }
 
           // Yield via macrotask to let Ink/React flush the user message
           // render before continuing with @-command processing and API
@@ -2629,6 +2655,7 @@ export const useGeminiStream = (
         onDelivered?: () => void;
         onDeliveryFailed?: () => void;
         steerInput?: SteerInput;
+        submittedPrompt?: string;
       },
     ) => {
       const allowConcurrentBtwDuringResponse =
@@ -2686,6 +2713,7 @@ export const useGeminiStream = (
       // turn that already owns its own snapshot.
       if (!isTurnContinuation && !allowConcurrentBtwDuringResponse) {
         lastTurnUserItemRef.current = null;
+        canUndoLastLoggedUserMessageRef.current = false;
         turnSawContentEventRef.current = false;
         handledProviderToolCallIdsRef.current.clear();
         duplicateProviderToolCallResponseIdsRef.current.clear();
@@ -2775,6 +2803,10 @@ export const useGeminiStream = (
                 abortSignal,
                 prompt_id!,
                 submitType,
+                submitType === SendMessageType.UserQuery
+                  ? metadata?.submittedPrompt
+                  : undefined,
+                allowConcurrentBtwDuringResponse,
               );
 
         if (!shouldProceed || queryToSend === null) {
@@ -2865,19 +2897,24 @@ export const useGeminiStream = (
             dualOutput.emitUserMessage(userParts);
           }
 
+          const sendOptions = {
+            type: submitType,
+            notificationDisplayText: metadata?.notificationDisplayText,
+            modelOverride: modelOverrideRef.current,
+            steerInput: metadata?.steerInput,
+            ...(submitType === SendMessageType.UserQuery &&
+            metadata?.submittedPrompt !== undefined
+              ? { submittedPrompt: metadata.submittedPrompt }
+              : {}),
+            ...(!allowConcurrentBtwDuringResponse && midTurnDrainRef
+              ? { getSteerInput: drainSteerAtBoundary }
+              : {}),
+          };
           const stream = geminiClient.sendMessageStream(
             finalQueryToSend,
             abortSignal,
             prompt_id!,
-            {
-              type: submitType,
-              notificationDisplayText: metadata?.notificationDisplayText,
-              modelOverride: modelOverrideRef.current,
-              steerInput: metadata?.steerInput,
-              ...(!allowConcurrentBtwDuringResponse && midTurnDrainRef
-                ? { getSteerInput: drainSteerAtBoundary }
-                : {}),
-            },
+            sendOptions,
           );
 
           const processingStatus = await processGeminiStreamEvents(

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -2666,6 +2666,10 @@ export const useGeminiStream = (
       const isTurnContinuation =
         submitType === SendMessageType.ToolResult ||
         submitType === SendMessageType.Steer;
+      const submittedPrompt =
+        submitType === SendMessageType.UserQuery
+          ? metadata?.submittedPrompt
+          : undefined;
 
       // Prevent concurrent executions of submitQuery, but allow continuations
       // which are part of the same logical flow (tool responses)
@@ -2803,9 +2807,7 @@ export const useGeminiStream = (
                 abortSignal,
                 prompt_id!,
                 submitType,
-                submitType === SendMessageType.UserQuery
-                  ? metadata?.submittedPrompt
-                  : undefined,
+                submittedPrompt,
                 allowConcurrentBtwDuringResponse,
               );
 
@@ -2902,10 +2904,7 @@ export const useGeminiStream = (
             notificationDisplayText: metadata?.notificationDisplayText,
             modelOverride: modelOverrideRef.current,
             steerInput: metadata?.steerInput,
-            ...(submitType === SendMessageType.UserQuery &&
-            metadata?.submittedPrompt !== undefined
-              ? { submittedPrompt: metadata.submittedPrompt }
-              : {}),
+            ...(submittedPrompt !== undefined ? { submittedPrompt } : {}),
             ...(!allowConcurrentBtwDuringResponse && midTurnDrainRef
               ? { getSteerInput: drainSteerAtBoundary }
               : {}),

--- a/packages/cli/src/ui/hooks/useMessageQueue.test.ts
+++ b/packages/cli/src/ui/hooks/useMessageQueue.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { useMessageQueue } from './useMessageQueue.js';
+import { useMessageQueue, type QueuedSubmission } from './useMessageQueue.js';
 
 describe('useMessageQueue', () => {
   beforeEach(() => {
@@ -89,7 +89,7 @@ describe('useMessageQueue', () => {
     it('returns null when the queue is empty', () => {
       const { result } = renderHook(() => useMessageQueue());
 
-      let popped: string | null = null;
+      let popped: QueuedSubmission | null = null;
       act(() => {
         popped = result.current.popAllMessages();
       });
@@ -107,12 +107,14 @@ describe('useMessageQueue', () => {
         result.current.addMessage('Message 3');
       });
 
-      let popped: string | null = null;
+      let popped: QueuedSubmission | null = null;
       act(() => {
         popped = result.current.popAllMessages();
       });
 
-      expect(popped).toBe('Message 1\n\nMessage 2\n\nMessage 3');
+      expect(popped).toEqual({
+        modelText: 'Message 1\n\nMessage 2\n\nMessage 3',
+      });
       expect(result.current.messageQueue).toEqual([]);
     });
 
@@ -123,12 +125,12 @@ describe('useMessageQueue', () => {
         result.current.addMessage('Only message');
       });
 
-      let popped: string | null = null;
+      let popped: QueuedSubmission | null = null;
       act(() => {
         popped = result.current.popAllMessages();
       });
 
-      expect(popped).toBe('Only message');
+      expect(popped).toEqual({ modelText: 'Only message' });
       expect(result.current.messageQueue).toEqual([]);
     });
 
@@ -144,13 +146,52 @@ describe('useMessageQueue', () => {
         result.current.addMessage('world');
       });
 
-      let popped: string | null = null;
+      let popped: QueuedSubmission | null = null;
       act(() => {
         popped = result.current.popAllMessages();
       });
 
-      expect(popped).toBe('/model\n\nhello\n\nworld');
+      expect(popped).toEqual({
+        modelText: '/model\n\nhello\n\nworld',
+      });
       expect(result.current.messageQueue).toEqual([]);
+    });
+
+    it('aggregates provenance only when every queued message has it', () => {
+      const { result } = renderHook(() => useMessageQueue());
+
+      act(() => {
+        result.current.addMessage('model one', false, 'user one');
+        result.current.addMessage('model two', false, 'user two');
+      });
+
+      let popped: QueuedSubmission | null = null;
+      act(() => {
+        popped = result.current.popAllMessages();
+      });
+
+      expect(popped).toEqual({
+        modelText: 'model one\n\nmodel two',
+        submittedPrompt: 'user one\n\nuser two',
+      });
+    });
+
+    it('omits aggregate provenance when any queued message lacks it', () => {
+      const { result } = renderHook(() => useMessageQueue());
+
+      act(() => {
+        result.current.addMessage('model one', false, 'user one');
+        result.current.addMessage('restored steer');
+      });
+
+      let popped: QueuedSubmission | null = null;
+      act(() => {
+        popped = result.current.popAllMessages();
+      });
+
+      expect(popped).toEqual({
+        modelText: 'model one\n\nrestored steer',
+      });
     });
   });
 
@@ -305,20 +346,39 @@ describe('useMessageQueue', () => {
 
       expect(result.current.messageQueue).toEqual(['steer now', 'newer input']);
     });
+
+    it('drops provenance when interrupted steer messages are restored', () => {
+      const { result } = renderHook(() => useMessageQueue());
+
+      act(() => {
+        result.current.addMessage('steer now', false, 'raw steer');
+      });
+      act(() => {
+        const drained = result.current.drainQueue();
+        result.current.restoreMessages(drained);
+      });
+
+      let submission: QueuedSubmission | null = null;
+      act(() => {
+        submission = result.current.popNextTurn();
+      });
+
+      expect(submission).toEqual({ modelText: 'steer now' });
+    });
   });
 
-  describe('popNextSegment', () => {
+  describe('popNextTurn', () => {
     it('returns null when the queue is empty', () => {
       const { result } = renderHook(() => useMessageQueue());
 
-      let segment: string | null = null;
+      let submission: QueuedSubmission | null = null;
       act(() => {
-        segment = result.current.popNextSegment();
+        submission = result.current.popNextTurn();
       });
-      expect(segment).toBeNull();
+      expect(submission).toBeNull();
     });
 
-    it('pops the first item and leaves the rest queued', () => {
+    it('pops the first slash command and leaves the rest queued', () => {
       const { result } = renderHook(() => useMessageQueue());
 
       act(() => {
@@ -326,15 +386,15 @@ describe('useMessageQueue', () => {
         result.current.addMessage('/help');
       });
 
-      let segment: string | null = null;
+      let submission: QueuedSubmission | null = null;
       act(() => {
-        segment = result.current.popNextSegment();
+        submission = result.current.popNextTurn();
       });
-      expect(segment).toBe('/model');
+      expect(submission).toEqual({ modelText: '/model' });
       expect(result.current.messageQueue).toEqual(['/help']);
     });
 
-    it('drains the queue one item at a time across repeated calls', () => {
+    it('drains slash commands one item at a time across repeated calls', () => {
       const { result } = renderHook(() => useMessageQueue());
 
       act(() => {
@@ -343,22 +403,67 @@ describe('useMessageQueue', () => {
         result.current.addMessage('/help');
       });
 
-      const segments: Array<string | null> = [];
+      const submissions: Array<QueuedSubmission | null> = [];
       act(() => {
-        segments.push(result.current.popNextSegment());
+        submissions.push(result.current.popNextTurn());
       });
       act(() => {
-        segments.push(result.current.popNextSegment());
+        submissions.push(result.current.popNextTurn());
       });
       act(() => {
-        segments.push(result.current.popNextSegment());
+        submissions.push(result.current.popNextTurn());
       });
       act(() => {
-        segments.push(result.current.popNextSegment());
+        submissions.push(result.current.popNextTurn());
       });
 
-      expect(segments).toEqual(['/model', '/theme', '/help', null]);
+      expect(submissions).toEqual([
+        { modelText: '/model' },
+        { modelText: '/theme' },
+        { modelText: '/help' },
+        null,
+      ]);
       expect(result.current.messageQueue).toEqual([]);
+    });
+
+    it('batches all plain prompts while leaving interleaved slash commands', () => {
+      const { result } = renderHook(() => useMessageQueue());
+
+      act(() => {
+        result.current.addMessage('/model');
+        result.current.addMessage('model one', false, 'user one');
+        result.current.addMessage('/help');
+        result.current.addMessage('model two', true, 'user two');
+      });
+
+      let submission: QueuedSubmission | null = null;
+      act(() => {
+        submission = result.current.popNextTurn();
+      });
+
+      expect(submission).toEqual({
+        modelText: 'model one\n\nmodel two',
+        submittedPrompt: 'user one\n\nuser two',
+      });
+      expect(result.current.messageQueue).toEqual(['/model', '/help']);
+    });
+
+    it('fails closed when a batched prompt lacks provenance', () => {
+      const { result } = renderHook(() => useMessageQueue());
+
+      act(() => {
+        result.current.addMessage('model one', false, 'user one');
+        result.current.addMessage('model two');
+      });
+
+      let submission: QueuedSubmission | null = null;
+      act(() => {
+        submission = result.current.popNextTurn();
+      });
+
+      expect(submission).toEqual({
+        modelText: 'model one\n\nmodel two',
+      });
     });
   });
 });

--- a/packages/cli/src/ui/hooks/useMessageQueue.ts
+++ b/packages/cli/src/ui/hooks/useMessageQueue.ts
@@ -9,11 +9,15 @@ import { isSlashCommand } from '../utils/commandUtils.js';
 
 export interface UseMessageQueueReturn {
   messageQueue: string[];
-  addMessage: (message: string, deferUntilIdle?: boolean) => void;
+  addMessage: (
+    message: string,
+    deferUntilIdle?: boolean,
+    submittedPrompt?: string,
+  ) => void;
   clearQueue: () => void;
   getQueuedMessagesText: () => string;
   /** Drain the entire queue joined with `\n\n`. For Ctrl+C / ESC / Up edit-restore. */
-  popAllMessages: () => string | null;
+  popAllMessages: () => QueuedSubmission | null;
   /** Restore interrupted steer messages to the front of the queue. */
   restoreMessages: (messages: string[]) => void;
   /**
@@ -22,32 +26,52 @@ export interface UseMessageQueueReturn {
    * Slash commands stay queued except `/goal`, which must control active loops.
    */
   drainQueue: (includeDeferred?: boolean) => string[];
-  /** Pop the first item from the queue. */
-  popNextSegment: () => string | null;
+  /** Drain the next idle turn while preserving eligible prompt provenance. */
+  popNextTurn: () => QueuedSubmission | null;
 }
 
-interface QueuedMessage {
-  text: string;
+export interface QueuedSubmission {
+  modelText: string;
+  submittedPrompt?: string;
+}
+
+interface QueuedMessage extends QueuedSubmission {
   deferUntilIdle: boolean;
 }
 
 export const GOAL_COMMAND_RE = /^\/goal(?:\s|$)/;
+
+function aggregateMessages(
+  messages: readonly QueuedMessage[],
+): QueuedSubmission {
+  const modelText = messages.map((message) => message.modelText).join('\n\n');
+  const submittedPrompts = messages.map((message) => message.submittedPrompt);
+  return submittedPrompts.every(
+    (submittedPrompt): submittedPrompt is string =>
+      submittedPrompt !== undefined,
+  )
+    ? { modelText, submittedPrompt: submittedPrompts.join('\n\n') }
+    : { modelText };
+}
 
 export function useMessageQueue(): UseMessageQueueReturn {
   const [queuedMessages, setQueuedMessages] = useState<QueuedMessage[]>([]);
   // Synchronous mirror so non-React callbacks see the latest queue.
   const queueRef = useRef<QueuedMessage[]>([]);
 
-  const addMessage = useCallback((message: string, deferUntilIdle = false) => {
-    const trimmedMessage = message.trim();
-    if (trimmedMessage.length > 0) {
-      queueRef.current = [
-        ...queueRef.current,
-        { text: trimmedMessage, deferUntilIdle },
-      ];
-      setQueuedMessages(queueRef.current);
-    }
-  }, []);
+  const addMessage = useCallback(
+    (message: string, deferUntilIdle = false, submittedPrompt?: string) => {
+      const modelText = message.trim();
+      if (modelText.length > 0) {
+        queueRef.current = [
+          ...queueRef.current,
+          { modelText, deferUntilIdle, submittedPrompt },
+        ];
+        setQueuedMessages(queueRef.current);
+      }
+    },
+    [],
+  );
 
   const clearQueue = useCallback(() => {
     queueRef.current = [];
@@ -56,22 +80,22 @@ export function useMessageQueue(): UseMessageQueueReturn {
 
   const getQueuedMessagesText = useCallback(() => {
     if (queuedMessages.length === 0) return '';
-    return queuedMessages.map(({ text }) => text).join('\n\n');
+    return queuedMessages.map(({ modelText }) => modelText).join('\n\n');
   }, [queuedMessages]);
 
-  const popAllMessages = useCallback((): string | null => {
+  const popAllMessages = useCallback((): QueuedSubmission | null => {
     const current = queueRef.current;
     if (current.length === 0) return null;
     queueRef.current = [];
     setQueuedMessages([]);
-    return current.map(({ text }) => text).join('\n\n');
+    return aggregateMessages(current);
   }, []);
 
   const restoreMessages = useCallback((messages: string[]) => {
     const restored = messages
       .map((text) => text.trim())
       .filter(Boolean)
-      .map((text) => ({ text, deferUntilIdle: false }));
+      .map((modelText) => ({ modelText, deferUntilIdle: false }));
     if (restored.length === 0) return;
     queueRef.current = [...restored, ...queueRef.current];
     setQueuedMessages(queueRef.current);
@@ -81,34 +105,39 @@ export function useMessageQueue(): UseMessageQueueReturn {
     const current = queueRef.current;
     if (current.length === 0) return [];
     const shouldDrain = (message: QueuedMessage) =>
-      (!isSlashCommand(message.text) ||
-        (!includeDeferred && GOAL_COMMAND_RE.test(message.text))) &&
+      (!isSlashCommand(message.modelText) ||
+        (!includeDeferred && GOAL_COMMAND_RE.test(message.modelText))) &&
       (includeDeferred || !message.deferUntilIdle);
     const drained = current.filter(shouldDrain);
     if (drained.length === 0) return [];
     const rest = current.filter((message) => !shouldDrain(message));
     queueRef.current = rest;
     setQueuedMessages(rest);
-    return drained.map(({ text }) => text);
+    return drained.map(({ modelText }) => modelText);
   }, []);
 
-  const popNextSegment = useCallback((): string | null => {
+  const popNextTurn = useCallback((): QueuedSubmission | null => {
     const current = queueRef.current;
     if (current.length === 0) return null;
-    const [head, ...rest] = current;
+    const plainMessages = current.filter(
+      (message) => !isSlashCommand(message.modelText),
+    );
+    const messages = plainMessages.length > 0 ? plainMessages : [current[0]];
+    const selected = new Set(messages);
+    const rest = current.filter((message) => !selected.has(message));
     queueRef.current = rest;
     setQueuedMessages(rest);
-    return head.text;
+    return aggregateMessages(messages);
   }, []);
 
   return {
-    messageQueue: queuedMessages.map(({ text }) => text),
+    messageQueue: queuedMessages.map(({ modelText }) => modelText),
     addMessage,
     clearQueue,
     getQueuedMessagesText,
     popAllMessages,
     restoreMessages,
     drainQueue,
-    popNextSegment,
+    popNextTurn,
   };
 }

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -8107,9 +8107,19 @@ describe('Model Switching and Config Updates', () => {
         expected: 'submitted prompt',
       },
       {
-        name: 'preserves an empty submitted prompt',
+        name: 'preserves surrounding whitespace on a non-empty prompt',
+        submittedPrompt: '  submitted prompt  ',
+        expected: '  submitted prompt  ',
+      },
+      {
+        name: 'drops an empty submitted prompt',
         submittedPrompt: '',
-        expected: '',
+        expected: undefined,
+      },
+      {
+        name: 'drops a whitespace-only submitted prompt',
+        submittedPrompt: ' \t\n ',
+        expected: undefined,
       },
       {
         name: 'drops a numeric submitted prompt',

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -8099,6 +8099,69 @@ describe('Model Switching and Config Updates', () => {
     });
   });
 
+  describe('UserPromptSubmit dispatch through the hook execution bridge', () => {
+    it.each([
+      {
+        name: 'forwards a string submitted prompt',
+        submittedPrompt: 'submitted prompt',
+        expected: 'submitted prompt',
+      },
+      {
+        name: 'preserves an empty submitted prompt',
+        submittedPrompt: '',
+        expected: '',
+      },
+      {
+        name: 'drops a numeric submitted prompt',
+        submittedPrompt: 42,
+        expected: undefined,
+      },
+      {
+        name: 'drops an object submitted prompt',
+        submittedPrompt: { text: 'submitted prompt' },
+        expected: undefined,
+      },
+      {
+        name: 'drops a null submitted prompt',
+        submittedPrompt: null,
+        expected: undefined,
+      },
+      {
+        name: 'handles a missing submitted prompt',
+        submittedPrompt: undefined,
+        expected: undefined,
+      },
+    ])('$name', async ({ submittedPrompt, expected }) => {
+      const config = new Config({ ...baseParams });
+      await config.initialize();
+
+      const fireUserPromptSubmitEvent = vi.fn().mockResolvedValue(undefined);
+      // @ts-expect-error - accessing private for testing
+      config['hookSystem'] = { fireUserPromptSubmitEvent };
+
+      const response = await config
+        .getMessageBus()!
+        .request<HookExecutionRequest, HookExecutionResponse>(
+          {
+            type: MessageBusType.HOOK_EXECUTION_REQUEST,
+            eventName: 'UserPromptSubmit',
+            input: {
+              prompt: 'model prompt',
+              submitted_prompt: submittedPrompt,
+            },
+          },
+          MessageBusType.HOOK_EXECUTION_RESPONSE,
+        );
+
+      expect(fireUserPromptSubmitEvent).toHaveBeenCalledWith(
+        'model prompt',
+        undefined,
+        expected,
+      );
+      expect(response.success).toBe(true);
+    });
+  });
+
   describe('Stop dispatch through the hook execution bridge', () => {
     it.each([
       {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -2495,7 +2495,8 @@ export class Config {
                 result = await hookSystem.fireUserPromptSubmitEvent(
                   (input['prompt'] as string) || '',
                   signal,
-                  typeof input['submitted_prompt'] === 'string'
+                  typeof input['submitted_prompt'] === 'string' &&
+                    input['submitted_prompt'].trim().length > 0
                     ? input['submitted_prompt']
                     : undefined,
                 );

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -2495,6 +2495,9 @@ export class Config {
                 result = await hookSystem.fireUserPromptSubmitEvent(
                   (input['prompt'] as string) || '',
                   signal,
+                  typeof input['submitted_prompt'] === 'string'
+                    ? input['submitted_prompt']
+                    : undefined,
                 );
                 break;
               case 'UserPromptExpansion':

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -9346,6 +9346,137 @@ Other open files:
 
         // messageBus.request SHOULD be called for UserPromptSubmit
         expect(mockMessageBus.request).toHaveBeenCalled();
+        const hookRequest = mockMessageBus.request.mock.calls[0][0] as {
+          input: Record<string, unknown>;
+        };
+        expect(hookRequest.input).toEqual({ prompt: 'Hi' });
+      });
+
+      it('passes a non-empty submitted prompt for UserQuery hooks', async () => {
+        const mockMessageBus = {
+          request: vi.fn().mockResolvedValue({ output: undefined }),
+          response: vi.fn(),
+        };
+        vi.mocked(mockConfig.getDisableAllHooks).mockReturnValue(false);
+        vi.mocked(mockConfig.getMessageBus).mockReturnValue(
+          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
+        );
+        vi.mocked(mockConfig.hasHooksForEvent).mockImplementation(
+          (event: string) => event === 'UserPromptSubmit',
+        );
+
+        await fromAsync(
+          client.sendMessageStream(
+            [{ text: 'expanded model prompt' }],
+            new AbortController().signal,
+            'prompt-submitted-prompt',
+            {
+              type: SendMessageType.UserQuery,
+              submittedPrompt: 'raw @file prompt',
+            },
+          ),
+        );
+
+        const hookRequest = mockMessageBus.request.mock.calls[0][0] as {
+          input: Record<string, unknown>;
+        };
+        expect(hookRequest.input).toEqual({
+          prompt: 'expanded model prompt',
+          submitted_prompt: 'raw @file prompt',
+        });
+      });
+
+      it.each([
+        {
+          name: 'empty UserQuery value',
+          type: SendMessageType.UserQuery,
+          submittedPrompt: '',
+        },
+        {
+          name: 'whitespace-only UserQuery value',
+          type: SendMessageType.UserQuery,
+          submittedPrompt: ' \n\t ',
+        },
+        {
+          name: 'invalid UserQuery value',
+          type: SendMessageType.UserQuery,
+          submittedPrompt: 42 as unknown as string,
+        },
+        {
+          name: 'non-user ToolResult value',
+          type: SendMessageType.ToolResult,
+          submittedPrompt: 'must not propagate',
+        },
+        {
+          name: 'non-user Hook value',
+          type: SendMessageType.Hook,
+          submittedPrompt: 'must not propagate',
+        },
+      ])(
+        'omits submitted prompt for $name',
+        async ({ type, submittedPrompt }) => {
+          const mockMessageBus = {
+            request: vi.fn().mockResolvedValue({ output: undefined }),
+            response: vi.fn(),
+          };
+          vi.mocked(mockConfig.getDisableAllHooks).mockReturnValue(false);
+          vi.mocked(mockConfig.getMessageBus).mockReturnValue(
+            mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
+          );
+          vi.mocked(mockConfig.hasHooksForEvent).mockImplementation(
+            (event: string) => event === 'UserPromptSubmit',
+          );
+
+          await fromAsync(
+            client.sendMessageStream(
+              [{ text: 'model prompt' }],
+              new AbortController().signal,
+              `prompt-${type}`,
+              { type, submittedPrompt },
+            ),
+          );
+
+          const hookRequest = mockMessageBus.request.mock.calls[0][0] as {
+            input: Record<string, unknown>;
+          };
+          expect(hookRequest.input).toEqual({ prompt: 'model prompt' });
+        },
+      );
+
+      it('clears submitted prompt before a Steer continuation', async () => {
+        const sendSpy = vi.spyOn(client, 'sendMessageStream');
+        mockTurnRunFn.mockImplementation(() =>
+          (async function* () {
+            yield { type: GeminiEventType.Content, value: 'response' };
+          })(),
+        );
+        const getSteerInput = vi
+          .fn<() => Promise<SteerInput | undefined>>()
+          .mockResolvedValueOnce({
+            parts: [{ text: 'steer prompt' }],
+            accept: vi.fn(),
+            restore: vi.fn(),
+          })
+          .mockResolvedValue(undefined);
+
+        await fromAsync(
+          client.sendMessageStream(
+            [{ text: 'model prompt' }],
+            new AbortController().signal,
+            'prompt-clear-steer-submitted',
+            {
+              type: SendMessageType.UserQuery,
+              submittedPrompt: 'submitted prompt',
+              getSteerInput,
+            },
+          ),
+        );
+
+        expect(sendSpy.mock.calls).toHaveLength(2);
+        expect(sendSpy.mock.calls[1][3]).toMatchObject({
+          type: SendMessageType.Steer,
+          submittedPrompt: undefined,
+        });
       });
 
       it('does not run UserPromptSubmit hooks for same-turn steer input', async () => {
@@ -9720,6 +9851,7 @@ Other open files:
         const { checkNextSpeaker } = await import(
           '../utils/nextSpeakerChecker.js'
         );
+        const sendSpy = vi.spyOn(client, 'sendMessageStream');
         vi.mocked(checkNextSpeaker)
           .mockResolvedValueOnce({
             next_speaker: 'model',
@@ -9746,13 +9878,22 @@ Other open files:
             [{ text: 'start the analysis' }],
             new AbortController().signal,
             'prompt-steer-during-next-speaker',
-            { type: SendMessageType.UserQuery, getSteerInput },
+            {
+              type: SendMessageType.UserQuery,
+              submittedPrompt: 'submitted prompt',
+              getSteerInput,
+            },
           ),
         );
 
         expect(mockTurnRunFn).toHaveBeenCalledTimes(2);
         expect(getLastTurnRequestText()).toContain('focus on the failing test');
         expect(getLastTurnRequestText()).not.toContain('Please continue.');
+        expect(sendSpy.mock.calls).toHaveLength(2);
+        expect(sendSpy.mock.calls[1][3]).toMatchObject({
+          type: SendMessageType.Steer,
+          submittedPrompt: undefined,
+        });
       });
 
       it('does not drain steer input without another model-turn budget', async () => {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -175,6 +175,8 @@ export enum SendMessageType {
 
 export interface SendMessageOptions {
   type: SendMessageType;
+  /** User-submitted text captured before prompt expansion. */
+  submittedPrompt?: string;
   /** Returns user input waiting to steer the active turn at a model boundary. */
   getSteerInput?: (signal: AbortSignal) => Promise<SteerInput | undefined>;
   /** Steer lease already appended to this request, settled after history push. */
@@ -2017,6 +2019,12 @@ export class GeminiClient {
       this.config.hasHooksForEvent('UserPromptSubmit')
     ) {
       const promptText = partToString(request);
+      const submittedPrompt =
+        messageType === SendMessageType.UserQuery &&
+        typeof options?.submittedPrompt === 'string' &&
+        options.submittedPrompt.trim().length > 0
+          ? options.submittedPrompt
+          : undefined;
       const response = await messageBus.request<
         HookExecutionRequest,
         HookExecutionResponse
@@ -2026,6 +2034,9 @@ export class GeminiClient {
           eventName: 'UserPromptSubmit',
           input: {
             prompt: promptText,
+            ...(submittedPrompt !== undefined
+              ? { submitted_prompt: submittedPrompt }
+              : {}),
           },
         },
         MessageBusType.HOOK_EXECUTION_RESPONSE,
@@ -2753,6 +2764,7 @@ export class GeminiClient {
               {
                 ...options,
                 type: SendMessageType.Steer,
+                submittedPrompt: undefined,
                 steerInput,
               },
               steerTurnBudget,
@@ -3078,6 +3090,7 @@ export class GeminiClient {
                 type: pendingSteer
                   ? SendMessageType.Steer
                   : SendMessageType.Hook,
+                submittedPrompt: undefined,
                 steerInput: pendingSteer,
               },
               continueTurnBudget,

--- a/packages/core/src/hooks/hookEventHandler.test.ts
+++ b/packages/core/src/hooks/hookEventHandler.test.ts
@@ -165,6 +165,39 @@ describe('HookEventHandler', () => {
         .calls;
       const input = mockCalls[0][2] as { prompt: string };
       expect(input.prompt).toBe('my test prompt');
+      expect(input).not.toHaveProperty('submitted_prompt');
+    });
+
+    it('should include submitted prompt when provided', async () => {
+      const mockPlan = createMockExecutionPlan([
+        {
+          type: HookType.Command,
+          command: 'echo test',
+          source: HooksConfigSource.Project,
+        },
+      ]);
+      vi.mocked(mockHookPlanner.createExecutionPlan).mockReturnValue(mockPlan);
+      vi.mocked(mockHookRunner.executeHooksParallel).mockResolvedValue([]);
+      vi.mocked(mockHookAggregator.aggregateResults).mockReturnValue(
+        createMockAggregatedResult(true),
+      );
+
+      await hookEventHandler.fireUserPromptSubmitEvent(
+        'model prompt',
+        undefined,
+        'submitted prompt',
+      );
+
+      const mockCalls = (mockHookRunner.executeHooksParallel as Mock).mock
+        .calls;
+      const input = mockCalls[0][2] as {
+        prompt: string;
+        submitted_prompt?: string;
+      };
+      expect(input).toMatchObject({
+        prompt: 'model prompt',
+        submitted_prompt: 'submitted prompt',
+      });
     });
   });
 

--- a/packages/core/src/hooks/hookEventHandler.test.ts
+++ b/packages/core/src/hooks/hookEventHandler.test.ts
@@ -199,6 +199,36 @@ describe('HookEventHandler', () => {
         submitted_prompt: 'submitted prompt',
       });
     });
+
+    it.each(['', ' \t\n '])(
+      'should omit an empty submitted prompt',
+      async (submittedPrompt) => {
+        const mockPlan = createMockExecutionPlan([
+          {
+            type: HookType.Command,
+            command: 'echo test',
+            source: HooksConfigSource.Project,
+          },
+        ]);
+        vi.mocked(mockHookPlanner.createExecutionPlan).mockReturnValue(
+          mockPlan,
+        );
+        vi.mocked(mockHookRunner.executeHooksParallel).mockResolvedValue([]);
+        vi.mocked(mockHookAggregator.aggregateResults).mockReturnValue(
+          createMockAggregatedResult(true),
+        );
+
+        await hookEventHandler.fireUserPromptSubmitEvent(
+          'model prompt',
+          undefined,
+          submittedPrompt,
+        );
+
+        const input = (mockHookRunner.executeHooksParallel as Mock).mock
+          .calls[0][2] as { submitted_prompt?: string };
+        expect(input).not.toHaveProperty('submitted_prompt');
+      },
+    );
   });
 
   describe('fireInstructionsLoadedEvent', () => {

--- a/packages/core/src/hooks/hookEventHandler.ts
+++ b/packages/core/src/hooks/hookEventHandler.ts
@@ -162,7 +162,8 @@ export class HookEventHandler {
     const input: UserPromptSubmitInput = {
       ...this.createBaseInput(HookEventName.UserPromptSubmit),
       prompt,
-      ...(submittedPrompt !== undefined
+      ...(typeof submittedPrompt === 'string' &&
+      submittedPrompt.trim().length > 0
         ? { submitted_prompt: submittedPrompt }
         : {}),
     };

--- a/packages/core/src/hooks/hookEventHandler.ts
+++ b/packages/core/src/hooks/hookEventHandler.ts
@@ -157,10 +157,14 @@ export class HookEventHandler {
   async fireUserPromptSubmitEvent(
     prompt: string,
     signal?: AbortSignal,
+    submittedPrompt?: string,
   ): Promise<AggregatedHookResult> {
     const input: UserPromptSubmitInput = {
       ...this.createBaseInput(HookEventName.UserPromptSubmit),
       prompt,
+      ...(submittedPrompt !== undefined
+        ? { submitted_prompt: submittedPrompt }
+        : {}),
     };
 
     return this.executeHooks(

--- a/packages/core/src/hooks/hookRunner.test.ts
+++ b/packages/core/src/hooks/hookRunner.test.ts
@@ -573,14 +573,16 @@ describe('HookRunner', () => {
       expect(secondInput.prompt).toBe('Base prompt\n\nHook context');
     });
 
-    it('should preserve raw UserPromptSubmit additional context when chaining', async () => {
+    it('should preserve submitted prompt while chaining UserPromptSubmit context', async () => {
       const firstProcess = createMockProcess(
         0,
         JSON.stringify({
           hookSpecificOutput: {
             hookEventName: 'UserPromptSubmit',
             additionalContext: '<xml><item>raw</item></xml>',
+            submitted_prompt: 'forged prompt',
           },
+          submitted_prompt: 'another forged prompt',
         }),
       );
       const secondProcess = createMockProcess(0, 'result');
@@ -605,6 +607,7 @@ describe('HookRunner', () => {
           hook_event_name: HookEventName.UserPromptSubmit,
         }),
         prompt: 'Base prompt',
+        submitted_prompt: 'Submitted prompt',
       };
 
       await hookRunner.executeHooksSequential(
@@ -617,10 +620,12 @@ describe('HookRunner', () => {
       expect(typeof secondInputJson).toBe('string');
       const secondInput = JSON.parse(secondInputJson as string) as {
         prompt?: string;
+        submitted_prompt?: string;
       };
       expect(secondInput.prompt).toBe(
         'Base prompt\n\n<xml><item>raw</item></xml>',
       );
+      expect(secondInput.submitted_prompt).toBe('Submitted prompt');
     });
 
     it('should not append empty UserPromptSubmit additional context', async () => {

--- a/packages/core/src/hooks/hookSystem.test.ts
+++ b/packages/core/src/hooks/hookSystem.test.ts
@@ -454,7 +454,7 @@ describe('HookSystem', () => {
 
       expect(
         mockHookEventHandler.fireUserPromptSubmitEvent,
-      ).toHaveBeenCalledWith('test prompt', undefined);
+      ).toHaveBeenCalledWith('test prompt', undefined, undefined);
       expect(result).toBeDefined();
     });
 
@@ -476,7 +476,31 @@ describe('HookSystem', () => {
 
       expect(
         mockHookEventHandler.fireUserPromptSubmitEvent,
-      ).toHaveBeenCalledWith('my custom prompt', undefined);
+      ).toHaveBeenCalledWith('my custom prompt', undefined, undefined);
+    });
+
+    it('should pass submitted prompt after the existing signal argument', async () => {
+      const mockResult = {
+        success: true,
+        allOutputs: [],
+        errors: [],
+        totalDuration: 0,
+        finalOutput: undefined,
+      };
+      vi.mocked(
+        mockHookEventHandler.fireUserPromptSubmitEvent,
+      ).mockResolvedValue(mockResult);
+      const signal = new AbortController().signal;
+
+      await hookSystem.fireUserPromptSubmitEvent(
+        'model prompt',
+        signal,
+        'submitted prompt',
+      );
+
+      expect(
+        mockHookEventHandler.fireUserPromptSubmitEvent,
+      ).toHaveBeenCalledWith('model prompt', signal, 'submitted prompt');
     });
 
     it('should return undefined when no final output', async () => {

--- a/packages/core/src/hooks/hookSystem.ts
+++ b/packages/core/src/hooks/hookSystem.ts
@@ -153,10 +153,12 @@ export class HookSystem {
   async fireUserPromptSubmitEvent(
     prompt: string,
     signal?: AbortSignal,
+    submittedPrompt?: string,
   ): Promise<DefaultHookOutput | undefined> {
     const result = await this.hookEventHandler.fireUserPromptSubmitEvent(
       prompt,
       signal,
+      submittedPrompt,
     );
     return result.finalOutput
       ? createHookOutput('UserPromptSubmit', result.finalOutput)

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -854,6 +854,7 @@ export interface PostToolBatchOutput extends HookOutput {
  */
 export interface UserPromptSubmitInput extends HookInput {
   prompt: string;
+  submitted_prompt?: string;
 }
 
 /**

--- a/packages/core/src/telemetry/qwen-logger/qwen-logger.test.ts
+++ b/packages/core/src/telemetry/qwen-logger/qwen-logger.test.ts
@@ -599,6 +599,49 @@ describe('QwenLogger', () => {
       );
     });
 
+    it('should not include submitted prompts in hook telemetry', () => {
+      const configWithLogPrompts = makeFakeConfig({
+        getTelemetryLogPromptsEnabled: () => true,
+      });
+      const logger = QwenLogger.getInstance(configWithLogPrompts)!;
+      const enqueueSpy = vi.spyOn(logger, 'enqueueLogEvent');
+
+      const event = new HookCallEvent(
+        'UserPromptSubmit',
+        'command',
+        'external-context.sh',
+        {
+          prompt: 'model-bound prompt',
+          submitted_prompt: 'sensitive submitted prompt',
+        },
+        150,
+        true,
+        { echoed: 'sensitive hook output' },
+        0,
+        'sensitive hook stdout',
+        'sensitive hook stderr',
+      );
+
+      logger.logHookCallEvent(event);
+
+      const rumEvent = enqueueSpy.mock.calls[0][0];
+      expect(rumEvent.properties).not.toHaveProperty('hook_input');
+      expect(rumEvent.properties).not.toHaveProperty('hook_output');
+      expect(rumEvent.properties).not.toHaveProperty('prompt');
+      expect(rumEvent.properties).not.toHaveProperty('submitted_prompt');
+      expect(rumEvent.properties).not.toHaveProperty('stdout');
+      expect(rumEvent.properties).not.toHaveProperty('stderr');
+      const serializedEvent = JSON.stringify(rumEvent);
+      for (const sensitiveValue of [
+        'sensitive submitted prompt',
+        'sensitive hook output',
+        'sensitive hook stdout',
+        'sensitive hook stderr',
+      ]) {
+        expect(serializedEvent).not.toContain(sensitiveValue);
+      }
+    });
+
     it('should log a failed hook call event with error when telemetry log prompts enabled', () => {
       const configWithLogPrompts = makeFakeConfig({
         getTelemetryLogPromptsEnabled: () => true,


### PR DESCRIPTION
## What this PR does

This PR adds an optional `submitted_prompt` field to `UserPromptSubmit` while preserving the existing model-bound `prompt`, event timing, blocking behavior, hook ordering, and `additionalContext` chaining. The built-in interactive TUI supplies the field only for fresh `UserQuery` submissions, capturing the trimmed text projection before Qwen adds reminders or expands files, resources, slash or extension output, and vision input.

Deferred turns and exact in-memory restorations carry provenance in a sidecar without changing queue rendering. Large-paste content remains represented by the TUI's compact placeholder projection instead of being duplicated in the hook payload. Ambiguous batches, edited restorations, same-turn steering, recursive continuations, retries, machine-driven traffic, unsupported producers, configured `--prompt-interactive` startup, Vim NORMAL-mode direct submissions, and image-only submissions omit the field.

Exact cancellation restoration must retain ownership of the main turn while a concurrent `/btw` side question runs. The coupled history guard removes the latest persisted user entry only when that entry still belongs to the cancelled main turn, preventing cancellation from deleting the newer side-question log. The documentation describes forward-compatible decoding, strict-schema migration, data recipients, and the trusted same-process function-hook boundary. A real interactive command-hook E2E verifies the expansion boundary and tool-result omission.

## Why it's needed

The existing `UserPromptSubmit.prompt` is the text bound for the current model invocation, not a reliable copy of what a person submitted. It can contain generated reminders, expanded content, prior hook context, or continuation traffic. Consumers such as a future fail-closed Auto Recall hook therefore need an explicit provenance signal and must never reconstruct it from `prompt`.

The Core contract and TUI producer ship together so the new option has a production caller from its first release. Keeping the field additive avoids changing the broad legacy `UserPromptSubmit` trigger semantics in the same compatibility-sensitive PR.

## Reviewer Test Plan

### How to verify

1. Configure a command `UserPromptSubmit` hook that records stdin, start the interactive TUI, and submit `@context.txt Inspect this context.` where the file contains a unique canary. The first hook payload should contain the typed text in `submitted_prompt`; only `prompt` should contain the file canary.
2. Let a fake model issue one tool call. The initial `UserQuery` hook invocation should contain `submitted_prompt`, while the following `ToolResult` invocation should preserve its legacy `prompt` and omit the new key.
3. Verify Ctrl+Q deferred turns and unchanged queue or cancellation restorations retain provenance. Editing restored text, mixing an unknown-source item into a batch, or draining it as same-turn steering should omit provenance.
4. Run the targeted Core and CLI suites. The final local run passed 1,045 Core tests and 525 CLI tests. `npm run build`, `npm run bundle`, `npm run typecheck`, `npm run lint`, and the real interactive provenance E2E also passed.

### Evidence (Before & After)

N/A — this changes a hook payload contract and internal provenance propagation without changing visible TUI rendering.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally; CI is the cross-platform gate |
|  🐧 Linux  | ⚠️ not tested locally; CI is the cross-platform gate |

### Environment (optional)

macOS 26.4.1, Node.js 26.0.0, npm 11.12.1, `QWEN_SANDBOX=false` for interactive E2E, and local fake OpenAI plus command-hook processes. No external context provider or production model was used.

## Risk & Scope

- Main risk or tradeoff: Strict third-party hook decoders using `additionalProperties: false` must allow the optional string field before upgrading. The field is potentially sensitive and is delivered to every configured executor for the event; function hooks remain trusted same-process code. Exact provenance restoration also depends on cancellation/history ownership: if a concurrent `/btw` writes a newer user entry, cancelling the main turn intentionally leaves that latest disk-history entry intact instead of deleting the wrong message.
- Not validated / out of scope: Auto Recall, provider requests, configuration v2, writes, new adapters, a global `UserPromptSubmit` semantic change, canonicalizing the Vim NORMAL-mode direct submit path, ACP/headless/`serve`/SDK/remote producers, persisted provenance, and local Windows or Linux execution. Accepted speculation retains its existing hook-bypass behavior.
- Breaking changes / migration notes: The JSON change is additive for forward-compatible consumers. No stored data migration is required. Security-sensitive strict decoders should be updated and tested before rollout.

## Linked Issues

Refs #7585

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本 PR 为 `UserPromptSubmit` 增加可选的 `submitted_prompt` 字段，同时保持现有 model-bound `prompt`、事件时机、阻断行为、Hook 顺序和 `additionalContext` chaining 不变。内置交互式 TUI 只为新的 `UserQuery` 提供该字段，在 Qwen 添加 reminder 或展开文件、资源、slash/extension 输出和 vision 输入之前捕获 trim 后的文本投影。

延迟到下一回合的输入和可证明的原样内存恢复通过 sidecar 保留来源信息，不改变队列展示。大段粘贴内容在 Hook payload 中只保留 TUI 的紧凑占位文本投影，不会再复制一份完整内容。来源有歧义的批次、编辑后的恢复输入、同回合 steering、递归 continuation、retry、机器驱动流量、不支持的 producer、配置的 `--prompt-interactive` 启动输入、Vim NORMAL-mode 直提交流程以及纯图片提交都会省略该字段。

原样取消恢复必须在并发 `/btw` 旁路问题运行期间继续保有主回合 ownership。配套的历史保护仅在最新持久化用户条目仍属于被取消的主回合时才删除它，避免取消操作误删更新的旁路问题日志。文档说明了向前兼容解析、严格 schema 迁移、数据接收方和可信同进程 Function Hook 边界。真实交互式 command Hook E2E 验证了展开边界和 ToolResult omission。

## 为什么需要

现有 `UserPromptSubmit.prompt` 是当前模型调用绑定的文本，并不是用户提交内容的可靠副本。它可能包含生成的 reminder、展开内容、前序 Hook context 或 continuation 流量。因此，未来 fail-closed Auto Recall Hook 等消费者需要显式的来源信号，并且绝不能从 `prompt` 中重建来源。

Core Contract 和 TUI producer 一起交付，确保新 option 从首次发布开始就有生产调用方。采用增量字段可以避免在同一个兼容性敏感 PR 中改变现有较宽的 `UserPromptSubmit` 触发语义。

## Reviewer 测试计划

### 如何验证

1. 配置一个记录 stdin 的 command `UserPromptSubmit` Hook，启动交互式 TUI，并提交 `@context.txt Inspect this context.`，其中该文件包含唯一 canary。第一次 Hook payload 的 `submitted_prompt` 应为用户输入文本；只有 `prompt` 应包含文件 canary。
2. 让 Fake Model 发起一次工具调用。初始 `UserQuery` Hook invocation 应包含 `submitted_prompt`，后续 `ToolResult` invocation 应保持 legacy `prompt` 并省略新 key。
3. 验证 Ctrl+Q 延迟回合和未修改的队列/取消恢复保留来源。编辑恢复文本、在 batch 中混入未知来源条目，或将其作为同回合 steering drain 时，应省略来源字段。
4. 运行定向 Core 和 CLI 测试。最终本地运行通过了 1,045 个 Core 测试和 525 个 CLI 测试。`npm run build`、`npm run bundle`、`npm run typecheck`、`npm run lint` 和真实交互式 provenance E2E 也全部通过。

### 证据（Before & After）

N/A —— 本 PR 修改 Hook payload Contract 和内部来源传递，不改变可见 TUI 渲染。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 本地未测试；CI 作为跨平台门禁 |
|  🐧 Linux  | ⚠️ 本地未测试；CI 作为跨平台门禁 |

### 环境（可选）

macOS 26.4.1、Node.js 26.0.0、npm 11.12.1；交互式 E2E 使用 `QWEN_SANDBOX=false`，并使用本地 Fake OpenAI 和 command Hook 进程。未使用外部 context provider 或生产模型。

## 风险与范围

- 主要风险或取舍：使用 `additionalProperties: false` 的严格第三方 Hook decoder 必须在升级前允许该可选字符串字段。该字段可能包含敏感内容，并会发送给该事件配置的每个 executor；Function Hook 仍属于可信同进程代码。原样 provenance 恢复还依赖取消/历史 ownership：如果并发 `/btw` 写入了更新的用户条目，取消主回合会有意保留最新的磁盘历史条目，而不是误删另一条消息。
- 未验证 / 范围外：Auto Recall、Provider 请求、配置 v2、写入、新 Adapter、全局 `UserPromptSubmit` 语义修改、统一 Vim NORMAL-mode 直提交流程、ACP/headless/`serve`/SDK/remote producer、持久化 provenance，以及本地 Windows 或 Linux 执行。accepted speculation 保持现有 Hook 绕过行为。
- Breaking change / 迁移说明：对向前兼容的消费者而言，JSON 变化是增量式的，不需要存储数据迁移。安全敏感的严格 decoder 应在放量前更新并完成验证。

## 关联 Issue

Refs #7585

</details>
