### PR TITLE
fix(core): keep leading whitespace in gitignore patterns

### DIFF
--- a/packages/core/src/utils/gitIgnoreParser.test.ts
+++ b/packages/core/src/utils/gitIgnoreParser.test.ts
@@ -240,4 +240,52 @@ src/*.tmp
       );
     });
   });
+
+  // Every expectation below was read off `git check-ignore` in a real
+  // repository rather than off the documentation.
+  describe('pattern whitespace', () => {
+    beforeEach(async () => {
+      await setupGitRepo();
+    });
+
+    it('keeps leading whitespace as part of the pattern', async () => {
+      await createTestFile('.gitignore', ' leading.txt\n');
+
+      // Both directions matter. `trim()` did not merely fail to ignore the
+      // right file, it ignored the wrong one instead, so an assertion on the
+      // first line alone would also pass for the broken implementation.
+      expect(parser.isIgnored(' leading.txt')).toBe(true);
+      expect(parser.isIgnored('leading.txt')).toBe(false);
+    });
+
+    it('still drops unescaped trailing whitespace', async () => {
+      await createTestFile('.gitignore', 'trail.txt   \n');
+
+      expect(parser.isIgnored('trail.txt')).toBe(true);
+    });
+
+    it('still skips blank and whitespace-only lines', async () => {
+      await createTestFile('.gitignore', '\n   \n\t\nkept.txt\n');
+
+      expect(parser.isIgnored('kept.txt')).toBe(true);
+      // A whitespace-only line must not survive as a pattern of its own.
+      expect(parser.isIgnored('other.txt')).toBe(false);
+    });
+
+    it('treats an indented # as a pattern rather than a comment', async () => {
+      // git honours `#` as a comment only as the first character of the line.
+      // Trimming first hid that: `  #hash.txt` was discarded as a comment.
+      await createTestFile('.gitignore', '  #hash.txt\n# real comment\n');
+
+      expect(parser.isIgnored('  #hash.txt')).toBe(true);
+      expect(parser.isIgnored('real comment')).toBe(false);
+    });
+
+    it('reads patterns from a CRLF .gitignore', async () => {
+      await createTestFile('.gitignore', 'crlf.txt\r\nsecond.txt\r\n');
+
+      expect(parser.isIgnored('crlf.txt')).toBe(true);
+      expect(parser.isIgnored('second.txt')).toBe(true);
+    });
+  });
 });

--- a/packages/core/src/utils/gitIgnoreParser.ts
+++ b/packages/core/src/utils/gitIgnoreParser.ts
@@ -40,10 +40,18 @@ export class GitIgnoreParser implements GitIgnoreFilter {
       ? '.'
       : path.dirname(path.relative(this.projectRoot, patternsFilePath));
 
+    // Git strips a trailing CR, so that CRLF files work, and nothing else.
+    // Leading whitespace is part of the pattern, and trailing whitespace is
+    // stripped only when it is not backslash-escaped — both rules the `ignore`
+    // library already applies to the raw pattern text. `trim()` overrode them
+    // and inverted the match: a pattern ` leading.txt` stopped matching
+    // ` leading.txt` and started matching `leading.txt` instead. A comment is
+    // likewise a line whose FIRST character is `#`, so `  #foo` is a pattern to
+    // git rather than a comment, and testing the untrimmed line reproduces that.
     return content
       .split('\n')
-      .map((p) => p.trim())
-      .filter((p) => p !== '' && !p.startsWith('#'))
+      .map((p) => (p.endsWith('\r') ? p.slice(0, -1) : p))
+      .filter((p) => p.trim() !== '' && !p.startsWith('#'))
       .map((p) => {
         const isNegative = p.startsWith('!');
         if (isNegative) {

--- a/packages/core/src/utils/qwenIgnoreParser.test.ts
+++ b/packages/core/src/utils/qwenIgnoreParser.test.ts
@@ -196,4 +196,22 @@ describe('QwenIgnoreParser', () => {
       expect(parser.isIgnored('any_file.txt')).toBe(false);
     });
   });
+
+  // These files use gitignore syntax, so they inherit gitignore whitespace
+  // rules — see the matching suite in gitIgnoreParser.test.ts.
+  describe('pattern whitespace', () => {
+    it('keeps leading whitespace and strips only a trailing CR', async () => {
+      await createTestFile(
+        '.qwenignore',
+        ' leading.txt\r\n  #hash.txt\r\n# real comment\r\n',
+      );
+      const parser = new QwenIgnoreParser(projectRoot);
+
+      // `getPatterns()` is public and feeds FileDiscoveryService, so the
+      // stored text is asserted as well as the match result.
+      expect(parser.getPatterns()).toEqual([' leading.txt', '  #hash.txt']);
+      expect(parser.isIgnored(' leading.txt')).toBe(true);
+      expect(parser.isIgnored('leading.txt')).toBe(false);
+    });
+  });
 });

--- a/packages/core/src/utils/qwenIgnoreParser.ts
+++ b/packages/core/src/utils/qwenIgnoreParser.ts
@@ -117,10 +117,15 @@ export class QwenIgnoreParser implements QwenIgnoreFilter {
         continue;
       }
 
+      // These files use gitignore syntax, so they follow gitignore whitespace
+      // rules: only a trailing CR is stripped here, leading whitespace is part
+      // of the pattern, and unescaped trailing whitespace is dropped by the
+      // `ignore` library itself. See the same fix in `gitIgnoreParser.ts` for
+      // why `trim()` inverted the match.
       const patterns = (content ?? '')
         .split('\n')
-        .map((p) => p.trim())
-        .filter((p) => p !== '' && !p.startsWith('#'));
+        .map((p) => (p.endsWith('\r') ? p.slice(0, -1) : p))
+        .filter((p) => p.trim() !== '' && !p.startsWith('#'));
       if (patterns.length > 0) {
         const sourceIgnorer = ignore();
         sourceIgnorer.add(patterns);


### PR DESCRIPTION
## What this PR does

Ignore-file patterns were passed through `.trim()` before being handed to the `ignore` library. Git strips only *trailing* whitespace from a pattern, and only when it is not backslash-escaped; leading whitespace is part of the pattern. Trimming both ends does not merely weaken the match — it **inverts** it:

| `.gitignore` line | file | git | before this PR |
|---|---|---|---|
| `" leading.txt"` | `" leading.txt"` | IGNORED | not ignored |
| `" leading.txt"` | `"leading.txt"` | not ignored | **IGNORED** |

The wrong file is ignored and the right one is not. A file the user deliberately excluded is read and sent to the model, and an unrelated file with the same name minus the space silently disappears from every listing.

The same `.trim()` produced a second divergence. Git treats `#` as a comment marker only as the **first** character of the line, so `  #hash.txt` is a pattern; trimming first turned it into `#hash.txt` and the line was discarded as a comment, dropping the rule entirely.

The fix removes the trim and strips only a trailing `\r`, which is exactly what git does for CRLF files. Everything else was already correct in the `ignore` library, which implements the escaped-trailing-whitespace rule on the raw pattern text — `trim()` was overriding a correct implementation.

## Why it's needed

`GitIgnoreParser` is the repo-wide file filter: it backs `FileDiscoveryService` and through it `glob`, `ls`, `read_many_files` and traversal pruning. A pattern that matches the wrong file changes which files the agent can see.

`qwenIgnoreParser.ts` had the identical line and is fixed in the same commit. It is not a second bug — it is the same defect at its second site, `.qwenignore` / `.agentignore` / `.aiignore` parse with gitignore syntax, and the correction is character-for-character the same. Splitting it would mean writing the same explanation twice and knowingly leaving a sibling parser inverted.

## Reviewer Test Plan

### How to verify

Every expectation in the new tests was read off `git check-ignore` in a real repository (git 2.50.1) rather than off the documentation. To reproduce the table above:

```sh
mkdir /tmp/gi && cd /tmp/gi && git init -q
printf ' leading.txt\n' > .gitignore
touch ' leading.txt' leading.txt
git check-ignore -v -- ' leading.txt' leading.txt   # only the space-prefixed one is ignored
```

- `npx vitest run --root packages/core src/utils/gitIgnoreParser.test.ts src/utils/qwenIgnoreParser.test.ts` → 38/38.
- Reverting **only** the two source files and keeping the new tests fails exactly three cases and nothing else: `3 failed | 35 passed (38)`.
- The other three new cases (`still drops unescaped trailing whitespace`, `still skips blank and whitespace-only lines`, `reads patterns from a CRLF .gitignore`) pass both before and after **on purpose** — they are the guard against over-correcting. Removing a `trim()` can easily start emitting whitespace-only patterns or break CRLF files, and those three pin that it did not.
- No regression in the consumers: `npx vitest run --root packages/core src/utils/gitIgnoreParser.test.ts src/utils/qwenIgnoreParser.test.ts src/services/fileDiscoveryService.test.ts src/tools/glob.test.ts src/tools/ls.test.ts src/tools/read-many-files.test.ts src/utils/ignorePatterns.test.ts` → **172 passed (6 files)**.

### Evidence (Before & After)

N/A — not user-visible as UI. The behaviour change is which files are filtered, covered by the differential tests above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only, no platform-dependent behaviour in the changed lines. CI covers Windows and Linux.

## Risk & Scope

- Main risk or tradeoff: a `.gitignore` whose author *relied* on the old trimming — that is, indented their patterns for readability — will see those patterns stop matching. That is the correct behaviour (git never matched them either), but it is a real behaviour change for such a repository. Indented `.gitignore` patterns are not idiomatic, and matching git is the whole contract of this class.
- Not validated / out of scope: an escaped trailing space (`esc\ `) still does not match, because line 96 rewrites every backslash in the pattern to `/`. That is a **separate** defect with a separate fix, and it also breaks `\#hash.txt` and `a\[b\].txt`; it is deliberately left for its own PR rather than folded in here.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

忽略文件中的模式在交给 `ignore` 库之前先经过了 `.trim()`。而 git 只剥离模式**尾部**的空白，且仅在其未被反斜杠转义时才剥离；**前导**空白是模式的组成部分。两端都裁剪不只是削弱匹配，而是把匹配**颠倒**了：

| `.gitignore` 中的行 | 文件 | git | 本 PR 之前 |
|---|---|---|---|
| `" leading.txt"` | `" leading.txt"` | 忽略 | 不忽略 |
| `" leading.txt"` | `"leading.txt"` | 不忽略 | **忽略** |

被忽略的是错误的文件，而正确的文件反而没有被忽略。用户明确排除的文件会被读取并发送给模型，而另一个仅少一个空格的同名文件则会从所有列举结果中悄悄消失。

同一个 `.trim()` 还造成了第二处偏差。git 仅在 `#` 位于行的**第一个**字符时才将其视为注释标记，因此 `  #hash.txt` 是一条模式；先裁剪会把它变成 `#hash.txt`，该行遂被当作注释丢弃，规则完全失效。

修复方式是移除该 trim，仅剥离尾部的 `\r`——这正是 git 对 CRLF 文件的处理。其余部分在 `ignore` 库中本就正确：该库已在原始模式文本上实现了「转义尾部空白」规则，`trim()` 恰恰覆盖了一个正确的实现。

## 为什么需要

`GitIgnoreParser` 是全仓库的文件过滤器：它支撑 `FileDiscoveryService`，并经由它支撑 `glob`、`ls`、`read_many_files` 以及遍历剪枝。模式匹配错文件，就会改变 agent 能看到哪些文件。

`qwenIgnoreParser.ts` 存在完全相同的一行，已在同一提交中修复。它不是第二个 bug，而是同一缺陷的第二处站点：`.qwenignore` / `.agentignore` / `.aiignore` 使用 gitignore 语法解析，修正逐字符相同。拆分意味着把同一段解释写两遍，并且明知故犯地把一个同类解析器继续留在颠倒状态。

## 复核测试计划

### 如何验证

新增测试中的每一条预期都来自在真实仓库上运行 `git check-ignore`（git 2.50.1），而非来自阅读文档。复现上表：

```sh
mkdir /tmp/gi && cd /tmp/gi && git init -q
printf ' leading.txt\n' > .gitignore
touch ' leading.txt' leading.txt
git check-ignore -v -- ' leading.txt' leading.txt   # 仅带前导空格的那个被忽略
```

- `npx vitest run --root packages/core src/utils/gitIgnoreParser.test.ts src/utils/qwenIgnoreParser.test.ts` → 38/38 通过。
- **仅**还原两个源文件、保留新增测试时，恰好三项失败，且无其他失败：`3 failed | 35 passed (38)`。
- 另外三项新增用例（`still drops unescaped trailing whitespace`、`still skips blank and whitespace-only lines`、`reads patterns from a CRLF .gitignore`）在修复前后**都通过，这是刻意为之**——它们是防止「矫枉过正」的保险。移除 `trim()` 很容易反过来产出纯空白模式或破坏 CRLF 文件，这三项锚定了并未发生。
- 调用方无回归：`npx vitest run --root packages/core src/utils/gitIgnoreParser.test.ts src/utils/qwenIgnoreParser.test.ts src/services/fileDiscoveryService.test.ts src/tools/glob.test.ts src/tools/ls.test.ts src/tools/read-many-files.test.ts src/utils/ignorePatterns.test.ts` → **172 通过（6 个文件）**。

### 证据（修复前后对比）

N/A —— 无 UI 层面的可见变化。行为改变的是哪些文件被过滤，已由上述差分测试覆盖。

### 测试环境

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

仅单元测试；改动行不含平台相关行为。Windows 与 Linux 由 CI 覆盖。

## 风险与范围

- 主要风险或权衡：若某个 `.gitignore` 的作者**依赖**了旧的裁剪行为——即为了可读性而缩进书写模式——这些模式将不再匹配。这是正确行为（git 本来也从不匹配它们），但对这类仓库而言确是真实的行为变更。缩进书写 `.gitignore` 模式并非惯用写法，而与 git 保持一致正是本类的全部契约。
- 未验证 / 不在范围内：转义的尾部空格（`esc\ `）仍不匹配，因为第 96 行会把模式中的每一个反斜杠改写为 `/`。那是**另一个**缺陷，需要另一处修复，并且它同样破坏 `\#hash.txt` 与 `a\[b\].txt`；此处有意留给单独的 PR，而不并入本 PR。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
