### PR TITLE
fix(core): stop trailing slash from anchoring nested gitignore patterns

### DIFF
--- a/packages/core/src/utils/gitIgnoreParser.test.ts
+++ b/packages/core/src/utils/gitIgnoreParser.test.ts
@@ -213,6 +213,55 @@ src/*.tmp
     });
   });
 
+  // A trailing `/` means "directories only"; it is not a separator that
+  // anchors the pattern. Every expectation here was read off `git
+  // check-ignore` in a real repository. This needs its own setup because the
+  // suite above ignores `a/b` outright, which would stop `a/b/.gitignore`
+  // from being consulted at all.
+  describe('directory-only patterns in a nested .gitignore', () => {
+    beforeEach(async () => {
+      await setupGitRepo();
+      await createTestFile('.gitignore', '');
+    });
+
+    it('applies below the nested ignore file, not only beside it', async () => {
+      // git expands `foo/` in `a/b/.gitignore` to `/a/b/**/foo/`.
+      await createTestFile('a/b/.gitignore', 'foo/');
+
+      expect(parser.isIgnored('a/b/foo/f')).toBe(true);
+      expect(parser.isIgnored('a/b/x/foo/f')).toBe(true);
+      expect(parser.isIgnored('a/b/x/y/foo/f')).toBe(true);
+      // Still scoped to the ignore file's own directory.
+      expect(parser.isIgnored('a/foo/f')).toBe(false);
+    });
+
+    it('still matches directories only', async () => {
+      await createTestFile('a/b/.gitignore', 'foo/');
+
+      // `foo` here is a file, not a directory, so git leaves it alone. The
+      // `**/` prefix must not cost the trailing slash its meaning.
+      expect(parser.isIgnored('a/b/x/foo')).toBe(false);
+    });
+
+    it('leaves an anchored directory-only pattern anchored', async () => {
+      // The guard against over-correcting: `/foo/` has a leading slash, so it
+      // matches `a/b/foo/` alone and must not gain the `**/` prefix.
+      await createTestFile('a/b/.gitignore', '/foo/');
+
+      expect(parser.isIgnored('a/b/foo/f')).toBe(true);
+      expect(parser.isIgnored('a/b/x/foo/f')).toBe(false);
+    });
+
+    it('leaves a mid-path directory-only pattern anchored', async () => {
+      // `c/d/` has a real interior separator, so the trailing slash is not
+      // the only slash and the pattern stays anchored.
+      await createTestFile('a/b/.gitignore', 'c/d/');
+
+      expect(parser.isIgnored('a/b/c/d/f')).toBe(true);
+      expect(parser.isIgnored('a/b/x/c/d/f')).toBe(false);
+    });
+  });
+
   describe('precedence rules', () => {
     beforeEach(async () => {
       await setupGitRepo();

--- a/packages/core/src/utils/gitIgnoreParser.ts
+++ b/packages/core/src/utils/gitIgnoreParser.ts
@@ -68,7 +68,15 @@ export class GitIgnoreParser implements GitIgnoreFilter {
           // - If `a/b/.gitignore` defines `c` then it needs to be changed to `/a/b/**/c`
           // - If `a/b/.gitignore` defines `c/d` then it needs to be changed to `/a/b/c/d`
 
-          if (!isAnchoredInFile && !p.includes('/')) {
+          // A trailing `/` is not a separator for this test — it only means
+          // "directories only". Git anchors a pattern when a `/` appears at
+          // the start or in the middle, so `foo/` in `a/b/.gitignore` means
+          // `/a/b/**/foo/` and still matches `a/b/x/foo/`, while `c/d` stays
+          // anchored as `/a/b/c/d`. Counting the trailing slash made every
+          // directory-only rule in a nested ignore file stop applying below
+          // its own directory.
+          const withoutDirSuffix = p.endsWith('/') ? p.slice(0, -1) : p;
+          if (!isAnchoredInFile && !withoutDirSuffix.includes('/')) {
             // If no slash and not anchored in file, it matches files in any
             // subdirectory.
             newPattern = path.join('**', p);


### PR DESCRIPTION
## What this PR does

When a nested `.gitignore` is loaded, `loadPatternsForFile` decides whether the pattern is anchored to that directory by asking `!p.includes('/')`. A trailing slash satisfies that test, so a directory-only pattern such as `foo/` was classified as anchored and never got the `**/` prefix.

Git's rule is about a separator at the **beginning or in the middle** of the pattern. A trailing slash carries a different meaning entirely — "match directories only" — and does not anchor anything. So `foo/` in `a/b/.gitignore` means `/a/b/**/foo/`, but was being expanded to `/a/b/foo/`:

| file | git | before this PR |
|---|---|---|
| `a/b/foo/f` | IGNORED | IGNORED |
| `a/b/x/foo/f` | IGNORED | **not ignored** |
| `a/b/x/y/foo/f` | IGNORED | **not ignored** |

The fix strips a single trailing `/` before the separator test, and only for that test — the pattern handed to the `ignore` library keeps its slash, so directory-only semantics are preserved.

## Why it's needed

This is the common shape of a nested ignore file. `build/`, `dist/`, `node_modules/`, `target/` are all directory-only patterns, and a `.gitignore` inside a subproject is exactly where they appear. Under the old behaviour such a rule silently stopped applying anywhere below its own directory, so a nested `packages/foo/.gitignore` containing `dist/` still let `packages/foo/anything/dist/**` through.

`GitIgnoreParser` backs `FileDiscoveryService` and through it `glob`, `ls`, `read_many_files` and traversal pruning, so the leak is not cosmetic: build output the user excluded gets walked, listed, and read into context.

## Reviewer Test Plan

### How to verify

Every expectation in the new tests was read off `git check-ignore` in a real repository (git 2.50.1) rather than off the documentation:

```sh
mkdir /tmp/b2 && cd /tmp/b2 && git init -q
mkdir -p a/b/foo a/b/x/foo && printf 'foo/\n' > a/b/.gitignore
touch a/b/foo/f a/b/x/foo/f
git check-ignore -v -- a/b/foo/f a/b/x/foo/f   # git reports BOTH
```

- `npx vitest run --root packages/core src/utils/gitIgnoreParser.test.ts` → 25/25.
- Reverting **only** `gitIgnoreParser.ts` and keeping the new tests fails exactly one case: `1 failed | 24 passed (25)`.
- The other three new cases pass both before and after **on purpose** — they are the guard against over-correcting, which is the real risk here. Widening the anchoring test could easily turn `/foo/` into `**/foo/` or cost the trailing slash its directory-only meaning, so the suite pins all three separately:
  - `leaves an anchored directory-only pattern anchored` — `/foo/` must still match `a/b/foo/` alone.
  - `leaves a mid-path directory-only pattern anchored` — `c/d/` has a real interior separator and must stay anchored.
  - `still matches directories only` — a *file* named `foo` at `a/b/x/foo` must remain un-ignored.
- The new suite needs its own `beforeEach` rather than joining the existing `nested .gitignore files` block, because that block ignores `a/b` outright via `/b`, which would stop `a/b/.gitignore` from being consulted at all and make the tests vacuous.
- No regression in the consumers: `npx vitest run --root packages/core src/utils/gitIgnoreParser.test.ts src/services/fileDiscoveryService.test.ts src/tools/glob.test.ts src/tools/ls.test.ts src/utils/ignorePatterns.test.ts` → **159 passed (5 files)**.

### Evidence (Before & After)

N/A — not user-visible as UI. The behaviour change is which files are filtered, covered by the differential tests above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only. CI covers Windows and Linux.

## Risk & Scope

- Main risk or tradeoff: directory-only rules in nested ignore files now match more paths than before. That is the point of the change, and it is what git does, but a repository that had come to rely on the narrower behaviour will see more files filtered out of `glob` / `ls` / `read_many_files`. The three over-correction guards above are what bound that widening to exactly the unanchored case.
- Not validated / out of scope: this file has two other divergences from git that this PR deliberately does not touch — leading whitespace being trimmed off patterns, and every backslash in a pattern being rewritten to `/`. Each has its own fix and its own tests.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

加载嵌套 `.gitignore` 时，`loadPatternsForFile` 通过 `!p.includes('/')` 判断该模式是否锚定到该目录。尾部斜杠会让这个判断成立，因此像 `foo/` 这样的「仅目录」模式被归类为已锚定，从未获得 `**/` 前缀。

git 的规则针对的是位于模式**开头或中间**的分隔符。尾部斜杠含义完全不同——「仅匹配目录」——它不产生任何锚定作用。因此 `a/b/.gitignore` 中的 `foo/` 意为 `/a/b/**/foo/`，却被展开成了 `/a/b/foo/`：

| 文件 | git | 本 PR 之前 |
|---|---|---|
| `a/b/foo/f` | 忽略 | 忽略 |
| `a/b/x/foo/f` | 忽略 | **不忽略** |
| `a/b/x/y/foo/f` | 忽略 | **不忽略** |

修复方式是在做分隔符判断前剥离单个尾部 `/`，且仅用于该判断——交给 `ignore` 库的模式仍保留斜杠，因此「仅目录」语义得以保留。

## 为什么需要

这正是嵌套忽略文件最常见的形态。`build/`、`dist/`、`node_modules/`、`target/` 全都是仅目录模式，而子项目内的 `.gitignore` 恰是它们出现的地方。在旧行为下，此类规则会在其所在目录之下的任何层级悄悄失效：嵌套的 `packages/foo/.gitignore` 中的 `dist/` 依然放行 `packages/foo/anything/dist/**`。

`GitIgnoreParser` 支撑 `FileDiscoveryService`，并经由它支撑 `glob`、`ls`、`read_many_files` 与遍历剪枝，因此这一泄漏并非表面问题：用户排除掉的构建产物会被遍历、列举，并读入上下文。

## 复核测试计划

### 如何验证

新增测试中的每一条预期都来自在真实仓库上运行 `git check-ignore`（git 2.50.1），而非来自阅读文档：

```sh
mkdir /tmp/b2 && cd /tmp/b2 && git init -q
mkdir -p a/b/foo a/b/x/foo && printf 'foo/\n' > a/b/.gitignore
touch a/b/foo/f a/b/x/foo/f
git check-ignore -v -- a/b/foo/f a/b/x/foo/f   # git 两个都会报告
```

- `npx vitest run --root packages/core src/utils/gitIgnoreParser.test.ts` → 25/25 通过。
- **仅**还原 `gitIgnoreParser.ts`、保留新增测试时，恰好一项失败：`1 failed | 24 passed (25)`。
- 另外三项新增用例在修复前后**都通过，这是刻意为之**——它们是防止「矫枉过正」的保险，而这正是此处的真实风险。放宽锚定判断很容易把 `/foo/` 变成 `**/foo/`，或让尾部斜杠丧失「仅目录」的含义，因此测试分别锚定了三点：
  - `leaves an anchored directory-only pattern anchored` —— `/foo/` 必须仍只匹配 `a/b/foo/`。
  - `leaves a mid-path directory-only pattern anchored` —— `c/d/` 含真正的内部分隔符，必须保持锚定。
  - `still matches directories only` —— 位于 `a/b/x/foo` 的**文件** `foo` 必须仍不被忽略。
- 新增套件需要自己的 `beforeEach`，而非并入已有的 `nested .gitignore files` 块，因为该块通过 `/b` 直接忽略了 `a/b`，会导致 `a/b/.gitignore` 根本不被读取，测试将沦为空断言。
- 调用方无回归：`npx vitest run --root packages/core src/utils/gitIgnoreParser.test.ts src/services/fileDiscoveryService.test.ts src/tools/glob.test.ts src/tools/ls.test.ts src/utils/ignorePatterns.test.ts` → **159 通过（5 个文件）**。

### 证据（修复前后对比）

N/A —— 无 UI 层面的可见变化。行为改变的是哪些文件被过滤，已由上述差分测试覆盖。

### 测试环境

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

仅单元测试。Windows 与 Linux 由 CI 覆盖。

## 风险与范围

- 主要风险或权衡：嵌套忽略文件中的仅目录规则现在会匹配到比以前更多的路径。这正是本次改动的目的，也与 git 一致，但对于已经依赖较窄行为的仓库，`glob` / `ls` / `read_many_files` 会过滤掉更多文件。上述三项「矫枉过正」保险正是把这一放宽严格限定在「未锚定」这一种情形上的手段。
- 未验证 / 不在范围内：本文件还有另外两处与 git 的偏差，本 PR 有意不予触碰——模式的前导空白被裁剪，以及模式中的每个反斜杠被改写为 `/`。二者各有独立的修复与测试。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
