### PR TITLE
fix(core): stop rewriting backslash escapes in gitignore patterns

### DIFF
--- a/packages/core/src/utils/gitIgnoreParser.test.ts
+++ b/packages/core/src/utils/gitIgnoreParser.test.ts
@@ -213,6 +213,69 @@ src/*.tmp
     });
   });
 
+  // In gitignore syntax `/` is always the separator and `\` is an escape
+  // character, so a pattern's backslashes are content, not path separators.
+  // Every expectation here was read off `git check-ignore` in a real
+  // repository.
+  describe('backslash escapes in patterns', () => {
+    beforeEach(async () => {
+      await setupGitRepo();
+    });
+
+    it('honours an escaped space', async () => {
+      await createTestFile('.gitignore', 'foo\\ bar.txt\n');
+
+      expect(parser.isIgnored('foo bar.txt')).toBe(true);
+    });
+
+    it('honours an escaped leading hash', async () => {
+      // `\#hash.txt` escapes the comment marker. Rewriting the backslash to
+      // `/` turned it into `/#hash.txt`, which additionally anchored the
+      // pattern to the repository root — so the rule both stopped matching
+      // and changed scope.
+      await createTestFile('.gitignore', '\\#hash.txt\n');
+
+      expect(parser.isIgnored('#hash.txt')).toBe(true);
+      expect(parser.isIgnored('sub/#hash.txt')).toBe(true);
+    });
+
+    it('honours escaped glob metacharacters', async () => {
+      await createTestFile('.gitignore', 'a\\[b\\].txt\nlit\\*.txt\n');
+
+      expect(parser.isIgnored('a[b].txt')).toBe(true);
+      expect(parser.isIgnored('lit*.txt')).toBe(true);
+      // The escape must still suppress the wildcard.
+      expect(parser.isIgnored('litX.txt')).toBe(false);
+    });
+
+    it('honours an escape inside a nested .gitignore', async () => {
+      // The nested path is where the prefix is assembled, so it is the case
+      // that would break if the pattern were passed through a path function.
+      await createTestFile('.gitignore', '');
+      await createTestFile('a/b/.gitignore', 'foo\\ bar.txt\n');
+
+      expect(parser.isIgnored('a/b/foo bar.txt')).toBe(true);
+      expect(parser.isIgnored('a/b/x/foo bar.txt')).toBe(true);
+    });
+
+    it('still expands nested patterns the documented way', async () => {
+      // The guard against over-correcting: the three rules in the comment
+      // above the prefix assembly must survive it unchanged.
+      await createTestFile('.gitignore', '');
+      await createTestFile('a/b/.gitignore', 'c\nd/e\n/f\n');
+
+      // `c` -> /a/b/**/c
+      expect(parser.isIgnored('a/b/c')).toBe(true);
+      expect(parser.isIgnored('a/b/x/c')).toBe(true);
+      // `d/e` -> /a/b/d/e
+      expect(parser.isIgnored('a/b/d/e')).toBe(true);
+      expect(parser.isIgnored('a/b/x/d/e')).toBe(false);
+      // `/f` -> /a/b/f
+      expect(parser.isIgnored('a/b/f')).toBe(true);
+      expect(parser.isIgnored('a/b/x/f')).toBe(false);
+    });
+  });
+
   describe('precedence rules', () => {
     beforeEach(async () => {
       await setupGitRepo();

--- a/packages/core/src/utils/gitIgnoreParser.ts
+++ b/packages/core/src/utils/gitIgnoreParser.ts
@@ -68,19 +68,16 @@ export class GitIgnoreParser implements GitIgnoreFilter {
           // - If `a/b/.gitignore` defines `c` then it needs to be changed to `/a/b/**/c`
           // - If `a/b/.gitignore` defines `c/d` then it needs to be changed to `/a/b/c/d`
 
-          if (!isAnchoredInFile && !p.includes('/')) {
-            // If no slash and not anchored in file, it matches files in any
-            // subdirectory.
-            newPattern = path.join('**', p);
-          }
-
-          // Prepend the .gitignore file's directory.
-          newPattern = path.join(relativeBaseDir, newPattern);
-
-          // Anchor the pattern to a nested gitignore directory.
-          if (!newPattern.startsWith('/')) {
-            newPattern = '/' + newPattern;
-          }
+          // The prefix is assembled by hand rather than with path.join so the
+          // pattern text is never passed through a platform path function.
+          // `relativeBaseDir` comes from path.relative and is the only piece
+          // that can hold a platform separator, so it is the only piece that
+          // is normalised.
+          const baseDir = relativeBaseDir.replace(/\\/g, '/');
+          // If no slash and not anchored in file, it matches files in any
+          // subdirectory.
+          const anyDepth = !isAnchoredInFile && !p.includes('/') ? '**/' : '';
+          newPattern = `/${baseDir}/${anyDepth}${p}`;
         }
 
         // Anchor the pattern if originally anchored
@@ -92,9 +89,13 @@ export class GitIgnoreParser implements GitIgnoreFilter {
           newPattern = '!' + newPattern;
         }
 
-        // Even in windows, Ignore expects forward slashes.
-        newPattern = newPattern.replace(/\\/g, '/');
-
+        // No blanket backslash rewrite here. In gitignore syntax `/` is always
+        // the separator and `\` is an escape character, so rewriting every
+        // backslash to `/` corrupted the pattern instead of normalising it:
+        // `foo\ bar.txt` became `foo/ bar.txt`, `\#hash.txt` became
+        // `/#hash.txt` (a comment escape turned into a root anchor) and
+        // `a\[b\].txt` became `a/[b/].txt`. Windows separators can only enter
+        // through `relativeBaseDir`, which is normalised at its source above.
         return newPattern;
       })
       .filter((p) => p !== '');


### PR DESCRIPTION
## What this PR does

The last step of pattern assembly was `newPattern.replace(/\\/g, '/')`, commented "Even in windows, Ignore expects forward slashes." The intent was to normalise the Windows separators that `path.join` had just introduced, but the replacement runs over the whole pattern, including the user's own text.

In gitignore syntax `/` is always the separator and `\` is an **escape character**, so this corrupts patterns rather than normalising them:

| `.gitignore` line | became | file | git | before this PR |
|---|---|---|---|---|
| `foo\ bar.txt` | `foo/ bar.txt` | `foo bar.txt` | IGNORED | not ignored |
| `\#hash.txt` | `/#hash.txt` | `sub/#hash.txt` | IGNORED | not ignored |
| `a\[b\].txt` | `a/[b/].txt` | `a[b].txt` | IGNORED | not ignored |

The `\#hash.txt` row is the worst of the three: the backslash is what stops `#` being read as a comment marker, and rewriting it to `/` turns the pattern into a root anchor. The rule does not merely stop matching — it changes scope.

The fix removes the blanket rewrite and assembles the nested-directory prefix by hand, so the pattern text is never passed through a platform path function. `relativeBaseDir` comes from `path.relative` and is the only piece that can hold a platform separator, so it is normalised at its source instead.

## Why it's needed

Escaped spaces are the common case — a `.gitignore` entry for a filename containing a space has to be written `foo\ bar.txt`, and that entry silently did nothing. `GitIgnoreParser` backs `FileDiscoveryService` and through it `glob`, `ls`, `read_many_files` and traversal pruning, so a file the user deliberately excluded is walked, listed, and read into the model's context.

## Reviewer Test Plan

### How to verify

Every expectation in the new tests was read off `git check-ignore` in a real repository (git 2.50.1) rather than off the documentation:

```sh
mkdir /tmp/b1 && cd /tmp/b1 && git init -q
printf 'foo\\ bar.txt\n' > .gitignore && touch 'foo bar.txt'
git check-ignore -v -- 'foo bar.txt'
```

- `npx vitest run --root packages/core src/utils/gitIgnoreParser.test.ts` → 26/26.
- Reverting **only** `gitIgnoreParser.ts` and keeping the new tests fails exactly four cases: `4 failed | 22 passed (26)`.
- The fifth new case, `still expands nested patterns the documented way`, passes both before and after **on purpose**. Replacing `path.join` with string assembly is the risky half of this change, so that test pins all three rules from the comment above the assembly — `c` → `/a/b/**/c`, `d/e` → `/a/b/d/e`, `/f` → `/a/b/f` — including the negative side of each.
- `honours an escape inside a nested .gitignore` is separate from the root-level escape case for the same reason: the nested path is the one that runs the new assembly code, so a fix that only dropped the rewrite would pass the root case and still be wrong.
- No regression in the consumers: `npx vitest run --root packages/core src/utils/gitIgnoreParser.test.ts src/services/fileDiscoveryService.test.ts src/tools/glob.test.ts src/tools/ls.test.ts src/utils/ignorePatterns.test.ts` → **160 passed (5 files)**.

### Evidence (Before & After)

N/A — not user-visible as UI. The behaviour change is which files are filtered, covered by the differential tests above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

This is the one change in this area with genuinely platform-specific reasoning, since the removed line existed for Windows. The reasoning is that `path.join` was the only thing that could introduce a backslash into the pattern, and it is no longer applied to the pattern; the remaining source, `relativeBaseDir`, is normalised explicitly at line 76. `should normalize path separators on Windows` in the existing suite still passes, and CI covers Windows.

## Risk & Scope

- Main risk or tradeoff: `path.join` also normalised the pattern as a side effect (collapsing `//`, resolving `.` / `..` segments). String assembly no longer does, so a pattern like `a//b` now reaches the `ignore` library as written. That is closer to gitignore semantics, where the pattern is glob text rather than a filesystem path, but it is a behaviour change beyond the escape fix and worth a reviewer's eye.
- Not validated / out of scope: this file has two other divergences from git that this PR deliberately does not touch — leading whitespace being trimmed off patterns, and a trailing `/` being counted as a separator when deciding whether a nested pattern is anchored. Each has its own fix and its own tests. An escaped *trailing* space (`esc\ `) needs both this change and the whitespace one before it matches, so it is not covered here.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

模式组装的最后一步是 `newPattern.replace(/\\/g, '/')`，注释写着「Even in windows, Ignore expects forward slashes.」。其本意是规范化 `path.join` 刚刚引入的 Windows 分隔符，但该替换作用于整个模式，包括用户自己写的文本。

在 gitignore 语法中，`/` 始终是分隔符，而 `\` 是**转义字符**，因此这一步不是在规范化模式，而是在破坏它：

| `.gitignore` 中的行 | 变成 | 文件 | git | 本 PR 之前 |
|---|---|---|---|---|
| `foo\ bar.txt` | `foo/ bar.txt` | `foo bar.txt` | 忽略 | 不忽略 |
| `\#hash.txt` | `/#hash.txt` | `sub/#hash.txt` | 忽略 | 不忽略 |
| `a\[b\].txt` | `a/[b/].txt` | `a[b].txt` | 忽略 | 不忽略 |

其中 `\#hash.txt` 一行最严重：正是那个反斜杠让 `#` 不被当作注释标记，而把它改写为 `/` 会使该模式变成根锚定。规则不只是停止匹配，其作用域也变了。

修复方式是移除这一整体替换，并手工组装嵌套目录前缀，使模式文本永远不会经过平台路径函数。`relativeBaseDir` 来自 `path.relative`，是唯一可能带有平台分隔符的部分，因此改为在其来源处规范化。

## 为什么需要

转义空格是常见情形——若要在 `.gitignore` 中排除一个名字含空格的文件，就必须写成 `foo\ bar.txt`，而该条目此前悄无声息地毫无作用。`GitIgnoreParser` 支撑 `FileDiscoveryService`，并经由它支撑 `glob`、`ls`、`read_many_files` 与遍历剪枝，因此用户明确排除的文件会被遍历、列举，并读入模型上下文。

## 复核测试计划

### 如何验证

新增测试中的每一条预期都来自在真实仓库上运行 `git check-ignore`（git 2.50.1），而非来自阅读文档：

```sh
mkdir /tmp/b1 && cd /tmp/b1 && git init -q
printf 'foo\\ bar.txt\n' > .gitignore && touch 'foo bar.txt'
git check-ignore -v -- 'foo bar.txt'
```

- `npx vitest run --root packages/core src/utils/gitIgnoreParser.test.ts` → 26/26 通过。
- **仅**还原 `gitIgnoreParser.ts`、保留新增测试时，恰好四项失败：`4 failed | 22 passed (26)`。
- 第五项新增用例 `still expands nested patterns the documented way` 在修复前后**都通过，这是刻意为之**。用字符串组装替换 `path.join` 是本次改动中风险较高的一半，因此该测试锚定了组装代码上方注释中的全部三条规则——`c` → `/a/b/**/c`、`d/e` → `/a/b/d/e`、`/f` → `/a/b/f`——并包含每条的反面断言。
- `honours an escape inside a nested .gitignore` 与根级转义用例分开，理由相同：嵌套路径才会走新的组装代码，因此只删除替换、不改组装的修复会通过根级用例但依然是错的。
- 调用方无回归：`npx vitest run --root packages/core src/utils/gitIgnoreParser.test.ts src/services/fileDiscoveryService.test.ts src/tools/glob.test.ts src/tools/ls.test.ts src/utils/ignorePatterns.test.ts` → **160 通过（5 个文件）**。

### 证据（修复前后对比）

N/A —— 无 UI 层面的可见变化。行为改变的是哪些文件被过滤，已由上述差分测试覆盖。

### 测试环境

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

在这一区域的改动中，本项是唯一带有真正平台相关推理的一处，因为被删除的那行本就是为 Windows 而存在。推理如下：能把反斜杠引入模式的只有 `path.join`，而它已不再作用于模式；剩余的来源 `relativeBaseDir` 已在第 76 行显式规范化。既有套件中的 `should normalize path separators on Windows` 仍然通过，且 CI 覆盖 Windows。

## 风险与范围

- 主要风险或权衡：`path.join` 此前还顺带对模式做了规范化（折叠 `//`、消解 `.` / `..` 段）。字符串组装不再如此，因此像 `a//b` 这样的模式现在会原样送达 `ignore` 库。这更贴近 gitignore 语义（模式是 glob 文本而非文件系统路径），但它是超出转义修复本身的行为变更，值得复核者留意。
- 未验证 / 不在范围内：本文件还有另外两处与 git 的偏差，本 PR 有意不予触碰——模式前导空白被裁剪，以及判断嵌套模式是否锚定时把尾部 `/` 当作分隔符。二者各有独立的修复与测试。转义的**尾部**空格（`esc\ `）需要同时具备本改动与空白改动才能匹配，故不在此处覆盖。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
