### PR TITLE
fix(core): keep the model name when a model id carries a variant tag

### DIFF
--- a/packages/core/src/core/tokenLimits.test.ts
+++ b/packages/core/src/core/tokenLimits.test.ts
@@ -28,6 +28,17 @@ describe('normalize', () => {
     expect(normalize('qwen|qwen2.5:qwen2.5-1m')).toBe('qwen2.5-1m');
   });
 
+  it('should keep the model name when the colon carries a variant tag', () => {
+    // OpenRouter variants and Ollama / LM Studio tags put the colon on the
+    // right of the model name — the opposite side from the `family:model`
+    // form above — so the half worth keeping is the left one.
+    expect(normalize('qwen/qwen3-coder:free')).toBe('qwen3-coder');
+    expect(normalize('google/gemini-2.5-pro:online')).toBe('gemini-2.5-pro');
+    expect(normalize('qwen2.5-coder:32b')).toBe('qwen2.5-coder');
+    expect(normalize('llama3.1:8b-instruct-q4_k_m')).toBe('llama3.1');
+    expect(normalize('qwen2.5-coder:latest')).toBe('qwen2.5-coder');
+  });
+
   it('should collapse whitespace to a single hyphen', () => {
     expect(normalize('claude 3.5 sonnet')).toBe('claude-3.5-sonnet');
   });
@@ -278,6 +289,37 @@ describe('tokenLimit', () => {
   it('should handle case-insensitive model names', () => {
     expect(tokenLimit('GPT-4O')).toBe(131072);
     expect(tokenLimit('CLAUDE-3.5-SONNET')).toBe(200000);
+  });
+});
+
+describe('variant-tagged model ids', () => {
+  it('resolves the same limit with and without the tag', () => {
+    for (const [tagged, bare] of [
+      ['qwen/qwen3-coder:free', 'qwen/qwen3-coder'],
+      ['google/gemini-2.5-pro:online', 'google/gemini-2.5-pro'],
+      ['openai/gpt-5:free', 'openai/gpt-5'],
+      ['qwen2.5-coder:32b', 'qwen2.5-coder'],
+      ['qwen3-coder-plus:nitro', 'qwen3-coder-plus'],
+    ] as Array<[string, string]>) {
+      expect(tokenLimit(tagged)).toBe(tokenLimit(bare));
+      expect(tokenLimit(tagged, 'output')).toBe(tokenLimit(bare, 'output'));
+    }
+  });
+
+  it('reports the real window rather than the default fallback', () => {
+    // Pinned absolutely as well as relatively: if both sides of the
+    // comparison above regressed to the default the pairs would still match.
+    expect(tokenLimit('qwen/qwen3-coder:free')).toBe(262_144);
+    expect(tokenLimit('google/gemini-2.5-pro:online')).toBe(1_000_000);
+    expect(tokenLimit('openai/gpt-5:free')).toBe(272_000);
+    expect(tokenLimit('qwen2.5-coder:32b')).toBe(262_144);
+  });
+
+  it('still keeps the right half of a prefixed id', () => {
+    // The guard against over-correcting: a colon suffix is dropped only when
+    // it looks like a tag, so the `family:model` forms stay as they were.
+    expect(tokenLimit('qwen|qwen2.5:qwen2.5-1m')).toBe(262_144);
+    expect(tokenLimit('  a/b/c|GPT-4o:gpt-4o-2024-05-13-q4  ')).toBe(131_072);
   });
 });
 

--- a/packages/core/src/core/tokenLimits.ts
+++ b/packages/core/src/core/tokenLimits.ts
@@ -120,6 +120,22 @@ export function normalize(model: string): string {
   // keep final path segment (strip provider prefixes), handle pipe/colon
   s = s.replace(/^.*\//, '');
   s = s.split('|').pop() ?? s;
+
+  // A colon can sit on either side of the model name. `authType:model` and
+  // `family:model` put it on the left, and the split below keeps the right
+  // half. But OpenRouter variant suffixes and Ollama / LM Studio tags put it
+  // on the RIGHT — `qwen3-coder:free`, `gemini-2.5-pro:online`,
+  // `qwen2.5-coder:32b` — and there the right half is a tag, not a model, so
+  // keeping it discards the model name entirely and every such id silently
+  // falls through to the default limit. Those tags are a closed enough set to
+  // recognise, so they are removed first and the split below then sees a bare
+  // model name. `modelId.ts` documents the same collision from the other side
+  // ("Model IDs can legitimately contain colons").
+  s = s.replace(
+    /:(?:free|beta|extended|thinking|online|nitro|floor|latest|\d+(?:\.\d+)?(?:x\d+)?b(?:-[\w.]+)*)$/,
+    '',
+  );
+
   s = s.split(':').pop() ?? s;
 
   // collapse whitespace to single hyphen


### PR DESCRIPTION
## What this PR does

`normalize()` reduces a model id to a bare model name before it is matched against the limit tables. One of its steps is:

```ts
s = s.split(':').pop() ?? s;
```

That keeps the text after the **last** colon. It is right for `family:model` ids such as `qwen|qwen2.5:qwen2.5-1m`, where the model is on the right. But OpenRouter variant suffixes and Ollama / LM Studio tags put the colon on the *other* side, and there the right half is a tag rather than a model — so the model name is thrown away and only the tag survives:

| model id | `normalize()` | input limit used | should be |
|---|---|---|---|
| `qwen/qwen3-coder:free` | `free` | 200 000 | **262 144** |
| `google/gemini-2.5-pro:online` | `online` | 200 000 | **1 000 000** |
| `openai/gpt-5:free` | `free` | 200 000 | **272 000** |
| `qwen2.5-coder:32b` | `32b` | 200 000 | **262 144** |

No pattern matches `free`, so every one of these falls through to the default. Output limits collapse to the 32 000 default the same way.

The fix removes a recognised right-hand tag before the split, so the split then sees a bare model name. The tag set is the closed one: the OpenRouter variants (`free`, `beta`, `extended`, `thinking`, `online`, `nitro`, `floor`), `latest`, and the Ollama size/quantisation shape (`32b`, `8x7b`, `8b-instruct-q4_k_m`).

## Why it's needed

The context window is not cosmetic — it drives compaction. `tokenLimit()` feeds `chatCompressionService`, and a model advertised as 200 000 tokens when it actually has 1 000 000 gets compacted at a fifth of its real capacity: history is discarded, and the user pays for a summarisation pass that was not needed. In the other direction, a genuine 200 000-token default applied to a smaller local model overruns it.

The affected ids are the normal way to name a model on the two most common non-first-party paths: `:free` is how OpenRouter's free tier is addressed, and `name:size` is how *every* Ollama model is addressed — `ollama run qwen2.5-coder:32b` is the documented invocation.

The codebase already knows about this collision from the other side. `packages/core/src/utils/modelId.ts:99` refuses to treat a colon prefix as an auth type unless it recognises it, with the comment *"Model IDs can legitimately contain colons (e.g. gpt-4o:online)"* — naming one of the exact ids that breaks here.

## Reviewer Test Plan

### How to verify

- `npx vitest run --root packages/core src/core/tokenLimits.test.ts` → 79/79.
- Reverting **only** `tokenLimits.ts` and keeping the new tests fails exactly three cases: `3 failed | 76 passed (79)`.
- The suite pins the fix in three independent ways, because each alone can be satisfied by a wrong implementation:
  - `resolves the same limit with and without the tag` — relative: `tokenLimit('qwen/qwen3-coder:free') === tokenLimit('qwen/qwen3-coder')`, for input *and* output.
  - `reports the real window rather than the default fallback` — absolute. The relative test above would still pass if both sides regressed to the default, so the four numbers are pinned literally.
  - `still keeps the right half of a prefixed id` — the guard against over-correcting, and the one that constrains the design. `normalize('qwen|qwen2.5:qwen2.5-1m')` must stay `qwen2.5-1m` and `'  a/b/c|GPT-4o:gpt-4o-2024-05-13-q4  '` must stay 131 072. Both were already in the suite; this test states explicitly that they are load-bearing, since the obvious "just strip the trailing `:tag`" fix breaks them.
- No regression in the consumers: `npx vitest run --root packages/core src/core/tokenLimits.test.ts src/providers/__tests__/presets/grok.test.ts src/config/config.test.ts src/services/chatCompressionService.test.ts` → **612 passed (4 files)**.

### Evidence (Before & After)

N/A — not user-visible as UI. The change is which limit is selected for a model id, covered by the unit tests above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Pure string function, no I/O or platform-dependent behaviour. CI covers Windows and Linux.

## Risk & Scope

- Main risk or tradeoff: the tag list is a closed set, so it is a maintenance point — a new OpenRouter variant would need adding. The alternative designs are worse: stripping any trailing `:tag` unconditionally breaks the `family:model` ids the suite already pins, and inferring intent from the shape of the two halves works only by accident. A closed list is at least wrong in an obvious, greppable way.
- Not validated / out of scope: an unrecognised tag still falls through to the old behaviour and still loses the model name. That is a deliberate floor rather than a fix — it is exactly today's behaviour, so nothing regresses, but `some-model:someunknowntag` is not repaired by this PR.
- Breaking changes / migration notes: none. Ids without a colon, and ids whose colon carries a family prefix, normalise byte-identically — the 612 passing consumer tests are the evidence.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

`normalize()` 会先把模型 id 归约为纯模型名，再去匹配限额表。其中一步是：

```ts
s = s.split(':').pop() ?? s;
```

它保留**最后**一个冒号之后的文本。对于 `family:model` 形式的 id（如 `qwen|qwen2.5:qwen2.5-1m`，模型名在右侧）这是正确的。但 OpenRouter 的变体后缀与 Ollama / LM Studio 的标签把冒号放在了*另一侧*，此时右半部分是标签而非模型——于是模型名被丢弃，只剩下标签：

| 模型 id | `normalize()` | 实际采用的输入限额 | 应为 |
|---|---|---|---|
| `qwen/qwen3-coder:free` | `free` | 200 000 | **262 144** |
| `google/gemini-2.5-pro:online` | `online` | 200 000 | **1 000 000** |
| `openai/gpt-5:free` | `free` | 200 000 | **272 000** |
| `qwen2.5-coder:32b` | `32b` | 200 000 | **262 144** |

没有任何 pattern 能匹配 `free`，因此上述每一项都落到了默认值。输出限额同样会塌缩为 32 000 默认值。

修复方式是在 split 之前移除可识别的右侧标签，使 split 面对的是一个纯模型名。标签集合是封闭的：OpenRouter 变体（`free`、`beta`、`extended`、`thinking`、`online`、`nitro`、`floor`）、`latest`，以及 Ollama 的尺寸/量化形态（`32b`、`8x7b`、`8b-instruct-q4_k_m`）。

## 为什么需要

上下文窗口并非无关紧要——它驱动压缩逻辑。`tokenLimit()` 供给 `chatCompressionService`，一个实际拥有 1 000 000 token 却被当作 200 000 的模型，会在其真实容量的五分之一处就被压缩：历史被丢弃，用户还要为一次本不必要的摘要调用付费。反方向上，把 200 000 的默认值套在更小的本地模型上则会溢出。

受影响的这些 id 正是两条最常见的非第一方路径上命名模型的标准方式：`:free` 是 OpenRouter 免费档的寻址方式，而 `name:size` 是**每一个** Ollama 模型的寻址方式——`ollama run qwen2.5-coder:32b` 就是官方文档中的调用形式。

代码库其实已经从另一侧认识到这个冲突。`packages/core/src/utils/modelId.ts:99` 在无法识别冒号前缀时拒绝将其当作 authType，注释为 *"Model IDs can legitimately contain colons (e.g. gpt-4o:online)"*——点名的正是此处出错的 id 之一。

## 复核测试计划

### 如何验证

- `npx vitest run --root packages/core src/core/tokenLimits.test.ts` → 79/79 通过。
- **仅**还原 `tokenLimits.ts`、保留新增测试时，恰好三项失败：`3 failed | 76 passed (79)`。
- 测试从三个彼此独立的角度锚定该修复，因为任何单一角度都可能被错误实现所满足：
  - `resolves the same limit with and without the tag` —— 相对性：`tokenLimit('qwen/qwen3-coder:free') === tokenLimit('qwen/qwen3-coder')`，输入与输出**均**成立。
  - `reports the real window rather than the default fallback` —— 绝对性。若两侧同时退化为默认值，上面的相对测试仍会通过，因此这四个数值被逐一写死。
  - `still keeps the right half of a prefixed id` —— 防止「矫枉过正」的保险，也是约束设计的那一项。`normalize('qwen|qwen2.5:qwen2.5-1m')` 必须仍为 `qwen2.5-1m`，`'  a/b/c|GPT-4o:gpt-4o-2024-05-13-q4  '` 必须仍为 131 072。二者本就在套件中；本测试明确声明它们是承重的，因为最直觉的「直接剥离尾部 `:tag`」式修复会破坏它们。
- 调用方无回归：`npx vitest run --root packages/core src/core/tokenLimits.test.ts src/providers/__tests__/presets/grok.test.ts src/config/config.test.ts src/services/chatCompressionService.test.ts` → **612 通过（4 个文件）**。

### 证据（修复前后对比）

N/A —— 无 UI 层面的可见变化。改动的是为某个模型 id 选中哪个限额，已由上述单元测试覆盖。

### 测试环境

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

纯字符串函数，无 I/O，无平台相关行为。Windows 与 Linux 由 CI 覆盖。

## 风险与范围

- 主要风险或权衡：标签集合是封闭的，因此成为一个维护点——新增的 OpenRouter 变体需要补进来。其余设计更差：无条件剥离任何尾部 `:tag` 会破坏套件已锚定的 `family:model` 形式 id；而依据两侧文本形态去推断意图只是碰巧成立。封闭列表至少错得明显且可 grep。
- 未验证 / 不在范围内：未被识别的标签仍会走旧路径，仍会丢失模型名。这是刻意保留的下限而非修复——它与今日行为完全一致，故不产生回归，但 `some-model:someunknowntag` 并未被本 PR 修好。
- 破坏性变更 / 迁移说明：无。不含冒号的 id，以及冒号承载族前缀的 id，归一化结果逐字节一致——612 项通过的调用方测试即为证据。

## 关联 Issue

无。

</details>
