### PR TITLE
perf(acp): Preload providers after session creation

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -73,6 +73,10 @@ const { mockDebugLogger } = vi.hoisted(() => ({
   },
 }));
 
+const { mockPreloadContentGenerator } = vi.hoisted(() => ({
+  mockPreloadContentGenerator: vi.fn().mockResolvedValue(undefined),
+}));
+
 const {
   mockExtractDaemonTraceContext,
   mockSessionStartSpan,
@@ -198,6 +202,7 @@ vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => ({
       : undefined,
   ),
   initializeTelemetry: vi.fn().mockResolvedValue(undefined),
+  preloadContentGenerator: mockPreloadContentGenerator,
   createDebugLogger: () => mockDebugLogger,
   extractDaemonTraceContext: mockExtractDaemonTraceContext,
   withDaemonSpan: mockWithDaemonSpan,
@@ -875,6 +880,85 @@ describe('runAcpAgent shutdown cleanup', () => {
 
   const mockSettings = { merged: {} } as LoadedSettings;
   const mockArgv = {} as CliArgs;
+  type MessageObservedHook = NonNullable<
+    NonNullable<Parameters<typeof ndJsonStream>[2]>['onMessageObserved']
+  >;
+  type PreloadTestSession = {
+    getId: () => string;
+    getConfig: () => Config;
+  };
+  type PreloadTestAgent = {
+    sessions: Map<string, PreloadTestSession>;
+  };
+
+  const startPreloadTestAgent = async (instantiateAgent = true) => {
+    const agentPromise = runAcpAgent(mockConfig, mockSettings, mockArgv);
+    await vi.waitFor(() => expect(ndJsonStream).toHaveBeenCalledOnce());
+
+    const hook = vi.mocked(ndJsonStream).mock.calls[0]?.[2]
+      ?.onMessageObserved as MessageObservedHook | undefined;
+    if (!hook) throw new Error('Expected ACP message observation hook');
+
+    let agent: PreloadTestAgent | undefined;
+    if (instantiateAgent) {
+      const createAgent = vi.mocked(AgentSideConnection).mock.calls[0]?.[0] as
+        | ((connection: AgentSideConnection) => unknown)
+        | undefined;
+      if (!createAgent) throw new Error('Expected ACP agent factory');
+      agent = createAgent({} as AgentSideConnection) as PreloadTestAgent;
+    }
+    return { agent, agentPromise, hook };
+  };
+
+  const addPreloadTestSession = (
+    agent: PreloadTestAgent,
+    sessionId: string,
+    generator: object,
+  ) => {
+    const sessionConfig = {
+      getContentGenerator: vi.fn().mockReturnValue(generator),
+    } as unknown as Config;
+    agent.sessions.set(sessionId, {
+      getId: () => sessionId,
+      getConfig: () => sessionConfig,
+    });
+    return sessionConfig;
+  };
+
+  const observeNewSessionRequest = (
+    hook: MessageObservedHook,
+    id: string | number | null,
+  ) => {
+    hook({
+      direction: 'received',
+      bytes: 1,
+      message: {
+        jsonrpc: '2.0',
+        id,
+        method: 'session/new',
+        params: { cwd: '/tmp', mcpServers: [] },
+      },
+    });
+  };
+
+  const observeResponse = (
+    hook: MessageObservedHook,
+    id: string | number | null,
+    response:
+      | { result: { sessionId: string } }
+      | { error: { code: number; message: string } },
+  ) => {
+    hook({
+      direction: 'sent',
+      bytes: 1,
+      message: { jsonrpc: '2.0', id, ...response },
+    });
+  };
+
+  const flushImmediate = () =>
+    new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
 
   beforeEach(() => {
     resetAcpStartupProfilerForTesting();
@@ -890,6 +974,8 @@ describe('runAcpAgent shutdown cleanup', () => {
       getDisableAllHooks: vi.fn().mockReturnValue(false),
       hasHooksForEvent: vi.fn().mockReturnValue(false),
       getModel: vi.fn().mockReturnValue('test-model'),
+      getWorkspaceContext: vi.fn().mockReturnValue({}),
+      getDebugMode: vi.fn().mockReturnValue(false),
     } as unknown as Config;
 
     mockRunExitCleanup.mockResolvedValue(undefined);
@@ -1021,6 +1107,136 @@ describe('runAcpAgent shutdown cleanup', () => {
 
     expect(initializeTelemetry).toHaveBeenCalledOnce();
     expect(initializeTelemetry).toHaveBeenCalledWith(mockConfig);
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('preloads out-of-order session/new responses with string, number, and null ids', async () => {
+    const { agent, agentPromise, hook } = await startPreloadTestAgent();
+    expect(agent).toBeDefined();
+    const stringGenerator = { id: 'string-generator' };
+    const numberGenerator = { id: 'number-generator' };
+    const nullGenerator = { id: 'null-generator' };
+    addPreloadTestSession(agent!, 'string-session', stringGenerator);
+    addPreloadTestSession(agent!, 'number-session', numberGenerator);
+    addPreloadTestSession(agent!, 'null-session', nullGenerator);
+
+    observeNewSessionRequest(hook, 'request');
+    observeNewSessionRequest(hook, 7);
+    observeNewSessionRequest(hook, null);
+    observeResponse(hook, null, {
+      result: { sessionId: 'null-session' },
+    });
+    observeResponse(hook, 'request', {
+      result: { sessionId: 'string-session' },
+    });
+    observeResponse(hook, 7, {
+      result: { sessionId: 'number-session' },
+    });
+
+    expect(mockPreloadContentGenerator).not.toHaveBeenCalled();
+    await flushImmediate();
+    expect(mockPreloadContentGenerator.mock.calls).toEqual([
+      [nullGenerator],
+      [stringGenerator],
+      [numberGenerator],
+    ]);
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('consumes errors and ignores duplicate, nonmatching, and premature responses', async () => {
+    const { agent, agentPromise, hook } = await startPreloadTestAgent();
+    expect(agent).toBeDefined();
+    const generator = { id: 'only-generator' };
+    addPreloadTestSession(agent!, 'only-session', generator);
+
+    observeResponse(hook, 9, { result: { sessionId: 'only-session' } });
+    observeNewSessionRequest(hook, 9);
+
+    observeNewSessionRequest(hook, 10);
+    observeResponse(hook, 10, {
+      error: { code: -32603, message: 'failed' },
+    });
+    observeResponse(hook, 10, {
+      result: { sessionId: 'only-session' },
+    });
+
+    observeNewSessionRequest(hook, 11);
+    observeResponse(hook, 11, {
+      result: { sessionId: 'only-session' },
+    });
+    observeResponse(hook, 11, {
+      result: { sessionId: 'only-session' },
+    });
+
+    await flushImmediate();
+    expect(mockPreloadContentGenerator).toHaveBeenCalledOnce();
+    expect(mockPreloadContentGenerator).toHaveBeenCalledWith(generator);
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('re-finds the live session and its current generator in the scheduled callback', async () => {
+    const { agent, agentPromise, hook } = await startPreloadTestAgent();
+    expect(agent).toBeDefined();
+    const oldGenerator = { id: 'old-generator' };
+    const currentGenerator = { id: 'current-generator' };
+    addPreloadTestSession(agent!, 'session', oldGenerator);
+
+    observeNewSessionRequest(hook, 1);
+    observeResponse(hook, 1, { result: { sessionId: 'session' } });
+    addPreloadTestSession(agent!, 'session', currentGenerator);
+    await flushImmediate();
+
+    expect(mockPreloadContentGenerator).toHaveBeenCalledOnce();
+    expect(mockPreloadContentGenerator).toHaveBeenCalledWith(currentGenerator);
+
+    observeNewSessionRequest(hook, 2);
+    observeResponse(hook, 2, { result: { sessionId: 'session' } });
+    agent!.sessions.delete('session');
+    await flushImmediate();
+    expect(mockPreloadContentGenerator).toHaveBeenCalledOnce();
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('safely drops a preload response observed before the agent exists', async () => {
+    const { agentPromise, hook } = await startPreloadTestAgent(false);
+
+    observeNewSessionRequest(hook, 'early');
+    observeResponse(hook, 'early', {
+      result: { sessionId: 'missing-session' },
+    });
+    await flushImmediate();
+
+    expect(mockPreloadContentGenerator).not.toHaveBeenCalled();
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('catches and debug-logs background preload rejection', async () => {
+    const { agent, agentPromise, hook } = await startPreloadTestAgent();
+    expect(agent).toBeDefined();
+    const generator = { id: 'rejected-generator' };
+    addPreloadTestSession(agent!, 'rejected-session', generator);
+    mockPreloadContentGenerator.mockRejectedValueOnce(
+      new Error('provider import failed'),
+    );
+
+    observeNewSessionRequest(hook, 12);
+    observeResponse(hook, 12, {
+      result: { sessionId: 'rejected-session' },
+    });
+    await flushImmediate();
+
+    expect(mockDebugLogger.debug).toHaveBeenCalledWith(
+      '[ACP] Session provider preload failed for rejected-session: provider import failed',
+    );
 
     mockConnectionState.resolve();
     await agentPromise;

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -39,6 +39,7 @@ import {
   getMCPDiscoveryState,
   getMCPServerStatus,
   initializeTelemetry,
+  preloadContentGenerator,
   MCPDiscoveryState,
   MCPServerStatus,
   McpTransportPool,
@@ -2717,16 +2718,48 @@ export async function runAcpAgent(
     console.debug = console.error;
 
     let initializeRequestId: string | number | null | undefined;
+    const pendingNewSessionRequestIds = new Set<string | number | null>();
     const stream = ndJsonStream(stdout, stdin, {
       onMessageObserved: ({ direction, message }) => {
         if (
           direction === 'received' &&
           'id' in message &&
-          'method' in message &&
-          message.method === 'initialize'
+          'method' in message
         ) {
-          initializeRequestId = message.id;
+          if (message.method === 'session/new') {
+            pendingNewSessionRequestIds.add(message.id);
+          } else if (message.method === 'initialize') {
+            initializeRequestId = message.id;
+          }
           return;
+        }
+        if (
+          direction === 'sent' &&
+          'id' in message &&
+          !('method' in message) &&
+          pendingNewSessionRequestIds.delete(message.id) &&
+          'result' in message &&
+          typeof message.result === 'object' &&
+          message.result !== null &&
+          'sessionId' in message.result &&
+          typeof message.result.sessionId === 'string'
+        ) {
+          const sessionId = message.result.sessionId;
+          setImmediate(() => {
+            const session = agentInstance
+              ?.getActiveSessions()
+              .find((candidate) => candidate.getId() === sessionId);
+            if (!session) return;
+            void preloadContentGenerator(
+              session.getConfig().getContentGenerator(),
+            ).catch((error: unknown) => {
+              debugLogger.debug(
+                `[ACP] Session provider preload failed for ${sessionId}: ${
+                  error instanceof Error ? error.message : String(error)
+                }`,
+              );
+            });
+          }).unref();
         }
         if (
           direction !== 'sent' ||

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -44,6 +44,7 @@ import {
   AuthType,
   createContentGenerator,
   createContentGeneratorConfig,
+  resetPreloadedContentGenerator,
   resolveContentGeneratorConfigWithSources,
 } from '../core/contentGenerator.js';
 import { DEFAULT_TOKEN_LIMIT } from '../core/tokenLimits.js';
@@ -3581,6 +3582,7 @@ describe('Server Config (config.ts)', () => {
 
       // Spy after initial refresh to ensure model switch does not re-trigger refreshAuth.
       const refreshSpy = vi.spyOn(config, 'refreshAuth');
+      vi.mocked(resetPreloadedContentGenerator).mockClear();
 
       await config.switchModel(AuthType.QWEN_OAUTH, 'coder-model');
 
@@ -3591,6 +3593,10 @@ describe('Server Config (config.ts)', () => {
         vi.mocked(resolveContentGeneratorConfigWithSources),
       ).toHaveBeenCalledTimes(2);
       expect(vi.mocked(createContentGenerator)).toHaveBeenCalledTimes(1);
+      expect(resetPreloadedContentGenerator).toHaveBeenCalledOnce();
+      expect(resetPreloadedContentGenerator).toHaveBeenCalledWith(
+        config.getContentGenerator(),
+      );
     });
 
     it('should preserve thoughts from history on model switch', async () => {
@@ -4534,6 +4540,12 @@ describe('Server Config (config.ts)', () => {
 
   it('relocateWorkingDirectory should preserve leased storage for an ACP cwd change', async () => {
     const config = new Config(baseParams);
+    const generator = {} as ContentGenerator;
+    (
+      config as unknown as {
+        contentGenerator: ContentGenerator;
+      }
+    ).contentGenerator = generator;
     const originalStorage = config.storage;
     const originalPersistenceRoot = originalStorage.getProjectRoot();
     const newDir = path.resolve('/path/to/other');
@@ -4551,6 +4563,7 @@ describe('Server Config (config.ts)', () => {
     ).resolves.toEqual({});
 
     expect(config.getTargetDir()).toBe(newDir);
+    expect(resetPreloadedContentGenerator).toHaveBeenCalledWith(generator);
     expect(config.storage).toBe(originalStorage);
     expect(config.getSessionService().getProjectRoot()).toBe(
       originalPersistenceRoot,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -40,6 +40,7 @@ import { resolveInteractionMode } from '../core/prompts.js';
 import {
   AuthType,
   createContentGenerator,
+  resetPreloadedContentGenerator,
   resolveContentGeneratorConfigWithSources,
 } from '../core/contentGenerator.js';
 import { tokenLimit } from '../core/tokenLimits.js';
@@ -4116,6 +4117,7 @@ export class Config {
       if (priorReasoningEffort) {
         this.setReasoningEffort(priorReasoningEffort);
       }
+      resetPreloadedContentGenerator(this.contentGenerator);
       return;
     }
 
@@ -4417,6 +4419,7 @@ export class Config {
     this.backgroundTaskRegistry.disposeResidentAgents();
     this.targetDir = expected;
     this.cwd = expected;
+    resetPreloadedContentGenerator(this.contentGenerator);
     await this.refreshCurrentRuntimeStatus(expected);
     this.workspaceContext.applyRootDirectories(workspaceDirectories);
     this.fileDiscoveryService = null;

--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -9,21 +9,37 @@ import {
   createContentGenerator,
   createContentGeneratorConfig,
   AuthType,
+  preloadContentGenerator,
+  resetPreloadedContentGenerator,
 } from './contentGenerator.js';
 import { GoogleGenAI } from '@google/genai';
 import type { Config } from '../config/config.js';
+import type {
+  ContentGenerator,
+  ContentGeneratorConfig,
+} from './contentGenerator.js';
 
 vi.mock('@google/genai');
 
 const openaiMockState = vi.hoisted(() => ({
   generatorError: null as Error | null,
   createCount: 0,
+  constructionGates: [] as Array<Promise<void> | undefined>,
+  deferredErrors: [] as Array<Error | undefined>,
 }));
 
 const qwenMockState = vi.hoisted(() => ({
   oauthError: null as Error | null,
   oauthCount: 0,
   constructorCount: 0,
+  constructorModels: [] as Array<string | undefined>,
+}));
+
+const openaiLoggerMockState = vi.hoisted(() => ({
+  constructorCalls: [] as Array<{
+    customLogDir: string | undefined;
+    cwd: string | undefined;
+  }>,
 }));
 
 vi.mock('./openaiContentGenerator/index.js', () => ({
@@ -31,8 +47,9 @@ vi.mock('./openaiContentGenerator/index.js', () => ({
     if (openaiMockState.generatorError) {
       throw openaiMockState.generatorError;
     }
+    const attempt = openaiMockState.createCount;
     openaiMockState.createCount += 1;
-    return {
+    const createGenerator = () => ({
       generateContent: async () => ({}),
       generateContentStream: async () =>
         (async function* () {
@@ -41,7 +58,16 @@ vi.mock('./openaiContentGenerator/index.js', () => ({
       countTokens: async () => ({ totalTokens: 1 }),
       embedContent: async () => ({ embeddings: [] }),
       useSummarizedThinking: () => false,
-    };
+    });
+    const gate = openaiMockState.constructionGates[attempt];
+    if (!gate) {
+      return createGenerator();
+    }
+    return gate.then(() => {
+      const error = openaiMockState.deferredErrors[attempt];
+      if (error) throw error;
+      return createGenerator();
+    });
   },
 }));
 
@@ -57,8 +83,9 @@ vi.mock('../qwen/qwenOAuth2.js', () => ({
 
 vi.mock('../qwen/qwenContentGenerator.js', () => ({
   QwenContentGenerator: class {
-    constructor() {
+    constructor(_client: unknown, generatorConfig: { model?: string }) {
       qwenMockState.constructorCount += 1;
+      qwenMockState.constructorModels.push(generatorConfig.model);
     }
 
     async countTokens() {
@@ -71,14 +98,26 @@ vi.mock('../qwen/qwenContentGenerator.js', () => ({
   },
 }));
 
+vi.mock('../utils/openaiLogger.js', () => ({
+  OpenAILogger: class {
+    constructor(customLogDir?: string, cwd?: string) {
+      openaiLoggerMockState.constructorCalls.push({ customLogDir, cwd });
+    }
+  },
+}));
+
 describe('createContentGenerator', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     openaiMockState.generatorError = null;
     openaiMockState.createCount = 0;
+    openaiMockState.constructionGates = [];
+    openaiMockState.deferredErrors = [];
     qwenMockState.oauthError = null;
     qwenMockState.oauthCount = 0;
     qwenMockState.constructorCount = 0;
+    qwenMockState.constructorModels = [];
+    openaiLoggerMockState.constructorCalls = [];
   });
 
   it('should defer Gemini content generator creation until first use', async () => {
@@ -188,6 +227,294 @@ describe('createContentGenerator', () => {
     expect(openaiMockState.createCount).toBe(1);
   });
 
+  it('does not preload non-lazy content generators', async () => {
+    const generator: ContentGenerator = {
+      generateContent: vi.fn(),
+      generateContentStream: vi.fn(),
+      countTokens: vi.fn(),
+      embedContent: vi.fn(),
+      useSummarizedThinking: vi.fn(),
+    };
+
+    await expect(preloadContentGenerator(generator)).resolves.toBeUndefined();
+    resetPreloadedContentGenerator(generator);
+    expect(generator.generateContent).not.toHaveBeenCalled();
+    expect(generator.generateContentStream).not.toHaveBeenCalled();
+    expect(generator.countTokens).not.toHaveBeenCalled();
+    expect(generator.embedContent).not.toHaveBeenCalled();
+    expect(generator.useSummarizedThinking).not.toHaveBeenCalled();
+  });
+
+  it('loads a provider once across concurrent preload and first use', async () => {
+    const mockConfig = {
+      getUsageStatisticsEnabled: () => false,
+      getContentGeneratorConfig: () => ({}),
+      getCliVersion: () => '1.0.0',
+      getTelemetryEnabled: () => false,
+      getSessionId: () => 'test-session',
+    } as unknown as Config;
+    const generator = await createContentGenerator(
+      {
+        model: 'test-model',
+        apiKey: 'test-key',
+        authType: AuthType.USE_OPENAI,
+      },
+      mockConfig,
+    );
+
+    await Promise.all([
+      preloadContentGenerator(generator),
+      generator.countTokens({ model: 'test-model', contents: 'hello' }),
+    ]);
+
+    expect(openaiMockState.createCount).toBe(1);
+  });
+
+  it('discards an unused preload after session configuration changes', async () => {
+    const mockConfig = {
+      getUsageStatisticsEnabled: () => false,
+      getContentGeneratorConfig: () => ({}),
+      getCliVersion: () => '1.0.0',
+      getTelemetryEnabled: () => false,
+      getSessionId: () => 'test-session',
+    } as unknown as Config;
+    const generator = await createContentGenerator(
+      {
+        model: 'test-model',
+        apiKey: 'test-key',
+        authType: AuthType.USE_OPENAI,
+      },
+      mockConfig,
+    );
+
+    await preloadContentGenerator(generator);
+    resetPreloadedContentGenerator(generator);
+    await generator.countTokens({
+      model: 'test-model',
+      contents: 'hello',
+    });
+
+    expect(openaiMockState.createCount).toBe(2);
+  });
+
+  it('does not discard a generator that has already been used', async () => {
+    const mockConfig = {
+      getUsageStatisticsEnabled: () => false,
+      getContentGeneratorConfig: () => ({}),
+      getCliVersion: () => '1.0.0',
+      getTelemetryEnabled: () => false,
+      getSessionId: () => 'test-session',
+    } as unknown as Config;
+    const generator = await createContentGenerator(
+      {
+        model: 'test-model',
+        apiKey: 'test-key',
+        authType: AuthType.USE_OPENAI,
+      },
+      mockConfig,
+    );
+
+    await preloadContentGenerator(generator);
+    await generator.countTokens({
+      model: 'test-model',
+      contents: 'first',
+    });
+    resetPreloadedContentGenerator(generator);
+    await generator.countTokens({
+      model: 'test-model',
+      contents: 'second',
+    });
+
+    expect(openaiMockState.createCount).toBe(1);
+  });
+
+  it('does not discard an in-flight preload after real use begins', async () => {
+    let releaseConstruction: () => void = () => undefined;
+    openaiMockState.constructionGates = [
+      new Promise<void>((resolve) => {
+        releaseConstruction = resolve;
+      }),
+    ];
+    const mockConfig = {
+      getUsageStatisticsEnabled: () => false,
+      getContentGeneratorConfig: () => ({}),
+      getCliVersion: () => '1.0.0',
+      getTelemetryEnabled: () => false,
+      getSessionId: () => 'test-session',
+    } as unknown as Config;
+    const generator = await createContentGenerator(
+      {
+        model: 'test-model',
+        apiKey: 'test-key',
+        authType: AuthType.USE_OPENAI,
+      },
+      mockConfig,
+    );
+
+    const preload = preloadContentGenerator(generator);
+    await vi.waitFor(() => expect(openaiMockState.createCount).toBe(1));
+    const firstUse = generator.countTokens({
+      model: 'test-model',
+      contents: 'hello',
+    });
+    resetPreloadedContentGenerator(generator);
+    releaseConstruction();
+
+    await expect(preload).resolves.toBeUndefined();
+    await expect(firstUse).resolves.toEqual({ totalTokens: 1 });
+    expect(openaiMockState.createCount).toBe(1);
+  });
+
+  it('isolates a reset in-flight preload from the replacement first use', async () => {
+    let releasePreload: () => void = () => undefined;
+    let releaseFirstUse: () => void = () => undefined;
+    const preloadError = new Error('discarded preload failed');
+    openaiMockState.constructionGates = [
+      new Promise<void>((resolve) => {
+        releasePreload = resolve;
+      }),
+      new Promise<void>((resolve) => {
+        releaseFirstUse = resolve;
+      }),
+    ];
+    openaiMockState.deferredErrors = [preloadError];
+    const mockConfig = {
+      getUsageStatisticsEnabled: () => false,
+      getContentGeneratorConfig: () => ({}),
+      getCliVersion: () => '1.0.0',
+      getTelemetryEnabled: () => false,
+      getSessionId: () => 'test-session',
+    } as unknown as Config;
+    const generator = await createContentGenerator(
+      {
+        model: 'test-model',
+        apiKey: 'test-key',
+        authType: AuthType.USE_OPENAI,
+      },
+      mockConfig,
+    );
+
+    const discardedPreload = preloadContentGenerator(generator).catch(
+      (error: unknown) => error,
+    );
+    await vi.waitFor(() => expect(openaiMockState.createCount).toBe(1));
+    resetPreloadedContentGenerator(generator);
+    const firstUse = generator.countTokens({
+      model: 'test-model',
+      contents: 'hello',
+    });
+    await vi.waitFor(() => expect(openaiMockState.createCount).toBe(2));
+
+    releaseFirstUse();
+    await expect(firstUse).resolves.toEqual({ totalTokens: 1 });
+    releasePreload();
+    await expect(discardedPreload).resolves.toBe(preloadError);
+    await expect(
+      generator.countTokens({
+        model: 'test-model',
+        contents: 'still uses the replacement',
+      }),
+    ).resolves.toEqual({ totalTokens: 1 });
+    expect(openaiMockState.createCount).toBe(2);
+  });
+
+  it('rebuilds a preloaded Qwen generator from a hot-switched config', async () => {
+    const generatorConfig: ContentGeneratorConfig = {
+      model: 'qwen3-coder-flash',
+      authType: AuthType.QWEN_OAUTH,
+    };
+    const mockConfig = {
+      getUsageStatisticsEnabled: () => false,
+      getContentGeneratorConfig: () => generatorConfig,
+      getCliVersion: () => '1.0.0',
+      getTelemetryEnabled: () => false,
+      getSessionId: () => 'test-session',
+    } as unknown as Config;
+    const generator = await createContentGenerator(generatorConfig, mockConfig);
+
+    await preloadContentGenerator(generator);
+    generatorConfig.model = 'coder-model';
+    resetPreloadedContentGenerator(generator);
+    await generator.countTokens({
+      model: 'coder-model',
+      contents: 'hello',
+    });
+
+    expect(qwenMockState.constructorModels).toEqual([
+      'qwen3-coder-flash',
+      'coder-model',
+    ]);
+  });
+
+  it('rebuilds OpenAI logging with the relocated working directory', async () => {
+    let workingDir = '/workspace/before';
+    const mockConfig = {
+      getUsageStatisticsEnabled: () => false,
+      getContentGeneratorConfig: () => ({}),
+      getCliVersion: () => '1.0.0',
+      getTelemetryEnabled: () => false,
+      getSessionId: () => 'test-session',
+      getWorkingDir: () => workingDir,
+    } as unknown as Config;
+    const generator = await createContentGenerator(
+      {
+        model: 'test-model',
+        apiKey: 'test-key',
+        authType: AuthType.USE_OPENAI,
+        enableOpenAILogging: true,
+        openAILoggingDir: 'logs',
+      },
+      mockConfig,
+    );
+
+    await preloadContentGenerator(generator);
+    workingDir = '/workspace/after';
+    resetPreloadedContentGenerator(generator);
+    await generator.countTokens({
+      model: 'test-model',
+      contents: 'hello',
+    });
+
+    expect(openaiLoggerMockState.constructorCalls).toEqual([
+      { customLogDir: 'logs', cwd: '/workspace/before' },
+      { customLogDir: 'logs', cwd: '/workspace/after' },
+    ]);
+  });
+
+  it('memoizes preload rejection for the first use', async () => {
+    const mockConfig = {
+      getUsageStatisticsEnabled: () => false,
+      getContentGeneratorConfig: () => ({}),
+      getCliVersion: () => '1.0.0',
+      getTelemetryEnabled: () => false,
+      getSessionId: () => 'test-session',
+    } as unknown as Config;
+    const moduleError = new Error(
+      "Cannot find module './openaiContentGenerator-STALE.js'",
+    );
+    (moduleError as NodeJS.ErrnoException).code = 'ERR_MODULE_NOT_FOUND';
+    openaiMockState.generatorError = moduleError;
+    const generator = await createContentGenerator(
+      {
+        model: 'test-model',
+        apiKey: 'test-key',
+        authType: AuthType.USE_OPENAI,
+      },
+      mockConfig,
+    );
+
+    const preloadError = await preloadContentGenerator(generator).catch(
+      (error: unknown) => error,
+    );
+    const firstUseError = await generator
+      .countTokens({ model: 'test-model', contents: 'hello' })
+      .catch((error: unknown) => error);
+
+    expect(preloadError).toBeInstanceOf(Error);
+    expect(firstUseError).toBe(preloadError);
+    expect((preloadError as Error).cause).toBe(moduleError);
+  });
+
   it('checks Qwen credentials before deferring provider creation', async () => {
     const mockConfig = {
       getUsageStatisticsEnabled: () => false,
@@ -289,9 +616,13 @@ describe('createContentGenerator - ERR_MODULE_NOT_FOUND handling', () => {
   beforeEach(() => {
     openaiMockState.generatorError = null;
     openaiMockState.createCount = 0;
+    openaiMockState.constructionGates = [];
+    openaiMockState.deferredErrors = [];
     qwenMockState.oauthError = null;
     qwenMockState.oauthCount = 0;
     qwenMockState.constructorCount = 0;
+    qwenMockState.constructorModels = [];
+    openaiLoggerMockState.constructorCalls = [];
     vi.resetModules();
   });
 

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -370,6 +370,7 @@ function wrapProviderLoadError(error: unknown, authType: AuthType): unknown {
 
 class LazyContentGenerator implements ContentGenerator {
   private generatorPromise?: Promise<ContentGenerator>;
+  private preloadedOnly = false;
 
   constructor(
     private readonly loader: () => Promise<ContentGenerator>,
@@ -381,18 +382,39 @@ class LazyContentGenerator implements ContentGenerator {
     return this.generatorPromise;
   }
 
+  private getGeneratorForUse(): Promise<ContentGenerator> {
+    this.preloadedOnly = false;
+    return this.getGenerator();
+  }
+
+  preload(): Promise<ContentGenerator> {
+    if (!this.generatorPromise) {
+      this.preloadedOnly = true;
+    }
+    return this.getGenerator();
+  }
+
+  resetPreload(): void {
+    if (!this.preloadedOnly) return;
+    this.preloadedOnly = false;
+    this.generatorPromise = undefined;
+  }
+
   async generateContent(
     request: GenerateContentParameters,
     userPromptId: string,
   ): Promise<GenerateContentResponse> {
-    return (await this.getGenerator()).generateContent(request, userPromptId);
+    return (await this.getGeneratorForUse()).generateContent(
+      request,
+      userPromptId,
+    );
   }
 
   async generateContentStream(
     request: GenerateContentParameters,
     userPromptId: string,
   ): Promise<AsyncGenerator<GenerateContentResponse>> {
-    return (await this.getGenerator()).generateContentStream(
+    return (await this.getGeneratorForUse()).generateContentStream(
       request,
       userPromptId,
     );
@@ -401,17 +423,35 @@ class LazyContentGenerator implements ContentGenerator {
   async countTokens(
     request: CountTokensParameters,
   ): Promise<CountTokensResponse> {
-    return (await this.getGenerator()).countTokens(request);
+    return (await this.getGeneratorForUse()).countTokens(request);
   }
 
   async embedContent(
     request: EmbedContentParameters,
   ): Promise<EmbedContentResponse> {
-    return (await this.getGenerator()).embedContent(request);
+    return (await this.getGeneratorForUse()).embedContent(request);
   }
 
   useSummarizedThinking(): boolean {
     return this.summarizedThinking;
+  }
+}
+
+/** @internal */
+export async function preloadContentGenerator(
+  generator: ContentGenerator,
+): Promise<void> {
+  if (generator instanceof LazyContentGenerator) {
+    await generator.preload();
+  }
+}
+
+/** @internal */
+export function resetPreloadedContentGenerator(
+  generator: ContentGenerator | undefined,
+): void {
+  if (generator instanceof LazyContentGenerator) {
+    generator.resetPreload();
   }
 }
 


### PR DESCRIPTION
## What this PR does

This PR starts best-effort preparation of an internal lazy Provider after a successful ACP `session/new` response has been written to the child transport. The first prompt reuses the same in-flight or completed promise, so preparation and an immediate prompt still construct the Provider only once. Non-lazy generators remain a no-op, background failures are caught while the rejected promise remains memoized for the first real call, and the public content-generator interface, ACP response shape, configuration surface, wire protocol, production telemetry, and existing `ttft_ms` meaning are unchanged.

The scheduled callback re-finds the live session and its current generator instead of retaining a stale wrapper. An unused preload is invalidated when a Qwen OAuth hot model switch changes the generator configuration or an ACP worktree relocation changes the working directory; a generator that has already served a real call is never discarded.

## Why it's needed

The measurement work in #7761 found a 56.36 ms P50 cold-versus-warm gap before the first Provider request on the 2-vCPU Linux reference host, exceeding the data gate for a preload prototype. In the publication comparison, the candidate improved fake-Provider process-to-first-model-output by a paired median of 49.38 ms at 100 ms dwell (95% CI: 40.61–61.31 ms faster, 30/30 candidate wins) while the 0 ms immediate-prompt gate remained non-inferior. This moves local Provider import and construction into otherwise idle post-session time instead of changing model, network, or rendering behavior.

## Reviewer Test Plan

### How to verify

Create a daemon or direct ACP session and confirm that the successful `session/new` response has the same shape as before and that no model request is sent while the session is only being prepared. Prompt immediately and after a short dwell; both paths should complete normally, and concurrent preparation plus prompt admission should construct the lazy Provider only once.

Exercise a failed Provider load and confirm that the background task does not produce an unhandled rejection, while the first real prompt receives the same memoized wrapped error without an automatic retry. Close a session before the scheduled callback, switch Provider/model quickly, and relocate an ACP worktree before first use; closed sessions should be ignored, the current wrapper/configuration should win, and an already-used generator should not be rebuilt.

Automated verification passed 21 content-generator tests, 437 configuration tests, and 322 ACP agent tests, plus Core/CLI typecheck, targeted lint and formatting, full build, bundle, daemon/direct-ACP integration smokes, 60/60 decision-bearing fake-Provider pairs, 10/10 resource pairs, 30/30 real-Provider 100 ms pairs, and 10/10 real-Provider immediate-prompt pairs.

### Evidence (Before & After)

| Scenario and metric | Control | Candidate | Paired result |
| --- | ---: | ---: | --- |
| Fake Provider, 100 ms dwell, process to first model output P50 | 2102.65 ms | 2053.28 ms | -49.38 ms median, 95% CI [-61.31, -40.61], 30/30 wins |
| Fake Provider, 100 ms dwell, prompt to first model output P50 | 192.17 ms | 148.40 ms | -46.07 ms median, 95% CI [-48.76, -41.99] |
| Fake Provider, 0 ms dwell, process to session ready | — | — | +1.79 ms median, 95% CI [-0.40, +8.02] |
| Fake Provider, 0 ms dwell, prompt to first model output | — | — | -5.22 ms median, 95% CI [-7.95, -3.16] |

The 500 ms fake-Provider diagnostic showed a 38.73 ms paired-median process-to-first-output improvement but is not used as an independent merge reason. The real Provider completed every functional sample with matching output and clean teardown; its 100 ms performance result was inconclusive because network/model variance produced a wide CI and opposing AB/BA medians, and the 10-pair immediate-prompt run is reported only as a functional smoke. The authoritative local-performance conclusion therefore remains the deterministic fake-Provider comparison.

Idle-resource measurements passed: the single-session RSS P50 candidate-control increase was 4.29 MiB (limit 10 MiB), and the additional candidate-control growth from 1 to 16 sessions was -0.049 MiB per session (limit 0.5 MiB). No fake Provider request occurred during the preload-only window, and no benchmark left a residual daemon or ACP process.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Local correctness verification used macOS 26.4.1 arm64 with Node.js 22.22.3. Formal performance and resource gates used Linux x64 with Node.js 22.23.1, exactly two available CPUs via `taskset -c 0,1`, sandbox disabled, isolated homes/workspaces/ports, and fixed warmed per-variant compile caches. Fake-Provider runs used deterministic 0/100/500 ms dwell; real-Provider credentials and response text are intentionally omitted from artifacts.

## Risk & Scope

- Main risk or tradeoff: Provider import and local construction begin earlier and may consume resources for a session that is never prompted; measured single-session RSS increased by 4.29 MiB P50, and a rapid configuration change can waste at most one discarded preload. A preload performs no model request, credential refresh, or billable operation.
- Not validated / out of scope: Windows runtime verification, `session/load`, resume, model-switch prefetch, prompt-admission overlap, daemon outer-HTTP completion signaling, TUI/Web Shell paint, prompt cache/compression, network preconnection, and production telemetry changes. Real-Provider latency was functionally valid but statistically inconclusive because of external variance.
- Breaking changes / migration notes: None. There is no public API, configuration, ACP protocol, response-shape, or telemetry-schema change.

## Linked Issues

Relates to #7757.

Relates to #7264.

Depends on #7761.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 在成功的 ACP `session/new` 响应写入 child transport 后，以 best-effort 方式开始准备内部懒加载 Provider。首个 prompt 会复用同一个进行中或已完成的 promise，因此即使准备与立即 prompt 并发，也只会构造一次 Provider。非懒加载 generator 保持 no-op；后台失败会被显式捕获，同时 rejected promise 会保留并由第一次真实调用继续观察；公共 content-generator 接口、ACP 响应形状、配置面、wire protocol、生产 telemetry 以及现有 `ttft_ms` 的含义都不改变。

调度回调会重新查找仍然存活的 session 及其当前 generator，而不是持有可能过期的 wrapper。当 Qwen OAuth 热切模型改变 generator 配置，或 ACP worktree relocation 改变工作目录时，尚未被真实调用使用的 preload 会失效；已经服务过真实调用的 generator 永远不会被丢弃。

## 为什么需要

#7761 的测量工作在 2-vCPU Linux 参考机上发现，首个 Provider 请求之前的冷/热 P50 差距为 56.36 ms，超过了制作 preload 原型的数据门槛。在发布对比中，100 ms dwell 下 candidate 将 fake Provider 的进程到首个模型输出改善了 49.38 ms 配对中位数（95% CI：快 40.61–61.31 ms，candidate 30/30 全胜），同时 0 ms 立即 prompt 门禁保持非劣。该改动把本地 Provider import 与构造移动到 session 后原本空闲的时间，而不改变模型、网络或渲染行为。

## Reviewer 测试计划

### 如何验证

创建 daemon 或 direct ACP session，确认成功的 `session/new` 响应形状与之前一致，并且 session 仅处于准备状态时不会发送模型请求。分别立即 prompt 和短暂 dwell 后 prompt；两条路径都应正常完成，且并发的准备与 prompt admission 只构造一次懒加载 Provider。

构造一次 Provider 加载失败，确认后台任务不会产生 unhandled rejection，而第一次真实 prompt 会收到同一个已记忆的包装错误，且不会自动重试。在调度回调执行前关闭 session、快速切换 Provider/模型，以及在第一次使用前 relocation ACP worktree；已关闭 session 应被忽略，当前 wrapper/配置应胜出，而已经使用过的 generator 不应重建。

自动验证已通过 21 个 content-generator 测试、437 个配置测试和 322 个 ACP agent 测试，以及 Core/CLI typecheck、目标 lint 与格式检查、全量 build、bundle、daemon/direct-ACP integration smoke、60/60 个决定性 fake-Provider 配对、10/10 个资源配对、30/30 个真实 Provider 100 ms 配对和 10/10 个真实 Provider 立即 prompt 配对。

### 证据（Before & After）

| 场景与指标 | Control | Candidate | 配对结果 |
| --- | ---: | ---: | --- |
| Fake Provider，100 ms dwell，进程到首个模型输出 P50 | 2102.65 ms | 2053.28 ms | 中位数 -49.38 ms，95% CI [-61.31, -40.61]，30/30 全胜 |
| Fake Provider，100 ms dwell，prompt 到首个模型输出 P50 | 192.17 ms | 148.40 ms | 中位数 -46.07 ms，95% CI [-48.76, -41.99] |
| Fake Provider，0 ms dwell，进程到 session ready | — | — | 中位数 +1.79 ms，95% CI [-0.40, +8.02] |
| Fake Provider，0 ms dwell，prompt 到首个模型输出 | — | — | 中位数 -5.22 ms，95% CI [-7.95, -3.16] |

500 ms fake-Provider 诊断显示，进程到首输出的配对中位数改善为 38.73 ms，但它不作为独立的合入理由。真实 Provider 的每个功能样本都获得了匹配输出并完成了干净清理；其 100 ms 性能结果因为网络/模型方差造成宽 CI 和相反方向的 AB/BA 中位数而无法下结论，10 对立即 prompt 仅作为功能 smoke 报告。因此，权威的本地性能结论仍来自确定性的 fake-Provider 对比。

空闲资源测量通过：单 session RSS P50 的 candidate-control 增量为 4.29 MiB（上限 10 MiB），从 1 到 16 个 session 的额外 candidate-control 增长为每 session -0.049 MiB（上限 0.5 MiB）。preload-only 窗口没有发生 fake Provider 请求，所有 benchmark 都没有残留 daemon 或 ACP 进程。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  |  ✅  |

### 环境（可选）

本地正确性验证使用 macOS 26.4.1 arm64 与 Node.js 22.22.3。正式性能和资源门禁使用 Linux x64、Node.js 22.23.1，通过 `taskset -c 0,1` 限定为恰好两个可用 CPU，关闭 sandbox，并使用隔离的 home/workspace/端口和每个 variant 固定且预热的 compile cache。Fake-Provider 运行采用确定性的 0/100/500 ms dwell；真实 Provider 凭证和响应文本被有意排除在 artifact 之外。

## 风险与范围

- 主要风险或取舍：Provider import 和本地构造更早开始，可能为永远不会被 prompt 的 session 消耗资源；实测单 session RSS P50 增加 4.29 MiB，快速配置变化最多会浪费一次被丢弃的 preload。preload 不执行模型请求、凭证刷新或计费操作。
- 未验证 / 范围外：Windows 运行时验证、`session/load`、resume、model-switch prefetch、prompt-admission overlap、daemon 外层 HTTP 完成信号、TUI/Web Shell paint、prompt cache/compression、网络预连接和生产 telemetry 变更。真实 Provider 延迟的功能验证通过，但因为外部方差，统计结果无法下结论。
- Breaking change / 迁移说明：无。公共 API、配置、ACP 协议、响应形状和 telemetry schema 均不改变。

## 关联 Issue

Relates to #7757.

Relates to #7264.

Depends on #7761.

</details>
