### PR TITLE
fix(core): read the stash reflog from the common git dir

### DIFF
--- a/packages/core/src/utils/gitDiff.test.ts
+++ b/packages/core/src/utils/gitDiff.test.ts
@@ -1004,6 +1004,57 @@ describe('resolveGitDir', () => {
   });
 });
 
+describe('getGitWorkingTreeStatus stash count in a linked worktree', () => {
+  let main: string;
+
+  beforeEach(async () => {
+    main = await makeRepo();
+    await fs.writeFile(path.join(main, 'a.txt'), 'hi\n');
+    await git(main, 'add', '.');
+    await git(main, 'commit', '-q', '-m', 'init');
+    // Two entries so the assertion cannot pass on an off-by-one.
+    await fs.writeFile(path.join(main, 'a.txt'), 'one\n');
+    await git(main, 'stash', '-q');
+    await fs.writeFile(path.join(main, 'a.txt'), 'two\n');
+    await git(main, 'stash', '-q');
+  });
+
+  afterEach(async () => {
+    await fs.rm(main, { recursive: true, force: true });
+  });
+
+  it('counts the shared stash from inside a linked worktree', async () => {
+    const wtPath = path.join(main, 'wt');
+    await git(main, 'worktree', 'add', '-q', wtPath, '-b', 'side');
+
+    // `git stash list` reports both entries from either working tree, because
+    // the stash is one ref for the whole repository. Reading the reflog from
+    // the per-worktree gitdir found nothing and reported 0.
+    expect((await getGitWorkingTreeStatus(wtPath))?.stashCount).toBe(2);
+    // Same number from the main worktree: the two must not diverge.
+    expect((await getGitWorkingTreeStatus(main))?.stashCount).toBe(2);
+  });
+
+  it('still reports the per-worktree operation, not the shared one', async () => {
+    // The guard against over-correcting. Only refs are shared; MERGE_HEAD and
+    // friends are per-worktree, so redirecting everything to the common dir
+    // would make a merge in one worktree appear in all of them.
+    const wtPath = path.join(main, 'wt');
+    await git(main, 'worktree', 'add', '-q', wtPath, '-b', 'side');
+    await fs.writeFile(
+      path.join(main, '.git', 'MERGE_HEAD'),
+      '0000000000000000000000000000000000000000\n',
+    );
+
+    expect((await getGitWorkingTreeStatus(main))?.operation).toBe('merge');
+    expect((await getGitWorkingTreeStatus(wtPath))?.operation).toBeUndefined();
+  });
+
+  it('still counts the stash in a plain repository', async () => {
+    expect((await getGitWorkingTreeStatus(main))?.stashCount).toBe(2);
+  });
+});
+
 describe('fetchGitDiff transient-state detection', () => {
   let repo: string;
   beforeEach(async () => {

--- a/packages/core/src/utils/gitDiff.ts
+++ b/packages/core/src/utils/gitDiff.ts
@@ -17,7 +17,7 @@ import { access, lstat, open, readFile, stat } from 'node:fs/promises';
 import * as path from 'node:path';
 import { promisify } from 'node:util';
 import type { Hunk } from 'diff';
-import { findGitRoot } from './gitUtils.js';
+import { findGitRoot, readFirstLineNoFollow } from './gitUtils.js';
 
 /** Re-export so consumers don't need to depend on `diff` directly. */
 export type GitDiffHunk = Hunk;
@@ -1381,13 +1381,17 @@ async function detectGitOperation(
  * which is the right answer for a main worktree (no `commondir` file).
  */
 async function resolveCommonGitDir(gitDir: string): Promise<string> {
-  try {
-    const raw = (await readFile(path.join(gitDir, 'commondir'), 'utf8')).trim();
-    if (!raw) return gitDir;
-    return path.isAbsolute(raw) ? raw : path.resolve(gitDir, raw);
-  } catch {
-    return gitDir;
-  }
+  // Read it the way gitDirect.ts already reads this same file: O_NOFOLLOW
+  // refuses a symlink and O_NONBLOCK never blocks on a FIFO. A plain readFile
+  // on a crafted `commondir` named pipe would hang forever and pin a libuv
+  // thread-pool slot, and `getGitWorkingTreeStatus` polls unattended, so it has
+  // to survive a hostile repository -- the same hazard countStashEntries below
+  // guards against for the reflog it reads.
+  const raw = (
+    await readFirstLineNoFollow(path.join(gitDir, 'commondir'))
+  )?.trim();
+  if (!raw) return gitDir;
+  return path.isAbsolute(raw) ? raw : path.resolve(gitDir, raw);
 }
 
 /** Stash count = lines in `<commonDir>/logs/refs/stash` (0 when absent). */

--- a/packages/core/src/utils/gitDiff.ts
+++ b/packages/core/src/utils/gitDiff.ts
@@ -1369,11 +1369,36 @@ async function detectGitOperation(
   return undefined;
 }
 
-/** Stash count = lines in `<gitDir>/logs/refs/stash` (0 when absent). */
+/**
+ * Resolve the git dir shared by every worktree of a repository.
+ *
+ * For a linked worktree (`git worktree add`) `resolveGitDirFromRoot` returns
+ * the per-worktree dir `.git/worktrees/<name>`, which is correct for the
+ * per-worktree state the callers above probe — HEAD, the index, and the
+ * MERGE_HEAD / rebase-* / BISECT_LOG markers all live there. Refs and their
+ * reflogs do not: they live in the common dir, which git records in a
+ * `commondir` file next to those markers. Falls back to `gitDir` itself,
+ * which is the right answer for a main worktree (no `commondir` file).
+ */
+async function resolveCommonGitDir(gitDir: string): Promise<string> {
+  try {
+    const raw = (await readFile(path.join(gitDir, 'commondir'), 'utf8')).trim();
+    if (!raw) return gitDir;
+    return path.isAbsolute(raw) ? raw : path.resolve(gitDir, raw);
+  } catch {
+    return gitDir;
+  }
+}
+
+/** Stash count = lines in `<commonDir>/logs/refs/stash` (0 when absent). */
 async function countStashEntries(gitRoot: string): Promise<number> {
   const gitDir = await resolveGitDirFromRoot(gitRoot);
   if (!gitDir) return 0;
-  const stashLog = path.join(gitDir, 'logs', 'refs', 'stash');
+  // The stash is a single ref shared by the whole repository, so it must be
+  // read from the common dir. Reading it from the per-worktree dir reported 0
+  // stashes inside every linked worktree, whatever `git stash list` said.
+  const commonDir = await resolveCommonGitDir(gitDir);
+  const stashLog = path.join(commonDir, 'logs', 'refs', 'stash');
   // lstat before read: a symlink-to-FIFO would block readFile forever (the
   // same hazard the untracked-file readers guard against). Only count a
   // regular file.

--- a/packages/core/src/utils/gitDirect.ts
+++ b/packages/core/src/utils/gitDirect.ts
@@ -8,6 +8,7 @@ import * as fs from 'node:fs';
 import * as fsPromises from 'node:fs/promises';
 import * as path from 'node:path';
 import { resolveGitDir } from './gitDiff.js';
+import { readFirstLineNoFollow } from './gitUtils.js';
 import { createDebugLogger } from './debugLogger.js';
 
 /**
@@ -32,8 +33,6 @@ const SHORT_SHA_LENGTH = 7;
 // (watcher errors) emit a debug line, consistent with the other utils here.
 const debug = createDebugLogger('gitDirect');
 
-// Bound the HEAD read: it is one short line, never megabytes.
-const MAX_HEAD_BYTES = 4096;
 // git's per-component length cap (a filesystem limit). Applied per
 // slash-separated component, NOT to the whole ref — a valid ref can be longer
 // than one component's limit.
@@ -118,39 +117,6 @@ async function hasGitStore(dir: string): Promise<boolean> {
     isDir(path.join(dir, 'refs')),
   ]);
   return objects && refs;
-}
-
-/**
- * Read the first line of a file with O_NOFOLLOW (refuse symlinks atomically) and
- * a bounded prefix (never load a pathologically large file). Returns null on any
- * failure. Shared by the HEAD and commondir reads.
- */
-async function readFirstLineNoFollow(filePath: string): Promise<string | null> {
-  let fh: fsPromises.FileHandle;
-  try {
-    // O_NOFOLLOW refuses a symlink (ELOOP). O_NONBLOCK never blocks on a FIFO —
-    // a crafted `.git/HEAD` or commondir named pipe would otherwise hang here
-    // and pin a libuv thread-pool slot. Both are no-ops on a regular file.
-    fh = await fsPromises.open(
-      filePath,
-      (fs.constants?.O_RDONLY ?? 0) |
-        (fs.constants?.O_NOFOLLOW ?? 0) |
-        (fs.constants?.O_NONBLOCK ?? 0),
-    );
-  } catch {
-    return null;
-  }
-  try {
-    const buf = Buffer.allocUnsafe(MAX_HEAD_BYTES);
-    const { bytesRead } = await fh.read(buf, 0, MAX_HEAD_BYTES, 0);
-    return buf.toString('utf-8', 0, bytesRead).split('\n', 1)[0] ?? '';
-  } catch {
-    return null;
-  } finally {
-    // Per the codebase convention a close error must not escape — the docstring
-    // promises null on any failure.
-    await fh.close().catch(() => {});
-  }
 }
 
 /**

--- a/packages/core/src/utils/gitUtils.ts
+++ b/packages/core/src/utils/gitUtils.ts
@@ -5,6 +5,7 @@
  */
 
 import * as fs from 'node:fs';
+import * as fsPromises from 'node:fs/promises';
 import * as path from 'node:path';
 import { execSync } from 'node:child_process';
 import { stripVTControlCharacters } from 'node:util';
@@ -13,6 +14,49 @@ import { createDebugLogger } from './debugLogger.js';
 const debugLogger = createDebugLogger('GIT');
 const GIT_STATUS_TIMEOUT_MS = 5000;
 const DETACHED_HEAD_LABEL = '(detached HEAD)';
+
+// Bound the read: these files are one short line, never megabytes.
+const MAX_GIT_METADATA_BYTES = 4096;
+
+/**
+ * Read the first line of a git metadata file with O_NOFOLLOW (refuse symlinks
+ * atomically) and a bounded prefix (never load a pathologically large file).
+ * Returns null on any failure.
+ *
+ * Lives here rather than beside either caller because both `gitDirect.ts` (HEAD,
+ * commondir) and `gitDiff.ts` (commondir) need it, and `gitDirect.ts` already
+ * imports `gitDiff.ts` — exporting it from there would close an import cycle.
+ * This module imports nothing but node builtins, so it can be shared freely.
+ */
+export async function readFirstLineNoFollow(
+  filePath: string,
+): Promise<string | null> {
+  let fh: fsPromises.FileHandle;
+  try {
+    // O_NOFOLLOW refuses a symlink (ELOOP). O_NONBLOCK never blocks on a FIFO —
+    // a crafted `.git/HEAD` or commondir named pipe would otherwise hang here
+    // and pin a libuv thread-pool slot. Both are no-ops on a regular file.
+    fh = await fsPromises.open(
+      filePath,
+      (fs.constants?.O_RDONLY ?? 0) |
+        (fs.constants?.O_NOFOLLOW ?? 0) |
+        (fs.constants?.O_NONBLOCK ?? 0),
+    );
+  } catch {
+    return null;
+  }
+  try {
+    const buf = Buffer.allocUnsafe(MAX_GIT_METADATA_BYTES);
+    const { bytesRead } = await fh.read(buf, 0, MAX_GIT_METADATA_BYTES, 0);
+    return buf.toString('utf-8', 0, bytesRead).split('\n', 1)[0] ?? '';
+  } catch {
+    return null;
+  } finally {
+    // Per the codebase convention a close error must not escape — the docstring
+    // promises null on any failure.
+    await fh.close().catch(() => {});
+  }
+}
 
 /**
  * Checks if a directory is within a git repository


### PR DESCRIPTION
## What this PR does

`countStashEntries` reads the stash reflog from the directory `resolveGitDirFromRoot` returns. Inside a linked worktree (`git worktree add`) that is the **per-worktree** git dir, `.git/worktrees/<name>` — and the stash reflog is not there. It is a single ref belonging to the whole repository, so it lives in the common dir. The read fails, the `catch` returns 0, and the status is silently wrong:

```
main     git stash list = 2  |  qwen stashCount = 2
linked   git stash list = 2  |  qwen stashCount = 0     <- linked worktree
```

The fix resolves the common dir before reading, by following the `commondir` file git writes next to the per-worktree markers. A main worktree has no `commondir`, so the fallback returns the git dir unchanged and its behaviour does not move.

## Why it's needed

Worktrees are a first-class feature of this product, not an edge case: there is a `--worktree` flag, `enter_worktree` / `exit_worktree` tools, and Web Shell worktree sessions. `getGitWorkingTreeStatus` feeds the status line and git chip, so the one workflow the feature exists to support is the one where the stash indicator is always wrong.

Zero is also the worst possible failure value here. A stash count is a reminder of work set aside; reporting "no stashes" to someone who has two is not a missing indicator, it is a wrong one.

## Reviewer Test Plan

### How to verify

```sh
mkdir /tmp/f1 && cd /tmp/f1 && git init -q main && cd main
git commit -q --allow-empty -m init
echo hi > f.txt && git add f.txt && git commit -q -m f
echo one >> f.txt && git stash -q
echo two >> f.txt && git stash -q
git worktree add -q ../lw -b lw
cd ../lw && git stash list      # two entries, from the linked worktree
```

Before this change `getGitWorkingTreeStatus('/tmp/f1/lw').stashCount` is `0`; after, it is `2`.

- `npx vitest run --root packages/core src/utils/gitDiff.test.ts` → **120/120**. (This file drives real `git` subprocesses and takes a couple of minutes.)
- Reverting **only** `gitDiff.ts` and keeping the new tests fails exactly one case: `npx vitest run --root packages/core src/utils/gitDiff.test.ts -t "stash count in a linked worktree"` → `1 failed | 2 passed | 117 skipped`.
- The other two new cases pass both before and after **on purpose**, and the first of them is the one that constrains the fix:
  - `still reports the per-worktree operation, not the shared one` — only *refs* are shared. `MERGE_HEAD`, `rebase-merge`, `rebase-apply` and `BISECT_LOG` are per-worktree state, and `detectGitOperation` / `isInTransientGitState` are already right to read them from the per-worktree dir. Redirecting the whole file to the common dir would make a merge in one worktree appear in every worktree. The test starts a merge in the main tree and asserts the linked worktree still reports no operation.
  - `still counts the stash in a plain repository` — the `commondir` fallback path.
- Two stash entries rather than one, so the assertion cannot be satisfied by an off-by-one, and both worktrees are asserted to agree.

### Evidence (Before & After)

N/A as a screenshot — the visible surface is the status line's stash indicator, and the shell transcript above is the reproduction. Covered by the tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

git 2.50.1. `commondir` is written by git itself and its contents are a path git resolves relative to the per-worktree dir, which is what `path.resolve` does here; the existing linked-worktree test in this file already documents that git writes these pointers with forward slashes on Windows too. CI covers Windows and Linux.

## Risk & Scope

- Main risk or tradeoff: one extra `readFile` per `getGitWorkingTreeStatus` call. It is on the same path that already stats and reads the stash reflog, and it fails fast with ENOENT in a plain repository.
- Not validated / out of scope: submodules also use the `.git`-file indirection, and their `commondir` handling is not exercised by these tests. The change is a no-op for them unless a `commondir` file is present, in which case following it is the correct behaviour for a ref anyway.
- Breaking changes / migration notes: none. A main worktree resolves to exactly the same directory as before.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

`countStashEntries` 从 `resolveGitDirFromRoot` 返回的目录读取 stash reflog。而在链接工作树（`git worktree add`）中，该函数返回的是**每工作树**的 git 目录 `.git/worktrees/<name>`——stash reflog 并不在那里。stash 是属于整个仓库的单一 ref，因此位于 common dir。读取失败后 `catch` 返回 0，状态便悄然出错：

```
main     git stash list = 2  |  qwen stashCount = 2
linked   git stash list = 2  |  qwen stashCount = 0     <- 链接工作树
```

修复方式是在读取前先解析 common dir：跟随 git 写在每工作树标记文件旁的 `commondir` 文件。主工作树没有 `commondir`，因此回退分支原样返回该 git 目录，其行为不变。

## 为什么需要

工作树是本产品的一等特性而非边缘场景：有 `--worktree` 标志、`enter_worktree` / `exit_worktree` 工具，以及 Web Shell 的工作树会话。`getGitWorkingTreeStatus` 供给状态行与 git 标签，因此这一特性所服务的核心工作流，恰恰就是 stash 指示器永远出错的那一个。

而 0 在此处是最糟糕的失败取值。stash 计数是对「被搁置的工作」的提醒；对一个手里有两条 stash 的人报告「没有 stash」，这不是指示缺失，而是指示错误。

## 复核测试计划

### 如何验证

```sh
mkdir /tmp/f1 && cd /tmp/f1 && git init -q main && cd main
git commit -q --allow-empty -m init
echo hi > f.txt && git add f.txt && git commit -q -m f
echo one >> f.txt && git stash -q
echo two >> f.txt && git stash -q
git worktree add -q ../lw -b lw
cd ../lw && git stash list      # 在链接工作树中可见两条
```

本改动前 `getGitWorkingTreeStatus('/tmp/f1/lw').stashCount` 为 `0`；改动后为 `2`。

- `npx vitest run --root packages/core src/utils/gitDiff.test.ts` → **120/120 通过**。（该文件会拉起真实 `git` 子进程，耗时约两分钟。）
- **仅**还原 `gitDiff.ts`、保留新增测试时，恰好一项失败：`npx vitest run --root packages/core src/utils/gitDiff.test.ts -t "stash count in a linked worktree"` → `1 failed | 2 passed | 117 skipped`。
- 另外两项新增用例在修复前后**都通过，这是刻意为之**，其中第一项正是约束本次修复的那一项：
  - `still reports the per-worktree operation, not the shared one` —— 只有 *ref* 是共享的。`MERGE_HEAD`、`rebase-merge`、`rebase-apply` 与 `BISECT_LOG` 属于每工作树状态，而 `detectGitOperation` / `isInTransientGitState` 从每工作树目录读取它们本就是正确的。若把整个文件都改指向 common dir，一个工作树中的合并就会出现在所有工作树中。该测试在主工作树发起合并，并断言链接工作树仍报告无进行中操作。
  - `still counts the stash in a plain repository` —— 覆盖 `commondir` 回退路径。
- 使用两条 stash 而非一条，使断言无法被差一错误蒙混通过，并断言两个工作树的结果一致。

### 证据（修复前后对比）

无法以截图呈现 —— 可见面是状态行的 stash 指示器，上面的 shell 记录即为复现步骤。已由测试覆盖。

### 测试环境

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

git 2.50.1。`commondir` 由 git 自行写入，其内容是 git 相对每工作树目录解析的路径，这正是此处 `path.resolve` 的行为；本文件中既有的链接工作树测试已经写明，即便在 Windows 上 git 也以正斜杠书写这些指针。Windows 与 Linux 由 CI 覆盖。

## 风险与范围

- 主要风险或权衡：每次 `getGitWorkingTreeStatus` 调用多一次 `readFile`。它与既有的 stat + 读取 stash reflog 处于同一路径，且在普通仓库中会以 ENOENT 快速失败。
- 未验证 / 不在范围内：子模块同样使用 `.git` 文件间接寻址，本测试未覆盖其 `commondir` 处理。除非存在 `commondir` 文件，本改动对其为空操作；而若存在，对一个 ref 而言跟随它本就是正确行为。
- 破坏性变更 / 迁移说明：无。主工作树解析到的目录与此前完全一致。

## 关联 Issue

无。

</details>
