### PR TITLE
fix(core): decline sed patterns whose bracket expression starts with ]

### DIFF
--- a/packages/core/src/utils/sedEditParser.test.ts
+++ b/packages/core/src/utils/sedEditParser.test.ts
@@ -343,4 +343,41 @@ describe('sedEditParser', () => {
       }),
     ).toThrow(/sed pattern simulation failed/);
   });
+
+  // In POSIX BRE/ERE a `]` right after `[` or `[^` is a literal member of the
+  // bracket expression. JavaScript reads `[]` as an empty class and `[^]` as
+  // "any character", so simulating these rewrites the file differently from
+  // the command the user ran. Returning null hands the command back to the
+  // real sed. Behaviour of the real sed below was measured, not assumed.
+  it('declines a bracket expression whose first member is a literal ]', () => {
+    // On `a]b`, sed writes `XXb`; the simulation matched nothing at all.
+    expect(parseSedEditCommand("sed -i 's/[]a]/X/g' f.txt")).toBeNull();
+    // On `a]b`, sed writes `X]X`; the simulation wrote `Xb`, losing a byte,
+    // because JS reads `[^]` as "any character" and leaves `]` a literal.
+    expect(parseSedEditCommand("sed -i 's/[^]]/X/g' f.txt")).toBeNull();
+  });
+
+  it('declines the same bracket expressions under -E', () => {
+    // The -E path hands the pattern to RegExp untouched, so it diverges the
+    // same way and has to be declined separately.
+    expect(parseSedEditCommand("sed -E -i 's/[]a]/X/g' f.txt")).toBeNull();
+    expect(parseSedEditCommand("sed -E -i 's/[^]]/X/g' f.txt")).toBeNull();
+  });
+
+  it('still simulates ordinary bracket expressions', () => {
+    // The guard against over-correcting: declining every pattern would also
+    // satisfy the two tests above. A `]` that is not the first member, and an
+    // escaped `[`, both still translate exactly and must keep their fast path.
+    const plain = parseSedEditCommand("sed -i 's/[abc]/X/g' f.txt");
+    expect(plain).not.toBeNull();
+    expect(applySedSubstitution('a]b', plain!)).toBe('X]X');
+
+    const negated = parseSedEditCommand("sed -i 's/[^abc]/X/g' f.txt");
+    expect(negated).not.toBeNull();
+    expect(applySedSubstitution('a]b', negated!)).toBe('aXb');
+
+    const escaped = parseSedEditCommand("sed -i 's/a\\[b/X/g' f.txt");
+    expect(escaped).not.toBeNull();
+    expect(applySedSubstitution('a[b]c', escaped!)).toBe('X]c');
+  });
 });

--- a/packages/core/src/utils/sedEditParser.ts
+++ b/packages/core/src/utils/sedEditParser.ts
@@ -173,6 +173,7 @@ function canCompileSedPattern(sedInfo: SedEditInfo): boolean {
     const jsPattern = toJavascriptPattern(sedInfo);
     if (
       hasPosixBracketExpression(jsPattern) ||
+      hasLeadingBracketLiteral(jsPattern) ||
       hasSedJavascriptDivergentEscape(jsPattern)
     ) {
       return false;
@@ -194,6 +195,28 @@ function canCompileSedPattern(sedInfo: SedEditInfo): boolean {
 
 function hasPosixBracketExpression(pattern: string): boolean {
   return /\[\[:[A-Za-z]+:\]\]/u.test(pattern);
+}
+
+/**
+ * `]` immediately after `[` or `[^` is a literal member of a POSIX bracket
+ * expression, but means something else entirely in JavaScript: `[]` is an
+ * empty class that matches nothing, and `[^]` matches ANY character. So
+ * `s/[]a]/X/g` silently does nothing, and `s/[^]]/X/g` on `a]b` writes `Xb`
+ * where sed writes `X]X` -- a byte deleted from the user's file.
+ *
+ * Since these edits are simulated and written to disk rather than handed to
+ * sed, declining is the safe answer: the command then runs as the real sed
+ * and behaves exactly as asked. That is already what this parser does for
+ * the other constructs it cannot translate faithfully -- see
+ * `hasPosixBracketExpression` above.
+ *
+ * The test is deliberately blunt and matches the byte sequence anywhere, so
+ * a pattern such as `[a[]]` (a class containing `[`, which would in fact
+ * translate correctly) is declined too. Erring toward the real sed costs
+ * nothing but a fast path; erring the other way rewrites a file wrongly.
+ */
+function hasLeadingBracketLiteral(pattern: string): boolean {
+  return /\[\^?\]/u.test(pattern);
 }
 
 function hasSedJavascriptDivergentEscape(pattern: string): boolean {


### PR DESCRIPTION
## What this PR does

`ShellToolInvocation.getSedEditInfo()` intercepts `sed -i` commands, parses them, and **writes the simulated result to disk instead of running sed**. Any divergence from sed therefore does not produce a wrong preview — it produces a wrong file.

In POSIX BRE and ERE, a `]` immediately after `[` or `[^` is a **literal member** of the bracket expression. JavaScript reads those two spellings completely differently: `[]` is an empty class that matches nothing, and `[^]` matches *any* character. Neither `toJavascriptPattern` nor the `-E` path (which hands the pattern to `RegExp` untouched) accounts for that:

| command | input | real sed writes | this repo wrote |
|---|---|---|---|
| `sed -i 's/[]a]/X/g' f` | `a]b` | `XXb` | `a]b` (silent no-op) |
| `sed -i 's/[^]]/X/g' f` | `a]b` | `X]X` | **`Xb`** — a byte deleted |
| `sed -E -i 's/[]a]/X/g' f` | `a]b` | `XXb` | `a]b` (silent no-op) |
| `sed -E -i 's/[^]]/X/g' f` | `a]b` | `X]X` | **`Xb`** — a byte deleted |

The `[^]]` rows are the damaging ones. `[^]]` means "any character that is not `]`", a common idiom; JavaScript turns it into "any character" followed by a literal `]`, so the substitution consumes the `]` it was written to protect and the file loses content.

The fix declines these patterns. `parseSedEditCommand` returning `null` means the shell tool does not intercept, and the command runs as the real `sed` — which does exactly what the user asked. This is the mechanism the parser already uses for constructs it cannot translate faithfully; `hasPosixBracketExpression` declines `[[:alpha:]]` for the same reason, three lines up.

## Why it's needed

This is silent data loss on a write path. There is no error, no diff mismatch, and no signal to the user or the model that the file on disk is not what the command described — the tool reports success.

Declining rather than translating is a deliberate choice. A faithful translation is possible (`[]…]` → `[\]…]`, `[^]…]` → `[^\]…]`), but it requires the escaping scan to be exactly right on a path that overwrites the user's file, and it buys only a fast path. The cost of declining is that four spellings lose their in-process simulation and run as a subprocess instead.

## Reviewer Test Plan

### How to verify

```sh
mkdir /tmp/a1 && cd /tmp/a1 && printf 'a]b\n' > f.txt
sed -i '' 's/[^]]/X/g' f.txt && cat f.txt    # X]X  (BSD sed; GNU sed: sed -i '...')
```

Before this change the tool wrote `Xb` for that command. After, the command is not intercepted and the file matches sed.

- `npx vitest run --root packages/core src/utils/sedEditParser.test.ts` → 37/37.
- Reverting **only** `sedEditParser.ts` and keeping the new tests fails exactly two cases: `2 failed | 35 passed (37)`.
- The third new case, `still simulates ordinary bracket expressions`, passes both before and after **on purpose**. It is the guard that makes the other two non-trivial: declining *every* pattern would satisfy them, so this one pins that `[abc]`, `[^abc]` and an escaped `a\[b` keep their fast path and still produce the byte-exact output real sed produces.
- BRE and `-E` are asserted separately because they go through different code — the `-E` path returns the pattern untouched, so a fix applied only inside `toJavascriptPattern` would pass the first test and still corrupt files under `-E`.
- No regression in the caller: `npx vitest run --root packages/core src/utils/sedEditParser.test.ts src/tools/shell.test.ts` → **317 passed (2 files)**.

### Evidence (Before & After)

N/A as a screenshot. The observable artefact is the file on disk, and the shell transcript above reproduces it.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

The "real sed writes" column was measured against the system sed on macOS (BSD), not assumed. The behaviour at issue is specified by POSIX for both BRE and ERE rather than being a GNU extension, so GNU sed agrees; the originally reported figures were taken from GNU sed 4.9 and match. The change itself is a pure string test with no platform-dependent behaviour, and CI covers Windows and Linux.

## Risk & Scope

- Main risk or tradeoff: the test matches the byte sequence `[`, optional `^`, `]` anywhere in the pattern, so it also declines a pattern such as `[a[]]` — a class that happens to contain `[`, which would in fact have translated correctly. That is deliberate. A false decline costs a fast path; a false accept rewrites the user's file wrongly.
- Not validated / out of scope: this parser has other divergences from sed that this PR does not touch — `^` after `\(` is escaped into a literal caret, and GNU `\{,n\}` intervals silently no-op. Both need their own change and their own tests.
- Breaking changes / migration notes: none. Commands that were previously simulated correctly are still simulated; the four spellings above now run as a subprocess instead of in-process.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

`ShellToolInvocation.getSedEditInfo()` 会拦截 `sed -i` 命令，解析后**把模拟结果写入磁盘，而不是真正执行 sed**。因此任何与 sed 的偏差都不只是预览错误，而是文件被写错。

在 POSIX BRE 与 ERE 中，紧跟在 `[` 或 `[^` 之后的 `]` 是该括号表达式的**字面成员**。JavaScript 对这两种写法的解读完全不同：`[]` 是匹配不到任何东西的空字符类，而 `[^]` 匹配*任意*字符。`toJavascriptPattern` 与 `-E` 路径（把模式原样交给 `RegExp`）都没有处理这一点：

| 命令 | 输入 | 真实 sed 写出 | 本仓库写出 |
|---|---|---|---|
| `sed -i 's/[]a]/X/g' f` | `a]b` | `XXb` | `a]b`（静默空操作） |
| `sed -i 's/[^]]/X/g' f` | `a]b` | `X]X` | **`Xb`** —— 丢失一个字节 |
| `sed -E -i 's/[]a]/X/g' f` | `a]b` | `XXb` | `a]b`（静默空操作） |
| `sed -E -i 's/[^]]/X/g' f` | `a]b` | `X]X` | **`Xb`** —— 丢失一个字节 |

`[^]]` 两行危害最大。`[^]]` 意为「任意非 `]` 的字符」，是常见惯用写法；JavaScript 把它变成「任意字符」后跟一个字面 `]`，于是替换吞掉了它本应保护的那个 `]`，文件内容随之丢失。

修复方式是拒绝这些模式。`parseSedEditCommand` 返回 `null` 意味着 shell 工具不再拦截，命令按真实 `sed` 执行——其行为正是用户所要求的。这也是该解析器对无法忠实翻译的构造已经采用的机制；仅三行之上的 `hasPosixBracketExpression` 出于同样理由拒绝 `[[:alpha:]]`。

## 为什么需要

这是发生在写入路径上的静默数据丢失。没有报错，没有 diff 不一致，也没有任何信号提示用户或模型：磁盘上的文件与命令所描述的并不相同——工具报告的是成功。

选择拒绝而非翻译是刻意的。忠实翻译是可行的（`[]…]` → `[\]…]`，`[^]…]` → `[^\]…]`），但它要求转义扫描在一条会覆写用户文件的路径上做到分毫不差，而换来的仅仅是一条快速路径。拒绝的代价是四种写法失去进程内模拟，改以子进程执行。

## 复核测试计划

### 如何验证

```sh
mkdir /tmp/a1 && cd /tmp/a1 && printf 'a]b\n' > f.txt
sed -i '' 's/[^]]/X/g' f.txt && cat f.txt    # X]X（BSD sed；GNU sed 用 sed -i '...'）
```

本改动前该命令会写出 `Xb`。改动后命令不再被拦截，文件与 sed 一致。

- `npx vitest run --root packages/core src/utils/sedEditParser.test.ts` → 37/37 通过。
- **仅**还原 `sedEditParser.ts`、保留新增测试时，恰好两项失败：`2 failed | 35 passed (37)`。
- 第三项新增用例 `still simulates ordinary bracket expressions` 在修复前后**都通过，这是刻意为之**。它使前两项不再是空断言：拒绝**所有**模式同样能让前两项通过，因此本项锚定了 `[abc]`、`[^abc]` 与被转义的 `a\[b` 仍走快速路径，且输出与真实 sed 逐字节一致。
- BRE 与 `-E` 分开断言，因为二者走不同代码——`-E` 路径原样返回模式，因此只在 `toJavascriptPattern` 内部实施的修复会通过第一项测试，却仍在 `-E` 下损坏文件。
- 调用方无回归：`npx vitest run --root packages/core src/utils/sedEditParser.test.ts src/tools/shell.test.ts` → **317 通过（2 个文件）**。

### 证据（修复前后对比）

无法以截图呈现。可观测产物是磁盘上的文件，上面的 shell 记录即为复现步骤。

### 测试环境

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

「真实 sed 写出」一列是对 macOS 系统自带 sed（BSD）实测所得，而非假设。所涉行为由 POSIX 对 BRE 与 ERE 共同规定，并非 GNU 扩展，故 GNU sed 结果一致；最初报告中的数据取自 GNU sed 4.9，与此吻合。改动本身是纯字符串判断，无平台相关行为，Windows 与 Linux 由 CI 覆盖。

## 风险与范围

- 主要风险或权衡：该判断会匹配模式中任意位置上的字节序列 `[`、可选 `^`、`]`，因此也会拒绝形如 `[a[]]` 的模式——一个恰好包含 `[` 的字符类，它其实是可以正确翻译的。这是刻意的。误拒的代价只是失去快速路径；误收则会把用户的文件写错。
- 未验证 / 不在范围内：该解析器还有其他与 sed 的偏差，本 PR 不予触碰——`\(` 之后的 `^` 被转义成字面脱字符，以及 GNU 的 `\{,n\}` 区间静默空操作。二者各需独立的改动与测试。
- 破坏性变更 / 迁移说明：无。此前能被正确模拟的命令仍然被模拟；上述四种写法改为以子进程执行。

## 关联 Issue

无。

</details>
