### PR TITLE
fix(core): scope the timeout veto to the fragment it appears in

### DIFF
--- a/packages/core/src/utils/contextLengthError.test.ts
+++ b/packages/core/src/utils/contextLengthError.test.ts
@@ -157,4 +157,50 @@ describe('contextLengthError', () => {
     expect(info.isExceeded).toBe(true);
     expect(info.message).toContain('context_length_exceeded');
   });
+
+  // A timeout phrase vetoes the fragment it appears in, not the whole error.
+  // Provider SDKs routinely attach retry/attempt metadata to an error, so a
+  // sibling field mentioning an earlier timeout must not hide a real overflow.
+  describe('timeout veto scope', () => {
+    const OVERFLOW =
+      "This model's maximum context length is 128000 tokens, however you requested 200000 tokens";
+
+    it('still detects overflow when a sibling field mentions a timeout', () => {
+      const error = Object.assign(new Error(OVERFLOW), {
+        detail: 'previous attempt: request timed out after 60s',
+      });
+
+      const info = getContextLengthExceededInfo(error);
+
+      expect(info.isExceeded).toBe(true);
+      // The token counts must survive too: they are parsed only when the
+      // error is classified as an overflow, so a veto silently lost them.
+      expect(info.actualTokens).toBe(200000);
+      expect(info.limitTokens).toBe(128000);
+    });
+
+    it('still detects overflow when retry metadata is nested deeper', () => {
+      const error = Object.assign(new Error(OVERFLOW), {
+        meta: {
+          attempts: [
+            { note: 'connection timed out while waiting for response' },
+          ],
+        },
+      });
+
+      expect(isContextLengthExceededError(error)).toBe(true);
+    });
+
+    it('does not treat a fragment that is itself a timeout as overflow', () => {
+      // The guard against over-correcting: dropping the veto entirely would
+      // also satisfy the two tests above. Here the timeout phrase and the
+      // context-length phrase are in the SAME fragment, so the veto applies
+      // and the error stays classified as a timeout.
+      expect(
+        isContextLengthExceededError(
+          new Error('request timed out while checking maximum context length'),
+        ),
+      ).toBe(false);
+    });
+  });
 });

--- a/packages/core/src/utils/contextLengthError.ts
+++ b/packages/core/src/utils/contextLengthError.ts
@@ -201,12 +201,19 @@ export function getContextLengthExceededInfo(
 ): ContextLengthExceededInfo {
   const fragments = uniqueNonEmpty(collectStrings(error, new Set<object>()));
   const message = fragments.join('\n');
-  const isTimeout = TIMEOUT_PATTERNS.some((pattern) => pattern.test(message));
-  const isExceeded =
-    !isTimeout &&
-    fragments.some((fragment) =>
-      CONTEXT_LENGTH_PATTERNS.some((pattern) => pattern.test(fragment)),
-    );
+  // The timeout veto is applied per fragment, alongside the context-length
+  // test it is vetoing. Testing it against the joined message instead let a
+  // timeout phrase anywhere in the error object suppress detection for the
+  // whole error -- and provider SDKs routinely attach retry/attempt metadata,
+  // so an overflow arriving with `previous attempt: request timed out` in a
+  // sibling field was reported as not-an-overflow and never reached the
+  // compaction path. A fragment counts as evidence only if it names a
+  // context-length failure and is not itself a timeout message.
+  const isExceeded = fragments.some(
+    (fragment) =>
+      CONTEXT_LENGTH_PATTERNS.some((pattern) => pattern.test(fragment)) &&
+      !TIMEOUT_PATTERNS.some((pattern) => pattern.test(fragment)),
+  );
   const counts = isExceeded ? parseTokenCounts(message) : {};
 
   return {


### PR DESCRIPTION
## What this PR does

`getContextLengthExceededInfo` collects every string it can reach inside an error object, then classifies. The two tests were applied at different granularities:

```ts
const isTimeout = TIMEOUT_PATTERNS.some((pattern) => pattern.test(message)); // joined
const isExceeded =
  !isTimeout &&
  fragments.some((fragment) => CONTEXT_LENGTH_PATTERNS.some(…));            // per fragment
```

`message` is every fragment joined with newlines, so a timeout phrase **anywhere** in the error object vetoed the whole classification — including in a field that has nothing to do with the failure being reported:

```js
const e = new Error("This model's maximum context length is 128000 tokens, "
                  + "however you requested 200000 tokens");
isContextLengthExceededError(e);                                  // true

e.detail = 'previous attempt: request timed out after 60s';
isContextLengthExceededError(e);                                  // false
```

The fix applies the timeout test at the same granularity as the test it is vetoing: a fragment is evidence of an overflow only if it names a context-length failure **and** is not itself a timeout message.

## Why it's needed

Provider SDKs routinely attach retry and attempt metadata to the error they finally throw, so the extra field is not a contrived case — it is what an overflow looks like after the client has already retried once.

The consequence is not a cosmetic misclassification. `isContextLengthExceededError` is what routes a failure to the compaction / context-rescue path. Classified as a timeout instead, the request is retried unchanged against a context that is still too large, and the user sees a generic failure loop rather than the compaction that would have fixed it.

`actualTokens` / `limitTokens` are also lost, because `parseTokenCounts` only runs when `isExceeded` is true — so the caller loses the numbers it needs to decide how much to compact.

## Reviewer Test Plan

### How to verify

The snippet above is the whole reproduction — paste it against `packages/core/src/utils/contextLengthError.ts`.

- `npx vitest run --root packages/core src/utils/contextLengthError.test.ts` → 30/30.
- Reverting **only** `contextLengthError.ts` and keeping the new tests fails exactly two cases: `2 failed | 28 passed (30)`.
- The third new case, `does not treat a fragment that is itself a timeout as overflow`, passes both before and after **on purpose**. Deleting the veto entirely would satisfy the first two tests, so this one pins that the veto still works when the timeout phrase and the context-length phrase are in the *same* fragment. That, plus the eleven existing `does not match unrelated errors` rows — which include `context deadline exceeded`, `connection timed out while waiting for response` and `Request timeout after 60s. Try reducing input length…` — is what bounds the change to the joined-vs-per-fragment distinction.
- The first new test asserts `actualTokens` and `limitTokens` as well as the boolean, because the counts are parsed only on the `isExceeded` path and were silently lost with it.
- The second uses metadata nested two levels down inside an array, so it exercises the collector rather than just a top-level property.
- No regression in the consumers: `npx vitest run --root packages/core src/utils/contextLengthError.test.ts src/permissions/classifier.test.ts src/services/chatCompressionService.test.ts` → **143 passed (3 files)**.

### Evidence (Before & After)

N/A — not user-visible as UI. The change is which recovery path a failed request takes, covered by the unit tests above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Pure function over an error object, no I/O or platform-dependent behaviour. CI covers Windows and Linux.

## Risk & Scope

- Main risk or tradeoff: the change makes detection strictly more willing to classify an error as an overflow, so an error that genuinely is a timeout but also happens to carry a context-length phrase in a *different* fragment would now be classified as an overflow. The existing suite covers the realistic shapes of that — a timeout message that mentions input length is a single fragment and is still rejected — but it is the direction the change moves, and it is worth a reviewer's eye.
- Not validated / out of scope: the patterns themselves are unchanged. Whether `TIMEOUT_PATTERNS` and `CONTEXT_LENGTH_PATTERNS` have the right membership is a separate question from where they are applied, and this PR only changes the latter.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

`getContextLengthExceededInfo` 会先收集错误对象中所有可达的字符串，再进行分类。而两个判断被施加在了不同的粒度上：

```ts
const isTimeout = TIMEOUT_PATTERNS.some((pattern) => pattern.test(message)); // 拼接后的整体
const isExceeded =
  !isTimeout &&
  fragments.some((fragment) => CONTEXT_LENGTH_PATTERNS.some(…));            // 逐片段
```

`message` 是所有片段以换行拼接的结果，因此错误对象中**任何位置**出现的超时字样都会否决整个分类——哪怕它所在的字段与当前上报的故障毫无关系：

```js
const e = new Error("This model's maximum context length is 128000 tokens, "
                  + "however you requested 200000 tokens");
isContextLengthExceededError(e);                                  // true

e.detail = 'previous attempt: request timed out after 60s';
isContextLengthExceededError(e);                                  // false
```

修复方式是把超时判断施加在与被否决判断相同的粒度上：只有当某个片段既指明上下文长度故障，**且**其本身不是超时消息时，它才算作溢出的证据。

## 为什么需要

各家 Provider SDK 惯于把重试与尝试相关的元数据附在最终抛出的错误上，因此这个额外字段并非人为构造——它正是「客户端已重试过一次之后」的溢出错误的真实形态。

其后果并非无关痛痒的分类偏差。`isContextLengthExceededError` 决定故障是否被路由到压缩 / 上下文救援路径。一旦被误判为超时，请求会在上下文依然过大的情况下原样重试，用户看到的是一串通用失败循环，而非本可解决问题的压缩。

`actualTokens` / `limitTokens` 同样丢失，因为 `parseTokenCounts` 仅在 `isExceeded` 为真时才运行——于是调用方失去了判断「该压缩多少」所需的数字。

## 复核测试计划

### 如何验证

上面的代码片段即为完整复现——对着 `packages/core/src/utils/contextLengthError.ts` 直接运行即可。

- `npx vitest run --root packages/core src/utils/contextLengthError.test.ts` → 30/30 通过。
- **仅**还原 `contextLengthError.ts`、保留新增测试时，恰好两项失败：`2 failed | 28 passed (30)`。
- 第三项新增用例 `does not treat a fragment that is itself a timeout as overflow` 在修复前后**都通过，这是刻意为之**。彻底删除该否决同样能让前两项通过，因此本项锚定了：当超时字样与上下文长度字样位于**同一**片段时，否决依然生效。这一点，再加上既有的 11 行 `does not match unrelated errors`（其中包含 `context deadline exceeded`、`connection timed out while waiting for response` 与 `Request timeout after 60s. Try reducing input length…`），共同把本次改动限定在「整体 vs 逐片段」这一区别上。
- 第一项新增测试除布尔值外还断言了 `actualTokens` 与 `limitTokens`，因为这些数值仅在 `isExceeded` 路径上解析，会随之一同静默丢失。
- 第二项把元数据嵌套在数组内部两层深处，从而检验的是收集器本身，而不只是顶层属性。
- 调用方无回归：`npx vitest run --root packages/core src/utils/contextLengthError.test.ts src/permissions/classifier.test.ts src/services/chatCompressionService.test.ts` → **143 通过（3 个文件）**。

### 证据（修复前后对比）

N/A —— 无 UI 层面的可见变化。改动的是失败请求走哪条恢复路径，已由上述单元测试覆盖。

### 测试环境

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

针对错误对象的纯函数，无 I/O，无平台相关行为。Windows 与 Linux 由 CI 覆盖。

## 风险与范围

- 主要风险或权衡：该改动使检测在判定「溢出」时严格地更宽松，因此一个确实属于超时、但恰好在**另一个**片段中带有上下文长度字样的错误，现在会被判为溢出。既有套件已覆盖此类的现实形态——提到 input length 的超时消息本身是单一片段，仍会被拒——但这确是改动移动的方向，值得复核者留意。
- 未验证 / 不在范围内：两组 pattern 本身未作改动。`TIMEOUT_PATTERNS` 与 `CONTEXT_LENGTH_PATTERNS` 的成员是否恰当，与它们被施加在何处是两个问题，本 PR 只改动后者。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
