### PR TITLE
feat(web-shell): allow widening sidebar up to half the window width

### DIFF
--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -98,6 +98,7 @@ const SIDEBAR_WIDTH_STORAGE_KEY = 'qwen-code-web-shell-sidebar-width';
 const SIDEBAR_DEFAULT_WIDTH = 260;
 const SIDEBAR_MIN_WIDTH = 220;
 const SIDEBAR_MAX_WIDTH = 420;
+const SIDEBAR_MAX_WIDTH_WINDOW_RATIO = 0.5;
 const SIDEBAR_FOOTER_COMPACT_WIDTH = 344;
 const SIDEBAR_FOOTER_TIGHT_WIDTH = 250;
 const SIDEBAR_DRAG_VISUAL_MIN_WIDTH = 200;
@@ -410,13 +411,25 @@ function getGroupColorStyle(
   return color.startsWith('#') ? { backgroundColor: color } : undefined;
 }
 
+// The cap scales with the window so wide displays can reveal full session
+// names, but never exceeds half the window so the sidebar cannot crush the
+// main content area. SIDEBAR_MAX_WIDTH is the floor, preserving the old
+// fixed cap on small windows.
+function getSidebarMaxWidth(): number {
+  if (typeof window === 'undefined') return SIDEBAR_MAX_WIDTH;
+  return Math.max(
+    SIDEBAR_MAX_WIDTH,
+    Math.floor(window.innerWidth * SIDEBAR_MAX_WIDTH_WINDOW_RATIO),
+  );
+}
+
 function clampSidebarWidth(width: number): number {
-  return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, width));
+  return Math.min(getSidebarMaxWidth(), Math.max(SIDEBAR_MIN_WIDTH, width));
 }
 
 function clampSidebarVisualWidth(width: number): number {
   return Math.min(
-    SIDEBAR_MAX_WIDTH,
+    getSidebarMaxWidth(),
     Math.max(SIDEBAR_DRAG_VISUAL_MIN_WIDTH, width),
   );
 }
@@ -1342,6 +1355,16 @@ export function WebShellSidebar({
     },
     [],
   );
+
+  // The max width derives from window size, so re-clamp when the window
+  // shrinks below a previously stored wider sidebar.
+  useEffect(() => {
+    function handleWindowResize() {
+      setSidebarWidth((current) => clampSidebarWidth(current));
+    }
+    window.addEventListener('resize', handleWindowResize);
+    return () => window.removeEventListener('resize', handleWindowResize);
+  }, []);
 
   useEffect(() => {
     if (collapsed) {


### PR DESCRIPTION
## What this PR does

The Web Shell sidebar's maximum width was a fixed constant, so dragging the resize handle stopped at that cap regardless of how wide the display is. This PR makes the cap dynamic: the sidebar can now be widened up to half of the browser window, while the previous fixed cap is kept as a floor so behavior on small windows is unchanged. When the browser window shrinks below a previously stored wider sidebar, the sidebar is automatically re-clamped so it cannot crush the main content area.

## Why it's needed

Session names in the sidebar are truncated with an ellipsis, and with the old fixed cap there was no way to widen the sidebar enough to read long names in full. On wide displays users can now reveal full session names by dragging, while the half-window cap guarantees the conversation area always keeps at least half of the window.

## Reviewer Test Plan

### How to verify

- Open the Web Shell and drag the sidebar's right edge on a window wider than ~840px: the sidebar should now grow past the old fixed cap, up to half the window width.
- On a window narrower than ~840px the cap should stay at the old fixed value, i.e. small-window behavior is unchanged.
- Widen the sidebar, then make the browser window narrower: the sidebar should shrink automatically to stay within half the window.
- Reload the page: the stored width should be restored, clamped to the current window's cap.
- Locally: sidebar unit tests pass (81/81), ESLint clean, TypeScript error count unchanged vs. base.

### Evidence (Before & After)

N/A — no screenshots captured; the change is a drag-constraint constant plus clamp logic, verified via the steps above and unit tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests via vitest; no e2e run.

## Risk & Scope

- Main risk or tradeoff: on very wide windows the sidebar can now occupy up to half the window; the half-window cap is the guardrail that keeps the main content usable.
- Not validated / out of scope: the Electron desktop app has a separate sidebar implementation with its own fixed cap, untouched here.
- Breaking changes / migration notes: none; the stored-width localStorage key is unchanged and stored values are clamped on load.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

Web Shell 侧边栏的最大宽度此前是一个固定常量，无论显示器多宽，拖拽分隔条到该上限就停止了。本 PR 将上限改为动态值：侧边栏现在最宽可拖到浏览器窗口宽度的一半，同时保留原固定上限作为下限，小窗口下的行为完全不变。当浏览器窗口缩小到比已保存的更宽侧栏还窄时，侧栏会自动重新收敛，不会挤占主内容区。

## 为什么需要

侧边栏中的 session 名称会以省略号截断，而在旧的固定上限下，无法把侧栏拖宽到足以完整显示长名称。现在在宽屏上用户可以通过拖拽看到完整的 session 名称，同时「不超过半窗」的上限保证会话主区域始终至少保留一半窗口。

## 评审测试计划

### 如何验证

- 打开 Web Shell，在宽于约 840px 的窗口中拖拽侧栏右边缘：侧栏现在应能超过旧固定上限，最宽到窗口宽度的一半。
- 在窄于约 840px 的窗口中，上限应保持为旧固定值，即小窗口行为不变。
- 拖宽侧栏后缩小浏览器窗口：侧栏应自动收窄，保持不超过半窗。
- 刷新页面：已保存的宽度应被恢复，并按当前窗口的上限收敛。
- 本地：侧栏单元测试全部通过（81/81），ESLint 干净，TypeScript 错误数与基线一致。

### 证据（前后对比）

N/A — 未截图；本次改动是拖拽上限常量与收敛逻辑，通过上述步骤和单元测试验证。

### 测试环境

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

vitest 单元测试；未跑 e2e。

## 风险与范围

- 主要风险或权衡：在超宽窗口下侧栏现在最多可占半窗；半窗上限就是保证主内容区可用的护栏。
- 未验证 / 不在范围内：Electron 桌面端是另一套独立的侧栏实现，有自己的固定上限，本次未改动。
- 破坏性变更 / 迁移说明：无；保存宽度的 localStorage key 不变，读取时会按上限收敛。

## 关联 Issue

无。

</details>
