### PR TITLE
fix(core): keep Draft 4 boolean exclusive bounds in toOpenAPI30

### DIFF
--- a/packages/core/src/utils/schemaConverter.test.ts
+++ b/packages/core/src/utils/schemaConverter.test.ts
@@ -96,6 +96,60 @@ describe('convertSchema', () => {
       expect(convertSchema(input, 'openapi_30')).toEqual(expected);
     });
 
+    it('should keep a Draft 4 boolean exclusive limit instead of dropping it', () => {
+      expect(
+        convertSchema(
+          { type: 'number', minimum: 10, exclusiveMinimum: true },
+          'openapi_30',
+        ),
+      ).toEqual({ type: 'number', minimum: 10, exclusiveMinimum: true });
+      expect(
+        convertSchema(
+          { type: 'number', maximum: 10, exclusiveMaximum: true },
+          'openapi_30',
+        ),
+      ).toEqual({ type: 'number', maximum: 10, exclusiveMaximum: true });
+    });
+
+    it('should keep a nested Draft 4 boolean exclusive limit', () => {
+      expect(
+        convertSchema(
+          {
+            type: 'object',
+            properties: {
+              pct: { type: 'number', minimum: 0, exclusiveMinimum: true },
+            },
+          },
+          'openapi_30',
+        ),
+      ).toEqual({
+        type: 'object',
+        properties: {
+          pct: { type: 'number', minimum: 0, exclusiveMinimum: true },
+        },
+      });
+    });
+
+    it('should be idempotent for exclusive limits', () => {
+      const once = convertSchema(
+        { type: 'number', exclusiveMinimum: 10 },
+        'openapi_30',
+      );
+      expect(convertSchema(once, 'openapi_30')).toEqual(once);
+    });
+
+    // Guard against over-correcting: the numeric form must still be CONSUMED
+    // by step 3 rather than passed through, or the boolean it writes would be
+    // overwritten by the number and the output would stop being Draft 4.
+    it('should not pass a numeric exclusive limit through unconverted', () => {
+      const result = convertSchema(
+        { type: 'number', exclusiveMaximum: 5 },
+        'openapi_30',
+      );
+      expect(result['exclusiveMaximum']).toBe(true);
+      expect(result['maximum']).toBe(5);
+    });
+
     it('should convert nested objects recursively', () => {
       const input = {
         type: 'object',

--- a/packages/core/src/utils/schemaConverter.ts
+++ b/packages/core/src/utils/schemaConverter.ts
@@ -137,8 +137,6 @@ function toOpenAPI30(schema: Record<string, unknown>): Record<string, unknown> {
       if (
         key === 'type' ||
         key === 'const' ||
-        key === 'exclusiveMinimum' ||
-        key === 'exclusiveMaximum' ||
         key === 'items' ||
         key === 'enum' ||
         key === '$schema' ||
@@ -146,6 +144,21 @@ function toOpenAPI30(schema: Record<string, unknown>): Record<string, unknown> {
         key === 'default' || // Optional: Gemini sometimes complains about defaults conflicting with types
         key === 'dependencies' ||
         key === 'patternProperties'
+      ) {
+        continue;
+      }
+
+      // Step 3 consumes only the NUMERIC form of the exclusive limits, so
+      // only the numeric form may be skipped here. A boolean is a Draft 4
+      // schema that already carries the exact shape step 3 emits, and
+      // skipping it unconditionally dropped it: `{minimum: 10,
+      // exclusiveMinimum: true}` came back as `{minimum: 10}`, silently
+      // relaxing `> 10` into `>= 10`. That also made this function
+      // non-idempotent — feeding its own output back in lost the flag it had
+      // just added.
+      if (
+        (key === 'exclusiveMinimum' || key === 'exclusiveMaximum') &&
+        typeof value === 'number'
       ) {
         continue;
       }


### PR DESCRIPTION
## Description

`toOpenAPI30` converts a Draft 6+ **numeric** `exclusiveMinimum` / `exclusiveMaximum` into the Draft 4 **boolean** form (step 3), then step 6 skips both keys unconditionally when copying the remaining fields. The skip is too broad: it also swallows a value that is *already* boolean.

So a schema that arrives in Draft 4 loses its exclusivity flag, and the bound silently loosens from `> 10` to `>= 10`:

```
in : {"type":"number","minimum":10,"exclusiveMinimum":true}
out: {"type":"number","minimum":10}
```

The sharpest symptom is that the function is not idempotent — it drops the exact flag it emits, so running it on its own output changes the meaning of the schema:

```
once : {"type":"number","minimum":10,"exclusiveMinimum":true}
twice: {"type":"number","minimum":10}          <- stable: false
```

This matters on a live path. `convertSchema(..., 'openapi_30')` is applied to tool parameter schemas in `openaiContentGenerator/converter.ts` and `anthropicContentGenerator/converter.ts`, and MCP servers supply those schemas. A server that declares `draft-04` sends the boolean form directly, and its exclusive bound is dropped on the wire — the model is told `>= 0` where the tool means `> 0`. Nothing errors; the constraint just quietly weakens.

### Fix

Skip the key only when the value is a number, which is the only form step 3 consumes. Anything else passes through untouched.

```ts
if (
  (key === 'exclusiveMinimum' || key === 'exclusiveMaximum') &&
  typeof value === 'number'
) {
  continue;
}
```

The numeric path is unchanged: step 3 still rewrites `exclusiveMinimum: 10` to `minimum: 10, exclusiveMinimum: true`.

### Not fixed here

While confirming the above I found a second, separate defect in the same function: when a schema carries a numeric exclusive limit *and* a sibling inclusive one, step 6 copies the sibling over the value step 3 wrote.

```
in : {"type":"number","exclusiveMinimum":10,"minimum":5}
out: {"type":"number","minimum":5,"exclusiveMinimum":true}     -> "> 5", source meant "> 10"
```

It has a different trigger and a different symptom, so it is left for a separate PR rather than bundled in here. This PR does not change that behaviour in either direction.

Follow-up to #7760, which flagged this as a separate fix.

<details>
<summary>中文说明</summary>

`toOpenAPI30` 会把 Draft 6+ 的**数值**形式 `exclusiveMinimum` / `exclusiveMaximum` 转换成 Draft 4 的**布尔**形式（步骤 3），随后步骤 6 在复制其余字段时无条件跳过这两个键。这个跳过范围过宽：它把本来就已经是布尔值的情况也一并吞掉了。

于是，一个本身就是 Draft 4 的 schema 会丢失排他标志，边界从 `> 10` 悄悄放宽成 `>= 10`：

```
输入：{"type":"number","minimum":10,"exclusiveMinimum":true}
输出：{"type":"number","minimum":10}
```

最明显的症状是该函数不满足幂等性——它丢掉的正是自己输出的那个标志，因此把它的输出再喂回去就会改变 schema 的语义：

```
第一次：{"type":"number","minimum":10,"exclusiveMinimum":true}
第二次：{"type":"number","minimum":10}          <- 不稳定
```

这条路径是实际生效的。`convertSchema(..., 'openapi_30')` 会作用于 `openaiContentGenerator/converter.ts` 和 `anthropicContentGenerator/converter.ts` 中的工具参数 schema，而这些 schema 由 MCP server 提供。声明 `draft-04` 的 server 直接发送布尔形式，其排他边界会在传输时被丢弃——工具本意是 `> 0`，模型收到的却是 `>= 0`。全程没有任何报错，约束只是被悄悄削弱。

### 修复

仅在取值为数值时跳过该键，因为数值形式才是步骤 3 真正消费的形式。其余形式原样透传。

```ts
if (
  (key === 'exclusiveMinimum' || key === 'exclusiveMaximum') &&
  typeof value === 'number'
) {
  continue;
}
```

数值路径保持不变：步骤 3 仍会把 `exclusiveMinimum: 10` 改写为 `minimum: 10, exclusiveMinimum: true`。

### 本次不修复的问题

在确认上述问题时，我在同一个函数里发现了另一个独立缺陷：当 schema 同时带有数值形式的排他边界和相邻的包含边界时，步骤 6 会用后者覆盖步骤 3 写入的值。

```
输入：{"type":"number","exclusiveMinimum":10,"minimum":5}
输出：{"type":"number","minimum":5,"exclusiveMinimum":true}     -> 变成 "> 5"，而源 schema 的本意是 "> 10"
```

它的触发条件和症状都不同，因此留待单独的 PR 处理，不在此处捆绑。本 PR 不会在任何方向上改变该行为。

本 PR 是 #7760 的后续，该 PR 已将此问题标注为需要单独修复。

</details>

## Testing

`packages/core/src/utils/schemaConverter.test.ts`, four new cases:

- a Draft 4 boolean `exclusiveMinimum` / `exclusiveMaximum` survives conversion;
- the same, nested inside `properties`;
- `convert(convert(x))` equals `convert(x)` for exclusive limits;
- an over-correction guard asserting the numeric form is still *consumed* — it must come out as `exclusiveMaximum: true`, not passed through as `5`. This one passes both before and after on purpose, so the new tests cannot be satisfied by simply deleting the skip.

The three fix tests fail on `main` and pass with the change; the guard and all 26 pre-existing cases pass in both states.

```
before: Tests  3 failed | 27 passed (30)
after:  Tests  30 passed (30)
```

Consumer suites also run clean:

```
npx vitest run src/utils/schemaConverter.test.ts \
  src/core/openaiContentGenerator/converter.test.ts \
  src/core/anthropicContentGenerator/converter.test.ts
Test Files  3 passed (3)
     Tests  312 passed (312)
```

`eslint` and `prettier --check` are clean on both changed files, and `tsc --noEmit` on `packages/core` reports the same set of pre-existing unrelated errors before and after (local `simple-git` / `chardet` type resolution), with none in `schemaConverter`.
