### PR TITLE
fix(cli): report a genuine $0.00 cost instead of N/A

### DIFF
--- a/packages/cli/src/ui/components/ModelStatsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/ModelStatsDisplay.test.tsx
@@ -488,6 +488,21 @@ describe('<ModelStatsDisplay />', () => {
         expect(lastFrame()).toContain('0.0001');
       });
 
+      it('should display $0.0000 rather than N/A for a model priced at zero', () => {
+        const { lastFrame } = renderCostTest(
+          { 'qwen3-coder:free': mainOnly(makeCore(1000, 2000, 0)) },
+          {
+            'qwen3-coder:free': {
+              inputPerMillionTokens: 0,
+              outputPerMillionTokens: 0,
+            },
+          },
+        );
+        expect(lastFrame()).toContain('Estimated');
+        expect(lastFrame()).toContain('0.0000');
+        expect(lastFrame()).not.toContain('N/A');
+      });
+
       it('should include thoughts tokens in cost calculation (regression)', () => {
         const { lastFrame } = renderCostTest(
           { 'gemini-2.5-pro': mainOnly(makeCore(10, 20, 5)) },

--- a/packages/cli/src/utils/costCalculator.test.ts
+++ b/packages/cli/src/utils/costCalculator.test.ts
@@ -77,6 +77,67 @@ describe('calculateCost', () => {
     expect(cost).toBeNull();
   });
 
+  it('returns zero rather than null for a model priced at zero', () => {
+    const cost = calculateCost({
+      inputTokens: 1_000_000,
+      outputTokens: 500_000,
+      pricing: {
+        inputPerMillionTokens: 0,
+        outputPerMillionTokens: 0,
+      },
+    });
+
+    expect(cost).toBe(0);
+  });
+
+  it('returns a number when only one side is priced at zero', () => {
+    expect(
+      calculateCost({
+        inputTokens: 1_000_000,
+        outputTokens: 0,
+        pricing: { inputPerMillionTokens: 0, outputPerMillionTokens: 1.2 },
+      }),
+    ).toBe(0);
+    expect(
+      calculateCost({
+        inputTokens: 1_000_000,
+        outputTokens: 1_000_000,
+        pricing: { inputPerMillionTokens: 0, outputPerMillionTokens: 1.2 },
+      }),
+    ).toBe(1.2);
+  });
+
+  // Guards against over-correcting. `null` still has to mean "nothing to
+  // report", or the stats table would print `$0.0000` for models the user
+  // never priced and for models with no recorded usage. Both pass before and
+  // after the fix.
+  it('keeps null for an unpriced model regardless of token counts', () => {
+    expect(
+      calculateCost({
+        inputTokens: 1_000_000,
+        outputTokens: 1_000_000,
+        pricing: {},
+      }),
+    ).toBeNull();
+    expect(
+      calculateCost({
+        inputTokens: 1_000_000,
+        outputTokens: 1_000_000,
+        pricing: undefined,
+      }),
+    ).toBeNull();
+  });
+
+  it('keeps null for an unused model even when it is priced at zero', () => {
+    expect(
+      calculateCost({
+        inputTokens: 0,
+        outputTokens: 0,
+        pricing: { inputPerMillionTokens: 0, outputPerMillionTokens: 0 },
+      }),
+    ).toBeNull();
+  });
+
   it('handles partial tokens correctly', () => {
     const cost = calculateCost({
       inputTokens: 500_000,

--- a/packages/cli/src/utils/costCalculator.ts
+++ b/packages/cli/src/utils/costCalculator.ts
@@ -18,6 +18,27 @@ export function calculateCost(args: {
 
   if (!pricing) return null;
 
+  // `null` means "no cost to report", which is how callers read it: the stats
+  // table renders it as `N/A` and hides the whole Cost section when no model
+  // produces a number. Two things can make a cost unreportable -- no price is
+  // configured, or the model recorded no usage -- and both are decided here,
+  // before any arithmetic.
+  if (
+    pricing.inputPerMillionTokens == null &&
+    pricing.outputPerMillionTokens == null
+  ) {
+    return null;
+  }
+  if (inputTokens <= 0 && outputTokens <= 0) {
+    return null;
+  }
+
+  // Past this point the cost is knowable, so it is returned even when it comes
+  // out as exactly zero. Testing the total instead conflated a zero cost with
+  // an unknown one: a model the user had deliberately priced at 0 -- a free
+  // OpenRouter variant, a local Ollama or LM Studio model -- reported `N/A`
+  // despite $0.0000 being the correct and known answer, and the Cost section
+  // disappeared entirely when that was the only model in the session.
   const inputCost =
     pricing.inputPerMillionTokens != null
       ? (inputTokens / 1_000_000) * pricing.inputPerMillionTokens
@@ -28,6 +49,5 @@ export function calculateCost(args: {
       ? (outputTokens / 1_000_000) * pricing.outputPerMillionTokens
       : 0;
 
-  const total = inputCost + outputCost;
-  return total > 0 ? total : null;
+  return inputCost + outputCost;
 }


### PR DESCRIPTION
## Description

`calculateCost` ends with `return total > 0 ? total : null`, and every caller reads `null` as "no cost to report":

```ts
// ModelStatsDisplay.tsx
return cost != null ? `$${cost.toFixed(4)}` : 'N/A';
```

```ts
// statsCommand.ts, non-interactive /stats model
if (cost != null) { lines.push(`  Estimated cost: $${cost.toFixed(4)}`); }
```

Testing the *total* rather than the pricing conflates a cost of zero with an unknown cost. A model the user has deliberately priced at `0` — a free OpenRouter variant, a local Ollama or LM Studio model — produces a total of exactly `0` and is reported as `N/A`, indistinguishable from a model whose price was never configured. In non-interactive `/stats model` the "Estimated cost" line is dropped for it entirely.

It also propagates one level up. `ModelStatsDisplay` decides whether to render the Cost section at all with

```ts
const hasPricing = entries.some(({ key, metrics }) => calculateCost({ ... }) != null);
```

so when a free model is the only model in the session, the entire Cost section disappears even though the user configured pricing for it.

### Fix

Decide on the pricing and the usage, before the arithmetic, then return the total unconditionally:

```ts
if (pricing.inputPerMillionTokens == null && pricing.outputPerMillionTokens == null) {
  return null;
}
if (inputTokens <= 0 && outputTokens <= 0) {
  return null;
}
...
return inputCost + outputCost;
```

Only one behaviour changes: a priced model with recorded usage whose cost works out to zero now returns `0` instead of `null`. Everything else is preserved on purpose, including the case where a model recorded no tokens — `statsCommand.test.ts` documents that one explicitly ("Zero tokens mean zero cost, so no cost line should appear"), so it is a deliberate decision and not part of this bug. No existing test was modified.

<details>
<summary>中文说明</summary>

`calculateCost` 的结尾是 `return total > 0 ? total : null`，而所有调用方都把 `null` 理解为"没有可报告的费用"：

```ts
// ModelStatsDisplay.tsx
return cost != null ? `$${cost.toFixed(4)}` : 'N/A';
```

```ts
// statsCommand.ts，非交互式 /stats model
if (cost != null) { lines.push(`  Estimated cost: $${cost.toFixed(4)}`); }
```

以*总额*而非定价来做判断，会把"费用为零"和"费用未知"混为一谈。用户明确将价格配置为 `0` 的模型——免费的 OpenRouter 变体、本地的 Ollama 或 LM Studio 模型——算出的总额恰好是 `0`，于是被显示为 `N/A`，与从未配置过价格的模型无法区分。在非交互式的 `/stats model` 中，它的 "Estimated cost" 一行会被整个丢弃。

这个问题还会向上传播一层。`ModelStatsDisplay` 用以下方式决定是否渲染 Cost 区块：

```ts
const hasPricing = entries.some(({ key, metrics }) => calculateCost({ ... }) != null);
```

因此当会话中只有一个免费模型时，即便用户为它配置了价格，整个 Cost 区块也会消失。

### 修复

在做算术之前，先根据定价和用量作出判断，然后无条件返回总额：

```ts
if (pricing.inputPerMillionTokens == null && pricing.outputPerMillionTokens == null) {
  return null;
}
if (inputTokens <= 0 && outputTokens <= 0) {
  return null;
}
...
return inputCost + outputCost;
```

只有一处行为发生变化：已配置价格、有实际用量、且费用算下来为零的模型，现在返回 `0` 而不是 `null`。其余行为均刻意保持不变，包括模型没有任何 token 记录的情况——`statsCommand.test.ts` 对该情况有明确说明（"Zero tokens mean zero cost, so no cost line should appear"），说明那是有意为之的设计，不属于本 bug 的范围。本 PR 未修改任何既有测试。

</details>

## Testing

Three new cases, in `costCalculator.test.ts` and `ModelStatsDisplay.test.tsx`:

- a model priced at `0` with real usage returns `0`, not `null`;
- one side priced at `0` still returns a number (`0` when only the free side has tokens, `1.2` when the paid side does);
- end to end, a `qwen3-coder:free` entry priced at `0` renders `Estimated $0.0000` and the frame contains no `N/A`.

Two guard cases against over-correcting, both passing before *and* after the change so the new tests cannot be satisfied by simply returning the total in every case:

- an unpriced model still returns `null` no matter how many tokens it used;
- a model with no recorded usage still returns `null` even when it is priced at `0`.

```
before: Tests  3 failed | 71 passed (74)
after:  Tests  74 passed (74)
```

across `costCalculator.test.ts`, `ModelStatsDisplay.test.tsx` and `statsCommand.test.ts`. `statsCommand.test.ts` is fully green in both states. `eslint` and `prettier --check` are clean on all three changed files.
