### PR TITLE
fix(core): reject socks5h and socks4a proxy URLs

### DIFF
--- a/packages/core/src/utils/proxyUtils.test.ts
+++ b/packages/core/src/utils/proxyUtils.test.ts
@@ -102,4 +102,50 @@ describe('normalizeProxyUrl', () => {
       'SOCKS proxy is not supported',
     );
   });
+
+  // socks5h and socks4a ask the proxy to resolve hostnames and are the forms
+  // curl, proxychains and most tunnels emit. They used to fall through to the
+  // http:// prefix and yield `http://socks5h://...`, which parses as the host
+  // `socks5h` on port 80.
+  it('should throw error for socks5h:// proxy URL', () => {
+    expect(() => normalizeProxyUrl('socks5h://127.0.0.1:1080')).toThrow(
+      'SOCKS proxy is not supported',
+    );
+  });
+
+  it('should throw error for socks4a:// proxy URL', () => {
+    expect(() => normalizeProxyUrl('socks4a://127.0.0.1:1080')).toThrow(
+      'SOCKS proxy is not supported',
+    );
+  });
+
+  it('should throw error for SOCKS5H:// proxy URL (case insensitive)', () => {
+    expect(() => normalizeProxyUrl('SOCKS5H://proxy.example.com:1080')).toThrow(
+      'SOCKS proxy is not supported',
+    );
+  });
+
+  it('should never prefix http:// onto a socks scheme', () => {
+    for (const url of [
+      'socks://h:1080',
+      'socks4://h:1080',
+      'socks4a://h:1080',
+      'socks5://h:1080',
+      'socks5h://h:1080',
+    ]) {
+      expect(() => normalizeProxyUrl(url)).toThrow('SOCKS proxy');
+    }
+  });
+
+  // Guards against over-correcting: a host that merely starts with "socks" is
+  // not a socks scheme, since there is no `://` after it. Passes before and
+  // after the fix.
+  it('should still accept a hostname that begins with socks', () => {
+    expect(normalizeProxyUrl('socks.example.com:1080')).toBe(
+      'http://socks.example.com:1080',
+    );
+    expect(normalizeProxyUrl('http://socks5h.example.com:1080')).toBe(
+      'http://socks5h.example.com:1080',
+    );
+  });
 });

--- a/packages/core/src/utils/proxyUtils.ts
+++ b/packages/core/src/utils/proxyUtils.ts
@@ -13,8 +13,9 @@
  * the most common default.
  *
  * Note: Only HTTP and HTTPS proxies are supported. SOCKS proxies (socks://,
- * socks4://, socks5://) are NOT supported because the underlying undici library
- * does not support them. See: https://github.com/nodejs/undici/issues/2224
+ * socks4://, socks4a://, socks5://, socks5h://) are NOT supported because the
+ * underlying undici library does not support them.
+ * See: https://github.com/nodejs/undici/issues/2224
  *
  * @param proxyUrl - The proxy URL to normalize
  * @returns The normalized proxy URL with protocol prefix, or undefined if input is undefined/empty
@@ -38,8 +39,19 @@ export function normalizeProxyUrl(
     return trimmed;
   }
 
-  // Reject SOCKS proxies - undici does not support them
-  if (/^socks[45]?:\/\//i.test(trimmed)) {
+  // Reject SOCKS proxies - undici does not support them.
+  //
+  // Any scheme in the socks family is matched, not just socks/socks4/socks5.
+  // The `socks5h` and `socks4a` variants -- which ask the proxy to resolve
+  // hostnames, and are what curl, proxychains and most tunnels emit -- were
+  // missed by the narrower test, so `HTTPS_PROXY=socks5h://127.0.0.1:1080`
+  // fell through to the http:// prefix below and produced
+  // `http://socks5h://127.0.0.1:1080`. That parses as the host `socks5h` on
+  // port 80, so the user saw an ENOTFOUND for a nonexistent host instead of
+  // the actionable message this guard exists to give. A scheme starting with
+  // `socks` is always a SOCKS proxy, and prefixing http:// to one is never
+  // the right answer.
+  if (/^socks[a-z0-9]*:\/\//i.test(trimmed)) {
     throw new Error(
       `SOCKS proxy is not supported. The underlying HTTP client (undici) only supports HTTP and HTTPS proxies. ` +
         `Please use an HTTP/HTTPS proxy instead, or set up a SOCKS-to-HTTP proxy converter. ` +


### PR DESCRIPTION
## Description

`normalizeProxyUrl` rejects SOCKS proxies with an actionable message, because undici cannot use them. The test that decides this is

```ts
if (/^socks[45]?:\/\//i.test(trimmed)) {
```

which matches `socks://`, `socks4://` and `socks5://` — but not `socks5h://` or `socks4a://`. Those two variants ask the proxy to resolve hostnames rather than resolving them locally, and they are the forms curl, proxychains and most tunnel front-ends emit; `socks5h` is the usual recommendation precisely because it avoids DNS leaks.

Missing them means the URL falls through to the `http://` prefix at the end of the function:

```
"socks5h://127.0.0.1:1080"  ->  "http://socks5h://127.0.0.1:1080"
"socks4a://127.0.0.1:1080"  ->  "http://socks4a://127.0.0.1:1080"
```

That is not a URL that fails cleanly. It parses:

```
> new URL('http://socks5h://127.0.0.1:1080')
host: socks5h | port: (default 80) | path: //127.0.0.1:1080
```

so it is handed to `EnvHttpProxyAgent` as a real proxy pointing at a host literally named `socks5h` on port 80. Every request then fails with `ENOTFOUND socks5h` (or a connect timeout), and nothing anywhere mentions SOCKS. The guard exists specifically to turn this into a clear message, and the most common spelling of the thing it guards against walks straight past it.

`HTTPS_PROXY` / `ALL_PROXY` set to `socks5h://…` is the ordinary way to hit this — see `resolveProxyUrl` in `packages/cli/src/commands/channel/proxy.ts`, which feeds those environment variables straight into this function.

### Fix

Match the whole socks family rather than three specific spellings:

```ts
if (/^socks[a-z0-9]*:\/\//i.test(trimmed)) {
```

A scheme beginning with `socks` is always a SOCKS proxy, and prefixing `http://` to one is never the right answer. This cannot over-match a hostname, because the pattern requires `://` immediately after the scheme and `.` is not in the character class — `socks.example.com:1080` is still normalized to `http://socks.example.com:1080`. The doc comment is updated to list the two variants.

### Not fixed here

Any *other* unsupported scheme (`ftp://`, `quic://`, …) is still given an `http://` prefix and produces the same class of malformed URL. That is a broader change to the function's contract with a different set of trade-offs, so it is left alone here rather than bundled in.

<details>
<summary>中文说明</summary>

`normalizeProxyUrl` 会拒绝 SOCKS 代理并给出可操作的提示，因为 undici 无法使用它们。做出该判断的检查是：

```ts
if (/^socks[45]?:\/\//i.test(trimmed)) {
```

它能匹配 `socks://`、`socks4://` 和 `socks5://`，却匹配不到 `socks5h://` 和 `socks4a://`。这两个变体要求由代理端而非本地解析主机名，而它们正是 curl、proxychains 以及大多数隧道前端所输出的形式；`socks5h` 通常是被推荐的写法，原因恰恰是它能避免 DNS 泄漏。

漏掉它们，就意味着这类 URL 会一路落到函数末尾的 `http://` 前缀处理：

```
"socks5h://127.0.0.1:1080"  ->  "http://socks5h://127.0.0.1:1080"
"socks4a://127.0.0.1:1080"  ->  "http://socks4a://127.0.0.1:1080"
```

这并不是一个会干脆失败的 URL，它是可以被解析的：

```
> new URL('http://socks5h://127.0.0.1:1080')
host: socks5h | port: （默认 80）| path: //127.0.0.1:1080
```

于是它会作为一个真实代理传给 `EnvHttpProxyAgent`，指向一台名字就叫 `socks5h`、端口为 80 的主机。此后每个请求都会以 `ENOTFOUND socks5h`（或连接超时）失败，而任何地方都不会提到 SOCKS。这个防护本来就是为了把这种情况转成清晰的提示，结果它要防的东西最常见的写法却直接绕了过去。

把 `HTTPS_PROXY` / `ALL_PROXY` 设为 `socks5h://…` 就是触发该问题的常规途径——参见 `packages/cli/src/commands/channel/proxy.ts` 中的 `resolveProxyUrl`，它会把这些环境变量直接传入本函数。

### 修复

匹配整个 socks 协议族，而不是三种特定写法：

```ts
if (/^socks[a-z0-9]*:\/\//i.test(trimmed)) {
```

以 `socks` 开头的协议一定是 SOCKS 代理，给它加上 `http://` 前缀在任何情况下都不是正确答案。这不会误伤主机名，因为该模式要求协议名后紧跟 `://`，而 `.` 不在字符类中——`socks.example.com:1080` 仍会被规范化为 `http://socks.example.com:1080`。文档注释也已更新，补上了这两个变体。

### 本次不修复的问题

其他不受支持的协议（`ftp://`、`quic://` 等）仍然会被加上 `http://` 前缀，产生同一类畸形 URL。那属于对本函数契约更大范围的改动，取舍也不同，因此不在此处一并处理。

</details>

## Testing

`packages/core/src/utils/proxyUtils.test.ts`, four new cases:

- `socks5h://` and `socks4a://` throw the SOCKS message;
- `SOCKS5H://` throws too (case insensitivity holds for the variants);
- a loop asserting that none of the five socks spellings is ever given an `http://` prefix.

Plus an over-correction guard that passes before *and* after, so the new tests cannot be satisfied by a pattern that swallows anything containing "socks":

- `socks.example.com:1080` still normalizes to `http://socks.example.com:1080`, and `http://socks5h.example.com:1080` is still returned unchanged.

```
before: Tests  4 failed | 19 passed (23)
after:  Tests  23 passed (23)
```

All 19 pre-existing cases pass in both states. `eslint` and `prettier --check` are clean on both changed files.
