### PR TITLE
fix(web-shell): make /copy with a bare index work

### DIFF
--- a/packages/web-shell/client/utils/copyCommand.test.ts
+++ b/packages/web-shell/client/utils/copyCommand.test.ts
@@ -98,6 +98,45 @@ describe('copyFromLastAssistantMessage', () => {
     expect(result.message).toBe('Code block 2 copied to the clipboard');
   });
 
+  // The argument hint is `[code|<lang>|latex|inline-latex] [index]`, both
+  // groups optional, so a bare index is a documented form.
+  it('copies a numbered fenced code block with a bare index', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const content = [
+      '```ts',
+      'const first = 1;',
+      '```',
+      '```json',
+      '{"second": true}',
+      '```',
+    ].join('\n');
+
+    const result = await copyFromLastAssistantMessage(
+      [assistant(content)],
+      '2',
+      writeText,
+    );
+
+    expect(writeText).toHaveBeenCalledWith('{"second": true}');
+    expect(result.message).toBe('Code block 2 copied to the clipboard');
+  });
+
+  it('reports a missing block for a bare index that is out of range', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const content = ['```ts', 'const only = 1;', '```'].join('\n');
+
+    const result = await copyFromLastAssistantMessage(
+      [assistant(content)],
+      '9',
+      writeText,
+    );
+
+    expect(writeText).not.toHaveBeenCalled();
+    expect(result.message).toBe(
+      'No matching code block found in the last AI output.',
+    );
+  });
+
   it('copies the last matching language code block', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     const content = [

--- a/packages/web-shell/client/utils/copyCommand.ts
+++ b/packages/web-shell/client/utils/copyCommand.ts
@@ -227,11 +227,16 @@ function selectCodeBlock(
 
   let lang: string | null = null;
   let requestedIndex: number | null = null;
-  const selectorTokens =
-    firstToken === 'code' ? tokens.slice(1) : tokens.map((token) => token);
-  if (firstToken !== 'code') {
-    lang = firstToken;
-  }
+  // Only the leading `code` keyword is consumed here. Every other token is
+  // classified by the loop below, which already assigns `lang` for anything
+  // that is not a number. Seeding `lang` from the first token beforehand was
+  // redundant for `/copy ts` and actively wrong for a bare index: `/copy 3`
+  // set lang to "3" here and requestedIndex to 3 in the loop, so the filter
+  // looked for blocks written in a language called "3", found none, and
+  // reported that no code block matched. The argument hint advertises
+  // `[code|<lang>|latex|inline-latex] [index]` with both groups optional, so
+  // a bare index is exactly what users are told to type.
+  const selectorTokens = firstToken === 'code' ? tokens.slice(1) : tokens;
 
   for (const token of selectorTokens) {
     if (/^\d+$/.test(token)) {


### PR DESCRIPTION
## Description

`/copy 3` never copies anything. It always reports `No matching code block found in the last AI output.`, however many code blocks the message contains.

The argument hint the UI shows for the command is

```
/copy [code|<lang>|latex|inline-latex] [index]
```

Both groups are optional, so a bare index is exactly the form users are told they can type — and it is the only documented form that does not work.

In `selectCodeBlock`, the first token is assigned to `lang` before the classification loop runs:

```ts
const selectorTokens =
  firstToken === 'code' ? tokens.slice(1) : tokens.map((token) => token);
if (firstToken !== 'code') {
  lang = firstToken;          // for `/copy 3` this is "3"
}

for (const token of selectorTokens) {
  if (/^\d+$/.test(token)) {
    requestedIndex = Number(token);   // ... and this is also 3
  } else if (token.toLowerCase() !== 'code') {
    lang = token.toLowerCase();
  }
}

const candidates = lang ? blocks.filter((block) => block.lang === lang) : blocks;
if (candidates.length === 0) return null;
```

For `/copy 3` the single token is used twice: it seeds `lang` with `"3"` and then sets `requestedIndex` to `3`. The filter goes looking for code blocks whose language is literally `3`, finds none, and returns `null` before `requestedIndex` is ever consulted.

### Fix

Drop the pre-loop assignment. It was redundant to begin with — when the first token is not `code`, `selectorTokens` already contains it, and the loop assigns `lang` for every token that is not a number. Removing it leaves the loop as the single place tokens are classified:

```ts
const selectorTokens = firstToken === 'code' ? tokens.slice(1) : tokens;
```

Every other form is unaffected, because for them the loop reaches the same conclusion the pre-assignment did:

| input | before | after |
| --- | --- | --- |
| `/copy 3` | lang `"3"`, index 3 → no match | lang none, index 3 → block 3 |
| `/copy ts` | lang `ts` | lang `ts` |
| `/copy ts 2` | lang `ts`, index 2 | lang `ts`, index 2 |
| `/copy code` | lang none | lang none |
| `/copy code 2` | index 2 | index 2 |
| `/copy code ts 2` | lang `ts`, index 2 | lang `ts`, index 2 |

The `tokens.map((token) => token)` copy is dropped at the same time, since it was only there to mirror the `slice` branch and produces an identical array.

<details>
<summary>中文说明</summary>

`/copy 3` 永远复制不到任何内容。无论消息里有多少个代码块，它总是报 `No matching code block found in the last AI output.`。

界面为该命令展示的参数提示是：

```
/copy [code|<lang>|latex|inline-latex] [index]
```

两组都是可选的，因此只写一个序号正是用户被告知可以使用的形式——而它偏偏是唯一一个用不了的已文档化形式。

在 `selectCodeBlock` 中，第一个 token 在分类循环运行之前就被赋给了 `lang`：

```ts
const selectorTokens =
  firstToken === 'code' ? tokens.slice(1) : tokens.map((token) => token);
if (firstToken !== 'code') {
  lang = firstToken;          // 对 `/copy 3` 来说，这里是 "3"
}

for (const token of selectorTokens) {
  if (/^\d+$/.test(token)) {
    requestedIndex = Number(token);   // ……而这里同样是 3
  } else if (token.toLowerCase() !== 'code') {
    lang = token.toLowerCase();
  }
}

const candidates = lang ? blocks.filter((block) => block.lang === lang) : blocks;
if (candidates.length === 0) return null;
```

对于 `/copy 3`，这唯一的 token 被使用了两次：它先把 `lang` 置为 `"3"`，随后又把 `requestedIndex` 置为 `3`。过滤器于是去寻找语言名就叫 `3` 的代码块，一个也找不到，在 `requestedIndex` 被用到之前就返回了 `null`。

### 修复

去掉循环之前的那次赋值。它本来就是多余的——当第一个 token 不是 `code` 时，它已经包含在 `selectorTokens` 里，而循环会为每个非数字 token 赋值 `lang`。移除之后，循环就成为 token 分类的唯一场所：

```ts
const selectorTokens = firstToken === 'code' ? tokens.slice(1) : tokens;
```

其他所有形式都不受影响，因为对它们而言循环得出的结论与那次预先赋值完全相同：

| 输入 | 修复前 | 修复后 |
| --- | --- | --- |
| `/copy 3` | lang `"3"`、序号 3 → 无匹配 | 无 lang、序号 3 → 第 3 个代码块 |
| `/copy ts` | lang `ts` | lang `ts` |
| `/copy ts 2` | lang `ts`、序号 2 | lang `ts`、序号 2 |
| `/copy code` | 无 lang | 无 lang |
| `/copy code 2` | 序号 2 | 序号 2 |
| `/copy code ts 2` | lang `ts`、序号 2 | lang `ts`、序号 2 |

同时移除了 `tokens.map((token) => token)` 这次拷贝，它的存在只是为了与 `slice` 分支形式对称，产生的数组完全相同。

</details>

## Testing

Two new cases in `copyCommand.test.ts`:

- `/copy 2` against a message with a `ts` block and a `json` block copies the second block and reports `Code block 2 copied to the clipboard`;
- `/copy 9` against a message with one block still reports the missing-block message, so a bare index that is genuinely out of range is not turned into a silent wrong copy.

The out-of-range case passes before *and* after on purpose. Before the fix it produced the right message for the wrong reason (the language filter emptied the list); after the fix it produces it because no block has that index. Keeping it pins the behaviour either way.

```
before: Tests  1 failed | 12 passed (13)
after:  Tests  13 passed (13)
```

All 11 pre-existing cases — including `/copy code`, `/copy code 2`, `/copy code mermaid` and `/copy mermaid 1` — pass in both states, which is what establishes that the removed assignment was redundant for every form that already worked. `eslint` and `prettier` are clean on both changed files.
