### PR TITLE
fix(core): decline combined sed flags where -i is not last

### DIFF
--- a/packages/core/src/utils/sedEditParser.test.ts
+++ b/packages/core/src/utils/sedEditParser.test.ts
@@ -73,9 +73,30 @@ describe('sedEditParser', () => {
       flags: 'g',
       extendedRegex: true,
     });
+    expect(parseSedEditCommand("sed -Eri 's/foo|bar/baz/g' src/a.ts")).toEqual({
+      filePath: 'src/a.ts',
+      pattern: 'foo|bar',
+      replacement: 'baz',
+      flags: 'g',
+      extendedRegex: true,
+    });
     expect(
       parseSedEditCommand("sed -iE 's/foo|bar/baz/g' src/a.ts"),
     ).toBeNull();
+  });
+
+  // Everything after -i is the backup suffix, so -Eir is `-E` plus in-place
+  // with an `r` suffix: real sed writes src/a.tsr next to the edit. The
+  // simulation makes no backup, so these have to fall through to real sed --
+  // the same reason `-i.bak` is rejected below.
+  it('rejects combined flags where in-place is not last', () => {
+    expect(
+      parseSedEditCommand("sed -Eir 's/foo|bar/baz/g' src/a.ts"),
+    ).toBeNull();
+    expect(
+      parseSedEditCommand("sed -riE 's/foo|bar/baz/g' src/a.ts"),
+    ).toBeNull();
+    expect(parseSedEditCommand("sed -iri 's/foo/bar/' src/a.ts")).toBeNull();
   });
 
   it('parses expression flag forms', () => {

--- a/packages/core/src/utils/sedEditParser.ts
+++ b/packages/core/src/utils/sedEditParser.ts
@@ -152,10 +152,17 @@ function isSafeCombinedFlagArg(arg: string): boolean {
     return false;
   }
   const flags = arg.slice(1);
-  // GNU sed treats everything after -i in a combined flag as the backup suffix:
-  // -iE means in-place with .E backup, not -i + -E. Only forms with i last
+  // sed treats everything after -i in a combined flag as the backup suffix:
+  // -iE means in-place with an .E backup, not -i + -E. Only forms with i last
   // (for example, -Ei/-ri) are safe.
-  if (flags.startsWith('i') || !/^[Eri]+$/u.test(flags)) {
+  //
+  // Testing `startsWith('i')` only rejected i FIRST, not i anywhere but last,
+  // so -Eir and -riE were accepted. Real sed reads those as -E plus in-place
+  // with the backup suffix `r` / `E`, writing an f.txtr or f.txtE alongside
+  // the edit. The simulation creates no backup, so the user asked for one and
+  // silently did not get it -- the same reason `-i.bak` is already declined a
+  // few lines up, just spelled as a combined flag.
+  if (!/^[Er]*i?$/u.test(flags)) {
     return false;
   }
   return true;


### PR DESCRIPTION
## Description

`isSafeCombinedFlagArg` decides whether a bundled short-flag argument such as `-Ei` can be treated as separate flags. Its own comment states the rule:

> sed treats everything after `-i` in a combined flag as the backup suffix: `-iE` means in-place with an `.E` backup, not `-i` + `-E`. **Only forms with `i` last** (for example, `-Ei`/`-ri`) are safe.

The check does not implement that rule:

```ts
if (flags.startsWith('i') || !/^[Eri]+$/u.test(flags)) {
  return false;
}
```

`startsWith('i')` rejects `i` **first**, not `i` anywhere but last. `-Eir` does not start with `i` and matches `^[Eri]+$`, so it is accepted as three separate flags.

Real sed reads it as `-E` plus in-place with the backup suffix `r`:

```console
$ printf 'aaa\n' > f.txt
$ sed -Eir 's/a/b/' f.txt
$ ls
f.txt   f.txtr        <- the backup real sed wrote
```

The parser instead reports it as safe, so `shell.ts` intercepts the command and simulates the edit. The simulation writes the file but creates no backup, so the user asked for one and silently did not get it. Measured against the current parser:

```
sed -Ei  's/a/b/' f.txt   -> INTERCEPTED     (correct, i is last)
sed -ri  's/a/b/' f.txt   -> INTERCEPTED     (correct, i is last)
sed -iE  's/a/b/' f.txt   -> declined        (correct, i is first)
sed -Eir 's/a/b/' f.txt   -> INTERCEPTED     <- real sed writes f.txtr
sed -riE 's/a/b/' f.txt   -> INTERCEPTED     <- real sed writes f.txtE
```

This is the same hazard the parser already guards against one test away: `sed -i.bak 's/foo/bar/' a.ts` is rejected precisely because a backup suffix cannot be simulated. `-Eir` is that command spelled as a combined flag.

### Fix

Test the rule the comment describes — `i` last if present — with a single pattern:

```ts
if (!/^[Er]*i?$/u.test(flags)) {
  return false;
}
```

This subsumes the old `^[Eri]+$` character check, so unrelated flags are still rejected. Declining is the safe direction here: a declined command is not intercepted and real sed runs it, which is the parser's existing escape hatch, so the only cost is losing a fast path on an unusual flag spelling. Accepting wrongly loses a backup file the user asked for.

<details>
<summary>中文说明</summary>

`isSafeCombinedFlagArg` 负责判断像 `-Ei` 这样的短选项合并写法能否被拆成独立的标志。它自己的注释写明了规则：

> sed 会把合并标志中 `-i` 之后的一切都当作备份后缀：`-iE` 表示原地编辑并生成 `.E` 备份，而不是 `-i` + `-E`。**只有 `i` 在最后**的写法（例如 `-Ei`/`-ri`）才是安全的。

但检查并没有实现该规则：

```ts
if (flags.startsWith('i') || !/^[Eri]+$/u.test(flags)) {
  return false;
}
```

`startsWith('i')` 拒绝的是 `i` 在**开头**的情况，而不是"`i` 不在最后"。`-Eir` 并不以 `i` 开头，且能匹配 `^[Eri]+$`，于是被当成三个独立标志接受了。

真实的 sed 会把它理解为 `-E` 加上原地编辑、备份后缀为 `r`：

```console
$ printf 'aaa\n' > f.txt
$ sed -Eir 's/a/b/' f.txt
$ ls
f.txt   f.txtr        <- 真实 sed 写出的备份
```

而解析器却判定它安全，于是 `shell.ts` 拦截该命令并模拟这次编辑。模拟会写入文件，却不会创建备份——用户要了备份，却悄无声息地没有拿到。针对当前解析器的实测结果：

```
sed -Ei  's/a/b/' f.txt   -> 拦截     （正确，i 在最后）
sed -ri  's/a/b/' f.txt   -> 拦截     （正确，i 在最后）
sed -iE  's/a/b/' f.txt   -> 放行     （正确，i 在开头）
sed -Eir 's/a/b/' f.txt   -> 拦截     <- 真实 sed 会写出 f.txtr
sed -riE 's/a/b/' f.txt   -> 拦截     <- 真实 sed 会写出 f.txtE
```

这与解析器在相邻测试中已经防住的风险完全相同：`sed -i.bak 's/foo/bar/' a.ts` 之所以被拒绝，正是因为备份后缀无法被模拟。`-Eir` 就是同一条命令的合并标志写法。

### 修复

用一个模式来检验注释所描述的规则——若出现 `i`，它必须在最后：

```ts
if (!/^[Er]*i?$/u.test(flags)) {
  return false;
}
```

它同时涵盖了原先的 `^[Eri]+$` 字符检查，因此无关标志仍会被拒绝。在这里，倾向于放行是安全的方向：被放行的命令不会被拦截，而是交由真实 sed 执行——这是解析器既有的兜底机制——因此代价只是在一种少见的标志写法上失去快速路径。而错误地接受，代价是丢掉用户明确要求的备份文件。

</details>

## Testing

`packages/core/src/utils/sedEditParser.test.ts`:

- a new case asserting `-Eir`, `-riE` and `-iri` all return `null`, so the command falls through to real sed;
- `-Eri` added to the existing safe-combination test. Three flags with `i` last is still intercepted, which is the over-correction guard: it passes before *and* after, so the fix cannot be satisfied by rejecting every multi-flag form.

```
before: Tests  1 failed | 34 passed (35)
after:  Tests  35 passed (35)
```

All 34 pre-existing cases pass in both states, including `-Ei`, `-ri` and `-iE`. The sed-related cases in `src/tools/shell.test.ts` also pass (`28 passed | 252 skipped`). `eslint` and `prettier --check` are clean on both changed files.

The `f.txtr` backup shown above was produced by BSD sed on macOS, which is what I have locally; the "everything after `-i` is the backup suffix" behaviour is shared with GNU sed, and the existing comment in the file describes it for GNU.
