### PR TITLE
feat(autofix): retry deterministic rejection once

### DIFF
--- a/.github/scripts/run-autofix-review-verification.sh
+++ b/.github/scripts/run-autofix-review-verification.sh
@@ -40,6 +40,35 @@ fi
 git config core.hooksPath /dev/null
 git checkout "${BRANCH}"
 
+GATE_LOG="${WORKDIR}/gate-output.log"
+: > "${GATE_LOG}"
+reject_fix() {
+  echo "❌ ${1}"
+  # Declare the verdict before writing its detail. An empty outcome on a failed
+  # step means the gate itself crashed, so losing the detail file must not turn
+  # a deterministic rejection into an infrastructure retry.
+  echo "outcome=failed" >> "${GITHUB_OUTPUT}"
+  echo "retryable=true" >> "${GITHUB_OUTPUT}"
+  {
+    echo "**${1}**"
+    echo
+    # Captured output can contain triple-backtick fences.
+    echo '````'
+    tail -c 3000 "${GATE_LOG}" 2> /dev/null
+    echo '````'
+  } > "${WORKDIR}/gate-rejection.md" ||
+    echo "::warning::could not write the gate rejection detail; the verdict stands."
+  exit 1
+}
+run_check() {
+  # pipefail makes the pipeline carry the command's status, not tee's.
+  local label="${1}"
+  shift
+  if ! "$@" 2>&1 | tee -a "${GATE_LOG}"; then
+    reject_fix "${label}"
+  fi
+}
+
 # Settings-schema freshness is a STRUCTURAL guard, checked BEFORE the
 # no-op/unchanged return: on a stale-schema PR the agent can wrongly
 # write no-action.md, and without this the no-op path would report the
@@ -53,9 +82,11 @@ git checkout "${BRANCH}"
 # that predates the script does not contain it (bash would exit 127
 # and kill the gate with no outcome), and the gate logic must come
 # from the trusted base, not the branch under verification.
-bash "${RUNNER_TEMP}/check-settings-schema.sh"
-git diff --name-only "origin/main...${BRANCH}" \
-  | bash "${RUNNER_TEMP}/check-autofix-contracts.sh"
+run_check 'settings schema is stale on the agent-committed fix' \
+  bash "${RUNNER_TEMP}/check-settings-schema.sh"
+CHANGED_FILES="$(git diff --name-only "origin/main...${BRANCH}")"
+run_check 'cross-package contract verification failed' \
+  bash "${RUNNER_TEMP}/check-autofix-contracts.sh" <<< "${CHANGED_FILES}"
 
 if git diff --quiet "origin/${BRANCH}...${BRANCH}"; then
   # No new commit. That is only legitimate as a deliberate no-action.
@@ -75,51 +106,6 @@ if [[ ! -s "${WORKDIR}/address-summary.md" ]]; then
   echo "outcome=failed" >> "${GITHUB_OUTPUT}"
   exit 1
 fi
-
-# Every check below can legitimately REJECT the agent's attempt, so
-# each declares that verdict explicitly. That is what lets the handoff
-# tell a rejection apart from the gate's OWN death: an empty outcome
-# on a failed job means the gate never reached a verdict (its own bug,
-# an infra blip), and the agent's work must then be retried rather
-# than buried by a watermark advance.
-# Capture each check's output. A rejection has to tell the agent WHY
-# its change was refused: without that, the next round re-reads only
-# the original review feedback and re-makes the same mistake - #7208
-# was handed to a human over a two-character TS4111 fix its own
-# compiler output already spelled out.
-GATE_LOG="${WORKDIR}/gate-output.log"
-: > "${GATE_LOG}"
-reject_fix() {
-  echo "❌ ${1}"
-  # Declare the verdict FIRST. The handoff routes on outcome=, and an
-  # empty outcome on a failed job means "the gate never reached a
-  # verdict" — i.e. a crash, which is RETRIED. So a rejection that
-  # dies while writing its detail file would be re-attempted forever
-  # instead of reported once. A detail we cannot write is a degraded
-  # message; it must never cost the verdict, hence this order and the
-  # non-fatal write below.
-  echo "outcome=failed" >> "${GITHUB_OUTPUT}"
-  {
-    echo "**${1}**"
-    echo
-    # A four-backtick fence cannot be closed by a ``` line, so
-    # captured output containing its own fences stays inside the
-    # block when this is posted verbatim as a PR comment.
-    echo '````'
-    tail -c 3000 "${GATE_LOG}" 2> /dev/null
-    echo '````'
-  } > "${WORKDIR}/gate-rejection.md" ||
-    echo "::warning::could not write the gate rejection detail; the verdict stands."
-  exit 1
-}
-run_check() {
-  # pipefail makes the pipeline carry the command's status, not tee's.
-  local label="${1}"
-  shift
-  if ! "$@" 2>&1 | tee -a "${GATE_LOG}"; then
-    reject_fix "${label}"
-  fi
-}
 
 echo '🔬 Re-running deterministic checks (independent of the agent)...'
 run_check 'build failed on the agent-committed fix' npm run build

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -3071,6 +3071,36 @@ jobs:
           QWEN_TIMEOUT_MS: '1080000'
           CONFLICT: '${{ steps.prepare.outputs.conflict }}'
           BASE: 'main'
+          SETTINGS_JSON: |-
+            {
+              "maxSessionTurns": 400,
+              "coreTools": [
+                "read_file",
+                "read_many_files",
+                "glob",
+                "search_file_content",
+                "write_file",
+                "run_shell_command(cat)",
+                "run_shell_command(git add)",
+                "run_shell_command(git checkout)",
+                "run_shell_command(git commit)",
+                "run_shell_command(git diff)",
+                "run_shell_command(git log)",
+                "run_shell_command(git merge)",
+                "run_shell_command(git status)",
+                "run_shell_command(ls)",
+                "run_shell_command(mkdir)",
+                "run_shell_command(npm run build)",
+                "run_shell_command(npm run typecheck)",
+                "run_shell_command(npm run lint)",
+                "run_shell_command(npx vitest)",
+                "run_shell_command(npm run generate:settings-schema)",
+                "run_shell_command(pwd)"
+              ],
+              "tools": {
+                "sandbox": "docker"
+              }
+            }
         run: |-
           echo "attempted=true" >> "${GITHUB_OUTPUT}"
           if [[ -z "${OPENAI_API_KEY:-}" ]]; then
@@ -3103,12 +3133,12 @@ jobs:
             "${WORKDIR}/failure.md" \
             "${WORKDIR}/handoff.md" \
             "${WORKDIR}/gate-output.log" \
-            "${WORKDIR}/gate-rejection.md" \
             "${WORKDIR}/agent-api-error" \
             "${WORKDIR}/agent-api-error-kind" \
             "${WORKDIR}/agent-timeout"
           rm -rf "${QWEN_HOME}"
-          mkdir -p "${QWEN_HOME}"
+          mkdir -p .qwen "${QWEN_HOME}"
+          printf '%s\n' "${SETTINGS_JSON}" > .qwen/settings.json
           git config core.hooksPath .husky
           node "${RUNNER_TEMP}/autofix-skill/scripts/run-agent.mjs" \
             --mode address-review \

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -3839,7 +3839,7 @@ jobs:
         env:
           GITHUB_TOKEN: '${{ secrets.CI_DEV_BOT_PAT }}'
           EFFECTIVE_ROUND: '${{ steps.prepare.outputs.effective_round }}'
-          OUTCOME: '${{ steps.verify.outputs.outcome }}'
+          OUTCOME: '${{ steps.final_verify.outputs.outcome }}'
           RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
           # The id the announcement wrote. Empty means this round never
           # announced (its step was skipped, or the post itself failed) — then

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2366,7 +2366,7 @@ jobs:
     if: |-
       ${{ needs.review-scan.outputs.has_targets == 'true' }}
     runs-on: 'ubuntu-latest'
-    timeout-minutes: 120
+    timeout-minutes: 150
     permissions:
       contents: 'read'
     strategy:
@@ -2970,11 +2970,12 @@ jobs:
         # revalidation in prepare) — no agent run, no marker, no comment.
         if: |-
           ${{ steps.prepare.outputs.stale != 'true' }}
-        # Bound the agent well below the 120-minute job timeout so a runaway agent
+        # Bound the agent well below the 150-minute job timeout so a runaway agent
         # fails THIS step (not the whole job), leaving the always() verify and
         # report steps time to run and post a handoff. A job-level timeout would
-        # cancel those steps too and leave the loop silent. 80 leaves ~40 minutes
-        # of headroom for setup (install/build) plus verify + report.
+        # cancel those steps too and leave the loop silent. The 80-minute primary
+        # attempt plus one 20-minute repair leaves ~50 minutes for setup, two
+        # verification passes, and reporting.
         timeout-minutes: 80
         env:
           PR: '${{ env.PR }}'
@@ -3050,8 +3051,106 @@ jobs:
         id: 'verify'
         if: |-
           ${{ always() && steps.prepare.outputs.stale != 'true' }}
+        continue-on-error: true
         run: |-
           bash "${RUNNER_TEMP}/run-autofix-review-verification.sh"
+
+      - name: 'Repair deterministic rejection'
+        id: 'repair'
+        if: |-
+          ${{ always() && steps.verify.outputs.retryable == 'true' }}
+        timeout-minutes: 20
+        env:
+          PR: '${{ env.PR }}'
+          ISSUE: '${{ env.ISSUE }}'
+          OPENAI_API_KEY: '${{ secrets.AUTOFIX_OPENAI_API_KEY }}'
+          OPENAI_BASE_URL: '${{ secrets.AUTOFIX_OPENAI_BASE_URL || secrets.OPENAI_BASE_URL }}'
+          OPENAI_MODEL: '${{ vars.QWEN_AUTOFIX_MODEL || vars.QWEN_PR_REVIEW_MODEL }}'
+          NO_PROXY: '127.0.0.1,localhost,::1'
+          QWEN_HOME: '${{ runner.temp }}/qwen-autofix-review-home'
+          QWEN_TIMEOUT_MS: '1080000'
+          CONFLICT: '${{ steps.prepare.outputs.conflict }}'
+          BASE: 'main'
+        run: |-
+          echo "attempted=true" >> "${GITHUB_OUTPUT}"
+          if [[ -z "${OPENAI_API_KEY:-}" ]]; then
+            echo '::error::AUTOFIX_OPENAI_API_KEY secret is required for Qwen Autofix.'
+            exit 1
+          fi
+          if [[ ! -s "${WORKDIR}/gate-rejection.md" ]]; then
+            echo '::error::Retryable verification rejection has no gate-rejection.md.'
+            exit 1
+          fi
+          {
+            cat "${WORKDIR}/feedback.md"
+            if [[ -s "${WORKDIR}/address-summary.md" ]]; then
+              echo
+              echo '## Previous attempt summary'
+              cat "${WORKDIR}/address-summary.md"
+            fi
+            echo
+            echo '## Same-run verification repair'
+            echo
+            echo 'The previous commit was rejected by deterministic verification.'
+            echo 'Keep that commit and add one follow-up commit that fixes this rejection:'
+            echo
+            cat "${WORKDIR}/gate-rejection.md"
+          } > "${WORKDIR}/feedback.retry.md"
+          mv "${WORKDIR}/feedback.retry.md" "${WORKDIR}/feedback.md"
+          rm -f \
+            "${WORKDIR}/address-summary.md" \
+            "${WORKDIR}/no-action.md" \
+            "${WORKDIR}/failure.md" \
+            "${WORKDIR}/handoff.md" \
+            "${WORKDIR}/gate-output.log" \
+            "${WORKDIR}/gate-rejection.md" \
+            "${WORKDIR}/agent-api-error" \
+            "${WORKDIR}/agent-api-error-kind" \
+            "${WORKDIR}/agent-timeout"
+          rm -rf "${QWEN_HOME}"
+          mkdir -p "${QWEN_HOME}"
+          git config core.hooksPath .husky
+          node "${RUNNER_TEMP}/autofix-skill/scripts/run-agent.mjs" \
+            --mode address-review \
+            --pr "${PR}" \
+            --issue "${ISSUE}" \
+            --workdir "${WORKDIR}" \
+            --conflict "${CONFLICT}" \
+            --base "${BASE}"
+
+      - name: 'Repair verification gate'
+        id: 'verify_repair'
+        if: |-
+          ${{ always() && steps.repair.outputs.attempted == 'true' }}
+        continue-on-error: true
+        run: |-
+          bash "${RUNNER_TEMP}/run-autofix-review-verification.sh"
+
+      - name: 'Finalize verification'
+        id: 'final_verify'
+        if: |-
+          ${{ always() && steps.prepare.outputs.stale != 'true' }}
+        env:
+          FIRST_OUTCOME: '${{ steps.verify.outputs.outcome }}'
+          FIRST_COMMITTED: '${{ steps.verify.outputs.committed }}'
+          REPAIR_ATTEMPTED: '${{ steps.repair.outputs.attempted }}'
+          REPAIR_OUTCOME: '${{ steps.verify_repair.outputs.outcome }}'
+          REPAIR_COMMITTED: '${{ steps.verify_repair.outputs.committed }}'
+        run: |-
+          OUTCOME="${FIRST_OUTCOME}"
+          COMMITTED="${FIRST_COMMITTED}"
+          if [[ "${REPAIR_ATTEMPTED}" == 'true' ]]; then
+            OUTCOME="${REPAIR_OUTCOME}"
+            COMMITTED="${REPAIR_COMMITTED:-${FIRST_COMMITTED}}"
+          fi
+          echo "outcome=${OUTCOME}" >> "${GITHUB_OUTPUT}"
+          if [[ -n "${COMMITTED}" ]]; then
+            echo "committed=${COMMITTED}" >> "${GITHUB_OUTPUT}"
+          fi
+          case "${OUTCOME}" in
+            fixed|noop) ;;
+            *) exit 1 ;;
+          esac
 
       - name: 'Show run artifacts'
         if: |-
@@ -3079,14 +3178,14 @@ jobs:
 
       - name: 'Push and report'
         if: |-
-          ${{ always() && needs.route.outputs.dry_run != 'true' && (steps.verify.outputs.outcome == 'fixed' || steps.verify.outputs.outcome == 'noop') }}
+          ${{ always() && needs.route.outputs.dry_run != 'true' && (steps.final_verify.outputs.outcome == 'fixed' || steps.final_verify.outputs.outcome == 'noop') }}
         env:
           # CI_DEV_BOT_PAT (the qwen-code-dev-bot PAT) pushes the branch and
           # posts the report as qwen-code-dev-bot, the same identity that opened
           # the PR. The default GITHUB_TOKEN cannot do either on a bot-owned PR
           # in a way that re-triggers CI.
           GITHUB_TOKEN: '${{ secrets.CI_DEV_BOT_PAT }}'
-          OUTCOME: '${{ steps.verify.outputs.outcome }}'
+          OUTCOME: '${{ steps.final_verify.outputs.outcome }}'
           CONFLICT: '${{ steps.prepare.outputs.conflict }}'
           NEWEST: '${{ steps.prepare.outputs.newest }}'
           EFFECTIVE_ROUND: '${{ steps.prepare.outputs.effective_round }}'
@@ -3299,8 +3398,8 @@ jobs:
         if: |-
           ${{ always() && (needs.route.outputs.dry_run == 'true' || failure() || cancelled()) }}
         env:
-          OUTCOME: '${{ steps.verify.outputs.outcome }}'
-          COMMITTED: '${{ steps.verify.outputs.committed }}'
+          OUTCOME: '${{ steps.final_verify.outputs.outcome }}'
+          COMMITTED: '${{ steps.final_verify.outputs.committed }}'
           CONFLICT: '${{ steps.prepare.outputs.conflict }}'
           DRY_RUN: '${{ needs.route.outputs.dry_run }}'
           GITHUB_TOKEN: '${{ secrets.CI_DEV_BOT_PAT }}'

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -4677,6 +4677,14 @@ describe('qwen-autofix workflow', () => {
       status: 1,
       written: expect.stringContaining('outcome=failed'),
     });
+    expect(run({ FIRST_OUTCOME: '' })).toMatchObject({ status: 1 });
+    expect(
+      run({
+        FIRST_OUTCOME: 'failed',
+        REPAIR_ATTEMPTED: 'true',
+        REPAIR_OUTCOME: '',
+      }),
+    ).toMatchObject({ status: 1 });
   });
 
   it('posts a human-handoff marker when review addressing reaches a terminal handoff', () => {

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -4586,6 +4586,9 @@ describe('qwen-autofix workflow', () => {
     expect(reviewAddressReportStep).toContain(
       "COMMITTED: '${{ steps.final_verify.outputs.committed }}'",
     );
+    expect(finalizeStatusCommentStep).toContain(
+      "OUTCOME: '${{ steps.final_verify.outputs.outcome }}'",
+    );
 
     const body = finalizeVerificationStep
       .match(/ {8}run: \|-\n([\s\S]*)$/)?.[1]
@@ -4618,6 +4621,10 @@ describe('qwen-autofix workflow', () => {
       status: 0,
       written: expect.stringContaining('outcome=fixed'),
     });
+    expect(run({ FIRST_OUTCOME: 'noop' })).toMatchObject({
+      status: 0,
+      written: expect.stringContaining('outcome=noop'),
+    });
     expect(
       run({
         FIRST_OUTCOME: 'failed',
@@ -4629,6 +4636,17 @@ describe('qwen-autofix workflow', () => {
     ).toMatchObject({
       status: 0,
       written: expect.stringContaining('outcome=fixed'),
+    });
+    expect(
+      run({
+        FIRST_OUTCOME: 'failed',
+        FIRST_COMMITTED: 'true',
+        REPAIR_ATTEMPTED: 'true',
+        REPAIR_OUTCOME: 'fixed',
+      }),
+    ).toMatchObject({
+      status: 0,
+      written: expect.stringContaining('committed=true'),
     });
     expect(
       run({

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -4538,6 +4538,20 @@ describe('qwen-autofix workflow', () => {
     expect(repairDeterministicRejectionStep).toContain(
       "QWEN_TIMEOUT_MS: '1080000'",
     );
+    const settingsJson = (step) =>
+      step.match(/SETTINGS_JSON: \|-\n([\s\S]*?)\n {8}run: \|-/)?.[1] ?? '';
+    expect(settingsJson(repairDeterministicRejectionStep)).toBe(
+      settingsJson(triageAndAddressStep),
+    );
+    expect(settingsJson(repairDeterministicRejectionStep)).toContain(
+      '"sandbox": "docker"',
+    );
+    expect(repairDeterministicRejectionStep).toContain(
+      'mkdir -p .qwen "${QWEN_HOME}"',
+    );
+    expect(repairDeterministicRejectionStep).toContain(
+      'printf \'%s\\n\' "${SETTINGS_JSON}" > .qwen/settings.json',
+    );
     expect(repairDeterministicRejectionStep).toContain(
       'echo "attempted=true" >> "${GITHUB_OUTPUT}"',
     );
@@ -4547,6 +4561,11 @@ describe('qwen-autofix workflow', () => {
     expect(repairDeterministicRejectionStep).toContain(
       'Keep that commit and add one follow-up commit',
     );
+    const repairCleanup =
+      repairDeterministicRejectionStep.match(
+        /rm -f \\\n([\s\S]*?)\n {10}rm -rf "\$\{QWEN_HOME\}"/,
+      )?.[1] ?? '';
+    expect(repairCleanup).not.toContain('gate-rejection.md');
     expect(repairDeterministicRejectionStep).not.toContain(
       '"${WORKDIR}/resolved-comments.txt"',
     );

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -100,6 +100,18 @@ const triageAndAddressStep =
   workflow.match(
     /- name: 'Triage and address'[\s\S]*?(?=\n[ ]{6}- name: 'Verification gate')/,
   )?.[0] ?? '';
+const repairDeterministicRejectionStep =
+  workflow.match(
+    /- name: 'Repair deterministic rejection'[\s\S]*?(?=\n[ ]{6}- name: 'Repair verification gate')/,
+  )?.[0] ?? '';
+const repairVerificationGateStep =
+  workflow.match(
+    /- name: 'Repair verification gate'[\s\S]*?(?=\n[ ]{6}- name: 'Finalize verification')/,
+  )?.[0] ?? '';
+const finalizeVerificationStep =
+  workflow.match(
+    /- name: 'Finalize verification'[\s\S]*?(?=\n[ ]{6}- name: 'Show run artifacts')/,
+  )?.[0] ?? '';
 const prepareBranchAndFeedbackStep =
   workflow.match(
     /- name: 'Prepare branch and feedback'[\s\S]*?(?=\n[ ]{6}- name: 'Post autofix status comment')/,
@@ -301,12 +313,12 @@ describe('qwen-autofix workflow', () => {
     // discards itself — no agent run, no marker, no comment.
     expect(prepareBranchAndFeedbackStep).toContain('LIVE_EVAL_WM');
     expect(prepareBranchAndFeedbackStep).toContain('stale duplicate target');
-    // Four gates, and both status-comment steps are among them: a discarded
-    // duplicate must neither announce a round it will never run nor rewrite
-    // the status the real round already finalised.
+    // Addressing, the first verification, the final verdict, and both status
+    // comment steps discard stale targets. The repair is gated by the first
+    // verdict, so it cannot start for a stale target.
     expect(
       workflow.split("steps.prepare.outputs.stale != 'true'").length - 1,
-    ).toBe(4);
+    ).toBe(5);
     expect(reviewScanJob).toContain(
       'capture("^review-address \\\\((?<pr>[0-9]+),")',
     );
@@ -3769,6 +3781,7 @@ describe('qwen-autofix workflow', () => {
       assessCandidatesStep,
       developFixStep,
       triageAndAddressStep,
+      repairDeterministicRejectionStep,
     ];
     for (const step of qwenSteps) {
       expect(step.length).toBeGreaterThan(0);
@@ -3790,6 +3803,9 @@ describe('qwen-autofix workflow', () => {
     );
     expect(developFixStep).toContain('rm -f "${WORKDIR}/failure.md"');
     expect(triageAndAddressStep).toContain('rm -f "${WORKDIR}/failure.md"');
+    expect(repairDeterministicRejectionStep).toContain(
+      '"${WORKDIR}/failure.md"',
+    );
   });
 
   it('keeps agent decision logic in the project autofix skill', () => {
@@ -3827,6 +3843,9 @@ describe('qwen-autofix workflow', () => {
     expect(triageAndAddressStep).toContain(
       'node "${RUNNER_TEMP}/autofix-skill/scripts/run-agent.mjs" \\\n            --mode address-review',
     );
+    expect(repairDeterministicRejectionStep).toContain(
+      'node "${RUNNER_TEMP}/autofix-skill/scripts/run-agent.mjs" \\\n            --mode address-review',
+    );
     // Staging must MIRROR the skill layout: run-agent.mjs resolves its
     // SKILL as `<own dir>/../SKILL.md`, so the staged runner and a staged
     // SKILL.md must sit in autofix-skill/{scripts/run-agent.mjs,SKILL.md}.
@@ -3856,6 +3875,7 @@ describe('qwen-autofix workflow', () => {
       assessCandidatesStep,
       developFixStep,
       triageAndAddressStep,
+      repairDeterministicRejectionStep,
     ]) {
       expect(step).not.toContain('## Role');
       expect(step).not.toContain('## Workflow');
@@ -4162,6 +4182,7 @@ describe('qwen-autofix workflow', () => {
       assessCandidatesStep,
       developFixStep,
       triageAndAddressStep,
+      repairDeterministicRejectionStep,
     ];
     for (const step of qwenSteps) {
       expect(step.length).toBeGreaterThan(0);
@@ -4505,6 +4526,120 @@ describe('qwen-autofix workflow', () => {
     expect(reviewAddressReportStep).not.toContain(
       "steps.verify.outputs.outcome == 'failed'",
     );
+  });
+
+  it('repairs one deterministic rejection and finalizes only the last verdict', () => {
+    const reviewVerificationGateStep = verificationGateSteps[1];
+    expect(reviewVerificationGateStep).toContain('continue-on-error: true');
+    expect(repairDeterministicRejectionStep).toContain(
+      "steps.verify.outputs.retryable == 'true'",
+    );
+    expect(repairDeterministicRejectionStep).toContain('timeout-minutes: 20');
+    expect(repairDeterministicRejectionStep).toContain(
+      "QWEN_TIMEOUT_MS: '1080000'",
+    );
+    expect(repairDeterministicRejectionStep).toContain(
+      'echo "attempted=true" >> "${GITHUB_OUTPUT}"',
+    );
+    expect(repairDeterministicRejectionStep).toContain(
+      'cat "${WORKDIR}/gate-rejection.md"',
+    );
+    expect(repairDeterministicRejectionStep).toContain(
+      'Keep that commit and add one follow-up commit',
+    );
+    expect(repairDeterministicRejectionStep).not.toContain(
+      '"${WORKDIR}/resolved-comments.txt"',
+    );
+    expect(
+      repairDeterministicRejectionStep.match(
+        /node "\$\{RUNNER_TEMP\}\/autofix-skill\/scripts\/run-agent\.mjs"/g,
+      ) ?? [],
+    ).toHaveLength(1);
+    expect(
+      workflow.match(/- name: 'Repair deterministic rejection'/g) ?? [],
+    ).toHaveLength(1);
+    expect(repairVerificationGateStep).toContain('continue-on-error: true');
+    expect(repairVerificationGateStep).toContain(
+      "steps.repair.outputs.attempted == 'true'",
+    );
+    expect(repairVerificationGateStep).toContain(
+      'bash "${RUNNER_TEMP}/run-autofix-review-verification.sh"',
+    );
+    expect(
+      reviewVerificationRunner.match(/retryable=true/g) ?? [],
+    ).toHaveLength(1);
+    expect(reviewVerificationRunner).toContain(
+      "run_check 'settings schema is stale on the agent-committed fix'",
+    );
+    expect(reviewVerificationRunner).toContain(
+      "run_check 'cross-package contract verification failed'",
+    );
+    expect(pushAndReportStep).toContain(
+      "steps.final_verify.outputs.outcome == 'fixed'",
+    );
+    expect(pushAndReportStep).toContain(
+      "OUTCOME: '${{ steps.final_verify.outputs.outcome }}'",
+    );
+    expect(reviewAddressReportStep).toContain(
+      "OUTCOME: '${{ steps.final_verify.outputs.outcome }}'",
+    );
+    expect(reviewAddressReportStep).toContain(
+      "COMMITTED: '${{ steps.final_verify.outputs.committed }}'",
+    );
+
+    const body = finalizeVerificationStep
+      .match(/ {8}run: \|-\n([\s\S]*)$/)?.[1]
+      .split('\n')
+      .map((line) => (line.startsWith('          ') ? line.slice(10) : line))
+      .join('\n');
+    expect(body).toBeTruthy();
+    const run = (env) => {
+      const dir = mkdtempSync(join(tmpdir(), 'final-verify-'));
+      const output = join(dir, 'output');
+      const result = spawnSync('bash', ['-c', `set -eo pipefail\n${body}`], {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          GITHUB_OUTPUT: output,
+          FIRST_OUTCOME: '',
+          FIRST_COMMITTED: '',
+          REPAIR_ATTEMPTED: '',
+          REPAIR_OUTCOME: '',
+          REPAIR_COMMITTED: '',
+          ...env,
+        },
+      });
+      const written = existsSync(output) ? readFileSync(output, 'utf8') : '';
+      rmSync(dir, { recursive: true, force: true });
+      return { status: result.status, written };
+    };
+
+    expect(run({ FIRST_OUTCOME: 'fixed' })).toMatchObject({
+      status: 0,
+      written: expect.stringContaining('outcome=fixed'),
+    });
+    expect(
+      run({
+        FIRST_OUTCOME: 'failed',
+        FIRST_COMMITTED: 'true',
+        REPAIR_ATTEMPTED: 'true',
+        REPAIR_OUTCOME: 'fixed',
+        REPAIR_COMMITTED: 'true',
+      }),
+    ).toMatchObject({
+      status: 0,
+      written: expect.stringContaining('outcome=fixed'),
+    });
+    expect(
+      run({
+        FIRST_OUTCOME: 'failed',
+        REPAIR_ATTEMPTED: 'true',
+        REPAIR_OUTCOME: 'failed',
+      }),
+    ).toMatchObject({
+      status: 1,
+      written: expect.stringContaining('outcome=failed'),
+    });
   });
 
   it('posts a human-handoff marker when review addressing reaches a terminal handoff', () => {
@@ -5365,6 +5500,8 @@ describe('qwen-autofix workflow', () => {
     // calls reject_fix on failure - so the verdict is declared AND the reason
     // is captured for the retry.
     for (const check of [
+      "run_check 'settings schema is stale on the agent-committed fix'",
+      "run_check 'cross-package contract verification failed'",
       "run_check 'build failed on the agent-committed fix' npm run build",
       "run_check 'typecheck failed on the agent-committed fix' npm run typecheck",
       "run_check 'lint failed on the agent-committed fix' npm run lint",
@@ -5389,6 +5526,7 @@ describe('qwen-autofix workflow', () => {
     }
     expect(status).not.toBe(0);
     expect(readFileSync(out, 'utf8')).toContain('outcome=failed');
+    expect(readFileSync(out, 'utf8')).toContain('retryable=true');
     // The verdict must be declared BEFORE the detail file is written, and the
     // write must be non-fatal. An empty outcome on a failed job reads as "the
     // gate never reached a verdict" — a CRASH, which is retried — so a
@@ -6040,16 +6178,18 @@ describe('qwen-autofix workflow', () => {
   });
 
   it('replays the handoff decision and terminal-round transitions under bash', () => {
-    // The agent step is bounded below the 120-minute job timeout so a runaway
+    // The primary + repair steps are bounded below the 150-minute job timeout
+    // so a runaway
     // agent fails the STEP, not the job, leaving the always() report step time to
     // run (a job-level timeout would cancel that step too and go silent).
-    // 120 is the review-address job timeout (unique; other jobs use 5/15/180).
-    expect(workflow).toContain('timeout-minutes: 120');
+    // 150 is the review-address job timeout (unique; other jobs use 5/15/180).
+    expect(workflow).toContain('timeout-minutes: 150');
     const addressStep =
       workflow.match(
         /- name: 'Triage and address'[\s\S]*?(?=\n {6}- name: )/,
       )?.[0] ?? '';
     expect(addressStep).toContain('timeout-minutes: 80');
+    expect(repairDeterministicRejectionStep).toContain('timeout-minutes: 20');
 
     // Replay the ACTUAL POST_HANDOFF decision extracted from the workflow so the
     // state transitions are exercised, not merely string-matched.


### PR DESCRIPTION
## What this PR does

Adds one bounded same-run repair pass when the first post-agent verification explicitly rejects a change for a deterministic reason. The rejection output is fed back to the agent, which keeps the previous commit and may add one follow-up commit; a second verification then becomes the only verdict used for publishing and failure reporting. The primary agent remains capped at 80 minutes, the repair at 20 minutes, and the job at 150 minutes.

This does not add a new takeover trigger. It only runs inside the existing review-address lifecycle after a PR has already been engaged through the current `@qwen-code /takeover` flow (or is otherwise already managed by AutoFix).

## Why it's needed

A deterministic verification rejection currently ends the run even though the exact build, typecheck, lint, schema, contract, or related-test failure is already available. That delays a small mechanical correction until a later scan or human handoff. One immediate, explicitly bounded repair attempt shortens that loop without turning infrastructure failures, model failures, missing credentials, or gate crashes into an unbounded retry.

## Reviewer Test Plan

### How to verify

- Confirm that a deterministic verification rejection emits one retry signal, preserves the first commit, supplies the captured rejection to one repair attempt, and runs verification once more.
- Confirm that a successful first verification skips the repair, while a second rejection remains terminal and cannot start a third attempt.
- Confirm that publishing and failure reporting consume the final verification verdict, not the first rejected verdict.
- Confirm that agent aborts, missing output, Git failures, gate crashes, model/auth failures, and stale targets do not enter the new same-run repair path.
- Confirm that the takeover command and scheduling routes are unchanged.
- Local validation passed: `bash -n .github/scripts/run-autofix-review-verification.sh .github/scripts/check-autofix-contracts.sh`; `npx prettier --check .github/workflows/qwen-autofix.yml scripts/tests/qwen-autofix-workflow.test.js`; `GH_TOKEN=test-only GH_HOST=127.0.0.1 npx vitest run scripts/tests/qwen-autofix-workflow.test.js` (102/102); `npm run build`; `npm run typecheck`; `npm run lint`; `npm run check-i18n`; settings-schema verification; and the Web Shell tool-formatting drift test (2/2).

### Evidence (Before & After)

N/A — workflow-only change with no user-visible UI.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Node.js 25.9.0, npm 11.12.1, local checkout without a sandboxed model invocation.

## Risk & Scope

- Main risk or tradeoff: a deterministically rejected takeover round may spend one additional model invocation and one additional verification pass; both are explicitly bounded and the job budget is increased accordingly.
- Not validated / out of scope: live GitHub Actions credentials and a real model repair invocation; CI remains responsible for hosted-runner coverage.
- Breaking changes / migration notes: none. Trigger routing and takeover authorization are unchanged.

## Linked Issues

Closes #7638

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当第一次 agent 后验证因确定性原因明确拒绝改动时，增加一次有界的同轮修复。拒绝输出会反馈给 agent；agent 保留上一次提交，并可以追加一个修复提交；随后第二次验证成为发布与失败报告唯一使用的最终结论。主 agent 仍限制为 80 分钟，修复限制为 20 分钟，整个 job 限制为 150 分钟。

本 PR 不增加新的 takeover 触发方式。它只在 PR 已通过现有 `@qwen-code /takeover` 流程接管（或已经由 AutoFix 管理）后，进入既有 review-address 生命周期时运行。

## 为什么需要

目前确定性验证失败会直接结束本轮，即使具体的构建、类型检查、lint、schema、契约或相关测试错误已经明确可用。这会让一个很小的机械修复延迟到下一次扫描或人工接管。一次立即且明确有界的修复尝试可以缩短反馈闭环，同时不会把基础设施故障、模型故障、凭据缺失或 gate 崩溃变成无限重试。

## Reviewer 测试计划

### 如何验证

- 确认确定性验证拒绝只产生一个 retry 信号，保留第一次提交，把捕获的拒绝原因交给一次修复，并只再运行一次验证。
- 确认第一次验证成功时跳过修复；第二次验证再次拒绝时为终态，不能发起第三次尝试。
- 确认发布与失败报告读取最终验证结论，而不是第一次被拒绝的结论。
- 确认 agent 主动中止、缺少输出、Git 故障、gate 崩溃、模型/认证故障和 stale target 都不会进入新的同轮修复路径。
- 确认 takeover 命令与定时路由没有变化。
- 本地验证已通过：`bash -n .github/scripts/run-autofix-review-verification.sh .github/scripts/check-autofix-contracts.sh`；`npx prettier --check .github/workflows/qwen-autofix.yml scripts/tests/qwen-autofix-workflow.test.js`；`GH_TOKEN=test-only GH_HOST=127.0.0.1 npx vitest run scripts/tests/qwen-autofix-workflow.test.js`（102/102）；`npm run build`；`npm run typecheck`；`npm run lint`；`npm run check-i18n`；settings schema 校验；以及 Web Shell tool-formatting drift 测试（2/2）。

### 证据（修改前后）

N/A——仅工作流改动，没有用户可见 UI。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

Node.js 25.9.0、npm 11.12.1；本地 checkout，未执行真实模型修复。

## 风险与范围

- 主要风险或取舍：一次确定性拒绝的 takeover 轮次可能增加一次模型调用和一次验证；两者都有明确上限，job 预算也相应增加。
- 未验证 / 不在范围内：真实 GitHub Actions 凭据和真实模型修复调用；托管 runner 覆盖继续由 CI 负责。
- 破坏性变更 / 迁移说明：无。触发路由和 takeover 授权没有变化。

## 关联 Issue

Closes #7638

</details>