### PR TITLE
perf(ci): cut the E2E suite from ~40min to ~24min

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -112,7 +112,10 @@ jobs:
         if: |-
           ${{ matrix.sandbox == 'sandbox:docker' }}
         env:
-          QWEN_SANDBOX: docker
+          # build_sandbox.js resolves the container command through
+          # sandbox_command.js, which exits non-zero on Linux when this is unset
+          # — the test script used to supply it.
+          QWEN_SANDBOX: 'docker'
         run: |-
           npm run build:sandbox -- -s
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -111,6 +111,8 @@ jobs:
       - name: 'Build the sandbox image'
         if: |-
           ${{ matrix.sandbox == 'sandbox:docker' }}
+        env:
+          QWEN_SANDBOX: docker
         run: |-
           npm run build:sandbox -- -s
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   e2e-test-linux:
-    name: 'E2E Test (Linux) - ${{ matrix.sandbox }}'
+    name: 'E2E Test (Linux) - ${{ matrix.sandbox }} - shard ${{ matrix.shard }}'
     runs-on: 'ubuntu-latest'
     # Skip on fork PRs: forks have no access to repository secrets
     # (OPENAI_*, DOCKERHUB_*), so the matrix would fail unconditionally
@@ -36,10 +36,20 @@ jobs:
     if: |-
       ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     strategy:
+      # One failing shard must not cancel the others: a partial matrix hides the
+      # rest of the suite and reports an incomplete failure set.
+      fail-fast: false
       matrix:
         sandbox:
           - 'sandbox:none'
           - 'sandbox:docker'
+        # The suite is ~16min of wall clock on one runner, dominated by a long
+        # tail of sdk-typescript files. vitest assigns files to shards by path
+        # hash, so those spread out instead of clustering in one shard.
+        shard:
+          - '1/3'
+          - '2/3'
+          - '3/3'
         node-version:
           - '22.x'
     steps:
@@ -62,6 +72,13 @@ jobs:
           npm config set fetch-timeout 300000
 
       - name: 'Install dependencies'
+        env:
+          # `npm ci` runs the `prepare` script, which builds and bundles the
+          # whole workspace — and the two steps below then do it a second time.
+          # Skip it so the install only installs; `prepare` still generates
+          # git-commit.ts, which the build needs. (The web-shell job below has
+          # no build step of its own, so it keeps building during install.)
+          QWEN_SKIP_PREPARE: '1'
         run: |-
           npm ci --prefer-offline --no-audit --progress=false
 
@@ -87,6 +104,16 @@ jobs:
           username: '${{ secrets.DOCKERHUB_USERNAME }}'
           password: '${{ secrets.DOCKERHUB_TOKEN }}'
 
+      # The sandbox test script builds this image itself, but without `-s` it
+      # first re-runs install + build + bundle + pack on the host — all of which
+      # the steps above already did, and none of which the image consumes (the
+      # Dockerfile rebuilds and packs inside its own builder stage).
+      - name: 'Build the sandbox image'
+        if: |-
+          ${{ matrix.sandbox == 'sandbox:docker' }}
+        run: |-
+          npm run build:sandbox -- -s
+
       - name: 'Run E2E tests'
         env:
           OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
@@ -95,18 +122,29 @@ jobs:
           KEEP_OUTPUT: 'true'
           VERBOSE: 'true'
         run: |-
+          # The docker leg runs vitest directly instead of through
+          # test:integration:sandbox:docker: that script would rebuild the image
+          # the step above just built.
           if [[ "${{ matrix.sandbox }}" == "sandbox:docker" ]]; then
-            npm run test:integration:sandbox:docker -- --exclude '**/interactive/cron-interactive.test.ts'
+            npx cross-env QWEN_SANDBOX=docker vitest run --root ./integration-tests --exclude '**/interactive/cron-interactive.test.ts' --shard='${{ matrix.shard }}'
           else
-            npm run test:integration:sandbox:none -- --exclude '**/interactive/cron-interactive.test.ts'
+            npm run test:integration:sandbox:none -- --exclude '**/interactive/cron-interactive.test.ts' --shard='${{ matrix.shard }}'
           fi
 
   e2e-test-macos:
-    name: 'E2E Test - macOS'
+    name: 'E2E Test - macOS - shard ${{ matrix.shard }}'
     runs-on: 'macos-latest'
     # Skip on fork PRs (no secrets) — see e2e-test-linux above.
     if: |-
       ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Two shards, not three: the macOS runner is the slowest to install and
+        # build, so a third shard would add more fixed cost than it removes.
+        shard:
+          - '1/2'
+          - '2/2'
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10'  # v6.0.3
@@ -127,6 +165,10 @@ jobs:
           npm config set fetch-timeout 300000
 
       - name: 'Install dependencies'
+        env:
+          # See e2e-test-linux: the install must not build, the two steps
+          # below do it explicitly.
+          QWEN_SKIP_PREPARE: '1'
         run: |-
           npm ci --prefer-offline --no-audit --progress=false
 
@@ -143,7 +185,7 @@ jobs:
           OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
           OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'
           OPENAI_MODEL: '${{ secrets.OPENAI_MODEL }}'
-        run: 'npx cross-env VERBOSE=true KEEP_OUTPUT=true QWEN_SANDBOX=false vitest run --root ./integration-tests --exclude "**/interactive/cron-interactive.test.ts"'
+        run: 'npx cross-env VERBOSE=true KEEP_OUTPUT=true QWEN_SANDBOX=false vitest run --root ./integration-tests --exclude "**/interactive/cron-interactive.test.ts" --shard="${{ matrix.shard }}"'
 
   cron-interactive-nightly:
     name: 'cron-interactive E2E (nightly)'
@@ -174,6 +216,10 @@ jobs:
           npm config set fetch-timeout 300000
 
       - name: 'Install dependencies'
+        env:
+          # See e2e-test-linux: the install must not build, the two steps
+          # below do it explicitly.
+          QWEN_SKIP_PREPARE: '1'
         run: |-
           npm ci --prefer-offline --no-audit --progress=false
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -116,6 +116,9 @@ jobs:
           # sandbox_command.js, which exits non-zero on Linux when this is unset
           # — the test script used to supply it.
           QWEN_SANDBOX: 'docker'
+          # Without this, build_sandbox.js pipes docker build output to
+          # /dev/null — the longest step in the docker leg becomes undiagnosable.
+          VERBOSE: 'true'
         run: |-
           npm run build:sandbox -- -s
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,10 @@ ENV PATH=$PATH:/usr/local/share/npm-global/bin
 COPY . /home/node/app
 WORKDIR /home/node/app
 
-# Install dependencies, build workspaces, bundle into a single distributable, and pack
-RUN npm ci \
+# Install dependencies, build workspaces, bundle into a single distributable, and pack.
+# QWEN_SKIP_PREPARE=1 stops npm ci's prepare script from building and bundling —
+# the explicit build and bundle steps below already do that.
+RUN QWEN_SKIP_PREPARE=1 npm ci \
   && npm run build \
   && npm run bundle \
   && npm run prepare:package \


### PR DESCRIPTION
## What this PR does

Cuts the E2E suite's wall clock from about 40 minutes to about 24 by removing duplicated build work and sharding the test run.

Every E2E job installed dependencies with the default install behaviour, which builds and bundles the whole workspace as part of `prepare`, and then ran explicit build and bundle steps that did the same work again — roughly 3.5 minutes on Linux and 5 on macOS, wasted per job. The install now skips that implicit build, exactly as the release workflows already do, so the build happens once and explicitly. The one job with no build step of its own keeps installing the old way.

The docker leg additionally let the sandbox script re-run install, build, bundle and pack on the host before building the image. None of that reaches the image: the Dockerfile rebuilds and packs inside its own builder stage, and the host `dist` is excluded from the build context. The image is now built with that host-side work skipped, and the docker leg runs vitest directly rather than through the script that would rebuild the image a second time.

What remains is the test run, now split across shards — three per Linux sandbox mode, two on macOS. The matrix also no longer fails fast, since a cancelled sibling shard would hide most of the suite and report an incomplete failure set.

## Why it's needed

Merges land on `main` roughly every 18 minutes at the median while a full E2E run takes about 40, so the post-merge suite structurally cannot keep up with the merge rate — it either gets cancelled or reports against a tree several commits behind. Companion PR #7795 stops the cancelling; this PR attacks the duration itself, which is what keeps each batched result small enough to attribute.

Most of the reduction is not a tradeoff at all, just work that was being done twice.

## Reviewer Test Plan

### How to verify

The wasteful work is visible in the stored logs of the last green run. In the docker leg, the install step spans 12:38:55 to 12:43:24 and its `prepare` script starts a full build at 12:39:42 — so the install itself takes about 50 seconds and the rest is a build. The explicit build step then runs from 12:43:24 to 12:46:47, building everything again. Confirm that `npm run build` plus `npm run bundle` is exactly what the skipped script would have run, so skipping it changes nothing but the count (the skip path still generates the git commit info the build needs, which is why the release workflows can rely on it).

For the sandbox image, confirm from the Dockerfile that the runtime stage takes its tarball from the builder stage rather than from the host, and that the build context excludes `dist` and `node_modules` — together those mean the host-side install/build/bundle/pack the script performs is unused. Both docker steps still run on the same runner in the same order, so the image the tests use is unchanged.

For sharding I replayed the real numbers rather than guessing. Vitest 3.2.4 assigns files to shards by sorting the SHA-1 of each file's path relative to the test root and taking a contiguous slice, so the assignment is fully determined by the file list. I reproduced that algorithm over the current 55 test files and combined it with the per-file durations recorded in the last green run's logs:

| leg | before | shard 1 | shard 2 | shard 3 |
| --- | --- | --- | --- | --- |
| Linux `sandbox:none` | 16.0 min | 6.2 min | 4.2 min | 3.8 min |
| Linux `sandbox:docker` | 30.8 min (13 of it the image build) | 6.1 min | 3.6 min | 3.8 min |
| macOS | 25.0 min | 6.5 min | 6.3 min | — |

Every file lands in exactly one shard and the union is the full set, which the same script asserts. The slowest shard is bounded from below by the single slowest file (about 6.2 minutes for the tool-control suite), so going past three shards on Linux would buy very little. A reviewer can sanity-check the balance differently by counting files per shard: 19/19/17 on Linux and 28/27 on macOS.

Worth knowing when reading the run: each docker shard now builds the sandbox image, so that 13-minute build is paid three times in parallel instead of once. That is the largest remaining item and the reason the docker leg is still the critical path at roughly 24 minutes; restructuring the Dockerfile so the dependency install becomes a cacheable layer, with a build cache, would remove most of it and speed up image publishing too. I did not attempt it here because this environment has no Docker and I would not be able to verify it before merge.

### Evidence (Before & After)

N/A — CI-only change, no user-visible surface.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Linux; actionlint, shellcheck and yamllint via the repo lint entry point, plus the shard replay described above. The suite itself needs model credentials and about 25 minutes per leg, so it runs for real on merge.

## Risk & Scope

- Main risk or tradeoff: sharding multiplies the fixed per-job cost, which for the docker legs means three parallel sandbox image builds per run. Hosted runner minutes are free for this repository, so the real cost is concurrency slots; if that turns out to hurt, the shard count is a one-line change. Skipping the build during install relies on every affected job having explicit build and bundle steps — true for the three jobs changed here, and deliberately not applied to the browser-regression job, which has none.
- Not validated / out of scope: the shard balance is a replay of recorded timings, not a live run — the first real run on `main` is the confirmation. The Docker layer-caching restructure is left out for the reason given above. Test flakiness itself (#7616) is untouched.
- Breaking changes / migration notes: the E2E job names change because they now carry a shard suffix, which matters only if a branch protection rule ever names them (E2E is not a required check today).

## Linked Issues

Companion to #7795, which keeps a run from being cancelled; related to #7616 on E2E cost and flakiness.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 E2E 的墙钟时间从约 40 分钟降到约 24 分钟，做法是去掉重复的构建工作并对测试运行分片。

之前每个 E2E job 安装依赖时都会走默认行为，也就是在 `prepare` 阶段构建并打包整个 workspace，然后再执行显式的 build 和 bundle 步骤，把同样的工作又做一遍——Linux 上大约浪费 3.5 分钟，macOS 上大约 5 分钟，每个 job 都是。现在安装阶段跳过那次隐式构建，和 release workflow 已有的做法完全一致，于是构建只发生一次、而且是显式的。唯一没有自己的构建步骤的那个 job 保持原来的安装方式。

docker 这条腿还额外让沙箱脚本在构建镜像之前，在宿主机上重新跑一遍 install、build、bundle 和 pack。这些工作没有任何一部分进入镜像：Dockerfile 在自己的 builder stage 里重新构建并打包，而宿主机的 `dist` 被排除在构建上下文之外。现在构建镜像时跳过这部分宿主机工作，并且 docker 腿直接运行 vitest，而不是通过那个会把镜像再建一遍的脚本。

剩下的就是测试运行本身，现在被拆分成多个分片——每种 Linux 沙箱模式 3 片，macOS 2 片。matrix 也不再 fail-fast，因为被取消的同级分片会隐藏掉大部分套件，并报告一个不完整的失败集合。

## 为什么需要

`main` 上的合并间隔中位数大约 18 分钟，而一次完整的 E2E 大约 40 分钟，所以合并后的套件在结构上就跟不上合并速度——它要么被取消，要么报告的是落后好几个 commit 的代码树。配套 PR #7795 解决"被取消"，本 PR 针对时长本身，这也是让每个批次结果小到可以归因的前提。

其中大部分收益根本不是取舍，只是原本被做了两遍的工作。

## 审查者测试计划

### 如何验证

浪费的工作在最近一次绿色 run 的存档日志里可以直接看到。docker 腿的安装步骤从 12:38:55 到 12:43:24，而它的 `prepare` 脚本在 12:39:42 就开始了一次完整构建——也就是说安装本身约 50 秒，剩下的都是构建。随后显式的 build 步骤从 12:43:24 跑到 12:46:47，把所有东西又构建了一遍。请确认 `npm run build` 加 `npm run bundle` 正是被跳过的那个脚本会执行的内容，因此跳过它除了次数之外不改变任何东西（跳过路径仍会生成构建所需的 git commit 信息，这也是 release workflow 能依赖它的原因）。

关于沙箱镜像，请从 Dockerfile 确认运行时 stage 的 tarball 来自 builder stage 而不是宿主机，并且构建上下文排除了 `dist` 和 `node_modules`——两点合起来说明脚本在宿主机上做的 install/build/bundle/pack 是用不上的。两个 docker 步骤仍然在同一台 runner 上按同样顺序执行，因此测试使用的镜像没有变化。

分片这部分我是用真实数据复算的，而不是估计。Vitest 3.2.4 分配分片的方式是：对每个文件相对测试根目录的路径取 SHA-1，按哈希排序后取连续切片，所以分配完全由文件列表决定。我在当前 55 个测试文件上复现了这个算法，并结合最近一次绿色 run 日志里记录的每个文件耗时：

| leg | 之前 | 分片 1 | 分片 2 | 分片 3 |
| --- | --- | --- | --- | --- |
| Linux `sandbox:none` | 16.0 min | 6.2 min | 4.2 min | 3.8 min |
| Linux `sandbox:docker` | 30.8 min（其中 13 分钟是镜像构建） | 6.1 min | 3.6 min | 3.8 min |
| macOS | 25.0 min | 6.5 min | 6.3 min | — |

每个文件恰好落在一个分片里，并集就是全集，这一点由同一个脚本断言。最慢的分片下限是单个最慢文件（tool-control 套件约 6.2 分钟），所以 Linux 上再加更多分片收益很小。审查者也可以换个角度检查均衡性：每片文件数为 Linux 19/19/17、macOS 28/27。

阅读 run 时需要知道的一点：现在每个 docker 分片都会构建沙箱镜像，因此那 13 分钟的构建从一次变成并行三次。这是剩下最大的一项，也是 docker 腿仍以约 24 分钟处于关键路径的原因；把 Dockerfile 重构成依赖安装成为可缓存层并配合构建缓存，可以去掉其中大部分，同时也会加快镜像发布。我这次没有动它，因为当前环境没有 Docker，合并前无法验证。

### 证据（前后对比）

N/A —— 仅 CI 改动，没有用户可见的界面。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

### 环境（可选）

Linux；通过仓库的 lint 入口跑了 actionlint、shellcheck、yamllint，另外做了上面描述的分片复算。套件本身需要模型凭据、每条腿约 25 分钟，因此真实运行发生在合并之后。

## 风险与范围

- 主要风险或取舍：分片会把每个 job 的固定成本乘以份数，对 docker 腿来说意味着每次 run 并行构建三次沙箱镜像。本仓库的 hosted runner 分钟数是免费的，真正的成本是并发槽位；如果发现有影响，分片数只是一行改动。安装阶段跳过构建依赖于每个受影响 job 都有显式的 build 和 bundle 步骤——这里改动的三个 job 都满足，而没有这些步骤的浏览器回归 job 被有意排除在外。
- 未验证 / 不在范围内：分片均衡性是基于记录耗时的复算，不是真实运行——`main` 上的第一次真实 run 才是确认。Dockerfile 分层缓存重构因为上述原因没有包含。测试自身的不稳定性（#7616）没有触及。
- 破坏性变更 / 迁移说明：E2E 的 job 名称因为带上了分片后缀而改变，这只在分支保护规则引用它们时才有影响（目前 E2E 不是必需检查）。

## 关联 issue

与 #7795 配套（那个 PR 负责让 run 不被取消）；与 #7616（E2E 成本与不稳定性）相关。

</details>
