### PR TITLE
fix(web-shell): stabilize mobile voice input

### DIFF
--- a/packages/web-shell/client/components/ChatEditor.module.css
+++ b/packages/web-shell/client/components/ChatEditor.module.css
@@ -933,6 +933,15 @@
   min-width: 0;
 }
 
+.toolbar[data-mobile-voice-active='true'] .toolbarLeading,
+.toolbar[data-mobile-voice-active='true'] [data-hide-during-mobile-voice] {
+  display: none;
+}
+
+.toolbar[data-mobile-voice-active='true'] .toolbarRight {
+  margin-left: auto;
+}
+
 .toolbarStart {
   min-width: 0;
 }

--- a/packages/web-shell/client/components/ChatEditor.test.tsx
+++ b/packages/web-shell/client/components/ChatEditor.test.tsx
@@ -35,6 +35,10 @@ const composerCoreState = vi.hoisted(() => ({
   openHistorySearch: vi.fn(),
 }));
 
+const voiceButtonState = vi.hoisted(() => ({
+  onActiveChange: undefined as ((active: boolean) => void) | undefined,
+}));
+
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
   value: vi.fn().mockImplementation(() => ({
@@ -125,7 +129,14 @@ vi.mock('../hooks/useComposerCore', async (importOriginal) => {
 });
 
 vi.mock('../voice/VoiceButton', () => ({
-  VoiceButton: () => <span data-testid="voice-button" />,
+  VoiceButton: ({
+    onActiveChange,
+  }: {
+    onActiveChange?: (active: boolean) => void;
+  }) => {
+    voiceButtonState.onActiveChange = onActiveChange;
+    return <span data-testid="voice-button" />;
+  },
 }));
 
 const mounted: Array<{
@@ -140,6 +151,7 @@ afterEach(() => {
   composerCoreState.closeSlashMenu.mockReset();
   composerCoreState.mobileComposer = null;
   composerCoreState.openHistorySearch.mockReset();
+  voiceButtonState.onActiveChange = undefined;
   for (const { root, container, portalRoot } of mounted.splice(0)) {
     act(() => root.unmount());
     container.remove();
@@ -817,6 +829,43 @@ describe('ChatEditor mobile composer quick actions', () => {
           (button) => button.textContent === 'Tab',
         ),
       ).toBe(true);
+    });
+  });
+
+  it('hides other toolbar actions while mobile voice capture is active', () => {
+    withTouchDevice(() => {
+      const container = renderChatEditor({
+        currentModel: 'qwen-test',
+        availableModels: [{ id: 'qwen-test' }],
+      });
+
+      expect(
+        container.querySelector('[data-web-shell-toolbar-leading]'),
+      ).toBeTruthy();
+      expect(
+        container.querySelector(
+          'button[aria-label="more actions"][data-hide-during-mobile-voice]',
+        ),
+      ).toBeTruthy();
+      expect(
+        container.querySelector('[data-web-shell-composer-submit]'),
+      ).toBeTruthy();
+
+      act(() => {
+        voiceButtonState.onActiveChange?.(true);
+      });
+
+      expect(
+        container.querySelector('[data-mobile-voice-active="true"]'),
+      ).toBeTruthy();
+
+      act(() => {
+        voiceButtonState.onActiveChange?.(false);
+      });
+
+      expect(
+        container.querySelector('[data-mobile-voice-active="true"]'),
+      ).toBeFalsy();
     });
   });
 });

--- a/packages/web-shell/client/components/ChatEditor.tsx
+++ b/packages/web-shell/client/components/ChatEditor.tsx
@@ -1262,6 +1262,7 @@ export const ChatEditor = memo(
     const toolbarRightCustomRef = useRef<HTMLDivElement>(null);
     const toolbarMeasurementsRef = useRef<HTMLDivElement>(null);
     const [widthToggleFits, setWidthToggleFits] = useState(false);
+    const [voiceActive, setVoiceActive] = useState(false);
     const [toolbarLabelVisibility, setToolbarLabelVisibility] = useState({
       workspaceSelect: false,
       workspace: false,
@@ -1665,6 +1666,11 @@ export const ChatEditor = memo(
     const showModeLabel = toolbarLabelVisibility.mode;
     const showModelLabel = toolbarLabelVisibility.model;
     const showCancelButton = isRunning && !core.hasContent;
+    const mobileVoiceActive = showQuickActions && voiceActive;
+
+    useEffect(() => {
+      if (mobileVoiceActive) setQuickActionsOpen(false);
+    }, [mobileVoiceActive]);
 
     useLayoutEffect(() => {
       const toolbar = toolbarRef.current;
@@ -2059,8 +2065,16 @@ export const ChatEditor = memo(
                 <div ref={core.containerRef} data-web-shell-composer-editor />
               )}
             </div>
-            <div ref={toolbarRef} className={styles.toolbar}>
-              <div ref={toolbarLeadingRef} className={styles.toolbarLeading}>
+            <div
+              ref={toolbarRef}
+              className={styles.toolbar}
+              data-mobile-voice-active={mobileVoiceActive || undefined}
+            >
+              <div
+                ref={toolbarLeadingRef}
+                className={styles.toolbarLeading}
+                data-web-shell-toolbar-leading
+              >
                 {ToolbarStart && (
                   <div ref={toolbarStartRef} className={styles.toolbarStart}>
                     <ToolbarStart
@@ -2243,6 +2257,7 @@ export const ChatEditor = memo(
                 {showQuickActions && quickActions.length > 0 && (
                   <button
                     className={`${styles.toolBtn} ${styles.quickActionsBtn}`}
+                    data-hide-during-mobile-voice
                     onClick={(e) => {
                       e.stopPropagation();
                       core.closeSlashMenu();
@@ -2265,6 +2280,7 @@ export const ChatEditor = memo(
                   <div
                     ref={toolbarRightCustomRef}
                     className={styles.toolbarRightCustom}
+                    data-hide-during-mobile-voice
                   >
                     <ToolbarRight
                       disabled={disabled}
@@ -2280,6 +2296,7 @@ export const ChatEditor = memo(
                   showToolbarAction('widthMode') && (
                     <button
                       className={`${styles.toolBtn} ${styles.widthModeBtn}`}
+                      data-hide-during-mobile-voice
                       onClick={(e) => {
                         e.stopPropagation();
                         onChatWidthModeChange?.(
@@ -2311,6 +2328,7 @@ export const ChatEditor = memo(
                 {showToolbarAction('voice') && (
                   <VoiceButton
                     disabled={disabled}
+                    onActiveChange={setVoiceActive}
                     onInsert={(text) => {
                       const existing = core.getText();
                       const sep = existing && !/\s$/.test(existing) ? ' ' : '';

--- a/packages/web-shell/client/e2e/web-shell.composer.mobile.spec.ts
+++ b/packages/web-shell/client/e2e/web-shell.composer.mobile.spec.ts
@@ -34,6 +34,46 @@ test('renders the textarea backend instead of CodeMirror on touch devices', asyn
   await expect(page.locator('.cm-editor')).toHaveCount(0);
 });
 
+test('keeps voice controls reachable on an extra-narrow touch viewport', async ({
+  page,
+}, testInfo) => {
+  await page.setViewportSize({ width: 240, height: 700 });
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: {
+        getUserMedia: () => new Promise(() => undefined),
+      },
+    });
+  });
+  const scenario = createWebShellDaemonScenario({
+    capabilities: {
+      features: ['voice_transcribe', 'workspace_voice'],
+    },
+    voice: { enabled: true },
+  });
+  const daemon = await installScenario(page, scenario, testInfo);
+
+  await gotoSession(page, scenario, daemon);
+  const model = page.locator('[data-web-shell-model-button]');
+  const more = page.getByRole('button', { name: 'more actions' });
+  const voice = page.getByRole('button', { name: 'Start voice dictation' });
+  const send = page.locator('[data-web-shell-composer-submit]');
+  await expect(model).toBeVisible();
+  await expect(more).toBeVisible();
+  await expect(voice).toBeVisible();
+  await expect(send).toBeVisible();
+
+  await voice.tap();
+
+  const activeToolbar = page.locator('[data-mobile-voice-active="true"]');
+  await expect(activeToolbar).toBeVisible();
+  await expect(model).toBeHidden();
+  await expect(more).toBeHidden();
+  await expect(send).toBeVisible();
+  await expect(activeToolbar.locator('button:visible')).toHaveCount(2);
+});
+
 test('tap, type, and Send submit through the shared prompt pipeline', async ({
   page,
 }, testInfo) => {

--- a/packages/web-shell/client/voice/VoiceButton.test.tsx
+++ b/packages/web-shell/client/voice/VoiceButton.test.tsx
@@ -4,7 +4,10 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { VoiceButton } from './VoiceButton';
-import type { UseVoiceCaptureReturn } from './useVoiceCapture';
+import type {
+  UseVoiceCaptureOptions,
+  UseVoiceCaptureReturn,
+} from './useVoiceCapture';
 
 (
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -13,6 +16,7 @@ import type { UseVoiceCaptureReturn } from './useVoiceCapture';
 const mocks = vi.hoisted(() => ({
   settingsVersion: 0,
   workspaceVoice: vi.fn(),
+  onFinal: undefined as UseVoiceCaptureOptions['onFinal'] | undefined,
   workspace: {
     baseUrl: 'http://127.0.0.1:1234',
     token: undefined as string | undefined,
@@ -40,8 +44,10 @@ vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
 }));
 
 vi.mock('./useVoiceCapture', () => ({
-  useVoiceCapture: (): UseVoiceCaptureReturn =>
-    mocks.capture as unknown as UseVoiceCaptureReturn,
+  useVoiceCapture: (options: UseVoiceCaptureOptions): UseVoiceCaptureReturn => {
+    mocks.onFinal = options.onFinal;
+    return mocks.capture as unknown as UseVoiceCaptureReturn;
+  },
 }));
 
 const mounted: Array<{ root: Root; container: HTMLElement }> = [];
@@ -58,12 +64,18 @@ function voiceStatus(enabled: boolean) {
   };
 }
 
-function mount(disabled: boolean) {
+function mount(disabled: boolean, onActiveChange?: (active: boolean) => void) {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
   act(() => {
-    root.render(<VoiceButton disabled={disabled} onInsert={() => {}} />);
+    root.render(
+      <VoiceButton
+        disabled={disabled}
+        onInsert={() => {}}
+        onActiveChange={onActiveChange}
+      />,
+    );
   });
   mounted.push({ root, container });
   return { root, container };
@@ -97,6 +109,7 @@ beforeEach(() => {
   };
   mocks.workspaceVoice.mockReset();
   mocks.workspaceVoice.mockResolvedValue(voiceStatus(true));
+  mocks.onFinal = undefined;
   mocks.capture.status = 'idle';
   mocks.capture.interimText = '';
   mocks.capture.audioLevel = 0;
@@ -111,6 +124,7 @@ afterEach(() => {
     act(() => root.unmount());
     container.remove();
   }
+  vi.useRealTimers();
 });
 
 describe('VoiceButton', () => {
@@ -267,6 +281,55 @@ describe('VoiceButton', () => {
     click(button);
 
     expect(mocks.capture.abort).toHaveBeenCalledOnce();
+  });
+
+  it('reports whether voice capture is active', async () => {
+    const onActiveChange = vi.fn();
+    const { root } = mount(false, onActiveChange);
+    await flush();
+    expect(onActiveChange).toHaveBeenLastCalledWith(false);
+
+    mocks.capture.status = 'connecting';
+    act(() => {
+      root.render(
+        <VoiceButton
+          disabled={false}
+          onInsert={() => {}}
+          onActiveChange={onActiveChange}
+        />,
+      );
+    });
+    expect(onActiveChange).toHaveBeenLastCalledWith(true);
+
+    mocks.capture.status = 'idle';
+    act(() => {
+      root.render(
+        <VoiceButton
+          disabled={false}
+          onInsert={() => {}}
+          onActiveChange={onActiveChange}
+        />,
+      );
+    });
+    expect(onActiveChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('clears the no-speech notice after two seconds', async () => {
+    vi.useFakeTimers();
+    const { container } = mount(false);
+    await flush();
+
+    act(() => {
+      mocks.onFinal?.('');
+    });
+    expect(container.querySelector('[role="status"]')?.textContent).toBe(
+      'voice.noSpeech',
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(2_000);
+    });
+    expect(container.querySelector('[role="status"]')).toBeNull();
   });
 
   it('keeps disabled idle dictation from starting', async () => {

--- a/packages/web-shell/client/voice/VoiceButton.tsx
+++ b/packages/web-shell/client/voice/VoiceButton.tsx
@@ -18,10 +18,12 @@ import styles from './VoiceButton.module.css';
 const VOICE_FEATURE = 'voice_transcribe';
 /** Live waveform bar count in the recording pill. */
 const BAR_COUNT = 16;
+const NOTICE_TIMEOUT_MS = 2_000;
 
 export interface VoiceButtonProps {
   /** Insert the final transcript into the composer (user reviews, then sends). */
   onInsert: (text: string) => void;
+  onActiveChange?: (active: boolean) => void;
   disabled?: boolean;
 }
 
@@ -59,6 +61,7 @@ function formatElapsed(ms: number): string {
 
 export function VoiceButton({
   onInsert,
+  onActiveChange,
   disabled,
 }: VoiceButtonProps): React.JSX.Element | null {
   const workspace = useWorkspace();
@@ -112,6 +115,14 @@ export function VoiceButton({
   const [noticeMessage, setNoticeMessage] = useState<string | undefined>(
     undefined,
   );
+  useEffect(() => {
+    if (!noticeMessage) return undefined;
+    const timer = window.setTimeout(
+      () => setNoticeMessage(undefined),
+      NOTICE_TIMEOUT_MS,
+    );
+    return () => window.clearTimeout(timer);
+  }, [noticeMessage]);
 
   const { status, interimText, audioLevel, errorMessage, start, stop, abort } =
     useVoiceCapture({
@@ -128,7 +139,22 @@ export function VoiceButton({
       },
     });
 
+  const isActive =
+    status === 'connecting' ||
+    status === 'recording' ||
+    status === 'transcribing';
   const isRecording = status === 'recording';
+
+  useEffect(() => {
+    onActiveChange?.(isActive);
+  }, [isActive, onActiveChange]);
+
+  useEffect(
+    () => () => {
+      onActiveChange?.(false);
+    },
+    [onActiveChange],
+  );
 
   // Rolling waveform history, fed by the live RMS meter while recording.
   const [levels, setLevels] = useState<number[]>(() =>

--- a/packages/web-shell/client/voice/useVoiceCapture.test.tsx
+++ b/packages/web-shell/client/voice/useVoiceCapture.test.tsx
@@ -183,6 +183,85 @@ describe('useVoiceCapture', () => {
     expect(MockWebSocket.latest?.protocols).toBeUndefined();
   });
 
+  it('resumes audio during the start gesture before mic permission resolves', async () => {
+    let resolveStream: (stream: {
+      getTracks: () => (typeof track)[];
+    }) => void = () => undefined;
+    const getUserMedia = vi.fn(
+      () =>
+        new Promise<{ getTracks: () => (typeof track)[] }>((resolve) => {
+          resolveStream = resolve;
+        }),
+    );
+    Object.defineProperty(navigator, 'mediaDevices', {
+      value: { getUserMedia },
+      configurable: true,
+    });
+    const resume = vi.fn(async () => {});
+    class SuspendedAudioContext extends MockAudioContext {
+      override state = 'suspended';
+      override resume = resume;
+    }
+    Object.defineProperty(window, 'AudioContext', {
+      value: SuspendedAudioContext,
+      configurable: true,
+    });
+    const result = await renderHookHost();
+
+    act(() => {
+      result.start();
+    });
+
+    expect(getUserMedia).toHaveBeenCalledOnce();
+    expect(resume).toHaveBeenCalledOnce();
+    expect(capture?.status).toBe('connecting');
+
+    await act(async () => {
+      resolveStream({ getTracks: () => [track] });
+      await Promise.resolve();
+    });
+    const ws = MockWebSocket.latest;
+    if (!ws) throw new Error('WebSocket was not created');
+
+    await act(async () => {
+      ws.onopen?.();
+    });
+    expect(capture?.status).toBe('recording');
+  });
+
+  it('times out and cleans up when mobile audio resume stalls', async () => {
+    vi.useFakeTimers();
+    const close = vi.fn(async () => {});
+    class StalledAudioContext extends MockAudioContext {
+      override state = 'suspended';
+      override resume = vi.fn(() => new Promise<void>(() => undefined));
+      override close = close;
+    }
+    Object.defineProperty(window, 'AudioContext', {
+      value: StalledAudioContext,
+      configurable: true,
+    });
+    const result = await renderHookHost();
+
+    await act(async () => {
+      result.start();
+      await Promise.resolve();
+    });
+    expect(capture?.status).toBe('connecting');
+    expect(MockWebSocket.latest).toBeUndefined();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    expect(onError).toHaveBeenCalledWith(
+      'Voice capture timed out while starting.',
+    );
+    expect(capture?.status).toBe('error');
+    expect(track.stop).toHaveBeenCalledOnce();
+    expect(close).toHaveBeenCalledOnce();
+  });
+
   it('uses server error frame messages', async () => {
     const result = await renderHookHost();
 

--- a/packages/web-shell/client/voice/useVoiceCapture.ts
+++ b/packages/web-shell/client/voice/useVoiceCapture.ts
@@ -47,6 +47,7 @@ export interface UseVoiceCaptureReturn {
 
 const SAMPLE_RATE = 16_000;
 const FRAME_SIZE = 4096;
+const START_TIMEOUT_MS = 60_000;
 const TRANSCRIPTION_TIMEOUT_MS = 60_000;
 
 function toWebSocketUrl(baseUrl: string): string {
@@ -257,49 +258,65 @@ export function useVoiceCapture(
     const isStale = () =>
       !mountedRef.current || captureGenerationRef.current !== generation;
 
+    if (!navigator.mediaDevices?.getUserMedia) {
+      fail(
+        window.isSecureContext
+          ? 'Microphone capture is not supported in this browser.'
+          : 'Microphone needs a secure context — open the Web Shell via localhost/127.0.0.1 or https.',
+        generation,
+      );
+      return;
+    }
+
+    let context: AudioContext;
+    let contextReady: Promise<void>;
+    try {
+      context = new AudioContext({ sampleRate: SAMPLE_RATE });
+      resourcesRef.current.context = context;
+      if (context.sampleRate !== SAMPLE_RATE) {
+        throw new Error(
+          `Browser audio rate ${context.sampleRate} Hz is not the required ${SAMPLE_RATE} Hz.`,
+        );
+      }
+      contextReady =
+        context.state === 'suspended' ? context.resume() : Promise.resolve();
+    } catch (error) {
+      fail(error instanceof Error ? error.message : String(error), generation);
+      return;
+    }
+
+    clearTranscribeTimeout();
+    resourcesRef.current.transcribeTimeout = setTimeout(() => {
+      if (statusRef.current === 'connecting') {
+        fail('Voice capture timed out while starting.', generation);
+      }
+    }, START_TIMEOUT_MS);
+
     void (async () => {
       try {
-        if (!navigator.mediaDevices?.getUserMedia) {
-          throw new Error(
-            window.isSecureContext
-              ? 'Microphone capture is not supported in this browser.'
-              : 'Microphone needs a secure context — open the Web Shell via localhost/127.0.0.1 or https.',
-          );
-        }
-        let stream: MediaStream;
-        try {
-          stream = await navigator.mediaDevices.getUserMedia({
+        const streamPromise = navigator.mediaDevices
+          .getUserMedia({
             audio: {
               channelCount: 1,
               echoCancellation: true,
               noiseSuppression: true,
             },
-          });
-        } catch (err) {
-          throw new Error(describeMicError(err));
-        }
-        if (isStale()) {
-          stream.getTracks().forEach((track) => track.stop());
-          return;
-        }
-        resourcesRef.current.stream = stream;
-
-        const context = new AudioContext({ sampleRate: SAMPLE_RATE });
-        if (context.sampleRate !== SAMPLE_RATE) {
-          stream.getTracks().forEach((track) => track.stop());
-          void context.close().catch(() => {});
-          throw new Error(
-            `Browser audio rate ${context.sampleRate} Hz is not the required ${SAMPLE_RATE} Hz.`,
+          })
+          .then(
+            (stream) => {
+              if (isStale()) {
+                stream.getTracks().forEach((track) => track.stop());
+              } else {
+                resourcesRef.current.stream = stream;
+              }
+              return stream;
+            },
+            (error: unknown) => {
+              throw new Error(describeMicError(error));
+            },
           );
-        }
-        resourcesRef.current.context = context;
-        // Resume in case the browser created it suspended (pre-gesture).
-        if (context.state === 'suspended') await context.resume();
-        if (isStale()) {
-          stream.getTracks().forEach((track) => track.stop());
-          void context.close().catch(() => {});
-          return;
-        }
+        const [stream] = await Promise.all([streamPromise, contextReady]);
+        if (isStale()) return;
 
         const source = context.createMediaStreamSource(stream);
         const processor = context.createScriptProcessor(FRAME_SIZE, 1, 1);

--- a/packages/web-shell/vite.config.ts
+++ b/packages/web-shell/vite.config.ts
@@ -35,6 +35,10 @@ const daemonProxy: ProxyOptions = {
       proxyReq.removeHeader('origin');
       proxyReq.removeHeader('referer');
     });
+    proxy.on('proxyReqWs', (proxyReq) => {
+      proxyReq.removeHeader('origin');
+      proxyReq.removeHeader('referer');
+    });
   },
 };
 


### PR DESCRIPTION
## What this PR does

This PR stabilizes Web Shell voice dictation on mobile browsers. It starts and resumes the browser audio context directly from the initiating tap, bounds a stalled startup with cleanup, keeps the active voice control and Send reachable in narrow touch layouts, clears the no-speech notice after two seconds, and forwards development WebSocket upgrades without browser Origin or Referer headers.

## Why it's needed

Mobile browsers can keep an audio context suspended when it is resumed only after microphone permission resolves, because that continuation is no longer treated as part of the user gesture. Voice dictation then remains in a pulsing connecting state with no usable stop control or transcript. Narrow mobile toolbars can also crowd the active voice control, while the development proxy can reject the voice WebSocket upgrade with a 403/1006 path when Origin headers reach the daemon.

## Reviewer Test Plan

### How to verify

Enable voice dictation and open the Web Shell in a touch-device browser or Pixel 7 emulation. At a 240 px viewport, tap the microphone and confirm that the leading toolbar and More actions are hidden while the active voice control and Send remain visible. Confirm that cancelling remains possible while connecting, a suspended audio context resumes from the tap, a stalled startup releases microphone/audio resources after the timeout, and an empty final transcript disappears after two seconds. In development, confirm `/voice/stream` upgrades through Vite and negotiates the `qwen-ws` protocol.

### Evidence (Before & After)

Before: on mobile, the microphone icon could pulse indefinitely without reaching recording or producing a transcript; narrow toolbars could obscure the active control; the development WebSocket path could close with code 1006.

After: the focused unit suite passes 45/45, the complete mobile composer E2E suite passes 7/7 including the 240×700 active-voice layout, and a real Vite-proxied voice WebSocket opens with `qwen-ws` and closes normally with code 1000.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js 22, mobile Chromium Pixel 7 emulation, Web Shell Vite development server, and local daemon.

## Risk & Scope

- Main risk or tradeoff: Mobile voice startup now has a 60-second bound, after which microphone and audio resources are released and the user can retry.
- Not validated / out of scope: Native-device coverage outside Chromium and proxy configuration owned by external Web Shell hosts.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 提升了 Web Shell 在移动浏览器中的语音输入稳定性：在用户点击的同步调用链中创建并恢复浏览器音频上下文；为卡住的启动过程增加超时与资源清理；在狭窄触控布局中保留可操作的语音控件和发送按钮；让“未检测到语音”提示在两秒后消失；并在开发代理转发 WebSocket Upgrade 时移除浏览器的 Origin 和 Referer 请求头。

## 为什么需要

移动浏览器中，如果等待麦克风权限完成后才恢复音频上下文，该异步续接可能不再被视为用户手势的一部分，音频上下文会一直保持挂起。此时语音按钮会持续闪烁在连接状态，没有可用的停止控件，也不会产生转写结果。狭窄的移动端工具栏还可能挤压正在使用的语音控件；开发代理将 Origin 头传给 daemon 时，语音 WebSocket Upgrade 也可能走到 403/1006 的失败路径。

## Reviewer Test Plan

### 如何验证

启用语音输入，在触控设备浏览器或 Pixel 7 模拟环境中打开 Web Shell。将视口设为 240 px，点击麦克风，确认左侧工具栏和“更多操作”被隐藏，正在使用的语音控件与发送按钮仍然可见。确认连接过程中仍可取消；挂起的音频上下文会由本次点击恢复；启动卡住时会在超时后释放麦克风和音频资源；空转写结果的提示会在两秒后消失。在开发环境中，确认 `/voice/stream` 可通过 Vite 完成 Upgrade，并协商出 `qwen-ws` 协议。

### 证据（修改前后）

修改前：移动端麦克风图标可能持续闪烁，无法进入录音或生成转写；狭窄工具栏可能遮挡正在使用的控件；开发环境的 WebSocket 可能以 1006 关闭。

修改后：相关单测 45/45 通过；完整移动端 composer E2E 7/7 通过，其中包含 240×700 的语音激活布局；真实经过 Vite 代理的语音 WebSocket 使用 `qwen-ws` 成功打开，并以 1000 正常关闭。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

Node.js 22、移动 Chromium Pixel 7 模拟、Web Shell Vite 开发服务和本地 daemon。

## 风险与范围

- 主要风险或取舍：移动端语音启动现在有 60 秒上限，超时后会释放麦克风和音频资源，用户可重新尝试。
- 未验证 / 范围之外：Chromium 之外的真机覆盖，以及外部 Web Shell 宿主自行维护的代理配置。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无

</details>
