### PR TITLE
fix(test): give every E2E case a clean directory again

### DIFF
--- a/integration-tests/sdk-typescript/test-helper.ts
+++ b/integration-tests/sdk-typescript/test-helper.ts
@@ -77,6 +77,13 @@ export class SDKTestHelper {
     const sanitizedName = this.sanitizeTestName(testName);
     this.testDir = join(this.baseDir, sanitizedName);
 
+    // Suites call setup() from beforeEach with a fixed name, so every case in a
+    // file lands in this same directory — and cleanup() below keeps it whenever
+    // KEEP_OUTPUT is set, which CI always sets. Without this reset one case's
+    // files stay visible to the next: a `.env` written by an earlier case made a
+    // later write fail the prior-read check instead of the permission check it
+    // was asserting, so the suite passed locally and failed only in CI.
+    await rm(this.testDir, { recursive: true, force: true });
     await mkdir(this.testDir, { recursive: true });
 
     // Optionally create .qwen/settings.json for CLI configuration

--- a/integration-tests/test-helper.ts
+++ b/integration-tests/test-helper.ts
@@ -5,7 +5,7 @@
  */
 
 import { execSync, spawn } from 'node:child_process';
-import { mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { mkdirSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { env } from 'node:process';
@@ -167,6 +167,11 @@ export class TestRig {
     this.testName = testName;
     const sanitizedName = sanitizeTestName(testName);
     this.testDir = join(env['INTEGRATION_TEST_FILE_DIR']!, sanitizedName);
+    // Two cases that set up under the same name share this directory, and
+    // cleanup() below keeps it whenever KEEP_OUTPUT is set — which CI always
+    // sets. Reset it so a case never inherits the previous one's files; see the
+    // SDK helper, where exactly that made a suite pass locally and fail in CI.
+    rmSync(this.testDir, { recursive: true, force: true });
     mkdirSync(this.testDir, { recursive: true });
 
     // Create a settings file to point the CLI to the local collector


### PR DESCRIPTION
## What this PR does

Makes each E2E case start from a clean working directory again, which fixes the tool-control case that has been failing on `main` since 2026-07-26.

The E2E helpers set up under a fixed name, so every case in a file shares one directory, and the teardown that would remove it is skipped whenever `KEEP_OUTPUT` is set. CI always sets it and local runs never do, so in CI one case's files stayed visible to the next. Setting up now clears the directory first: a case starts from the same state in CI that it has always had locally, and `KEEP_OUTPUT` keeps the artefacts of the run that produced them instead of a mixture of several. The helper used by the CLI suites gets the same treatment — those mostly set up under a per-case name, but not all of them do.

## Why it's needed

The failing case writes two files and asserts that one is auto-approved by the allow pattern while the other is refused by the permission callback. What actually came back for the second file was the prior-read refusal: an earlier case in the same file writes a `.env`, that file was still there, and writing over an existing file requires reading it first. So the write never reached the permission layer the case was testing.

That is also why the failure looked like flakiness and survived several rounds of deflaking, including a migration of this very case to the deterministic fake model: the assertion was never the unstable part. It fails the same way every time in CI and passes every time locally, purely because of `KEEP_OUTPUT`.

Every completed E2E run on `main` between 2026-07-26 14:53 UTC and this PR failed on exactly this case — runs 3341, 3345, 3346, 3350, 3352 and 3354, on both the Linux and the macOS legs — and each one opened its own duplicate issue.

## Reviewer Test Plan

### How to verify

The failure reproduces locally once the environment matches CI. Build the bundle, then run the file with the leftover-producing case included and `KEEP_OUTPUT` set — the deterministic cases need no model credentials:

```
npx cross-env QWEN_SANDBOX=false KEEP_OUTPUT=true vitest run --root ./integration-tests \
  sdk-typescript/tool-control.test.ts --retry=0 -t "path patterns"
```

Before this change that fails with `File …/.env has not been read in this session`, character for character what CI reported. After it, the same command passes. Dropping `KEEP_OUTPUT` makes it pass either way, which is the whole point: without this change local runs cannot see the bug.

I also ran the other deterministic cases in that file, plus three model-free CLI suites that exercise the sibling helper (settings-migration, qwen-config-dir, json-schema), all with `KEEP_OUTPUT=true`. They pass. One case in the tool-control file, the shell-command allow pattern, fails on my machine both with and without this change — it expects `rm` to be refused and here it runs; that is a local root-user artefact, it is green in CI, and it is untouched by this PR.

### Evidence (Before & After)

N/A — test infrastructure, no user-visible surface.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Linux, `npm ci` plus the bundled CLI, running the integration suite directly against the fake OpenAI server.

## Risk & Scope

- Main risk or tradeoff: a suite that deliberately carried state from one case to the next through the shared directory would now lose it. Nothing can be relying on that today, because local runs have always removed the directory between cases — such a suite would already fail locally. `KEEP_OUTPUT` also now keeps one directory per name rather than an accumulation, which is what makes the kept output attributable.
- Not validated / out of scope: the suites that need real model credentials were not run locally; the full suite runs on merge. The prior-read behaviour itself is correct and unchanged — this PR only stops a leftover file from putting a case on that path.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #7755, fixes #7759, fixes #7773, fixes #7777, fixes #7780, fixes #7787 — all six are the same failing case, filed once per commit by the per-commit issue keying that #7795 replaces.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让每个 E2E 用例重新从干净的工作目录开始，从而修复自 2026-07-26 起在 `main` 上一直失败的那个 tool-control 用例。

E2E 的两个 helper 都用固定名字创建目录，因此同一文件里的每个用例共享一个目录；而负责删除它的清理逻辑在设置了 `KEEP_OUTPUT` 时会被跳过——CI 总是设置它，本地从不设置，于是在 CI 里前一个用例的文件对后一个用例仍然可见。现在创建目录前会先清空：用例在 CI 里的起始状态和它在本地一直以来的状态一致，而 `KEEP_OUTPUT` 保留的是产生这些产物的那次运行的结果，而不是好几次混在一起。CLI 套件使用的那个 helper 也做同样处理——它们大多按用例命名目录，但并非全部。

## 为什么需要

失败的用例写两个文件，并断言其中一个被允许模式自动放行，另一个被权限回调拒绝。实际返回的却是"需先读取"的拒绝：同一文件里更早的一个用例写过一个 `.env`，那个文件还在，而覆盖已存在的文件需要先读取它。于是这次写入根本没走到用例想测试的权限层。

这也是为什么这个失败看起来像不稳定，并且熬过了几轮 deflake（包括把这个用例本身迁移到确定性的 fake model）：不稳定的从来就不是断言。它在 CI 里每次都以同样方式失败，在本地每次都通过，纯粹是因为 `KEEP_OUTPUT`。

2026-07-26 14:53 UTC 到本 PR 之间，`main` 上每一次跑完的 E2E 都倒在这个用例上——run 3341、3345、3346、3350、3352、3354，Linux 和 macOS 两条腿都是——而且每一次都开了一个重复的 issue。

## 审查者测试计划

### 如何验证

只要把环境对齐到 CI，这个失败在本地可以复现。构建 bundle 之后，连同那个留下残留文件的用例一起运行，并设置 `KEEP_OUTPUT`——这些确定性用例不需要模型凭据：

```
npx cross-env QWEN_SANDBOX=false KEEP_OUTPUT=true vitest run --root ./integration-tests \
  sdk-typescript/tool-control.test.ts --retry=0 -t "path patterns"
```

改动之前，它会以 `File …/.env has not been read in this session` 失败，和 CI 报告的一字不差；改动之后，同样的命令通过。去掉 `KEEP_OUTPUT` 则两种情况都通过——这正是问题所在：没有这个改动，本地运行根本看不到这个 bug。

我还运行了该文件里其他确定性用例，以及三个不需要模型、会用到另一个 helper 的 CLI 套件（settings-migration、qwen-config-dir、json-schema），全部带 `KEEP_OUTPUT=true`，都通过。tool-control 文件里有一个用例（shell 命令允许模式）在我的机器上无论有没有这个改动都失败——它期望 `rm` 被拒绝，而这里它执行了；那是本地 root 用户造成的现象，在 CI 里是绿的，本 PR 也没有触及它。

### 证据（前后对比）

N/A —— 测试基础设施改动，没有用户可见的界面。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

### 环境（可选）

Linux，`npm ci` 加打包后的 CLI，直接针对 fake OpenAI server 运行集成套件。

## 风险与范围

- 主要风险或取舍：如果某个套件刻意通过共享目录把状态从一个用例带到下一个用例，现在会丢失。今天不可能有东西依赖这一点，因为本地运行一直都会在用例之间删除目录——这样的套件在本地早就失败了。另外 `KEEP_OUTPUT` 现在为每个名字保留一个目录而不是层层累积，这也正是保留下来的产物能对应到具体用例的原因。
- 未验证 / 不在范围内：需要真实模型凭据的套件没有在本地运行，完整套件在合并后运行。prior-read 行为本身是正确的、未做改动——本 PR 只是不再让残留文件把用例推到那条路径上。
- 破坏性变更 / 迁移说明：无。

## 关联 issue

Fixes #7755, fixes #7759, fixes #7773, fixes #7777, fixes #7780, fixes #7787 —— 这六个都是同一个失败用例，由按 commit 去重的 issue 创建逻辑每次合并各开一个；#7795 会替换掉那套逻辑。

</details>
