### PR TITLE
ci(release): comment released-in version on merged PRs

### DIFF
--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -154,7 +154,7 @@ jobs:
           set -euo pipefail
           # Squash-merge commit subjects carry the PR as "(#NNN)"; collect those between the two tags.
           # The trailing "|| true" keeps "no matches" (empty range) from failing under pipefail.
-          pr_numbers="$(git log --pretty=format:'%s' "${PREVIOUS_TAG}..${RELEASE_TAG}" | grep -oE '#[0-9]+' | tr -d '#' | sort -un || true)"
+          pr_numbers="$(git log --pretty=format:'%s' "${PREVIOUS_TAG}..${RELEASE_TAG}" | grep -oE '\(#[0-9]+\)$' | tr -d '()#' | sort -un || true)"
           if [[ -z "${pr_numbers}" ]]; then
             echo "No PR references found between ${PREVIOUS_TAG} and ${RELEASE_TAG}."
             exit 0

--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -142,6 +142,41 @@ jobs:
             echo "::warning::AI release notes were not generated; keeping GitHub-generated notes."
           fi
 
+      - name: 'Comment released-in version on merged PRs'
+        if: |-
+          ${{ steps.meta.outputs.is_stable == 'true' }}
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: '${{ secrets.CI_BOT_PAT }}'
+          PREVIOUS_TAG: '${{ steps.previous.outputs.tag }}'
+          RELEASE_TAG: '${{ env.RELEASE_TAG }}'
+        run: |-
+          set -euo pipefail
+          # Squash-merge commit subjects carry the PR as "(#NNN)"; collect those between the two tags.
+          # The trailing "|| true" keeps "no matches" (empty range) from failing under pipefail.
+          pr_numbers="$(git log --pretty=format:'%s' "${PREVIOUS_TAG}..${RELEASE_TAG}" | grep -oE '#[0-9]+' | tr -d '#' | sort -un || true)"
+          if [[ -z "${pr_numbers}" ]]; then
+            echo "No PR references found between ${PREVIOUS_TAG} and ${RELEASE_TAG}."
+            exit 0
+          fi
+          echo "Found PRs between ${PREVIOUS_TAG} and ${RELEASE_TAG}:"
+          echo "${pr_numbers}"
+          marker='<!-- qwen-release-comment:v1 -->'
+          release_url="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG}"
+          while IFS= read -r num; do
+            if [[ -z "${num}" ]]; then
+              continue
+            fi
+            # Re-run safety: skip PRs that already carry this release marker.
+            existing="$(gh pr view "${num}" --json comments --jq '.comments[].body' 2>/dev/null || true)"
+            if grep -qF "${marker}" <<<"${existing}"; then
+              echo "PR #${num} already has a release comment; skipping."
+              continue
+            fi
+            body="${marker}"$'\n'"Released in [${RELEASE_TAG}](${release_url})."
+            gh pr comment "${num}" --body "${body}" && echo "Commented on PR #${num}." || echo "::warning::Failed to comment on PR #${num}."
+          done <<< "${pr_numbers}"
+
       - name: 'Regenerate CHANGELOG.md'
         if: |-
           ${{ steps.meta.outputs.is_stable == 'true' }}

--- a/scripts/tests/ai-release-notes-workflow.test.js
+++ b/scripts/tests/ai-release-notes-workflow.test.js
@@ -85,6 +85,20 @@ describe('stable release notes workflow', () => {
     );
   });
 
+  it('comments released-in version only for squash-merge PR trailers', () => {
+    const step = getStep(
+      finalizeWorkflow,
+      'Comment released-in version on merged PRs',
+    );
+
+    expect(step).toContain("grep -oE '\\(#[0-9]+\\)$'");
+    expect(step).toContain("tr -d '()#'");
+    expect(step).not.toContain("grep -oE '#[0-9]+'");
+    expect(step).toContain("marker='<!-- qwen-release-comment:v1 -->'");
+    expect(step).toContain('gh pr view "${num}" --json comments');
+    expect(step).toContain('gh pr comment "${num}" --body "${body}"');
+  });
+
   it('does not recreate an already merged release PR during retries', () => {
     const pr = getStep(
       finalizeWorkflow,

--- a/scripts/tests/ai-release-notes-workflow.test.js
+++ b/scripts/tests/ai-release-notes-workflow.test.js
@@ -91,11 +91,13 @@ describe('stable release notes workflow', () => {
       'Comment released-in version on merged PRs',
     );
 
+    expect(step).toContain('continue-on-error: true');
     expect(step).toContain("grep -oE '\\(#[0-9]+\\)$'");
     expect(step).toContain("tr -d '()#'");
     expect(step).not.toContain("grep -oE '#[0-9]+'");
     expect(step).toContain("marker='<!-- qwen-release-comment:v1 -->'");
     expect(step).toContain('gh pr view "${num}" --json comments');
+    expect(step).toContain('grep -qF "${marker}" <<<"${existing}"');
     expect(step).toContain('gh pr comment "${num}" --body "${body}"');
   });
 


### PR DESCRIPTION
## What this PR does

When a stable release is published, the release finalization job now leaves a short comment on every PR that landed in that release, linking to the release tag. The comment carries a hidden marker so it can be detected later, and posting it is best-effort — any failure (a number that resolves to an issue rather than a PR, a rate-limited call) is logged as a warning and never blocks the release.

## Why it's needed

Once a PR is merged, there is no easy way to look at that PR and tell which stable version shipped it. Release notes answer "version → PR", but contributors usually want the reverse: "my PR → which release". Tagging PRs with per-version labels does not scale (one label per release forever), so a timestamped bot comment on the PR timeline is the standard pattern used by projects like angular/babel/vue, and it keeps the label namespace clean.

## Reviewer Test Plan

### How to verify

The step only runs on real stable releases, so the lightest confirmation path is:

1. Trigger the finalization workflow manually on an already-shipped stable tag (e.g. v0.20.1) via the workflow_dispatch input `tag = v0.20.1`. The comment is marker-tagged and the merge-back PR is skipped when already merged, so re-running on a past tag is safe and idempotent.
2. Pick a few PRs from the v0.20.1 release notes and confirm a "Released in [v0.20.1](...)" comment now appears on each, posted by the CI bot.
3. Trigger the same dispatch again; the second run should log "already has a release comment; skipping" for every PR and post nothing new (marker dedup).
4. Inspect the run log for the new step: it prints "Found N PRs between v0.20.0 and v0.20.1", then one line per PR.

### Evidence (Before & After)

N/A — non-UI change. The PR-timeline outcome is what the "How to verify" steps produce.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ⚠️   |

The bash enumeration logic was dry-run locally against real tags (v0.20.1..v0.21.0 resolved 137 PRs; the empty-range path exits 0 cleanly). Actual comment posting only happens inside the ubuntu-latest runner.

### Environment (optional)

N/A — change is to a GitHub Actions workflow; no local runtime involved.

## Risk & Scope

- Main risk or tradeoff: On a large release (~150 PRs) the step issues ~300 API calls (one `gh pr view` + one `gh pr comment` per PR), well within the 5000/hr authenticated limit but visible in the run. Posting is best-effort with `continue-on-error`, so a partial failure never breaks the release.
- Not validated / out of scope: Nightly and preview releases are intentionally excluded (finalization only handles stable tags). False-positive `#NNN` matches that resolve to issues rather than PRs are tolerated — `gh pr comment` fails on them and the step logs a warning and continues.
- Breaking changes / migration notes: None. Purely additive step; no existing finalization behavior changes.

## Linked Issues

None — opened per maintainer request.

<details>
<summary>中文说明</summary>

## 这个 PR 做什么

稳定版发布后，发布收尾任务会为该版本包含的每个 PR 留下一句简短评论，并附上 release tag 链接。评论带有一个隐藏 marker 以便后续识别；投递是 best-effort 的——任何失败（编号实为 issue 而非 PR、限流）只记为 warning，绝不阻塞发布。

## 为什么需要

PR 合并后，没有便捷的办法从 PR 反查它进了哪个稳定版本。Release notes 只回答「版本 → PR」，而贡献者通常要的是反方向「我的 PR → 哪个版本」。按版本打 label 不可持续（版本无限多），所以用带时间戳的 bot 评论记录在 PR timeline 上，是 angular/babel/vue 等项目的标准做法，也不污染 label 命名空间。

## 评审验证计划

### 如何验证

该 step 仅在真实稳定版发布时触发，最轻的验证路径是：

1. 对已发布的稳定 tag（如 v0.20.1）用 workflow_dispatch 输入 `tag = v0.20.1` 手动触发收尾 workflow。评论带 marker，且回合 PR 在已合并时会被跳过，故对历史 tag 重跑是安全幂等的。
2. 从 v0.20.1 的 release notes 里挑几个 PR，确认每个 PR 上都出现了由 CI bot 发的 "Released in [v0.20.1](...)" 评论。
3. 再次触发同一 dispatch；第二次应为每个 PR 输出 "already has a release comment; skipping" 且不发新评论（marker 去重）。
4. 查看新 step 的运行日志：先打印 "Found N PRs between v0.20.0 and v0.20.1"，随后每个 PR 一行。

### 证据（Before & After）

N/A —— 非 UI 改动。PR timeline 上的结果即「如何验证」步骤的产物。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  |  ⚠️  |

bash 枚举逻辑已在本地用真实 tag 干跑（v0.20.1..v0.21.0 解析出 137 个 PR；空范围路径干净退出 0）。实际评论投递只发生在 ubuntu-latest runner 内。

### 环境

N/A —— 改动为 GitHub Actions workflow，无本地运行时。

## 风险与范围

- 主要风险/取舍：大版本（约 150 PR）该 step 会发约 300 次 API 调用（每 PR 一次 `gh pr view` + 一次 `gh pr comment`），远低于认证 5000/小时限额，但在 run 中可见。投递为 best-effort，带 `continue-on-error`，部分失败绝不阻塞发布。
- 未覆盖/超出范围：nightly 与 preview 发布被有意排除（收尾只处理稳定 tag）。grep 误匹配到的 `#NNN` 若实为 issue 而非 PR 会被容忍——`gh pr comment` 会失败，step 记 warning 后继续。
- 破坏性变更/迁移说明：无。纯新增 step，不改变任何既有收尾行为。

## 关联 Issue

无——按 maintainer 要求开启。

</details>
