### PR TITLE
feat(core): persist and replay Goal v3 state

### DIFF
--- a/packages/acp-bridge/src/transcript-replay.test.ts
+++ b/packages/acp-bridge/src/transcript-replay.test.ts
@@ -112,6 +112,26 @@ describe('createTranscriptReplayMachine', () => {
     });
   });
 
+  it('emits legacy goalTerminal metadata for a terminal goal_state', () => {
+    const projected = updates(
+      createTranscriptReplayMachine(),
+      goalStateRecord('goal-complete', 'complete', {
+        ...GOAL,
+        status: 'complete',
+      }),
+    );
+
+    expect(projected[0]?._meta).toMatchObject({
+      goalStatus: { kind: 'achieved', condition: GOAL.objective },
+      goalTerminal: {
+        kind: 'achieved',
+        condition: GOAL.objective,
+        iterations: GOAL.turnCount,
+        durationMs: GOAL.activeTimeMs,
+      },
+    });
+  });
+
   it('reports and skips a malformed goal_state record', () => {
     const onDiagnostic = vi.fn();
     const machine = createTranscriptReplayMachine({ onDiagnostic });

--- a/packages/acp-bridge/src/transcript-replay.test.ts
+++ b/packages/acp-bridge/src/transcript-replay.test.ts
@@ -356,6 +356,33 @@ describe('createTranscriptReplayMachine', () => {
     ).toThrow('Unsupported transcript replay state version');
   });
 
+  it('drops a malformed goalState from initialState and reports it', () => {
+    const onDiagnostic = vi.fn();
+    const machine = createTranscriptReplayMachine({
+      onDiagnostic,
+      initialState: {
+        v: 1,
+        pendingToolCalls: [],
+        cumulativeUsage: {
+          promptTokens: 0,
+          cachedTokens: 0,
+          candidateTokens: 0,
+          apiTimeMs: 0,
+        },
+        goalState: { v: 2, activity: 'bogus', goal: null },
+      } as unknown as TranscriptReplayStateV1,
+    });
+
+    expect(onDiagnostic).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'invalid_replay_state',
+        message: 'Dropped a malformed Goal state from replay state.',
+        affectsCompleteness: true,
+      }),
+    );
+    expect(machine.snapshot().goalState).toBeUndefined();
+  });
+
   it('emits gaps, todo plans, and cumulative usage deterministically', () => {
     const machine = createTranscriptReplayMachine({
       gaps: [{ childUuid: 'assistant-1', missingParentUuid: 'missing' }],

--- a/packages/acp-bridge/src/transcript-replay.test.ts
+++ b/packages/acp-bridge/src/transcript-replay.test.ts
@@ -11,6 +11,23 @@ import {
   type TranscriptReplayStateV1,
 } from './transcript-replay.js';
 import type { TranscriptRecordInput } from '@qwen-code/qwen-code-core/transcriptRecords';
+import type {
+  GoalRecord,
+  GoalStateCause,
+} from '@qwen-code/qwen-code-core/goalWire';
+
+const GOAL: GoalRecord = {
+  goalId: 'goal-1',
+  revision: 3,
+  objective: 'ship it',
+  status: 'active',
+  evidenceCursor: { recordId: 'record-0' },
+  turnCount: 4,
+  activeTimeMs: 2000,
+  createdAt: 100,
+  updatedAt: 200,
+  lastReason: 'continuing',
+};
 
 function record(
   uuid: string,
@@ -34,7 +51,89 @@ function updates(
   return [...machine.project(item)].map((emission) => emission.update);
 }
 
+function goalStateRecord(
+  uuid: string,
+  cause: GoalStateCause,
+  goal: GoalRecord | null,
+): TranscriptRecordInput {
+  return record(uuid, 'system', {
+    subtype: 'goal_state',
+    systemPayload: {
+      v: 2,
+      cause,
+      snapshot: { v: 2, activity: 'idle', goal },
+    },
+  });
+}
+
 describe('createTranscriptReplayMachine', () => {
+  it('does not replay internal Goal runtime prompts as user messages', () => {
+    expect(
+      updates(
+        createTranscriptReplayMachine(),
+        record('goal-runtime', 'user', {
+          subtype: 'goal_runtime',
+          message: { role: 'user', parts: [{ text: 'Continue working.' }] },
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it('projects goal_state through v2-first metadata', () => {
+    const projected = updates(
+      createTranscriptReplayMachine(),
+      goalStateRecord('goal-create', 'create', GOAL),
+    );
+
+    expect(projected).toHaveLength(1);
+    expect(projected[0]?._meta).toMatchObject({
+      goalState: { v: 2, goal: GOAL, activity: 'idle' },
+      goalStatus: { kind: 'set', condition: GOAL.objective },
+      'qwen.session.recordId': 'goal-create',
+    });
+  });
+
+  it('tracks Goal state across replay pages', () => {
+    const first = createTranscriptReplayMachine();
+    updates(first, goalStateRecord('goal-create', 'create', GOAL));
+    const second = createTranscriptReplayMachine({
+      initialState: first.snapshot(),
+    });
+
+    const projected = updates(
+      second,
+      goalStateRecord('goal-clear', 'clear', null),
+    );
+
+    expect(projected[0]?._meta).toMatchObject({
+      goalState: { v: 2, goal: null, activity: 'idle' },
+      goalStatus: { kind: 'cleared', condition: GOAL.objective },
+      'qwen.session.recordId': 'goal-clear',
+    });
+  });
+
+  it('reports and skips a malformed goal_state record', () => {
+    const onDiagnostic = vi.fn();
+    const machine = createTranscriptReplayMachine({ onDiagnostic });
+    const malformed = record('goal-malformed', 'system', {
+      subtype: 'goal_state',
+      systemPayload: {
+        v: 2,
+        cause: 'create',
+        snapshot: { v: 2, activity: 'running', goal: GOAL },
+      },
+    });
+
+    expect(updates(machine, malformed)).toEqual([]);
+    expect(onDiagnostic).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'malformed_goal_state',
+        recordId: 'goal-malformed',
+        path: 'systemPayload',
+      }),
+    );
+  });
+
   it('projects ordered message parts with source metadata', () => {
     const machine = createTranscriptReplayMachine();
     const projected = updates(

--- a/packages/acp-bridge/src/transcript-replay.ts
+++ b/packages/acp-bridge/src/transcript-replay.ts
@@ -15,6 +15,12 @@ import type {
   TranscriptRecordInput,
   TranscriptReplayGapInput,
 } from '@qwen-code/qwen-code-core/transcriptRecords';
+import {
+  parseGoalSnapshotV2,
+  parseGoalStateRecordPayloadV2,
+  projectGoalStateToLegacy,
+  type GoalSnapshotV2,
+} from '@qwen-code/qwen-code-core/goalWire';
 
 export const MISSING_TRANSCRIPT_TOOL_RESULT_MESSAGE =
   'Tool result missing from saved history; the previous run likely ended ' +
@@ -45,6 +51,7 @@ export interface TranscriptReplayStateV1 {
   readonly v: 1;
   readonly pendingToolCalls: readonly PendingTranscriptToolCall[];
   readonly cumulativeUsage: TranscriptReplayUsageState;
+  readonly goalState?: GoalSnapshotV2;
 }
 
 export interface TranscriptReplayToolMetadata {
@@ -349,6 +356,7 @@ class DefaultTranscriptReplayMachine implements TranscriptReplayMachine {
     apiTimeMs: number;
   };
   private finalized = false;
+  private goalState: GoalSnapshotV2 | undefined;
 
   constructor(private readonly options: TranscriptReplayMachineOptions) {
     const initialState = parseInitialState(
@@ -356,6 +364,7 @@ class DefaultTranscriptReplayMachine implements TranscriptReplayMachine {
       options.onDiagnostic,
     );
     this.usage = { ...initialState.cumulativeUsage };
+    this.goalState = initialState.goalState;
     for (const pending of initialState.pendingToolCalls) {
       this.pendingToolCalls.set(pending.callId, pending);
       this.usedToolCallIds.add(pending.callId);
@@ -455,6 +464,7 @@ class DefaultTranscriptReplayMachine implements TranscriptReplayMachine {
         ...pending,
       })),
       cumulativeUsage: { ...this.usage },
+      ...(this.goalState ? { goalState: this.goalState } : {}),
     };
   }
 
@@ -464,6 +474,7 @@ class DefaultTranscriptReplayMachine implements TranscriptReplayMachine {
     meta: UpdateMetaOptions,
   ): Iterable<TranscriptReplayEmission> {
     if (
+      record.subtype === 'goal_runtime' ||
       record.subtype === 'notification' ||
       record.subtype === 'cron' ||
       record.subtype === 'mid_turn_user_message'
@@ -704,6 +715,40 @@ class DefaultTranscriptReplayMachine implements TranscriptReplayMachine {
     emit: (update: SessionUpdate) => TranscriptReplayEmission,
     meta: UpdateMetaOptions,
   ): Iterable<TranscriptReplayEmission> {
+    if (record.subtype === 'goal_state') {
+      const payload = parseGoalStateRecordPayloadV2(record.systemPayload);
+      if (!payload) {
+        this.report(
+          'malformed_goal_state',
+          'Skipped a malformed Goal state transcript record.',
+          record.uuid,
+          'systemPayload',
+        );
+        return;
+      }
+      const projection = projectGoalStateToLegacy(
+        payload,
+        this.goalState?.goal ?? null,
+      );
+      this.goalState = payload.snapshot;
+      const { type: _type, ...goalStatus } = projection.goalStatus;
+      yield emit(
+        createTranscriptMessageUpdate({
+          role: 'assistant',
+          text: '',
+          ...meta,
+          extra: {
+            goalState: payload.snapshot,
+            goalStatus,
+            ...(projection.goalTerminal
+              ? { goalTerminal: projection.goalTerminal }
+              : {}),
+            'qwen.session.recordId': record.uuid,
+          },
+        }),
+      );
+      return;
+    }
     if (record.subtype !== 'slash_command') return;
     const payload = isObjectRecord(record.systemPayload)
       ? record.systemPayload
@@ -982,6 +1027,17 @@ function parseInitialState(
       affectsCompleteness: true,
     });
   }
+  const rawGoalState = value['goalState'];
+  const goalState =
+    rawGoalState === undefined ? undefined : parseGoalSnapshotV2(rawGoalState);
+  if (rawGoalState !== undefined && !goalState) {
+    onDiagnostic?.({
+      code: 'invalid_replay_state',
+      severity: 'warning',
+      message: 'Dropped a malformed Goal state from replay state.',
+      affectsCompleteness: true,
+    });
+  }
   return {
     v: 1,
     pendingToolCalls,
@@ -993,6 +1049,7 @@ function parseInitialState(
           apiTimeMs: usage['apiTimeMs'] as number,
         }
       : emptyUsage(),
+    ...(goalState ? { goalState } : {}),
   };
 }
 

--- a/packages/acp-bridge/vitest.config.ts
+++ b/packages/acp-bridge/vitest.config.ts
@@ -5,8 +5,21 @@
  */
 
 import { defineConfig } from 'vitest/config';
+import path from 'node:path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@qwen-code/qwen-code-core/goalWire': path.resolve(
+        __dirname,
+        '../core/src/goals/goal-wire.ts',
+      ),
+      '@qwen-code/qwen-code-core/transcriptRecords': path.resolve(
+        __dirname,
+        '../core/src/utils/transcript-records.ts',
+      ),
+    },
+  },
   test: {
     reporters: ['default'],
     silent: true,

--- a/packages/cli/src/acp-integration/session/history-replay-page.test.ts
+++ b/packages/cli/src/acp-integration/session/history-replay-page.test.ts
@@ -6,6 +6,7 @@
 
 import type {
   ChatRecord,
+  GoalSnapshotV2,
   SessionTranscriptCursorState,
   SessionTranscriptRecordPage,
 } from '@qwen-code/qwen-code-core';
@@ -19,6 +20,21 @@ import {
 
 const SESSION_ID = '550e8400-e29b-41d4-a716-446655440000';
 const TIMESTAMP = '2026-07-12T00:00:00.000Z';
+const GOAL_STATE: GoalSnapshotV2 = {
+  v: 2,
+  activity: 'idle',
+  goal: {
+    goalId: 'goal-1',
+    revision: 1,
+    objective: 'ship it',
+    status: 'active',
+    evidenceCursor: { recordId: 'goal-state' },
+    turnCount: 2,
+    activeTimeMs: 1000,
+    createdAt: 1,
+    updatedAt: 2,
+  },
+};
 
 function userRecord(): ChatRecord {
   return {
@@ -183,6 +199,36 @@ describe('history replay page', () => {
       gaps: [],
     });
     expect(encodeCursor).toHaveBeenCalledWith(cursorState());
+  });
+
+  it('passes authoritative Goal state into backward replay', async () => {
+    const replayPage = vi
+      .spyOn(HistoryReplayer.prototype, 'replayPage')
+      .mockResolvedValueOnce({
+        pendingToolCalls: [],
+        replay: {
+          v: 1,
+          pendingToolCalls: [],
+          cumulativeUsage: createReplayCumulativeUsage(),
+          goalState: GOAL_STATE,
+        },
+      });
+
+    await replayTranscriptRecordPage({
+      sessionId: SESSION_ID,
+      page: recordPage({
+        direction: 'backward',
+        replay: { goalState: GOAL_STATE },
+      }),
+      encodeCursor: vi.fn(),
+    });
+
+    expect(replayPage).toHaveBeenCalledWith([], {
+      pendingToolCalls: [],
+      finalizeDangling: true,
+      gaps: [],
+      goalState: GOAL_STATE,
+    });
   });
 
   it('terminates pagination when replay conversion fails', async () => {

--- a/packages/cli/src/acp-integration/session/history-replay-page.test.ts
+++ b/packages/cli/src/acp-integration/session/history-replay-page.test.ts
@@ -231,6 +231,70 @@ describe('history replay page', () => {
     });
   });
 
+  it('seeds backward replay so a cleared Goal keeps its prior condition', async () => {
+    // Drives the real (unspied) replayPage: the authoritative pre-page Goal
+    // state must seed the replay machine so a `clear` record still projects its
+    // original condition, iteration count, and timing. Without the seed the
+    // cleared card degrades to an empty condition.
+    const priorGoalState: GoalSnapshotV2 = {
+      v: 2,
+      activity: 'idle',
+      goal: {
+        goalId: 'goal-1',
+        revision: 1,
+        objective: 'ship the transcript work',
+        status: 'active',
+        evidenceCursor: { recordId: 'goal-state' },
+        turnCount: 3,
+        activeTimeMs: 1234,
+        createdAt: 10,
+        updatedAt: 20,
+      },
+    };
+    const goalClearRecord = {
+      uuid: 'goal-clear',
+      parentUuid: 'u2',
+      sessionId: SESSION_ID,
+      timestamp: TIMESTAMP,
+      type: 'system',
+      subtype: 'goal_state',
+      cwd: '/workspace',
+      version: '1.0.0',
+      systemPayload: {
+        v: 2,
+        cause: 'clear',
+        snapshot: { v: 2, activity: 'idle', goal: null },
+      },
+    } as unknown as ChatRecord;
+
+    const result = await replayTranscriptRecordPage({
+      sessionId: SESSION_ID,
+      page: recordPage({
+        direction: 'backward',
+        records: [goalClearRecord],
+        replay: { goalState: priorGoalState },
+      }),
+      encodeCursor: vi.fn(),
+    });
+
+    const goalUpdate = result.updates.find((update) => {
+      const meta = (update as { _meta?: Record<string, unknown> })._meta;
+      return meta?.['goalStatus'] !== undefined;
+    }) as { _meta?: Record<string, unknown> } | undefined;
+
+    expect(goalUpdate?._meta).toMatchObject({
+      goalState: { v: 2, goal: null, activity: 'idle' },
+      goalStatus: {
+        kind: 'cleared',
+        condition: 'ship the transcript work',
+        iterations: 3,
+        setAt: 10,
+        durationMs: 1234,
+      },
+    });
+    expect(goalUpdate?._meta?.['goalStatus']).not.toHaveProperty('type');
+  });
+
   it('terminates pagination when replay conversion fails', async () => {
     vi.spyOn(HistoryReplayer.prototype, 'replayPage').mockRejectedValueOnce(
       new Error('replay failed'),

--- a/packages/cli/src/acp-integration/session/history-replay-page.test.ts
+++ b/packages/cli/src/acp-integration/session/history-replay-page.test.ts
@@ -231,6 +231,38 @@ describe('history replay page', () => {
     });
   });
 
+  it('drops a malformed goalState from replay state and warns', async () => {
+    const logger = { warn: vi.fn() };
+    const replayPage = vi
+      .spyOn(HistoryReplayer.prototype, 'replayPage')
+      .mockResolvedValueOnce({
+        pendingToolCalls: [],
+        replay: {
+          v: 1,
+          pendingToolCalls: [],
+          cumulativeUsage: createReplayCumulativeUsage(),
+        },
+      });
+
+    await replayTranscriptRecordPage({
+      sessionId: SESSION_ID,
+      page: recordPage({
+        replay: { goalState: { v: 2, activity: 'bogus', goal: null } },
+      }),
+      encodeCursor: vi.fn(),
+      logger,
+    });
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[transcript] replay state dropped a malformed Goal state',
+    );
+    expect(replayPage).toHaveBeenCalledWith([], {
+      pendingToolCalls: [],
+      finalizeDangling: true,
+      gaps: [],
+    });
+  });
+
   it('seeds backward replay so a cleared Goal keeps its prior condition', async () => {
     // Drives the real (unspied) replayPage: the authoritative pre-page Goal
     // state must seed the replay machine so a `clear` record still projects its

--- a/packages/cli/src/acp-integration/session/history-replay-page.ts
+++ b/packages/cli/src/acp-integration/session/history-replay-page.ts
@@ -183,7 +183,6 @@ export async function collectHistoryReplayUpdates({
   records,
   gaps,
   cumulativeUsage,
-  goalState,
   logger,
   supersedeUnrestorableGoal,
 }: {
@@ -192,7 +191,6 @@ export async function collectHistoryReplayUpdates({
   records: ChatRecord[];
   gaps?: HistoryGap[];
   cumulativeUsage: CumulativeUsage;
-  goalState?: GoalSnapshotV2;
   logger?: ReplayLogger;
   /**
    * Forwarded to `HistoryReplayer`. Only the resume path, where
@@ -206,7 +204,7 @@ export async function collectHistoryReplayUpdates({
     await new HistoryReplayer(
       replayContext(sessionId, updates, cumulativeUsage, config),
       { supersedeUnrestorableGoal },
-    ).replay(records, gaps, goalState);
+    ).replay(records, gaps);
   } catch (error) {
     const replayError = error instanceof Error ? error.message : String(error);
     logger?.warn(

--- a/packages/cli/src/acp-integration/session/history-replay-page.ts
+++ b/packages/cli/src/acp-integration/session/history-replay-page.ts
@@ -4,12 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {
-  ChatRecord,
-  Config,
-  HistoryGap,
-  SessionTranscriptCursorState,
-  SessionTranscriptRecordPage,
+import {
+  parseGoalSnapshotV2,
+  type ChatRecord,
+  type Config,
+  type GoalSnapshotV2,
+  type HistoryGap,
+  type SessionTranscriptCursorState,
+  type SessionTranscriptRecordPage,
 } from '@qwen-code/qwen-code-core';
 import type { SessionUpdate } from '@agentclientprotocol/sdk';
 import type { TranscriptReplayStateV1 } from '@qwen-code/acp-bridge/transcriptReplay';
@@ -90,6 +92,7 @@ function parseTranscriptReplayState(
 ): {
   pendingToolCalls: PendingReplayToolCall[];
   cumulativeUsage: CumulativeUsage;
+  goalState?: GoalSnapshotV2;
 } {
   if (!isObjectRecord(replay)) {
     return {
@@ -132,7 +135,17 @@ function parseTranscriptReplayState(
   const cumulativeUsage = isCumulativeUsage(replay['cumulativeUsage'])
     ? { ...replay['cumulativeUsage'] }
     : createReplayCumulativeUsage();
-  return { pendingToolCalls, cumulativeUsage };
+  const rawGoalState = replay['goalState'];
+  const goalState =
+    rawGoalState === undefined ? undefined : parseGoalSnapshotV2(rawGoalState);
+  if (logger && rawGoalState !== undefined && !goalState) {
+    logger.warn('[transcript] replay state dropped a malformed Goal state');
+  }
+  return {
+    pendingToolCalls,
+    cumulativeUsage,
+    ...(goalState ? { goalState } : {}),
+  };
 }
 
 function replayContext(
@@ -170,6 +183,7 @@ export async function collectHistoryReplayUpdates({
   records,
   gaps,
   cumulativeUsage,
+  goalState,
   logger,
   supersedeUnrestorableGoal,
 }: {
@@ -178,6 +192,7 @@ export async function collectHistoryReplayUpdates({
   records: ChatRecord[];
   gaps?: HistoryGap[];
   cumulativeUsage: CumulativeUsage;
+  goalState?: GoalSnapshotV2;
   logger?: ReplayLogger;
   /**
    * Forwarded to `HistoryReplayer`. Only the resume path, where
@@ -191,7 +206,7 @@ export async function collectHistoryReplayUpdates({
     await new HistoryReplayer(
       replayContext(sessionId, updates, cumulativeUsage, config),
       { supersedeUnrestorableGoal },
-    ).replay(records, gaps);
+    ).replay(records, gaps, goalState);
   } catch (error) {
     const replayError = error instanceof Error ? error.message : String(error);
     logger?.warn(
@@ -254,6 +269,7 @@ export async function replayTranscriptRecordPage({
         page.direction === 'backward' ? [] : state.pendingToolCalls,
       finalizeDangling: page.direction === 'backward' || !page.hasMore,
       gaps: page.gaps,
+      ...(state.goalState ? { goalState: state.goalState } : {}),
     });
     replayState = replayPageState.replay;
   } catch (error) {

--- a/packages/cli/src/acp-integration/session/history-replayer.ts
+++ b/packages/cli/src/acp-integration/session/history-replayer.ts
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ChatRecord, HistoryGap } from '@qwen-code/qwen-code-core';
+import type {
+  ChatRecord,
+  GoalSnapshotV2,
+  HistoryGap,
+} from '@qwen-code/qwen-code-core';
 import {
   createTranscriptReplayMachine,
   MISSING_TRANSCRIPT_TOOL_RESULT_MESSAGE,
@@ -59,6 +63,7 @@ export interface HistoryReplayPageOptions {
   pendingToolCalls?: PendingReplayToolCall[];
   finalizeDangling?: boolean;
   gaps?: HistoryGap[];
+  goalState?: GoalSnapshotV2;
 }
 
 export interface HistoryReplayPageState {
@@ -103,9 +108,17 @@ export class HistoryReplayer {
     this.machine = this.createMachine();
   }
 
-  async replay(records: ChatRecord[], gaps?: HistoryGap[]): Promise<void> {
+  async replay(
+    records: ChatRecord[],
+    gaps?: HistoryGap[],
+    goalState?: GoalSnapshotV2,
+  ): Promise<void> {
     try {
-      await this.replayPage(records, { finalizeDangling: true, gaps });
+      await this.replayPage(records, {
+        finalizeDangling: true,
+        gaps,
+        ...(goalState ? { goalState } : {}),
+      });
       await this.supersedeUnrestorableGoal(records);
     } finally {
       this.setActiveRecordId(null);
@@ -196,6 +209,7 @@ export class HistoryReplayer {
             candidateTokens: 0,
             apiTimeMs: 0,
           },
+      ...(options.goalState ? { goalState: options.goalState } : {}),
     };
     return createTranscriptReplayMachine({
       initialState,

--- a/packages/cli/src/acp-integration/session/history-replayer.ts
+++ b/packages/cli/src/acp-integration/session/history-replayer.ts
@@ -108,16 +108,11 @@ export class HistoryReplayer {
     this.machine = this.createMachine();
   }
 
-  async replay(
-    records: ChatRecord[],
-    gaps?: HistoryGap[],
-    goalState?: GoalSnapshotV2,
-  ): Promise<void> {
+  async replay(records: ChatRecord[], gaps?: HistoryGap[]): Promise<void> {
     try {
       await this.replayPage(records, {
         finalizeDangling: true,
         gaps,
-        ...(goalState ? { goalState } : {}),
       });
       await this.supersedeUnrestorableGoal(records);
     } finally {

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -11,6 +11,10 @@ import path from 'node:path';
 export default defineConfig({
   resolve: {
     alias: {
+      '@qwen-code/qwen-code-core/goalWire': path.resolve(
+        __dirname,
+        '../core/src/goals/goal-wire.ts',
+      ),
       '@qwen-code/qwen-code-core/transcriptRecords': path.resolve(
         __dirname,
         '../core/src/utils/transcript-records.ts',

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -562,6 +562,77 @@ describe('ChatRecordingService', () => {
       expect(rewind.parentUuid).toBe('pre-resume-parent');
     });
 
+    it('does not treat a resumed Goal runtime continuation as a rewind boundary', async () => {
+      chatRecordingService.rebuildTurnBoundaries([
+        {
+          uuid: 'user-1',
+          parentUuid: null,
+          sessionId: 'test-session-id',
+          timestamp: '2026-06-27T00:00:00.000Z',
+          type: 'user',
+          cwd: '/test/project/root',
+          version: '1.0.0',
+          message: { role: 'user', parts: [{ text: 'first turn' }] },
+        },
+        {
+          uuid: 'assistant-1',
+          parentUuid: 'user-1',
+          sessionId: 'test-session-id',
+          timestamp: '2026-06-27T00:00:01.000Z',
+          type: 'assistant',
+          cwd: '/test/project/root',
+          version: '1.0.0',
+          message: { role: 'model', parts: [{ text: 'response' }] },
+          model: 'gemini-pro',
+        },
+        {
+          uuid: 'goal-runtime-1',
+          parentUuid: 'assistant-1',
+          sessionId: 'test-session-id',
+          timestamp: '2026-06-27T00:00:02.000Z',
+          type: 'user',
+          subtype: 'goal_runtime',
+          provenance: 'goal_runtime',
+          cwd: '/test/project/root',
+          version: '1.0.0',
+          message: { role: 'user', parts: [{ text: 'Continue working.' }] },
+        },
+        {
+          uuid: 'assistant-2',
+          parentUuid: 'goal-runtime-1',
+          sessionId: 'test-session-id',
+          timestamp: '2026-06-27T00:00:03.000Z',
+          type: 'assistant',
+          cwd: '/test/project/root',
+          version: '1.0.0',
+          message: { role: 'model', parts: [{ text: 'still working' }] },
+          model: 'gemini-pro',
+        },
+        {
+          uuid: 'user-2',
+          parentUuid: 'assistant-2',
+          sessionId: 'test-session-id',
+          timestamp: '2026-06-27T00:00:04.000Z',
+          type: 'user',
+          cwd: '/test/project/root',
+          version: '1.0.0',
+          message: { role: 'user', parts: [{ text: 'second turn' }] },
+        },
+      ]);
+
+      // The Goal runtime continuation is not a turn boundary, so turn index 1
+      // is the second REAL user turn (user-2), re-rooting at assistant-2. Were
+      // the continuation counted, index 1 would re-root at assistant-1.
+      chatRecordingService.rewindRecording(1, { truncatedCount: 3 });
+      await chatRecordingService.flush();
+
+      const records = vi
+        .mocked(jsonl.writeLine)
+        .mock.calls.map((call) => call[1] as ChatRecord);
+      const rewind = records.find((record) => record.subtype === 'rewind');
+      expect(rewind?.parentUuid).toBe('assistant-2');
+    });
+
     it('restores a rebuilt persisted tail after a failed append', async () => {
       chatRecordingService.rebuildTurnBoundaries([
         {

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -460,6 +460,32 @@ describe('ChatRecordingService', () => {
       ]);
     });
 
+    it('overrides tool result provenance to goal_runtime when requested', async () => {
+      const permit: GoalTurnPermit = {
+        goalId: 'goal-1',
+        revision: 4,
+        turnId: 'tool-override-turn',
+      };
+
+      chatRecordingService.recordToolResult(
+        [{ functionResponse: { name: 'run', response: { ok: true } } }],
+        undefined,
+        { goalContext: permit, provenance: 'goal_runtime' },
+      );
+      permit.turnId = 'mutated';
+      await chatRecordingService.flush();
+
+      const record = vi.mocked(jsonl.writeLine).mock.calls[0][1] as ChatRecord;
+      expect(record).toMatchObject({
+        provenance: 'goal_runtime',
+        goalContext: {
+          goalId: 'goal-1',
+          revision: 4,
+          turnId: 'tool-override-turn',
+        },
+      });
+    });
+
     it('does not treat Goal runtime continuations as rewind boundaries', async () => {
       chatRecordingService.recordAssistantTurn({
         model: 'gemini-pro',

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -28,6 +28,10 @@ import type {
   SessionWriterUnavailableError,
   SessionWriterLease,
 } from './session-writer-lease.js';
+import type {
+  GoalStateRecordPayloadV2,
+  GoalTurnPermit,
+} from '../goals/goal-protocol.js';
 
 vi.mock('node:path');
 vi.mock('node:child_process');
@@ -75,6 +79,7 @@ describe('ChatRecordingService', () => {
         }),
       }),
       getResumedSessionData: vi.fn().mockReturnValue(undefined),
+      getSessionService: vi.fn(),
     } as unknown as Config;
 
     vi.mocked(randomUUID).mockImplementation(
@@ -149,6 +154,7 @@ describe('ChatRecordingService', () => {
       expect(record.cwd).toBe('/test/project/root');
       expect(record.version).toBe('1.0.0');
       expect(record.gitBranch).toBe('main');
+      expect(record.provenance).toBe('real_user');
     });
 
     it('blocks later turns after a generic durable write failure', async () => {
@@ -241,6 +247,264 @@ describe('ChatRecordingService', () => {
       });
       expect(record.systemPayload).toEqual({ displayText: 'save logs' });
     });
+
+    it('records defensive Goal context on real user messages', async () => {
+      const topLevelPermit: GoalTurnPermit = {
+        goalId: 'goal-1',
+        revision: 2,
+        turnId: 'turn-top-level',
+      };
+      const midTurnPermit: GoalTurnPermit = {
+        goalId: 'goal-1',
+        revision: 2,
+        turnId: 'turn-mid-turn',
+      };
+
+      chatRecordingService.recordUserMessage(
+        [{ text: 'top-level evidence' }],
+        topLevelPermit,
+      );
+      chatRecordingService.recordMidTurnUserMessage(
+        [{ text: 'mid-turn evidence' }],
+        'mid-turn evidence',
+        midTurnPermit,
+      );
+      topLevelPermit.revision = 99;
+      midTurnPermit.turnId = 'mutated';
+      await chatRecordingService.flush();
+
+      const [topLevel, midTurn] = vi
+        .mocked(jsonl.writeLine)
+        .mock.calls.map((call) => call[1] as ChatRecord);
+      expect(topLevel).toMatchObject({
+        provenance: 'real_user',
+        goalContext: {
+          goalId: 'goal-1',
+          revision: 2,
+          turnId: 'turn-top-level',
+        },
+      });
+      expect(midTurn).toMatchObject({
+        subtype: 'mid_turn_user_message',
+        provenance: 'real_user',
+        goalContext: {
+          goalId: 'goal-1',
+          revision: 2,
+          turnId: 'turn-mid-turn',
+        },
+      });
+    });
+
+    it('classifies notification-like records as system provenance', async () => {
+      const permit: GoalTurnPermit = {
+        goalId: 'goal-1',
+        revision: 2,
+        turnId: 'turn-notification',
+      };
+
+      chatRecordingService.recordNotification(
+        [{ text: 'dependency completed' }],
+        'Dependency completed',
+        permit,
+      );
+      permit.turnId = 'mutated';
+      await chatRecordingService.flush();
+
+      const record = vi.mocked(jsonl.writeLine).mock.calls[0][1] as ChatRecord;
+      expect(record).toMatchObject({
+        subtype: 'notification',
+        provenance: 'system',
+        goalContext: {
+          goalId: 'goal-1',
+          revision: 2,
+          turnId: 'turn-notification',
+        },
+      });
+    });
+  });
+
+  describe('Goal records', () => {
+    const goalPayload: GoalStateRecordPayloadV2 = {
+      v: 2,
+      cause: 'create',
+      snapshot: {
+        v: 2,
+        activity: 'running',
+        goal: {
+          goalId: 'goal-1',
+          revision: 1,
+          objective: 'ship it',
+          status: 'active',
+          evidenceCursor: { recordId: 'goal-record' },
+          turnCount: 0,
+          activeTimeMs: 0,
+          createdAt: 100,
+          updatedAt: 100,
+        },
+      },
+    };
+
+    it('strictly persists the caller-owned state UUID', async () => {
+      const record = await chatRecordingService.recordGoalState(
+        'goal-record',
+        goalPayload,
+      );
+
+      expect(record).toMatchObject({
+        uuid: 'goal-record',
+        subtype: 'goal_state',
+        provenance: 'goal_control',
+        systemPayload: {
+          snapshot: {
+            activity: 'idle',
+            goal: { evidenceCursor: { recordId: 'goal-record' } },
+          },
+        },
+      });
+      expect(chatRecordingService.getTranscriptCursor()).toEqual({
+        recordId: 'goal-record',
+      });
+    });
+
+    it('restores the persisted cursor when a queued append fails', async () => {
+      chatRecordingService.recordUserMessage([{ text: 'persisted baseline' }]);
+      await chatRecordingService.flush();
+      const persistedCursor = chatRecordingService.getTranscriptCursor();
+
+      let rejectStrict!: (error: Error) => void;
+      vi.mocked(jsonl.writeLine).mockImplementationOnce(
+        () =>
+          new Promise<void>((_resolve, reject) => {
+            rejectStrict = reject;
+          }),
+      );
+
+      const strict = chatRecordingService.recordGoalState(
+        'goal-record',
+        goalPayload,
+      );
+      chatRecordingService.recordUserMessage([
+        { text: 'queued after strict record' },
+      ]);
+      await Promise.resolve();
+      rejectStrict(new Error('disk full'));
+
+      await expect(strict).rejects.toThrow('disk full');
+      await expect(chatRecordingService.flush()).rejects.toThrow('disk full');
+      expect(chatRecordingService.getTranscriptCursor()).toEqual(
+        persistedCursor,
+      );
+    });
+
+    it('records Goal-owned model traffic without aliasing permits', async () => {
+      const runtimePermit: GoalTurnPermit = {
+        goalId: 'goal-1',
+        revision: 3,
+        turnId: 'runtime-turn',
+      };
+      const assistantPermit: GoalTurnPermit = {
+        goalId: 'goal-1',
+        revision: 3,
+        turnId: 'assistant-turn',
+      };
+      const toolPermit: GoalTurnPermit = {
+        goalId: 'goal-1',
+        revision: 3,
+        turnId: 'tool-turn',
+      };
+
+      chatRecordingService.recordGoalRuntimeMessage(
+        [{ text: 'continue' }],
+        runtimePermit,
+      );
+      chatRecordingService.recordAssistantTurn({
+        model: 'gemini-pro',
+        message: [{ text: 'working' }],
+        goalContext: assistantPermit,
+      });
+      chatRecordingService.recordToolResult(
+        [{ functionResponse: { name: 'run', response: { ok: true } } }],
+        undefined,
+        { goalContext: toolPermit },
+      );
+      runtimePermit.turnId = 'mutated-runtime';
+      assistantPermit.revision = 99;
+      toolPermit.goalId = 'mutated-goal';
+      await chatRecordingService.flush();
+
+      const records = vi
+        .mocked(jsonl.writeLine)
+        .mock.calls.map((call) => call[1] as ChatRecord);
+      expect(records.map((record) => record.provenance)).toEqual([
+        'goal_runtime',
+        'assistant_output',
+        'tool_result',
+      ]);
+      expect(records.map((record) => record.goalContext)).toEqual([
+        { goalId: 'goal-1', revision: 3, turnId: 'runtime-turn' },
+        { goalId: 'goal-1', revision: 3, turnId: 'assistant-turn' },
+        { goalId: 'goal-1', revision: 3, turnId: 'tool-turn' },
+      ]);
+    });
+
+    it('does not treat Goal runtime continuations as rewind boundaries', async () => {
+      chatRecordingService.recordAssistantTurn({
+        model: 'gemini-pro',
+        message: [{ text: 'before Goal runtime turn' }],
+      });
+      chatRecordingService.recordGoalRuntimeMessage(
+        [{ text: 'continue Goal' }],
+        { goalId: 'goal-1', revision: 1, turnId: 'turn-1' },
+      );
+      chatRecordingService.recordAssistantTurn({
+        model: 'gemini-pro',
+        message: [{ text: 'after Goal runtime turn' }],
+      });
+
+      chatRecordingService.rewindRecording(0, { truncatedCount: 2 });
+      await chatRecordingService.flush();
+
+      const rewind = vi.mocked(jsonl.writeLine).mock.calls[3][1] as ChatRecord;
+      expect(rewind).toMatchObject({
+        subtype: 'rewind',
+        parentUuid: null,
+      });
+    });
+
+    it('flushes before reading the canonical active transcript', async () => {
+      const order: string[] = [];
+      const activeChain = [
+        {
+          uuid: 'active-record',
+          parentUuid: null,
+          sessionId: 'test-session-id',
+          timestamp: '2026-07-21T00:00:00.000Z',
+          type: 'user' as const,
+          provenance: 'real_user' as const,
+          cwd: '/test/project/root',
+          version: '1.0.0',
+          message: { role: 'user' as const, parts: [{ text: 'active' }] },
+        },
+      ];
+      const originalFlush =
+        chatRecordingService.flush.bind(chatRecordingService);
+      vi.spyOn(chatRecordingService, 'flush').mockImplementation(async () => {
+        order.push('flush');
+        await originalFlush();
+      });
+      const loadSession = vi.fn().mockImplementation(async () => {
+        order.push('load');
+        return { conversation: { messages: activeChain } };
+      });
+      vi.mocked(mockConfig.getSessionService).mockReturnValue({
+        loadSession,
+      } as unknown as ReturnType<Config['getSessionService']>);
+
+      await expect(
+        chatRecordingService.readActiveTranscriptChain(),
+      ).resolves.toEqual(activeChain);
+      expect(order).toEqual(['flush', 'load']);
+    });
   });
 
   describe('rewindRecording', () => {
@@ -283,6 +547,30 @@ describe('ChatRecordingService', () => {
       const rewind = vi.mocked(jsonl.writeLine).mock.calls[0][1] as ChatRecord;
       expect(rewind.subtype).toBe('rewind');
       expect(rewind.parentUuid).toBe('pre-resume-parent');
+    });
+
+    it('restores a rebuilt persisted tail after a failed append', async () => {
+      chatRecordingService.rebuildTurnBoundaries([
+        {
+          uuid: 'persisted-tail',
+          parentUuid: null,
+          sessionId: 'test-session-id',
+          timestamp: '2026-06-27T00:00:00.000Z',
+          type: 'assistant',
+          cwd: '/test/project/root',
+          version: '1.0.0',
+          message: { role: 'model', parts: [{ text: 'persisted response' }] },
+          model: 'gemini-pro',
+        },
+      ]);
+      vi.mocked(jsonl.writeLine).mockRejectedValueOnce(new Error('disk full'));
+
+      chatRecordingService.recordUserMessage([{ text: 'new message' }]);
+
+      await expect(chatRecordingService.flush()).rejects.toThrow('disk full');
+      expect(chatRecordingService.getTranscriptCursor()).toEqual({
+        recordId: 'persisted-tail',
+      });
     });
   });
 

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -43,6 +43,11 @@ import {
   SessionWriterUnavailableError,
   type SessionWriterLease,
 } from './session-writer-lease.js';
+import type {
+  GoalStateRecordPayloadV2,
+  GoalTurnPermit,
+  TranscriptCursor,
+} from '../goals/goal-protocol.js';
 
 const debugLogger = createDebugLogger('CHAT_RECORDING');
 
@@ -231,6 +236,32 @@ function autoTitleDisabledByEnv(): boolean {
  * - Tree reconstruction by following parentUuid chain
  * - Future conversation branching by forking from any historical record
  */
+export type ChatRecordProvenance =
+  | 'real_user'
+  | 'assistant_output'
+  | 'tool_result'
+  | 'goal_control'
+  | 'goal_runtime'
+  | 'system';
+
+export type RecordToolResultOptions =
+  | {
+      goalContext?: GoalTurnPermit;
+      provenance?: 'tool_result';
+    }
+  | {
+      goalContext: GoalTurnPermit;
+      provenance: 'goal_runtime';
+    };
+
+function copyGoalContext(goalContext: GoalTurnPermit): GoalTurnPermit {
+  return {
+    goalId: goalContext.goalId,
+    revision: goalContext.revision,
+    turnId: goalContext.turnId,
+  };
+}
+
 export interface ChatRecord {
   /** Unique identifier for this logical message */
   uuid: string;
@@ -265,7 +296,13 @@ export interface ChatRecord {
     | 'file_history_snapshot'
     | 'user_text_elements'
     | 'session_artifact_event'
-    | 'session_artifact_snapshot';
+    | 'session_artifact_snapshot'
+    | 'goal_state'
+    | 'goal_runtime';
+  /** Explicit source classification used by Goal evidence validation. */
+  provenance?: ChatRecordProvenance;
+  /** Goal identity and logical turn that owned this model-facing record. */
+  goalContext?: GoalTurnPermit;
   /** Working directory at time of message */
   cwd: string;
   /** CLI version for compatibility tracking */
@@ -317,7 +354,8 @@ export interface ChatRecord {
     | FileHistorySnapshotRecordPayload
     | UserTextElementsRecordPayload
     | SessionArtifactEventRecordPayload
-    | SessionArtifactSnapshotRecordPayload;
+    | SessionArtifactSnapshotRecordPayload
+    | GoalStateRecordPayloadV2;
 
   /** Background subagent that produced this record (e.g. "explore-7f3c"). */
   agentId?: string;
@@ -534,6 +572,8 @@ export type ChatRecordingFailureListener = (
 export class ChatRecordingService {
   /** UUID of the active logical tail, including records queued for writing. */
   private lastRecordUuid: string | null = null;
+  /** UUID of the last active-tail record confirmed written to disk. */
+  private lastPersistedRecordUuid: string | null = null;
   private readonly config: Config;
   /**
    * Tracks the `lastRecordUuid` value just before each user turn was recorded.
@@ -647,6 +687,7 @@ export class ChatRecordingService {
     const resumed = config.getResumedSessionData();
     if (writerLeaseRequired) {
       this.lastRecordUuid = resumed?.lastCompletedUuid ?? null;
+      this.lastPersistedRecordUuid = this.lastRecordUuid;
     } else {
       this.state = 'active';
       this.restoreSessionState(
@@ -738,6 +779,7 @@ export class ChatRecordingService {
     persistedTitleInfo?: { title?: string; source?: TitleSource },
   ): void {
     this.lastRecordUuid = sessionData?.lastCompletedUuid ?? null;
+    this.lastPersistedRecordUuid = this.lastRecordUuid;
     this.currentCustomTitle = undefined;
     this.currentTitleSource = undefined;
     this.currentParentSessionId = undefined;
@@ -807,6 +849,14 @@ export class ChatRecordingService {
       sessionId: this.getSessionId(),
       timestamp: new Date().toISOString(),
       type,
+      provenance:
+        type === 'user'
+          ? 'real_user'
+          : type === 'assistant'
+            ? 'assistant_output'
+            : type === 'tool_result'
+              ? 'tool_result'
+              : 'system',
       cwd,
       version: this.config.getCliVersion() || 'unknown',
       gitBranch: this.getCachedGitBranch(cwd),
@@ -840,6 +890,7 @@ export class ChatRecordingService {
     }
     if (!this.writeFailure) {
       this.writeFailure = failure;
+      this.lastRecordUuid = this.lastPersistedRecordUuid;
       debugLogger.error('Chat recording failure:', this.writeFailure);
       try {
         const notification = this.onWriteFailure?.({
@@ -864,6 +915,7 @@ export class ChatRecordingService {
   private enqueueRecordWrite(
     record: ChatRecord,
     legacyConversationFile?: string,
+    updateActiveTail = true,
   ): Promise<void> {
     const pendingWrite = this.operationTail.then(async () => {
       if (this.writeFailure) throw this.writeFailure;
@@ -875,6 +927,9 @@ export class ChatRecordingService {
           await jsonl.writeLine(legacyConversationFile, record);
         } else {
           throw new SessionWriterUnavailableError();
+        }
+        if (updateActiveTail) {
+          this.lastPersistedRecordUuid = record.uuid;
         }
       } catch (error) {
         throw this.enterWriteFailure(error, record.sessionId);
@@ -900,10 +955,11 @@ export class ChatRecordingService {
     const legacyConversationFile = this.writerLeaseRequired
       ? undefined
       : this.ensureConversationFile();
-    if (options?.updateActiveTail !== false) {
+    const updateActiveTail = options?.updateActiveTail !== false;
+    if (updateActiveTail) {
       this.lastRecordUuid = record.uuid;
     }
-    this.enqueueRecordWrite(record, legacyConversationFile);
+    this.enqueueRecordWrite(record, legacyConversationFile, updateActiveTail);
     this.updateTitleAnchorTracking(record);
   }
 
@@ -914,7 +970,6 @@ export class ChatRecordingService {
     if (this.writeFailure) throw this.writeFailure;
     if (this.state !== 'active') throw new SessionWriterUnavailableError();
 
-    const previousLastRecordUuid = this.lastRecordUuid;
     const updateActiveTail = options?.updateActiveTail !== false;
     const legacyConversationFile = this.writerLeaseRequired
       ? undefined
@@ -925,20 +980,14 @@ export class ChatRecordingService {
     const pendingWrite = this.enqueueRecordWrite(
       record,
       legacyConversationFile,
+      updateActiveTail,
     );
     // Keep anchor accounting in logical queue order, matching appendRecord.
     // Once accepted, a failed write permanently stops this recorder, so no
     // rollback of this bookkeeping is needed on rejection.
     this.updateTitleAnchorTracking(record);
 
-    try {
-      await pendingWrite;
-    } catch (error) {
-      if (updateActiveTail && this.lastRecordUuid === record.uuid) {
-        this.lastRecordUuid = previousLastRecordUuid;
-      }
-      throw error;
-    }
+    await pendingWrite;
   }
 
   /**
@@ -1115,6 +1164,43 @@ export class ChatRecordingService {
     return this.binding !== undefined;
   }
 
+  async readActiveTranscriptChain(): Promise<readonly ChatRecord[]> {
+    await this.flush();
+    const sessionId = this.getSessionId();
+    const session = await this.config
+      .getSessionService()
+      .loadSession(sessionId);
+    if (!session) {
+      throw new Error(
+        `Unable to load active transcript for session ${sessionId}`,
+      );
+    }
+    return session.conversation.messages;
+  }
+
+  getTranscriptCursor(): TranscriptCursor {
+    return { recordId: this.lastRecordUuid };
+  }
+
+  async recordGoalState(
+    recordUuid: string,
+    payload: GoalStateRecordPayloadV2,
+  ): Promise<ChatRecord> {
+    const record: ChatRecord = {
+      ...this.createBaseRecord('system'),
+      uuid: recordUuid,
+      type: 'system',
+      subtype: 'goal_state',
+      provenance: 'goal_control',
+      systemPayload: {
+        ...payload,
+        snapshot: { ...payload.snapshot, activity: 'idle' },
+      },
+    };
+    await this.appendRecordStrict(record);
+    return record;
+  }
+
   /**
    * Clears cached filesystem paths after Config swaps to a new working
    * directory. The recorder keeps session state, but future appends must
@@ -1134,16 +1220,38 @@ export class ChatRecordingService {
    *
    * @param message The raw PartListUnion object as used with the API
    */
-  recordUserMessage(message: PartListUnion): void {
+  recordUserMessage(
+    message: PartListUnion,
+    goalContext?: GoalTurnPermit,
+  ): void {
     try {
       this.turnParentUuids.push(this.lastRecordUuid);
       const record: ChatRecord = {
         ...this.createBaseRecord('user'),
+        ...(goalContext ? { goalContext: copyGoalContext(goalContext) } : {}),
         message: createUserContent(message),
       };
       this.appendRecord(record);
     } catch (error) {
       debugLogger.error('Error saving user message:', error);
+    }
+  }
+
+  recordGoalRuntimeMessage(
+    message: PartListUnion,
+    goalContext: GoalTurnPermit,
+  ): void {
+    try {
+      const record: ChatRecord = {
+        ...this.createBaseRecord('user'),
+        subtype: 'goal_runtime',
+        provenance: 'goal_runtime',
+        goalContext: copyGoalContext(goalContext),
+        message: createUserContent(message),
+      };
+      this.appendRecord(record);
+    } catch (error) {
+      debugLogger.error('Error saving Goal runtime message:', error);
     }
   }
 
@@ -1154,11 +1262,16 @@ export class ChatRecordingService {
    * tool results. Keeping a distinct subtype lets resume reconstruct that shape
    * instead of replaying consecutive user-role entries.
    */
-  recordMidTurnUserMessage(message: PartListUnion, displayText?: string): void {
+  recordMidTurnUserMessage(
+    message: PartListUnion,
+    displayText?: string,
+    goalContext?: GoalTurnPermit,
+  ): void {
     try {
       const record: ChatRecord = {
         ...this.createBaseRecord('user'),
         subtype: 'mid_turn_user_message',
+        ...(goalContext ? { goalContext: copyGoalContext(goalContext) } : {}),
         message: createUserContent(message),
         systemPayload: displayText
           ? ({ displayText } as NotificationRecordPayload)
@@ -1175,8 +1288,12 @@ export class ChatRecordingService {
    * Stored as a user-role message with subtype 'cron' so the UI
    * restores it as a notification item instead of a user turn.
    */
-  recordCronPrompt(message: PartListUnion, displayText?: string): void {
-    this.recordNotificationLike(message, 'cron', displayText);
+  recordCronPrompt(
+    message: PartListUnion,
+    displayText?: string,
+    goalContext?: GoalTurnPermit,
+  ): void {
+    this.recordNotificationLike(message, 'cron', displayText, goalContext);
   }
 
   /**
@@ -1184,19 +1301,31 @@ export class ChatRecordingService {
    * Stored as a user-role message with subtype 'notification' so the
    * UI restores it as an info item, not a user turn.
    */
-  recordNotification(message: PartListUnion, displayText?: string): void {
-    this.recordNotificationLike(message, 'notification', displayText);
+  recordNotification(
+    message: PartListUnion,
+    displayText?: string,
+    goalContext?: GoalTurnPermit,
+  ): void {
+    this.recordNotificationLike(
+      message,
+      'notification',
+      displayText,
+      goalContext,
+    );
   }
 
   private recordNotificationLike(
     message: PartListUnion,
     subtype: 'notification' | 'cron',
     displayText?: string,
+    goalContext?: GoalTurnPermit,
   ): void {
     try {
       const record: ChatRecord = {
         ...this.createBaseRecord('user'),
         subtype,
+        provenance: 'system',
+        ...(goalContext ? { goalContext: copyGoalContext(goalContext) } : {}),
         message: createUserContent(message),
         systemPayload: displayText
           ? ({ displayText } as NotificationRecordPayload)
@@ -1223,11 +1352,15 @@ export class ChatRecordingService {
     message?: PartListUnion;
     tokens?: GenerateContentResponseUsageMetadata;
     contextWindowSize?: number;
+    goalContext?: GoalTurnPermit;
   }): void {
     try {
       const record: ChatRecord = {
         ...this.createBaseRecord('assistant'),
         model: data.model,
+        ...(data.goalContext
+          ? { goalContext: copyGoalContext(data.goalContext) }
+          : {}),
       };
 
       if (data.message !== undefined) {
@@ -1358,10 +1491,15 @@ export class ChatRecordingService {
   recordToolResult(
     message: PartListUnion,
     toolCallResult?: Partial<ToolCallResponseInfo> & { status: Status },
+    options?: RecordToolResultOptions,
   ): void {
     try {
       const record: ChatRecord = {
         ...this.createBaseRecord('tool_result'),
+        ...(options?.goalContext
+          ? { goalContext: copyGoalContext(options.goalContext) }
+          : {}),
+        ...(options?.provenance ? { provenance: options.provenance } : {}),
         message: createUserContent(message),
       };
 
@@ -1516,6 +1654,7 @@ export class ChatRecordingService {
       const record = messages[i];
       if (
         record.type === 'user' &&
+        record.subtype !== 'goal_runtime' &&
         record.subtype !== 'notification' &&
         record.subtype !== 'cron' &&
         record.subtype !== 'mid_turn_user_message'
@@ -1528,6 +1667,7 @@ export class ChatRecordingService {
     // Ensure lastRecordUuid points to the end of the reconstructed chain.
     if (messages.length > 0) {
       this.lastRecordUuid = messages[messages.length - 1].uuid;
+      this.lastPersistedRecordUuid = this.lastRecordUuid;
     }
   }
 

--- a/packages/core/src/services/session-transcript-reader.test.ts
+++ b/packages/core/src/services/session-transcript-reader.test.ts
@@ -429,7 +429,24 @@ describe('SessionTranscriptReader', () => {
       systemPayload: {
         v: 2,
         cause: 'clear',
-        snapshot: null,
+        // Truthy but invalid: the parser only accepts `activity === 'idle'`,
+        // so a `running` snapshot must be rejected. A falsy `null` here would
+        // pass even with the validation deleted, leaving the guard untested.
+        snapshot: {
+          v: 2,
+          activity: 'running',
+          goal: {
+            goalId: 'goal-1',
+            revision: 1,
+            objective: 'do not revive me',
+            status: 'active',
+            evidenceCursor: { recordId: null },
+            turnCount: 0,
+            activeTimeMs: 0,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        },
       } as unknown as ChatRecord['systemPayload'],
     };
     await writeRecords([

--- a/packages/core/src/services/session-transcript-reader.test.ts
+++ b/packages/core/src/services/session-transcript-reader.test.ts
@@ -329,6 +329,128 @@ describe('SessionTranscriptReader', () => {
     });
   });
 
+  it('seeds backward replay from the latest authoritative Goal state', async () => {
+    const goalState: ChatRecord = {
+      ...record('goal-state', null, 'ignored'),
+      type: 'system',
+      subtype: 'goal_state',
+      message: undefined,
+      systemPayload: {
+        v: 2,
+        cause: 'create',
+        snapshot: {
+          v: 2,
+          activity: 'idle',
+          goal: {
+            goalId: 'goal-1',
+            revision: 1,
+            objective: 'ship backward replay',
+            status: 'active',
+            evidenceCursor: { recordId: null },
+            turnCount: 0,
+            activeTimeMs: 0,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        },
+      },
+    };
+    const clearState: ChatRecord = {
+      ...record('goal-clear', 'u2', 'ignored'),
+      type: 'system',
+      subtype: 'goal_state',
+      message: undefined,
+      systemPayload: {
+        v: 2,
+        cause: 'clear',
+        snapshot: { v: 2, activity: 'idle', goal: null },
+      },
+    };
+    await writeRecords([
+      goalState,
+      record('u1', 'goal-state', 'first prompt'),
+      record('a1', 'u1', 'first answer'),
+      record('u2', 'a1', 'second prompt'),
+      clearState,
+      record('a2', 'goal-clear', 'second answer'),
+      record('u3', 'a2', 'third prompt'),
+    ]);
+
+    const page = await new SessionTranscriptReader(workspaceDir).readPage(
+      sessionId,
+      { beforeRecordId: 'u3', limit: 2 },
+    );
+
+    expect(page.records.map((item) => item.uuid)).toEqual([
+      'u2',
+      'goal-clear',
+      'a2',
+    ]);
+    expect(page.replay).toMatchObject({
+      goalState: {
+        v: 2,
+        activity: 'idle',
+        goal: { objective: 'ship backward replay' },
+      },
+    });
+  });
+
+  it('does not revive older Goal state when the latest state is malformed', async () => {
+    const validGoalState: ChatRecord = {
+      ...record('goal-state', null, 'ignored'),
+      type: 'system',
+      subtype: 'goal_state',
+      message: undefined,
+      systemPayload: {
+        v: 2,
+        cause: 'create',
+        snapshot: {
+          v: 2,
+          activity: 'idle',
+          goal: {
+            goalId: 'goal-1',
+            revision: 1,
+            objective: 'do not revive me',
+            status: 'active',
+            evidenceCursor: { recordId: null },
+            turnCount: 0,
+            activeTimeMs: 0,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        },
+      },
+    };
+    const malformedGoalState: ChatRecord = {
+      ...record('goal-invalid', 'a1', 'ignored'),
+      type: 'system',
+      subtype: 'goal_state',
+      message: undefined,
+      systemPayload: {
+        v: 2,
+        cause: 'clear',
+        snapshot: null,
+      } as unknown as ChatRecord['systemPayload'],
+    };
+    await writeRecords([
+      validGoalState,
+      record('u1', 'goal-state', 'first prompt'),
+      record('a1', 'u1', 'first answer'),
+      malformedGoalState,
+      record('u2', 'goal-invalid', 'second prompt'),
+      record('a2', 'u2', 'second answer'),
+      record('u3', 'a2', 'third prompt'),
+    ]);
+
+    const page = await new SessionTranscriptReader(workspaceDir).readPage(
+      sessionId,
+      { beforeRecordId: 'u3', limit: 2 },
+    );
+
+    expect(page.records.map((item) => item.uuid)).toEqual(['u2', 'a2']);
+    expect(page.replay).toBeUndefined();
+  });
+
   it('includes leading session metadata with the first backward page', async () => {
     const sessionSource = {
       ...record('source', null, 'session source'),

--- a/packages/core/src/services/session-transcript-reader.ts
+++ b/packages/core/src/services/session-transcript-reader.ts
@@ -12,6 +12,8 @@ import { Storage } from '../config/storage.js';
 import * as jsonl from '../utils/jsonl-utils.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import type { HistoryGap } from '../utils/conversation-chain.js';
+import { parseGoalStateRecordPayloadV2 } from '../goals/goal-reducer.js';
+import type { GoalSnapshotV2 } from '../goals/goal-protocol.js';
 import type { ChatRecord } from './chatRecordingService.js';
 import {
   aggregateTranscriptRecordFragments,
@@ -129,6 +131,7 @@ interface TranscriptIndex {
   snapshotSize: number;
   leafUuid: string;
   activeUuids: string[];
+  goalStatePositions: number[];
   gaps: HistoryGap[];
   startTime: string;
   lastUpdated: string;
@@ -601,6 +604,7 @@ function estimateIndexCacheBytes(index: TranscriptIndex): number {
   for (const uuid of index.activeUuids) {
     total += estimateStringBytes(uuid);
   }
+  total += index.goalStatePositions.length * 8;
   for (const gap of index.gaps) {
     total +=
       INDEX_ENTRY_BASE_BYTES +
@@ -786,6 +790,27 @@ async function readAggregatedRecords(
   }
 }
 
+async function readGoalStateBeforePosition(
+  index: TranscriptIndex,
+  position: number,
+): Promise<GoalSnapshotV2 | undefined> {
+  let low = 0;
+  let high = index.goalStatePositions.length;
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2);
+    if (index.goalStatePositions[middle]! < position) {
+      low = middle + 1;
+    } else {
+      high = middle;
+    }
+  }
+  const goalStatePosition = index.goalStatePositions[low - 1];
+  if (goalStatePosition === undefined) return undefined;
+  const uuid = index.activeUuids[goalStatePosition]!;
+  const [record] = await readAggregatedRecords(index, [uuid]);
+  return parseGoalStateRecordPayloadV2(record?.systemPayload)?.snapshot;
+}
+
 async function buildIndex(params: {
   filePath: string;
   fileIdentity: SessionTranscriptFileIdentity;
@@ -872,6 +897,14 @@ async function buildIndex(params: {
       : undefined;
   });
   const activeUuids = [...chain.uuids];
+  const goalStatePositions: number[] = [];
+  for (let position = 0; position < activeUuids.length; position++) {
+    const uuid = activeUuids[position]!;
+    const entry = byUuid.get(uuid);
+    if (entry?.type === 'system' && entry.subtype === 'goal_state') {
+      goalStatePositions.push(position);
+    }
+  }
   const gaps: HistoryGap[] = [...chain.gaps];
   if (chain.cycleUuid) {
     debugLogger.debug(
@@ -890,6 +923,7 @@ async function buildIndex(params: {
     snapshotSize,
     leafUuid,
     activeUuids,
+    goalStatePositions,
     gaps,
     startTime,
     lastUpdated,
@@ -1070,6 +1104,10 @@ export class SessionTranscriptReader {
     const nextPosition =
       backwardPage?.nextPosition ?? position + pageUuids.length;
     const records = await readAggregatedRecords(index, pageUuids);
+    const backwardGoalState =
+      direction === 'backward'
+        ? await readGoalStateBeforePosition(index, nextPosition)
+        : undefined;
     const hasMore =
       direction === 'backward'
         ? nextPosition > 0
@@ -1104,7 +1142,11 @@ export class SessionTranscriptReader {
       hasMore,
       ...(direction === 'backward' ? { direction: 'backward' as const } : {}),
       ...(nextCursorState ? { nextCursorState } : {}),
-      ...(cursor?.replay !== undefined ? { replay: cursor.replay } : {}),
+      ...(backwardGoalState
+        ? { replay: { goalState: backwardGoalState } }
+        : cursor?.replay !== undefined
+          ? { replay: cursor.replay }
+          : {}),
       startTime: index.startTime,
       lastUpdated: index.lastUpdated,
     };

--- a/packages/core/src/utils/transcript-records.test.ts
+++ b/packages/core/src/utils/transcript-records.test.ts
@@ -155,6 +155,26 @@ describe('prepareTranscriptRecords', () => {
     );
   });
 
+  it('accepts Goal state and runtime records as known subtypes', () => {
+    const prepared = prepareTranscriptRecords([
+      record('goal-state', null, {
+        type: 'system',
+        subtype: 'goal_state',
+        message: undefined,
+      }),
+      record('goal-runtime', 'goal-state', {
+        subtype: 'goal_runtime',
+      }),
+    ]);
+
+    expect(prepared.diagnostics).not.toContainEqual(
+      expect.objectContaining({
+        code: 'unknown_record_or_part',
+        path: 'subtype',
+      }),
+    );
+  });
+
   it('rejects mixed sessions and an explicit artifact leaf', () => {
     expect(() =>
       prepareTranscriptRecords([

--- a/packages/core/src/utils/transcript-records.ts
+++ b/packages/core/src/utils/transcript-records.ts
@@ -102,6 +102,8 @@ const KNOWN_RECORD_SUBTYPES = new Set([
   'agent_launch_prompt',
   'file_history_snapshot',
   'session_source',
+  'goal_state',
+  'goal_runtime',
   ...ARTIFACT_RECORD_SUBTYPES,
 ]);
 


### PR DESCRIPTION
## What this PR does

This PR adds the durable transcript and replay foundation for Goal v3. Goal lifecycle snapshots are recorded with explicit provenance and exact turn ownership, internal continuation prompts are kept out of user-visible replay and rewind boundaries, and write failures restore the transcript cursor to the last record confirmed on disk.

Replay now carries authoritative Goal v3 state across forward and backward pages, emits v2-first metadata with legacy Goal compatibility fields, and rejects malformed state without reviving an older Goal. Backward paging indexes Goal state positions so long sessions do not repeatedly scan the full transcript.

## Why it's needed

Goal execution cannot be safely connected to the CLI and UI until its state, evidence ownership, resume behavior, and failure semantics are durable and deterministic. This isolates that persistence/replay contract from the next PR, which will connect the Goal runtime to the core turn engine.

## Reviewer Test Plan

### How to verify

1. Record normal user, assistant, tool, Goal-control, and Goal-runtime traffic and confirm each record keeps the expected provenance and immutable turn ownership.
2. Force a queued durable write to fail and confirm the exposed transcript cursor returns to the last successfully persisted record.
3. Replay Goal create and clear records across page boundaries and confirm v2 state is emitted before legacy compatibility metadata, while internal continuation prompts never appear as user messages.
4. Place a malformed Goal state after a valid state and confirm backward replay remains unknown instead of restoring the older Goal.
5. Run the focused Core, ACP bridge, and CLI replay suites, then run the full build and typecheck.

Focused results: Core 115 passed; ACP bridge 10 passed; CLI replay/conformance 59 passed. Full `npm run build` and `npm run typecheck` passed.

### Evidence (Before & After)

N/A — this PR changes transcript persistence and replay contracts only; user-visible Goal execution and presentation remain in follow-up PRs.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

Node.js 25.9.0, local no-sandbox test environment.

## Risk & Scope

- Main risk or tradeoff: Transcript records gain additive Goal metadata, and backward paging keeps a compact Goal-state position index in memory.
- Not validated / out of scope: Goal runtime orchestration, TUI commands and cards, non-interactive mode, ACP/serve control routes, SDK/Web UI, Web Shell, and Desktop UI.
- Breaking changes / migration notes: None. Existing transcripts and legacy Goal replay remain supported.

## Linked Issues

Split follow-up to #7494.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 增加 Goal v3 的持久化 transcript 与回放基础。Goal 生命周期快照会携带明确的来源分类和精确的轮次归属写入；内部续跑提示不会出现在用户可见回放中，也不会被当作倒带边界；持久化写入失败时，transcript 游标会恢复到最后一条已确认落盘的记录。

回放现在可以在向前和向后分页之间传递权威的 Goal v3 状态，以 v2 状态优先、旧 Goal 兼容字段随后输出；损坏状态不会导致更早的旧 Goal 被重新恢复。向后分页会索引 Goal 状态位置，避免长会话反复扫描完整 transcript。

## 为什么需要

在把 Goal 执行接入 CLI 和 UI 之前，必须先保证状态、证据归属、恢复行为和失败语义可持久化且确定。本 PR 将持久化/回放契约独立出来，下一张 PR 再把 Goal runtime 接入核心轮次引擎。

## Reviewer Test Plan

### 验证方式

1. 记录普通用户、assistant、工具、Goal 控制和 Goal runtime 流量，确认每条记录都保留正确的来源分类和不可变的轮次归属。
2. 强制一个已排队的持久化写入失败，确认对外 transcript 游标回到最后一条成功落盘的记录。
3. 跨分页回放 Goal 创建和清除记录，确认先输出 v2 状态、再携带旧版兼容元数据，同时内部续跑提示不会显示为用户消息。
4. 在有效 Goal 状态之后放置损坏状态，确认向后回放保持未知，而不是恢复更早的旧 Goal。
5. 运行 Core、ACP bridge 和 CLI replay 的聚焦测试，然后运行全仓 build 和 typecheck。

聚焦测试结果：Core 115 个通过；ACP bridge 10 个通过；CLI replay/conformance 59 个通过。完整 `npm run build` 和 `npm run typecheck` 均通过。

### 证据（Before & After）

不适用——本 PR 只修改 transcript 持久化和回放契约；用户可见的 Goal 执行与展示将在后续 PR 中实现。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### 环境（可选）

Node.js 25.9.0，本地无 sandbox 测试环境。

## 风险与范围

- 主要风险或取舍：Transcript 记录增加了可选的 Goal 元数据；向后分页会在内存中保存一个紧凑的 Goal 状态位置索引。
- 未验证 / 不在范围内：Goal runtime 编排、TUI 命令和卡片、非交互模式、ACP/serve 控制路由、SDK/Web UI、Web Shell 和 Desktop UI。
- 破坏性变更 / 迁移说明：无。现有 transcript 和旧版 Goal 回放仍然兼容。

## 关联项

#7494 的拆分后续 PR。

</details>
