### PR TITLE
fix(cli): patch ink to clear staticNode on indirect subtree removal

### DIFF
--- a/patches/ink+7.0.3.patch
+++ b/patches/ink+7.0.3.patch
@@ -18,7 +18,7 @@ index 1d7bf6b..29401a6 100644
 -export default function Text({ color, backgroundColor, dimColor, bold, italic, underline, strikethrough, inverse, wrap, children, 'aria-label': ariaLabel, 'aria-hidden': ariaHidden, }: Props): React.JSX.Element | null;
 +export default function Text({ color, backgroundColor, dimColor, bold, italic, underline, strikethrough, inverse, wrap, selectable, selectionFlow, selectionBreakAfter, selectionJoiner, children, 'aria-label': ariaLabel, 'aria-hidden': ariaHidden, }: Props): React.JSX.Element | null;
 diff --git a/node_modules/ink/build/components/Text.js b/node_modules/ink/build/components/Text.js
-index 2e4b9ff..1ec2ae6 100644
+index 2e4b9ff..77ed0f6 100644
 --- a/node_modules/ink/build/components/Text.js
 +++ b/node_modules/ink/build/components/Text.js
 @@ -6,7 +6,7 @@ import { backgroundContext } from './BackgroundContext.js';
@@ -38,6 +38,7 @@ index 2e4b9ff..1ec2ae6 100644
 +    return (React.createElement("ink-text", { style: { flexGrow: 0, flexShrink: 1, flexDirection: 'row', textWrap: wrap }, internal_transform: transform, selectable: selectable, selectionFlow: selectionFlow, selectionBreakAfter: selectionBreakAfter, selectionJoiner: selectionJoiner }, childrenOrAriaLabel));
  }
  //# sourceMappingURL=Text.js.map
+\ No newline at end of file
 diff --git a/node_modules/ink/build/frame-controller.d.ts b/node_modules/ink/build/frame-controller.d.ts
 new file mode 100644
 index 0000000..c294036
@@ -153,7 +154,7 @@ index cc849f0..25d6b33 100644
  //# sourceMappingURL=index.js.map
 \ No newline at end of file
 diff --git a/node_modules/ink/build/ink.js b/node_modules/ink/build/ink.js
-index ef659f3..6e97480 100644
+index ef659f3..767d861 100644
 --- a/node_modules/ink/build/ink.js
 +++ b/node_modules/ink/build/ink.js
 @@ -17,6 +17,7 @@ import { hideCursorEscape, showCursorEscape } from './cursor-helpers.js';
@@ -254,7 +255,7 @@ index 0f4523f..a3ef634 100644
  }
  export {};
 diff --git a/node_modules/ink/build/output.js b/node_modules/ink/build/output.js
-index c763b77..ac81f2e 100644
+index c763b77..bfd3d08 100644
 --- a/node_modules/ink/build/output.js
 +++ b/node_modules/ink/build/output.js
 @@ -1,6 +1,26 @@
@@ -451,8 +452,70 @@ index c763b77..ac81f2e 100644
          };
      }
  }
+diff --git a/node_modules/ink/build/reconciler.js b/node_modules/ink/build/reconciler.js
+index 5b4a9d7..25cc017 100644
+--- a/node_modules/ink/build/reconciler.js
++++ b/node_modules/ink/build/reconciler.js
+@@ -53,6 +53,25 @@ const cleanupYogaNode = (node) => {
+     node?.unsetMeasureFunc();
+     node?.freeRecursive();
+ };
++// Clear staticNode when the node it points at is removed as part of a larger
++// subtree. The previous identity check (staticNode === removeNode) only caught
++// direct removal of <Static>; removing an ancestor left a dangling reference
++// whose freed WASM memory crashed the next render (QwenLM/qwen-code#6820).
++// Must be called BEFORE removeChildNode breaks the parent chain.
++const clearStaticNodeIfContained = (removeNode) => {
++    const staticNode = currentRootNode?.staticNode;
++    if (!staticNode) {
++        return;
++    }
++    let current = staticNode;
++    while (current) {
++        if (current === removeNode) {
++            currentRootNode.staticNode = undefined;
++            return;
++        }
++        current = current.parentNode;
++    }
++};
+ let currentUpdatePriority = NoEventPriority;
+ let currentRootNode;
+ async function loadPackageJson() {
+@@ -212,13 +231,10 @@ export default createReconciler({
+     appendChildToContainer: appendChildNode,
+     insertInContainerBefore: insertBeforeNode,
+     removeChildFromContainer(node, removeNode) {
++        clearStaticNodeIfContained(removeNode);
+         removeChildNode(node, removeNode);
+         cleanupYogaNode(removeNode.yogaNode);
+-        // Only clear staticNode if it still points at the removed node. On key-driven remounts, `createInstance` already registered the new node before this removal fires.
+-        if (removeNode.internal_static &&
+-            currentRootNode?.staticNode === removeNode) {
+-            currentRootNode.staticNode = undefined;
+-        }
++        removeNode.yogaNode = undefined;
+     },
+     commitUpdate(node, _type, oldProps, newProps) {
+         if (currentRootNode && node.internal_static) {
+@@ -254,13 +270,10 @@ export default createReconciler({
+         setTextNodeValue(node, newText);
+     },
+     removeChild(node, removeNode) {
++        clearStaticNodeIfContained(removeNode);
+         removeChildNode(node, removeNode);
+         cleanupYogaNode(removeNode.yogaNode);
+-        // Same guard as removeChildFromContainer: only clear if this is still the active static node.
+-        if (removeNode.internal_static &&
+-            currentRootNode?.staticNode === removeNode) {
+-            currentRootNode.staticNode = undefined;
+-        }
++        removeNode.yogaNode = undefined;
+     },
+     setCurrentUpdatePriority(newPriority) {
+         currentUpdatePriority = newPriority;
 diff --git a/node_modules/ink/build/render-background.js b/node_modules/ink/build/render-background.js
-index db5c807..bb54771 100644
+index db5c807..3ac805a 100644
 --- a/node_modules/ink/build/render-background.js
 +++ b/node_modules/ink/build/render-background.js
 @@ -18,7 +18,10 @@ const renderBackground = (x, y, node, output) => {
@@ -482,7 +545,7 @@ index 127c620..6d5a005 100644
  }) => void;
  export default renderNodeToOutput;
 diff --git a/node_modules/ink/build/render-node-to-output.js b/node_modules/ink/build/render-node-to-output.js
-index f00a278..07a98d0 100644
+index f00a278..e6bc4ca 100644
 --- a/node_modules/ink/build/render-node-to-output.js
 +++ b/node_modules/ink/build/render-node-to-output.js
 @@ -1,7 +1,6 @@
@@ -615,7 +678,7 @@ index 8c35aea..26e3196 100644
 +declare const renderer: (node: DOMElement, isScreenReaderEnabled: boolean, selection?: ScreenSelection | null) => Result;
  export default renderer;
 diff --git a/node_modules/ink/build/renderer.js b/node_modules/ink/build/renderer.js
-index bf23246..81d72e9 100644
+index bf23246..7fa831f 100644
 --- a/node_modules/ink/build/renderer.js
 +++ b/node_modules/ink/build/renderer.js
 @@ -1,6 +1,6 @@
@@ -678,7 +741,7 @@ index 935cfb8..3dddced 100644
 +};
  export default wrapText;
 diff --git a/node_modules/ink/build/wrap-text.js b/node_modules/ink/build/wrap-text.js
-index 51f696c..d96d438 100644
+index 51f696c..1f66ca0 100644
 --- a/node_modules/ink/build/wrap-text.js
 +++ b/node_modules/ink/build/wrap-text.js
 @@ -1,5 +1,6 @@
@@ -740,3 +803,4 @@ index 51f696c..d96d438 100644
 +};
  export default wrapText;
  //# sourceMappingURL=wrap-text.js.map
+\ No newline at end of file


### PR DESCRIPTION
## What this PR does

Patches the ink reconciler to correctly clear the `staticNode` reference when a `<Static>` component is removed as part of a larger subtree unmount, and nulls out the freed yoga node pointer to prevent stale WASM memory access.

## Why it's needed

Issue #6820 reports a `RuntimeError: memory access out of bounds` crash in Yoga WASM during Ink's render cycle. The root cause is an incomplete fix in ink's upstream #904/#905: the reconciler's `removeChild`/`removeChildFromContainer` only checks `removeNode.internal_static` on the node being directly removed. When an *ancestor* of `<Static>` is unmounted (e.g. `transcriptFreeze` toggling `<App/>` off in `AppContainer.tsx`), `freeRecursive()` frees the static node's Yoga WASM memory as part of the subtree, but the identity check skips it because the removed node is the ancestor, not the `<Static>` element itself. The dangling `staticNode` reference then causes `getComputedWidth()` to access freed WASM memory on the next render, crashing the process.

The fix adds `clearStaticNodeIfContained()` which walks up the parent chain from `staticNode` to detect whether it is contained in the subtree being removed, and also nulls out `removeNode.yogaNode` after `freeRecursive()` so any remaining stale JS references short-circuit on `?.yogaNode` optional chaining instead of trapping into invalid WASM memory.

The same fix has been implemented and tested in the ink fork (branch `fix/static-node-dangling-wasm`) and will be proposed upstream.

## Reviewer Test Plan

### How to verify

1. Apply the patch: `npm install` (postinstall runs patch-package automatically)
2. Confirm the patch applies cleanly: look for `ink@7.0.3` in postinstall output
3. Build: `npm run build` — should succeed with no new errors
4. The patch adds `clearStaticNodeIfContained` to `node_modules/ink/build/reconciler.js` — grep to confirm

The crash itself requires a specific unmount sequence (transcript freeze toggling) under WSL2/Node v24 to reproduce, so direct reproduction is impractical in CI. The fix is verified by the ink fork's regression test which exercises the exact code path (unmounting an ancestor of `<Static>` and confirming the renderer remains functional).

### Evidence (Before & After)

N/A — non-UI internal patch change. No user-visible behavior change except eliminating a crash.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS     | tested (build + patch apply) |
| Windows    | not tested |
|  Linux     | not tested |

### Environment (optional)

npm run build, patch-package apply verification

## Risk & Scope

- Main risk or tradeoff: The `clearStaticNodeIfContained` parent-chain walk adds O(depth) work per node removal. Tree depth is small in practice (< 20 levels), so the cost is negligible.
- Not validated / out of scope: Direct reproduction of the original WSL2/Node v24 crash. The fix addresses the confirmed logical bug; environment-specific factors (Node v24 WASM timing, WSL2 PTY) may have additional contributing causes.
- Breaking changes / migration notes: None. The patch only modifies internal reconciler cleanup logic.

## Linked Issues

Fixes #6820

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修补 ink 的 reconciler，在 `<Static>` 组件作为更大子树的一部分被移除时正确清除 `staticNode` 引用，并置空已释放的 yoga 节点指针以防止残留的 WASM 内存访问。

## 为什么需要

Issue #6820 报告了 Yoga WASM 在 Ink 渲染周期中因 `RuntimeError: memory access out of bounds` 崩溃。根因是 ink 上游 #904/#905 修复不完整：reconciler 的 `removeChild`/`removeChildFromContainer` 只检查被直接移除节点的 `internal_static` 属性。当 `<Static>` 的祖先被卸载时（例如 `AppContainer.tsx` 中 `transcriptFreeze` 切换关闭 `<App/>`），`freeRecursive()` 作为子树的一部分释放了 static 节点的 Yoga WASM 内存，但 identity check 跳过了它，因为被移除的节点是祖先而非 `<Static>` 元素本身。残留的 `staticNode` 引用在下次渲染时导致 `getComputedWidth()` 访问已释放的 WASM 内存，进程崩溃。

修复方案新增 `clearStaticNodeIfContained()` 函数，从 `staticNode` 沿 parent chain 向上遍历以检测其是否包含在被移除的子树中，同时在 `freeRecursive()` 后置空 `removeNode.yogaNode`，使残留的 JS 引用通过 `?.yogaNode` 可选链正确短路，而非触发 WASM trap。

同一修复已在 ink fork 中实现并通过回归测试（分支 `fix/static-node-dangling-wasm`），将向上游提交。

## 审阅者测试计划

### 如何验证

1. 应用 patch：`npm install`（postinstall 自动运行 patch-package）
2. 确认 patch 干净应用：postinstall 输出中应有 `ink@7.0.3`
3. 构建：`npm run build` — 应成功且无新错误

### 证据（前后对比）

N/A — 非 UI 内部 patch 变更。除消除崩溃外无用户可见行为变化。

## 风险与范围

- 主要风险或权衡：`clearStaticNodeIfContained` 的 parent chain 遍历为每次节点移除增加 O(depth) 开销。实际树深度很小（< 20 层），开销可忽略。
- 未验证 / 超出范围：原始 WSL2/Node v24 崩溃的直接复现。修复针对已确认的逻辑 bug；环境特有因素（Node v24 WASM 时序、WSL2 PTY）可能有其他贡献原因。
- 破坏性变更 / 迁移说明：无。patch 仅修改内部 reconciler 清理逻辑。

## 关联 Issue

Fixes #6820

</details>
