### PR TITLE
fix(web-shell): render task notifications as system messages

### DIFF
--- a/docs/design/task-notification-transcript-placement.md
+++ b/docs/design/task-notification-transcript-placement.md
@@ -1,0 +1,16 @@
+# Task notification transcript placement
+
+Background task completions are model inputs, not user-authored prompts. The
+live daemon path already identifies them with
+`_meta.source = "background_notification"`, but history replay previously
+projected persisted notification records as unmarked user messages.
+
+History replay will preserve the persisted model-input role while adding the
+same source marker used by live notifications. The Web Shell transcript adapter
+will map that source, from either a user or assistant chunk, to an informational
+system message. New records also persist the existing structured task status so
+live and replayed messages use the same completed, failed, or cancelled label;
+older records fall back to a generic notification label. The notification
+content is rendered unchanged beside a semantic status icon. This keeps both
+live and replayed notifications visible on the left without changing shared
+replay semantics for other consumers.

--- a/packages/acp-bridge/src/transcript-replay.test.ts
+++ b/packages/acp-bridge/src/transcript-replay.test.ts
@@ -35,6 +35,45 @@ function updates(
 }
 
 describe('createTranscriptReplayMachine', () => {
+  it('preserves task notification metadata during replay', () => {
+    const machine = createTranscriptReplayMachine();
+    const projected = updates(
+      machine,
+      record('notification-1', 'user', {
+        subtype: 'notification',
+        message: {
+          role: 'user',
+          parts: [{ text: '<task-notification />' }],
+        },
+        systemPayload: {
+          displayText: 'Background agent completed.',
+          backgroundTask: {
+            taskId: 'task-1',
+            status: 'completed',
+            kind: 'agent',
+          },
+        },
+      }),
+    );
+
+    expect(projected).toMatchObject([
+      {
+        sessionUpdate: 'user_message_chunk',
+        content: { type: 'text', text: 'Background agent completed.' },
+        _meta: {
+          source: 'background_notification',
+          qwenDiscreteMessage: true,
+          backgroundTask: {
+            taskId: 'task-1',
+            status: 'completed',
+            kind: 'agent',
+          },
+          qwenTranscript: { sourceRecordIds: ['notification-1'] },
+        },
+      },
+    ]);
+  });
+
   it('projects ordered message parts with source metadata', () => {
     const machine = createTranscriptReplayMachine();
     const projected = updates(

--- a/packages/acp-bridge/src/transcript-replay.ts
+++ b/packages/acp-bridge/src/transcript-replay.ts
@@ -475,13 +475,28 @@ class DefaultTranscriptReplayMachine implements TranscriptReplayMachine {
         payload && typeof payload['displayText'] === 'string'
           ? payload['displayText']
           : undefined;
+      const backgroundTask =
+        payload && isObjectRecord(payload['backgroundTask'])
+          ? payload['backgroundTask']
+          : undefined;
       if (displayText) {
+        const isNotification = record.subtype === 'notification';
         yield emit(
           createTranscriptMessageUpdate({
             role: 'user',
             text: displayText,
             ...meta,
-            ...(record.subtype === 'cron' ? { extra: { source: 'cron' } } : {}),
+            ...(isNotification
+              ? {
+                  extra: {
+                    source: 'background_notification',
+                    qwenDiscreteMessage: true,
+                    ...(backgroundTask ? { backgroundTask } : {}),
+                  },
+                }
+              : record.subtype === 'cron'
+                ? { extra: { source: 'cron' } }
+                : {}),
           }),
         );
         return;

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -2867,6 +2867,12 @@ describe('Session', () => {
           },
         ],
         'Background agent "worker" completed.',
+        {
+          taskId: 'agent-1',
+          status: 'completed',
+          kind: 'agent',
+          toolUseId: 'tool-1',
+        },
       );
       expect(mockClient.sessionUpdate).toHaveBeenCalledWith({
         sessionId: 'test-session-id',

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -5308,7 +5308,12 @@ export class Session implements SessionContext {
           const notificationParts: Part[] = [{ text: item.modelText }];
           this.config
             .getChatRecordingService()
-            ?.recordNotification(notificationParts, item.displayText);
+            ?.recordNotification(notificationParts, item.displayText, {
+              taskId: item.taskId,
+              status: item.status,
+              kind: item.kind,
+              toolUseId: item.toolUseId,
+            });
 
           const notificationReminders =
             await this.#buildInitialSystemReminders();

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -355,6 +355,12 @@ export interface ChatRecord {
 
 export interface NotificationRecordPayload {
   displayText: string;
+  backgroundTask?: {
+    taskId: string;
+    status: string;
+    kind: 'agent' | 'monitor' | 'shell';
+    toolUseId?: string;
+  };
 }
 
 export interface AgentBootstrapRecordPayload {
@@ -1184,14 +1190,24 @@ export class ChatRecordingService {
    * Stored as a user-role message with subtype 'notification' so the
    * UI restores it as an info item, not a user turn.
    */
-  recordNotification(message: PartListUnion, displayText?: string): void {
-    this.recordNotificationLike(message, 'notification', displayText);
+  recordNotification(
+    message: PartListUnion,
+    displayText?: string,
+    backgroundTask?: NotificationRecordPayload['backgroundTask'],
+  ): void {
+    this.recordNotificationLike(
+      message,
+      'notification',
+      displayText,
+      backgroundTask,
+    );
   }
 
   private recordNotificationLike(
     message: PartListUnion,
     subtype: 'notification' | 'cron',
     displayText?: string,
+    backgroundTask?: NotificationRecordPayload['backgroundTask'],
   ): void {
     try {
       const record: ChatRecord = {
@@ -1199,7 +1215,7 @@ export class ChatRecordingService {
         subtype,
         message: createUserContent(message),
         systemPayload: displayText
-          ? ({ displayText } as NotificationRecordPayload)
+          ? ({ displayText, backgroundTask } as NotificationRecordPayload)
           : undefined,
       };
       this.appendRecord(record);

--- a/packages/web-shell/client/adapters/transcriptToMessages.test.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.test.ts
@@ -170,7 +170,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
     });
   });
 
-  it('hides background task notifications by metadata', () => {
+  it('renders live background task notifications as system messages', () => {
     const messages = transcriptBlocksToDaemonMessages([
       textBlock(
         'bg-1',
@@ -190,6 +190,16 @@ describe('transcriptBlocksToDaemonMessages', () => {
     ]);
 
     expect(messages).toEqual([
+      {
+        id: 'bg-1',
+        role: 'system',
+        content:
+          'Background agent "general-purpose: 查询百度云活动信息" completed.',
+        variant: 'info',
+        source: 'background_notification',
+        data: { taskId: 'task-1', status: 'completed' },
+        timestamp: 1,
+      },
       {
         id: 'assistant-1',
         role: 'assistant',
@@ -234,10 +244,20 @@ describe('transcriptBlocksToDaemonMessages', () => {
         ),
       ]);
 
-      expect(messages).toHaveLength(1);
+      expect(messages).toHaveLength(2);
       expect(messages[0]).toMatchObject({
         role: 'tool_group',
         tools: [{ callId: 'agent-call', status: expectedStatus, endTime: 2 }],
+      });
+      expect(messages[1]).toMatchObject({
+        role: 'system',
+        source: 'background_notification',
+        data: {
+          kind: 'agent',
+          status: notificationStatus,
+          taskId: 'agent-task',
+          toolUseId: 'agent-call',
+        },
       });
       if (notificationStatus === 'cancelled') {
         expect(
@@ -270,6 +290,37 @@ describe('transcriptBlocksToDaemonMessages', () => {
 
     expect(messages).toMatchObject([
       { role: 'tool_group', tools: [{ status: 'pending' }] },
+      {
+        role: 'system',
+        source: 'background_notification',
+        data: {
+          kind: 'shell',
+          status: 'completed',
+          toolUseId: 'agent-call',
+        },
+      },
+    ]);
+  });
+
+  it('renders replayed background notifications without task metadata', () => {
+    const messages = transcriptBlocksToDaemonMessages([
+      textBlock('bg-replay', 'user', 'Monitor completed.', 1, false, {
+        meta: {
+          source: 'background_notification',
+          qwenDiscreteMessage: true,
+        },
+      }),
+    ]);
+
+    expect(messages).toEqual([
+      {
+        id: 'bg-replay',
+        role: 'system',
+        content: 'Monitor completed.',
+        variant: 'info',
+        source: 'background_notification',
+        timestamp: 1,
+      },
     ]);
   });
 

--- a/packages/web-shell/client/adapters/transcriptToMessages.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.ts
@@ -38,8 +38,6 @@ type ExtendedDaemonTextTranscriptBlock = DaemonTextTranscriptBlock & {
   meta?: {
     source?: unknown;
     inputAnnotations?: unknown;
-    qwenDiscreteMessage?: boolean;
-    backgroundTask?: unknown;
   };
 };
 
@@ -172,24 +170,18 @@ function getMidTurnInjectedText(data: unknown): string | null {
   return text || null;
 }
 
-function isBackgroundNotificationAssistantBlock(
+function isBackgroundNotificationBlock(
   block: DaemonTextTranscriptBlock,
 ): boolean {
   const extended = block as ExtendedDaemonTextTranscriptBlock;
-  const meta = extended.meta;
-  return (
-    meta?.['source'] === 'background_notification' &&
-    meta['qwenDiscreteMessage'] === true &&
-    meta['backgroundTask'] !== undefined
-  );
+  return extended.meta?.['source'] === 'background_notification';
 }
 
-function normalizeAssistantTextBlock(
+function getBackgroundNotificationData(
   block: DaemonTextTranscriptBlock,
-): DaemonTextTranscriptBlock | null {
-  if (isBackgroundNotificationAssistantBlock(block)) return null;
-  if (!block.text && !block.usage) return null;
-  return block;
+): Record<string, unknown> | undefined {
+  const extended = block as ExtendedDaemonTextTranscriptBlock;
+  return getRecord(extended.meta?.['backgroundTask']) ?? undefined;
 }
 
 function isTextBlockEmpty(block: DaemonTextTranscriptBlock): boolean {
@@ -276,10 +268,25 @@ export function transcriptBlocksToDaemonMessages(
 
     switch (block.kind) {
       case 'user': {
+        const textBlock = block as DaemonTextTranscriptBlock;
+        if (isBackgroundNotificationBlock(textBlock)) {
+          currentAssistantIdx = null;
+          currentThinkingIdx = null;
+          needsNewContentMessage = true;
+          messages.push({
+            id: block.id,
+            role: 'system',
+            content: textBlock.text,
+            variant: 'info',
+            source: 'background_notification',
+            data: getBackgroundNotificationData(textBlock),
+            timestamp: blockTime,
+          });
+          break;
+        }
         currentAssistantIdx = null;
         currentThinkingIdx = null;
         needsNewContentMessage = false;
-        const textBlock = block as DaemonTextTranscriptBlock;
         const meta = getRecord(
           (textBlock as ExtendedDaemonTextTranscriptBlock).meta,
         );
@@ -307,10 +314,23 @@ export function transcriptBlocksToDaemonMessages(
       }
 
       case 'assistant': {
-        const textBlock = normalizeAssistantTextBlock(
-          block as DaemonTextTranscriptBlock,
-        );
-        if (!textBlock) break;
+        const textBlock = block as DaemonTextTranscriptBlock;
+        if (isBackgroundNotificationBlock(textBlock)) {
+          currentAssistantIdx = null;
+          currentThinkingIdx = null;
+          needsNewContentMessage = true;
+          messages.push({
+            id: block.id,
+            role: 'system',
+            content: textBlock.text,
+            variant: 'info',
+            source: 'background_notification',
+            data: getBackgroundNotificationData(textBlock),
+            timestamp: blockTime,
+          });
+          break;
+        }
+        if (!textBlock.text && !textBlock.usage) break;
 
         const parentSubAgent = textBlock.parentToolCallId
           ? toolsByCallId.get(textBlock.parentToolCallId)

--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -182,6 +182,13 @@ const systemMsg = (id: string): SystemMessage => ({
   variant: 'warning',
   source: 'prompt_cancelled',
 });
+const backgroundNotificationMsg = (id: string): SystemMessage => ({
+  id,
+  role: 'system',
+  content: 'background task completed',
+  variant: 'info',
+  source: 'background_notification',
+});
 const thinkingMsg = (id: string): ThinkingMessage => ({
   id,
   role: 'thinking',
@@ -450,6 +457,32 @@ describe('MessageList — turn collapse (DOM)', () => {
     expect(has(c, 'a1')).toBe(true);
     expect(isCollapsed(c, 'g1')).toBe(true);
     expect(toggleRow(c, 'u1').getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('collapses a background notification before the final assistant content', () => {
+    const c = mount([
+      userMsg('u1'),
+      backgroundNotificationMsg('bg1'),
+      asstMsg('a1'),
+    ]);
+
+    expect(has(c, 'bg1')).toBe(false);
+    expect(has(c, 'a1')).toBe(true);
+    click(toggle(c, 'u1'));
+    expect(has(c, 'bg1')).toBe(true);
+  });
+
+  it('keeps a background notification when it is the final content', () => {
+    const c = mount([
+      userMsg('u1'),
+      asstMsg('a1'),
+      backgroundNotificationMsg('bg1'),
+    ]);
+
+    expect(has(c, 'a1')).toBe(false);
+    expect(has(c, 'bg1')).toBe(true);
+    click(toggle(c, 'u1'));
+    expect(has(c, 'a1')).toBe(true);
   });
 
   it('renders collapse metrics in the standalone turn row', () => {

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -486,10 +486,16 @@ export interface ApplyTurnCollapseOptions {
   enabled: boolean;
 }
 
-function isAssistantAnswer(item: DisplayItem): boolean {
+function isFinalContentCandidate(
+  item: DisplayItem,
+  includeBackgroundNotifications: boolean,
+): boolean {
   return (
     item.type === 'message' &&
-    item.message.role === 'assistant' &&
+    (item.message.role === 'assistant' ||
+      (includeBackgroundNotifications &&
+        item.message.role === 'system' &&
+        item.message.source === 'background_notification')) &&
     // `content` is typed `string`, but daemon SSE text can be undefined at
     // runtime (transcriptToMessages copies `textBlock.text` through). Guard it:
     // `applyTurnCollapse` runs in render, so a bare `.trim()` would blank the
@@ -503,6 +509,7 @@ function findFinalAnswerIndex(
   items: readonly DisplayItem[],
   start: number,
   end: number,
+  includeBackgroundNotifications = true,
 ): number {
   let lastWorkStepIndex = start;
   for (let i = end; i > start; i--) {
@@ -512,7 +519,9 @@ function findFinalAnswerIndex(
     }
   }
   for (let i = end; i > lastWorkStepIndex; i--) {
-    if (isAssistantAnswer(items[i]!)) return i;
+    if (isFinalContentCandidate(items[i]!, includeBackgroundNotifications)) {
+      return i;
+    }
   }
   return -1;
 }
@@ -535,7 +544,7 @@ function collectFinalAssistantTurnIds(
     const start = userIdxs[k];
     const end = (k + 1 < userIdxs.length ? userIdxs[k + 1] : items.length) - 1;
     const turnHead = items[start];
-    const answerIdx = findFinalAnswerIndex(items, start, end);
+    const answerIdx = findFinalAnswerIndex(items, start, end, false);
     if (answerIdx < 0) continue;
     const item = items[answerIdx];
     if (
@@ -550,9 +559,10 @@ function collectFinalAssistantTurnIds(
 }
 
 /**
- * A turn's hideable "steps": tool activity, plans, and mid-turn assistant text.
- * The final answer and any system/shell/insight rows (errors, cancellations,
- * command output) are kept visible even when the turn is collapsed.
+ * A turn's hideable "steps": tool activity, plans, mid-turn assistant text,
+ * and non-final background notifications. The final content and any other
+ * system/shell/insight rows (errors, cancellations, command output) are kept
+ * visible even when the turn is collapsed.
  */
 function isHideableStep(item: DisplayItem, isFinalAnswer: boolean): boolean {
   if (item.type === 'parallel_agents') return true;
@@ -567,6 +577,9 @@ function isHideableStep(item: DisplayItem, isFinalAnswer: boolean): boolean {
     case 'thinking':
       return true;
     case 'system':
+      if (item.message.source === 'background_notification') {
+        return !isFinalAnswer;
+      }
       return isMidTurnInjectedDebugMessage(item.message);
     case 'user':
     case 'user_shell':
@@ -888,6 +901,7 @@ export function getSessionTimelineEntries(
       timelineItems,
       -1,
       timelineItems.length - 1,
+      false,
     );
     const finalAssistantItem =
       finalAssistantIndex >= 0 ? timelineItems[finalAssistantIndex] : null;

--- a/packages/web-shell/client/components/messages/SystemMessage.module.css
+++ b/packages/web-shell/client/components/messages/SystemMessage.module.css
@@ -31,6 +31,37 @@
   min-width: 0;
 }
 
+.notificationContent {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.notificationIcon {
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+  flex: 0 0 auto;
+  margin-top: calc((1.6em - 14px) / 2);
+}
+
+.notificationIcon svg {
+  width: 14px;
+  height: 14px;
+}
+
+.notificationIcon[data-tone='success'] {
+  color: var(--success-color);
+}
+
+.notificationIcon[data-tone='error'] {
+  color: var(--error-color);
+}
+
+.notificationText {
+  min-width: 0;
+}
+
 .message pre {
   display: inline;
   margin: 0;

--- a/packages/web-shell/client/components/messages/SystemMessage.test.tsx
+++ b/packages/web-shell/client/components/messages/SystemMessage.test.tsx
@@ -20,12 +20,12 @@ afterEach(() => {
   }
 });
 
-function render(node: ReactNode): HTMLElement {
+function render(node: ReactNode, language: 'en' | 'zh-CN' = 'en'): HTMLElement {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
   act(() => {
-    root.render(<I18nProvider language="en">{node}</I18nProvider>);
+    root.render(<I18nProvider language={language}>{node}</I18nProvider>);
   });
   mounted.push({ root, container });
   return container;
@@ -59,6 +59,78 @@ describe('SystemMessage — prompt_cancelled marker', () => {
     );
     expect(container.querySelector('[role="status"]')).toBeNull();
     expect(container.textContent).toContain('a plain note');
+  });
+});
+
+describe('SystemMessage — background notification label', () => {
+  it('labels background task notifications and preserves display text', () => {
+    const container = render(
+      <SystemMessage
+        content='Background agent "worker" completed.'
+        variant="info"
+        source="background_notification"
+        data={{ status: 'completed' }}
+      />,
+    );
+
+    expect(container.textContent).toContain(
+      'Background agent "worker" completed.',
+    );
+    const icon = container.querySelector('[role="img"][data-tone="success"]');
+    expect(icon?.getAttribute('aria-label')).toBe('Background task completed');
+    expect(icon?.nextElementSibling?.textContent).toContain(
+      'Background agent "worker" completed.',
+    );
+    expect(icon?.querySelector('svg')).not.toBeNull();
+  });
+
+  it('localizes the label', () => {
+    const container = render(
+      <SystemMessage
+        content="后台代理已完成。"
+        variant="info"
+        source="background_notification"
+        data={{ status: 'completed' }}
+      />,
+      'zh-CN',
+    );
+
+    expect(
+      container
+        .querySelector('[role="img"][data-tone="success"]')
+        ?.getAttribute('aria-label'),
+    ).toBe('后台任务执行完成');
+  });
+
+  it.each([
+    ['failed', '后台任务执行失败', 'error'],
+    ['cancelled', '后台任务已取消', 'neutral'],
+    ['unknown', '后台任务通知', 'neutral'],
+  ])(
+    'uses the matching label and tone for %s status',
+    (status, label, tone) => {
+      const container = render(
+        <SystemMessage
+          content="任务结果"
+          variant="info"
+          source="background_notification"
+          data={{ status }}
+        />,
+        'zh-CN',
+      );
+
+      const icon = container.querySelector(`[role="img"][data-tone="${tone}"]`);
+      expect(icon?.getAttribute('aria-label')).toBe(label);
+      expect(icon?.querySelector('svg')).not.toBeNull();
+    },
+  );
+
+  it('does not label generic system information', () => {
+    const container = render(
+      <SystemMessage content="Connected." variant="info" />,
+    );
+
+    expect(container.textContent).toBe('Connected.');
   });
 });
 

--- a/packages/web-shell/client/components/messages/SystemMessage.tsx
+++ b/packages/web-shell/client/components/messages/SystemMessage.tsx
@@ -1,4 +1,10 @@
 import { memo } from 'react';
+import {
+  CircleCheckIcon,
+  CircleMinusIcon,
+  CircleXIcon,
+  InfoIcon,
+} from 'lucide-react';
 import { useI18n } from '../../i18n';
 import {
   ContextUsageMessage,
@@ -114,20 +120,70 @@ export const SystemMessage = memo(function SystemMessage({
   const preserveWhitespace =
     variant === 'info' && source === 'model_switch_summary';
   const isRecap = variant === 'info' && source === 'recap';
+  const isTaskNotification =
+    variant === 'info' && source === 'background_notification';
+  const taskStatus =
+    isTaskNotification &&
+    typeof data === 'object' &&
+    data !== null &&
+    'status' in data &&
+    typeof data.status === 'string'
+      ? data.status
+      : undefined;
+  const taskNotificationLabel =
+    taskStatus === 'completed'
+      ? t('system.taskCompleted')
+      : taskStatus === 'failed'
+        ? t('system.taskFailed')
+        : taskStatus === 'cancelled'
+          ? t('system.taskCancelled')
+          : t('system.taskNotification');
+  const taskNotificationTone =
+    taskStatus === 'completed'
+      ? 'success'
+      : taskStatus === 'failed'
+        ? 'error'
+        : 'neutral';
+  const TaskNotificationIcon =
+    taskStatus === 'completed'
+      ? CircleCheckIcon
+      : taskStatus === 'failed'
+        ? CircleXIcon
+        : taskStatus === 'cancelled'
+          ? CircleMinusIcon
+          : InfoIcon;
+  const renderedContent = preserveWhitespace ? (
+    <pre>{content}</pre>
+  ) : variant === 'info' ? (
+    <Markdown content={content} />
+  ) : (
+    <pre>{content}</pre>
+  );
 
   return (
     <div
       className={`${styles.message} ${styles[variant]} ${
         preserveWhitespace ? styles.modelSwitch : ''
-      } ${isRecap ? styles.recap : ''}`}
+      } ${isRecap ? styles.recap : ''} ${
+        isTaskNotification ? styles.noMarker : ''
+      }`}
     >
       <div className={styles.content}>
-        {preserveWhitespace ? (
-          <pre>{content}</pre>
-        ) : variant === 'info' ? (
-          <Markdown content={content} />
+        {isTaskNotification ? (
+          <div className={styles.notificationContent}>
+            <span
+              className={styles.notificationIcon}
+              data-tone={taskNotificationTone}
+              role="img"
+              aria-label={taskNotificationLabel}
+              title={taskNotificationLabel}
+            >
+              <TaskNotificationIcon aria-hidden="true" />
+            </span>
+            <div className={styles.notificationText}>{renderedContent}</div>
+          </div>
         ) : (
-          <pre>{content}</pre>
+          renderedContent
         )}
         {showRetryHint && onRetryClick && (
           <div className={styles.retryHint}>

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -1191,6 +1191,10 @@ const EN: Messages = {
   'help.shortcut.compact': 'Toggle compact mode',
   'retry.hint': 'Press Ctrl+Y to retry or click to retry',
   'retry.none': 'No failed request to retry.',
+  'system.taskNotification': 'Task notification',
+  'system.taskCompleted': 'Background task completed',
+  'system.taskFailed': 'Background task failed',
+  'system.taskCancelled': 'Background task cancelled',
   'branch.failed': 'Failed to branch session.',
   'branch.success': (v) =>
     `Copied session. New session name: "${v?.name ?? ''}". Switched to the new session.`,
@@ -3472,6 +3476,10 @@ const ZH: Messages = {
   'help.shortcut.compact': '切换紧凑模式',
   'retry.hint': '按 Ctrl+Y 重试或点击重试',
   'retry.none': '没有可重试的失败请求。',
+  'system.taskNotification': '后台任务通知',
+  'system.taskCompleted': '后台任务执行完成',
+  'system.taskFailed': '后台任务执行失败',
+  'system.taskCancelled': '后台任务已取消',
   'branch.failed': '分支会话失败。',
   'branch.success': (v) =>
     `已复制会话，新会话名称为： "${v?.name ?? ''}"，当前已切换到新的会话。`,

--- a/packages/web-shell/client/main.tsx
+++ b/packages/web-shell/client/main.tsx
@@ -173,7 +173,6 @@ function StandaloneApp({ daemonToken }: { daemonToken?: string }) {
             onSessionIdChange: handleSessionIdChange,
             sidebar: true,
             compactThinking: true,
-            markdownTableMode: 'advanced',
           }}
         />
       </DaemonWorkspaceProvider>


### PR DESCRIPTION
## What this PR does

Background task notifications loaded from persisted transcripts are now identified as model-input/system-originated messages instead of being rendered as user messages. Live and replayed notifications share the same left-side presentation, use a status icon for completed, failed, and cancelled tasks, keep the backend notification text intact, and participate in completed-turn folding unless the notification is the final assistant-side content.

This PR also removes the Web Shell entry point's `advanced` Markdown table mode default. The shared renderer's existing basic table mode is now used by default, while callers can still opt into advanced table rendering explicitly.

## Why it's needed

After a page refresh, the transcript load path previously converted task completion notifications into ordinary user-message chunks. That made system-generated context appear as if the user had typed it, while the live path filtered the same information out completely. Preserving source and task-status metadata across recording and replay lets both paths present the notification consistently without parsing display text.

The table-mode change fixes an unrelated default-value issue included in this branch: the application entry point should not override the renderer's basic default for every Web Shell consumer.

## Reviewer Test Plan

### How to verify

1. Complete, fail, or cancel a background task and confirm its notification appears on the left with the corresponding status icon and the original backend text.
2. Refresh the page and confirm the same notification remains a system message rather than moving to the user-message side.
3. Confirm a notification between assistant turns is included in completed-turn folding, while a final notification remains visible.
4. Render a Markdown table without specifying a table mode and confirm it uses the basic renderer; explicitly request advanced mode and confirm that option still works.

### Evidence (Before & After)

| Before | After |
| --- | --- |
| Replayed task notifications appeared as right-side user messages; live notifications were hidden. | Live and replayed notifications use the same left-side system presentation with status icons and unchanged backend text. |
| The Web Shell entry point forced advanced table rendering. | The renderer's basic table mode is used by default; advanced mode remains opt-in. |

### Tested on

| OS | Status |
| --- | --- |
| macOS | ✅ |
| Windows | Not tested |
| Linux | Not tested |

### Environment (optional)

- Node.js 22+
- npm workspaces

## Risk & Scope

- Main risk or tradeoff: The notification source and optional task status now pass through recording, ACP replay, and Web Shell mapping. Legacy records without structured status metadata continue to use the neutral notification presentation.
- Not validated / out of scope: Windows and Linux visual verification; changes to task notification wording produced by the backend.
- Breaking changes / migration notes: None. Existing persisted records remain readable, and advanced table rendering remains available through an explicit option.

## Linked Issues

N/A

## Pictures
<img width="2298" height="1832" alt="image" src="https://github.com/user-attachments/assets/e73d0259-b410-4050-9fd4-f941606a4cd6" />



<details>
<summary>中文说明</summary>

页面刷新后，历史记录中的后台任务通知不再被当作用户消息展示。录制和回放链路会保留消息来源与可选的任务状态，实时消息和回放消息统一在左侧以系统通知形式展示；完成、失败、取消分别使用对应状态图标，正文保持后端返回的原始内容。位于中间的通知会参与“已处理”折叠，作为最后一条助手侧内容时则保持可见。

本 PR 还包含一个独立的默认值修复：移除 Web Shell 入口对高级 Markdown 表格模式的默认指定，恢复共享渲染器原有的基础表格默认行为；调用方仍然可以显式开启高级表格模式。

</details>
