### PR TITLE
fix(web-shell): preserve pasted text in composer

### DIFF
--- a/packages/web-shell/client/e2e/web-shell.smoke.spec.ts
+++ b/packages/web-shell/client/e2e/web-shell.smoke.spec.ts
@@ -69,6 +69,32 @@ test('submits a prompt and renders a streamed assistant response @smoke', async 
   );
 });
 
+test('pastes long plain text as editable composer content @smoke', async ({
+  page,
+}, testInfo) => {
+  const scenario = createWebShellDaemonScenario();
+  const daemon = await installScenario(page, scenario, testInfo);
+  const pasted = `${'original '.repeat(151)}end`;
+  const edited = `${pasted} edited`;
+
+  await gotoSession(page, scenario, daemon);
+  await pasteComposerText(page, pasted);
+
+  const editor = page.locator('[data-web-shell-composer-editor] .cm-content');
+  await expect(editor).toHaveText(pasted);
+  await expect(editor).not.toContainText('Pasted Content');
+
+  await page.keyboard.type(' edited');
+  await expect(editor).toHaveText(edited);
+  await page.locator('[data-web-shell-composer-submit]').click();
+
+  await expect.poll(() => daemon.promptRequests().length).toBe(1);
+  expectPromptBodyToContainText(
+    requestBodyRecord(firstRequest(daemon.promptRequests())),
+    edited,
+  );
+});
+
 test('keeps later SSE connections alive when an earlier one is cancelled @smoke', async ({
   page,
 }, testInfo) => {
@@ -626,6 +652,20 @@ async function replaceComposerText(page: Page, text: string): Promise<void> {
     process.platform === 'darwin' ? 'Meta+A' : 'Control+A',
   );
   await page.keyboard.insertText(text);
+}
+
+async function pasteComposerText(page: Page, text: string): Promise<void> {
+  const origin = new URL(page.url()).origin;
+  await page
+    .context()
+    .grantPermissions(['clipboard-read', 'clipboard-write'], { origin });
+  await page.evaluate((clipboardText) => {
+    return navigator.clipboard.writeText(clipboardText);
+  }, text);
+  await page.locator('[data-web-shell-composer-editor] .cm-content').click();
+  await page.keyboard.press(
+    process.platform === 'darwin' ? 'Meta+V' : 'Control+V',
+  );
 }
 
 async function pasteComposerImages(page: Page, count: number): Promise<void> {

--- a/packages/web-shell/client/hooks/useComposerCore.test.ts
+++ b/packages/web-shell/client/hooks/useComposerCore.test.ts
@@ -2,38 +2,13 @@ import { describe, expect, it } from 'vitest';
 import {
   buildComposerPrompt,
   buildComposerPromptWithInlineTagPlacements,
-  createLargePastePlaceholder,
-  expandLargePastePlaceholders,
   getComposerTagDisplay,
   getComposerTagLabel,
   getComposerTagValue,
   getFollowupCompletion,
-  isLargePaste,
-  normalizePastedText,
-  prunePendingPastes,
   replaceInlineTagPlacements,
   serializeComposerTag,
 } from './useComposerCore';
-
-describe('composer paste helpers', () => {
-  it('normalizes CRLF and CR newlines', () => {
-    expect(normalizePastedText('a\r\nb\rc')).toBe('a\nb\nc');
-  });
-
-  it('treats short text as a normal paste', () => {
-    expect(isLargePaste('hello\nworld')).toBe(false);
-  });
-
-  it('treats long text as a large paste', () => {
-    expect(isLargePaste('x'.repeat(1001))).toBe(true);
-  });
-
-  it('treats many lines as a large paste', () => {
-    expect(isLargePaste(Array.from({ length: 11 }, () => 'x').join('\n'))).toBe(
-      true,
-    );
-  });
-});
 
 describe('follow-up completion helpers', () => {
   it('uses the full suggestion when the editor is empty', () => {
@@ -48,56 +23,6 @@ describe('follow-up completion helpers', () => {
 
   it('ignores suggestions that no longer match the editor text', () => {
     expect(getFollowupCompletion('run', 'show me tests')).toBeNull();
-  });
-});
-
-describe('large paste placeholders', () => {
-  it('creates stable placeholders and increments duplicate labels', () => {
-    const pending = new Map<string, string>();
-
-    const first = createLargePastePlaceholder(pending, 1, 'abc');
-    const second = createLargePastePlaceholder(
-      pending,
-      first.nextPasteId,
-      'def',
-    );
-
-    expect(first).toEqual({
-      placeholderText: '[Pasted Content 3 chars]',
-      nextPasteId: 2,
-    });
-    expect(second).toEqual({
-      placeholderText: '[Pasted Content 3 chars] #2',
-      nextPasteId: 3,
-    });
-    expect(pending.get(first.placeholderText)).toBe('abc');
-    expect(pending.get(second.placeholderText)).toBe('def');
-  });
-
-  it('expands longer placeholder names before shorter prefixes', () => {
-    const pending = new Map<string, string>([
-      ['[Pasted Content 3 chars]', 'first'],
-      ['[Pasted Content 3 chars] #2', 'second'],
-    ]);
-
-    expect(
-      expandLargePastePlaceholders(
-        pending,
-        '[Pasted Content 3 chars] #2\n[Pasted Content 3 chars]',
-      ),
-    ).toBe('second\nfirst');
-  });
-
-  it('prunes placeholders missing from the current editor text', () => {
-    const pending = new Map<string, string>([
-      ['[Pasted Content 3 chars]', 'first'],
-      ['[Pasted Content 4 chars]', 'next'],
-    ]);
-
-    expect(prunePendingPastes(pending, '[Pasted Content 4 chars]')).toBeNull();
-    expect([...pending.keys()]).toEqual(['[Pasted Content 4 chars]']);
-    expect(prunePendingPastes(pending, '')).toBe(1);
-    expect(pending.size).toBe(0);
   });
 });
 
@@ -190,27 +115,5 @@ describe('composer tag serialization', () => {
         },
       ]),
     ).toBe('a <one /> and <two />');
-  });
-
-  it('replaces inline tags before expanding large paste placeholders', () => {
-    const pending = new Map<string, string>();
-    const paste = createLargePastePlaceholder(
-      pending,
-      1,
-      'expanded pasted content that is longer than the placeholder',
-    );
-    const text = `${paste.placeholderText} explain @orders`;
-    const tagStart = text.indexOf('@orders');
-    const withInlineTags = replaceInlineTagPlacements(text, [
-      {
-        start: tagStart,
-        end: tagStart + '@orders'.length,
-        tag: { id: 'table', value: 'orders', serialized: '<table />' },
-      },
-    ]);
-
-    expect(expandLargePastePlaceholders(pending, withInlineTags)).toBe(
-      'expanded pasted content that is longer than the placeholder explain <table />',
-    );
   });
 });

--- a/packages/web-shell/client/hooks/useComposerCore.ts
+++ b/packages/web-shell/client/hooks/useComposerCore.ts
@@ -93,10 +93,6 @@ import type {
 } from '../customization';
 import { useWebShellPortalRoot } from '../portalRoot';
 
-// ---- Large paste handling (shared utilities) ----
-
-const LARGE_PASTE_CHAR_THRESHOLD = 1000;
-const LARGE_PASTE_LINE_THRESHOLD = 10;
 const TOOLTIP_STYLE_ID = 'web-shell-tooltip-styles';
 const TOOLTIP_STYLES = `
 [data-web-shell-tooltip-portal] {
@@ -452,65 +448,6 @@ function renderCompletionHoverInfo(completion: Completion): HTMLElement | null {
     });
   });
   return anchor;
-}
-
-export function normalizePastedText(text: string): string {
-  return text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
-}
-
-export function isLargePaste(text: string): boolean {
-  return (
-    [...text].length > LARGE_PASTE_CHAR_THRESHOLD ||
-    text.split('\n').length > LARGE_PASTE_LINE_THRESHOLD
-  );
-}
-
-function escapeRegExp(text: string): string {
-  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-export interface LargePastePlaceholderResult {
-  placeholderText: string;
-  nextPasteId: number;
-}
-
-export function createLargePastePlaceholder(
-  pendingPastes: Map<string, string>,
-  nextPasteId: number,
-  pasted: string,
-): LargePastePlaceholderResult {
-  const charCount = [...pasted].length;
-  const base = `[Pasted Content ${charCount} chars]`;
-  const placeholderText = nextPasteId === 1 ? base : `${base} #${nextPasteId}`;
-  pendingPastes.set(placeholderText, pasted);
-  return { placeholderText, nextPasteId: nextPasteId + 1 };
-}
-
-export function prunePendingPastes(
-  pendingPastes: Map<string, string>,
-  docText: string,
-): number | null {
-  for (const placeholderText of pendingPastes.keys()) {
-    if (!docText.includes(placeholderText)) {
-      pendingPastes.delete(placeholderText);
-    }
-  }
-  return pendingPastes.size === 0 ? 1 : null;
-}
-
-export function expandLargePastePlaceholders(
-  pendingPastes: Map<string, string>,
-  text: string,
-): string {
-  if (pendingPastes.size === 0) return text;
-  const placeholders = [...pendingPastes.keys()].sort(
-    (a, b) => b.length - a.length,
-  );
-  const pattern = new RegExp(placeholders.map(escapeRegExp).join('|'), 'g');
-  return text.replace(
-    pattern,
-    (placeholderText) => pendingPastes.get(placeholderText) ?? placeholderText,
-  );
 }
 
 // ---- Tag serialization (shared) ----
@@ -1491,8 +1428,6 @@ export function useComposerCore(
   const searchDraftRef = useRef('');
   const [pastedImages, setPastedImages] = useState<PromptImage[]>([]);
   const pastedImagesRef = useRef<PromptImage[]>([]);
-  const pendingPastesRef = useRef<Map<string, string>>(new Map());
-  const nextPasteIdRef = useRef(1);
   const [composerTags, setComposerTags] = useState<WebShellComposerTag[]>([]);
   const composerTagsRef = useRef<WebShellComposerTag[]>([]);
   composerTagsRef.current = composerTags;
@@ -1935,8 +1870,7 @@ export function useComposerCore(
       const hasImage = collectClipboardImages(items, (image) =>
         setPastedImages((prev) => [...prev, image]),
       );
-      // Plain text falls through to the native paste. Large-paste
-      // placeholders are a CodeMirror-only affordance.
+      // Plain text falls through to the native paste.
       if (hasImage) {
         event.preventDefault();
       }
@@ -1985,14 +1919,10 @@ export function useComposerCore(
         : [];
     const tags = tagsOverride ?? composerTagsRef.current;
     if (!rawText && tags.length === 0 && inlineTags.length === 0) return true;
-    const textWithInlineTags =
+    const text =
       tagsOverride === undefined
         ? replaceInlineTagPlacements(rawText, normalizedInlineTags)
         : rawText;
-    const text = expandLargePastePlaceholders(
-      pendingPastesRef.current,
-      textWithInlineTags,
-    );
     const prompt = buildComposerPrompt(text, tags);
     const images = pastedImagesRef.current;
     const isShellMode = shellModeRef.current;
@@ -2010,8 +1940,6 @@ export function useComposerCore(
         onAcceptFollowupRef.current?.('enter', { skipOnAccept: true });
       }
       onDismissFollowupRef.current?.();
-      pendingPastesRef.current.clear();
-      nextPasteIdRef.current = 1;
       if (isShellMode) {
         shellHistoryActionsRef.current.push(text);
         shellHistoryActionsRef.current.reset();
@@ -2439,15 +2367,6 @@ export function useComposerCore(
     ]);
 
     const composerUpdateListener = EditorView.updateListener.of((update) => {
-      if (update.docChanged && pendingPastesRef.current.size > 0) {
-        const nextPasteId = prunePendingPastes(
-          pendingPastesRef.current,
-          update.state.doc.toString(),
-        );
-        if (nextPasteId !== null) {
-          nextPasteIdRef.current = nextPasteId;
-        }
-      }
       // A genuine edit (typing/deleting/pasting) ends history-browse mode, so
       // arrows go back to driving any open menu. Programmatic history recall
       // dispatches carry no user event, so they do not clear the flag.
@@ -2637,36 +2556,7 @@ export function useComposerCore(
               event.preventDefault();
               return true;
             }
-            const pasted = normalizePastedText(
-              event.clipboardData?.getData('text/plain') ?? '',
-            );
-            if (!pasted || !isLargePaste(pasted)) return false;
-
-            event.preventDefault();
-            if (
-              view.state.doc.toString() === '' &&
-              followupStateRef.current?.isVisible
-            ) {
-              onDismissFollowupRef.current?.();
-            }
-            const { placeholderText: pt, nextPasteId } =
-              createLargePastePlaceholder(
-                pendingPastesRef.current,
-                nextPasteIdRef.current,
-                pasted,
-              );
-            nextPasteIdRef.current = nextPasteId;
-            const selection = view.state.selection.main;
-            view.dispatch({
-              changes: {
-                from: selection.from,
-                to: selection.to,
-                insert: pt,
-              },
-              selection: { anchor: selection.from + pt.length },
-              scrollIntoView: true,
-            });
-            return true;
+            return false;
           },
         }),
         EditorView.theme(editorTheme),
@@ -3104,8 +2994,6 @@ export function useComposerCore(
       }
       if (clearTextOpt) {
         setPastedImages([]);
-        pendingPastesRef.current.clear();
-        nextPasteIdRef.current = 1;
       }
       if (clearTags) {
         setComposerTags([]);


### PR DESCRIPTION
## What this PR does

Removes the Web Shell composer behavior that replaced large pasted text with a `[Pasted Content N chars]` placeholder. Plain text now follows the editor's native paste path, so the complete clipboard content remains visible and editable. Image paste behavior is unchanged.

## Why it's needed

Text longer than 1000 characters or 10 lines was hidden behind a placeholder, so users could not modify the actual pasted input before submitting it. Editing the placeholder could also discard the cached original text. The composer already has a maximum height and scrolls long content internally, so large pasted text does not need a separate collapsing mechanism.

## Reviewer Test Plan

### How to verify

Paste text longer than 1000 characters into the Web Shell composer. Confirm that the full text is displayed instead of a placeholder, append or remove text, submit the prompt, and verify that the submitted prompt exactly matches the edited content. Paste a supported image and confirm that it is still added as an attachment.

### Evidence (Before & After)

Before: large plain-text pastes appeared as `[Pasted Content N chars]` and the original text could not be edited in place.

After: the complete pasted text appears in the composer, remains editable, and is submitted exactly as edited. The existing composer height limit keeps large pastes contained within the layout. Automated browser coverage verifies a 1200+ character system-clipboard paste and the existing image-paste path.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local Chromium through Playwright with the Web Shell mock daemon.

## Risk & Scope

- Main risk or tradeoff: large pasted text remains in the editor document, while the existing maximum height and internal scrolling continue to constrain its visual footprint.
- Not validated / out of scope: native clipboard shortcuts were not manually tested on Windows or Linux; automated Chromium coverage exercises the platform-specific shortcut path.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 此 PR 的改动

移除 Web Shell 输入框将大段粘贴文本替换为 `[Pasted Content N chars]` 占位符的行为。纯文本现在使用编辑器原生粘贴路径，因此剪贴板完整内容会保持可见且可编辑。图片粘贴行为不变。

## 为什么需要

超过 1000 个字符或 10 行的文本此前会隐藏在占位符后面，导致用户提交前无法修改实际粘贴的输入内容，而且修改占位符还可能导致缓存的原始文本丢失。输入框本身已有最大高度限制，长内容会在内部滚动，因此大段粘贴文本不需要额外的折叠机制。

## Reviewer 测试计划

### 验证方式

在 Web Shell 输入框中粘贴超过 1000 个字符的文本。确认显示完整文本而不是占位符，追加或删除文本后提交，并验证提交内容与编辑后的内容完全一致。再粘贴一张支持的图片，确认图片仍会作为附件添加。

### 前后对比证据

之前：大段纯文本粘贴会显示为 `[Pasted Content N chars]`，原始文本无法直接编辑。

之后：完整粘贴文本会显示在输入框中，可以继续编辑，并严格按编辑后的内容提交。现有输入框高度限制会将大段粘贴内容约束在布局内。浏览器自动化测试覆盖了 1200 多字符的系统剪贴板粘贴和现有图片粘贴路径。

### 测试平台

|     系统     | 状态 |
| :----------: | :--: |
|  🍏 macOS   |  ✅  |
| 🪟 Windows  |  ⚠️  |
|  🐧 Linux   |  ⚠️  |

### 环境（可选）

使用 Web Shell mock daemon 的本地 Playwright Chromium。

## 风险与范围

- 主要风险或权衡：大段粘贴文本会保留在编辑器文档中，其视觉占用仍由现有最大高度和内部滚动约束。
- 未验证或不在范围内：未在 Windows 或 Linux 上手动测试原生剪贴板快捷键；Chromium 自动化测试覆盖了平台对应的快捷键路径。
- 破坏性变更或迁移说明：无。

## 关联 Issue

无

</details>
