### PR TITLE
fix(safe-mode): preserve caller-supplied top-tier MCP servers

### DIFF
--- a/docs/users/support/troubleshooting.md
+++ b/docs/users/support/troubleshooting.md
@@ -59,6 +59,7 @@ This guide provides solutions to common issues and debugging tips, including top
   - A: Start Qwen Code with the `--safe-mode` flag to disable all customizations — context files, hooks, extensions, skills, MCP servers, custom subagents (only built-in subagents load), permission rules, settings-sourced approval mode overrides, memory features, and sandbox settings — for the session. Note: the CLI flags `--yolo` and `--approval-mode` still take effect in safe mode. If the problem disappears in safe mode, re-enable your customizations one at a time to find the culprit.
     - Example: `qwen --safe-mode`
     - Alternative: set the environment variable `QWEN_CODE_SAFE_MODE=true` if the CLI cannot accept flags.
+    - Note: "MCP servers" here means servers configured in `settings.json` / project `.mcp.json` — local, ambient state that safe mode is meant to isolate against. MCP servers you explicitly supply for the current invocation (an embedding ACP client's `session/new` `mcpServers`, or `--mcp-config`) are not local/ambient state and are still honored under safe mode.
 
 ## Common error messages and solutions
 

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -13812,6 +13812,8 @@ describe('QwenAgent extMethod runtime MCP add/remove (T2.8)', () => {
       getRuntimeMcpServers: vi.fn().mockReturnValue({}),
       getCliAllowedMcpServerNames: vi.fn().mockReturnValue(undefined),
       getApprovalMode: vi.fn().mockReturnValue('default'),
+      getBareMode: vi.fn().mockReturnValue(false),
+      isSafeMode: vi.fn().mockReturnValue(false),
       setExcludedMcpServers: vi.fn(),
       setAllowedMcpServers: vi.fn(),
       setPendingMcpServers: vi.fn(),
@@ -13881,6 +13883,8 @@ describe('QwenAgent extMethod runtime MCP add/remove (T2.8)', () => {
       getRuntimeMcpServers: vi.fn().mockReturnValue({}),
       getCliAllowedMcpServerNames: vi.fn().mockReturnValue(undefined),
       getApprovalMode: vi.fn().mockReturnValue('default'),
+      getBareMode: vi.fn().mockReturnValue(false),
+      isSafeMode: vi.fn().mockReturnValue(false),
       setExcludedMcpServers: vi.fn(),
       setAllowedMcpServers: vi.fn(),
       setPendingMcpServers: vi.fn(),
@@ -14022,6 +14026,96 @@ describe('QwenAgent extMethod runtime MCP add/remove (T2.8)', () => {
     await vi.waitFor(() =>
       expect(forceDiscover).toHaveBeenCalledWith('secondary'),
     );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('safe mode: workspaceMcpReload does NOT leak settings.mcpServers/mcp.allowed into an already-running session', async () => {
+    // Same bare/safe guard as registerMcpHotReload (config/hot-reload.ts) and
+    // loadCliConfig (config.ts) — reloadWorkspaceMcpDiscovery (this ACP
+    // control-endpoint reload path) used to call assembleMcpServers /
+    // recomputeMcpGating unconditionally, per live Config in liveConfigs, so
+    // a workspaceMcpReload request against an already-running safe/bare
+    // session would fold settings.mcpServers/mcp.allowed (local state safe
+    // mode distrusts) back in, silently stranding or filtering the caller's
+    // own top-tier server. Found by an automated review pass on PR #7827.
+    mockConfig.isSafeMode = vi.fn().mockReturnValue(true);
+    mockConfig.getTopTierMcpServers = vi
+      .fn()
+      .mockReturnValue({ probe: { command: 'probe' } });
+
+    const discoveryManager = {
+      discoverAllMcpToolsIncremental: vi.fn().mockResolvedValue(undefined),
+      getDiscoveryState: vi.fn().mockReturnValue(MCPDiscoveryState.COMPLETED),
+      getMcpClientAccounting: vi.fn().mockReturnValue({
+        total: 0,
+        refusedServerNames: [],
+      }),
+      getMcpClientBudget: vi.fn().mockReturnValue(undefined),
+      getMcpBudgetMode: vi.fn().mockReturnValue(undefined),
+    };
+    const discoveryConfig = {
+      initialize: vi.fn().mockResolvedValue(undefined),
+      reinitializeMcpServers: vi.fn().mockResolvedValue(undefined),
+      setMcpTransportPool: vi.fn(),
+      getTargetDir: vi.fn().mockReturnValue('/tmp'),
+      getMcpServers: vi.fn().mockReturnValue({}),
+      getTopTierMcpServers: vi.fn().mockReturnValue(undefined),
+      getRuntimeMcpServers: vi.fn().mockReturnValue({}),
+      getCliAllowedMcpServerNames: vi.fn().mockReturnValue(undefined),
+      getApprovalMode: vi.fn().mockReturnValue('default'),
+      getBareMode: vi.fn().mockReturnValue(false),
+      isSafeMode: vi.fn().mockReturnValue(false),
+      setExcludedMcpServers: vi.fn(),
+      setAllowedMcpServers: vi.fn(),
+      setPendingMcpServers: vi.fn(),
+      getToolRegistry: vi.fn().mockReturnValue({
+        getMcpClientManager: vi.fn().mockReturnValue(discoveryManager),
+      }),
+    } as unknown as Config;
+    vi.mocked(loadSettings).mockReturnValue({
+      merged: { mcpServers: {} },
+      forScope: vi.fn().mockReturnValue({ settings: {} }),
+      getUserHooks: vi.fn().mockReturnValue({}),
+      getProjectHooks: vi.fn().mockReturnValue({}),
+    } as unknown as LoadedSettings);
+    vi.mocked(loadCliConfig).mockResolvedValue(discoveryConfig);
+
+    const { agent, agentPromise } = await getAgent();
+    await expect(
+      agent.extMethod(SERVE_CONTROL_EXT_METHODS.workspaceMcpInitialize, {}),
+    ).resolves.toEqual({ accepted: true });
+    await vi.waitFor(() =>
+      expect(
+        discoveryManager.discoverAllMcpToolsIncremental,
+      ).toHaveBeenCalledWith(discoveryConfig),
+    );
+
+    // A settings.json edit fires while the safe-mode session is live —
+    // local mcpServers/mcp.allowed that must NOT reach an already-running
+    // safe-mode session.
+    vi.mocked(loadSettings).mockReturnValue({
+      merged: {
+        mcpServers: { local: { command: 'should-not-leak-in' } },
+        mcp: { allowed: ['some-other-server'] },
+      },
+      forScope: vi.fn().mockReturnValue({ settings: {} }),
+      getUserHooks: vi.fn().mockReturnValue({}),
+      getProjectHooks: vi.fn().mockReturnValue({}),
+    } as unknown as LoadedSettings);
+    await expect(
+      agent.extMethod(SERVE_CONTROL_EXT_METHODS.workspaceMcpReload, {}),
+    ).resolves.toEqual({ accepted: true });
+
+    await vi.waitFor(() =>
+      expect(mockConfig.reinitializeMcpServers).toHaveBeenCalledWith({
+        probe: { command: 'probe' },
+      }),
+    );
+    expect(mockConfig.setAllowedMcpServers).toHaveBeenCalledWith(undefined);
+    expect(mockConfig.setExcludedMcpServers).toHaveBeenCalledWith([]);
+    expect(mockConfig.setPendingMcpServers).toHaveBeenCalledWith(undefined);
 
     mockConnectionState.resolve();
     await agentPromise;

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -14121,6 +14121,92 @@ describe('QwenAgent extMethod runtime MCP add/remove (T2.8)', () => {
     await agentPromise;
   });
 
+  it('bare mode: workspaceMcpReload does NOT leak settings.mcpServers/mcp.allowed into an already-running session', async () => {
+    // Bare-mode counterpart of the safe-mode test above — suggested by an
+    // automated review pass on PR #7827: the safe-mode half alone doesn't
+    // prove the bare-mode branch of `config.getBareMode() || config.isSafeMode()`
+    // wasn't accidentally narrowed to isSafeMode() only.
+    mockConfig.getBareMode = vi.fn().mockReturnValue(true);
+    mockConfig.getTopTierMcpServers = vi
+      .fn()
+      .mockReturnValue({ probe: { command: 'probe' } });
+
+    const discoveryManager = {
+      discoverAllMcpToolsIncremental: vi.fn().mockResolvedValue(undefined),
+      getDiscoveryState: vi.fn().mockReturnValue(MCPDiscoveryState.COMPLETED),
+      getMcpClientAccounting: vi.fn().mockReturnValue({
+        total: 0,
+        refusedServerNames: [],
+      }),
+      getMcpClientBudget: vi.fn().mockReturnValue(undefined),
+      getMcpBudgetMode: vi.fn().mockReturnValue(undefined),
+    };
+    const discoveryConfig = {
+      initialize: vi.fn().mockResolvedValue(undefined),
+      reinitializeMcpServers: vi.fn().mockResolvedValue(undefined),
+      setMcpTransportPool: vi.fn(),
+      getTargetDir: vi.fn().mockReturnValue('/tmp'),
+      getMcpServers: vi.fn().mockReturnValue({}),
+      getTopTierMcpServers: vi.fn().mockReturnValue(undefined),
+      getRuntimeMcpServers: vi.fn().mockReturnValue({}),
+      getCliAllowedMcpServerNames: vi.fn().mockReturnValue(undefined),
+      getApprovalMode: vi.fn().mockReturnValue('default'),
+      getBareMode: vi.fn().mockReturnValue(false),
+      isSafeMode: vi.fn().mockReturnValue(false),
+      setExcludedMcpServers: vi.fn(),
+      setAllowedMcpServers: vi.fn(),
+      setPendingMcpServers: vi.fn(),
+      getToolRegistry: vi.fn().mockReturnValue({
+        getMcpClientManager: vi.fn().mockReturnValue(discoveryManager),
+      }),
+    } as unknown as Config;
+    vi.mocked(loadSettings).mockReturnValue({
+      merged: { mcpServers: {} },
+      forScope: vi.fn().mockReturnValue({ settings: {} }),
+      getUserHooks: vi.fn().mockReturnValue({}),
+      getProjectHooks: vi.fn().mockReturnValue({}),
+    } as unknown as LoadedSettings);
+    vi.mocked(loadCliConfig).mockResolvedValue(discoveryConfig);
+
+    const { agent, agentPromise } = await getAgent();
+    await expect(
+      agent.extMethod(SERVE_CONTROL_EXT_METHODS.workspaceMcpInitialize, {}),
+    ).resolves.toEqual({ accepted: true });
+    await vi.waitFor(() =>
+      expect(
+        discoveryManager.discoverAllMcpToolsIncremental,
+      ).toHaveBeenCalledWith(discoveryConfig),
+    );
+
+    // A settings.json edit fires while the bare-mode session is live — local
+    // mcpServers/mcp.allowed that must NOT reach an already-running bare-mode
+    // session.
+    vi.mocked(loadSettings).mockReturnValue({
+      merged: {
+        mcpServers: { local: { command: 'should-not-leak-in' } },
+        mcp: { allowed: ['some-other-server'] },
+      },
+      forScope: vi.fn().mockReturnValue({ settings: {} }),
+      getUserHooks: vi.fn().mockReturnValue({}),
+      getProjectHooks: vi.fn().mockReturnValue({}),
+    } as unknown as LoadedSettings);
+    await expect(
+      agent.extMethod(SERVE_CONTROL_EXT_METHODS.workspaceMcpReload, {}),
+    ).resolves.toEqual({ accepted: true });
+
+    await vi.waitFor(() =>
+      expect(mockConfig.reinitializeMcpServers).toHaveBeenCalledWith({
+        probe: { command: 'probe' },
+      }),
+    );
+    expect(mockConfig.setAllowedMcpServers).toHaveBeenCalledWith(undefined);
+    expect(mockConfig.setExcludedMcpServers).toHaveBeenCalledWith([]);
+    expect(mockConfig.setPendingMcpServers).toHaveBeenCalledWith(undefined);
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
   it('allows workspace MCP initialization to retry after a failure', async () => {
     const stop = vi.fn().mockResolvedValue(undefined);
     const failedConfig = {

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -3292,18 +3292,35 @@ class QwenAgent implements Agent {
       for (const config of liveConfigs) {
         try {
           const cwd = config.getTargetDir();
-          const mcpServers = assembleMcpServers(
-            settings.merged.mcpServers,
-            cwd,
-            config.getTopTierMcpServers(),
-          );
-          const gating = recomputeMcpGating(
-            settings,
-            mcpServers,
-            cwd,
-            config.getCliAllowedMcpServerNames(),
-            config.getApprovalMode() === ApprovalMode.YOLO,
-          );
+          // Same bare/safe guard as registerMcpHotReload (config/hot-reload.ts)
+          // — each live Config in this Set may independently be bare/safe or
+          // not, so the check is per-config, not hoisted outside the loop.
+          // Without it, this control-endpoint reload path (workspaceMcpReload)
+          // would fold settings.merged.mcpServers/mcp.allowed/excluded — LOCAL
+          // state safe/bare mode is supposed to distrust — back into an
+          // already-running safe/bare session, silently stranding or
+          // filtering out the caller's own top-tier server. Same bug class as
+          // the loadCliConfig (boot) and registerMcpHotReload (settings-file
+          // watcher) fixes earlier in this PR, found here in the third
+          // reload path.
+          const isBareOrSafe = config.getBareMode() || config.isSafeMode();
+          const mcpServers = isBareOrSafe
+            ? { ...config.getTopTierMcpServers() }
+            : assembleMcpServers(
+                settings.merged.mcpServers,
+                cwd,
+                config.getTopTierMcpServers(),
+              );
+          const bootAllowed = config.getCliAllowedMcpServerNames();
+          const gating = isBareOrSafe
+            ? { allowed: bootAllowed ? [...bootAllowed] : undefined }
+            : recomputeMcpGating(
+                settings,
+                mcpServers,
+                cwd,
+                bootAllowed,
+                config.getApprovalMode() === ApprovalMode.YOLO,
+              );
           config.setExcludedMcpServers(gating.excluded ?? []);
           config.setAllowedMcpServers(gating.allowed);
           config.setPendingMcpServers(gating.pending);

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1453,6 +1453,40 @@ describe('loadCliConfig', () => {
     expect(servers['settings-only']).toBeUndefined();
   });
 
+  it('does NOT let a settings-sourced mcp.allowed list silently filter a session-supplied server under safe mode', async () => {
+    // Found by an automated review pass on PR #7827: the allowedMcpServers
+    // assembly guard was `!bareMode` only (missing `&& !safeMode`), so
+    // settings.mcp.allowed/excluded — LOCAL/ambient state, same category as
+    // settings.mcpServers itself — was still read under safe mode. Combined
+    // with getMcpServers()'s own allowedMcpServers filter (added earlier in
+    // this same PR for the --allowed-mcp-server-names case), a narrow
+    // settings.json mcp.allowed list would silently drop a caller-supplied
+    // top-tier server, defeating the very guarantee this PR exists to
+    // provide — via an indirect vector (a filter's SOURCE), not the
+    // mcpServers map directly.
+    process.argv = ['node', 'script.js', '--safe-mode'];
+    const argv = await parseArguments();
+    const settings: Settings = {
+      mcp: { allowed: ['some-other-server'] },
+    };
+    const sessionMcpServers = {
+      'session-server': new ServerConfig.MCPServerConfig('session-cmd'),
+    };
+
+    const config = await loadCliConfig(
+      settings,
+      argv,
+      process.cwd(),
+      undefined,
+      undefined,
+      undefined,
+      sessionMcpServers,
+    );
+
+    const servers = config.getMcpServers() ?? {};
+    expect(servers['session-server']?.command).toBe('session-cmd');
+  });
+
   it('drops ALL MCP servers under safe mode when none were supplied by the caller', async () => {
     process.argv = ['node', 'script.js', '--safe-mode'];
     const argv = await parseArguments();

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1399,6 +1399,74 @@ describe('loadCliConfig', () => {
     expect(config.isMcpServerPendingApproval('ide-only')).toBe(false);
   });
 
+  it('preserves session/CLI-supplied MCP servers under safe mode while dropping settings-sourced ones', async () => {
+    process.argv = ['node', 'script.js', '--safe-mode'];
+    const argv = await parseArguments();
+    const settings: Settings = {
+      mcpServers: {
+        'settings-only': { command: 'settings-only-cmd' },
+      },
+    };
+    const sessionMcpServers = {
+      'session-server': new ServerConfig.MCPServerConfig('session-cmd'),
+    };
+
+    const config = await loadCliConfig(
+      settings,
+      argv,
+      process.cwd(),
+      undefined,
+      undefined,
+      undefined,
+      sessionMcpServers,
+    );
+
+    const servers = config.getMcpServers() ?? {};
+    // Session-supplied server survives safe mode — it's an explicit,
+    // per-invocation argument (ACP session/new), not ambient local state.
+    expect(servers['session-server']?.command).toBe('session-cmd');
+    // Settings-sourced server is still dropped under safe mode.
+    expect(servers['settings-only']).toBeUndefined();
+    // Never approval-gated, same as the non-safe-mode case above.
+    expect(config.isMcpServerPendingApproval('session-server')).toBe(false);
+  });
+
+  it('preserves --mcp-config-supplied MCP servers under safe mode while dropping settings-sourced ones', async () => {
+    process.argv = [
+      'node',
+      'script.js',
+      '--safe-mode',
+      '--mcp-config',
+      JSON.stringify({ 'cli-server': { command: 'cli-cmd' } }),
+    ];
+    const argv = await parseArguments();
+    const settings: Settings = {
+      mcpServers: {
+        'settings-only': { command: 'settings-only-cmd' },
+      },
+    };
+
+    const config = await loadCliConfig(settings, argv, process.cwd());
+
+    const servers = config.getMcpServers() ?? {};
+    expect(servers['cli-server']?.command).toBe('cli-cmd');
+    expect(servers['settings-only']).toBeUndefined();
+  });
+
+  it('drops ALL MCP servers under safe mode when none were supplied by the caller', async () => {
+    process.argv = ['node', 'script.js', '--safe-mode'];
+    const argv = await parseArguments();
+    const settings: Settings = {
+      mcpServers: {
+        'settings-only': { command: 'settings-only-cmd' },
+      },
+    };
+
+    const config = await loadCliConfig(settings, argv, process.cwd());
+
+    expect(config.getMcpServers()).toEqual({});
+  });
+
   it('gates unapproved workspace MCP servers in non-interactive runs', async () => {
     process.argv = ['node', 'script.js', '-p', 'hello'];
     const argv = await parseArguments();

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -1862,7 +1862,18 @@ export async function loadCliConfig(
   if (argv.allowedMcpServerNames) {
     allowedMcpServers = new Set(argv.allowedMcpServerNames.filter(Boolean));
     excludedMcpServers = undefined;
-  } else if (!bareMode) {
+  } else if (!bareMode && !safeMode) {
+    // Settings-sourced allow/exclude lists are LOCAL/ambient state, same
+    // category as settings.mcpServers itself — safe mode already drops the
+    // latter (getMcpServers()) but this branch used to read the former
+    // unconditionally (only bareMode was guarded), so a settings.json
+    // mcp.allowed narrower than the caller's own top-tier servers would
+    // silently filter them back out via getMcpServers()'s allowedMcpServers
+    // filter (added in this same PR, #7827, for the `--allowed-mcp-server-
+    // names` case) — defeating the very guarantee this PR exists to provide.
+    // The argv.allowedMcpServerNames branch above is unaffected: that's an
+    // explicit per-invocation argument, not local state, so it still applies
+    // under safe mode same as topTierMcpServers itself.
     allowedMcpServers = settings.mcp?.allowed
       ? new Set(settings.mcp.allowed.filter(Boolean))
       : undefined;

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -2008,12 +2008,20 @@ export async function loadCliConfig(
     sessionMcpServers || cliMcpServers
       ? { ...sessionMcpServers, ...(cliMcpServers ?? {}) }
       : undefined;
+  // Bare/safe mode still drop settings.mcpServers/`.mcp.json` entirely (local,
+  // ambient, file-sourced state they're meant to distrust) — but top-tier
+  // servers are an explicit, per-invocation argument from the caller (ACP
+  // `session/new`, `--mcp-config`), not ambient local state, so they survive.
   const mcpServers =
     bareMode || safeMode
-      ? {}
+      ? { ...topTierMcpServers }
       : assembleMcpServers(settings.mcpServers, cwd, topTierMcpServers);
+  // Top-tier servers are never gated (#4615, see the comment above), so
+  // running this under safe mode is a harmless no-op for them today — kept
+  // enabled (only `bareMode`/YOLO skip it) rather than special-cased, so a
+  // future gated top-tier source doesn't silently bypass approval.
   const pendingMcpServers =
-    bareMode || safeMode || approvalMode === ApprovalMode.YOLO
+    bareMode || approvalMode === ApprovalMode.YOLO
       ? undefined
       : getPendingGatedMcpServers(mcpServers, cwd);
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -2016,12 +2016,14 @@ export async function loadCliConfig(
     bareMode || safeMode
       ? { ...topTierMcpServers }
       : assembleMcpServers(settings.mcpServers, cwd, topTierMcpServers);
-  // Top-tier servers are never gated (#4615, see the comment above), so
-  // running this under safe mode is a harmless no-op for them today — kept
-  // enabled (only `bareMode`/YOLO skip it) rather than special-cased, so a
-  // future gated top-tier source doesn't silently bypass approval.
+  // Top-tier servers are never gated (#4615, see the comment above), so this
+  // is a no-op for them either way today. Skipped under safe mode anyway
+  // (Copilot review, PR #7827): getPendingGatedMcpServers reads the local
+  // mcpApprovals.json file, and safe mode shouldn't touch local/ambient
+  // state at all, not even a read with no behavioral effect. Revisit if a
+  // future gated top-tier source needs this to run under safe mode too.
   const pendingMcpServers =
-    bareMode || approvalMode === ApprovalMode.YOLO
+    bareMode || safeMode || approvalMode === ApprovalMode.YOLO
       ? undefined
       : getPendingGatedMcpServers(mcpServers, cwd);
 

--- a/packages/cli/src/config/hot-reload.test.ts
+++ b/packages/cli/src/config/hot-reload.test.ts
@@ -111,6 +111,8 @@ interface FakeConfigState {
   /** Startup `--allowed-mcp-server-names` upper bound (K); default undefined. */
   bootAllowed?: string[];
   approvalMode?: ApprovalMode;
+  bareMode?: boolean;
+  safeMode?: boolean;
 }
 
 function makeFakeConfig(cwd: string, state: FakeConfigState) {
@@ -126,6 +128,8 @@ function makeFakeConfig(cwd: string, state: FakeConfigState) {
   });
   const config = {
     getApprovalMode: () => state.approvalMode ?? ApprovalMode.DEFAULT,
+    getBareMode: () => state.bareMode ?? false,
+    isSafeMode: () => state.safeMode ?? false,
     getTargetDir: () => cwd,
     getSettingsMcpServers: () => state.settingsMcp,
     // Stand-in for the effective (settings + extensions + runtime) map; the
@@ -211,6 +215,41 @@ describe('registerMcpHotReload', () => {
       a: { command: 'a' },
       cliSrv: { command: 'cli' },
     });
+  });
+
+  it('safe mode: a settings.mcpServers change does NOT smuggle local servers into the live session, only top-tier survives', async () => {
+    const fc = makeFakeConfig(cwd, {
+      settingsMcp: {},
+      gating: {},
+      safeMode: true,
+    });
+    const topTier = { cliSrv: { command: 'cli' } };
+    registerMcpHotReload(watcher, settings, fc.config, topTier);
+
+    // A local settings.json edit fires while the safe-mode session is live.
+    merged.mcpServers = { local: { command: 'should-not-leak-in' } };
+    await listener([]);
+
+    expect(fc.reinitializeMcpServers).toHaveBeenCalledWith({
+      cliSrv: { command: 'cli' },
+    });
+  });
+
+  it('bare mode: a settings.mcpServers change does NOT smuggle local servers into the live session', async () => {
+    // Non-empty initial state so the bare-mode-forced `{}` below is a real,
+    // detectable diff (a `{} -> {}` no-op wouldn't exercise the reconcile
+    // path at all).
+    const fc = makeFakeConfig(cwd, {
+      settingsMcp: { stale: { command: 'stale' } },
+      gating: {},
+      bareMode: true,
+    });
+    registerMcpHotReload(watcher, settings, fc.config, undefined);
+
+    merged.mcpServers = { local: { command: 'should-not-leak-in' } };
+    await listener([]);
+
+    expect(fc.reinitializeMcpServers).toHaveBeenCalledWith({});
   });
 
   it('reconciles on an admission-list-only change (mcp.excluded), servers unchanged', async () => {

--- a/packages/cli/src/config/hot-reload.test.ts
+++ b/packages/cli/src/config/hot-reload.test.ts
@@ -252,6 +252,53 @@ describe('registerMcpHotReload', () => {
     expect(fc.reinitializeMcpServers).toHaveBeenCalledWith({});
   });
 
+  it('safe mode: a settings.json mcp.allowed edit does NOT leak in and filter the caller-supplied top-tier server mid-session', async () => {
+    // recomputeMcpGating reads settings.merged.mcp.allowed/excluded
+    // unconditionally, with no bare/safe guard of its own — before the fix,
+    // registerMcpHotReload's own bare/safe guard only covered `next` (the
+    // servers map), not the gating lists computed right after it. A live
+    // settings.json edit narrowing mcp.allowed during an already-running
+    // safe-mode session would flow straight into setAllowedMcpServers and
+    // silently filter the caller's top-tier server out of getMcpServers()
+    // mid-session — the same stranded-server class of bug this PR already
+    // fixes at boot, reached through the gating list's SOURCE instead of the
+    // mcpServers map. Initial gating.allowed is non-empty so the edit below
+    // is a real, detectable change regardless of which branch runs (bug or
+    // fix) — otherwise a same-value no-op would short-circuit before either
+    // branch's result is ever applied.
+    const fc = makeFakeConfig(cwd, {
+      settingsMcp: {},
+      gating: { allowed: ['probe'] },
+      safeMode: true,
+    });
+    const topTier = { probe: { command: 'probe' } };
+    registerMcpHotReload(watcher, settings, fc.config, topTier);
+
+    merged.mcp = { allowed: ['some-other-server'] };
+    await listener([]);
+
+    // No --allowed-mcp-server-names flag at startup (bootAllowed undefined)
+    // ⇒ the fixed path applies `undefined` (allow-all, i.e. only the
+    // never-gated top-tier map matters); the buggy path would instead pass
+    // through the settings-sourced ['some-other-server'], excluding `probe`.
+    expect(fc.setAllowedMcpServers).toHaveBeenCalledWith(undefined);
+  });
+
+  it('bare mode: a settings.json mcp.allowed edit does NOT leak in and filter the caller-supplied top-tier server mid-session', async () => {
+    const fc = makeFakeConfig(cwd, {
+      settingsMcp: {},
+      gating: { allowed: ['probe'] },
+      bareMode: true,
+    });
+    const topTier = { probe: { command: 'probe' } };
+    registerMcpHotReload(watcher, settings, fc.config, topTier);
+
+    merged.mcp = { allowed: ['some-other-server'] };
+    await listener([]);
+
+    expect(fc.setAllowedMcpServers).toHaveBeenCalledWith(undefined);
+  });
+
   it('reconciles on an admission-list-only change (mcp.excluded), servers unchanged', async () => {
     const fc = makeFakeConfig(cwd, {
       settingsMcp: { a: { command: 'a' } },

--- a/packages/cli/src/config/hot-reload.ts
+++ b/packages/cli/src/config/hot-reload.ts
@@ -140,11 +140,19 @@ export function registerMcpHotReload(
     const cwd = config.getTargetDir();
     // Rebuild exactly the way Config boot did — including top-tier
     // (CLI / session-injected) servers layered above settings + `.mcp.json`.
-    const next = assembleMcpServers(
-      settings.merged.mcpServers,
-      cwd,
-      topTierMcpServers,
-    );
+    // Bare/safe mode: mirror loadCliConfig's own guard (config.ts) — a live
+    // settings.json edit must not smuggle local/ambient MCP servers into an
+    // already-running bare/safe-mode session; only the top-tier servers this
+    // session started with (explicit, per-invocation, not ambient state)
+    // survive.
+    const next =
+      config.getBareMode() || config.isSafeMode()
+        ? { ...topTierMcpServers }
+        : assembleMcpServers(
+            settings.merged.mcpServers,
+            cwd,
+            topTierMcpServers,
+          );
     const isYolo = config.getApprovalMode() === ApprovalMode.YOLO;
     const nextGating = recomputeMcpGating(
       settings,

--- a/packages/cli/src/config/hot-reload.ts
+++ b/packages/cli/src/config/hot-reload.ts
@@ -154,13 +154,23 @@ export function registerMcpHotReload(
             topTierMcpServers,
           );
     const isYolo = config.getApprovalMode() === ApprovalMode.YOLO;
-    const nextGating = recomputeMcpGating(
-      settings,
-      next,
-      cwd,
-      config.getCliAllowedMcpServerNames(),
-      isYolo,
-    );
+    // Same bare/safe guard as `next` above, applied to the admission lists:
+    // `recomputeMcpGating` reads settings.merged.mcp.allowed/excluded
+    // unconditionally, with no bare/safe check of its own — a live
+    // settings.json edit during an already-running bare/safe session would
+    // otherwise smuggle a local-state-sourced allow-list back in, silently
+    // filtering the caller's own top-tier server out of `getMcpServers()`
+    // mid-session (the same stranded-server class of bug this PR fixes at
+    // boot, just reached through the gating list's SOURCE instead of the
+    // mcpServers map). Only the CLI `--allowed-mcp-server-names` bound
+    // (explicit, per-invocation, not ambient state) still applies, mirroring
+    // topTierMcpServers' own treatment; `excluded`/`pending` are irrelevant
+    // once nothing but the never-gated top-tier servers can be present.
+    const bootAllowed = config.getCliAllowedMcpServerNames();
+    const nextGating: McpGating =
+      config.getBareMode() || config.isSafeMode()
+        ? { allowed: bootAllowed ? [...bootAllowed] : undefined }
+        : recomputeMcpGating(settings, next, cwd, bootAllowed, isYolo);
 
     const prevServers = config.getSettingsMcpServers();
     const prevGating = config.getMcpGating();

--- a/packages/core/src/config/config.safe-mode.test.ts
+++ b/packages/core/src/config/config.safe-mode.test.ts
@@ -339,6 +339,63 @@ describe('Config safe mode', () => {
     });
   });
 
+  describe('safe mode MCP discovery — a stranded-server regression (found live-testing PR #7827)', () => {
+    // `getMcpServers()` reporting a top-tier server as configured is not
+    // enough on its own — something has to actually CONNECT to it and
+    // register its tools. That's a separate gate in `initialize()`
+    // (`startMcpDiscoveryInBackground` behind `!this.isSafeMode()`), written
+    // when `getMcpServers()` always returned `{}` under safe mode and so
+    // discovery had nothing to do anyway. Left unpatched, a caller-supplied
+    // top-tier server survives `getMcpServers()` but never actually gets
+    // discovered/connected — confirmed live against a real ACP session
+    // before this fix (the agent reported the tool as configured-but-absent).
+    function getMcpManagerMock(config: Config) {
+      return (
+        config.getToolRegistry() as unknown as {
+          __mcpManagerMock: { discoverAllMcpToolsIncremental: Mock };
+        }
+      ).__mcpManagerMock;
+    }
+
+    it('still kicks off background MCP discovery in safe mode when a top-tier server is present', async () => {
+      const config = new Config({
+        ...baseParams,
+        safeMode: true,
+        mcpServers: { local: { command: 'local', args: [] } },
+        topTierMcpServers: { probe: { command: 'probe', args: [] } },
+      });
+      await config.initialize();
+      expect(
+        getMcpManagerMock(config).discoverAllMcpToolsIncremental,
+      ).toHaveBeenCalledWith(config);
+    });
+
+    it('does not kick off background MCP discovery in safe mode when nothing was supplied (no wasted work)', async () => {
+      const config = new Config({
+        ...baseParams,
+        safeMode: true,
+        mcpServers: { local: { command: 'local', args: [] } },
+      });
+      await config.initialize();
+      expect(
+        getMcpManagerMock(config).discoverAllMcpToolsIncremental,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('does not kick off background MCP discovery in safe mode when the only top-tier server is filtered out by allowedMcpServers', async () => {
+      const config = new Config({
+        ...baseParams,
+        safeMode: true,
+        allowedMcpServers: ['nope'],
+        topTierMcpServers: { probe: { command: 'probe', args: [] } },
+      });
+      await config.initialize();
+      expect(
+        getMcpManagerMock(config).discoverAllMcpToolsIncremental,
+      ).not.toHaveBeenCalled();
+    });
+  });
+
   describe('safe mode skips context file loading', () => {
     it('sets empty user memory after refreshHierarchicalMemory', async () => {
       const config = new Config({ ...baseParams, safeMode: true });

--- a/packages/core/src/config/config.safe-mode.test.ts
+++ b/packages/core/src/config/config.safe-mode.test.ts
@@ -292,14 +292,31 @@ describe('Config safe mode', () => {
     });
   });
 
-  describe('safe mode blocks MCP servers', () => {
-    it('should return empty MCP servers in safe mode', () => {
+  describe('safe mode blocks local/ambient MCP servers, preserves caller-supplied top-tier ones', () => {
+    it('should return empty MCP servers in safe mode when nothing was supplied as top-tier', () => {
       const config = new Config({
         ...baseParams,
         safeMode: true,
         mcpServers: { test: { command: 'test', args: [] } },
       });
       expect(config.getMcpServers()).toEqual({});
+    });
+
+    it('should still return top-tier (ACP session/new / --mcp-config-supplied) MCP servers in safe mode', () => {
+      // `mcpServers` here stands in for the LOCAL/ambient map `loadCliConfig`
+      // assembles from settings.json/.mcp.json — dropped under safe mode.
+      // `topTierMcpServers` stands in for the caller's own explicit,
+      // per-invocation request (ACP `session/new`, `--mcp-config`) — an
+      // explicit argument, not ambient local state, so it survives.
+      const config = new Config({
+        ...baseParams,
+        safeMode: true,
+        mcpServers: { local: { command: 'local', args: [] } },
+        topTierMcpServers: { probe: { command: 'probe', args: [] } },
+      });
+      expect(config.getMcpServers()).toEqual({
+        probe: { command: 'probe', args: [] },
+      });
     });
   });
 

--- a/packages/core/src/config/config.safe-mode.test.ts
+++ b/packages/core/src/config/config.safe-mode.test.ts
@@ -394,6 +394,57 @@ describe('Config safe mode', () => {
         getMcpManagerMock(config).discoverAllMcpToolsIncremental,
       ).not.toHaveBeenCalled();
     });
+
+    // The safe-mode half of this gate (`!this.isSafeMode() || getMcpServers()
+    // non-empty`) shipped in the commit above; the bare-mode half
+    // (`!this.getBareMode()`, unconditional) was left unfixed despite
+    // `loadCliConfig` feeding top-tier servers into bare mode's `mcpServers`
+    // param exactly the same way it does safe mode's `topTierMcpServers`
+    // field (`packages/cli/src/config/config.ts`'s `bareMode || safeMode ?
+    // { ...topTierMcpServers } : assembleMcpServers(...)`) — found
+    // live-testing `qwen --bare --mcp-config`, same stranded-server symptom.
+    // Unlike the safe-mode tests above, bare mode has no redundant
+    // `getMcpServers()`-level short-circuit of its own — bare mode's
+    // "local sources dropped" guarantee lives entirely in that CLI-layer
+    // assembly, so these tests set `mcpServers` directly (what `loadCliConfig`
+    // would have already produced by the time `Config` is constructed), not
+    // `topTierMcpServers` (only consulted by `getMcpServers()`'s safe-mode
+    // branch).
+    it('still kicks off background MCP discovery in bare mode when a top-tier server is present', async () => {
+      const config = new Config({
+        ...baseParams,
+        bareMode: true,
+        mcpServers: { probe: { command: 'probe', args: [] } },
+      });
+      await config.initialize();
+      expect(
+        getMcpManagerMock(config).discoverAllMcpToolsIncremental,
+      ).toHaveBeenCalledWith(config);
+    });
+
+    it('does not kick off background MCP discovery in bare mode when nothing was supplied (no wasted work)', async () => {
+      const config = new Config({
+        ...baseParams,
+        bareMode: true,
+      });
+      await config.initialize();
+      expect(
+        getMcpManagerMock(config).discoverAllMcpToolsIncremental,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('does not kick off background MCP discovery in bare mode when the only supplied server is filtered out by allowedMcpServers', async () => {
+      const config = new Config({
+        ...baseParams,
+        bareMode: true,
+        allowedMcpServers: ['nope'],
+        mcpServers: { probe: { command: 'probe', args: [] } },
+      });
+      await config.initialize();
+      expect(
+        getMcpManagerMock(config).discoverAllMcpToolsIncremental,
+      ).not.toHaveBeenCalled();
+    });
   });
 
   describe('safe mode skips context file loading', () => {

--- a/packages/core/src/config/config.safe-mode.test.ts
+++ b/packages/core/src/config/config.safe-mode.test.ts
@@ -318,6 +318,25 @@ describe('Config safe mode', () => {
         probe: { command: 'probe', args: [] },
       });
     });
+
+    it('still applies allowedMcpServers to top-tier servers in safe mode (Copilot review, PR #7827)', () => {
+      // Safe mode is not an exemption from a session's own
+      // --allowed-mcp-server-names upper bound — a caller-supplied server
+      // outside that allow-list must still be filtered out, exactly like the
+      // non-safe-mode path a few lines below does.
+      const config = new Config({
+        ...baseParams,
+        safeMode: true,
+        allowedMcpServers: ['probe'],
+        topTierMcpServers: {
+          probe: { command: 'probe', args: [] },
+          notAllowed: { command: 'not-allowed', args: [] },
+        },
+      });
+      expect(config.getMcpServers()).toEqual({
+        probe: { command: 'probe', args: [] },
+      });
+    });
   });
 
   describe('safe mode skips context file loading', () => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -2802,10 +2802,22 @@ export class Config {
     // Also gated on `!options?.skipMcpDiscovery` — the ACP
     // bootstrap path passes `skipMcpDiscovery: true` so the bootstrap
     // config doesn't run discovery under its pool-less manager.
+    //
+    // Safe mode still skips discovery when there's nothing to discover (the
+    // common case: no top-tier servers supplied) — this block predates the
+    // safe-mode `getMcpServers()` fix (PR #7827) and was written when
+    // `getMcpServers()` always returned `{}` under safe mode, making this a
+    // harmless no-op regardless. Now that caller-supplied top-tier servers
+    // survive safe mode, unconditionally skipping discovery here would
+    // silently strand them: `getMcpServers()` reports them as configured,
+    // but nothing ever connects to them or registers their tools. Checking
+    // `getMcpServers()` (not `topTierMcpServers` directly) also respects the
+    // `allowedMcpServers` filter already applied there.
     if (
       skipInlineMcpDiscovery &&
       !this.getBareMode() &&
-      !this.isSafeMode() &&
+      (!this.isSafeMode() ||
+        Object.keys(this.getMcpServers() ?? {}).length > 0) &&
       !options?.skipMcpDiscovery
     ) {
       this.startMcpDiscoveryInBackground();

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -2803,19 +2803,23 @@ export class Config {
     // bootstrap path passes `skipMcpDiscovery: true` so the bootstrap
     // config doesn't run discovery under its pool-less manager.
     //
-    // Safe mode still skips discovery when there's nothing to discover (the
-    // common case: no top-tier servers supplied) — this block predates the
-    // safe-mode `getMcpServers()` fix (PR #7827) and was written when
-    // `getMcpServers()` always returned `{}` under safe mode, making this a
-    // harmless no-op regardless. Now that caller-supplied top-tier servers
-    // survive safe mode, unconditionally skipping discovery here would
-    // silently strand them: `getMcpServers()` reports them as configured,
-    // but nothing ever connects to them or registers their tools. Checking
-    // `getMcpServers()` (not `topTierMcpServers` directly) also respects the
-    // `allowedMcpServers` filter already applied there.
+    // Safe/bare mode still skip discovery when there's nothing to discover
+    // (the common case: no top-tier servers supplied) — this block predates
+    // the safe-mode `getMcpServers()` fix (PR #7827) and was written when
+    // `getMcpServers()` always returned `{}` under both modes, making the
+    // unconditional skip a harmless no-op regardless. Now that
+    // caller-supplied top-tier servers survive safe mode AND bare mode,
+    // unconditionally skipping discovery in either would silently strand
+    // them: `getMcpServers()` reports them as configured, but nothing ever
+    // connects to them or registers their tools (a live repro of exactly
+    // this — `qwen --bare --mcp-config` with a top-tier server — surfaced
+    // the bare-mode half of this gate was never updated alongside safe
+    // mode's). Checking `getMcpServers()` (not `topTierMcpServers` directly)
+    // also respects the `allowedMcpServers` filter already applied there.
     if (
       skipInlineMcpDiscovery &&
-      !this.getBareMode() &&
+      (!this.getBareMode() ||
+        Object.keys(this.getMcpServers() ?? {}).length > 0) &&
       (!this.isSafeMode() ||
         Object.keys(this.getMcpServers() ?? {}).length > 0) &&
       !options?.skipMcpDiscovery

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -2816,12 +2816,10 @@ export class Config {
     // the bare-mode half of this gate was never updated alongside safe
     // mode's). Checking `getMcpServers()` (not `topTierMcpServers` directly)
     // also respects the `allowedMcpServers` filter already applied there.
+    const hasMcpServers = Object.keys(this.getMcpServers() ?? {}).length > 0;
     if (
       skipInlineMcpDiscovery &&
-      (!this.getBareMode() ||
-        Object.keys(this.getMcpServers() ?? {}).length > 0) &&
-      (!this.isSafeMode() ||
-        Object.keys(this.getMcpServers() ?? {}).length > 0) &&
+      (!(this.getBareMode() || this.isSafeMode()) || hasMcpServers) &&
       !options?.skipMcpDiscovery
     ) {
       this.startMcpDiscoveryInBackground();

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -4815,8 +4815,12 @@ export class Config {
     // request. `topTierMcpServers` (ACP `session/new`'s `mcpServers` field,
     // `--mcp-config`) is that explicit request, so it survives safe mode;
     // everything `getMergedMcpServers()` would otherwise fold in does not.
-    if (this.isSafeMode()) return { ...this.topTierMcpServers };
-    let mcpServers = this.getMergedMcpServers();
+    // Still runs through the `allowedMcpServers` filter below like any other
+    // source — safe mode isn't an exemption from a session's own
+    // `--allowed-mcp-server-names` upper bound (Copilot review, PR #7827).
+    let mcpServers = this.isSafeMode()
+      ? { ...this.topTierMcpServers }
+      : this.getMergedMcpServers();
 
     if (this.allowedMcpServers) {
       mcpServers = Object.fromEntries(

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -4810,7 +4810,12 @@ export class Config {
   }
 
   getMcpServers(): Record<string, MCPServerConfig> | undefined {
-    if (this.isSafeMode()) return {};
+    // Safe mode distrusts LOCAL/ambient state (settings.json, extensions,
+    // project `.mcp.json`) — not the caller's own explicit, per-invocation
+    // request. `topTierMcpServers` (ACP `session/new`'s `mcpServers` field,
+    // `--mcp-config`) is that explicit request, so it survives safe mode;
+    // everything `getMergedMcpServers()` would otherwise fold in does not.
+    if (this.isSafeMode()) return { ...this.topTierMcpServers };
     let mcpServers = this.getMergedMcpServers();
 
     if (this.allowedMcpServers) {


### PR DESCRIPTION
## What this PR does

Preserves caller-supplied "top-tier" MCP servers (ACP `session/new`'s `mcpServers` field, or `--mcp-config`) when `--safe-mode`/`--bare` is on, instead of unconditionally dropping every MCP server. Local/ambient sources (`settings.json`, extensions, project `.mcp.json`) are still dropped under safe mode -- only the explicit, per-invocation servers the caller supplied for this session now survive.

## Why it's needed

Safe mode is meant to distrust LOCAL/ambient state so a user can isolate which local customization is misbehaving (see the troubleshooting doc's own framing). It was also unconditionally dropping `topTierMcpServers`, which are an explicit, per-invocation argument from the caller -- not ambient local state. An ACP client granting a session-specific MCP server via the protocol's own client-controlled channel (`session/new.mcpServers`, stdio transport -- "All Agents MUST support this transport") had no way to make that server actually usable while safe mode was on.

The issue's original scope pointed only at `packages/cli/src/config/config.ts`'s `loadCliConfig`. Fixing only that would NOT have fixed the live bug -- the actual authoritative gate is `packages/core/src/config/config.ts`'s `Config.getMcpServers()`, the accessor `mcp-client-manager.ts` reads everywhere for MCP discovery/connection, which has its own independent `if (this.isSafeMode()) return {};` short-circuit, decoupled from whatever `loadCliConfig` computed. Fixed both, so the raw field and the accessor agree.

## Reviewer Test Plan

### How to verify

Check 1: `new Config({ safeMode: true, mcpServers: { local: {...} }, topTierMcpServers: { probe: {...} } }).getMcpServers()` -- before this PR returns `{}`; after, returns `{ probe: {...} }` only.

Check 2: start an ACP session (`qwen --acp --safe-mode`), send `session/new` with a `mcpServers` entry pointing at any trivial stdio MCP server, then ask the agent to call its tool -- before this PR the tool is never discovered; after, it is.

Check 3: `npm run dev -- --safe-mode` with a `settings.json` `mcpServers` entry configured -- the server never connects (still correctly dropped, unaffected by this PR).

### Evidence (Before & After)

Before (documented in #7819's repro, against the installed 0.21.0 build): an ACP `session/new` with `mcpServers: [{name:"probe", command, args, env}]` under `qwen --acp --safe-mode` -- the agent reports the tool as not present, never wired into `Config.mcpServers`.

After (this branch, per the new `config.safe-mode.test.ts` case): `getMcpServers()` returns exactly the caller-supplied server, local ones dropped. See the new tests in `config.safe-mode.test.ts` / `config.test.ts` / `hot-reload.test.ts` for the full set of before/after assertions -- no UI to screenshot, this is ACP/backend config-merging behavior, not an interactive CLI surface.

### Tested on

| OS | Status |
|---|---|
| 🍏 macOS | Not tested (no macOS machine available) |
| 🪠 Windows | Green: `vitest run` (packages/core: 453 tests, packages/cli: 331 tests), `tsc --noEmit`, `eslint` all clean on both packages |
| 🐧 Linux | Not tested locally -- should be covered by CI |

### Environment (optional)

qwen-code 0.21.0 installed build (for the original live repro in #7819) + this repo's `main` at time of writing. Node v26.3.0, Windows 11 Pro (10.0.26200), x64.

## Risk & Scope

**Main risk or tradeoff:** widens what's reachable under safe mode -- a caller-supplied MCP server (not local config) is now connectable during a safe-mode session. This is the intended fix, not a regression: safe mode's job is to distrust local/ambient state, and this was already the caller's own explicit request via a client-controlled protocol channel.

**Not validated / out of scope:** did not run the full `npm run preflight` (clean reinstall + full monorepo build/test) given the fix's narrow, well-covered scope -- happy to run it if a maintainer wants that before merge. Did not test on macOS/Linux locally.

**Breaking changes / migration notes:** none for typical usage. A caller relying on safe mode to also silence its own explicitly-supplied `mcpServers`/`--mcp-config` servers (unlikely -- that's the caller's own input) would see a behavior change.

## Linked Issues

Fixes #7819 
<details>
<summary>中文说明</summary>

在 `--safe-mode`/`--bare` 模式下，保留调用方显式提供的 "top-tier" MCP 服务器（ACP `session/new` 的 `mcpServers` 字段，或 `--mcp-config`），不再无条件清空所有 MCP 服务器。本地/环境来源（`settings.json`、扩展、项目 `.mcp.json`）在安全模式下仍然会被丢弃 -- 只有调用方为本次会话显式提供的服务器才会保留。

真正的权威判断点在 `packages/core/src/config/config.ts` 的 `Config.getMcpServers()`（`mcp-client-manager.ts` 在所有发现/连接路径中读取的访问器），而不仅仅是 `loadCliConfig` 里的组装逻辑 -- 两处均已修复，保持字段与访问器一致。

修复 #7819。
</details>