### PR TITLE
fix(core): wait for output stream flush before settling background shells

### DIFF
--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -184,6 +184,15 @@ describe('ShellTool', () => {
       write: vi.fn(),
       end: vi.fn(),
       on: vi.fn(),
+      // Both settle paths (promote + executeBackground) wait for the
+      // stream flush via `once('finish', ...)` before transitioning
+      // the registry. Default impl: immediately invoke the handler so
+      // tests don't hang waiting for an event the mocked stream never
+      // emits naturally. Ordering-sensitive tests install their own
+      // deferred stream via `mockReturnValueOnce`.
+      once: vi.fn((event: string, handler: () => void) => {
+        if (event === 'finish') handler();
+      }),
     } as unknown as fs.WriteStream);
 
     vi.mocked(os.platform).mockReturnValue('linux');
@@ -1254,6 +1263,134 @@ describe('ShellTool', () => {
         expect.any(Number),
       );
       expect(registry.complete).not.toHaveBeenCalled();
+    });
+
+    describe('background settle waits for the output stream flush', () => {
+      // `stream.end()` is asynchronous — pending writes can still be in
+      // the libuv queue when it returns. Transitioning the registry
+      // before the stream's 'finish' event lets consumers observe a
+      // terminal status (and the status sidecar report it) while the
+      // trailing output bytes are not yet on disk. These tests pin the
+      // ordering with a stream whose events fire only when the test
+      // says so.
+      const makeDeferredStream = () => {
+        const handlers = new Map<string, Array<() => void>>();
+        return {
+          write: vi.fn(),
+          end: vi.fn(),
+          on: vi.fn(),
+          once: vi.fn((event: string, handler: () => void) => {
+            const list = handlers.get(event) ?? [];
+            list.push(handler);
+            handlers.set(event, list);
+          }),
+          emit: (event: string) => {
+            const list = handlers.get(event) ?? [];
+            handlers.set(event, []);
+            for (const h of list) h();
+          },
+        };
+      };
+
+      const startBackgroundAndExit = async (deferred: {
+        end: Mock;
+      }): Promise<{ shellId: string }> => {
+        vi.mocked(fs.createWriteStream).mockReturnValueOnce(
+          deferred as unknown as fs.WriteStream,
+        );
+        const registry = mockConfig.getBackgroundShellRegistry();
+        const invocation = shellTool.build({
+          command: 'true',
+          is_background: true,
+        });
+        await invocation.execute(mockAbortSignal);
+        const entry = (registry.register as Mock).mock.calls[0][0];
+
+        resolveExecutionPromise({
+          rawOutput: Buffer.from(''),
+          output: '',
+          exitCode: 0,
+          signal: null,
+          error: null,
+          aborted: false,
+          pid: 12345,
+          executionMethod: 'child_process',
+        });
+        // Flush the .then() microtask attached to resultPromise.
+        await new Promise((r) => setImmediate(r));
+        // The stream has been asked to flush…
+        expect(deferred.end).toHaveBeenCalledTimes(1);
+        return { shellId: entry.shellId };
+      };
+
+      it('holds the registry transition until the stream finish event', async () => {
+        const registry = mockConfig.getBackgroundShellRegistry();
+        const deferred = makeDeferredStream();
+        const { shellId } = await startBackgroundAndExit(deferred);
+
+        // …but the registry must NOT transition before the flush
+        // completes — this is the truncated-log window.
+        expect(registry.complete).not.toHaveBeenCalled();
+
+        deferred.emit('finish');
+        expect(registry.complete).toHaveBeenCalledTimes(1);
+        expect(registry.complete).toHaveBeenCalledWith(
+          shellId,
+          0,
+          expect.any(Number),
+        );
+
+        // Exactly once: a late duplicate event must not re-transition.
+        deferred.emit('finish');
+        deferred.emit('error');
+        expect(registry.complete).toHaveBeenCalledTimes(1);
+      });
+
+      it('still transitions when the stream errors instead of finishing', async () => {
+        // A dead stream (EIO / ENOSPC racing `.end()`) must not strand
+        // the entry as running — the flush is best-effort, the
+        // transition is mandatory.
+        const registry = mockConfig.getBackgroundShellRegistry();
+        const deferred = makeDeferredStream();
+        const { shellId } = await startBackgroundAndExit(deferred);
+        expect(registry.complete).not.toHaveBeenCalled();
+
+        deferred.emit('error');
+        expect(registry.complete).toHaveBeenCalledTimes(1);
+        expect(registry.complete).toHaveBeenCalledWith(
+          shellId,
+          0,
+          expect.any(Number),
+        );
+      });
+
+      it('transitions after the flush timeout when the stream never settles', async () => {
+        // Wedged fd whose 'finish'/'error' never fire (e.g. destroyed
+        // by an earlier write error): the 10s timer is the backstop.
+        // Fake only the timer functions so the setImmediate-based
+        // microtask flush in the helper stays real.
+        vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+        try {
+          const registry = mockConfig.getBackgroundShellRegistry();
+          const deferred = makeDeferredStream();
+          const { shellId } = await startBackgroundAndExit(deferred);
+          expect(registry.complete).not.toHaveBeenCalled();
+
+          await vi.advanceTimersByTimeAsync(10_000);
+          expect(registry.complete).toHaveBeenCalledTimes(1);
+          expect(registry.complete).toHaveBeenCalledWith(
+            shellId,
+            0,
+            expect.any(Number),
+          );
+
+          // The finish landing after the timeout must not double-fire.
+          deferred.emit('finish');
+          expect(registry.complete).toHaveBeenCalledTimes(1);
+        } finally {
+          vi.useRealTimers();
+        }
+      });
     });
 
     it('rejects a bare trailing & in managed background mode', async () => {

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -1007,8 +1007,61 @@ const DEFAULT_FOREGROUND_TIMEOUT_MS = 120000;
  */
 const PROMOTE_CANCEL_SIGKILL_TIMEOUT_MS = 200;
 
-/** Maximum wait for the output stream flush before transitioning the registry. */
-const PROMOTE_FLUSH_TIMEOUT_MS = 10_000;
+/**
+ * Maximum wait for the output stream flush before transitioning the
+ * registry. Shared by the promote settle path and `executeBackground`'s
+ * settle path — see `endStreamThenSettle`.
+ */
+const OUTPUT_FLUSH_TIMEOUT_MS = 10_000;
+
+/**
+ * End `stream` and run `settle` exactly once after its queued writes
+ * have been flushed to the underlying fd (`'finish'`). `stream.end()`
+ * is asynchronous — pending writes can still be in the libuv queue
+ * when it returns, so transitioning the registry before the flush
+ * lets `/tasks` consumers (and the status sidecar) observe a terminal
+ * status and read the output file BEFORE the trailing bytes are on
+ * disk, producing truncated logs. `'error'` covers a late EIO /
+ * ENOSPC racing `.end()` itself, and the timer covers a stream whose
+ * events never fire at all (e.g. one already destroyed by an earlier
+ * write error) — whichever lands first, `settle` runs exactly once.
+ */
+function endStreamThenSettle(
+  stream: fs.WriteStream,
+  origin: 'promote' | 'background',
+  shellId: string,
+  settle: () => void,
+): void {
+  let settled = false;
+  const runOnce = () => {
+    if (settled) return;
+    settled = true;
+    settle();
+  };
+  try {
+    const flushTimer = setTimeout(() => {
+      debugLogger.warn(
+        `${origin}: output stream flush timed out for ${shellId} after ${OUTPUT_FLUSH_TIMEOUT_MS}ms — transitioning registry without flush confirmation`,
+      );
+      runOnce();
+    }, OUTPUT_FLUSH_TIMEOUT_MS);
+    flushTimer.unref();
+    stream.once('finish', () => {
+      clearTimeout(flushTimer);
+      runOnce();
+    });
+    stream.once('error', () => {
+      clearTimeout(flushTimer);
+      runOnce();
+    });
+    stream.end();
+  } catch (closeErr) {
+    debugLogger.warn(
+      `${origin}: closing output stream on settle threw: ${getErrorMessage(closeErr)}`,
+    );
+    runOnce();
+  }
+}
 
 /**
  * PR-2.5 slots shared between the foreground `execute()` postPromote
@@ -3422,39 +3475,9 @@ export class ShellToolInvocation extends BaseToolInvocation<
         transitionRegistry(info);
         return;
       }
-      try {
-        // `finish` fires after all queued writes have been flushed to
-        // the underlying fd. `error` covers a late EIO / ENOSPC that
-        // doesn't reach the existing `'error'` listener — race with
-        // `.end()` itself. Either way, run the transition once.
-        let transitioned = false;
-        const finalize = () => {
-          if (transitioned) return;
-          transitioned = true;
-          transitionRegistry(info);
-        };
-        const flushTimer = setTimeout(() => {
-          debugLogger.warn(
-            `promote: output stream flush timed out for ${shellId} after ${PROMOTE_FLUSH_TIMEOUT_MS}ms — transitioning registry without flush confirmation`,
-          );
-          finalize();
-        }, PROMOTE_FLUSH_TIMEOUT_MS);
-        flushTimer.unref();
-        stream.once('finish', () => {
-          clearTimeout(flushTimer);
-          finalize();
-        });
-        stream.once('error', () => {
-          clearTimeout(flushTimer);
-          finalize();
-        });
-        stream.end();
-      } catch (closeErr) {
-        debugLogger.warn(
-          `promote: closing output stream on settle threw: ${getErrorMessage(closeErr)}`,
-        );
-        transitionRegistry(info);
-      }
+      endStreamThenSettle(stream, 'promote', shellId, () =>
+        transitionRegistry(info),
+      );
     };
     // Drain a settle that landed BEFORE the wire installed (fast
     // commands can exit between `result.promoted` and this line).
@@ -3667,36 +3690,46 @@ export class ShellToolInvocation extends BaseToolInvocation<
 
     // Settle in the background — do NOT await here, the agent should be
     // unblocked immediately.
+    //
+    // Same flush-ordering hazard as the promote settle path: transition
+    // the registry only after the output stream has flushed, so the
+    // status sidecar can't report a terminal state while the trailing
+    // output bytes are still in the libuv queue. The exit timestamp is
+    // captured BEFORE the flush wait — endTime records when the child
+    // exited, not when its bytes reached disk.
     void resultPromise.then(
       (result) => {
-        outputStream.end();
         const endTime = Date.now();
-        if (entryAc.signal.aborted) {
-          if (registry.get(shellId)?.status === 'running') {
-            registry.cancel(shellId, endTime);
+        endStreamThenSettle(outputStream, 'background', shellId, () => {
+          if (entryAc.signal.aborted) {
+            if (registry.get(shellId)?.status === 'running') {
+              registry.cancel(shellId, endTime);
+            }
+          } else if (
+            result.error ||
+            (result.exitCode !== null && result.exitCode !== 0) ||
+            result.signal !== null
+          ) {
+            // Non-zero exit / killed by signal / spawn error all count as failed.
+            // Treating them as `completed` would let `/tasks` (and any future
+            // model-facing notification) misreport a failed `npm test` or
+            // `false` command as a success.
+            const reason = result.error
+              ? result.error.message
+              : result.signal !== null
+                ? `terminated by signal ${result.signal}`
+                : `exited with code ${result.exitCode}`;
+            registry.fail(shellId, reason, endTime);
+          } else {
+            registry.complete(shellId, result.exitCode ?? 0, endTime);
           }
-        } else if (
-          result.error ||
-          (result.exitCode !== null && result.exitCode !== 0) ||
-          result.signal !== null
-        ) {
-          // Non-zero exit / killed by signal / spawn error all count as failed.
-          // Treating them as `completed` would let `/tasks` (and any future
-          // model-facing notification) misreport a failed `npm test` or
-          // `false` command as a success.
-          const reason = result.error
-            ? result.error.message
-            : result.signal !== null
-              ? `terminated by signal ${result.signal}`
-              : `exited with code ${result.exitCode}`;
-          registry.fail(shellId, reason, endTime);
-        } else {
-          registry.complete(shellId, result.exitCode ?? 0, endTime);
-        }
+        });
       },
       (err) => {
-        outputStream.end();
-        registry.fail(shellId, getErrorMessage(err), Date.now());
+        const endTime = Date.now();
+        endStreamThenSettle(outputStream, 'background', shellId, () =>
+          registry.fail(shellId, getErrorMessage(err), endTime),
+        );
       },
     );
 


### PR DESCRIPTION
## Summary

Follow-up ① from the verification report on #7669: `executeBackground`'s settle handler now waits for the output stream to flush before transitioning the registry, reusing the same finish-wait the promote path already had.

## Problem

`executeBackground`'s settle handler called `outputStream.end()` and then transitioned the registry (`complete` / `fail` / `cancel`) immediately. `stream.end()` is asynchronous — pending writes can still be sitting in the libuv queue when it returns — so `/tasks` consumers and the status sidecar could observe a terminal status and read the output file **before the trailing bytes were on disk**, producing truncated logs for the exact reads a terminal status invites.

The promote settle path already handled this correctly (added in #7669): wait for the stream's `'finish'` event, with `'error'` and a 10s timeout as fallbacks.

## Fix

- Extracted the promote path's flush-wait into a shared `endStreamThenSettle(stream, origin, shellId, settle)` helper so the two settle paths cannot drift (same rationale as the `statusFileGuidance` extraction in #7669).
- `executeBackground`'s settle handler (both the resolve and reject arms) now runs its registry transition inside that helper. The exit timestamp is still captured before the flush wait — `endTime` records when the child exited, not when its bytes reached disk.
- Renamed `PROMOTE_FLUSH_TIMEOUT_MS` → `OUTPUT_FLUSH_TIMEOUT_MS` (now shared). Value unchanged (10s), timer is `unref()`'d.
- Promote-path behavior is unchanged — it's the same logic, relocated.

## Tests

`stream.end()` usually flushes fast enough that the race doesn't reproduce under natural timing (0/8 in the report's stress runs), so timing-based integration tests can't discriminate. Coverage is instead deterministic deferred-stream unit tests (same pattern as the promote flush tests):

- holds the registry transition until the stream `'finish'` event fires — asserts `complete` is **not** called pre-finish (the discriminating regression assertion), then called exactly once after, and duplicate events don't double-fire;
- still transitions when the stream emits `'error'` instead of finishing;
- transitions after the 10s timeout (fake timers) when the stream never settles, and a late `'finish'` doesn't double-fire.

The default test stream mock now fires `'finish'` immediately so the existing settle tests keep their original timing.

```
vitest run src/tools/shell.test.ts src/tools/shell.backgroundStatus.test.ts src/services/backgroundShellRegistry.test.ts
  → 3 files, 342 tests, all passing
tsc --noEmit, eslint, prettier: clean
```

## Scope notes (vs. the report's follow-up list)

- ② (`0o600` on the forceMode/noFollow write path) — already landed on main (`a4642de`), not touched here.
- ④ (fixed tmpdir path in a registry test) — already fixed on main via `makeTempDir()`, not touched here.
- ③ (sidecar pruning) — intentionally deferred per the report's own recommendation, since the sidecar design may change with future background-shells cleanup work.
