### PR TITLE
fix(core): fast-fail permanent quota-exhaustion 429s instead of silent retry

### DIFF
--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -7952,6 +7952,47 @@ describe('GeminiChat', async () => {
       }
     });
 
+    it('fast-fails a mid-stream quota-exhaustion error instead of scheduling a rate-limit retry', async () => {
+      // A permanent quota-exhaustion 429 can arrive mid-stream as a
+      // StreamContentError while reading, bypassing the retryWithBackoff
+      // fast-fail that only wraps stream establishment. The stream-side
+      // catch must fast-fail it before the rate-limit branch; otherwise
+      // isRateLimitError (code 429) schedules a 1-5 minute delay on an
+      // error that cannot succeed until the reset time.
+      vi.useFakeTimers();
+
+      try {
+        const quotaError = new StreamContentError(
+          '{"error":{"code":"429","message":"Your token-plan 1-week quota has been exhausted. The quota will reset at 07-27 09:25:00 UTC."}}',
+        );
+        vi.mocked(
+          mockContentGenerator.generateContentStream,
+        ).mockResolvedValueOnce(
+          (async function* () {
+            throw quotaError;
+
+            yield {} as GenerateContentResponse;
+          })(),
+        );
+
+        const stream = await chat.sendMessageStream(
+          'test-model',
+          { message: 'test' },
+          'prompt-quota-fastfail',
+        );
+        const iterator = stream[Symbol.asyncIterator]();
+
+        // Fast-fail: the first pull rejects with the friendly message. No
+        // RETRY event is yielded and no rate-limit delay is scheduled.
+        await expect(iterator.next()).rejects.toThrow(/Quota exhausted/);
+        expect(
+          mockContentGenerator.generateContentStream,
+        ).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('should use Retry-After delay for streamed rate-limit errors', async () => {
       vi.useFakeTimers();
 

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -24,6 +24,10 @@ import {
   isUnattendedMode,
   type HeartbeatInfo,
 } from '../utils/retry.js';
+import {
+  isQuotaExhaustedError,
+  formatQuotaExhaustedMessage,
+} from '../utils/quotaErrorDetection.js';
 import { getErrorStatus, isAbortError } from '../utils/errors.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { parseAndFormatApiError } from '../utils/errorParsing.js';
@@ -2503,6 +2507,26 @@ export class GeminiChat {
               authType: cgConfig?.authType,
               extraRetryErrorCodes,
             });
+
+            // Permanent quota exhaustion (e.g. Bailian token-plan "1-week
+            // quota has been exhausted, will reset at ...") can arrive
+            // mid-stream as a StreamContentError, bypassing retryWithBackoff
+            // (which only wraps stream establishment). Fast-fail before the
+            // rate-limit branch: its 429 code would otherwise schedule a 1-5
+            // minute delay on an error that cannot succeed until the reset
+            // time. Throws a plain Error (no .status) and skips model
+            // fallback, matching the retryWithBackoff fast-fail.
+            if (isQuotaExhaustedError(error)) {
+              debugLogger.warn('Quota exhausted mid-stream, fast-failing', {
+                retryPath: 'stream',
+                retryDecision: 'fail-fast',
+                errorKind: classification.kind,
+                classificationReason: classification.reason,
+              });
+              throw new Error(formatQuotaExhaustedMessage(error), {
+                cause: error,
+              });
+            }
 
             const isRateLimit = isRateLimitError(error, extraRetryErrorCodes);
             if (isRateLimit) {

--- a/packages/core/src/utils/errorParsing.test.ts
+++ b/packages/core/src/utils/errorParsing.test.ts
@@ -153,6 +153,24 @@ describe('parseAndFormatApiError', () => {
     expect(parseAndFormatApiError(error)).toBe(message);
   });
 
+  it.each([
+    'Quota exhausted: Your token-plan 1-week quota has been exhausted. The quota will reset at 07-27 09:25:00 UTC.\n\nPlease retry after the reset time, or switch to another API key / auth method.',
+  ])(
+    'should surface a friendly quota-exhaustion message verbatim (string): %s',
+    (message) => {
+      // Must NOT be re-wrapped in "[API Error: …]" and must NOT pick up the
+      // misleading "please wait and try again later" transient-throttle suffix.
+      expect(parseAndFormatApiError(message)).toBe(message);
+    },
+  );
+
+  it('should surface a friendly quota-exhaustion StructuredError.message verbatim', () => {
+    const message =
+      'Quota exhausted: Your token-plan 1-week quota has been exhausted. The quota will reset at 07-27 09:25:00 UTC.\n\nPlease retry after the reset time, or switch to another API key / auth method.';
+    const error: StructuredError = { message, status: 429 };
+    expect(parseAndFormatApiError(error, AuthType.USE_OPENAI)).toBe(message);
+  });
+
   // Idempotency — added after a customer report where a 4xx in non-interactive
   // mode produced "[API Error: [API Error: ...]]". The non-interactive runner
   // formats once, prints, then throws an Error whose .message is the formatted

--- a/packages/core/src/utils/errorParsing.test.ts
+++ b/packages/core/src/utils/errorParsing.test.ts
@@ -153,16 +153,13 @@ describe('parseAndFormatApiError', () => {
     expect(parseAndFormatApiError(error)).toBe(message);
   });
 
-  it.each([
-    'Quota exhausted: Your token-plan 1-week quota has been exhausted. The quota will reset at 07-27 09:25:00 UTC.\n\nPlease retry after the reset time, or switch to another API key / auth method.',
-  ])(
-    'should surface a friendly quota-exhaustion message verbatim (string): %s',
-    (message) => {
-      // Must NOT be re-wrapped in "[API Error: …]" and must NOT pick up the
-      // misleading "please wait and try again later" transient-throttle suffix.
-      expect(parseAndFormatApiError(message)).toBe(message);
-    },
-  );
+  it('should surface a friendly quota-exhaustion message verbatim (string)', () => {
+    const message =
+      'Quota exhausted: Your token-plan 1-week quota has been exhausted. The quota will reset at 07-27 09:25:00 UTC.\n\nPlease retry after the reset time, or switch to another API key / auth method.';
+    // Must NOT be re-wrapped in "[API Error: …]" and must NOT pick up the
+    // misleading "please wait and try again later" transient-throttle suffix.
+    expect(parseAndFormatApiError(message)).toBe(message);
+  });
 
   it('should surface a friendly quota-exhaustion StructuredError.message verbatim', () => {
     const message =

--- a/packages/core/src/utils/errorParsing.ts
+++ b/packages/core/src/utils/errorParsing.ts
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isApiError, isStructuredError } from './quotaErrorDetection.js';
+import {
+  isApiError,
+  isStructuredError,
+  QUOTA_EXHAUSTED_PREFIX,
+} from './quotaErrorDetection.js';
 import { AuthType } from '../core/contentGenerator.js';
 import { getErrorMessage } from './errors.js';
 
@@ -49,6 +53,13 @@ const API_ERROR_PREFIX = '[API Error: ';
  */
 function isAlreadyFormatted(value: string): boolean {
   const trimmed = value.trimEnd();
+
+  // Friendly quota-exhaustion messages built by formatQuotaExhaustedMessage
+  // are already in final form — surface them verbatim, do not wrap.
+  if (trimmed.startsWith(QUOTA_EXHAUSTED_PREFIX)) {
+    return true;
+  }
+
   if (!trimmed.startsWith(API_ERROR_PREFIX)) {
     return false;
   }

--- a/packages/core/src/utils/errorParsing.ts
+++ b/packages/core/src/utils/errorParsing.ts
@@ -38,13 +38,17 @@ function getRateLimitMessage(authType?: AuthType): string {
 const API_ERROR_PREFIX = '[API Error: ';
 
 /**
- * Returns true when `value` already looks like the output of
- * parseAndFormatApiError.
+ * Returns true when `value` is already in final user-facing form and must not
+ * be re-wrapped by parseAndFormatApiError.
  *
  * Accepts:
  * 1) base format: "[API Error: ...]"
  * 2) 429 format: "[API Error: ...]" followed by one of the known quota
  *    guidance suffixes.
+ * 3) friendly quota-exhaustion messages ("Quota exhausted: ...") built by
+ *    formatQuotaExhaustedMessage — these live here rather than in the
+ *    Qwen-OAuth prefix list because they also arrive via the plain-string
+ *    path (a StreamContentError whose .message is the formatted text).
  *
  * Used as an idempotency guard: when an upstream caller has already passed an
  * Error through parseAndFormatApiError, stuffed the formatted string into

--- a/packages/core/src/utils/quotaErrorDetection.test.ts
+++ b/packages/core/src/utils/quotaErrorDetection.test.ts
@@ -123,6 +123,14 @@ describe('quotaErrorDetection', () => {
       ).toBe(true);
     });
 
+    it('detects a reset-time message without the word "will"', () => {
+      expect(
+        isQuotaExhaustedError(
+          new Error('Your quota is exhausted. Reset at 2026-08-01 00:00 UTC.'),
+        ),
+      ).toBe(true);
+    });
+
     it('detects an ApiError-shaped quota-exhaustion message', () => {
       const error: ApiError = {
         error: {
@@ -148,9 +156,9 @@ describe('quotaErrorDetection', () => {
     });
 
     it('does not match a 429 that only says quota without a reset time', () => {
-      expect(
-        isQuotaExhaustedError(new Error('Your quota is exhausted.')),
-      ).toBe(false);
+      expect(isQuotaExhaustedError(new Error('Your quota is exhausted.'))).toBe(
+        false,
+      );
     });
 
     it('does not match unrelated errors', () => {

--- a/packages/core/src/utils/quotaErrorDetection.test.ts
+++ b/packages/core/src/utils/quotaErrorDetection.test.ts
@@ -123,6 +123,22 @@ describe('quotaErrorDetection', () => {
       ).toBe(true);
     });
 
+    it('detects an ApiError-shaped quota-exhaustion message', () => {
+      const error: ApiError = {
+        error: {
+          code: 429,
+          message:
+            'Your quota has been exhausted. It will reset at 2026-07-28.',
+          status: 'RESOURCE_EXHAUSTED',
+          details: [],
+        },
+      };
+      expect(isQuotaExhaustedError(error)).toBe(true);
+      expect(formatQuotaExhaustedMessage(error)).toContain(
+        'Your quota has been exhausted. It will reset at 2026-07-28.',
+      );
+    });
+
     it('does not match transient throttling without a reset time', () => {
       expect(
         isQuotaExhaustedError(

--- a/packages/core/src/utils/quotaErrorDetection.test.ts
+++ b/packages/core/src/utils/quotaErrorDetection.test.ts
@@ -161,6 +161,27 @@ describe('quotaErrorDetection', () => {
       );
     });
 
+    it('does not match quota + reset time without exhausted/exceeded', () => {
+      // Pins the (exhausted || exceeded) clause: an OpenAI-style TPM body
+      // "Rate limit reached … Your quota will reset at …" must stay false.
+      expect(
+        isQuotaExhaustedError(
+          new Error(
+            'Rate limit reached for gpt-4. Your quota will reset at 12:00:05Z.',
+          ),
+        ),
+      ).toBe(false);
+    });
+
+    it('does not match exhausted + reset time without quota', () => {
+      // Pins the quota clause.
+      expect(
+        isQuotaExhaustedError(
+          new Error('Resources exhausted. Will reset at 2026-08-01.'),
+        ),
+      ).toBe(false);
+    });
+
     it('does not match unrelated errors', () => {
       expect(isQuotaExhaustedError(new Error('Network timeout'))).toBe(false);
       expect(isQuotaExhaustedError(null)).toBe(false);
@@ -187,6 +208,29 @@ describe('quotaErrorDetection', () => {
       const message = formatQuotaExhaustedMessage(42);
       expect(message.startsWith('Quota exhausted: ')).toBe(true);
       expect(message).toContain('quota has been exhausted');
+    });
+
+    it('unwraps a JSON error body to surface the nested message', () => {
+      // openai-compatible providers emit 429 bodies as JSON; the friendly
+      // message must show the human-readable text, not raw JSON.
+      const error = new Error(
+        '{"error":{"code":"429","message":"Your token-plan 1-week quota has been exhausted. The quota will reset at 07-27 09:25:00 UTC.","status":"RESOURCE_EXHAUSTED","details":[]}}',
+      );
+      const message = formatQuotaExhaustedMessage(error);
+      expect(message).toContain(
+        'Your token-plan 1-week quota has been exhausted. The quota will reset at 07-27 09:25:00 UTC.',
+      );
+      expect(message).not.toContain('{"error"');
+    });
+
+    it('is idempotent — does not double-wrap its own output', () => {
+      const first = formatQuotaExhaustedMessage(
+        new Error(
+          'Your quota has been exhausted. It will reset at 2026-07-28.',
+        ),
+      );
+      const second = formatQuotaExhaustedMessage(new Error(first));
+      expect(second).toBe(first);
     });
   });
 

--- a/packages/core/src/utils/quotaErrorDetection.test.ts
+++ b/packages/core/src/utils/quotaErrorDetection.test.ts
@@ -11,6 +11,8 @@ import {
   isGenericQuotaExceededError,
   isApiError,
   isStructuredError,
+  isQuotaExhaustedError,
+  formatQuotaExhaustedMessage,
   type ApiError,
 } from './quotaErrorDetection.js';
 
@@ -99,6 +101,68 @@ describe('quotaErrorDetection', () => {
     it('should not detect non-quota errors', () => {
       const error = new Error('Network error');
       expect(isGenericQuotaExceededError(error)).toBe(false);
+    });
+  });
+
+  describe('isQuotaExhaustedError', () => {
+    it('detects the Bailian token-plan quota-exhaustion error', () => {
+      const error = Object.assign(
+        new Error(
+          '429 Your token-plan 1-week quota has been exhausted. The quota will reset at 07-27 09:25:00 UTC.',
+        ),
+        { status: 429 },
+      );
+      expect(isQuotaExhaustedError(error)).toBe(true);
+    });
+
+    it('detects a plain-string quota-exhaustion message', () => {
+      expect(
+        isQuotaExhaustedError(
+          'Your token-plan quota has been exceeded. It will reset at 2026-07-27.',
+        ),
+      ).toBe(true);
+    });
+
+    it('does not match transient throttling without a reset time', () => {
+      expect(
+        isQuotaExhaustedError(
+          new Error('Rate limit exceeded. Please retry later.'),
+        ),
+      ).toBe(false);
+    });
+
+    it('does not match a 429 that only says quota without a reset time', () => {
+      expect(
+        isQuotaExhaustedError(new Error('Your quota is exhausted.')),
+      ).toBe(false);
+    });
+
+    it('does not match unrelated errors', () => {
+      expect(isQuotaExhaustedError(new Error('Network timeout'))).toBe(false);
+      expect(isQuotaExhaustedError(null)).toBe(false);
+      expect(isQuotaExhaustedError(undefined)).toBe(false);
+    });
+  });
+
+  describe('formatQuotaExhaustedMessage', () => {
+    it('strips the leading HTTP-status prefix and keeps the reset time', () => {
+      const error = Object.assign(
+        new Error(
+          '429 Your token-plan 1-week quota has been exhausted. The quota will reset at 07-27 09:25:00 UTC.',
+        ),
+        { status: 429 },
+      );
+      const message = formatQuotaExhaustedMessage(error);
+      expect(message.startsWith('Quota exhausted: ')).toBe(true);
+      expect(message).not.toContain('429 Your');
+      expect(message).toContain('will reset at 07-27 09:25:00 UTC');
+      expect(message).toContain('switch to another API key');
+    });
+
+    it('falls back when no message can be extracted', () => {
+      const message = formatQuotaExhaustedMessage(42);
+      expect(message.startsWith('Quota exhausted: ')).toBe(true);
+      expect(message).toContain('quota has been exhausted');
     });
   });
 

--- a/packages/core/src/utils/quotaErrorDetection.ts
+++ b/packages/core/src/utils/quotaErrorDetection.ts
@@ -118,3 +118,68 @@ export function isQwenQuotaExceededError(error: unknown): boolean {
     message.toLowerCase().includes('free allocated quota exceeded')
   );
 }
+
+/**
+ * Prefix marking a friendly quota-exhausted message produced by
+ * {@link formatQuotaExhaustedMessage}. `parseAndFormatApiError` recognizes it
+ * so the message is surfaced verbatim instead of being re-wrapped in
+ * "[API Error: …]".
+ */
+export const QUOTA_EXHAUSTED_PREFIX = 'Quota exhausted: ';
+
+/** Best-effort extraction of a human-readable message from common error shapes. */
+function getQuotaMessage(error: unknown): string | null {
+  if (typeof error === 'string') return error;
+  if (isStructuredError(error)) return error.message;
+  if (isApiError(error)) return error.error.message;
+  return null;
+}
+
+/**
+ * Detects permanent quota-exhaustion errors that carry a reset time.
+ *
+ * Unlike transient rate-limiting (TPM/RPM throttling, which lifts within
+ * seconds–minutes), these signal an allocated quota fully spent and only
+ * resetting at a specific future time. Retrying cannot succeed until then —
+ * the caller should fast-fail and surface the reset time instead of hanging
+ * the session through the full retry budget with no output.
+ *
+ * Matches e.g. the Bailian token-plan error surfaced via the OpenAI SDK:
+ *   "429 Your token-plan 1-week quota has been exhausted. The quota will
+ *    reset at 07-27 09:25:00 UTC."
+ *
+ * @param error The error to check (Error, ApiError, or message string).
+ * @returns True when the error names a quota that is exhausted/exceeded AND
+ *   carries a reset time — the combination that signals a permanent condition.
+ */
+export function isQuotaExhaustedError(error: unknown): boolean {
+  const message = getQuotaMessage(error);
+  if (!message) return false;
+  const lower = message.toLowerCase();
+  return (
+    lower.includes('quota') &&
+    (lower.includes('exhausted') || lower.includes('exceeded')) &&
+    (lower.includes('will reset') || lower.includes('reset at'))
+  );
+}
+
+/**
+ * Builds a friendly, self-contained message for a permanent quota-exhaustion
+ * error. Preserves the provider's verbatim wording (which names the quota and
+ * the reset time) and appends an actionable hint.
+ *
+ * The result is prefixed with {@link QUOTA_EXHAUSTED_PREFIX} so
+ * `parseAndFormatApiError` surfaces it verbatim rather than wrapping it.
+ *
+ * @param error The error whose message should be surfaced.
+ * @returns A user-facing message starting with `QUOTA_EXHAUSTED_PREFIX`.
+ */
+export function formatQuotaExhaustedMessage(error: unknown): string {
+  const raw = getQuotaMessage(error) ?? '';
+  // Strip a leading "NNN " HTTP-status prefix the OpenAI SDK prepends
+  // (e.g. "429 Your token-plan …") so the surfaced text does not start with
+  // a bare status code.
+  const stripped =
+    raw.replace(/^\d{3}\s+/, '').trim() || 'quota has been exhausted';
+  return `${QUOTA_EXHAUSTED_PREFIX}${stripped}\n\nPlease retry after the reset time, or switch to another API key / auth method.`;
+}

--- a/packages/core/src/utils/quotaErrorDetection.ts
+++ b/packages/core/src/utils/quotaErrorDetection.ts
@@ -129,10 +129,24 @@ export const QUOTA_EXHAUSTED_PREFIX = 'Quota exhausted: ';
 
 /** Best-effort extraction of a human-readable message from common error shapes. */
 function getQuotaMessage(error: unknown): string | null {
-  if (typeof error === 'string') return error;
-  if (isStructuredError(error)) return error.message;
-  if (isApiError(error)) return error.error.message;
-  return null;
+  let message: string | null = null;
+  if (typeof error === 'string') message = error;
+  else if (isStructuredError(error)) message = error.message;
+  else if (isApiError(error)) message = error.error.message;
+  if (message === null) return null;
+  // Unwrap a JSON error body ('{"error":{"code":"429","message":"..."}}')
+  // so the nested human-readable message is surfaced instead of raw JSON —
+  // the same extraction parseAndFormatApiError performs.
+  const start = message.indexOf('{');
+  if (start !== -1) {
+    try {
+      const parsed = JSON.parse(message.substring(start)) as unknown;
+      if (isApiError(parsed)) return parsed.error.message;
+    } catch {
+      /* not a JSON error body */
+    }
+  }
+  return message;
 }
 
 /**
@@ -176,6 +190,7 @@ export function isQuotaExhaustedError(error: unknown): boolean {
  */
 export function formatQuotaExhaustedMessage(error: unknown): string {
   const raw = getQuotaMessage(error) ?? '';
+  if (raw.startsWith(QUOTA_EXHAUSTED_PREFIX)) return raw;
   // Strip a leading "NNN " HTTP-status prefix the OpenAI SDK prepends
   // (e.g. "429 Your token-plan …") so the surfaced text does not start with
   // a bare status code.

--- a/packages/core/src/utils/retry.test.ts
+++ b/packages/core/src/utils/retry.test.ts
@@ -22,6 +22,7 @@ import {
 } from './retry.js';
 import { retryContext } from './retryContext.js';
 import { getErrorStatus } from './errors.js';
+import { isRateLimitError } from './rateLimit.js';
 import { setSimulate429 } from './testUtils.js';
 import { AuthType } from '../core/contentGenerator.js';
 
@@ -523,56 +524,6 @@ describe('retryWithBackoff', () => {
       expect(fn).toHaveBeenCalledTimes(1);
     });
 
-    it('should throw immediately for a permanent quota-exhaustion error (any auth)', async () => {
-      // Bailian token-plan "1-week quota has been exhausted" surfaces as a 429
-      // from the OpenAI SDK but is permanent — it must fast-fail, not retry.
-      const quotaError = Object.assign(
-        new Error(
-          '429 Your token-plan 1-week quota has been exhausted. The quota will reset at 07-27 09:25:00 UTC.',
-        ),
-        { status: 429 },
-      );
-      const fn = vi.fn().mockRejectedValue(quotaError);
-
-      const promise = retryWithBackoff(fn, {
-        maxAttempts: 5,
-        initialDelayMs: 1000,
-        maxDelayMs: 5000,
-        authType: AuthType.USE_OPENAI,
-      });
-
-      await expect(promise).rejects.toMatchObject({
-        message: expect.stringContaining('Quota exhausted'),
-        status: 429,
-      });
-      // Should be called only once (no retries)
-      expect(fn).toHaveBeenCalledTimes(1);
-    });
-
-    it('should retry a transient 429 that does not carry a reset time', async () => {
-      // A plain TPM/RPM 429 (no "will reset at") stays retryable — the
-      // quota-exhaustion fast-fail must not swallow transient throttling.
-      const transient429 = Object.assign(
-        new Error('Rate limit exceeded. Please retry later.'),
-        { status: 429 },
-      );
-      const fn = vi
-        .fn()
-        .mockRejectedValueOnce(transient429)
-        .mockResolvedValue('success');
-
-      const promise = retryWithBackoff(fn, {
-        maxAttempts: 5,
-        initialDelayMs: 100,
-        maxDelayMs: 1000,
-        authType: AuthType.USE_OPENAI,
-      });
-      await vi.runAllTimersAsync();
-
-      await expect(promise).resolves.toBe('success');
-      expect(fn).toHaveBeenCalledTimes(2);
-    });
-
     it('should retry for Qwen OAuth with throttling message', async () => {
       const throttlingError: HttpError = new Error(
         'requests throttling triggered',
@@ -673,6 +624,87 @@ describe('retryWithBackoff', () => {
 
       // Should be called 3 times (2 failures + 1 success)
       expect(fn).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('permanent quota-exhaustion fast-fail (any auth)', () => {
+    it('should throw immediately for a permanent quota-exhaustion error', async () => {
+      // Bailian token-plan "1-week quota has been exhausted" surfaces as a 429
+      // from the OpenAI SDK but is permanent — it must fast-fail, not retry.
+      const quotaError = Object.assign(
+        new Error(
+          '429 Your token-plan 1-week quota has been exhausted. The quota will reset at 07-27 09:25:00 UTC.',
+        ),
+        { status: 429 },
+      );
+      const fn = vi.fn().mockRejectedValue(quotaError);
+
+      const promise = retryWithBackoff(fn, {
+        maxAttempts: 5,
+        initialDelayMs: 1000,
+        maxDelayMs: 5000,
+        authType: AuthType.USE_OPENAI,
+      });
+
+      await expect(promise).rejects.toMatchObject({
+        message: expect.stringContaining('Quota exhausted'),
+      });
+
+      // Should be called only once (no retries)
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('thrown error must not be a rate-limit error (pins no-status intent)', async () => {
+      // The thrown error deliberately carries no .status so that
+      // isRateLimitError() returns false — preventing the stream-side
+      // rate-limit retry loop in geminiChat.ts from re-driving it.
+      const quotaError = Object.assign(
+        new Error(
+          '429 Your token-plan 1-week quota has been exhausted. The quota will reset at 07-27 09:25:00 UTC.',
+        ),
+        { status: 429 },
+      );
+      const fn = vi.fn().mockRejectedValue(quotaError);
+
+      const promise = retryWithBackoff(fn, {
+        maxAttempts: 5,
+        initialDelayMs: 1000,
+        maxDelayMs: 5000,
+        authType: AuthType.USE_OPENAI,
+      });
+
+      let thrown: unknown;
+      const assertionPromise = promise.catch((e: unknown) => {
+        thrown = e;
+      });
+      await vi.runAllTimersAsync();
+      await assertionPromise;
+
+      expect(isRateLimitError(thrown)).toBe(false);
+    });
+
+    it('should retry a transient 429 that does not carry a reset time', async () => {
+      // A plain TPM/RPM 429 (no "will reset at") stays retryable — the
+      // quota-exhaustion fast-fail must not swallow transient throttling.
+      const transient429 = Object.assign(
+        new Error('Rate limit exceeded. Please retry later.'),
+        { status: 429 },
+      );
+      const fn = vi
+        .fn()
+        .mockRejectedValueOnce(transient429)
+        .mockResolvedValue('success');
+
+      const promise = retryWithBackoff(fn, {
+        maxAttempts: 5,
+        initialDelayMs: 100,
+        maxDelayMs: 1000,
+        authType: AuthType.USE_OPENAI,
+      });
+      await vi.runAllTimersAsync();
+
+      await expect(promise).resolves.toBe('success');
+      expect(fn).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/packages/core/src/utils/retry.test.ts
+++ b/packages/core/src/utils/retry.test.ts
@@ -523,6 +523,53 @@ describe('retryWithBackoff', () => {
       expect(fn).toHaveBeenCalledTimes(1);
     });
 
+    it('should throw immediately for a permanent quota-exhaustion error (any auth)', async () => {
+      // Bailian token-plan "1-week quota has been exhausted" surfaces as a 429
+      // from the OpenAI SDK but is permanent — it must fast-fail, not retry.
+      const quotaError = Object.assign(
+        new Error(
+          '429 Your token-plan 1-week quota has been exhausted. The quota will reset at 07-27 09:25:00 UTC.',
+        ),
+        { status: 429 },
+      );
+      const fn = vi.fn().mockRejectedValue(quotaError);
+
+      const promise = retryWithBackoff(fn, {
+        maxAttempts: 5,
+        initialDelayMs: 1000,
+        maxDelayMs: 5000,
+        authType: AuthType.USE_OPENAI,
+      });
+
+      await expect(promise).rejects.toThrow(/Quota exhausted/);
+      // Should be called only once (no retries)
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should retry a transient 429 that does not carry a reset time', async () => {
+      // A plain TPM/RPM 429 (no "will reset at") stays retryable — the
+      // quota-exhaustion fast-fail must not swallow transient throttling.
+      const transient429 = Object.assign(
+        new Error('Rate limit exceeded. Please retry later.'),
+        { status: 429 },
+      );
+      const fn = vi
+        .fn()
+        .mockRejectedValueOnce(transient429)
+        .mockResolvedValue('success');
+
+      const promise = retryWithBackoff(fn, {
+        maxAttempts: 5,
+        initialDelayMs: 100,
+        maxDelayMs: 1000,
+        authType: AuthType.USE_OPENAI,
+      });
+      await vi.runAllTimersAsync();
+
+      await expect(promise).resolves.toBe('success');
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+
     it('should retry for Qwen OAuth with throttling message', async () => {
       const throttlingError: HttpError = new Error(
         'requests throttling triggered',

--- a/packages/core/src/utils/retry.test.ts
+++ b/packages/core/src/utils/retry.test.ts
@@ -541,7 +541,10 @@ describe('retryWithBackoff', () => {
         authType: AuthType.USE_OPENAI,
       });
 
-      await expect(promise).rejects.toThrow(/Quota exhausted/);
+      await expect(promise).rejects.toMatchObject({
+        message: expect.stringContaining('Quota exhausted'),
+        status: 429,
+      });
       // Should be called only once (no retries)
       expect(fn).toHaveBeenCalledTimes(1);
     });

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -6,7 +6,11 @@
 
 import type { GenerateContentResponse } from '@google/genai';
 import { AuthType } from '../core/contentGenerator.js';
-import { isQwenQuotaExceededError } from './quotaErrorDetection.js';
+import {
+  isQwenQuotaExceededError,
+  isQuotaExhaustedError,
+  formatQuotaExhaustedMessage,
+} from './quotaErrorDetection.js';
 import { createDebugLogger } from './debugLogger.js';
 import { getErrorStatus } from './errors.js';
 import { isRateLimitError } from './rateLimit.js';
@@ -353,6 +357,21 @@ export async function retryWithBackoff<T>(
             `  - ModelStudio:   https://help.aliyun.com/zh/model-studio/coding-plan\n\n` +
             `After setting up your API key, run /auth to configure your provider.`,
         );
+      }
+
+      // Permanent quota exhaustion (e.g. Bailian token-plan "1-week quota has
+      // been exhausted, will reset at …"). Unlike transient 429 throttling,
+      // retrying cannot succeed until the reset time — fast-fail and surface a
+      // friendly message so the session does not hang through the full retry
+      // budget with no output. Applies to any auth type since a reset time is
+      // the universal signal of a permanently exhausted quota.
+      if (isQuotaExhaustedError(error)) {
+        debugLogger.error(
+          'Quota exhausted, fast-failing',
+          retryDiagnostics,
+          error,
+        );
+        throw new Error(formatQuotaExhaustedMessage(error));
       }
 
       // Determine if this error qualifies for persistent retry.

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -371,7 +371,12 @@ export async function retryWithBackoff<T>(
           retryDiagnostics,
           error,
         );
-        throw new Error(formatQuotaExhaustedMessage(error));
+        const quotaError: HttpError = new Error(
+          formatQuotaExhaustedMessage(error),
+        );
+        const status = getErrorStatus(error);
+        if (status !== undefined) quotaError.status = status;
+        throw quotaError;
       }
 
       // Determine if this error qualifies for persistent retry.

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -371,12 +371,15 @@ export async function retryWithBackoff<T>(
           retryDiagnostics,
           error,
         );
-        const quotaError: HttpError = new Error(
-          formatQuotaExhaustedMessage(error),
-        );
-        const status = getErrorStatus(error);
-        if (status !== undefined) quotaError.status = status;
-        throw quotaError;
+        // Intentionally throws a plain Error with no `.status`: a 429 status
+        // would make isRateLimitError() return true and re-trigger the
+        // stream-side rate-limit retry loop in geminiChat.ts (up to 10 retries
+        // at 1-5 min delays), reintroducing the silent hang this fast-fail
+        // eliminates. This also skips model fallback — quota exhaustion is
+        // provider-scoped and temporary, so the user should retry after the
+        // reset time rather than burning fallback provider quota. `cause`
+        // preserves the original error for diagnostics.
+        throw new Error(formatQuotaExhaustedMessage(error), { cause: error });
       }
 
       // Determine if this error qualifies for persistent retry.


### PR DESCRIPTION
## What this PR does

Makes qwen-code recognize a `429` that signals a **permanently exhausted quota** — one whose body carries a reset time — and fast-fail it on the first attempt with a friendly message, instead of retrying it silently through the full budget.

## Why it's needed

Today only `Throttling.AllocationQuota` (DashScope) and the Qwen-OAuth free-tier quota are treated as permanent. Any other provider that returns a `429` saying *"quota has been exhausted ... will reset at ..."* is classified as a transient rate-limit: `retryWithBackoff` retries it (and the stream-side loop on top), the HTTP-path retry only emits telemetry (no TUI countdown), and since the condition is permanent, every retry just re-hits the same `429`. The session appears to hang with **no output** — no error toast, no retry hint, no message — for the duration of the retry budget.

A reset time in the body is the clean discriminator between a permanently exhausted quota and transient TPM/RPM throttling; the latter never carries one.

## Reviewer Test Plan

### How to verify

Unit tests cover both directions:

- `packages/core/src/utils/quotaErrorDetection.test.ts` — `isQuotaExhaustedError` matches a quota-exhausted body with a reset time, and does **not** match transient throttling or a bare `429`.
- `packages/core/src/utils/retry.test.ts` — a permanent quota-exhaustion `429` fast-fails (`fn` called once, throws `/Quota exhausted/`), while a transient `429` without a reset time still retries to success.
- `packages/core/src/utils/errorParsing.test.ts` — the friendly message is surfaced verbatim, not wrapped in `[API Error: ...]`.

```
cd packages/core && npx vitest run src/utils/quotaErrorDetection.test.ts src/utils/retry.test.ts src/utils/errorParsing.test.ts
```

### Evidence (Before & After)

- **Before:** a quota-exhausted `429` is retried silently for the full budget; the user sees no error and no retry indication.
- **After:** the same `429` fast-fails on the first attempt and surfaces, e.g.:

```
Quota exhausted: Your ... quota has been exhausted. The quota will reset at ...

Please retry after the reset time, or switch to another API key / auth method.
```

with the existing `Press Ctrl+Y to retry` hint.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

## Risk & Scope

- **Main risk:** a transient `429` that *happens* to mention "quota" and a reset time would be misclassified as permanent and fast-failed (one less retry). The detection requires the combination `quota + (exhausted|exceeded) + (will reset|reset at)`, which transient throttling does not carry; the transient-retry test guards this.
- **Not validated / out of scope:** the OpenAI SDK still retries such `429`s internally before throwing (~seconds); that happens below qwen-code and is not changed here. Also not addressed here: the broader gap that HTTP-path retries emit no TUI countdown — tracked separately.
- **Breaking changes:** none. Transient `429` behavior is unchanged.

## Linked Issues

Closes #7841

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让 qwen-code 识别"永久额度耗尽"的 `429`（响应体里带重置时间的），并在第一次失败就 fast-fail、抛出友好提示，而不是静默重试满整个重试预算。

## 为什么需要

目前只有 `Throttling.AllocationQuota`（DashScope）和 Qwen-OAuth 免费层额度被当作永久错误。其他 provider 返回的 *"quota has been exhausted ... will reset at ..."* 的 `429` 会被当成瞬时限流：`retryWithBackoff` 重试（外层流式重试再叠加），HTTP 路径重试只发遥测、不发 TUI 倒计时，而该条件是永久的，每次重试只会再次撞同一个 `429`。会话表现为**长时间无输出地卡住**——没有错误提示、没有重试提示、没有消息。

响应体里的重置时间是"永久额度耗尽"与"瞬时 TPM/RPM 限流"的清晰判别信号；后者从不携带重置时间。

## Reviewer 测试计划

### 如何验证

单测覆盖两个方向：

- `quotaErrorDetection.test.ts`：`isQuotaExhaustedError` 命中带重置时间的额度耗尽响应体，**不**命中瞬时限流或裸 `429`。
- `retry.test.ts`：永久额度耗尽 `429` fast-fail（`fn` 只调一次，抛 `/Quota exhausted/`）；不带重置时间的瞬时 `429` 仍重试到成功。
- `errorParsing.test.ts`：友好消息原样透出，不被包成 `[API Error: ...]`。

```
cd packages/core && npx vitest run src/utils/quotaErrorDetection.test.ts src/utils/retry.test.ts src/utils/errorParsing.test.ts
```

### 证据（前后对比）

- **之前：** 额度耗尽 `429` 静默重试满整个预算；用户看不到任何错误和重试提示。
- **之后：** 同样的 `429` 第一次就 fast-fail，透出例如：

```
Quota exhausted: Your ... quota has been exhausted. The quota will reset at ...

Please retry after the reset time, or switch to another API key / auth method.
```

并带既有的 `Press Ctrl+Y to retry` 提示。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

## 风险与范围

- **主要风险：** 某**恰好**提到 "quota" 和重置时间的瞬时 `429` 会被误判为永久并 fast-fail（少一次重试）。检测要求三者同时出现 `quota + (exhausted|exceeded) + (will reset|reset at)`，瞬时限流不会这样；有瞬时任然重试的测试护栏。
- **未验证/范围外：** OpenAI SDK 在抛出前仍会内部重试此类 `429`（约数秒）；这在 qwen-code 之下，本 PR 不改动。也未处理：HTTP 路径重试不发 TUI 倒计时的更广泛缺口——另行跟踪。
- **破坏性变更：** 无。瞬时 `429` 行为不变。

## 关联 Issue

Closes #7841

</details>
