### PR TITLE
fix(release): publish all channel packages, not just channel-base

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -456,6 +456,17 @@ jobs:
         env:
           NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}'
 
+      - name: 'Publish remaining channel packages'
+        working-directory: 'packages/channels'
+        run: |-
+          for channel in dingtalk feishu github qqbot telegram wecom weixin; do
+            echo "::group::Publishing @qwen-code/channel-${channel}"
+            (cd "${channel}" && npm publish --access public --tag=${{ needs.prepare.outputs.npm_tag }} ${{ needs.prepare.outputs.is_dry_run == 'true' && '--dry-run' || '' }})
+            echo "::endgroup::"
+          done
+        env:
+          NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}'
+
       - name: 'Verify Standalone Archives'
         run: |-
           npm run verify:installation-release -- --dir dist/standalone

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -459,6 +459,7 @@ jobs:
       - name: 'Publish remaining channel packages'
         working-directory: 'packages/channels'
         run: |-
+          # Explicit allowlist: new channel workspaces require release approval.
           for channel in dingtalk feishu github qqbot telegram wecom weixin; do
             echo "::group::Publishing @qwen-code/channel-${channel}"
             (cd "${channel}" && npm publish --access public --tag=${{ needs.prepare.outputs.npm_tag }} ${{ needs.prepare.outputs.is_dry_run == 'true' && '--dry-run' || '' }})

--- a/package-lock.json
+++ b/package-lock.json
@@ -27559,9 +27559,9 @@
     },
     "packages/channels/dingtalk": {
       "name": "@qwen-code/channel-dingtalk",
-      "version": "0.21.0",
+      "version": "0.21.0-preview.1",
       "dependencies": {
-        "@qwen-code/channel-base": "file:../base",
+        "@qwen-code/channel-base": "^0.21.0",
         "dingtalk-stream-sdk-nodejs": "^2.0.4"
       },
       "devDependencies": {
@@ -27570,10 +27570,10 @@
     },
     "packages/channels/feishu": {
       "name": "@qwen-code/channel-feishu",
-      "version": "0.21.0",
+      "version": "0.21.0-preview.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.45.0",
-        "@qwen-code/channel-base": "file:../base"
+        "@qwen-code/channel-base": "^0.21.0"
       },
       "devDependencies": {
         "typescript": "^5.0.0"
@@ -27581,10 +27581,10 @@
     },
     "packages/channels/github": {
       "name": "@qwen-code/channel-github",
-      "version": "0.21.0",
+      "version": "0.21.0-preview.0",
       "dependencies": {
         "@octokit/rest": "^21.1.1",
-        "@qwen-code/channel-base": "file:../base",
+        "@qwen-code/channel-base": "^0.21.0",
         "https-proxy-agent": "^7.0.6"
       },
       "devDependencies": {
@@ -27607,9 +27607,9 @@
     },
     "packages/channels/qqbot": {
       "name": "@qwen-code/channel-qqbot",
-      "version": "0.21.0",
+      "version": "0.21.0-preview.0",
       "dependencies": {
-        "@qwen-code/channel-base": "file:../base",
+        "@qwen-code/channel-base": "^0.21.0",
         "@tencent-connect/qqbot-connector": "^1.1.0",
         "ws": "^8.18.0"
       },
@@ -27619,9 +27619,9 @@
     },
     "packages/channels/telegram": {
       "name": "@qwen-code/channel-telegram",
-      "version": "0.21.0",
+      "version": "0.21.0-preview.0",
       "dependencies": {
-        "@qwen-code/channel-base": "file:../base",
+        "@qwen-code/channel-base": "^0.21.0",
         "grammy": "^1.41.1",
         "https-proxy-agent": "^7.0.6",
         "telegram-markdown-formatter": "^0.1.2"
@@ -27632,9 +27632,9 @@
     },
     "packages/channels/wecom": {
       "name": "@qwen-code/channel-wecom",
-      "version": "0.21.0",
+      "version": "0.21.0-preview.0",
       "dependencies": {
-        "@qwen-code/channel-base": "file:../base",
+        "@qwen-code/channel-base": "^0.21.0",
         "@wecom/aibot-node-sdk": "^1.0.7"
       },
       "devDependencies": {
@@ -27643,9 +27643,9 @@
     },
     "packages/channels/weixin": {
       "name": "@qwen-code/channel-weixin",
-      "version": "0.21.0",
+      "version": "0.21.0-preview.0",
       "dependencies": {
-        "@qwen-code/channel-base": "file:../base"
+        "@qwen-code/channel-base": "^0.21.0"
       },
       "devDependencies": {
         "typescript": "^5.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -27549,7 +27549,7 @@
     },
     "packages/channels/base": {
       "name": "@qwen-code/channel-base",
-      "version": "0.21.1-preview.0",
+      "version": "0.21.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.14.1"
       },
@@ -27559,9 +27559,9 @@
     },
     "packages/channels/dingtalk": {
       "name": "@qwen-code/channel-dingtalk",
-      "version": "0.21.1-preview.0",
+      "version": "0.21.0",
       "dependencies": {
-        "@qwen-code/channel-base": "^0.21.1-preview.0",
+        "@qwen-code/channel-base": "^0.21.0",
         "dingtalk-stream-sdk-nodejs": "^2.0.4"
       },
       "devDependencies": {
@@ -27570,10 +27570,10 @@
     },
     "packages/channels/feishu": {
       "name": "@qwen-code/channel-feishu",
-      "version": "0.21.1-preview.0",
+      "version": "0.21.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.45.0",
-        "@qwen-code/channel-base": "^0.21.1-preview.0"
+        "@qwen-code/channel-base": "^0.21.0"
       },
       "devDependencies": {
         "typescript": "^5.0.0"
@@ -27581,10 +27581,10 @@
     },
     "packages/channels/github": {
       "name": "@qwen-code/channel-github",
-      "version": "0.21.1-preview.0",
+      "version": "0.21.0",
       "dependencies": {
         "@octokit/rest": "^21.1.1",
-        "@qwen-code/channel-base": "^0.21.1-preview.0",
+        "@qwen-code/channel-base": "^0.21.0",
         "https-proxy-agent": "^7.0.6"
       },
       "devDependencies": {
@@ -27607,9 +27607,9 @@
     },
     "packages/channels/qqbot": {
       "name": "@qwen-code/channel-qqbot",
-      "version": "0.21.1-preview.0",
+      "version": "0.21.0",
       "dependencies": {
-        "@qwen-code/channel-base": "^0.21.1-preview.0",
+        "@qwen-code/channel-base": "^0.21.0",
         "@tencent-connect/qqbot-connector": "^1.1.0",
         "ws": "^8.18.0"
       },
@@ -27619,9 +27619,9 @@
     },
     "packages/channels/telegram": {
       "name": "@qwen-code/channel-telegram",
-      "version": "0.21.1-preview.0",
+      "version": "0.21.0",
       "dependencies": {
-        "@qwen-code/channel-base": "^0.21.1-preview.0",
+        "@qwen-code/channel-base": "^0.21.0",
         "grammy": "^1.41.1",
         "https-proxy-agent": "^7.0.6",
         "telegram-markdown-formatter": "^0.1.2"
@@ -27632,9 +27632,9 @@
     },
     "packages/channels/wecom": {
       "name": "@qwen-code/channel-wecom",
-      "version": "0.21.1-preview.0",
+      "version": "0.21.0",
       "dependencies": {
-        "@qwen-code/channel-base": "^0.21.1-preview.0",
+        "@qwen-code/channel-base": "^0.21.0",
         "@wecom/aibot-node-sdk": "^1.0.7"
       },
       "devDependencies": {
@@ -27643,9 +27643,9 @@
     },
     "packages/channels/weixin": {
       "name": "@qwen-code/channel-weixin",
-      "version": "0.21.1-preview.0",
+      "version": "0.21.0",
       "dependencies": {
-        "@qwen-code/channel-base": "^0.21.1-preview.0"
+        "@qwen-code/channel-base": "^0.21.0"
       },
       "devDependencies": {
         "typescript": "^5.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -27549,7 +27549,7 @@
     },
     "packages/channels/base": {
       "name": "@qwen-code/channel-base",
-      "version": "0.21.0",
+      "version": "0.21.1-preview.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.14.1"
       },
@@ -27559,9 +27559,9 @@
     },
     "packages/channels/dingtalk": {
       "name": "@qwen-code/channel-dingtalk",
-      "version": "0.21.0-preview.1",
+      "version": "0.21.1-preview.0",
       "dependencies": {
-        "@qwen-code/channel-base": "^0.21.0",
+        "@qwen-code/channel-base": "^0.21.1-preview.0",
         "dingtalk-stream-sdk-nodejs": "^2.0.4"
       },
       "devDependencies": {
@@ -27570,10 +27570,10 @@
     },
     "packages/channels/feishu": {
       "name": "@qwen-code/channel-feishu",
-      "version": "0.21.0-preview.0",
+      "version": "0.21.1-preview.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.45.0",
-        "@qwen-code/channel-base": "^0.21.0"
+        "@qwen-code/channel-base": "^0.21.1-preview.0"
       },
       "devDependencies": {
         "typescript": "^5.0.0"
@@ -27581,10 +27581,10 @@
     },
     "packages/channels/github": {
       "name": "@qwen-code/channel-github",
-      "version": "0.21.0-preview.0",
+      "version": "0.21.1-preview.0",
       "dependencies": {
         "@octokit/rest": "^21.1.1",
-        "@qwen-code/channel-base": "^0.21.0",
+        "@qwen-code/channel-base": "^0.21.1-preview.0",
         "https-proxy-agent": "^7.0.6"
       },
       "devDependencies": {
@@ -27607,9 +27607,9 @@
     },
     "packages/channels/qqbot": {
       "name": "@qwen-code/channel-qqbot",
-      "version": "0.21.0-preview.0",
+      "version": "0.21.1-preview.0",
       "dependencies": {
-        "@qwen-code/channel-base": "^0.21.0",
+        "@qwen-code/channel-base": "^0.21.1-preview.0",
         "@tencent-connect/qqbot-connector": "^1.1.0",
         "ws": "^8.18.0"
       },
@@ -27619,9 +27619,9 @@
     },
     "packages/channels/telegram": {
       "name": "@qwen-code/channel-telegram",
-      "version": "0.21.0-preview.0",
+      "version": "0.21.1-preview.0",
       "dependencies": {
-        "@qwen-code/channel-base": "^0.21.0",
+        "@qwen-code/channel-base": "^0.21.1-preview.0",
         "grammy": "^1.41.1",
         "https-proxy-agent": "^7.0.6",
         "telegram-markdown-formatter": "^0.1.2"
@@ -27632,9 +27632,9 @@
     },
     "packages/channels/wecom": {
       "name": "@qwen-code/channel-wecom",
-      "version": "0.21.0-preview.0",
+      "version": "0.21.1-preview.0",
       "dependencies": {
-        "@qwen-code/channel-base": "^0.21.0",
+        "@qwen-code/channel-base": "^0.21.1-preview.0",
         "@wecom/aibot-node-sdk": "^1.0.7"
       },
       "devDependencies": {
@@ -27643,9 +27643,9 @@
     },
     "packages/channels/weixin": {
       "name": "@qwen-code/channel-weixin",
-      "version": "0.21.0-preview.0",
+      "version": "0.21.1-preview.0",
       "dependencies": {
-        "@qwen-code/channel-base": "^0.21.0"
+        "@qwen-code/channel-base": "^0.21.1-preview.0"
       },
       "devDependencies": {
         "typescript": "^5.0.0"

--- a/packages/channels/base/package.json
+++ b/packages/channels/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-base",
-  "version": "0.21.0",
+  "version": "0.21.1-preview.0",
   "description": "Base channel infrastructure for Qwen Code",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/channels/base/package.json
+++ b/packages/channels/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-base",
-  "version": "0.21.1-preview.0",
+  "version": "0.21.0",
   "description": "Base channel infrastructure for Qwen Code",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/channels/base/tsconfig.json
+++ b/packages/channels/base/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
+    "declarationMap": true,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/channels/dingtalk/package.json
+++ b/packages/channels/dingtalk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-dingtalk",
-  "version": "0.21.0-preview.1",
+  "version": "0.21.1-preview.0",
   "description": "DingTalk channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
     "test:ci": "vitest run"
   },
   "dependencies": {
-    "@qwen-code/channel-base": "^0.21.0",
+    "@qwen-code/channel-base": "^0.21.1-preview.0",
     "dingtalk-stream-sdk-nodejs": "^2.0.4"
   },
   "devDependencies": {

--- a/packages/channels/dingtalk/package.json
+++ b/packages/channels/dingtalk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-dingtalk",
-  "version": "0.21.1-preview.0",
+  "version": "0.21.0",
   "description": "DingTalk channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
     "test:ci": "vitest run"
   },
   "dependencies": {
-    "@qwen-code/channel-base": "^0.21.1-preview.0",
+    "@qwen-code/channel-base": "^0.21.0",
     "dingtalk-stream-sdk-nodejs": "^2.0.4"
   },
   "devDependencies": {

--- a/packages/channels/dingtalk/package.json
+++ b/packages/channels/dingtalk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-dingtalk",
-  "version": "0.21.0",
+  "version": "0.21.0-preview.1",
   "description": "DingTalk channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
     "test:ci": "vitest run"
   },
   "dependencies": {
-    "@qwen-code/channel-base": "file:../base",
+    "@qwen-code/channel-base": "^0.21.0",
     "dingtalk-stream-sdk-nodejs": "^2.0.4"
   },
   "devDependencies": {

--- a/packages/channels/dingtalk/tsconfig.json
+++ b/packages/channels/dingtalk/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
+    "declarationMap": true,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/channels/feishu/package.json
+++ b/packages/channels/feishu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-feishu",
-  "version": "0.21.0-preview.0",
+  "version": "0.21.1-preview.0",
   "description": "Feishu (Lark) channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",
@@ -18,7 +18,7 @@
     "build": "tsc --build"
   },
   "dependencies": {
-    "@qwen-code/channel-base": "^0.21.0",
+    "@qwen-code/channel-base": "^0.21.1-preview.0",
     "@larksuiteoapi/node-sdk": "^1.45.0"
   },
   "devDependencies": {

--- a/packages/channels/feishu/package.json
+++ b/packages/channels/feishu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-feishu",
-  "version": "0.21.0",
+  "version": "0.21.0-preview.0",
   "description": "Feishu (Lark) channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",
@@ -18,7 +18,7 @@
     "build": "tsc --build"
   },
   "dependencies": {
-    "@qwen-code/channel-base": "file:../base",
+    "@qwen-code/channel-base": "^0.21.0",
     "@larksuiteoapi/node-sdk": "^1.45.0"
   },
   "devDependencies": {

--- a/packages/channels/feishu/package.json
+++ b/packages/channels/feishu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-feishu",
-  "version": "0.21.1-preview.0",
+  "version": "0.21.0",
   "description": "Feishu (Lark) channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",
@@ -18,7 +18,7 @@
     "build": "tsc --build"
   },
   "dependencies": {
-    "@qwen-code/channel-base": "^0.21.1-preview.0",
+    "@qwen-code/channel-base": "^0.21.0",
     "@larksuiteoapi/node-sdk": "^1.45.0"
   },
   "devDependencies": {

--- a/packages/channels/feishu/tsconfig.json
+++ b/packages/channels/feishu/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
+    "declarationMap": true,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/channels/github/package.json
+++ b/packages/channels/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-github",
-  "version": "0.21.1-preview.0",
+  "version": "0.21.0",
   "description": "GitHub polling channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
     "test:ci": "vitest run"
   },
   "dependencies": {
-    "@qwen-code/channel-base": "^0.21.1-preview.0",
+    "@qwen-code/channel-base": "^0.21.0",
     "@octokit/rest": "^21.1.1",
     "https-proxy-agent": "^7.0.6"
   },

--- a/packages/channels/github/package.json
+++ b/packages/channels/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-github",
-  "version": "0.21.0-preview.0",
+  "version": "0.21.1-preview.0",
   "description": "GitHub polling channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
     "test:ci": "vitest run"
   },
   "dependencies": {
-    "@qwen-code/channel-base": "^0.21.0",
+    "@qwen-code/channel-base": "^0.21.1-preview.0",
     "@octokit/rest": "^21.1.1",
     "https-proxy-agent": "^7.0.6"
   },

--- a/packages/channels/github/package.json
+++ b/packages/channels/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-github",
-  "version": "0.21.0",
+  "version": "0.21.0-preview.0",
   "description": "GitHub polling channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
     "test:ci": "vitest run"
   },
   "dependencies": {
-    "@qwen-code/channel-base": "file:../base",
+    "@qwen-code/channel-base": "^0.21.0",
     "@octokit/rest": "^21.1.1",
     "https-proxy-agent": "^7.0.6"
   },

--- a/packages/channels/github/tsconfig.json
+++ b/packages/channels/github/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
+    "declarationMap": true,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/channels/qqbot/package.json
+++ b/packages/channels/qqbot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-qqbot",
-  "version": "0.21.0-preview.0",
+  "version": "0.21.1-preview.0",
   "description": "QQ Bot (QQ机器人) channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",
@@ -19,7 +19,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@qwen-code/channel-base": "^0.21.0",
+    "@qwen-code/channel-base": "^0.21.1-preview.0",
     "@tencent-connect/qqbot-connector": "^1.1.0",
     "ws": "^8.18.0"
   },

--- a/packages/channels/qqbot/package.json
+++ b/packages/channels/qqbot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-qqbot",
-  "version": "0.21.0",
+  "version": "0.21.0-preview.0",
   "description": "QQ Bot (QQ机器人) channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",
@@ -19,7 +19,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@qwen-code/channel-base": "file:../base",
+    "@qwen-code/channel-base": "^0.21.0",
     "@tencent-connect/qqbot-connector": "^1.1.0",
     "ws": "^8.18.0"
   },

--- a/packages/channels/qqbot/package.json
+++ b/packages/channels/qqbot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-qqbot",
-  "version": "0.21.1-preview.0",
+  "version": "0.21.0",
   "description": "QQ Bot (QQ机器人) channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",
@@ -19,7 +19,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@qwen-code/channel-base": "^0.21.1-preview.0",
+    "@qwen-code/channel-base": "^0.21.0",
     "@tencent-connect/qqbot-connector": "^1.1.0",
     "ws": "^8.18.0"
   },

--- a/packages/channels/qqbot/tsconfig.json
+++ b/packages/channels/qqbot/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
+    "declarationMap": true,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/channels/telegram/package.json
+++ b/packages/channels/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-telegram",
-  "version": "0.21.1-preview.0",
+  "version": "0.21.0",
   "description": "Telegram channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
     "test:ci": "vitest run"
   },
   "dependencies": {
-    "@qwen-code/channel-base": "^0.21.1-preview.0",
+    "@qwen-code/channel-base": "^0.21.0",
     "grammy": "^1.41.1",
     "https-proxy-agent": "^7.0.6",
     "telegram-markdown-formatter": "^0.1.2"

--- a/packages/channels/telegram/package.json
+++ b/packages/channels/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-telegram",
-  "version": "0.21.0-preview.0",
+  "version": "0.21.1-preview.0",
   "description": "Telegram channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
     "test:ci": "vitest run"
   },
   "dependencies": {
-    "@qwen-code/channel-base": "^0.21.0",
+    "@qwen-code/channel-base": "^0.21.1-preview.0",
     "grammy": "^1.41.1",
     "https-proxy-agent": "^7.0.6",
     "telegram-markdown-formatter": "^0.1.2"

--- a/packages/channels/telegram/package.json
+++ b/packages/channels/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-telegram",
-  "version": "0.21.0",
+  "version": "0.21.0-preview.0",
   "description": "Telegram channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
     "test:ci": "vitest run"
   },
   "dependencies": {
-    "@qwen-code/channel-base": "file:../base",
+    "@qwen-code/channel-base": "^0.21.0",
     "grammy": "^1.41.1",
     "https-proxy-agent": "^7.0.6",
     "telegram-markdown-formatter": "^0.1.2"

--- a/packages/channels/telegram/tsconfig.json
+++ b/packages/channels/telegram/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
+    "declarationMap": true,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/channels/wecom/package.json
+++ b/packages/channels/wecom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-wecom",
-  "version": "0.21.0-preview.0",
+  "version": "0.21.1-preview.0",
   "description": "WeCom channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
     "test:ci": "vitest run"
   },
   "dependencies": {
-    "@qwen-code/channel-base": "^0.21.0",
+    "@qwen-code/channel-base": "^0.21.1-preview.0",
     "@wecom/aibot-node-sdk": "^1.0.7"
   },
   "devDependencies": {

--- a/packages/channels/wecom/package.json
+++ b/packages/channels/wecom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-wecom",
-  "version": "0.21.1-preview.0",
+  "version": "0.21.0",
   "description": "WeCom channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
     "test:ci": "vitest run"
   },
   "dependencies": {
-    "@qwen-code/channel-base": "^0.21.1-preview.0",
+    "@qwen-code/channel-base": "^0.21.0",
     "@wecom/aibot-node-sdk": "^1.0.7"
   },
   "devDependencies": {

--- a/packages/channels/wecom/package.json
+++ b/packages/channels/wecom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-wecom",
-  "version": "0.21.0",
+  "version": "0.21.0-preview.0",
   "description": "WeCom channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
     "test:ci": "vitest run"
   },
   "dependencies": {
-    "@qwen-code/channel-base": "file:../base",
+    "@qwen-code/channel-base": "^0.21.0",
     "@wecom/aibot-node-sdk": "^1.0.7"
   },
   "devDependencies": {

--- a/packages/channels/wecom/tsconfig.json
+++ b/packages/channels/wecom/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
+    "declarationMap": true,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/channels/weixin/package.json
+++ b/packages/channels/weixin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-weixin",
-  "version": "0.21.0-preview.0",
+  "version": "0.21.1-preview.0",
   "description": "WeChat (Weixin) channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",
@@ -26,7 +26,7 @@
     "build": "tsc --build"
   },
   "dependencies": {
-    "@qwen-code/channel-base": "^0.21.0"
+    "@qwen-code/channel-base": "^0.21.1-preview.0"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/channels/weixin/package.json
+++ b/packages/channels/weixin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-weixin",
-  "version": "0.21.0",
+  "version": "0.21.0-preview.0",
   "description": "WeChat (Weixin) channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",
@@ -26,7 +26,7 @@
     "build": "tsc --build"
   },
   "dependencies": {
-    "@qwen-code/channel-base": "file:../base"
+    "@qwen-code/channel-base": "^0.21.0"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/channels/weixin/package.json
+++ b/packages/channels/weixin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-weixin",
-  "version": "0.21.1-preview.0",
+  "version": "0.21.0",
   "description": "WeChat (Weixin) channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",
@@ -26,7 +26,7 @@
     "build": "tsc --build"
   },
   "dependencies": {
-    "@qwen-code/channel-base": "^0.21.1-preview.0"
+    "@qwen-code/channel-base": "^0.21.0"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/channels/weixin/tsconfig.json
+++ b/packages/channels/weixin/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
+    "declarationMap": true,
     "outDir": "dist",
     "rootDir": "src"
   },


### PR DESCRIPTION
## What this PR does

Adds a publish step to the release workflow that publishes all remaining channel packages (dingtalk, feishu, github, qqbot, telegram, wecom, weixin) to npm, after `@qwen-code/channel-base`.

## Why it's needed

The release workflow only had a publish step for `@qwen-code/channel-base`. The other 7 channel packages are non-private (`private` not set in package.json), version-synced by the release bump step (`packages/channels/*/package.json`), but never actually published — all return E404 on npm.

## What changed

A single new step `Publish remaining channel packages` loops over the 7 channel directories and runs `npm publish` with the same `--tag` and `--dry-run` support as the existing steps. Placed after `channel-base` to respect the dependency order (all channels depend on base).

Uses a shell loop instead of 7 duplicate steps to keep the workflow maintainable — adding a new channel only requires appending to the list.

## Reviewer Test Plan

### How to verify

Trigger a dry-run release (`dry_run: true`) and confirm the new step logs `::group::Publishing @qwen-code/channel-<name>` for each channel with `--dry-run` in the npm publish command.

### Risk & Scope

- **Scope**: CI/CD workflow only. No application code changed.
- **Risk**: Low. The step uses the same `npm publish --access public` pattern as existing steps. Dry-run support is preserved. If a channel package is not ready for publication, it can be marked `private: true` in its `package.json` to skip it.
- **Rollback**: Remove the step from `release.yml`.

## Linked Issues

N/A — discovered during channel package audit.