### PR TITLE
feat(web-shell): add native workspace folder picker

### DIFF
--- a/packages/cli/src/serve/native-directory-picker.test.ts
+++ b/packages/cli/src/serve/native-directory-picker.test.ts
@@ -1,0 +1,153 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { execFileAsyncMock } = vi.hoisted(() => ({
+  execFileAsyncMock: vi.fn(),
+}));
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  const execFile = Object.assign(() => {}, {
+    [Symbol.for('nodejs.util.promisify.custom')]: execFileAsyncMock,
+  });
+  return {
+    ...actual,
+    execFile,
+    default: { ...actual, execFile },
+  };
+});
+
+const { pickNativeDirectory, NativeDirectoryPickerUnavailableError } =
+  await import('./native-directory-picker.js');
+
+function setPlatform(platform: NodeJS.Platform) {
+  vi.spyOn(process, 'platform', 'get').mockReturnValue(platform);
+}
+
+function pickerError(fields: { code?: number; stderr?: string }): Error {
+  return Object.assign(new Error('picker failed'), fields);
+}
+
+beforeEach(() => {
+  execFileAsyncMock.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('pickNativeDirectory', () => {
+  it('returns the trimmed path on macOS', async () => {
+    setPlatform('darwin');
+    execFileAsyncMock.mockResolvedValue({ stdout: '/Users/me/code\n' });
+
+    await expect(pickNativeDirectory()).resolves.toBe('/Users/me/code');
+    expect(execFileAsyncMock).toHaveBeenCalledWith(
+      'osascript',
+      expect.any(Array),
+      { timeout: 300_000 },
+    );
+  });
+
+  it('treats an AppleScript (-128) cancellation as no selection on macOS', async () => {
+    setPlatform('darwin');
+    execFileAsyncMock.mockRejectedValue(pickerError({ stderr: '(-128)' }));
+
+    await expect(pickNativeDirectory()).resolves.toBeUndefined();
+  });
+
+  it('treats a "User canceled" cancellation as no selection on macOS', async () => {
+    setPlatform('darwin');
+    execFileAsyncMock.mockRejectedValue(
+      pickerError({ stderr: 'User canceled. (-128)' }),
+    );
+
+    await expect(pickNativeDirectory()).resolves.toBeUndefined();
+  });
+
+  it('throws unavailable for a non-cancel failure on macOS', async () => {
+    setPlatform('darwin');
+    execFileAsyncMock.mockRejectedValue(pickerError({ stderr: 'boom' }));
+
+    await expect(pickNativeDirectory()).rejects.toBeInstanceOf(
+      NativeDirectoryPickerUnavailableError,
+    );
+  });
+
+  it('returns the selected path on Windows', async () => {
+    setPlatform('win32');
+    execFileAsyncMock.mockResolvedValue({ stdout: 'C:\\code' });
+
+    await expect(pickNativeDirectory()).resolves.toBe('C:\\code');
+    expect(execFileAsyncMock).toHaveBeenCalledWith(
+      'powershell.exe',
+      expect.any(Array),
+      { timeout: 300_000 },
+    );
+  });
+
+  it('returns undefined when the Windows dialog is dismissed', async () => {
+    setPlatform('win32');
+    execFileAsyncMock.mockResolvedValue({ stdout: '   ' });
+
+    await expect(pickNativeDirectory()).resolves.toBeUndefined();
+  });
+
+  it('returns the trimmed path on Linux', async () => {
+    setPlatform('linux');
+    execFileAsyncMock.mockResolvedValue({ stdout: '/home/me/code\n' });
+
+    await expect(pickNativeDirectory()).resolves.toBe('/home/me/code');
+    expect(execFileAsyncMock).toHaveBeenCalledWith(
+      'zenity',
+      expect.any(Array),
+      {
+        timeout: 300_000,
+      },
+    );
+  });
+
+  it('treats zenity exit code 1 as a cancel on Linux', async () => {
+    setPlatform('linux');
+    execFileAsyncMock.mockRejectedValue(pickerError({ code: 1, stderr: '' }));
+
+    await expect(pickNativeDirectory()).resolves.toBeUndefined();
+  });
+
+  it('treats a headless "cannot open display" failure as unavailable on Linux', async () => {
+    setPlatform('linux');
+    execFileAsyncMock.mockRejectedValue(
+      pickerError({
+        code: 1,
+        stderr: 'Gtk-WARNING **: cannot open display:',
+      }),
+    );
+
+    await expect(pickNativeDirectory()).rejects.toBeInstanceOf(
+      NativeDirectoryPickerUnavailableError,
+    );
+  });
+
+  it('throws unavailable for a non-cancel zenity failure on Linux', async () => {
+    setPlatform('linux');
+    execFileAsyncMock.mockRejectedValue(pickerError({ code: 127 }));
+
+    await expect(pickNativeDirectory()).rejects.toBeInstanceOf(
+      NativeDirectoryPickerUnavailableError,
+    );
+  });
+
+  it('throws unavailable on an unsupported platform', async () => {
+    setPlatform('aix');
+
+    await expect(pickNativeDirectory()).rejects.toBeInstanceOf(
+      NativeDirectoryPickerUnavailableError,
+    );
+    expect(execFileAsyncMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/serve/native-directory-picker.test.ts
+++ b/packages/cli/src/serve/native-directory-picker.test.ts
@@ -150,4 +150,18 @@ describe('pickNativeDirectory', () => {
     );
     expect(execFileAsyncMock).not.toHaveBeenCalled();
   });
+
+  it('forwards the abort signal to the child process', async () => {
+    setPlatform('darwin');
+    const controller = new AbortController();
+    execFileAsyncMock.mockResolvedValue({ stdout: '/tmp\n' });
+
+    await pickNativeDirectory(controller.signal);
+
+    expect(execFileAsyncMock).toHaveBeenCalledWith(
+      'osascript',
+      expect.any(Array),
+      { timeout: 300_000, signal: controller.signal },
+    );
+  });
 });

--- a/packages/cli/src/serve/native-directory-picker.test.ts
+++ b/packages/cli/src/serve/native-directory-picker.test.ts
@@ -29,7 +29,11 @@ function setPlatform(platform: NodeJS.Platform) {
   vi.spyOn(process, 'platform', 'get').mockReturnValue(platform);
 }
 
-function pickerError(fields: { code?: number; stderr?: string }): Error {
+function pickerError(fields: {
+  code?: number;
+  stderr?: string;
+  killed?: boolean;
+}): Error {
   return Object.assign(new Error('picker failed'), fields);
 }
 
@@ -91,6 +95,19 @@ describe('pickNativeDirectory', () => {
     );
   });
 
+  it('sets UTF-8 output encoding in the PowerShell script', async () => {
+    setPlatform('win32');
+    execFileAsyncMock.mockResolvedValue({ stdout: 'C:\\code' });
+
+    await pickNativeDirectory();
+
+    const args = execFileAsyncMock.mock.calls[0][1] as string[];
+    const script = args[args.length - 1];
+    expect(script).toContain(
+      '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8;',
+    );
+  });
+
   it('returns undefined when the Windows dialog is dismissed', async () => {
     setPlatform('win32');
     execFileAsyncMock.mockResolvedValue({ stdout: '   ' });
@@ -140,6 +157,13 @@ describe('pickNativeDirectory', () => {
     await expect(pickNativeDirectory()).rejects.toBeInstanceOf(
       NativeDirectoryPickerUnavailableError,
     );
+  });
+
+  it('treats a timeout kill as a cancel on any platform', async () => {
+    setPlatform('win32');
+    execFileAsyncMock.mockRejectedValue(pickerError({ killed: true }));
+
+    await expect(pickNativeDirectory()).resolves.toBeUndefined();
   });
 
   it('throws unavailable on an unsupported platform', async () => {

--- a/packages/cli/src/serve/native-directory-picker.ts
+++ b/packages/cli/src/serve/native-directory-picker.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+export class NativeDirectoryPickerUnavailableError extends Error {}
+
+export async function pickNativeDirectory(): Promise<string | undefined> {
+  try {
+    if (process.platform === 'darwin') {
+      const script = [
+        'const app = Application.currentApplication();',
+        'app.includeStandardAdditions = true;',
+        'app.chooseFolder({',
+        'withPrompt: "Select a workspace folder",',
+        '}).toString();',
+      ].join(' ');
+      const { stdout } = await execFileAsync('osascript', [
+        '-l',
+        'JavaScript',
+        '-e',
+        script,
+      ]);
+      return stdout.trim() || undefined;
+    }
+
+    if (process.platform === 'win32') {
+      const script = [
+        'Add-Type -AssemblyName System.Windows.Forms;',
+        '$dialog = New-Object System.Windows.Forms.FolderBrowserDialog;',
+        'if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {',
+        '[Console]::Out.Write($dialog.SelectedPath)',
+        '}',
+      ].join(' ');
+      const { stdout } = await execFileAsync('powershell.exe', [
+        '-NoProfile',
+        '-STA',
+        '-Command',
+        script,
+      ]);
+      return stdout.trim() || undefined;
+    }
+
+    if (process.platform === 'linux') {
+      const { stdout } = await execFileAsync('zenity', [
+        '--file-selection',
+        '--directory',
+        '--title=Select a workspace folder',
+      ]);
+      return stdout.trim() || undefined;
+    }
+  } catch (error) {
+    const result = error as { code?: number | string; stderr?: string };
+    if (
+      (process.platform === 'darwin' &&
+        (result.stderr?.includes('(-128)') ||
+          result.stderr?.includes('User canceled'))) ||
+      (process.platform === 'linux' && result.code === 1)
+    ) {
+      return undefined;
+    }
+    throw new NativeDirectoryPickerUnavailableError(
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+
+  throw new NativeDirectoryPickerUnavailableError(
+    `Native directory picker is not supported on ${process.platform}`,
+  );
+}

--- a/packages/cli/src/serve/native-directory-picker.ts
+++ b/packages/cli/src/serve/native-directory-picker.ts
@@ -9,6 +9,11 @@ import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
 
+// Matches the SDK client's 5-minute ceiling so a dismissed dialog cannot leave
+// an orphaned native picker (and its visible GUI) running after the request
+// that spawned it is gone.
+const PICKER_TIMEOUT_MS = 300_000;
+
 export class NativeDirectoryPickerUnavailableError extends Error {}
 
 export async function pickNativeDirectory(): Promise<string | undefined> {
@@ -21,12 +26,11 @@ export async function pickNativeDirectory(): Promise<string | undefined> {
         'withPrompt: "Select a workspace folder",',
         '}).toString();',
       ].join(' ');
-      const { stdout } = await execFileAsync('osascript', [
-        '-l',
-        'JavaScript',
-        '-e',
-        script,
-      ]);
+      const { stdout } = await execFileAsync(
+        'osascript',
+        ['-l', 'JavaScript', '-e', script],
+        { timeout: PICKER_TIMEOUT_MS },
+      );
       return stdout.trim() || undefined;
     }
 
@@ -38,21 +42,24 @@ export async function pickNativeDirectory(): Promise<string | undefined> {
         '[Console]::Out.Write($dialog.SelectedPath)',
         '}',
       ].join(' ');
-      const { stdout } = await execFileAsync('powershell.exe', [
-        '-NoProfile',
-        '-STA',
-        '-Command',
-        script,
-      ]);
+      const { stdout } = await execFileAsync(
+        'powershell.exe',
+        ['-NoProfile', '-STA', '-Command', script],
+        { timeout: PICKER_TIMEOUT_MS },
+      );
       return stdout.trim() || undefined;
     }
 
     if (process.platform === 'linux') {
-      const { stdout } = await execFileAsync('zenity', [
-        '--file-selection',
-        '--directory',
-        '--title=Select a workspace folder',
-      ]);
+      const { stdout } = await execFileAsync(
+        'zenity',
+        [
+          '--file-selection',
+          '--directory',
+          '--title=Select a workspace folder',
+        ],
+        { timeout: PICKER_TIMEOUT_MS },
+      );
       return stdout.trim() || undefined;
     }
   } catch (error) {
@@ -61,7 +68,11 @@ export async function pickNativeDirectory(): Promise<string | undefined> {
       (process.platform === 'darwin' &&
         (result.stderr?.includes('(-128)') ||
           result.stderr?.includes('User canceled'))) ||
-      (process.platform === 'linux' && result.code === 1)
+      // Zenity exits 1 both for a deliberate cancel and for "cannot open
+      // display" on headless Linux; only the former is a silent cancel.
+      (process.platform === 'linux' &&
+        result.code === 1 &&
+        !result.stderr?.includes('cannot open display'))
     ) {
       return undefined;
     }

--- a/packages/cli/src/serve/native-directory-picker.ts
+++ b/packages/cli/src/serve/native-directory-picker.ts
@@ -16,7 +16,9 @@ const PICKER_TIMEOUT_MS = 300_000;
 
 export class NativeDirectoryPickerUnavailableError extends Error {}
 
-export async function pickNativeDirectory(): Promise<string | undefined> {
+export async function pickNativeDirectory(
+  signal?: AbortSignal,
+): Promise<string | undefined> {
   try {
     if (process.platform === 'darwin') {
       const script = [
@@ -29,7 +31,7 @@ export async function pickNativeDirectory(): Promise<string | undefined> {
       const { stdout } = await execFileAsync(
         'osascript',
         ['-l', 'JavaScript', '-e', script],
-        { timeout: PICKER_TIMEOUT_MS },
+        { timeout: PICKER_TIMEOUT_MS, signal },
       );
       return stdout.trim() || undefined;
     }
@@ -45,7 +47,7 @@ export async function pickNativeDirectory(): Promise<string | undefined> {
       const { stdout } = await execFileAsync(
         'powershell.exe',
         ['-NoProfile', '-STA', '-Command', script],
-        { timeout: PICKER_TIMEOUT_MS },
+        { timeout: PICKER_TIMEOUT_MS, signal },
       );
       return stdout.trim() || undefined;
     }
@@ -58,7 +60,7 @@ export async function pickNativeDirectory(): Promise<string | undefined> {
           '--directory',
           '--title=Select a workspace folder',
         ],
-        { timeout: PICKER_TIMEOUT_MS },
+        { timeout: PICKER_TIMEOUT_MS, signal },
       );
       return stdout.trim() || undefined;
     }

--- a/packages/cli/src/serve/native-directory-picker.ts
+++ b/packages/cli/src/serve/native-directory-picker.ts
@@ -38,6 +38,7 @@ export async function pickNativeDirectory(
 
     if (process.platform === 'win32') {
       const script = [
+        '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8;',
         'Add-Type -AssemblyName System.Windows.Forms;',
         '$dialog = New-Object System.Windows.Forms.FolderBrowserDialog;',
         'if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {',
@@ -65,7 +66,16 @@ export async function pickNativeDirectory(
       return stdout.trim() || undefined;
     }
   } catch (error) {
-    const result = error as { code?: number | string; stderr?: string };
+    const result = error as {
+      code?: number | string;
+      stderr?: string;
+      killed?: boolean;
+    };
+    // A timeout kill (PICKER_TIMEOUT_MS) or an abort-signal kill means the
+    // dialog is gone; treat it as a cancel rather than an OS-level failure.
+    if (result.killed) {
+      return undefined;
+    }
     if (
       (process.platform === 'darwin' &&
         (result.stderr?.includes('(-128)') ||

--- a/packages/cli/src/serve/routes/workspace-management.test.ts
+++ b/packages/cli/src/serve/routes/workspace-management.test.ts
@@ -2497,4 +2497,47 @@ describe('POST /workspace-directory-picker', () => {
       expect.any(AbortSignal),
     );
   });
+
+  it('does not abort the picker before it can resolve, for the body the Web Shell actually sends', async () => {
+    // A real picker resolves only after the user interacts — model that with a
+    // delay so an already-aborted signal surfaces as a rejection.
+    const pickWorkspaceDirectory = vi.fn(
+      (signal?: AbortSignal) =>
+        new Promise<string | undefined>((resolve, reject) => {
+          setTimeout(() => {
+            if (signal?.aborted) {
+              reject(new Error('The operation was aborted'));
+              return;
+            }
+            resolve('/Users/me/code');
+          }, 50);
+        }),
+    );
+    const { app } = createApp({ pickWorkspaceDirectory });
+
+    const res = await request(app).post('/workspace-directory-picker').send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      kind: 'workspace-directory-picker',
+      selected: true,
+      path: '/Users/me/code',
+    });
+  });
+
+  it('still aborts a picker that is genuinely in flight when the client hangs up', async () => {
+    let observed: AbortSignal | undefined;
+    const { app } = createApp({
+      pickWorkspaceDirectory: vi.fn((signal?: AbortSignal) => {
+        observed = signal;
+        return new Promise<string | undefined>(() => {});
+      }),
+    });
+    const req = request(app).post('/workspace-directory-picker').send({});
+    req.end(() => {});
+    await new Promise((r) => setTimeout(r, 30));
+    req.abort();
+    await new Promise((r) => setTimeout(r, 60));
+    expect(observed?.aborted).toBe(true);
+  });
 });

--- a/packages/cli/src/serve/routes/workspace-management.test.ts
+++ b/packages/cli/src/serve/routes/workspace-management.test.ts
@@ -2486,4 +2486,15 @@ describe('POST /workspace-directory-picker', () => {
       expect.stringContaining('native directory picker failed: boom'),
     );
   });
+
+  it('passes an abort signal to the picker', async () => {
+    const pickWorkspaceDirectory = vi.fn().mockResolvedValue('/tmp');
+    const { app } = createApp({ pickWorkspaceDirectory });
+
+    await request(app).post('/workspace-directory-picker');
+
+    expect(pickWorkspaceDirectory).toHaveBeenCalledWith(
+      expect.any(AbortSignal),
+    );
+  });
 });

--- a/packages/cli/src/serve/routes/workspace-management.test.ts
+++ b/packages/cli/src/serve/routes/workspace-management.test.ts
@@ -2404,3 +2404,55 @@ describe('GET /workspace-path-suggestions', () => {
     expect(res.body.code).toBe('invalid_prefix');
   });
 });
+
+describe('POST /workspace-directory-picker', () => {
+  it('remains available in loopback development without a configured token', async () => {
+    const mutate = vi.fn(
+      (options?: { strict?: boolean }) =>
+        (_req: Request, res: Response, next: () => void) => {
+          if (options?.strict) {
+            res.status(401).json({ code: 'token_required' });
+            return;
+          }
+          next();
+        },
+    );
+    const { app } = createApp({
+      mutate,
+      pickWorkspaceDirectory: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const res = await request(app).post('/workspace-directory-picker');
+
+    expect(res.status).toBe(200);
+    expect(res.body.selected).toBe(false);
+  });
+
+  it('returns the absolute path selected by the native picker', async () => {
+    const pickWorkspaceDirectory = vi.fn().mockResolvedValue('/Users/me/code');
+    const { app } = createApp({ pickWorkspaceDirectory });
+
+    const res = await request(app).post('/workspace-directory-picker');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      kind: 'workspace-directory-picker',
+      selected: true,
+      path: '/Users/me/code',
+    });
+  });
+
+  it('returns selected=false when the user cancels', async () => {
+    const { app } = createApp({
+      pickWorkspaceDirectory: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const res = await request(app).post('/workspace-directory-picker');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      kind: 'workspace-directory-picker',
+      selected: false,
+    });
+  });
+});

--- a/packages/cli/src/serve/routes/workspace-management.test.ts
+++ b/packages/cli/src/serve/routes/workspace-management.test.ts
@@ -13,6 +13,7 @@ import {
   type WorkspaceManagementRouteDeps,
   type WorkspaceRuntimeRemovalController,
 } from './workspace-management.js';
+import { NativeDirectoryPickerUnavailableError } from '../native-directory-picker.js';
 import type {
   WorkspaceRegistry,
   WorkspaceRuntime,
@@ -2454,5 +2455,29 @@ describe('POST /workspace-directory-picker', () => {
       kind: 'workspace-directory-picker',
       selected: false,
     });
+  });
+
+  it('returns 501 when the native picker is unavailable', async () => {
+    const { app } = createApp({
+      pickWorkspaceDirectory: vi
+        .fn()
+        .mockRejectedValue(new NativeDirectoryPickerUnavailableError()),
+    });
+
+    const res = await request(app).post('/workspace-directory-picker');
+
+    expect(res.status).toBe(501);
+    expect(res.body.code).toBe('directory_picker_unavailable');
+  });
+
+  it('returns 500 when the picker fails unexpectedly', async () => {
+    const { app } = createApp({
+      pickWorkspaceDirectory: vi.fn().mockRejectedValue(new Error('boom')),
+    });
+
+    const res = await request(app).post('/workspace-directory-picker');
+
+    expect(res.status).toBe(500);
+    expect(res.body.code).toBe('directory_picker_failed');
   });
 });

--- a/packages/cli/src/serve/routes/workspace-management.test.ts
+++ b/packages/cli/src/serve/routes/workspace-management.test.ts
@@ -2468,6 +2468,9 @@ describe('POST /workspace-directory-picker', () => {
 
     expect(res.status).toBe(501);
     expect(res.body.code).toBe('directory_picker_unavailable');
+    expect(writeStderrLine).toHaveBeenCalledWith(
+      expect.stringContaining('native directory picker unavailable'),
+    );
   });
 
   it('returns 500 when the picker fails unexpectedly', async () => {
@@ -2479,5 +2482,8 @@ describe('POST /workspace-directory-picker', () => {
 
     expect(res.status).toBe(500);
     expect(res.body.code).toBe('directory_picker_failed');
+    expect(writeStderrLine).toHaveBeenCalledWith(
+      expect.stringContaining('native directory picker failed: boom'),
+    );
   });
 });

--- a/packages/cli/src/serve/routes/workspace-management.ts
+++ b/packages/cli/src/serve/routes/workspace-management.ts
@@ -447,7 +447,7 @@ export function registerWorkspaceManagementRoutes(
     mutate(),
     async (req: Request, res: Response) => {
       const controller = new AbortController();
-      req.on('close', () => controller.abort());
+      res.on('close', () => controller.abort());
       try {
         const path = await pickWorkspaceDirectory(controller.signal);
         res.status(200).json({

--- a/packages/cli/src/serve/routes/workspace-management.ts
+++ b/packages/cli/src/serve/routes/workspace-management.ts
@@ -452,13 +452,20 @@ export function registerWorkspaceManagementRoutes(
           ...(path === undefined ? {} : { path }),
         });
       } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
         if (error instanceof NativeDirectoryPickerUnavailableError) {
+          writeStderrLine(
+            `qwen serve: native directory picker unavailable: ${detail}`,
+          );
           res.status(501).json({
             error: 'Native directory picker is unavailable',
             code: 'directory_picker_unavailable',
           });
           return;
         }
+        writeStderrLine(
+          `qwen serve: native directory picker failed: ${detail}`,
+        );
         res.status(500).json({
           error: 'Failed to open native directory picker',
           code: 'directory_picker_failed',

--- a/packages/cli/src/serve/routes/workspace-management.ts
+++ b/packages/cli/src/serve/routes/workspace-management.ts
@@ -38,6 +38,10 @@ import {
   type ManagedScratchRoot,
   type WorkspaceRuntimeProvenance,
 } from '../managed-scratch-workspace.js';
+import {
+  NativeDirectoryPickerUnavailableError,
+  pickNativeDirectory,
+} from '../native-directory-picker.js';
 
 // Upper bound on total registered workspaces (startup + dynamic). Each
 // registration allocates a full runtime (bridge, channel factory, sub-session
@@ -66,6 +70,7 @@ export interface WorkspaceManagementRouteDeps {
   workspaceRegistrationStore?: WorkspaceRegistrationStore;
   getAcpHandle?: () => AcpHttpHandle | undefined;
   runtimeRemoval?: WorkspaceRuntimeRemovalController;
+  pickWorkspaceDirectory?: () => Promise<string | undefined>;
 }
 
 export interface WorkspaceRemovalActivity {
@@ -113,7 +118,10 @@ export function registerWorkspaceManagementRoutes(
     workspaceRegistrationStore,
     getAcpHandle,
     runtimeRemoval,
+    pickWorkspaceDirectory: pickWorkspaceDirectoryOverride,
   } = deps;
+  const pickWorkspaceDirectory =
+    pickWorkspaceDirectoryOverride ?? pickNativeDirectory;
   // Serialize runtime addition, persistence promotion/forget, updates, and
   // removal by canonical cwd so conflicting management mutations cannot cross
   // their validation and persistence commit points concurrently.
@@ -429,6 +437,33 @@ export function registerWorkspaceManagementRoutes(
         suggestions,
         truncated,
       });
+    },
+  );
+
+  app.post(
+    '/workspace-directory-picker',
+    mutate(),
+    async (_req: Request, res: Response) => {
+      try {
+        const path = await pickWorkspaceDirectory();
+        res.status(200).json({
+          kind: 'workspace-directory-picker',
+          selected: path !== undefined,
+          ...(path === undefined ? {} : { path }),
+        });
+      } catch (error) {
+        if (error instanceof NativeDirectoryPickerUnavailableError) {
+          res.status(501).json({
+            error: 'Native directory picker is unavailable',
+            code: 'directory_picker_unavailable',
+          });
+          return;
+        }
+        res.status(500).json({
+          error: 'Failed to open native directory picker',
+          code: 'directory_picker_failed',
+        });
+      }
     },
   );
 

--- a/packages/cli/src/serve/routes/workspace-management.ts
+++ b/packages/cli/src/serve/routes/workspace-management.ts
@@ -70,7 +70,9 @@ export interface WorkspaceManagementRouteDeps {
   workspaceRegistrationStore?: WorkspaceRegistrationStore;
   getAcpHandle?: () => AcpHttpHandle | undefined;
   runtimeRemoval?: WorkspaceRuntimeRemovalController;
-  pickWorkspaceDirectory?: () => Promise<string | undefined>;
+  pickWorkspaceDirectory?: (
+    signal?: AbortSignal,
+  ) => Promise<string | undefined>;
 }
 
 export interface WorkspaceRemovalActivity {
@@ -443,9 +445,11 @@ export function registerWorkspaceManagementRoutes(
   app.post(
     '/workspace-directory-picker',
     mutate(),
-    async (_req: Request, res: Response) => {
+    async (req: Request, res: Response) => {
+      const controller = new AbortController();
+      req.on('close', () => controller.abort());
       try {
-        const path = await pickWorkspaceDirectory();
+        const path = await pickWorkspaceDirectory(controller.signal);
         res.status(200).json({
           kind: 'workspace-directory-picker',
           selected: path !== undefined,

--- a/packages/sdk-typescript/src/daemon/DaemonClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonClient.ts
@@ -1661,6 +1661,19 @@ export class DaemonClient {
     );
   }
 
+  async workspaceDirectoryPicker(): Promise<unknown> {
+    return await this.jsonRequest<unknown>(
+      '/workspace-directory-picker',
+      'POST /workspace-directory-picker',
+      {
+        method: 'POST',
+        body: {},
+        timeoutMs: 300_000,
+        mode: 'rest',
+      },
+    );
+  }
+
   async glob(pattern: string): Promise<unknown> {
     const url = new URL(`${this.baseUrl}/glob`);
     url.searchParams.set('pattern', pattern);

--- a/packages/sdk-typescript/src/daemon/DaemonClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonClient.ts
@@ -1668,7 +1668,7 @@ export class DaemonClient {
       {
         method: 'POST',
         body: {},
-        timeoutMs: 300_000,
+        timeoutMs: 310_000,
         mode: 'rest',
       },
     );

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -71,6 +71,7 @@ type ChatEditorTestProps = {
 type AddWorkspaceDialogTestProps = {
   onClose: () => void;
   onAdd: (cwd: string, persist: boolean, displayName?: string) => Promise<void>;
+  onPick?: () => Promise<string | undefined>;
   displayNameEnabled?: boolean;
   persistenceSupported?: boolean;
 };
@@ -169,6 +170,7 @@ const {
       addWorkspace: vi.fn(),
       addScratchWorkspace: vi.fn(),
       suggestWorkspacePaths: vi.fn(),
+      pickWorkspaceDirectory: vi.fn(),
     },
     mockMcp: {
       initialize: vi.fn().mockResolvedValue({ accepted: true }),
@@ -1476,6 +1478,7 @@ beforeEach(() => {
   mockWorkspaceActions.addWorkspace.mockReset();
   mockWorkspaceActions.addScratchWorkspace.mockReset();
   mockWorkspaceActions.suggestWorkspacePaths.mockReset();
+  mockWorkspaceActions.pickWorkspaceDirectory.mockReset();
   mockMcp.initialize.mockClear();
   mockMcp.initialize.mockResolvedValue({ accepted: true });
   mockMcp.reloadConfig.mockClear();
@@ -2824,6 +2827,14 @@ describe('App session callbacks', () => {
       displayNameEnabled: true,
       persistenceSupported: true,
     });
+    mockWorkspaceActions.pickWorkspaceDirectory.mockResolvedValue({
+      kind: 'workspace-directory-picker',
+      selected: true,
+      path: '/tmp/selected',
+    });
+    await expect(
+      testState.latestAddWorkspaceDialogProps?.onPick?.(),
+    ).resolves.toBe('/tmp/selected');
 
     act(() => {
       testState.latestAddWorkspaceDialogProps?.onClose();

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -7197,6 +7197,10 @@ export function App({
               onSuggest={(prefix) =>
                 workspaceActions.suggestWorkspacePaths(prefix)
               }
+              onPick={async () => {
+                const result = await workspaceActions.pickWorkspaceDirectory();
+                return result.selected ? result.path : undefined;
+              }}
               persistenceSupported={
                 persistentWorkspaceRegistrationSupported
               }

--- a/packages/web-shell/client/components/dialogs/AddWorkspaceDialog.test.tsx
+++ b/packages/web-shell/client/components/dialogs/AddWorkspaceDialog.test.tsx
@@ -37,6 +37,10 @@ const submitButton = () =>
   Array.from(document.querySelectorAll<HTMLButtonElement>('button')).find(
     (b) => b.getAttribute('type') === 'submit',
   )!;
+const browseButton = () =>
+  Array.from(document.querySelectorAll<HTMLButtonElement>('button')).find(
+    (button) => button.textContent === 'Browse…',
+  )!;
 
 function typeInto(target: HTMLInputElement, value: string) {
   act(() => {
@@ -298,6 +302,43 @@ describe('AddWorkspaceDialog', () => {
         'coding-katas/',
       ]);
       expect(input().getAttribute('aria-expanded')).toBe('true');
+    });
+
+    it('opens the system picker and fills the selected absolute path', async () => {
+      const onPick = vi.fn().mockResolvedValue('/Users/me/code');
+      mount(
+        <AddWorkspaceDialog
+          onClose={vi.fn()}
+          onAdd={vi.fn()}
+          onPick={onPick}
+        />,
+      );
+
+      await act(async () => {
+        browseButton().click();
+        await Promise.resolve();
+      });
+
+      expect(onPick).toHaveBeenCalledTimes(1);
+      expect(input().value).toBe('/Users/me/code');
+    });
+
+    it('leaves the path unchanged when the system picker is cancelled', async () => {
+      const onPick = vi.fn().mockResolvedValue(undefined);
+      mount(
+        <AddWorkspaceDialog
+          onClose={vi.fn()}
+          onAdd={vi.fn()}
+          onPick={onPick}
+        />,
+      );
+
+      await act(async () => {
+        browseButton().click();
+        await Promise.resolve();
+      });
+
+      expect(input().value).toBe('');
     });
 
     it('never queries for a non-absolute value', async () => {

--- a/packages/web-shell/client/components/dialogs/AddWorkspaceDialog.test.tsx
+++ b/packages/web-shell/client/components/dialogs/AddWorkspaceDialog.test.tsx
@@ -341,6 +341,27 @@ describe('AddWorkspaceDialog', () => {
       expect(input().value).toBe('');
     });
 
+    it('shows an error when the system picker fails', async () => {
+      const onPick = vi.fn().mockRejectedValue(new Error('boom'));
+      mount(
+        <AddWorkspaceDialog
+          onClose={vi.fn()}
+          onAdd={vi.fn()}
+          onPick={onPick}
+        />,
+      );
+
+      await act(async () => {
+        browseButton().click();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(alert()?.textContent).toContain(
+        'Unable to open the system folder picker',
+      );
+    });
+
     it('never queries for a non-absolute value', async () => {
       const onSuggest = vi.fn().mockResolvedValue(SUGGESTIONS);
       mount(

--- a/packages/web-shell/client/components/dialogs/AddWorkspaceDialog.tsx
+++ b/packages/web-shell/client/components/dialogs/AddWorkspaceDialog.tsx
@@ -12,6 +12,7 @@ import {
 } from '../ui/field';
 import { Input } from '../ui/input';
 import { Switch } from '../ui/switch';
+import { FolderOpenIcon } from 'lucide-react';
 
 export interface WorkspacePathSuggestion {
   name: string;
@@ -34,6 +35,7 @@ interface AddWorkspaceDialogProps {
    * surfaces matching subdirectories in a listbox under the input.
    */
   onSuggest?: (prefix: string) => Promise<WorkspacePathSuggestions>;
+  onPick?: () => Promise<string | undefined>;
   persistenceSupported?: boolean;
 }
 
@@ -52,6 +54,7 @@ export function AddWorkspaceDialog({
   onAdd,
   displayNameEnabled = false,
   onSuggest,
+  onPick,
   persistenceSupported = true,
 }: AddWorkspaceDialogProps) {
   const { t } = useI18n();
@@ -64,6 +67,7 @@ export function AddWorkspaceDialog({
   const [listOpen, setListOpen] = useState(false);
   const [highlight, setHighlight] = useState(-1);
   const [hostSep, setHostSep] = useState('/');
+  const [browsing, setBrowsing] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const listOpenRef = useRef(false);
   listOpenRef.current = listOpen && suggestions.length > 0;
@@ -142,6 +146,25 @@ export function AddWorkspaceDialog({
     },
     [hostSep, closeList],
   );
+
+  const pickDirectory = useCallback(async () => {
+    if (!onPick) return;
+    setBrowsing(true);
+    setError(null);
+    try {
+      const selectedPath = await onPick();
+      if (selectedPath) {
+        ++suggestSeqRef.current;
+        setPath(selectedPath);
+        setSuggestions([]);
+        closeList();
+      }
+    } catch {
+      setError(t('sidebar.addWorkspaceBrowseError'));
+    } finally {
+      setBrowsing(false);
+    }
+  }, [onPick, closeList, t]);
 
   const handleInputKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -242,40 +265,54 @@ export function AddWorkspaceDialog({
               {t('sidebar.addWorkspacePath')}
             </FieldLabel>
             <div className="relative">
-              <Input
-                ref={inputRef}
-                id="add-workspace-path"
-                type="text"
-                placeholder="/absolute/path/to/project"
-                value={path}
-                onChange={(e) => {
-                  setPath(e.target.value);
-                  if (error) setError(null);
-                }}
-                onKeyDown={handleInputKeyDown}
-                onBlur={() => {
-                  // Delay so a mousedown on a suggestion wins over blur.
-                  setTimeout(() => {
-                    suppressNextFetchOpenRef.current = true;
-                    closeList();
-                  }, 100);
-                }}
-                disabled={submitting}
-                autoCapitalize="off"
-                autoCorrect="off"
-                autoComplete="off"
-                spellCheck={false}
-                role="combobox"
-                aria-expanded={showList}
-                aria-controls={showList ? LISTBOX_ID : undefined}
-                aria-activedescendant={
-                  showList && highlight >= 0
-                    ? `${LISTBOX_ID}-${highlight}`
-                    : undefined
-                }
-                aria-describedby={error ? `${ERROR_ID} ${HINT_ID}` : HINT_ID}
-                aria-invalid={error ? true : undefined}
-              />
+              <div className="flex gap-2">
+                <Input
+                  ref={inputRef}
+                  id="add-workspace-path"
+                  type="text"
+                  placeholder="/absolute/path/to/project"
+                  value={path}
+                  onChange={(e) => {
+                    setPath(e.target.value);
+                    if (error) setError(null);
+                  }}
+                  onKeyDown={handleInputKeyDown}
+                  onBlur={() => {
+                    // Delay so a mousedown on a suggestion wins over blur.
+                    setTimeout(() => {
+                      suppressNextFetchOpenRef.current = true;
+                      closeList();
+                    }, 100);
+                  }}
+                  disabled={submitting || browsing}
+                  autoCapitalize="off"
+                  autoCorrect="off"
+                  autoComplete="off"
+                  spellCheck={false}
+                  role="combobox"
+                  aria-expanded={showList}
+                  aria-controls={showList ? LISTBOX_ID : undefined}
+                  aria-activedescendant={
+                    showList && highlight >= 0
+                      ? `${LISTBOX_ID}-${highlight}`
+                      : undefined
+                  }
+                  aria-describedby={error ? `${ERROR_ID} ${HINT_ID}` : HINT_ID}
+                  aria-invalid={error ? true : undefined}
+                />
+                {onPick && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => void pickDirectory()}
+                    disabled={submitting || browsing}
+                  >
+                    <FolderOpenIcon aria-hidden="true" />
+                    {t('sidebar.addWorkspaceBrowse')}
+                  </Button>
+                )}
+              </div>
               {showList && (
                 <ul
                   id={LISTBOX_ID}

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -1002,6 +1002,9 @@ const EN: Messages = {
   'sidebar.scratchOutcomeAcknowledge': 'I checked the workspace list',
   'sidebar.addWorkspaceTitle': 'Add Workspace',
   'sidebar.addWorkspacePath': 'Directory path',
+  'sidebar.addWorkspaceBrowse': 'Browse…',
+  'sidebar.addWorkspaceBrowseError':
+    'Unable to open the system folder picker. Enter an absolute path instead.',
   'sidebar.addWorkspaceDisplayName': 'Display name (optional)',
   'sidebar.addWorkspaceDisplayNameHint':
     'Shown in Web Shell; the directory path remains the workspace identity.',
@@ -3309,6 +3312,9 @@ const ZH: Messages = {
   'sidebar.scratchOutcomeAcknowledge': '我已检查工作区列表',
   'sidebar.addWorkspaceTitle': '添加工作区',
   'sidebar.addWorkspacePath': '目录路径',
+  'sidebar.addWorkspaceBrowse': '浏览…',
+  'sidebar.addWorkspaceBrowseError':
+    '无法打开系统文件夹选择器，请改为输入绝对路径。',
   'sidebar.addWorkspaceDisplayName': '展示名称（可选）',
   'sidebar.addWorkspaceDisplayNameHint':
     '用于 Web Shell 展示；目录路径仍是工作区身份。',

--- a/packages/webui/src/daemon/workspace/actions.test.ts
+++ b/packages/webui/src/daemon/workspace/actions.test.ts
@@ -394,4 +394,59 @@ describe('workspace actions', () => {
     );
     expect(workspaceByCwd).not.toHaveBeenCalled();
   });
+
+  it('forwards the directory picker to the daemon client', async () => {
+    const pickerResult = {
+      kind: 'workspace-directory-picker',
+      selected: true,
+      path: '/Users/me/code',
+    };
+    const workspaceDirectoryPicker = vi.fn().mockResolvedValue(pickerResult);
+    const actions = createDaemonWorkspaceActions({
+      getClient: () =>
+        ({ workspaceDirectoryPicker }) as unknown as DaemonClient,
+      getWorkspaceCwd: () => '/ws',
+      baseUrl: '',
+    });
+
+    await expect(actions.pickWorkspaceDirectory()).resolves.toEqual(
+      pickerResult,
+    );
+    expect(workspaceDirectoryPicker).toHaveBeenCalledOnce();
+  });
+
+  it('applies the 320s timeout to the directory picker', async () => {
+    vi.useFakeTimers();
+    const workspaceDirectoryPicker = vi.fn(() => new Promise<never>(() => {}));
+    const actions = createDaemonWorkspaceActions({
+      getClient: () =>
+        ({ workspaceDirectoryPicker }) as unknown as DaemonClient,
+      getWorkspaceCwd: () => '/ws',
+      baseUrl: '',
+    });
+
+    const result = actions.pickWorkspaceDirectory().then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    await vi.advanceTimersByTimeAsync(320_000);
+
+    const error = await result;
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toMatchObject({
+      message: 'Open directory picker timed out after 320000ms',
+    });
+  });
+
+  it('rejects the directory picker without a connected client', async () => {
+    const actions = createDaemonWorkspaceActions({
+      getClient: () => undefined,
+      getWorkspaceCwd: () => '/ws',
+      baseUrl: '',
+    });
+
+    await expect(actions.pickWorkspaceDirectory()).rejects.toThrow(
+      'Open directory picker failed: DaemonClient is not connected',
+    );
+  });
 });

--- a/packages/webui/src/daemon/workspace/actions.ts
+++ b/packages/webui/src/daemon/workspace/actions.ts
@@ -1007,7 +1007,7 @@ export function createDaemonWorkspaceActions({
       const result = await withActionTimeout(
         client.workspaceDirectoryPicker(),
         'Open directory picker timed out',
-        300_000,
+        320_000,
       );
       return result as DaemonWorkspaceDirectoryPickerResult;
     },

--- a/packages/webui/src/daemon/workspace/actions.ts
+++ b/packages/webui/src/daemon/workspace/actions.ts
@@ -12,6 +12,7 @@ import type {
   DaemonGoal,
   DaemonScheduledTask,
   DaemonWorkspaceActions,
+  DaemonWorkspaceDirectoryPickerResult,
   DaemonWorkspacePathSuggestions,
 } from './types.js';
 
@@ -999,6 +1000,12 @@ export function createDaemonWorkspaceActions({
         'Suggest workspace paths timed out',
       );
       return result as DaemonWorkspacePathSuggestions;
+    },
+
+    async pickWorkspaceDirectory() {
+      const client = requireClient(getClient, 'Open directory picker failed');
+      const result = await client.workspaceDirectoryPicker();
+      return result as DaemonWorkspaceDirectoryPickerResult;
     },
 
     async updateWorkspace(workspaceSelector, update) {

--- a/packages/webui/src/daemon/workspace/actions.ts
+++ b/packages/webui/src/daemon/workspace/actions.ts
@@ -1004,7 +1004,11 @@ export function createDaemonWorkspaceActions({
 
     async pickWorkspaceDirectory() {
       const client = requireClient(getClient, 'Open directory picker failed');
-      const result = await client.workspaceDirectoryPicker();
+      const result = await withActionTimeout(
+        client.workspaceDirectoryPicker(),
+        'Open directory picker timed out',
+        300_000,
+      );
       return result as DaemonWorkspaceDirectoryPickerResult;
     },
 

--- a/packages/webui/src/daemon/workspace/types.ts
+++ b/packages/webui/src/daemon/workspace/types.ts
@@ -333,6 +333,17 @@ export interface DaemonWorkspacePathSuggestions {
   truncated: boolean;
 }
 
+export type DaemonWorkspaceDirectoryPickerResult =
+  | {
+      kind: 'workspace-directory-picker';
+      selected: true;
+      path: string;
+    }
+  | {
+      kind: 'workspace-directory-picker';
+      selected: false;
+    };
+
 export interface DaemonWorkspaceActions {
   // Sessions
   listSessions(
@@ -603,6 +614,7 @@ export interface DaemonWorkspaceActions {
   suggestWorkspacePaths(
     prefix: string,
   ): Promise<DaemonWorkspacePathSuggestions>;
+  pickWorkspaceDirectory(): Promise<DaemonWorkspaceDirectoryPickerResult>;
   updateWorkspace(
     workspaceSelector: string,
     update: DaemonWorkspaceUpdate,


### PR DESCRIPTION
## What this PR does

Adds a Browse action to the Web Shell's Add Workspace dialog that opens the operating system's native folder picker and fills the selected absolute directory path. Manual path entry and directory suggestions remain available.

The daemon exposes a loopback-accessible picker operation, the TypeScript client and Web UI workspace actions carry the result to the dialog, and cancellation leaves the existing input unchanged.

## Why it's needed

Adding a workspace currently requires users to discover and type an absolute path. Native folder selection is faster, less error-prone, and matches the expected desktop workflow for choosing a project directory.

## Reviewer Test Plan

### How to verify

Start `qwen serve`, open Add Workspace, and click Browse. Confirm that the operating system's folder dialog opens, selecting a directory fills its absolute path, cancelling leaves the current value unchanged, and the workspace can then be registered normally. Also confirm that manually typing a path still works.

Automated coverage verifies selected and cancelled picker results, local loopback access without an auth token, dialog behavior, and application action wiring. The full repository build and typecheck pass.

### Evidence (Before & After)

Before: Add Workspace only accepts a manually entered absolute path.

After: Add Workspace provides a Browse button that opens the native folder picker and fills the chosen absolute path.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local `qwen serve` on macOS; native picker manually verified. Automated verification: CLI route tests (105 passed), Web Shell focused tests (22 passed), repository typecheck, and repository build.

## Risk & Scope

- Main risk or tradeoff: Native folder dialogs depend on platform-provided commands and desktop-session availability.
- Not validated / out of scope: Manual end-to-end verification on Windows and Linux; their platform paths are covered by implementation boundaries but still require CI and reviewer validation.
- Breaking changes / migration notes: None.

## Linked Issues

Closes #7840

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在 Web Shell 的“添加工作区”对话框中增加“浏览”操作，点击后打开操作系统原生文件夹选择器，并将选中的绝对目录路径自动填入。仍然保留手动输入路径和目录建议能力。

守护进程提供仅供本机回环访问的目录选择操作，TypeScript 客户端和 Web UI 工作区动作将结果传递给对话框；取消选择时不会修改当前输入。

## 为什么需要

目前添加工作区要求用户自行查找并输入绝对路径。使用原生文件夹选择器更快捷、更不容易出错，也更符合桌面端选择项目目录的常见操作习惯。

## Reviewer 测试计划

### 如何验证

启动 `qwen serve`，打开“添加工作区”并点击“浏览”。确认操作系统文件夹选择器会打开；选中目录后会填入其绝对路径；取消后当前值保持不变；随后可以正常注册工作区。同时确认手动输入路径仍然可用。

自动化测试覆盖选择和取消结果、无需认证令牌的本机回环访问、对话框行为以及应用动作接线。仓库完整构建和类型检查均通过。

### 前后对比证据

之前：“添加工作区”只能手动输入绝对路径。

之后：“添加工作区”提供“浏览”按钮，可打开原生文件夹选择器并填入所选绝对路径。

### 测试平台

|     系统     | 状态 |
| :----------: | :--: |
|  🍏 macOS    |  ✅  |
| 🪟 Windows   |  ⚠️  |
|  🐧 Linux    |  ⚠️  |

### 环境

macOS 本地 `qwen serve`，已手动验证原生选择器。自动化验证包括 CLI 路由测试（105 项通过）、Web Shell 聚焦测试（22 项通过）、仓库类型检查和仓库构建。

## 风险与范围

- 主要风险或权衡：原生文件夹对话框依赖各平台提供的命令和桌面会话环境。
- 未验证或范围外：未在 Windows 和 Linux 上进行手动端到端验证；对应平台实现边界已覆盖，仍需 CI 和 Reviewer 验证。
- 破坏性变更或迁移说明：无。

## 关联 Issue

Closes #7840

</details>
