### PR TITLE
fix(feishu): keep code-fence chunks within the message size limit

### DIFF
--- a/packages/channels/feishu/src/markdown.test.ts
+++ b/packages/channels/feishu/src/markdown.test.ts
@@ -179,6 +179,40 @@ describe('Feishu markdown utilities', () => {
       expect(chunks[0]!.length).toBe(4000);
       expect(chunks[1]!.length).toBe(1000);
     });
+
+    it('accounts for the closing fence when a code line lands near the limit', () => {
+      // 3993 puts the buffer at CHUNK_LIMIT - 3 once the opening fence and
+      // newline are counted, so appending the closing fence overshot by one.
+      const longCode = '```\n' + 'x'.repeat(3993) + '\n```';
+      const chunks = splitChunks(longCode);
+      chunks.forEach((chunk) => {
+        expect(chunk.length).toBeLessThanOrEqual(4000);
+      });
+    });
+
+    it('reserves room for the closing fence on the line that opens a block', () => {
+      // The opening fence arrives while `inCode` is still false, so the reserve
+      // has to look at the fence state this line produces, not the one it found.
+      const text = 'a'.repeat(3991) + '\n```js\n' + 'z'.repeat(500) + '\n```';
+      const chunks = splitChunks(text);
+      chunks.forEach((chunk) => {
+        expect(chunk.length).toBeLessThanOrEqual(4000);
+      });
+    });
+
+    it('keeps every code character when splitting near the limit', () => {
+      // Passes both before and after the fence-reserve fix, on purpose: the
+      // chunks were oversized, not lossy. It pins the other half of the
+      // contract so shrinking a chunk can never be achieved by dropping code.
+      const body = 'x'.repeat(3993);
+      const chunks = splitChunks('```\n' + body + '\n```');
+      const recovered = chunks
+        .join('\n')
+        .split('\n')
+        .filter((l) => !l.startsWith('```'))
+        .join('');
+      expect(recovered).toBe(body);
+    });
   });
 
   describe('buildCardContent table splitting', () => {

--- a/packages/channels/feishu/src/markdown.ts
+++ b/packages/channels/feishu/src/markdown.ts
@@ -219,8 +219,16 @@ export function splitChunks(text: string): string[] {
   for (const line of lines) {
     const fenceCount = (line.match(/```/g) || []).length;
 
+    // Whether the buffer sits inside a code block once this line is part of it.
+    // The closing-fence reserve has to be based on this rather than on `inCode`,
+    // which still describes the buffer as it was before the line was seen: a
+    // line that opens a fence leaves the buffer needing a closing fence it was
+    // charged nothing for, and one that closes a fence is charged for a fence it
+    // no longer needs.
+    const willBeInCode = fenceCount % 2 === 1 ? !inCode : inCode;
+
     // Reserve space for closing fence when inside a code block
-    const reserve = inCode ? fenceLine.length + 1 : 0;
+    const reserve = willBeInCode ? fenceLine.length + 1 : 0;
     if (
       buf.length + line.length + 1 + reserve > CHUNK_LIMIT &&
       buf.length > 0
@@ -234,8 +242,16 @@ export function splitChunks(text: string): string[] {
 
     buf += (buf ? '\n' : '') + line;
 
-    // Hard-split oversized lines that exceed the limit on their own
-    while (buf.length > CHUNK_LIMIT) {
+    // Hard-split oversized lines that exceed the limit on their own.
+    //
+    // A buffer inside a code block has `\n``` ` appended to it when it is
+    // flushed above, so the space available to it is the limit minus that
+    // closing fence. Testing `buf.length > CHUNK_LIMIT` ignored the fence, so a
+    // code line that left the buffer within three characters of the limit
+    // passed this loop untouched and was then flushed at CHUNK_LIMIT + 1, over
+    // the very limit this function exists to enforce.
+    const budget = willBeInCode ? CHUNK_LIMIT - '\n```'.length : CHUNK_LIMIT;
+    while (buf.length > budget) {
       const maxSlice = inCode ? CHUNK_LIMIT - '\n```'.length - 1 : CHUNK_LIMIT;
       let piece = buf.slice(0, maxSlice);
       buf = buf.slice(maxSlice);


### PR DESCRIPTION
## What this PR does

`splitChunks` reserves room for the closing fence it appends when a chunk ends inside a code block, but it decides how much to reserve from the fence state as it was *before* the current line was examined. Two paths escape that reserve: a line that **opens** a fence is charged nothing for the closing fence it has just made necessary, and the hard-split loop that breaks up oversized lines compares against the raw limit with no reserve at all. Both emit chunks longer than `CHUNK_LIMIT`. This computes the fence state the line *produces* and uses it in both places.

## Why it's needed

The function's contract is stated in its own doc comment — "Split long text into chunks that fit within Feishu's message size limit" — and it returns chunks that do not fit.

This is also the exact regression #7324 set out to catch. That PR tightened the long-text assertion from 4100 to the production 4000 because "that slack meant a regression producing oversized chunks could still pass". The assertion it tightened only covers the plain-text path, though; no test ever asserted the limit on the code-fence path, and that is where the overflow lives.

Two reproductions, both measured against the current code:

````
'```\n' + 'x'.repeat(3993) + '\n```'                         -> chunk of 4001 chars
'a'.repeat(3991) + '\n```js\n' + 'z'.repeat(500) + '\n```'   -> chunk of 4001 chars
````

They overshoot at the two different sites. In the first, the buffer reaches `CHUNK_LIMIT - 3` inside a code block; the hard-split loop tests `buf.length > CHUNK_LIMIT`, sees 3997, leaves it alone, and the flush then appends `\n``` ` to produce 4001. In the second, the opening fence line arrives while `inCode` is still `false`, so `reserve` is 0 and the line is accepted into the buffer; by the time the next line forces a flush the buffer is in a code block and gets a closing fence it was never charged for.

A sweep over 6662 inputs — fenced blocks swept character by character across the boundary, prose adjoining a fence, unterminated fences, and randomized mixed markdown — finds **21 inputs producing an over-limit chunk before this change and 0 after, with 0 inputs losing content in either state**.

On impact I want to be precise about what I did and did not verify. `CHUNK_LIMIT` is this repo's own declared bound on what it will post, and `FeishuAdapter.sendMessage` posts each chunk as its own card, so an over-limit chunk is a card sent above the size the code intends. I have not exercised Feishu's live API, so the exact server-side outcome is not something I can evidence here. What is verifiable locally is that the splitter breaks the invariant it exists to maintain, on the content type most likely to be long — code.

For context on why the two adapters differ: DingTalk's `splitChunks` has had this class of fix applied (#5299, #5204) and carries 13 tests covering these shapes. The Feishu copy never received them.

## Reviewer Test Plan

### How to verify

Same command #7324 used:

```
cd packages/channels/feishu && npx vitest run src/markdown.test.ts
```

Expected: 26 passed. Reverting `src/markdown.ts` alone (keeping the new tests) fails exactly the two new limit assertions:

```
before: Tests  2 failed | 24 passed (26)
after:  Tests  26 passed (26)
```

The full package suite is also green — `npx vitest run` in that directory gives 113 passed across 3 files, with no pre-existing test modified.

To reproduce independently without the tests, in a Node REPL against the built module:

````
splitChunks('```\n' + 'x'.repeat(3993) + '\n```').map((c) => c.length)
  before: [ 7, 4001, 7 ]
  after:  [ 7, 3999, 10 ]
````

### Evidence (Before & After)

N/A — not user-visible in the TUI; this is a message-splitting change verified by the test output above.

### Tested on

|     OS     |    Status     |
| :--------: | :-----------: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Unit tests only.

## Risk & Scope

- Main risk or tradeoff: a chunk that ends inside a code block is now cut up to four characters earlier, so a boundary can shift by a few characters. The fuzz above shows no content is lost or duplicated by the shift, and chunk counts are unchanged except where an over-limit chunk previously existed.
- Not validated / out of scope: **the tests added here will not run in CI**, and they have to be run with the command above. CI's unit-test step is `npm run test:ci --workspaces --if-present`, and `packages/channels/feishu` defines neither `test` nor `test:ci`, so the package is skipped whole. I'd rather flag that than let it look covered. Wiring it up takes more than a script entry: Feishu's `vitest.config.ts` also lacks the `@qwen-code/channel-base` → source alias that DingTalk's config carries, and since no build step runs ahead of the test job, the package cannot resolve `channel-base` from `dist` on a fresh checkout. I'm happy to send that as its own PR — `weixin` has both of the same gaps, and `qqbot` defines `test` but not `test:ci`, so its suite is skipped as well.
- Also not fixed here: `splitChunks` can still emit a chunk that is nothing but an opening and closing fence — an empty code block posted as its own Feishu card. That comes from a flush leaving the buffer holding only a reopened fence, which is a different defect with a different fix, so keeping it out leaves this change to the size invariant alone. Visible in the `[ 7, 3999, 10 ]` output above as the leading `7`.
- Breaking changes / migration notes: none.

## Linked Issues

None. Follows up #7324, which added the chunk-limit assertion this extends to the code-fence path.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

`splitChunks` 会为"块在代码块内部结束时追加的收尾围栏"预留空间，但它判断预留多少时，依据的是**处理当前行之前**的围栏状态。有两条路径因此绕开了预留：**开启**围栏的那一行，并没有为它刚刚导致的收尾围栏付出任何额度；而负责拆分超长行的硬拆分循环，则完全不带预留地直接和上限比较。两者都会产出长度超过 `CHUNK_LIMIT` 的分块。本 PR 改为计算该行**所产生**的围栏状态，并在这两处都使用它。

## 为什么需要

该函数的约定就写在它自己的文档注释里——"将长文本切分为符合飞书消息体积上限的分块"——而它返回了不符合上限的分块。

这也正是 #7324 想要防住的回归。那个 PR 把长文本断言从 4100 收紧到生产值 4000，理由是"这点余量意味着即使回归产生了超限分块，测试仍可能通过"。但它收紧的那条断言只覆盖了纯文本路径；代码围栏路径从来没有被断言过上限，而溢出恰恰就发生在那里。

两个复现，均针对当前代码实测：

````
'```\n' + 'x'.repeat(3993) + '\n```'                         -> 4001 字符的分块
'a'.repeat(3991) + '\n```js\n' + 'z'.repeat(500) + '\n```'   -> 4001 字符的分块
````

它们在两个不同的位置越界。第一例中，缓冲区在代码块内部达到了 `CHUNK_LIMIT - 3`；硬拆分循环检查的是 `buf.length > CHUNK_LIMIT`，看到 3997 便放行，随后 flush 追加 `\n``` `，得到 4001。第二例中，开启围栏的那一行到达时 `inCode` 仍为 `false`，于是 `reserve` 为 0，该行被收入缓冲区；等到下一行触发 flush 时，缓冲区已处于代码块内，会被追加一个它从未付过额度的收尾围栏。

对 6662 个输入的扫描——包括逐字符跨越边界的围栏代码块、与围栏相邻的正文、未闭合的围栏，以及随机混合 markdown——发现**改动前有 21 个输入产生超限分块，改动后为 0，且两种状态下都没有任何输入丢失内容**。

关于影响，我想把"验证了什么、没验证什么"说清楚。`CHUNK_LIMIT` 是本仓库自己声明的发送上限，而 `FeishuAdapter.sendMessage` 会把每个分块作为独立卡片发出，因此超限分块就是一张超过代码本意体积的卡片。我没有实际调用飞书线上 API，所以服务端的确切表现不是我能在此举证的。可以在本地验证的是：切分器破坏了它本该维护的不变量，而且恰恰发生在最容易变长的内容类型——代码——上。

关于两个适配器为何不同：DingTalk 的 `splitChunks` 已经收到过同类修复（#5299、#5204），并带有 13 个覆盖这些形态的测试。飞书这份副本从未同步过。

## 评审测试计划

### 如何验证

与 #7324 使用的命令相同：

```
cd packages/channels/feishu && npx vitest run src/markdown.test.ts
```

预期：26 个通过。仅回退 `src/markdown.ts`（保留新增测试），恰好是两条新增的上限断言失败：

```
改动前：Tests  2 failed | 24 passed (26)
改动后：Tests  26 passed (26)
```

整个包的测试同样为绿——在该目录执行 `npx vitest run` 得到 3 个文件共 113 个通过，且未修改任何既有测试。

若不借助测试独立复现，可在 Node REPL 中针对已构建模块执行：

````
splitChunks('```\n' + 'x'.repeat(3993) + '\n```').map((c) => c.length)
  改动前：[ 7, 4001, 7 ]
  改动后：[ 7, 3999, 10 ]
````

### 证据（改动前后对比）

N/A——在 TUI 中不可见；这是一处消息切分改动，由上面的测试输出验证。

### 测试环境

|     OS     |    Status     |
| :--------: | :-----------: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### 运行环境（可选）

仅单元测试。

## 风险与范围

- 主要风险或取舍：在代码块内部结束的分块，现在最多会提前四个字符被切开，因此边界可能移动几个字符。上面的模糊测试表明这一位移不会丢失或重复任何内容，并且除了原本存在超限分块的情形外，分块数量保持不变。
- 未验证／不在本次范围：**本 PR 新增的测试在 CI 中不会运行**，运行它们必须使用上面的命令。CI 的单元测试步骤是 `npm run test:ci --workspaces --if-present`，而 `packages/channels/feishu` 既没有定义 `test` 也没有定义 `test:ci`，因此整个包被整体跳过。与其让它看起来已被覆盖，我更愿意把这一点标出来。要把它接入 CI，仅加一条脚本还不够：飞书的 `vitest.config.ts` 同样缺少 DingTalk 配置中那条把 `@qwen-code/channel-base` 指向源码的 alias，而测试任务之前并没有构建步骤，因此在全新检出的环境下该包无法从 `dist` 解析 `channel-base`。我很乐意另开一个 PR 来处理——`weixin` 存在同样的两处缺口，而 `qqbot` 定义了 `test` 却没有 `test:ci`，它的测试同样被跳过。
- 同样不在本次修复范围：`splitChunks` 仍可能产出一个只包含开启与收尾围栏的分块——即作为独立飞书卡片发出的空代码块。它源于 flush 之后缓冲区只剩下一个重新开启的围栏，属于另一个缺陷、另一种修法，因此不纳入本次改动，好让这个 PR 只专注于体积不变量。在上面 `[ 7, 3999, 10 ]` 的输出中，它就是开头的那个 `7`。
- 破坏性变更／迁移说明：无。

## 关联 Issue

无。本 PR 承接 #7324，把它引入的分块上限断言扩展到代码围栏路径。

</details>
