### PR TITLE
fix(core): apply maxDepth to flat-format memory imports

### DIFF
--- a/packages/core/src/utils/memoryImportProcessor.test.ts
+++ b/packages/core/src/utils/memoryImportProcessor.test.ts
@@ -993,6 +993,66 @@ describe('memoryImportProcessor', () => {
       // The shallower re-expansion must not emit x.md a second time.
       expect(result.content.match(/XFILE/g)).toHaveLength(1);
     });
+
+    it('notifies once for a file a shallower route re-expands', async () => {
+      const projectRoot = testPath('test', 'project');
+      const basePath = testPath(projectRoot, 'src');
+
+      mockedFs.access.mockReset();
+      mockedFs.readFile.mockReset();
+      mockedFs.access.mockResolvedValue(undefined);
+      mockedFs.readFile.mockImplementation(async (file: unknown) => {
+        switch (path.basename(String(file))) {
+          case 'deep0.md':
+            return 'DEEP0 @./deep1.md';
+          case 'deep1.md':
+            return 'DEEP1 @./x.md';
+          case 'x.md':
+            return 'XFILE @./y.md';
+          case 'y.md':
+            return 'YFILE';
+          default:
+            return '';
+        }
+      });
+
+      const importedFiles: Array<{
+        filePath: string;
+        parentFilePath: string;
+      }> = [];
+
+      // Same shape as the re-expansion case above: the deep route reaches x.md
+      // at the limit, then the root's own direct import re-expands it.
+      await processImports(
+        'Root @./x.md @./deep0.md',
+        basePath,
+        { processedFiles: new Set(), maxDepth: 3, currentDepth: 0 },
+        projectRoot,
+        'flat',
+        {
+          onFileImported: (event) => {
+            importedFiles.push(event);
+          },
+        },
+      );
+
+      // The notification says "this instruction file was loaded", and x.md is
+      // emitted into the flat output exactly once however many routes reach
+      // it, so it must be announced exactly once too. Nothing downstream
+      // de-duplicates: onFileImported feeds notifyInstructionsLoaded in
+      // memoryDiscovery, which forwards every call straight to the consumer.
+      const announced = importedFiles.map((event) =>
+        path.basename(event.filePath),
+      );
+      expect(announced.filter((name) => name === 'x.md')).toHaveLength(1);
+      // Every other file is announced once as well, and each exactly once.
+      expect([...announced].sort()).toEqual([
+        'deep0.md',
+        'deep1.md',
+        'x.md',
+        'y.md',
+      ]);
+    });
   });
 
   describe('validateImportPath', () => {

--- a/packages/core/src/utils/memoryImportProcessor.test.ts
+++ b/packages/core/src/utils/memoryImportProcessor.test.ts
@@ -935,6 +935,37 @@ describe('memoryImportProcessor', () => {
       );
     });
 
+    it('spends the same budget in both formats when depth is already partly used', async () => {
+      const projectRoot = testPath('test', 'project');
+      const basePath = testPath(projectRoot, 'src');
+
+      // Entering with 2 of 3 levels already spent leaves one level of budget.
+      // The flat path used to start its own counter at 0 and hand out the
+      // full limit again, so it expanded two levels further than tree mode.
+      mockChain(8);
+      const flat = await processImports(
+        'Root @./chain0.md',
+        basePath,
+        { processedFiles: new Set(), maxDepth: 3, currentDepth: 2 },
+        projectRoot,
+        'flat',
+      );
+
+      mockChain(8);
+      const tree = await processImports(
+        'Root @./chain0.md',
+        basePath,
+        { processedFiles: new Set(), maxDepth: 3, currentDepth: 2 },
+        projectRoot,
+        'tree',
+      );
+
+      expect(chainMarkers(flat.content, 8)).toEqual(
+        chainMarkers(tree.content, 8),
+      );
+      expect(chainMarkers(flat.content, 8)).toEqual([0]);
+    });
+
     it('fully expands a flat import chain that stays within maxDepth', async () => {
       const projectRoot = testPath('test', 'project');
       const basePath = testPath(projectRoot, 'src');

--- a/packages/core/src/utils/memoryImportProcessor.test.ts
+++ b/packages/core/src/utils/memoryImportProcessor.test.ts
@@ -953,6 +953,46 @@ describe('memoryImportProcessor', () => {
       // truncating chains that were always allowed.
       expect(chainMarkers(result.content, 3)).toEqual([0, 1, 2]);
     });
+
+    it('re-expands a file first reached by a route at the depth limit', async () => {
+      const projectRoot = testPath('test', 'project');
+      const basePath = testPath(projectRoot, 'src');
+
+      mockedFs.access.mockReset();
+      mockedFs.readFile.mockReset();
+      mockedFs.access.mockResolvedValue(undefined);
+      mockedFs.readFile.mockImplementation(async (file: unknown) => {
+        switch (path.basename(String(file))) {
+          case 'deep0.md':
+            return 'DEEP0 @./deep1.md';
+          case 'deep1.md':
+            return 'DEEP1 @./x.md';
+          case 'x.md':
+            return 'XFILE @./y.md';
+          case 'y.md':
+            return 'YFILE';
+          default:
+            return '';
+        }
+      });
+
+      // deep0.md is listed last, so the reverse iteration takes the deep route
+      // to x.md first and lands on it exactly at the limit, truncating it.
+      const result = await processImports(
+        'Root @./x.md @./deep0.md',
+        basePath,
+        { processedFiles: new Set(), maxDepth: 3, currentDepth: 0 },
+        projectRoot,
+        'flat',
+      );
+
+      // x.md is also a direct import of the root at depth 1, so y.md sits well
+      // inside the limit and has to survive the deep route having got there
+      // first. Tracking a bare "seen" set instead of the depth dropped it.
+      expect(result.content).toContain('YFILE');
+      // The shallower re-expansion must not emit x.md a second time.
+      expect(result.content.match(/XFILE/g)).toHaveLength(1);
+    });
   });
 
   describe('validateImportPath', () => {

--- a/packages/core/src/utils/memoryImportProcessor.test.ts
+++ b/packages/core/src/utils/memoryImportProcessor.test.ts
@@ -871,6 +871,88 @@ describe('memoryImportProcessor', () => {
       expect(result.content).toContain('A @./b.md');
       expect(result.content).toContain('B content');
     });
+
+    // chain0 -> chain1 -> ... -> chain7, each importing the next.
+    const mockChain = (length: number) => {
+      mockedFs.access.mockReset();
+      mockedFs.readFile.mockReset();
+      mockedFs.access.mockResolvedValue(undefined);
+      mockedFs.readFile.mockImplementation(async (file: unknown) => {
+        const index = Number(
+          path.basename(String(file), '.md').replace('chain', ''),
+        );
+        return index < length - 1
+          ? `CHAIN${index} @./chain${index + 1}.md`
+          : `CHAIN${index}`;
+      });
+    };
+
+    const chainMarkers = (content: string, length: number) =>
+      [...Array(length).keys()].filter((i) => content.includes(`CHAIN${i}`));
+
+    it('stops expanding a flat import chain at maxDepth', async () => {
+      const projectRoot = testPath('test', 'project');
+      const basePath = testPath(projectRoot, 'src');
+      mockChain(8);
+
+      const result = await processImports(
+        'Root @./chain0.md',
+        basePath,
+        { processedFiles: new Set(), maxDepth: 3, currentDepth: 0 },
+        projectRoot,
+        'flat',
+      );
+
+      // The root is depth 0, so chain0..chain2 sit at depths 1..3 and chain2 is
+      // the last file allowed to expand its own imports.
+      expect(chainMarkers(result.content, 8)).toEqual([0, 1, 2]);
+    });
+
+    it('applies the same depth limit in flat and tree formats', async () => {
+      const projectRoot = testPath('test', 'project');
+      const basePath = testPath(projectRoot, 'src');
+
+      mockChain(8);
+      const flat = await processImports(
+        'Root @./chain0.md',
+        basePath,
+        { processedFiles: new Set(), maxDepth: 3, currentDepth: 0 },
+        projectRoot,
+        'flat',
+      );
+
+      mockChain(8);
+      const tree = await processImports(
+        'Root @./chain0.md',
+        basePath,
+        { processedFiles: new Set(), maxDepth: 3, currentDepth: 0 },
+        projectRoot,
+        'tree',
+      );
+
+      expect(chainMarkers(flat.content, 8)).toEqual(
+        chainMarkers(tree.content, 8),
+      );
+    });
+
+    it('fully expands a flat import chain that stays within maxDepth', async () => {
+      const projectRoot = testPath('test', 'project');
+      const basePath = testPath(projectRoot, 'src');
+      mockChain(3);
+
+      const result = await processImports(
+        'Root @./chain0.md',
+        basePath,
+        { processedFiles: new Set(), maxDepth: 5, currentDepth: 0 },
+        projectRoot,
+        'flat',
+      );
+
+      // Passes both before and after the depth guard, on purpose: it pins the
+      // other half of the contract so the limit can never be enforced by
+      // truncating chains that were always allowed.
+      expect(chainMarkers(result.content, 3)).toEqual([0, 1, 2]);
+    });
   });
 
   describe('validateImportPath', () => {

--- a/packages/core/src/utils/memoryImportProcessor.ts
+++ b/packages/core/src/utils/memoryImportProcessor.ts
@@ -327,10 +327,20 @@ export async function processImports(
             normalizedFullPath,
             depth + 1,
           );
-          await notifyFileImported(options, {
-            filePath: normalizedFullPath,
-            parentFilePath: normalizedPath,
-          });
+          // Announce a file the first time it is reached, matching the single
+          // copy of it in the flat output. A file first met down a truncated
+          // route is re-expanded when a shallower route reaches it, and that
+          // second pass must not announce it again: nothing downstream
+          // de-duplicates, so the consumer would see one loaded file reported
+          // twice under two different parents. `childSeenAt` is read before
+          // the recursion above, which is what makes it a first-visit test --
+          // afterwards the entry always reads `depth + 1`.
+          if (childSeenAt === undefined) {
+            await notifyFileImported(options, {
+              filePath: normalizedFullPath,
+              parentFilePath: normalizedPath,
+            });
+          }
         } catch (error) {
           // If file doesn't exist, silently skip this import (it's not a real import)
           // Only log warnings for other types of errors

--- a/packages/core/src/utils/memoryImportProcessor.ts
+++ b/packages/core/src/utils/memoryImportProcessor.ts
@@ -275,14 +275,6 @@ export async function processImports(
       // Stop descending once the depth limit is reached, matching what the tree
       // path does at the top of processImports: the file sitting at the limit is
       // still included, its own imports are simply not expanded.
-      //
-      // `depth` was threaded through every recursive call below and incremented
-      // each time, but never compared against anything, so flat mode expanded an
-      // import chain of any length while tree mode stopped at maxDepth. Given
-      // maxDepth 3 and a chain of twelve files, tree emitted four and flat
-      // emitted all twelve -- the limit that exists to bound how much a QWEN.md
-      // can pull into context did nothing in the one format that concatenates
-      // every imported file whole.
       if (depth >= importState.maxDepth) {
         logger.warn(
           `Maximum import depth (${importState.maxDepth}) reached. Stopping import processing.`,

--- a/packages/core/src/utils/memoryImportProcessor.ts
+++ b/packages/core/src/utils/memoryImportProcessor.ts
@@ -358,7 +358,12 @@ export async function processImports(
     const rootPath = path.normalize(
       importState.currentFile || path.resolve(basePath),
     );
-    await processFlat(content, basePath, rootPath, 0);
+    // Start from the depth already spent rather than 0, so the two formats
+    // budget from the same origin. Every caller today enters flat mode at
+    // depth 0, which makes this a no-op for them, but a caller arriving with
+    // budget already spent would otherwise get the full limit over again in
+    // flat mode while tree mode gave it only what was left.
+    await processFlat(content, basePath, rootPath, importState.currentDepth);
 
     // Concatenate all unique files in order, Claude-style
     const flatContent = flatFiles

--- a/packages/core/src/utils/memoryImportProcessor.ts
+++ b/packages/core/src/utils/memoryImportProcessor.ts
@@ -261,6 +261,24 @@ export async function processImports(
       // Add this file to the flat list
       flatFiles.push({ path: normalizedPath, content: fileContent });
 
+      // Stop descending once the depth limit is reached, matching what the tree
+      // path does at the top of processImports: the file sitting at the limit is
+      // still included, its own imports are simply not expanded.
+      //
+      // `depth` was threaded through every recursive call below and incremented
+      // each time, but never compared against anything, so flat mode expanded an
+      // import chain of any length while tree mode stopped at maxDepth. Given
+      // maxDepth 3 and a chain of twelve files, tree emitted four and flat
+      // emitted all twelve -- the limit that exists to bound how much a QWEN.md
+      // can pull into context did nothing in the one format that concatenates
+      // every imported file whole.
+      if (depth >= importState.maxDepth) {
+        logger.warn(
+          `Maximum import depth (${importState.maxDepth}) reached. Stopping import processing.`,
+        );
+        return;
+      }
+
       // Find imports in this file
       const codeRegions = findCodeRegions(fileContent);
       const imports = findImports(fileContent);

--- a/packages/core/src/utils/memoryImportProcessor.ts
+++ b/packages/core/src/utils/memoryImportProcessor.ts
@@ -237,7 +237,8 @@ export async function processImports(
 
   // --- FLAT FORMAT LOGIC ---
   if (importFormat === 'flat') {
-    // Use a queue to process files in order of first encounter, and a set to avoid duplicates
+    // Collect files in order of first encounter, deduplicated by the depth map
+    // below rather than by a plain set.
     const flatFiles: Array<{ path: string; content: string }> = [];
     // Track the shallowest depth each file has been expanded at, rather than a
     // plain "seen" set. Once a depth limit exists the two differ: a file first
@@ -277,7 +278,7 @@ export async function processImports(
       // still included, its own imports are simply not expanded.
       if (depth >= importState.maxDepth) {
         logger.warn(
-          `Maximum import depth (${importState.maxDepth}) reached. Stopping import processing.`,
+          `Maximum import depth (${importState.maxDepth}) reached at ${normalizedPath}. Stopping import processing.`,
         );
         return;
       }

--- a/packages/core/src/utils/memoryImportProcessor.ts
+++ b/packages/core/src/utils/memoryImportProcessor.ts
@@ -239,8 +239,14 @@ export async function processImports(
   if (importFormat === 'flat') {
     // Use a queue to process files in order of first encounter, and a set to avoid duplicates
     const flatFiles: Array<{ path: string; content: string }> = [];
-    // Track processed files across the entire operation
-    const processedFiles = new Set<string>();
+    // Track the shallowest depth each file has been expanded at, rather than a
+    // plain "seen" set. Once a depth limit exists the two differ: a file first
+    // reached down a long chain is truncated there, and a later, shallower route
+    // to that same file -- comfortably inside the limit -- would be dismissed as
+    // already seen, so its own imports would never be expanded. Recording the
+    // depth lets the shallower route re-expand it while the file itself is still
+    // emitted only once.
+    const expandedAt = new Map<string, number>();
 
     // Helper to recursively process imports
     async function processFlat(
@@ -252,14 +258,19 @@ export async function processImports(
       // Normalize the file path to ensure consistent comparison
       const normalizedPath = path.normalize(filePath);
 
-      // Skip if already processed
-      if (processedFiles.has(normalizedPath)) return;
+      // Already expanded by an equally shallow or shallower route, so this one
+      // cannot reach anything new. This is also what stops cycles: a repeat
+      // visit always arrives at a greater depth.
+      const seenAt = expandedAt.get(normalizedPath);
+      if (seenAt !== undefined && seenAt <= depth) return;
 
-      // Mark as processed before processing to prevent infinite recursion
-      processedFiles.add(normalizedPath);
+      // Add this file to the flat list, once, however many routes reach it.
+      if (seenAt === undefined) {
+        flatFiles.push({ path: normalizedPath, content: fileContent });
+      }
 
-      // Add this file to the flat list
-      flatFiles.push({ path: normalizedPath, content: fileContent });
+      // Record before recursing to prevent infinite recursion.
+      expandedAt.set(normalizedPath, depth);
 
       // Stop descending once the depth limit is reached, matching what the tree
       // path does at the top of processImports: the file sitting at the limit is
@@ -307,8 +318,10 @@ export async function processImports(
         const fullPath = path.resolve(fileBasePath, importPath);
         const normalizedFullPath = path.normalize(fullPath);
 
-        // Skip if already processed
-        if (processedFiles.has(normalizedFullPath)) continue;
+        // Skip if already expanded from here or shallower, so the file is not
+        // re-read when the recursion would immediately return anyway.
+        const childSeenAt = expandedAt.get(normalizedFullPath);
+        if (childSeenAt !== undefined && childSeenAt <= depth + 1) continue;
 
         try {
           await fs.access(fullPath);


### PR DESCRIPTION
## What this PR does

`processImports` enforces `maxDepth` on the tree path but not on the flat one. Its inner `processFlat` helper takes a `depth` parameter and increments it on every recursive call, yet never compares it to anything — the value is threaded all the way down purely to be discarded. This adds the missing check, matching what the tree path already does: the file sitting at the limit is still included, its own imports are simply not expanded.

## Why it's needed

The same import chain, the same `maxDepth`, and the two formats disagree — one honours the limit and the other ignores it entirely.

Measured with real files on disk (twelve files, `chain0` importing `chain1` importing `chain2`, and so on, `maxDepth: 3`):

```
format=tree  ->  reached depth 3   (4 of 12 files)
format=flat  ->  reached depth 11  (12 of 12 files)
```

`maxDepth` exists to bound how much a `QWEN.md` can pull into context, and flat is the format where that matters most: tree mode inlines imports into a nested document, while flat mode concatenates every file whole under its own `--- File: … ---` banner. The one format that duplicates each file in full is the one where the bound did nothing.

The dead `depth` parameter is what makes the intent unambiguous. It is accepted, incremented at each level, and never read; the only reason to thread a depth through a recursion is to limit it. `memoryDiscovery.ts` hardcodes `maxDepth: 5`, so the trigger is an import chain more than five levels deep under `context.importFormat: "flat"`. That is not a typical layout — but a depth guard is only ever load-bearing in the atypical case, which is the reason it was written.

After this change the two formats return the same set of files for the same input, which is the property the new test asserts.

## Reviewer Test Plan

### How to verify

```
npx vitest run --root packages/core src/utils/memoryImportProcessor.test.ts
```

Expected: 34 passed. Reverting `src/utils/memoryImportProcessor.ts` alone, keeping the new tests, fails exactly the two depth assertions:

```
before: Tests  2 failed | 32 passed (34)
after:  Tests  34 passed (34)
```

All 31 pre-existing tests pass in both states; none were modified.

To confirm against real files rather than the mocked `fs` used by the suite, write `chain0.md` … `chain11.md` into a directory containing a `.git`, each importing the next with `@./chainN.md`, then call `processImports` with `maxDepth: 3` in each format and compare which files come back. Before this change flat returns all twelve and tree returns four; after, both return four.

### Evidence (Before & After)

N/A — not user-visible in the TUI; this is context-assembly behaviour verified by the test output above.

### Tested on

|     OS     |    Status     |
| :--------: | :-----------: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Unit tests only.

## Risk & Scope

- Main risk or tradeoff: a flat-format import chain deeper than `maxDepth` now stops expanding, so such a chain contributes fewer files to context than before. That is the intended effect and it matches tree-format behaviour for the same input; nothing changes for any chain within the limit, which the third new test pins.
- Not validated / out of scope: flat mode also emits sibling imports in reverse source order — `@a.md @b.md @c.md` comes back as c, b, a — because the import loop iterates backwards with a comment about handling indices correctly that applies to the tree path's string splicing, not here. It is a separate defect with a separate fix and I have left it alone rather than fold it in.
- Breaking changes / migration notes: none. `maxDepth` is not user-configurable; `memoryDiscovery.ts` passes 5.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

`processImports` 在 tree 路径上执行了 `maxDepth`，但在 flat 路径上没有。其内部的 `processFlat` 辅助函数接收一个 `depth` 参数，并在每次递归调用时递增它，却从不把它与任何值比较——这个值一路向下传递，只是为了被丢弃。本 PR 补上了缺失的检查，并与 tree 路径的既有行为保持一致：位于上限处的文件仍会被收录，只是不再展开它自己的 import。

## 为什么需要

同样的 import 链、同样的 `maxDepth`，两种格式的结果却不一致——一种遵守上限，另一种完全无视。

以磁盘上的真实文件实测（十二个文件，`chain0` 引入 `chain1`，`chain1` 引入 `chain2`，依此类推，`maxDepth: 3`）：

```
format=tree  ->  到达深度 3    （12 个文件中的 4 个）
format=flat  ->  到达深度 11   （12 个文件全部）
```

`maxDepth` 的存在是为了限制一个 `QWEN.md` 能往上下文里拉进多少内容，而 flat 恰恰是最需要这个限制的格式：tree 模式把 import 内联进一个嵌套文档，flat 模式则把每个文件完整地拼接在各自的 `--- File: … ---` 标题之下。唯一会把每个文件完整复制一遍的格式，正是该限制失效的那一个。

那个无人使用的 `depth` 参数让意图变得毫无歧义。它被接收、在每一层递增，却从未被读取；而在递归中传递深度的唯一理由，就是为了限制它。`memoryDiscovery.ts` 硬编码了 `maxDepth: 5`，因此触发条件是在 `context.importFormat: "flat"` 之下存在超过五层的 import 链。这并非常见布局——但深度保护本来就只在非常规情形下才起作用，这正是它被写出来的理由。

改动之后，两种格式对同一输入会返回相同的文件集合，这也正是新增测试所断言的性质。

## 评审测试计划

### 如何验证

```
npx vitest run --root packages/core src/utils/memoryImportProcessor.test.ts
```

预期：34 个通过。仅回退 `src/utils/memoryImportProcessor.ts`（保留新增测试），恰好是两条深度断言失败：

```
改动前：Tests  2 failed | 32 passed (34)
改动后：Tests  34 passed (34)
```

31 个既有测试在两种状态下都通过，且未修改任何一个。

若想脱离测试套件所用的 mock `fs`、直接针对真实文件确认：在一个包含 `.git` 的目录里写入 `chain0.md` … `chain11.md`，每个用 `@./chainN.md` 引入下一个，然后分别以两种格式、`maxDepth: 3` 调用 `processImports`，比较返回的文件。改动前 flat 返回全部十二个而 tree 返回四个；改动后两者都返回四个。

### 证据（改动前后对比）

N/A——在 TUI 中不可见；这是上下文组装行为的改动，由上面的测试输出验证。

### 测试环境

|     OS     |    Status     |
| :--------: | :-----------: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### 运行环境（可选）

仅单元测试。

## 风险与范围

- 主要风险或取舍：深度超过 `maxDepth` 的 flat 格式 import 链现在会停止展开，因此这类链向上下文贡献的文件会比以前少。这正是预期效果，并且与相同输入下的 tree 格式行为一致；对任何在限制之内的链都没有变化，第三个新增测试正是为此把关。
- 未验证／不在本次范围：flat 模式还会以与源文件相反的顺序输出同级 import——`@a.md @b.md @c.md` 会变成 c、b、a——原因是 import 循环反向迭代，而那句"为正确处理索引"的注释适用于 tree 路径的字符串拼接，在这里并不成立。它是另一个缺陷、另一种修法，我把它单独留出而没有并进来。
- 破坏性变更／迁移说明：无。`maxDepth` 不可由用户配置；`memoryDiscovery.ts` 传入的是 5。

## 关联 Issue

无。

</details>
