### PR TITLE
fix(review): give the review retry the remaining time budget

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -827,25 +827,25 @@ jobs:
           }
 
           # Retry budget: all attempts SHARE QWEN_TIMEOUT, so two tries can never
-          # exceed the single-review budget (nor the job timeout). The first
-          # attempt gets the whole remaining budget; a retry is capped at 5 min —
-          # a transient that has cleared succeeds fast, and a still-failing retry
-          # can't burn another hour. Retry only a `retryable` outcome, only once,
-          # and only with real budget left.
+          # exceed the single-review budget (nor the job timeout), and that
+          # shared budget is the only thing that needs to bound them. A retry
+          # re-runs the whole review from scratch rather than resuming the failed
+          # one, so on a large PR it spends minutes re-fetching, re-chunking and
+          # re-launching agents before the first finding exists — a short retry
+          # cap makes the retry die on the clock instead of clearing the
+          # transient it was meant to clear. Every attempt therefore gets the
+          # whole remaining budget. Retry only a `retryable` outcome, only once,
+          # and only when enough budget is left for the retry to plausibly
+          # finish; below that, report the transient failure so the next run
+          # starts over with a full budget.
           BUDGET_SECONDS=$(( QWEN_TIMEOUT * 60 ))
-          RETRY_CAP_SECONDS=300
           RETRY_BACKOFF_SECONDS=60
+          RETRY_MIN_SECONDS=600
           MAX_ATTEMPTS=2
           START_TS="$(date +%s)"
           attempt=1
           while :; do
-            remaining=$(( BUDGET_SECONDS - ($(date +%s) - START_TS) ))
-            if [ "$attempt" -eq 1 ]; then
-              attempt_timeout="$remaining"
-            else
-              attempt_timeout="$RETRY_CAP_SECONDS"
-              [ "$remaining" -lt "$attempt_timeout" ] && attempt_timeout="$remaining"
-            fi
+            attempt_timeout=$(( BUDGET_SECONDS - ($(date +%s) - START_TS) ))
             if [ "$attempt_timeout" -lt 30 ]; then
               fail "${REASON:-Qwen review ran out of time budget before it could complete.}" 1 "$KIND"
             fi
@@ -854,7 +854,7 @@ jobs:
               break
             fi
             if [ "$OUTCOME" = "retryable" ] && [ "$attempt" -lt "$MAX_ATTEMPTS" ] \
-              && [ "$(( BUDGET_SECONDS - ($(date +%s) - START_TS) ))" -gt "$(( RETRY_BACKOFF_SECONDS + RETRY_CAP_SECONDS ))" ]; then
+              && [ "$(( BUDGET_SECONDS - ($(date +%s) - START_TS) ))" -gt "$(( RETRY_BACKOFF_SECONDS + RETRY_MIN_SECONDS ))" ]; then
               echo "::warning::Transient review failure (${REASON}) — retrying once after ${RETRY_BACKOFF_SECONDS}s."
               sleep "$RETRY_BACKOFF_SECONDS"
               attempt=$(( attempt + 1 ))

--- a/scripts/tests/qwen-pr-review-workflow.test.js
+++ b/scripts/tests/qwen-pr-review-workflow.test.js
@@ -54,17 +54,21 @@ function runScenario(scenario, { timeoutMinutes = 180 } = {}) {
   try {
     const bin = join(dir, 'bin');
     const attemptFile = join(dir, 'attempts');
+    const durationFile = join(dir, 'durations');
     writeFileSync(attemptFile, '');
+    writeFileSync(durationFile, '');
     const write = (name, body) => {
       const p = join(bin, name);
       writeFileSync(p, body);
       chmodSync(p, 0o755);
     };
     execFileSync('mkdir', ['-p', bin]);
-    // timeout: drop `--kill-after=Xs` and the duration, exec the rest.
+    // timeout: record the per-attempt duration (`$2`, e.g. `10800s`) so tests
+    // can assert the budget each attempt was given, then drop
+    // `--kill-after=Xs` and that duration and exec the rest.
     write(
       'timeout',
-      '#!/bin/bash\nif [ "${SCENARIO:-}" = "timeout_kill" ]; then exit 124; fi\nshift\nshift\nexec "$@"\n',
+      '#!/bin/bash\necho "$2" >> "$DUR"\nif [ "${SCENARIO:-}" = "timeout_kill" ]; then exit 124; fi\nshift\nshift\nexec "$@"\n',
     );
     write('sleep', '#!/bin/bash\nexit 0\n');
     write(
@@ -113,6 +117,7 @@ function runScenario(scenario, { timeoutMinutes = 180 } = {}) {
           PATH: `${bin}:${process.env.PATH}`,
           SCENARIO: scenario,
           ATT: attemptFile,
+          DUR: durationFile,
         },
       });
     } catch (e) {
@@ -124,7 +129,15 @@ function runScenario(scenario, { timeoutMinutes = 180 } = {}) {
         .split('\n')
         .filter((l) => l.startsWith('OK ') || l.startsWith('FAIL '))
         .pop() ?? stdout.trim();
-    return { line, attempts: Number(readFileSync(attemptFile, 'utf8').trim()) };
+    const durations = readFileSync(durationFile, 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .map((d) => Number.parseInt(d, 10));
+    return {
+      line,
+      attempts: Number(readFileSync(attemptFile, 'utf8').trim()),
+      durations,
+    };
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -261,6 +274,40 @@ describe('qwen pr review transient retry', () => {
     expect(r.line).toContain('FAIL');
     expect(r.line).toContain('ran out of time budget');
     expect(r.attempts).toBe(0);
+  });
+
+  it('gives the retry the remaining budget, not a fixed cap', () => {
+    // A retry re-runs the whole review from scratch, so the 300s cap this
+    // replaced killed it mid-preamble on any large PR and reported a timeout.
+    // The stub timeout used to discard the duration argument, so no test
+    // observed what each attempt was actually given: reintroducing a cap here
+    // would leave the suite green while making every retry unusable again.
+    const r = runScenario('transient_then_success');
+    expect(r.attempts).toBe(2);
+    expect(r.durations).toHaveLength(2);
+    expect(r.durations[0]).toBeGreaterThan(10_000); // ~10800s == 180min budget
+    expect(r.durations[1]).toBeGreaterThan(300); // the cap this replaced
+    expect(r.durations[1]).toBeGreaterThan(10_000); // the rest of the budget
+    // Attempts share one budget, so the retry can never exceed what is left.
+    expect(r.durations[1]).toBeLessThanOrEqual(r.durations[0]);
+  });
+
+  it('does NOT start a retry that the remaining budget cannot finish', () => {
+    // 8min budget: over the old 360s gate, under the current 660s one. Pins
+    // the gate — dropping RETRY_MIN_SECONDS back to the old cap would retry
+    // here into a review that cannot complete.
+    const r = runScenario('transient_then_success', { timeoutMinutes: 8 });
+    expect(r.line).toContain('FAIL');
+    expect(r.line).not.toContain('kind=[timeout]'); // reports the transient
+    expect(r.attempts).toBe(1);
+  });
+
+  it('still retries once the remaining budget clears the gate', () => {
+    // 12min budget, just over the 660s gate: the other side of the boundary,
+    // so a RETRY_MIN_SECONDS raised too far cannot pass unnoticed.
+    const r = runScenario('transient_then_success', { timeoutMinutes: 12 });
+    expect(r.line).toContain('OK outcome=success');
+    expect(r.attempts).toBe(2);
   });
 
   it('keeps the fallback comment quota-aware', () => {


### PR DESCRIPTION
## What this PR does

Every attempt of the Qwen PR review now gets whatever is left of the shared review time budget, instead of the first attempt getting the whole budget and the retry getting a hardcoded five minutes. The retry is still allowed only once, only after a transient failure, and only when enough budget remains for it to plausibly finish; below that threshold the transient failure is reported so the next run starts over with a full budget.

## Why it's needed

The retry path was unusable for anything but a trivial PR. It does not resume the review that failed — it re-runs the whole thing from scratch, so it has to re-fetch the PR worktree, re-chunk the diff and re-launch every review agent before it can produce a single finding. On a large PR that preamble alone takes longer than five minutes, so the retry was killed on the clock every time and the run was reported as a timeout.

The run on #7821 is a clean example. The first attempt used the full budget, got as far as deciding it needed 26 agents for an 18-chunk diff, and then the model connection dropped with a read ECONNRESET about four and three quarter minutes in. That was correctly classified as transient and retried. The retry got five minutes, reached the same point — all agents constructed, pipeline about to launch — and was terminated. The reviewer then saw "review timed out after 300 seconds (of the 180-minute budget)", which reads like a misconfiguration, together with advice to re-run with a longer timeout. That advice could not have helped: the requested timeout never reached the retry cap, so a longer timeout would have produced exactly the same five-minute retry.

All attempts already share the single-review budget, which is what keeps two tries from exceeding the configured timeout or the job timeout. That shared budget is the only bound the retry needs, so the separate cap only ever subtracted capability. Removing it also makes the timeout message and its recovery advice consistent again: a timeout now means the review genuinely used the time it was given, and asking for more time genuinely gives it more.

## Reviewer Test Plan

### How to verify

- Confirm the observed failure first: the second attempt of the review run linked below fails with a 300-second timeout even though the run was given 180 minutes, and the step log shows the first attempt ending in an ECONNRESET API error followed by a 60-second backoff.
- Run the review workflow test suite. It extracts the real retry loop out of the workflow and drives it with a stubbed review command, so the assertions run against the shipped bash rather than a paraphrase of it.
- Check that the retry now receives the remaining budget rather than a fixed five minutes, and that it can never receive more than the first attempt had — the two attempts share one budget.
- Check the retry gate from both sides. A budget above the threshold must still retry; one below it must not start a retry at all, and must report the transient failure rather than a timeout.
- Check the non-retry outcomes are unchanged: a genuine timeout on the first attempt is never retried, an exhausted model quota is never retried and still reports as a quota failure, a second transient failure does not produce a third attempt, and a successful first attempt is unaffected.
- To confirm the tests are not vacuous, put the old capped logic back and re-run them: the two tests covering the cap and the gate must fail, and raising the gate threshold far too high must fail the test guarding the other side of the boundary.

### Evidence (Before & After)

No screenshots — this is a CI workflow timing change with no user-visible interface.

Before, from the failing run: the first attempt ends with an API error after roughly 285 seconds, and the second is cut off at exactly 300 seconds with the message that the review timed out after 300 seconds of a 180-minute budget.

After: the retry receives the remainder of the budget and completes normally. Replaying the new tests against the previous logic reproduces the bug as an assertion failure — the retry is measured at exactly the old cap, and the gate lets through a retry that cannot finish.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ CI only |
| 🪟 Windows | ⚠️ CI only |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Node.js 22 workspace on Linux. Workflow YAML parsed and linted, the review step's shell script syntax-checked, and the full workflow test suite green, including three cases added here for the retry budget and gate.

## Risk & Scope

- Main risk or tradeoff: a retry that hangs can now consume the rest of the review budget rather than at most five minutes. This is bounded by the same shared budget and job timeout that already bound a single attempt, so the worst case is unchanged; the tradeoff is that a doomed retry occupies a runner longer than before, in exchange for retries that can actually succeed.
- Not validated / out of scope: end-to-end behavior against the live model API, which is what makes these failures transient in the first place. The classification of which failures are retryable is unchanged, and the tests stub the review command rather than calling a model.
- Breaking changes / migration notes: none. The requested timeout, its bounds, the single-retry policy and the backoff are all unchanged.

## Linked Issues

Observed on the review run for #7821.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

Qwen PR review 的每一次尝试现在都能拿到共享评审时间预算的剩余部分，而不再是第一次尝试独占整个预算、重试只有写死的五分钟。重试仍然只允许一次、只在瞬时失败后触发，并且只有在剩余预算足以让它有机会跑完时才会开始；低于该阈值时直接报告瞬时失败，让下一次运行从完整预算重新开始。

## 为什么需要

重试路径对任何非平凡 PR 都是不可用的。它并不是接着失败的评审继续跑，而是从零完整重跑一遍：必须重新拉取 PR worktree、重新对 diff 分块、重新拉起全部评审 agent，然后才可能产出第一条结论。在大 PR 上，光是这段准备工作就超过五分钟，所以重试每次都会被时钟杀掉，整个运行最终被报成超时。

#7821 的那次运行是一个干净的例子。第一次尝试拿到了完整预算，走到判定这个 18 分块的 diff 需要 26 个 agent，随后在大约四分四十五秒时模型连接以 read ECONNRESET 断开。这被正确判定为瞬时失败并触发重试。重试只有五分钟，跑到了同一个位置——所有 agent 都已就绪、流水线正要启动——然后被终止。评审者看到的是「review timed out after 300 seconds (of the 180-minute budget)」，读起来像是配置错误，并附带一条「用更长的 timeout 重试」的建议。但这条建议不可能有帮助：用户请求的 timeout 根本影响不到重试的上限，调大它得到的仍然是同样的五分钟重试。

所有尝试本来就共享同一份单次评审预算，正是这一点保证两次尝试不会超过配置的 timeout 或 job timeout。这个共享预算就是重试唯一需要的边界，所以那个额外的上限只是在单方面削弱能力。移除它也让超时信息和它给出的恢复建议重新自洽：超时现在意味着评审确实用完了分配给它的时间，而请求更多时间也确实会给到更多时间。

## Reviewer 测试计划

### 如何验证

- 先确认观察到的失败：下面链接的评审运行的第二次尝试，在整体给了 180 分钟的情况下以 300 秒超时失败，步骤日志显示第一次尝试以 ECONNRESET API 错误结束，随后是 60 秒退避。
- 运行评审 workflow 的测试套件。它会从 workflow 中提取真实的重试循环，并用打桩的评审命令驱动它，因此断言针对的是实际发布的 bash，而不是它的复述版本。
- 确认重试现在拿到的是剩余预算而非固定的五分钟，并且它拿到的绝不会超过第一次尝试所拥有的——两次尝试共享同一份预算。
- 从两侧检查重试门槛。高于阈值的预算必须仍会重试；低于阈值的必须完全不启动重试，并且报告的是瞬时失败而不是超时。
- 检查非重试路径未变：第一次尝试的真实超时不会被重试；模型配额耗尽不会被重试且仍报告为配额失败；第二次瞬时失败不会产生第三次尝试；第一次就成功的情况不受影响。
- 为确认这些测试不是空转，把旧的带上限逻辑放回去重跑：覆盖上限和门槛的两条测试必须失败；把门槛阈值调得过高，则守住边界另一侧的那条测试必须失败。

### 证据（Before & After）

无截图——这是 CI workflow 的时间处理变更，没有用户可见界面。

Before（来自失败的运行）：第一次尝试在约 285 秒后以 API 错误结束，第二次在恰好 300 秒处被切断，信息为「在 180 分钟预算中，评审在 300 秒后超时」。

After：重试拿到预算的剩余部分并正常完成。把新增的测试放回旧逻辑重跑，可以把这个 bug 复现为断言失败——重试的时长被量到恰好是旧的上限，且门槛放行了一次跑不完的重试。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | ⚠️ 仅 CI |
| 🪟 Windows | ⚠️ 仅 CI |
|  🐧 Linux  | ✅ 已测试 |

### 环境（可选）

Linux 上的 Node.js 22 workspace。已解析并 lint workflow YAML，对评审步骤的 shell 脚本做了语法检查，workflow 测试套件全绿，其中包含本次为重试预算和门槛新增的三个用例。

## 风险与范围

- 主要风险或取舍：卡住的重试现在可能消耗掉剩余的全部评审预算，而不是最多五分钟。这仍受与单次尝试相同的共享预算和 job timeout 约束，所以最坏情况没有变化；取舍是一次注定失败的重试会比以前更长时间占用 runner，换来的是重试真正有可能成功。
- 未验证 / 范围外：针对真实模型 API 的端到端行为，而这正是这类失败之所以是瞬时的原因。哪些失败算 retryable 的判定逻辑未作改动，且测试是对评审命令打桩，并不真正调用模型。
- 破坏性变更 / 迁移说明：无。请求的 timeout、其取值范围、单次重试策略和退避时间均未改变。

## 关联 Issue

在 #7821 的评审运行中观察到。

</details>
