### PR TITLE
test(channels): run the feishu, weixin and qqbot suites in CI

### DIFF
--- a/packages/channels/feishu/package.json
+++ b/packages/channels/feishu/package.json
@@ -15,7 +15,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --build"
+    "build": "tsc --build",
+    "test": "vitest run",
+    "test:ci": "vitest run"
   },
   "dependencies": {
     "@qwen-code/channel-base": "file:../base",

--- a/packages/channels/feishu/vitest.config.ts
+++ b/packages/channels/feishu/vitest.config.ts
@@ -1,8 +1,21 @@
 import { defineConfig } from 'vitest/config';
+import path from 'node:path';
 
 export default defineConfig({
   test: {
     include: ['src/**/*.test.ts'],
     globals: true,
+  },
+  resolve: {
+    alias: {
+      // Resolve the in-repo channel-base to its live SOURCE so a package-local
+      // test run (e.g. `cd packages/channels/feishu && vitest`) doesn't depend
+      // on a prior `tsc --build` of base — its dist may be absent or stale during
+      // development. Mirrors packages/cli/vitest.config.ts.
+      '@qwen-code/channel-base': path.resolve(
+        __dirname,
+        '../base/src/index.ts',
+      ),
+    },
   },
 });

--- a/packages/channels/qqbot/package.json
+++ b/packages/channels/qqbot/package.json
@@ -16,7 +16,8 @@
   ],
   "scripts": {
     "build": "tsc --build",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:ci": "vitest run"
   },
   "dependencies": {
     "@qwen-code/channel-base": "file:../base",

--- a/packages/channels/weixin/package.json
+++ b/packages/channels/weixin/package.json
@@ -23,7 +23,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --build"
+    "build": "tsc --build",
+    "test": "vitest run",
+    "test:ci": "vitest run"
   },
   "dependencies": {
     "@qwen-code/channel-base": "file:../base"

--- a/packages/channels/weixin/vitest.config.ts
+++ b/packages/channels/weixin/vitest.config.ts
@@ -1,8 +1,21 @@
 import { defineConfig } from 'vitest/config';
+import path from 'node:path';
 
 export default defineConfig({
   test: {
     include: ['src/**/*.test.ts'],
     globals: true,
+  },
+  resolve: {
+    alias: {
+      // Resolve the in-repo channel-base to its live SOURCE so a package-local
+      // test run (e.g. `cd packages/channels/weixin && vitest`) doesn't depend
+      // on a prior `tsc --build` of base — its dist may be absent or stale during
+      // development. Mirrors packages/cli/vitest.config.ts.
+      '@qwen-code/channel-base': path.resolve(
+        __dirname,
+        '../base/src/index.ts',
+      ),
+    },
   },
 });


### PR DESCRIPTION
## What this PR does

Three channel packages ship test files that CI never runs. This wires them in: `test`/`test:ci` scripts for `feishu`, `weixin` and `qqbot`, plus the `@qwen-code/channel-base` → source alias that `feishu` and `weixin` need before their suites can run without a prior build.

## Why it's needed

CI's unit-test step runs `npm run test:ci --workspaces --if-present`. A package that does not define `test:ci` is skipped silently — `--if-present` is doing exactly what it says, so there is no error and nothing in the log to notice.

| package  | test files | `test:ci` before | after |
| -------- | ---------: | ---------------- | ----- |
| base     |         19 | yes              | yes   |
| dingtalk |          5 | yes              | yes   |
| github   |          2 | yes              | yes   |
| telegram |          1 | yes              | yes   |
| wecom    |          1 | yes              | yes   |
| feishu   |          3 | **no**           | yes   |
| qqbot    |          7 | **no**           | yes   |
| weixin   |          5 | **no**           | yes   |

That is 15 test files and 455 tests that currently protect nothing.

`qqbot` is the one worth pointing at. It *does* define a `test` script, so it reads as wired up in every place you would think to look — but CI invokes `test:ci`, so its 274 tests have been skipped all along. `feishu` and `weixin` define neither.

A script entry alone is not enough for `feishu` and `weixin`. Their `vitest.config.ts` files lack the alias that `dingtalk` and `qqbot` carry, which points `@qwen-code/channel-base` at `../base/src/index.ts` instead of its `dist`. No build step runs ahead of the unit-test job, so on a fresh checkout `dist` does not exist and the suite dies before collecting a single test:

```
Error: Failed to resolve entry for package "@qwen-code/channel-base".
The package may have incorrect main/module/exports specified in its package.json.
 Test Files  1 failed (1)
      Tests  no tests
```

Adding the scripts without the alias would therefore have turned a silent gap into a red build. The alias text is copied verbatim from `dingtalk`'s config, comment included, so all four adapters that depend on `channel-base` now resolve it the same way.

The same missing alias has a day-to-day cost too: without it a package-local run binds to whatever `dist` happens to be lying around. On my checkout `packages/channels/base/dist` predated `deliverProactive`, and six `feishu` adapter tests failed against the stale build for reasons that had nothing to do with the code under test. With the alias they pass, because they read the source.

## Reviewer Test Plan

### How to verify

Confirm each package now runs under the command CI actually uses:

```
npm run test:ci --workspace=packages/channels/feishu --if-present   # Tests  110 passed (110)
npm run test:ci --workspace=packages/channels/weixin --if-present   # Tests   71 passed  (71)
npm run test:ci --workspace=packages/channels/qqbot  --if-present   # Tests  274 passed (274)
```

On `main` the same three commands print nothing and exit 0, which is the bug.

To confirm the suites do not depend on a prior build — the condition CI runs under — move the base build out of the way and run them again:

```
mv packages/channels/base/dist packages/channels/base/dist.bak
cd packages/channels/feishu && npx vitest run    # 110 passed
cd ../weixin && npx vitest run                   #  71 passed
cd ../qqbot  && npx vitest run                   # 274 passed
mv packages/channels/base/dist.bak packages/channels/base/dist
```

All three pass with `dist` absent. Before this change, `feishu` and `weixin` fail there with the resolve error quoted above.

I ran all three suites three times over to check for flakiness before proposing that CI gate on them; 455 passed every time, no failures and no intermittents.

### Evidence (Before & After)

N/A — no user-visible or TUI change. Evidence is the command output above.

### Tested on

|     OS     |    Status     |
| :--------: | :-----------: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Unit tests only.

## Risk & Scope

- Main risk or tradeoff: CI now gates on 455 tests it previously skipped, so a latent failure in any of them would surface as a red build rather than staying invisible. That is the point of the change, and all three suites pass repeatedly on macOS here; Linux and Windows runners will be first exercised by this PR's own CI run, which is the honest place to find out.
- Not validated / out of scope: no test content is touched, and no adapter source is touched. `plugin-example` still has no `test:ci`, correctly — it ships no test files.
- Breaking changes / migration notes: none.

## Linked Issues

None. Noted while working on #7850, whose new Feishu tests are skipped by CI for the reason fixed here.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

有三个 channel 包带有测试文件，但 CI 从不运行它们。本 PR 把它们接入：为 `feishu`、`weixin` 和 `qqbot` 添加 `test`/`test:ci` 脚本，并补上 `feishu` 与 `weixin` 所需的 `@qwen-code/channel-base` → 源码 alias，否则它们的测试无法在没有预先构建的情况下运行。

## 为什么需要

CI 的单元测试步骤执行的是 `npm run test:ci --workspaces --if-present`。没有定义 `test:ci` 的包会被静默跳过——`--if-present` 完全是按字面意思工作的，因此不会报错，日志里也没有任何可察觉的迹象。

| 包       | 测试文件数 | 改动前 `test:ci` | 改动后 |
| -------- | ---------: | ---------------- | ------ |
| base     |         19 | 有               | 有     |
| dingtalk |          5 | 有               | 有     |
| github   |          2 | 有               | 有     |
| telegram |          1 | 有               | 有     |
| wecom    |          1 | 有               | 有     |
| feishu   |          3 | **无**           | 有     |
| qqbot    |          7 | **无**           | 有     |
| weixin   |          5 | **无**           | 有     |

也就是说，有 15 个测试文件、455 个测试目前什么都没有保护。

`qqbot` 尤其值得一提。它**确实**定义了 `test` 脚本，所以在任何你会想到去看的地方，它看起来都已经接好了——但 CI 调用的是 `test:ci`，因此它的 274 个测试一直被跳过。`feishu` 和 `weixin` 则两者都没有定义。

对 `feishu` 和 `weixin` 来说，只加脚本还不够。它们的 `vitest.config.ts` 缺少 `dingtalk` 和 `qqbot` 都有的那条 alias——把 `@qwen-code/channel-base` 指向 `../base/src/index.ts` 而不是它的 `dist`。单元测试任务之前并没有构建步骤，因此在全新检出的环境下 `dist` 并不存在，测试还没收集到一个用例就会失败：

```
Error: Failed to resolve entry for package "@qwen-code/channel-base".
The package may have incorrect main/module/exports specified in its package.json.
 Test Files  1 failed (1)
      Tests  no tests
```

因此，只加脚本而不加 alias，只会把一个静默的缺口变成一个红色的构建。alias 的文本是从 `dingtalk` 的配置里逐字复制的（含注释），这样四个依赖 `channel-base` 的适配器现在都以同样的方式解析它。

缺少这条 alias 在日常开发中也有代价：没有它，包内的本地测试会绑定到当时恰好存在的那份 `dist`。在我的检出里，`packages/channels/base/dist` 早于 `deliverProactive`，于是六个 `feishu` 适配器测试因为这份陈旧构建而失败，原因与被测代码毫无关系。加上 alias 后它们全部通过，因为读的是源码。

## 评审测试计划

### 如何验证

确认每个包现在都能在 CI 实际使用的命令下运行：

```
npm run test:ci --workspace=packages/channels/feishu --if-present   # Tests  110 passed (110)
npm run test:ci --workspace=packages/channels/weixin --if-present   # Tests   71 passed  (71)
npm run test:ci --workspace=packages/channels/qqbot  --if-present   # Tests  274 passed (274)
```

在 `main` 上，同样这三条命令不会有任何输出并以 0 退出——这正是问题所在。

若要确认这些测试不依赖预先构建（也就是 CI 所处的条件），把 base 的构建产物移开再跑一次：

```
mv packages/channels/base/dist packages/channels/base/dist.bak
cd packages/channels/feishu && npx vitest run    # 110 passed
cd ../weixin && npx vitest run                   #  71 passed
cd ../qqbot  && npx vitest run                   # 274 passed
mv packages/channels/base/dist.bak packages/channels/base/dist
```

在 `dist` 缺失的情况下三者都通过。而在本次改动之前，`feishu` 和 `weixin` 会以上面引用的解析错误失败。

在提议让 CI 依赖这些测试之前，我把三个测试套件各完整跑了三遍以检查不稳定性；455 个测试每次都通过，没有失败，也没有偶发问题。

### 证据（改动前后对比）

N/A——没有用户可见或 TUI 层面的改动。证据即上面的命令输出。

### 测试环境

|     OS     |    Status     |
| :--------: | :-----------: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### 运行环境（可选）

仅单元测试。

## 风险与范围

- 主要风险或取舍：CI 现在会对此前被跳过的 455 个测试把关，因此其中任何潜在的失败都会表现为红色构建，而不再是不可见的。这正是本次改动的目的；三个套件在我这里的 macOS 上反复运行均通过，而 Linux 与 Windows runner 将由本 PR 自身的 CI 运行首次检验——这也是最诚实的验证场所。
- 未验证／不在本次范围：没有改动任何测试内容，也没有改动任何适配器源码。`plugin-example` 仍然没有 `test:ci`，这是正确的——它不含任何测试文件。
- 破坏性变更／迁移说明：无。

## 关联 Issue

无。这是在处理 #7850 时发现的——该 PR 新增的飞书测试正因这里修复的原因而被 CI 跳过。

</details>
