### PR TITLE
fix(scripts): harden retry classification and preserve deadline error context

### DIFF
--- a/scripts/generate-release-notes.js
+++ b/scripts/generate-release-notes.js
@@ -458,12 +458,15 @@ export function createOpenAiCompleter({
     const prompt = promptFor(request);
     let attempt = 0;
     let lastError;
+    const deadlineError = () =>
+      new Error(
+        `Model generation time budget exhausted: ${lastError?.message ?? 'unknown error'}`,
+        { cause: lastError },
+      );
     for (;;) {
       const remainingMs = deadline - Date.now();
       if (remainingMs <= 0) {
-        throw new Error(
-          `Model generation time budget exhausted: ${lastError?.message ?? 'unknown error'}`,
-        );
+        throw deadlineError();
       }
       try {
         const response = await fetchImpl(endpoint, {
@@ -497,7 +500,7 @@ export function createOpenAiCompleter({
         lastError = error;
         attempt += 1;
         if (Date.now() >= deadline) {
-          throw new Error(`Model generation time budget exhausted: ${error?.message ?? 'unknown error'}`);
+          throw deadlineError();
         }
         if (attempt > maxRetries || !isRetryableModelError(error)) {
           throw error;
@@ -505,7 +508,7 @@ export function createOpenAiCompleter({
         const delayMs =
           baseDelayMs * 2 ** (attempt - 1) * (0.5 + Math.random());
         if (Date.now() + delayMs >= deadline) {
-          throw new Error(`Model generation time budget exhausted: ${error?.message ?? 'unknown error'}`);
+          throw deadlineError();
         }
         console.error(
           `Model request retry ${attempt}/${maxRetries} after ${escapeWorkflowCommand(error.message)}; backing off ${Math.round(delayMs)}ms.`,

--- a/scripts/generate-release-notes.js
+++ b/scripts/generate-release-notes.js
@@ -426,6 +426,12 @@ function isRetryableModelError(error) {
     return true;
   }
   const match = /HTTP (\d{3})/.exec(error?.message ?? '');
+  // Content-validation errors from our own code are deterministic — retrying
+  // the same prompt will reproduce the same failure. Only network-level errors
+  // (no HTTP status) are transient.
+  if (error?.message === 'Model response did not contain message content.') {
+    return false;
+  }
   if (!match) {
     // Network-level failure (DNS, reset, TLS): worth another attempt.
     return true;
@@ -452,7 +458,7 @@ export function createOpenAiCompleter({
     for (;;) {
       const remainingMs = deadline - Date.now();
       if (remainingMs <= 0) {
-        throw new Error('Model generation time budget exhausted.');
+        throw new Error(`Model generation time budget exhausted: ${error?.message ?? 'unknown error'}`);
       }
       try {
         const response = await fetchImpl(endpoint, {
@@ -485,7 +491,7 @@ export function createOpenAiCompleter({
       } catch (error) {
         attempt += 1;
         if (Date.now() >= deadline) {
-          throw new Error('Model generation time budget exhausted.');
+          throw new Error(`Model generation time budget exhausted: ${error?.message ?? 'unknown error'}`);
         }
         if (attempt > maxRetries || !isRetryableModelError(error)) {
           throw error;
@@ -493,7 +499,7 @@ export function createOpenAiCompleter({
         const delayMs =
           baseDelayMs * 2 ** (attempt - 1) * (0.5 + Math.random());
         if (Date.now() + delayMs >= deadline) {
-          throw new Error('Model generation time budget exhausted.');
+          throw new Error(`Model generation time budget exhausted: ${error?.message ?? 'unknown error'}`);
         }
         console.error(
           `Model request retry ${attempt}/${maxRetries} after ${escapeWorkflowCommand(error.message)}; backing off ${Math.round(delayMs)}ms.`,

--- a/scripts/generate-release-notes.js
+++ b/scripts/generate-release-notes.js
@@ -419,6 +419,8 @@ function promptFor(request) {
 }
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const CONTENT_VALIDATION_ERROR_MESSAGE =
+  'Model response did not contain message content.';
 
 function isRetryableModelError(error) {
   // AbortSignal.timeout raises TimeoutError; older paths may surface AbortError.
@@ -429,7 +431,7 @@ function isRetryableModelError(error) {
   // Content-validation errors from our own code are deterministic — retrying
   // the same prompt will reproduce the same failure. Only network-level errors
   // (no HTTP status) are transient.
-  if (error?.message === 'Model response did not contain message content.') {
+  if (error?.message === CONTENT_VALIDATION_ERROR_MESSAGE) {
     return false;
   }
   if (!match) {
@@ -455,10 +457,13 @@ export function createOpenAiCompleter({
   return async (request) => {
     const prompt = promptFor(request);
     let attempt = 0;
+    let lastError;
     for (;;) {
       const remainingMs = deadline - Date.now();
       if (remainingMs <= 0) {
-        throw new Error(`Model generation time budget exhausted: ${error?.message ?? 'unknown error'}`);
+        throw new Error(
+          `Model generation time budget exhausted: ${lastError?.message ?? 'unknown error'}`,
+        );
       }
       try {
         const response = await fetchImpl(endpoint, {
@@ -485,10 +490,11 @@ export function createOpenAiCompleter({
         const data = await response.json();
         const content = data?.choices?.[0]?.message?.content;
         if (typeof content !== 'string' || !content.trim()) {
-          throw new Error('Model response did not contain message content.');
+          throw new Error(CONTENT_VALIDATION_ERROR_MESSAGE);
         }
         return content;
       } catch (error) {
+        lastError = error;
         attempt += 1;
         if (Date.now() >= deadline) {
           throw new Error(`Model generation time budget exhausted: ${error?.message ?? 'unknown error'}`);

--- a/scripts/tests/generate-release-notes.test.js
+++ b/scripts/tests/generate-release-notes.test.js
@@ -740,7 +740,7 @@ describe('createOpenAiCompleter retries', () => {
     });
 
     await expect(complete({ kind: 'summaries', entries: [] })).rejects.toThrow(
-      'Model generation time budget exhausted.',
+      /budget exhausted.*HTTP 500/,
     );
     expect(calls).toBe(1);
     expect(timeout).not.toHaveBeenCalled();
@@ -781,7 +781,7 @@ describe('createOpenAiCompleter retries', () => {
     await complete({ kind: 'summaries', entries: [] });
     now = 51;
     await expect(complete({ kind: 'highlights', entries: [] })).rejects.toThrow(
-      'Model generation time budget exhausted.',
+      'Model generation time budget exhausted: unknown error',
     );
     expect(calls).toBe(1);
     clock.mockRestore();

--- a/scripts/tests/generate-release-notes.test.js
+++ b/scripts/tests/generate-release-notes.test.js
@@ -698,6 +698,41 @@ describe('createOpenAiCompleter retries', () => {
     );
   });
 
+  it('preserves original error when the deadline expires after backoff', async () => {
+    let now = 0;
+    let calls = 0;
+    const clock = vi.spyOn(Date, 'now').mockImplementation(() => now);
+    const random = vi.spyOn(Math, 'random').mockReturnValue(0);
+    const timeout = vi
+      .spyOn(globalThis, 'setTimeout')
+      .mockImplementation((callback) => {
+        now = 1001;
+        callback();
+        return 0;
+      });
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const complete = createOpenAiCompleter({
+      apiKey: 'secret',
+      baseUrl: 'https://model.example/v1/',
+      model: 'qwen-test',
+      baseDelayMs: 100,
+      totalTimeoutMs: 1000,
+      fetchImpl: async () => {
+        calls += 1;
+        return { ok: false, status: 500 };
+      },
+    });
+
+    await expect(complete({ kind: 'summaries', entries: [] })).rejects.toThrow(
+      /budget exhausted.*HTTP 500/,
+    );
+    expect(calls).toBe(1);
+    clock.mockRestore();
+    random.mockRestore();
+    timeout.mockRestore();
+    errSpy.mockRestore();
+  });
+
   it('logs a retry line when backing off', async () => {
     let calls = 0;
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/scripts/tests/generate-release-notes.test.js
+++ b/scripts/tests/generate-release-notes.test.js
@@ -618,6 +618,86 @@ describe('createOpenAiCompleter retries', () => {
     expect(calls).toBe(1);
   });
 
+
+  it('retries HTTP 429 (rate limiting)', async () => {
+    let calls = 0;
+    const complete = createOpenAiCompleter({
+      apiKey: 'secret',
+      baseUrl: 'https://model.example/v1/',
+      model: 'qwen-test',
+      baseDelayMs: 1,
+      fetchImpl: async () => {
+        calls += 1;
+        return calls === 1
+          ? { ok: false, status: 429 }
+          : okResponse;
+      },
+    });
+
+    await complete({ kind: 'summaries', entries: [] });
+    expect(calls).toBe(2);
+  });
+
+  it('retries network errors without HTTP status', async () => {
+    let calls = 0;
+    const complete = createOpenAiCompleter({
+      apiKey: 'secret',
+      baseUrl: 'https://model.example/v1/',
+      model: 'qwen-test',
+      baseDelayMs: 1,
+      fetchImpl: async () => {
+        calls += 1;
+        if (calls === 1) {
+          throw new Error('fetch failed: ECONNRESET');
+        }
+        return okResponse;
+      },
+    });
+
+    await complete({ kind: 'summaries', entries: [] });
+    expect(calls).toBe(2);
+  });
+
+  it('does not retry content-validation errors', async () => {
+    let calls = 0;
+    const complete = createOpenAiCompleter({
+      apiKey: 'secret',
+      baseUrl: 'https://model.example/v1/',
+      model: 'qwen-test',
+      baseDelayMs: 1,
+      fetchImpl: async () => {
+        calls += 1;
+        // Returns 200 OK but empty content — triggers content-validation error
+        return new Response(JSON.stringify({ choices: [{ message: { content: '' } }] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      },
+    });
+
+    await expect(complete({ kind: 'summaries', entries: [] })).rejects.toThrow(
+      'Model response did not contain message content.',
+    );
+    expect(calls).toBe(1);
+  });
+
+  it('preserves original error in deadline-expired message', async () => {
+    const complete = createOpenAiCompleter({
+      apiKey: 'secret',
+      baseUrl: 'https://model.example/v1/',
+      model: 'qwen-test',
+      baseDelayMs: 100,
+      totalTimeoutMs: 50,
+      fetchImpl: async () => {
+        return { ok: false, status: 503 };
+      },
+    });
+
+    await expect(complete({ kind: 'summaries', entries: [] })).rejects.toThrow(
+      /budget exhausted.*HTTP 503/,
+    );
+  });
+
   it('logs a retry line when backing off', async () => {
     let calls = 0;
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/scripts/tests/generate-release-notes.test.js
+++ b/scripts/tests/generate-release-notes.test.js
@@ -618,7 +618,6 @@ describe('createOpenAiCompleter retries', () => {
     expect(calls).toBe(1);
   });
 
-
   it('retries HTTP 429 (rate limiting)', async () => {
     let calls = 0;
     const complete = createOpenAiCompleter({
@@ -628,9 +627,7 @@ describe('createOpenAiCompleter retries', () => {
       baseDelayMs: 1,
       fetchImpl: async () => {
         calls += 1;
-        return calls === 1
-          ? { ok: false, status: 429 }
-          : okResponse;
+        return calls === 1 ? { ok: false, status: 429 } : okResponse;
       },
     });
 
@@ -668,10 +665,13 @@ describe('createOpenAiCompleter retries', () => {
       fetchImpl: async () => {
         calls += 1;
         // Returns 200 OK but empty content — triggers content-validation error
-        return new Response(JSON.stringify({ choices: [{ message: { content: '' } }] }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        });
+        return new Response(
+          JSON.stringify({ choices: [{ message: { content: '' } }] }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        );
       },
     });
 
@@ -696,6 +696,25 @@ describe('createOpenAiCompleter retries', () => {
     await expect(complete({ kind: 'summaries', entries: [] })).rejects.toThrow(
       /budget exhausted.*HTTP 503/,
     );
+  });
+
+  it('preserves the original error as the deadline error cause', async () => {
+    const complete = createOpenAiCompleter({
+      apiKey: 'secret',
+      baseUrl: 'https://model.example/v1/',
+      model: 'qwen-test',
+      baseDelayMs: 100,
+      totalTimeoutMs: 50,
+      fetchImpl: async () => {
+        return { ok: false, status: 503 };
+      },
+    });
+
+    const error = await complete({ kind: 'summaries', entries: [] }).catch(
+      (err) => err,
+    );
+    expect(error.message).toMatch(/budget exhausted.*HTTP 503/);
+    expect(error.cause?.message).toBe('Model request failed with HTTP 503.');
   });
 
   it('preserves original error when the deadline expires after backoff', async () => {


### PR DESCRIPTION
## What this PR does

Follow-up to #7535 addressing remaining review suggestions on `scripts/generate-release-notes.js`.

## Changes

### `isRetryableModelError` — content-validation errors are non-retryable

The `!match` branch (no HTTP status in the error message) previously returned `true` for **all** errors, including `'Model response did not contain message content.'` thrown by our own code at line ~482. This is a deterministic failure — retrying the same prompt reproduces the same result. Now explicitly returns `false` for content-validation errors before the network-error fallback.

### Deadline-expired errors preserve original context

Both deadline checks previously threw a generic `'Model generation time budget exhausted.'` that discarded the root cause. Now includes the original error message: `Model generation time budget exhausted: <original error>`.

### 4 new tests

| Test | What it pins |
|------|-------------|
| `retries HTTP 429 (rate limiting)` | The `status === 429` branch was untested |
| `retries network errors without HTTP status` | The `!match → return true` branch |
| `does not retry content-validation errors` | The new non-retryable classification |
| `preserves original error in deadline-expired message` | Root cause is visible in the error |

## Why

From the #7535 review comments:
- `isRetryableModelError` treats every error without `HTTP NNN` in its message as a retryable network failure — including content-validation errors thrown by our own code
- The deadline-expired branch discards the original error, replacing it with a generic message that hides the root cause
- No test exercises HTTP 429, and no test covers the network-error retry path

## Reviewer Test Plan

### How to verify

```
npx vitest run --config ./scripts/tests/vitest.config.ts
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

## Risk & Scope

- Main risk: a content-validation error that was previously retried (and eventually succeeded) will now fail immediately. This is the intended behavior — the retry was wasted effort.
- Not in scope: the remaining suggestions from #7535 (JSON.stringify hoisting, multiplicative retry layers, degraded summary message). Those are lower priority and can be addressed separately.

## Linked Issues

Follow-up to #7535.