### PR TITLE
fix(review): recover the resolved effort when --effort is not re-threaded

### DIFF
--- a/packages/cli/src/commands/review/capture-local.test.ts
+++ b/packages/cli/src/commands/review/capture-local.test.ts
@@ -11,17 +11,10 @@
 // command that reports it stopped saying a file was skipped.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import {
-  mkdtempSync,
-  mkdirSync,
-  rmSync,
-  readFileSync,
-  writeFileSync,
-  existsSync,
-} from 'node:fs';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { PARSE_ARGS_REPORT } from './lib/paths.js';
+import { join } from 'node:path';
+import { seedParseArgs } from './lib/test-utils.js';
 
 const captureMock = vi.hoisted(() => vi.fn());
 vi.mock('./lib/local-diff.js', async (orig) => ({
@@ -63,16 +56,6 @@ function capture(over: Record<string, unknown> = {}) {
     unbornHead: false,
     ...over,
   });
-}
-
-/** Seed the report `parse-args` tees, so the effort fallback has something to read. */
-function seedParseArgs(effort: unknown): void {
-  mkdirSync(join(dir, dirname(PARSE_ARGS_REPORT)), { recursive: true });
-  writeFileSync(
-    join(dir, PARSE_ARGS_REPORT),
-    JSON.stringify({ effort, effortSource: 'flag' }),
-    'utf8',
-  );
 }
 
 beforeEach(() => {
@@ -174,6 +157,7 @@ describe('capture-local (command boundary)', () => {
 
     const plan = JSON.parse(readFileSync(join(dir, 'plan.json'), 'utf8'));
     expect(plan.effort).toBe('medium');
+    expect(errs.join('')).toContain('from --effort');
   });
 
   it('recovers the effort parse-args resolved when --effort is not re-threaded', () => {
@@ -182,16 +166,17 @@ describe('capture-local (command boundary)', () => {
     // plan carries no effort and the roster safe-expands to the FULL set — the
     // user's `medium` is silently ignored. The report parse-args already wrote is
     // the deterministic source of truth.
-    seedParseArgs('medium');
+    seedParseArgs(dir, 'medium');
     capture();
     run('plan.json'); // note: no effort passed
 
     const plan = JSON.parse(readFileSync(join(dir, 'plan.json'), 'utf8'));
     expect(plan.effort).toBe('medium');
+    expect(errs.join('')).toContain('from parse-args report');
   });
 
   it('lets an explicit --effort win over the parse-args report', () => {
-    seedParseArgs('high');
+    seedParseArgs(dir, 'high');
     capture();
     run('plan.json', { effort: 'low' });
 
@@ -210,7 +195,7 @@ describe('capture-local (command boundary)', () => {
   it('ignores a malformed effort in the report rather than trusting it', () => {
     // A corrupt/hand-edited report must not smuggle a bogus level into the roster;
     // an unrecognised value falls through to the full-roster fail-safe.
-    seedParseArgs('turbo');
+    seedParseArgs(dir, 'turbo');
     capture();
     run('plan.json');
 

--- a/packages/cli/src/commands/review/capture-local.test.ts
+++ b/packages/cli/src/commands/review/capture-local.test.ts
@@ -11,9 +11,17 @@
 // command that reports it stopped saying a file was skipped.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { PARSE_ARGS_REPORT } from './lib/paths.js';
 
 const captureMock = vi.hoisted(() => vi.fn());
 vi.mock('./lib/local-diff.js', async (orig) => ({
@@ -55,6 +63,16 @@ function capture(over: Record<string, unknown> = {}) {
     unbornHead: false,
     ...over,
   });
+}
+
+/** Seed the report `parse-args` tees, so the effort fallback has something to read. */
+function seedParseArgs(effort: unknown): void {
+  mkdirSync(join(dir, dirname(PARSE_ARGS_REPORT)), { recursive: true });
+  writeFileSync(
+    join(dir, PARSE_ARGS_REPORT),
+    JSON.stringify({ effort, effortSource: 'flag' }),
+    'utf8',
+  );
 }
 
 beforeEach(() => {
@@ -148,6 +166,56 @@ describe('capture-local (command boundary)', () => {
     run('plan.json');
 
     expect(errs.join('')).toContain('the working tree is clean');
+  });
+
+  it('records an explicit --effort in the plan', () => {
+    capture();
+    run('plan.json', { effort: 'medium' });
+
+    const plan = JSON.parse(readFileSync(join(dir, 'plan.json'), 'utf8'));
+    expect(plan.effort).toBe('medium');
+  });
+
+  it('recovers the effort parse-args resolved when --effort is not re-threaded', () => {
+    // The gap this closes: the orchestrator ran `/review --effort medium`, but did
+    // not copy the level into `capture-local --effort`. Without the fallback the
+    // plan carries no effort and the roster safe-expands to the FULL set — the
+    // user's `medium` is silently ignored. The report parse-args already wrote is
+    // the deterministic source of truth.
+    seedParseArgs('medium');
+    capture();
+    run('plan.json'); // note: no effort passed
+
+    const plan = JSON.parse(readFileSync(join(dir, 'plan.json'), 'utf8'));
+    expect(plan.effort).toBe('medium');
+  });
+
+  it('lets an explicit --effort win over the parse-args report', () => {
+    seedParseArgs('high');
+    capture();
+    run('plan.json', { effort: 'low' });
+
+    const plan = JSON.parse(readFileSync(join(dir, 'plan.json'), 'utf8'));
+    expect(plan.effort).toBe('low');
+  });
+
+  it('omits effort (roster fail-safe to full) when neither flag nor report is present', () => {
+    capture();
+    run('plan.json');
+
+    const plan = JSON.parse(readFileSync(join(dir, 'plan.json'), 'utf8'));
+    expect(plan.effort).toBeUndefined();
+  });
+
+  it('ignores a malformed effort in the report rather than trusting it', () => {
+    // A corrupt/hand-edited report must not smuggle a bogus level into the roster;
+    // an unrecognised value falls through to the full-roster fail-safe.
+    seedParseArgs('turbo');
+    capture();
+    run('plan.json');
+
+    const plan = JSON.parse(readFileSync(join(dir, 'plan.json'), 'utf8'));
+    expect(plan.effort).toBeUndefined();
   });
 
   it('escapes a filename carrying terminal control characters', () => {

--- a/packages/cli/src/commands/review/capture-local.ts
+++ b/packages/cli/src/commands/review/capture-local.ts
@@ -21,7 +21,7 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { writeStdoutLine, writeStderrLine } from '../../utils/stdioHelpers.js';
 import { REVIEW_TMP_DIR, tmpFile } from './lib/paths.js';
-import { resolveEffort } from './lib/effort.js';
+import { planEffortField } from './lib/effort.js';
 import type { ReviewEffort } from './parse-args.js';
 import { captureLocalDiff, type SkippedFile } from './lib/local-diff.js';
 import { buildDiffPlan, READ_FILE_CHAR_CAP } from './lib/diff-plan.js';
@@ -97,14 +97,7 @@ function runCaptureLocal(args: CaptureLocalArgs): void {
     ...buildPlanReport(plan, null),
     untrackedFiles: capture.untracked,
     skippedFiles: capture.skipped,
-    // `--effort` wins; otherwise recover the level parse-args resolved, so a
-    // `/review --effort medium` reaches `plan.effort` even when the orchestrator
-    // did not re-thread the flag (see resolveEffort). Absent → roster fail-safes
-    // to full, unchanged.
-    ...(() => {
-      const effort = resolveEffort(args.effort);
-      return effort ? { effort } : {};
-    })(),
+    ...planEffortField(args.effort),
   };
 
   writeFileSync(out, stringifyPlanReport(result), 'utf8');

--- a/packages/cli/src/commands/review/capture-local.ts
+++ b/packages/cli/src/commands/review/capture-local.ts
@@ -21,6 +21,7 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { writeStdoutLine, writeStderrLine } from '../../utils/stdioHelpers.js';
 import { REVIEW_TMP_DIR, tmpFile } from './lib/paths.js';
+import { resolveEffort } from './lib/effort.js';
 import type { ReviewEffort } from './parse-args.js';
 import { captureLocalDiff, type SkippedFile } from './lib/local-diff.js';
 import { buildDiffPlan, READ_FILE_CHAR_CAP } from './lib/diff-plan.js';
@@ -96,7 +97,14 @@ function runCaptureLocal(args: CaptureLocalArgs): void {
     ...buildPlanReport(plan, null),
     untrackedFiles: capture.untracked,
     skippedFiles: capture.skipped,
-    ...(args.effort ? { effort: args.effort } : {}),
+    // `--effort` wins; otherwise recover the level parse-args resolved, so a
+    // `/review --effort medium` reaches `plan.effort` even when the orchestrator
+    // did not re-thread the flag (see resolveEffort). Absent → roster fail-safes
+    // to full, unchanged.
+    ...(() => {
+      const effort = resolveEffort(args.effort);
+      return effort ? { effort } : {};
+    })(),
   };
 
   writeFileSync(out, stringifyPlanReport(result), 'utf8');

--- a/packages/cli/src/commands/review/fetch-pr.test.ts
+++ b/packages/cli/src/commands/review/fetch-pr.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Argv, CommandModule } from 'yargs';
 import { fetchPrCommand } from './fetch-pr.js';
 import { classifyHeavy } from './lib/heavy.js';
+import { PARSE_ARGS_REPORT } from './lib/paths.js';
 
 describe('classifyHeavy', () => {
   it('flags a substantially rewritten existing file', () => {
@@ -206,7 +207,7 @@ describe('fetchPrCommand builder', () => {
 
 const producerMocks = vi.hoisted(() => ({
   writeFileSync: vi.fn(),
-  readFileSync: vi.fn((): string => {
+  readFileSync: vi.fn((_path?: unknown): string => {
     throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
   }),
   gh: vi.fn(),
@@ -266,7 +267,7 @@ vi.mock('./lib/merge-base.js', () => ({
   resolveMergeBase: vi.fn(() => ({ sha: null, baseFetchFailed: false })),
 }));
 
-describe('fetch-pr report — audit-window contract', () => {
+describe('fetch-pr report assembly', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // clearAllMocks resets call history but NOT implementations, so a
@@ -400,5 +401,51 @@ describe('fetch-pr report — audit-window contract', () => {
       .map((c) => String(c[0]))
       .some((l) => l.includes('could not read the previous fetch report'));
     expect(warned).toBe(true);
+  });
+
+  describe('effort threading', () => {
+    // The PR path spreads `planEffortField(args.effort)` into the report exactly
+    // as capture-local and plan-diff do, but a refactor of this result assembly
+    // (dropping the import, or a later property shadowing `effort`) would silently
+    // lose it — safe-expanding the roster to the full set even with `--effort
+    // medium` while the sibling tests still pass. These trip that wire.
+    function seedReport(effort: unknown): void {
+      producerMocks.readFileSync.mockImplementation((path?: unknown) => {
+        if (path === PARSE_ARGS_REPORT) {
+          return JSON.stringify({ effort, effortSource: 'flag' });
+        }
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      });
+    }
+
+    it('records an explicit --effort in the report', async () => {
+      const report = await reportFor({ effort: 'medium' });
+      expect(report.effort).toBe('medium');
+    });
+
+    it('recovers the effort parse-args resolved when --effort is not re-threaded', async () => {
+      seedReport('medium');
+      const report = await reportFor({});
+      expect(report.effort).toBe('medium');
+      // And the resolution is disclosed on stderr, not silent.
+      const traced = producerMocks.writeStderrLine.mock.calls
+        .map((c) => String(c[0]))
+        .some(
+          (l) =>
+            l.includes('effort: medium') && l.includes('parse-args report'),
+        );
+      expect(traced).toBe(true);
+    });
+
+    it('omits effort when neither flag nor report is present', async () => {
+      const report = await reportFor({});
+      expect(report.effort).toBeUndefined();
+    });
+
+    it('ignores a malformed effort in the report rather than trusting it', async () => {
+      seedReport('turbo');
+      const report = await reportFor({});
+      expect(report.effort).toBeUndefined();
+    });
   });
 });

--- a/packages/cli/src/commands/review/fetch-pr.ts
+++ b/packages/cli/src/commands/review/fetch-pr.ts
@@ -41,7 +41,7 @@ import {
   tmpFile,
   worktreePath,
 } from './lib/paths.js';
-import { resolveEffort } from './lib/effort.js';
+import { planEffortField } from './lib/effort.js';
 import {
   buildDiffPlan,
   DEFAULT_MAX_CHUNK_LINES,
@@ -378,13 +378,7 @@ async function runFetchPr(args: FetchPrArgs): Promise<void> {
     diffPath,
     diffPathAbsolute,
     prDescriptionHasHan: /\p{Script=Han}/u.test(meta.body ?? ''),
-    // `--effort` wins; else recover the level parse-args resolved, so the effort
-    // reaches `plan.effort` without the orchestrator re-threading the flag (see
-    // resolveEffort). Absent → roster fail-safes to full, unchanged.
-    ...(() => {
-      const effort = resolveEffort(args.effort);
-      return effort ? { effort } : {};
-    })(),
+    ...planEffortField(args.effort),
     ...buildPlanReport(plan, (path) => fileLineCount(fetchedSha, path)),
   };
 

--- a/packages/cli/src/commands/review/fetch-pr.ts
+++ b/packages/cli/src/commands/review/fetch-pr.ts
@@ -41,6 +41,7 @@ import {
   tmpFile,
   worktreePath,
 } from './lib/paths.js';
+import { resolveEffort } from './lib/effort.js';
 import {
   buildDiffPlan,
   DEFAULT_MAX_CHUNK_LINES,
@@ -377,7 +378,13 @@ async function runFetchPr(args: FetchPrArgs): Promise<void> {
     diffPath,
     diffPathAbsolute,
     prDescriptionHasHan: /\p{Script=Han}/u.test(meta.body ?? ''),
-    ...(args.effort ? { effort: args.effort } : {}),
+    // `--effort` wins; else recover the level parse-args resolved, so the effort
+    // reaches `plan.effort` without the orchestrator re-threading the flag (see
+    // resolveEffort). Absent → roster fail-safes to full, unchanged.
+    ...(() => {
+      const effort = resolveEffort(args.effort);
+      return effort ? { effort } : {};
+    })(),
     ...buildPlanReport(plan, (path) => fileLineCount(fetchedSha, path)),
   };
 

--- a/packages/cli/src/commands/review/fetch-pr.ts
+++ b/packages/cli/src/commands/review/fetch-pr.ts
@@ -378,8 +378,8 @@ async function runFetchPr(args: FetchPrArgs): Promise<void> {
     diffPath,
     diffPathAbsolute,
     prDescriptionHasHan: /\p{Script=Han}/u.test(meta.body ?? ''),
-    ...planEffortField(args.effort),
     ...buildPlanReport(plan, (path) => fileLineCount(fetchedSha, path)),
+    ...planEffortField(args.effort),
   };
 
   writeFileSync(out, stringifyPlanReport(result), 'utf8');

--- a/packages/cli/src/commands/review/lib/effort.ts
+++ b/packages/cli/src/commands/review/lib/effort.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Resolve the review effort for a capture command's plan — with the orchestrator
+// taken OUT of the threading loop.
+//
+// The effort reaches every consumer (roster, check-coverage, compose-review) as
+// `plan.effort`, which the capture commands (`capture-local`, `plan-diff`,
+// `fetch-pr`) write. They learn it from `--effort <level>`, and the skill tells the
+// orchestrator to pass the level `parse-args` resolved. But that is a *value the
+// model must copy from one file into a flag*, and measured, it does not reliably
+// happen: a `/review --effort medium` local run had the orchestrator omit the flag,
+// so `plan.effort` was absent and the roster safe-fell-back to the FULL set — the
+// user asked for the reduced medium roster and silently got every agent (6a/6b/6c
+// included). The fix is deterministic: when `--effort` is not given, read the level
+// `parse-args` already wrote to its conventional report. No model action required.
+
+import { readFileSync } from 'node:fs';
+import { PARSE_ARGS_REPORT } from './paths.js';
+import type { ReviewEffort } from '../parse-args.js';
+
+const LEVELS: ReadonlySet<string> = new Set(['low', 'medium', 'high']);
+
+/**
+ * The effort to record in a capture command's plan. An explicit `--effort` wins;
+ * otherwise fall back to the level `parse-args` resolved (read from
+ * `PARSE_ARGS_REPORT`, relative to the same CWD the skill tee'd it in). `undefined`
+ * when neither is available — the roster then fail-safes to the full set, exactly as
+ * before, so a missing report never *reduces* coverage.
+ */
+export function resolveEffort(
+  explicit: string | undefined,
+): ReviewEffort | undefined {
+  if (explicit && LEVELS.has(explicit)) return explicit as ReviewEffort;
+  try {
+    const parsed = JSON.parse(readFileSync(PARSE_ARGS_REPORT, 'utf8')) as {
+      effort?: unknown;
+    };
+    if (typeof parsed.effort === 'string' && LEVELS.has(parsed.effort)) {
+      return parsed.effort as ReviewEffort;
+    }
+  } catch {
+    /* no report, or unreadable/unparseable — undefined (roster fail-safe to full) */
+  }
+  return undefined;
+}

--- a/packages/cli/src/commands/review/lib/effort.ts
+++ b/packages/cli/src/commands/review/lib/effort.ts
@@ -19,6 +19,7 @@
 // `parse-args` already wrote to its conventional report. No model action required.
 
 import { readFileSync } from 'node:fs';
+import { writeStderrLine } from '../../../utils/stdioHelpers.js';
 import { PARSE_ARGS_REPORT } from './paths.js';
 import { EFFORT_LEVELS } from '../parse-args.js';
 import type { ReviewEffort } from '../parse-args.js';
@@ -57,5 +58,15 @@ export function planEffortField(explicit: string | undefined): {
   effort?: ReviewEffort;
 } {
   const effort = resolveEffort(explicit);
-  return effort ? { effort } : {};
+  if (!effort) return {};
+  // The fallback this PR adds is silent by nature — name the resolved level and
+  // where it came from so a review that ran at an unexpected effort is one stderr
+  // line to diagnose, not a hunt for the parse-args report. Quiet when nothing
+  // resolves: the full-roster fail-safe is the long-standing default, not news.
+  writeStderrLine(
+    `effort: ${effort} (from ${
+      explicit && EFFORT_LEVELS.has(explicit) ? '--effort' : 'parse-args report'
+    })`,
+  );
+  return { effort };
 }

--- a/packages/cli/src/commands/review/lib/effort.ts
+++ b/packages/cli/src/commands/review/lib/effort.ts
@@ -20,9 +20,8 @@
 
 import { readFileSync } from 'node:fs';
 import { PARSE_ARGS_REPORT } from './paths.js';
+import { EFFORT_LEVELS } from '../parse-args.js';
 import type { ReviewEffort } from '../parse-args.js';
-
-const LEVELS: ReadonlySet<string> = new Set(['low', 'medium', 'high']);
 
 /**
  * The effort to record in a capture command's plan. An explicit `--effort` wins;
@@ -34,16 +33,29 @@ const LEVELS: ReadonlySet<string> = new Set(['low', 'medium', 'high']);
 export function resolveEffort(
   explicit: string | undefined,
 ): ReviewEffort | undefined {
-  if (explicit && LEVELS.has(explicit)) return explicit as ReviewEffort;
+  if (explicit && EFFORT_LEVELS.has(explicit)) return explicit as ReviewEffort;
   try {
     const parsed = JSON.parse(readFileSync(PARSE_ARGS_REPORT, 'utf8')) as {
       effort?: unknown;
     };
-    if (typeof parsed.effort === 'string' && LEVELS.has(parsed.effort)) {
+    if (typeof parsed.effort === 'string' && EFFORT_LEVELS.has(parsed.effort)) {
       return parsed.effort as ReviewEffort;
     }
   } catch {
     /* no report, or unreadable/unparseable — undefined (roster fail-safe to full) */
   }
   return undefined;
+}
+
+/**
+ * The resolved effort shaped for spreading into a capture command's plan:
+ * `{ effort }` when a level resolves, `{}` otherwise (roster fail-safes to full).
+ * The three capture commands spread this verbatim, so the conditional spread lives
+ * here once rather than being re-spelled at each call site.
+ */
+export function planEffortField(explicit: string | undefined): {
+  effort?: ReviewEffort;
+} {
+  const effort = resolveEffort(explicit);
+  return effort ? { effort } : {};
 }

--- a/packages/cli/src/commands/review/lib/paths.test.ts
+++ b/packages/cli/src/commands/review/lib/paths.test.ts
@@ -5,8 +5,24 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { resolve } from 'node:path';
-import { tmpFile, probeWorktreePath, worktreePath } from './paths.js';
+import { join, resolve } from 'node:path';
+import {
+  tmpFile,
+  probeWorktreePath,
+  worktreePath,
+  PARSE_ARGS_REPORT,
+} from './paths.js';
+
+describe('PARSE_ARGS_REPORT', () => {
+  it('is the literal path the skill tees to in Step 0', () => {
+    // The skill's Step 0 hard-codes `.qwen/tmp/qwen-review-parse-args.json` in
+    // its tee command. If this constant drifts from that literal the fallback
+    // silently stops reading the report and the original bug returns.
+    expect(PARSE_ARGS_REPORT).toBe(
+      join('.qwen', 'tmp', 'qwen-review-parse-args.json'),
+    );
+  });
+});
 
 describe('tmpFile — target is a single safe component', () => {
   it('keeps ordinary labels intact', () => {

--- a/packages/cli/src/commands/review/lib/paths.ts
+++ b/packages/cli/src/commands/review/lib/paths.ts
@@ -15,6 +15,17 @@ export const REVIEW_TMP_DIR = join('.qwen', 'tmp');
 export const REVIEWS_DIR = join('.qwen', 'reviews');
 export const REVIEW_CACHE_DIR = join('.qwen', 'review-cache');
 
+/**
+ * Where the skill tees `qwen review parse-args`'s verdict (SKILL Step 0). A fixed,
+ * conventional name so a capture command can read back the effort the parser
+ * already resolved without the orchestrator threading the `--effort` value through
+ * by hand — see `resolveEffort`.
+ */
+export const PARSE_ARGS_REPORT = join(
+  REVIEW_TMP_DIR,
+  'qwen-review-parse-args.json',
+);
+
 /** Worktree path for a given PR review session. */
 export function worktreePath(prNumber: string | number): string {
   return join(REVIEW_TMP_DIR, `review-pr-${prNumber}`);

--- a/packages/cli/src/commands/review/lib/test-utils.ts
+++ b/packages/cli/src/commands/review/lib/test-utils.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { PARSE_ARGS_REPORT } from './paths.js';
+
+/** Seed the report `parse-args` tees, so the effort fallback has something to read. */
+export function seedParseArgs(dir: string, effort: unknown): void {
+  mkdirSync(join(dir, dirname(PARSE_ARGS_REPORT)), { recursive: true });
+  writeFileSync(
+    join(dir, PARSE_ARGS_REPORT),
+    JSON.stringify({ effort, effortSource: 'flag' }),
+    'utf8',
+  );
+}

--- a/packages/cli/src/commands/review/parse-args.ts
+++ b/packages/cli/src/commands/review/parse-args.ts
@@ -55,7 +55,11 @@ export interface ParsedReviewArgs {
   warnings: string[];
 }
 
-const EFFORT_LEVELS: ReadonlySet<string> = new Set(['low', 'medium', 'high']);
+export const EFFORT_LEVELS: ReadonlySet<string> = new Set([
+  'low',
+  'medium',
+  'high',
+]);
 
 // The verdict's owner/repo/number are interpolated into `gh` commands by the
 // caller, so they must be established trustworthily, not merely extracted:

--- a/packages/cli/src/commands/review/plan-diff.test.ts
+++ b/packages/cli/src/commands/review/plan-diff.test.ts
@@ -12,6 +12,7 @@ import { planDiffCommand } from './plan-diff.js';
 import { chunksCoverDiff } from './lib/diff-plan.js';
 
 let dir: string;
+let cwd: string;
 const run = (diffPath: string, out: string, maxChunkLines = 400) =>
   (planDiffCommand.handler as (a: unknown) => void)({
     diff_path: diffPath,
@@ -21,8 +22,11 @@ const run = (diffPath: string, out: string, maxChunkLines = 400) =>
 
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), 'plan-diff-'));
+  cwd = process.cwd();
+  process.chdir(dir);
 });
 afterEach(() => {
+  process.chdir(cwd);
   if (dir) rmSync(dir, { recursive: true, force: true });
 });
 

--- a/packages/cli/src/commands/review/plan-diff.test.ts
+++ b/packages/cli/src/commands/review/plan-diff.test.ts
@@ -5,18 +5,12 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import {
-  mkdtempSync,
-  mkdirSync,
-  rmSync,
-  writeFileSync,
-  readFileSync,
-} from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import { planDiffCommand } from './plan-diff.js';
 import { chunksCoverDiff } from './lib/diff-plan.js';
-import { PARSE_ARGS_REPORT } from './lib/paths.js';
+import { seedParseArgs } from './lib/test-utils.js';
 
 let dir: string;
 let cwd: string;
@@ -59,16 +53,6 @@ function makeDiff(path: string, n: number): string {
     ...body,
     '',
   ].join('\n');
-}
-
-/** Seed the report `parse-args` tees, so the effort fallback has something to read. */
-function seedParseArgs(effort: unknown): void {
-  mkdirSync(join(dir, dirname(PARSE_ARGS_REPORT)), { recursive: true });
-  writeFileSync(
-    join(dir, PARSE_ARGS_REPORT),
-    JSON.stringify({ effort, effortSource: 'flag' }),
-    'utf8',
-  );
 }
 
 describe('plan-diff', () => {
@@ -131,7 +115,7 @@ describe('plan-diff', () => {
   });
 
   it('recovers the effort from the parse-args report when --effort is not re-threaded', () => {
-    seedParseArgs('medium');
+    seedParseArgs(dir, 'medium');
     const diffPath = join(dir, 'local.diff');
     const out = join(dir, 'plan.json');
     writeFileSync(diffPath, makeDiff('src/a.ts', 60));

--- a/packages/cli/src/commands/review/plan-diff.test.ts
+++ b/packages/cli/src/commands/review/plan-diff.test.ts
@@ -5,11 +5,18 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { planDiffCommand } from './plan-diff.js';
 import { chunksCoverDiff } from './lib/diff-plan.js';
+import { PARSE_ARGS_REPORT } from './lib/paths.js';
 
 let dir: string;
 let cwd: string;
@@ -52,6 +59,16 @@ function makeDiff(path: string, n: number): string {
     ...body,
     '',
   ].join('\n');
+}
+
+/** Seed the report `parse-args` tees, so the effort fallback has something to read. */
+function seedParseArgs(effort: unknown): void {
+  mkdirSync(join(dir, dirname(PARSE_ARGS_REPORT)), { recursive: true });
+  writeFileSync(
+    join(dir, PARSE_ARGS_REPORT),
+    JSON.stringify({ effort, effortSource: 'flag' }),
+    'utf8',
+  );
 }
 
 describe('plan-diff', () => {
@@ -110,6 +127,16 @@ describe('plan-diff', () => {
       maxChunkLines: 400,
       effort: 'medium',
     });
+    expect(JSON.parse(readFileSync(out, 'utf8')).effort).toBe('medium');
+  });
+
+  it('recovers the effort from the parse-args report when --effort is not re-threaded', () => {
+    seedParseArgs('medium');
+    const diffPath = join(dir, 'local.diff');
+    const out = join(dir, 'plan.json');
+    writeFileSync(diffPath, makeDiff('src/a.ts', 60));
+    run(diffPath, out); // note: no effort passed
+
     expect(JSON.parse(readFileSync(out, 'utf8')).effort).toBe('medium');
   });
 

--- a/packages/cli/src/commands/review/plan-diff.ts
+++ b/packages/cli/src/commands/review/plan-diff.ts
@@ -19,6 +19,7 @@ import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { writeStdoutLine, writeStderrLine } from '../../utils/stdioHelpers.js';
 import { REVIEW_TMP_DIR } from './lib/paths.js';
+import { resolveEffort } from './lib/effort.js';
 import type { ReviewEffort } from './parse-args.js';
 import {
   buildDiffPlan,
@@ -90,7 +91,13 @@ function runPlanDiff(args: PlanDiffArgs): void {
     ...(args.pr !== undefined && args.repo !== undefined
       ? { prNumber: String(args.pr), ownerRepo: args.repo }
       : {}),
-    ...(args.effort ? { effort: args.effort } : {}),
+    // `--effort` wins; else recover the level parse-args resolved, so the effort
+    // reaches `plan.effort` without the orchestrator re-threading the flag (see
+    // resolveEffort). Absent → roster fail-safes to full, unchanged.
+    ...(() => {
+      const effort = resolveEffort(args.effort);
+      return effort ? { effort } : {};
+    })(),
     // No `git show` is possible here — there is no ref to resolve a path
     // against — so per-file line counts and heaviness are unavailable. Chunk
     // coverage, which is what Step 3B needs, is not.

--- a/packages/cli/src/commands/review/plan-diff.ts
+++ b/packages/cli/src/commands/review/plan-diff.ts
@@ -19,7 +19,7 @@ import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { writeStdoutLine, writeStderrLine } from '../../utils/stdioHelpers.js';
 import { REVIEW_TMP_DIR } from './lib/paths.js';
-import { resolveEffort } from './lib/effort.js';
+import { planEffortField } from './lib/effort.js';
 import type { ReviewEffort } from './parse-args.js';
 import {
   buildDiffPlan,
@@ -91,13 +91,7 @@ function runPlanDiff(args: PlanDiffArgs): void {
     ...(args.pr !== undefined && args.repo !== undefined
       ? { prNumber: String(args.pr), ownerRepo: args.repo }
       : {}),
-    // `--effort` wins; else recover the level parse-args resolved, so the effort
-    // reaches `plan.effort` without the orchestrator re-threading the flag (see
-    // resolveEffort). Absent → roster fail-safes to full, unchanged.
-    ...(() => {
-      const effort = resolveEffort(args.effort);
-      return effort ? { effort } : {};
-    })(),
+    ...planEffortField(args.effort),
     // No `git show` is possible here — there is no ref to resolve a path
     // against — so per-file line counts and heaviness are unavailable. Chunk
     // coverage, which is what Step 3B needs, is not.

--- a/packages/cli/src/commands/review/plan-diff.ts
+++ b/packages/cli/src/commands/review/plan-diff.ts
@@ -91,11 +91,11 @@ function runPlanDiff(args: PlanDiffArgs): void {
     ...(args.pr !== undefined && args.repo !== undefined
       ? { prNumber: String(args.pr), ownerRepo: args.repo }
       : {}),
-    ...planEffortField(args.effort),
     // No `git show` is possible here — there is no ref to resolve a path
     // against — so per-file line counts and heaviness are unavailable. Chunk
     // coverage, which is what Step 3B needs, is not.
     ...buildPlanReport(plan, null),
+    ...planEffortField(args.effort),
   };
 
   mkdirSync(REVIEW_TMP_DIR, { recursive: true });


### PR DESCRIPTION
## What

`/review --effort medium` (and `--effort low`) could be silently ignored: the run would go ahead with the **full** agent roster as if no effort had been given.

## Why

The capture commands — `capture-local`, `plan-diff`, `fetch-pr` — record the review effort as `plan.effort`, which every downstream consumer (roster, `check-coverage`, `compose-review`) reads. They learn it from `--effort <level>`, and the skill asks the orchestrator to pass along the level `parse-args` resolved.

But that is a value the model has to copy from one file into a flag on a later command, and in practice it does not reliably happen. A `/review --effort medium` local run had the orchestrator omit the flag on `capture-local`, so `plan.effort` was absent and the roster safe-expanded to the full set. The safe expansion is correct as a fail-safe (never review *less* than asked), but it means the user's `medium` was dropped without a trace and every agent (including the adversarial `6a`/`6b`/`6c`) ran anyway.

## Fix

Close the gap deterministically, without depending on the model to thread the flag.

A new `resolveEffort()`:
- prefers an explicit `--effort`;
- otherwise reads the level `parse-args` already wrote to its conventional report (`.qwen/tmp/qwen-review-parse-args.json`);
- returns `undefined` when neither is available — the roster then fail-safes to the full set exactly as before, so a missing report never *reduces* coverage;
- ignores a malformed/unrecognised level in the report rather than trusting it.

Applied uniformly to all three capture commands so `plan.effort` is filled the same way whether the review is local or a PR.

## Test

`capture-local.test.ts` gains cases for: explicit `--effort` recorded; effort recovered from the report when the flag is not re-threaded; explicit flag winning over the report; neither present → effort omitted (full-roster fail-safe); malformed report level ignored. Full review suite green (987 tests).

<details>
<summary>中文说明</summary>

## 问题

`/review --effort medium`(以及 `--effort low`)可能被静默忽略:评审会照常以**完整**的 agent 名册运行,就好像没有指定 effort 一样。

## 原因

各 capture 命令(`capture-local`、`plan-diff`、`fetch-pr`)把评审 effort 记录为 `plan.effort`,下游所有消费方(roster、`check-coverage`、`compose-review`)都读它。它们通过 `--effort <level>` 得到这个值,而 skill 要求编排模型把 `parse-args` 解析出的等级继续透传下去。

但这需要模型把一个值从某个文件里抄到后续命令的参数上,实际中并不可靠。一次 `/review --effort medium` 的本地评审里,编排模型在调用 `capture-local` 时漏掉了该参数,导致 `plan.effort` 缺失,名册于是安全地扩展为完整集合。这种扩展作为 fail-safe 是对的(绝不比用户要求的评审得更少),但它意味着用户指定的 `medium` 被无声丢弃,所有 agent(包括对抗性的 `6a`/`6b`/`6c`)仍然全部运行。

## 修复

以确定性的方式补上这个缺口,不再依赖模型透传参数。

新增 `resolveEffort()`:
- 优先采用显式的 `--effort`;
- 否则读取 `parse-args` 已经写入其约定报告(`.qwen/tmp/qwen-review-parse-args.json`)的等级;
- 两者都没有时返回 `undefined`——名册照旧 fail-safe 到完整集合,因此报告缺失绝不会**减少**覆盖面;
- 报告里出现非法/无法识别的等级时忽略它,而不是盲信。

三个 capture 命令统一采用该逻辑,无论本地评审还是 PR 评审,`plan.effort` 都以同样方式填充。

## 测试

`capture-local.test.ts` 新增用例:显式 `--effort` 被记录;未透传参数时从报告恢复 effort;显式参数优先于报告;两者皆无 → 省略 effort(完整名册 fail-safe);报告等级非法时被忽略。整套 review 测试通过(987 个)。

</details>
