### PR TITLE
feat(web-shell): add composer footer renderer

### DIFF
--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -14,6 +14,7 @@ import type {
   VoiceStatusRevision,
   VoiceWorkspaceTarget,
 } from './voice/voice-workspace-target';
+import type { WebShellComposerToolbarRenderInfo } from './customization';
 import { loadSplitSessions, saveSplitSessions } from './utils/splitUrl';
 
 type StreamingState = 'idle' | 'responding';
@@ -420,8 +421,8 @@ vi.mock('./components/ChatEditor', async () => {
         focus: editorFocus,
       }));
       return React.createElement(
-        React.Fragment,
-        null,
+        'div',
+        { 'data-web-shell-composer': '' },
         React.createElement(
           'button',
           {
@@ -1467,6 +1468,8 @@ beforeEach(() => {
   mockConnection.workspaceCwd = '/tmp/project';
   mockConnection.status = 'connected';
   mockConnection.displayName = 'Session One';
+  mockConnection.currentMode = 'default';
+  mockConnection.currentModel = 'qwen';
   mockConnection.error = undefined;
   mockConnection.errorStatus = undefined;
   mockConnection.missingSession = false;
@@ -1610,6 +1613,134 @@ afterEach(() => {
   }
   vi.useRealTimers();
   vi.restoreAllMocks();
+});
+
+describe('App composer footer renderer', () => {
+  it('passes composer state and keeps the header, composer, and footers ordered', async () => {
+    const composerFooterProps: WebShellComposerToolbarRenderInfo[] = [];
+    const ComposerFooter = (props: WebShellComposerToolbarRenderInfo) => {
+      composerFooterProps.push(props);
+      return <div data-testid="composer-footer">composer footer</div>;
+    };
+    const { container } = renderApp({
+      renderComposerHeader: () => (
+        <div data-testid="composer-header">composer header</div>
+      ),
+      renderComposerFooter: ComposerFooter,
+      renderFooter: () => <div data-testid="shell-footer">shell footer</div>,
+    });
+    await flush();
+
+    expect(composerFooterProps.at(-1)).toEqual({
+      disabled: false,
+      isRunning: false,
+      currentMode: 'default',
+      currentModel: 'qwen',
+      sessionName: 'Session One',
+    });
+
+    const composer = container.querySelector('[data-web-shell-composer]');
+    const composerHeader = container.querySelector(
+      '[data-testid="composer-header"]',
+    );
+    const composerFooter = container.querySelector(
+      '[data-testid="composer-footer"]',
+    );
+    const shellFooter = container.querySelector('[data-testid="shell-footer"]');
+
+    expect(composer).not.toBeNull();
+    expect(composerHeader?.parentElement?.nextElementSibling).toBe(composer);
+    expect(composer?.nextElementSibling).toBe(composerFooter);
+    expect(composerFooter?.parentElement).toBe(composer?.parentElement);
+    expect(composer?.parentElement?.nextElementSibling).toBe(shellFooter);
+  });
+
+  it('updates composer footer state and renders it in the empty welcome state', async () => {
+    const composerFooterProps: WebShellComposerToolbarRenderInfo[] = [];
+    const ComposerFooter = (props: WebShellComposerToolbarRenderInfo) => {
+      composerFooterProps.push(props);
+      return <div data-testid="composer-footer" />;
+    };
+    const { container, rerender } = renderApp({
+      renderComposerFooter: ComposerFooter,
+    });
+    await flush();
+
+    testState.streamingState = 'responding';
+    mockConnection.currentMode = 'plan';
+    mockConnection.currentModel = 'qwen-next';
+    mockConnection.displayName = 'Session Two';
+    rerender({ renderComposerFooter: ComposerFooter });
+    await flush();
+
+    expect(composerFooterProps.at(-1)).toEqual({
+      disabled: false,
+      isRunning: true,
+      currentMode: 'plan',
+      currentModel: 'qwen-next',
+      sessionName: 'Session Two',
+    });
+
+    mockConnection.catchingUp = true;
+    rerender({ renderComposerFooter: ComposerFooter });
+    await flush();
+
+    expect(composerFooterProps.at(-1)).toEqual({
+      disabled: true,
+      isRunning: true,
+      currentMode: 'plan',
+      currentModel: 'qwen-next',
+      sessionName: 'Session Two',
+    });
+
+    mockConnection.catchingUp = false;
+    testState.streamingState = 'idle';
+    mockConnection.sessionId = undefined;
+    mockConnection.displayName = undefined;
+    rerender({ renderComposerFooter: ComposerFooter });
+    await flush();
+
+    expect(
+      container.querySelector('[data-testid="composer-footer"]'),
+    ).not.toBeNull();
+    expect(composerFooterProps.at(-1)).toEqual({
+      disabled: false,
+      isRunning: false,
+      currentMode: 'plan',
+      currentModel: 'qwen-next',
+      sessionName: undefined,
+    });
+  });
+
+  it('does not add composer footer DOM when omitted or when the renderer returns null', async () => {
+    const { container, rerender } = renderApp();
+    await flush();
+
+    const composer = container.querySelector('[data-web-shell-composer]');
+    const composerChildren = Array.from(
+      composer?.parentElement?.children ?? [],
+    );
+    expect(composer?.nextElementSibling).toBeNull();
+
+    rerender({ renderComposerFooter: () => null });
+    await flush();
+
+    const nullComposer = container.querySelector('[data-web-shell-composer]');
+    const nullComposerChildren = Array.from(
+      nullComposer?.parentElement?.children ?? [],
+    );
+    expect(nullComposer?.nextElementSibling).toBeNull();
+    expect(nullComposerChildren).toHaveLength(composerChildren.length);
+    expect(
+      nullComposerChildren.map((child) =>
+        child.getAttribute('data-web-shell-composer'),
+      ),
+    ).toEqual(
+      composerChildren.map((child) =>
+        child.getAttribute('data-web-shell-composer'),
+      ),
+    );
+  });
 });
 
 describe('App shell command queueing', () => {

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -271,6 +271,7 @@ import {
   type ComposerToolbarEndRenderer,
   type ComposerToolbarRightRenderer,
   type ComposerHeaderRenderer,
+  type ComposerFooterRenderer,
   type ChatHeaderRenderer,
   type FooterRenderer,
   type LoadingPhrasesResolver,
@@ -619,6 +620,8 @@ export interface WebShellProps {
   renderComposerToolbarRight?: ComposerToolbarRightRenderer;
   /** Custom renderer shown directly above the chat composer input. */
   renderComposerHeader?: ComposerHeaderRenderer;
+  /** Custom renderer shown directly below the chat composer input. */
+  renderComposerFooter?: ComposerFooterRenderer;
   /**
    * Custom renderer shown at the top of the chat view, above the message list.
    * Only rendered when a session is active (not in the welcome/empty state).
@@ -1111,6 +1114,7 @@ export function App({
   renderComposerToolbarEnd,
   renderComposerToolbarRight,
   renderComposerHeader,
+  renderComposerFooter,
   renderChatHeader,
   renderFooter,
   bottomStatusItems,
@@ -1315,6 +1319,7 @@ export function App({
       renderComposerToolbarEnd,
       renderComposerToolbarRight,
       renderComposerHeader,
+      renderComposerFooter,
       renderFooter,
       compactThinking,
       collapseCompletedTurns,
@@ -1337,6 +1342,7 @@ export function App({
       renderComposerToolbarEnd,
       renderComposerToolbarRight,
       renderComposerHeader,
+      renderComposerFooter,
       renderFooter,
       compactThinking,
       collapseCompletedTurns,
@@ -1347,6 +1353,7 @@ export function App({
   );
   const CustomFooter = renderFooter;
   const CustomComposerHeader = renderComposerHeader;
+  const CustomComposerFooter = renderComposerFooter;
   const store = useTranscriptStore();
   const blocks = useTranscriptBlocks();
   const connection = useConnection();
@@ -8586,6 +8593,15 @@ export function App({
                           composerInputVersion={composerInputVersion}
                           placeholderText={composerPlaceholderText}
                         />
+                        {CustomComposerFooter && (
+                          <CustomComposerFooter
+                            disabled={isDisabled}
+                            isRunning={streamingState !== 'idle'}
+                            currentMode={currentMode}
+                            currentModel={currentModel}
+                            sessionName={sessionDisplayName}
+                          />
+                        )}
                       </div>
                       {CustomFooter ? (
                         hasMobileComposerBottom ? (

--- a/packages/web-shell/client/components/ChatPane.test.tsx
+++ b/packages/web-shell/client/components/ChatPane.test.tsx
@@ -224,6 +224,7 @@ const { ChatPane } = await import('./ChatPane');
 
 let root: Root | null = null;
 let container: HTMLDivElement | null = null;
+const EMPTY_CUSTOMIZATION: WebShellCustomization = {};
 
 beforeEach(() => {
   connectionState = {
@@ -275,7 +276,7 @@ afterEach(() => {
 
 function render(
   props: Record<string, unknown> = {},
-  customization: WebShellCustomization = {},
+  customization: WebShellCustomization = EMPTY_CUSTOMIZATION,
 ): void {
   container = document.createElement('div');
   document.body.appendChild(container);
@@ -293,7 +294,7 @@ function render(
 
 function rerender(
   props: Record<string, unknown> = {},
-  customization: WebShellCustomization = {},
+  customization: WebShellCustomization = EMPTY_CUSTOMIZATION,
 ): void {
   act(() =>
     root!.render(
@@ -365,8 +366,8 @@ describe('ChatPane', () => {
     };
     rerender({}, customization);
 
-    expect(latestChatEditorProps.disabled).toBeUndefined();
-    expect(footerProps.at(-1)?.disabled).toBe(false);
+    expect(latestChatEditorProps.disabled).toBe(true);
+    expect(footerProps.at(-1)?.disabled).toBe(true);
   });
 
   it('adds no composer footer DOM when omitted or returning null', () => {
@@ -374,7 +375,7 @@ describe('ChatPane', () => {
     const composer = container!.querySelector('[data-web-shell-composer]');
     const children = Array.from(composer?.parentElement?.children ?? []);
     expect(composer?.nextElementSibling).toBeNull();
-    expect(latestChatEditorProps.disabled).toBeUndefined();
+    expect(latestChatEditorProps.disabled).toBe(false);
 
     rerender({}, { renderComposerFooter: () => null });
 
@@ -483,13 +484,7 @@ describe('ChatPane', () => {
     expect(voiceTarget).toBeDefined();
 
     pendingPermission = { id: 'perm-1', toolName: 'write_file', rawInput: {} };
-    act(() => {
-      root?.render(
-        <I18nProvider language="en">
-          <ChatPane workspaceCwd="/w" />
-        </I18nProvider>,
-      );
-    });
+    rerender({ workspaceCwd: '/w' });
 
     expect(latestChatEditorProps.dialogOpen).toBe(true);
     expect(latestChatEditorProps.disabled).toBe(true);

--- a/packages/web-shell/client/components/ChatPane.test.tsx
+++ b/packages/web-shell/client/components/ChatPane.test.tsx
@@ -9,6 +9,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, forwardRef, useImperativeHandle } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { I18nProvider } from '../i18n';
+import {
+  WebShellCustomizationProvider,
+  type WebShellComposerToolbarRenderInfo,
+  type WebShellCustomization,
+} from '../customization';
 
 Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
 
@@ -136,7 +141,7 @@ vi.mock('./ChatEditor', () => ({
       insertText,
     }));
     return (
-      <div>
+      <div data-web-shell-composer>
         <button
           data-testid="pane-submit"
           onClick={() => props.onSubmit('hello there')}
@@ -268,15 +273,35 @@ afterEach(() => {
   container = null;
 });
 
-function render(props: Record<string, unknown> = {}): void {
+function render(
+  props: Record<string, unknown> = {},
+  customization: WebShellCustomization = {},
+): void {
   container = document.createElement('div');
   document.body.appendChild(container);
   root = createRoot(container);
   act(() =>
     root!.render(
-      <I18nProvider language="en">
-        <ChatPane {...props} />
-      </I18nProvider>,
+      <WebShellCustomizationProvider value={customization}>
+        <I18nProvider language="en">
+          <ChatPane {...props} />
+        </I18nProvider>
+      </WebShellCustomizationProvider>,
+    ),
+  );
+}
+
+function rerender(
+  props: Record<string, unknown> = {},
+  customization: WebShellCustomization = {},
+): void {
+  act(() =>
+    root!.render(
+      <WebShellCustomizationProvider value={customization}>
+        <I18nProvider language="en">
+          <ChatPane {...props} />
+        </I18nProvider>
+      </WebShellCustomizationProvider>,
     ),
   );
 }
@@ -286,6 +311,80 @@ function testid(id: string): HTMLElement | null {
 }
 
 describe('ChatPane', () => {
+  it('renders the custom composer footer directly after the pane editor', () => {
+    const footerProps: WebShellComposerToolbarRenderInfo[] = [];
+    const ComposerFooter = (props: WebShellComposerToolbarRenderInfo) => {
+      footerProps.push(props);
+      return <div data-testid="pane-composer-footer">pane footer</div>;
+    };
+
+    render({}, { renderComposerFooter: ComposerFooter });
+
+    const composer = container!.querySelector('[data-web-shell-composer]');
+    const footer = testid('pane-composer-footer');
+    expect(composer?.nextElementSibling).toBe(footer);
+    expect(footer?.parentElement).toBe(composer?.parentElement);
+    expect(footerProps.at(-1)).toEqual({
+      disabled: false,
+      isRunning: false,
+      currentMode: 'default',
+      currentModel: '',
+      sessionName: 'Refactor core',
+    });
+  });
+
+  it('updates the custom composer footer with pane-scoped state', () => {
+    const footerProps: WebShellComposerToolbarRenderInfo[] = [];
+    const ComposerFooter = (props: WebShellComposerToolbarRenderInfo) => {
+      footerProps.push(props);
+      return <div data-testid="pane-composer-footer" />;
+    };
+    const customization = { renderComposerFooter: ComposerFooter };
+    render({}, customization);
+
+    streamingStateValue = 'responding';
+    connectionState.catchingUp = true;
+    connectionState.currentMode = 'plan';
+    connectionState.currentModel = 'qwen-next';
+    connectionState.displayName = 'Pane Two';
+    rerender({}, customization);
+
+    expect(footerProps.at(-1)).toEqual({
+      disabled: false,
+      isRunning: true,
+      currentMode: 'plan',
+      currentModel: 'qwen-next',
+      sessionName: 'Pane Two',
+    });
+
+    connectionState.catchingUp = false;
+    pendingPermission = {
+      id: 'perm-1',
+      toolName: 'write_file',
+      rawInput: {},
+    };
+    rerender({}, customization);
+
+    expect(latestChatEditorProps.disabled).toBeUndefined();
+    expect(footerProps.at(-1)?.disabled).toBe(false);
+  });
+
+  it('adds no composer footer DOM when omitted or returning null', () => {
+    render();
+    const composer = container!.querySelector('[data-web-shell-composer]');
+    const children = Array.from(composer?.parentElement?.children ?? []);
+    expect(composer?.nextElementSibling).toBeNull();
+    expect(latestChatEditorProps.disabled).toBeUndefined();
+
+    rerender({}, { renderComposerFooter: () => null });
+
+    const nullComposer = container!.querySelector('[data-web-shell-composer]');
+    expect(nullComposer?.nextElementSibling).toBeNull();
+    expect(
+      Array.from(nullComposer?.parentElement?.children ?? []),
+    ).toHaveLength(children.length);
+  });
+
   it('renders the session transcript and header label', () => {
     render({ title: 'Refactor core' });
     expect(testid('pane-messages')?.textContent).toBe('1');

--- a/packages/web-shell/client/components/ChatPane.test.tsx
+++ b/packages/web-shell/client/components/ChatPane.test.tsx
@@ -537,13 +537,7 @@ describe('ChatPane', () => {
     render({ workspaceCwd: '/work/other' });
     expect(latestChatEditorProps.voiceTarget).toBeUndefined();
 
-    act(() => {
-      root?.render(
-        <I18nProvider language="en">
-          <ChatPane workspaceCwd="/work/api" hidden />
-        </I18nProvider>,
-      );
-    });
+    rerender({ workspaceCwd: '/work/api', hidden: true });
     expect(latestChatEditorProps.voiceTarget).toBeUndefined();
   });
 

--- a/packages/web-shell/client/components/ChatPane.tsx
+++ b/packages/web-shell/client/components/ChatPane.tsx
@@ -736,7 +736,7 @@ export function ChatPane({
         />
         {CustomComposerFooter && (
           <CustomComposerFooter
-            disabled={false}
+            disabled={approvalActive}
             isRunning={isResponding}
             currentMode={connection.currentMode ?? 'default'}
             currentModel={connection.currentModel ?? ''}

--- a/packages/web-shell/client/components/ChatPane.tsx
+++ b/packages/web-shell/client/components/ChatPane.tsx
@@ -25,6 +25,7 @@ import type {
 import type { ACPToolCall } from '../adapters/types';
 import { SubagentDetailsProvider } from '../subagentDetailsContext';
 import { useI18n } from '../i18n';
+import { useWebShellCustomization } from '../customization';
 import { SESSION_TRANSCRIPT_PAGINATION_FEATURE } from '../constants/sessions';
 import { useMessages } from '../hooks/useMessages';
 import { useSessionArtifacts } from '../hooks/useSessionArtifacts';
@@ -149,6 +150,8 @@ export function ChatPane({
   voiceWorkspaces,
 }: ChatPaneProps) {
   const { t } = useI18n();
+  const { renderComposerFooter: CustomComposerFooter } =
+    useWebShellCustomization();
   const connection = useConnection();
   const actions = useActions();
   const workspaceActions = useWorkspaceActions();
@@ -731,6 +734,15 @@ export function ChatPane({
           onDismissFollowup={onDismissFollowup}
           placeholderText={t('splitView.composerPlaceholder')}
         />
+        {CustomComposerFooter && (
+          <CustomComposerFooter
+            disabled={false}
+            isRunning={isResponding}
+            currentMode={connection.currentMode ?? 'default'}
+            currentModel={connection.currentModel ?? ''}
+            sessionName={connection.displayName}
+          />
+        )}
       </div>
     </section>
   );

--- a/packages/web-shell/client/customization.tsx
+++ b/packages/web-shell/client/customization.tsx
@@ -318,6 +318,9 @@ export type ComposerToolbarRightRenderer =
 export type ComposerHeaderRenderer =
   ComponentType<WebShellComposerToolbarRenderInfo>;
 
+export type ComposerFooterRenderer =
+  ComponentType<WebShellComposerToolbarRenderInfo>;
+
 // ---- Background task info (public type for footer renderer) ----
 
 interface WebShellTaskBase {
@@ -422,6 +425,7 @@ export interface WebShellCustomization {
   renderComposerToolbarEnd?: ComposerToolbarEndRenderer;
   renderComposerToolbarRight?: ComposerToolbarRightRenderer;
   renderComposerHeader?: ComposerHeaderRenderer;
+  renderComposerFooter?: ComposerFooterRenderer;
   renderFooter?: FooterRenderer;
   compactThinking?: boolean;
   /**

--- a/packages/web-shell/client/index.tsx
+++ b/packages/web-shell/client/index.tsx
@@ -172,6 +172,7 @@ export type {
   UserMessageContentRenderInfo,
   UserMessageContentParser,
   ComposerHeaderRenderer,
+  ComposerFooterRenderer,
   ComposerToolbarStartRenderer,
   ComposerToolbarRightRenderer,
   WebShellAtItemRenderInfo,


### PR DESCRIPTION
## What this PR does

Adds an optional `renderComposerFooter` customization hook to WebShell. Hosts can render contextual content immediately after the composer in both the primary chat and split-view panes. The renderer receives the same composer state contract used by the existing header hook (`sessionId` and `inputDisabled`), and omitting the hook or returning `null` adds no DOM.

## Why it's needed

Embedded WebShell hosts sometimes need to place notices, guidance, or other host-owned content next to the composer. A generic render hook provides that placement without moving host-specific wording, styling, or policy into WebShell.

## Reviewer Test Plan

### How to verify

1. Run `npm run test --workspace=packages/web-shell -- client/App.test.tsx client/components/ChatPane.test.tsx` and confirm all focused tests pass.
2. Run `npm run test --workspace=packages/web-shell` and confirm the full WebShell suite passes.
3. Run `npm run build --workspace=packages/web-shell` and confirm the package builds.
4. Review the composer tests and confirm the footer is placed directly after `ChatEditor` in the primary and split-pane composers, receives the pane-specific state, and produces no extra DOM when omitted or when the renderer returns `null`.

Local results: focused tests passed (264/264), the full WebShell suite passed (138 files, 2268 tests), and the WebShell build passed. `npm run verify --workspace=packages/web-shell` passed linting but stopped on formatting in two unchanged baseline files (`packages/web-shell/client/components/GitModePopover.module.css` and `packages/web-shell/client/index.html`). Root `npm run preflight` passed clean, install, format, lint, build, and typecheck, then `test:ci` failed in unrelated CLI tests; a focused rerun left four failures in `packages/cli/src/commands/extensions/list.test.ts` (local Chinese locale versus an English assertion) and `packages/cli/src/ui/auth/AuthDialog.test.tsx` (three interaction timing/selection assertions).

### Evidence (Before & After)

N/A — this PR adds an opt-in WebShell extension point and does not change the default UI. Host content and styling are intentionally outside this PR.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local macOS development environment with the repository workspace dependencies installed through `npm ci`.

## Risk & Scope

- Main risk or tradeoff: The renderer runs for each composer instance, so hosts must keep rendered content pane-safe and lightweight; coverage includes primary and split-view composers.
- Not validated / out of scope: Windows and Linux were not tested locally. Host-specific content, styling, and business policy are not included.
- Breaking changes / migration notes: None. The hook is optional and existing consumers render exactly as before when it is omitted or returns `null`.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

为 WebShell 新增可选的 `renderComposerFooter` 自定义渲染钩子。宿主可以在主聊天和分屏面板的输入框后方紧邻位置渲染上下文内容。渲染器接收与现有 header 钩子一致的输入框状态契约（`sessionId` 和 `inputDisabled`）；未传入该钩子或渲染器返回 `null` 时不会增加任何 DOM。

## 为什么需要它

嵌入 WebShell 的宿主有时需要在输入框附近展示提示、引导或其他由宿主管理的内容。通用渲染钩子可以提供这一挂载位置，同时避免把宿主特有的文案、样式或策略放进 WebShell。

## Reviewer 测试计划

### 如何验证

1. 运行 `npm run test --workspace=packages/web-shell -- client/App.test.tsx client/components/ChatPane.test.tsx`，确认所有定向测试通过。
2. 运行 `npm run test --workspace=packages/web-shell`，确认 WebShell 全量测试通过。
3. 运行 `npm run build --workspace=packages/web-shell`，确认包构建通过。
4. 检查输入框相关测试，确认 footer 在主输入框和分屏输入框中都直接位于 `ChatEditor` 之后，能够收到对应面板的状态，并且未传入渲染器或渲染器返回 `null` 时不会产生额外 DOM。

本地结果：定向测试通过（264/264），WebShell 全量测试通过（138 个文件、2268 个测试），WebShell 构建通过。`npm run verify --workspace=packages/web-shell` 的 lint 已通过，但被两个未修改的基线格式文件拦截（`packages/web-shell/client/components/GitModePopover.module.css` 和 `packages/web-shell/client/index.html`）。根目录 `npm run preflight` 的清理、安装、格式化、lint、构建和类型检查均通过，随后 `test:ci` 在与本 PR 无关的 CLI 测试中失败；定向复跑后剩余 4 个失败，分别位于 `packages/cli/src/commands/extensions/list.test.ts`（本机中文 locale 与英文断言不一致）和 `packages/cli/src/ui/auth/AuthDialog.test.tsx`（3 个交互时序/选择断言）。

### 证据（修改前与修改后）

不适用——本 PR 新增的是按需启用的 WebShell 扩展点，不会改变默认 UI。宿主内容和样式有意不包含在本 PR 中。

### 测试平台

|    操作系统    | 状态 |
| :------------: | :--: |
|   🍏 macOS     |  ✅  |
|  🪟 Windows    |  ⚠️  |
|   🐧 Linux     |  ⚠️  |

### 环境（可选）

本地 macOS 开发环境，仓库工作区依赖通过 `npm ci` 安装。

## 风险与范围

- 主要风险或取舍：每个输入框实例都会调用该渲染器，因此宿主应确保渲染内容可安全用于不同面板且足够轻量；测试已覆盖主输入框和分屏输入框。
- 未验证 / 范围外：未在本地验证 Windows 和 Linux。宿主特有的内容、样式和业务策略不在本 PR 范围内。
- 破坏性变更 / 迁移说明：无。该钩子是可选的；未传入或返回 `null` 时，现有消费者的渲染行为与之前完全一致。

## 关联 Issue

不适用

</details>
