### PR TITLE
fix(core): pass the Grep pattern behind -e so a leading dash is not an option

### DIFF
--- a/packages/core/src/tools/grep.test.ts
+++ b/packages/core/src/tools/grep.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { spawn } from 'node:child_process';
 import type { GrepToolParams } from './grep.js';
 import { GrepTool } from './grep.js';
 import path from 'node:path';
@@ -853,6 +854,82 @@ describe('GrepTool', () => {
 
       // sub/fileC.txt (or its absolute path equivalent) should appear only once
       expect(result.llmContent).toContain('Found 1 match');
+    });
+  });
+
+  describe('search binary arguments', () => {
+    // The pattern reaches git grep and system grep as an argv entry, so a
+    // pattern that begins with a dash is indistinguishable from an option
+    // unless it is introduced by `-e`. `validateToolParams` accepts it --
+    // `new RegExp('-n')` is a perfectly good regex -- so the tool has to be the
+    // one to disambiguate it.
+    const argsFor = (bin: string): string[][] =>
+      vi
+        .mocked(spawn)
+        .mock.calls.filter((call) => call[0] === bin)
+        .map((call) => call[1] as string[]);
+
+    // True only when `b` directly follows `a`, which is what distinguishes the
+    // pattern from the identically-spelled `-n` flag git grep already passes.
+    const hasAdjacent = (args: string[], a: string, b: string): boolean =>
+      args.some((value, i) => value === a && args[i + 1] === b);
+
+    beforeEach(async () => {
+      vi.mocked(spawn).mockClear();
+      // isGitRepository only looks for a .git entry, so this is enough to make
+      // the git grep strategy run before the system grep fallback.
+      await fs.mkdir(path.join(tempRootDir, '.git'), { recursive: true });
+    });
+
+    it.each([['-n'], ['-i'], ['--color']])(
+      'introduces the pattern "%s" with -e for git grep',
+      async (pattern) => {
+        await grepTool.build({ pattern }).execute(abortSignal);
+
+        const calls = argsFor('git');
+        expect(calls).not.toHaveLength(0);
+        for (const args of calls) {
+          expect(hasAdjacent(args, '-e', pattern)).toBe(true);
+        }
+      },
+    );
+
+    it.each([['-n'], ['-i'], ['--color']])(
+      'introduces the pattern "%s" with -e for system grep',
+      async (pattern) => {
+        await grepTool.build({ pattern }).execute(abortSignal);
+
+        const calls = argsFor('grep');
+        expect(calls).not.toHaveLength(0);
+        for (const args of calls) {
+          expect(hasAdjacent(args, '-e', pattern)).toBe(true);
+        }
+      },
+    );
+
+    // Guards against over-correcting: the surrounding argv has to keep its
+    // shape. These assertions hold both before and after the fix.
+    it('leaves the rest of the argument list unchanged', async () => {
+      await grepTool
+        .build({ pattern: 'world', glob: '*.ts' })
+        .execute(abortSignal);
+
+      for (const args of argsFor('git')) {
+        expect(args[0]).toBe('grep');
+        expect(args).toEqual(
+          expect.arrayContaining(['--untracked', '-z', '-E']),
+        );
+        // The glob stays a pathspec, behind the `--` separator.
+        expect(hasAdjacent(args, '--', '*.ts')).toBe(true);
+      }
+      for (const args of argsFor('grep')) {
+        expect(args).toEqual(
+          expect.arrayContaining(['-r', '-n', '-H', '-E', '--null']),
+        );
+        expect(args).toContain('--include=*.ts');
+        // The search path stays the final operand.
+        expect(args[args.length - 1]).toBe('.');
+      }
     });
   });
 

--- a/packages/core/src/tools/grep.ts
+++ b/packages/core/src/tools/grep.ts
@@ -441,6 +441,11 @@ class GrepToolInvocation extends BaseToolInvocation<
 
       if (gitAvailable) {
         strategyUsed = 'git grep';
+        // The pattern goes behind `-e` so that one beginning with a dash is
+        // read as the pattern instead of as an option. Passed positionally,
+        // `git grep -E '-n'` consumes the `-n` as an option and then fails with
+        // `fatal: no pattern given` -- and that failure is swallowed by the
+        // fallback below, which has the same flaw with a quieter symptom.
         const gitArgs = [
           'grep',
           '--untracked',
@@ -448,6 +453,7 @@ class GrepToolInvocation extends BaseToolInvocation<
           '-z',
           '-E',
           '--ignore-case',
+          '-e',
           pattern,
         ];
         if (glob) {
@@ -520,7 +526,12 @@ class GrepToolInvocation extends BaseToolInvocation<
         if (glob) {
           grepArgs.push(`--include=${glob}`);
         }
-        grepArgs.push(pattern);
+        // Same reason as the `-e` above, but this strategy fails silently
+        // rather than loudly: with the pattern passed positionally, grep
+        // consumes a leading-dash pattern as an option and promotes the `.`
+        // search path to be the pattern, which matches every line of every
+        // file. The model is handed the whole tree as if it were the result.
+        grepArgs.push('-e', pattern);
         grepArgs.push('.');
 
         try {


### PR DESCRIPTION
## What this PR does

Introduces the Grep tool's search pattern with `-e` when invoking the external search binaries, so that a pattern beginning with a dash is read as the pattern rather than as a command-line option.

## Why it's needed

Both external strategies pass the user's pattern as a positional argument. A pattern like `-n`, `-i`, `-w` or `--color` is therefore consumed as an option by the search binary, and the results are wrong in two different ways depending on which strategy runs.

The git strategy fails loudly: `git grep --untracked -n -z -E --ignore-case '-n'` swallows the `-n` as a flag and exits with `fatal: no pattern given`. That failure is caught and logged at debug level, and execution falls through to the system grep — which has the same flaw with a much quieter symptom. `grep -r -n -H -E --null '-n' .` treats the `-n` as a flag and promotes the `.` search path to be the pattern, which matches every line of every file. The model asked for one thing and is handed the entire tree back as though it were the answer, with no error anywhere.

Nothing upstream rejects these patterns: `validateToolParams` only checks that the pattern compiles, and `new RegExp('-n')` is a perfectly good regex. The sibling ripgrep tool already avoids this by passing the pattern behind `--regexp`; this brings the two into line.

## Reviewer Test Plan

### How to verify

Against a scratch directory containing `f.txt` = `hello -world\n-n test\nplain\n` and `g.txt` = `alpha\nbeta\n`, running the exact argument lists the tool builds:

```
$ git grep --untracked -n -z -E --ignore-case '-n'          # before
fatal: no pattern given                                      (exit 128)

$ git grep --untracked -n -z -E --ignore-case -e '-n'       # after
f.txt 2 -n test                                              (exit 0)
```

```
$ grep -r -n -H -E --null '-n' .                            # before
./f.txt:1:hello -world
./f.txt:2:-n test
./f.txt:3:plain
./g.txt:1:alpha
./g.txt:2:beta                    <-- every line of every file; `.` became the pattern

$ grep -r -n -H -E --null -e '-n' .                         # after
./f.txt:2:-n test
```

An ordinary pattern is unaffected in both strategies (`-e 'hello'` returns exactly `./f.txt:1:hello -world`, as it did before).

Unit tests assert on the argv handed to `spawn`: six cases covering `-n`, `-i` and `--color` across both strategies, plus a guard that the rest of the argument list keeps its shape (the glob stays a pathspec behind `--` for git grep, `--include=` for system grep, and `.` stays the final operand). Reverting only `grep.ts` and keeping the tests fails exactly those six and leaves the guard passing.

```
$ npx vitest run --root packages/core src/tools/grep.test.ts
 Test Files  1 passed (1)
      Tests  59 passed (59)

# with src/tools/grep.ts reverted:
      Tests  6 failed | 53 passed (59)
```

### Evidence (Before & After)

N/A — not user-visible; the before/after command output is above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only, plus the shell reproduction above against BSD grep and git 2.x on macOS.

## Risk & Scope

- Main risk or tradeoff: `-e` is POSIX and supported by GNU grep, BSD grep and `git grep`, so the flag itself is safe. The only behavioural change is for patterns that begin with a dash, which previously could not work at all.
- Not validated / out of scope: no `--` separator was added before the search path, because that operand is the literal `.` and can never look like an option. The `ripGrep` tool needs no change — it already passes the pattern via `--regexp`.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

在调用外部搜索程序时，用 `-e` 引出 Grep 工具的搜索模式，使以短横线开头的模式被当作搜索模式读取，而不是被当作命令行选项。

## 为什么需要

两种外部策略都把用户的模式作为位置参数传递。因此像 `-n`、`-i`、`-w` 或 `--color` 这样的模式会被搜索程序当作选项吞掉，而且根据实际执行的是哪种策略，结果会以两种不同的方式出错。

git 策略是显式失败：`git grep --untracked -n -z -E --ignore-case '-n'` 把 `-n` 当作标志吞掉，并以 `fatal: no pattern given` 退出。该失败被捕获并记录为 debug 级别日志，随后回退到系统 grep——而系统 grep 存在同样的缺陷，症状却隐蔽得多。`grep -r -n -H -E --null '-n' .` 把 `-n` 当作标志，并把搜索路径 `.` 提升为搜索模式，于是匹配到每个文件的每一行。模型请求的是某个特定内容，拿回来的却是整棵目录树，却被当成了答案，而且任何地方都不会报错。

上游没有任何环节会拒绝这类模式：`validateToolParams` 只检查模式能否编译，而 `new RegExp('-n')` 是一个完全合法的正则表达式。同类的 ripgrep 工具已经通过 `--regexp` 传递模式从而规避了该问题；本次改动让两者保持一致。

## 审阅者测试计划

### 如何验证

在一个包含 `f.txt` = `hello -world\n-n test\nplain\n` 和 `g.txt` = `alpha\nbeta\n` 的临时目录中，运行本工具实际构造的参数列表：

```
$ git grep --untracked -n -z -E --ignore-case '-n'          # 修复前
fatal: no pattern given                                      (退出码 128)

$ git grep --untracked -n -z -E --ignore-case -e '-n'       # 修复后
f.txt 2 -n test                                              (退出码 0)
```

```
$ grep -r -n -H -E --null '-n' .                            # 修复前
./f.txt:1:hello -world
./f.txt:2:-n test
./f.txt:3:plain
./g.txt:1:alpha
./g.txt:2:beta                    <-- 每个文件的每一行；`.` 变成了搜索模式

$ grep -r -n -H -E --null -e '-n' .                         # 修复后
./f.txt:2:-n test
```

普通模式在两种策略下均不受影响（`-e 'hello'` 仍然只返回 `./f.txt:1:hello -world`，与修复前一致）。

单元测试针对传给 `spawn` 的 argv 进行断言：覆盖两种策略下 `-n`、`-i` 和 `--color` 共六个用例，另加一个防过度修正的保护性测试，确认参数列表其余部分保持原有形态（git grep 的 glob 仍作为 pathspec 位于 `--` 之后，系统 grep 仍使用 `--include=`，且 `.` 仍是最后一个操作数）。仅回退 `grep.ts` 而保留测试时，恰好这六个用例失败，保护性测试仍然通过。

```
$ npx vitest run --root packages/core src/tools/grep.test.ts
 Test Files  1 passed (1)
      Tests  59 passed (59)

# 回退 src/tools/grep.ts 后：
      Tests  6 failed | 53 passed (59)
```

### 证据（修复前后对比）

N/A——非用户可见改动；修复前后的命令输出见上文。

### 测试环境

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

仅单元测试，外加上文在 macOS 上针对 BSD grep 与 git 2.x 的 shell 复现。

## 风险与影响范围

- 主要风险或权衡：`-e` 是 POSIX 标准选项，GNU grep、BSD grep 和 `git grep` 均支持，因此该标志本身是安全的。唯一的行为变化针对以短横线开头的模式，而这类模式此前根本无法正常工作。
- 未验证 / 不在范围内：未在搜索路径前添加 `--` 分隔符，因为该操作数是字面量 `.`，永远不可能看起来像选项。`ripGrep` 工具无需改动——它已经通过 `--regexp` 传递模式。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
