### PR TITLE
fix(core): treat a bare & as a command boundary in splitCompoundCommand

### DIFF
--- a/packages/core/src/permissions/permission-manager.test.ts
+++ b/packages/core/src/permissions/permission-manager.test.ts
@@ -530,6 +530,9 @@ describe('splitCompoundCommand', () => {
     ['ls /nope 2>&1'],
     ['echo err >&2'],
     ['ls /nope > out.txt 2>& 1'],
+    // Input-descriptor duplication: the `<` branch of the backward scan.
+    ['exec 3<&4'],
+    ['cat <&3'],
   ])('does not split %s, where & belongs to a redirection', async (command) => {
     expect(splitCompoundCommand(command)).toEqual([command]);
   });

--- a/packages/core/src/permissions/permission-manager.test.ts
+++ b/packages/core/src/permissions/permission-manager.test.ts
@@ -478,7 +478,16 @@ describe('splitCompoundCommand', () => {
   });
 
   it('handles escaped characters', async () => {
-    expect(splitCompoundCommand('echo a \\&& b')).toEqual(['echo a \\&& b']);
+    // A backslash escapes exactly one character, so `\&` is a literal
+    // ampersand argument and the command really is a single one.
+    expect(splitCompoundCommand('echo a \\& b')).toEqual(['echo a \\& b']);
+  });
+
+  it('escapes only the first of two ampersands', async () => {
+    // `echo a \&& b` is not an escaped `&&`: the backslash consumes the first
+    // ampersand and the second is a live async operator. `bash -x` runs it as
+    // two commands, `echo a '&'` and `b`, so the splitter has to see two.
+    expect(splitCompoundCommand('echo a \\&& b')).toEqual(['echo a \\&', 'b']);
   });
 
   it('trims whitespace around sub-commands', async () => {
@@ -486,6 +495,63 @@ describe('splitCompoundCommand', () => {
       'git status',
       'rm -rf /',
     ]);
+  });
+
+  // The async operator. Everything after a bare `&` is a separate command that
+  // the shell will run, so leaving it joined let one segment's allow rule
+  // authorise whatever followed it.
+  it('splits on the async operator', async () => {
+    expect(splitCompoundCommand('git status & rm -rf /tmp/x')).toEqual([
+      'git status',
+      'rm -rf /tmp/x',
+    ]);
+  });
+
+  it('splits on repeated async operators', async () => {
+    expect(splitCompoundCommand('a & b & c')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('drops the empty segment after a trailing async operator', async () => {
+    expect(splitCompoundCommand('npm test &')).toEqual(['npm test']);
+  });
+
+  it('splits an unquoted URL query the way the shell does', async () => {
+    // Not a special case: an unquoted `&` in a URL really is the async
+    // operator, and bash runs `b=2` as its own command.
+    expect(splitCompoundCommand('curl http://x?a=1&b=2')).toEqual([
+      'curl http://x?a=1',
+      'b=2',
+    ]);
+  });
+
+  it.each([
+    ['build &> log.txt'],
+    ['build &>> log.txt'],
+    ['ls /nope 2>&1'],
+    ['echo err >&2'],
+    ['ls /nope > out.txt 2>& 1'],
+  ])('does not split %s, where & belongs to a redirection', async (command) => {
+    expect(splitCompoundCommand(command)).toEqual([command]);
+  });
+
+  it.each([["echo 'x & y'"], ['echo "x & y"']])(
+    'does not split %s, where & is quoted',
+    async (command) => {
+      expect(splitCompoundCommand(command)).toEqual([command]);
+    },
+  );
+
+  // Over-correction guard: the longer operators must keep winning over the
+  // bare `&`, so these two pass both before and after the change.
+  it.each([
+    ['a && b', ['a', 'b']],
+    ['a |& b', ['a', 'b']],
+  ])('keeps %s splitting on the longer operator', async (command, expected) => {
+    expect(splitCompoundCommand(command)).toEqual(expected);
+  });
+
+  it('splits a mix of long and bare operators', async () => {
+    expect(splitCompoundCommand('a && b & c')).toEqual(['a', 'b', 'c']);
   });
 });
 

--- a/packages/core/src/permissions/permission-manager.test.ts
+++ b/packages/core/src/permissions/permission-manager.test.ts
@@ -20,6 +20,7 @@ import {
   getSpecifierKind,
   toolMatchesRuleToolName,
   splitCompoundCommand,
+  splitCompoundCommandSegments,
   buildPermissionRules,
   getRuleDisplayName,
   buildHumanReadableRuleLabel,
@@ -555,6 +556,78 @@ describe('splitCompoundCommand', () => {
 
   it('splits a mix of long and bare operators', async () => {
     expect(splitCompoundCommand('a && b & c')).toEqual(['a', 'b', 'c']);
+  });
+
+  // The backward scan for a redirection has to respect escaping. `\>` is a
+  // literal `>` argument, so bash backgrounds the `echo` and then runs the
+  // `rm`; reading it as a redirection kept both in one segment and let the
+  // `echo`'s allow rule authorise the `rm`.
+  it.each([
+    ['echo a \\> & rm -rf /tmp/x', ['echo a \\>', 'rm -rf /tmp/x']],
+    ['echo a \\< & rm -rf /tmp/x', ['echo a \\<', 'rm -rf /tmp/x']],
+  ])('splits %s, where the redirection is escaped', async (command, parts) => {
+    expect(splitCompoundCommand(command)).toEqual(parts);
+  });
+
+  it('keeps an escaped backslash before a real redirection unsplit', async () => {
+    // Two backslashes are a literal backslash, so the `>` really is a
+    // redirection and the `&` really does duplicate a descriptor.
+    expect(splitCompoundCommand('echo a \\\\>& 2')).toEqual([
+      'echo a \\\\>& 2',
+    ]);
+  });
+
+  // Inside `$(( … ))` / `(( … ))` a bare `&` is bitwise AND. Splitting there
+  // produced two fragments that match no rule, so an otherwise allowed command
+  // stopped matching its own allow rule.
+  it.each([
+    ['VAR=$(( FLAGS & MASK ))'],
+    ['(( a & b ))'],
+    ['echo $(( (x & y) + z ))'],
+  ])('does not split %s, where & is arithmetic', async (command) => {
+    expect(splitCompoundCommand(command)).toEqual([command]);
+  });
+
+  it('still splits a bare & that follows an arithmetic expansion', async () => {
+    // Over-correction guard: the depth counter has to come back down.
+    expect(splitCompoundCommand('echo $(( a & b )) & rm -rf /tmp/x')).toEqual([
+      'echo $(( a & b ))',
+      'rm -rf /tmp/x',
+    ]);
+  });
+
+  // The backward scan runs off the front of the string: nothing precedes the
+  // `&`, so it cannot be part of a redirection and is the async operator.
+  it.each([['& echo hi'], ['   & echo hi']])(
+    'treats the leading & in %s as the async operator',
+    async (command) => {
+      expect(splitCompoundCommand(command)).toEqual(['echo hi']);
+    },
+  );
+});
+
+// ─── splitCompoundCommandSegments ────────────────────────────────────────────
+
+describe('splitCompoundCommandSegments', () => {
+  it('reports the operator that terminated each segment', async () => {
+    expect(splitCompoundCommandSegments('a & b && c | d')).toEqual([
+      { command: 'a', terminator: '&' },
+      { command: 'b', terminator: '&&' },
+      { command: 'c', terminator: '|' },
+      { command: 'd', terminator: '' },
+    ]);
+  });
+
+  it('reports an empty terminator for a single command', async () => {
+    expect(splitCompoundCommandSegments('git status')).toEqual([
+      { command: 'git status', terminator: '' },
+    ]);
+  });
+
+  it('keeps the async terminator on a trailing background command', async () => {
+    expect(splitCompoundCommandSegments('npm test &')).toEqual([
+      { command: 'npm test', terminator: '&' },
+    ]);
   });
 });
 

--- a/packages/core/src/permissions/rule-parser.ts
+++ b/packages/core/src/permissions/rule-parser.ts
@@ -662,7 +662,31 @@ export function buildHumanReadableRuleLabel(rules: string[]): string {
  * Shell operator tokens that act as command boundaries.
  * Ordered by length (longest first) for correct multi-char operator detection.
  */
-const SHELL_OPERATORS = ['&&', '||', ';;', '|&', '|', ';', '\n'];
+const SHELL_OPERATORS = ['&&', '||', ';;', '|&', '|', ';', '&', '\n'];
+
+/**
+ * Whether the `&` at `index` is the async (background) operator rather than
+ * part of a redirection.
+ *
+ * `&&` and `|&` never reach here — they are longer, so they match first — which
+ * leaves three forms to exclude: `&>` and `&>>` redirect both streams, and
+ * `>&` / `<&` duplicate a descriptor (`2>&1`, `>&2`). Confirmed against bash:
+ * `echo hi &> out` writes the file and backgrounds nothing, while
+ * `echo one & echo two` really does run two commands.
+ */
+function isAsyncOperator(command: string, index: number): boolean {
+  if (command[index + 1] === '>') {
+    return false;
+  }
+  for (let j = index - 1; j >= 0; j--) {
+    const ch = command[j]!;
+    if (/\s/.test(ch)) {
+      continue;
+    }
+    return ch !== '>' && ch !== '<';
+  }
+  return true;
+}
 
 /**
  * Split a compound shell command into its individual simple commands
@@ -676,6 +700,8 @@ const SHELL_OPERATORS = ['&&', '||', ';;', '|&', '|', ';', '\n'];
  *   "ls -la | grep foo"      → ["ls -la", "grep foo"]
  *   "echo 'a && b'"          → ["echo 'a && b'"]  (inside quotes)
  *   "a && b || c"            → ["a", "b", "c"]
+ *   "git status & rm -rf /"  → ["git status", "rm -rf /"]  (async operator)
+ *   "build &> log.txt"       → ["build &> log.txt"]  (redirection, not async)
  */
 export function splitCompoundCommand(command: string): string[] {
   const commands: string[] = [];
@@ -709,15 +735,21 @@ export function splitCompoundCommand(command: string): string[] {
 
     // Check for shell operators (longest match first)
     for (const op of SHELL_OPERATORS) {
-      if (command.substring(i, i + op.length) === op) {
-        const segment = command.substring(lastSplit, i).trim();
-        if (segment) {
-          commands.push(segment);
-        }
-        lastSplit = i + op.length;
-        i = lastSplit - 1; // -1 because the loop will i++
-        break;
+      if (command.substring(i, i + op.length) !== op) {
+        continue;
       }
+      // A bare `&` bounds a command only when it is the async operator; its
+      // other spellings belong to a redirection and stay in the segment.
+      if (op === '&' && !isAsyncOperator(command, i)) {
+        continue;
+      }
+      const segment = command.substring(lastSplit, i).trim();
+      if (segment) {
+        commands.push(segment);
+      }
+      lastSplit = i + op.length;
+      i = lastSplit - 1; // -1 because the loop will i++
+      break;
     }
   }
 

--- a/packages/core/src/permissions/rule-parser.ts
+++ b/packages/core/src/permissions/rule-parser.ts
@@ -665,6 +665,20 @@ export function buildHumanReadableRuleLabel(rules: string[]): string {
 const SHELL_OPERATORS = ['&&', '||', ';;', '|&', '|', ';', '&', '\n'];
 
 /**
+ * Count the consecutive backslashes immediately before `index`.
+ *
+ * An odd count means the character at `index` is itself escaped, so it is a
+ * literal rather than a shell metacharacter.
+ */
+function precedingBackslashCount(command: string, index: number): number {
+  let count = 0;
+  for (let k = index - 1; k >= 0 && command[k] === '\\'; k--) {
+    count++;
+  }
+  return count;
+}
+
+/**
  * Whether the `&` at `index` is the async (background) operator rather than
  * part of a redirection.
  *
@@ -673,6 +687,12 @@ const SHELL_OPERATORS = ['&&', '||', ';;', '|&', '|', ';', '&', '\n'];
  * `>&` / `<&` duplicate a descriptor (`2>&1`, `>&2`). Confirmed against bash:
  * `echo hi &> out` writes the file and backgrounds nothing, while
  * `echo one & echo two` really does run two commands.
+ *
+ * The backward scan is escape-aware, and has to be: `\>` is a literal `>`
+ * argument, not a redirection, so `echo a \> & rm -rf /` really does background
+ * the `echo` and then run the `rm`. Reading that `\>` as a redirection would
+ * keep both halves in one segment and let the `echo`'s allow rule cover the
+ * `rm`.
  */
 function isAsyncOperator(command: string, index: number): boolean {
   if (command[index + 1] === '>') {
@@ -683,32 +703,47 @@ function isAsyncOperator(command: string, index: number): boolean {
     if (/\s/.test(ch)) {
       continue;
     }
-    return ch !== '>' && ch !== '<';
+    if (ch === '>' || ch === '<') {
+      // Escaped, so a literal argument and the `&` still backgrounds.
+      return precedingBackslashCount(command, j) % 2 === 1;
+    }
+    return true;
   }
   return true;
 }
 
 /**
- * Split a compound shell command into its individual simple commands
- * by splitting on unquoted shell operators (&&, ||, ;, |, etc.).
- *
- * Returns an array of trimmed simple command strings.
- * For simple commands (no operators), returns a single-element array.
- *
- * Examples:
- *   "git status && rm -rf /"  → ["git status", "rm -rf /"]
- *   "ls -la | grep foo"      → ["ls -la", "grep foo"]
- *   "echo 'a && b'"          → ["echo 'a && b'"]  (inside quotes)
- *   "a && b || c"            → ["a", "b", "c"]
- *   "git status & rm -rf /"  → ["git status", "rm -rf /"]  (async operator)
- *   "build &> log.txt"       → ["build &> log.txt"]  (redirection, not async)
+ * One segment of a compound command, together with the operator that ended it.
  */
-export function splitCompoundCommand(command: string): string[] {
-  const commands: string[] = [];
+export interface CompoundCommandSegment {
+  /** The trimmed simple command. */
+  command: string;
+  /**
+   * The operator that terminated this segment, or `''` when the segment ran to
+   * the end of the input. Lets callers tell a foreground segment from one the
+   * shell runs in a subshell (`&`).
+   */
+  terminator: string;
+}
+
+/**
+ * Split a compound shell command into its individual simple commands, keeping
+ * the operator that terminated each one.
+ *
+ * See {@link splitCompoundCommand} for the string-only form and for examples;
+ * this is the same split, and that function is a projection of this one.
+ */
+export function splitCompoundCommandSegments(
+  command: string,
+): CompoundCommandSegment[] {
+  const segments: CompoundCommandSegment[] = [];
   let inSingle = false;
   let inDouble = false;
   let escaped = false;
   let lastSplit = 0;
+  // Nesting depth of `$(( … ))` / `(( … ))`. Inside arithmetic a bare `&` is
+  // bitwise AND, not the async operator, so `$(( FLAGS & MASK ))` is one word.
+  let arithmeticDepth = 0;
 
   for (let i = 0; i < command.length; i++) {
     const ch = command[i]!;
@@ -733,19 +768,31 @@ export function splitCompoundCommand(command: string): string[] {
       continue;
     }
 
+    if (ch === '(' && command[i + 1] === '(') {
+      arithmeticDepth++;
+      i++;
+      continue;
+    }
+    if (arithmeticDepth > 0 && ch === ')' && command[i + 1] === ')') {
+      arithmeticDepth--;
+      i++;
+      continue;
+    }
+
     // Check for shell operators (longest match first)
     for (const op of SHELL_OPERATORS) {
       if (command.substring(i, i + op.length) !== op) {
         continue;
       }
       // A bare `&` bounds a command only when it is the async operator; its
-      // other spellings belong to a redirection and stay in the segment.
-      if (op === '&' && !isAsyncOperator(command, i)) {
+      // other spellings belong to a redirection or to arithmetic, and stay in
+      // the segment.
+      if (op === '&' && (arithmeticDepth > 0 || !isAsyncOperator(command, i))) {
         continue;
       }
       const segment = command.substring(lastSplit, i).trim();
       if (segment) {
-        commands.push(segment);
+        segments.push({ command: segment, terminator: op });
       }
       lastSplit = i + op.length;
       i = lastSplit - 1; // -1 because the loop will i++
@@ -756,9 +803,32 @@ export function splitCompoundCommand(command: string): string[] {
   // Add the last segment
   const lastSegment = command.substring(lastSplit).trim();
   if (lastSegment) {
-    commands.push(lastSegment);
+    segments.push({ command: lastSegment, terminator: '' });
   }
 
+  return segments;
+}
+
+/**
+ * Split a compound shell command into its individual simple commands
+ * by splitting on unquoted shell operators (&&, ||, ;, |, etc.).
+ *
+ * Returns an array of trimmed simple command strings.
+ * For simple commands (no operators), returns a single-element array.
+ *
+ * Examples:
+ *   "git status && rm -rf /"  → ["git status", "rm -rf /"]
+ *   "ls -la | grep foo"      → ["ls -la", "grep foo"]
+ *   "echo 'a && b'"          → ["echo 'a && b'"]  (inside quotes)
+ *   "a && b || c"            → ["a", "b", "c"]
+ *   "git status & rm -rf /"  → ["git status", "rm -rf /"]  (async operator)
+ *   "build &> log.txt"       → ["build &> log.txt"]  (redirection, not async)
+ *   "x=$(( a & b ))"         → ["x=$(( a & b ))"]  (arithmetic, not async)
+ */
+export function splitCompoundCommand(command: string): string[] {
+  const commands = splitCompoundCommandSegments(command).map(
+    (segment) => segment.command,
+  );
   return commands.length > 0 ? commands : [command];
 }
 

--- a/packages/core/src/permissions/shell-semantics.test.ts
+++ b/packages/core/src/permissions/shell-semantics.test.ts
@@ -742,6 +742,66 @@ describe('extractShellOperationsAcrossCommand', () => {
     ]);
   });
 
+  // A backgrounded `cd` runs in a subshell, so the parent's cwd is untouched
+  // and the next segment's relative write lands in the *original* directory —
+  // which is exactly where a protected settings file lives. Attributing the
+  // write to the `cd` target instead would check the wrong path.
+  it.each([
+    ['cd /tmp & echo {} > settings.json'],
+    ['cd .qwen & echo {} > settings.json'],
+  ])('does not move the cwd for the backgrounded `cd` in %s', (command) => {
+    expect(extractShellOperationsAcrossCommand(command, '/repo')).toEqual([
+      { virtualTool: 'write_file', filePath: '/repo/settings.json' },
+    ]);
+  });
+
+  it('does not mark later paths uncertain for a backgrounded dynamic `cd`', () => {
+    // The foreground form below cannot know where it landed; the backgrounded
+    // one can, because it did not move the cwd at all.
+    expect(
+      extractShellOperationsAcrossCommand(
+        'cd "$TARGET" & echo {} > settings.json',
+        '/repo',
+      ),
+    ).toEqual([{ virtualTool: 'write_file', filePath: '/repo/settings.json' }]);
+  });
+
+  // Over-correction guards: only the backgrounded `cd` is exempt. Both of
+  // these pass before and after the change.
+  it('keeps a foreground `cd` moving the cwd', () => {
+    expect(
+      extractShellOperationsAcrossCommand(
+        'cd /tmp && echo {} > settings.json',
+        '/repo',
+      ),
+    ).toEqual([{ virtualTool: 'write_file', filePath: '/tmp/settings.json' }]);
+  });
+
+  it('keeps a foreground dynamic `cd` marking later paths uncertain', () => {
+    expect(
+      extractShellOperationsAcrossCommand(
+        'cd "$TARGET" && echo {} > settings.json',
+        '/repo',
+      ),
+    ).toEqual([
+      {
+        virtualTool: 'write_file',
+        filePath: '/repo/settings.json',
+        cwdUnknown: true,
+        pathMayDependOnCwd: true,
+      },
+    ]);
+  });
+
+  it('applies a foreground `cd` that follows a backgrounded one', () => {
+    expect(
+      extractShellOperationsAcrossCommand(
+        'cd /tmp & cd /var && echo {} > settings.json',
+        '/repo',
+      ),
+    ).toEqual([{ virtualTool: 'write_file', filePath: '/var/settings.json' }]);
+  });
+
   it('recursively unwraps nested shell wrappers', () => {
     // The actual write is nested two wrapper levels deep.
     expect(

--- a/packages/core/src/permissions/shell-semantics.ts
+++ b/packages/core/src/permissions/shell-semantics.ts
@@ -35,7 +35,7 @@ import nodePath from 'node:path';
 import os from 'node:os';
 import { stripShellWrapper } from '../utils/shell-utils.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
-import { splitCompoundCommand } from './rule-parser.js';
+import { splitCompoundCommandSegments } from './rule-parser.js';
 
 const shellSemanticsDebugLogger = createDebugLogger('SHELL_SEMANTICS');
 
@@ -2263,21 +2263,32 @@ function walkCompoundCommand(
   depth: number,
   initialCwdUnknown: boolean,
 ): ShellOperation[] {
-  const subCommands = splitCompoundCommand(stripHeredocBodies(command));
+  const subCommands = splitCompoundCommandSegments(stripHeredocBodies(command));
 
   const ops: ShellOperation[] = [];
   let effectiveCwd = cwd;
   let cwdUnknown = initialCwdUnknown;
 
-  for (const sub of subCommands) {
+  for (const { command: sub, terminator } of subCommands) {
+    // `cd x & …` runs the `cd` in a background subshell, so it does not move
+    // the cwd the following segments run in. Treating it as a foreground `cd`
+    // would attribute their relative writes to the wrong directory — for
+    // `cd /tmp & echo {} > settings.json` the write lands in the *original*
+    // cwd, which is exactly where a protected settings file would be.
+    const backgrounded = terminator === '&';
+
     const cdTarget = resolveCdTargetCwd(sub, effectiveCwd, cwdUnknown);
     if (cdTarget.kind === 'static') {
-      effectiveCwd = cdTarget.cwd;
-      cwdUnknown = cdTarget.cwdUnknown;
+      if (!backgrounded) {
+        effectiveCwd = cdTarget.cwd;
+        cwdUnknown = cdTarget.cwdUnknown;
+      }
       continue;
     }
     if (cdTarget.kind === 'dynamic') {
-      cwdUnknown = true;
+      if (!backgrounded) {
+        cwdUnknown = true;
+      }
       continue;
     }
 


### PR DESCRIPTION
## What this PR does

Adds the bare `&` — the async, or background, operator — to the list of shell operators that `splitCompoundCommand` treats as a command boundary, while keeping the three uses of `&` that belong to a redirection inside their segment.

## Why it's needed

`splitCompoundCommand` is how the permission layer finds the individual commands inside a compound one. `PermissionManager` calls it at three sites, and when it reports more than one sub-command each is evaluated independently and the most restrictive verdict wins. That is the mechanism that stops an allow rule scoped to one command from covering whatever was chained after it.

`SHELL_OPERATORS` lists `&&`, `||`, `;;`, `|&`, `|`, `;` and newline, but not the bare `&`. So `git status & rm -rf /tmp/x` came back as a single segment, `evaluateSingle` matched that whole string against the Bash patterns, and `Bash(git status)` authorised the `rm` along with it. The shell will run both commands; only the permission check saw one. `Bash(foo *)` covering `foo & rm -rf /tmp/x` is the same shape.

The codebase already disagreed with itself here: `splitCommands` in `utils/shell-utils.ts` — the other splitter, used by the shell tool — does treat `&` as a boundary. The two returned different answers for the same string.

Not every `&` is a boundary, and this is where the fix is deliberately stricter than the existing `splitCommands`. `&>` and `&>>` redirect both streams, and `>&` / `<&` duplicate a file descriptor (`2>&1`, `>&2`); none of those start a new command. `splitCommands` only inspects the character *before* the `&`, which catches `2>&1` but not `&>`, so it splits `a &> /dev/null` into two segments. The guard added here checks both directions.

I also corrected an existing test that asserted `echo a \&& b` is a single command. The backslash escapes only the first ampersand, and the second is a live async operator — `bash -x` runs the line as `echo a '&'` followed by `b`. The old expectation encoded the missing split, so it had to move with the fix.

## Reviewer Test Plan

### How to verify

Confirm the semantics against bash first, since the whole change rests on which spellings of `&` start a new command:

```
$ bash -c 'echo one & echo two; wait'
two
one                                  # two commands

$ bash -c 'echo redirected &> out.txt; cat out.txt'
redirected                           # one command; nothing backgrounded

$ printf 'b() { echo B; }\nset -x\necho a \\&& b\n' | bash
+ b
+ echo a '&'                         # two commands, not an escaped &&
```

Then the splitter, before and after:

| command | before | after | bash runs |
| --- | --- | --- | --- |
| `git status & rm -rf /tmp/x` | `["git status & rm -rf /tmp/x"]` | `["git status", "rm -rf /tmp/x"]` | two commands |
| `a & b & c` | `["a & b & c"]` | `["a", "b", "c"]` | three commands |
| `npm test &` | `["npm test &"]` | `["npm test"]` | one command, backgrounded |
| `curl http://x?a=1&b=2` | `["curl http://x?a=1&b=2"]` | `["curl http://x?a=1", "b=2"]` | two commands |
| `build &> log.txt` | `["build &> log.txt"]` | unchanged | one command |
| `ls /nope 2>&1` | `["ls /nope 2>&1"]` | unchanged | one command |
| `echo 'x & y'` | `["echo 'x & y'"]` | unchanged | one command |
| `a && b` / `a \|& b` | `["a","b"]` | unchanged | two commands |

The unquoted-URL row is not a special case — bash really does background `curl http://x?a=1` and then run `b=2` as its own command, so the new answer is the shell's answer.

```
$ npx vitest run --root packages/core src/permissions/
 Test Files  9 passed (9)
      Tests  731 passed (731)

$ npx vitest run --root packages/core src/utils/shell-utils.test.ts src/tools/shell.test.ts
      Tests  433 passed (433)

# with src/permissions/rule-parser.ts reverted and the tests kept:
      Tests  6 failed | 309 passed (315)
```

The six that fail without the fix are the async-operator cases. The redirection and quoting cases pass both before and after on purpose — they guard against over-correcting into splitting a redirect.

### Evidence (Before & After)

N/A — not user-visible; the before/after splitter output is tabulated above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests, plus the bash reproductions above (GNU bash 3.2 on macOS).

## Risk & Scope

- Main risk or tradeoff: commands that were previously evaluated as one segment are now evaluated as several, so a rule that used to cover a whole `&`-joined string will now be asked about for the trailing commands. That is the intended correction, and it matches both bash and the existing `splitCommands`. Users who had allow rules relying on the old behaviour will see additional prompts.
- Not validated / out of scope: I did not change `splitCommands` in `utils/shell-utils.ts`, even though its `&` guard mishandles `a &> /dev/null` — that is a separate bug in a different splitter and belongs in its own PR.
- Breaking changes / migration notes: none in API terms; the behavioural change is the extra splitting described above.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

把裸 `&`（异步/后台操作符）加入 `splitCompoundCommand` 视为命令边界的 shell 操作符列表，同时让属于重定向的三种 `&` 用法继续留在原有分段内。

## 为什么需要

`splitCompoundCommand` 是权限层用来识别复合命令中各个独立命令的方式。`PermissionManager` 在三处调用它，当它返回多个子命令时，每个子命令会被独立评估，并取最严格的判定结果。正是这一机制阻止了作用于单条命令的放行规则覆盖其后串联的其他命令。

`SHELL_OPERATORS` 列出了 `&&`、`||`、`;;`、`|&`、`|`、`;` 和换行符，唯独没有裸 `&`。于是 `git status & rm -rf /tmp/x` 会作为单一分段返回，`evaluateSingle` 用整个字符串去匹配 Bash 规则，`Bash(git status)` 便连同其后的 `rm` 一起放行了。shell 会执行这两条命令，而权限检查只看到了一条。`Bash(foo *)` 覆盖 `foo & rm -rf /tmp/x` 属于同一情形。

代码库本身在这一点上就已自相矛盾：`utils/shell-utils.ts` 中的 `splitCommands`——即 shell 工具使用的另一个切分器——确实把 `&` 当作边界。两者对同一字符串给出了不同的结果。

并非所有 `&` 都是边界，而这正是本次修复有意比现有 `splitCommands` 更严格之处。`&>` 和 `&>>` 会重定向两个流，`>&` / `<&` 会复制文件描述符（`2>&1`、`>&2`）；这些都不会开启新命令。`splitCommands` 只检查 `&` *之前*的字符，因此能识别 `2>&1` 却识别不了 `&>`，于是会把 `a &> /dev/null` 切成两段。本次新增的判断会同时检查前后两个方向。

我还修正了一个既有测试，它断言 `echo a \&& b` 是单条命令。反斜杠只转义了第一个 `&`，第二个是生效的异步操作符——`bash -x` 显示该行被执行为 `echo a '&'` 加 `b`。旧的预期把缺失的切分固化了下来，因此必须随本次修复一并调整。

## 审阅者测试计划

### 如何验证

先对照 bash 确认语义，因为整个改动的依据就是哪些 `&` 写法会开启新命令：

```
$ bash -c 'echo one & echo two; wait'
two
one                                  # 两条命令

$ bash -c 'echo redirected &> out.txt; cat out.txt'
redirected                           # 一条命令；没有任何后台任务

$ printf 'b() { echo B; }\nset -x\necho a \\&& b\n' | bash
+ b
+ echo a '&'                         # 两条命令，并非被转义的 &&
```

然后对比切分器的修复前后：

| 命令 | 修复前 | 修复后 | bash 实际执行 |
| --- | --- | --- | --- |
| `git status & rm -rf /tmp/x` | `["git status & rm -rf /tmp/x"]` | `["git status", "rm -rf /tmp/x"]` | 两条命令 |
| `a & b & c` | `["a & b & c"]` | `["a", "b", "c"]` | 三条命令 |
| `npm test &` | `["npm test &"]` | `["npm test"]` | 一条命令，后台执行 |
| `curl http://x?a=1&b=2` | `["curl http://x?a=1&b=2"]` | `["curl http://x?a=1", "b=2"]` | 两条命令 |
| `build &> log.txt` | `["build &> log.txt"]` | 不变 | 一条命令 |
| `ls /nope 2>&1` | `["ls /nope 2>&1"]` | 不变 | 一条命令 |
| `echo 'x & y'` | `["echo 'x & y'"]` | 不变 | 一条命令 |
| `a && b` / `a \|& b` | `["a","b"]` | 不变 | 两条命令 |

未加引号的 URL 那一行并非特例——bash 确实会把 `curl http://x?a=1` 放到后台，然后把 `b=2` 作为独立命令执行，因此新的结果正是 shell 的结果。

```
$ npx vitest run --root packages/core src/permissions/
 Test Files  9 passed (9)
      Tests  731 passed (731)

$ npx vitest run --root packages/core src/utils/shell-utils.test.ts src/tools/shell.test.ts
      Tests  433 passed (433)

# 回退 src/permissions/rule-parser.ts 并保留测试后：
      Tests  6 failed | 309 passed (315)
```

在没有修复时失败的这 6 项都是异步操作符相关用例。重定向和引号相关的用例在修复前后均通过，这是有意为之——它们用于防止过度修正而误切重定向。

### 证据（修复前后对比）

N/A——非用户可见改动；切分器修复前后的输出已在上表列出。

### 测试环境

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

单元测试，外加上文的 bash 复现（macOS 上的 GNU bash 3.2）。

## 风险与影响范围

- 主要风险或权衡：此前作为单一分段评估的命令现在会被拆成多段评估，因此原先覆盖整条 `&` 连接字符串的规则，现在会针对后续命令重新询问。这正是预期的修正，且与 bash 和既有的 `splitCommands` 保持一致。依赖旧行为的放行规则的用户会看到额外的确认提示。
- 未验证 / 不在范围内：我没有改动 `utils/shell-utils.ts` 中的 `splitCommands`，尽管它的 `&` 判断会错误处理 `a &> /dev/null`——那是另一个切分器中的独立缺陷，应当另开 PR 处理。
- 破坏性变更 / 迁移说明：API 层面没有；行为变化即上文所述的额外切分。

## 关联 Issue

无。

</details>
