### PR TITLE
fix(core): cap a bare Error's message like every other getErrorMessage path

### DIFF
--- a/packages/core/src/utils/errors.test.ts
+++ b/packages/core/src/utils/errors.test.ts
@@ -253,3 +253,43 @@ describe('isNodeError', () => {
     expect(isNodeError(null)).toBe(false);
   });
 });
+
+describe('getErrorMessage length cap', () => {
+  // `MAX_STRINGIFIED_ERROR_MESSAGE_LENGTH` is 1000 and is not exported; the
+  // truncated form is the first 997 characters plus an ellipsis.
+  const CAP = 1000;
+  const big = 'x'.repeat(5000);
+
+  it('caps a bare Error whose message carries a response body', () => {
+    const message = getErrorMessage(new Error(big));
+
+    expect(message).toHaveLength(CAP);
+    expect(message.endsWith('...')).toBe(true);
+  });
+
+  // The cap used to depend on things unrelated to length: the same string was
+  // capped in every other shape and uncapped only for a bare Error. Each of
+  // these is the same message reached by a different branch.
+  it.each([
+    ['bare Error', () => new Error(big)],
+    ['Error with a distinct cause', () => new Error(big, { cause: 'boom' })],
+    ['object with a message', () => ({ message: big })],
+    [
+      'object with a message and cause',
+      () => ({ message: big, cause: 'boom' }),
+    ],
+    ['object serialised as JSON', () => ({ blob: big })],
+  ])('caps %s at the same length', (_label, makeError) => {
+    expect(getErrorMessage(makeError()).length).toBeLessThanOrEqual(CAP);
+  });
+
+  // Guards against over-correcting: a message inside the limit must come back
+  // whole, with no ellipsis. Passes both before and after the change.
+  it.each([
+    ['short', 'boom'],
+    ['exactly at the cap', 'y'.repeat(CAP)],
+    ['one under the cap', 'y'.repeat(CAP - 1)],
+  ])('returns a %s message unchanged', (_label, message) => {
+    expect(getErrorMessage(new Error(message))).toBe(message);
+  });
+});

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -160,7 +160,13 @@ export function getErrorMessage(error: unknown): string {
         `${error.message} (cause: ${detail})`,
       );
     }
-    return error.message;
+    // Capped like every other branch. Returning `error.message` raw made the
+    // limit depend on details of the error that have nothing to do with how
+    // long it is: the same string was capped as `{ message }` or once a
+    // distinct `cause` was attached, and uncapped only for a bare `Error`.
+    // That is the shape a provider SDK throws when it packs a whole response
+    // body into the message, and the result flows straight into `llmContent`.
+    return truncateStringifiedErrorMessage(error.message);
   }
   if (error !== null && typeof error === 'object' && !Array.isArray(error)) {
     const { message, cause } = error as {


### PR DESCRIPTION
## What this PR does

Applies the existing length cap to the one branch of `getErrorMessage` that skipped it: an `Error` instance whose cause adds nothing to the message.

## Why it's needed

`getErrorMessage` truncates its result to `MAX_STRINGIFIED_ERROR_MESSAGE_LENGTH` (1000) on every path — the object-with-a-message path, the `JSON.stringify` path, the `describeSingleError` fallback, and the `Error`-with-a-distinct-cause path. The bare `Error` path returned `error.message` unchanged.

The effect is that the cap keyed off something other than length. Handed the same 5000-character string, the function returns 1000 characters as `{ message }`, 1000 as `{ message, cause }`, 1000 through the JSON path, 1000 for an `Error` once a distinct cause is attached — and 5000 for a plain `Error`. Measured against the current code:

| input | returned length |
| --- | --- |
| `new Error(big)` | **5000** |
| `new Error(big, { cause })` | 1000 |
| `{ message: big }` | 1000 |
| `{ message: big, cause }` | 1000 |
| `{ blob: big }` | 1000 |

A bare `Error` carrying a very long message is not a hypothetical shape — it is what a provider SDK throws when it packs an entire response body into the message, which is the case the cap exists for. `getErrorMessage` feeds `llmContent` at dozens of call sites, so an uncapped message goes straight into the model's context.

## Reviewer Test Plan

### How to verify

```
$ npx vitest run --root packages/core --coverage.enabled=false src/utils/errors.test.ts
 Test Files  1 passed (1)
      Tests  41 passed (41)

# with src/utils/errors.ts reverted and the tests kept:
      Tests  2 failed | 39 passed (41)
```

The two that fail without the fix are the bare-`Error` cases. The rest of the parametrised set covers the branches that already truncated, so they pass either way and pin the branches to each other rather than to a hard-coded number.

There are also three guards against over-correcting — a short message, one exactly at the cap, and one a character under — which assert the message comes back whole with no ellipsis. Those pass both before and after.

Whole `src/utils` suite on this branch:

```
$ npx vitest run --root packages/core --coverage.enabled=false src/utils/
 Test Files  1 failed | 116 passed (117)
      Tests  1 failed | 4047 passed | 2 skipped (4050)
```

The single failure is `shell-ast-parser-lazy.test.ts`, which fails identically on unmodified `main` in my environment — its own esbuild step reports `Build failed with 11 errors`. It is unrelated to this change.

### Evidence (Before & After)

N/A — not user-visible; the returned-length table above is the before/after.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only.

## Risk & Scope

- Main risk or tradeoff: error messages longer than 1000 characters are now shortened on this path too, so a caller that relied on receiving a full multi-kilobyte message will see it end in `...`. That is the behaviour every other branch already had.
- Not validated / out of scope: the cap value itself is unchanged, and no other branch is touched. I did not audit whether 1000 is the right number.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

把既有的长度上限应用到 `getErrorMessage` 中唯一遗漏的分支：`cause` 未给消息带来额外信息的 `Error` 实例。

## 为什么需要

`getErrorMessage` 在所有路径上都会把结果截断到 `MAX_STRINGIFIED_ERROR_MESSAGE_LENGTH`（1000）——带 message 的对象路径、`JSON.stringify` 路径、`describeSingleError` 兜底路径，以及带独立 `cause` 的 `Error` 路径。唯独裸 `Error` 路径原样返回 `error.message`。

其结果是，这个上限的触发条件变成了与长度无关的东西。面对同一个 5000 字符的字符串，该函数以 `{ message }` 形式返回 1000 字符，以 `{ message, cause }` 形式返回 1000 字符，走 JSON 路径返回 1000 字符，附加了独立 cause 的 `Error` 返回 1000 字符——而普通 `Error` 返回 5000 字符。针对当前代码实测：

| 输入 | 返回长度 |
| --- | --- |
| `new Error(big)` | **5000** |
| `new Error(big, { cause })` | 1000 |
| `{ message: big }` | 1000 |
| `{ message: big, cause }` | 1000 |
| `{ blob: big }` | 1000 |

携带超长消息的裸 `Error` 并非假想情形——当服务商 SDK 把整个响应体塞进 message 时，抛出的正是这种形态，而这恰恰是该上限存在的意义。`getErrorMessage` 在数十处调用点为 `llmContent` 提供内容，因此未截断的消息会直接进入模型上下文。

## 审阅者测试计划

### 如何验证

```
$ npx vitest run --root packages/core --coverage.enabled=false src/utils/errors.test.ts
 Test Files  1 passed (1)
      Tests  41 passed (41)

# 回退 src/utils/errors.ts 并保留测试后：
      Tests  2 failed | 39 passed (41)
```

在没有修复时失败的两项都是裸 `Error` 的用例。参数化用例集中的其余项覆盖了本来就会截断的分支，因此修复前后均通过——它们把各分支相互锚定，而不是锚定到一个硬编码数字上。

此外还有三项防过度修正的保护性用例——短消息、恰好等于上限、比上限少一个字符——断言消息应原样返回且不带省略号。这些在修复前后均通过。

本分支上 `src/utils` 全量测试：

```
$ npx vitest run --root packages/core --coverage.enabled=false src/utils/
 Test Files  1 failed | 116 passed (117)
      Tests  1 failed | 4047 passed | 2 skipped (4050)
```

唯一失败的是 `shell-ast-parser-lazy.test.ts`，在我的环境中它在未修改的 `main` 上同样失败——其自身的 esbuild 步骤报告 `Build failed with 11 errors`。与本次改动无关。

### 证据（修复前后对比）

N/A——非用户可见改动；上文的返回长度对照表即为修复前后对比。

### 测试环境

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

仅单元测试。

## 风险与影响范围

- 主要风险或权衡：超过 1000 字符的错误消息在这条路径上现在也会被缩短，因此依赖拿到完整数千字节消息的调用方会看到结尾变成 `...`。这与其他所有分支原本的行为一致。
- 未验证 / 不在范围内：上限数值本身未作改动，其他分支也未触及。我没有评估 1000 这个数字是否合适。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
