### PR TITLE
fix(core): render a thought part's reasoning instead of the boolean flag

### DIFF
--- a/packages/core/src/core/geminiRequest.test.ts
+++ b/packages/core/src/core/geminiRequest.test.ts
@@ -25,10 +25,16 @@ describe('partListUnionToString', () => {
     expect(result).toBe('[Video Metadata]');
   });
 
-  it('should handle thought', () => {
+  it('should handle a thought with no text', () => {
     const part: Part = { thought: true };
     const result = partListUnionToString(part);
-    expect(result).toBe('[Thought: true]');
+    expect(result).toBe('[Thought]');
+  });
+
+  it('should handle a thought carrying its reasoning', () => {
+    const part: Part = { thought: true, text: 'weighing the options' };
+    const result = partListUnionToString(part);
+    expect(result).toBe('[Thought: weighing the options]');
   });
 
   it('should handle codeExecutionResult', () => {

--- a/packages/core/src/utils/partUtils.test.ts
+++ b/packages/core/src/utils/partUtils.test.ts
@@ -12,6 +12,7 @@ import {
   appendToLastTextPart,
   prependToFirstTextPart,
 } from './partUtils.js';
+import { createOpenAIReasoningThoughtPart } from './thoughtUtils.js';
 import type { GenerateContentResponse, Part, PartUnion } from '@google/genai';
 
 const mockResponse = (
@@ -86,9 +87,35 @@ describe('partUtils', () => {
       expect(partToString(part, verboseOptions)).toBe('[Video Metadata]');
     });
 
-    it('should return descriptive string for thought part', () => {
-      const part = { thought: 'thinking' } as unknown as Part;
+    // `Part.thought` is a boolean flag; the reasoning is in `part.text`. The
+    // previous expectation was built from `{ thought: 'thinking' }`, a shape
+    // that only type-checks through `as unknown as Part` and that the SDK
+    // never produces.
+    it('should return the reasoning text for a thought part', () => {
+      const part: Part = { thought: true, text: 'thinking' };
       expect(partToString(part, verboseOptions)).toBe('[Thought: thinking]');
+    });
+
+    it('should label a thought part that carries no text', () => {
+      const part: Part = { thought: true };
+      expect(partToString(part, verboseOptions)).toBe('[Thought]');
+    });
+
+    it('should render a part flagged thought: false as its own text', () => {
+      const part: Part = { thought: false, text: 'ordinary' };
+      expect(partToString(part, verboseOptions)).toBe('ordinary');
+    });
+
+    it('should render a thought part built by the real constructor', () => {
+      const part = createOpenAIReasoningThoughtPart('step one');
+      expect(partToString(part, verboseOptions)).toBe('[Thought: step one]');
+    });
+
+    // Guard against over-correcting: without verbose, a thought part is still
+    // just its text. Passes both before and after.
+    it('should return the plain text for a thought part when not verbose', () => {
+      const part: Part = { thought: true, text: 'thinking' };
+      expect(partToString(part)).toBe('thinking');
     });
 
     it('should return descriptive string for codeExecutionResult part', () => {

--- a/packages/core/src/utils/partUtils.ts
+++ b/packages/core/src/utils/partUtils.ts
@@ -32,7 +32,6 @@ export function partToString(
   // Cast to Part, assuming it might contain project-specific fields
   const part = value as Part & {
     videoMetadata?: unknown;
-    thought?: string;
     codeExecutionResult?: unknown;
     executableCode?: unknown;
   };
@@ -41,8 +40,14 @@ export function partToString(
     if (part.videoMetadata !== undefined) {
       return `[Video Metadata]`;
     }
-    if (part.thought !== undefined) {
-      return `[Thought: ${part.thought}]`;
+    // `thought` is a boolean flag and the reasoning itself is in `part.text` --
+    // that is what `createOpenAIReasoningThoughtPart` builds and what every
+    // other consumer reads. Interpolating the flag rendered every thought as
+    // the literal `[Thought: true]`, dropping the reasoning entirely, and
+    // testing `!== undefined` also caught a part carrying `thought: false`,
+    // which is an ordinary part and should render as its own text.
+    if (part.thought) {
+      return part.text ? `[Thought: ${part.text}]` : `[Thought]`;
     }
     if (part.codeExecutionResult !== undefined) {
       return `[Code Execution Result]`;


### PR DESCRIPTION
## What this PR does

Makes the verbose rendering of a thought part show the reasoning it carries, rather than the literal string `true`.

## Why it's needed

`Part.thought` is a boolean flag; the reasoning itself lives in `part.text`. `partToString` declared it as `thought?: string` in a local cast and then interpolated the flag directly, so every thought part rendered verbose as `[Thought: true]` and the reasoning was thrown away.

The local cast was the only thing letting that compile. The SDK declares `thought?: boolean` (`@google/genai` `genai.d.ts`), `createOpenAIReasoningThoughtPart` in `thoughtUtils.ts` builds exactly `{ text, thought: true }`, and every other consumer in the repo reads the text and tests the flag for truthiness — `part.thought === true`, `if (!part.thought)`, `filter((part) => part.text && !part.thought)`. `partToString` was the one place treating the flag as the payload.

Testing `!== undefined` instead of truthiness had a second consequence: a part carrying `thought: false` is an ordinary part, but it took the thought branch and rendered as `[Thought: false]` instead of its own text.

Both live verbose callers are affected — `partListUnionToString` in `geminiRequest.ts` and the prompt-expansion hook in `packages/cli`.

## Reviewer Test Plan

### How to verify

| part | before | after |
| --- | --- | --- |
| `{ thought: true, text: 'thinking' }` | `[Thought: true]` | `[Thought: thinking]` |
| `{ thought: true }` | `[Thought: true]` | `[Thought]` |
| `{ thought: false, text: 'ordinary' }` | `[Thought: false]` | `ordinary` |
| `createOpenAIReasoningThoughtPart('step one')` | `[Thought: true]` | `[Thought: step one]` |
| `{ thought: true, text: 'thinking' }`, non-verbose | `thinking` | `thinking` (unchanged) |

The fourth row goes through the repo's own constructor rather than a hand-built object, so it pins the fix to the shape the code actually produces. The last row is a guard against over-correcting and passes both before and after.

```
$ npx vitest run --root packages/core --coverage.enabled=false src/utils/partUtils.test.ts src/core/geminiRequest.test.ts
 Test Files  2 passed (2)
      Tests  60 passed (60)

# with src/utils/partUtils.ts reverted and the tests kept:
AssertionError: expected '[Thought: true]' to be '[Thought: thinking]'
AssertionError: expected '[Thought: true]' to be '[Thought]'
AssertionError: expected '[Thought: false]' to be 'ordinary'
```

### Evidence (Before & After)

N/A — not user-visible in the TUI; the rendering table above is the before/after.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only.

## Risk & Scope

- Main risk or tradeoff: the verbose string for a thought part changes shape. Anything matching on the literal `[Thought: true]` would need updating — I searched and found only the two tests corrected here.
- Not validated / out of scope: `loggingContentGenerator.toPart` has the same interpolation and appends `[Thought: true]` to the text it sends to the CountToken API. It is a different function with different semantics — there the text is not lost, only a useless marker is added — so it belongs in its own PR rather than being folded in here.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

让 thought part 的 verbose 渲染显示其承载的推理内容，而不是字面量字符串 `true`。

## 为什么需要

`Part.thought` 是一个布尔标志，推理内容本身位于 `part.text` 中。`partToString` 在局部类型断言里把它声明为 `thought?: string`，然后直接对该标志做字符串插值，于是每个 thought part 在 verbose 模式下都渲染成 `[Thought: true]`，推理内容被丢弃。

正是这个局部断言让上述代码得以通过类型检查。SDK 将其声明为 `thought?: boolean`（`@google/genai` 的 `genai.d.ts`），`thoughtUtils.ts` 中的 `createOpenAIReasoningThoughtPart` 构造的正是 `{ text, thought: true }`，而仓库中其他所有使用方都是读取 text、并对该标志做真值判断——`part.thought === true`、`if (!part.thought)`、`filter((part) => part.text && !part.thought)`。`partToString` 是唯一把标志当作内容本身的地方。

使用 `!== undefined` 而非真值判断还带来第二个后果：带有 `thought: false` 的 part 属于普通 part，却进入了 thought 分支，渲染成 `[Thought: false]` 而不是它自己的文本。

两个实际使用 verbose 的调用方都受影响——`geminiRequest.ts` 中的 `partListUnionToString`，以及 `packages/cli` 中的 prompt 展开钩子。

## 审阅者测试计划

### 如何验证

| part | 修复前 | 修复后 |
| --- | --- | --- |
| `{ thought: true, text: 'thinking' }` | `[Thought: true]` | `[Thought: thinking]` |
| `{ thought: true }` | `[Thought: true]` | `[Thought]` |
| `{ thought: false, text: 'ordinary' }` | `[Thought: false]` | `ordinary` |
| `createOpenAIReasoningThoughtPart('step one')` | `[Thought: true]` | `[Thought: step one]` |
| `{ thought: true, text: 'thinking' }`，非 verbose | `thinking` | `thinking`（不变） |

第四行走的是仓库自身的构造函数，而非手工拼装的对象，因此能把修复锚定在代码实际产出的形态上。最后一行是防过度修正的保护用例，修复前后均通过。

```
$ npx vitest run --root packages/core --coverage.enabled=false src/utils/partUtils.test.ts src/core/geminiRequest.test.ts
 Test Files  2 passed (2)
      Tests  60 passed (60)

# 回退 src/utils/partUtils.ts 并保留测试后：
AssertionError: expected '[Thought: true]' to be '[Thought: thinking]'
AssertionError: expected '[Thought: true]' to be '[Thought]'
AssertionError: expected '[Thought: false]' to be 'ordinary'
```

### 证据（修复前后对比）

N/A——在 TUI 中不可见；上方的渲染对照表即为修复前后对比。

### 测试环境

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

仅单元测试。

## 风险与影响范围

- 主要风险或权衡：thought part 的 verbose 字符串形态发生变化。任何按字面量 `[Thought: true]` 做匹配的代码都需要相应调整——我已检索过，只有本 PR 中修正的那两个测试。
- 未验证 / 不在范围内：`loggingContentGenerator.toPart` 存在同样的插值问题，会把 `[Thought: true]` 追加到发往 CountToken API 的文本中。那是一个语义不同的函数——在那里文本并未丢失，只是多了一个无用的标记——因此应当另开 PR，而不是并入本 PR。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
