### PR TITLE
fix(core): stop reporting "[0 lines truncated]" when ripgrep truncated

### DIFF
--- a/docs/developers/tools/file-system.md
+++ b/docs/developers/tools/file-system.md
@@ -173,9 +173,24 @@ notebook_edit(
   src/utils.ts:15:export function myFunction() {
   src/utils.ts:22:  myFunction.call();
   src/index.ts:5:import { myFunction } from './utils';
-  ---
+  ```
 
-  [0 lines truncated] ...
+  A notice is appended only when the output was actually cut short. When `limit`
+  or the character budget did the cutting, the notice names how many matching
+  lines were dropped:
+
+  ```
+  ---
+  [42 lines truncated] ...
+  ```
+
+  When ripgrep itself stopped early at its own output limit, how many matches
+  remain is not knowable — the total is short for the same reason the output is
+  — so the notice says that rather than printing a count:
+
+  ```
+  ---
+  [Truncated by ripgrep's output limit: an unknown number of further matches were not returned. Narrow the pattern or the search path.] ...
   ```
 
 - **Confirmation:** No.

--- a/packages/core/src/tools/ripGrep.test.ts
+++ b/packages/core/src/tools/ripGrep.test.ts
@@ -300,7 +300,65 @@ describe('RipGrepTool', () => {
       const result = await invocation.execute(abortSignal);
 
       expect(result.returnDisplay).toBe('Found 1 match (truncated)');
-      expect(result.llmContent).toContain('[0 lines truncated] ...');
+      // The count is derived from the lines ripgrep returned, so when ripgrep
+      // itself stopped early there is no honest number to print. This used to
+      // read `[0 lines truncated]`, contradicting the `(truncated)` above it.
+      expect(result.llmContent).toContain("ripgrep's output limit");
+      expect(result.llmContent).not.toContain('[0 lines truncated]');
+    });
+
+    it('still reports an exact count when only the line limit truncates', async () => {
+      const lines = Array.from(
+        { length: 5 },
+        (_, i) => `fileA.txt${sep}${i + 1}${sep}hello ${i}`,
+      ).join(EOL);
+      (runRipgrep as Mock).mockResolvedValue({
+        stdout: lines + EOL,
+        truncated: false,
+        error: undefined,
+      });
+
+      const invocation = grepTool.build({ pattern: 'hello', limit: 2 });
+      const result = await invocation.execute(abortSignal);
+
+      expect(result.llmContent).toContain('[3 lines truncated] ...');
+      expect(result.llmContent).not.toContain("ripgrep's output limit");
+    });
+
+    it('prefers the uncertainty notice when both limits truncate', async () => {
+      const lines = Array.from(
+        { length: 5 },
+        (_, i) => `fileA.txt${sep}${i + 1}${sep}hello ${i}`,
+      ).join(EOL);
+      (runRipgrep as Mock).mockResolvedValue({
+        stdout: lines + EOL,
+        truncated: true,
+        error: undefined,
+      });
+
+      const invocation = grepTool.build({ pattern: 'hello', limit: 2 });
+      const result = await invocation.execute(abortSignal);
+
+      // A count here would be measured against a total ripgrep already cut
+      // short, so it would understate rather than merely read as zero.
+      expect(result.llmContent).toContain("ripgrep's output limit");
+      expect(result.llmContent).not.toContain('lines truncated] ...');
+    });
+
+    // Guard against over-correcting: an untruncated result carries no notice
+    // at all. Passes both before and after.
+    it('adds no truncation notice when nothing truncated', async () => {
+      (runRipgrep as Mock).mockResolvedValue({
+        stdout: `fileA.txt${sep}1${sep}hello world${EOL}`,
+        truncated: false,
+        error: undefined,
+      });
+
+      const invocation = grepTool.build({ pattern: 'hello' });
+      const result = await invocation.execute(abortSignal);
+
+      expect(result.returnDisplay).toBe('Found 1 match');
+      expect(result.llmContent).not.toContain('truncated');
     });
 
     it('should preserve absolute result paths reported by ripgrep', async () => {

--- a/packages/core/src/tools/ripGrep.test.ts
+++ b/packages/core/src/tools/ripGrep.test.ts
@@ -358,7 +358,10 @@ describe('RipGrepTool', () => {
       const result = await invocation.execute(abortSignal);
 
       expect(result.returnDisplay).toBe('Found 1 match');
-      expect(result.llmContent).not.toContain('truncated');
+      // Case-insensitive so the guard covers both notice formats: the
+      // `[N lines truncated]` count and the `[Truncated by ripgrep's output
+      // limit: ...]` uncertainty notice, whose only match is capitalized.
+      expect(result.llmContent).not.toMatch(/truncat/i);
     });
 
     it('should preserve absolute result paths reported by ripgrep', async () => {

--- a/packages/core/src/tools/ripGrep.ts
+++ b/packages/core/src/tools/ripGrep.ts
@@ -380,11 +380,15 @@ class GrepToolInvocation extends BaseToolInvocation<
       let llmContent = header + grepOutput;
 
       // Add truncation notice if needed
-      if (
-        truncatedByLineLimit ||
-        truncatedByCharLimit ||
-        truncatedBySystemLimit
-      ) {
+      if (truncatedBySystemLimit) {
+        // `totalMatches` counts the lines ripgrep actually returned, and this
+        // flag means ripgrep stopped early -- so the omitted count is measured
+        // against a total that is itself short. When nothing else truncated it
+        // came out as `[0 lines truncated]`, telling the model nothing was
+        // dropped in the one case where an unknown amount was. Report the
+        // uncertainty instead of a number that cannot be right.
+        llmContent += `\n---\n[Truncated by ripgrep's output limit: an unknown number of further matches were not returned. Narrow the pattern or the search path.] ...`;
+      } else if (truncatedByLineLimit || truncatedByCharLimit) {
         const omittedMatches = totalMatches - includedLines;
         llmContent += `\n---\n[${omittedMatches} ${omittedMatches === 1 ? 'line' : 'lines'} truncated] ...`;
       }


### PR DESCRIPTION
## What this PR does

Replaces the `[0 lines truncated]` notice the Grep tool emits when ripgrep hits its own output limit with one that states an unknown number of matches were dropped.

## Why it's needed

`totalMatches` is `allLines.length` — the lines ripgrep actually returned. When ripgrep stops early on its own output limit (buffer overflow or signal termination, per `runRipgrep`), that total is itself short. The omitted count was computed as `totalMatches - includedLines`, so if nothing else truncated, every returned line was included and the subtraction came out as exactly zero.

The model was therefore told `[0 lines truncated] ...` in the one case where the number of dropped matches is unknowable — and told it directly beneath a display line reading `Found N matches (truncated)`. The two contradict each other, and the one the model reads says nothing was lost.

When the system limit fires *together with* a line or char limit, a count is no better: it is measured against a total ripgrep already cut short, so it understates rather than merely reading as zero. So the fix branches on the system limit first and stops printing a number whenever that flag is set. The exact count is still reported when only the line or char limit truncated, which is where it is trustworthy.

## Reviewer Test Plan

### How to verify

| scenario | before | after |
| --- | --- | --- |
| ripgrep's own limit only | `[0 lines truncated] ...` | `[Truncated by ripgrep's output limit: an unknown number of further matches were not returned. …]` |
| line limit only (5 matches, `limit: 2`) | `[3 lines truncated] ...` | unchanged |
| both | `[3 lines truncated] ...` (understated) | the uncertainty notice |
| nothing truncated | no notice | unchanged |

```
$ npx vitest run --root packages/core --coverage.enabled=false src/tools/ripGrep.test.ts
 Test Files  1 passed (1)
      Tests  79 passed (79)

# with src/tools/ripGrep.ts reverted and the tests kept:
      Tests  2 failed | 77 passed (79)
```

The two that fail without the fix are the system-limit cases. The exact-count row and the nothing-truncated row pass both before and after — they guard against over-correcting into dropping counts that are still accurate, or into emitting a notice when nothing was cut.

### Evidence (Before & After)

N/A — the affected string goes to `llmContent`, not the TUI; the table above is the before/after. The user-facing `returnDisplay` (`Found N matches (truncated)`) is unchanged.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only; `runRipgrep` is already mocked in this suite, so the truncation flag is driven directly.

## Risk & Scope

- Main risk or tradeoff: an existing test, `surfaces ripgrep system-level truncation in display metadata`, asserted `[0 lines truncated] ...`. I have kept that test and its stated subject — the `returnDisplay` assertion beside it is untouched — and changed only the `llmContent` expectation, since the old string is the behaviour being corrected. Flagging it explicitly in case it was deliberate rather than recorded.
- Not validated / out of scope: the wording of the new notice is a judgement call; happy to reword. I did not change how `truncated` is determined in `runRipgrep`, nor the display string.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

当 ripgrep 触及自身输出上限时，Grep 工具原本输出的 `[0 lines truncated]` 提示，改为明确说明有未知数量的匹配被丢弃。

## 为什么需要

`totalMatches` 就是 `allLines.length`——即 ripgrep 实际返回的行数。当 ripgrep 因自身输出上限提前停止时（按 `runRipgrep` 的定义，即缓冲区溢出或信号终止），这个总数本身就是不完整的。被省略的数量是按 `totalMatches - includedLines` 计算的，因此若没有其他截断发生，返回的每一行都会被包含，相减结果恰好为零。

于是在被丢弃匹配数量根本无从得知的这唯一场景下，模型却被告知 `[0 lines truncated] ...`——而且就显示在写着 `Found N matches (truncated)` 的那一行下方。两者自相矛盾，而模型读到的那一条却表示什么都没丢。

当系统上限与行数/字符数上限*同时*触发时，给出计数同样无济于事：它是相对于一个已被 ripgrep 截短的总数计算的，因此会低估，而不只是显示为零。所以本次修复优先判断系统上限，只要该标志被置位就不再输出数字。而在仅由行数或字符数上限触发截断时，仍然报告精确计数——那种情况下计数是可信的。

## 审阅者测试计划

### 如何验证

| 场景 | 修复前 | 修复后 |
| --- | --- | --- |
| 仅 ripgrep 自身上限 | `[0 lines truncated] ...` | `[Truncated by ripgrep's output limit: an unknown number of further matches were not returned. …]` |
| 仅行数上限（5 条匹配，`limit: 2`） | `[3 lines truncated] ...` | 不变 |
| 两者同时 | `[3 lines truncated] ...`（低估） | 不确定性提示 |
| 未发生截断 | 无提示 | 不变 |

```
$ npx vitest run --root packages/core --coverage.enabled=false src/tools/ripGrep.test.ts
 Test Files  1 passed (1)
      Tests  79 passed (79)

# 回退 src/tools/ripGrep.ts 并保留测试后：
      Tests  2 failed | 77 passed (79)
```

在没有修复时失败的两项都是系统上限相关场景。精确计数那一行和未截断那一行在修复前后均通过——它们用于防止过度修正：既不能丢弃仍然准确的计数，也不能在没有截断时输出提示。

### 证据（修复前后对比）

N/A——受影响的字符串进入的是 `llmContent` 而非 TUI；上方表格即为修复前后对比。面向用户的 `returnDisplay`（`Found N matches (truncated)`）保持不变。

### 测试环境

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

仅单元测试；该测试套件中 `runRipgrep` 本就是被 mock 的，因此可以直接驱动截断标志。

## 风险与影响范围

- 主要风险或权衡：既有测试 `surfaces ripgrep system-level truncation in display metadata` 断言了 `[0 lines truncated] ...`。我保留了该测试及其既定主题——旁边的 `returnDisplay` 断言原封不动——只修改了 `llmContent` 的预期，因为旧字符串正是本次要修正的行为。特此明确指出，以防它是有意为之而非仅仅记录了当时的输出。
- 未验证 / 不在范围内：新提示的措辞属于主观判断，如需调整我很乐意修改。我没有改动 `runRipgrep` 中 `truncated` 的判定方式，也没有改动显示字符串。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
