### PR TITLE
fix(core): mark folders the item budget never expanded

### DIFF
--- a/packages/core/src/utils/getFolderStructure.test.ts
+++ b/packages/core/src/utils/getFolderStructure.test.ts
@@ -153,6 +153,7 @@ ${testRootDir}${path.sep}
 ├───fileA1.ts
 ├───fileA2.js
 └───subfolderB${path.sep}
+    └───...
 `.trim();
     expect(structure.trim()).toBe(expected);
   });
@@ -170,9 +171,13 @@ Showing up to 4 items:
 
 ${testRootDir}${path.sep}
 ├───folder-0${path.sep}
+│   └───...
 ├───folder-1${path.sep}
+│   └───...
 ├───folder-2${path.sep}
+│   └───...
 ├───folder-3${path.sep}
+│   └───...
 └───...
 `.trim();
     expect(structure.trim()).toBe(expectedRevised);
@@ -236,8 +241,44 @@ ${testRootDir}${path.sep}
 └───level1${path.sep}
     └───level2${path.sep}
         └───level3${path.sep}
+            └───...
 `.trim();
     expect(structure.trim()).toBe(expected);
+  });
+
+  // A folder queued but never expanded was rendered as a bare leaf, which is
+  // exactly how a genuinely empty folder renders. The same tree therefore
+  // described `withContents` as empty or not depending only on the budget.
+  it('marks a folder whose contents the budget never reached', async () => {
+    await createTestFile('a.txt');
+    await createTestFile('withContents', 'hidden.txt');
+
+    const truncated = await getFolderStructure(testRootDir, { maxItems: 2 });
+    const complete = await getFolderStructure(testRootDir, { maxItems: 50 });
+
+    expect(truncated).toContain(`withContents${path.sep}`);
+    expect(truncated).toContain('...');
+    // The file is out of budget either way; what matters is that the folder is
+    // not presented as fully known.
+    expect(truncated).not.toContain('hidden.txt');
+
+    // Guard against over-correcting: given room, the folder expands and no
+    // truncation indicator appears anywhere.
+    expect(complete).toContain('hidden.txt');
+    expect(complete).not.toContain('...');
+  });
+
+  // The other direction: a folder that really is empty and really was read
+  // must not gain a marker suggesting there is more to see.
+  it('does not mark an empty folder that was fully read', async () => {
+    await fsPromises.mkdir(path.join(testRootDir, 'genuinelyEmpty'), {
+      recursive: true,
+    });
+
+    const structure = await getFolderStructure(testRootDir, { maxItems: 50 });
+
+    expect(structure).toContain(`genuinelyEmpty${path.sep}`);
+    expect(structure).not.toContain('...');
   });
 
   describe('with gitignore', () => {

--- a/packages/core/src/utils/getFolderStructure.ts
+++ b/packages/core/src/utils/getFolderStructure.ts
@@ -53,7 +53,12 @@ interface FullFolderInfo {
   totalFiles: number; // Number of files included from this folder during BFS scan
   isIgnored?: boolean; // Flag to easily identify ignored folders later
   hasMoreFiles?: boolean; // Indicates if files were truncated for this specific folder
-  hasMoreSubfolders?: boolean; // Indicates if subfolders were truncated for this specific folder
+  // True when this folder's subfolders were truncated, OR when the item budget
+  // ran out before the folder was read at all. Both render as a trailing `...`,
+  // which is the point: an unread folder must not be indistinguishable from one
+  // that was read and found empty. Any new consumer has to cover the second
+  // case too — gating on `subFolders.length > 0` drops it silently.
+  hasMoreSubfolders?: boolean;
 }
 
 // --- Interfaces ---

--- a/packages/core/src/utils/getFolderStructure.ts
+++ b/packages/core/src/utils/getFolderStructure.ts
@@ -91,9 +91,16 @@ async function readFullStructure(
     processedPaths.add(currentPath);
 
     if (currentItemCount >= options.maxItems) {
-      // If the root itself caused us to exceed, we can't really show anything.
-      // Otherwise, this folder won't be processed further.
-      // The parent that queued this would have set its own hasMoreSubfolders flag.
+      // The budget ran out before this folder's own contents could be read.
+      // It was already added to its parent, so without a marker it renders as
+      // a bare leaf and reads as an empty directory. The parent's
+      // hasMoreSubfolders flag says nothing about it either -- that flag means
+      // "I could not add every subfolder", and this one was added.
+      //
+      // Only one flag is set: formatStructure emits an indicator per flag, and
+      // hasMoreSubfolders alone produces the single trailing `...` that says
+      // the contents are unexplored, whether they are files or folders.
+      folderInfo.hasMoreSubfolders = true;
       continue;
     }
 


### PR DESCRIPTION
## What this PR does

Marks a directory that the `maxItems` budget stopped the BFS from expanding, so it no longer renders identically to an empty directory.

## Why it's needed

`readFullStructure` pushes each subfolder into its parent's `subFolders` and queues it for expansion. When that queue entry is later dequeued and the budget is already spent, it is skipped with a bare `continue`, so `hasMoreFiles` and `hasMoreSubfolders` are never set on it. `formatStructure` then renders it as `└───somedir/` with nothing beneath — byte for byte how a directory that was read and found empty renders.

The result is that the same tree is described differently depending only on the budget, and the model has no way to tell which it is looking at. The existing suite already contains the demonstration:

```
maxItems 10                         maxItems 3
└───level1/                         └───level1/
    └───level2/                         └───level2/
        └───level3/                         └───level3/
            └───file.txt                                       <-- reads as empty
```

`level3` contains `file.txt` in both runs. The subfolder case is worse: with five `folder-N/child.txt` directories and `maxItems: 4`, all four rendered folders claim to be empty while each has a child.

The parent's `hasMoreSubfolders` flag does not cover this, and the comment at the skip site saying "the parent that queued this would have set its own hasMoreSubfolders flag" is about a different condition. That flag means *"I could not add every subfolder"* — these folders were added successfully; only their expansion never happened.

The fix sets `hasMoreSubfolders` on the skipped node itself. Only that one flag is set, deliberately: `formatStructure` emits one indicator per flag, so setting both would print two `...` lines. `hasMoreSubfolders` alone produces the single trailing indicator, which reads correctly whether the unexplored contents are files or folders.

## Reviewer Test Plan

### How to verify

A root with three files and `deep/` containing two files, at `maxItems: 4`:

```
before                              after
├───a.txt                           ├───a.txt
├───b.txt                           ├───b.txt
├───c.txt                           ├───c.txt
└───deep/                           └───deep/
                                        └───...
```

Given `maxItems: 100` the same tree fully expands and gains no indicator, before and after alike.

```
$ npx vitest run --root packages/core --coverage.enabled=false src/utils/getFolderStructure.test.ts
 Test Files  1 passed (1)
      Tests  17 passed (17)

# with src/utils/getFolderStructure.ts reverted and the tests kept:
      Tests  4 failed | 13 passed (17)
```

Other consumers are unaffected: `environmentContext.test.ts` 64 passed, `client.test.ts` 301 passed.

Two new tests. One takes a single tree and reads it at two budgets, asserting the folder is marked when truncated and expands with no indicator when not. The other is the guard for the opposite error — a directory that really is empty and really was read must not gain an indicator suggesting there is more; it passes both before and after.

### Evidence (Before & After)

The before/after trees are above. This string is assembled for the model's context rather than drawn in the TUI, so there is no screenshot to attach.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only.

## Risk & Scope

- Main risk or tradeoff: three existing expectations encoded the old rendering and are updated here. They are the ones quoted above, where the fixture proves the folder is not empty, so I read them as recording the behaviour rather than specifying it — flagging it explicitly in case that is wrong. The indicator also appears for a truncated folder that happens to be empty, which is unavoidable: the budget ran out precisely because it was never read.
- Not validated / out of scope: I did not change how the budget is counted or when folders are queued, only how a skipped node is marked.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

为那些因 `maxItems` 预算耗尽而未被 BFS 展开的目录添加标记，使其不再与空目录渲染成完全相同的样子。

## 为什么需要

`readFullStructure` 会把每个子目录放入其父目录的 `subFolders` 并加入队列等待展开。当该队列项稍后出队而预算已经耗尽时，代码只是用一个裸 `continue` 跳过它，因此它的 `hasMoreFiles` 和 `hasMoreSubfolders` 从未被设置。于是 `formatStructure` 把它渲染成 `└───somedir/` 且下方空无一物——与一个已被读取且确认为空的目录逐字节一致。

结果就是：同一棵目录树仅仅因为预算不同而被描述成不同的样子，而模型无从分辨自己看到的是哪一种。现有测试套件中已经包含了这个对比：

```
maxItems 10                         maxItems 3
└───level1/                         └───level1/
    └───level2/                         └───level2/
        └───level3/                         └───level3/
            └───file.txt                                       <-- 看起来像是空的
```

两次运行中 `level3` 都包含 `file.txt`。子目录那个用例更严重：五个 `folder-N/child.txt` 目录，`maxItems: 4`，渲染出的四个目录全都显示为空，而每一个其实都有子项。

父目录的 `hasMoreSubfolders` 标志并不能覆盖这种情况，跳过处那句"排队它的父目录会设置自己的 hasMoreSubfolders 标志"的注释说的是另一回事。该标志的含义是*"我没能加入全部子目录"*——而这些目录都成功加入了，只是从未被展开。

修复方式是在被跳过的节点自身上设置 `hasMoreSubfolders`。这里有意只设置这一个标志：`formatStructure` 每个标志输出一个指示符，两个都设置就会打印两行 `...`。只设 `hasMoreSubfolders` 会产生单个末尾指示符，且无论未探索的内容是文件还是目录，读起来都正确。

## 审阅者测试计划

### 如何验证

一个包含三个文件和一个含两个文件的 `deep/` 的根目录，`maxItems: 4`：

```
修复前                               修复后
├───a.txt                           ├───a.txt
├───b.txt                           ├───b.txt
├───c.txt                           ├───c.txt
└───deep/                           └───deep/
                                        └───...
```

在 `maxItems: 100` 下，同一棵树会完整展开且不会出现任何指示符，修复前后一致。

```
$ npx vitest run --root packages/core --coverage.enabled=false src/utils/getFolderStructure.test.ts
 Test Files  1 passed (1)
      Tests  17 passed (17)

# 回退 src/utils/getFolderStructure.ts 并保留测试后：
      Tests  4 failed | 13 passed (17)
```

其他使用方不受影响：`environmentContext.test.ts` 64 项通过，`client.test.ts` 301 项通过。

新增两个测试。其一对同一棵树在两种预算下分别读取，断言被截断时该目录会被标记、未截断时会完整展开且无指示符。其二是反向错误的保护用例——一个确实为空且确实被读取过的目录，不得获得暗示"还有更多内容"的指示符；该用例在修复前后均通过。

### 证据（修复前后对比）

修复前后的目录树见上文。该字符串是为模型上下文拼装的，并非在 TUI 中绘制，因此没有截图可附。

### 测试环境

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

仅单元测试。

## 风险与影响范围

- 主要风险或权衡：三个既有预期固化了旧的渲染结果，本 PR 对其做了更新。它们正是上文引用的那几个——其测试数据本身就证明了目录并非为空——因此我认为它们只是记录了当时的行为，而非在规定行为；特此明确指出，以防这一判断有误。此外，对于一个恰好为空的被截断目录同样会出现指示符，这无法避免：预算耗尽的原因正是它从未被读取。
- 未验证 / 不在范围内：我没有改动预算的计数方式或目录入队的时机，只改动了被跳过节点的标记方式。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
