### PR TITLE
fix(core): count the per-server and per-tool always-allow outcomes as approvals

### DIFF
--- a/packages/core/src/permissions/denialTracking.test.ts
+++ b/packages/core/src/permissions/denialTracking.test.ts
@@ -19,6 +19,7 @@ import {
   shouldFallback,
   type AutoModeDenialState,
 } from './denialTracking.js';
+import { ToolConfirmationOutcome } from '../tools/tools.js';
 
 const FRESH: AutoModeDenialState = {
   consecutiveBlock: 0,
@@ -266,18 +267,42 @@ describe('isApproveOutcome', () => {
   // Single source of truth for "user said yes" — shared between the CLI
   // scheduler and the ACP Session. Drift between them was a previous
   // round's bug; this test guards both call sites at once.
-  it('returns true for every proceed_* outcome plus modify_with_editor', () => {
-    expect(isApproveOutcome('proceed_once')).toBe(true);
-    expect(isApproveOutcome('proceed_always')).toBe(true);
-    expect(isApproveOutcome('proceed_always_project')).toBe(true);
-    expect(isApproveOutcome('proceed_always_user')).toBe(true);
-    expect(isApproveOutcome('modify_with_editor')).toBe(true);
+  // Enumerated from the enum rather than hand-listed. The hand-written list
+  // had drifted from it -- `proceed_always_server` and `proceed_always_tool`
+  // were missing while the test claimed to cover "every proceed_* outcome" --
+  // so a future addition to the enum now fails here instead of silently
+  // reading as a denial.
+  const proceedOutcomes = Object.values(ToolConfirmationOutcome).filter(
+    (outcome) => outcome.startsWith('proceed_'),
+  );
+
+  it('covers every proceed_* value the enum declares', () => {
+    // Guards the filter itself: if the naming convention changes, the
+    // parametrised test below would silently shrink to nothing.
+    expect(proceedOutcomes.length).toBeGreaterThanOrEqual(7);
+  });
+
+  it.each(proceedOutcomes)('returns true for %s', (outcome) => {
+    expect(isApproveOutcome(outcome)).toBe(true);
+  });
+
+  it('returns true for modify_with_editor', () => {
+    expect(isApproveOutcome(ToolConfirmationOutcome.ModifyWithEditor)).toBe(
+      true,
+    );
   });
 
   it('returns false for cancel and unknown outcomes', () => {
     expect(isApproveOutcome('cancel')).toBe(false);
     expect(isApproveOutcome('')).toBe(false);
     expect(isApproveOutcome('unknown_outcome')).toBe(false);
+  });
+
+  // Restoring the previous approval mode is not an approval of this call.
+  it('returns false for restore_previous', () => {
+    expect(isApproveOutcome(ToolConfirmationOutcome.RestorePrevious)).toBe(
+      false,
+    );
   });
 });
 

--- a/packages/core/src/permissions/denialTracking.ts
+++ b/packages/core/src/permissions/denialTracking.ts
@@ -194,6 +194,14 @@ export function isApproveOutcome(outcome: string): boolean {
     outcome === 'proceed_always' ||
     outcome === 'proceed_always_project' ||
     outcome === 'proceed_always_user' ||
+    // The per-server and per-tool "always allow" buttons. They are older than
+    // the project/user pair above but still reach here -- web-shell's
+    // ToolApproval sends them, and background-tasks, tool-call-decision and
+    // the ACP Session all count them as approvals. Omitting them here meant a
+    // user who approved a fallen-back call with one of these two buttons did
+    // not clear the AUTO denial counters, so the session kept prompting.
+    outcome === 'proceed_always_server' ||
+    outcome === 'proceed_always_tool' ||
     outcome === 'modify_with_editor'
   );
 }


### PR DESCRIPTION
## What this PR does

Adds `proceed_always_server` and `proceed_always_tool` to `isApproveOutcome`, so the two per-server / per-tool "always allow" buttons count as approvals like every other proceed outcome.

## Why it's needed

`isApproveOutcome` describes itself as the single source of truth for "the user approved the call", shared between the CLI scheduler and the ACP Session precisely so a new approve-shaped outcome cannot drift between the two paths. It listed every `proceed_*` value the enum declares except these two.

They are marked deprecated, but they are still live end to end. `web-shell`'s `ToolApproval` sends them, and four other places already treat them as approvals:

| location | treats them as approval |
| --- | --- |
| `agents/background-tasks.ts` | yes |
| `telemetry/tool-call-decision.ts` | yes |
| `acp-integration/session/Session.ts` | yes |
| `tools/agent/agent.ts` | yes |
| `permissions/denialTracking.ts` | **no** |

Both consumers use the result for the same job. In AUTO mode, when a call falls back to a manual prompt because `denialTracking` was armed, an approval clears the counters so subsequent calls return to classifier flow. Approving with "always allow for this server" or "always allow for this tool" did not clear them — so the session went on prompting after the user had granted the broadest permission available. The narrower buttons beside them (`proceed_always_project`, `proceed_always_user`) did clear the counters, which makes the behaviour hard to attribute from the outside.

## Reviewer Test Plan

### How to verify

```
$ npx vitest run --root packages/core --coverage.enabled=false src/permissions/denialTracking.test.ts
 Test Files  1 passed (1)
      Tests  34 passed (34)

# with src/permissions/denialTracking.ts reverted and the tests kept:
      Tests  2 failed | 32 passed (34)
```

The two failures are exactly `proceed_always_server` and `proceed_always_tool`; everything else passes before and after.

The test now derives the `proceed_*` set from `ToolConfirmationOutcome` rather than hand-listing it, since the hand-written list is what drifted — it asserted it covered "every proceed_* outcome" while naming four of seven. A guard asserts the filter still matches at least seven values, so if the naming convention ever changes the parametrised test cannot silently shrink to nothing. `restore_previous` is asserted false: restoring the previous approval mode is not an approval of the call in hand.

Whole permissions suite on this branch:

```
$ npx vitest run --root packages/core --coverage.enabled=false src/permissions/
      Tests  725 passed (725)
```

### Evidence (Before & After)

N/A — not user-visible as a rendering change; the observable difference is that AUTO mode stops re-prompting after one of these two buttons is used.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only.

## Risk & Scope

- Main risk or tradeoff: these outcomes now clear the AUTO fallback counters where previously they did not. That is the intended correction and matches what the four other call sites already assume, but it does mean AUTO mode returns to classifier flow sooner after one of these approvals.
- Not validated / out of scope: I did not undeprecate or remove the two outcomes, and did not touch how they are handled anywhere else. If the intent is that deprecated outcomes should stop being emitted, that is a larger change than this one.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

在 `isApproveOutcome` 中补上 `proceed_always_server` 和 `proceed_always_tool`，使这两个"按服务端 / 按工具始终允许"按钮与其他所有 proceed 结果一样被视为批准。

## 为什么需要

`isApproveOutcome` 自述为"用户已批准该调用"的唯一事实来源，由 CLI 调度器与 ACP Session 共用，正是为了让新增的批准类结果不会在两条路径之间产生分歧。然而它列出了枚举中所有 `proceed_*` 值，唯独漏掉了这两个。

它们虽被标记为废弃，但端到端仍在使用。`web-shell` 的 `ToolApproval` 会发送它们，另有四处已将其视为批准：

| 位置 | 是否视为批准 |
| --- | --- |
| `agents/background-tasks.ts` | 是 |
| `telemetry/tool-call-decision.ts` | 是 |
| `acp-integration/session/Session.ts` | 是 |
| `tools/agent/agent.ts` | 是 |
| `permissions/denialTracking.ts` | **否** |

两个使用方对结果的用途相同。在 AUTO 模式下，当某次调用因 `denialTracking` 被触发而回退到手动确认时，一次批准会清空计数器，使后续调用回到分类器流程。而用"按此服务端始终允许"或"按此工具始终允许"进行批准时并不会清空——于是在用户已经授予了范围最广的权限之后，会话仍会继续弹出确认。旁边范围更窄的按钮（`proceed_always_project`、`proceed_always_user`）却会清空计数器，这使得该现象从外部很难归因。

## 审阅者测试计划

### 如何验证

```
$ npx vitest run --root packages/core --coverage.enabled=false src/permissions/denialTracking.test.ts
 Test Files  1 passed (1)
      Tests  34 passed (34)

# 回退 src/permissions/denialTracking.ts 并保留测试后：
      Tests  2 failed | 32 passed (34)
```

失败的恰好是 `proceed_always_server` 和 `proceed_always_tool`；其余用例在修复前后均通过。

测试现在改为从 `ToolConfirmationOutcome` 推导出 `proceed_*` 集合，而不再手工罗列——因为产生分歧的正是那份手写清单：它声称覆盖了"每一个 proceed_* 结果"，实际只列出了七个中的四个。另有一个保护性断言要求该过滤结果至少匹配七个值，这样一来即便命名约定日后发生变化，参数化测试也不会悄无声息地缩减为零。`restore_previous` 被断言为 false：恢复此前的审批模式并不等于批准当前这次调用。

本分支上的权限全量测试：

```
$ npx vitest run --root packages/core --coverage.enabled=false src/permissions/
      Tests  725 passed (725)
```

### 证据（修复前后对比）

N/A——并非可见的渲染变化；可观察到的差别是：使用这两个按钮之一后，AUTO 模式不再反复弹出确认。

### 测试环境

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

仅单元测试。

## 风险与影响范围

- 主要风险或权衡：这两个结果现在会清空 AUTO 回退计数器，而此前不会。这正是预期的修正，也与其他四处调用点已有的假设一致，但确实意味着在这类批准之后，AUTO 模式会更早地回到分类器流程。
- 未验证 / 不在范围内：我没有取消这两个结果的废弃标记，也没有将其移除，更没有改动它们在其他地方的处理方式。如果本意是让废弃结果彻底停止发出，那属于比本 PR 大得多的改动。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
