### PR TITLE
fix(cli): pick the memory unit from the rounded figure, not the raw bytes

### DIFF
--- a/packages/cli/src/serve/env-snapshot.ts
+++ b/packages/cli/src/serve/env-snapshot.ts
@@ -7,6 +7,7 @@
 import os from 'node:os';
 import {
   detectRuntime,
+  formatMemoryUsage,
   redactProxyCredentials,
 } from '@qwen-code/qwen-code-core';
 import {
@@ -14,17 +15,6 @@ import {
   type ServeEnvCell,
   type ServeWorkspaceEnvStatus,
 } from '@qwen-code/acp-bridge/status';
-
-function formatMemoryUsage(bytes: number): string {
-  const gb = bytes / (1024 * 1024 * 1024);
-  if (bytes < 1024 * 1024) {
-    return `${(bytes / 1024).toFixed(1)} KB`;
-  }
-  if (bytes < 1024 * 1024 * 1024) {
-    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  }
-  return `${gb.toFixed(2)} GB`;
-}
 
 /**
  * Whitelisted environment variables whose **presence** the daemon will

--- a/packages/cli/src/ui/utils/formatters.test.ts
+++ b/packages/cli/src/ui/utils/formatters.test.ts
@@ -94,42 +94,18 @@ describe('formatters', () => {
     });
   });
 
+  // The implementation and its full case table live in core
+  // (`packages/core/src/utils/formatters.test.ts`); this module only
+  // re-exports it. These pin the re-export itself, including the unit
+  // rollover that used to differ between the copies.
   describe('formatMemoryUsage', () => {
-    it('should format bytes into KB', () => {
-      expect(formatMemoryUsage(12345)).toBe('12.1 KB');
-    });
-
-    it('should format bytes into MB', () => {
-      expect(formatMemoryUsage(12345678)).toBe('11.8 MB');
-    });
-
-    it('should format bytes into GB', () => {
-      expect(formatMemoryUsage(12345678901)).toBe('11.50 GB');
-    });
-
-    // Rounding to one decimal can carry a value up to the next unit's
-    // boundary. Choosing the unit from the raw byte count kept the smaller
-    // label, so a value one byte under a megabyte printed as "1024.0 KB".
     it.each([
+      [12345, '12.1 KB'],
+      [12345678, '11.8 MB'],
+      [12345678901, '11.50 GB'],
       [1024 * 1024 - 1, '1.0 MB'],
       [1024 * 1024 * 1024 - 1, '1.00 GB'],
-    ])('rolls %d over to the next unit', (bytes, expected) => {
-      expect(formatMemoryUsage(bytes)).toBe(expected);
-    });
-
-    // Guards against over-correcting into rolling over too eagerly. Each of
-    // these stays in its own unit, and all pass before and after.
-    it.each([
-      [0, '0.0 KB'],
-      [512, '0.5 KB'],
-      [1024, '1.0 KB'],
-      [1024 * 1024, '1.0 MB'],
-      [1024 * 1024 * 1024, '1.00 GB'],
-      [1024 * 1023, '1023.0 KB'],
-      [1024 * 1024 * 1023, '1023.0 MB'],
-      // Just below the point where rounding would reach the boundary.
-      [1024 * 1024 - 100, '1023.9 KB'],
-    ])('keeps %d in its own unit', (bytes, expected) => {
+    ])('formats %d as %s', (bytes, expected) => {
       expect(formatMemoryUsage(bytes)).toBe(expected);
     });
   });

--- a/packages/cli/src/ui/utils/formatters.test.ts
+++ b/packages/cli/src/ui/utils/formatters.test.ts
@@ -106,6 +106,32 @@ describe('formatters', () => {
     it('should format bytes into GB', () => {
       expect(formatMemoryUsage(12345678901)).toBe('11.50 GB');
     });
+
+    // Rounding to one decimal can carry a value up to the next unit's
+    // boundary. Choosing the unit from the raw byte count kept the smaller
+    // label, so a value one byte under a megabyte printed as "1024.0 KB".
+    it.each([
+      [1024 * 1024 - 1, '1.0 MB'],
+      [1024 * 1024 * 1024 - 1, '1.00 GB'],
+    ])('rolls %d over to the next unit', (bytes, expected) => {
+      expect(formatMemoryUsage(bytes)).toBe(expected);
+    });
+
+    // Guards against over-correcting into rolling over too eagerly. Each of
+    // these stays in its own unit, and all pass before and after.
+    it.each([
+      [0, '0.0 KB'],
+      [512, '0.5 KB'],
+      [1024, '1.0 KB'],
+      [1024 * 1024, '1.0 MB'],
+      [1024 * 1024 * 1024, '1.00 GB'],
+      [1024 * 1023, '1023.0 KB'],
+      [1024 * 1024 * 1023, '1023.0 MB'],
+      // Just below the point where rounding would reach the boundary.
+      [1024 * 1024 - 100, '1023.9 KB'],
+    ])('keeps %d in its own unit', (bytes, expected) => {
+      expect(formatMemoryUsage(bytes)).toBe(expected);
+    });
   });
 
   describe('formatDuration', () => {

--- a/packages/cli/src/ui/utils/formatters.ts
+++ b/packages/cli/src/ui/utils/formatters.ts
@@ -4,15 +4,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+const BYTES_PER_KB = 1024;
+const BYTES_PER_MB = BYTES_PER_KB * 1024;
+const BYTES_PER_GB = BYTES_PER_MB * 1024;
+
+/** The value as it will actually be printed, so the unit can be picked from it. */
+const roundedTo = (value: number, digits: number): number =>
+  Number(value.toFixed(digits));
+
 export const formatMemoryUsage = (bytes: number): string => {
-  const gb = bytes / (1024 * 1024 * 1024);
-  if (bytes < 1024 * 1024) {
-    return `${(bytes / 1024).toFixed(1)} KB`;
+  // The unit is chosen from the rounded figure rather than the raw byte
+  // count. Rounding to one decimal can carry a value up to the next unit's
+  // boundary, and testing the raw count then kept the smaller label: 1048575
+  // is under a megabyte, so it took the KB branch and printed "1024.0 KB" --
+  // a megabyte-sized number wearing a kilobyte label. The same happened one
+  // byte below a gigabyte, which printed "1024.0 MB".
+  if (roundedTo(bytes / BYTES_PER_KB, 1) < 1024) {
+    return `${(bytes / BYTES_PER_KB).toFixed(1)} KB`;
   }
-  if (bytes < 1024 * 1024 * 1024) {
-    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  if (roundedTo(bytes / BYTES_PER_MB, 1) < 1024) {
+    return `${(bytes / BYTES_PER_MB).toFixed(1)} MB`;
   }
-  return `${gb.toFixed(2)} GB`;
+  return `${(bytes / BYTES_PER_GB).toFixed(2)} GB`;
 };
 
 /**

--- a/packages/cli/src/ui/utils/formatters.ts
+++ b/packages/cli/src/ui/utils/formatters.ts
@@ -4,29 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const BYTES_PER_KB = 1024;
-const BYTES_PER_MB = BYTES_PER_KB * 1024;
-const BYTES_PER_GB = BYTES_PER_MB * 1024;
-
-/** The value as it will actually be printed, so the unit can be picked from it. */
-const roundedTo = (value: number, digits: number): number =>
-  Number(value.toFixed(digits));
-
-export const formatMemoryUsage = (bytes: number): string => {
-  // The unit is chosen from the rounded figure rather than the raw byte
-  // count. Rounding to one decimal can carry a value up to the next unit's
-  // boundary, and testing the raw count then kept the smaller label: 1048575
-  // is under a megabyte, so it took the KB branch and printed "1024.0 KB" --
-  // a megabyte-sized number wearing a kilobyte label. The same happened one
-  // byte below a gigabyte, which printed "1024.0 MB".
-  if (roundedTo(bytes / BYTES_PER_KB, 1) < 1024) {
-    return `${(bytes / BYTES_PER_KB).toFixed(1)} KB`;
-  }
-  if (roundedTo(bytes / BYTES_PER_MB, 1) < 1024) {
-    return `${(bytes / BYTES_PER_MB).toFixed(1)} MB`;
-  }
-  return `${(bytes / BYTES_PER_GB).toFixed(2)} GB`;
-};
+// Re-exported from core so the CLI UI, the shell/diagnostics paths in core
+// and the serve daemon all render a byte count identically.
+export { formatMemoryUsage } from '@qwen-code/qwen-code-core';
 
 /**
  * Formats a duration in milliseconds into a concise, human-readable string (e.g., "1h 5s").

--- a/packages/core/src/utils/formatters.test.ts
+++ b/packages/core/src/utils/formatters.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { formatMemoryUsage } from './formatters.js';
+
+describe('formatMemoryUsage', () => {
+  it.each([
+    [12345, '12.1 KB'],
+    [12345678, '11.8 MB'],
+    [12345678901, '11.50 GB'],
+  ])('formats %d with the expected unit', (bytes, expected) => {
+    expect(formatMemoryUsage(bytes)).toBe(expected);
+  });
+
+  // Rounding to one decimal can carry a value up to the next unit's boundary.
+  // Choosing the unit from the raw byte count kept the smaller label, so a
+  // value one byte under a megabyte printed as "1024.0 KB".
+  it.each([
+    [1024 * 1024 - 1, '1.0 MB'],
+    [1024 * 1024 * 1024 - 1, '1.00 GB'],
+  ])('rolls %d over to the next unit', (bytes, expected) => {
+    expect(formatMemoryUsage(bytes)).toBe(expected);
+  });
+
+  // Guards against over-correcting into rolling over too eagerly. Each of
+  // these stays in its own unit, and all pass before and after.
+  it.each([
+    [0, '0.0 KB'],
+    [512, '0.5 KB'],
+    [1024, '1.0 KB'],
+    [1024 * 1024, '1.0 MB'],
+    [1024 * 1024 * 1024, '1.00 GB'],
+    [1024 * 1023, '1023.0 KB'],
+    [1024 * 1024 * 1023, '1023.0 MB'],
+    // Just below the point where rounding would reach the boundary.
+    [1024 * 1024 - 100, '1023.9 KB'],
+  ])('keeps %d in its own unit', (bytes, expected) => {
+    expect(formatMemoryUsage(bytes)).toBe(expected);
+  });
+});

--- a/packages/core/src/utils/formatters.ts
+++ b/packages/core/src/utils/formatters.ts
@@ -4,13 +4,33 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+const BYTES_PER_KB = 1024;
+const BYTES_PER_MB = BYTES_PER_KB * 1024;
+const BYTES_PER_GB = BYTES_PER_MB * 1024;
+
+/** The value as it will actually be printed, so the unit can be picked from it. */
+const roundedTo = (value: number, digits: number): number =>
+  Number(value.toFixed(digits));
+
+/**
+ * Renders a byte count with a human-readable unit. This is the one
+ * implementation: `packages/cli/src/ui/utils/formatters.ts` and
+ * `packages/cli/src/serve/env-snapshot.ts` re-use it instead of keeping their
+ * own copies, so the same byte count cannot format differently depending on
+ * which code path prints it.
+ */
 export const formatMemoryUsage = (bytes: number): string => {
-  const gb = bytes / (1024 * 1024 * 1024);
-  if (bytes < 1024 * 1024) {
-    return `${(bytes / 1024).toFixed(1)} KB`;
+  // The unit is chosen from the rounded figure rather than the raw byte
+  // count. Rounding to one decimal can carry a value up to the next unit's
+  // boundary, and testing the raw count then kept the smaller label: 1048575
+  // is under a megabyte, so it took the KB branch and printed "1024.0 KB" --
+  // a megabyte-sized number wearing a kilobyte label. The same happened one
+  // byte below a gigabyte, which printed "1024.0 MB".
+  if (roundedTo(bytes / BYTES_PER_KB, 1) < 1024) {
+    return `${(bytes / BYTES_PER_KB).toFixed(1)} KB`;
   }
-  if (bytes < 1024 * 1024 * 1024) {
-    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  if (roundedTo(bytes / BYTES_PER_MB, 1) < 1024) {
+    return `${(bytes / BYTES_PER_MB).toFixed(1)} MB`;
   }
-  return `${gb.toFixed(2)} GB`;
+  return `${(bytes / BYTES_PER_GB).toFixed(2)} GB`;
 };


### PR DESCRIPTION
## What this PR does

Picks the memory unit from the figure `formatMemoryUsage` is about to print, rather than from the raw byte count, so a value that rounds up to the next boundary is no longer labelled with the unit below it.

## Why it's needed

The unit was selected by comparing the raw byte count against each boundary, but the number printed is rounded to one decimal place. Rounding can carry a value up to the next boundary while the branch that was already chosen keeps the smaller label:

| bytes | before | after |
| --- | --- | --- |
| `1048575` (one under 1 MB) | **`1024.0 KB`** | `1.0 MB` |
| `1073741823` (one under 1 GB) | **`1024.0 MB`** | `1.00 GB` |

`1024.0 KB` is a megabyte-sized number wearing a kilobyte label. This is the live memory readout, so any process sitting just under a boundary displays it.

## Reviewer Test Plan

### How to verify

```
$ npx vitest run --root packages/cli --coverage.enabled=false src/ui/utils/formatters.test.ts
      Tests  43 passed (43)

# with src/ui/utils/formatters.ts reverted and the tests kept:
      Tests  2 failed | 41 passed (43)
```

The two failures are the two rows above. The rest of the added cases are guards against over-correcting into rolling over too eagerly, and pass before and after: `0`, `512`, `1024`, `1024*1024`, `1024*1024*1024`, `1023 KB`, `1023 MB`, and `1024*1024 - 100` — the last of which rounds to `1023.9` and must therefore stay in KB.

### Evidence (Before & After)

The before/after strings are tabulated above. This value appears in the footer's memory readout; the change is to the string these pure functions return, and the tests assert it directly.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only.

## Risk & Scope

- Main risk or tradeoff: values within one rounding step of a boundary now print in the larger unit. That is the intent, and the guard cases pin everything else in place.
- Not validated / out of scope: `formatTokenCount` in the same file has a related oddity — `9999` prints `10.0k` while `10000` prints `10k`. I left it alone on purpose: nothing there is mislabelled, and every way of smoothing it either understates `9999` as `9k` or changes the output across the whole range above it (`999999` would move from `999k` to `1000k`). That is a formatting preference rather than a defect, so it does not belong in a fix PR.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

让 `formatMemoryUsage` 依据它即将打印出来的数值来选择单位，而不是依据原始字节数，这样四舍五入后进位到下一个边界的数值就不会再被标上低一级的单位。

## 为什么需要

单位是通过将原始字节数与各个边界比较来选定的，但打印出来的数字保留了一位小数。四舍五入可能把数值推进到下一个边界，而此前已经选定的分支仍然沿用较小的单位标签：

| 字节数 | 修复前 | 修复后 |
| --- | --- | --- |
| `1048575`（比 1 MB 少 1） | **`1024.0 KB`** | `1.0 MB` |
| `1073741823`（比 1 GB 少 1） | **`1024.0 MB`** | `1.00 GB` |

`1024.0 KB` 是一个兆字节量级的数字却挂着千字节的标签。这是实时的内存读数，因此任何内存占用恰好略低于边界的进程都会显示成这样。

## 审阅者测试计划

### 如何验证

```
$ npx vitest run --root packages/cli --coverage.enabled=false src/ui/utils/formatters.test.ts
      Tests  43 passed (43)

# 回退 src/ui/utils/formatters.ts 并保留测试后：
      Tests  2 failed | 41 passed (43)
```

失败的两项正是上表中的两行。新增的其余用例都是防止过度修正（避免过早进位）的保护性用例，修复前后均通过：`0`、`512`、`1024`、`1024*1024`、`1024*1024*1024`、`1023 KB`、`1023 MB`，以及 `1024*1024 - 100`——最后这一项四舍五入后为 `1023.9`，因此必须保持在 KB。

### 证据（修复前后对比）

修复前后的字符串已在上表列出。该数值出现在底栏的内存读数中；本次改动针对的是这些纯函数返回的字符串，测试直接对其进行断言。

### 测试环境

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

仅单元测试。

## 风险与影响范围

- 主要风险或权衡：与边界相差不到一个舍入步长的数值现在会以更大的单位显示。这正是本次改动的意图，而保护性用例已将其余情况固定住。
- 未验证 / 不在范围内：同一文件中的 `formatTokenCount` 存在类似的怪异之处——`9999` 显示为 `10.0k`，而 `10000` 显示为 `10k`。我有意没有改动它：那里并不存在单位标错的问题，而任何抹平这一差异的做法，要么会把 `9999` 低估为 `9k`，要么会改变其之上整个区间的输出（`999999` 会从 `999k` 变成 `1000k`）。这属于格式偏好而非缺陷，因此不应放进一个修复类 PR。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
