### PR TITLE
fix(cli): make wrapToVisualLines count zero-width characters like its sibling

### DIFF
--- a/packages/cli/src/ui/utils/textUtils.test.ts
+++ b/packages/cli/src/ui/utils/textUtils.test.ts
@@ -16,6 +16,7 @@ import {
   sanitizeSensitiveText,
   sliceTextByVisualHeight,
   truncateToWidth,
+  wrapToVisualLines,
 } from './textUtils.js';
 
 describe('textUtils', () => {
@@ -395,5 +396,51 @@ describe('textUtils', () => {
       // 5 CJK characters (10 cells) plus the ellipsis fit an 11-cell budget.
       expect(truncateToWidth('目标配置参数设置', 11)).toBe('目标配置参…');
     });
+  });
+});
+
+describe('visual row counting agrees between wrap and slice', () => {
+  // Both functions are documented as measuring visual rows at a given width,
+  // and callers mix them (scroll offsets, pending-render height). They
+  // disagreed on anything `string-width` reports as zero width, because only
+  // one of them clamped the per-character width to 1.
+  // `hiddenLinesCount + visible` only recovers the true row count when the
+  // text actually overflows `visible`, so every case below is chosen to.
+  const rowsFromSlice = (text: string, width: number): number => {
+    const visible = 3;
+    return (
+      sliceTextByVisualHeight(text, visible, width).hiddenLinesCount + visible
+    );
+  };
+
+  it.each([
+    ['tabs', '\t'.repeat(50)],
+    ['combining marks', '́'.repeat(50)],
+    ['zero-width joiners', '‍'.repeat(50)],
+    ['a letter then combining marks', 'e' + '́'.repeat(49)],
+  ])('agrees on a run of %s', (_label, text) => {
+    expect(wrapToVisualLines(text, 10).length).toBe(rowsFromSlice(text, 10));
+  });
+
+  // Guards against over-correcting: ordinary and wide characters were always
+  // consistent and must stay so. These pass before and after.
+  it.each([
+    ['ascii', 'a'.repeat(50), 10],
+    ['wide CJK', '漢'.repeat(25), 10],
+    ['mixed', 'ab漢cd'.repeat(10), 10],
+  ])('still agrees on %s', (_label, text, width) => {
+    expect(wrapToVisualLines(text, width).length).toBe(
+      rowsFromSlice(text, width),
+    );
+  });
+
+  it('still wraps a string shorter than the width to one row', () => {
+    expect(wrapToVisualLines('abc', 10)).toEqual(['abc']);
+  });
+
+  it('counts a run of tabs as more than one row', () => {
+    // The concrete regression: 50 zero-width characters at width 10 used to
+    // wrap to a single row.
+    expect(wrapToVisualLines('\t'.repeat(50), 10).length).toBe(5);
   });
 });

--- a/packages/cli/src/ui/utils/textUtils.ts
+++ b/packages/cli/src/ui/utils/textUtils.ts
@@ -295,7 +295,15 @@ export function wrapToVisualLines(text: string, width: number): string[] {
     let currentLine = '';
     let currentWidth = 0;
     for (const char of logicalLine) {
-      const charWidth = getCachedStringWidth(char);
+      // Clamped to 1, matching sliceTextByVisualHeight. `string-width` reports
+      // 0 for TAB, ZWJ and combining marks, so without this a run of them was
+      // charged nothing and the whole run counted as a single row: 50 tabs at
+      // width 10 came back as 1 row here and 5 there, for the same input. Any
+      // caller mixing the two -- scroll offsets, pending-render height -- then
+      // disagreed with itself. Erring high is the safe direction for a
+      // terminal: reserving a row too many costs a blank line, while counting
+      // one too few overflows the region and pushes content off screen.
+      const charWidth = Math.max(getCachedStringWidth(char), 1);
       if (currentWidth + charWidth > width && currentWidth > 0) {
         visualLines.push(currentLine);
         currentLine = '';


### PR DESCRIPTION
## What this PR does

Applies the same per-character width clamp in `wrapToVisualLines` that `sliceTextByVisualHeight` already uses, so the two functions stop returning different row counts for the same text at the same width.

## Why it's needed

Both are documented as computing visual rows at a given width, and callers mix them — scroll offsets and pending-render height are derived from one and checked against the other. Only `sliceTextByVisualHeight` clamps with `Math.max(getCachedStringWidth(char), 1)`.

`string-width` reports 0 for TAB, ZWJ and combining marks, so in `wrapToVisualLines` a run of them was charged nothing and the whole run collapsed into a single row:

| text (width 10) | `wrapToVisualLines` | `sliceTextByVisualHeight` |
| --- | --- | --- |
| 50 tabs | **1 row** | **5 rows** |
| 50 combining marks | **1 row** | **5 rows** |
| 50 zero-width joiners | **1 row** | **5 rows** |
| 50 ascii | 5 rows | 5 rows |
| 25 wide CJK | 5 rows | 5 rows |

The ascii and CJK rows already agreed; the disagreement is confined to characters of reported width zero.

Erring high is the safe direction here. Reserving one row too many costs a blank line; counting one too few means the region overflows and content is pushed off screen. That is also the direction the existing clamp in `sliceTextByVisualHeight` already picked, so this converges on it rather than inventing a third behaviour.

## Reviewer Test Plan

### How to verify

```
$ npx vitest run --root packages/cli --coverage.enabled=false src/ui/utils/textUtils.test.ts
      Tests  46 passed (46)

# with src/ui/utils/textUtils.ts reverted and the tests kept:
      Tests  5 failed | 41 passed (46)
```

The five failures are the zero-width cases. The added tests assert agreement between the two functions rather than a hard-coded row count, so they pin the two together rather than to a number.

The ascii, wide-CJK and mixed rows are guards against over-correcting and pass before and after, as does a short string still wrapping to one row.

The only consumer of `wrapToVisualLines` is `ConversationMessages.tsx`; its package suite is unchanged by this:

```
$ npx vitest run --root packages/cli --coverage.enabled=false src/ui/components/messages/
      Tests  2 failed | 307 passed | 1 skipped (310)
```

Both failures (`DiffRenderer` line numbers, `ToolMessage` TAB/LF) reproduce identically on unmodified `main` in my environment, so they are pre-existing and unrelated.

### Evidence (Before & After)

The row-count table above is the before/after. These are pure functions and the tests assert their return values directly.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only.

## Risk & Scope

- Main risk or tradeoff: text containing zero-width characters now wraps sooner in `wrapToVisualLines`, so such lines occupy more rows than before. That is the point — they already occupied those rows according to the other function, and according to the terminal for TAB.
- Not validated / out of scope: both functions now charge a combining mark a full column, which over-counts a grapheme like `e` + U+0301. That is pre-existing behaviour in `sliceTextByVisualHeight`; making it precise would mean grapheme-aware measurement in both, which is a larger change than reconciling them. I have not touched `sliceTextByVisualHeight`.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

在 `wrapToVisualLines` 中应用与 `sliceTextByVisualHeight` 相同的单字符宽度下限钳制，使这两个函数不再对相同文本、相同宽度给出不同的行数。

## 为什么需要

两者的文档都声称是在给定宽度下计算可视行数，而调用方会混用它们——滚动偏移和待渲染高度由其中一个推导、再用另一个校验。但只有 `sliceTextByVisualHeight` 使用了 `Math.max(getCachedStringWidth(char), 1)` 进行钳制。

`string-width` 对 TAB、ZWJ 和组合字符返回 0，因此在 `wrapToVisualLines` 中，一连串这样的字符不计任何宽度，整段被压缩成了一行：

| 文本（宽度 10） | `wrapToVisualLines` | `sliceTextByVisualHeight` |
| --- | --- | --- |
| 50 个制表符 | **1 行** | **5 行** |
| 50 个组合字符 | **1 行** | **5 行** |
| 50 个零宽连接符 | **1 行** | **5 行** |
| 50 个 ASCII 字符 | 5 行 | 5 行 |
| 25 个全角汉字 | 5 行 | 5 行 |

ASCII 和汉字两行本来就一致；分歧仅限于报告宽度为零的字符。

在这里宁可高估。多预留一行的代价只是一个空行；而少算一行则会导致区域溢出、内容被挤出屏幕。这也正是 `sliceTextByVisualHeight` 中既有钳制所选择的方向，因此本次改动是向它靠拢，而不是引入第三种行为。

## 审阅者测试计划

### 如何验证

```
$ npx vitest run --root packages/cli --coverage.enabled=false src/ui/utils/textUtils.test.ts
      Tests  46 passed (46)

# 回退 src/ui/utils/textUtils.ts 并保留测试后：
      Tests  5 failed | 41 passed (46)
```

失败的五项都是零宽字符相关用例。新增测试断言的是两个函数彼此一致，而非某个硬编码行数，因此它们把两者绑定在一起，而不是绑定到某个数字上。

ASCII、全角汉字和混合三行是防过度修正的保护性用例，修复前后均通过；短字符串仍应换行为一行的用例同样如此。

`wrapToVisualLines` 的唯一使用方是 `ConversationMessages.tsx`；其所在包的测试套件不受本次改动影响：

```
$ npx vitest run --root packages/cli --coverage.enabled=false src/ui/components/messages/
      Tests  2 failed | 307 passed | 1 skipped (310)
```

这两个失败（`DiffRenderer` 行号、`ToolMessage` TAB/LF）在我的环境中于未修改的 `main` 上同样复现，因此属于既有问题，与本次改动无关。

### 证据（修复前后对比）

上方的行数对照表即为修复前后对比。它们是纯函数，测试直接断言其返回值。

### 测试环境

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

仅单元测试。

## 风险与影响范围

- 主要风险或权衡：含零宽字符的文本在 `wrapToVisualLines` 中会更早换行，因此这类行会占据比以前更多的行数。这正是本次改动的目的——按照另一个函数的计算它们本就占据那些行，而对 TAB 而言，终端本身也是这么渲染的。
- 未验证 / 不在范围内：现在两个函数都会为组合字符计入一整列，这会高估形如 `e` + U+0301 这样的字素簇。该行为在 `sliceTextByVisualHeight` 中本就存在；要做到精确就需要在两者中都实现字素感知的宽度测量，这比让两者保持一致要大得多。我没有改动 `sliceTextByVisualHeight`。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
