### PR TITLE
fix(core): charge the separator and ellipsis to the preview budget

### DIFF
--- a/packages/core/src/utils/truncation.test.ts
+++ b/packages/core/src/utils/truncation.test.ts
@@ -700,3 +700,99 @@ describe('truncateLlmContent', () => {
     expect(result.content).toEqual(content);
   });
 });
+
+describe('truncateAndSaveToFile preview budget', () => {
+  const mockWriteFile = vi.mocked(fs.writeFile);
+  const mockMkdir = vi.mocked(fs.mkdir);
+  const PREVIEW_MARKER = 'Truncated part of the output:\n';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+  });
+
+  const previewOf = (wrapped: string): string =>
+    wrapped.slice(wrapped.indexOf(PREVIEW_MARKER) + PREVIEW_MARKER.length);
+
+  const content = Array.from(
+    { length: 200 },
+    (_, i) => `line ${i} ${'y'.repeat(40)}`,
+  ).join('\n');
+
+  // The separator is 39 characters and the ellipsis 3, and both were emitted
+  // without being charged to the budget, so a small previewChars came back
+  // over it: 0 produced 39 characters, 10 produced 42, 40 produced 47.
+  it.each([
+    ['both' as const, 0],
+    ['both' as const, 10],
+    ['both' as const, 40],
+    ['both' as const, 47],
+    ['head' as const, 40],
+    ['tail' as const, 40],
+  ])(
+    'keeps the %s preview within previewChars=%d',
+    async (keep, previewChars) => {
+      const result = await truncateAndSaveToFile(
+        content,
+        'budget',
+        '/tmp',
+        100,
+        20,
+        keep,
+        previewChars,
+      );
+
+      expect(previewOf(result.content).length).toBeLessThanOrEqual(
+        previewChars,
+      );
+    },
+  );
+
+  it('stays within budget for every previewChars from 0 to 120', async () => {
+    for (const keep of ['both', 'head', 'tail'] as const) {
+      for (let previewChars = 0; previewChars <= 120; previewChars++) {
+        const result = await truncateAndSaveToFile(
+          content,
+          'sweep',
+          '/tmp',
+          100,
+          20,
+          keep,
+          previewChars,
+        );
+        expect(previewOf(result.content).length).toBeLessThanOrEqual(
+          previewChars,
+        );
+      }
+    }
+  });
+
+  // Guards against over-correcting: where the budget has room, the separator
+  // and real content must both survive. The two `toContain` assertions are the
+  // guard proper and hold before and after; the length assertion alongside
+  // them does not, since `keep: 'head'` overran even at 200.
+  it.each([
+    ['both' as const, 200],
+    ['head' as const, 200],
+    ['tail' as const, 200],
+  ])(
+    'still marks the cut for %s at previewChars=%d',
+    async (keep, previewChars) => {
+      const result = await truncateAndSaveToFile(
+        content,
+        'roomy',
+        '/tmp',
+        100,
+        20,
+        keep,
+        previewChars,
+      );
+      const preview = previewOf(result.content);
+
+      expect(preview.length).toBeLessThanOrEqual(previewChars);
+      expect(preview).toContain('[CONTENT TRUNCATED]');
+      expect(preview).toContain('line ');
+    },
+  );
+});

--- a/packages/core/src/utils/truncation.ts
+++ b/packages/core/src/utils/truncation.ts
@@ -88,20 +88,35 @@ export async function truncateAndSaveToFile(
   // Collect head lines within budget. If a single line exceeds the
   // remaining budget, include a truncated slice of it.
   const previewBudget = Math.max(0, previewChars);
+
+  // The separator sits between (or beside) the head and tail, so it has to
+  // come out of the budget rather than be added on top of it. It was emitted
+  // unconditionally while the head budget ignored it entirely, so a small
+  // previewChars came back over budget every time: 0 produced 39 characters,
+  // 10 produced 42, 40 produced 47. Below the separator's own length there is
+  // no room to say anything and still show content -- and the wrapper message
+  // above already states the output was truncated -- so drop it there.
+  const sep = previewBudget > separator.length ? separator : '';
+  const contentBudget = previewBudget - sep.length;
   const headBudget =
     keep === 'head'
-      ? previewBudget
+      ? contentBudget
       : keep === 'tail'
         ? 0
-        : Math.floor(previewBudget / 5);
+        : Math.floor(contentBudget / 5);
   const beginning: string[] = [];
   let headChars = 0;
   for (let i = 0; i < Math.min(headCount, lines.length); i++) {
     const remaining = headBudget - headChars;
     if (remaining <= 0) break;
     if (lines[i].length + 1 > remaining) {
-      const sliceLen = Math.max(remaining - ellipsis.length, 0);
-      beginning.push(lines[i].slice(0, sliceLen) + ellipsis);
+      // The ellipsis has to fit inside `remaining` too. Emitting it when
+      // fewer than three characters were left put the preview over budget by
+      // the difference, on top of the separator overrun above.
+      if (remaining >= ellipsis.length) {
+        const sliceLen = remaining - ellipsis.length;
+        beginning.push(lines[i].slice(0, sliceLen) + ellipsis);
+      }
       headChars = headBudget;
       break;
     }
@@ -112,9 +127,7 @@ export async function truncateAndSaveToFile(
   // Collect tail lines within remaining budget. If a single line exceeds
   // the remaining budget, include a truncated slice of it.
   const tailBudget =
-    keep === 'head'
-      ? 0
-      : Math.max(previewBudget - headChars - separator.length, 0);
+    keep === 'head' ? 0 : Math.max(contentBudget - headChars, 0);
   const end: string[] = [];
   let tailChars = 0;
   const tailStart = Math.max(lines.length - tailCount, beginning.length);
@@ -122,11 +135,15 @@ export async function truncateAndSaveToFile(
     const remaining = tailBudget - tailChars;
     if (remaining <= 0) break;
     if (lines[i].length + 1 > remaining) {
-      const sliceLen = Math.max(remaining - ellipsis.length, 0);
-      // slice(-0) === slice(0) returns the WHOLE line, so guard the zero case
-      // explicitly: sliceLen === 0 means no budget for any tail chars (the head
-      // branch's slice(0, 0) already yields '' correctly).
-      end.unshift(ellipsis + (sliceLen > 0 ? lines[i].slice(-sliceLen) : ''));
+      // As above: below the ellipsis's own length there is no room to mark the
+      // cut without overshooting, so mark nothing.
+      if (remaining >= ellipsis.length) {
+        const sliceLen = remaining - ellipsis.length;
+        // slice(-0) === slice(0) returns the WHOLE line, so guard the zero
+        // case explicitly: sliceLen === 0 means no budget for any tail chars
+        // (the head branch's slice(0, 0) already yields '' correctly).
+        end.unshift(ellipsis + (sliceLen > 0 ? lines[i].slice(-sliceLen) : ''));
+      }
       tailChars = tailBudget;
       break;
     }
@@ -139,10 +156,10 @@ export async function truncateAndSaveToFile(
   // both keeps the existing head+separator+tail shape.
   const truncatedContent =
     keep === 'head'
-      ? beginning.join('\n') + separator
+      ? beginning.join('\n') + sep
       : keep === 'tail'
-        ? separator + end.join('\n')
-        : beginning.join('\n') + separator + end.join('\n');
+        ? sep + end.join('\n')
+        : beginning.join('\n') + sep + end.join('\n');
 
   // Sanitize fileName to prevent path traversal.
   const safeFileName = `${path.basename(fileName)}.output`;


### PR DESCRIPTION
## What this PR does

Charges the truncation separator and the cut-line ellipsis to `previewChars`, so the preview handed to the model stays inside the budget the caller set.

## Why it's needed

`previewChars` bounds the preview that goes into the model's context, but two fixed strings were emitted outside it.

The separator (`\n\n---\n... [CONTENT TRUNCATED] ...\n---\n\n`, 39 characters) was appended whatever the budget was, and the head budget never subtracted it — only the tail budget did. Separately, when fewer than three characters remained, the 3-character ellipsis marking a partially-included line was still emitted. Together:

| `previewChars` | preview returned |
| --- | --- |
| 0 | **39** |
| 10 | **42** |
| 40 | **47** |
| 60 | 60 |
| 200 | 200 |

This is reachable through `truncateToolOutput`'s per-tool `limits.previewChars`, not only via the default.

The fix takes the separator out of the budget before head and tail are split, drops it entirely when the budget cannot fit it alongside any content — the wrapper message above the preview already states the output was truncated, so nothing is lost by omitting it — and skips the ellipsis when there is no room for that either.

## Reviewer Test Plan

### How to verify

```
$ npx vitest run --root packages/core --coverage.enabled=false src/utils/truncation.test.ts
      Tests  40 passed (40)

# with src/utils/truncation.ts reverted and the tests kept:
      Tests  8 failed | 32 passed (40)
```

One of the added tests sweeps `previewChars` from 0 to 120 across all three `keep` directions and asserts the preview never exceeds it. I also swept 0 to 260 locally while developing: 0 over budget after, and every value below roughly 47 over budget before.

The final case guards against over-correcting — where the budget has room, the separator and real content must both still be present. Its two `toContain` assertions hold before and after; the length assertion beside them does not, because `keep: 'head'` overran even at 200.

Main consumer is unaffected:

```
$ npx vitest run --root packages/core --coverage.enabled=false src/tools/shell.test.ts
      Tests  283 passed (283)
```

### Evidence (Before & After)

N/A — not user-visible; the returned-length table above is the before/after.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only.

## Risk & Scope

- Main risk or tradeoff: because the separator now comes out of the budget before the head/tail split, the 1/5–4/5 ratio applies to the content rather than to content-plus-separator. Mid-range budgets therefore distribute slightly differently between head and tail than before, though the total stays within the limit. At budgets below the separator's length the preview no longer carries any marker at all.
- Not validated / out of scope: I did not change the separator or ellipsis text, the line-count budgeting, or the wrapper message.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

把截断分隔符和标记截断行的省略号计入 `previewChars` 预算，使交给模型的预览内容保持在调用方设定的上限之内。

## 为什么需要

`previewChars` 用于限制进入模型上下文的预览内容，但有两段固定字符串是在该预算之外输出的。

分隔符（`\n\n---\n... [CONTENT TRUNCATED] ...\n---\n\n`，共 39 个字符）无论预算多少都会被追加，而头部预算从未扣除它——只有尾部预算扣除了。另外，当剩余不足三个字符时，用于标记部分保留行的 3 字符省略号仍会被输出。两者叠加的结果：

| `previewChars` | 返回的预览长度 |
| --- | --- |
| 0 | **39** |
| 10 | **42** |
| 40 | **47** |
| 60 | 60 |
| 200 | 200 |

该问题可通过 `truncateToolOutput` 的按工具 `limits.previewChars` 触发，而不只是走默认值时才会出现。

修复方式是：在划分头部与尾部之前先从预算中扣除分隔符；当预算无法同时容纳分隔符和任何内容时，直接不输出分隔符——预览上方的包装说明本就写明了输出已被截断，因此省略它不会丢失信息；当同样没有空间时，也跳过省略号。

## 审阅者测试计划

### 如何验证

```
$ npx vitest run --root packages/core --coverage.enabled=false src/utils/truncation.test.ts
      Tests  40 passed (40)

# 回退 src/utils/truncation.ts 并保留测试后：
      Tests  8 failed | 32 passed (40)
```

新增测试中有一项会在三种 `keep` 方向下将 `previewChars` 从 0 遍历到 120，断言预览长度始终不超过它。开发过程中我还在本地遍历了 0 到 260：修复后 0 项超预算，修复前约 47 以下的每个取值都会超。

最后一个用例用于防止过度修正——在预算有余地时，分隔符和真实内容都必须仍然存在。其中两个 `toContain` 断言在修复前后均成立；而与之并列的长度断言在修复前并不成立，因为 `keep: 'head'` 即便在 200 时也会超出预算。

主要使用方不受影响：

```
$ npx vitest run --root packages/core --coverage.enabled=false src/tools/shell.test.ts
      Tests  283 passed (283)
```

### 证据（修复前后对比）

N/A——非用户可见改动；上方的返回长度对照表即为修复前后对比。

### 测试环境

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

仅单元测试。

## 风险与影响范围

- 主要风险或权衡：由于分隔符现在在划分头尾之前就从预算中扣除，1/5–4/5 的比例作用于内容本身，而不再作用于"内容加分隔符"。因此中等大小的预算在头尾之间的分配与此前略有不同，但总长度始终在上限之内。当预算小于分隔符长度时，预览将不再包含任何标记。
- 未验证 / 不在范围内：我没有改动分隔符或省略号的文本、行数预算逻辑，也没有改动包装说明。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
