### PR TITLE
fix(cli): do not count a partial trailing line when re-opening a split fence

### DIFF
--- a/packages/cli/src/ui/utils/markdownUtilities.test.ts
+++ b/packages/cli/src/ui/utils/markdownUtilities.test.ts
@@ -135,8 +135,41 @@ describe('markdownUtilities', () => {
       const splitPoint = 40; // mid-line hard split inside the fence
       const { before, after } = splitFencedMarkdown(content, splitPoint);
       expect(before).toBe(content.slice(0, 40) + '\n```\n');
-      expect(after).toBe('```ts qwen-code:start-line=2\n' + content.slice(40));
+      // The block holds a single content line and the split lands inside it,
+      // so the tail is the remainder of line 1 and its gutter must still say
+      // 1. This previously read `start-line=2`, counting the unfinished line
+      // as though it had been completed in the head.
+      expect(after).toBe('```ts qwen-code:start-line=1\n' + content.slice(40));
     });
+
+    it('keeps the tail on the same source line when split mid-line', () => {
+      const content = '```js\naaa\nbbb\nccc\n```';
+      // Lands inside `bbb`: the head ends `bb`, the tail begins `b`.
+      const { before, after } = splitFencedMarkdown(content, 12);
+
+      expect(before).toBe('```js\naaa\nbb\n```\n');
+      expect(after).toBe('```js qwen-code:start-line=2\nb\nccc\n```');
+    });
+
+    // Guards against over-correcting. Splits that land on a line boundary were
+    // already right and must stay put; these pass before and after.
+    it.each([
+      [6, 1],
+      [10, 2],
+      [14, 3],
+      [18, 4],
+    ])(
+      'splitting at %d (a line boundary) starts the tail at line %d',
+      (splitPoint, expectedStartLine) => {
+        const content = '```js\naaa\nbbb\nccc\n```';
+        const { after } = splitFencedMarkdown(content, splitPoint);
+        expect(
+          after.startsWith(
+            `\`\`\`js qwen-code:start-line=${expectedStartLine}\n`,
+          ),
+        ).toBe(true);
+      },
+    );
 
     it('accumulates the start line when a re-opened tail is split again', () => {
       // Simulate the tail produced by a prior split (already carries a directive).

--- a/packages/cli/src/ui/utils/markdownUtilities.ts
+++ b/packages/cli/src/ui/utils/markdownUtilities.ts
@@ -237,9 +237,18 @@ const countHeadContentLines = (
 ): number => {
   const headFromFence = content.slice(fenceStartIndex, splitPoint);
   const newlineCount = (headFromFence.match(/\n/g) || []).length;
-  // The opening fence line owns the first newline; the rest are content lines.
-  // A head not ending in a newline has one trailing partial content line.
-  return headFromFence.endsWith('\n') ? newlineCount - 1 : newlineCount;
+  // The opening fence line owns the first newline; every newline after it ends
+  // one completed content line.
+  //
+  // A head that stops mid-line was previously counted as if that line were
+  // finished, which advanced the tail's gutter one line too far: the tail's
+  // first row is the *remainder* of that same source line, not the next one.
+  // Splitting ````js\naaa\nbbb\nccc\n```` at 12
+  // put `bb` at the end of the head and `b` at the start of the tail, then
+  // labelled the tail start-line 3 -- so every line number after a mid-line
+  // split was off by one. A completed line and a partial one both leave the
+  // same number of newlines behind, so neither needs a special case.
+  return Math.max(newlineCount - 1, 0);
 };
 
 /**


### PR DESCRIPTION
## What this PR does

Stops `countHeadContentLines` from counting an unfinished trailing line as a completed one, so the `start-line` directive on a re-opened fence points at the right source line.

## Why it's needed

When a hard split lands inside a fenced code block, the head is closed with a fence and the tail is re-opened with `qwen-code:start-line=N` so its gutter continues instead of resetting to 1. `N` comes from `countHeadContentLines`, which counted the newlines in the head and — when the head did not end in a newline — returned the raw count.

A head that stops mid-line has not finished that line. The tail's first row is the *remainder of that same source line*, not the next one, so the count was one too high and every line number after a mid-line split was off by one:

```
splitFencedMarkdown('```js\naaa\nbbb\nccc\n```', 12)

  head:  ```js
         aaa
         bb            <- line 2, cut in half
         ```
  tail:  ```js qwen-code:start-line=3     <- labelled 3
         b             <- still line 2
         ccc
         ```
```

A completed line and a partial one leave the same number of newlines behind, so neither needs a special case: the count is always one less than the newlines in the head, floored at zero. Splits landing on a line boundary produce the same numbers as before.

## Reviewer Test Plan

### How to verify

Splitting ` ```js\naaa\nbbb\nccc\n``` ` at each offset:

| split at | lands | before | after |
| --- | --- | --- | --- |
| 6 | after the opening fence | `start-line=1` | unchanged |
| 10 | after `aaa\n` | `start-line=2` | unchanged |
| **12** | **inside `bbb`** | **`start-line=3`** | **`start-line=2`** |
| 14 | after `bbb\n` | `start-line=3` | unchanged |
| 18 | after `ccc\n` | `start-line=4` | unchanged |

Only the mid-line split changes.

```
$ npx vitest run --root packages/cli --coverage.enabled=false src/ui/utils/markdownUtilities.test.ts
      Tests  35 passed (35)

# with src/ui/utils/markdownUtilities.ts reverted and the tests kept:
      Tests  2 failed | 33 passed (35)
```

The two failures are the mid-line cases. The four line-boundary rows are added as guards against over-correcting and pass before and after.

Consumers (`MarkdownDisplay`, `useGeminiStream`, `CodeColorizer`) are unaffected:

```
$ npx vitest run --root packages/cli --coverage.enabled=false src/ui/utils/MarkdownDisplay.test.tsx
      Tests  4 failed | 182 passed (186)
```

Those four failures (unordered-list markers, table rendering, both line-ending variants) reproduce identically on unmodified `main` in my environment and are unrelated.

### Evidence (Before & After)

The annotated split above is the before/after. The visible effect is the line-number gutter of a code block that streamed in across a split; the directive it is computed from is asserted directly in the tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only.

## Risk & Scope

- Main risk or tradeoff: an existing test asserted `start-line=2` for a block holding a single 100-character line split at offset 40. The tail there is the remainder of line 1, so the expectation is updated to 1. Flagging it explicitly in case that number was deliberate rather than recorded.
- Not validated / out of scope: I did not change how the split point is chosen, the fence reconstruction, or the directive syntax — only the line count feeding it.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

修正 `countHeadContentLines`，使其不再把未写完的末行当作已完成的一行来计数，从而让重新打开的围栏上的 `start-line` 指令指向正确的源代码行。

## 为什么需要

当硬切分落在围栏代码块内部时，头部会被补上收尾围栏，尾部则以 `qwen-code:start-line=N` 重新开启，使其行号栏得以延续而不是重置为 1。`N` 来自 `countHeadContentLines`，它统计头部中的换行符数量，并且在头部不以换行符结尾时直接返回该原始计数。

在行中间停止的头部并没有写完那一行。尾部的第一行是*同一源代码行的剩余部分*，而不是下一行，因此该计数多了 1，导致行中切分之后的每个行号都偏移了一位：

```
splitFencedMarkdown('```js\naaa\nbbb\nccc\n```', 12)

  头部： ```js
         aaa
         bb            <- 第 2 行，被从中截断
         ```
  尾部： ```js qwen-code:start-line=3     <- 被标为 3
         b             <- 仍然是第 2 行
         ccc
         ```
```

已完成的一行与部分保留的一行留下的换行符数量相同，因此两者都不需要特殊处理：计数始终等于头部换行符数减一，并以零为下限。落在行边界上的切分产生的数字与此前完全一致。

## 审阅者测试计划

### 如何验证

对 ` ```js\naaa\nbbb\nccc\n``` ` 在各个偏移处切分：

| 切分位置 | 落点 | 修复前 | 修复后 |
| --- | --- | --- | --- |
| 6 | 开启围栏之后 | `start-line=1` | 不变 |
| 10 | `aaa\n` 之后 | `start-line=2` | 不变 |
| **12** | **`bbb` 内部** | **`start-line=3`** | **`start-line=2`** |
| 14 | `bbb\n` 之后 | `start-line=3` | 不变 |
| 18 | `ccc\n` 之后 | `start-line=4` | 不变 |

只有行中切分发生了变化。

```
$ npx vitest run --root packages/cli --coverage.enabled=false src/ui/utils/markdownUtilities.test.ts
      Tests  35 passed (35)

# 回退 src/ui/utils/markdownUtilities.ts 并保留测试后：
      Tests  2 failed | 33 passed (35)
```

失败的两项正是行中切分的用例。表中四行行边界切分作为防过度修正的保护性用例加入，修复前后均通过。

各使用方（`MarkdownDisplay`、`useGeminiStream`、`CodeColorizer`）不受影响：

```
$ npx vitest run --root packages/cli --coverage.enabled=false src/ui/utils/MarkdownDisplay.test.tsx
      Tests  4 failed | 182 passed (186)
```

这四个失败（无序列表标记、表格渲染，两种换行符变体）在我的环境中于未修改的 `main` 上同样复现，与本次改动无关。

### 证据（修复前后对比）

上方带注释的切分示意即为修复前后对比。可见效果体现在跨切分流式渲染的代码块的行号栏上；而计算该行号所依据的指令，测试中已直接断言。

### 测试环境

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

仅单元测试。

## 风险与影响范围

- 主要风险或权衡：有一个既有测试针对"仅含一行 100 字符、在偏移 40 处切分"的代码块断言了 `start-line=2`。该场景下尾部是第 1 行的剩余部分，因此预期值已更新为 1。特此明确指出，以防那个数字是有意为之而非仅仅记录了当时的行为。
- 未验证 / 不在范围内：我没有改动切分点的选择方式、围栏的重建逻辑或指令语法——只改动了为其提供输入的行数统计。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
