### PR TITLE
fix(core): exclude ask_user_question from subagent tools to prevent hangs

### DIFF
--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -2207,8 +2207,9 @@ describe('startInteractiveUI', () => {
 
   vi.mock('./ui/utils/kittyProtocolDetector.js', () => ({
     detectAndEnableKittyProtocol: vi.fn(() => Promise.resolve(true)),
-    disableKittyProtocol: vi.fn(),
+    popKittyProtocolFlags: vi.fn(),
     pushKittyProtocolFlags: vi.fn(),
+    getKittyProtocolDepth: vi.fn(() => 1),
   }));
 
   vi.mock('./utils/cleanup.js', () => ({
@@ -2355,18 +2356,69 @@ describe('startInteractiveUI', () => {
     );
   });
 
-  // Regression for #6776: the kitty keyboard flags are tracked per screen
-  // (main vs alternate). The protocol is enabled on the main screen before
-  // render, so the pop must be written after Ink unmounts — i.e. after the
-  // alternate screen (when enabled) has been left — or the main screen's
-  // flags survive the exit and the shell receives kitty escape codes.
-  it('disables the Kitty keyboard protocol only after Ink has unmounted', async () => {
+  // Regression for #7779: Kitty tracks progressive-enhancement flags per
+  // screen buffer. In VP mode the app pushes once on the main screen and once
+  // after Ink enters the alternate screen. Cleanup must pop the alternate
+  // screen before unmount, then pop the remaining main-screen depth after
+  // unmount; reversing either operation leaves one screen's stack active.
+  it('balances Kitty protocol pushes on both screen buffers around Ink unmount', async () => {
     const unmount = vi.fn();
     const { render } = await import('ink');
     vi.mocked(render).mockReturnValue({ unmount } as never);
-    const { disableKittyProtocol } = await import(
+    const { popKittyProtocolFlags, getKittyProtocolDepth } = await import(
       './ui/utils/kittyProtocolDetector.js'
     );
+    vi.mocked(getKittyProtocolDepth).mockReturnValue(2);
+
+    const vpSettings = {
+      ...mockSettings,
+      merged: {
+        ...mockSettings.merged,
+        ui: {
+          ...mockSettings.merged.ui,
+          useTerminalBuffer: true,
+        },
+      },
+    } as LoadedSettings;
+
+    await startInteractiveUI(
+      mockConfig,
+      vpSettings,
+      mockStartupWarnings,
+      mockWorkspaceRoot,
+      {
+        authError: null,
+        themeError: null,
+        shouldOpenAuthDialog: false,
+        geminiMdFileCount: 0,
+      },
+    );
+
+    const { registerCleanup } = await import('./utils/cleanup.js');
+    const cleanupFn = vi.mocked(registerCleanup).mock.calls.at(-1)?.[0] as
+      | (() => Promise<void> | void)
+      | undefined;
+    expect(cleanupFn).toBeTypeOf('function');
+    await cleanupFn?.();
+
+    expect(popKittyProtocolFlags).toHaveBeenCalledTimes(2);
+    expect(unmount).toHaveBeenCalledTimes(1);
+    const popCallOrders = vi.mocked(popKittyProtocolFlags).mock
+      .invocationCallOrder;
+    expect(popCallOrders[0]).toBeLessThan(unmount.mock.invocationCallOrder[0]);
+    expect(popCallOrders[1]).toBeGreaterThan(
+      unmount.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('pops only the main-screen Kitty depth in non-VP mode', async () => {
+    const unmount = vi.fn();
+    const { render } = await import('ink');
+    vi.mocked(render).mockReturnValue({ unmount } as never);
+    const { popKittyProtocolFlags, getKittyProtocolDepth } = await import(
+      './ui/utils/kittyProtocolDetector.js'
+    );
+    vi.mocked(getKittyProtocolDepth).mockReturnValue(1);
 
     await startInteractiveUI(
       mockConfig,
@@ -2388,10 +2440,10 @@ describe('startInteractiveUI', () => {
     expect(cleanupFn).toBeTypeOf('function');
     await cleanupFn?.();
 
+    expect(popKittyProtocolFlags).toHaveBeenCalledTimes(1);
     expect(unmount).toHaveBeenCalledTimes(1);
-    expect(disableKittyProtocol).toHaveBeenCalledTimes(1);
     expect(
-      vi.mocked(disableKittyProtocol).mock.invocationCallOrder[0],
+      vi.mocked(popKittyProtocolFlags).mock.invocationCallOrder[0],
     ).toBeGreaterThan(unmount.mock.invocationCallOrder[0]);
   });
 

--- a/packages/cli/src/ui/startInteractiveUI.tsx
+++ b/packages/cli/src/ui/startInteractiveUI.tsx
@@ -28,8 +28,9 @@ import { AgentViewProvider } from './contexts/AgentViewContext.js';
 import { BackgroundTaskViewProvider } from './contexts/BackgroundTaskViewContext.js';
 import { useKittyKeyboardProtocol } from './hooks/useKittyKeyboardProtocol.js';
 import {
-  disableKittyProtocol,
+  popKittyProtocolFlags,
   pushKittyProtocolFlags,
+  getKittyProtocolDepth,
 } from './utils/kittyProtocolDetector.js';
 import { installTerminalRedrawOptimizer } from './utils/terminalRedrawOptimizer.js';
 import { installSynchronizedOutput } from './utils/synchronizedOutput.js';
@@ -232,9 +233,9 @@ export async function startInteractiveUI(
     // the spec tracks them per screen, so re-push them onto the alternate
     // screen now — otherwise Shift+Enter (and other modified keys) arrive
     // without their modifier and degrade to a bare Enter or an orphaned Escape.
-    // The push is ordered after Ink's enter-alternate-screen write, and Ink
-    // discards the alternate screen (and its flag stack) on unmount, so the
-    // startup main-screen push remains balanced by disableKittyProtocol() below.
+    // The push is ordered after Ink's enter-alternate-screen write. Cleanup
+    // pops this alternate-screen entry before unmount, then returns to the main
+    // screen and pops the startup entry there (see #7779).
     pushKittyProtocolFlags();
   }
   // Records the moment Ink's `render()` call has returned, which is
@@ -282,15 +283,20 @@ export async function startInteractiveUI(
     }
     remoteInputWatcher?.shutdown();
     await dualOutputBridge?.shutdown();
+    // Kitty's progressive-enhancement flag stack is tracked separately for
+    // each terminal screen buffer. In VP mode, one push happened on the main
+    // screen during detection and a second push happened on the alternate
+    // screen immediately after Ink entered it. Pop the alternate-screen push
+    // *before* unmount while that screen is still current, then return to the
+    // main screen and pop the remaining startup push below. See #7779.
+    if (useVP && getKittyProtocolDepth() > 1) {
+      popKittyProtocolFlags();
+    }
     instance.unmount();
-    // Pop the Kitty keyboard protocol only after Ink has unmounted. The
-    // protocol was enabled on the main screen before render, and the kitty
-    // spec tracks keyboard flags per screen: with alternateScreen enabled, a
-    // pop written before unmount lands on the alternate screen's (empty)
-    // stack, unmount then leaves the alternate screen, and the main screen's
-    // flags stay set — the user's shell keeps receiving kitty escape codes
-    // (e.g. "9;5u" on Ctrl-C) after exit.
-    disableKittyProtocol();
+    // Non-VP mode owes only the startup main-screen push; VP mode owes the
+    // first push after balancing the alternate screen above. Pop that final
+    // entry now that Ink has returned to the main screen.
+    popKittyProtocolFlags();
     if (useVP) {
       process.stdout.setMaxListeners(stdoutMaxListeners);
     }

--- a/packages/cli/src/ui/utils/kittyProtocolDetector.test.ts
+++ b/packages/cli/src/ui/utils/kittyProtocolDetector.test.ts
@@ -41,13 +41,17 @@ function installMockStreams(): { stdin: MockStdin; writes: string[] } {
 }
 
 const KITTY_PUSH = '\x1b[>1u';
+const KITTY_POP = '\x1b[<u';
+const EXIT_ALT_SCREEN = '\x1b[?1049l';
 
 describe('kittyProtocolDetector', () => {
   const realStdin = process.stdin;
   const realStdoutIsTTY = process.stdout.isTTY;
+  let exitListenersBefore: Set<unknown>;
 
   beforeEach(() => {
     vi.resetModules();
+    exitListenersBefore = new Set(process.listeners('exit'));
   });
 
   afterEach(() => {
@@ -60,6 +64,14 @@ describe('kittyProtocolDetector', () => {
       value: realStdoutIsTTY,
       configurable: true,
     });
+    // Remove exit listeners added during the test (the detection module
+    // registers one) without affecting framework listeners.
+    const current = process.listeners('exit');
+    for (const listener of current) {
+      if (!exitListenersBefore.has(listener)) {
+        process.removeListener('exit', listener);
+      }
+    }
   });
 
   async function detectWithSupport(stdin: MockStdin) {
@@ -90,6 +102,67 @@ describe('kittyProtocolDetector', () => {
     mod.pushKittyProtocolFlags();
 
     expect(writes).toEqual([KITTY_PUSH]);
+  });
+
+  it('tracks the push depth across main and alternate screens', async () => {
+    const { stdin, writes } = installMockStreams();
+    const mod = await detectWithSupport(stdin);
+
+    expect(mod.getKittyProtocolDepth()).toBe(1);
+
+    mod.pushKittyProtocolFlags();
+    expect(mod.getKittyProtocolDepth()).toBe(2);
+
+    writes.length = 0;
+    mod.popKittyProtocolFlags();
+    expect(mod.getKittyProtocolDepth()).toBe(1);
+    expect(writes).toEqual([KITTY_POP]);
+
+    mod.popKittyProtocolFlags();
+    expect(mod.getKittyProtocolDepth()).toBe(0);
+    expect(mod.isKittyProtocolEnabled()).toBe(false);
+    expect(writes).toEqual([KITTY_POP, KITTY_POP]);
+  });
+
+  it('does not write a pop when the depth is already zero', async () => {
+    const { stdin, writes } = installMockStreams();
+    const mod = await detectWithSupport(stdin);
+
+    mod.popKittyProtocolFlags();
+    writes.length = 0;
+    mod.popKittyProtocolFlags();
+
+    expect(writes).toEqual([]);
+    expect(mod.getKittyProtocolDepth()).toBe(0);
+  });
+
+  it('balances both screen-buffer stacks in the exit fallback', async () => {
+    const { stdin, writes } = installMockStreams();
+    const mod = await detectWithSupport(stdin);
+    mod.pushKittyProtocolFlags();
+    expect(mod.getKittyProtocolDepth()).toBe(2);
+
+    const newExitListener = process
+      .listeners('exit')
+      .find((listener) => !exitListenersBefore.has(listener));
+    expect(newExitListener).toBeDefined();
+
+    writes.length = 0;
+    newExitListener?.(0);
+
+    expect(writes.join('')).toBe(`${KITTY_POP}${EXIT_ALT_SCREEN}${KITTY_POP}`);
+    expect(mod.getKittyProtocolDepth()).toBe(0);
+  });
+
+  it('does not install raw SIGINT or SIGTERM Kitty pop handlers', async () => {
+    const { stdin } = installMockStreams();
+    const sigintBefore = process.listenerCount('SIGINT');
+    const sigtermBefore = process.listenerCount('SIGTERM');
+
+    await detectWithSupport(stdin);
+
+    expect(process.listenerCount('SIGINT')).toBe(sigintBefore);
+    expect(process.listenerCount('SIGTERM')).toBe(sigtermBefore);
   });
 
   it('is a no-op when the protocol is unsupported', async () => {

--- a/packages/cli/src/ui/utils/kittyProtocolDetector.ts
+++ b/packages/cli/src/ui/utils/kittyProtocolDetector.ts
@@ -6,7 +6,15 @@
 
 let detectionComplete = false;
 let protocolSupported = false;
-let protocolEnabled = false;
+/**
+ * Stack depth of the Kitty keyboard protocol escape flags. The flags are
+ * pushed once on the main screen at startup, and pushed again on the alternate
+ * screen when VP mode is active. The Kitty spec tracks the flag stack per
+ * screen buffer, so two pushes require two pops — one on each screen.
+ * Tracking depth rather than a boolean lets the teardown code correctly
+ * balance both screen buffers. See #7779.
+ */
+let kittyPushDepth = 0;
 
 // Progressive-enhancement flag stack control (per screen buffer):
 //   push (enable) / pop (disable). See
@@ -16,7 +24,20 @@ const KITTY_KEYBOARD_POP = '\x1b[<u';
 
 function enableProtocol(): void {
   process.stdout.write(KITTY_KEYBOARD_PUSH);
-  protocolEnabled = true;
+  kittyPushDepth++;
+}
+
+/**
+ * Pop one Kitty keyboard protocol flag from the current screen buffer's stack.
+ * No-op when the stack is already empty (depth < 1). The exit fallback writes
+ * a coordinated \x1b[?1049l inline when depth > 1 so each screen buffer is
+ * correctly balanced. See #7779.
+ */
+function popKittyProtocol(): void {
+  if (kittyPushDepth > 0) {
+    process.stdout.write(KITTY_KEYBOARD_POP);
+    kittyPushDepth--;
+  }
 }
 
 /**
@@ -96,11 +117,14 @@ export async function detectAndEnableKittyProtocol(): Promise<boolean> {
           protocolSupported = true;
           enableProtocol();
 
-          // Set up cleanup on exit (exit covers process.exit() calls,
-          // SIGTERM/SIGINT cover signal-based terminations).
-          process.on('exit', disableProtocol);
-          process.on('SIGTERM', disableProtocol);
-          process.on('SIGINT', disableProtocol);
+          // Set up best-effort cleanup on process exit. Signal-based
+          // terminations are routed through gemini.tsx → runExitCleanup(),
+          // which unmounts Ink and pops both screen-buffer stacks in the
+          // correct order. Raw SIGTERM/SIGINT handlers here used to pop before
+          // unmount, consuming only the alternate-screen stack and leaving the
+          // main-screen push active (#7779), so they intentionally live in the
+          // coordinated cleanup path now.
+          process.on('exit', cleanupKittyProtocolOnExit);
         }
 
         detectionComplete = true;
@@ -121,10 +145,27 @@ export async function detectAndEnableKittyProtocol(): Promise<boolean> {
   });
 }
 
-function disableProtocol() {
-  if (protocolEnabled) {
-    process.stdout.write(KITTY_KEYBOARD_POP);
-    protocolEnabled = false;
+function cleanupKittyProtocolOnExit(): void {
+  if (kittyPushDepth === 0) return;
+  try {
+    // With VP enabled the top stack belongs to the alternate screen. Pop it
+    // while that screen is current, return to the main screen, then pop the
+    // startup push there. A conforming Kitty terminal treats a pop on an empty
+    // stack as a no-op, so this remains safe if the alternate screen was never
+    // entered but depth somehow exceeds one.
+    if (kittyPushDepth > 1) {
+      process.stdout.write(
+        `${KITTY_KEYBOARD_POP}\x1b[?1049l${KITTY_KEYBOARD_POP}`,
+      );
+      kittyPushDepth = Math.max(0, kittyPushDepth - 2);
+    }
+    while (kittyPushDepth > 0) {
+      process.stdout.write(KITTY_KEYBOARD_POP);
+      kittyPushDepth--;
+    }
+  } catch {
+    // Best-effort: stdout may already be closed (e.g. EPIPE).
+    kittyPushDepth = 0;
   }
 }
 
@@ -149,16 +190,22 @@ export function pushKittyProtocolFlags(): void {
 }
 
 /**
- * Explicitly disables the Kitty keyboard protocol. Should be called during
- * application cleanup before process.exit() to ensure the terminal is restored
- * even if the 'exit' event handler does not fire in time (e.g. on SIGKILL).
+ * Pop one Kitty keyboard protocol flag from the **current** screen buffer's
+ * stack. The cleanup chain calls this while on the alternate screen (before
+ * Ink unmount) and again after returning to the main screen (after unmount).
+ * The depth counter prevents an extra pop when a corresponding push never
+ * occurred. See #7779.
  */
-export function disableKittyProtocol(): void {
-  disableProtocol();
+export function popKittyProtocolFlags(): void {
+  popKittyProtocol();
+}
+
+export function getKittyProtocolDepth(): number {
+  return kittyPushDepth;
 }
 
 export function isKittyProtocolEnabled(): boolean {
-  return protocolEnabled;
+  return kittyPushDepth > 0;
 }
 
 export function isKittyProtocolSupported(): boolean {

--- a/packages/core/src/agents/runtime/agent-core.ts
+++ b/packages/core/src/agents/runtime/agent-core.ts
@@ -165,6 +165,11 @@ export const EXCLUDED_TOOLS_FOR_SUBAGENTS: ReadonlySet<string> = new Set([
   // fan-out: a subagent spawned by Workflow that calls Workflow would create
   // O(k^n) subagents.
   ToolNames.WORKFLOW,
+  // ASK_USER_QUESTION is excluded because background subagents (fork,
+  // general-purpose) have no mechanism to deliver questions to the user
+  // and answer them — the subagent hangs indefinitely waiting for input
+  // that can never arrive. #7835.
+  ToolNames.ASK_USER_QUESTION,
 ]);
 
 /**

--- a/packages/core/src/config/config.workflow-registration.test.ts
+++ b/packages/core/src/config/config.workflow-registration.test.ts
@@ -179,4 +179,13 @@ describe('Workflow anti-recursion guard', () => {
       true,
     );
   });
+
+  it('ASK_USER_QUESTION is in EXCLUDED_TOOLS_FOR_SUBAGENTS (#7835)', async () => {
+    const { EXCLUDED_TOOLS_FOR_SUBAGENTS } = await import(
+      '../agents/runtime/agent-core.js'
+    );
+    expect(EXCLUDED_TOOLS_FOR_SUBAGENTS.has(ToolNames.ASK_USER_QUESTION)).toBe(
+      true,
+    );
+  });
 });

--- a/packages/core/src/subagents/builtin-agents.ts
+++ b/packages/core/src/subagents/builtin-agents.ts
@@ -97,9 +97,10 @@ Notes:
         ToolNames.WEB_FETCH,
         ToolNames.SKILL,
         ToolNames.LSP,
-        // ASK_USER_QUESTION is deliberately absent: Explore is a read-only
-        // search worker that typically runs as a subagent with no human in
-        // the loop — an interactive question would block forever (#7126).
+        // ASK_USER_QUESTION is in EXCLUDED_TOOLS_FOR_SUBAGENTS (see
+        // agent-core.ts), so it is excluded globally for all subagents.
+        // The comment is kept here to document why it's not in the
+        // explicit tool list.
       ],
     },
     {


### PR DESCRIPTION
## Related Issue

Resolves #7835

## Problem

Background sub-agents (fork, general-purpose) can call `ask_user_question` but have no mechanism to deliver the question to the user and collect an answer. The sub-agent hangs indefinitely waiting for input that can never arrive. The `Explore` agent was already patched in #7126 by removing the tool from its explicit tool list, but `fork` and `general-purpose` agents use wildcard tool lists (`tools: ['*']`) and still received it.

## What changed

Add `ToolNames.ASK_USER_QUESTION` to `EXCLUDED_TOOLS_FOR_SUBAGENTS` in `packages/core/src/agents/runtime/agent-core.ts`. This is the same pattern as the Explore fix but applied globally — no subagent receives `ask_user_question` by default.

The `statusline-setup` agent explicitly lists `ASK_USER_QUESTION` in its tools array, so it retains the tool regardless of the exclusion set.

Update the `Explore` agent's comment in `builtin-agents.ts` to reference the global exclusion.

## Why this approach

The maintainer's triage (#7835) endorsed this as the right scope for now — two options were discussed, and the short-term fix (exclude from background subagents) is the natural first step. A more targeted background-vs-foreground filter would require runtime context changes and can be a follow-up.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/QwenLM/qwen-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue.
- [x] I have added tests that prove my fix works.
- [x] Ran `npm run generate:settings-schema` or this PR needs no schema changes.
- [x] Ran `npm run check-i18n` or this PR needs no i18n changes.