### PR TITLE
fix(cli): make /copy <message> <index> select the code block

### DIFF
--- a/packages/cli/src/ui/commands/copyCommand.test.ts
+++ b/packages/cli/src/ui/commands/copyCommand.test.ts
@@ -310,6 +310,132 @@ describe('copyCommand', () => {
     });
   });
 
+  // The argument hint is `[N] [<lang>|code|latex|mermaid] [<index>]`, every
+  // group optional, so "message N, block M" is a documented form. The leading
+  // N is stripped as the message index, leaving a bare number as the whole
+  // selector argument.
+  it('should copy a numbered code block with /copy 1 2', async () => {
+    if (!copyCommand.action) throw new Error('Command has no action');
+
+    mockGetHistoryShallow.mockReturnValue([
+      {
+        role: 'model',
+        parts: [
+          {
+            text: [
+              '```ts',
+              'const first = 1;',
+              '```',
+              '```json',
+              '{"second": true}',
+              '```',
+            ].join('\n'),
+          },
+        ],
+      },
+    ]);
+    mockCopyToClipboard.mockResolvedValue(undefined);
+
+    const result = await copyCommand.action(mockContext, '1 2');
+
+    expect(mockCopyToClipboard).toHaveBeenCalledWith('{"second": true}');
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'Code block 2 copied to the clipboard',
+    });
+  });
+
+  it('should copy the first code block with /copy 1 1', async () => {
+    if (!copyCommand.action) throw new Error('Command has no action');
+
+    mockGetHistoryShallow.mockReturnValue([
+      {
+        role: 'model',
+        parts: [
+          {
+            text: [
+              '```ts',
+              'const first = 1;',
+              '```',
+              '```json',
+              '{"second": true}',
+              '```',
+            ].join('\n'),
+          },
+        ],
+      },
+    ]);
+    mockCopyToClipboard.mockResolvedValue(undefined);
+
+    const result = await copyCommand.action(mockContext, '1 1');
+
+    expect(mockCopyToClipboard).toHaveBeenCalledWith('const first = 1;');
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'Code block 1 copied to the clipboard',
+    });
+  });
+
+  // Passes before the fix as well, but for the wrong reason: the old code
+  // filtered for a language named "9" and found nothing. Pinned so the
+  // out-of-range path keeps reporting a miss now that the index is real.
+  it('should report a missing block for an out-of-range index with /copy 1 9', async () => {
+    if (!copyCommand.action) throw new Error('Command has no action');
+
+    mockGetHistoryShallow.mockReturnValue([
+      {
+        role: 'model',
+        parts: [{ text: ['```ts', 'const only = 1;', '```'].join('\n') }],
+      },
+    ]);
+    mockCopyToClipboard.mockResolvedValue(undefined);
+
+    const result = await copyCommand.action(mockContext, '1 9');
+
+    expect(mockCopyToClipboard).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'No matching code block found in the last AI output.',
+    });
+  });
+
+  // Over-correction guard: dropping the pre-assignment must not stop a bare
+  // language from selecting. Passes both before and after.
+  it('should still select by language with /copy 1 json', async () => {
+    if (!copyCommand.action) throw new Error('Command has no action');
+
+    mockGetHistoryShallow.mockReturnValue([
+      {
+        role: 'model',
+        parts: [
+          {
+            text: [
+              '```ts',
+              'const first = 1;',
+              '```',
+              '```json',
+              '{"second": true}',
+              '```',
+            ].join('\n'),
+          },
+        ],
+      },
+    ]);
+    mockCopyToClipboard.mockResolvedValue(undefined);
+
+    const result = await copyCommand.action(mockContext, '1 json');
+
+    expect(mockCopyToClipboard).toHaveBeenCalledWith('{"second": true}');
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'json code block 1 copied to the clipboard',
+    });
+  });
+
   it('should copy the last matching language code block with /copy code mermaid', async () => {
     if (!copyCommand.action) throw new Error('Command has no action');
 

--- a/packages/cli/src/ui/commands/copyCommand.ts
+++ b/packages/cli/src/ui/commands/copyCommand.ts
@@ -285,11 +285,15 @@ function selectCodeBlock(
 
   let lang: string | null = null;
   let requestedIndex: number | null = null;
-  const selectorTokens =
-    firstToken === 'code' ? tokens.slice(1) : tokens.map((token) => token);
-  if (firstToken !== 'code') {
-    lang = firstToken;
-  }
+  // Only the leading `code` keyword is consumed here. Every other token is
+  // classified by the loop below, which already assigns `lang` for anything
+  // that is not a number. Seeding `lang` from the first token beforehand was
+  // redundant for `/copy ts` and actively wrong once a message index has been
+  // stripped off the front: `/copy 1 2` leaves "2" as the whole argument, so
+  // this set lang to "2" while the loop set requestedIndex to 2, the filter
+  // looked for blocks written in a language called "2", found none, and
+  // reported that no code block matched.
+  const selectorTokens = firstToken === 'code' ? tokens.slice(1) : tokens;
 
   for (const token of selectorTokens) {
     if (/^\d+$/.test(token)) {


### PR DESCRIPTION
## What this PR does

Makes `/copy <message> <index>` actually copy the requested code block. Selecting a block by number from a specific AI message — `/copy 1 2` for "the second code block of the last AI message" — reported that no code block matched, no matter how many blocks that message contained.

The block selector seeded the language filter from the first argument token before the loop that classifies tokens ran. That seeding is redundant for a real language name, because the loop already assigns the language for any token that is neither a number nor `code`, and it is wrong for a number: the leading message index is stripped off first, so `/copy 1 2` hands `"2"` to the selector as its entire argument. The language filter was set to `"2"` and the loop set the requested index to 2, so the selector looked for blocks written in a language called `"2"`, found none, and returned a miss. Removing the pre-assignment leaves the loop as the single place that classifies tokens.

## Why it's needed

`argumentHint` advertises `[N] [<lang>|code|latex|mermaid] [<index>]` with every group optional, so combining a message number with a block number is a documented form, and it is the natural way to reach a block in an earlier message. Every spelling of it failed. `/copy 1 1`, `/copy 2 3` and so on all reported `No matching code block found in the last AI output.`, which reads as "that message has no such block" rather than "the command cannot express this", so there is no reason for a user to try a different spelling.

Plain `/copy 2` is unaffected — it has no sub-argument, so the selector is never reached and the whole message is copied as before.

This is the same defect and the same fix as #7789 in `packages/web-shell`, whose selector contains these five lines verbatim. @wenshao verified during review of that PR that the CLI carried the identical bug and suggested a follow-up; this is that follow-up, filed separately rather than folded into #7789. The two PRs are independent and can merge in either order.

## Reviewer Test Plan

### How to verify

`npx vitest run src/ui/commands/copyCommand.test.ts` in `packages/cli` — 43 pass.

Reverting only `copyCommand.ts` and keeping the new tests fails exactly the two that encode the bug:

```
 × copyCommand > should copy a numbered code block with /copy 1 2
 × copyCommand > should copy the first code block with /copy 1 1
      Tests  2 failed | 41 passed (43)
```

Interactively, with an AI message containing a `ts` block and a `json` block:

| Command | Before | After |
| --- | --- | --- |
| `/copy 1 1` | `No matching code block found in the last AI output.` | copies the `ts` block |
| `/copy 1 2` | `No matching code block found in the last AI output.` | copies the `json` block |
| `/copy 1 json` | copies the `json` block | unchanged |
| `/copy code 2` | copies the `json` block | unchanged |
| `/copy 2` | copies AI message 2 whole | unchanged |

The four new tests cover the two broken forms, an out-of-range index, and language selection. The language test is an over-correction guard: it passes both before and after on purpose, so the fix cannot be satisfied by breaking language selection. The out-of-range test also passes before, but for the wrong reason — the old code filtered for a language named `"9"` — and is pinned so that path keeps reporting a miss now that the index is real; its comment says so.

### Evidence (Before & After)

The table above is the user-visible before/after. The change is one expression in a pure selector function; the messages in the table are the command's own return values, asserted by the tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only, macOS, Node 22. `prettier --check` and `eslint --max-warnings 0` clean on both changed files.

## Risk & Scope

- Main risk or tradeoff: a code fence whose language tag is itself a bare number — ` ```2 ` — can no longer be selected as a language by that number alone, since the token now reads as an index. This ambiguity is inherent to a `[<lang>] [<index>]` grammar that cannot tell the two apart, and the previous behavior was not self-consistent either. No real language name is a number.
- Not validated / out of scope: the LaTeX and mermaid selectors are untouched; only `selectCodeBlock` changes. Not exercised on Windows or Linux locally, though nothing here is platform-dependent.
- Breaking changes / migration notes: none. Every previously working form still works, verified by the existing 39 tests plus the language guard.

## Linked Issues

Follow-up to #7789, per the maintainer verification comment there. No open issue.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

让 `/copy <消息序号> <代码块序号>` 真正复制到指定的代码块。此前按序号从特定 AI 消息中选取代码块 —— 例如用 `/copy 1 2` 表示"最后一条 AI 消息的第 2 个代码块" —— 无论该消息包含多少代码块，都会报告未找到匹配的代码块。

代码块选择器在负责分类各 token 的循环运行之前，先用第一个参数 token 预先给语言过滤器赋值。对真实的语言名而言这一预赋值是多余的，因为循环本身已经会为任何既非数字也非 `code` 的 token 赋值语言；而对数字来说它是错误的：开头的消息序号会先被剥离，因此 `/copy 1 2` 交给选择器的全部参数就是 `"2"`。于是语言过滤器被设为 `"2"`，循环又把请求序号设为 2，选择器便去查找以名为 `"2"` 的语言编写的代码块，一无所获，返回未匹配。移除该预赋值后，循环成为分类 token 的唯一场所。

## 为什么需要

`argumentHint` 声明的是 `[N] [<lang>|code|latex|mermaid] [<index>]`，其中每一组都是可选的，因此把消息序号与代码块序号组合使用是被文档认可的形式，也是访问较早消息中某个代码块的自然方式。而它的所有写法此前全部失效。`/copy 1 1`、`/copy 2 3` 等都会报告 `No matching code block found in the last AI output.`，这读起来像是"该消息没有这个代码块"，而非"该命令无法表达这个意图"，所以用户没有理由去尝试别的写法。

单独的 `/copy 2` 不受影响 —— 它没有子参数，因此根本不会进入选择器，仍然整条复制该消息。

这与 `packages/web-shell` 中的 #7789 是同一个缺陷、同一个修复，那里的选择器逐字包含这五行代码。@wenshao 在评审该 PR 时验证了 CLI 存在完全相同的 bug 并建议开后续 PR；本 PR 即为该后续，独立提交而未并入 #7789。两个 PR 相互独立，合并顺序任意。

## 评审者测试计划

### 如何验证

在 `packages/cli` 下执行 `npx vitest run src/ui/commands/copyCommand.test.ts` —— 43 项通过。

仅还原 `copyCommand.ts` 而保留新测试，恰好失败两项编码了该 bug 的用例：

```
 × copyCommand > should copy a numbered code block with /copy 1 2
 × copyCommand > should copy the first code block with /copy 1 1
      Tests  2 failed | 41 passed (43)
```

交互验证，AI 消息中包含一个 `ts` 代码块和一个 `json` 代码块：

| 命令 | 修复前 | 修复后 |
| --- | --- | --- |
| `/copy 1 1` | `No matching code block found in the last AI output.` | 复制 `ts` 代码块 |
| `/copy 1 2` | `No matching code block found in the last AI output.` | 复制 `json` 代码块 |
| `/copy 1 json` | 复制 `json` 代码块 | 不变 |
| `/copy code 2` | 复制 `json` 代码块 | 不变 |
| `/copy 2` | 整条复制 AI 消息 2 | 不变 |

四项新增测试覆盖两种失效写法、一个越界序号以及按语言选取。语言那项是防过度修正的守卫：它有意在修复前后均通过，因此本修复无法通过破坏语言选取来蒙混达成。越界那项在修复前同样通过，但原因是错的 —— 旧代码是在过滤名为 `"9"` 的语言 —— 之所以固定下来，是为了在序号真正生效后该路径仍会报告未匹配；其注释已说明这一点。

### 证据（前后对比）

上表即为用户可见的前后对比。本次改动是一个纯选择器函数中的一个表达式；表中的提示文本就是该命令自身的返回值，并由测试断言。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

仅单元测试，macOS，Node 22。两个改动文件的 `prettier --check` 与 `eslint --max-warnings 0` 均干净。

## 风险与范围

- 主要风险或权衡：语言标记本身就是纯数字的代码围栏 —— 形如 ` ```2 ` —— 将无法再单凭该数字被当作语言选中，因为该 token 现在会被读作序号。这一歧义是 `[<lang>] [<index>]` 语法本身固有的，它无法区分两者；而且此前的行为本来也不自洽。现实中没有哪种语言名是数字。
- 未验证 / 不在范围内：LaTeX 与 mermaid 选择器未作改动，仅 `selectCodeBlock` 发生变化。本地未在 Windows 或 Linux 上验证，不过此处没有任何平台相关逻辑。
- 破坏性变更 / 迁移说明：无。此前可用的所有形式均仍然可用，由既有的 39 项测试加上语言守卫共同验证。

## 关联 Issue

依据 #7789 中维护者的验证评论开出的后续 PR。无相关的 open issue。

</details>
