### PR TITLE
fix(triage): retry a transient npm ci before blaming the PR for it

### DIFF
--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -1036,12 +1036,26 @@ jobs:
 
           set +e
           {
-            printf '%s\n' '$ npm ci --prefer-offline --no-audit --progress=false'
-            runuser -u node -- env -u GITHUB_OUTPUT -u GITHUB_STATE -u GITHUB_ENV -u GITHUB_PATH -u GITHUB_STEP_SUMMARY \
-              npm ci --prefer-offline --no-audit --progress=false
-            install_status=$?
+            # Retried once for the same reason as the verify lane: npm can
+            # exec a dependency's binary before its own write is closed and
+            # take an ETXTBSY that has nothing to do with the PR, and this
+            # lane blames the PR for any install failure. Unconditional, so
+            # nothing the PR can print decides whether it gets a retry. The
+            # build stays single-shot: compile errors are deterministic.
+            install_attempt=1
+            while :; do
+              printf '%s\n' '$ npm ci --prefer-offline --no-audit --progress=false'
+              runuser -u node -- env -u GITHUB_OUTPUT -u GITHUB_STATE -u GITHUB_ENV -u GITHUB_PATH -u GITHUB_STEP_SUMMARY \
+                npm ci --prefer-offline --no-audit --progress=false
+              install_status=$?
+              if [ "$install_status" -eq 0 ] || [ "$install_attempt" -ge 2 ]; then
+                break
+              fi
+              printf '\n%s\n' "npm ci failed with exit code ${install_status}; retrying once."
+              install_attempt=$((install_attempt + 1))
+            done
             if [ "$install_status" -ne 0 ]; then
-              printf '\n%s\n' "npm ci failed with exit code ${install_status}."
+              printf '\n%s\n' "npm ci failed with exit code ${install_status} after ${install_attempt} attempts."
             else
               printf '\n%s\n' '$ npm run build'
               runuser -u node -- env -u GITHUB_OUTPUT -u GITHUB_STATE -u GITHUB_ENV -u GITHUB_PATH -u GITHUB_STEP_SUMMARY \
@@ -1638,8 +1652,17 @@ jobs:
             } > "$BODY_FILE"
           elif [ -n "${PREPARE_FAILURE_PHASE:-}" ]; then
             PREPARE_LOG="$(find tmux-results -name 'prepare.log' 2>/dev/null | head -1 || true)"
+            # Initialised, not merely defaulted at use: an inherited value
+            # would otherwise tell a reader that a single-shot `npm run
+            # build` had "failed twice in a row" — the same false
+            # accusation, from the other direction.
+            PREPARE_ATTEMPTS=''
             case "$PREPARE_FAILURE_PHASE" in
-              install) PREPARE_COMMAND='npm ci' ;;
+              install)
+                PREPARE_COMMAND='npm ci'
+                # Retried once in the prepare step; see the verify lane.
+                PREPARE_ATTEMPTS=' twice in a row'
+                ;;
               build) PREPARE_COMMAND='npm run build' ;;
               *)
                 PREPARE_COMMAND='install/build'
@@ -1656,7 +1679,7 @@ jobs:
             {
               printf '%s\n\n' '<!-- qwen-triage:tmux -->'
               printf '**tmux real-user testing: fail** - [workflow run](%s)\n\n' "$RUN_URL"
-              printf 'The PR app could not be launched because `%s` failed before the tmux session started. This is treated as a PR failure verdict rather than an infrastructure failure.\n\n' "$PREPARE_COMMAND"
+              printf 'The PR app could not be launched because `%s` failed%s before the tmux session started. This is treated as a PR failure verdict rather than an infrastructure failure.\n\n' "$PREPARE_COMMAND" "${PREPARE_ATTEMPTS:-}"
               if [ -n "${PREPARE_LOG_NOTE:-}" ]; then
                 printf '%s\n\n' "$PREPARE_LOG_NOTE"
               fi
@@ -2183,12 +2206,37 @@ jobs:
 
           set +e
           {
-            printf '%s\n' '$ npm ci --prefer-offline --no-audit --progress=false'
-            runuser -u node -- env -u GITHUB_OUTPUT -u GITHUB_STATE -u GITHUB_ENV -u GITHUB_PATH -u GITHUB_STEP_SUMMARY \
-              npm ci --prefer-offline --no-audit --progress=false
-            install_status=$?
+            # `npm ci` can die on a race that has nothing to do with the PR:
+            # npm writes a dependency's binary and that package's install
+            # script execs it before the write is closed, so Linux answers
+            # ETXTBSY. Observed on esbuild in run 30319209722, which turned
+            # it into a `fail` verdict against a PR that never touched the
+            # dependency. One clean retry absorbs that class — `npm ci`
+            # removes node_modules before installing, so the second attempt
+            # cannot inherit the half-written file.
+            #
+            # Unconditional by design. Gating the retry on the log would
+            # read text the PR's own lifecycle scripts can write, which is
+            # exactly the forgeable-signal mistake the verdict logic below
+            # was rewritten to avoid. A deterministically broken tree just
+            # fails twice and still earns `fail`; the second attempt is only
+            # ever paid on a path that is already failing. The build is not
+            # retried: a compile error is deterministic, so a second run
+            # would only double the cost of an honest failure.
+            install_attempt=1
+            while :; do
+              printf '%s\n' '$ npm ci --prefer-offline --no-audit --progress=false'
+              runuser -u node -- env -u GITHUB_OUTPUT -u GITHUB_STATE -u GITHUB_ENV -u GITHUB_PATH -u GITHUB_STEP_SUMMARY \
+                npm ci --prefer-offline --no-audit --progress=false
+              install_status=$?
+              if [ "$install_status" -eq 0 ] || [ "$install_attempt" -ge 2 ]; then
+                break
+              fi
+              printf '\n%s\n' "npm ci failed with exit code ${install_status}; retrying once."
+              install_attempt=$((install_attempt + 1))
+            done
             if [ "$install_status" -ne 0 ]; then
-              printf '\n%s\n' "npm ci failed with exit code ${install_status}."
+              printf '\n%s\n' "npm ci failed with exit code ${install_status} after ${install_attempt} attempts."
             else
               printf '\n%s\n' '$ npm run build'
               runuser -u node -- env -u GITHUB_OUTPUT -u GITHUB_STATE -u GITHUB_ENV -u GITHUB_PATH -u GITHUB_STEP_SUMMARY \
@@ -3060,8 +3108,20 @@ jobs:
             # so it must not overwrite a previous round's real report.
             [ "${VERDICT:-}" = 'infra-error' ] && WEAK_BODY=true
             PREPARE_LOG="$(find verify-results -name 'prepare.log' 2>/dev/null | head -1 || true)"
+            # Initialised, not merely defaulted at use: an inherited value
+            # would otherwise tell a reader that a single-shot `npm run
+            # build` had "failed twice in a row" — the same false
+            # accusation, from the other direction.
+            PREPARE_ATTEMPTS=''
             case "$PREPARE_FAILURE_PHASE" in
-              install) PREPARE_COMMAND='npm ci' ;;
+              install)
+                PREPARE_COMMAND='npm ci'
+                # The prepare step retries the install once, so reaching
+                # this phase means two consecutive failures. Say so: the
+                # sentence below blames the PR for it, and "failed twice in
+                # a row" is the part that earns the accusation.
+                PREPARE_ATTEMPTS=' twice in a row'
+                ;;
               build) PREPARE_COMMAND='npm run build' ;;
               *)
                 PREPARE_COMMAND='install/build'
@@ -3089,7 +3149,7 @@ jobs:
               else
                 printf '%s\n\n' '<!-- qwen-triage:verify-substantive -->'
                 printf '**Sandboxed verification: fail** - [workflow run](%s)\n\n' "$RUN_URL"
-                printf 'The PR could not be built because `%s` failed before any verification started. This is treated as a PR failure verdict rather than an infrastructure failure.\n\n' "$PREPARE_COMMAND"
+                printf 'The PR could not be built because `%s` failed%s before any verification started. This is treated as a PR failure verdict rather than an infrastructure failure.\n\n' "$PREPARE_COMMAND" "${PREPARE_ATTEMPTS:-}"
               fi
               emit_block 'Install/build log' "$PREPARE_LOG" 20000
               printf '%s\n' '— _Qwen Code · sandboxed verification_'

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -328,9 +328,7 @@ describe('qwen-triage tmux workflow', () => {
 
     const finalizeStep = step('Finalize triage status comment');
     // Runs on both outcomes and edits the SAME marker comment (no second post).
-    expect(finalizeStep).toContain(
-      "MARKER='<!-- qwen-triage lifecycle -->'",
-    );
+    expect(finalizeStep).toContain("MARKER='<!-- qwen-triage lifecycle -->'");
     expect(finalizeStep).toContain(
       "LEGACY_MARKER='<!-- qwen-triage stage=status -->'",
     );
@@ -1561,6 +1559,11 @@ describe('qwen-triage verify publish fidelity', () => {
       });
       expect(real).toContain('treated as a PR failure');
       expect(real).toContain('npm ci');
+      // The install is retried, so this sentence is blaming the PR for two
+      // consecutive failures and has to say which. Without the count a
+      // reader cannot tell this verdict from the single-shot one that
+      // mis-blamed a PR for an ETXTBSY race.
+      expect(real).toContain('failed twice in a row');
 
       // The build arm of the phase mapping was never rendered by any test,
       // so a typo in that command name would have shipped unnoticed.
@@ -1571,6 +1574,23 @@ describe('qwen-triage verify publish fidelity', () => {
       });
       expect(buildPhase).toContain('npm run build');
       expect(buildPhase).not.toContain('`npm ci` failed');
+      // The build is single-shot, so the retry clause must not leak onto it.
+      expect(buildPhase).not.toContain('twice in a row');
+
+      // Same arm, but with the clause pre-seeded in the environment. This
+      // is what makes the explicit `PREPARE_ATTEMPTS=''` load-bearing
+      // rather than decorative: defaulting it at the point of use (
+      // `${PREPARE_ATTEMPTS:-}`) does nothing against an inherited value,
+      // and the result would be a report claiming a single-shot build had
+      // failed twice.
+      const seededBuild = render(dir, {
+        NAME: 'buildfail-seeded',
+        VERDICT: 'fail',
+        PREPARE_FAILURE_PHASE: 'build',
+        PREPARE_ATTEMPTS: ' twice in a row',
+      });
+      expect(seededBuild).toContain('npm run build');
+      expect(seededBuild).not.toContain('twice in a row');
 
       // An unrecognized phase must degrade, not mislabel.
       const unknownPhase = render(dir, {
@@ -2041,6 +2061,164 @@ describe('qwen-triage verify round-3 hardening', () => {
     const infra = prepare.indexOf('verdict=infra-error');
     if (infra > -1) {
       expect(prepare.slice(0, infra)).toContain('registry_unreachable');
+    }
+  });
+
+  // Run 30319209722 reported `fail` against a PR whose only crime was that
+  // npm exec'd esbuild's binary before its own write was closed (ETXTBSY),
+  // so the install is now retried once.
+  //
+  // Asserting that structurally — "the step contains a loop" — would pass
+  // on a loop that never retries and equally on one that never stops, which
+  // are the two ways this can actually be wrong. So run the real step text:
+  // `runuser` is stubbed to drop its own arguments and exec the rest (which
+  // keeps the genuine `env -u ...` stripping in the path under test),
+  // `chown` and `curl` are no-ops, and `npm` fails a set number of times.
+  const runPrepare = (jobName, { failures, resultsDir }) => {
+    const script = stepIn(jobName, 'Install and build PR app')
+      .match(/run: \|-\n([\s\S]*)$/)?.[1]
+      .replace(/^ {10}/gm, '');
+    expect(script).toBeTruthy();
+    const dir = mkdtempSync(join(tmpdir(), 'prepare-retry-'));
+    try {
+      const work = join(dir, 'work');
+      mkdirSync(work, { recursive: true });
+      const calls = join(dir, 'npm-ci-calls');
+      writeFileSync(calls, '');
+      writeFileSync(
+        join(dir, 'runuser'),
+        [
+          '#!/usr/bin/env bash',
+          'while [ "$#" -gt 0 ] && [ "$1" != \'--\' ]; do shift; done',
+          'shift || true',
+          'exec "$@"',
+        ].join('\n'),
+        { mode: 0o755 },
+      );
+      writeFileSync(
+        join(dir, 'npm'),
+        [
+          '#!/usr/bin/env bash',
+          // Only `ci` is counted/failed: `run build` shares this stub and
+          // must stay a success, or an install-phase assertion could pass
+          // because the BUILD failed instead.
+          'if [ "$1" = ci ]; then',
+          '  printf "ci\\n" >> "$NPM_CI_CALLS"',
+          '  n=$(wc -l < "$NPM_CI_CALLS" | tr -d " ")',
+          '  if [ "$n" -le "$NPM_CI_FAILURES" ]; then',
+          '    echo "npm error ETXTBSY" >&2',
+          '    exit 1',
+          '  fi',
+          'fi',
+          'exit 0',
+        ].join('\n'),
+        { mode: 0o755 },
+      );
+      for (const noop of ['chown', 'curl']) {
+        writeFileSync(join(dir, noop), '#!/usr/bin/env bash\nexit 0\n', {
+          mode: 0o755,
+        });
+      }
+      const out = join(dir, 'step-output');
+      writeFileSync(out, '');
+      const res = spawnSync('bash', ['-c', script], {
+        cwd: work,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${dir}:${process.env.PATH}`,
+          NPM_CI_CALLS: calls,
+          NPM_CI_FAILURES: String(failures),
+          RUNNER_TEMP: dir,
+          GITHUB_WORKSPACE: work,
+          GITHUB_OUTPUT: out,
+          GITHUB_STEP_SUMMARY: '/dev/null',
+        },
+      });
+      return {
+        status: res.status,
+        stderr: res.stderr,
+        output: readFileSync(out, 'utf8'),
+        attempts: readFileSync(calls, 'utf8').trim()
+          ? readFileSync(calls, 'utf8').trim().split('\n').length
+          : 0,
+        log: readFileSync(join(dir, resultsDir, 'prepare.log'), 'utf8'),
+      };
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  };
+
+  for (const [jobName, resultsDir] of [
+    ['verify', 'verify-results'],
+    ['tmux-testing', 'tmux-results'],
+  ]) {
+    it(`retries a transient npm ci once in the ${jobName} lane`, () => {
+      // One ETXTBSY-style failure then success: the run must continue to
+      // the build with no verdict at all. This is the arm the bug lives in
+      // — before the retry it emitted verdict=fail here.
+      const flaky = runPrepare(jobName, { failures: 1, resultsDir });
+      expect(flaky.attempts).toBe(2);
+      expect(flaky.output).not.toContain('verdict=');
+      expect(flaky.log).toContain('retrying once');
+      expect(flaky.log).toContain('$ npm run build');
+
+      // A tree that is genuinely broken still fails, and the retry is
+      // bounded: exactly two attempts, not an unbounded loop.
+      const broken = runPrepare(jobName, { failures: 99, resultsDir });
+      expect(broken.attempts).toBe(2);
+      expect(broken.output).toContain('verdict=fail');
+      expect(broken.output).toContain('failure_phase=install');
+      expect(broken.log).toContain('after 2 attempts');
+      // The build must not have run once the install gave up.
+      expect(broken.log).not.toContain('$ npm run build');
+
+      // Control: a healthy install must not pay for the retry at all.
+      const clean = runPrepare(jobName, { failures: 0, resultsDir });
+      expect(clean.attempts).toBe(1);
+      expect(clean.output).not.toContain('verdict=');
+      expect(clean.log).not.toContain('retrying once');
+    });
+  }
+
+  // The build is deliberately NOT retried — a compile error is
+  // deterministic, so a second run would only double the cost of an honest
+  // failure. Pin that asymmetry so a future "retry everything" edit is a
+  // decision rather than an accident.
+  it('does not retry the build in either lane', () => {
+    for (const jobName of ['verify', 'tmux-testing']) {
+      const prepare = stepIn(jobName, 'Install and build PR app');
+      const build = prepare.slice(prepare.indexOf('$ npm run build'));
+      expect(build).not.toContain('while :;');
+      expect(build).not.toContain('build_attempt');
+    }
+  });
+
+  // The verify comment's retry clause is rendered for real by the publish
+  // fidelity suite. There is no equivalent render harness for the tmux
+  // comment, so its copy of the same wiring is pinned structurally: the
+  // clause must be set ONLY on the install arm (the build is single-shot)
+  // and must actually reach the sentence that blames the PR.
+  it('threads the retry count into both lanes fail copy', () => {
+    for (const [jobName, stepName] of [
+      ['publish-verify', 'Post verification report comment'],
+      ['publish-tmux', 'Post tmux result comment'],
+    ]) {
+      const publish = stepIn(jobName, stepName);
+      const install = publish.indexOf("PREPARE_COMMAND='npm ci'");
+      const build = publish.indexOf("PREPARE_COMMAND='npm run build'");
+      expect(install).toBeGreaterThan(-1);
+      expect(build).toBeGreaterThan(install);
+      // Assigned between the install arm and the build arm — i.e. inside
+      // the install arm and nowhere else.
+      const attempts = publish.indexOf("PREPARE_ATTEMPTS=' twice in a row'");
+      expect(attempts).toBeGreaterThan(install);
+      expect(attempts).toBeLessThan(build);
+      expect(publish.slice(build)).not.toContain('PREPARE_ATTEMPTS=');
+      // ...and consumed by the PR-blaming sentence, not left dangling.
+      expect(publish).toMatch(
+        /failed%s[\s\S]*?treated as a PR failure verdict[\s\S]*?"\$\{PREPARE_ATTEMPTS:-\}"/,
+      );
     }
   });
 


### PR DESCRIPTION
## What this PR does

Retries `npm ci` once in both sandbox lanes, so a transient install race stops being reported as the PR's fault.

[Run 30319209722](https://github.com/QwenLM/qwen-code/actions/runs/30319209722) posted **"Sandboxed verification: fail — The PR could not be built ... treated as a PR failure verdict rather than an infrastructure failure"** on #7856, a six-file source change. The install died here:

```
Error: spawnSync .../packages/web-templates/node_modules/esbuild/bin/esbuild ETXTBSY
    at validateBinaryVersion (esbuild/install.js:99:28)
```

`ETXTBSY` is npm writing a dependency's binary and that package's own install script exec'ing it before the write is closed. It is a race, and the PR had no part in it — but the comment accused its author, on a lane whose whole purpose is to produce evidence a maintainer can trust.

Two changes, applied to the `verify` and `tmux-testing` lanes:

- **Retry the install once.** `npm ci` removes `node_modules` before installing, so the second attempt cannot inherit the half-written file.
- **Say that it was retried.** The sentence that blames the PR now reads "failed **twice in a row**", because that is what now earns the accusation.

The build is deliberately **not** retried: a compile error is deterministic, so a second run would only double the cost of an honest failure.

## Why it's needed

The obvious fix is to match `ETXTBSY` in the log and downgrade to `infra-error`. That would be a regression, and the code already says why:

> BOTH inputs are PR-controlled. A lifecycle script can exit with a signal status, and it can print any line the log heuristic looked for — so the old classifier let a PR turn its own deterministic breakage into "infrastructure, please re-run", which hides the failure and preserves a stale report.

A retry consults nothing. It sidesteps the classification question entirely rather than reopening it:

|                                       | log-matching downgrade   | retry (this PR)     |
| ------------------------------------- | ------------------------ | ------------------- |
| Reads PR-controlled text              | yes                      | **no**              |
| A PR can talk itself out of a verdict | yes                      | **no**              |
| Transient race                        | relabelled, still a fail | **absorbed, passes** |
| Deterministic breakage                | `fail`                   | `fail` (twice)      |
| Cost when the install is healthy      | none                     | **none**            |

The extra attempt is only ever paid on a path that is already failing.

## Reviewer Test Plan

### How to verify

The retry is covered **behaviourally**, not structurally. Asserting "the step contains a loop" would pass on a loop that never retries *and* on one that never stops — the two ways this can actually be wrong. So the tests run the real step text with `runuser` stubbed to drop its own arguments and exec the rest (which keeps the genuine `env -u …` stripping in the path under test), and an `npm` stub that fails a set number of times, then count actual attempts:

| arm                       | attempts | verdict           | log                       |
| ------------------------- | :------: | ----------------- | ------------------------- |
| healthy install           |    1     | none              | no retry notice           |
| one ETXTBSY, then success |    2     | none — build runs | `retrying once`           |
| broken tree               |    2     | `fail` / `install` | `after 2 attempts`        |

The middle row is the bug: before this change it emitted `verdict=fail`. The third row pins the bound — a retry that never stops would report 99.

**Mutation-verified 5/5**, each turning at least one test red:

| # | mutation                                     | result                             |
| - | -------------------------------------------- | ---------------------------------- |
| 1 | unbounded retry (`-ge 2` → `-ge 99`)         | `expected 99 to be 2`              |
| 2 | no retry (break unconditionally)             | 2 failed                           |
| 3 | give the build a retry loop too              | 1 failed                           |
| 4 | drop `PREPARE_ATTEMPTS=''`                   | build report claims "twice in a row" |
| 5 | revert the wording to the single-shot copy   | 2 failed                           |

Worth recording: mutation 1 appeared to *survive* on the first pass. It had not — the `perl -0pi -e 's/\Q"$install_attempt" -ge 2\E/…/'` interpolated `$install_attempt` as an empty Perl variable, so the file was never modified. `\Q` suppresses metacharacters, not interpolation. Re-run with the `$` escaped, it kills the test. A mutation that does not change the file is not evidence of anything.

`PREPARE_ATTEMPTS` is initialised rather than defaulted at the point of use, and mutation 4 is what makes that load-bearing: `${PREPARE_ATTEMPTS:-}` does nothing against an *inherited* value, and the result would be a report claiming a single-shot `npm run build` had failed twice — the same false accusation this PR removes, pointed the other way.

77 tests, 75 pass; `actionlint` finding-set **identical to `main`** (no new findings); both prepare steps and both publish steps pass `bash -n` and `shellcheck -S warning --enable=all`; prettier and eslint clean.

### Evidence (Before & After)

Real comment posted on #7856 by run 30319209722 — the accusation this removes:

> **Sandboxed verification: fail**
> The PR could not be built because `npm ci` failed before any verification started. This is treated as a PR failure verdict rather than an infrastructure failure.

After, for the same log: the install is retried, succeeds, and no verdict is posted at all. When a tree really is broken, the copy states what it is now claiming:

> The PR could not be built because `npm ci` failed **twice in a row** before any verification started.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ⚠️   |

Linux: `ETXTBSY` is the Linux-side race being absorbed; the retry logic itself is OS-independent and is exercised on macOS with stubs. Confirmation on a runner needs one `/verify` run that hits a flaky install, which is by nature not schedulable.

## Risk & Scope

- **Main risk or tradeoff:** a PR whose install fails deterministically now spends a second `npm ci` before reporting `fail`. Bounded and only on an already-failing path; the `verify` job's budget is 60 min and `tmux-testing`'s 45 min, against an install of a few minutes.
- **Known limitation, not fixed here:** `emit_block` truncates from the **head** (`buf.subarray(0, max)`), so a long enough first attempt could push the decisive second failure out of the 20,000-char window. Measured against the real #7856 log — one failing attempt renders to 2,701 bytes, two to roughly 5.4 KB — that leaves ~3.7× headroom, so it is not reachable at observed sizes. It is a pre-existing weakness (a single >20 KB failure truncates its own error away on `main` too) that this change makes about twice as easy to reach. Tail-truncating install logs is the real fix and is deliberately left out of scope.
- **Not validated / out of scope:** the runner-side `dubious ownership` inconsistency that stops most machines earlier at `Clean stale agent state`; the two proxy-watchdog tests that time out on `main` (20 chunks × 200 ms exceeds vitest's 5 s default) — those are fixed by #7858 and not duplicated here to avoid a conflict.
- **Breaking changes / migration notes:** none.

## Linked Issues

Follow-up to #7710 and #7753. Independent of #7858 (different steps in the same file). No issues closed.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在两条沙箱车道中为 `npm ci` 增加一次重试，使**瞬时安装竞态不再被报告为 PR 的问题**。

[运行 30319209722](https://github.com/QwenLM/qwen-code/actions/runs/30319209722) 在 #7856（一个仅改动 6 个源文件的 PR）上发布了 **"Sandboxed verification: fail —— 该 PR 无法构建……判定为 PR 失败而非基础设施故障"**。安装失败于：

```
Error: spawnSync .../packages/web-templates/node_modules/esbuild/bin/esbuild ETXTBSY
    at validateBinaryVersion (esbuild/install.js:99:28)
```

`ETXTBSY` 是 npm 写入依赖的二进制文件后、该包自身的安装脚本在写入尚未关闭时就去 exec 它——这是一个竞态，与该 PR 毫无关系。但评论仍然指控了它的作者，而这条车道的全部意义正是产出维护者可以信赖的证据。

两处改动，`verify` 与 `tmux-testing` 两条车道同时应用：**安装重试一次**（`npm ci` 会在安装前删除 `node_modules`，因此第二次尝试不可能继承半写入的文件）；**并在措辞中说明重试过**——归咎于 PR 的那句话现在写作"**连续失败两次**"，因为这才是支撑这项指控的依据。

构建**刻意不重试**：编译错误是确定性的，重跑只会让一次诚实的失败成本翻倍。

## 为什么需要

直觉修法是在日志中匹配 `ETXTBSY` 并降级为 `infra-error`。那会是一次倒退，而代码里已经写明了原因：

> 两个输入都是 PR 可控的。lifecycle 脚本可以以信号状态退出，也可以打印日志启发式所查找的任何一行——因此旧的分类器让 PR 得以把自己确定性的故障洗成"基础设施问题，请重跑"，从而掩盖失败并保留过期报告。

重试则**不查询任何东西**。它绕开了整个分类问题，而不是重新打开它：

|                          | 日志匹配降级       | 重试（本 PR）  |
| ------------------------ | ------------------ | -------------- |
| 读取 PR 可控的文本       | 是                 | **否**         |
| PR 能为自己开脱判决      | 是                 | **否**         |
| 瞬时竞态                 | 改了标签，仍是失败 | **被吸收，通过** |
| 确定性故障               | `fail`             | `fail`（两次） |
| 安装健康时的代价         | 无                 | **无**         |

额外的那次尝试只在**已经失败**的路径上付出。

## 评审验证方案

重试是**行为性**覆盖而非结构性覆盖。断言"该步骤包含一个循环"会在"从不重试的循环"和"永不停止的循环"上同时通过——而这恰是它可能出错的两种方式。因此测试运行**真实的步骤文本**：`runuser` 被 stub 为丢弃自身参数并 exec 其余部分（从而保留被测路径中真正的 `env -u …` 剥离逻辑），`npm` stub 失败指定次数，然后统计实际尝试次数：

| 场景                 | 尝试次数 | 判决              | 日志             |
| -------------------- | :------: | ----------------- | ---------------- |
| 健康安装             |    1     | 无                | 无重试提示       |
| 一次 ETXTBSY 后成功  |    2     | 无——继续构建      | `retrying once`  |
| 确实坏掉的代码树     |    2     | `fail` / `install` | `after 2 attempts` |

中间一行就是这个 bug：改动前它会发出 `verdict=fail`。第三行钉住了上界——永不停止的重试会报告 99 次。

**5/5 变异验证**，每项至少使一条测试变红：无界重试（`-ge 2` → `-ge 99`）→ `expected 99 to be 2`；完全不重试 → 2 条失败；给 build 也加重试循环 → 1 条失败；去掉 `PREPARE_ATTEMPTS=''` → 构建报告谎称"连续失败两次"；还原为单次尝试的措辞 → 2 条失败。

值得记录：变异 1 起初**看似存活**。其实并没有——`perl -0pi -e 's/\Q"$install_attempt" -ge 2\E/…/'` 把 `$install_attempt` 当作 Perl 变量插值成了空串，文件根本没被修改。`\Q` 抑制的是元字符，不是插值。把 `$` 转义后重跑，它确实致死。**一个没有改动文件的变异不能证明任何事情。**

`PREPARE_ATTEMPTS` 是显式初始化而非在使用处默认，变异 4 正是让这一点成为承重结构的原因：`${PREPARE_ATTEMPTS:-}` 对**继承而来的**值毫无作用，其后果会是一份声称单次执行的 `npm run build` 失败了两次的报告——正是本 PR 要消除的那种错误归因，只是方向相反。

77 条测试、75 条通过；`actionlint` 的发现集**与 `main` 完全一致**（无新增）；两个 prepare 步骤与两个 publish 步骤均通过 `bash -n` 与 `shellcheck -S warning --enable=all`；prettier 与 eslint 干净。

### 测试平台

macOS ✅；Windows N/A；Linux ⚠️——`ETXTBSY` 正是被吸收的 Linux 侧竞态，而重试逻辑本身与操作系统无关，已在 macOS 上用 stub 完整验证。在 runner 上的最终确认需要一次恰好遇到 flaky 安装的 `/verify` 运行，这本质上无法排期。

## 风险与范围

- **主要权衡**：确定性安装失败的 PR 现在会在报出 `fail` 前多花一次 `npm ci`。这是有界的，且只发生在已经失败的路径上；`verify` job 的预算是 60 分钟、`tmux-testing` 是 45 分钟，而安装耗时只有几分钟。
- **已知限制，本 PR 不修**：`emit_block` 从**头部**截断（`buf.subarray(0, max)`），因此足够长的第一次尝试可能把决定性的第二次失败挤出 20,000 字符窗口。以 #7856 的真实日志实测——单次失败渲染为 2,701 字节，两次约 5.4 KB——尚有约 3.7 倍余量，在已观测的规模下不可达。这是一个既有弱点（在 `main` 上，单次超过 20 KB 的失败同样会把自己的错误截掉），本改动使其大约容易触发一倍。真正的修法是对安装日志做尾部截断，刻意留作范围外。
- **未验证/范围外**：导致多数机器更早在 `Clean stale agent state` 失败的 runner 侧 `dubious ownership` 不一致；以及在 `main` 上超时的两条 proxy-watchdog 测试（20 个数据块 × 200 ms 超过 vitest 默认的 5 秒）——那两条由 #7858 修复，此处不重复以避免冲突。
- **破坏性变更**：无。

## 关联 Issue

#7710 与 #7753 的后续。与 #7858 相互独立（同一文件的不同步骤）。不关闭任何 issue。

</details>
