### PR TITLE
feat(channels): expose loop tools in daemon sessions

### DIFF
--- a/packages/channels/base/src/DaemonChannelBridge.test.ts
+++ b/packages/channels/base/src/DaemonChannelBridge.test.ts
@@ -6,6 +6,7 @@ import type {
 import {
   DaemonChannelBridge,
   type DaemonChannelEvent,
+  type DaemonChannelLoopMcpHost,
   type DaemonChannelSessionClient,
 } from './DaemonChannelBridge.js';
 
@@ -130,6 +131,67 @@ function turnCompleteEvent(sessionId = 'session-1'): DaemonChannelEvent {
 }
 
 describe('DaemonChannelBridge', () => {
+  it('registers the loop MCP server for the exact daemon session', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const handlers = new Map<
+      string,
+      (
+        message: Record<string, unknown>,
+      ) => Promise<Record<string, unknown> | undefined>
+    >();
+    const host: DaemonChannelLoopMcpHost = {
+      register: vi.fn(async (sessionId, handler) => {
+        handlers.set(sessionId, handler);
+      }),
+      unregister: vi.fn(async (sessionId) => {
+        handlers.delete(sessionId);
+      }),
+    };
+    const create = vi.fn(async () => ({ text: 'created' }));
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+      channelLoopMcpHost: host,
+    });
+    bridge.registerChannelLoopToolHandler({
+      create,
+      list: vi.fn(async () => ({ text: 'listed' })),
+      cancel: vi.fn(async () => ({ text: 'cancelled' })),
+    });
+
+    await bridge.start();
+    await bridge.newSession('/repo');
+
+    expect(host.register).toHaveBeenCalledWith(
+      'session-1',
+      expect.any(Function),
+    );
+    await expect(
+      handlers.get('session-1')?.({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'channel_loop_create',
+          arguments: { cron: '*/5 * * * *', prompt: 'check status' },
+        },
+      }),
+    ).resolves.toMatchObject({
+      id: 1,
+      result: { content: [{ type: 'text', text: 'created' }] },
+    });
+    expect(create).toHaveBeenCalledWith('session-1', {
+      cron: '*/5 * * * *',
+      prompt: 'check status',
+    });
+
+    await bridge.discardSession('session-1');
+    expect(host.unregister).toHaveBeenCalledWith('session-1');
+    expect(handlers.has('session-1')).toBe(false);
+    bridge.stop();
+  });
+
   it('binds a daemon session and collects assistant chunks during prompt', async () => {
     const events = new EventQueue();
     const session = createFakeSession(events);

--- a/packages/channels/base/src/DaemonChannelBridge.ts
+++ b/packages/channels/base/src/DaemonChannelBridge.ts
@@ -8,9 +8,14 @@ import type {
   BridgeSessionInfo,
   ChannelAgentBridge,
   ChannelAgentBridgeSessionOptions,
+  ChannelLoopToolHandler,
   ToolCallEvent,
 } from './ChannelAgentBridge.js';
 import { readAvailableCommandAltNames } from './AcpBridge.js';
+import {
+  ChannelLoopMcpServer,
+  type JsonRpcMessage,
+} from './ChannelLoopTools.js';
 import type { SessionScope } from './types.js';
 
 const MAX_RESPONDED_PERMISSION_REQUESTS = 256;
@@ -65,11 +70,20 @@ export type DaemonChannelSessionFactory = (
   req: DaemonChannelSessionFactoryRequest,
 ) => Promise<DaemonChannelSessionClient>;
 
+export interface DaemonChannelLoopMcpHost {
+  register(
+    sessionId: string,
+    handler: (message: JsonRpcMessage) => Promise<JsonRpcMessage | undefined>,
+  ): Promise<void>;
+  unregister(sessionId: string): Promise<void>;
+}
+
 export interface DaemonChannelBridgeOptions {
   cwd: string;
   sessionFactory: DaemonChannelSessionFactory;
   modelServiceId?: string;
   sessionScope?: SessionScope;
+  channelLoopMcpHost?: DaemonChannelLoopMcpHost;
 }
 
 export interface DaemonPermissionRequestEvent {
@@ -206,6 +220,13 @@ export class DaemonChannelBridge
     AvailableCommand[]
   >();
   private readonly turnBarriers = new Map<string, () => void>();
+  private readonly channelLoopToolHandlers: ChannelLoopToolHandler[] = [];
+  private readonly registeredChannelLoopMcpSessions = new Set<string>();
+  private readonly channelLoopMcpRegistrations = new Map<
+    string,
+    Promise<void>
+  >();
+  private channelLoopMcpServer: ChannelLoopMcpServer | undefined;
   private connected = false;
   private lifecycleGeneration = 0;
   private latestAvailableCommandsSessionId: string | undefined;
@@ -271,6 +292,7 @@ export class DaemonChannelBridge
       await this.rejectStaleSession(session);
     }
     this.attachSession(session, bindingToken);
+    await this.registerChannelLoopMcpForSession(session.sessionId);
     return session.sessionId;
   }
 
@@ -300,7 +322,25 @@ export class DaemonChannelBridge
       );
     }
     this.attachSession(session, bindingToken);
+    await this.registerChannelLoopMcpForSession(session.sessionId);
     return session.sessionId;
+  }
+
+  registerChannelLoopToolHandler(handler: ChannelLoopToolHandler): void {
+    if (!this.channelLoopToolHandlers.includes(handler)) {
+      this.channelLoopToolHandlers.push(handler);
+    }
+    this.channelLoopMcpServer ??= new ChannelLoopMcpServer({
+      create: (sessionId, input) =>
+        this.resolveChannelLoopToolHandler(sessionId).create(sessionId, input),
+      list: (sessionId) =>
+        this.resolveChannelLoopToolHandler(sessionId).list(sessionId),
+      cancel: (sessionId, id) =>
+        this.resolveChannelLoopToolHandler(sessionId).cancel(sessionId, id),
+    });
+    for (const sessionId of this.sessions.keys()) {
+      void this.registerChannelLoopMcpForSession(sessionId);
+    }
   }
 
   async prompt(
@@ -505,7 +545,7 @@ export class DaemonChannelBridge
     session: DaemonChannelSessionClient,
     bindingToken?: object,
   ): void {
-    const replacedSession = this.removeSessionBinding(session.sessionId);
+    const replacedSession = this.removeSessionBinding(session.sessionId, false);
     if (replacedSession) {
       void this.releaseSessionClient(replacedSession).catch(
         (error: unknown) => {
@@ -879,6 +919,7 @@ export class DaemonChannelBridge
 
   private removeSessionBinding(
     sessionId: string,
+    unregisterChannelLoopMcp = true,
   ): DaemonChannelSessionClient | undefined {
     const session = this.sessions.get(sessionId);
     if (!session) return undefined;
@@ -905,7 +946,71 @@ export class DaemonChannelBridge
         this.respondedRequestToSession.delete(requestId);
       }
     }
+    if (unregisterChannelLoopMcp) {
+      this.unregisterChannelLoopMcpForSession(sessionId);
+    }
     return session;
+  }
+
+  private async registerChannelLoopMcpForSession(
+    sessionId: string,
+  ): Promise<void> {
+    const host = this.options.channelLoopMcpHost;
+    const server = this.channelLoopMcpServer;
+    if (
+      !host ||
+      !server ||
+      this.registeredChannelLoopMcpSessions.has(sessionId)
+    ) {
+      return;
+    }
+    const pending = this.channelLoopMcpRegistrations.get(sessionId);
+    if (pending) {
+      await pending;
+      return;
+    }
+    const registration = host
+      .register(sessionId, (message) =>
+        server.handleMessage(message, { sessionId }),
+      )
+      .then(async () => {
+        if (this.sessions.has(sessionId)) {
+          this.registeredChannelLoopMcpSessions.add(sessionId);
+        } else {
+          await host.unregister(sessionId);
+        }
+      })
+      .catch((error: unknown) => {
+        this.lastError = error;
+      })
+      .finally(() => {
+        if (this.channelLoopMcpRegistrations.get(sessionId) === registration) {
+          this.channelLoopMcpRegistrations.delete(sessionId);
+        }
+      });
+    this.channelLoopMcpRegistrations.set(sessionId, registration);
+    await registration;
+  }
+
+  private unregisterChannelLoopMcpForSession(sessionId: string): void {
+    if (!this.registeredChannelLoopMcpSessions.delete(sessionId)) return;
+    void this.options.channelLoopMcpHost
+      ?.unregister(sessionId)
+      .catch((error: unknown) => {
+        this.lastError = error;
+      });
+  }
+
+  private resolveChannelLoopToolHandler(
+    sessionId: string,
+  ): ChannelLoopToolHandler {
+    const handler = this.channelLoopToolHandlers.find(
+      (candidate) =>
+        candidate.canHandle?.(sessionId) === true ||
+        (this.channelLoopToolHandlers.length === 1 && !candidate.canHandle),
+    );
+    if (handler) return handler;
+    throw new Error(`No channel loop handler matched session ${sessionId}.`);
   }
 
   private getStringField(

--- a/packages/channels/base/src/index.ts
+++ b/packages/channels/base/src/index.ts
@@ -16,6 +16,7 @@ export type { AcpBridgeOptions } from './AcpBridge.js';
 export { DaemonChannelBridge } from './DaemonChannelBridge.js';
 export type {
   DaemonChannelBridgeOptions,
+  DaemonChannelLoopMcpHost,
   DaemonChannelEvent,
   DaemonChannelSessionClient,
   DaemonChannelSessionFactory,
@@ -41,6 +42,7 @@ export type {
   ChannelLoopController,
 } from './ChannelBase.js';
 export { ChannelLoopScheduler } from './ChannelLoopScheduler.js';
+export { CHANNEL_LOOP_MCP_SERVER_NAME } from './ChannelLoopTools.js';
 export type {
   ChannelLoopSchedulerOptions,
   ChannelLoopRunner,

--- a/packages/cli/src/commands/channel/daemon-worker.test.ts
+++ b/packages/cli/src/commands/channel/daemon-worker.test.ts
@@ -127,6 +127,7 @@ const mockBridgeDiscardSession = vi.hoisted(() => vi.fn());
 const mockBridgeRespondToPermission = vi.hoisted(() => vi.fn());
 const mockBridgeShellCommand = vi.hoisted(() => vi.fn());
 const mockBridgeGetAvailableCommands = vi.hoisted(() => vi.fn(() => []));
+const mockBridgeRegisterChannelLoopToolHandler = vi.hoisted(() => vi.fn());
 const mockChannelLoopStoreCreate = vi.hoisted(() => vi.fn());
 const mockChannelLoopStoreCreateForTarget = vi.hoisted(() => vi.fn());
 const mockChannelLoopStoreListForTarget = vi.hoisted(() => vi.fn());
@@ -162,6 +163,7 @@ const mockDaemonChannelBridge = vi.hoisted(() =>
     discardSession: mockBridgeDiscardSession,
     respondToPermission: mockBridgeRespondToPermission,
     shellCommand: mockBridgeShellCommand,
+    registerChannelLoopToolHandler: mockBridgeRegisterChannelLoopToolHandler,
     start: mockBridgeStart,
     stop: mockBridgeStop,
   })),
@@ -673,7 +675,8 @@ describe('createDaemonChannelBridgeFacade', () => {
     expect('listSessions' in facade).toBe(false);
   });
 
-  it('does not expose channel loop MCP registration through the daemon facade', () => {
+  it('forwards channel loop MCP registration through the daemon facade', () => {
+    const registerChannelLoopToolHandler = vi.fn();
     const bridge = {
       availableCommands: [],
       on: mockBridgeOn,
@@ -682,14 +685,21 @@ describe('createDaemonChannelBridgeFacade', () => {
       loadSession: mockBridgeLoadSession,
       prompt: mockBridgePrompt,
       cancelSession: mockBridgeCancelSession,
-      registerChannelLoopToolHandler: vi.fn(),
+      registerChannelLoopToolHandler,
     };
 
     const facade = createDaemonChannelBridgeFacade(bridge, {
       exposeShellCommand: false,
     });
 
-    expect('registerChannelLoopToolHandler' in facade).toBe(false);
+    const handler = {
+      create: vi.fn(),
+      list: vi.fn(),
+      cancel: vi.fn(),
+    };
+    facade.registerChannelLoopToolHandler?.(handler);
+
+    expect(registerChannelLoopToolHandler).toHaveBeenCalledWith(handler);
   });
 });
 

--- a/packages/cli/src/commands/channel/daemon-worker.ts
+++ b/packages/cli/src/commands/channel/daemon-worker.ts
@@ -26,6 +26,7 @@ import type {
   ChannelLoopRunner,
   ChannelWebhookRunOptions,
   ChannelWebhookTask,
+  DaemonChannelLoopMcpHost,
   DaemonChannelSessionClient,
   DaemonChannelSessionFactory,
   DaemonChannelSessionFactoryRequest,
@@ -62,6 +63,7 @@ import {
   type ChannelStartupReportMessage,
 } from '../../serve/channel-worker-startup-ipc.js';
 import { isLoopbackBind } from '../../serve/loopback-binds.js';
+import { ChannelLoopMcpWorkerHost } from '../../serve/channel-loop-mcp-ipc.js';
 import { writeStderrLine, writeStdoutLine } from '../../utils/stdioHelpers.js';
 import { resolveProxyUrl } from './proxy.js';
 import {
@@ -169,6 +171,7 @@ export interface RunChannelDaemonWorkerOptions {
   sendReady?: (ready: ChannelDaemonWorkerReady) => void;
   reportStartup?: (message: ChannelStartupReportMessage) => Promise<void>;
   startupSignal?: AbortSignal;
+  channelLoopMcpHost?: DaemonChannelLoopMcpHost;
 }
 
 export function createDaemonSessionFactory({
@@ -251,6 +254,11 @@ export function createDaemonChannelBridgeFacade(
 
   if (bridge.listSessions) {
     facade.listSessions = bridge.listSessions.bind(bridge);
+  }
+
+  if (bridge.registerChannelLoopToolHandler) {
+    facade.registerChannelLoopToolHandler =
+      bridge.registerChannelLoopToolHandler.bind(bridge);
   }
 
   return facade;
@@ -464,6 +472,9 @@ export async function runChannelDaemonWorker(
       clientId: `qwen-channel-worker:${process.pid}`,
     }),
     ...(modelServiceId ? { modelServiceId } : {}),
+    ...(opts.channelLoopMcpHost
+      ? { channelLoopMcpHost: opts.channelLoopMcpHost }
+      : {}),
   });
 
   const channels = new Map<string, ChannelBase>();
@@ -769,6 +780,12 @@ function assertInternalDaemonWorkerInvocation(): void {
 function reportStartupToSupervisor(
   message: ChannelStartupReportMessage,
   signal: AbortSignal,
+  subscribeMessage: (listener: (message: unknown) => void) => () => void = (
+    listener,
+  ) => {
+    process.on('message', listener);
+    return () => process.removeListener('message', listener);
+  },
 ): Promise<void> {
   if (signal.aborted) {
     return Promise.reject(startupAbortError());
@@ -779,8 +796,9 @@ function reportStartupToSupervisor(
   }
   return new Promise<void>((resolve, reject) => {
     let settled = false;
+    let unsubscribeMessage = () => {};
     const cleanup = () => {
-      process.removeListener('message', onMessage);
+      unsubscribeMessage();
       process.removeListener('disconnect', onDisconnect);
       signal.removeEventListener('abort', onAbort);
     };
@@ -802,7 +820,7 @@ function reportStartupToSupervisor(
     const onAbort = () => {
       finish(startupAbortError());
     };
-    process.on('message', onMessage);
+    unsubscribeMessage = subscribeMessage(onMessage);
     process.once('disconnect', onDisconnect);
     signal.addEventListener('abort', onAbort, { once: true });
     try {
@@ -828,6 +846,22 @@ export const daemonWorkerCommand: CommandModule<unknown, DaemonWorkerArgs> = {
     }),
   handler: async (argv) => {
     const startupAbortController = new AbortController();
+    let channelLoopMcpHost: ChannelLoopMcpWorkerHost | undefined;
+    const messageSubscribers = new Set<(message: unknown) => void>();
+    let onWorkerMessage: ((message: unknown) => void) | undefined;
+    const subscribeMessage = (listener: (message: unknown) => void) => {
+      messageSubscribers.add(listener);
+      return () => messageSubscribers.delete(listener);
+    };
+    const disposeChannelLoopMcpHost = () => {
+      if (onWorkerMessage) {
+        process.removeListener('message', onWorkerMessage);
+        onWorkerMessage = undefined;
+      }
+      messageSubscribers.clear();
+      channelLoopMcpHost?.dispose();
+      channelLoopMcpHost = undefined;
+    };
     let pendingShutdownReason: NodeJS.Signals | 'disconnect' | undefined;
     const onEarlyShutdown = (reason: NodeJS.Signals | 'disconnect') => {
       if (pendingShutdownReason) {
@@ -857,6 +891,17 @@ export const daemonWorkerCommand: CommandModule<unknown, DaemonWorkerArgs> = {
     try {
       assertInternalDaemonWorkerInvocation();
       const { daemonToken, daemonUrl, workspace } = readDaemonWorkerEnv();
+      const send = process.send!;
+      channelLoopMcpHost = new ChannelLoopMcpWorkerHost((message, callback) =>
+        send.call(process, message, callback ?? (() => {})),
+      );
+      onWorkerMessage = (message: unknown) => {
+        if (channelLoopMcpHost?.handleMessage(message)) return;
+        for (const subscriber of [...messageSubscribers]) {
+          subscriber(message);
+        }
+      };
+      process.on('message', onWorkerMessage);
       const selection = normalizeServeChannelSelection(argv.channel);
       if (!selection) {
         throw new Error('--channel is required.');
@@ -868,7 +913,12 @@ export const daemonWorkerCommand: CommandModule<unknown, DaemonWorkerArgs> = {
         selection,
         startupSignal: startupAbortController.signal,
         reportStartup: (message) =>
-          reportStartupToSupervisor(message, startupAbortController.signal),
+          reportStartupToSupervisor(
+            message,
+            startupAbortController.signal,
+            subscribeMessage,
+          ),
+        channelLoopMcpHost,
         sendReady: (ready) => {
           process.send?.({ type: 'ready', ...ready });
         },
@@ -1035,7 +1085,7 @@ export const daemonWorkerCommand: CommandModule<unknown, DaemonWorkerArgs> = {
         }
       }, CHANNEL_WORKER_HEARTBEAT_INTERVAL_MS);
       heartbeatTimer.unref();
-      process.on('message', onMessage);
+      const unsubscribeMessage = subscribeMessage(onMessage);
 
       let shuttingDown = false;
       let exitCode = 0;
@@ -1049,7 +1099,7 @@ export const daemonWorkerCommand: CommandModule<unknown, DaemonWorkerArgs> = {
         } else {
           shuttingDown = true;
           clearHeartbeat();
-          process.removeListener('message', onMessage);
+          unsubscribeMessage();
           try {
             const deliveryCount = activeChannelDeliveries.size;
             const webhookCount = activeWebhookTasks.size;
@@ -1088,6 +1138,7 @@ export const daemonWorkerCommand: CommandModule<unknown, DaemonWorkerArgs> = {
             );
           } finally {
             clearHeartbeat();
+            disposeChannelLoopMcpHost();
             finish();
           }
         }
@@ -1103,13 +1154,14 @@ export const daemonWorkerCommand: CommandModule<unknown, DaemonWorkerArgs> = {
       }
       await finished;
       clearHeartbeat();
-      process.removeListener('message', onMessage);
+      unsubscribeMessage();
       process.removeListener('SIGINT', shutdown);
       process.removeListener('SIGTERM', shutdown);
       process.removeListener('disconnect', onDisconnect);
       process.exit(exitCode);
     } catch (err) {
       removeEarlyShutdownHandlers();
+      disposeChannelLoopMcpHost();
       const safeMessage = sanitizeLogText(
         err instanceof Error ? err.message : String(err),
         512,

--- a/packages/cli/src/serve/acp-http/client-mcp-sender-registry.test.ts
+++ b/packages/cli/src/serve/acp-http/client-mcp-sender-registry.test.ts
@@ -67,6 +67,56 @@ describe('ClientMcpSenderRegistry', () => {
     reg.delete('srv', 'connA'); // already gone -> no throw
     expect(reg.serverNames()).toEqual([]);
   });
+
+  it('routes session-scoped senders by exact session id', async () => {
+    const reg = new ClientMcpSenderRegistry();
+    const senderA = vi.fn(async () => msg(1));
+    const senderB = vi.fn(async () => msg(2));
+    reg.setSession('channel_loop', 'session-a', senderA, 'worker-a');
+    reg.setSession('channel_loop', 'session-b', senderB, 'worker-a');
+
+    await reg.lookup('channel_loop')!(msg(7), { sessionId: 'session-b' });
+
+    expect(senderA).not.toHaveBeenCalled();
+    expect(senderB).toHaveBeenCalledWith(msg(7));
+  });
+
+  it('keeps session deletion scoped to the current worker owner', async () => {
+    const reg = new ClientMcpSenderRegistry();
+    const senderA = vi.fn(async () => msg(1));
+    const senderB = vi.fn(async () => msg(2));
+    reg.setSession('channel_loop', 'session-a', senderA, 'worker-a');
+    reg.setSession('channel_loop', 'session-a', senderB, 'worker-b');
+
+    expect(reg.deleteSession('channel_loop', 'session-a', 'worker-a')).toBe(
+      false,
+    );
+    await reg.lookup('channel_loop')!(msg(7), { sessionId: 'session-a' });
+    expect(senderB).toHaveBeenCalled();
+    expect(reg.deleteSession('channel_loop', 'session-a', 'worker-b')).toBe(
+      true,
+    );
+  });
+
+  it('never falls back to a global sender for a reserved session server', async () => {
+    const reg = new ClientMcpSenderRegistry();
+    const globalSender = vi.fn(async () => msg(1));
+    reg.set('channel_loop', globalSender, 'browser');
+    reg.setSession(
+      'channel_loop',
+      'session-a',
+      vi.fn(async () => msg(2)),
+      'worker',
+    );
+
+    await expect(
+      reg.lookup('channel_loop')!(msg(7), { sessionId: 'session-b' }),
+    ).rejects.toThrow(/No session-scoped MCP sender/);
+    await expect(reg.lookup('channel_loop')!(msg(8))).rejects.toThrow(
+      /requires a session context/,
+    );
+    expect(globalSender).not.toHaveBeenCalled();
+  });
 });
 
 describe('createClientMcpServerProvider', () => {

--- a/packages/cli/src/serve/acp-http/client-mcp-sender-registry.ts
+++ b/packages/cli/src/serve/acp-http/client-mcp-sender-registry.ts
@@ -82,6 +82,14 @@ export class ClientMcpSenderRegistry {
     string,
     { sender: WsClientMcpSender; owner: string }
   >();
+  private readonly sessionSenders = new Map<
+    string,
+    Map<
+      string,
+      { sender: (payload: unknown) => Promise<unknown>; owner: string }
+    >
+  >();
+  private readonly sessionScopedServerNames = new Set<string>();
 
   /**
    * Record a server's WS sender, owned by `owner` (the registering
@@ -108,6 +116,35 @@ export class ClientMcpSenderRegistry {
     return this.senders.get(serverName)?.owner === owner;
   }
 
+  setSession(
+    serverName: string,
+    sessionId: string,
+    sender: (payload: unknown) => Promise<unknown>,
+    owner: string,
+  ): void {
+    let bySession = this.sessionSenders.get(serverName);
+    if (!bySession) {
+      bySession = new Map();
+      this.sessionSenders.set(serverName, bySession);
+    }
+    bySession.set(sessionId, { sender, owner });
+    this.sessionScopedServerNames.add(serverName);
+  }
+
+  ownsSession(serverName: string, sessionId: string, owner: string): boolean {
+    return this.sessionSenders.get(serverName)?.get(sessionId)?.owner === owner;
+  }
+
+  deleteSession(serverName: string, sessionId: string, owner: string): boolean {
+    const bySession = this.sessionSenders.get(serverName);
+    if (bySession?.get(sessionId)?.owner !== owner) return false;
+    bySession.delete(sessionId);
+    if (bySession.size === 0) {
+      this.sessionSenders.delete(serverName);
+    }
+    return true;
+  }
+
   /** Currently-registered server names (tests / accounting). */
   serverNames(): string[] {
     return [...this.senders.keys()];
@@ -122,9 +159,37 @@ export class ClientMcpSenderRegistry {
    */
   readonly lookup: ClientMcpMessageSender = (serverName: string) => {
     const entry = this.senders.get(serverName);
-    if (!entry) return undefined;
-    return (payload: unknown) =>
-      entry.sender(serverName, payload as JSONRPCMessage) as Promise<unknown>;
+    const sessionEntries = this.sessionSenders.get(serverName);
+    if (!entry && !sessionEntries) return undefined;
+    return (payload, context) => {
+      if (context?.sessionId) {
+        const sessionEntry = sessionEntries?.get(context.sessionId);
+        if (sessionEntry) return sessionEntry.sender(payload);
+        if (this.sessionScopedServerNames.has(serverName)) {
+          return Promise.reject(
+            new Error(
+              `No session-scoped MCP sender for '${serverName}' in session '${context.sessionId}'.`,
+            ),
+          );
+        }
+      }
+      if (this.sessionScopedServerNames.has(serverName)) {
+        return Promise.reject(
+          new Error(
+            `Session-scoped MCP server '${serverName}' requires a session context.`,
+          ),
+        );
+      }
+      if (!entry) {
+        return Promise.reject(
+          new Error(`No client MCP sender for '${serverName}'.`),
+        );
+      }
+      return entry.sender(
+        serverName,
+        payload as JSONRPCMessage,
+      ) as Promise<unknown>;
+    };
   };
 }
 

--- a/packages/cli/src/serve/channel-loop-mcp-ipc.test.ts
+++ b/packages/cli/src/serve/channel-loop-mcp-ipc.test.ts
@@ -1,0 +1,158 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ChannelLoopMcpWorkerHost,
+  isChannelLoopMcpControlMessage,
+  isChannelLoopMcpRequestMessage,
+  isChannelLoopMcpResultMessage,
+  type ChannelLoopMcpIpcSend,
+} from './channel-loop-mcp-ipc.js';
+
+async function drainMicrotasks(): Promise<void> {
+  for (let index = 0; index < 10; index += 1) {
+    await Promise.resolve();
+  }
+}
+
+describe('ChannelLoopMcpWorkerHost', () => {
+  it('installs the exact-session handler before registration is acknowledged', async () => {
+    const sent: unknown[] = [];
+    const handler = vi.fn(async (message: Record<string, unknown>) => ({
+      jsonrpc: '2.0',
+      id: message['id'],
+      result: { tools: [] },
+    }));
+    const send: ChannelLoopMcpIpcSend = (message) => {
+      sent.push(message);
+      if (isChannelLoopMcpControlMessage(message)) {
+        expect(
+          host.handleMessage({
+            type: 'channel_loop_mcp_message',
+            id: 'request-1',
+            sessionId: message.sessionId,
+            payload: { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+          }),
+        ).toBe(true);
+        host.handleMessage({
+          type: 'channel_loop_mcp_control_result',
+          id: message.id,
+          ok: true,
+        });
+      }
+      return true;
+    };
+    const host = new ChannelLoopMcpWorkerHost(send);
+
+    await host.register('session-1', handler);
+    await drainMicrotasks();
+
+    expect(handler).toHaveBeenCalledWith({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/list',
+    });
+    expect(sent).toContainEqual({
+      type: 'channel_loop_mcp_result',
+      id: 'request-1',
+      ok: true,
+      payload: { jsonrpc: '2.0', id: 1, result: { tools: [] } },
+    });
+  });
+
+  it('rejects a request for a sibling session', async () => {
+    const sent: unknown[] = [];
+    const host = new ChannelLoopMcpWorkerHost((message) => {
+      sent.push(message);
+      return true;
+    });
+
+    expect(
+      host.handleMessage({
+        type: 'channel_loop_mcp_message',
+        id: 'request-2',
+        sessionId: 'session-2',
+        payload: { jsonrpc: '2.0', id: 2, method: 'tools/list' },
+      }),
+    ).toBe(true);
+    await drainMicrotasks();
+
+    expect(sent).toContainEqual({
+      type: 'channel_loop_mcp_result',
+      id: 'request-2',
+      ok: false,
+      error: 'No channel loop MCP handler for this session.',
+    });
+  });
+
+  it('returns a valid bounded error when a handler throws an empty error', async () => {
+    const sent: unknown[] = [];
+    const host = new ChannelLoopMcpWorkerHost((message) => {
+      sent.push(message);
+      if (isChannelLoopMcpControlMessage(message)) {
+        host.handleMessage({
+          type: 'channel_loop_mcp_control_result',
+          id: message.id,
+          ok: true,
+        });
+      }
+      return true;
+    });
+    await host.register('session-1', async () => {
+      throw new Error('');
+    });
+
+    host.handleMessage({
+      type: 'channel_loop_mcp_message',
+      id: 'request-empty-error',
+      sessionId: 'session-1',
+      payload: { jsonrpc: '2.0', id: 3, method: 'tools/call' },
+    });
+    await drainMicrotasks();
+
+    const result = sent.find(
+      (message) =>
+        (message as { type?: string }).type === 'channel_loop_mcp_result',
+    );
+    expect(result).toEqual({
+      type: 'channel_loop_mcp_result',
+      id: 'request-empty-error',
+      ok: false,
+      error: 'Channel loop MCP request failed.',
+    });
+    expect(isChannelLoopMcpResultMessage(result)).toBe(true);
+  });
+});
+
+describe('channel loop MCP IPC validation', () => {
+  it('accepts bounded messages and rejects malformed payloads', () => {
+    expect(
+      isChannelLoopMcpRequestMessage({
+        type: 'channel_loop_mcp_message',
+        id: 'request',
+        sessionId: 'session',
+        payload: { jsonrpc: '2.0', method: 'ping' },
+      }),
+    ).toBe(true);
+    expect(
+      isChannelLoopMcpRequestMessage({
+        type: 'channel_loop_mcp_message',
+        id: 'request',
+        sessionId: '',
+        payload: { jsonrpc: '2.0' },
+      }),
+    ).toBe(false);
+    expect(
+      isChannelLoopMcpResultMessage({
+        type: 'channel_loop_mcp_result',
+        id: 'request',
+        ok: true,
+        payload: { jsonrpc: '2.0', id: 1, result: {} },
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/cli/src/serve/channel-loop-mcp-ipc.ts
+++ b/packages/cli/src/serve/channel-loop-mcp-ipc.ts
@@ -1,0 +1,291 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { DaemonChannelLoopMcpHost } from '@qwen-code/channel-base';
+
+export const CHANNEL_LOOP_MCP_IPC_TIMEOUT_MS = 30_000;
+export const MAX_CHANNEL_LOOP_MCP_IN_FLIGHT = 64;
+const MAX_IPC_ID_LENGTH = 128;
+const MAX_SESSION_ID_LENGTH = 512;
+const MAX_ERROR_LENGTH = 512;
+
+type JsonRpcMessage = Record<string, unknown>;
+
+export interface ChannelLoopMcpRegisterMessage {
+  type: 'channel_loop_mcp_register';
+  id: string;
+  sessionId: string;
+}
+
+export interface ChannelLoopMcpUnregisterMessage {
+  type: 'channel_loop_mcp_unregister';
+  id: string;
+  sessionId: string;
+}
+
+export interface ChannelLoopMcpControlResultMessage {
+  type: 'channel_loop_mcp_control_result';
+  id: string;
+  ok: boolean;
+  error?: string;
+}
+
+export interface ChannelLoopMcpRequestMessage {
+  type: 'channel_loop_mcp_message';
+  id: string;
+  sessionId: string;
+  payload: JsonRpcMessage;
+}
+
+export interface ChannelLoopMcpResultMessage {
+  type: 'channel_loop_mcp_result';
+  id: string;
+  ok: boolean;
+  payload?: JsonRpcMessage;
+  error?: string;
+}
+
+export type ChannelLoopMcpControlMessage =
+  | ChannelLoopMcpRegisterMessage
+  | ChannelLoopMcpUnregisterMessage;
+
+export type ChannelLoopMcpIpcSend = (
+  message: unknown,
+  callback?: (error: Error | null) => void,
+) => boolean;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isBoundedString(value: unknown, maxLength: number): value is string {
+  return (
+    typeof value === 'string' && value.length > 0 && value.length <= maxLength
+  );
+}
+
+function isBaseMessage(
+  value: unknown,
+): value is Record<string, unknown> & { id: string } {
+  return isRecord(value) && isBoundedString(value['id'], MAX_IPC_ID_LENGTH);
+}
+
+export function isChannelLoopMcpControlMessage(
+  value: unknown,
+): value is ChannelLoopMcpControlMessage {
+  return (
+    isBaseMessage(value) &&
+    (value['type'] === 'channel_loop_mcp_register' ||
+      value['type'] === 'channel_loop_mcp_unregister') &&
+    isBoundedString(value['sessionId'], MAX_SESSION_ID_LENGTH)
+  );
+}
+
+export function isChannelLoopMcpControlResultMessage(
+  value: unknown,
+): value is ChannelLoopMcpControlResultMessage {
+  return (
+    isBaseMessage(value) &&
+    value['type'] === 'channel_loop_mcp_control_result' &&
+    typeof value['ok'] === 'boolean' &&
+    (value['error'] === undefined ||
+      isBoundedString(value['error'], MAX_ERROR_LENGTH))
+  );
+}
+
+export function isChannelLoopMcpRequestMessage(
+  value: unknown,
+): value is ChannelLoopMcpRequestMessage {
+  return (
+    isBaseMessage(value) &&
+    value['type'] === 'channel_loop_mcp_message' &&
+    isBoundedString(value['sessionId'], MAX_SESSION_ID_LENGTH) &&
+    isRecord(value['payload'])
+  );
+}
+
+export function isChannelLoopMcpResultMessage(
+  value: unknown,
+): value is ChannelLoopMcpResultMessage {
+  return (
+    isBaseMessage(value) &&
+    value['type'] === 'channel_loop_mcp_result' &&
+    typeof value['ok'] === 'boolean' &&
+    (value['payload'] === undefined || isRecord(value['payload'])) &&
+    (value['error'] === undefined ||
+      isBoundedString(value['error'], MAX_ERROR_LENGTH))
+  );
+}
+
+export function createChannelLoopMcpRequest(
+  sessionId: string,
+  payload: unknown,
+): ChannelLoopMcpRequestMessage {
+  if (!isBoundedString(sessionId, MAX_SESSION_ID_LENGTH)) {
+    throw new Error('Invalid channel loop MCP session id.');
+  }
+  if (!isRecord(payload)) {
+    throw new Error('Invalid channel loop MCP payload.');
+  }
+  return {
+    type: 'channel_loop_mcp_message',
+    id: randomUUID(),
+    sessionId,
+    payload,
+  };
+}
+
+export class ChannelLoopMcpWorkerHost implements DaemonChannelLoopMcpHost {
+  private readonly handlers = new Map<
+    string,
+    (message: JsonRpcMessage) => Promise<JsonRpcMessage | undefined>
+  >();
+  private readonly pending = new Map<
+    string,
+    {
+      resolve: () => void;
+      reject: (error: Error) => void;
+      timer: NodeJS.Timeout;
+    }
+  >();
+  private disposed = false;
+
+  constructor(private readonly send: ChannelLoopMcpIpcSend) {}
+
+  async register(
+    sessionId: string,
+    handler: (message: JsonRpcMessage) => Promise<JsonRpcMessage | undefined>,
+  ): Promise<void> {
+    this.handlers.set(sessionId, handler);
+    try {
+      await this.sendControl('channel_loop_mcp_register', sessionId);
+    } catch (error) {
+      if (this.handlers.get(sessionId) === handler) {
+        this.handlers.delete(sessionId);
+      }
+      throw error;
+    }
+  }
+
+  async unregister(sessionId: string): Promise<void> {
+    this.handlers.delete(sessionId);
+    await this.sendControl('channel_loop_mcp_unregister', sessionId);
+  }
+
+  handleMessage(value: unknown): boolean {
+    if (isChannelLoopMcpControlResultMessage(value)) {
+      const pending = this.pending.get(value.id);
+      if (!pending) return true;
+      this.pending.delete(value.id);
+      clearTimeout(pending.timer);
+      if (value.ok) pending.resolve();
+      else pending.reject(new Error(value.error ?? 'Channel loop MCP failed.'));
+      return true;
+    }
+    if (!isChannelLoopMcpRequestMessage(value)) return false;
+    void this.handleRequest(value);
+    return true;
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.handlers.clear();
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error('Channel loop MCP IPC closed.'));
+    }
+    this.pending.clear();
+  }
+
+  private sendControl(
+    type: ChannelLoopMcpControlMessage['type'],
+    sessionId: string,
+  ): Promise<void> {
+    if (this.disposed) {
+      return Promise.reject(new Error('Channel loop MCP IPC is closed.'));
+    }
+    if (!isBoundedString(sessionId, MAX_SESSION_ID_LENGTH)) {
+      return Promise.reject(new Error('Invalid channel loop MCP session id.'));
+    }
+    if (this.pending.size >= MAX_CHANNEL_LOOP_MCP_IN_FLIGHT) {
+      return Promise.reject(new Error('Channel loop MCP IPC queue is full.'));
+    }
+    const id = randomUUID();
+    const message: ChannelLoopMcpControlMessage = { type, id, sessionId };
+    return new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error('Channel loop MCP IPC timed out.'));
+      }, CHANNEL_LOOP_MCP_IPC_TIMEOUT_MS);
+      timer.unref();
+      this.pending.set(id, { resolve, reject, timer });
+      try {
+        this.send(message, (error) => {
+          if (!error) return;
+          const pending = this.pending.get(id);
+          if (!pending) return;
+          this.pending.delete(id);
+          clearTimeout(pending.timer);
+          pending.reject(new Error('Channel loop MCP IPC send failed.'));
+        });
+      } catch {
+        const pending = this.pending.get(id);
+        if (!pending) return;
+        this.pending.delete(id);
+        clearTimeout(pending.timer);
+        pending.reject(new Error('Channel loop MCP IPC send failed.'));
+      }
+    });
+  }
+
+  private async handleRequest(
+    message: ChannelLoopMcpRequestMessage,
+  ): Promise<void> {
+    const handler = this.handlers.get(message.sessionId);
+    if (!handler) {
+      this.sendResult(message.id, {
+        ok: false,
+        error: 'No channel loop MCP handler for this session.',
+      });
+      return;
+    }
+    try {
+      const payload = await handler(message.payload);
+      this.sendResult(message.id, {
+        ok: true,
+        payload: payload ?? { jsonrpc: '2.0', id: 0, result: {} },
+      });
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error
+          ? error.message.slice(0, MAX_ERROR_LENGTH)
+          : 'Channel loop MCP request failed.';
+      this.sendResult(message.id, {
+        ok: false,
+        error: errorMessage || 'Channel loop MCP request failed.',
+      });
+    }
+  }
+
+  private sendResult(
+    id: string,
+    result:
+      | { ok: true; payload: JsonRpcMessage }
+      | { ok: false; error: string },
+  ): void {
+    try {
+      this.send({
+        type: 'channel_loop_mcp_result',
+        id,
+        ...result,
+      } satisfies ChannelLoopMcpResultMessage);
+    } catch {
+      // The parent request owns the timeout when IPC is already closed.
+    }
+  }
+}

--- a/packages/cli/src/serve/channel-worker-group.test.ts
+++ b/packages/cli/src/serve/channel-worker-group.test.ts
@@ -5,8 +5,12 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import type { ChannelWebhookTask } from '@qwen-code/channel-base';
+import {
+  CHANNEL_LOOP_MCP_SERVER_NAME,
+  type ChannelWebhookTask,
+} from '@qwen-code/channel-base';
 import { createChannelWorkerGroup } from './channel-worker-group.js';
+import { ClientMcpSenderRegistry } from './acp-http/client-mcp-sender-registry.js';
 import type {
   ChannelWorkerSnapshot,
   ChannelWorkerSupervisor,
@@ -137,6 +141,82 @@ const deliveryRequest: ChannelDeliveryRequest = {
 };
 
 describe('createChannelWorkerGroup', () => {
+  it('wires loop MCP to the exact workspace session with owner-safe cleanup', async () => {
+    const addSessionRuntimeMcpServer = vi.fn(async () => ({ toolCount: 3 }));
+    const removeSessionRuntimeMcpServer = vi.fn(async () => ({}));
+    const clientMcpSenderRegistry = new ClientMcpSenderRegistry();
+    const secondary = {
+      ...fakeRuntime(SECONDARY, false),
+      bridge: {
+        addSessionRuntimeMcpServer,
+        removeSessionRuntimeMcpServer,
+      },
+      clientMcpSenderRegistry,
+    } as unknown as WorkspaceRuntime;
+    const registry = fakeRegistry([fakeRuntime(PRIMARY, true), secondary]);
+    const { createSupervisor, recorded } = makeCreateSupervisor(() =>
+      snapshot({}),
+    );
+    createChannelWorkerGroup({
+      groups: [
+        {
+          workspaceCwd: SECONDARY,
+          selection: { mode: 'names', names: ['b'] },
+        },
+      ],
+      registry,
+      createSupervisor,
+      shared,
+    });
+    const oldSender = vi.fn(async (payload: unknown) => payload);
+
+    await recorded[0]!.opts.registerChannelLoopMcp?.({
+      sessionId: 'session-1',
+      ownerId: 'worker-old',
+      sendMessage: oldSender,
+    });
+
+    expect(addSessionRuntimeMcpServer).toHaveBeenCalledWith(
+      'session-1',
+      CHANNEL_LOOP_MCP_SERVER_NAME,
+      {
+        type: 'sdk',
+        __clientMcpOverWs: true,
+      },
+      'worker-old',
+    );
+    const reverseSender = clientMcpSenderRegistry.lookup(
+      CHANNEL_LOOP_MCP_SERVER_NAME,
+    );
+    await expect(
+      reverseSender?.(
+        { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+        { sessionId: 'session-1' },
+      ),
+    ).resolves.toMatchObject({ method: 'tools/list' });
+    expect(oldSender).toHaveBeenCalledOnce();
+
+    const newSender = vi.fn(async () => ({ owner: 'new' }));
+    clientMcpSenderRegistry.setSession(
+      CHANNEL_LOOP_MCP_SERVER_NAME,
+      'session-1',
+      newSender,
+      'worker-new',
+    );
+    await recorded[0]!.opts.unregisterChannelLoopMcp?.(
+      'session-1',
+      'worker-old',
+    );
+
+    expect(removeSessionRuntimeMcpServer).not.toHaveBeenCalled();
+    await expect(
+      clientMcpSenderRegistry.lookup(CHANNEL_LOOP_MCP_SERVER_NAME)?.(
+        { jsonrpc: '2.0', id: 2, method: 'ping' },
+        { sessionId: 'session-1' },
+      ),
+    ).resolves.toEqual({ owner: 'new' });
+  });
+
   it('routes delivery to the exact workspace owner', async () => {
     const registry = fakeRegistry([
       fakeRuntime(PRIMARY, true),

--- a/packages/cli/src/serve/channel-worker-group.ts
+++ b/packages/cli/src/serve/channel-worker-group.ts
@@ -18,7 +18,7 @@ import {
   CLIENT_MCP_OVER_WS_CONFIG_FLAG,
   type ClientMcpOverWsRuntimeConfig,
 } from '@qwen-code/acp-bridge/bridgeTypes';
-import { SessionNotFoundError } from './acp-session-bridge.js';
+import { SessionNotFoundError } from '@qwen-code/acp-bridge/bridgeErrors';
 import { ChannelDeliveryError } from './channel-delivery-ipc.js';
 import { ChannelWebhookEnqueueError } from './channel-webhook-ipc.js';
 import type { ChannelWorkspaceGroup } from './channel-workspace-grouping.js';

--- a/packages/cli/src/serve/channel-worker-group.ts
+++ b/packages/cli/src/serve/channel-worker-group.ts
@@ -13,6 +13,12 @@ import type {
   CreateChannelWorkerSupervisorOptions,
 } from './channel-worker-supervisor.js';
 import { ChannelWorkerStartupError } from './channel-worker-supervisor.js';
+import { CHANNEL_LOOP_MCP_SERVER_NAME } from '@qwen-code/channel-base';
+import {
+  CLIENT_MCP_OVER_WS_CONFIG_FLAG,
+  type ClientMcpOverWsRuntimeConfig,
+} from '@qwen-code/acp-bridge/bridgeTypes';
+import { SessionNotFoundError } from './acp-session-bridge.js';
 import { ChannelDeliveryError } from './channel-delivery-ipc.js';
 import { ChannelWebhookEnqueueError } from './channel-webhook-ipc.js';
 import type { ChannelWorkspaceGroup } from './channel-workspace-grouping.js';
@@ -242,6 +248,84 @@ export function createChannelWorkerGroup(
       ...(opts.shared.heartbeatTimeoutMs !== undefined
         ? { heartbeatTimeoutMs: opts.shared.heartbeatTimeoutMs }
         : {}),
+      registerChannelLoopMcp: async ({ sessionId, ownerId, sendMessage }) => {
+        runtime.clientMcpSenderRegistry.setSession(
+          CHANNEL_LOOP_MCP_SERVER_NAME,
+          sessionId,
+          sendMessage,
+          ownerId,
+        );
+        try {
+          const config: ClientMcpOverWsRuntimeConfig = {
+            type: 'sdk',
+            [CLIENT_MCP_OVER_WS_CONFIG_FLAG]: true,
+          };
+          const result = await runtime.bridge.addSessionRuntimeMcpServer(
+            sessionId,
+            CHANNEL_LOOP_MCP_SERVER_NAME,
+            config,
+            ownerId,
+          );
+          if ((result as { skipped?: boolean }).skipped) {
+            throw new Error(
+              `runtime MCP add skipped: ${
+                (result as { reason?: string }).reason ?? 'unknown'
+              }`,
+            );
+          }
+          if ((result as { shadowedSettings?: boolean }).shadowedSettings) {
+            throw new Error(
+              `channel loop MCP server conflicts with a configured MCP server`,
+            );
+          }
+          if (
+            !runtime.clientMcpSenderRegistry.ownsSession(
+              CHANNEL_LOOP_MCP_SERVER_NAME,
+              sessionId,
+              ownerId,
+            )
+          ) {
+            throw new Error('Channel loop MCP registration was superseded.');
+          }
+        } catch (error) {
+          if (
+            runtime.clientMcpSenderRegistry.deleteSession(
+              CHANNEL_LOOP_MCP_SERVER_NAME,
+              sessionId,
+              ownerId,
+            )
+          ) {
+            await runtime.bridge
+              .removeSessionRuntimeMcpServer(
+                sessionId,
+                CHANNEL_LOOP_MCP_SERVER_NAME,
+                ownerId,
+              )
+              .catch(() => {});
+          }
+          throw error;
+        }
+      },
+      unregisterChannelLoopMcp: async (sessionId, ownerId) => {
+        if (
+          !runtime.clientMcpSenderRegistry.deleteSession(
+            CHANNEL_LOOP_MCP_SERVER_NAME,
+            sessionId,
+            ownerId,
+          )
+        ) {
+          return;
+        }
+        try {
+          await runtime.bridge.removeSessionRuntimeMcpServer(
+            sessionId,
+            CHANNEL_LOOP_MCP_SERVER_NAME,
+            ownerId,
+          );
+        } catch (error) {
+          if (!(error instanceof SessionNotFoundError)) throw error;
+        }
+      },
       ...(opts.onReady
         ? {
             onReady: (snapshot) => {

--- a/packages/cli/src/serve/channel-worker-supervisor.test.ts
+++ b/packages/cli/src/serve/channel-worker-supervisor.test.ts
@@ -59,6 +59,131 @@ describe('createChannelWorkerSupervisor', () => {
     vi.unstubAllEnvs();
   });
 
+  it('accepts loop MCP registration before the worker ready signal', async () => {
+    const child = new FakeChild();
+    const registerChannelLoopMcp = vi.fn(async () => {});
+    const unregisterChannelLoopMcp = vi.fn(async () => {});
+    const supervisor = createChannelWorkerSupervisor({
+      cliEntryPath: '/repo/dist/index.js',
+      daemonUrl: 'http://127.0.0.1:4170',
+      workspace: '/workspace',
+      selection: { mode: 'names', names: ['telegram'] },
+      spawnWorker: vi.fn(() => child),
+      registerChannelLoopMcp,
+      unregisterChannelLoopMcp,
+    });
+    const started = supervisor.start();
+
+    child.emit('message', {
+      type: 'channel_loop_mcp_register',
+      id: 'register-before-ready',
+      sessionId: 'session-early',
+    });
+
+    await vi.waitFor(() =>
+      expect(registerChannelLoopMcp).toHaveBeenCalledWith({
+        sessionId: 'session-early',
+        ownerId: expect.stringMatching(/^channel-worker:/),
+        sendMessage: expect.any(Function),
+      }),
+    );
+    await vi.waitFor(() =>
+      expect(child.send).toHaveBeenCalledWith({
+        type: 'channel_loop_mcp_control_result',
+        id: 'register-before-ready',
+        ok: true,
+      }),
+    );
+
+    child.emit('message', {
+      type: 'ready',
+      channels: ['telegram'],
+    });
+    await started;
+    await supervisor.stop();
+  });
+
+  it('correlates exact-session loop MCP traffic and unregisters on exit', async () => {
+    const child = new FakeChild();
+    let reverseSender: ((payload: unknown) => Promise<unknown>) | undefined;
+    let ownerId: string | undefined;
+    const registerChannelLoopMcp = vi.fn(
+      async (request: {
+        sessionId: string;
+        ownerId: string;
+        sendMessage: (payload: unknown) => Promise<unknown>;
+      }) => {
+        ownerId = request.ownerId;
+        reverseSender = request.sendMessage;
+      },
+    );
+    const unregisterChannelLoopMcp = vi.fn(async () => {});
+    const supervisor = createChannelWorkerSupervisor({
+      cliEntryPath: '/repo/dist/index.js',
+      daemonUrl: 'http://127.0.0.1:4170',
+      workspace: '/workspace',
+      selection: { mode: 'names', names: ['telegram'] },
+      spawnWorker: vi.fn(() => child),
+      registerChannelLoopMcp,
+      unregisterChannelLoopMcp,
+    });
+    const started = supervisor.start();
+    child.emit('message', {
+      type: 'ready',
+      channels: ['telegram'],
+    });
+    await started;
+
+    child.emit('message', {
+      type: 'channel_loop_mcp_register',
+      id: 'register-1',
+      sessionId: 'session-1',
+    });
+    await vi.waitFor(() => expect(registerChannelLoopMcp).toHaveBeenCalled());
+    expect(registerChannelLoopMcp).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      ownerId: expect.stringMatching(/^channel-worker:/),
+      sendMessage: expect.any(Function),
+    });
+    await vi.waitFor(() =>
+      expect(child.send).toHaveBeenCalledWith({
+        type: 'channel_loop_mcp_control_result',
+        id: 'register-1',
+        ok: true,
+      }),
+    );
+
+    const response = reverseSender?.({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/list',
+    });
+    const request = child.send.mock.calls
+      .map(([message]) => message)
+      .find(
+        (message) =>
+          (message as { type?: string }).type === 'channel_loop_mcp_message',
+      ) as { id: string; sessionId: string };
+    expect(request.sessionId).toBe('session-1');
+    child.emit('message', {
+      type: 'channel_loop_mcp_result',
+      id: request.id,
+      ok: true,
+      payload: { jsonrpc: '2.0', id: 1, result: { tools: [] } },
+    });
+    await expect(response).resolves.toMatchObject({
+      result: { tools: [] },
+    });
+
+    await supervisor.stop();
+    await vi.waitFor(() =>
+      expect(unregisterChannelLoopMcp).toHaveBeenCalledWith(
+        'session-1',
+        ownerId,
+      ),
+    );
+  });
+
   it('passes daemon connection details through env without putting token in argv', async () => {
     vi.stubEnv('QWEN_SERVER_TOKEN', 'serve-token');
     vi.stubEnv('QWEN_DAEMON_TOKEN', 'stale-daemon-token');

--- a/packages/cli/src/serve/channel-worker-supervisor.ts
+++ b/packages/cli/src/serve/channel-worker-supervisor.ts
@@ -53,6 +53,15 @@ import {
   type ChannelAdapterSnapshot,
   type ChannelStartupFailure,
 } from './channel-worker-startup-ipc.js';
+import {
+  CHANNEL_LOOP_MCP_IPC_TIMEOUT_MS,
+  createChannelLoopMcpRequest,
+  isChannelLoopMcpControlMessage,
+  isChannelLoopMcpResultMessage,
+  MAX_CHANNEL_LOOP_MCP_IN_FLIGHT,
+  type ChannelLoopMcpControlMessage,
+  type ChannelLoopMcpIpcSend,
+} from './channel-loop-mcp-ipc.js';
 
 const DEFAULT_CHANNEL_WORKER_HEARTBEAT_TIMEOUT_MS = 45_000;
 const MAX_WORKER_LOG_LINE_LENGTH = 4096;
@@ -215,6 +224,15 @@ export interface CreateChannelWorkerSupervisorOptions {
   onLog?: (entry: ChannelWorkerLogEntry) => void;
   restartPolicy?: ChannelWorkerRestartPolicy;
   heartbeatTimeoutMs?: number;
+  registerChannelLoopMcp?: (request: {
+    sessionId: string;
+    ownerId: string;
+    sendMessage: (payload: unknown) => Promise<unknown>;
+  }) => Promise<void>;
+  unregisterChannelLoopMcp?: (
+    sessionId: string,
+    ownerId: string,
+  ) => Promise<void>;
 }
 
 function selectionChannelArgs(selection: ServeChannelSelection): string[] {
@@ -494,6 +512,15 @@ export function createChannelWorkerSupervisor(
       timer: NodeJS.Timeout;
     }
   >();
+  const pendingChannelLoopMcpMessages = new Map<
+    string,
+    {
+      resolve: (payload: unknown) => void;
+      reject: (error: Error) => void;
+      timer: NodeJS.Timeout;
+    }
+  >();
+  let cleanupChannelLoopMcpRegistrations: (() => void) | undefined;
   let restarting: Promise<ChannelWorkerSnapshot> | undefined;
   let disposed = false;
 
@@ -609,6 +636,30 @@ export function createChannelWorkerSupervisor(
           message.code,
           message.error || 'Channel delivery failed.',
         ),
+      );
+    }
+    return true;
+  };
+
+  const rejectPendingChannelLoopMcpMessages = (message: string) => {
+    for (const pending of pendingChannelLoopMcpMessages.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error(message));
+    }
+    pendingChannelLoopMcpMessages.clear();
+  };
+
+  const settleChannelLoopMcpMessage = (message: unknown): boolean => {
+    if (!isChannelLoopMcpResultMessage(message)) return false;
+    const pending = pendingChannelLoopMcpMessages.get(message.id);
+    if (!pending) return true;
+    pendingChannelLoopMcpMessages.delete(message.id);
+    clearTimeout(pending.timer);
+    if (message.ok) {
+      pending.resolve(message.payload ?? {});
+    } else {
+      pending.reject(
+        new Error(message.error ?? 'Channel loop MCP request failed.'),
       );
     }
     return true;
@@ -801,6 +852,67 @@ export function createChannelWorkerSupervisor(
     if (startedChild.pid !== undefined) {
       snapshot = { ...snapshot, pid: startedChild.pid };
     }
+
+    const channelLoopMcpOwnerId = `channel-worker:${randomUUID()}`;
+    const registeredChannelLoopMcpSessions = new Set<string>();
+    const activeChannelLoopMcpControls = new Set<string>();
+    const sendToStartedChild: ChannelLoopMcpIpcSend = (message, callback) => {
+      if (child !== startedChild || !startedChild.send) {
+        throw new Error('Channel worker IPC is unavailable.');
+      }
+      return callback
+        ? startedChild.send.call(startedChild, message, callback)
+        : startedChild.send.call(startedChild, message);
+    };
+    const sendChannelLoopMcpMessage = (
+      sessionId: string,
+      payload: unknown,
+    ): Promise<unknown> => {
+      if (
+        pendingChannelLoopMcpMessages.size >= MAX_CHANNEL_LOOP_MCP_IN_FLIGHT
+      ) {
+        return Promise.reject(new Error('Channel loop MCP IPC queue is full.'));
+      }
+      const message = createChannelLoopMcpRequest(sessionId, payload);
+      return new Promise<unknown>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          pendingChannelLoopMcpMessages.delete(message.id);
+          reject(new Error('Channel loop MCP IPC timed out.'));
+        }, CHANNEL_LOOP_MCP_IPC_TIMEOUT_MS);
+        timer.unref();
+        pendingChannelLoopMcpMessages.set(message.id, {
+          resolve,
+          reject,
+          timer,
+        });
+        try {
+          sendToStartedChild(message, (error) => {
+            if (!error) return;
+            const pending = pendingChannelLoopMcpMessages.get(message.id);
+            if (!pending) return;
+            pendingChannelLoopMcpMessages.delete(message.id);
+            clearTimeout(pending.timer);
+            pending.reject(new Error('Channel loop MCP IPC send failed.'));
+          });
+        } catch {
+          const pending = pendingChannelLoopMcpMessages.get(message.id);
+          if (!pending) return;
+          pendingChannelLoopMcpMessages.delete(message.id);
+          clearTimeout(pending.timer);
+          pending.reject(new Error('Channel loop MCP IPC send failed.'));
+        }
+      });
+    };
+    const cleanupLaunchChannelLoopMcpRegistrations = () => {
+      for (const sessionId of registeredChannelLoopMcpSessions) {
+        void opts
+          .unregisterChannelLoopMcp?.(sessionId, channelLoopMcpOwnerId)
+          .catch(() => {});
+      }
+      registeredChannelLoopMcpSessions.clear();
+    };
+    cleanupChannelLoopMcpRegistrations =
+      cleanupLaunchChannelLoopMcpRegistrations;
 
     await new Promise<void>((resolve, reject) => {
       let settled = false;
@@ -1028,12 +1140,95 @@ export function createChannelWorkerSupervisor(
         };
         armStaleHeartbeatTimer(startedChild);
       };
+      const sendChannelLoopMcpControlResult = (
+        id: string,
+        result: { ok: true } | { ok: false; error: string },
+      ) => {
+        try {
+          sendToStartedChild({
+            type: 'channel_loop_mcp_control_result',
+            id,
+            ...result,
+          });
+        } catch {
+          // The worker request owns the timeout when IPC is already closed.
+        }
+      };
+      const handleChannelLoopMcpControl = (
+        message: ChannelLoopMcpControlMessage,
+      ) => {
+        if (
+          activeChannelLoopMcpControls.size >= MAX_CHANNEL_LOOP_MCP_IN_FLIGHT
+        ) {
+          sendChannelLoopMcpControlResult(message.id, {
+            ok: false,
+            error: 'Channel loop MCP IPC queue is full.',
+          });
+          return;
+        }
+        activeChannelLoopMcpControls.add(message.id);
+        const operation =
+          message.type === 'channel_loop_mcp_register'
+            ? (opts
+                .registerChannelLoopMcp?.({
+                  sessionId: message.sessionId,
+                  ownerId: channelLoopMcpOwnerId,
+                  sendMessage: (payload) =>
+                    sendChannelLoopMcpMessage(message.sessionId, payload),
+                })
+                .then(async () => {
+                  if (child !== startedChild) {
+                    await opts.unregisterChannelLoopMcp?.(
+                      message.sessionId,
+                      channelLoopMcpOwnerId,
+                    );
+                    throw new Error('Channel worker exited during MCP setup.');
+                  }
+                  registeredChannelLoopMcpSessions.add(message.sessionId);
+                }) ??
+              Promise.reject(
+                new Error('Channel loop MCP registration is unavailable.'),
+              ))
+            : (opts
+                .unregisterChannelLoopMcp?.(
+                  message.sessionId,
+                  channelLoopMcpOwnerId,
+                )
+                .then(() => {
+                  registeredChannelLoopMcpSessions.delete(message.sessionId);
+                }) ?? Promise.resolve());
+        void operation
+          .then(() => {
+            sendChannelLoopMcpControlResult(message.id, { ok: true });
+          })
+          .catch((error: unknown) => {
+            sendChannelLoopMcpControlResult(message.id, {
+              ok: false,
+              error:
+                sanitizeWorkerDiagnostic(
+                  error instanceof Error ? error.message : String(error),
+                  512,
+                  redaction,
+                ) || 'Channel loop MCP operation failed.',
+            });
+          })
+          .finally(() => {
+            activeChannelLoopMcpControls.delete(message.id);
+          });
+      };
       function handleMessage(message: unknown) {
         if (child !== startedChild) return;
         if (settleChannelDelivery(message)) {
           return;
         }
         if (settleWebhookTask(message)) {
+          return;
+        }
+        if (settleChannelLoopMcpMessage(message)) {
+          return;
+        }
+        if (isChannelLoopMcpControlMessage(message)) {
+          handleChannelLoopMcpControl(message);
           return;
         }
         if (!ready && isChannelStartupReportType(message)) {
@@ -1065,6 +1260,14 @@ export function createChannelWorkerSupervisor(
           'channel_worker_unavailable',
           'Channel worker exited.',
         );
+        rejectPendingChannelLoopMcpMessages('Channel worker exited.');
+        cleanupLaunchChannelLoopMcpRegistrations();
+        if (
+          cleanupChannelLoopMcpRegistrations ===
+          cleanupLaunchChannelLoopMcpRegistrations
+        ) {
+          cleanupChannelLoopMcpRegistrations = undefined;
+        }
         child = undefined;
         if ((ready || kind === 'restart') && !stopping) {
           scheduleRestart();
@@ -1147,6 +1350,7 @@ export function createChannelWorkerSupervisor(
         'channel_worker_unavailable',
         'Channel worker stopped.',
       );
+      rejectPendingChannelLoopMcpMessages('Channel worker stopped.');
       if (
         !child ||
         snapshot.state === 'exited' ||
@@ -1208,6 +1412,9 @@ export function createChannelWorkerSupervisor(
         'channel_worker_unavailable',
         'Channel worker stopped.',
       );
+      rejectPendingChannelLoopMcpMessages('Channel worker stopped.');
+      cleanupChannelLoopMcpRegistrations?.();
+      cleanupChannelLoopMcpRegistrations = undefined;
       if (
         !child ||
         snapshot.state === 'exited' ||


### PR DESCRIPTION
## What this PR does

Daemon-managed channel sessions now expose the existing channel loop tools through a private, session-scoped MCP server. A channel user can ask the agent in natural language to create, list, or cancel recurring proactive work without leaving the daemon-managed session.

The integration carries MCP control and JSON-RPC traffic between the daemon supervisor and its channel worker, binds every sender to the exact live session and workspace runtime, and removes the binding when the session or worker exits. Requests are correlated, bounded, timed out, and protected by per-worker ownership so a stale worker cannot remove a replacement worker's registration.

The startup path also accepts session MCP registration before the worker emits its ready signal. This matters because channel connection can create a daemon session while the worker is still starting.

## Why it's needed

The daemon worker can already run and deliver recurring channel loops, and the daemon can already add runtime MCP servers to one live session. The missing integration meant daemon-managed channel sessions still could not discover or call the channel loop tools. This completes that path while preserving the key isolation rule: a loop tool registered for one session must never fall back to a sibling session, another workspace runtime, or a same-named global sender.

## Reviewer Test Plan

### How to verify

1. Start a daemon-managed channel with loop scheduling enabled, enter a channel-backed session, and ask the agent to create, list, then cancel a recurring loop. The three channel loop tools should be discoverable and should operate on that chat's loop state.
2. Open a sibling channel session and confirm its list result does not expose the first session's loop. A missing or mismatched session context must fail instead of routing through a same-named global MCP sender.
3. Restart the channel worker and confirm the old session registrations are removed and the replacement worker can register its own senders without stale cleanup deleting them.
4. Exercise channel startup where a session is created before the worker ready signal. MCP registration should complete and startup should continue normally.

### Evidence (Before & After)

Before: daemon-managed channel sessions did not receive the channel loop MCP tools.

After: the tools are installed on the exact live daemon session, requests round-trip through the worker, and registration is cleaned up on session removal, worker exit, restart, and hard shutdown.

Automated evidence: 269 focused tests passed across the daemon channel bridge, daemon worker, sender registry, loop MCP IPC, worker group, and worker supervisor. The full build, TypeScript typecheck, and lint also passed.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS 26.5.1, Node.js 25.9.0, local daemon/channel unit and integration-component tests.

## Risk & Scope

- Main risk or tradeoff: Cross-process registration depends on worker lifecycle ordering. The implementation uses exact-session routing, per-launch owner IDs, bounded in-flight work, timeouts, and cleanup on every worker termination path; regression coverage includes registration before ready.
- Not validated / out of scope: A live external channel end-to-end run was not performed because it requires channel credentials and would send real external messages. Windows and Linux were not tested locally.
- Breaking changes / migration notes: None. Existing standalone channel behavior and global client-hosted MCP registration remain unchanged.

## Linked Issues

Related to #7628. Builds on #7641 and #7847.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

daemon 管理的 channel session 现在会通过一个私有、session-scoped 的 MCP server 暴露已有的 channel loop tools。Channel 用户可以直接用自然语言让 agent 创建、列出或取消周期性主动任务，无需离开 daemon 管理的 session。

这次集成在 daemon supervisor 与 channel worker 之间传递 MCP 控制消息和 JSON-RPC 流量，将每个 sender 绑定到精确的 live session 与 workspace runtime，并在 session 或 worker 退出时移除绑定。请求具有关联 ID、并发上限和超时，并通过每个 worker 独立的 owner 身份保护，避免旧 worker 清理掉替代 worker 的注册。

启动路径现在也允许在 worker 发出 ready 信号之前注册 session MCP。这一点很重要，因为 channel 连接过程可能在 worker 仍处于启动阶段时就创建 daemon session。

## 为什么需要

daemon worker 已经能够运行并投递周期性 channel loop，daemon 也已经能够只向一个 live session 添加 runtime MCP server。缺少的是两者之间的集成，因此 daemon 管理的 channel session 仍然无法发现或调用 channel loop tools。本 PR 补齐这条链路，同时保留关键隔离规则：为某个 session 注册的 loop tool 绝不能回退到 sibling session、其他 workspace runtime 或同名的全局 sender。

## Reviewer 测试计划

### 如何验证

1. 启动已启用 loop 调度的 daemon 管理 channel，进入一个 channel-backed session，并让 agent 创建、列出、再取消一个周期性 loop。三个 channel loop tools 应可被发现，并且只操作当前聊天的 loop 状态。
2. 打开另一个 sibling channel session，确认其列表结果不会暴露第一个 session 的 loop。缺失或不匹配的 session context 必须失败，不能路由到同名的全局 MCP sender。
3. 重启 channel worker，确认旧 session 注册已移除，替代 worker 可以注册自己的 sender，且旧 worker 的清理不会删除新注册。
4. 覆盖 channel 启动期间 session 早于 worker ready 信号创建的场景。MCP 注册应完成，启动过程应正常继续。

### 证据（Before & After）

Before：daemon 管理的 channel session 无法获得 channel loop MCP tools。

After：这些 tools 会安装到精确的 live daemon session，请求可以经由 worker 完成往返，并且注册会在 session 移除、worker 退出、重启和强制关闭时被清理。

自动化证据：daemon channel bridge、daemon worker、sender registry、loop MCP IPC、worker group 和 worker supervisor 共 269 个聚焦测试通过。完整构建、TypeScript 类型检查和 lint 也全部通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS 26.5.1、Node.js 25.9.0，本地 daemon/channel 单元测试与集成组件测试。

## 风险与范围

- 主要风险或取舍：跨进程注册依赖 worker 生命周期顺序。实现使用精确 session 路由、每次启动独立的 owner ID、并发上限、超时以及所有 worker 终止路径上的清理；回归测试包含 ready 之前注册的场景。
- 未验证 / 不在范围内：未执行真实外部 channel 的端到端测试，因为这需要 channel 凭据并会发送真实外部消息。本地未测试 Windows 和 Linux。
- 破坏性变更 / 迁移说明：无。现有 standalone channel 行为和全局 client-hosted MCP 注册保持不变。

## 关联问题

关联 #7628。基于 #7641 和 #7847。

</details>
