### PR TITLE
fix(core): resume long streams cut by a socket-level close

### DIFF
--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -7274,54 +7274,81 @@ describe('GeminiChat', async () => {
       }
     });
 
-    it('does not retry retryable transport stream errors after yielding a content chunk', async () => {
-      const transportError = Object.assign(new TypeError('terminated'), {
-        cause: Object.assign(new Error('other side closed'), {
-          code: 'UND_ERR_SOCKET',
-        }),
-      });
+    it('does not replay a transport stream error after yielding a chunk', async () => {
+      // The replay path stays closed once output has reached callers —
+      // re-sending would duplicate it. Recovery goes through the
+      // continuation path instead (see 'transport stream continuation'
+      // below), which is what the second attempt here is.
+      vi.useFakeTimers();
+      try {
+        const transportError = Object.assign(new TypeError('terminated'), {
+          cause: Object.assign(new Error('other side closed'), {
+            code: 'UND_ERR_SOCKET',
+          }),
+        });
 
-      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
-        (async function* () {
-          yield {
-            candidates: [
-              {
-                content: {
-                  parts: [{ text: 'Partial response before socket close' }],
-                },
-              },
-            ],
-          } as unknown as GenerateContentResponse;
-          throw transportError;
-        })(),
-      );
+        vi.mocked(mockContentGenerator.generateContentStream)
+          .mockResolvedValueOnce(
+            (async function* () {
+              yield {
+                candidates: [
+                  {
+                    content: {
+                      parts: [{ text: 'Partial response before socket close' }],
+                    },
+                  },
+                ],
+              } as unknown as GenerateContentResponse;
+              throw transportError;
+            })(),
+          )
+          .mockResolvedValueOnce(
+            (async function* () {
+              yield {
+                candidates: [
+                  {
+                    content: { parts: [{ text: ' …and the rest.' }] },
+                    finishReason: 'STOP',
+                  },
+                ],
+              } as unknown as GenerateContentResponse;
+            })(),
+          );
 
-      const stream = await chat.sendMessageStream(
-        'test-model',
-        { message: 'test' },
-        'prompt-transport-no-retry-after-chunk',
-      );
-      const events: StreamEvent[] = [];
-      await expect(async () => {
-        for await (const event of stream) {
-          events.push(event);
-        }
-      }).rejects.toThrow('terminated');
+        const stream = await chat.sendMessageStream(
+          'test-model',
+          { message: 'test' },
+          'prompt-transport-no-replay-after-chunk',
+        );
+        const events = await collectStreamWithFakeTimers(stream, 5_000);
 
-      expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(
-        1,
-      );
-      expect(
-        events.filter((event) => event.type === StreamEventType.RETRY),
-      ).toHaveLength(0);
-      expect(
-        events.some(
-          (event) =>
-            event.type === StreamEventType.CHUNK &&
-            event.value.candidates?.[0]?.content?.parts?.[0]?.text ===
-              'Partial response before socket close',
-        ),
-      ).toBe(true);
+        // The second attempt is a continuation, not a replay: its request
+        // carries the delivered text plus a resume instruction rather than
+        // repeating the original contents unchanged.
+        const secondRequest = vi.mocked(
+          mockContentGenerator.generateContentStream,
+        ).mock.calls[1]![0].contents as Content[];
+        expect(secondRequest.at(-2)).toEqual({
+          role: 'model',
+          parts: [{ text: 'Partial response before socket close' }],
+        });
+        expect(
+          events.filter(
+            (event) =>
+              event.type === StreamEventType.RETRY && !event.isContinuation,
+          ),
+        ).toHaveLength(0);
+        expect(
+          events.some(
+            (event) =>
+              event.type === StreamEventType.CHUNK &&
+              event.value.candidates?.[0]?.content?.parts?.[0]?.text ===
+                'Partial response before socket close',
+          ),
+        ).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('retries a transport stream error after yielding only thinking chunks', async () => {
@@ -7396,58 +7423,86 @@ describe('GeminiChat', async () => {
       }
     });
 
-    it('does not retry when visible content followed the thinking chunks', async () => {
+    it('does not replay when visible content followed the thinking chunks', async () => {
       // The content flag must accumulate across the whole attempt: once a
       // non-thought part has flowed — even after any amount of thinking —
-      // a replay would duplicate visible output and stays blocked.
-      const transportError = Object.assign(new TypeError('terminated'), {
-        cause: Object.assign(new Error('other side closed'), {
-          code: 'UND_ERR_SOCKET',
-        }),
-      });
+      // a replay would duplicate visible output and stays blocked. Recovery
+      // goes through the continuation path instead, so the assertion is on
+      // *which* path fired rather than on the request count: a replay resends
+      // the original contents unchanged, a continuation carries the delivered
+      // text and a resume instruction, and only the latter is acceptable here.
+      //
+      // Only the visible text is anchored on. The thought part is excluded
+      // from the continuation prefix as well, so this also covers thoughts not
+      // leaking into the resumed request.
+      vi.useFakeTimers();
+      try {
+        const transportError = Object.assign(new TypeError('terminated'), {
+          cause: Object.assign(new Error('other side closed'), {
+            code: 'UND_ERR_SOCKET',
+          }),
+        });
 
-      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
-        (async function* () {
-          yield {
-            candidates: [
-              {
-                content: {
-                  parts: [{ text: 'Reasoning first…', thought: true }],
-                },
-              },
-            ],
-          } as unknown as GenerateContentResponse;
-          yield {
-            candidates: [
-              {
-                content: {
-                  parts: [{ text: 'Visible answer begins' }],
-                },
-              },
-            ],
-          } as unknown as GenerateContentResponse;
-          throw transportError;
-        })(),
-      );
+        vi.mocked(mockContentGenerator.generateContentStream)
+          .mockResolvedValueOnce(
+            (async function* () {
+              yield {
+                candidates: [
+                  {
+                    content: {
+                      parts: [{ text: 'Reasoning first…', thought: true }],
+                    },
+                  },
+                ],
+              } as unknown as GenerateContentResponse;
+              yield {
+                candidates: [
+                  {
+                    content: {
+                      parts: [{ text: 'Visible answer begins' }],
+                    },
+                  },
+                ],
+              } as unknown as GenerateContentResponse;
+              throw transportError;
+            })(),
+          )
+          .mockResolvedValueOnce(
+            (async function* () {
+              yield {
+                candidates: [
+                  {
+                    content: { parts: [{ text: ' …and ends.' }] },
+                    finishReason: 'STOP',
+                  },
+                ],
+              } as unknown as GenerateContentResponse;
+            })(),
+          );
 
-      const stream = await chat.sendMessageStream(
-        'test-model',
-        { message: 'test' },
-        'prompt-transport-no-retry-after-thinking-then-content',
-      );
-      const events: StreamEvent[] = [];
-      await expect(async () => {
-        for await (const event of stream) {
-          events.push(event);
-        }
-      }).rejects.toThrow('terminated');
+        const stream = await chat.sendMessageStream(
+          'test-model',
+          { message: 'test' },
+          'prompt-transport-no-replay-after-thinking-then-content',
+        );
+        const events = await collectStreamWithFakeTimers(stream, 5_000);
 
-      expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(
-        1,
-      );
-      expect(
-        events.filter((event) => event.type === StreamEventType.RETRY),
-      ).toHaveLength(0);
+        const secondRequest = vi.mocked(
+          mockContentGenerator.generateContentStream,
+        ).mock.calls[1]![0].contents as Content[];
+        expect(secondRequest.at(-2)).toEqual({
+          role: 'model',
+          parts: [{ text: 'Visible answer begins' }],
+        });
+        expect(
+          events.filter(
+            (event) =>
+              event.type === StreamEventType.RETRY && !event.isContinuation,
+          ),
+        ).toHaveLength(0);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('retries a transport stream error after yielding only tool preparation metadata', async () => {
@@ -7503,6 +7558,448 @@ describe('GeminiChat', async () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+
+    describe('transport stream continuation (#7832)', () => {
+      const socketCut = () =>
+        Object.assign(new TypeError('terminated'), {
+          cause: Object.assign(new Error('other side closed'), {
+            code: 'UND_ERR_SOCKET',
+          }),
+        });
+
+      function textChunk(
+        text: string,
+        finishReason?: string,
+      ): GenerateContentResponse {
+        return {
+          candidates: [
+            {
+              content: { role: 'model', parts: [{ text }] },
+              ...(finishReason ? { finishReason } : {}),
+            },
+          ],
+        } as unknown as GenerateContentResponse;
+      }
+
+      /** Stream that yields `chunks` and then dies from a socket cut. */
+      function cutAfter(chunks: GenerateContentResponse[]) {
+        return (async function* () {
+          for (const chunk of chunks) yield chunk;
+          throw socketCut();
+        })();
+      }
+
+      function requestContentsOfCall(index: number): Content[] {
+        return vi.mocked(mockContentGenerator.generateContentStream).mock.calls[
+          index
+        ]![0].contents as Content[];
+      }
+
+      it('continues from the delivered text instead of failing the send', async () => {
+        vi.useFakeTimers();
+        try {
+          vi.mocked(mockContentGenerator.generateContentStream)
+            .mockResolvedValueOnce(cutAfter([textChunk('<html><body>')]))
+            .mockResolvedValueOnce(
+              (async function* () {
+                yield textChunk('</body></html>', 'STOP');
+              })(),
+            );
+
+          const stream = await chat.sendMessageStream(
+            'test-model',
+            { message: 'write a game' },
+            'prompt-transport-continuation',
+          );
+          const events = await collectStreamWithFakeTimers(stream, 5_000);
+
+          expect(
+            mockContentGenerator.generateContentStream,
+          ).toHaveBeenCalledTimes(2);
+
+          // `isContinuation` is what tells the UI to KEEP the text already on
+          // screen. A plain RETRY would make it discard the first half.
+          const retries = events.filter(
+            (event) => event.type === StreamEventType.RETRY,
+          );
+          expect(retries).toHaveLength(1);
+          expect(
+            retries[0]!.type === StreamEventType.RETRY &&
+              retries[0]!.isContinuation,
+          ).toBe(true);
+
+          // The continuation request shows the model its own output and asks
+          // it to resume — it does not re-send the original request alone.
+          const secondRequest = requestContentsOfCall(1);
+          expect(secondRequest.at(-2)).toEqual({
+            role: 'model',
+            parts: [{ text: '<html><body>' }],
+          });
+          const instruction = secondRequest.at(-1)!;
+          expect(instruction.role).toBe('user');
+          expect(instruction.parts?.[0]?.text).toContain(
+            'The connection dropped mid-response',
+          );
+          expect(instruction.parts?.[0]?.text).toContain(
+            '<previous_response_suffix>',
+          );
+
+          // Both halves reach the caller, in order and exactly once.
+          const delivered = events
+            .filter((event) => event.type === StreamEventType.CHUNK)
+            .map(
+              (event) =>
+                (event as { value: GenerateContentResponse }).value
+                  .candidates?.[0]?.content?.parts?.[0]?.text ?? '',
+            )
+            .join('');
+          expect(delivered).toBe('<html><body></body></html>');
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it('stitches the delivered text into durable history', async () => {
+        // Without the merge, history would keep only the continuation half and
+        // every later turn (plus /compress and --resume) would see an answer
+        // that starts mid-document.
+        vi.useFakeTimers();
+        try {
+          vi.mocked(mockContentGenerator.generateContentStream)
+            .mockResolvedValueOnce(cutAfter([textChunk('first half ')]))
+            .mockResolvedValueOnce(
+              (async function* () {
+                yield textChunk('second half', 'STOP');
+              })(),
+            );
+
+          const stream = await chat.sendMessageStream(
+            'test-model',
+            { message: 'test' },
+            'prompt-transport-continuation-history',
+          );
+          await collectStreamWithFakeTimers(stream, 5_000);
+
+          const history = chat.getHistory();
+          expect(history.at(-1)).toEqual({
+            role: 'model',
+            parts: [{ text: 'first half second half' }],
+          });
+          // The synthetic resume instruction is request-only; it must never
+          // land in history as if the user had typed it.
+          expect(
+            history.some((entry) =>
+              entry.parts?.some((part) =>
+                part.text?.includes('The connection dropped mid-response'),
+              ),
+            ),
+          ).toBe(false);
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it('drops replayed overlap when the model repeats its own tail', async () => {
+        vi.useFakeTimers();
+        try {
+          vi.mocked(mockContentGenerator.generateContentStream)
+            .mockResolvedValueOnce(
+              cutAfter([textChunk('The quick brown fox jumps over')]),
+            )
+            .mockResolvedValueOnce(
+              (async function* () {
+                yield textChunk('jumps over the lazy dog.', 'STOP');
+              })(),
+            );
+
+          const stream = await chat.sendMessageStream(
+            'test-model',
+            { message: 'test' },
+            'prompt-transport-continuation-overlap',
+          );
+          await collectStreamWithFakeTimers(stream, 5_000);
+
+          expect(chat.getHistory().at(-1)).toEqual({
+            role: 'model',
+            parts: [{ text: 'The quick brown fox jumps over the lazy dog.' }],
+          });
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it('survives repeated cuts and accumulates every delivered fragment', async () => {
+        vi.useFakeTimers();
+        try {
+          vi.mocked(mockContentGenerator.generateContentStream)
+            .mockResolvedValueOnce(cutAfter([textChunk('part one ')]))
+            .mockResolvedValueOnce(cutAfter([textChunk('part two ')]))
+            .mockResolvedValueOnce(
+              (async function* () {
+                yield textChunk('part three', 'STOP');
+              })(),
+            );
+
+          const stream = await chat.sendMessageStream(
+            'test-model',
+            { message: 'test' },
+            'prompt-transport-continuation-repeated',
+          );
+          const events = await collectStreamWithFakeTimers(stream, 10_000);
+
+          expect(
+            mockContentGenerator.generateContentStream,
+          ).toHaveBeenCalledTimes(3);
+          // The third request carries BOTH earlier fragments, not just the
+          // most recent one.
+          expect(requestContentsOfCall(2).at(-2)).toEqual({
+            role: 'model',
+            parts: [{ text: 'part one part two ' }],
+          });
+          expect(
+            events.filter(
+              (event) =>
+                event.type === StreamEventType.RETRY && event.isContinuation,
+            ),
+          ).toHaveLength(2);
+          expect(chat.getHistory().at(-1)).toEqual({
+            role: 'model',
+            parts: [{ text: 'part one part two part three' }],
+          });
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it('propagates once the continuation budget is exhausted', async () => {
+        vi.useFakeTimers();
+        try {
+          let call = 0;
+          vi.mocked(
+            mockContentGenerator.generateContentStream,
+          ).mockImplementation(() =>
+            Promise.resolve(cutAfter([textChunk(`fragment ${call++} `)])),
+          );
+
+          const stream = await chat.sendMessageStream(
+            'test-model',
+            { message: 'test' },
+            'prompt-transport-continuation-exhausted',
+          );
+          let caughtError: unknown;
+          const collecting = (async () => {
+            try {
+              for await (const _ of stream) {
+                /* consume */
+              }
+            } catch (error) {
+              caughtError = error;
+            }
+          })();
+          await vi.advanceTimersByTimeAsync(0);
+          await vi.advanceTimersByTimeAsync(30_000);
+          await collecting;
+
+          expect((caughtError as Error).message).toContain('terminated');
+          // Initial attempt + maxContinuationRetries continuations, then stop.
+          expect(
+            mockContentGenerator.generateContentStream,
+          ).toHaveBeenCalledTimes(4);
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it('does not continue a cut that delivered a functionCall', async () => {
+        // Injecting a user turn between a functionCall and its
+        // functionResponse produces a sequence providers reject; the partial
+        // tool-use turn is left for the scheduler's repair path instead.
+        const toolChunk = {
+          candidates: [
+            {
+              content: {
+                role: 'model',
+                parts: [
+                  { text: 'Let me read that file. ' },
+                  {
+                    functionCall: {
+                      id: 'call_1',
+                      name: 'read_file',
+                      args: { path: '/tmp/a.txt' },
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        } as unknown as GenerateContentResponse;
+
+        vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+          cutAfter([toolChunk]),
+        );
+
+        const stream = await chat.sendMessageStream(
+          'test-model',
+          { message: 'test' },
+          'prompt-transport-continuation-functioncall',
+        );
+        await expect(async () => {
+          for await (const _ of stream) {
+            /* consume */
+          }
+        }).rejects.toThrow('terminated');
+
+        expect(
+          mockContentGenerator.generateContentStream,
+        ).toHaveBeenCalledTimes(1);
+      });
+
+      it('replays rather than continues when only a thought was delivered', async () => {
+        // The reported failure mode: thinking models emit reasoning within
+        // seconds, so gating replay on "any chunk yielded" made it
+        // unreachable. A thought carries no answer text a replay could
+        // duplicate, so the clean replay is still the right recovery.
+        vi.useFakeTimers();
+        try {
+          const thoughtChunk = {
+            candidates: [
+              {
+                content: {
+                  role: 'model',
+                  parts: [{ text: 'Let me plan this out.', thought: true }],
+                },
+              },
+            ],
+          } as unknown as GenerateContentResponse;
+
+          vi.mocked(mockContentGenerator.generateContentStream)
+            .mockResolvedValueOnce(cutAfter([thoughtChunk]))
+            .mockResolvedValueOnce(
+              (async function* () {
+                yield textChunk('the full answer', 'STOP');
+              })(),
+            );
+
+          const stream = await chat.sendMessageStream(
+            'test-model',
+            { message: 'test' },
+            'prompt-transport-thought-only',
+          );
+          const events = await collectStreamWithFakeTimers(stream, 5_000);
+
+          expect(
+            mockContentGenerator.generateContentStream,
+          ).toHaveBeenCalledTimes(2);
+          // A replay, not a continuation: no resume instruction is injected
+          // and the RETRY tells the UI to discard the failed attempt.
+          const secondRequest = requestContentsOfCall(1);
+          expect(
+            secondRequest.some((entry) =>
+              entry.parts?.some((part) =>
+                part.text?.includes('The connection dropped mid-response'),
+              ),
+            ),
+          ).toBe(false);
+          expect(
+            events.filter(
+              (event) =>
+                event.type === StreamEventType.RETRY && !event.isContinuation,
+            ),
+          ).toHaveLength(1);
+          expect(chat.getHistory().at(-1)).toEqual({
+            role: 'model',
+            parts: [{ text: 'the full answer' }],
+          });
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it('replays rather than continues when the delivered text was blank', async () => {
+        vi.useFakeTimers();
+        try {
+          vi.mocked(mockContentGenerator.generateContentStream)
+            .mockResolvedValueOnce(cutAfter([textChunk('   ')]))
+            .mockResolvedValueOnce(
+              (async function* () {
+                yield textChunk('real content', 'STOP');
+              })(),
+            );
+
+          const stream = await chat.sendMessageStream(
+            'test-model',
+            { message: 'test' },
+            'prompt-transport-continuation-blank',
+          );
+          const events = await collectStreamWithFakeTimers(stream, 5_000);
+
+          expect(
+            mockContentGenerator.generateContentStream,
+          ).toHaveBeenCalledTimes(2);
+          expect(
+            events.filter(
+              (event) =>
+                event.type === StreamEventType.RETRY && event.isContinuation,
+            ),
+          ).toHaveLength(0);
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it('drops a pending continuation when a fresh-restart retry takes over', async () => {
+        // A socket cut starts a continuation; the continuation attempt then
+        // fails with an InvalidStreamError, whose retry re-sends the ORIGINAL
+        // request and emits a plain RETRY (UI discards the delivered text).
+        // The request must drop it too — otherwise the resend keeps asking the
+        // model to continue output the caller no longer has.
+        vi.useFakeTimers();
+        try {
+          vi.mocked(mockContentGenerator.generateContentStream)
+            .mockResolvedValueOnce(cutAfter([textChunk('doomed fragment ')]))
+            .mockResolvedValueOnce(
+              (async function* () {
+                throw new InvalidStreamError(
+                  'Model stream ended with empty response text.',
+                  'NO_RESPONSE_TEXT',
+                );
+
+                yield {} as GenerateContentResponse;
+              })(),
+            )
+            .mockResolvedValueOnce(
+              (async function* () {
+                yield textChunk('a clean answer', 'STOP');
+              })(),
+            );
+
+          const stream = await chat.sendMessageStream(
+            'test-model',
+            { message: 'test' },
+            'prompt-transport-continuation-superseded',
+          );
+          await collectStreamWithFakeTimers(stream, 10_000);
+
+          expect(
+            mockContentGenerator.generateContentStream,
+          ).toHaveBeenCalledTimes(3);
+          const thirdRequest = requestContentsOfCall(2);
+          expect(
+            thirdRequest.some((entry) =>
+              entry.parts?.some((part) =>
+                part.text?.includes('doomed fragment'),
+              ),
+            ),
+          ).toBe(false);
+          expect(chat.getHistory().at(-1)).toEqual({
+            role: 'model',
+            parts: [{ text: 'a clean answer' }],
+          });
+        } finally {
+          vi.useRealTimers();
+        }
+      });
     });
 
     it('falls back after yielding only tool preparation metadata', async () => {

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -7772,6 +7772,136 @@ describe('GeminiChat', async () => {
         }
       });
 
+      it('drops replayed overlap when an intermediate attempt is cut again', async () => {
+        // The two cases above, combined: a middle attempt both replays the
+        // previous tail *and* is cut before finishing. Dedup at merge time
+        // only compares the final attempt against the accumulated prefix, so
+        // an overlap replayed by an intermediate attempt is baked into that
+        // prefix — it is propagated to every later request and into durable
+        // history, where it corrupts /compress, --resume, and the context of
+        // every following turn.
+        vi.useFakeTimers();
+        try {
+          vi.mocked(mockContentGenerator.generateContentStream)
+            .mockResolvedValueOnce(cutAfter([textChunk('part one ')]))
+            .mockResolvedValueOnce(cutAfter([textChunk('part one part two ')]))
+            .mockResolvedValueOnce(
+              (async function* () {
+                yield textChunk('part three', 'STOP');
+              })(),
+            );
+
+          const stream = await chat.sendMessageStream(
+            'test-model',
+            { message: 'test' },
+            'prompt-transport-continuation-intermediate-replay',
+          );
+          await collectStreamWithFakeTimers(stream, 10_000);
+
+          // The third request must not carry "part one" twice.
+          expect(requestContentsOfCall(2).at(-2)).toEqual({
+            role: 'model',
+            parts: [{ text: 'part one part two ' }],
+          });
+          expect(chat.getHistory().at(-1)).toEqual({
+            role: 'model',
+            parts: [{ text: 'part one part two part three' }],
+          });
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it('pins the delivered text after a thought part in the merged turn', async () => {
+        // Covers `textIndex > 0`: the continuation turn leads with a thought
+        // part, so the delivered text must merge into the *text* part rather
+        // than being spliced at index 0 ahead of the thinking.
+        vi.useFakeTimers();
+        try {
+          vi.mocked(mockContentGenerator.generateContentStream)
+            .mockResolvedValueOnce(cutAfter([textChunk('part one ')]))
+            .mockResolvedValueOnce(
+              (async function* () {
+                yield {
+                  candidates: [
+                    {
+                      content: {
+                        role: 'model',
+                        parts: [
+                          { text: 'still reasoning', thought: true },
+                          { text: 'part two' },
+                        ],
+                      },
+                      finishReason: 'STOP',
+                    },
+                  ],
+                } as unknown as GenerateContentResponse;
+              })(),
+            );
+
+          const stream = await chat.sendMessageStream(
+            'test-model',
+            { message: 'test' },
+            'prompt-transport-continuation-thought-then-text',
+          );
+          await collectStreamWithFakeTimers(stream, 10_000);
+
+          expect(chat.getHistory().at(-1)).toEqual({
+            role: 'model',
+            parts: [
+              { text: 'still reasoning', thought: true },
+              { text: 'part one part two' },
+            ],
+          });
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it('inserts the delivered text when the continuation has no text part', async () => {
+        // Covers `textIndex < 0`: a thinking model completes the continuation
+        // with only a thought part. The delivered text has nothing to merge
+        // into, so it is inserted as its own part — and must land *after* the
+        // thought, not ahead of it.
+        vi.useFakeTimers();
+        try {
+          vi.mocked(mockContentGenerator.generateContentStream)
+            .mockResolvedValueOnce(cutAfter([textChunk('part one ')]))
+            .mockResolvedValueOnce(
+              (async function* () {
+                yield {
+                  candidates: [
+                    {
+                      content: {
+                        role: 'model',
+                        parts: [{ text: 'only thinking', thought: true }],
+                      },
+                      finishReason: 'STOP',
+                    },
+                  ],
+                } as unknown as GenerateContentResponse;
+              })(),
+            );
+
+          const stream = await chat.sendMessageStream(
+            'test-model',
+            { message: 'test' },
+            'prompt-transport-continuation-thought-only',
+          );
+          await collectStreamWithFakeTimers(stream, 10_000);
+
+          expect(chat.getHistory().at(-1)).toEqual({
+            role: 'model',
+            parts: [
+              { text: 'only thinking', thought: true },
+              { text: 'part one ' },
+            ],
+          });
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
       it('propagates once the continuation budget is exhausted', async () => {
         vi.useFakeTimers();
         try {

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -8000,6 +8000,140 @@ describe('GeminiChat', async () => {
           vi.useRealTimers();
         }
       });
+
+      it('drops a pending continuation when a replay takes over', async () => {
+        // Same requirement as the test above, but through the branch that sets
+        // `suppressNextRetryEvent`: a socket cut delivers text and schedules a
+        // continuation, then the continuation attempt is cut again *before*
+        // yielding anything visible — which lands in the replay branch, not the
+        // continuation branch, because replay is still legal with no visible
+        // output. Replay re-sends the original request and emits a plain RETRY,
+        // so the staged continuation must be discarded. Otherwise the replay
+        // would carry a resume instruction for text the UI has thrown away, and
+        // the merge on success would put that text back into history.
+        vi.useFakeTimers();
+        try {
+          vi.mocked(mockContentGenerator.generateContentStream)
+            .mockResolvedValueOnce(cutAfter([textChunk('discarded half ')]))
+            .mockResolvedValueOnce(cutAfter([]))
+            .mockResolvedValueOnce(
+              (async function* () {
+                yield textChunk('a clean answer', 'STOP');
+              })(),
+            );
+
+          const stream = await chat.sendMessageStream(
+            'test-model',
+            { message: 'test' },
+            'prompt-transport-continuation-replaced-by-replay',
+          );
+          await collectStreamWithFakeTimers(stream, 10_000);
+
+          expect(
+            mockContentGenerator.generateContentStream,
+          ).toHaveBeenCalledTimes(3);
+          const thirdRequest = requestContentsOfCall(2);
+          expect(
+            thirdRequest.some((entry) =>
+              entry.parts?.some((part) =>
+                part.text?.includes('discarded half'),
+              ),
+            ),
+          ).toBe(false);
+          expect(
+            thirdRequest.some((entry) =>
+              entry.parts?.some((part) =>
+                part.text?.includes('The connection dropped mid-response'),
+              ),
+            ),
+          ).toBe(false);
+          // The delivered text was discarded by the UI on the plain RETRY, so
+          // it must not be merged back in here.
+          expect(chat.getHistory().at(-1)).toEqual({
+            role: 'model',
+            parts: [{ text: 'a clean answer' }],
+          });
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it('drops a pending continuation when reactive compression takes over', async () => {
+        // The third branch that emits a plain RETRY alongside
+        // `suppressNextRetryEvent`. This ordering is not far-fetched: a
+        // continuation attempt sends *more* than the original request (the
+        // delivered text plus the resume instruction ride along), so it is
+        // exactly the attempt most likely to overflow the context window.
+        // Compression rebuilds `requestContents` from a compacted history, so a
+        // continuation staged against the old contents is stale twice over.
+        vi.useFakeTimers();
+        try {
+          vi.spyOn(ChatCompressionService.prototype, 'compress')
+            // The pre-send proactive pass; the reactive one is the second call.
+            .mockResolvedValueOnce({
+              newHistory: null,
+              info: {
+                originalTokenCount: 0,
+                newTokenCount: 0,
+                compressionStatus: CompressionStatus.NOOP,
+              },
+            })
+            .mockResolvedValueOnce({
+              newHistory: [
+                { role: 'user', parts: [{ text: 'summary' }] },
+                { role: 'model', parts: [{ text: 'ack' }] },
+                { role: 'user', parts: [{ text: 'test' }] },
+              ],
+              info: {
+                originalTokenCount: 135_000,
+                newTokenCount: 40_000,
+                compressionStatus: CompressionStatus.COMPRESSED,
+              },
+            });
+          vi.mocked(mockContentGenerator.generateContentStream)
+            .mockResolvedValueOnce(cutAfter([textChunk('discarded half ')]))
+            .mockRejectedValueOnce(
+              new Error('prompt is too long: 135000 tokens > 128000 maximum'),
+            )
+            .mockResolvedValueOnce(
+              (async function* () {
+                yield textChunk('a clean answer', 'STOP');
+              })(),
+            );
+
+          const stream = await chat.sendMessageStream(
+            'test-model',
+            { message: 'test' },
+            'prompt-transport-continuation-replaced-by-compression',
+          );
+          await collectStreamWithFakeTimers(stream, 10_000);
+
+          expect(
+            mockContentGenerator.generateContentStream,
+          ).toHaveBeenCalledTimes(3);
+          const thirdRequest = requestContentsOfCall(2);
+          expect(
+            thirdRequest.some((entry) =>
+              entry.parts?.some((part) =>
+                part.text?.includes('discarded half'),
+              ),
+            ),
+          ).toBe(false);
+          expect(
+            thirdRequest.some((entry) =>
+              entry.parts?.some((part) =>
+                part.text?.includes('The connection dropped mid-response'),
+              ),
+            ),
+          ).toBe(false);
+          expect(chat.getHistory().at(-1)).toEqual({
+            role: 'model',
+            parts: [{ text: 'a clean answer' }],
+          });
+        } finally {
+          vi.useRealTimers();
+        }
+      });
     });
 
     it('falls back after yielding only tool preparation metadata', async () => {

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -7812,6 +7812,73 @@ describe('GeminiChat', async () => {
         }
       });
 
+      it('keeps continuing when a later attempt is cut during thinking', async () => {
+        // `streamYieldedContentChunk` is per-attempt, so an attempt cut while
+        // still in its thinking phase looks identical to a cut that delivered
+        // nothing at all — even though earlier attempts already put text on
+        // the caller's screen. The replay gate is checked first, so without a
+        // guard on the accumulated text it fires here, resets the
+        // continuation state, and emits a plain RETRY that tells the UI to
+        // discard output the user was watching.
+        vi.useFakeTimers();
+        try {
+          const thoughtOnly = {
+            candidates: [
+              {
+                content: {
+                  role: 'model',
+                  parts: [
+                    { text: 'Now let me check the next part.', thought: true },
+                  ],
+                },
+              },
+            ],
+          } as unknown as GenerateContentResponse;
+
+          vi.mocked(mockContentGenerator.generateContentStream)
+            .mockResolvedValueOnce(cutAfter([textChunk('part one ')]))
+            .mockResolvedValueOnce(cutAfter([thoughtOnly]))
+            .mockResolvedValueOnce(
+              (async function* () {
+                yield textChunk('part two', 'STOP');
+              })(),
+            );
+
+          const stream = await chat.sendMessageStream(
+            'test-model',
+            { message: 'test' },
+            'prompt-transport-continuation-thought-only-cut',
+          );
+          const events = await collectStreamWithFakeTimers(stream, 10_000);
+
+          // Every RETRY must be a continuation. A plain RETRY here is the UI
+          // being told to throw away "part one ".
+          const retries = events.filter(
+            (event) => event.type === StreamEventType.RETRY,
+          );
+          expect(retries).toHaveLength(2);
+          expect(
+            retries.every(
+              (event) =>
+                (event as { isContinuation?: boolean }).isContinuation === true,
+            ),
+          ).toBe(true);
+
+          // The delivered text must still anchor the third request...
+          expect(requestContentsOfCall(2).at(-2)).toEqual({
+            role: 'model',
+            parts: [{ text: 'part one ' }],
+          });
+          // ...and survive into history rather than being regenerated.
+          expect(chat.getHistory().at(-1)).toEqual({
+            role: 'model',
+            parts: [{ text: 'part one part two' }],
+          });
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
       it('pins the delivered text after a thought part in the merged turn', async () => {
         // Covers `textIndex > 0`: the continuation turn leads with a thought
         // part, so the delivered text must merge into the *text* part rather
@@ -8131,20 +8198,18 @@ describe('GeminiChat', async () => {
         }
       });
 
-      it('drops a pending continuation when a replay takes over', async () => {
-        // Same requirement as the test above, but through the branch that sets
-        // `suppressNextRetryEvent`: a socket cut delivers text and schedules a
-        // continuation, then the continuation attempt is cut again *before*
-        // yielding anything visible — which lands in the replay branch, not the
-        // continuation branch, because replay is still legal with no visible
-        // output. Replay re-sends the original request and emits a plain RETRY,
-        // so the staged continuation must be discarded. Otherwise the replay
-        // would carry a resume instruction for text the UI has thrown away, and
-        // the merge on success would put that text back into history.
+      it('keeps continuing when a later attempt is cut with nothing yielded', async () => {
+        // A socket cut delivers text and schedules a continuation; the
+        // continuation attempt is then cut again having yielded nothing at
+        // all. The replay branch is checked first and its per-attempt
+        // "nothing delivered" test is satisfied here, so it must also consult
+        // the accumulated buffer — replaying would re-send the original
+        // request under a plain RETRY, telling the UI to discard text the
+        // caller already has and making the model regenerate it.
         vi.useFakeTimers();
         try {
           vi.mocked(mockContentGenerator.generateContentStream)
-            .mockResolvedValueOnce(cutAfter([textChunk('discarded half ')]))
+            .mockResolvedValueOnce(cutAfter([textChunk('kept half ')]))
             .mockResolvedValueOnce(cutAfter([]))
             .mockResolvedValueOnce(
               (async function* () {
@@ -8155,33 +8220,34 @@ describe('GeminiChat', async () => {
           const stream = await chat.sendMessageStream(
             'test-model',
             { message: 'test' },
-            'prompt-transport-continuation-replaced-by-replay',
+            'prompt-transport-continuation-empty-later-attempt',
           );
-          await collectStreamWithFakeTimers(stream, 10_000);
+          const events = await collectStreamWithFakeTimers(stream, 10_000);
 
           expect(
             mockContentGenerator.generateContentStream,
           ).toHaveBeenCalledTimes(3);
-          const thirdRequest = requestContentsOfCall(2);
+          // Both RETRYs keep the UI's buffer; a plain one would drop the text.
           expect(
-            thirdRequest.some((entry) =>
-              entry.parts?.some((part) =>
-                part.text?.includes('discarded half'),
+            events
+              .filter((event) => event.type === StreamEventType.RETRY)
+              .every(
+                (event) =>
+                  (event as { isContinuation?: boolean }).isContinuation ===
+                  true,
               ),
-            ),
-          ).toBe(false);
+          ).toBe(true);
+          const thirdRequest = requestContentsOfCall(2);
           expect(
             thirdRequest.some((entry) =>
               entry.parts?.some((part) =>
                 part.text?.includes('The connection dropped mid-response'),
               ),
             ),
-          ).toBe(false);
-          // The delivered text was discarded by the UI on the plain RETRY, so
-          // it must not be merged back in here.
+          ).toBe(true);
           expect(chat.getHistory().at(-1)).toEqual({
             role: 'model',
-            parts: [{ text: 'a clean answer' }],
+            parts: [{ text: 'kept half a clean answer' }],
           });
         } finally {
           vi.useRealTimers();

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -2564,6 +2564,22 @@ export class GeminiChat {
               ]
             : requestContents;
 
+        /**
+         * Forget any in-flight continuation.
+         *
+         * Called from every branch that re-sends the *original* request, since
+         * those emit a `RETRY` without `isContinuation` and the UI drops the
+         * delivered text on that event. The request has to drop it too, or the
+         * resend would keep asking the model to resume output the caller no
+         * longer has — and a later success would merge that discarded text back
+         * into history, leaving the UI and history permanently out of step.
+         */
+        const resetTransportContinuation = () => {
+          transportContinuationCount = 0;
+          transportContinuationText = '';
+          transportContinuationPrefix = '';
+        };
+
         for (;;) {
           let streamYieldedChunk = false;
           let streamYieldedContentChunk = false;
@@ -2572,6 +2588,11 @@ export class GeminiChat {
           let streamYieldedFunctionCall = false;
           try {
             if (suppressNextRetryEvent) {
+              // The branch that scheduled this attempt already emitted its own
+              // RETRY, and — if that RETRY was a fresh restart rather than a
+              // continuation — already called `resetTransportContinuation`.
+              // Resetting again here would clear the state of a continuation
+              // that is legitimately in flight.
               suppressNextRetryEvent = false;
             } else if (
               rateLimitRetryCount > 0 ||
@@ -2579,15 +2600,10 @@ export class GeminiChat {
               transportStreamRetryCount > 0 ||
               transportContinuationCount > 0
             ) {
-              // A fresh-restart retry reaching this point means some other
-              // branch (rate limit, invalid stream, reactive compression)
-              // chose to re-send the original request. That RETRY event has no
-              // `isContinuation`, so the UI discards the delivered text — the
-              // request must discard it too, or the resend would keep asking
-              // the model to continue output the caller no longer has.
-              transportContinuationCount = 0;
-              transportContinuationText = '';
-              transportContinuationPrefix = '';
+              // A fresh-restart retry reaching this point means a branch that
+              // does not set `suppressNextRetryEvent` (rate limit, invalid
+              // stream) chose to re-send the original request.
+              resetTransportContinuation();
               yield { type: StreamEventType.RETRY };
             }
 
@@ -2763,6 +2779,12 @@ export class GeminiChat {
                 transportCode: classification.transportCode,
               });
               yield { type: StreamEventType.RETRY };
+              // A replay is a fresh restart, so anything a previous
+              // continuation had staged must go. Reaching here with state to
+              // clear is possible: a continuation attempt can itself die from
+              // a transport error before yielding visible output, which lands
+              // in this branch rather than the continuation one.
+              resetTransportContinuation();
               suppressNextRetryEvent = true;
               await delay(delayMs, params.config?.abortSignal).promise;
               continue;
@@ -2914,6 +2936,11 @@ export class GeminiChat {
                       info: reactiveInfo,
                     };
                     yield { type: StreamEventType.RETRY };
+                    // Compression rebuilt `requestContents` from scratch, so
+                    // any continuation staged against the old contents is
+                    // stale — and the RETRY above already told the UI to drop
+                    // the delivered text.
+                    resetTransportContinuation();
                     suppressNextRetryEvent = true;
                     continue;
                   }

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -2597,9 +2597,14 @@ export class GeminiChat {
         };
 
         // Fold the running attempt's text into the accumulated buffer,
-        // stripping any overlap it replayed from the previous attempt's tail.
-        // Called on both exits from an attempt — success and cut — so the
-        // accumulated buffer never contains text twice.
+        // stripping any overlap it replayed from the previous attempt's tail,
+        // so the accumulated buffer never contains text twice.
+        //
+        // Called on the cut exit only. The success exit merges the prefix into
+        // history and breaks, and nothing reads the buffer after the loop, so
+        // folding there would have no reader. A post-loop read added later
+        // (telemetry, a MAX_TOKENS-recovery guard) would be missing the final
+        // attempt's text and must fold on the success path too.
         const foldTransportAttemptText = () => {
           transportContinuationText += getRecoveryContinuationSuffix(
             transportContinuationText,

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -484,6 +484,17 @@ const INVALID_STREAM_RETRY_CONFIG = {
 const TRANSPORT_STREAM_RETRY_CONFIG = {
   maxRetries: 2,
   initialDelayMs: 1000,
+  /**
+   * Budget for *continuation* recovery after a socket-level cut that already
+   * delivered output (issue #7832). This is a different mechanism from the
+   * `maxRetries` replay above and therefore has its own budget: a replay
+   * re-sends the request from scratch and is only legal before any chunk
+   * reached callers, while a continuation keeps the delivered output and asks
+   * the model to resume from it. A single long generation can be cut more than
+   * once by the same gateway idle timeout, so this is sized like
+   * {@link MAX_OUTPUT_RECOVERY_ATTEMPTS} rather than like the replay budget.
+   */
+  maxContinuationRetries: 3,
 };
 
 /**
@@ -514,6 +525,20 @@ const OUTPUT_RECOVERY_MESSAGE =
   'Output token limit hit. Resume directly — no apology, no recap of what ' +
   'you were doing. Pick up mid-thought if that is where the cut happened. ' +
   'Break remaining work into smaller pieces.';
+
+/**
+ * Lead-in for the same recovery user-turn when the cause was a socket-level
+ * cut mid-stream rather than the output token limit (issue #7832). Gateways
+ * that cap SSE connection lifetime close long generations after a few
+ * minutes; the response so far is already on the caller's screen, so the only
+ * safe recovery is to resume from it. Worded like
+ * {@link OUTPUT_RECOVERY_MESSAGE} — the model does not need to know which
+ * limit it hit, only that it was cut off and must not restart.
+ */
+const TRANSPORT_CONTINUATION_MESSAGE =
+  'The connection dropped mid-response. Resume directly — no apology, no ' +
+  'recap of what you were doing. Pick up mid-thought if that is where the ' +
+  'cut happened. Break remaining work into smaller pieces.';
 
 /**
  * Maximum length of the previous-response tail embedded inside the
@@ -839,13 +864,18 @@ function sanitizeRecoverySuffixTail(tail: string): string {
     .replace(/<previous_response_suffix>/g, '<​previous_response_suffix>');
 }
 
-function buildOutputRecoveryMessage(previousModelTurn: Content | undefined) {
-  const previousText =
-    previousModelTurn?.role === 'model'
-      ? getPlainTextFromParts(previousModelTurn.parts)
-      : '';
+/**
+ * Build a recovery user-turn from the text the model already produced.
+ *
+ * Shared by both continuation paths: output-token truncation (which reads the
+ * partial turn back out of history) and mid-stream transport cuts (which
+ * cannot, because a text-only partial is deliberately never persisted — see
+ * `processStreamResponse`). `lead` states the cause; everything after it is
+ * identical so the two paths cannot drift in how they fence the suffix.
+ */
+function buildRecoveryMessageFromText(lead: string, previousText: string) {
   if (previousText.trim().length === 0) {
-    return OUTPUT_RECOVERY_MESSAGE;
+    return lead;
   }
 
   const rawTail =
@@ -855,13 +885,22 @@ function buildOutputRecoveryMessage(previousModelTurn: Content | undefined) {
   const tail = sanitizeRecoverySuffixTail(rawTail);
 
   return (
-    `${OUTPUT_RECOVERY_MESSAGE}\n\n` +
+    `${lead}\n\n` +
     'The previous assistant response ended with this exact suffix. ' +
     'Do not repeat any line, table row, code line, or prose that already ' +
     'appears in it; output only text that comes after this suffix:\n\n' +
     '<previous_response_suffix>\n' +
     tail +
     '\n</previous_response_suffix>'
+  );
+}
+
+function buildOutputRecoveryMessage(previousModelTurn: Content | undefined) {
+  return buildRecoveryMessageFromText(
+    OUTPUT_RECOVERY_MESSAGE,
+    previousModelTurn?.role === 'model'
+      ? getPlainTextFromParts(previousModelTurn.parts)
+      : '',
   );
 }
 
@@ -2435,6 +2474,19 @@ export class GeminiChat {
         const totalInvalidStreamRetryCount = () =>
           transientInvalidStreamRetryCount + protocolTagLeakRetryCount;
         let transportStreamRetryCount = 0;
+        // Continuation recovery for mid-stream socket closes (issue #7832).
+        // `transportContinuationText` accumulates every plain-text chunk this
+        // send has already handed to callers across all continuation attempts,
+        // so each attempt can show the model its own visible output and ask it
+        // to resume instead of replaying (which would duplicate that output).
+        let transportContinuationCount = 0;
+        let transportContinuationText = '';
+        // Text delivered *before* the attempt currently running. Empty unless
+        // a continuation is in flight. `processStreamResponse` only pushes the
+        // final attempt's own output to history, so this is what has to be
+        // prepended once the send succeeds, or the next turn would see the
+        // model's answer starting mid-sentence.
+        let transportContinuationPrefix = '';
         let reactiveCompressionAttempted = false;
         let suppressNextRetryEvent = false;
         let streamYieldedAnyChunk = false;
@@ -2483,23 +2535,65 @@ export class GeminiChat {
 
         let lastFinishReason: string | undefined;
 
+        /**
+         * Contents for the next attempt. Identical to `requestContents` on
+         * every normal send; while a transport continuation is pending it
+         * appends the two synthetic turns that carry the delivered output and
+         * the instruction to resume from it. Built per attempt and never
+         * written to `self.history`, so the synthetic turns cannot leak into
+         * durable history, the JSONL transcript, or a later compression —
+         * unlike the MAX_TOKENS recovery loop, which has to route through
+         * history and clean up afterwards with `coalesceRecoveryPairs`.
+         */
+        const buildAttemptContents = (): Content[] =>
+          transportContinuationPrefix.length > 0
+            ? [
+                ...requestContents,
+                {
+                  role: 'model',
+                  parts: [{ text: transportContinuationPrefix }],
+                },
+                createUserContent([
+                  {
+                    text: buildRecoveryMessageFromText(
+                      TRANSPORT_CONTINUATION_MESSAGE,
+                      transportContinuationPrefix,
+                    ),
+                  },
+                ]),
+              ]
+            : requestContents;
+
         for (;;) {
           let streamYieldedChunk = false;
           let streamYieldedContentChunk = false;
+          // A cut that already delivered a `functionCall` cannot be continued
+          // from — see the continuation gate below.
+          let streamYieldedFunctionCall = false;
           try {
             if (suppressNextRetryEvent) {
               suppressNextRetryEvent = false;
             } else if (
               rateLimitRetryCount > 0 ||
               totalInvalidStreamRetryCount() > 0 ||
-              transportStreamRetryCount > 0
+              transportStreamRetryCount > 0 ||
+              transportContinuationCount > 0
             ) {
+              // A fresh-restart retry reaching this point means some other
+              // branch (rate limit, invalid stream, reactive compression)
+              // chose to re-send the original request. That RETRY event has no
+              // `isContinuation`, so the UI discards the delivered text — the
+              // request must discard it too, or the resend would keep asking
+              // the model to continue output the caller no longer has.
+              transportContinuationCount = 0;
+              transportContinuationText = '';
+              transportContinuationPrefix = '';
               yield { type: StreamEventType.RETRY };
             }
 
             const stream = await self.makeApiCallAndProcessStream(
               model,
-              requestContents,
+              buildAttemptContents(),
               params,
               prompt_id,
               requestOverrides,
@@ -2515,12 +2609,27 @@ export class GeminiChat {
               if (hasNonThoughtCandidateParts(chunk)) {
                 streamYieldedContentChunk = true;
               }
+              // Mirror the visible text into the continuation buffer as it is
+              // yielded. Reading it back off history is not an option on the
+              // transport path: processStreamResponse deliberately does NOT
+              // persist a text-only partial turn when the stream throws, so at
+              // the catch below history holds nothing about what the user
+              // already saw.
+              const chunkParts = chunk.candidates?.[0]?.content?.parts;
+              transportContinuationText += getPlainTextFromParts(chunkParts);
+              if (chunkParts?.some((part) => part.functionCall)) {
+                streamYieldedFunctionCall = true;
+              }
               const fr = chunk.candidates?.[0]?.finishReason;
               if (fr) lastFinishReason = fr;
               yield { type: StreamEventType.CHUNK, value: chunk };
             }
 
             lastError = null;
+            if (transportContinuationPrefix.length > 0) {
+              self.prependTextToLastModelTurn(transportContinuationPrefix);
+              transportContinuationPrefix = '';
+            }
             break;
           } catch (error) {
             lastError = error;
@@ -2658,11 +2767,67 @@ export class GeminiChat {
               await delay(delayMs, params.config?.abortSignal).promise;
               continue;
             }
+            // Continuation recovery (issue #7832). Once answer text has been
+            // delivered, replaying is off the table — it would duplicate what
+            // the caller already has — but propagating is not the only
+            // alternative left. Gateways that cap SSE connection lifetime
+            // (DashScope closes at ~3-5 min) cut long generations partway
+            // through the answer, which is precisely when the replay gate is
+            // shut, so large outputs failed outright however many retries were
+            // configured. Instead of replaying, keep the delivered text and
+            // ask the model to continue from it — the same shape the MAX_TOKENS
+            // truncation path already uses: show the model its own partial
+            // output, inject a resume instruction, and signal the UI with
+            // `isContinuation` so it keeps its text buffer rather than
+            // discarding it.
+            //
+            // A cut that delivered a `functionCall` is excluded: injecting a
+            // user turn between a `functionCall` and its `functionResponse`
+            // produces a sequence providers reject (the same constraint the
+            // MAX_TOKENS recovery loop enforces via its `hasFunctionCall`
+            // check), and the scheduler's repair path already covers it.
+            const canContinueAfterTransportCut =
+              isRetryableStreamTransportError &&
+              !streamYieldedFunctionCall &&
+              transportContinuationText.trim().length > 0 &&
+              transportContinuationCount <
+                TRANSPORT_STREAM_RETRY_CONFIG.maxContinuationRetries;
+            if (canContinueAfterTransportCut) {
+              self.popPendingPartialAssistantTurn();
+              transportContinuationCount++;
+              // Everything delivered so far — across earlier continuation
+              // attempts too, since `transportContinuationText` accumulates
+              // and is never reset while continuing.
+              transportContinuationPrefix = transportContinuationText;
+              const delayMs =
+                TRANSPORT_STREAM_RETRY_CONFIG.initialDelayMs *
+                transportContinuationCount;
+              debugLogger.warn('Transport stream continuation scheduled', {
+                retryPath: 'stream',
+                retryDecision: 'continue',
+                attempt: transportContinuationCount,
+                maxRetries:
+                  TRANSPORT_STREAM_RETRY_CONFIG.maxContinuationRetries,
+                retryDelayMs: delayMs,
+                errorKind: classification.kind,
+                transportCode: classification.transportCode,
+                deliveredChars: transportContinuationText.length,
+              });
+              // `isContinuation` keeps the UI's text buffer, so the next
+              // attempt's chunks append to what is already on screen instead
+              // of replacing it. The delivered text and the resume
+              // instruction ride along in `buildAttemptContents()`.
+              yield { type: StreamEventType.RETRY, isContinuation: true };
+              suppressNextRetryEvent = true;
+              await delay(delayMs, params.config?.abortSignal).promise;
+              continue;
+            }
             if (isRetryableStreamTransportError) {
-              // Reached only when the retry above did not fire: either
-              // user-visible content was already yielded (replaying would
-              // duplicate it) or the retry budget is exhausted. Either way
-              // the error propagates.
+              // Reached only when neither branch above fired: content was
+              // already delivered so replaying would duplicate it, or the
+              // replay budget is exhausted, or continuation is unavailable
+              // (function-call cut, no text to anchor on, or its own budget
+              // exhausted).
               debugLogger.warn('Transport stream retry not taken', {
                 retryPath: 'stream',
                 retryDecision: streamYieldedContentChunk
@@ -2670,6 +2835,9 @@ export class GeminiChat {
                   : 'exhausted',
                 attempts: transportStreamRetryCount,
                 maxRetries: TRANSPORT_STREAM_RETRY_CONFIG.maxRetries,
+                continuationAttempts: transportContinuationCount,
+                maxContinuationRetries:
+                  TRANSPORT_STREAM_RETRY_CONFIG.maxContinuationRetries,
                 errorKind: classification.kind,
                 transportCode: classification.transportCode,
               });
@@ -4446,6 +4614,53 @@ export class GeminiChat {
         usageMetadata,
       } as GenerateContentResponse;
     }
+  }
+
+  /**
+   * Prepend already-delivered text to the trailing model turn.
+   *
+   * Used by the transport-continuation path (issue #7832): after a socket cut
+   * mid-response, the caller has seen text that `processStreamResponse`
+   * deliberately did not persist, and the continuation attempt's own turn
+   * carries only the resumed remainder. Without this, durable history would
+   * hold an answer that starts mid-sentence — visibly wrong on `/compress`,
+   * `--resume`, and every later turn's context.
+   *
+   * The delivered text is merged into the turn's first plain-text part (kept
+   * after any leading thought part, matching the
+   * `[thoughtPart?, ...text]` shape `processStreamResponse` produces), or
+   * inserted as a new part when the continuation returned no text of its own.
+   * Overlap is deduped by the same helper the output-recovery merge uses, so a
+   * model that replays part of its previous tail does not double it.
+   */
+  private prependTextToLastModelTurn(deliveredText: string): void {
+    if (deliveredText.length === 0) return;
+    const lastEntry = this.history.at(-1);
+    if (lastEntry?.role !== 'model') {
+      debugLogger.warn(
+        '[TRANSPORT_CONTINUATION] Trailing entry is not a model turn; ' +
+          'dropping the delivered-text merge.',
+        { role: lastEntry?.role ?? 'undefined' },
+      );
+      return;
+    }
+    const parts = [...(lastEntry.parts ?? [])];
+    const textIndex = parts.findIndex(isPlainTextPart);
+    if (textIndex < 0) {
+      const insertAt = parts.findIndex((part) => !part.thought);
+      parts.splice(insertAt < 0 ? parts.length : insertAt, 0, {
+        text: deliveredText,
+      });
+    } else {
+      const continuationPart = parts[textIndex] as Part & { text: string };
+      parts[textIndex] = {
+        ...continuationPart,
+        text:
+          deliveredText +
+          getRecoveryContinuationSuffix(deliveredText, continuationPart.text),
+      };
+    }
+    lastEntry.parts = parts;
   }
 
   /**

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -517,28 +517,35 @@ const FIRST_SEND_CLAMP_OVERHEAD_PAD = 20_000;
 const MAX_OUTPUT_RECOVERY_ATTEMPTS = 3;
 
 /**
+ * The resume instruction shared by every recovery user-turn, whatever cut the
+ * response short. Only the lead-in sentence naming the cause differs between
+ * the paths below, so the instruction itself lives here: tuning it (say, to
+ * curb recap behaviour) has to apply to both, and duplicating it invites one
+ * path to be updated while the other silently keeps the old wording.
+ */
+const RECOVERY_RESUME_INSTRUCTION =
+  'Resume directly — no apology, no recap of what you were doing. Pick up ' +
+  'mid-thought if that is where the cut happened. Break remaining work into ' +
+  'smaller pieces.';
+
+/**
  * Recovery message injected as a user turn when the model's output is
  * truncated even after token escalation. Instructs the model to resume
  * without repeating itself and to break remaining work into smaller steps.
  */
-const OUTPUT_RECOVERY_MESSAGE =
-  'Output token limit hit. Resume directly — no apology, no recap of what ' +
-  'you were doing. Pick up mid-thought if that is where the cut happened. ' +
-  'Break remaining work into smaller pieces.';
+const OUTPUT_RECOVERY_MESSAGE = `Output token limit hit. ${RECOVERY_RESUME_INSTRUCTION}`;
 
 /**
  * Lead-in for the same recovery user-turn when the cause was a socket-level
  * cut mid-stream rather than the output token limit (issue #7832). Gateways
  * that cap SSE connection lifetime close long generations after a few
  * minutes; the response so far is already on the caller's screen, so the only
- * safe recovery is to resume from it. Worded like
- * {@link OUTPUT_RECOVERY_MESSAGE} — the model does not need to know which
- * limit it hit, only that it was cut off and must not restart.
+ * safe recovery is to resume from it. Deliberately shares
+ * {@link RECOVERY_RESUME_INSTRUCTION} with {@link OUTPUT_RECOVERY_MESSAGE} —
+ * the model does not need to know which limit it hit, only that it was cut
+ * off and must not restart.
  */
-const TRANSPORT_CONTINUATION_MESSAGE =
-  'The connection dropped mid-response. Resume directly — no apology, no ' +
-  'recap of what you were doing. Pick up mid-thought if that is where the ' +
-  'cut happened. Break remaining work into smaller pieces.';
+const TRANSPORT_CONTINUATION_MESSAGE = `The connection dropped mid-response. ${RECOVERY_RESUME_INSTRUCTION}`;
 
 /**
  * Maximum length of the previous-response tail embedded inside the
@@ -2787,6 +2794,15 @@ export class GeminiChat {
             if (
               isRetryableStreamTransportError &&
               !streamYieldedContentChunk &&
+              // `streamYieldedContentChunk` is per-attempt, so on its own it
+              // cannot tell "nothing has been delivered" from "this attempt
+              // was cut while thinking, after earlier attempts already put
+              // text on screen". Only the first is replayable; replaying the
+              // second discards output the caller is watching. The
+              // accumulated buffer is what distinguishes them, and it must be
+              // consulted here because this branch is checked before the
+              // continuation one below.
+              transportContinuationText.trim().length === 0 &&
               transportStreamRetryCount <
                 TRANSPORT_STREAM_RETRY_CONFIG.maxRetries
             ) {
@@ -2807,10 +2823,11 @@ export class GeminiChat {
               });
               yield { type: StreamEventType.RETRY };
               // A replay is a fresh restart, so anything a previous
-              // continuation had staged must go. Reaching here with state to
-              // clear is possible: a continuation attempt can itself die from
-              // a transport error before yielding visible output, which lands
-              // in this branch rather than the continuation one.
+              // continuation had staged must go. The gate above now admits
+              // only an empty accumulated buffer, which leaves nothing for
+              // this to clear — it stays as an assertion of that invariant,
+              // so a future gate change cannot leak staged text into a
+              // restarted attempt.
               resetTransportContinuation();
               suppressNextRetryEvent = true;
               await delay(delayMs, params.config?.abortSignal).promise;

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -2479,8 +2479,16 @@ export class GeminiChat {
         // send has already handed to callers across all continuation attempts,
         // so each attempt can show the model its own visible output and ask it
         // to resume instead of replaying (which would duplicate that output).
+        // Attempts are folded in one at a time, each with any overlap it
+        // replayed stripped, so the buffer holds no fragment twice.
         let transportContinuationCount = 0;
         let transportContinuationText = '';
+        // Text delivered by the attempt currently running, before it is folded
+        // into `transportContinuationText`. Kept separate so the overlap a
+        // continuation attempt replays is stripped once, at the attempt
+        // boundary where it occurs, rather than per chunk — the overlap scan is
+        // suffix-anchored and would eat legitimately repeated text mid-stream.
+        let transportAttemptText = '';
         // Text delivered *before* the attempt currently running. Empty unless
         // a continuation is in flight. `processStreamResponse` only pushes the
         // final attempt's own output to history, so this is what has to be
@@ -2577,10 +2585,24 @@ export class GeminiChat {
         const resetTransportContinuation = () => {
           transportContinuationCount = 0;
           transportContinuationText = '';
+          transportAttemptText = '';
           transportContinuationPrefix = '';
         };
 
+        // Fold the running attempt's text into the accumulated buffer,
+        // stripping any overlap it replayed from the previous attempt's tail.
+        // Called on both exits from an attempt — success and cut — so the
+        // accumulated buffer never contains text twice.
+        const foldTransportAttemptText = () => {
+          transportContinuationText += getRecoveryContinuationSuffix(
+            transportContinuationText,
+            transportAttemptText,
+          );
+          transportAttemptText = '';
+        };
+
         for (;;) {
+          transportAttemptText = '';
           let streamYieldedChunk = false;
           let streamYieldedContentChunk = false;
           // A cut that already delivered a `functionCall` cannot be continued
@@ -2632,7 +2654,7 @@ export class GeminiChat {
               // the catch below history holds nothing about what the user
               // already saw.
               const chunkParts = chunk.candidates?.[0]?.content?.parts;
-              transportContinuationText += getPlainTextFromParts(chunkParts);
+              transportAttemptText += getPlainTextFromParts(chunkParts);
               if (chunkParts?.some((part) => part.functionCall)) {
                 streamYieldedFunctionCall = true;
               }
@@ -2649,6 +2671,11 @@ export class GeminiChat {
             break;
           } catch (error) {
             lastError = error;
+            // This attempt is over; fold what it delivered into the running
+            // buffer before any branch below reads it. Doing this here rather
+            // than per chunk keeps the overlap scan anchored at the attempt
+            // boundary, which is the only place a replay can occur.
+            foldTransportAttemptText();
 
             // Handle rate-limit / throttling errors returned as stream content.
             // These arrive as StreamContentError with finish_reason="error_finish"
@@ -2819,7 +2846,9 @@ export class GeminiChat {
               transportContinuationCount++;
               // Everything delivered so far — across earlier continuation
               // attempts too, since `transportContinuationText` accumulates
-              // and is never reset while continuing.
+              // and is never reset while continuing. Each attempt's own text
+              // was folded in at the catch above with its replayed overlap
+              // stripped, so this carries no fragment twice.
               transportContinuationPrefix = transportContinuationText;
               const delayMs =
                 TRANSPORT_STREAM_RETRY_CONFIG.initialDelayMs *


### PR DESCRIPTION
## What this PR does

Makes a response that gets cut off by a socket-level close mid-stream recoverable, instead of failing the whole send. Two changes, both in `packages/core/src/core/geminiChat.ts`.

First, the existing replay path no longer treats reasoning as delivered output. Its guard used to be "has any chunk reached the caller", which a thinking model trips within seconds of starting, so replay was unavailable for precisely the long generations that need it. The guard now asks whether anything a replay could *duplicate* was delivered — non-blank answer text or a `functionCall`. Thoughts and tool-call preparation metadata no longer count. This is consistent with the rate-limit and invalid-stream branches, which already re-send after reasoning has streamed, and with the UI's non-continuation `RETRY` handler, which clears the thought buffer.

Second, once answer text *has* been delivered, replaying is genuinely off the table — the user would see the first half of the answer twice — but failing the send is not the only remaining option. The response so far is already on screen, so the fix keeps it, asks the model to resume from it, and signals the UI with `{ type: StreamEventType.RETRY, isContinuation: true }` so it appends to its text buffer rather than replacing it. This is the same shape the `MAX_TOKENS` truncation path already uses; the continuation reuses that machinery rather than introducing a parallel one. Budget is 3 attempts, since one long generation can be cut repeatedly by the same idle timeout.

Three implementation points worth a reviewer's attention. The delivered text is mirrored into a local buffer as it is yielded rather than read back from history, because it cannot be read back: `processStreamResponse` deliberately does not persist a text-only partial turn when the stream throws, so at the catch site history holds nothing about what the user already saw. The synthetic turns that carry the delivered text and the resume instruction are built into the request only and never written to `self.history`, so they cannot leak into the JSONL transcript or a later `/compress` — unlike the `MAX_TOKENS` loop, which routes through history and cleans up afterwards with `coalesceRecoveryPairs`. And on success the delivered prefix is merged back into the trailing model turn, because otherwise in-memory history would hold an answer that begins mid-sentence, which is visible on `/compress` and every later turn's context; replayed overlap is deduped with the existing `getRecoveryContinuationSuffix`. This merge targets `this.history` only, not the recorder, so the JSONL transcript that `--resume` reads still starts the turn mid-sentence -- see the Known gap below.

Cuts that delivered a `functionCall` are excluded. Injecting a user turn between a `functionCall` and its `functionResponse` produces a sequence providers reject — the same constraint the `MAX_TOKENS` recovery loop enforces through its `hasFunctionCall` check — and the scheduler's repair path already covers that case.

## Why it's needed

Long generations behind a gateway that caps SSE connection lifetime die with `TypeError: terminated` / `UND_ERR_SOCKET`, and no retry setting helps. DashScope closes at roughly 3–5 minutes, so in YOLO mode a long task is unrecoverable: the work already streamed to the screen is thrown away and the turn fails outright. Short requests never reach the timeout, so the failure is specific to exactly the requests that took the most time to produce.

A note on the two fixes suggested in #7832, since the first one is misleading. Suggested fix 1 — classify `UND_ERR_SOCKET` as retryable — is already implemented; the code is in `RETRYABLE_STREAM_TRANSPORT_CODES` in `packages/core/src/core/stream-transport-retry.ts`. The second half of that suggestion, retry regardless of whether chunks were yielded, would actively introduce a bug, because the retry in question is a replay of the whole request and the user would see duplicated output. The error classification was never the blocker; the `streamYieldedChunk` guard was. Suggested fix 2 — send the accumulated partial output as context and continue — is what this PR implements.

## Reviewer Test Plan

### How to verify

The unit suite is the primary evidence, since the production trigger needs a real gateway. From the repo root:

```
npx vitest run packages/core/src/core/geminiChat.test.ts
npx tsc --noEmit -p packages/core
npx eslint packages/core/src/core/geminiChat.ts packages/core/src/core/geminiChat.test.ts --max-warnings 0
```

Expected: `geminiChat.test.ts` 277 passed / 0 failed; typecheck and lint clean.

The behaviour is covered by a new `describe('transport stream continuation (#7832)')` block with fifteen cases: it continues from the delivered text instead of failing the send; stitches the delivered text into durable history; drops replayed overlap when the model repeats its own tail; survives repeated cuts and accumulates every delivered fragment; propagates once the continuation budget is exhausted (asserting exactly four calls — initial plus three); does not continue a cut that delivered a `functionCall`; **replays** rather than continues when only a thought was delivered; **replays** rather than continues when the delivered text was blank; and drops a pending continuation when a fresh-restart retry takes over.

Two things a reviewer may want to check specifically. One pre-existing test was changed by design: `does not retry retryable transport stream errors after yielding a chunk` asserted `toHaveBeenCalledTimes(1)` and zero `RETRY` events, which encoded the old policy. It is now `does not replay a transport stream error after yielding a chunk` and asserts the new distinction — still no replay (zero non-continuation `RETRY`s, and the second request carries the delivered turn), but a continuation is expected. Separately, to confirm the tests exercise the new behaviour rather than restating it, revert `geminiChat.ts` while keeping the test file: fourteen tests fail, 263 pass. The three that stay green are the negative cases (`functionCall` cut, thought-only replay, blank-text replay), which is correct, since they assert that recovery does *not* happen.

Reproducing the original bug against a live gateway requires a long generation behind DashScope and cannot be simulated locally; a maintainer with credentials can confirm the behavioural claim end-to-end if they want it.

### Evidence (Before & After)

N/A — no TUI or user-visible surface changes. The user-facing effect is that an existing failure mode stops failing; there is no new UI. The `isContinuation` rendering path this relies on is pre-existing and unchanged (`packages/cli/src/ui/hooks/useGeminiStream.ts`).

Test output from the local run:

```
Test Files  1 passed (1)
     Tests  277 passed (277)
```

A wider sweep across `packages/core/src/core` plus `retryErrorClassification.test.ts` gives 2576 passed, 2 skipped, 2 failed. The two failures are in `session-start-profiler.test.ts` (`writes bounded JSONL without sensitive fields`, `appends to an existing JSONL file`) and are pre-existing and unrelated: `git stash -u` on clean `main` reproduces the identical pair.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

Unit tests only, via `vitest` on Node 22, Windows 11. No sandbox or live provider involved.

## Risk & Scope

- **Main risk or tradeoff:** the one behaviour change outside the new code path is the replay guard widening, so a replay can now happen after a thought-only or blank-text prefix where it previously would not. Its downstream consumer is the non-continuation `RETRY` handler in `packages/cli/src/ui/hooks/useGeminiStream.ts`, which clears both the text and thought buffers, so a replay after a thought-only prefix renders correctly. On the continuation path the tradeoff is that the model is asked to resume from a suffix of its own output, so a model that ignores the instruction and restarts would produce a duplicated opening; the existing `getRecoveryContinuationSuffix` dedup mitigates this, and it is the same tradeoff the `MAX_TOKENS` recovery path already accepts.


## Known gap: `max_tokens` is not re-clamped for continuation attempts

Raised by @wenshao and confirmed here by reading both paths. `buildAttemptContents()` grows the prompt by the delivered text, but `params` — which carries `maxOutputTokens` — is passed to `makeApiCallAndProcessStream` unchanged, so every continuation attempt reuses the value clamped before the first send. The pre-existing `MAX_TOKENS` recovery loop re-clamps per iteration (`geminiChat.ts`, the `Re-clamp maxOutputTokens for THIS iteration` block) precisely because its prompt grows the same way:

```
transport continuation (this PR)        pre-existing MAX_TOKENS recovery
  req#0  max_tokens=32000                 req#0  max_tokens=32000
  req#1  max_tokens=32000                 req#1  max_tokens=64000   <- escalated
  req#2  max_tokens=32000                 req#2  max_tokens=64000   <- re-clamped per iteration
  req#3  max_tokens=32000
```

Neither of us can make it fail: the delivered text has to be large enough for `prompt + max_tokens` to cross the window, and the continuation budget caps the growth at three attempts. So this is a documented asymmetry with the path this PR mirrors, not a confirmed bug — recorded here rather than fixed so it is not rediscovered as a new finding. Fixing it means routing the continuation attempt through the same `clampOutputTokensToWindow` call the recovery loop uses.

## Known gap: `--resume` / `--continue`

Not fixed here, and confirmed by @wenshao with a real socket-cutting gateway. `prependTextToLastModelTurn` writes to `this.history`, not to `chatRecordingService`, so a resumed session still sees the recovered turn starting mid-sentence. `/compress` and later-turn context *are* fixed, because those read in-memory history.

The naive fix -- recording the delivered delta as its own assistant turn when the continuation is scheduled -- was prototyped and measured, and it trades this defect for a worse one: on the fresh-restart-retry path the discarded prefix is already durable, so the resumed transcript shows the answer twice. That is the exact hazard the existing comment in `processStreamResponse` warns about.

The correct fix is the stash-and-decide pattern this file already uses for `functionCall` partials (`pendingPartialAssistantRecord`): stash the delta, flush it on success alongside `prependTextToLastModelTurn`, discard it in `resetTransportContinuation`. That is a real change rather than a one-liner, so it belongs in a follow-up rather than bolted onto this PR.

Not a regression against `main`: on merge-base the cut turn records no assistant record at all.

<details>
<summary>中文说明</summary>

本 PR 未修复此项，且已由 @wenshao 用真实掐断 socket 的网关验证。`prependTextToLastModelTurn` 只写 `this.history`，不写 `chatRecordingService`，所以恢复的会话里该轮仍然从句子中间开始。`/compress` 和后续轮次的上下文**确实**已修复，因为它们读的是内存中的历史。

最直接的修法——在调度续写时把已交付增量作为独立 assistant turn 记录下来——已被做成原型并实测，结果是用一个缺陷换了个更糟的：在完整重发型重试路径上，被丢弃的前缀已经落盘，于是恢复后的转录会把答案显示两次。这正是 `processStreamResponse` 中既有注释所警告的风险。

正确的修法是采用该文件对 `functionCall` 半截 turn 已经在用的「暂存再决定」模式（`pendingPartialAssistantRecord`）：暂存增量，成功时与 `prependTextToLastModelTurn` 一并 flush，在 `resetTransportContinuation` 中丢弃。这是一个真正的改动而非一行代码，因此更适合作为后续 PR，而不是硬塞进本 PR。

相对 `main` 不构成回归：在 merge-base 上，被掐断的这一轮根本不会留下任何 assistant 记录。

</details>
- **Not validated / out of scope:** CI has not run the suite yet — the workflow is in `action_required`, awaiting maintainer approval for a fork PR — so the test, lint, and typecheck results above are local only. Reproduction against a live DashScope gateway is not covered, since the 3–5 minute connection cap cannot be simulated in a unit test. macOS and Linux are untested locally. Providers other than DashScope that cut long streams differently are not specifically exercised, though the fix keys off the transport code rather than the provider.
- **Breaking changes / migration notes:** none. No public API, config, or type surface changes; `stream-transport-retry.ts` is deliberately outside the package barrel. The new `maxContinuationRetries` is an internal constant, not user-configurable.

Also worth flagging, rather than leaving it to be discovered: this touches `packages/core/src/**`, so it falls under the two-tier core gate in `AGENTS.md`. It is a `fix` rather than a `refactor`, at 250 production lines in a single file, well under the 500-line hard block, so it should fall to Tier 2.

## Linked Issues

Fixes #7832

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让流式响应在传输层中途被掐断时可以恢复，而不是整次发送直接失败。两处改动，都在 `packages/core/src/core/geminiChat.ts`。

第一处，已有的「重放」路径不再把思考内容当作已交付的输出。它原本的门控条件是「是否已有任何 chunk 到达调用方」，而思考模型在开始后几秒内就会触发这个条件，于是重放对最需要它的长生成恰好不可用。现在门控问的是「是否交付了重放会**重复**的东西」——非空的正文，或者一个 `functionCall`。思考内容和工具调用的准备元数据不再计入。这与限流分支、无效流分支的行为一致（它们本来就在思考内容流完之后重发），也与 UI 的非续写 `RETRY` 处理器一致（它会清空思考缓冲）。

第二处，一旦正文**已经**交付，重放就确实不能用了——用户会看到答案的前半段出现两次——但整次发送失败并非唯一剩下的选择。目前的响应已经在屏幕上，所以修复的做法是保留它、让模型从它继续，并向 UI 发出 `{ type: StreamEventType.RETRY, isContinuation: true }`，使 UI 在已有文本后追加而不是替换。这与 `MAX_TOKENS` 截断路径已有的形态相同；续写复用了那套机制，而不是另起一套。预算为 3 次，因为同一次长生成可能被同一个空闲超时反复掐断。

有三处实现细节值得审查者注意。已交付文本是在 yield 时镜像进一个本地缓冲区的，而不是从历史中读回——因为读不回来：`processStreamResponse` 在流抛错时故意不持久化纯文本的半截 turn，所以在 catch 处，历史里没有任何关于用户已看到内容的记录。承载已交付文本和续写指令的合成 turn 只构建进请求，绝不写入 `self.history`，因此不会漏进 JSONL 转录或后续的 `/compress`——这与 `MAX_TOKENS` 循环不同，后者要经由历史再用 `coalesceRecoveryPairs` 清理。成功后已交付前缀会被并回尾部的 model turn，否则内存中的历史里会存下一个从句子中间开始的答案，这在 `/compress` 和之后每一轮的上下文里都能看到；重叠部分用现有的 `getRecoveryContinuationSuffix` 去重。这次并回只作用于 `this.history`，不涉及 recorder，因此 `--resume` 读取的 JSONL 转录中该轮仍然从句子中间开始——详见下方的 Known gap。

交付了 `functionCall` 的中断被排除在外。在 `functionCall` 和它的 `functionResponse` 之间插入用户 turn 会产生 provider 拒绝的序列——这与 `MAX_TOKENS` 恢复循环通过 `hasFunctionCall` 检查所遵守的约束相同——而且调度器的修复路径已经覆盖了这种情况。

## 为什么需要

在限制 SSE 连接生命周期的网关后面，长生成会以 `TypeError: terminated` / `UND_ERR_SOCKET` 失败，任何重试设置都无济于事。DashScope 大约在 3–5 分钟关闭连接，所以在 YOLO 模式下长任务不可恢复：已经流到屏幕上的成果被丢弃，整轮直接失败。短请求永远碰不到这个超时，所以这个故障恰好只发生在最耗时的请求上。

关于 #7832 里提出的两个修复方案，需要说明一下，因为第一个有误导性。方案 1——把 `UND_ERR_SOCKET` 归类为可重试——**已经实现了**，代码就在 `packages/core/src/core/stream-transport-retry.ts` 的 `RETRYABLE_STREAM_TRANSPORT_CODES` 里。而该方案的后半句「不论是否已 yield chunk 都重试」会主动引入 bug，因为这里的重试是整个请求的重放，用户会看到重复输出。错误分类从来不是堵点，`streamYieldedChunk` 门控才是。方案 2——把累积的部分输出作为上下文发送并继续——正是本 PR 实现的内容。

## 审查者测试计划

### 如何验证

单元测试是主要证据，因为生产环境的触发条件需要真实网关。在仓库根目录：

```
npx vitest run packages/core/src/core/geminiChat.test.ts
npx tsc --noEmit -p packages/core
npx eslint packages/core/src/core/geminiChat.ts packages/core/src/core/geminiChat.test.ts --max-warnings 0
```

预期：`geminiChat.test.ts` 277 通过 / 0 失败；类型检查与 lint 干净。

行为由新增的 `describe('transport stream continuation (#7832)')` 块覆盖，共十五个用例：从已交付文本继续而非失败；将已交付文本缝合进持久化历史；模型重复自己尾部时丢弃重叠；在反复中断下存活并累积每一个已交付片段；续写预算耗尽后向上抛出（断言恰好四次调用——首次加三次续写）；不对交付了 `functionCall` 的中断做续写；只交付了思考内容时走**重放**而非续写；已交付文本为空白时走**重放**而非续写；有新的完整重发型重试接管时丢弃待处理的续写状态。

有两点审查者可能想专门确认。有一个既有测试是按设计修改的：`does not retry retryable transport stream errors after yielding a chunk` 原本断言 `toHaveBeenCalledTimes(1)` 和零个 `RETRY` 事件，编码的是旧策略。现在它是 `does not replay a transport stream error after yielding a chunk`，断言新的区分——仍然不重放（零个非续写 `RETRY`，且第二次请求携带已交付的 turn），但预期会有一次续写。另外，为确认这些测试是在检验新行为而不是复述新行为：保留测试文件、只回退 `geminiChat.ts`，**14 个失败、263 个通过**。仍然通过的三个是负向用例（`functionCall` 中断、仅思考内容时重放、空白文本时重放），这是正确的，因为它们断言的正是「不应发生恢复」。

针对真实网关复现原始 bug 需要在 DashScope 后面跑一次长生成，本地无法模拟；有凭据的维护者如果需要，可以端到端确认行为主张。

### 证据（改动前后）

N/A——没有 TUI 或用户可见界面的改动。用户可感知的效果是一个既有的故障模式不再发生，没有新增 UI。本改动依赖的 `isContinuation` 渲染路径是既有的且未被修改（`packages/cli/src/ui/hooks/useGeminiStream.ts`）。

本地运行的测试输出：

```
Test Files  1 passed (1)
     Tests  277 passed (277)
```

在 `packages/core/src/core` 加 `retryErrorClassification.test.ts` 的更大范围扫描结果为 2576 通过、2 跳过、2 失败。这 2 个失败在 `session-start-profiler.test.ts`（`writes bounded JSONL without sensitive fields`、`appends to an existing JSONL file`），是预先存在且无关的：在干净的 `main` 上执行 `git stash -u` 可复现完全相同的这两个失败。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

仅单元测试，通过 `vitest` 在 Node 22、Windows 11 上运行。不涉及沙箱或真实 provider。

## 风险与范围

- **主要风险或取舍：** 新代码路径之外唯一的行为变更是重放门控的放宽，因此在只交付了思考内容或空白文本的前缀之后，现在可能发生一次重放，而这在以前不会。它的下游消费方是 `packages/cli/src/ui/hooks/useGeminiStream.ts` 中的非续写 `RETRY` 处理器，它会同时清空文本缓冲和思考缓冲，所以思考内容之后的重放渲染是正确的。在续写路径上，取舍在于模型被要求从自己输出的一个后缀继续，因此如果模型忽略指令重新开始，就会产生重复的开头；现有的 `getRecoveryContinuationSuffix` 去重可以缓解，而且这与 `MAX_TOKENS` 恢复路径已经接受的取舍相同。
- **未验证 / 范围之外：** CI 尚未运行测试套件——工作流处于 `action_required`，等待维护者批准 fork PR——所以上面的测试、lint 和类型检查结果仅为本地结果。针对真实 DashScope 网关的复现未覆盖，因为 3–5 分钟的连接上限无法在单元测试中模拟。macOS 和 Linux 未在本地测试。对以不同方式掐断长流的其他 provider 未做专门验证，不过本修复依据的是传输错误码而非 provider。
- **破坏性变更 / 迁移说明：** 无。没有公开 API、配置或类型接口的变更；`stream-transport-retry.ts` 是故意放在包 barrel 之外的。新增的 `maxContinuationRetries` 是内部常量，不对用户开放配置。

另外主动说明一点，而不是留着被发现：本改动触及 `packages/core/src/**`，因此落在 `AGENTS.md` 的核心模块两级门禁之内。它的类型是 `fix` 而非 `refactor`，单文件 250 行生产代码，远低于 500 行硬阻断线，所以应当归入 Tier 2。

## 关联 Issue

Fixes #7832

</details>
