### PR TITLE
fix(core): auto-retry transient network errors during API calls

### DIFF
--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -7575,6 +7575,68 @@ describe('GeminiChat', async () => {
       }
     });
 
+    it('retries an SDK-wrapped transport error whose code sits at cause depth 2', async () => {
+      // The OpenAI SDK wraps a pre-header socket reset as APIConnectionError ->
+      // TypeError('fetch failed') -> cause { code: 'ECONNRESET' }, so the code
+      // is two cause levels down. Drive the real inline shouldRetryOnError
+      // predicate through the retryWithBackoff options and assert it retries.
+      const transportError = Object.assign(new Error('Connection error.'), {
+        cause: Object.assign(new TypeError('fetch failed'), {
+          cause: Object.assign(new Error('read ECONNRESET'), {
+            code: 'ECONNRESET',
+          }),
+        }),
+      });
+
+      mockRetryWithBackoff.mockImplementation(async (apiCall, options) => {
+        try {
+          return await apiCall();
+        } catch (error) {
+          expect(options?.shouldRetryOnError?.(error)).toBe(true);
+          return apiCall();
+        }
+      });
+
+      vi.mocked(mockContentGenerator.generateContentStream)
+        .mockRejectedValueOnce(transportError)
+        .mockResolvedValueOnce(
+          (async function* () {
+            yield {
+              candidates: [
+                {
+                  content: {
+                    parts: [{ text: 'Recovered from depth-2 RST' }],
+                  },
+                  finishReason: 'STOP',
+                },
+              ],
+            } as unknown as GenerateContentResponse;
+          })(),
+        );
+
+      const stream = await chat.sendMessageStream(
+        'test-model',
+        { message: 'test' },
+        'prompt-transport-sdk-wrapped-depth2',
+      );
+      const events: StreamEvent[] = [];
+      for await (const event of stream) {
+        events.push(event);
+      }
+
+      expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(
+        2,
+      );
+      expect(
+        events.some(
+          (event) =>
+            event.type === StreamEventType.CHUNK &&
+            event.value.candidates?.[0]?.content?.parts?.[0]?.text ===
+              'Recovered from depth-2 RST',
+        ),
+      ).toBe(true);
+    });
+
     it('does not retry a transport error that carries an HTTP 4xx status', async () => {
       // A definitive 4xx is a permanent client error; the socket-level cause
       // must not relabel it as retryable (classifier keeps 4xx authoritative).

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -3492,6 +3492,15 @@ export class GeminiChat {
         // via defaultShouldRetry, but a custom shouldRetryOnError bypasses it.
         if (isRateLimitError(error, extraRetryErrorCodes)) return true;
 
+        // Transient network errors (ECONNRESET, ETIMEDOUT, etc.) carry no HTTP
+        // status and would otherwise fall through every predicate above.
+        if (
+          classifyRetryError(error, { extraRetryErrorCodes }).kind ===
+          'transport'
+        ) {
+          return true;
+        }
+
         return false;
       },
       authType,

--- a/packages/core/src/utils/retry.test.ts
+++ b/packages/core/src/utils/retry.test.ts
@@ -418,6 +418,35 @@ describe('retryWithBackoff', () => {
     expect(mockFn).toHaveBeenCalledTimes(2);
   });
 
+  it('should retry on SDK-wrapped transport errors (code at cause depth 2)', async () => {
+    let attempts = 0;
+    const mockFn = vi.fn(async () => {
+      attempts++;
+      if (attempts <= 1) {
+        // Mirrors the OpenAI SDK shape: APIConnectionError ->
+        // TypeError('fetch failed') -> cause { code: 'ECONNRESET' }.
+        throw Object.assign(new Error('Connection error.'), {
+          cause: Object.assign(new TypeError('fetch failed'), {
+            cause: Object.assign(new Error('read ECONNRESET'), {
+              code: 'ECONNRESET',
+            }),
+          }),
+        });
+      }
+      return 'ok';
+    });
+
+    const promise = retryWithBackoff(mockFn, {
+      maxAttempts: 3,
+      initialDelayMs: 10,
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(result).toBe('ok');
+    expect(mockFn).toHaveBeenCalledTimes(2);
+  });
+
   it('should respect maxDelayMs', async () => {
     const mockFn = createFailingFunction(3);
     const setTimeoutSpy = vi.spyOn(global, 'setTimeout');

--- a/packages/core/src/utils/retry.test.ts
+++ b/packages/core/src/utils/retry.test.ts
@@ -369,6 +369,55 @@ describe('retryWithBackoff', () => {
     expect(mockFn).toHaveBeenCalledTimes(1);
   });
 
+  it('should retry on transient network errors (ECONNRESET) by default', async () => {
+    let attempts = 0;
+    const mockFn = vi.fn(async () => {
+      attempts++;
+      if (attempts <= 2) {
+        const err = Object.assign(new TypeError('terminated'), {
+          cause: Object.assign(new Error('read ECONNRESET'), {
+            code: 'ECONNRESET',
+          }),
+        });
+        throw err;
+      }
+      return 'success';
+    });
+
+    const promise = retryWithBackoff(mockFn, {
+      maxAttempts: 3,
+      initialDelayMs: 10,
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(result).toBe('success');
+    expect(mockFn).toHaveBeenCalledTimes(3);
+  });
+
+  it('should retry on ETIMEDOUT by default', async () => {
+    let attempts = 0;
+    const mockFn = vi.fn(async () => {
+      attempts++;
+      if (attempts <= 1) {
+        throw Object.assign(new Error('connect ETIMEDOUT'), {
+          code: 'ETIMEDOUT',
+        });
+      }
+      return 'ok';
+    });
+
+    const promise = retryWithBackoff(mockFn, {
+      maxAttempts: 3,
+      initialDelayMs: 10,
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(result).toBe('ok');
+    expect(mockFn).toHaveBeenCalledTimes(2);
+  });
+
   it('should respect maxDelayMs', async () => {
     const mockFn = createFailingFunction(3);
     const setTimeoutSpy = vi.spyOn(global, 'setTimeout');

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -107,9 +107,16 @@ function defaultShouldRetry(
   const status = getErrorStatus(error);
   // isRateLimitError already covers HTTP 429 (and 503) via RATE_LIMIT_ERROR_CODES,
   // so an explicit `status === 429` check here would be redundant.
-  return (
+  if (
     isRateLimitError(error, extraRetryErrorCodes) ||
     (status !== undefined && status >= 500 && status < 600)
+  ) {
+    return true;
+  }
+  // Transport errors (ECONNRESET, ETIMEDOUT, etc.) carry no HTTP status and
+  // would otherwise fall through every predicate above.
+  return (
+    classifyRetryError(error, { extraRetryErrorCodes }).kind === 'transport'
   );
 }
 

--- a/packages/core/src/utils/retryErrorClassification.test.ts
+++ b/packages/core/src/utils/retryErrorClassification.test.ts
@@ -299,6 +299,26 @@ describe('classifyRetryError', () => {
     });
   });
 
+  it('classifies SDK-wrapped transport codes nested in the cause chain', () => {
+    // The OpenAI SDK surfaces a pre-header reset as APIConnectionError ->
+    // TypeError('fetch failed') -> cause { code: 'ECONNRESET' }; the socket
+    // code sits two cause levels down and must still classify as transport.
+    const error = Object.assign(new Error('Connection error.'), {
+      cause: Object.assign(new TypeError('fetch failed'), {
+        cause: Object.assign(new Error('read ECONNRESET'), {
+          code: 'ECONNRESET',
+        }),
+      }),
+    });
+
+    expect(classifyRetryError(error)).toMatchObject({
+      kind: 'transport',
+      diagnosis: 'retryable',
+      transportCode: 'ECONNRESET',
+      reason: 'transport-error',
+    });
+  });
+
   it('prefers a transport cause over an HTTP status when both are present', () => {
     // An SDK error can surface an HTTP status while its underlying cause is a
     // socket-level failure. The transport cause is the more fundamental

--- a/packages/core/src/utils/retryErrorClassification.ts
+++ b/packages/core/src/utils/retryErrorClassification.ts
@@ -194,24 +194,25 @@ function isRetryAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === 'CanceledError';
 }
 
+// SDKs wrap socket-level failures a couple of cause levels deep — e.g. the
+// OpenAI SDK surfaces a pre-header reset as APIConnectionError ->
+// TypeError('fetch failed') -> cause { code: 'ECONNRESET' }. Walk the cause
+// chain so those still reach the transport classification. The bound keeps a
+// malformed or circular chain from an unbounded traversal.
+const MAX_TRANSPORT_CAUSE_DEPTH = 4;
+
 function getTransportCode(error: unknown): string | undefined {
-  if (typeof error !== 'object' || error === null) {
-    return undefined;
-  }
-
-  const directCode = (error as { code?: unknown }).code;
-  if (typeof directCode === 'string' && isTransportCode(directCode)) {
-    return directCode;
-  }
-
-  const cause = error instanceof Error ? error.cause : undefined;
-  if (typeof cause === 'object' && cause !== null) {
-    const causeCode = (cause as { code?: unknown }).code;
-    if (typeof causeCode === 'string' && isTransportCode(causeCode)) {
-      return causeCode;
+  let current: unknown = error;
+  for (let depth = 0; depth <= MAX_TRANSPORT_CAUSE_DEPTH; depth++) {
+    if (typeof current !== 'object' || current === null) {
+      return undefined;
     }
+    const code = (current as { code?: unknown }).code;
+    if (typeof code === 'string' && isTransportCode(code)) {
+      return code;
+    }
+    current = current instanceof Error ? current.cause : undefined;
   }
-
   return undefined;
 }
 


### PR DESCRIPTION
## What this PR does

Adds transient network errors (ECONNRESET, ETIMEDOUT, ECONNREFUSED, etc.) to the set of conditions that trigger automatic retry at the API-call level. Previously, these TCP-level errors carried no HTTP status code and fell through every existing retry predicate, surfacing as raw `[API Error: terminated (cause: read ECONNRESET)]` to the user. The fix wires the existing transport-error classification into both retry decision points so that network glitches are retried with exponential backoff, just like rate-limit and server errors already are.

## Why it's needed

Closes #7831.

Users with large contexts (150k+ tokens) experience repeated `ECONNRESET` failures when a server-side gateway timeout (~90s) kills the TCP connection before the model finishes streaming. The next manual retry always succeeds immediately, confirming these are transient. The client already classifies these errors as transport-retryable and already retries them mid-stream (when no chunk has been yielded), but the API-call-level retry path did not consult that classification — so the error propagated to the user instead of being retried automatically.

## Reviewer Test Plan

### How to verify

1. Run the unit tests: `cd packages/core && npx vitest run src/utils/retry.test.ts` — confirm the two new tests ("should retry on transient network errors (ECONNRESET) by default" and "should retry on ETIMEDOUT by default") pass alongside all existing tests.
2. Confirm that existing retry behavior is unchanged: rate-limit (429/503), 5xx, and fail-fast quota 429 bounded-retry all still work as before — the new transport check is appended after these predicates and does not alter their logic.
3. Optionally, simulate a network error against a real endpoint and observe that the CLI retries automatically instead of showing a raw error.

### Evidence (Before & After)

N/A (non-UI change; retry behavior is internal)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Unit tests only (`npx vitest run`).

## Risk & Scope

- Main risk or tradeoff: transient network errors that indicate a persistent outage (e.g., server permanently unreachable) will now be retried up to the configured max attempts before surfacing, adding a short delay. This matches the existing behavior for 5xx errors and is bounded by the retry budget.
- Not validated / out of scope: the server-side gateway timeout root cause (~90s SLB timeout on Bailian Token Plan) is tracked separately. Mid-stream transport retry (after chunks have been yielded) is unchanged.
- Breaking changes / migration notes: none.

## Linked Issues

Closes #7831

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

将瞬态网络错误（ECONNRESET、ETIMEDOUT、ECONNREFUSED 等）加入 API 调用级别的自动重试条件。此前，这些 TCP 层错误不携带 HTTP 状态码，会穿透所有现有的重试判定逻辑，以原始的 `[API Error: terminated (cause: read ECONNRESET)]` 形式直接暴露给用户。本次修复将已有的传输层错误分类接入两个重试判定点，使网络抖动像限流和服务端错误一样自动进行指数退避重试。

## 为什么需要

关闭 #7831。

大上下文（150k+ tokens）用户在服务端网关超时（约 90 秒）切断 TCP 连接时，会反复遇到 `ECONNRESET` 失败。每次手动重试都立即成功，证实这些是瞬态错误。客户端已将这些错误归类为可重试的传输层错误，且已在流式传输中途（未产出任何 chunk 时）进行重试，但 API 调用级别的重试路径未引用该分类——因此错误直接传播给用户，而非自动重试。

## 审阅者测试计划

### 如何验证

1. 运行单元测试：`cd packages/core && npx vitest run src/utils/retry.test.ts`——确认两个新测试（"should retry on transient network errors (ECONNRESET) by default" 和 "should retry on ETIMEDOUT by default"）与所有现有测试一起通过。
2. 确认现有重试行为未变：限流（429/503）、5xx、以及快速失败配额 429 有限重试均保持原有逻辑——新的传输层检查追加在这些判定之后，不改变其逻辑。
3. 可选：对真实端点模拟网络错误，观察 CLI 自动重试而非显示原始错误。

### 证据（前后对比）

N/A（非 UI 变更；重试行为为内部逻辑）

### 测试环境

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### 环境（可选）

仅单元测试（`npx vitest run`）。

## 风险与范围

- 主要风险或权衡：如果瞬态网络错误实际代表持续性故障（如服务器永久不可达），现在会在达到配置的最大重试次数后才暴露，增加短暂延迟。这与 5xx 错误的现有行为一致，且受重试预算约束。
- 未验证 / 不在范围内：服务端网关超时根因（百炼 Token Plan 约 90 秒 SLB 超时）另行跟踪。流式传输中途的传输层重试（已产出 chunk 后）未做变更。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

关闭 #7831

</details>
