### PR TITLE
fix(cli): hide stale sticky todos from previous turns

### DIFF
--- a/packages/cli/src/ui/utils/todoSnapshot.test.ts
+++ b/packages/cli/src/ui/utils/todoSnapshot.test.ts
@@ -117,6 +117,14 @@ function makeGeminiHistoryItem(text: string, id: number): HistoryItem {
   };
 }
 
+function makeUserHistoryItem(text: string, id: number): HistoryItem {
+  return {
+    type: 'user',
+    id,
+    text,
+  };
+}
+
 describe('getStickyTodos', () => {
   it('returns the latest todo snapshot from history', () => {
     const history = [
@@ -209,6 +217,38 @@ describe('getStickyTodos', () => {
     ] as HistoryItem[];
 
     expect(getStickyTodos(history, [])).toBeNull();
+  });
+
+  it('hides sticky todos when a new user message starts after the snapshot', () => {
+    // Simulates: turn N creates todos → turn N ends → turn N+1 user message
+    // The stale todo list from turn N should not resurface.
+    const history = [
+      makeUserHistoryItem('Do the tasks', 1),
+      makeTodoToolGroup('task from turn N', 2),
+      makeGeminiHistoryItem('Working on it', 3),
+      makeGeminiHistoryItem('Done with turn N', 4),
+      makeUserHistoryItem('/stats', 5),
+    ] as HistoryItem[];
+
+    expect(getStickyTodos(history, [])).toBeNull();
+  });
+
+  it('shows sticky todos when no new user message follows the snapshot', () => {
+    // Normal case: todo snapshot is from the current turn.
+    const history = [
+      makeUserHistoryItem('Do the tasks', 1),
+      makeTodoToolGroup('current task', 2),
+      makeGeminiHistoryItem('Working on it', 3),
+      makeGeminiHistoryItem('Still working', 4),
+    ] as HistoryItem[];
+
+    expect(getStickyTodos(history, [])).toEqual([
+      {
+        id: 'todo-current task',
+        content: 'current task',
+        status: 'pending',
+      },
+    ]);
   });
 
   it('keeps sticky todos hidden for a completed pending snapshot', () => {

--- a/packages/cli/src/ui/utils/todoSnapshot.test.ts
+++ b/packages/cli/src/ui/utils/todoSnapshot.test.ts
@@ -117,11 +117,16 @@ function makeGeminiHistoryItem(text: string, id: number): HistoryItem {
   };
 }
 
-function makeUserHistoryItem(text: string, id: number): HistoryItem {
+function makeUserHistoryItem(
+  text: string,
+  id: number,
+  sentToModel?: boolean,
+): HistoryItem {
   return {
     type: 'user',
     id,
     text,
+    ...(sentToModel === undefined ? {} : { sentToModel }),
   };
 }
 
@@ -227,7 +232,23 @@ describe('getStickyTodos', () => {
       makeTodoToolGroup('task from turn N', 2),
       makeGeminiHistoryItem('Working on it', 3),
       makeGeminiHistoryItem('Done with turn N', 4),
-      makeUserHistoryItem('/stats', 5),
+      makeUserHistoryItem('Next question', 5),
+    ] as HistoryItem[];
+
+    expect(getStickyTodos(history, [])).toBeNull();
+  });
+
+  it('hides sticky todos when a local slash command starts after the snapshot', () => {
+    // Local slash commands (/stats, /about, /exit) are handled without entering
+    // API history and carry sentToModel: false, yet they are still a new user
+    // interaction that must hide stale todos. Guarding hasUserMessageAfter on
+    // sentToModel !== false would silently regress this case (#7061).
+    const history = [
+      makeUserHistoryItem('Do the tasks', 1),
+      makeTodoToolGroup('task from turn N', 2),
+      makeGeminiHistoryItem('Working on it', 3),
+      makeGeminiHistoryItem('Done with turn N', 4),
+      makeUserHistoryItem('/stats', 5, false),
     ] as HistoryItem[];
 
     expect(getStickyTodos(history, [])).toBeNull();

--- a/packages/cli/src/ui/utils/todoSnapshot.ts
+++ b/packages/cli/src/ui/utils/todoSnapshot.ts
@@ -120,6 +120,23 @@ function isRecentHistoryTodoSnapshot(
   return historyItemsAfterSnapshot < MIN_HISTORY_ITEMS_AFTER_TODO_BEFORE_STICKY;
 }
 
+/**
+ * Returns true when a user message exists after the given index, meaning the
+ * todo snapshot belongs to a previous turn.  The sticky panel should not
+ * resurface stale todos from an earlier turn when the user starts a new one.
+ */
+function hasUserMessageAfter(
+  items: readonly HistoryLikeItem[],
+  afterIndex: number,
+): boolean {
+  for (let i = afterIndex + 1; i < items.length; i++) {
+    if (items[i].type === 'user') {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function getStickyTodos(
   history: readonly HistoryItem[],
   pendingHistoryItems: readonly HistoryItemWithoutId[],
@@ -140,6 +157,12 @@ export function getStickyTodos(
   // reliable per-item viewport API. Treat very recent TodoWrite snapshots as
   // still visible so the footer does not duplicate the inline result.
   if (isRecentHistoryTodoSnapshot(historySnapshot.itemIndex, history.length)) {
+    return null;
+  }
+
+  // If a new user message appeared after the todo snapshot, the snapshot
+  // belongs to a previous turn.  Do not resurface stale todos.
+  if (hasUserMessageAfter(history, historySnapshot.itemIndex)) {
     return null;
   }
 


### PR DESCRIPTION
## What this PR does

Prevents the sticky todo panel from resurfacing with stale todos from a previous turn. The sticky panel now checks whether a new user message exists after the todo snapshot in history; if so, the snapshot belongs to an earlier turn and the panel stays hidden. This is a pure data-layer change — no layout components or streaming-state logic are modified.

## Why it's needed

Fixes #7061 (reopened scenario not covered by #7062).

PR #7062 hid the sticky panel when streaming is idle, but the panel resurfaces with stale todos as soon as the user sends a new message (state → Responding). The user sees in-progress indicators (`◐`/`○`) for work that already finished in an earlier turn — exactly the scenario in the #7831 screenshot: the model hit ECONNRESET, the turn ended, the user typed `/stats`, and the old todo list reappeared.

## Reviewer Test Plan

### How to verify

1. Run the unit tests: `cd packages/cli && npx vitest run src/ui/utils/todoSnapshot.test.ts` — confirm the two new tests pass alongside all existing ones.
2. Manual check: start a multi-step task so the sticky todo panel appears, let the turn finish, then send a new message — the stale todo panel should not reappear during the new turn's response.
3. Confirm the normal case still works: while the model is actively working on a task with todos, the sticky panel should still appear and update as todos change.

### Evidence (Before & After)

N/A (data-layer logic change; the visual behavior is a panel not appearing when it previously did)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Unit tests only (`npx vitest run`).

## Risk & Scope

- Main risk or tradeoff: `Enter to steer` injects a user message mid-turn, which triggers the same turn-boundary check and temporarily hides the sticky panel. Impact is minimal — steer implies a direction change so old todos are likely stale anyway, and the model typically calls `todo_write` again shortly after, which creates a new snapshot after the steer message and the panel reappears. Worst case: the panel stays hidden for the remainder of that turn if the model doesn't update todos.
- Not validated / out of scope: a 100% precise fix that distinguishes steer messages from real turn starts (e.g., tracking a stale flag in the message-submission path) was considered but would invade the message-submission logic for marginal benefit.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #7061

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

防止 sticky todo 面板在新轮次中重新显示上一轮的过期 todo。sticky 面板现在会检查 history 中 todo 快照之后是否存在新的用户消息；如果存在，说明快照属于上一轮，面板保持隐藏。这是纯数据层的修改——不涉及布局组件或流式状态逻辑。

## 为什么需要

修复 #7061（#7062 未覆盖的重现场景）。

PR #7062 在流式空闲时隐藏了 sticky 面板，但用户发送新消息后（状态 → Responding），面板会带着过期 todo 重新出现。用户看到的是上一轮已完成工作的进行中指示器（`◐`/`○`）——正是 #7831 截图中的场景：模型遇到 ECONNRESET，轮次结束，用户输入 `/stats`，旧 todo 列表重新出现。

## 审阅者测试计划

### 如何验证

1. 运行单元测试：`cd packages/cli && npx vitest run src/ui/utils/todoSnapshot.test.ts`——确认两个新测试与所有现有测试一起通过。
2. 手动验证：启动一个多步骤任务使 sticky todo 面板出现，等轮次结束后发送新消息——过期的 todo 面板不应在新轮次的响应中重新出现。
3. 确认正常场景仍然有效：模型正在处理含 todo 的任务时，sticky 面板应正常显示并随 todo 变化更新。

### 证据（前后对比）

N/A（数据层逻辑变更；视觉行为是面板在之前会显示时不再显示）

### 测试环境

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### 环境（可选）

仅单元测试（`npx vitest run`）。

## 风险与范围

- 主要风险或权衡：`Enter to steer` 在模型响应过程中注入用户消息，会触发相同的轮次边界检查，临时隐藏 sticky 面板。实际影响很小——steer 本身意味着用户改变了方向，旧 todo 大概率已不适用；且模型收到 steer 后通常会很快更新 todo，新快照在 steer 消息之后，面板自动恢复。最坏情况：steer 后模型没更新 todo，面板在该轮剩余时间不显示。
- 未验证 / 不在范围内：曾考虑 100% 精确区分 steer 消息和真实轮次开始的方案（如在消息提交路径中跟踪 stale 标记），但这会侵入消息提交逻辑，收益有限。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

修复 #7061

</details>
