### PR TITLE
fix(core): short-circuit the flush wait when the output stream cannot flush

### DIFF
--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -1438,6 +1438,70 @@ describe('ShellTool', () => {
         );
         expect(deferred.end).not.toHaveBeenCalled();
       });
+
+      it('still waits when the stream has ended but not yet finished flushing', async () => {
+        // writableEnded flips true the moment `.end()` is called while
+        // bytes can still sit in the libuv queue — writableFinished
+        // only turns true with 'finish'. The short-circuit must NOT
+        // fire in this state: settling here is exactly the truncation
+        // window the flush wait exists to prevent.
+        const registry = mockConfig.getBackgroundShellRegistry();
+        const deferred = {
+          ...makeDeferredStream(),
+          writableEnded: true,
+          writableFinished: false,
+        };
+        const { shellId } = await startBackgroundAndExit(deferred);
+
+        // Mid-flush: the transition is still held…
+        expect(registry.complete).not.toHaveBeenCalled();
+
+        // …until the flush actually completes.
+        deferred.emit('finish');
+        expect(registry.complete).toHaveBeenCalledTimes(1);
+        expect(registry.complete).toHaveBeenCalledWith(
+          shellId,
+          0,
+          expect.any(Number),
+        );
+      });
+
+      it('disarms the flush timer when stream.end() throws synchronously', async () => {
+        // The catch path settles immediately — but it must also clear
+        // the already-armed timer, or 10s later it fires and logs a
+        // misleading flush-timeout warning for a shell that settled
+        // long ago.
+        vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+        try {
+          const registry = mockConfig.getBackgroundShellRegistry();
+          const deferred = makeDeferredStream();
+          deferred.end.mockImplementation(() => {
+            throw new Error('EBADF: bad file descriptor, close');
+          });
+          const { shellId } = await startBackgroundAndExit(deferred);
+
+          // Settled via the catch path, immediately.
+          expect(registry.complete).toHaveBeenCalledTimes(1);
+          expect(registry.complete).toHaveBeenCalledWith(
+            shellId,
+            0,
+            expect.any(Number),
+          );
+          expect(mockDebugLogger.warn).toHaveBeenCalledWith(
+            expect.stringContaining('closing output stream on settle threw'),
+          );
+
+          // The timer must be gone: advancing past the timeout fires
+          // nothing and logs nothing.
+          await vi.advanceTimersByTimeAsync(10_000);
+          expect(registry.complete).toHaveBeenCalledTimes(1);
+          expect(mockDebugLogger.warn).not.toHaveBeenCalledWith(
+            expect.stringContaining('flush timed out'),
+          );
+        } finally {
+          vi.useRealTimers();
+        }
+      });
     });
 
     it('rejects a bare trailing & in managed background mode', async () => {

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -1292,9 +1292,10 @@ describe('ShellTool', () => {
         };
       };
 
-      const startBackgroundAndExit = async (deferred: {
-        end: Mock;
-      }): Promise<{ shellId: string }> => {
+      const startBackgroundAndExit = async (
+        deferred: { end: Mock },
+        { expectFlushRequested = true } = {},
+      ): Promise<{ shellId: string }> => {
         vi.mocked(fs.createWriteStream).mockReturnValueOnce(
           deferred as unknown as fs.WriteStream,
         );
@@ -1318,8 +1319,10 @@ describe('ShellTool', () => {
         });
         // Flush the .then() microtask attached to resultPromise.
         await new Promise((r) => setImmediate(r));
-        // The stream has been asked to flush…
-        expect(deferred.end).toHaveBeenCalledTimes(1);
+        if (expectFlushRequested) {
+          // The stream has been asked to flush…
+          expect(deferred.end).toHaveBeenCalledTimes(1);
+        }
         return { shellId: entry.shellId };
       };
 
@@ -1340,8 +1343,9 @@ describe('ShellTool', () => {
           expect.any(Number),
         );
 
-        // Exactly once: a late duplicate event must not re-transition.
-        deferred.emit('finish');
+        // Exactly once: the still-armed 'error' listener firing later
+        // must not re-transition. (A second 'finish' emit would be
+        // vacuous — `once` semantics already drained its handler.)
         deferred.emit('error');
         expect(registry.complete).toHaveBeenCalledTimes(1);
       });
@@ -1365,10 +1369,10 @@ describe('ShellTool', () => {
       });
 
       it('transitions after the flush timeout when the stream never settles', async () => {
-        // Wedged fd whose 'finish'/'error' never fire (e.g. destroyed
-        // by an earlier write error): the 10s timer is the backstop.
-        // Fake only the timer functions so the setImmediate-based
-        // microtask flush in the helper stays real.
+        // Wedged fd whose 'finish'/'error' never fire (e.g. stuck
+        // mid-flush on an unresponsive filesystem): the 10s timer is
+        // the backstop. Fake only the timer functions so the
+        // setImmediate-based microtask flush in the helper stays real.
         vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
         try {
           const registry = mockConfig.getBackgroundShellRegistry();
@@ -1390,6 +1394,49 @@ describe('ShellTool', () => {
         } finally {
           vi.useRealTimers();
         }
+      });
+
+      it('settles immediately when the stream was already destroyed by a write error', async () => {
+        // fs.WriteStream has autoDestroy — an earlier EIO/ENOSPC write
+        // error destroys the stream long before the child exits. On a
+        // destroyed writable `.end()` is a silent no-op and neither
+        // 'finish' nor 'error' will ever fire, so waiting would stall
+        // the transition (and every /tasks or sidecar reader) for the
+        // full flush timeout with nothing left to flush.
+        const registry = mockConfig.getBackgroundShellRegistry();
+        const deferred = { ...makeDeferredStream(), destroyed: true };
+        const { shellId } = await startBackgroundAndExit(deferred, {
+          expectFlushRequested: false,
+        });
+
+        expect(registry.complete).toHaveBeenCalledTimes(1);
+        expect(registry.complete).toHaveBeenCalledWith(
+          shellId,
+          0,
+          expect.any(Number),
+        );
+        // The dead stream is not asked to flush at all.
+        expect(deferred.end).not.toHaveBeenCalled();
+      });
+
+      it('settles immediately when the stream has already finished flushing', async () => {
+        // writableFinished means every byte reached the fd and 'finish'
+        // already fired — nothing left to wait for. (The guard must NOT
+        // use writableEnded: that flag is already true mid-flush, which
+        // is exactly the window these tests exist to protect.)
+        const registry = mockConfig.getBackgroundShellRegistry();
+        const deferred = { ...makeDeferredStream(), writableFinished: true };
+        const { shellId } = await startBackgroundAndExit(deferred, {
+          expectFlushRequested: false,
+        });
+
+        expect(registry.complete).toHaveBeenCalledTimes(1);
+        expect(registry.complete).toHaveBeenCalledWith(
+          shellId,
+          0,
+          expect.any(Number),
+        );
+        expect(deferred.end).not.toHaveBeenCalled();
       });
     });
 

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -1022,9 +1022,10 @@ const OUTPUT_FLUSH_TIMEOUT_MS = 10_000;
  * lets `/tasks` consumers (and the status sidecar) observe a terminal
  * status and read the output file BEFORE the trailing bytes are on
  * disk, producing truncated logs. `'error'` covers a late EIO /
- * ENOSPC racing `.end()` itself, and the timer covers a stream whose
- * events never fire at all (e.g. one already destroyed by an earlier
- * write error) — whichever lands first, `settle` runs exactly once.
+ * ENOSPC racing `.end()` itself, an already-destroyed or
+ * already-finished stream short-circuits (neither event would ever
+ * fire on it), and the timer backstops a stream wedged mid-flush —
+ * whichever lands first, `settle` runs exactly once.
  */
 function endStreamThenSettle(
   stream: fs.WriteStream,
@@ -1033,27 +1034,33 @@ function endStreamThenSettle(
   settle: () => void,
 ): void {
   let settled = false;
+  let flushTimer: ReturnType<typeof setTimeout> | null = null;
   const runOnce = () => {
     if (settled) return;
     settled = true;
+    if (flushTimer !== null) clearTimeout(flushTimer);
     settle();
   };
+  // A destroyed or already-finished stream emits neither 'finish' nor
+  // 'error' — `.end()` on it is a silent no-op (Node only delivers
+  // ERR_STREAM_DESTROYED to an `end()` callback), so waiting would
+  // always burn the full timeout with nothing left to flush.
+  // `writableFinished`, not `writableEnded`: the latter is already
+  // true mid-flush, which is exactly the window this helper waits for.
+  if (stream.destroyed || stream.writableFinished) {
+    runOnce();
+    return;
+  }
   try {
-    const flushTimer = setTimeout(() => {
+    flushTimer = setTimeout(() => {
       debugLogger.warn(
         `${origin}: output stream flush timed out for ${shellId} after ${OUTPUT_FLUSH_TIMEOUT_MS}ms — transitioning registry without flush confirmation`,
       );
       runOnce();
     }, OUTPUT_FLUSH_TIMEOUT_MS);
     flushTimer.unref();
-    stream.once('finish', () => {
-      clearTimeout(flushTimer);
-      runOnce();
-    });
-    stream.once('error', () => {
-      clearTimeout(flushTimer);
-      runOnce();
-    });
+    stream.once('finish', runOnce);
+    stream.once('error', runOnce);
     stream.end();
   } catch (closeErr) {
     debugLogger.warn(


### PR DESCRIPTION
## What

Follow-up to #7833, implementing both findings from [the verification review](https://github.com/QwenLM/qwen-code/pull/7833#issuecomment-5092467219) by @wenshao (the fix raced the merge by a few seconds — it landed on the PR branch as `57e37a4` right after the merge commit was created, so it's re-submitted here on top of main):

- **Finding 1 (the suggested guard):** `endStreamThenSettle` now short-circuits before arming the timer when the stream can no longer flush: `if (stream.destroyed || stream.writableFinished)`. A destroyed stream (autoDestroy after an earlier EIO/ENOSPC write error) or an already-finished one emits neither `'finish'` nor `'error'`, and `.end()` on it is a silent no-op — so the settle stalled for the full 10s with nothing left to flush, `/tasks` and the sidecar reported `running` for a shell whose child had exited, and an `abortAll()` landing in that window (`/clear`, shutdown) would write `cancelled` to the sidecar as the wrong terminal status. Per the review's measured predicate table: `writableFinished`, not `writableEnded` — the latter is already true mid-flush, which is exactly the window the flush wait exists to protect.
- **Finding 2:** `clearTimeout(flushTimer)` is hoisted into `runOnce`, so the synchronous-throw path no longer leaves the timer armed to log a misleading flush-timeout warning 10s after the shell settled. This also covers any future exit path by construction.
- **Test nit:** dropped the vacuous duplicate-`'finish'` assertion (the mock's `once` semantics had already drained the handler, so the line could never discriminate; the exactly-once guard remains pinned by the `'error'` emit and the timeout test's late finish).

## Why

Both wedge states were measured in the #7833 review to burn the full timeout (healthy stream: 0ms; destroyed / already-ended: full 10s), and the mis-labeled `cancelled` sidecar status in the `/clear` window is a correctness regression on the error path, not just latency.

## Reviewer Test Plan

- `vitest run src/tools/shell.test.ts src/tools/shell.backgroundStatus.test.ts src/services/backgroundShellRegistry.test.ts` → 3 files, **344 tests passing** (two new deferred-stream tests: destroyed and already-finished streams settle immediately and are never asked to `.end()`).
- Mutation check: neutering the guard (`if (false && …)`) fails exactly the two new tests; restoring it goes green.
- `tsc --noEmit`, `eslint`, `prettier --check`: clean.

## Risk & Scope

Error-path-only behavior change in one shared helper; the healthy path still settles on `'finish'` with every byte on disk (pinned by the existing deferred-stream ordering tests, unchanged). No API or message changes.

## Linked Issues

Follow-up to #7833 (which was follow-up ① from the #7669 verification report).