### PR TITLE
test(web-shell): expand restored-history pagination regression coverage

### DIFF
--- a/packages/cli/src/acp-integration/session/history-replayer.test.ts
+++ b/packages/cli/src/acp-integration/session/history-replayer.test.ts
@@ -1552,4 +1552,26 @@ describe('HistoryReplayer', () => {
       expect(hasGap).toBe(false);
     });
   });
+
+  describe('qwen.session.recordId stamping', () => {
+    it('should stamp persisted updates with activeRecordId for user messages', async () => {
+      const userRecord = createUserRecord('Hello');
+      await replayer.replay([userRecord]);
+
+      expect(setActiveRecordIdSpy).toHaveBeenCalledWith(
+        userRecord.uuid,
+        userRecord.timestamp,
+      );
+    });
+
+    it('should stamp persisted updates with activeRecordId for assistant messages', async () => {
+      const assistantRecord = createAssistantRecord('Hi there');
+      await replayer.replay([assistantRecord]);
+
+      expect(setActiveRecordIdSpy).toHaveBeenCalledWith(
+        assistantRecord.uuid,
+        assistantRecord.timestamp,
+      );
+    });
+  });
 });

--- a/packages/core/src/services/session-transcript-reader.test.ts
+++ b/packages/core/src/services/session-transcript-reader.test.ts
@@ -178,7 +178,7 @@ describe('SessionTranscriptReader', () => {
     expect(page.records.map((item) => item.uuid)).toEqual(['u1']);
   });
 
-  it.each([0, -1, SESSION_TRANSCRIPT_MAX_LIMIT + 1, 1.5])(
+  it.each([0, -1, NaN, Infinity, SESSION_TRANSCRIPT_MAX_LIMIT + 1, 1.5])(
     'rejects invalid page limit %s',
     async (limit) => {
       await expect(
@@ -997,5 +997,63 @@ describe('SessionTranscriptReader', () => {
         (r) => r.uuid,
       ),
     ).toEqual(['33333333', '44444444']);
+  });
+
+  describe('boundary and turn-start edge cases', () => {
+    it('makes exact turn-boundary cuts when limit aligns perfectly', async () => {
+      await writeRecords([
+        record('u1', null, 'first prompt'),
+        record('a1', 'u1', 'first answer'),
+        record('u2', 'a1', 'second prompt'),
+        record('a2', 'u2', 'second answer'),
+      ]);
+
+      const reader = new SessionTranscriptReader(workspaceDir);
+      const first = await reader.readPage(sessionId, {
+        beforeRecordId: 'u2',
+        limit: 2,
+      });
+
+      expect(first.records.map((item) => item.uuid)).toEqual(['u1', 'a1']);
+      expect(first.hasMore).toBe(false);
+      expect(first.nextCursorState).toBeUndefined();
+    });
+
+    it('discovers backward boundary when beforeRecordId is an assistant record', async () => {
+      await writeRecords([
+        record('u1', null, 'first prompt'),
+        record('a1', 'u1', 'first answer'),
+        record('u2', 'a1', 'second prompt'),
+        record('a2', 'u2', 'second answer'),
+      ]);
+
+      const reader = new SessionTranscriptReader(workspaceDir);
+      const page = await reader.readPage(sessionId, {
+        beforeRecordId: 'a2',
+        limit: 2,
+      });
+
+      expect(page.records.map((item) => item.uuid)).toEqual(['u2']);
+      expect(page.direction).toBe('backward');
+      expect(page.hasMore).toBe(true);
+    });
+
+    it('pages backward through records without a normal user turn start', async () => {
+
+      await writeRecords([
+        record('a1', null, 'orphan assistant reply'),
+        record('u1', 'a1', 'second prompt'),
+        record('a2', 'u1', 'second answer'),
+      ]);
+
+      const reader = new SessionTranscriptReader(workspaceDir);
+      const page = await reader.readPage(sessionId, {
+        beforeRecordId: 'u1',
+        limit: 5,
+      });
+
+      expect(page.records.map((item) => item.uuid)).toEqual(['a1']);
+      expect(page.hasMore).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## What this PR does

This PR expands the regression test coverage for restored session history pagination as requested in #7084. It adds focused tests in `history-replayer.test.ts` to assert that replay production tracks the active record ID via `setActiveRecordId` for user and assistant messages. It also adds edge case tests in `session-transcript-reader.test.ts` for page-size parsing (adding `NaN` and `Infinity` to invalid limits) and boundary discovery (exact turn-boundary cuts, backward boundary discovery from assistant records, and records without a normal user turn start). Note: The transient retry and `beforeRecordId` query string encoding tests mentioned in the issue were already addressed in PR #7657.

## Why it's needed

This completes the non-blocking test suggestions deferred from the feature PR #7064. Expanding this coverage ensures the robustness of the pagination and replay logic against edge cases (like orphaned records or exact boundary alignments) without having widened the scope of the original feature PR.

## Reviewer Test Plan

### How to verify

Run the targeted unit tests for the modified files and confirm all new tests pass:
```bash
npx vitest run packages/cli/src/acp-integration/session/history-replayer.test.ts packages/core/src/services/session-transcript-reader.test.ts
```
*Note: There are a few pre-existing flaky tests in `session-transcript-reader.test.ts` related to file system timing on Windows (`Invalid transcript cursor`), but all newly added tests should pass.*

### Evidence (Before & After)

N/A (Non-UI changes, test-only PR)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

N/A (Only local unit test execution via `vitest`)

## Risk & Scope

- Main risk or tradeoff: None. This is a test-only PR and introduces no changes to production code.
- Not validated / out of scope: The transient retry and query string encoding tests were already implemented in #7657, so they are excluded here to prevent duplication.
- Breaking changes / migration notes: None.

## Linked Issues

Closes #7084

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

本 PR 根据 #7084 的要求，扩展了恢复会话历史分页的回归测试覆盖率。在 `history-replayer.test.ts` 中添加了针对性测试，以断言重放生产过程通过 `setActiveRecordId` 为用户和助手消息标记了活动记录 ID。同时，在 `session-transcript-reader.test.ts` 中添加了页面大小解析的边缘案例测试（在无效限制中增加了 `NaN` 和 `Infinity`）以及边界发现测试（精确的轮次边界切割、从助手记录向后发现边界，以及没有正常用户轮次开始的记录）。注：Issue 中提到的临时重试和 `beforeRecordId` 查询字符串编码测试已在 PR #7657 中解决，因此未包含在此处。

## 为什么需要它

这完成了从功能 PR #7064 中推迟的非阻塞性测试建议。扩展此覆盖率可确保分页和重放逻辑在面对边缘案例（如孤立记录或精确边界对齐）时的鲁棒性，同时不会扩大原功能 PR 的范围。

## 审查者测试计划

### 如何验证

运行修改文件的针对性单元测试，确认所有新测试通过：
```bash
npx vitest run packages/cli/src/acp-integration/session/history-replayer.test.ts packages/core/src/services/session-transcript-reader.test.ts
```
*注：`session-transcript-reader.test.ts` 中存在几个由于 Windows 文件系统计时问题导致的预先存在的偶发失败测试（`Invalid transcript cursor`），但所有新增测试均应通过。*

### 证据 (之前与之后)

N/A（非 UI 更改，仅测试 PR）

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |   ⚠️   |

### 环境 (可选)

N/A（仅通过 `vitest` 执行本地单元测试）

## 风险与范围

- 主要风险或权衡：无。这是一个仅包含测试的 PR，未对生产代码进行任何更改。
- 未验证/超出范围：临时重试和查询字符串编码测试已在 #7657 中实现，因此在此排除以避免重复。
- 破坏性更改/迁移说明：无。

## 关联 Issue

Closes #7084

</details>