### PR TITLE
fix(web-shell): report intended workspace to host when starting a new chat

### DIFF
--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -3570,6 +3570,123 @@ describe('App session callbacks', () => {
     );
   });
 
+  it('reports the primary workspace, not the stale connection workspace, when the selection is unset', async () => {
+    // The common new-chat path (sidebar "New task", /clear, /new) leaves
+    // selectedWorkspaceCwd undefined — that is how "primary" is spelled. The
+    // report must fall back to the primary workspace, not the stale
+    // connection.workspaceCwd left over from the previous session.
+    mockConnection.sessionId = undefined;
+    mockConnection.workspaceCwd = '/work/secondary';
+    mockWorkspace.capabilities = {
+      workspaces: [
+        { id: 'primary', cwd: '/workspace', primary: true, trusted: true },
+        {
+          id: 'secondary',
+          cwd: '/work/secondary',
+          primary: false,
+          trusted: true,
+        },
+      ],
+    };
+    const onSessionIdChange = vi.fn();
+
+    renderApp({ onSessionIdChange });
+    await flush();
+
+    expect(onSessionIdChange).toHaveBeenCalledWith(
+      undefined,
+      undefined,
+      '/workspace',
+    );
+    expect(onSessionIdChange).not.toHaveBeenCalledWith(
+      undefined,
+      'secondary',
+      '/work/secondary',
+    );
+  });
+
+  it('keeps reporting the active session workspace despite a conflicting next-session selection', async () => {
+    // A selection for the next session must not leak into an active session's
+    // report: while a session is live the host is routed by that session's own
+    // workspace.
+    mockConnection.workspaceCwd = '/work/secondary';
+    mockWorkspace.capabilities = {
+      workspaces: [
+        { id: 'primary', cwd: '/workspace', primary: true, trusted: true },
+        {
+          id: 'secondary',
+          cwd: '/work/secondary',
+          primary: false,
+          trusted: true,
+        },
+      ],
+    };
+    const onSessionIdChange = vi.fn();
+
+    renderApp({
+      onSessionIdChange,
+      initialSelectedWorkspaceCwd: '/workspace',
+    });
+    await flush();
+
+    expect(onSessionIdChange).toHaveBeenCalledWith(
+      'session-1',
+      'secondary',
+      '/work/secondary',
+    );
+    expect(onSessionIdChange).not.toHaveBeenCalledWith(
+      'session-1',
+      undefined,
+      '/workspace',
+    );
+  });
+
+  it('notifies the host on each deferred workspace switch while no session is active', async () => {
+    // With no active session the report must re-run when the next-session
+    // workspace selection changes, so a routing host follows each switch
+    // rather than reacting to session-id changes alone.
+    mockConnection.sessionId = undefined;
+    mockConnection.workspaceCwd = '/work/secondary';
+    mockWorkspace.capabilities = {
+      workspaces: [
+        { id: 'primary', cwd: '/workspace', primary: true, trusted: true },
+        {
+          id: 'secondary',
+          cwd: '/work/secondary',
+          primary: false,
+          trusted: true,
+        },
+        {
+          id: 'tertiary',
+          cwd: '/work/tertiary',
+          primary: false,
+          trusted: true,
+        },
+      ],
+    };
+    const onSessionIdChange = vi.fn();
+
+    renderApp({ onSessionIdChange });
+    await flush();
+
+    expect(onSessionIdChange).toHaveBeenLastCalledWith(
+      undefined,
+      undefined,
+      '/workspace',
+    );
+
+    act(() => {
+      testState.latestChatEditorProps?.onSelectWorkspace?.('/work/tertiary');
+    });
+    await flush();
+
+    expect(onSessionIdChange).toHaveBeenLastCalledWith(
+      undefined,
+      'tertiary',
+      '/work/tertiary',
+    );
+  });
+
   it('creates scratch once, accepts refreshed capabilities, and opens a fresh chat', async () => {
     mockWorkspace.capabilities = {
       features: [

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -3532,6 +3532,44 @@ describe('App session callbacks', () => {
     );
   });
 
+  it('reports the selected workspace, not the stale connection workspace, when no session is active', async () => {
+    // A cleared session leaves connection.workspaceCwd pointing at the old
+    // workspace (here: a secondary with a running task). Starting a new chat
+    // in the primary must report the primary, not route the host back to the
+    // stale workspace.
+    mockConnection.sessionId = undefined;
+    mockConnection.workspaceCwd = '/work/secondary';
+    mockWorkspace.capabilities = {
+      workspaces: [
+        { id: 'primary', cwd: '/workspace', primary: true, trusted: true },
+        {
+          id: 'secondary',
+          cwd: '/work/secondary',
+          primary: false,
+          trusted: true,
+        },
+      ],
+    };
+    const onSessionIdChange = vi.fn();
+
+    renderApp({
+      onSessionIdChange,
+      initialSelectedWorkspaceCwd: '/workspace',
+    });
+    await flush();
+
+    expect(onSessionIdChange).toHaveBeenCalledWith(
+      undefined,
+      undefined,
+      '/workspace',
+    );
+    expect(onSessionIdChange).not.toHaveBeenCalledWith(
+      undefined,
+      'secondary',
+      '/work/secondary',
+    );
+  });
+
   it('creates scratch once, accepts refreshed capabilities, and opens a fresh chat', async () => {
     mockWorkspace.capabilities = {
       features: [

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -4619,8 +4619,16 @@ export function App({
       lastNotifiedWorkspaceCwdRef.current = undefined;
       return;
     }
+    // With no active session (deferred or just cleared) the connection's
+    // workspaceCwd is a leftover from the previous session — routing the host
+    // by it would send a "new chat in workspace A" back to the old workspace
+    // (e.g. one with a running task). The workspace picked for the next
+    // session is the source of truth in that state.
+    const reportedWorkspaceCwd = connection.sessionId
+      ? connection.workspaceCwd
+      : (selectedWorkspaceCwd ?? connection.workspaceCwd);
     const activeWorkspace = workspaces.find(
-      (entry) => entry.cwd === connection.workspaceCwd,
+      (entry) => entry.cwd === reportedWorkspaceCwd,
     );
     if (connection.sessionId && !workspace.capabilities) return;
     const workspaceId =
@@ -4630,23 +4638,24 @@ export function App({
     if (
       lastNotifiedSessionIdRef.current === connection.sessionId &&
       lastNotifiedWorkspaceIdRef.current === workspaceId &&
-      lastNotifiedWorkspaceCwdRef.current === connection.workspaceCwd
+      lastNotifiedWorkspaceCwdRef.current === reportedWorkspaceCwd
     ) {
       return;
     }
     lastNotifiedSessionIdRef.current = connection.sessionId;
     lastNotifiedWorkspaceIdRef.current = workspaceId;
-    lastNotifiedWorkspaceCwdRef.current = connection.workspaceCwd;
+    lastNotifiedWorkspaceCwdRef.current = reportedWorkspaceCwd;
     onSessionIdChange?.(
       connection.sessionId,
       workspaceId,
-      connection.workspaceCwd,
+      reportedWorkspaceCwd,
     );
   }, [
     connection.missingSession,
     connection.sessionId,
     connection.workspaceCwd,
     onSessionIdChange,
+    selectedWorkspaceCwd,
     workspace.capabilities,
     workspaces,
   ]);

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -4619,14 +4619,12 @@ export function App({
       lastNotifiedWorkspaceCwdRef.current = undefined;
       return;
     }
-    // With no active session (deferred or just cleared) the connection's
-    // workspaceCwd is a leftover from the previous session — routing the host
-    // by it would send a "new chat in workspace A" back to the old workspace
-    // (e.g. one with a running task). The workspace picked for the next
-    // session is the source of truth in that state.
-    const reportedWorkspaceCwd = connection.sessionId
-      ? connection.workspaceCwd
-      : (selectedWorkspaceCwd ?? connection.workspaceCwd);
+    // After a session is cleared the connection's workspaceCwd is a leftover
+    // from the previous session; reporting it would misroute the host back to
+    // the old workspace. activeWorkspaceCwd resolves the workspace picked for
+    // the next session (locked / selected / primary) and is what the composer
+    // chip reports, so the host and the chip stay in agreement.
+    const reportedWorkspaceCwd = activeWorkspaceCwd ?? connection.workspaceCwd;
     const activeWorkspace = workspaces.find(
       (entry) => entry.cwd === reportedWorkspaceCwd,
     );
@@ -4655,7 +4653,7 @@ export function App({
     connection.sessionId,
     connection.workspaceCwd,
     onSessionIdChange,
-    selectedWorkspaceCwd,
+    activeWorkspaceCwd,
     workspace.capabilities,
     workspaces,
   ]);


### PR DESCRIPTION
## What this PR does

When you start a new chat in a multi-workspace Web Shell, the workspace reported to the host (and therefore shown in the composer's workspace chip/selector) is now the workspace you actually picked for the new chat. Previously, if another workspace had the active session — for example one with a running task — the new chat could be reported against that other workspace instead, so the composer showed the wrong workspace right after the new session appeared.

## Why it's needed

Clearing a session to start a fresh chat drops the session id but keeps the connection's last workspace around as a leftover. The notification that tells the host "the view changed" read that leftover workspace, so a "new chat in workspace A" was routed back to the previous workspace B. The host then re-mounted the shell for workspace B, and the composer displayed B even though the user asked for A. The leftover workspace only matters when there is no active session, which is exactly the state a cleared/new chat is in — so with no active session we now report the workspace picked for the next session rather than the stale connection workspace. Behavior with an active session is unchanged.

## Reviewer Test Plan

### How to verify

- Unit: a regression test covers the exact state — no active session, a stale connection workspace pointing at a secondary workspace, and the next-session workspace set to the primary. It asserts the host is notified with the primary, not the secondary. This test fails on `main` (reports the stale secondary) and passes with this change.
- Manual (multi-workspace deployment): with workspaces A and B registered, start a long-running task in B so B holds the active session, then click "new task" under workspace A in the sidebar. Expected: the composer's workspace indicator shows A. Observed before the fix: it showed B.

### Evidence (Before & After)

Verified via the regression test in `client/App.test.tsx`:
- Before (stashed fix): `reports the selected workspace...` fails — `onSessionIdChange` was called with `(undefined, 'secondary', '/work/secondary')`.
- After: the same test passes — `onSessionIdChange` is called with `(undefined, undefined, '/workspace')` and never with the stale secondary.
- Full `client/App.test.tsx` suite: 234 passed.

Manual TUI capture in a real multi-workspace daemon was not recorded; the routing behavior is exercised by the unit test above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only (`npx vitest run client/App.test.tsx` in `packages/web-shell`), plus package typecheck and ESLint.

## Risk & Scope

- Main risk or tradeoff: with no active session, changing the next-session workspace now also notifies the host (previously it could stay silent and leave the host route stale). The existing last-notified guard prevents duplicate notifications, and the full App suite passes.
- Not validated / out of scope: no manual multi-workspace TUI recording; behavior with an active session is intentionally unchanged.
- Breaking changes / migration notes: none.

## Linked Issues

<!-- No linked issue; this addresses a reported multi-workspace composer bug. -->

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在多 workspace 的 Web Shell 中新建会话时，上报给 host（也就是 composer 里 workspace 标签/选择器显示的）workspace，现在会是你真正为本次新会话选择的 workspace。之前，如果另一个 workspace 持有当前活跃会话（例如它有正在运行的任务），新会话可能被上报成那个 workspace，导致新会话出现后 composer 立刻显示错误的 workspace。

## 为什么需要

清空会话以开启新聊天时，会清掉 session id，但 connection 上一次的 workspace 会作为残留保留下来。那个告诉 host「视图变了」的通知读取了这个残留 workspace，于是「在 A 新建会话」被路由回了上一个 workspace B。host 随后按 workspace B 重新挂载 shell，composer 就显示 B，即使用户要的是 A。残留 workspace 只在没有活跃会话时才有影响，而清空/新建会话恰恰就处于这种状态——所以在没有活跃会话时，现在上报「为下一个会话选择的 workspace」，而不是残留的 connection workspace。有活跃会话时的行为保持不变。

## 评审测试计划

### 如何验证

- 单测：一个回归测试覆盖了精确状态——无活跃会话、残留的 connection workspace 指向某个 secondary workspace、下一会话 workspace 设为 primary。它断言 host 收到的是 primary，而不是 secondary。该测试在 `main` 上失败（上报残留的 secondary），在本改动后通过。
- 手动（多 workspace 部署）：注册 workspace A 和 B，在 B 中启动一个长时间运行的任务使 B 持有活跃会话，然后点击侧栏 A 下的「new task」。预期：composer 的 workspace 指示显示 A。修复前观察到：显示 B。

### 证据（Before & After）

通过 `client/App.test.tsx` 中的回归测试验证：
- 修复前（stash 掉修复）：`reports the selected workspace...` 失败——`onSessionIdChange` 被以 `(undefined, 'secondary', '/work/secondary')` 调用。
- 修复后：同一测试通过——`onSessionIdChange` 被以 `(undefined, undefined, '/workspace')` 调用，且从不以残留的 secondary 调用。
- 完整 `client/App.test.tsx` 套件：234 通过。

未在真实多 workspace daemon 中录制手动 TUI；上述路由行为由单测覆盖。

### 测试环境

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

仅单测（在 `packages/web-shell` 中 `npx vitest run client/App.test.tsx`），外加 package typecheck 与 ESLint。

## 风险与范围

- 主要风险/权衡：在没有活跃会话时，更改下一会话 workspace 现在也会通知 host（之前可能保持沉默，使 host 路由保持过期）。已有的 last-notified 守卫避免了重复通知，完整 App 套件通过。
- 未验证/超出范围：未做手动多 workspace TUI 录制；有活跃会话时的行为有意保持不变。
- 破坏性变更/迁移说明：无。

## 关联 Issue

<!-- 无关联 issue；本 PR 修复一个已上报的多 workspace composer 问题。 -->

</details>
