### PR TITLE
feat(core): bound image reads for reliable zoom

### DIFF
--- a/packages/core/src/tools/read-file.test.ts
+++ b/packages/core/src/tools/read-file.test.ts
@@ -12,6 +12,7 @@ import path from 'node:path';
 import os from 'node:os';
 import fs from 'node:fs';
 import fsp from 'node:fs/promises';
+import sharp from 'sharp';
 import type { Config } from '../config/config.js';
 import { Storage } from '../config/storage.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
@@ -545,11 +546,16 @@ describe('ReadFileTool', () => {
 
     it('should handle image file and return appropriate content', async () => {
       const imagePath = path.join(tempRootDir, 'image.png');
-      // Minimal PNG header
-      const pngHeader = Buffer.from([
-        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
-      ]);
-      await fsp.writeFile(imagePath, pngHeader);
+      await sharp({
+        create: {
+          width: 20,
+          height: 10,
+          channels: 3,
+          background: '#306090',
+        },
+      })
+        .png()
+        .toFile(imagePath);
       const params: ReadFileToolParams = { file_path: imagePath };
       const invocation = tool.build(params) as ToolInvocation<
         ReadFileToolParams,
@@ -557,13 +563,20 @@ describe('ReadFileTool', () => {
       >;
 
       const result = await invocation.execute(abortSignal);
-      expect(result.llmContent).toEqual({
-        inlineData: {
-          data: pngHeader.toString('base64'),
-          mimeType: 'image/png',
-          displayName: 'image.png',
+      expect(result.llmContent).toEqual([
+        {
+          text: expect.stringMatching(
+            /Image overview: 20x10; oriented source: 20x10.*tool_search.*zoom_image.*0 to 1000/,
+          ),
         },
-      });
+        {
+          inlineData: {
+            data: expect.any(String),
+            mimeType: 'image/jpeg',
+            displayName: 'image.png',
+          },
+        },
+      ]);
       expect(result.returnDisplay).toBe('Read image file: image.png');
     });
 
@@ -1526,17 +1539,23 @@ describe('ReadFileTool', () => {
 
       it('does not return the placeholder for image files', async () => {
         const imagePath = path.join(tempRootDir, 'pic.png');
-        const pngHeader = Buffer.from([
-          0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
-        ]);
-        await fsp.writeFile(imagePath, pngHeader);
+        await sharp({
+          create: {
+            width: 8,
+            height: 8,
+            channels: 3,
+            background: '#306090',
+          },
+        })
+          .png()
+          .toFile(imagePath);
 
         const first = await read({ file_path: imagePath });
-        // Image returns a Part, not a string.
+        // Image returns Parts, not a string.
         expect(typeof first.llmContent).not.toBe('string');
 
         const second = await read({ file_path: imagePath });
-        // Must remain a Part — never collapsed to a string placeholder.
+        // Must remain Parts — never collapsed to a string placeholder.
         expect(typeof second.llmContent).not.toBe('string');
       });
 

--- a/packages/core/src/tools/zoom-image.ts
+++ b/packages/core/src/tools/zoom-image.ts
@@ -5,30 +5,23 @@
  */
 
 import path from 'node:path';
-import fs from 'node:fs/promises';
 import type { Part } from '@google/genai';
-import type { Metadata } from 'sharp';
 import type { Config } from '../config/config.js';
 import type { PermissionDecision } from '../permissions/types.js';
 import { logFileOperation } from '../telemetry/loggers.js';
 import { FileOperation } from '../telemetry/metrics.js';
 import { FileOperationEvent } from '../telemetry/types.js';
 import { getSpecificMimeType } from '../utils/fileUtils.js';
+import {
+  ImageViewError,
+  renderNormalizedImageCrop,
+} from '../utils/image-view.js';
 import { makeRelative, shortenPath, unescapePath } from '../utils/paths.js';
 import { getFileReadDefaultPermission } from './file-read-permission.js';
 import { ToolErrorType } from './tool-error.js';
 import { ToolDisplayNames, ToolNames } from './tool-names.js';
 import type { ToolInvocation, ToolLocation, ToolResult } from './tools.js';
 import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
-
-const IMAGE_VIEW_MAX_EDGE = 1568;
-const IMAGE_VIEW_MAX_PATCHES = 1568;
-const IMAGE_PATCH_SIZE = 28;
-const IMAGE_MAX_UPSCALE = 8;
-const IMAGE_JPEG_QUALITY = 92;
-const IMAGE_MAX_SOURCE_BYTES = 100 * 1024 * 1024;
-const IMAGE_MAX_OUTPUT_BYTES = 9 * 1024 * 1024;
-const SUPPORTED_IMAGE_FORMATS = new Set(['jpeg', 'png', 'webp']);
 
 export interface ZoomImageParams {
   file_path: string;
@@ -38,59 +31,12 @@ export interface ZoomImageParams {
   y2: number;
 }
 
-interface ImageSize {
-  width: number;
-  height: number;
-}
-
 function failureResult(message: string, type: ToolErrorType): ToolResult {
   return {
     llmContent: message,
     returnDisplay: message,
     error: { message, type },
   };
-}
-
-function fitsVisualBudget({ width, height }: ImageSize): boolean {
-  return (
-    width <= IMAGE_VIEW_MAX_EDGE &&
-    height <= IMAGE_VIEW_MAX_EDGE &&
-    Math.ceil(width / IMAGE_PATCH_SIZE) *
-      Math.ceil(height / IMAGE_PATCH_SIZE) <=
-      IMAGE_VIEW_MAX_PATCHES
-  );
-}
-
-function magnifiedSize(width: number, height: number): ImageSize {
-  const widthIsLongEdge = width >= height;
-  const maxLongEdge = Math.min(
-    IMAGE_VIEW_MAX_EDGE,
-    Math.max(width, height) * IMAGE_MAX_UPSCALE,
-  );
-  let low = 1;
-  let high = maxLongEdge;
-  let best: ImageSize = { width: 1, height: 1 };
-
-  while (low <= high) {
-    const longEdge = Math.floor((low + high) / 2);
-    const candidate = widthIsLongEdge
-      ? {
-          width: longEdge,
-          height: Math.max(1, Math.round((height / width) * longEdge)),
-        }
-      : {
-          width: Math.max(1, Math.round((width / height) * longEdge)),
-          height: longEdge,
-        };
-    if (fitsVisualBudget(candidate)) {
-      best = candidate;
-      low = longEdge + 1;
-    } else {
-      high = longEdge - 1;
-    }
-  }
-
-  return best;
 }
 
 class ZoomImageInvocation extends BaseToolInvocation<
@@ -130,145 +76,47 @@ class ZoomImageInvocation extends BaseToolInvocation<
         ToolErrorType.READ_CONTENT_FAILURE,
       );
     }
-    let sharp: typeof import('sharp');
+    let view: Awaited<ReturnType<typeof renderNormalizedImageCrop>>;
     try {
-      // sharp is a CJS `export =` module: at runtime the dynamic-import
-      // namespace carries the callable on `.default`, which the NodeNext types
-      // collapse away, so unwrap it explicitly (cf. utils/iconvHelper.ts).
-      sharp = (
-        (await import('sharp')) as unknown as {
-          default: typeof import('sharp');
-        }
-      ).default;
-    } catch {
-      return failureResult(
-        'zoom_image is unavailable because the "sharp" image module could not be loaded.',
-        ToolErrorType.READ_CONTENT_FAILURE,
+      view = await renderNormalizedImageCrop(
+        this.params.file_path,
+        this.params,
+        signal,
       );
-    }
-    let stats: Awaited<ReturnType<typeof fs.stat>>;
-    try {
-      stats = await fs.stat(this.params.file_path);
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-        return failureResult(
-          `Image file not found: ${this.params.file_path}`,
-          ToolErrorType.FILE_NOT_FOUND,
-        );
-      }
-      throw error;
-    }
-    if (stats.isDirectory()) {
-      return failureResult(
-        `Image path is a directory: ${this.params.file_path}`,
-        ToolErrorType.TARGET_IS_DIRECTORY,
-      );
-    }
-    if (!stats.isFile()) {
-      return failureResult(
-        `Image path is not a regular file: ${this.params.file_path}`,
-        ToolErrorType.TARGET_NOT_REGULAR_FILE,
-      );
-    }
-    if (stats.size > IMAGE_MAX_SOURCE_BYTES) {
-      return failureResult(
-        `Image file exceeds the 100 MB source limit: ${this.params.file_path}`,
-        ToolErrorType.FILE_TOO_LARGE,
-      );
-    }
-    let metadata: Metadata;
-    try {
-      metadata = await sharp(this.params.file_path, {
-        failOn: 'error',
-        limitInputPixels: true,
-      }).metadata();
-    } catch {
-      return failureResult(
-        `Unsupported image. zoom_image accepts static PNG, JPEG, or WebP files: ${this.params.file_path}`,
-        ToolErrorType.READ_CONTENT_FAILURE,
-      );
-    }
-    signal.throwIfAborted();
-    if (!SUPPORTED_IMAGE_FORMATS.has(metadata.format)) {
-      return failureResult(
-        `Unsupported image. zoom_image accepts static PNG, JPEG, or WebP files: ${this.params.file_path}`,
-        ToolErrorType.READ_CONTENT_FAILURE,
-      );
-    }
-    if ((metadata.pages ?? 1) > 1) {
-      return failureResult(
-        `zoom_image accepts static images only: ${this.params.file_path}`,
-        ToolErrorType.READ_CONTENT_FAILURE,
-      );
-    }
-
-    const sourceWidth = metadata.autoOrient.width;
-    const sourceHeight = metadata.autoOrient.height;
-    const left = Math.min(
-      sourceWidth - 1,
-      Math.max(0, Math.floor((this.params.x1 / 1000) * sourceWidth)),
-    );
-    const top = Math.min(
-      sourceHeight - 1,
-      Math.max(0, Math.floor((this.params.y1 / 1000) * sourceHeight)),
-    );
-    const right = Math.min(
-      sourceWidth,
-      Math.max(left + 1, Math.ceil((this.params.x2 / 1000) * sourceWidth)),
-    );
-    const bottom = Math.min(
-      sourceHeight,
-      Math.max(top + 1, Math.ceil((this.params.y2 / 1000) * sourceHeight)),
-    );
-    const cropWidth = right - left;
-    const cropHeight = bottom - top;
-    const outputSize = magnifiedSize(cropWidth, cropHeight);
-
-    let output: Buffer;
-    try {
-      output = await sharp(this.params.file_path, {
-        autoOrient: true,
-        failOn: 'error',
-        limitInputPixels: true,
-      })
-        .extract({ left, top, width: cropWidth, height: cropHeight })
-        .resize(outputSize.width, outputSize.height, {
-          fit: 'fill',
-          kernel: sharp.kernel.lanczos3,
-        })
-        .flatten({ background: '#ffffff' })
-        .jpeg({
-          quality: IMAGE_JPEG_QUALITY,
-          chromaSubsampling: '4:4:4',
-        })
-        .toBuffer();
-    } catch {
       signal.throwIfAborted();
-      return failureResult(
-        `Failed to decode image: ${this.params.file_path}`,
-        ToolErrorType.READ_CONTENT_FAILURE,
-      );
-    }
-    signal.throwIfAborted();
-    if (output.length > IMAGE_MAX_OUTPUT_BYTES) {
-      return failureResult(
-        `Zoomed image exceeds the 9 MB output limit: ${this.params.file_path}`,
-        ToolErrorType.FILE_TOO_LARGE,
-      );
+      const message =
+        error instanceof Error ? error.message : 'Failed to decode image.';
+      let errorType = ToolErrorType.READ_CONTENT_FAILURE;
+      if (error instanceof ImageViewError) {
+        if (error.code === 'file_not_found') {
+          errorType = ToolErrorType.FILE_NOT_FOUND;
+        } else if (error.code === 'target_is_directory') {
+          errorType = ToolErrorType.TARGET_IS_DIRECTORY;
+        } else if (error.code === 'target_not_regular_file') {
+          errorType = ToolErrorType.TARGET_NOT_REGULAR_FILE;
+        } else if (
+          error.code === 'source_too_large' ||
+          error.code === 'output_too_large'
+        ) {
+          errorType = ToolErrorType.FILE_TOO_LARGE;
+        }
+      }
+      return failureResult(message, errorType);
     }
 
     const text =
       `Zoomed normalized region (${this.params.x1},${this.params.y1})-` +
       `(${this.params.x2},${this.params.y2}) from ${this.params.file_path}. ` +
-      `Oriented source: ${sourceWidth}x${sourceHeight}; source crop: ` +
-      `${cropWidth}x${cropHeight}; returned view: ` +
-      `${outputSize.width}x${outputSize.height}.`;
+      `Oriented source: ${view.sourceWidth}x${view.sourceHeight}; source crop: ` +
+      `${view.selectedWidth}x${view.selectedHeight}; returned view: ` +
+      `${view.outputWidth}x${view.outputHeight}.`;
     const llmContent: Part[] = [
       { text },
       {
         inlineData: {
-          mimeType: 'image/jpeg',
-          data: output.toString('base64'),
+          mimeType: view.mimeType,
+          data: view.bytes.toString('base64'),
         },
       },
     ];

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -22,6 +22,7 @@ import path from 'node:path';
 import os from 'node:os';
 import mime from 'mime/lite';
 import type { Part } from '@google/genai';
+import sharp from 'sharp';
 
 import {
   isWithinRoot,
@@ -1179,28 +1180,169 @@ describe('fileUtils', () => {
     });
 
     it('should process an image file', async () => {
-      const fakePngData = Buffer.from('fake png data');
-      actualNodeFs.writeFileSync(testImageFilePath, fakePngData);
+      await sharp({
+        create: {
+          width: 20,
+          height: 10,
+          channels: 3,
+          background: '#306090',
+        },
+      })
+        .png()
+        .toFile(testImageFilePath);
       mockMimeGetType.mockReturnValue('image/png');
       const result = await processSingleFileContent(
         testImageFilePath,
         mockConfig,
       );
-      expect(
-        (result.llmContent as { inlineData: unknown }).inlineData,
-      ).toBeDefined();
-      expect(
-        (result.llmContent as { inlineData: { mimeType: string } }).inlineData
-          .mimeType,
-      ).toBe('image/png');
-      expect(
-        (result.llmContent as { inlineData: { data: string } }).inlineData.data,
-      ).toBe(fakePngData.toString('base64'));
-      expect(
-        (result.llmContent as { inlineData: { displayName?: string } })
-          .inlineData.displayName,
-      ).toBe('image.png');
+      const parts = result.llmContent as Part[];
+      expect(parts[0]).toEqual({
+        text:
+          'Image overview: 20x10; oriented source: 20x10. ' +
+          'If details are too small, use tool_search for "zoom image", then ' +
+          'call zoom_image with coordinates normalized from 0 to 1000.',
+      });
+      expect(parts[1]).toEqual({
+        inlineData: {
+          mimeType: 'image/jpeg',
+          data: expect.any(String),
+          displayName: 'image.png',
+        },
+      });
+      const metadata = await sharp(
+        Buffer.from(parts[1]!.inlineData!.data!, 'base64'),
+      ).metadata();
+      expect(metadata).toMatchObject({ width: 20, height: 10 });
       expect(result.returnDisplay).toContain('Read image file: image.png');
+    });
+
+    it('returns a bounded overview when a PNG exceeds the old data URI limit', async () => {
+      const largeImagePath = path.join(tempRootDir, 'large.png');
+      await sharp({
+        create: {
+          width: 2200,
+          height: 1800,
+          channels: 3,
+          background: '#306090',
+        },
+      })
+        .png({ compressionLevel: 0 })
+        .toFile(largeImagePath);
+      expect(actualNodeFs.statSync(largeImagePath).size).toBeGreaterThan(
+        9.9 * 1024 * 1024,
+      );
+      mockMimeGetType.mockReturnValue('image/png');
+
+      const result = await processSingleFileContent(largeImagePath, mockConfig);
+
+      expect(result.error).toBeUndefined();
+      const parts = result.llmContent as Part[];
+      const overview = parts[1]!.inlineData!;
+      const metadata = await sharp(
+        Buffer.from(overview.data!, 'base64'),
+      ).metadata();
+      expect(overview.mimeType).toBe('image/jpeg');
+      expect(Buffer.from(overview.data!, 'base64').length).toBeLessThanOrEqual(
+        9 * 1024 * 1024,
+      );
+      expect(Math.max(metadata.width!, metadata.height!)).toBeLessThanOrEqual(
+        1568,
+      );
+      expect(
+        Math.ceil(metadata.width! / 28) * Math.ceil(metadata.height! / 28),
+      ).toBeLessThanOrEqual(1568);
+    });
+
+    it('rejects canonical image sources above 100 MB before decoding', async () => {
+      const oversizedPath = path.join(tempRootDir, 'oversized.png');
+      const handle = await fsPromises.open(oversizedPath, 'w');
+      await handle.truncate(100 * 1024 * 1024 + 1);
+      await handle.close();
+      mockMimeGetType.mockReturnValue('image/png');
+
+      const result = await processSingleFileContent(oversizedPath, mockConfig);
+
+      expect(result.errorType).toBe(ToolErrorType.FILE_TOO_LARGE);
+      expect(result.llmContent).toContain('100 MB source limit');
+    });
+
+    it('applies EXIF orientation before describing and rendering an overview', async () => {
+      const orientedPath = path.join(tempRootDir, 'oriented.jpg');
+      await sharp({
+        create: {
+          width: 60,
+          height: 40,
+          channels: 3,
+          background: '#306090',
+        },
+      })
+        .jpeg()
+        .withMetadata({ orientation: 6 })
+        .toFile(orientedPath);
+      mockMimeGetType.mockReturnValue('image/jpeg');
+
+      const result = await processSingleFileContent(orientedPath, mockConfig);
+      const parts = result.llmContent as Part[];
+      const metadata = await sharp(
+        Buffer.from(parts[1]!.inlineData!.data!, 'base64'),
+      ).metadata();
+
+      expect(parts[0]?.text).toContain('oriented source: 40x60');
+      expect(metadata).toMatchObject({ width: 40, height: 60 });
+    });
+
+    it('flattens transparent overview pixels onto white', async () => {
+      const transparentPath = path.join(tempRootDir, 'transparent.webp');
+      await sharp({
+        create: {
+          width: 20,
+          height: 20,
+          channels: 4,
+          background: { r: 0, g: 0, b: 0, alpha: 0 },
+        },
+      })
+        .webp()
+        .toFile(transparentPath);
+      mockMimeGetType.mockReturnValue('image/webp');
+
+      const result = await processSingleFileContent(
+        transparentPath,
+        mockConfig,
+      );
+      const parts = result.llmContent as Part[];
+      const { data, info } = await sharp(
+        Buffer.from(parts[1]!.inlineData!.data!, 'base64'),
+      )
+        .raw()
+        .toBuffer({ resolveWithObject: true });
+      const center =
+        (Math.floor(info.height / 2) * info.width +
+          Math.floor(info.width / 2)) *
+        info.channels;
+
+      expect(Array.from(data.subarray(center, center + 3))).toEqual([
+        255, 255, 255,
+      ]);
+    });
+
+    it.each([
+      ['animated GIF', 'animation.gif', 'image/gif'],
+      ['BMP', 'bitmap.bmp', 'image/bmp'],
+    ])('keeps %s image bytes unchanged', async (_label, name, mimeType) => {
+      const filePath = path.join(tempRootDir, name);
+      const bytes = Buffer.from('unchanged image bytes');
+      actualNodeFs.writeFileSync(filePath, bytes);
+      mockMimeGetType.mockReturnValue(mimeType);
+
+      const result = await processSingleFileContent(filePath, mockConfig);
+
+      expect(result.llmContent).toEqual({
+        inlineData: {
+          data: bytes.toString('base64'),
+          mimeType,
+          displayName: name,
+        },
+      });
     });
 
     it('should reject image files when model does not support image', async () => {
@@ -1224,8 +1366,16 @@ describe('fileUtils', () => {
     });
 
     it('keeps image inline when preserveUnsupportedImage is true', async () => {
-      const fakePngData = Buffer.from('fake png data');
-      actualNodeFs.writeFileSync(testImageFilePath, fakePngData);
+      await sharp({
+        create: {
+          width: 8,
+          height: 8,
+          channels: 3,
+          background: '#306090',
+        },
+      })
+        .png()
+        .toFile(testImageFilePath);
       mockMimeGetType.mockReturnValue('image/png');
 
       const mockConfigNoImage = {
@@ -1239,10 +1389,13 @@ describe('fileUtils', () => {
         { preserveUnsupportedImage: true },
       );
       expect(typeof result.llmContent).toBe('object');
-      expect(
-        (result.llmContent as { inlineData: { mimeType: string } }).inlineData
-          .mimeType,
-      ).toBe('image/png');
+      const parts = result.llmContent as Part[];
+      expect(parts[0]?.text).toContain('Image overview');
+      expect(parts[1]?.inlineData).toMatchObject({
+        mimeType: 'image/jpeg',
+        data: expect.any(String),
+        displayName: 'image.png',
+      });
       expect(result.returnDisplay).toContain('Read image file');
     });
 
@@ -1283,6 +1436,29 @@ describe('fileUtils', () => {
       );
       expect(typeof result.llmContent).toBe('string');
       expect(result.llmContent).toContain('does not support audio input');
+    });
+
+    it('keeps supported audio bytes unchanged', async () => {
+      const audioPath = path.join(tempRootDir, 'clip.mp3');
+      const audioBytes = Buffer.from('fake audio data');
+      actualNodeFs.writeFileSync(audioPath, audioBytes);
+      mockMimeGetType.mockReturnValue('audio/mpeg');
+      const audioConfig = {
+        ...mockConfig,
+        getContentGeneratorConfig: () => ({
+          modalities: { image: true, audio: true, video: true },
+        }),
+      } as unknown as Config;
+
+      const result = await processSingleFileContent(audioPath, audioConfig);
+
+      expect(result.llmContent).toEqual({
+        inlineData: {
+          data: audioBytes.toString('base64'),
+          mimeType: 'audio/mpeg',
+          displayName: 'clip.mp3',
+        },
+      });
     });
 
     it('processes an .m4v video as inline data despite the mime/lite gap', async () => {
@@ -3088,16 +3264,11 @@ describe('fileUtils', () => {
     });
 
     it('should still return an error if an inline media file exceeds 10MB', async () => {
-      mockMimeGetType.mockReturnValue('image/png');
-      actualNodeFs.writeFileSync(
-        testImageFilePath,
-        Buffer.alloc(11 * 1024 * 1024),
-      );
+      const largeGifPath = path.join(tempRootDir, 'large.gif');
+      mockMimeGetType.mockReturnValue('image/gif');
+      actualNodeFs.writeFileSync(largeGifPath, Buffer.alloc(11 * 1024 * 1024));
 
-      const result = await processSingleFileContent(
-        testImageFilePath,
-        mockConfig,
-      );
+      const result = await processSingleFileContent(largeGifPath, mockConfig);
 
       expect(result.error).toContain('File size exceeds the 10MB limit');
       expect(result.returnDisplay).toContain(

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -1266,21 +1266,26 @@ describe('fileUtils', () => {
       expect(result.llmContent).toContain('100 MB source limit');
     });
 
-    it('returns READ_CONTENT_FAILURE for a corrupt canonical image', async () => {
+    it('forwards a corrupt canonical image verbatim instead of failing the read', async () => {
       const corruptPath = path.join(tempRootDir, 'corrupt.png');
-      await fsPromises.writeFile(corruptPath, 'not a real png');
+      const bytes = Buffer.from('not a real png');
+      await fsPromises.writeFile(corruptPath, bytes);
       mockMimeGetType.mockReturnValue('image/png');
 
       const result = await processSingleFileContent(corruptPath, mockConfig);
 
-      expect(result.errorType).toBe(ToolErrorType.READ_CONTENT_FAILURE);
-      expect(result.error).toContain(corruptPath);
-      expect(typeof result.llmContent).toBe('string');
-      expect(result.llmContent).not.toContain(corruptPath);
-      expect(result.returnDisplay).not.toContain(corruptPath);
+      expect(result.error).toBeUndefined();
+      expect(result.llmContent).toEqual({
+        inlineData: {
+          data: bytes.toString('base64'),
+          mimeType: 'image/png',
+          displayName: 'corrupt.png',
+        },
+      });
+      expect(result.returnDisplay).toContain('Read image file: corrupt.png');
     });
 
-    it('returns READ_CONTENT_FAILURE for an animated canonical image', async () => {
+    it('forwards an animated canonical image verbatim instead of failing the read', async () => {
       const twoFrameGif = Buffer.from(
         '47494638396101000100800000000000ffffff21f90400010000002c000000000100010000020244010021f90400010000002c00000000010001000002024c01003b',
         'hex',
@@ -1291,9 +1296,37 @@ describe('fileUtils', () => {
 
       const result = await processSingleFileContent(animatedPath, mockConfig);
 
-      expect(result.errorType).toBe(ToolErrorType.READ_CONTENT_FAILURE);
-      expect(typeof result.llmContent).toBe('string');
-      expect(result.llmContent).toMatch(/static/i);
+      const onDisk = await fsPromises.readFile(animatedPath);
+      expect(result.error).toBeUndefined();
+      expect(result.llmContent).toEqual({
+        inlineData: {
+          data: onDisk.toString('base64'),
+          mimeType: 'image/webp',
+          displayName: 'animated.webp',
+        },
+      });
+      expect(result.returnDisplay).toContain('Read image file: animated.webp');
+    });
+
+    it('forwards non-canonical content behind a canonical extension verbatim', async () => {
+      const gifBytes = Buffer.from(
+        '47494638396101000100800000000000ffffff21f90400010000002c000000000100010000020244010021f90400010000002c00000000010001000002024c01003b',
+        'hex',
+      );
+      const mismatchPath = path.join(tempRootDir, 'mismatch.png');
+      await fsPromises.writeFile(mismatchPath, gifBytes);
+      mockMimeGetType.mockReturnValue('image/png');
+
+      const result = await processSingleFileContent(mismatchPath, mockConfig);
+
+      expect(result.error).toBeUndefined();
+      expect(result.llmContent).toEqual({
+        inlineData: {
+          data: gifBytes.toString('base64'),
+          mimeType: 'image/png',
+          displayName: 'mismatch.png',
+        },
+      });
     });
 
     it('applies EXIF orientation before describing and rendering an overview', async () => {

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -1274,8 +1274,26 @@ describe('fileUtils', () => {
       const result = await processSingleFileContent(corruptPath, mockConfig);
 
       expect(result.errorType).toBe(ToolErrorType.READ_CONTENT_FAILURE);
-      expect(result.error).toBeDefined();
+      expect(result.error).toContain(corruptPath);
       expect(typeof result.llmContent).toBe('string');
+      expect(result.llmContent).not.toContain(corruptPath);
+      expect(result.returnDisplay).not.toContain(corruptPath);
+    });
+
+    it('returns READ_CONTENT_FAILURE for an animated canonical image', async () => {
+      const twoFrameGif = Buffer.from(
+        '47494638396101000100800000000000ffffff21f90400010000002c000000000100010000020244010021f90400010000002c00000000010001000002024c01003b',
+        'hex',
+      );
+      const animatedPath = path.join(tempRootDir, 'animated.webp');
+      await sharp(twoFrameGif, { animated: true }).webp().toFile(animatedPath);
+      mockMimeGetType.mockReturnValue('image/webp');
+
+      const result = await processSingleFileContent(animatedPath, mockConfig);
+
+      expect(result.errorType).toBe(ToolErrorType.READ_CONTENT_FAILURE);
+      expect(typeof result.llmContent).toBe('string');
+      expect(result.llmContent).toMatch(/static/i);
     });
 
     it('applies EXIF orientation before describing and rendering an overview', async () => {

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -1266,6 +1266,18 @@ describe('fileUtils', () => {
       expect(result.llmContent).toContain('100 MB source limit');
     });
 
+    it('returns READ_CONTENT_FAILURE for a corrupt canonical image', async () => {
+      const corruptPath = path.join(tempRootDir, 'corrupt.png');
+      await fsPromises.writeFile(corruptPath, 'not a real png');
+      mockMimeGetType.mockReturnValue('image/png');
+
+      const result = await processSingleFileContent(corruptPath, mockConfig);
+
+      expect(result.errorType).toBe(ToolErrorType.READ_CONTENT_FAILURE);
+      expect(result.error).toBeDefined();
+      expect(typeof result.llmContent).toBe('string');
+    });
+
     it('applies EXIF orientation before describing and rendering an overview', async () => {
       const orientedPath = path.join(tempRootDir, 'oriented.jpg');
       await sharp({

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -1480,9 +1480,10 @@ export async function processSingleFileContent(
                 error.code === 'output_too_large'
                   ? ToolErrorType.FILE_TOO_LARGE
                   : ToolErrorType.READ_CONTENT_FAILURE;
+              const userMessage = message.replace(`: ${filePath}`, '');
               return {
-                llmContent: message,
-                returnDisplay: message,
+                llmContent: userMessage,
+                returnDisplay: userMessage,
                 error: message,
                 errorType,
               };

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -41,8 +41,18 @@ import {
   DEFAULT_RANGE_READ_BYTES,
   TEXT_RANGE_FAST_PATH_MAX_SIZE,
 } from './text-range-constants.js';
+import {
+  IMAGE_MAX_SOURCE_BYTES,
+  ImageViewError,
+  renderImageOverview,
+} from './image-view.js';
 
 const debugLogger = createDebugLogger('FILE_UTILS');
+const CANONICAL_IMAGE_MIME_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+]);
 
 // Default values for encoding and separator format
 export const DEFAULT_ENCODING: BufferEncoding = 'utf-8';
@@ -1093,6 +1103,12 @@ export async function processSingleFileContent(
     }
 
     const fileType = await detectFileType(filePath);
+    const mediaMimeType =
+      mime.getType(filePath) ??
+      MIME_LITE_MISSING_VIDEO_TYPES.get(path.extname(filePath).toLowerCase()) ??
+      'application/octet-stream';
+    const shouldRenderImageOverview =
+      fileType === 'image' && CANONICAL_IMAGE_MIME_TYPES.has(mediaMimeType);
     const relativePathForDisplay = path
       .relative(rootDirectory, filePath)
       .replace(/\\/g, '/');
@@ -1229,7 +1245,20 @@ export async function processSingleFileContent(
         };
       }
     }
-    if (fileSizeInMB > 9.9 && !willExtractPdfText && fileType !== 'text') {
+    if (shouldRenderImageOverview && stats.size > IMAGE_MAX_SOURCE_BYTES) {
+      return {
+        llmContent: 'Image file exceeds the 100 MB source limit.',
+        returnDisplay: 'Image file exceeds the 100 MB source limit.',
+        error: `Image file exceeds the 100 MB source limit: ${filePath}`,
+        errorType: ToolErrorType.FILE_TOO_LARGE,
+      };
+    }
+    if (
+      fileSizeInMB > 9.9 &&
+      !willExtractPdfText &&
+      fileType !== 'text' &&
+      !shouldRenderImageOverview
+    ) {
       return {
         llmContent: 'File size exceeds the 10MB limit.',
         returnDisplay: 'File size exceeds the 10MB limit.',
@@ -1416,7 +1445,71 @@ export async function processSingleFileContent(
           stats,
         };
       }
-      case 'image':
+      case 'image': {
+        if (shouldRenderImageOverview) {
+          try {
+            const view = await renderImageOverview(
+              filePath,
+              signal ?? new AbortController().signal,
+            );
+            return {
+              llmContent: [
+                {
+                  text:
+                    `Image overview: ${view.outputWidth}x${view.outputHeight}; ` +
+                    `oriented source: ${view.sourceWidth}x${view.sourceHeight}. ` +
+                    `If details are too small, use tool_search for "zoom image", then ` +
+                    `call zoom_image with coordinates normalized from 0 to 1000.`,
+                },
+                {
+                  inlineData: {
+                    data: view.bytes.toString('base64'),
+                    mimeType: view.mimeType,
+                    displayName,
+                  },
+                },
+              ],
+              returnDisplay: `Read image file: ${relativePathForDisplay}`,
+            };
+          } catch (error) {
+            signal?.throwIfAborted();
+            if (
+              error instanceof ImageViewError &&
+              (error.code === 'source_too_large' ||
+                error.code === 'output_too_large')
+            ) {
+              return {
+                llmContent: error.message,
+                returnDisplay: error.message,
+                error: error.message,
+                errorType: ToolErrorType.FILE_TOO_LARGE,
+              };
+            }
+            throw error;
+          }
+        }
+        const contentBuffer = await fs.promises.readFile(filePath);
+        const base64Data = contentBuffer.toString('base64');
+        const base64SizeInMB = base64Data.length / (1024 * 1024);
+        if (base64SizeInMB > 9.9) {
+          return {
+            llmContent: `File exceeds the 10MB data URI limit after base64 encoding (${base64SizeInMB.toFixed(2)}MB encoded).`,
+            returnDisplay: `File exceeds the 10MB data URI limit after base64 encoding.`,
+            error: `File exceeds the 10MB data URI limit after base64 encoding: ${filePath} (${base64SizeInMB.toFixed(2)}MB encoded)`,
+            errorType: ToolErrorType.FILE_TOO_LARGE,
+          };
+        }
+        return {
+          llmContent: {
+            inlineData: {
+              data: base64Data,
+              mimeType: mediaMimeType,
+              displayName,
+            },
+          },
+          returnDisplay: `Read image file: ${relativePathForDisplay}`,
+        };
+      }
       case 'audio':
       case 'video': {
         const contentBuffer = await fs.promises.readFile(filePath);
@@ -1435,12 +1528,7 @@ export async function processSingleFileContent(
           llmContent: {
             inlineData: {
               data: base64Data,
-              mimeType:
-                mime.getType(filePath) ??
-                MIME_LITE_MISSING_VIDEO_TYPES.get(
-                  path.extname(filePath).toLowerCase(),
-                ) ??
-                'application/octet-stream',
+              mimeType: mediaMimeType,
               displayName,
             },
           },

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -1474,21 +1474,26 @@ export async function processSingleFileContent(
           } catch (error) {
             signal?.throwIfAborted();
             if (error instanceof ImageViewError) {
-              const message = error.message;
-              const errorType =
+              // Non-size render failures (sharp missing, animated,
+              // unsupported, or corrupt input) fall through to the legacy
+              // inline-bytes branch below rather than hard-failing the read,
+              // matching main's forward-verbatim behaviour. The size codes
+              // stay a hard error because that branch cannot shrink them.
+              if (
                 error.code === 'source_too_large' ||
                 error.code === 'output_too_large'
-                  ? ToolErrorType.FILE_TOO_LARGE
-                  : ToolErrorType.READ_CONTENT_FAILURE;
-              const userMessage = message.replace(`: ${filePath}`, '');
-              return {
-                llmContent: userMessage,
-                returnDisplay: userMessage,
-                error: message,
-                errorType,
-              };
+              ) {
+                const userMessage = error.message.replace(`: ${filePath}`, '');
+                return {
+                  llmContent: userMessage,
+                  returnDisplay: userMessage,
+                  error: error.message,
+                  errorType: ToolErrorType.FILE_TOO_LARGE,
+                };
+              }
+            } else {
+              throw error;
             }
-            throw error;
           }
         }
         const contentBuffer = await fs.promises.readFile(filePath);

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -1473,16 +1473,18 @@ export async function processSingleFileContent(
             };
           } catch (error) {
             signal?.throwIfAborted();
-            if (
-              error instanceof ImageViewError &&
-              (error.code === 'source_too_large' ||
-                error.code === 'output_too_large')
-            ) {
+            if (error instanceof ImageViewError) {
+              const message = error.message;
+              const errorType =
+                error.code === 'source_too_large' ||
+                error.code === 'output_too_large'
+                  ? ToolErrorType.FILE_TOO_LARGE
+                  : ToolErrorType.READ_CONTENT_FAILURE;
               return {
-                llmContent: error.message,
-                returnDisplay: error.message,
-                error: error.message,
-                errorType: ToolErrorType.FILE_TOO_LARGE,
+                llmContent: message,
+                returnDisplay: message,
+                error: message,
+                errorType,
               };
             }
             throw error;

--- a/packages/core/src/utils/image-view.test.ts
+++ b/packages/core/src/utils/image-view.test.ts
@@ -110,4 +110,13 @@ describe('image views', () => {
     expect(metadata).toMatchObject({ width: 80, height: 80, format: 'jpeg' });
     expect(view.bytes.length).toBeLessThanOrEqual(9 * 1024 * 1024);
   });
+
+  it('reports decode_failed for a corrupt canonical image', async () => {
+    const filePath = path.join(root, 'corrupt.png');
+    await fs.writeFile(filePath, 'not a real png');
+
+    await expect(renderImageOverview(filePath, signal)).rejects.toMatchObject({
+      code: 'decode_failed',
+    });
+  });
 });

--- a/packages/core/src/utils/image-view.test.ts
+++ b/packages/core/src/utils/image-view.test.ts
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2026 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import sharp from 'sharp';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  renderImageOverview,
+  renderNormalizedImageCrop,
+} from './image-view.js';
+
+describe('image views', () => {
+  let root: string;
+  const signal = new AbortController().signal;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'image-view-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('keeps a small overview at its oriented source size', async () => {
+    const filePath = path.join(root, 'small.png');
+    await sharp({
+      create: {
+        width: 20,
+        height: 10,
+        channels: 3,
+        background: '#306090',
+      },
+    })
+      .png()
+      .toFile(filePath);
+
+    const view = await renderImageOverview(filePath, signal);
+    const metadata = await sharp(view.bytes).metadata();
+
+    expect(view).toMatchObject({
+      mimeType: 'image/jpeg',
+      sourceWidth: 20,
+      sourceHeight: 10,
+      selectedWidth: 20,
+      selectedHeight: 10,
+      outputWidth: 20,
+      outputHeight: 10,
+    });
+    expect(metadata).toMatchObject({ width: 20, height: 10, format: 'jpeg' });
+  });
+
+  it('bounds a large overview by the shared edge and patch budget', async () => {
+    const filePath = path.join(root, 'large.png');
+    await sharp({
+      create: {
+        width: 4000,
+        height: 2000,
+        channels: 3,
+        background: '#804020',
+      },
+    })
+      .png()
+      .toFile(filePath);
+
+    const view = await renderImageOverview(filePath, signal);
+
+    expect(Math.max(view.outputWidth, view.outputHeight)).toBeLessThanOrEqual(
+      1568,
+    );
+    expect(
+      Math.ceil(view.outputWidth / 28) * Math.ceil(view.outputHeight / 28),
+    ).toBeLessThanOrEqual(1568);
+    expect(view.bytes.length).toBeLessThanOrEqual(9 * 1024 * 1024);
+  });
+
+  it('may magnify a normalized crop while preserving its source dimensions', async () => {
+    const filePath = path.join(root, 'crop.png');
+    await sharp({
+      create: {
+        width: 400,
+        height: 400,
+        channels: 3,
+        background: '#306090',
+      },
+    })
+      .png()
+      .toFile(filePath);
+
+    const view = await renderNormalizedImageCrop(
+      filePath,
+      { x1: 0, y1: 0, x2: 25, y2: 25 },
+      signal,
+    );
+    const metadata = await sharp(view.bytes).metadata();
+
+    expect(view).toMatchObject({
+      mimeType: 'image/jpeg',
+      sourceWidth: 400,
+      sourceHeight: 400,
+      selectedWidth: 10,
+      selectedHeight: 10,
+      outputWidth: 80,
+      outputHeight: 80,
+    });
+    expect(metadata).toMatchObject({ width: 80, height: 80, format: 'jpeg' });
+    expect(view.bytes.length).toBeLessThanOrEqual(9 * 1024 * 1024);
+  });
+});

--- a/packages/core/src/utils/image-view.ts
+++ b/packages/core/src/utils/image-view.ts
@@ -1,0 +1,314 @@
+/**
+ * @license
+ * Copyright 2026 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs/promises';
+import type { Metadata } from 'sharp';
+
+const IMAGE_VIEW_MAX_EDGE = 1568;
+const IMAGE_VIEW_MAX_PATCHES = 1568;
+const IMAGE_PATCH_SIZE = 28;
+const IMAGE_MAX_UPSCALE = 8;
+const IMAGE_JPEG_QUALITY = 92;
+export const IMAGE_MAX_SOURCE_BYTES = 100 * 1024 * 1024;
+const IMAGE_MAX_OUTPUT_BYTES = 9 * 1024 * 1024;
+const SUPPORTED_IMAGE_FORMATS = new Set(['jpeg', 'png', 'webp']);
+
+export interface NormalizedRegion {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}
+
+export interface ImageView {
+  bytes: Buffer;
+  mimeType: 'image/jpeg';
+  sourceWidth: number;
+  sourceHeight: number;
+  selectedWidth: number;
+  selectedHeight: number;
+  outputWidth: number;
+  outputHeight: number;
+}
+
+interface ImageSize {
+  width: number;
+  height: number;
+}
+
+interface PreparedImage {
+  bytes: Buffer;
+  metadata: Metadata;
+  sharp: typeof import('sharp');
+}
+
+export type ImageViewErrorCode =
+  | 'renderer_unavailable'
+  | 'file_not_found'
+  | 'target_is_directory'
+  | 'target_not_regular_file'
+  | 'source_too_large'
+  | 'unsupported_image'
+  | 'animated_image'
+  | 'decode_failed'
+  | 'output_too_large';
+
+export class ImageViewError extends Error {
+  constructor(
+    readonly code: ImageViewErrorCode,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+function fitsVisualBudget({ width, height }: ImageSize): boolean {
+  return (
+    width <= IMAGE_VIEW_MAX_EDGE &&
+    height <= IMAGE_VIEW_MAX_EDGE &&
+    Math.ceil(width / IMAGE_PATCH_SIZE) *
+      Math.ceil(height / IMAGE_PATCH_SIZE) <=
+      IMAGE_VIEW_MAX_PATCHES
+  );
+}
+
+function boundedSize(
+  width: number,
+  height: number,
+  maxUpscale: number,
+): ImageSize {
+  const widthIsLongEdge = width >= height;
+  const maxLongEdge = Math.min(
+    IMAGE_VIEW_MAX_EDGE,
+    Math.max(width, height) * maxUpscale,
+  );
+  let low = 1;
+  let high = maxLongEdge;
+  let best: ImageSize = { width: 1, height: 1 };
+
+  while (low <= high) {
+    const longEdge = Math.floor((low + high) / 2);
+    const candidate = widthIsLongEdge
+      ? {
+          width: longEdge,
+          height: Math.max(1, Math.round((height / width) * longEdge)),
+        }
+      : {
+          width: Math.max(1, Math.round((width / height) * longEdge)),
+          height: longEdge,
+        };
+    if (fitsVisualBudget(candidate)) {
+      best = candidate;
+      low = longEdge + 1;
+    } else {
+      high = longEdge - 1;
+    }
+  }
+
+  return best;
+}
+
+async function prepareImage(
+  filePath: string,
+  signal: AbortSignal,
+): Promise<PreparedImage> {
+  signal.throwIfAborted();
+  let sharp: typeof import('sharp');
+  try {
+    // sharp is a CJS `export =` module, so the callable is on `.default`
+    // at runtime even though NodeNext types collapse that namespace away.
+    sharp = (
+      (await import('sharp')) as unknown as {
+        default: typeof import('sharp');
+      }
+    ).default;
+  } catch {
+    throw new ImageViewError(
+      'renderer_unavailable',
+      'Image rendering is unavailable because the "sharp" image module could not be loaded.',
+    );
+  }
+
+  let stats: Awaited<ReturnType<typeof fs.stat>>;
+  try {
+    stats = await fs.stat(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new ImageViewError(
+        'file_not_found',
+        `Image file not found: ${filePath}`,
+      );
+    }
+    throw error;
+  }
+  if (stats.isDirectory()) {
+    throw new ImageViewError(
+      'target_is_directory',
+      `Image path is a directory: ${filePath}`,
+    );
+  }
+  if (!stats.isFile()) {
+    throw new ImageViewError(
+      'target_not_regular_file',
+      `Image path is not a regular file: ${filePath}`,
+    );
+  }
+  if (stats.size > IMAGE_MAX_SOURCE_BYTES) {
+    throw new ImageViewError(
+      'source_too_large',
+      `Image file exceeds the 100 MB source limit: ${filePath}`,
+    );
+  }
+
+  const bytes = await fs.readFile(filePath, { signal });
+  if (bytes.length > IMAGE_MAX_SOURCE_BYTES) {
+    throw new ImageViewError(
+      'source_too_large',
+      `Image file exceeds the 100 MB source limit: ${filePath}`,
+    );
+  }
+
+  let metadata: Metadata;
+  try {
+    metadata = await sharp(bytes, {
+      failOn: 'error',
+      limitInputPixels: true,
+    }).metadata();
+  } catch {
+    signal.throwIfAborted();
+    throw new ImageViewError(
+      'unsupported_image',
+      `Unsupported image. Expected a static PNG, JPEG, or WebP file: ${filePath}`,
+    );
+  }
+  signal.throwIfAborted();
+
+  if (!SUPPORTED_IMAGE_FORMATS.has(metadata.format)) {
+    throw new ImageViewError(
+      'unsupported_image',
+      `Unsupported image. Expected a static PNG, JPEG, or WebP file: ${filePath}`,
+    );
+  }
+  if ((metadata.pages ?? 1) > 1) {
+    throw new ImageViewError(
+      'animated_image',
+      `Only static images are supported: ${filePath}`,
+    );
+  }
+
+  return { bytes, metadata, sharp };
+}
+
+async function renderImageView(
+  filePath: string,
+  prepared: PreparedImage,
+  selection: { left: number; top: number; width: number; height: number },
+  outputSize: ImageSize,
+  signal: AbortSignal,
+): Promise<ImageView> {
+  const { bytes, metadata, sharp } = prepared;
+  let output: Buffer;
+  try {
+    output = await sharp(bytes, {
+      autoOrient: true,
+      failOn: 'error',
+      limitInputPixels: true,
+    })
+      .extract(selection)
+      .resize(outputSize.width, outputSize.height, {
+        fit: 'fill',
+        kernel: sharp.kernel.lanczos3,
+      })
+      .flatten({ background: '#ffffff' })
+      .jpeg({
+        quality: IMAGE_JPEG_QUALITY,
+        chromaSubsampling: '4:4:4',
+      })
+      .toBuffer();
+  } catch {
+    signal.throwIfAborted();
+    throw new ImageViewError(
+      'decode_failed',
+      `Failed to decode image: ${filePath}`,
+    );
+  }
+  signal.throwIfAborted();
+  if (output.length > IMAGE_MAX_OUTPUT_BYTES) {
+    throw new ImageViewError(
+      'output_too_large',
+      `Rendered image exceeds the 9 MB output limit: ${filePath}`,
+    );
+  }
+
+  return {
+    bytes: output,
+    mimeType: 'image/jpeg',
+    sourceWidth: metadata.autoOrient.width,
+    sourceHeight: metadata.autoOrient.height,
+    selectedWidth: selection.width,
+    selectedHeight: selection.height,
+    outputWidth: outputSize.width,
+    outputHeight: outputSize.height,
+  };
+}
+
+export async function renderImageOverview(
+  filePath: string,
+  signal: AbortSignal,
+): Promise<ImageView> {
+  const prepared = await prepareImage(filePath, signal);
+  const sourceWidth = prepared.metadata.autoOrient.width;
+  const sourceHeight = prepared.metadata.autoOrient.height;
+  const outputSize = boundedSize(sourceWidth, sourceHeight, 1);
+  return renderImageView(
+    filePath,
+    prepared,
+    { left: 0, top: 0, width: sourceWidth, height: sourceHeight },
+    outputSize,
+    signal,
+  );
+}
+
+export async function renderNormalizedImageCrop(
+  filePath: string,
+  region: NormalizedRegion,
+  signal: AbortSignal,
+): Promise<ImageView> {
+  const prepared = await prepareImage(filePath, signal);
+  const sourceWidth = prepared.metadata.autoOrient.width;
+  const sourceHeight = prepared.metadata.autoOrient.height;
+  const left = Math.min(
+    sourceWidth - 1,
+    Math.max(0, Math.floor((region.x1 / 1000) * sourceWidth)),
+  );
+  const top = Math.min(
+    sourceHeight - 1,
+    Math.max(0, Math.floor((region.y1 / 1000) * sourceHeight)),
+  );
+  const right = Math.min(
+    sourceWidth,
+    Math.max(left + 1, Math.ceil((region.x2 / 1000) * sourceWidth)),
+  );
+  const bottom = Math.min(
+    sourceHeight,
+    Math.max(top + 1, Math.ceil((region.y2 / 1000) * sourceHeight)),
+  );
+  const selectedWidth = right - left;
+  const selectedHeight = bottom - top;
+  const outputSize = boundedSize(
+    selectedWidth,
+    selectedHeight,
+    IMAGE_MAX_UPSCALE,
+  );
+
+  return renderImageView(
+    filePath,
+    prepared,
+    { left, top, width: selectedWidth, height: selectedHeight },
+    outputSize,
+    signal,
+  );
+}

--- a/packages/core/src/utils/image-view.ts
+++ b/packages/core/src/utils/image-view.ts
@@ -181,7 +181,7 @@ async function prepareImage(
     signal.throwIfAborted();
     throw new ImageViewError(
       'decode_failed',
-      `Failed to decode image metadata (file may be corrupt): ${filePath}`,
+      `Failed to decode image (file may be corrupt or not a static PNG, JPEG, or WebP): ${filePath}`,
     );
   }
   signal.throwIfAborted();

--- a/packages/core/src/utils/image-view.ts
+++ b/packages/core/src/utils/image-view.ts
@@ -232,7 +232,7 @@ async function renderImageView(
     signal.throwIfAborted();
     throw new ImageViewError(
       'decode_failed',
-      `Failed to decode image: ${filePath}`,
+      `Failed to render image overview: ${filePath}`,
     );
   }
   signal.throwIfAborted();

--- a/packages/core/src/utils/image-view.ts
+++ b/packages/core/src/utils/image-view.ts
@@ -180,8 +180,8 @@ async function prepareImage(
   } catch {
     signal.throwIfAborted();
     throw new ImageViewError(
-      'unsupported_image',
-      `Unsupported image. Expected a static PNG, JPEG, or WebP file: ${filePath}`,
+      'decode_failed',
+      `Failed to decode image metadata (file may be corrupt): ${filePath}`,
     );
   }
   signal.throwIfAborted();

--- a/packages/core/src/utils/pathReader.test.ts
+++ b/packages/core/src/utils/pathReader.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import mock from 'mock-fs';
 import * as path from 'node:path';
+import sharp from 'sharp';
 import { WorkspaceContext } from './workspaceContext.js';
 import { readPathFromWorkspace } from './pathReader.js';
 import type { Config } from '../config/config.js';
@@ -104,11 +105,17 @@ describe('readPathFromWorkspace', () => {
     expect(result).toEqual(['hello from cwd']);
   });
 
-  it('should read an image file and return it as inlineData (Part object)', async () => {
-    // Use a real PNG header for robustness
-    const imageData = Buffer.from([
-      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
-    ]);
+  it('should read an image file as overview text and inlineData', async () => {
+    const imageData = await sharp({
+      create: {
+        width: 20,
+        height: 10,
+        channels: 3,
+        background: '#306090',
+      },
+    })
+      .png()
+      .toBuffer();
     mock({
       [CWD]: {
         'image.png': imageData,
@@ -119,12 +126,17 @@ describe('readPathFromWorkspace', () => {
     } as unknown as FileDiscoveryService;
     const config = createMockConfig(CWD, [], mockFileService);
     const result = await readPathFromWorkspace('image.png', config);
-    // Expect [Part] for image content
+    // Expect overview text immediately followed by the bounded image.
     expect(result).toEqual([
       {
+        text: expect.stringContaining(
+          'Image overview: 20x10; oriented source: 20x10',
+        ),
+      },
+      {
         inlineData: {
-          mimeType: 'image/png',
-          data: imageData.toString('base64'),
+          mimeType: 'image/jpeg',
+          data: expect.any(String),
           displayName: 'image.png',
         },
       },
@@ -236,9 +248,16 @@ describe('readPathFromWorkspace', () => {
     });
 
     it('should handle mixed content and include files from subdirectories', async () => {
-      const imageData = Buffer.from([
-        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
-      ]);
+      const imageData = await sharp({
+        create: {
+          width: 8,
+          height: 8,
+          channels: 3,
+          background: '#306090',
+        },
+      })
+        .png()
+        .toBuffer();
       mock({
         [CWD]: {
           'mixed-dir': {
@@ -274,8 +293,8 @@ describe('readPathFromWorkspace', () => {
       );
       expect(imagePart).toEqual({
         inlineData: {
-          mimeType: 'image/png',
-          data: imageData.toString('base64'),
+          mimeType: 'image/jpeg',
+          data: expect.any(String),
           displayName: 'photo.png',
         },
       });

--- a/packages/core/src/utils/readManyFiles.test.ts
+++ b/packages/core/src/utils/readManyFiles.test.ts
@@ -9,6 +9,7 @@ import fs from 'node:fs/promises';
 import * as nodeFs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+import sharp from 'sharp';
 import type { Part, PartListUnion } from '@google/genai';
 import { readManyFiles } from './readManyFiles.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
@@ -195,8 +196,16 @@ describe('readManyFiles', () => {
     it('preserves unsupported images when the bridge handoff flag is set', async () => {
       const relativePath = 'screenshot.png';
       const absolutePath = path.join(tempRootDir, relativePath);
-      const imageBytes = Buffer.from('fake png data');
-      await fs.writeFile(absolutePath, imageBytes);
+      await sharp({
+        create: {
+          width: 20,
+          height: 10,
+          channels: 3,
+          background: '#306090',
+        },
+      })
+        .png()
+        .toFile(absolutePath);
       const mockConfig = createMockConfig(tempRootDir);
 
       const result = await readManyFiles(mockConfig, {
@@ -209,13 +218,24 @@ describe('readManyFiles', () => {
       expect(
         (imagePart as { inlineData: { mimeType: string; data: string } })
           .inlineData,
-      ).toEqual({
-        mimeType: 'image/png',
-        data: imageBytes.toString('base64'),
+      ).toMatchObject({
+        mimeType: 'image/jpeg',
+        data: expect.any(String),
         displayName: 'screenshot.png',
       });
+      const parts = result.contentParts as Part[];
+      const imageIndex = parts.indexOf(imagePart!);
+      expect(parts[imageIndex - 2]?.text).toBe(
+        `\nContent from ${absolutePath}:\n`,
+      );
+      expect(parts[imageIndex - 1]?.text).toContain(
+        'Image overview: 20x10; oriented source: 20x10',
+      );
       expect(result.files).toHaveLength(1);
-      expect(result.files[0]!.content).toEqual(imagePart);
+      expect(result.files[0]!.content).toEqual([
+        parts[imageIndex - 1],
+        imagePart,
+      ]);
     });
 
     it('skips unsupported images when the bridge handoff flag is absent', async () => {

--- a/packages/core/src/utils/readManyFiles.test.ts
+++ b/packages/core/src/utils/readManyFiles.test.ts
@@ -193,7 +193,7 @@ describe('readManyFiles', () => {
       expect(result.files[0]!.filePath).toBe(absolutePath);
     });
 
-    it('preserves unsupported images when the bridge handoff flag is set', async () => {
+    it('renders canonical images through the overview pipeline even when the bridge handoff flag is set', async () => {
       const relativePath = 'screenshot.png';
       const absolutePath = path.join(tempRootDir, relativePath);
       await sharp({


### PR DESCRIPTION
## What this PR does

Static PNG, JPEG, and WebP reads now return a canonical JPEG overview together with its oriented source dimensions and a short hint describing how to request a normalized zoom. The overview is auto-oriented, flattened onto white, and constrained by the same edge, visual-patch, source-byte, and output-byte budgets as image zooms. Small overviews are not upscaled, while zoomed crops may still be magnified within the shared budget.

The shared rendering path keeps direct single-file reads and zoomed crops aligned. Batch and directory reads preserve the overview text immediately before the image. GIF, BMP, audio, video, SVG, and PDF handling retain their existing byte and size-limit behavior.

The downstream paths reviewed for the new two-part image result include direct reads, batch reads, workspace path reads, interactive `@` attachments, pasted temporary images, vision-bridge preservation, request token estimation, Gemini/Anthropic/OpenAI-compatible conversion, file-read telemetry, and compaction.

## Why it's needed

Large source images can exceed the existing inline-media limit or be downscaled differently by providers, which can hide labels and other small details before the model sees them. Returning one deterministic bounded overview reduces first-request payload size, gives every provider the same coordinate frame, and tells the model how to reopen a full-resolution region through the zoom tool introduced in #7809.

## Reviewer Test Plan

### How to verify

1. Read small and large static PNG, JPEG, and WebP files. Expect overview text followed immediately by a JPEG image; small images keep their oriented dimensions, while large images stay within the documented edge, patch, source, and output limits.
2. Read an EXIF-rotated or transparent image. Expect reported dimensions to match the oriented image and transparent pixels to render on white.
3. Request a normalized zoom from an overview. Expect the crop to map to the same full-resolution oriented coordinate space and remain within the shared output budget.
4. Read GIF, BMP, supported audio/video, SVG, and PDF inputs. Expect their existing behavior and limits to remain unchanged.
5. Exercise direct reads, `@` attachments, batch reads, a text-only vision bridge, and image-capable provider conversion. Expect overview text to remain text, image bytes to remain image parts, and no raw base64 to appear as model-visible text.

### Evidence (Before & After)

| Before | After |
| --- | --- |
| Static raster reads forwarded original bytes and rejected sources above the legacy inline-media limit. Provider-side resizing could discard small details without giving the model a stable zoom frame. | Static PNG/JPEG/WebP reads return a bounded, oriented JPEG overview plus explicit normalized zoom guidance. Legacy media paths are unchanged. |

Automated evidence after rebasing onto the latest upstream main: 1,084 focused Core tests passed across image rendering, zoom, direct and batch reads, workspace paths, registration, and scheduling. Full repository build, typecheck, and bundle also passed.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS, Node.js 22-compatible workspace, native Sharp renderer, sandbox disabled for local build and tests.

## Risk & Scope

- Main risk or tradeoff: Static PNG/JPEG/WebP reads now decode and re-encode the source as JPEG, so exact original pixels and alpha are intentionally replaced by a bounded white-background overview.
- Not validated / out of scope: Live answer-quality and latency comparison across the primary Qwen vision model and an OpenAI-compatible vision provider; pathless images that exist only in tool or MCP results; animated image, video-frame, PDF-page, remote-URL, and provider-specific budget support.
- Breaking changes / migration notes: No tool-schema, configuration, provider, session-state, or migration changes. Existing zoom coordinates remain normalized from 0 to 1000.

## Linked Issues

Follow-up to #7809.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

静态 PNG、JPEG 和 WebP 读取现在会返回统一的 JPEG 概览、按 EXIF 方向处理后的原图尺寸，以及如何使用归一化坐标请求局部放大的简短提示。概览会自动旋转、将透明背景铺成白色，并与图片放大共用最长边、视觉 patch、源文件字节和输出字节预算。小图不会被放大，局部裁剪仍可在统一预算内放大。

统一渲染路径保证直接读取与局部放大使用相同坐标空间。批量和目录读取会保持概览文字紧邻图片之前。GIF、BMP、音频、视频、SVG 和 PDF 继续沿用现有字节与大小限制行为。

本次复查的新双 Part 图片结果下游包括直接读取、批量读取、工作区路径读取、交互式 `@` 附件、粘贴到临时目录的图片、视觉桥接保留、请求 token 估算、Gemini/Anthropic/OpenAI-compatible 转换、文件读取遥测和上下文压缩。

## 为什么需要

大尺寸源图可能超过现有内联媒体限制，也可能被不同 provider 以不同方式缩小，导致标签等小细节在模型看到之前丢失。返回确定且有界的概览可以降低首次请求负载、为所有 provider 提供一致坐标框架，并引导模型通过 #7809 引入的放大工具重新读取全分辨率局部。

## Reviewer Test Plan

### 如何验证

1. 读取小型和大型静态 PNG、JPEG、WebP。预期先出现概览文字，随后紧邻 JPEG 图片；小图保持按方向处理后的尺寸，大图满足最长边、patch、源文件和输出限制。
2. 读取带 EXIF 方向或透明背景的图片。预期文字尺寸与旋转后的图片一致，透明像素显示为白色。
3. 根据概览请求归一化局部放大。预期裁剪映射到同一套全分辨率方向坐标，并满足统一输出预算。
4. 读取 GIF、BMP、受支持的音视频、SVG 和 PDF。预期保持现有行为和大小限制。
5. 覆盖直接读取、`@` 附件、批量读取、文本模型视觉桥接以及支持图片的 provider 转换。预期概览仍为文本、图片字节仍为图片 Part，原始 base64 不会作为模型可见文本泄漏。

### 证据（前后对比）

| 之前 | 之后 |
| --- | --- |
| 静态栅格图片读取直接传递原始字节，超过旧内联媒体限制的源图会被拒绝；provider 侧缩放可能丢失小细节，也没有稳定的放大坐标框架。 | 静态 PNG/JPEG/WebP 返回有界、按方向处理的 JPEG 概览和明确的归一化放大提示；旧媒体路径保持不变。 |

重放到最新 upstream main 后的自动化证据：图片渲染、放大、直接与批量读取、工作区路径、注册和调度共 1,084 个 Core 测试通过；全仓 build、typecheck 和 bundle 也全部通过。

### 测试平台

|   系统    | 状态 |
| :-------: | :--: |
| 🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
| 🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS、兼容 Node.js 22 的工作区、原生 Sharp 渲染器；本地构建和测试未启用 sandbox。

## 风险与范围

- 主要风险或权衡：静态 PNG/JPEG/WebP 现在会解码并重新编码为 JPEG，因此原始精确像素与透明通道会按设计替换为有界白底概览。
- 未验证或范围外：主 Qwen 视觉模型与一个 OpenAI-compatible 视觉 provider 的真实回答质量和延迟对比；仅存在于工具或 MCP 结果中的无路径图片；动画图片、视频帧、PDF 页面、远程 URL 和 provider 专属预算支持。
- 破坏性变更或迁移说明：没有工具 schema、配置、provider、会话状态或迁移变更；现有放大坐标继续使用 0 到 1000 的归一化范围。

## 关联项

#7809 的后续阶段。

</details>
