### PR TITLE
perf(core): add early Anthropic cache breakpoint on the stable system prefix

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1777,6 +1777,15 @@ export class Config {
   private sessionSubagents: SubagentConfig[];
   private userMemory: string;
   /**
+   * The cross-session-stable prefix of the main-session system prompt —
+   * the stable → context layers `GeminiClient.getMainSessionSystemInstruction()`
+   * assembles before the volatile tails (git status, auto-memory). Recorded
+   * so the Anthropic converter can place an early cache breakpoint on the
+   * stable prefix; consumers match it via `startsWith` and fail open to the
+   * single-block layout when it doesn't match the request's system text.
+   */
+  private staticSystemPrefix: string | undefined;
+  /**
    * Volatile system-prompt layer: the managed auto-memory section
    * (instructions + MEMORY.md indexes). Kept separate from `userMemory`
    * (context files, stable in-session) because it is rewritten on every
@@ -5282,6 +5291,14 @@ export class Config {
 
   getUserMemory(): string {
     return this.userMemory;
+  }
+
+  getStaticSystemPrefix(): string | undefined {
+    return this.staticSystemPrefix;
+  }
+
+  setStaticSystemPrefix(prefix: string | undefined): void {
+    this.staticSystemPrefix = prefix;
   }
 
   /**

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
@@ -128,6 +128,7 @@ describe('AnthropicContentGenerator', () => {
       getProxy: vi.fn().mockReturnValue(undefined),
       getTelemetryEnabled: vi.fn().mockReturnValue(false),
       getSessionId: vi.fn().mockReturnValue('test-session'),
+      getStaticSystemPrefix: vi.fn().mockReturnValue(undefined),
     } as unknown as Config;
   });
 
@@ -974,6 +975,58 @@ describe('AnthropicContentGenerator', () => {
         type: 'ephemeral',
         scope: 'global',
       });
+    });
+
+    it('splits the system prompt at the Config-recorded static prefix (4-breakpoint layout)', async () => {
+      // End-to-end through the generator: `GeminiClient` records the
+      // gitStatus-free base on Config, the generator reads it per request,
+      // and the converter splits the system prompt there — static prefix
+      // carries scope:'global' (cross-session reuse), volatile suffix stays
+      // per-session. Together with the last-tool and last-user-message
+      // markers this fills all 4 Anthropic breakpoints.
+      const { AnthropicContentGenerator } = await importGenerator();
+      anthropicState.createImpl.mockResolvedValue({
+        id: 'msg-1',
+        model: 'claude-test',
+        content: [{ type: 'text', text: 'ok' }],
+      });
+
+      (
+        mockConfig.getStaticSystemPrefix as ReturnType<typeof vi.fn>
+      ).mockReturnValue('sys-base');
+      const generator = new AnthropicContentGenerator(
+        { ...baseConfig, reasoning: false },
+        mockConfig,
+      );
+      await generator.generateContent({
+        model: 'models/ignored',
+        contents: 'Hi',
+        config: {
+          systemInstruction: 'sys-base\n\n# Git Status\nbranch: main',
+        },
+      } as unknown as GenerateContentParameters);
+
+      const [req, options] =
+        anthropicState.lastCreateArgs as AnthropicCreateArgs;
+      expect((req as { system?: unknown }).system).toEqual([
+        {
+          type: 'text',
+          text: 'sys-base',
+          cache_control: { type: 'ephemeral', scope: 'global' },
+        },
+        {
+          type: 'text',
+          text: '\n\n# Git Status\nbranch: main',
+          cache_control: { type: 'ephemeral' },
+        },
+      ]);
+      // The scope entry on the split prefix block is enough for the
+      // body-scan beta gate to fire.
+      const reqHeaders = ((options as { headers?: Record<string, string> })
+        ?.headers || {}) as Record<string, string>;
+      expect(reqHeaders['anthropic-beta']).toContain(
+        'prompt-caching-scope-2026-01-05',
+      );
     });
 
     it('suppresses scope:"global" when enableCacheControl is false even with forceGlobalCacheScope', async () => {

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
@@ -530,6 +530,7 @@ export class AnthropicContentGenerator implements ContentGenerator {
     // The `prompt-caching-scope-2026-01-05` beta is meaningful only when
     // the body actually carries a `cache_control: { …, scope: 'global' }`
     // entry. The converter emits those entries on the system text block
+    // (the static-prefix block when the system prompt is split)
     // and the last tool entry when `useGlobalCacheScope` is true (gated
     // on `enableCacheControl !== false` AND (Anthropic-native baseURL OR `forceGlobalCacheScope`)).
     // Scan the assembled request body for that field rather than
@@ -704,6 +705,12 @@ export class AnthropicContentGenerator implements ContentGenerator {
         stripAssistantThinking,
         enableCacheControl,
         useGlobalCacheScope,
+        // Read per request (not latched at construction): the client
+        // re-records the prefix whenever it rebuilds the system prompt
+        // (memory refresh, model change), and the converter fails open to
+        // the single-block layout when the request's system text doesn't
+        // start with it (subagent prompts, stale prefix).
+        staticSystemPrefix: this.cliConfig.getStaticSystemPrefix(),
       },
     );
 

--- a/packages/core/src/core/anthropicContentGenerator/converter.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.test.ts
@@ -88,6 +88,103 @@ describe('AnthropicContentConverter', () => {
       ]);
     });
 
+    describe('staticSystemPrefix split', () => {
+      const staticPrefix = 'core prompt + memory';
+      const volatileSuffix = '\n\n# Git Status\nbranch: main';
+      const fullSystem = staticPrefix + volatileSuffix;
+
+      it('splits the system prompt at the static prefix boundary, scoping only the prefix', () => {
+        const { system } = converter.convertGeminiRequestToAnthropic(
+          {
+            model: 'models/test',
+            contents: 'hi',
+            config: { systemInstruction: fullSystem },
+          },
+          { useGlobalCacheScope: true, staticSystemPrefix: staticPrefix },
+        );
+
+        expect(system).toEqual([
+          {
+            type: 'text',
+            text: staticPrefix,
+            cache_control: { type: 'ephemeral', scope: 'global' },
+          },
+          {
+            // The volatile tail (git status, session-start context) always
+            // carries the per-session shape — it differs across sessions,
+            // so a global entry here would churn cache for zero hits.
+            type: 'text',
+            text: volatileSuffix,
+            cache_control: { type: 'ephemeral' },
+          },
+        ]);
+      });
+
+      it('splits without scope when useGlobalCacheScope is off', () => {
+        const { system } = converter.convertGeminiRequestToAnthropic(
+          {
+            model: 'models/test',
+            contents: 'hi',
+            config: { systemInstruction: fullSystem },
+          },
+          { staticSystemPrefix: staticPrefix },
+        );
+
+        expect(system).toEqual([
+          {
+            type: 'text',
+            text: staticPrefix,
+            cache_control: { type: 'ephemeral' },
+          },
+          {
+            type: 'text',
+            text: volatileSuffix,
+            cache_control: { type: 'ephemeral' },
+          },
+        ]);
+      });
+
+      it('falls back to a single block when the prefix does not match (subagent prompt)', () => {
+        const { system } = converter.convertGeminiRequestToAnthropic(
+          {
+            model: 'models/test',
+            contents: 'hi',
+            config: { systemInstruction: 'a different subagent prompt' },
+          },
+          { useGlobalCacheScope: true, staticSystemPrefix: staticPrefix },
+        );
+
+        expect(system).toEqual([
+          {
+            type: 'text',
+            text: 'a different subagent prompt',
+            cache_control: { type: 'ephemeral', scope: 'global' },
+          },
+        ]);
+      });
+
+      it('falls back to a single block when there is no suffix beyond the prefix', () => {
+        // Not a git repo → the system prompt IS the static prefix. A split
+        // would leave an empty second block, which Anthropic rejects.
+        const { system } = converter.convertGeminiRequestToAnthropic(
+          {
+            model: 'models/test',
+            contents: 'hi',
+            config: { systemInstruction: staticPrefix },
+          },
+          { useGlobalCacheScope: true, staticSystemPrefix: staticPrefix },
+        );
+
+        expect(system).toEqual([
+          {
+            type: 'text',
+            text: staticPrefix,
+            cache_control: { type: 'ephemeral', scope: 'global' },
+          },
+        ]);
+      });
+    });
+
     it('converts a plain string content into a user message', () => {
       const { messages } = converter.convertGeminiRequestToAnthropic({
         model: 'models/test',

--- a/packages/core/src/core/anthropicContentGenerator/converter.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.ts
@@ -111,6 +111,17 @@ export interface ConvertGeminiRequestToAnthropicOptions {
    * cross-session caching support don't see an unrecognized scope field.
    */
   useGlobalCacheScope?: boolean;
+  /**
+   * The cross-session-stable prefix of the system prompt (everything the
+   * client assembles before appending volatile tails like git status or
+   * session-start context). When it exactly matches the beginning of the
+   * request's system text and a suffix follows, the system prompt is split
+   * into two text blocks with one cache breakpoint each, making the stable
+   * prefix independently cacheable. No match (subagent prompts, stale
+   * prefix) falls back to the single-block layout — fail-open, never worse
+   * than before. Only meaningful when `enableCacheControl` is on.
+   */
+  staticSystemPrefix?: string;
 }
 
 export class AnthropicContentConverter {
@@ -186,7 +197,11 @@ export class AnthropicContentConverter {
       options.enableCacheControl ?? this.enableCacheControl;
     const useGlobalCacheScope = options.useGlobalCacheScope ?? false;
     const system = enableCacheControl
-      ? this.buildSystemWithCacheControl(systemText, useGlobalCacheScope)
+      ? this.buildSystemWithCacheControl(
+          systemText,
+          useGlobalCacheScope,
+          options.staticSystemPrefix,
+        )
       : systemText;
     if (enableCacheControl) {
       this.addCacheControlToMessages(messages);
@@ -688,22 +703,60 @@ export class AnthropicContentConverter {
    * `prompt-caching-scope-2026-01-05` beta. Otherwise emit the standard
    * per-session shape so non-Anthropic baseURLs aren't sent a scope
    * extension they may not recognize.
+   *
+   * When `staticSystemPrefix` matches the beginning of the system text and
+   * a suffix follows (git status, session-start context — the volatile
+   * tails the client appends after the stable prompt), the text is split
+   * into two blocks carrying one breakpoint each:
+   *   1. the stable prefix — scoped per `useGlobalCacheScope`, so new
+   *      sessions reuse it even though their suffix differs;
+   *   2. the end of the full system prompt — always the per-session
+   *      `{ type: 'ephemeral' }` shape. The suffix varies across sessions,
+   *      so a global-scope entry here would churn cache for zero hits
+   *      (same reasoning as `addCacheControlToMessages`). Within a session
+   *      it still caches the suffix, and when the suffix changes mid-session
+   *      (/cd refreshes git status, session-start context lands) the prefix
+   *      breakpoint keeps the big block from re-billing.
+   * The split only shapes the outgoing request; stored history and
+   * non-Anthropic transports keep seeing a single system string.
    */
   private buildSystemWithCacheControl(
     systemText: string,
     useGlobalCacheScope: boolean,
+    staticSystemPrefix?: string,
   ): AnthropicTextBlockParam[] | string {
     if (!systemText) {
       return systemText;
+    }
+
+    const scopedCacheControl: AnthropicCacheControl = useGlobalCacheScope
+      ? { type: 'ephemeral', scope: 'global' }
+      : { type: 'ephemeral' };
+
+    if (
+      staticSystemPrefix &&
+      systemText.length > staticSystemPrefix.length &&
+      systemText.startsWith(staticSystemPrefix)
+    ) {
+      return [
+        {
+          type: 'text',
+          text: staticSystemPrefix,
+          cache_control: scopedCacheControl,
+        },
+        {
+          type: 'text',
+          text: systemText.slice(staticSystemPrefix.length),
+          cache_control: { type: 'ephemeral' },
+        },
+      ];
     }
 
     return [
       {
         type: 'text',
         text: systemText,
-        cache_control: useGlobalCacheScope
-          ? { type: 'ephemeral', scope: 'global' }
-          : { type: 'ephemeral' },
+        cache_control: scopedCacheControl,
       },
     ];
   }
@@ -910,8 +963,8 @@ export class AnthropicContentConverter {
    * no `scope: 'global'`. The last user message changes every turn (it's
    * the live prompt and any tool_result blocks from the immediately prior
    * round), so cross-session reuse here has effectively zero hit rate and
-   * paying the global-scope overhead would just churn cache. System text
-   * and tool prefixes (which DO repeat across sessions) carry
+   * paying the global-scope overhead would just churn cache. The static
+   * system prefix and tool prefixes (which DO repeat across sessions) carry
    * `scope: 'global'` instead.
    */
   private addCacheControlToMessages(messages: Anthropic.MessageParam[]): void {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -557,6 +557,8 @@ describe('Gemini Client (client.ts)', () => {
       getAutoMemoryPrompt: vi.fn().mockReturnValue(''),
       getSystemPrompt: vi.fn().mockReturnValue(undefined),
       getAppendSystemPrompt: vi.fn().mockReturnValue(undefined),
+      getStaticSystemPrefix: vi.fn().mockReturnValue(undefined),
+      setStaticSystemPrefix: vi.fn(),
       getFullContext: vi.fn().mockReturnValue(false),
       getSessionId: vi.fn().mockReturnValue('test-session-id'),
       getProxy: vi.fn().mockReturnValue(undefined),
@@ -2081,6 +2083,26 @@ describe('Gemini Client (client.ts)', () => {
       await client.addHistory(newContent);
 
       expect(mockChat.addHistory).toHaveBeenCalledWith(newContent);
+    });
+  });
+
+  describe('getMainSessionSystemInstruction', () => {
+    it('records the gitStatus-free base as the static system prefix on Config', () => {
+      vi.mocked(getCoreSystemPrompt).mockReturnValueOnce('core base prompt');
+      vi.mocked(getRecentGitStatus).mockReturnValueOnce('Git snapshot A');
+
+      const instruction = (
+        client as unknown as { getMainSessionSystemInstruction: () => string }
+      ).getMainSessionSystemInstruction();
+
+      // The recorded prefix must be exactly the instruction minus the
+      // volatile git tail — that's the boundary the Anthropic converter's
+      // startsWith split relies on for the early cache breakpoint.
+      const recorded = vi
+        .mocked(client['config'].setStaticSystemPrefix)
+        .mock.calls.at(-1)?.[0];
+      expect(recorded).toBeTruthy();
+      expect(instruction).toBe(`${recorded}\n\nGit snapshot A`);
     });
   });
 

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -892,10 +892,22 @@ export class GeminiClient {
           undefined,
           resolveInteractionMode(this.config),
         );
-    return assembleSystemPrompt({
+    const stableLayers = {
       base,
       contextFiles: this.config.getUserMemory(),
       appendPrompt: this.config.getAppendSystemPrompt(),
+    };
+    // Record the stable → context layers (everything before the volatile
+    // gitStatus/autoMemory tail) as the cross-session-stable system prefix.
+    // The Anthropic converter splits the outgoing system prompt at this
+    // boundary and puts an early cache breakpoint on the stable part, so
+    // new sessions (different git status) and in-session memory saves
+    // don't re-bill it. Recorded on every rebuild so it tracks
+    // memory/model/mode changes; consumers match via `startsWith` and fail
+    // open when it goes stale.
+    this.config.setStaticSystemPrefix(assembleSystemPrompt(stableLayers));
+    return assembleSystemPrompt({
+      ...stableLayers,
       gitStatus: this.getCachedGitStatus(),
       autoMemory: this.config.getAutoMemoryPrompt(),
     });


### PR DESCRIPTION
## What this PR does

Adds a fourth Anthropic prompt-cache breakpoint by splitting the outgoing system prompt into two text blocks at the stable/volatile boundary. The client records the cross-session-stable prefix (base prompt + context files + append prompt — everything before the volatile git-status and auto-memory tails) on `Config`, and the Anthropic converter emits that prefix as its own `cache_control` block carrying `scope: 'global'` when cross-session caching is enabled, while the block covering the end of the full system prompt is demoted to the per-session `{ type: 'ephemeral' }` shape. The converter matches the prefix via `startsWith` and fails open to the previous single-block layout whenever it doesn't match (subagent prompts, stale prefix), so the wire shape never regresses. The request now uses all 4 breakpoints Anthropic allows: last tool (global), stable system prefix (global), end of system (per-session), last user message (per-session).

## Why it's needed

The request previously placed 3 breakpoints, and the `scope: 'global'` entry on the system end was mostly wasted: the system prompt ends with volatile tails (git status differs across sessions; the auto-memory section is rewritten on every in-session memory save), so that global cache entry almost never hit across sessions — only the tools breakpoint did. With the split, a new session re-bills only the small volatile tail instead of the entire system prompt (base prompt + tool examples + QWEN.md context, typically the largest stable chunk of the request), and an in-session memory save no longer invalidates the stable prefix either. This is the same static-prefix layout the system-prompt layering in `assembleSystemPrompt` was designed around ("ordered stable → context → volatile … so a save invalidates the shortest possible cached prompt prefix").

## Reviewer Test Plan

### How to verify

- `cd packages/core && npx vitest run src/core/anthropicContentGenerator/converter.test.ts src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts src/core/client.test.ts src/config/config.test.ts` — all pass (933 tests).
- Converter unit tests cover: split with global scope (prefix `{ephemeral, scope:'global'}` + suffix `{ephemeral}`), split without scope, fall-back on prefix mismatch, and fall-back when there is no suffix beyond the prefix (non-git cwd).
- Generator test covers the end-to-end path: `Config.getStaticSystemPrefix()` → converter split → request body carries the two system blocks, and the body-scan gate still ships the `prompt-caching-scope-2026-01-05` beta header off the scoped prefix block.
- Client test covers the recording side: the prefix stored on `Config` is exactly the built instruction minus the volatile git tail, which is the invariant the `startsWith` split relies on.
- Manual check against a live Anthropic-compatible endpoint: run a turn in a git repo, dump the request body, and confirm `system` is two text blocks (prefix with `scope:'global'`, tail without) and that `usage.cache_read_input_tokens` covers the prefix on a fresh session whose git status differs.

### Evidence (Before & After)

N/A (wire-shape change, no UI). Request-body shape before: `system: [{text: <full prompt>, cache_control: {ephemeral, scope:'global'}}]`. After: `system: [{text: <stable prefix>, cache_control: {ephemeral, scope:'global'}}, {text: <git status + auto-memory tail>, cache_control: {ephemeral}}]`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only (`npx vitest` in `packages/core`), plus `tsc --noEmit`, eslint, and prettier on the touched files.

## Risk & Scope

- Main risk or tradeoff: if the recorded prefix ever went stale relative to the request's system text, the split silently degrades to the previous single-block layout — behavior is never worse than before, but the extra breakpoint would silently stop applying. The prefix is re-recorded on every system-prompt rebuild to keep that window small.
- Not validated / out of scope: hit-rate measurement against production traffic; the DashScope/OpenAI provider path (untouched); proxy providers that don't recognize multiple system blocks (they already receive the same `TextBlockParam[]` shape, just with one more entry).
- Breaking changes / migration notes: none. `Config.getStaticSystemPrefix()` is a new optional accessor; requests without a recorded prefix keep the existing 3-breakpoint layout.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

通过在稳定/易变边界处把发出的 system prompt 拆成两个 text block，为 Anthropic prompt 缓存增加第 4 个断点。客户端把跨 session 稳定的前缀（base prompt + context files + append prompt——即 git status 和 auto-memory 这些易变尾部之前的全部内容）记录到 `Config` 上；Anthropic converter 将该前缀作为独立的 `cache_control` block 发出（启用跨 session 缓存时带 `scope: 'global'`），同时把覆盖整个 system prompt 结尾的 block 降级为 per-session 的 `{ type: 'ephemeral' }` 形态。converter 通过 `startsWith` 匹配前缀，匹配不上（子 agent prompt、前缀过期）就回退到原有的单 block 布局，线上请求形态永远不会比之前差。现在请求用满了 Anthropic 允许的全部 4 个断点：最后一个 tool（global）、稳定 system 前缀（global）、system 结尾（per-session）、最后一条 user 消息（per-session）。

## 为什么需要

此前请求只打了 3 个断点，且 system 结尾的 `scope: 'global'` 基本是浪费的：system prompt 以易变尾部结束（git status 每个 session 都不同；auto-memory 段在 session 内每次保存记忆都会重写），所以那个 global 缓存条目跨 session 几乎永远无法命中——只有 tools 断点能命中。拆分后，新 session 只需重新计费小的易变尾部，而不是整个 system prompt（base prompt + 工具示例 + QWEN.md 上下文，通常是请求中最大的稳定块）；session 内保存记忆也不再使稳定前缀失效。这正是 `assembleSystemPrompt` 分层设计（"ordered stable → context → volatile … so a save invalidates the shortest possible cached prompt prefix"）所指向的静态前缀布局。

## 审阅者测试计划

### 如何验证

- `cd packages/core && npx vitest run src/core/anthropicContentGenerator/converter.test.ts src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts src/core/client.test.ts src/config/config.test.ts` —— 全部通过（933 个测试）。
- converter 单测覆盖：带 global scope 的拆分（前缀 `{ephemeral, scope:'global'}` + 尾部 `{ephemeral}`）、不带 scope 的拆分、前缀不匹配时回退、前缀之外没有尾部时回退（非 git 目录）。
- generator 测试覆盖端到端路径：`Config.getStaticSystemPrefix()` → converter 拆分 → 请求体携带两个 system block，且 body 扫描门控仍会因带 scope 的前缀 block 而发出 `prompt-caching-scope-2026-01-05` beta header。
- client 测试覆盖记录侧：存到 `Config` 的前缀恰好等于构建出的 instruction 去掉易变 git 尾部，这正是 `startsWith` 拆分依赖的不变量。
- 对真实 Anthropic 兼容端点的手动检查：在 git 仓库里跑一轮对话，dump 请求体，确认 `system` 是两个 text block（前缀带 `scope:'global'`，尾部不带），并在 git status 不同的新 session 中确认 `usage.cache_read_input_tokens` 覆盖了前缀。

### 证据（前后对比）

N/A（线上请求形态变更，无 UI）。请求体形态之前：`system: [{text: <完整 prompt>, cache_control: {ephemeral, scope:'global'}}]`。之后：`system: [{text: <稳定前缀>, cache_control: {ephemeral, scope:'global'}}, {text: <git status + auto-memory 尾部>, cache_control: {ephemeral}}]`。

### 测试平台

macOS ✅ / Windows ⚠️ / Linux ⚠️

### 环境（可选）

仅单元测试（`packages/core` 下 `npx vitest`），另跑了 `tsc --noEmit`、eslint、prettier。

## 风险与范围

- 主要风险或取舍：如果记录的前缀相对请求的 system 文本过期，拆分会静默退化为原有单 block 布局——行为永远不会比之前差，但额外断点会静默失效。前缀在每次 system prompt 重建时都会重新记录，把这个窗口降到最小。
- 未验证/超出范围：生产流量的命中率测量；DashScope/OpenAI provider 路径（未改动）；不识别多个 system block 的代理 provider（它们收到的仍是同样的 `TextBlockParam[]` 形态，只是多一个条目）。
- 破坏性变更/迁移说明：无。`Config.getStaticSystemPrefix()` 是新增的可选访问器；没有记录前缀的请求保持现有 3 断点布局。

## 关联 Issue

N/A

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
