### PR TITLE
fix(core): preserve active Todo context across tool turns

### DIFF
--- a/docs/design/active-todo-context.md
+++ b/docs/design/active-todo-context.md
@@ -1,0 +1,33 @@
+# Active Todo Context
+
+## Problem
+
+`todo_write` presents the current list as a reminder only in its own tool
+result. After more tool calls, that reminder loses salience and the model may
+end the turn with unfinished items. The persisted todo file is unsuitable as
+live control state because it can outlive the work chain that created it.
+
+## Design
+
+After a successful `todo_write`, keep a reminder containing only unfinished
+items, keyed by the prompt ID that owns the work chain. Append it after function
+responses on subsequent tool-result turns with the same owner in both the core
+and ACP loops. This isolates ordinary prompts, cron jobs, and background
+notifications even when they share a session. Clear the reminder when all todos
+complete, a new work chain starts, or the session changes. Retry, continue, and
+explicitly related automatic requests move the reminder to the new prompt ID
+because they resume the same work chain. The repeated reminder is capped at
+4,000 characters.
+
+This does not change stop semantics or enable `todoStopGuard`. The guard remains
+an optional bounded recovery after a model has already tried to stop; this
+change instead preserves task context before that decision.
+
+## Verification
+
+- A successful write with unfinished items updates the session reminder.
+- A completed list clears it.
+- Core and ACP tool-result messages append the reminder after function results.
+- ACP mid-turn user input remains last and therefore keeps precedence.
+- An ordinary new prompt clears stale state while retry/continue retains it.
+- Independent automatic turns are isolated; related automatic turns inherit.

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -563,6 +563,10 @@ describe('Session', () => {
       switchModel: switchModelSpy,
       getModel: vi.fn().mockImplementation(() => currentModel),
       getSessionId: vi.fn().mockReturnValue('test-session-id'),
+      getActiveTodoReminder: vi.fn().mockReturnValue(undefined),
+      setActiveTodoReminder: vi.fn(),
+      startActiveTodoWorkChain: vi.fn(),
+      startAutomaticActiveTodoWorkChain: vi.fn(),
       assertCanStartTurn: vi.fn().mockResolvedValue(undefined),
       getWorkingDir: vi.fn().mockReturnValue(process.cwd()),
       getProjectRoot: vi.fn().mockReturnValue('/repo'),
@@ -757,6 +761,66 @@ describe('Session', () => {
     });
     expect(nonInteractiveCliCommands.handleSlashCommand).not.toHaveBeenCalled();
     expect(mockChat.sendMessageStream).not.toHaveBeenCalled();
+  });
+
+  it('clears active todo context when an ordinary prompt starts', async () => {
+    mockChat.sendMessageStream = vi
+      .fn()
+      .mockImplementation(async () => createEmptyStream());
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'start different work' }],
+    });
+
+    expect(mockConfig.startActiveTodoWorkChain).toHaveBeenCalledWith(
+      'test-session-id########1',
+      undefined,
+    );
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'start different work' }],
+      retry: true,
+    } as PromptRequest);
+
+    expect(mockConfig.startActiveTodoWorkChain).toHaveBeenCalledWith(
+      'test-session-id########2',
+      'test-session-id########1',
+    );
+  });
+
+  it('continues active Todo context for related automatic turns', async () => {
+    mockChat.sendMessageStream = vi
+      .fn()
+      .mockImplementation(async () => createEmptyStream());
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'start work' }],
+    });
+    vi.mocked(mockConfig.startAutomaticActiveTodoWorkChain).mockClear();
+    const internals = session as unknown as {
+      relatedAgentIds: Set<string>;
+    };
+    internals.relatedAgentIds.add('related-agent');
+    const callback = mockBackgroundTaskRegistry.setNotificationCallback.mock
+      .calls[0][0] as (
+      displayText: string,
+      modelText: string,
+      meta: { agentId: string; status: string },
+    ) => void;
+
+    callback('Background task completed.', '<task-notification/>', {
+      agentId: 'related-agent',
+      status: 'completed',
+    });
+
+    await vi.waitFor(() =>
+      expect(mockConfig.startAutomaticActiveTodoWorkChain).toHaveBeenCalledWith(
+        expect.stringContaining('########notification'),
+        'test-session-id########1',
+      ),
+    );
   });
 
   it('holds the close gate until active turns settle', async () => {
@@ -6056,9 +6120,26 @@ describe('Session', () => {
       });
 
       it('injects drained mid-turn user messages with tool responses', async () => {
-        const executeSpy = vi.fn().mockResolvedValue({
-          llmContent: 'file contents',
-          returnDisplay: 'file contents',
+        const todoReminder =
+          '<system-reminder>unfinished todo: check tests</system-reminder>';
+        const activeTodoReminders = new Map<string, string>();
+        vi.mocked(mockConfig.getActiveTodoReminder).mockImplementation(
+          (promptId) => activeTodoReminders.get(promptId),
+        );
+        vi.mocked(mockConfig.setActiveTodoReminder).mockImplementation(
+          (promptId, reminder) => {
+            if (reminder) activeTodoReminders.set(promptId, reminder);
+          },
+        );
+        const executeSpy = vi.fn().mockImplementation(async () => {
+          const promptId = core.promptIdContext.getStore();
+          if (promptId) {
+            mockConfig.setActiveTodoReminder(promptId, todoReminder);
+          }
+          return {
+            llmContent: 'file contents',
+            returnDisplay: 'file contents',
+          };
         });
         const tool = {
           name: 'read_file',
@@ -6110,9 +6191,19 @@ describe('Session', () => {
         const midTurnPart = {
           text: '\n[User message received during tool execution]:   please also check tests  ',
         };
-        expect(secondCall?.[1].message).toEqual(
-          expect.arrayContaining([midTurnPart]),
+        const nextMessage = secondCall?.[1].message as Part[];
+        const functionResponseIndex = nextMessage.findIndex(
+          (part) => part.functionResponse !== undefined,
         );
+        const reminderIndex = nextMessage.findIndex(
+          (part) => part.text === todoReminder,
+        );
+        const midTurnIndex = nextMessage.findIndex(
+          (part) => part.text === midTurnPart.text,
+        );
+        expect(functionResponseIndex).toBeGreaterThanOrEqual(0);
+        expect(reminderIndex).toBeGreaterThan(functionResponseIndex);
+        expect(midTurnIndex).toBeGreaterThan(reminderIndex);
         expect(
           mockChatRecordingService.recordMidTurnUserMessage,
         ).toHaveBeenCalledWith([midTurnPart], '  please also check tests  ');

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -1236,6 +1236,7 @@ export class Session implements SessionContext {
    */
   private followupAbort: AbortController | null = null;
   private turn: number = 0;
+  private activeTodoWorkChainPromptId: string | undefined;
   private readonly createdAt: number = Date.now();
   /**
    * Running cumulative usage for this session, snapshotted onto each todo/plan
@@ -1345,14 +1346,8 @@ export class Session implements SessionContext {
       !this.config.getBareMode() &&
       !this.config.isSafeMode();
     this.todoStopGuard = new DaemonTodoStopGuard(todoStopGuardEnabled);
-    this.todoStopGuardBackgroundBaseline = todoStopGuardEnabled
-      ? this.#captureTodoStopGuardBackgroundBaseline()
-      : {
-          agents: new Set(),
-          shells: new Set(),
-          monitors: new Set(),
-          wakeups: new Set(),
-        };
+    this.todoStopGuardBackgroundBaseline =
+      this.#captureTodoStopGuardBackgroundBaseline();
 
     // Initialize modular components with this session as context
     this.toolCallEmitter = new ToolCallEmitter(this);
@@ -2634,6 +2629,22 @@ export class Session implements SessionContext {
         this.turn += 1;
 
         const promptId = this.config.getSessionId() + '########' + this.turn;
+        const promptMetadata = (params as { _meta?: Record<string, unknown> })
+          ._meta;
+        const continuesCurrentWorkChain =
+          (params as { retry?: boolean }).retry === true ||
+          promptMetadata?.[DAEMON_RETRY_META_KEY] === true ||
+          promptMetadata?.[DAEMON_CONTINUE_META_KEY] === true;
+        if (!continuesCurrentWorkChain && !this.todoStopGuard.enabled) {
+          this.#resetTodoStopGuardBackgroundLineage();
+        }
+        this.config.startActiveTodoWorkChain(
+          promptId,
+          continuesCurrentWorkChain
+            ? this.activeTodoWorkChainPromptId
+            : undefined,
+        );
+        this.activeTodoWorkChainPromptId = promptId;
         // Bind the prompt ID for the remainder of this turn, mirroring the
         // sessionIdContext.run wrapper in #executePrompt. Shell subprocesses
         // read it via getShellContextEnvVars (QWEN_CODE_PROMPT_ID) — without
@@ -3187,6 +3198,7 @@ export class Session implements SessionContext {
                     await this.#buildNextMessageAfterToolRun(
                       toolRun,
                       pendingSend.signal,
+                      promptId,
                       onFullTurnModel,
                     );
                   nextMessage = nextAfterTools.message;
@@ -4127,6 +4139,7 @@ export class Session implements SessionContext {
         const nextAfterTools = await this.#buildNextMessageAfterToolRun(
           toolRun,
           pendingSend.signal,
+          toolPromptId,
           options.onFullTurnModel,
         );
         nextMessage = nextAfterTools.message;
@@ -4530,6 +4543,7 @@ export class Session implements SessionContext {
   async #buildNextMessageAfterToolRun(
     toolRun: RunToolResult,
     abortSignal: AbortSignal,
+    promptId: string,
     onFullTurnModel?: (model: string) => boolean,
   ): Promise<NextMessageAfterToolRun> {
     if (toolRun.loopDetected) {
@@ -4550,7 +4564,12 @@ export class Session implements SessionContext {
     if (hadMidTurnUserInput) {
       this.todoStopGuard.acceptMidTurnUserInput();
     }
-    const parts = [...toolRun.parts, ...drained.parts];
+    const activeTodoReminder = this.config.getActiveTodoReminder(promptId);
+    const parts = [
+      ...toolRun.parts,
+      ...(activeTodoReminder ? [{ text: activeTodoReminder }] : []),
+      ...drained.parts,
+    ];
     return {
       message: { role: 'user', parts },
       hadMidTurnUserInput,
@@ -5131,9 +5150,9 @@ export class Session implements SessionContext {
       async () => {
         const ac = new AbortController();
         this.cronAbortController = ac;
-        this.#prepareTodoStopGuardForAutomaticTurn(
-          this.#cronContinuesTodoStopGuardWorkChain(item),
-        );
+        const continuesCurrentWorkChain =
+          this.#cronContinuesTodoStopGuardWorkChain(item);
+        this.#prepareTodoStopGuardForAutomaticTurn(continuesCurrentWorkChain);
         const promptId =
           this.config.getSessionId() + '########cron' + Date.now();
         let cronHadError = false;
@@ -5153,6 +5172,15 @@ export class Session implements SessionContext {
             try {
               await this.assertCanStartTurn();
               if (ac.signal.aborted) return;
+              this.config.startAutomaticActiveTodoWorkChain(
+                promptId,
+                continuesCurrentWorkChain
+                  ? this.activeTodoWorkChainPromptId
+                  : undefined,
+              );
+              if (continuesCurrentWorkChain) {
+                this.activeTodoWorkChainPromptId = promptId;
+              }
               // A `<<loop.md>>` / `<<loop.md-dynamic>>` sentinel is expanded at
               // fire time into the loop.md task block — full on the first or a
               // changed fire, a short reminder when unchanged. Non-sentinel
@@ -5455,6 +5483,7 @@ export class Session implements SessionContext {
                     await this.#buildNextMessageAfterToolRun(
                       toolRun,
                       ac.signal,
+                      promptId,
                     );
                   nextMessage = nextAfterTools.message;
                   if (toolRun.loopDetected) {
@@ -5773,14 +5802,23 @@ export class Session implements SessionContext {
       async () => {
         const ac = new AbortController();
         this.notificationAbortController = ac;
-        this.#prepareTodoStopGuardForAutomaticTurn(
-          this.#notificationContinuesTodoStopGuardWorkChain(item),
-        );
+        const continuesCurrentWorkChain =
+          this.#notificationContinuesTodoStopGuardWorkChain(item);
+        this.#prepareTodoStopGuardForAutomaticTurn(continuesCurrentWorkChain);
         const promptId =
           this.config.getSessionId() + '########notification' + Date.now();
         try {
           await this.assertCanStartTurn();
           if (ac.signal.aborted) return;
+          this.config.startAutomaticActiveTodoWorkChain(
+            promptId,
+            continuesCurrentWorkChain
+              ? this.activeTodoWorkChainPromptId
+              : undefined,
+          );
+          if (continuesCurrentWorkChain) {
+            this.activeTodoWorkChainPromptId = promptId;
+          }
           await this.#emitBackgroundNotificationDisplay(item);
 
           const notificationParts: Part[] = [{ text: item.modelText }];
@@ -5953,6 +5991,7 @@ export class Session implements SessionContext {
               const nextAfterTools = await this.#buildNextMessageAfterToolRun(
                 toolRun,
                 ac.signal,
+                promptId,
               );
               nextMessage = nextAfterTools.message;
               if (toolRun.loopDetected) {
@@ -6376,6 +6415,7 @@ export class Session implements SessionContext {
     functionCalls: FunctionCall[],
     toolLoopState?: DaemonToolLoopState,
   ): Promise<RunToolResult> {
+    promptIdContext.enterWith(promptId);
     const dedupedFunctionCalls = dedupeToolCallsById(functionCalls);
     const generatedCallIdBase = randomUUID();
     const executionCallIds = new Map(

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -1995,6 +1995,12 @@ describe('runNonInteractive', () => {
     expect(exitCode).toBe(1);
     expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(3);
     expect(mockCoreExecuteToolCall).not.toHaveBeenCalled();
+    const drainPromptIds = mockGeminiClient.sendMessageStream.mock.calls
+      .slice(1)
+      .map((call) => call[2]);
+    expect(new Set(drainPromptIds)).toEqual(
+      new Set(['prompt-id-drain-dup-loop/automatic/2']),
+    );
 
     const duplicateParts = mockGeminiClient.sendMessageStream.mock
       .calls[2][0] as Part[];
@@ -3188,7 +3194,7 @@ describe('runNonInteractive', () => {
       2,
       [{ text: notificationXml }],
       expect.any(AbortSignal),
-      'prompt-monitor',
+      'prompt-monitor/automatic/2',
       {
         type: SendMessageType.Notification,
         modelOverride: undefined,

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -1625,6 +1625,7 @@ export async function runNonInteractive(
         };
       };
 
+      let currentPromptId = prompt_id;
       while (true) {
         // Drain pending teammate messages into the conversation.
         // sendMessageStream only reads currentMessages[0].parts,
@@ -1678,13 +1679,16 @@ export async function runNonInteractive(
         } else {
           sendType = SendMessageType.ToolResult;
         }
+        if (isTeammateTurn) {
+          currentPromptId = `${prompt_id}/teammate/${turnCount}`;
+        }
 
         const toolCallRequests: ToolCallRequestInfo[] = [];
         const apiStartTime = Date.now();
         const responseStream = geminiClient.sendMessageStream(
           currentMessages[0]?.parts || [],
           abortController.signal,
-          prompt_id,
+          currentPromptId,
           {
             type: sendType,
             modelOverride,
@@ -1926,6 +1930,7 @@ export async function runNonInteractive(
             ];
             let itemIsFirstTurn = true;
             let itemModelOverride: string | undefined;
+            const itemPromptId = `${prompt_id}/automatic/${turnCount}`;
 
             while (true) {
               const itemToolCallRequests: ToolCallRequestInfo[] = [];
@@ -1933,7 +1938,7 @@ export async function runNonInteractive(
               const itemStream = geminiClient.sendMessageStream(
                 itemMessages[0]?.parts || [],
                 abortController.signal,
-                prompt_id,
+                itemPromptId,
                 {
                   type: itemIsFirstTurn
                     ? item.sendMessageType

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -8347,4 +8347,60 @@ describe('Model Switching and Config Updates', () => {
       expect(response.success).toBe(true);
     });
   });
+
+  it('moves only the continued work chain Todo reminder', () => {
+    const config = Object.create(Config.prototype) as Config;
+    config.setActiveTodoReminder('prompt-user', 'unfinished user work');
+    config.setActiveTodoReminder('prompt-cron', 'unfinished cron work');
+
+    config.startActiveTodoWorkChain('prompt-retry', 'prompt-user');
+
+    expect(config.getActiveTodoReminder('prompt-retry')).toBe(
+      'unfinished user work',
+    );
+    expect(config.getActiveTodoReminder('prompt-user')).toBeUndefined();
+    expect(config.getActiveTodoReminder('prompt-cron')).toBeUndefined();
+  });
+
+  it('moves related automatic work without clearing unrelated reminders', () => {
+    const config = Object.create(Config.prototype) as Config;
+    config.setActiveTodoReminder('prompt-user', 'unfinished user work');
+    config.setActiveTodoReminder('prompt-unrelated', 'other work');
+
+    config.startAutomaticActiveTodoWorkChain('prompt-cron');
+    config.startAutomaticActiveTodoWorkChain(
+      'prompt-related-notification',
+      'prompt-user',
+    );
+
+    expect(config.getActiveTodoReminder('prompt-user')).toBeUndefined();
+    expect(config.getActiveTodoReminder('prompt-cron')).toBeUndefined();
+    expect(config.getActiveTodoReminder('prompt-related-notification')).toBe(
+      'unfinished user work',
+    );
+    expect(config.getActiveTodoReminder('prompt-unrelated')).toBe('other work');
+  });
+
+  it('isolates active Todo reminders inherited through child Configs', () => {
+    const parent = Object.create(Config.prototype) as Config;
+    const child = Object.create(parent) as Config;
+    parent.setActiveTodoReminder('parent-prompt', 'parent work');
+
+    child.setActiveTodoReminder('child-prompt', 'child work');
+    child.startActiveTodoWorkChain('child-retry', 'child-prompt');
+
+    expect(parent.getActiveTodoReminder('parent-prompt')).toBe('parent work');
+    expect(parent.getActiveTodoReminder('child-retry')).toBeUndefined();
+    expect(child.getActiveTodoReminder('parent-prompt')).toBeUndefined();
+    expect(child.getActiveTodoReminder('child-retry')).toBe('child work');
+  });
+
+  it('clears active Todo reminders for a new session', () => {
+    const config = new Config(baseParams);
+    config.setActiveTodoReminder('old-prompt', 'unfinished old work');
+
+    config.startNewSession('new-session-id');
+
+    expect(config.getActiveTodoReminder('old-prompt')).toBeUndefined();
+  });
 });

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1806,6 +1806,7 @@ export class Config {
   private readonly gitCoAuthor: GitCoAuthorSettings;
   private readonly usageStatisticsEnabled: boolean;
   private readonly fileReadCacheDisabled: boolean;
+  private activeTodoReminders = new Map<string, string>();
   private geminiClient!: GeminiClient;
   private baseLlmClient!: BaseLlmClient;
   private cronScheduler: CronScheduler | null = null;
@@ -3531,6 +3532,7 @@ export class Config {
     }
     this.sessionData = sessionData;
     this.pendingRecoveredAgentsNotice = null;
+    this.getOwnActiveTodoReminders().clear();
     setDebugLogSession(this);
     this.debugLogger = createDebugLogger();
     this.chatRecordingService = this.chatRecordingEnabled
@@ -5838,6 +5840,44 @@ export class Config {
 
   getGeminiClient(): GeminiClient {
     return this.geminiClient;
+  }
+
+  private getOwnActiveTodoReminders(): Map<string, string> {
+    if (!Object.prototype.hasOwnProperty.call(this, 'activeTodoReminders')) {
+      this.activeTodoReminders = new Map();
+    }
+    return this.activeTodoReminders;
+  }
+
+  getActiveTodoReminder(promptId: string): string | undefined {
+    return this.getOwnActiveTodoReminders().get(promptId);
+  }
+
+  setActiveTodoReminder(promptId: string, reminder: string | undefined): void {
+    const reminders = this.getOwnActiveTodoReminders();
+    if (reminder) {
+      reminders.set(promptId, reminder);
+    } else {
+      reminders.delete(promptId);
+    }
+  }
+
+  startActiveTodoWorkChain(promptId: string, continuedFrom?: string): void {
+    const reminders = this.getOwnActiveTodoReminders();
+    const reminder = continuedFrom ? reminders.get(continuedFrom) : undefined;
+    reminders.clear();
+    if (reminder) reminders.set(promptId, reminder);
+  }
+
+  startAutomaticActiveTodoWorkChain(
+    promptId: string,
+    continuedFrom?: string,
+  ): void {
+    const reminders = this.getOwnActiveTodoReminders();
+    const reminder = continuedFrom ? reminders.get(continuedFrom) : undefined;
+    if (continuedFrom) reminders.delete(continuedFrom);
+    reminders.delete(promptId);
+    if (reminder) reminders.set(promptId, reminder);
   }
 
   /**

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -559,6 +559,9 @@ describe('Gemini Client (client.ts)', () => {
       getAppendSystemPrompt: vi.fn().mockReturnValue(undefined),
       getFullContext: vi.fn().mockReturnValue(false),
       getSessionId: vi.fn().mockReturnValue('test-session-id'),
+      getActiveTodoReminder: vi.fn().mockReturnValue(undefined),
+      startActiveTodoWorkChain: vi.fn(),
+      startAutomaticActiveTodoWorkChain: vi.fn(),
       getProxy: vi.fn().mockReturnValue(undefined),
       getWorkingDir: vi.fn().mockReturnValue('/test/dir'),
       getFileService: vi.fn().mockReturnValue(fileService),
@@ -1708,6 +1711,59 @@ describe('Gemini Client (client.ts)', () => {
         // drain
       }
     }
+
+    it('carries active todos after tool results and clears them for new work', async () => {
+      const reminder =
+        '<system-reminder>unfinished todo: run tests</system-reminder>';
+      vi.mocked(mockConfig.getActiveTodoReminder).mockReturnValue(reminder);
+
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield { type: GeminiEventType.Content, value: 'response' };
+        })(),
+      );
+      const stream = client.sendMessageStream(
+        [{ functionResponse: { name: 'read_file', response: { ok: true } } }],
+        new AbortController().signal,
+        'prompt-tool-result',
+        { type: SendMessageType.ToolResult },
+      );
+      for await (const _ of stream) {
+        // drain
+      }
+
+      const request = mockTurnRunFn.mock.lastCall?.[1] as unknown[];
+      const functionResponseIndex = request.findIndex(
+        (part) =>
+          typeof part === 'object' &&
+          part !== null &&
+          'functionResponse' in part,
+      );
+      expect(functionResponseIndex).toBeGreaterThanOrEqual(0);
+      expect(request.indexOf(reminder)).toBeGreaterThan(functionResponseIndex);
+      expect(mockConfig.getActiveTodoReminder).toHaveBeenCalledWith(
+        'prompt-tool-result',
+      );
+
+      await runTurn(SendMessageType.UserQuery);
+
+      expect(mockConfig.startActiveTodoWorkChain).toHaveBeenCalledWith(
+        'prompt-userQuery',
+      );
+
+      await runTurn(SendMessageType.Retry);
+
+      expect(mockConfig.startActiveTodoWorkChain).toHaveBeenCalledWith(
+        'prompt-retry',
+        'prompt-userQuery',
+      );
+
+      await runTurn(SendMessageType.Cron);
+
+      expect(mockConfig.startActiveTodoWorkChain).toHaveBeenCalledWith(
+        'prompt-cron',
+      );
+    });
 
     it('queues and drains a reminder for newly registered MCP deferred tools', async () => {
       const reg = getRegistryMock();

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -256,6 +256,7 @@ export class GeminiClient {
 
   private readonly loopDetector: LoopDetectionService;
   private lastPromptId: string | undefined = undefined;
+  private activeTodoWorkChainPromptId: string | undefined;
   private lastSentIdeContext: IdeContext | undefined;
   private forceFullIdeContext = true;
   private recentCompletedToolNames: string[] = [];
@@ -2085,6 +2086,23 @@ export class GeminiClient {
     // Notifications start a fresh Turn with a new prompt_id, so the loop
     // detector must reset — otherwise a prior turn's count can trip
     // LoopDetected early on the notification turn.
+    if (messageType === SendMessageType.UserQuery) {
+      this.config.startActiveTodoWorkChain(prompt_id);
+      this.activeTodoWorkChainPromptId = prompt_id;
+    } else if (messageType === SendMessageType.Retry) {
+      this.config.startActiveTodoWorkChain(
+        prompt_id,
+        this.activeTodoWorkChainPromptId,
+      );
+      this.activeTodoWorkChainPromptId = prompt_id;
+    } else if (
+      messageType === SendMessageType.Cron ||
+      messageType === SendMessageType.Notification ||
+      messageType === SendMessageType.Teammate
+    ) {
+      this.config.startActiveTodoWorkChain(prompt_id);
+      this.activeTodoWorkChainPromptId = prompt_id;
+    }
     const isTopLevelInteraction =
       messageType === SendMessageType.UserQuery ||
       messageType === SendMessageType.Cron ||
@@ -2523,6 +2541,10 @@ export class GeminiClient {
           // intact under native Gemini; the OpenAI converter then emits the
           // text as a separate user message after the tool messages.
           requestToSend = [...requestToSend, toolResultMemory.prompt];
+        }
+        const activeTodoReminder = this.config.getActiveTodoReminder(prompt_id);
+        if (activeTodoReminder) {
+          requestToSend = [...requestToSend, activeTodoReminder];
         }
         await this.microcompactHistoryBeforeSend(null, {
           sizeOnly: true,

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -84,6 +84,7 @@ import {
 } from '../utils/invocation-context.js';
 import { getPlanModeSystemReminder } from './prompts.js';
 import { PLAN_MODE_ENTRY_SIBLING_SKIP_MESSAGE } from './plan-mode-entry-policy.js';
+import { promptIdContext } from '../utils/promptIdContext.js';
 
 type ToolSpanRecord = {
   name: string;
@@ -845,6 +846,7 @@ describe('CoreToolScheduler', () => {
       promptId: 'unrelated-prompt',
     };
     let observedContext: InvocationContextV1 | undefined;
+    let observedPromptId: string | undefined;
     const tool = new MockTool({
       name: 'approval-context-tool',
       getDefaultPermission: async () => 'ask',
@@ -856,6 +858,7 @@ describe('CoreToolScheduler', () => {
       }),
       execute: async () => {
         observedContext = getInvocationContext();
+        observedPromptId = promptIdContext.getStore();
         return { llmContent: 'ok', returnDisplay: 'ok' };
       },
     });
@@ -890,6 +893,7 @@ describe('CoreToolScheduler', () => {
     );
 
     expect(observedContext).toEqual(invocationContext);
+    expect(observedPromptId).toBe(invocationContext.promptId);
   });
 
   it('isolates enter_plan_mode as a batch boundary and preserves its full reminder', async () => {

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -70,6 +70,7 @@ import {
   type AvailableSkillEntry,
 } from '../tools/skill-utils.js';
 import { escapeSystemReminderTags } from '../utils/xml.js';
+import { promptIdContext } from '../utils/promptIdContext.js';
 import { unescapePath, PATH_ARG_KEYS } from '../utils/paths.js';
 import type { MemoryPressureMonitor } from '../services/memoryPressureMonitor.js';
 import { CONCURRENCY_SAFE_KINDS, isShellProgressData } from '../tools/tools.js';
@@ -4136,20 +4137,24 @@ export class CoreToolScheduler {
           );
         };
         this.safelyAddToolArgumentsAttributes(span, invocation.params);
-        promise = invocation.execute(
-          execSignal,
-          liveOutputCallback,
-          shellExecutionConfig,
-          setPidCallback,
-          setPromoteAbortControllerCallback,
-          canPromoteForegroundShell,
+        promise = promptIdContext.run(scheduledCall.request.prompt_id, () =>
+          invocation.execute(
+            execSignal,
+            liveOutputCallback,
+            shellExecutionConfig,
+            setPidCallback,
+            setPromoteAbortControllerCallback,
+            canPromoteForegroundShell,
+          ),
         );
       } else {
         this.safelyAddToolArgumentsAttributes(span, invocation.params);
-        promise = invocation.execute(
-          execSignal,
-          liveOutputCallback,
-          shellExecutionConfig,
+        promise = promptIdContext.run(scheduledCall.request.prompt_id, () =>
+          invocation.execute(
+            execSignal,
+            liveOutputCallback,
+            shellExecutionConfig,
+          ),
         );
       }
 

--- a/packages/core/src/tools/todoWrite.test.ts
+++ b/packages/core/src/tools/todoWrite.test.ts
@@ -15,6 +15,7 @@ import type { Config } from '../config/config.js';
 import type { AggregatedHookResult } from '../hooks/hookAggregator.js';
 import { Storage } from '../config/storage.js';
 import { atomicWriteFile } from '../utils/atomicFileWrite.js';
+import { promptIdContext } from '../utils/promptIdContext.js';
 
 // Mock fs modules
 vi.mock('fs/promises');
@@ -37,7 +38,8 @@ describe('TodoWriteTool', () => {
     mockConfig = {
       getSessionId: () => 'test-session-123',
       getHookSystem: () => undefined,
-    } as Config;
+      setActiveTodoReminder: vi.fn(),
+    } as unknown as Config;
     tool = new TodoWriteTool(mockConfig);
     mockAbortSignal = new AbortController().signal;
     vi.clearAllMocks();
@@ -152,7 +154,9 @@ describe('TodoWriteTool', () => {
       mockAtomicWrite.mockResolvedValue(undefined);
 
       const invocation = tool.build(params);
-      const result = await invocation.execute(mockAbortSignal);
+      const result = await promptIdContext.run('todo-prompt', () =>
+        invocation.execute(mockAbortSignal),
+      );
 
       expect(result.llmContent).toContain(
         'Todos have been modified successfully',
@@ -172,6 +176,30 @@ describe('TodoWriteTool', () => {
         expect.stringContaining('"todos"'),
         { encoding: 'utf-8' },
       );
+      expect(mockConfig.setActiveTodoReminder).toHaveBeenCalledWith(
+        'todo-prompt',
+        expect.stringContaining('Task 1'),
+      );
+    });
+
+    it('bounds the active Todo reminder', async () => {
+      const params: TodoWriteParams = {
+        todos: [{ id: '1', content: 'x'.repeat(5000), status: 'in_progress' }],
+      };
+      const enoentError = new Error('ENOENT') as Error & { code: string };
+      enoentError.code = 'ENOENT';
+      mockFs.readFile.mockRejectedValue(enoentError);
+      mockFs.mkdir.mockResolvedValue(undefined);
+      mockAtomicWrite.mockResolvedValue(undefined);
+
+      await promptIdContext.run('todo-prompt', () =>
+        tool.build(params).execute(mockAbortSignal),
+      );
+
+      const reminder = vi.mocked(mockConfig.setActiveTodoReminder).mock
+        .lastCall?.[1];
+      expect(reminder).toContain('[truncated]');
+      expect(reminder?.length).toBeLessThan(4300);
     });
 
     it('should replace todos with new ones', async () => {
@@ -194,7 +222,9 @@ describe('TodoWriteTool', () => {
       mockAtomicWrite.mockResolvedValue(undefined);
 
       const invocation = tool.build(params);
-      const result = await invocation.execute(mockAbortSignal);
+      const result = await promptIdContext.run('todo-prompt', () =>
+        invocation.execute(mockAbortSignal),
+      );
 
       expect(result.llmContent).toContain(
         'Todos have been modified successfully',
@@ -214,6 +244,10 @@ describe('TodoWriteTool', () => {
         expect.stringMatching(/"Updated Task"/),
         { encoding: 'utf-8' },
       );
+      const reminder = vi.mocked(mockConfig.setActiveTodoReminder).mock
+        .lastCall?.[1];
+      expect(reminder).toContain('New Task');
+      expect(reminder).not.toContain('Updated Task');
     });
 
     it('should handle file write errors', async () => {
@@ -256,7 +290,9 @@ describe('TodoWriteTool', () => {
       );
 
       const invocation = tool.build(params);
-      const result = await invocation.execute(mockAbortSignal);
+      const result = await promptIdContext.run('todo-prompt', () =>
+        invocation.execute(mockAbortSignal),
+      );
 
       expect(result.llmContent).toContain('Todo list has been cleared');
       expect(result.llmContent).toContain('<system-reminder>');
@@ -270,6 +306,10 @@ describe('TodoWriteTool', () => {
         expect.stringContaining('test-session-123.json'),
         expect.stringContaining('"todos"'),
         { encoding: 'utf-8' },
+      );
+      expect(mockConfig.setActiveTodoReminder).toHaveBeenCalledWith(
+        'todo-prompt',
+        undefined,
       );
     });
 
@@ -794,7 +834,7 @@ describe('TodoWriteTool – runtime output directory', () => {
     mockConfig = {
       getSessionId: () => 'runtime-session',
       getHookSystem: () => undefined,
-    } as Config;
+    } as unknown as Config;
     tool = new TodoWriteTool(mockConfig);
     mockAbortSignal = new AbortController().signal;
     Storage.setRuntimeBaseDir(null);

--- a/packages/core/src/tools/todoWrite.ts
+++ b/packages/core/src/tools/todoWrite.ts
@@ -17,9 +17,12 @@ import { ToolDisplayNames, ToolNames } from './tool-names.js';
 import { atomicWriteFile } from '../utils/atomicFileWrite.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { detectTodoChanges, HookPhase, type TodoItem } from '../hooks/types.js';
+import { escapeSystemReminderTags } from '../utils/xml.js';
+import { promptIdContext } from '../utils/promptIdContext.js';
 export type { TodoItem } from '../hooks/types.js';
 
 const debugLogger = createDebugLogger('TODO_WRITE');
+const MAX_ACTIVE_TODO_CONTEXT_CHARS = 4000;
 
 export interface TodoWriteParams {
   todos: TodoItem[];
@@ -250,6 +253,25 @@ class TodoWriteToolInvocation extends BaseToolInvocation<
 
       // 4. Write new todos AFTER all validation passes
       await writeTodosToFile(finalTodos, sessionId);
+      const unfinishedTodos = finalTodos.filter(
+        (todo) => todo.status !== 'completed',
+      );
+      const promptId = promptIdContext.getStore();
+      if (promptId) {
+        const serializedTodos = escapeSystemReminderTags(
+          JSON.stringify(unfinishedTodos),
+        );
+        const todoContext = serializedTodos.slice(
+          0,
+          MAX_ACTIVE_TODO_CONTEXT_CHARS,
+        );
+        this.config.setActiveTodoReminder(
+          promptId,
+          unfinishedTodos.length > 0
+            ? `<system-reminder>\nThe current task still has unfinished todo items:\n${todoContext}${serializedTodos.length > todoContext.length ? '\n[truncated]' : ''}\nKeep the todo list current and continue the task. Do not treat a successful intermediate tool call as task completion.\n</system-reminder>`
+            : undefined,
+        );
+      }
 
       // 5. POST-WRITE PHASE: Execute hooks for side effects (logging, HTTP sync, etc.)
       // These hooks can now safely perform side effects knowing data is persisted


### PR DESCRIPTION
## What this PR does

This change keeps the latest unfinished Todo list salient across tool turns. After a successful Todo update, Qwen Code retains a bounded prompt-scoped reminder and appends it after function responses in both the core and ACP loops. Mid-turn user input remains last so the user's newest direction keeps precedence.

Todo reminders are isolated by work-chain prompt ID, so cron jobs and background notifications cannot overwrite an ordinary user task. Retry, continue, and explicitly related automatic turns move the reminder to their new prompt ID, while session changes clear it. The existing experimental Todo Stop Guard remains unchanged and disabled by default.

## Why it's needed

Today the complete Todo state is emphasized only in the immediate `todo_write` result. After several other tool calls, that state loses salience and the model can naturally end the turn while Todo items are still pending. Re-reading the persisted Todo file is not safe because it can outlive the work chain that created it, and changing stop semantics would turn a planning aid into a completion oracle.

This preserves the current task context before the stop decision without treating Todo state as proof that the task is complete or forcing an automatic retry.

## Reviewer Test Plan

### How to verify

1. Start a multi-step task that creates a pending Todo and performs at least one additional tool call. Confirm the next model request contains the unfinished Todo reminder after the tool's function response.
2. Complete every Todo and perform another tool call. Confirm the reminder is absent.
3. Start an unrelated user prompt. Confirm the previous reminder is cleared.
4. Retry or continue the interrupted task. Confirm its reminder follows the continued work chain.
5. Run a cron or background-notification tool loop alongside an ordinary task. Confirm each loop reads only the reminder owned by its prompt ID.
6. Queue mid-turn user input while a tool executes. Confirm the request order is function responses, Todo reminder, then the user's new input.

### Evidence (Before & After)

N/A — model-context behavior with no UI change. Focused regressions cover Todo persistence, prompt ownership, Core and ACP injection order, retry/continue transfer, and the Todo Stop Guard remaining off by default.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local Node.js 22 workspace. `npm run build`, `npm run typecheck`, changed-file ESLint and Prettier, TodoWrite and Config tests, Core client and scheduler tests, non-interactive CLI tests, and focused ACP Session regressions all pass. A full ACP Session run reached 454 passing tests and one pre-existing 30-second mid-turn drain timeout; the affected ACP tests pass when run directly.

## Risk & Scope

- Main risk or tradeoff: active Todo reminders add a small amount of repeated context on tool-result turns; only unfinished items are included, the payload is capped at 4,000 characters, and prompt ownership bounds its lifetime.
- Not validated / out of scope: changing natural-stop semantics, enabling or removing `todoStopGuard`, and guaranteeing that every model will always follow the reminder.
- Breaking changes / migration notes: none.

## Linked Issues

Related to #6945 and #7821.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个改动让最新的未完成 Todo 列表在连续工具轮次中保持显著。`todo_write` 成功后，Qwen Code 会保留一段有大小上限、按 prompt 隔离的 reminder，并在 Core 和 ACP 循环中把它追加到 function response 之后。轮次中途到达的用户输入仍然放在最后，因此用户最新指令保持最高优先级。

Todo reminder 按工作链 prompt ID 隔离，因此 cron 任务和后台 notification 不会覆盖普通用户任务。retry、continue 和明确相关的自动轮次会把 reminder 转移到新的 prompt ID；session 切换会清理 reminder。现有实验性 Todo Stop Guard 不做修改，默认仍然关闭。

## 为什么需要

当前完整 Todo 状态只会在当次 `todo_write` 结果中被重点提示。经过若干其他工具调用后，这段状态的显著性会降低，模型可能在仍有 pending Todo 时自然结束轮次。直接重新读取持久化 Todo 文件并不安全，因为文件可能比创建它的工作链存活更久；而修改 stop 语义则会把规划辅助误当成完成判定器。

这个方案在模型做出停止决定之前持续保留当前任务上下文，但不会把 Todo 状态当作任务已经完成的证据，也不会强制自动重试。

## Reviewer 测试计划

### 如何验证

1. 启动一个会创建 pending Todo、并至少继续执行一次其他工具调用的多步骤任务。确认下一次模型请求在工具 function response 之后包含未完成 Todo reminder。
2. 完成所有 Todo 后再执行一次工具调用。确认 reminder 不再出现。
3. 启动一个无关的新用户 prompt。确认旧 reminder 已清理。
4. retry 或 continue 被中断的任务。确认 reminder 跟随续接后的工作链。
5. 在普通任务旁运行 cron 或后台 notification 工具循环。确认每个循环只读取自己 prompt ID 对应的 reminder。
6. 工具执行期间加入一条中途用户输入。确认请求顺序是 function response、Todo reminder、用户新输入。

### 证据（Before & After）

N/A —— 这是模型上下文行为变化，没有 UI 改动。聚焦回归覆盖 Todo 持久化、prompt ownership、Core 与 ACP 注入顺序、retry/continue 转移，以及 Todo Stop Guard 默认仍关闭。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

本地 Node.js 22 workspace。`npm run build`、`npm run typecheck`、变更文件 ESLint 与 Prettier、TodoWrite 与 Config 测试、Core client 与 scheduler 测试、non-interactive CLI 测试和 ACP Session 聚焦回归均通过。ACP Session 全量运行有 454 个测试通过，另有一个既有的 mid-turn drain 用例在 30 秒超时；本次影响到的 ACP 测试单独运行均通过。

## 风险与范围

- 主要风险或取舍：active Todo reminder 会在 tool-result 轮次加入少量重复上下文；内容只包含未完成项、上限为 4,000 字符，并通过 prompt ownership 限制生命周期。
- 未验证 / 不在本次范围：修改自然停止语义、开启或移除 `todoStopGuard`，以及保证所有模型始终遵循 reminder。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

与 #6945 和 #7821 相关。

</details>
