### PR TITLE
fix(core): rebind fork capabilities on resume

### DIFF
--- a/docs/design/fork-resume-live-capabilities.md
+++ b/docs/design/fork-resume-live-capabilities.md
@@ -1,0 +1,35 @@
+# Fork resume live capabilities
+
+## Problem
+
+Fork background agents persist the parent's rendered system instruction and
+inline tool declarations. Resume sends those launch-time declarations to the
+model, while execution still uses the current `ToolRegistry`. A removed or
+changed tool can therefore remain model-visible even though it cannot be
+executed.
+
+## Design
+
+Keep the fork's bootstrap and runtime messages as its durable identity. On
+resume, rebuild its executable surface from the current parent session:
+
+- use the current parent's rendered system instruction;
+- take the current parent's advertised tool names and resolve their schemas
+  through the resumed agent's current registry;
+- include current MCP, deferred-tool, and Skill reminders on the continuation
+  turn, while declaring earlier capability listings obsolete;
+- leave the task paused when the current parent prompt or tool surface cannot
+  be reconstructed.
+
+Launch-time system instructions and tool declarations remain readable in old
+transcripts for compatibility, but resume no longer treats them as executable
+authority. New transcripts persist the inherited history and task prompt, not
+capability snapshots; current runtime state is authoritative.
+
+## Consequences
+
+Removed tools are no longer advertised after resume, and changed tools use
+their current schemas. A resumed fork can gain a tool that is newly available
+to its parent, so this favors live consistency over byte-identical replay.
+Rebinding can also invalidate the old prompt-cache prefix, which is preferable
+to sending stale capabilities.

--- a/packages/core/src/agents/agent-transcript.test.ts
+++ b/packages/core/src/agents/agent-transcript.test.ts
@@ -21,7 +21,7 @@ import {
 } from './agent-transcript.js';
 import { AgentEventEmitter, AgentEventType } from './runtime/agent-events.js';
 import type { ChatRecord } from '../services/chatRecordingService.js';
-import type { Content, FunctionDeclaration } from '@google/genai';
+import type { Content } from '@google/genai';
 
 describe('agent-transcript', () => {
   describe('path helpers', () => {
@@ -172,8 +172,6 @@ describe('agent-transcript', () => {
       extra: {
         initialUserPrompt?: string;
         bootstrapHistory?: Content[];
-        bootstrapSystemInstruction?: string | Content;
-        bootstrapTools?: Array<string | FunctionDeclaration>;
         launchTaskPrompt?: string;
       } = {},
     ) {
@@ -261,11 +259,6 @@ describe('agent-transcript', () => {
       const jsonlPath = path.join(tempDir, 's', 'agent-x.jsonl');
       const { cleanup } = makeWriter(jsonlPath, {
         bootstrapHistory: [],
-        bootstrapSystemInstruction: {
-          role: 'system',
-          parts: [{ text: 'fork system' }],
-        },
-        bootstrapTools: [{ name: 'Bash' }],
         launchTaskPrompt: 'Begin.',
       });
 
@@ -279,11 +272,6 @@ describe('agent-transcript', () => {
       expect(records[0]?.systemPayload).toMatchObject({
         kind: 'fork',
         history: [],
-        systemInstruction: {
-          role: 'system',
-          parts: [{ text: 'fork system' }],
-        },
-        tools: [{ name: 'Bash' }],
       });
     });
 

--- a/packages/core/src/agents/agent-transcript.ts
+++ b/packages/core/src/agents/agent-transcript.ts
@@ -40,7 +40,7 @@ import { MAX_SUBAGENT_DEPTH_LIMIT } from '../config/config.js';
 import type { SandboxConfig } from '../config/config.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { _recoverObjectsFromLine } from '../utils/jsonl-utils.js';
-import type { FunctionDeclaration, Content } from '@google/genai';
+import type { Content } from '@google/genai';
 
 const debugLogger = createDebugLogger('AGENT_TRANSCRIPT');
 const MAX_PENDING_STREAM_BYTES = 64 * 1024;
@@ -298,17 +298,9 @@ export interface AttachJsonlOptions {
   initialUserPrompt?: string;
   /**
    * Exact bootstrap history that seeded the agent before its first runtime
-   * turn. Used by transcript-first resume to reconstruct fork constraints.
+   * turn. Used by transcript-first resume to reconstruct fork context.
    */
   bootstrapHistory?: Content[];
-  /**
-   * Immutable launch-time system instruction for fork resume.
-   */
-  bootstrapSystemInstruction?: string | Content;
-  /**
-   * Immutable launch-time tool declarations / allowlist for fork resume.
-   */
-  bootstrapTools?: Array<string | FunctionDeclaration>;
   /**
    * Launching prompt that should be treated as the first model-facing task
    * prompt during transcript-based resume. For forks this may differ from the
@@ -536,25 +528,10 @@ export function attachJsonlTranscriptWriter(
     recordUserMessage(event.text, event.kind ?? 'message');
   };
 
-  const hasBootstrapPayload =
-    options.bootstrapHistory !== undefined ||
-    options.bootstrapSystemInstruction !== undefined ||
-    options.bootstrapTools !== undefined;
-
-  if (hasBootstrapPayload) {
+  if (options.bootstrapHistory !== undefined) {
     const payload: AgentBootstrapRecordPayload = {
       kind: 'fork',
       history: structuredClone(options.bootstrapHistory ?? []),
-      ...(options.bootstrapSystemInstruction !== undefined
-        ? {
-            systemInstruction: structuredClone(
-              options.bootstrapSystemInstruction,
-            ),
-          }
-        : {}),
-      ...(options.bootstrapTools !== undefined
-        ? { tools: structuredClone(options.bootstrapTools) }
-        : {}),
     };
     recordSystem('agent_bootstrap', payload);
   }

--- a/packages/core/src/agents/background-agent-resume.test.ts
+++ b/packages/core/src/agents/background-agent-resume.test.ts
@@ -21,6 +21,7 @@ import {
   readAgentMeta,
   writeAgentMeta,
 } from './agent-transcript.js';
+import { ToolNames } from '../tools/tool-names.js';
 import { AgentTerminateMode } from './runtime/agent-types.js';
 import { AgentEventEmitter } from './runtime/agent-events.js';
 import { getCurrentAgentDepth } from './runtime/agent-context.js';
@@ -2303,6 +2304,135 @@ describe('BackgroundAgentResumeService', () => {
     expect(registry.get(agentId)?.resumeBlockedReason).toContain(
       'current parent system prompt or tool surface is unavailable',
     );
+    expect(createSpy).not.toHaveBeenCalled();
+    createSpy.mockRestore();
+  });
+
+  // Seeds a resumable fork task with a complete bootstrap transcript so
+  // resumeBackgroundAgent reaches resolveCurrentForkRuntime — the branch under
+  // test — rather than short-circuiting earlier on a missing transcript.
+  function seedResumableForkTask(sessionId: string, agentId: string) {
+    const metaPath = getAgentMetaPath(tempDir, sessionId, agentId);
+    const outputFile = getAgentJsonlPath(tempDir, sessionId, agentId);
+
+    writeAgentMeta(metaPath, {
+      agentId,
+      agentType: FORK_SUBAGENT_TYPE,
+      description: 'Fork task pending capability rebind',
+      parentSessionId: sessionId,
+      parentAgentId: null,
+      createdAt: '2026-04-20T00:00:00.000Z',
+      status: 'running',
+      subagentName: FORK_SUBAGENT_TYPE,
+      resolvedApprovalMode: 'default',
+    });
+    fs.writeFileSync(
+      outputFile,
+      [
+        JSON.stringify({
+          uuid: 'sys1',
+          parentUuid: null,
+          sessionId,
+          timestamp: '2026-04-20T00:00:00.000Z',
+          type: 'system',
+          subtype: 'agent_bootstrap',
+          systemPayload: {
+            kind: 'fork',
+            history: [{ role: 'user', parts: [{ text: 'bootstrap env' }] }],
+          },
+        }),
+        JSON.stringify({
+          uuid: 'u1',
+          parentUuid: 'sys1',
+          sessionId,
+          timestamp: '2026-04-20T00:00:00.100Z',
+          type: 'user',
+          message: { role: 'user', parts: [{ text: 'Fork task' }] },
+        }),
+        JSON.stringify({
+          uuid: 'sys2',
+          parentUuid: 'u1',
+          sessionId,
+          timestamp: '2026-04-20T00:00:00.200Z',
+          type: 'system',
+          subtype: 'agent_launch_prompt',
+          systemPayload: {
+            displayText: buildChildMessage('Fork task'),
+          },
+        }),
+      ].join('\n') + '\n',
+      'utf8',
+    );
+
+    registry.register({
+      agentId,
+      description: 'Fork task pending capability rebind',
+      subagentType: FORK_SUBAGENT_TYPE,
+      status: 'paused',
+      startTime: Date.now(),
+      abortController: new AbortController(),
+      prompt: 'Fork task',
+      outputFile,
+      metaPath,
+      isBackgrounded: true,
+    });
+
+    return { metaPath, outputFile };
+  }
+
+  it('keeps fork tasks paused when every advertised parent tool is excluded from subagents', async () => {
+    const sessionId = 'session-fork-cap-excluded';
+    const agentId = 'agent-fork-cap-excluded';
+    seedResumableForkTask(sessionId, agentId);
+
+    const createSpy = vi.spyOn(AgentHeadless, 'create');
+    const { service } = createService({
+      currentForkRuntime: {
+        systemInstruction: 'current parent system instruction',
+        // Every advertised tool is in EXCLUDED_TOOLS_FOR_SUBAGENTS, so the
+        // filtered advertised-name set collapses to empty and the fork must
+        // stay paused instead of resuming with no tools.
+        advertisedTools: [
+          { name: ToolNames.WORKFLOW },
+          { name: ToolNames.AGENT },
+        ],
+      },
+    });
+    const resumed = await service.resumeBackgroundAgent(agentId, 'continue');
+
+    expect(resumed).toBeUndefined();
+    expect(registry.get(agentId)?.status).toBe('paused');
+    expect(registry.get(agentId)?.resumeBlockedReason).toContain(
+      'current parent system prompt or tool surface is unavailable',
+    );
+    expect(registry.get(agentId)?.error).toBeUndefined();
+    expect(createSpy).not.toHaveBeenCalled();
+    createSpy.mockRestore();
+  });
+
+  it('keeps fork tasks paused when no advertised parent tool is still registered', async () => {
+    const sessionId = 'session-fork-cap-unregistered';
+    const agentId = 'agent-fork-cap-unregistered';
+    seedResumableForkTask(sessionId, agentId);
+
+    const createSpy = vi.spyOn(AgentHeadless, 'create');
+    const { service } = createService({
+      currentForkRuntime: {
+        systemInstruction: 'current parent system instruction',
+        advertisedTools: [{ name: 'mcp__removed__search' }],
+        // The advertised tool is no longer in the live registry, so the
+        // registry filter yields no resolvable tool and the fork stays paused.
+        registeredTools: [],
+      },
+    });
+    const resumed = await service.resumeBackgroundAgent(agentId, 'continue');
+
+    expect(resumed).toBeUndefined();
+    expect(registry.get(agentId)?.status).toBe('paused');
+    expect(registry.get(agentId)?.resumeBlockedReason).toContain(
+      'current parent system prompt or tool surface is unavailable',
+    );
+    expect(registry.get(agentId)?.error).toBeUndefined();
     expect(createSpy).not.toHaveBeenCalled();
     createSpy.mockRestore();
   });

--- a/packages/core/src/agents/background-agent-resume.test.ts
+++ b/packages/core/src/agents/background-agent-resume.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import type { Content, FunctionDeclaration } from '@google/genai';
 import type { Config } from '../config/config.js';
 import {
   BackgroundTaskRegistry,
@@ -56,6 +57,11 @@ describe('BackgroundAgentResumeService', () => {
   function createService(
     options: {
       stopHookBlockingCap?: number;
+      currentForkRuntime?: {
+        systemInstruction: string | Content;
+        advertisedTools: FunctionDeclaration[];
+        registeredTools?: FunctionDeclaration[];
+      };
       hookSystem?:
         | {
             fireSubagentStartEvent: ReturnType<typeof vi.fn>;
@@ -97,6 +103,16 @@ describe('BackgroundAgentResumeService', () => {
       getDeferredToolSummary: vi.fn().mockReturnValue([]),
       isDeferredToolRevealed: vi.fn().mockReturnValue(false),
       getMcpServerInstructions: vi.fn().mockReturnValue(new Map()),
+      getFunctionDeclarationsFiltered: vi.fn((names: string[]) =>
+        (
+          options.currentForkRuntime?.registeredTools ??
+          options.currentForkRuntime?.advertisedTools ??
+          []
+        ).filter(
+          (declaration) =>
+            declaration.name !== undefined && names.includes(declaration.name),
+        ),
+      ),
     };
     const permissionManager = {
       stripDangerousRulesForAutoMode: vi.fn(),
@@ -127,7 +143,23 @@ describe('BackgroundAgentResumeService', () => {
       isInteractive: () => false,
       getProjectRoot: () => tempDir,
       getCliVersion: () => 'test-version',
-      getGeminiClient: () => undefined,
+      getGeminiClient: () =>
+        options.currentForkRuntime
+          ? {
+              getChat: () => ({
+                getGenerationConfig: () => ({
+                  systemInstruction:
+                    options.currentForkRuntime!.systemInstruction,
+                  tools: [
+                    {
+                      functionDeclarations:
+                        options.currentForkRuntime!.advertisedTools,
+                    },
+                  ],
+                }),
+              }),
+            }
+          : undefined,
       getSkillManager: () => undefined,
       getSkipStartupContext: () => true,
       getTranscriptPath: () => path.join(tempDir, 'session.jsonl'),
@@ -1959,147 +1991,173 @@ describe('BackgroundAgentResumeService', () => {
     );
   });
 
-  it('resumes fork agents from transcript bootstrap instead of current parent config', async () => {
-    const sessionId = 'session-fork-resume';
-    const agentId = 'agent-fork-resume';
-    const metaPath = getAgentMetaPath(tempDir, sessionId, agentId);
-    const outputFile = getAgentJsonlPath(tempDir, sessionId, agentId);
-    const launchPrompt = 'Investigate the retry loop and patch it';
-
-    writeAgentMeta(metaPath, {
-      agentId,
-      agentType: FORK_SUBAGENT_TYPE,
-      description: launchPrompt,
-      parentSessionId: sessionId,
-      parentAgentId: null,
-      createdAt: '2026-04-20T00:00:00.000Z',
-      status: 'running',
-      subagentName: FORK_SUBAGENT_TYPE,
-      resolvedApprovalMode: 'default',
-    });
-    fs.writeFileSync(
-      outputFile,
-      [
-        JSON.stringify({
-          uuid: 'sys1',
-          parentUuid: null,
-          sessionId,
-          timestamp: '2026-04-20T00:00:00.000Z',
-          type: 'system',
-          subtype: 'agent_bootstrap',
-          systemPayload: {
-            kind: 'fork',
-            history: [
-              { role: 'user', parts: [{ text: 'bootstrap env' }] },
-              { role: 'model', parts: [{ text: 'bootstrap ack' }] },
-            ],
-            systemInstruction: {
-              role: 'system',
-              parts: [{ text: 'persisted system instruction' }],
-            },
-            tools: [{ name: 'Bash' }, { name: 'Read' }],
-          },
-        }),
-        JSON.stringify({
-          uuid: 'u1',
-          parentUuid: 'sys1',
-          sessionId,
-          timestamp: '2026-04-20T00:00:00.100Z',
-          type: 'user',
-          message: { role: 'user', parts: [{ text: launchPrompt }] },
-        }),
-        JSON.stringify({
-          uuid: 'sys2',
-          parentUuid: 'u1',
-          sessionId,
-          timestamp: '2026-04-20T00:00:00.200Z',
-          type: 'system',
-          subtype: 'agent_launch_prompt',
-          systemPayload: {
-            displayText: buildChildMessage(launchPrompt),
-          },
-        }),
-        JSON.stringify({
-          uuid: 'a1',
-          parentUuid: 'sys2',
-          sessionId,
-          timestamp: '2026-04-20T00:00:01.000Z',
-          type: 'assistant',
-          message: { role: 'model', parts: [{ text: 'Working silently' }] },
-        }),
-      ].join('\n') + '\n',
-      'utf8',
-    );
-
-    registry.register({
-      agentId,
-      description: launchPrompt,
-      subagentType: FORK_SUBAGENT_TYPE,
-      status: 'paused',
-      startTime: Date.now(),
-      abortController: new AbortController(),
-      prompt: launchPrompt,
-      outputFile,
-      metaPath,
-      isBackgrounded: true,
-    });
-
-    const execute = vi.fn(async (_context: unknown) => undefined);
-    const subagent = {
-      execute,
-      setExternalMessageProvider: vi.fn(),
-      getCore: () => ({ getEventEmitter: () => new AgentEventEmitter() }),
-      getExecutionSummary: () => ({
-        totalTokens: 0,
-        outputTokens: 0,
-        totalDurationMs: 0,
-      }),
-      getTerminateMode: () => AgentTerminateMode.GOAL,
-      getFinalText: () => 'done',
-    };
-
-    const createSpy = vi
-      .spyOn(AgentHeadless, 'create')
-      .mockResolvedValue(subagent as unknown as AgentHeadless);
-    const { service, subagentManager } = createService();
-    const resumed = await service.resumeBackgroundAgent(agentId, 'continue');
-
-    expect(resumed).toBeDefined();
-    expect(subagentManager.createAgentHeadless).not.toHaveBeenCalled();
-    expect(createSpy).toHaveBeenCalledTimes(1);
-    const createArgs = createSpy.mock.calls[0];
-    expect(createArgs).toBeDefined();
-    expect(createArgs![2]).toMatchObject({
-      renderedSystemPrompt: {
-        role: 'system',
-        parts: [{ text: 'persisted system instruction' }],
+  it.each([
+    {
+      format: 'legacy capability snapshots',
+      legacyCapabilities: {
+        systemInstruction: {
+          role: 'system' as const,
+          parts: [{ text: 'persisted system instruction' }],
+        },
+        tools: [{ name: 'Bash' }, { name: 'mcp__removed__search' }],
       },
-      initialMessages: [
-        { role: 'user', parts: [{ text: 'bootstrap env' }] },
-        { role: 'model', parts: [{ text: 'bootstrap ack' }] },
-        { role: 'user', parts: [{ text: buildChildMessage(launchPrompt) }] },
-        { role: 'model', parts: [{ text: 'Working silently' }] },
-      ],
-    });
-    expect(createArgs?.[4]).toEqual({
-      max_turns: FORK_DEFAULT_MAX_TURNS,
-    });
-    expect(createArgs?.[5]).toEqual({
-      tools: [{ name: 'Bash' }, { name: 'Read' }],
-    });
-    expect(execute).toHaveBeenCalledTimes(1);
-    const executeCall = execute.mock.calls[0];
-    expect(executeCall).toBeDefined();
-    const contextArg = executeCall?.[0] as
-      | { get(key: string): unknown }
-      | undefined;
-    expect(contextArg).toBeDefined();
-    if (!contextArg) {
-      throw new Error('Expected resume execute context');
-    }
-    expect(contextArg.get('task_prompt')).toBe('continue');
-    createSpy.mockRestore();
-  });
+    },
+    { format: 'history-only bootstrap', legacyCapabilities: {} },
+  ])(
+    'resumes fork agents with the current parent prompt and live tool registry ($format)',
+    async ({ legacyCapabilities }) => {
+      const sessionId = 'session-fork-resume';
+      const agentId = 'agent-fork-resume';
+      const metaPath = getAgentMetaPath(tempDir, sessionId, agentId);
+      const outputFile = getAgentJsonlPath(tempDir, sessionId, agentId);
+      const launchPrompt = 'Investigate the retry loop and patch it';
+
+      writeAgentMeta(metaPath, {
+        agentId,
+        agentType: FORK_SUBAGENT_TYPE,
+        description: launchPrompt,
+        parentSessionId: sessionId,
+        parentAgentId: null,
+        createdAt: '2026-04-20T00:00:00.000Z',
+        status: 'running',
+        subagentName: FORK_SUBAGENT_TYPE,
+        resolvedApprovalMode: 'default',
+      });
+      fs.writeFileSync(
+        outputFile,
+        [
+          JSON.stringify({
+            uuid: 'sys1',
+            parentUuid: null,
+            sessionId,
+            timestamp: '2026-04-20T00:00:00.000Z',
+            type: 'system',
+            subtype: 'agent_bootstrap',
+            systemPayload: {
+              kind: 'fork',
+              history: [
+                { role: 'user', parts: [{ text: 'bootstrap env' }] },
+                { role: 'model', parts: [{ text: 'bootstrap ack' }] },
+              ],
+              ...legacyCapabilities,
+            },
+          }),
+          JSON.stringify({
+            uuid: 'u1',
+            parentUuid: 'sys1',
+            sessionId,
+            timestamp: '2026-04-20T00:00:00.100Z',
+            type: 'user',
+            message: { role: 'user', parts: [{ text: launchPrompt }] },
+          }),
+          JSON.stringify({
+            uuid: 'sys2',
+            parentUuid: 'u1',
+            sessionId,
+            timestamp: '2026-04-20T00:00:00.200Z',
+            type: 'system',
+            subtype: 'agent_launch_prompt',
+            systemPayload: {
+              displayText: buildChildMessage(launchPrompt),
+            },
+          }),
+          JSON.stringify({
+            uuid: 'a1',
+            parentUuid: 'sys2',
+            sessionId,
+            timestamp: '2026-04-20T00:00:01.000Z',
+            type: 'assistant',
+            message: { role: 'model', parts: [{ text: 'Working silently' }] },
+          }),
+        ].join('\n') + '\n',
+        'utf8',
+      );
+
+      registry.register({
+        agentId,
+        description: launchPrompt,
+        subagentType: FORK_SUBAGENT_TYPE,
+        status: 'paused',
+        startTime: Date.now(),
+        abortController: new AbortController(),
+        prompt: launchPrompt,
+        outputFile,
+        metaPath,
+        isBackgrounded: true,
+      });
+
+      const execute = vi.fn(async (_context: unknown) => undefined);
+      const subagent = {
+        execute,
+        setExternalMessageProvider: vi.fn(),
+        getCore: () => ({ getEventEmitter: () => new AgentEventEmitter() }),
+        getExecutionSummary: () => ({
+          totalTokens: 0,
+          outputTokens: 0,
+          totalDurationMs: 0,
+        }),
+        getTerminateMode: () => AgentTerminateMode.GOAL,
+        getFinalText: () => 'done',
+      };
+
+      const createSpy = vi
+        .spyOn(AgentHeadless, 'create')
+        .mockResolvedValue(subagent as unknown as AgentHeadless);
+      const currentSystemInstruction: Content = {
+        role: 'system',
+        parts: [{ text: 'current parent system instruction' }],
+      };
+      const { service, subagentManager } = createService({
+        currentForkRuntime: {
+          systemInstruction: currentSystemInstruction,
+          advertisedTools: [
+            { name: 'Read', description: 'advertised current schema' },
+            { name: 'mcp__removed__search' },
+          ],
+          registeredTools: [
+            { name: 'Read', description: 'registered current schema' },
+          ],
+        },
+      });
+      const resumed = await service.resumeBackgroundAgent(agentId, 'continue');
+
+      expect(resumed).toBeDefined();
+      expect(subagentManager.createAgentHeadless).not.toHaveBeenCalled();
+      expect(createSpy).toHaveBeenCalledTimes(1);
+      const createArgs = createSpy.mock.calls[0];
+      expect(createArgs).toBeDefined();
+      expect(createArgs![2]).toMatchObject({
+        renderedSystemPrompt: currentSystemInstruction,
+        initialMessages: [
+          { role: 'user', parts: [{ text: 'bootstrap env' }] },
+          { role: 'model', parts: [{ text: 'bootstrap ack' }] },
+          { role: 'user', parts: [{ text: buildChildMessage(launchPrompt) }] },
+          { role: 'model', parts: [{ text: 'Working silently' }] },
+        ],
+      });
+      expect(createArgs?.[4]).toEqual({
+        max_turns: FORK_DEFAULT_MAX_TURNS,
+      });
+      expect(createArgs?.[5]).toEqual({
+        tools: ['Read'],
+      });
+      expect(execute).toHaveBeenCalledTimes(1);
+      const executeCall = execute.mock.calls[0];
+      expect(executeCall).toBeDefined();
+      const contextArg = executeCall?.[0] as
+        | { get(key: string): unknown }
+        | undefined;
+      expect(contextArg).toBeDefined();
+      if (!contextArg) {
+        throw new Error('Expected resume execute context');
+      }
+      expect(contextArg.get('task_prompt')).toContain(
+        'Earlier capability listings in the conversation history are obsolete',
+      );
+      expect(contextArg.get('task_prompt')).toContain('continue');
+      createSpy.mockRestore();
+    },
+  );
 
   it('keeps legacy fork tasks paused when transcript bootstrap is missing', async () => {
     const sessionId = 'session-fork-legacy';
@@ -2145,7 +2203,12 @@ describe('BackgroundAgentResumeService', () => {
     });
 
     const createSpy = vi.spyOn(AgentHeadless, 'create');
-    const { service, permissionManager, stubToolRegistry } = createService();
+    const { service, permissionManager, stubToolRegistry } = createService({
+      currentForkRuntime: {
+        systemInstruction: 'current parent system instruction',
+        advertisedTools: [{ name: 'Read' }],
+      },
+    });
     const resumed = await service.resumeBackgroundAgent(agentId, 'continue');
 
     expect(resumed).toBeUndefined();
@@ -2163,7 +2226,7 @@ describe('BackgroundAgentResumeService', () => {
     createSpy.mockRestore();
   });
 
-  it('keeps fork tasks paused when bootstrap capabilities are missing', async () => {
+  it('keeps fork tasks paused when the current parent runtime is unavailable', async () => {
     const sessionId = 'session-fork-cap-legacy';
     const agentId = 'agent-fork-cap-legacy';
     const metaPath = getAgentMetaPath(tempDir, sessionId, agentId);
@@ -2238,7 +2301,7 @@ describe('BackgroundAgentResumeService', () => {
     expect(resumed).toBeUndefined();
     expect(registry.get(agentId)?.status).toBe('paused');
     expect(registry.get(agentId)?.resumeBlockedReason).toContain(
-      'runtime constraints are missing',
+      'current parent system prompt or tool surface is unavailable',
     );
     expect(createSpy).not.toHaveBeenCalled();
     createSpy.mockRestore();

--- a/packages/core/src/agents/background-agent-resume.test.ts
+++ b/packages/core/src/agents/background-agent-resume.test.ts
@@ -63,6 +63,16 @@ describe('BackgroundAgentResumeService', () => {
         advertisedTools: FunctionDeclaration[];
         registeredTools?: FunctionDeclaration[];
       };
+      // Optional capability context used to exercise the non-empty branches of
+      // buildForkResumeCapabilityReminder (MCP instructions, skills, and
+      // deferred tools). Defaults keep the reminder minimal for other tests.
+      mcpServerInstructions?: Map<string, string>;
+      deferredToolSummary?: Array<{
+        name: string;
+        description: string;
+        serverName?: string;
+      }>;
+      skillManager?: unknown;
       hookSystem?:
         | {
             fireSubagentStartEvent: ReturnType<typeof vi.fn>;
@@ -101,9 +111,13 @@ describe('BackgroundAgentResumeService', () => {
       getAllToolNames: vi.fn().mockReturnValue([]),
       stop: vi.fn().mockResolvedValue(undefined),
       warmAll: vi.fn().mockResolvedValue(undefined),
-      getDeferredToolSummary: vi.fn().mockReturnValue([]),
+      getDeferredToolSummary: vi
+        .fn()
+        .mockReturnValue(options.deferredToolSummary ?? []),
       isDeferredToolRevealed: vi.fn().mockReturnValue(false),
-      getMcpServerInstructions: vi.fn().mockReturnValue(new Map()),
+      getMcpServerInstructions: vi
+        .fn()
+        .mockReturnValue(options.mcpServerInstructions ?? new Map()),
       getFunctionDeclarationsFiltered: vi.fn((names: string[]) =>
         (
           options.currentForkRuntime?.registeredTools ??
@@ -161,7 +175,9 @@ describe('BackgroundAgentResumeService', () => {
               }),
             }
           : undefined,
-      getSkillManager: () => undefined,
+      getSkillManager: () => options.skillManager,
+      getDisabledSkillNames: () => new Set<string>(),
+      getModelInvocableCommandsProvider: () => undefined,
       getSkipStartupContext: () => true,
       getTranscriptPath: () => path.join(tempDir, 'session.jsonl'),
       getToolRegistry: () => stubToolRegistry,
@@ -2434,6 +2450,84 @@ describe('BackgroundAgentResumeService', () => {
     );
     expect(registry.get(agentId)?.error).toBeUndefined();
     expect(createSpy).not.toHaveBeenCalled();
+    createSpy.mockRestore();
+  });
+
+  it('injects live MCP, skill, and deferred-tool reminders into the resumed fork prompt', async () => {
+    const sessionId = 'session-fork-cap-reminders';
+    const agentId = 'agent-fork-cap-reminders';
+    seedResumableForkTask(sessionId, agentId);
+
+    const execute = vi.fn(async (_context: unknown) => undefined);
+    const subagent = {
+      execute,
+      setExternalMessageProvider: vi.fn(),
+      getCore: () => ({ getEventEmitter: () => new AgentEventEmitter() }),
+      getExecutionSummary: () => ({
+        totalTokens: 0,
+        outputTokens: 0,
+        totalDurationMs: 0,
+      }),
+      getTerminateMode: () => AgentTerminateMode.GOAL,
+      getFinalText: () => 'done',
+    };
+    const createSpy = vi
+      .spyOn(AgentHeadless, 'create')
+      .mockResolvedValue(subagent as unknown as AgentHeadless);
+
+    const { service } = createService({
+      currentForkRuntime: {
+        systemInstruction: 'current parent system instruction',
+        // SKILL must be in the resolved tool surface so the skills branch of
+        // buildForkResumeCapabilityReminder runs.
+        advertisedTools: [{ name: ToolNames.SKILL }, { name: 'Read' }],
+        registeredTools: [{ name: ToolNames.SKILL }, { name: 'Read' }],
+      },
+      mcpServerInstructions: new Map([
+        ['docs-server', 'Use ISO-8601 dates when calling docs tools.'],
+      ]),
+      deferredToolSummary: [
+        { name: 'web_search', description: 'Search the web.' },
+      ],
+      skillManager: {
+        listSkills: vi.fn().mockResolvedValue([
+          {
+            name: 'auto-skill-demo',
+            description: 'Demo project skill',
+            level: 'project',
+            disableModelInvocation: false,
+          },
+        ]),
+        isSkillActive: vi.fn().mockReturnValue(true),
+      },
+    });
+
+    const resumed = await service.resumeBackgroundAgent(agentId, 'continue');
+
+    expect(resumed).toBeDefined();
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    expect(execute).toHaveBeenCalledTimes(1);
+    const contextArg = execute.mock.calls[0]?.[0] as
+      | { get(key: string): unknown }
+      | undefined;
+    if (!contextArg) {
+      throw new Error('Expected resume execute context');
+    }
+    const taskPrompt = String(contextArg.get('task_prompt'));
+
+    // MCP server-instructions reminder branch.
+    expect(taskPrompt).toContain('The text below was supplied by the MCP');
+    expect(taskPrompt).toContain('docs-server');
+    expect(taskPrompt).toContain('Use ISO-8601 dates when calling docs tools.');
+    // Skills reminder branch (gated on ToolNames.SKILL being present).
+    expect(taskPrompt).toContain(
+      'The following skills are available for use with the Skill tool',
+    );
+    expect(taskPrompt).toContain('auto-skill-demo');
+    // Deferred-tools reminder branch.
+    expect(taskPrompt).toContain('web_search');
+    expect(taskPrompt).toContain(ToolNames.TOOL_SEARCH);
+
     createSpy.mockRestore();
   });
 

--- a/packages/core/src/agents/background-agent-resume.test.ts
+++ b/packages/core/src/agents/background-agent-resume.test.ts
@@ -67,6 +67,7 @@ describe('BackgroundAgentResumeService', () => {
       // buildForkResumeCapabilityReminder (MCP instructions, skills, and
       // deferred tools). Defaults keep the reminder minimal for other tests.
       mcpServerInstructions?: Map<string, string>;
+      overrideMcpServerInstructions?: Map<string, string>;
       deferredToolSummary?: Array<{
         name: string;
         description: string;
@@ -129,6 +130,15 @@ describe('BackgroundAgentResumeService', () => {
         ),
       ),
     };
+    const overrideToolRegistry =
+      options.overrideMcpServerInstructions === undefined
+        ? stubToolRegistry
+        : {
+            ...stubToolRegistry,
+            getMcpServerInstructions: vi
+              .fn()
+              .mockReturnValue(options.overrideMcpServerInstructions),
+          };
     const permissionManager = {
       stripDangerousRulesForAutoMode: vi.fn(),
       restoreDangerousRules: vi.fn(),
@@ -181,7 +191,7 @@ describe('BackgroundAgentResumeService', () => {
       getSkipStartupContext: () => true,
       getTranscriptPath: () => path.join(tempDir, 'session.jsonl'),
       getToolRegistry: () => stubToolRegistry,
-      createToolRegistry: vi.fn().mockResolvedValue(stubToolRegistry),
+      createToolRegistry: vi.fn().mockResolvedValue(overrideToolRegistry),
       getPermissionManager: () => permissionManager,
     } as unknown as Config;
 
@@ -2486,6 +2496,10 @@ describe('BackgroundAgentResumeService', () => {
       mcpServerInstructions: new Map([
         ['docs-server', 'Use ISO-8601 dates when calling docs tools.'],
       ]),
+      // The resumed fork override owns a fresh registry whose MCP client
+      // manager has no connected clients. Capability reminders must still
+      // read instructions from the live parent registry above.
+      overrideMcpServerInstructions: new Map(),
       deferredToolSummary: [
         { name: 'web_search', description: 'Search the web.' },
       ],

--- a/packages/core/src/agents/background-agent-resume.ts
+++ b/packages/core/src/agents/background-agent-resume.ts
@@ -6,7 +6,7 @@
 
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import type { Content, FunctionDeclaration, Part } from '@google/genai';
+import type { Content, Part } from '@google/genai';
 import type { Config } from '../config/config.js';
 import * as jsonl from '../utils/jsonl-utils.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
@@ -126,8 +126,6 @@ interface TranscriptRecovery {
     history: Content[];
     taskPrompt: string;
     runtimeHistory: Content[];
-    systemInstruction?: string | Content;
-    tools?: Array<string | FunctionDeclaration>;
   };
 }
 
@@ -363,14 +361,6 @@ function recoverTranscript(records: ChatRecord[]): TranscriptRecovery {
             history: structuredClone(
               (bootstrapRecord.systemPayload as AgentBootstrapRecordPayload)
                 .history,
-            ),
-            systemInstruction: structuredClone(
-              (bootstrapRecord.systemPayload as AgentBootstrapRecordPayload)
-                .systemInstruction,
-            ),
-            tools: structuredClone(
-              (bootstrapRecord.systemPayload as AgentBootstrapRecordPayload)
-                .tools,
             ),
             taskPrompt: (
               launchPromptRecord!.systemPayload as NotificationRecordPayload
@@ -976,7 +966,7 @@ export class BackgroundAgentResumeService {
       }
       const forkResumeCapabilityReminder = target.isFork
         ? await this.buildForkResumeCapabilityReminder(
-            bgConfig as Config,
+            this.config,
             currentForkRuntime!.toolNames,
           )
         : undefined;

--- a/packages/core/src/agents/background-agent-resume.ts
+++ b/packages/core/src/agents/background-agent-resume.ts
@@ -61,7 +61,10 @@ import {
 } from './background-tasks.js';
 import type { SubagentConfig } from '../subagents/types.js';
 import { BUBBLE_APPROVAL_MODE } from '../subagents/types.js';
-import { EXCLUDED_TOOLS_FOR_SUBAGENTS } from './runtime/agent-core.js';
+import {
+  EXCLUDED_TOOLS_FOR_SUBAGENTS,
+  extractParentToolNames,
+} from './runtime/agent-core.js';
 import { ToolNames } from '../tools/tool-names.js';
 import type {
   AgentExternalInput,
@@ -1588,23 +1591,7 @@ export class BackgroundAgentResumeService {
         return undefined;
       }
 
-      const advertisedNames = Array.from(
-        new Set(
-          (
-            generationConfig.tools as Array<{
-              functionDeclarations?: FunctionDeclaration[];
-            }>
-          )
-            ?.flatMap((tool) => tool.functionDeclarations ?? [])
-            .map((declaration) => declaration.name)
-            .filter(
-              (name): name is string =>
-                typeof name === 'string' &&
-                name.length > 0 &&
-                !EXCLUDED_TOOLS_FOR_SUBAGENTS.has(name),
-            ) ?? [],
-        ),
-      );
+      const advertisedNames = extractParentToolNames(generationConfig);
       if (advertisedNames.length === 0) {
         return undefined;
       }

--- a/packages/core/src/agents/background-agent-resume.ts
+++ b/packages/core/src/agents/background-agent-resume.ts
@@ -29,7 +29,12 @@ import {
 } from './agent-transcript.js';
 import type { ChatRecord } from '../services/chatRecordingService.js';
 import { buildOrderedUuidChain } from '../utils/conversation-chain.js';
-import { getInitialChatHistory } from '../utils/environmentContext.js';
+import {
+  buildAvailableSkillsReminder,
+  buildDeferredToolsReminder,
+  buildMcpServerInstructionsReminder,
+  getInitialChatHistory,
+} from '../utils/environmentContext.js';
 import { getGitBranch } from '../utils/gitUtils.js';
 import { runWithInvocationContext } from '../utils/invocation-context.js';
 import { PermissionMode, type StopHookOutput } from '../hooks/types.js';
@@ -77,8 +82,11 @@ export const DEFAULT_BACKGROUND_AGENT_CONTINUATION_MESSAGE =
 
 const LEGACY_FORK_RESUME_BLOCKED_REASON =
   'Fork background task cannot be safely resumed because its bootstrap transcript is missing.';
-const LEGACY_FORK_CAPABILITIES_BLOCKED_REASON =
-  'Fork background task cannot be safely resumed because its launch-time runtime constraints are missing.';
+const CURRENT_FORK_RUNTIME_BLOCKED_REASON =
+  'Fork background task cannot be safely resumed because the current parent system prompt or tool surface is unavailable.';
+const FORK_RESUME_CAPABILITY_NOTICE = `<system-reminder>
+This fork was resumed in a new runtime. The current system instruction, tool declarations, MCP connections, and skill listing are authoritative. Earlier capability listings in the conversation history are obsolete; do not invoke a tool or skill unless it is available in the current runtime.
+</system-reminder>`;
 const MISSING_TRANSCRIPT_BLOCKED_REASON =
   'Background task transcript is missing or unreadable.';
 const TRANSCRIPT_IDENTITY_BLOCKED_REASON =
@@ -125,6 +133,11 @@ interface ResolvedResumeTarget {
   isFork: boolean;
   subagentConfig?: SubagentConfig;
   unavailableReason?: string;
+}
+
+interface CurrentForkRuntime {
+  systemInstruction: string | Content;
+  toolNames: string[];
 }
 
 interface ResumeOperation {
@@ -531,11 +544,7 @@ export class BackgroundAgentResumeService {
           target.unavailableReason ||
           (target.isFork && !recovery.forkBootstrap
             ? LEGACY_FORK_RESUME_BLOCKED_REASON
-            : target.isFork &&
-                (!recovery.forkBootstrap?.systemInstruction ||
-                  !recovery.forkBootstrap?.tools)
-              ? LEGACY_FORK_CAPABILITIES_BLOCKED_REASON
-              : undefined);
+            : undefined);
 
         const registration: AgentTaskRegistration = {
           agentId: meta.agentId,
@@ -859,6 +868,20 @@ export class BackgroundAgentResumeService {
         return undefined;
       }
 
+      const currentForkRuntime = target.isFork
+        ? await this.resolveCurrentForkRuntime()
+        : undefined;
+      if (target.isFork && !currentForkRuntime) {
+        patchAgentMeta(metaPath, {
+          lastError: undefined,
+          lastUpdatedAt: new Date().toISOString(),
+        });
+        this.restorePausedEntry(agentId, {
+          resumeBlockedReason: CURRENT_FORK_RUNTIME_BLOCKED_REASON,
+        });
+        return undefined;
+      }
+
       const parentApprovalMode = normalizeApprovalMode(
         this.config.getApprovalMode() as ApprovalModeValue,
         'default',
@@ -948,20 +971,12 @@ export class BackgroundAgentResumeService {
         cleanupPreparedRuntime();
         return undefined;
       }
-      if (
-        target.isFork &&
-        (!recovery.forkBootstrap?.systemInstruction ||
-          !recovery.forkBootstrap?.tools)
-      ) {
-        const reason = LEGACY_FORK_CAPABILITIES_BLOCKED_REASON;
-        patchAgentMeta(metaPath, {
-          lastError: undefined,
-          lastUpdatedAt: new Date().toISOString(),
-        });
-        this.restorePausedEntry(agentId, { resumeBlockedReason: reason });
-        cleanupPreparedRuntime();
-        return undefined;
-      }
+      const forkResumeCapabilityReminder = target.isFork
+        ? await this.buildForkResumeCapabilityReminder(
+            bgConfig as Config,
+            currentForkRuntime!.toolNames,
+          )
+        : undefined;
 
       const bgEventEmitter = new AgentEventEmitter();
       const launchModel = meta.model ?? meta.persistedCliFlags?.model;
@@ -971,7 +986,7 @@ export class BackgroundAgentResumeService {
           bgConfig as Config,
           bgEventEmitter,
           resumeHistory ?? [],
-          recovery.forkBootstrap!,
+          currentForkRuntime!,
         );
       } else {
         const resumeSubagentConfig =
@@ -1097,7 +1112,12 @@ export class BackgroundAgentResumeService {
 
       const hookSystem = this.config.getHookSystem();
       const contextState = new ContextState();
-      contextState.set('task_prompt', continuationPrompt);
+      contextState.set(
+        'task_prompt',
+        forkResumeCapabilityReminder
+          ? `${forkResumeCapabilityReminder}\n\n${continuationPrompt}`
+          : continuationPrompt,
+      );
       const resolvedMode = approvalModeToPermissionMode(resolvedApprovalMode);
       await this.applySubagentStartHook(contextState, {
         agentId: meta.agentId,
@@ -1558,18 +1578,108 @@ export class BackgroundAgentResumeService {
     return restored;
   }
 
+  private async resolveCurrentForkRuntime(): Promise<
+    CurrentForkRuntime | undefined
+  > {
+    try {
+      const geminiClient = this.config.getGeminiClient();
+      const generationConfig = geminiClient?.getChat().getGenerationConfig();
+      if (!generationConfig?.systemInstruction) {
+        return undefined;
+      }
+
+      const advertisedNames = Array.from(
+        new Set(
+          (
+            generationConfig.tools as Array<{
+              functionDeclarations?: FunctionDeclaration[];
+            }>
+          )
+            ?.flatMap((tool) => tool.functionDeclarations ?? [])
+            .map((declaration) => declaration.name)
+            .filter(
+              (name): name is string =>
+                typeof name === 'string' &&
+                name.length > 0 &&
+                !EXCLUDED_TOOLS_FOR_SUBAGENTS.has(name),
+            ) ?? [],
+        ),
+      );
+      if (advertisedNames.length === 0) {
+        return undefined;
+      }
+
+      const toolRegistry = this.config.getToolRegistry();
+      await toolRegistry.warmAll();
+      const registeredNames = new Set(
+        toolRegistry
+          .getFunctionDeclarationsFiltered(advertisedNames)
+          .map((declaration) => declaration.name)
+          .filter((name): name is string => Boolean(name)),
+      );
+      const toolNames = advertisedNames.filter((name) =>
+        registeredNames.has(name),
+      );
+      if (toolNames.length === 0) {
+        return undefined;
+      }
+
+      return {
+        systemInstruction: structuredClone(
+          generationConfig.systemInstruction as string | Content,
+        ),
+        toolNames,
+      };
+    } catch (error) {
+      debugLogger.warn(
+        `[BackgroundAgentResume] Failed to reconstruct current fork runtime: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return undefined;
+    }
+  }
+
+  private async buildForkResumeCapabilityReminder(
+    agentConfig: Config,
+    toolNames: string[],
+  ): Promise<string> {
+    const reminders = [FORK_RESUME_CAPABILITY_NOTICE];
+    try {
+      const toolRegistry = agentConfig.getToolRegistry();
+      await toolRegistry.warmAll();
+      const mcpInstructions = buildMcpServerInstructionsReminder(toolRegistry);
+      if (mcpInstructions) reminders.push(mcpInstructions);
+
+      if (toolNames.includes(ToolNames.SKILL)) {
+        const skills = await buildAvailableSkillsReminder(agentConfig);
+        if (skills) reminders.push(skills.reminder);
+      }
+
+      const deferredTools = buildDeferredToolsReminder(toolRegistry);
+      if (deferredTools) reminders.push(deferredTools);
+    } catch (error) {
+      debugLogger.warn(
+        `[BackgroundAgentResume] Failed to build current fork capability reminder: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+    return reminders.join('\n\n');
+  }
+
   private async createResumedForkSubagent(
     agentConfig: Config,
     eventEmitter: AgentEventEmitter,
     initialMessages: Content[],
-    bootstrap: NonNullable<TranscriptRecovery['forkBootstrap']>,
+    runtime: CurrentForkRuntime,
   ): Promise<AgentHeadless> {
     const promptConfig: PromptConfig = {
-      renderedSystemPrompt: structuredClone(bootstrap.systemInstruction!),
+      renderedSystemPrompt: structuredClone(runtime.systemInstruction),
       initialMessages,
     };
     const toolConfig: ToolConfig = {
-      tools: structuredClone(bootstrap.tools!),
+      tools: [...runtime.toolNames],
     };
 
     return AgentHeadless.create(

--- a/packages/core/src/agents/background-agent-resume.ts
+++ b/packages/core/src/agents/background-agent-resume.ts
@@ -1588,11 +1588,17 @@ export class BackgroundAgentResumeService {
       const geminiClient = this.config.getGeminiClient();
       const generationConfig = geminiClient?.getChat().getGenerationConfig();
       if (!generationConfig?.systemInstruction) {
+        debugLogger.debug(
+          '[BackgroundAgentResume] Current fork runtime unavailable (no_system_instruction): parent Gemini client or system instruction is missing.',
+        );
         return undefined;
       }
 
       const advertisedNames = extractParentToolNames(generationConfig);
       if (advertisedNames.length === 0) {
+        debugLogger.debug(
+          '[BackgroundAgentResume] Current fork runtime unavailable (no_advertised_tools): parent advertises no inheritable tools after subagent exclusions.',
+        );
         return undefined;
       }
 
@@ -1608,6 +1614,9 @@ export class BackgroundAgentResumeService {
         registeredNames.has(name),
       );
       if (toolNames.length === 0) {
+        debugLogger.debug(
+          '[BackgroundAgentResume] Current fork runtime unavailable (no_registered_tools): none of the parent advertised tools are present in the live registry.',
+        );
         return undefined;
       }
 

--- a/packages/core/src/agents/runtime/agent-core.test.ts
+++ b/packages/core/src/agents/runtime/agent-core.test.ts
@@ -8,8 +8,12 @@ import { describe, it, expect, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import type { FunctionDeclaration } from '@google/genai';
-import { AgentCore, type ReasoningLoopResult } from './agent-core.js';
+import type { FunctionDeclaration, GenerateContentConfig } from '@google/genai';
+import {
+  AgentCore,
+  extractParentToolNames,
+  type ReasoningLoopResult,
+} from './agent-core.js';
 import { attachJsonlTranscriptWriter } from '../agent-transcript.js';
 import {
   getCurrentAgentDepth,
@@ -887,5 +891,80 @@ describe('AgentCore.prepareTools', () => {
     const deniedNames = deniedTools.map((t) => t.name);
     expect(deniedNames).not.toContain(ToolNames.AGENT);
     expect(deniedNames).toContain('read_file');
+  });
+});
+
+describe('extractParentToolNames', () => {
+  const configWithTools = (
+    tools: Array<{ functionDeclarations?: FunctionDeclaration[] }>,
+  ): GenerateContentConfig => ({ tools }) as unknown as GenerateContentConfig;
+
+  it('extracts declaration names from a single group', () => {
+    const names = extractParentToolNames(
+      configWithTools([
+        {
+          functionDeclarations: [
+            { name: ToolNames.READ_FILE },
+            { name: ToolNames.WRITE_FILE },
+          ],
+        },
+      ]),
+    );
+    expect(names).toEqual([ToolNames.READ_FILE, ToolNames.WRITE_FILE]);
+  });
+
+  it('flattens and deduplicates names across multiple functionDeclarations groups', () => {
+    const names = extractParentToolNames(
+      configWithTools([
+        { functionDeclarations: [{ name: ToolNames.READ_FILE }] },
+        {
+          functionDeclarations: [
+            { name: ToolNames.READ_FILE },
+            { name: ToolNames.GREP },
+          ],
+        },
+      ]),
+    );
+    // READ_FILE appears in both groups but is returned once.
+    expect(names).toEqual([ToolNames.READ_FILE, ToolNames.GREP]);
+  });
+
+  it('drops tools a subagent must never inherit (EXCLUDED_TOOLS_FOR_SUBAGENTS)', () => {
+    const names = extractParentToolNames(
+      configWithTools([
+        {
+          functionDeclarations: [
+            { name: ToolNames.WORKFLOW },
+            { name: ToolNames.AGENT },
+            { name: ToolNames.READ_FILE },
+          ],
+        },
+      ]),
+    );
+    expect(names).toEqual([ToolNames.READ_FILE]);
+    expect(names).not.toContain(ToolNames.WORKFLOW);
+    expect(names).not.toContain(ToolNames.AGENT);
+  });
+
+  it('filters out empty and non-string declaration names', () => {
+    const names = extractParentToolNames(
+      configWithTools([
+        {
+          functionDeclarations: [
+            { name: '' },
+            { name: undefined } as FunctionDeclaration,
+            { name: ToolNames.READ_FILE },
+          ],
+        },
+      ]),
+    );
+    expect(names).toEqual([ToolNames.READ_FILE]);
+  });
+
+  it('returns an empty array for undefined config or missing tools', () => {
+    expect(extractParentToolNames(undefined)).toEqual([]);
+    expect(extractParentToolNames({} as GenerateContentConfig)).toEqual([]);
+    expect(extractParentToolNames(configWithTools([]))).toEqual([]);
+    expect(extractParentToolNames(configWithTools([{}]))).toEqual([]);
   });
 });

--- a/packages/core/src/agents/runtime/agent-core.ts
+++ b/packages/core/src/agents/runtime/agent-core.ts
@@ -168,6 +168,37 @@ export const EXCLUDED_TOOLS_FOR_SUBAGENTS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Extract the parent session's advertised tool names from its generation
+ * config: flatten every function declaration, drop tools a subagent must
+ * never inherit (EXCLUDED_TOOLS_FOR_SUBAGENTS), and deduplicate. Shared by
+ * fork launch (the Agent tool) and fork resume (background-agent-resume) so
+ * both derive the inherited tool surface identically — a single source of
+ * truth prevents the two paths from silently diverging when the exclusion or
+ * extraction logic changes.
+ */
+export function extractParentToolNames(
+  generationConfig: GenerateContentConfig | undefined,
+): string[] {
+  return Array.from(
+    new Set(
+      (
+        generationConfig?.tools as
+          | Array<{ functionDeclarations?: FunctionDeclaration[] }>
+          | undefined
+      )
+        ?.flatMap((tool) => tool.functionDeclarations ?? [])
+        .map((declaration) => declaration.name)
+        .filter(
+          (name): name is string =>
+            typeof name === 'string' &&
+            name.length > 0 &&
+            !EXCLUDED_TOOLS_FOR_SUBAGENTS.has(name),
+        ) ?? [],
+    ),
+  );
+}
+
+/**
  * Tools excluded from teammates. Teammates need send_message and the
  * task_* coordination tools to do their job, but they must not be able
  * to create or destroy the team itself — only the leader can do that.

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -411,13 +411,13 @@ export interface AgentBootstrapRecordPayload {
    */
   history: Content[];
   /**
-   * Immutable launch-time system instruction for the fork runtime. Resume must
-   * reuse this exact value rather than reading the current parent config.
+   * Legacy launch-time system instruction. Current writers omit this field and
+   * resume reconstructs the instruction from the current parent runtime.
    */
   systemInstruction?: string | Content;
   /**
-   * Immutable launch-time tool declarations / allowlist for the fork runtime.
-   * Resume must reuse this exact capability set or stay blocked.
+   * Legacy launch-time tool declarations / allowlist. Current writers omit
+   * this field and resume resolves tool names through the current registry.
    */
   tools?: Array<string | FunctionDeclaration>;
 }

--- a/packages/core/src/tools/agent/agent.test.ts
+++ b/packages/core/src/tools/agent/agent.test.ts
@@ -5958,6 +5958,8 @@ describe('AgentTool', () => {
         bootstrapHistory: [{ role: 'model', parts: [{ text: 'Ready' }] }],
         launchTaskPrompt: expect.any(String),
       });
+      const createArgs = createSpy.mock.calls[0];
+      expect(createArgs?.[5]).toEqual({ tools: ['Bash', 'Read'] });
 
       attachSpy.mockRestore();
       createSpy.mockRestore();

--- a/packages/core/src/tools/agent/agent.test.ts
+++ b/packages/core/src/tools/agent/agent.test.ts
@@ -5910,7 +5910,7 @@ describe('AgentTool', () => {
       });
     });
 
-    it('persists fork capability snapshots in the bootstrap transcript', async () => {
+    it('does not persist fork capability snapshots in the bootstrap transcript', async () => {
       (config as unknown as Record<string, unknown>)['isInteractive'] = vi
         .fn()
         .mockReturnValue(true);
@@ -5950,14 +5950,14 @@ describe('AgentTool', () => {
       ).createInvocation(forkParams);
       await invocation.execute();
 
-      expect(attachSpy).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.any(String),
-        expect.objectContaining({
-          bootstrapSystemInstruction: generationConfig.systemInstruction,
-          bootstrapTools: generationConfig.tools[0].functionDeclarations,
-        }),
-      );
+      const writerOptions = attachSpy.mock.calls[0]?.[2];
+      expect(writerOptions).toBeDefined();
+      expect(writerOptions).not.toHaveProperty('bootstrapSystemInstruction');
+      expect(writerOptions).not.toHaveProperty('bootstrapTools');
+      expect(writerOptions).toMatchObject({
+        bootstrapHistory: [{ role: 'model', parts: [{ text: 'Ready' }] }],
+        launchTaskPrompt: expect.any(String),
+      });
 
       attachSpy.mockRestore();
       createSpy.mockRestore();

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -9,7 +9,7 @@ import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
 import { BaseDeclarativeTool, BaseToolInvocation, Kind } from '../tools.js';
 import { ToolNames, ToolDisplayNames } from '../tool-names.js';
-import { EXCLUDED_TOOLS_FOR_SUBAGENTS } from '../../agents/runtime/agent-core.js';
+import { extractParentToolNames } from '../../agents/runtime/agent-core.js';
 import type {
   ToolResult,
   ToolResultDisplay,
@@ -34,7 +34,7 @@ import {
   ContextState,
 } from '../../agents/runtime/agent-headless.js';
 import type { AgentExternalInput } from '../../agents/runtime/agent-types.js';
-import type { Content, FunctionDeclaration } from '@google/genai';
+import type { Content } from '@google/genai';
 import {
   FORK_AGENT,
   FORK_DEFAULT_MAX_TURNS,
@@ -1681,23 +1681,7 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
       // current ToolRegistry. This preserves the parent's tool surface and
       // cache prefix when schemas are unchanged without letting a persisted or
       // stale declaration bypass the live registry.
-      const parentToolNames = Array.from(
-        new Set(
-          (
-            generationConfig.tools as Array<{
-              functionDeclarations?: FunctionDeclaration[];
-            }>
-          )
-            ?.flatMap((t) => t.functionDeclarations ?? [])
-            .map((declaration) => declaration.name)
-            .filter(
-              (name): name is string =>
-                typeof name === 'string' &&
-                name.length > 0 &&
-                !EXCLUDED_TOOLS_FOR_SUBAGENTS.has(name),
-            ) ?? [],
-        ),
-      );
+      const parentToolNames = extractParentToolNames(generationConfig);
 
       promptConfig = {
         renderedSystemPrompt: generationConfig.systemInstruction as

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -1578,8 +1578,6 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
     subagent: AgentHeadless;
     initialMessages?: Content[];
     taskPrompt: string;
-    promptConfig: PromptConfig;
-    toolConfig: ToolConfig;
   }> {
     const geminiClient = this.config.getGeminiClient();
     const forkTurns = normalizeForkTurns(this.params.fork_turns);
@@ -1678,25 +1676,28 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
 
     const generationConfig = geminiClient?.getChat().getGenerationConfig();
     if (generationConfig?.systemInstruction) {
-      // Inline FunctionDeclaration[] from the parent — passed verbatim
-      // (including `agent` and cron tools) so the fork's system prompt,
-      // tools, and history exactly match the parent's and share its
-      // DashScope cache prefix. A fork is a context-sharing extension of
-      // the parent, not an isolated subagent, so the general subagent
-      // exclusion list does not apply. Recursive forks are blocked by the
-      // ALS-based `isInForkExecution()` guard.
-      // However, we still exclude tools that must never be available to
-      // any subagent (agent, cron tools).
-      const parentToolDecls: FunctionDeclaration[] =
-        (
-          generationConfig.tools as Array<{
-            functionDeclarations?: FunctionDeclaration[];
-          }>
-        )
-          ?.flatMap((t) => t.functionDeclarations ?? [])
-          .filter(
-            (d) => !(d.name && EXCLUDED_TOOLS_FOR_SUBAGENTS.has(d.name)),
-          ) ?? [];
+      // Keep the parent's current allowlist, but pass names rather than inline
+      // schemas so AgentCore resolves every declaration through the fork's
+      // current ToolRegistry. This preserves the parent's tool surface and
+      // cache prefix when schemas are unchanged without letting a persisted or
+      // stale declaration bypass the live registry.
+      const parentToolNames = Array.from(
+        new Set(
+          (
+            generationConfig.tools as Array<{
+              functionDeclarations?: FunctionDeclaration[];
+            }>
+          )
+            ?.flatMap((t) => t.functionDeclarations ?? [])
+            .map((declaration) => declaration.name)
+            .filter(
+              (name): name is string =>
+                typeof name === 'string' &&
+                name.length > 0 &&
+                !EXCLUDED_TOOLS_FOR_SUBAGENTS.has(name),
+            ) ?? [],
+        ),
+      );
 
       promptConfig = {
         renderedSystemPrompt: generationConfig.systemInstruction as
@@ -1705,8 +1706,7 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
         initialMessages,
       };
       toolConfig = {
-        tools:
-          parentToolDecls.length > 0 ? parentToolDecls : (['*'] as string[]),
+        tools: parentToolNames.length > 0 ? parentToolNames : ['*'],
       };
     } else {
       promptConfig = {
@@ -1726,7 +1726,7 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
       eventEmitter,
     );
 
-    return { subagent, initialMessages, taskPrompt, promptConfig, toolConfig };
+    return { subagent, initialMessages, taskPrompt };
   }
 
   // Runs the SubagentStop hook after execution. On a blocking decision, feeds
@@ -2878,8 +2878,6 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
       let subagent: AgentHeadless;
       let taskPrompt: string;
       let initialMessages: Content[] | undefined;
-      let promptConfig: PromptConfig | undefined;
-      let toolConfig: ToolConfig | undefined;
 
       // Per-spawn cleanup the subagent manager returns. The caller MUST
       // invoke this in the same `finally` block that wraps `execute()` —
@@ -2897,8 +2895,6 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
         subagent = fork.subagent;
         taskPrompt = fork.taskPrompt;
         initialMessages = fork.initialMessages;
-        promptConfig = fork.promptConfig;
-        toolConfig = fork.toolConfig;
       } else {
         const result = await this.subagentManager.createAgentHeadless(
           subagentConfig,
@@ -2998,8 +2994,6 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
         const bgSubagent = subagent;
         const bgInitialMessages = initialMessages;
         const bgTaskPrompt = taskPrompt;
-        const bgPromptConfig = promptConfig;
-        const bgToolConfig = toolConfig;
         const bgSubagentDispose = subagentDispose;
 
         const registry = this.config.getBackgroundTaskRegistry();
@@ -3121,11 +3115,6 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
             // know what the agent was asked to do.
             initialUserPrompt: this.params.prompt,
             bootstrapHistory: isFork ? bgInitialMessages : undefined,
-            bootstrapSystemInstruction: isFork
-              ? (bgPromptConfig?.renderedSystemPrompt ??
-                bgPromptConfig?.systemPrompt)
-              : undefined,
-            bootstrapTools: isFork ? bgToolConfig?.tools : undefined,
             launchTaskPrompt: isFork ? bgTaskPrompt : undefined,
           },
         );


### PR DESCRIPTION
## What this PR does

This change keeps a fork background agent's persisted conversation history and task progress, while rebuilding its executable runtime when the agent is resumed. The resumed fork receives the current parent system instruction, and its current advertised tool names are resolved through the live registry so removed tools disappear and changed schemas are refreshed.

New fork transcripts now persist inherited history and the launch task prompt without persisting system-prompt or tool-schema snapshots. Existing transcripts with legacy capability fields remain readable, but those values are no longer treated as runtime authority. The continuation turn also refreshes current MCP, Skill, and deferred-tool context and marks older capability listings as obsolete. If the current parent prompt or tool surface cannot be reconstructed safely, the task remains paused.

## Why it's needed

A resumed fork previously replayed launch-time prompt and inline tool snapshots from JSONL while actual execution still used the current registry. After an MCP server, skill, tool schema, or system instruction changed, the model could therefore see stale capabilities that the scheduler could no longer execute. Rebinding runtime authority on resume keeps what the agent knows about the task without granting or advertising capabilities that no longer exist.

## Reviewer Test Plan

### How to verify

1. Resume a legacy fork transcript containing an old system instruction and a removed MCP tool while the parent exposes a different current instruction and registry. Confirm the full conversation history is retained, the current instruction is used, and only tools still present in the live registry are exposed.
2. Repeat with a new history-only bootstrap record and confirm the same successful resume behavior.
3. Launch a new background fork and confirm its bootstrap record contains inherited history and the launch task prompt, but no system-instruction or tool-schema snapshot.
4. Resume a fork when the current parent prompt or tool surface is unavailable and confirm it stays paused with a resume-blocked reason.

### Evidence (Before & After)

N/A — this is a non-UI runtime and persistence change covered by unit tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS 27.0, Node.js v24.18.0, npm 11.16.0, sandbox disabled. Validation: 308 focused tests passed; repository build and workspace typecheck passed.

## Risk & Scope

- Main risk or tradeoff: rebinding can invalidate an old prompt-cache prefix and can expose tools newly available to the current parent; this intentionally favors current runtime consistency over byte-identical replay.
- Not validated / out of scope: no real MCP process reload or interactive TUI flow was exercised; the persistence boundary, registry filtering, and resume behavior are covered deterministically in unit tests.
- Breaking changes / migration notes: no user-facing migration is required. Legacy transcript fields remain readable but are ignored as executable authority.

## Linked Issues

Closes #7924

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

这个改动继续保留 fork 后台 agent 持久化的对话历史和任务进度，但在恢复 agent 时重新构建它的可执行运行环境。恢复后的 fork 会获得当前父会话的系统提示词，并且当前声明的工具名会通过实时工具注册表重新解析，因此已经删除的工具会消失，发生变化的 schema 会被刷新。

新的 fork 日志只持久化继承的历史和启动任务提示，不再持久化系统提示词或工具 schema 快照。带有旧能力字段的历史日志仍然可以读取，但这些字段不再被视为运行时权威。继续执行的回合还会刷新当前 MCP、Skill 和延迟工具上下文，并明确旧的能力列表已经失效。如果无法安全地重建当前父会话的提示词或工具面，任务会继续保持暂停状态。

## 为什么需要这个改动

此前，恢复 fork 时会从 JSONL 重放启动时的提示词和内联工具快照，而真正执行工具时仍然使用当前注册表。当 MCP server、skill、工具 schema 或系统提示词发生变化后，模型可能继续看到调度器已经无法执行的旧能力。恢复时重新绑定运行时权威，可以保留 agent 对任务的理解，同时避免授予或声明已经不存在的能力。

## Reviewer 测试计划

### 如何验证

1. 使用包含旧系统提示词和已删除 MCP 工具的旧格式 fork 日志进行恢复，同时让父会话提供不同的当前提示词和注册表。确认完整对话历史被保留、使用当前提示词，并且只暴露仍存在于实时注册表中的工具。
2. 使用新的纯历史 bootstrap 记录重复验证，并确认同样能够成功恢复。
3. 启动新的后台 fork，确认 bootstrap 记录包含继承历史和启动任务提示，但不包含系统提示词或工具 schema 快照。
4. 在当前父会话提示词或工具面不可用时恢复 fork，确认任务保持暂停，并带有阻止恢复的原因。

### 证据（修改前后）

不适用——这是非 UI 的运行时与持久化改动，由单元测试覆盖。

### 测试平台

|     系统     | 状态 |
| :----------: | :--: |
|  🍏 macOS    |  ✅  |
| 🪟 Windows   |  ⚠️  |
|  🐧 Linux    |  ⚠️  |

### 环境（可选）

macOS 27.0、Node.js v24.18.0、npm 11.16.0、关闭 sandbox。验证结果：308 个聚焦测试通过；仓库 build 和 workspace typecheck 通过。

## 风险与范围

- 主要风险或权衡：重新绑定可能使旧的 prompt cache 前缀失效，也可能让 fork 获得当前父会话新增加的工具；这里有意优先保证当前运行环境的一致性，而不是逐字节重放。
- 未验证或不在范围内：没有启动真实 MCP 进程进行重载，也没有执行交互式 TUI 流程；持久化边界、注册表过滤和恢复行为由确定性的单元测试覆盖。
- 破坏性变化或迁移说明：用户无需迁移。旧日志字段仍可读取，但不会再被视为可执行权威。

## 关联 Issue

Closes #7924

</details>
