### PR TITLE
fix(daemon): distinguish draining channel worker diagnostics

### DIFF
--- a/packages/cli/src/serve/channel-worker-group.test.ts
+++ b/packages/cli/src/serve/channel-worker-group.test.ts
@@ -196,7 +196,10 @@ describe('createChannelWorkerGroup', () => {
     const error = await group
       .deliverChannelMessage(deliveryRequest, SECONDARY)
       .catch((value: unknown) => value);
-    expect(error).toMatchObject({ code: 'channel_worker_unavailable' });
+    expect(error).toMatchObject({
+      code: 'channel_worker_unavailable',
+      message: 'No channel worker for the selected workspace owns channel "b".',
+    });
     expect((error as Error).message).not.toContain(SECONDARY);
     expect(
       recorded[0]!.supervisor.deliverChannelMessage,
@@ -230,7 +233,11 @@ describe('createChannelWorkerGroup', () => {
 
     await expect(
       group.deliverChannelMessage(deliveryRequest, SECONDARY),
-    ).rejects.toMatchObject({ code: 'channel_worker_unavailable' });
+    ).rejects.toMatchObject({
+      code: 'channel_worker_unavailable',
+      message:
+        'Channel worker for channel "b" is unavailable while its workspace is draining.',
+    });
     expect(
       recorded[1]!.supervisor.deliverChannelMessage,
     ).not.toHaveBeenCalled();
@@ -289,6 +296,8 @@ describe('createChannelWorkerGroup', () => {
     group.beginWorkspaceDrain(SECONDARY);
     await expect(group.enqueueWebhookTask(webhookTask)).rejects.toMatchObject({
       code: 'channel_worker_unavailable',
+      message:
+        'Channel worker for channel "b" is unavailable while its workspace is draining.',
     });
     await expect(group.reconcile(groups, { force: true })).rejects.toThrow(
       'cannot change while a workspace is draining',
@@ -319,6 +328,7 @@ describe('createChannelWorkerGroup', () => {
     ]);
     await expect(group.enqueueWebhookTask(webhookTask)).rejects.toMatchObject({
       code: 'channel_worker_unavailable',
+      message: 'No channel worker owns channel "b".',
     });
 
     await group.stop();

--- a/packages/cli/src/serve/channel-worker-group.ts
+++ b/packages/cli/src/serve/channel-worker-group.ts
@@ -742,7 +742,13 @@ export function createChannelWorkerGroup(
     async deliverChannelMessage(request, workspaceCwd) {
       const entry = routeEntry(request.channelName, workspaceCwd);
       const deliver = entry?.supervisor.deliverChannelMessage;
-      if (!entry || drainingWorkspaces.has(entry.workspaceCwd) || !deliver) {
+      if (entry && drainingWorkspaces.has(entry.workspaceCwd)) {
+        throw new ChannelDeliveryError(
+          'channel_worker_unavailable',
+          `Channel worker for channel "${request.channelName}" is unavailable while its workspace is draining.`,
+        );
+      }
+      if (!entry || !deliver) {
         const hint = workspaceCwd
           ? `No channel worker for the selected workspace owns channel "${request.channelName}".`
           : `No channel worker owns channel "${request.channelName}".`;
@@ -752,7 +758,13 @@ export function createChannelWorkerGroup(
     },
     async enqueueWebhookTask(task) {
       const entry = routeEntry(task.channelName);
-      if (!entry || drainingWorkspaces.has(entry.workspaceCwd)) {
+      if (entry && drainingWorkspaces.has(entry.workspaceCwd)) {
+        throw new ChannelWebhookEnqueueError(
+          'channel_worker_unavailable',
+          `Channel worker for channel "${task.channelName}" is unavailable while its workspace is draining.`,
+        );
+      }
+      if (!entry) {
         throw new ChannelWebhookEnqueueError(
           'channel_worker_unavailable',
           `No channel worker owns channel "${task.channelName}".`,


### PR DESCRIPTION
## What this PR does

This change gives channel delivery and webhook enqueue a distinct diagnostic when their owning workspace is draining. A genuinely missing worker keeps the existing `No channel worker...` diagnostic, while both conditions continue to use the stable `channel_worker_unavailable` error code.

## Why it's needed

The routing layer previously collapsed a draining workspace and a missing channel worker into the same message. During workspace reload or removal, operators were told that no worker owned the channel even though the worker existed and was intentionally rejecting new work while draining. Distinguishing the messages makes the failure actionable without changing the delivery protocol.

## Reviewer Test Plan

### How to verify

- Route delivery to a worker owned by a selected workspace, begin draining that workspace, and confirm delivery is rejected with a workspace-draining diagnostic.
- Enqueue a webhook task while its owning workspace is draining and confirm it receives the same draining-specific diagnostic.
- Remove the owning worker completely and confirm both missing-worker paths keep their existing diagnostics.
- Confirm all failure paths retain `channel_worker_unavailable`, do not invoke the supervisor, and do not expose the workspace path.

### Evidence (Before & After)

Before: missing workers and draining workspaces both reported `No channel worker...`.

After: missing workers keep `No channel worker...`, while draining workspaces report `Channel worker for channel "..." is unavailable while its workspace is draining.`

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js v26.5.0. The focused channel worker group suite passed 39/39 tests. The full workspace build and typecheck passed, along with focused Prettier and ESLint checks.

## Risk & Scope

- Main risk or tradeoff: Consumers that match the exact draining error text will see the new, more accurate message; the stable error code and HTTP status are unchanged.
- Not validated / out of scope: Platform-specific integration tests, delivery persistence, retries, replay, and the other follow-ups tracked by #7504.
- Breaking changes / migration notes: None.

## Linked Issues

Refs #7504

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当 Channel 投递或 webhook 入队对应的 workspace 正在 draining 时，本修改会返回独立、准确的诊断信息。真正缺少 worker 的情况继续使用原有的 `No channel worker...` 提示，两种情况仍统一保留稳定的 `channel_worker_unavailable` 错误码。

## 为什么需要

此前路由层把 workspace 正在 draining 和 Channel worker 不存在合并成同一条错误信息。在 workspace 重载或移除期间，worker 明明存在并且只是按设计拒绝新任务，运维人员却会看到“没有 worker 管理该 Channel”的错误提示。拆分两种提示后，错误更便于排查，同时不会改变投递协议。

## Reviewer 测试计划

### 如何验证

- 将投递路由到选定 workspace 所属的 worker，开始 draining 该 workspace，确认投递被拒绝并返回 workspace-draining 专属诊断。
- 在 Channel 所属 workspace 正在 draining 时入队 webhook 任务，确认返回相同的 draining 专属诊断。
- 完全移除所属 worker，确认缺失 worker 的两条路径仍保留原有诊断。
- 确认所有失败路径继续返回 `channel_worker_unavailable`，不会调用 supervisor，也不会暴露 workspace 路径。

### 修改前后证据

修改前：worker 缺失和 workspace draining 都返回 `No channel worker...`。

修改后：worker 缺失继续返回 `No channel worker...`，workspace draining 则返回 `Channel worker for channel "..." is unavailable while its workspace is draining.`

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|     🍏 macOS     | ✅ 已测试 |
|    🪟 Windows    | ⚠️ 未测试 |
|     🐧 Linux     | ⚠️ 未测试 |

### 环境（可选）

Node.js v26.5.0。Channel worker group 聚焦测试 39/39 通过；完整 workspace build 和 typecheck 通过，相关文件的 Prettier 与 ESLint 检查也通过。

## 风险与范围

- 主要风险或取舍：依赖 draining 错误文本精确匹配的调用方会看到新的、更准确的信息；稳定错误码和 HTTP 状态不变。
- 未验证 / 不在范围内：平台相关集成测试、投递持久化、重试、重放，以及 #7504 跟踪的其他后续项。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Refs #7504

</details>
