### PR TITLE
fix(scripts): slim release-note model prompts and log request timing

### DIFF
--- a/scripts/generate-release-notes.js
+++ b/scripts/generate-release-notes.js
@@ -34,11 +34,7 @@ export function buildPullRequestQuery(numbers) {
         pr${index}: pullRequest(number: ${number}) {
           number
           body
-          additions
-          deletions
-          changedFiles
           labels(first: 20) { nodes { name } }
-          files(first: 40) { nodes { path } }
         }`,
     )
     .join('\n');
@@ -262,14 +258,7 @@ function compactEntry(entry) {
   return {
     number: entry.number,
     title: entry.title,
-    body: (entry.body || '').slice(0, 3000),
-    labels: (entry.labels || []).map((label) =>
-      typeof label === 'string' ? label : label.name,
-    ),
-    files: (entry.files || []).slice(0, 40),
-    additions: entry.additions,
-    deletions: entry.deletions,
-    changedFiles: entry.changedFiles,
+    body: (entry.body || '').slice(0, 700),
     category: classifyChange(entry),
   };
 }
@@ -375,15 +364,10 @@ export function enrichEntries(entries, metadata) {
   const byNumber = new Map(metadata.map((item) => [item.number, item]));
   return entries.map((entry) => {
     const details = byNumber.get(entry.number) || {};
-    const files = details.files?.nodes || details.files || [];
     return {
       ...entry,
       body: details.body || '',
       labels: details.labels?.nodes || details.labels || [],
-      files: files.map((file) => (typeof file === 'string' ? file : file.path)),
-      additions: details.additions || 0,
-      deletions: details.deletions || 0,
-      changedFiles: details.changedFiles || files.length,
     };
   });
 }
@@ -468,6 +452,7 @@ export function createOpenAiCompleter({
       if (remainingMs <= 0) {
         throw deadlineError();
       }
+      const attemptStartedAt = Date.now();
       try {
         const response = await fetchImpl(endpoint, {
           method: 'POST',
@@ -495,10 +480,16 @@ export function createOpenAiCompleter({
         if (typeof content !== 'string' || !content.trim()) {
           throw new Error(CONTENT_VALIDATION_ERROR_MESSAGE);
         }
+        console.error(
+          `Model ${request.kind} request succeeded in ${Date.now() - attemptStartedAt}ms (prompt ${prompt.user.length} chars).`,
+        );
         return content;
       } catch (error) {
         lastError = error;
         attempt += 1;
+        console.error(
+          `Model ${request.kind} request failed after ${Date.now() - attemptStartedAt}ms (prompt ${prompt.user.length} chars): ${escapeWorkflowCommand(error.message)}`,
+        );
         if (Date.now() >= deadline) {
           throw deadlineError();
         }

--- a/scripts/tests/generate-release-notes.test.js
+++ b/scripts/tests/generate-release-notes.test.js
@@ -39,10 +39,6 @@ const entry = (number, title, labels = []) => ({
   author: 'alice',
   labels,
   body: '',
-  files: [],
-  additions: 1,
-  deletions: 0,
-  changedFiles: 1,
 });
 
 describe('parseGeneratedEntries', () => {
@@ -240,6 +236,34 @@ describe('generateAiContent', () => {
     ]);
   });
 
+  it('sends only title, a bounded body excerpt, and category to the model', async () => {
+    const long = { ...entry(1, 'feat: long body'), body: 'x'.repeat(5000) };
+    const calls = [];
+    const complete = async (request) => {
+      calls.push(request);
+      if (request.kind === 'summaries') {
+        return JSON.stringify({
+          summaries: request.entries.map((item) => ({
+            pr: item.number,
+            summary: 'Summary.',
+          })),
+        });
+      }
+      return JSON.stringify({ highlights: [] });
+    };
+
+    await generateAiContent([long], complete);
+
+    const [payload] = calls[0].entries;
+    expect(Object.keys(payload).sort()).toEqual([
+      'body',
+      'category',
+      'number',
+      'title',
+    ]);
+    expect(payload.body).toHaveLength(700);
+  });
+
   it('falls back to original titles for an invalid summary batch', async () => {
     const entries = [entry(1, 'feat: original'), entry(2, 'fix: original')];
     const complete = async (request) => {
@@ -359,17 +383,13 @@ describe('enrichEntries', () => {
         number: 1,
         body: 'Why it matters.',
         labels: [{ name: 'type/bug' }],
-        files: [{ path: 'packages/core/a.ts' }],
-        additions: 3,
-        deletions: 2,
-        changedFiles: 1,
       },
     ]);
 
     expect(enriched.map((item) => item.number)).toEqual([2, 1]);
     expect(enriched[0].body).toBe('');
     expect(enriched[1].body).toBe('Why it matters.');
-    expect(enriched[1].files).toEqual(['packages/core/a.ts']);
+    expect(enriched[1].labels).toEqual([{ name: 'type/bug' }]);
   });
 });
 
@@ -379,7 +399,8 @@ describe('buildPullRequestQuery', () => {
 
     expect(query).toContain('pr0: pullRequest(number: 12)');
     expect(query).toContain('pr1: pullRequest(number: 8)');
-    expect(query).toContain('files(first: 40)');
+    expect(query).toContain('labels(first: 20)');
+    expect(query).not.toContain('files(first: 40)');
     expect(query).not.toContain('pullRequest(number: undefined)');
   });
 });
@@ -480,7 +501,7 @@ describe('generateReleaseNotes', () => {
           '  process.exit(0);',
           '}',
           "if (args[0] === 'api' && args[1] === 'graphql') {",
-          "  process.stdout.write(JSON.stringify({ data: { repository: { pr0: { number: 1, body: 'Body.', additions: 1, deletions: 0, changedFiles: 1, labels: { nodes: [] }, files: { nodes: [] } } } } }));",
+          "  process.stdout.write(JSON.stringify({ data: { repository: { pr0: { number: 1, body: 'Body.', labels: { nodes: [] } } } } }));",
           '  process.exit(0);',
           '}',
           'process.exit(1);',


### PR DESCRIPTION
## What this PR does

Shrinks the payload the AI release-notes generator sends per pull request to the title, a 700-character body excerpt, and the locally computed category. File paths, line counts, and label lists are no longer serialized into the model prompt, and the metadata query stops fetching the fields that no longer have a consumer. Every model request now also logs its elapsed time and prompt size on both success and failure.

## Why it's needed

The AI-assisted step for recent stable releases timed out on nearly every request (#7523). Each summary batch packed 12 PRs with up to 3,000 characters of description plus up to 40 file paths and size counts into a single non-streaming request, and the run logs offered no way to tell whether a request was slowly generating or silently hung. A manual experiment over the full v0.20.1..v0.21.0 range (135 PRs) produced complete, well-categorized notes and highlights from titles and bodies alone — the classification the extra metadata supported is already derived locally from labels and conventional-commit prefixes before the prompt is built. Slimming the payload cuts each batch request to roughly a quarter of its former size, and the new per-request timing lines give the next timeout investigation the elapsed/size evidence it currently lacks.

## Reviewer Test Plan

### How to verify

Run the script suite: `npx vitest run scripts/tests/generate-release-notes.test.js --config scripts/tests/vitest.config.ts` (52 tests). The new regression test pins the model payload to exactly number, title, a 700-character body excerpt, and category. With model credentials you can also run the generator with `--dry-run` for any tag pair and confirm the stderr now carries one `Model summaries request succeeded/failed in Nms (prompt N chars).` line per request.

### Evidence (Before & After)

N/A (CI-only script; output format is unchanged, only the model input and stderr diagnostics change).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Unit tests only (vitest via the scripts project config).

## Risk & Scope

- Main risk or tradeoff: summaries lose the file-path and change-size signal; the v0.20.1..v0.21.0 experiment showed titles and bodies carry the user-facing content, and shorter prompts reduce the chance of hitting the 60s request timeout.
- Not validated / out of scope: whether slimmer prompts fully eliminate the CI model timeouts — the next stable release will confirm, and the per-request timing logs added here make any residual failure diagnosable; timeout and batch-size values are unchanged.
- Breaking changes / migration notes: none.

## Linked Issues

Closes #7523.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

将 AI release notes 生成器发送给模型的每个 PR 载荷缩减为标题、700 字符的描述摘录和本地计算的分类。文件路径、增删行数和标签列表不再序列化进模型 prompt，元数据查询也不再抓取这些已无消费者的字段。每次模型请求现在会在成功和失败时都记录耗时与 prompt 大小。

## 为什么需要

最近几个 stable release 的 AI 步骤几乎每个请求都超时（#7523）。每个摘要批次把 12 个 PR、每个最多 3000 字符描述外加最多 40 个文件路径和行数统计塞进一个非流式请求，且日志无法区分请求是在缓慢生成还是静默挂起。用 v0.20.1..v0.21.0 全量 135 个 PR 做的人工实验表明，仅凭标题和描述就能产出完整、分类准确的 notes 和 highlights——这些额外元数据支撑的分类本来就在构建 prompt 之前由标签和 conventional commit 前缀在本地推出。瘦身后每个批次请求约为原来的四分之一，新增的耗时日志为后续超时排查提供了目前缺失的耗时/大小证据。

## 评审验证

运行 `npx vitest run scripts/tests/generate-release-notes.test.js --config scripts/tests/vitest.config.ts`（52 个测试）。新增回归测试钉住模型载荷仅含 number、title、700 字符 body 摘录和 category。有模型凭据时也可对任意 tag 区间 `--dry-run`，确认 stderr 每个请求输出一行耗时日志。

## 风险与范围

- 主要权衡：摘要失去文件路径和改动规模信号；实验表明标题和描述已承载用户可见内容，且更短的 prompt 降低触发 60 秒请求超时的概率。
- 未验证/超出范围：更小的 prompt 是否能完全消除 CI 模型超时——将由下一次 stable release 确认，本 PR 新增的逐请求耗时日志可让任何残留失败可诊断；超时与批次大小参数未改动。
- 破坏性变更：无。

</details>
