### PR TITLE
fix(ci): give each job its own proxy wrapper directory

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -500,7 +500,9 @@ jobs:
           REPO="${GITHUB_REPOSITORY}"
           REVIEW_URL="${GITHUB_SERVER_URL}/${REPO}/pull/${PR_NUMBER}"
           LOG_PATH="${RUNNER_TEMP:-/tmp}/qwen-review-pr-${PR_NUMBER}.jsonl"
-          trap 'rm -f "$LOG_PATH"' EXIT
+          # Set by configure_qwen_network once the wrapper dir exists.
+          PROXY_BIN=""
+          trap 'rm -f "$LOG_PATH"; [ -z "$PROXY_BIN" ] || rm -rf "$PROXY_BIN"' EXIT
 
           if [ -z "${GH_TOKEN:-}" ]; then
             fail "CI_BOT_PAT secret is required for Qwen PR review."
@@ -535,8 +537,16 @@ jobs:
             export QWEN_CI_https_proxy="${https_proxy:-}"
             export QWEN_CI_HTTP_PROXY="${HTTP_PROXY:-}"
             export QWEN_CI_http_proxy="${http_proxy:-}"
-            proxy_bin="${RUNNER_TEMP:-/tmp}/qwen-network-bin"
-            mkdir -p "$proxy_bin"
+            # A fixed path is a landmine on the shared self-hosted runner:
+            # RUNNER_TEMP survives across jobs, and the triage workflow's
+            # containerised jobs write this same path as root through the
+            # RUNNER_TEMP bind mount. This job runs as the unprivileged runner
+            # user, so once that happens it can neither overwrite the wrapper
+            # nor remove the root-owned directory holding it, and every review
+            # landing on that runner dies here with EACCES. Use a private
+            # directory per run, cleaned up by the EXIT trap.
+            proxy_bin="$(mktemp -d "${RUNNER_TEMP:-/tmp}/qwen-network-bin.XXXXXX")"
+            PROXY_BIN="$proxy_bin"
 
             if command -v gh >/dev/null 2>&1; then
               local real_gh

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -1162,8 +1162,13 @@ jobs:
             export QWEN_CI_https_proxy="${https_proxy:-}"
             export QWEN_CI_HTTP_PROXY="${HTTP_PROXY:-}"
             export QWEN_CI_http_proxy="${http_proxy:-}"
-            proxy_bin="${RUNNER_TEMP:-/tmp}/qwen-network-bin"
-            mkdir -p "$proxy_bin"
+            # This job runs in a container, and RUNNER_TEMP is bind-mounted
+            # from the self-hosted runner's host filesystem. Writing the
+            # wrappers there leaves root-owned files on the host that later
+            # non-container jobs (the PR review) can neither overwrite nor
+            # delete, breaking every review scheduled on that runner. Keep
+            # them on the container's own disk, under a per-run directory.
+            proxy_bin="$(mktemp -d /tmp/qwen-network-bin.XXXXXX)"
 
             if command -v gh >/dev/null 2>&1; then
               local real_gh
@@ -2415,8 +2420,13 @@ jobs:
             export QWEN_CI_https_proxy="${https_proxy:-}"
             export QWEN_CI_HTTP_PROXY="${HTTP_PROXY:-}"
             export QWEN_CI_http_proxy="${http_proxy:-}"
-            proxy_bin="${RUNNER_TEMP:-/tmp}/qwen-network-bin"
-            mkdir -p "$proxy_bin"
+            # This job runs in a container, and RUNNER_TEMP is bind-mounted
+            # from the self-hosted runner's host filesystem. Writing the
+            # wrappers there leaves root-owned files on the host that later
+            # non-container jobs (the PR review) can neither overwrite nor
+            # delete, breaking every review scheduled on that runner. Keep
+            # them on the container's own disk, under a per-run directory.
+            proxy_bin="$(mktemp -d /tmp/qwen-network-bin.XXXXXX)"
 
             if command -v gh >/dev/null 2>&1; then
               local real_gh


### PR DESCRIPTION
## What this PR does

The PR review job and the two containerised triage jobs each build a pair of proxy wrappers for `gh` and `git` before handing control to the agent, and all three built them in the same fixed directory under `RUNNER_TEMP`. This change gives every run its own private wrapper directory, removed again when the step exits. The container jobs additionally keep their wrappers on the container's own disk instead of the bind-mounted runner temp directory.

## Why it's needed

On the shared self-hosted runners `RUNNER_TEMP` outlives an individual job, and the triage jobs that run inside a container write into it as root through the bind mount. Once one of those jobs had run on a given runner, the fixed wrapper path on that host was owned by root. The review job runs directly on the host as the unprivileged runner user, so from then on it could neither overwrite the wrapper file nor delete the root-owned directory holding it — the runner's own temp cleanup cannot remove it either. Every review scheduled onto that runner then failed with `Permission denied` while writing the wrapper, roughly twenty seconds in and before the review had started, and the fallback comment told the author to retry — which failed the same way whenever the retry landed on the same runner.

Runner `ecs-qwen-runner-sg-12` was in that state today; reviews on the other runners were unaffected, which is why this looked intermittent rather than broken.

Note that this stops new runners from being poisoned, but the leftover root-owned directory on an already-affected runner still has to be removed by hand on the host, since nothing running in CI has the privileges to delete it.

## Reviewer Test Plan

### How to verify

The failure is reproducible locally without CI. Create a directory owned by an unprivileged user, then, as root, create the shared wrapper directory and file inside it the way a container job does. Acting as the unprivileged user, writing the wrapper to that fixed path fails with exactly the error seen in CI, and an attempt to clean it up fails too:

```
bash: line 1: .../_temp/qwen-network-bin/gh: Permission denied
rm: cannot remove '.../_temp/qwen-network-bin/gh': Permission denied
```

With the change, the same unprivileged user creates its own directory next to the poisoned one and writes, marks executable and runs the wrapper successfully, then removes it — the stale root-owned directory no longer matters.

Worth confirming on review: the cleanup runs on both the success and failure paths and does not alter the step's exit status, including when the step fails before the wrapper directory is ever created. I checked all three cases (success with a directory, failure before one exists, and failure after) and the exit codes are preserved with no directory left behind. The extracted step scripts also still pass `bash -n` and `shellcheck`, and both workflow files still parse as YAML.

An end-to-end confirmation is simply that reviews scheduled onto the affected runner start completing again.

### Evidence (Before & After)

N/A — CI-only change with no user-visible surface.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

## Risk & Scope

- Main risk or tradeoff: the wrapper directory is now created per run rather than reused, so a step that is killed hard enough to skip its exit handler leaves a small empty directory behind. It is uniquely named and owned by the job's own user, so it cannot block a later run the way the shared path did.
- Not validated / out of scope: removing the existing root-owned leftovers from the affected runner, which needs host access; and the fallback comment's wording, which currently suggests a retry even for infrastructure failures that a retry cannot fix.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

PR review job 和两个跑在容器里的 triage job，在把控制权交给 agent 之前都会各自生成一对 `gh` 和 `git` 的代理 wrapper，而三者都把它们生成在 `RUNNER_TEMP` 下同一个固定目录里。这个改动让每次运行使用自己私有的 wrapper 目录，并在步骤结束时删除。容器里的 job 额外改为把 wrapper 放在容器自身的磁盘上，而不是 bind mount 进来的 runner 临时目录。

## 为什么需要

在共享的自托管 runner 上，`RUNNER_TEMP` 的生命周期长于单个 job，而跑在容器里的 triage job 会通过 bind mount 以 root 身份往里写。只要某台 runner 上跑过一次这样的 job，该宿主上那个固定的 wrapper 路径就归 root 所有。review job 直接以非特权的 runner 用户在宿主上运行，从那以后它既无法覆盖 wrapper 文件，也无法删除持有该文件的 root 属主目录 —— runner 自带的临时目录清理同样删不掉。此后调度到这台 runner 上的每一次 review 都会在写 wrapper 时以 `Permission denied` 失败，大约二十秒就挂掉，此时 review 根本还没开始；而 fallback 评论会让作者重试 —— 只要重试再次落到同一台 runner，就会以同样的方式失败。

今天 runner `ecs-qwen-runner-sg-12` 就处于这个状态；其他 runner 上的 review 不受影响，所以这个问题看起来是偶发的，而不是彻底坏掉。

需要说明的是，这个改动能防止新的 runner 被污染，但已经受影响的 runner 上残留的 root 属主目录仍然需要在宿主上手工删除，因为 CI 里运行的任何东西都没有权限删掉它。

## Reviewer Test Plan

### 如何验证

这个失败不依赖 CI，本地即可复现。先建一个属于非特权用户的目录，然后以 root 身份、按照容器 job 的方式在其中创建那个共享的 wrapper 目录和文件。再以非特权用户的身份往这个固定路径写 wrapper，就会得到与 CI 中完全一致的报错，而且尝试清理同样会失败：

```
bash: line 1: .../_temp/qwen-network-bin/gh: Permission denied
rm: cannot remove '.../_temp/qwen-network-bin/gh': Permission denied
```

应用改动之后，同一个非特权用户会在被污染的目录旁边创建属于自己的目录，成功写入 wrapper、赋予可执行权限并运行，随后将其删除 —— 残留的 root 属主目录不再有影响。

评审时值得确认的点：清理在成功和失败两条路径上都会执行，并且不会改变步骤的退出码，包括步骤在 wrapper 目录创建之前就失败的情况。我验证了全部三种情形（成功且已创建目录、目录创建前失败、目录创建后失败），退出码均被保留，且没有目录残留。抽取出来的步骤脚本仍然通过 `bash -n` 和 `shellcheck`，两个 workflow 文件也仍然能正常解析为 YAML。

端到端的确认方式很简单：调度到受影响 runner 上的 review 重新开始正常完成。

### Evidence (Before & After)

N/A —— 仅涉及 CI，没有用户可见的界面。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

## 风险与范围

- 主要风险或权衡：wrapper 目录现在是每次运行新建而不是复用，因此如果某个步骤被强制杀死、来不及执行退出处理，会留下一个很小的空目录。它的名字是唯一的、属主是该 job 自己的用户，因此不会像原来那个共享路径一样阻塞后续运行。
- 未验证 / 不在范围内：清除受影响 runner 上已有的 root 属主残留，这需要宿主访问权限；以及 fallback 评论的措辞 —— 它目前即使对重试也无法解决的基础设施故障，仍然建议重试。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
