### PR TITLE
fix(release): pin channel-base dep to exact version during release bump

### DIFF
--- a/scripts/version.js
+++ b/scripts/version.js
@@ -5,8 +5,14 @@
  */
 
 import { execSync } from 'node:child_process';
-import { readFileSync, writeFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { join, resolve } from 'node:path';
 
 // A script to handle versioning and ensure all related changes are in a single, atomic commit.
 
@@ -104,12 +110,42 @@ if (cliPackageJson.config?.sandboxImageUri) {
   writeJson(cliPackageJsonPath, cliPackageJson);
 }
 
-// 7. Run `npm install` to update package-lock.json.
+// 7. Pin channel adapters' semver dependency on @qwen-code/channel-base to
+// the exact new version. A caret range like ^0.21.0 does not match a
+// prerelease bump (e.g. 0.21.1-preview.0), so npm would replace the workspace
+// link with the stale registry package and the release build would compile
+// against outdated types.
+const channelsDir = resolve(process.cwd(), 'packages/channels');
+for (const entry of readdirSync(channelsDir)) {
+  const pkgPath = join(channelsDir, entry, 'package.json');
+  if (!existsSync(pkgPath)) continue;
+  const pkg = readJson(pkgPath);
+  const dep = pkg.dependencies?.['@qwen-code/channel-base'];
+  if (dep && !dep.startsWith('file:')) {
+    pkg.dependencies['@qwen-code/channel-base'] = newVersion;
+    writeJson(pkgPath, pkg);
+    console.log(
+      `Pinned @qwen-code/channel-base to ${newVersion} in ${pkg.name}`,
+    );
+  }
+}
+
+// 8. Refresh node_modules and package-lock.json against the pinned exact
+// versions so the adapters resolve channel-base to the workspace link again.
 // --ignore-scripts prevents the root `prepare` lifecycle from triggering a
 // redundant full build that fails with TS5055 when dist/ already exists from
 // the initial `npm ci` install.
-run(
-  'npm install --workspace packages/cli --workspace packages/core --workspace packages/channels/base --workspace packages/channels/plugin-example --package-lock-only --ignore-scripts',
-);
+run('npm install --ignore-scripts');
+
+// 9. The per-workspace `npm version` reifies above nested a stale registry
+// copy of channel-base under each adapter while ranges briefly mismatched.
+// The install above cleans both lockfiles but can leave that directory on
+// disk, where it shadows the workspace link during tsc. Remove it.
+for (const entry of readdirSync(channelsDir)) {
+  rmSync(join(channelsDir, entry, 'node_modules', '@qwen-code'), {
+    recursive: true,
+    force: true,
+  });
+}
 
 console.log(`Successfully bumped versions to v${newVersion}.`);


### PR DESCRIPTION
## What this PR does

Makes the release version-bump script pin the channel adapter packages' dependency on the shared channel base package to the exact version being released, refresh the install afterwards, and remove the stale nested copies npm leaves behind under each adapter during the bump.

## Why it's needed

The v0.21.1-preview.0 release failed in the publish job (run [30370180438](https://github.com/QwenLM/qwen-code/actions/runs/30370180438), issue #7945). The adapters declare their base dependency with a caret range (`^0.21.0`), and per semver a caret range never matches a prerelease bump like `0.21.1-preview.0`. During the release bump, npm therefore stopped linking the workspace copy and materialized the published `0.21.0` registry package instead, so the adapters compiled against outdated types that predate the polling base class — producing `TS2305: Module '"@qwen-code/channel-base"' has no exported member 'PollingChannelBase'` and dozens of follow-on errors. Pinning to the exact release version keeps the workspace link during the build, and the published tarballs depend on the matching base version that the workflow publishes first.

## Reviewer Test Plan

### How to verify

Reproduce the CI failure locally on main: run `node scripts/version.js 0.21.99-preview.0`, then build `packages/channels/base` followed by `packages/channels/github` — the github build fails with the same `TS2305` error as the failed run. With this PR, the same sequence keeps `node_modules/@qwen-code/channel-base` as a symlink to the workspace, leaves no nested registry copy under any adapter, and the github adapter builds cleanly. Also confirm `package-lock.json` after the bump only contains the workspace link entry for the base package.

### Evidence (Before & After)

Before (identical to CI): `src/GithubAdapter.ts(10,10): error TS2305: Module '"@qwen-code/channel-base"' has no exported member 'PollingChannelBase'.`

After: bump prints `Pinned @qwen-code/channel-base to 0.21.99-preview.0 in @qwen-code/channel-<name>` for all seven adapters; no nested copies remain; `npm run build --workspace=packages/channels/github` exits 0.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

Fixes #7945