### PR TITLE
fix(release): rewrite inter-workspace dep ranges during version bump

### DIFF
--- a/scripts/bump-workspace-versions.js
+++ b/scripts/bump-workspace-versions.js
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { getWorkspacePackageJsonPaths } from './workspaces.js';
+
+const DEP_SECTIONS = [
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+  'optionalDependencies',
+];
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, 'utf-8'));
+}
+
+function writeJson(filePath, data) {
+  writeFileSync(filePath, JSON.stringify(data, null, 2) + '\n');
+}
+
+/**
+ * Bump every workspace package to `newVersion` (except `exclude`d names) and
+ * rewrite inter-workspace ^/~ dependency ranges to `^newVersion`.
+ *
+ * Editing package.json directly (instead of `npm version --workspace`) keeps
+ * npm from reifying intermediate states where the bumped version no longer
+ * satisfies sibling ranges like ^0.21.0 — npm "fixes" those by installing
+ * the stale registry build into packages/*\/node_modules, which shadows the
+ * workspace symlinks, breaks the release build, and leaks into
+ * package-lock.json.
+ *
+ * @returns the names of the packages whose package.json was updated
+ */
+export function bumpWorkspaceVersions(root, newVersion, { exclude = [] } = {}) {
+  const { workspaces: workspacePatterns } = readJson(
+    path.join(root, 'package.json'),
+  );
+  const workspaces = getWorkspacePackageJsonPaths(root, workspacePatterns).map(
+    (relativePath) => {
+      const pkgPath = path.join(root, relativePath);
+      return { pkgPath, pkg: readJson(pkgPath) };
+    },
+  );
+  const versionedNames = new Set(
+    workspaces
+      .filter(({ pkg }) => !exclude.includes(pkg.name))
+      .map(({ pkg }) => pkg.name),
+  );
+
+  const updated = [];
+  for (const { pkgPath, pkg } of workspaces) {
+    let changed = false;
+    if (versionedNames.has(pkg.name)) {
+      pkg.version = newVersion;
+      changed = true;
+    }
+    for (const section of DEP_SECTIONS) {
+      for (const [dep, range] of Object.entries(pkg[section] ?? {})) {
+        if (
+          versionedNames.has(dep) &&
+          (range.startsWith('^') || range.startsWith('~'))
+        ) {
+          pkg[section][dep] = `^${newVersion}`;
+          changed = true;
+        }
+      }
+    }
+    if (changed) {
+      writeJson(pkgPath, pkg);
+      updated.push(pkg.name);
+    }
+  }
+  return updated;
+}

--- a/scripts/tests/bump-workspace-versions.test.js
+++ b/scripts/tests/bump-workspace-versions.test.js
@@ -1,0 +1,136 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { bumpWorkspaceVersions } from '../bump-workspace-versions.js';
+
+describe('bumpWorkspaceVersions', () => {
+  const tempDirs = [];
+
+  afterEach(() => {
+    for (const tempDir of tempDirs.splice(0)) {
+      rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  function setup() {
+    const root = mkdtempSync(path.join(tmpdir(), 'qwen-version-bump-'));
+    tempDirs.push(root);
+    writeFile(root, 'package.json', {
+      name: 'root',
+      version: '0.21.0',
+      workspaces: ['packages/*', '!packages/desktop'],
+    });
+    writeFile(root, 'packages/base/package.json', {
+      name: '@scope/base',
+      version: '0.21.0',
+    });
+    writeFile(root, 'packages/adapter/package.json', {
+      name: '@scope/adapter',
+      version: '0.21.0',
+      dependencies: {
+        '@scope/base': '^0.21.0',
+        'ext-pkg': '^2.0.0',
+      },
+      devDependencies: {
+        '@scope/core': 'file:../core',
+      },
+    });
+    writeFile(root, 'packages/core/package.json', {
+      name: '@scope/core',
+      version: '0.21.0',
+      peerDependencies: {
+        '@scope/base': '~0.21.0',
+      },
+    });
+    writeFile(root, 'packages/sdk/package.json', {
+      name: '@scope/sdk',
+      version: '0.1.8',
+      dependencies: {
+        '@scope/base': '^0.21.0',
+      },
+    });
+    writeFile(root, 'packages/desktop/package.json', {
+      name: '@scope/desktop',
+      version: '0.21.0',
+      dependencies: {
+        '@scope/base': '^0.21.0',
+      },
+    });
+    return root;
+  }
+
+  function writeFile(root, relativePath, data) {
+    const filePath = path.join(root, relativePath);
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    writeFileSync(filePath, JSON.stringify(data, null, 2) + '\n');
+  }
+
+  function readPkg(root, relativePath) {
+    return JSON.parse(readFileSync(path.join(root, relativePath), 'utf-8'));
+  }
+
+  it('bumps workspace versions and rewrites inter-workspace ^/~ ranges', () => {
+    const root = setup();
+
+    const updated = bumpWorkspaceVersions(root, '0.21.1-preview.0', {
+      exclude: ['@scope/sdk'],
+    });
+
+    expect(updated.sort()).toEqual([
+      '@scope/adapter',
+      '@scope/base',
+      '@scope/core',
+      '@scope/sdk',
+    ]);
+    const adapter = readPkg(root, 'packages/adapter/package.json');
+    expect(adapter.version).toBe('0.21.1-preview.0');
+    // The regression this covers: a bumped sibling must still satisfy the
+    // dependent's range, otherwise npm installs a stale registry copy into
+    // the dependent's node_modules during the release version bump.
+    expect(adapter.dependencies['@scope/base']).toBe('^0.21.1-preview.0');
+    expect(adapter.dependencies['ext-pkg']).toBe('^2.0.0');
+    expect(adapter.devDependencies['@scope/core']).toBe('file:../core');
+    expect(
+      readPkg(root, 'packages/core/package.json').peerDependencies,
+    ).toEqual({
+      '@scope/base': '^0.21.1-preview.0',
+    });
+  });
+
+  it('keeps excluded workspace versions but still rewrites their ranges', () => {
+    const root = setup();
+
+    bumpWorkspaceVersions(root, '0.21.1-preview.0', {
+      exclude: ['@scope/sdk'],
+    });
+
+    const sdk = readPkg(root, 'packages/sdk/package.json');
+    expect(sdk.version).toBe('0.1.8');
+    expect(sdk.dependencies['@scope/base']).toBe('^0.21.1-preview.0');
+  });
+
+  it('ignores packages excluded by negated workspace patterns', () => {
+    const root = setup();
+
+    bumpWorkspaceVersions(root, '0.21.1-preview.0', {
+      exclude: ['@scope/sdk'],
+    });
+
+    const desktop = readPkg(root, 'packages/desktop/package.json');
+    expect(desktop.version).toBe('0.21.0');
+    expect(desktop.dependencies['@scope/base']).toBe('^0.21.0');
+  });
+});

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -7,6 +7,7 @@
 import { execSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { bumpWorkspaceVersions } from './bump-workspace-versions.js';
 
 // A script to handle versioning and ensure all related changes are in a single, atomic commit.
 
@@ -33,55 +34,23 @@ if (!versionType) {
   process.exit(1);
 }
 
-// 2. Bump the version in the root and all workspace package.json files.
+// 2. Bump the version in the root package.json file.
 run(`npm version ${versionType} --no-git-tag-version --allow-same-version`);
 
-// 3. Get all workspaces and filter out the one we don't want to version.
-// We intend to maintain sdk and mobile-mcp versions independently.
-const workspacesToExclude = ['@qwen-code/sdk', '@qwen-code/mobile-mcp'];
-let lsOutput;
-try {
-  lsOutput = JSON.parse(
-    execSync('npm ls --workspaces --json --depth=0').toString(),
-  );
-} catch (e) {
-  // `npm ls` can exit with a non-zero status code if there are issues
-  // with dependencies, but it will still produce the JSON output we need.
-  // We'll try to parse the stdout from the error object.
-  if (e.stdout) {
-    console.warn(
-      'Warning: `npm ls` exited with a non-zero status code. Attempting to proceed with the output.',
-    );
-    try {
-      lsOutput = JSON.parse(e.stdout.toString());
-    } catch (parseError) {
-      console.error(
-        'Error: Failed to parse JSON from `npm ls` output even after `npm ls` failed.',
-      );
-      console.error('npm ls stderr:', e.stderr.toString());
-      console.error('Parse error:', parseError);
-      process.exit(1);
-    }
-  } else {
-    console.error('Error: `npm ls` failed with no output.');
-    console.error(e.stderr?.toString() || e);
-    process.exit(1);
-  }
-}
-const allWorkspaces = Object.keys(lsOutput.dependencies || {});
-const workspacesToVersion = allWorkspaces.filter(
-  (wsName) => !workspacesToExclude.includes(wsName),
-);
-
-for (const workspaceName of workspacesToVersion) {
-  run(
-    `npm version ${versionType} --workspace ${workspaceName} --no-git-tag-version --allow-same-version`,
-  );
-}
-
-// 4. Get the new version number from the root package.json
+// 3. Get the new version number from the root package.json
 const rootPackageJsonPath = resolve(process.cwd(), 'package.json');
 const newVersion = readJson(rootPackageJsonPath).version;
+
+// 4. Bump every workspace (except sdk and mobile-mcp, which are versioned
+// independently) and rewrite inter-workspace ^/~ dependency ranges to the new
+// version, so the bumped workspaces keep satisfying their dependents and npm
+// never backfills stale registry copies into packages/*/node_modules.
+const workspacesToExclude = ['@qwen-code/sdk', '@qwen-code/mobile-mcp'];
+for (const name of bumpWorkspaceVersions(process.cwd(), newVersion, {
+  exclude: workspacesToExclude,
+})) {
+  console.log(`Updated ${name}`);
+}
 
 // 5. Update the sandboxImageUri in the root package.json
 const rootPackageJson = readJson(rootPackageJsonPath);
@@ -104,12 +73,12 @@ if (cliPackageJson.config?.sandboxImageUri) {
   writeJson(cliPackageJsonPath, cliPackageJson);
 }
 
-// 7. Run `npm install` to update package-lock.json.
+// 7. Run `npm install` to update package-lock.json with the new versions and
+// inter-workspace ranges in one pass, so npm never sees an inconsistent
+// tree that it would "fix" with stale registry copies.
 // --ignore-scripts prevents the root `prepare` lifecycle from triggering a
 // redundant full build that fails with TS5055 when dist/ already exists from
 // the initial `npm ci` install.
-run(
-  'npm install --workspace packages/cli --workspace packages/core --workspace packages/channels/base --workspace packages/channels/plugin-example --package-lock-only --ignore-scripts',
-);
+run('npm install --package-lock-only --ignore-scripts');
 
 console.log(`Successfully bumped versions to v${newVersion}.`);


### PR DESCRIPTION
## What this PR does

Changes the release version-bump script so that, instead of shelling out to `npm version --workspace` for each workspace, it edits each workspace's package.json directly — setting the new version and rewriting inter-workspace `^`/`~` dependency ranges to the new version — and then syncs package-lock.json in a single `npm install --package-lock-only` pass.

## Why it's needed

The preview release run [30370180438](https://github.com/QwenLM/qwen-code/actions/runs/30370180438) failed in the Publish job: building `@qwen-code/channel-github` errored with `TS2305: Module '"@qwen-code/channel-base"' has no exported member 'PollingChannelBase'` plus cascading type errors, while Quality Checks on the same commit passed. Root cause, reproduced locally step by step: after the bump to `0.21.1-preview.0`, the workspace `channel-base` no longer satisfies the sibling range `^0.21.0` declared by the channel adapters (a prerelease only satisfies a range whose comparator carries a prerelease on the same major.minor.patch). `npm version --workspace` reifies node_modules after each bump and "fixes" that mismatch by installing the **published registry** `channel-base@0.21.0` into `packages/channels/*/node_modules` — a copy that predates `PollingChannelBase` (added in #7632 after 0.21.0 shipped) and shadows the workspace symlink, so tsc resolves the stale `.d.ts`. The same pollution is committed into the release branch's package-lock.json (7 nested registry entries on `release/v0.21.1-preview.0`), and it means published channel packages declare ranges that resolve to siblings lacking the APIs they actually use. Any bump that leaves the existing `^X.Y.Z` range (preview, nightly, minor/major) is affected; it went unnoticed until a channel adapter started using an export that only exists in the unreleased sibling.

## Reviewer Test Plan

### How to verify

On a clean checkout: `npm ci`, then `node scripts/version.js 0.21.1-preview.0`. Expected after this PR: no `node_modules/@qwen-code` directory appears under any `packages/*` workspace; package-lock.json contains zero nested registry entries for `@qwen-code/*`; `packages/channels/github/package.json` depends on `@qwen-code/channel-base@^0.21.1-preview.0`; `@qwen-code/sdk` and `@qwen-code/mobile-mcp` keep their independent versions; a follow-up `npm ci` succeeds and `npm run build --workspace=packages/channels/github` passes. Before this PR the same sequence installs registry `channel-base@0.21.0` into `packages/channels/github/node_modules` and the build fails with TS2305. Unit tests: `npm run test:scripts` (new `bump-workspace-versions` tests cover range rewriting, exclusions, and negated workspace patterns).

### Evidence (Before & After)

N/A (release tooling, not user-visible)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Verified in a fresh local clone replaying the Release publish job's exact sequence (`npm ci` → `node scripts/version.js 0.21.1-preview.0` → build), for both preview (`0.21.1-preview.0`) and stable (`0.21.1`) version shapes; full `npm run build` passed on the bumped tree.

## Risk & Scope

- Main risk or tradeoff: the final lockfile sync now runs unfiltered (no `--workspace` list) so every workspace's version entry is updated in one pass — verified the resulting lockfile passes `npm ci` and full build.
- Not validated / out of scope: the actual npm publish of channel packages (dry-run build path only); Windows/Linux run of the script (logic is path- and platform-agnostic, covered by unit tests).
- Breaking changes / migration notes: none. Previously pushed release branches (e.g. `release/v0.21.1-preview.0`) carry the polluted lockfile and should be regenerated after this merges.

## Linked Issues

Refs https://github.com/QwenLM/qwen-code/actions/runs/30370180438

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修改发布版本升级脚本：不再对每个 workspace 调用 `npm version --workspace`，而是直接编辑各 workspace 的 package.json——写入新版本号，并把 workspace 间的 `^`/`~` 依赖范围重写为新版本——最后用一次 `npm install --package-lock-only` 统一同步 package-lock.json。

## 为什么需要

preview 发布 run [30370180438](https://github.com/QwenLM/qwen-code/actions/runs/30370180438) 在 Publish job 中失败：构建 `@qwen-code/channel-github` 时报 `TS2305: Module '"@qwen-code/channel-base"' has no exported member 'PollingChannelBase'` 及一系列级联类型错误，而同一 commit 的 Quality Checks 全部通过。根因（已本地逐步复现）：版本升级到 `0.21.1-preview.0` 后，workspace 里的 `channel-base` 不再满足兄弟包声明的 `^0.21.0` 范围（semver 规则：prerelease 版本只满足带有相同 major.minor.patch prerelease 比较符的 range）。`npm version --workspace` 每次升级后都会 reify node_modules，为了"修复"这个不匹配，它把 **registry 上已发布的** `channel-base@0.21.0` 装进 `packages/channels/*/node_modules`——这份副本早于 `PollingChannelBase`（#7632 在 0.21.0 发布后才合入），遮蔽了 workspace 符号链接，导致 tsc 解析到过时的 `.d.ts`。同样的污染还会被提交进 release 分支的 package-lock.json（`release/v0.21.1-preview.0` 上有 7 条嵌套 registry 条目），且意味着发布的 channel 包声明的依赖范围会解析到缺少实际所需 API 的旧版兄弟包。任何脱离现有 `^X.Y.Z` 范围的升级（preview、nightly、minor/major）都会触发；此前一直未暴露，直到某个 channel adapter 开始使用仅存在于未发布兄弟版本中的导出。

## Reviewer 验证计划

### 如何验证

在干净检出上：`npm ci`，然后 `node scripts/version.js 0.21.1-preview.0`。本 PR 之后的预期：任何 `packages/*` workspace 下都不出现 `node_modules/@qwen-code` 目录；package-lock.json 中 `@qwen-code/*` 的嵌套 registry 条目为 0；`packages/channels/github/package.json` 依赖 `@qwen-code/channel-base@^0.21.1-preview.0`；`@qwen-code/sdk` 与 `@qwen-code/mobile-mcp` 保持各自独立版本；随后 `npm ci` 成功且 `npm run build --workspace=packages/channels/github` 通过。本 PR 之前，同一序列会把 registry 的 `channel-base@0.21.0` 装入 `packages/channels/github/node_modules`，构建以 TS2305 失败。单元测试：`npm run test:scripts`（新增 `bump-workspace-versions` 测试覆盖范围重写、排除项与取反的 workspace 模式）。

### 证据（Before & After）

N/A（发布工具链，非用户可见）

### 测试平台

macOS ✅；Windows ⚠️ 未测；Linux ⚠️ 未测（CI 会覆盖）。

### 环境（可选）

在全新本地克隆中完整复放了 Release publish job 的序列（`npm ci` → `node scripts/version.js 0.21.1-preview.0` → 构建），preview（`0.21.1-preview.0`）与稳定版（`0.21.1`）两种版本形态均验证；升级后的工作区上完整 `npm run build` 通过。

## 风险与范围

- 主要风险/取舍：最后的 lockfile 同步改为不过滤 workspace（去掉 `--workspace` 列表），一次性更新所有 workspace 的版本条目——已验证生成的 lockfile 能通过 `npm ci` 与完整构建。
- 未验证/范围外：channel 包的真实 npm 发布（仅验证到 dry-run 构建路径）；脚本在 Windows/Linux 上的运行（逻辑与平台无关，有单元测试覆盖）。
- 破坏性变更/迁移说明：无。已推送的 release 分支（如 `release/v0.21.1-preview.0`）带有被污染的 lockfile，合并后应重新生成。

## 关联 Issue

Refs https://github.com/QwenLM/qwen-code/actions/runs/30370180438

</details>
