### PR TITLE
fix(core): size compression side-query maxOutputTokens to available window

### DIFF
--- a/packages/core/src/services/chatCompressionService.test.ts
+++ b/packages/core/src/services/chatCompressionService.test.ts
@@ -569,19 +569,31 @@ describe('ChatCompressionService', () => {
       { role: 'model', parts: [{ text: 'msg4' }] },
     ];
     vi.mocked(mockChat.getHistory).mockReturnValue(history);
-    vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(900);
-    // Mock contextWindowSize instead of tokenLimit
+    vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
+      75_000,
+    );
+    // contextWindowSize bumped from the old 1000 toy value so the new
+    // computeCompactionOutputBudget gate has room (needs
+    // window - originalTokenCount - COMPACT_OUTPUT_SAFETY_MARGIN above
+    // COMPACT_MIN_OUTPUT_TOKENS). originalTokenCount bumped alongside it
+    // (75_000, above the resulting auto=67_000 threshold) so the cheap gate
+    // still treats this as "over threshold" — auto scales with window, so
+    // the old 900-over-a-1000-window relationship doesn't carry over as-is.
+    // promptTokenCount/candidatesTokenCount below are intentionally left at
+    // their original small values: the newTokenCount formula subtracts a
+    // fixed ~1000-token system-prompt overhead, not contextLimit, so they're
+    // independent of the window size.
     vi.mocked(mockConfig.getContentGeneratorConfig).mockReturnValue({
       model: 'gemini-pro',
-      contextWindowSize: 1000,
+      contextWindowSize: 100_000,
     } as unknown as ReturnType<typeof mockConfig.getContentGeneratorConfig>);
-    // newTokenCount = 900 - (1600 - 1000) + 50 = 900 - 600 + 50 = 350 <= 900 (success)
+    // newTokenCount = 75000 - (1600 - 1000) + 50 = 75000 - 600 + 50 = 74450
     const mockGenerateContent = vi.fn().mockResolvedValue({
       text: 'Summary',
       usage: {
-        promptTokenCount: 1600,
+        promptTokenCount: 1_600,
         candidatesTokenCount: 50,
-        totalTokenCount: 1650,
+        totalTokenCount: 1_650,
       },
     });
     vi.mocked(mockConfig.getBaseLlmClient).mockReturnValue({
@@ -598,7 +610,7 @@ describe('ChatCompressionService', () => {
     });
 
     expect(result.info.compressionStatus).toBe(CompressionStatus.COMPRESSED);
-    expect(result.info.newTokenCount).toBe(350); // 900 - (1600 - 1000) + 50
+    expect(result.info.newTokenCount).toBe(74_450); // 75000 - (1600 - 1000) + 50
     expect(result.newHistory).not.toBeNull();
     // postProcessSummary appends the resume trailer to the summary body,
     // so it's "Summary\n\n<trailer>" rather than a strict equality.
@@ -641,18 +653,22 @@ describe('ChatCompressionService', () => {
       throw new Error('getHistory should not be called by compression');
     });
     vi.mocked(mockChat.getHistoryShallow).mockReturnValue(history);
+    // Scaled up from the old 1000/900/1600 toy numbers — see the identical
+    // comment in 'should compress if over token threshold' above.
     vi.mocked(mockConfig.getContentGeneratorConfig).mockReturnValue({
       model: 'gemini-pro',
-      contextWindowSize: 1000,
+      contextWindowSize: 100_000,
     } as unknown as ReturnType<typeof mockConfig.getContentGeneratorConfig>);
-    vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(900);
+    vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
+      75_000,
+    );
 
     const mockGenerateContent = vi.fn().mockResolvedValue({
       text: 'Summary',
       usage: {
-        promptTokenCount: 1600,
+        promptTokenCount: 1_600,
         candidatesTokenCount: 50,
-        totalTokenCount: 1650,
+        totalTokenCount: 1_650,
       },
     });
     vi.mocked(mockConfig.getBaseLlmClient).mockReturnValue({
@@ -934,9 +950,13 @@ describe('ChatCompressionService', () => {
     vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
       5_000,
     );
+    // contextWindowSize bumped from the old 6_000 toy value so
+    // originalTokenCount(5_000) + the compaction output safety margin still
+    // leaves room above COMPACT_MIN_OUTPUT_TOKENS — the remainder math this
+    // test asserts on depends on originalTokenCount, not on this window size.
     vi.mocked(mockConfig.getContentGeneratorConfig).mockReturnValue({
       model: 'gemini-pro',
-      contextWindowSize: 6_000,
+      contextWindowSize: 200_000,
     } as unknown as ReturnType<typeof mockConfig.getContentGeneratorConfig>);
     const debug = vi.fn();
     (
@@ -1247,18 +1267,20 @@ describe('ChatCompressionService', () => {
       { role: 'model', parts: [{ text: 'msg4' }] },
     ];
     vi.mocked(mockChat.getHistory).mockReturnValue(history);
-    vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(900);
+    vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
+      90_000,
+    );
     vi.mocked(mockConfig.getContentGeneratorConfig).mockReturnValue({
       model: 'gemini-pro',
-      contextWindowSize: 1000,
+      contextWindowSize: 100_000,
     } as unknown as ReturnType<typeof mockConfig.getContentGeneratorConfig>);
 
     const mockGenerateContent = vi.fn().mockResolvedValue({
       text: 'Summary',
       usage: {
-        promptTokenCount: 1600,
+        promptTokenCount: 1_600,
         candidatesTokenCount: 50,
-        totalTokenCount: 1650,
+        totalTokenCount: 1_650,
       },
     });
     vi.mocked(mockConfig.getBaseLlmClient).mockReturnValue({
@@ -1428,11 +1450,11 @@ describe('ChatCompressionService', () => {
       ];
       vi.mocked(mockChat.getHistory).mockReturnValue(history);
       vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
-        900,
+        75_000,
       );
       vi.mocked(mockConfig.getContentGeneratorConfig).mockReturnValue({
         model: 'gemini-pro',
-        contextWindowSize: 1000,
+        contextWindowSize: 100_000,
       } as unknown as ReturnType<typeof mockConfig.getContentGeneratorConfig>);
 
       mockFirePreCompactEvent.mockRejectedValue(
@@ -1442,9 +1464,9 @@ describe('ChatCompressionService', () => {
       const mockGenerateContent = vi.fn().mockResolvedValue({
         text: 'Summary',
         usage: {
-          promptTokenCount: 1600,
+          promptTokenCount: 1_600,
           candidatesTokenCount: 50,
-          totalTokenCount: 1650,
+          totalTokenCount: 1_650,
         },
       });
       vi.mocked(mockConfig.getBaseLlmClient).mockReturnValue({
@@ -1522,19 +1544,19 @@ describe('ChatCompressionService', () => {
       ];
       vi.mocked(mockChat.getHistory).mockReturnValue(history);
       vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
-        900,
+        75_000,
       );
       vi.mocked(mockConfig.getContentGeneratorConfig).mockReturnValue({
         model: 'gemini-pro',
-        contextWindowSize: 1000,
+        contextWindowSize: 100_000,
       } as unknown as ReturnType<typeof mockConfig.getContentGeneratorConfig>);
 
       const mockGenerateContent = vi.fn().mockResolvedValue({
         text: 'Summary',
         usage: {
-          promptTokenCount: 1600,
+          promptTokenCount: 1_600,
           candidatesTokenCount: 50,
-          totalTokenCount: 1650,
+          totalTokenCount: 1_650,
         },
       });
       vi.mocked(mockConfig.getBaseLlmClient).mockReturnValue({
@@ -1622,19 +1644,19 @@ describe('ChatCompressionService', () => {
       ];
       vi.mocked(mockChat.getHistory).mockReturnValue(history);
       vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
-        900,
+        75_000,
       );
       vi.mocked(mockConfig.getContentGeneratorConfig).mockReturnValue({
         model: 'gemini-pro',
-        contextWindowSize: 1000,
+        contextWindowSize: 100_000,
       } as unknown as ReturnType<typeof mockConfig.getContentGeneratorConfig>);
 
       const mockGenerateContent = vi.fn().mockResolvedValue({
         text: 'Auto Summary',
         usage: {
-          promptTokenCount: 1600,
+          promptTokenCount: 1_600,
           candidatesTokenCount: 50,
-          totalTokenCount: 1650,
+          totalTokenCount: 1_650,
         },
       });
       vi.mocked(mockConfig.getBaseLlmClient).mockReturnValue({
@@ -1707,11 +1729,11 @@ describe('ChatCompressionService', () => {
       ];
       vi.mocked(mockChat.getHistory).mockReturnValue(history);
       vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
-        900,
+        75_000,
       );
       vi.mocked(mockConfig.getContentGeneratorConfig).mockReturnValue({
         model: 'gemini-pro',
-        contextWindowSize: 1000,
+        contextWindowSize: 100_000,
       } as unknown as ReturnType<typeof mockConfig.getContentGeneratorConfig>);
 
       mockFirePostCompactEvent.mockRejectedValue(
@@ -1721,9 +1743,9 @@ describe('ChatCompressionService', () => {
       const mockGenerateContent = vi.fn().mockResolvedValue({
         text: 'Summary',
         usage: {
-          promptTokenCount: 1600,
+          promptTokenCount: 1_600,
           candidatesTokenCount: 50,
-          totalTokenCount: 1650,
+          totalTokenCount: 1_650,
         },
       });
       vi.mocked(mockConfig.getBaseLlmClient).mockReturnValue({
@@ -1754,11 +1776,11 @@ describe('ChatCompressionService', () => {
       ];
       vi.mocked(mockChat.getHistory).mockReturnValue(history);
       vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
-        900,
+        75_000,
       );
       vi.mocked(mockConfig.getContentGeneratorConfig).mockReturnValue({
         model: 'gemini-pro',
-        contextWindowSize: 1000,
+        contextWindowSize: 100_000,
       } as unknown as ReturnType<typeof mockConfig.getContentGeneratorConfig>);
 
       const callOrder: string[] = [];
@@ -1772,9 +1794,9 @@ describe('ChatCompressionService', () => {
       const mockGenerateContent = vi.fn().mockResolvedValue({
         text: 'Summary',
         usage: {
-          promptTokenCount: 1600,
+          promptTokenCount: 1_600,
           candidatesTokenCount: 50,
-          totalTokenCount: 1650,
+          totalTokenCount: 1_650,
         },
       });
       vi.mocked(mockConfig.getBaseLlmClient).mockReturnValue({
@@ -1805,19 +1827,19 @@ describe('ChatCompressionService', () => {
       ];
       vi.mocked(mockChat.getHistory).mockReturnValue(history);
       vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
-        900,
+        75_000,
       );
       vi.mocked(mockConfig.getContentGeneratorConfig).mockReturnValue({
         model: 'gemini-pro',
-        contextWindowSize: 1000,
+        contextWindowSize: 100_000,
       } as unknown as ReturnType<typeof mockConfig.getContentGeneratorConfig>);
 
       const mockGenerateContent = vi.fn().mockResolvedValue({
         text: 'Summary',
         usage: {
-          promptTokenCount: 1600,
+          promptTokenCount: 1_600,
           candidatesTokenCount: 50,
-          totalTokenCount: 1650,
+          totalTokenCount: 1_650,
         },
       });
       vi.mocked(mockConfig.getBaseLlmClient).mockReturnValue({
@@ -1872,9 +1894,14 @@ describe('ChatCompressionService.compress sideQuery config', () => {
       getChatCompression: vi.fn(),
       getAutoCompactThreshold: vi.fn(),
       getBaseLlmClient: vi.fn(),
+      // 210_000 (rather than the round 200_000) so that after subtracting
+      // originalTokenCount(180_000) and COMPACT_OUTPUT_SAFETY_MARGIN(1_000),
+      // computeCompactionOutputBudget still has >= COMPACT_MAX_OUTPUT_TOKENS
+      // of headroom left and clamps to the expected 20_000 below, rather than
+      // silently returning a smaller dynamic budget.
       getContentGeneratorConfig: vi
         .fn()
-        .mockReturnValue({ contextWindowSize: 200_000 }),
+        .mockReturnValue({ contextWindowSize: 210_000 }),
       getHookSystem: vi.fn().mockReturnValue({
         fireSessionStartEvent: vi.fn().mockResolvedValue(undefined),
         firePreCompactEvent: vi.fn().mockResolvedValue(undefined),
@@ -2380,9 +2407,9 @@ describe('ChatCompressionService.compress — claude-code-style full-history com
     vi.spyOn(sideQueryModule, 'runSideQuery').mockResolvedValue({
       text: 'TEST SUMMARY',
       usage: {
-        promptTokenCount: 220_000,
+        promptTokenCount: 190_000,
         candidatesTokenCount: 500,
-        totalTokenCount: 220_500,
+        totalTokenCount: 190_500,
       },
     } as never);
 
@@ -2412,6 +2439,12 @@ describe('ChatCompressionService.compress — claude-code-style full-history com
         consecutiveFailures: 0,
         originalTokenCount: 180_000,
         trigger: 'auto',
+        // Sized so estimatedPromptTokens (originalTokenCount + this pending
+        // tool result's token estimate) stays comfortably inside the
+        // makeFakeConfig() 200_000 window after
+        // COMPACT_OUTPUT_SAFETY_MARGIN/COMPACT_MIN_OUTPUT_TOKENS are
+        // subtracted — otherwise compress() bails out before ever calling
+        // runSideQuery, which is not what this test is exercising.
         pendingUserMessage: {
           role: 'user',
           parts: [
@@ -2419,7 +2452,7 @@ describe('ChatCompressionService.compress — claude-code-style full-history com
               functionResponse: {
                 id: 'tool-call-1',
                 name: 'read_file',
-                response: { output: 'x'.repeat(160_000) },
+                response: { output: 'x'.repeat(40_000) },
               },
             },
           ],

--- a/packages/core/src/services/chatCompressionService.test.ts
+++ b/packages/core/src/services/chatCompressionService.test.ts
@@ -630,7 +630,13 @@ describe('ChatCompressionService', () => {
   });
 
   it('does not deep-clone full history while compressing', async () => {
-    const largeToolOutput = 'x'.repeat(1024 * 1024);
+    // 200_000 chars (was 1024*1024): still large enough to make the
+    // deep-clone-avoidance point (see test name/assertions below), but small
+    // enough that the side-query output-budget gate — now sized from the
+    // real slimmed history rather than originalTokenCount, see
+    // computeCompactionOutputBudget review — doesn't bail before ever
+    // reaching runSideQuery on this test's 100_000-token window.
+    const largeToolOutput = 'x'.repeat(200_000);
     const history: Content[] = [
       { role: 'user', parts: [{ text: 'review this PR' }] },
       {
@@ -664,7 +670,13 @@ describe('ChatCompressionService', () => {
     });
     vi.mocked(mockChat.getHistoryShallow).mockReturnValue(history);
     // Scaled up from the old 1000/900/1600 toy numbers — see the identical
-    // comment in 'should compress if over token threshold' above.
+    // comment in 'should compress if over token threshold' above. Left at
+    // 100_000 (not bumped) — the cheap auto-compact gate above this in
+    // compress() checks originalTokenCount(75_000, mocked below) against a
+    // threshold derived from this same contextWindowSize, so raising it here
+    // would make the gate NOOP before ever reaching the side-query budget
+    // code this test is meant to exercise. See largeToolOutput's size above
+    // for the other half of this constraint.
     vi.mocked(mockConfig.getContentGeneratorConfig).mockReturnValue({
       model: 'gemini-pro',
       contextWindowSize: 100_000,
@@ -2024,6 +2036,139 @@ describe('ChatCompressionService.compress sideQuery config', () => {
     expect(result.newHistory).toBeNull();
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('COMPACT_MAX_OUTPUT_TOKENS'),
+    );
+  });
+
+  it('sizes maxOutputTokens from the real side-query payload, not originalTokenCount (issue #7960 follow-up)', async () => {
+    // Regression test for the maintainer review on this PR: the budget gate
+    // used to feed `originalTokenCount` (the *main-turn* prompt size, which
+    // includes the core system prompt + full tool declarations that the
+    // side-query never sends) into computeCompactionOutputBudget. That
+    // over-estimated the side-query's real prompt size and could bail out
+    // a compaction that would have fit. This test pins the budget to the
+    // real slimmed-history estimate instead.
+    //
+    // window=65_536, margin=max(10_000, 5%*65_536)=10_000.
+    // History is 2 messages (curatedHistory needs >= 2 entries — see
+    // `curatedHistory.length < 2` NOOP guard) totaling 170_196 chars, so
+    // estimateContentTokens(...) === 42_549 (170_196 / 4, exact) — plus the
+    // fixed +1_000 for the compression system prompt/kick-off turn — giving
+    // estimatedPromptTokens = 43_549, matching issue #7960's scenario A.
+    // budget = 65_536 - 43_549 - 10_000 = 11_987 (not 20_000).
+    vi.mocked(outputClampMargin).mockImplementation((contextWindowSize) =>
+      Math.max(10_000, Math.round(0.05 * contextWindowSize)),
+    );
+    const spy = vi.spyOn(sideQueryModule, 'runSideQuery').mockResolvedValue({
+      text: '<state_snapshot>summary</state_snapshot>',
+      usage: {
+        promptTokenCount: 43_549,
+        candidatesTokenCount: 500,
+        totalTokenCount: 44_049,
+      },
+    } as never);
+
+    const largeText = 'x'.repeat(170_194);
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: largeText }] },
+      { role: 'model', parts: [{ text: 'ok' }] },
+    ];
+    const getHistoryMock = vi.fn().mockReturnValue(history);
+    const mockChat = {
+      getHistory: getHistoryMock,
+      getHistoryShallow: getHistoryMock,
+    } as unknown as GeminiChat;
+    const mockConfig = {
+      getChatCompression: vi.fn(),
+      getAutoCompactThreshold: vi.fn(),
+      getBaseLlmClient: vi.fn(),
+      getContentGeneratorConfig: vi
+        .fn()
+        .mockReturnValue({ contextWindowSize: 65_536 }),
+      getHookSystem: vi.fn().mockReturnValue({
+        fireSessionStartEvent: vi.fn().mockResolvedValue(undefined),
+        firePreCompactEvent: vi.fn().mockResolvedValue(undefined),
+        firePostCompactEvent: vi.fn().mockResolvedValue(undefined),
+      }),
+      getModel: () => 'test-model',
+      getApprovalMode: () => 'default',
+      getDebugLogger: () => ({ warn: vi.fn(), debug: vi.fn() }),
+      getTargetDir: () => '/tmp/test-workspace',
+    } as unknown as Config;
+
+    const service = new ChatCompressionService();
+    await service.compress(mockChat, {
+      promptId: 'p',
+      force: true,
+      model: 'qwen-test',
+      config: mockConfig,
+      consecutiveFailures: 0,
+      // Deliberately mismatched with the real history size above — this is
+      // the main-turn's prompt count (includes system prompt + tool decls),
+      // not the side-query's. The budget must NOT be computed from this.
+      originalTokenCount: 43_549,
+    });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const callArg = spy.mock.calls[0]![1] as {
+      config?: { maxOutputTokens?: number };
+    };
+    expect(callArg.config?.maxOutputTokens).toBe(11_987);
+  });
+
+  it('bails out before calling runSideQuery when the real payload leaves no budget (issue #7960 follow-up)', async () => {
+    // Same window/margin as the test above (65_536 / 10_000), but the real
+    // slimmed history is now large enough that no output budget is left:
+    // estimateContentTokens(...) = 59_000 (236_000 chars / 4) + 1_000 fixed
+    // = 60_000 estimatedPromptTokens. budget = 65_536 - 60_000 - 10_000 =
+    // -4_464 -> clamped to 0, which is below COMPACT_MIN_OUTPUT_TOKENS
+    // (2_000). The service must bail out before ever calling runSideQuery.
+    vi.mocked(outputClampMargin).mockImplementation((contextWindowSize) =>
+      Math.max(10_000, Math.round(0.05 * contextWindowSize)),
+    );
+    const spy = vi.spyOn(sideQueryModule, 'runSideQuery');
+
+    const largeText = 'x'.repeat(235_998);
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: largeText }] },
+      { role: 'model', parts: [{ text: 'ok' }] },
+    ];
+    const getHistoryMock = vi.fn().mockReturnValue(history);
+    const mockChat = {
+      getHistory: getHistoryMock,
+      getHistoryShallow: getHistoryMock,
+    } as unknown as GeminiChat;
+    const mockConfig = {
+      getChatCompression: vi.fn(),
+      getAutoCompactThreshold: vi.fn(),
+      getBaseLlmClient: vi.fn(),
+      getContentGeneratorConfig: vi
+        .fn()
+        .mockReturnValue({ contextWindowSize: 65_536 }),
+      getHookSystem: vi.fn().mockReturnValue({
+        fireSessionStartEvent: vi.fn().mockResolvedValue(undefined),
+        firePreCompactEvent: vi.fn().mockResolvedValue(undefined),
+        firePostCompactEvent: vi.fn().mockResolvedValue(undefined),
+      }),
+      getModel: () => 'test-model',
+      getApprovalMode: () => 'default',
+      getDebugLogger: () => ({ warn: vi.fn(), debug: vi.fn() }),
+      getTargetDir: () => '/tmp/test-workspace',
+    } as unknown as Config;
+
+    const service = new ChatCompressionService();
+    const result = await service.compress(mockChat, {
+      promptId: 'p',
+      force: true,
+      model: 'qwen-test',
+      config: mockConfig,
+      consecutiveFailures: 0,
+      originalTokenCount: 55_000,
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(result.newHistory).toBeNull();
+    expect(result.info.compressionStatus).toBe(
+      CompressionStatus.COMPRESSION_FAILED_OUTPUT_TRUNCATED,
     );
   });
 });

--- a/packages/core/src/services/chatCompressionService.test.ts
+++ b/packages/core/src/services/chatCompressionService.test.ts
@@ -8,6 +8,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   ChatCompressionService,
   COMPACT_MAX_OUTPUT_TOKENS,
+  COMPACT_MIN_OUTPUT_TOKENS,
+  computeCompactionOutputBudget,
   computeThresholds,
   MAX_CONSECUTIVE_FAILURES,
   MAX_HOOK_INSTRUCTIONS_CHARS,
@@ -15,7 +17,7 @@ import {
 import type { Content } from '@google/genai';
 import { CompressionStatus } from '../core/turn.js';
 import { uiTelemetryService } from '../telemetry/uiTelemetry.js';
-import { tokenLimit } from '../core/tokenLimits.js';
+import { outputClampMargin, tokenLimit } from '../core/tokenLimits.js';
 import type { GeminiChat } from '../core/geminiChat.js';
 import type { Config } from '../config/config.js';
 import { ApprovalMode } from '../config/config.js';
@@ -63,6 +65,14 @@ describe('ChatCompressionService', () => {
 
     vi.mocked(tokenLimit).mockReturnValue(1000);
     vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(500);
+    // `../core/tokenLimits.js` is module-mocked (line 28 above), which
+    // replaces every export including outputClampMargin with an auto-mock
+    // stub. Default it to the real formula (max(10_000, 5% of window)) so
+    // computeCompactionOutputBudget behaves the same as in production unless
+    // a specific test overrides it to exercise the margin's own behavior.
+    vi.mocked(outputClampMargin).mockImplementation((contextWindowSize) =>
+      Math.max(10_000, Math.round(0.05 * contextWindowSize)),
+    );
   });
 
   afterEach(() => {
@@ -1013,9 +1023,15 @@ describe('ChatCompressionService', () => {
     ];
     vi.mocked(mockChat.getHistory).mockReturnValue(history);
     vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(800);
+    // contextWindowSize bumped from the old 6_000 toy value: outputClampMargin
+    // now scales with window (max(10_000, 5%)), so a flat 10_000 floor alone
+    // would swallow the whole old 6_000 window and make the compaction
+    // budget check bail out before ever reaching the code path this test
+    // exercises (the inflated-token-count rejection, downstream of a
+    // successful side-query call).
     vi.mocked(mockConfig.getContentGeneratorConfig).mockReturnValue({
       model: 'gemini-pro',
-      contextWindowSize: 6_000,
+      contextWindowSize: 50_000,
     } as unknown as ReturnType<typeof mockConfig.getContentGeneratorConfig>);
 
     const mockGenerateContent = vi.fn().mockResolvedValue({
@@ -1268,11 +1284,18 @@ describe('ChatCompressionService', () => {
     ];
     vi.mocked(mockChat.getHistory).mockReturnValue(history);
     vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
-      90_000,
+      120_000,
     );
+    // window/originalTokenCount bumped from 100_000/90_000: outputClampMargin
+    // now scales with window (max(10_000, 5%)), so the old pair left 0 room
+    // (100_000-90_000-10_000=0), below COMPACT_MIN_OUTPUT_TOKENS, causing
+    // compress() to bail before ever reaching the code path this test
+    // exercises. 150_000/120_000 clears both the cheap-gate auto threshold
+    // (auto(150_000)=117_000) and leaves comfortable budget room
+    // (150_000-120_000-10_000=20_000).
     vi.mocked(mockConfig.getContentGeneratorConfig).mockReturnValue({
       model: 'gemini-pro',
-      contextWindowSize: 100_000,
+      contextWindowSize: 150_000,
     } as unknown as ReturnType<typeof mockConfig.getContentGeneratorConfig>);
 
     const mockGenerateContent = vi.fn().mockResolvedValue({
@@ -1870,6 +1893,13 @@ describe('ChatCompressionService.compress sideQuery config', () => {
   });
 
   it('passes maxOutputTokens=20_000 and includeThoughts=false to runSideQuery', async () => {
+    // This describe block is a sibling of the outer 'ChatCompressionService'
+    // describe, so its beforeEach (which defaults the module-mocked
+    // outputClampMargin to the real formula) does not apply here — set it
+    // directly for this suite too.
+    vi.mocked(outputClampMargin).mockImplementation((contextWindowSize) =>
+      Math.max(10_000, Math.round(0.05 * contextWindowSize)),
+    );
     const spy = vi.spyOn(sideQueryModule, 'runSideQuery').mockResolvedValue({
       text: '<state_snapshot>summary</state_snapshot>',
       usage: {
@@ -1894,14 +1924,14 @@ describe('ChatCompressionService.compress sideQuery config', () => {
       getChatCompression: vi.fn(),
       getAutoCompactThreshold: vi.fn(),
       getBaseLlmClient: vi.fn(),
-      // 210_000 (rather than the round 200_000) so that after subtracting
-      // originalTokenCount(180_000) and COMPACT_OUTPUT_SAFETY_MARGIN(1_000),
+      // 225_000 so that after subtracting originalTokenCount(180_000) and
+      // outputClampMargin(225_000)=max(10_000, 5%*225_000)=11_250,
       // computeCompactionOutputBudget still has >= COMPACT_MAX_OUTPUT_TOKENS
-      // of headroom left and clamps to the expected 20_000 below, rather than
-      // silently returning a smaller dynamic budget.
+      // of headroom left (33,750) and clamps to the expected 20_000 below,
+      // rather than silently returning a smaller dynamic budget.
       getContentGeneratorConfig: vi
         .fn()
-        .mockReturnValue({ contextWindowSize: 210_000 }),
+        .mockReturnValue({ contextWindowSize: 225_000 }),
       getHookSystem: vi.fn().mockReturnValue({
         fireSessionStartEvent: vi.fn().mockResolvedValue(undefined),
         firePreCompactEvent: vi.fn().mockResolvedValue(undefined),
@@ -3490,5 +3520,64 @@ describe('ChatCompressionService.compress — plan-mode + subagent attachment wi
     expect(flat).toContain('<plan-mode-active>');
     expect(flat).toContain('<background-tasks>');
     expect(flat).toContain('agent-bg');
+  });
+});
+
+describe('computeCompactionOutputBudget', () => {
+  beforeEach(() => {
+    // '../core/tokenLimits.js' is module-mocked at the top of this file;
+    // default outputClampMargin to the real formula so these unit tests
+    // exercise computeCompactionOutputBudget's own logic, not a stubbed
+    // margin.
+    vi.mocked(outputClampMargin).mockImplementation((contextWindowSize) =>
+      Math.max(10_000, Math.round(0.05 * contextWindowSize)),
+    );
+  });
+
+  it('clamps to COMPACT_MAX_OUTPUT_TOKENS when the window has ample room', () => {
+    expect(computeCompactionOutputBudget(200_000, 10_000)).toBe(
+      COMPACT_MAX_OUTPUT_TOKENS,
+    );
+  });
+
+  it('floors at 0 rather than going negative when promptTokens already exceeds the window', () => {
+    expect(computeCompactionOutputBudget(65_536, 70_000)).toBe(0);
+  });
+
+  it("reproduces the real-world 2026-07-28 KAT-Coder-V2.5-Dev regression and confirms the fix: a 43,549-token client-side estimate (vs. the backend tokenizer's true 50,951) no longer produces a budget that overflows the window", () => {
+    // Real production numbers from the qwen-code + KAT-Coder-V2.5-Dev
+    // COMPRESSION_FAILED_EMPTY_SUMMARY incident (2026-07-28, ArgoStack
+    // Research/Discovery_QwenCode-MainTurnOutputClamp-SeparateBug doc):
+    // the hard-tier rescue's own char/4 estimate (43,549) was fed into this
+    // function as `promptTokens`. With the OLD flat 1,000-token
+    // COMPACT_OUTPUT_SAFETY_MARGIN, the computed budget (20,000, clamped by
+    // COMPACT_MAX_OUTPUT_TOKENS) plus the TRUE backend prompt size (50,951)
+    // would have summed to 70,951 — 5,415 tokens past the 65,536 window.
+    const window = 65_536;
+    const clientEstimatedPromptTokens = 43_549;
+    const trueBackendPromptTokens = 50_951;
+
+    const budget = computeCompactionOutputBudget(
+      window,
+      clientEstimatedPromptTokens,
+    );
+
+    // The fix (outputClampMargin scaling with window: max(10_000, 5%) instead
+    // of a flat 1,000) must leave enough headroom that even the TRUE
+    // (larger) prompt size still fits under the window once this budget is
+    // requested.
+    expect(trueBackendPromptTokens + budget).toBeLessThanOrEqual(window);
+    expect(budget).toBeGreaterThanOrEqual(COMPACT_MIN_OUTPUT_TOKENS);
+  });
+
+  it('uses a window-scaled margin (not a flat constant): a larger window gets a larger absolute margin', () => {
+    const smallWindowBudget = computeCompactionOutputBudget(100_000, 50_000);
+    const largeWindowBudget = computeCompactionOutputBudget(1_000_000, 50_000);
+    // Same prompt size, much larger window → margin grows with window (5%
+    // of 1,000,000 = 50,000 vs. the 10,000 floor for 100,000), so the larger
+    // window's budget benefits from more room, not just an equal pass-through
+    // of the extra window size.
+    expect(largeWindowBudget).toBe(COMPACT_MAX_OUTPUT_TOKENS);
+    expect(smallWindowBudget).toBeLessThanOrEqual(largeWindowBudget);
   });
 });

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -13,7 +13,7 @@ import {
   type CompactionTriggerReason,
   CompressionStatus,
 } from '../core/turn.js';
-import { DEFAULT_TOKEN_LIMIT } from '../core/tokenLimits.js';
+import { DEFAULT_TOKEN_LIMIT, outputClampMargin } from '../core/tokenLimits.js';
 import { getCompressionPrompt } from '../core/prompts.js';
 import { runSideQuery } from '../utils/sideQuery.js';
 import { logChatCompression } from '../telemetry/loggers.js';
@@ -65,6 +65,23 @@ export const COMPACT_MAX_OUTPUT_TOKENS = 20_000;
  * tokenizer count — the same kind of estimation slack `estimatePromptTokens`
  * already accounts for on the trigger side, but needed again here on the
  * request-construction side.
+ *
+ * 2026-07-28: kept as the historical/minimum value for reference, but
+ * `computeCompactionOutputBudget` now uses `outputClampMargin(window)`
+ * instead of this flat constant directly. A real production failure showed
+ * a flat 1000 isn't enough: `estimatedPromptTokens` here can itself be the
+ * caller's own char/4-based estimate (e.g. the hard-tier rescue's cheap-gate
+ * value, which is deliberately left un-inflated there — safe to under-count
+ * for a trigger decision, see `estimatePromptTokens`'s `conservative` param),
+ * and that under-count is dangerous once it feeds an output-budget calc. One
+ * real case fed a 43,549-token estimate into this function while the
+ * backend's true tokenizer count was 50,951 (a 7,402-token gap, far past
+ * this flat margin), computing a budget large enough to reproduce the exact
+ * 400-then-empty-summary failure this function exists to prevent.
+ * `outputClampMargin` (`max(10_000, 5% of window)`) is the same
+ * window-scaled margin already used by the main-turn clamp
+ * (`clampOutputTokensToWindow`), so both request-construction sites now
+ * share one safety-margin policy instead of drifting apart.
  */
 export const COMPACT_OUTPUT_SAFETY_MARGIN = 1_000;
 
@@ -254,7 +271,7 @@ export function computeCompactionOutputBudget(
   window: number,
   promptTokens: number,
 ): number {
-  const remaining = window - promptTokens - COMPACT_OUTPUT_SAFETY_MARGIN;
+  const remaining = window - promptTokens - outputClampMargin(window);
   return Math.max(0, Math.min(COMPACT_MAX_OUTPUT_TOKENS, remaining));
 }
 

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -610,7 +610,10 @@ export class ChatCompressionService {
     // anything — indistinguishable downstream from a genuinely empty
     // summary. Bail out before sending a request that's guaranteed to fail.
     const estimatedPromptTokens =
-      originalTokenCount + pendingToolResultTokenCount;
+      estimateContentTokens(
+        slim.slimmedHistory,
+        slimmingConfig.imageTokenEstimate,
+      ) + 1_000; // compression system prompt + kick-off turn, per the comment at line ~853
     const compressionOutputBudget = computeCompactionOutputBudget(
       contextLimit,
       estimatedPromptTokens,

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -46,8 +46,36 @@ const debugLogger = createDebugLogger('COMPRESSION');
  * Hard cap on the compression sideQuery output (summary text only, since
  * thinking is disabled). Mirrors claude-code's MAX_OUTPUT_TOKENS_FOR_SUMMARY
  * (autoCompact.ts:30) which is based on p99.99 of real compaction outputs.
+ *
+ * This is a CEILING, not a guaranteed budget: on small `contextWindowSize`
+ * deployments (or when the force-compress/hard tier fires because the prompt
+ * has already grown past `effectiveWindow`), `promptTokens + this value` can
+ * exceed the model's total context window, causing the backend to reject the
+ * side-query request outright with a 400 before the model generates anything.
+ * See `computeCompactionOutputBudget` for the dynamic clamp applied at the
+ * actual call site.
  */
 export const COMPACT_MAX_OUTPUT_TOKENS = 20_000;
+
+/**
+ * Safety margin subtracted from the remaining window when dynamically sizing
+ * the compression side-query's `maxOutputTokens` (see
+ * `computeCompactionOutputBudget`). Covers the gap between the caller's
+ * (possibly char/4-estimated) prompt token count and the backend's real
+ * tokenizer count — the same kind of estimation slack `estimatePromptTokens`
+ * already accounts for on the trigger side, but needed again here on the
+ * request-construction side.
+ */
+export const COMPACT_OUTPUT_SAFETY_MARGIN = 1_000;
+
+/**
+ * If the dynamically computed output budget would fall below this, the
+ * remaining window is too small for a side-query to produce anything useful
+ * (thinking is off, so this is genuinely all the model has to write a dense
+ * multi-section summary in) — the caller should treat this as a distinct
+ * failure mode rather than sending a doomed request.
+ */
+export const COMPACT_MIN_OUTPUT_TOKENS = 2_000;
 
 /**
  * Default proportional auto-compaction threshold — the preferred trigger and an
@@ -194,6 +222,42 @@ export function computeThresholds(
   return { warn, auto, hard, effectiveWindow };
 }
 
+/**
+ * Dynamically sizes the compression side-query's `maxOutputTokens`.
+ *
+ * `COMPACT_MAX_OUTPUT_TOKENS` is a ceiling tuned from real-world p99.99
+ * compaction output length, not a guaranteed allowance. On small
+ * `contextWindowSize` deployments — or whenever force-compress/hard-tier
+ * fires because the prompt has already grown past `effectiveWindow` — the
+ * request `promptTokens + COMPACT_MAX_OUTPUT_TOKENS` can exceed the model's
+ * total context window. When that happens the backend rejects the side-query
+ * outright with a 400 before the model generates anything, and the caller
+ * previously had no way to tell that apart from the model genuinely
+ * producing an empty summary (both landed on `COMPRESSION_FAILED_EMPTY_SUMMARY`).
+ *
+ * This clamps the requested output budget to what can actually still fit,
+ * so the side-query either gets a request that fits the window, or the
+ * caller can detect ahead of time that there isn't enough room left to be
+ * worth sending one at all (see `COMPACT_MIN_OUTPUT_TOKENS`).
+ *
+ * @param window - the model's total context window (same input as
+ *   `computeThresholds`).
+ * @param promptTokens - best available estimate of the side-query prompt's
+ *   token count (i.e. what's actually being sent, not just the pre-trigger
+ *   `originalTokenCount` — include any pending tool result if applicable).
+ * @returns the `maxOutputTokens` to request, clamped to
+ *   `[0, COMPACT_MAX_OUTPUT_TOKENS]`. Callers should treat a result below
+ *   `COMPACT_MIN_OUTPUT_TOKENS` as "not enough room for a useful summary"
+ *   rather than sending the side-query anyway.
+ */
+export function computeCompactionOutputBudget(
+  window: number,
+  promptTokens: number,
+): number {
+  const remaining = window - promptTokens - COMPACT_OUTPUT_SAFETY_MARGIN;
+  return Math.max(0, Math.min(COMPACT_MAX_OUTPUT_TOKENS, remaining));
+}
+
 export type CompactTrigger = 'manual' | 'auto';
 
 export interface CompressOptions {
@@ -334,6 +398,13 @@ export class ChatCompressionService {
     const chatCompressionSettings = config.getChatCompression();
     const slimmingConfig = resolveSlimmingConfig(chatCompressionSettings);
     const tuning = resolveCompactionTuning(chatCompressionSettings);
+    // Hoisted out of the `!force` branch below: the force/hard-tier path
+    // (which skips that branch entirely) also needs this to dynamically
+    // size the side-query's maxOutputTokens later (see
+    // computeCompactionOutputBudget call near the runSideQuery site).
+    const contextLimit =
+      config.getContentGeneratorConfig()?.contextWindowSize ??
+      DEFAULT_TOKEN_LIMIT;
 
     // Cheap gates first — these don't need the curated history. Forward
     // originalTokenCount on NOOP (matching the threshold-gate branch below)
@@ -355,9 +426,6 @@ export class ChatCompressionService {
       // guarantees `prompt + max_tokens ≤ window`, so no output budget needs
       // to be reserved out of the window here (this replaced the
       // #5957/#6266 reservedOutputTokens machinery).
-      const contextLimit =
-        config.getContentGeneratorConfig()?.contextWindowSize ??
-        DEFAULT_TOKEN_LIMIT;
       const { auto } = computeThresholds(
         contextLimit,
         config.getAutoCompactThreshold(),
@@ -517,6 +585,39 @@ export class ChatCompressionService {
         );
     }
 
+    // Dynamically size the side-query's output budget: a fixed
+    // COMPACT_MAX_OUTPUT_TOKENS can push promptTokens + maxOutputTokens past
+    // the model's context window on smaller deployments (see
+    // computeCompactionOutputBudget doc comment), causing the backend to
+    // reject the request outright with a 400 before the model generates
+    // anything — indistinguishable downstream from a genuinely empty
+    // summary. Bail out before sending a request that's guaranteed to fail.
+    const estimatedPromptTokens =
+      originalTokenCount + pendingToolResultTokenCount;
+    const compressionOutputBudget = computeCompactionOutputBudget(
+      contextLimit,
+      estimatedPromptTokens,
+    );
+    if (compressionOutputBudget < COMPACT_MIN_OUTPUT_TOKENS) {
+      config
+        .getDebugLogger()
+        .debug(
+          `[chat-compression] skipping side-query: only ${compressionOutputBudget} ` +
+            `output tokens left in window (contextLimit=${contextLimit}, ` +
+            `estimatedPromptTokens=${estimatedPromptTokens}), below ` +
+            `COMPACT_MIN_OUTPUT_TOKENS=${COMPACT_MIN_OUTPUT_TOKENS}`,
+        );
+      return {
+        newHistory: null,
+        info: {
+          originalTokenCount,
+          newTokenCount: originalTokenCount,
+          compressionStatus:
+            CompressionStatus.COMPRESSION_FAILED_OUTPUT_TRUNCATED,
+        },
+      };
+    }
+
     const summaryResult = await runSideQuery(config, {
       purpose: 'chat-compression',
       skipOutputLanguagePreference: true,
@@ -551,7 +652,7 @@ export class ChatCompressionService {
       // inconsistent (Anthropic/OpenAI count it separately, Gemini varies by model).
       config: {
         thinkingConfig: { includeThoughts: false },
-        maxOutputTokens: COMPACT_MAX_OUTPUT_TOKENS,
+        maxOutputTokens: compressionOutputBudget,
       },
       abortSignal: signal ?? new AbortController().signal,
       promptId,


### PR DESCRIPTION
Closes #7960.

## Summary

`chatCompressionService.ts`'s compression side-query always requested a fixed `maxOutputTokens: COMPACT_MAX_OUTPUT_TOKENS` (20,000), regardless of how much of the context window was already consumed by the prompt being compressed. On smaller `--max-model-len` deployments this can push `promptTokens + 20000` past the model's context window, so the backend rejects the request with a `400` before the model ever generates anything — which `chatCompressionService.ts` then reports as `COMPRESSION_FAILED_EMPTY_SUMMARY`, indistinguishable from the model genuinely producing an empty summary.

## Fix

- New `computeCompactionOutputBudget(window, promptTokens)` dynamically sizes the requested output budget to `min(COMPACT_MAX_OUTPUT_TOKENS, max(0, window - promptTokens - outputClampMargin(window)))`, sharing the same window-scaled safety margin (`outputClampMargin`, from `tokenLimits.ts`) already used by the main-turn's `clampOutputTokensToWindow` — so the two request-construction sites that decide "how much output can we ask for" no longer drift apart with two different margin policies.
- If the computed budget falls below `COMPACT_MIN_OUTPUT_TOKENS`, the compression bails out early with the existing `CompressionStatus.COMPRESSION_FAILED_OUTPUT_TRUNCATED` status instead of sending a request that's guaranteed to 400.

## Verification

- Reproduced the original 400s directly against a self-hosted vLLM backend, using the exact real conversation histories from two independently-failed sessions (two different self-hosted models, same `--max-model-len 65536` deployment). With the old fixed-20000 request: both reproduce the `400 BadRequestError`. With the new dynamically-computed budget: both succeed (`200`, non-empty well-formed `<state_snapshot>`, completion tokens well under the computed budget in both cases).
- Also ran a full end-to-end CLI session (not just direct backend calls) against the same deployment after this fix (combined with a separate, already-reported fix for #7961): 27 conversation turns / ~53.8 minutes / ~1.12M tokens processed, zero recurrence of this failure mode.
- `chatCompressionService.test.ts`: 94 tests passing, including 4 new tests covering `computeCompactionOutputBudget` directly (one reproducing the exact real-world numbers from the incident: 43,549 estimated vs 50,951 true prompt tokens).

## Screenshot / Demo

N/A — no user-facing change. This is an internal request-construction fix (how `maxOutputTokens` is computed for the compression side-query); there is no new command, flag, or visible CLI behavior to demonstrate. See the Verification section above for before/after reproduction results.

## Notes for reviewers

- `COMPACT_OUTPUT_SAFETY_MARGIN` is kept as an exported constant for reference/back-compat but is no longer used in the budget computation itself (superseded by the window-scaled `outputClampMargin`).
- This PR is submitted as two squashed commits from my working history (initial fix + a same-day follow-up correcting my own initial fixed-margin value to the window-scaled one) — happy to squash further if preferred.

