### PR TITLE
fix(core): guard against CJK-driven char/4 under-count in output clamp

### DIFF
--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -4997,11 +4997,13 @@ describe('GeminiChat', async () => {
       expect(compressSpy.mock.calls[0][1].force).toBe(false);
 
       // The outgoing request is clamped to the room left in the window:
-      // estimate = 170,000 + 1 ("hi"), room = 200,000 − 170,001 − 10,000.
+      // char/4("hi") = 1 token, inflated by the conservative safety factor
+      // (1.5x, ceil'd) to 2, estimate = 170,000 + 2,
+      // room = 200,000 − 170,002 − 10,000.
       const requestConfig = vi.mocked(
         mockContentGenerator.generateContentStream,
       ).mock.calls[0][0].config as { maxOutputTokens?: number };
-      expect(requestConfig.maxOutputTokens).toBe(19_999);
+      expect(requestConfig.maxOutputTokens).toBe(19_998);
       expect(170_000 + requestConfig.maxOutputTokens!).toBeLessThanOrEqual(
         200_000,
       );
@@ -10357,10 +10359,12 @@ describe('GeminiChat', async () => {
       const recoveryConfig = calls[1]![0].config as {
         maxOutputTokens?: number;
       };
-      // Initial: room = 131072 − 71350 − 10000 = 49722 (below the 64K ceiling).
-      expect(initialConfig.maxOutputTokens).toBe(49_722);
+      // Initial: char/4("hi")=1 token, inflated by the conservative safety
+      // factor (1.5x, ceil'd) to 2, room = 131072 − 71351 − 10000 = 49721
+      // (below the 64K ceiling).
+      expect(initialConfig.maxOutputTokens).toBe(49_721);
       // Recovery: prompt grew to ~121K → re-clamped to the 4,000 floor, NOT
-      // the stale 49,722 (which would overflow the window by ~40K).
+      // the stale 49,721 (which would overflow the window by ~40K).
       expect(recoveryConfig.maxOutputTokens).toBe(4_000);
     });
 

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -2354,6 +2354,7 @@ export class GeminiChat {
               this.lastPromptTokenCount,
               this.lastOutputTokenCount,
               imageTokenEstimate,
+              /* conservative= */ true,
             )
           : effectiveTokens + FIRST_SEND_CLAMP_OVERHEAD_PAD;
       const clampedMaxOutputTokens = clampOutputTokensToWindow(
@@ -3068,6 +3069,7 @@ export class GeminiChat {
                     self.lastPromptTokenCount,
                     self.lastOutputTokenCount,
                     recoveryImageTokenEstimate,
+                    /* conservative= */ true,
                   )
                 : 0;
             self.history.push(recoveryUserContent);

--- a/packages/core/src/services/tokenEstimation.test.ts
+++ b/packages/core/src/services/tokenEstimation.test.ts
@@ -107,6 +107,72 @@ describe('estimatePromptTokens', () => {
     const fullEst = estimateContentTokens([...history, user]);
     expect(estimatePromptTokens(history, user, 0)).toBe(fullEst);
   });
+
+  describe('conservative mode (window-clamp callers)', () => {
+    it('defaults to non-conservative (identical to the 5-arg call) when omitted', () => {
+      const userEst = estimateContentTokens([user]);
+      expect(estimatePromptTokens(history, user, 5000, 1200)).toBe(
+        estimatePromptTokens(history, user, 5000, 1200, undefined, false),
+      );
+      expect(
+        estimatePromptTokens(history, user, 5000, 1200, undefined, false),
+      ).toBe(5000 + 1200 + userEst);
+    });
+
+    it('inflates only the new-content term by 1.5x (ceil), not the API-authoritative running total', () => {
+      const userEst = estimateContentTokens([user]);
+      const conservativeEst = Math.ceil(userEst * 1.5);
+      expect(
+        estimatePromptTokens(history, user, 5000, 1200, undefined, true),
+      ).toBe(5000 + 1200 + conservativeEst);
+    });
+
+    it('reproduces the real-world 2026-07-28 window-overflow scenario: a large CJK-heavy tool result under-counted by char/4 without conservative mode, corrected with it', () => {
+      // Mirrors the KAT-Coder-V2.5-Dev / Nex-N2-mini real failures: several
+      // parallel read_file results returning CJK-dense design docs pushed
+      // the true prompt to ~35,619 tokens while char/4 (which does not
+      // account for CJK density) estimated a smaller figure from
+      // lastPromptTokenCount + this turn's new content alone, causing
+      // maxOutputTokens to be clamped too loosely and
+      // `prompt + max_tokens` to exceed the window by ~1 token in
+      // production (see Research/Discovery_QwenCode-MainTurnOutputClamp-
+      // SeparateBug_20260728.md in the ArgoStack repo).
+      const cjkToolResult: Content = {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              name: 'read_file',
+              // A realistic stand-in for a CJK-dense design doc chunk.
+              response: { output: '设计文档章节内容。'.repeat(2000) },
+            },
+          },
+        ],
+      };
+      const lastPromptTokenCount = 25_000;
+      const nonConservative = estimatePromptTokens(
+        [],
+        cjkToolResult,
+        lastPromptTokenCount,
+        0,
+      );
+      const conservative = estimatePromptTokens(
+        [],
+        cjkToolResult,
+        lastPromptTokenCount,
+        0,
+        undefined,
+        true,
+      );
+      // Conservative mode must produce a strictly larger (safer, smaller
+      // effective output budget) estimate for the same inputs.
+      expect(conservative).toBeGreaterThan(nonConservative);
+      expect(conservative).toBe(
+        lastPromptTokenCount +
+          Math.ceil(estimateContentTokens([cjkToolResult]) * 1.5),
+      );
+    });
+  });
 });
 
 describe('getUsageOutputTokenCountForPromptEstimate', () => {

--- a/packages/core/src/services/tokenEstimation.ts
+++ b/packages/core/src/services/tokenEstimation.ts
@@ -62,18 +62,40 @@ export function estimateContentTokens(
  * (lastPromptTokenCount === 0) returns a pure estimate with no API-
  * authoritative anchor.
  */
+/**
+ * Multiplier applied to the char/4 estimate of NEWLY-added content when
+ * `conservative` is set. char/4 is documented (see file header) as varying
+ * ±30% against real tokenizers, but that band was measured against mixed
+ * English-heavy content; two independent real production failures
+ * (chatCompressionService's 400-overflow root cause doc and a main-turn
+ * `prompt + max_tokens > window` overflow, both 2026-07-28) traced back to
+ * char/4 under-counting CJK-dense tool output (design docs, large file
+ * reads) by 39-54% — beyond the documented band. 1.5x covers both observed
+ * cases with headroom without materially eating into the output budget for
+ * ordinary (non-CJK-heavy) content, since it only scales the incremental
+ * new-content term, not the API-authoritative running total.
+ */
+export const CONSERVATIVE_NEW_CONTENT_SAFETY_FACTOR = 1.5;
+
 export function estimatePromptTokens(
   history: Content[],
   userMessage: Content,
   lastPromptTokenCount: number,
   lastOutputTokenCount: number = 0,
   imageTokenEstimate: number = DEFAULT_IMAGE_TOKEN_ESTIMATE,
+  conservative: boolean = false,
 ): number {
   if (lastPromptTokenCount > 0) {
+    const newContentTokens = estimateContentTokens(
+      [userMessage],
+      imageTokenEstimate,
+    );
     return (
       lastPromptTokenCount +
       lastOutputTokenCount +
-      estimateContentTokens([userMessage], imageTokenEstimate)
+      (conservative
+        ? Math.ceil(newContentTokens * CONSERVATIVE_NEW_CONTENT_SAFETY_FACTOR)
+        : newContentTokens)
     );
   }
   // First-send fallback (no API data yet): estimate from `history + userMessage`


### PR DESCRIPTION
Closes #7961.

## Summary

`clampOutputTokensToWindow`'s steady-state and recovery-path branches compute the remaining output budget using `estimatePromptTokens(...)`, which estimates *new* content (not yet covered by the API's own authoritative `lastPromptTokenCount`) with a flat `chars / 4` heuristic. That heuristic under-counts CJK-dense text — a single CJK character is very often close to one token by itself, nowhere near 4 chars/token — so when the new content since the last confirmed count is CJK-heavy, the computed remaining budget comes out slightly too generous, and the real request can end up a handful of tokens over the window, triggering the same class of `400` the clamp is meant to prevent.

## Fix

- Added a `conservative` parameter (default `false`, backward compatible) to `estimatePromptTokens()`. When `true`, only the *new-content* term (`estimateContentTokens([userMessage])`) is inflated by `CONSERVATIVE_NEW_CONTENT_SAFETY_FACTOR = 1.5` — the API-authoritative `lastPromptTokenCount`/`lastOutputTokenCount` terms are left untouched, since they don't need padding.
- Passed `conservative: true` at the two call sites that feed `clampOutputTokensToWindow` (the steady-state `promptTokensForClamp` computation and the recovery-path `countBasedRecoveryEstimate`). Left the two earlier "cheap gate / should we compact at all" call sites unchanged — under-counting there is already documented as safe (it only makes compaction trigger a little earlier, never skips it).

## Verification

- Reproduced independently on 3 separate samples, including one from a different CLI client entirely (OpenCode) hitting the same self-hosted backend — same "~1 token over window" signature each time.
- `tokenEstimation.test.ts`: added a `conservative mode` test suite (3 tests), including one reproducing the real CJK-undercount scenario with a synthetic Chinese-heavy `functionResponse`.
- `geminiChat.test.ts`: 2 existing tests' expected `maxOutputTokens` bumped by 1 (19999→19998, 49722→49721) to reflect the inflation on tiny messages (e.g. "hi"), with comments explaining why.
- Full end-to-end CLI verification (combined with the fix in #7962): 27 turns / ~53.8 min / ~1.12M tokens, zero recurrence.

## Screenshot / Demo

N/A — no user-facing change. This adjusts an internal token-budget safety margin (`estimatePromptTokens`'s conservative mode); there is no new command, flag, or visible CLI behavior to demonstrate. See the Verification section above for the reproduction cases and updated test expectations.

## Notes for reviewers

- The 1.5x factor is a starting point, not derived from a rigorous CJK-tokenization ratio study — happy to tune it (or switch to a proper tokenizer-based estimate) based on maintainer input.

