### PR TITLE
feat(triage): make the not-verified sentence a mechanical 2b-bis trigger

### DIFF
--- a/.qwen/skills/triage/references/pr-workflow.md
+++ b/.qwen/skills/triage/references/pr-workflow.md
@@ -499,6 +499,20 @@ skipped. The value is in naming what is currently **unsubstantiated**; a
 reader who disagrees with that assessment can ignore the line, which is a
 better outcome than never seeing it.
 
+**Text trigger — this rule is mechanical, not a judgement call.** Before
+posting, grep your own draft. If your comment contains a sentence of the
+shape "not verified …", "author tested on <one platform> only", "author's
+claim, not independently re-run", or any other admission that a behavioural
+claim rests on the author's word or a single environment — **that sentence
+is the trigger.** You have already written down the gap; the 2b-bis line is
+the same sentence with the remedy attached, and omitting it means telling
+the maintainer what is missing while withholding the one command that would
+supply it. "CI is still running" does not lift the trigger: a green suite
+proves the tests pass, not that the untested behaviour holds. (Real miss
+this rule exists for: a serve-side bounded-read change whose own Stage 2
+comment said "author tested on macOS only" and never named a lane — the
+gap was written down and the remedy was not.)
+
 **Skip it — explicitly — in exactly two cases:**
 
 - **No behavioural claim to settle**: docs, types, pure refactor with an

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -553,6 +553,42 @@ describe('qwen-triage tmux workflow', () => {
     expect(order).toContain('not an enrichment');
   });
 
+  it('makes the not-verified sentence a mechanical 2b-bis trigger', () => {
+    // Post-merge measurement of #7917 (2026-07-29): 9 eligible PRs, two
+    // considered-and-declined mentions, zero positive recommendations — and
+    // the one clear behavioural candidate (#7947, bounded reads) wrote
+    // "author tested on macOS only" in its own Stage 2 comment and never
+    // named a lane. The judgement-based rule ("when 2b cannot settle it")
+    // failed exactly where the comment had already written the gap down. So
+    // the trigger is now textual: the draft's own admission is the trigger,
+    // and pending CI does not lift it.
+    const section = prSkill
+      .slice(
+        prSkill.indexOf('#### 2b-bis.'),
+        prSkill.indexOf('#### 2c. Real-Scenario'),
+      )
+      .replace(/\s+/g, ' ');
+    expect(section).toContain('mechanical, not a judgement call');
+    expect(section).toContain('grep your own draft');
+    // The trigger phrases are the ones real comments actually emit — the
+    // first two are verbatim from #7947's and #7951's Stage 2 comments.
+    expect(section).toContain('not verified');
+    expect(section).toContain('author tested on <one platform> only');
+    expect(section).toContain('not independently re-run');
+    // Pending CI must not lift the trigger: #7947's likely out was "the
+    // ubuntu Test job is still in progress".
+    expect(section).toContain('"CI is still running" does not lift');
+    // The mechanical rule must sit BEFORE the skip cases, or the skip cases
+    // read as outs from it rather than the other way around.
+    expect(section.indexOf('mechanical, not a judgement call')).toBeLessThan(
+      section.indexOf('Skip it — explicitly'),
+    );
+    // And the skip cases themselves must survive — the trigger tightens the
+    // rule, it does not replace the two legitimate outs.
+    expect(section).toContain('No behavioural claim to settle');
+    expect(section).toContain('The author lacks write access');
+  });
+
   it('names /verify on the high-risk paths, not just tmux', () => {
     // 1e is the strongest triage-time signal in the skill (10 of 31 reverted
     // PRs touched these paths vs 5 of 60 controls, p = 0.006) — and it used


### PR DESCRIPTION
## What this PR does

Turns the 2b-bis sandboxed-lane recommendation from a judgement call into a text-triggered rule: **if the Stage 2 draft itself contains a "not verified / author tested on one platform only" sentence, that sentence is the trigger.**

### The measurement that motivated it

#7917 merged 2026-07-28T14:28Z. Re-running its own acceptance criterion one day later, on every Stage 2 comment posted since the merge (write-access authors only):

| | pre-merge baseline | post-merge |
| --- | --- | --- |
| eligible PRs | 16 | 9 |
| lane mentioned | 1 | 2 |
| **positive recommendation** | — | **0** |

The two mentions are both *considered-and-declined* — and both are correct calls (#7952 is a lockfile defect the diff itself disproves; #7951 is CI-workflow behaviour the product lanes cannot exercise). That is real progress over the baseline, where the section was simply never read.

But the one clear behavioural candidate in the window — **#7947, `fix(serve): allow bounded reads of large text files`** — wrote this in its own Stage 2 comment:

> Not verified: Windows and Linux manual runs (**author tested on macOS only**).

and never named a lane (grep count 0).

### Why this failure shape gets a rule and not more prose

The judgement-based condition — "when neither static review nor 2b substantiates it" — failed **exactly where the comment had already written the gap down in so many words.** The model plausibly judged that the still-running CI would substantiate the claim; a green suite proves the tests pass, not that the untested behaviour holds. No rewording of a judgement rule fixes a judgement failure. A text rule does:

> Before posting, grep your own draft. If your comment contains a sentence of the shape "not verified …", "author tested on \<one platform\> only", "author's claim, not independently re-run" — **that sentence is the trigger.** You have already written down the gap; the 2b-bis line is the same sentence with the remedy attached, and omitting it means telling the maintainer what is missing while withholding the one command that would supply it. "CI is still running" does not lift the trigger.

The trigger phrases are verbatim from real comments: "not verified" and "author tested on macOS only" from #7947, "author's claim, not independently re-run" from #7951.

The two legitimate skip cases (nothing behavioural to settle; author lacks write) are unchanged, and the rule is placed **before** them, so they read as outs from the requirement rather than the requirement as an out from them.

## Why it's needed

The point of #7917 was that a maintainer cannot act on a line that was never written. The post-merge data shows the line is now *considered* but still not *written* where it matters most — on the PR whose own comment admits the gap. This closes that residual, mechanically.

## Reviewer Test Plan

### How to verify

The test pins the rule's presence, its trigger phrases, the pending-CI clause, and its **position before the skip cases** — position is load-bearing, because a rule placed after the outs reads as subordinate to them.

**Mutation-verified 3/3**, each with landing proof before the result was read:

| # | mutation | landing proof | result |
| - | -------- | ------------- | ------ |
| 1 | drop the trigger paragraph | marker absent | `to contain 'mechanical, not a judgement call'` |
| 2 | move it after the skip cases | index comparison flips | `expected 2484 to be less than 1818` |
| 3 | drop only the pending-CI sentence | marker absent | `to contain '"CI is still running" does not lift'` |

89/89 tests pass (the two proxy-watchdog timeouts are gone from `main` since #7858 merged); prettier and eslint clean. Prose assertions are whitespace-normalised, same as the sibling tests, so a prettier re-wrap cannot redden them.

### Evidence (Before & After)

Before — #7947's Stage 2 comment, the miss this rule exists for:

> Not verified: Windows and Linux manual runs (author tested on macOS only). The `Test (ubuntu-latest)` job is still in progress …

(no lane named anywhere in the comment)

After — the same draft self-triggers, and the required line is the admission with the remedy attached:

> Sandboxed verification would settle this: `@qwen-code /verify` — bounded reads of large text files are verified on macOS only, by the author; the unit suite does not exercise the size-cap path against a real large file, and a green CI will not change that.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

Skill text and its tests; no platform-dependent behaviour.

## Risk & Scope

- **Main risk or tradeoff:** n=1 is thin evidence for changing a behavioural rule — one day of post-merge data, one clear miss. The reason to move now anyway: **this rule is text-matching, not probability-weighing, so it cannot overfit to the sample that motivated it.** The failure mode it adds (an unnecessary 2b-bis line on a PR whose "not verified" sentence covers something trivial) is the cheap direction — a maintainer can ignore a line, but cannot act on one never written.
- **Not validated / out of scope:** as with #7917, the tests pin the instruction, not the resulting agent behaviour. The acceptance check is the same measurement re-run after this merges; **#7947-shaped PRs (a written "not verified" admission with no lane named) are the class to count.** Auto-running `/verify` remains out of scope — unchanged from #7917's reasoning.
- **Breaking changes / migration notes:** none.

## Linked Issues

Follow-up to #7917 (its post-merge measurement is the motivation). Related to #7710. No issues closed.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

把 2b-bis 的沙箱车道推荐从**主观判断**改为**文本触发**的规则：**如果 Stage 2 评论草稿自己就写了"未验证 / 作者仅在单一平台测试"这类句子，那个句子本身就是触发器。**

### 促成本次改动的测量

#7917 于 2026-07-28T14:28Z 合入。一天后，按它自己写下的验收标准，对合入后发布的全部 Stage 2 评论（仅限有写权限的作者）重跑同一测量：

| | 合入前基线 | 合入后 |
| --- | --- | --- |
| 符合条件的 PR | 16 | 9 |
| 提及车道 | 1 | 2 |
| **正面推荐运行** | — | **0** |

那 2 次提及都是**「考虑后明确否决」**——且各自的判断是对的（#7952 是 diff 本身即可证伪的 lockfile 缺陷；#7951 是产品车道无法验证的 CI workflow 行为）。相比基线（该小节根本不被读到），这是真实的进步。

但窗口内唯一清晰的行为性候选——**#7947 `fix(serve): allow bounded reads of large text files`**——在自己的 Stage 2 评论里写着：

> Not verified: Windows and Linux manual runs (**author tested on macOS only**).

却从头到尾没有点名任何车道（grep 计数为 0）。

### 为什么这种失败形态需要一条规则而不是更多措辞

基于判断的条件——"当静态评审与 2b 都无法证实时"——**恰恰在评论已经把缺口白纸黑字写下来的地方失效了。** 模型大概率判断"还在跑的 CI 会证实它"；而绿色的测试套件只证明测试通过，不证明未测试的行为成立。判断规则的失效无法靠改写判断规则来修复，文本规则可以：

> 发布前，grep 你自己的草稿。若评论中含有"not verified …"、"author tested on \<one platform\> only"、"author's claim, not independently re-run"形态的句子——**那个句子就是触发器。** 你已经把缺口写下来了；2b-bis 那一行就是同一句话加上补救命令，省略它等于告诉维护者缺什么、却扣下唯一能补上它的命令。"CI 还在运行"不解除触发。

触发短语全部逐字取自真实评论：#7947 的 "not verified" 与 "author tested on macOS only"，#7951 的 "author's claim, not independently re-run"。

两个正当的跳过条件（无行为性主张可证；作者无写权限）保持不变，且规则被放在它们**之前**——让跳过条件读作规则的豁免，而不是让规则读作跳过条件的豁免。

## 为什么需要

#7917 的立意是：维护者无法根据一行从未被写出的字采取行动。合入后的数据显示，这行字现在会被**考虑**，却仍然没有在最需要的地方被**写出**——在那个自己的评论都承认了缺口的 PR 上。本 PR 以机械规则关闭这个残余缺口。

## 评审验证方案

测试钉住规则的存在、触发短语、pending-CI 条款、以及它**位于跳过条件之前**的位置——位置是承重的：放在豁免之后的规则读起来就从属于豁免。

**3/3 变异验证**，每项在读取结果前先证明改动落地：删除触发段落（标记消失 → `to contain 'mechanical, not a judgement call'`）；移到跳过条件之后（索引比较翻转 → `expected 2484 to be less than 1818`）；仅删除 pending-CI 句（标记消失 → `to contain '"CI is still running" does not lift'`）。

89/89 测试通过（#7858 合入后 `main` 上那两条 proxy-watchdog 超时已消失）；prettier 与 eslint 干净。散文断言与同类测试一样做了空白归一化，prettier 重排不会使其变红。

### 测试平台

macOS ✅；Windows N/A；Linux N/A——skill 文本及其测试，无平台相关行为。

## 风险与范围

- **主要权衡**：n=1 对行为规则改动而言证据偏薄——合入后仅一天数据、一次清晰漏判。仍然现在就动的理由：**该规则是文本匹配而非概率权衡，因此不会对促成它的那个样本过拟合。** 它新增的失败模式（在"not verified"句子涉及琐事的 PR 上多一行 2b-bis）是代价低的方向——维护者可以忽略一行字，却无法根据一行从未被写出的字行动。
- **未验证/范围外**：与 #7917 相同，测试钉住的是指令而非 agent 的实际行为。验收方式是合入后重跑同一测量；**要数的正是 #7947 形态的 PR（评论写下了"not verified"的承认、却没有点名车道）。** 自动运行 `/verify` 依旧不在范围内——理由与 #7917 不变。
- **破坏性变更**：无。

## 关联 Issue

#7917 的后续（其合入后测量即本 PR 的动机）。与 #7710 相关。不关闭任何 issue。

</details>
