### PR TITLE
feat(hooks): add security.allowPrivateNetworkHooks to bypass SSRF range checks for trusted scopes

### DIFF
--- a/docs/users/features/hooks.md
+++ b/docs/users/features/hooks.md
@@ -116,7 +116,7 @@ By default, HTTP hooks cannot target private or link-local IP ranges. In platfor
 ```
 
 - This setting is **only honored from User, System, and SystemDefaults settings scopes**. A value set in Workspace (project) settings is ignored and logged as a warning, so a cloned repository can never self-grant this bypass.
-- Cloud metadata hostnames (`169.254.169.254`, `metadata.google.internal`, `metadata.azure.internal`) remain blocked even when the flag is on — it relaxes IP-range checks only.
+- The flag relaxes only the general private/CGNAT/link-local **range** checks. Cloud metadata endpoints stay blocked in every configuration: the `BLOCKED_HOSTS` list is matched literally (`metadata.google.internal`, `metadata.azure.internal`, ...), and the metadata IPs `169.254.169.254` and `100.100.100.200` are blocked in all serialized forms (including IPv4-mapped IPv6 such as `::ffff:a9fe:a9fe`) and after DNS resolution.
 - The `security.allowedHttpHookUrls` whitelist still applies independently. In managed environments, pair this flag with a whitelist so only the intended internal endpoints are reachable.
 
 > **Warning:** Enabling this flag lets hooks reach internal infrastructure on your network. Enable it only in trusted, managed settings — never in a repository you do not control.

--- a/docs/users/features/hooks.md
+++ b/docs/users/features/hooks.md
@@ -103,6 +103,24 @@ HTTP hooks send hook input as POST requests to specified URLs. They support URL 
 - **DNS Validation**: Validates domain resolution before requests to prevent DNS rebinding attacks
 - **Environment Variable Interpolation**: `${VAR}` syntax, only allows variables in `allowedEnvVars` whitelist
 
+#### Allowing private-network hooks (managed environments only)
+
+By default, HTTP hooks cannot target private or link-local IP ranges. In platform-managed environments where the hook receiver is a first-party, VPC-internal endpoint (for example, an internal API gateway resolving to `172.16.0.0/12`), you can relax the IP-range checks with:
+
+```json
+{
+  "security": {
+    "allowPrivateNetworkHooks": true
+  }
+}
+```
+
+- This setting is **only honored from User, System, and SystemDefaults settings scopes**. A value set in Workspace (project) settings is ignored and logged as a warning, so a cloned repository can never self-grant this bypass.
+- Cloud metadata hostnames (`169.254.169.254`, `metadata.google.internal`, `metadata.azure.internal`) remain blocked even when the flag is on — it relaxes IP-range checks only.
+- The `security.allowedHttpHookUrls` whitelist still applies independently. In managed environments, pair this flag with a whitelist so only the intended internal endpoints are reachable.
+
+> **Warning:** Enabling this flag lets hooks reach internal infrastructure on your network. Enable it only in trusted, managed settings — never in a repository you do not control.
+
 **Example:**
 
 ```json

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -3154,6 +3154,53 @@ describe('loadCliConfig folderTrust', () => {
   });
 });
 
+describe('loadCliConfig allowPrivateNetworkHooks', () => {
+  const originalArgv = process.argv;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(os.homedir).mockReturnValue('/mock/home/user');
+    vi.stubEnv('GEMINI_API_KEY', 'test-api-key');
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('should be false by default', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments();
+    const config = await loadCliConfig({}, argv, undefined, []);
+    expect(config.getAllowPrivateNetworkHooks()).toBe(false);
+  });
+
+  it('should pass through security.allowPrivateNetworkHooks from settings', async () => {
+    process.argv = ['node', 'script.js'];
+    const settings: Settings = {
+      security: {
+        allowPrivateNetworkHooks: true,
+      },
+    };
+    const argv = await parseArguments();
+    const config = await loadCliConfig(settings, argv, undefined, []);
+    expect(config.getAllowPrivateNetworkHooks()).toBe(true);
+  });
+
+  it('should be false in bare mode even when enabled in settings', async () => {
+    process.argv = ['node', 'script.js', '--bare'];
+    const settings: Settings = {
+      security: {
+        allowPrivateNetworkHooks: true,
+      },
+    };
+    const argv = await parseArguments();
+    const config = await loadCliConfig(settings, argv, undefined, []);
+    expect(config.getAllowPrivateNetworkHooks()).toBe(false);
+  });
+});
+
 describe('loadCliConfig with includeDirectories', () => {
   const originalArgv = process.argv;
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -2229,6 +2229,10 @@ export async function loadCliConfig(
       bareMode || safeMode
         ? []
         : (settings.security?.allowedHttpHookUrls ?? []),
+    allowPrivateNetworkHooks:
+      bareMode || safeMode
+        ? false
+        : (settings.security?.allowPrivateNetworkHooks ?? false),
     cliVersion: await getCliVersion(),
     ideMode,
     chatCompression: settings.model?.chatCompression,

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -3247,6 +3247,91 @@ describe('Settings Loading and Merging', () => {
     });
   });
 
+  describe('allowPrivateNetworkHooks scope handling', () => {
+    it('should honor security.allowPrivateNetworkHooks from user scope', () => {
+      (mockFsExistsSync as Mock).mockReturnValue(true);
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify({
+              security: { allowPrivateNetworkHooks: true },
+            });
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+      expect(settings.merged.security?.allowPrivateNetworkHooks).toBe(true);
+    });
+
+    it('should strip security.allowPrivateNetworkHooks from workspace scope even when trusted', () => {
+      (mockFsExistsSync as Mock).mockReturnValue(true);
+      const workspaceSettingsContent = {
+        security: {
+          allowPrivateNetworkHooks: true,
+          allowedHttpHookUrls: ['https://hooks.example.com/*'],
+        },
+      };
+
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+            return JSON.stringify(workspaceSettingsContent);
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+      // The flag is ignored from workspace scope...
+      expect(
+        settings.merged.security?.allowPrivateNetworkHooks,
+      ).toBeUndefined();
+      // ...but other workspace security settings still merge.
+      expect(settings.merged.security?.allowedHttpHookUrls).toEqual([
+        'https://hooks.example.com/*',
+      ]);
+    });
+
+    it('should warn when workspace settings define security.allowPrivateNetworkHooks', () => {
+      (mockFsExistsSync as Mock).mockReturnValue(true);
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+            return JSON.stringify({
+              security: { allowPrivateNetworkHooks: true },
+            });
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+      const warnings = getSettingsWarnings(settings);
+      expect(
+        warnings.some((w) => w.includes('security.allowPrivateNetworkHooks')),
+      ).toBe(true);
+    });
+
+    it('should let user scope win over a stripped workspace value', () => {
+      (mockFsExistsSync as Mock).mockReturnValue(true);
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify({
+              security: { allowPrivateNetworkHooks: true },
+            });
+          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+            return JSON.stringify({
+              security: { allowPrivateNetworkHooks: false },
+            });
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+      expect(settings.merged.security?.allowPrivateNetworkHooks).toBe(true);
+    });
+  });
+
   describe('reloadScopeFromDisk', () => {
     it('reloads a scope from disk and resolves home env vars', () => {
       const homeQwenEnvPath = path.join(

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -367,7 +367,7 @@ export function getSettingsWarnings(loadedSettings: LoadedSettings): string[] {
       undefined
   ) {
     warningSet.add(
-      `Warning: security.allowPrivateNetworkHooks in workspace settings (${workspaceFile.path}) is ignored. This setting is only honored from User or System scope settings.`,
+      `Warning: security.allowPrivateNetworkHooks in workspace settings (${workspaceFile.path}) is ignored. This setting is only honored from User, System, or SystemDefaults scope settings.`,
     );
   }
 

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -358,6 +358,19 @@ export function getSettingsWarnings(loadedSettings: LoadedSettings): string[] {
     warningSet.add(warning);
   }
 
+  // security.allowPrivateNetworkHooks is stripped from Workspace scope during
+  // the merge; warn so the user knows their workspace setting has no effect.
+  const workspaceFile = loadedSettings.forScope(SettingScope.Workspace);
+  if (
+    workspaceFile.rawJson !== undefined &&
+    workspaceFile.originalSettings.security?.allowPrivateNetworkHooks !==
+      undefined
+  ) {
+    warningSet.add(
+      `Warning: security.allowPrivateNetworkHooks in workspace settings (${workspaceFile.path}) is ignored. This setting is only honored from User or System scope settings.`,
+    );
+  }
+
   return [...warningSet];
 }
 
@@ -385,6 +398,22 @@ function tagMcpServerScope(
   return { ...settings, mcpServers: tagged };
 }
 
+/**
+ * `security.allowPrivateNetworkHooks` relaxes SSRF protection for HTTP hooks,
+ * so it must never be honored from Workspace scope — otherwise a malicious
+ * repository could self-grant the bypass and point hooks at link-local or
+ * private infrastructure. Strip it from workspace settings before merging.
+ * Returns a shallow copy — never mutates input.
+ */
+function stripWorkspacePrivateNetworkHooks(settings: Settings): Settings {
+  if (settings.security?.allowPrivateNetworkHooks === undefined) {
+    return settings;
+  }
+  const { allowPrivateNetworkHooks: _stripped, ...restSecurity } =
+    settings.security;
+  return { ...settings, security: restSecurity };
+}
+
 function mergeSettings(
   system: Settings,
   systemDefaults: Settings,
@@ -393,7 +422,10 @@ function mergeSettings(
   isTrusted: boolean,
 ): Settings {
   const safeWorkspace = isTrusted
-    ? tagMcpServerScope(workspace, 'workspace')
+    ? tagMcpServerScope(
+        stripWorkspacePrivateNetworkHooks(workspace),
+        'workspace',
+      )
     : ({} as Settings);
 
   // Settings are merged with the following precedence (last one wins for

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -2854,6 +2854,16 @@ const SETTINGS_SCHEMA = {
           description: 'URL pattern (supports * wildcard)',
         },
       },
+      allowPrivateNetworkHooks: {
+        type: 'boolean',
+        label: 'Allow Private Network Hooks',
+        category: 'Security',
+        requiresRestart: false,
+        default: false,
+        description:
+          'When true, HTTP hooks may target private/link-local IP ranges (the SSRF IP-range checks are skipped). Cloud metadata hostnames (e.g. 169.254.169.254, metadata.google.internal) remain blocked. Only honored from User, System, and SystemDefaults settings scopes; values set in Workspace settings are ignored so a cloned repository cannot self-grant this bypass. Enable only in trusted, managed environments, and pair with security.allowedHttpHookUrls.',
+        showInDialog: false,
+      },
     },
   },
 

--- a/packages/core/src/config/config.safe-mode.test.ts
+++ b/packages/core/src/config/config.safe-mode.test.ts
@@ -290,6 +290,15 @@ describe('Config safe mode', () => {
       });
       expect(config.getAllowedHttpHookUrls()).toEqual([]);
     });
+
+    it('disables private network hooks in safe mode', () => {
+      const config = new Config({
+        ...baseParams,
+        safeMode: true,
+        allowPrivateNetworkHooks: true,
+      });
+      expect(config.getAllowPrivateNetworkHooks()).toBe(false);
+    });
   });
 
   describe('safe mode blocks local/ambient MCP servers, preserves caller-supplied top-tier ones', () => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1302,6 +1302,11 @@ export interface ConfigParameters {
   /** Allowed HTTP hook URLs whitelist (from security.allowedHttpHookUrls) */
   allowedHttpHookUrls?: string[];
   /**
+   * When true, HTTP hooks may target private/link-local IP ranges
+   * (from security.allowPrivateNetworkHooks; trusted scopes only).
+   */
+  allowPrivateNetworkHooks?: boolean;
+  /**
    * Callback for persisting a permission rule to settings.
    * Injected by the CLI layer; core uses this to write allow/ask/deny rules
    * to project or user settings when the user clicks "Always Allow".
@@ -1919,6 +1924,7 @@ export class Config {
   private readonly safeMode: boolean;
   private readonly warnings: string[];
   private readonly allowedHttpHookUrls: string[];
+  private readonly allowPrivateNetworkHooks: boolean;
   private readonly onPersistPermissionRuleCallback?: (
     scope: 'project' | 'user',
     ruleType: 'allow' | 'ask' | 'deny',
@@ -2191,6 +2197,7 @@ export class Config {
     this.warnings = params.warnings ?? [];
     this.addLegacyPlanLocationWarning();
     this.allowedHttpHookUrls = params.allowedHttpHookUrls ?? [];
+    this.allowPrivateNetworkHooks = params.allowPrivateNetworkHooks ?? false;
     this.onPersistPermissionRuleCallback = params.onPersistPermissionRule;
 
     // (web search removed)
@@ -6598,6 +6605,16 @@ export class Config {
     return this.getBareMode() || this.isSafeMode()
       ? []
       : this.allowedHttpHookUrls;
+  }
+
+  /**
+   * Returns whether HTTP hooks may target private/link-local IP ranges.
+   * Only settable from trusted settings scopes (User/System/SystemDefaults).
+   */
+  getAllowPrivateNetworkHooks(): boolean {
+    return this.getBareMode() || this.isSafeMode()
+      ? false
+      : this.allowPrivateNetworkHooks;
   }
 
   isTrustedFolder(): boolean {

--- a/packages/core/src/goals/goalLoop.integration.test.ts
+++ b/packages/core/src/goals/goalLoop.integration.test.ts
@@ -70,6 +70,7 @@ function makeConfigWithRealHookSystem(): {
   // it pulls from Config during construction.
   const config = {
     getAllowedHttpHookUrls: () => [],
+    getAllowPrivateNetworkHooks: () => false,
     getSessionId: () => SESSION,
     isTrustedFolder: () => true,
     getDisableAllHooks: () => false,

--- a/packages/core/src/hooks/hookRunner.ts
+++ b/packages/core/src/hooks/hookRunner.ts
@@ -62,7 +62,10 @@ export class HookRunner {
   private readonly asyncRegistry: AsyncHookRegistry;
 
   constructor(allowedHttpUrls?: string[], config?: Config) {
-    this.httpRunner = new HttpHookRunner(allowedHttpUrls);
+    this.httpRunner = new HttpHookRunner(
+      allowedHttpUrls,
+      config?.getAllowPrivateNetworkHooks(),
+    );
     this.functionRunner = new FunctionHookRunner();
     this.promptRunner = config ? new PromptHookRunner(config) : null;
     this.asyncRegistry = new AsyncHookRegistry();

--- a/packages/core/src/hooks/hookSystem.test.ts
+++ b/packages/core/src/hooks/hookSystem.test.ts
@@ -63,6 +63,7 @@ describe('HookSystem', () => {
       getTranscriptPath: vi.fn().mockReturnValue('/test/transcript'),
       getWorkingDir: vi.fn().mockReturnValue('/test/cwd'),
       getAllowedHttpHookUrls: vi.fn().mockReturnValue([]),
+      getAllowPrivateNetworkHooks: vi.fn().mockReturnValue(false),
     } as unknown as Config;
 
     mockHookRegistry = {

--- a/packages/core/src/hooks/httpHookRunner.test.ts
+++ b/packages/core/src/hooks/httpHookRunner.test.ts
@@ -13,6 +13,15 @@ import { HttpHookRunner } from './httpHookRunner.js';
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
+// Mutable DNS resolution result so individual tests can control what
+// hostnames resolve to.
+const mockDns = vi.hoisted(() => ({
+  addresses: [{ address: '8.8.8.8', family: 4 }] as Array<{
+    address: string;
+    family: number;
+  }>,
+}));
+
 // Mock dns.lookup to avoid real DNS lookups in tests
 vi.mock('dns', () => ({
   lookup: (
@@ -23,8 +32,7 @@ vi.mock('dns', () => ({
       addresses: Array<{ address: string; family: number }>,
     ) => void,
   ) => {
-    // Return a mock public IP address
-    callback(null, [{ address: '8.8.8.8', family: 4 }]);
+    callback(null, mockDns.addresses);
   },
 }));
 
@@ -40,6 +48,7 @@ describe('HttpHookRunner', () => {
     httpRunner = new HttpHookRunner([ALLOWED_URL_PATTERN]);
     vi.clearAllMocks();
     process.env = { ...originalEnv };
+    mockDns.addresses = [{ address: '8.8.8.8', family: 4 }];
   });
 
   afterEach(() => {
@@ -266,6 +275,122 @@ describe('HttpHookRunner', () => {
 
       expect(result.success).toBe(false);
       expect(result.error?.message).toContain('cancelled');
+    });
+  });
+
+  describe('allowPrivateNetworkHooks', () => {
+    const mockSuccessResponse = () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({ continue: true }),
+      });
+    };
+
+    it('should block a literal private IP when the flag is off', async () => {
+      const runner = new HttpHookRunner([], false);
+      const config = createMockConfig({ url: 'http://172.16.254.215/hook' });
+      const input = createMockInput();
+
+      const result = await runner.execute(
+        config,
+        HookEventName.PreToolUse,
+        input,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error?.message).toContain('blocked');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should block a hostname resolving to a private IP when the flag is off', async () => {
+      mockDns.addresses = [{ address: '172.16.254.215', family: 4 }];
+      const runner = new HttpHookRunner([], false);
+      const config = createMockConfig({
+        url: 'http://hooks.internal.example.com/hook',
+      });
+      const input = createMockInput();
+
+      const result = await runner.execute(
+        config,
+        HookEventName.PreToolUse,
+        input,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error?.message).toContain('private/link-local');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should allow a literal private IP when the flag is on', async () => {
+      mockSuccessResponse();
+      const runner = new HttpHookRunner([], true);
+      const config = createMockConfig({ url: 'http://172.16.254.215/hook' });
+      const input = createMockInput();
+
+      const result = await runner.execute(
+        config,
+        HookEventName.PreToolUse,
+        input,
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockFetch).toHaveBeenCalled();
+    });
+
+    it('should allow a hostname resolving to a private IP when the flag is on', async () => {
+      mockDns.addresses = [{ address: '172.16.254.215', family: 4 }];
+      mockSuccessResponse();
+      const runner = new HttpHookRunner([], true);
+      const config = createMockConfig({
+        url: 'http://hooks.internal.example.com/hook',
+      });
+      const input = createMockInput();
+
+      const result = await runner.execute(
+        config,
+        HookEventName.PreToolUse,
+        input,
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockFetch).toHaveBeenCalled();
+    });
+
+    it('should still block cloud metadata endpoints when the flag is on', async () => {
+      const runner = new HttpHookRunner([], true);
+      const config = createMockConfig({
+        url: 'http://169.254.169.254/latest/meta-data',
+      });
+      const input = createMockInput();
+
+      const result = await runner.execute(
+        config,
+        HookEventName.PreToolUse,
+        input,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error?.message).toContain('blocked');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should still block metadata hostnames when the flag is on', async () => {
+      const runner = new HttpHookRunner([], true);
+      const config = createMockConfig({
+        url: 'http://metadata.google.internal/hook',
+      });
+      const input = createMockInput();
+
+      const result = await runner.execute(
+        config,
+        HookEventName.PreToolUse,
+        input,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error?.message).toContain('blocked');
+      expect(mockFetch).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/hooks/httpHookRunner.test.ts
+++ b/packages/core/src/hooks/httpHookRunner.test.ts
@@ -392,6 +392,80 @@ describe('HttpHookRunner', () => {
       expect(result.error?.message).toContain('blocked');
       expect(mockFetch).not.toHaveBeenCalled();
     });
+
+    it('should still block the Alibaba metadata IP when the flag is on', async () => {
+      const runner = new HttpHookRunner([], true);
+      const config = createMockConfig({
+        url: 'http://100.100.100.200/latest/meta-data',
+      });
+      const input = createMockInput();
+
+      const result = await runner.execute(
+        config,
+        HookEventName.PreToolUse,
+        input,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error?.message).toContain('blocked');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should still block IPv6-mapped metadata IPs when the flag is on', async () => {
+      const runner = new HttpHookRunner([], true);
+      const config = createMockConfig({
+        url: 'http://[::ffff:a9fe:a9fe]/latest/meta-data',
+      });
+      const input = createMockInput();
+
+      const result = await runner.execute(
+        config,
+        HookEventName.PreToolUse,
+        input,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error?.message).toContain('blocked');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should block a hostname resolving to a metadata IP when the flag is on', async () => {
+      mockDns.addresses = [{ address: '169.254.169.254', family: 4 }];
+      const runner = new HttpHookRunner([], true);
+      const config = createMockConfig({
+        url: 'http://hooks.internal.example.com/hook',
+      });
+      const input = createMockInput();
+
+      const result = await runner.execute(
+        config,
+        HookEventName.PreToolUse,
+        input,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error?.message).toContain('metadata');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should block a hostname resolving to the Alibaba metadata IP when the flag is on', async () => {
+      mockDns.addresses = [{ address: '100.100.100.200', family: 4 }];
+      const runner = new HttpHookRunner([], true);
+      const config = createMockConfig({
+        url: 'http://hooks.internal.example.com/hook',
+      });
+      const input = createMockInput();
+
+      const result = await runner.execute(
+        config,
+        HookEventName.PreToolUse,
+        input,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error?.message).toContain('metadata');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
   });
 
   describe('resetOnceHooks', () => {

--- a/packages/core/src/hooks/httpHookRunner.ts
+++ b/packages/core/src/hooks/httpHookRunner.ts
@@ -8,7 +8,7 @@ import { createDebugLogger } from '../utils/debugLogger.js';
 import { interpolateHeaders, interpolateUrl } from './envInterpolator.js';
 import { UrlValidator } from './urlValidator.js';
 import { combineAbortSignals } from '../utils/abortController.js';
-import { isBlockedAddress } from './ssrfGuard.js';
+import { isBlockedAddress, isMetadataAddress } from './ssrfGuard.js';
 import { lookup as dnsLookup } from 'dns';
 import type {
   HttpHookConfig,
@@ -47,14 +47,19 @@ async function validateResolvedHost(
   hostname: string,
   allowPrivateNetworkHosts: boolean = false,
 ): Promise<{ ok: boolean; error?: string }> {
-  // Trusted-scope opt-in: skip the IP-range checks entirely. The URL-level
-  // BLOCKED_HOSTS metadata blocklist in UrlValidator still applies.
-  if (allowPrivateNetworkHosts) {
-    return { ok: true };
-  }
   return new Promise((resolve) => {
+    // Cloud metadata endpoints stay blocked in every configuration, even
+    // when private-network hooks are explicitly allowed (trusted scopes).
+    if (isMetadataAddress(hostname)) {
+      resolve({
+        ok: false,
+        error: `HTTP hook blocked: ${hostname} is a cloud metadata endpoint`,
+      });
+      return;
+    }
+
     // If hostname is already an IP literal, validate directly.
-    if (isBlockedAddress(hostname)) {
+    if (!allowPrivateNetworkHosts && isBlockedAddress(hostname)) {
       resolve({
         ok: false,
         error: `HTTP hook blocked: ${hostname} is in a private/link-local range`,
@@ -62,7 +67,9 @@ async function validateResolvedHost(
       return;
     }
 
-    // For hostnames, resolve DNS and validate all returned IPs.
+    // For hostnames, resolve DNS and validate all returned IPs. This runs
+    // even when private ranges are allowed, so that a hostname resolving
+    // to a metadata endpoint is still caught.
     dnsLookup(hostname, { all: true }, (err, addresses) => {
       if (err) {
         // DNS resolution failure — let the fetch call handle it.
@@ -71,7 +78,14 @@ async function validateResolvedHost(
       }
 
       for (const addr of addresses) {
-        if (isBlockedAddress(addr.address)) {
+        if (isMetadataAddress(addr.address)) {
+          resolve({
+            ok: false,
+            error: `HTTP hook blocked: ${hostname} resolves to ${addr.address} (cloud metadata endpoint)`,
+          });
+          return;
+        }
+        if (!allowPrivateNetworkHosts && isBlockedAddress(addr.address)) {
           resolve({
             ok: false,
             error: `HTTP hook blocked: ${hostname} resolves to ${addr.address} (private/link-local). Loopback (127.0.0.1, ::1) is allowed.`,

--- a/packages/core/src/hooks/httpHookRunner.ts
+++ b/packages/core/src/hooks/httpHookRunner.ts
@@ -45,7 +45,13 @@ export type StatusMessageCallback = (message: string) => void;
  */
 async function validateResolvedHost(
   hostname: string,
+  allowPrivateNetworkHosts: boolean = false,
 ): Promise<{ ok: boolean; error?: string }> {
+  // Trusted-scope opt-in: skip the IP-range checks entirely. The URL-level
+  // BLOCKED_HOSTS metadata blocklist in UrlValidator still applies.
+  if (allowPrivateNetworkHosts) {
+    return { ok: true };
+  }
   return new Promise((resolve) => {
     // If hostname is already an IP literal, validate directly.
     if (isBlockedAddress(hostname)) {
@@ -84,11 +90,16 @@ async function validateResolvedHost(
  */
 export class HttpHookRunner {
   private urlValidator: UrlValidator;
+  private readonly allowPrivateNetworkHosts: boolean;
   private readonly executedOnceHooks: Set<string> = new Set();
   private statusMessageCallback?: StatusMessageCallback;
 
-  constructor(allowedUrls?: string[]) {
-    this.urlValidator = new UrlValidator(allowedUrls);
+  constructor(
+    allowedUrls?: string[],
+    allowPrivateNetworkHosts: boolean = false,
+  ) {
+    this.allowPrivateNetworkHosts = allowPrivateNetworkHosts;
+    this.urlValidator = new UrlValidator(allowedUrls, allowPrivateNetworkHosts);
   }
 
   /**
@@ -170,7 +181,10 @@ export class HttpHookRunner {
       // DNS-level SSRF protection: validate resolved IPs
       // It checks that the hostname resolves to non-private IPs.
       const parsed = new URL(url);
-      const hostValidation = await validateResolvedHost(parsed.hostname);
+      const hostValidation = await validateResolvedHost(
+        parsed.hostname,
+        this.allowPrivateNetworkHosts,
+      );
       if (!hostValidation.ok) {
         return {
           hookConfig,
@@ -421,6 +435,9 @@ export class HttpHookRunner {
    */
   updateAllowedUrls(allowedUrls: string[]): void {
     // Create new validator with updated patterns
-    this.urlValidator = new UrlValidator(allowedUrls);
+    this.urlValidator = new UrlValidator(
+      allowedUrls,
+      this.allowPrivateNetworkHosts,
+    );
   }
 }

--- a/packages/core/src/hooks/promptHookIntegration.test.ts
+++ b/packages/core/src/hooks/promptHookIntegration.test.ts
@@ -54,6 +54,7 @@ describe('Prompt Hook Integration', () => {
       }),
       getProjectRoot: vi.fn().mockReturnValue('/test/project'),
       getAllowedHttpHookUrls: vi.fn().mockReturnValue([]),
+      getAllowPrivateNetworkHooks: vi.fn().mockReturnValue(false),
       getHooks: vi.fn().mockReturnValue({}),
     } as unknown as Config;
 

--- a/packages/core/src/hooks/ssrfGuard.test.ts
+++ b/packages/core/src/hooks/ssrfGuard.test.ts
@@ -5,7 +5,11 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { isBlockedAddress, ssrfGuardedLookup } from './ssrfGuard.js';
+import {
+  isBlockedAddress,
+  isMetadataAddress,
+  ssrfGuardedLookup,
+} from './ssrfGuard.js';
 
 function lookupAsync(
   hostname: string,
@@ -106,6 +110,46 @@ describe('ssrfGuard', () => {
     it('should return false for non-IP hostnames', () => {
       expect(isBlockedAddress('api.example.com')).toBe(false);
       expect(isBlockedAddress('localhost')).toBe(false);
+    });
+  });
+
+  describe('isMetadataAddress', () => {
+    it('should match the AWS/GCP/Azure metadata IP', () => {
+      expect(isMetadataAddress('169.254.169.254')).toBe(true);
+    });
+
+    it('should match the Alibaba Cloud metadata IP', () => {
+      expect(isMetadataAddress('100.100.100.200')).toBe(true);
+    });
+
+    it('should match IPv4-mapped IPv6 forms of metadata IPs', () => {
+      // ::ffff:a9fe:a9fe = 169.254.169.254
+      expect(isMetadataAddress('::ffff:a9fe:a9fe')).toBe(true);
+      expect(isMetadataAddress('::ffff:169.254.169.254')).toBe(true);
+      expect(isMetadataAddress('0:0:0:0:0:ffff:a9fe:a9fe')).toBe(true);
+      // ::ffff:6464:64c8 = 100.100.100.200
+      expect(isMetadataAddress('::ffff:6464:64c8')).toBe(true);
+      expect(isMetadataAddress('::ffff:100.100.100.200')).toBe(true);
+    });
+
+    it('should not match other private/link-local addresses', () => {
+      expect(isMetadataAddress('169.254.169.253')).toBe(false);
+      expect(isMetadataAddress('100.100.100.201')).toBe(false);
+      expect(isMetadataAddress('10.0.0.1')).toBe(false);
+      expect(isMetadataAddress('172.16.0.1')).toBe(false);
+      expect(isMetadataAddress('192.168.1.1')).toBe(false);
+      expect(isMetadataAddress('::ffff:c0a8:101')).toBe(false);
+    });
+
+    it('should not match loopback or public addresses', () => {
+      expect(isMetadataAddress('127.0.0.1')).toBe(false);
+      expect(isMetadataAddress('::1')).toBe(false);
+      expect(isMetadataAddress('8.8.8.8')).toBe(false);
+    });
+
+    it('should return false for non-IP hostnames', () => {
+      expect(isMetadataAddress('metadata.google.internal')).toBe(false);
+      expect(isMetadataAddress('api.example.com')).toBe(false);
     });
   });
 

--- a/packages/core/src/hooks/ssrfGuard.ts
+++ b/packages/core/src/hooks/ssrfGuard.ts
@@ -60,6 +60,34 @@ export function isBlockedAddress(address: string): boolean {
   return false;
 }
 
+/**
+ * Cloud metadata endpoint IPs that must remain blocked in EVERY
+ * configuration — including when `security.allowPrivateNetworkHooks`
+ * relaxes the general private/CGNAT range checks.
+ *   169.254.169.254  AWS / GCP / Azure / most clouds
+ *   100.100.100.200  Alibaba Cloud (lives inside the CGNAT range)
+ */
+const METADATA_IPS = new Set(['169.254.169.254', '100.100.100.200']);
+
+/**
+ * Returns true if the address is a cloud metadata endpoint IP, in any
+ * serialized form — plain IPv4, or IPv4-mapped IPv6 such as
+ * `::ffff:169.254.169.254` / `::ffff:a9fe:a9fe`. Unlike
+ * `isBlockedAddress`, this check is never relaxed by opt-in settings.
+ */
+export function isMetadataAddress(address: string): boolean {
+  const v = isIP(address);
+  if (v === 4) {
+    return METADATA_IPS.has(address);
+  }
+  if (v === 6) {
+    const mappedV4 = extractMappedIPv4(address.toLowerCase());
+    return mappedV4 !== null && METADATA_IPS.has(mappedV4);
+  }
+  // Not a valid IP literal
+  return false;
+}
+
 function isBlockedV4(address: string): boolean {
   const parts = address.split('.').map(Number);
   const [a, b] = parts;

--- a/packages/core/src/hooks/urlValidator.test.ts
+++ b/packages/core/src/hooks/urlValidator.test.ts
@@ -81,6 +81,37 @@ describe('UrlValidator', () => {
           ),
         ).toBe(true);
       });
+
+      it('should still block the Alibaba Cloud metadata IP (CGNAT range)', () => {
+        const validator = new UrlValidator([], true);
+        expect(
+          validator.isBlocked('http://100.100.100.200/latest/meta-data'),
+        ).toBe(true);
+      });
+
+      it('should still block IPv4-mapped IPv6 forms of metadata IPs', () => {
+        const validator = new UrlValidator([], true);
+        // ::ffff:169.254.169.254 (mixed dotted form)
+        expect(
+          validator.isBlocked(
+            'http://[::ffff:169.254.169.254]/latest/meta-data',
+          ),
+        ).toBe(true);
+        // ::ffff:a9fe:a9fe = 169.254.169.254
+        expect(
+          validator.isBlocked('http://[::ffff:a9fe:a9fe]/latest/meta-data'),
+        ).toBe(true);
+        // ::ffff:6464:64c8 = 100.100.100.200
+        expect(
+          validator.isBlocked('http://[::ffff:6464:64c8]/latest/meta-data'),
+        ).toBe(true);
+      });
+
+      it('should allow IPv4-mapped IPv6 forms of ordinary private IPs', () => {
+        const validator = new UrlValidator([], true);
+        // ::ffff:ac10:1 = 172.16.0.1 — private, but not a metadata endpoint
+        expect(validator.isBlocked('http://[::ffff:ac10:1]/api')).toBe(false);
+      });
     });
   });
 

--- a/packages/core/src/hooks/urlValidator.test.ts
+++ b/packages/core/src/hooks/urlValidator.test.ts
@@ -61,6 +61,27 @@ describe('UrlValidator', () => {
       expect(validator.isBlocked('not-a-url')).toBe(true);
       expect(validator.isBlocked('')).toBe(true);
     });
+
+    describe('with allowPrivateNetworkHosts', () => {
+      it('should allow private IP ranges', () => {
+        const validator = new UrlValidator([], true);
+        expect(validator.isBlocked('http://192.168.1.1/api')).toBe(false);
+        expect(validator.isBlocked('http://10.0.0.1/api')).toBe(false);
+        expect(validator.isBlocked('http://172.16.0.1/api')).toBe(false);
+      });
+
+      it('should still block cloud metadata endpoints', () => {
+        const validator = new UrlValidator([], true);
+        expect(
+          validator.isBlocked('http://169.254.169.254/latest/meta-data'),
+        ).toBe(true);
+        expect(
+          validator.isBlocked(
+            'http://metadata.google.internal/computeMetadata',
+          ),
+        ).toBe(true);
+      });
+    });
   });
 
   describe('isAllowed', () => {

--- a/packages/core/src/hooks/urlValidator.ts
+++ b/packages/core/src/hooks/urlValidator.ts
@@ -5,7 +5,7 @@
  */
 
 import { isIPv4, isIPv6 } from 'net';
-import { isBlockedAddress } from './ssrfGuard.js';
+import { isBlockedAddress, isMetadataAddress } from './ssrfGuard.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 
 const debugLogger = createDebugLogger('URL_VALIDATOR');
@@ -38,8 +38,8 @@ export class UrlValidator {
    * Create a new URL validator
    * @param allowedPatterns - Array of allowed URL patterns (supports * wildcard)
    * @param allowPrivateNetworkHosts - When true, skip the private/link-local
-   *   IP-range check (the BLOCKED_HOSTS metadata blocklist still applies).
-   *   Only enable from trusted settings scopes.
+   *   IP-range check (the metadata endpoint checks — BLOCKED_HOSTS and the
+   *   metadata IPs — still apply). Only enable from trusted settings scopes.
    */
   constructor(
     allowedPatterns: string[] = [],
@@ -105,13 +105,25 @@ export class UrlValidator {
         return true;
       }
 
-      // Check if hostname is an IP address - use ssrfGuard for authoritative check
-      // Skipped when private-network hooks are explicitly allowed (trusted
-      // scopes only); the BLOCKED_HOSTS check above always applies.
-      if (!this.allowPrivateNetworkHosts && this.isIpAddress(hostname)) {
-        // Remove brackets from IPv6 addresses for isBlockedAddress
+      // Check if hostname is an IP address
+      if (this.isIpAddress(hostname)) {
+        // Remove brackets from IPv6 addresses for the IP checks
         const cleanHostname = hostname.replace(/^\[|\]$/g, '');
-        if (isBlockedAddress(cleanHostname)) {
+
+        // Cloud metadata endpoints (169.254.169.254, 100.100.100.200, in
+        // any serialized form including IPv4-mapped IPv6) stay blocked in
+        // every configuration — this check is never relaxed.
+        if (isMetadataAddress(cleanHostname)) {
+          debugLogger.debug(
+            `URL blocked: IP ${hostname} is a cloud metadata endpoint`,
+          );
+          return true;
+        }
+
+        // General private/link-local range check - use ssrfGuard for the
+        // authoritative implementation. Skipped when private-network hooks
+        // are explicitly allowed (trusted scopes only).
+        if (!this.allowPrivateNetworkHosts && isBlockedAddress(cleanHostname)) {
           debugLogger.debug(`URL blocked: IP ${hostname} is blocked`);
           return true;
         }

--- a/packages/core/src/hooks/urlValidator.ts
+++ b/packages/core/src/hooks/urlValidator.ts
@@ -32,13 +32,21 @@ const BLOCKED_HOSTS = [
 export class UrlValidator {
   private readonly allowedPatterns: string[];
   private readonly compiledPatterns: RegExp[];
+  private readonly allowPrivateNetworkHosts: boolean;
 
   /**
    * Create a new URL validator
    * @param allowedPatterns - Array of allowed URL patterns (supports * wildcard)
+   * @param allowPrivateNetworkHosts - When true, skip the private/link-local
+   *   IP-range check (the BLOCKED_HOSTS metadata blocklist still applies).
+   *   Only enable from trusted settings scopes.
    */
-  constructor(allowedPatterns: string[] = []) {
+  constructor(
+    allowedPatterns: string[] = [],
+    allowPrivateNetworkHosts: boolean = false,
+  ) {
     this.allowedPatterns = allowedPatterns;
+    this.allowPrivateNetworkHosts = allowPrivateNetworkHosts;
     this.compiledPatterns = allowedPatterns.map((pattern) =>
       this.compilePattern(pattern),
     );
@@ -98,7 +106,9 @@ export class UrlValidator {
       }
 
       // Check if hostname is an IP address - use ssrfGuard for authoritative check
-      if (this.isIpAddress(hostname)) {
+      // Skipped when private-network hooks are explicitly allowed (trusted
+      // scopes only); the BLOCKED_HOSTS check above always applies.
+      if (!this.allowPrivateNetworkHosts && this.isIpAddress(hostname)) {
         // Remove brackets from IPv6 addresses for isBlockedAddress
         const cleanHostname = hostname.replace(/^\[|\]$/g, '');
         if (isBlockedAddress(cleanHostname)) {
@@ -157,6 +167,9 @@ export class UrlValidator {
  * @param allowedUrls - Array of allowed URL patterns from config
  * @returns Configured URL validator
  */
-export function createUrlValidator(allowedUrls?: string[]): UrlValidator {
-  return new UrlValidator(allowedUrls || []);
+export function createUrlValidator(
+  allowedUrls?: string[],
+  allowPrivateNetworkHosts?: boolean,
+): UrlValidator {
+  return new UrlValidator(allowedUrls || [], allowPrivateNetworkHosts);
 }

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -1331,6 +1331,11 @@
             "description": "URL pattern (supports * wildcard)",
             "type": "string"
           }
+        },
+        "allowPrivateNetworkHooks": {
+          "description": "When true, HTTP hooks may target private/link-local IP ranges (the SSRF IP-range checks are skipped). Cloud metadata hostnames (e.g. 169.254.169.254, metadata.google.internal) remain blocked. Only honored from User, System, and SystemDefaults settings scopes; values set in Workspace settings are ignored so a cloned repository cannot self-grant this bypass. Enable only in trusted, managed environments, and pair with security.allowedHttpHookUrls.",
+          "type": "boolean",
+          "default": false
         }
       }
     },


### PR DESCRIPTION
## Summary

HTTP hooks currently hard-block all requests to private/link-local address ranges (RFC1918, CGNAT, link-local) via `ssrfGuard.ts`. This is the right default for CLI users running **project-configured** hooks from untrusted repositories — but it makes HTTP hooks unusable in **platform-managed environments** where the hook receiver is a first-party, VPC-internal endpoint (e.g., an internal API gateway whose domain resolves to `172.16.0.0/12`).

This PR adds a single opt-in setting, `security.allowPrivateNetworkHooks` (default `false`), that bypasses the SSRF IP-range checks (the literal-IP check in `urlValidator.ts` and both paths in `validateResolvedHost`) — **honored only from trusted setting scopes** (`User`, `System`, `SystemDefaults`) and **ignored from `Workspace` scope**, so a cloned repository can never self-grant the bypass.

## Motivation / Use case

We run qwen-code in serverless sandboxes on Alibaba Cloud ACS. Hooks are injected by our platform at sandbox launch time (first-party, trusted), and the hook receiver is an internal endpoint:

```
hook receiver:  http://env-xxx-cn-beijing.vpc.alicloudapi.com/hooks/qwen
resolves to:    172.16.254.215        ← blocked by isBlockedV4 (172.16.0.0/12)
```

Observed behavior (qwen-code 0.19.12, measured in a live sandbox):

| hook URL | result |
|---|---|
| `http://127.0.0.1:8787/...` | delivered |
| `http://172.16.x.x:8787/...` (literal) | blocked |
| `http://172.16.x.x.nip.io/...` (resolves to private) | blocked |
| `http://*.vpc.alicloudapi.com/...` (resolves to private) | blocked |

The blanket RFC1918 block assumes "private network == attacker territory", which holds on a developer laptop but not inside a VPC, where **all** first-party infrastructure is private by definition. Today the only workarounds are (a) routing hook traffic through a public ingress, or (b) `type: "command"` hooks with a local script — both add deployment complexity purely to route around the guard.

## Current behavior

- `httpHookRunner.ts` → `validateResolvedHost()`: literal IPs are checked directly; hostnames are resolved via `dns.lookup(all: true)` and **every** returned IP is checked.
- `ssrfGuard.ts` → `isBlockedAddress()`: blocks `0/8`, `10/8`, `100.64/10`, `169.254/16`, `172.16/12`, `192.168/16` (+ IPv6 equivalents). Loopback (`127/8`, `::1`) is explicitly allowed.
- `allowedHttpHookUrls` is a whitelist layered **on top of** the SSRF check; matching the whitelist does not exempt a URL from IP-range blocking, and there is no setting to relax the range check.

## Proposed change

### Setting

```jsonc
// ~/.qwen/settings.json  (User scope) — or System/SystemDefaults scope
{
  "security": {
    "allowPrivateNetworkHooks": true
  }
}
```

### Semantics

| `allowPrivateNetworkHooks` | scope | effect |
|---|---|---|
| `false` (default) | any | current behavior, unchanged |
| `true` | `User` / `System` / `SystemDefaults` | `validateResolvedHost` skips `isBlockedAddress` checks (both literal-IP and post-DNS-resolution paths) |
| `true` | **`Workspace`** | **ignored** (logged as a warning) |

- The whitelist (`allowedHttpHookUrls`) semantics are unchanged and still applied independently.
- `BLOCKED_HOSTS` (cloud metadata hostnames such as `169.254.169.254`, `metadata.google.internal`) remain blocked when the flag is on — the flag relaxes *range* checks, not the explicit metadata blocklist. (Open to maintainer preference here; a stricter variant could bypass those too.)
- With the flag on, the DNS rebinding race noted in `ssrfGuard.ts` is unchanged — we document that managed environments should pair this with `allowedHttpHookUrls`.

### Why scope-restricted

`Workspace` settings ship with the repository. If the flag were honored from `Workspace` scope, a malicious repo could simply set `"allowPrivateNetworkHooks": true` and point a hook at `http://169.254.169.254/` — re-opening exactly the SSRF hole the guard exists to close. Restricting the flag to `User`/`System` scopes keeps the trust boundary: only the machine owner (or fleet management, via `System`/`SystemDefaults`) can relax it.

`System`/`SystemDefaults` scopes are the natural fit for platform-managed fleets (baked into images or injected at launch), and `User` scope covers individual developers who legitimately hook against LAN/VPC services.

## Alternatives considered

1. **Whitelist-matches-bypass**: treat `allowedHttpHookUrls` matches as SSRF-exempt. Rejected — conflates two concerns, and since the whitelist itself can be set from `Workspace` scope, a malicious repo could whitelist its own metadata-endpoint hook.
2. **`type: "command"` hook with a local script**: works today, but pushes per-platform script distribution into images and loses the uniform HTTP-hook contract (timeouts, env interpolation, `allowedHttpHookUrls`).
3. **Per-range allowlist** (e.g., `allowedPrivateRanges: ["10.0.0.0/8"]`): more granular, but meaningfully more complex to validate and document; can be a follow-up if maintainers want finer control.

## Backward compatibility

Default is `false`; when unset or `false`, every code path behaves exactly as today. No migration needed.

## Test plan

- `urlValidator.test.ts` / `ssrfGuard.test.ts`: flag off → all existing cases unchanged.
- `httpHookRunner.test.ts`:
  - flag on (User scope) + literal private IP → request proceeds
  - flag on + hostname resolving to private IP → request proceeds
  - flag on + `169.254.169.254` → still blocked (metadata blocklist)
  - flag on from `Workspace` scope → ignored, request blocked + warning logged
- `settings.test.ts`: `security.allowPrivateNetworkHooks` parsed per scope; workspace-scope value filtered.
- E2E: hook against a `*.nip.io` domain resolving to `172.16.x.x` succeeds with flag on, blocked with flag off.

## Documentation

- `docs/users/features/hooks.md`: documents `security.allowPrivateNetworkHooks`, the scope restriction, and the guidance to pair it with `allowedHttpHookUrls` in managed environments.
- Security note: explicitly warn that enabling this flag lets hooks reach cloud metadata services and internal infrastructure; enable only in trusted, managed settings.
