### PR TITLE
fix(web-shell): prefer artifact type metadata in cards

### DIFF
--- a/packages/web-shell/client/components/artifacts/TurnOutputs.tsx
+++ b/packages/web-shell/client/components/artifacts/TurnOutputs.tsx
@@ -5,8 +5,8 @@ import { memo, useState } from 'react';
 import { useI18n } from '../../i18n';
 import { describeCron } from '../dialogs/scheduledTasksSchedule';
 import {
-  artifactKindLabel,
   formatArtifactSize,
+  getArtifactTypeLabel,
   isSamePath,
   stripWorkspacePath,
 } from './artifactUtils';
@@ -321,9 +321,7 @@ function ArtifactCard({
         <div className={styles.artifactInfo}>
           <div className={styles.title}>{artifact.title}</div>
           <div className={styles.artifactMeta}>
-            {[artifactKindLabel(artifact.kind), size]
-              .filter(Boolean)
-              .join(' · ')}
+            {[getArtifactTypeLabel(artifact), size].filter(Boolean).join(' · ')}
           </div>
         </div>
         <div className={styles.actions}>

--- a/packages/web-shell/client/components/artifacts/artifactUtils.test.ts
+++ b/packages/web-shell/client/components/artifacts/artifactUtils.test.ts
@@ -1,7 +1,12 @@
 // @vitest-environment jsdom
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { normalizePath, withArtifactPreviewCsp } from './artifactUtils';
+import type { DaemonSessionArtifact } from '@qwen-code/sdk/daemon';
+import {
+  getArtifactTypeLabel,
+  normalizePath,
+  withArtifactPreviewCsp,
+} from './artifactUtils';
 
 describe('artifactUtils', () => {
   afterEach(() => {
@@ -14,6 +19,21 @@ describe('artifactUtils', () => {
       '/workspace/app/src/main.ts',
     );
     expect(normalizePath('../outside/file.ts')).toBe('../outside/file.ts');
+  });
+
+  it('prefers the artifact type from metadata', () => {
+    const artifact = {
+      kind: 'other',
+      metadata: { artifactType: 'Diagram' },
+    } as DaemonSessionArtifact;
+
+    expect(getArtifactTypeLabel(artifact)).toBe('Diagram');
+  });
+
+  it('falls back to the artifact kind label without metadata', () => {
+    const artifact = { kind: 'other' } as DaemonSessionArtifact;
+
+    expect(getArtifactTypeLabel(artifact)).toBe('other');
   });
 
   it('injects preview CSP and strips unsafe metadata', () => {

--- a/packages/web-shell/client/components/artifacts/artifactUtils.ts
+++ b/packages/web-shell/client/components/artifacts/artifactUtils.ts
@@ -13,6 +13,13 @@ export function artifactKindLabel(kind: string): string {
   }
 }
 
+export function getArtifactTypeLabel(artifact: DaemonSessionArtifact): string {
+  const artifactType = artifact.metadata?.['artifactType'];
+  return typeof artifactType === 'string' && artifactType
+    ? artifactType
+    : artifactKindLabel(artifact.kind);
+}
+
 export function formatArtifactSize(sizeBytes: number | undefined): string {
   if (sizeBytes === undefined) return '';
   if (sizeBytes < 1024) return `${sizeBytes} B`;


### PR DESCRIPTION
## What this PR does

Artifact cards now prefer a non-empty string from `metadata.artifactType` for their displayed type label. Cards continue to use the existing artifact kind label when that metadata is absent or invalid.

## Why it's needed

Developer-defined artifacts use the generic `other` kind, which previously caused their cards to show `other` even when the producer supplied a more descriptive artifact type in metadata.

## Reviewer Test Plan

### How to verify

Render an artifact card with the `other` kind and `metadata.artifactType` set to `Diagram`; confirm the metadata line shows `Diagram`. Render an `other` artifact without `metadata.artifactType`; confirm it still shows `other`.

### Evidence (Before & After)

Before: an `other` artifact with `metadata.artifactType: "Diagram"` displayed `other`.

After: the same artifact displays `Diagram`, while an artifact without the metadata field continues to display `other`. Automated unit tests cover both outcomes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local Node.js workspace. The focused artifact tests, repository build, repository typecheck, ESLint, and Prettier checks pass.

## Risk & Scope

- Main risk or tradeoff: A producer-supplied artifact type is displayed verbatim when it is a non-empty string.
- Not validated / out of scope: Visual validation on Windows and Linux.
- Breaking changes / migration notes: None.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的改动

Artifact 卡片现在会优先使用 `metadata.artifactType` 中的非空字符串作为类型标签。如果该 metadata 缺失或无效，卡片仍会使用现有的 artifact kind 标签。

## 为什么需要此改动

开发者自定义的 artifact 使用通用的 `other` kind。此前，即使生产方在 metadata 中提供了更具描述性的 artifact 类型，卡片仍然只会显示 `other`。

## Reviewer 测试计划

### 验证方式

渲染一个 kind 为 `other` 且 `metadata.artifactType` 为 `Diagram` 的 artifact 卡片，确认 metadata 行显示 `Diagram`。再渲染一个未提供 `metadata.artifactType` 的 `other` artifact，确认它仍显示 `other`。

### 前后对比证据

改动前：设置了 `metadata.artifactType: "Diagram"` 的 `other` artifact 显示 `other`。

改动后：同一个 artifact 显示 `Diagram`，未提供该 metadata 字段的 artifact 仍显示 `other`。自动化单元测试覆盖了这两种结果。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|    🍏 macOS      |  ✅  |
|   🪟 Windows     |  ⚠️  |
|    🐧 Linux      |  ⚠️  |

### 环境（可选）

本地 Node.js workspace。针对 artifact 的定向测试、仓库构建、仓库类型检查、ESLint 和 Prettier 检查均通过。

## 风险与范围

- 主要风险或权衡：当生产方提供的 artifact 类型是非空字符串时，会原样显示该内容。
- 未验证或范围外：未在 Windows 和 Linux 上进行视觉验证。
- 破坏性变更或迁移说明：无。

## 关联 Issue

无。

</details>
