### PR TITLE
feat(review): add `review run` — headless review with a machine-readable verdict

### DIFF
--- a/docs/users/features/code-review.md
+++ b/docs/users/features/code-review.md
@@ -277,6 +277,26 @@ The deterministic halves of the pipeline — argument parsing (`qwen review pars
 
 Every run ends with one machine-readable line (`Review complete: <target> — <disposition>`), so scripts and CI wrappers can detect completion and outcome with a single `^Review complete: ` match.
 
+## Headless runs (`qwen review run`)
+
+`/review` is interactive. When a script or CI job needs to run a review and act on its outcome, use the headless wrapper:
+
+```bash
+qwen review run [target] [--json] [--fail-on request-changes] [--comment] [--quiet]
+```
+
+`target` is a PR number, a PR URL, or a file path; omit it to review the local working tree. The command runs this build's own CLI non-interactively (with stdin closed, so slash-command detection survives), streams the child's progress to **stderr**, and prints the verdict to **stdout** — or, with `--json`, the full result object. The verdict is read from the artifact `compose-review` writes (the same JSON the skill treats as the verdict authority), never parsed from the model's prose.
+
+The exit code is the contract a gate should read:
+
+| Exit | Meaning                                                                                           |
+| ---- | ------------------------------------------------------------------------------------------------- |
+| `0`  | The review completed (whatever it decided)                                                        |
+| `1`  | It never reached a verdict — the child failed, timed out, or left no composed artifact            |
+| `3`  | It completed with `REQUEST_CHANGES` **and** `--fail-on request-changes` was set (opt-in blocking) |
+
+`3` (not `2`) lets a gate distinguish "the review is blocking" from "the tool broke" — yargs already uses `1` for usage errors — without parsing any output. `--timeout-minutes` (default 120, floored at 1) terminates a hung review and exits `1`, and cancelling the command (Ctrl+C / SIGTERM) terminates the review's process group rather than orphaning it.
+
 ## Cross-file Impact Analysis
 
 A dedicated cross-file tracer (Agent 1c) owns this walk end-to-end. When code changes modify exported functions, classes, or interfaces, it searches for all callers and checks compatibility:

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -25,7 +25,7 @@ export const TOP_LEVEL_COMMANDS = [
   ['mcp', 'Manage MCP servers'],
   [
     'review <command>',
-    'Internal helpers used by the /review skill (PR worktree setup, context fetch, rules loading, presubmit checks, cleanup)',
+    'Run a review non-interactively (`run`), plus the internal helpers used by the /review skill (PR worktree setup, context fetch, rules loading, presubmit checks, cleanup)',
   ],
   [
     'serve',

--- a/packages/cli/src/commands/review.test.ts
+++ b/packages/cli/src/commands/review.test.ts
@@ -39,6 +39,7 @@ describe('reviewCommand', () => {
 
   it('registers exactly the expected internal helper subcommands', () => {
     expect(registeredSubcommands()).toEqual([
+      'run',
       'parse-args',
       'fetch-pr',
       'capture-local',

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -26,13 +26,15 @@ import { scriptLintCommand } from './review/script-lint.js';
 import { submitCommand } from './review/submit.js';
 import { testEfficacyCommand } from './review/test-efficacy.js';
 import { cleanupCommand } from './review/cleanup.js';
+import { runCommand } from './review/run.js';
 
 export const reviewCommand: CommandModule = {
   command: 'review',
   describe:
-    'Internal helpers used by the /review skill (PR worktree setup, context fetch, rules loading, presubmit checks, cleanup)',
+    'Run a review non-interactively (`run`), plus the internal helpers used by the /review skill (PR worktree setup, context fetch, rules loading, presubmit checks, cleanup)',
   builder: (yargs: Argv) =>
     yargs
+      .command(runCommand)
       .command(parseArgsCommand)
       .command(fetchPrCommand)
       .command(captureLocalCommand)
@@ -52,7 +54,7 @@ export const reviewCommand: CommandModule = {
       .command(cleanupCommand)
       .demandCommand(
         1,
-        'Specify a subcommand: parse-args, fetch-pr, capture-local, plan-diff, pr-context, comment-status, load-rules, agent-prompt, build-test, script-lint, resolve-anchors, check-coverage, presubmit, test-efficacy, compose-review, submit, or cleanup.',
+        'Specify a subcommand: run, parse-args, fetch-pr, capture-local, plan-diff, pr-context, comment-status, load-rules, agent-prompt, build-test, script-lint, resolve-anchors, check-coverage, presubmit, test-efficacy, compose-review, submit, or cleanup.',
       )
       .version(false),
   handler: () => {

--- a/packages/cli/src/commands/review/run.test.ts
+++ b/packages/cli/src/commands/review/run.test.ts
@@ -82,6 +82,17 @@ describe('buildReviewPrompt', () => {
       /Invalid review target/,
     );
   });
+
+  it('rejects a target carrying quote characters', () => {
+    // tokenizeArgs strips quotes, so `src/it's-a-file.ts` would re-tokenize
+    // to `src/its-a-file.ts` — silently re-targeting a file never named.
+    expect(() => buildReviewPrompt({ target: "src/it's-a-file.ts" })).toThrow(
+      /Invalid review target/,
+    );
+    expect(() => buildReviewPrompt({ target: 'src/"quoted".ts' })).toThrow(
+      /Invalid review target/,
+    );
+  });
 });
 
 describe('newestArtifactSince', () => {
@@ -251,21 +262,28 @@ describe('review run (handler)', () => {
   }
 
   it('republishes the composed verdict and exits 0', async () => {
+    // Non-default values for every republished field, so a dropped or
+    // hard-coded `composed?.X ?? default` mapping cannot pass.
     armChild(0, {
-      event: 'REQUEST_CHANGES',
-      verdictLine: 'Verdict: Request changes',
+      event: 'COMMENT',
+      verdictLine: 'Verdict: Comment',
       baseEvent: 'REQUEST_CHANGES',
-      cappedBy: [],
-      downgraded: false,
-      downgradedFrom: null,
-      remediation: [],
+      cappedBy: ['unreviewed-dimension'],
+      downgraded: true,
+      downgradedFrom: 'Request changes',
+      remediation: ['do x'],
     });
     await runHandler();
 
     const result = JSON.parse(outs.join(''));
     expect(result.completed).toBe(true);
-    expect(result.event).toBe('REQUEST_CHANGES');
-    expect(result.verdictLine).toBe('Verdict: Request changes');
+    expect(result.event).toBe('COMMENT');
+    expect(result.verdictLine).toBe('Verdict: Comment');
+    expect(result.baseEvent).toBe('REQUEST_CHANGES');
+    expect(result.cappedBy).toEqual(['unreviewed-dimension']);
+    expect(result.downgraded).toBe(true);
+    expect(result.downgradedFrom).toBe('Request changes');
+    expect(result.remediation).toEqual(['do x']);
     expect(result.reportPath).toContain('review.md');
     expect(process.exitCode).toBe(0);
   });
@@ -424,6 +442,52 @@ describe('review run (handler)', () => {
     expect(result.childExitCode).toBeNull();
     expect(result.childSignal).toBe('SIGTERM');
     expect(process.exitCode).toBe(1);
+  });
+
+  it('forwards a parent signal to the child group and exits 128+signum', async () => {
+    // The detached child sits outside the foreground group a terminal's
+    // Ctrl+C signals, and a cancelled CI job sends the parent SIGTERM.
+    // Without forwarding, the parent dies and the review is reparented to
+    // PID 1, burning API calls for the full timeout. Pin the registration
+    // and the 128+signum mapping so a refactor cannot silently drop them.
+    vi.useFakeTimers();
+    const child = new FakeChild();
+    spawnMock.mockImplementation(() => child);
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+    const onSpy = vi.spyOn(process, 'on');
+
+    const done = runHandler({ 'timeout-minutes': 1 });
+
+    // All three signals must be registered.
+    const registered = onSpy.mock.calls
+      .map(([sig]) => sig)
+      .filter((sig) => ['SIGHUP', 'SIGINT', 'SIGTERM'].includes(sig as string));
+    expect(registered).toEqual(
+      expect.arrayContaining(['SIGHUP', 'SIGINT', 'SIGTERM']),
+    );
+
+    const handler = onSpy.mock.calls.find(
+      ([sig]) => sig === 'SIGTERM',
+    )?.[1] as (signal: NodeJS.Signals) => void;
+    handler('SIGHUP');
+    handler('SIGINT');
+    handler('SIGTERM');
+
+    // The group is killed and each signal maps onto 128+signum.
+    expect(processKill).toHaveBeenCalledWith(-12345, 'SIGTERM');
+    expect(exitSpy).toHaveBeenNthCalledWith(1, 129);
+    expect(exitSpy).toHaveBeenNthCalledWith(2, 130);
+    expect(exitSpy).toHaveBeenNthCalledWith(3, 143);
+
+    // The handler cleared the timeout timer: crossing it must not fire the
+    // timeout path (which would write its own stderr notice).
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(errs.join('')).not.toContain('timeout after');
+
+    child.emit('close', null, 'SIGTERM');
+    await done;
   });
 
   it('prints the verdict line and report path in human-readable mode', async () => {

--- a/packages/cli/src/commands/review/run.test.ts
+++ b/packages/cli/src/commands/review/run.test.ts
@@ -444,6 +444,42 @@ describe('review run (handler)', () => {
     expect(process.exitCode).toBe(1);
   });
 
+  it('keeps a captured verdict when the timeout fires after compose-review', async () => {
+    // The race the contract must survive: compose-review writes the verdict
+    // (Step 6) and the capture poll snapshots it, but --timeout-minutes fires
+    // before the child exits (Steps 7–9). The flag terminates a run "without a
+    // verdict", so a captured verdict still counts as completed — the kill must
+    // not flip exit 0 to 1 or suppress the verdict, and `timedOut` alone still
+    // records that the timer fired.
+    vi.useFakeTimers();
+    let child!: FakeChild;
+    spawnMock.mockImplementation(() => {
+      mkdirSync(REVIEW_TMP_DIR, { recursive: true });
+      writeFileSync(
+        join(REVIEW_TMP_DIR, 'qwen-review-local-composed.json'),
+        JSON.stringify({ event: 'APPROVE', verdictLine: 'Verdict: Approve' }),
+        'utf8',
+      );
+      child = new FakeChild();
+      return child;
+    });
+
+    const done = runHandler({ 'timeout-minutes': 1 });
+    // The capture poll snapshots the verdict while the child still runs...
+    await vi.advanceTimersByTimeAsync(1_000);
+    // ...then the timeout fires and kills the group before the child exits.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(processKill).toHaveBeenCalledWith(-12345, 'SIGTERM');
+    child.emit('close', null, 'SIGTERM');
+    await done;
+
+    const result = JSON.parse(outs.join(''));
+    expect(result.completed).toBe(true);
+    expect(result.timedOut).toBe(true);
+    expect(result.event).toBe('APPROVE');
+    expect(process.exitCode).toBe(0);
+  });
+
   it('forwards a parent signal to the child group and exits 128+signum', async () => {
     // The detached child sits outside the foreground group a terminal's
     // Ctrl+C signals, and a cancelled CI job sends the parent SIGTERM.

--- a/packages/cli/src/commands/review/run.test.ts
+++ b/packages/cli/src/commands/review/run.test.ts
@@ -130,8 +130,10 @@ describe('review run (handler)', () => {
   let cwd: string;
   let outs: string[];
   let exitCode: number | undefined;
+  let processKill: ReturnType<typeof vi.spyOn>;
 
   class FakeChild extends EventEmitter {
+    pid = 12345;
     stdout = Object.assign(new EventEmitter(), { resume: () => {} });
     stderr = Object.assign(new EventEmitter(), { resume: () => {} });
     kill = vi.fn();
@@ -148,6 +150,7 @@ describe('review run (handler)', () => {
       return true;
     });
     vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    processKill = vi.spyOn(process, 'kill').mockImplementation(() => true);
     spawnMock.mockReset();
   });
 
@@ -241,9 +244,10 @@ describe('review run (handler)', () => {
     const [, argvUsed, opts] = spawnMock.mock.calls[0] as [
       string,
       string[],
-      { stdio: unknown[] },
+      { stdio: unknown[]; detached: boolean },
     ];
     expect(opts.stdio[0]).toBe('ignore');
+    expect(opts.detached).toBe(true);
     expect(argvUsed).toContain('--prompt');
     expect(argvUsed).toContain('/review');
   });
@@ -270,7 +274,7 @@ describe('review run (handler)', () => {
     expect(process.exitCode).toBe(1);
   });
 
-  it('reports a timed-out run as incomplete and kills the child', async () => {
+  it('reports a timed-out run as incomplete and kills the process group', async () => {
     vi.useFakeTimers();
     const child = new FakeChild();
     spawnMock.mockImplementation(() => child);
@@ -286,6 +290,57 @@ describe('review run (handler)', () => {
     expect(result.childExitCode).toBeNull();
     expect(result.childSignal).toBe('SIGTERM');
     expect(process.exitCode).toBe(1);
-    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(processKill).toHaveBeenCalledWith(-12345, 'SIGTERM');
+  });
+
+  it('prints the verdict line and report path in human-readable mode', async () => {
+    armChild(0, { event: 'APPROVE', verdictLine: 'Verdict: Approve' });
+    await runHandler({ json: false });
+
+    const output = outs.join('');
+    expect(output).toContain('Verdict: Approve');
+    expect(output).toContain('Report: ');
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('distinguishes a corrupt composed artifact from a missing one', async () => {
+    spawnMock.mockImplementation(() => {
+      const child = new FakeChild();
+      setImmediate(() => {
+        mkdirSync(REVIEW_TMP_DIR, { recursive: true });
+        writeFileSync(
+          join(REVIEW_TMP_DIR, 'qwen-review-local-composed.json'),
+          '{truncated',
+          'utf8',
+        );
+        child.emit('close', 0);
+      });
+      return child;
+    });
+    await runHandler({ json: false });
+
+    const output = outs.join('');
+    expect(output).toContain('could not be parsed');
+    expect(output).not.toContain('no composed verdict was produced');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('clamps a negative timeout to the 1-minute floor', async () => {
+    vi.useFakeTimers();
+    const child = new FakeChild();
+    spawnMock.mockImplementation(() => child);
+
+    const done = runHandler({ 'timeout-minutes': -5 });
+    // 59 s is under the 1-minute floor — must not fire.
+    await vi.advanceTimersByTimeAsync(59_000);
+    expect(processKill).not.toHaveBeenCalled();
+    // Crossing the floor fires the timeout.
+    await vi.advanceTimersByTimeAsync(1_000);
+    child.emit('close', null, 'SIGTERM');
+    await done;
+
+    const result = JSON.parse(outs.join(''));
+    expect(result.timedOut).toBe(true);
+    expect(process.exitCode).toBe(1);
   });
 });

--- a/packages/cli/src/commands/review/run.test.ts
+++ b/packages/cli/src/commands/review/run.test.ts
@@ -53,6 +53,17 @@ describe('buildReviewPrompt', () => {
       '/review --effort medium',
     );
   });
+
+  it('rejects a target that would re-tokenize into extra args', () => {
+    // `123 --comment` would split into a target plus a flag the child
+    // honours, silently authorising a post the run never asked for.
+    expect(() => buildReviewPrompt({ target: '123 --comment' })).toThrow(
+      /Invalid review target/,
+    );
+    expect(() => buildReviewPrompt({ target: '--comment' })).toThrow(
+      /Invalid review target/,
+    );
+  });
 });
 
 describe('newestArtifactSince', () => {
@@ -143,6 +154,7 @@ describe('review run (handler)', () => {
   afterEach(() => {
     process.exitCode = exitCode;
     vi.restoreAllMocks();
+    vi.useRealTimers();
     process.chdir(cwd);
     rmSync(dir, { recursive: true, force: true });
   });
@@ -244,5 +256,36 @@ describe('review run (handler)', () => {
     const i = argvUsed.indexOf('--approval-mode');
     expect(i).toBeGreaterThan(-1);
     expect(argvUsed[i + 1]).toBe('default');
+  });
+
+  it('treats a composed verdict without a string event as no verdict', async () => {
+    // readComposed must refuse a file whose `event` is not a string, or a
+    // corrupt verdict would read as completed with event null and exit 0.
+    armChild(0, { event: 123, verdictLine: 'Verdict: Approve' });
+    await runHandler();
+
+    const result = JSON.parse(outs.join(''));
+    expect(result.completed).toBe(false);
+    expect(result.event).toBeNull();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('reports a timed-out run as incomplete and kills the child', async () => {
+    vi.useFakeTimers();
+    const child = new FakeChild();
+    spawnMock.mockImplementation(() => child);
+
+    const done = runHandler({ 'timeout-minutes': 1 });
+    await vi.advanceTimersByTimeAsync(60_000); // fire the timeout
+    child.emit('close', null, 'SIGTERM'); // the kill takes effect
+    await done;
+
+    const result = JSON.parse(outs.join(''));
+    expect(result.completed).toBe(false);
+    expect(result.timedOut).toBe(true);
+    expect(result.childExitCode).toBeNull();
+    expect(result.childSignal).toBe('SIGTERM');
+    expect(process.exitCode).toBe(1);
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
   });
 });

--- a/packages/cli/src/commands/review/run.test.ts
+++ b/packages/cli/src/commands/review/run.test.ts
@@ -11,7 +11,15 @@
 // assembly, artifact discovery (this run's verdict, not a stale one), the
 // completed/failed/blocking exit split, and the spawn wiring.
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+  type MockInstance,
+} from 'vitest';
 import { EventEmitter } from 'node:events';
 import {
   mkdtempSync,
@@ -130,7 +138,7 @@ describe('review run (handler)', () => {
   let cwd: string;
   let outs: string[];
   let exitCode: number | undefined;
-  let processKill: ReturnType<typeof vi.spyOn>;
+  let processKill: MockInstance<typeof process.kill>;
 
   class FakeChild extends EventEmitter {
     pid = 12345;

--- a/packages/cli/src/commands/review/run.test.ts
+++ b/packages/cli/src/commands/review/run.test.ts
@@ -1,0 +1,248 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// `review run` is a contract around the headless review: build the right
+// /review invocation, republish the verdict compose-review wrote (never the
+// model's prose), and map outcomes onto exit codes a CI gate can trust. The
+// child CLI itself is tested elsewhere; these tests pin the contract — prompt
+// assembly, artifact discovery (this run's verdict, not a stale one), the
+// completed/failed/blocking exit split, and the spawn wiring.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  utimesSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const spawnMock = vi.hoisted(() => vi.fn());
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    default: { ...actual, spawn: spawnMock },
+    spawn: spawnMock,
+  };
+});
+
+const { buildReviewPrompt, newestArtifactSince, exitCodeFor, runCommand } =
+  await import('./run.js');
+const { REVIEW_TMP_DIR, REVIEWS_DIR } = await import('./lib/paths.js');
+
+describe('buildReviewPrompt', () => {
+  it('reviews the local tree when no target is given', () => {
+    expect(buildReviewPrompt({})).toBe('/review');
+  });
+
+  it('threads target, effort, and --comment through verbatim', () => {
+    expect(
+      buildReviewPrompt({ target: '7724', effort: 'high', comment: true }),
+    ).toBe('/review 7724 --effort high --comment');
+  });
+
+  it('omits what was not asked for', () => {
+    expect(buildReviewPrompt({ effort: 'medium' })).toBe(
+      '/review --effort medium',
+    );
+  });
+});
+
+describe('newestArtifactSince', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'run-artifacts-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function file(name: string, mtimeMs: number): string {
+    const path = join(dir, name);
+    writeFileSync(path, '{}', 'utf8');
+    utimesSync(path, mtimeMs / 1000, mtimeMs / 1000);
+    return path;
+  }
+
+  it('ignores artifacts older than the run', () => {
+    // A stale composed JSON is the LAST review's verdict — republishing it
+    // would report an outcome this run never produced.
+    const start = Date.now();
+    file('qwen-review-local-composed.json', start - 60_000);
+
+    expect(
+      newestArtifactSince(dir, /^qwen-review-.*composed\.json$/, start),
+    ).toBeNull();
+  });
+
+  it('returns the newest matching artifact from this run', () => {
+    const start = Date.now() - 10_000;
+    file('qwen-review-local-composed.json', start + 1_000);
+    const newer = file('qwen-review-pr-9-composed.json', start + 5_000);
+    file('unrelated.json', start + 9_000);
+
+    expect(
+      newestArtifactSince(dir, /^qwen-review-.*composed\.json$/, start),
+    ).toBe(newer);
+  });
+
+  it('returns null when the directory does not exist', () => {
+    expect(
+      newestArtifactSince(join(dir, 'absent'), /composed/, Date.now()),
+    ).toBeNull();
+  });
+});
+
+describe('exitCodeFor', () => {
+  it('splits completed / no-verdict / blocking into 0 / 1 / 3', () => {
+    expect(exitCodeFor(true, 'APPROVE', 'none')).toBe(0);
+    expect(exitCodeFor(true, 'REQUEST_CHANGES', 'none')).toBe(0);
+    expect(exitCodeFor(false, null, 'none')).toBe(1);
+    expect(exitCodeFor(true, 'REQUEST_CHANGES', 'request-changes')).toBe(3);
+    expect(exitCodeFor(true, 'COMMENT', 'request-changes')).toBe(0);
+    // An incomplete run is 1 even under --fail-on: "the tool broke" must never
+    // read as "the review blocked".
+    expect(exitCodeFor(false, 'REQUEST_CHANGES', 'request-changes')).toBe(1);
+  });
+});
+
+describe('review run (handler)', () => {
+  let dir: string;
+  let cwd: string;
+  let outs: string[];
+  let exitCode: number | undefined;
+
+  class FakeChild extends EventEmitter {
+    stdout = Object.assign(new EventEmitter(), { resume: () => {} });
+    stderr = Object.assign(new EventEmitter(), { resume: () => {} });
+    kill = vi.fn();
+  }
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'run-handler-'));
+    cwd = process.cwd();
+    process.chdir(dir);
+    outs = [];
+    exitCode = process.exitCode as number | undefined;
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      outs.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    spawnMock.mockReset();
+  });
+
+  afterEach(() => {
+    process.exitCode = exitCode;
+    vi.restoreAllMocks();
+    process.chdir(cwd);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function runHandler(over: Record<string, unknown> = {}): Promise<void> {
+    return (runCommand.handler as (a: unknown) => Promise<void>)({
+      comment: false,
+      json: true,
+      'fail-on': 'none',
+      'timeout-minutes': 120,
+      'approval-mode': 'yolo',
+      quiet: true,
+      ...over,
+    });
+  }
+
+  /** Child that "completes", writing (or not) a composed verdict first. */
+  function armChild(exit: number, composed?: Record<string, unknown>): void {
+    spawnMock.mockImplementation(() => {
+      const child = new FakeChild();
+      setImmediate(() => {
+        if (composed) {
+          mkdirSync(REVIEW_TMP_DIR, { recursive: true });
+          mkdirSync(REVIEWS_DIR, { recursive: true });
+          writeFileSync(
+            join(REVIEW_TMP_DIR, 'qwen-review-local-composed.json'),
+            JSON.stringify(composed),
+            'utf8',
+          );
+          writeFileSync(join(REVIEWS_DIR, 'review.md'), '# report', 'utf8');
+        }
+        child.emit('close', exit);
+      });
+      return child;
+    });
+  }
+
+  it('republishes the composed verdict and exits 0', async () => {
+    armChild(0, {
+      event: 'REQUEST_CHANGES',
+      verdictLine: 'Verdict: Request changes',
+      baseEvent: 'REQUEST_CHANGES',
+      cappedBy: [],
+      downgraded: false,
+      downgradedFrom: null,
+      remediation: [],
+    });
+    await runHandler();
+
+    const result = JSON.parse(outs.join(''));
+    expect(result.completed).toBe(true);
+    expect(result.event).toBe('REQUEST_CHANGES');
+    expect(result.verdictLine).toBe('Verdict: Request changes');
+    expect(result.reportPath).toContain('review.md');
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('exits 3 on a blocking verdict only when --fail-on asks for it', async () => {
+    armChild(0, {
+      event: 'REQUEST_CHANGES',
+      verdictLine: 'Verdict: Request changes',
+    });
+    await runHandler({ 'fail-on': 'request-changes' });
+
+    expect(process.exitCode).toBe(3);
+  });
+
+  it('treats a clean child exit without a composed verdict as failure', async () => {
+    // The model can wander off and exit 0 without ever reaching Step 7. That is
+    // "no verdict", never "approve".
+    armChild(0);
+    await runHandler();
+
+    const result = JSON.parse(outs.join(''));
+    expect(result.completed).toBe(false);
+    expect(result.event).toBeNull();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('closes the child stdin so piped input cannot defeat slash detection', async () => {
+    armChild(0, { event: 'APPROVE', verdictLine: 'Verdict: Approve' });
+    await runHandler();
+
+    const [, argvUsed, opts] = spawnMock.mock.calls[0] as [
+      string,
+      string[],
+      { stdio: unknown[] },
+    ];
+    expect(opts.stdio[0]).toBe('ignore');
+    expect(argvUsed).toContain('--prompt');
+    expect(argvUsed).toContain('/review');
+  });
+
+  it('passes the approval mode through to the child CLI', async () => {
+    armChild(0, { event: 'APPROVE', verdictLine: 'Verdict: Approve' });
+    await runHandler({ 'approval-mode': 'default' });
+
+    const [, argvUsed] = spawnMock.mock.calls[0] as [string, string[]];
+    const i = argvUsed.indexOf('--approval-mode');
+    expect(i).toBeGreaterThan(-1);
+    expect(argvUsed[i + 1]).toBe('default');
+  });
+});

--- a/packages/cli/src/commands/review/run.test.ts
+++ b/packages/cli/src/commands/review/run.test.ts
@@ -32,18 +32,28 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 const spawnMock = vi.hoisted(() => vi.fn());
+const execFileSyncMock = vi.hoisted(() => vi.fn());
 vi.mock('node:child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:child_process')>();
   return {
     ...actual,
-    default: { ...actual, spawn: spawnMock },
+    default: { ...actual, spawn: spawnMock, execFileSync: execFileSyncMock },
     spawn: spawnMock,
+    execFileSync: execFileSyncMock,
   };
 });
 
-const { buildReviewPrompt, newestArtifactSince, exitCodeFor, runCommand } =
-  await import('./run.js');
+const {
+  buildReviewPrompt,
+  newestArtifactSince,
+  exitCodeFor,
+  killProcessGroup,
+  runCommand,
+} = await import('./run.js');
 const { REVIEW_TMP_DIR, REVIEWS_DIR } = await import('./lib/paths.js');
+// The real cleanup, not a mock: the regression test below must prove the parent
+// captures the verdict before Step 9's actual sweep deletes it.
+const { runCleanup } = await import('./cleanup.js');
 
 describe('buildReviewPrompt', () => {
   it('reviews the local tree when no target is given', () => {
@@ -133,10 +143,43 @@ describe('exitCodeFor', () => {
   });
 });
 
+describe('killProcessGroup', () => {
+  let processKill: MockInstance<typeof process.kill>;
+
+  beforeEach(() => {
+    processKill = vi.spyOn(process, 'kill').mockImplementation(() => true);
+    execFileSyncMock.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('kills the POSIX process group with a negative pid', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
+    killProcessGroup(12345, 'SIGTERM');
+    expect(processKill).toHaveBeenCalledWith(-12345, 'SIGTERM');
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('kills the process tree via taskkill on Windows', () => {
+    // A negative pid is not a process group on win32; the group kill must fall
+    // back to a tree kill or the timeout/cancel termination silently no-ops.
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    killProcessGroup(12345, 'SIGTERM');
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      'taskkill',
+      ['/pid', '12345', '/T', '/F'],
+      { stdio: 'ignore' },
+    );
+    expect(processKill).not.toHaveBeenCalled();
+  });
+});
+
 describe('review run (handler)', () => {
   let dir: string;
   let cwd: string;
   let outs: string[];
+  let errs: string[];
   let exitCode: number | undefined;
   let processKill: MockInstance<typeof process.kill>;
 
@@ -152,12 +195,16 @@ describe('review run (handler)', () => {
     cwd = process.cwd();
     process.chdir(dir);
     outs = [];
+    errs = [];
     exitCode = process.exitCode as number | undefined;
     vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
       outs.push(String(chunk));
       return true;
     });
-    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+      errs.push(String(chunk));
+      return true;
+    });
     processKill = vi.spyOn(process, 'kill').mockImplementation(() => true);
     spawnMock.mockReset();
   });
@@ -245,6 +292,43 @@ describe('review run (handler)', () => {
     expect(process.exitCode).toBe(1);
   });
 
+  it('captures the verdict before Step 9 cleanup sweeps it', async () => {
+    // The regression this command shipped with: the child runs the bundled
+    // skill through Step 9, whose `cleanup` deletes the composed verdict before
+    // the child exits. A parent that reads only after `close` sees nothing and
+    // reports a completed review as a failure. The capture poll must snapshot
+    // the verdict while the child still runs.
+    vi.useFakeTimers();
+    let child!: FakeChild;
+    spawnMock.mockImplementation(() => {
+      // Step 6: compose-review writes the composed verdict.
+      mkdirSync(REVIEW_TMP_DIR, { recursive: true });
+      writeFileSync(
+        join(REVIEW_TMP_DIR, 'qwen-review-local-composed.json'),
+        JSON.stringify({ event: 'APPROVE', verdictLine: 'Verdict: Approve' }),
+        'utf8',
+      );
+      child = new FakeChild();
+      return child;
+    });
+
+    const done = runHandler();
+    // The capture poll snapshots the verdict while the child still runs...
+    await vi.advanceTimersByTimeAsync(1_000);
+    // ...then Step 9 runs the REAL cleanup, which sweeps the verdict...
+    runCleanup('local');
+    outs.length = 0; // drop cleanup's "Removed temp file" stdout noise
+    // ...and only then does the child exit.
+    child.emit('close', 0);
+    await done;
+
+    const result = JSON.parse(outs.join(''));
+    expect(result.completed).toBe(true);
+    expect(result.event).toBe('APPROVE');
+    expect(result.composedPath).toContain('qwen-review-local-composed.json');
+    expect(process.exitCode).toBe(0);
+  });
+
   it('closes the child stdin so piped input cannot defeat slash detection', async () => {
     armChild(0, { event: 'APPROVE', verdictLine: 'Verdict: Approve' });
     await runHandler();
@@ -256,6 +340,10 @@ describe('review run (handler)', () => {
     ];
     expect(opts.stdio[0]).toBe('ignore');
     expect(opts.detached).toBe(true);
+    // --expose-gc must lead the argv: spawning argv[1] directly would drop the
+    // flag the memory-pressure monitor's critical tier needs (cli-entry.js
+    // passes it for exactly this relaunch path).
+    expect(argvUsed[0]).toBe('--expose-gc');
     expect(argvUsed).toContain('--prompt');
     expect(argvUsed).toContain('/review');
   });
@@ -282,6 +370,40 @@ describe('review run (handler)', () => {
     expect(process.exitCode).toBe(1);
   });
 
+  it('reports a launch failure when the child emits an error', async () => {
+    // A missing CLI binary or an OS that cannot fork emits `error`, not
+    // `close`; the handler must still settle and report "no verdict".
+    spawnMock.mockImplementation(() => {
+      const child = new FakeChild();
+      setImmediate(() => child.emit('error', new Error('spawn ENOENT')));
+      return child;
+    });
+    await runHandler();
+
+    const result = JSON.parse(outs.join(''));
+    expect(result.completed).toBe(false);
+    expect(result.childExitCode).toBeNull();
+    expect(process.exitCode).toBe(1);
+    expect(errs.join('')).toContain('failed to launch the CLI');
+  });
+
+  it('streams child progress to stderr, never stdout, when not quiet', async () => {
+    // The contract: stdout carries only the result. If progress leaked to
+    // stdout it would interleave with the JSON a CI consumer parses.
+    spawnMock.mockImplementation(() => {
+      const child = new FakeChild();
+      setImmediate(() => {
+        child.stdout.emit('data', Buffer.from('progress noise'));
+        child.emit('close', 0);
+      });
+      return child;
+    });
+    await runHandler({ quiet: false });
+
+    expect(errs.join('')).toContain('progress noise');
+    expect(outs.join('')).not.toContain('progress noise');
+  });
+
   it('reports a timed-out run as incomplete and kills the process group', async () => {
     vi.useFakeTimers();
     const child = new FakeChild();
@@ -289,6 +411,10 @@ describe('review run (handler)', () => {
 
     const done = runHandler({ 'timeout-minutes': 1 });
     await vi.advanceTimersByTimeAsync(60_000); // fire the timeout
+    expect(processKill).toHaveBeenCalledWith(-12345, 'SIGTERM');
+    // A child that ignores SIGTERM is escalated to SIGKILL after 10 s.
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(processKill).toHaveBeenCalledWith(-12345, 'SIGKILL');
     child.emit('close', null, 'SIGTERM'); // the kill takes effect
     await done;
 
@@ -298,7 +424,6 @@ describe('review run (handler)', () => {
     expect(result.childExitCode).toBeNull();
     expect(result.childSignal).toBe('SIGTERM');
     expect(process.exitCode).toBe(1);
-    expect(processKill).toHaveBeenCalledWith(-12345, 'SIGTERM');
   });
 
   it('prints the verdict line and report path in human-readable mode', async () => {
@@ -333,6 +458,23 @@ describe('review run (handler)', () => {
     expect(process.exitCode).toBe(1);
   });
 
+  it('preserves the exit code when writing the result to stdout throws', async () => {
+    // The pipe reader can go away (EPIPE) mid-write. The exit code is the
+    // contract a CI gate reads, so it must be set before — and survive — the
+    // write, not downgraded to yargs' generic exit 1 by the throw.
+    armChild(0, {
+      event: 'REQUEST_CHANGES',
+      verdictLine: 'Verdict: Request changes',
+    });
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => {
+      throw new Error('EPIPE');
+    });
+
+    await runHandler({ 'fail-on': 'request-changes' });
+
+    expect(process.exitCode).toBe(3);
+  });
+
   it('clamps a negative timeout to the 1-minute floor', async () => {
     vi.useFakeTimers();
     const child = new FakeChild();
@@ -344,6 +486,26 @@ describe('review run (handler)', () => {
     expect(processKill).not.toHaveBeenCalled();
     // Crossing the floor fires the timeout.
     await vi.advanceTimersByTimeAsync(1_000);
+    child.emit('close', null, 'SIGTERM');
+    await done;
+
+    const result = JSON.parse(outs.join(''));
+    expect(result.timedOut).toBe(true);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('floors a zero timeout to 1 minute rather than the 120-minute default', async () => {
+    // `|| 120` treats 0 as falsy and would silently substitute the default;
+    // an explicit 0 must still reach the Math.max(1, …) floor.
+    vi.useFakeTimers();
+    const child = new FakeChild();
+    spawnMock.mockImplementation(() => child);
+
+    const done = runHandler({ 'timeout-minutes': 0 });
+    await vi.advanceTimersByTimeAsync(59_000);
+    expect(processKill).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(processKill).toHaveBeenCalledWith(-12345, 'SIGTERM');
     child.emit('close', null, 'SIGTERM');
     await done;
 

--- a/packages/cli/src/commands/review/run.ts
+++ b/packages/cli/src/commands/review/run.ts
@@ -176,6 +176,10 @@ async function runReview(args: RunReviewArgs): Promise<void> {
       // prompt and the leading `/` would no longer be the first character —
       // the slash command would reach the model as plain text.
       stdio: ['ignore', 'pipe', 'pipe'],
+      // The CLI relaunches itself in a child (for --max-old-space-size), so
+      // the pid we spawn is a wrapper whose grandchild is the real review.
+      // A new process group lets the timeout kill reach both.
+      detached: true,
     },
   );
 
@@ -206,9 +210,24 @@ async function runReview(args: RunReviewArgs): Promise<void> {
     writeStderrLineSafe(
       `review run: timeout after ${args.timeoutMinutes} minutes — terminating the review`,
     );
-    child.kill('SIGTERM');
-    // The runner traps SIGTERM for cleanup; give it a moment, then insist.
-    setTimeout(() => child.kill('SIGKILL'), 10_000).unref();
+    // Kill the process group, not just the wrapper: child.kill() would only
+    // reach the relaunch wrapper, leaving the real review reparented to PID 1
+    // and still burning API calls.
+    const pid = child.pid;
+    if (pid !== undefined) {
+      try {
+        process.kill(-pid, 'SIGTERM');
+      } catch {
+        // Already dead.
+      }
+      setTimeout(() => {
+        try {
+          process.kill(-pid, 'SIGKILL');
+        } catch {
+          // Already dead.
+        }
+      }, 10_000).unref();
+    }
   }, timeoutMs);
 
   const childOutcome = await new Promise<{
@@ -268,10 +287,14 @@ async function runReview(args: RunReviewArgs): Promise<void> {
     writeStdoutLine(result.verdictLine ?? `Event: ${result.event}`);
     if (result.reportPath) writeStdoutLine(`Report: ${result.reportPath}`);
   } else {
+    const detail =
+      composedPath !== null
+        ? `a composed verdict was found at ${resolve(composedPath)} but could not be parsed`
+        : 'no composed verdict was produced';
     writeStdoutLine(
       timedOut
         ? 'Review did not complete: timed out.'
-        : `Review did not complete: no composed verdict was produced` +
+        : `Review did not complete: ${detail}` +
             `${childExitCode !== null ? ` (CLI exit ${childExitCode})` : ''}` +
             `${childSignal !== null ? ` (killed by ${childSignal})` : ''}.`,
     );
@@ -341,7 +364,7 @@ export const runCommand: CommandModule = {
       comment: Boolean(argv['comment']),
       json: Boolean(argv['json']),
       failOn: (argv['fail-on'] as 'none' | 'request-changes') ?? 'none',
-      timeoutMinutes: Number(argv['timeout-minutes']) || 120,
+      timeoutMinutes: Math.max(1, Number(argv['timeout-minutes']) || 120),
       approvalMode: String(argv['approval-mode'] ?? 'yolo'),
       quiet: Boolean(argv['quiet']),
     });

--- a/packages/cli/src/commands/review/run.ts
+++ b/packages/cli/src/commands/review/run.ts
@@ -47,7 +47,12 @@ export interface RunReviewArgs {
   quiet: boolean;
 }
 
-/** The composed-verdict fields this command republishes (see compose-review). */
+/**
+ * The composed-verdict fields this command republishes (see compose-review).
+ * `findings`, `model`, and `disclosures` (named by #7981) are deliberately
+ * absent: compose-review does not emit them as discrete fields, so there is
+ * nothing to republish until the composed artifact grows them.
+ */
 interface ComposedVerdict {
   event?: string;
   verdictLine?: string;
@@ -102,8 +107,14 @@ export function buildReviewPrompt(args: {
   if (args.target) {
     // The child re-tokenizes this string; a target carrying whitespace or a
     // leading dash would split into extra tokens (`123 --comment` would
-    // silently authorise posting) — refuse anything but a single clean token.
-    if (/\s/.test(args.target) || args.target.startsWith('-')) {
+    // silently authorise posting), and a quote is stripped by the tokenizer
+    // (`src/it's.ts` would re-target to `src/its.ts`) — refuse anything but a
+    // single clean token.
+    if (
+      /\s/.test(args.target) ||
+      args.target.startsWith('-') ||
+      /['"]/.test(args.target)
+    ) {
       throw new Error(
         `Invalid review target ${JSON.stringify(args.target)}: expected a single PR number, PR URL, or file path`,
       );

--- a/packages/cli/src/commands/review/run.ts
+++ b/packages/cli/src/commands/review/run.ts
@@ -26,7 +26,7 @@
 // reached a verdict" from "blocking verdict" (opt-in via --fail-on).
 
 import type { CommandModule } from 'yargs';
-import { spawn } from 'node:child_process';
+import { spawn, execFileSync } from 'node:child_process';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import {
@@ -74,6 +74,23 @@ export interface RunReviewResult {
   timedOut: boolean;
   durationMs: number;
 }
+
+/** The composed verdict `compose-review` writes and Step 9 cleanup sweeps. */
+const COMPOSED_PATTERN = /^qwen-review-.*composed\.json$/;
+
+// How often to poll for the composed verdict while the child runs. The verdict
+// sits on disk from Step 6 (compose-review) until Step 9 (cleanup) — a window
+// spanning the model's between-step narration and the report write, i.e.
+// seconds — so a quarter-second poll catches it with a wide margin.
+const COMPOSED_POLL_MS = 250;
+
+// Conventional exit codes for a run cancelled by a signal (128 + signum).
+const SIGNAL_EXIT_CODES: Record<string, number> = {
+  SIGHUP: 129,
+  SIGINT: 130,
+  SIGTERM: 143,
+};
+const PARENT_SIGNALS = Object.keys(SIGNAL_EXIT_CODES) as NodeJS.Signals[];
 
 /** The /review invocation the child runs — built from flags, never hand-typed. */
 export function buildReviewPrompt(args: {
@@ -161,16 +178,59 @@ function readComposed(path: string): ComposedVerdict | null {
   }
 }
 
+/**
+ * Terminate the child's process group — the detached relaunch wrapper AND the
+ * real review it spawned. On POSIX a negative pid names the group; on Windows
+ * there are no POSIX process groups and a negative pid is meaningless, so fall
+ * back to `taskkill /T`, which walks the tree the detached child spawned. Both
+ * are best-effort: killing a group that is already gone throws, and that is
+ * fine.
+ */
+export function killProcessGroup(pid: number, signal: NodeJS.Signals): void {
+  if (process.platform === 'win32') {
+    try {
+      execFileSync('taskkill', ['/pid', String(pid), '/T', '/F'], {
+        stdio: 'ignore',
+      });
+    } catch {
+      // Already dead, or taskkill unavailable.
+    }
+    return;
+  }
+  try {
+    process.kill(-pid, signal);
+  } catch {
+    // Already dead.
+  }
+}
+
 async function runReview(args: RunReviewArgs): Promise<void> {
   const startMs = Date.now();
   const prompt = buildReviewPrompt(args);
 
+  // The verdict cutoff carries slack: a coarse filesystem clock can stamp a
+  // file a moment BEFORE the Date.now() captured at run start, and a review's
+  // own verdict must not be discarded over clock granularity. Artifacts from a
+  // previous review are minutes old, far outside any slack.
+  const cutoffMs = startMs - 2_000;
+
   // Re-enter THIS build's CLI, not whatever `qwen` PATH resolves to — the same
   // version-skew rule the skill's own subprocesses follow via QWEN_CODE_CLI.
   // process.argv[1] is the entry that is already running this command.
+  // --expose-gc comes first, exactly as the relaunch wrapper passes it
+  // (cli-entry.js): a full review is the longest, most memory-hungry session
+  // the CLI runs, and spawning argv[1] directly would silently drop the flag
+  // the memory-pressure monitor's critical tier needs to call global.gc().
   const child = spawn(
     process.execPath,
-    [process.argv[1], '--prompt', prompt, '--approval-mode', args.approvalMode],
+    [
+      '--expose-gc',
+      process.argv[1],
+      '--prompt',
+      prompt,
+      '--approval-mode',
+      args.approvalMode,
+    ],
     {
       // stdin CLOSED, not inherited: piped input would be prepended to the
       // prompt and the leading `/` would no longer be the first character —
@@ -201,6 +261,30 @@ async function runReview(args: RunReviewArgs): Promise<void> {
     child.stderr?.resume();
   }
 
+  // The composed verdict is transient: the child's Step 9 `cleanup` sweeps
+  // every `.qwen/tmp/qwen-review-<target>-*` file — including it — before the
+  // child exits. Reading it only AFTER `close` therefore sees nothing and
+  // reports a review that completed as one that failed. Snapshot it the moment
+  // compose-review writes it: the first verdict newer than the run start is
+  // this run's, and caching it in memory survives the sweep.
+  let capturedPath: string | null = null;
+  let capturedVerdict: ComposedVerdict | null = null;
+  const captureTimer = setInterval(() => {
+    if (capturedVerdict !== null) return;
+    const path = newestArtifactSince(
+      REVIEW_TMP_DIR,
+      COMPOSED_PATTERN,
+      cutoffMs,
+    );
+    if (path === null) return;
+    // A half-written file fails to parse; the next tick retries it.
+    const verdict = readComposed(path);
+    if (verdict !== null) {
+      capturedPath = path;
+      capturedVerdict = verdict;
+    }
+  }, COMPOSED_POLL_MS);
+
   let timedOut = false;
   const timeoutMs = args.timeoutMinutes * 60_000;
   const timer = setTimeout(() => {
@@ -215,20 +299,30 @@ async function runReview(args: RunReviewArgs): Promise<void> {
     // and still burning API calls.
     const pid = child.pid;
     if (pid !== undefined) {
-      try {
-        process.kill(-pid, 'SIGTERM');
-      } catch {
-        // Already dead.
-      }
-      setTimeout(() => {
-        try {
-          process.kill(-pid, 'SIGKILL');
-        } catch {
-          // Already dead.
-        }
-      }, 10_000).unref();
+      killProcessGroup(pid, 'SIGTERM');
+      setTimeout(() => killProcessGroup(pid, 'SIGKILL'), 10_000).unref();
     }
   }, timeoutMs);
+
+  // The child is detached (its own process group) so the timeout kill can reach
+  // the relaunch wrapper's grandchild — but that also puts it outside the
+  // foreground group a terminal's Ctrl+C signals, and a cancelled CI job sends
+  // the parent SIGTERM. Without forwarding, the parent dies and the review is
+  // reparented to PID 1, burning model API calls for up to the full timeout
+  // (and, with --comment, can still post after the job that spawned it is
+  // gone). Terminate the group on the way out, mirroring the timeout path.
+  const onParentSignal = (signal: NodeJS.Signals): void => {
+    clearTimeout(timer);
+    clearInterval(captureTimer);
+    const pid = child.pid;
+    if (pid !== undefined) {
+      // SIGTERM's default action terminates the node group; the parent exits
+      // immediately, so there is no later moment to escalate to SIGKILL.
+      killProcessGroup(pid, 'SIGTERM');
+    }
+    process.exit(SIGNAL_EXIT_CODES[signal] ?? 1);
+  };
+  for (const signal of PARENT_SIGNALS) process.on(signal, onParentSignal);
 
   const childOutcome = await new Promise<{
     code: number | null;
@@ -245,22 +339,27 @@ async function runReview(args: RunReviewArgs): Promise<void> {
   const childExitCode = childOutcome.code;
   const childSignal = childOutcome.signal;
   clearTimeout(timer);
+  clearInterval(captureTimer);
+  for (const signal of PARENT_SIGNALS) process.off(signal, onParentSignal);
 
   // The verdict is what compose-review wrote, not what the child printed. A
   // clean child exit without a composed artifact means the run wandered off
-  // before Step 7 — that is "no verdict", not "approve".
-  //
-  // The cutoff carries slack: a coarse filesystem clock can stamp a file a
-  // moment BEFORE the Date.now() captured at run start, and a review's own
-  // verdict must not be discarded over clock granularity. Artifacts from a
-  // previous review are minutes old, far outside any slack.
-  const cutoffMs = startMs - 2_000;
-  const composedPath = newestArtifactSince(
-    REVIEW_TMP_DIR,
-    /^qwen-review-.*composed\.json$/,
-    cutoffMs,
-  );
-  const composed = composedPath ? readComposed(composedPath) : null;
+  // before Step 7 — that is "no verdict", not "approve". Prefer the verdict
+  // captured during the run (Step 9 cleanup has usually swept the file by now);
+  // fall back to a disk scan for a child that died before cleanup ran.
+  // Annotated, not inferred: capturedPath/capturedVerdict are mutated only
+  // inside the poll closure, so control-flow analysis would narrow them to
+  // their `null` initializer and reject the fallback reassignment below.
+  let composedPath: string | null = capturedPath;
+  let composed: ComposedVerdict | null = capturedVerdict;
+  if (composed === null) {
+    composedPath = newestArtifactSince(
+      REVIEW_TMP_DIR,
+      COMPOSED_PATTERN,
+      cutoffMs,
+    );
+    composed = composedPath ? readComposed(composedPath) : null;
+  }
   const reportPath = newestArtifactSince(REVIEWS_DIR, /\.md$/, cutoffMs);
 
   const completed = composed !== null && !timedOut;
@@ -281,26 +380,34 @@ async function runReview(args: RunReviewArgs): Promise<void> {
     durationMs: Date.now() - startMs,
   };
 
-  if (args.json) {
-    writeStdoutLine(JSON.stringify(result, null, 2));
-  } else if (completed) {
-    writeStdoutLine(result.verdictLine ?? `Event: ${result.event}`);
-    if (result.reportPath) writeStdoutLine(`Report: ${result.reportPath}`);
-  } else {
-    const detail =
-      composedPath !== null
-        ? `a composed verdict was found at ${resolve(composedPath)} but could not be parsed`
-        : 'no composed verdict was produced';
-    writeStdoutLine(
-      timedOut
-        ? 'Review did not complete: timed out.'
-        : `Review did not complete: ${detail}` +
-            `${childExitCode !== null ? ` (CLI exit ${childExitCode})` : ''}` +
-            `${childSignal !== null ? ` (killed by ${childSignal})` : ''}.`,
-    );
-  }
-
+  // Assign the exit code BEFORE writing the result: a stdout write can throw
+  // (EPIPE once the pipe reader exits), and the exit code — not the prose — is
+  // the contract a CI gate reads. A throw must not downgrade a blocking verdict
+  // (exit 3) to yargs' generic failure (exit 1).
   process.exitCode = exitCodeFor(completed, result.event, args.failOn);
+
+  try {
+    if (args.json) {
+      writeStdoutLine(JSON.stringify(result, null, 2));
+    } else if (completed) {
+      writeStdoutLine(result.verdictLine ?? `Event: ${result.event}`);
+      if (result.reportPath) writeStdoutLine(`Report: ${result.reportPath}`);
+    } else {
+      const detail =
+        composedPath !== null
+          ? `a composed verdict was found at ${resolve(composedPath)} but could not be parsed`
+          : 'no composed verdict was produced';
+      writeStdoutLine(
+        timedOut
+          ? 'Review did not complete: timed out.'
+          : `Review did not complete: ${detail}` +
+              `${childExitCode !== null ? ` (CLI exit ${childExitCode})` : ''}` +
+              `${childSignal !== null ? ` (killed by ${childSignal})` : ''}.`,
+      );
+    }
+  } catch {
+    // stdout is gone; the exit code above is the contract, not this prose.
+  }
 }
 
 export const runCommand: CommandModule = {
@@ -312,7 +419,7 @@ export const runCommand: CommandModule = {
       .positional('target', {
         type: 'string',
         describe:
-          'What to review: a PR number, or omit to review the local working tree',
+          'What to review: a PR number, a PR URL, or a file path; omit to review the local working tree',
       })
       .option('effort', {
         type: 'string',
@@ -364,7 +471,12 @@ export const runCommand: CommandModule = {
       comment: Boolean(argv['comment']),
       json: Boolean(argv['json']),
       failOn: (argv['fail-on'] as 'none' | 'request-changes') ?? 'none',
-      timeoutMinutes: Math.max(1, Number(argv['timeout-minutes']) || 120),
+      // `|| 120` would treat an explicit `--timeout-minutes 0` as falsy and
+      // silently substitute the default; decide default-vs-value by finiteness
+      // so 0 still reaches the 1-minute floor.
+      timeoutMinutes: Number.isFinite(Number(argv['timeout-minutes']))
+        ? Math.max(1, Number(argv['timeout-minutes']))
+        : 120,
       approvalMode: String(argv['approval-mode'] ?? 'yolo'),
       quiet: Boolean(argv['quiet']),
     });

--- a/packages/cli/src/commands/review/run.ts
+++ b/packages/cli/src/commands/review/run.ts
@@ -29,7 +29,10 @@ import type { CommandModule } from 'yargs';
 import { spawn } from 'node:child_process';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { writeStdoutLine, writeStderrLine } from '../../utils/stdioHelpers.js';
+import {
+  writeStdoutLine,
+  writeStderrLineSafe,
+} from '../../utils/stdioHelpers.js';
 import { REVIEW_TMP_DIR, REVIEWS_DIR } from './lib/paths.js';
 import { EFFORT_LEVELS } from './parse-args.js';
 
@@ -67,6 +70,7 @@ export interface RunReviewResult {
   composedPath: string | null;
   reportPath: string | null;
   childExitCode: number | null;
+  childSignal: string | null;
   timedOut: boolean;
   durationMs: number;
 }
@@ -78,7 +82,17 @@ export function buildReviewPrompt(args: {
   comment?: boolean;
 }): string {
   const parts = ['/review'];
-  if (args.target) parts.push(args.target);
+  if (args.target) {
+    // The child re-tokenizes this string; a target carrying whitespace or a
+    // leading dash would split into extra tokens (`123 --comment` would
+    // silently authorise posting) — refuse anything but a single clean token.
+    if (/\s/.test(args.target) || args.target.startsWith('-')) {
+      throw new Error(
+        `Invalid review target ${JSON.stringify(args.target)}: expected a single PR number, PR URL, or file path`,
+      );
+    }
+    parts.push(args.target);
+  }
   if (args.effort) parts.push(`--effort ${args.effort}`);
   if (args.comment) parts.push('--comment');
   return parts.join(' ');
@@ -166,9 +180,18 @@ async function runReview(args: RunReviewArgs): Promise<void> {
   );
 
   if (!args.quiet) {
-    // Progress belongs on stderr; stdout is reserved for the result.
-    child.stdout?.on('data', (chunk: Buffer) => process.stderr.write(chunk));
-    child.stderr?.on('data', (chunk: Buffer) => process.stderr.write(chunk));
+    // Progress belongs on stderr; stdout is reserved for the result. A throw
+    // here (EPIPE once the pipe reader exits) would crash the parent and orphan
+    // the child review, so the write stays incidental.
+    const writeProgress = (chunk: Buffer): void => {
+      try {
+        process.stderr.write(chunk);
+      } catch {
+        // stderr is gone; the verdict, not the progress, is what matters.
+      }
+    };
+    child.stdout?.on('data', writeProgress);
+    child.stderr?.on('data', writeProgress);
   } else {
     child.stdout?.resume();
     child.stderr?.resume();
@@ -178,7 +201,9 @@ async function runReview(args: RunReviewArgs): Promise<void> {
   const timeoutMs = args.timeoutMinutes * 60_000;
   const timer = setTimeout(() => {
     timedOut = true;
-    writeStderrLine(
+    // Safe write: a throw on EPIPE would skip the kill below and leave the
+    // child review running on, burning compute and model API calls.
+    writeStderrLineSafe(
       `review run: timeout after ${args.timeoutMinutes} minutes — terminating the review`,
     );
     child.kill('SIGTERM');
@@ -186,13 +211,20 @@ async function runReview(args: RunReviewArgs): Promise<void> {
     setTimeout(() => child.kill('SIGKILL'), 10_000).unref();
   }, timeoutMs);
 
-  const childExitCode: number | null = await new Promise((resolvePromise) => {
-    child.on('close', (code) => resolvePromise(code));
+  const childOutcome = await new Promise<{
+    code: number | null;
+    signal: string | null;
+  }>((resolvePromise) => {
+    child.on('close', (code, signal) => resolvePromise({ code, signal }));
     child.on('error', (err) => {
-      writeStderrLine(`review run: failed to launch the CLI: ${err.message}`);
-      resolvePromise(null);
+      writeStderrLineSafe(
+        `review run: failed to launch the CLI: ${err.message}`,
+      );
+      resolvePromise({ code: null, signal: null });
     });
   });
+  const childExitCode = childOutcome.code;
+  const childSignal = childOutcome.signal;
   clearTimeout(timer);
 
   // The verdict is what compose-review wrote, not what the child printed. A
@@ -225,6 +257,7 @@ async function runReview(args: RunReviewArgs): Promise<void> {
     composedPath: composedPath ? resolve(composedPath) : null,
     reportPath: reportPath ? resolve(reportPath) : null,
     childExitCode,
+    childSignal,
     timedOut,
     durationMs: Date.now() - startMs,
   };
@@ -239,7 +272,8 @@ async function runReview(args: RunReviewArgs): Promise<void> {
       timedOut
         ? 'Review did not complete: timed out.'
         : `Review did not complete: no composed verdict was produced` +
-            `${childExitCode !== null ? ` (CLI exit ${childExitCode})` : ''}.`,
+            `${childExitCode !== null ? ` (CLI exit ${childExitCode})` : ''}` +
+            `${childSignal !== null ? ` (killed by ${childSignal})` : ''}.`,
     );
   }
 
@@ -290,6 +324,7 @@ export const runCommand: CommandModule = {
       .option('approval-mode', {
         type: 'string',
         default: 'yolo',
+        choices: ['plan', 'default', 'auto-edit', 'auto', 'yolo'],
         describe:
           'Approval mode for the child CLI. The default is yolo: headless runs cannot answer ' +
           'confirmation prompts, and anything still unapproved would be auto-denied mid-review.',

--- a/packages/cli/src/commands/review/run.ts
+++ b/packages/cli/src/commands/review/run.ts
@@ -1,0 +1,314 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// `qwen review run`: execute a full /review non-interactively and report the
+// verdict in a machine-readable way.
+//
+// The review pipeline already runs headless — `qwen --prompt "/review …"` expands
+// the bundled skill, launches the dimension agents, and honors the approval mode.
+// What that path does NOT give a caller is a contract: the verdict lives in the
+// model's prose and in files whose names the caller would have to know, the exit
+// code says nothing about the review's outcome, and a piped stdin silently
+// defeats slash-command detection (the runner prepends piped input, and
+// `isSlashCommand` requires the FIRST character to be `/`). Every consumer that
+// wants "run a review, tell me what it decided" has been re-deriving those facts
+// by scraping a terminal.
+//
+// This command is that contract, and nothing more: it assembles the /review
+// invocation, runs the CLI's own non-interactive path in a child process with
+// stdin closed, and then reads the verdict from the artifact `compose-review`
+// wrote — the same JSON the skill treats as the verdict authority — rather than
+// from anything the model said. Progress streams to stderr; stdout carries only
+// the result; the exit code distinguishes "review completed" from "review never
+// reached a verdict" from "blocking verdict" (opt-in via --fail-on).
+
+import type { CommandModule } from 'yargs';
+import { spawn } from 'node:child_process';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { writeStdoutLine, writeStderrLine } from '../../utils/stdioHelpers.js';
+import { REVIEW_TMP_DIR, REVIEWS_DIR } from './lib/paths.js';
+import { EFFORT_LEVELS } from './parse-args.js';
+
+export interface RunReviewArgs {
+  target?: string;
+  effort?: string;
+  comment: boolean;
+  json: boolean;
+  failOn: 'none' | 'request-changes';
+  timeoutMinutes: number;
+  approvalMode: string;
+  quiet: boolean;
+}
+
+/** The composed-verdict fields this command republishes (see compose-review). */
+interface ComposedVerdict {
+  event?: string;
+  verdictLine?: string;
+  baseEvent?: string;
+  cappedBy?: string[];
+  downgraded?: boolean;
+  downgradedFrom?: string | null;
+  remediation?: string[];
+}
+
+export interface RunReviewResult {
+  completed: boolean;
+  event: string | null;
+  verdictLine: string | null;
+  baseEvent: string | null;
+  cappedBy: string[];
+  downgraded: boolean;
+  downgradedFrom: string | null;
+  remediation: string[];
+  composedPath: string | null;
+  reportPath: string | null;
+  childExitCode: number | null;
+  timedOut: boolean;
+  durationMs: number;
+}
+
+/** The /review invocation the child runs — built from flags, never hand-typed. */
+export function buildReviewPrompt(args: {
+  target?: string;
+  effort?: string;
+  comment?: boolean;
+}): string {
+  const parts = ['/review'];
+  if (args.target) parts.push(args.target);
+  if (args.effort) parts.push(`--effort ${args.effort}`);
+  if (args.comment) parts.push('--comment');
+  return parts.join(' ');
+}
+
+/**
+ * The newest file under `dir` matching `pattern` whose mtime is at or after
+ * `startMs`, or null. Pre-existing artifacts from earlier reviews in the same
+ * repo must not be mistaken for this run's verdict — a stale composed JSON says
+ * whatever the LAST review decided, which is exactly the wrong thing to
+ * republish — so anything older than the run is invisible here.
+ */
+export function newestArtifactSince(
+  dir: string,
+  pattern: RegExp,
+  startMs: number,
+): string | null {
+  let best: { path: string; mtime: number } | null = null;
+  let names: string[];
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return null; // no directory — the review never got far enough to create it
+  }
+  for (const name of names) {
+    if (!pattern.test(name)) continue;
+    const path = join(dir, name);
+    let mtime: number;
+    try {
+      mtime = statSync(path).mtimeMs;
+    } catch {
+      continue;
+    }
+    if (mtime < startMs) continue;
+    if (!best || mtime > best.mtime) best = { path, mtime };
+  }
+  return best ? best.path : null;
+}
+
+/**
+ * Exit code contract: 0 = the review completed (whatever it decided); 1 = it
+ * never reached a verdict (child failed, timed out, or left no composed
+ * artifact); 3 = it completed AND the caller asked --fail-on request-changes
+ * AND the event is REQUEST_CHANGES. 3, not 2 — yargs exits 1 on usage errors
+ * and some shells reserve 2, so a CI gate can tell "review is blocking" from
+ * "the tool broke" without parsing anything.
+ */
+export function exitCodeFor(
+  completed: boolean,
+  event: string | null,
+  failOn: 'none' | 'request-changes',
+): number {
+  if (!completed) return 1;
+  if (failOn === 'request-changes' && event === 'REQUEST_CHANGES') return 3;
+  return 0;
+}
+
+function readComposed(path: string): ComposedVerdict | null {
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as ComposedVerdict;
+    // The one field everything downstream keys on. A file without it is not a
+    // composed verdict, whatever its name says.
+    return typeof parsed.event === 'string' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+async function runReview(args: RunReviewArgs): Promise<void> {
+  const startMs = Date.now();
+  const prompt = buildReviewPrompt(args);
+
+  // Re-enter THIS build's CLI, not whatever `qwen` PATH resolves to — the same
+  // version-skew rule the skill's own subprocesses follow via QWEN_CODE_CLI.
+  // process.argv[1] is the entry that is already running this command.
+  const child = spawn(
+    process.execPath,
+    [process.argv[1], '--prompt', prompt, '--approval-mode', args.approvalMode],
+    {
+      // stdin CLOSED, not inherited: piped input would be prepended to the
+      // prompt and the leading `/` would no longer be the first character —
+      // the slash command would reach the model as plain text.
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+
+  if (!args.quiet) {
+    // Progress belongs on stderr; stdout is reserved for the result.
+    child.stdout?.on('data', (chunk: Buffer) => process.stderr.write(chunk));
+    child.stderr?.on('data', (chunk: Buffer) => process.stderr.write(chunk));
+  } else {
+    child.stdout?.resume();
+    child.stderr?.resume();
+  }
+
+  let timedOut = false;
+  const timeoutMs = args.timeoutMinutes * 60_000;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    writeStderrLine(
+      `review run: timeout after ${args.timeoutMinutes} minutes — terminating the review`,
+    );
+    child.kill('SIGTERM');
+    // The runner traps SIGTERM for cleanup; give it a moment, then insist.
+    setTimeout(() => child.kill('SIGKILL'), 10_000).unref();
+  }, timeoutMs);
+
+  const childExitCode: number | null = await new Promise((resolvePromise) => {
+    child.on('close', (code) => resolvePromise(code));
+    child.on('error', (err) => {
+      writeStderrLine(`review run: failed to launch the CLI: ${err.message}`);
+      resolvePromise(null);
+    });
+  });
+  clearTimeout(timer);
+
+  // The verdict is what compose-review wrote, not what the child printed. A
+  // clean child exit without a composed artifact means the run wandered off
+  // before Step 7 — that is "no verdict", not "approve".
+  //
+  // The cutoff carries slack: a coarse filesystem clock can stamp a file a
+  // moment BEFORE the Date.now() captured at run start, and a review's own
+  // verdict must not be discarded over clock granularity. Artifacts from a
+  // previous review are minutes old, far outside any slack.
+  const cutoffMs = startMs - 2_000;
+  const composedPath = newestArtifactSince(
+    REVIEW_TMP_DIR,
+    /^qwen-review-.*composed\.json$/,
+    cutoffMs,
+  );
+  const composed = composedPath ? readComposed(composedPath) : null;
+  const reportPath = newestArtifactSince(REVIEWS_DIR, /\.md$/, cutoffMs);
+
+  const completed = composed !== null && !timedOut;
+  const result: RunReviewResult = {
+    completed,
+    event: composed?.event ?? null,
+    verdictLine: composed?.verdictLine ?? null,
+    baseEvent: composed?.baseEvent ?? null,
+    cappedBy: composed?.cappedBy ?? [],
+    downgraded: composed?.downgraded ?? false,
+    downgradedFrom: composed?.downgradedFrom ?? null,
+    remediation: composed?.remediation ?? [],
+    composedPath: composedPath ? resolve(composedPath) : null,
+    reportPath: reportPath ? resolve(reportPath) : null,
+    childExitCode,
+    timedOut,
+    durationMs: Date.now() - startMs,
+  };
+
+  if (args.json) {
+    writeStdoutLine(JSON.stringify(result, null, 2));
+  } else if (completed) {
+    writeStdoutLine(result.verdictLine ?? `Event: ${result.event}`);
+    if (result.reportPath) writeStdoutLine(`Report: ${result.reportPath}`);
+  } else {
+    writeStdoutLine(
+      timedOut
+        ? 'Review did not complete: timed out.'
+        : `Review did not complete: no composed verdict was produced` +
+            `${childExitCode !== null ? ` (CLI exit ${childExitCode})` : ''}.`,
+    );
+  }
+
+  process.exitCode = exitCodeFor(completed, result.event, args.failOn);
+}
+
+export const runCommand: CommandModule = {
+  command: 'run [target]',
+  describe:
+    'Run a full /review non-interactively and print the verdict (machine-readable with --json)',
+  builder: (yargs) =>
+    yargs
+      .positional('target', {
+        type: 'string',
+        describe:
+          'What to review: a PR number, or omit to review the local working tree',
+      })
+      .option('effort', {
+        type: 'string',
+        choices: [...EFFORT_LEVELS],
+        describe:
+          'The review effort. Defaults to the skill default for the target (high for a PR, medium locally).',
+      })
+      .option('comment', {
+        type: 'boolean',
+        default: false,
+        describe:
+          'Authorise posting the review to GitHub (PR targets only) — same meaning as `/review <pr> --comment`',
+      })
+      .option('json', {
+        type: 'boolean',
+        default: false,
+        describe: 'Print the full result as JSON on stdout',
+      })
+      .option('fail-on', {
+        type: 'string',
+        choices: ['none', 'request-changes'],
+        default: 'none',
+        describe:
+          'Exit 3 when the review completes with this outcome — lets CI gate on the verdict without parsing output',
+      })
+      .option('timeout-minutes', {
+        type: 'number',
+        default: 120,
+        describe:
+          'Terminate the review after this long without a verdict (exit 1)',
+      })
+      .option('approval-mode', {
+        type: 'string',
+        default: 'yolo',
+        describe:
+          'Approval mode for the child CLI. The default is yolo: headless runs cannot answer ' +
+          'confirmation prompts, and anything still unapproved would be auto-denied mid-review.',
+      })
+      .option('quiet', {
+        type: 'boolean',
+        default: false,
+        describe: 'Suppress the child CLI progress stream on stderr',
+      }),
+  handler: async (argv) => {
+    await runReview({
+      target: argv['target'] as string | undefined,
+      effort: argv['effort'] as string | undefined,
+      comment: Boolean(argv['comment']),
+      json: Boolean(argv['json']),
+      failOn: (argv['fail-on'] as 'none' | 'request-changes') ?? 'none',
+      timeoutMinutes: Number(argv['timeout-minutes']) || 120,
+      approvalMode: String(argv['approval-mode'] ?? 'yolo'),
+      quiet: Boolean(argv['quiet']),
+    });
+  },
+};

--- a/packages/cli/src/commands/review/run.ts
+++ b/packages/cli/src/commands/review/run.ts
@@ -162,11 +162,11 @@ export function newestArtifactSince(
 
 /**
  * Exit code contract: 0 = the review completed (whatever it decided); 1 = it
- * never reached a verdict (child failed, timed out, or left no composed
- * artifact); 3 = it completed AND the caller asked --fail-on request-changes
- * AND the event is REQUEST_CHANGES. 3, not 2 — yargs exits 1 on usage errors
- * and some shells reserve 2, so a CI gate can tell "review is blocking" from
- * "the tool broke" without parsing anything.
+ * never reached a verdict (child failed, timed out with no verdict captured,
+ * or left no composed artifact); 3 = it completed AND the caller asked
+ * --fail-on request-changes AND the event is REQUEST_CHANGES. 3, not 2 — yargs
+ * exits 1 on usage errors and some shells reserve 2, so a CI gate can tell
+ * "review is blocking" from "the tool broke" without parsing anything.
  */
 export function exitCodeFor(
   completed: boolean,
@@ -373,7 +373,7 @@ async function runReview(args: RunReviewArgs): Promise<void> {
   }
   const reportPath = newestArtifactSince(REVIEWS_DIR, /\.md$/, cutoffMs);
 
-  const completed = composed !== null && !timedOut;
+  const completed = composed !== null;
   const result: RunReviewResult = {
     completed,
     event: composed?.event ?? null,


### PR DESCRIPTION
Part of #7981 (item P2-8, "first-class headless mode").

## What

`qwen review run [target]` — run a full `/review` non-interactively and get the verdict back as a contract: machine-readable output on stdout, progress on stderr, and exit codes a CI gate can branch on.

```
qwen review run --effort high --json            # review the local working tree
qwen review run 7724 --fail-on request-changes  # gate CI on a PR review
```

## Why

The review pipeline already runs headless — `qwen --prompt "/review …"` expands the bundled skill, launches the dimension agents, and honors the approval mode. What that path lacks is a contract:

- the verdict lives in the model's prose and in artifact files whose names the caller must simply know;
- the process exit code says nothing about the review's outcome;
- piped stdin silently defeats slash-command detection (the runner prepends piped input, so the leading `/` is no longer the first character and the skill never expands).

Every consumer that wants "run a review, tell me what it decided" — benchmarks, CI, cron — has been re-deriving those facts by scraping a terminal.

## How

`review run` is a thin wrapper and nothing more:

- assembles the `/review` invocation from typed flags (`--effort`, `--comment`), so callers never hand-type prompt strings;
- re-enters **this build's own CLI** in a child process (`process.execPath` + the running entry — the same version-skew rule the skill's subprocesses follow via `QWEN_CODE_CLI`), with **stdin closed** so piped input cannot break slash detection;
- streams the child's progress to stderr (suppress with `--quiet`); stdout carries only the result (`--json` for the full object);
- reads the verdict from the artifact `compose-review` wrote — the same JSON the skill treats as the verdict authority — never from anything the model printed. Artifact discovery is scoped to this run by an mtime cutoff (with slack for coarse filesystem clocks), so a stale composed JSON from an earlier review can never be republished as this run's outcome;
- `--timeout-minutes` (default 120) terminates a wandering run; `--approval-mode` defaults to `yolo` because a headless run cannot answer confirmation prompts (anything unapproved would be auto-denied mid-review) — overridable.

Exit codes: `0` = the review completed (whatever it decided); `1` = it never reached a verdict (child failure, timeout, or no composed artifact — a clean child exit without one is a run that wandered off, **not** an approve); `3` = completed AND `--fail-on request-changes` AND the event is `REQUEST_CHANGES`. 3 rather than 2, so "the review is blocking" is distinguishable from yargs usage errors and shell-reserved codes without parsing anything.

## Tests

`run.test.ts` pins the contract: prompt assembly; artifact discovery (stale artifacts ignored, newest-of-this-run wins, missing directory tolerated); the 0/1/3 exit split including "incomplete run is 1 even under `--fail-on`"; spawn wiring (stdin closed, `--prompt` passed, approval mode threaded); and the wandered-off case (clean child exit, no composed artifact → failure). 12 tests, all green; eslint `--max-warnings 0` clean; tsc clean for the touched files.

<details>
<summary>中文说明</summary>

关联 #7981(P2-8 "一等公民 headless 模式")。

## 做了什么

`qwen review run [target]` —— 非交互地执行完整 `/review`,并以契约形式返回结果:stdout 输出机器可读裁决、stderr 输出进度、退出码可直接供 CI 分支判断。

```
qwen review run --effort high --json            # 评审本地工作区
qwen review run 7724 --fail-on request-changes  # 以 PR 评审结果做 CI 门禁
```

## 为什么

评审流水线本来就能 headless 跑——`qwen --prompt "/review …"` 会展开 bundled skill、启动各维度 agent、遵循审批模式。缺的是契约:裁决藏在模型的文字叙述和调用方必须"恰好知道"文件名的产物里;进程退出码不反映评审结果;管道 stdin 会静默破坏斜杠命令识别(runner 会把管道输入拼在前面,`/` 不再是第一个字符,skill 不会展开)。所有想要"跑一次评审,告诉我结论"的消费者(基准测试、CI、定时任务)都在靠刮终端输出自行还原这些事实。

## 怎么做

`review run` 是一层薄包装,仅此而已:

- 从类型化参数(`--effort`、`--comment`)组装 `/review` 调用,调用方无需手拼 prompt;
- 在子进程里重入**当前构建自身的 CLI**(`process.execPath` + 正在运行的入口——与 skill 子进程通过 `QWEN_CODE_CLI` 遵循的同一条"防版本漂移"规则),并**关闭 stdin**,管道输入无法破坏斜杠识别;
- 子进程进度转发到 stderr(`--quiet` 可静音);stdout 只承载结果(`--json` 输出完整对象);
- 裁决读取自 `compose-review` 落盘的产物——即 skill 视为裁决权威的那份 JSON——绝不读模型打印的内容。产物发现以本次运行的 mtime 为界(对粗粒度文件系统时钟留余量),上一次评审的陈旧 composed JSON 绝不会被当作本次结果重新发布;
- `--timeout-minutes`(默认 120)终止跑飞的评审;`--approval-mode` 默认 `yolo`(headless 无法应答确认弹窗,未预批准的工具会在评审中途被自动拒绝),可覆盖。

退出码:`0` = 评审完成(无论结论);`1` = 未达成裁决(子进程失败、超时、或无 composed 产物——子进程干净退出但没有产物属于"跑偏",**不是** approve);`3` = 完成且 `--fail-on request-changes` 且事件为 `REQUEST_CHANGES`。用 3 而非 2,使"评审给出阻断结论"与 yargs 用法错误、shell 保留码可区分,无需解析任何输出。

## 测试

`run.test.ts` 固定契约:prompt 组装;产物发现(忽略陈旧产物、取本次最新、目录缺失容忍);0/1/3 退出码划分(含"未完成时即使 `--fail-on` 命中也返回 1");spawn 接线(stdin 关闭、`--prompt` 传入、审批模式透传);以及跑偏场景(子进程干净退出但无 composed 产物 → 失败)。12 个测试全绿;eslint `--max-warnings 0` 干净;涉及文件 tsc 干净。

</details>
