### PR TITLE
fix(review): preflight free disk before build-test installs and builds

### DIFF
--- a/packages/cli/src/commands/review/build-test.test.ts
+++ b/packages/cli/src/commands/review/build-test.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -14,6 +14,19 @@ import {
   buildRunEnv,
 } from './build-test.js';
 import type { WorkspacePackage } from './lib/workspaces.js';
+
+const statfsSyncMock = vi.hoisted(() => vi.fn());
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  const mock = { ...actual, statfsSync: statfsSyncMock };
+  return { ...mock, default: mock };
+});
+
+beforeEach(() => {
+  // Plenty of disk by default, so this suite behaves the same on a nearly-full
+  // machine as on an empty one — the low-disk cases below opt in explicitly.
+  statfsSyncMock.mockReturnValue({ bavail: 16 * 1024 ** 3, bsize: 1 });
+});
 
 const PKGS: WorkspacePackage[] = [
   { dir: 'packages/core', name: '@x/core', scripts: ['build'], deps: [] },
@@ -915,6 +928,184 @@ describe('runBuildTest', () => {
     expect(calls.some((c) => c.startsWith('npm run build'))).toBe(false);
     expect(rep.note).toContain('infrastructure');
     expect(rep.note).not.toContain('Critical');
+  });
+
+  it('skips `npm ci` on a low disk, with the deadline-skip shape and disclosure', () => {
+    // The dogfood failure this pins: ~2.7G free, `npm ci` ran 33 seconds, died
+    // on ENOSPC, and the now-full disk failed every agent downstream. The
+    // preflight finds that out before the command runs, and reports it exactly
+    // like a deadline skip: nothing executed, ok:false, and a note that frames
+    // the skip as environment — never a finding against the PR.
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({ name: 'r', workspaces: ['packages/*'] }),
+    );
+    pkg('packages/a', {
+      name: '@x/a',
+      scripts: { build: 'exit 0', test: 'exit 0' },
+    });
+    writePlan(['packages/a/src/x.ts']);
+    rmSync(join(root, 'node_modules'), { recursive: true, force: true });
+    statfsSyncMock.mockReturnValue({ bavail: 2.9e9, bsize: 1 }); // ~2.7G free
+
+    const calls: string[] = [];
+    const rep = runBuildTest({
+      plan: planPath,
+      worktree: root,
+      timeout: 60,
+      install: true,
+      exec: (command) => {
+        calls.push(command);
+        return {
+          command,
+          exitCode: 0,
+          seconds: 1,
+          timedOut: false,
+          output: '',
+        };
+      },
+    });
+
+    // Nothing ran: not `npm ci`, and not a build against the absent tree.
+    expect(calls).toEqual([]);
+    expect(rep.install).toBeNull();
+    // The same shape a deadline skip leaves: ok:false, empty build/test, and a
+    // note the agent reports as informational. (`timedOut` stays empty — no
+    // command ran long enough to time out.)
+    expect(rep.ok).toBe(false);
+    expect(rep.build).toEqual([]);
+    expect(rep.test).toEqual([]);
+    expect(rep.timedOut).toEqual([]);
+    expect(rep.note).toContain('Insufficient disk space (2.7G free');
+    expect(rep.note).toContain('skipped `npm ci --no-audit --no-fund`');
+    expect(rep.note).toContain('environment');
+    expect(rep.note).toContain('informational');
+    expect(rep.note).not.toContain('Critical');
+  });
+
+  it('skips the build phase when a warm tree meets a nearly-full disk', () => {
+    // A complete node_modules skips the install (and its 3 GiB gate) entirely,
+    // but a compile that hits ENOSPC mid-write fails with errors that read as
+    // defects in the diff — and leaves the disk full for every later agent.
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({ name: 'r', workspaces: ['packages/*'] }),
+    );
+    pkg('packages/a', {
+      name: '@x/a',
+      scripts: { build: 'exit 0', test: 'exit 0' },
+    });
+    writePlan(['packages/a/src/x.ts']);
+    statfsSyncMock.mockReturnValue({ bavail: 5.4e8, bsize: 1 }); // ~0.5G free
+
+    const calls: string[] = [];
+    const rep = runBuildTest({
+      plan: planPath,
+      worktree: root,
+      timeout: 60,
+      install: true,
+      exec: (command) => {
+        calls.push(command);
+        return {
+          command,
+          exitCode: 0,
+          seconds: 1,
+          timedOut: false,
+          output: '',
+        };
+      },
+    });
+
+    expect(calls).toEqual([]);
+    expect(rep.ok).toBe(false);
+    expect(rep.build).toEqual([]);
+    expect(rep.test).toEqual([]);
+    expect(rep.note).toContain('Insufficient disk space (0.5G free');
+    expect(rep.note).toContain('informational');
+    expect(rep.note).not.toContain('Critical');
+  });
+
+  it('still builds a warm tree between the build floor and the install floor', () => {
+    // ~2G free fails the 3 GiB install gate but the install is not needed here
+    // (the tree is complete), and it clears the 1 GiB build floor — so the run
+    // proceeds. The two floors exist so a warm tree is not refused an install
+    // it was never going to run.
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({ name: 'r', workspaces: ['packages/*'] }),
+    );
+    pkg('packages/a', {
+      name: '@x/a',
+      scripts: { build: 'exit 0', test: 'exit 0' },
+    });
+    writePlan(['packages/a/src/x.ts']);
+    statfsSyncMock.mockReturnValue({ bavail: 2.2e9, bsize: 1 }); // ~2G free
+
+    const calls: string[] = [];
+    const rep = runBuildTest({
+      plan: planPath,
+      worktree: root,
+      timeout: 60,
+      install: true,
+      exec: (command) => {
+        calls.push(command);
+        return {
+          command,
+          exitCode: 0,
+          seconds: 1,
+          timedOut: false,
+          output: '',
+        };
+      },
+    });
+
+    expect(calls.some((c) => c.startsWith('npm ci'))).toBe(false);
+    expect(calls).toContain('npm run build --workspace="packages/a"');
+    expect(rep.ok).toBe(true);
+  });
+
+  it('proceeds when statfs itself is unavailable — the preflight must not invent failures', () => {
+    // `statfsSync` does not exist on every platform. An unmeasurable disk lets
+    // the run proceed; the preflight exists to prevent failures, not cause them.
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({ name: 'r', workspaces: ['packages/*'] }),
+    );
+    pkg('packages/a', {
+      name: '@x/a',
+      scripts: { build: 'exit 0', test: 'exit 0' },
+    });
+    writePlan(['packages/a/src/x.ts']);
+    rmSync(join(root, 'node_modules'), { recursive: true, force: true });
+    statfsSyncMock.mockImplementation(() => {
+      throw new Error('ENOSYS: statfs not supported');
+    });
+
+    const calls: string[] = [];
+    const rep = runBuildTest({
+      plan: planPath,
+      worktree: root,
+      timeout: 60,
+      install: true,
+      exec: (command, cwd) => {
+        calls.push(command);
+        if (command.startsWith('npm ci')) {
+          mkdirSync(join(cwd, 'node_modules'), { recursive: true });
+          writeFileSync(join(cwd, 'node_modules', '.package-lock.json'), '{}');
+        }
+        return {
+          command,
+          exitCode: 0,
+          seconds: 1,
+          timedOut: false,
+          output: '',
+        };
+      },
+    });
+
+    expect(calls.some((c) => c.startsWith('npm ci'))).toBe(true);
+    expect(calls).toContain('npm run build --workspace="packages/a"');
+    expect(rep.ok).toBe(true);
   });
 
   it('frames a TEST timeout as infrastructure, not a defect to correlate', () => {

--- a/packages/cli/src/commands/review/build-test.ts
+++ b/packages/cli/src/commands/review/build-test.ts
@@ -39,7 +39,13 @@
 
 import type { CommandModule } from 'yargs';
 import { spawnSync } from 'node:child_process';
-import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  readFileSync,
+  rmSync,
+  statfsSync,
+  writeFileSync,
+} from 'node:fs';
 import { join, resolve } from 'node:path';
 import { writeStdoutLine, writeStderrLine } from '../../utils/stdioHelpers.js';
 import {
@@ -121,6 +127,40 @@ function trimOutput(s: string): string {
     : `\n\n... [${omitted} characters omitted] ...\n\n`;
   return s.slice(0, KEEP_HEAD) + marker + s.slice(-KEEP_TAIL);
 }
+
+/**
+ * Free-disk floors for the preflights below, in bytes.
+ *
+ * Dogfooded on a live review: with ~2.7G free, `npm ci` on this monorepo ran 33
+ * seconds, died on `ENOSPC`, and the now-full disk went on to fail every agent
+ * scheduled after this command — a disk a command fills is not a failure that
+ * stays contained to that command. The installed `node_modules` here is ~1.4G,
+ * and npm stages cache and temp writes on the same filesystem while it
+ * materialises the tree, so 3 GiB is the least an install can be trusted with.
+ * The build phase writes far less (`dist/` and tsbuildinfo) and gets a lower
+ * floor — enough that a compile cannot be the thing that fills the disk. Like
+ * the deadline, a floor violation is skip-and-disclose, never a finding: an
+ * environment that cannot fit the command is not a defect in the diff.
+ */
+const INSTALL_MIN_FREE_BYTES = 3 * 1024 ** 3;
+const BUILD_MIN_FREE_BYTES = 1024 ** 3;
+
+/**
+ * Free bytes on the filesystem holding `dir`, or `null` where that cannot be
+ * measured (`statfsSync` is not available on every platform). An unmeasurable
+ * disk lets the run proceed: the preflight exists to prevent failures, not to
+ * invent them.
+ */
+function freeDiskBytes(dir: string): number | null {
+  try {
+    const s = statfsSync(dir);
+    return s.bavail * s.bsize;
+  } catch {
+    return null;
+  }
+}
+
+const gib = (bytes: number): string => (bytes / 1024 ** 3).toFixed(1);
 
 /**
  * The environment every build/test/install command runs under.
@@ -430,7 +470,24 @@ export function runBuildTest(args: BuildTestArgs): BuildTestReport {
     );
   }
   if (args.install && npmLock && !installComplete()) {
-    const install = exec('npm ci --no-audit --no-fund', root, perCommandMs);
+    // Disk preflight. The deadline already treats "cannot finish in time" as an
+    // infrastructure result and skips ahead with a disclosure; "cannot fit on
+    // the disk" is the same class of result, discovered before the command runs
+    // instead of 33 seconds into it. An `npm ci` that dies on ENOSPC is
+    // strictly worse than one that never starts: it leaves a partial tree AND a
+    // full disk that fails every agent scheduled after this one.
+    const installCmd = 'npm ci --no-audit --no-fund';
+    const free = freeDiskBytes(root);
+    if (free !== null && free < INSTALL_MIN_FREE_BYTES) {
+      results.ok = false;
+      results.note =
+        `Insufficient disk space (${gib(free)}G free, need ~${gib(INSTALL_MIN_FREE_BYTES)}G): ` +
+        `skipped \`${installCmd}\`, so nothing could be built or tested. This ` +
+        'is an environment issue, not a code finding — report it as ' +
+        'informational.';
+      return results;
+    }
+    const install = exec(installCmd, root, perCommandMs);
     results.install = install;
     if (install.timedOut) results.timedOut.push(install.command);
     // A timeout leaves a partial tree — remove it, so this is not mistaken next time
@@ -462,6 +519,20 @@ export function runBuildTest(args: BuildTestArgs): BuildTestReport {
           'report it as informational.';
       return results;
     }
+  }
+
+  // The same preflight before the build phase, at a lower floor. A warm tree
+  // skips the install (and its 3 GiB gate) entirely, but a compile that hits
+  // ENOSPC mid-write fails with errors that read as defects in the diff — and
+  // leaves the disk full for everything that runs after this command.
+  const freeForBuild = freeDiskBytes(root);
+  if (freeForBuild !== null && freeForBuild < BUILD_MIN_FREE_BYTES) {
+    results.ok = false;
+    results.note =
+      `Insufficient disk space (${gib(freeForBuild)}G free, need ~${gib(BUILD_MIN_FREE_BYTES)}G): ` +
+      'skipped the build and tests rather than fill the disk mid-compile. This ' +
+      'is an environment issue, not a code finding — report it as informational.';
+    return results;
   }
 
   const alsoBuild: string[] = [];


### PR DESCRIPTION
Part of #7981 (item P0-3, the `build-test` half).

## What

`qwen review build-test` now preflights free disk before running `npm ci` (3 GiB floor) and before the build phase (1 GiB floor). Below a floor the command is skipped with the same disclosure shape as a deadline skip — an environment result, never a finding.

## Why

Dogfooded on a live review: with ~2.7G free, `npm ci` on this monorepo ran 33 seconds and died on `ENOSPC` — and the now-full disk went on to fail every agent scheduled after this command. Verification and reverse-audit agents could not even spawn, so a Critical that nine agents independently reported ended the run capped at Comment, because nothing could verify it. A disk a command fills is not a failure that stays contained to that command.

`build-test` already treats "cannot finish in time" as an infrastructure result: the deadline skips the command and discloses it, and the agent brief routes such notes to informational. "Cannot fit on the disk" is the same class of result — discoverable *before* the command runs instead of 33 seconds into it, and before it has poisoned the environment for everyone else.

## How

- `INSTALL_MIN_FREE_BYTES = 3 GiB`: the installed tree is ~1.4G, and npm stages cache and temp writes on the same filesystem while materialising it; the dogfooded failure (~2.7G free) sits just under this floor.
- `BUILD_MIN_FREE_BYTES = 1 GiB`: builds write far less (`dist/`, tsbuildinfo); the floor exists so a compile cannot be the thing that fills the disk.
- Two floors deliberately: a warm tree at ~2G free skips the install anyway and must still be allowed to build (pinned by a test).
- Where `statfsSync` is unavailable the preflight passes — it exists to prevent failures, not to invent them.
- The skip mirrors the deadline-skip representation exactly (`ok: false`, `install: null` — the command never executed — and a `note` in the register downstream agents already consume), so no consumer changes are needed.

## Tests

4 new cases: install skipped below the floor with the disclosure; build phase skipped on a warm tree below its floor; a warm tree *between* the floors still builds; `statfsSync` throwing proceeds as before. 34/34 green; eslint `--max-warnings 0` and tsc clean for the touched files. Negative control: with the source change stashed, the two skip tests fail and the two behavior-preserving tests still pass.

<details>
<summary>中文说明</summary>

关联 #7981(P0-3 中 `build-test` 的部分)。

## 做了什么

`qwen review build-test` 在运行 `npm ci` 前(3 GiB 下限)与构建阶段前(1 GiB 下限)预检磁盘剩余空间。低于下限时跳过该命令,披露形式与 deadline 跳过完全一致——环境结果,绝不是代码发现。

## 为什么

真实评审中实测:磁盘剩余 ~2.7G 时,`npm ci` 跑了 33 秒死于 `ENOSPC`——被填满的磁盘随后拖垮了这条命令之后调度的所有 agent。验证与反向审计 agent 连启动都失败,九个 agent 独立报出的 Critical 因无法验证被封顶在 Comment。一条命令填满的磁盘,不是一个只影响这条命令的故障。

`build-test` 已经把"时间内跑不完"当作基础设施结果处理:deadline 跳过命令并披露,agent brief 把此类注记归为 informational。"磁盘装不下"是同一类结果——而且可以在命令运行**之前**发现,而不是 33 秒之后、环境已被毒化之时。

## 怎么做

- `INSTALL_MIN_FREE_BYTES = 3 GiB`:安装后的依赖树 ~1.4G,npm 物化过程中还会在同一文件系统上写缓存与临时文件;实测故障(~2.7G 剩余)恰好落在该下限之下。
- `BUILD_MIN_FREE_BYTES = 1 GiB`:构建写入量小得多(`dist/`、tsbuildinfo);设下限是为了让编译不可能成为填满磁盘的那一步。
- 刻意用两级下限:热依赖树在 ~2G 剩余时本就跳过安装,必须仍被允许构建(有测试固定)。
- `statfsSync` 不可用的平台直接放行——预检为防止故障而生,不为制造故障。
- 跳过的表示与 deadline 跳过完全一致(`ok: false`、`install: null`——命令从未执行——以及下游 agent 已在消费的 `note` 口径),无需改动任何消费方。

## 测试

新增 4 个用例:低于下限跳过安装并披露;热树低于构建下限跳过构建;热树处于两级下限之间仍然构建;`statfsSync` 抛错照常放行。34/34 全绿;涉及文件 eslint `--max-warnings 0` 与 tsc 干净。负向对照:暂存源码改动后,两个跳过用例失败、两个保持行为的用例仍通过。

</details>
