### PR TITLE
feat(review): disclose a zero-finding Approve on a non-trivial diff as low signal

### DIFF
--- a/packages/cli/src/commands/review/compose-review.test.ts
+++ b/packages/cli/src/commands/review/compose-review.test.ts
@@ -85,6 +85,8 @@ function plan(
     step45?: boolean;
     han?: boolean;
     effort?: 'low' | 'medium' | 'high';
+    /** Override the fixture's 5000 — the low-signal floor reads this. */
+    srcDiffLines?: number;
   } = {},
 ): string {
   const p = join(dir, 'plan.json');
@@ -98,7 +100,7 @@ function plan(
       // The effort the capturing command recorded — the roster and the
       // reverse-audit floor both read it from here.
       ...(opts.effort ? { effort: opts.effort } : {}),
-      srcDiffLines: 5000,
+      srcDiffLines: opts.srcDiffLines ?? 5000,
       diffLines: 5000,
       files: [{ path: 'a.ts', kind: 'source', removedLines: 0, heavy: false }],
       // Real plans carry each chunk's files (`DiffChunk.files`) — the body
@@ -312,7 +314,11 @@ function blindPrompt(chunk: number): string {
  */
 function coveredPlan(
   step45Keys: string[] = ['verify', 'reverse-audit'],
-  planOpts: { han?: boolean; effort?: 'low' | 'medium' | 'high' } = {},
+  planOpts: {
+    han?: boolean;
+    effort?: 'low' | 'medium' | 'high';
+    srcDiffLines?: number;
+  } = {},
 ): string {
   transcript('a1', goodPrompt(1), { toolCalls: 3 });
   transcript('a2', goodPrompt(2), { toolCalls: 2 });
@@ -383,6 +389,53 @@ describe('composeReview — the C/S table', () => {
     const r = composeReview(base({ bodyCriticals: ['whole-PR blocker X'] }));
     expect(r.event).toBe('REQUEST_CHANGES');
     expect(r.body).toContain('**[Critical]** whole-PR blocker X');
+  });
+});
+
+describe('composeReview — the low-signal Approve disclosure', () => {
+  // The coverage gate proves the agents READ the diff, not that the review had
+  // discriminating power: a dogfooded weak-model run drafted nothing from all
+  // of its agents on a non-trivial source diff where stronger same-condition
+  // runs found a verified blocker, and composed a bare confident Approve.
+  it('a zero-finding APPROVE over a non-trivial source diff carries the marker — event and body unchanged', () => {
+    const r = composeReview(base({}));
+    expect(r.event).toBe('APPROVE');
+    expect(r.body).toBe(`No issues found. LGTM! ✅\n\n${FOOTER}`);
+    // The fixture's roster: two chunk agents plus the test matrix.
+    expect(r.lowSignal).toEqual({ agents: 3, srcDiffLines: 5000 });
+    expect(verdictLine(r)).toBe(
+      'Verdict: Approve — low signal: none of the 3 review agents reported ' +
+        'a finding on a non-trivial diff (5000 source diff lines)',
+    );
+  });
+
+  it('a docs-only diff keeps the bare Approve — finding nothing there is the expected outcome', () => {
+    const r = composeReview({
+      planPath: coveredPlan(undefined, { srcDiffLines: 0 }),
+      env: ENV,
+      modelId: MODEL,
+    });
+    expect(r.event).toBe('APPROVE');
+    expect(r.lowSignal).toBeNull();
+    expect(verdictLine(r)).toBe('Verdict: Approve');
+  });
+
+  it('a tiny source change at the floor keeps the bare Approve — the marker needs strictly more', () => {
+    const r = composeReview({
+      planPath: coveredPlan(undefined, { srcDiffLines: 100 }),
+      env: ENV,
+      modelId: MODEL,
+    });
+    expect(r.event).toBe('APPROVE');
+    expect(r.lowSignal).toBeNull();
+    expect(verdictLine(r)).toBe('Verdict: Approve');
+  });
+
+  it('a review with findings never carries the marker — low signal is about empty reviews', () => {
+    const r = composeReview(base({ suggestionsInline: 1 }));
+    expect(r.event).toBe('COMMENT');
+    expect(r.lowSignal).toBeNull();
+    expect(verdictLine(r)).not.toContain('low signal');
   });
 });
 
@@ -2013,6 +2066,7 @@ describe('verdictLine — the terminal verdict, and its dangling colon', () => {
       downgraded: false,
       downgradedFrom: null,
       remediation: [],
+      lowSignal: null,
       ...over,
     });
 
@@ -2104,6 +2158,19 @@ describe('verdictLine — the terminal verdict, and its dangling colon', () => {
   it('is bare for a clean Approve', () => {
     expect(line({ event: 'APPROVE', baseEvent: 'APPROVE' })).toBe(
       'Verdict: Approve',
+    );
+  });
+
+  it("marks a low-signal Approve, with the run's own numbers", () => {
+    expect(
+      line({
+        event: 'APPROVE',
+        baseEvent: 'APPROVE',
+        lowSignal: { agents: 11, srcDiffLines: 642 },
+      }),
+    ).toBe(
+      'Verdict: Approve — low signal: none of the 11 review agents reported ' +
+        'a finding on a non-trivial diff (642 source diff lines)',
     );
   });
 });

--- a/packages/cli/src/commands/review/compose-review.ts
+++ b/packages/cli/src/commands/review/compose-review.ts
@@ -34,6 +34,7 @@ import { gh, setGhHost } from './lib/gh.js';
 import {
   isPositivePrNumber,
   hasExecutableScript,
+  requiredAgents,
   reviewMode,
   type RosterPlan,
 } from './lib/roster.js';
@@ -47,6 +48,18 @@ import {
 } from './lib/inline-counts.js';
 
 export type ReviewEvent = 'APPROVE' | 'REQUEST_CHANGES' | 'COMMENT';
+
+/**
+ * The floor above which a zero-finding Approve is disclosed as low-signal,
+ * in the plan's `srcDiffLines` — diff lines belonging to `source` files, the
+ * same field the review topology is chosen from (tests, docs and generated
+ * files excluded by construction). A trivial edit stays under it even
+ * scattered one changed line per hunk (~8 diff lines each with context and
+ * hunk header, plus 4 file-header lines), and the smallest diff the topology
+ * gate calls big is 500 — so the floor sits well past the typo-fix class and
+ * well before "big".
+ */
+export const LOW_SIGNAL_SRC_DIFF_LINES = 100;
 
 /**
  * Reads a PR's description body, given its `owner/repo` and number. The one
@@ -160,6 +173,18 @@ export interface ComposeReviewResult {
    * operator which command repairs it. Two registers, two channels.
    */
   remediation: string[];
+  /**
+   * Set on an APPROVE composed from zero findings over a non-trivial source
+   * diff (the plan's `srcDiffLines` above `LOW_SIGNAL_SRC_DIFF_LINES`).
+   * Disclosure only — the event never moves on it: the coverage gate proves
+   * the agents READ the diff, not that the review had discriminating power,
+   * and a dogfooded weak-model run drafted nothing from its whole roster on a
+   * diff where stronger same-condition runs found a verified blocker, then
+   * printed a bare confident Approve. The verdict line names the shape.
+   * `agents` is the plan's required roster — all on record at APPROVE, or
+   * coverage would have capped — and `srcDiffLines` the plan's own count.
+   */
+  lowSignal: { agents: number; srcDiffLines: number } | null;
 }
 
 function withMarker(line: string): string {
@@ -641,6 +666,32 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
     downgradedFrom = 'Request changes';
   }
 
+  // A zero-finding Approve over a non-trivial source diff is disclosed, not
+  // capped. Every gate above proves the agents READ the diff; none proves the
+  // review could tell good code from bad, and a dogfooded weak-model run
+  // drafted nothing from all of its agents on a diff where stronger runs found
+  // a verified blocker — then composed a bare confident Approve. The verdict
+  // stands (nothing was found, and a cap would punish every genuinely clean
+  // diff), but the verdict line must say which kind of Approve this is.
+  // "Non-trivial" is measured in the plan's own risk metric (`srcDiffLines`,
+  // the field the topology is chosen from), so a docs-only or typo-class diff
+  // keeps its bare Approve — there, finding nothing is the expected outcome.
+  let lowSignal: ComposeReviewResult['lowSignal'] = null;
+  if (event === 'APPROVE' && input.planPath) {
+    try {
+      const plan = JSON.parse(
+        readFileSync(input.planPath, 'utf8'),
+      ) as RosterPlan;
+      const src = Number(plan.srcDiffLines ?? 0);
+      if (src > LOW_SIGNAL_SRC_DIFF_LINES) {
+        lowSignal = { agents: requiredAgents(plan).length, srcDiffLines: src };
+      }
+    } catch {
+      // Unreachable on a real APPROVE — the coverage gate already read this
+      // plan — and a disclosure must never take the review down.
+    }
+  }
+
   const footer = `_— ${modelId} via Qwen Code /review_`;
   // Bilingual rendering: when the plan (fetch-pr's report) says the PR
   // description contains Han characters, the posted body carries the complete
@@ -901,6 +952,7 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
       downgraded,
       downgradedFrom,
       remediation,
+      lowSignal,
     };
   }
 
@@ -919,6 +971,7 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
       downgraded,
       downgradedFrom,
       remediation,
+      lowSignal,
     };
   }
 
@@ -1040,6 +1093,7 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
     downgraded,
     downgradedFrom,
     remediation,
+    lowSignal,
   };
 }
 
@@ -1581,6 +1635,18 @@ export function verdictLine(r: ComposeReviewResult): string {
     // lose and no blocker to hide, but the event did change and the user should see
     // it did.
     line += ' — downgraded by a presubmit check';
+  }
+  // Not a cap and not a downgrade — the Approve stands. But a bare confident
+  // Approve from a run that drafted nothing on a real diff reads as evidence
+  // of quality when it is only absence of signal, so the line says which
+  // Approve this is. Both numbers are the run's own: the roster the plan
+  // required (all on record, or coverage would have capped) and the plan's
+  // source-line count.
+  if (r.event === 'APPROVE' && r.lowSignal) {
+    line +=
+      ` — low signal: none of the ${r.lowSignal.agents} review agents ` +
+      `reported a finding on a non-trivial diff ` +
+      `(${r.lowSignal.srcDiffLines} source diff lines)`;
   }
   return line;
 }


### PR DESCRIPTION
Part of #7981 (item P0-1, the false-green guard).

## What

When `compose-review` composes an **Approve from zero findings over a non-trivial source diff**, the verdict line now discloses it:

```
Verdict: Approve — low signal: none of the 11 review agents reported a finding on a non-trivial diff (155 source diff lines)
```

The event never moves — disclosure only.

## Why

Every gate compose-review enforces proves the agents **read** the diff: coverage proves the transcripts, anchors prove the quotes. None proves the review could tell good code from bad. Dogfooded: a weak-model run drafted nothing from its entire roster on a diff where stronger same-condition runs found a *verified blocking Critical* — and compose printed a bare, confident `Verdict: Approve`. A reader takes that as evidence of quality when it is only absence of signal: the most dangerous shape a review verdict can have.

## How

- Fires iff the final event is `APPROVE` (which structurally implies zero drafted comments) **and** the plan's `srcDiffLines` exceeds `LOW_SIGNAL_SRC_DIFF_LINES = 100`.
- `srcDiffLines` is the plan's own risk metric — the field the review topology is chosen from, with test/docs/generated lines excluded by construction — so a docs-only or typo-class diff keeps its bare Approve; there, finding nothing is the expected outcome. The floor sits well past the typo-fix class (a tiny edit scattered one changed line per hunk stays under it) and at a fifth of the smallest diff the topology gate treats as big.
- The agent count is `requiredAgents(plan).length` — the same roster function the coverage gate checks; at APPROVE every required agent is on record (coverage would have capped otherwise), so the line claims only data compose actually has.
- No cap, no downgrade: a cap would punish every genuinely clean diff, and nothing was in fact found. The skill relays the `Verdict:` line verbatim, so the marker flows through to the terminal and the archived report unchanged.
- Plan read failure never takes the disclosure path down (unreachable on a real APPROVE — the coverage gate already read this plan).

## Tests

New cases pin: zero comments + non-trivial source plan → marker present, event unchanged; docs-only / under-floor plans → bare Approve; non-empty comments → no marker; exact-floor boundary stays bare; a `verdictLine` unit test for the wording. 135/135 green; eslint `--max-warnings 0` and tsc clean for the touched files.

<details>
<summary>中文说明</summary>

关联 #7981(P0-1 假绿防护)。

## 做了什么

当 `compose-review` 在**非平凡源码 diff 上由零发现组合出 Approve** 时,裁决行现在会披露:

```
Verdict: Approve — low signal: none of the 11 review agents reported a finding on a non-trivial diff (155 source diff lines)
```

事件绝不移动——仅披露。

## 为什么

compose-review 强制执行的每道门禁都只证明 agent **读过** diff:coverage 证明转录、anchors 证明引用,没有一道证明这次评审有分辨好坏代码的能力。实测:一次弱模型运行的整个名册在某个 diff 上零起草,而同条件更强的运行在同一 diff 上找到了*经验证的阻断级 Critical*——compose 仍打印了一个干净自信的 `Verdict: Approve`。读者会把它当作质量证据,而它只是信号缺失:这是评审裁决最危险的形态。

## 怎么做

- 触发条件:最终事件为 `APPROVE`(结构上蕴含零起草评论)**且** plan 的 `srcDiffLines` 超过 `LOW_SIGNAL_SRC_DIFF_LINES = 100`。
- `srcDiffLines` 是 plan 自己的风险度量——评审拓扑就按这个字段选择,测试/文档/生成文件按构造被排除——因此 docs-only 或 typo 级 diff 保持裸 Approve:在那里零发现是预期结果。下限远高于 typo 修复类(小改动即使每 hunk 散布一行也在下限之下),且只有拓扑门禁认定"大 diff"的五分之一。
- agent 数取 `requiredAgents(plan).length`——与 coverage 门禁校验的同一个名册函数;APPROVE 时全部要求的 agent 都已有记录(否则 coverage 早已封顶),裁决行只声称 compose 真正掌握的数据。
- 不封顶、不降级:封顶会惩罚每一个真正干净的 diff,而事实是确实什么都没找到。skill 原样转发 `Verdict:` 行,标记原封不动流到终端与归档报告。
- plan 读取失败绝不拖垮披露路径(真实 APPROVE 上不可达——coverage 门禁已经读过这份 plan)。

## 测试

新用例固定:零评论 + 非平凡源码 plan → 标记出现、事件不变;docs-only / 低于下限的 plan → 裸 Approve;有评论 → 无标记;恰好压线保持裸 Approve;`verdictLine` 文案单测。135/135 全绿;涉及文件 eslint `--max-warnings 0` 与 tsc 干净。

</details>
