### PR TITLE
fix(cli): prevent SGR mouse events from being swallowed as paste on Windows

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -1031,6 +1031,111 @@ describe('KeypressContext - Kitty Protocol', () => {
         expect(mouseHandler).not.toHaveBeenCalled();
       });
 
+      it('dispatches a standalone SGR wheel event to mouse subscribers (pasteWorkaround path)', async () => {
+        const mouseHandler = vi.fn();
+
+        const { result } = renderHook(() => useKeypressContext(), {
+          wrapper: ({ children }) =>
+            wrapper({ children, pasteWorkaround: true }),
+        });
+
+        act(() => {
+          result.current.subscribeMouse(mouseHandler);
+        });
+
+        // A pure SGR scroll-down event (button 65) arriving alone.
+        act(() => {
+          stdin.emit('data', Buffer.from('\x1b[<65;10;20M'));
+        });
+
+        await waitFor(() => {
+          expect(mouseHandler).toHaveBeenCalledTimes(1);
+        });
+        expect(mouseHandler).toHaveBeenCalledWith(
+          expect.objectContaining({ name: 'scroll-down', col: 10, row: 20 }),
+        );
+      });
+
+      it('dispatches SGR wheel event arriving in fragmented chunks (pasteWorkaround path)', async () => {
+        const mouseHandler = vi.fn();
+
+        const { result } = renderHook(() => useKeypressContext(), {
+          wrapper: ({ children }) =>
+            wrapper({ children, pasteWorkaround: true }),
+        });
+
+        act(() => {
+          result.current.subscribeMouse(mouseHandler);
+        });
+
+        // SGR sequence split across two stdin chunks.
+        act(() => {
+          stdin.emit('data', Buffer.from('\x1b[<64;5'));
+          stdin.emit('data', Buffer.from(';15M'));
+        });
+
+        await waitFor(() => {
+          expect(mouseHandler).toHaveBeenCalledTimes(1);
+        });
+        expect(mouseHandler).toHaveBeenCalledWith(
+          expect.objectContaining({ name: 'scroll-up', col: 5, row: 15 }),
+        );
+      });
+
+      it('dispatches SGR wheel event when \\r arrives in the same chunk (pasteWorkaround path)', async () => {
+        const mouseHandler = vi.fn();
+        const keyHandler = vi.fn();
+
+        const { result } = renderHook(() => useKeypressContext(), {
+          wrapper: ({ children }) =>
+            wrapper({ children, pasteWorkaround: true }),
+        });
+
+        act(() => {
+          result.current.subscribe(keyHandler);
+          result.current.subscribeMouse(mouseHandler);
+        });
+
+        // Windows Terminal may deliver a preceding Enter (\r) in the same
+        // stdin chunk as the SGR mouse sequence. The \r must not cause
+        // shouldFlushRawDataAsPaste to misclassify the SGR data as paste.
+        act(() => {
+          stdin.emit('data', Buffer.from('\r\x1b[<65;10;20M'));
+        });
+
+        await waitFor(() => {
+          expect(mouseHandler).toHaveBeenCalledTimes(1);
+        });
+        expect(mouseHandler).toHaveBeenCalledWith(
+          expect.objectContaining({ name: 'scroll-down', col: 10, row: 20 }),
+        );
+      });
+
+      it('dispatches SGR wheel event when \\r\\n arrives in the same chunk (pasteWorkaround path)', async () => {
+        const mouseHandler = vi.fn();
+
+        const { result } = renderHook(() => useKeypressContext(), {
+          wrapper: ({ children }) =>
+            wrapper({ children, pasteWorkaround: true }),
+        });
+
+        act(() => {
+          result.current.subscribeMouse(mouseHandler);
+        });
+
+        // Windows-style \r\n followed by SGR in one chunk.
+        act(() => {
+          stdin.emit('data', Buffer.from('\r\n\x1b[<65;3;7M'));
+        });
+
+        await waitFor(() => {
+          expect(mouseHandler).toHaveBeenCalledTimes(1);
+        });
+        expect(mouseHandler).toHaveBeenCalledWith(
+          expect.objectContaining({ name: 'scroll-down', col: 3, row: 7 }),
+        );
+      });
+
       it('should handle empty paste sequence', async () => {
         const keyHandler = vi.fn();
 

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -1201,6 +1201,13 @@ export function KeypressProvider({
     });
 
     const shouldFlushRawDataAsPaste = (data: Buffer) => {
+      // ANSI escape sequences (SGR mouse events, cursor keys) must reach
+      // readline for proper parsing. Wrapping them in synthetic paste events
+      // causes handleKeypress's isPaste guard to discard SGR mouse data,
+      // breaking wheel scrolling on Windows where \r from Enter commonly
+      // shares a stdin chunk with a subsequent mouse event.
+      if (data.includes(0x1b)) return false;
+
       const hasReturn = data.includes(0x0d);
       const hasEmbeddedTab = data.length > 1 && data.includes(0x09);
       const isSingleReturn = data.length <= 2 && hasReturn;


### PR DESCRIPTION
## What this PR does

On the Windows input path (`pasteWorkaround`), the `shouldFlushRawDataAsPaste` heuristic in `flushRawBuffer` misclassifies raw stdin data as pasted content when it contains both a carriage return (`0x0d`) and an SGR mouse escape sequence. The data gets wrapped in synthetic `paste-start`/`paste-end` events, which sets `isPaste=true` in `handleKeypress`. The SGR mouse reassembly logic then discards the sequence via `resetSgrMouse()`, so wheel scroll events never reach `ScrollableList` and VP-mode scrolling silently stops working.

The fix adds a single guard: if the raw buffer contains an ANSI escape byte (`0x1b`), skip the paste heuristic entirely and forward the data to readline for proper parsing. This ensures SGR mouse sequences (and other ANSI escape sequences like cursor keys) are always dispatched correctly, regardless of what other bytes share the same stdin chunk.

## Why it's needed

v0.21.1 enabled VP (Virtual Viewport) mode by default (`ui.useTerminalBuffer: true`), which enters the alternate screen and enables SGR mouse tracking. The terminal no longer does native scrollback — the app must handle wheel events itself. On Windows, Enter sends `\r` (`0x0d`), and when a user presses Enter then scrolls (e.g. sending a message then scrolling history), both events commonly arrive in the same stdin chunk. The `\r` triggers the paste heuristic, the SGR mouse data is swallowed as "paste content", and scrolling breaks. macOS is unaffected because it uses the `handleStdinData` path which has no such heuristic.

Closes #7964.

## Reviewer Test Plan

### How to verify

Four new unit tests in `KeypressContext.test.tsx` cover the `pasteWorkaround=true` (Windows) path:

1. **Standalone SGR wheel event** — a pure `\x1b[<65;10;20M` scroll-down arrives alone → mouse subscriber receives `scroll-down` (passed before and after fix; baseline).
2. **Fragmented SGR chunks** — the sequence is split across two `stdin.emit('data')` calls → correctly reassembled and dispatched (baseline).
3. **SGR + `\r` in same chunk** — `\r\x1b[<65;10;20M` arrives together → **failed before fix** (mouse handler called 0 times), passes after.
4. **SGR + `\r\n` in same chunk** — `\r\n\x1b[<65;3;7M` arrives together → **failed before fix**, passes after.

Run: `cd packages/cli && npx vitest run src/ui/contexts/KeypressContext.test.tsx`

All 112 tests in the suite pass (108 existing + 4 new, no regressions).

### Evidence (Before & After)

Before fix (tests 3 & 4 fail):
```
FAIL  dispatches SGR wheel event when \r arrives in the same chunk (pasteWorkaround path)
AssertionError: expected "spy" to be called 1 times, but got 0 times

FAIL  dispatches SGR wheel event when \r\n arrives in the same chunk (pasteWorkaround path)
AssertionError: expected "spy" to be called 1 times, but got 0 times
```

After fix:
```
✓ src/ui/contexts/KeypressContext.test.tsx (112 tests) 2774ms
Test Files  1 passed (1)
     Tests  112 passed (112)
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

Unit tests simulate the Windows `pasteWorkaround` path on macOS. Real Windows Terminal verification is welcome.

### Environment (optional)

Unit tests only (`npx vitest`).

## Risk & Scope

- Main risk or tradeoff: the ESC-byte guard (`data.includes(0x1b)`) means any raw buffer containing an escape byte bypasses the synthetic-paste heuristic. In theory a paste without bracketed-paste markers that contains ESC bytes would no longer be detected as paste. In practice this is negligible: modern terminals use bracketed paste (handled by the marker-scanning loop above), and non-bracketed pastes containing raw ESC are extremely rare.
- Not validated / out of scope: real Windows Terminal E2E verification; other potential VP-mode issues on Windows (e.g. ConPTY chunk boundaries).
- Breaking changes / migration notes: none.

## Linked Issues

Closes #7964

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在 Windows 输入路径（`pasteWorkaround`）中，`flushRawBuffer` 里的 `shouldFlushRawDataAsPaste` 启发式函数会在原始 stdin 数据同时包含回车符（`0x0d`）和 SGR 鼠标转义序列时，将其误判为粘贴内容。数据被包裹在合成的 `paste-start`/`paste-end` 事件中，导致 `handleKeypress` 中 `isPaste=true`，SGR 鼠标重组逻辑随后通过 `resetSgrMouse()` 丢弃该序列，滚轮事件永远无法到达 `ScrollableList`，VP 模式下的滚动静默失效。

修复方案：当原始缓冲区包含 ANSI 转义字节（`0x1b`）时，跳过粘贴启发式判断，直接将数据转发给 readline 进行正确解析。

## 为什么需要

v0.21.1 默认启用了 VP（虚拟视口）模式，进入备用屏幕并启用 SGR 鼠标追踪，终端不再提供原生滚动。在 Windows 上，Enter 键发送 `\r`（`0x0d`），当用户按 Enter 后立即滚动（如发送消息后滚动历史），两个事件通常会落在同一个 stdin 数据块中。`\r` 触发粘贴启发式，SGR 鼠标数据被当作"粘贴内容"吞掉，滚动失效。macOS 不受影响，因为它使用的 `handleStdinData` 路径没有此启发式逻辑。

## 风险与范围

- 主要风险：ESC 字节守卫意味着包含转义字节的原始缓冲区会绕过合成粘贴启发式。实际上影响可忽略：现代终端使用括号粘贴（由上方的标记扫描循环处理），不含括号粘贴标记且包含 ESC 的粘贴极为罕见。
- 未验证/不在范围内：真实 Windows Terminal 端到端验证。
- 破坏性变更：无。

</details>