### PR TITLE
fix(core): drop top-level oneOf from send_message tool schema

### DIFF
--- a/packages/core/src/tools/send-message.ts
+++ b/packages/core/src/tools/send-message.ts
@@ -336,12 +336,6 @@ export class SendMessageTool extends BaseDeclarativeTool<
           },
         },
         required: ['message'],
-        // Either a teammate recipient (`to`) or a background-task
-        // (`task_id`) must be specified — they correspond to the
-        // two routing modes. Letting the model send `{message}`
-        // alone wastes a round-trip on the runtime "Recipient is
-        // required" error.
-        oneOf: [{ required: ['to'] }, { required: ['task_id'] }],
         additionalProperties: false,
       },
       true, // isOutputMarkdown


### PR DESCRIPTION
## What this PR does

Removes the top-level `oneOf` combinator from `send_message`'s tool
`input_schema`. Anthropic's Messages API rejects any tool schema
carrying a top-level `oneOf`/`allOf`/`anyOf` with a hard 400, so this
made `send_message` completely unusable on every Anthropic-backed
model (native API, Vertex, or an Anthropic-compatible proxy).

## Why it is needed

Fixes #7984.

`send_message`'s schema used `oneOf: [{ required: ['to'] }, {
required: ['task_id'] }]` to express "either a teammate recipient or a
background-task id is required." This schema is forwarded verbatim as
`tools[].input_schema` to Anthropic in
`packages/core/src/core/anthropicContentGenerator/converter.ts`
(`convertSchema` → `input_schema`), and Anthropic's tool-schema
validator does not accept `oneOf` at the schema root — every call
400s before the model even sees the tool.

The `oneOf` constraint was redundant, not the sole enforcement:
`send_message`'s `execute()` already returns a clear runtime error
("No active team and no task_id provided...") when neither `to` nor
`task_id` is supplied. Removing it from the JSON Schema leaves that
runtime check intact and unchanged for OpenAI/Gemini-backed models,
while making the tool actually callable on Anthropic-backed models.

## Verification

Reproduced against the live Anthropic Messages API with
`claude-sonnet-5`, isolating the exact schema shape:

Request with the `oneOf` constraint (current `main`):

```json
{
  "type": "error",
  "error": {
    "type": "invalid_request_error",
    "message": "tools.0.custom.input_schema: input_schema does not support oneOf, allOf, or anyOf at the top level"
  }
}
```

Identical request with `oneOf` removed (this PR): `200`, `tool_use`
returned successfully.

`packages/core/src/tools/send-message.test.ts` (20 tests) passes
unchanged — no test asserted on the `oneOf` field, and the tool's
runtime "missing recipient" behavior is untouched.

Also ran, clean:
- `npx tsc --noEmit -p packages/core/tsconfig.json` (0 errors)
- `npx eslint packages/core/src/tools/send-message.ts` (0 warnings)
- `npx prettier --check packages/core/src/tools/send-message.ts`
- repo's own `pre-commit` lint-staged hook (prettier + eslint --fix
  --max-warnings 0) on the commit

### Demo

N/A — internal tool schema fix, no user-facing UI. Behavioral
before/after is the curl reproduction above (400 → 200) rather than a
screenshot, since this is a wire-level API compatibility fix.
