### PR TITLE
fix(ci): restore verify workspace permissions

### DIFF
--- a/.github/scripts/qwen-triage-workflow.test.mjs
+++ b/.github/scripts/qwen-triage-workflow.test.mjs
@@ -36,6 +36,10 @@ const triageJob = doc.jobs.triage;
 const steps = triageJob.steps;
 const triageStep = steps.find((s) => s.id === 'triage');
 const cleanStep = steps.find((s) => s.name === 'Clean stale agent state');
+const verifyJob = doc.jobs.verify;
+const verifyCleanupStep = verifyJob.steps.find(
+  (s) => s.name === 'Clean up runner workspace',
+);
 
 describe('qwen-triage: agent tool/permission settings', () => {
   it('passes `settings:` (not the silently-dropped `settings_json:`)', () => {
@@ -275,6 +279,28 @@ describe('qwen-triage: git exec-vector cleanup', () => {
         assert.match(remaining(), new RegExp(kept.replace(/\./g, '\\.')));
       });
     }
+  });
+});
+
+describe('qwen-triage: verify workspace cleanup', () => {
+  it('restores write permission before returning the workspace to the runner', () => {
+    assert.ok(verifyCleanupStep, 'verify cleanup step must exist');
+    assert.match(
+      verifyCleanupStep.run,
+      /chmod -R u\+rwX "\$GITHUB_WORKSPACE\/\.qwen"/,
+      'verify makes .qwen read-only before the agent runs, so cleanup must restore its owner write bits',
+    );
+
+    const chmodIndex = verifyCleanupStep.run.indexOf(
+      'chmod -R u+rwX "$GITHUB_WORKSPACE/.qwen"',
+    );
+    const chownIndex = verifyCleanupStep.run.indexOf(
+      'chown -R "$RUNNER_UID:$RUNNER_GID" "$GITHUB_WORKSPACE"',
+    );
+    assert.ok(
+      chmodIndex < chownIndex,
+      'the root-owned read-only tree must be made writable before ownership is returned',
+    );
   });
 });
 

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -2876,10 +2876,13 @@ jobs:
             esac
           done
           git worktree prune -v || true
-          # Restore workspace ownership to the runner user so the next job's
-          # checkout step can clean the tree without EACCES. The prepare step
-          # chowned everything to node:node; without this, node_modules and
-          # .qwen/ remain node-owned and the next checkout's rm -rf fails.
+          # The verifier was deliberately made root-owned and read-only before
+          # the node-owned agent ran. Restore its owner write bits while this
+          # container still has root, then return the whole workspace to the
+          # runner user so every later checkout can clean it.
+          if [ -d "$GITHUB_WORKSPACE/.qwen" ] && [ ! -L "$GITHUB_WORKSPACE/.qwen" ]; then
+            chmod -R u+rwX "$GITHUB_WORKSPACE/.qwen"
+          fi
           RUNNER_UID="$(stat -c '%u' "$RUNNER_TEMP" 2>/dev/null || stat -f '%u' "$RUNNER_TEMP" 2>/dev/null || echo 0)"
           RUNNER_GID="$(stat -c '%g' "$RUNNER_TEMP" 2>/dev/null || stat -f '%g' "$RUNNER_TEMP" 2>/dev/null || echo 0)"
           if [ "$RUNNER_UID" != "0" ]; then


### PR DESCRIPTION
## What this PR does

Restores write permission on the verifier-owned `.qwen` tree during the verify job's final cleanup, before returning workspace ownership to the persistent ECS runner. It also adds a regression guard that requires the permission restoration to happen before the existing recursive `chown`.

## Why it's needed

The verify agent intentionally runs with a base-pinned `.qwen` tree owned by root and made read-only, preventing PR-controlled code from changing its own verification instructions. PR #7931 restored workspace ownership after the job, but ownership alone left `.qwen` directories at mode `0555` and files at `0444`. Later self-hosted checkouts still could not unlink them. PR #7977 added a pre-checkout fallback for the main Test job; this change fixes the producer so other ECS jobs no longer inherit a read-only workspace.

## Reviewer Test Plan

### How to verify

1. Confirm the verify agent still receives a root-owned, read-only base-pinned `.qwen` tree before it starts.
2. Confirm the final cleanup changes only a real `.qwen` directory, restores owner write bits while the container still has root, and then returns the workspace to the runner UID/GID.
3. Run the workflow regression test and the action/YAML linters.

### Evidence (Before & After)

Before: the verify cleanup only changed ownership, leaving `.qwen` read-only and causing later ECS checkouts to fail with `Permission denied`.

After: cleanup restores `u+rwX` before the existing `chown`, and the regression test locks that ordering.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | N/A |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

- `node --test .github/scripts/qwen-triage-workflow.test.mjs` — 31 passed
- `node scripts/lint.js --actionlint` — passed
- `node scripts/lint.js --yamllint` — passed

## Risk & Scope

- Main risk or tradeoff: the permission restoration is recursive over `.qwen`, matching the earlier recursive read-only operation.
- Not validated / out of scope: existing fleet workspaces poisoned before the cleanup fix still require one-time operator cleanup if they remain root-owned.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #7931 and #7977.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 verify job 的最终清理阶段恢复 verifier 所有的 `.qwen` 目录写权限，然后再把 workspace ownership 交还给持久化 ECS runner。同时增加回归测试，确保权限恢复发生在现有递归 `chown` 之前。

## 为什么需要

verify agent 会故意使用从 base 分支固定下来的 `.qwen`，并将其设为 root 所有和只读，防止 PR 控制的代码修改验证自身的指令。PR #7931 在任务结束后恢复了 workspace ownership，但只恢复 owner 会让 `.qwen` 目录继续保持 `0555`、文件保持 `0444`，后续 self-hosted checkout 仍然无法删除。PR #7977 为主 Test job 增加了 checkout 前兜底；这个 PR 修复产生只读 workspace 的源头，避免其他 ECS job 继续继承该状态。

## Reviewer Test Plan

### 如何验证

1. 确认 verify agent 启动前，仍然使用 root 所有、只读、来自 base 分支的 `.qwen`。
2. 确认最终 cleanup 只处理真实 `.qwen` 目录，在容器仍有 root 权限时恢复 owner write bits，然后再把 workspace 交还给 runner UID/GID。
3. 运行 workflow 回归测试以及 action/YAML lint。

### Evidence（Before & After）

Before：verify cleanup 只改变 ownership，`.qwen` 仍然只读，导致后续 ECS checkout 报 `Permission denied`。

After：cleanup 在现有 `chown` 前恢复 `u+rwX`，回归测试锁定该顺序。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | N/A |
|  🐧 Linux  | ✅ tested |

### Environment（可选）

- `node --test .github/scripts/qwen-triage-workflow.test.mjs` — 31 passed
- `node scripts/lint.js --actionlint` — passed
- `node scripts/lint.js --yamllint` — passed

## Risk & Scope

- 主要风险或取舍：权限恢复会递归处理 `.qwen`，与之前递归设置只读的行为一致。
- 未验证 / 范围外：在修复前已经被污染且仍为 root-owned 的 runner workspace，可能仍需要运维一次性清理。
- Breaking changes / migration notes：无。

## Linked Issues

Follow-up to #7931 and #7977.

</details>
