### PR TITLE
fix(cli): stamp QWEN_CODE_CLI at the workspace entry and publish QWEN_CODE_MODEL

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -452,10 +452,11 @@ describe('stampCliEntryEnv', () => {
   });
 
   it('default derivation never throws and never stamps outside a built layout', () => {
-    // Under vitest import.meta.url is not even a file: URL, and in dev runs
-    // the derived ../index.js is the unbuilt packages/cli/index.js. Both must
-    // keep the bare-`qwen` fallback — a failed derivation taking the CLI down
-    // would be worse than the version skew this stamp exists to fix.
+    // Under vitest Vite rewrites new URL(…, import.meta.url) to a non-file
+    // URL, and in dev runs the derived ../index.js is the unbuilt
+    // packages/cli/index.js. Both must keep the bare-`qwen` fallback — a
+    // failed derivation taking the CLI down would be worse than the version
+    // skew this stamp exists to fix.
     stampCliEntryEnv();
 
     expect(process.env['QWEN_CODE_CLI']).toBeUndefined();

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -381,8 +381,8 @@ describe('stampCliEntryEnv', () => {
   });
 
   it('stamps the built bin entry so skill shell-outs reach THIS build', () => {
-    // Workspace launches (`node dist/index.js`, `npm start`) never pass
-    // through scripts/cli-entry.js, so without this stamp every
+    // A direct workspace launch (`node dist/index.js`) never passes through
+    // scripts/cli-entry.js, so without this stamp every
     // `"${QWEN_CODE_CLI:-qwen}"` resolved a global install off PATH.
     const entry = path.join(tempDir, 'index.js');
     writeFileSync(entry, '#!/usr/bin/env node\nconsole.log("hi");\n');

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -33,6 +33,7 @@ import {
   resolveBootstrapRoute,
   runCliEntry,
   runCliEntryPoint,
+  stampCliEntryEnv,
 } from './cli.js';
 
 const mocks = vi.hoisted(() => ({
@@ -355,6 +356,109 @@ describe('runCliEntry', () => {
     expect(mocks.initializeAcpStartupProfiler).not.toHaveBeenCalled();
     expect(mocks.markAcpStartup).not.toHaveBeenCalled();
     expect(mocks.main).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('stampCliEntryEnv', () => {
+  // Isolated because the CLI exports QWEN_CODE_CLI to every shell it spawns —
+  // a test run started from inside a qwen session inherits it.
+  let originalCli: string | undefined;
+  let tempDir: string;
+
+  beforeEach(() => {
+    originalCli = process.env['QWEN_CODE_CLI'];
+    delete process.env['QWEN_CODE_CLI'];
+    tempDir = mkdtempSync(path.join(tmpdir(), 'qwen-entry-stamp-'));
+  });
+
+  afterEach(() => {
+    if (originalCli !== undefined) {
+      process.env['QWEN_CODE_CLI'] = originalCli;
+    } else {
+      delete process.env['QWEN_CODE_CLI'];
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('stamps the built bin entry so skill shell-outs reach THIS build', () => {
+    // Workspace launches (`node dist/index.js`, `npm start`) never pass
+    // through scripts/cli-entry.js, so without this stamp every
+    // `"${QWEN_CODE_CLI:-qwen}"` resolved a global install off PATH.
+    const entry = path.join(tempDir, 'index.js');
+    writeFileSync(entry, '#!/usr/bin/env node\nconsole.log("hi");\n');
+
+    stampCliEntryEnv(entry);
+
+    expect(process.env['QWEN_CODE_CLI']).toBe(entry);
+  });
+
+  it("never overwrites an outer launcher's stamp", () => {
+    // cli-entry.js may have selected a standalone shim, and the desktop app
+    // stamps its vendored bundle — both know launch details this module
+    // cannot see, and both run before runCliEntryPoint in the same process.
+    const entry = path.join(tempDir, 'index.js');
+    writeFileSync(entry, '#!/usr/bin/env node\n');
+    process.env['QWEN_CODE_CLI'] = '/outer/launcher/qwen';
+
+    stampCliEntryEnv(entry);
+
+    expect(process.env['QWEN_CODE_CLI']).toBe('/outer/launcher/qwen');
+  });
+
+  it('treats an inherited empty string as unset', () => {
+    // A parent session's spawn filter writes '' for an entry its shell could
+    // not exec. That verdict is about the parent's entry — this build must
+    // still stamp its own.
+    const entry = path.join(tempDir, 'index.js');
+    writeFileSync(entry, '#!/usr/bin/env node\n');
+    process.env['QWEN_CODE_CLI'] = '';
+
+    stampCliEntryEnv(entry);
+
+    expect(process.env['QWEN_CODE_CLI']).toBe(entry);
+  });
+
+  it('grants the execute bit tsc never emits, so the spawn filter passes the stamp', () => {
+    // tsc writes dist/index.js as 0644 and only npm's bin-link chmods it; the
+    // spawn-time filter in core blanks a shebang-bearing entry without X_OK,
+    // which would turn this stamp into a no-op on every plain-build checkout.
+    const entry = path.join(tempDir, 'index.js');
+    writeFileSync(entry, '#!/usr/bin/env node\n', { mode: 0o644 });
+
+    stampCliEntryEnv(entry);
+
+    expect(process.env['QWEN_CODE_CLI']).toBe(entry);
+    expect(statSync(entry).mode & 0o111).not.toBe(0);
+  });
+
+  it('leaves the slot unset when the derived entry does not exist', () => {
+    stampCliEntryEnv(path.join(tempDir, 'no', 'such', 'index.js'));
+
+    expect(process.env['QWEN_CODE_CLI']).toBeUndefined();
+  });
+
+  it('derives the bin entry one level up from the compiled module', () => {
+    // cli.ts emits to dist/src/cli.js and the shebang bin is dist/index.js —
+    // one level up, not two. Two lands on the unbuilt packages/cli/index.js,
+    // which fails the existence check and silently never stamps, and no other
+    // test can catch that: the derivation is only reachable under a built
+    // layout, where vitest never runs.
+    const source = readFileSync('src/cli.ts', 'utf8');
+    expect(source).toContain("new URL('../index.js', import.meta.url)");
+    expect(
+      new URL('../index.js', 'file:///repo/packages/cli/dist/src/cli.js')
+        .pathname,
+    ).toBe('/repo/packages/cli/dist/index.js');
+  });
+
+  it('default derivation never throws and never stamps outside a built layout', () => {
+    // Under vitest import.meta.url is not even a file: URL, and in dev runs
+    // the derived ../index.js is the unbuilt packages/cli/index.js. Both must
+    // keep the bare-`qwen` fallback — a failed derivation taking the CLI down
+    // would be worse than the version skew this stamp exists to fix.
+    stampCliEntryEnv();
+
+    expect(process.env['QWEN_CODE_CLI']).toBeUndefined();
   });
 });
 

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1195,4 +1195,12 @@ describe('bootstrap error handling', () => {
     expect(output).toContain('Error handler failed:');
     expect(output).toContain('handler failed');
   });
+
+  it('wires stampCliEntryEnv into the entry point', () => {
+    const source = readFileSync('src/cli.ts', 'utf8');
+    const entryPoint = source.slice(
+      source.indexOf('export async function runCliEntryPoint'),
+    );
+    expect(entryPoint).toContain('stampCliEntryEnv()');
+  });
 });

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1202,5 +1202,11 @@ describe('bootstrap error handling', () => {
       source.indexOf('export async function runCliEntryPoint'),
     );
     expect(entryPoint).toContain('stampCliEntryEnv()');
+    // "First thing in runCliEntryPoint" is the property the doc relies on: the
+    // stamp must land before the CLI runs, not merely somewhere in the body —
+    // a stamp moved below `await run()` would still pass a contains() check.
+    expect(entryPoint.indexOf('stampCliEntryEnv()')).toBeLessThan(
+      entryPoint.indexOf('await run()'),
+    );
   });
 });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -460,9 +460,10 @@ function writeStderrLine(line: string): void {
  * The entry a subprocess should call to reach THIS build, consumed by shell
  * children as `"${QWEN_CODE_CLI:-qwen}"` (see getShellContextEnvVars in core).
  * The npm bin wrapper (scripts/cli-entry.js) stamps installed launches, but a
- * workspace launch — `node dist/index.js`, `npm start` — never passes through
- * it, so every skill shell-out resolved `qwen` off PATH: a different install,
- * silently.
+ * workspace launch — a direct `node dist/index.js` — never passes through
+ * it (the npm `start` and `dev` scripts stamp QWEN_CODE_CLI in their own
+ * launchers), so every skill shell-out resolved `qwen` off PATH: a different
+ * install, silently.
  *
  * Stamps the bin entry (dist/index.js), not this module: cli.ts compiles to
  * dist/src/cli.js, which carries no shebang, and the spawn-time filter blanks

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -469,8 +469,9 @@ function writeStderrLine(line: string): void {
  * an entry a shell cannot exec. Skipped when the derived path does not exist
  * (dev runs execute .ts sources with no built entry; the bare-`qwen` fallback
  * is the pre-existing behavior there) and when the module was not loaded from
- * the filesystem at all — test runners rewrite import.meta.url to non-file
- * schemes, and the stamp must never take the CLI down.
+ * the filesystem at all — under test runners, Vite statically rewrites the
+ * new URL(…, import.meta.url) expression to a non-file URL, and the stamp
+ * must never take the CLI down.
  *
  * The execute bit is granted here when missing, best-effort: the stamped file
  * must be shell-execable, but tsc emits dist/index.js as 0644 and only npm's

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { pathToFileURL } from 'node:url';
+import { accessSync, chmodSync, constants, existsSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import type { ArgumentsCamelCase, Argv, Options } from 'yargs';
 import { normalizeServeFastPathArgv } from './serve/fast-path-argv.js';
 import { initStartupProfiler } from './utils/startupProfiler.js';
@@ -449,10 +450,75 @@ function writeStderrLine(line: string): void {
   process.stderr.write(line.endsWith('\n') ? line : `${line}\n`);
 }
 
+/**
+ * The entry a subprocess should call to reach THIS build, consumed by shell
+ * children as `"${QWEN_CODE_CLI:-qwen}"` (see getShellContextEnvVars in core).
+ * The npm bin wrapper (scripts/cli-entry.js) stamps installed launches, but a
+ * workspace launch — `node dist/index.js`, `npm start` — never passes through
+ * it, so every skill shell-out resolved `qwen` off PATH: a different install,
+ * silently.
+ *
+ * Stamps the bin entry (dist/index.js), not this module: cli.ts compiles to
+ * dist/src/cli.js, which carries no shebang, and the spawn-time filter blanks
+ * an entry a shell cannot exec. Skipped when the derived path does not exist
+ * (dev runs execute .ts sources with no built entry; the bare-`qwen` fallback
+ * is the pre-existing behavior there) and when the module was not loaded from
+ * the filesystem at all — test runners rewrite import.meta.url to non-file
+ * schemes, and the stamp must never take the CLI down.
+ *
+ * The execute bit is granted here when missing, best-effort: the stamped file
+ * must be shell-execable, but tsc emits dist/index.js as 0644 and only npm's
+ * bin-link ever chmods it — on a plain `npm run build` checkout the spawn
+ * filter would blank the stamp and the version skew this exists to fix would
+ * survive. A failed chmod keeps the old fallback: the filter writes '' and
+ * subprocesses run `qwen`.
+ *
+ * First writer wins, unlike the wrapper's unconditional assignment: an
+ * already-set value may come from an outer launcher in THIS process —
+ * cli-entry.js selecting a standalone shim, or the desktop app's vendored
+ * bundle — which knows launch details this module cannot see and must not be
+ * overwritten. The cost is that a value inherited from a PARENT qwen session
+ * also survives, since the two cases are indistinguishable here; the primary
+ * skew scenario — a workspace launch from a plain terminal — has the slot
+ * unset either way. Empty counts as unset: a parent session's spawn filter
+ * writes '' for an entry its shell could not exec, and that verdict is about
+ * the parent's entry, not this build's.
+ */
+export function stampCliEntryEnv(entryPath?: string): void {
+  if (process.env['QWEN_CODE_CLI']) {
+    return;
+  }
+  let entry = entryPath;
+  if (entry === undefined) {
+    // dist/src/cli.js → dist/index.js. In dev (src/cli.ts) this lands on the
+    // unbuilt packages/cli/index.js and the existence check below skips it.
+    const entryUrl = new URL('../index.js', import.meta.url);
+    if (entryUrl.protocol !== 'file:') {
+      return;
+    }
+    entry = fileURLToPath(entryUrl);
+  }
+  if (existsSync(entry)) {
+    try {
+      accessSync(entry, constants.X_OK);
+    } catch {
+      try {
+        chmodSync(entry, 0o755);
+      } catch {
+        // Not chmoddable (read-only checkout): the spawn filter blanks the
+        // stamp and subprocesses fall back to `qwen`, as before this stamp.
+      }
+    }
+    process.env['QWEN_CODE_CLI'] = entry;
+  }
+}
+
 export async function runCliEntryPoint(
   run: () => Promise<void> = runCliEntry,
   handleError: (error: unknown) => Promise<void> = handleCriticalError,
 ): Promise<void> {
+  stampCliEntryEnv();
+
   process.on('uncaughtException', (error) => {
     if (isExpectedPtyRaceError(error)) {
       return;

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,7 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { accessSync, chmodSync, constants, existsSync } from 'node:fs';
+import {
+  accessSync,
+  chmodSync,
+  constants,
+  existsSync,
+  statSync,
+} from 'node:fs';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import type { ArgumentsCamelCase, Argv, Options } from 'yargs';
 import { normalizeServeFastPathArgv } from './serve/fast-path-argv.js';
@@ -483,6 +489,15 @@ function writeStderrLine(line: string): void {
  * unset either way. Empty counts as unset: a parent session's spawn filter
  * writes '' for an entry its shell could not exec, and that verdict is about
  * the parent's entry, not this build's.
+ *
+ * scripts/dev.js and scripts/start.js assign QWEN_CODE_CLI unconditionally —
+ * the opposite policy on purpose, not an oversight: those files ARE the outer
+ * launcher (they spawn the CLI as a child and must re-point an inherited value
+ * at this build), whereas this module runs in-process AFTER an outer launcher
+ * may already have stamped, so it yields. The bundled `node dist/cli.js` launch
+ * (the desktop error message's instruction) is not stamped either — cli.js sits
+ * at the package root, so the derived ../index.js does not exist and the
+ * existence check skips it, consistent with this PR's workspace-entry scope.
  */
 export function stampCliEntryEnv(entryPath?: string): void {
   if (process.env['QWEN_CODE_CLI']) {
@@ -503,7 +518,10 @@ export function stampCliEntryEnv(entryPath?: string): void {
       accessSync(entry, constants.X_OK);
     } catch {
       try {
-        chmodSync(entry, 0o755);
+        // Add exec bits to whatever mode the build/umask chose, rather than
+        // setting 0o755 — a deliberately-private 0o600 checkout becomes
+        // execable without also becoming world-readable.
+        chmodSync(entry, statSync(entry).mode | 0o111);
       } catch {
         // Not chmoddable (read-only checkout): the spawn filter blanks the
         // stamp and subprocesses fall back to `qwen`, as before this stamp.

--- a/packages/core/src/config/config-session-env.test.ts
+++ b/packages/core/src/config/config-session-env.test.ts
@@ -43,7 +43,7 @@ vi.mock('../core/contentGenerator.js', () => ({
   }),
   createContentGeneratorConfig: vi.fn().mockReturnValue({}),
   createContentGenerator: vi.fn().mockReturnValue({}),
-  AuthType: { API_KEY: 'apiKey' },
+  AuthType: { USE_GEMINI: 'gemini' },
 }));
 vi.mock('../core/baseLlmClient.js');
 vi.mock('../core/toolHookTriggers.js', () => ({
@@ -94,6 +94,7 @@ vi.mock('../memory/const.js', () => ({
 import * as fs from 'node:fs';
 import type { Mock } from 'vitest';
 import type { ConfigParameters } from './config.js';
+import type { ContentGeneratorConfig } from '../core/contentGenerator.js';
 
 const baseParams: ConfigParameters = {
   cwd: '/tmp',
@@ -220,5 +221,30 @@ describe('Config modelEnvClaimed guard', () => {
     // A non-owner's switch must not touch the process-global slot
     await later.setModel('hijacked-model');
     expect(process.env['QWEN_CODE_MODEL']).toBe('switched-model');
+  });
+
+  it('republishes on refreshAuth when the resolved model changes', async () => {
+    const { Config } = await import('./config.js');
+    // Import from the same (mocked) module instance the cold config.js import
+    // above binds to, so the re-mock below is what refreshAuth actually calls.
+    const { resolveContentGeneratorConfigWithSources, AuthType } = await import(
+      '../core/contentGenerator.js'
+    );
+    const config = new Config({ ...baseParams });
+    expect(process.env['QWEN_CODE_MODEL']).toBe('test-model');
+
+    // Auth flows call refreshAuth directly — no model-change listener fires —
+    // and the resolved model can differ from the pre-auth one; the slot must
+    // follow it so subprocesses report the model that is actually active.
+    vi.mocked(resolveContentGeneratorConfigWithSources).mockReturnValue({
+      config: {
+        model: 'auth-resolved-model',
+        apiKey: 'k',
+      } as ContentGeneratorConfig,
+      sources: {},
+    });
+    await config.refreshAuth(AuthType.USE_GEMINI);
+
+    expect(process.env['QWEN_CODE_MODEL']).toBe('auth-resolved-model');
   });
 });

--- a/packages/core/src/config/config-session-env.test.ts
+++ b/packages/core/src/config/config-session-env.test.ts
@@ -7,14 +7,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 /**
- * Tests for the module-level `sessionEnvClaimed` guard in Config.
+ * Tests for the module-level `sessionEnvClaimed` and `modelEnvClaimed`
+ * guards in Config.
  *
- * The guard ensures that only the first Config instance in a process sets
- * `process.env['QWEN_CODE_SESSION_ID']`, preventing throwaway instances
- * (e.g. telemetry-only) from overwriting the real session's ID.
+ * The guards ensure that only the first Config instance in a process sets
+ * `process.env['QWEN_CODE_SESSION_ID']` / `process.env['QWEN_CODE_MODEL']`,
+ * preventing throwaway instances (e.g. telemetry-only) from overwriting the
+ * real session's values.
  *
  * We use `vi.isolateModules` to get a fresh module scope (resetting the
- * module-level flag) for each test.
+ * module-level flags) for each test.
  */
 
 // Shared mocks needed by Config constructor
@@ -110,36 +112,44 @@ const baseParams: ConfigParameters = {
 // The reset is load-bearing for what these tests check, so give them headroom.
 vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
-describe('Config sessionEnvClaimed guard', () => {
-  let originalEnv: string | undefined;
+let originalEnv: string | undefined;
+let originalModelEnv: string | undefined;
 
-  beforeEach(() => {
-    originalEnv = process.env['QWEN_CODE_SESSION_ID'];
+beforeEach(() => {
+  originalEnv = process.env['QWEN_CODE_SESSION_ID'];
+  delete process.env['QWEN_CODE_SESSION_ID'];
+  originalModelEnv = process.env['QWEN_CODE_MODEL'];
+  delete process.env['QWEN_CODE_MODEL'];
+
+  (fs.existsSync as Mock).mockReturnValue(true);
+  (fs.readdirSync as Mock).mockReturnValue([]);
+  (fs.statSync as Mock).mockReturnValue({
+    isDirectory: vi.fn().mockReturnValue(true),
+  });
+  vi.mocked(fs.realpathSync).mockImplementation((p) => String(p));
+  (fs.mkdirSync as Mock).mockImplementation(() => undefined);
+  (fs.writeFileSync as Mock).mockImplementation(() => undefined);
+  (fs.renameSync as Mock).mockImplementation(() => undefined);
+  (fs.copyFileSync as Mock).mockImplementation(() => undefined);
+  (fs.unlinkSync as Mock).mockImplementation(() => undefined);
+  (fs.readFileSync as Mock).mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  if (originalEnv !== undefined) {
+    process.env['QWEN_CODE_SESSION_ID'] = originalEnv;
+  } else {
     delete process.env['QWEN_CODE_SESSION_ID'];
+  }
+  if (originalModelEnv !== undefined) {
+    process.env['QWEN_CODE_MODEL'] = originalModelEnv;
+  } else {
+    delete process.env['QWEN_CODE_MODEL'];
+  }
+  vi.resetModules();
+});
 
-    (fs.existsSync as Mock).mockReturnValue(true);
-    (fs.readdirSync as Mock).mockReturnValue([]);
-    (fs.statSync as Mock).mockReturnValue({
-      isDirectory: vi.fn().mockReturnValue(true),
-    });
-    vi.mocked(fs.realpathSync).mockImplementation((p) => String(p));
-    (fs.mkdirSync as Mock).mockImplementation(() => undefined);
-    (fs.writeFileSync as Mock).mockImplementation(() => undefined);
-    (fs.renameSync as Mock).mockImplementation(() => undefined);
-    (fs.copyFileSync as Mock).mockImplementation(() => undefined);
-    (fs.unlinkSync as Mock).mockImplementation(() => undefined);
-    (fs.readFileSync as Mock).mockImplementation(() => undefined);
-  });
-
-  afterEach(() => {
-    if (originalEnv !== undefined) {
-      process.env['QWEN_CODE_SESSION_ID'] = originalEnv;
-    } else {
-      delete process.env['QWEN_CODE_SESSION_ID'];
-    }
-    vi.resetModules();
-  });
-
+describe('Config sessionEnvClaimed guard', () => {
   it('first Config sets process.env QWEN_CODE_SESSION_ID to its sessionId', async () => {
     const { Config } = await import('./config.js');
     const config = new Config({ ...baseParams });
@@ -177,5 +187,38 @@ describe('Config sessionEnvClaimed guard', () => {
 
     expect(process.env['QWEN_CODE_SESSION_ID']).toBe('new-session-uuid-123');
     expect(process.env['QWEN_CODE_SESSION_ID']).not.toBe(originalSessionId);
+  });
+});
+
+describe('Config modelEnvClaimed guard', () => {
+  it('first Config publishes its model to QWEN_CODE_MODEL', async () => {
+    const { Config } = await import('./config.js');
+    new Config({ ...baseParams });
+
+    expect(process.env['QWEN_CODE_MODEL']).toBe('test-model');
+  });
+
+  it('a later Config does not overwrite the claimed slot', async () => {
+    const { Config } = await import('./config.js');
+    new Config({ ...baseParams });
+
+    // Second Config (daemon side-session or telemetry-only throwaway)
+    new Config({ ...baseParams, model: 'other-model' });
+
+    expect(process.env['QWEN_CODE_MODEL']).toBe('test-model');
+  });
+
+  it('only the claiming Config republishes on setModel', async () => {
+    const { Config } = await import('./config.js');
+    const owner = new Config({ ...baseParams });
+    const later = new Config({ ...baseParams, model: 'other-model' });
+
+    // Simulate /model on the live session
+    await owner.setModel('switched-model');
+    expect(process.env['QWEN_CODE_MODEL']).toBe('switched-model');
+
+    // A non-owner's switch must not touch the process-global slot
+    await later.setModel('hijacked-model');
+    expect(process.env['QWEN_CODE_MODEL']).toBe('switched-model');
   });
 });

--- a/packages/core/src/config/config-session-env.test.ts
+++ b/packages/core/src/config/config-session-env.test.ts
@@ -263,4 +263,25 @@ describe('Config modelEnvClaimed guard', () => {
     expect(getSessionModel(first.getSessionId())).toBe('test-model');
     expect(getSessionModel(later.getSessionId())).toBe('other-model');
   });
+
+  it('re-keys the per-session model registry on startNewSession', async () => {
+    const { Config } = await import('./config.js');
+    const { getSessionModel } = await import('../utils/sessionIdContext.js');
+    // Owner boots first and claims the process-global slot; the side-session
+    // is the non-owner Config whose subprocesses read the per-session registry.
+    new Config({ ...baseParams });
+    const side = new Config({ ...baseParams, model: 'other-model' });
+    const oldSessionId = side.getSessionId();
+    expect(getSessionModel(oldSessionId)).toBe('other-model');
+
+    // /clear (and /reset, /new, /resume) flow through startNewSession, which
+    // mints a new session id. The registry entry must move with it — leaving
+    // it keyed on the old id would make the side-session's subprocesses miss
+    // and fall back to the owner's model.
+    const newSessionId = side.startNewSession();
+
+    expect(newSessionId).not.toBe(oldSessionId);
+    expect(getSessionModel(newSessionId)).toBe('other-model');
+    expect(getSessionModel(oldSessionId)).toBeUndefined();
+  });
 });

--- a/packages/core/src/config/config-session-env.test.ts
+++ b/packages/core/src/config/config-session-env.test.ts
@@ -43,7 +43,7 @@ vi.mock('../core/contentGenerator.js', () => ({
   }),
   createContentGeneratorConfig: vi.fn().mockReturnValue({}),
   createContentGenerator: vi.fn().mockReturnValue({}),
-  AuthType: { USE_GEMINI: 'gemini' },
+  AuthType: { USE_GEMINI: 'gemini', QWEN_OAUTH: 'qwen-oauth' },
 }));
 vi.mock('../core/baseLlmClient.js');
 vi.mock('../core/toolHookTriggers.js', () => ({
@@ -246,5 +246,21 @@ describe('Config modelEnvClaimed guard', () => {
     await config.refreshAuth(AuthType.USE_GEMINI);
 
     expect(process.env['QWEN_CODE_MODEL']).toBe('auth-resolved-model');
+  });
+
+  it("registers each Config's model per session, so a daemon side-session reads its own", async () => {
+    const { Config } = await import('./config.js');
+    // Import from the same cold module graph the Config above bound to, so this
+    // reads the registry the constructor actually wrote.
+    const { getSessionModel } = await import('../utils/sessionIdContext.js');
+    const first = new Config({ ...baseParams });
+    const later = new Config({ ...baseParams, model: 'other-model' });
+
+    // The process-global slot is first-writer-wins (covered above), but the
+    // per-session registry holds EACH session's model — this is what daemon
+    // mode reads at spawn time, so a later session is not stuck reporting the
+    // first session's model.
+    expect(getSessionModel(first.getSessionId())).toBe('test-model');
+    expect(getSessionModel(later.getSessionId())).toBe('other-model');
   });
 });

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -3663,6 +3663,13 @@ export class Config {
     if (process.env) {
       process.env['QWEN_CODE_SESSION_ID'] = this.sessionId;
     }
+    // Re-key the per-session model registry onto the new session id. Without
+    // this the entry stays keyed on the outgoing id, so after /clear (or
+    // /reset, /new, /resume) a non-owner Config's subprocesses resolve the
+    // model by the new id, miss, and fall back to another session's value.
+    // Drop the orphaned entry too — shutdown only unregisters the current id.
+    unregisterSessionModel(previousSessionId);
+    this.publishModelEnv();
     this.sessionData = sessionData;
     this.pendingRecoveredAgentsNotice = null;
     setDebugLogSession(this);

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -190,7 +190,9 @@ import { DEFAULT_QWEN_CUSTOM_IGNORE_FILE_NAMES } from '../utils/qwenIgnoreParser
 import { DEFAULT_TOOL_RESULTS_TOTAL_CHARS_THRESHOLD } from './clearContextDefaults.js';
 import { DEFAULT_QWEN_EMBEDDING_MODEL } from './models.js';
 import {
+  registerSessionModel,
   registerSessionProjectDir,
+  unregisterSessionModel,
   unregisterSessionProjectDir,
 } from '../utils/sessionIdContext.js';
 import { Storage } from './storage.js';
@@ -1994,8 +1996,9 @@ export class Config {
   private messageBus?: MessageBus;
   private readonly memoryManager: MemoryManager;
   private readonly modelChangeListeners = new Set<(model: string) => void>();
-  // True on the Config that claimed the QWEN_CODE_MODEL slot (first in this
-  // process); gates publishModelEnv so no other instance updates it.
+  // True on the Config that claimed the process-global QWEN_CODE_MODEL slot
+  // (first in this process); gates the global write in publishModelEnv so no
+  // other instance updates it. Per-session publishing is not gated on it.
   private readonly ownsModelEnvSlot: boolean = false;
   private readonly settingsWatcher?: { stopWatching(): void };
 
@@ -2320,17 +2323,19 @@ export class Config {
       onModelChange: this.handleModelChange.bind(this),
     });
 
-    // Publish the active model id for shell subprocesses, under the same claim
-    // discipline as QWEN_CODE_SESSION_ID above: the first Config wins, and only
-    // the claiming instance republishes on model changes (publishModelEnv), so
-    // throwaway Configs never clobber the live session's model. Claimed here
-    // rather than alongside the session ID because the value comes from the
-    // ModelsConfig just constructed.
+    // Publish the active model id for shell subprocesses. Every Config
+    // publishes its own session's model — publishModelEnv registers it per
+    // session, like the project dir above, so daemon-mode subprocesses read
+    // theirs, not the first session's. The process-global slot is claimed
+    // first-writer-wins, as QWEN_CODE_SESSION_ID is, so a throwaway Config
+    // never clobbers the live session's global value. Done here rather than
+    // alongside the session ID because the value comes from the ModelsConfig
+    // just constructed.
     if (!modelEnvClaimed && process.env) {
       modelEnvClaimed = true;
       this.ownsModelEnvSlot = true;
-      this.publishModelEnv();
     }
+    this.publishModelEnv();
 
     if (
       this.telemetrySettings.enabled &&
@@ -3853,13 +3858,21 @@ export class Config {
 
   // Keeps QWEN_CODE_MODEL on the model that is actually active. A subprocess
   // has no other authoritative source: settings files miss /model switches and
-  // describe the wrong home under QWEN_HOME isolation. Gated on the claiming
-  // instance (see the constructor), so in daemon mode the slot — like
-  // QWEN_CODE_SESSION_ID — only ever reflects the first session; later
-  // sessions' Configs never write it.
+  // describe the wrong home under QWEN_HOME isolation. Published per session —
+  // every Config writes its OWN session's model, keyed on sessionId exactly
+  // like the project dir, so in daemon mode each session's subprocesses read
+  // theirs, not the first session's (a process-global slot alone would hold
+  // whichever session booted first). The process-global slot is the
+  // single-session CLI fallback, gated on the claiming instance so a throwaway
+  // Config never clobbers the live session's value there.
   private publishModelEnv(): void {
-    if (this.ownsModelEnvSlot && process.env) {
-      process.env['QWEN_CODE_MODEL'] = this.getModel();
+    if (!process.env) {
+      return;
+    }
+    const model = this.getModel();
+    registerSessionModel(this.sessionId, model);
+    if (this.ownsModelEnvSlot) {
+      process.env['QWEN_CODE_MODEL'] = model;
     }
   }
 
@@ -4735,6 +4748,10 @@ export class Config {
         unregisterSessionProjectDir(this.sessionId);
         this.sessionProjectDirRegistered = false;
       }
+      // Drop this session's model registry entry. It is registered at
+      // construction (publishModelEnv), so it is released on every shutdown —
+      // same daemon-mode leak rationale as the project dir above.
+      unregisterSessionModel(this.sessionId);
 
       if (Object.hasOwn(this, 'goalRuntime')) {
         this.goalTurnHostUnbind?.();

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1552,6 +1552,7 @@ const EMPTY_DISABLED_SKILL_NAMES: ReadonlySet<string> = Object.freeze(
 // processes to claim their own (they start with a fresh module scope).
 let sessionEnvClaimed = false;
 let projectDirEnvClaimed = false;
+let modelEnvClaimed = false;
 
 function resolveSensitiveSpanAttributeMaxLength(
   value: number | undefined,
@@ -1993,6 +1994,9 @@ export class Config {
   private messageBus?: MessageBus;
   private readonly memoryManager: MemoryManager;
   private readonly modelChangeListeners = new Set<(model: string) => void>();
+  // True on the Config that claimed the QWEN_CODE_MODEL slot (first in this
+  // process); gates publishModelEnv so no other instance updates it.
+  private readonly ownsModelEnvSlot: boolean = false;
   private readonly settingsWatcher?: { stopWatching(): void };
 
   constructor(params: ConfigParameters) {
@@ -2315,6 +2319,18 @@ export class Config {
       initialRegistryBaseUrl: params.initialModelRegistryBaseUrl,
       onModelChange: this.handleModelChange.bind(this),
     });
+
+    // Publish the active model id for shell subprocesses, under the same claim
+    // discipline as QWEN_CODE_SESSION_ID above: the first Config wins, and only
+    // the claiming instance republishes on model changes (publishModelEnv), so
+    // throwaway Configs never clobber the live session's model. Claimed here
+    // rather than alongside the session ID because the value comes from the
+    // ModelsConfig just constructed.
+    if (!modelEnvClaimed && process.env) {
+      modelEnvClaimed = true;
+      this.ownsModelEnvSlot = true;
+      this.publishModelEnv();
+    }
 
     if (
       this.telemetrySettings.enabled &&
@@ -3534,6 +3550,9 @@ export class Config {
     // Only assign to instance properties after successful initialization
     this.contentGeneratorConfig = newContentGeneratorConfig;
     this.contentGeneratorConfigSources = sources;
+    // Auth flows call refreshAuth directly — no model-change notification
+    // fires — and the resolved model can differ from the pre-auth one.
+    this.publishModelEnv();
 
     // Re-apply the user's reasoning effort that the provider sync above wiped.
     if (priorReasoningEffort) {
@@ -3825,9 +3844,22 @@ export class Config {
   }
 
   private notifyModelChangeListeners(): void {
+    this.publishModelEnv();
     const model = this.getModel();
     for (const listener of this.modelChangeListeners) {
       listener(model);
+    }
+  }
+
+  // Keeps QWEN_CODE_MODEL on the model that is actually active. A subprocess
+  // has no other authoritative source: settings files miss /model switches and
+  // describe the wrong home under QWEN_HOME isolation. Gated on the claiming
+  // instance (see the constructor), so in daemon mode the slot — like
+  // QWEN_CODE_SESSION_ID — only ever reflects the first session; later
+  // sessions' Configs never write it.
+  private publishModelEnv(): void {
+    if (this.ownsModelEnvSlot && process.env) {
+      process.env['QWEN_CODE_MODEL'] = this.getModel();
     }
   }
 

--- a/packages/core/src/utils/sessionIdContext.ts
+++ b/packages/core/src/utils/sessionIdContext.ts
@@ -61,3 +61,36 @@ export function getSessionProjectDir(sessionId: string): string | undefined {
 export function unregisterSessionProjectDir(sessionId: string): void {
   projectDirBySession.delete(sessionId);
 }
+
+/**
+ * Each session's active model id, keyed by its session id.
+ *
+ * A subprocess that reports which model ran (the /review compose step) needs
+ * the model that is ACTIVE in this session, and settings files are not a
+ * substitute: they miss /model switches and, under QWEN_HOME isolation,
+ * describe a different home entirely. So the live model is passed down through
+ * the environment.
+ *
+ * Keyed on the session for the same reason the project dir is: a single
+ * process-global slot holds whichever session booted first, and in daemon mode
+ * every later session would then hand its subprocesses another session's model
+ * — a confidently-wrong id, worse than an absent one.
+ */
+const modelBySession = new Map<string, string>();
+
+export function registerSessionModel(sessionId: string, model: string): void {
+  if (sessionId && model) modelBySession.set(sessionId, model);
+}
+
+export function getSessionModel(sessionId: string): string | undefined {
+  return modelBySession.get(sessionId);
+}
+
+/**
+ * Drop a session's entry when it ends, for the same reason as
+ * {@link unregisterSessionProjectDir}: the map would otherwise grow one entry
+ * per session for the life of a daemon process.
+ */
+export function unregisterSessionModel(sessionId: string): void {
+  modelBySession.delete(sessionId);
+}

--- a/packages/core/src/utils/shellContextEnv.test.ts
+++ b/packages/core/src/utils/shellContextEnv.test.ts
@@ -41,6 +41,9 @@ describe('getShellContextEnvVars', () => {
   // here also cleans up after the per-session tests below, which assign it and
   // used to leak the assignment into every later test in the file.
   let originalProjectDir: string | undefined;
+  // And QWEN_CODE_MODEL — Config claims it into process.env, so a test run
+  // started from inside a qwen session inherits it too.
+  let originalModel: string | undefined;
 
   beforeEach(() => {
     originalSessionId = process.env['QWEN_CODE_SESSION_ID'];
@@ -49,6 +52,8 @@ describe('getShellContextEnvVars', () => {
     delete process.env['QWEN_CODE_CLI'];
     originalProjectDir = process.env['QWEN_CODE_PROJECT_DIR'];
     delete process.env['QWEN_CODE_PROJECT_DIR'];
+    originalModel = process.env['QWEN_CODE_MODEL'];
+    delete process.env['QWEN_CODE_MODEL'];
   });
 
   afterEach(() => {
@@ -66,6 +71,11 @@ describe('getShellContextEnvVars', () => {
       process.env['QWEN_CODE_PROJECT_DIR'] = originalProjectDir;
     } else {
       delete process.env['QWEN_CODE_PROJECT_DIR'];
+    }
+    if (originalModel !== undefined) {
+      process.env['QWEN_CODE_MODEL'] = originalModel;
+    } else {
+      delete process.env['QWEN_CODE_MODEL'];
     }
   });
 
@@ -303,6 +313,36 @@ describe('getShellContextEnvVars', () => {
 
       expect(envSeenByA['QWEN_CODE_SESSION_ID']).toBe('session-A');
       expect(envSeenByB['QWEN_CODE_SESSION_ID']).toBe('session-B');
+    });
+  });
+
+  describe('active model id (QWEN_CODE_MODEL)', () => {
+    it('passes the active model down from the Config-claimed slot', () => {
+      // A subprocess that must report which model ran (the /review compose
+      // step) has no other authoritative source — settings files miss /model
+      // switches and describe the wrong home under QWEN_HOME isolation.
+      process.env['QWEN_CODE_MODEL'] = 'qwen3-coder-plus';
+      expect(getShellContextEnvVars()['QWEN_CODE_MODEL']).toBe(
+        'qwen3-coder-plus',
+      );
+    });
+
+    it('omits the key when no Config has claimed the slot', () => {
+      // Same rule as the session ID: nothing in process.env means the
+      // spawn-site spread has nothing stale to leak, so absence is correct.
+      expect('QWEN_CODE_MODEL' in getShellContextEnvVars()).toBe(false);
+    });
+
+    it('reflects a republished slot after a model switch', () => {
+      // publishModelEnv in config.ts rewrites the slot on set/switchModel and
+      // refreshAuth; spawn-time reads must see the CURRENT value, not one
+      // captured earlier.
+      process.env['QWEN_CODE_MODEL'] = 'model-before-switch';
+      getShellContextEnvVars();
+      process.env['QWEN_CODE_MODEL'] = 'model-after-switch';
+      expect(getShellContextEnvVars()['QWEN_CODE_MODEL']).toBe(
+        'model-after-switch',
+      );
     });
   });
 

--- a/packages/core/src/utils/shellContextEnv.test.ts
+++ b/packages/core/src/utils/shellContextEnv.test.ts
@@ -15,6 +15,8 @@ import {
   sessionIdContext,
   registerSessionProjectDir,
   unregisterSessionProjectDir,
+  registerSessionModel,
+  unregisterSessionModel,
 } from './sessionIdContext.js';
 import {
   isShellTracePropagationEnabled,
@@ -343,6 +345,45 @@ describe('getShellContextEnvVars', () => {
       expect(getShellContextEnvVars()['QWEN_CODE_MODEL']).toBe(
         'model-after-switch',
       );
+    });
+  });
+
+  describe('model is per-session, not per-process', () => {
+    it('hands each session its own active model', () => {
+      // One daemon process, two sessions, two /model selections. A single
+      // process-global slot holds whichever booted first — and every later
+      // session would then stamp a model that never ran the review, the exact
+      // bug this PR opens with, relocated to the consumer.
+      registerSessionModel('sess-A', 'model-A');
+      registerSessionModel('sess-B', 'model-B');
+      process.env['QWEN_CODE_MODEL'] = 'model-A'; // the first to boot
+
+      const a = sessionIdContext.run('sess-A', () => getShellContextEnvVars());
+      const b = sessionIdContext.run('sess-B', () => getShellContextEnvVars());
+
+      expect(a['QWEN_CODE_MODEL']).toBe('model-A');
+      expect(b['QWEN_CODE_MODEL']).toBe('model-B'); // NOT A's
+    });
+
+    it('drops a session entry on unregister — no daemon leak', () => {
+      registerSessionModel('sess-X', 'model-X');
+      expect(
+        sessionIdContext.run('sess-X', () => getShellContextEnvVars())[
+          'QWEN_CODE_MODEL'
+        ],
+      ).toBe('model-X');
+      unregisterSessionModel('sess-X');
+      delete process.env['QWEN_CODE_MODEL'];
+      expect(
+        sessionIdContext.run('sess-X', () => getShellContextEnvVars())[
+          'QWEN_CODE_MODEL'
+        ],
+      ).toBeUndefined();
+    });
+
+    it('falls back to the global slot for the single-session CLI', () => {
+      process.env['QWEN_CODE_MODEL'] = 'model-only';
+      expect(getShellContextEnvVars()['QWEN_CODE_MODEL']).toBe('model-only');
     });
   });
 

--- a/packages/core/src/utils/shellContextEnv.ts
+++ b/packages/core/src/utils/shellContextEnv.ts
@@ -127,6 +127,21 @@ export function getShellContextEnvVars(): Record<string, string> {
     env['QWEN_CODE_CLI'] = isUnusableScriptEntry(cliEntry) ? '' : cliEntry;
   }
 
+  // The model id that is ACTIVE in this session, for subprocesses that report
+  // which model ran (the /review skill stamps its compose report with one).
+  // Settings files are not a substitute: they miss /model switches, and under
+  // QWEN_HOME isolation they describe a different home entirely. Config claims
+  // this slot at construction and republishes on every model change
+  // (publishModelEnv in config.ts). Process-global like the session-ID
+  // fallback above, with the same daemon limitation: later sessions read the
+  // first session's model. Omitted (not blanked) when absent, for the session
+  // ID's reason — no value in this process means the spawn-site spread has
+  // nothing stale to leak.
+  const model = process.env['QWEN_CODE_MODEL'];
+  if (model) {
+    env['QWEN_CODE_MODEL'] = model;
+  }
+
   // For agent/prompt IDs: explicitly set empty string when no ALS context
   // exists, so that stale values inherited from a parent qwen-code process
   // (via process.env spread) are overwritten rather than leaked.

--- a/packages/core/src/utils/shellContextEnv.ts
+++ b/packages/core/src/utils/shellContextEnv.ts
@@ -132,11 +132,11 @@ export function getShellContextEnvVars(): Record<string, string> {
   // Settings files are not a substitute: they miss /model switches, and under
   // QWEN_HOME isolation they describe a different home entirely. Config claims
   // this slot at construction and republishes on every model change
-  // (publishModelEnv in config.ts). Process-global like the session-ID
-  // fallback above, with the same daemon limitation: later sessions read the
-  // first session's model. Omitted (not blanked) when absent, for the session
-  // ID's reason — no value in this process means the spawn-site spread has
-  // nothing stale to leak.
+  // (publishModelEnv in config.ts). Process-global only — unlike the session ID
+  // above, there is no per-session ALS context here, so in daemon mode later
+  // sessions read the first session's model and nothing corrects it per-session.
+  // Omitted (not blanked) when absent, for the session ID's reason — no value in
+  // this process means the spawn-site spread has nothing stale to leak.
   const model = process.env['QWEN_CODE_MODEL'];
   if (model) {
     env['QWEN_CODE_MODEL'] = model;

--- a/packages/core/src/utils/shellContextEnv.ts
+++ b/packages/core/src/utils/shellContextEnv.ts
@@ -26,7 +26,11 @@
 import { accessSync, closeSync, constants, openSync, readSync } from 'node:fs';
 import { getCurrentAgentId } from '../agents/runtime/agent-context.js';
 import { promptIdContext } from './promptIdContext.js';
-import { sessionIdContext, getSessionProjectDir } from './sessionIdContext.js';
+import {
+  sessionIdContext,
+  getSessionProjectDir,
+  getSessionModel,
+} from './sessionIdContext.js';
 import {
   isShellTracePropagationEnabled,
   getTraceContext,
@@ -130,14 +134,18 @@ export function getShellContextEnvVars(): Record<string, string> {
   // The model id that is ACTIVE in this session, for subprocesses that report
   // which model ran (the /review skill stamps its compose report with one).
   // Settings files are not a substitute: they miss /model switches, and under
-  // QWEN_HOME isolation they describe a different home entirely. Config claims
-  // this slot at construction and republishes on every model change
-  // (publishModelEnv in config.ts). Process-global only — unlike the session ID
-  // above, there is no per-session ALS context here, so in daemon mode later
-  // sessions read the first session's model and nothing corrects it per-session.
-  // Omitted (not blanked) when absent, for the session ID's reason — no value in
-  // this process means the spawn-site spread has nothing stale to leak.
-  const model = process.env['QWEN_CODE_MODEL'];
+  // QWEN_HOME isolation they describe a different home entirely. Config
+  // publishes it per session and republishes on every model change
+  // (publishModelEnv in config.ts). Keyed on this session exactly as the
+  // project dir above is — a process-global slot would hold whichever session
+  // booted first, and in daemon mode every later one would hand its
+  // subprocesses another session's model. Falls back to the global slot for the
+  // single-session CLI. Omitted (not blanked) when absent, for the session ID's
+  // reason — no value in this process means the spawn-site spread has nothing
+  // stale to leak.
+  const model =
+    (sessionId ? getSessionModel(sessionId) : undefined) ??
+    process.env['QWEN_CODE_MODEL'];
   if (model) {
     env['QWEN_CODE_MODEL'] = model;
   }


### PR DESCRIPTION
Part of #7981 (item P0-2, runtime identity for skill subprocesses).

## What

Two gaps, one theme: a skill's shell subprocesses could neither reliably reach **the build that launched them** nor learn **the model actually running**.

1. **`QWEN_CODE_CLI` is now stamped at the workspace entry.** The npm entry (`scripts/cli-entry.js`) stamps it; the workspace entry (`packages/cli/dist/index.js`) never did — so dev runs and direct `node dist/index.js` launches left it unset, and every `"${QWEN_CODE_CLI:-qwen}"` the /review skill issues silently landed in whatever global `qwen` PATH resolves to. Measured on a live run: a freshly built CLI's whole review pipeline executed on a global v0.21.0 — `script-lint` did not exist there, so the deterministic gate the skill expected was silently absent, and any behavioral fix to the review CLI is inert in such runs.
2. **The active model is published as `QWEN_CODE_MODEL`.** The /review compose step wants a `modelId`, and with no authoritative source the orchestrator resorts to reading settings files — wrong under `QWEN_HOME` isolation and after `/model` switches (measured: a report stamped with a model that never ran the review).

## How

- **Stamp:** `stampCliEntryEnv()` runs first thing in `runCliEntryPoint`, first-writer-wins — an outer launcher (`cli-entry.js`, the desktop shim) has already stamped in-process and must keep winning; an empty value counts as unset, matching the consumer's `:-` semantics. The entry derives as `../index.js` from the compiled `dist/src/cli.js` (the shebang-bearing bin); non-`file:` schemes (vitest) and unbuilt layouts (tsx dev) skip the stamp and keep today's fallback. `tsc` emits `dist/index.js` as 0644 and the spawn-time filter blanks a non-execable entry — the stamp grants `0o755` best-effort; a failed chmod degrades to today's `qwen` fallback.
- **Model:** published exactly the way `QWEN_CODE_SESSION_ID` is — the first `Config` claims the process-global slot, and only the claiming instance republishes (on `refreshAuth` and every model-change notification, which covers `setModel`/`switchModel` and all `ModelsConfig.onModelChange` routes; verified no bypass callers). `getShellContextEnvVars` passes it through, omitted when absent. The daemon limitation is the session ID's own — later sessions read the first session's model — documented at both producer and consumer.

## Tests

- `cli.test.ts`: 7 new cases for the stamp (stamp, outer-launcher precedence, empty-as-unset, exec-bit grant, missing entry, path-derivation regression guard, default-derivation safety) — 52/52.
- `config-session-env.test.ts`: claim, non-clobber by later Configs, owner-only republish on `setModel`, against the real unmocked model path — 6/6.
- `shellContextEnv.test.ts`: pass-through, omission when absent, republished-slot freshness — 25/25.
- Also verified out-of-band: esbuild-bundling `cli.ts` into a synthetic `dist/src/cli.js` layout and running it under plain node stamps the correct `dist/index.js`, chmods 644→755, and preserves a preset outer value; the tsx-from-source path leaves the slot unset. `config.test.ts` 449/449 as regression; eslint `--max-warnings 0` and core tsc clean.

<details>
<summary>中文说明</summary>

关联 #7981(P0-2,skill 子进程的运行时身份)。

## 做了什么

两个缺口,同一主题:skill 的 shell 子进程既不能可靠调用到**启动它的那个构建**,也无法得知**实际运行的模型**。

1. **workspace 入口现在会盖 `QWEN_CODE_CLI` 戳。** npm 入口(`scripts/cli-entry.js`)会设置它;workspace 入口(`packages/cli/dist/index.js`)从未设置——dev 运行和直接 `node dist/index.js` 启动时该变量为空,/review skill 发出的每条 `"${QWEN_CODE_CLI:-qwen}"` 都静默落到 PATH 上的全局 `qwen`。真实运行实测:新构建 CLI 的整条评审流水线跑在全局 v0.21.0 上——那里没有 `script-lint`,skill 预期的确定性门禁静默缺失,而且任何对 review CLI 的行为修复在这类运行中都不生效。
2. **活动模型以 `QWEN_CODE_MODEL` 发布。** /review 的 compose 步骤需要 `modelId`,没有权威来源时编排模型只能去读 settings 文件——在 `QWEN_HOME` 隔离下、在 `/model` 切换后都会读错(实测:报告盖了一个从未跑过该评审的模型名)。

## 怎么做

- **盖戳**:`stampCliEntryEnv()` 在 `runCliEntryPoint` 最先执行,先写者胜——外层启动器(`cli-entry.js`、桌面 shim)已在同进程内盖戳,必须继续获胜;空串按未设处理,与消费方 `:-` 语义一致。入口从编译后的 `dist/src/cli.js` 推导为 `../index.js`(带 shebang 的 bin);非 `file:` 协议(vitest)和未构建布局(tsx dev)跳过盖戳,保持现状回退。`tsc` 产出的 `dist/index.js` 是 0644,而 spawn 时的过滤器会把不可执行的入口置空——盖戳时尽力授予 `0o755`;chmod 失败则退化为现状的 `qwen` 回退。
- **模型**:与 `QWEN_CODE_SESSION_ID` 完全同构——首个 `Config` 认领进程级槽位,且仅认领实例重发布(在 `refreshAuth` 与每次模型变更通知时,覆盖 `setModel`/`switchModel` 及全部 `ModelsConfig.onModelChange` 路径;已核实无绕过调用方)。`getShellContextEnvVars` 透传,缺失时省略。daemon 局限与 session ID 相同——后续会话读到首个会话的模型——已在生产端与消费端双侧注明。

## 测试

- `cli.test.ts`:盖戳 7 个新用例(盖戳、外层启动器优先、空串视为未设、exec 位授予、入口缺失、路径推导回归守卫、默认推导安全)——52/52。
- `config-session-env.test.ts`:认领、后续 Config 不覆盖、仅 owner 在 `setModel` 时重发布,走真实未 mock 的模型路径——6/6。
- `shellContextEnv.test.ts`:透传、缺失省略、重发布后的新鲜度——25/25。
- 另有带外验证:用 esbuild 将 `cli.ts` 打包成合成的 `dist/src/cli.js` 布局后以纯 node 运行,正确盖戳 `dist/index.js`、chmod 644→755、保留外层预设值;tsx 源码路径保持槽位为空。`config.test.ts` 449/449 回归;eslint `--max-warnings 0` 与 core tsc 干净。

</details>
