### PR TITLE
fix(cli): map Kitty Super (Command) modifier to meta

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -391,6 +391,50 @@ describe('KeypressContext - Kitty Protocol', () => {
       );
     });
 
+    it('maps the Kitty Super bit to meta on the reverse-tab path', () => {
+      const keyHandler = vi.fn();
+
+      const { result } = renderHook(() => useKeypressContext(), {
+        wrapper: ({ children }) =>
+          wrapper({ children, kittyProtocolEnabled: true }),
+      });
+
+      act(() => {
+        result.current.subscribe(keyHandler);
+      });
+
+      // Cmd+Shift+Tab: modifier 10 = base 1 + Shift 1 + Super 8
+      act(() => {
+        stdin.sendKittySequence(`\x1b[1;10Z`);
+      });
+
+      expect(keyHandler).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'tab', shift: true, meta: true }),
+      );
+    });
+
+    it('maps the Kitty Super bit to meta on the functional-keys path', () => {
+      const keyHandler = vi.fn();
+
+      const { result } = renderHook(() => useKeypressContext(), {
+        wrapper: ({ children }) =>
+          wrapper({ children, kittyProtocolEnabled: true }),
+      });
+
+      act(() => {
+        result.current.subscribe(keyHandler);
+      });
+
+      // Cmd+Up: modifier 9 = base 1 + Super 8
+      act(() => {
+        stdin.sendKittySequence(`\x1b[1;9A`);
+      });
+
+      expect(keyHandler).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'up', meta: true }),
+      );
+    });
+
     it('decodes Shift+Enter modifyOtherKeys form without Kitty enabled', () => {
       // Ghostty (and other xterm modifyOtherKeys terminals) send Shift+Enter as
       // ESC [ 27 ; 2 ; 13 ~ when the Kitty protocol is not negotiated. readline

--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -359,6 +359,38 @@ describe('KeypressContext - Kitty Protocol', () => {
       );
     });
 
+    it('maps the Kitty Super (Command) bit to meta so Cmd+C does not leak "c"', () => {
+      // A Kitty-protocol terminal forwards Cmd+C as ESC [ 99 ; 9 u (keycode 99
+      // = "c", modifier 9 = base 1 + Super bit 8) while performing the copy
+      // itself. If the Super bit is dropped, this parses as a bare printable
+      // "c" (meta: false) and the text buffer inserts it. Super must surface as
+      // meta so the input handler skips insertion. See issue #7990.
+      const keyHandler = vi.fn();
+
+      const { result } = renderHook(() => useKeypressContext(), {
+        wrapper: ({ children }) =>
+          wrapper({ children, kittyProtocolEnabled: true }),
+      });
+
+      act(() => {
+        result.current.subscribe(keyHandler);
+      });
+
+      act(() => {
+        stdin.sendKittySequence(`\x1b[99;9u`);
+      });
+
+      expect(keyHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'c',
+          kittyProtocol: true,
+          ctrl: false,
+          meta: true,
+          shift: false,
+        }),
+      );
+    });
+
     it('decodes Shift+Enter modifyOtherKeys form without Kitty enabled', () => {
       // Ghostty (and other xterm modifyOtherKeys terminals) send Shift+Enter as
       // ESC [ 27 ; 2 ; 13 ~ when the Kitty protocol is not negotiated. readline

--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -425,13 +425,15 @@ describe('KeypressContext - Kitty Protocol', () => {
         result.current.subscribe(keyHandler);
       });
 
-      // Cmd+Up: modifier 9 = base 1 + Super 8
+      // Cmd+Home: modifier 9 = base 1 + Super 8. Use Home (H), not an arrow
+      // (A/B/C/D): readline claims modified arrows before they reach the Kitty
+      // arrowPrefix decoder, so an arrow case would pass even without the fix.
       act(() => {
-        stdin.sendKittySequence(`\x1b[1;9A`);
+        stdin.sendKittySequence(`\x1b[1;9H`);
       });
 
       expect(keyHandler).toHaveBeenCalledWith(
-        expect.objectContaining({ name: 'up', meta: true }),
+        expect.objectContaining({ name: 'home', meta: true }),
       );
     });
 

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -42,6 +42,7 @@ import {
   MODIFIER_SHIFT_BIT,
   MODIFIER_ALT_BIT,
   MODIFIER_CTRL_BIT,
+  MODIFIER_SUPER_BIT,
 } from '../utils/platformConstants.js';
 import { clipboardHasImage } from '../utils/clipboardUtils.js';
 
@@ -439,7 +440,11 @@ export function KeypressProvider({
           mods -= KITTY_MODIFIER_EVENT_TYPES_OFFSET;
         }
         const bits = mods - KITTY_MODIFIER_BASE;
-        const alt = (bits & MODIFIER_ALT_BIT) === MODIFIER_ALT_BIT;
+        // Fold the Super (Command) bit into `alt` so it surfaces as `meta`,
+        // matching the CSI-u path.
+        const alt =
+          (bits & MODIFIER_ALT_BIT) === MODIFIER_ALT_BIT ||
+          (bits & MODIFIER_SUPER_BIT) === MODIFIER_SUPER_BIT;
         const ctrl = (bits & MODIFIER_CTRL_BIT) === MODIFIER_CTRL_BIT;
         return {
           key: {
@@ -468,7 +473,11 @@ export function KeypressProvider({
         }
         const bits = mods - KITTY_MODIFIER_BASE;
         const shift = (bits & MODIFIER_SHIFT_BIT) === MODIFIER_SHIFT_BIT;
-        const alt = (bits & MODIFIER_ALT_BIT) === MODIFIER_ALT_BIT;
+        // Fold the Super (Command) bit into `alt` so it surfaces as `meta`,
+        // matching the CSI-u path above.
+        const alt =
+          (bits & MODIFIER_ALT_BIT) === MODIFIER_ALT_BIT ||
+          (bits & MODIFIER_SUPER_BIT) === MODIFIER_SUPER_BIT;
         const ctrl = (bits & MODIFIER_CTRL_BIT) === MODIFIER_CTRL_BIT;
         const sym = m[2];
         const symbolToName: { [k: string]: string } = {
@@ -518,7 +527,15 @@ export function KeypressProvider({
         const modifierBits = modifiers - KITTY_MODIFIER_BASE;
         const shift =
           (modifierBits & MODIFIER_SHIFT_BIT) === MODIFIER_SHIFT_BIT;
-        const alt = (modifierBits & MODIFIER_ALT_BIT) === MODIFIER_ALT_BIT;
+        // The rest of the codebase models the macOS Command / Windows Super key
+        // as `meta` (see keyMatchers, where a binding's `command` maps to
+        // key.meta), so fold the Kitty Super bit into `alt` — which feeds the
+        // emitted `meta` flag — instead of dropping it. Otherwise a Super-only
+        // combo such as Cmd+C parses as a bare printable key and the character
+        // leaks into text input (the terminal performs the copy itself).
+        const alt =
+          (modifierBits & MODIFIER_ALT_BIT) === MODIFIER_ALT_BIT ||
+          (modifierBits & MODIFIER_SUPER_BIT) === MODIFIER_SUPER_BIT;
         const ctrl = (modifierBits & MODIFIER_CTRL_BIT) === MODIFIER_CTRL_BIT;
         const terminator = m[4];
 

--- a/packages/cli/src/ui/utils/platformConstants.ts
+++ b/packages/cli/src/ui/utils/platformConstants.ts
@@ -42,6 +42,7 @@ export const KITTY_MODIFIER_EVENT_TYPES_OFFSET = 128; // Added when event types 
  * - bit 0 (1): Shift
  * - bit 1 (2): Alt/Option (reported as "alt" in spec; we map to meta)
  * - bit 2 (4): Ctrl
+ * - bit 3 (8): Super (Windows key / macOS Command; we map to meta)
  *
  * Some terminals add 128 to the entire modifiers field when reporting event types.
  * See: https://sw.kovidgoyal.net/kitty/keyboard-protocol/#modifiers
@@ -49,6 +50,7 @@ export const KITTY_MODIFIER_EVENT_TYPES_OFFSET = 128; // Added when event types 
 export const MODIFIER_SHIFT_BIT = 1;
 export const MODIFIER_ALT_BIT = 2;
 export const MODIFIER_CTRL_BIT = 4;
+export const MODIFIER_SUPER_BIT = 8;
 
 /**
  * Timing constants for terminal interactions


### PR DESCRIPTION
## What this PR does

Terminals that speak the Kitty keyboard protocol report the macOS Command / Windows Super key as a dedicated modifier bit on every key they forward. The keyboard parser previously only understood the Shift, Alt, and Ctrl bits and silently ignored the Super bit, so a Super-only combination was decoded as if no modifier were held at all. This PR teaches the parser to recognize the Super bit and surface it through the same `meta` flag the rest of the UI already uses for the Command key, at every point where Kitty modifier parameters are decoded.

## Why it's needed

In Kitty-protocol terminals, pressing `Cmd+C` to copy selected text in the input box also forwarded the keypress to the app with the Super modifier bit set. Because that bit was dropped, the event collapsed into a plain printable `c` with no modifier, and the input handler inserted it — leaving a stray `c` in the input box on every copy (issue #7990). With the Super bit mapped to `meta`, the combination is now treated as a modified shortcut rather than literal text, so the character no longer leaks while the terminal still performs the copy.

## Reviewer Test Plan

### How to verify

The leak only reproduces in a Kitty-protocol terminal (ordinary terminals swallow `Cmd+C` and never forward it), so the authoritative check is at the parsing level. A regression test feeds the exact bytes such a terminal sends for `Cmd+C` (`ESC [ 99 ; 9 u`, keycode 99 = `c`, modifier 9 = base 1 + Super bit 8) and asserts the emitted key now carries `meta: true` instead of being a bare printable `c`. To confirm the test is load-bearing, stash the two source changes and re-run it: it fails with `meta: false` on the old code and passes with the fix restored. Also confirm `Ctrl+C` still decodes with `ctrl: true` (quit/clear behavior unchanged) and that the full keyboard, key-matching, and text-buffer suites stay green.

```
cd packages/cli
npx vitest run src/ui/contexts/KeypressContext.test.tsx
npx vitest run src/ui/keyMatchers.test.ts src/ui/hooks/useKeypress.test.ts src/ui/components/shared/text-buffer.test.ts
```

### Evidence (Before & After)

Parsing-level change; no TUI visual diff. Before: `ESC [ 99 ; 9 u` → `{ name: 'c', ctrl: false, meta: false }` (inserted as text). After: `{ name: 'c', ctrl: false, meta: true }` (not inserted). The new regression test fails before the fix and passes after.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only (`npx vitest`), plus `tsc --noEmit` and `eslint` on the changed files.

## Risk & Scope

- Main risk or tradeoff: Super-modified keys now arrive with `meta: true`, so any binding that explicitly requires `command: false` will no longer match when Command is held. This is the intended behavior and matches how the Command key is modeled elsewhere; no existing binding relied on Super being dropped.
- Not validated / out of scope: live reproduction in a real Kitty-protocol terminal (e.g. Ghostty/kitty) was not performed; verification is at the parsing level. The Hyper and Kitty "meta" bits (16/32) are intentionally left unmapped as they are out of scope for this bug.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #7990

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

支持 Kitty 键盘协议的终端在转发每个按键时，会把 macOS Command / Windows Super 键作为一个独立的修饰位上报。键盘解析器此前只识别 Shift、Alt、Ctrl 三个位，会静默忽略 Super 位，导致仅带 Super 的组合键被解析成完全没有修饰键。本 PR 让解析器在所有解码 Kitty 修饰参数的位置识别 Super 位，并通过 UI 其余部分已用于表示 Command 键的同一个 `meta` 标志暴露出来。

## 为什么需要

在 Kitty 协议终端中，于输入框按 `Cmd+C` 复制选中文本时，终端会把该按键连同 Super 修饰位一起转发给应用。由于该位被丢弃，事件坍缩成一个不带任何修饰的纯可打印字符 `c`，输入处理器便把它插了进去——每次复制都会在输入框留下一个多余的 `c`（issue #7990）。将 Super 位映射到 `meta` 后，该组合键现在被视为带修饰的快捷键而非字面文本，字符不再泄漏，同时终端仍会完成复制。

## 评审测试计划

### 如何验证

该泄漏只在 Kitty 协议终端中复现（普通终端会吞掉 `Cmd+C`，从不转发），因此权威验证在解析层。回归测试喂入此类终端为 `Cmd+C` 发送的精确字节（`ESC [ 99 ; 9 u`，keycode 99 = `c`，modifier 9 = 基数 1 + Super 位 8），断言发出的按键现在带 `meta: true`，而非裸的可打印 `c`。为证明该测试确实有效，可暂存两处源码改动后重跑：旧代码下以 `meta: false` 失败，恢复修复后通过。同时确认 `Ctrl+C` 仍解析为 `ctrl: true`（退出/清空行为不变），且完整的键盘、按键匹配、文本缓冲区测试套件保持绿色。

### 证据（前后对比）

解析层改动，无 TUI 视觉差异。修复前：`ESC [ 99 ; 9 u` → `{ name: 'c', ctrl: false, meta: false }`（被当作文本插入）；修复后：`{ name: 'c', ctrl: false, meta: true }`（不插入）。新增回归测试在修复前失败、修复后通过。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

仅单元测试（`npx vitest`），外加对改动文件运行 `tsc --noEmit` 与 `eslint`。

## 风险与范围

- 主要风险或权衡：带 Super 修饰的按键现在会以 `meta: true` 到达，因此任何显式要求 `command: false` 的绑定在按住 Command 时将不再匹配。这是预期行为，与代码库其余部分对 Command 键的建模一致；没有现有绑定依赖 Super 被丢弃。
- 未验证 / 超出范围：未在真实 Kitty 协议终端（如 Ghostty/kitty）中实际复现；验证在解析层完成。Hyper 位与 Kitty "meta" 位（16/32）有意不做映射，因为超出本 bug 范围。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #7990

</details>
