### PR TITLE
fix(web-shell): polish Channel pairing requests

### DIFF
--- a/packages/web-shell/client/components/channels/ChannelPairingRequests.test.tsx
+++ b/packages/web-shell/client/components/channels/ChannelPairingRequests.test.tsx
@@ -37,6 +37,7 @@ async function renderRequests({
   channelName = 'release-bot',
   list = vi.fn().mockResolvedValue(PENDING),
   approve = vi.fn(),
+  language = 'en',
 }: {
   channelName?: string;
   list?: (name: string) => Promise<DaemonChannelPairingRequestsSnapshot>;
@@ -44,10 +45,11 @@ async function renderRequests({
     name: string,
     code: string,
   ) => Promise<DaemonChannelPairingApprovalResult>;
+  language?: 'en' | 'zh-CN';
 } = {}) {
   await act(async () => {
     root.render(
-      <I18nProvider language="en">
+      <I18nProvider language={language}>
         <ChannelPairingRequests
           channelName={channelName}
           listRequests={list}
@@ -83,6 +85,15 @@ describe('ChannelPairingRequests', () => {
     expect(container.textContent).toContain('user-42');
     expect(container.textContent).toContain('ABCD1234');
     expect(container.textContent).toContain('5 min ago');
+    expect(container.textContent).toContain(
+      'Approvals take effect immediately; Save and Cancel do not undo them.',
+    );
+    const approve = Array.from(container.querySelectorAll('button')).find(
+      (item) => item.textContent?.trim() === 'Approve',
+    );
+    expect(approve?.getAttribute('aria-label')).toBe(
+      'Approve Ada, code ABCD1234',
+    );
   });
 
   it('approves a request and replaces the list with the daemon response', async () => {
@@ -121,6 +132,62 @@ describe('ChannelPairingRequests', () => {
     expect(container.textContent).toContain('ABCD1234');
   });
 
+  it('uses an actionable message when approval cannot reach the daemon', async () => {
+    const approve = vi
+      .fn()
+      .mockRejectedValue(
+        new Error(
+          'POST /workspaces/:workspace/channels/:name/pairing-requests/approve: HTTP 500',
+        ),
+      );
+    await renderRequests({ approve });
+
+    const button = Array.from(container.querySelectorAll('button')).find(
+      (item) => item.textContent?.trim() === 'Approve',
+    );
+    await act(async () => {
+      button?.click();
+    });
+
+    expect(container.textContent).toContain(
+      'Pairing requests are temporarily unavailable. Try again.',
+    );
+    expect(container.textContent).toContain('ABCD1234');
+  });
+
+  it('refreshes the list when an approval request has expired', async () => {
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce(PENDING)
+      .mockResolvedValueOnce({ requests: [] });
+    const error = Object.assign(
+      new Error(
+        'POST /workspaces/:workspace/channels/:name/pairing-requests/approve: Pairing request was not found or has expired.',
+      ),
+      {
+        body: {
+          error: 'Pairing request was not found or has expired.',
+          code: 'channel_pairing_request_not_found',
+        },
+      },
+    );
+    const approve = vi.fn().mockRejectedValue(error);
+    await renderRequests({ list, approve });
+
+    const button = Array.from(container.querySelectorAll('button')).find(
+      (item) => item.textContent?.trim() === 'Approve',
+    );
+    await act(async () => {
+      button?.click();
+    });
+
+    expect(list).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toContain(
+      'Pairing request was not found or has expired.',
+    );
+    expect(container.textContent).not.toContain('ABCD1234');
+  });
+
   it('retries after loading requests fails', async () => {
     const list = vi
       .fn()
@@ -138,6 +205,34 @@ describe('ChannelPairingRequests', () => {
 
     expect(list).toHaveBeenCalledTimes(2);
     expect(container.textContent).toContain('ABCD1234');
+  });
+
+  it('uses an actionable message for transport failures', async () => {
+    const list = vi
+      .fn()
+      .mockRejectedValue(
+        new Error(
+          'GET /workspaces/:workspace/channels/:name/pairing-requests: HTTP 500',
+        ),
+      );
+    await renderRequests({ list });
+
+    expect(container.textContent).toContain(
+      'Pairing requests are temporarily unavailable. Try again.',
+    );
+    expect(container.textContent).not.toContain(
+      'GET /workspaces/:workspace/channels/:name/pairing-requests',
+    );
+  });
+
+  it('uses consistent approval wording in Chinese', async () => {
+    await renderRequests({ language: 'zh-CN' });
+
+    expect(container.textContent).toContain(
+      '批准会立即生效，保存或取消都不会撤销已批准的访问。',
+    );
+    expect(container.textContent).toContain('批准');
+    expect(container.textContent).not.toContain('允许');
   });
 
   it('ignores an approval response after the selected Channel changes', async () => {

--- a/packages/web-shell/client/components/channels/ChannelPairingRequests.test.tsx
+++ b/packages/web-shell/client/components/channels/ChannelPairingRequests.test.tsx
@@ -118,7 +118,11 @@ describe('ChannelPairingRequests', () => {
   });
 
   it('keeps a request visible when approval fails', async () => {
-    const approve = vi.fn().mockRejectedValue(new Error('Approval failed.'));
+    const error = Object.assign(new Error('Approval failed.'), {
+      status: 409,
+      body: { error: 'Approval failed.' },
+    });
+    const approve = vi.fn().mockRejectedValue(error);
     await renderRequests({ approve });
 
     const button = Array.from(container.querySelectorAll('button')).find(
@@ -132,14 +136,30 @@ describe('ChannelPairingRequests', () => {
     expect(container.textContent).toContain('ABCD1234');
   });
 
-  it('uses an actionable message when approval cannot reach the daemon', async () => {
-    const approve = vi
-      .fn()
-      .mockRejectedValue(
-        new Error(
-          'POST /workspaces/:workspace/channels/:name/pairing-requests/approve: HTTP 500',
-        ),
+  it.each([
+    new TypeError('Failed to fetch'),
+    new DOMException('timeout', 'TimeoutError'),
+  ])(
+    'uses an actionable message when the daemon does not respond',
+    async (error) => {
+      const list = vi.fn().mockRejectedValue(error);
+      await renderRequests({ list });
+
+      expect(container.textContent).toContain(
+        'Pairing requests are temporarily unavailable. Try again.',
       );
+      expect(container.textContent).not.toContain(error.message);
+    },
+  );
+
+  it('uses an actionable message when approval cannot reach the daemon', async () => {
+    const error = Object.assign(
+      new Error(
+        'POST /workspaces/:workspace/channels/:name/pairing-requests/approve: HTTP 500',
+      ),
+      { status: 500, body: undefined },
+    );
+    const approve = vi.fn().mockRejectedValue(error);
     await renderRequests({ approve });
 
     const button = Array.from(container.querySelectorAll('button')).find(
@@ -155,6 +175,33 @@ describe('ChannelPairingRequests', () => {
     expect(container.textContent).toContain('ABCD1234');
   });
 
+  it('uses an actionable message for malformed daemon errors', async () => {
+    const error = Object.assign(
+      new Error(
+        'POST /workspaces/:workspace/channels/:name/pairing-requests/approve: [object Object]',
+      ),
+      {
+        status: 502,
+        body: { error: { message: 'Bad gateway' } },
+      },
+    );
+    const approve = vi.fn().mockRejectedValue(error);
+    await renderRequests({ approve });
+
+    const button = Array.from(container.querySelectorAll('button')).find(
+      (item) => item.textContent?.trim() === 'Approve',
+    );
+    await act(async () => {
+      button?.click();
+    });
+
+    expect(container.textContent).toContain(
+      'Pairing requests are temporarily unavailable. Try again.',
+    );
+    expect(container.textContent).not.toContain(':workspace');
+    expect(container.textContent).toContain('ABCD1234');
+  });
+
   it('refreshes the list when an approval request has expired', async () => {
     const list = vi
       .fn()
@@ -165,6 +212,7 @@ describe('ChannelPairingRequests', () => {
         'POST /workspaces/:workspace/channels/:name/pairing-requests/approve: Pairing request was not found or has expired.',
       ),
       {
+        status: 404,
         body: {
           error: 'Pairing request was not found or has expired.',
           code: 'channel_pairing_request_not_found',
@@ -189,9 +237,13 @@ describe('ChannelPairingRequests', () => {
   });
 
   it('retries after loading requests fails', async () => {
+    const error = Object.assign(new Error('Pairing list unavailable.'), {
+      status: 503,
+      body: { error: 'Pairing list unavailable.' },
+    });
     const list = vi
       .fn()
-      .mockRejectedValueOnce(new Error('Pairing list unavailable.'))
+      .mockRejectedValueOnce(error)
       .mockResolvedValueOnce(PENDING);
     await renderRequests({ list });
 
@@ -208,13 +260,13 @@ describe('ChannelPairingRequests', () => {
   });
 
   it('uses an actionable message for transport failures', async () => {
-    const list = vi
-      .fn()
-      .mockRejectedValue(
-        new Error(
-          'GET /workspaces/:workspace/channels/:name/pairing-requests: HTTP 500',
-        ),
-      );
+    const error = Object.assign(
+      new Error(
+        'GET /workspaces/:workspace/channels/:name/pairing-requests: HTTP 500',
+      ),
+      { status: 500, body: undefined },
+    );
+    const list = vi.fn().mockRejectedValue(error);
     await renderRequests({ list });
 
     expect(container.textContent).toContain(

--- a/packages/web-shell/client/components/channels/ChannelPairingRequests.tsx
+++ b/packages/web-shell/client/components/channels/ChannelPairingRequests.tsx
@@ -38,6 +38,19 @@ function senderLabel(request: DaemonChannelPairingRequest): string {
   return request.senderName.trim() || request.senderId;
 }
 
+function errorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+  const body = (error as { body?: unknown }).body;
+  if (!body || typeof body !== 'object') return undefined;
+  const code = (body as { code?: unknown }).code;
+  return typeof code === 'string' ? code : undefined;
+}
+
+function pairingErrorDetail(error: unknown, unavailable: string): string {
+  const detail = extractErrorDetail(error);
+  return /^(?:GET|POST) \/\S+: HTTP \d{3}$/.test(detail) ? unavailable : detail;
+}
+
 export function ChannelPairingRequests({
   channelName,
   listRequests,
@@ -77,14 +90,19 @@ export function ChannelPairingRequests({
       },
       (loadError: unknown) => {
         if (!active) return;
-        setError(extractErrorDetail(loadError));
+        setError(
+          pairingErrorDetail(
+            loadError,
+            t('channels.editor.pairing.unavailable'),
+          ),
+        );
         setLoading(false);
       },
     );
     return () => {
       active = false;
     };
-  }, [channelName, listRequests, reloadToken]);
+  }, [channelName, listRequests, reloadToken, t]);
 
   const approve = async (request: DaemonChannelPairingRequest) => {
     if (approvingCode) return;
@@ -107,7 +125,39 @@ export function ChannelPairingRequests({
       if (!mounted.current || currentChannelName.current !== approvalChannel) {
         return;
       }
-      setError(extractErrorDetail(approvalError));
+      if (errorCode(approvalError) === 'channel_pairing_request_not_found') {
+        try {
+          const snapshot = await listRequests(approvalChannel);
+          if (
+            mounted.current &&
+            currentChannelName.current === approvalChannel
+          ) {
+            setRequests(snapshot.requests);
+          }
+        } catch (refreshError) {
+          if (
+            mounted.current &&
+            currentChannelName.current === approvalChannel
+          ) {
+            setError(
+              pairingErrorDetail(
+                refreshError,
+                t('channels.editor.pairing.unavailable'),
+              ),
+            );
+          }
+          return;
+        }
+      }
+      if (!mounted.current || currentChannelName.current !== approvalChannel) {
+        return;
+      }
+      setError(
+        pairingErrorDetail(
+          approvalError,
+          t('channels.editor.pairing.unavailable'),
+        ),
+      );
     } finally {
       if (mounted.current && currentChannelName.current === approvalChannel) {
         setApprovingCode(undefined);
@@ -206,6 +256,10 @@ export function ChannelPairingRequests({
                   type="button"
                   size="sm"
                   disabled={Boolean(approvingCode)}
+                  aria-label={t('channels.editor.pairing.approveFor', {
+                    sender: label,
+                    code: request.code,
+                  })}
                   onClick={() => void approve(request)}
                 >
                   {approvingCode === request.code ? <Spinner /> : null}

--- a/packages/web-shell/client/components/channels/ChannelPairingRequests.tsx
+++ b/packages/web-shell/client/components/channels/ChannelPairingRequests.tsx
@@ -17,7 +17,6 @@ import type {
   DaemonChannelPairingRequestsSnapshot,
 } from '@qwen-code/sdk/daemon';
 import { useI18n } from '../../i18n';
-import { extractErrorDetail } from '../../utils/errorDetail';
 import { formatRelativeTime } from '../../utils/formatRelativeTime';
 import { Alert, AlertDescription, AlertTitle } from '../ui/alert';
 import { Badge } from '../ui/badge';
@@ -47,8 +46,15 @@ function errorCode(error: unknown): string | undefined {
 }
 
 function pairingErrorDetail(error: unknown, unavailable: string): string {
-  const detail = extractErrorDetail(error);
-  return /^(?:GET|POST) \/\S+: HTTP \d{3}$/.test(detail) ? unavailable : detail;
+  if (!error || typeof error !== 'object' || !('status' in error)) {
+    return unavailable;
+  }
+  const body = (error as { body?: unknown }).body;
+  const message =
+    body && typeof body === 'object'
+      ? (body as { error?: unknown }).error
+      : undefined;
+  return typeof message === 'string' && message ? message : unavailable;
 }
 
 export function ChannelPairingRequests({

--- a/packages/web-shell/client/e2e/web-shell.channels.spec.ts
+++ b/packages/web-shell/client/e2e/web-shell.channels.spec.ts
@@ -135,7 +135,9 @@ test('creates and deletes a typed Channel configuration', async ({
   ).toBeVisible();
   await expect(page.getByText('Ada', { exact: true })).toBeVisible();
   await expect(page.getByText('ABCD1234', { exact: true })).toBeVisible();
-  await page.getByRole('button', { name: 'Approve' }).click();
+  await page
+    .getByRole('button', { name: 'Approve Ada, code ABCD1234' })
+    .click();
   await expect(page.getByText('No pending requests')).toBeVisible();
   await expect
     .poll(() =>

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -2390,12 +2390,16 @@ const EN: Messages = {
     'People receive a pairing code and can chat after you approve them.',
   'channels.editor.pairing.title': 'Pending requests',
   'channels.editor.pairing.description':
-    'Match the code shared by the person before approving access.',
+    'Match the code shared by the person before approving access. Approvals take effect immediately; Save and Cancel do not undo them.',
   'channels.editor.pairing.refresh': 'Refresh pairing requests',
   'channels.editor.pairing.approve': 'Approve',
+  'channels.editor.pairing.approveFor': (v) =>
+    `Approve ${v?.sender ?? 'request'}, code ${v?.code ?? ''}`,
   'channels.editor.pairing.approved': (v) =>
     `${v?.sender ?? 'This person'} can now use this Channel.`,
   'channels.editor.pairing.error': 'Pairing requests were not updated',
+  'channels.editor.pairing.unavailable':
+    'Pairing requests are temporarily unavailable. Try again.',
   'channels.editor.pairing.retry': 'Try again',
   'channels.editor.pairing.empty.title': 'No pending requests',
   'channels.editor.pairing.empty.description':
@@ -4755,12 +4759,15 @@ const ZH: Messages = {
     '用户会收到配对码，经您批准后才能开始对话。',
   'channels.editor.pairing.title': '待处理的配对请求',
   'channels.editor.pairing.description':
-    '批准前，请核对用户提供的配对码是否一致。',
+    '批准前，请核对用户提供的配对码是否一致。批准会立即生效，保存或取消都不会撤销已批准的访问。',
   'channels.editor.pairing.refresh': '刷新配对请求',
-  'channels.editor.pairing.approve': '允许',
+  'channels.editor.pairing.approve': '批准',
+  'channels.editor.pairing.approveFor': (v) =>
+    `批准${v?.sender ?? '该请求'}，配对码 ${v?.code ?? ''}`,
   'channels.editor.pairing.approved': (v) =>
     `${v?.sender ?? '该用户'}现在可以使用此频道。`,
   'channels.editor.pairing.error': '未能更新配对请求',
+  'channels.editor.pairing.unavailable': '暂时无法获取配对请求，请重试。',
   'channels.editor.pairing.retry': '重试',
   'channels.editor.pairing.empty.title': '暂无待处理请求',
   'channels.editor.pairing.empty.description':


### PR DESCRIPTION
## What this PR does

Polishes the workspace-scoped Channel pairing request panel that landed in #7909. The panel now explains that approvals take effect immediately and are not undone by Save or Cancel, uses sender-specific accessible names for approval actions, and uses consistent approval wording in Chinese.

When an approval code has already expired or was consumed elsewhere, the panel refreshes the daemon-backed pending list so the stale row disappears. Transport-style route and HTTP errors are replaced with a localized retry message, while structured daemon errors remain visible.

## Why it's needed

Pairing approval is an immediate access grant, but the surrounding editor footer made it easy to assume Cancel could undo it. Expired codes also left a permanently failing row until the operator manually refreshed, and daemon outages exposed an internal route template instead of a useful recovery message. These follow-ups make the existing pairing loop clearer, self-healing, and usable with assistive technology without adding a new daemon contract.

## Reviewer Test Plan

### How to verify

1. Open a saved DingTalk, WeCom, or Feishu Channel in Pairing mode and confirm the panel states that approval takes effect immediately and cannot be undone by Save or Cancel.
2. With more than one pending request, inspect the approval controls and confirm each accessible name includes the sender and pairing code.
3. Consume or expire a pending code outside the editor, then try to approve its stale row. Confirm the panel reloads the current pending list, removes the stale row, and reports that the request was not found or expired.
4. Make the pairing list or approval request return an unstructured route/HTTP failure. Confirm the panel shows a localized temporary-unavailability message and retains a retry path instead of exposing the route template.
5. Approve a valid request and confirm the row disappears and the sender can immediately use the Channel.

### Evidence (Before & After)

Before: approval actions had the same accessible name, the copy did not explain immediate persistence, stale 404 rows remained, and transport failures exposed route text.

After:

| Light | Dark |
| --- | --- |
| ![Light Channel pairing editor](https://raw.githubusercontent.com/qqqys/qwen-code/assets-issue-7209-pairing-polish/.github/pr-assets/issue-7209/pairing-polish-light.png) | ![Dark Channel pairing editor](https://raw.githubusercontent.com/qqqys/qwen-code/assets-issue-7209-pairing-polish/.github/pr-assets/issue-7209/pairing-polish-dark.png) |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 25.9.0, Web Shell Vite development server, and Playwright Chromium.

## Risk & Scope

- Main risk or tradeoff: The self-healing refresh is limited to the daemon's explicit pairing-request-not-found code; other approval failures keep the request visible for retry.
- Not validated / out of scope: Rejecting or revoking access, QR-based application registration, daemon API changes, and enabling Channel types beyond DingTalk, WeCom, and Feishu.
- Breaking changes / migration notes: None.

## Linked Issues

Part of #7209. Follows #7909.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

完善 #7909 合入的工作区级频道配对请求面板。面板现在会明确说明批准会立即生效，且不会因保存或取消而撤销；每个批准操作都有包含用户和配对码的独立无障碍名称；中文操作文案也统一使用“批准”。

当配对码已经过期或在其他位置被处理时，面板会重新读取 daemon 中当前的待处理列表，让失效行自动消失。路由和 HTTP 状态组成的底层传输错误会替换为本地化的重试提示，而 daemon 返回的结构化业务错误仍会正常展示。

## 为什么需要

配对批准是立即生效的访问授权，但编辑器底部的保存和取消容易让人误以为取消可以撤销批准。失效配对码此前也会一直残留并重复失败，直到管理员手动刷新；daemon 不可用时还会暴露内部路由模板，而不是提供可操作的恢复提示。本阶段在不新增 daemon 契约的前提下，让现有配对闭环更清晰、可自愈，并支持辅助技术。

## Reviewer 测试计划

### 如何验证

1. 打开一个已保存且使用配对模式的钉钉、企业微信或飞书频道，确认面板说明批准会立即生效，并且保存或取消都不会撤销批准。
2. 准备多个待处理请求，检查批准控件，确认每个无障碍名称都包含对应用户和配对码。
3. 在编辑器外消费或使某个配对码过期，再批准界面中的失效行。确认面板重新加载当前列表、移除失效行，并提示请求不存在或已过期。
4. 让配对列表或批准请求返回未结构化的路由/HTTP 错误。确认面板显示本地化的暂时不可用提示和重试入口，而不暴露路由模板。
5. 批准有效请求，确认请求行消失，并且该用户立即可以使用频道。

### 证据（修改前后）

修改前：批准操作的无障碍名称完全相同，文案没有说明授权立即持久生效，404 失效行会残留，传输失败会暴露路由文本。

修改后：

| 浅色 | 深色 |
| --- | --- |
| ![浅色频道配对编辑器](https://raw.githubusercontent.com/qqqys/qwen-code/assets-issue-7209-pairing-polish/.github/pr-assets/issue-7209/pairing-polish-light.png) | ![深色频道配对编辑器](https://raw.githubusercontent.com/qqqys/qwen-code/assets-issue-7209-pairing-polish/.github/pr-assets/issue-7209/pairing-polish-dark.png) |

### 测试平台

|     系统     | 状态 |
| :----------: | :--: |
|  🍏 macOS    |  ✅  |
| 🪟 Windows   |  ⚠️  |
|  🐧 Linux    |  ⚠️  |

### 环境（可选）

Node.js 25.9.0、Web Shell Vite 开发服务器和 Playwright Chromium。

## 风险与范围

- 主要风险或取舍：自动刷新只针对 daemon 明确返回的“配对请求不存在”错误；其他批准失败仍会保留请求行，供管理员重试。
- 未验证 / 不在范围内：拒绝或撤销授权、扫码创建平台应用、daemon API 变更，以及开放钉钉、企业微信、飞书之外的频道类型。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

属于 #7209 的一部分，承接 #7909。

</details>
