### PR TITLE
fix(cli): correct hardware cursor off-by-one in fullscreen mode

### DIFF
--- a/packages/cli/src/ui/ink-cursor-rendering.test.tsx
+++ b/packages/cli/src/ui/ink-cursor-rendering.test.tsx
@@ -215,7 +215,46 @@ describe.each([false, true])(
 
       expect(cursorRenderCount).toBe(1);
       expect(capture.read()).toContain(ansiEscapes.clearTerminal);
-      expect(capture.read()).toContain(expectedCursorSuffix(3));
+      // Fullscreen mode (output >= terminal rows) omits the trailing newline,
+      // so the cursor starts one line higher: moveUp = visibleLines - 1 - y.
+      expect(capture.read()).toContain(expectedCursorSuffix(2));
+      await unmount(app);
+    });
+
+    it('positions the hardware cursor at the correct row in fullscreen (y > 0)', async () => {
+      // Regression test for QwenLM/qwen-code#7980: in fullscreen mode the
+      // output has no trailing newline, so the terminal cursor sits ON the
+      // last line rather than one past it. buildCursorSuffix must account
+      // for this, otherwise the hardware cursor lands one row too high.
+      const capture = createTestStdout(3);
+
+      function CursorOwner() {
+        // y=1 — the second row of the 3-line output. With the old bug the
+        // escape sequence would move the cursor to y=0 instead.
+        useCursor().setCursorPosition({ x: 2, y: 1 });
+        return <Text>input</Text>;
+      }
+
+      const app = await mount(
+        <Box flexDirection="column">
+          <CursorOwner />
+          <Text>{'mid\nbottom'}</Text>
+        </Box>,
+        capture.stdout,
+        incrementalRendering,
+      );
+
+      // 3 visible lines, fullscreen (3 >= 3 rows), no trailing \n.
+      // Terminal cursor after write: line 2. Target: y=1.
+      // Correct moveUp = 2 - 1 = 1.
+      const output = capture.read();
+      expect(output).toContain(
+        ansiEscapes.cursorUp(1) + ansiEscapes.cursorTo(2) + SHOW_CURSOR,
+      );
+      // The buggy value would have been cursorUp(2) — verify it's absent.
+      expect(output).not.toContain(
+        ansiEscapes.cursorUp(2) + ansiEscapes.cursorTo(2) + SHOW_CURSOR,
+      );
       await unmount(app);
     });
 

--- a/packages/cli/src/ui/ink-cursor-rendering.test.tsx
+++ b/packages/cli/src/ui/ink-cursor-rendering.test.tsx
@@ -285,6 +285,41 @@ describe.each([false, true])(
       await unmount(app);
     });
 
+    it('preserves cursor-only position updates in fullscreen', async () => {
+      const capture = createTestStdout(2);
+      let moveCursor!: () => void;
+
+      function CursorOwner() {
+        const [x, setX] = useState(2);
+        moveCursor = () => setX(4);
+        useCursor().setCursorPosition({ x, y: 0 });
+        return <Text>input</Text>;
+      }
+
+      const app = await mount(
+        <Box flexDirection="column">
+          <CursorOwner />
+          <Text>footer</Text>
+        </Box>,
+        capture.stdout,
+        incrementalRendering,
+      );
+      capture.reset();
+
+      await updateAndFlush(app, moveCursor);
+
+      // Fullscreen (2 lines >= 2 rows): no trailing newline, so
+      // moveUp = (visibleLines - 1) - y = 1, not visibleLines - y = 2.
+      const output = capture.read();
+      expect(output).toContain(
+        ansiEscapes.cursorUp(1) + ansiEscapes.cursorTo(4) + SHOW_CURSOR,
+      );
+      expect(output).not.toContain(
+        ansiEscapes.cursorUp(2) + ansiEscapes.cursorTo(4) + SHOW_CURSOR,
+      );
+      await unmount(app);
+    });
+
     it('reasserts the latest committed cursor after a later sibling update', async () => {
       const capture = createTestStdout();
       let moveCursor!: () => void;

--- a/patches/ink+7.0.3.patch
+++ b/patches/ink+7.0.3.patch
@@ -39,6 +39,32 @@ index 2e4b9ff..77ed0f6 100644
  }
  //# sourceMappingURL=Text.js.map
 \ No newline at end of file
+diff --git a/node_modules/ink/build/cursor-helpers.d.ts b/node_modules/ink/build/cursor-helpers.d.ts
+index c6e9466..6dd4c0f 100644
+--- a/node_modules/ink/build/cursor-helpers.d.ts
++++ b/node_modules/ink/build/cursor-helpers.d.ts
+@@ -11,9 +11,11 @@
+ export declare const cursorPositionChanged: (a: CursorPosition | undefined, b: CursorPosition | undefined) => boolean;
+ /**
+ Build escape sequence to move cursor from bottom of output to the target position and show it.
+-Assumes cursor is at (col 0, line visibleLineCount) — i.e. just after the last output line.
++When hasTrailingNewline is true the terminal cursor sits at (col 0, line visibleLineCount)
++— i.e. just after the last output line. When false (fullscreen mode) it sits at the END
++of the last visible line (line visibleLineCount - 1), so one fewer cursorUp is needed.
+ */
+-export declare const buildCursorSuffix: (visibleLineCount: number, cursorPosition: CursorPosition | undefined) => string;
++export declare const buildCursorSuffix: (visibleLineCount: number, cursorPosition: CursorPosition | undefined, hasTrailingNewline?: boolean) => string;
+ /**
+ Build escape sequence to move cursor from previousCursorPosition back to the bottom of output.
+ This must be done before eraseLines or any operation that assumes cursor is at the bottom.
+@@ -25,6 +27,7 @@
+     previousCursorPosition: CursorPosition | undefined;
+     visibleLineCount: number;
+     cursorPosition: CursorPosition | undefined;
++    hasTrailingNewline?: boolean;
+ };
+ /**
+ Build the escape sequence for cursor-only updates (output unchanged, cursor moved).
 diff --git a/node_modules/ink/build/cursor-helpers.js b/node_modules/ink/build/cursor-helpers.js
 index be49354..14215f0 100644
 --- a/node_modules/ink/build/cursor-helpers.js

--- a/patches/ink+7.0.3.patch
+++ b/patches/ink+7.0.3.patch
@@ -39,6 +39,75 @@ index 2e4b9ff..77ed0f6 100644
  }
  //# sourceMappingURL=Text.js.map
 \ No newline at end of file
+diff --git a/node_modules/ink/build/cursor-helpers.js b/node_modules/ink/build/cursor-helpers.js
+index be49354..2b2ca8c 100644
+--- a/node_modules/ink/build/cursor-helpers.js
++++ b/node_modules/ink/build/cursor-helpers.js
+@@ -8,13 +8,15 @@ Compare two cursor positions. Returns true if they differ.
+ export const cursorPositionChanged = (a, b) => a?.x !== b?.x || a?.y !== b?.y;
+ /**
+ Build escape sequence to move cursor from bottom of output to the target position and show it.
+-Assumes cursor is at (col 0, line visibleLineCount) — i.e. just after the last output line.
++When hasTrailingNewline is true the terminal cursor sits at (col 0, line visibleLineCount)
++— i.e. just after the last output line. When false (fullscreen mode) it sits at the END
++of the last visible line (line visibleLineCount - 1), so one fewer cursorUp is needed.
+ */
+-export const buildCursorSuffix = (visibleLineCount, cursorPosition) => {
++export const buildCursorSuffix = (visibleLineCount, cursorPosition, hasTrailingNewline = true) => {
+     if (!cursorPosition) {
+         return '';
+     }
+-    const moveUp = visibleLineCount - cursorPosition.y;
++    const moveUp = (hasTrailingNewline ? visibleLineCount : visibleLineCount - 1) - cursorPosition.y;
+     return ((moveUp > 0 ? ansiEscapes.cursorUp(moveUp) : '') +
+         ansiEscapes.cursorTo(cursorPosition.x) +
+         showCursorEscape);
+@@ -22,14 +24,16 @@ export const buildCursorSuffix = (visibleLineCount, cursorPosition) => {
+ /**
+ Build escape sequence to move cursor from previousCursorPosition back to the bottom of output.
+ This must be done before eraseLines or any operation that assumes cursor is at the bottom.
++When hasTrailingNewline is true the cursor sits one line past the last visible line;
++when false (fullscreen) it sits ON the last visible line, so one fewer cursorDown is needed.
+ */
+-export const buildReturnToBottom = (previousLineCount, previousCursorPosition) => {
++export const buildReturnToBottom = (previousLineCount, previousCursorPosition, hasTrailingNewline = true) => {
+     if (!previousCursorPosition) {
+         return '';
+     }
+-    // PreviousLineCount includes trailing newline, so visible lines = previousLineCount - 1
+-    // cursor is at previousCursorPosition.y, need to go to line (previousLineCount - 1)
+-    const down = previousLineCount - 1 - previousCursorPosition.y;
++    const lastLine = previousLineCount - 1;
++    const cursorBase = hasTrailingNewline ? lastLine : lastLine - 1;
++    const down = cursorBase - previousCursorPosition.y;
+     return ((down > 0 ? ansiEscapes.cursorDown(down) : '') + ansiEscapes.cursorTo(0));
+ };
+ /**
+@@ -38,19 +42,19 @@ Hides cursor if it was previously shown, returns to bottom, then repositions.
+ */
+ export const buildCursorOnlySequence = (input) => {
+     const hidePrefix = input.cursorWasShown ? hideCursorEscape : '';
+-    const returnToBottom = buildReturnToBottom(input.previousLineCount, input.previousCursorPosition);
+-    const cursorSuffix = buildCursorSuffix(input.visibleLineCount, input.cursorPosition);
++    const returnToBottom = buildReturnToBottom(input.previousLineCount, input.previousCursorPosition, input.hasTrailingNewline);
++    const cursorSuffix = buildCursorSuffix(input.visibleLineCount, input.cursorPosition, input.hasTrailingNewline);
+     return hidePrefix + returnToBottom + cursorSuffix;
+ };
+ /**
+ Build the prefix that hides cursor and returns to bottom before erasing or rewriting.
+ Returns empty string if cursor was not shown.
+ */
+-export const buildReturnToBottomPrefix = (cursorWasShown, previousLineCount, previousCursorPosition) => {
++export const buildReturnToBottomPrefix = (cursorWasShown, previousLineCount, previousCursorPosition, hasTrailingNewline = true) => {
+     if (!cursorWasShown) {
+         return '';
+     }
+     return (hideCursorEscape +
+-        buildReturnToBottom(previousLineCount, previousCursorPosition));
++        buildReturnToBottom(previousLineCount, previousCursorPosition, hasTrailingNewline));
+ };
+ //# sourceMappingURL=cursor-helpers.js.map
+\ No newline at end of file
 diff --git a/node_modules/ink/build/frame-controller.d.ts b/node_modules/ink/build/frame-controller.d.ts
 new file mode 100644
 index 0000000..c294036
@@ -220,6 +289,181 @@ index ef659f3..767d861 100644
          const hasStaticOutput = staticOutput !== '';
          const isTty = this.options.stdout.isTTY;
          // Detect fullscreen: output fills or exceeds terminal height.
+diff --git a/node_modules/ink/build/log-update.js b/node_modules/ink/build/log-update.js
+index cdb5fc4..b626cde 100644
+--- a/node_modules/ink/build/log-update.js
++++ b/node_modules/ink/build/log-update.js
+@@ -12,6 +12,7 @@ const createStandard = (stream, { showCursor = false } = {}) => {
+     let cursorDirty = false;
+     let previousCursorPosition;
+     let cursorWasShown = false;
++    let previousHasTrailingNewline = true;
+     const getActiveCursor = () => (cursorDirty ? cursorPosition : undefined);
+     const hasChanges = (str, activeCursor) => {
+         const cursorChanged = cursorPositionChanged(activeCursor, previousCursorPosition);
+@@ -32,7 +33,8 @@ const createStandard = (stream, { showCursor = false } = {}) => {
+         }
+         const lines = str.split('\n');
+         const visibleCount = visibleLineCount(lines, str);
+-        const cursorSuffix = buildCursorSuffix(visibleCount, activeCursor);
++        const hasTrailingNewline = str.endsWith('\n');
++        const cursorSuffix = buildCursorSuffix(visibleCount, activeCursor, hasTrailingNewline);
+         if (str === previousOutput && cursorChanged) {
+             stream.write(buildCursorOnlySequence({
+                 cursorWasShown,
+@@ -40,34 +42,38 @@ const createStandard = (stream, { showCursor = false } = {}) => {
+                 previousCursorPosition,
+                 visibleLineCount: visibleCount,
+                 cursorPosition: activeCursor,
++                hasTrailingNewline: previousHasTrailingNewline,
+             }));
+         }
+         else {
+             previousOutput = str;
+-            const returnPrefix = buildReturnToBottomPrefix(cursorWasShown, previousLineCount, previousCursorPosition);
++            const returnPrefix = buildReturnToBottomPrefix(cursorWasShown, previousLineCount, previousCursorPosition, previousHasTrailingNewline);
+             stream.write(returnPrefix +
+                 ansiEscapes.eraseLines(previousLineCount) +
+                 str +
+                 cursorSuffix);
+             previousLineCount = lines.length;
++            previousHasTrailingNewline = hasTrailingNewline;
+         }
+         previousCursorPosition = activeCursor ? { ...activeCursor } : undefined;
+         cursorWasShown = activeCursor !== undefined;
+         return true;
+     };
+     render.clear = () => {
+-        const prefix = buildReturnToBottomPrefix(cursorWasShown, previousLineCount, previousCursorPosition);
++        const prefix = buildReturnToBottomPrefix(cursorWasShown, previousLineCount, previousCursorPosition, previousHasTrailingNewline);
+         stream.write(prefix + ansiEscapes.eraseLines(previousLineCount));
+         previousOutput = '';
+         previousLineCount = 0;
+         previousCursorPosition = undefined;
+         cursorWasShown = false;
++        previousHasTrailingNewline = true;
+     };
+     render.done = () => {
+         previousOutput = '';
+         previousLineCount = 0;
+         previousCursorPosition = undefined;
+         cursorWasShown = false;
++        previousHasTrailingNewline = true;
+         if (!showCursor) {
+             cliCursor.show(stream);
+             hasHiddenCursor = false;
+@@ -78,6 +84,7 @@ const createStandard = (stream, { showCursor = false } = {}) => {
+         previousLineCount = 0;
+         previousCursorPosition = undefined;
+         cursorWasShown = false;
++        previousHasTrailingNewline = true;
+     };
+     render.sync = (str) => {
+         const activeCursor = cursorDirty ? cursorPosition : undefined;
+@@ -85,11 +92,12 @@ const createStandard = (stream, { showCursor = false } = {}) => {
+         const lines = str.split('\n');
+         previousOutput = str;
+         previousLineCount = lines.length;
++        previousHasTrailingNewline = str.endsWith('\n');
+         if (!activeCursor && cursorWasShown) {
+             stream.write(hideCursorEscape);
+         }
+         if (activeCursor) {
+-            stream.write(buildCursorSuffix(visibleLineCount(lines, str), activeCursor));
++            stream.write(buildCursorSuffix(visibleLineCount(lines, str), activeCursor, previousHasTrailingNewline));
+         }
+         previousCursorPosition = activeCursor ? { ...activeCursor } : undefined;
+         cursorWasShown = activeCursor !== undefined;
+@@ -110,6 +118,7 @@ const createIncremental = (stream, { showCursor = false } = {}) => {
+     let cursorDirty = false;
+     let previousCursorPosition;
+     let cursorWasShown = false;
++    let previousHasTrailingNewline = true;
+     const getActiveCursor = () => (cursorDirty ? cursorPosition : undefined);
+     const hasChanges = (str, activeCursor) => {
+         const cursorChanged = cursorPositionChanged(activeCursor, previousCursorPosition);
+@@ -138,14 +147,15 @@ const createIncremental = (stream, { showCursor = false } = {}) => {
+                 previousCursorPosition,
+                 visibleLineCount: visibleCount,
+                 cursorPosition: activeCursor,
++                hasTrailingNewline: previousHasTrailingNewline,
+             }));
+             previousCursorPosition = activeCursor ? { ...activeCursor } : undefined;
+             cursorWasShown = activeCursor !== undefined;
+             return true;
+         }
+-        const returnPrefix = buildReturnToBottomPrefix(cursorWasShown, previousLines.length, previousCursorPosition);
++        const returnPrefix = buildReturnToBottomPrefix(cursorWasShown, previousLines.length, previousCursorPosition, previousHasTrailingNewline);
+         if (str === '\n' || previousOutput.length === 0) {
+-            const cursorSuffix = buildCursorSuffix(visibleCount, activeCursor);
++            const cursorSuffix = buildCursorSuffix(visibleCount, activeCursor, str.endsWith('\n'));
+             stream.write(returnPrefix +
+                 ansiEscapes.eraseLines(previousLines.length) +
+                 str +
+@@ -154,6 +164,7 @@ const createIncremental = (stream, { showCursor = false } = {}) => {
+             previousCursorPosition = activeCursor ? { ...activeCursor } : undefined;
+             previousOutput = str;
+             previousLines = nextLines;
++            previousHasTrailingNewline = str.endsWith('\n');
+             return true;
+         }
+         const hasTrailingNewline = str.endsWith('\n');
+@@ -187,28 +198,31 @@ const createIncremental = (stream, { showCursor = false } = {}) => {
+                 // has no trailing newline (fullscreen mode).
+                 (isLastLine && !hasTrailingNewline ? '' : '\n'));
+         }
+-        const cursorSuffix = buildCursorSuffix(visibleCount, activeCursor);
++        const cursorSuffix = buildCursorSuffix(visibleCount, activeCursor, hasTrailingNewline);
+         buffer.push(cursorSuffix);
+         stream.write(buffer.join(''));
+         cursorWasShown = activeCursor !== undefined;
+         previousCursorPosition = activeCursor ? { ...activeCursor } : undefined;
+         previousOutput = str;
+         previousLines = nextLines;
++        previousHasTrailingNewline = hasTrailingNewline;
+         return true;
+     };
+     render.clear = () => {
+-        const prefix = buildReturnToBottomPrefix(cursorWasShown, previousLines.length, previousCursorPosition);
++        const prefix = buildReturnToBottomPrefix(cursorWasShown, previousLines.length, previousCursorPosition, previousHasTrailingNewline);
+         stream.write(prefix + ansiEscapes.eraseLines(previousLines.length));
+         previousOutput = '';
+         previousLines = [];
+         previousCursorPosition = undefined;
+         cursorWasShown = false;
++        previousHasTrailingNewline = true;
+     };
+     render.done = () => {
+         previousOutput = '';
+         previousLines = [];
+         previousCursorPosition = undefined;
+         cursorWasShown = false;
++        previousHasTrailingNewline = true;
+         if (!showCursor) {
+             cliCursor.show(stream);
+             hasHiddenCursor = false;
+@@ -219,6 +233,7 @@ const createIncremental = (stream, { showCursor = false } = {}) => {
+         previousLines = [];
+         previousCursorPosition = undefined;
+         cursorWasShown = false;
++        previousHasTrailingNewline = true;
+     };
+     render.sync = (str) => {
+         const activeCursor = cursorDirty ? cursorPosition : undefined;
+@@ -226,11 +241,12 @@ const createIncremental = (stream, { showCursor = false } = {}) => {
+         const lines = str.split('\n');
+         previousOutput = str;
+         previousLines = lines;
++        previousHasTrailingNewline = str.endsWith('\n');
+         if (!activeCursor && cursorWasShown) {
+             stream.write(hideCursorEscape);
+         }
+         if (activeCursor) {
+-            stream.write(buildCursorSuffix(visibleLineCount(lines, str), activeCursor));
++            stream.write(buildCursorSuffix(visibleLineCount(lines, str), activeCursor, previousHasTrailingNewline));
+         }
+         previousCursorPosition = activeCursor ? { ...activeCursor } : undefined;
+         cursorWasShown = activeCursor !== undefined;
 diff --git a/node_modules/ink/build/output.d.ts b/node_modules/ink/build/output.d.ts
 index 0f4523f..a3ef634 100644
 --- a/node_modules/ink/build/output.d.ts

--- a/patches/ink+7.0.3.patch
+++ b/patches/ink+7.0.3.patch
@@ -40,7 +40,7 @@ index 2e4b9ff..77ed0f6 100644
  //# sourceMappingURL=Text.js.map
 \ No newline at end of file
 diff --git a/node_modules/ink/build/cursor-helpers.js b/node_modules/ink/build/cursor-helpers.js
-index be49354..2b2ca8c 100644
+index be49354..14215f0 100644
 --- a/node_modules/ink/build/cursor-helpers.js
 +++ b/node_modules/ink/build/cursor-helpers.js
 @@ -8,13 +8,15 @@ Compare two cursor positions. Returns true if they differ.
@@ -62,52 +62,28 @@ index be49354..2b2ca8c 100644
      return ((moveUp > 0 ? ansiEscapes.cursorUp(moveUp) : '') +
          ansiEscapes.cursorTo(cursorPosition.x) +
          showCursorEscape);
-@@ -22,14 +24,16 @@ export const buildCursorSuffix = (visibleLineCount, cursorPosition) => {
- /**
- Build escape sequence to move cursor from previousCursorPosition back to the bottom of output.
- This must be done before eraseLines or any operation that assumes cursor is at the bottom.
-+When hasTrailingNewline is true the cursor sits one line past the last visible line;
-+when false (fullscreen) it sits ON the last visible line, so one fewer cursorDown is needed.
- */
--export const buildReturnToBottom = (previousLineCount, previousCursorPosition) => {
-+export const buildReturnToBottom = (previousLineCount, previousCursorPosition, hasTrailingNewline = true) => {
+@@ -27,8 +29,10 @@ export const buildReturnToBottom = (previousLineCount, previousCursorPosition) =
      if (!previousCursorPosition) {
          return '';
      }
 -    // PreviousLineCount includes trailing newline, so visible lines = previousLineCount - 1
 -    // cursor is at previousCursorPosition.y, need to go to line (previousLineCount - 1)
--    const down = previousLineCount - 1 - previousCursorPosition.y;
-+    const lastLine = previousLineCount - 1;
-+    const cursorBase = hasTrailingNewline ? lastLine : lastLine - 1;
-+    const down = cursorBase - previousCursorPosition.y;
++    // previousLineCount is lines.length from str.split('\n'), which already
++    // includes the trailing empty element when the output ends with '\n'.
++    // The bottom line is therefore always previousLineCount - 1 regardless
++    // of whether a trailing newline was present.
+     const down = previousLineCount - 1 - previousCursorPosition.y;
      return ((down > 0 ? ansiEscapes.cursorDown(down) : '') + ansiEscapes.cursorTo(0));
  };
- /**
-@@ -38,19 +42,19 @@ Hides cursor if it was previously shown, returns to bottom, then repositions.
- */
+@@ -39,7 +43,7 @@ Hides cursor if it was previously shown, returns to bottom, then repositions.
  export const buildCursorOnlySequence = (input) => {
      const hidePrefix = input.cursorWasShown ? hideCursorEscape : '';
--    const returnToBottom = buildReturnToBottom(input.previousLineCount, input.previousCursorPosition);
+     const returnToBottom = buildReturnToBottom(input.previousLineCount, input.previousCursorPosition);
 -    const cursorSuffix = buildCursorSuffix(input.visibleLineCount, input.cursorPosition);
-+    const returnToBottom = buildReturnToBottom(input.previousLineCount, input.previousCursorPosition, input.hasTrailingNewline);
 +    const cursorSuffix = buildCursorSuffix(input.visibleLineCount, input.cursorPosition, input.hasTrailingNewline);
      return hidePrefix + returnToBottom + cursorSuffix;
  };
  /**
- Build the prefix that hides cursor and returns to bottom before erasing or rewriting.
- Returns empty string if cursor was not shown.
- */
--export const buildReturnToBottomPrefix = (cursorWasShown, previousLineCount, previousCursorPosition) => {
-+export const buildReturnToBottomPrefix = (cursorWasShown, previousLineCount, previousCursorPosition, hasTrailingNewline = true) => {
-     if (!cursorWasShown) {
-         return '';
-     }
-     return (hideCursorEscape +
--        buildReturnToBottom(previousLineCount, previousCursorPosition));
-+        buildReturnToBottom(previousLineCount, previousCursorPosition, hasTrailingNewline));
- };
- //# sourceMappingURL=cursor-helpers.js.map
-\ No newline at end of file
 diff --git a/node_modules/ink/build/frame-controller.d.ts b/node_modules/ink/build/frame-controller.d.ts
 new file mode 100644
 index 0000000..c294036
@@ -290,7 +266,7 @@ index ef659f3..767d861 100644
          const isTty = this.options.stdout.isTTY;
          // Detect fullscreen: output fills or exceeds terminal height.
 diff --git a/node_modules/ink/build/log-update.js b/node_modules/ink/build/log-update.js
-index cdb5fc4..b626cde 100644
+index cdb5fc4..89925ea 100644
 --- a/node_modules/ink/build/log-update.js
 +++ b/node_modules/ink/build/log-update.js
 @@ -12,6 +12,7 @@ const createStandard = (stream, { showCursor = false } = {}) => {
@@ -311,7 +287,7 @@ index cdb5fc4..b626cde 100644
          if (str === previousOutput && cursorChanged) {
              stream.write(buildCursorOnlySequence({
                  cursorWasShown,
-@@ -40,34 +42,38 @@ const createStandard = (stream, { showCursor = false } = {}) => {
+@@ -40,6 +42,7 @@ const createStandard = (stream, { showCursor = false } = {}) => {
                  previousCursorPosition,
                  visibleLineCount: visibleCount,
                  cursorPosition: activeCursor,
@@ -319,11 +295,7 @@ index cdb5fc4..b626cde 100644
              }));
          }
          else {
-             previousOutput = str;
--            const returnPrefix = buildReturnToBottomPrefix(cursorWasShown, previousLineCount, previousCursorPosition);
-+            const returnPrefix = buildReturnToBottomPrefix(cursorWasShown, previousLineCount, previousCursorPosition, previousHasTrailingNewline);
-             stream.write(returnPrefix +
-                 ansiEscapes.eraseLines(previousLineCount) +
+@@ -50,6 +53,7 @@ const createStandard = (stream, { showCursor = false } = {}) => {
                  str +
                  cursorSuffix);
              previousLineCount = lines.length;
@@ -331,13 +303,7 @@ index cdb5fc4..b626cde 100644
          }
          previousCursorPosition = activeCursor ? { ...activeCursor } : undefined;
          cursorWasShown = activeCursor !== undefined;
-         return true;
-     };
-     render.clear = () => {
--        const prefix = buildReturnToBottomPrefix(cursorWasShown, previousLineCount, previousCursorPosition);
-+        const prefix = buildReturnToBottomPrefix(cursorWasShown, previousLineCount, previousCursorPosition, previousHasTrailingNewline);
-         stream.write(prefix + ansiEscapes.eraseLines(previousLineCount));
-         previousOutput = '';
+@@ -62,12 +66,14 @@ const createStandard = (stream, { showCursor = false } = {}) => {
          previousLineCount = 0;
          previousCursorPosition = undefined;
          cursorWasShown = false;
@@ -382,7 +348,7 @@ index cdb5fc4..b626cde 100644
      const getActiveCursor = () => (cursorDirty ? cursorPosition : undefined);
      const hasChanges = (str, activeCursor) => {
          const cursorChanged = cursorPositionChanged(activeCursor, previousCursorPosition);
-@@ -138,14 +147,15 @@ const createIncremental = (stream, { showCursor = false } = {}) => {
+@@ -138,6 +147,7 @@ const createIncremental = (stream, { showCursor = false } = {}) => {
                  previousCursorPosition,
                  visibleLineCount: visibleCount,
                  cursorPosition: activeCursor,
@@ -390,10 +356,9 @@ index cdb5fc4..b626cde 100644
              }));
              previousCursorPosition = activeCursor ? { ...activeCursor } : undefined;
              cursorWasShown = activeCursor !== undefined;
-             return true;
+@@ -145,7 +155,7 @@ const createIncremental = (stream, { showCursor = false } = {}) => {
          }
--        const returnPrefix = buildReturnToBottomPrefix(cursorWasShown, previousLines.length, previousCursorPosition);
-+        const returnPrefix = buildReturnToBottomPrefix(cursorWasShown, previousLines.length, previousCursorPosition, previousHasTrailingNewline);
+         const returnPrefix = buildReturnToBottomPrefix(cursorWasShown, previousLines.length, previousCursorPosition);
          if (str === '\n' || previousOutput.length === 0) {
 -            const cursorSuffix = buildCursorSuffix(visibleCount, activeCursor);
 +            const cursorSuffix = buildCursorSuffix(visibleCount, activeCursor, str.endsWith('\n'));
@@ -408,7 +373,7 @@ index cdb5fc4..b626cde 100644
              return true;
          }
          const hasTrailingNewline = str.endsWith('\n');
-@@ -187,28 +198,31 @@ const createIncremental = (stream, { showCursor = false } = {}) => {
+@@ -187,13 +198,14 @@ const createIncremental = (stream, { showCursor = false } = {}) => {
                  // has no trailing newline (fullscreen mode).
                  (isLastLine && !hasTrailingNewline ? '' : '\n'));
          }
@@ -424,10 +389,7 @@ index cdb5fc4..b626cde 100644
          return true;
      };
      render.clear = () => {
--        const prefix = buildReturnToBottomPrefix(cursorWasShown, previousLines.length, previousCursorPosition);
-+        const prefix = buildReturnToBottomPrefix(cursorWasShown, previousLines.length, previousCursorPosition, previousHasTrailingNewline);
-         stream.write(prefix + ansiEscapes.eraseLines(previousLines.length));
-         previousOutput = '';
+@@ -203,12 +215,14 @@ const createIncremental = (stream, { showCursor = false } = {}) => {
          previousLines = [];
          previousCursorPosition = undefined;
          cursorWasShown = false;


### PR DESCRIPTION
## What this PR does

When the TUI output fills the terminal (fullscreen mode), Ink omits the trailing newline from the rendered output. The cursor-positioning escape sequence assumed a trailing newline was always present, causing the hardware terminal cursor (used for IME input positioning) to be placed one row above the software block cursor. This produced a visible "extra white rectangular segment" protruding above the input line.

The fix threads a `hasTrailingNewline` flag through the four cursor-movement helpers in the Ink patch (`buildCursorSuffix`, `buildReturnToBottom`, `buildCursorOnlySequence`, `buildReturnToBottomPrefix`) and updates every call site in both the standard and incremental log-update renderers to pass whether the current output ends with `\n`. When there is no trailing newline, one fewer `cursorUp` / `cursorDown` is emitted, landing the hardware cursor on the correct row.

## Why it's needed

Closes #7980. The input box cursor renders with an extra vertical segment on every launch. The TUI almost always fills the terminal, so fullscreen mode (and the bug) is active in virtually every session. Beyond the visual artifact, the mispositioned hardware cursor also causes IME composition windows to appear one row too high.

## Reviewer Test Plan

### How to verify

1. Run `npm run dev` in a terminal where the TUI fills the screen (e.g. 80×24 tmux pane).
2. Observe the input cursor: it should occupy exactly one character cell, flush with the current input line, with no extra segment above.
3. Type text and move the cursor with arrow keys — the cursor should track correctly on every row.
4. If using an IME (e.g. Chinese input), the composition window should appear at the cursor's row, not one row above.
5. Run the unit tests: `cd packages/cli && npx vitest run src/ui/ink-cursor-rendering.test.tsx` — 18/18 should pass, including the new fullscreen y>0 regression test.

### Evidence (Before & After)

**Before:** In fullscreen mode, `buildCursorSuffix` emitted `cursorUp(N - y)` where N = visible line count. Since the terminal cursor sat on line N-1 (no trailing `\n`), the hardware cursor landed at line `y - 1` — one row above the software cursor.

**After:** With `hasTrailingNewline = false`, the formula becomes `cursorUp(N - 1 - y)`, landing the hardware cursor at the correct row `y`.

Verified via pty escape-sequence capture: the output now contains `^[[2A^[[5G^[[?25h` (cursorUp=2, the correct value) instead of the buggy cursorUp=3.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`npm run dev` in tmux 80×24, plus pty capture via `script(1)`.

## Risk & Scope

- Main risk or tradeoff: The change touches the Ink patch's cursor-movement helpers, which affect every render frame. The `hasTrailingNewline` parameter defaults to `true`, preserving existing behavior for non-fullscreen mode.
- Not validated / out of scope: Windows and Linux terminals; incremental rendering path is patched but not exercised by qwen-code (it uses the standard renderer).
- Breaking changes / migration notes: None. The patch is regenerated via `npx patch-package ink`.

## Linked Issues

Closes #7980

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当 TUI 输出填满终端（全屏模式）时，Ink 省略渲染输出末尾的换行符。光标定位转义序列始终假设存在尾部换行，导致硬件终端光标（用于 IME 输入定位）被放置在软件块状光标的上一行，产生"向上突出的白色矩形段"。

修复方案：在 Ink patch 的四个光标移动辅助函数中传入 `hasTrailingNewline` 标志，并在标准渲染器和增量渲染器的所有调用点传入当前输出是否以 `\n` 结尾。无尾部换行时少发一次 `cursorUp`/`cursorDown`，使硬件光标落在正确行。

## 为什么需要

关闭 #7980。输入框光标每次启动都渲染出多余的垂直段。TUI 几乎总是填满终端，因此全屏模式（及此 bug）在几乎所有会话中都处于激活状态。除视觉问题外，错位的硬件光标还导致 IME 候选窗口出现在错误行。

## 审阅者测试计划

### 如何验证

1. 在 TUI 填满屏幕的终端中运行 `npm run dev`（如 80×24 tmux 窗格）。
2. 观察输入光标：应恰好占一个字符单元格，与当前输入行齐平，上方无多余段。
3. 输入文字并用方向键移动光标——光标应在每一行正确跟踪。
4. 如使用 IME（如中文输入），候选窗口应出现在光标所在行，而非上一行。
5. 运行单元测试：`cd packages/cli && npx vitest run src/ui/ink-cursor-rendering.test.tsx`——18/18 应通过，包含新增的全屏 y>0 回归测试。

### 证据（修复前后）

**修复前：** 全屏模式下 `buildCursorSuffix` 发出 `cursorUp(N - y)`（N = 可见行数）。因终端光标在第 N-1 行（无尾部 `\n`），硬件光标落在第 `y - 1` 行——比软件光标高一行。

**修复后：** `hasTrailingNewline = false` 时公式变为 `cursorUp(N - 1 - y)`，硬件光标落在正确的第 `y` 行。

通过 pty 转义序列捕获验证：输出现在包含 `^[[2A^[[5G^[[?25h`（cursorUp=2，正确值），而非错误的 cursorUp=3。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

`npm run dev`，tmux 80×24，另通过 `script(1)` 进行 pty 捕获。

## 风险与范围

- 主要风险或权衡：改动涉及 Ink patch 的光标移动辅助函数，影响每个渲染帧。`hasTrailingNewline` 参数默认为 `true`，保持非全屏模式的现有行为。
- 未验证 / 不在范围内：Windows 和 Linux 终端；增量渲染路径已修补但 qwen-code 未使用（使用标准渲染器）。
- 破坏性变更 / 迁移说明：无。Patch 通过 `npx patch-package ink` 重新生成。

## 关联 Issue

Closes #7980

</details>