### PR TITLE
fix(ci): update the Qwen binary used by ECS runners

### DIFF
--- a/.github/workflows/update-ecs-runner-qwen.yml
+++ b/.github/workflows/update-ecs-runner-qwen.yml
@@ -51,18 +51,20 @@ jobs:
           VERSION: '${{ steps.version.outputs.version }}'
         run: |-
           set -euo pipefail
-          global_prefix="$(npm prefix -g)"
-          if [[ -w "${global_prefix}" ]]; then
-            npm install -g "@qwen-code/qwen-code@${VERSION}"
-          else
-            sudo env "NPM_CONFIG_PREFIX=${global_prefix}" npm install -g "@qwen-code/qwen-code@${VERSION}"
-          fi
+          # The runner service resolves the system-wide qwen binary. Do not
+          # carry a runner user's custom npm prefix into the sudo install.
+          (
+            cd "${RUNNER_TEMP:?}"
+            sudo env -u NPM_CONFIG_PREFIX npm install -g --registry=https://registry.npmjs.org "@qwen-code/qwen-code@${VERSION}"
+          )
 
       - name: 'Verify version'
         env:
           VERSION: '${{ steps.version.outputs.version }}'
         run: |-
           set -euo pipefail
-          actual="$(qwen --version)"
+          qwen_path="$(command -v qwen)"
+          actual="$("${qwen_path}" --version)"
+          echo "qwen path: ${qwen_path}"
           echo "qwen version: ${actual}"
           test "${actual}" = "${VERSION}"

--- a/scripts/tests/update-ecs-runner-qwen-workflow.test.js
+++ b/scripts/tests/update-ecs-runner-qwen-workflow.test.js
@@ -13,14 +13,8 @@ describe('ECS runner qwen update workflow', () => {
     'utf8',
   );
 
-  it('updates the npm prefix used by the selected runner', () => {
-    expect(workflow).toContain('global_prefix="$(npm prefix -g)"');
-    expect(workflow).toContain('if [[ -w "${global_prefix}" ]]');
-    expect(workflow).toContain(
-      'sudo env "NPM_CONFIG_PREFIX=${global_prefix}" npm install -g',
-    );
-    expect(workflow).toMatch(
-      /if \[\[ -w "\$\{global_prefix\}" \]\][\s\S]*?then\s*\n\s*npm install -g/,
-    );
+  it('installs without the selected runner npm prefix', () => {
+    expect(workflow).toContain('cd "${RUNNER_TEMP:?}"');
+    expect(workflow).toContain('sudo env -u NPM_CONFIG_PREFIX npm install -g');
   });
 });


### PR DESCRIPTION
## What this PR does

Installs the requested Qwen release into the system-wide npm location used by the self-hosted runner service, and logs the resolved executable during verification.

## Why it's needed

The updater previously preserved a runner user's custom npm prefix while running sudo. On the Singapore host that installed the new package outside the service PATH, so verification continued to run the previous Qwen version.

## Reviewer Test Plan

### How to verify

Dispatch the ECS runner update workflow with a published version. Both matrix jobs should report the requested version, and the Singapore job should print the system qwen path.

### Evidence (Before & After)

Before: the Singapore update job installed 0.21.1 but verification resolved 0.21.0. After: the workflow installs using root's system npm prefix and verifies the executable on the runner service PATH.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | N/A |
|  🐧 Linux  | ✅ Prettier YAML check |

### Environment (optional)

GitHub Actions self-hosted Linux runner workflow.

## Risk & Scope

- Main risk or tradeoff: requires the existing passwordless sudo capability already used by the updater.
- Not validated / out of scope: live runner execution is dispatched from this branch after PR creation.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 此 PR 的内容

将指定的 Qwen 版本安装到自托管 runner 服务实际使用的系统级 npm 位置，并在校验阶段输出实际解析到的可执行文件路径。

## 背景

原更新流程在执行 sudo 时保留了 runner 用户的自定义 npm prefix。新加坡宿主机因此把新包安装到了服务 PATH 之外的位置，校验仍执行旧版本 Qwen。

## 验证方式

手动触发 ECS runner 更新工作流并指定一个已发布版本。两个矩阵任务都应输出目标版本，新加坡任务还应输出系统 qwen 路径。

## 证据

修复前：新加坡任务安装了 0.21.1，但校验解析到 0.21.0。修复后：工作流使用 root 的系统 npm prefix 安装，并校验 runner 服务 PATH 中的可执行文件。

## 测试环境

Linux：已通过 Prettier YAML 检查；macOS 和 Windows：不适用。

## 风险与范围

主要风险是依赖更新工作流原本已有的免密 sudo 能力。分支创建后将实际触发一次 runner 更新验证；无破坏性变更或迁移要求。

</details>