### PR TITLE
fix(webui): stabilize session history pagination

### DIFF
--- a/docs/design/web-shell-history-boundary-pagination.md
+++ b/docs/design/web-shell-history-boundary-pagination.md
@@ -1,0 +1,28 @@
+# Web Shell history boundary pagination
+
+## Problem
+
+Web Shell starts restored-history pagination with `beforeRecordId`, then switches
+to the opaque `nextCursor` returned by the transcript endpoint. A cursor can be
+rejected with `invalid_transcript_cursor` when the next request is handled by a
+runtime that cannot validate the original HMAC. The user then cannot load the
+remaining history.
+
+## Design
+
+Continue backward Web Shell pagination with record boundaries whenever a page
+contains a persisted record id. Replay already stamps
+`qwen.session.recordId` on transcript events, and `beforeRecordId` is exclusive,
+so the earliest record id in the returned page is the next boundary.
+
+Keep `nextCursor` as a compatibility fallback for older daemons or malformed
+pages that do not expose any persisted record id. No daemon API or cursor
+security semantics change.
+
+## Verification
+
+- A multi-page transcript uses `beforeRecordId` for every Web Shell request.
+- Events already displayed remain deduplicated.
+- A page without a persisted record id still advances with `nextCursor`.
+- Existing retry, terminal-error, capacity, and malformed-event behavior stays
+  unchanged.

--- a/packages/core/src/services/session-transcript-reader.test.ts
+++ b/packages/core/src/services/session-transcript-reader.test.ts
@@ -291,7 +291,7 @@ describe('SessionTranscriptReader', () => {
       limit: 2,
     });
     const second = await reader.readPage(sessionId, {
-      cursor: encodeCursor(first.nextCursorState!),
+      beforeRecordId: first.records[0]!.uuid,
       limit: 2,
     });
 

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -9527,7 +9527,7 @@ describe('DaemonSessionProvider', () => {
     expect(sdkMocks.getSessionTranscriptPage).toHaveBeenCalledTimes(1);
   });
 
-  it('skips malformed older-page events and advances the cursor', async () => {
+  it('skips malformed older-page events and advances by record boundary', async () => {
     sdkMocks.capabilities.mockResolvedValue({
       workspaceCwd: '/mock-workspace',
       features: ['session_transcript_pagination'],
@@ -9608,7 +9608,7 @@ describe('DaemonSessionProvider', () => {
       2,
       session.sessionId,
       {
-        cursor: 'next-page',
+        beforeRecordId: 'record-2',
         limit: 25,
         clientId: session.clientId,
       },
@@ -9623,6 +9623,78 @@ describe('DaemonSessionProvider', () => {
         message: 'Skipped malformed history event',
         debugMessage: 'malformed history event',
       }),
+    );
+  });
+
+  it('falls back to the server cursor when a page has no record boundary', async () => {
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['session_transcript_pagination'],
+    });
+    const replayEvent = (
+      id: number,
+      text: string,
+      recordId?: string,
+    ): DaemonEvent => ({
+      id,
+      v: 1,
+      type: 'session_update',
+      data: {
+        update: {
+          sessionUpdate: 'user_message_chunk',
+          content: { type: 'text', text },
+          ...(recordId ? { _meta: { 'qwen.session.recordId': recordId } } : {}),
+        },
+      },
+    });
+    const session = createMockSession({
+      sessionId: 'session-history-cursor-fallback',
+      historyHasMore: true,
+      replaySnapshot: {
+        compactedReplay: [replayEvent(3, 'recent prompt', 'recent-record')],
+        liveJournal: [],
+      },
+    });
+    sdkMocks.sessions.push(session);
+    sdkMocks.getSessionTranscriptPage
+      .mockResolvedValueOnce({
+        v: 1,
+        sessionId: session.sessionId,
+        events: [replayEvent(2, 'older prompt')],
+        nextCursor: 'next-page',
+        hasMore: true,
+      })
+      .mockResolvedValueOnce({
+        v: 1,
+        sessionId: session.sessionId,
+        events: [replayEvent(1, 'oldest prompt')],
+        hasMore: false,
+      });
+    let history: ReturnType<typeof useDaemonTranscriptHistory> | undefined;
+
+    function Harness() {
+      history = useDaemonTranscriptHistory();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      historyPageSize: 25,
+    });
+    await act(async () => {
+      await history?.loadMore();
+      await history?.loadMore();
+      await flushPromises();
+    });
+
+    expect(sdkMocks.getSessionTranscriptPage).toHaveBeenNthCalledWith(
+      2,
+      session.sessionId,
+      {
+        cursor: 'next-page',
+        limit: 25,
+        clientId: session.clientId,
+      },
     );
   });
 

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -2454,6 +2454,9 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
         ...eventOptionsRef.current,
         suppressOwnUserEcho: false,
       };
+      const nextBeforeRecordId = page.events
+        .map(getPersistedReplayRecordId)
+        .find((recordId): recordId is string => recordId !== undefined);
       const uiEvents: DaemonUiEvent[] = [];
       for (const replayEvent of page.events) {
         try {
@@ -2509,8 +2512,9 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
       }
       const hasCapacity = store.getSnapshot().blocks.length < maxBlocks;
       history.capacityReached = page.hasMore && !hasCapacity;
-      history.cursor = page.nextCursor;
-      history.beforeRecordId = undefined;
+      history.cursor =
+        nextBeforeRecordId === undefined ? page.nextCursor : undefined;
+      history.beforeRecordId = nextBeforeRecordId;
       history.hasMore = page.hasMore && hasCapacity;
       history.loading = false;
       setTranscriptHistoryState({


### PR DESCRIPTION
## What this PR does

This change keeps backward Web Shell history pagination on persisted record boundaries. After each page, the client uses the earliest returned record ID as the next exclusive boundary. The opaque server cursor remains available as a compatibility fallback when a page does not expose any persisted record ID.

## Why it's needed

Loading earlier session history could fail after the first page when the continuation cursor was rejected with `invalid_transcript_cursor`, leaving users with a "Failed to load earlier session history" notification. Record boundaries are already part of replayed transcript events and do not depend on a cursor-signing key, so they provide a stable continuation point for backward pagination.

## Reviewer Test Plan

### How to verify

Restore a session whose persisted transcript spans more than one history page, then repeatedly load earlier history. Confirm that the first and subsequent requests use exclusive `beforeRecordId` boundaries, older messages are prepended in chronological order without duplicates, and pagination reaches the beginning of the transcript. Also confirm that a synthetic page without a persisted record ID continues with its returned cursor.

### Evidence (Before & After)

Before: the first history page loaded, but the following `GET .../transcript?cursor=...` request returned HTTP 400 with `invalid_transcript_cursor`, and Web Shell displayed "Failed to load earlier session history."

After: provider regression tests confirm that subsequent pages use the earliest returned record boundary, preserve transcript ordering and deduplication, and retain cursor fallback for pages without a record boundary. The full provider test file passes with 177 tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Node.js 22 workspace; Vitest unit tests, ESLint, full workspace build, and TypeScript typecheck.

## Risk & Scope

- Main risk or tradeoff: record-boundary continuation reads against the current active transcript rather than retaining the cursor's frozen snapshot metadata.
- Not validated / out of scope: a live multi-process daemon E2E run and platform-specific validation on Windows or Linux.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本次修改让 Web Shell 的历史记录向前分页持续使用持久化记录边界。每页返回后，客户端会把最早返回的记录 ID 作为下一页的排他边界。当页面没有暴露任何持久化记录 ID 时，仍保留服务端不透明 cursor 作为兼容回退。

## 为什么需要

此前加载更早的会话历史时，第一页可以成功，但后续 continuation cursor 可能因 `invalid_transcript_cursor` 被拒绝，最终向用户显示“Failed to load earlier session history”。记录边界已经包含在重放的 transcript 事件中，并且不依赖 cursor 签名密钥，因此可以作为向前分页的稳定续传点。

## Reviewer 测试计划

### 如何验证

恢复一个持久化 transcript 跨越多个历史分页的会话，然后反复加载更早历史。确认第一页及后续请求都使用排他的 `beforeRecordId` 边界，更早的消息按时间顺序插入且没有重复，并最终到达 transcript 开头。同时确认构造一个没有持久化记录 ID 的页面时，客户端仍会使用该页面返回的 cursor 继续分页。

### 证据（修复前与修复后）

修复前：第一页历史能够加载，但后续 `GET .../transcript?cursor=...` 请求返回 HTTP 400 和 `invalid_transcript_cursor`，Web Shell 显示“Failed to load earlier session history”。

修复后：Provider 回归测试确认后续页面使用最早返回的记录边界，保持 transcript 顺序和去重行为，并在页面缺少记录边界时保留 cursor 回退。完整 Provider 测试文件的 177 个测试全部通过。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|    🍏 macOS      |  ✅  |
|    🪟 Windows    | N/A  |
|     🐧 Linux     | N/A  |

### 环境（可选）

Node.js 22 工作区；执行了 Vitest 单元测试、ESLint、完整工作区构建和 TypeScript 类型检查。

## 风险与范围

- 主要风险或权衡：记录边界续传读取的是当前活动 transcript，而不是保留 cursor 中冻结的快照元数据。
- 未验证或不在范围内：真实多进程 daemon E2E，以及 Windows 或 Linux 平台专项验证。
- 破坏性变更或迁移说明：无。

## 关联 Issue

N/A

</details>
