### PR TITLE
fix(web-shell): reduce composer input latency

### DIFF
--- a/docs/design/2026-07-28-web-shell-composer-intent-suggestions.md
+++ b/docs/design/2026-07-28-web-shell-composer-intent-suggestions.md
@@ -62,10 +62,21 @@ The change stays inside Web Shell. It reuses existing daemon session generation,
 editor submission, and `/btw` behavior. It does not add daemon or SDK routes,
 change styling, or introduce a general-purpose suggestion framework.
 
+## Composer performance
+
+Draft changes enter the classifier through a stable callback. They update the
+classifier's refs, cancellation state, and debounce timer without updating
+React state. The Web Shell app only rerenders when an actionable suggestion
+appears or an existing suggestion is invalidated.
+
+This keeps intent classification off the composer's render path while
+preserving immediate cancellation when the draft changes.
+
 ## Test strategy
 
 - Hook tests cover the three decision values, strict parsing, confidence,
   attachment gating, and stale-session results.
 - App tests cover `/btw` execution and composer clearing, stale draft/session
-  rejection, attachment rejection, and the existing new-session races.
+  rejection, attachment rejection, the existing new-session races, and the
+  absence of an app rerender while classification is pending.
 - ChatEditor tests cover attachment-presence reporting.

--- a/docs/design/web-shell-composer-performance.md
+++ b/docs/design/web-shell-composer-performance.md
@@ -1,0 +1,66 @@
+# Web Shell Composer Performance
+
+## Problem
+
+Composer input competes with several unrelated or document-wide operations:
+
+- intent classification previously lifted every settled draft into `App`;
+- input highlighting rescanned the complete CodeMirror document;
+- slash and mention menus rebuilt unchanged state and could render unbounded
+  category or command lists;
+- the touch textarea reread computed styles after every input;
+- transcript store notifications rerendered Web Shell once per streaming chunk.
+
+These costs are small in an empty session but compound with long drafts, large
+command sets, and active streaming.
+
+## Design
+
+Keep work proportional to what is visible or changing:
+
+- intent classification receives drafts through a stable callback and only
+  updates React when its visible suggestion changes;
+- input decorations cover CodeMirror's visible ranges;
+- slash completion reads only the current line and translates its result back
+  to document coordinates;
+- command and mention menus expose at most 50 immediately rendered results and
+  reuse semantically unchanged menu state;
+- inline-tag presence checks stop at the first decoration while retaining
+  ordinary document-change mapping;
+- mobile browsers use CSS intrinsic textarea sizing when available, while the
+  fallback caches its computed height cap;
+- Web Shell subscribes to transcript blocks through an animation-frame
+  boundary, coalescing streaming notifications before they reach `App` or
+  split chat panes;
+- the shared streaming-state hook subscribes to its derived enum instead of
+  rerendering consumers for block updates that keep the same state.
+
+Search still reaches commands and providers outside the initial 50-item view.
+Transcript consumers receive the newest complete snapshot at most once per
+animation frame.
+
+## Safety
+
+- Suggestion cancellation, stale-draft checks, and session checks remain
+  synchronous.
+- CodeMirror rebuilds decorations when the document or viewport changes.
+- The mobile JavaScript auto-grow path remains as a fallback when
+  `field-sizing: content` is unsupported.
+- Approval extraction, goal state, transcript callbacks, and message
+  conversion all consume the same framed transcript snapshot.
+
+## Verification
+
+- A draft waiting for intent classification does not rerender the app shell.
+- A 10,000-line composer scans only its visible line for input decorations.
+- A slash refresh in a 10,000-line draft does not serialize the document again,
+  and multiline replacement coordinates remain correct.
+- Removing the final inline tag through an ordinary document change clears
+  attachment state.
+- Slash and mention menus cap their immediate result sets at 50.
+- Repeating an unchanged mention refresh preserves state identity.
+- Mobile input does not reread computed styles after mount.
+- One hundred transcript notifications in a frame produce one React update
+  containing the latest snapshot.
+- Equivalent transcript updates do not rerender streaming-state-only
+  consumers.

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -251,6 +251,7 @@ const {
       streamingState: 'idle' as StreamingState,
       blocks: [] as unknown[],
       messages: [] as unknown[],
+      chatEditorRenderCount: 0,
       latestChatEditorProps: null as ChatEditorTestProps | null,
       latestAddWorkspaceDialogProps: null as AddWorkspaceDialogTestProps | null,
       latestToolApprovalKeyboardActive: null as boolean | null,
@@ -364,6 +365,11 @@ vi.mock('@qwen-code/sdk/daemon', () => ({
 
 vi.mock('./hooks/useMessages', () => ({
   useMessages: () => testState.messages,
+  useMessagesFromBlocks: () => testState.messages,
+}));
+
+vi.mock('./hooks/useAnimationFrameTranscriptBlocks', () => ({
+  useAnimationFrameTranscriptBlocks: () => testState.blocks,
 }));
 
 vi.mock('./hooks/useBackgroundTasks', () => ({
@@ -398,94 +404,97 @@ vi.mock('./hooks/useQueuedPrompts', () => ({
 vi.mock('./components/ChatEditor', async () => {
   const React = await import('react');
   return {
-    ChatEditor: React.forwardRef(function ChatEditor(
-      props: ChatEditorTestProps,
-      ref: React.ForwardedRef<{
-        clear: () => void;
-        hasAttachments: () => boolean;
-        hasInput: () => boolean;
-        insertText: (text: string) => void;
-        submit: (input?: { text?: string }) => void;
-        focus: () => void;
-      }>,
-    ) {
-      testState.latestChatEditorProps = props;
-      const { onAttachmentsChange } = props;
-      React.useEffect(() => {
-        onAttachmentsChange?.(
-          Boolean(
-            testState.promptImages?.length ||
-              testState.inputAnnotations?.length,
-          ),
-        );
-      }, [onAttachmentsChange]);
-      React.useImperativeHandle(ref, () => ({
-        clear: () => {
-          testState.prompt = '';
-          testState.promptImages = undefined;
-          props.onInputTextChange?.('');
-          editorClear();
-        },
-        hasAttachments: () =>
-          Boolean(
-            testState.promptImages?.length ||
-              testState.inputAnnotations?.length,
-          ),
-        hasInput: () => testState.prompt.trim().length > 0,
-        insertText: editorInsertText,
-        submit: (input) => {
-          const accepted = props.onSubmit(
-            input?.text ?? testState.prompt,
-            testState.promptImages,
-            editorCommit,
-            testState.inputAnnotations
-              ? { inputAnnotations: testState.inputAnnotations }
-              : undefined,
+    ChatEditor: React.memo(
+      React.forwardRef(function ChatEditor(
+        props: ChatEditorTestProps,
+        ref: React.ForwardedRef<{
+          clear: () => void;
+          hasAttachments: () => boolean;
+          hasInput: () => boolean;
+          insertText: (text: string) => void;
+          submit: (input?: { text?: string }) => void;
+          focus: () => void;
+        }>,
+      ) {
+        testState.chatEditorRenderCount += 1;
+        testState.latestChatEditorProps = props;
+        const { onAttachmentsChange } = props;
+        React.useEffect(() => {
+          onAttachmentsChange?.(
+            Boolean(
+              testState.promptImages?.length ||
+                testState.inputAnnotations?.length,
+            ),
           );
-          if (accepted) editorCommit();
-        },
-        // The panel focus effect calls editorRef.current?.focus() when a panel
-        // closes with no pending approval (e.g. resuming a session).
-        focus: editorFocus,
-      }));
-      return React.createElement(
-        'div',
-        { 'data-web-shell-composer': '' },
-        React.createElement(
-          'button',
-          {
-            'data-testid': 'submit',
-            'data-preparing': props.isPreparing ? 'true' : 'false',
-            onClick: () => {
-              if (testState.inputAnnotations) {
-                props.onSubmit(testState.prompt, undefined, editorCommit, {
-                  inputAnnotations: testState.inputAnnotations,
-                });
-                return;
-              }
-              props.onSubmit(testState.prompt, undefined, editorCommit);
-            },
-            type: 'button',
+        }, [onAttachmentsChange]);
+        React.useImperativeHandle(ref, () => ({
+          clear: () => {
+            testState.prompt = '';
+            testState.promptImages = undefined;
+            props.onInputTextChange?.('');
+            editorClear();
           },
-          'submit',
-        ),
-        props.newSessionSuggestion
-          ? React.createElement(
-              'div',
-              { 'data-testid': 'new-session-suggestion' },
-              React.createElement(
-                'button',
-                {
-                  'data-testid': 'new-session-suggestion-start',
-                  onClick: () => props.onStartNewSessionSuggestion?.(),
-                  type: 'button',
-                },
-                'This looks like a new topic',
-              ),
-            )
-          : null,
-      );
-    }),
+          hasAttachments: () =>
+            Boolean(
+              testState.promptImages?.length ||
+                testState.inputAnnotations?.length,
+            ),
+          hasInput: () => testState.prompt.trim().length > 0,
+          insertText: editorInsertText,
+          submit: (input) => {
+            const accepted = props.onSubmit(
+              input?.text ?? testState.prompt,
+              testState.promptImages,
+              editorCommit,
+              testState.inputAnnotations
+                ? { inputAnnotations: testState.inputAnnotations }
+                : undefined,
+            );
+            if (accepted) editorCommit();
+          },
+          // The panel focus effect calls editorRef.current?.focus() when a panel
+          // closes with no pending approval (e.g. resuming a session).
+          focus: editorFocus,
+        }));
+        return React.createElement(
+          'div',
+          { 'data-web-shell-composer': '' },
+          React.createElement(
+            'button',
+            {
+              'data-testid': 'submit',
+              'data-preparing': props.isPreparing ? 'true' : 'false',
+              onClick: () => {
+                if (testState.inputAnnotations) {
+                  props.onSubmit(testState.prompt, undefined, editorCommit, {
+                    inputAnnotations: testState.inputAnnotations,
+                  });
+                  return;
+                }
+                props.onSubmit(testState.prompt, undefined, editorCommit);
+              },
+              type: 'button',
+            },
+            'submit',
+          ),
+          props.newSessionSuggestion
+            ? React.createElement(
+                'div',
+                { 'data-testid': 'new-session-suggestion' },
+                React.createElement(
+                  'button',
+                  {
+                    'data-testid': 'new-session-suggestion-start',
+                    onClick: () => props.onStartNewSessionSuggestion?.(),
+                    type: 'button',
+                  },
+                  'This looks like a new topic',
+                ),
+              )
+            : null,
+        );
+      }),
+    ),
   };
 });
 
@@ -1553,6 +1562,7 @@ beforeEach(() => {
   testState.streamingState = 'idle';
   testState.blocks = [];
   testState.messages = [];
+  testState.chatEditorRenderCount = 0;
   testState.latestChatEditorProps = null;
   testState.latestAddWorkspaceDialogProps = null;
   testState.latestToolApprovalKeyboardActive = null;
@@ -4665,7 +4675,7 @@ describe('App session callbacks', () => {
       workspaceGit: vi.fn().mockResolvedValue({ branch: 'main' }),
       workspaceSkills: mockWorkspaceActions.loadSkillsStatus,
     }));
-    renderApp();
+    const { rerender } = renderApp();
     await flush();
     await flush();
 
@@ -4678,7 +4688,7 @@ describe('App session callbacks', () => {
 
     // The daemon's `git_status_changed` push lands as connection.gitStatus
     // (a provider state update in production; simulated here by mutating the
-    // connection object and forcing a re-render).
+    // connection object and rerendering the provider consumer).
     act(() => {
       mockConnection.gitStatus = {
         v: 2,
@@ -4687,8 +4697,8 @@ describe('App session callbacks', () => {
         staged: 2,
         computedAt: 1_700_000_000_000,
       };
-      testState.latestChatEditorProps?.onInputTextChange?.('x');
     });
+    rerender();
     await flush();
 
     await vi.waitFor(() => {
@@ -5415,6 +5425,40 @@ describe('App session callbacks', () => {
       finishClear?.();
       await Promise.resolve();
     });
+  });
+
+  it('does not rerender the composer while a draft waits for intent classification', async () => {
+    vi.useFakeTimers();
+    const ComposerFooter = vi.fn(() => null);
+
+    renderApp({ renderComposerFooter: ComposerFooter });
+    await flush();
+    const renderCount = ComposerFooter.mock.calls.length;
+
+    act(() => {
+      testState.latestChatEditorProps?.onInputTextChange?.(
+        'Help me brainstorm a separate Web Shell design proposal',
+      );
+      vi.advanceTimersByTime(121);
+    });
+    await flush();
+
+    expect(ComposerFooter).toHaveBeenCalledTimes(renderCount);
+  });
+
+  it('keeps ChatEditor memoized across transcript-only app renders', async () => {
+    testState.streamingState = 'responding';
+    testState.messages = [{ role: 'assistant', content: 'first delta' }];
+    const { rerender } = renderApp();
+    await flush();
+    const renderCount = testState.chatEditorRenderCount;
+
+    testState.blocks = [{ kind: 'debug', text: 'streaming delta' }];
+    testState.messages = [{ role: 'assistant', content: 'next delta' }];
+    rerender();
+    await flush();
+
+    expect(testState.chatEditorRenderCount).toBe(renderCount);
   });
 
   it('does not suggest a new session for obvious follow-up prompts', async () => {

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -20,7 +20,6 @@ import {
   useProviders,
   useSessionNotices,
   useStreamingState,
-  useTranscriptBlocks,
   useTranscriptHistory,
   useTranscriptStore,
   useWorkspace,
@@ -168,9 +167,9 @@ import {
   skillDescriptionKey,
 } from './constants/localCommands';
 import { mergeCommands } from './hooks/daemonSessionMappers';
-import { useAnimationFrameValue } from './hooks/useAnimationFrameValue';
+import { useAnimationFrameTranscriptBlocks } from './hooks/useAnimationFrameTranscriptBlocks';
 import { useBackgroundTasks } from './hooks/useBackgroundTasks';
-import { useMessages } from './hooks/useMessages';
+import { useMessagesFromBlocks } from './hooks/useMessages';
 import { useSessionArtifacts } from './hooks/useSessionArtifacts';
 import { useShallowMemo, useStableArray } from './hooks/useShallowMemo';
 import {
@@ -566,8 +565,7 @@ export interface WebShellProps {
   onStreamingStateChange?: (state: DaemonStreamingState) => void;
   /**
    * Called whenever transcript blocks change. Receives the full blocks array
-   * from useTranscriptBlocks(). Fires on every streaming delta during active
-   * generation, so consumers should debounce or throttle expensive work.
+   * at most once per animation frame during active generation.
    */
   onTranscriptChange?: (blocks: readonly DaemonTranscriptBlock[]) => void;
   /** Called when a critical error occurs (auth failure, session gone, etc). */
@@ -1379,7 +1377,7 @@ export function App({
   const CustomComposerHeader = renderComposerHeader;
   const CustomComposerFooter = renderComposerFooter;
   const store = useTranscriptStore();
-  const blocks = useTranscriptBlocks();
+  const blocks = useAnimationFrameTranscriptBlocks();
   const connection = useConnection();
   const transcriptHistory = useTranscriptHistory();
   const workspace = useWorkspace();
@@ -1693,7 +1691,7 @@ export function App({
     });
   }, []);
 
-  const messages = useMessages(t);
+  const messages = useMessagesFromBlocks(t, blocks);
   const messagesRef = useRef(messages);
   messagesRef.current = messages;
   const [recapMessage, setRecapMessage] = useState<LocalAnchoredMessage | null>(
@@ -2353,10 +2351,9 @@ export function App({
     [artifactPanelWidth, getMaxArtifactPanelWidth],
   );
   useEffect(() => () => artifactPanelResizeCleanupRef.current?.(), []);
-  const messageBlocks = useAnimationFrameValue(blocks);
   const rawPendingApproval = useMemo(
-    () => extractPendingPermission(messageBlocks),
-    [messageBlocks],
+    () => extractPendingPermission(blocks),
+    [blocks],
   );
   const pendingApproval = useShallowMemo(rawPendingApproval);
   const canActOnPendingApproval = !(
@@ -2614,10 +2611,6 @@ export function App({
     },
   });
   const composerTextRef = useRef('');
-  const composerTextDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
-  const [composerText, setComposerText] = useState('');
   const [hasComposerAttachments, setHasComposerAttachments] = useState<
     boolean | null
   >(null);
@@ -5167,25 +5160,6 @@ export function App({
   const handleOpenExistingWorkspace = useCallback(() => {
     setShowAddWorkspaceDialog(true);
   }, []);
-  useEffect(
-    () => () => {
-      if (composerTextDebounceRef.current) {
-        clearTimeout(composerTextDebounceRef.current);
-      }
-    },
-    [],
-  );
-
-  const handleComposerTextChange = useCallback((text: string) => {
-    composerTextRef.current = text;
-    if (composerTextDebounceRef.current) {
-      clearTimeout(composerTextDebounceRef.current);
-    }
-    composerTextDebounceRef.current = setTimeout(() => {
-      setComposerText(text);
-      composerTextDebounceRef.current = null;
-    }, 120);
-  }, []);
 
   const handleComposerAttachmentsChange = useCallback(
     (hasAttachments: boolean) => {
@@ -5196,12 +5170,12 @@ export function App({
 
   const {
     suggestion: newSessionSuggestion,
+    updateInput: updateNewSessionSuggestionInput,
     dismiss: dismissNewSessionSuggestion,
     suppress: suppressNewSessionSuggestion,
   } = useNewSessionSuggestion({
     enabled:
       connection.capabilities?.features.includes('session_generation') === true,
-    inputText: composerText,
     messages,
     sessionId: connection.sessionId,
     contextUsageRatio:
@@ -5213,6 +5187,14 @@ export function App({
     hasAttachments: hasComposerAttachments,
     generateContent: sessionActions.generateSessionContent,
   });
+
+  const handleComposerTextChange = useCallback(
+    (text: string) => {
+      composerTextRef.current = text;
+      updateNewSessionSuggestionInput(text);
+    },
+    [updateNewSessionSuggestionInput],
+  );
 
   const flushPendingNewSessionSuggestionSubmit = useCallback(
     (expectedToken?: number) => {

--- a/packages/web-shell/client/completions/slashCompletion.test.ts
+++ b/packages/web-shell/client/completions/slashCompletion.test.ts
@@ -303,6 +303,24 @@ describe('getSlashCommandCompletionResult', () => {
       '/demo:ping',
     ]);
   });
+
+  it('limits the rendered command menu while keeping search available', () => {
+    const commands = Array.from({ length: 1_000 }, (_, index) => ({
+      name: `command-${index}`,
+      description: `Command ${index}`,
+      source: 'builtin-command' as const,
+    }));
+
+    const browsing = getSlashCommandCompletionResult('/', 1, commands);
+    const searching = getSlashCommandCompletionResult(
+      '/command-999',
+      12,
+      commands,
+    );
+
+    expect(browsing?.items).toHaveLength(50);
+    expect(searching?.items[0]?.label).toBe('/command-999');
+  });
 });
 
 describe('slashCompletionSource', () => {

--- a/packages/web-shell/client/completions/slashCompletion.ts
+++ b/packages/web-shell/client/completions/slashCompletion.ts
@@ -231,6 +231,7 @@ const COMMAND_SECTION_KEYS: Record<CommandDisplayCategory, string> = {
   skill: 'slash.category.skill',
   system: 'slash.category.system',
 };
+const COMPLETION_ITEM_LIMIT = 50;
 
 function renderCommandSectionHeader(section: CompletionSection): HTMLElement {
   const header = document.createElement('completion-section');
@@ -456,16 +457,18 @@ export function getSlashCommandCompletionResult(
         currentTyping ? comparePrefixFirst(a.name, b.name, lp) : 0,
       );
     const isSkillList = cmdName === 'skills' && completedParts.length === 0;
-    const items = filteredNodes.map((node): SlashCommandCompletionItem => {
-      const command = `${prefix}${node.name}`;
-      return {
-        id: command,
-        label: node.name,
-        detail: node.description || undefined,
-        apply: `${command} `,
-        ...(isSkillList ? { type: 'skill' as const } : {}),
-      };
-    });
+    const items = filteredNodes
+      .slice(0, COMPLETION_ITEM_LIMIT)
+      .map((node): SlashCommandCompletionItem => {
+        const command = `${prefix}${node.name}`;
+        return {
+          id: command,
+          label: node.name,
+          detail: node.description || undefined,
+          apply: `${command} `,
+          ...(isSkillList ? { type: 'skill' as const } : {}),
+        };
+      });
 
     if (items.length === 0) return null;
     return {
@@ -491,27 +494,29 @@ export function getSlashCommandCompletionResult(
       )
     : fuzzyRankCommands(commands, prefix);
 
-  const items = filteredCommands.map((command): SlashCommandCompletionItem => {
-    const apply = `/${command.name} `;
-    const category = getCommandDisplayCategory(command);
-    const showCommandInfo = category === 'custom' || category === 'skill';
-    return {
-      id: command.name,
-      label: `/${command.name}`,
-      detail: command.description || undefined,
-      apply,
-      category,
-      // Section headers only make sense while browsing the category-ordered
-      // list; a relevance-ranked result set interleaves categories, so headers
-      // would appear before nearly every row. Drop them during search.
-      ...(isBrowsing
-        ? { section: translate(COMMAND_SECTION_KEYS[category]) }
-        : {}),
-      ...(showCommandInfo && command.description
-        ? { type: 'command-info' as const }
-        : {}),
-    };
-  });
+  const items = filteredCommands
+    .slice(0, COMPLETION_ITEM_LIMIT)
+    .map((command): SlashCommandCompletionItem => {
+      const apply = `/${command.name} `;
+      const category = getCommandDisplayCategory(command);
+      const showCommandInfo = category === 'custom' || category === 'skill';
+      return {
+        id: command.name,
+        label: `/${command.name}`,
+        detail: command.description || undefined,
+        apply,
+        category,
+        // Section headers only make sense while browsing the category-ordered
+        // list; a relevance-ranked result set interleaves categories, so headers
+        // would appear before nearly every row. Drop them during search.
+        ...(isBrowsing
+          ? { section: translate(COMMAND_SECTION_KEYS[category]) }
+          : {}),
+        ...(showCommandInfo && command.description
+          ? { type: 'command-info' as const }
+          : {}),
+      };
+    });
 
   if (items.length === 0) return null;
   return {

--- a/packages/web-shell/client/components/ChatEditor.module.css
+++ b/packages/web-shell/client/components/ChatEditor.module.css
@@ -863,6 +863,7 @@
    16px font size is mandatory: iOS Safari auto-zooms the page when focusing
    any input with a smaller font. */
 .mobileTextarea {
+  field-sizing: content;
   width: 100%;
   min-height: var(--chat-editor-input-min-height, 44px);
   max-height: var(--chat-editor-input-max-height, 300px);

--- a/packages/web-shell/client/components/ChatPane.test.tsx
+++ b/packages/web-shell/client/components/ChatPane.test.tsx
@@ -106,6 +106,11 @@ vi.mock('../hooks/useQueuedPrompts', () => ({
 let messagesState: any[];
 vi.mock('../hooks/useMessages', () => ({
   useMessages: () => messagesState,
+  useMessagesFromBlocks: () => messagesState,
+}));
+
+vi.mock('../hooks/useAnimationFrameTranscriptBlocks', () => ({
+  useAnimationFrameTranscriptBlocks: () => [],
 }));
 
 vi.mock('../adapters/transcriptAdapter', () => ({

--- a/packages/web-shell/client/components/ChatPane.tsx
+++ b/packages/web-shell/client/components/ChatPane.tsx
@@ -11,7 +11,6 @@ import {
   useConnection,
   useDaemonFollowupSuggestion,
   useStreamingState,
-  useTranscriptBlocks,
   useTranscriptHistory,
   useTranscriptStore,
   useWorkspace,
@@ -27,7 +26,8 @@ import { SubagentDetailsProvider } from '../subagentDetailsContext';
 import { useI18n } from '../i18n';
 import { useWebShellCustomization } from '../customization';
 import { SESSION_TRANSCRIPT_PAGINATION_FEATURE } from '../constants/sessions';
-import { useMessages } from '../hooks/useMessages';
+import { useAnimationFrameTranscriptBlocks } from '../hooks/useAnimationFrameTranscriptBlocks';
+import { useMessagesFromBlocks } from '../hooks/useMessages';
 import { useSessionArtifacts } from '../hooks/useSessionArtifacts';
 import { extractPendingPermission } from '../adapters/transcriptAdapter';
 import type { PromptImage } from '../adapters/promptTypes';
@@ -156,8 +156,8 @@ export function ChatPane({
   const actions = useActions();
   const workspaceActions = useWorkspaceActions();
   const workspace = useWorkspace();
-  const messages = useMessages(t);
-  const blocks = useTranscriptBlocks();
+  const blocks = useAnimationFrameTranscriptBlocks();
+  const messages = useMessagesFromBlocks(t, blocks);
   const transcriptHistory = useTranscriptHistory();
   const store = useTranscriptStore();
   const streamingState = useStreamingState();

--- a/packages/web-shell/client/extensions/inputHighlight.test.ts
+++ b/packages/web-shell/client/extensions/inputHighlight.test.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EditorState } from '@codemirror/state';
+import type { EditorView } from '@codemirror/view';
+import { describe, expect, it, vi } from 'vitest';
+import { buildInputHighlightDecorations } from './inputHighlight';
+
+describe('inputHighlight', () => {
+  it('scans visible lines instead of the entire composer document', () => {
+    const state = EditorState.create({
+      doc: `${Array.from({ length: 10_000 }, () => '@hidden').join('\n')}\n/final`,
+    });
+    const lastLine = state.doc.line(state.doc.lines);
+    const view = {
+      state,
+      visibleRanges: [{ from: lastLine.from, to: lastLine.to }],
+    } as EditorView;
+    const getCommands = vi.fn(() => []);
+
+    const decorations = buildInputHighlightDecorations(
+      view,
+      getCommands,
+      () => 'en',
+    );
+
+    expect(getCommands).toHaveBeenCalledOnce();
+    expect(decorations.size).toBe(1);
+  });
+});

--- a/packages/web-shell/client/extensions/inputHighlight.ts
+++ b/packages/web-shell/client/extensions/inputHighlight.ts
@@ -35,7 +35,7 @@ class SlashArgumentHintWidget extends WidgetType {
   }
 }
 
-function buildDecorations(
+export function buildInputHighlightDecorations(
   view: EditorView,
   getCommands: () => CommandInfo[],
   getLanguage: () => WebShellLanguage,
@@ -43,55 +43,65 @@ function buildDecorations(
   const builder = new RangeSetBuilder<Decoration>();
   const doc = view.state.doc;
   const ranges: Array<{ from: number; to: number; deco: Decoration }> = [];
+  let lastProcessedLine = 0;
+  let commands: CommandInfo[] | null = null;
+  let language: WebShellLanguage | null = null;
 
-  for (let i = 1; i <= doc.lines; i++) {
-    const line = doc.line(i);
-    const text = line.text;
-    const offset = line.from;
+  for (const visibleRange of view.visibleRanges) {
+    const firstLine = doc.lineAt(visibleRange.from).number;
+    const lastLine = doc.lineAt(visibleRange.to).number;
+    for (let i = firstLine; i <= lastLine; i++) {
+      if (i <= lastProcessedLine) continue;
+      lastProcessedLine = i;
+      const line = doc.line(i);
+      const text = line.text;
+      const offset = line.from;
 
-    // /command at start of line
-    if (text.startsWith('/')) {
-      const end = text.indexOf(' ');
-      const slashEnd = end === -1 ? text.length : end;
-      ranges.push({ from: offset, to: offset + slashEnd, deco: slashDeco });
-    }
+      // /command at start of line
+      if (text.startsWith('/')) {
+        const end = text.indexOf(' ');
+        const slashEnd = end === -1 ? text.length : end;
+        ranges.push({ from: offset, to: offset + slashEnd, deco: slashDeco });
+        commands ??= getCommands();
+        language ??= getLanguage();
+        const argumentHint = getSlashCommandArgumentHint(
+          text,
+          commands,
+          language,
+        );
+        if (argumentHint) {
+          const prefix = text.endsWith(' ') ? '' : ' ';
+          ranges.push({
+            from: offset + text.length,
+            to: offset + text.length,
+            deco: Decoration.widget({
+              widget: new SlashArgumentHintWidget(`${prefix}${argumentHint}`),
+              side: 1,
+            }),
+          });
+        }
+      }
 
-    const argumentHint = getSlashCommandArgumentHint(
-      text,
-      getCommands(),
-      getLanguage(),
-    );
-    if (argumentHint) {
-      const prefix = text.endsWith(' ') ? '' : ' ';
-      ranges.push({
-        from: offset + text.length,
-        to: offset + text.length,
-        deco: Decoration.widget({
-          widget: new SlashArgumentHintWidget(`${prefix}${argumentHint}`),
-          side: 1,
-        }),
-      });
-    }
+      // @path tokens
+      const atRe = /@[^\s]+/g;
+      let m: RegExpExecArray | null;
+      while ((m = atRe.exec(text)) !== null) {
+        ranges.push({
+          from: offset + m.index,
+          to: offset + m.index + m[0].length,
+          deco: atDeco,
+        });
+      }
 
-    // @path tokens
-    const atRe = /@[^\s]+/g;
-    let m: RegExpExecArray | null;
-    while ((m = atRe.exec(text)) !== null) {
-      ranges.push({
-        from: offset + m.index,
-        to: offset + m.index + m[0].length,
-        deco: atDeco,
-      });
-    }
-
-    // `inline code`
-    const codeRe = /`[^`]+`/g;
-    while ((m = codeRe.exec(text)) !== null) {
-      ranges.push({
-        from: offset + m.index,
-        to: offset + m.index + m[0].length,
-        deco: backtickDeco,
-      });
+      // `inline code`
+      const codeRe = /`[^`]+`/g;
+      while ((m = codeRe.exec(text)) !== null) {
+        ranges.push({
+          from: offset + m.index,
+          to: offset + m.index + m[0].length,
+          deco: backtickDeco,
+        });
+      }
     }
   }
 
@@ -111,11 +121,15 @@ export function inputHighlight(
     class {
       decorations: DecorationSet;
       constructor(view: EditorView) {
-        this.decorations = buildDecorations(view, getCommands, getLanguage);
+        this.decorations = buildInputHighlightDecorations(
+          view,
+          getCommands,
+          getLanguage,
+        );
       }
       update(update: ViewUpdate) {
         if (update.docChanged || update.viewportChanged) {
-          this.decorations = buildDecorations(
+          this.decorations = buildInputHighlightDecorations(
             update.view,
             getCommands,
             getLanguage,

--- a/packages/web-shell/client/hooks/useAnimationFrameTranscriptBlocks.test.tsx
+++ b/packages/web-shell/client/hooks/useAnimationFrameTranscriptBlocks.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { DaemonTranscriptBlock } from '@qwen-code/sdk/daemon';
+import { useAnimationFrameTranscriptBlocks } from './useAnimationFrameTranscriptBlocks';
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+const testStore = vi.hoisted(() => {
+  let blocks: readonly DaemonTranscriptBlock[] = [];
+  const listeners = new Set<() => void>();
+  return {
+    getSnapshot: () => ({ blocks }),
+    subscribe: (listener: () => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    update(nextBlocks: readonly DaemonTranscriptBlock[]) {
+      blocks = nextBlocks;
+      listeners.forEach((listener) => listener());
+    },
+    reset() {
+      blocks = [];
+      listeners.clear();
+    },
+  };
+});
+
+vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
+  useTranscriptStore: () => testStore,
+}));
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+let renderCount = 0;
+let latestBlocks: readonly DaemonTranscriptBlock[] = [];
+
+function Harness() {
+  latestBlocks = useAnimationFrameTranscriptBlocks();
+  renderCount += 1;
+  return null;
+}
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+  renderCount = 0;
+  latestBlocks = [];
+  testStore.reset();
+  vi.restoreAllMocks();
+});
+
+describe('useAnimationFrameTranscriptBlocks', () => {
+  it('coalesces transcript notifications into one render per frame', () => {
+    let pendingFrame: FrameRequestCallback | null = null;
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      pendingFrame = callback;
+      return 1;
+    });
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+    act(() => root!.render(<Harness />));
+    const initialRenderCount = renderCount;
+
+    act(() => {
+      for (let index = 1; index <= 100; index++) {
+        testStore.update(
+          Array.from({ length: index }, () => ({}) as DaemonTranscriptBlock),
+        );
+      }
+    });
+
+    expect(renderCount).toBe(initialRenderCount);
+    expect(pendingFrame).not.toBeNull();
+
+    act(() => {
+      pendingFrame?.(performance.now());
+    });
+
+    expect(renderCount).toBe(initialRenderCount + 1);
+    expect(latestBlocks).toHaveLength(100);
+  });
+
+  it('cancels a pending frame on unmount', () => {
+    vi.spyOn(window, 'requestAnimationFrame').mockReturnValue(7);
+    const cancelFrame = vi.spyOn(window, 'cancelAnimationFrame');
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+    act(() => root!.render(<Harness />));
+    act(() => testStore.update([{} as DaemonTranscriptBlock]));
+
+    act(() => root!.unmount());
+    root = null;
+
+    expect(cancelFrame).toHaveBeenCalledWith(7);
+  });
+});

--- a/packages/web-shell/client/hooks/useAnimationFrameTranscriptBlocks.ts
+++ b/packages/web-shell/client/hooks/useAnimationFrameTranscriptBlocks.ts
@@ -1,0 +1,28 @@
+import { useCallback, useSyncExternalStore } from 'react';
+import type { DaemonTranscriptBlock } from '@qwen-code/sdk/daemon';
+import { useTranscriptStore } from '@qwen-code/webui/daemon-react-sdk';
+
+export function useAnimationFrameTranscriptBlocks(): readonly DaemonTranscriptBlock[] {
+  const store = useTranscriptStore();
+  const subscribe = useCallback(
+    (notify: () => void) => {
+      let frame: number | null = null;
+      const unsubscribe = store.subscribe(() => {
+        if (frame !== null) return;
+        frame = window.requestAnimationFrame(() => {
+          frame = null;
+          notify();
+        });
+      });
+      return () => {
+        unsubscribe();
+        if (frame !== null) {
+          window.cancelAnimationFrame(frame);
+        }
+      };
+    },
+    [store],
+  );
+  const getSnapshot = useCallback(() => store.getSnapshot().blocks, [store]);
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}

--- a/packages/web-shell/client/hooks/useAtMentionMenu.test.tsx
+++ b/packages/web-shell/client/hooks/useAtMentionMenu.test.tsx
@@ -172,6 +172,23 @@ describe('useAtMentionMenu', () => {
     ]);
   });
 
+  it('reuses an unchanged category menu and limits rendered providers', () => {
+    const providers = Array.from({ length: 100 }, (_, index) => ({
+      id: `custom-${index}`,
+      label: `Custom ${index}`,
+      search: vi.fn().mockResolvedValue([]),
+    }));
+    mount({ builtinProviders: false, providers });
+    const view = makeView('@');
+
+    act(() => latest!.refreshForView(view));
+    const firstState = latest!.state;
+    act(() => latest!.refreshForView(view));
+
+    expect(latest!.state).toBe(firstState);
+    expect(latest!.state?.providers).toHaveLength(50);
+  });
+
   it('rejects custom providers that reuse built-in ids', () => {
     const error = vi.spyOn(console, 'error').mockImplementation(() => {});
     mount({

--- a/packages/web-shell/client/hooks/useAtMentionMenu.ts
+++ b/packages/web-shell/client/hooks/useAtMentionMenu.ts
@@ -193,6 +193,52 @@ const ANSI_RE = new RegExp(`${ESC}(?:[@-Z\\\\-_]|\\[[0-?]*[ -/]*[@-~])`, 'g');
 const BIDI_CONTROL_RE = /[\u200B\u200E\u200F\u061C\u2066-\u2069\u202A-\u202E]/g;
 const SAFE_DISPLAY_FALLBACK = '[invalid]';
 const AT_REFERENCE_UNSAFE_CHARS = /[^\p{L}\p{N}_./-]/gu;
+
+function shallowEqualMenuState(
+  current: AtMentionMenuState | null,
+  next: AtMentionMenuState | null,
+): boolean {
+  if (current === next) return true;
+  if (!current || !next) return false;
+  const keys = Object.keys(current) as Array<keyof AtMentionMenuState>;
+  return (
+    keys.length === Object.keys(next).length &&
+    keys.every((key) => {
+      const currentValue = current[key];
+      const nextValue = next[key];
+      if (Object.is(currentValue, nextValue)) return true;
+      return (
+        Array.isArray(currentValue) &&
+        Array.isArray(nextValue) &&
+        currentValue.length === nextValue.length &&
+        currentValue.every((value, index) => Object.is(value, nextValue[index]))
+      );
+    })
+  );
+}
+
+function equalProviderViews(
+  current: readonly AtMentionProviderView[],
+  next: readonly AtMentionProviderView[],
+): boolean {
+  return (
+    current.length === next.length &&
+    current.every((provider, index) => {
+      const nextProvider = next[index];
+      return (
+        nextProvider !== undefined &&
+        provider.id === nextProvider.id &&
+        provider.textValue === nextProvider.textValue &&
+        Object.is(provider.label, nextProvider.label) &&
+        provider.description === nextProvider.description &&
+        provider.tabs === nextProvider.tabs &&
+        provider.selectedTabId === nextProvider.selectedTabId &&
+        provider.renderItem === nextProvider.renderItem
+      );
+    })
+  );
+}
+
 function isBuiltinProviderId(providerId: string): boolean {
   return BUILTIN_PROVIDER_IDS.includes(
     providerId as WebShellBuiltinAtProviderId,
@@ -934,6 +980,7 @@ export function useAtMentionMenu({
     (next: SetStateAction<AtMentionMenuState | null>) => {
       const resolved =
         typeof next === 'function' ? next(stateRef.current) : next;
+      if (shallowEqualMenuState(stateRef.current, resolved)) return;
       stateRef.current = resolved;
       setState(resolved);
     },
@@ -964,6 +1011,16 @@ export function useAtMentionMenu({
 
   const close = useCallback(
     (options: { preserveProviderSelection?: boolean } = {}) => {
+      if (
+        stateRef.current === null &&
+        abortRef.current === null &&
+        searchTimerRef.current === null &&
+        lastSelectedProviderIdRef.current === null &&
+        lastSelectedMcpServerNameRef.current === null &&
+        !preserveProviderSelectionRef.current
+      ) {
+        return;
+      }
       clearPendingLoad();
       builtinCacheRef.current = createBuiltinProviderCache();
       const preserveSelection =
@@ -1422,13 +1479,24 @@ export function useAtMentionMenu({
         });
         return true;
       }
-      const filteredProviders = providerViewsRef.current.filter((provider) => {
-        return matchesQuery(
-          parsed.query,
-          provider.textValue,
-          provider.description,
-        );
-      });
+      const filteredProviders = providerViewsRef.current
+        .filter((provider) => {
+          return matchesQuery(
+            parsed.query,
+            provider.textValue,
+            provider.description,
+          );
+        })
+        .slice(0, ITEM_LIMIT);
+      if (
+        current?.level === 'categories' &&
+        current.from === parsed.from &&
+        current.to === parsed.to &&
+        current.query === parsed.query &&
+        equalProviderViews(current.providers, filteredProviders)
+      ) {
+        return true;
+      }
       if (filteredProviders.length === 0 && parsed.query) {
         const insertedReference = splitInsertedReferenceQuery(
           parsed.query,

--- a/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
+++ b/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
@@ -31,6 +31,7 @@ function Harness({
   followupState,
   sessionId,
   atWorkspaceCwd,
+  commands,
 }: {
   composerInput?: WebShellComposerInput;
   onSubmit: ReturnType<typeof vi.fn>;
@@ -44,10 +45,11 @@ function Harness({
   };
   sessionId?: string;
   atWorkspaceCwd?: string;
+  commands?: UseComposerCoreOptions['commands'];
 }) {
   const composer = useComposerCore({
     onSubmit,
-    commands: [],
+    commands: commands ?? [],
     editorTheme: {},
     renderComposerTag,
     renderComposerTagTooltip,
@@ -72,6 +74,7 @@ async function mount({
   followupState,
   sessionId,
   atWorkspaceCwd,
+  commands,
 }: {
   composerInput?: WebShellComposerInput;
   onSubmit?: ReturnType<typeof vi.fn>;
@@ -85,6 +88,7 @@ async function mount({
   };
   sessionId?: string;
   atWorkspaceCwd?: string;
+  commands?: UseComposerCoreOptions['commands'];
 } = {}) {
   container = document.createElement('div');
   document.body.append(container);
@@ -106,6 +110,7 @@ async function mount({
             followupState={followupState}
             sessionId={currentSessionId}
             atWorkspaceCwd={currentWorkspaceCwd}
+            commands={commands}
           />
         </I18nProvider>
       </WebShellPortalRootContext.Provider>,
@@ -204,6 +209,41 @@ describe('useComposerCore tooltip portal', () => {
 });
 
 describe('useComposerCore history and drafts', () => {
+  it('does not serialize the whole document again for a slash menu refresh', async () => {
+    await mount();
+    const doc = latest!.viewRef.current!.state.doc;
+    const textPrototype = Object.getPrototypeOf(
+      Object.getPrototypeOf(doc),
+    ) as typeof doc;
+    const toString = vi.spyOn(textPrototype, 'toString');
+
+    act(() =>
+      latest!.setText(
+        `${Array.from({ length: 10_000 }, () => 'draft').join('\n')}\n/`,
+      ),
+    );
+
+    expect(toString).toHaveBeenCalledOnce();
+  });
+
+  it('keeps slash completion replacement coordinates absolute', async () => {
+    await mount({
+      commands: [
+        {
+          name: 'help',
+          description: 'Show help',
+          source: 'builtin-command',
+        },
+      ],
+    });
+
+    act(() => latest!.setText('context\n/he'));
+
+    expect(latest!.slashMenu).toMatchObject({ from: 8, to: 11 });
+    act(() => latest!.acceptSlashCompletion());
+    expect(latest!.getText()).toBe('context\n/help ');
+  });
+
   it('does not reread history storage on unrelated rerenders', async () => {
     const getItem = vi.spyOn(Storage.prototype, 'getItem');
     const mounted = await mount({
@@ -899,6 +939,27 @@ describe('useComposerCore tags', () => {
       latest!.removeInlineTags();
     });
     expect(latest!.handle.hasAttachments()).toBe(false);
+    expect(latest!.hasAttachments).toBe(false);
+  });
+
+  it('updates inline tag state when a document change removes the last tag', async () => {
+    await mount();
+
+    act(() => {
+      latest!.addTags(
+        [{ id: 'orders', value: 'orders', serialized: '@orders' }],
+        { placement: 'inline' },
+      );
+    });
+    expect(latest!.hasAttachments).toBe(true);
+
+    const view = latest!.viewRef.current!;
+    act(() => {
+      view.dispatch({
+        changes: { from: 0, to: view.state.doc.length, insert: '' },
+      });
+    });
+
     expect(latest!.hasAttachments).toBe(false);
   });
 

--- a/packages/web-shell/client/hooks/useComposerCore.mobile.dom.test.tsx
+++ b/packages/web-shell/client/hooks/useComposerCore.mobile.dom.test.tsx
@@ -157,6 +157,7 @@ afterEach(() => {
     delete (navigator as unknown as Record<string, unknown>)['maxTouchPoints'];
   }
   window.history.replaceState({}, '', '/');
+  vi.restoreAllMocks();
 });
 
 describe('useComposerCore mobile textarea backend', () => {
@@ -194,6 +195,29 @@ describe('useComposerCore mobile textarea backend', () => {
     expect(onInputTextChange).toHaveBeenCalledWith('hello');
     typeText('');
     expect(latest!.hasContent).toBe(false);
+  });
+
+  it('reads the textarea height cap once instead of on every input', async () => {
+    mockTouchDevice();
+    const getComputedStyle = window.getComputedStyle.bind(window);
+    let textareaStyleReads = 0;
+    const styleSpy = vi
+      .spyOn(window, 'getComputedStyle')
+      .mockImplementation((element, pseudoElement) => {
+        if (element instanceof HTMLTextAreaElement) {
+          textareaStyleReads += 1;
+        }
+        return getComputedStyle(element, pseudoElement);
+      });
+
+    await mount();
+    const initialStyleReads = textareaStyleReads;
+    typeText('one');
+    typeText('one two');
+    typeText('one two three');
+
+    expect(textareaStyleReads).toBe(initialStyleReads);
+    styleSpy.mockRestore();
   });
 
   it('submits through the shared pipeline and clears the draft', async () => {

--- a/packages/web-shell/client/hooks/useComposerCore.ts
+++ b/packages/web-shell/client/hooks/useComposerCore.ts
@@ -1,5 +1,6 @@
 import {
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   useCallback,
@@ -936,6 +937,17 @@ export function getInlineComposerTags(view: EditorView): WebShellComposerTag[] {
   return tags;
 }
 
+function hasInlineComposerTags(view: EditorView): boolean {
+  const tags = view.state.field(inlineComposerTagField, false);
+  if (!tags) return false;
+  let hasTags = false;
+  tags.between(0, view.state.doc.length, () => {
+    hasTags = true;
+    return false;
+  });
+  return hasTags;
+}
+
 function getInlineComposerTagPlacements(
   view: EditorView,
 ): InlineTagPlacement[] {
@@ -1173,6 +1185,35 @@ export interface SlashMenuState extends SlashCommandCompletionResult {
   selectedIndex: number;
 }
 
+function shallowEqualSlashMenu(
+  current: SlashMenuState | null,
+  next: SlashMenuState | null,
+): boolean {
+  if (current === next) return true;
+  if (!current || !next) return false;
+  const keys = Object.keys(current) as Array<keyof SlashMenuState>;
+  return (
+    keys.length === Object.keys(next).length &&
+    keys.every((key) => {
+      if (key !== 'items') return Object.is(current[key], next[key]);
+      return (
+        current.items.length === next.items.length &&
+        current.items.every((item, index) => {
+          const nextItem = next.items[index];
+          if (!nextItem) return false;
+          const itemKeys = Object.keys(item) as Array<keyof typeof item>;
+          return (
+            itemKeys.length === Object.keys(nextItem).length &&
+            itemKeys.every((itemKey) =>
+              Object.is(item[itemKey], nextItem[itemKey]),
+            )
+          );
+        })
+      );
+    })
+  );
+}
+
 type MultilineHistoryBoundary = 'editor' | 'handled' | 'history';
 
 function handleMultilineHistoryBoundary(
@@ -1371,6 +1412,7 @@ export function useComposerCore(
   // mirrored into a ref so submit/getText read synchronously.
   const isTouchComposer = useIsTouchComposer();
   const mobileTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const mobileMaxHeightRef = useRef<number | null>(null);
   const [mobileText, setMobileTextState] = useState(() =>
     isTouchComposer ? (loadComposerDraft(composerDraftStorageKey) ?? '') : '',
   );
@@ -1610,6 +1652,7 @@ export function useComposerCore(
   const composerTagsRef = useRef<WebShellComposerTag[]>([]);
   composerTagsRef.current = composerTags;
   const [hasInlineTags, setHasInlineTags] = useState(false);
+  const hasInlineTagsRef = useRef(false);
   const historyDraftComposerTagsRef = useRef<WebShellComposerTag[] | null>(
     null,
   );
@@ -1804,6 +1847,7 @@ export function useComposerCore(
   }, []);
 
   const setSlashMenu = useCallback((next: SlashMenuState | null) => {
+    if (shallowEqualSlashMenu(slashMenuRef.current, next)) return;
     slashMenuRef.current = next;
     setSlashMenuState(next);
   }, []);
@@ -1862,19 +1906,29 @@ export function useComposerCore(
         setSlashMenu(null);
         return;
       }
-      const result = getSlashCommandCompletionResult(
-        view.state.doc.toString(),
-        selection.head,
+      const line = view.state.doc.lineAt(selection.head);
+      if (!line.text.startsWith('/')) {
+        setSlashMenu(null);
+        return;
+      }
+      const relativeResult = getSlashCommandCompletionResult(
+        line.text,
+        selection.head - line.from,
         commandsRef.current,
         skillsRef.current,
         languageRef.current,
         (key) => tRef.current(key),
         slashCommandCategoryOrderRef.current ?? DEFAULT_COMMAND_CATEGORY_ORDER,
       );
-      if (!result) {
+      if (!relativeResult) {
         setSlashMenu(null);
         return;
       }
+      const result = {
+        ...relativeResult,
+        from: line.from + relativeResult.from,
+        to: line.from + relativeResult.to,
+      };
       closeAtMenu();
       const currentIndex =
         preferredIndex ?? slashMenuRef.current?.selectedIndex ?? 0;
@@ -1937,6 +1991,12 @@ export function useComposerCore(
 
   // Track whether editor has content for send button state
   const [hasContent, setHasContent] = useState(false);
+  const hasContentRef = useRef(false);
+  const updateHasContent = useCallback((next: boolean) => {
+    if (hasContentRef.current === next) return;
+    hasContentRef.current = next;
+    setHasContent(next);
+  }, []);
 
   // Update hasContent when tags or images change
   useEffect(() => {
@@ -1946,7 +2006,7 @@ export function useComposerCore(
       text,
       followupState?.isVisible ? followupState.suggestion : null,
     );
-    setHasContent(
+    updateHasContent(
       text.trim().length > 0 ||
         !!followupCompletion ||
         composerTags.length > 0 ||
@@ -1958,6 +2018,7 @@ export function useComposerCore(
     mobileText,
     followupState?.isVisible,
     followupState?.suggestion,
+    updateHasContent,
   ]);
 
   const promptHistory = useInputHistory(
@@ -2100,6 +2161,15 @@ export function useComposerCore(
     [setMobileText],
   );
 
+  useLayoutEffect(() => {
+    if (!isTouchComposer) return;
+    const el = mobileTextareaRef.current;
+    if (!el) return;
+    const cap = parseFloat(getComputedStyle(el).maxHeight);
+    mobileMaxHeightRef.current =
+      Number.isFinite(cap) && cap > 0 ? cap : Number.POSITIVE_INFINITY;
+  }, [isTouchComposer]);
+
   // Auto-grow the mobile textarea with its content, capped by the CSS
   // max-height (the cap is read from the computed style so a deployment
   // overriding --chat-editor-input-max-height stays authoritative). Without
@@ -2108,13 +2178,17 @@ export function useComposerCore(
     if (!isTouchComposer) return;
     const el = mobileTextareaRef.current;
     if (!el) return;
+    if (
+      typeof CSS !== 'undefined' &&
+      CSS.supports?.('field-sizing', 'content')
+    ) {
+      el.style.height = '';
+      return;
+    }
     el.style.height = 'auto';
     if (el.scrollHeight > 0) {
-      const cap = parseFloat(getComputedStyle(el).maxHeight);
-      const next =
-        Number.isFinite(cap) && cap > 0
-          ? Math.min(el.scrollHeight, cap)
-          : el.scrollHeight;
+      const cap = mobileMaxHeightRef.current ?? Number.POSITIVE_INFINITY;
+      const next = Math.min(el.scrollHeight, cap);
       el.style.height = `${next}px`;
     }
   }, [isTouchComposer, mobileText]);
@@ -2442,7 +2516,7 @@ export function useComposerCore(
           }
           if (completionStatus(view.state) === 'active') return false;
           const followup = followupStateRef.current;
-          const hasInlineTags = getInlineComposerTags(view).length > 0;
+          const hasInlineTags = hasInlineComposerTags(view);
           const followupCompletion = hasInlineTags
             ? null
             : getFollowupCompletion(
@@ -2828,7 +2902,23 @@ export function useComposerCore(
         triggerCleanupListener,
         // Update hasContent state when document changes
         EditorView.updateListener.of((update) => {
-          setHasInlineTags(getInlineComposerTags(update.view).length > 0);
+          const inlineTagsChanged =
+            update.docChanged ||
+            update.transactions.some((transaction) =>
+              transaction.effects.some(
+                (effect) =>
+                  effect.is(addInlineTagEffect) ||
+                  effect.is(removeInlineTagEffect) ||
+                  effect.is(clearInlineTagsEffect),
+              ),
+            );
+          if (inlineTagsChanged) {
+            const nextHasInlineTags = hasInlineComposerTags(update.view);
+            if (hasInlineTagsRef.current !== nextHasInlineTags) {
+              hasInlineTagsRef.current = nextHasInlineTags;
+              setHasInlineTags(nextHasInlineTags);
+            }
+          }
           if (update.docChanged) {
             const text = getDocText(update.state);
             if (draftIdentityRef.current.storageKey === undefined) {
@@ -2843,7 +2933,7 @@ export function useComposerCore(
               text,
               followup?.isVisible ? followup.suggestion : null,
             );
-            setHasContent(
+            updateHasContent(
               text.trim().length > 0 ||
                 !!followupCompletion ||
                 composerTagsRef.current.length > 0 ||
@@ -2960,7 +3050,7 @@ export function useComposerCore(
     if (initialTextValue) {
       onInputTextChangeRef.current?.(initialTextValue);
     }
-    setHasContent(
+    updateHasContent(
       initialText.length > 0 ||
         composerTagsRef.current.length > 0 ||
         pastedImagesRef.current.length > 0,

--- a/packages/web-shell/client/hooks/useMessages.ts
+++ b/packages/web-shell/client/hooks/useMessages.ts
@@ -142,8 +142,10 @@ export function reconcileBackgroundAgentResolutions(
   return changed ? reconciled : messages;
 }
 
-export function useMessages(t: Translator): Message[] {
-  const blocks = useTranscriptBlocks();
+export function useMessagesFromBlocks(
+  t: Translator,
+  blocks: readonly DaemonTranscriptBlock[],
+): Message[] {
   const workspace = useWorkspace();
   const connection = useConnection();
   const messages = useMemo(
@@ -259,4 +261,9 @@ export function useMessages(t: Translator): Message[] {
       resolutionSnapshot.resolutions,
     );
   }, [connection.sessionId, messages, resolutionSnapshot]);
+}
+
+export function useMessages(t: Translator): Message[] {
+  const blocks = useTranscriptBlocks();
+  return useMessagesFromBlocks(t, blocks);
 }

--- a/packages/web-shell/client/hooks/useNewSessionSuggestion.test.tsx
+++ b/packages/web-shell/client/hooks/useNewSessionSuggestion.test.tsx
@@ -34,7 +34,11 @@ const testState = {
 };
 
 function Host() {
-  const { suggestion } = useNewSessionSuggestion(testState);
+  const { inputText, ...options } = testState;
+  const { suggestion, updateInput } = useNewSessionSuggestion(options);
+  React.useEffect(() => {
+    updateInput(inputText);
+  }, [inputText, updateInput]);
   latestSuggestion = suggestion;
   return null;
 }
@@ -164,6 +168,47 @@ describe('useNewSessionSuggestion', () => {
     await flush(3);
 
     expect(latestSuggestion).toBeNull();
+  });
+
+  it('reclassifies a preserved draft after the session changes', async () => {
+    vi.useFakeTimers();
+    testState.inputText = '帮我写一篇新的设计文档，主题是 Web Shell 新功能方案';
+    testState.messages = [
+      {
+        id: 'm-1',
+        role: 'user',
+        content: '先看一下当前实现',
+        timestamp: 1,
+      },
+      {
+        id: 'm-2',
+        role: 'assistant',
+        content: '这里是当前实现的说明',
+        timestamp: 2,
+      },
+    ] as Message[];
+    testState.generateContent.mockImplementation(async function* () {
+      yield {
+        type: 'delta',
+        requestId: 'req-1',
+        seq: 0,
+        text: JSON.stringify({
+          suggestion: 'new_session',
+          confidence: 0.9,
+        }),
+      };
+    });
+
+    await renderHost();
+    testState.sessionId = 'session-2';
+    await rerenderHost();
+    act(() => {
+      vi.advanceTimersByTime(701);
+    });
+    await flush(3);
+
+    expect(testState.generateContent).toHaveBeenCalledOnce();
+    expect(latestSuggestion?.sourceSessionId).toBe('session-2');
   });
 
   // The classifier is instructed to return JSON only, but live it sometimes

--- a/packages/web-shell/client/hooks/useNewSessionSuggestion.ts
+++ b/packages/web-shell/client/hooks/useNewSessionSuggestion.ts
@@ -66,7 +66,6 @@ export interface NewSessionSuggestionState {
 
 export interface UseNewSessionSuggestionOptions {
   enabled: boolean;
-  inputText: string;
   messages: Message[];
   sessionId?: string;
   contextUsageRatio: number;
@@ -78,6 +77,7 @@ export interface UseNewSessionSuggestionOptions {
 
 export interface UseNewSessionSuggestionReturn {
   suggestion: NewSessionSuggestionState | null;
+  updateInput: (inputText: string) => void;
   dismiss: () => void;
   suppress: () => void;
 }
@@ -192,7 +192,6 @@ function parseDecision(text: string): ComposerSuggestionDecision | null {
 
 export function useNewSessionSuggestion({
   enabled,
-  inputText,
   messages,
   sessionId,
   contextUsageRatio,
@@ -206,9 +205,31 @@ export function useNewSessionSuggestion({
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const suppressUntilRef = useRef(0);
+  const currentInputRef = useRef('');
+  const suggestionRef = useRef<NewSessionSuggestionState | null>(null);
   const latestSessionIdRef = useRef(sessionId);
 
   const recentMessages = useMemo(() => summarizeMessages(messages), [messages]);
+  const optionsRef = useRef({
+    enabled,
+    recentMessages,
+    sessionId,
+    contextUsageRatio,
+    isRunning,
+    dialogOpen,
+    hasAttachments,
+    generateContent,
+  });
+  optionsRef.current = {
+    enabled,
+    recentMessages,
+    sessionId,
+    contextUsageRatio,
+    isRunning,
+    dialogOpen,
+    hasAttachments,
+    generateContent,
+  };
 
   const clearPending = useCallback(() => {
     if (timerRef.current) {
@@ -219,135 +240,170 @@ export function useNewSessionSuggestion({
     abortRef.current = null;
   }, []);
 
-  const dismiss = useCallback(() => {
+  const clearSuggestion = useCallback(() => {
+    if (suggestionRef.current === null) return;
+    suggestionRef.current = null;
     setSuggestion(null);
+  }, []);
+
+  const dismiss = useCallback(() => {
+    clearSuggestion();
     clearPending();
-  }, [clearPending]);
+  }, [clearPending, clearSuggestion]);
 
   const suppress = useCallback(() => {
     suppressUntilRef.current = Date.now() + SUPPRESS_MS;
-    setSuggestion(null);
+    clearSuggestion();
     clearPending();
-  }, [clearPending]);
+  }, [clearPending, clearSuggestion]);
+
+  const scheduleInput = useCallback(
+    (inputText: string) => {
+      clearPending();
+      const {
+        enabled: currentEnabled,
+        recentMessages: currentRecentMessages,
+        sessionId: currentSessionId,
+        contextUsageRatio: currentContextUsageRatio,
+        isRunning: currentIsRunning,
+        dialogOpen: currentDialogOpen,
+        hasAttachments: currentHasAttachments,
+        generateContent: currentGenerateContent,
+      } = optionsRef.current;
+      if (!currentEnabled || !currentGenerateContent || !currentSessionId) {
+        clearSuggestion();
+        return;
+      }
+      const trimmed = inputText.trim();
+      if (trimmed.length < MIN_PROMPT_LENGTH) {
+        clearSuggestion();
+        return;
+      }
+      const explicitNewTaskCue = hasExplicitNewTaskCue(trimmed);
+      if (currentIsRunning || currentDialogOpen) {
+        clearSuggestion();
+        return;
+      }
+      const allowBtw =
+        currentHasAttachments === false &&
+        currentRecentMessages.length >= MIN_BTW_MESSAGE_COUNT;
+      const allowNewSession =
+        !isFollowupLike(trimmed) &&
+        (explicitNewTaskCue
+          ? currentRecentMessages.length >= MIN_EXPLICIT_CUE_MESSAGE_COUNT ||
+            currentContextUsageRatio >= MIN_EXPLICIT_CUE_CONTEXT_USAGE_RATIO
+          : currentRecentMessages.length >= MIN_MESSAGE_COUNT ||
+            currentContextUsageRatio >= MIN_CONTEXT_USAGE_RATIO);
+      if (!allowBtw && !allowNewSession) {
+        clearSuggestion();
+        return;
+      }
+      if (Date.now() < suppressUntilRef.current) {
+        clearSuggestion();
+        return;
+      }
+
+      clearSuggestion();
+      timerRef.current = setTimeout(() => {
+        const controller = new AbortController();
+        abortRef.current = controller;
+        const prompt = buildPrompt({
+          recentMessages: currentRecentMessages,
+          currentInput: trimmed,
+          contextUsageRatio: currentContextUsageRatio,
+          messageCount: currentRecentMessages.length,
+          allowBtw,
+          allowNewSession,
+        });
+        void (async () => {
+          let text = '';
+          try {
+            for await (const event of currentGenerateContent(prompt, {
+              signal: controller.signal,
+            })) {
+              if (abortRef.current !== controller) return;
+              if (event.type === 'delta') {
+                text += event.text;
+              } else if (event.type === 'error') {
+                if (abortRef.current === controller) {
+                  clearSuggestion();
+                }
+                return;
+              }
+            }
+            if (abortRef.current !== controller) return;
+            const decision = parseDecision(text.trim());
+            if (
+              decision &&
+              decision.suggestion !== 'none' &&
+              ((decision.suggestion === 'btw' && allowBtw) ||
+                (decision.suggestion === 'new_session' && allowNewSession)) &&
+              decision.confidence >= MIN_CONFIDENCE
+            ) {
+              const nextSuggestion = {
+                suggestion: decision.suggestion,
+                classifiedInput: trimmed,
+                sourceSessionId: currentSessionId,
+              } satisfies NewSessionSuggestionState;
+              suggestionRef.current = nextSuggestion;
+              setSuggestion(nextSuggestion);
+              return;
+            }
+            clearSuggestion();
+          } catch {
+            if (!controller.signal.aborted) {
+              clearSuggestion();
+            }
+          } finally {
+            if (abortRef.current === controller) {
+              abortRef.current = null;
+            }
+          }
+        })();
+      }, REQUEST_DEBOUNCE_MS);
+    },
+    [clearPending, clearSuggestion],
+  );
+
+  const updateInput = useCallback(
+    (inputText: string) => {
+      currentInputRef.current = inputText;
+      scheduleInput(inputText);
+    },
+    [scheduleInput],
+  );
 
   useEffect(() => {
     if (latestSessionIdRef.current !== sessionId) {
-      setSuggestion(null);
-      clearPending();
       latestSessionIdRef.current = sessionId;
-    }
-  }, [clearPending, sessionId]);
-
-  useEffect(() => {
-    clearPending();
-    if (!enabled || !generateContent || !sessionId) {
-      setSuggestion(null);
-      return;
-    }
-    const trimmed = inputText.trim();
-    if (trimmed.length < MIN_PROMPT_LENGTH) {
-      setSuggestion(null);
-      return;
-    }
-    const explicitNewTaskCue = hasExplicitNewTaskCue(trimmed);
-    if (isRunning || dialogOpen) {
-      setSuggestion(null);
-      return;
-    }
-    const allowBtw =
-      hasAttachments === false &&
-      recentMessages.length >= MIN_BTW_MESSAGE_COUNT;
-    const allowNewSession =
-      !isFollowupLike(trimmed) &&
-      (explicitNewTaskCue
-        ? recentMessages.length >= MIN_EXPLICIT_CUE_MESSAGE_COUNT ||
-          contextUsageRatio >= MIN_EXPLICIT_CUE_CONTEXT_USAGE_RATIO
-        : recentMessages.length >= MIN_MESSAGE_COUNT ||
-          contextUsageRatio >= MIN_CONTEXT_USAGE_RATIO);
-    if (!allowBtw && !allowNewSession) {
-      setSuggestion(null);
-      return;
-    }
-    if (Date.now() < suppressUntilRef.current) {
-      setSuggestion(null);
-      return;
-    }
-
-    setSuggestion(null);
-    timerRef.current = setTimeout(() => {
-      const controller = new AbortController();
-      abortRef.current = controller;
-      const prompt = buildPrompt({
-        recentMessages,
-        currentInput: trimmed,
-        contextUsageRatio,
-        messageCount: recentMessages.length,
-        allowBtw,
-        allowNewSession,
-      });
-      void (async () => {
-        let text = '';
-        try {
-          for await (const event of generateContent(prompt, {
-            signal: controller.signal,
-          })) {
-            if (abortRef.current !== controller) return;
-            if (event.type === 'delta') {
-              text += event.text;
-            } else if (event.type === 'error') {
-              if (abortRef.current === controller) {
-                setSuggestion(null);
-              }
-              return;
-            }
-          }
-          if (abortRef.current !== controller) return;
-          const decision = parseDecision(text.trim());
-          if (
-            decision &&
-            decision.suggestion !== 'none' &&
-            ((decision.suggestion === 'btw' && allowBtw) ||
-              (decision.suggestion === 'new_session' && allowNewSession)) &&
-            decision.confidence >= MIN_CONFIDENCE
-          ) {
-            setSuggestion({
-              suggestion: decision.suggestion,
-              classifiedInput: trimmed,
-              sourceSessionId: sessionId,
-            });
-            return;
-          }
-          setSuggestion(null);
-        } catch {
-          if (!controller.signal.aborted) {
-            setSuggestion(null);
-          }
-        } finally {
-          if (abortRef.current === controller) {
-            abortRef.current = null;
-          }
-        }
-      })();
-    }, REQUEST_DEBOUNCE_MS);
-
-    return () => {
       clearPending();
-    };
+      clearSuggestion();
+    }
+    scheduleInput(currentInputRef.current);
   }, [
     clearPending,
+    clearSuggestion,
     contextUsageRatio,
     dialogOpen,
     enabled,
     generateContent,
     hasAttachments,
-    inputText,
     isRunning,
     recentMessages,
+    scheduleInput,
     sessionId,
   ]);
 
+  useEffect(
+    () => () => {
+      clearPending();
+    },
+    [clearPending],
+  );
+
   return {
     suggestion,
+    updateInput,
     dismiss,
     suppress,
   };

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -416,6 +416,28 @@ describe('DaemonSessionProvider', () => {
     expect(blocks).toEqual([]);
   });
 
+  it('does not rerender streaming state consumers for equivalent transcript updates', async () => {
+    let store: DaemonTranscriptStore | undefined;
+    let renderCount = 0;
+
+    function Harness() {
+      store = useDaemonTranscriptStore();
+      useDaemonStreamingState();
+      renderCount += 1;
+      return null;
+    }
+
+    await renderWithProvider(<Harness />);
+    const initialRenderCount = renderCount;
+
+    act(() => {
+      store?.appendLocalUserMessage('first');
+      store?.appendLocalUserMessage('second');
+    });
+
+    expect(renderCount).toBe(initialRenderCount);
+  });
+
   it('keeps capabilities handshake failures out of the transcript', async () => {
     sdkMocks.capabilities.mockRejectedValue(
       Object.assign(new Error('GET /capabilities: HTTP 400'), { status: 400 }),

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -2932,12 +2932,16 @@ export function useDaemonActiveTodoList() {
 }
 
 export function useDaemonStreamingState() {
-  const blocks = useDaemonTranscriptBlocks();
+  const store = useDaemonTranscriptStore();
   const promptStatus = useDaemonPromptStatus();
-
-  return useMemo(
-    () => selectDaemonStreamingState(blocks, promptStatus),
-    [blocks, promptStatus],
+  const getStreamingState = useCallback(
+    () => selectDaemonStreamingState(store.getSnapshot().blocks, promptStatus),
+    [promptStatus, store],
+  );
+  return useSyncExternalStore(
+    store.subscribe,
+    getStreamingState,
+    getStreamingState,
   );
 }
 


### PR DESCRIPTION
## What this PR does

This change reduces Web Shell composer latency by coalescing streaming transcript updates to animation frames, stabilizing values passed into the editor, and avoiding repeated full-document work in slash-command, mention, highlight, and inline-tag paths. It also bounds suggestion work and preserves existing completion behavior with focused regression coverage.

## Why it's needed

Streaming responses could cause the application and composer tree to update at high frequency while the user was typing. Several editor paths also repeated work proportional to the whole draft, so long prompts and active streaming could produce visible input delay.

## Reviewer Test Plan

### How to verify

Open Web Shell with a long conversation and a long draft, start a streaming response, and continue typing while opening slash-command and mention completion. Typing, cursor movement, completion results, background-agent resolution, and new-session suggestions should remain responsive and behaviorally unchanged.

### Evidence (Before & After)

Before: streaming updates and document-wide completion/highlight work could repeatedly block composer input. After: transcript publication is frame-bounded, editor props remain stable across unrelated application updates, and hot completion paths limit work to the relevant line or changed ranges.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Focused Web Shell unit tests, TypeScript type checking, package build, and repository pre-commit formatting/lint checks.

## Risk & Scope

- Main risk or tradeoff: streaming transcript visibility may be delayed by at most one animation frame, and memoized editor inputs must continue to reflect semantic changes.
- Not validated / out of scope: browser-specific profiling results and host application rendering outside Web Shell.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 此 PR 的作用

此变更通过把流式 transcript 更新合并到动画帧、稳定传入编辑器的值，并避免斜杠命令、mention、高亮和内联标签路径反复处理完整文档，降低 Web Shell 输入区延迟。同时限制建议逻辑的工作量，并通过针对性回归测试保持现有补全行为。

## 为什么需要

流式响应期间，应用和输入区组件树可能在用户输入时高频更新。部分编辑器路径还会重复执行与整个草稿长度相关的工作，因此长提示词和流式输出同时发生时可能产生明显输入延迟。

## Reviewer Test Plan

### 验证方式

在包含长会话和长草稿的 Web Shell 中启动流式响应，同时继续输入并打开斜杠命令和 mention 补全。输入、光标移动、补全结果、后台代理结果处理和新会话建议应保持流畅且行为不变。

### 证据（优化前后）

优化前：流式更新和全量文档补全、高亮工作可能反复阻塞输入。优化后：transcript 发布频率被限制到动画帧，编辑器属性不会因无关应用更新而变化，补全热路径只处理相关行或变更范围。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

已执行针对性的 Web Shell 单元测试、TypeScript 类型检查、包构建以及仓库 pre-commit 格式化和 lint 检查。

## 风险和范围

- 主要风险或取舍：流式 transcript 的可见更新最多延迟一个动画帧，且编辑器 memo 输入必须继续反映语义变化。
- 未验证或范围外：特定浏览器的 profiling 结果和 Web Shell 之外的宿主应用渲染。
- 破坏性变更或迁移说明：无。

## 关联 Issue

无

</details>
