### PR TITLE
fix(sdk): raise daemon browser bundle budget to 177KB

### DIFF
--- a/packages/sdk-typescript/scripts/build.js
+++ b/packages/sdk-typescript/scripts/build.js
@@ -73,7 +73,9 @@ const rootDir = join(__dirname, '..');
 // Bumped from 174KB to 175KB for git branch listing/checkout/push/pull/commit
 // client methods on both daemon client classes.
 // Bumped from 175KB to 176KB for GitHub PR create + default-branch methods.
-const MAX_DAEMON_BROWSER_BUNDLE_BYTES = 176 * 1024;
+// Bumped from 176KB to 177KB for concurrent session-cancellation coalescing in
+// DaemonSessionClient (#6930).
+const MAX_DAEMON_BROWSER_BUNDLE_BYTES = 177 * 1024;
 // The opt-in `daemon/transports` browser bundle legitimately ships the concrete
 // ACP transports (AcpHttpTransport/AcpWsTransport/AutoReconnect + negotiate), so
 // it's larger than the default barrel — but still budgeted so a future PR can't


### PR DESCRIPTION
## What this PR does

Raises the browser daemon SDK bundle size budget from 176KB to 177KB in the sdk-typescript build script, with a comment recording the reason for the bump.

## Why it's needed

`npm run build` is broken on main: the DingTalk interactive cards change (#6930) added concurrent session-cancellation coalescing to the daemon session client, growing the minified browser daemon bundle to 180295 bytes — 71 bytes over the 180224-byte (176KB) budget asserted by the build script. The bump follows the established pattern of previous budget raises (e.g. 173→174KB, 174→176KB) that accompanied legitimate bundle growth.

## Reviewer Test Plan

### How to verify

Run `npm run build` on main without this change — it fails with `Browser daemon SDK bundle is 180295 bytes; expected <= 180224`. With this change the full build completes successfully.

### Evidence (Before & After)

N/A (build script constant only)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

N/A

## Risk & Scope

- Main risk or tradeoff: none — raises a byte ceiling to match actual bundle size; the browser-safety assertion (no Node builtins) is unchanged.
- Not validated / out of scope: Windows/Linux local builds (CI covers them).
- Breaking changes / migration notes: none.

## Linked Issues

Refs #6930

<details>
<summary>中文说明</summary>

## 本 PR 内容

将 sdk-typescript 构建脚本中 browser daemon SDK bundle 的体积预算从 176KB 提高到 177KB，并按惯例补充注释说明本次提升原因。

## 背景原因

main 分支上 `npm run build` 目前失败：DingTalk 交互卡片改动（#6930）为 daemon session client 增加了并发会话取消合并逻辑，使压缩后的 browser daemon bundle 增长到 180295 字节，超出构建脚本断言的 180224 字节（176KB）预算 71 字节。本次提升沿用了此前历次预算调整的既有模式（如 173→174KB、174→176KB），均为合理体积增长配套的调整。

## 验证方式

在 main 上运行 `npm run build` 会报错 `Browser daemon SDK bundle is 180295 bytes; expected <= 180224`；应用本改动后完整构建成功通过。

## 风险与范围

- 主要风险：无 —— 仅将字节上限调整至与实际产物体积匹配，browser 安全性断言（禁止 Node 内置模块）未改动。
- 未验证 / 范围外：Windows/Linux 本地构建（由 CI 覆盖）。
- 破坏性变更 / 迁移说明：无。

关联 #6930

</details>
