### PR TITLE
feat(github-channel): filter notification reasons

### DIFF
--- a/docs/users/features/channels/github.md
+++ b/docs/users/features/channels/github.md
@@ -26,6 +26,7 @@ Add the channel to `~/.qwen/settings.json`:
       "type": "github",
       "token": "$GITHUB_TOKEN",
       "pollInterval": 60000,
+      "reasonFilter": ["mention", "review_requested", "assign"],
       "senderPolicy": "allowlist",
       "allowedUsers": ["your-github-username"],
       "sessionScope": "chat_thread",
@@ -62,6 +63,7 @@ For GitHub Enterprise Server, set `baseUrl`:
 | `token`                   | (required)               | Classic PAT with `notifications` scope                                           |
 | `pollInterval`            | `60000`                  | Poll interval in ms                                                              |
 | `baseUrl`                 | `https://api.github.com` | API base URL (for GHE)                                                           |
+| `reasonFilter`            | all reasons              | Optional list of GitHub notification reasons to process before dispatch          |
 | `groupPolicy`             | `"disabled"`             | Must be `"open"` for notifications to flow                                       |
 | `senderPolicy`            | `"allowlist"`            | Who can trigger the bot                                                          |
 | `groups.*.requireMention` | `true`                   | Require @mentions for ordinary comments; directed notification reasons still run |

--- a/packages/channels/github/src/GithubAdapter.test.ts
+++ b/packages/channels/github/src/GithubAdapter.test.ts
@@ -823,6 +823,45 @@ describe('GithubChannel', () => {
       },
     );
 
+    it('skips notifications whose reason is not in reasonFilter', async () => {
+      await initWithoutLoop({
+        reasonFilter: ['mention', 'review_requested', 'assign'],
+      });
+      mockOctokit.paginate.mockClear();
+      mockOctokit.paginate.mockResolvedValueOnce([
+        makeNotification({
+          reason: 'author',
+          last_read_at: '2026-07-01T12:00:00.000Z',
+        }),
+      ]);
+
+      await pollOnce();
+
+      expect(channel.inboundEnvelopes).toHaveLength(0);
+      expect(mockOctokit.paginate).toHaveBeenCalledTimes(1);
+      expect(mockOctokit.rest.issues.listComments).not.toHaveBeenCalled();
+      expect(channel.cursor.lastProcessedAt).toBe('2026-07-02T10:00:00.000Z');
+    });
+
+    it('normalizes configured reasonFilter entries before matching', async () => {
+      await initWithoutLoop({
+        reasonFilter: [' COMMENT ', 123, ''],
+      });
+      mockOctokit.paginate
+        .mockResolvedValueOnce([
+          makeNotification({
+            reason: 'comment',
+            last_read_at: '2026-07-01T12:00:00.000Z',
+          }),
+        ])
+        .mockResolvedValueOnce([makeComment({ body: 'allowed comment' })]);
+
+      await pollOnce();
+
+      expect(channel.inboundEnvelopes).toHaveLength(1);
+      expect(channel.inboundEnvelopes[0]!.text).toContain('allowed comment');
+    });
+
     it('excludes comments from disallowed senders when aggregating', async () => {
       await initWithoutLoop({
         senderPolicy: 'allowlist',

--- a/packages/channels/github/src/GithubAdapter.ts
+++ b/packages/channels/github/src/GithubAdapter.ts
@@ -12,6 +12,7 @@ import { testBotMention, stripBotMention } from './mention.js';
 
 interface GithubConfig extends ChannelConfig {
   baseUrl?: string;
+  reasonFilter?: unknown;
 }
 
 interface GithubCursor {
@@ -77,10 +78,20 @@ interface NotificationContext {
   reason: string;
 }
 
+function normalizeReasonFilter(config: GithubConfig): Set<string> | null {
+  if (!Array.isArray(config.reasonFilter)) return null;
+  const reasons = config.reasonFilter
+    .filter((reason): reason is string => typeof reason === 'string')
+    .map((reason) => reason.trim().toLowerCase())
+    .filter((reason) => reason.length > 0);
+  return new Set(reasons);
+}
+
 export class GithubChannel extends PollingChannelBase<GithubCursor> {
   private octokit!: Octokit;
   private botUsername: string | null = null;
   private webOrigin = 'https://github.com';
+  private reasonFilter: Set<string> | null = null;
 
   constructor(
     name: string,
@@ -120,6 +131,7 @@ export class GithubChannel extends PollingChannelBase<GithubCursor> {
 
   async connect(): Promise<void> {
     const cfg = this.config as GithubConfig;
+    this.reasonFilter = normalizeReasonFilter(cfg);
     const baseUrl = cfg.baseUrl || 'https://api.github.com';
     this.webOrigin = baseUrl
       .replace(/\/api\/v3\/?$/, '')
@@ -230,6 +242,16 @@ export class GithubChannel extends PollingChannelBase<GithubCursor> {
 
       const { chatId, threadId, issueNumber } = extracted;
       const lastReadAt = notification.last_read_at;
+      const reason = String(notification.reason ?? '').toLowerCase();
+      if (this.reasonFilter && !this.reasonFilter.has(reason)) {
+        this.logDebugPayload('Github', {
+          event: 'reasonFilter.skip',
+          chatId,
+          threadId,
+          reason: notification.reason,
+        });
+        continue;
+      }
       const ctx: NotificationContext = {
         chatId,
         threadId,
@@ -239,11 +261,11 @@ export class GithubChannel extends PollingChannelBase<GithubCursor> {
         metaFloor: this.cursor.metaFloor,
         maxUpdatedAt,
         subjectTitle: notification.subject.title || '',
-        reason: notification.reason,
+        reason,
       };
 
       try {
-        switch (notification.reason) {
+        switch (reason) {
           case 'mention':
             await this.processCommentLane(ctx, true);
             break;


### PR DESCRIPTION
## What this PR does

Adds an optional `reasonFilter` setting to the GitHub channel. When configured, the adapter normalizes the configured GitHub notification reasons and skips notifications whose reason is not allowed before any reason-specific dispatch lane runs. Skipped notifications are recorded through the channel debug payload logger when channel debug payload logging is enabled. The default behavior remains unchanged: if `reasonFilter` is omitted, all notification reasons are processed as before.

## Why it's needed

Self-operated GitHub channels can receive `author` or followed-thread notifications that are not intended to wake the agent, which can lead to unwanted public comments. This lets operators narrow the bot to reasons such as `mention`, `review_requested`, and `assign` while preserving the existing behavior for current users.

## Reviewer Test Plan

### How to verify

Configure a GitHub channel with `"reasonFilter": ["mention", "review_requested", "assign"]`, then deliver an unread notification with reason `author`. The adapter should mark the notification window as processed but should not enumerate comments or dispatch an inbound envelope. Configure a mixed-case/space-padded entry such as `" COMMENT "` and verify a `comment` notification is still accepted.

### Evidence (Before & After)

N/A - non-UI channel behavior and docs update.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

- `npm --workspace=@qwen-code/channel-github run test -- GithubAdapter.test.ts` - 76 tests passed
- `npm --workspace=@qwen-code/channel-github run build` - passed
- `git diff --check` - passed

## Risk & Scope

- Main risk or tradeoff: an explicit empty or invalid `reasonFilter` array filters out every notification reason; this follows the configured allowlist semantics.
- Not validated / out of scope: live GitHub API polling against a real repository.
- Breaking changes / migration notes: none when `reasonFilter` is omitted.

## Linked Issues

Fixes #8028

<details>
<summary>中文说明</summary>

## What this PR does

给 GitHub channel 新增可选的 `reasonFilter` 配置。配置后，adapter 会先规范化 GitHub notification reason，然后在进入任何 reason 对应的分发 lane 之前跳过不在列表里的通知。被跳过的通知会在开启 channel debug payload 日志时记录下来。默认行为不变：不配置 `reasonFilter` 时，仍然像之前一样处理所有 notification reason。

## Why it's needed

自运营 GitHub channel 可能会收到 `author` 或 followed-thread 这类并不希望唤醒 agent 的通知，进而导致不想要的公开评论。这个配置可以让使用者只允许 `mention`、`review_requested`、`assign` 这类原因触发 bot，同时不影响现有用户的默认行为。

## Reviewer Test Plan

### How to verify

给 GitHub channel 配置 `"reasonFilter": ["mention", "review_requested", "assign"]`，然后投递一条 reason 为 `author` 的未读通知。adapter 应该会推进已处理通知窗口，但不会枚举评论，也不会分发 inbound envelope。再配置类似 `" COMMENT "` 这种带大小写和空格的条目，确认 `comment` 通知仍然会被接受。

### Evidence (Before & After)

N/A - 非 UI 的 channel 行为和文档更新。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

- `npm --workspace=@qwen-code/channel-github run test -- GithubAdapter.test.ts` - 76 个测试通过
- `npm --workspace=@qwen-code/channel-github run build` - 通过
- `git diff --check` - 通过

## Risk & Scope

- Main risk or tradeoff: 如果显式配置空数组或只包含无效项的 `reasonFilter`，会过滤掉所有 notification reason；这符合 allowlist 配置语义。
- Not validated / out of scope: 没有用真实仓库跑 live GitHub API polling。
- Breaking changes / migration notes: 不配置 `reasonFilter` 时没有破坏性变化。

## Linked Issues

Fixes #8028

</details>
