### PR TITLE
feat(core): add a host tool invocation guard

### DIFF
--- a/docs/design/2026-07-30-host-tool-invocation-guard.md
+++ b/docs/design/2026-07-30-host-tool-invocation-guard.md
@@ -1,0 +1,96 @@
+# Host tool invocation guard
+
+## Status
+
+Draft design for issue [#8102](https://github.com/QwenLM/qwen-code/issues/8102) and PR [#8032](https://github.com/QwenLM/qwen-code/pull/8032).
+
+## Problem
+
+An in-process embedding host can evaluate a model-proposed tool call through existing permissions and hooks, but those checks may run before Qwen Code has resolved the canonical tool name or built the final invocation parameters. A host that enforces organization policy therefore cannot prove that it evaluated the same call that reached `invocation.execute()`.
+
+The missing primitive is a final execution-boundary decision over the effective tool call. Product-specific task state, approval workflows, policy storage, and audit transport do not belong in Qwen Code.
+
+## Goals
+
+- Let an in-process host provide one allow/deny function through `ConfigParameters`.
+- Evaluate the canonical tool name and cloned final invocation parameters immediately before execution.
+- Cover all currently reachable Config-owned runtime paths: the core scheduler, ACP session runtime, and speculative execution.
+- Fail closed when a configured guard denies, throws, returns a malformed decision, or cannot receive cloned arguments.
+- Preserve the existing execution path when no guard is configured.
+- Prevent execution if cancellation occurs before or while awaiting the guard.
+
+## Non-goals
+
+- No CLI flag, settings key, environment variable, daemon route, network client, or external policy transport.
+- No task, plan, grant, business authorization, or audit schema.
+- No change to permission, hook, sandbox, or approval-mode semantics.
+- No claim that model planning or tool implementations become deterministic.
+- No result callback or parallel tool-result protocol.
+- No interception of an SDK consumer that manually calls `ToolInvocation.execute()` or `Tool.buildAndExecute()` outside a Config-owned runtime.
+
+## Contract
+
+The host supplies a `ToolInvocationGuard` in `ConfigParameters`. The guard receives:
+
+- the runtime-owned tool call identifier;
+- the canonical tool name;
+- a structured clone of the final invocation parameters; and
+- the invocation abort signal.
+
+The decision is either `{ allowed: true }` or `{ allowed: false, reason? }`. A missing or blank denial reason uses a stable generic message. Exceptions, malformed decisions, and clone failures use a separate stable failure message and deny execution. A supplied denial reason is user-visible and may enter existing tool-result and telemetry surfaces, so it must not contain secrets or raw provider errors.
+
+The cloned arguments prevent a guard from mutating the invocation that Qwen Code will execute. The contract does not make arbitrary tool arguments secret; an embedding host must treat them as sensitive application data.
+
+## Execution placement
+
+The core scheduler evaluates the guard after tool construction, permission handling, path normalization, and `PreToolUse`, but before the call changes to `executing` and before `invocation.execute()`.
+
+The ACP session evaluates the same contract after tool construction, permission handling, and `PreToolUse`, but before its direct `invocation.execute()` path.
+
+The experimental speculation engine also executes invocations directly instead of using the core scheduler. It evaluates the same guard after building the invocation and converts a denial or cancellation into a speculation boundary with zero executor calls. A future managed external-provider mode must disable speculative apply because copying an overlay into the real filesystem is a separate effect boundary outside `invocation.execute()`.
+
+All three paths use the built invocation parameters rather than the model-provided draft arguments. In the core and ACP paths, a denial produces zero executor calls and a structured `execution_denied` tool result.
+
+Any future Config-owned runtime that executes a `ToolInvocation` directly must evaluate the same guard or route through an already guarded scheduler. This is a code-review invariant, not a claim that arbitrary external callers can be intercepted.
+
+## Default-off compatibility
+
+Qwen Code does not populate `toolInvocationGuard` in its CLI or daemon bootstrap. The field is an in-process embedding API only.
+
+Each execution path reads the optional callback and enters the asynchronous evaluator only when the callback exists. When absent, Qwen Code performs no guard promise allocation, argument clone, provider call, capability advertisement, or additional asynchronous yield. Existing CLI and daemon deployments therefore retain their prior execution path.
+
+The intentionally absent in-repository production setter means this change requires maintainer agreement on the public embedding seam before merge. A future external-provider change must remain a separate PR and cannot be assumed as part of this PR's approval.
+
+## Cancellation and failure semantics
+
+The evaluator checks cancellation both before invoking the guard and after its promise settles. Each execution path also checks its active signal immediately after the await and before any executor call.
+
+- cancellation before evaluation: do not call the guard or executor;
+- cancellation while awaiting a guard: record cancellation and do not call the executor;
+- explicit denial: record `execution_denied` and do not call the executor;
+- guard exception, malformed response, or clone failure: fail closed and do not call the executor.
+
+There is no automatic retry. The guard callback owns any provider-specific retry policy, but an embedding host must not retry or execute an ambiguous side effect through this API.
+
+## Evidence
+
+The unit and integration tests cover:
+
+- configured allow and deny decisions;
+- default denial reason;
+- guard exception, malformed response, and clone failure;
+- argument mutation isolation;
+- cancellation before and during guard evaluation;
+- final normalized arguments in the core and ACP paths;
+- speculative execution stops at a boundary on denial;
+- zero executor calls on denial and cancellation;
+- `execution_denied` parity between core and ACP tool-result records; and
+- existing unconfigured execution through the surrounding scheduler and ACP suites.
+
+No E2E plan is required for this PR because it adds no CLI, setting, daemon route, or other user-activatable behavior. Cross-platform CI remains required before merge.
+
+## Follow-up boundary
+
+A future external policy provider may extend the context with trusted runtime-owned session and prompt identity and adapt the in-process callback across the `qwen serve` to ACP child boundary. That follow-up must be default off, independently reviewed, and prove that an unconfigured CLI and daemon do not initialize a provider or change their child process environment.
+
+Result observation should reuse existing structured tool lifecycle events unless a separate issue demonstrates a concrete correlation gap. Product-specific orchestration and policy remain outside Qwen Code.

--- a/docs/design/2026-07-30-host-tool-invocation-guard.md
+++ b/docs/design/2026-07-30-host-tool-invocation-guard.md
@@ -32,7 +32,7 @@ The missing primitive is a final execution-boundary decision over the effective 
 
 The host supplies a `ToolInvocationGuard` in `ConfigParameters`. The guard receives:
 
-- the runtime-owned tool call identifier;
+- the runtime-accepted tool-call correlation identifier;
 - the canonical tool name;
 - a structured clone of the final invocation parameters; and
 - the invocation abort signal.
@@ -40,6 +40,11 @@ The host supplies a `ToolInvocationGuard` in `ConfigParameters`. The guard recei
 The decision is either `{ allowed: true }` or `{ allowed: false, reason? }`. A missing or blank denial reason uses a stable generic message. Exceptions, malformed decisions, and clone failures use a separate stable failure message and deny execution. A supplied denial reason is user-visible and may enter existing tool-result and telemetry surfaces, so it must not contain secrets or raw provider errors.
 
 The cloned arguments prevent a guard from mutating the invocation that Qwen Code will execute. The contract does not make arbitrary tool arguments secret; an embedding host must treat them as sensitive application data.
+
+The tool-call identifier may originate in a model response. It is useful for
+correlating the guard decision with existing lifecycle events, but it is not an
+authenticated subject or a standalone idempotency key. A managed host that
+needs strong identity must bind it to host-owned session and prompt identity.
 
 ## Execution placement
 

--- a/docs/design/2026-07-30-host-tool-invocation-guard.md
+++ b/docs/design/2026-07-30-host-tool-invocation-guard.md
@@ -14,7 +14,7 @@ The missing primitive is a final execution-boundary decision over the effective 
 
 - Let an in-process host provide one allow/deny function through `ConfigParameters`.
 - Evaluate the canonical tool name and cloned final invocation parameters immediately before execution.
-- Cover all currently reachable Config-owned runtime paths: the core scheduler, ACP session runtime, and speculative execution.
+- Cover the core scheduler, ACP session runtime, and speculative execution paths.
 - Fail closed when a configured guard denies, throws, returns a malformed decision, or cannot receive cloned arguments.
 - Preserve the existing execution path when no guard is configured.
 - Prevent execution if cancellation occurs before or while awaiting the guard.
@@ -57,6 +57,12 @@ The experimental speculation engine also executes invocations directly instead o
 All three paths use the built invocation parameters rather than the model-provided draft arguments. In the core and ACP paths, a denial produces zero executor calls and a structured `execution_denied` tool result.
 
 Any future Config-owned runtime that executes a `ToolInvocation` directly must evaluate the same guard or route through an already guarded scheduler. This is a code-review invariant, not a claim that arbitrary external callers can be intercepted.
+
+Two agent-dispatch call sites — the `/fork` slash command and the ACP agent
+fork handler — build and execute an agent tool invocation directly without
+consulting the guard. The spawned subagent shares the caller's `Config`, so
+every tool the subagent itself calls is guarded; only the dispatch call itself
+is unguarded. A future change may extend the guard to these sites.
 
 ## Default-off compatibility
 

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -588,6 +588,7 @@ describe('Session', () => {
         .fn()
         .mockReturnValue(mockChatRecordingService),
       getToolRegistry: vi.fn().mockReturnValue(mockToolRegistry),
+      getToolInvocationGuard: vi.fn().mockReturnValue(undefined),
       getFileService: vi.fn().mockReturnValue(fileService),
       getFileFilteringRespectGitIgnore: vi.fn().mockReturnValue(true),
       getFileFilteringOptions: vi.fn().mockReturnValue({
@@ -14208,6 +14209,186 @@ describe('Session', () => {
           });
 
           expect(executeSpy).not.toHaveBeenCalled();
+        });
+
+        it('runs the host guard with final params and denies before execution', async () => {
+          mockConfig.getApprovalMode = vi
+            .fn()
+            .mockReturnValue(ApprovalMode.YOLO);
+          const guard = vi.fn().mockResolvedValue({
+            allowed: false,
+            reason: 'host policy denied',
+          });
+          mockConfig.getToolInvocationGuard = vi.fn().mockReturnValue(guard);
+
+          const executeSpy = vi.fn();
+          const tool = {
+            name: 'read_file',
+            kind: core.Kind.Read,
+            build: vi.fn().mockReturnValue({
+              params: { path: '/normalized/final.txt' },
+              getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+              execute: executeSpy,
+            }),
+          };
+
+          mockToolRegistry.getTool.mockReturnValue(tool);
+          mockChat.sendMessageStream = vi.fn().mockResolvedValue(
+            createStreamWithChunks([
+              {
+                type: core.StreamEventType.CHUNK,
+                value: {
+                  functionCalls: [
+                    {
+                      id: 'call-guard',
+                      name: 'read_file',
+                      args: { path: './original.txt' },
+                    },
+                  ],
+                },
+              },
+            ]),
+          );
+
+          await session.prompt({
+            sessionId: 'test-session-id',
+            prompt: [{ type: 'text', text: 'read the file' }],
+          });
+
+          expect(guard).toHaveBeenCalledWith({
+            callId: 'call-guard',
+            toolName: 'read_file',
+            args: { path: '/normalized/final.txt' },
+            signal: expect.any(AbortSignal),
+          });
+          expect(executeSpy).not.toHaveBeenCalled();
+          expect(
+            mockChatRecordingService.recordToolResult,
+          ).toHaveBeenCalledWith(
+            expect.any(Array),
+            expect.objectContaining({
+              callId: 'call-guard',
+              status: 'error',
+              errorType: core.ToolErrorType.EXECUTION_DENIED,
+            }),
+          );
+        });
+
+        it('executes once when the host guard allows the final invocation', async () => {
+          mockConfig.getApprovalMode = vi
+            .fn()
+            .mockReturnValue(ApprovalMode.YOLO);
+          const guard = vi.fn().mockResolvedValue({ allowed: true });
+          mockConfig.getToolInvocationGuard = vi.fn().mockReturnValue(guard);
+
+          const executeSpy = vi.fn().mockResolvedValue({
+            llmContent: 'file contents',
+            returnDisplay: 'success',
+          });
+          const tool = {
+            name: 'read_file',
+            kind: core.Kind.Read,
+            build: vi.fn().mockReturnValue({
+              params: { path: '/normalized/final.txt' },
+              getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+              execute: executeSpy,
+            }),
+          };
+
+          mockToolRegistry.getTool.mockReturnValue(tool);
+          mockChat.sendMessageStream = vi.fn().mockResolvedValue(
+            createStreamWithChunks([
+              {
+                type: core.StreamEventType.CHUNK,
+                value: {
+                  functionCalls: [
+                    {
+                      id: 'call-guard-allowed',
+                      name: 'read_file',
+                      args: { path: './original.txt' },
+                    },
+                  ],
+                },
+              },
+            ]),
+          );
+
+          await session.prompt({
+            sessionId: 'test-session-id',
+            prompt: [{ type: 'text', text: 'read the file' }],
+          });
+
+          expect(guard).toHaveBeenCalledWith({
+            callId: 'call-guard-allowed',
+            toolName: 'read_file',
+            args: { path: '/normalized/final.txt' },
+            signal: expect.any(AbortSignal),
+          });
+          expect(executeSpy).toHaveBeenCalledOnce();
+        });
+
+        it('cancels without execution when aborted while awaiting the host guard', async () => {
+          mockConfig.getApprovalMode = vi
+            .fn()
+            .mockReturnValue(ApprovalMode.YOLO);
+          let resolveGuard!: (decision: { allowed: true }) => void;
+          const guard = vi.fn(
+            () =>
+              new Promise<{ allowed: true }>((resolve) => {
+                resolveGuard = resolve;
+              }),
+          );
+          mockConfig.getToolInvocationGuard = vi.fn().mockReturnValue(guard);
+
+          const executeSpy = vi.fn();
+          const tool = {
+            name: 'read_file',
+            kind: core.Kind.Read,
+            build: vi.fn().mockReturnValue({
+              params: { path: '/tmp/test.txt' },
+              getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+              execute: executeSpy,
+            }),
+          };
+
+          mockToolRegistry.getTool.mockReturnValue(tool);
+          mockChat.sendMessageStream = vi.fn().mockResolvedValue(
+            createStreamWithChunks([
+              {
+                type: core.StreamEventType.CHUNK,
+                value: {
+                  functionCalls: [
+                    {
+                      id: 'call-guard-aborted',
+                      name: 'read_file',
+                      args: { path: '/tmp/test.txt' },
+                    },
+                  ],
+                },
+              },
+            ]),
+          );
+
+          const prompt = session.prompt({
+            sessionId: 'test-session-id',
+            prompt: [{ type: 'text', text: 'read the file' }],
+          });
+          await vi.waitFor(() => expect(guard).toHaveBeenCalledOnce());
+          const cancel = session.cancelPendingPrompt();
+          resolveGuard({ allowed: true });
+
+          await cancel;
+          await prompt;
+          expect(executeSpy).not.toHaveBeenCalled();
+          expect(
+            mockChatRecordingService.recordToolResult,
+          ).toHaveBeenCalledWith(
+            expect.any(Array),
+            expect.objectContaining({
+              callId: 'call-guard-aborted',
+              status: 'cancelled',
+            }),
+          );
         });
       });
 

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -96,6 +96,7 @@ import {
   buildSessionRecoveryPlanFromApiHistory,
   TURN_INTERRUPTION_HISTORY_TAIL_COUNT,
   evaluatePermissionFlow,
+  evaluateToolInvocationGuard,
   getEffectivePermissionForConfirmation,
   needsConfirmation,
   isPlanModeBlocked,
@@ -7131,7 +7132,9 @@ export class Session implements SessionContext {
       error: Error,
       toolName = fc.name ?? 'unknown_tool',
       opts?: {
+        errorType?: ToolErrorType;
         recordInvalidToolParams?: boolean;
+        status?: 'error' | 'cancelled';
         stopAfterPermissionCancel?: boolean;
       },
     ) => {
@@ -7148,10 +7151,10 @@ export class Session implements SessionContext {
         responseParts: errorParts,
         metadata: {
           callId,
-          status: 'error',
+          status: opts?.status ?? 'error',
           resultDisplay: undefined,
           error,
-          errorType: undefined,
+          errorType: opts?.errorType,
         },
       });
       const loopDetected =
@@ -7984,6 +7987,33 @@ export class Session implements SessionContext {
             if (preHookResult.additionalContext) {
               debugLogger.debug(
                 `PreToolUse hook additional context for ${toolName}: ${preHookResult.additionalContext}`,
+              );
+            }
+          }
+
+          const toolInvocationGuard = this.config.getToolInvocationGuard?.();
+          if (toolInvocationGuard) {
+            const guardDecision = await evaluateToolInvocationGuard(
+              toolInvocationGuard,
+              {
+                callId,
+                toolName: policyToolName,
+                args: invocation.params as Record<string, unknown>,
+                signal: activeToolAbortSignal,
+              },
+            );
+            if (activeToolAbortSignal.aborted) {
+              return earlyErrorResponse(
+                new Error('Tool invocation was cancelled'),
+                toolName,
+                { status: 'cancelled' },
+              );
+            }
+            if (!guardDecision.allowed) {
+              return earlyErrorResponse(
+                new Error(guardDecision.reason),
+                toolName,
+                { errorType: ToolErrorType.EXECUTION_DENIED },
               );
             }
           }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -165,6 +165,7 @@ import {
   type GoalTurnHost,
 } from '../goals/goal-runtime.js';
 import { createGoalVerifier } from '../goals/goal-verifier.js';
+import type { ToolInvocationGuard } from '../core/tool-invocation-guard.js';
 
 // Utils
 import { shouldAttemptBrowserLaunch } from '../utils/browser.js';
@@ -1004,6 +1005,11 @@ export interface ConfigParameters {
     /** Settings consumed by the AUTO approval mode classifier. */
     autoMode?: AutoModeSettings;
   };
+  /**
+   * Optional host policy evaluated with final tool arguments immediately
+   * before execution. A configured guard fails closed.
+   */
+  toolInvocationGuard?: ToolInvocationGuard;
   toolDiscoveryCommand?: string;
   toolCallCommand?: string;
   mcpServerCommand?: string;
@@ -1725,6 +1731,7 @@ export class Config {
   private extensionManager!: ExtensionManager;
   private skillManager: SkillManager | null = null;
   private permissionManager: PermissionManager | null = null;
+  private readonly toolInvocationGuard: ToolInvocationGuard | undefined;
   private modelInvocableCommandsProvider:
     | (() => ReadonlyArray<{ name: string; description: string }>)
     | null = null;
@@ -2090,6 +2097,7 @@ export class Config {
     this.permissionsAsk = params.permissions?.ask || [];
     this.permissionsDeny = params.permissions?.deny || [];
     this.permissionsAutoMode = params.permissions?.autoMode ?? {};
+    this.toolInvocationGuard = params.toolInvocationGuard;
     this.toolDiscoveryCommand = params.toolDiscoveryCommand;
     this.toolCallCommand = params.toolCallCommand;
     this.mcpServerCommand = params.mcpServerCommand;
@@ -7561,6 +7569,10 @@ export class Config {
 
   getPermissionManager(): PermissionManager | null {
     return this.permissionManager;
+  }
+
+  getToolInvocationGuard(): ToolInvocationGuard | undefined {
+    return this.toolInvocationGuard;
   }
 
   /**

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -14,6 +14,7 @@ import type {
   ToolCallConfirmationDetails,
   ToolConfirmationPayload,
   ToolInvocation,
+  ToolInvocationGuard,
   ToolResult,
   ToolResultDisplay,
   ToolRegistry,
@@ -8621,6 +8622,7 @@ describe('CoreToolScheduler Plan shell routing', () => {
     disableHooks?: boolean;
     avoidPermissionPrompts?: boolean;
     targetDir?: () => string;
+    toolInvocationGuard?: ToolInvocationGuard;
   }) {
     const tools = new Map(options.tools.map((tool) => [tool.name, tool]));
     const registry = {
@@ -8676,6 +8678,7 @@ describe('CoreToolScheduler Plan shell routing', () => {
       getShouldAvoidPermissionPrompts: () =>
         options.avoidPermissionPrompts ?? false,
       getOnPersistPermissionRule: () => undefined,
+      getToolInvocationGuard: () => options.toolInvocationGuard,
     } as unknown as Config;
 
     return {
@@ -8761,6 +8764,99 @@ describe('CoreToolScheduler Plan shell routing', () => {
 
     expect(execute).toHaveBeenCalledOnce();
     expect(getConfirmationDetails).not.toHaveBeenCalled();
+  });
+
+  it('runs the host guard with final params and denies before execution', async () => {
+    const execute = vi.fn();
+    const toolInvocationGuard = vi
+      .fn()
+      .mockResolvedValue({ allowed: false, reason: 'host policy denied' });
+    const { scheduler, onAllToolCallsComplete } = buildPlanShellScheduler({
+      tools: [shellTool({ execute })],
+      toolInvocationGuard,
+      targetDir: () => '/workspace',
+    });
+
+    await scheduler.schedule(
+      [request('guard-denied', 'git status')],
+      new AbortController().signal,
+    );
+    await vi.waitFor(() => expect(onAllToolCallsComplete).toHaveBeenCalled());
+
+    expect(toolInvocationGuard).toHaveBeenCalledWith({
+      callId: 'guard-denied',
+      toolName: ToolNames.SHELL,
+      args: { command: 'git status', directory: '/workspace' },
+      signal: expect.any(AbortSignal),
+    });
+    expect(execute).not.toHaveBeenCalled();
+    const completed = onAllToolCallsComplete.mock.calls[0][0] as ToolCall[];
+    const deniedCall = completed[0];
+    expect(deniedCall.status).toBe('error');
+    expect(JSON.stringify(deniedCall)).toContain('host policy denied');
+    if (deniedCall.status !== 'error') {
+      throw new Error('Expected the guarded tool call to fail');
+    }
+    expect(deniedCall.response.errorType).toBe(ToolErrorType.EXECUTION_DENIED);
+  });
+
+  it('executes once when the host guard allows the final invocation', async () => {
+    const execute = vi.fn().mockResolvedValue({
+      llmContent: 'ok',
+      returnDisplay: 'ok',
+    });
+    const toolInvocationGuard = vi.fn().mockResolvedValue({ allowed: true });
+    const { scheduler, onAllToolCallsComplete } = buildPlanShellScheduler({
+      tools: [shellTool({ execute })],
+      toolInvocationGuard,
+      targetDir: () => '/workspace',
+    });
+
+    await scheduler.schedule(
+      [request('guard-allowed', 'git status')],
+      new AbortController().signal,
+    );
+    await vi.waitFor(() => expect(onAllToolCallsComplete).toHaveBeenCalled());
+
+    expect(toolInvocationGuard).toHaveBeenCalledWith({
+      callId: 'guard-allowed',
+      toolName: ToolNames.SHELL,
+      args: { command: 'git status', directory: '/workspace' },
+      signal: expect.any(AbortSignal),
+    });
+    expect(execute).toHaveBeenCalledOnce();
+    const completed = onAllToolCallsComplete.mock.calls[0][0] as ToolCall[];
+    expect(completed[0].status).toBe('success');
+  });
+
+  it('cancels without execution when aborted while awaiting the host guard', async () => {
+    const execute = vi.fn();
+    let resolveGuard!: (decision: { allowed: true }) => void;
+    const toolInvocationGuard = vi.fn(
+      () =>
+        new Promise<{ allowed: true }>((resolve) => {
+          resolveGuard = resolve;
+        }),
+    );
+    const { scheduler, onAllToolCallsComplete } = buildPlanShellScheduler({
+      tools: [shellTool({ execute })],
+      toolInvocationGuard,
+    });
+    const abortController = new AbortController();
+
+    const schedule = scheduler.schedule(
+      [request('guard-aborted', 'git status')],
+      abortController.signal,
+    );
+    await vi.waitFor(() => expect(toolInvocationGuard).toHaveBeenCalledOnce());
+    abortController.abort();
+    resolveGuard({ allowed: true });
+
+    await schedule;
+    await vi.waitFor(() => expect(onAllToolCallsComplete).toHaveBeenCalled());
+    expect(execute).not.toHaveBeenCalled();
+    const completed = onAllToolCallsComplete.mock.calls[0][0] as ToolCall[];
+    expect(completed[0].status).toBe('cancelled');
   });
 
   it('limits PM-confirmed read-only shell calls to exact one-off approval', async () => {

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -330,6 +330,21 @@ vi.mock('../ide/ide-client.js', () => ({
   },
 }));
 
+const evaluateGuardSpy = vi.hoisted(() => vi.fn());
+vi.mock('./tool-invocation-guard.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('./tool-invocation-guard.js')>();
+  return {
+    ...actual,
+    evaluateToolInvocationGuard: (
+      ...args: Parameters<typeof actual.evaluateToolInvocationGuard>
+    ) => {
+      evaluateGuardSpy(...args);
+      return actual.evaluateToolInvocationGuard(...args);
+    },
+  };
+});
+
 const mockIdeClient = {
   openDiff: vi.fn(),
   isDiffingEnabled: vi.fn(),
@@ -8857,6 +8872,28 @@ describe('CoreToolScheduler Plan shell routing', () => {
     expect(execute).not.toHaveBeenCalled();
     const completed = onAllToolCallsComplete.mock.calls[0][0] as ToolCall[];
     expect(completed[0].status).toBe('cancelled');
+  });
+
+  it('skips guard evaluation entirely when no guard is configured', async () => {
+    evaluateGuardSpy.mockClear();
+    const execute = vi.fn().mockResolvedValue({
+      llmContent: 'ok',
+      returnDisplay: 'ok',
+    });
+    const { scheduler, onAllToolCallsComplete } = buildPlanShellScheduler({
+      tools: [shellTool({ execute })],
+    });
+
+    await scheduler.schedule(
+      [request('no-guard', 'git status')],
+      new AbortController().signal,
+    );
+    await vi.waitFor(() => expect(onAllToolCallsComplete).toHaveBeenCalled());
+
+    expect(evaluateGuardSpy).not.toHaveBeenCalled();
+    expect(execute).toHaveBeenCalledOnce();
+    const completed = onAllToolCallsComplete.mock.calls[0][0] as ToolCall[];
+    expect(completed[0].status).toBe('success');
   });
 
   it('limits PM-confirmed read-only shell calls to exact one-off approval', async () => {

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -177,6 +177,7 @@ import {
   getInvocationContext,
   runWithInvocationContext,
 } from '../utils/invocation-context.js';
+import { evaluateToolInvocationGuard } from './tool-invocation-guard.js';
 import { goalTurnContext } from '../goals/goal-turn-context.js';
 
 const debugLogger = createDebugLogger('TOOL_SCHEDULER');
@@ -255,6 +256,7 @@ function extractTextFromPartListUnion(c: PartListUnion): string {
 
 const TOOL_FAILURE_KIND_ATTRIBUTE = 'tool.failure_kind';
 const TOOL_FAILURE_KIND_PRE_HOOK_BLOCKED = 'pre_hook_blocked';
+const TOOL_FAILURE_KIND_INVOCATION_GUARD_DENIED = 'invocation_guard_denied';
 const TOOL_FAILURE_KIND_POST_HOOK_STOPPED = 'post_hook_stopped';
 const TOOL_FAILURE_KIND_TOOL_ERROR = 'tool_error';
 const TOOL_FAILURE_KIND_TOOL_EXCEPTION = 'tool_exception';
@@ -269,6 +271,8 @@ const TOOL_FAILURE_KIND_NON_INTERACTIVE_DENIED = 'non_interactive_denied';
 const TOOL_FAILURE_KIND_BACKGROUND_AGENT_DENIED = 'background_agent_denied';
 
 const TOOL_SPAN_STATUS_PRE_HOOK_BLOCKED = 'Tool execution blocked by hook';
+const TOOL_SPAN_STATUS_INVOCATION_GUARD_DENIED =
+  'Tool execution blocked by host policy';
 
 const TOOL_SPAN_STATUS_POST_HOOK_STOPPED = 'Tool execution stopped by hook';
 const TOOL_SPAN_STATUS_PERMISSION_DENIED = 'Permission denied for tool';
@@ -4124,6 +4128,42 @@ export class CoreToolScheduler {
           span,
           TOOL_FAILURE_KIND_PRE_HOOK_BLOCKED,
           TOOL_SPAN_STATUS_PRE_HOOK_BLOCKED,
+        );
+        return;
+      }
+    }
+
+    const toolInvocationGuard = this.config.getToolInvocationGuard?.();
+    if (toolInvocationGuard) {
+      const guardDecision = await evaluateToolInvocationGuard(
+        toolInvocationGuard,
+        {
+          callId,
+          toolName: canonicalName,
+          args: invocation.params as Record<string, unknown>,
+          signal,
+        },
+      );
+      if (signal.aborted) {
+        this.setStatusInternal(
+          callId,
+          'cancelled',
+          'Tool call cancelled by user.',
+        );
+        setToolSpanCancelled(span);
+        return;
+      }
+      if (!guardDecision.allowed) {
+        const errorResponse = createErrorResponse(
+          scheduledCall.request,
+          new Error(guardDecision.reason),
+          ToolErrorType.EXECUTION_DENIED,
+        );
+        this.setStatusInternal(callId, 'error', errorResponse);
+        setToolSpanFailure(
+          span,
+          TOOL_FAILURE_KIND_INVOCATION_GUARD_DENIED,
+          TOOL_SPAN_STATUS_INVOCATION_GUARD_DENIED,
         );
         return;
       }

--- a/packages/core/src/core/tool-invocation-guard.test.ts
+++ b/packages/core/src/core/tool-invocation-guard.test.ts
@@ -45,6 +45,30 @@ describe('evaluateToolInvocationGuard', () => {
     });
   });
 
+  it('uses a stable reason when the guard denies with a blank reason', async () => {
+    await expect(
+      evaluateToolInvocationGuard(
+        vi.fn().mockResolvedValue({ allowed: false, reason: ' ' }),
+        context(),
+      ),
+    ).resolves.toEqual({
+      allowed: false,
+      reason: 'Tool invocation denied by host policy',
+    });
+  });
+
+  it('uses a stable reason when the guard denies with a non-string reason', async () => {
+    await expect(
+      evaluateToolInvocationGuard(
+        vi.fn().mockResolvedValue({ allowed: false, reason: 42 }),
+        context(),
+      ),
+    ).resolves.toEqual({
+      allowed: false,
+      reason: 'Tool invocation denied by host policy',
+    });
+  });
+
   it('fails closed when the guard throws', async () => {
     await expect(
       evaluateToolInvocationGuard(

--- a/packages/core/src/core/tool-invocation-guard.test.ts
+++ b/packages/core/src/core/tool-invocation-guard.test.ts
@@ -1,0 +1,137 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { evaluateToolInvocationGuard } from './tool-invocation-guard.js';
+
+const context = () => ({
+  callId: 'call-1',
+  toolName: 'read_file',
+  args: { path: '/tmp/input.txt', nested: { value: 'original' } },
+  signal: new AbortController().signal,
+});
+
+describe('evaluateToolInvocationGuard', () => {
+  it('allows calls when the guard permits them', async () => {
+    await expect(
+      evaluateToolInvocationGuard(
+        vi.fn().mockResolvedValue({ allowed: true }),
+        context(),
+      ),
+    ).resolves.toEqual({ allowed: true });
+  });
+
+  it('returns the configured denial reason', async () => {
+    await expect(
+      evaluateToolInvocationGuard(
+        vi.fn().mockResolvedValue({ allowed: false, reason: 'blocked' }),
+        context(),
+      ),
+    ).resolves.toEqual({ allowed: false, reason: 'blocked' });
+  });
+
+  it('uses a stable reason when the guard denies without one', async () => {
+    await expect(
+      evaluateToolInvocationGuard(
+        vi.fn().mockResolvedValue({ allowed: false }),
+        context(),
+      ),
+    ).resolves.toEqual({
+      allowed: false,
+      reason: 'Tool invocation denied by host policy',
+    });
+  });
+
+  it('fails closed when the guard throws', async () => {
+    await expect(
+      evaluateToolInvocationGuard(
+        vi.fn().mockRejectedValue(new Error('sensitive provider error')),
+        context(),
+      ),
+    ).resolves.toEqual({
+      allowed: false,
+      reason: 'Tool invocation guard failed',
+    });
+  });
+
+  it('fails closed when the guard returns a malformed decision', async () => {
+    await expect(
+      evaluateToolInvocationGuard(
+        vi.fn().mockResolvedValue({ result: 'allow' }),
+        context(),
+      ),
+    ).resolves.toEqual({
+      allowed: false,
+      reason: 'Tool invocation guard failed',
+    });
+  });
+
+  it('fails closed when invocation arguments cannot be cloned', async () => {
+    const guard = vi.fn();
+
+    await expect(
+      evaluateToolInvocationGuard(guard, {
+        ...context(),
+        args: { callback: () => undefined },
+      }),
+    ).resolves.toEqual({
+      allowed: false,
+      reason: 'Tool invocation guard failed',
+    });
+    expect(guard).not.toHaveBeenCalled();
+  });
+
+  it('does not call the guard for an already-aborted invocation', async () => {
+    const controller = new AbortController();
+    const guard = vi.fn();
+    controller.abort();
+
+    await expect(
+      evaluateToolInvocationGuard(guard, {
+        ...context(),
+        signal: controller.signal,
+      }),
+    ).resolves.toEqual({
+      allowed: false,
+      reason: 'Tool invocation guard failed',
+    });
+    expect(guard).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the invocation is aborted while awaiting the guard', async () => {
+    const controller = new AbortController();
+    let resolveGuard!: (decision: { allowed: true }) => void;
+    const guard = vi.fn(
+      () =>
+        new Promise<{ allowed: true }>((resolve) => {
+          resolveGuard = resolve;
+        }),
+    );
+    const evaluation = evaluateToolInvocationGuard(guard, {
+      ...context(),
+      signal: controller.signal,
+    });
+
+    await vi.waitFor(() => expect(guard).toHaveBeenCalledOnce());
+    controller.abort();
+    resolveGuard({ allowed: true });
+
+    await expect(evaluation).resolves.toEqual({
+      allowed: false,
+      reason: 'Tool invocation guard failed',
+    });
+  });
+
+  it('does not let the guard mutate invocation arguments', async () => {
+    const original = context();
+    await evaluateToolInvocationGuard((received) => {
+      (received.args['nested'] as { value: string }).value = 'changed';
+      return { allowed: true };
+    }, original);
+
+    expect(original.args['nested'].value).toBe('original');
+  });
+});

--- a/packages/core/src/core/tool-invocation-guard.ts
+++ b/packages/core/src/core/tool-invocation-guard.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface ToolInvocationGuardContext {
+  callId: string;
+  toolName: string;
+  args: Readonly<Record<string, unknown>>;
+  signal: AbortSignal;
+}
+
+export type ToolInvocationGuardDecision =
+  | { allowed: true }
+  | {
+      allowed: false;
+      /** User-visible denial reason. It must not contain secrets. */
+      reason?: string;
+    };
+
+export type ToolInvocationGuard = (
+  context: ToolInvocationGuardContext,
+) => ToolInvocationGuardDecision | Promise<ToolInvocationGuardDecision>;
+
+export type EvaluatedToolInvocationGuardDecision =
+  | { allowed: true }
+  | { allowed: false; reason: string };
+
+const DENIED_MESSAGE = 'Tool invocation denied by host policy';
+const FAILED_MESSAGE = 'Tool invocation guard failed';
+
+export async function evaluateToolInvocationGuard(
+  guard: ToolInvocationGuard,
+  context: ToolInvocationGuardContext,
+): Promise<EvaluatedToolInvocationGuardDecision> {
+  if (context.signal.aborted) {
+    return { allowed: false, reason: FAILED_MESSAGE };
+  }
+
+  try {
+    const decision = await guard({
+      ...context,
+      args: structuredClone(context.args),
+    });
+    if (context.signal.aborted) {
+      return { allowed: false, reason: FAILED_MESSAGE };
+    }
+    if (decision?.allowed === true) {
+      return { allowed: true };
+    }
+    if (decision?.allowed === false) {
+      return {
+        allowed: false,
+        reason:
+          typeof decision.reason === 'string' && decision.reason.trim()
+            ? decision.reason
+            : DENIED_MESSAGE,
+      };
+    }
+  } catch {
+    // A configured guard is an enforcement boundary. Provider and cloning
+    // failures must deny the call instead of falling back to execution.
+  }
+
+  return { allowed: false, reason: FAILED_MESSAGE };
+}

--- a/packages/core/src/core/tool-invocation-guard.ts
+++ b/packages/core/src/core/tool-invocation-guard.ts
@@ -34,6 +34,14 @@ const debugLogger = createDebugLogger('TOOL_INVOCATION_GUARD');
 const DENIED_MESSAGE = 'Tool invocation denied by host policy';
 const FAILED_MESSAGE = 'Tool invocation guard failed';
 
+/**
+ * Evaluate a host-supplied guard against a pending tool invocation. The guard
+ * fails closed: an aborted signal, a guard exception, a malformed decision, or
+ * a cloning failure all yield `{ allowed: false, reason: FAILED_MESSAGE }`.
+ * Because an aborted signal is reported in the same shape as a policy failure,
+ * callers must re-derive cancellation from `context.signal` instead of reading
+ * it off the returned decision.
+ */
 export async function evaluateToolInvocationGuard(
   guard: ToolInvocationGuard,
   context: ToolInvocationGuardContext,
@@ -43,6 +51,10 @@ export async function evaluateToolInvocationGuard(
   }
 
   try {
+    debugLogger.debug('Evaluating tool invocation guard', {
+      callId: context.callId,
+      toolName: context.toolName,
+    });
     const decision = await guard({
       ...context,
       args: structuredClone(context.args),

--- a/packages/core/src/core/tool-invocation-guard.ts
+++ b/packages/core/src/core/tool-invocation-guard.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { createDebugLogger } from '../utils/debugLogger.js';
+
 export interface ToolInvocationGuardContext {
   callId: string;
   toolName: string;
@@ -26,6 +28,8 @@ export type ToolInvocationGuard = (
 export type EvaluatedToolInvocationGuardDecision =
   | { allowed: true }
   | { allowed: false; reason: string };
+
+const debugLogger = createDebugLogger('TOOL_INVOCATION_GUARD');
 
 const DENIED_MESSAGE = 'Tool invocation denied by host policy';
 const FAILED_MESSAGE = 'Tool invocation guard failed';
@@ -58,9 +62,10 @@ export async function evaluateToolInvocationGuard(
             : DENIED_MESSAGE,
       };
     }
-  } catch {
+  } catch (error) {
     // A configured guard is an enforcement boundary. Provider and cloning
     // failures must deny the call instead of falling back to execution.
+    debugLogger.debug('Tool invocation guard evaluation failed', error);
   }
 
   return { allowed: false, reason: FAILED_MESSAGE };

--- a/packages/core/src/core/tool-invocation-guard.ts
+++ b/packages/core/src/core/tool-invocation-guard.ts
@@ -62,6 +62,10 @@ export async function evaluateToolInvocationGuard(
             : DENIED_MESSAGE,
       };
     }
+    debugLogger.debug(
+      'Tool invocation guard returned an unrecognized decision; failing closed',
+      decision,
+    );
   } catch (error) {
     // A configured guard is an enforcement boundary. Provider and cloning
     // failures must deny the call instead of falling back to execution.

--- a/packages/core/src/followup/speculation.test.ts
+++ b/packages/core/src/followup/speculation.test.ts
@@ -43,6 +43,70 @@ afterEach(() => {
 });
 
 describe('startSpeculation', () => {
+  it('stops at a boundary when the host guard denies a speculative invocation', async () => {
+    const execute = vi.fn();
+    const guard = vi.fn().mockResolvedValue({
+      allowed: false,
+      reason: 'host policy denied',
+    });
+    const toolRegistry = {
+      ensureTool: vi.fn().mockResolvedValue({
+        build: vi.fn().mockReturnValue({
+          params: { path: '/normalized/a.ts' },
+          execute,
+        }),
+      }),
+    };
+    const config = {
+      getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
+      getCwd: vi.fn().mockReturnValue(process.cwd()),
+      getFastModel: vi.fn().mockReturnValue(undefined),
+      getToolRegistry: vi.fn().mockReturnValue(toolRegistry),
+      getToolInvocationGuard: vi.fn().mockReturnValue(guard),
+    } as unknown as Config;
+
+    forkedAgentMocks.runForkedAgent.mockResolvedValue({
+      jsonResult: { suggestion: '' },
+    });
+    forkedAgentMocks.sendMessageStream.mockImplementation(async function* () {
+      if (forkedAgentMocks.sendMessageStream.mock.calls.length === 1) {
+        yield {
+          type: 'chunk',
+          value: {
+            candidates: [
+              {
+                content: {
+                  parts: [
+                    {
+                      functionCall: {
+                        id: 'call-speculation-guard',
+                        name: 'read_file',
+                        args: { path: 'a.ts' },
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        };
+      }
+    });
+
+    const state = await startSpeculation(config, 'read a.ts');
+    await vi.waitFor(() => expect(state.status).toBe('boundary'));
+
+    expect(guard).toHaveBeenCalledWith({
+      callId: 'call-speculation-guard',
+      toolName: 'read_file',
+      args: { path: '/normalized/a.ts' },
+      signal: expect.any(AbortSignal),
+    });
+    expect(execute).not.toHaveBeenCalled();
+
+    await abortSpeculation(state);
+  });
+
   it('preserves generated tool call ids in paired responses', async () => {
     const execute = vi.fn().mockResolvedValue({
       llmContent: 'file contents',

--- a/packages/core/src/followup/speculation.test.ts
+++ b/packages/core/src/followup/speculation.test.ts
@@ -107,6 +107,70 @@ describe('startSpeculation', () => {
     await abortSpeculation(state);
   });
 
+  it('proceeds to execution when the host guard allows a speculative invocation', async () => {
+    const execute = vi.fn().mockResolvedValue({
+      llmContent: 'file contents',
+      returnDisplay: 'file contents',
+    });
+    const guard = vi.fn().mockResolvedValue({ allowed: true });
+    const toolRegistry = {
+      ensureTool: vi.fn().mockResolvedValue({
+        build: vi.fn().mockReturnValue({
+          params: { path: '/normalized/a.ts' },
+          execute,
+        }),
+      }),
+    };
+    const config = {
+      getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
+      getCwd: vi.fn().mockReturnValue(process.cwd()),
+      getFastModel: vi.fn().mockReturnValue(undefined),
+      getToolRegistry: vi.fn().mockReturnValue(toolRegistry),
+      getToolInvocationGuard: vi.fn().mockReturnValue(guard),
+    } as unknown as Config;
+
+    forkedAgentMocks.runForkedAgent.mockResolvedValue({
+      jsonResult: { suggestion: '' },
+    });
+    forkedAgentMocks.sendMessageStream.mockImplementation(async function* () {
+      if (forkedAgentMocks.sendMessageStream.mock.calls.length === 1) {
+        yield {
+          type: 'chunk',
+          value: {
+            candidates: [
+              {
+                content: {
+                  parts: [
+                    {
+                      functionCall: {
+                        id: 'call-speculation-guard-allow',
+                        name: 'read_file',
+                        args: { path: 'a.ts' },
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        };
+      }
+    });
+
+    const state = await startSpeculation(config, 'read a.ts');
+    await vi.waitFor(() => expect(state.status).toBe('completed'));
+
+    expect(guard).toHaveBeenCalledWith({
+      callId: 'call-speculation-guard-allow',
+      toolName: 'read_file',
+      args: { path: '/normalized/a.ts' },
+      signal: expect.any(AbortSignal),
+    });
+    expect(execute).toHaveBeenCalledOnce();
+
+    await abortSpeculation(state);
+  });
+
   it('preserves generated tool call ids in paired responses', async () => {
     const execute = vi.fn().mockResolvedValue({
       llmContent: 'file contents',

--- a/packages/core/src/followup/speculation.ts
+++ b/packages/core/src/followup/speculation.ts
@@ -34,6 +34,7 @@ import {
   runForkedAgent,
   runWithForkedChatModel,
 } from '../utils/forkedAgent.js';
+import { createDebugLogger } from '../utils/debugLogger.js';
 import { getFilterReason, SUGGESTION_PROMPT } from './suggestionGenerator.js';
 import {
   finalizeToolResponses,
@@ -43,6 +44,8 @@ import {
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
+
+const debugLogger = createDebugLogger('SPECULATION');
 
 const MAX_SPECULATION_TURNS = 20;
 const MAX_SPECULATION_MESSAGES = 100;
@@ -346,10 +349,14 @@ async function runSpeculativeLoop(
                 signal: state.abortController!.signal,
               },
             );
-            if (
-              state.abortController!.signal.aborted ||
-              !guardDecision.allowed
-            ) {
+            if (state.abortController!.signal.aborted) {
+              hitBoundary = true;
+              break;
+            }
+            if (!guardDecision.allowed) {
+              debugLogger.debug(
+                `Speculative guard denial: ${guardDecision.reason}`,
+              );
               hitBoundary = true;
               break;
             }

--- a/packages/core/src/followup/speculation.ts
+++ b/packages/core/src/followup/speculation.ts
@@ -20,9 +20,11 @@ import type { Config } from '../config/config.js';
 import type { GeminiClient } from '../core/client.js';
 import { StreamEventType } from '../core/geminiChat.js';
 import {
+  canonicalToolName,
   convertToFunctionErrorResponse,
   convertToFunctionResponse,
 } from '../core/coreToolScheduler.js';
+import { evaluateToolInvocationGuard } from '../core/tool-invocation-guard.js';
 import { stripToolResultImages } from '../services/visionBridge/tool-result-vision-bridge.js';
 import { OverlayFs } from './overlayFs.js';
 import { evaluateToolCall, rewritePathArgs } from './speculationToolGate.js';
@@ -333,6 +335,25 @@ async function runSpeculativeLoop(
           }
 
           const invocation = tool.build(args);
+          const toolInvocationGuard = config.getToolInvocationGuard?.();
+          if (toolInvocationGuard) {
+            const guardDecision = await evaluateToolInvocationGuard(
+              toolInvocationGuard,
+              {
+                callId: persistenceCallId,
+                toolName: canonicalToolName(name),
+                args: invocation.params as Record<string, unknown>,
+                signal: state.abortController!.signal,
+              },
+            );
+            if (
+              state.abortController!.signal.aborted ||
+              !guardDecision.allowed
+            ) {
+              hitBoundary = true;
+              break;
+            }
+          }
           const result = await invocation.execute(
             state.abortController!.signal,
           );

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -93,6 +93,7 @@ export * from './core/session-recovery.js';
 export * from './core/tokenLimits.js';
 export * from './core/tool-call-preparation.js';
 export * from './core/toolCallIdUtils.js';
+export * from './core/tool-invocation-guard.js';
 export * from './core/turn.js';
 export * from './core/turn-interruption.js';
 


### PR DESCRIPTION
## What this PR does

Adds an optional in-process host guard for the final effective tool invocation. When configured through `ConfigParameters`, it receives the runtime call ID, canonical tool name, a structured clone of the built invocation parameters, and the abort signal immediately before execution. The same fail-closed contract covers the core scheduler, ACP session runtime, and the experimental speculation path.

An explicit denial, exception, malformed decision, argument-clone failure, or cancellation prevents the executor from being called. Core and ACP record guard denials as `execution_denied`; speculation stops at a boundary. When no guard is configured, these paths skip the asynchronous evaluator entirely, and Qwen Code does not configure a production guard in this PR.

The implementation contract and scope are documented in `docs/design/2026-07-30-host-tool-invocation-guard.md`.

## Why it's needed

An embedding host may need to enforce policy over the exact invocation that will reach a tool rather than the model's draft arguments. Existing permission and hook checks solve related problems but are not a single final, fail-closed embedding seam. This change adds that narrow runtime primitive while keeping task state, product authorization, policy transport, and audit storage outside Qwen Code.

## Reviewer Test Plan

### How to verify

1. Run `cd packages/core && npx vitest run src/core/tool-invocation-guard.test.ts --coverage.enabled=false`; all 9 evaluator tests should pass, including denial, malformed/throw/clone failure, argument isolation, and cancellation.
2. Run `cd packages/core && npx vitest run src/core/coreToolScheduler.test.ts -t "host guard" --coverage.enabled=false`; all 3 scheduler tests should pass, the guard should receive built shell parameters, denial/cancellation should produce zero executor calls, and allow should execute exactly once.
3. Run `cd packages/cli && npx vitest run src/acp-integration/session/Session.test.ts -t "host guard" --coverage.enabled=false`; all 3 ACP tests should pass with the same final-parameter, zero-execution, cancellation, and structured-denial behavior.
4. Run `cd packages/core && npx vitest run src/followup/speculation.test.ts --coverage.enabled=false`; all 15 tests should pass, including the denial-to-boundary test and existing unconfigured behavior.
5. Run `npm run build`, then `npm run typecheck`, then `npm run lint` at the repository root; all commands should pass.
6. Review the three call sites and confirm they only enter `evaluateToolInvocationGuard` after a non-undefined callback is read. No CLI flag, setting, environment variable, daemon route, provider client, or production setter is added.

### Evidence (Before & After)

N/A — this is a non-UI embedding API and enforcement-path change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS, Node.js 24.15.0. The focused suites above, repository-wide build, repository-wide typecheck, repository-wide lint, changed-file Prettier/ESLint, and `git diff --check` pass locally. Cross-platform validation is left to CI.

## Risk & Scope

- Main risk or tradeoff: once an embedding host configures the guard, provider and contract failures intentionally deny execution; a host-supplied denial reason is user-visible and must not contain secrets.
- Not validated / out of scope: an external provider transport, `qwen serve` configuration, product-specific task/plan/grant state, result callbacks, audit storage, arbitrary SDK consumers that invoke tools outside a Config-owned runtime, and local Windows/Linux execution.
- Breaking changes / migration notes: none. The configuration field is optional, has no in-repository production setter, and the unconfigured CLI/daemon path does not await or initialize a guard.

## Linked Issues

Related to #8102

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

增加一个可选的进程内宿主门禁，用于检查最终实际生效的工具调用。宿主通过 `ConfigParameters` 配置后，门禁会在执行前立即收到运行时 call ID、规范化工具名、构建后调用参数的结构化副本以及 abort signal。同一套 fail-closed 合约覆盖 core scheduler、ACP session runtime 和实验性的 speculation 路径。

显式拒绝、异常、非法决策、参数复制失败或取消都会阻止 executor 被调用。Core 和 ACP 将门禁拒绝记录为 `execution_denied`；speculation 则停止在 boundary。未配置门禁时，这些路径完全跳过异步 evaluator，而且本 PR 不在 Qwen Code 的任何生产启动入口配置门禁。

实现合约与范围记录在 `docs/design/2026-07-30-host-tool-invocation-guard.md`。

## 为什么需要

嵌入宿主可能需要针对真正送达工具的精确调用实施策略，而不能只检查模型生成的草稿参数。现有权限与 Hook 能解决相关问题，但它们不是一个统一的、最终的、fail-closed 嵌入接缝。本改动只补充这一项窄化的 runtime primitive，并把 Task 状态、产品鉴权、策略传输和审计存储留在 Qwen Code 之外。

## Reviewer 测试计划

### 如何验证

1. 运行 `cd packages/core && npx vitest run src/core/tool-invocation-guard.test.ts --coverage.enabled=false`；9 个 evaluator 测试应全部通过，包括拒绝、malformed/throw/clone failure、参数隔离和取消。
2. 运行 `cd packages/core && npx vitest run src/core/coreToolScheduler.test.ts -t "host guard" --coverage.enabled=false`；3 个 scheduler 测试应全部通过，门禁应收到构建后的 shell 参数，拒绝/取消时 executor 调用次数为零，允许时只执行一次。
3. 运行 `cd packages/cli && npx vitest run src/acp-integration/session/Session.test.ts -t "host guard" --coverage.enabled=false`；3 个 ACP 测试应全部通过，并具有相同的最终参数、零执行、取消和结构化拒绝语义。
4. 运行 `cd packages/core && npx vitest run src/followup/speculation.test.ts --coverage.enabled=false`；15 个测试应全部通过，包括拒绝转 boundary 和原有未配置行为。
5. 在仓库根目录依次运行 `npm run build`、`npm run typecheck`、`npm run lint`；所有命令应通过。
6. 审查三个调用点，确认只有读取到非空 callback 后才进入 `evaluateToolInvocationGuard`。本 PR 不新增 CLI flag、setting、环境变量、daemon route、provider client 或生产 setter。

### 前后证据

N/A——这是非 UI 的嵌入 API 与执行门禁变更。

### 已测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境

macOS，Node.js 24.15.0。以上聚焦测试、仓库级 build、仓库级 typecheck、仓库级 lint、变更文件 Prettier/ESLint 和 `git diff --check` 均在本地通过。跨平台验证交由 CI。

## 风险与范围

- 主要风险或取舍：嵌入宿主一旦配置门禁，provider 和合约失败会有意拒绝执行；宿主提供的拒绝原因对用户可见，不能包含秘密。
- 未验证或不在范围内：external provider transport、`qwen serve` 配置、产品特定 Task/Plan/grant 状态、结果 callback、审计存储、绕过 Config-owned runtime 直接调用工具的任意 SDK 消费方，以及本地 Windows/Linux 执行。
- 破坏性变更或迁移说明：无。配置字段可选，仓库内没有生产 setter，未配置的 CLI/daemon 路径不会等待或初始化门禁。

## 关联 Issue

关联 #8102

</details>
