### PR TITLE
fix(channels): disable native cron in daemon sessions

### DIFF
--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -42,6 +42,7 @@ import {
   WorkspaceMismatchError,
 } from './bridgeErrors.js';
 import { MAX_WORKSPACE_PATH_LENGTH } from './workspacePaths.js';
+import { SESSION_SOURCE_META_KEY } from './session-source.js';
 import {
   classifyTurnErrorKind,
   extractErrorMessage,
@@ -10816,8 +10817,47 @@ describe('createAcpSessionBridge', () => {
           sourceId: 'task-123',
         },
       });
+      expect(handles[0]?.agent.newSessionCalls[0]?._meta).toMatchObject({
+        [SESSION_SOURCE_META_KEY]: {
+          sourceType: 'scheduled_task',
+          sourceId: 'task-123',
+        },
+      });
 
       await bridge.shutdown();
+    });
+
+    it('carries persisted source metadata into ACP session restore', async () => {
+      for (const action of ['load', 'resume'] as const) {
+        const handle = makeChannel();
+        const bridge = makeBridge({
+          channelFactory: async () => handle.channel,
+        });
+        const request = {
+          sessionId: `channel-${action}`,
+          workspaceCwd: WS_A,
+          sourceType: 'channel',
+          sourceId: 'dingtalk-main',
+        };
+
+        if (action === 'load') {
+          await bridge.loadSession(request);
+        } else {
+          await bridge.resumeSession(request);
+        }
+
+        const call =
+          action === 'load'
+            ? handle.agent.loadSessionCalls[0]
+            : handle.agent.resumeSessionCalls[0];
+        expect(call?._meta).toMatchObject({
+          [SESSION_SOURCE_META_KEY]: {
+            sourceType: 'channel',
+            sourceId: 'dingtalk-main',
+          },
+        });
+        await bridge.shutdown();
+      }
     });
 
     it('does not replace the source when single scope attaches', async () => {

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -94,7 +94,10 @@ import {
   canonicalizeWorkspace,
   translateAndCheckAbsoluteWorkspacePath,
 } from './workspacePaths.js';
-import { parseSessionSource } from './session-source.js';
+import {
+  parseSessionSource,
+  SESSION_SOURCE_META_KEY,
+} from './session-source.js';
 import {
   CHANNEL_STARTUP_PROFILE_META_KEY,
   CHANNEL_STARTUP_PROFILE_VERSION,
@@ -212,6 +215,20 @@ const MAX_BULK_REPLAY_UPDATES = 10_000;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function sessionSourceRequestMeta(
+  sourceType: string | undefined,
+  sourceId: string | undefined,
+): Record<string, unknown> {
+  return sourceType
+    ? {
+        [SESSION_SOURCE_META_KEY]: {
+          sourceType,
+          ...(sourceId !== undefined ? { sourceId } : {}),
+        },
+      }
+    : {};
 }
 
 function isDefinitiveAcpRequestError(error: unknown): boolean {
@@ -2633,6 +2650,11 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
                 telemetry.injectPromptContext({
                   cwd: boundWorkspace,
                   mcpServers: [],
+                  ...(sourceType
+                    ? {
+                        _meta: sessionSourceRequestMeta(sourceType, sourceId),
+                      }
+                    : {}),
                 }),
               ),
               initTimeoutMs,
@@ -4562,14 +4584,23 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
                 // intentionally has no `mcpServers` field for the
                 // same reason.
                 mcpServers: [],
-                ...(historyReplay === 'response'
+                ...(historyReplay === 'response' || req.sourceType
                   ? {
                       _meta: {
-                        [LOAD_REPLAY_MODE_META_KEY]: LOAD_REPLAY_BULK_MODE,
-                        ...(req.historyPageSize !== undefined
+                        ...sessionSourceRequestMeta(
+                          req.sourceType,
+                          req.sourceId,
+                        ),
+                        ...(historyReplay === 'response'
                           ? {
-                              [LOAD_REPLAY_PAGE_SIZE_META_KEY]:
-                                req.historyPageSize,
+                              [LOAD_REPLAY_MODE_META_KEY]:
+                                LOAD_REPLAY_BULK_MODE,
+                              ...(req.historyPageSize !== undefined
+                                ? {
+                                    [LOAD_REPLAY_PAGE_SIZE_META_KEY]:
+                                      req.historyPageSize,
+                                  }
+                                : {}),
                             }
                           : {}),
                       },
@@ -4588,6 +4619,14 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
                 sessionId: req.sessionId,
                 cwd: workspaceKey,
                 mcpServers: [],
+                ...(req.sourceType
+                  ? {
+                      _meta: sessionSourceRequestMeta(
+                        req.sourceType,
+                        req.sourceId,
+                      ),
+                    }
+                  : {}),
               }),
               initTimeoutMs,
               'resumeSession',

--- a/packages/acp-bridge/src/session-source.ts
+++ b/packages/acp-bridge/src/session-source.ts
@@ -3,6 +3,7 @@ export interface SessionSourceMetadata {
   sourceId?: string;
 }
 
+export const SESSION_SOURCE_META_KEY = 'qwen.session.source';
 export const SESSION_SOURCE_TYPE_PATTERN = /^[a-z][a-z0-9_-]{0,63}$/;
 export const MAX_SESSION_SOURCE_ID_LENGTH = 256;
 

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -835,6 +835,7 @@ import {
   APPROVAL_MODES,
 } from '@qwen-code/qwen-code-core';
 import { ndJsonStream } from '@qwen-code/acp-bridge/ndJsonStream';
+import { SESSION_SOURCE_META_KEY } from '@qwen-code/acp-bridge';
 import type {
   Agent,
   LoadSessionResponse,
@@ -2679,6 +2680,53 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
 
       mockConnectionState.resolve();
       await agentPromise;
+    },
+  );
+
+  it.each([
+    ['channel', 'channel', false],
+    ['scheduled task', 'scheduled_task', true],
+    ['unattributed', undefined, true],
+  ])(
+    'sets native Cron for a %s daemon session without mutating persisted settings',
+    async (_label, sourceType, expectedCron) => {
+      await setupSessionMocks(`session-cron-${sourceType ?? 'default'}`);
+      const requestSettings = makeSessionSettings();
+      requestSettings.merged.experimental = { cron: true };
+      vi.mocked(loadSettings).mockReturnValue(requestSettings);
+
+      const agentPromise = runAcpAgent(
+        mockConfig,
+        makeSessionSettings(),
+        mockArgv,
+      );
+      await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+      const agent = capturedAgentFactory!({
+        get closed() {
+          return mockConnectionState.promise;
+        },
+      }) as AgentLike;
+
+      try {
+        await agent.newSession({
+          cwd: '/tmp',
+          mcpServers: [],
+          ...(sourceType
+            ? {
+                _meta: {
+                  [SESSION_SOURCE_META_KEY]: { sourceType },
+                },
+              }
+            : {}),
+        });
+
+        const sessionSettings = vi.mocked(loadCliConfig).mock.calls[0]?.[0];
+        expect(sessionSettings?.experimental?.cron).toBe(expectedCron);
+        expect(requestSettings.merged.experimental?.cron).toBe(true);
+      } finally {
+        mockConnectionState.resolve();
+        await agentPromise;
+      }
     },
   );
 

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -13198,6 +13198,38 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
     expect(innerConfig.shutdown).toHaveBeenCalledTimes(2);
   });
 
+  it.each(['load', 'resume'] as const)(
+    'disables native Cron when %s restores a channel session',
+    async (action) => {
+      bindRestoreMocks({ sessionExists: true });
+      const requestSettings = makeRestoreSettings();
+      requestSettings.merged.experimental = { cron: true };
+      vi.mocked(loadSettings).mockReturnValue(requestSettings);
+      const { agent, agentPromise } = await spawnAgent();
+      const params = {
+        cwd: '/tmp',
+        sessionId: 'persisted-1',
+        mcpServers: [],
+        _meta: {
+          [SESSION_SOURCE_META_KEY]: { sourceType: 'channel' },
+        },
+      };
+
+      if (action === 'load') {
+        await agent.loadSession(params);
+      } else {
+        await agent.unstable_resumeSession(params);
+      }
+
+      const sessionSettings = vi.mocked(loadCliConfig).mock.calls[0]?.[0];
+      expect(sessionSettings?.experimental?.cron).toBe(false);
+      expect(requestSettings.merged.experimental?.cron).toBe(true);
+
+      mockConnectionState.resolve();
+      await agentPromise;
+    },
+  );
+
   /**
    * A persisted `system` / `slash_command` record carrying goal cards — the only
    * place a daemon transcript stores them.

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -291,7 +291,10 @@ import {
   type ServeWorkspaceExtensionsStatus,
   IDLE_HOOK_EVENTS,
 } from '@qwen-code/acp-bridge/status';
-import { parseSessionSource } from '@qwen-code/acp-bridge';
+import {
+  parseSessionSource,
+  SESSION_SOURCE_META_KEY,
+} from '@qwen-code/acp-bridge';
 import {
   CHANNEL_STARTUP_PROFILE_META_KEY,
   CHANNEL_STARTUP_PROFILE_VERSION,
@@ -621,6 +624,12 @@ function invalidArtifactPersistPayload(): Error {
 function isBulkLoadReplayRequest(params: LoadSessionRequest): boolean {
   const meta = isObjectRecord(params._meta) ? params._meta : undefined;
   return meta?.[LOAD_REPLAY_MODE_META_KEY] === LOAD_REPLAY_BULK_MODE;
+}
+
+function isChannelSessionRequest(params: { _meta?: unknown }): boolean {
+  const meta = isObjectRecord(params._meta) ? params._meta : undefined;
+  const value = meta?.[SESSION_SOURCE_META_KEY];
+  return isObjectRecord(value) && value['sourceType'] === 'channel';
 }
 
 function getLoadReplayPageSize(params: LoadSessionRequest): number | undefined {
@@ -4327,6 +4336,7 @@ class QwenAgent implements Agent {
 
   async newSession(params: NewSessionRequest): Promise<NewSessionResponse> {
     const { cwd, mcpServers } = params;
+    const isChannelSession = isChannelSessionRequest(params);
     const parentContext = extractDaemonTraceContext(params);
     return await withDaemonSpan(
       'qwen-code.daemon.session_start',
@@ -4344,7 +4354,7 @@ class QwenAgent implements Agent {
         );
         this.settings = settings;
         const config = await profiler.time('config_setup', () =>
-          this.newSessionConfig(cwd, mcpServers, settings),
+          this.newSessionConfig(cwd, mcpServers, settings, isChannelSession),
         );
         let session: Session;
         try {
@@ -4377,6 +4387,7 @@ class QwenAgent implements Agent {
   }
 
   async loadSession(params: LoadSessionRequest): Promise<LoadSessionResponse> {
+    const isChannelSession = isChannelSessionRequest(params);
     // Load per-request settings BEFORE the existence check: the check must
     // resolve `advanced.runtimeOutputDir` from THIS request's cwd, not from
     // whichever settings a concurrent handler loaded last.
@@ -4462,6 +4473,7 @@ class QwenAgent implements Agent {
       // a `null`/`undefined` would otherwise throw `TypeError`.
       params.mcpServers ?? [],
       settings,
+      isChannelSession,
       params.sessionId,
       true,
     );
@@ -4558,6 +4570,7 @@ class QwenAgent implements Agent {
   async unstable_resumeSession(
     params: ResumeSessionRequest,
   ): Promise<ResumeSessionResponse> {
+    const isChannelSession = isChannelSessionRequest(params);
     // Same per-request settings discipline as `loadSession`.
     const settings = loadSettingsCached(params.cwd);
     const liveSession = this.sessions.get(params.sessionId);
@@ -4595,6 +4608,7 @@ class QwenAgent implements Agent {
       params.cwd,
       params.mcpServers ?? [],
       settings,
+      isChannelSession,
       params.sessionId,
       true,
     );
@@ -10575,6 +10589,7 @@ class QwenAgent implements Agent {
       [],
       settings,
       undefined,
+      undefined,
       false,
       {
         skipMcpDiscovery: true,
@@ -10621,6 +10636,7 @@ class QwenAgent implements Agent {
     cwd: string,
     mcpServers: McpServer[],
     settings: LoadedSettings,
+    isChannelSession?: boolean,
     sessionId?: string,
     resume?: boolean,
     initializeOptions: ConfigInitializeOptions = {},
@@ -10637,6 +10653,7 @@ class QwenAgent implements Agent {
           cwd,
           mcpServers,
           settings,
+          isChannelSession,
           sessionId,
           resume,
           initializeOptions,
@@ -10658,6 +10675,7 @@ class QwenAgent implements Agent {
     cwd: string,
     mcpServers: McpServer[],
     settings: LoadedSettings,
+    isChannelSession?: boolean,
     sessionId?: string,
     resume?: boolean,
     initializeOptions: ConfigInitializeOptions = {},
@@ -10728,6 +10746,7 @@ class QwenAgent implements Agent {
       experimental: {
         ...settings.merged.experimental,
         sessionWriterLease: this.sessionWriterLeaseEnabledAtStartup,
+        ...(isChannelSession ? { cron: false } : {}),
       },
     };
 


### PR DESCRIPTION
## What this PR does

This change carries immutable session-source attribution into ACP session creation and restoration, then disables native Cron only while initializing daemon-managed Channel sessions. Channel agents therefore use the Channel Loop tools for scheduled work, while scheduled-task and unattributed daemon sessions retain native Cron. The existing transcript source metadata remains unchanged.

## Why it's needed

A natural-language scheduling request received through a daemon-managed Channel could select the native `cron_create` tool. That job continued firing inside the ACP session but was absent from the Channel Loop store, so it had no proactive delivery path back to DingTalk. This restores the expected Channel-owned scheduling and delivery boundary.

## Reviewer Test Plan

### How to verify

- Start a daemon-managed Channel with native Cron enabled in persisted settings, ask it to create a recurring reminder, and confirm the agent is offered the Channel Loop path rather than native Cron.
- Restart the daemon and restore the Channel session; confirm the same Channel-only scheduling behavior remains in effect.
- Start a scheduled-task or unattributed daemon session with native Cron enabled; confirm native Cron remains enabled.
- Confirm persisted settings are not rewritten when the Channel-specific override is applied.

### Evidence (Before & After)

Before: a live DingTalk direct-message request created a session-only native Cron job. The transcript recorded more than 40 internal firings, but the job was absent from the Channel Loop store and no proactive DingTalk reminder was delivered.

After: regression coverage verifies that source attribution reaches ACP create, load, and resume requests; Channel initialization receives `cron: false`; scheduled-task and unattributed sessions retain `cron: true`; and the persisted settings object remains unchanged. The complete ACP bridge test file passed 459/459 tests and the complete ACP agent test file passed 338/338 tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22.17.0. Package lint, the repository build, the repository typecheck, and both complete regression suites passed.

## Risk & Scope

- Main risk or tradeoff: the source attribution uses a namespaced ACP `_meta` entry; requests without that entry and all non-Channel source types follow the previous behavior.
- Not validated / out of scope: a post-fix live DingTalk delivery run was not performed because it would require replacing the currently installed CLI/daemon; the initialization and restore contracts are covered by regression tests.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #8030

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本改动将不可变的会话来源信息带入 ACP 会话创建和恢复请求，并且只在初始化 daemon 管理的 Channel 会话时关闭原生 Cron。因此 Channel Agent 会使用 Channel Loop 工具处理定时任务，而定时任务来源和无来源的 daemon 会话仍保留原生 Cron。现有的 transcript 来源元数据持久化行为不变。

## 为什么需要

daemon 管理的 Channel 收到自然语言定时请求后，之前可能选择原生 `cron_create` 工具。该任务会在 ACP 会话内部持续触发，但不会进入 Channel Loop 存储，因此没有主动投递回钉钉的链路。本修复恢复了由 Channel 负责定时和投递的边界。

## Reviewer 测试计划

### 如何验证

- 在持久化设置已启用原生 Cron 的情况下启动 daemon 管理的 Channel，请它创建循环提醒，确认 Agent 只获得 Channel Loop 路径而不是原生 Cron。
- 重启 daemon 并恢复 Channel 会话，确认仍保持仅使用 Channel 定时能力。
- 启动定时任务来源或无来源的 daemon 会话并启用原生 Cron，确认原生 Cron 仍可用。
- 确认应用 Channel 专属覆盖时不会改写持久化设置。

### 证据（修复前与修复后）

修复前：一次真实的钉钉单聊请求创建了仅会话有效的原生 Cron 任务。Transcript 记录了 40 多次内部触发，但 Channel Loop 存储中没有该任务，钉钉也没有收到主动提醒。

修复后：回归测试验证了来源信息会进入 ACP 创建、加载和恢复请求；Channel 初始化收到 `cron: false`；定时任务和无来源会话仍收到 `cron: true`；持久化设置对象保持不变。ACP bridge 完整测试文件 459/459 通过，ACP agent 完整测试文件 338/338 通过。

### 已测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|     🍏 macOS      |  ✅  |
|    🪟 Windows     |  ⚠️  |
|     🐧 Linux      |  ⚠️  |

### 环境（可选）

Node.js 22.17.0。包级 lint、仓库级构建、仓库级类型检查和两组完整回归测试均通过。

## 风险与范围

- 主要风险或权衡：来源信息使用带命名空间的 ACP `_meta` 条目；没有该条目的请求以及所有非 Channel 来源类型都保持原行为。
- 未验证或不在范围内：没有执行修复后的真实钉钉投递，因为这需要替换当前安装的 CLI/daemon；初始化和恢复契约已由回归测试覆盖。
- 破坏性变更或迁移说明：无。

## 关联 Issue

Fixes #8030

</details>
