### PR TITLE
fix(web-shell): stabilize enhanced table controls

### DIFF
--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.module.css
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.module.css
@@ -190,10 +190,6 @@
   background: linear-gradient(90deg, rgb(0 0 0 / 8%), rgb(0 0 0 / 0));
 }
 
-.scrollerWithDetail {
-  max-height: none;
-}
-
 .table {
   --action-column-width: 40px;
 

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.module.css
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.module.css
@@ -128,6 +128,16 @@
   font-size: 12px;
 }
 
+.densityTrigger:focus,
+.densityTrigger:focus-visible,
+.densityTrigger[data-state='open'] {
+  border-color: transparent;
+  box-shadow: none;
+  outline: none;
+  --tw-ring-color: transparent;
+  --tw-ring-shadow: 0 0 #0000;
+}
+
 .densityTrigger svg,
 .densityMenu svg {
   width: 14px;
@@ -160,6 +170,7 @@
 }
 
 .scroller {
+  position: relative;
   container: table-scroller / inline-size;
   max-width: 100%;
   max-height: min(75vh, 720px);
@@ -168,23 +179,35 @@
   outline: none;
 }
 
-.scrollerWithDetail {
-  max-height: none;
+.frozenColumnShadow {
+  position: absolute;
+  top: 38px;
+  bottom: 0;
+  z-index: 9;
+  width: 14px;
+  pointer-events: none;
+  transform: translateX(-1px);
+  background: linear-gradient(90deg, rgb(0 0 0 / 8%), rgb(0 0 0 / 0));
 }
 
-.scroller:focus-visible {
-  outline: 2px solid var(--agent-blue-500);
-  outline-offset: -2px;
+.scrollerWithDetail {
+  max-height: none;
 }
 
 .table {
   --action-column-width: 40px;
 
-  width: max-content;
-  min-width: 100%;
+  width: 100%;
   border-collapse: separate;
   border-spacing: 0;
   font-size: 13px;
+  table-layout: fixed;
+}
+
+.actionColumn {
+  width: var(--action-column-width);
+  min-width: var(--action-column-width);
+  max-width: var(--action-column-width);
 }
 
 .headerCell,
@@ -410,9 +433,7 @@ tr:hover .selectedCell {
 
 .hasFrozenColumn .frozenHeaderCell,
 .hasFrozenColumn .frozenCell {
-  box-shadow:
-    8px 0 14px -12px rgb(0 0 0 / 55%),
-    inset -1px 0 0 var(--border, rgb(255 255 255 / 18%));
+  box-shadow: inset -1px 0 0 var(--border, rgb(255 255 255 / 18%));
 }
 
 .stickyActionHeaderCell,

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.module.css
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.module.css
@@ -206,10 +206,28 @@
   max-width: var(--action-column-width);
 }
 
+.fillerColumn {
+  width: auto;
+}
+
 .headerCell,
 .cell {
   box-sizing: border-box;
   border-bottom: 1px solid var(--border);
+}
+
+.fillerHeaderCell,
+.fillerCell {
+  padding: 0;
+  border-bottom: 1px solid var(--border);
+  background: var(--card);
+}
+
+.fillerHeaderCell {
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  height: 40px;
 }
 
 .headerCell {
@@ -384,6 +402,10 @@
 }
 
 tr:hover .cell {
+  background: var(--subtle-bg-strong);
+}
+
+tr:hover .fillerCell {
   background: var(--subtle-bg-strong);
 }
 

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.module.css
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.module.css
@@ -1,5 +1,6 @@
 .tableShell {
   position: relative;
+  --toolbar-height: 38px;
   max-width: 100%;
   margin: 8px 0;
   overflow: visible;
@@ -52,7 +53,7 @@
   gap: 8px;
   align-items: center;
   box-sizing: border-box;
-  height: 38px;
+  height: var(--toolbar-height);
   padding: 4px 10px;
   border-bottom: 1px solid var(--border);
   border-radius: 14px 14px 0 0;
@@ -128,8 +129,6 @@
   font-size: 12px;
 }
 
-.densityTrigger:focus,
-.densityTrigger:focus-visible,
 .densityTrigger[data-state='open'] {
   border-color: transparent;
   box-shadow: none;
@@ -179,9 +178,14 @@
   outline: none;
 }
 
+.scroller:focus-visible {
+  outline: 2px solid var(--agent-blue-500);
+  outline-offset: -2px;
+}
+
 .frozenColumnShadow {
   position: absolute;
-  top: 38px;
+  top: var(--toolbar-height);
   bottom: 0;
   z-index: 9;
   width: 14px;

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
@@ -1448,6 +1448,30 @@ describe('EnhancedMarkdownTable', () => {
     );
   });
 
+  it('spans the detail row across the filler column', () => {
+    const container = renderTable();
+
+    for (const column of ['Team', 'Score']) {
+      act(() => {
+        button(container, `Resize ${column}`).dispatchEvent(
+          new KeyboardEvent('keydown', {
+            bubbles: true,
+            key: 'ArrowRight',
+          }),
+        );
+      });
+    }
+    expect(container.querySelector('[class*="fillerColumn"]')).not.toBeNull();
+
+    click(button(container, 'View details for row 1'));
+
+    const detailCell = container.querySelector<HTMLTableCellElement>(
+      '[class*="detailCell"]',
+    );
+    expect(detailCell).not.toBeNull();
+    expect(detailCell!.colSpan).toBe(4);
+  });
+
   it('resizes compact auto columns from their rendered width with keyboard arrows', () => {
     const container = renderTable();
     selectValue(button(container, 'Table density'), 'compact');
@@ -1643,6 +1667,68 @@ describe('EnhancedMarkdownTable', () => {
       container.querySelector<HTMLElement>('[class*="frozenColumnShadow"]')
         ?.style.left,
     ).toBe('280px');
+  });
+
+  it('repositions the frozen shadow when the ResizeObserver fires', () => {
+    const callbacks: ResizeObserverCallback[] = [];
+    const OriginalResizeObserver = globalThis.ResizeObserver;
+    class CapturingResizeObserver {
+      constructor(private readonly callback: ResizeObserverCallback) {
+        callbacks.push(callback);
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver =
+      CapturingResizeObserver;
+
+    try {
+      const container = renderWideTable();
+      const shell = container.querySelector<HTMLElement>(
+        '[class*="tableShell"]',
+      );
+      const header = button(container, 'Sort by Team').closest('th');
+      expect(shell).not.toBeNull();
+      expect(header).not.toBeNull();
+      Object.defineProperty(shell, 'clientLeft', {
+        configurable: true,
+        value: 1,
+      });
+      Object.defineProperty(shell, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => ({ left: 20 }) as DOMRect,
+      });
+      Object.defineProperty(header, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => ({ right: 301 }) as DOMRect,
+      });
+
+      freezeFirstColumn(container);
+
+      expect(
+        container.querySelector<HTMLElement>('[class*="frozenColumnShadow"]')
+          ?.style.left,
+      ).toBe('280px');
+
+      Object.defineProperty(header, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => ({ right: 351 }) as DOMRect,
+      });
+      act(() => {
+        for (const cb of callbacks) {
+          cb([], {} as ResizeObserver);
+        }
+      });
+
+      expect(
+        container.querySelector<HTMLElement>('[class*="frozenColumnShadow"]')
+          ?.style.left,
+      ).toBe('330px');
+    } finally {
+      (globalThis as { ResizeObserver?: unknown }).ResizeObserver =
+        OriginalResizeObserver;
+    }
   });
 
   it('dismisses the first-column context menu without clearing the active column', () => {
@@ -2054,6 +2140,24 @@ describe('EnhancedMarkdownTable', () => {
 
     expect(rowRect).toHaveBeenCalledTimes(2);
     expect(container.scrollTop).toBe(200);
+    expect(detailsButton.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('falls back to window.scrollBy when no scroll ancestor exists', () => {
+    const container = renderTable();
+    const scrollBySpy = vi
+      .spyOn(window, 'scrollBy')
+      .mockImplementation(() => {});
+    const detailsButton = button(container, 'View details for row 3');
+    const row = detailsButton.closest('tr');
+    expect(row).not.toBeNull();
+    vi.spyOn(row!, 'getBoundingClientRect')
+      .mockReturnValueOnce({ top: 120 } as DOMRect)
+      .mockReturnValueOnce({ top: 280 } as DOMRect);
+
+    click(detailsButton);
+
+    expect(scrollBySpy).toHaveBeenCalledWith(0, 160);
     expect(detailsButton.getAttribute('aria-expanded')).toBe('true');
   });
 

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
@@ -321,6 +321,17 @@ function dataCell(
   return cell!;
 }
 
+function columnGroup(
+  container: HTMLElement,
+  visibleColumnIndex: number,
+): HTMLColElement {
+  const col = [...container.querySelectorAll<HTMLColElement>('col')].slice(1)[
+    visibleColumnIndex
+  ];
+  expect(col).toBeDefined();
+  return col!;
+}
+
 function dragCells(from: Element, to: Element): void {
   act(() => {
     from.dispatchEvent(
@@ -1213,10 +1224,7 @@ describe('EnhancedMarkdownTable', () => {
       window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
     });
 
-    expect(button(container, 'Sort by Team').closest('th')?.style.width).toBe(
-      '220px',
-    );
-    expect(dataCell(container, 0, 0).style.width).toBe('220px');
+    expect(columnGroup(container, 0).style.width).toBe('220px');
   });
 
   it('clamps resized columns to the minimum width', () => {
@@ -1239,10 +1247,7 @@ describe('EnhancedMarkdownTable', () => {
       window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
     });
 
-    expect(button(container, 'Sort by Team').closest('th')?.style.width).toBe(
-      '80px',
-    );
-    expect(dataCell(container, 0, 0).style.width).toBe('80px');
+    expect(columnGroup(container, 0).style.width).toBe('80px');
   });
 
   it('clamps resized columns to the maximum width', () => {
@@ -1265,10 +1270,7 @@ describe('EnhancedMarkdownTable', () => {
       window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
     });
 
-    expect(button(container, 'Sort by Team').closest('th')?.style.width).toBe(
-      '640px',
-    );
-    expect(dataCell(container, 0, 0).style.width).toBe('640px');
+    expect(columnGroup(container, 0).style.width).toBe('640px');
   });
 
   it('stops resizing a column when the window blurs', () => {
@@ -1293,9 +1295,7 @@ describe('EnhancedMarkdownTable', () => {
       );
     });
 
-    expect(button(container, 'Sort by Team').closest('th')?.style.width).toBe(
-      '160px',
-    );
+    expect(columnGroup(container, 0).style.width).toContain('160px');
   });
 
   it('flushes pending resize width when the window blurs', () => {
@@ -1318,9 +1318,7 @@ describe('EnhancedMarkdownTable', () => {
       window.dispatchEvent(new Event('blur'));
     });
 
-    expect(button(container, 'Sort by Team').closest('th')?.style.width).toBe(
-      '260px',
-    );
+    expect(columnGroup(container, 0).style.width).toBe('260px');
   });
 
   it('stops resizing a column when page visibility changes', () => {
@@ -1349,9 +1347,7 @@ describe('EnhancedMarkdownTable', () => {
       );
     });
 
-    expect(button(container, 'Sort by Team').closest('th')?.style.width).toBe(
-      '160px',
-    );
+    expect(columnGroup(container, 0).style.width).toContain('160px');
   });
 
   it('keeps resizing when page visibility changes while visible', () => {
@@ -1381,9 +1377,7 @@ describe('EnhancedMarkdownTable', () => {
       window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
     });
 
-    expect(button(container, 'Sort by Team').closest('th')?.style.width).toBe(
-      '280px',
-    );
+    expect(columnGroup(container, 0).style.width).toBe('280px');
   });
 
   it('resizes a column with keyboard arrows', () => {
@@ -1399,9 +1393,7 @@ describe('EnhancedMarkdownTable', () => {
       );
     });
 
-    expect(button(container, 'Sort by Team').closest('th')?.style.width).toBe(
-      '176px',
-    );
+    expect(columnGroup(container, 0).style.width).toBe('176px');
 
     act(() => {
       resize.dispatchEvent(
@@ -1412,9 +1404,7 @@ describe('EnhancedMarkdownTable', () => {
       );
     });
 
-    expect(button(container, 'Sort by Team').closest('th')?.style.width).toBe(
-      '160px',
-    );
+    expect(columnGroup(container, 0).style.width).toContain('160px');
   });
 
   it('uses a filler column after every visible column is manually sized', () => {
@@ -1522,7 +1512,7 @@ describe('EnhancedMarkdownTable', () => {
       );
     });
 
-    expect(header?.style.width).toBe('108px');
+    expect(columnGroup(container, 0).style.width).toBe('108px');
   });
 
   it('ignores keyboard resize arrows with modifiers', () => {
@@ -1539,9 +1529,7 @@ describe('EnhancedMarkdownTable', () => {
       );
     });
 
-    expect(button(container, 'Sort by Team').closest('th')?.style.width).toBe(
-      '160px',
-    );
+    expect(columnGroup(container, 0).style.width).toContain('160px');
   });
 
   it('reorders columns and quick copies in the visible order', () => {
@@ -2144,13 +2132,11 @@ describe('EnhancedMarkdownTable', () => {
   it('selects display density from the toolbar', () => {
     const container = renderTable();
     const shell = container.querySelector<HTMLElement>('[class*="tableShell"]');
-    const teamHeader = button(container, 'Sort by Team').closest('th');
     const columns = () => Array.from(container.querySelectorAll('col'));
     expect(shell?.className).toContain('densityStandard');
     expect(button(container, 'Table density').textContent).toContain(
       'Standard density',
     );
-    expect(teamHeader?.style.width).toBe('160px');
     expect(columns()[0]?.style.width).toBe('40px');
     expect(columns()[1]?.style.width).toContain('160px');
 
@@ -2159,9 +2145,6 @@ describe('EnhancedMarkdownTable', () => {
     expect(button(container, 'Table density').textContent).toContain(
       'Compact density',
     );
-    expect(teamHeader?.style.width).toBe('auto');
-    expect(teamHeader?.style.minWidth).toBe('');
-    expect(teamHeader?.style.maxWidth).toBe('');
     expect(columns()[0]?.style.width).toBe('40px');
     expect(columns()[1]?.style.width).toContain('72px');
     expect(columns()[1]?.style.width).not.toContain('160px');
@@ -2171,7 +2154,6 @@ describe('EnhancedMarkdownTable', () => {
     expect(button(container, 'Table density').textContent).toContain(
       'Comfortable density',
     );
-    expect(teamHeader?.style.width).toBe('160px');
     expect(columns()[0]?.style.width).toBe('40px');
     expect(columns()[1]?.style.width).toContain('160px');
   });

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
@@ -1448,6 +1448,26 @@ describe('EnhancedMarkdownTable', () => {
     );
   });
 
+  it('subtracts fixed widths from the flexible column calc()', () => {
+    const container = renderTable();
+
+    act(() => {
+      button(container, 'Resize Team').dispatchEvent(
+        new KeyboardEvent('keydown', {
+          bubbles: true,
+          key: 'ArrowRight',
+        }),
+      );
+    });
+
+    const columns = Array.from(container.querySelectorAll('col'));
+    expect(columns).toHaveLength(3);
+    expect(columns[1]?.style.width).toBe('176px');
+    expect(columns[2]?.style.width).toContain('176px');
+    expect(columns[2]?.style.width).toContain('calc');
+    expect(container.querySelector('[class*="fillerColumn"]')).toBeNull();
+  });
+
   it('spans the detail row across the filler column', () => {
     const container = renderTable();
 

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
@@ -2007,6 +2007,25 @@ describe('EnhancedMarkdownTable', () => {
     expect(textButton(container, 'Collapse text')).toBeDefined();
   });
 
+  it('keeps the opened row anchored when the table scroller expands', () => {
+    const container = renderTable();
+    container.style.overflowY = 'auto';
+    container.scrollTop = 40;
+    const detailsButton = button(container, 'View details for row 3');
+    const row = detailsButton.closest('tr');
+    expect(row).not.toBeNull();
+    const rowRect = vi
+      .spyOn(row!, 'getBoundingClientRect')
+      .mockReturnValueOnce({ top: 120 } as DOMRect)
+      .mockReturnValueOnce({ top: 280 } as DOMRect);
+
+    click(detailsButton);
+
+    expect(rowRect).toHaveBeenCalledTimes(2);
+    expect(container.scrollTop).toBe(200);
+    expect(detailsButton.getAttribute('aria-expanded')).toBe('true');
+  });
+
   it('shows statistics for a numeric selection', () => {
     const container = renderTable();
 

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
@@ -1451,6 +1451,17 @@ describe('EnhancedMarkdownTable', () => {
   it('subtracts fixed widths from the flexible column calc()', () => {
     const container = renderTable();
 
+    const initialColumns = Array.from(container.querySelectorAll('col'));
+    // Two flexible columns share the remaining width, so the divisor is 2
+    // (jsdom serializes `/ 2` as `0.5 *`); a `/ 1` mutant would claim the
+    // full width and fail this assertion.
+    expect(initialColumns[1]?.style.width).toContain(
+      '0.5 * (100cqw - 40px - 0px)',
+    );
+    expect(initialColumns[2]?.style.width).toContain(
+      '0.5 * (100cqw - 40px - 0px)',
+    );
+
     act(() => {
       button(container, 'Resize Team').dispatchEvent(
         new KeyboardEvent('keydown', {
@@ -1463,8 +1474,7 @@ describe('EnhancedMarkdownTable', () => {
     const columns = Array.from(container.querySelectorAll('col'));
     expect(columns).toHaveLength(3);
     expect(columns[1]?.style.width).toBe('176px');
-    expect(columns[2]?.style.width).toContain('176px');
-    expect(columns[2]?.style.width).toContain('calc');
+    expect(columns[2]?.style.width).toContain('1 * (100cqw - 40px - 176px)');
     expect(container.querySelector('[class*="fillerColumn"]')).toBeNull();
   });
 
@@ -1748,6 +1758,56 @@ describe('EnhancedMarkdownTable', () => {
     } finally {
       (globalThis as { ResizeObserver?: unknown }).ResizeObserver =
         OriginalResizeObserver;
+    }
+  });
+
+  it('repositions the frozen shadow on window resize without ResizeObserver', () => {
+    const OriginalResizeObserver = globalThis.ResizeObserver;
+    // @ts-expect-error -- force the window-resize fallback branch
+    delete globalThis.ResizeObserver;
+
+    try {
+      const container = renderWideTable();
+      const shell = container.querySelector<HTMLElement>(
+        '[class*="tableShell"]',
+      );
+      const header = button(container, 'Sort by Team').closest('th');
+      expect(shell).not.toBeNull();
+      expect(header).not.toBeNull();
+      Object.defineProperty(shell, 'clientLeft', {
+        configurable: true,
+        value: 1,
+      });
+      Object.defineProperty(shell, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => ({ left: 20 }) as DOMRect,
+      });
+      Object.defineProperty(header, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => ({ right: 301 }) as DOMRect,
+      });
+
+      freezeFirstColumn(container);
+
+      expect(
+        container.querySelector<HTMLElement>('[class*="frozenColumnShadow"]')
+          ?.style.left,
+      ).toBe('280px');
+
+      Object.defineProperty(header, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => ({ right: 351 }) as DOMRect,
+      });
+      act(() => {
+        window.dispatchEvent(new Event('resize'));
+      });
+
+      expect(
+        container.querySelector<HTMLElement>('[class*="frozenColumnShadow"]')
+          ?.style.left,
+      ).toBe('330px');
+    } finally {
+      globalThis.ResizeObserver = OriginalResizeObserver;
     }
   });
 

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
@@ -1417,6 +1417,37 @@ describe('EnhancedMarkdownTable', () => {
     );
   });
 
+  it('uses a filler column after every visible column is manually sized', () => {
+    const container = renderTable();
+    const table = container.querySelector('table');
+    expect(table).not.toBeNull();
+    expect(container.querySelector('[class*="fillerColumn"]')).toBeNull();
+
+    for (const column of ['Team', 'Score']) {
+      act(() => {
+        button(container, `Resize ${column}`).dispatchEvent(
+          new KeyboardEvent('keydown', {
+            bubbles: true,
+            key: 'ArrowRight',
+          }),
+        );
+      });
+    }
+
+    const columns = Array.from(table!.querySelectorAll('col'));
+    expect(columns).toHaveLength(4);
+    expect(columns[0]?.style.width).toBe('40px');
+    expect(columns[1]?.style.width).toBe('176px');
+    expect(columns[2]?.style.width).toBe('176px');
+    expect(columns[3]?.className).toContain('fillerColumn');
+    expect(table!.querySelector('thead th:last-child')?.className).toContain(
+      'fillerHeaderCell',
+    );
+    expect(table!.querySelector('tbody td:last-child')?.className).toContain(
+      'fillerCell',
+    );
+  });
+
   it('resizes compact auto columns from their rendered width with keyboard arrows', () => {
     const container = renderTable();
     selectValue(button(container, 'Table density'), 'compact');

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
@@ -1587,6 +1587,33 @@ describe('EnhancedMarkdownTable', () => {
     ).not.toContain('frozenHeaderCell');
   });
 
+  it('positions the frozen shadow from the rendered column edge', () => {
+    const container = renderWideTable();
+    const shell = container.querySelector<HTMLElement>('[class*="tableShell"]');
+    const header = button(container, 'Sort by Team').closest('th');
+    expect(shell).not.toBeNull();
+    expect(header).not.toBeNull();
+    Object.defineProperty(shell, 'clientLeft', {
+      configurable: true,
+      value: 1,
+    });
+    Object.defineProperty(shell, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ left: 20 }) as DOMRect,
+    });
+    Object.defineProperty(header, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ right: 301 }) as DOMRect,
+    });
+
+    freezeFirstColumn(container);
+
+    expect(
+      container.querySelector<HTMLElement>('[class*="frozenColumnShadow"]')
+        ?.style.left,
+    ).toBe('280px');
+  });
+
   it('dismisses the first-column context menu without clearing the active column', () => {
     const container = renderWideTable();
 
@@ -1921,11 +1948,14 @@ describe('EnhancedMarkdownTable', () => {
     const container = renderTable();
     const shell = container.querySelector<HTMLElement>('[class*="tableShell"]');
     const teamHeader = button(container, 'Sort by Team').closest('th');
+    const columns = () => Array.from(container.querySelectorAll('col'));
     expect(shell?.className).toContain('densityStandard');
     expect(button(container, 'Table density').textContent).toContain(
       'Standard density',
     );
     expect(teamHeader?.style.width).toBe('160px');
+    expect(columns()[0]?.style.width).toBe('40px');
+    expect(columns()[1]?.style.width).toContain('160px');
 
     selectValue(button(container, 'Table density'), 'compact');
     expect(shell?.className).toContain('densityCompact');
@@ -1935,6 +1965,9 @@ describe('EnhancedMarkdownTable', () => {
     expect(teamHeader?.style.width).toBe('auto');
     expect(teamHeader?.style.minWidth).toBe('');
     expect(teamHeader?.style.maxWidth).toBe('');
+    expect(columns()[0]?.style.width).toBe('40px');
+    expect(columns()[1]?.style.width).toContain('72px');
+    expect(columns()[1]?.style.width).not.toContain('160px');
 
     selectValue(button(container, 'Table density'), 'comfortable');
     expect(shell?.className).toContain('densityComfortable');
@@ -1942,6 +1975,8 @@ describe('EnhancedMarkdownTable', () => {
       'Comfortable density',
     );
     expect(teamHeader?.style.width).toBe('160px');
+    expect(columns()[0]?.style.width).toBe('40px');
+    expect(columns()[1]?.style.width).toContain('160px');
   });
 
   it('renders compact row details with blank values and globally expandable long values', () => {

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
@@ -182,6 +182,7 @@ const NUMBER_FILTER_LABEL_KEYS: Record<NumberFilterOperator, string> = {
 
 export const MAX_ENHANCED_TABLE_ROWS = 500;
 export const MAX_ENHANCED_TABLE_COLUMNS = 50;
+// Must stay in sync with --action-column-width in EnhancedMarkdownTable.module.css
 const ACTION_COLUMN_WIDTH = 40;
 const DEFAULT_COLUMN_WIDTH = 160;
 const COMPACT_COLUMN_WIDTH = 72;
@@ -2175,9 +2176,8 @@ export function EnhancedTable({
     minWidth: number,
     fixedWidth: number,
     flexibleColumnCount: number,
-    containerWidth: '100cqw' | '100%',
   ): string =>
-    `max(${minWidth}px, calc((${containerWidth} - ${ACTION_COLUMN_WIDTH}px - ${fixedWidth}px) / ${flexibleColumnCount}))`;
+    `max(${minWidth}px, calc((100cqw - ${ACTION_COLUMN_WIDTH}px - ${fixedWidth}px) / ${flexibleColumnCount}))`;
 
   const columnGroupStyle = (columnIndex: number): CSSProperties => {
     const width = columnWidths[columnIndex];
@@ -2190,7 +2190,6 @@ export function EnhancedTable({
         minWidth,
         fixedVisibleColumnWidth,
         flexibleColumnCount,
-        '100cqw',
       ),
     };
   };

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
@@ -1824,6 +1824,14 @@ export function EnhancedTable({
   const frozenColumnIndex = freezeFirstColumn
     ? orderedVisibleColumnIndexes[0]
     : undefined;
+  const fixedVisibleColumnWidth = orderedVisibleColumnIndexes.reduce(
+    (total, index) => total + (columnWidths[index] ?? 0),
+    0,
+  );
+  const flexibleColumnCount = orderedVisibleColumnIndexes.filter(
+    (index) => columnWidths[index] === undefined,
+  ).length;
+  const hasFillerColumn = flexibleColumnCount === 0;
   const currentCellDialogCell = useMemo(() => {
     if (!cellDialog) return null;
     const row = visibleRows.find((item) => item.key === cellDialog.rowKey);
@@ -2176,18 +2184,11 @@ export function EnhancedTable({
     if (width !== undefined) return { width };
     const minWidth =
       density === 'compact' ? COMPACT_COLUMN_WIDTH : DEFAULT_COLUMN_WIDTH;
-    const fixedWidth = orderedVisibleColumnIndexes.reduce(
-      (total, index) => total + (columnWidths[index] ?? 0),
-      0,
-    );
-    const flexibleColumnCount = orderedVisibleColumnIndexes.filter(
-      (index) => columnWidths[index] === undefined,
-    ).length;
     if (flexibleColumnCount === 0) return { width: minWidth };
     return {
       width: flexibleColumnWidth(
         minWidth,
-        fixedWidth,
+        fixedVisibleColumnWidth,
         flexibleColumnCount,
         '100cqw',
       ),
@@ -2741,6 +2742,7 @@ export function EnhancedTable({
                 style={columnGroupStyle(columnIndex)}
               />
             ))}
+            {hasFillerColumn && <col className={styles.fillerColumn} />}
           </colgroup>
           <thead>
             <tr>
@@ -2878,6 +2880,9 @@ export function EnhancedTable({
                   </th>
                 );
               })}
+              {hasFillerColumn && (
+                <th className={styles.fillerHeaderCell} aria-hidden="true" />
+              )}
             </tr>
           </thead>
           <tbody>
@@ -2958,12 +2963,19 @@ export function EnhancedTable({
                         </td>
                       );
                     })}
+                    {hasFillerColumn && (
+                      <td className={styles.fillerCell} aria-hidden="true" />
+                    )}
                   </tr>
                   {detailOpen && (
                     <tr id={detailId} className={styles.detailRow}>
                       <td
                         className={styles.detailCell}
-                        colSpan={orderedVisibleColumnIndexes.length + 1}
+                        colSpan={
+                          orderedVisibleColumnIndexes.length +
+                          1 +
+                          (hasFillerColumn ? 1 : 0)
+                        }
                       >
                         <div className={styles.detailPanel}>
                           <span className="sr-only">

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
@@ -2184,7 +2184,6 @@ export function EnhancedTable({
     if (width !== undefined) return { width };
     const minWidth =
       density === 'compact' ? COMPACT_COLUMN_WIDTH : DEFAULT_COLUMN_WIDTH;
-    if (flexibleColumnCount === 0) return { width: minWidth };
     return {
       width: flexibleColumnWidth(
         minWidth,

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
@@ -193,18 +193,10 @@ const COLUMN_DRAG_MIME = 'application/x-qwen-web-shell-table-column';
 const LONG_CELL_TEXT_LENGTH = 60;
 const LONG_CELL_LINE_COUNT = 3;
 const DENSITY_OPTIONS: TableDensity[] = ['standard', 'compact', 'comfortable'];
-const DEFAULT_COLUMN_STYLE: CSSProperties = {
-  width: DEFAULT_COLUMN_WIDTH,
-  minWidth: DEFAULT_COLUMN_WIDTH,
-  maxWidth: DEFAULT_COLUMN_WIDTH,
-};
 const ACTION_COLUMN_STYLE: CSSProperties = {
   width: ACTION_COLUMN_WIDTH,
   minWidth: ACTION_COLUMN_WIDTH,
   maxWidth: ACTION_COLUMN_WIDTH,
-};
-const COMPACT_AUTO_COLUMN_STYLE: CSSProperties = {
-  width: 'auto',
 };
 
 function clampColumnWidth(width: number): number {
@@ -2152,26 +2144,6 @@ export function EnhancedTable({
     );
   };
 
-  const columnStyle = (
-    columnIndex: number,
-    extra?: CSSProperties,
-  ): CSSProperties => {
-    const width = columnWidths[columnIndex];
-    if (width === undefined) {
-      const defaultStyle =
-        density === 'compact'
-          ? COMPACT_AUTO_COLUMN_STYLE
-          : DEFAULT_COLUMN_STYLE;
-      return extra ? { ...defaultStyle, ...extra } : defaultStyle;
-    }
-    return {
-      width,
-      minWidth: width,
-      maxWidth: width,
-      ...extra,
-    };
-  };
-
   const flexibleColumnWidth = (
     minWidth: number,
     fixedWidth: number,
@@ -2790,7 +2762,7 @@ export function EnhancedTable({
                     onContextMenu={(event) =>
                       openColumnContextMenu(event, columnIndex)
                     }
-                    style={columnStyle(columnIndex, headerAlignStyle)}
+                    style={headerAlignStyle}
                     title={columnName}
                   >
                     <div className={styles.headerControls}>
@@ -2935,7 +2907,7 @@ export function EnhancedTable({
                               ? styles.selectedCell
                               : ''
                           } ${isFrozenColumn ? styles.frozenCell : ''}`}
-                          style={columnStyle(columnIndex, cellAlignStyle)}
+                          style={cellAlignStyle}
                           data-row-index={rowIndex}
                           data-column-index={columnIndex}
                           onMouseDown={(event) =>

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useEffect,
   useId,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -181,7 +182,9 @@ const NUMBER_FILTER_LABEL_KEYS: Record<NumberFilterOperator, string> = {
 
 export const MAX_ENHANCED_TABLE_ROWS = 500;
 export const MAX_ENHANCED_TABLE_COLUMNS = 50;
+const ACTION_COLUMN_WIDTH = 40;
 const DEFAULT_COLUMN_WIDTH = 160;
+const COMPACT_COLUMN_WIDTH = 72;
 const MIN_COLUMN_WIDTH = 80;
 const MAX_COLUMN_WIDTH = 640;
 const KEYBOARD_COLUMN_RESIZE_STEP = 16;
@@ -193,6 +196,11 @@ const DEFAULT_COLUMN_STYLE: CSSProperties = {
   width: DEFAULT_COLUMN_WIDTH,
   minWidth: DEFAULT_COLUMN_WIDTH,
   maxWidth: DEFAULT_COLUMN_WIDTH,
+};
+const ACTION_COLUMN_STYLE: CSSProperties = {
+  width: ACTION_COLUMN_WIDTH,
+  minWidth: ACTION_COLUMN_WIDTH,
+  maxWidth: ACTION_COLUMN_WIDTH,
 };
 const COMPACT_AUTO_COLUMN_STYLE: CSSProperties = {
   width: 'auto',
@@ -1468,6 +1476,9 @@ export function EnhancedTable({
   const [cellDialog, setCellDialog] = useState<CellDialogState | null>(null);
   const [longTextExpanded, setLongTextExpanded] = useState(false);
   const [density, setDensity] = useState<TableDensity>('standard');
+  const [frozenColumnShadowLeft, setFrozenColumnShadowLeft] = useState<
+    number | null
+  >(null);
   const [isDragging, setIsDragging] = useState(false);
   const [copiedVisible, setCopiedVisible] = useState(false);
   const [copiedSelection, setCopiedSelection] = useState(false);
@@ -1488,6 +1499,7 @@ export function EnhancedTable({
   const mountedRef = useRef(true);
   const shellRef = useRef<HTMLDivElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const frozenHeaderCellRef = useRef<HTMLTableCellElement | null>(null);
   const columnContextMenuRef = useRef<HTMLDivElement | null>(null);
   const cellDialogRef = useRef<HTMLDivElement | null>(null);
   const cellDialogFocusReturnRef = useRef<HTMLElement | null>(null);
@@ -2106,6 +2118,69 @@ export function EnhancedTable({
     };
   };
 
+  const flexibleColumnWidth = (
+    minWidth: number,
+    fixedWidth: number,
+    flexibleColumnCount: number,
+    containerWidth: '100cqw' | '100%',
+  ): string =>
+    `max(${minWidth}px, calc((${containerWidth} - ${ACTION_COLUMN_WIDTH}px - ${fixedWidth}px) / ${flexibleColumnCount}))`;
+
+  const columnGroupStyle = (columnIndex: number): CSSProperties => {
+    const width = columnWidths[columnIndex];
+    if (width !== undefined) return { width };
+    const minWidth =
+      density === 'compact' ? COMPACT_COLUMN_WIDTH : DEFAULT_COLUMN_WIDTH;
+    const fixedWidth = orderedVisibleColumnIndexes.reduce(
+      (total, index) => total + (columnWidths[index] ?? 0),
+      0,
+    );
+    const flexibleColumnCount = orderedVisibleColumnIndexes.filter(
+      (index) => columnWidths[index] === undefined,
+    ).length;
+    if (flexibleColumnCount === 0) return { width: minWidth };
+    return {
+      width: flexibleColumnWidth(
+        minWidth,
+        fixedWidth,
+        flexibleColumnCount,
+        '100cqw',
+      ),
+    };
+  };
+
+  useLayoutEffect(() => {
+    if (!freezeFirstColumn || frozenColumnIndex === undefined) {
+      setFrozenColumnShadowLeft(null);
+      return;
+    }
+    const shell = shellRef.current;
+    const frozenHeader = frozenHeaderCellRef.current;
+    if (!shell || !frozenHeader) return;
+    const updateShadowPosition = () => {
+      const shellRect = shell.getBoundingClientRect();
+      const headerRect = frozenHeader.getBoundingClientRect();
+      setFrozenColumnShadowLeft(
+        Math.max(0, headerRect.right - shellRect.left - shell.clientLeft),
+      );
+    };
+    updateShadowPosition();
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', updateShadowPosition);
+      return () => window.removeEventListener('resize', updateShadowPosition);
+    }
+    const resizeObserver = new ResizeObserver(updateShadowPosition);
+    resizeObserver.observe(shell);
+    resizeObserver.observe(frozenHeader);
+    return () => resizeObserver.disconnect();
+  }, [
+    columnWidths,
+    density,
+    freezeFirstColumn,
+    frozenColumnIndex,
+    orderedVisibleColumnIndexes,
+  ]);
+
   const startColumnResize = (
     event: ReactMouseEvent<HTMLButtonElement>,
     columnIndex: number,
@@ -2615,6 +2690,15 @@ export function EnhancedTable({
         onCopy={handleCopy}
       >
         <table className={styles.table}>
+          <colgroup>
+            <col className={styles.actionColumn} style={ACTION_COLUMN_STYLE} />
+            {orderedVisibleColumnIndexes.map((columnIndex) => (
+              <col
+                key={`column-${columnIndex}`}
+                style={columnGroupStyle(columnIndex)}
+              />
+            ))}
+          </colgroup>
           <thead>
             <tr>
               <th
@@ -2655,6 +2739,7 @@ export function EnhancedTable({
                 return (
                   <th
                     key={header.key}
+                    ref={isFrozenColumn ? frozenHeaderCellRef : undefined}
                     className={`${styles.headerCell} ${
                       isFrozenColumn ? styles.frozenHeaderCell : ''
                     } ${isActiveColumn ? styles.activeHeaderCell : ''}`}
@@ -2879,6 +2964,13 @@ export function EnhancedTable({
           </div>
         )}
       </div>
+      {freezeFirstColumn && frozenColumnShadowLeft !== null && (
+        <div
+          className={styles.frozenColumnShadow}
+          style={{ left: frozenColumnShadowLeft }}
+          aria-hidden="true"
+        />
+      )}
       {columnContextMenu && orderedVisibleColumnIndexes.length > 0 && (
         <div
           ref={columnContextMenuRef}

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
@@ -253,6 +253,24 @@ function densityClassName(density: TableDensity): string {
   }
 }
 
+function findVerticalScrollContainer(
+  element: HTMLElement | null,
+): HTMLElement | null {
+  let current = element;
+  while (current) {
+    const overflowY = window.getComputedStyle(current).overflowY;
+    if (
+      overflowY === 'auto' ||
+      overflowY === 'scroll' ||
+      overflowY === 'overlay'
+    ) {
+      return current;
+    }
+    current = current.parentElement;
+  }
+  return null;
+}
+
 function getTextContent(node: ReactNode): string {
   if (node === null || node === undefined || typeof node === 'boolean') {
     return '';
@@ -1500,6 +1518,11 @@ export function EnhancedTable({
   const shellRef = useRef<HTMLDivElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const frozenHeaderCellRef = useRef<HTMLTableCellElement | null>(null);
+  const detailToggleAnchorRef = useRef<{
+    element: HTMLElement;
+    scrollContainer: HTMLElement | null;
+    top: number;
+  } | null>(null);
   const columnContextMenuRef = useRef<HTMLDivElement | null>(null);
   const cellDialogRef = useRef<HTMLDivElement | null>(null);
   const cellDialogFocusReturnRef = useRef<HTMLElement | null>(null);
@@ -1871,6 +1894,19 @@ export function EnhancedTable({
     }
   }, [cellDialog, detailRowKey, visibleRows]);
 
+  useLayoutEffect(() => {
+    const anchor = detailToggleAnchorRef.current;
+    detailToggleAnchorRef.current = null;
+    if (!anchor?.element.isConnected) return;
+    const offset = anchor.element.getBoundingClientRect().top - anchor.top;
+    if (offset === 0) return;
+    if (anchor.scrollContainer) {
+      anchor.scrollContainer.scrollTop += offset;
+    } else {
+      window.scrollBy(0, offset);
+    }
+  }, [detailRowKey]);
+
   useEffect(() => {
     if (!cellDialog) return;
     return registerInteractionBlocker();
@@ -2029,7 +2065,16 @@ export function EnhancedTable({
     });
   };
 
-  const toggleRowDetail = (rowKey: string) => {
+  const toggleRowDetail = (rowKey: string, rowElement: HTMLElement | null) => {
+    if (detailRowKey !== rowKey && rowElement) {
+      detailToggleAnchorRef.current = {
+        element: rowElement,
+        scrollContainer: findVerticalScrollContainer(
+          shellRef.current?.parentElement ?? null,
+        ),
+        top: rowElement.getBoundingClientRect().top,
+      };
+    }
     setSelection(null);
     setCellDialog(null);
     resetCopiedCellDialog();
@@ -2683,9 +2728,7 @@ export function EnhancedTable({
       </TooltipProvider>
       <div
         ref={containerRef}
-        className={`${styles.scroller} ${
-          detailRowKey ? styles.scrollerWithDetail : ''
-        }`}
+        className={styles.scroller}
         tabIndex={0}
         onCopy={handleCopy}
       >
@@ -2852,7 +2895,12 @@ export function EnhancedTable({
                       <button
                         className={styles.rowDetailButton}
                         type="button"
-                        onClick={() => toggleRowDetail(row.key)}
+                        onClick={(event) =>
+                          toggleRowDetail(
+                            row.key,
+                            event.currentTarget.closest('tr'),
+                          )
+                        }
                         aria-expanded={detailOpen}
                         aria-controls={detailId}
                         aria-label={t(


### PR DESCRIPTION
## What this PR does

This PR stabilizes advanced Markdown table sizing, frozen-column controls, and expanded-row scrolling. Automatic columns fill the available width, a dedicated filler absorbs unused space after every visible data column is manually sized, the frozen-column shadow follows the actual rendered column edge, and opening a row detail panel preserves the table scrollbar and clicked row position.

## Why it's needed

The enhanced table could render unstable column widths across density modes, redistribute manually selected widths when fixed columns did not consume the full table width, place the frozen-column shadow incorrectly, and jump back toward the top when a detail panel removed the table's internal scrollbar. These changes keep column sizing, frozen boundaries, and detail scrolling predictable.

## Reviewer Test Plan

### How to verify

Render an advanced Markdown table with enough rows and columns to scroll. Switch between compact, standard, and comfortable density and confirm the action column remains narrow while automatic data columns fill the available width. Resize every visible data column and confirm those exact widths remain unchanged while the filler consumes remaining space. Freeze the first data column and confirm the shadow stays on its rendered right edge. Scroll down inside the table, expand a lower row, and confirm the table scrollbar and clicked row position are preserved.

### Evidence (Before & After)

No screenshots were captured at the user's request. Automated regression tests cover density-specific column sizing, fixed-column filler behavior, rendered frozen-column boundary positioning, and expanded-row scroll anchoring.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local Node.js workspace; Web Shell unit tests, type checks, linting, formatting checks, and production/library builds.

## Risk & Scope

- Main risk or tradeoff: Frozen-column shadow placement now reads the rendered table boundary and observes subsequent size changes; an aria-hidden filler column absorbs unused width after every visible data column is fixed; expanded-row anchoring may adjust the nearest outer vertical scroll container.
- Not validated / out of scope: No manual interface validation or Windows/Linux local run; keyboard focus styling remains intentionally unchanged.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 提升高级 Markdown 表格的列宽、冻结列控制和详情展开滚动稳定性。自动列会填满可用宽度；当所有可见数据列都被手动定宽时，由专用占位列吸收剩余空间；冻结列阴影会跟随实际渲染边界；展开行详情时会保留表格滚动条和被点击行的位置。

## 为什么需要

此前高级表格在切换密度时可能出现列宽不稳定；当固定列没有占满表格宽度时，浏览器可能重新分配用户设置的列宽，冻结列阴影也可能错位；展开详情导致内部滚动条消失时，还可能跳回表格上方。本次修改让列宽、冻结边界和详情滚动都更加稳定。

## Reviewer 测试计划

### 如何验证

渲染一个行列数量足以滚动的高级 Markdown 表格。切换紧凑、标准和舒适密度，确认操作列保持较窄，自动数据列填满可用宽度。手动调整所有可见数据列，确认列宽保持精确且剩余空间由占位列吸收。冻结第一列，确认阴影始终位于实际渲染右边界。向下滚动表格并展开靠下的一行，确认表格滚动条和被点击行的位置保持不变。

### 证据（修改前后）

按用户要求未进行截图。自动化回归测试覆盖不同密度的列宽、固定列占位行为、冻结列实际边界定位，以及展开行时的滚动锚定。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|      🍏 macOS     |  ✅  |
|     🪟 Windows    |  ⚠️  |
|      🐧 Linux     |  ⚠️  |

### 环境（可选）

本地 Node.js 工作区；已运行 Web Shell 单元测试、类型检查、Lint、格式检查，以及生产和组件库构建。

## 风险与范围

- 主要风险或权衡：冻结列阴影现在读取实际表格边界并监听后续尺寸变化；所有可见数据列固定后，会使用对辅助技术隐藏的占位列吸收剩余宽度；展开行的锚定可能调整最近的外层纵向滚动容器。
- 未验证或范围外：未进行手动界面验证或 Windows/Linux 本地运行；键盘焦点样式按设计保持不变。
- 破坏性变更或迁移说明：无。

## 关联 Issue

无

</details>
