### PR TITLE
fix(autofix): salvage race-lost pushes by merging the moved head and retrying

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -3522,7 +3522,16 @@ jobs:
                 exit 1
               fi
               echo "⚠️ push rejected (attempt ${push_attempt}) — branch moved during the run; merging the new head and retrying"
-              git fetch "${PUSH_URL}" "refs/heads/${BRANCH}"
+              if ! git fetch "${PUSH_URL}" "refs/heads/${BRANCH}"; then
+                echo "::error::could not fetch the moved head (attempt ${push_attempt}) — cannot salvage this push"
+                exit 1
+              fi
+              # The disclosure flag keys on HEAD actually advancing: a push
+              # can fail transiently (upload timeout, 503) with the branch
+              # unmoved, and the merge then no-ops "Already up to date" —
+              # flagging that would tell the reviewer to re-check mid-run
+              # commits that never existed.
+              PRE_MERGE_HEAD="$(git rev-parse HEAD)"
               if ! git -c user.name="${AUTOFIX_BOT}" \
                 -c user.email="${AUTOFIX_BOT}@users.noreply.github.com" \
                 merge --no-edit FETCH_HEAD; then
@@ -3530,7 +3539,9 @@ jobs:
                 echo "::error::the commits pushed during the run conflict with this fix — handing off instead of overwriting either side"
                 exit 1
               fi
-              PUSH_RACE_MERGED='true'
+              if [[ "$(git rev-parse HEAD)" != "${PRE_MERGE_HEAD}" ]]; then
+                PUSH_RACE_MERGED='true'
+              fi
             done
             # Resolve the review threads whose findings the agent actually
             # IMPLEMENTED, so a human re-reviewing sees only what is still open

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -3495,10 +3495,43 @@ jobs:
               # Push back to the FORK branch via allow-edits (PAT has push
               # rights on the upstream, which GitHub extends to the fork's
               # PR branch when the author ticked the box).
-              git push --no-verify "https://x-access-token:${GITHUB_TOKEN}@github.com/${HEAD_REPO}.git" HEAD:"${BRANCH}"
+              PUSH_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${HEAD_REPO}.git"
             else
-              git push --no-verify origin "${BRANCH}"
+              PUSH_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git"
             fi
+            # Salvage a race-lost push instead of discarding the run. The
+            # per-PR head-write concurrency group serialises THIS repo's
+            # workflows, but it cannot stop the PR author (or anything on the
+            # fork side) pushing during the agent's ~50-minute window —
+            # observed twice in one day (#7983, #7985): a one-shot push died
+            # `fetch first` and a full verified agent run was thrown away.
+            # On rejection, fetch the moved head and MERGE it into the local
+            # line (merge, not rebase: the agent's own conflict-resolution
+            # rounds create merge commits, and a rebase would flatten them
+            # and can silently re-introduce the conflicts it resolved). The
+            # merge result descends from the remote head, so the retried push
+            # is a fast-forward. A genuine content conflict aborts and falls
+            # through to the existing failure path — same as today.
+            PUSH_RACE_MERGED='false'
+            for push_attempt in 1 2 3; do
+              if git push --no-verify "${PUSH_URL}" HEAD:"${BRANCH}"; then
+                break
+              fi
+              if [[ "${push_attempt}" == 3 ]]; then
+                echo "::error::push rejected ${push_attempt} times; giving up"
+                exit 1
+              fi
+              echo "⚠️ push rejected (attempt ${push_attempt}) — branch moved during the run; merging the new head and retrying"
+              git fetch "${PUSH_URL}" "refs/heads/${BRANCH}"
+              if ! git -c user.name="${AUTOFIX_BOT}" \
+                -c user.email="${AUTOFIX_BOT}@users.noreply.github.com" \
+                merge --no-edit FETCH_HEAD; then
+                git merge --abort || true
+                echo "::error::the commits pushed during the run conflict with this fix — handing off instead of overwriting either side"
+                exit 1
+              fi
+              PUSH_RACE_MERGED='true'
+            done
             # Resolve the review threads whose findings the agent actually
             # IMPLEMENTED, so a human re-reviewing sees only what is still open
             # instead of re-reading every thread to work out what was handled.
@@ -3614,6 +3647,10 @@ jobs:
               fi
               echo
               echo "Base-conflict check · 基分支冲突检查: $([[ "${CONFLICT}" == "true" ]] && echo 'conflicted with main — resolved in this push. · 与 main 有冲突——已在本次推送中解决。' || echo 'no conflict with main. · 与 main 无冲突。')"
+              if [[ "${PUSH_RACE_MERGED}" == 'true' ]]; then
+                echo
+                echo "⚠️ The branch received new commits while this round ran; they were merged into this push, but this round's verification predates that merge — re-check anything that landed mid-run. · 本轮运行期间分支收到了新的提交；本次推送已将其合并，但本轮验证在合并之前完成——请复查运行期间落地的改动。"
+              fi
               echo
               echo "Re-review when you have a moment. After round ${MAX_ROUNDS} this bot stops and leaves the PR for a human. · 有空请复审；第 ${MAX_ROUNDS} 轮后本 bot 停止并将 PR 交给人工。"
               echo

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -5266,8 +5266,8 @@ describe('qwen-autofix workflow', () => {
     // push failure on an unmoved branch no-ops the merge ("Already up to
     // date") and must NOT tell the reviewer to re-check commits that
     // never existed.
-    expect(pushAndReportStep).toContain(
-      'PRE_MERGE_HEAD="$(git rev-parse HEAD)"',
+    expect(pushAndReportStep).toMatch(
+      /PRE_MERGE_HEAD="\$\(git rev-parse HEAD\)"\n\s+if ! git -c user\.name=/,
     );
     expect(pushAndReportStep).toMatch(
       /if \[\[ "\$\(git rev-parse HEAD\)" != "\$\{PRE_MERGE_HEAD\}" \]\]; then\n\s+PUSH_RACE_MERGED='true'/,
@@ -5298,7 +5298,9 @@ describe('qwen-autofix workflow', () => {
     expect(pushAndReportStep).toMatch(
       /if \[\[ "\$\{PUSH_RACE_MERGED\}" == .true. \]\]; then\n\s+echo\n\s+echo "⚠️ The branch received new commits/,
     );
-    expect(pushAndReportStep).toContain('PUSH_RACE_MERGED');
+    expect(pushAndReportStep).toMatch(
+      /PUSH_RACE_MERGED='false'\n\s+for push_attempt in 1 2 3; do/,
+    );
     expect(pushAndReportStep).toContain('verification predates that merge');
     // Bounded: the loop gives up after the last attempt instead of spinning.
     // The structural pin connects the guard value to the error exit — a

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -2179,7 +2179,10 @@ describe('qwen-autofix workflow', () => {
       'git fetch "https://github.com/${HEAD_REPO}.git" "refs/heads/${BRANCH}"',
     );
     expect(workflow).toContain(
-      'git push --no-verify "https://x-access-token:${GITHUB_TOKEN}@github.com/${HEAD_REPO}.git" HEAD:"${BRANCH}"',
+      'PUSH_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${HEAD_REPO}.git"',
+    );
+    expect(workflow).toContain(
+      'git push --no-verify "${PUSH_URL}" HEAD:"${BRANCH}"',
     );
     // The allow-edits grant rides the classic-PAT path only — prepare must
     // prove push access BEFORE an agent round is spent, discarding
@@ -5222,6 +5225,42 @@ describe('qwen-autofix workflow', () => {
     expect(pushAndReportStep).toContain('milestone digest failed to post');
   });
 
+  it('salvages a race-lost push by merging the moved head instead of discarding the run', () => {
+    // A one-shot push dies `fetch first` whenever anything pushes to the PR
+    // head during the agent's ~50-minute window (observed twice in one day,
+    // #7983/#7985 — a full verified agent run thrown away each time). The
+    // per-PR head-write concurrency group cannot prevent this: it only
+    // serialises THIS repo's workflows, not the PR author or the fork side.
+    // On rejection the report step fetches the moved head, MERGES it into
+    // the local line, and retries a bounded number of times; the merge
+    // result descends from the remote head so the retry is a fast-forward.
+    expect(pushAndReportStep).toContain('for push_attempt in 1 2 3; do');
+    expect(pushAndReportStep).toContain(
+      'git fetch "${PUSH_URL}" "refs/heads/${BRANCH}"',
+    );
+    // Merge, never rebase: the agent's own conflict-resolution rounds create
+    // merge commits, and a rebase would flatten them and can silently
+    // re-introduce the conflicts they resolved.
+    expect(pushAndReportStep).toContain('merge --no-edit FETCH_HEAD');
+    expect(pushAndReportStep).not.toContain('git rebase');
+    // The merge commit needs an explicit identity on a bare runner.
+    expect(pushAndReportStep).toContain('-c user.name="${AUTOFIX_BOT}"');
+    expect(pushAndReportStep).toContain(
+      '-c user.email="${AUTOFIX_BOT}@users.noreply.github.com"',
+    );
+    // A genuine content conflict aborts cleanly and falls through to the
+    // existing failure path — the salvage must never overwrite either side.
+    expect(pushAndReportStep).toContain('git merge --abort || true');
+    // The salvage is disclosed in the round report: the round's verification
+    // ran before the merge, so mid-run commits deserve a re-check.
+    expect(pushAndReportStep).toContain('PUSH_RACE_MERGED');
+    expect(pushAndReportStep).toContain('verification predates that merge');
+    // Bounded: the loop gives up after the last attempt instead of spinning.
+    expect(pushAndReportStep).toContain(
+      'push rejected ${push_attempt} times; giving up',
+    );
+  });
+
   it('pushes autofix branches without rewriting remote history', () => {
     expect(workflow).not.toMatch(/\bgit push\b[^\n]*--force(?:-with-lease)?/);
     // No bare -f / +refspec force forms either. (--no-verify is NOT a force
@@ -5233,7 +5272,7 @@ describe('qwen-autofix workflow', () => {
     expect(workflow).not.toMatch(/\bgit push\b[^\n]* \+\S/);
     expect(publishPrStep).toContain('git push --no-verify origin "${BRANCH}"');
     expect(pushAndReportStep).toContain(
-      'git push --no-verify origin "${BRANCH}"',
+      'git push --no-verify "${PUSH_URL}" HEAD:"${BRANCH}"',
     );
     // Five sites now: both PAT pushes, the PAT-bearing prepare checkout,
     // AND both no-secret verification checkouts (convention: every host

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -5235,6 +5235,14 @@ describe('qwen-autofix workflow', () => {
     // the local line, and retries a bounded number of times; the merge
     // result descends from the remote head so the retry is a fast-forward.
     expect(pushAndReportStep).toContain('for push_attempt in 1 2 3; do');
+    // A successful push breaks out of the loop immediately — without this
+    // pin, deleting the break survives: the loop range and give-up message
+    // are still asserted as strings, but a successful push then re-runs
+    // git push twice more and the salvage legs execute against a branch
+    // that was already pushed.
+    expect(pushAndReportStep).toMatch(
+      /if git push --no-verify "\$\{PUSH_URL\}" HEAD:"\$\{BRANCH\}"; then\n\s+break/,
+    );
     // BOTH push-URL constructions stay pinned — the fork one is pinned by
     // the fork-plumbing test, and the same-repo one lost its old
     // `origin "${BRANCH}"` pin in this rework: a mutation swapping ${REPO}
@@ -5275,11 +5283,29 @@ describe('qwen-autofix workflow', () => {
     // A genuine content conflict aborts cleanly and falls through to the
     // existing failure path — the salvage must never overwrite either side.
     expect(pushAndReportStep).toContain('git merge --abort || true');
+    expect(pushAndReportStep).toContain(
+      'the commits pushed during the run conflict with this fix',
+    );
     // The salvage is disclosed in the round report: the round's verification
-    // ran before the merge, so mid-run commits deserve a re-check.
+    // ran before the merge, so mid-run commits deserve a re-check. The
+    // structure pin keeps the warning conditional — making it unconditional
+    // (printed every round) passes presence-only checks but is the exact
+    // false-disclosure this head's own fix commit closes from the other side.
+    expect(pushAndReportStep).toMatch(
+      /if \[\[ "\$\{PUSH_RACE_MERGED\}" == .true. \]\]; then\n\s+echo\n\s+echo "⚠️ The branch received new commits/,
+    );
     expect(pushAndReportStep).toContain('PUSH_RACE_MERGED');
     expect(pushAndReportStep).toContain('verification predates that merge');
     // Bounded: the loop gives up after the last attempt instead of spinning.
+    // The structural pin connects the guard value to the error exit — a
+    // mutation of == 3 to == 4 survives presence-only checks: the loop
+    // range string is unchanged and the error message still exists as dead
+    // code, but execution falls through to the report section after 3
+    // failed attempts and posts a round-complete comment as if the push
+    // succeeded.
+    expect(pushAndReportStep).toMatch(
+      /if \[\[ "\$\{push_attempt\}" == 3 \]\]; then\n\s+echo "::error::push rejected/,
+    );
     expect(pushAndReportStep).toContain(
       'push rejected ${push_attempt} times; giving up',
     );

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -5235,8 +5235,32 @@ describe('qwen-autofix workflow', () => {
     // the local line, and retries a bounded number of times; the merge
     // result descends from the remote head so the retry is a fast-forward.
     expect(pushAndReportStep).toContain('for push_attempt in 1 2 3; do');
+    // BOTH push-URL constructions stay pinned — the fork one is pinned by
+    // the fork-plumbing test, and the same-repo one lost its old
+    // `origin "${BRANCH}"` pin in this rework: a mutation swapping ${REPO}
+    // for ${HEAD_REPO} (empty in the same-repo case → a malformed
+    // `github.com/.git` remote) must not survive.
+    expect(pushAndReportStep).toContain(
+      'PUSH_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git"',
+    );
     expect(pushAndReportStep).toContain(
       'git fetch "${PUSH_URL}" "refs/heads/${BRANCH}"',
+    );
+    // Every failure path in the salvage loop is ::error::-annotated — a
+    // deleted fork branch (or transient network error) must not kill the
+    // step with an unannotated exit 128 under bash -e.
+    expect(pushAndReportStep).toContain(
+      'could not fetch the moved head (attempt ${push_attempt})',
+    );
+    // The disclosure flag keys on HEAD actually advancing: a transient
+    // push failure on an unmoved branch no-ops the merge ("Already up to
+    // date") and must NOT tell the reviewer to re-check commits that
+    // never existed.
+    expect(pushAndReportStep).toContain(
+      'PRE_MERGE_HEAD="$(git rev-parse HEAD)"',
+    );
+    expect(pushAndReportStep).toMatch(
+      /if \[\[ "\$\(git rev-parse HEAD\)" != "\$\{PRE_MERGE_HEAD\}" \]\]; then\n\s+PUSH_RACE_MERGED='true'/,
     );
     // Merge, never rebase: the agent's own conflict-resolution rounds create
     // merge commits, and a rebase would flatten them and can silently

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -5302,12 +5302,11 @@ describe('qwen-autofix workflow', () => {
     // range string is unchanged and the error message still exists as dead
     // code, but execution falls through to the report section after 3
     // failed attempts and posts a round-complete comment as if the push
-    // succeeded.
+    // succeeded. Deleting exit 1 alone also survives without this pin:
+    // the guard fires and prints the error but execution continues past
+    // fi, the for-loop exhausts, and the report section runs.
     expect(pushAndReportStep).toMatch(
-      /if \[\[ "\$\{push_attempt\}" == 3 \]\]; then\n\s+echo "::error::push rejected/,
-    );
-    expect(pushAndReportStep).toContain(
-      'push rejected ${push_attempt} times; giving up',
+      /if \[\[ "\$\{push_attempt\}" == 3 \]\]; then\n\s+echo "::error::push rejected \$\{push_attempt\} times; giving up"\n\s+exit 1/,
     );
   });
 

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -5256,9 +5256,11 @@ describe('qwen-autofix workflow', () => {
     );
     // Every failure path in the salvage loop is ::error::-annotated — a
     // deleted fork branch (or transient network error) must not kill the
-    // step with an unannotated exit 128 under bash -e.
-    expect(pushAndReportStep).toContain(
-      'could not fetch the moved head (attempt ${push_attempt})',
+    // step with an unannotated exit 128 under bash -e. The structural pin
+    // connects the message to its exit 1: deleting that exit 1 proceeds to
+    // `git merge FETCH_HEAD` against a stale FETCH_HEAD.
+    expect(pushAndReportStep).toMatch(
+      /echo "::error::could not fetch the moved head \(attempt \$\{push_attempt\}\)[^\n]*"\n\s+exit 1/,
     );
     // The disclosure flag keys on HEAD actually advancing: a transient
     // push failure on an unmoved branch no-ops the merge ("Already up to
@@ -5283,8 +5285,10 @@ describe('qwen-autofix workflow', () => {
     // A genuine content conflict aborts cleanly and falls through to the
     // existing failure path — the salvage must never overwrite either side.
     expect(pushAndReportStep).toContain('git merge --abort || true');
-    expect(pushAndReportStep).toContain(
-      'the commits pushed during the run conflict with this fix',
+    // Structural pin: deleting this exit 1 falls through to the report
+    // section and posts a round-complete comment as if the push succeeded.
+    expect(pushAndReportStep).toMatch(
+      /echo "::error::the commits pushed during the run conflict with this fix[^\n]*"\n\s+exit 1/,
     );
     // The salvage is disclosed in the round report: the round's verification
     // ran before the merge, so mid-run commits deserve a re-check. The


### PR DESCRIPTION
## Problem

The `review-address` push is one-shot. When anything pushes to the PR head branch during the agent's ~50-minute run window — the PR author, a maintainer, or anything on the fork side — the final `git push` dies with `fetch first`, and the **entire verified agent run is discarded**.

The per-PR `qwen-pr-head-write-*` concurrency group cannot prevent this: it serialises writers inside this repository's workflows only.

Observed twice on 2026-07-29 alone:
- #7983 — push rejected after a 56-minute agent run
- #7985 — push rejected after a 43-minute agent run

Both runs produced verified fixes that were thrown away, and each burned an ~hour-long runner slot for nothing.

## Change

On push rejection, the report step now:

1. fetches the moved head,
2. **merges** it into the local line (`git merge --no-edit FETCH_HEAD`),
3. retries the push — the merge result descends from the remote head, so the retry is a fast-forward.

Bounded at 3 attempts, then gives up into the existing failure path.

Why merge and not rebase: the agent's own conflict-resolution rounds create merge commits (`git merge` is one of its allowed commands), and a rebase would flatten them and can silently re-introduce the conflicts they resolved. The merge rewrites no pushed history on either side.

If the mid-run commits genuinely conflict with the fix, the merge aborts (`git merge --abort`) and the job falls through to the existing failure path — exactly today's behavior.

When a salvage merge happened, the round report adds a ⚠️ note: the round's verification ran **before** the merge, so commits that landed mid-run deserve a human re-check.

Both push sites (same-repo and fork/allow-edits) go through the same salvage loop; the fork push preflight in `prepare` is unchanged.

## Tests

- New pin: `salvages a race-lost push by merging the moved head instead of discarding the run` — loop bounds, fetch/merge form, no-rebase, explicit merge identity, clean abort, report disclosure.
- Updated the two pins that referenced the old one-shot push literals.
- `qwen-autofix-workflow.test.js`: 103/103 pass; workflow YAML parses.

<details>
<summary>中文说明</summary>

## 问题

`review-address` 的推送是一次性的：agent 运行的约 50 分钟窗口内，只要有人（PR 作者、维护者或 fork 侧）向 head 分支推送，最终 `git push` 就会以 `fetch first` 被拒，**整轮已验证的 agent 运行被丢弃**。

per-PR 并发组只能串行化本仓库 workflow 内部的写者，挡不住外部推送。仅 2026-07-29 一天就发生两次：#7983（56 分钟运行）、#7985（43 分钟运行），产出全部作废。

## 改动

推送被拒时：fetch 移动后的 head → `git merge --no-edit FETCH_HEAD` 合入本地 → 重试推送（merge 结果是远端 head 的后代，重试即 fast-forward）。最多 3 次，之后进入原失败路径。

用 merge 而非 rebase：agent 解冲突轮会产生 merge commit（`git merge` 在其允许命令中），rebase 会将其打平并可能静默重引入已解决的冲突；merge 不改写任何已推送历史。真实内容冲突则 `git merge --abort`，行为与现状完全一致。

发生过抢救合并时，本轮报告会加 ⚠️ 说明：验证发生在合并之前，运行期间落地的提交需要人工复查。

## 测试

新增 pin 测试（重试上限、fetch/merge 形式、禁 rebase、显式身份、干净 abort、报告披露）；更新两处旧推送字面量 pin；`qwen-autofix-workflow.test.js` 103/103 通过，YAML 解析正常。

</details>
