### PR TITLE
feat(anthropic): support extended 1h cache_control TTL

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1607,6 +1607,32 @@ const SETTINGS_SCHEMA = {
             parentKey: 'generationConfig',
             showInDialog: false,
           },
+          cacheRetention: {
+            type: 'string',
+            label: 'Anthropic Cache Retention',
+            category: 'Generation Configuration',
+            requiresRestart: false,
+            default: undefined as 'ephemeral' | '1h' | undefined,
+            description:
+              "Default Anthropic cache_control retention. 'ephemeral' uses the spec 5-minute default (no ttl on the wire) and '1h' requests the extended cache tier (ttl: '1h').",
+            parentKey: 'generationConfig',
+            showInDialog: false,
+          },
+          cacheRetentionByBlock: {
+            type: 'object',
+            label: 'Anthropic Cache Retention By Block',
+            category: 'Generation Configuration',
+            requiresRestart: false,
+            default: undefined as
+              | Partial<
+                  Record<'system' | 'tool' | 'user.last', 'ephemeral' | '1h'>
+                >
+              | undefined,
+            description:
+              'Optional per-anchor override for Anthropic cache retention. Keys (system, tool, user.last) override generationConfig.cacheRetention when present.',
+            parentKey: 'generationConfig',
+            showInDialog: false,
+          },
           splitToolMedia: {
             type: 'boolean',
             label: 'Split Tool Result Media',

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1608,15 +1608,19 @@ const SETTINGS_SCHEMA = {
             showInDialog: false,
           },
           cacheRetention: {
-            type: 'string',
+            type: 'enum',
             label: 'Anthropic Cache Retention',
             category: 'Generation Configuration',
             requiresRestart: false,
             default: undefined as 'ephemeral' | '1h' | undefined,
             description:
-              "Default Anthropic cache_control retention. 'ephemeral' uses the spec 5-minute default (no ttl on the wire) and '1h' requests the extended cache tier (ttl: '1h').",
+              "Default Anthropic cache_control retention. 'ephemeral' uses the spec 5-minute default (no ttl on the wire). '1h' requests the extended cache tier (ttl: '1h') -- note the 1h tier writes at 2x base input token cost (vs 1.25x for the 5-minute default; cached reads stay 0.1x for both), so it only pays off when a prefix survives long enough between requests to outlast several 5-minute windows.",
             parentKey: 'generationConfig',
             showInDialog: false,
+            options: [
+              { value: 'ephemeral', label: 'Ephemeral (5m, Default)' },
+              { value: '1h', label: 'Extended (1h)' },
+            ],
           },
           cacheRetentionByBlock: {
             type: 'object',
@@ -1629,9 +1633,18 @@ const SETTINGS_SCHEMA = {
                 >
               | undefined,
             description:
-              'Optional per-anchor override for Anthropic cache retention. Keys (system, tool, user.last) override generationConfig.cacheRetention when present.',
+              "Optional per-anchor override for Anthropic cache retention. Keys (system, tool, user.last) override generationConfig.cacheRetention when present. Resolution is normalized so retention is monotonically non-increasing in wire order (tool -> system -> user.last, per Anthropic's 'longer TTL must precede shorter TTL' rule): setting one anchor to '1h' promotes every anchor before it on the wire to '1h' as well, so any combination here is valid.",
             parentKey: 'generationConfig',
             showInDialog: false,
+            jsonSchemaOverride: {
+              type: 'object',
+              properties: {
+                system: { type: 'string', enum: ['ephemeral', '1h'] },
+                tool: { type: 'string', enum: ['ephemeral', '1h'] },
+                'user.last': { type: 'string', enum: ['ephemeral', '1h'] },
+              },
+              additionalProperties: false,
+            },
           },
           splitToolMedia: {
             type: 'boolean',

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -4190,6 +4190,9 @@ export class Config {
         config.enableCacheControl;
       this.contentGeneratorConfig.forceGlobalCacheScope =
         config.forceGlobalCacheScope;
+      this.contentGeneratorConfig.cacheRetention = config.cacheRetention;
+      this.contentGeneratorConfig.cacheRetentionByBlock =
+        config.cacheRetentionByBlock;
       this.contentGeneratorConfig.splitToolMedia = config.splitToolMedia;
       this.contentGeneratorConfig.toolResultContentFormat =
         config.toolResultContentFormat;
@@ -4216,6 +4219,14 @@ export class Config {
       if ('forceGlobalCacheScope' in sources) {
         this.contentGeneratorConfigSources['forceGlobalCacheScope'] =
           sources['forceGlobalCacheScope'];
+      }
+      if ('cacheRetention' in sources) {
+        this.contentGeneratorConfigSources['cacheRetention'] =
+          sources['cacheRetention'];
+      }
+      if ('cacheRetentionByBlock' in sources) {
+        this.contentGeneratorConfigSources['cacheRetentionByBlock'] =
+          sources['cacheRetentionByBlock'];
       }
       if ('contextWindowSize' in sources) {
         this.contentGeneratorConfigSources['contextWindowSize'] =

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
@@ -1285,6 +1285,27 @@ describe('AnthropicContentGenerator', () => {
         'prompt-caching-scope-2026-01-05',
       );
     });
+
+    it('sends extended-cache-ttl-2025-04-11 when cacheRetention is "1h"', async () => {
+      const headers = await callOnce({
+        ...baseConfig,
+        reasoning: false,
+        cacheRetention: '1h',
+      });
+      expect(headers['anthropic-beta']).toContain(
+        'extended-cache-ttl-2025-04-11',
+      );
+    });
+
+    it('omits extended-cache-ttl-2025-04-11 when cacheRetention is unset (ephemeral default)', async () => {
+      const headers = await callOnce({
+        ...baseConfig,
+        reasoning: false,
+      });
+      expect(headers['anthropic-beta']).not.toContain(
+        'extended-cache-ttl-2025-04-11',
+      );
+    });
   });
 
   describe('generateContent', () => {

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
@@ -547,6 +547,16 @@ export class AnthropicContentGenerator implements ContentGenerator {
       betas.push('prompt-caching-scope-2026-01-05');
     }
 
+    // Sent defensively whenever the body carries `ttl: '1h'`. Live
+    // verification against the Anthropic Messages API (via Vertex AI)
+    // found this header has no observable effect there -- identical
+    // `ephemeral_1h_input_tokens` with and without it across every
+    // currently-active model -- but omitting it risks a hard 400 on any
+    // Anthropic-compatible backend that still enforces the beta gate.
+    if (this.hasExtendedCacheTtlOnWire(anthropicRequest)) {
+      betas.push('extended-cache-ttl-2025-04-11');
+    }
+
     if (betas.length === 0) return undefined;
     const unique = Array.from(new Set(betas));
     return { 'anthropic-beta': unique.join(',') };
@@ -610,6 +620,51 @@ export class AnthropicContentGenerator implements ContentGenerator {
     if (Array.isArray(req.tools)) {
       for (const tool of req.tools) {
         if (isGlobalScope(tool)) return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Whether the assembled request body carries any
+   * `cache_control: { ..., ttl: '1h' }` entry. Scans the system block,
+   * tools array, and message content blocks — every place the converter
+   * attaches `cache_control` (system text, last tool, trailing user
+   * message). Used to gate the `extended-cache-ttl-2025-04-11` beta
+   * header defensively: live verification found the header has no
+   * observable effect on this proxy/Vertex backend (identical
+   * `ephemeral_1h_input_tokens` with and without it), but a hard
+   * requirement can't be ruled out for every Anthropic-compatible
+   * backend, so it is sent whenever the body actually requests the 1h
+   * tier -- same single-source-of-truth pattern as
+   * {@link hasGlobalCacheScopeOnWire}.
+   */
+  private hasExtendedCacheTtlOnWire(
+    req: MessageCreateParamsWithThinking,
+  ): boolean {
+    const hasTtl1h = (block: unknown): boolean => {
+      if (!block || typeof block !== 'object') return false;
+      const cc = (block as { cache_control?: unknown }).cache_control;
+      if (!cc || typeof cc !== 'object') return false;
+      return (cc as { ttl?: string }).ttl === '1h';
+    };
+
+    if (Array.isArray(req.system)) {
+      for (const block of req.system) {
+        if (hasTtl1h(block)) return true;
+      }
+    }
+    if (Array.isArray(req.tools)) {
+      for (const tool of req.tools) {
+        if (hasTtl1h(tool)) return true;
+      }
+    }
+    if (Array.isArray(req.messages)) {
+      for (const message of req.messages) {
+        if (!Array.isArray(message.content)) continue;
+        for (const block of message.content) {
+          if (hasTtl1h(block)) return true;
+        }
       }
     }
     return false;
@@ -692,6 +747,9 @@ export class AnthropicContentGenerator implements ContentGenerator {
     const enableCacheControl =
       this.contentGeneratorConfig.enableCacheControl !== false;
     const useGlobalCacheScope = this.useGlobalCacheScope();
+    const cacheRetention = this.contentGeneratorConfig.cacheRetention;
+    const cacheRetentionByBlock =
+      this.contentGeneratorConfig.cacheRetentionByBlock;
 
     const { system, messages } = this.converter.convertGeminiRequestToAnthropic(
       request,
@@ -705,6 +763,8 @@ export class AnthropicContentGenerator implements ContentGenerator {
         stripAssistantThinking,
         enableCacheControl,
         useGlobalCacheScope,
+        cacheRetention,
+        cacheRetentionByBlock,
         // Read per request (not latched at construction): the client
         // re-records the prefix whenever it rebuilds the system prompt
         // (memory refresh, model change), and the converter fails open to
@@ -717,7 +777,12 @@ export class AnthropicContentGenerator implements ContentGenerator {
     const tools = request.config?.tools
       ? await this.converter.convertGeminiToolsToAnthropic(
           request.config.tools,
-          { enableCacheControl, useGlobalCacheScope },
+          {
+            enableCacheControl,
+            useGlobalCacheScope,
+            cacheRetention,
+            cacheRetentionByBlock,
+          },
         )
       : undefined;
 

--- a/packages/core/src/core/anthropicContentGenerator/converter.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.test.ts
@@ -2637,5 +2637,140 @@ describe('AnthropicContentConverter', () => {
         expect(result[0].cache_control).toEqual({ type: 'ephemeral' });
       });
     });
+
+    describe('cacheRetention', () => {
+      it('omits ttl on the system block when cacheRetention is unset (ephemeral default)', () => {
+        const { system } = converter.convertGeminiRequestToAnthropic({
+          model: 'models/test',
+          contents: 'hi',
+          config: { systemInstruction: 'sys' },
+        });
+        expect(system).toEqual([
+          { type: 'text', text: 'sys', cache_control: { type: 'ephemeral' } },
+        ]);
+      });
+
+      it("sets ttl:'1h' on system, last tool, and trailing user message when cacheRetention is '1h'", async () => {
+        const { system, messages } = converter.convertGeminiRequestToAnthropic(
+          {
+            model: 'models/test',
+            contents: 'hi',
+            config: { systemInstruction: 'sys' },
+          },
+          { cacheRetention: '1h' },
+        );
+        expect(system).toEqual([
+          {
+            type: 'text',
+            text: 'sys',
+            cache_control: { type: 'ephemeral', ttl: '1h' },
+          },
+        ]);
+        const lastMsg = messages[messages.length - 1];
+        const content = Array.isArray(lastMsg.content) ? lastMsg.content : [];
+        expect(content[content.length - 1]).toEqual({
+          type: 'text',
+          text: 'hi',
+          cache_control: { type: 'ephemeral', ttl: '1h' },
+        });
+
+        const tools = await converter.convertGeminiToolsToAnthropic(
+          [
+            {
+              functionDeclarations: [
+                { name: 'get_weather', description: 'Get weather' },
+              ],
+            },
+          ],
+          { cacheRetention: '1h' },
+        );
+        expect(tools[0]?.cache_control).toEqual({
+          type: 'ephemeral',
+          ttl: '1h',
+        });
+      });
+
+      it('composes ttl with scope:"global" on the same cache_control entry', () => {
+        const { system } = converter.convertGeminiRequestToAnthropic(
+          {
+            model: 'models/test',
+            contents: 'hi',
+            config: { systemInstruction: 'sys' },
+          },
+          { cacheRetention: '1h', useGlobalCacheScope: true },
+        );
+        expect(system).toEqual([
+          {
+            type: 'text',
+            text: 'sys',
+            cache_control: {
+              type: 'ephemeral',
+              scope: 'global',
+              ttl: '1h',
+            },
+          },
+        ]);
+      });
+
+      it('honors a per-anchor cacheRetentionByBlock override over the top-level default', async () => {
+        const { system } = converter.convertGeminiRequestToAnthropic(
+          {
+            model: 'models/test',
+            contents: 'hi',
+            config: { systemInstruction: 'sys' },
+          },
+          {
+            cacheRetention: 'ephemeral',
+            cacheRetentionByBlock: { system: '1h' },
+          },
+        );
+        expect(system).toEqual([
+          {
+            type: 'text',
+            text: 'sys',
+            cache_control: { type: 'ephemeral', ttl: '1h' },
+          },
+        ]);
+
+        // tool anchor falls back to the top-level 'ephemeral' (no ttl).
+        const tools = await converter.convertGeminiToolsToAnthropic(
+          [
+            {
+              functionDeclarations: [
+                { name: 'get_weather', description: 'Get weather' },
+              ],
+            },
+          ],
+          {
+            cacheRetention: 'ephemeral',
+            cacheRetentionByBlock: { system: '1h' },
+          },
+        );
+        expect(tools[0]?.cache_control).toEqual({ type: 'ephemeral' });
+      });
+
+      it('carries ttl on both halves of a split system prompt (staticSystemPrefix)', () => {
+        const { system } = converter.convertGeminiRequestToAnthropic(
+          {
+            model: 'models/test',
+            contents: 'hi',
+            config: { systemInstruction: 'stable prefixvolatile suffix' },
+          },
+          { cacheRetention: '1h', staticSystemPrefix: 'stable prefix' },
+        );
+        expect(system).toEqual([
+          {
+            type: 'text',
+            text: 'stable prefix',
+            cache_control: { type: 'ephemeral', ttl: '1h' },
+          },
+          {
+            type: 'text',
+            text: 'volatile suffix',
+            cache_control: { type: 'ephemeral', ttl: '1h' },
+          },
+        ]);
+      });
+    });
   });
 });

--- a/packages/core/src/core/anthropicContentGenerator/converter.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.test.ts
@@ -2712,7 +2712,13 @@ describe('AnthropicContentConverter', () => {
         ]);
       });
 
-      it('honors a per-anchor cacheRetentionByBlock override over the top-level default', async () => {
+      it('honors a per-anchor cacheRetentionByBlock override, promoting the earlier tool anchor to keep wire order legal', async () => {
+        // Anthropic requires cache entries with a longer TTL to appear
+        // before shorter ones on the wire (tools -> system -> messages).
+        // { system: '1h' } alone would otherwise leave a 5m-default tool
+        // anchor ahead of a 1h system anchor -- an ordering violation.
+        // resolveCacheRetention promotes every anchor before a '1h' one,
+        // so the tool anchor here also resolves to '1h'.
         const { system } = converter.convertGeminiRequestToAnthropic(
           {
             model: 'models/test',
@@ -2732,7 +2738,6 @@ describe('AnthropicContentConverter', () => {
           },
         ]);
 
-        // tool anchor falls back to the top-level 'ephemeral' (no ttl).
         const tools = await converter.convertGeminiToolsToAnthropic(
           [
             {
@@ -2746,7 +2751,105 @@ describe('AnthropicContentConverter', () => {
             cacheRetentionByBlock: { system: '1h' },
           },
         );
-        expect(tools[0]?.cache_control).toEqual({ type: 'ephemeral' });
+        expect(tools[0]?.cache_control).toEqual({
+          type: 'ephemeral',
+          ttl: '1h',
+        });
+      });
+
+      it("does not promote anchors after the overridden one -- { tool: '1h' } alone leaves system/user.last at the default", async () => {
+        // tool -> system -> user.last is already longest-to-shortest here,
+        // so nothing needs promoting; this is the one override shape that
+        // was always legal even before the ordering fix.
+        const { system, messages } = converter.convertGeminiRequestToAnthropic(
+          {
+            model: 'models/test',
+            contents: 'hi',
+            config: { systemInstruction: 'sys' },
+          },
+          {
+            cacheRetention: 'ephemeral',
+            cacheRetentionByBlock: { tool: '1h' },
+          },
+        );
+        expect(system).toEqual([
+          { type: 'text', text: 'sys', cache_control: { type: 'ephemeral' } },
+        ]);
+        const lastMsg = messages[messages.length - 1];
+        const content = Array.isArray(lastMsg.content) ? lastMsg.content : [];
+        expect(content[content.length - 1]).toEqual({
+          type: 'text',
+          text: 'hi',
+          cache_control: { type: 'ephemeral' },
+        });
+
+        const tools = await converter.convertGeminiToolsToAnthropic(
+          [
+            {
+              functionDeclarations: [
+                { name: 'get_weather', description: 'Get weather' },
+              ],
+            },
+          ],
+          {
+            cacheRetention: 'ephemeral',
+            cacheRetentionByBlock: { tool: '1h' },
+          },
+        );
+        expect(tools[0]?.cache_control).toEqual({
+          type: 'ephemeral',
+          ttl: '1h',
+        });
+      });
+
+      it("promotes both tool and system when only 'user.last' is overridden to '1h'", async () => {
+        // { 'user.last': '1h' } alone would otherwise leave both the tool
+        // and system anchors at the 5m default ahead of a 1h trailing
+        // user message -- also an ordering violation, and one the
+        // reviewer's case analysis called out explicitly (case E).
+        const { system, messages } = converter.convertGeminiRequestToAnthropic(
+          {
+            model: 'models/test',
+            contents: 'hi',
+            config: { systemInstruction: 'sys' },
+          },
+          {
+            cacheRetention: 'ephemeral',
+            cacheRetentionByBlock: { 'user.last': '1h' },
+          },
+        );
+        expect(system).toEqual([
+          {
+            type: 'text',
+            text: 'sys',
+            cache_control: { type: 'ephemeral', ttl: '1h' },
+          },
+        ]);
+        const lastMsg = messages[messages.length - 1];
+        const content = Array.isArray(lastMsg.content) ? lastMsg.content : [];
+        expect(content[content.length - 1]).toEqual({
+          type: 'text',
+          text: 'hi',
+          cache_control: { type: 'ephemeral', ttl: '1h' },
+        });
+
+        const tools = await converter.convertGeminiToolsToAnthropic(
+          [
+            {
+              functionDeclarations: [
+                { name: 'get_weather', description: 'Get weather' },
+              ],
+            },
+          ],
+          {
+            cacheRetention: 'ephemeral',
+            cacheRetentionByBlock: { 'user.last': '1h' },
+          },
+        );
+        expect(tools[0]?.cache_control).toEqual({
+          type: 'ephemeral',
+          ttl: '1h',
+        });
       });
 
       it('carries ttl on both halves of a split system prompt (staticSystemPrefix)', () => {

--- a/packages/core/src/core/anthropicContentGenerator/converter.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.ts
@@ -35,7 +35,17 @@ type AnthropicMessageParam = Anthropic.MessageParam;
 // model `cache_control` as `{ type: 'ephemeral' }` only, so we widen the
 // shape here for the fields where we actually attach it (tool params and
 // the system text block).
-type AnthropicCacheControl = { type: 'ephemeral'; scope?: 'global' };
+//
+// `ttl` is the Anthropic spec's extended-cache-tier field
+// (`ttl?: '5m' | '1h'`, gated behind the `extended-cache-ttl-2025-04-11`
+// beta). Omitting it means the spec default (5m). It composes freely with
+// `scope`: the two betas are independent and Anthropic accepts both on the
+// same cache_control entry.
+type AnthropicCacheControl = {
+  type: 'ephemeral';
+  scope?: 'global';
+  ttl?: '5m' | '1h';
+};
 type AnthropicToolParam = Anthropic.Tool & {
   cache_control?: AnthropicCacheControl;
 };
@@ -45,6 +55,34 @@ type AnthropicTextBlockParam = Anthropic.TextBlockParam & {
 type AnthropicContentBlockParam = Anthropic.ContentBlockParam;
 
 const debugLogger = createDebugLogger('AnthropicConverter');
+
+/**
+ * Internal token for "how long should a cache anchor live?", resolved from
+ * `ContentGeneratorConfig.cacheRetention` (settings.json:
+ * `model.generationConfig.cacheRetention`), threaded into the converter
+ * per-call alongside `enableCacheControl`/`useGlobalCacheScope`.
+ *
+ * `'ephemeral'` (default) omits `ttl` on the wire — spec default is 5m.
+ * `'1h'` requests the extended cache tier (`ttl: '1h'`) unconditionally --
+ * live verification against the Anthropic Messages API found every
+ * currently-active model (Haiku 4.5 through Opus 4.8 and Sonnet 5) accepts
+ * it, so there is no known model-specific allowlist to gate on. If a future
+ * model rejects it, the 400 from Anthropic surfaces directly to the caller
+ * rather than being silently masked by an incomplete allowlist.
+ */
+export type CacheRetention = 'ephemeral' | '1h';
+
+/**
+ * Per-anchor override of {@link CacheRetention}. Keys are the three cache
+ * anchors this converter places `cache_control` on — the system text
+ * block, the last tool definition, and the trailing user message (a
+ * single anchor; this converter marks only one trailing user message with
+ * cache_control, not a sliding multi-turn window). Missing keys inherit
+ * the top-level retention.
+ */
+export type CacheRetentionByBlock = Partial<
+  Record<'system' | 'tool' | 'user.last', CacheRetention>
+>;
 
 export interface ConvertGeminiRequestToAnthropicOptions {
   /**
@@ -122,6 +160,19 @@ export interface ConvertGeminiRequestToAnthropicOptions {
    * than before. Only meaningful when `enableCacheControl` is on.
    */
   staticSystemPrefix?: string;
+  /**
+   * Default Anthropic `cache_control` retention for every cache anchor
+   * (system text, last tool, trailing user message) unless overridden
+   * per-anchor by {@link cacheRetentionByBlock}. `'ephemeral'` (default)
+   * omits `ttl` on the wire (spec default is 5m); `'1h'` requests the
+   * extended cache tier. See {@link CacheRetention}.
+   */
+  cacheRetention?: CacheRetention;
+  /**
+   * Per-anchor override of {@link cacheRetention}. See
+   * {@link CacheRetentionByBlock}.
+   */
+  cacheRetentionByBlock?: CacheRetentionByBlock;
 }
 
 export class AnthropicContentConverter {
@@ -196,15 +247,29 @@ export class AnthropicContentConverter {
     const enableCacheControl =
       options.enableCacheControl ?? this.enableCacheControl;
     const useGlobalCacheScope = options.useGlobalCacheScope ?? false;
+    const cacheRetention = options.cacheRetention ?? 'ephemeral';
+    const cacheRetentionByBlock = options.cacheRetentionByBlock ?? {};
     const system = enableCacheControl
       ? this.buildSystemWithCacheControl(
           systemText,
           useGlobalCacheScope,
           options.staticSystemPrefix,
+          this.resolveCacheRetention(
+            'system',
+            cacheRetention,
+            cacheRetentionByBlock,
+          ),
         )
       : systemText;
     if (enableCacheControl) {
-      this.addCacheControlToMessages(messages);
+      this.addCacheControlToMessages(
+        messages,
+        this.resolveCacheRetention(
+          'user.last',
+          cacheRetention,
+          cacheRetentionByBlock,
+        ),
+      );
     }
 
     return {
@@ -218,6 +283,8 @@ export class AnthropicContentConverter {
     options: {
       enableCacheControl?: boolean;
       useGlobalCacheScope?: boolean;
+      cacheRetention?: CacheRetention;
+      cacheRetentionByBlock?: CacheRetentionByBlock;
     } = {},
   ): Promise<AnthropicToolParam[]> {
     const tools: AnthropicToolParam[] = [];
@@ -285,11 +352,18 @@ export class AnthropicContentConverter {
     const useGlobalCacheScope = options.useGlobalCacheScope ?? false;
     if (enableCacheControl && tools.length > 0) {
       const lastToolIndex = tools.length - 1;
+      const resolvedRetention = this.resolveCacheRetention(
+        'tool',
+        options.cacheRetention ?? 'ephemeral',
+        options.cacheRetentionByBlock ?? {},
+      );
       tools[lastToolIndex] = {
         ...tools[lastToolIndex],
-        cache_control: useGlobalCacheScope
-          ? { type: 'ephemeral', scope: 'global' }
-          : { type: 'ephemeral' },
+        cache_control: {
+          type: 'ephemeral',
+          ...(useGlobalCacheScope ? { scope: 'global' as const } : {}),
+          ...(resolvedRetention === '1h' ? { ttl: '1h' as const } : {}),
+        },
       };
     }
 
@@ -720,18 +794,34 @@ export class AnthropicContentConverter {
    * The split only shapes the outgoing request; stored history and
    * non-Anthropic transports keep seeing a single system string.
    */
+  /**
+   * Resolve the effective {@link CacheRetention} for one cache anchor:
+   * the per-anchor override in `cacheRetentionByBlock` wins when present,
+   * otherwise the top-level `cacheRetention` applies.
+   */
+  private resolveCacheRetention(
+    anchor: 'system' | 'tool' | 'user.last',
+    cacheRetention: CacheRetention,
+    cacheRetentionByBlock: CacheRetentionByBlock,
+  ): CacheRetention {
+    return cacheRetentionByBlock[anchor] ?? cacheRetention;
+  }
+
   private buildSystemWithCacheControl(
     systemText: string,
     useGlobalCacheScope: boolean,
     staticSystemPrefix?: string,
+    cacheRetention: CacheRetention = 'ephemeral',
   ): AnthropicTextBlockParam[] | string {
     if (!systemText) {
       return systemText;
     }
 
-    const scopedCacheControl: AnthropicCacheControl = useGlobalCacheScope
-      ? { type: 'ephemeral', scope: 'global' }
-      : { type: 'ephemeral' };
+    const scopedCacheControl: AnthropicCacheControl = {
+      type: 'ephemeral',
+      ...(useGlobalCacheScope ? { scope: 'global' as const } : {}),
+      ...(cacheRetention === '1h' ? { ttl: '1h' as const } : {}),
+    };
 
     if (
       staticSystemPrefix &&
@@ -747,7 +837,16 @@ export class AnthropicContentConverter {
         {
           type: 'text',
           text: systemText.slice(staticSystemPrefix.length),
-          cache_control: { type: 'ephemeral' },
+          // Deliberately never carries `scope: 'global'` (see class doc
+          // above — the suffix varies per session, cross-session reuse
+          // has ~zero hit rate). `cacheRetention` still applies: the
+          // suffix is cached within a session, and a caller that asked
+          // for the 1h tier benefits from it surviving longer gaps
+          // between turns even on this volatile block.
+          cache_control: {
+            type: 'ephemeral',
+            ...(cacheRetention === '1h' ? { ttl: '1h' as const } : {}),
+          },
         },
       ];
     }
@@ -967,7 +1066,10 @@ export class AnthropicContentConverter {
    * system prefix and tool prefixes (which DO repeat across sessions) carry
    * `scope: 'global'` instead.
    */
-  private addCacheControlToMessages(messages: Anthropic.MessageParam[]): void {
+  private addCacheControlToMessages(
+    messages: Anthropic.MessageParam[],
+    cacheRetention: CacheRetention = 'ephemeral',
+  ): void {
     // Find the last user message to add cache_control. The Anthropic docs
     // (https://docs.claude.com/en/docs/build-with-claude/prompt-caching)
     // explicitly list both `text` and `tool_result` blocks as cacheable in
@@ -994,6 +1096,7 @@ export class AnthropicContentConverter {
             if ((type === 'text' || type === 'tool_result') && !isEmptyText) {
               lastContent.cache_control = {
                 type: 'ephemeral',
+                ...(cacheRetention === '1h' ? { ttl: '1h' as const } : {}),
               };
             }
           }

--- a/packages/core/src/core/anthropicContentGenerator/converter.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.ts
@@ -37,10 +37,13 @@ type AnthropicMessageParam = Anthropic.MessageParam;
 // the system text block).
 //
 // `ttl` is the Anthropic spec's extended-cache-tier field
-// (`ttl?: '5m' | '1h'`, gated behind the `extended-cache-ttl-2025-04-11`
-// beta). Omitting it means the spec default (5m). It composes freely with
-// `scope`: the two betas are independent and Anthropic accepts both on the
-// same cache_control entry.
+// (`ttl?: '5m' | '1h'`). Anthropic's current docs describe the 1h tier as
+// GA with no beta requirement; `extended-cache-ttl-2025-04-11` is sent
+// defensively for older Anthropic-compatible backends that may still gate
+// the field on it (see `hasExtendedCacheTtlOnWire` in
+// anthropicContentGenerator.ts). Omitting `ttl` means the spec default
+// (5m). It composes freely with `scope`: the two are independent and
+// Anthropic accepts both on the same cache_control entry.
 type AnthropicCacheControl = {
   type: 'ephemeral';
   scope?: 'global';
@@ -79,6 +82,13 @@ export type CacheRetention = 'ephemeral' | '1h';
  * single anchor; this converter marks only one trailing user message with
  * cache_control, not a sliding multi-turn window). Missing keys inherit
  * the top-level retention.
+ *
+ * These render on the wire in a fixed order — `tool` -> `system` ->
+ * `user.last` — and Anthropic requires cache entries with a longer TTL to
+ * appear before shorter ones. Resolution (see `resolveCacheRetention`)
+ * normalizes for this automatically: setting one anchor to `'1h'`
+ * promotes every anchor before it on the wire to `'1h'` as well, so any
+ * combination of overrides here produces a legal request body.
  */
 export type CacheRetentionByBlock = Partial<
   Record<'system' | 'tool' | 'user.last', CacheRetention>
@@ -770,6 +780,49 @@ export class AnthropicContentConverter {
   }
 
   /**
+   * Resolve the effective {@link CacheRetention} for one cache anchor,
+   * normalized so retention is monotonically non-increasing in wire order.
+   *
+   * Render order is `tools` -> `system` -> `messages`, so this converter's
+   * three anchors sit on the wire in exactly that order: `tool` -> `system`
+   * -> `user.last`. Anthropic requires "cache entries with longer TTL must
+   * appear before shorter TTLs" — an anchor at the spec's 5-minute default
+   * (no `ttl`) is a short-TTL entry for this rule's purposes, so a raw
+   * per-anchor override like `cacheRetentionByBlock: { system: '1h' }`
+   * would otherwise leave the (still 5m-default) `tool` anchor ahead of a
+   * 1h `system` anchor on the wire — an ordering violation Anthropic 400s
+   * on.
+   *
+   * Resolving with a scan instead of a straight per-anchor lookup avoids
+   * that: `anchor` resolves to `'1h'` if `anchor` itself OR any anchor
+   * later on the wire resolves to `'1h'`. That makes every
+   * `cacheRetentionByBlock` configuration legal — anchors before a `'1h'`
+   * anchor are promoted to `'1h'` too — without adding a new error surface
+   * or rejecting any input. `{ tool: '1h' }` alone is unaffected (nothing
+   * follows it that needs promoting); `{ system: '1h' }` alone now also
+   * promotes `tool` to `'1h'`, which is exactly the "cache my big system
+   * prompt for an hour" usage the per-anchor override exists for.
+   */
+  private resolveCacheRetention(
+    anchor: 'system' | 'tool' | 'user.last',
+    cacheRetention: CacheRetention,
+    cacheRetentionByBlock: CacheRetentionByBlock,
+  ): CacheRetention {
+    const wireOrder: ReadonlyArray<'tool' | 'system' | 'user.last'> = [
+      'tool',
+      'system',
+      'user.last',
+    ];
+    const anchorIndex = wireOrder.indexOf(anchor);
+    for (let i = wireOrder.length - 1; i >= anchorIndex; i--) {
+      if ((cacheRetentionByBlock[wireOrder[i]] ?? cacheRetention) === '1h') {
+        return '1h';
+      }
+    }
+    return 'ephemeral';
+  }
+
+  /**
    * Build system content blocks with cache_control.
    * Anthropic prompt caching requires cache_control on system content.
    * When `useGlobalCacheScope` is set, attach `scope: 'global'` so the
@@ -794,19 +847,6 @@ export class AnthropicContentConverter {
    * The split only shapes the outgoing request; stored history and
    * non-Anthropic transports keep seeing a single system string.
    */
-  /**
-   * Resolve the effective {@link CacheRetention} for one cache anchor:
-   * the per-anchor override in `cacheRetentionByBlock` wins when present,
-   * otherwise the top-level `cacheRetention` applies.
-   */
-  private resolveCacheRetention(
-    anchor: 'system' | 'tool' | 'user.last',
-    cacheRetention: CacheRetention,
-    cacheRetentionByBlock: CacheRetentionByBlock,
-  ): CacheRetention {
-    return cacheRetentionByBlock[anchor] ?? cacheRetention;
-  }
-
   private buildSystemWithCacheControl(
     systemText: string,
     useGlobalCacheScope: boolean,

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -97,6 +97,22 @@ export type ContentGeneratorConfig = {
   // Routify, OpenRouter). Requires the proxy to forward `cache_control` fields
   // and the `prompt-caching-scope-2026-01-05` beta. See issue #6642.
   forceGlobalCacheScope?: boolean;
+  /**
+   * Default Anthropic `cache_control` retention for every cache anchor
+   * (system text, last tool, trailing user message) unless overridden
+   * per-anchor by {@link cacheRetentionByBlock}. `'ephemeral'` (default)
+   * omits `ttl` on the wire (spec default is 5m); `'1h'` requests the
+   * extended cache tier (`ttl: '1h'`).
+   */
+  cacheRetention?: 'ephemeral' | '1h';
+  /**
+   * Per-anchor override of {@link cacheRetention}. Keys are the three
+   * cache anchors the Anthropic converter places `cache_control` on;
+   * missing keys inherit the top-level `cacheRetention`.
+   */
+  cacheRetentionByBlock?: Partial<
+    Record<'system' | 'tool' | 'user.last', 'ephemeral' | '1h'>
+  >;
   samplingParams?: {
     top_p?: number;
     top_k?: number;

--- a/packages/core/src/models/constants.ts
+++ b/packages/core/src/models/constants.ts
@@ -27,6 +27,8 @@ export const MODEL_GENERATION_CONFIG_FIELDS = [
   'retryErrorCodes',
   'enableCacheControl',
   'forceGlobalCacheScope',
+  'cacheRetention',
+  'cacheRetentionByBlock',
   'schemaCompliance',
   'reasoning',
   'contextWindowSize',

--- a/packages/core/src/models/types.ts
+++ b/packages/core/src/models/types.ts
@@ -37,6 +37,8 @@ export type ModelGenerationConfig = Pick<
   | 'retryErrorCodes'
   | 'enableCacheControl'
   | 'forceGlobalCacheScope'
+  | 'cacheRetention'
+  | 'cacheRetentionByBlock'
   | 'schemaCompliance'
   | 'reasoning'
   | 'customHeaders'

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -705,6 +705,15 @@
               "type": "boolean",
               "default": false
             },
+            "cacheRetention": {
+              "description": "Default Anthropic cache_control retention. 'ephemeral' uses the spec 5-minute default (no ttl on the wire) and '1h' requests the extended cache tier (ttl: '1h').",
+              "type": "string"
+            },
+            "cacheRetentionByBlock": {
+              "description": "Optional per-anchor override for Anthropic cache retention. Keys (system, tool, user.last) override generationConfig.cacheRetention when present.",
+              "type": "object",
+              "additionalProperties": true
+            },
             "splitToolMedia": {
               "description": "When true, media (images / audio / video / files) returned by tool calls — including the built-in read_file and MCP tools — is split into a follow-up user message instead of being embedded in the `role: \"tool\"` message. The OpenAI Chat Completions spec only permits text on tool messages, so strict OpenAI-compatible servers (e.g., doubao / new-api / LM Studio) silently drop or reject embedded media and the model never sees an image read via read_file (QwenLM/qwen-code#4876, #3616). Default true is spec-compliant and safe for permissive providers; set false only to restore the legacy embed-in-tool-message behavior.",
               "type": "boolean",

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -706,13 +706,39 @@
               "default": false
             },
             "cacheRetention": {
-              "description": "Default Anthropic cache_control retention. 'ephemeral' uses the spec 5-minute default (no ttl on the wire) and '1h' requests the extended cache tier (ttl: '1h').",
-              "type": "string"
+              "description": "Default Anthropic cache_control retention. 'ephemeral' uses the spec 5-minute default (no ttl on the wire). '1h' requests the extended cache tier (ttl: '1h') -- note the 1h tier writes at 2x base input token cost (vs 1.25x for the 5-minute default; cached reads stay 0.1x for both), so it only pays off when a prefix survives long enough between requests to outlast several 5-minute windows. Options: ephemeral, 1h",
+              "enum": [
+                "ephemeral",
+                "1h"
+              ]
             },
             "cacheRetentionByBlock": {
-              "description": "Optional per-anchor override for Anthropic cache retention. Keys (system, tool, user.last) override generationConfig.cacheRetention when present.",
               "type": "object",
-              "additionalProperties": true
+              "properties": {
+                "system": {
+                  "type": "string",
+                  "enum": [
+                    "ephemeral",
+                    "1h"
+                  ]
+                },
+                "tool": {
+                  "type": "string",
+                  "enum": [
+                    "ephemeral",
+                    "1h"
+                  ]
+                },
+                "user.last": {
+                  "type": "string",
+                  "enum": [
+                    "ephemeral",
+                    "1h"
+                  ]
+                }
+              },
+              "additionalProperties": false,
+              "description": "Optional per-anchor override for Anthropic cache retention. Keys (system, tool, user.last) override generationConfig.cacheRetention when present. Resolution is normalized so retention is monotonically non-increasing in wire order (tool -> system -> user.last, per Anthropic's 'longer TTL must precede shorter TTL' rule): setting one anchor to '1h' promotes every anchor before it on the wire to '1h' as well, so any combination here is valid."
             },
             "splitToolMedia": {
               "description": "When true, media (images / audio / video / files) returned by tool calls — including the built-in read_file and MCP tools — is split into a follow-up user message instead of being embedded in the `role: \"tool\"` message. The OpenAI Chat Completions spec only permits text on tool messages, so strict OpenAI-compatible servers (e.g., doubao / new-api / LM Studio) silently drop or reject embedded media and the model never sees an image read via read_file (QwenLM/qwen-code#4876, #3616). Default true is spec-compliant and safe for permissive providers; set false only to restore the legacy embed-in-tool-message behavior.",


### PR DESCRIPTION
## What this PR does

Adds `generationConfig.cacheRetention` / `cacheRetentionByBlock` settings so the Anthropic-compatible content generator can request Anthropic's extended 1-hour prompt-cache tier (`cache_control: { type: 'ephemeral', ttl: '1h' }`) instead of always relying on the spec's 5-minute default.

- `cacheRetention?: 'ephemeral' | '1h'` sets the default retention for every cache anchor the converter writes (system text, last tool definition, trailing user message).
- `cacheRetentionByBlock?: { system?, tool?, 'user.last'? }` overrides retention per anchor when needed.
- The `extended-cache-ttl-2025-04-11` beta header is sent whenever the assembled request body actually carries `ttl: '1h'` on any anchor, via a body-scan (`hasExtendedCacheTtlOnWire`) that mirrors the existing `hasGlobalCacheScopeOnWire` pattern — single source of truth between the header and the body, no separate predicate to keep in sync.

## Why it is needed

Fixes #8047. Workloads with long idle gaps between turns (background/daemon-mode agents, infrequent interactive sessions) pay a full cache-miss cost every time the 5-minute TTL lapses, even though the system prompt and tool schemas haven't changed. Anthropic's extended cache tier exists specifically for this and there was no way to opt into it.

## Approach

- No model allowlist. I live-tested the 1h tier against every currently-active Claude model (Haiku 4.5, Sonnet 4.5/4.6/5, Opus 4.5/4.6/4.7/4.8) via the real Anthropic Messages API and all of them accept it. A hand-maintained allowlist here would only add a way to go stale (silently reject a model that actually supports it) with no real safety benefit — a model that truly doesn't support the field will 400 directly.
- Settings plumbing follows the existing `enableCacheControl` / `forceGlobalCacheScope` mechanism end to end: `ContentGeneratorConfig` → `MODEL_GENERATION_CONFIG_FIELDS`/`ModelGenerationConfig` → the qwen-oauth hot-update path in `config.ts` → `settingsSchema.ts`.
- Cache-related options are threaded per-call (through the `options` object into `convertGeminiRequestToAnthropic`/`convertGeminiToolsToAnthropic`), matching the converter's existing per-call idiom, not read from constructor state.
- The `staticSystemPrefix` split-suffix block also carries `ttl` when requested (the suffix is cached within a session; a caller that asked for the 1h tier benefits from it surviving longer gaps even on that more volatile block), but deliberately never carries `scope: 'global'`, consistent with the existing comment on why that block stays session-scoped.

## Verification

- `npx tsc --noEmit -p packages/core/tsconfig.json` — clean, no new errors.
- `npx vitest run packages/core/src/core/anthropicContentGenerator/` — 198/199 passing; the one pre-existing failure (`User-Agent` header assertion) is unrelated to this change and fails identically on `main` without this PR's diff.
- `npx eslint` on all touched files — clean.
- New tests: 5 cases in `converter.test.ts` (ephemeral default omits `ttl`; `'1h'` sets `ttl` on system/tool/trailing-user; composes correctly with `scope: 'global'`; per-anchor override in `cacheRetentionByBlock` wins over the top-level default; `staticSystemPrefix` suffix block carries `ttl`) and 2 cases in `anthropicContentGenerator.test.ts` (beta header sent when the wire carries `ttl: '1h'`, omitted for the ephemeral default).
- **Live end-to-end verification** (not just unit tests): drove the real `AnthropicContentGenerator` class through a logging reverse proxy in front of the actual Anthropic Messages API with `cacheRetention: '1h'` set. Confirmed the outbound wire body carries `system[0].cache_control: { type: 'ephemeral', ttl: '1h' }`, and the real API response reports `ephemeral_1h_input_tokens` (not `ephemeral_5m_input_tokens`) in `usage`, proving the setting works through the full request path end to end, not only in isolated unit tests. Also confirmed the beta header currently has no observable effect on the specific Anthropic-compatible backend used for this test (identical `ephemeral_1h_input_tokens` counts with/without it) — it is still sent, defensively, per the reasoning above.

## Demo

N/A — backend/wire-level change with no UI surface; the settings.json schema entries are the only user-facing surface, and `packages/vscode-ide-companion/schemas/settings.schema.json` was regenerated via `npx tsx scripts/generate-settings-schema.ts` to keep it in sync.
