### PR TITLE
feat(autofix): back off scan inspection of idle candidates

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -1816,29 +1816,33 @@ jobs:
           [[ "${BUSY_PRS}" != ' ' ]] && echo "🚧 address in flight/queued for PR(s):${BUSY_PRS}"
 
           # Idle backoff, from the list's own updatedAt (no API call): a
-          # candidate with no activity for >24h gets inspected on roughly
-          # every 4th scan instead of every one. The pool doubled in two
+          # candidate with no activity for >24h is inspected on about one
+          # scan in four instead of every one. The pool doubled in two
           # days (28 takeover PRs, 8 of them idle in "nothing new" state
-          # for 10+ hours), and every idle inspection costs twice: a unit
-          # of the SHARED MAX_CANDIDATE_INSPECTIONS budget, and a slice of
-          # the serial API walk over the candidate list — the walk is what
-          # delayed #8002's first pickup (admitted at 09:09, six minutes
-          # into the 09:03 scan's serial reads). Idle PRs never reach the
+          # for 10+ hours), and every idle inspection costs a unit of the
+          # SHARED MAX_CANDIDATE_INSPECTIONS budget plus a slice of the
+          # serial API walk over the candidate list. The win is small: a
+          # few fewer gh round-trips per scan (~2-3 of the pool) and less
+          # rate-limit pressure. It does NOT recover the job's queue or
+          # startup latency, which dwarfed the walk in the #8002
+          # measurement that motivated this. Idle PRs never reach the
           # 10-target budget (the "nothing new" branch continues before
-          # the TARGETS append), so that cap is NOT what this relieves —
-          # the win is inspection budget plus scan-walk latency for fresh
-          # engagements. Safe because comments, reviews, labels, and
-          # pushes all bump updatedAt or route in real time; the two
-          # scan-only signals that do NOT bump it — a base conflict
-          # appearing when main moves, and still-red checks awaiting the
-          # redcheck marker — wait at most the backoff gap (~40 min) on a
-          # PR nobody touched in a day, and self-correct (the eventual
-          # address run comments/pushes). Slotting is deterministic — one
-          # eligible 10-minute tick in every four, keyed by PR number, the
-          # same 600s quantum as ROT_OFF — so the gap is bounded at ~40
-          # minutes and no PR is unlucky forever. The forced-dispatch path
-          # never builds the list files, so a forced PR is always
-          # inspected (fail-open, like a PR missing from the set).
+          # the TARGETS append), so that cap is NOT what this relieves.
+          # Safe because comments, reviews, labels, and pushes all bump
+          # updatedAt or route in real time; the two scan-only signals
+          # that do NOT bump it — a base conflict appearing when main
+          # moves, and still-red checks awaiting the redcheck marker —
+          # wait out the backoff on a PR nobody touched in a day, then
+          # self-correct (the eventual address run comments/pushes). The
+          # slot is keyed by PR number mod 4 against a 600s time quantum
+          # (same quantum as ROT_OFF), so each scan is an independent
+          # ~25% draw per idle PR — about one scan in four. This is NOT a
+          # bounded gap: the scheduled scan lands every ~40-70 min on
+          # this repo (not the */10 the cron implies), so the wait is
+          # geometric — measured median ~2h, p90 ~6h across 100 real
+          # scans. The forced-dispatch path never builds the list files,
+          # so a forced PR is always inspected (fail-open, like a PR
+          # missing from the set).
           IDLE_PRS=' '
           if [[ -f "${WORKDIR}/bot-prs.json" && -f "${WORKDIR}/takeover-prs.json" ]]; then
             IDLE_CUTOFF="$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)"
@@ -1863,8 +1867,8 @@ jobs:
             # the precomputed set, same idiom as the busy skip) — it must
             # not consume inspection budget either.
             if [[ "${IDLE_PRS}" == *" ${PR} "* && "$(( PR % 4 ))" != "${IDLE_SLOT_NOW}" ]]; then
-              echo "😴 #${PR}: idle >24h — deferring to its rotation slot (slot $(( PR % 4 )), current ${IDLE_SLOT_NOW}, next eligible tick ≤30m away)"
-              fleet_row "${PR}" 'idle-backoff' 'idle >24h; inspected roughly every 4th scan (gap ≤40m)'
+              echo "😴 #${PR}: idle >24h — deferring to its rotation slot (slot $(( PR % 4 )), current ${IDLE_SLOT_NOW}; inspected ~1 scan in 4)"
+              fleet_row "${PR}" 'idle-backoff' 'idle >24h; inspected ~1 scan in 4 (median ~2h, p90 ~6h)'
               continue
             fi
             INSPECTED=$(( INSPECTED + 1 ))

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -1669,10 +1669,10 @@ jobs:
           else
             gh pr list --repo "${REPO}" --state open --author "${AUTOFIX_BOT}" \
               --base main \
-              --limit 100 --json number,headRefName,isCrossRepository,labels,author,maintainerCanModify > "${WORKDIR}/bot-prs.json"
+              --limit 100 --json number,headRefName,isCrossRepository,labels,author,maintainerCanModify,updatedAt > "${WORKDIR}/bot-prs.json"
             gh pr list --repo "${REPO}" --state open --label "${TAKEOVER_LABEL}" \
               --base main \
-              --limit 100 --json number,headRefName,isCrossRepository,labels,author,maintainerCanModify > "${WORKDIR}/takeover-prs.json"
+              --limit 100 --json number,headRefName,isCrossRepository,labels,author,maintainerCanModify,updatedAt > "${WORKDIR}/takeover-prs.json"
             # Skip-labeled PRs are excluded HERE, not only at the address
             # gate: that gate discards without writing a marker, so the
             # watermark never advances and an unfiltered scan would re-emit
@@ -1815,6 +1815,30 @@ jobs:
           )
           [[ "${BUSY_PRS}" != ' ' ]] && echo "🚧 address in flight/queued for PR(s):${BUSY_PRS}"
 
+          # Idle backoff, from the list's own updatedAt (no extra API call):
+          # a candidate with no activity for >24h gets inspected on roughly
+          # every 4th scan instead of every one. The pool doubled in two
+          # days (28 takeover PRs, 8 of them idle in "nothing new" state for
+          # 10+ hours), and idle candidates crowd the SHARED inspection and
+          # target budgets — #8002 was admitted and then deferred by the
+          # 10-target cap while long-idle PRs re-confirmed "nothing new".
+          # Safe because every real wake-up path bumps updatedAt (reviews,
+          # comments, labels, pushes) or routes in real time anyway; the only
+          # thing deferred is the scheduled re-confirmation of idleness, plus
+          # worst-case ~a few hours of latency on base-conflict detection for
+          # a PR nobody has touched in a day. Slotting is deterministic —
+          # one eligible hour in every four, keyed by PR number — so no PR
+          # is unlucky forever. The forced-dispatch path never builds the
+          # list files, so a forced PR is always inspected.
+          IDLE_UPDATED='{}'
+          if [[ -f "${WORKDIR}/bot-prs.json" && -f "${WORKDIR}/takeover-prs.json" ]]; then
+            IDLE_UPDATED="$(jq -cs 'add | unique_by(.number)
+              | map({(.number | tostring): (.updatedAt // "")}) | add // {}' \
+              "${WORKDIR}/bot-prs.json" "${WORKDIR}/takeover-prs.json" 2> /dev/null || echo '{}')"
+          fi
+          IDLE_CUTOFF="$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)"
+          IDLE_SLOT_NOW="$(( ($(date -u +%s) / 3600) % 4 ))"
+
           TARGETS='[]'
           INSPECTED=0
           for PR in ${CANDIDATES}; do
@@ -1823,6 +1847,14 @@ jobs:
             if [[ "${BUSY_PRS}" == *" ${PR} "* ]]; then
               echo "⏳ #${PR}: review-address already in flight or queued — skipping"
               fleet_row "${PR}" 'busy' 'address run in flight'
+              continue
+            fi
+            # The idle-backoff skip is free too (in-memory lookup) — it must
+            # not consume inspection budget either.
+            PR_UPDATED="$(jq -r --arg pr "${PR}" '.[$pr] // ""' <<< "${IDLE_UPDATED}")"
+            if [[ -n "${PR_UPDATED}" && "${PR_UPDATED}" < "${IDLE_CUTOFF}" && "$(( PR % 4 ))" != "${IDLE_SLOT_NOW}" ]]; then
+              echo "😴 #${PR}: idle since ${PR_UPDATED} (>24h) — deferring to its rotation slot (slot $(( PR % 4 )), current ${IDLE_SLOT_NOW})"
+              fleet_row "${PR}" 'idle-backoff' "idle since ${PR_UPDATED}; inspected roughly every 4th scan"
               continue
             fi
             INSPECTED=$(( INSPECTED + 1 ))

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -1815,29 +1815,39 @@ jobs:
           )
           [[ "${BUSY_PRS}" != ' ' ]] && echo "🚧 address in flight/queued for PR(s):${BUSY_PRS}"
 
-          # Idle backoff, from the list's own updatedAt (no extra API call):
-          # a candidate with no activity for >24h gets inspected on roughly
+          # Idle backoff, from the list's own updatedAt (no API call): a
+          # candidate with no activity for >24h gets inspected on roughly
           # every 4th scan instead of every one. The pool doubled in two
-          # days (28 takeover PRs, 8 of them idle in "nothing new" state for
-          # 10+ hours), and idle candidates crowd the SHARED inspection and
-          # target budgets — #8002 was admitted and then deferred by the
-          # 10-target cap while long-idle PRs re-confirmed "nothing new".
-          # Safe because every real wake-up path bumps updatedAt (reviews,
-          # comments, labels, pushes) or routes in real time anyway; the only
-          # thing deferred is the scheduled re-confirmation of idleness, plus
-          # worst-case ~a few hours of latency on base-conflict detection for
-          # a PR nobody has touched in a day. Slotting is deterministic —
-          # one eligible hour in every four, keyed by PR number — so no PR
-          # is unlucky forever. The forced-dispatch path never builds the
-          # list files, so a forced PR is always inspected.
-          IDLE_UPDATED='{}'
+          # days (28 takeover PRs, 8 of them idle in "nothing new" state
+          # for 10+ hours), and every idle inspection costs twice: a unit
+          # of the SHARED MAX_CANDIDATE_INSPECTIONS budget, and a slice of
+          # the serial API walk over the candidate list — the walk is what
+          # delayed #8002's first pickup (admitted at 09:09, six minutes
+          # into the 09:03 scan's serial reads). Idle PRs never reach the
+          # 10-target budget (the "nothing new" branch continues before
+          # the TARGETS append), so that cap is NOT what this relieves —
+          # the win is inspection budget plus scan-walk latency for fresh
+          # engagements. Safe because comments, reviews, labels, and
+          # pushes all bump updatedAt or route in real time; the two
+          # scan-only signals that do NOT bump it — a base conflict
+          # appearing when main moves, and still-red checks awaiting the
+          # redcheck marker — wait at most the backoff gap (~30 min) on a
+          # PR nobody touched in a day, and self-correct (the eventual
+          # address run comments/pushes). Slotting is deterministic — one
+          # eligible 10-minute tick in every four, keyed by PR number, the
+          # same 600s quantum as ROT_OFF — so the gap is bounded at ~30
+          # minutes and no PR is unlucky forever. The forced-dispatch path
+          # never builds the list files, so a forced PR is always
+          # inspected (fail-open, like a PR missing from the set).
+          IDLE_PRS=' '
           if [[ -f "${WORKDIR}/bot-prs.json" && -f "${WORKDIR}/takeover-prs.json" ]]; then
-            IDLE_UPDATED="$(jq -cs 'add | unique_by(.number)
-              | map({(.number | tostring): (.updatedAt // "")}) | add // {}' \
-              "${WORKDIR}/bot-prs.json" "${WORKDIR}/takeover-prs.json" 2> /dev/null || echo '{}')"
+            IDLE_CUTOFF="$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)"
+            IDLE_PRS=" $(jq -rs --arg cut "${IDLE_CUTOFF}" 'add | unique_by(.number)
+              | map(select((.updatedAt // "") != "" and .updatedAt < $cut) | .number | tostring)
+              | join(" ")' \
+              "${WORKDIR}/bot-prs.json" "${WORKDIR}/takeover-prs.json" 2> /dev/null || echo '') "
           fi
-          IDLE_CUTOFF="$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)"
-          IDLE_SLOT_NOW="$(( ($(date -u +%s) / 3600) % 4 ))"
+          IDLE_SLOT_NOW="$(( ($(date -u +%s) / 600) % 4 ))"
 
           TARGETS='[]'
           INSPECTED=0
@@ -1849,12 +1859,12 @@ jobs:
               fleet_row "${PR}" 'busy' 'address run in flight'
               continue
             fi
-            # The idle-backoff skip is free too (in-memory lookup) — it must
+            # The idle-backoff skip is free too (a bash substring test on
+            # the precomputed set, same idiom as the busy skip) — it must
             # not consume inspection budget either.
-            PR_UPDATED="$(jq -r --arg pr "${PR}" '.[$pr] // ""' <<< "${IDLE_UPDATED}")"
-            if [[ -n "${PR_UPDATED}" && "${PR_UPDATED}" < "${IDLE_CUTOFF}" && "$(( PR % 4 ))" != "${IDLE_SLOT_NOW}" ]]; then
-              echo "😴 #${PR}: idle since ${PR_UPDATED} (>24h) — deferring to its rotation slot (slot $(( PR % 4 )), current ${IDLE_SLOT_NOW})"
-              fleet_row "${PR}" 'idle-backoff' "idle since ${PR_UPDATED}; inspected roughly every 4th scan"
+            if [[ "${IDLE_PRS}" == *" ${PR} "* && "$(( PR % 4 ))" != "${IDLE_SLOT_NOW}" ]]; then
+              echo "😴 #${PR}: idle >24h — deferring to its rotation slot (slot $(( PR % 4 )), current ${IDLE_SLOT_NOW}, next eligible tick ≤30m away)"
+              fleet_row "${PR}" 'idle-backoff' 'idle >24h; inspected roughly every 4th scan (gap ≤30m)'
               continue
             fi
             INSPECTED=$(( INSPECTED + 1 ))

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -1831,11 +1831,11 @@ jobs:
           # pushes all bump updatedAt or route in real time; the two
           # scan-only signals that do NOT bump it — a base conflict
           # appearing when main moves, and still-red checks awaiting the
-          # redcheck marker — wait at most the backoff gap (~30 min) on a
+          # redcheck marker — wait at most the backoff gap (~40 min) on a
           # PR nobody touched in a day, and self-correct (the eventual
           # address run comments/pushes). Slotting is deterministic — one
           # eligible 10-minute tick in every four, keyed by PR number, the
-          # same 600s quantum as ROT_OFF — so the gap is bounded at ~30
+          # same 600s quantum as ROT_OFF — so the gap is bounded at ~40
           # minutes and no PR is unlucky forever. The forced-dispatch path
           # never builds the list files, so a forced PR is always
           # inspected (fail-open, like a PR missing from the set).
@@ -1864,7 +1864,7 @@ jobs:
             # not consume inspection budget either.
             if [[ "${IDLE_PRS}" == *" ${PR} "* && "$(( PR % 4 ))" != "${IDLE_SLOT_NOW}" ]]; then
               echo "😴 #${PR}: idle >24h — deferring to its rotation slot (slot $(( PR % 4 )), current ${IDLE_SLOT_NOW}, next eligible tick ≤30m away)"
-              fleet_row "${PR}" 'idle-backoff' 'idle >24h; inspected roughly every 4th scan (gap ≤30m)'
+              fleet_row "${PR}" 'idle-backoff' 'idle >24h; inspected roughly every 4th scan (gap ≤40m)'
               continue
             fi
             INSPECTED=$(( INSPECTED + 1 ))

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -2498,6 +2498,11 @@ describe('qwen-autofix workflow', () => {
       }),
     ).toBe('inspect');
 
+    // Null/empty updatedAt (defensive guard) → inspected, not idle.
+    expect(runBackoff({ pr: '8001', updatedAt: null, slotNow: 0 })).toBe(
+      'inspect',
+    );
+
     // Visible in the fleet dashboard, like the busy skip.
     expect(reviewScanJob).toContain("'idle-backoff'");
     // The workflow comment must not claim the 10-target cap is relieved —

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -2398,46 +2398,119 @@ describe('qwen-autofix workflow', () => {
     // starve the oldest tail forever once the pool exceeds the budget.
     expect(reviewScanJob).toContain('ROT_OFF=');
     expect(reviewScanJob).toContain('.[$o:] + .[:$o]');
-    // The free skips (busy, idle-backoff) both come before the budget
-    // increment — neither may consume inspection budget.
-    expect(reviewScanJob).toMatch(
-      /BUSY_PRS[\s\S]{0,1600}INSPECTED=\$\(\( INSPECTED \+ 1 \)\)/,
+    // The free skips (busy, idle-backoff) both live in the loop head,
+    // BEFORE the budget increment — assert on the slice, not a byte
+    // distance (comment growth must not red-light CI, and arbitrary code
+    // between the skips and the increment must).
+    const loopHead = reviewScanJob.slice(
+      reviewScanJob.indexOf('for PR in ${CANDIDATES}'),
+      reviewScanJob.indexOf('INSPECTED=$(( INSPECTED + 1 ))'),
     );
-    expect(reviewScanJob).toMatch(
-      /fleet_row "\$\{PR\}" 'idle-backoff'[\s\S]{0,120}INSPECTED=\$\(\( INSPECTED \+ 1 \)\)/,
-    );
+    expect(loopHead).toContain("'busy'");
+    expect(loopHead).toContain("'idle-backoff'");
+    expect(loopHead).not.toContain('INSPECTED=');
   });
 
   it('backs off idle candidates without spending inspection budget', () => {
-    // Measured 2026-07-29: 28 open takeover PRs, 8 of them idle in
-    // "nothing new" state for 10+ hours — every scan re-confirmed their
-    // idleness while #8002 (freshly engaged) was admitted and then
-    // deferred by the 10-target cap. Candidates idle >24h are inspected
-    // on roughly every 4th scan instead of every one.
-    // The staleness signal is the list's own updatedAt — no extra API
-    // call per candidate.
+    // Measured 2026-07-29: 28 open takeover PRs, 8 idle in "nothing new"
+    // state for 10+ hours. Every idle inspection costs a unit of the
+    // shared MAX_CANDIDATE_INSPECTIONS budget and a slice of the serial
+    // API walk (the walk is what delayed #8002's first pickup by ~6
+    // minutes). Candidates idle >24h are inspected on roughly every 4th
+    // scan. The staleness signal is the list's own updatedAt — no API
+    // call, and no per-candidate process fork either: one jq builds the
+    // idle SET, and the loop tests membership like the busy skip does.
     expect(
-      reviewScanJob.split('maintainerCanModify,updatedAt').length - 1,
+      (reviewScanJob.match(/--json [^\n]*\bupdatedAt\b/g) ?? []).length,
     ).toBe(2);
     expect(reviewScanJob).toContain(`IDLE_CUTOFF="$(date -u -d '24 hours ago'`);
-    // Deterministic slotting by PR number and UTC hour — one eligible hour
-    // in every four, so no PR is unlucky forever.
+    // Slotting quantum is the SCAN TICK (600s, same quantum as ROT_OFF),
+    // not the hour: an hourly slot against a */10 cron means 6 back-to-back
+    // inspections then a ~3h blind window — same 25% average, terrible
+    // shape. With 600s the gap is bounded at ~30 minutes, which is what
+    // the operator-facing strings promise.
     expect(reviewScanJob).toContain(
-      'IDLE_SLOT_NOW="$(( ($(date -u +%s) / 3600) % 4 ))"',
+      'IDLE_SLOT_NOW="$(( ($(date -u +%s) / 600) % 4 ))"',
     );
-    expect(reviewScanJob).toContain('"$(( PR % 4 ))" != "${IDLE_SLOT_NOW}"');
+    expect(reviewScanJob).not.toMatch(/IDLE_SLOT_NOW[^\n]*\/ 3600/);
+    expect(reviewScanJob).toContain('gap ≤30m');
     // Fail-open on the forced-dispatch path: it never builds the list
-    // files, so the lookup stays empty and a forced PR is always
-    // inspected. Same for a PR missing from the lookup.
-    expect(reviewScanJob).toContain("IDLE_UPDATED='{}'");
+    // files, so the set stays empty and a forced PR is always inspected.
+    expect(reviewScanJob).toContain("IDLE_PRS=' '");
     expect(reviewScanJob).toMatch(
-      /if \[\[ -f "\$\{WORKDIR\}\/bot-prs\.json" && -f "\$\{WORKDIR\}\/takeover-prs\.json" \]\]; then\n\s+IDLE_UPDATED=/,
+      /if \[\[ -f "\$\{WORKDIR\}\/bot-prs\.json" && -f "\$\{WORKDIR\}\/takeover-prs\.json" \]\]; then\n\s+IDLE_CUTOFF=/,
     );
-    expect(reviewScanJob).toContain(
-      '[[ -n "${PR_UPDATED}" && "${PR_UPDATED}" < "${IDLE_CUTOFF}"',
-    );
+
+    // Behavioral replay of the set builder + skip predicate (the string
+    // pins alone cannot catch a flipped comparison or slot equality):
+    // run the real jq and the real predicate over four candidate shapes.
+    const setSrc = reviewScanJob.match(
+      /IDLE_PRS=" \$\(jq -rs[\s\S]*?\) "/,
+    )?.[0];
+    expect(setSrc).toBeTruthy();
+    const runBackoff = ({ pr, updatedAt, slotNow, listed = true }) => {
+      const dir = mkdtempSync(join(tmpdir(), 'idle-backoff-'));
+      try {
+        const row = listed
+          ? [{ number: Number(pr), updatedAt }]
+          : [{ number: 99999, updatedAt: '2026-01-01T00:00:00Z' }];
+        writeFileSync(join(dir, 'bot-prs.json'), JSON.stringify(row));
+        writeFileSync(join(dir, 'takeover-prs.json'), '[]');
+        return execFileSync(
+          'bash',
+          [
+            '-c',
+            [
+              'set -uo pipefail',
+              `WORKDIR='${dir}'`,
+              `IDLE_CUTOFF='2026-07-28T12:00:00Z'`,
+              setSrc,
+              `IDLE_SLOT_NOW='${slotNow}'`,
+              `PR='${pr}'`,
+              'if [[ "${IDLE_PRS}" == *" ${PR} "* && "$(( PR % 4 ))" != "${IDLE_SLOT_NOW}" ]]; then printf skip; else printf inspect; fi',
+            ].join('\n'),
+          ],
+          { encoding: 'utf8' },
+        );
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    };
+    // Idle and out of slot → deferred (8001 % 4 = 1).
+    expect(
+      runBackoff({ pr: '8001', updatedAt: '2026-07-27T00:00:00Z', slotNow: 0 }),
+    ).toBe('skip');
+    // Idle but IN its slot → inspected (the gap is bounded).
+    expect(
+      runBackoff({ pr: '8001', updatedAt: '2026-07-27T00:00:00Z', slotNow: 1 }),
+    ).toBe('inspect');
+    // Fresh activity → inspected regardless of slot.
+    expect(
+      runBackoff({ pr: '8001', updatedAt: '2026-07-28T13:00:00Z', slotNow: 0 }),
+    ).toBe('inspect');
+    // Missing from the lookup (forced-dispatch shape) → inspected.
+    expect(
+      runBackoff({
+        pr: '8001',
+        updatedAt: '2026-07-27T00:00:00Z',
+        slotNow: 0,
+        listed: false,
+      }),
+    ).toBe('inspect');
+
     // Visible in the fleet dashboard, like the busy skip.
     expect(reviewScanJob).toContain("'idle-backoff'");
+    // The workflow comment must not claim the 10-target cap is relieved —
+    // idle candidates hit `continue` before the TARGETS append, so they
+    // never contend for it; the real win is inspection budget + walk
+    // latency, and the comment says so.
+    expect(reviewScanJob).toContain(
+      'Idle PRs never reach the\n          # 10-target budget',
+    );
+    // The two scan-only signals updatedAt cannot see are named, not
+    // papered over by an absolute invariant.
+    expect(reviewScanJob).toContain('base conflict');
+    expect(reviewScanJob).toContain('still-red checks');
   });
 
   it('behaviorally replays the takeover-command toggle across all four paths', () => {

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -2398,9 +2398,46 @@ describe('qwen-autofix workflow', () => {
     // starve the oldest tail forever once the pool exceeds the budget.
     expect(reviewScanJob).toContain('ROT_OFF=');
     expect(reviewScanJob).toContain('.[$o:] + .[:$o]');
+    // The free skips (busy, idle-backoff) both come before the budget
+    // increment — neither may consume inspection budget.
     expect(reviewScanJob).toMatch(
-      /BUSY_PRS[\s\S]{0,240}INSPECTED=\$\(\( INSPECTED \+ 1 \)\)/,
+      /BUSY_PRS[\s\S]{0,1600}INSPECTED=\$\(\( INSPECTED \+ 1 \)\)/,
     );
+    expect(reviewScanJob).toMatch(
+      /fleet_row "\$\{PR\}" 'idle-backoff'[\s\S]{0,120}INSPECTED=\$\(\( INSPECTED \+ 1 \)\)/,
+    );
+  });
+
+  it('backs off idle candidates without spending inspection budget', () => {
+    // Measured 2026-07-29: 28 open takeover PRs, 8 of them idle in
+    // "nothing new" state for 10+ hours — every scan re-confirmed their
+    // idleness while #8002 (freshly engaged) was admitted and then
+    // deferred by the 10-target cap. Candidates idle >24h are inspected
+    // on roughly every 4th scan instead of every one.
+    // The staleness signal is the list's own updatedAt — no extra API
+    // call per candidate.
+    expect(
+      reviewScanJob.split('maintainerCanModify,updatedAt').length - 1,
+    ).toBe(2);
+    expect(reviewScanJob).toContain(`IDLE_CUTOFF="$(date -u -d '24 hours ago'`);
+    // Deterministic slotting by PR number and UTC hour — one eligible hour
+    // in every four, so no PR is unlucky forever.
+    expect(reviewScanJob).toContain(
+      'IDLE_SLOT_NOW="$(( ($(date -u +%s) / 3600) % 4 ))"',
+    );
+    expect(reviewScanJob).toContain('"$(( PR % 4 ))" != "${IDLE_SLOT_NOW}"');
+    // Fail-open on the forced-dispatch path: it never builds the list
+    // files, so the lookup stays empty and a forced PR is always
+    // inspected. Same for a PR missing from the lookup.
+    expect(reviewScanJob).toContain("IDLE_UPDATED='{}'");
+    expect(reviewScanJob).toMatch(
+      /if \[\[ -f "\$\{WORKDIR\}\/bot-prs\.json" && -f "\$\{WORKDIR\}\/takeover-prs\.json" \]\]; then\n\s+IDLE_UPDATED=/,
+    );
+    expect(reviewScanJob).toContain(
+      '[[ -n "${PR_UPDATED}" && "${PR_UPDATED}" < "${IDLE_CUTOFF}"',
+    );
+    // Visible in the fleet dashboard, like the busy skip.
+    expect(reviewScanJob).toContain("'idle-backoff'");
   });
 
   it('behaviorally replays the takeover-command toggle across all four paths', () => {

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -2415,25 +2415,30 @@ describe('qwen-autofix workflow', () => {
     // Measured 2026-07-29: 28 open takeover PRs, 8 idle in "nothing new"
     // state for 10+ hours. Every idle inspection costs a unit of the
     // shared MAX_CANDIDATE_INSPECTIONS budget and a slice of the serial
-    // API walk (the walk is what delayed #8002's first pickup by ~6
-    // minutes). Candidates idle >24h are inspected on roughly every 4th
-    // scan. The staleness signal is the list's own updatedAt — no API
-    // call, and no per-candidate process fork either: one jq builds the
-    // idle SET, and the loop tests membership like the busy skip does.
+    // API walk (a few fewer gh round-trips per scan; the #8002 delay was
+    // queue/startup, which the candidate loop cannot recover). Candidates
+    // idle >24h are inspected on about one scan in four. The staleness
+    // signal is the list's own updatedAt — no API call, and no
+    // per-candidate process fork either: one jq builds the idle SET, and
+    // the loop tests membership like the busy skip does.
     expect(
       (reviewScanJob.match(/--json [^\n]*\bupdatedAt\b/g) ?? []).length,
     ).toBe(2);
     expect(reviewScanJob).toContain(`IDLE_CUTOFF="$(date -u -d '24 hours ago'`);
-    // Slotting quantum is the SCAN TICK (600s, same quantum as ROT_OFF),
-    // not the hour: an hourly slot against a */10 cron means 6 back-to-back
-    // inspections then a ~3h blind window — same 25% average, terrible
-    // shape. With 600s the gap is bounded at ~40 minutes, which is what
-    // the operator-facing strings promise.
-    expect(reviewScanJob).toContain(
-      'IDLE_SLOT_NOW="$(( ($(date -u +%s) / 600) % 4 ))"',
+    // The slot is a time quantum mod 4 keyed against PR % 4 (same quantum
+    // family as ROT_OFF). The exact quantum is deliberately NOT pinned:
+    // against the real irregular scan cadence (~40-70 min gaps, not */10)
+    // no constant quantum bounds the gap — the wait is geometric (measured
+    // median ~2h, p90 ~6h) — and 3600 s actually measures better on p90/max
+    // than 600 s, so CI must not forbid a future quantum change. The
+    // behavioral replay below (which passes slotNow explicitly) protects
+    // the slot logic; this pin only asserts the mod-4 time-quantum shape.
+    expect(reviewScanJob).toMatch(
+      /IDLE_SLOT_NOW="\$\(\(.*\$\(date -u \+%s\) \/ \d+\) % 4 \)\)"/,
     );
-    expect(reviewScanJob).not.toMatch(/IDLE_SLOT_NOW[^\n]*\/ 3600/);
-    expect(reviewScanJob).toContain('gap ≤40m');
+    expect(reviewScanJob).toContain(
+      'inspected ~1 scan in 4 (median ~2h, p90 ~6h)',
+    );
     // Fail-open on the forced-dispatch path: it never builds the list
     // files, so the set stays empty and a forced PR is always inspected.
     expect(reviewScanJob).toContain("IDLE_PRS=' '");
@@ -2497,7 +2502,7 @@ describe('qwen-autofix workflow', () => {
     expect(
       runBackoff({ pr: '8001', updatedAt: '2026-07-27T00:00:00Z', slotNow: 0 }),
     ).toBe('skip');
-    // Idle but IN its slot → inspected (the gap is bounded).
+    // Idle but IN its slot → inspected (its slot matched this scan).
     expect(
       runBackoff({ pr: '8001', updatedAt: '2026-07-27T00:00:00Z', slotNow: 1 }),
     ).toBe('inspect');

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -2427,13 +2427,13 @@ describe('qwen-autofix workflow', () => {
     // Slotting quantum is the SCAN TICK (600s, same quantum as ROT_OFF),
     // not the hour: an hourly slot against a */10 cron means 6 back-to-back
     // inspections then a ~3h blind window — same 25% average, terrible
-    // shape. With 600s the gap is bounded at ~30 minutes, which is what
+    // shape. With 600s the gap is bounded at ~40 minutes, which is what
     // the operator-facing strings promise.
     expect(reviewScanJob).toContain(
       'IDLE_SLOT_NOW="$(( ($(date -u +%s) / 600) % 4 ))"',
     );
     expect(reviewScanJob).not.toMatch(/IDLE_SLOT_NOW[^\n]*\/ 3600/);
-    expect(reviewScanJob).toContain('gap ≤30m');
+    expect(reviewScanJob).toContain('gap ≤40m');
     // Fail-open on the forced-dispatch path: it never builds the list
     // files, so the set stays empty and a forced PR is always inspected.
     expect(reviewScanJob).toContain("IDLE_PRS=' '");
@@ -2448,6 +2448,10 @@ describe('qwen-autofix workflow', () => {
       /IDLE_PRS=" \$\(jq -rs[\s\S]*?\) "/,
     )?.[0];
     expect(setSrc).toBeTruthy();
+    const predSrc = reviewScanJob.match(
+      /if \[\[ "\$\{IDLE_PRS\}" == \*" \$\{PR\} "\* &&[^\n]*\]\]; then/,
+    )?.[0];
+    expect(predSrc).toBeTruthy();
     const runBackoff = ({ pr, updatedAt, slotNow, listed = true }) => {
       const dir = mkdtempSync(join(tmpdir(), 'idle-backoff-'));
       try {
@@ -2467,7 +2471,7 @@ describe('qwen-autofix workflow', () => {
               setSrc,
               `IDLE_SLOT_NOW='${slotNow}'`,
               `PR='${pr}'`,
-              'if [[ "${IDLE_PRS}" == *" ${PR} "* && "$(( PR % 4 ))" != "${IDLE_SLOT_NOW}" ]]; then printf skip; else printf inspect; fi',
+              `${predSrc} printf skip; else printf inspect; fi`,
             ].join('\n'),
           ],
           { encoding: 'utf8' },

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -2448,18 +2448,31 @@ describe('qwen-autofix workflow', () => {
       /IDLE_PRS=" \$\(jq -rs[\s\S]*?\) "/,
     )?.[0];
     expect(setSrc).toBeTruthy();
+    expect(setSrc).toContain('takeover-prs.json');
     const predSrc = reviewScanJob.match(
       /if \[\[ "\$\{IDLE_PRS\}" == \*" \$\{PR\} "\* &&[^\n]*\]\]; then/,
     )?.[0];
     expect(predSrc).toBeTruthy();
-    const runBackoff = ({ pr, updatedAt, slotNow, listed = true }) => {
+    const runBackoff = ({
+      pr,
+      updatedAt,
+      slotNow,
+      listed = true,
+      inTakeover = false,
+    }) => {
       const dir = mkdtempSync(join(tmpdir(), 'idle-backoff-'));
       try {
         const row = listed
           ? [{ number: Number(pr), updatedAt }]
           : [{ number: 99999, updatedAt: '2026-01-01T00:00:00Z' }];
-        writeFileSync(join(dir, 'bot-prs.json'), JSON.stringify(row));
-        writeFileSync(join(dir, 'takeover-prs.json'), '[]');
+        writeFileSync(
+          join(dir, 'bot-prs.json'),
+          inTakeover ? '[]' : JSON.stringify(row),
+        );
+        writeFileSync(
+          join(dir, 'takeover-prs.json'),
+          inTakeover ? JSON.stringify(row) : '[]',
+        );
         return execFileSync(
           'bash',
           [
@@ -2506,6 +2519,15 @@ describe('qwen-autofix workflow', () => {
     expect(runBackoff({ pr: '8001', updatedAt: null, slotNow: 0 })).toBe(
       'inspect',
     );
+    // Idle candidate in takeover-prs.json (the cohort this targets) → deferred.
+    expect(
+      runBackoff({
+        pr: '8001',
+        updatedAt: '2026-07-27T00:00:00Z',
+        slotNow: 0,
+        inTakeover: true,
+      }),
+    ).toBe('skip');
 
     // Visible in the fleet dashboard, like the busy skip.
     expect(reviewScanJob).toContain("'idle-backoff'");


### PR DESCRIPTION
## Problem

The scheduled scan inspects every candidate on every tick. The takeover pool doubled in two days — 28 open takeover PRs at last count, 8 of them sitting in "nothing new" state for 10+ hours — and every idle inspection costs twice: a unit of the shared `MAX_CANDIDATE_INSPECTIONS` budget (60), and a slice of the **serial API walk** over the candidate list. That walk is what delays fresh engagements: on the 09:03 scan (2026-07-29), #8002 — freshly engaged at 08:00 — was not reached until 09:09, six minutes of serial `gh` reads in.

(Idle candidates never contend for the 10-target cap — the "nothing new" branch `continue`s before the `TARGETS` append — so this change does not claim to relieve it. The win is inspection budget plus scan-walk latency.)

## Change

Candidates whose `updatedAt` — taken from the candidate list itself, **no extra API call, no per-candidate process fork** (one `jq` builds an idle set; the loop does a bash substring test, same idiom as the busy skip) — is older than 24h are inspected on roughly every 4th scan instead of every one.

Slotting is deterministic on the **scan tick** (600s, the same quantum as `ROT_OFF`): each PR is eligible one 10-minute tick in every four, so the skip gap is bounded at **~30 minutes** and no PR is unlucky forever. The skip sits with the busy skip **before** the inspection-budget increment.

Why this is safe:
- Comments, reviews, labels, and pushes all bump `updatedAt` or route in **real time** — a review event on a takeover PR never waits for a scan.
- The two scan-only signals `updatedAt` cannot see — a base conflict appearing when main moves, and still-red checks awaiting the redcheck marker — wait at most the ~30-minute gap on a PR nobody has touched in a day, and self-correct (the eventual address run comments/pushes).
- The forced-dispatch path never builds the list files, so the set stays empty and a **forced PR is always inspected**; same fail-open for any PR missing from the set.
- Fresh engagements are immune: the takeover label application itself bumps `updatedAt`.

Backed-off candidates are visible in the fleet dashboard as `idle-backoff` rows (`idle >24h; inspected roughly every 4th scan (gap ≤30m)`).

## Tests

Behavioral replay of the set builder + skip predicate (idle+out-of-slot defers; idle+in-slot inspects; fresh inspects; missing-from-lookup inspects), loop-head slice assertions (both free skips before the budget increment, no budget spend in between — immune to comment growth), an order-independent `--json` field pin, the 600s quantum pinned in and the 3600s quantum pinned out, and the corrected cost-model statements pinned in the workflow comment. 103/103; YAML parses.

<details>
<summary>中文说明</summary>

## 问题

定时扫描每一轮检查所有候选。接管池两天翻倍（28 个 open 接管 PR，8 个已空闲 10+ 小时），每次空闲检查有双重代价：占一个共享检查预算（`MAX_CANDIDATE_INSPECTIONS`=60），以及**串行 API 遍历**的一段时长——正是这个遍历拖慢新接管的首次拾取：09:03 扫描直到 09:09（6 分钟串行读之后）才走到 08:00 刚接管的 #8002。

（空闲候选不会争抢 10 目标上限——"无新反馈"分支在 `TARGETS` 追加之前就 `continue` 了——本改动不声称缓解该上限；收益在检查预算与遍历延迟。）

## 改动

`updatedAt`（取自候选列表本身，**零额外 API 调用、零每候选进程 fork**：一次 `jq` 构建空闲集合，循环内做 bash 子串判断，与 busy 跳过同款写法）超过 24h 的候选，约每 4 次扫描检查一次。按**扫描 tick**（600s，与 `ROT_OFF` 同量子）确定性排片：每 PR 每 4 个 10 分钟 tick 有 1 个可检，跳过间隔上界 **~30 分钟**。跳过与 busy 跳过一起位于检查预算自增之前。

安全性：评论/评审/标签/推送都会刷新 `updatedAt` 或本就实时路由；`updatedAt` 看不到的两个仅扫描信号（main 前进导致的 base 冲突、等待 redcheck 标记的持续红检查）最多等 ~30 分钟且自我修正；强制 dispatch 不生成列表文件，集合为空，**强制 PR 永远被检查**（缺失同样 fail-open）；新接管免疫（打标签即刷新 `updatedAt`）。fleet 面板以 `idle-backoff` 行可见（`idle >24h; inspected roughly every 4th scan (gap ≤30m)`）。

## 测试

集合构建器+跳过谓词的行为回放（空闲出槽推迟/空闲在槽检查/新活动检查/未列出检查）；loop-head 切片断言（两个免费跳过均在预算自增前、其间无预算消耗，注释增长免疫）；字段顺序无关的 `--json` pin；600s 量子 pin 入、3600s pin 出；注释中修正后的成本模型表述 pin 入。103/103；YAML 解析正常。

</details>
