### PR TITLE
fix(channels): reject unusable GitHub self-allowlists

### DIFF
--- a/docs/users/features/channels/github.md
+++ b/docs/users/features/channels/github.md
@@ -4,7 +4,8 @@ This guide covers setting up a Qwen Code channel that monitors GitHub notificati
 
 ## Prerequisites
 
-- A GitHub account (or a dedicated bot account)
+- A GitHub account for the channel. Use a dedicated bot account when the PAT
+  owner also needs to operate the channel.
 - A GitHub Personal Access Token (PAT) with `notifications` and `public_repo` (or `repo`) scopes
 
 ## Creating a Token
@@ -27,7 +28,7 @@ Add the channel to `~/.qwen/settings.json`:
       "token": "$GITHUB_TOKEN",
       "pollInterval": 60000,
       "senderPolicy": "allowlist",
-      "allowedUsers": ["your-github-username"],
+      "allowedUsers": ["operator-github-username"],
       "sessionScope": "chat_thread",
       "cwd": "/path/to/your/project",
       "groupPolicy": "open",
@@ -44,6 +45,13 @@ Set the token as an environment variable:
 ```bash
 export GITHUB_TOKEN="ghp_your_token_here"
 ```
+
+The PAT owner cannot trigger its own channel: GitHub self-activity does not
+provide a usable notification, and the adapter intentionally ignores its own
+comments to prevent reply loops. If the PAT owner needs to operate the channel,
+use a separate bot-owned PAT and put only operator accounts in `allowedUsers`.
+Startup rejects an allowlist containing only the PAT owner and warns when the
+PAT owner appears alongside other operators.
 
 ### GitHub Enterprise
 

--- a/packages/channels/github/src/GithubAdapter.test.ts
+++ b/packages/channels/github/src/GithubAdapter.test.ts
@@ -247,6 +247,44 @@ describe('GithubChannel', () => {
       channel.disconnect();
     });
 
+    it('rejects an allowlist containing only the authenticated GitHub account', async () => {
+      const config = makeConfig({
+        senderPolicy: 'allowlist',
+        allowedUsers: ['TEST-BOT', 'test-bot'],
+      });
+      channel = new TestableGithubChannel('test-github', config, makeBridge());
+      mockOctokit.paginate.mockResolvedValue([]);
+
+      try {
+        await expect(channel.connect()).rejects.toThrow(
+          'allowlist only contains the authenticated GitHub account "test-bot"',
+        );
+      } finally {
+        channel.disconnect();
+      }
+      expect(config.allowedUsers).toEqual(['test-bot', 'test-bot']);
+    });
+
+    it('warns when the authenticated GitHub account is part of a mixed allowlist', async () => {
+      const config = makeConfig({
+        senderPolicy: 'allowlist',
+        allowedUsers: ['TEST-BOT', 'operator'],
+      });
+      channel = new TestableGithubChannel('test-github', config, makeBridge());
+      mockOctokit.paginate.mockResolvedValue([]);
+      const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+
+      try {
+        await channel.connect();
+        expect(stderr).toHaveBeenCalledWith(
+          '[Channel:test-github] warning: authenticated GitHub account "test-bot" is allowlisted but cannot trigger this channel; use a separate operator account.\n',
+        );
+      } finally {
+        channel.disconnect();
+        stderr.mockRestore();
+      }
+    });
+
     it('connect() is idempotent across reconnects', async () => {
       const config = makeConfig({
         senderPolicy: 'allowlist',

--- a/packages/channels/github/src/GithubAdapter.ts
+++ b/packages/channels/github/src/GithubAdapter.ts
@@ -146,6 +146,21 @@ export class GithubChannel extends PollingChannelBase<GithubCursor> {
       u.toLowerCase(),
     );
     this.config.allowedUsers = allowed;
+    const botUsername = this.botUsername?.toLowerCase();
+    if (
+      this.config.senderPolicy === 'allowlist' &&
+      botUsername &&
+      allowed.includes(botUsername)
+    ) {
+      if (allowed.every((user) => user === botUsername)) {
+        throw new Error(
+          `[Channel:${this.name}] GitHub allowlist only contains the authenticated GitHub account "${this.botUsername}", which cannot trigger this channel because self-authored comments are ignored. Use a separate bot-owned PAT and allowlist the operator account.`,
+        );
+      }
+      process.stderr.write(
+        `[Channel:${this.name}] warning: authenticated GitHub account "${this.botUsername}" is allowlisted but cannot trigger this channel; use a separate operator account.\n`,
+      );
+    }
     this.gate.replaceAllowedUsers(allowed);
     this.startPollLoop();
   }


### PR DESCRIPTION
## What this PR does

GitHub channels now compare the authenticated PAT owner with the normalized operator allowlist during startup. A self-only allowlist fails immediately with actionable guidance, while a mixed allowlist continues after warning that the authenticated account cannot act as an operator. The setup guide now makes the dedicated bot-account requirement explicit for self-operated workflows.

## Why it's needed

A channel configured with the operator's own PAT could previously start and poll successfully even though that same account could never trigger it: GitHub self-activity does not provide a usable notification, and the existing anti-loop protection correctly ignores the channel account's own comments. Rejecting this unusable identity combination prevents a silent failure that otherwise looks like a healthy channel.

## Reviewer Test Plan

### How to verify

Configure a GitHub channel whose authenticated account is `test-bot` and whose case-insensitive allowlist contains only `test-bot`. Startup should stop after identity resolution, explain that a separate bot-owned PAT and operator account are required, and never begin notification polling. Then add another operator to the allowlist: startup should continue, emit one warning identifying `test-bot` as unable to trigger the channel, and begin polling. Finally, verify that comments authored by `test-bot` remain ignored so the anti-loop behavior is unchanged.

### Evidence (Before & After)

Before: the self-only configuration connected successfully and issued notification polling requests. After: the same configuration is rejected after the authenticated-user request with no notification request, while a mixed allowlist warns and continues. This is terminal/daemon integration behavior, so the evidence is an exact localhost HTTP transcript rather than a screenshot; a separate E2E report will be posted on the PR.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 15.6 arm64, Node.js v22.23.1, a fake token, and a localhost-only GitHub API mock. The complete 76-test GitHub channel suite, exact-file formatting and lint checks, full build, bundle, and workspace typecheck all passed. The rebuilt delivery chunk was exercised directly from the bundled CLI graph.

## Risk & Scope

- Main risk or tradeoff: a previously accepted but nonfunctional self-only allowlist now fails startup by design; mixed and non-self allowlists retain their existing behavior.
- Not validated / out of scope: live polling with a real GitHub credential and GitHub's external self-notification delivery semantics.
- Breaking changes / migration notes: affected self-only configurations must move the PAT to a dedicated bot account and allowlist the human operator.

## Linked Issues

Fixes #8017

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

GitHub Channel 现在会在启动时比较 PAT 的认证账号与规范化后的操作者 allowlist。仅包含认证账号自身的 allowlist 会立即失败并给出可操作的指引；混合 allowlist 则会继续启动，同时警告认证账号不能充当操作者。配置指南也明确说明：如果需要由本人操作 Channel，就必须使用独立 bot 账号。

## 为什么需要这个改动

此前，使用操作者本人 PAT 的 Channel 可以成功启动并持续轮询，但同一账号实际上永远无法触发它：GitHub 的自身活动不会产生可用通知，而现有的防循环保护也会正确忽略 Channel 账号自己发布的评论。拒绝这种不可用的身份组合，可以避免一个表面健康、实际静默失效的 Channel。

## Reviewer 测试计划

### 如何验证

配置一个认证账号为 `test-bot` 的 GitHub Channel，并让不区分大小写的 allowlist 只包含 `test-bot`。启动应在解析身份后停止，说明需要独立 bot 所有的 PAT 和操作者账号，并且不得开始通知轮询。随后在 allowlist 中加入另一个操作者：启动应继续，发出一条警告说明 `test-bot` 无法触发 Channel，并开始轮询。最后确认 `test-bot` 自己发布的评论仍会被忽略，防循环行为没有改变。

### 证据（Before & After）

Before：仅包含自身账号的配置会成功连接并发起通知轮询请求。After：同一配置在认证用户请求后被拒绝，不会发起通知请求；混合 allowlist 会警告后继续。这是终端/daemon 集成行为，因此证据采用精确的 localhost HTTP 记录而非截图；PR 上还会单独发布 E2E 报告。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

macOS 15.6 arm64、Node.js v22.23.1、假 token 和仅限 localhost 的 GitHub API mock。GitHub Channel 的完整 76 项测试、精确文件格式与 lint 检查、完整构建、bundle 和工作区 typecheck 均通过；同时直接从已打包 CLI 的交付依赖图验证了重建后的 GitHub chunk。

## 风险与范围

- 主要风险或取舍：此前会被接受但实际不可用的 self-only allowlist 现在会按设计启动失败；混合 allowlist 和不包含自身账号的 allowlist 保持原有行为。
- 未验证 / 范围外：使用真实 GitHub 凭据进行线上轮询，以及 GitHub 外部 self-notification 的实际投递语义。
- 破坏性变更 / 迁移说明：受影响的 self-only 配置需要把 PAT 迁移到独立 bot 账号，并将人类操作者加入 allowlist。

## 关联 Issue

Fixes #8017

</details>
