### PR TITLE
feat(hooks): add SessionDelete event

### DIFF
--- a/docs/design/2026-07-29-session-delete-hook.md
+++ b/docs/design/2026-07-29-session-delete-hook.md
@@ -1,0 +1,30 @@
+# SessionDelete hook
+
+## Goal
+
+Notify a user's hook after an explicitly selected session has been deleted.
+
+## Contract
+
+- `SessionDelete` runs after `SessionService.removeSession` or
+  `removeSessions` reports that a transcript was removed.
+- The hook is fire-and-forget. Its output and failure cannot undo or delay a
+  completed deletion.
+- The payload contains the hook runtime's normal hook fields plus
+  `deleted_session_id`. The hook runtime owns the hook configuration;
+  the deleted session can be inactive and has no live hook runtime.
+- The interactive `/delete` flow and ACP's explicit `deleteSession` extension
+  method emit the event. Cleanup, rollback, archive, close, and daemon REST
+  batch deletion do not.
+
+## Rationale
+
+`SessionEnd` describes an active conversation lifecycle. Permanent deletion is
+storage lifecycle work and can target an inactive transcript, so it needs a
+separate event and identifier. Running it only after success prevents hooks
+from leaving close-and-delete flows partially completed.
+
+Daemon REST deletion has no `Config` or `HookSystem` owner in the process that
+removes transcripts. Wiring that path would require an explicit workspace-hook
+execution contract, rather than reconstructing a deleted session's in-memory
+hooks. It is intentionally out of scope for this change.

--- a/docs/users/features/hooks.md
+++ b/docs/users/features/hooks.md
@@ -116,7 +116,7 @@ By default, HTTP hooks cannot target private or link-local IP ranges. In platfor
 ```
 
 - This setting is **only honored from User, System, and SystemDefaults settings scopes**. A value set in Workspace (project) settings is ignored and logged as a warning, so a cloned repository can never self-grant this bypass.
-- Cloud metadata hostnames (`169.254.169.254`, `metadata.google.internal`, `metadata.azure.internal`) remain blocked even when the flag is on — it relaxes IP-range checks only.
+- The flag relaxes only the general private/CGNAT/link-local **range** checks. Cloud metadata endpoints stay blocked in every configuration: the `BLOCKED_HOSTS` list is matched literally (`metadata.google.internal`, `metadata.azure.internal`, ...), and the metadata IPs `169.254.169.254` and `100.100.100.200` are blocked in all serialized forms (including IPv4-mapped IPv6 such as `::ffff:a9fe:a9fe`) and after DNS resolution.
 - The `security.allowedHttpHookUrls` whitelist still applies independently. In managed environments, pair this flag with a whitelist so only the intended internal endpoints are reachable.
 
 > **Warning:** Enabling this flag lets hooks reach internal infrastructure on your network. Enable it only in trusted, managed settings — never in a repository you do not control.

--- a/docs/users/features/hooks.md
+++ b/docs/users/features/hooks.md
@@ -103,6 +103,24 @@ HTTP hooks send hook input as POST requests to specified URLs. They support URL 
 - **DNS Validation**: Validates domain resolution before requests to prevent DNS rebinding attacks
 - **Environment Variable Interpolation**: `${VAR}` syntax, only allows variables in `allowedEnvVars` whitelist
 
+#### Allowing private-network hooks (managed environments only)
+
+By default, HTTP hooks cannot target private or link-local IP ranges. In platform-managed environments where the hook receiver is a first-party, VPC-internal endpoint (for example, an internal API gateway resolving to `172.16.0.0/12`), you can relax the IP-range checks with:
+
+```json
+{
+  "security": {
+    "allowPrivateNetworkHooks": true
+  }
+}
+```
+
+- This setting is **only honored from User, System, and SystemDefaults settings scopes**. A value set in Workspace (project) settings is ignored and logged as a warning, so a cloned repository can never self-grant this bypass.
+- Cloud metadata hostnames (`169.254.169.254`, `metadata.google.internal`, `metadata.azure.internal`) remain blocked even when the flag is on — it relaxes IP-range checks only.
+- The `security.allowedHttpHookUrls` whitelist still applies independently. In managed environments, pair this flag with a whitelist so only the intended internal endpoints are reachable.
+
+> **Warning:** Enabling this flag lets hooks reach internal infrastructure on your network. Enable it only in trusted, managed settings — never in a repository you do not control.
+
 **Example:**
 
 ```json

--- a/docs/users/features/hooks.md
+++ b/docs/users/features/hooks.md
@@ -255,24 +255,25 @@ When `ok` is `false`, Qwen Code will continue working and use the `reason` as co
 
 Hooks fire at specific points during a Qwen Code session. Different events support different matchers to filter trigger conditions.
 
-| Event                | Triggered When                            | Matcher Target                                                 |
-| :------------------- | :---------------------------------------- | :------------------------------------------------------------- |
-| `PreToolUse`         | Before tool execution                     | Tool id (`write_file`, `read_file`, `run_shell_command`, etc.) |
-| `PostToolUse`        | After successful tool execution           | Tool id                                                        |
-| `PostToolUseFailure` | After tool execution fails                | Tool id                                                        |
-| `UserPromptSubmit`   | Before supported model invocations        | None                                                           |
-| `SessionStart`       | When session starts or resumes            | Source (`startup`, `resume`, `clear`, `compact`)               |
-| `SessionEnd`         | When session ends                         | Reason (`clear`, `logout`, `prompt_input_exit`, etc.)          |
-| `MessageDisplay`     | Repeatedly, as the reply streams          | None (always fires)                                            |
-| `Stop`               | When Claude prepares to conclude response | None (always fires)                                            |
-| `SubagentStart`      | When subagent starts                      | Agent type (`Bash`, `Explorer`, `Plan`, etc.)                  |
-| `SubagentStop`       | When subagent stops                       | Agent type                                                     |
-| `PreCompact`         | Before conversation compaction            | Trigger (`manual`, `auto`)                                     |
-| `Notification`       | When notifications are sent               | Type (`permission_prompt`, `idle_prompt`, `auth_success`)      |
-| `PermissionRequest`  | When permission dialog is shown           | Tool id                                                        |
-| `PermissionDenied`   | When tool permission is denied            | Tool id                                                        |
-| `TodoCreated`        | When a new todo item is created           | None (always fires)                                            |
-| `TodoCompleted`      | When a todo item is marked as completed   | None (always fires)                                            |
+| Event                | Triggered When                                  | Matcher Target                                                 |
+| :------------------- | :---------------------------------------------- | :------------------------------------------------------------- |
+| `PreToolUse`         | Before tool execution                           | Tool id (`write_file`, `read_file`, `run_shell_command`, etc.) |
+| `PostToolUse`        | After successful tool execution                 | Tool id                                                        |
+| `PostToolUseFailure` | After tool execution fails                      | Tool id                                                        |
+| `UserPromptSubmit`   | Before supported model invocations              | None                                                           |
+| `SessionStart`       | When session starts or resumes                  | Source (`startup`, `resume`, `clear`, `compact`)               |
+| `SessionEnd`         | When session ends                               | Reason (`clear`, `logout`, `prompt_input_exit`, etc.)          |
+| `SessionDelete`      | After an explicitly selected session is deleted | None                                                           |
+| `MessageDisplay`     | Repeatedly, as the reply streams                | None (always fires)                                            |
+| `Stop`               | When Claude prepares to conclude response       | None (always fires)                                            |
+| `SubagentStart`      | When subagent starts                            | Agent type (`Bash`, `Explorer`, `Plan`, etc.)                  |
+| `SubagentStop`       | When subagent stops                             | Agent type                                                     |
+| `PreCompact`         | Before conversation compaction                  | Trigger (`manual`, `auto`)                                     |
+| `Notification`       | When notifications are sent                     | Type (`permission_prompt`, `idle_prompt`, `auth_success`)      |
+| `PermissionRequest`  | When permission dialog is shown                 | Tool id                                                        |
+| `PermissionDenied`   | When tool permission is denied                  | Tool id                                                        |
+| `TodoCreated`        | When a new todo item is created                 | None (always fires)                                            |
+| `TodoCompleted`      | When a todo item is marked as completed         | None (always fires)                                            |
 
 ### Matcher Patterns
 
@@ -284,6 +285,7 @@ Hooks fire at specific points during a Qwen Code session. Different events suppo
 | Subagent Events     | `SubagentStart`, `SubagentStop`                                                            | ✅ Regex        | Agent type: `Bash`, `Explorer`, etc.                          |
 | Session Events      | `SessionStart`                                                                             | ✅ Regex        | Source: `startup`, `resume`, `clear`, `compact`               |
 | Session Events      | `SessionEnd`                                                                               | ✅ Regex        | Reason: `clear`, `logout`, `prompt_input_exit`, etc.          |
+| Session Events      | `SessionDelete`                                                                            | ❌ No           | N/A                                                           |
 | Notification Events | `Notification`                                                                             | ✅ Exact match  | Type: `permission_prompt`, `idle_prompt`, `auth_success`      |
 | Compact Events      | `PreCompact`                                                                               | ✅ Exact match  | Trigger: `manual`, `auto`                                     |
 | Todo Events         | `TodoCreated`, `TodoCompleted`                                                             | ❌ No           | N/A                                                           |
@@ -616,6 +618,20 @@ Sequential UserPromptSubmit hooks can append `additionalContext` to `prompt`; `s
 **Output Options**:
 
 - Standard hook output fields (typically not used for blocking)
+
+#### SessionDelete
+
+**Purpose**: Runs after an explicitly selected session has been permanently deleted. This event is fire-and-forget: output and failures cannot undo the deletion.
+
+**Event-specific fields**:
+
+```json
+{
+  "deleted_session_id": "the session that was deleted"
+}
+```
+
+The hook uses the deleting runtime's normal session fields (`session_id`, `transcript_path`, and `cwd`). `SessionDelete` currently fires for the interactive `/delete` flow and ACP's explicit `deleteSession` method; daemon REST batch deletion and internal cleanup do not emit it.
 
 #### MessageDisplay
 

--- a/packages/acp-bridge/src/status.ts
+++ b/packages/acp-bridge/src/status.ts
@@ -1011,6 +1011,9 @@ export const IDLE_HOOK_EVENTS: Record<HookEventName, ServeHookEventMeta> = {
     description: 'When a session is ending',
     matcherKind: 'sessionTrigger',
   },
+  SessionDelete: {
+    description: 'After an explicitly selected session is deleted',
+  },
   PermissionRequest: {
     description: 'When a permission dialog is displayed',
     matcherKind: 'toolName',

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -12206,6 +12206,37 @@ describe('QwenAgent extMethod renameSession routing', () => {
     await agentPromise;
   });
 
+  it('fires SessionDelete after an offline session is removed', async () => {
+    const innerConfig = makeLiveSessionInnerConfig(null);
+    const sessionDeleteHook = vi.fn().mockResolvedValue(undefined);
+    mockConfig.getHookSystem = vi.fn().mockReturnValue({
+      fireSessionDeleteEvent: sessionDeleteHook,
+    });
+    const { agent, agentPromise } = await bootAgent(innerConfig);
+
+    const removeSession = vi.fn().mockResolvedValue(true);
+    vi.mocked(SessionService).mockImplementation(
+      () =>
+        ({ removeSession }) as unknown as InstanceType<typeof SessionService>,
+    );
+
+    const deletedSessionId = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+    await expect(
+      agent.extMethod('deleteSession', {
+        cwd: '/tmp',
+        sessionId: deletedSessionId,
+      }),
+    ).resolves.toEqual({ success: true });
+
+    expect(removeSession).toHaveBeenCalledWith(deletedSessionId);
+    await vi.waitFor(() =>
+      expect(sessionDeleteHook).toHaveBeenCalledWith(deletedSessionId),
+    );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
   it('returns success=false when the live ChatRecordingService rejects the title (I/O error)', async () => {
     const recording = makeRecordingService();
     recording.recordCustomTitle.mockResolvedValue(false);

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -9694,6 +9694,16 @@ class QwenAgent implements Agent {
             return sessionService.removeSession(sessionId);
           },
         );
+        if (success) {
+          void this.config
+            .getHookSystem()
+            ?.fireSessionDeleteEvent(sessionId)
+            .catch((error) => {
+              debugLogger.warn(
+                `SessionDelete hook failed: ${error instanceof Error ? error.message : String(error)}`,
+              );
+            });
+        }
         return { success };
       }
       case 'renameSession': {

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -3154,6 +3154,53 @@ describe('loadCliConfig folderTrust', () => {
   });
 });
 
+describe('loadCliConfig allowPrivateNetworkHooks', () => {
+  const originalArgv = process.argv;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(os.homedir).mockReturnValue('/mock/home/user');
+    vi.stubEnv('GEMINI_API_KEY', 'test-api-key');
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('should be false by default', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments();
+    const config = await loadCliConfig({}, argv, undefined, []);
+    expect(config.getAllowPrivateNetworkHooks()).toBe(false);
+  });
+
+  it('should pass through security.allowPrivateNetworkHooks from settings', async () => {
+    process.argv = ['node', 'script.js'];
+    const settings: Settings = {
+      security: {
+        allowPrivateNetworkHooks: true,
+      },
+    };
+    const argv = await parseArguments();
+    const config = await loadCliConfig(settings, argv, undefined, []);
+    expect(config.getAllowPrivateNetworkHooks()).toBe(true);
+  });
+
+  it('should be false in bare mode even when enabled in settings', async () => {
+    process.argv = ['node', 'script.js', '--bare'];
+    const settings: Settings = {
+      security: {
+        allowPrivateNetworkHooks: true,
+      },
+    };
+    const argv = await parseArguments();
+    const config = await loadCliConfig(settings, argv, undefined, []);
+    expect(config.getAllowPrivateNetworkHooks()).toBe(false);
+  });
+});
+
 describe('loadCliConfig with includeDirectories', () => {
   const originalArgv = process.argv;
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -2229,6 +2229,10 @@ export async function loadCliConfig(
       bareMode || safeMode
         ? []
         : (settings.security?.allowedHttpHookUrls ?? []),
+    allowPrivateNetworkHooks:
+      bareMode || safeMode
+        ? false
+        : (settings.security?.allowPrivateNetworkHooks ?? false),
     cliVersion: await getCliVersion(),
     ideMode,
     chatCompression: settings.model?.chatCompression,

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -3247,6 +3247,91 @@ describe('Settings Loading and Merging', () => {
     });
   });
 
+  describe('allowPrivateNetworkHooks scope handling', () => {
+    it('should honor security.allowPrivateNetworkHooks from user scope', () => {
+      (mockFsExistsSync as Mock).mockReturnValue(true);
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify({
+              security: { allowPrivateNetworkHooks: true },
+            });
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+      expect(settings.merged.security?.allowPrivateNetworkHooks).toBe(true);
+    });
+
+    it('should strip security.allowPrivateNetworkHooks from workspace scope even when trusted', () => {
+      (mockFsExistsSync as Mock).mockReturnValue(true);
+      const workspaceSettingsContent = {
+        security: {
+          allowPrivateNetworkHooks: true,
+          allowedHttpHookUrls: ['https://hooks.example.com/*'],
+        },
+      };
+
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+            return JSON.stringify(workspaceSettingsContent);
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+      // The flag is ignored from workspace scope...
+      expect(
+        settings.merged.security?.allowPrivateNetworkHooks,
+      ).toBeUndefined();
+      // ...but other workspace security settings still merge.
+      expect(settings.merged.security?.allowedHttpHookUrls).toEqual([
+        'https://hooks.example.com/*',
+      ]);
+    });
+
+    it('should warn when workspace settings define security.allowPrivateNetworkHooks', () => {
+      (mockFsExistsSync as Mock).mockReturnValue(true);
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+            return JSON.stringify({
+              security: { allowPrivateNetworkHooks: true },
+            });
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+      const warnings = getSettingsWarnings(settings);
+      expect(
+        warnings.some((w) => w.includes('security.allowPrivateNetworkHooks')),
+      ).toBe(true);
+    });
+
+    it('should let user scope win over a stripped workspace value', () => {
+      (mockFsExistsSync as Mock).mockReturnValue(true);
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify({
+              security: { allowPrivateNetworkHooks: true },
+            });
+          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+            return JSON.stringify({
+              security: { allowPrivateNetworkHooks: false },
+            });
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+      expect(settings.merged.security?.allowPrivateNetworkHooks).toBe(true);
+    });
+  });
+
   describe('reloadScopeFromDisk', () => {
     it('reloads a scope from disk and resolves home env vars', () => {
       const homeQwenEnvPath = path.join(

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -367,7 +367,7 @@ export function getSettingsWarnings(loadedSettings: LoadedSettings): string[] {
       undefined
   ) {
     warningSet.add(
-      `Warning: security.allowPrivateNetworkHooks in workspace settings (${workspaceFile.path}) is ignored. This setting is only honored from User or System scope settings.`,
+      `Warning: security.allowPrivateNetworkHooks in workspace settings (${workspaceFile.path}) is ignored. This setting is only honored from User, System, or SystemDefaults scope settings.`,
     );
   }
 

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -358,6 +358,19 @@ export function getSettingsWarnings(loadedSettings: LoadedSettings): string[] {
     warningSet.add(warning);
   }
 
+  // security.allowPrivateNetworkHooks is stripped from Workspace scope during
+  // the merge; warn so the user knows their workspace setting has no effect.
+  const workspaceFile = loadedSettings.forScope(SettingScope.Workspace);
+  if (
+    workspaceFile.rawJson !== undefined &&
+    workspaceFile.originalSettings.security?.allowPrivateNetworkHooks !==
+      undefined
+  ) {
+    warningSet.add(
+      `Warning: security.allowPrivateNetworkHooks in workspace settings (${workspaceFile.path}) is ignored. This setting is only honored from User or System scope settings.`,
+    );
+  }
+
   return [...warningSet];
 }
 
@@ -385,6 +398,22 @@ function tagMcpServerScope(
   return { ...settings, mcpServers: tagged };
 }
 
+/**
+ * `security.allowPrivateNetworkHooks` relaxes SSRF protection for HTTP hooks,
+ * so it must never be honored from Workspace scope — otherwise a malicious
+ * repository could self-grant the bypass and point hooks at link-local or
+ * private infrastructure. Strip it from workspace settings before merging.
+ * Returns a shallow copy — never mutates input.
+ */
+function stripWorkspacePrivateNetworkHooks(settings: Settings): Settings {
+  if (settings.security?.allowPrivateNetworkHooks === undefined) {
+    return settings;
+  }
+  const { allowPrivateNetworkHooks: _stripped, ...restSecurity } =
+    settings.security;
+  return { ...settings, security: restSecurity };
+}
+
 function mergeSettings(
   system: Settings,
   systemDefaults: Settings,
@@ -393,7 +422,10 @@ function mergeSettings(
   isTrusted: boolean,
 ): Settings {
   const safeWorkspace = isTrusted
-    ? tagMcpServerScope(workspace, 'workspace')
+    ? tagMcpServerScope(
+        stripWorkspacePrivateNetworkHooks(workspace),
+        'workspace',
+      )
     : ({} as Settings);
 
   // Settings are merged with the following precedence (last one wins for

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -2854,6 +2854,16 @@ const SETTINGS_SCHEMA = {
           description: 'URL pattern (supports * wildcard)',
         },
       },
+      allowPrivateNetworkHooks: {
+        type: 'boolean',
+        label: 'Allow Private Network Hooks',
+        category: 'Security',
+        requiresRestart: false,
+        default: false,
+        description:
+          'When true, HTTP hooks may target private/link-local IP ranges (the SSRF IP-range checks are skipped). Cloud metadata hostnames (e.g. 169.254.169.254, metadata.google.internal) remain blocked. Only honored from User, System, and SystemDefaults settings scopes; values set in Workspace settings are ignored so a cloned repository cannot self-grant this bypass. Enable only in trusted, managed environments, and pair with security.allowedHttpHookUrls.',
+        showInDialog: false,
+      },
     },
   },
 

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -3287,6 +3287,18 @@ const SETTINGS_SCHEMA = {
         mergeStrategy: MergeStrategy.CONCAT,
         items: HOOK_DEFINITION_ITEMS,
       },
+      SessionDelete: {
+        type: 'array',
+        label: 'Session Delete Hooks',
+        category: 'Advanced',
+        requiresRestart: false,
+        default: [],
+        description:
+          'Hooks that execute after an explicitly selected session is deleted.',
+        showInDialog: false,
+        mergeStrategy: MergeStrategy.CONCAT,
+        items: HOOK_DEFINITION_ITEMS,
+      },
       PreCompact: {
         type: 'array',
         label: 'Pre Compact Hooks',

--- a/packages/cli/src/ui/components/hooks/constants.test.ts
+++ b/packages/cli/src/ui/components/hooks/constants.test.ts
@@ -93,6 +93,14 @@ describe('hooks constants', () => {
       expect(exitCodes).toHaveLength(2);
     });
 
+    it('should return fire-and-forget exit codes for SessionDelete event', () => {
+      const exitCodes = getHookExitCodes(HookEventName.SessionDelete);
+      expect(exitCodes).toHaveLength(2);
+      for (const row of exitCodes) {
+        expect(row.description).toContain('fire-and-forget');
+      }
+    });
+
     it('should return exit codes for PreCompact event', () => {
       const exitCodes = getHookExitCodes(HookEventName.PreCompact);
       expect(exitCodes).toHaveLength(3);
@@ -153,6 +161,12 @@ describe('hooks constants', () => {
       expect(desc).toBe('When a new session is started');
     });
 
+    it('should return description for SessionDelete', () => {
+      expect(getHookShortDescription(HookEventName.SessionDelete)).toBe(
+        'After a session is deleted',
+      );
+    });
+
     it('should return description for InstructionsLoaded', () => {
       const desc = getHookShortDescription(HookEventName.InstructionsLoaded);
       expect(desc).toBe('When instruction files are loaded');
@@ -161,6 +175,12 @@ describe('hooks constants', () => {
     it('should return description for PostCompact', () => {
       const desc = getHookShortDescription(HookEventName.PostCompact);
       expect(desc).toBe('After conversation compaction');
+    });
+
+    it('should describe the deleted session id for SessionDelete', () => {
+      expect(getHookDescription(HookEventName.SessionDelete)).toContain(
+        'deleted_session_id',
+      );
     });
 
     it('should return description for StopFailure', () => {
@@ -272,6 +292,7 @@ describe('hooks constants', () => {
       expect(DISPLAY_HOOK_EVENTS).toContain(HookEventName.UserPromptExpansion);
       expect(DISPLAY_HOOK_EVENTS).toContain(HookEventName.SessionStart);
       expect(DISPLAY_HOOK_EVENTS).toContain(HookEventName.SessionEnd);
+      expect(DISPLAY_HOOK_EVENTS).toContain(HookEventName.SessionDelete);
       expect(DISPLAY_HOOK_EVENTS).toContain(HookEventName.SubagentStart);
       expect(DISPLAY_HOOK_EVENTS).toContain(HookEventName.SubagentStop);
       expect(DISPLAY_HOOK_EVENTS).toContain(HookEventName.PreCompact);
@@ -313,6 +334,7 @@ describe('hooks constants', () => {
       expect(supportsMatchers(HookEventName.UserPromptSubmit)).toBe(false);
       expect(supportsMatchers(HookEventName.TodoCreated)).toBe(false);
       expect(supportsMatchers(HookEventName.TodoCompleted)).toBe(false);
+      expect(supportsMatchers(HookEventName.SessionDelete)).toBe(false);
     });
 
     it('returns false for unknown events', () => {

--- a/packages/cli/src/ui/components/hooks/constants.ts
+++ b/packages/cli/src/ui/components/hooks/constants.ts
@@ -97,6 +97,13 @@ export function getHookExitCodes(eventName: string): HookExitCode[] {
       { code: 0, description: t('command completes successfully') },
       { code: 'Other', description: t('show stderr to user only') },
     ],
+    [HookEventName.SessionDelete]: [
+      { code: 0, description: t('fire-and-forget; exit status is ignored') },
+      {
+        code: 'Other',
+        description: t('fire-and-forget; exit status is ignored'),
+      },
+    ],
     [HookEventName.SubagentStart]: [
       { code: 0, description: t('stdout shown to subagent') },
       {
@@ -197,6 +204,7 @@ export function getHookShortDescription(eventName: string): string {
       'When the turn ends due to an API error (fires instead of Stop)',
     ),
     [HookEventName.SessionEnd]: t('When a session is ending'),
+    [HookEventName.SessionDelete]: t('After a session is deleted'),
     [HookEventName.PermissionRequest]: t(
       'When a permission dialog is displayed',
     ),
@@ -247,6 +255,9 @@ export function getHookDescription(eventName: string): string {
     ),
     [HookEventName.SessionEnd]: t(
       'Input to command is JSON with session end reason.',
+    ),
+    [HookEventName.SessionDelete]: t(
+      'Input to command is JSON with deleted_session_id. It runs after an explicitly selected session is deleted; output and failures are ignored.',
     ),
     [HookEventName.SubagentStart]: t(
       'Input to command is JSON with agent_id and agent_type.',

--- a/packages/cli/src/ui/hooks/useDeleteCommand.test.ts
+++ b/packages/cli/src/ui/hooks/useDeleteCommand.test.ts
@@ -13,6 +13,7 @@ function createConfig(opts: {
   currentSessionId: string;
   removeSessions?: (ids: string[]) => Promise<RemoveSessionsResult>;
   removeSession?: (id: string) => Promise<boolean>;
+  fireSessionDeleteEvent?: (id: string) => Promise<unknown>;
 }) {
   const sessionService = {
     removeSession: opts.removeSession ?? vi.fn().mockResolvedValue(true),
@@ -20,12 +21,19 @@ function createConfig(opts: {
       opts.removeSessions ??
       vi.fn().mockResolvedValue({ removed: [], notFound: [], errors: [] }),
   };
+  const hookSystem = {
+    fireSessionDeleteEvent:
+      opts.fireSessionDeleteEvent ?? vi.fn().mockResolvedValue(undefined),
+  };
   return {
     config: {
       getSessionId: () => opts.currentSessionId,
       getSessionService: () => sessionService,
+      getHookSystem: () => hookSystem,
+      getDebugLogger: () => ({ warn: vi.fn() }),
     } as unknown as Config,
     sessionService,
+    hookSystem,
   };
 }
 
@@ -515,6 +523,67 @@ describe('useDeleteCommand', () => {
       ];
       expect(item.type).toBe('error');
       expect(item.text).toContain('raw failure');
+    });
+
+    it('fires once for each successfully deleted session', async () => {
+      const { config, hookSystem } = createConfig({
+        currentSessionId: 'current',
+        removeSessions: vi.fn().mockResolvedValue({
+          removed: ['a', 'b'],
+          notFound: ['missing'],
+          errors: [],
+        }),
+      });
+      const { result } = renderHook(() =>
+        useDeleteCommand({ config, addItem: vi.fn() }),
+      );
+
+      await act(async () => {
+        result.current.handleDeleteMany(['a', 'b', 'missing']);
+        await flushAsync();
+      });
+
+      expect(hookSystem.fireSessionDeleteEvent).toHaveBeenCalledTimes(2);
+      expect(hookSystem.fireSessionDeleteEvent).toHaveBeenNthCalledWith(1, 'a');
+      expect(hookSystem.fireSessionDeleteEvent).toHaveBeenNthCalledWith(2, 'b');
+    });
+  });
+
+  describe('handleDelete', () => {
+    it('fires after a successful deletion', async () => {
+      const { config, hookSystem } = createConfig({
+        currentSessionId: 'current',
+        removeSession: vi.fn().mockResolvedValue(true),
+      });
+      const { result } = renderHook(() =>
+        useDeleteCommand({ config, addItem: vi.fn() }),
+      );
+
+      await act(async () => {
+        result.current.handleDelete('deleted-id');
+        await flushAsync();
+      });
+
+      expect(hookSystem.fireSessionDeleteEvent).toHaveBeenCalledWith(
+        'deleted-id',
+      );
+    });
+
+    it('does not fire when the session was not removed', async () => {
+      const { config, hookSystem } = createConfig({
+        currentSessionId: 'current',
+        removeSession: vi.fn().mockResolvedValue(false),
+      });
+      const { result } = renderHook(() =>
+        useDeleteCommand({ config, addItem: vi.fn() }),
+      );
+
+      await act(async () => {
+        result.current.handleDelete('missing-id');
+        await flushAsync();
+      });
+
+      expect(hookSystem.fireSessionDeleteEvent).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/cli/src/ui/hooks/useDeleteCommand.ts
+++ b/packages/cli/src/ui/hooks/useDeleteCommand.ts
@@ -75,6 +75,14 @@ export function useDeleteCommand(
         const success = await sessionService.removeSession(sessionId);
 
         if (success) {
+          void config
+            .getHookSystem()
+            ?.fireSessionDeleteEvent(sessionId)
+            .catch((error) => {
+              config
+                .getDebugLogger()
+                .warn(`SessionDelete hook failed: ${String(error)}`);
+            });
           addItem?.(
             {
               type: 'info',
@@ -161,6 +169,17 @@ export function useDeleteCommand(
 
         const sessionService = config.getSessionService();
         const result = await sessionService.removeSessions(filtered);
+
+        for (const sessionId of result.removed) {
+          void config
+            .getHookSystem()
+            ?.fireSessionDeleteEvent(sessionId)
+            .catch((error) => {
+              config
+                .getDebugLogger()
+                .warn(`SessionDelete hook failed: ${String(error)}`);
+            });
+        }
 
         const removedCount = result.removed.length;
         const failedIds = [

--- a/packages/core/src/config/config.safe-mode.test.ts
+++ b/packages/core/src/config/config.safe-mode.test.ts
@@ -290,6 +290,15 @@ describe('Config safe mode', () => {
       });
       expect(config.getAllowedHttpHookUrls()).toEqual([]);
     });
+
+    it('disables private network hooks in safe mode', () => {
+      const config = new Config({
+        ...baseParams,
+        safeMode: true,
+        allowPrivateNetworkHooks: true,
+      });
+      expect(config.getAllowPrivateNetworkHooks()).toBe(false);
+    });
   });
 
   describe('safe mode blocks local/ambient MCP servers, preserves caller-supplied top-tier ones', () => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1302,6 +1302,11 @@ export interface ConfigParameters {
   /** Allowed HTTP hook URLs whitelist (from security.allowedHttpHookUrls) */
   allowedHttpHookUrls?: string[];
   /**
+   * When true, HTTP hooks may target private/link-local IP ranges
+   * (from security.allowPrivateNetworkHooks; trusted scopes only).
+   */
+  allowPrivateNetworkHooks?: boolean;
+  /**
    * Callback for persisting a permission rule to settings.
    * Injected by the CLI layer; core uses this to write allow/ask/deny rules
    * to project or user settings when the user clicks "Always Allow".
@@ -1919,6 +1924,7 @@ export class Config {
   private readonly safeMode: boolean;
   private readonly warnings: string[];
   private readonly allowedHttpHookUrls: string[];
+  private readonly allowPrivateNetworkHooks: boolean;
   private readonly onPersistPermissionRuleCallback?: (
     scope: 'project' | 'user',
     ruleType: 'allow' | 'ask' | 'deny',
@@ -2191,6 +2197,7 @@ export class Config {
     this.warnings = params.warnings ?? [];
     this.addLegacyPlanLocationWarning();
     this.allowedHttpHookUrls = params.allowedHttpHookUrls ?? [];
+    this.allowPrivateNetworkHooks = params.allowPrivateNetworkHooks ?? false;
     this.onPersistPermissionRuleCallback = params.onPersistPermissionRule;
 
     // (web search removed)
@@ -6598,6 +6605,16 @@ export class Config {
     return this.getBareMode() || this.isSafeMode()
       ? []
       : this.allowedHttpHookUrls;
+  }
+
+  /**
+   * Returns whether HTTP hooks may target private/link-local IP ranges.
+   * Only settable from trusted settings scopes (User/System/SystemDefaults).
+   */
+  getAllowPrivateNetworkHooks(): boolean {
+    return this.getBareMode() || this.isSafeMode()
+      ? false
+      : this.allowPrivateNetworkHooks;
   }
 
   isTrustedFolder(): boolean {

--- a/packages/core/src/goals/goalLoop.integration.test.ts
+++ b/packages/core/src/goals/goalLoop.integration.test.ts
@@ -70,6 +70,7 @@ function makeConfigWithRealHookSystem(): {
   // it pulls from Config during construction.
   const config = {
     getAllowedHttpHookUrls: () => [],
+    getAllowPrivateNetworkHooks: () => false,
     getSessionId: () => SESSION,
     isTrustedFolder: () => true,
     getDisableAllHooks: () => false,

--- a/packages/core/src/hooks/hookEventHandler.test.ts
+++ b/packages/core/src/hooks/hookEventHandler.test.ts
@@ -867,6 +867,39 @@ describe('HookEventHandler', () => {
     });
   });
 
+  describe('fireSessionDeleteEvent', () => {
+    it('should execute hooks with the deleted session id', async () => {
+      const mockPlan = createMockExecutionPlan([
+        {
+          type: HookType.Command,
+          command: 'echo test',
+          source: HooksConfigSource.Project,
+        },
+      ]);
+      vi.mocked(mockHookPlanner.createExecutionPlan).mockReturnValue(mockPlan);
+      vi.mocked(mockHookRunner.executeHooksParallel).mockResolvedValue([]);
+      vi.mocked(mockHookAggregator.aggregateResults).mockReturnValue(
+        createMockAggregatedResult(true),
+      );
+
+      const result =
+        await hookEventHandler.fireSessionDeleteEvent('deleted-session-id');
+
+      expect(mockHookPlanner.createExecutionPlan).toHaveBeenCalledWith(
+        HookEventName.SessionDelete,
+        undefined,
+      );
+      const input = (mockHookRunner.executeHooksParallel as Mock).mock
+        .calls[0][2] as {
+        hook_event_name: HookEventName;
+        deleted_session_id: string;
+      };
+      expect(input.hook_event_name).toBe(HookEventName.SessionDelete);
+      expect(input.deleted_session_id).toBe('deleted-session-id');
+      expect(result.success).toBe(true);
+    });
+  });
+
   describe('session hook matcher targets', () => {
     it('matches SessionStart session hooks against the session source', async () => {
       const sessionHook = createSessionHookEntry(

--- a/packages/core/src/hooks/hookEventHandler.ts
+++ b/packages/core/src/hooks/hookEventHandler.ts
@@ -22,6 +22,7 @@ import type {
   ContextUsageData,
   SessionStartInput,
   SessionEndInput,
+  SessionDeleteInput,
   SessionStartSource,
   SessionEndReason,
   AgentType,
@@ -334,6 +335,26 @@ export class HookEventHandler {
       {
         trigger: reason,
       },
+      signal,
+    );
+  }
+
+  /**
+   * Fire a SessionDelete event after an explicitly selected session is deleted.
+   */
+  async fireSessionDeleteEvent(
+    deletedSessionId: string,
+    signal?: AbortSignal,
+  ): Promise<AggregatedHookResult> {
+    const input: SessionDeleteInput = {
+      ...this.createBaseInput(HookEventName.SessionDelete),
+      deleted_session_id: deletedSessionId,
+    };
+
+    return this.executeHooks(
+      HookEventName.SessionDelete,
+      input,
+      undefined,
       signal,
     );
   }

--- a/packages/core/src/hooks/hookPlanner.test.ts
+++ b/packages/core/src/hooks/hookPlanner.test.ts
@@ -111,6 +111,7 @@ describe('HookPlanner', () => {
         undefined,
       );
       expect(getHookMatcherTarget(HookEventName.PostToolBatch)).toBe(undefined);
+      expect(getHookMatcherTarget(HookEventName.SessionDelete)).toBe(undefined);
       expect(getHookMatcherTarget(HookEventName.MessageDisplay)).toBe(
         undefined,
       );

--- a/packages/core/src/hooks/hookPlanner.ts
+++ b/packages/core/src/hooks/hookPlanner.ts
@@ -76,6 +76,7 @@ export function getHookMatcherTarget(
     case HookEventName.Stop:
     case HookEventName.MessageDisplay:
     case HookEventName.PostToolBatch:
+    case HookEventName.SessionDelete:
     case HookEventName.TodoCreated:
     case HookEventName.TodoCompleted:
       return undefined;

--- a/packages/core/src/hooks/hookRunner.ts
+++ b/packages/core/src/hooks/hookRunner.ts
@@ -62,7 +62,10 @@ export class HookRunner {
   private readonly asyncRegistry: AsyncHookRegistry;
 
   constructor(allowedHttpUrls?: string[], config?: Config) {
-    this.httpRunner = new HttpHookRunner(allowedHttpUrls);
+    this.httpRunner = new HttpHookRunner(
+      allowedHttpUrls,
+      config?.getAllowPrivateNetworkHooks(),
+    );
     this.functionRunner = new FunctionHookRunner();
     this.promptRunner = config ? new PromptHookRunner(config) : null;
     this.asyncRegistry = new AsyncHookRegistry();

--- a/packages/core/src/hooks/hookSystem.test.ts
+++ b/packages/core/src/hooks/hookSystem.test.ts
@@ -95,6 +95,7 @@ describe('HookSystem', () => {
       fireMessageDisplayEvent: vi.fn(),
       fireSessionStartEvent: vi.fn(),
       fireSessionEndEvent: vi.fn(),
+      fireSessionDeleteEvent: vi.fn(),
       firePreToolUseEvent: vi.fn(),
       firePostToolUseEvent: vi.fn(),
       firePostToolUseFailureEvent: vi.fn(),
@@ -262,6 +263,16 @@ describe('HookSystem', () => {
 
       expect(mockHookRegistry.getHooksForEvent).toHaveBeenCalledWith(
         'SessionEnd',
+      );
+    });
+
+    it('should check the correct event name for SessionDelete', () => {
+      vi.mocked(mockHookRegistry.getHooksForEvent).mockReturnValue([]);
+
+      hookSystem.hasHooksForEvent('SessionDelete');
+
+      expect(mockHookRegistry.getHooksForEvent).toHaveBeenCalledWith(
+        'SessionDelete',
       );
     });
 
@@ -843,6 +854,25 @@ describe('HookSystem', () => {
       );
 
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe('fireSessionDeleteEvent', () => {
+    it('should fire the event with the deleted session id', async () => {
+      const mockResult = createMockAggregatedResult(true, {
+        decision: 'allow',
+      });
+      vi.mocked(mockHookEventHandler.fireSessionDeleteEvent).mockResolvedValue(
+        mockResult,
+      );
+
+      const result = await hookSystem.fireSessionDeleteEvent('deleted-id');
+
+      expect(mockHookEventHandler.fireSessionDeleteEvent).toHaveBeenCalledWith(
+        'deleted-id',
+        undefined,
+      );
+      expect(result).toBeDefined();
     });
   });
 

--- a/packages/core/src/hooks/hookSystem.test.ts
+++ b/packages/core/src/hooks/hookSystem.test.ts
@@ -63,6 +63,7 @@ describe('HookSystem', () => {
       getTranscriptPath: vi.fn().mockReturnValue('/test/transcript'),
       getWorkingDir: vi.fn().mockReturnValue('/test/cwd'),
       getAllowedHttpHookUrls: vi.fn().mockReturnValue([]),
+      getAllowPrivateNetworkHooks: vi.fn().mockReturnValue(false),
     } as unknown as Config;
 
     mockHookRegistry = {

--- a/packages/core/src/hooks/hookSystem.ts
+++ b/packages/core/src/hooks/hookSystem.ts
@@ -271,6 +271,19 @@ export class HookSystem {
       : undefined;
   }
 
+  async fireSessionDeleteEvent(
+    deletedSessionId: string,
+    signal?: AbortSignal,
+  ): Promise<DefaultHookOutput | undefined> {
+    const result = await this.hookEventHandler.fireSessionDeleteEvent(
+      deletedSessionId,
+      signal,
+    );
+    return result.finalOutput
+      ? createHookOutput('SessionDelete', result.finalOutput)
+      : undefined;
+  }
+
   /**
    * Fire a PreToolUse event - called before tool execution
    */

--- a/packages/core/src/hooks/httpHookRunner.test.ts
+++ b/packages/core/src/hooks/httpHookRunner.test.ts
@@ -13,6 +13,15 @@ import { HttpHookRunner } from './httpHookRunner.js';
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
+// Mutable DNS resolution result so individual tests can control what
+// hostnames resolve to.
+const mockDns = vi.hoisted(() => ({
+  addresses: [{ address: '8.8.8.8', family: 4 }] as Array<{
+    address: string;
+    family: number;
+  }>,
+}));
+
 // Mock dns.lookup to avoid real DNS lookups in tests
 vi.mock('dns', () => ({
   lookup: (
@@ -23,8 +32,7 @@ vi.mock('dns', () => ({
       addresses: Array<{ address: string; family: number }>,
     ) => void,
   ) => {
-    // Return a mock public IP address
-    callback(null, [{ address: '8.8.8.8', family: 4 }]);
+    callback(null, mockDns.addresses);
   },
 }));
 
@@ -40,6 +48,7 @@ describe('HttpHookRunner', () => {
     httpRunner = new HttpHookRunner([ALLOWED_URL_PATTERN]);
     vi.clearAllMocks();
     process.env = { ...originalEnv };
+    mockDns.addresses = [{ address: '8.8.8.8', family: 4 }];
   });
 
   afterEach(() => {
@@ -266,6 +275,122 @@ describe('HttpHookRunner', () => {
 
       expect(result.success).toBe(false);
       expect(result.error?.message).toContain('cancelled');
+    });
+  });
+
+  describe('allowPrivateNetworkHooks', () => {
+    const mockSuccessResponse = () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({ continue: true }),
+      });
+    };
+
+    it('should block a literal private IP when the flag is off', async () => {
+      const runner = new HttpHookRunner([], false);
+      const config = createMockConfig({ url: 'http://172.16.254.215/hook' });
+      const input = createMockInput();
+
+      const result = await runner.execute(
+        config,
+        HookEventName.PreToolUse,
+        input,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error?.message).toContain('blocked');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should block a hostname resolving to a private IP when the flag is off', async () => {
+      mockDns.addresses = [{ address: '172.16.254.215', family: 4 }];
+      const runner = new HttpHookRunner([], false);
+      const config = createMockConfig({
+        url: 'http://hooks.internal.example.com/hook',
+      });
+      const input = createMockInput();
+
+      const result = await runner.execute(
+        config,
+        HookEventName.PreToolUse,
+        input,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error?.message).toContain('private/link-local');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should allow a literal private IP when the flag is on', async () => {
+      mockSuccessResponse();
+      const runner = new HttpHookRunner([], true);
+      const config = createMockConfig({ url: 'http://172.16.254.215/hook' });
+      const input = createMockInput();
+
+      const result = await runner.execute(
+        config,
+        HookEventName.PreToolUse,
+        input,
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockFetch).toHaveBeenCalled();
+    });
+
+    it('should allow a hostname resolving to a private IP when the flag is on', async () => {
+      mockDns.addresses = [{ address: '172.16.254.215', family: 4 }];
+      mockSuccessResponse();
+      const runner = new HttpHookRunner([], true);
+      const config = createMockConfig({
+        url: 'http://hooks.internal.example.com/hook',
+      });
+      const input = createMockInput();
+
+      const result = await runner.execute(
+        config,
+        HookEventName.PreToolUse,
+        input,
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockFetch).toHaveBeenCalled();
+    });
+
+    it('should still block cloud metadata endpoints when the flag is on', async () => {
+      const runner = new HttpHookRunner([], true);
+      const config = createMockConfig({
+        url: 'http://169.254.169.254/latest/meta-data',
+      });
+      const input = createMockInput();
+
+      const result = await runner.execute(
+        config,
+        HookEventName.PreToolUse,
+        input,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error?.message).toContain('blocked');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should still block metadata hostnames when the flag is on', async () => {
+      const runner = new HttpHookRunner([], true);
+      const config = createMockConfig({
+        url: 'http://metadata.google.internal/hook',
+      });
+      const input = createMockInput();
+
+      const result = await runner.execute(
+        config,
+        HookEventName.PreToolUse,
+        input,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error?.message).toContain('blocked');
+      expect(mockFetch).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/hooks/httpHookRunner.test.ts
+++ b/packages/core/src/hooks/httpHookRunner.test.ts
@@ -392,6 +392,80 @@ describe('HttpHookRunner', () => {
       expect(result.error?.message).toContain('blocked');
       expect(mockFetch).not.toHaveBeenCalled();
     });
+
+    it('should still block the Alibaba metadata IP when the flag is on', async () => {
+      const runner = new HttpHookRunner([], true);
+      const config = createMockConfig({
+        url: 'http://100.100.100.200/latest/meta-data',
+      });
+      const input = createMockInput();
+
+      const result = await runner.execute(
+        config,
+        HookEventName.PreToolUse,
+        input,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error?.message).toContain('blocked');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should still block IPv6-mapped metadata IPs when the flag is on', async () => {
+      const runner = new HttpHookRunner([], true);
+      const config = createMockConfig({
+        url: 'http://[::ffff:a9fe:a9fe]/latest/meta-data',
+      });
+      const input = createMockInput();
+
+      const result = await runner.execute(
+        config,
+        HookEventName.PreToolUse,
+        input,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error?.message).toContain('blocked');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should block a hostname resolving to a metadata IP when the flag is on', async () => {
+      mockDns.addresses = [{ address: '169.254.169.254', family: 4 }];
+      const runner = new HttpHookRunner([], true);
+      const config = createMockConfig({
+        url: 'http://hooks.internal.example.com/hook',
+      });
+      const input = createMockInput();
+
+      const result = await runner.execute(
+        config,
+        HookEventName.PreToolUse,
+        input,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error?.message).toContain('metadata');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should block a hostname resolving to the Alibaba metadata IP when the flag is on', async () => {
+      mockDns.addresses = [{ address: '100.100.100.200', family: 4 }];
+      const runner = new HttpHookRunner([], true);
+      const config = createMockConfig({
+        url: 'http://hooks.internal.example.com/hook',
+      });
+      const input = createMockInput();
+
+      const result = await runner.execute(
+        config,
+        HookEventName.PreToolUse,
+        input,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error?.message).toContain('metadata');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
   });
 
   describe('resetOnceHooks', () => {

--- a/packages/core/src/hooks/httpHookRunner.ts
+++ b/packages/core/src/hooks/httpHookRunner.ts
@@ -8,7 +8,7 @@ import { createDebugLogger } from '../utils/debugLogger.js';
 import { interpolateHeaders, interpolateUrl } from './envInterpolator.js';
 import { UrlValidator } from './urlValidator.js';
 import { combineAbortSignals } from '../utils/abortController.js';
-import { isBlockedAddress } from './ssrfGuard.js';
+import { isBlockedAddress, isMetadataAddress } from './ssrfGuard.js';
 import { lookup as dnsLookup } from 'dns';
 import type {
   HttpHookConfig,
@@ -47,14 +47,19 @@ async function validateResolvedHost(
   hostname: string,
   allowPrivateNetworkHosts: boolean = false,
 ): Promise<{ ok: boolean; error?: string }> {
-  // Trusted-scope opt-in: skip the IP-range checks entirely. The URL-level
-  // BLOCKED_HOSTS metadata blocklist in UrlValidator still applies.
-  if (allowPrivateNetworkHosts) {
-    return { ok: true };
-  }
   return new Promise((resolve) => {
+    // Cloud metadata endpoints stay blocked in every configuration, even
+    // when private-network hooks are explicitly allowed (trusted scopes).
+    if (isMetadataAddress(hostname)) {
+      resolve({
+        ok: false,
+        error: `HTTP hook blocked: ${hostname} is a cloud metadata endpoint`,
+      });
+      return;
+    }
+
     // If hostname is already an IP literal, validate directly.
-    if (isBlockedAddress(hostname)) {
+    if (!allowPrivateNetworkHosts && isBlockedAddress(hostname)) {
       resolve({
         ok: false,
         error: `HTTP hook blocked: ${hostname} is in a private/link-local range`,
@@ -62,7 +67,9 @@ async function validateResolvedHost(
       return;
     }
 
-    // For hostnames, resolve DNS and validate all returned IPs.
+    // For hostnames, resolve DNS and validate all returned IPs. This runs
+    // even when private ranges are allowed, so that a hostname resolving
+    // to a metadata endpoint is still caught.
     dnsLookup(hostname, { all: true }, (err, addresses) => {
       if (err) {
         // DNS resolution failure — let the fetch call handle it.
@@ -71,7 +78,14 @@ async function validateResolvedHost(
       }
 
       for (const addr of addresses) {
-        if (isBlockedAddress(addr.address)) {
+        if (isMetadataAddress(addr.address)) {
+          resolve({
+            ok: false,
+            error: `HTTP hook blocked: ${hostname} resolves to ${addr.address} (cloud metadata endpoint)`,
+          });
+          return;
+        }
+        if (!allowPrivateNetworkHosts && isBlockedAddress(addr.address)) {
           resolve({
             ok: false,
             error: `HTTP hook blocked: ${hostname} resolves to ${addr.address} (private/link-local). Loopback (127.0.0.1, ::1) is allowed.`,

--- a/packages/core/src/hooks/httpHookRunner.ts
+++ b/packages/core/src/hooks/httpHookRunner.ts
@@ -45,7 +45,13 @@ export type StatusMessageCallback = (message: string) => void;
  */
 async function validateResolvedHost(
   hostname: string,
+  allowPrivateNetworkHosts: boolean = false,
 ): Promise<{ ok: boolean; error?: string }> {
+  // Trusted-scope opt-in: skip the IP-range checks entirely. The URL-level
+  // BLOCKED_HOSTS metadata blocklist in UrlValidator still applies.
+  if (allowPrivateNetworkHosts) {
+    return { ok: true };
+  }
   return new Promise((resolve) => {
     // If hostname is already an IP literal, validate directly.
     if (isBlockedAddress(hostname)) {
@@ -84,11 +90,16 @@ async function validateResolvedHost(
  */
 export class HttpHookRunner {
   private urlValidator: UrlValidator;
+  private readonly allowPrivateNetworkHosts: boolean;
   private readonly executedOnceHooks: Set<string> = new Set();
   private statusMessageCallback?: StatusMessageCallback;
 
-  constructor(allowedUrls?: string[]) {
-    this.urlValidator = new UrlValidator(allowedUrls);
+  constructor(
+    allowedUrls?: string[],
+    allowPrivateNetworkHosts: boolean = false,
+  ) {
+    this.allowPrivateNetworkHosts = allowPrivateNetworkHosts;
+    this.urlValidator = new UrlValidator(allowedUrls, allowPrivateNetworkHosts);
   }
 
   /**
@@ -170,7 +181,10 @@ export class HttpHookRunner {
       // DNS-level SSRF protection: validate resolved IPs
       // It checks that the hostname resolves to non-private IPs.
       const parsed = new URL(url);
-      const hostValidation = await validateResolvedHost(parsed.hostname);
+      const hostValidation = await validateResolvedHost(
+        parsed.hostname,
+        this.allowPrivateNetworkHosts,
+      );
       if (!hostValidation.ok) {
         return {
           hookConfig,
@@ -421,6 +435,9 @@ export class HttpHookRunner {
    */
   updateAllowedUrls(allowedUrls: string[]): void {
     // Create new validator with updated patterns
-    this.urlValidator = new UrlValidator(allowedUrls);
+    this.urlValidator = new UrlValidator(
+      allowedUrls,
+      this.allowPrivateNetworkHosts,
+    );
   }
 }

--- a/packages/core/src/hooks/promptHookIntegration.test.ts
+++ b/packages/core/src/hooks/promptHookIntegration.test.ts
@@ -54,6 +54,7 @@ describe('Prompt Hook Integration', () => {
       }),
       getProjectRoot: vi.fn().mockReturnValue('/test/project'),
       getAllowedHttpHookUrls: vi.fn().mockReturnValue([]),
+      getAllowPrivateNetworkHooks: vi.fn().mockReturnValue(false),
       getHooks: vi.fn().mockReturnValue({}),
     } as unknown as Config;
 

--- a/packages/core/src/hooks/ssrfGuard.test.ts
+++ b/packages/core/src/hooks/ssrfGuard.test.ts
@@ -5,7 +5,11 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { isBlockedAddress, ssrfGuardedLookup } from './ssrfGuard.js';
+import {
+  isBlockedAddress,
+  isMetadataAddress,
+  ssrfGuardedLookup,
+} from './ssrfGuard.js';
 
 function lookupAsync(
   hostname: string,
@@ -106,6 +110,46 @@ describe('ssrfGuard', () => {
     it('should return false for non-IP hostnames', () => {
       expect(isBlockedAddress('api.example.com')).toBe(false);
       expect(isBlockedAddress('localhost')).toBe(false);
+    });
+  });
+
+  describe('isMetadataAddress', () => {
+    it('should match the AWS/GCP/Azure metadata IP', () => {
+      expect(isMetadataAddress('169.254.169.254')).toBe(true);
+    });
+
+    it('should match the Alibaba Cloud metadata IP', () => {
+      expect(isMetadataAddress('100.100.100.200')).toBe(true);
+    });
+
+    it('should match IPv4-mapped IPv6 forms of metadata IPs', () => {
+      // ::ffff:a9fe:a9fe = 169.254.169.254
+      expect(isMetadataAddress('::ffff:a9fe:a9fe')).toBe(true);
+      expect(isMetadataAddress('::ffff:169.254.169.254')).toBe(true);
+      expect(isMetadataAddress('0:0:0:0:0:ffff:a9fe:a9fe')).toBe(true);
+      // ::ffff:6464:64c8 = 100.100.100.200
+      expect(isMetadataAddress('::ffff:6464:64c8')).toBe(true);
+      expect(isMetadataAddress('::ffff:100.100.100.200')).toBe(true);
+    });
+
+    it('should not match other private/link-local addresses', () => {
+      expect(isMetadataAddress('169.254.169.253')).toBe(false);
+      expect(isMetadataAddress('100.100.100.201')).toBe(false);
+      expect(isMetadataAddress('10.0.0.1')).toBe(false);
+      expect(isMetadataAddress('172.16.0.1')).toBe(false);
+      expect(isMetadataAddress('192.168.1.1')).toBe(false);
+      expect(isMetadataAddress('::ffff:c0a8:101')).toBe(false);
+    });
+
+    it('should not match loopback or public addresses', () => {
+      expect(isMetadataAddress('127.0.0.1')).toBe(false);
+      expect(isMetadataAddress('::1')).toBe(false);
+      expect(isMetadataAddress('8.8.8.8')).toBe(false);
+    });
+
+    it('should return false for non-IP hostnames', () => {
+      expect(isMetadataAddress('metadata.google.internal')).toBe(false);
+      expect(isMetadataAddress('api.example.com')).toBe(false);
     });
   });
 

--- a/packages/core/src/hooks/ssrfGuard.ts
+++ b/packages/core/src/hooks/ssrfGuard.ts
@@ -60,6 +60,34 @@ export function isBlockedAddress(address: string): boolean {
   return false;
 }
 
+/**
+ * Cloud metadata endpoint IPs that must remain blocked in EVERY
+ * configuration — including when `security.allowPrivateNetworkHooks`
+ * relaxes the general private/CGNAT range checks.
+ *   169.254.169.254  AWS / GCP / Azure / most clouds
+ *   100.100.100.200  Alibaba Cloud (lives inside the CGNAT range)
+ */
+const METADATA_IPS = new Set(['169.254.169.254', '100.100.100.200']);
+
+/**
+ * Returns true if the address is a cloud metadata endpoint IP, in any
+ * serialized form — plain IPv4, or IPv4-mapped IPv6 such as
+ * `::ffff:169.254.169.254` / `::ffff:a9fe:a9fe`. Unlike
+ * `isBlockedAddress`, this check is never relaxed by opt-in settings.
+ */
+export function isMetadataAddress(address: string): boolean {
+  const v = isIP(address);
+  if (v === 4) {
+    return METADATA_IPS.has(address);
+  }
+  if (v === 6) {
+    const mappedV4 = extractMappedIPv4(address.toLowerCase());
+    return mappedV4 !== null && METADATA_IPS.has(mappedV4);
+  }
+  // Not a valid IP literal
+  return false;
+}
+
 function isBlockedV4(address: string): boolean {
   const parts = address.split('.').map(Number);
   const [a, b] = parts;

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -52,6 +52,8 @@ export enum HookEventName {
   PostCompact = 'PostCompact',
   // SessionEnd - When a session is ending
   SessionEnd = 'SessionEnd',
+  // SessionDelete - After an explicitly selected session is deleted
+  SessionDelete = 'SessionDelete',
   // When a permission dialog is displayed
   PermissionRequest = 'PermissionRequest',
   // When a tool call is denied before a permission dialog is displayed
@@ -1066,6 +1068,13 @@ export interface SessionEndOutput extends HookOutput {
     hookEventName: 'SessionEnd';
     additionalContext?: string;
   };
+}
+
+/**
+ * SessionDelete hook input
+ */
+export interface SessionDeleteInput extends HookInput {
+  deleted_session_id: string;
 }
 
 /**

--- a/packages/core/src/hooks/urlValidator.test.ts
+++ b/packages/core/src/hooks/urlValidator.test.ts
@@ -81,6 +81,37 @@ describe('UrlValidator', () => {
           ),
         ).toBe(true);
       });
+
+      it('should still block the Alibaba Cloud metadata IP (CGNAT range)', () => {
+        const validator = new UrlValidator([], true);
+        expect(
+          validator.isBlocked('http://100.100.100.200/latest/meta-data'),
+        ).toBe(true);
+      });
+
+      it('should still block IPv4-mapped IPv6 forms of metadata IPs', () => {
+        const validator = new UrlValidator([], true);
+        // ::ffff:169.254.169.254 (mixed dotted form)
+        expect(
+          validator.isBlocked(
+            'http://[::ffff:169.254.169.254]/latest/meta-data',
+          ),
+        ).toBe(true);
+        // ::ffff:a9fe:a9fe = 169.254.169.254
+        expect(
+          validator.isBlocked('http://[::ffff:a9fe:a9fe]/latest/meta-data'),
+        ).toBe(true);
+        // ::ffff:6464:64c8 = 100.100.100.200
+        expect(
+          validator.isBlocked('http://[::ffff:6464:64c8]/latest/meta-data'),
+        ).toBe(true);
+      });
+
+      it('should allow IPv4-mapped IPv6 forms of ordinary private IPs', () => {
+        const validator = new UrlValidator([], true);
+        // ::ffff:ac10:1 = 172.16.0.1 — private, but not a metadata endpoint
+        expect(validator.isBlocked('http://[::ffff:ac10:1]/api')).toBe(false);
+      });
     });
   });
 

--- a/packages/core/src/hooks/urlValidator.test.ts
+++ b/packages/core/src/hooks/urlValidator.test.ts
@@ -61,6 +61,27 @@ describe('UrlValidator', () => {
       expect(validator.isBlocked('not-a-url')).toBe(true);
       expect(validator.isBlocked('')).toBe(true);
     });
+
+    describe('with allowPrivateNetworkHosts', () => {
+      it('should allow private IP ranges', () => {
+        const validator = new UrlValidator([], true);
+        expect(validator.isBlocked('http://192.168.1.1/api')).toBe(false);
+        expect(validator.isBlocked('http://10.0.0.1/api')).toBe(false);
+        expect(validator.isBlocked('http://172.16.0.1/api')).toBe(false);
+      });
+
+      it('should still block cloud metadata endpoints', () => {
+        const validator = new UrlValidator([], true);
+        expect(
+          validator.isBlocked('http://169.254.169.254/latest/meta-data'),
+        ).toBe(true);
+        expect(
+          validator.isBlocked(
+            'http://metadata.google.internal/computeMetadata',
+          ),
+        ).toBe(true);
+      });
+    });
   });
 
   describe('isAllowed', () => {

--- a/packages/core/src/hooks/urlValidator.ts
+++ b/packages/core/src/hooks/urlValidator.ts
@@ -5,7 +5,7 @@
  */
 
 import { isIPv4, isIPv6 } from 'net';
-import { isBlockedAddress } from './ssrfGuard.js';
+import { isBlockedAddress, isMetadataAddress } from './ssrfGuard.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 
 const debugLogger = createDebugLogger('URL_VALIDATOR');
@@ -38,8 +38,8 @@ export class UrlValidator {
    * Create a new URL validator
    * @param allowedPatterns - Array of allowed URL patterns (supports * wildcard)
    * @param allowPrivateNetworkHosts - When true, skip the private/link-local
-   *   IP-range check (the BLOCKED_HOSTS metadata blocklist still applies).
-   *   Only enable from trusted settings scopes.
+   *   IP-range check (the metadata endpoint checks — BLOCKED_HOSTS and the
+   *   metadata IPs — still apply). Only enable from trusted settings scopes.
    */
   constructor(
     allowedPatterns: string[] = [],
@@ -105,13 +105,25 @@ export class UrlValidator {
         return true;
       }
 
-      // Check if hostname is an IP address - use ssrfGuard for authoritative check
-      // Skipped when private-network hooks are explicitly allowed (trusted
-      // scopes only); the BLOCKED_HOSTS check above always applies.
-      if (!this.allowPrivateNetworkHosts && this.isIpAddress(hostname)) {
-        // Remove brackets from IPv6 addresses for isBlockedAddress
+      // Check if hostname is an IP address
+      if (this.isIpAddress(hostname)) {
+        // Remove brackets from IPv6 addresses for the IP checks
         const cleanHostname = hostname.replace(/^\[|\]$/g, '');
-        if (isBlockedAddress(cleanHostname)) {
+
+        // Cloud metadata endpoints (169.254.169.254, 100.100.100.200, in
+        // any serialized form including IPv4-mapped IPv6) stay blocked in
+        // every configuration — this check is never relaxed.
+        if (isMetadataAddress(cleanHostname)) {
+          debugLogger.debug(
+            `URL blocked: IP ${hostname} is a cloud metadata endpoint`,
+          );
+          return true;
+        }
+
+        // General private/link-local range check - use ssrfGuard for the
+        // authoritative implementation. Skipped when private-network hooks
+        // are explicitly allowed (trusted scopes only).
+        if (!this.allowPrivateNetworkHosts && isBlockedAddress(cleanHostname)) {
           debugLogger.debug(`URL blocked: IP ${hostname} is blocked`);
           return true;
         }

--- a/packages/core/src/hooks/urlValidator.ts
+++ b/packages/core/src/hooks/urlValidator.ts
@@ -32,13 +32,21 @@ const BLOCKED_HOSTS = [
 export class UrlValidator {
   private readonly allowedPatterns: string[];
   private readonly compiledPatterns: RegExp[];
+  private readonly allowPrivateNetworkHosts: boolean;
 
   /**
    * Create a new URL validator
    * @param allowedPatterns - Array of allowed URL patterns (supports * wildcard)
+   * @param allowPrivateNetworkHosts - When true, skip the private/link-local
+   *   IP-range check (the BLOCKED_HOSTS metadata blocklist still applies).
+   *   Only enable from trusted settings scopes.
    */
-  constructor(allowedPatterns: string[] = []) {
+  constructor(
+    allowedPatterns: string[] = [],
+    allowPrivateNetworkHosts: boolean = false,
+  ) {
     this.allowedPatterns = allowedPatterns;
+    this.allowPrivateNetworkHosts = allowPrivateNetworkHosts;
     this.compiledPatterns = allowedPatterns.map((pattern) =>
       this.compilePattern(pattern),
     );
@@ -98,7 +106,9 @@ export class UrlValidator {
       }
 
       // Check if hostname is an IP address - use ssrfGuard for authoritative check
-      if (this.isIpAddress(hostname)) {
+      // Skipped when private-network hooks are explicitly allowed (trusted
+      // scopes only); the BLOCKED_HOSTS check above always applies.
+      if (!this.allowPrivateNetworkHosts && this.isIpAddress(hostname)) {
         // Remove brackets from IPv6 addresses for isBlockedAddress
         const cleanHostname = hostname.replace(/^\[|\]$/g, '');
         if (isBlockedAddress(cleanHostname)) {
@@ -157,6 +167,9 @@ export class UrlValidator {
  * @param allowedUrls - Array of allowed URL patterns from config
  * @returns Configured URL validator
  */
-export function createUrlValidator(allowedUrls?: string[]): UrlValidator {
-  return new UrlValidator(allowedUrls || []);
+export function createUrlValidator(
+  allowedUrls?: string[],
+  allowPrivateNetworkHosts?: boolean,
+): UrlValidator {
+  return new UrlValidator(allowedUrls || [], allowPrivateNetworkHosts);
 }

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -1331,6 +1331,11 @@
             "description": "URL pattern (supports * wildcard)",
             "type": "string"
           }
+        },
+        "allowPrivateNetworkHooks": {
+          "description": "When true, HTTP hooks may target private/link-local IP ranges (the SSRF IP-range checks are skipped). Cloud metadata hostnames (e.g. 169.254.169.254, metadata.google.internal) remain blocked. Only honored from User, System, and SystemDefaults settings scopes; values set in Workspace settings are ignored so a cloned repository cannot self-grant this bypass. Enable only in trusted, managed environments, and pair with security.allowedHttpHookUrls.",
+          "type": "boolean",
+          "default": false
         }
       }
     },

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -2711,6 +2711,109 @@
             ]
           }
         },
+        "SessionDelete": {
+          "description": "Hooks that execute after an explicitly selected session is deleted.",
+          "type": "array",
+          "items": {
+            "description": "A hook definition with an optional matcher and a list of hook configurations.",
+            "type": "object",
+            "properties": {
+              "matcher": {
+                "description": "An optional matcher pattern to filter when this hook definition applies.",
+                "type": "string"
+              },
+              "sequential": {
+                "description": "Whether the hooks should be executed sequentially instead of in parallel.",
+                "type": "boolean"
+              },
+              "hooks": {
+                "description": "The list of hook configurations to execute.",
+                "type": "array",
+                "items": {
+                  "description": "A hook configuration entry that defines a hook to execute.",
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "description": "The type of hook. Note: \"function\" type is only available via SDK registration, not settings.json.",
+                      "type": "string",
+                      "enum": [
+                        "command",
+                        "http"
+                      ]
+                    },
+                    "command": {
+                      "description": "The command to execute when the hook is triggered. Required for \"command\" type.",
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "The URL to send the POST request to. Required for \"http\" type.",
+                      "type": "string"
+                    },
+                    "headers": {
+                      "description": "HTTP headers to include in the request. Supports env var interpolation ($VAR, ${VAR}).",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "allowedEnvVars": {
+                      "description": "List of environment variables allowed for interpolation in headers and URL.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "name": {
+                      "description": "An optional name for the hook.",
+                      "type": "string"
+                    },
+                    "description": {
+                      "description": "An optional description of what the hook does.",
+                      "type": "string"
+                    },
+                    "timeout": {
+                      "description": "Timeout in seconds for the hook execution.",
+                      "type": "number"
+                    },
+                    "env": {
+                      "description": "Environment variables to set when executing the hook command.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "async": {
+                      "description": "Whether to execute the hook asynchronously (non-blocking, for \"command\" type only).",
+                      "type": "boolean"
+                    },
+                    "once": {
+                      "description": "Whether to execute the hook only once per session (for \"http\" type).",
+                      "type": "boolean"
+                    },
+                    "statusMessage": {
+                      "description": "A message to display while the hook is executing.",
+                      "type": "string"
+                    },
+                    "shell": {
+                      "description": "The shell to use for command execution.",
+                      "type": "string",
+                      "enum": [
+                        "bash",
+                        "powershell"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "hooks"
+            ]
+          }
+        },
         "PreCompact": {
           "description": "Hooks that execute before conversation compaction.",
           "type": "array",


### PR DESCRIPTION
## What this PR does

Adds a `SessionDelete` hook that fires after an explicitly selected session is successfully removed. The event includes `deleted_session_id`, is shown in hook configuration surfaces, and is emitted by interactive `/delete` and the ACP `deleteSession` extension method.

## Why it's needed

Session deletion permanently removes a transcript but previously had no lifecycle notification. `SessionEnd` is tied to an active session and cannot reliably identify an inactive transcript selected for deletion.

## Reviewer Test Plan

### How to verify

Configure a `hooks.SessionDelete` command hook that records its JSON input. Delete an inactive session through `/delete` and confirm the transcript is removed and the hook receives `hook_event_name: "SessionDelete"` plus the deleted session ID. Repeat with a failing hook and confirm deletion still succeeds. The included tests cover the event payload, UI configuration metadata, interactive single and batch delete flows, and ACP extension deletion.

### Evidence (Before & After)

N/A — automated unit coverage validates this lifecycle event; the manual interactive scenario requires a configured model account and persistent local sessions.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ |
| 🪟 Windows | ⚠️ not tested |
| 🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS; `npm run build`, `npm run typecheck`, `npm run lint`, targeted core and CLI Vitest suites.

## Risk & Scope

- Main risk or tradeoff: the hook runs after deletion and is fire-and-forget, so its output and failures cannot affect a completed deletion.
- Not validated / out of scope: daemon REST batch deletion and internal cleanup do not have a hook-runtime owner and intentionally do not emit this event.
- Breaking changes / migration notes: none; users can opt in with `hooks.SessionDelete`.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 此 PR 做了什么

新增 `SessionDelete` hook：当用户明确选择的 session 被成功删除后触发。该事件包含 `deleted_session_id`，会显示在 hook 配置界面，并由交互式 `/delete` 与 ACP 的 `deleteSession` 扩展方法触发。

## 为什么需要

删除 session 会永久移除 transcript，但此前没有对应的生命周期通知。`SessionEnd` 绑定活动 session，无法可靠识别被选择删除的非活动 transcript。

## Reviewer 测试计划

### 如何验证

配置一个 `hooks.SessionDelete` command hook 来记录 JSON 输入。通过 `/delete` 删除非活动 session，确认 transcript 已删除，同时 hook 收到 `hook_event_name: "SessionDelete"` 和被删 session ID。再使用一个失败的 hook 重复操作，确认删除仍然成功。随 PR 的测试覆盖事件 payload、UI 配置元数据、交互式单个和批量删除流程，以及 ACP 扩展删除。

### 证据（Before & After）

不适用——自动化单元测试验证该生命周期事件；手工交互场景需要已配置的模型账号和持久化本地 session。

### 测试环境

macOS；已运行 `npm run build`、`npm run typecheck`、`npm run lint`，以及针对性的 core 和 CLI Vitest 测试集。

## 风险与范围

- 主要风险或取舍：hook 在删除成功后以 fire-and-forget 方式运行，因此它的输出和失败不能影响已完成的删除。
- 未验证 / 范围外：daemon REST 批量删除和内部清理没有 hook-runtime owner，因此有意不触发此事件。
- 破坏性变更 / 迁移说明：无；用户可通过 `hooks.SessionDelete` 选择启用。

## 关联 Issue

无。

</details>
