### PR TITLE
fix(ci): restore workspace ownership before checkout in PR review job

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -362,9 +362,9 @@ jobs:
           RUNNER_UID="$(id -u)"
           RUNNER_GID="$(id -g)"
           if [ "$RUNNER_UID" != "0" ]; then
-            chown -R "$RUNNER_UID:$RUNNER_GID" "$GITHUB_WORKSPACE" 2>/dev/null || sudo -n chown -R "$RUNNER_UID:$RUNNER_GID" "$GITHUB_WORKSPACE" 2>/dev/null || true
+            chown -R "$RUNNER_UID:$RUNNER_GID" "$GITHUB_WORKSPACE" 2>/dev/null || sudo -n chown -R "$RUNNER_UID:$RUNNER_GID" "$GITHUB_WORKSPACE" 2>/dev/null || echo "::warning::could not restore workspace ownership; checkout may fail on leftover root-owned files"
           fi
-          chmod -R u+rwX "$GITHUB_WORKSPACE" 2>/dev/null || sudo -n chmod -R u+rwX "$GITHUB_WORKSPACE" 2>/dev/null || true
+          chmod -R u+rwX "$GITHUB_WORKSPACE" 2>/dev/null || sudo -n chmod -R u+rwX "$GITHUB_WORKSPACE" 2>/dev/null || echo "::warning::could not restore workspace write permissions; checkout may fail on leftover read-only files"
 
       # Self-hosted runners reuse $HOME, /tmp and the workspace, so a prior run
       # can bleed into this one: its agent session/memory (under QWEN_HOME),

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -354,6 +354,21 @@ jobs:
       pull-requests: 'write'
       issues: 'write'
     steps:
+      # Self-hosted runners reuse the workspace across jobs. A prior
+      # containerised job (verify/tmux) may leave files owned by root/node or
+      # made read-only, which causes the checkout action to fail with EACCES
+      # while wiping the tree. Restore ownership and write bits before any
+      # cleanup or checkout runs; never fail the job.
+      - name: 'Restore workspace ownership'
+        run: |-
+          set -uo pipefail
+          RUNNER_UID="$(stat -c '%u' "$RUNNER_TEMP" 2>/dev/null || stat -f '%u' "$RUNNER_TEMP" 2>/dev/null || echo 0)"
+          RUNNER_GID="$(stat -c '%g' "$RUNNER_TEMP" 2>/dev/null || stat -f '%g' "$RUNNER_TEMP" 2>/dev/null || echo 0)"
+          if [ "$RUNNER_UID" != "0" ]; then
+            chown -R "$RUNNER_UID:$RUNNER_GID" "$GITHUB_WORKSPACE" 2>/dev/null || true
+          fi
+          chmod -R u+rwX "$GITHUB_WORKSPACE" 2>/dev/null || true
+
       # Self-hosted runners reuse $HOME, /tmp and the workspace, so a prior run
       # can bleed into this one: its agent session/memory (under QWEN_HOME),
       # leftover draft comments (/tmp/stage-*.md, which survive `git clean`), or

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -354,20 +354,17 @@ jobs:
       pull-requests: 'write'
       issues: 'write'
     steps:
-      # Self-hosted runners reuse the workspace across jobs. A prior
-      # containerised job (verify/tmux) may leave files owned by root/node or
-      # made read-only, which causes the checkout action to fail with EACCES
-      # while wiping the tree. Restore ownership and write bits before any
-      # cleanup or checkout runs; never fail the job.
+      # Self-hosted runners reuse the workspace; restore permissions before
+      # checkout tries to wipe files left by prior containerised jobs.
       - name: 'Restore workspace ownership'
         run: |-
           set -uo pipefail
-          RUNNER_UID="$(stat -c '%u' "$RUNNER_TEMP" 2>/dev/null || stat -f '%u' "$RUNNER_TEMP" 2>/dev/null || echo 0)"
-          RUNNER_GID="$(stat -c '%g' "$RUNNER_TEMP" 2>/dev/null || stat -f '%g' "$RUNNER_TEMP" 2>/dev/null || echo 0)"
+          RUNNER_UID="$(id -u)"
+          RUNNER_GID="$(id -g)"
           if [ "$RUNNER_UID" != "0" ]; then
-            chown -R "$RUNNER_UID:$RUNNER_GID" "$GITHUB_WORKSPACE" 2>/dev/null || true
+            chown -R "$RUNNER_UID:$RUNNER_GID" "$GITHUB_WORKSPACE" 2>/dev/null || sudo -n chown -R "$RUNNER_UID:$RUNNER_GID" "$GITHUB_WORKSPACE" 2>/dev/null || true
           fi
-          chmod -R u+rwX "$GITHUB_WORKSPACE" 2>/dev/null || true
+          chmod -R u+rwX "$GITHUB_WORKSPACE" 2>/dev/null || sudo -n chmod -R u+rwX "$GITHUB_WORKSPACE" 2>/dev/null || true
 
       # Self-hosted runners reuse $HOME, /tmp and the workspace, so a prior run
       # can bleed into this one: its agent session/memory (under QWEN_HOME),


### PR DESCRIPTION
## TLDR

The `review-pr` job fails with `EACCES: permission denied, unlink '.git/FETCH_HEAD'` on reused self-hosted runners because a prior containerised job leaves the workspace owned by root/node or read-only. This PR adds a pre-checkout step that restores ownership and write bits, mirroring the cleanup already in `ci.yml` and `qwen-triage.yml`.

## What this changes

Before this change, the `review-pr` job in `qwen-code-pr-review.yml` had no workspace permission restoration. When a prior verify/tmux job left files root-owned or read-only, the checkout action's attempt to wipe the tree failed immediately.

After this change, a new `Restore workspace ownership` step runs first: it chowns the workspace back to the runner user and makes it writable, so the subsequent cleanup and checkout steps can proceed.

## Reviewer Test Plan

1. Trigger `/review` on a PR that lands on a self-hosted runner with prior container-job state.
2. Confirm the `Restore workspace ownership` step runs and the checkout succeeds.
3. Verify no EACCES in the job log.

## Linked issues

Observed in https://github.com/QwenLM/qwen-code/actions/runs/30460552812/job/90626319066