### PR TITLE
fix(core): prevent Anthropic 4.6+ prefill 400s and pin thinking.display

### DIFF
--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
@@ -1696,7 +1696,7 @@ describe('AnthropicContentGenerator', () => {
         expect.objectContaining({
           output_config: { effort: 'max' },
           // 4.6+ uses adaptive thinking; the server controls the budget.
-          thinking: { type: 'adaptive' },
+          thinking: { type: 'adaptive', display: 'summarized' },
         }),
       );
     });
@@ -1733,7 +1733,7 @@ describe('AnthropicContentGenerator', () => {
       expect(anthropicRequest).toEqual(
         expect.objectContaining({
           output_config: { effort: 'xhigh' },
-          thinking: { type: 'adaptive' },
+          thinking: { type: 'adaptive', display: 'summarized' },
         }),
       );
     });
@@ -2169,12 +2169,15 @@ describe('AnthropicContentGenerator', () => {
       it('selects adaptive for claude-opus-4-6 / sonnet-4-6 / opus-4-7', async () => {
         expect(await thinkingFor('claude-opus-4-6')).toEqual({
           type: 'adaptive',
+          display: 'summarized',
         });
         expect(await thinkingFor('claude-sonnet-4-6')).toEqual({
           type: 'adaptive',
+          display: 'summarized',
         });
         expect(await thinkingFor('claude-opus-4-7')).toEqual({
           type: 'adaptive',
+          display: 'summarized',
         });
       });
 
@@ -2182,6 +2185,7 @@ describe('AnthropicContentGenerator', () => {
         // Single-digit character-class regex would have missed haiku entirely.
         expect(await thinkingFor('claude-haiku-4-6')).toEqual({
           type: 'adaptive',
+          display: 'summarized',
         });
       });
 
@@ -2190,12 +2194,14 @@ describe('AnthropicContentGenerator', () => {
         // invalid `{ type: 'enabled', budget_tokens: ... }` body.
         expect(await thinkingFor('claude-opus-4-10')).toEqual({
           type: 'adaptive',
+          display: 'summarized',
         });
       });
 
       it('selects adaptive for a future major like claude-opus-5-1', async () => {
         expect(await thinkingFor('claude-opus-5-1')).toEqual({
           type: 'adaptive',
+          display: 'summarized',
         });
       });
 
@@ -2241,7 +2247,7 @@ describe('AnthropicContentGenerator', () => {
             effort: 'medium',
             budget_tokens: 42_000,
           }),
-        ).toEqual({ type: 'adaptive' });
+        ).toEqual({ type: 'adaptive', display: 'summarized' });
       });
 
       it('still ships adaptive (no output_config, no effort beta) when reasoning is undefined on a 4.6+ model', async () => {
@@ -2288,6 +2294,7 @@ describe('AnthropicContentGenerator', () => {
           anthropicState.lastCreateArgs as AnthropicCreateArgs;
         expect((req as { thinking?: unknown }).thinking).toEqual({
           type: 'adaptive',
+          display: 'summarized',
         });
         expect(req).toEqual(
           expect.not.objectContaining({ output_config: expect.anything() }),
@@ -2301,6 +2308,60 @@ describe('AnthropicContentGenerator', () => {
         expect(headers['anthropic-beta']).toContain(
           'prompt-caching-scope-2026-01-05',
         );
+      });
+    });
+
+    describe('trailing assistant prefill gating (Claude 4.6+ removed prefill)', () => {
+      // Claude 4.6+ rejects a conversation ending on an assistant message
+      // with HTTP 400 ("This model does not support assistant message
+      // prefill."). The generator turns the converter's
+      // stripTrailingAssistantPrefill pass on for exactly the models that
+      // support adaptive thinking — the same 4.6+ cutoff.
+      async function messagesFor(model: string): Promise<unknown[]> {
+        const { AnthropicContentGenerator } = await importGenerator();
+        anthropicState.createImpl.mockResolvedValue({
+          id: 'anthropic-1',
+          model,
+          content: [{ type: 'text', text: 'hi' }],
+        });
+        const generator = new AnthropicContentGenerator(
+          {
+            model,
+            apiKey: 'test-key',
+            baseUrl: 'https://api.anthropic.com',
+            timeout: 10_000,
+            maxRetries: 2,
+            samplingParams: { max_tokens: 500 },
+            schemaCompliance: 'auto',
+          },
+          mockConfig,
+        );
+        await generator.generateContent({
+          model: 'models/ignored',
+          contents: [
+            { role: 'user', parts: [{ text: 'hi' }] },
+            { role: 'model', parts: [{ text: 'Sure, here is' }] },
+          ],
+        } as unknown as GenerateContentParameters);
+        const [req] = anthropicState.lastCreateArgs as AnthropicCreateArgs;
+        return (req as { messages: unknown[] }).messages;
+      }
+
+      it('terminates a trailing assistant turn with a synthetic user turn on 4.6+ models', async () => {
+        const messages = await messagesFor('claude-opus-4-7');
+        expect(messages).toHaveLength(3);
+        expect(messages[2]).toMatchObject({
+          role: 'user',
+          content: [
+            expect.objectContaining({ type: 'text', text: 'Continue.' }),
+          ],
+        });
+      });
+
+      it('leaves the trailing assistant turn untouched on pre-4.6 models (prefill still supported)', async () => {
+        const messages = await messagesFor('claude-opus-4-5');
+        expect(messages).toHaveLength(2);
+        expect(messages[1]).toMatchObject({ role: 'assistant' });
       });
     });
 
@@ -2624,7 +2685,10 @@ describe('AnthropicContentGenerator', () => {
         'https://internal-proxy.example/anthropic',
       );
 
-      expect(request.thinking).toEqual({ type: 'adaptive' });
+      expect(request.thinking).toEqual({
+        type: 'adaptive',
+        display: 'summarized',
+      });
       expect(request.messages[1]).toEqual({
         role: 'assistant',
         content: [{ type: 'text', text: 'Visible answer' }],

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
@@ -263,7 +263,7 @@ type StreamingBlockState = {
 // stay in lockstep when a third shape (e.g. `extended`) eventually lands.
 type AnthropicThinkingParam =
   | { type: 'enabled'; budget_tokens: number }
-  | { type: 'adaptive' };
+  | { type: 'adaptive'; display: 'summarized' };
 
 type MessageCreateParamsWithThinking = MessageCreateParamsNonStreaming & {
   thinking?: AnthropicThinkingParam;
@@ -703,6 +703,11 @@ export class AnthropicContentGenerator implements ContentGenerator {
         injectThinkingOnToolUseTurns: deepseekThinkingOn,
         dropUnsignedAssistantThinking,
         stripAssistantThinking,
+        // Claude 4.6+ removed assistant-message prefill (HTTP 400 when the
+        // conversation ends on an assistant turn). Same model cutoff as the
+        // adaptive-thinking shape, so reuse that gate rather than adding a
+        // second version predicate that could drift.
+        stripTrailingAssistantPrefill: this.modelSupportsAdaptiveThinking(),
         enableCacheControl,
         useGlobalCacheScope,
         // Read per request (not latched at construction): the client
@@ -1008,8 +1013,15 @@ export class AnthropicContentGenerator implements ContentGenerator {
     // Models that support adaptive thinking use { type: 'adaptive' } without
     // a budget_tokens field. The server controls the thinking budget via
     // output_config.effort instead.
+    //
+    // `display` is pinned to 'summarized' because the server-side default
+    // changed between model generations: Sonnet 4.6 / Opus 4.6 default to
+    // 'summarized' but Opus 4.7+ and every 5.x family default to 'omitted',
+    // which streams thinking blocks with empty text — reasoning silently
+    // disappears from the UI. Pinning is a no-op where the default already
+    // matches. https://github.com/QwenLM/qwen-code/issues/8039
     if (this.modelSupportsAdaptiveThinking()) {
-      return { type: 'adaptive' };
+      return { type: 'adaptive', display: 'summarized' };
     }
 
     // Budget path for non-adaptive (pre-4.6) models. resolveEffectiveEffort has

--- a/packages/core/src/core/anthropicContentGenerator/converter.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.test.ts
@@ -2099,6 +2099,119 @@ describe('AnthropicContentConverter', () => {
     });
   });
 
+  describe('trailing assistant prefill (Claude 4.6+ removed prefill)', () => {
+    it('appends a synthetic user turn when the trailing assistant message has real content', () => {
+      const { messages } = converter.convertGeminiRequestToAnthropic(
+        {
+          model: 'models/test',
+          contents: [
+            { role: 'user', parts: [{ text: 'hi' }] },
+            { role: 'model', parts: [{ text: 'Sure, here is' }] },
+          ],
+        },
+        { stripTrailingAssistantPrefill: true },
+      );
+
+      expect(messages).toHaveLength(3);
+      expect(messages[1]).toEqual({
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Sure, here is' }],
+      });
+      expect(messages[2]).toEqual({
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'Continue.',
+            // The synthetic turn is the final user message, so the per-turn
+            // cache breakpoint lands on it like any other last user turn.
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
+      });
+    });
+
+    it('drops a trailing assistant message that carries no meaningful content (thinking-only)', () => {
+      const { messages } = converter.convertGeminiRequestToAnthropic(
+        {
+          model: 'models/test',
+          contents: [
+            { role: 'user', parts: [{ text: 'hi' }] },
+            {
+              role: 'model',
+              parts: [
+                { text: 'planning...', thought: true, thoughtSignature: 'sig' },
+              ],
+            },
+          ],
+        },
+        { stripTrailingAssistantPrefill: true },
+      );
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0]!.role).toBe('user');
+    });
+
+    it('treats a trailing tool_use assistant turn left by orphan cleanup as real content', () => {
+      // Context trimming can drop the user turn carrying the tool_result;
+      // cleanOrphanedToolCalls then strips the orphaned tool_use, and the
+      // remaining assistant text still ends the conversation. The pass must
+      // still terminate the request on a user turn.
+      const { messages } = converter.convertGeminiRequestToAnthropic(
+        {
+          model: 'models/test',
+          contents: [
+            { role: 'user', parts: [{ text: 'hi' }] },
+            {
+              role: 'model',
+              parts: [
+                { text: 'Let me look that up' },
+                { functionCall: { id: 't1', name: 'lookup', args: {} } },
+              ],
+            },
+          ],
+        },
+        { stripTrailingAssistantPrefill: true },
+      );
+
+      const last = messages[messages.length - 1]!;
+      expect(last.role).toBe('user');
+      expect(messages[1]).toEqual({
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Let me look that up' }],
+      });
+    });
+
+    it('does nothing when the conversation already ends on a user message', () => {
+      const { messages } = converter.convertGeminiRequestToAnthropic(
+        {
+          model: 'models/test',
+          contents: [
+            { role: 'model', parts: [{ text: 'earlier answer' }] },
+            { role: 'user', parts: [{ text: 'follow-up' }] },
+          ],
+        },
+        { stripTrailingAssistantPrefill: true },
+      );
+
+      expect(messages).toHaveLength(2);
+      expect(messages[1]!.role).toBe('user');
+    });
+
+    it('does nothing when the option is disabled (default, pre-4.6 models keep prefill)', () => {
+      const { messages } = converter.convertGeminiRequestToAnthropic({
+        model: 'models/test',
+        contents: [
+          { role: 'user', parts: [{ text: 'hi' }] },
+          { role: 'model', parts: [{ text: 'Sure, here is' }] },
+        ],
+      });
+
+      expect(messages).toHaveLength(2);
+      expect(messages[1]!.role).toBe('assistant');
+    });
+  });
+
   describe('convertGeminiToolsToAnthropic', () => {
     it('converts Tool.functionDeclarations to Anthropic tools and runs schema conversion', async () => {
       const tools = [

--- a/packages/core/src/core/anthropicContentGenerator/converter.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.ts
@@ -90,6 +90,20 @@ export interface ConvertGeminiRequestToAnthropicOptions {
    */
   stripAssistantThinking?: boolean;
   /**
+   * Ensure the request does not end on an assistant message. Claude 4.6+
+   * models removed assistant-message prefill and reject such requests with
+   * HTTP 400 ("This model does not support assistant message prefill. The
+   * conversation must end with a user message."). History can legitimately
+   * end on a model turn — context trimming that drops the next user turn,
+   * subagent transcript replay, or cleanOrphanedToolCalls dropping a
+   * trailing tool_result-only user message. A trailing assistant message
+   * with no meaningful content (empty or thinking-only) is dropped; one
+   * carrying real content (text or tool_use) is kept and a synthetic user
+   * turn is appended so nothing the model already said is discarded.
+   * https://github.com/QwenLM/qwen-code/issues/8039
+   */
+  stripTrailingAssistantPrefill?: boolean;
+  /**
    * Per-call override for `enableCacheControl`. Falls back to the value
    * captured at construction. The generator passes the live
    * `contentGeneratorConfig.enableCacheControl` here so a hot
@@ -183,6 +197,13 @@ export class AnthropicContentConverter {
       this.stripThinkingFromAssistantMessages(messages);
     }
     messages = mergeConsecutiveUserMessages(messages);
+    // Runs last among the structural passes (the earlier cleanups can
+    // themselves leave a trailing assistant message) and before the cache
+    // pass so an appended synthetic user turn becomes the per-turn cache
+    // breakpoint target like any other final user message.
+    if (options.stripTrailingAssistantPrefill) {
+      messages = this.stripTrailingAssistantPrefill(messages);
+    }
 
     // Add cache_control to enable prompt caching (if enabled). Prefer the
     // per-call override when the caller (typically the generator) passes
@@ -953,6 +974,42 @@ export class AnthropicContentConverter {
       } as unknown as AnthropicContentBlockParam;
       message.content = [emptyThinking, ...blocks];
     }
+  }
+
+  /**
+   * Make a history that ends on an assistant message safe for Claude 4.6+
+   * models, which reject assistant-message prefill with HTTP 400. At this
+   * point the merge passes guarantee at most one trailing assistant message.
+   * If it carries nothing the model visibly said (no tool_use, no non-empty
+   * text — e.g. a thinking-only turn cut off by max_tokens), drop it; a
+   * thinking block without a continuation is useless on replay anyway.
+   * Otherwise keep it and append a synthetic user turn so the model's own
+   * words are preserved as ordinary history rather than discarded.
+   */
+  private stripTrailingAssistantPrefill(
+    messages: AnthropicMessageParam[],
+  ): AnthropicMessageParam[] {
+    const last = messages[messages.length - 1];
+    if (!last || last.role !== 'assistant') {
+      return messages;
+    }
+
+    const hasMeaningfulContent = Array.isArray(last.content)
+      ? last.content.some((block) => {
+          const type = (block as { type?: string }).type;
+          if (type === 'tool_use') return true;
+          return type === 'text' && Boolean((block as { text?: string }).text);
+        })
+      : Boolean(last.content);
+
+    if (!hasMeaningfulContent) {
+      return messages.slice(0, -1);
+    }
+
+    return [
+      ...messages,
+      { role: 'user', content: [{ type: 'text', text: 'Continue.' }] },
+    ];
   }
 
   /**


### PR DESCRIPTION
<!-- PR title: fix(core): prevent Anthropic 4.6+ assistant-prefill 400s and pin thinking.display to summarized -->

## What this PR does

Makes two wire-level fixes for Claude 4.6+ and 5.x models on the Anthropic content generator. First, a conversation that would reach the API ending on an assistant message is now made safe before it is sent: a trailing assistant turn with no meaningful content (empty or thinking-only) is dropped, and one carrying real content is kept with a synthetic `Continue.` user turn appended after it, so the request always ends on a user message and nothing the model already said is discarded. Second, the adaptive thinking configuration now sets `display: 'summarized'` explicitly instead of relying on the server-side default, so reasoning text stays visible regardless of which model generation's default applies.

## Why it's needed

Claude 4.6+ removed assistant-message prefill: any request whose `messages` array ends with `role: 'assistant'` is rejected with HTTP 400 ("This model does not support assistant message prefill. The conversation must end with a user message."). The converter had no pass guaranteeing the final message is a user turn, and history can legitimately end on a model turn — context trimming that drops the next user turn, subagent transcript replay, or the converter's own `cleanOrphanedToolCalls` dropping a trailing tool_result-only user message. Separately, the server-side default for `thinking.display` changed between model generations (`summarized` on Sonnet/Opus 4.6, `omitted` on Opus 4.7+ and every 5.x family), so thinking blocks streamed back with empty text on newer models — no error, just reasoning silently disappearing from the UI. Both fixes are gated on or no-ops for older models: the prefill pass reuses the existing `modelSupportsAdaptiveThinking()` 4.6+ cutoff, and pinning `display` is a no-op where the default already matches. Pre-4.6 models, non-Claude ids, and DeepSeek anthropic-compatible endpoints see byte-identical requests.

## Reviewer Test Plan

### How to verify

Run the module's unit tests — they cover both fixes end to end (converter pass semantics, generator gating per model version, and the `display` field on the wire shape):

```bash
cd packages/core && npx vitest run src/core/anthropicContentGenerator/
# Test Files  3 passed (3)
#      Tests  199 passed (199)
```

To confirm the underlying API behavior this defends against (optional, needs an Anthropic API key): send `{"messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "Sure, here is"}]}` to `POST /v1/messages` with a 4.6+ model — it 400s with the prefill error; the same request against `claude-haiku-4-5` succeeds. Full curl reproductions are in issue #8039.

What a reviewer should confirm in the code: the new converter pass runs after all passes that can create a trailing assistant message (`cleanOrphanedToolCalls`, `dropUnsignedAssistantThinking`) and before `addCacheControlToMessages`, so the synthetic user turn becomes the per-turn cache breakpoint (asserted in `converter.test.ts`); the gate in `buildRequest` reuses `modelSupportsAdaptiveThinking()` rather than introducing a second version predicate; and the `AnthropicThinkingParam` adaptive variant now requires `display`, so the omitted-default bug cannot silently regress.

### Evidence (Before & After)

N/A (non-UI change). Before: a request ending on an assistant turn is sent as-is and 400s on 4.6+ models; adaptive thinking is sent as `{"type": "adaptive"}` and thinking text streams back empty on Opus 4.7+/5.x. After: the request ends on a user turn and thinking is sent as `{"type": "adaptive", "display": "summarized"}` — pinned by the updated unit tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

N/A (unit tests only: `npx vitest run` in `packages/core`, plus `npm run typecheck`, ESLint, and Prettier on the touched files).

## Risk & Scope

- Main risk or tradeoff: the synthetic `Continue.` user turn is visible to the model as an ordinary user message on the affected edge-case requests; the alternative (dropping the assistant turn) would discard content the model already produced. The trailing-prefill pass also activates for 4.6+ models behind anthropic-compatible proxies (gate is model-version based), where ending on a user turn is harmless even if the proxy tolerates prefill.
- Not validated / out of scope: no live-API end-to-end run in CI (unit tests pin the wire shapes; the reporter's curl reproductions in #8039 verified the server behavior). `useSummarizedThinking()` on the Anthropic generator still returns `false` — it is a UI hint the issue does not cover, left for a follow-up. No `display` opt-out for proxies that might not recognize the field.
- Breaking changes / migration notes: none. The new converter option is additive and defaults off; pre-4.6 models keep their existing request shape.

## Linked Issues

Fixes #8039

<details>
<summary>中文说明</summary>

## 本 PR 的内容

为 Anthropic content generator 上的 Claude 4.6+ 及 5.x 系列模型做了两处请求层面的修复。第一,当会话历史以 assistant 消息结尾时,请求在发出前会被修正:不含有效内容的尾部 assistant 消息(空消息或仅含 thinking)会被移除;含有真实内容的则被保留,并在其后追加一条合成的 `Continue.` 用户消息,使请求始终以 user 消息结尾,且不丢弃模型已经说过的任何内容。第二,adaptive thinking 配置现在显式设置 `display: 'summarized'`,不再依赖服务端默认值,使推理文本在任何模型代际的默认值下都保持可见。

## 为什么需要

Claude 4.6+ 移除了 assistant 消息 prefill:任何 `messages` 数组以 `role: 'assistant'` 结尾的请求都会被拒绝并返回 HTTP 400("This model does not support assistant message prefill. The conversation must end with a user message.")。converter 中没有任何步骤保证最终消息是 user 消息,而历史确实可能以 model 消息结尾——上下文裁剪丢弃了下一条 user 消息、子代理会话回放,或 converter 自身的 `cleanOrphanedToolCalls` 移除了仅含 tool_result 的尾部 user 消息。另外,`thinking.display` 的服务端默认值在模型代际之间发生了变化(Sonnet/Opus 4.6 默认 `summarized`,Opus 4.7+ 及所有 5.x 系列默认 `omitted`),导致较新模型上 thinking 块以空文本返回——没有报错,推理内容只是静默地从 UI 中消失。两处修复对旧模型均无影响:prefill 保护复用现有的 `modelSupportsAdaptiveThinking()` 4.6+ 判定;显式设置 `display` 在默认值已一致的模型上是 no-op。4.6 之前的模型、非 Claude 模型 id 以及 DeepSeek anthropic 兼容端点收到的请求字节级不变。

## 审阅者测试计划

### 如何验证

运行该模块的单元测试——覆盖两处修复的全部路径(converter pass 语义、按模型版本的 generator 门控、以及请求中的 `display` 字段):

```bash
cd packages/core && npx vitest run src/core/anthropicContentGenerator/
# Test Files  3 passed (3)
#      Tests  199 passed (199)
```

如需确认底层 API 行为(可选,需要 Anthropic API key):向 `POST /v1/messages` 发送 `{"messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "Sure, here is"}]}`,4.6+ 模型返回 prefill 400 错误;同一请求对 `claude-haiku-4-5` 则成功。完整 curl 复现见 issue #8039。

代码层面建议确认:新的 converter pass 在所有可能产生尾部 assistant 消息的 pass(`cleanOrphanedToolCalls`、`dropUnsignedAssistantThinking`)之后、`addCacheControlToMessages` 之前运行,因此合成的 user 消息会成为逐轮缓存断点(已在 `converter.test.ts` 中断言);`buildRequest` 中的门控复用 `modelSupportsAdaptiveThinking()` 而非引入第二个版本判定;`AnthropicThinkingParam` 的 adaptive 变体现在要求 `display` 字段,因此 omitted 默认值的 bug 无法静默复发。

### 证据(修改前后对比)

N/A(非 UI 变更)。修改前:以 assistant 消息结尾的请求原样发出,在 4.6+ 模型上 400;adaptive thinking 以 `{"type": "adaptive"}` 发送,Opus 4.7+/5.x 上 thinking 文本为空。修改后:请求以 user 消息结尾,thinking 以 `{"type": "adaptive", "display": "summarized"}` 发送——由更新后的单元测试固定。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境(可选)

N/A(仅单元测试:在 `packages/core` 中运行 `npx vitest run`,并对改动文件运行 `npm run typecheck`、ESLint 和 Prettier)。

## 风险与范围

- 主要风险或权衡:在受影响的边缘请求中,合成的 `Continue.` 用户消息会作为普通 user 消息被模型看到;替代方案(直接丢弃 assistant 消息)会丢失模型已生成的内容。尾部 prefill 保护对位于 anthropic 兼容代理之后的 4.6+ 模型同样生效(门控基于模型版本),即使代理容忍 prefill,以 user 消息结尾也是无害的。
- 未验证 / 范围之外:CI 中没有真实 API 的端到端验证(单元测试固定了请求形状;issue #8039 中报告者的 curl 复现已验证服务端行为)。Anthropic generator 的 `useSummarizedThinking()` 仍返回 `false`——这是 issue 未涉及的 UI 提示,留作后续处理。未为可能不识别 `display` 字段的代理提供退出开关。
- 破坏性变更 / 迁移说明:无。新的 converter 选项为增量式且默认关闭;4.6 之前的模型保持现有请求形状。

## 关联 Issue

Fixes #8039

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)