### PR TITLE
fix(web-shell): show server queue status for pending messages

### DIFF
--- a/packages/web-shell/client/components/QueuedPromptDisplay.test.tsx
+++ b/packages/web-shell/client/components/QueuedPromptDisplay.test.tsx
@@ -73,9 +73,11 @@ describe('QueuedPromptDisplay', () => {
     expect(container.textContent).toContain('排队消息二');
   });
 
-  it('shows when an accepted prompt is queued on the server', () => {
+  it('shows server queue status without an insert action', () => {
+    const onInsert = vi.fn();
     const { container } = setup({
       prompts: [{ id: 1, text: '等待处理', serverState: 'queued' }],
+      onInsert,
     });
 
     expect(container.textContent).toContain('服务器排队中...');
@@ -83,11 +85,11 @@ describe('QueuedPromptDisplay', () => {
     expect(
       container.querySelector('[class*="queuedPromptSpinner"]'),
     ).toBeNull();
-    expect(
-      [...container.querySelectorAll('button')].every(
-        (button) => !button.disabled,
-      ),
-    ).toBe(true);
+    const buttons = [...container.querySelectorAll('button')];
+    expect(buttons).toHaveLength(2);
+    expect(buttons.every((button) => !button.disabled)).toBe(true);
+    expect(container.textContent).not.toContain('插入');
+    expect(onInsert).not.toHaveBeenCalled();
   });
 
   it('keeps the spinner while a prompt is still submitting', () => {

--- a/packages/web-shell/client/components/QueuedPromptDisplay.test.tsx
+++ b/packages/web-shell/client/components/QueuedPromptDisplay.test.tsx
@@ -73,6 +73,34 @@ describe('QueuedPromptDisplay', () => {
     expect(container.textContent).toContain('排队消息二');
   });
 
+  it('shows when an accepted prompt is queued on the server', () => {
+    const { container } = setup({
+      prompts: [{ id: 1, text: '等待处理', serverState: 'queued' }],
+    });
+
+    expect(container.textContent).toContain('服务器排队中...');
+    expect(container.querySelector('[role="status"]')).toBeTruthy();
+    expect(
+      container.querySelector('[class*="queuedPromptSpinner"]'),
+    ).toBeNull();
+    expect(
+      [...container.querySelectorAll('button')].every(
+        (button) => !button.disabled,
+      ),
+    ).toBe(true);
+  });
+
+  it('keeps the spinner while a prompt is still submitting', () => {
+    const { container } = setup({
+      prompts: [{ id: 1, text: '正在发送', serverState: 'submitting' }],
+    });
+
+    expect(container.textContent).toContain('提交中...');
+    expect(
+      container.querySelector('[class*="queuedPromptSpinner"]'),
+    ).toBeTruthy();
+  });
+
   it('renders queued reference annotations as tags', () => {
     const serialized = '<context id="orders">orders</context>';
     const text = `inspect ${serialized} now`;

--- a/packages/web-shell/client/components/QueuedPromptDisplay.tsx
+++ b/packages/web-shell/client/components/QueuedPromptDisplay.tsx
@@ -163,6 +163,7 @@ export function QueuedPromptDisplay({
         const imageCount = prompt.images?.length ?? 0;
         const isCommand = isCommandPrompt(prompt.text);
         const isSubmitting = prompt.serverState === 'submitting';
+        const isQueued = prompt.serverState === 'queued';
         const isRunning = prompt.serverState === 'running';
         const isRemoving = prompt.isRemoving === true;
         const isBusy =
@@ -208,14 +209,18 @@ export function QueuedPromptDisplay({
               {imageCount > 0
                 ? ` ${t('queue.imageCount', { count: imageCount })}`
                 : ''}
-              {isSubmitting || prompt.isEditing || isRemoving ? (
-                <span className={styles.queuedPromptState}>
-                  <span className={styles.queuedPromptSpinner} />
+              {isSubmitting || isQueued || prompt.isEditing || isRemoving ? (
+                <span className={styles.queuedPromptState} role="status">
+                  {(isSubmitting || prompt.isEditing || isRemoving) && (
+                    <span className={styles.queuedPromptSpinner} />
+                  )}
                   {isRemoving
                     ? t('queue.removing')
                     : prompt.isEditing
                       ? t('queue.editing')
-                      : t('queue.submitting')}
+                      : isQueued
+                        ? t('queue.serverQueued')
+                        : t('queue.submitting')}
                 </span>
               ) : null}
             </span>

--- a/packages/web-shell/client/components/QueuedPromptDisplay.tsx
+++ b/packages/web-shell/client/components/QueuedPromptDisplay.tsx
@@ -225,7 +225,7 @@ export function QueuedPromptDisplay({
               ) : null}
             </span>
             <span className={styles.queuedPromptActions}>
-              {imageCount === 0 && (
+              {imageCount === 0 && !isQueued && (
                 <button
                   type="button"
                   className={styles.queuedPromptAction}

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -1204,6 +1204,7 @@ const EN: Messages = {
   'queue.insertCommandDisabled':
     "Commands can't be inserted into the running turn; they run after it finishes.",
   'queue.submitting': 'Submitting...',
+  'queue.serverQueued': 'Queued on server...',
   'queue.editing': 'Editing...',
   'queue.removing': 'Updating...',
   'queue.submittingDisabled': 'Submitting queued message...',
@@ -3676,6 +3677,7 @@ const ZH: Messages = {
   'queue.inserted': '已插入，下次模型调用生效。',
   'queue.insertCommandDisabled': '命令无法插入当前回合。',
   'queue.submitting': '提交中...',
+  'queue.serverQueued': '服务器排队中...',
   'queue.editing': '编辑中...',
   'queue.removing': '处理中...',
   'queue.submittingDisabled': '排队消息正在提交中...',


### PR DESCRIPTION
## What this PR does

Shows an explicit “Queued on server...” status above the composer after a message has been accepted into the daemon's per-session queue but has not started running yet. The existing “Submitting...” status remains visible while admission is still in progress. Server-queued messages remain editable and removable, while the mid-turn insert action is hidden until its transfer semantics can guarantee that an accepted-but-undrained message stays visible and recoverable.

## Why it's needed

A queued message can already be visible in the Web Shell while the daemon is still waiting to dispatch it. Without a visible server-queue state, users can interpret the lack of processing feedback as a lost message and may submit it again.

## Reviewer Test Plan

### How to verify

Start a turn, submit another message while that turn is still running, and confirm the queued message appears above the composer with “Queued on server...” after admission completes. Confirm that “Submitting...” is shown before admission completes, that the server-queued state does not show an activity spinner, that the insert action is hidden, and that delete and edit remain enabled. Once the daemon starts the queued prompt, confirm it leaves the queue display and proceeds through the normal turn UI.

Automated verification completed locally: `npx vitest run client/components/QueuedPromptDisplay.test.tsx` (14 tests), targeted ESLint for the changed files, `npm run build`, and `npm run typecheck`.

### Evidence (Before & After)

Before: an accepted message waiting in the daemon queue had no state label, which could make it appear lost.

After: the queued message displays “Queued on server...” / “服务器排队中...” above the composer until dispatch begins.

The screenshot below comes from the Chinese UI of a real local daemon and the real Web Shell client, not the mock-daemon visual harness. The first prompt requested a 45-second shell wait and remained active while the second prompt was submitted through the browser. The daemon's `/pending-prompts` response reported the first prompt as `running` and the second prompt as `queued`; the browser visibly rendered “服务器排队中...” with only delete and edit actions.

![Real daemon E2E showing 服务器排队中 with delete and edit actions only](https://raw.githubusercontent.com/wenshao/qwen-code/fix-web-shell-server-queue-status-screenshots/server-queue-status/03-real-daemon-server-queued-no-insert-zh.png)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS local workspace. The visual evidence was captured in headless Chromium against the real source daemon and real Vite-served Web Shell client. Component tests used Vitest and jsdom.

## Risk & Scope

- Main risk or tradeoff: The new label depends on the existing daemon `queued` state; it intentionally does not infer queueing from network latency or show a spinner while waiting for dispatch.
- Not validated / out of scope: Cross-client visual E2E behavior and Windows/Linux browser rendering were not manually tested. No daemon, SDK, queue lifecycle, or message ordering behavior is changed.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 此 PR 的改动

消息已被 daemon 接收到每会话队列、但尚未开始执行时，在输入框上方明确显示“服务器排队中...”。请求仍在提交阶段时继续显示“提交中...”；服务端排队中的消息仍可编辑、删除，但暂时隐藏插入当前回合的操作，直到该转移过程能够保证尚未被消费的消息仍然可见且可恢复。

## 为什么需要

排队消息可能已经在 Web Shell 中可见，但 daemon 尚未调度执行。此前这一阶段没有明确反馈，用户容易认为消息丢失，并重复提交相同内容。

## Reviewer 测试计划

### 验证方式

启动一个回合，在当前回合仍运行时再次提交消息，确认请求被接受后，排队消息在输入框上方显示“服务器排队中...”。确认请求被接受前显示“提交中...”，服务器排队状态不显示活动 spinner，插入操作已隐藏，而删除和编辑仍保持可用。当 daemon 开始执行该排队消息后，确认它离开排队区域并进入正常回合 UI。

本地已完成自动验证：`npx vitest run client/components/QueuedPromptDisplay.test.tsx`（14 个测试）、针对修改文件的 ESLint、`npm run build` 和 `npm run typecheck`。

### 证据（改动前后）

改动前：已被服务器接受、但仍在 daemon 队列中等待的消息没有状态标签，看起来可能像消息丢失。

改动后：排队消息在开始调度前，会在输入框上方显示“Queued on server...” / “服务器排队中...”。

上方截图来自真实本地 daemon 和真实 Web Shell 中文客户端，不是 mock-daemon visual harness。第一条消息请求执行 45 秒 shell 等待，并在仍处于运行状态时通过浏览器提交第二条消息。daemon 的 `/pending-prompts` 响应显示第一条为 `running`、第二条为 `queued`；截图中可直接看到“服务器排队中...”，右侧仅保留删除和编辑操作。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS 本地工作区。视觉证据使用 headless Chromium，连接真实源码 daemon 和由 Vite 提供的真实 Web Shell 客户端；组件测试使用 Vitest 和 jsdom。

## 风险与范围

- 主要风险或取舍：新标签依赖现有 daemon `queued` 状态；不会根据网络延迟推测排队，也不会在等待调度时显示 spinner。
- 未验证或范围外：未手动验证跨客户端视觉 E2E 行为以及 Windows/Linux 浏览器渲染。未修改 daemon、SDK、队列生命周期或消息顺序行为。
- 破坏性变更或迁移说明：无。

## 关联 Issue

无

</details>




