### PR TITLE
fix(autofix): answer round-cap refusals on the PR instead of only in logs

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -1689,6 +1689,7 @@ jobs:
           GITHUB_TOKEN: '${{ secrets.CI_DEV_BOT_PAT }}'
           FORCED_PR: '${{ needs.route.outputs.pr_number }}'
           DRY_RUN: '${{ needs.route.outputs.dry_run }}'
+          EVENT_NAME: '${{ github.event_name }}'
         run: |-
           # Fleet visibility: every per-PR decision below also records a row so
           # the run summary shows the WHOLE managed fleet in one table.
@@ -2209,11 +2210,16 @@ jobs:
               # unhandled for hours. The shepherd also dedups per head SHA,
               # and a capped PR gets no pushes, so its head never changes:
               # silence here freezes conflict handling until a human notices
-              # by accident. Every forced dispatch is explicit intent (the
-              # shepherd lever or a human), so every refusal is answered —
-              # no dedup: the shepherd sends at most one dispatch per head,
-              # and a human asking twice deserves two answers.
-              if [[ -n "${FORCED_PR}" && "${FORCED_PR}" == "${PR}" ]]; then
+              # by accident. Gate on workflow_dispatch — that is the explicit
+              # dispatch lever (the shepherd's `gh workflow run` or a human).
+              # FORCED_PR is ALSO set for every trusted pull_request_review
+              # (route emits pr_number for those), which is not an explicit
+              # dispatch: answering each one here spammed 7 refusals on
+              # #7836, so review submissions stay covered by the
+              # once-per-window pause notice below. No dedup on the dispatch
+              # itself: the shepherd sends at most one per head, and a human
+              # asking twice deserves two answers.
+              if [[ -n "${FORCED_PR}" && "${FORCED_PR}" == "${PR}" && "${EVENT_NAME}" == 'workflow_dispatch' ]]; then
                 if [[ "${DRY_RUN}" == "true" ]]; then
                   echo "🧪 DRY-RUN: would post cap-refused notice on #${PR}"
                 else

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2201,43 +2201,80 @@ jobs:
             if [[ "${ROUND}" -ge "${EFF_MAX_ROUNDS}" ]]; then
               echo "🚧 #${PR}: hit the round cap (${ROUND}/${EFF_MAX_ROUNDS}) — leaving for a human"
               fleet_row "${PR}" 'round-capped' "round ${ROUND}/${EFF_MAX_ROUNDS} - needs a human or @qwen-code /retry"
-              # A MANAGED PR pausing at its cap deserves a visible reminder —
-              # maintainers otherwise learn about it only from workflow logs.
-              # Once per counting window: re-arming opens a fresh window and,
-              # if the cap is hit again, a fresh reminder. A failed post
-              # retries naturally on the next scan (marker still absent).
-              if [[ "${HAS_TAKEOVER}" == "true" ]]; then
-                # Dedup boundary = the current window key; with no engage ack
-                # yet (key 'none') fall back to LIFETIME dedup — created_at is
-                # never > 'none' lexically, which would flip this into posting
-                # every scan.
-                NOTICE_RT="${REARM_KEY}"
-                [[ "${NOTICE_RT}" == "none" ]] && NOTICE_RT=''
-                CAP_NOTICED="$(jq -r --arg ab "${AUTOFIX_BOT}" --arg rt "${NOTICE_RT}" '
-                  [ .[] | select((.user.login // "") == $ab)
-                    | select((.body // "") | contains("<!-- takeover-cap-reached -->"))
-                    | select((.created_at // "") > $rt) ] | length' "${WORKDIR}/ic.json")"
+              # A FORCED dispatch refused here answers OUT LOUD. Observed on
+              # #7836: the fleet shepherd detected a merge conflict, posted
+              # "dispatched the autofix loop to resolve it", and the dispatch
+              # died right here with only the log line above — the PR page
+              # showed a promise, the run showed green, and the conflict sat
+              # unhandled for hours. The shepherd also dedups per head SHA,
+              # and a capped PR gets no pushes, so its head never changes:
+              # silence here freezes conflict handling until a human notices
+              # by accident. Every forced dispatch is explicit intent (the
+              # shepherd lever or a human), so every refusal is answered —
+              # no dedup: the shepherd sends at most one dispatch per head,
+              # and a human asking twice deserves two answers.
+              if [[ -n "${FORCED_PR}" && "${FORCED_PR}" == "${PR}" ]]; then
                 if [[ "${DRY_RUN}" == "true" ]]; then
-                  echo "🧪 DRY-RUN: would post cap-paused notice on #${PR}"
-                elif [[ "${CAP_NOTICED}" == "0" ]]; then
-                  # Consent may have moved since PR_META: a takeover label
-                  # removed (or skip added) moments ago must not receive a
-                  # stale 'paused' notice.
-                  LIVE_LABELS="$(gh pr view "${PR}" --repo "${REPO}" --json labels 2> /dev/null | jq -r '[.labels[]?.name] | join(" ")' || echo '')"
-                  if [[ " ${LIVE_LABELS} " != *" ${TAKEOVER_LABEL} "* || " ${LIVE_LABELS} " == *" ${SKIP_LABEL} "* ]]; then
-                    echo "🧭 cap notice skipped: consent changed since the snapshot (labels: ${LIVE_LABELS:-unreadable})"
-                    continue
-                  fi
-                  # Convention: verify the PAT identity before ANY write. A
-                  # rotated PAT would post under a foreign login the dedup
-                  # (which counts AUTOFIX_BOT comments only) can never see —
-                  # reposting the notice every scan. Memoized per scan run.
+                  echo "🧪 DRY-RUN: would post cap-refused notice on #${PR}"
+                else
                   if [[ -z "${SCAN_BOT_ACTOR:-}" ]]; then
                     SCAN_BOT_ACTOR="$(gh api user --jq '.login' 2> /dev/null || echo 'unknown')"
                   fi
                   if [[ "${SCAN_BOT_ACTOR}" != "${AUTOFIX_BOT}" ]]; then
-                    echo "::warning::cap-paused notice skipped: PAT authenticates as '${SCAN_BOT_ACTOR}', expected ${AUTOFIX_BOT}"
-                  elif ! gh pr comment "${PR}" --repo "${REPO}" --body "$(printf '⏸️ Takeover paused: this PR reached its round cap (%s/%s). Comment `%s` to re-arm a fresh window and continue management, or `%s stop` to release.\n\n<details>\n<summary>中文说明</summary>\n\n⏸️ 托管已暂停：本 PR 达到轮次上限（%s/%s）。评论 `%s` 可重新武装、开启新窗口继续托管；或评论 `%s stop` 释放。\n\n</details>\n\n<!-- takeover-cap-reached -->' "${ROUND}" "${EFF_MAX_ROUNDS}" "${TAKEOVER_COMMAND}" "${TAKEOVER_COMMAND}" "${ROUND}" "${EFF_MAX_ROUNDS}" "${TAKEOVER_COMMAND}" "${TAKEOVER_COMMAND}")"; then
+                    echo "::warning::cap-refused notice skipped: PAT authenticates as '${SCAN_BOT_ACTOR}', expected ${AUTOFIX_BOT}"
+                  elif ! gh pr comment "${PR}" --repo "${REPO}" --body "$(printf '⏸️ Dispatch refused: this PR has exhausted its automatic round cap (%s/%s), so the loop will not touch it — whatever triggered this dispatch (a merge conflict, new feedback) stays unhandled. Comment `%s` to re-arm a fresh window, or `%s` for the raised takeover cap; the next scheduled scan then picks it up.\n\n<details>\n<summary>中文说明</summary>\n\n⏸️ 已拒绝本次调度：本 PR 的自动轮次上限已用完（%s/%s），循环不会介入——触发本次调度的事项（合并冲突、新反馈）仍未处理。评论 `%s` 可重置计数窗口，或 `%s` 获得更高的接管上限；随后下一次定时扫描会接手。\n\n</details>\n\n<!-- takeover-cap-refused -->' "${ROUND}" "${EFF_MAX_ROUNDS}" "${RETRY_COMMAND}" "${TAKEOVER_COMMAND}" "${ROUND}" "${EFF_MAX_ROUNDS}" "${RETRY_COMMAND}" "${TAKEOVER_COMMAND}")"; then
+                    echo "::warning::cap-refused notice failed for #${PR}"
+                  fi
+                fi
+              fi
+              # A MANAGED PR pausing at its cap deserves a visible reminder —
+              # maintainers otherwise learn about it only from workflow logs.
+              # ALL managed PRs, not just takeover: the takeover-only gate
+              # left standard bot PRs capping in silence (#7836 hit 10/10
+              # with zero PR-visible notice), which is the root of the
+              # frozen-conflict chain above. Once per counting window:
+              # re-arming opens a fresh window and, if the cap is hit again,
+              # a fresh reminder. A failed post retries naturally on the
+              # next scan (marker still absent).
+              # Dedup boundary = the current window key; with no engage ack
+              # or re-arm yet (key 'none') fall back to LIFETIME dedup —
+              # created_at is never > 'none' lexically, which would flip
+              # this into posting every scan.
+              NOTICE_RT="${REARM_KEY}"
+              [[ "${NOTICE_RT}" == "none" ]] && NOTICE_RT=''
+              CAP_NOTICED="$(jq -r --arg ab "${AUTOFIX_BOT}" --arg rt "${NOTICE_RT}" '
+                [ .[] | select((.user.login // "") == $ab)
+                  | select((.body // "") | contains("<!-- takeover-cap-reached -->"))
+                  | select((.created_at // "") > $rt) ] | length' "${WORKDIR}/ic.json")"
+              if [[ "${DRY_RUN}" == "true" ]]; then
+                echo "🧪 DRY-RUN: would post cap-paused notice on #${PR}"
+              elif [[ "${CAP_NOTICED}" == "0" ]]; then
+                # Consent may have moved since PR_META: skip wins everywhere,
+                # and a takeover notice additionally requires the label to
+                # still be present — a label removed (or skip added) moments
+                # ago must not receive a stale 'paused' notice.
+                LIVE_LABELS="$(gh pr view "${PR}" --repo "${REPO}" --json labels 2> /dev/null | jq -r '[.labels[]?.name] | join(" ")' || echo '')"
+                if [[ " ${LIVE_LABELS} " == *" ${SKIP_LABEL} "* ]] \
+                  || [[ "${HAS_TAKEOVER}" == "true" && " ${LIVE_LABELS} " != *" ${TAKEOVER_LABEL} "* ]]; then
+                  echo "🧭 cap notice skipped: consent changed since the snapshot (labels: ${LIVE_LABELS:-unreadable})"
+                  continue
+                fi
+                # Convention: verify the PAT identity before ANY write. A
+                # rotated PAT would post under a foreign login the dedup
+                # (which counts AUTOFIX_BOT comments only) can never see —
+                # reposting the notice every scan. Memoized per scan run.
+                if [[ -z "${SCAN_BOT_ACTOR:-}" ]]; then
+                  SCAN_BOT_ACTOR="$(gh api user --jq '.login' 2> /dev/null || echo 'unknown')"
+                fi
+                if [[ "${SCAN_BOT_ACTOR}" != "${AUTOFIX_BOT}" ]]; then
+                  echo "::warning::cap-paused notice skipped: PAT authenticates as '${SCAN_BOT_ACTOR}', expected ${AUTOFIX_BOT}"
+                else
+                  if [[ "${HAS_TAKEOVER}" == "true" ]]; then
+                    CAP_BODY="$(printf '⏸️ Takeover paused: this PR reached its round cap (%s/%s). Comment `%s` to re-arm a fresh window and continue management, or `%s stop` to release.\n\n<details>\n<summary>中文说明</summary>\n\n⏸️ 托管已暂停：本 PR 达到轮次上限（%s/%s）。评论 `%s` 可重新武装、开启新窗口继续托管；或评论 `%s stop` 释放。\n\n</details>\n\n<!-- takeover-cap-reached -->' "${ROUND}" "${EFF_MAX_ROUNDS}" "${TAKEOVER_COMMAND}" "${TAKEOVER_COMMAND}" "${ROUND}" "${EFF_MAX_ROUNDS}" "${TAKEOVER_COMMAND}" "${TAKEOVER_COMMAND}")"
+                  else
+                    CAP_BODY="$(printf '⏸️ AutoFix paused: this PR reached its automatic round cap (%s/%s) and the loop will not manage it further — new feedback and base conflicts stay unhandled. Comment `%s` to re-arm a fresh window under the same cap, or `%s` to take it over with the raised cap.\n\n<details>\n<summary>中文说明</summary>\n\n⏸️ AutoFix 已暂停：本 PR 达到自动轮次上限（%s/%s），循环不再管理——新反馈与 base 冲突将无人处理。评论 `%s` 可在同一上限下重置计数窗口，或评论 `%s` 以更高上限接管。\n\n</details>\n\n<!-- takeover-cap-reached -->' "${ROUND}" "${EFF_MAX_ROUNDS}" "${RETRY_COMMAND}" "${TAKEOVER_COMMAND}" "${ROUND}" "${EFF_MAX_ROUNDS}" "${RETRY_COMMAND}" "${TAKEOVER_COMMAND}")"
+                  fi
+                  if ! gh pr comment "${PR}" --repo "${REPO}" --body "${CAP_BODY}"; then
                     echo "::warning::cap-paused notice failed for #${PR}; will retry next scan"
                   fi
                 fi

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -2407,11 +2407,15 @@ describe('qwen-autofix workflow', () => {
     // A FORCED dispatch (shepherd conflict lever or a human) refused at the
     // cap gate answers on the PR — observed on #7836: '🐑 dispatched the
     // autofix loop' followed by a green run that did nothing, with the
-    // refusal visible only in the Actions log. No dedup: the shepherd
-    // sends at most one dispatch per head, and a human asking twice
+    // refusal visible only in the Actions log. Gated on workflow_dispatch:
+    // FORCED_PR is ALSO set for trusted pull_request_review submissions
+    // (route emits pr_number for those), and answering each one loudly
+    // spammed 7 refusals on #7836 — those stay covered by the
+    // once-per-window pause notice. No dedup on the dispatch itself: the
+    // shepherd sends at most one per head, and a human asking twice
     // deserves two answers.
     expect(reviewScanJob).toContain(
-      'if [[ -n "${FORCED_PR}" && "${FORCED_PR}" == "${PR}" ]]; then',
+      'if [[ -n "${FORCED_PR}" && "${FORCED_PR}" == "${PR}" && "${EVENT_NAME}" == \'workflow_dispatch\' ]]; then',
     );
     expect(reviewScanJob).toContain('<!-- takeover-cap-refused -->');
     expect(reviewScanJob).toContain('Dispatch refused');
@@ -2419,6 +2423,26 @@ describe('qwen-autofix workflow', () => {
     expect(reviewScanJob).toContain(
       'cap-refused notice skipped: PAT authenticates as',
     );
+    // The loud refusal is gated on workflow_dispatch (FORCED_PR is also set
+    // for trusted review submissions). Replay the guard VERBATIM so a
+    // dropped EVENT_NAME condition fails the test, not just a substring: a
+    // dispatch is answered, a review submission is left to the pause notice.
+    const refusedGuard = reviewScanJob.match(
+      /(if \[\[ -n "\$\{FORCED_PR\}" && "\$\{FORCED_PR\}" == "\$\{PR\}" && "\$\{EVENT_NAME\}" == 'workflow_dispatch' \]\]; then)/,
+    )?.[1];
+    expect(refusedGuard).toBeTruthy();
+    const refuses = (eventName) =>
+      execFileSync('bash', ['-c', `${refusedGuard}\necho REFUSED\nfi`], {
+        env: {
+          ...process.env,
+          FORCED_PR: '7836',
+          PR: '7836',
+          EVENT_NAME: eventName,
+        },
+        encoding: 'utf8',
+      }).trim();
+    expect(refuses('workflow_dispatch')).toContain('REFUSED');
+    expect(refuses('pull_request_review')).not.toContain('REFUSED');
     // The standard-mode pause and the refusal both point at the actual
     // recovery command as a printf ARG (the takeover variant keeps its
     // takeover-command-only wording).

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -2512,6 +2512,45 @@ describe('qwen-autofix workflow', () => {
     expect(noticed('2026-07-18T11:00:00Z', '2026-07-18T10:00:00Z')).toBe('1');
     // No key yet (lifetime dedup, rt='') → any prior notice suppresses.
     expect(noticed('2026-07-18T09:00:00Z', '')).toBe('1');
+    // The consent gate is the core behavioral change: standard bot PRs now
+    // receive cap notices (they used to be takeover-only). Replay the gate
+    // VERBATIM under all four label/takeover permutations so a dropped
+    // HAS_TAKEOVER guard or a reverted skip-wins condition fails the test,
+    // not just a substring assertion.
+    const consentGate = reviewScanJob.match(
+      /(if \[\[ " \$\{LIVE_LABELS\} " == \*" \$\{SKIP_LABEL\} "\* \]\] \\\n[\s\S]*?continue\n {16}fi)/,
+    )?.[1];
+    expect(consentGate).toBeTruthy();
+    const gate = (liveLabels, hasTakeover) =>
+      execFileSync(
+        'bash',
+        [
+          '-c',
+          `for _ in 1; do\n${consentGate.replace(/\n {16}/g, '\n')}\necho PROCEED\ndone`,
+        ],
+        {
+          env: {
+            ...process.env,
+            LIVE_LABELS: liveLabels,
+            HAS_TAKEOVER: hasTakeover,
+            SKIP_LABEL: 'autofix/skip',
+            TAKEOVER_LABEL: 'autofix/takeover',
+          },
+          encoding: 'utf8',
+        },
+      ).trim();
+    // Standard bot PR, no skip label → NOT skipped (the #7836 case).
+    expect(gate('autofix/managed', 'false')).toContain('PROCEED');
+    // Standard bot PR + skip label → skipped everywhere.
+    expect(gate('autofix/managed autofix/skip', 'false')).toContain(
+      'cap notice skipped',
+    );
+    // Takeover PR with its label removed → skipped (stale consent).
+    expect(gate('autofix/managed', 'true')).toContain('cap notice skipped');
+    // Takeover PR with the label still present → NOT skipped.
+    expect(gate('autofix/managed autofix/takeover', 'true')).toContain(
+      'PROCEED',
+    );
     // Candidates drain newest-first, and the free busy skip never consumes
     // inspection budget.
     expect(reviewScanJob).toContain('sort_by(-.number)');

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -1961,7 +1961,8 @@ describe('qwen-autofix workflow', () => {
     // honest bot-PR release, skip-labeled bot-PR release, human-PR
     // release, re-arm, fork allow-edits refusal, two skip-blocked refusals,
     // the label-path non-main base refusal, the command-path non-main base
-    // refusal, the cap pause, the command-path direct engage ack (the
+    // refusal, the takeover cap pause, the standard-mode cap pause, the
+    // forced-dispatch cap refusal, the command-path direct engage ack (the
     // labeled event has been observed to not fire — #7999, #8002 — so the
     // command acks itself), the command-path direct release acks (all three
     // variants, mirroring the ack job — a loud add next to a mute stop
@@ -1971,7 +1972,7 @@ describe('qwen-autofix workflow', () => {
     const ackBodies = workflow.match(
       /printf '[^']*takeover-(?:ack|cap)[^']*'/g,
     );
-    expect(ackBodies).toHaveLength(17);
+    expect(ackBodies).toHaveLength(19);
     for (const body of ackBodies) {
       expect(body).toContain('<summary>中文说明</summary>');
     }
@@ -2392,6 +2393,41 @@ describe('qwen-autofix workflow', () => {
     // guidance in the body.
     expect(reviewScanJob).toContain('<!-- takeover-cap-reached -->');
     expect(reviewScanJob).toContain('Takeover paused');
+    // The cap notice covers ALL managed PRs, not just takeover: standard
+    // bot PRs used to cap in silence (#7836 hit 10/10 with zero PR-visible
+    // notice), which let the shepherd's conflict dispatch die silently on
+    // a cap the PR page never mentioned. Same marker → same
+    // once-per-window dedup for both variants.
+    expect(reviewScanJob).toContain('AutoFix paused');
+    // Three sites: the dedup census read + BOTH notice bodies — the shared
+    // marker is what gives the two variants one once-per-window dedup.
+    expect(
+      reviewScanJob.split('<!-- takeover-cap-reached -->').length - 1,
+    ).toBe(3);
+    // A FORCED dispatch (shepherd conflict lever or a human) refused at the
+    // cap gate answers on the PR — observed on #7836: '🐑 dispatched the
+    // autofix loop' followed by a green run that did nothing, with the
+    // refusal visible only in the Actions log. No dedup: the shepherd
+    // sends at most one dispatch per head, and a human asking twice
+    // deserves two answers.
+    expect(reviewScanJob).toContain(
+      'if [[ -n "${FORCED_PR}" && "${FORCED_PR}" == "${PR}" ]]; then',
+    );
+    expect(reviewScanJob).toContain('<!-- takeover-cap-refused -->');
+    expect(reviewScanJob).toContain('Dispatch refused');
+    expect(reviewScanJob).toContain('DRY-RUN: would post cap-refused notice');
+    expect(reviewScanJob).toContain(
+      'cap-refused notice skipped: PAT authenticates as',
+    );
+    // The standard-mode pause and the refusal both point at the actual
+    // recovery command as a printf ARG (the takeover variant keeps its
+    // takeover-command-only wording).
+    const capBodies =
+      reviewScanJob.match(/printf '[^']*takeover-cap-re[^']*'[^\n]*/g) ?? [];
+    expect(capBodies).toHaveLength(3);
+    expect(
+      capBodies.filter((b) => b.includes('"${RETRY_COMMAND}"')),
+    ).toHaveLength(2);
     expect(reviewScanJob).toMatch(
       /CAP_NOTICED=[\s\S]*?contains\("<!-- takeover-cap-reached -->"\)[\s\S]*?> \$rt/,
     );


### PR DESCRIPTION
## Problem

Observed end-to-end on #7836 (2026-07-29):

1. The bot-authored PR exhausted its standard round cap (10/10) on 07-28 06:56 — **with zero PR-visible notice**: the cap pause notice is takeover-only, so standard-management PRs cap in silence.
2. Main moved and the PR became CONFLICTING. The fleet shepherd's conflict lever posted **"🐑 … dispatched the autofix loop to resolve it"** at 17:43 and dispatched `qwen-autofix` with `pr_number=7836`.
3. The dispatch run executed, and the scan **refused the PR at the round-cap gate** — `🚧 #7836: hit the round cap (10/10)` — visible only in the Actions log. The run completed green.
4. The shepherd dedups conflict dispatches **per head SHA**, and a capped PR receives no pushes, so its head never changes: no re-dispatch, ever. The PR page shows a promise; the conflict sits unhandled indefinitely (4+ hours until a human happened to look).

Three silences stacked into a frozen state that looks healthy from every dashboard.

## Change

Both fixes live in the scan — the shepherd stays untouched, because the windowed round computation (`REARM_KEY`, `win=` scoping, effective cap) has exactly one correct implementation and duplicating it into the shepherd would drift.

**1. Forced-dispatch refusals answer on the PR.** When the refused candidate is the run's `FORCED_PR` (shepherd conflict lever or a human dispatch), the cap gate posts: the cap value, what stays unhandled (the conflict/feedback that triggered the dispatch), and the two recovery commands — `@qwen-code /retry` (fresh window, same cap) or `@qwen-code /takeover` (raised cap). No dedup by design: the shepherd sends at most one dispatch per head, and a human asking twice deserves two answers. The PR page now reads "🐑 dispatched" → "⏸️ Dispatch refused: … /retry to re-arm" instead of a promise followed by silence.

**2. The cap pause notice covers all managed PRs.** The takeover variant keeps its existing wording; standard bot PRs get their own ("⏸️ AutoFix paused … `/retry` … or `/takeover`"). Same `<!-- takeover-cap-reached -->` marker → same once-per-window dedup, same consent re-check (skip wins everywhere; only the takeover variant requires the label to still be present) and the same PAT-identity convention.

After a re-arm, the next scheduled scan picks the PR up through the normal path (conflict targets are label-independent), so the frozen-head loop resolves without touching the shepherd's dedup.

## Tests

- Census: `takeover-cap-reached` now appears at 3 sites (dedup read + both bodies) — pinned; the ack-body bilingual census grows 12 → 14 (standard pause + refusal), each individually carrying collapsed Chinese.
- Pins: the `FORCED_PR == PR` guard, the refusal marker/wording, DRY-RUN and PAT-identity lines for the refusal path, and both `/retry`-bearing bodies as printf args.
- 103/103 in `qwen-autofix-workflow.test.js` (+ 14/14 package-scripts); workflow YAML parses.

<details>
<summary>中文说明</summary>

## 问题

在 #7836 上完整观测到的链路：bot 自建 PR 于 07-28 06:56 跑满常规上限（10/10），**PR 页面零通知**（暂停通知此前仅限接管 PR）；随后 main 前进产生冲突，fleet shepherd 17:43 发"🐑 已触发 autofix 处理"并 dispatch；扫描在轮次上限门**静默拒绝**（仅 Actions 日志可见），运行绿色收场；shepherd 按 head SHA 去重、而封顶 PR 不会有新推送，head 永不变化——**冲突处理被永久冻结**，页面上却挂着一句承诺。三层静默叠加成一个从任何面板看都"健康"的死局。

## 改动

两处都在 scan 侧（shepherd 一行不动——窗口化轮次计算只有 scan 里一份正确实现，复制即漂移）：

1. **forced dispatch 被拒时在 PR 上回帖**：说明上限值、什么仍未处理、两条恢复命令（`/retry` 重置窗口 / `/takeover` 升上限）。不去重（shepherd 每 head 至多一次 dispatch；人工问两次就答两次）。页面链路变为"🐑 已触发 → ⏸️ 已拒绝 + 怎么办"。
2. **上限暂停通知覆盖全部受管 PR**：接管变体保持原文案，常规 bot PR 新增专属文案（`/retry` 或 `/takeover`）。同一标记 → 同一 once-per-window 去重，同样的 consent 复查（skip 全局优先；仅接管变体要求标签仍在）与 PAT 身份校验。

re-arm 之后由下一次定时扫描按常规路径接手（冲突目标的选取与标签无关），冻结自然解除。

## 测试

标记三处计数 pin；双语正文普查 12 → 14（新增两条均带折叠中文）；FORCED 守卫、拒绝文案、DRY-RUN 与 PAT 身份行、两处 `/retry` printf 参数均有 pin。103/103 + 14/14 通过；YAML 解析正常。

</details>
