### PR TITLE
feat(autofix): per-source feedback budget in Critical-only mode

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -119,6 +119,17 @@ env:
   # changes, failed checks, and base conflicts may drive code changes;
   # lower-severity feedback is recorded and left open.
   CRITICAL_ONLY_AFTER_ROUND: '5'
+  # Per-author tail budget inside Critical-only mode. An account is an
+  # ACCOUNTABILITY unit, not a throttle: a human login can host an automated
+  # reviewer loop with the exact regeneration property the review bot has
+  # (feedback re-generated after every push, at zero marginal cost). So the
+  # brake keys on measured regeneration, not identity: every source gets a
+  # bounded number of untagged feedback batches per counting window once
+  # Critical-only engages — the review bot's budget is zero (all deferred),
+  # a human's is this many CONSUMED batches. Past it, continuing requires
+  # one conscious act (**[Critical]**, a Request changes review, or /retry),
+  # which is precisely what separates intent from automation.
+  CRITICAL_ONLY_HUMAN_BATCHES: '2'
   # An auth/access model error (401/402/403, "no access"/"does not exist")
   # never self-heals - only a maintainer can fix the key - and every retry
   # costs an agent run AND a PR comment. Cap those attempts far below
@@ -2823,6 +2834,47 @@ jobs:
           if [[ "${ROUND}" -ge "${CRITICAL_ONLY_AFTER_ROUND}" ]]; then
             CRITICAL_ONLY='true'
           fi
+          # Which trusted humans have exhausted their per-window regular
+          # feedback budget (see CRITICAL_ONLY_HUMAN_BATCHES). A batch is
+          # COUNTED only when a Critical-only round actually consumed it:
+          # feedback items are bucketed into the (prev marker ts, marker ts]
+          # span that evaluated them, spans are kept only for markers that
+          # ran in Critical-only territory (acted rounds numbered past the
+          # threshold, no-change rounds at it), and an author needs >= K
+          # distinct consumed spans to land here. Fresh, not-yet-evaluated
+          # feedback never counts against its own author, and everything is
+          # window-scoped so a /retry resets the budget with the window.
+          OVER_BUDGET_AUTHORS='[]'
+          if [[ "${CRITICAL_ONLY}" == "true" ]]; then
+            OVER_BUDGET_AUTHORS="$(jq -n \
+              --arg key "${LIVE_REARM_KEY}" --arg ab "${AUTOFIX_BOT}" --arg rb "${REVIEW_BOT}" \
+              --argjson trust "${TRUSTED_ASSOC}" \
+              --argjson r5 "${CRITICAL_ONLY_AFTER_ROUND}" \
+              --argjson k "${CRITICAL_ONLY_HUMAN_BATCHES}" \
+              --slurpfile rv "${WORKDIR}/rv.json" --slurpfile rc "${WORKDIR}/rc.json" --slurpfile ic "${WORKDIR}/ic.json" '
+              ([ ($ic | add)[] | select((.user.login // "") == $ab) | . as $c | ($c.body // "")
+                 | [ scan("<!-- autofix-eval ts=([^ ]+) acted=([^ ]+) round=([0-9]+)(?: win=([^ ]+))? -->") ] | .[]
+                 | {ts: .[0], acted: .[1], round: (.[2] | tonumber), win: (.[3] // "none"), at: ($c.created_at // "")} ]
+               | map(select(.win == $key) | select(.ts != "9999-12-31T23:59:59Z"))
+               | sort_by(.at)) as $ms
+              | ([ range(0; ($ms | length)) as $i
+                   | ($ms[$i]
+                      | select((.acted == "true" and .round > $r5) or (.acted == "false" and .round >= $r5))
+                      | {lo: (if $i == 0 then "" else ($ms[$i - 1].ts) end), hi: .ts}) ]) as $spans
+              | ([ ($rv | add)[] | {at: (.submitted_at // ""), login: (.user.login // ""), assoc: (.author_association // "")} ]
+                 + [ ($rc | add)[] | {at: (.created_at // ""), login: (.user.login // ""), assoc: (.author_association // "")} ]
+                 + [ ($ic | add)[] | select((.body // "") | test("^\\s*@qwen-code /") | not)
+                     | {at: (.created_at // ""), login: (.user.login // ""), assoc: (.author_association // "")} ])
+              | map(select(.login != "" and .login != $ab and .login != $rb) | select(.assoc | IN($trust[])))
+              | [ .[] | . as $c
+                  | ([ $spans[] | select($c.at > .lo and $c.at <= .hi) ] | .[0] // empty)
+                  | {login: $c.login, span: .hi} ]
+              | group_by(.login)
+              | map(select((map(.span) | unique | length) >= $k) | .[0].login)
+              ' 2> /dev/null || echo '[]')"
+            [[ -z "${OVER_BUDGET_AUTHORS}" ]] && OVER_BUDGET_AUTHORS='[]'
+            [[ "${OVER_BUDGET_AUTHORS}" != '[]' ]] && echo "🚦 regular-feedback budget exhausted this window for: $(jq -r 'join(", ")' <<< "${OVER_BUDGET_AUTHORS}")"
+          fi
           echo "stale=${STALE}" >> "${GITHUB_OUTPUT}"
           echo "effective_round=${ROUND}" >> "${GITHUB_OUTPUT}"
 
@@ -2832,27 +2884,27 @@ jobs:
             {
               echo '## Deferred non-Critical feedback'
               echo
-              echo "Critical-only mode is active after ${CRITICAL_ONLY_AFTER_ROUND} change-producing rounds: the automated reviewer's non-Critical suggestions below are deferred and stay open for human follow-up — do not modify code, resolve threads, or reply on their behalf. Maintainer feedback is never deferred. (A maintainer can lift the mode itself: \`@qwen-code /retry\` starts a fresh counting window.)"
+              echo "Critical-only mode is active after ${CRITICAL_ONLY_AFTER_ROUND} change-producing rounds: the automated reviewer's non-Critical suggestions below are deferred and stay open for human follow-up — do not modify code, resolve threads, or reply on their behalf. Maintainer feedback defers only once its author has already had ${CRITICAL_ONLY_HUMAN_BATCHES} regular feedback batches addressed in this window'"'"'s Critical-only tail — an account can host an automated reviewer loop, so the brake keys on measured regeneration, not identity; authors at their budget, if any, are named below. (A maintainer can lift the mode itself: \`@qwen-code /retry\` starts a fresh counting window.)"
               echo
               jq -r --arg wm "${WATERMARK}" --arg rb "${REVIEW_BOT}" --arg ab "${AUTOFIX_BOT}" \
-                --argjson trust "${TRUSTED_ASSOC}" --arg pr_url "${PR_URL}" '
+                --argjson trust "${TRUSTED_ASSOC}" --arg pr_url "${PR_URL}" --argjson over "${OVER_BUDGET_AUTHORS}" '
                 .[]
                 | select((.submitted_at // "") > $wm)
                 | select((.user.login // "") != $ab)
-                | select((.user.login // "") == $rb)
+                | select(((.user.login // "") == $rb) or ((.user.login // "") | IN($over[])))
                 | select((.state // "") == "COMMENTED")
                 | select(((.body // "") | contains("**[Critical]**")) | not)
                 | "- Review by @\(.user.login): \(.html_url // $pr_url)"' \
                 "${WORKDIR}/rv.json"
               jq -rs --arg wm "${WATERMARK}" --arg rb "${REVIEW_BOT}" --arg ab "${AUTOFIX_BOT}" \
-                --argjson trust "${TRUSTED_ASSOC}" --arg pr_url "${PR_URL}" \
+                --argjson trust "${TRUSTED_ASSOC}" --arg pr_url "${PR_URL}" --argjson over "${OVER_BUDGET_AUTHORS}" \
                 --slurpfile reviews "${WORKDIR}/rv.json" '
                 add as $comments
                 | ($reviews | add) as $reviews
                 | $comments[]
                 | select((.created_at // "") > $wm)
                 | select((.user.login // "") != $ab)
-                | select((.user.login // "") == $rb)
+                | select(((.user.login // "") == $rb) or ((.user.login // "") | IN($over[])))
                 | select((
                     ((.body // "") | contains("**[Critical]**"))
                     or ((.in_reply_to_id // null) as $root
@@ -2869,21 +2921,25 @@ jobs:
                 | "- Inline rc:\(.id) \(.path // "?"):\(.line // "?"): \(.html_url // $pr_url)"' \
                 "${WORKDIR}/rc.json"
               jq -r --arg wm "${WATERMARK}" --arg rb "${REVIEW_BOT}" --arg ab "${AUTOFIX_BOT}" \
-                --argjson trust "${TRUSTED_ASSOC}" --arg pr_url "${PR_URL}" '
+                --argjson trust "${TRUSTED_ASSOC}" --arg pr_url "${PR_URL}" --argjson over "${OVER_BUDGET_AUTHORS}" '
                 .[]
                 | select((.created_at // "") > $wm)
                 | select((.user.login // "") != $ab)
-                | select((.user.login // "") == $rb)
+                | select(((.user.login // "") == $rb) or ((.user.login // "") | IN($over[])))
                 | select((.body // "") | test("<!-- (autofix-eval|autofix-rearm|qwen-triage|qwen-review-suggestion-summary|pr-force-push|qwen-review-ack) ") | not)
                 | select((.body // "") | test("^\\s*@qwen-code /") | not)
                 | select(((.body // "") | contains("**[Critical]**")) | not)
                 | "- PR comment by @\(.user.login): \(.html_url // $pr_url)"' \
                 "${WORKDIR}/ic.json"
+              if [[ "${OVER_BUDGET_AUTHORS}" != '[]' ]]; then
+                echo
+                jq -r '.[] | "- @" + . + " is at this window'"'"'s regular-feedback budget — to continue: tag **[Critical]**, submit a Request changes review, or comment `@qwen-code /retry` for a fresh window. / @" + . + " 本窗口常规反馈预算已用完——继续请标 **[Critical]**、提交 Request changes、或评论 `@qwen-code /retry` 开新窗口。"' <<< "${OVER_BUDGET_AUTHORS}"
+              fi
               echo
               echo '<details>'
               echo '<summary>中文说明</summary>'
               echo
-              echo "完成 ${CRITICAL_ONLY_AFTER_ROUND} 个产生改动的轮次后进入仅处理 Critical 的模式：以上为自动评审的非 Critical 建议，予以延后、保持开放并留待人工跟进——不要为其修改代码、解决线程或代为回复。维护者的反馈永远不会被延后。（如需解除该模式，评论 \`@qwen-code /retry\` 即可开启新的计数窗口。）"
+              echo "完成 ${CRITICAL_ONLY_AFTER_ROUND} 个产生改动的轮次后进入仅处理 Critical 的模式：以上为自动评审的非 Critical 建议，予以延后、保持开放并留待人工跟进——不要为其修改代码、解决线程或代为回复。维护者的反馈仅在其本人于本窗口 Critical-only 阶段已被处理 ${CRITICAL_ONLY_HUMAN_BATCHES} 批常规反馈之后才会被延后——账号可能挂着自动评审循环，因此刹车依据实测的再生频度而非身份；达到预算的作者（如有）在下方点名。（如需解除该模式，评论 \`@qwen-code /retry\` 即可开启新的计数窗口。）"
               echo
               echo '</details>'
             } > "${WORKDIR}/deferred-feedback.md"
@@ -2900,14 +2956,15 @@ jobs:
             echo
             echo "## Reviews"
             jq -r --arg wm "${WATERMARK}" --arg rb "${REVIEW_BOT}" --arg ab "${AUTOFIX_BOT}" \
-              --argjson critical_only "${CRITICAL_ONLY}" --argjson trust "${TRUSTED_ASSOC}" '
+              --argjson critical_only "${CRITICAL_ONLY}" --argjson trust "${TRUSTED_ASSOC}" \
+              --argjson over "${OVER_BUDGET_AUTHORS}" '
               .[]
               | select((.submitted_at // "") > $wm)
               | select((.user.login // "") != $ab)
               | select(((.author_association // "") | IN($trust[])) or (.user.login // "") == $rb)
               | select((.state // "") | IN("CHANGES_REQUESTED", "COMMENTED"))
               | select(($critical_only | not)
-                  or ((.user.login // "") != $rb)
+                  or (((.user.login // "") != $rb) and (((.user.login // "") | IN($over[])) | not))
                   or (.state // "") == "CHANGES_REQUESTED"
                   or ((.body // "") | contains("**[Critical]**")))
               | "- [\(.state)] @\(.user.login): \(.body // "" | gsub("\r"; ""))"' \
@@ -2916,6 +2973,7 @@ jobs:
             echo "## Inline comments"
             jq -rs --arg wm "${WATERMARK}" --arg rb "${REVIEW_BOT}" --arg ab "${AUTOFIX_BOT}" \
               --argjson critical_only "${CRITICAL_ONLY}" --argjson trust "${TRUSTED_ASSOC}" \
+              --argjson over "${OVER_BUDGET_AUTHORS}" \
               --slurpfile reviews "${WORKDIR}/rv.json" '
               add as $comments
               | ($reviews | add) as $reviews
@@ -2924,7 +2982,7 @@ jobs:
               | select((.user.login // "") != $ab)
               | select(((.author_association // "") | IN($trust[])) or (.user.login // "") == $rb)
               | select(($critical_only | not)
-                  or ((.user.login // "") != $rb)
+                  or (((.user.login // "") != $rb) and (((.user.login // "") | IN($over[])) | not))
                   or ((.body // "") | contains("**[Critical]**"))
                   or ((.in_reply_to_id // null) as $root
                     | $root != null
@@ -2941,7 +2999,8 @@ jobs:
             echo
             echo "## Issue-level comments"
             jq -r --arg wm "${WATERMARK}" --arg rb "${REVIEW_BOT}" --arg ab "${AUTOFIX_BOT}" \
-              --argjson critical_only "${CRITICAL_ONLY}" --argjson trust "${TRUSTED_ASSOC}" '
+              --argjson critical_only "${CRITICAL_ONLY}" --argjson trust "${TRUSTED_ASSOC}" \
+              --argjson over "${OVER_BUDGET_AUTHORS}" '
               .[]
               | select((.created_at // "") > $wm)
               | select((.user.login // "") != $ab)
@@ -2949,7 +3008,7 @@ jobs:
               | select((.body // "") | test("<!-- (autofix-eval|autofix-rearm|qwen-triage|qwen-review-suggestion-summary|pr-force-push|qwen-review-ack) ") | not)
                 | select((.body // "") | test("^\\s*@qwen-code /") | not)
               | select(($critical_only | not)
-                  or ((.user.login // "") != $rb)
+                  or (((.user.login // "") != $rb) and (((.user.login // "") | IN($over[])) | not))
                   or ((.body // "") | contains("**[Critical]**")))
               | "- @\(.user.login): \(.body // "" | gsub("\r"; ""))"' \
               "${WORKDIR}/ic.json"

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2949,6 +2949,11 @@ jobs:
           # distinct consumed spans to land here. Fresh, not-yet-evaluated
           # feedback never counts against its own author, and everything is
           # window-scoped so a /retry resets the budget with the window.
+          # Only feedback the deferred renderer below would actually defer is
+          # counted: Critical-tagged items, Request changes / APPROVED reviews,
+          # and inline comments rooted at a Critical comment or attached to a
+          # Request changes review are never deferrable, so they must not burn
+          # an author's budget — the item filter mirrors those predicates.
           OVER_BUDGET_AUTHORS='[]'
           if [[ "${CRITICAL_ONLY}" == "true" ]]; then
             OVER_BUDGET_AUTHORS="$(jq -n \
@@ -2966,10 +2971,28 @@ jobs:
                    | ($ms[$i]
                       | select((.acted == "true" and .round > $r5) or (.acted == "false" and .round >= $r5))
                       | {lo: (if $i == 0 then "" else ($ms[$i - 1].ts) end), hi: .ts}) ]) as $spans
-              | ([ ($rv | add)[] | {at: (.submitted_at // ""), login: (.user.login // ""), assoc: (.author_association // "")} ]
-                 + [ ($rc | add)[] | {at: (.created_at // ""), login: (.user.login // ""), assoc: (.author_association // "")} ]
-                 + [ ($ic | add)[] | select((.body // "") | test("^\\s*@qwen-code /") | not)
-                     | {at: (.created_at // ""), login: (.user.login // ""), assoc: (.author_association // "")} ])
+              | ($rv | add) as $reviews
+              | ($rc | add) as $comments
+              | ([ $reviews[]
+                   | select((.state // "") == "COMMENTED")
+                   | select(((.body // "") | contains("**[Critical]**")) | not)
+                   | {at: (.submitted_at // ""), login: (.user.login // ""), assoc: (.author_association // "")} ]
+                 + [ $comments[]
+                   | select((
+                       ((.body // "") | contains("**[Critical]**"))
+                       or ((.in_reply_to_id // null) as $root
+                         | $root != null
+                         and any($comments[]; .id == $root and ((.body // "") | contains("**[Critical]**"))))
+                       or ((.pull_request_review_id // null) as $review
+                         | $review != null
+                         and any($reviews[]; .id == $review and ((.state // "") == "CHANGES_REQUESTED")))
+                     ) | not)
+                   | {at: (.created_at // ""), login: (.user.login // ""), assoc: (.author_association // "")} ]
+                 + [ ($ic | add)[]
+                   | select((.body // "") | test("<!-- (autofix-eval|autofix-rearm|qwen-triage|qwen-review-suggestion-summary|pr-force-push|qwen-review-ack) ") | not)
+                   | select((.body // "") | test("^\\s*@qwen-code /") | not)
+                   | select(((.body // "") | contains("**[Critical]**")) | not)
+                   | {at: (.created_at // ""), login: (.user.login // ""), assoc: (.author_association // "")} ])
               | map(select(.login != "" and .login != $ab and .login != $rb) | select(.assoc | IN($trust[])))
               | [ .[] | . as $c
                   | ([ $spans[] | select($c.at > .lo and $c.at <= .hi) ] | .[0] // empty)

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2832,14 +2832,14 @@ jobs:
             {
               echo '## Deferred non-Critical feedback'
               echo
-              echo "Critical-only mode is active after ${CRITICAL_ONLY_AFTER_ROUND} change-producing rounds. Any items listed below stay open for human follow-up; do not modify code, resolve threads, or reply on their behalf."
+              echo "Critical-only mode is active after ${CRITICAL_ONLY_AFTER_ROUND} change-producing rounds: the automated reviewer's non-Critical suggestions below are deferred and stay open for human follow-up — do not modify code, resolve threads, or reply on their behalf. Maintainer feedback is never deferred. (A maintainer can lift the mode itself: \`@qwen-code /retry\` starts a fresh counting window.)"
               echo
               jq -r --arg wm "${WATERMARK}" --arg rb "${REVIEW_BOT}" --arg ab "${AUTOFIX_BOT}" \
                 --argjson trust "${TRUSTED_ASSOC}" --arg pr_url "${PR_URL}" '
                 .[]
                 | select((.submitted_at // "") > $wm)
                 | select((.user.login // "") != $ab)
-                | select(((.author_association // "") | IN($trust[])) or (.user.login // "") == $rb)
+                | select((.user.login // "") == $rb)
                 | select((.state // "") == "COMMENTED")
                 | select(((.body // "") | contains("**[Critical]**")) | not)
                 | "- Review by @\(.user.login): \(.html_url // $pr_url)"' \
@@ -2852,7 +2852,7 @@ jobs:
                 | $comments[]
                 | select((.created_at // "") > $wm)
                 | select((.user.login // "") != $ab)
-                | select(((.author_association // "") | IN($trust[])) or (.user.login // "") == $rb)
+                | select((.user.login // "") == $rb)
                 | select((
                     ((.body // "") | contains("**[Critical]**"))
                     or ((.in_reply_to_id // null) as $root
@@ -2873,7 +2873,7 @@ jobs:
                 .[]
                 | select((.created_at // "") > $wm)
                 | select((.user.login // "") != $ab)
-                | select(((.author_association // "") | IN($trust[])) or (.user.login // "") == $rb)
+                | select((.user.login // "") == $rb)
                 | select((.body // "") | test("<!-- (autofix-eval|autofix-rearm|qwen-triage|qwen-review-suggestion-summary|pr-force-push|qwen-review-ack) ") | not)
                 | select((.body // "") | test("^\\s*@qwen-code /") | not)
                 | select(((.body // "") | contains("**[Critical]**")) | not)
@@ -2883,7 +2883,7 @@ jobs:
               echo '<details>'
               echo '<summary>中文说明</summary>'
               echo
-              echo "完成 ${CRITICAL_ONLY_AFTER_ROUND} 个产生改动的轮次后，进入仅处理 Critical 的模式。以上内容保持开放，留待人工跟进；不要为其修改代码、解决线程或代为回复。"
+              echo "完成 ${CRITICAL_ONLY_AFTER_ROUND} 个产生改动的轮次后进入仅处理 Critical 的模式：以上为自动评审的非 Critical 建议，予以延后、保持开放并留待人工跟进——不要为其修改代码、解决线程或代为回复。维护者的反馈永远不会被延后。（如需解除该模式，评论 \`@qwen-code /retry\` 即可开启新的计数窗口。）"
               echo
               echo '</details>'
             } > "${WORKDIR}/deferred-feedback.md"
@@ -2907,6 +2907,7 @@ jobs:
               | select(((.author_association // "") | IN($trust[])) or (.user.login // "") == $rb)
               | select((.state // "") | IN("CHANGES_REQUESTED", "COMMENTED"))
               | select(($critical_only | not)
+                  or ((.user.login // "") != $rb)
                   or (.state // "") == "CHANGES_REQUESTED"
                   or ((.body // "") | contains("**[Critical]**")))
               | "- [\(.state)] @\(.user.login): \(.body // "" | gsub("\r"; ""))"' \
@@ -2923,6 +2924,7 @@ jobs:
               | select((.user.login // "") != $ab)
               | select(((.author_association // "") | IN($trust[])) or (.user.login // "") == $rb)
               | select(($critical_only | not)
+                  or ((.user.login // "") != $rb)
                   or ((.body // "") | contains("**[Critical]**"))
                   or ((.in_reply_to_id // null) as $root
                     | $root != null
@@ -2947,6 +2949,7 @@ jobs:
               | select((.body // "") | test("<!-- (autofix-eval|autofix-rearm|qwen-triage|qwen-review-suggestion-summary|pr-force-push|qwen-review-ack) ") | not)
                 | select((.body // "") | test("^\\s*@qwen-code /") | not)
               | select(($critical_only | not)
+                  or ((.user.login // "") != $rb)
                   or ((.body // "") | contains("**[Critical]**")))
               | "- @\(.user.login): \(.body // "" | gsub("\r"; ""))"' \
               "${WORKDIR}/ic.json"

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2989,10 +2989,10 @@ jobs:
             {
               echo '## Deferred non-Critical feedback'
               echo
-              echo "Critical-only mode is active after ${CRITICAL_ONLY_AFTER_ROUND} change-producing rounds: the automated reviewer's non-Critical suggestions below are deferred and stay open for human follow-up — do not modify code, resolve threads, or reply on their behalf. Maintainer feedback defers only once its author has already had ${CRITICAL_ONLY_HUMAN_BATCHES} regular feedback batches addressed in this window'"'"'s Critical-only tail — an account can host an automated reviewer loop, so the brake keys on measured regeneration, not identity; authors at their budget, if any, are named below. (A maintainer can lift the mode itself: \`@qwen-code /retry\` starts a fresh counting window.)"
+              echo "Critical-only mode is active after ${CRITICAL_ONLY_AFTER_ROUND} change-producing rounds: the automated reviewer's non-Critical suggestions below are deferred and stay open for human follow-up — do not modify code, resolve threads, or reply on their behalf. Maintainer feedback defers only once its author has already had ${CRITICAL_ONLY_HUMAN_BATCHES} regular feedback batches addressed in this window's Critical-only tail — an account can host an automated reviewer loop, so the brake keys on measured regeneration, not identity; authors at their budget, if any, are named below. (A maintainer can lift the mode itself: \`@qwen-code /retry\` starts a fresh counting window.)"
               echo
               jq -r --arg wm "${WATERMARK}" --arg rb "${REVIEW_BOT}" --arg ab "${AUTOFIX_BOT}" \
-                --argjson trust "${TRUSTED_ASSOC}" --arg pr_url "${PR_URL}" --argjson over "${OVER_BUDGET_AUTHORS}" '
+                --arg pr_url "${PR_URL}" --argjson over "${OVER_BUDGET_AUTHORS}" '
                 .[]
                 | select((.submitted_at // "") > $wm)
                 | select((.user.login // "") != $ab)
@@ -3002,7 +3002,7 @@ jobs:
                 | "- Review by @\(.user.login): \(.html_url // $pr_url)"' \
                 "${WORKDIR}/rv.json"
               jq -rs --arg wm "${WATERMARK}" --arg rb "${REVIEW_BOT}" --arg ab "${AUTOFIX_BOT}" \
-                --argjson trust "${TRUSTED_ASSOC}" --arg pr_url "${PR_URL}" --argjson over "${OVER_BUDGET_AUTHORS}" \
+                --arg pr_url "${PR_URL}" --argjson over "${OVER_BUDGET_AUTHORS}" \
                 --slurpfile reviews "${WORKDIR}/rv.json" '
                 add as $comments
                 | ($reviews | add) as $reviews
@@ -3026,7 +3026,7 @@ jobs:
                 | "- Inline rc:\(.id) \(.path // "?"):\(.line // "?"): \(.html_url // $pr_url)"' \
                 "${WORKDIR}/rc.json"
               jq -r --arg wm "${WATERMARK}" --arg rb "${REVIEW_BOT}" --arg ab "${AUTOFIX_BOT}" \
-                --argjson trust "${TRUSTED_ASSOC}" --arg pr_url "${PR_URL}" --argjson over "${OVER_BUDGET_AUTHORS}" '
+                --arg pr_url "${PR_URL}" --argjson over "${OVER_BUDGET_AUTHORS}" '
                 .[]
                 | select((.created_at // "") > $wm)
                 | select((.user.login // "") != $ab)

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2976,7 +2976,7 @@ jobs:
                   | {login: $c.login, span: .hi} ]
               | group_by(.login)
               | map(select((map(.span) | unique | length) >= $k) | .[0].login)
-              ' 2> /dev/null || echo '[]')"
+              ' || echo '[]')"
             [[ -z "${OVER_BUDGET_AUTHORS}" ]] && OVER_BUDGET_AUTHORS='[]'
             [[ "${OVER_BUDGET_AUTHORS}" != '[]' ]] && echo "🚦 regular-feedback budget exhausted this window for: $(jq -r 'join(", ")' <<< "${OVER_BUDGET_AUTHORS}")"
           fi

--- a/.qwen/skills/autofix/SKILL.md
+++ b/.qwen/skills/autofix/SKILL.md
@@ -206,9 +206,11 @@ implement — satisfying a nit is never a reason to bloat the code.
   `Deferred non-Critical feedback` section, the PR has already completed five
   suggestion-capable, change-producing rounds. That section is an audit record,
   not work: do not modify code, resolve threads, or write comment replies for
-  those items. Act only on Critical feedback and formally requested changes
-  rendered in the actionable sections, failed checks, and the requested
-  base-conflict resolution.
+  those items. Everything rendered in the actionable sections IS in scope —
+  the deterministic filter defers only the automated reviewer's non-Critical
+  suggestions, and maintainer feedback is never deferred (a maintainer writing
+  "fix X before merge" after round five means exactly that) — plus failed
+  checks and the requested base-conflict resolution.
 - Needs a maintainer's decision: a finding that turns on a judgment that is
   NOT yours to make — a product or scope tradeoff (is this acceptable for v1?
   should the PR be split?), two reviewers asking for opposite things, or whether

--- a/.qwen/skills/autofix/SKILL.md
+++ b/.qwen/skills/autofix/SKILL.md
@@ -207,10 +207,13 @@ implement — satisfying a nit is never a reason to bloat the code.
   suggestion-capable, change-producing rounds. That section is an audit record,
   not work: do not modify code, resolve threads, or write comment replies for
   those items. Everything rendered in the actionable sections IS in scope —
-  the deterministic filter defers only the automated reviewer's non-Critical
-  suggestions, and maintainer feedback is never deferred (a maintainer writing
-  "fix X before merge" after round five means exactly that) — plus failed
-  checks and the requested base-conflict resolution.
+  the deterministic filter defers the automated reviewer's non-Critical
+  suggestions and, past a small per-window budget of already-addressed
+  batches, a human author's untagged feedback too (an account can host an
+  automated reviewer loop, so the brake keys on measured regeneration, not
+  identity). A maintainer writing "fix X before merge" after round five
+  means exactly that when it reaches you — plus failed checks and the
+  requested base-conflict resolution.
 - Needs a maintainer's decision: a finding that turns on a judgment that is
   NOT yours to make — a product or scope tradeoff (is this acceptable for v1?
   should the PR be split?), two reviewers asking for opposite things, or whether

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -254,7 +254,12 @@ describe('qwen-autofix workflow', () => {
       encoding: 'utf8',
       input: runBlock.replace(/^ {10}/gm, ''),
     });
-    expect(res.status).toBe(0);
+    // Surface bash's syntax error on failure, not just `expected 2 to be 0`:
+    // this test exists precisely to diagnose quoting breakage.
+    expect({ status: res.status, stderr: res.stderr }).toEqual({
+      status: 0,
+      stderr: '',
+    });
   });
 
   it('runs scheduled autofix as a 10-minute multi-target fan-out worker', () => {
@@ -4038,6 +4043,12 @@ describe('qwen-autofix workflow', () => {
     // looped reviewer with two CONSUMED batches in the Critical-only tail
     // is listed; one batch, pre-Critical batches, unconsumed (fresh)
     // feedback, untrusted authors, and command comments never count.
+    // Never-deferrable feedback must not burn budget either, mirroring the
+    // deferred renderer: Critical-tagged comments, Request changes / APPROVED
+    // reviews, inline replies rooted at a Critical comment, and inline comments
+    // under a Request changes review all stay absent (crit/cr/appr/replyguy/
+    // crinline). The review bot stays absent even as a trusted MEMBER, and a
+    // sentinel-ts marker opens no span (sentinelvictim stays at one batch).
     expect(workflow).toContain("CRITICAL_ONLY_HUMAN_BATCHES: '2'");
     const censusBlock = prepareBranchAndFeedbackStep.match(
       /OVER_BUDGET_AUTHORS="\$\(jq -n[\s\S]*?' \|\| echo '\[\]'\)"/,
@@ -4071,6 +4082,10 @@ describe('qwen-autofix workflow', () => {
             '2026-06-15T01:00:00Z',
             '2026-06-01T00:00:00Z',
           ),
+          // Sentinel-ts marker: filtered out, so it opens no span. Dropping
+          // the guard would open a (2026-07-04, 9999] span that absorbs
+          // sentinelvictim's second batch below and surface them.
+          markerC('9999-12-31T23:59:59Z', 'true', 6, '2026-07-04T02:00:00Z'),
           humanC('looper', '2026-07-02T12:00:00Z'),
           humanC('looper', '2026-07-03T12:00:00Z'),
           humanC('onetime', '2026-07-03T13:00:00Z'),
@@ -4101,6 +4116,40 @@ describe('qwen-autofix workflow', () => {
             'MEMBER',
             '@qwen-code /retry',
           ),
+          // Critical-only author: both batches are **[Critical]**-tagged, so
+          // they are never deferrable and must not count (absent). Dropping the
+          // Critical exclusion would surface them.
+          humanC(
+            'crit',
+            '2026-07-02T15:00:00Z',
+            'MEMBER',
+            '**[Critical]** fix X',
+          ),
+          humanC(
+            'crit',
+            '2026-07-03T15:00:00Z',
+            'MEMBER',
+            '**[Critical]** still broken',
+          ),
+          // Review bot, even carrying a trusted association, is excluded by
+          // login (its budget is zero). Dropping `.login != $rb` surfaces it.
+          humanC(
+            'qwen-code-ci-bot',
+            '2026-07-02T18:00:00Z',
+            'MEMBER',
+            'bot suggestion',
+          ),
+          humanC(
+            'qwen-code-ci-bot',
+            '2026-07-03T18:00:00Z',
+            'MEMBER',
+            'bot suggestion 2',
+          ),
+          // Sentinel-span probe: the first batch lands in span B; the second
+          // falls after span B and only counts if the sentinel marker above
+          // wrongly opens a span. With the guard, stays at one batch (absent).
+          humanC('sentinelvictim', '2026-07-03T12:30:00Z'),
+          humanC('sentinelvictim', '2026-07-04T12:00:00Z'),
         ]),
       );
       // A second author whose two consumed batches arrive through the review
@@ -4116,6 +4165,47 @@ describe('qwen-autofix workflow', () => {
             submitted_at: '2026-07-02T12:30:00Z',
             body: 'feedback delivered through a review',
           },
+          // Request changes / APPROVED reviews are never deferrable, so two
+          // consumed-span batches of each must not count (both authors absent):
+          // the census mirrors the deferred renderer's `state == "COMMENTED"`.
+          {
+            user: { login: 'cr' },
+            author_association: 'MEMBER',
+            state: 'CHANGES_REQUESTED',
+            submitted_at: '2026-07-02T16:00:00Z',
+            body: 'changes requested',
+          },
+          {
+            user: { login: 'cr' },
+            author_association: 'MEMBER',
+            state: 'CHANGES_REQUESTED',
+            submitted_at: '2026-07-03T16:00:00Z',
+            body: 'changes requested again',
+          },
+          {
+            user: { login: 'appr' },
+            author_association: 'MEMBER',
+            state: 'APPROVED',
+            submitted_at: '2026-07-02T17:00:00Z',
+            body: 'lgtm',
+          },
+          {
+            user: { login: 'appr' },
+            author_association: 'MEMBER',
+            state: 'APPROVED',
+            submitted_at: '2026-07-03T17:00:00Z',
+            body: 'lgtm again',
+          },
+          // Request changes review container (id 801) that the crinline
+          // comments below attach to; itself never deferrable.
+          {
+            id: 801,
+            user: { login: 'crreviewer' },
+            author_association: 'MEMBER',
+            state: 'CHANGES_REQUESTED',
+            submitted_at: '2026-07-02T10:00:00Z',
+            body: 'requesting changes',
+          },
         ]),
       );
       writeFileSync(
@@ -4126,6 +4216,47 @@ describe('qwen-autofix workflow', () => {
             author_association: 'MEMBER',
             created_at: '2026-07-03T13:30:00Z',
             body: 'feedback delivered through an inline comment',
+          },
+          // Critical root comment (id 901) that replyguy's replies attach to.
+          {
+            id: 901,
+            user: { login: 'somecrit' },
+            author_association: 'MEMBER',
+            created_at: '2026-07-02T11:00:00Z',
+            body: '**[Critical]** root finding',
+          },
+          // Inline replies rooted at a Critical comment are never deferrable,
+          // so two consumed-span replies must not count (replyguy absent).
+          {
+            user: { login: 'replyguy' },
+            author_association: 'MEMBER',
+            in_reply_to_id: 901,
+            created_at: '2026-07-02T12:45:00Z',
+            body: 'me too',
+          },
+          {
+            user: { login: 'replyguy' },
+            author_association: 'MEMBER',
+            in_reply_to_id: 901,
+            created_at: '2026-07-03T12:45:00Z',
+            body: 'me too again',
+          },
+          // Inline comments under a Request changes review are never
+          // deferrable, so two consumed-span comments must not count
+          // (crinline absent).
+          {
+            user: { login: 'crinline' },
+            author_association: 'MEMBER',
+            pull_request_review_id: 801,
+            created_at: '2026-07-02T13:45:00Z',
+            body: 'inline under CR review',
+          },
+          {
+            user: { login: 'crinline' },
+            author_association: 'MEMBER',
+            pull_request_review_id: 801,
+            created_at: '2026-07-03T13:45:00Z',
+            body: 'inline under CR review 2',
           },
         ]),
       );
@@ -4148,6 +4279,10 @@ describe('qwen-autofix workflow', () => {
         ],
         { encoding: 'utf8' },
       );
+      // Only the two looped authors land here; every protected author above
+      // (crit/cr/appr/replyguy/crinline/qwen-code-ci-bot/sentinelvictim) has
+      // two consumed-span batches yet stays absent — dropping any one of the
+      // census's deferral-mirroring exclusions surfaces one of them and fails.
       expect(JSON.parse(overOut)).toEqual(['looper', 'reviewer2']);
     } finally {
       rmSync(budgetDir, { recursive: true, force: true });

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -2295,8 +2295,11 @@ describe('qwen-autofix workflow', () => {
     // invocations never burn an agent cycle on a no-action report.
     expect(reviewScanJob).toContain("COMMAND_FILTER='^\\s*@qwen-code /'");
     expect(reviewScanJob).toContain('test($cf) | not');
+    // Five sites now: the four feedback/deferral exclusions plus the
+    // over-budget census, which must not count command comments as
+    // feedback batches either.
     expect(workflow.split('test("^\\\\s*@qwen-code /") | not').length - 1).toBe(
-      4,
+      5,
     );
   });
 
@@ -3289,7 +3292,7 @@ describe('qwen-autofix workflow', () => {
         state: 'CHANGES_REQUESTED',
       },
     ];
-    const countInline = (criticalOnly) =>
+    const countInline = (criticalOnly, over = []) =>
       Number(
         execFileSync(
           'jq',
@@ -3311,6 +3314,9 @@ describe('qwen-autofix workflow', () => {
             'trust',
             '["OWNER","MEMBER","COLLABORATOR"]',
             '--argjson',
+            'over',
+            JSON.stringify(over),
+            '--argjson',
             'reviews',
             JSON.stringify([reviews]),
             `[\n${inlineFilter}\n] | length`,
@@ -3329,12 +3335,17 @@ describe('qwen-autofix workflow', () => {
     // "fix 1 and 3 before merge" was deferred wholesale as one
     // 'non-Critical item' and the agent never read it.
     expect(countInline(true)).toBe(4);
+    // …until that maintainer exhausts the per-window budget: an account can
+    // host an automated reviewer loop, so past K consumed batches their
+    // untagged feedback defers like the bot's. The tagged/CR escapes stay:
+    // the reply-to-Critical (14) and CR-review (15) items survive.
+    expect(countInline(true, ['maintainer'])).toBe(3);
 
     // Actionable reviews and issue-level comments filters: extract and
     // execute against fixture data with critical_only both ways, mirroring
     // the inline filter test above.
     const actionableReviewsFilter = prepareBranchAndFeedbackStep.match(
-      /echo "## Reviews"[\s\S]*?jq -r --arg wm "\$\{WATERMARK\}" --arg rb "\$\{REVIEW_BOT\}" --arg ab "\$\{AUTOFIX_BOT\}" \\\n\s+--argjson critical_only "\$\{CRITICAL_ONLY\}" --argjson trust "\$\{TRUSTED_ASSOC\}" '([\s\S]*?)' \\\n\s+"\$\{WORKDIR\}\/rv\.json"/,
+      /echo "## Reviews"[\s\S]*?jq -r --arg wm "\$\{WATERMARK\}" --arg rb "\$\{REVIEW_BOT\}" --arg ab "\$\{AUTOFIX_BOT\}" \\\n\s+--argjson critical_only "\$\{CRITICAL_ONLY\}" --argjson trust "\$\{TRUSTED_ASSOC\}" \\\n\s+--argjson over "\$\{OVER_BUDGET_AUTHORS\}" '([\s\S]*?)' \\\n\s+"\$\{WORKDIR\}\/rv\.json"/,
     )?.[1];
     expect(actionableReviewsFilter).toBeTruthy();
     const actionableReviews = [
@@ -3371,7 +3382,7 @@ describe('qwen-autofix workflow', () => {
         body: 'I verified locally; please fix findings 1 and 3 before merge.',
       },
     ];
-    const countActionableReviews = (criticalOnly) =>
+    const countActionableReviews = (criticalOnly, over = []) =>
       Number(
         execFileSync(
           'jq',
@@ -3391,6 +3402,9 @@ describe('qwen-autofix workflow', () => {
             '--argjson',
             'trust',
             '["OWNER","MEMBER","COLLABORATOR"]',
+            '--argjson',
+            'over',
+            JSON.stringify(over),
             `[${actionableReviewsFilter}] | length`,
           ],
           { encoding: 'utf8', input: JSON.stringify(actionableReviews) },
@@ -3401,9 +3415,12 @@ describe('qwen-autofix workflow', () => {
     // excluded — the maintainer's COMMENTED review stays actionable.
     expect(countActionableReviews(false)).toBe(4);
     expect(countActionableReviews(true)).toBe(3);
+    // Over-budget: the maintainer's COMMENTED review defers; their formal
+    // CHANGES_REQUESTED (20) still cuts through.
+    expect(countActionableReviews(true, ['maintainer'])).toBe(2);
 
     const actionableIssueFilter = prepareBranchAndFeedbackStep.match(
-      /echo "## Issue-level comments"[\s\S]*?jq -r --arg wm "\$\{WATERMARK\}" --arg rb "\$\{REVIEW_BOT\}" --arg ab "\$\{AUTOFIX_BOT\}" \\\n\s+--argjson critical_only "\$\{CRITICAL_ONLY\}" --argjson trust "\$\{TRUSTED_ASSOC\}" '([\s\S]*?)' \\\n\s+"\$\{WORKDIR\}\/ic\.json"/,
+      /echo "## Issue-level comments"[\s\S]*?jq -r --arg wm "\$\{WATERMARK\}" --arg rb "\$\{REVIEW_BOT\}" --arg ab "\$\{AUTOFIX_BOT\}" \\\n\s+--argjson critical_only "\$\{CRITICAL_ONLY\}" --argjson trust "\$\{TRUSTED_ASSOC\}" \\\n\s+--argjson over "\$\{OVER_BUDGET_AUTHORS\}" '([\s\S]*?)' \\\n\s+"\$\{WORKDIR\}\/ic\.json"/,
     )?.[1];
     expect(actionableIssueFilter).toBeTruthy();
     const actionableIssueComments = [
@@ -3429,7 +3446,7 @@ describe('qwen-autofix workflow', () => {
         body: '@qwen-code /review',
       },
     ];
-    const countActionableIssue = (criticalOnly) =>
+    const countActionableIssue = (criticalOnly, over = []) =>
       Number(
         execFileSync(
           'jq',
@@ -3449,6 +3466,9 @@ describe('qwen-autofix workflow', () => {
             '--argjson',
             'trust',
             '["OWNER","MEMBER","COLLABORATOR"]',
+            '--argjson',
+            'over',
+            JSON.stringify(over),
             `[${actionableIssueFilter}] | length`,
           ],
           { encoding: 'utf8', input: JSON.stringify(actionableIssueComments) },
@@ -3460,11 +3480,14 @@ describe('qwen-autofix workflow', () => {
     // Critical one — only bot non-Critical output is filtered.
     expect(countActionableIssue(false)).toBe(2);
     expect(countActionableIssue(true)).toBe(2);
+    // Over-budget: the plain comment defers; the bot's **[Critical]** (31)
+    // still counts.
+    expect(countActionableIssue(true, ['maintainer'])).toBe(1);
 
     // Deferred queries: extract and execute against fixture data,
     // mirroring the actionable inline filter test above.
     const deferredReviewsFilter = prepareBranchAndFeedbackStep.match(
-      /## Deferred non-Critical feedback[\s\S]*?jq -r --arg wm "\$\{WATERMARK\}" --arg rb "\$\{REVIEW_BOT\}" --arg ab "\$\{AUTOFIX_BOT\}" \\\n\s+--argjson trust "\$\{TRUSTED_ASSOC\}" --arg pr_url "\$\{PR_URL\}" '([\s\S]*?)' \\\n\s+"\$\{WORKDIR\}\/rv\.json"/,
+      /## Deferred non-Critical feedback[\s\S]*?jq -r --arg wm "\$\{WATERMARK\}" --arg rb "\$\{REVIEW_BOT\}" --arg ab "\$\{AUTOFIX_BOT\}" \\\n\s+--argjson trust "\$\{TRUSTED_ASSOC\}" --arg pr_url "\$\{PR_URL\}" --argjson over "\$\{OVER_BUDGET_AUTHORS\}" '([\s\S]*?)' \\\n\s+"\$\{WORKDIR\}\/rv\.json"/,
     )?.[1];
     expect(deferredReviewsFilter).toBeTruthy();
     const deferredReviews = [
@@ -3497,75 +3520,87 @@ describe('qwen-autofix workflow', () => {
         html_url: 'https://github.com/test/pull/1#review-23',
       },
     ];
-    const countDeferredReviews = Number(
-      execFileSync(
-        'jq',
-        [
-          '--arg',
-          'wm',
-          '2026-01-01T00:00:00Z',
-          '--arg',
-          'rb',
-          'qwen-code-ci-bot',
-          '--arg',
-          'ab',
-          'qwen-code-dev-bot',
-          '--argjson',
-          'trust',
-          '["OWNER","MEMBER","COLLABORATOR"]',
-          '--arg',
-          'pr_url',
-          'https://github.com/test/pull/1',
-          `[${deferredReviewsFilter}] | length`,
-        ],
-        { encoding: 'utf8', input: JSON.stringify(deferredReviews) },
-      ),
-    );
+    const countDeferredReviews = (over = []) =>
+      Number(
+        execFileSync(
+          'jq',
+          [
+            '--arg',
+            'wm',
+            '2026-01-01T00:00:00Z',
+            '--arg',
+            'rb',
+            'qwen-code-ci-bot',
+            '--arg',
+            'ab',
+            'qwen-code-dev-bot',
+            '--argjson',
+            'trust',
+            '["OWNER","MEMBER","COLLABORATOR"]',
+            '--arg',
+            'pr_url',
+            'https://github.com/test/pull/1',
+            '--argjson',
+            'over',
+            JSON.stringify(over),
+            `[${deferredReviewsFilter}] | length`,
+          ],
+          { encoding: 'utf8', input: JSON.stringify(deferredReviews) },
+        ),
+      );
     // Only the BOT's COMMENTED non-Critical review is deferred;
     // CHANGES_REQUESTED, COMMENTED-Critical, and the MAINTAINER's
     // COMMENTED review are not.
-    expect(countDeferredReviews).toBe(1);
+    expect(countDeferredReviews()).toBe(1);
+    expect(countDeferredReviews(['maintainer'])).toBe(2);
 
     const deferredInlineFilter = prepareBranchAndFeedbackStep.match(
-      /jq -rs --arg wm "\$\{WATERMARK\}" --arg rb "\$\{REVIEW_BOT\}" --arg ab "\$\{AUTOFIX_BOT\}" \\\n\s+--argjson trust "\$\{TRUSTED_ASSOC\}" --arg pr_url "\$\{PR_URL\}" \\\n\s+--slurpfile reviews "\$\{WORKDIR\}\/rv\.json" '([\s\S]*?)' \\\n\s+"\$\{WORKDIR\}\/rc\.json"/,
+      /jq -rs --arg wm "\$\{WATERMARK\}" --arg rb "\$\{REVIEW_BOT\}" --arg ab "\$\{AUTOFIX_BOT\}" \\\n\s+--argjson trust "\$\{TRUSTED_ASSOC\}" --arg pr_url "\$\{PR_URL\}" --argjson over "\$\{OVER_BUDGET_AUTHORS\}" \\\n\s+--slurpfile reviews "\$\{WORKDIR\}\/rv\.json" '([\s\S]*?)' \\\n\s+"\$\{WORKDIR\}\/rc\.json"/,
     )?.[1];
     expect(deferredInlineFilter).toBeTruthy();
-    const countDeferredInline = Number(
-      execFileSync(
-        'jq',
-        [
-          '-s',
-          '--arg',
-          'wm',
-          '2026-01-01T00:00:00Z',
-          '--arg',
-          'rb',
-          'qwen-code-ci-bot',
-          '--arg',
-          'ab',
-          'qwen-code-dev-bot',
-          '--argjson',
-          'trust',
-          '["OWNER","MEMBER","COLLABORATOR"]',
-          '--arg',
-          'pr_url',
-          'https://github.com/test/pull/1',
-          '--argjson',
-          'reviews',
-          JSON.stringify([reviews]),
-          `[\n${deferredInlineFilter}\n] | length`,
-        ],
-        { encoding: 'utf8', input: JSON.stringify(inlineFeedback) },
-      ),
-    );
+    const countDeferredInline = (over = []) =>
+      Number(
+        execFileSync(
+          'jq',
+          [
+            '-s',
+            '--arg',
+            'wm',
+            '2026-01-01T00:00:00Z',
+            '--arg',
+            'rb',
+            'qwen-code-ci-bot',
+            '--arg',
+            'ab',
+            'qwen-code-dev-bot',
+            '--argjson',
+            'trust',
+            '["OWNER","MEMBER","COLLABORATOR"]',
+            '--arg',
+            'pr_url',
+            'https://github.com/test/pull/1',
+            '--argjson',
+            'over',
+            JSON.stringify(over),
+            '--argjson',
+            'reviews',
+            JSON.stringify([reviews]),
+            `[\n${deferredInlineFilter}\n] | length`,
+          ],
+          { encoding: 'utf8', input: JSON.stringify(inlineFeedback) },
+        ),
+      );
     // Only the BOT's suggestion (id 12) is deferred; the maintainer's
     // unclassified comment (13) stays actionable, and Critical (11),
     // reply-to-Critical (14), and CHANGES_REQUESTED-associated (15) were
     // never deferred.
-    expect(countDeferredInline).toBe(1);
+    expect(countDeferredInline()).toBe(1);
+    // Over-budget maintainer: their unclassified comment (13) joins the
+    // deferred list; reply-to-Critical (14) and CR-associated (15) never do.
+    expect(countDeferredInline(['maintainer'])).toBe(2);
 
     const deferredIssueFilter = prepareBranchAndFeedbackStep.match(
-      /"\$\{WORKDIR\}\/rc\.json"\n\s+jq -r --arg wm "\$\{WATERMARK\}" --arg rb "\$\{REVIEW_BOT\}" --arg ab "\$\{AUTOFIX_BOT\}" \\\n\s+--argjson trust "\$\{TRUSTED_ASSOC\}" --arg pr_url "\$\{PR_URL\}" '([\s\S]*?)' \\\n\s+"\$\{WORKDIR\}\/ic\.json"/,
+      /"\$\{WORKDIR\}\/rc\.json"\n\s+jq -r --arg wm "\$\{WATERMARK\}" --arg rb "\$\{REVIEW_BOT\}" --arg ab "\$\{AUTOFIX_BOT\}" \\\n\s+--argjson trust "\$\{TRUSTED_ASSOC\}" --arg pr_url "\$\{PR_URL\}" --argjson over "\$\{OVER_BUDGET_AUTHORS\}" '([\s\S]*?)' \\\n\s+"\$\{WORKDIR\}\/ic\.json"/,
     )?.[1];
     expect(deferredIssueFilter).toBeTruthy();
     const issueComments = [
@@ -3602,33 +3637,38 @@ describe('qwen-autofix workflow', () => {
         html_url: 'https://github.com/test/pull/1#issuecomment-33',
       },
     ];
-    const countDeferredIssue = Number(
-      execFileSync(
-        'jq',
-        [
-          '--arg',
-          'wm',
-          '2026-01-01T00:00:00Z',
-          '--arg',
-          'rb',
-          'qwen-code-ci-bot',
-          '--arg',
-          'ab',
-          'qwen-code-dev-bot',
-          '--argjson',
-          'trust',
-          '["OWNER","MEMBER","COLLABORATOR"]',
-          '--arg',
-          'pr_url',
-          'https://github.com/test/pull/1',
-          `[${deferredIssueFilter}] | length`,
-        ],
-        { encoding: 'utf8', input: JSON.stringify(issueComments) },
-      ),
-    );
+    const countDeferredIssue = (over = []) =>
+      Number(
+        execFileSync(
+          'jq',
+          [
+            '--arg',
+            'wm',
+            '2026-01-01T00:00:00Z',
+            '--arg',
+            'rb',
+            'qwen-code-ci-bot',
+            '--arg',
+            'ab',
+            'qwen-code-dev-bot',
+            '--argjson',
+            'trust',
+            '["OWNER","MEMBER","COLLABORATOR"]',
+            '--arg',
+            'pr_url',
+            'https://github.com/test/pull/1',
+            '--argjson',
+            'over',
+            JSON.stringify(over),
+            `[${deferredIssueFilter}] | length`,
+          ],
+          { encoding: 'utf8', input: JSON.stringify(issueComments) },
+        ),
+      );
     // Only the BOT's suggestion (33) is deferred; the maintainer's normal
     // comment (30), the Critical (31), and the command (32) are not.
-    expect(countDeferredIssue).toBe(1);
+    expect(countDeferredIssue()).toBe(1);
+    expect(countDeferredIssue(['maintainer'])).toBe(2);
 
     // CHANGES_REQUESTED is a formal merge blocker, so its review summary and
     // associated inline details remain actionable even without the marker.
@@ -3639,16 +3679,90 @@ describe('qwen-autofix workflow', () => {
     // bot-only select in ALL THREE deferred builders — the lexical
     // **[Critical]** test applies exclusively to the review bot's output.
     expect(
-      prepareBranchAndFeedbackStep.split('or ((.user.login // "") != $rb)')
-        .length - 1,
+      prepareBranchAndFeedbackStep.split(
+        'or (((.user.login // "") != $rb) and (((.user.login // "") | IN($over[])) | not))',
+      ).length - 1,
     ).toBe(3);
     expect(
       prepareBranchAndFeedbackStep
         .match(
           /## Deferred non-Critical feedback[\s\S]*?deferred-feedback\.md/,
         )?.[0]
-        ?.split('| select((.user.login // "") == $rb)').length - 1,
+        ?.split(
+          '| select(((.user.login // "") == $rb) or ((.user.login // "") | IN($over[])))',
+        ).length - 1,
     ).toBe(3);
+    // The budget census itself: replay the real jq over fixture files. A
+    // looped reviewer with two CONSUMED batches in the Critical-only tail
+    // is listed; one batch, pre-Critical batches, unconsumed (fresh)
+    // feedback, untrusted authors, and command comments never count.
+    expect(workflow).toContain("CRITICAL_ONLY_HUMAN_BATCHES: '2'");
+    const censusBlock = prepareBranchAndFeedbackStep.match(
+      /OVER_BUDGET_AUTHORS="\$\(jq -n[\s\S]*?' 2> \/dev\/null \|\| echo '\[\]'\)"/,
+    )?.[0];
+    expect(censusBlock).toBeTruthy();
+    const WKEY = '2026-07-01T00:00:00Z';
+    const markerC = (ts, acted, round, at) => ({
+      user: { login: 'qwen-code-dev-bot' },
+      created_at: at,
+      body: `head\n<!-- autofix-eval ts=${ts} acted=${acted} round=${round} win=${WKEY} -->`,
+    });
+    const humanC = (login, at, assoc = 'MEMBER', body = 'feedback') => ({
+      user: { login },
+      created_at: at,
+      author_association: assoc,
+      body,
+    });
+    const budgetDir = mkdtempSync(join(tmpdir(), 'over-budget-'));
+    try {
+      writeFileSync(
+        join(budgetDir, 'ic.json'),
+        JSON.stringify([
+          markerC('2026-07-02T00:00:00Z', 'true', 5, '2026-07-02T01:00:00Z'),
+          markerC('2026-07-03T00:00:00Z', 'true', 6, '2026-07-03T01:00:00Z'),
+          markerC('2026-07-04T00:00:00Z', 'false', 6, '2026-07-04T01:00:00Z'),
+          humanC('looper', '2026-07-02T12:00:00Z'),
+          humanC('looper', '2026-07-03T12:00:00Z'),
+          humanC('onetime', '2026-07-03T13:00:00Z'),
+          humanC('looper', '2026-07-01T12:00:00Z'),
+          humanC('looper', '2026-07-05T00:00:00Z'),
+          humanC('rando', '2026-07-02T13:00:00Z', 'NONE'),
+          humanC(
+            'looper',
+            '2026-07-02T13:00:00Z',
+            'MEMBER',
+            '@qwen-code /review',
+          ),
+        ]),
+      );
+      writeFileSync(join(budgetDir, 'rv.json'), '[]');
+      writeFileSync(join(budgetDir, 'rc.json'), '[]');
+      const overOut = execFileSync(
+        'bash',
+        [
+          '-c',
+          [
+            'set -uo pipefail',
+            `WORKDIR='${budgetDir}'`,
+            `LIVE_REARM_KEY='${WKEY}'`,
+            "AUTOFIX_BOT='qwen-code-dev-bot'",
+            "REVIEW_BOT='qwen-code-ci-bot'",
+            `TRUSTED_ASSOC='["OWNER","MEMBER","COLLABORATOR"]'`,
+            'CRITICAL_ONLY_AFTER_ROUND=5',
+            'CRITICAL_ONLY_HUMAN_BATCHES=2',
+            censusBlock.replace(/\n {10}/g, '\n'),
+            'printf %s "${OVER_BUDGET_AUTHORS}"',
+          ].join('\n'),
+        ],
+        { encoding: 'utf8' },
+      );
+      expect(JSON.parse(overOut)).toEqual(['looper']);
+    } finally {
+      rmSync(budgetDir, { recursive: true, force: true });
+    }
+    // The deferral note names over-budget authors with the escapes.
+    expect(prepareBranchAndFeedbackStep).toContain('is at this window');
+    expect(prepareBranchAndFeedbackStep).toContain('regular-feedback budget');
     expect(inlineFilter).toContain('pull_request_review_id');
 
     // Scan still selects fresh suggestions so a no-op report can advance the

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -4040,7 +4040,7 @@ describe('qwen-autofix workflow', () => {
     // feedback, untrusted authors, and command comments never count.
     expect(workflow).toContain("CRITICAL_ONLY_HUMAN_BATCHES: '2'");
     const censusBlock = prepareBranchAndFeedbackStep.match(
-      /OVER_BUDGET_AUTHORS="\$\(jq -n[\s\S]*?' 2> \/dev\/null \|\| echo '\[\]'\)"/,
+      /OVER_BUDGET_AUTHORS="\$\(jq -n[\s\S]*?' \|\| echo '\[\]'\)"/,
     )?.[0];
     expect(censusBlock).toBeTruthy();
     const WKEY = '2026-07-01T00:00:00Z';
@@ -4084,6 +4084,22 @@ describe('qwen-autofix workflow', () => {
             '2026-07-02T13:00:00Z',
             'MEMBER',
             '@qwen-code /review',
+          ),
+          // Command-only author: both items are /commands, so with the
+          // command-exclusion filter they count 0 consumed spans and stay
+          // absent; dropping the filter would surface them and fail the
+          // assertion, which is what makes the guard observable.
+          humanC(
+            'commander',
+            '2026-07-02T14:00:00Z',
+            'MEMBER',
+            '@qwen-code /review',
+          ),
+          humanC(
+            'commander',
+            '2026-07-03T14:00:00Z',
+            'MEMBER',
+            '@qwen-code /retry',
           ),
         ]),
       );

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -4044,10 +4044,10 @@ describe('qwen-autofix workflow', () => {
     )?.[0];
     expect(censusBlock).toBeTruthy();
     const WKEY = '2026-07-01T00:00:00Z';
-    const markerC = (ts, acted, round, at) => ({
+    const markerC = (ts, acted, round, at, win = WKEY) => ({
       user: { login: 'qwen-code-dev-bot' },
       created_at: at,
-      body: `head\n<!-- autofix-eval ts=${ts} acted=${acted} round=${round} win=${WKEY} -->`,
+      body: `head\n<!-- autofix-eval ts=${ts} acted=${acted} round=${round} win=${win} -->`,
     });
     const humanC = (login, at, assoc = 'MEMBER', body = 'feedback') => ({
       user: { login },
@@ -4063,9 +4063,19 @@ describe('qwen-autofix workflow', () => {
           markerC('2026-07-02T00:00:00Z', 'true', 5, '2026-07-02T01:00:00Z'),
           markerC('2026-07-03T00:00:00Z', 'true', 6, '2026-07-03T01:00:00Z'),
           markerC('2026-07-04T00:00:00Z', 'false', 6, '2026-07-04T01:00:00Z'),
+          // Stale-window marker: qualifies for a span but win != WKEY.
+          markerC(
+            '2026-06-15T00:00:00Z',
+            'true',
+            6,
+            '2026-06-15T01:00:00Z',
+            '2026-06-01T00:00:00Z',
+          ),
           humanC('looper', '2026-07-02T12:00:00Z'),
           humanC('looper', '2026-07-03T12:00:00Z'),
           humanC('onetime', '2026-07-03T13:00:00Z'),
+          // Stale-window human inside the stale span; must not count.
+          humanC('onetime', '2026-06-14T12:00:00Z'),
           humanC('looper', '2026-07-01T12:00:00Z'),
           humanC('looper', '2026-07-05T00:00:00Z'),
           humanC('rando', '2026-07-02T13:00:00Z', 'NONE'),

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -3322,7 +3322,13 @@ describe('qwen-autofix workflow', () => {
         ),
       );
     expect(countInline(false)).toBe(5);
-    expect(countInline(true)).toBe(3);
+    // In Critical-only mode the REVIEW BOT's suggestion (12) is filtered,
+    // but MAINTAINER comments (13) stay actionable regardless of wording —
+    // the lexical **[Critical]** test applies only to the bot's own
+    // findings. Observed on #8037/#7944/#7885/#7799: a maintainer's
+    // "fix 1 and 3 before merge" was deferred wholesale as one
+    // 'non-Critical item' and the agent never read it.
+    expect(countInline(true)).toBe(4);
 
     // Actionable reviews and issue-level comments filters: extract and
     // execute against fixture data with critical_only both ways, mirroring
@@ -3356,6 +3362,14 @@ describe('qwen-autofix workflow', () => {
         author_association: 'NONE',
         body: '**[Critical]** memory leak in the owner route',
       },
+      {
+        id: 23,
+        state: 'COMMENTED',
+        submitted_at: '2026-01-02T00:00:03Z',
+        user: { login: 'maintainer' },
+        author_association: 'MEMBER',
+        body: 'I verified locally; please fix findings 1 and 3 before merge.',
+      },
     ];
     const countActionableReviews = (criticalOnly) =>
       Number(
@@ -3382,10 +3396,11 @@ describe('qwen-autofix workflow', () => {
           { encoding: 'utf8', input: JSON.stringify(actionableReviews) },
         ),
       );
-    // All three are actionable while suggestions are in scope; in
-    // Critical-only mode the non-Critical COMMENTED review is excluded.
-    expect(countActionableReviews(false)).toBe(3);
-    expect(countActionableReviews(true)).toBe(2);
+    // All four are actionable while suggestions are in scope; in
+    // Critical-only mode only the BOT's non-Critical COMMENTED review is
+    // excluded — the maintainer's COMMENTED review stays actionable.
+    expect(countActionableReviews(false)).toBe(4);
+    expect(countActionableReviews(true)).toBe(3);
 
     const actionableIssueFilter = prepareBranchAndFeedbackStep.match(
       /echo "## Issue-level comments"[\s\S]*?jq -r --arg wm "\$\{WATERMARK\}" --arg rb "\$\{REVIEW_BOT\}" --arg ab "\$\{AUTOFIX_BOT\}" \\\n\s+--argjson critical_only "\$\{CRITICAL_ONLY\}" --argjson trust "\$\{TRUSTED_ASSOC\}" '([\s\S]*?)' \\\n\s+"\$\{WORKDIR\}\/ic\.json"/,
@@ -3441,9 +3456,10 @@ describe('qwen-autofix workflow', () => {
       );
     // Normal and Critical comments are actionable while suggestions are in
     // scope; the command-style comment is always excluded. In Critical-only
-    // mode, only the Critical comment remains.
+    // mode the maintainer's comment STAYS actionable alongside the bot's
+    // Critical one — only bot non-Critical output is filtered.
     expect(countActionableIssue(false)).toBe(2);
-    expect(countActionableIssue(true)).toBe(1);
+    expect(countActionableIssue(true)).toBe(2);
 
     // Deferred queries: extract and execute against fixture data,
     // mirroring the actionable inline filter test above.
@@ -3471,6 +3487,15 @@ describe('qwen-autofix workflow', () => {
         body: '**[Critical]** memory leak in the owner route',
         html_url: 'https://github.com/test/pull/1#review-22',
       },
+      {
+        id: 23,
+        state: 'COMMENTED',
+        submitted_at: '2026-01-02T00:00:02Z',
+        user: { login: 'maintainer' },
+        author_association: 'MEMBER',
+        body: 'I verified locally; please fix findings 1 and 3 before merge.',
+        html_url: 'https://github.com/test/pull/1#review-23',
+      },
     ];
     const countDeferredReviews = Number(
       execFileSync(
@@ -3496,8 +3521,9 @@ describe('qwen-autofix workflow', () => {
         { encoding: 'utf8', input: JSON.stringify(deferredReviews) },
       ),
     );
-    // COMMENTED non-Critical review is deferred; CHANGES_REQUESTED and
-    // COMMENTED Critical reviews are not.
+    // Only the BOT's COMMENTED non-Critical review is deferred;
+    // CHANGES_REQUESTED, COMMENTED-Critical, and the MAINTAINER's
+    // COMMENTED review are not.
     expect(countDeferredReviews).toBe(1);
 
     const deferredInlineFilter = prepareBranchAndFeedbackStep.match(
@@ -3532,10 +3558,11 @@ describe('qwen-autofix workflow', () => {
         { encoding: 'utf8', input: JSON.stringify(inlineFeedback) },
       ),
     );
-    // Suggestion (id 12) and unclassified (id 13) are deferred; Critical
-    // (11), reply-to-Critical (14), and CHANGES_REQUESTED-associated (15)
-    // are not.
-    expect(countDeferredInline).toBe(2);
+    // Only the BOT's suggestion (id 12) is deferred; the maintainer's
+    // unclassified comment (13) stays actionable, and Critical (11),
+    // reply-to-Critical (14), and CHANGES_REQUESTED-associated (15) were
+    // never deferred.
+    expect(countDeferredInline).toBe(1);
 
     const deferredIssueFilter = prepareBranchAndFeedbackStep.match(
       /"\$\{WORKDIR\}\/rc\.json"\n\s+jq -r --arg wm "\$\{WATERMARK\}" --arg rb "\$\{REVIEW_BOT\}" --arg ab "\$\{AUTOFIX_BOT\}" \\\n\s+--argjson trust "\$\{TRUSTED_ASSOC\}" --arg pr_url "\$\{PR_URL\}" '([\s\S]*?)' \\\n\s+"\$\{WORKDIR\}\/ic\.json"/,
@@ -3566,6 +3593,14 @@ describe('qwen-autofix workflow', () => {
         body: '@qwen-code /review',
         html_url: 'https://github.com/test/pull/1#issuecomment-32',
       },
+      {
+        id: 33,
+        created_at: '2026-01-02T00:00:03Z',
+        user: { login: 'qwen-code-ci-bot' },
+        author_association: 'NONE',
+        body: '**[Suggestion]** consider caching this lookup',
+        html_url: 'https://github.com/test/pull/1#issuecomment-33',
+      },
     ];
     const countDeferredIssue = Number(
       execFileSync(
@@ -3591,8 +3626,8 @@ describe('qwen-autofix workflow', () => {
         { encoding: 'utf8', input: JSON.stringify(issueComments) },
       ),
     );
-    // Normal comment is deferred; Critical and command-style comments are
-    // not.
+    // Only the BOT's suggestion (33) is deferred; the maintainer's normal
+    // comment (30), the Critical (31), and the command (32) are not.
     expect(countDeferredIssue).toBe(1);
 
     // CHANGES_REQUESTED is a formal merge blocker, so its review summary and
@@ -3600,6 +3635,20 @@ describe('qwen-autofix workflow', () => {
     expect(prepareBranchAndFeedbackStep).toContain(
       'or (.state // "") == "CHANGES_REQUESTED"',
     );
+    // The human bypass is present in ALL THREE actionable filters and the
+    // bot-only select in ALL THREE deferred builders — the lexical
+    // **[Critical]** test applies exclusively to the review bot's output.
+    expect(
+      prepareBranchAndFeedbackStep.split('or ((.user.login // "") != $rb)')
+        .length - 1,
+    ).toBe(3);
+    expect(
+      prepareBranchAndFeedbackStep
+        .match(
+          /## Deferred non-Critical feedback[\s\S]*?deferred-feedback\.md/,
+        )?.[0]
+        ?.split('| select((.user.login // "") == $rb)').length - 1,
+    ).toBe(3);
     expect(inlineFilter).toContain('pull_request_review_id');
 
     // Scan still selects fresh suggestions so a no-op report can advance the

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -240,6 +240,23 @@ describe('qwen-autofix workflow', () => {
     expect(workflow).not.toMatch(/^\s*(fi|done|esac)"\s*$/m);
   });
 
+  it('keeps the prepare-branch-and-feedback run block bash-parseable', () => {
+    // The deferred-feedback echo sits inside a double-quoted string, where the
+    // '"'"' idiom is a literal apostrophe followed by a string CLOSER rather
+    // than an embedded quote — a parse-time syntax error that aborts the step
+    // for every run while the jq-filter tests (which never run the echo lines)
+    // stay green. bash -n the whole run block so a future quoting regression in
+    // this step fails CI instead of breaking every autofix run.
+    const runBlock =
+      prepareBranchAndFeedbackStep.match(/run: \|-\n([\s\S]*)$/)?.[1];
+    expect(runBlock).toBeTruthy();
+    const res = spawnSync('bash', ['-n'], {
+      encoding: 'utf8',
+      input: runBlock.replace(/^ {10}/gm, ''),
+    });
+    expect(res.status).toBe(0);
+  });
+
   it('runs scheduled autofix as a 10-minute multi-target fan-out worker', () => {
     expect(workflow).toContain("cron: '*/10 * * * *'");
     expect(workflow).not.toContain("cron: '0 0,12 * * *'");
@@ -3821,7 +3838,7 @@ describe('qwen-autofix workflow', () => {
     // Deferred queries: extract and execute against fixture data,
     // mirroring the actionable inline filter test above.
     const deferredReviewsFilter = prepareBranchAndFeedbackStep.match(
-      /## Deferred non-Critical feedback[\s\S]*?jq -r --arg wm "\$\{WATERMARK\}" --arg rb "\$\{REVIEW_BOT\}" --arg ab "\$\{AUTOFIX_BOT\}" \\\n\s+--argjson trust "\$\{TRUSTED_ASSOC\}" --arg pr_url "\$\{PR_URL\}" --argjson over "\$\{OVER_BUDGET_AUTHORS\}" '([\s\S]*?)' \\\n\s+"\$\{WORKDIR\}\/rv\.json"/,
+      /## Deferred non-Critical feedback[\s\S]*?jq -r --arg wm "\$\{WATERMARK\}" --arg rb "\$\{REVIEW_BOT\}" --arg ab "\$\{AUTOFIX_BOT\}" \\\n\s+--arg pr_url "\$\{PR_URL\}" --argjson over "\$\{OVER_BUDGET_AUTHORS\}" '([\s\S]*?)' \\\n\s+"\$\{WORKDIR\}\/rv\.json"/,
     )?.[1];
     expect(deferredReviewsFilter).toBeTruthy();
     const deferredReviews = [
@@ -3868,9 +3885,6 @@ describe('qwen-autofix workflow', () => {
             '--arg',
             'ab',
             'qwen-code-dev-bot',
-            '--argjson',
-            'trust',
-            '["OWNER","MEMBER","COLLABORATOR"]',
             '--arg',
             'pr_url',
             'https://github.com/test/pull/1',
@@ -3889,7 +3903,7 @@ describe('qwen-autofix workflow', () => {
     expect(countDeferredReviews(['maintainer'])).toBe(2);
 
     const deferredInlineFilter = prepareBranchAndFeedbackStep.match(
-      /jq -rs --arg wm "\$\{WATERMARK\}" --arg rb "\$\{REVIEW_BOT\}" --arg ab "\$\{AUTOFIX_BOT\}" \\\n\s+--argjson trust "\$\{TRUSTED_ASSOC\}" --arg pr_url "\$\{PR_URL\}" --argjson over "\$\{OVER_BUDGET_AUTHORS\}" \\\n\s+--slurpfile reviews "\$\{WORKDIR\}\/rv\.json" '([\s\S]*?)' \\\n\s+"\$\{WORKDIR\}\/rc\.json"/,
+      /jq -rs --arg wm "\$\{WATERMARK\}" --arg rb "\$\{REVIEW_BOT\}" --arg ab "\$\{AUTOFIX_BOT\}" \\\n\s+--arg pr_url "\$\{PR_URL\}" --argjson over "\$\{OVER_BUDGET_AUTHORS\}" \\\n\s+--slurpfile reviews "\$\{WORKDIR\}\/rv\.json" '([\s\S]*?)' \\\n\s+"\$\{WORKDIR\}\/rc\.json"/,
     )?.[1];
     expect(deferredInlineFilter).toBeTruthy();
     const countDeferredInline = (over = []) =>
@@ -3907,9 +3921,6 @@ describe('qwen-autofix workflow', () => {
             '--arg',
             'ab',
             'qwen-code-dev-bot',
-            '--argjson',
-            'trust',
-            '["OWNER","MEMBER","COLLABORATOR"]',
             '--arg',
             'pr_url',
             'https://github.com/test/pull/1',
@@ -3934,7 +3945,7 @@ describe('qwen-autofix workflow', () => {
     expect(countDeferredInline(['maintainer'])).toBe(2);
 
     const deferredIssueFilter = prepareBranchAndFeedbackStep.match(
-      /"\$\{WORKDIR\}\/rc\.json"\n\s+jq -r --arg wm "\$\{WATERMARK\}" --arg rb "\$\{REVIEW_BOT\}" --arg ab "\$\{AUTOFIX_BOT\}" \\\n\s+--argjson trust "\$\{TRUSTED_ASSOC\}" --arg pr_url "\$\{PR_URL\}" --argjson over "\$\{OVER_BUDGET_AUTHORS\}" '([\s\S]*?)' \\\n\s+"\$\{WORKDIR\}\/ic\.json"/,
+      /"\$\{WORKDIR\}\/rc\.json"\n\s+jq -r --arg wm "\$\{WATERMARK\}" --arg rb "\$\{REVIEW_BOT\}" --arg ab "\$\{AUTOFIX_BOT\}" \\\n\s+--arg pr_url "\$\{PR_URL\}" --argjson over "\$\{OVER_BUDGET_AUTHORS\}" '([\s\S]*?)' \\\n\s+"\$\{WORKDIR\}\/ic\.json"/,
     )?.[1];
     expect(deferredIssueFilter).toBeTruthy();
     const issueComments = [
@@ -3985,9 +3996,6 @@ describe('qwen-autofix workflow', () => {
             '--arg',
             'ab',
             'qwen-code-dev-bot',
-            '--argjson',
-            'trust',
-            '["OWNER","MEMBER","COLLABORATOR"]',
             '--arg',
             'pr_url',
             'https://github.com/test/pull/1',
@@ -4069,8 +4077,32 @@ describe('qwen-autofix workflow', () => {
           ),
         ]),
       );
-      writeFileSync(join(budgetDir, 'rv.json'), '[]');
-      writeFileSync(join(budgetDir, 'rc.json'), '[]');
+      // A second author whose two consumed batches arrive through the review
+      // (.submitted_at) and inline-comment (.created_at) branches, not ic.json:
+      // both are untagged, so they count under either census semantic.
+      writeFileSync(
+        join(budgetDir, 'rv.json'),
+        JSON.stringify([
+          {
+            user: { login: 'reviewer2' },
+            author_association: 'MEMBER',
+            state: 'COMMENTED',
+            submitted_at: '2026-07-02T12:30:00Z',
+            body: 'feedback delivered through a review',
+          },
+        ]),
+      );
+      writeFileSync(
+        join(budgetDir, 'rc.json'),
+        JSON.stringify([
+          {
+            user: { login: 'reviewer2' },
+            author_association: 'MEMBER',
+            created_at: '2026-07-03T13:30:00Z',
+            body: 'feedback delivered through an inline comment',
+          },
+        ]),
+      );
       const overOut = execFileSync(
         'bash',
         [
@@ -4090,7 +4122,7 @@ describe('qwen-autofix workflow', () => {
         ],
         { encoding: 'utf8' },
       );
-      expect(JSON.parse(overOut)).toEqual(['looper']);
+      expect(JSON.parse(overOut)).toEqual(['looper', 'reviewer2']);
     } finally {
       rmSync(budgetDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Problem

Critical-only mode (after `CRITICAL_ONLY_AFTER_ROUND=5` change-producing rounds) classifies feedback **lexically**, before the agent reads a word of it: only a literal `**[Critical]**` tag or a `CHANGES_REQUESTED` review survives; everything else is deferred wholesale.

That rule was built to stop the review bot's suggestion ping-pong (#7913) — but it catches maintainers too. Observed **four times in two days** (#8037, #7944, #7885, #7799): a maintainer's E2E-verified review saying *"I'd fix before merge"* on a correctness bug and a security-adjacent one was deferred as one "non-Critical item", and the bot reported *"No Critical feedback. The Issue-level comments sections are empty"* — lexically true, substantively false. The agent that could have applied the bot's own advertised Critical definition never saw the comment.

The naive fix — "never defer humans" — fails an obvious counterexample: **a human account can host an automated reviewer loop** with the exact regeneration property the bot has (feedback re-generated after every push, zero marginal cost). An account is an *accountability* unit, not a throttle.

## Change: a per-source budget keyed on measured regeneration

Once Critical-only engages, every source has a bounded budget of **untagged feedback batches per counting window**:

- **Review bot: 0** — all its non-Critical output defers, exactly as today.
- **Trusted humans: `CRITICAL_ONLY_HUMAN_BATCHES` (2) consumed batches.** A batch counts only when a Critical-only round actually consumed it: items are bucketed into the `(prev marker ts, marker ts]` span that evaluated them; only spans from Critical-only rounds count; an author needs K distinct consumed spans before their **new** untagged feedback defers. Fresh, not-yet-evaluated feedback never counts against its own author.

Effects:
- The four observed cases (one or two late verification reports each) are fully served under K=2 — nothing defers.
- A looped reviewer is throttled after ~5+K driven rounds instead of grinding a takeover PR toward the 100-round cap.
- Past the budget, continuing requires one **conscious act** — `**[Critical]**`, a formal Request changes review, or `/retry` (which rotates the window and resets the budget with it) — which is precisely what separates intent from automation. These escapes cut through at any time, for anyone.
- Over-budget authors are **named** in the deferral note with those exact escapes; the note also states what is deferred and why, instead of a generic "audit record".
- `SKILL.md`'s Critical-only policy marks everything rendered actionable as in scope, so the agent doesn't re-refuse what the filter passed through.

## Tests

- The six filter replays (real jq over fixtures, `critical_only` both ways) gain over-budget cases in both directions: an over-budget maintainer's plain comment defers across all three sources, while their reply-to-Critical, CR-review-associated, and formal CHANGES_REQUESTED items still cut through; within-budget maintainers are untouched; bot suggestions defer as before.
- The budget census itself is replayed over fixture files: two consumed critical-tail batches list the author; one batch, pre-Critical-mode batches, unconsumed (fresh) feedback, untrusted authors, and command comments never count.
- Structural pins hold the budget-aware bypass and the bot-or-over-budget select in all six filters, plus the five command-comment exclusion sites.
- 102/102 + 14/14 pass; `check-autofix-contracts.sh` clean; workflow YAML parses.

<details>
<summary>中文说明</summary>

## 问题

Critical-only 模式（5 轮后）在 agent 读到反馈前做纯词法分类：只有字面 `**[Critical]**` 或 `CHANGES_REQUESTED` review 能通过。该规则本为掐断 review bot 的建议乒乓（#7913），却把维护者一并挡掉——两天内实锤四例（#8037/#7944/#7885/#7799）：明确写"合并前要修"的正确性/安全问题被整条打包延后，bot 随即宣称"No Critical feedback"。

而朴素修法"人类永不延后"过不了一个显然的反例：**人类账号完全可以挂自动评审循环**，具备与 bot 相同的再生性质（每次 push 重新生成、零边际成本）。账号是问责单位，不是节流阀。

## 改动：按实测再生频度计费的每来源预算

Critical-only 生效后，每个来源在每个计数窗口内有一个未标记反馈批次预算：**review bot 为 0**（现状不变）；**受信人类为 `CRITICAL_ONLY_HUMAN_BATCHES`（2）个已消化批次**——反馈按消化它的 `(上一标记 ts, 标记 ts]` 区间分桶，只计 Critical-only 轮次的区间，作者需累计 K 个不同的已消化区间后，其**新**的未标记反馈才开始延后；尚未被消化的新反馈永远不计入其作者。

效果：四个实测案例在 K=2 下完全不受影响；挂循环的 reviewer 在驱动 ~5+K 轮后被节流，而不是把接管 PR 磨向 100 轮上限；超预算后继续推进需要一次**有意识的动作**——`**[Critical]**`、正式 Request changes、或 `/retry`（轮转窗口、预算随之重置）——这正是意图与自动化的分界；超预算作者在延后说明中被点名并附上这三条通道；SKILL 策略同步声明 actionable 区内一切都在范围内。

## 测试

六个过滤器回放双向覆盖超预算场景（超预算者的普通评论在三个来源全部延后，其 reply-to-Critical / CR-review / 正式 Request changes 仍然穿透；预算内维护者不受影响；bot 建议照旧延后）；预算普查本体用 fixture 文件回放（2 个已消化 critical-tail 批次入列；1 批、pre-Critical 批、未消化反馈、非受信作者、命令评论均不计）；结构 pin 锁死六处子句与五处命令排除站点。102/102 + 14/14 通过；contracts 通过；YAML 正常。

</details>
