### PR TITLE
fix(web-shell): improve artifact previews

### DIFF
--- a/packages/web-shell/client/components/artifacts/ArtifactPanel.module.css
+++ b/packages/web-shell/client/components/artifacts/ArtifactPanel.module.css
@@ -806,6 +806,54 @@ button.treeRow:hover {
   overflow-wrap: anywhere;
 }
 
+.imagePreviewWrap {
+  position: relative;
+  min-height: 520px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.imagePreview {
+  display: block;
+  max-width: 100%;
+  max-height: calc(100vh - 120px);
+  object-fit: contain;
+}
+
+.imageDownloadButton {
+  position: absolute;
+  z-index: 1;
+  top: 12px;
+  right: 12px;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--background);
+  color: var(--foreground);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  pointer-events: none;
+  text-decoration: none;
+  transition:
+    opacity 120ms ease,
+    background 120ms ease;
+}
+
+.imagePreviewWrap:hover .imageDownloadButton,
+.imageDownloadButton:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.imageDownloadButton:hover {
+  background: var(--accent);
+}
+
 .htmlPreview {
   width: 100%;
   flex: 1 1 auto;

--- a/packages/web-shell/client/components/artifacts/ArtifactPanel.tsx
+++ b/packages/web-shell/client/components/artifacts/ArtifactPanel.tsx
@@ -10,6 +10,7 @@ import {
 } from '@qwen-code/webui/daemon-react-sdk';
 import { EditorState } from '@codemirror/state';
 import { basicSetup, EditorView } from 'codemirror';
+import { DownloadIcon } from 'lucide-react';
 import {
   useCallback,
   useEffect,
@@ -35,7 +36,10 @@ import {
   artifactKindLabel,
   formatArtifactSize,
   getArtifactLocation,
+  getArtifactImageMimeType,
+  getImageMimeTypeFromPath,
   normalizePath,
+  readWorkspaceFileAsBlob,
   withArtifactPreviewCsp,
 } from './artifactUtils';
 import {
@@ -1695,6 +1699,7 @@ function ArtifactDetail({
     artifact.metadata?.['artifactType'] === 'automation_snapshot';
   const canPreviewWorkspaceFile =
     artifact.storage === 'workspace' && Boolean(artifact.workspacePath);
+  const imageMimeType = getArtifactImageMimeType(artifact);
 
   if (canPreviewWorkspaceFile && artifact.workspacePath) {
     return (
@@ -1703,12 +1708,15 @@ function ArtifactDetail({
         artifactVersion={artifact.updatedAt}
         workspaceActions={workspaceActions}
         previewContent={previewContent}
+        imageMimeType={imageMimeType}
         previewKind={
           isHtmlArtifact(artifact)
             ? 'html'
             : isMarkdownArtifact(artifact)
               ? 'markdown'
-              : 'source'
+              : imageMimeType
+                ? 'image'
+                : 'source'
         }
       />
     );
@@ -1804,21 +1812,29 @@ function WorkspaceFilePreview({
   artifactVersion,
   workspaceActions,
   previewContent,
-  previewKind = workspacePath.toLowerCase().endsWith('.html') ||
-  workspacePath.toLowerCase().endsWith('.htm')
-    ? 'html'
-    : workspacePath.toLowerCase().endsWith('.md') ||
-        workspacePath.toLowerCase().endsWith('.markdown')
-      ? 'markdown'
-      : 'source',
+  imageMimeType,
+  previewKind,
 }: {
   workspacePath: string;
   artifactVersion?: string;
   workspaceActions: DaemonWorkspaceActions;
   previewContent?: string;
-  previewKind?: 'html' | 'markdown' | 'source';
+  imageMimeType?: string;
+  previewKind?: 'html' | 'markdown' | 'image' | 'source';
 }) {
-  if (previewKind === 'html') {
+  const path = workspacePath.toLowerCase();
+  const resolvedImageMimeType =
+    imageMimeType ?? getImageMimeTypeFromPath(workspacePath);
+  const resolvedPreviewKind =
+    previewKind ??
+    (path.endsWith('.html') || path.endsWith('.htm')
+      ? 'html'
+      : path.endsWith('.md') || path.endsWith('.markdown')
+        ? 'markdown'
+        : resolvedImageMimeType
+          ? 'image'
+          : 'source');
+  if (resolvedPreviewKind === 'html') {
     return (
       <HtmlArtifactPreview
         workspacePath={workspacePath}
@@ -1828,7 +1844,7 @@ function WorkspaceFilePreview({
       />
     );
   }
-  if (previewKind === 'markdown') {
+  if (resolvedPreviewKind === 'markdown') {
     return (
       <MarkdownArtifactPreview
         workspacePath={workspacePath}
@@ -1838,12 +1854,92 @@ function WorkspaceFilePreview({
       />
     );
   }
+  if (resolvedPreviewKind === 'image' && resolvedImageMimeType) {
+    return (
+      <ImageArtifactPreview
+        workspacePath={workspacePath}
+        artifactVersion={artifactVersion}
+        workspaceActions={workspaceActions}
+        mimeType={resolvedImageMimeType}
+      />
+    );
+  }
   return (
     <FileArtifactPreview
       workspacePath={workspacePath}
       artifactVersion={artifactVersion}
       workspaceActions={workspaceActions}
     />
+  );
+}
+
+function ImageArtifactPreview({
+  workspacePath,
+  artifactVersion,
+  workspaceActions,
+  mimeType,
+}: {
+  workspacePath: string;
+  artifactVersion?: string;
+  workspaceActions: DaemonWorkspaceActions;
+  mimeType: string;
+}) {
+  const [src, setSrc] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let objectUrl: string | undefined;
+    setSrc(null);
+    setError(null);
+    readWorkspaceFileAsBlob(
+      (filePath, opts) => workspaceActions.readFileBytes(filePath, opts),
+      workspacePath,
+      mimeType,
+      {
+        statFile: (filePath) => workspaceActions.stat(filePath),
+        isCancelled: () => cancelled,
+      },
+    )
+      .then((blob) => {
+        if (cancelled) return;
+        objectUrl = URL.createObjectURL(blob);
+        setSrc(objectUrl);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [artifactVersion, mimeType, workspaceActions, workspacePath]);
+
+  return (
+    <div className={styles.imagePreviewWrap}>
+      {src ? (
+        <>
+          <img
+            className={styles.imagePreview}
+            src={src}
+            alt={fileName(workspacePath)}
+          />
+          <a
+            className={styles.imageDownloadButton}
+            href={src}
+            download={fileName(workspacePath)}
+            aria-label={`Download ${fileName(workspacePath)}`}
+            title="Download"
+          >
+            <DownloadIcon size={16} strokeWidth={1.8} />
+          </a>
+        </>
+      ) : !error ? (
+        <div className={styles.empty}>Loading image...</div>
+      ) : null}
+      {error && <div className={styles.previewError}>{error}</div>}
+    </div>
   );
 }
 
@@ -1919,7 +2015,7 @@ function HtmlArtifactPreview({
         <iframe
           className={styles.htmlPreview}
           referrerPolicy="no-referrer"
-          sandbox=""
+          sandbox="allow-scripts"
           srcDoc={withArtifactPreviewCsp(content)}
           title={`Preview ${workspacePath}`}
         />

--- a/packages/web-shell/client/components/artifacts/TurnOutputs.module.css
+++ b/packages/web-shell/client/components/artifacts/TurnOutputs.module.css
@@ -13,15 +13,15 @@
 
 .summary {
   display: grid;
-  grid-template-columns: 34px minmax(0, 1fr) auto;
+  grid-template-columns: 36px minmax(0, 1fr) auto;
   gap: 12px;
   align-items: center;
   padding: 12px;
 }
 
 .icon {
-  width: 34px;
-  height: 34px;
+  width: 36px;
+  height: 36px;
   border-radius: 6px;
   background: var(--accent);
   color: var(--muted-foreground);
@@ -43,6 +43,25 @@
   font-weight: 400;
 }
 
+.reviewSummary {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.reviewSummaryWithStats {
+  display: grid;
+  gap: 0;
+}
+
+.reviewMeta {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .linkButton,
 .reviewButton,
 .showMoreButton {
@@ -55,8 +74,6 @@
 }
 
 .linkButton {
-  margin-top: 2px;
-  margin-left: 8px;
   padding: 0;
   color: var(--muted-foreground);
   font-size: 13px;
@@ -172,7 +189,6 @@
 .artifactInfo {
   min-width: 0;
   display: grid;
-  gap: 2px;
 }
 
 .artifactMeta {

--- a/packages/web-shell/client/components/artifacts/TurnOutputs.test.ts
+++ b/packages/web-shell/client/components/artifacts/TurnOutputs.test.ts
@@ -1,11 +1,22 @@
 import { describe, expect, it } from 'vitest';
 import type { DaemonSessionArtifact } from '@qwen-code/sdk/daemon';
 import {
+  getArtifactFormatIcon,
   getArtifactPreviewContent,
   getFileChangePreviewContent,
   isRenderedFilePath,
   type TurnOutputFileChange,
 } from './TurnOutputs';
+import {
+  FileAudioIcon,
+  FileCode2Icon,
+  FileIcon,
+  FileImageIcon,
+  FileTextIcon,
+  FileVideoIcon,
+  LinkIcon,
+  NotebookTabsIcon,
+} from 'lucide-react';
 
 describe('TurnOutputs helpers', () => {
   it('uses workspace cwd when matching artifact preview content', () => {
@@ -76,9 +87,29 @@ describe('TurnOutputs helpers', () => {
     expect(getFileChangePreviewContent(change)).toBe('latest');
   });
 
-  it('limits rendered review previews to HTML and Markdown files', () => {
+  it('enables review previews for rendered documents and raster images', () => {
     expect(isRenderedFilePath('REPORT.HTML')).toBe(true);
     expect(isRenderedFilePath('notes.markdown')).toBe(true);
+    expect(isRenderedFilePath('screenshots/result.PNG')).toBe(true);
+    expect(isRenderedFilePath('diagram.svg')).toBe(false);
     expect(isRenderedFilePath('source.ts')).toBe(false);
+  });
+
+  it.each([
+    ['file', FileIcon],
+    ['link', LinkIcon],
+    ['html', FileCode2Icon],
+    ['image', FileImageIcon],
+    ['video', FileVideoIcon],
+    ['audio', FileAudioIcon],
+    ['pdf', FileTextIcon],
+    ['notebook', NotebookTabsIcon],
+  ])('selects the Lucide icon for %s artifacts', (kind, icon) => {
+    expect(getArtifactFormatIcon(kind)).toBe(icon);
+  });
+
+  it('uses the existing document icon for unsupported artifact kinds', () => {
+    expect(getArtifactFormatIcon('other')).toBeUndefined();
+    expect(getArtifactFormatIcon('future-format')).toBeUndefined();
   });
 });

--- a/packages/web-shell/client/components/artifacts/TurnOutputs.tsx
+++ b/packages/web-shell/client/components/artifacts/TurnOutputs.tsx
@@ -1,12 +1,24 @@
 import type { DaemonSessionArtifact } from '@qwen-code/sdk/daemon';
 import type { ACPToolCall } from '../../adapters/types';
 import type { DaemonWorkspaceActions } from '@qwen-code/webui/daemon-react-sdk';
+import {
+  FileAudioIcon,
+  FileCode2Icon,
+  FileIcon,
+  FileImageIcon,
+  FileTextIcon,
+  FileVideoIcon,
+  LinkIcon,
+  NotebookTabsIcon,
+  type LucideIcon,
+} from 'lucide-react';
 import { memo, useState } from 'react';
 import { useI18n } from '../../i18n';
 import { describeCron } from '../dialogs/scheduledTasksSchedule';
 import {
   formatArtifactSize,
   getArtifactTypeLabel,
+  getImageMimeTypeFromPath,
   isSamePath,
   stripWorkspacePath,
 } from './artifactUtils';
@@ -212,24 +224,33 @@ function TurnOutputsComponent({
                 />
               </svg>
             </span>
-            <div>
+            <div
+              className={[
+                styles.reviewSummary,
+                totals ? styles.reviewSummaryWithStats : '',
+              ]
+                .filter(Boolean)
+                .join(' ')}
+            >
               <div className={styles.title}>
                 {t('turnOutputs.filesEdited', { count: changes.length })}
               </div>
-              <LineStats
-                additions={totals?.additions}
-                deletions={totals?.deletions}
-                className={styles.lineStats}
-                additionsClassName={styles.additions}
-                deletionsClassName={styles.deletions}
-              />
-              <button
-                type="button"
-                className={styles.linkButton}
-                onClick={() => openReview()}
-              >
-                {t('turnOutputs.viewChanges')} ↗
-              </button>
+              <div className={styles.reviewMeta}>
+                <LineStats
+                  additions={totals?.additions}
+                  deletions={totals?.deletions}
+                  className={styles.lineStats}
+                  additionsClassName={styles.additions}
+                  deletionsClassName={styles.deletions}
+                />
+                <button
+                  type="button"
+                  className={styles.linkButton}
+                  onClick={() => openReview()}
+                >
+                  {t('turnOutputs.viewChanges')} ↗
+                </button>
+              </div>
             </div>
             <div className={styles.actions}>
               <button
@@ -312,11 +333,16 @@ function ArtifactCard({
 }) {
   const { t } = useI18n();
   const size = formatArtifactSize(artifact.sizeBytes);
+  const FormatIcon = getArtifactFormatIcon(artifact.kind);
   return (
     <div className={styles.card}>
       <div className={styles.summary}>
         <span className={styles.icon} aria-hidden="true">
-          <DocumentIcon />
+          {FormatIcon ? (
+            <FormatIcon className={styles.iconSvg} strokeWidth={1.8} />
+          ) : (
+            <DocumentIcon />
+          )}
         </span>
         <div className={styles.artifactInfo}>
           <div className={styles.title}>{artifact.title}</div>
@@ -337,6 +363,21 @@ function ArtifactCard({
       </div>
     </div>
   );
+}
+
+const ARTIFACT_FORMAT_ICONS: Readonly<Record<string, LucideIcon>> = {
+  file: FileIcon,
+  link: LinkIcon,
+  html: FileCode2Icon,
+  image: FileImageIcon,
+  video: FileVideoIcon,
+  audio: FileAudioIcon,
+  pdf: FileTextIcon,
+  notebook: NotebookTabsIcon,
+};
+
+export function getArtifactFormatIcon(kind: string): LucideIcon | undefined {
+  return ARTIFACT_FORMAT_ICONS[kind];
 }
 
 function ScheduledTaskCard({
@@ -504,7 +545,8 @@ export function isRenderedFilePath(value: string) {
     path.endsWith('.html') ||
     path.endsWith('.htm') ||
     path.endsWith('.md') ||
-    path.endsWith('.markdown')
+    path.endsWith('.markdown') ||
+    getImageMimeTypeFromPath(path) !== undefined
   );
 }
 

--- a/packages/web-shell/client/components/artifacts/artifactUtils.test.ts
+++ b/packages/web-shell/client/components/artifacts/artifactUtils.test.ts
@@ -3,8 +3,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { DaemonSessionArtifact } from '@qwen-code/sdk/daemon';
 import {
+  getArtifactImageMimeType,
   getArtifactTypeLabel,
   normalizePath,
+  readWorkspaceFileAsBlob,
   withArtifactPreviewCsp,
 } from './artifactUtils';
 
@@ -36,6 +38,137 @@ describe('artifactUtils', () => {
     expect(getArtifactTypeLabel(artifact)).toBe('other');
   });
 
+  it('detects safe raster image artifacts from MIME type or path', () => {
+    expect(
+      getArtifactImageMimeType({
+        mimeType: 'image/webp; charset=binary',
+      } as DaemonSessionArtifact),
+    ).toBe('image/webp');
+    expect(
+      getArtifactImageMimeType({
+        workspacePath: 'images/photo.JPG',
+      } as DaemonSessionArtifact),
+    ).toBe('image/jpeg');
+    expect(
+      getArtifactImageMimeType({
+        mimeType: 'image/svg+xml',
+        workspacePath: 'diagram.jpg',
+      } as DaemonSessionArtifact),
+    ).toBeUndefined();
+    expect(
+      getArtifactImageMimeType({
+        mimeType: 'image/jpg',
+      } as DaemonSessionArtifact),
+    ).toBe('image/jpeg');
+  });
+
+  it('stops at the file size even when byte windows stay truncated', async () => {
+    const statFile = vi.fn().mockResolvedValue({
+      sizeBytes: 5,
+      modifiedMs: 1,
+    });
+    const readFileBytes = vi
+      .fn()
+      .mockResolvedValueOnce({
+        contentBase64: btoa('ab'),
+        offset: 0,
+        returnedBytes: 2,
+        sizeBytes: 5,
+        truncated: true,
+      })
+      .mockResolvedValueOnce({
+        contentBase64: btoa('cde'),
+        offset: 2,
+        returnedBytes: 3,
+        sizeBytes: 5,
+        truncated: true,
+      });
+
+    const blob = await readWorkspaceFileAsBlob(
+      readFileBytes,
+      'photo.jpg',
+      'image/jpeg',
+      { statFile },
+    );
+
+    expect(blob).toMatchObject({ size: 5, type: 'image/jpeg' });
+    expect(statFile).toHaveBeenCalledTimes(2);
+    expect(readFileBytes).toHaveBeenNthCalledWith(1, 'photo.jpg', {
+      offset: 0,
+      maxBytes: 100 * 1024,
+    });
+    expect(readFileBytes).toHaveBeenNthCalledWith(2, 'photo.jpg', {
+      offset: 2,
+      maxBytes: 100 * 1024,
+    });
+  });
+
+  it('stops reading image chunks after cancellation', async () => {
+    let cancelled = false;
+    const statFile = vi.fn().mockResolvedValue({
+      sizeBytes: 5,
+      modifiedMs: 1,
+    });
+    const readFileBytes = vi.fn().mockImplementation(async () => {
+      cancelled = true;
+      return {
+        contentBase64: btoa('ab'),
+        offset: 0,
+        returnedBytes: 2,
+        sizeBytes: 5,
+      };
+    });
+
+    await expect(
+      readWorkspaceFileAsBlob(readFileBytes, 'photo.jpg', 'image/jpeg', {
+        statFile,
+        isCancelled: () => cancelled,
+      }),
+    ).rejects.toThrow('cancelled');
+    expect(readFileBytes).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects images larger than the configured preview limit', async () => {
+    const statFile = vi.fn().mockResolvedValue({
+      sizeBytes: 5,
+      modifiedMs: 1,
+    });
+    const readFileBytes = vi.fn().mockResolvedValue({
+      contentBase64: btoa('ab'),
+      offset: 0,
+      returnedBytes: 2,
+      sizeBytes: 5,
+    });
+
+    await expect(
+      readWorkspaceFileAsBlob(readFileBytes, 'photo.jpg', 'image/jpeg', {
+        statFile,
+        maxBytes: 4,
+      }),
+    ).rejects.toThrow('too large');
+    expect(readFileBytes).not.toHaveBeenCalled();
+  });
+
+  it('rejects chunks read across different file versions', async () => {
+    const statFile = vi
+      .fn()
+      .mockResolvedValueOnce({ sizeBytes: 2, modifiedMs: 1 })
+      .mockResolvedValueOnce({ sizeBytes: 2, modifiedMs: 2 });
+    const readFileBytes = vi.fn().mockResolvedValue({
+      contentBase64: btoa('ab'),
+      offset: 0,
+      returnedBytes: 2,
+      sizeBytes: 2,
+    });
+
+    await expect(
+      readWorkspaceFileAsBlob(readFileBytes, 'photo.jpg', 'image/jpeg', {
+        statFile,
+      }),
+    ).rejects.toThrow('changed while loading');
+    expect(statFile).toHaveBeenCalledTimes(2);
+  });
+
   it('injects preview CSP and strips unsafe metadata', () => {
     const output = withArtifactPreviewCsp(`
       <html>
@@ -52,6 +185,7 @@ describe('artifactUtils', () => {
 
     expect(output).toContain('Content-Security-Policy');
     expect(output).toContain("default-src 'none'");
+    expect(output).toContain("script-src 'unsafe-inline'");
     expect(output).not.toContain('report-uri');
     expect(output).not.toMatch(/http-equiv=["']?refresh/i);
     expect(output).not.toMatch(/<noscript\b/i);
@@ -70,6 +204,7 @@ describe('artifactUtils', () => {
 
     expect(output).toContain('Content-Security-Policy');
     expect(output).toContain("default-src 'none'");
+    expect(output).toContain("script-src 'unsafe-inline'");
     expect(output).not.toContain('report-uri');
     expect(output).not.toMatch(/http-equiv=["']?refresh/i);
     expect(output).not.toMatch(/<noscript\b/i);

--- a/packages/web-shell/client/components/artifacts/artifactUtils.ts
+++ b/packages/web-shell/client/components/artifacts/artifactUtils.ts
@@ -1,4 +1,7 @@
-import type { DaemonSessionArtifact } from '@qwen-code/sdk/daemon';
+import type {
+  DaemonSessionArtifact,
+  DaemonWorkspaceFileBytes,
+} from '@qwen-code/sdk/daemon';
 
 export function artifactKindLabel(kind: string): string {
   switch (kind) {
@@ -25,6 +28,111 @@ export function formatArtifactSize(sizeBytes: number | undefined): string {
   if (sizeBytes < 1024) return `${sizeBytes} B`;
   if (sizeBytes < 1024 * 1024) return `${(sizeBytes / 1024).toFixed(1)} KB`;
   return `${(sizeBytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+const IMAGE_MIME_TYPES: Readonly<Record<string, string>> = {
+  avif: 'image/avif',
+  bmp: 'image/bmp',
+  gif: 'image/gif',
+  ico: 'image/x-icon',
+  jpeg: 'image/jpeg',
+  jpg: 'image/jpeg',
+  png: 'image/png',
+  webp: 'image/webp',
+};
+
+const MAX_IMAGE_PREVIEW_BYTES = 100 * 1024 * 1024;
+const IMAGE_PREVIEW_CHUNK_BYTES = 100 * 1024;
+
+export function getArtifactImageMimeType(
+  artifact: DaemonSessionArtifact,
+): string | undefined {
+  const mimeType = artifact.mimeType?.split(';', 1)[0]?.trim().toLowerCase();
+  if (mimeType?.startsWith('image/')) {
+    if (mimeType === 'image/jpg') return 'image/jpeg';
+    return Object.values(IMAGE_MIME_TYPES).includes(mimeType)
+      ? mimeType
+      : undefined;
+  }
+  return getImageMimeTypeFromPath(artifact.workspacePath ?? '');
+}
+
+export function getImageMimeTypeFromPath(path: string): string | undefined {
+  const normalizedPath = path.toLowerCase();
+  const extension = normalizedPath.includes('.')
+    ? normalizedPath.split('.').pop()
+    : undefined;
+  return extension ? IMAGE_MIME_TYPES[extension] : undefined;
+}
+
+export async function readWorkspaceFileAsBlob(
+  readFileBytes: (
+    filePath: string,
+    opts?: { offset?: number; maxBytes?: number },
+  ) => Promise<
+    Pick<
+      DaemonWorkspaceFileBytes,
+      'contentBase64' | 'offset' | 'returnedBytes' | 'sizeBytes'
+    >
+  >,
+  filePath: string,
+  mimeType: string,
+  options: {
+    statFile: (
+      filePath: string,
+    ) => Promise<{ sizeBytes: number; modifiedMs: number }>;
+    isCancelled?: () => boolean;
+    maxBytes?: number;
+  },
+): Promise<Blob> {
+  const chunks: Uint8Array[] = [];
+  const maxBytes = options.maxBytes ?? MAX_IMAGE_PREVIEW_BYTES;
+  const initialStat = await options.statFile(filePath);
+  if (options.isCancelled?.()) {
+    throw new Error('Image loading was cancelled.');
+  }
+  if (initialStat.sizeBytes > maxBytes) {
+    throw new Error('Image is too large to preview or download.');
+  }
+  let offset = 0;
+  while (true) {
+    if (options.isCancelled?.()) {
+      throw new Error('Image loading was cancelled.');
+    }
+    const file = await readFileBytes(filePath, {
+      offset,
+      maxBytes: IMAGE_PREVIEW_CHUNK_BYTES,
+    });
+    if (options.isCancelled?.()) {
+      throw new Error('Image loading was cancelled.');
+    }
+    if (file.sizeBytes !== initialStat.sizeBytes) {
+      throw new Error('Image changed while loading. Please retry.');
+    }
+    if (file.returnedBytes <= 0 && offset < initialStat.sizeBytes) {
+      throw new Error('Image loading made no progress.');
+    }
+    const binary = atob(file.contentBase64);
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index++) {
+      bytes[index] = binary.charCodeAt(index);
+    }
+    chunks.push(bytes);
+    offset = file.offset + file.returnedBytes;
+    if (offset >= initialStat.sizeBytes) {
+      const finalStat = await options.statFile(filePath);
+      if (options.isCancelled?.()) {
+        throw new Error('Image loading was cancelled.');
+      }
+      if (
+        finalStat.sizeBytes !== initialStat.sizeBytes ||
+        finalStat.modifiedMs !== initialStat.modifiedMs
+      ) {
+        throw new Error('Image changed while loading. Please retry.');
+      }
+      return new Blob(chunks, { type: mimeType });
+    }
+  }
 }
 
 export function getArtifactLocation(artifact: DaemonSessionArtifact): string {
@@ -81,7 +189,7 @@ export function isSamePath(
 }
 
 const ARTIFACT_PREVIEW_CSP =
-  "default-src 'none'; base-uri 'none'; style-src 'unsafe-inline'; img-src data: blob:;";
+  "default-src 'none'; base-uri 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:;";
 
 export function withArtifactPreviewCsp(html: string) {
   if (typeof DOMParser === 'undefined') {


### PR DESCRIPTION
## What this PR does

This PR fixes two Web Shell artifact-preview failures. HTML artifacts can now run their inline rendering scripts inside a sandboxed iframe, and workspace image artifacts are read through the binary byte endpoint instead of the text-file endpoint. Image reads use bounded 100 KiB windows, stop at the reported file size, stop after cancellation, reject files larger than 100 MiB, and verify the file size and modification time across the full read so preview and download data cannot silently mix file versions.

It also improves the artifact experience by showing format-specific Lucide icons with the existing document icon as the fallback, adding raster-image previews to review results, exposing a download action when hovering or focusing an image preview, and refining the edited-files summary so line statistics stay on the second row while summaries without statistics remain vertically centered.

## Why it's needed

Generated HTML artifacts previously rendered only partially because iframe scripts were blocked. Binary images were sent through the text-file route, which returned HTTP 422, and the first byte-reading implementation treated the route's `truncated` flag as an end-of-file signal even though that flag remains true for every windowed response. This could repeatedly request the end offset instead of completing.

The HTML iframe remains isolated from the Web Shell: scripts are allowed, but same-origin access is not, and the injected CSP continues to block external network access. Image previews are limited to safe raster formats; SVG remains excluded.

## Reviewer Test Plan

### How to verify

Open a generated HTML artifact that relies on inline JavaScript and confirm the complete content renders while external stylesheet and network requests remain blocked. Open PNG, JPEG, GIF, WebP, AVIF, BMP, or ICO workspace artifacts and confirm the image loads, the download action appears on hover or keyboard focus, and closing the preview stops subsequent byte-window requests. Open an image from the review panel and confirm it uses the same preview. Confirm edited-file summaries keep additions and deletions below the title when statistics exist and remain vertically centered when they do not.

Run the focused artifact unit tests and confirm the CSP, icon selection, image format detection, 100 KiB byte windows, end-of-file handling, cancellation, size limit, and cross-window file-version checks pass.

### Evidence (Before & After)

Before: inline scripts were blocked by the iframe sandbox, image files failed through the text route with HTTP 422, and windowed reads could continue at the final offset. After: focused tests cover inline-script CSP, safe raster detection, bounded byte assembly, cancellation, file-version consistency, and review preview eligibility. UI automation and screenshots were not captured for this change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Focused Web Shell Vitest, ESLint, Prettier, and diff checks were run locally. The full repository build and UI automation were not run.

## Risk & Scope

- Main risk or tradeoff: Allowing inline scripts increases artifact capability, but the iframe keeps an opaque origin and the CSP blocks external resources; raster image preview and in-memory download are capped at 100 MiB.
- Not validated / out of scope: UI automation, full repository build, external scripts and styles, SVG rendering, image zoom or full-screen lightbox behavior.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 修复了 Web Shell 中两个 artifact 预览问题。HTML artifact 现在可以在沙箱 iframe 中执行内联渲染脚本；工作区图片 artifact 改用二进制字节接口读取，不再走文本文件接口。图片读取使用受限的 100 KiB 分片，在到达服务端返回的文件大小后结束，关闭预览后停止后续分片，拒绝超过 100 MiB 的文件，并在完整读取前后校验文件大小和修改时间，避免预览或下载静默拼接不同版本的文件内容。

同时优化了 artifact 体验：根据格式显示对应的 Lucide 图标，现有文档图标继续作为兜底；审核结果中的栅格图片支持预览；鼠标悬停或键盘聚焦图片时显示下载操作；调整已编辑文件摘要布局，有行数统计时统计信息位于第二行，没有统计时摘要保持垂直居中。

## 为什么需要

此前生成的 HTML artifact 会因为 iframe 脚本被阻止而只渲染部分内容。二进制图片通过文本文件接口读取时会返回 HTTP 422；最初的字节读取实现还把接口的 `truncated` 字段当成文件结束标记，但窗口读取的每个响应都会保持该字段为 true，因此可能在最终 offset 上持续发起请求而无法完成。

HTML iframe 仍与 Web Shell 隔离：允许执行脚本，但不开放同源权限，并且注入的 CSP 继续阻止外部网络访问。图片预览只支持安全的栅格格式，SVG 仍不包含在内。

## 审核测试计划

### 如何验证

打开依赖内联 JavaScript 的生成 HTML artifact，确认完整内容能够渲染，同时外部样式表和网络请求仍被阻止。打开 PNG、JPEG、GIF、WebP、AVIF、BMP 或 ICO 工作区 artifact，确认图片可以加载，鼠标悬停或键盘聚焦时出现下载操作，并且关闭预览后不再发起新的字节分片请求。从审核面板打开图片，确认复用相同的预览。确认存在行数统计时，已编辑文件摘要的新增和删除统计位于标题下方；没有统计时摘要保持垂直居中。

运行 artifact 定向单元测试，确认 CSP、图标选择、图片格式识别、100 KiB 字节分片、文件结束处理、取消、大小限制和跨分片文件版本校验均通过。

### 证据（修改前后）

修改前：内联脚本被 iframe sandbox 阻止，图片文件通过文本接口读取时返回 HTTP 422，窗口读取可能在最终 offset 上继续请求。修改后：定向测试覆盖了内联脚本 CSP、安全栅格图片识别、受限字节拼接、取消、文件版本一致性和审核预览资格。本次变更未采集 UI 自动化结果或截图。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|     🍏 macOS      |  ✅  |
|    🪟 Windows     |  ⚠️  |
|     🐧 Linux      |  ⚠️  |

### 环境（可选）

本地运行了 Web Shell 定向 Vitest、ESLint、Prettier 和 diff 检查。未运行全仓库构建和 UI 自动化。

## 风险与范围

- 主要风险或权衡：允许内联脚本提升了 artifact 能力，但 iframe 仍使用不透明源，CSP 继续阻止外部资源；栅格图片预览和内存下载上限为 100 MiB。
- 未验证或不在范围内：UI 自动化、全仓库构建、外部脚本和样式、SVG 渲染、图片缩放或全屏灯箱。
- 破坏性变更或迁移说明：无。

## 关联 Issue

无

</details>
