### PR TITLE
feat(serve): Add daemon resource budgeting foundations

### DIFF
--- a/docs/design/daemon-multi-workspace-resource-protection-phase-1.md
+++ b/docs/design/daemon-multi-workspace-resource-protection-phase-1.md
@@ -1,0 +1,358 @@
+# Daemon Multi-Workspace Resource Protection: Phase 1
+
+## Status
+
+- Tracking issue: [#8051](https://github.com/QwenLM/qwen-code/issues/8051)
+- Delivery split: [#8091](https://github.com/QwenLM/qwen-code/issues/8091)
+- Scope: production `qwen serve` root and daemon-managed restore paths
+- Out of scope: workspace/session capacity LRU, active-session eviction,
+  RSS-triggered remediation, and generic exactly-once operation receipts
+
+This document describes the target state after the complete Phase 1 stack
+lands. The first delivery PR adds only the budget and scheduler foundations; it
+does not wire production routes, advertise resource guards, or change daemon
+behavior.
+
+## Problem
+
+The daemon limits registered workspaces and sessions, but count limits are not
+memory limits. A single large request, transcript, replay burst, slow client,
+child-process result, or generation-scoped cache can still exhaust the daemon.
+Dynamic workspace churn also makes any missing disposal hook an unbounded
+retention path.
+
+Phase 1 establishes deterministic byte and queue limits before adding any
+memory-pressure action. It keeps the existing workspace and session defaults:
+25 registered workspaces, 20 sessions per workspace, and the existing
+`maxTotalSessions` derivation behavior.
+
+## Invariants
+
+1. Resource admission is synchronous and never waits.
+2. Operations with a declared heap peak reserve it before entering a scheduler
+   lane or state lock. Reader-only operations use fixed source/record limits;
+   no path waits for memory while holding a lane or lock.
+3. Every reservation has one generation-scoped owner and an idempotent release
+   path.
+4. New work cannot consume the completion reserve.
+5. Cleanup and fixed terminal responses remain possible when normal admission
+   is full.
+6. Workspace-scoped work stays pinned to its resolved runtime generation and
+   never falls back to the primary runtime.
+7. Memory observation has no remediation side effects in Phase 1.
+
+## Resource Budget
+
+The daemon creates one process-owned `ResourceBudget` at the start of
+`runQwenServeImpl`, before runtime configuration, bridge, route, and logger
+publication work. The same instance is injected into every daemon-owned
+runtime and transport.
+
+The default heap proxy cap is 512 MiB. Normal admissions may consume at most
+384 MiB. The remaining 128 MiB is reserved for completion-priority leases held
+by already-admitted response encoding and cleanup. Fixed overload and shutdown
+responses are constant-size schemas, do not copy request payloads, and use a
+separate emergency category capped below 3 MiB. Business responses cannot
+reserve that category.
+
+`tryReserveComposite` atomically evaluates the parent cap, admission ceiling,
+and every requested category watermark. Leases can be split, transferred,
+shrunk, grown with a non-waiting attempt, and released idempotently. A lease is
+tagged with its category and optional workspace/runtime/channel generation.
+
+Heap proxy charging includes all simultaneously retained representations:
+
+- buffer bytes;
+- two bytes per JavaScript string code unit;
+- 96 bytes per object/array node;
+- 16 bytes per property or array slot;
+- raw, decoded, parsed, encoded, and base64 copies while they coexist.
+
+The initial policy is:
+
+| Resource                    |                                                   Limit |
+| --------------------------- | ------------------------------------------------------: |
+| Daemon heap proxy           |                                                 512 MiB |
+| Normal admission ceiling    |                                                 384 MiB |
+| Completion reserve          |                                                 128 MiB |
+| Emergency response pool     |                                                 < 3 MiB |
+| Runtime baseline            |                                                   1 MiB |
+| Root session baseline       |                                                 256 KiB |
+| ACP connection baseline     |                                                  32 KiB |
+| WebSocket active + pending  |                                                      32 |
+| WebSocket assembly          |                                                 256 MiB |
+| Parsed inbound              | 128 MiB global / 32 MiB and 256 messages per connection |
+| Prepared outbound           |                                   256 MiB / 4096 frames |
+| Prompt                      |                     48 accepted globally, 5 per session |
+| Completed replay/cache      |                                                 128 MiB |
+| Background jobs             |                                                  64 MiB |
+| Voice retained data         |                                                 128 MiB |
+| Buffered process output     |                                                 128 MiB |
+| Fan-out snapshots           |                                                  32 MiB |
+| Settings source per scope   |                                                   8 MiB |
+| Session organization store  |                                                   8 MiB |
+| ACP pending client requests |                              256 / 8 MiB per connection |
+| Generation stream queue     |                          128 frames / 8 MiB per request |
+| Session shell output        |                                                   8 MiB |
+| Early child events          |      64 sessions / 32 each / 8 MiB per channel retained |
+| Daemon log directory scan   |                                            4096 entries |
+
+Category limits are watermarks, not partitions. The parent and completion
+reserve still apply when the category limits sum to more than 512 MiB.
+
+## Bounded Protocols
+
+### HTTP and JSON
+
+HTTP JSON bodies remain limited to 10 MiB and accept only identity
+`Content-Encoding`. A JSON request reserves the parser ceiling before body
+collection, then shrinks or non-blockingly grows the lease to the inspected
+raw/decoded/parsed heap estimate before `JSON.parse`.
+
+Generic JSON is limited to depth 64, 10,000 nodes, and 1 MiB per string.
+Prompt, file, and voice routes use fixed schema profiles that allow their
+documented large fields. Protected routes encode with a bounded canonical JSON
+encoder that rejects accessors, `toJSON`, cycles, `BigInt`, and non-plain
+objects unless the endpoint normalizes them first.
+
+### WebSocket and NDJSON
+
+ACP and CDP WebSocket frames are limited to 8 MiB. Voice retains its existing
+10 MiB frame contract. Compression is disabled. The global active-plus-pending
+WebSocket cap is 32 and remains active when the listener connection cap is
+disabled. ACP, CDP, and voice message handling uses a FIFO with explicit
+message-count and retained-byte admission; daemon-owned frames also reserve
+the shared ingress category until handling settles.
+
+Parent-to-channel-worker webhook IPC permits 64 pending tasks and 16 MiB of
+serialized pending data. Success, failure, timeout, worker exit, and shutdown
+all release the same accounting.
+
+The internal ACP NDJSON frame limit is 64 MiB including the line terminator.
+The reader is pull-driven, keeps at most one parsed message queued, and charges
+raw chunks, concatenation copies, parsed heap estimates, and outbound encoding
+copies. It counts chunks before concatenation, decoding, and parsing. Outbound
+messages are structurally inspected and measured before `JSON.stringify`, so
+escaping cannot allocate past the declared frame budget; unsafe JSON objects
+are rejected without invoking their accessors or `toJSON`. Incomplete EOF is
+fatal on daemon-managed streams. Malformed input diagnostics contain only size
+and a bounded SHA-256 fingerprint.
+
+Streamable HTTP transfers the parsed-body lease to each accepted post-response
+dispatch before returning 202 and limits a semantic connection to 256
+in-flight dispatches. The lease remains charged until dispatch settles rather
+than being released with the acknowledgement response.
+
+Public `ndJsonStream` defaults stay source compatible. Daemon callers opt into
+the frame/structure limits, resource leases, and fatal EOF behavior. Existing
+payload-byte hooks keep their meaning; an additive wire-byte hook includes
+CR/LF.
+
+### Delivery ownership
+
+Transport send operations resolve to `delivered`, `closed`, or `failed`:
+
+- HTTP delivery completes on response `finish`;
+- SSE delivery completes after the write callback or drain while the stream is
+  still open;
+- WebSocket delivery completes in the send callback.
+
+These states cover local socket delivery, not an end-client acknowledgement.
+Fresh session ownership follows:
+
+`REQUEST -> OPERATION -> PENDING_DELIVERY -> OWNED | DISCARDED`
+
+A provisional binding cannot prompt or appear in `ownedSessions`. Failed
+delivery removes a fresh session and rolls back an existing attach.
+
+## Event and Replay Protection
+
+One event and one replay turn are limited to 8 MiB. The per-session ring is
+bounded by both its configured count and an 8 MiB heap proxy. Completed,
+rebuildable replay caches may use LRU eviction; workspace and session objects
+may not.
+
+Byte eviction sets a sticky
+`requiresAuthoritativeReload { reason, anchor }`. It remains until an
+authoritative restore or a new bus generation. Active turns use only lossless
+coalescing. A turn over 8 MiB, 10,000 events, or its retained ceiling emits one
+`turn_workset_too_large` terminal error and closes the exact channel
+generation.
+
+Explicit `historyPageSize` selects byte-paged mode and returns the newest
+complete-turn suffix with `hasMore`, `anchorRecordId`, `byteLimited`, and
+`limitBytes`. Omitting `historyPageSize` keeps legacy full mode: histories up
+to 8 MiB are returned in full; larger histories fail atomically with
+`session_replay_limit_exceeded`. They are never silently truncated.
+
+## Session and File Protection
+
+Daemon-managed `SessionService` instances receive a
+`SessionLoadProtectionPolicy`:
+
+- source snapshot: 32 MiB;
+- physical line: 8 MiB;
+- records: 100,000;
+- depth: 64;
+- nodes: 10,000 per record;
+- single string: 8 MiB;
+- retained decoded records/messages/artifacts: 128 MiB.
+
+Restore acquires the writer barrier, records file identity and size, reads that
+snapshot, and checks identity again. Replacement, shrinkage, and short reads
+fail. Appends after the snapshot are ignored and reported as
+`hasNewerData: true`. Managed resume performs one authoritative load and then
+atomically initializes session data, goal runtime, recorder, and Gemini.
+
+Session catalogs use bounded directory iteration instead of materializing all
+names. A request inspects and matches at most 50,000 entries and retains only
+the requested top-k page plus one. Head scans reuse the physical-line and file
+identity checks. An oversized individual file is skipped with a truncation
+diagnostic rather than failing the whole page.
+
+Workspace path completion also streams directory entries. It inspects at most
+4,096 entries and retains the lexicographically smallest 50 matching
+directories.
+
+Virtual subagent readers use the same bounded reader. Branch and rewind use
+bounded snapshots, temporary files, and atomic rename. A post-commit delivery
+failure is `outcome_unknown` and is not automatically retried. Export admits a
+64 MiB representation before collection/formatting, then writes the bounded
+encoded result to a mode-0600 temporary file. The spool permits four files and
+256 MiB total.
+
+## Scheduling and Lifecycle
+
+`FairDaemonBulkScheduler` permits four global active operations, 128 waiting
+operations, one active operation per workspace, and 16 waiters per workspace.
+`FairDaemonSpawnScheduler` permits four active roots and 128 waiters. Buffered
+child processes use four active slots, 128 waiters, and 128 MiB of retained
+output. Queue entries have a 30-second deadline and an abort signal. A shared
+execution context rejects nested and cross-lane acquisition while a scheduled
+task is active.
+
+The ordering is:
+
+1. bounded ingress and authentication;
+2. resolve and pin the runtime generation;
+3. semantic singleflight;
+4. acquire Spawn only at the actual root-fork point;
+5. acquire generation/read lease, ordered archive keys, and session FIFO;
+6. acquire Heavy only at the source/decode/format seam;
+7. prepare the bounded result, release locks and lanes, then deliver.
+
+Heavy code cannot call `ensureChannel`, acquire Spawn, or recursively acquire
+Heavy. A channel failure fails the top-level operation without restarting
+inside a state lock.
+
+Every runtime owns a `WorkspaceResourceScope`. Its single disposal commit runs
+registered cleanup callbacks, prevents late generation work from repopulating
+generation-scoped state, and only then releases runtime and session baseline
+leases. Runtime shutdown remains the owner of bridge, MCP, skills, goal,
+authorization, and background-job state. The added disposer registry covers
+module caches and queues that previously outlived runtime removal, including
+settings mutation locks, transcript state, GitHub PR cache, and extension
+controller state. Process-global canonical-path and telemetry memoization use
+a fixed LRU of at most 64 entries.
+
+Daemon settings reads use fixed snapshots capped at 8 MiB per system-default,
+system, user, and workspace scope. The serve fast path applies the same cap to
+settings, trust, and environment sources before parsing. The session
+organization sidecar uses the same per-workspace cap, fixed-snapshot identity
+checks, and generation disposal for its warning cache.
+
+## Observe-Only Memory Status
+
+The CLI adds:
+
+- `--memory-pressure-mode <off|observe>`, default `off`;
+- `--memory-budget-mb <positive-safe-integer>`.
+
+Providing only a budget enables observe mode. Explicit `off` with a budget is
+invalid. Phase 1 does not accept `enforce`.
+
+A non-overlapping sampler runs every 15 seconds. It reports daemon process-tree
+RSS and cgroup usage/limit as independent sources. Linux prefers cgroup data
+for the pressure level and uses process-tree data for fallback or attribution.
+Windows validates PID creation identity.
+
+Levels are `normal <70%`, `soft >=70%`, `hard >=85%`, and
+`critical >=95%`. Escalation is immediate. Recovery requires three consecutive
+complete samples below the target boundary minus five percentage points.
+Partial or stale samples may escalate but cannot recover a hard or critical
+state.
+
+The observer never invokes GC, LRU, session closure, channel reclamation, or
+process termination. Existing child-local legacy policies remain unchanged
+and are reported as such.
+
+## Status and Errors
+
+Status adds:
+
+- `limits.maxTotalSessionsSource`;
+- `limits.resourceGuards`, whose matrix names only paths that are fully wired;
+- `limits.memory { mode, budgetBytes, enforced: false }`;
+- `runtime.resourceBudget`;
+- `runtime.memory`;
+- `daemon_memory_pressure` and `daemon_memory_observation_stale` issues.
+
+The legacy primary-only `childRssBytes` field remains. Additive fields report
+child sum, maximum, unknown count, and bounded per-workspace attribution.
+
+REST and ACP share:
+
+```ts
+interface DaemonResourceErrorData {
+  errorKind: string;
+  httpStatus: number;
+  limitBytes?: number;
+  observedBytes?: number;
+  minimumBytes?: number;
+  actualBytesKnown?: boolean;
+  retryable: boolean;
+}
+```
+
+Representation limits return 413. Resource and queue admission return 503 with
+`Retry-After`. The existing workspace registration cap remains 409. Error
+summaries are at most 1 KiB and never include the original large payload.
+
+## Shutdown
+
+The shutdown implementation builds on
+[#7975](https://github.com/QwenLM/qwen-code/pull/7975). Root-owned POSIX
+children use their own process group. Windows registrations retain PID and
+creation identity and revalidate it before tree termination.
+
+At shutdown entry the daemon synchronously seals listener, workspace/session,
+Bulk, Spawn, Process, and process-registry admission. Runtime and bridge
+cleanup then drains or aborts writers before the shared process registry
+verifies owned process trees. Remaining children receive the registry's
+graceful-close, TERM, rescan, and KILL sequence. Only after runtime/process
+cleanup does the listener's five-second drain deadline force-close sockets; a
+second two-second deadline turns a missing `server.close` callback into an
+unclean error.
+
+Unsettled resource leases, process-tree verification failures, writer/runtime
+shutdown failures, or a stuck listener make shutdown unclean and produce a
+non-zero exit. The strong guarantee covers daemon root-owned process groups.
+Detached descendants created inside ACP remain a documented Phase 2 residual.
+
+## Compatibility
+
+The workspace and session count defaults do not change. Resource admission can
+return 503 even when count caps are disabled. Other intentional changes are:
+
+- global WebSocket cap 32;
+- ACP/CDP frame cap 8 MiB, voice unchanged at 10 MiB;
+- compressed JSON rejected with 415;
+- large legacy replay fails with 413 unless byte paging is requested;
+- replay count may be shortened by the byte cap;
+- oversized active turns close their exact channel generation;
+- slow clients and full queues fail deterministically;
+- shutdown waits for writer/runtime cleanup before applying a bounded
+  seven-second listener drain and terminates root-owned descendants.
+
+Standalone ACP construction and public `ndJsonStream` defaults remain
+unchanged.

--- a/packages/cli/src/serve/buffered-process-budget.test.ts
+++ b/packages/cli/src/serve/buffered-process-budget.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  DaemonBulkAdmissionError,
+  FairDaemonProcessScheduler,
+} from './fair-daemon-bulk-scheduler.js';
+import { ResourceBudget } from './resource-budget.js';
+import { runBufferedProcessOperation } from './buffered-process-budget.js';
+
+describe('runBufferedProcessOperation', () => {
+  it('holds the declared process output budget until completion', async () => {
+    const budget = new ResourceBudget({
+      capBytes: 1024,
+      normalAdmissionBytes: 1024,
+      categoryCaps: { process: 1024 },
+    });
+    let observed = 0;
+    await runBufferedProcessOperation(
+      new FairDaemonProcessScheduler(),
+      budget,
+      '/workspace',
+      'git',
+      256,
+      async () => {
+        observed = budget.snapshot().categories.process.usedBytes;
+      },
+    );
+    expect(observed).toBe(256);
+    expect(budget.snapshot().usedBytes).toBe(0);
+  });
+
+  it('releases the reservation when the task or scheduler rejects', async () => {
+    const budget = new ResourceBudget({
+      capBytes: 1024,
+      normalAdmissionBytes: 1024,
+      categoryCaps: { process: 1024 },
+    });
+    const scheduler = new FairDaemonProcessScheduler();
+
+    await expect(
+      runBufferedProcessOperation(
+        scheduler,
+        budget,
+        '/workspace',
+        'git',
+        256,
+        async () => {
+          throw new Error('process failed');
+        },
+      ),
+    ).rejects.toThrow('process failed');
+    expect(budget.snapshot().usedBytes).toBe(0);
+
+    scheduler.seal();
+    await expect(
+      runBufferedProcessOperation(
+        scheduler,
+        budget,
+        '/workspace',
+        'git',
+        256,
+        async () => undefined,
+      ),
+    ).rejects.toBeInstanceOf(DaemonBulkAdmissionError);
+    expect(budget.snapshot().usedBytes).toBe(0);
+  });
+});

--- a/packages/cli/src/serve/buffered-process-budget.ts
+++ b/packages/cli/src/serve/buffered-process-budget.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  ResourceAdmissionError,
+  type ResourceBudget,
+} from './resource-budget.js';
+import type { FairDaemonProcessScheduler } from './fair-daemon-bulk-scheduler.js';
+
+export type BufferedProcessRunner = <T>(
+  workspaceCwd: string,
+  operation: string,
+  maximumBufferedBytes: number,
+  task: () => Promise<T>,
+  signal?: AbortSignal,
+) => Promise<T>;
+
+export function createBufferedProcessRunner(
+  scheduler: FairDaemonProcessScheduler,
+  budget: ResourceBudget,
+): BufferedProcessRunner {
+  return (workspaceCwd, operation, maximumBufferedBytes, task, signal) =>
+    runBufferedProcessOperation(
+      scheduler,
+      budget,
+      workspaceCwd,
+      operation,
+      maximumBufferedBytes,
+      task,
+      signal,
+    );
+}
+
+export async function runBufferedProcessOperation<T>(
+  scheduler: FairDaemonProcessScheduler,
+  budget: ResourceBudget,
+  workspaceCwd: string,
+  operation: string,
+  maximumBufferedBytes: number,
+  task: () => Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  if (!Number.isSafeInteger(maximumBufferedBytes) || maximumBufferedBytes < 1) {
+    throw new TypeError('maximumBufferedBytes must be a positive safe integer');
+  }
+  const reservation = budget.tryReserveComposite(
+    [{ category: 'process', bytes: maximumBufferedBytes }],
+    { owner: { workspaceId: workspaceCwd, operation } },
+  );
+  if (!reservation.ok) throw new ResourceAdmissionError(reservation);
+  try {
+    return await scheduler.run(workspaceCwd, operation, task, signal);
+  } finally {
+    reservation.lease.release();
+  }
+}

--- a/packages/cli/src/serve/fair-daemon-bulk-scheduler.test.ts
+++ b/packages/cli/src/serve/fair-daemon-bulk-scheduler.test.ts
@@ -1,0 +1,250 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DAEMON_BULK_GLOBAL_ACTIVE_LIMIT,
+  DAEMON_BULK_GLOBAL_WAIT_LIMIT,
+  DAEMON_BULK_WORKSPACE_WAIT_LIMIT,
+  DaemonBulkAdmissionError,
+  FairDaemonBulkScheduler,
+  FairDaemonProcessScheduler,
+  FairDaemonSpawnScheduler,
+} from './fair-daemon-bulk-scheduler.js';
+
+function deferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+} {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe('FairDaemonBulkScheduler', () => {
+  it('limits global and per-workspace concurrency while rotating workspaces', async () => {
+    const scheduler = new FairDaemonBulkScheduler();
+    const gates = Array.from({ length: 6 }, deferred);
+    const started: string[] = [];
+    const runs = [
+      scheduler.run('/a', 'a1', async () => {
+        started.push('a1');
+        await gates[0].promise;
+      }),
+      scheduler.run('/a', 'a2', async () => {
+        started.push('a2');
+        await gates[1].promise;
+      }),
+      scheduler.run('/b', 'b1', async () => {
+        started.push('b1');
+        await gates[2].promise;
+      }),
+      scheduler.run('/c', 'c1', async () => {
+        started.push('c1');
+        await gates[3].promise;
+      }),
+      scheduler.run('/d', 'd1', async () => {
+        started.push('d1');
+        await gates[4].promise;
+      }),
+      scheduler.run('/e', 'e1', async () => {
+        started.push('e1');
+        await gates[5].promise;
+      }),
+    ];
+
+    await vi.waitFor(() => {
+      expect(started).toEqual(['a1', 'b1', 'c1', 'd1']);
+    });
+    expect(scheduler.snapshot().active).toBe(DAEMON_BULK_GLOBAL_ACTIVE_LIMIT);
+
+    gates[0].resolve();
+    await vi.waitFor(() => {
+      expect(started).toContain('e1');
+    });
+    expect(started).not.toContain('a2');
+
+    gates[2].resolve();
+    await vi.waitFor(() => {
+      expect(started).toContain('a2');
+    });
+    for (const gate of gates) gate.resolve();
+    await Promise.all(runs);
+    expect(scheduler.snapshot()).toEqual({
+      active: 0,
+      waiting: 0,
+      workspacesWaiting: 0,
+      sealed: false,
+    });
+  });
+
+  it('rejects workspace and global queue overflow', async () => {
+    const scheduler = new FairDaemonBulkScheduler();
+    const gate = deferred();
+    const active = scheduler.run('/a', 'active', () => gate.promise);
+    const workspaceWaiters = Array.from(
+      { length: DAEMON_BULK_WORKSPACE_WAIT_LIMIT },
+      (_, index) => scheduler.run('/a', `wait-${index}`, async () => {}),
+    );
+    await expect(
+      scheduler.run('/a', 'overflow', async () => {}),
+    ).rejects.toBeInstanceOf(DaemonBulkAdmissionError);
+
+    const otherGate = deferred();
+    const globalScheduler = new FairDaemonBulkScheduler();
+    const activeRuns = Array.from(
+      { length: DAEMON_BULK_GLOBAL_ACTIVE_LIMIT },
+      (_, index) =>
+        globalScheduler.run(
+          `/active-${index}`,
+          'active',
+          () => otherGate.promise,
+        ),
+    );
+    const globalWaiters = Array.from(
+      { length: DAEMON_BULK_GLOBAL_WAIT_LIMIT },
+      (_, index) =>
+        globalScheduler.run(`/wait-${index}`, 'wait', async () => {}),
+    );
+    await expect(
+      globalScheduler.run('/overflow', 'overflow', async () => {}),
+    ).rejects.toMatchObject({
+      data: { errorKind: 'daemon_bulk_queue_full', httpStatus: 503 },
+    });
+
+    gate.resolve();
+    otherGate.resolve();
+    await Promise.all([active, ...workspaceWaiters]);
+    await Promise.all([...activeRuns, ...globalWaiters]);
+  });
+
+  it('removes aborted waiters and rejects nested heavy operations', async () => {
+    const scheduler = new FairDaemonBulkScheduler();
+    const gate = deferred();
+    const active = scheduler.run('/a', 'active', () => gate.promise);
+    const controller = new AbortController();
+    const queued = scheduler.run(
+      '/a',
+      'queued',
+      async () => {},
+      controller.signal,
+    );
+    controller.abort(new Error('cancelled'));
+    await expect(queued).rejects.toThrow('cancelled');
+    expect(scheduler.snapshot().waiting).toBe(0);
+
+    gate.resolve();
+    await active;
+    await expect(
+      scheduler.run('/a', 'outer', () =>
+        scheduler.run('/a', 'inner', async () => {}),
+      ),
+    ).rejects.toMatchObject({
+      data: { errorKind: 'nested_daemon_bulk_operation' },
+    });
+  });
+
+  it('rejects cross-lane acquisition from a running operation', async () => {
+    const bulk = new FairDaemonBulkScheduler();
+    const spawn = new FairDaemonSpawnScheduler();
+    const process = new FairDaemonProcessScheduler();
+
+    await expect(
+      bulk.run('/a', 'outer', () =>
+        spawn.run('/a', 'spawn', async () => undefined),
+      ),
+    ).rejects.toMatchObject({
+      data: {
+        errorKind: 'nested_daemon_bulk_to_daemon_spawn_operation',
+      },
+    });
+    await expect(
+      spawn.run('/a', 'outer', () =>
+        process.run('/a', 'process', async () => undefined),
+      ),
+    ).rejects.toMatchObject({
+      data: {
+        errorKind: 'nested_daemon_spawn_to_daemon_process_operation',
+      },
+    });
+  });
+
+  it('allows inherited async work after the parent operation settles', async () => {
+    const bulk = new FairDaemonBulkScheduler();
+    const spawn = new FairDaemonSpawnScheduler();
+    const detachedGate = deferred();
+    let detached: Promise<void> | undefined;
+
+    await bulk.run('/a', 'outer', async () => {
+      detached = detachedGate.promise.then(() =>
+        spawn.run('/a', 'spawn', async () => undefined),
+      );
+    });
+    detachedGate.resolve();
+    await expect(detached).resolves.toBeUndefined();
+  });
+
+  it('seals admission and cancels queued work', async () => {
+    const scheduler = new FairDaemonBulkScheduler();
+    const gate = deferred();
+    const active = scheduler.run('/a', 'active', () => gate.promise);
+    const queued = scheduler.run('/a', 'queued', async () => {});
+    scheduler.seal();
+
+    await expect(queued).rejects.toMatchObject({
+      data: { errorKind: 'daemon_bulk_admission_closed' },
+    });
+    await expect(
+      scheduler.run('/b', 'new', async () => {}),
+    ).rejects.toBeInstanceOf(DaemonBulkAdmissionError);
+    gate.resolve();
+    await active;
+  });
+
+  it('expires queued work at the bounded wait deadline', async () => {
+    vi.useFakeTimers();
+    try {
+      const scheduler = new FairDaemonBulkScheduler({ waitTimeoutMs: 25 });
+      const gate = deferred();
+      const active = scheduler.run('/a', 'active', () => gate.promise);
+      const queued = scheduler.run('/a', 'queued', async () => {});
+      let rejection: unknown;
+      const observed = queued.catch((error: unknown) => {
+        rejection = error;
+      });
+
+      await vi.advanceTimersByTimeAsync(25);
+      await observed;
+      expect(rejection).toMatchObject({
+        data: { errorKind: 'daemon_bulk_queue_timeout', retryable: true },
+      });
+      expect(scheduler.snapshot().waiting).toBe(0);
+      gate.resolve();
+      await active;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('allows four concurrent spawn operations from one workspace', async () => {
+    const scheduler = new FairDaemonSpawnScheduler();
+    const gate = deferred();
+    const started: number[] = [];
+    const runs = Array.from({ length: 5 }, (_, index) =>
+      scheduler.run('/a', `spawn-${index}`, async () => {
+        started.push(index);
+        await gate.promise;
+      }),
+    );
+
+    await vi.waitFor(() => expect(started).toEqual([0, 1, 2, 3]));
+    expect(scheduler.snapshot()).toMatchObject({ active: 4, waiting: 1 });
+    gate.resolve();
+    await Promise.all(runs);
+  });
+});

--- a/packages/cli/src/serve/fair-daemon-bulk-scheduler.ts
+++ b/packages/cli/src/serve/fair-daemon-bulk-scheduler.ts
@@ -1,0 +1,335 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+export const DAEMON_BULK_GLOBAL_ACTIVE_LIMIT = 4;
+export const DAEMON_BULK_GLOBAL_WAIT_LIMIT = 128;
+export const DAEMON_BULK_WORKSPACE_ACTIVE_LIMIT = 1;
+export const DAEMON_BULK_WORKSPACE_WAIT_LIMIT = 16;
+export const DAEMON_SPAWN_GLOBAL_ACTIVE_LIMIT = 4;
+export const DAEMON_SPAWN_GLOBAL_WAIT_LIMIT = 128;
+export const DAEMON_SPAWN_WORKSPACE_WAIT_LIMIT = 16;
+export const DAEMON_PROCESS_GLOBAL_ACTIVE_LIMIT = 4;
+export const DAEMON_PROCESS_GLOBAL_WAIT_LIMIT = 128;
+export const DAEMON_PROCESS_WORKSPACE_WAIT_LIMIT = 16;
+export const DAEMON_SCHEDULER_WAIT_TIMEOUT_MS = 30_000;
+
+interface FairDaemonSchedulerOptions {
+  globalActiveLimit?: number;
+  globalWaitLimit?: number;
+  workspaceActiveLimit?: number;
+  workspaceWaitLimit?: number;
+  waitTimeoutMs?: number;
+  lane?: 'daemon_bulk' | 'daemon_spawn' | 'daemon_process';
+}
+
+interface QueueItem {
+  readonly workspaceCwd: string;
+  readonly operation: string;
+  readonly task: () => Promise<unknown>;
+  readonly resolve: (value: unknown) => void;
+  readonly reject: (reason: unknown) => void;
+  readonly signal?: AbortSignal;
+  abortListener?: () => void;
+  waitTimer?: NodeJS.Timeout;
+}
+
+interface DaemonSchedulerExecution {
+  readonly scheduler: FairDaemonBulkScheduler;
+  readonly lane: 'daemon_bulk' | 'daemon_spawn' | 'daemon_process';
+  active: boolean;
+}
+
+const runningScheduler = new AsyncLocalStorage<DaemonSchedulerExecution>();
+
+export class DaemonBulkAdmissionError extends Error {
+  readonly data: {
+    errorKind: string;
+    httpStatus: 503;
+    actualBytesKnown: false;
+    retryable: true;
+  };
+
+  constructor(errorKind = 'daemon_bulk_queue_full') {
+    super('Daemon bulk-operation capacity is temporarily exhausted');
+    this.name = 'DaemonBulkAdmissionError';
+    this.data = {
+      errorKind,
+      httpStatus: 503,
+      actualBytesKnown: false,
+      retryable: true,
+    };
+  }
+}
+
+export class FairDaemonBulkScheduler {
+  private readonly queues = new Map<string, QueueItem[]>();
+  private readonly workspaceOrder: string[] = [];
+  private readonly activeByWorkspace = new Map<string, number>();
+  private active = 0;
+  private waiting = 0;
+  private sealed = false;
+  private readonly globalActiveLimit: number;
+  private readonly globalWaitLimit: number;
+  private readonly workspaceActiveLimit: number;
+  private readonly workspaceWaitLimit: number;
+  private readonly waitTimeoutMs: number;
+  private readonly lane: 'daemon_bulk' | 'daemon_spawn' | 'daemon_process';
+
+  constructor(options: FairDaemonSchedulerOptions = {}) {
+    this.globalActiveLimit =
+      options.globalActiveLimit ?? DAEMON_BULK_GLOBAL_ACTIVE_LIMIT;
+    this.globalWaitLimit =
+      options.globalWaitLimit ?? DAEMON_BULK_GLOBAL_WAIT_LIMIT;
+    this.workspaceActiveLimit =
+      options.workspaceActiveLimit ?? DAEMON_BULK_WORKSPACE_ACTIVE_LIMIT;
+    this.workspaceWaitLimit =
+      options.workspaceWaitLimit ?? DAEMON_BULK_WORKSPACE_WAIT_LIMIT;
+    this.waitTimeoutMs =
+      options.waitTimeoutMs ?? DAEMON_SCHEDULER_WAIT_TIMEOUT_MS;
+    if (!Number.isSafeInteger(this.waitTimeoutMs) || this.waitTimeoutMs < 1) {
+      throw new TypeError('waitTimeoutMs must be a positive safe integer');
+    }
+    this.lane = options.lane ?? 'daemon_bulk';
+  }
+
+  run<T>(
+    workspaceCwd: string,
+    operation: string,
+    task: () => Promise<T>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    const running = runningScheduler.getStore();
+    if (running?.active) {
+      const errorKind =
+        running.scheduler === this
+          ? `nested_${this.lane}_operation`
+          : `nested_${running.lane}_to_${this.lane}_operation`;
+      return Promise.reject(new DaemonBulkAdmissionError(errorKind));
+    }
+    if (this.sealed) {
+      return Promise.reject(
+        new DaemonBulkAdmissionError(`${this.lane}_admission_closed`),
+      );
+    }
+    if (signal?.aborted) {
+      return Promise.reject(this.abortReason(signal));
+    }
+
+    const queue = this.queues.get(workspaceCwd);
+    if (
+      this.waiting >= this.globalWaitLimit ||
+      (queue?.length ?? 0) >= this.workspaceWaitLimit
+    ) {
+      return Promise.reject(
+        new DaemonBulkAdmissionError(`${this.lane}_queue_full`),
+      );
+    }
+
+    return new Promise<T>((resolve, reject) => {
+      const item: QueueItem = {
+        workspaceCwd,
+        operation,
+        task,
+        resolve: (value) => resolve(value as T),
+        reject,
+        signal,
+      };
+      if (signal) {
+        item.abortListener = () => {
+          if (!this.removeQueuedItem(item)) return;
+          reject(this.abortReason(signal));
+          this.drain();
+        };
+        signal.addEventListener('abort', item.abortListener, { once: true });
+      }
+      item.waitTimer = setTimeout(() => {
+        if (!this.removeQueuedItem(item)) return;
+        reject(new DaemonBulkAdmissionError(`${this.lane}_queue_timeout`));
+        this.drain();
+      }, this.waitTimeoutMs);
+      item.waitTimer.unref?.();
+
+      if (queue) {
+        queue.push(item);
+      } else {
+        this.queues.set(workspaceCwd, [item]);
+        this.workspaceOrder.push(workspaceCwd);
+      }
+      this.waiting++;
+      this.drain();
+    });
+  }
+
+  seal(): void {
+    if (this.sealed) return;
+    this.sealed = true;
+    const error = new DaemonBulkAdmissionError(`${this.lane}_admission_closed`);
+    for (const queue of this.queues.values()) {
+      for (const item of queue) {
+        this.removeQueueHooks(item);
+        item.reject(error);
+      }
+    }
+    this.queues.clear();
+    this.workspaceOrder.length = 0;
+    this.waiting = 0;
+  }
+
+  snapshot(): {
+    active: number;
+    waiting: number;
+    workspacesWaiting: number;
+    sealed: boolean;
+  } {
+    return {
+      active: this.active,
+      waiting: this.waiting,
+      workspacesWaiting: this.queues.size,
+      sealed: this.sealed,
+    };
+  }
+
+  private drain(): void {
+    while (
+      !this.sealed &&
+      this.active < this.globalActiveLimit &&
+      this.workspaceOrder.length > 0
+    ) {
+      const candidates = this.workspaceOrder.length;
+      let selected: QueueItem | undefined;
+      for (let index = 0; index < candidates; index++) {
+        const workspaceCwd = this.workspaceOrder.shift();
+        if (workspaceCwd === undefined) break;
+        const queue = this.queues.get(workspaceCwd);
+        if (!queue || queue.length === 0) {
+          this.queues.delete(workspaceCwd);
+          continue;
+        }
+        if (
+          (this.activeByWorkspace.get(workspaceCwd) ?? 0) >=
+          this.workspaceActiveLimit
+        ) {
+          this.workspaceOrder.push(workspaceCwd);
+          continue;
+        }
+
+        selected = queue.shift();
+        if (queue.length === 0) {
+          this.queues.delete(workspaceCwd);
+        } else {
+          this.workspaceOrder.push(workspaceCwd);
+        }
+        break;
+      }
+      if (!selected) return;
+      this.start(selected);
+    }
+  }
+
+  private start(item: QueueItem): void {
+    this.waiting--;
+    this.active++;
+    this.activeByWorkspace.set(
+      item.workspaceCwd,
+      (this.activeByWorkspace.get(item.workspaceCwd) ?? 0) + 1,
+    );
+    this.removeQueueHooks(item);
+
+    const execution: DaemonSchedulerExecution = {
+      scheduler: this,
+      lane: this.lane,
+      active: true,
+    };
+    void runningScheduler
+      .run(execution, async () => {
+        try {
+          return await item.task();
+        } finally {
+          execution.active = false;
+        }
+      })
+      .then(item.resolve, item.reject)
+      .finally(() => {
+        this.active--;
+        const workspaceActive =
+          (this.activeByWorkspace.get(item.workspaceCwd) ?? 1) - 1;
+        if (workspaceActive === 0) {
+          this.activeByWorkspace.delete(item.workspaceCwd);
+          const orderIndex = this.workspaceOrder.indexOf(item.workspaceCwd);
+          if (orderIndex !== -1) {
+            this.workspaceOrder.splice(orderIndex, 1);
+            this.workspaceOrder.push(item.workspaceCwd);
+          }
+        } else {
+          this.activeByWorkspace.set(item.workspaceCwd, workspaceActive);
+        }
+        this.drain();
+      });
+  }
+
+  private removeQueuedItem(item: QueueItem): boolean {
+    const queue = this.queues.get(item.workspaceCwd);
+    if (!queue) return false;
+    const index = queue.indexOf(item);
+    if (index === -1) return false;
+    queue.splice(index, 1);
+    this.waiting--;
+    this.removeQueueHooks(item);
+    if (queue.length === 0) {
+      this.queues.delete(item.workspaceCwd);
+      const orderIndex = this.workspaceOrder.indexOf(item.workspaceCwd);
+      if (orderIndex !== -1) this.workspaceOrder.splice(orderIndex, 1);
+    }
+    return true;
+  }
+
+  private removeAbortListener(item: QueueItem): void {
+    if (item.signal && item.abortListener) {
+      item.signal.removeEventListener('abort', item.abortListener);
+      item.abortListener = undefined;
+    }
+  }
+
+  private removeQueueHooks(item: QueueItem): void {
+    this.removeAbortListener(item);
+    if (item.waitTimer) {
+      clearTimeout(item.waitTimer);
+      item.waitTimer = undefined;
+    }
+  }
+
+  private abortReason(signal: AbortSignal): unknown {
+    return signal.reason instanceof Error
+      ? signal.reason
+      : new Error('Daemon bulk operation was aborted');
+  }
+}
+
+export class FairDaemonSpawnScheduler extends FairDaemonBulkScheduler {
+  constructor() {
+    super({
+      globalActiveLimit: DAEMON_SPAWN_GLOBAL_ACTIVE_LIMIT,
+      globalWaitLimit: DAEMON_SPAWN_GLOBAL_WAIT_LIMIT,
+      workspaceActiveLimit: DAEMON_SPAWN_GLOBAL_ACTIVE_LIMIT,
+      workspaceWaitLimit: DAEMON_SPAWN_WORKSPACE_WAIT_LIMIT,
+      lane: 'daemon_spawn',
+    });
+  }
+}
+
+export class FairDaemonProcessScheduler extends FairDaemonBulkScheduler {
+  constructor() {
+    super({
+      globalActiveLimit: DAEMON_PROCESS_GLOBAL_ACTIVE_LIMIT,
+      globalWaitLimit: DAEMON_PROCESS_GLOBAL_WAIT_LIMIT,
+      workspaceActiveLimit: DAEMON_PROCESS_GLOBAL_ACTIVE_LIMIT,
+      workspaceWaitLimit: DAEMON_PROCESS_WORKSPACE_WAIT_LIMIT,
+      lane: 'daemon_process',
+    });
+  }
+}

--- a/packages/cli/src/serve/resource-budget.test.ts
+++ b/packages/cli/src/serve/resource-budget.test.ts
@@ -1,0 +1,222 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  DAEMON_EMERGENCY_POOL_BYTES,
+  ResourceBudget,
+} from './resource-budget.js';
+
+describe('ResourceBudget', () => {
+  it('atomically enforces parent, normal admission, and category limits', () => {
+    const budget = new ResourceBudget({
+      capBytes: 100,
+      normalAdmissionBytes: 70,
+      categoryCaps: { ingress: 60, outbound: 50 },
+    });
+
+    const first = budget.tryReserveComposite([
+      { category: 'ingress', bytes: 40 },
+      { category: 'outbound', bytes: 20 },
+    ]);
+    expect(first.ok).toBe(true);
+
+    expect(
+      budget.tryReserveComposite([{ category: 'ingress', bytes: 21 }]),
+    ).toMatchObject({
+      ok: false,
+      reason: 'category_limit',
+      category: 'ingress',
+    });
+    expect(
+      budget.tryReserveComposite([{ category: 'outbound', bytes: 11 }]),
+    ).toMatchObject({
+      ok: false,
+      reason: 'normal_admission_limit',
+    });
+    expect(budget.snapshot()).toMatchObject({
+      usedBytes: 60,
+      normalUsedBytes: 60,
+      highWaterBytes: 60,
+    });
+  });
+
+  it('keeps the completion reserve unavailable to normal work', () => {
+    const budget = new ResourceBudget({
+      capBytes: 100,
+      normalAdmissionBytes: 60,
+      categoryCaps: { prompt: 100 },
+    });
+    expect(
+      budget.tryReserveComposite([{ category: 'prompt', bytes: 60 }]).ok,
+    ).toBe(true);
+    expect(
+      budget.tryReserveComposite([{ category: 'prompt', bytes: 1 }]),
+    ).toMatchObject({
+      ok: false,
+      reason: 'normal_admission_limit',
+    });
+    expect(
+      budget.tryReserveComposite([{ category: 'prompt', bytes: 40 }], {
+        priority: 'completion',
+      }).ok,
+    ).toBe(true);
+    expect(
+      budget.tryReserveComposite([{ category: 'prompt', bytes: 1 }], {
+        priority: 'completion',
+      }),
+    ).toMatchObject({ ok: false, reason: 'parent_limit' });
+  });
+
+  it('keeps the emergency response pool below 3 MiB', () => {
+    const budget = new ResourceBudget();
+
+    expect(budget.snapshot().categories.emergency.capBytes).toBe(
+      DAEMON_EMERGENCY_POOL_BYTES,
+    );
+    expect(DAEMON_EMERGENCY_POOL_BYTES).toBeLessThan(3 * 1024 * 1024);
+  });
+
+  it('keeps the emergency pool unavailable to business reservations', () => {
+    const budget = new ResourceBudget({
+      capBytes: 100,
+      normalAdmissionBytes: 60,
+      categoryCaps: { outbound: 100, emergency: 10 },
+    });
+    const normal = budget.tryReserveComposite([
+      { category: 'outbound', bytes: 60 },
+    ]);
+    expect(normal.ok).toBe(true);
+    const completion = budget.tryReserveComposite(
+      [{ category: 'outbound', bytes: 30 }],
+      { priority: 'completion' },
+    );
+    expect(completion.ok).toBe(true);
+    expect(
+      budget.tryReserveComposite([{ category: 'outbound', bytes: 1 }], {
+        priority: 'completion',
+      }),
+    ).toMatchObject({ ok: false, reason: 'parent_limit', limitBytes: 90 });
+    expect(
+      budget.tryReserveComposite([{ category: 'emergency', bytes: 10 }], {
+        priority: 'completion',
+      }).ok,
+    ).toBe(true);
+    expect(budget.snapshot().usedBytes).toBe(100);
+  });
+
+  it('keeps emergency reservations outside normal admission accounting', () => {
+    const budget = new ResourceBudget({
+      capBytes: 100,
+      normalAdmissionBytes: 80,
+      categoryCaps: {
+        background: 100,
+        emergency: 10,
+      },
+    });
+    const business = budget.tryReserveComposite([
+      { category: 'background', bytes: 80 },
+    ]);
+    expect(business.ok).toBe(true);
+
+    const emergency = budget.tryReserveComposite([
+      { category: 'emergency', bytes: 10 },
+    ]);
+    expect(emergency.ok).toBe(true);
+    expect(budget.snapshot()).toMatchObject({
+      usedBytes: 90,
+      normalUsedBytes: 80,
+    });
+
+    if (!business.ok || !emergency.ok) return;
+    emergency.lease.release();
+    business.lease.release();
+    expect(budget.snapshot()).toMatchObject({
+      usedBytes: 0,
+      normalUsedBytes: 0,
+    });
+  });
+
+  it('supports split, transfer, grow, shrink, and idempotent release', () => {
+    const budget = new ResourceBudget({
+      capBytes: 100,
+      normalAdmissionBytes: 100,
+      categoryCaps: { ingress: 100 },
+    });
+    const reservation = budget.tryReserveComposite(
+      [{ category: 'ingress', bytes: 60 }],
+      { owner: { operation: 'request' } },
+    );
+    if (!reservation.ok) throw new Error('reservation failed');
+
+    const child = reservation.lease.split(
+      [{ category: 'ingress', bytes: 20 }],
+      { operation: 'delivery' },
+    );
+    expect(reservation.lease.bytes).toBe(40);
+    expect(child.currentOwner).toEqual({ operation: 'delivery' });
+    child.transferOwner({ operation: 'owned' });
+    expect(child.currentOwner).toEqual({ operation: 'owned' });
+    expect(
+      reservation.lease.tryGrow([{ category: 'ingress', bytes: 10 }]).ok,
+    ).toBe(true);
+    reservation.lease.shrink([{ category: 'ingress', bytes: 5 }]);
+
+    child.release();
+    child.release();
+    reservation.lease.release();
+    reservation.lease.release();
+
+    expect(budget.snapshot().usedBytes).toBe(0);
+    expect(budget.snapshot().categories.ingress.highWaterBytes).toBe(70);
+  });
+
+  it('leaves accounting unchanged after a rejected grow', () => {
+    const budget = new ResourceBudget({
+      capBytes: 100,
+      normalAdmissionBytes: 100,
+      categoryCaps: { ingress: 50 },
+    });
+    const reservation = budget.tryReserveComposite([
+      { category: 'ingress', bytes: 40 },
+    ]);
+    if (!reservation.ok) throw new Error('reservation failed');
+
+    expect(
+      reservation.lease.tryGrow([{ category: 'ingress', bytes: 11 }]),
+    ).toMatchObject({
+      ok: false,
+      reason: 'category_limit',
+    });
+    expect(reservation.lease.bytes).toBe(40);
+    expect(budget.snapshot().usedBytes).toBe(40);
+  });
+
+  it('rejects invalid configuration and reservations', () => {
+    expect(
+      () => new ResourceBudget({ capBytes: 10, normalAdmissionBytes: 11 }),
+    ).toThrow(/must not exceed/);
+    const budget = new ResourceBudget({
+      capBytes: 10,
+      normalAdmissionBytes: 10,
+      categoryCaps: { ingress: 10 },
+    });
+    expect(() =>
+      budget.tryReserveComposite([{ category: 'ingress', bytes: -1 }]),
+    ).toThrow(/non-negative safe integer/);
+  });
+
+  it('rejects unsafe combined reservations without changing counters', () => {
+    const budget = new ResourceBudget();
+    expect(() =>
+      budget.tryReserveComposite([
+        { category: 'ingress', bytes: Number.MAX_SAFE_INTEGER },
+        { category: 'ingress', bytes: 1 },
+      ]),
+    ).toThrow(/combined resource reservation is too large/);
+    expect(budget.snapshot().usedBytes).toBe(0);
+  });
+});

--- a/packages/cli/src/serve/resource-budget.ts
+++ b/packages/cli/src/serve/resource-budget.ts
@@ -1,0 +1,461 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const DEFAULT_DAEMON_RESOURCE_BUDGET_BYTES = 512 * 1024 * 1024;
+export const DEFAULT_DAEMON_NORMAL_ADMISSION_BYTES = 384 * 1024 * 1024;
+export const DAEMON_EMERGENCY_POOL_BYTES = 3 * 1024 * 1024 - 1;
+
+export type ResourceBudgetCategory =
+  | 'runtime'
+  | 'session'
+  | 'connection'
+  | 'ingress'
+  | 'websocket_assembly'
+  | 'outbound'
+  | 'prompt'
+  | 'replay'
+  | 'virtual_transcript'
+  | 'background'
+  | 'voice'
+  | 'process'
+  | 'export'
+  | 'fanout'
+  | 'emergency';
+
+export interface ResourceBudgetOwner {
+  workspaceId?: string;
+  runtimeGeneration?: string;
+  channelGeneration?: string;
+  operation?: string;
+}
+
+export interface ResourceBudgetRequest {
+  category: ResourceBudgetCategory;
+  bytes: number;
+}
+
+export type ResourceBudgetPriority = 'normal' | 'completion';
+
+export interface ResourceBudgetCategorySnapshot {
+  usedBytes: number;
+  capBytes: number;
+  highWaterBytes: number;
+}
+
+export interface ResourceBudgetSnapshot {
+  enforced: true;
+  usedBytes: number;
+  normalUsedBytes: number;
+  capBytes: number;
+  normalAdmissionBytes: number;
+  completionReserveBytes: number;
+  highWaterBytes: number;
+  categories: Record<ResourceBudgetCategory, ResourceBudgetCategorySnapshot>;
+}
+
+export type ResourceBudgetReservationResult =
+  | { ok: true; lease: ResourceBudgetLease }
+  | {
+      ok: false;
+      reason: 'parent_limit' | 'normal_admission_limit' | 'category_limit';
+      category?: ResourceBudgetCategory;
+      limitBytes: number;
+      usedBytes: number;
+      requestedBytes: number;
+    };
+
+export interface ResourceBudgetOptions {
+  capBytes?: number;
+  normalAdmissionBytes?: number;
+  categoryCaps?: Partial<Record<ResourceBudgetCategory, number>>;
+}
+
+export class ResourceAdmissionError extends Error {
+  readonly data: {
+    errorKind: 'resource_admission_exhausted';
+    httpStatus: 503;
+    limitBytes: number;
+    minimumBytes: number;
+    actualBytesKnown: true;
+    retryable: true;
+  };
+
+  constructor(result: Exclude<ResourceBudgetReservationResult, { ok: true }>) {
+    super(
+      `Resource admission requires ${result.requestedBytes} bytes but the effective limit is ${result.limitBytes} bytes`,
+    );
+    this.name = 'ResourceAdmissionError';
+    this.data = {
+      errorKind: 'resource_admission_exhausted',
+      httpStatus: 503,
+      limitBytes: result.limitBytes,
+      minimumBytes: result.requestedBytes,
+      actualBytesKnown: true,
+      retryable: true,
+    };
+  }
+}
+
+const DEFAULT_CATEGORY_CAPS: Record<ResourceBudgetCategory, number> = {
+  runtime: 25 * 1024 * 1024,
+  session: 256 * 1024 * 1024,
+  connection: 16 * 1024 * 1024,
+  ingress: 128 * 1024 * 1024,
+  websocket_assembly: 256 * 1024 * 1024,
+  outbound: 256 * 1024 * 1024,
+  prompt: 384 * 1024 * 1024,
+  replay: 128 * 1024 * 1024,
+  virtual_transcript: 64 * 1024 * 1024,
+  background: 64 * 1024 * 1024,
+  voice: 128 * 1024 * 1024,
+  process: 128 * 1024 * 1024,
+  export: 256 * 1024 * 1024,
+  fanout: 32 * 1024 * 1024,
+  emergency: DAEMON_EMERGENCY_POOL_BYTES,
+};
+
+const RESOURCE_BUDGET_CATEGORIES = Object.freeze(
+  Object.keys(DEFAULT_CATEGORY_CAPS) as ResourceBudgetCategory[],
+);
+
+function assertPositiveSafeInteger(name: string, value: number): void {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new TypeError(`${name} must be a positive safe integer`);
+  }
+}
+
+function normalizeRequests(
+  requests: readonly ResourceBudgetRequest[],
+): Map<ResourceBudgetCategory, number> {
+  const normalized = new Map<ResourceBudgetCategory, number>();
+  for (const request of requests) {
+    if (!Number.isSafeInteger(request.bytes) || request.bytes < 0) {
+      throw new TypeError(
+        'resource reservation bytes must be a non-negative safe integer',
+      );
+    }
+    if (request.bytes === 0) continue;
+    const combined = (normalized.get(request.category) ?? 0) + request.bytes;
+    if (!Number.isSafeInteger(combined)) {
+      throw new RangeError('combined resource reservation is too large');
+    }
+    normalized.set(request.category, combined);
+  }
+  return normalized;
+}
+
+function totalBytes(
+  entries: ReadonlyMap<ResourceBudgetCategory, number>,
+): number {
+  let total = 0;
+  for (const bytes of entries.values()) {
+    total += bytes;
+    if (!Number.isSafeInteger(total)) {
+      throw new RangeError('total resource reservation is too large');
+    }
+  }
+  return total;
+}
+
+export class ResourceBudget {
+  readonly capBytes: number;
+  readonly normalAdmissionBytes: number;
+  readonly completionReserveBytes: number;
+
+  private usedBytes = 0;
+  private normalUsedBytes = 0;
+  private highWaterBytes = 0;
+  private readonly emergencyPoolBytes: number;
+  private readonly categoryCaps: Record<ResourceBudgetCategory, number>;
+  private readonly categoryUsed = new Map<ResourceBudgetCategory, number>();
+  private readonly categoryHighWater = new Map<
+    ResourceBudgetCategory,
+    number
+  >();
+
+  constructor(options: ResourceBudgetOptions = {}) {
+    this.capBytes = options.capBytes ?? DEFAULT_DAEMON_RESOURCE_BUDGET_BYTES;
+    this.normalAdmissionBytes =
+      options.normalAdmissionBytes ?? DEFAULT_DAEMON_NORMAL_ADMISSION_BYTES;
+    assertPositiveSafeInteger('capBytes', this.capBytes);
+    assertPositiveSafeInteger(
+      'normalAdmissionBytes',
+      this.normalAdmissionBytes,
+    );
+    if (this.normalAdmissionBytes > this.capBytes) {
+      throw new TypeError('normalAdmissionBytes must not exceed capBytes');
+    }
+    this.completionReserveBytes = this.capBytes - this.normalAdmissionBytes;
+    this.categoryCaps = { ...DEFAULT_CATEGORY_CAPS };
+    for (const [category, cap] of Object.entries(
+      options.categoryCaps ?? {},
+    ) as Array<[ResourceBudgetCategory, number]>) {
+      assertPositiveSafeInteger(`categoryCaps.${category}`, cap);
+      this.categoryCaps[category] = cap;
+    }
+    this.emergencyPoolBytes =
+      options.categoryCaps?.emergency ??
+      (options.capBytes === undefined ? DAEMON_EMERGENCY_POOL_BYTES : 0);
+    if (this.emergencyPoolBytes > this.capBytes) {
+      throw new TypeError('emergency category cap must not exceed capBytes');
+    }
+    for (const category of RESOURCE_BUDGET_CATEGORIES) {
+      this.categoryUsed.set(category, 0);
+      this.categoryHighWater.set(category, 0);
+    }
+  }
+
+  tryReserveComposite(
+    requests: readonly ResourceBudgetRequest[],
+    options: {
+      priority?: ResourceBudgetPriority;
+      owner?: ResourceBudgetOwner;
+    } = {},
+  ): ResourceBudgetReservationResult {
+    const entries = normalizeRequests(requests);
+    const requestedBytes = totalBytes(entries);
+    const priority = options.priority ?? 'normal';
+    const failure = this.checkReservation(entries, requestedBytes, priority);
+    if (failure) return failure;
+    this.commitReservation(entries, requestedBytes, priority);
+    return {
+      ok: true,
+      lease: new ResourceBudgetLease(this, entries, priority, options.owner),
+    };
+  }
+
+  snapshot(): ResourceBudgetSnapshot {
+    const categories = {} as Record<
+      ResourceBudgetCategory,
+      ResourceBudgetCategorySnapshot
+    >;
+    for (const category of RESOURCE_BUDGET_CATEGORIES) {
+      categories[category] = {
+        usedBytes: this.categoryUsed.get(category) ?? 0,
+        capBytes: this.categoryCaps[category],
+        highWaterBytes: this.categoryHighWater.get(category) ?? 0,
+      };
+    }
+    return {
+      enforced: true,
+      usedBytes: this.usedBytes,
+      normalUsedBytes: this.normalUsedBytes,
+      capBytes: this.capBytes,
+      normalAdmissionBytes: this.normalAdmissionBytes,
+      completionReserveBytes: this.completionReserveBytes,
+      highWaterBytes: this.highWaterBytes,
+      categories,
+    };
+  }
+
+  grow(
+    lease: ResourceBudgetLease,
+    requests: readonly ResourceBudgetRequest[],
+  ): ResourceBudgetReservationResult {
+    const entries = normalizeRequests(requests);
+    const requestedBytes = totalBytes(entries);
+    const failure = this.checkReservation(
+      entries,
+      requestedBytes,
+      lease.priority,
+    );
+    if (failure) return failure;
+    this.commitReservation(entries, requestedBytes, lease.priority);
+    lease.commitGrow(entries);
+    return { ok: true, lease };
+  }
+
+  release(
+    entries: ReadonlyMap<ResourceBudgetCategory, number>,
+    priority: ResourceBudgetPriority,
+  ): void {
+    const releasedBytes = totalBytes(entries);
+    this.usedBytes -= releasedBytes;
+    if (priority === 'normal' && !entries.has('emergency')) {
+      this.normalUsedBytes -= releasedBytes;
+    }
+    for (const [category, bytes] of entries) {
+      this.categoryUsed.set(
+        category,
+        (this.categoryUsed.get(category) ?? 0) - bytes,
+      );
+    }
+  }
+
+  private checkReservation(
+    entries: ReadonlyMap<ResourceBudgetCategory, number>,
+    requestedBytes: number,
+    priority: ResourceBudgetPriority,
+  ): Exclude<ResourceBudgetReservationResult, { ok: true }> | undefined {
+    const emergencyBytes = entries.get('emergency') ?? 0;
+    if (emergencyBytes > 0 && entries.size !== 1) {
+      throw new TypeError(
+        'emergency reservations cannot include business categories',
+      );
+    }
+    const emergencyUsed = this.categoryUsed.get('emergency') ?? 0;
+    const parentUsed =
+      emergencyBytes > 0 ? this.usedBytes : this.usedBytes - emergencyUsed;
+    const parentLimit =
+      emergencyBytes > 0
+        ? this.capBytes
+        : this.capBytes - this.emergencyPoolBytes;
+    if (parentUsed + requestedBytes > parentLimit) {
+      return {
+        ok: false,
+        reason: 'parent_limit',
+        limitBytes: parentLimit,
+        usedBytes: parentUsed,
+        requestedBytes,
+      };
+    }
+    for (const [category, bytes] of entries) {
+      const usedBytes = this.categoryUsed.get(category) ?? 0;
+      const capBytes = this.categoryCaps[category];
+      if (usedBytes + bytes > capBytes) {
+        return {
+          ok: false,
+          reason: 'category_limit',
+          category,
+          limitBytes: capBytes,
+          usedBytes,
+          requestedBytes: bytes,
+        };
+      }
+    }
+    if (
+      emergencyBytes === 0 &&
+      priority === 'normal' &&
+      this.normalUsedBytes + requestedBytes > this.normalAdmissionBytes
+    ) {
+      return {
+        ok: false,
+        reason: 'normal_admission_limit',
+        limitBytes: this.normalAdmissionBytes,
+        usedBytes: this.normalUsedBytes,
+        requestedBytes,
+      };
+    }
+    return undefined;
+  }
+
+  private commitReservation(
+    entries: ReadonlyMap<ResourceBudgetCategory, number>,
+    requestedBytes: number,
+    priority: ResourceBudgetPriority,
+  ): void {
+    this.usedBytes += requestedBytes;
+    if (priority === 'normal' && !entries.has('emergency')) {
+      this.normalUsedBytes += requestedBytes;
+    }
+    this.highWaterBytes = Math.max(this.highWaterBytes, this.usedBytes);
+    for (const [category, bytes] of entries) {
+      const usedBytes = (this.categoryUsed.get(category) ?? 0) + bytes;
+      this.categoryUsed.set(category, usedBytes);
+      this.categoryHighWater.set(
+        category,
+        Math.max(this.categoryHighWater.get(category) ?? 0, usedBytes),
+      );
+    }
+  }
+}
+
+export class ResourceBudgetLease {
+  private entries: Map<ResourceBudgetCategory, number>;
+  private released = false;
+
+  constructor(
+    private readonly budget: ResourceBudget,
+    entries: ReadonlyMap<ResourceBudgetCategory, number>,
+    readonly priority: ResourceBudgetPriority,
+    private owner?: ResourceBudgetOwner,
+  ) {
+    this.entries = new Map(entries);
+  }
+
+  get bytes(): number {
+    return totalBytes(this.entries);
+  }
+
+  get currentOwner(): ResourceBudgetOwner | undefined {
+    return this.owner;
+  }
+
+  transferOwner(owner: ResourceBudgetOwner): void {
+    this.assertOpen();
+    this.owner = owner;
+  }
+
+  tryGrow(
+    requests: readonly ResourceBudgetRequest[],
+  ): ResourceBudgetReservationResult {
+    this.assertOpen();
+    return this.budget.grow(this, requests);
+  }
+
+  split(
+    requests: readonly ResourceBudgetRequest[],
+    owner = this.owner,
+  ): ResourceBudgetLease {
+    this.assertOpen();
+    const splitEntries = normalizeRequests(requests);
+    for (const [category, bytes] of splitEntries) {
+      if ((this.entries.get(category) ?? 0) < bytes) {
+        throw new RangeError(
+          `cannot split ${bytes} bytes from ${category} reservation`,
+        );
+      }
+    }
+    for (const [category, bytes] of splitEntries) {
+      const remaining = (this.entries.get(category) ?? 0) - bytes;
+      if (remaining === 0) this.entries.delete(category);
+      else this.entries.set(category, remaining);
+    }
+    return new ResourceBudgetLease(
+      this.budget,
+      splitEntries,
+      this.priority,
+      owner,
+    );
+  }
+
+  shrink(requests: readonly ResourceBudgetRequest[]): void {
+    this.assertOpen();
+    const shrinkEntries = normalizeRequests(requests);
+    for (const [category, bytes] of shrinkEntries) {
+      if ((this.entries.get(category) ?? 0) < bytes) {
+        throw new RangeError(
+          `cannot release ${bytes} bytes from ${category} reservation`,
+        );
+      }
+    }
+    for (const [category, bytes] of shrinkEntries) {
+      const remaining = (this.entries.get(category) ?? 0) - bytes;
+      if (remaining === 0) this.entries.delete(category);
+      else this.entries.set(category, remaining);
+    }
+    this.budget.release(shrinkEntries, this.priority);
+  }
+
+  release(): void {
+    if (this.released) return;
+    this.released = true;
+    this.budget.release(this.entries, this.priority);
+    this.entries.clear();
+  }
+
+  commitGrow(entries: ReadonlyMap<ResourceBudgetCategory, number>): void {
+    for (const [category, bytes] of entries) {
+      this.entries.set(category, (this.entries.get(category) ?? 0) + bytes);
+    }
+  }
+
+  private assertOpen(): void {
+    if (this.released) {
+      throw new Error('resource budget lease is already released');
+    }
+  }
+}


### PR DESCRIPTION
<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item as one long line.
-->

## What this PR does

This PR establishes the first independently reviewable foundation for daemon multi-workspace resource protection. It adds a synchronous process-wide resource budget with composite atomic admission and lifecycle-safe leases, fair bounded schedulers for bulk, spawn, and buffered-process work, and a buffered-process wrapper that reserves output capacity before entering its lane and releases it on every completion path.

It also adds the Phase 1 target-state design and explicitly records that this first PR does not wire the new primitives into production routes, advertise a capability, or change daemon behavior. Transport bounds, replay and restore protection, workspace lifecycle cleanup, memory observation, and process-tree shutdown remain separate follow-up PRs tracked by #8091.

## Why it's needed

The current daemon primarily limits workspace and session counts, which does not bound bytes, queued work, process output, or other variable-size resources. The complete hardening proposal in #8051 spans several ownership and compatibility boundaries, so landing it as one change would be difficult to review and unsafe to partially advertise. This PR defines the shared accounting and scheduling invariants first, allowing each production integration to be reviewed and activated only when its full path is protected.

## Reviewer Test Plan

### How to verify

- Verify that composite budget reservations atomically enforce the process cap, normal-admission ceiling, category limits, completion reserve, and emergency pool, and that failed growth, lease splitting and transfer, shrink, and repeated release preserve accounting.
- Verify that the schedulers enforce global and per-workspace active and waiting limits, make round-robin progress across workspaces, and correctly handle abort, timeout, sealing, nested acquisition, cross-lane acquisition, and inherited asynchronous work after a parent task settles.
- Verify that buffered-process execution reserves declared output bytes before scheduler admission and releases the reservation after success, task failure, or scheduler rejection.
- Run `cd packages/cli && npx vitest run src/serve/resource-budget.test.ts src/serve/fair-daemon-bulk-scheduler.test.ts src/serve/buffered-process-budget.test.ts`; all 19 tests should pass.
- Run `npm run build`, `npm run typecheck`, and `npm run lint`; all commands should complete successfully.

### Evidence (Before & After)

N/A — this PR adds internal foundations and documentation without production wiring or user-visible behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS local workspace, Node.js v22.22.3, npm 10.9.8.

## Risk & Scope

- Main risk or tradeoff: The foundational APIs and limit constants may need small adjustments as production consumers are integrated, but this PR intentionally keeps those changes isolated from runtime behavior.
- Not validated / out of scope: No daemon route, transport, session, workspace lifecycle, status capability, memory observer, or shutdown path uses these primitives yet; Windows and Linux were not tested locally.
- Breaking changes / migration notes: None in this PR.

## Linked Issues

Part of #8091.

Related to #8051.

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本 PR 为 daemon 多 workspace 资源保护建立首个可独立审查的基础层。它新增同步的进程级资源预算，支持组合式原子准入与生命周期安全的 lease；新增面向批量任务、进程创建和缓冲进程任务的公平有界调度器；并新增一个缓冲进程包装器，在进入调度 lane 前预留输出容量，并在所有完成路径上释放资源。

本 PR 同时加入 Phase 1 目标状态设计，并明确记录首个 PR 不会把这些新基础设施接入生产路由、广告 capability 或改变 daemon 行为。传输边界、replay 与 restore 保护、workspace 生命周期清理、内存观测及进程树 shutdown 将作为 #8091 跟踪的独立后续 PR。

## 为什么需要

当前 daemon 主要限制 workspace 和 session 数量，但这不能限制字节量、排队任务、进程输出或其他可变大小资源。#8051 中的完整加固方案跨越多个所有权与兼容性边界，作为单个变更很难审查，也不适合在仅有部分路径受保护时对外广告。本 PR 先定义共享的计费与调度不变量，使每个生产接入都能独立审查，并且只在整条路径完成保护后启用。

## Reviewer 测试计划

### 如何验证

- 验证组合预算预留会原子地执行进程总额、正常准入上限、分类限额、完成保留区和 emergency pool，并确认 grow 失败、lease split 与 transfer、shrink 及重复 release 都能保持计费守恒。
- 验证调度器会执行全局及单 workspace 的 active/waiting 限制，让不同 workspace 按轮转方式取得进展，并正确处理 abort、timeout、seal、嵌套获取、跨 lane 获取，以及父任务结束后的继承异步工作。
- 验证缓冲进程执行会在调度准入前预留声明的输出字节，并在成功、任务失败或调度拒绝后释放预留。
- 运行 `cd packages/cli && npx vitest run src/serve/resource-budget.test.ts src/serve/fair-daemon-bulk-scheduler.test.ts src/serve/buffered-process-budget.test.ts`；应有 19 个测试全部通过。
- 运行 `npm run build`、`npm run typecheck` 和 `npm run lint`；所有命令都应成功完成。

### 证据（Before & After）

N/A — 本 PR 仅增加内部基础设施和文档，没有生产接入或用户可见行为。

### 已测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS 本地 workspace，Node.js v22.22.3，npm 10.9.8。

## 风险与范围

- 主要风险或取舍：随着生产消费者逐步接入，基础 API 和限额常量可能需要小幅调整，但本 PR 有意将这些调整与运行时行为隔离。
- 未验证／范围外：尚无 daemon 路由、传输、session、workspace 生命周期、状态 capability、内存 observer 或 shutdown 路径使用这些基础设施；未在本地测试 Windows 和 Linux。
- Breaking changes／迁移说明：本 PR 没有 breaking change。

## 关联 Issue

属于 #8091 的一部分。

关联 #8051。

</details>
