### PR TITLE
fix(ci): gate the attachment guard before it allocates a runner

### DIFF
--- a/.github/workflows/comment-attachment-guard.yml
+++ b/.github/workflows/comment-attachment-guard.yml
@@ -19,11 +19,44 @@ permissions:
   issues: 'write'
   pull-requests: 'write'
 
+concurrency:
+  # One scan per comment, keyed on whichever id this event carries. The scan
+  # reads the comment's CURRENT body, so when an edit lands while an earlier
+  # scan is queued the earlier result is already stale — cancelling it loses
+  # nothing. (Contrast the verify lane, where cancel-in-progress is false
+  # because a cancelled run destroys evidence.) Falling back to run_id keeps
+  # unexpected payloads on their own group instead of serialising them all
+  # into one.
+  group: >-
+    attachment-guard-${{
+      github.event.comment.id || github.event.review.id || github.run_id
+    }}
+  cancel-in-progress: true
+
 jobs:
   remove-suspicious-attachments:
     timeout-minutes: 2
-    if: |-
-      ${{ github.repository == 'QwenLM/qwen-code' }}
+    # The trust check used to live inside the script, which means a runner was
+    # queued, allocated and started before the job could decide it had nothing
+    # to do. Measured over the 200 most recent comments on this repo: 184 from
+    # trusted associations and 9 from bots — 96.5% of runs existed only to
+    # print "Trusted author; skipping". On a saturated hosted pool those waited
+    # up to 629s each for 2-5s of work.
+    #
+    # Hoisted here because GitHub evaluates `if:` BEFORE allocating a runner.
+    # The script keeps its own copy of these checks: this is an optimisation,
+    # not the control, and the two must be able to disagree without becoming
+    # unsafe. Every ambiguity therefore resolves toward RUNNING the scan — an
+    # unknown payload yields an empty association, which is not in the trusted
+    # list, so the job runs.
+    if: >-
+      github.repository == 'QwenLM/qwen-code' &&
+      github.event.sender.type != 'Bot' &&
+      !contains(
+        fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+        github.event.comment.author_association ||
+        github.event.review.author_association
+      )
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Remove suspicious attachment comments'

--- a/scripts/tests/comment-attachment-guard-workflow.test.js
+++ b/scripts/tests/comment-attachment-guard-workflow.test.js
@@ -97,6 +97,96 @@ describe('comment attachment guard workflow', () => {
     return { calls, failures, summaries, warnings };
   }
 
+  // The trust check used to run only INSIDE the script, so a runner was
+  // queued, allocated and started before the job could decide it had nothing
+  // to do. Measured over the 200 most recent comments on this repo: 184
+  // trusted associations + 9 bots = 96.5% of runs existed to print "Trusted
+  // author; skipping", each waiting up to 629s on a saturated hosted pool.
+  //
+  // The hoisted `if:` is an OPTIMISATION, not the control — the script keeps
+  // its own checks. So the only unsafe direction is skipping a scan that
+  // should have run, and every ambiguity must resolve toward running.
+  describe('job-level gate', () => {
+    const gate = workflow.slice(
+      workflow.indexOf('  remove-suspicious-attachments:'),
+      workflow.indexOf("runs-on: 'ubuntu-latest'"),
+    );
+
+    it('gates on association and sender before a runner is allocated', () => {
+      expect(gate).toContain('if: >-');
+      expect(gate).toContain("github.event.sender.type != 'Bot'");
+      expect(gate).toContain('!contains(');
+      expect(gate).toContain('["OWNER","MEMBER","COLLABORATOR"]');
+      // Both payload shapes: reviews carry the association on `review`,
+      // comments on `comment`. Missing one silently un-gates that event.
+      expect(gate).toContain('github.event.comment.author_association');
+      expect(gate).toContain('github.event.review.author_association');
+      // The script must KEEP its own copy — defence in depth, and the two
+      // are allowed to disagree only in the safe direction.
+      expect(script).toContain('trustedAssociations');
+      expect(script).toContain("sender?.type === 'Bot'");
+    });
+
+    // Replicates GitHub expression semantics: `a || b` yields the first
+    // truthy value, a missing path is '', and contains(list, '') is false.
+    it('resolves every payload shape, ambiguity toward running', () => {
+      const TRUSTED = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+      const runs = (ev) =>
+        (ev?.sender?.type ?? '') !== 'Bot' &&
+        !TRUSTED.includes(
+          ev?.comment?.author_association ||
+            ev?.review?.author_association ||
+            '',
+        );
+      const user = { type: 'User' };
+      // Trusted -> skipped, which is the whole saving.
+      for (const a of TRUSTED) {
+        expect(runs({ sender: user, comment: { author_association: a } })).toBe(
+          false,
+        );
+        expect(runs({ sender: user, review: { author_association: a } })).toBe(
+          false,
+        );
+      }
+      expect(
+        runs({
+          sender: { type: 'Bot' },
+          comment: { author_association: 'NONE' },
+        }),
+      ).toBe(false);
+      // Everyone else -> scanned. CONTRIBUTOR is deliberately NOT trusted:
+      // a merged PR does not make someone's links safe.
+      for (const a of ['CONTRIBUTOR', 'FIRST_TIME_CONTRIBUTOR', 'NONE', '']) {
+        expect(runs({ sender: user, comment: { author_association: a } })).toBe(
+          true,
+        );
+      }
+      // Fail-safe: an unrecognised or empty payload runs the scan rather
+      // than skipping it.
+      expect(runs({ sender: user })).toBe(true);
+      expect(runs({})).toBe(true);
+    });
+  });
+
+  // Every comment event started its own job, `edited` included — and the bot
+  // PATCHes its own comments constantly, so repeated edits of one comment
+  // stacked. The scan reads the CURRENT body, so a queued earlier scan is
+  // already stale and cancelling it loses nothing.
+  it('collapses repeated scans of one comment', () => {
+    const concurrency = workflow.slice(
+      workflow.indexOf('concurrency:'),
+      workflow.indexOf('jobs:'),
+    );
+    expect(concurrency).toContain('cancel-in-progress: true');
+    // Keyed per comment, not globally — a global group would serialise every
+    // scan in the repo behind one runner.
+    expect(concurrency).toContain('github.event.comment.id');
+    expect(concurrency).toContain('github.event.review.id');
+    // ...and an unexpected payload gets its own group rather than joining a
+    // shared empty-key group where unrelated scans cancel each other.
+    expect(concurrency).toContain('github.run_id');
+  });
+
   it('stops risky extensions only on alphanumeric continuation', () => {
     expect(workflow).toContain('(?![a-zA-Z0-9])');
   });


### PR DESCRIPTION
## What this PR does

Stops `Comment Attachment Guard` from allocating a runner for work it will immediately skip, and collapses duplicate scans of the same comment.

### The measurement

While investigating why two `/verify` triggers sat queued for 5+ minutes, I sampled the live queue: **88 active jobs — 72 hosted, 15 self-hosted.** The self-hosted 15 were *all running, zero queued*. The hosted 72 were contending, and **20 of them were the same job**: `remove-suspicious-attachments`, all `queued`, none running.

Its cost is not the work. Recent completed runs:

| queue | run |
| ----: | --: |
| 629s | 5s |
| 568s | 2s |
| 518s | 2s |
| 340s | 3s |

Two to five seconds of API calls behind up to ten minutes of queueing.

**And almost none of it needed to happen.** The trust check lived *inside* the github-script, so a runner was queued, allocated and started before the job could decide it had nothing to do. Over the 200 most recent comments on this repo:

| author | count | outcome |
| --- | ---: | --- |
| trusted association (OWNER/MEMBER/COLLABORATOR) | 184 | skipped after starting |
| bot | 9 | skipped after starting |
| **actually needs a scan** | **7** | scanned |

**96.5% of these runs existed to print `Trusted author; skipping`.**

### Two changes

**1. Hoist the association and bot checks into the job `if:`.** GitHub evaluates `if:` *before* allocating a runner, so a trusted comment now costs nothing at all.

The script **keeps its own copies**. This is important: the gate is an *optimisation*, not the control, and the two must be able to disagree without becoming unsafe. So every ambiguity resolves toward **running** the scan — an unrecognised payload yields an empty association, which is not in the trusted list, so the job runs.

**2. Add a per-comment concurrency group with `cancel-in-progress: true`.** The workflow listens on `edited` as well as `created`, and the bot PATCHes its own comments constantly, so repeated edits of one comment stacked. The scan reads the comment's **current** body, so a queued earlier scan is already stale and cancelling it loses nothing.

> Contrast the verify lane, where `cancel-in-progress` is deliberately `false` because a cancelled run destroys evidence. Same mechanism, opposite correct setting — which is why the group carries a comment saying so.

The key falls back to `run_id` so an unexpected payload gets its own group instead of serialising every scan into one.

### Why not move it to the self-hosted pool

It would fit technically — no checkout, no `run:`, no PR code, only API calls — and the ECS pool had zero queue at the time. I did not, for two reasons:

- **The 20 stacked jobs were duplicates.** Relocating them fills the ECS pool instead, and that pool is what `/verify` and `/triage` depend on. Fixing the duplication is the actual repair; moving it would hide the symptom in a place where it hurts more.
- **It holds `issues: write` while processing untrusted comment bodies.** That belongs on ephemeral hardware rather than reused machines — the same persistence argument as #7985, pointed the other way.

## Reviewer Test Plan

### How to verify

The `if:` expression is the risky part: written wrong in the permissive direction it is a **security regression**, not a cost regression. So its semantics are replicated in a test and asserted per payload shape — `a || b` yields the first truthy value, a missing path is `''`, and `contains(list, '')` is false:

| payload | runs? |
| --- | --- |
| `comment.author_association` ∈ {OWNER, MEMBER, COLLABORATOR} | no |
| `review.author_association` ∈ same | no |
| `sender.type == 'Bot'` | no |
| CONTRIBUTOR / FIRST_TIME_CONTRIBUTOR / NONE / `''` | **yes** |
| unrecognised payload, empty payload | **yes (fail-safe)** |

`CONTRIBUTOR` is deliberately **not** trusted: a merged PR does not make someone's links safe. That matches the script's existing list exactly.

**Mutation-verified 6/6**, each with landing proof:

| # | mutation | why it matters |
| - | -------- | -------------- |
| 1 | drop the `review.*` payload path | PR-review events silently un-gated |
| 2 | drop the bot check | 9 of 200 runs return |
| 3 | add CONTRIBUTOR to the trusted list | scans stop on a real risk class |
| 4 | `cancel-in-progress: false` | duplicate edits stack again |
| 5 | collapse to a global concurrency key | every scan in the repo serialises behind one runner |
| 6 | **invert the gate** (skip untrusted, scan trusted) | **the only mutation here that is a security regression** |

Mutation 2 first reported `landed=False` — the anchor's indentation did not match, so nothing changed and the green proved nothing. Re-run against the exact line, it kills.

148/148 tests across both suites; **actionlint exit 0** (it validates the expression syntax, which is the failure mode a YAML-only check would miss); prettier and eslint clean.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

Workflow expression and its tests; no platform-dependent behaviour. The `if:` semantics are asserted against a replication of GitHub's expression rules rather than executed on GitHub — the acceptance check is the first trusted comment after merge producing **no run at all** rather than a skipped one.

## Risk & Scope

- **Main risk:** an `if:` that is wrong in the permissive direction silently disables a security control. Mitigated three ways — the script retains its own checks (so the gate can only *add* skipping, never *remove* scanning that the script would do), every ambiguous payload resolves toward running, and mutation 6 pins the polarity. Worth a reviewer's own read of the expression regardless; that is the one line in this PR where being wrong is expensive.
- **Behaviour change:** trusted-author comments produce **no workflow run** rather than a run that skips. Anyone reading the Actions tab for "did the guard look at this comment" will see nothing instead of a green skip. That is the intended saving, but it is a visible difference.
- **Not validated / out of scope:** actual queue relief is measurable only after merge — the number to watch is `remove-suspicious-attachments` queue depth, which was 20 at the time of writing. I have not touched the guard's detection logic, its extension list, or its moderation behaviour.
- **Breaking changes / migration notes:** none.

## Linked Issues

Found while investigating queue latency on the `/verify` lane (#8014, #8016). No issues closed.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让 `Comment Attachment Guard` 不再为"马上就会跳过"的工作分配 runner，并合并对同一条评论的重复扫描。

### 测量

在排查两次 `/verify` 触发为何排队 5 分钟以上时，我采样了实时队列：**88 个活跃作业——72 个托管、15 个自建。** 自建的 15 个**全部在运行、零排队**；托管的 72 个在争抢，其中 **20 个是同一个作业**：`remove-suspicious-attachments`，全部 `queued`，无一在运行。

它的代价不在于工作量。近期已完成的运行：排队 629 秒 / 执行 5 秒；排队 568 秒 / 执行 2 秒；排队 518 秒 / 执行 2 秒；排队 340 秒 / 执行 3 秒。**2–5 秒的 API 调用，排在最多十分钟的队列之后。**

**而这里面几乎没有一次是必要的。** 信任检查写在 github-script **内部**，因此 runner 已排队、已分配、已启动，作业才能判断自己无事可做。对本仓库最近 200 条评论的统计：

| 作者 | 数量 | 结果 |
| --- | ---: | --- |
| 受信任关联（OWNER/MEMBER/COLLABORATOR） | 184 | 启动后跳过 |
| bot | 9 | 启动后跳过 |
| **确实需要扫描** | **7** | 执行扫描 |

**96.5% 的运行只是为了打印 `Trusted author; skipping`。**

### 两处改动

**1. 把关联与 bot 检查提升到作业级 `if:`。** GitHub 在**分配 runner 之前**求值 `if:`，因此受信任的评论现在完全不产生成本。

脚本**保留了自己的那份检查**。这一点很重要：这道门是**优化**，不是控制，二者必须能够分歧而不至于变得不安全。因此所有歧义都倒向**执行**扫描——无法识别的载荷会得到空关联，而空值不在受信任列表中，于是作业照常运行。

**2. 增加按评论维度的 concurrency 分组 + `cancel-in-progress: true`。** 该工作流除 `created` 外还监听 `edited`，而 bot 会频繁 PATCH 自己的评论，因此对同一条评论的重复编辑会不断堆叠。扫描读取的是评论的**当前**正文，所以排队中的早先扫描本已过期，取消它不损失任何东西。

> 对照 verify 车道，那里 `cancel-in-progress` 刻意设为 `false`，因为被取消的运行会摧毁证据。**同一机制，相反的正确取值**——这也是分组处附了注释说明的原因。

分组 key 回退到 `run_id`，使异常载荷各自成组，而不是把所有扫描串行化进同一组。

### 为什么不搬到自建池

技术上完全可行——不 checkout、无 `run:`、不执行 PR 代码、只调 API——而且当时 ECS 池零排队。我没有这么做，有两个理由：

- **那 20 个堆积作业是重复触发。** 搬过去只是改为填满 ECS 池，而那个池正是 `/verify` 与 `/triage` 所依赖的。修掉重复才是真正的修复；搬迁只是把症状藏到一个危害更大的地方。
- **它持有 `issues: write` 且处理的是不可信的评论正文。** 这类角色更适合运行在用后即毁的机器上，而非复用机器——与 #7985 同一条"持久性"论证，方向相反。

## 评审验证方案

`if:` 表达式是风险所在：一旦朝**放行**方向写错，就是**安全回退**而不仅是成本回退。因此其语义在测试中被复现并按载荷形态逐一断言（`a || b` 取第一个真值、缺失路径为 `''`、`contains(list, '')` 为 false）：

| 载荷 | 是否运行 |
| --- | --- |
| `comment.author_association` ∈ {OWNER, MEMBER, COLLABORATOR} | 否 |
| `review.author_association` ∈ 同上 | 否 |
| `sender.type == 'Bot'` | 否 |
| CONTRIBUTOR / FIRST_TIME_CONTRIBUTOR / NONE / `''` | **是** |
| 无法识别的载荷、空载荷 | **是（fail-safe）** |

`CONTRIBUTOR` **刻意不被信任**：合并过一个 PR 并不能让某人的链接变得安全。这与脚本中既有的列表完全一致。

**6/6 变异验证**，每项均带落地证明：删除 `review.*` 载荷路径（PR review 事件被静默放行）；删除 bot 检查（200 次中的 9 次回归）；把 CONTRIBUTOR 加入受信任列表（对真实风险类别停止扫描）；`cancel-in-progress: false`（重复编辑重新堆叠）；塌缩为全局 concurrency key（全仓扫描串行到一个 runner）；**反转门禁**（跳过不可信、扫描可信）——**这是本 PR 中唯一属于安全回退而非成本回退的变异。**

变异 2 起初报告 `landed=False`——锚点缩进不匹配，什么也没改，绿色结果毫无意义。改用精确行重跑后致死。

两个测试套件共 148/148 通过；**actionlint exit 0**（它会校验表达式语法，而这正是仅做 YAML 检查会漏掉的失败模式）；prettier 与 eslint 干净。

### 测试平台

macOS ✅；Windows N/A；Linux N/A——工作流表达式及其测试，无平台相关行为。`if:` 语义是针对 GitHub 表达式规则的复现进行断言，而非在 GitHub 上实际执行——验收标准是合入后第一条受信任评论**完全不产生运行**，而不是产生一次被跳过的运行。

## 风险与范围

- **主要风险**：朝放行方向写错的 `if:` 会静默停用一项安全控制。三重缓解——脚本保留自己的检查（因此这道门只能**增加**跳过，绝不能**移除**脚本本会执行的扫描）、所有歧义载荷都倒向执行、变异 6 钉住了极性。无论如何仍值得评审者亲自读一遍那个表达式；这是本 PR 中唯一"写错代价高昂"的一行。
- **行为变化**：受信任作者的评论**不再产生 workflow run**，而不是产生一次跳过的运行。习惯在 Actions 页面确认"守卫是否看过这条评论"的人会看到"什么都没有"而不是一个绿色的跳过。这正是节省的来源，但确实是一处可见差异。
- **未验证/范围外**：真实的队列缓解只能在合入后测量——要观察的数字是 `remove-suspicious-attachments` 的排队深度，撰写本文时为 20。我未改动守卫的检测逻辑、扩展名列表或处置行为。
- **破坏性变更**：无。

## 关联 Issue

在排查 `/verify` 车道（#8014、#8016）的队列延迟时发现。不关闭任何 issue。

</details>
