### PR TITLE
feat(web-shell): enhance composer and empty-session animations

### DIFF
--- a/docs/design/web-shell-specular-composer-animation.md
+++ b/docs/design/web-shell-specular-composer-animation.md
@@ -1,0 +1,73 @@
+# Web Shell Specular Composer Animation
+
+## Goal
+
+Replace the current composer-only DAC glow with the supplied specular edge
+animation, and add the supplied DotField animation behind the empty new-session
+view. Existing composer behavior, layout, controls, and keyboard handling remain
+unchanged.
+
+## Scope
+
+- Render a WebGL edge highlight around the complete composer surface.
+- Follow pointer direction while the composer is unfocused and within 250 CSS
+  pixels of the pointer.
+- Continue from the current highlight angle and rotate at 0.85 radians per
+  second while the editor is focused.
+- Keep the supplied light and dark animation colors and support live theme
+  changes.
+- Render the DotField only while `isChatEmptyState` is true.
+- Play the empty composer placeholder twice with a three-second pause, then
+  leave the complete placeholder visible.
+- Preserve the current 12 pixel composer radius and use that radius for the
+  shader geometry.
+- Preserve all existing CodeMirror, mobile textarea, toolbar, attachment,
+  submission, and disabled/running behavior.
+
+The demo's page layout, toolbar styling, send button styling, and fixed
+20-pixel composer radius are not part of this change.
+
+## Structure
+
+`SpecularComposerEffect` owns the composer canvas and all pointer, focus,
+resize, animation-frame, and WebGL resources. It is an inert sibling of the
+composer content and never receives pointer events.
+
+`NewSessionDotField` owns the empty-state background canvas. `App` mounts it
+only for the empty new-session state, so starting or loading a session removes
+the canvas and releases its resources.
+
+The composer effect uses WebGL2 directly, while the DotField uses the browser's
+2D canvas API, matching the handoff without adding a runtime dependency. If
+WebGL2 is unavailable, the specular canvas remains absent and the existing CSS
+surface continues to work.
+
+## Motion and accessibility
+
+The composer highlight uses the supplied 32 degree highlight and 68 degree
+fade, a one-CSS-pixel edge, 1.0 proximity intensity, and 1.4 focused intensity.
+Focus and blur both lock the current angle before changing modes, so the
+focused rotation stays clockwise and never jumps or reverses during
+hover/focus transitions. The hover/focus underlay expands four pixels around
+the existing radius.
+
+The DotField uses 1-pixel dots on a 15-pixel grid, a 500-pixel pointer radius,
+0.1 pointer force, a 67-pixel bulge, and a 160-pixel glow. The glow erases the
+canvas dots so the actual host background shows through without color
+interpolation.
+
+The typewriter stops as soon as the user interacts with the editor. If the
+empty editor loses focus, it gets another two-run sequence. Empty placeholder
+strings do not mount the effect.
+
+When `prefers-reduced-motion: reduce` is active, both animation loops remain
+disabled. Changes to the system preference apply without reloading the page.
+The composer retains its ordinary CSS border and focus affordance.
+
+## Lifecycle and verification
+
+Each effect cancels animation frames, disconnects its `ResizeObserver`, and
+removes event listeners. The composer effect also deletes its WebGL resources
+and loses its context. Tests cover empty-state mounting, non-empty removal,
+composer effect presence, and WebGL-unavailable fallback. Existing composer
+interaction tests guard against functional regressions.

--- a/packages/web-shell/client/App.module.css
+++ b/packages/web-shell/client/App.module.css
@@ -646,8 +646,14 @@
    the wrapper must shrink to its content instead of filling the pane — the same
    thing `.content` already does in this state. */
 .appChatEmpty .chatViewWrap {
+  position: relative;
+  z-index: 1;
   flex: 0 0 auto;
   overflow: visible;
+}
+
+.appChatEmpty .chatPane {
+  position: relative;
 }
 
 .footer {

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -489,6 +489,12 @@ vi.mock('./components/ChatEditor', async () => {
   };
 });
 
+vi.mock('./components/NewSessionDotField', () => ({
+  NewSessionDotField: () => (
+    <div data-web-shell-new-session-dot-field aria-hidden="true" />
+  ),
+}));
+
 vi.mock('./components/MessageList', async () => {
   const React = await import('react');
   const { useInteractionBlocker } = await import('./interactionBlockContext');
@@ -1710,6 +1716,9 @@ describe('App composer footer renderer', () => {
     expect(composer?.nextElementSibling).toBe(composerFooter);
     expect(composerFooter?.parentElement).toBe(composer?.parentElement);
     expect(composer?.parentElement?.nextElementSibling).toBe(shellFooter);
+    expect(
+      container.querySelector('[data-web-shell-new-session-dot-field]'),
+    ).toBeNull();
   });
 
   it('updates composer footer state and renders it in the empty welcome state', async () => {
@@ -1759,6 +1768,9 @@ describe('App composer footer renderer', () => {
 
     expect(
       container.querySelector('[data-testid="composer-footer"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-web-shell-new-session-dot-field]'),
     ).not.toBeNull();
     expect(composerFooterProps.at(-1)).toEqual({
       disabled: false,

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -78,6 +78,7 @@ import {
 } from './components/ToastHost';
 import { TodoPanel } from './components/panels/TodoPanel';
 import { WelcomeHeader } from './components/WelcomeHeader';
+import { NewSessionDotField } from './components/NewSessionDotField';
 import { ApprovalModeDialog } from './components/dialogs/ApprovalModeDialog';
 import { ResumeDialog } from './components/dialogs/ResumeDialog';
 import { DialogShell } from './components/dialogs/DialogShell';
@@ -7916,6 +7917,10 @@ export function App({
                 .filter(Boolean)
                 .join(' ')}
             >
+              {isChatEmptyState &&
+                !showMissingSessionState &&
+                !activePanel &&
+                mainView === 'chat' && <NewSessionDotField />}
               {sidebarOptions.enabled &&
                 sidebarOptions.showCompactToggle &&
                 !activePanel &&

--- a/packages/web-shell/client/components/ChatEditor.module.css
+++ b/packages/web-shell/client/components/ChatEditor.module.css
@@ -19,10 +19,6 @@
   --chat-editor-input-min-height: 44px;
   --chat-editor-input-max-height: 300px;
   --chat-editor-attachments-max-height: 136px;
-  --dac-glow-on: 0;
-  --dac-glow-pulse: 0;
-  --dac-g1: #6a78ff;
-  --dac-g2: #8a7bff;
   --chat-send-button-disabled-foreground: var(--secondary-foreground);
   --chat-send-button-foreground: #fafafa;
 }
@@ -43,146 +39,45 @@
   padding: 12px;
 }
 
-.dacAura,
-.dacHalo {
+.specularEffect {
+  position: absolute;
+  inset: -20px;
+  z-index: 3;
+  overflow: visible;
   pointer-events: none;
 }
 
-.dacAura {
+.specularEffect::before {
   position: absolute;
-  inset: -50px;
-  z-index: 0;
-  opacity: calc(var(--dac-glow-on) * (0.66 + var(--dac-glow-pulse) * 0.34));
-  -webkit-mask: radial-gradient(
-    ellipse 56% 64% at center,
-    transparent 28%,
-    #000 48%,
-    transparent 94%
-  );
-  mask: radial-gradient(
-    ellipse 56% 64% at center,
-    transparent 28%,
-    #000 48%,
-    transparent 94%
-  );
-  will-change: opacity;
-}
-
-.dacAura::before,
-.dacAura::after {
-  position: absolute;
-  inset: 0;
+  inset: 20px;
+  border-radius: 12px;
   content: '';
+  opacity: 0;
+  transition: opacity 0.45s cubic-bezier(0.22, 1, 0.36, 1);
   will-change: opacity;
 }
 
-.dacAura::before {
-  background: color-mix(in srgb, var(--dac-g1) 58%, transparent);
-  -webkit-mask:
-    repeating-linear-gradient(90deg, #000 0 1px, transparent 1px 5px),
-    repeating-linear-gradient(0deg, #000 0 1px, transparent 1px 5px);
-  -webkit-mask-composite: source-in;
-  mask:
-    repeating-linear-gradient(90deg, #000 0 1px, transparent 1px 5px),
-    repeating-linear-gradient(0deg, #000 0 1px, transparent 1px 5px);
-  mask-composite: intersect;
-  opacity: 1;
-  transition: opacity 0.2s ease;
-}
-
-.dacAura::after {
-  background: color-mix(in srgb, var(--dac-g1) 66%, transparent);
-  -webkit-mask:
-    repeating-linear-gradient(90deg, #000 0 1px, transparent 1px 5px),
-    repeating-linear-gradient(0deg, #000 0 1px, transparent 1px 5px),
-    repeating-linear-gradient(
-      90deg,
-      #000 0,
-      rgba(0, 0, 0, 0.08) 28px,
-      #000 56px
-    );
-  -webkit-mask-composite: source-in, source-in;
-  mask:
-    repeating-linear-gradient(90deg, #000 0 1px, transparent 1px 5px),
-    repeating-linear-gradient(0deg, #000 0 1px, transparent 1px 5px),
-    repeating-linear-gradient(
-      90deg,
-      #000 0,
-      rgba(0, 0, 0, 0.08) 28px,
-      #000 56px
-    );
-  mask-composite: intersect, intersect;
-  opacity: 0;
-  animation: dac-aura-cols 2.4s linear infinite paused;
-  transition: opacity 0.2s ease;
-}
-
-.container[data-dac-typing] .dacAura::before {
-  opacity: 0;
-}
-
-.container[data-dac-typing] .dacAura::after {
-  opacity: 1;
-  animation-play-state: running;
-}
-
-.dacHalo {
-  position: absolute;
-  inset: 0;
-  z-index: 1;
-  border-radius: inherit;
-  opacity: var(--dac-glow-on);
+.specularEffect[data-theme='light']::before {
   box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--dac-g2) 36%, transparent),
-    0 1px 5px color-mix(in srgb, var(--dac-g1) 18%, transparent),
-    0 6px 30px color-mix(in srgb, var(--dac-g1) 22%, transparent);
-  will-change: opacity;
+    0 0 0 4px rgba(205, 217, 255, 0.5),
+    0 16px 46px rgba(51, 92, 255, 0.08);
 }
 
-.dacHalo::after {
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  box-shadow: 0 6px 40px color-mix(in srgb, var(--dac-g1) 14%, transparent);
-  content: '';
-  opacity: calc(var(--dac-glow-on) * var(--dac-glow-pulse));
-  will-change: opacity;
+.specularEffect[data-theme='dark']::before {
+  box-shadow:
+    0 0 0 4px rgba(83, 103, 159, 0.3),
+    0 18px 54px rgba(51, 92, 255, 0.18);
 }
 
-@keyframes dac-aura-cols {
-  from {
-    -webkit-mask-position:
-      0 0,
-      0 0,
-      0 0;
-    mask-position:
-      0 0,
-      0 0,
-      0 0;
-  }
-
-  to {
-    -webkit-mask-position:
-      0 0,
-      0 0,
-      56px 0;
-    mask-position:
-      0 0,
-      0 0,
-      56px 0;
-  }
+.container:hover .specularEffect::before,
+.container:focus-within .specularEffect::before {
+  opacity: 1;
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .dacAura::after,
-  .container[data-dac-typing] .dacAura::after {
-    opacity: 0;
-    animation: none;
-  }
-
-  .container[data-dac-typing] .dacAura::before {
-    opacity: 1;
-  }
+.specularEffect canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 .atPortalLayer {
@@ -812,6 +707,7 @@
 }
 
 .editorArea {
+  position: relative;
   display: flex;
   flex: 1 1 auto;
   align-items: stretch;
@@ -819,6 +715,69 @@
   min-height: var(--chat-editor-input-min-height, 44px);
   padding: 4px 0;
   overflow: clip;
+}
+
+.typewriterPlaceholder {
+  position: absolute;
+  top: 4px;
+  left: 0;
+  z-index: 1;
+  color: var(--chat-editor-text-dimmed, #666);
+  font-family: var(--font-sans, system-ui, sans-serif);
+  font-size: 14px;
+  line-height: 1.6;
+  pointer-events: none;
+  white-space: pre-wrap;
+}
+
+.typewriterCaret {
+  display: inline-block;
+  margin-left: 1px;
+  color: #6785ff;
+}
+
+:global(.dark) .typewriterCaret {
+  color: rgba(205, 215, 255, 0.6);
+}
+
+.typewriterCaretFinished {
+  animation: typewriter-caret-blink 0.5s steps(1) 2 forwards;
+}
+
+.container[data-typewriter-visible] .editorArea :global(.cm-placeholder) {
+  opacity: 0;
+}
+
+.container[data-typewriter-visible] .mobileTextarea::placeholder {
+  color: transparent;
+}
+
+@keyframes typewriter-caret-blink {
+  0%,
+  48% {
+    opacity: 1;
+  }
+
+  49%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@media (pointer: coarse) {
+  .typewriterPlaceholder {
+    font-size: 16px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .specularEffect::before {
+    transition: none;
+  }
+
+  .typewriterCaretFinished {
+    animation: none;
+  }
 }
 
 .editorArea > :last-child {

--- a/packages/web-shell/client/components/ChatEditor.test.tsx
+++ b/packages/web-shell/client/components/ChatEditor.test.tsx
@@ -394,6 +394,54 @@ describe('ChatEditor animation layers', () => {
     ).toBeNull();
     expect(container.querySelector('[data-typewriter-visible]')).toBeNull();
   });
+
+  it('shows the full placeholder without a caret under prefers-reduced-motion', () => {
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = vi.fn(
+      (query: string) =>
+        ({
+          matches: query === '(prefers-reduced-motion: reduce)',
+          media: query,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+        }) as MediaQueryList,
+    );
+    try {
+      const container = renderChatEditor({ placeholderText: 'abc' });
+      const typewriter = container.querySelector(
+        '[data-web-shell-composer-typewriter]',
+      );
+
+      expect(typewriter?.textContent).toBe('abc');
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
+  });
+
+  it('replays the typewriter sequence after the empty editor loses focus', () => {
+    vi.useFakeTimers();
+    const container = renderChatEditor({ placeholderText: 'abc' });
+    const editor = container.querySelector<HTMLElement>(
+      '[data-web-shell-composer-editor]',
+    );
+    const outside = document.createElement('button');
+    container.appendChild(outside);
+    editor!.tabIndex = 0;
+    const typewriter = () =>
+      container.querySelector('[data-web-shell-composer-typewriter]');
+
+    act(() => editor!.focus());
+    act(() => {
+      editor!.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    });
+    expect(typewriter()).toBeNull();
+
+    act(() => outside.focus());
+    expect(typewriter()?.textContent).toBe('_');
+
+    act(() => vi.advanceTimersByTime(3 * 45));
+    expect(typewriter()?.textContent).toBe('abc_');
+  });
 });
 
 describe('ChatEditor attachment reporting', () => {

--- a/packages/web-shell/client/components/ChatEditor.test.tsx
+++ b/packages/web-shell/client/components/ChatEditor.test.tsx
@@ -212,6 +212,12 @@ vi.mock('../voice/VoiceButton', () => ({
   },
 }));
 
+vi.mock('./SpecularComposerEffect', () => ({
+  SpecularComposerEffect: () => (
+    <span data-web-shell-composer-specular aria-hidden="true" />
+  ),
+}));
+
 const mounted: Array<{
   root: Root;
   container: HTMLDivElement;
@@ -233,6 +239,7 @@ afterEach(() => {
   mockComposerCoreState.composerTags = [];
   mockComposerCoreState.pastedImages = [];
   mockComposerCoreState.removeTopTag.mockReset();
+  vi.useRealTimers();
 });
 
 function renderChatEditor(props: {
@@ -250,6 +257,7 @@ function renderChatEditor(props: {
   onSelectMode?: (mode: string) => void;
   onSelectModel?: (model: string) => void;
   onAttachmentsChange?: (hasAttachments: boolean) => void;
+  placeholderText?: string;
   customization?: WebShellCustomization;
 }) {
   const {
@@ -318,6 +326,73 @@ describe('ChatEditor voice toolbar integration', () => {
         visibleToolbarActions: [],
       }).querySelector('[data-testid="voice-button"]'),
     ).toBeNull();
+  });
+});
+
+describe('ChatEditor animation layers', () => {
+  it('mounts the inert specular layer without replacing composer controls', () => {
+    const container = renderChatEditor({});
+
+    expect(
+      container.querySelector('[data-web-shell-composer-specular]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-web-shell-composer-editor]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-web-shell-composer-submit]'),
+    ).not.toBeNull();
+  });
+
+  it('keeps the typewriter visible through automatic focus', () => {
+    const container = renderChatEditor({});
+    const editor = container.querySelector<HTMLElement>(
+      '[data-web-shell-composer-editor]',
+    );
+    const outside = document.createElement('button');
+    container.appendChild(outside);
+    editor!.tabIndex = 0;
+
+    act(() => editor!.focus());
+    expect(container.querySelector('[data-typewriter-visible]')).not.toBeNull();
+
+    act(() => {
+      editor!.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    });
+    expect(container.querySelector('[data-typewriter-visible]')).toBeNull();
+
+    act(() => outside.focus());
+    expect(container.querySelector('[data-typewriter-visible]')).not.toBeNull();
+  });
+
+  it('plays the typewriter twice and then keeps the completed text', () => {
+    vi.useFakeTimers();
+    const container = renderChatEditor({ placeholderText: 'abc' });
+    const typewriter = () =>
+      container.querySelector('[data-web-shell-composer-typewriter]');
+
+    expect(typewriter()?.textContent).toBe('_');
+
+    act(() => vi.advanceTimersByTime(3 * 45));
+    expect(typewriter()?.textContent).toBe('abc_');
+
+    act(() => vi.advanceTimersByTime(3000));
+    expect(typewriter()?.textContent).toBe('_');
+
+    act(() => vi.advanceTimersByTime(3 * 45));
+    expect(typewriter()?.textContent).toBe('abc_');
+
+    act(() => vi.advanceTimersByTime(3001));
+    expect(typewriter()?.textContent).toBe('abc_');
+  });
+
+  it('does not mount the typewriter for an empty placeholder', () => {
+    const container = renderChatEditor({ placeholderText: '' });
+
+    expect(
+      container.querySelector('[data-web-shell-composer-typewriter]'),
+    ).toBeNull();
+    expect(container.querySelector('[data-typewriter-visible]')).toBeNull();
   });
 });
 

--- a/packages/web-shell/client/components/ChatEditor.test.tsx
+++ b/packages/web-shell/client/components/ChatEditor.test.tsx
@@ -15,6 +15,7 @@ import type {
   MobileComposerBackend,
   SlashMenuState,
 } from '../hooks/useComposerCore';
+import type { UseDaemonFollowupSuggestionReturn } from '@qwen-code/webui/daemon-react-sdk';
 import { ChatEditor, type ComposerToolbarAction } from './ChatEditor';
 import { WebShellPortalRootContext } from '../portalRoot';
 
@@ -100,6 +101,7 @@ const composerCoreState = vi.hoisted(() => ({
   closeSlashMenu: vi.fn(),
   mobileComposer: null as unknown,
   openHistorySearch: vi.fn(),
+  shellMode: false,
 }));
 
 const voiceButtonState = vi.hoisted(() => ({
@@ -159,7 +161,7 @@ vi.mock('../hooks/useComposerCore', async (importOriginal) => {
       clear: vi.fn(),
       retryLast: vi.fn(),
       replaceEditorText: vi.fn(),
-      shellMode: false,
+      shellMode: composerCoreState.shellMode,
       setShellMode: vi.fn(),
       toggleShellMode: vi.fn(),
       currentMode: 'default',
@@ -226,6 +228,7 @@ const mounted: Array<{
 
 afterEach(() => {
   composerCoreState.slashMenu = null;
+  composerCoreState.shellMode = false;
   composerCoreState.focus.mockReset();
   composerCoreState.closeSlashMenu.mockReset();
   composerCoreState.mobileComposer = null;
@@ -258,6 +261,8 @@ function renderChatEditor(props: {
   onSelectModel?: (model: string) => void;
   onAttachmentsChange?: (hasAttachments: boolean) => void;
   placeholderText?: string;
+  disabled?: boolean;
+  followupState?: UseDaemonFollowupSuggestionReturn['followupState'];
   customization?: WebShellCustomization;
 }) {
   const {
@@ -441,6 +446,36 @@ describe('ChatEditor animation layers', () => {
 
     act(() => vi.advanceTimersByTime(3 * 45));
     expect(typewriter()?.textContent).toBe('abc_');
+  });
+
+  it('hides the typewriter when disabled, in shell mode, or during a followup', () => {
+    const typewriterOf = (container: HTMLElement) =>
+      container.querySelector('[data-web-shell-composer-typewriter]');
+
+    expect(
+      typewriterOf(renderChatEditor({ placeholderText: 'abc' })),
+    ).not.toBeNull();
+
+    expect(
+      typewriterOf(
+        renderChatEditor({ placeholderText: 'abc', disabled: true }),
+      ),
+    ).toBeNull();
+
+    composerCoreState.shellMode = true;
+    expect(
+      typewriterOf(renderChatEditor({ placeholderText: 'abc' })),
+    ).toBeNull();
+    composerCoreState.shellMode = false;
+
+    expect(
+      typewriterOf(
+        renderChatEditor({
+          placeholderText: 'abc',
+          followupState: { suggestion: 'next', isVisible: true, shownAt: 0 },
+        }),
+      ),
+    ).toBeNull();
   });
 });
 

--- a/packages/web-shell/client/components/ChatEditor.tsx
+++ b/packages/web-shell/client/components/ChatEditor.tsx
@@ -22,6 +22,8 @@ import type { CommandDisplayCategoryOrder } from '../utils/commandDisplay';
 import type { SkillInfo } from '../completions/slashCompletion';
 import { useI18n } from '../i18n';
 import { useWebShellPortalRoot } from '../portalRoot';
+import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion';
+import { SpecularComposerEffect } from './SpecularComposerEffect';
 import {
   useWebShellCustomization,
   type WebShellComposerInput,
@@ -406,89 +408,63 @@ function QuickActionsIcon() {
   );
 }
 
-function attachComposerGlow(glowRootEl: HTMLElement, inputEl: HTMLElement) {
-  let glowRaf: number | undefined;
-  let pulseRaf: number | undefined;
-  let pulseDecayTimer: number | undefined;
-  let typingTimer: number | undefined;
-  let glowCurrent = 0;
-  let pulseCurrent = 0;
+function TypewriterPlaceholder({ text }: { text: string }) {
+  const totalRuns = 2;
+  const replayDelay = 3000;
+  const reducedMotion = usePrefersReducedMotion();
+  const [visibleText, setVisibleText] = useState(reducedMotion ? text : '');
+  const [finished, setFinished] = useState(false);
 
-  const apply = (on: number, pulse: number) => {
-    glowRootEl.style.setProperty('--dac-glow-on', on.toFixed(4));
-    glowRootEl.style.setProperty('--dac-glow-pulse', pulse.toFixed(4));
-  };
-
-  const animateGlow = (target: number) => {
-    if (glowRaf !== undefined) window.cancelAnimationFrame(glowRaf);
-    const start = glowCurrent;
-    const diff = target - start;
-    if (Math.abs(diff) < 0.001) {
-      glowCurrent = target;
-      apply(target, pulseCurrent);
-      return;
+  useEffect(() => {
+    if (reducedMotion) {
+      setVisibleText(text);
+      setFinished(false);
+      return undefined;
     }
-    const t0 = performance.now();
-    const tick = (now: number) => {
-      const t = Math.min((now - t0) / 220, 1);
-      glowCurrent = start + diff * (1 - (1 - t) ** 2);
-      apply(glowCurrent, pulseCurrent);
-      glowRaf = t < 1 ? window.requestAnimationFrame(tick) : undefined;
+
+    let run = 0;
+    let timer = 0;
+    const startRun = () => {
+      let index = 0;
+      setVisibleText('');
+      setFinished(false);
+      const typeNextCharacter = () => {
+        index += 1;
+        setVisibleText(text.slice(0, index));
+        if (index === text.length) {
+          run += 1;
+          setFinished(true);
+          if (run < totalRuns) {
+            timer = window.setTimeout(startRun, replayDelay);
+          }
+          return;
+        }
+        timer = window.setTimeout(typeNextCharacter, 45);
+      };
+      timer = window.setTimeout(typeNextCharacter, 45);
     };
-    glowRaf = window.requestAnimationFrame(tick);
-  };
+    startRun();
+    return () => window.clearTimeout(timer);
+  }, [reducedMotion, text]);
 
-  const animatePulseDecay = () => {
-    if (pulseRaf !== undefined) window.cancelAnimationFrame(pulseRaf);
-    const start = pulseCurrent;
-    const t0 = performance.now();
-    const tick = (now: number) => {
-      const t = Math.min((now - t0) / 300, 1);
-      pulseCurrent = start * (1 - t);
-      apply(glowCurrent, pulseCurrent);
-      pulseRaf = t < 1 ? window.requestAnimationFrame(tick) : undefined;
-    };
-    pulseRaf = window.requestAnimationFrame(tick);
-  };
-
-  const setTyping = (on: boolean) => {
-    if (on) glowRootEl.setAttribute('data-dac-typing', '');
-    else glowRootEl.removeAttribute('data-dac-typing');
-  };
-
-  const onFocus = () => animateGlow(1);
-  const onBlur = () => {
-    animateGlow(0);
-    setTyping(false);
-    if (typingTimer !== undefined) window.clearTimeout(typingTimer);
-  };
-  const onKeydown = () => {
-    if (pulseRaf !== undefined) window.cancelAnimationFrame(pulseRaf);
-    if (pulseDecayTimer !== undefined) window.clearTimeout(pulseDecayTimer);
-    pulseCurrent = 1;
-    apply(glowCurrent, 1);
-    pulseDecayTimer = window.setTimeout(animatePulseDecay, 100);
-    setTyping(true);
-    if (typingTimer !== undefined) window.clearTimeout(typingTimer);
-    typingTimer = window.setTimeout(() => setTyping(false), 650);
-  };
-
-  inputEl.addEventListener('focus', onFocus);
-  inputEl.addEventListener('blur', onBlur);
-  inputEl.addEventListener('keydown', onKeydown);
-  if (document.activeElement === inputEl) animateGlow(1);
-
-  return () => {
-    if (glowRaf !== undefined) window.cancelAnimationFrame(glowRaf);
-    if (pulseRaf !== undefined) window.cancelAnimationFrame(pulseRaf);
-    if (pulseDecayTimer !== undefined) window.clearTimeout(pulseDecayTimer);
-    if (typingTimer !== undefined) window.clearTimeout(typingTimer);
-    inputEl.removeEventListener('focus', onFocus);
-    inputEl.removeEventListener('blur', onBlur);
-    inputEl.removeEventListener('keydown', onKeydown);
-    apply(0, 0);
-    setTyping(false);
-  };
+  return (
+    <span
+      className={styles.typewriterPlaceholder}
+      data-web-shell-composer-typewriter
+      aria-hidden="true"
+    >
+      {visibleText}
+      {!reducedMotion && (
+        <span
+          className={`${styles.typewriterCaret} ${
+            finished ? styles.typewriterCaretFinished : ''
+          }`}
+        >
+          _
+        </span>
+      )}
+    </span>
+  );
 }
 
 function WidthModeIcon({ mode }: { mode: '1000' | 'wide' }) {
@@ -1279,6 +1255,7 @@ export const ChatEditor = memo(
     const [quickActionsOpen, setQuickActionsOpen] = useState(false);
     const [branchPickerOpen, setBranchPickerOpen] = useState(false);
     const [showQuickActions, setShowQuickActions] = useState(isTouchLikeDevice);
+    const [typewriterSuppressed, setTypewriterSuppressed] = useState(false);
     const containerRef = useRef<HTMLDivElement>(null);
     const slashPanelRef = useRef<HTMLDivElement>(null);
     const slashDetailRef = useRef<HTMLDivElement>(null);
@@ -1306,7 +1283,13 @@ export const ChatEditor = memo(
     const closeAtMenu = core.closeAtMenu;
     const hasSlashMenu = Boolean(slashMenu);
     const hasAtMenu = Boolean(atMenu);
-    const editorViewRef = core.viewRef;
+    const showTypewriterPlaceholder =
+      !disabled &&
+      Boolean(placeholderText) &&
+      !core.hasInput() &&
+      !typewriterSuppressed &&
+      !core.shellMode &&
+      !followupState?.isVisible;
 
     useEffect(() => {
       if (typeof window === 'undefined' || !window.matchMedia) return;
@@ -1345,13 +1328,6 @@ export const ChatEditor = memo(
         window.removeEventListener('touchstart', onPointerOutside);
       };
     }, [hasAtMenu, hasSlashMenu, closeAtMenu, closeSlashMenu]);
-
-    useEffect(() => {
-      const glowRoot = containerRef.current;
-      const inputEl = editorViewRef.current?.contentDOM;
-      if (!glowRoot || !inputEl) return undefined;
-      return attachComposerGlow(glowRoot, inputEl);
-    }, [editorViewRef]);
 
     useEffect(() => {
       const container = containerRef.current;
@@ -1887,7 +1863,7 @@ export const ChatEditor = memo(
           ref={containerRef}
           className={styles.container}
           data-web-shell-composer-surface
-          data-dac-glow
+          data-typewriter-visible={showTypewriterPlaceholder || undefined}
           onClick={() => {
             setModeDropdownOpen(false);
             setModelDropdownOpen(false);
@@ -1895,8 +1871,7 @@ export const ChatEditor = memo(
             core.focus();
           }}
         >
-          <div className={styles.dacAura} aria-hidden="true" />
-          <div className={styles.dacHalo} aria-hidden="true" />
+          <SpecularComposerEffect targetRef={containerRef} />
           {searchMode && (
             <div
               ref={searchUiRef}
@@ -2064,7 +2039,19 @@ export const ChatEditor = memo(
                 onSelectTab={core.selectAtTab}
               />
             )}
-            <div className={styles.editorArea}>
+            <div
+              className={styles.editorArea}
+              onPointerDownCapture={() => setTypewriterSuppressed(true)}
+              onKeyDownCapture={() => setTypewriterSuppressed(true)}
+              onBlurCapture={(event) => {
+                if (!event.currentTarget.contains(event.relatedTarget)) {
+                  setTypewriterSuppressed(false);
+                }
+              }}
+            >
+              {showTypewriterPlaceholder && (
+                <TypewriterPlaceholder text={placeholderText} />
+              )}
               {core.shellMode && (
                 <span className={styles.shellPrefix} aria-hidden="true">
                   !

--- a/packages/web-shell/client/components/NewSessionDotField.module.css
+++ b/packages/web-shell/client/components/NewSessionDotField.module.css
@@ -1,0 +1,13 @@
+.root {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.root canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}

--- a/packages/web-shell/client/components/NewSessionDotField.tsx
+++ b/packages/web-shell/client/components/NewSessionDotField.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useRef } from 'react';
+import { useTheme, WebShellThemeId } from '../themeContext';
+import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion';
+import styles from './NewSessionDotField.module.css';
+
+interface Dot {
+  anchorX: number;
+  anchorY: number;
+  x: number;
+  y: number;
+}
+
+export function NewSessionDotField() {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const theme = useTheme();
+  const reducedMotion = usePrefersReducedMotion();
+
+  useEffect(() => {
+    const root = rootRef.current;
+    const canvas = canvasRef.current;
+    const context = canvas?.getContext('2d', { alpha: true });
+    if (!root || !canvas || !context) return undefined;
+
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    const dots: Dot[] = [];
+    const pointer = {
+      x: -9999,
+      y: -9999,
+      previousX: -9999,
+      previousY: -9999,
+      speed: 0,
+    };
+    let width = 0;
+    let height = 0;
+    let engagement = 0;
+    let glowOpacity = 0;
+    let frameId = 0;
+    let speedTimer: number | undefined;
+
+    const buildDots = () => {
+      dots.length = 0;
+      const step = 15;
+      const columns = Math.floor(width / step);
+      const rows = Math.floor(height / step);
+      const paddingX = (width % step) / 2;
+      const paddingY = (height % step) / 2;
+      for (let row = 0; row < rows; row += 1) {
+        for (let column = 0; column < columns; column += 1) {
+          const anchorX = paddingX + column * step + step / 2;
+          const anchorY = paddingY + row * step + step / 2;
+          dots.push({
+            anchorX,
+            anchorY,
+            x: anchorX,
+            y: anchorY,
+          });
+        }
+      }
+    };
+
+    const draw = () => {
+      const targetEngagement = Math.min(pointer.speed / 5, 1);
+      engagement += (targetEngagement - engagement) * 0.06;
+      if (engagement < 0.001) engagement = 0;
+      glowOpacity += (engagement - glowOpacity) * 0.08;
+
+      context.clearRect(0, 0, width, height);
+      context.fillStyle =
+        theme === WebShellThemeId.Light
+          ? 'rgba(172, 191, 255, 0.85)'
+          : 'rgba(172, 191, 255, 0.42)';
+      context.beginPath();
+
+      const cursorRadiusSquared = 500 * 500;
+      for (const dot of dots) {
+        const dx = pointer.x - dot.anchorX;
+        const dy = pointer.y - dot.anchorY;
+        const distanceSquared = dx * dx + dy * dy;
+        if (
+          !reducedMotion &&
+          distanceSquared < cursorRadiusSquared &&
+          engagement > 0.01
+        ) {
+          const distance = Math.sqrt(distanceSquared);
+          const amount = 1 - distance / 500;
+          const push = amount * amount * 67 * engagement;
+          const direction = Math.atan2(dy, dx);
+          dot.x += (dot.anchorX - Math.cos(direction) * push - dot.x) * 0.15;
+          dot.y += (dot.anchorY - Math.sin(direction) * push - dot.y) * 0.15;
+        } else {
+          dot.x += (dot.anchorX - dot.x) * 0.1;
+          dot.y += (dot.anchorY - dot.y) * 0.1;
+        }
+        context.moveTo(dot.x + 0.5, dot.y);
+        context.arc(dot.x, dot.y, 0.5, 0, Math.PI * 2);
+      }
+      context.fill();
+
+      if (!reducedMotion && glowOpacity > 0.001) {
+        const glow = context.createRadialGradient(
+          pointer.x,
+          pointer.y,
+          0,
+          pointer.x,
+          pointer.y,
+          160,
+        );
+        glow.addColorStop(0, 'rgba(0, 0, 0, 1)');
+        glow.addColorStop(1, 'rgba(0, 0, 0, 0)');
+        context.globalAlpha = glowOpacity;
+        context.globalCompositeOperation = 'destination-out';
+        context.fillStyle = glow;
+        context.fillRect(pointer.x - 160, pointer.y - 160, 320, 320);
+        context.globalCompositeOperation = 'source-over';
+        context.globalAlpha = 1;
+      }
+
+      if (!reducedMotion) frameId = window.requestAnimationFrame(draw);
+    };
+
+    const resize = () => {
+      const rect = root.getBoundingClientRect();
+      width = rect.width;
+      height = rect.height;
+      canvas.width = Math.ceil(width * dpr);
+      canvas.height = Math.ceil(height * dpr);
+      context.setTransform(dpr, 0, 0, dpr, 0, 0);
+      buildDots();
+      if (reducedMotion) draw();
+    };
+
+    const onPointerMove = (event: PointerEvent) => {
+      const rect = root.getBoundingClientRect();
+      pointer.x = event.clientX - rect.left;
+      pointer.y = event.clientY - rect.top;
+    };
+
+    const resizeObserver = new ResizeObserver(resize);
+    resizeObserver.observe(root);
+    resize();
+    if (!reducedMotion) {
+      window.addEventListener('pointermove', onPointerMove, { passive: true });
+      speedTimer = window.setInterval(() => {
+        const dx = pointer.previousX - pointer.x;
+        const dy = pointer.previousY - pointer.y;
+        const distance = Math.hypot(dx, dy);
+        pointer.speed += (distance - pointer.speed) * 0.5;
+        if (pointer.speed < 0.001) pointer.speed = 0;
+        pointer.previousX = pointer.x;
+        pointer.previousY = pointer.y;
+      }, 20);
+      frameId = window.requestAnimationFrame(draw);
+    }
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      if (speedTimer !== undefined) window.clearInterval(speedTimer);
+      resizeObserver.disconnect();
+      window.removeEventListener('pointermove', onPointerMove);
+    };
+  }, [reducedMotion, theme]);
+
+  return (
+    <div
+      ref={rootRef}
+      className={styles.root}
+      data-web-shell-new-session-dot-field
+      aria-hidden="true"
+    >
+      <canvas ref={canvasRef} />
+    </div>
+  );
+}

--- a/packages/web-shell/client/components/NewSessionDotField.tsx
+++ b/packages/web-shell/client/components/NewSessionDotField.tsx
@@ -35,6 +35,8 @@ export function NewSessionDotField() {
     let engagement = 0;
     let glowOpacity = 0;
     let frameId = 0;
+    let running = false;
+    let needsRepaint = true;
     let speedTimer: number | undefined;
 
     const buildDots = () => {
@@ -64,8 +66,8 @@ export function NewSessionDotField() {
       if (engagement < 0.001) engagement = 0;
       glowOpacity += (engagement - glowOpacity) * 0.08;
 
-      if (engagement === 0 && glowOpacity < 0.001) {
-        let settled = true;
+      let settled = engagement === 0 && glowOpacity < 0.001;
+      if (settled) {
         for (const dot of dots) {
           if (
             Math.abs(dot.x - dot.anchorX) > 0.01 ||
@@ -75,10 +77,12 @@ export function NewSessionDotField() {
             break;
           }
         }
-        if (settled) {
-          if (!reducedMotion) frameId = window.requestAnimationFrame(draw);
-          return;
-        }
+      }
+
+      if (settled && !needsRepaint) {
+        running = false;
+        frameId = 0;
+        return;
       }
 
       context.clearRect(0, 0, width, height);
@@ -132,7 +136,15 @@ export function NewSessionDotField() {
         context.globalAlpha = 1;
       }
 
+      needsRepaint = false;
       if (!reducedMotion) frameId = window.requestAnimationFrame(draw);
+    };
+
+    const startLoop = () => {
+      if (!reducedMotion && !running) {
+        running = true;
+        frameId = window.requestAnimationFrame(draw);
+      }
     };
 
     const resize = () => {
@@ -144,7 +156,9 @@ export function NewSessionDotField() {
       canvas.height = Math.ceil(height * dpr);
       context.setTransform(dpr, 0, 0, dpr, 0, 0);
       buildDots();
+      needsRepaint = true;
       if (reducedMotion) draw();
+      else startLoop();
     };
 
     const onPointerMove = (event: PointerEvent) => {
@@ -157,6 +171,7 @@ export function NewSessionDotField() {
       }
       pointer.x = x;
       pointer.y = y;
+      startLoop();
     };
 
     const resizeObserver = new ResizeObserver(resize);
@@ -172,8 +187,8 @@ export function NewSessionDotField() {
         if (pointer.speed < 0.001) pointer.speed = 0;
         pointer.previousX = pointer.x;
         pointer.previousY = pointer.y;
+        if (pointer.speed > 0) startLoop();
       }, 20);
-      frameId = window.requestAnimationFrame(draw);
     }
 
     return () => {

--- a/packages/web-shell/client/components/NewSessionDotField.tsx
+++ b/packages/web-shell/client/components/NewSessionDotField.tsx
@@ -149,8 +149,14 @@ export function NewSessionDotField() {
 
     const onPointerMove = (event: PointerEvent) => {
       const rect = root.getBoundingClientRect();
-      pointer.x = event.clientX - rect.left;
-      pointer.y = event.clientY - rect.top;
+      const x = event.clientX - rect.left;
+      const y = event.clientY - rect.top;
+      if (pointer.previousX === -9999) {
+        pointer.previousX = x;
+        pointer.previousY = y;
+      }
+      pointer.x = x;
+      pointer.y = y;
     };
 
     const resizeObserver = new ResizeObserver(resize);

--- a/packages/web-shell/client/components/NewSessionDotField.tsx
+++ b/packages/web-shell/client/components/NewSessionDotField.tsx
@@ -64,6 +64,23 @@ export function NewSessionDotField() {
       if (engagement < 0.001) engagement = 0;
       glowOpacity += (engagement - glowOpacity) * 0.08;
 
+      if (engagement === 0 && glowOpacity < 0.001) {
+        let settled = true;
+        for (const dot of dots) {
+          if (
+            Math.abs(dot.x - dot.anchorX) > 0.01 ||
+            Math.abs(dot.y - dot.anchorY) > 0.01
+          ) {
+            settled = false;
+            break;
+          }
+        }
+        if (settled) {
+          if (!reducedMotion) frameId = window.requestAnimationFrame(draw);
+          return;
+        }
+      }
+
       context.clearRect(0, 0, width, height);
       context.fillStyle =
         theme === WebShellThemeId.Light

--- a/packages/web-shell/client/components/NewSessionDotField.tsx
+++ b/packages/web-shell/client/components/NewSessionDotField.tsx
@@ -22,7 +22,6 @@ export function NewSessionDotField() {
     const context = canvas?.getContext('2d', { alpha: true });
     if (!root || !canvas || !context) return undefined;
 
-    const dpr = Math.min(window.devicePixelRatio || 1, 2);
     const dots: Dot[] = [];
     const pointer = {
       x: -9999,
@@ -120,6 +119,7 @@ export function NewSessionDotField() {
     };
 
     const resize = () => {
+      const dpr = Math.min(window.devicePixelRatio || 1, 2);
       const rect = root.getBoundingClientRect();
       width = rect.width;
       height = rect.height;

--- a/packages/web-shell/client/components/SpecularComposerEffect.test.tsx
+++ b/packages/web-shell/client/components/SpecularComposerEffect.test.tsx
@@ -38,10 +38,15 @@ describe('composer visual effects fallback', () => {
       );
     }
 
+    const requestAnimationFrameSpy = vi.spyOn(window, 'requestAnimationFrame');
+    const setIntervalSpy = vi.spyOn(window, 'setInterval');
+
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
     mounted.push({ container, root });
+    requestAnimationFrameSpy.mockClear();
+    setIntervalSpy.mockClear();
     act(() => root.render(<Harness />));
 
     expect(
@@ -53,12 +58,15 @@ describe('composer visual effects fallback', () => {
     expect(
       container.querySelector('[data-web-shell-new-session-dot-field] canvas'),
     ).not.toBeNull();
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+    expect(requestAnimationFrameSpy).not.toHaveBeenCalled();
   });
 
   it('erases dots for the pointer glow regardless of the background color', () => {
     vi.useFakeTimers();
     const addColorStop = vi.fn();
     const compositeOperations: string[] = [];
+    const globalAlphas: number[] = [];
     const contextStub = {
       arc: vi.fn(),
       beginPath: vi.fn(),
@@ -73,6 +81,11 @@ describe('composer visual effects fallback', () => {
       configurable: true,
       get: () => compositeOperations.at(-1) ?? 'source-over',
       set: (value: string) => compositeOperations.push(value),
+    });
+    Object.defineProperty(contextStub, 'globalAlpha', {
+      configurable: true,
+      get: () => globalAlphas.at(-1) ?? 1,
+      set: (value: number) => globalAlphas.push(value),
     });
     const context = contextStub as unknown as CanvasRenderingContext2D;
     vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
@@ -98,10 +111,22 @@ describe('composer visual effects fallback', () => {
       ),
     );
 
+    // Move the pointer across two speed samples so the field measures a real
+    // non-zero speed instead of relying on the unset previous-position seed.
     act(() => {
       window.dispatchEvent(
         new MouseEvent('pointermove', { clientX: 100, clientY: 100 }),
       );
+    });
+    act(() => {
+      vi.advanceTimersByTime(20);
+    });
+    act(() => {
+      window.dispatchEvent(
+        new MouseEvent('pointermove', { clientX: 300, clientY: 300 }),
+      );
+    });
+    act(() => {
       vi.advanceTimersByTime(20);
       drawFrame?.(0);
     });
@@ -109,6 +134,9 @@ describe('composer visual effects fallback', () => {
     expect(addColorStop).toHaveBeenCalledWith(0, 'rgba(0, 0, 0, 1)');
     expect(addColorStop).toHaveBeenCalledWith(1, 'rgba(0, 0, 0, 0)');
     expect(compositeOperations).toEqual(['destination-out', 'source-over']);
+    expect(globalAlphas).toHaveLength(2);
+    expect(globalAlphas[0]).toBeLessThan(1);
+    expect(globalAlphas[1]).toBe(1);
   });
 
   it('keeps both animation layers inert under prefers-reduced-motion', () => {
@@ -166,6 +194,47 @@ describe('composer visual effects fallback', () => {
     ).not.toBeNull();
     expect(setIntervalSpy).not.toHaveBeenCalled();
     expect(requestAnimationFrameSpy).not.toHaveBeenCalled();
+  });
+
+  it('cancels the dot field interval and animation frame on unmount', () => {
+    vi.useFakeTimers();
+    const contextStub = {
+      arc: vi.fn(),
+      beginPath: vi.fn(),
+      clearRect: vi.fn(),
+      createRadialGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+      fill: vi.fn(),
+      fillRect: vi.fn(),
+      moveTo: vi.fn(),
+      setTransform: vi.fn(),
+    };
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      contextStub as unknown as CanvasRenderingContext2D,
+    );
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1);
+    const cancelAnimationFrameSpy = vi
+      .spyOn(window, 'cancelAnimationFrame')
+      .mockImplementation(() => {});
+    const clearIntervalSpy = vi
+      .spyOn(window, 'clearInterval')
+      .mockImplementation(() => {});
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() =>
+      root.render(
+        <ThemeProvider value={WebShellThemeId.Dark}>
+          <NewSessionDotField />
+        </ThemeProvider>,
+      ),
+    );
+
+    act(() => root.unmount());
+    container.remove();
+
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    expect(cancelAnimationFrameSpy).toHaveBeenCalled();
   });
 });
 
@@ -335,5 +404,55 @@ describe('dot field settled skip', () => {
 
     expect(contextStub.arc.mock.calls.length).toBe(arcCallsAfterSettle);
     expect(contextStub.fill.mock.calls.length).toBe(fillCallsAfterSettle);
+  });
+});
+
+describe('dot field pointer speed baseline', () => {
+  it('does not report a phantom speed burst on the first pointer move', () => {
+    vi.useFakeTimers();
+    const addColorStop = vi.fn();
+    const contextStub = {
+      arc: vi.fn(),
+      beginPath: vi.fn(),
+      clearRect: vi.fn(),
+      createRadialGradient: vi.fn(() => ({ addColorStop })),
+      fill: vi.fn(),
+      fillRect: vi.fn(),
+      moveTo: vi.fn(),
+      setTransform: vi.fn(),
+    };
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      contextStub as unknown as CanvasRenderingContext2D,
+    );
+
+    let drawFrame: FrameRequestCallback | undefined;
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      drawFrame = callback;
+      return 1;
+    });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ container, root });
+    act(() =>
+      root.render(
+        <ThemeProvider value={WebShellThemeId.Dark}>
+          <NewSessionDotField />
+        </ThemeProvider>,
+      ),
+    );
+
+    // A lone first pointer move must seed the previous position so the speed
+    // sample stays zero and no glow burst is drawn.
+    act(() => {
+      window.dispatchEvent(
+        new MouseEvent('pointermove', { clientX: 100, clientY: 100 }),
+      );
+      vi.advanceTimersByTime(20);
+      drawFrame?.(0);
+    });
+
+    expect(addColorStop).not.toHaveBeenCalled();
   });
 });

--- a/packages/web-shell/client/components/SpecularComposerEffect.test.tsx
+++ b/packages/web-shell/client/components/SpecularComposerEffect.test.tsx
@@ -367,6 +367,194 @@ describe('specular effect idle bail-out', () => {
   });
 });
 
+describe('specular effect pointer leave', () => {
+  it('resets proximity so the idle bail-out fires after the pointer leaves', () => {
+    const drawArrays = vi.fn();
+    const clear = vi.fn();
+    const glStub = {
+      ARRAY_BUFFER: 0x8892,
+      BLEND: 0x0be2,
+      COLOR_BUFFER_BIT: 0x4000,
+      COMPILE_STATUS: 0x8b81,
+      FLOAT: 0x1406,
+      FRAGMENT_SHADER: 0x8b30,
+      LINK_STATUS: 0x8b82,
+      ONE: 1,
+      ONE_MINUS_SRC_ALPHA: 0x0303,
+      STATIC_DRAW: 0x88e4,
+      TRIANGLES: 0x0004,
+      VERTEX_SHADER: 0x8b31,
+      attachShader: vi.fn(),
+      bindBuffer: vi.fn(),
+      blendFunc: vi.fn(),
+      bufferData: vi.fn(),
+      clear,
+      compileShader: vi.fn(),
+      createBuffer: vi.fn(() => ({})),
+      createProgram: vi.fn(() => ({})),
+      createShader: vi.fn(() => ({})),
+      deleteBuffer: vi.fn(),
+      deleteProgram: vi.fn(),
+      deleteShader: vi.fn(),
+      drawArrays,
+      enable: vi.fn(),
+      enableVertexAttribArray: vi.fn(),
+      getAttribLocation: vi.fn(() => 0),
+      getExtension: vi.fn(() => ({ loseContext: vi.fn() })),
+      getProgramParameter: vi.fn(() => true),
+      getShaderParameter: vi.fn(() => true),
+      getUniformLocation: vi.fn(() => ({})),
+      linkProgram: vi.fn(),
+      shaderSource: vi.fn(),
+      uniform1f: vi.fn(),
+      uniform2f: vi.fn(),
+      uniform3f: vi.fn(),
+      useProgram: vi.fn(),
+      vertexAttribPointer: vi.fn(),
+      viewport: vi.fn(),
+    };
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      glStub as unknown as WebGL2RenderingContext,
+    );
+
+    const rafCallbacks: FrameRequestCallback[] = [];
+    let rafId = 0;
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      rafCallbacks.push(callback);
+      return ++rafId;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+
+    function Harness() {
+      const composerRef = useRef<HTMLDivElement>(null);
+      return (
+        <ThemeProvider value={WebShellThemeId.Dark}>
+          <div ref={composerRef} data-web-shell-composer-surface>
+            <SpecularComposerEffect targetRef={composerRef} />
+            <div data-web-shell-composer-editor />
+          </div>
+        </ThemeProvider>
+      );
+    }
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ container, root });
+    act(() => root.render(<Harness />));
+
+    let now = performance.now();
+    const drainFrames = (count: number, stepMs: number) => {
+      for (let i = 0; i < count; i++) {
+        const callback = rafCallbacks.shift();
+        if (!callback) break;
+        now += stepMs;
+        callback(now);
+      }
+    };
+
+    // Move the pointer close so proximity rises and the loop is drawing.
+    act(() => {
+      window.dispatchEvent(
+        new MouseEvent('pointermove', { clientX: 100, clientY: 100 }),
+      );
+    });
+    drainFrames(10, 16);
+    expect(drawArrays.mock.calls.length).toBeGreaterThan(0);
+
+    // Pointer leaves the document — proximity resets to zero.
+    act(() => {
+      document.documentElement.dispatchEvent(new MouseEvent('pointerleave'));
+    });
+
+    // Brightness decays and the idle bail-out stops the loop.
+    drainFrames(120, 16);
+    expect(rafCallbacks.length).toBe(0);
+  });
+});
+
+describe('specular effect WebGL cleanup', () => {
+  it('releases WebGL resources on unmount', () => {
+    const loseContext = vi.fn();
+    const glStub = {
+      ARRAY_BUFFER: 0x8892,
+      BLEND: 0x0be2,
+      COLOR_BUFFER_BIT: 0x4000,
+      COMPILE_STATUS: 0x8b81,
+      FLOAT: 0x1406,
+      FRAGMENT_SHADER: 0x8b30,
+      LINK_STATUS: 0x8b82,
+      ONE: 1,
+      ONE_MINUS_SRC_ALPHA: 0x0303,
+      STATIC_DRAW: 0x88e4,
+      TRIANGLES: 0x0004,
+      VERTEX_SHADER: 0x8b31,
+      attachShader: vi.fn(),
+      bindBuffer: vi.fn(),
+      blendFunc: vi.fn(),
+      bufferData: vi.fn(),
+      clear: vi.fn(),
+      compileShader: vi.fn(),
+      createBuffer: vi.fn(() => ({})),
+      createProgram: vi.fn(() => ({})),
+      createShader: vi.fn(() => ({})),
+      deleteBuffer: vi.fn(),
+      deleteProgram: vi.fn(),
+      deleteShader: vi.fn(),
+      drawArrays: vi.fn(),
+      enable: vi.fn(),
+      enableVertexAttribArray: vi.fn(),
+      getAttribLocation: vi.fn(() => 0),
+      getExtension: vi.fn(() => ({ loseContext })),
+      getProgramParameter: vi.fn(() => true),
+      getShaderParameter: vi.fn(() => true),
+      getUniformLocation: vi.fn(() => ({})),
+      linkProgram: vi.fn(),
+      shaderSource: vi.fn(),
+      uniform1f: vi.fn(),
+      uniform2f: vi.fn(),
+      uniform3f: vi.fn(),
+      useProgram: vi.fn(),
+      vertexAttribPointer: vi.fn(),
+      viewport: vi.fn(),
+    };
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      glStub as unknown as WebGL2RenderingContext,
+    );
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1);
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+
+    function Harness() {
+      const composerRef = useRef<HTMLDivElement>(null);
+      return (
+        <ThemeProvider value={WebShellThemeId.Dark}>
+          <div ref={composerRef} data-web-shell-composer-surface>
+            <SpecularComposerEffect targetRef={composerRef} />
+            <div data-web-shell-composer-editor />
+          </div>
+        </ThemeProvider>
+      );
+    }
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() => root.render(<Harness />));
+
+    expect(
+      container.querySelector('[data-web-shell-composer-specular] canvas'),
+    ).not.toBeNull();
+
+    act(() => root.unmount());
+    container.remove();
+
+    expect(glStub.deleteBuffer).toHaveBeenCalled();
+    expect(glStub.deleteProgram).toHaveBeenCalled();
+    expect(glStub.deleteShader).toHaveBeenCalled();
+    expect(loseContext).toHaveBeenCalled();
+  });
+});
+
 describe('dot field settled skip', () => {
   it('skips canvas draws when all dots are settled and engagement is zero', () => {
     vi.useFakeTimers();

--- a/packages/web-shell/client/components/SpecularComposerEffect.test.tsx
+++ b/packages/web-shell/client/components/SpecularComposerEffect.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+
+import { act, useRef } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ThemeProvider, WebShellThemeId } from '../themeContext';
+import { NewSessionDotField } from './NewSessionDotField';
+import { SpecularComposerEffect } from './SpecularComposerEffect';
+
+const mounted: Array<{
+  container: HTMLDivElement;
+  root: ReturnType<typeof createRoot>;
+}> = [];
+
+afterEach(() => {
+  for (const { container, root } of mounted.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('composer visual effects fallback', () => {
+  it('keeps both animation layers inert when canvas contexts are unavailable', () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
+
+    function Harness() {
+      const composerRef = useRef<HTMLDivElement>(null);
+      return (
+        <ThemeProvider value={WebShellThemeId.Light}>
+          <div ref={composerRef} data-web-shell-composer-surface>
+            <SpecularComposerEffect targetRef={composerRef} />
+            <div data-web-shell-composer-editor />
+          </div>
+          <NewSessionDotField />
+        </ThemeProvider>
+      );
+    }
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ container, root });
+    act(() => root.render(<Harness />));
+
+    expect(
+      container.querySelector('[data-web-shell-composer-editor]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-web-shell-composer-specular] canvas'),
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-web-shell-new-session-dot-field] canvas'),
+    ).not.toBeNull();
+  });
+
+  it('erases dots for the pointer glow regardless of the background color', () => {
+    vi.useFakeTimers();
+    const addColorStop = vi.fn();
+    const compositeOperations: string[] = [];
+    const contextStub = {
+      arc: vi.fn(),
+      beginPath: vi.fn(),
+      clearRect: vi.fn(),
+      createRadialGradient: vi.fn(() => ({ addColorStop })),
+      fill: vi.fn(),
+      fillRect: vi.fn(),
+      moveTo: vi.fn(),
+      setTransform: vi.fn(),
+    };
+    Object.defineProperty(contextStub, 'globalCompositeOperation', {
+      configurable: true,
+      get: () => compositeOperations.at(-1) ?? 'source-over',
+      set: (value: string) => compositeOperations.push(value),
+    });
+    const context = contextStub as unknown as CanvasRenderingContext2D;
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      context,
+    );
+
+    let drawFrame: FrameRequestCallback | undefined;
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      drawFrame = callback;
+      return 1;
+    });
+
+    const container = document.createElement('div');
+    container.style.setProperty('--background', '#ff00ff');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ container, root });
+    act(() =>
+      root.render(
+        <ThemeProvider value={WebShellThemeId.Light}>
+          <NewSessionDotField />
+        </ThemeProvider>,
+      ),
+    );
+
+    act(() => {
+      window.dispatchEvent(
+        new MouseEvent('pointermove', { clientX: 100, clientY: 100 }),
+      );
+      vi.advanceTimersByTime(20);
+      drawFrame?.(0);
+    });
+
+    expect(addColorStop).toHaveBeenCalledWith(0, 'rgba(0, 0, 0, 1)');
+    expect(addColorStop).toHaveBeenCalledWith(1, 'rgba(0, 0, 0, 0)');
+    expect(compositeOperations).toEqual(['destination-out', 'source-over']);
+  });
+});

--- a/packages/web-shell/client/components/SpecularComposerEffect.test.tsx
+++ b/packages/web-shell/client/components/SpecularComposerEffect.test.tsx
@@ -239,7 +239,7 @@ describe('composer visual effects fallback', () => {
 });
 
 describe('specular effect idle bail-out', () => {
-  it('stops the rAF loop when idle and restarts on pointer proximity', () => {
+  it('stops the rAF loop only after brightness decays below the threshold', () => {
     const drawArrays = vi.fn();
     const clear = vi.fn();
     const glStub = {
@@ -316,7 +316,10 @@ describe('specular effect idle bail-out', () => {
 
     expect(rafCallbacks.length).toBe(1);
 
-    let now = 0;
+    // Start at the real clock so the first delta is positive; the effect
+    // seeds lastFrame from performance.now() and a synthetic clock starting
+    // at zero would produce negative deltas that break the exponential decay.
+    let now = performance.now();
     const drainFrames = (count: number, stepMs: number) => {
       for (let i = 0; i < count; i++) {
         const callback = rafCallbacks.shift();
@@ -326,25 +329,41 @@ describe('specular effect idle bail-out', () => {
       }
     };
 
-    // Run enough idle frames for brightness to decay below 0.002
+    // Move the pointer close so proximity (and therefore brightness) rises,
+    // then drain frames while the highlight is visibly above the threshold.
+    act(() => {
+      window.dispatchEvent(
+        new MouseEvent('pointermove', { clientX: 100, clientY: 100 }),
+      );
+    });
+    drainFrames(30, 16);
+    const drawsWhileBright = drawArrays.mock.calls.length;
+    expect(drawsWhileBright).toBeGreaterThan(0);
+
+    // Move the pointer far away so proximity drops to zero and brightness
+    // decays exponentially until the bail-out threshold is crossed.
+    act(() => {
+      window.dispatchEvent(
+        new MouseEvent('pointermove', { clientX: 300, clientY: 300 }),
+      );
+    });
     drainFrames(120, 16);
-    const drawsAfterDecay = drawArrays.mock.calls.length;
 
-    // The loop should have stopped — no new rAF callback queued
+    // The loop kept drawing through the decay, then stopped — no new rAF
+    // callback queued, and the final frame cleared without drawing.
+    expect(drawArrays.mock.calls.length).toBeGreaterThan(drawsWhileBright);
     expect(rafCallbacks.length).toBe(0);
-    // The last frame cleared but did not draw
-    expect(clear.mock.calls.length).toBeGreaterThan(drawsAfterDecay);
+    expect(clear.mock.calls.length).toBeGreaterThan(
+      drawArrays.mock.calls.length,
+    );
 
-    // A nearby pointer move restarts the loop
+    // A nearby pointer move restarts the loop.
     act(() => {
       window.dispatchEvent(
         new MouseEvent('pointermove', { clientX: 100, clientY: 100 }),
       );
     });
     expect(rafCallbacks.length).toBe(1);
-
-    drainFrames(1, 16);
-    expect(drawArrays.mock.calls.length).toBeGreaterThan(drawsAfterDecay);
   });
 });
 
@@ -454,5 +473,152 @@ describe('dot field pointer speed baseline', () => {
     });
 
     expect(addColorStop).not.toHaveBeenCalled();
+  });
+});
+
+describe('dot field static grid and idle loop', () => {
+  const mockDotsRect = () =>
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+      width: 30,
+      height: 30,
+      top: 0,
+      left: 0,
+      right: 30,
+      bottom: 30,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+  const makeContextStub = () => ({
+    arc: vi.fn(),
+    beginPath: vi.fn(),
+    clearRect: vi.fn(),
+    createRadialGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+    fill: vi.fn(),
+    fillRect: vi.fn(),
+    moveTo: vi.fn(),
+    setTransform: vi.fn(),
+  });
+
+  it('renders the static dot grid once under prefers-reduced-motion', () => {
+    vi.spyOn(window, 'matchMedia').mockImplementation(
+      (query: string) =>
+        ({
+          matches: query === '(prefers-reduced-motion: reduce)',
+          media: query,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+        }) as MediaQueryList,
+    );
+    mockDotsRect();
+    const contextStub = makeContextStub();
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      contextStub as unknown as CanvasRenderingContext2D,
+    );
+    const rafSpy = vi.spyOn(window, 'requestAnimationFrame');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ container, root });
+    rafSpy.mockClear();
+    act(() =>
+      root.render(
+        <ThemeProvider value={WebShellThemeId.Dark}>
+          <NewSessionDotField />
+        </ThemeProvider>,
+      ),
+    );
+
+    // A 30px box at a 15px step yields a 2×2 grid that must be painted even
+    // though every dot is already settled on its anchor.
+    expect(contextStub.arc.mock.calls.length).toBeGreaterThan(0);
+    expect(contextStub.fill).toHaveBeenCalled();
+    expect(rafSpy).not.toHaveBeenCalled();
+  });
+
+  it('paints the grid on the first frame before any pointer movement', () => {
+    vi.useFakeTimers();
+    mockDotsRect();
+    const contextStub = makeContextStub();
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      contextStub as unknown as CanvasRenderingContext2D,
+    );
+
+    let drawFrame: FrameRequestCallback | undefined;
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      drawFrame = callback;
+      return 1;
+    });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ container, root });
+    act(() =>
+      root.render(
+        <ThemeProvider value={WebShellThemeId.Dark}>
+          <NewSessionDotField />
+        </ThemeProvider>,
+      ),
+    );
+
+    act(() => {
+      drawFrame?.(0);
+    });
+
+    expect(contextStub.arc.mock.calls.length).toBeGreaterThan(0);
+    expect(contextStub.fill).toHaveBeenCalled();
+  });
+
+  it('stops the rAF loop when idle and restarts on pointer movement', () => {
+    vi.useFakeTimers();
+    mockDotsRect();
+    const contextStub = makeContextStub();
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      contextStub as unknown as CanvasRenderingContext2D,
+    );
+
+    const rafCallbacks: FrameRequestCallback[] = [];
+    let rafId = 0;
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      rafCallbacks.push(callback);
+      return ++rafId;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ container, root });
+    act(() =>
+      root.render(
+        <ThemeProvider value={WebShellThemeId.Dark}>
+          <NewSessionDotField />
+        </ThemeProvider>,
+      ),
+    );
+
+    expect(rafCallbacks.length).toBe(1);
+
+    // First frame paints the grid and re-arms the loop.
+    act(() => {
+      rafCallbacks.shift()?.(0);
+    });
+    // The next idle frame settles and stops the loop without re-arming it.
+    act(() => {
+      vi.advanceTimersByTime(20);
+      rafCallbacks.shift()?.(16);
+    });
+    expect(rafCallbacks.length).toBe(0);
+
+    // Pointer movement wakes the loop again.
+    act(() => {
+      window.dispatchEvent(
+        new MouseEvent('pointermove', { clientX: 100, clientY: 100 }),
+      );
+    });
+    expect(rafCallbacks.length).toBe(1);
   });
 });

--- a/packages/web-shell/client/components/SpecularComposerEffect.test.tsx
+++ b/packages/web-shell/client/components/SpecularComposerEffect.test.tsx
@@ -110,4 +110,61 @@ describe('composer visual effects fallback', () => {
     expect(addColorStop).toHaveBeenCalledWith(1, 'rgba(0, 0, 0, 0)');
     expect(compositeOperations).toEqual(['destination-out', 'source-over']);
   });
+
+  it('keeps both animation layers inert under prefers-reduced-motion', () => {
+    vi.spyOn(window, 'matchMedia').mockImplementation(
+      (query: string) =>
+        ({
+          matches: query === '(prefers-reduced-motion: reduce)',
+          media: query,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+        }) as MediaQueryList,
+    );
+    const contextStub = {
+      arc: vi.fn(),
+      beginPath: vi.fn(),
+      clearRect: vi.fn(),
+      createRadialGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+      fill: vi.fn(),
+      fillRect: vi.fn(),
+      moveTo: vi.fn(),
+      setTransform: vi.fn(),
+    };
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      contextStub as unknown as CanvasRenderingContext2D,
+    );
+    const requestAnimationFrameSpy = vi.spyOn(window, 'requestAnimationFrame');
+    const setIntervalSpy = vi.spyOn(window, 'setInterval');
+
+    function Harness() {
+      const composerRef = useRef<HTMLDivElement>(null);
+      return (
+        <ThemeProvider value={WebShellThemeId.Light}>
+          <div ref={composerRef} data-web-shell-composer-surface>
+            <SpecularComposerEffect targetRef={composerRef} />
+            <div data-web-shell-composer-editor />
+          </div>
+          <NewSessionDotField />
+        </ThemeProvider>
+      );
+    }
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ container, root });
+    requestAnimationFrameSpy.mockClear();
+    setIntervalSpy.mockClear();
+    act(() => root.render(<Harness />));
+
+    expect(
+      container.querySelector('[data-web-shell-composer-specular] canvas'),
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-web-shell-new-session-dot-field] canvas'),
+    ).not.toBeNull();
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+    expect(requestAnimationFrameSpy).not.toHaveBeenCalled();
+  });
 });

--- a/packages/web-shell/client/components/SpecularComposerEffect.test.tsx
+++ b/packages/web-shell/client/components/SpecularComposerEffect.test.tsx
@@ -168,3 +168,172 @@ describe('composer visual effects fallback', () => {
     expect(requestAnimationFrameSpy).not.toHaveBeenCalled();
   });
 });
+
+describe('specular effect idle bail-out', () => {
+  it('stops the rAF loop when idle and restarts on pointer proximity', () => {
+    const drawArrays = vi.fn();
+    const clear = vi.fn();
+    const glStub = {
+      ARRAY_BUFFER: 0x8892,
+      BLEND: 0x0be2,
+      COLOR_BUFFER_BIT: 0x4000,
+      COMPILE_STATUS: 0x8b81,
+      FLOAT: 0x1406,
+      FRAGMENT_SHADER: 0x8b30,
+      LINK_STATUS: 0x8b82,
+      ONE: 1,
+      ONE_MINUS_SRC_ALPHA: 0x0303,
+      STATIC_DRAW: 0x88e4,
+      TRIANGLES: 0x0004,
+      VERTEX_SHADER: 0x8b31,
+      attachShader: vi.fn(),
+      bindBuffer: vi.fn(),
+      blendFunc: vi.fn(),
+      bufferData: vi.fn(),
+      clear,
+      compileShader: vi.fn(),
+      createBuffer: vi.fn(() => ({})),
+      createProgram: vi.fn(() => ({})),
+      createShader: vi.fn(() => ({})),
+      deleteBuffer: vi.fn(),
+      deleteProgram: vi.fn(),
+      deleteShader: vi.fn(),
+      drawArrays,
+      enable: vi.fn(),
+      enableVertexAttribArray: vi.fn(),
+      getAttribLocation: vi.fn(() => 0),
+      getExtension: vi.fn(() => ({ loseContext: vi.fn() })),
+      getProgramParameter: vi.fn(() => true),
+      getShaderParameter: vi.fn(() => true),
+      getUniformLocation: vi.fn(() => ({})),
+      linkProgram: vi.fn(),
+      shaderSource: vi.fn(),
+      uniform1f: vi.fn(),
+      uniform2f: vi.fn(),
+      uniform3f: vi.fn(),
+      useProgram: vi.fn(),
+      vertexAttribPointer: vi.fn(),
+      viewport: vi.fn(),
+    };
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      glStub as unknown as WebGL2RenderingContext,
+    );
+
+    const rafCallbacks: FrameRequestCallback[] = [];
+    let rafId = 0;
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      rafCallbacks.push(callback);
+      return ++rafId;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+
+    function Harness() {
+      const composerRef = useRef<HTMLDivElement>(null);
+      return (
+        <ThemeProvider value={WebShellThemeId.Dark}>
+          <div ref={composerRef} data-web-shell-composer-surface>
+            <SpecularComposerEffect targetRef={composerRef} />
+            <div data-web-shell-composer-editor />
+          </div>
+        </ThemeProvider>
+      );
+    }
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ container, root });
+    act(() => root.render(<Harness />));
+
+    expect(rafCallbacks.length).toBe(1);
+
+    let now = 0;
+    const drainFrames = (count: number, stepMs: number) => {
+      for (let i = 0; i < count; i++) {
+        const callback = rafCallbacks.shift();
+        if (!callback) break;
+        now += stepMs;
+        callback(now);
+      }
+    };
+
+    // Run enough idle frames for brightness to decay below 0.002
+    drainFrames(120, 16);
+    const drawsAfterDecay = drawArrays.mock.calls.length;
+
+    // The loop should have stopped — no new rAF callback queued
+    expect(rafCallbacks.length).toBe(0);
+    // The last frame cleared but did not draw
+    expect(clear.mock.calls.length).toBeGreaterThan(drawsAfterDecay);
+
+    // A nearby pointer move restarts the loop
+    act(() => {
+      window.dispatchEvent(
+        new MouseEvent('pointermove', { clientX: 100, clientY: 100 }),
+      );
+    });
+    expect(rafCallbacks.length).toBe(1);
+
+    drainFrames(1, 16);
+    expect(drawArrays.mock.calls.length).toBeGreaterThan(drawsAfterDecay);
+  });
+});
+
+describe('dot field settled skip', () => {
+  it('skips canvas draws when all dots are settled and engagement is zero', () => {
+    vi.useFakeTimers();
+    const contextStub = {
+      arc: vi.fn(),
+      beginPath: vi.fn(),
+      clearRect: vi.fn(),
+      createRadialGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+      fill: vi.fn(),
+      fillRect: vi.fn(),
+      moveTo: vi.fn(),
+      setTransform: vi.fn(),
+    };
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      contextStub as unknown as CanvasRenderingContext2D,
+    );
+
+    let drawFrame: FrameRequestCallback | undefined;
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      drawFrame = callback;
+      return 1;
+    });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ container, root });
+    act(() =>
+      root.render(
+        <ThemeProvider value={WebShellThemeId.Dark}>
+          <NewSessionDotField />
+        </ThemeProvider>,
+      ),
+    );
+
+    // Run many idle frames so dots settle and engagement stays 0
+    for (let i = 0; i < 200; i++) {
+      act(() => {
+        vi.advanceTimersByTime(20);
+        drawFrame?.(i * 16);
+      });
+    }
+
+    const arcCallsAfterSettle = contextStub.arc.mock.calls.length;
+    const fillCallsAfterSettle = contextStub.fill.mock.calls.length;
+
+    // Run more frames — draws should be skipped
+    for (let i = 200; i < 220; i++) {
+      act(() => {
+        vi.advanceTimersByTime(20);
+        drawFrame?.(i * 16);
+      });
+    }
+
+    expect(contextStub.arc.mock.calls.length).toBe(arcCallsAfterSettle);
+    expect(contextStub.fill.mock.calls.length).toBe(fillCallsAfterSettle);
+  });
+});

--- a/packages/web-shell/client/components/SpecularComposerEffect.tsx
+++ b/packages/web-shell/client/components/SpecularComposerEffect.tsx
@@ -262,7 +262,9 @@ export function SpecularComposerEffect({
           ? angle
           : pointerAngle;
       const difference =
-        ((targetAngle - angle + Math.PI * 3) % (Math.PI * 2)) - Math.PI;
+        ((((targetAngle - angle + Math.PI) % (Math.PI * 2)) + Math.PI * 2) %
+          (Math.PI * 2)) -
+        Math.PI;
       angle += difference * (1 - Math.exp(-delta * 7));
       const targetBrightness = focused ? 1.4 : proximity;
       brightness +=

--- a/packages/web-shell/client/components/SpecularComposerEffect.tsx
+++ b/packages/web-shell/client/components/SpecularComposerEffect.tsx
@@ -1,0 +1,317 @@
+import { useEffect, useRef } from 'react';
+import type { RefObject } from 'react';
+import { useTheme, WebShellThemeId } from '../themeContext';
+import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion';
+import styles from './ChatEditor.module.css';
+
+const VERTEX_SHADER = `#version 300 es
+  in vec2 position;
+  void main() {
+    gl_Position = vec4(position, 0.0, 1.0);
+  }
+`;
+
+const FRAGMENT_SHADER = `#version 300 es
+  precision highp float;
+  uniform vec2 center;
+  uniform vec2 halfSize;
+  uniform vec3 lineColor;
+  uniform float radius;
+  uniform float angle;
+  uniform float intensity;
+  uniform float px;
+  uniform float shineSize;
+  uniform float shineFade;
+  uniform float thickness;
+  out vec4 fragColor;
+
+  float roundedRect(vec2 point) {
+    vec2 edge = abs(point) - halfSize + radius;
+    return length(max(edge, 0.0)) + min(max(edge.x, edge.y), 0.0) - radius;
+  }
+
+  float gaussianLine(float distanceToEdge, float sigma) {
+    float normalized = distanceToEdge / (sigma + 0.000001);
+    float falloff = mix(1.0, 1.6, smoothstep(0.0, 1.5, normalized));
+    return exp(-falloff * normalized * normalized);
+  }
+
+  void main() {
+    vec2 point = gl_FragCoord.xy - center;
+    float distanceToEdge = roundedRect(point);
+    vec2 light = vec2(cos(angle), sin(angle));
+    vec2 normal = normalize(point / (halfSize * halfSize) + 0.000001);
+    float phi = acos(clamp(abs(dot(normal, light)), 0.0, 1.0));
+    float rim = 1.0 - smoothstep(
+      shineSize - shineFade,
+      shineSize + shineFade + 0.0001,
+      phi
+    );
+    float line = gaussianLine(distanceToEdge, thickness);
+    float edgeClamp = 1.0 - smoothstep(
+      0.5 * px,
+      3.0 * px,
+      abs(distanceToEdge)
+    );
+    float shine = line * rim * edgeClamp * intensity;
+    fragColor = vec4(lineColor * shine, shine);
+  }
+`;
+
+interface SpecularComposerEffectProps {
+  targetRef: RefObject<HTMLDivElement | null>;
+}
+
+function compileShader(
+  gl: WebGL2RenderingContext,
+  type: number,
+  source: string,
+): WebGLShader | null {
+  const shader = gl.createShader(type);
+  if (!shader) return null;
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+  if (gl.getShaderParameter(shader, gl.COMPILE_STATUS)) return shader;
+  gl.deleteShader(shader);
+  return null;
+}
+
+export function SpecularComposerEffect({
+  targetRef,
+}: SpecularComposerEffectProps) {
+  const hostRef = useRef<HTMLSpanElement>(null);
+  const theme = useTheme();
+  const reducedMotion = usePrefersReducedMotion();
+
+  useEffect(() => {
+    const target = targetRef.current;
+    const host = hostRef.current;
+    if (!target || !host || reducedMotion) {
+      return undefined;
+    }
+
+    const canvas = document.createElement('canvas');
+    const gl = canvas.getContext('webgl2', {
+      alpha: true,
+      antialias: true,
+      premultipliedAlpha: true,
+    });
+    if (!gl) return undefined;
+
+    const vertexShader = compileShader(gl, gl.VERTEX_SHADER, VERTEX_SHADER);
+    const fragmentShader = compileShader(
+      gl,
+      gl.FRAGMENT_SHADER,
+      FRAGMENT_SHADER,
+    );
+    const program = gl.createProgram();
+    if (!vertexShader || !fragmentShader || !program) {
+      if (vertexShader) gl.deleteShader(vertexShader);
+      if (fragmentShader) gl.deleteShader(fragmentShader);
+      if (program) gl.deleteProgram(program);
+      gl.getExtension('WEBGL_lose_context')?.loseContext();
+      return undefined;
+    }
+
+    gl.attachShader(program, vertexShader);
+    gl.attachShader(program, fragmentShader);
+    gl.linkProgram(program);
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+      gl.deleteProgram(program);
+      gl.deleteShader(vertexShader);
+      gl.deleteShader(fragmentShader);
+      gl.getExtension('WEBGL_lose_context')?.loseContext();
+      return undefined;
+    }
+
+    const buffer = gl.createBuffer();
+    if (!buffer) {
+      gl.deleteProgram(program);
+      gl.deleteShader(vertexShader);
+      gl.deleteShader(fragmentShader);
+      gl.getExtension('WEBGL_lose_context')?.loseContext();
+      return undefined;
+    }
+
+    host.appendChild(canvas);
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+    gl.bufferData(
+      gl.ARRAY_BUFFER,
+      new Float32Array([-1, -1, 3, -1, -1, 3]),
+      gl.STATIC_DRAW,
+    );
+    const position = gl.getAttribLocation(program, 'position');
+    gl.enableVertexAttribArray(position);
+    gl.vertexAttribPointer(position, 2, gl.FLOAT, false, 0, 0);
+    gl.useProgram(program);
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+
+    const center = gl.getUniformLocation(program, 'center');
+    const halfSize = gl.getUniformLocation(program, 'halfSize');
+    const lineColor = gl.getUniformLocation(program, 'lineColor');
+    const radius = gl.getUniformLocation(program, 'radius');
+    const angleUniform = gl.getUniformLocation(program, 'angle');
+    const intensity = gl.getUniformLocation(program, 'intensity');
+    const px = gl.getUniformLocation(program, 'px');
+    const shineSize = gl.getUniformLocation(program, 'shineSize');
+    const shineFade = gl.getUniformLocation(program, 'shineFade');
+    const thickness = gl.getUniformLocation(program, 'thickness');
+
+    const dpr = window.devicePixelRatio || 1;
+    let width = 1;
+    let height = 1;
+    let cornerRadius = 12;
+    let pointerAngle: number | null = null;
+    let angle = 2.4;
+    let idleAngle = 2.4;
+    let proximity = 0;
+    let brightness = 0;
+    let focused = false;
+    let lastFrame = performance.now();
+    let frameId = 0;
+
+    const resize = () => {
+      const rect = target.getBoundingClientRect();
+      width = rect.width;
+      height = rect.height;
+      cornerRadius =
+        Number.parseFloat(getComputedStyle(target).borderRadius) || 12;
+      canvas.width = Math.ceil((width + 40) * dpr);
+      canvas.height = Math.ceil((height + 40) * dpr);
+      gl.viewport(0, 0, canvas.width, canvas.height);
+    };
+
+    const isEditorTarget = (eventTarget: EventTarget | null) => {
+      const editor = target.querySelector('[data-web-shell-composer-editor]');
+      return (
+        eventTarget instanceof Node && Boolean(editor?.contains(eventTarget))
+      );
+    };
+
+    const onPointerMove = (event: PointerEvent) => {
+      const rect = target.getBoundingClientRect();
+      const centerX = rect.left + rect.width / 2;
+      const centerY = rect.top + rect.height / 2;
+      const dx = Math.max(
+        rect.left - event.clientX,
+        0,
+        event.clientX - rect.right,
+      );
+      const dy = Math.max(
+        rect.top - event.clientY,
+        0,
+        event.clientY - rect.bottom,
+      );
+      const distance = Math.hypot(dx, dy);
+      if (distance === 0) {
+        const normalizedX =
+          (event.clientX - centerX) / Math.max(rect.width / 2, 1);
+        const normalizedY =
+          (centerY - event.clientY) / Math.max(rect.height / 2, 1);
+        pointerAngle =
+          Math.atan2(2 / rect.height, -2 / rect.width) +
+          normalizedX * 0.3 +
+          normalizedY * 0.15;
+      } else {
+        pointerAngle = Math.atan2(
+          centerY - event.clientY,
+          event.clientX - centerX,
+        );
+      }
+      const amount = Math.max(0, 1 - distance / 250);
+      proximity = amount * amount * (3 - 2 * amount);
+    };
+
+    const onFocusIn = (event: FocusEvent) => {
+      if (!isEditorTarget(event.target)) return;
+      pointerAngle = angle;
+      idleAngle = angle;
+      focused = true;
+    };
+    const onFocusOut = (event: FocusEvent) => {
+      if (
+        isEditorTarget(event.target) &&
+        !isEditorTarget(event.relatedTarget)
+      ) {
+        pointerAngle = angle;
+        focused = false;
+      }
+    };
+
+    const draw = (now: number) => {
+      const delta = Math.min((now - lastFrame) / 1000, 0.05);
+      lastFrame = now;
+      if (focused) idleAngle += 0.85 * delta;
+      else idleAngle = angle;
+      const targetAngle = focused
+        ? idleAngle
+        : pointerAngle === null
+          ? angle
+          : pointerAngle;
+      const difference =
+        ((targetAngle - angle + Math.PI * 3) % (Math.PI * 2)) - Math.PI;
+      angle += difference * (1 - Math.exp(-delta * 7));
+      const targetBrightness = focused ? 1.4 : proximity;
+      brightness +=
+        (targetBrightness - brightness) * (1 - Math.exp(-delta * 8));
+
+      gl.uniform2f(center, (20 + width / 2) * dpr, (20 + height / 2) * dpr);
+      gl.uniform2f(halfSize, (width / 2) * dpr, (height / 2) * dpr);
+      gl.uniform3f(
+        lineColor,
+        theme === WebShellThemeId.Light ? 0.2 : 0.403922,
+        theme === WebShellThemeId.Light ? 0.360784 : 0.521569,
+        1,
+      );
+      gl.uniform1f(radius, Math.min(cornerRadius, height / 2) * dpr);
+      gl.uniform1f(angleUniform, angle);
+      gl.uniform1f(intensity, brightness);
+      gl.uniform1f(px, dpr);
+      gl.uniform1f(shineSize, (32 * Math.PI) / 180);
+      gl.uniform1f(shineFade, (68 * Math.PI) / 180);
+      gl.uniform1f(thickness, 0.5 * dpr);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+      gl.drawArrays(gl.TRIANGLES, 0, 3);
+      frameId = window.requestAnimationFrame(draw);
+    };
+
+    const resizeObserver = new ResizeObserver(resize);
+    resizeObserver.observe(target);
+    resize();
+    window.addEventListener('pointermove', onPointerMove, { passive: true });
+    target.addEventListener('focusin', onFocusIn);
+    target.addEventListener('focusout', onFocusOut);
+    const activeElement = document.activeElement;
+    focused =
+      activeElement !== null &&
+      target
+        .querySelector('[data-web-shell-composer-editor]')
+        ?.contains(activeElement) === true;
+    frameId = window.requestAnimationFrame(draw);
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      resizeObserver.disconnect();
+      window.removeEventListener('pointermove', onPointerMove);
+      target.removeEventListener('focusin', onFocusIn);
+      target.removeEventListener('focusout', onFocusOut);
+      canvas.remove();
+      gl.deleteBuffer(buffer);
+      gl.deleteProgram(program);
+      gl.deleteShader(vertexShader);
+      gl.deleteShader(fragmentShader);
+      gl.getExtension('WEBGL_lose_context')?.loseContext();
+    };
+  }, [reducedMotion, targetRef, theme]);
+
+  return (
+    <span
+      ref={hostRef}
+      className={styles.specularEffect}
+      data-web-shell-composer-specular
+      data-theme={theme}
+      aria-hidden="true"
+    />
+  );
+}

--- a/packages/web-shell/client/components/SpecularComposerEffect.tsx
+++ b/packages/web-shell/client/components/SpecularComposerEffect.tsx
@@ -158,7 +158,7 @@ export function SpecularComposerEffect({
     const shineFade = gl.getUniformLocation(program, 'shineFade');
     const thickness = gl.getUniformLocation(program, 'thickness');
 
-    const dpr = window.devicePixelRatio || 1;
+    let dpr = window.devicePixelRatio || 1;
     let width = 1;
     let height = 1;
     let cornerRadius = 12;
@@ -172,6 +172,7 @@ export function SpecularComposerEffect({
     let frameId = 0;
 
     const resize = () => {
+      dpr = window.devicePixelRatio || 1;
       const rect = target.getBoundingClientRect();
       width = rect.width;
       height = rect.height;

--- a/packages/web-shell/client/components/SpecularComposerEffect.tsx
+++ b/packages/web-shell/client/components/SpecularComposerEffect.tsx
@@ -40,7 +40,7 @@ const FRAGMENT_SHADER = `#version 300 es
     vec2 point = gl_FragCoord.xy - center;
     float distanceToEdge = roundedRect(point);
     vec2 light = vec2(cos(angle), sin(angle));
-    vec2 normal = normalize(point / (halfSize * halfSize) + 0.000001);
+    vec2 normal = normalize(point / halfSize + 0.000001);
     float phi = acos(clamp(abs(dot(normal, light)), 0.0, 1.0));
     float rim = 1.0 - smoothstep(
       shineSize - shineFade,
@@ -170,6 +170,7 @@ export function SpecularComposerEffect({
     let focused = false;
     let lastFrame = performance.now();
     let frameId = 0;
+    let running = false;
 
     const resize = () => {
       dpr = window.devicePixelRatio || 1;
@@ -188,6 +189,14 @@ export function SpecularComposerEffect({
       return (
         eventTarget instanceof Node && Boolean(editor?.contains(eventTarget))
       );
+    };
+
+    const startLoop = () => {
+      if (!running) {
+        running = true;
+        lastFrame = performance.now();
+        frameId = window.requestAnimationFrame(draw);
+      }
     };
 
     const onPointerMove = (event: PointerEvent) => {
@@ -222,6 +231,7 @@ export function SpecularComposerEffect({
       }
       const amount = Math.max(0, 1 - distance / 250);
       proximity = amount * amount * (3 - 2 * amount);
+      startLoop();
     };
 
     const onFocusIn = (event: FocusEvent) => {
@@ -229,6 +239,7 @@ export function SpecularComposerEffect({
       pointerAngle = angle;
       idleAngle = angle;
       focused = true;
+      startLoop();
     };
     const onFocusOut = (event: FocusEvent) => {
       if (
@@ -243,7 +254,7 @@ export function SpecularComposerEffect({
     const draw = (now: number) => {
       const delta = Math.min((now - lastFrame) / 1000, 0.05);
       lastFrame = now;
-      if (focused) idleAngle += 0.85 * delta;
+      if (focused) idleAngle -= 0.85 * delta;
       else idleAngle = angle;
       const targetAngle = focused
         ? idleAngle
@@ -256,6 +267,13 @@ export function SpecularComposerEffect({
       const targetBrightness = focused ? 1.4 : proximity;
       brightness +=
         (targetBrightness - brightness) * (1 - Math.exp(-delta * 8));
+
+      if (brightness < 0.002 && !focused && proximity === 0) {
+        running = false;
+        frameId = 0;
+        gl.clear(gl.COLOR_BUFFER_BIT);
+        return;
+      }
 
       gl.uniform2f(center, (20 + width / 2) * dpr, (20 + height / 2) * dpr);
       gl.uniform2f(halfSize, (width / 2) * dpr, (height / 2) * dpr);
@@ -289,9 +307,10 @@ export function SpecularComposerEffect({
       target
         .querySelector('[data-web-shell-composer-editor]')
         ?.contains(activeElement) === true;
-    frameId = window.requestAnimationFrame(draw);
+    startLoop();
 
     return () => {
+      running = false;
       window.cancelAnimationFrame(frameId);
       resizeObserver.disconnect();
       window.removeEventListener('pointermove', onPointerMove);

--- a/packages/web-shell/client/components/SpecularComposerEffect.tsx
+++ b/packages/web-shell/client/components/SpecularComposerEffect.tsx
@@ -234,6 +234,11 @@ export function SpecularComposerEffect({
       startLoop();
     };
 
+    const onPointerLeave = () => {
+      proximity = 0;
+      pointerAngle = null;
+    };
+
     const onFocusIn = (event: FocusEvent) => {
       if (!isEditorTarget(event.target)) return;
       pointerAngle = angle;
@@ -301,6 +306,7 @@ export function SpecularComposerEffect({
     resizeObserver.observe(target);
     resize();
     window.addEventListener('pointermove', onPointerMove, { passive: true });
+    document.documentElement.addEventListener('pointerleave', onPointerLeave);
     target.addEventListener('focusin', onFocusIn);
     target.addEventListener('focusout', onFocusOut);
     const activeElement = document.activeElement;
@@ -316,6 +322,10 @@ export function SpecularComposerEffect({
       window.cancelAnimationFrame(frameId);
       resizeObserver.disconnect();
       window.removeEventListener('pointermove', onPointerMove);
+      document.documentElement.removeEventListener(
+        'pointerleave',
+        onPointerLeave,
+      );
       target.removeEventListener('focusin', onFocusIn);
       target.removeEventListener('focusout', onFocusOut);
       canvas.remove();

--- a/packages/web-shell/client/components/SpecularComposerEffect.tsx
+++ b/packages/web-shell/client/components/SpecularComposerEffect.tsx
@@ -270,7 +270,7 @@ export function SpecularComposerEffect({
       brightness +=
         (targetBrightness - brightness) * (1 - Math.exp(-delta * 8));
 
-      if (brightness < 0.002 && !focused && proximity === 0) {
+      if (brightness < 0.002 && !focused && proximity < 0.002) {
         running = false;
         frameId = 0;
         gl.clear(gl.COLOR_BUFFER_BIT);

--- a/packages/web-shell/client/hooks/usePrefersReducedMotion.test.tsx
+++ b/packages/web-shell/client/hooks/usePrefersReducedMotion.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { usePrefersReducedMotion } from './usePrefersReducedMotion';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('usePrefersReducedMotion', () => {
+  it('updates when the system preference changes', () => {
+    let matches = false;
+    const listeners = new Set<() => void>();
+    vi.spyOn(window, 'matchMedia').mockImplementation(
+      () =>
+        ({
+          get matches() {
+            return matches;
+          },
+          addEventListener: (_type, listener) => {
+            listeners.add(listener as () => void);
+          },
+          removeEventListener: (_type, listener) => {
+            listeners.delete(listener as () => void);
+          },
+        }) as MediaQueryList,
+    );
+
+    function Harness() {
+      const reducedMotion = usePrefersReducedMotion();
+      return <div data-reduced-motion={reducedMotion} />;
+    }
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    act(() => root.render(<Harness />));
+    expect(
+      container
+        .querySelector('[data-reduced-motion]')
+        ?.getAttribute('data-reduced-motion'),
+    ).toBe('false');
+
+    act(() => {
+      matches = true;
+      for (const listener of listeners) listener();
+    });
+    expect(
+      container
+        .querySelector('[data-reduced-motion]')
+        ?.getAttribute('data-reduced-motion'),
+    ).toBe('true');
+
+    act(() => root.unmount());
+    expect(listeners).toHaveLength(0);
+  });
+});

--- a/packages/web-shell/client/hooks/usePrefersReducedMotion.ts
+++ b/packages/web-shell/client/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+
+function getPreference() {
+  return (
+    typeof window !== 'undefined' &&
+    window.matchMedia(REDUCED_MOTION_QUERY).matches
+  );
+}
+
+export function usePrefersReducedMotion() {
+  const [reducedMotion, setReducedMotion] = useState(getPreference);
+
+  useEffect(() => {
+    const media = window.matchMedia(REDUCED_MOTION_QUERY);
+    const update = () => setReducedMotion(media.matches);
+    update();
+    media.addEventListener('change', update);
+    return () => media.removeEventListener('change', update);
+  }, []);
+
+  return reducedMotion;
+}


### PR DESCRIPTION
## What this PR does

This PR refreshes the Web Shell composer and empty-session animations without removing or changing existing functionality.

- Adds a theme-aware specular highlight around the full composer surface. The highlight follows the pointer while nearby, then continues rotating clockwise at 0.85 radians per second while the editor is focused.
- Adds an animated dot field behind the empty new-session view. Pointer movement gently displaces nearby dots, while a soft spotlight clears the dots to reveal the real page background instead of painting an opaque overlay.
- Adds a two-pass typewriter treatment to the empty composer placeholder. It types at 45 milliseconds per character, pauses for three seconds, repeats once, and then leaves the complete placeholder visible. Direct editor interaction dismisses it, while an empty editor can replay it after losing focus.
- Preserves the existing composer radius, controls, attachments, submission behavior, keyboard handling, mobile input, light/dark themes, and host-page CSS isolation.
- Responds to live `prefers-reduced-motion` changes by stopping animation loops and showing stable fallbacks without requiring a reload.

## Why it's needed

The previous composer glow was subtle and did not match the supplied animation handoff, while the new-session page lacked the requested global background motion. These changes make the empty state and composer feel more responsive and polished while keeping the interaction model unchanged.

## Reviewer Test Plan

### How to verify

1. Open a new empty Web Shell session in both light and dark themes. Confirm that the dot field fills the page behind the welcome content, remains subtle, and reacts smoothly to pointer movement without showing a dark rectangular overlay.
2. Move the pointer toward the composer. Confirm that a localized edge highlight follows the pointer direction and that the existing controls remain clickable.
3. Focus the editor. Confirm that the edge highlight continues clockwise without jumping or reversing, then returns to pointer-following behavior after blur.
4. Reload an empty session without directly interacting with the editor. Confirm that the placeholder types twice with a three-second pause and then remains complete. Confirm that pointer or keyboard interaction dismisses it and that an empty editor can replay it after blur.
5. Start or load a conversation. Confirm that the empty-session dot field is removed and all existing composer behavior remains available.
6. Toggle the operating system's reduced-motion preference while the page is open. Confirm that animated loops stop and resume immediately and that the ordinary composer border remains visible.

### Evidence (Before & After)

Before: the composer used the previous low-visibility glow, the empty-session page had no global dot animation, and the placeholder was static.

After: the empty-session dot field, pointer/focus-driven specular edge, and two-pass typewriter behavior were visually verified locally in light and dark themes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local Web Shell development server and production Vite build.

## Risk & Scope

- Main risk or tradeoff: the specular highlight uses WebGL2 and intentionally falls back to the existing CSS surface when WebGL2 is unavailable.
- Not validated / out of scope: Windows and Linux visual rendering, changes to composer features, page layout, toolbar styling, or send-button styling.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

这个 PR 在不删减或改变现有功能的前提下，更新了 Web Shell 输入框和空会话页面的动画。

- 在完整输入框表面增加适配明暗主题的镜面高光。指针靠近时，高光会跟随指针方向；编辑器获得焦点后，高光会以每秒 0.85 弧度持续顺时针旋转。
- 在新建空会话页面后方增加动态点阵。指针移动会轻微推动附近的点，柔和的聚光区域通过擦除点阵来露出页面真实背景，不会再绘制不透明遮罩或出现黑色矩形。
- 为输入框空状态提示增加两轮打字机动画。每个字符间隔 45 毫秒，完整显示后暂停三秒，再播放一次，最后保持完整文字。用户直接操作编辑器时动画会消失；空编辑器失焦后可以重新播放。
- 保持现有输入框圆角、控件、附件、发送行为、键盘操作、移动端输入、明暗主题以及宿主页面 CSS 隔离不变。
- 支持运行时切换 `prefers-reduced-motion`：无需刷新页面即可停止动画循环并显示稳定的静态降级效果。

## 为什么需要

之前的输入框光效不够明显，也没有还原动画交付稿；新建会话页面同时缺少所需的全局背景动画。本次修改让空状态和输入框反馈更清晰、更有质感，同时不改变原有交互方式。

## Reviewer 测试计划

### 如何验证

1. 分别在明暗主题下打开新的空 Web Shell 会话。确认点阵覆盖欢迎内容后方的页面、视觉保持克制，并能平滑响应指针移动，同时没有深色矩形遮罩。
2. 将指针移向输入框。确认局部边缘高光跟随指针方向，且所有现有控件仍可点击。
3. 聚焦编辑器。确认边缘高光从当前角度继续顺时针运动，不发生跳变或反转；失焦后恢复跟随指针。
4. 在不直接操作编辑器的情况下重新加载空会话。确认提示文字播放两轮打字机动画，中间暂停三秒，之后保持完整显示。确认指针或键盘操作会使其消失，并且空编辑器失焦后可以重新播放。
5. 开始或加载一段会话。确认空页面点阵被移除，所有现有输入框功能仍然可用。
6. 在页面打开期间切换操作系统的减少动态效果设置。确认动画循环立即停止或恢复，且普通输入框边框仍然可见。

### 证据（修改前后）

修改前：输入框使用之前不够明显的光效，空会话页面没有全局点阵动画，提示文字为静态显示。

修改后：已在本地明暗主题下目视验证空页面点阵、由指针和焦点驱动的镜面边缘高光，以及两轮打字机动画。

### 测试平台

|     系统     | 状态 |
| :----------: | :--: |
|  🍏 macOS    | ✅ 已测试 |
| 🪟 Windows   | ⚠️ 未测试 |
|  🐧 Linux    | ⚠️ 未测试 |

### 环境（可选）

本地 Web Shell 开发服务器及 Vite 生产构建。

## 风险与范围

- 主要风险或取舍：镜面高光使用 WebGL2；当 WebGL2 不可用时，会按设计回退到现有 CSS 输入框表面。
- 未验证或不在范围内：Windows 和 Linux 的视觉渲染；输入框功能、页面布局、工具栏样式或发送按钮样式变更。
- 破坏性变更或迁移说明：无。

## 关联 Issue

无。

</details>
