### PR TITLE
fix(web-shell): preserve approved tool results

### DIFF
--- a/packages/web-shell/client/adapters/transcriptToMessages.test.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.test.ts
@@ -2049,6 +2049,93 @@ describe('transcriptBlocksToDaemonMessages', () => {
     });
   });
 
+  it('treats switch-to-default permission resolutions as approved', () => {
+    const messages = transcriptBlocksToDaemonMessages([
+      {
+        id: 'perm-1',
+        kind: 'permission',
+        requestId: 'req-1',
+        sessionId: 'sess-1',
+        title: 'Present HTML',
+        options: [
+          {
+            optionId: 'proceed_once_and_switch_to_default',
+            label: 'Switch to Default Mode and allow once (recommended)',
+            raw: { kind: 'allow_once' },
+          },
+        ],
+        toolCall: {
+          toolCallId: 'mcp-1',
+          kind: 'other',
+          _meta: { toolName: 'mcp__agentic-pai__present_html' },
+          rawInput: { path: 'interactive.html' },
+        },
+        preview: { kind: 'generic' as const },
+        resolved: 'selected:proceed_once_and_switch_to_default',
+        clientReceivedAt: 1,
+        createdAt: 1,
+        updatedAt: 2,
+      },
+    ]);
+
+    const tool =
+      messages[0].role === 'tool_group' ? messages[0].tools[0] : undefined;
+    expect(tool).toMatchObject({
+      callId: 'mcp-1',
+      status: 'in_progress',
+    });
+  });
+
+  it.each([
+    'selected:proceed_once',
+    'selected:proceed_once_and_switch_to_default',
+  ])(
+    'does not overwrite a completed tool with a later %s permission block',
+    (resolved) => {
+      const messages = transcriptBlocksToDaemonMessages([
+        toolBlock('tool-1', 'mcp-1', 'completed', 1, {
+          toolName: 'mcp__agentic-pai__present_html',
+          rawOutput: '{"approved":true}',
+          updatedAt: 3,
+        }),
+        {
+          id: 'perm-1',
+          kind: 'permission',
+          requestId: 'req-1',
+          sessionId: 'sess-1',
+          title: 'Present HTML',
+          options: [
+            {
+              optionId: resolved.slice('selected:'.length),
+              label: 'Allow',
+              raw: { kind: 'allow_once' },
+            },
+          ],
+          toolCall: {
+            toolCallId: 'mcp-1',
+            kind: 'other',
+            _meta: { toolName: 'mcp__agentic-pai__present_html' },
+            rawInput: { path: 'interactive.html' },
+          },
+          preview: { kind: 'generic' as const },
+          resolved,
+          clientReceivedAt: 2,
+          createdAt: 2,
+          updatedAt: 4,
+        },
+      ]);
+
+      const tool =
+        messages[0].role === 'tool_group' ? messages[0].tools[0] : undefined;
+      expect(tool).toMatchObject({
+        callId: 'mcp-1',
+        status: 'completed',
+        rawOutput: '{"approved":true}',
+        endTime: 3,
+      });
+    },
+  );
+
   it('renders rejected permission as completed agent card', () => {
     const messages = transcriptBlocksToDaemonMessages([
       textBlock('t1', 'thought', 'first thinking', 1),

--- a/packages/web-shell/client/adapters/transcriptToMessages.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.ts
@@ -500,6 +500,7 @@ export function transcriptBlocksToDaemonMessages(
         const existingPermission = toolsByCallId.get(permissionToolCall.callId);
         if (existingPermission) {
           const previousStatus = existingPermission.status;
+          const previousEndTime = existingPermission.endTime;
           permissionToolCall.toolName = existingPermission.toolName;
           if (permBlock.resolved) {
             if (isApprovedPermissionResolution(permBlock.resolved)) {
@@ -513,11 +514,13 @@ export function transcriptBlocksToDaemonMessages(
           }
           mergeToolCall(existingPermission, permissionToolCall);
           if (
-            permBlock.resolved &&
-            isSubAgentPermission &&
-            isApprovedPermissionResolution(permBlock.resolved)
+            isTerminalToolStatus(previousStatus) ||
+            (permBlock.resolved &&
+              isSubAgentPermission &&
+              isApprovedPermissionResolution(permBlock.resolved))
           ) {
             existingPermission.status = previousStatus;
+            existingPermission.endTime = previousEndTime;
           }
           break;
         }
@@ -740,6 +743,10 @@ function mergeToolCall(
   target.locations = source.locations ?? target.locations;
 }
 
+function isTerminalToolStatus(status: DaemonMessageToolCallStatus): boolean {
+  return status === 'completed' || status === 'failed';
+}
+
 function isSubAgentToolCall(tool: DaemonMessageToolCall): boolean {
   const name = tool.toolName.toLowerCase();
   if (name === 'agent' || name === 'task') return true;
@@ -925,6 +932,7 @@ function isApprovalToken(token: string): boolean {
     token === 'confirmed' ||
     token === 'proceed' ||
     token === 'proceed_once' ||
+    token === 'proceed_once_and_switch_to_default' ||
     token === 'proceed_always_project' ||
     token === 'proceed_always_user' ||
     token === 'allow_once' ||

--- a/packages/web-shell/client/components/messages/ToolApproval.test.tsx
+++ b/packages/web-shell/client/components/messages/ToolApproval.test.tsx
@@ -8,7 +8,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { I18nProvider } from '../../i18n';
+import { I18nProvider, type WebShellLanguage } from '../../i18n';
 import type { PermissionRequest } from '../../adapters/types';
 import { ToolApproval } from './ToolApproval';
 
@@ -56,10 +56,11 @@ afterEach(() => {
 function rerender(
   keyboardActive?: boolean,
   req: PermissionRequest = request,
+  language: WebShellLanguage = 'en',
 ): void {
   act(() =>
     root!.render(
-      <I18nProvider language="en">
+      <I18nProvider language={language}>
         <ToolApproval
           request={req}
           onConfirm={onConfirm}
@@ -73,11 +74,12 @@ function rerender(
 function render(
   keyboardActive?: boolean,
   req: PermissionRequest = request,
+  language: WebShellLanguage = 'en',
 ): void {
   container = document.createElement('div');
   document.body.appendChild(container);
   root = createRoot(container);
-  rerender(keyboardActive, req);
+  rerender(keyboardActive, req, language);
 }
 
 function optionButtons(): HTMLButtonElement[] {
@@ -173,6 +175,47 @@ describe('ToolApproval accessibility', () => {
     });
     expect(onConfirm).toHaveBeenCalledWith('req-1', 'proceed');
   });
+
+  it.each([
+    ['en' as const, 'Yes, allow once', 'Allow once and switch to Default mode'],
+    ['zh-CN' as const, '是，允许一次', '允许一次并切换到默认模式'],
+  ])(
+    'distinguishes the switch-to-default approval in %s',
+    (language, allowOnceLabel, switchLabel) => {
+      render(
+        undefined,
+        {
+          ...request,
+          options: [
+            {
+              id: 'proceed_once',
+              label: 'Allow',
+              kind: 'allow_once',
+            },
+            {
+              id: 'proceed_once_and_switch_to_default',
+              label: 'Switch to Default Mode and allow once (recommended)',
+              kind: 'allow_once',
+            },
+          ],
+        },
+        language,
+      );
+
+      expect(optionButtons().map((option) => option.textContent)).toEqual([
+        expect.stringContaining(allowOnceLabel),
+        expect.stringContaining(switchLabel),
+      ]);
+
+      act(() => {
+        optionButtons()[1]!.click();
+      });
+      expect(onConfirm).toHaveBeenCalledWith(
+        'req-1',
+        'proceed_once_and_switch_to_default',
+      );
+    },
+  );
 
   it('confirms by digit shortcut, scoped to the panel', () => {
     render(undefined);

--- a/packages/web-shell/client/components/messages/ToolApproval.tsx
+++ b/packages/web-shell/client/components/messages/ToolApproval.tsx
@@ -142,6 +142,9 @@ function orderPermissionOptions(
 function getOptionI18nKey(
   option: PermissionRequest['options'][number],
 ): string | undefined {
+  if (option.id === 'proceed_once_and_switch_to_default') {
+    return 'approval.option.allowOnceAndSwitchToDefault';
+  }
   if (option.kind === 'allow_once') return 'approval.option.allowOnce';
   if (option.kind === 'reject_once') return 'approval.option.rejectOnce';
   if (option.kind === 'allow_always') {

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -282,6 +282,8 @@ const EN: Messages = {
   'approval.changeQuestion': 'Apply this change?',
   'approval.launchAgentQuestion': 'Launch this agent?',
   'approval.option.allowOnce': 'Yes, allow once',
+  'approval.option.allowOnceAndSwitchToDefault':
+    'Allow once and switch to Default mode',
   'approval.option.rejectOnce': 'Reject',
   'approval.option.allowAllEdits': 'Allow All Edits',
   'approval.option.allowAlwaysProject': 'Always allow in this project',
@@ -2504,6 +2506,7 @@ const ZH: Messages = {
   'approval.changeQuestion': '是否继续？',
   'approval.launchAgentQuestion': '启动这个 agent？',
   'approval.option.allowOnce': '是，允许一次',
+  'approval.option.allowOnceAndSwitchToDefault': '允许一次并切换到默认模式',
   'approval.option.rejectOnce': '拒绝',
   'approval.option.allowAllEdits': '允许所有编辑',
   'approval.option.allowAlwaysProject': '项目内始终允许',


### PR DESCRIPTION
## What this PR does

This PR gives the one-time approval that also switches the session back to Default mode its own localized label, recognizes its option ID as an approved permission result, and prevents a later permission placeholder from replacing a real tool's terminal status or end time.

It also adds regression coverage for both transcript event orders and for the distinct English and Chinese approval labels.

## Why it's needed

Auto-mode fallback permissions expose two different one-time approval actions with the same ACP `allow_once` kind. Web Shell localized both actions from that shared kind, so users saw two identical buttons even though one also changed the approval mode.

During streaming, the switch-to-Default option ID was not recognized as approval. When the tool block had been created before the permission block, transcript projection could then overwrite a successful MCP tool result with a failed permission placeholder. Reloading reconstructed the successful persisted result, making the live and reloaded views disagree.

## Reviewer Test Plan

### How to verify

Trigger an Auto-mode classifier fallback and confirm that the approval panel shows separate actions for allowing once and allowing once while switching to Default mode. Select the switch-to-Default action and confirm that the tool proceeds.

For a tool whose transcript block is created before its permission block, complete the tool and then resolve the permission with either one-time approval option. The rendered tool must remain completed, retain its output and original completion time, and must not temporarily appear failed or in progress.

Focused Web Shell tests pass: 122/122. Web Shell lint, typecheck, and production build also pass.

### Evidence (Before & After)

Before: both one-time actions displayed the same label. Selecting the switch-to-Default action could make a successfully completed custom MCP tool appear failed until refresh.

After: the actions have distinct localized labels, the switch-to-Default result is treated as approval, and the real terminal tool result remains authoritative during streaming.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

Node.js 22; focused Vitest tests and the Web Shell production build.

## Risk & Scope

- Main risk or tradeoff: A terminal tool update now remains authoritative over a later permission placeholder for the same tool call.
- Not validated / out of scope: Full repository build and typecheck remain blocked by missing CLI workspace dependencies (`comment-json` and `update-notifier`); Web Shell checks pass.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本 PR 为“允许本次并切换回默认模式”的审批操作增加独立的本地化文案，将其选项 ID 正确识别为批准结果，并阻止后到的 permission 占位记录覆盖真实工具的终态或结束时间。

同时补充两种 transcript 事件顺序，以及中英文审批文案差异的回归测试。

## 为什么需要

Auto 模式回退审批会提供两个语义不同、但 ACP `kind` 都是 `allow_once` 的一次性批准操作。Web Shell 之前只根据共同的 kind 进行本地化，因此两个按钮显示完全相同，尽管其中一个还会改变审批模式。

流式处理期间，切换回默认模式的选项 ID 没有被识别为批准。当工具块早于 permission 块创建时，transcript 投影可能用失败的 permission 占位状态覆盖已经成功的 MCP 工具结果。刷新后会重新构建持久化的成功结果，因此实时界面和刷新后的界面不一致。

## Reviewer 测试计划

### 验证方法

触发 Auto 模式分类器回退，确认审批面板分别显示“仅允许本次”和“允许本次并切换到默认模式”。选择切换到默认模式的操作，确认工具继续执行。

对于 transcript 工具块早于 permission 块创建的场景，先让工具完成，再使用任意一个一次性批准选项解决 permission。渲染后的工具必须保持完成状态、保留输出和原始完成时间，不能临时显示为失败或执行中。

Web Shell 聚焦测试 122/122 通过，Web Shell lint、typecheck 和生产构建也均通过。

### 前后对比证据

修改前：两个一次性操作显示相同文案；选择“切换到默认模式并允许本次”后，成功完成的自定义 MCP 工具可能在刷新前显示失败。

修改后：两个操作具有不同的本地化文案，切换到默认模式的结果会被识别为批准，流式期间真实工具终态保持权威。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境

Node.js 22；聚焦 Vitest 测试和 Web Shell 生产构建。

## 风险与范围

- 主要风险或取舍：同一工具调用已有终态时，该真实工具更新现在优先于后到的 permission 占位记录。
- 未验证或不在范围内：仓库全量构建和 typecheck 仍被 CLI workspace 缺少 `comment-json`、`update-notifier` 依赖阻塞；Web Shell 自身检查通过。
- 破坏性变更或迁移说明：无。

## 关联 Issue

无。

</details>
