### PR TITLE
refactor(core): make derived Config ownership explicit

### DIFF
--- a/docs/design/derived-config-ownership.md
+++ b/docs/design/derived-config-ownership.md
@@ -1,0 +1,28 @@
+# Derived Config ownership
+
+`Config` derivation is a state-ownership operation, not a clone. `deriveConfig` keeps the existing prototype overlay model behind one boundary while production callers are migrated incrementally.
+
+| State                      | Ownership                        | Contract                                                                                                                         |
+| -------------------------- | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| workspace path and context | shared until explicitly overlaid | Worktree profiles must override the paired public getters and private reads together.                                            |
+| file service and discovery | shared until explicitly overlaid | Worktree profiles rebind both to the target workspace.                                                                           |
+| tool registry              | shared or explicitly replaced    | Agent profiles that rebuild it own cleanup of the replacement registry.                                                          |
+| permission manager         | shared or explicitly replaced    | Agent profiles preserve the existing strip/restore lifecycle.                                                                    |
+| approval mode              | shared                           | Derived profiles may read the inherited mode but cannot mutate it until they own an independent permission-manager lifecycle.    |
+| file-read cache            | child-local                      | The first getter call installs a fresh cache on the derived Config.                                                              |
+| memory-pressure monitor    | child-local                      | The first getter call installs a new monitor using the inherited configuration snapshot.                                         |
+| active todo state          | child-local                      | The first mutation installs independent maps.                                                                                    |
+| chat recording service     | shared unless hidden             | Scoped profiles may hide it through a getter override.                                                                           |
+| goal runtime               | prohibited                       | A derived Config cannot resolve the parent conversation's runtime.                                                               |
+| session writer state       | prohibited                       | Writer ownership stays with the canonical session Config.                                                                        |
+| canonical lifecycle        | prohibited                       | A derived Config cannot initialize, start a session, relocate the workspace, or clean up inherited Team/Arena runtime resources. |
+| approval mode mutation     | prohibited                       | A derived Config cannot restore or strip rules on the canonical PermissionManager.                                               |
+
+Migration order:
+
+1. Worktree contexts.
+2. Agent execution contexts.
+3. Scoped memory/remember/skill-review profiles.
+4. Enforce that production prototype derivation occurs only inside `deriveConfig`.
+
+The factory intentionally accepts public getter overrides only. Private field rebinding needed by worktree contexts remains a separate migration concern and must be encoded without exposing arbitrary Config mutation.

--- a/docs/design/derived-config-ownership.md
+++ b/docs/design/derived-config-ownership.md
@@ -26,3 +26,5 @@ Migration order:
 4. Enforce that production prototype derivation occurs only inside `deriveConfig`.
 
 The factory intentionally accepts public getter overrides only. Private field rebinding needed by worktree contexts remains a separate migration concern and must be encoded without exposing arbitrary Config mutation.
+
+Approval-mode override wrappers that call Config prototype mutators remain outside `deriveConfig` until their strip/restore lifecycle is owned independently from the parent permission manager.

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Mock } from 'vitest';
 import { mkdir, mkdtemp, open, rm, stat, writeFile } from 'node:fs/promises';
+import type { Stats } from 'node:fs';
 import type { ConfigParameters, SandboxConfig } from './config.js';
 import {
   Config,
@@ -14,6 +15,8 @@ import {
   APPROVAL_MODES,
   APPROVAL_MODE_INFO,
   MCPServerConfig,
+  DERIVED_CONFIG_STATE_OWNERSHIP,
+  deriveConfig,
   TrustGateError,
   matchesServerPattern,
   matchesAnyServerPattern,
@@ -1644,17 +1647,258 @@ describe('Server Config (config.ts)', () => {
     }
   });
 
-  describe('FileReadCache isolation', () => {
-    it('returns a distinct cache for child Configs created via Object.create', () => {
-      // Subagent / scoped-agent / fork construction all use
-      // `Object.create(parent)`, which does NOT run field initializers.
-      // Without explicit handling the child would resolve fileReadCache
-      // through the prototype chain back to the parent's instance, so a
-      // subagent's ReadFile would see the parent's recorded reads and
-      // return file_unchanged placeholders for files the subagent has
-      // never received in its own transcript.
+  describe('derived Config ownership', () => {
+    it('declares the mutable ownership decisions enforced by Config accessors', () => {
+      expect(DERIVED_CONFIG_STATE_OWNERSHIP).toMatchObject({
+        fileReadCache: 'child-local',
+        memoryPressureMonitor: 'child-local',
+        activeTodoState: 'child-local',
+        goalRuntime: 'prohibited',
+        sessionWriterState: 'prohibited',
+        canonicalLifecycle: 'prohibited',
+        approvalModeMutation: 'prohibited',
+      });
+    });
+
+    it('applies public getter overrides without mutating the parent', () => {
       const parent = new Config(baseParams);
-      const child = Object.create(parent) as Config;
+      const child = deriveConfig(parent, {
+        getCwd: () => '/tmp/derived',
+      });
+
+      expect(child.getCwd()).toBe('/tmp/derived');
+      expect(parent.getCwd()).toBe(baseParams.targetDir);
+      expect(Object.getPrototypeOf(child)).toBe(parent);
+    });
+
+    it('ignores undefined getter overrides', () => {
+      const parent = new Config(baseParams);
+      const child = deriveConfig(parent, { getCwd: undefined });
+
+      expect(child.getCwd()).toBe(parent.getCwd());
+      expect(Object.hasOwn(child, 'getCwd')).toBe(false);
+    });
+
+    it('prohibits inherited session-writer lifecycle access', async () => {
+      const parent = new Config(baseParams);
+      const beginClose = vi.fn();
+      const close = vi.fn().mockResolvedValue(undefined);
+      const assertCanStartTurn = vi.fn().mockResolvedValue(undefined);
+      (
+        parent as unknown as {
+          chatRecordingService: {
+            hasWriteOwnership: () => boolean;
+            beginClose: () => void;
+            close: () => Promise<void>;
+            assertCanStartTurn: () => Promise<void>;
+          };
+        }
+      ).chatRecordingService = {
+        hasWriteOwnership: () => true,
+        beginClose,
+        close,
+        assertCanStartTurn,
+      };
+      const child = deriveConfig(parent);
+
+      expect(child.hasSessionWriteOwnership()).toBe(false);
+      expect(() => child.setSessionWriterReclaimPolicy('never')).toThrow(
+        'Session write ownership could not be verified.',
+      );
+      expect(() => child.setSessionWriterTakeoverPolicy('certified')).toThrow(
+        'Session write ownership could not be verified.',
+      );
+      expect(() => child.closeSessionWriter()).toThrow(
+        'Session write ownership could not be verified.',
+      );
+      await expect(child.assertCanStartTurn()).resolves.toBeUndefined();
+      expect(assertCanStartTurn).not.toHaveBeenCalled();
+      expect(beginClose).not.toHaveBeenCalled();
+      expect(close).not.toHaveBeenCalled();
+      expect(parent.hasSessionWriteOwnership()).toBe(true);
+    });
+
+    it('prohibits initializing a derived Config', async () => {
+      const parent = new Config(baseParams);
+      const child = deriveConfig(parent);
+
+      await expect(child.initialize()).rejects.toThrow(
+        'Derived Configs cannot be initialized',
+      );
+    });
+
+    it('prohibits canonical lifecycle operations on derived Configs', async () => {
+      const parent = new Config(baseParams);
+      const finalize = vi.fn();
+      const flush = vi.fn().mockResolvedValue(undefined);
+      const teamCleanup = vi.fn().mockResolvedValue(undefined);
+      const arenaCleanup = vi.fn().mockResolvedValue(undefined);
+      const internal = parent as unknown as {
+        chatRecordingService: {
+          hasWriteOwnership: () => boolean;
+          finalize: () => void;
+          flush: () => Promise<void>;
+        };
+        teamManager: { cleanup: () => Promise<void> };
+        arenaManager: { cleanup: () => Promise<void> };
+      };
+      internal.chatRecordingService = {
+        hasWriteOwnership: () => false,
+        finalize,
+        flush,
+      };
+      internal.teamManager = { cleanup: teamCleanup };
+      internal.arenaManager = { cleanup: arenaCleanup };
+      const child = deriveConfig(parent);
+
+      expect(() => child.startNewSession()).toThrow(
+        'Derived Configs cannot start new sessions',
+      );
+      await expect(
+        child.relocateWorkingDirectory(baseParams.targetDir),
+      ).rejects.toThrow('Derived Configs cannot relocate working directories');
+      await expect(child.cleanupTeamRuntime()).rejects.toThrow(
+        'Derived Configs cannot clean up Team runtime',
+      );
+      await expect(child.cleanupArenaRuntime(true)).rejects.toThrow(
+        'Derived Configs cannot clean up Arena runtime',
+      );
+
+      expect(finalize).not.toHaveBeenCalled();
+      expect(flush).not.toHaveBeenCalled();
+      expect(teamCleanup).not.toHaveBeenCalled();
+      expect(arenaCleanup).not.toHaveBeenCalled();
+    });
+
+    it('preserves ownership guards through nested prototype wrappers', async () => {
+      const parent = new Config(baseParams);
+      const beginClose = vi.fn();
+      const close = vi.fn().mockResolvedValue(undefined);
+      const finalize = vi.fn();
+      const flush = vi.fn().mockResolvedValue(undefined);
+      const stop = vi.fn().mockResolvedValue(undefined);
+      const teamCleanup = vi.fn().mockResolvedValue(undefined);
+      const arenaCleanup = vi.fn().mockResolvedValue(undefined);
+      const internal = parent as unknown as {
+        initialized: boolean;
+        toolRegistry: ToolRegistry;
+        chatRecordingService: {
+          hasWriteOwnership: () => boolean;
+          beginClose: () => void;
+          close: () => Promise<void>;
+          finalize: () => void;
+          flush: () => Promise<void>;
+        };
+        teamManager: { cleanup: () => Promise<void> };
+        arenaManager: { cleanup: () => Promise<void> };
+      };
+      internal.initialized = true;
+      internal.toolRegistry = { stop } as unknown as ToolRegistry;
+      internal.chatRecordingService = {
+        hasWriteOwnership: () => false,
+        beginClose,
+        close,
+        finalize,
+        flush,
+      };
+      internal.teamManager = { cleanup: teamCleanup };
+      internal.arenaManager = { cleanup: arenaCleanup };
+      const wrapped = Object.create(deriveConfig(parent)) as Config;
+
+      expect(wrapped.hasSessionWriteOwnership()).toBe(false);
+      expect(() => wrapped.closeSessionWriter()).toThrow(
+        'Session write ownership could not be verified.',
+      );
+      expect(() => wrapped.startNewSession()).toThrow(
+        'Derived Configs cannot start new sessions',
+      );
+      await expect(
+        wrapped.relocateWorkingDirectory(baseParams.targetDir),
+      ).rejects.toThrow('Derived Configs cannot relocate working directories');
+      await expect(wrapped.cleanupTeamRuntime()).rejects.toThrow(
+        'Derived Configs cannot clean up Team runtime',
+      );
+      await expect(wrapped.cleanupArenaRuntime(true)).rejects.toThrow(
+        'Derived Configs cannot clean up Arena runtime',
+      );
+      await expect(
+        wrapped.shutdown({ shutdownTelemetry: false }),
+      ).resolves.toBeUndefined();
+
+      expect(stop).not.toHaveBeenCalled();
+      expect(beginClose).not.toHaveBeenCalled();
+      expect(close).not.toHaveBeenCalled();
+      expect(finalize).not.toHaveBeenCalled();
+      expect(flush).not.toHaveBeenCalled();
+      expect(teamCleanup).not.toHaveBeenCalled();
+      expect(arenaCleanup).not.toHaveBeenCalled();
+    });
+
+    it('prohibits derived approval changes from mutating parent permissions', () => {
+      const parent = new Config(baseParams);
+      const restoreDangerousRules = vi.fn();
+      const internal = parent as unknown as {
+        approvalMode: ApprovalMode;
+        permissionManager: {
+          stripDangerousRulesForAutoMode: () => void;
+          restoreDangerousRules: () => void;
+        };
+      };
+      internal.approvalMode = ApprovalMode.AUTO;
+      internal.permissionManager = {
+        stripDangerousRulesForAutoMode: vi.fn(),
+        restoreDangerousRules,
+      };
+      const child = deriveConfig(parent);
+
+      expect(() => child.setApprovalMode(ApprovalMode.DEFAULT)).toThrow(
+        'Derived Configs cannot change approval mode',
+      );
+      expect(restoreDangerousRules).not.toHaveBeenCalled();
+      expect(parent.getApprovalMode()).toBe(ApprovalMode.AUTO);
+    });
+
+    it('does not shut down resources inherited from the parent', async () => {
+      const parent = new Config(baseParams);
+      const stop = vi.fn().mockResolvedValue(undefined);
+      const finalize = vi.fn();
+      const flush = vi.fn().mockResolvedValue(undefined);
+      const beginClose = vi.fn();
+      const close = vi.fn().mockResolvedValue(undefined);
+      const internal = parent as unknown as {
+        initialized: boolean;
+        toolRegistry: ToolRegistry;
+        chatRecordingService: {
+          finalize: () => void;
+          flush: () => Promise<void>;
+          beginClose: () => void;
+          close: () => Promise<void>;
+        };
+      };
+      internal.initialized = true;
+      internal.toolRegistry = { stop } as unknown as ToolRegistry;
+      internal.chatRecordingService = {
+        finalize,
+        flush,
+        beginClose,
+        close,
+      };
+      const child = deriveConfig(parent);
+
+      await expect(
+        child.shutdown({ shutdownTelemetry: false }),
+      ).resolves.toBeUndefined();
+
+      expect(stop).not.toHaveBeenCalled();
+      expect(finalize).not.toHaveBeenCalled();
+      expect(flush).not.toHaveBeenCalled();
+      expect(beginClose).not.toHaveBeenCalled();
+      expect(close).not.toHaveBeenCalled();
+    });
+
+    it('returns a distinct file-read cache for derived Configs', () => {
+      const parent = new Config(baseParams);
+      const child = deriveConfig(parent);
 
       const parentCache = parent.getFileReadCache();
       const childCache = child.getFileReadCache();
@@ -1670,7 +1914,7 @@ describe('Server Config (config.ts)', () => {
           ino: 100,
           mtimeMs: 1_000_000,
           size: 42,
-        } as unknown as import('node:fs').Stats,
+        } as unknown as Stats,
         { full: true, cacheable: true },
       );
 
@@ -1679,9 +1923,6 @@ describe('Server Config (config.ts)', () => {
     });
 
     it('returns the same cache instance on repeated getter calls within one Config', () => {
-      // Sanity: the lazy own-property initialization in
-      // getFileReadCache() must not allocate a fresh cache on every
-      // call — recorded entries would vanish between operations.
       const config = new Config(baseParams);
       expect(config.getFileReadCache()).toBe(config.getFileReadCache());
     });
@@ -2081,7 +2322,7 @@ describe('Server Config (config.ts)', () => {
     it('returns a distinct monitor for child Configs created via Object.create', async () => {
       const parent = new Config(baseParams);
       await parent.initialize({ skipGeminiInitialization: true });
-      const child = Object.create(parent) as Config;
+      const child = deriveConfig(parent);
 
       const parentMonitor = parent.getMemoryPressureMonitor();
       const childMonitor = child.getMemoryPressureMonitor();
@@ -2258,7 +2499,7 @@ describe('Server Config (config.ts)', () => {
       process.env['QWEN_MEMORY_PRESSURE_SOFT'] = '0.9';
       process.env['QWEN_MEMORY_PRESSURE_HARD'] = '0.95';
       process.env['QWEN_MEMORY_PRESSURE_CRITICAL'] = '0.97';
-      const child = Object.create(parent) as Config;
+      const child = deriveConfig(parent);
       mockMemoryRatio(0.35);
 
       expect(child.getMemoryPressureMonitor()?.getPressureLevel()).toBe('soft');
@@ -2726,7 +2967,7 @@ describe('Server Config (config.ts)', () => {
     it('does not leak the canonical Goal runtime through subagent prototypes', async () => {
       const config = new Config({ ...baseParams, chatRecording: true });
       const canonical = config.getGoalRuntime();
-      const child = Object.create(config) as Config;
+      const child = deriveConfig(config);
 
       expect(() => child.getGoalRuntime()).toThrow(
         GoalPersistenceUnavailableError,
@@ -10815,7 +11056,7 @@ describe('Model Switching and Config Updates', () => {
 
   it('isolates active Todo reminders inherited through child Configs', () => {
     const parent = Object.create(Config.prototype) as Config;
-    const child = Object.create(parent) as Config;
+    const child = deriveConfig(parent);
     parent.setActiveTodoReminder('parent-prompt', 'parent work');
 
     child.setActiveTodoReminder('child-prompt', 'child work');

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -15,7 +15,6 @@ import {
   APPROVAL_MODES,
   APPROVAL_MODE_INFO,
   MCPServerConfig,
-  DERIVED_CONFIG_STATE_OWNERSHIP,
   deriveConfig,
   TrustGateError,
   matchesServerPattern,
@@ -1648,18 +1647,6 @@ describe('Server Config (config.ts)', () => {
   });
 
   describe('derived Config ownership', () => {
-    it('declares the mutable ownership decisions enforced by Config accessors', () => {
-      expect(DERIVED_CONFIG_STATE_OWNERSHIP).toMatchObject({
-        fileReadCache: 'child-local',
-        memoryPressureMonitor: 'child-local',
-        activeTodoState: 'child-local',
-        goalRuntime: 'prohibited',
-        sessionWriterState: 'prohibited',
-        canonicalLifecycle: 'prohibited',
-        approvalModeMutation: 'prohibited',
-      });
-    });
-
     it('applies public getter overrides without mutating the parent', () => {
       const parent = new Config(baseParams);
       const child = deriveConfig(parent, {
@@ -2319,7 +2306,7 @@ describe('Server Config (config.ts)', () => {
   });
 
   describe('MemoryPressureMonitor isolation', () => {
-    it('returns a distinct monitor for child Configs created via Object.create', async () => {
+    it('returns a distinct monitor for child Configs created via deriveConfig', async () => {
       const parent = new Config(baseParams);
       await parent.initialize({ skipGeminiInitialization: true });
       const child = deriveConfig(parent);

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1768,6 +1768,103 @@ function containsErrorByIdentity(error: unknown, candidate: unknown): boolean {
   );
 }
 
+const DERIVED_CONFIG = Symbol('derivedConfig');
+
+function isDerivedConfig(config: Config): boolean {
+  return (
+    (config as Config & { [DERIVED_CONFIG]?: boolean })[DERIVED_CONFIG] === true
+  );
+}
+
+/**
+ * State ownership for a Config derived through {@link deriveConfig}.
+ *
+ * - `shared`: reads and mutations intentionally resolve to the parent.
+ * - `copied`: the factory installs an own snapshot on the child.
+ * - `child-local`: Config lazily installs independent mutable state.
+ * - `prohibited`: the child must not resolve the parent's runtime object.
+ */
+export type DerivedConfigStateOwnership =
+  | 'shared'
+  | 'copied'
+  | 'child-local'
+  | 'prohibited';
+
+export const DERIVED_CONFIG_STATE_OWNERSHIP = {
+  workspacePathAndContext: 'shared',
+  fileService: 'shared',
+  toolRegistry: 'shared',
+  permissionManager: 'shared',
+  approvalModeState: 'shared',
+  fileReadCache: 'child-local',
+  memoryPressureMonitor: 'child-local',
+  activeTodoState: 'child-local',
+  chatRecordingService: 'shared',
+  goalRuntime: 'prohibited',
+  sessionWriterState: 'prohibited',
+  canonicalLifecycle: 'prohibited',
+  approvalModeMutation: 'prohibited',
+} as const satisfies Record<string, DerivedConfigStateOwnership>;
+
+export type DerivedConfigOverrides = Partial<
+  Pick<
+    Config,
+    | 'getTargetDir'
+    | 'getCwd'
+    | 'getWorkingDir'
+    | 'getProjectRoot'
+    | 'getPlanFilePath'
+    | 'getWorkspaceContext'
+    | 'getFileService'
+    | 'getToolRegistry'
+    | 'getPermissionManager'
+    | 'getApprovalMode'
+    | 'getShouldAvoidPermissionPrompts'
+    | 'getMcpServers'
+    | 'getBareMode'
+    | 'isSafeMode'
+    | 'getSandbox'
+    | 'getScreenReader'
+    | 'getModel'
+    | 'getMaxSessionTurns'
+    | 'getMaxToolCalls'
+    | 'getMaxSubagentDepth'
+    | 'getChatRecordingService'
+    | 'getTranscriptPath'
+    | 'getDisableAllHooks'
+    | 'getHookSystem'
+    | 'getMessageBus'
+    | 'getAutoMemoryPrompt'
+    | 'getUserMemory'
+  >
+>;
+
+/**
+ * Creates a Config overlay while keeping prototype delegation inside one
+ * reviewable boundary. Callers supply only public getter overrides; Config's
+ * child-local and prohibited runtime state remains enforced by its accessors.
+ */
+export function deriveConfig(
+  base: Config,
+  overrides: DerivedConfigOverrides = {},
+): Config {
+  const derived = Object.create(base) as Config;
+  for (const key in overrides) {
+    if (!Object.hasOwn(overrides, key)) continue;
+    const override = overrides[key as keyof DerivedConfigOverrides];
+    if (override !== undefined) {
+      Object.defineProperty(derived, key, {
+        value: override,
+        writable: true,
+        configurable: true,
+        enumerable: true,
+      });
+    }
+  }
+  Object.defineProperty(derived, DERIVED_CONFIG, { value: true });
+  return derived;
+}
+
 export class Config {
   private sessionId: string;
   private sessionSourceType?: string;
@@ -1952,6 +2049,7 @@ export class Config {
    * single-block layout when it doesn't match the request's system text.
    */
   private staticSystemPrefix: string | undefined;
+
   /**
    * Volatile system-prompt layer: the managed auto-memory section
    * (instructions + MEMORY.md indexes). Kept separate from `userMemory`
@@ -2665,6 +2763,9 @@ export class Config {
    * @param options Optional initialization options including sendSdkMcpMessage callback
    */
   async initialize(options?: ConfigInitializeOptions): Promise<void> {
+    if (isDerivedConfig(this)) {
+      throw new Error('Derived Configs cannot be initialized');
+    }
     if (this.initialized) {
       throw Error('Config was already initialized');
     }
@@ -3996,6 +4097,9 @@ export class Config {
     sessionId?: string,
     sessionData?: ResumedSessionData,
   ): string {
+    if (isDerivedConfig(this)) {
+      throw new Error('Derived Configs cannot start new sessions');
+    }
     if (this.chatRecordingService?.hasWriteOwnership()) {
       throw new SessionWriterUnavailableError();
     }
@@ -5193,6 +5297,9 @@ export class Config {
     memoryRefreshError?: unknown;
     mcpRefreshError?: unknown;
   }> {
+    if (isDerivedConfig(this)) {
+      throw new Error('Derived Configs cannot relocate working directories');
+    }
     if (
       !opts?.skipArtifactMigration &&
       this.chatRecordingService?.hasWriteOwnership()
@@ -5327,6 +5434,7 @@ export class Config {
     skipSessionWriter?: boolean;
     strictResourceCleanup?: boolean;
   }): Promise<void> {
+    if (isDerivedConfig(this)) return;
     this.shutdownRequested = true;
     this.settingsWatcher?.stopWatching();
     const closeWriter = () =>
@@ -6343,6 +6451,9 @@ export class Config {
    * Clean up Team runtime — stops all teammates and clears state.
    */
   async cleanupTeamRuntime(): Promise<void> {
+    if (isDerivedConfig(this)) {
+      throw new Error('Derived Configs cannot clean up Team runtime');
+    }
     const manager = this.teamManager;
     if (!manager) {
       return;
@@ -6369,6 +6480,9 @@ export class Config {
    * always removes worktrees regardless of preserveArtifacts.
    */
   async cleanupArenaRuntime(force?: boolean): Promise<void> {
+    if (isDerivedConfig(this)) {
+      throw new Error('Derived Configs cannot clean up Arena runtime');
+    }
     const manager = this.arenaManager;
     if (!manager) {
       return;
@@ -6465,6 +6579,9 @@ export class Config {
       fromApprovedPlanExit?: boolean;
     },
   ): void {
+    if (isDerivedConfig(this)) {
+      throw new Error('Derived Configs cannot change approval mode');
+    }
     if (
       !this.isTrustedFolder() &&
       mode !== ApprovalMode.DEFAULT &&
@@ -8094,12 +8211,14 @@ export class Config {
   }
 
   async assertCanStartTurn(): Promise<void> {
+    if (isDerivedConfig(this)) return;
     if (this.chatRecordingService?.hasWriteOwnership()) {
       await this.chatRecordingService.assertCanStartTurn();
     }
   }
 
   hasSessionWriteOwnership(): boolean {
+    if (isDerivedConfig(this)) return false;
     return (
       this.pendingSessionWriterLease !== undefined ||
       this.chatRecordingService?.hasWriteOwnership() === true
@@ -8107,6 +8226,9 @@ export class Config {
   }
 
   setSessionWriterReclaimPolicy(policy: 'local' | 'never'): void {
+    if (isDerivedConfig(this)) {
+      throw new SessionWriterUnavailableError();
+    }
     if (this.initialized) {
       throw new SessionWriterUnavailableError();
     }
@@ -8114,6 +8236,9 @@ export class Config {
   }
 
   setSessionWriterTakeoverPolicy(policy: 'never' | 'certified'): void {
+    if (isDerivedConfig(this)) {
+      throw new SessionWriterUnavailableError();
+    }
     if (this.initialized) {
       throw new SessionWriterUnavailableError();
     }
@@ -8121,6 +8246,9 @@ export class Config {
   }
 
   closeSessionWriter(options?: { handoff?: boolean }): Promise<void> {
+    if (isDerivedConfig(this)) {
+      throw new SessionWriterUnavailableError();
+    }
     if (options?.handoff && this.sessionWriterTakeoverPolicy === 'certified') {
       this.sessionWriterHandoffRequested = true;
     }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1776,36 +1776,6 @@ function isDerivedConfig(config: Config): boolean {
   );
 }
 
-/**
- * State ownership for a Config derived through {@link deriveConfig}.
- *
- * - `shared`: reads and mutations intentionally resolve to the parent.
- * - `copied`: the factory installs an own snapshot on the child.
- * - `child-local`: Config lazily installs independent mutable state.
- * - `prohibited`: the child must not resolve the parent's runtime object.
- */
-export type DerivedConfigStateOwnership =
-  | 'shared'
-  | 'copied'
-  | 'child-local'
-  | 'prohibited';
-
-export const DERIVED_CONFIG_STATE_OWNERSHIP = {
-  workspacePathAndContext: 'shared',
-  fileService: 'shared',
-  toolRegistry: 'shared',
-  permissionManager: 'shared',
-  approvalModeState: 'shared',
-  fileReadCache: 'child-local',
-  memoryPressureMonitor: 'child-local',
-  activeTodoState: 'child-local',
-  chatRecordingService: 'shared',
-  goalRuntime: 'prohibited',
-  sessionWriterState: 'prohibited',
-  canonicalLifecycle: 'prohibited',
-  approvalModeMutation: 'prohibited',
-} as const satisfies Record<string, DerivedConfigStateOwnership>;
-
 export type DerivedConfigOverrides = Partial<
   Pick<
     Config,
@@ -1843,6 +1813,8 @@ export type DerivedConfigOverrides = Partial<
  * Creates a Config overlay while keeping prototype delegation inside one
  * reviewable boundary. Callers supply only public getter overrides; Config's
  * child-local and prohibited runtime state remains enforced by its accessors.
+ * Approval-mode override wrappers that call Config prototype mutators must keep
+ * owning their strip/restore lifecycle before migrating to this factory.
  */
 export function deriveConfig(
   base: Config,
@@ -5434,6 +5406,8 @@ export class Config {
     skipSessionWriter?: boolean;
     strictResourceCleanup?: boolean;
   }): Promise<void> {
+    // Derived Configs share parent resources; any replacement resource a profile
+    // installs is owned and cleaned up by that profile.
     if (isDerivedConfig(this)) return;
     this.shutdownRequested = true;
     this.settingsWatcher?.stopWatching();


### PR DESCRIPTION
## What this PR does

This PR lands the first #8083 increment for derived `Config` ownership: a design document, a narrow `deriveConfig` factory boundary, a marker for factory-derived Config overlays, guards for canonical lifecycle/session-writer/approval mutation APIs, and focused tests for the ownership decisions that are enforceable at this step.

Production callers are not migrated in this PR. Existing production `Object.create(parent)` derivation sites remain intentionally untouched, so the new guards are inert for those callers until follow-up migrations route them through the factory. No ESLint enforcement is added here.

## Why it's needed

Prototype-derived Config instances previously depended on implicit ownership rules. A child could inherit mutable services, caches, getters, and lifecycle methods from the canonical Config, while each caller rebuilt its own overlay. That made ownership difficult to review and made it easy for later migrations to accidentally mutate resources the child does not own.

This increment makes the contract explicit before broad caller migration. Shared state remains shared only where the contract allows it; caches, memory-pressure monitors, active todo state, Goal/session-writer access, initialization, session switching, relocation, shutdown, cleanup, and approval mutation each have documented behavior and focused tests around the new factory-derived shape.

## Reviewer Test Plan

### How to verify

1. Review `docs/design/derived-config-ownership.md` and the `deriveConfig` API to confirm the intended shared, child-local, and prohibited ownership categories for factory-derived Config overlays.
2. Confirm the current diff is limited to the ownership contract, factory boundary, guards, and tests; production caller migration and lint enforcement remain out of scope for this PR.
3. Confirm derived contexts created through `deriveConfig` isolate child-local caches/state, preserve typed getter fallback semantics, and cannot mutate canonical Goal/session-writer/lifecycle/approval resources.
4. Run the focused Config tests that cover the factory, lifecycle guards, session-writer guards, approval-mode guard, child-local state, and nested prototype wrappers.

### Evidence (Before & After)

N/A — internal architecture contract change with no user-visible UI behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ CI validation |
| 🪟 Windows | ⚠️ CI validation |
|  🐧 Linux  | ✅ GitHub CI |

### Environment (optional)

GitHub Actions CI; focused package tests and repository checks where applicable.

## Risk & Scope

- Main risk or tradeoff: this PR declares and tests the factory-derived ownership contract before production callers are migrated, so it does not yet enforce the contract on existing production derivation sites.
- Not validated / out of scope: production caller migration, worktree private-field rebinding, no-config-object-create ESLint enforcement, broader Config decomposition, unrelated architecture hotspots, and daemon L2 work tracked by #4542.
- Breaking changes / migration notes: no user-facing behavior change is intended; follow-up migrations must route production derivation through the explicit factory boundary before relying on the new guards.

## Linked Issues

References #8083

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 落地 #8083 的第一步增量：派生 `Config` 所有权设计文档、窄 `deriveConfig` 工厂边界、用于识别工厂派生 Config overlay 的 marker、针对主 Config 生命周期 / session-writer / approval mutation API 的守卫，以及这个阶段可强制执行的所有权决策测试。

生产调用方迁移不在本 PR 中。现有生产 `Object.create(parent)` 派生点保持不动，因此新守卫在后续迁移把它们接到工厂之前，对这些调用方是惰性的。本 PR 也不添加 ESLint enforcement。

## 为什么需要

此前通过原型派生的 Config 依赖隐式所有权规则。子对象可能从规范主 Config 继承可变服务、缓存、getter 和生命周期方法，同时每个调用方各自重建 overlay。这让所有权难以审查，也让后续迁移容易误改子对象并不拥有的资源。

这个增量先把契约显式化，再做更大范围的调用方迁移。共享状态只在契约允许时共享；缓存、memory-pressure monitor、active todo state、Goal/session-writer 访问、初始化、会话切换、工作区迁移、shutdown、清理和 approval mutation 都有文档化行为，并围绕新的工厂派生形态补了聚焦测试。

## Reviewer Test Plan

### How to verify

1. 查看 `docs/design/derived-config-ownership.md` 和 `deriveConfig` API，确认工厂派生 Config overlay 的 shared、child-local、prohibited 所有权分类。
2. 确认当前 diff 仅限所有权契约、工厂边界、守卫和测试；生产调用方迁移和 lint enforcement 不属于本 PR。
3. 确认通过 `deriveConfig` 创建的派生上下文会隔离子对象本地缓存/状态，保留类型化 getter fallback 语义，并且不能修改主 Config 的 Goal/session-writer/lifecycle/approval 资源。
4. 运行覆盖 factory、生命周期守卫、session-writer 守卫、approval-mode 守卫、子对象本地状态和嵌套 prototype wrapper 的聚焦 Config 测试。

### Evidence (Before & After)

N/A——内部架构契约变更，没有用户可见 UI 行为。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ CI validation |
| 🪟 Windows | ⚠️ CI validation |
|  🐧 Linux  | ✅ GitHub CI |

### Environment (optional)

GitHub Actions CI；聚焦 package 测试和仓库检查（如适用）。

## Risk & Scope

- 主要风险或取舍：本 PR 先声明并测试工厂派生所有权契约，再迁移生产调用方，因此它尚不会在现有生产派生点上强制该契约。
- 未验证 / 范围外：生产调用方迁移、worktree private-field rebinding、no-config-object-create ESLint enforcement、更大范围 Config 拆分、无关架构热点，以及 #4542 跟踪的 daemon L2 工作。
- 破坏性变更 / 迁移说明：不预期改变用户可见行为；后续迁移必须把生产派生接入显式工厂边界后，才能依赖这些新守卫。

## 关联 Issue

References #8083

</details>