### PR TITLE
fix(web-shell): translate legacy /skills invocations

### DIFF
--- a/packages/web-shell/README.md
+++ b/packages/web-shell/README.md
@@ -344,7 +344,7 @@ Chart/Data 控件、无数据提示和错误提示默认跟随 WebShell 语言�
 | `/approval-mode` | 本地实现            | 打开审批模式弹窗或直接切换审批模式。                                                                                    |
 | `/mode`          | 本地实现            | web-shell 本地别名，用于切换审批模式。                                                                                  |
 | `/mcp`           | 本地实现            | 打开 MCP 管理弹窗。                                                                                                     |
-| `/skills`        | 本地实现 + ACP 透传 | 无参数打开 skills 弹窗；带参数时透传给 daemon 执行。                                                                    |
+| `/skills`        | 本地实现 + ACP 透传 | 无参数或 `detail`/`details` 打开 skills 弹窗；其他参数转换为直接 skill 命令（`/skills review` → `/review`）。           |
 | `/tools`         | 本地实现            | 打开 tools 弹窗，列表展示工具名称、启用状态和 `description`。                                                           |
 | `/memory`        | 本地实现            | 打开 memory 弹窗，支持 `show`、`refresh`、`add user`、`add project` 等分支。                                            |
 | `/agents`        | 本地实现            | 打开 agents 弹窗，支持 `manage`、`create user`、`create project` 等分支。                                               |

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -6751,6 +6751,21 @@ describe('App session callbacks', () => {
     },
   );
 
+  it('converts /skills arguments to a direct skill command', async () => {
+    const { container } = renderApp();
+    await flush();
+
+    testState.prompt = '/skills bugfix';
+    await clickSubmit(container);
+    await flush();
+
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledWith(
+      '/bugfix',
+      expect.any(Object),
+    );
+    expect(container.querySelector('[data-testid="inline-panel"]')).toBeNull();
+  });
+
   it('opens plugin management tabs from the sidebar', async () => {
     mockWorkspaceActions.loadMcpStatus.mockResolvedValue({
       initialized: true,

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -6147,9 +6147,10 @@ export function App({
             if (!skillArg || skillArg === 'detail' || skillArg === 'details') {
               openPanel('skills');
             } else {
+              const skillPrompt = `/${skillArg}`;
               if (promptBlocked) {
                 return enqueuePrompt(
-                  text,
+                  skillPrompt,
                   images,
                   undefined,
                   commitComposerAccepted,
@@ -6157,7 +6158,7 @@ export function App({
                 );
               }
               return submitPromptFromEditor(
-                text,
+                skillPrompt,
                 images,
                 'Failed to send /skills command',
                 { inputAnnotations: metadata?.inputAnnotations },


### PR DESCRIPTION
## What this PR does

Web Shell now treats `/skills <skill-name> [arguments]` as a legacy spelling of the direct skill command and rewrites it to `/<skill-name> [arguments]` before submission. Bare `/skills` and the existing `detail` / `details` compatibility entries continue to open the Skills panel.

## Why it's needed

PR #4533 intentionally removed the daemon-side `/skills <name>` invocation path in favor of the direct `/<name>` form, but Web Shell retained its older rule of forwarding any parameterized `/skills` input unchanged. ACP consequently parses `/skills bugfix` as the built-in dialog command, ignores `bugfix`, and falls back to an `Available skills: ...` listing because it cannot render the interactive dialog. Translating the legacy spelling in Web Shell follows the migration established by #4533 while preserving compatibility for Web Shell users who still enter `/skills <name>`.

## Reviewer Test Plan

### How to verify

1. Submit bare `/skills` and confirm the Skills panel opens without sending a prompt.
2. Submit `/skills detail` or `/skills details` and confirm the same panel opens.
3. Submit `/skills bugfix` and confirm Web Shell sends `/bugfix`, does not open the Skills panel, and does not receive the built-in `Available skills: ...` listing.
4. While a turn is active, submit `/skills bugfix reproduce this` and confirm the queued prompt is `/bugfix reproduce this`.

### Evidence (Before & After)

Before: `/skills bugfix` reached ACP unchanged and produced the built-in `Available skills: ...` response.

After: `/skills bugfix` is submitted as `/bugfix`, matching the direct skill invocation documented by #4533.

Automated verification: the Skills-focused Web Shell tests pass (8/8), the Web Shell TypeScript check passes, and the repository build and full workspace typecheck pass.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22; Web Shell unit tests and TypeScript checks.

## Risk & Scope

- Main risk or tradeoff: parameterized `/skills` input is intentionally interpreted as a direct skill command rather than passed through verbatim.
- Not validated / out of scope: no daemon command behavior changes; no manual browser recording or Windows/Linux verification.
- Breaking changes / migration notes: none. This is a Web Shell compatibility bridge for the `/skills <name>` → `/<name>` migration introduced by #4533.

## Linked Issues

Related migration: #4533.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

Web Shell 现在把 `/skills <skill-name> [arguments]` 视为直接 skill 命令的旧写法，并在提交前转换为 `/<skill-name> [arguments]`。裸 `/skills` 以及现有的 `detail` / `details` 兼容入口仍然打开 Skills 面板。

## 为什么需要

PR #4533 有意移除了 daemon 侧 `/skills <name>` 的调用路径，统一改用直接的 `/<name>` 形式；但 Web Shell 仍保留旧规则，会把所有带参数的 `/skills` 输入原样透传。结果是 ACP 将 `/skills bugfix` 解析成内置面板命令，忽略 `bugfix`，并且因为 ACP 无法渲染交互式面板而退化为输出 `Available skills: ...` 列表。在 Web Shell 中转换旧写法，既遵循 #4533 确立的迁移方向，也兼容仍在输入 `/skills <name>` 的 Web Shell 用户。

## Reviewer 测试计划

### 如何验证

1. 提交裸 `/skills`，确认打开 Skills 面板且不发送 prompt。
2. 提交 `/skills detail` 或 `/skills details`，确认同样打开 Skills 面板。
3. 提交 `/skills bugfix`，确认 Web Shell 发送 `/bugfix`、不打开 Skills 面板，也不再收到内置的 `Available skills: ...` 列表。
4. 在已有 turn 运行时提交 `/skills bugfix reproduce this`，确认排队的 prompt 是 `/bugfix reproduce this`。

### 证据（修改前后）

修改前：`/skills bugfix` 原样到达 ACP，并产生内置的 `Available skills: ...` 响应。

修改后：`/skills bugfix` 以 `/bugfix` 提交，与 #4533 记录的直接 skill 调用方式一致。

自动验证：Web Shell 的 Skills 定向测试通过（8/8），Web Shell TypeScript 检查通过，仓库 build 和完整 workspace typecheck 通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Node.js 22；Web Shell 单元测试和 TypeScript 检查。

## 风险与范围

- 主要风险或取舍：带参数的 `/skills` 输入会被有意解释为直接 skill 命令，而不是原样透传。
- 未验证 / 范围外：不修改 daemon 命令行为；未进行浏览器人工录屏或 Windows/Linux 验证。
- Breaking change / 迁移说明：无。本改动是 Web Shell 针对 #4533 引入的 `/skills <name>` → `/<name>` 迁移提供的兼容桥接。

## 关联事项

相关迁移：#4533。

</details>
