### PR TITLE
fix(verify-pr): budget evidence capture in scope selection

### DIFF
--- a/.qwen/skills/verify-pr/SKILL.md
+++ b/.qwen/skills/verify-pr/SKILL.md
@@ -104,6 +104,13 @@ secondary claims. Budget by value:
 1. **A/B load-bearing proof of the central claim** (always, ~half the budget).
 2. **One or two wire-oracle harnesses** on the changed surface.
 3. **Targeted gates**: tests/typecheck of the affected workspace(s) only.
+4. **Capture the A/B and the matrix as they print** (~5 minutes, whenever
+   `QWEN_VERIFY_CHROMIUM=1`). This is a budget line, not an afterthought:
+   two live runs with the browser installed and working produced **zero**
+   images, because the instruction lived in the artifact contract while the
+   plan the agent follows is this list. Decide here how many captures the
+   round needs — normally two, at most a handful — and reserve the time.
+   See the artifact contract for the mechanics and the naming rule.
 
 Everything else is explicitly out of scope — and is **listed as not covered**
 in the report. Never let breadth eat the A/B: one proven load-bearing claim
@@ -572,6 +579,8 @@ central claim from being tested — say why.
    them. Cite the tables below by name instead of restating their numbers in
    prose: a number written twice is a number that can disagree with itself.
 3. **Central claim + A/B table** (cells, oracles, head vs control counts).
+   Reference the capture of those cells here by its filename — a table with
+   no witness beside it is the shape every report has had so far.
 4. **Corrections**, when an earlier review round or bot comment described
    the code inaccurately (a wrong ARIA role, a wrong mechanism, a
    misattributed cause). State the correct fact with its evidence and label

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -3382,6 +3382,36 @@ describe('qwen-triage verify round-3 hardening', () => {
     expect(soft).toBeGreaterThanOrEqual(Math.floor(agentMinutes * 0.8));
   });
 
+  // Third instance of one structural bug: an instruction placed outside the
+  // flow the agent actually follows. #7917 buried the /verify recommendation
+  // in a "local invocation ONLY" section; #8016 marked captures "Optionally";
+  // and captures still came out ZERO on two live runs (#7975, #8066) where
+  // the browser installed fine — because the plan the agent executes is the
+  // Scope-selection budget list, and that list had no capture line at all.
+  it('budgets evidence capture in scope selection, not only in the contract', () => {
+    const scope = verifySkill.slice(
+      verifySkill.indexOf('## Scope selection'),
+      verifySkill.indexOf('## Method'),
+    );
+    // A numbered budget item alongside the A/B, harnesses and gates.
+    expect(scope).toMatch(/^4\. \*\*Capture/m);
+    expect(scope).toContain('QWEN_VERIFY_CHROMIUM=1');
+    // Time reserved, and the failure that motivated it named — a rule
+    // stated without its failure reads as advice and gets skipped.
+    expect(scope).toContain('~5 minutes');
+    expect(scope).toContain('produced **zero**');
+    // Bounded: the cap exists so "budget it" does not become eight images.
+    expect(scope).toMatch(/normally two, at most a handful/);
+
+    // And the report has somewhere to put it, or a produced capture has no
+    // referent and the naming rule means nothing.
+    const structure = verifySkill.slice(
+      verifySkill.indexOf('### report.md structure'),
+      verifySkill.indexOf('## Hard rules'),
+    );
+    expect(structure).toContain('Reference the capture of those cells here');
+  });
+
   // Cleanups must never descend through a PR-writable parent, and an
   // outward-resolving hooks entry must be removed rather than reported.
   it('survives symlink escapes in the workspace cleanup', () => {


### PR DESCRIPTION
## What this PR does

Makes evidence capture a **line in the budget the agent actually plans against**, because #8016 shipped the capability and the first two live runs still produced zero images.

### The measurement

#8016 merged, then two `/verify` runs landed on it:

| PR | verdict | assertions | tables | **images** | browser step |
| --- | --- | ---: | ---: | ---: | --- |
| #7975 | ✅ passed | 40 | 31 | **0** | `Install evidence browser: success` |
| #8066 | ✅ passed | 407 | 0 | **0** | `Install evidence browser: success` |

The browser installed. `QWEN_VERIFY_CHROMIUM=1` was set. Nothing was captured.

### The cause — third instance of one structural bug

This is the same defect twice already fixed in this lane:

| | instruction was… | reach |
| --- | --- | ---: |
| #7917 | inside a section headed **"local invocation ONLY"** | 1/16 |
| #8016 | **"Optionally** … when text cannot carry the oracle" | 0/14 |
| **now** | a required deliverable in the **artifact contract** | **0/2** |

The artifact contract is a checklist of *outputs*. The plan the agent *executes* is the Scope-selection budget list:

```
1. A/B load-bearing proof (~half the budget)
2. One or two wire-oracle harnesses
3. Targeted gates
```

`grep -ciE 'evidence|png|capture|screenshot'` over that whole section: **0**. An agent budgeting by that list never allocates time for a capture, however firmly a later section says to produce one.

### The fix

Captures become **budget item 4**, with the four things a rule needs to survive contact with a real run:

- **time reserved** — ~5 minutes
- **the gate named** — whenever `QWEN_VERIFY_CHROMIUM=1`
- **the count bounded** — normally two, at most a handful (so "budget it" does not become eight)
- **its own failure stated** — two live runs with a working browser produced zero, because a rule without its reason reads as advice

And the report structure gets the matching half: the A/B table item now says to reference the capture of those cells by filename. **A produced image with nowhere to go is as dead as an unproduced one.**

## Why it's needed

The capture is the provenance artifact — a table is the agent's claim, a capture of the run is the witness. #7975 has 31 tables and no witness; #8066 has 407 assertions and no witness. That is exactly the gap between this lane's output and the maintainer-written rounds it is modelled on.

## Reviewer Test Plan

### How to verify

One test asserts the budget item exists **as a numbered item in Scope selection** (`/^4\. \*\*Capture/m` — position is the whole point, since the instruction already existed elsewhere), plus the gate, the time allowance, the count bound, and the report-side reference.

**Mutation-verified 4/4:**

| # | mutation | result |
| - | -------- | ------ |
| 1 | drop the budget item | red |
| 2 | drop `~5 minutes` | red |
| 3 | drop `normally two, at most a handful` | red |
| 4 | drop the report-side reference | red |

107/107 tests; prettier and eslint clean.

### What the same measurement says about #8010 — reported, not spun

The seven techniques from #8010 **do not appear in either report.** I do not read that as failure, and the distinction matters:

- Every one of them is **conditional** — *"when one fix bundles two changes"*, *"when the oracle is an instrument"*, *"when a PR adds a writer to a shared store"*, *"committed generated artifacts"*. #7975 is a session-management refactor; #8066 is an allowlist feature. Neither met those conditions.
- **#8010 is therefore not yet falsifiable** from these runs. The keyword hits I found were coincidental — #8066's "collision" is about MCP tool-name sanitization, #7975's "independent" is `Not independently exercised` in its *Not covered* list.

What both reports **do** show is older skill rules working, which is worth recording because it is the control for this whole exercise:

- **#8066** built a *naive-matcher counterfactual* and reported that it "fails open on both wildcard collision cells" while the real gate denies all three — a reference-implementation differential, exactly as the wire-oracle section prescribes.
- **#7975** ran the realpath check and found `node_modules/@qwen-code/qwen-code-core` resolving into the **HEAD** tree, then reasoned explicitly about whether that contaminates the base control (it concluded not, because the base paths call no new core API). That is the A/B section's ⚠️ symlink bullet firing correctly.

Unlike captures — which are unconditional whenever a harness ran — those are the conditional rules behaving as designed. The acceptance check for #8010 is a future round on a PR that *does* bundle two fixes or add a writer to a shared store.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

Skill text and its test. The acceptance check is the next `/verify` run: images per report going from 0 to a small purposeful number, and the A/B table carrying a filename beside it.

## Risk & Scope

- **Main risk:** budgeting captures competes with verification depth. Bounded three ways — ~5 minutes of a 120-minute budget, "normally two, at most a handful", and the publisher's hard 8-image cap. If the next runs produce eight decorative screenshots the fix is the bound, not the budget line.
- **This is still guidance, not a mechanism.** Nothing in the workflow *requires* an image; a run with none still publishes. That is deliberate — the alternative is failing a verification over a missing screenshot — but it means the third fix for this structural bug could still fail like the first two. If it does, the next step is making the artifact contract enforce it (publisher warns when a harness ran and `evidence/` is empty), not more prose.
- **Not validated / out of scope:** no run yet under this change. #8010's techniques are untested against a matching PR, stated above rather than buried.
- **Breaking changes / migration notes:** none.

## Linked Issues

Follow-up to #8016, whose acceptance criterion this addresses. Same structural defect as #7917. No issues closed.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

把证据截图变成**agent 真正据以规划的那份预算中的一项**——因为 #8016 已经把能力做好了，而合入后最初两次真实运行仍然产出 0 张图。

### 测量

#8016 合入后，两次 `/verify` 落地：

| PR | 判决 | 断言 | 表格 | **图片** | 浏览器步骤 |
| --- | --- | ---: | ---: | ---: | --- |
| #7975 | ✅ 通过 | 40 | 31 | **0** | `Install evidence browser: success` |
| #8066 | ✅ 通过 | 407 | 0 | **0** | `Install evidence browser: success` |

浏览器装上了。`QWEN_VERIFY_CHROMIUM=1` 也设了。什么都没截。

### 病因——同一个结构性错误的第三次

这与本车道已经修过两次的缺陷完全同型：

| | 指令当时位于…… | 触达率 |
| --- | --- | ---: |
| #7917 | 标题写着 **"local invocation ONLY"** 的小节内 | 1/16 |
| #8016 | **"Optionally**……当文本无法承载 oracle 时" | 0/14 |
| **本次** | **artifact contract**（交付物契约）中的必需项 | **0/2** |

artifact contract 是一份**产出物清单**。而 agent 真正**执行**的计划是 Scope selection 的预算表：

```
1. A/B 承重证明（约半个预算）
2. 一到两个 wire-oracle harness
3. 定向门禁
```

对该小节全文执行 `grep -ciE 'evidence|png|capture|screenshot'`：**0**。按这份清单规划预算的 agent 永远不会为截图分配时间，无论后面的章节把话说得多硬。

### 修法

截图成为**预算第 4 项**，并带上一条规则要在真实运行中存活所需的四样东西：**预留时间**（约 5 分钟）、**点明门槛**（`QWEN_VERIFY_CHROMIUM=1` 时）、**限定数量**（通常两张，最多数张，以免"给它预算"变成八张）、**写出它自身的失败**（两次浏览器可用的真实运行产出 0 张——不附带理由的规则读起来就是建议）。

报告结构补上对应的另一半：A/B 表格那一项现在要求**按文件名引用该组单元格的截图**。**产出了却无处引用的图片，和没产出一样是死的。**

## 为什么需要

截图就是**溯源凭证**——表格是 agent 的主张，运行截图是见证。#7975 有 31 张表格、零见证；#8066 有 407 条断言、零见证。这正是本车道产出与它所对标的维护者手写轮次之间的差距。

## 评审验证方案

一条测试断言该预算项**作为 Scope selection 中的编号条目**存在（`/^4\. \*\*Capture/m`——位置就是全部要点，因为该指令在别处早已存在），外加门槛、时间预留、数量上限、以及报告侧的引用。

**4/4 变异验证**：删除预算项、删除 `~5 minutes`、删除数量上限、删除报告侧引用，各使测试变红。

107/107 测试；prettier 与 eslint 干净。

### 同一次测量对 #8010 的说明——如实报告，不做美化

#8010 的七项技术在两份报告中**均未出现**。我不认为这是失败，而这个区分很重要：

- 它们**每一条都是条件性的**——"当一个修复捆绑了两处改动时"、"当 oracle 本身是一件仪器时"、"当 PR 向共享存储新增写入者时"、"提交进仓库的生成物"。#7975 是会话管理重构，#8066 是允许清单特性，两者都不满足这些条件。
- 因此**从这两次运行无法判定 #8010**。我找到的关键词命中都是巧合——#8066 的 "collision" 说的是 MCP 工具名净化冲突，#7975 的 "independent" 出现在其 *Not covered* 列表的 `Not independently exercised`。

而两份报告**确实**显示了更早的 skill 规则在生效，这一点值得记录，因为它是整件事的对照组：

- **#8066** 构建了**朴素匹配器反事实对照**，报告称它"在两个通配符冲突单元格上都 fail open"，而真实门禁三个全部拒绝——这正是 wire-oracle 小节所规定的参考实现差分。
- **#7975** 执行了 realpath 检查，发现 `node_modules/@qwen-code/qwen-code-core` 解析到了 **HEAD** 树，随后明确论证这是否污染 base 对照（结论是不污染，因为 base 路径不调用任何新的 core API）。这是 A/B 小节那条 ⚠️ 符号链接条目的正确触发。

与截图不同（只要跑过 harness 就无条件适用），上述是条件性规则按设计行事。#8010 的验收标准是未来某次针对**确实**捆绑了两处修复、或**确实**向共享存储新增写入者的 PR 的验证轮次。

### 测试平台

macOS ✅；Windows N/A；Linux N/A——skill 文本及其测试。验收标准是下一次 `/verify` 运行：每份报告的图片数从 0 变成一个少而有目的的数值，且 A/B 表格旁带有文件名。

## 风险与范围

- **主要风险**：为截图分配预算会与验证深度争夺资源。三重约束——120 分钟预算中的约 5 分钟、"通常两张，最多数张"、以及发布方硬性的 8 张上限。如果接下来的运行产出八张装饰性截图，该修的是上限而不是这条预算项。
- **这仍然是引导，不是机制。** 工作流中没有任何东西**强制**要求图片；没有图的运行照样发布。这是刻意的——替代方案是因为缺一张截图而让整次验证失败——但这也意味着**这个结构性缺陷的第三次修复仍可能像前两次一样失败**。若果真如此，下一步应是让 artifact contract 强制执行（跑过 harness 而 `evidence/` 为空时由发布方 warning），而不是再写更多散文。
- **未验证/范围外**：本改动下尚无运行。#8010 的技术尚未在匹配的 PR 上得到检验，此点已如实写在上方而非藏起。
- **破坏性变更**：无。

## 关联 Issue

#8016 的后续，处理的正是其验收标准。与 #7917 同型的结构性缺陷。不关闭任何 issue。

</details>
