### PR TITLE
fix(core): abort workflows during session shutdown

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -3099,6 +3099,38 @@ describe('Server Config (config.ts)', () => {
       expect(stop).toHaveBeenCalledOnce();
     });
 
+    it('aborts active workflows during shutdown', async () => {
+      const config = new Config(baseParams);
+      const stop = vi.fn().mockResolvedValue(undefined);
+      const internal = config as unknown as {
+        initializeInternal: () => Promise<void>;
+        toolRegistry: ToolRegistry;
+      };
+      vi.spyOn(internal, 'initializeInternal').mockImplementation(async () => {
+        internal.toolRegistry = { stop } as unknown as ToolRegistry;
+      });
+      await config.initialize();
+      const abortController = new AbortController();
+      const registry = config.getWorkflowRunRegistry();
+      registry.register({
+        runId: 'wf_1234',
+        meta: null,
+        status: 'running',
+        startTime: Date.now(),
+        outputFile: '/tmp/wf_1234.jsonl',
+        abortController,
+      });
+
+      await config.shutdown({
+        shutdownTelemetry: false,
+        skipSessionWriter: true,
+        strictResourceCleanup: true,
+      });
+
+      expect(abortController.signal.aborted).toBe(true);
+      expect(registry.get('wf_1234')?.status).toBe('cancelled');
+    });
+
     it('allows a later shutdown to retry incomplete resource cleanup', async () => {
       const config = new Config(baseParams);
       const stop = vi

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -4816,6 +4816,7 @@ export class Config {
       this.backgroundTaskRegistry.abortAll();
       this.monitorRegistry.abortAll({ notify: false });
       this.backgroundShellRegistry.abortAll();
+      this.workflowRunRegistry.abortAll();
 
       await this.cleanupArenaRuntime();
       await this.cleanupTeamRuntime();


### PR DESCRIPTION
## What this PR does

Adds active workflow runs to the existing session resource shutdown sequence. Running workflow entries transition to `cancelled` and their controllers are aborted alongside the other session-owned background resources, while already-terminal entries remain unchanged.

## Why it's needed

The experimental Dynamic Workflows runtime registers live run controllers, but session shutdown did not clean up that registry. The current foreground execution path often masks the omission through its parent signal; once runs gain an independent session owner, the same gap could leave orphaned dispatches and token usage. This establishes the shutdown invariant before the later background-execution stages tracked in the umbrella roadmap.

## Reviewer Test Plan

### How to verify

Initialize a session configuration, register a running workflow with an observable abort signal, and shut the session down. Confirm that the signal is aborted and the registry reports the run as cancelled. Confirm that existing workflow-registry coverage still leaves completed entries untouched and that repeated cleanup remains idempotent.

Verification completed locally:

- The new shutdown regression was observed failing before the production change and passing afterward.
- Session configuration tests: 475 passed.
- Workflow registry tests: 32 passed.
- Repository build and typecheck passed.
- Pre-commit Prettier and ESLint checks passed.

### Evidence (Before & After)

N/A — lifecycle-only change with no UI output.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

macOS, Node.js 24.14.1, package-local Vitest with the repository's default coverage configuration.

## Risk & Scope

- Main risk or tradeoff: Session shutdown now cancels any workflow still marked as running; this is the intended lifecycle boundary and uses the registry's existing idempotent cancellation behavior.
- Not validated / out of scope: No CLI E2E is claimed because foreground workflows already inherit the parent signal, which cannot distinguish this registry delegation before and after the fix. Detached/background run E2E belongs to the later ownership stage.
- Breaking changes / migration notes: None.

## Linked Issues

Part of #8105

<!-- qwen-dynamic-workflows-train:2026-07-30.v1:PR0:predecessor=gate0-approved -->

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

把活动 Workflow 纳入现有的会话资源关闭序列。仍在运行的 Workflow 会转为 `cancelled`，其 controller 会与其他会话级后台资源一起被中止；已经终态的记录保持不变。

## 为什么需要

实验性的 Dynamic Workflows Runtime 会注册运行中的 controller，但会话关闭此前没有清理该 registry。当前 foreground 执行通常会被父 signal 掩盖这个缺口；一旦后续引入独立的会话级 run owner，同一个遗漏就可能产生孤儿 dispatch 和 token 消耗。本 PR 先建立可靠的 shutdown 不变量，再继续总路线图中的后台执行阶段。

## Reviewer 测试计划

### 如何验证

初始化一个会话配置，注册带有可观察 abort signal 的运行中 Workflow，然后关闭会话。确认 signal 已被中止，registry 中的状态变为 cancelled。再确认既有 Workflow registry 测试仍保证已完成记录不受影响，并且重复清理保持幂等。

本地已完成以下验证：

- 新增 shutdown 回归测试在生产修复前稳定失败，修复后通过。
- 会话配置测试：475 条通过。
- Workflow registry 测试：32 条通过。
- 仓库 build 和 typecheck 通过。
- pre-commit 的 Prettier 和 ESLint 检查通过。

### Before / After 证据

N/A——仅生命周期改动，不涉及 UI 输出。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境

macOS、Node.js 24.14.1、使用仓库默认 coverage 配置的 package-local Vitest。

## 风险与范围

- 主要风险或取舍：会话关闭现在会取消所有仍标记为 running 的 Workflow；这是预期生命周期边界，并复用 registry 已有的幂等取消行为。
- 未验证 / 不在范围内：不声明 CLI E2E，因为 foreground Workflow 已继承父 signal，无法有效区分修复前后是否执行了 registry delegation。Detached/background run 的 E2E 属于后续 ownership 阶段。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

属于 #8105 的分阶段工作。

</details>
