### PR TITLE
docs(omni): 多模态实验架构设计（识别/Policy/Memory/存储）

### DIFF
--- a/docs/design/2026-07-29-multimodal-file-recognition-and-metadata.md
+++ b/docs/design/2026-07-29-multimodal-file-recognition-and-metadata.md
@@ -1,0 +1,922 @@
+# 多模态文件识别与元数据提取架构设计
+
+## 状态
+
+- 状态：Draft
+- 范围：Qwen Code 内部的多模态文件识别与元数据提取
+- 基线：`origin/main`（包含 PR #7484 的工具结果统一处理链路）
+- 后续设计：
+  [Omni 多模态数据处理 Policy 编排架构设计](./2026-07-29-omni-multimodal-policy-orchestration.md)、
+  [Omni 多模态 Memory 架构设计](./2026-07-29-omni-multimodal-memory.md)、
+  [Omni 受管媒体存储设计](./2026-07-30-omni-managed-media-storage.md)
+
+## 1. 背景
+
+Qwen Code 当前已经可以从多个入口接触媒体数据：用户可以附加本地文件，
+ACP 可以传入 image、audio 或 resource，内置工具、MCP、Extension 和 Skill
+也可能返回 inline data、本地路径、URL 或资源链接。
+
+这些入口目前没有共享一套文件身份与元数据语义：
+
+- 本地文件识别主要依赖文件名扩展名和声明的 MIME；
+- MCP 的 image、audio 和 blob 主要信任返回方声明的 MIME，`resource_link`
+  仍可能退化为文本；
+- 工具结果虽然已经通过 PR #7484 汇入统一的 `FunctionResponse`
+  处理点，但媒体引用尚未形成独立、结构化的候选集合；
+- 图片尺寸提取、二进制 magic bytes 判断等能力散落在不同用途的工具函数中，
+  还不能形成一致的音频、视频和图片元数据结果；
+- URL、base64、data URI 和 bytes 没有先统一成本地文件再识别的共同规则。
+
+因此，本设计在现有 Qwen Code 输入和工具执行链路上增加一个统一的
+`MediaRecognitionService`。它只负责回答两个问题：
+
+1. 一个显式提供的资源是否是图片、音频或视频；
+2. 如果是，它的统一元数据和稳定内容身份是什么。
+
+## 2. 目标与非目标
+
+### 2.1 目标
+
+- 支持本地路径、HTTP(S) URL、base64、data URI、bytes 和 MCP resource
+  等明确结构化的资源表示；
+- 不信任扩展名或声明 MIME，以文件内容作为最终类型判断依据；
+- 将 URL 和内存数据在受控条件下落为 Qwen Code 管理的本地文件，之后统一走
+  本地识别链路；
+- 为图片、音频和视频输出统一的公共元数据与各模态技术元数据；
+- 按统一、可追溯的公式，基于原始资源的技术 metadata 估算每个媒体资源进入
+  模型时占用的 token 数；
+- 以本地路径和内容哈希登记资源身份，并保留原始来源；
+- 在用户输入和工具返回两条现有主链路中各设置一个逻辑识别触发点；
+- 延续 PR #7484 的原则：各来源先归一化，再在公共漏斗中处理一次。
+- 通过顶层 `omni.ingestion` 配置 URL 本地化、sniff 预算、probe 预算和模型可见
+  metadata 投影；
+- 为每次识别记录 resolved ingestion 配置哈希和 probe 后端信息，支持实验复现。
+
+### 2.2 非目标
+
+本文不设计：
+
+- 文件是否能够上传给某个模型；
+- 模型路由、Vision Bridge、媒体 payload 拼装或 provider 限制；
+- 压缩、切分、抽帧、转码等预处理 policy；
+- 衍生物管理和 memory；
+- computation 调度；
+- 面向第三方的通用媒体平台或新的独立产品。
+
+识别结果以后可以被这些能力消费，但本设计不为它们预先引入抽象。
+本文只定义 metadata 的模型可见字段投影，不负责把投影插入具体 Provider 请求。
+
+## 3. 核心决策
+
+### 3.1 一个服务，两处逻辑触发
+
+识别器只有一个实现，位于 `packages/core`。调用它的逻辑时机只有两处：
+
+1. **用户输入完成结构化归一化之后**：TUI、非交互模式、ACP、Web Shell
+   等入口先把附件或明确资源引用转为 `MediaCandidate`，再统一识别；
+2. **工具输出完成统一归一化之后**：内置工具、MCP、Extension 和 Skill
+   先汇入同一个 normalized tool result，再对其中的 `mediaCandidates`
+   统一识别。唯一例外是内部 `fixed_policy` 调用：它的结果由发起调用的 policy
+   orchestrator 独占消费，在同一个“Tool 输出完成后”逻辑时机复用识别服务，但不再
+   进入公共 Tool result 漏斗，因此不构成第三个触发点。
+
+“两处触发”指逻辑边界，不要求所有客户端共享同一个物理函数。各客户端可以有
+自己的输入适配代码，但不得复制 sniff、probe 或 hash 逻辑。
+
+### 3.2 不在每种工具结果里分别识别
+
+工具适配器只承担结构转换：把明确类型的媒体块、媒体 artifact 或资源链接提取为
+`MediaCandidate`。它不判断 magic bytes、不运行 ffprobe，也不递归扫描任意对象。
+
+统一工具结果增加媒体候选旁路：
+
+```ts
+interface NormalizedToolResult {
+  responseParts: Part[];
+  mediaCandidates: MediaCandidate[];
+}
+```
+
+公共调度链路在工具输出归一化完成后只处理一次：
+
+```ts
+const normalized = normalizeToolResult(toolResult);
+
+if (normalized.mediaCandidates.length > 0) {
+  await mediaRecognitionService.recognizeAll(normalized.mediaCandidates);
+}
+```
+
+上述公共链路处理 model/client/普通 Tool 结果；`executionOrigin = fixed_policy` 在进入
+该链路前由 owning orchestrator 截获，避免相同 policy artifact 被识别两次。
+
+这不是“逐个理解每种工具结构”。Builtin、MCP、Extension 和 Skill
+只需在各自现有的 adapter 边界保留结构化媒体引用，后续识别完全共用。
+
+### 3.3 只处理显式候选，不扫描文本
+
+以下内容可以成为候选：
+
+- 用户显式附加或通过文件引用语法解析出的文件；
+- ACP 的 image、audio、resource 和 file resource link；
+- 工具返回的 inline data、file data、媒体 `ToolArtifact`；
+- MCP 的 image、audio、blob、resource 和 `resource_link`；
+- 其他入口已经明确标记为媒体资源的 path、URL、data URI 或 bytes。
+
+以下内容不能自动成为候选：
+
+- 普通对话文本中看起来像路径、URL 或 base64 的片段；
+- 工具文本输出中偶然出现的路径或 URL；
+- 为文件激活规则或 Skill 而产生的通用 `resultFilePaths` 全量列表；
+- 任意工具返回对象的递归字段扫描结果。
+
+媒体生产者应通过已有 artifact、typed part 或显式媒体引用表达资源；不能表达时，
+只在对应 adapter 增加结构映射，不把来源特例加入识别器。
+
+### 3.4 内容证据优先
+
+识别结果同时保留三种类型证据：
+
+- `declaredMimeType`：调用方或协议声明；
+- `extensionMimeType`：文件名或 URL 后缀推断；
+- `detectedMimeType`：magic bytes、容器签名和 probe 得到的结果。
+
+最终 `mediaType` 和 `detectedMimeType` 以内容证据为准。声明 MIME 和扩展名只用于
+提示、初筛与冲突告警，不能覆盖内容结果。
+
+### 3.5 顶层 Omni ingestion 配置
+
+识别与 metadata 配置直接放在 settings 顶层 `omni.ingestion`。它仍复用 Qwen
+Code 现有 settings 加载和 workspace trust，不增加独立配置文件、环境变量、CLI
+flag 或热更新。首版要求重启生效。
+
+本文是 `omni.ingestion` 的权威契约；Policy 编排文档中的完整 Omni 示例只做同步
+展示。Scope 沿用现有优先级
+`SystemDefaults < User < trusted Workspace < System`，未信任 workspace 不参与
+合并。普通对象和 scalar 按现有 deep merge/last-wins 处理，所有字段数组整体替换而
+不做 concat 或 union；resolved ingestion config hash 在合并、默认值补齐和校验后
+计算。
+
+配置只开放会影响实验结果、资源成本或等待时间的参数。以下正确性和安全边界不是
+开关：两个统一触发点、显式候选、内容证据优先、受管本地化、SHA-256 身份、
+redirect 重新校验、`.part` 原子落盘和下载后重新识别。
+
+```jsonc
+{
+  // Omni 实验配置的唯一顶层入口；不增加 omni.enabled。
+  "omni": {
+    // 配置结构版本，用于记录实验和兼容后续结构调整。
+    "schemaVersion": 1,
+
+    // 文件本地化、识别和 metadata 提取配置。
+    "ingestion": {
+      // 将 URL、base64 等资源转为本地受管文件的配置。
+      "localization": {
+        // HTTP(S) URL 的预检和下载配置。
+        "url": {
+          // 超过该大小时必须征求用户下载许可；默认 100 MiB，只允许调低。
+          "approvalThresholdBytes": 104857600,
+          // URL 预检最多读取的响应前缀，用于初步判断 magic bytes。
+          "preflightBytes": 65536,
+          // HEAD 或 Range 预检的超时时间。
+          "preflightTimeoutMs": 30000,
+          // 用户许可后，完整文件下载允许的最长时间。
+          "downloadTimeoutMs": 600000,
+          // URL 下载最多允许的重定向次数；每一跳都会重新安全检查。
+          "maxRedirects": 5,
+        },
+        // base64、data URI 和直接 bytes 输入的本地化配置。
+        "inline": {
+          // 允许解码并落盘的最大二进制大小；超限返回 resource_limit。
+          "maxDecodedBytes": 104857600,
+        },
+      },
+
+      // 文件内容类型识别配置。
+      "recognition": {
+        // sniff 阶段最多读取的本地文件字节数；不能改变内容证据优先原则。
+        "sniffMaxReadBytes": 65536,
+      },
+
+      // Metadata 的 Harness 内部提取与模型可见字段配置。
+      "metadata": {
+        // Harness 内部完整 metadata 的提取配置。
+        "extraction": {
+          // 图片 probe 的资源控制配置。
+          "image": {
+            // 图片尺寸、方向和动图信息提取的最长执行时间。
+            "timeoutMs": 10000,
+          },
+          // 音频 ffprobe 配置。
+          "audio": {
+            // 单个音频 probe 的最长执行时间。
+            "timeoutMs": 30000,
+            // ffprobe probesize；null 表示使用 ffprobe 默认值。
+            "probeSizeBytes": null,
+            // ffprobe analyzeduration；null 表示使用 ffprobe 默认值。
+            "analyzeDurationUs": null,
+          },
+          // 视频 ffprobe 配置。
+          "video": {
+            // 单个视频 probe 的最长执行时间。
+            "timeoutMs": 30000,
+            // ffprobe probesize；可实验探测精度与耗时的关系。
+            "probeSizeBytes": null,
+            // ffprobe analyzeduration；可调整流信息分析深度。
+            "analyzeDurationUs": null,
+          },
+        },
+
+        // 控制模型能够看到哪些 metadata，不影响 Harness 内部 policy 判断。
+        "modelVisibility": {
+          // 所有媒体都可以展示的公共字段。
+          "commonFields": [
+            "displayName",
+            "sizeBytes",
+            "detectedMimeType",
+            "container",
+            "probe.status",
+            "tokenEstimate.status",
+            "tokenEstimate.estimatedTokenCount",
+            "tokenEstimate.method",
+          ],
+          // 图片可以展示的技术字段。
+          "imageFields": [
+            "width",
+            "height",
+            "orientation",
+            "animated",
+            "frameCount",
+            "durationMs",
+          ],
+          // 音频文件级可以展示的字段。
+          "audioFields": ["durationMs", "bitRate"],
+          // 音频 stream 可以展示的字段。
+          "audioStreamFields": [
+            "codec",
+            "sampleRateHz",
+            "channels",
+            "channelLayout",
+            "bitRate",
+          ],
+          // 视频文件级可以展示的字段。
+          "videoFields": ["durationMs", "bitRate"],
+          // 视频 stream 可以展示的字段。
+          "videoStreamFields": [
+            "codec",
+            "width",
+            "height",
+            "frameRate",
+            "bitRate",
+          ],
+          // 是否向模型展示 MIME 冲突、probe 不完整等非致命警告。
+          "includeWarnings": true,
+          // 是否向模型展示内容哈希；内部身份计算不受该开关影响。
+          "includeContentHash": false,
+        },
+      },
+    },
+  },
+}
+```
+
+`metadata.extraction` 是 Harness 的完整事实，供 fixed policy 条件判断和后续 memory
+使用；`metadata.modelVisibility` 只控制模型可见字段。字段数组可以为空以进行
+metadata 消融实验，但不能导致内部字段停止提取。模型信封中的 `resourceId` 和
+`mediaType` 始终存在；`localPath` 和鉴权 header 永不暴露。
+
+## 4. 总体架构
+
+```mermaid
+flowchart LR
+  subgraph User["用户输入链路"]
+    U1["TUI / Non-interactive / ACP / Web Shell"] --> U2["输入 adapter"]
+    U2 --> U3["MediaCandidate[]"]
+  end
+
+  subgraph Tool["工具返回链路"]
+    T1["Builtin / MCP / Extension / Skill"] --> T2["来源 adapter"]
+    T2 --> T3["NormalizedToolResult"]
+    T3 --> T4["mediaCandidates"]
+  end
+
+  U3 --> R["MediaRecognitionService"]
+  T4 --> R
+  R --> S["解析为受管本地文件"]
+  S --> N["sniff: magic bytes / container"]
+  N --> P["probe: image / audio / video"]
+  P --> T["estimate tokens"]
+  T --> H["identity: local path + SHA-256"]
+  H --> M["MediaFileMetadata"]
+```
+
+服务内部是一条流水线，不拆成多个对外模块。URL 预检、sniff、probe 和 hash
+可以用私有 helper 实现，但对调用方只暴露候选输入和识别结果。
+
+## 5. 数据契约
+
+### 5.1 媒体候选
+
+```ts
+type MediaLocator =
+  | { kind: 'path'; path: string }
+  | { kind: 'url'; url: string; headers?: Record<string, string> }
+  | { kind: 'base64'; data: string }
+  | { kind: 'data_uri'; dataUri: string }
+  | { kind: 'bytes'; data: Uint8Array }
+  | { kind: 'mcp_resource'; serverName: string; uri: string };
+
+interface MediaCandidate {
+  locator: MediaLocator;
+  origin:
+    | {
+        kind: 'user';
+        surface: 'tui' | 'non_interactive' | 'acp' | 'web_shell';
+      }
+    | { kind: 'tool'; toolName: string; callId: string }
+    | {
+        kind: 'policy';
+        executionOrigin: 'fixed_policy';
+        toolName: string;
+        invocationId: string;
+        policyId: string;
+        stage: 'preprocessing' | 'transport_guard';
+      }
+    | {
+        kind: 'policy';
+        executionOrigin: 'model' | 'client';
+        toolName: string;
+        invocationId: string;
+      };
+  displayName?: string;
+  declaredMimeType?: string;
+  declaredSizeBytes?: number;
+}
+```
+
+`MediaCandidate` 表示“值得交给识别器验证的显式资源”，不表示已经确认是媒体。
+MCP adapter 必须在 `resource_link` 退化为文本之前保留它；HTTP(S) resource
+可归一为 URL，必须通过 MCP server 读取的资源使用 `mcp_resource` locator。
+
+### 5.2 识别结果
+
+```ts
+type MediaRecognitionResult =
+  | { status: 'recognized'; resource: RecognizedMediaResource }
+  | { status: 'not_media'; evidence: RecognitionEvidence }
+  | {
+      status: 'approval_required';
+      request: LargeDownloadApproval;
+    }
+  | {
+      status: 'failed';
+      code:
+        | 'invalid_source'
+        | 'access_denied'
+        | 'download_failed'
+        | 'sniff_failed'
+        | 'resource_limit';
+      message: string;
+    };
+
+interface RecognizedMediaResource {
+  resourceId: string;
+  metadata: MediaFileMetadata;
+}
+
+interface RecognitionEvidence {
+  declaredMimeType?: string;
+  extensionMimeType?: string;
+  detectedSignature?: string;
+  reason: 'unsupported_signature';
+}
+
+interface LargeDownloadApproval {
+  sourceUrl: string;
+  displayName?: string;
+  thresholdBytes: number;
+  knownSizeBytes?: number;
+  downloadedBytes: number;
+  canResume: boolean;
+}
+```
+
+`approval_required` 是正常控制流，不是错误。调用入口负责使用自身已有的确认机制
+询问用户；同意后以 `largeDownloadApproved` 选项重试同一候选，服务复用可续传的
+`.part`。没有交互能力的入口直接把该状态返回给上层，不得静默下载。
+
+### 5.3 公共元数据
+
+```ts
+interface MediaFileMetadata {
+  schemaVersion: 1;
+  ingestionConfigHash: string;
+  mediaType: 'image' | 'audio' | 'video';
+  displayName?: string;
+  sizeBytes: number;
+  declaredMimeType?: string;
+  extensionMimeType?: string;
+  detectedMimeType: string;
+  container?: string;
+  identity: {
+    algorithm: 'sha256';
+    contentHash: string;
+    localPath: string;
+  };
+  source: {
+    originalKind: MediaLocator['kind'];
+    originalRef?: string;
+    finalUrl?: string;
+    etag?: string;
+    lastModified?: string;
+  };
+  probe: {
+    status: 'complete' | 'partial' | 'unavailable' | 'failed';
+    backend?: string;
+    backendVersion?: string;
+    timeoutMs: number;
+    probeSizeBytes?: number;
+    analyzeDurationUs?: number;
+    message?: string;
+  };
+  tokenEstimate: MediaTokenEstimate;
+  metrics: MediaMetrics;
+  technical: ImageMetadata | AudioMetadata | VideoMetadata;
+  warnings: MediaRecognitionWarning[];
+}
+
+interface MediaRecognitionWarning {
+  code:
+    | 'declared_mime_mismatch'
+    | 'extension_mime_mismatch'
+    | 'probe_incomplete';
+  message: string;
+}
+
+interface MediaTokenEstimate {
+  status: 'estimated' | 'unavailable';
+  estimatedTokenCount?: number;
+  method?: 'dashscope_audio_7tps_v1' | 'dashscope_visual_32x32x2_v1';
+  inputs?:
+    | {
+        mediaType: 'audio';
+        durationMs: number;
+        tokensPerSecond: 7;
+      }
+    | {
+        mediaType: 'image' | 'video';
+        width: number;
+        height: number;
+        frameCount: number;
+        patchSize: 32;
+        mergeFactor: 2;
+      };
+  unavailableReason?: string;
+}
+
+interface MediaMetrics {
+  durationMs?: number;
+  width?: number;
+  height?: number;
+  maxWidth?: number;
+  maxHeight?: number;
+  frameRate?: number;
+  frameCount?: number;
+  bitRate?: number;
+  sampleRateHz?: number;
+  channels?: number;
+}
+```
+
+公共字段保证上层不必先理解来源格式。`resourceId` 是后续 policy 和模型引用资源
+的 opaque 标识；真实本地路径只在 Harness 内解析。`originalRef` 不保存 base64、
+data URI 正文或鉴权 header，只保存可安全展示的路径、URL 或 resource URI。
+
+`ingestionConfigHash`、probe backend、版本和实际参数用于区分不同实验条件。图片
+probe 不使用 `probeSizeBytes` 或 `analyzeDurationUs` 时省略对应字段。
+
+### 5.4 各模态技术元数据
+
+初版字段集合如下：
+
+```ts
+interface ImageMetadata {
+  kind: 'image';
+  width?: number;
+  height?: number;
+  orientation?: number;
+  colorSpace?: string;
+  hasAlpha?: boolean;
+  animated: boolean;
+  frameCount?: number;
+  loopCount?: number;
+  durationMs?: number;
+}
+
+interface AudioStreamMetadata {
+  index: number;
+  isDefault?: boolean;
+  codec?: string;
+  sampleRateHz?: number;
+  channels?: number;
+  channelLayout?: string;
+  bitRate?: number;
+  durationMs?: number;
+}
+
+interface AudioMetadata {
+  kind: 'audio';
+  durationMs?: number;
+  bitRate?: number;
+  streams: AudioStreamMetadata[];
+}
+
+interface VideoStreamMetadata {
+  index: number;
+  isDefault?: boolean;
+  codec?: string;
+  width?: number;
+  height?: number;
+  frameRate?: number;
+  bitRate?: number;
+  durationMs?: number;
+}
+
+interface VideoMetadata {
+  kind: 'video';
+  durationMs?: number;
+  bitRate?: number;
+  videoStreams: VideoStreamMetadata[];
+  audioStreams: AudioStreamMetadata[];
+}
+```
+
+GIF、APNG、animated WebP 等仍归类为 `image`，通过 `animated`、
+`frameCount` 和可获取的 `durationMs` 表达动态属性，不提升为 video。
+
+`metrics` 是 fixed policy 条件引擎使用的稳定扁平字段，不要求条件解析器理解 stream
+数组。图片直接使用图片 metadata；音频和视频的 primary stream 优先选择
+`isDefault = true`，否则选择 index 最小的 stream。视频 `width`、`height` 和
+`frameRate` 来自 primary video stream，`maxWidth` 和 `maxHeight` 是所有视频流的
+最大值；音频 `sampleRateHz` 和 `channels` 来自 primary audio stream。文件级
+duration/bitrate 优先使用容器值，缺失时再使用 primary stream 值。所有选择规则
+固定并写入测试，不能随 ffprobe 输出顺序变化。
+
+## 6. 识别流程
+
+### 6.1 来源解析与本地化
+
+不同 locator 先解析成受管本地文件：
+
+- `path`：经过现有路径访问控制，确认是可读取的普通文件；
+- `url`：先执行有上限的远端预检，确认可能是多模态资源后再下载；
+- `base64`、`data_uri`、`bytes`：显式解码并写入受管临时文件；decoded bytes
+  超过 `omni.ingestion.localization.inline.maxDecodedBytes` 时返回
+  `failed/resource_limit`；
+- `mcp_resource`：通过产生该引用的 MCP server 读取，得到 bytes 或 URL 后
+  进入对应分支。
+
+临时文件先写 `.part`，成功后原子重命名。解析结束后，后续步骤只接收本地路径，
+不再区分最初来源。
+
+### 6.2 sniff
+
+sniff 最多读取 `omni.ingestion.recognition.sniffMaxReadBytes`，并在预算内读取容器
+索引所需的少量区域，用 magic bytes 和容器签名判断：
+
+- 是否属于 image、audio 或 video；
+- 精确 MIME 和容器；
+- 声明 MIME、扩展名与内容是否冲突。
+
+sniff 不以文件扩展名作为最终结论。如果内容不属于支持的三种媒体，返回
+`not_media`；如果文件无法访问或内容损坏到无法判断，返回 `failed`。
+
+### 6.3 probe
+
+sniff 确认媒体类型后运行对应 probe：
+
+- 图片使用现有 `sharp` 能力提取尺寸、方向、色彩、alpha 和动图信息；
+- 音频和视频通过一个内部 probe 接口调用 `ffprobe`，再把容器与 stream 输出
+  归一为本设计的数据结构；
+- 图片、音频和视频分别使用 `omni.ingestion.metadata.extraction` 中的 timeout；
+- 音频和视频可以显式设置 `probeSizeBytes` 和 `analyzeDurationUs`，`null` 表示不向
+  ffprobe 传入对应参数；
+- **`ffmpeg`/`ffprobe` 是本实验分支的硬性运行依赖**：启动时检测二进制可用性并
+  记录版本，缺失时直接启动失败并给出安装指引，不提供无 ffprobe 的降级运行模式。
+  `probe.status = unavailable` 仅保留用于表达单个文件的探测器异常，不再表示
+  "环境缺少 ffprobe"；
+- probe 部分字段失败时返回 `partial`，不能抹掉已经由 sniff 确认的类型。
+
+### 6.4 Token 估算
+
+识别服务在技术 metadata 完成后生成 `tokenEstimate`。估算完全以**发送给模型的
+原始媒体资源本身**为依据，不考虑 Provider 服务端的 resize、抽帧或其他预处理；
+这也是 URL 资源统一下载到本地的原因之一——本地文件就是估算与投递的唯一事实。
+初版采用需求方指定的 DashScope 估算方式，并统一向上取整：
+
+```text
+audioTokens = ceil(durationMs / 1000 * 7)
+
+visualTokens = ceil(width * height * frameCount / (32 * 32 * 2))
+```
+
+其中：
+
+- 音频固定按每秒 7 tokens 估算；
+- 静态图片使用 visual 公式且 `frameCount = 1`；
+- animated image 使用 metadata 中的实际 `frameCount`；
+- 视频的 `width`、`height` 来自 primary video stream；`frameCount` 优先使用
+  容器/stream 声明的总帧数，缺失时按 `ceil(durationMs / 1000 * frameRate)` 推导；
+- 每个 policy 衍生物重新进入识别链路后，按衍生物自己的技术 metadata 重新估算，
+  不继承原资源的数值。
+
+原始长视频的估算值会显著大于 Provider 实际计费 token（服务端会抽帧），这是
+有意的保守上界：估算的用途是驱动 fixed policy 条件（"资源太大 → 先处理"），
+而不是复现 Provider 账单。估算方法带版本号（`method` 字段），后续如需引入
+服务端口径的第二套估算，可作为新 method 并存，不覆盖本方法。
+
+如果 `durationMs`、`width`、`height` 或 `frameRate`/`frameCount` 等必需字段缺失，
+返回 `status = unavailable` 并记录原因；不允许用猜测值填充。
+
+`resource.estimatedTokenCount` 条件字段直接读取
+`tokenEstimate.estimatedTokenCount`，它是唯一的估算值存放位置，不在 `metrics`
+中重复投影。它是有公式版本和输入依据的估算值，不等于 Provider 最终返回的实际
+token usage。
+
+### 6.5 identity 登记
+
+服务在读取或下载文件时流式计算 SHA-256；无法与 sniff/probe 共用读取过程时，
+再单独顺序读取一次。最终身份锚点是：
+
+```text
+localPath + sha256(content)
+```
+
+路径、URL、mtime、size、ETag 和 Last-Modified 都可能变化，只能作为快速校验或
+来源信息，不能替代内容哈希。相同内容可以来自多个位置；内容哈希相同表示相同
+文件版本，来源记录仍分别保留。
+
+识别成功后为当前 Harness 资源登记 opaque `resourceId`。该 ID 供后续 policy 和
+模型 Tool 引用，不替代 `localPath + contentHash` 的内部身份锚点。
+
+## 7. URL 规则与可配置许可边界
+
+URL 是唯一需要在"尚未形成完整本地文件"时先判断是否值得下载的来源。
+
+即使投递层统一采用 DashScope 官方临时上传（见 Policy 编排设计 §10.3），外部
+URL 也**不透传给模型**，仍然必须先下载本地化。原因是本地字节是全链路的唯一
+事实源：
+
+1. 技术 metadata 依赖完整本地文件（MP4 moov atom 常在文件尾，远程 Range 探测
+   不可靠）；
+2. token 估算完全基于原始资源的技术 metadata；
+3. policy 加工（裁剪、抽帧、音轨提取）必须操作本地字节；
+4. 完整 SHA-256 身份与 Memory 版本判断需要全部字节；
+5. oss URL 48h 过期后的重传字节只能来自本地对象库；
+6. 外部 URL 可能缺失 `Content-Length`/`Content-Type`、带鉴权或内容漂移，服务端
+   拉取不可靠且实验不可复现；受管上传 URL 则始终可用。
+
+### 7.1 有界预检
+
+服务先执行 HEAD；如果服务端不支持，再执行带 Range 的有界 GET。预检最多读取
+`omni.ingestion.localization.url.preflightBytes`，并服从 `preflightTimeoutMs`，
+不把完整响应留在内存中，并尽量使用 `Accept-Encoding: identity`。记录：
+
+- `Content-Length`；
+- `Content-Type`；
+- `Content-Disposition`；
+- `ETag`、`Last-Modified`；
+- redirect 后的 final URL；
+- 前缀 magic bytes。
+
+预检阶段仍以 magic bytes 为主要证据。HTTP `Content-Type` 只作为声明信息。
+如果前缀能确认是非媒体，返回 `not_media`；如果证据不足，返回
+`failed/sniff_failed`。两种情况都不为了“试一试”而下载完整文件。
+
+### 7.2 大小许可
+
+许可阈值来自：
+
+```text
+omni.ingestion.localization.url.approvalThresholdBytes
+```
+
+默认值是 `100 MiB = 100 * 1024 * 1024 bytes`。为保持此前“超过 100 MiB 必须
+询问”的边界，实验配置可以调低但不能调高。
+
+- `Content-Length > approvalThresholdBytes`：在完整下载前返回
+  `approval_required`；
+- `Content-Length <= approvalThresholdBytes` 或缺失，但继续写入将使文件超过该
+  阈值：在写入超限字节前暂停并返回 `approval_required`；
+- 用户拒绝：删除 `.part`，不产生本地资源；
+- 用户同意：从中断位置继续；服务端不支持 Range 时重新下载；
+- 整个过程按实际写入字节计数，不能只相信 HTTP header；
+- redirect 最多进行 `maxRedirects` 次；每一跳重新执行访问控制和大小判断；
+- 预检和完整下载分别使用配置中的超时，超时按下载失败返回。
+
+用户授权的是当前资源的一次下载，不是对域名或后续所有大文件的永久授权。
+
+### 7.3 下载后的权威识别
+
+远端预检只用于决定是否本地化。下载完成后必须从本地文件重新执行完整的
+sniff、probe 和 hash，最终 metadata 不直接采用预检结论。
+
+## 8. 两条现有链路的接入
+
+### 8.1 用户输入链路
+
+各输入面保留自己的语法与协议解析，在完成结构化解析后输出候选：
+
+| 当前入口           | adapter 责任                                        | 统一触发位置            |
+| ------------------ | --------------------------------------------------- | ----------------------- |
+| TUI 附件与 `@file` | 将已解析出的真实文件引用变为 path candidate         | `@` 命令解析完成后      |
+| 非交互输入         | 将 `readManyFiles` 已解析出的显式文件变为 candidate | 文件输入归一化完成后    |
+| ACP                | 保留 image、audio、resource 和 resource link 的结构 | `#resolvePrompt` 完成后 |
+| Web Shell          | 将上传控件或协议层的显式附件变为 candidate          | 请求输入归一化完成后    |
+
+入口不得对整段 prompt 做 URL/base64 猜测。普通文本保持普通文本。
+
+### 8.2 工具返回链路
+
+PR #7484 已经让内置工具、MCP 和 Extension 的模型可见结果先归一化为
+response parts，再由共享 helper 处理。Core scheduler 与 ACP `Session.runTool()`
+各有物理调用点，但都处理模型 ToolCall 的同一个逻辑结果边界。文件识别沿用这个
+架构：
+
+1. 各来源 adapter 在既有转换过程中，同时产出 `mediaCandidates`；
+2. Core scheduler 与 ACP `Session.runTool()` 都在 normalized tool result
+   形成后调用同一个识别 helper；
+3. `fixed_policy` 由 owning orchestrator 在同一 Tool 输出逻辑边界消费并调用该
+   helper，不再进入上述公共漏斗；
+4. model/client MediaPolicyTool 的原始 producer artifacts 由公共漏斗中的 policy
+   bridge 分支转换为候选，不再由通用 artifact adapter 重复提取；hook artifacts
+   仍按普通显式候选处理；
+5. 候选为空时直接跳过，不运行 sniff/probe；
+6. 识别结果登记为 `RecognizedMediaResource`，同时生成配置控制的模型可见 metadata
+   投影；
+7. 本文不改变媒体 `responseParts` 如何序列化给 Provider，后续由 policy 编排和
+   delivery 设计消费该资源与投影。
+
+具体来源映射：
+
+| 来源      | 候选来源                                      | 不能做的事                            |
+| --------- | --------------------------------------------- | ------------------------------------- |
+| Builtin   | 明确媒体 artifact、typed part                 | 枚举所有 `resultFilePaths` 并逐个识别 |
+| MCP       | image、audio、blob、resource、`resource_link` | 先把 link 变成文本再从文本反推        |
+| Extension | 统一 tool result 中的 typed part 或 artifact  | 在 extension 分支复制识别器           |
+| Skill     | Skill/工具显式发布的媒体 artifact             | 扫描 Skill Markdown 中的任意链接      |
+
+现有 `processToolResultImages` 仍承担 Vision Bridge 的既有职责。文件识别与它共享
+“归一化后统一处理”的位置，但不能混入其模型上传或图像转写逻辑。
+
+### 8.3 Metadata extraction 与 model visibility
+
+每个识别入口都只生成一份完整内部 metadata。`metadata.modelVisibility` 从该事实对象生成
+模型可见投影，不反向控制 probe：
+
+- model visibility 字段数组为空时，只隐藏模型 metadata，不关闭内部提取；
+- fixed policy 始终读取完整内部 metadata；
+- probe 或 token 估算所需字段不可得时保留对应状态，供 Fixed Policy condition
+  产生 `unavailable`；
+- `resourceId` 和 `mediaType` 始终保留在模型可见资源信封；
+- `localPath` 和鉴权 header 不允许进入 model visibility；
+- 首版 `source` 只用于内部 provenance，不提供 source visibility 配置；
+- 新 policy artifact 重新进入识别服务后，使用同一套 model visibility 配置。
+
+## 9. 失败语义
+
+| 场景                               | 结果                                        |
+| ---------------------------------- | ------------------------------------------- |
+| 候选内容不是图片、音频或视频       | `not_media`                                 |
+| 文件不存在、权限拒绝、不是普通文件 | `failed`                                    |
+| URL 预检确认不是媒体               | `not_media`，不完整下载                     |
+| URL 预检证据不足                   | `failed/sniff_failed`，不完整下载           |
+| URL 已知或实际大小超过配置许可阈值 | `approval_required`                         |
+| 用户拒绝大文件下载                 | 终止并清理 `.part`                          |
+| inline decoded bytes 超过配置上限  | `failed/resource_limit`                     |
+| sniff 成功、probe 不可用           | `recognized` + `probe.status = unavailable` |
+| sniff 成功、probe 只得到部分字段   | `recognized` + `probe.status = partial`     |
+| probe 超过配置 timeout             | 保留身份，probe 标为 partial 或 unavailable |
+| 声明 MIME/扩展名与内容不一致       | 采用 detected MIME，并记录 warning          |
+| 同一候选被多个入口重复提交         | 允许按内容哈希复用识别结果                  |
+
+单个候选失败不应让同批其他候选丢失结果。`recognizeAll` 保持输入顺序，并为每个
+候选返回独立状态。
+
+## 10. 安全与资源约束
+
+- 复用 Qwen Code 现有的文件访问、workspace trust、网络访问和用户确认机制；
+- 只读取普通文件，不读取 device、FIFO 或 socket；
+- URL 每次 redirect 后重新校验目标，不允许通过 redirect 绕过网络规则；
+- 鉴权 header 仅用于当前读取，不写入 metadata、日志或内容身份；
+- base64、data URI 和 bytes 只接受结构化字段，不尝试从任意文本中提取；
+- 解码、预检和下载均使用流式或有界缓冲，禁止把大文件整体复制到内存；
+- 临时文件只能在成功原子重命名后暴露，失败和拒绝路径清理 `.part`；
+- 内容哈希缓存若后续实现，只能用 size、mtime、inode 等作为命中提示，命中失效后
+  必须重新计算，不能把可变属性当成稳定身份。
+
+## 11. 与当前代码的对应关系
+
+本设计是对现有链路的收敛，不新建平行产品：
+
+- `packages/core/src/utils/fileUtils.ts` 当前的路径解析、`FileType` 和本地内容读取
+  继续作为文件入口，但媒体最终类型从扩展名/MIME 判断迁移到统一 sniff；
+- `packages/cli/src/ui/components/InputPrompt.tsx` 与
+  `packages/cli/src/ui/hooks/atCommandProcessor.ts` 保留 TUI/非交互输入语法，
+  只在解析完成后产生候选；
+- `packages/cli/src/acp-integration/session/Session.ts` 保留 ACP 协议解析，
+  避免 resource link 在识别前丢失结构；
+- `packages/core/src/tools/mcp-tool.ts` 和 `mcp-resource-content.ts` 负责把 MCP
+  typed content 转为候选，不再把声明 MIME 当作识别结论；
+- `packages/core/src/tools/tools.ts` 的 `ToolArtifact` 是工具显式媒体资源的主要
+  承载方式；通用 `resultFilePaths` 继续服务原有文件规则，不被扩大为媒体扫描器；
+- `packages/cli/src/config/settingsSchema.ts` 和 `packages/cli/src/config/config.ts`
+  加载顶层 `omni.ingestion`，执行专用结构与范围校验后传入 Core `Config`；
+- `packages/core/src/config/config.ts` 保存不可变的 normalized Omni 配置并提供只读
+  getter；识别结果记录 resolved ingestion config hash；
+- `packages/core/src/core/coreToolScheduler.ts` 中 `convertToFunctionResponse`
+  之后，以及 ACP `Session.runTool()` 形成 response parts 之后，是同一逻辑触发点在
+  两条执行链路中的物理接入位置；二者必须调用同一个识别 helper；
+- `packages/core/src/services/visionBridge` 保持既有职责，不承载通用文件识别。
+
+识别成功后的固定 policy、模型 Tool、衍生物回流与 DashScope 投递由
+[Omni 多模态数据处理 Policy 编排架构设计](./2026-07-29-omni-multimodal-policy-orchestration.md)
+继续定义。
+
+建议把新服务放在：
+
+```text
+packages/core/src/services/media-recognition/
+```
+
+目录内部可以按 locator 解析、sniff 和 probe 组织私有文件，但只对外导出服务、
+候选类型和结果类型，避免形成多个需要调用方自行编排的模块。
+
+## 12. 可验证性与验收标准
+
+### 12.1 统一识别
+
+- 同一媒体分别以 path、URL、base64、data URI 和 bytes 输入，最终
+  `mediaType`、`detectedMimeType`、技术元数据和 SHA-256 一致；
+- 将图片改成错误扩展名并声明错误 MIME，仍按 magic bytes 识别，并产生冲突告警；
+- GIF/APNG/animated WebP 返回 `mediaType = image` 且 `animated = true`；
+- 普通文本文件和伪装成媒体的文件返回 `not_media`。
+
+### 12.2 触发点
+
+- TUI、非交互、ACP 的显式媒体输入均在输入归一化后进入同一个服务；
+- Builtin、MCP、Extension 和 Skill 的显式媒体结果均在
+  normalized tool result 形成后进入同一个服务；
+- 候选为空的工具结果不运行 sniff 或 probe；
+- 工具文本中出现 URL、路径或 base64 时不触发识别；
+- MCP `resource_link` 在退化为文本前被保留为结构化候选；
+- 不通过 `resultFilePaths` 扫描工具产生的所有文件。
+
+### 12.3 URL 与大文件
+
+- 默认配置下，已知 101 MiB 的媒体 URL 在完整下载前请求一次用户许可；
+- 将许可阈值调低后，下载行为使用新阈值且 resolved config hash 发生变化；
+- 缺少或伪报 `Content-Length` 的响应在继续写入将超过配置阈值时暂停并请求许可；
+- 拒绝后 `.part` 被清理；允许后可继续，Range 不可用时能安全重启；
+- 非媒体 URL 只进行有界预检，不完整下载；
+- redirect 后重新执行安全和大小检查；
+- 下载结果使用本地完整文件重新 sniff/probe/hash。
+
+### 12.4 配置与 metadata 投影
+
+- inline decoded bytes 超过 `maxDecodedBytes` 时返回 `failed/resource_limit`；
+- sniff 读取不超过 `sniffMaxReadBytes`；
+- probe 使用配置的 timeout、probeSizeBytes 和 analyzeDurationUs，并记录实际值；
+- 音频 10 秒的 `estimatedTokenCount` 为 70；
+- 静态图片和视频严格按原始资源技术 metadata 及 `32 * 32 * 2` 公式向上取整；
+- 视频缺失容器总帧数时按 `duration * frameRate` 推导 frameCount；
+- 缺少 duration/width/height/frameRate 等必需字段时 token estimate 标为
+  unavailable，不伪造数值；
+- `estimatedTokenCount` 只存在于 `tokenEstimate` 一处，`metrics` 不重复投影；
+- model visibility allowlist 为空时，fixed policy 可用的内部 metadata 不减少；
+- `resourceId` 和 `mediaType` 始终可见，`localPath` 和鉴权 header 始终不可见；
+- 不支持的 model visibility 字段、非法超时和高于 100 MiB 的下载许可阈值在启动时失败。
+- scope 合并时 model visibility 字段数组整体替换，未信任 workspace 的 ingestion 配置不
+  生效。
+
+### 12.5 降级
+
+- 启动时缺少 `ffmpeg`/`ffprobe` 直接启动失败并给出明确报错，不进入无 probe 的
+  降级运行；
+- 单个损坏媒体的 probe 失败不影响同批其他候选；
+- 无交互入口遇到大文件时返回 `approval_required`，不自行授权。
+
+## 13. 待实现阶段确认的细节
+
+以下问题不影响本架构边界，在进入实现计划时再确定：
+
+- 初版完整支持的 image/audio/video magic bytes 与容器矩阵；
+- `ffmpeg`/`ffprobe` 的具体分发方式（系统依赖 + 启动检查，或随实验分支捆绑
+  `ffmpeg-static` 一类静态二进制）；两种方式都必须满足"缺失即启动失败"；
+- 内容哈希与 probe 结果的缓存实现。
+
+受管本地文件的目录布局、staging/quarantine、保留周期和垃圾回收由
+[Omni 受管媒体存储设计](./2026-07-30-omni-managed-media-storage.md) 单独定义。
+
+这些选择不得改变已经确定的约束：**显式候选、统一漏斗、内容证据优先、基于
+原始资源的可追溯 token 估算，以及内部 metadata 与模型可见字段分离**。

--- a/docs/design/2026-07-29-omni-multimodal-memory.md
+++ b/docs/design/2026-07-29-omni-multimodal-memory.md
@@ -1,0 +1,909 @@
+# Omni 多模态 Memory 架构设计
+
+## 状态
+
+- 状态：Draft
+- 范围：Qwen Code 实验分支中的图片、音频、视频文件级 Memory
+- 前置设计：
+  [多模态文件识别与元数据提取架构设计](./2026-07-29-multimodal-file-recognition-and-metadata.md)、
+  [Omni 多模态数据处理 Policy 编排架构设计](./2026-07-29-omni-multimodal-policy-orchestration.md)
+- 配套设计：
+  [Omni 受管媒体存储设计](./2026-07-30-omni-managed-media-storage.md)
+- 基线：`origin/main`，核对至 `2ce9da85bd99`
+
+## 1. 背景
+
+文件识别阶段已经把用户输入、工具结果、URL、base64 和 bytes 归一为带有完整
+SHA-256 与技术 metadata 的媒体资源；Policy 阶段又可以从这些资源产生音轨、切片、
+关键帧、转写、OCR、caption 和 summary 等结果。
+
+如果这些事实只存在于当前 Tool 返回或当前模型上下文中，后续调用无法稳定回答：
+
+- 当前文件已经提取过哪些 metadata；
+- 哪些衍生物来自哪个文件版本、哪个 policy 和哪段范围；
+- 一段转写、OCR 或 summary 覆盖了文件的哪些部分；
+- 当前问题是否已有可复用结果，还是仍需调用某个 policy；
+- 原文件发生变化后，哪些旧结果已经不应默认召回。
+
+因此，本设计在现有 Qwen Code 识别服务、Policy Tool 和请求构造链路上增加一个
+文件级的结构化 Memory。它不是新的产品、独立平台或 Agent 自主记忆系统；它只把
+Harness 已经确定的文件事实和成功 policy 结果组织成可追溯、可召回的文件内图。
+
+## 2. 目标与非目标
+
+### 2.1 目标
+
+- 只在两个确定的 Harness 生命周期边界收集 Memory：`FileRecognized` 与
+  `OmniPolicySucceeded`；
+- 建立文件、文件版本、policy 执行、媒体衍生物和文本结果之间的文件内关联；
+- 保留来源、完整内容哈希、处理参数、作用范围、覆盖度和 producer lineage；
+- 对成功 policy 的全部有效输出进行原子登记，不留下半套可召回结果；
+- 支持 Agent 主动调用 Tool 召回，以及 Harness 通过 side query 被动召回；
+- 两种召回模式复用同一查询服务和返回协议，并通过 `omni.memory.recall.mode`
+  切换；
+- 默认只召回当前文件版本的记录，文件变化后自动隔离旧版本结果；
+- 允许后续 policy 直接使用召回到的既有媒体衍生物，而不向模型暴露真实本地路径；
+- 记录 resolved Omni 配置、Tool 版本和最终参数，支持实验复现与训练数据追溯。
+
+### 2.2 非目标
+
+初版不设计：
+
+- `MediaTurnCompleted` 或其他轮次结束后的总结触发；
+- `MediaTurnTrace`，以及“模型在本轮实际看过什么”的完整轨迹；
+- 从主 Agent 最终回答中抽取结论并写入 Memory；
+- 允许 Agent 通过 Tool 直接创建、修改或删除 Memory；
+- Agent 驱动的 memory extraction、dream 或 consolidation；
+- 跨文件语义关联、相似文件合并或全库内容搜索；
+- `/learn` command 的任何接入；
+- computation 调度；
+- 具体存储后端、长期保留周期和垃圾回收实现。
+
+本设计中的 side query 只选择已经存在的记录，不能生成新结论并写回 Memory。
+
+## 3. 核心决策
+
+### 3.1 初版只有两个收集触发点
+
+初版只允许以下两类事实进入媒体 Memory：
+
+1. `FileRecognized`：统一识别器已经确认媒体类型、计算完整 SHA-256，并产出可用的
+   文件 metadata；
+2. `OmniPolicySucceeded`：一个 MediaPolicyTool 已成功执行，所有返回产物已经完成
+   descriptor、路径、类型、内容和 lineage 校验。
+
+这里的“触发点”是语义生命周期边界，不要求新增全局 EventBus。实现可以是识别服务
+和 policy orchestrator 对同一个 `MediaMemoryService` 的显式方法调用：
+
+```ts
+await mediaMemory.recordFileRecognized(payload);
+await mediaMemory.commitPolicySucceeded(payload);
+```
+
+这样可以沿用现有调用链、事务和错误传播，不建立另一套异步消息平台。
+
+### 3.2 Harness 独占写入，Agent 只读
+
+Memory 的写入事实必须来自可验证的 Harness 事件，而不是模型判断：
+
+- Agent 可以调用 MediaPolicyTool；Tool 成功后由 Harness 触发
+  `OmniPolicySucceeded`，间接增加 Memory；
+- Agent 可以调用召回 Tool 读取既有记录；
+- Agent 不能提交任意文本让 Memory 保存；
+- side query 只能返回候选记录 ID，不能生成新 Memory 条目；
+- 主 Agent 的回答、推理或猜测不自动进入 Memory。
+
+因此，初版不需要 `MediaTurnTrace`。只有未来要保存“本轮采用了哪些证据、模型形成了
+什么结论”时，才需要引入轮次级 trace 和第三个收集触发点。
+
+### 3.3 初版只建立文件内图
+
+每个原始文件形成一个独立 root graph。它的 metadata、policy 执行、衍生媒体和文本
+结果都挂在这个 root 下；初版不在两个 root file 之间建边。
+
+即使两个文件的完整 SHA-256 相同，也只能复用底层识别或 policy 缓存，不能合并
+它们的 `fileId` 或来源关系。这样可以保留“用户从哪里得到这个文件、在哪个上下文中
+使用它”的独立事实，避免内容相同但权限、来源或语义不同的资源被错误混为一体。
+
+### 3.4 文件身份与内容版本分离
+
+`fileId` 表示一个逻辑文件，`fileVersionId` 表示该逻辑文件的一份确定字节内容。
+
+初版只在以下场景确认是同一个逻辑文件：
+
+- 上游携带已知的稳定 `fileRef`，或者同一 project 内再次出现相同来源类型和规范化
+  locator（例如同一个本地路径或同一个 URL）；
+- URL、base64 或 bytes 本地化过程显式把来源和受管本地文件登记为同一资源；
+- policy 产物通过 `parentRef`、`rootFileId` 和 `producedBy` 明确建立 lineage；
+- 同一受管资源在当前系统内被再次解析，且携带既有持久引用。
+
+不同路径、不同 URL，或没有稳定 locator/lineage 的独立工具结果，即使名称、大小、
+ETag 或 SHA-256 相同，也作为另一个 `File` 处理。locator 只确定逻辑 File，不能证明
+其内容版本没有变化。
+
+在已经确认的同一 `fileId` 内，只有完整文件 SHA-256 相同才能确认是同一版本：
+
+- SHA-256 相同：复用现有 `FileVersion`；
+- SHA-256 不同：创建新版本，并把它设为当前版本；
+- URL、文件名、大小、mtime、ETag、声明 MIME 和部分哈希都不能单独证明版本相同。
+
+### 3.5 Metadata 是版本属性，不强制拆成节点
+
+技术 metadata 直接保存在 `FileVersion` 上即可。只有具有独立来源、范围或 producer
+语义的 policy 结果才成为独立节点。这样既能查询宽高、时长、流信息和 probe 状态，
+又不会把每个标量字段膨胀成图节点。
+
+## 4. 总体架构
+
+```mermaid
+flowchart TD
+  U["用户输入或普通工具结果"] --> R["统一媒体识别"]
+  P["MediaPolicyTool 原始产物"] --> R
+  R --> F{"资源来源"}
+  F -- "user / tool" --> FR["FileRecognized 直接提交"]
+  F -- "policy" --> ST["按 invocation 暂存识别结果"]
+
+  PT["Policy Tool 执行成功"] --> V["校验全部 required/returned outputs"]
+  ST --> V
+  V --> PS["OmniPolicySucceeded 原子提交"]
+
+  FR --> G["文件内 Media Memory Graph"]
+  PS --> G
+
+  AQ["Agent 主动调用 Recall Tool"] --> RS["共享 Recall Service"]
+  SQ["Harness side query 选择已有 entryId"] --> RS
+  G --> RS
+  RS --> RR["统一 RecallResult"]
+  RR --> AQ
+  RR --> SQ
+```
+
+写链路只由两个触发点驱动。主动召回和 side-query 召回是读链路，不构成新的收集
+触发点。
+
+## 5. 文件内逻辑数据模型
+
+### 5.1 概念图
+
+```text
+File
+  └── FileVersion
+        ├── technical metadata
+        ├── PolicyExecution
+        │     ├── final arguments / input scope / config hash
+        │     └── output references
+        ├── DerivedMedia (另一个带 lineage 的 File/FileVersion)
+        │     └── subsequent PolicyExecution
+        └── PolicyResult
+              ├── transcript
+              ├── OCR
+              ├── caption
+              └── summary
+```
+
+媒体衍生物在物理模型中仍使用 `File + FileVersion`，从而复用统一识别、版本和
+metadata 契约；`DerivedMedia` 只是它在父文件图中的角色。文本结果使用
+`PolicyResult`，不伪装成媒体文件。
+
+### 5.2 持久 ID 与 session resourceId
+
+当前 Policy 设计中的 `resourceId` 是会话内 opaque handle，用于让模型调用 Tool，
+不能作为跨 session 的持久主键。Memory 使用独立 ID：
+
+```ts
+type MediaFileId = string;
+type MediaFileVersionId = string;
+type MediaMemoryEntryId = string;
+type PolicyExecutionId = string;
+```
+
+召回某个仍可访问的媒体文件或衍生物时，Harness 把持久 `fileVersionId` 重新绑定到
+当前 session 的 `MediaResourceRegistry`，再返回新的或已存在的 `resourceId`。
+模型只看到 `resourceId` 和持久 evidence ref，不看到本地路径。
+
+### 5.3 File 与 FileVersion
+
+以下接口是逻辑契约，不预先绑定 SQLite、JSON 或其他存储格式：
+
+```ts
+interface MediaFileRecord {
+  fileId: MediaFileId;
+  rootFileId: MediaFileId;
+  origin: 'user' | 'tool' | 'policy';
+  currentVersionId: MediaFileVersionId;
+  createdAt: string;
+}
+
+interface MediaFileVersionRecord {
+  fileVersionId: MediaFileVersionId;
+  fileId: MediaFileId;
+  sha256: string;
+  mediaType: 'image' | 'audio' | 'video';
+  metadata: MediaFileMetadata;
+  source: MediaSourceProvenance;
+  recognition: {
+    ingestionConfigHash: string;
+    detectorVersion: string;
+    probeBackend?: string;
+    probeStatus: 'complete' | 'partial' | 'unavailable';
+  };
+  parentVersionId?: MediaFileVersionId;
+  producedByExecutionId?: PolicyExecutionId;
+  createdAt: string;
+}
+```
+
+`source` 保留来源类型和经过脱敏的 locator/protocol 信息。鉴权 header、token 和真实
+受管路径不进入模型可见协议。
+
+### 5.4 PolicyExecution
+
+```ts
+interface MediaPolicyExecutionRecord {
+  executionId: PolicyExecutionId;
+  invocationId: string;
+  sourceVersionId: MediaFileVersionId;
+  rootFileId: MediaFileId;
+  executionOrigin:
+    | {
+        kind: 'fixed_policy';
+        policyId: string;
+        stage: 'preprocessing' | 'transport_guard';
+      }
+    | { kind: 'model' | 'client' };
+  toolName: string;
+  toolVersion: string;
+  finalArguments: Record<string, unknown>;
+  inputScope: MediaScope;
+  omniConfigHash: string;
+  outputRefs: MediaMemoryEntryId[];
+  startedAt: string;
+  completedAt: string;
+}
+```
+
+Memory 记录的是通过 Tool 原生 schema、`defaultArguments`、`lockedArguments` 和
+runtime resolver 之后的最终参数，不只记录用户原始配置或模型原始参数。
+
+### 5.5 Scope、channel 与 coverage
+
+同一结果必须明确“它描述了文件的哪一部分”和“覆盖了哪些信息通道”：
+
+```ts
+interface MediaScope {
+  temporal?: { startMs: number; endMs: number };
+  spatial?: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    unit: 'normalized';
+  };
+  frameRange?: { start: number; end: number };
+  streamIndexes?: number[];
+  audioChannels?: number[];
+}
+
+type MediaChannel =
+  | 'technical_metadata'
+  | 'visual'
+  | 'acoustic'
+  | 'speech_text'
+  | 'onscreen_text';
+
+interface MediaCoverage {
+  mode: 'complete' | 'continuous' | 'sampled' | 'partial' | 'summary';
+  scope: MediaScope;
+  sampleCount?: number;
+  sampleRate?: number;
+}
+```
+
+空 `MediaScope` 表示整个文件版本。示例：
+
+- 完整音频转写：`speech_text + complete + {}`；
+- 视频 15s 到 30s 的切片：`visual/acoustic + continuous + temporal`；
+- 每 10 秒抽一帧：`visual + sampled + temporal + sampleRate`；
+- 图片局部 OCR：`onscreen_text + partial + spatial`；
+- 全片 summary：`visual/acoustic + summary + {}`。
+
+### 5.6 统一 Policy 输出记录
+
+Memory 不解析 `llmContent` 寻找结果。每个可持久化输出必须来自
+`PolicyArtifactBatch`，并由 Tool descriptor 和 bridge 归一为：
+
+```ts
+interface NormalizedPolicyOutput {
+  outputId: MediaMemoryEntryId;
+  kind: 'derived_media' | 'policy_result';
+  role: string;
+  artifactRef?: {
+    storage: 'managed' | 'workspace';
+    managedId?: string;
+    workspacePath?: string;
+    mimeType: string;
+    sizeBytes: number;
+  };
+  inlineText?: string;
+  /** 有损/表达变换输出随附的处理与降质披露文本（见 Policy 设计 3.2）。 */
+  disclosure?: string;
+  scope: MediaScope;
+  channels: MediaChannel[];
+  coverage: MediaCoverage;
+  parentVersionId: MediaFileVersionId;
+  producedByExecutionId: PolicyExecutionId;
+}
+```
+
+初版至少需要稳定表达这些 role：
+
+- 文本结果：`transcript`、`ocr`、`caption`、`summary`；
+- 媒体结果：`keyframe`、`clip`、`extracted_audio`；
+- 其他实验产物由 MediaPolicyTool descriptor 声明稳定 role，不能依赖展示标题猜测。
+
+媒体结果必须使用 artifact 引用并重新经过文件识别。小型 UTF-8 文本可以内联保存；
+超过 `collection.maxInlineTextBytes` 的文本必须由 policy 输出受管文本 artifact。两者都
+必须带 scope、channel、coverage 和 producer，不能只存一段无来源文本。
+
+## 6. 收集触发点一：FileRecognized
+
+### 6.1 触发条件
+
+只有识别结果满足以下条件时才产生 `FileRecognized` payload：
+
+- `mediaType` 已确定为 image、audio 或 video；
+- 完整文件 SHA-256 已计算；
+- 本地化和安全检查已完成；
+- 公共 metadata 可用；
+- probe 即使降级，也有明确的 `complete`、`partial` 或 `unavailable` 状态。
+
+`not_media`、`approval_required`、下载失败、hash 失败或无法建立受控引用的候选不写入
+Memory；它们只进入识别日志或用户可见错误。
+
+### 6.2 写入内容
+
+一次成功触发至少登记：
+
+- 逻辑 `File` 和当前 `FileVersion`；
+- 来源类型、显式 lineage 和本地化关系；
+- 完整 SHA-256；
+- detected/declared/extension MIME 与冲突告警；
+- 图片、音频或视频技术 metadata；
+- versioned token estimate、估算方法和实际估算输入；
+- probe 状态、后端和 resolved ingestion config hash；
+- 如果是 policy 媒体产物，则登记 parent、root 和 producer invocation。
+
+### 6.3 普通来源直接提交
+
+用户输入和普通工具结果没有等待中的 policy 事务。识别成功后可以立即、幂等地提交
+File 与 FileVersion。相同事件重试不会生成重复版本。
+
+### 6.4 Policy 媒体产物先暂存
+
+Policy Tool 可能声明多个必须同时成立的输出。例如一次视频处理同时产生音轨、
+关键帧和索引文件。不能在第一个媒体完成识别时就把它暴露为可召回节点，否则后续
+必需产物失败会留下孤儿或半套结果。
+
+因此，policy-origin 的 `FileRecognized` 结果按 `invocationId` 进入 staging：
+
+```text
+原始 Tool artifacts
+  → 每个媒体 artifact 识别 / hash / probe
+  → staging[invocationId]
+  → 全部 descriptor 与文本产物校验
+  → OmniPolicySucceeded 原子提交
+```
+
+staging 不是第三个触发点，也不是持久可召回图；它只是
+`OmniPolicySucceeded` 事务的准备状态。
+
+## 7. 收集触发点二：OmniPolicySucceeded
+
+### 7.1 固定调用与模型调用共用
+
+所有 policy 都以 Qwen Code Tool 实现；Fixed Policy 与 Transport Guard policy 也
+通过 `execute` 运行。因此，固定调用、模型 ToolCall 和 direct client 调用在成功后
+都进入同一个 `OmniPolicySucceeded` 逻辑边界，不为不同调用来源复制 Memory 写入代码。
+
+### 7.2 成功门槛
+
+只有同时满足以下条件才允许触发：
+
+- Tool 返回没有 `error`，也没有取消或 timeout；
+- descriptor 中所有 required output 已出现；
+- 所有实际返回 output 都命中 descriptor；
+- 所有 artifact 都通过 managed/workspace path、文件存在性和权限校验；
+- 所有媒体 artifact 都已完成识别、完整 hash 和 probe 状态登记；
+- 所有文本 artifact 都可读取、编码有效且未越过对应资源预算；
+- 每个 output 的 role、scope、channels、coverage 和 producer 已归一化；
+- source version、最终参数、execution origin、policy ID、stage 和配置哈希都已确定。
+
+Policy 文档定义的 delivery `include` 与 `retain` 只决定是否进入当前模型输入，不决定
+是否进入 Memory。一个成功 invocation 的有效输出都会被登记；`source: omit` 也只
+影响投递，不删除 source 的 Memory。
+
+### 7.3 原子提交内容
+
+一次事务同时写入：
+
+1. `PolicyExecution`；
+2. source/root/version 关系；
+3. staging 中已经识别的媒体衍生文件与版本；
+4. transcript、OCR、caption、summary 等 policy-native 文本结果；
+5. execution 到全部 output 的 producer edge；
+6. parent、root、scope、channel、coverage 和配置 provenance。
+
+任一步失败都不提交本 invocation 的 active Memory。已产生的文件按 Policy 设计进入
+quarantine/cleanup；失败记录可以进入独立运行日志，但不能伪装成可召回 Memory。
+
+### 7.4 禁止从模型文本反推产物
+
+以下内容不能成为 `OmniPolicySucceeded` 的输出来源：
+
+- `llmContent` 中提到的路径、URL 或摘要；
+- `returnDisplay` 中的 Markdown；
+- PostToolUse hook 追加的 artifact；
+- 对任意返回对象进行递归扫描发现的字段。
+
+Memory 只消费 Policy 文档定义的原始 `PolicyArtifactBatch`。这样能证明 producer，
+也不会把 hook 或 UI 产物错误关联到 MediaPolicyTool。
+
+## 8. 图关系与查询边界
+
+初版需要支持以下关系：
+
+| 关系              | 含义                                   |
+| ----------------- | -------------------------------------- |
+| `HAS_VERSION`     | File 拥有不可变 FileVersion            |
+| `CURRENT_VERSION` | File 当前默认召回的版本                |
+| `DERIVED_FROM`    | 衍生媒体版本来自某个父版本             |
+| `PRODUCED_BY`     | 衍生媒体或 PolicyResult 由某次执行产生 |
+| `EXECUTED_ON`     | PolicyExecution 的输入文件版本         |
+| `HAS_OUTPUT`      | PolicyExecution 的结构化输出           |
+
+所有遍历必须被 `rootFileId` 限制。查询一个文件可以沿 lineage 查看它的祖先、后代、
+执行和结果，但不能自动跳到另一个 root graph。相同 hash 的缓存映射不是图关系。
+
+## 9. Recall 设计
+
+### 9.1 一个 Recall Service，两种触发方式
+
+主动与被动召回共享：
+
+- 同一个项目作用域和权限检查；
+- 同一个 file/version 解析器；
+- 同一个查询、过滤和预算逻辑；
+- 同一个 `MediaMemoryRecallResult`；
+- 同一个 current-version 默认规则；
+- 同一个持久 fileVersion 到 session resourceId 的绑定器。
+
+两者的差异仅在于谁发起查询：
+
+- `active`：Agent 调用 `omni_recall_media_memory` Tool；
+- `sideQuery`：Harness 在构造相关模型请求前运行 side query，自动选择已有记录。
+
+配置 `mode` 用于实验切换。`active` 模式不自动注入，`sideQuery` 模式不向模型暴露
+主动召回 Tool，避免一次实验同时混入两种策略。
+
+### 9.2 主动召回
+
+主动 Tool 最小输入包括：
+
+```ts
+interface MediaMemoryRecallRequest {
+  resourceIds: string[];
+  query: string;
+  kinds?: Array<'metadata' | 'derived_media' | 'policy_result' | 'execution'>;
+  roles?: string[];
+  scope?: MediaScope;
+  includeHistoricalVersions?: boolean;
+  limit?: number;
+}
+```
+
+`resourceIds` 必须属于当前 session 已授权资源。服务先解析为持久 file/version，再只在
+对应 root graph 内查询。模型不能用任意路径、hash 或 fileId 扫描整个项目。
+
+召回返回的可用媒体衍生物会绑定出当前 session 的 `resourceId`，Agent 随后可把它传给
+另一个 MediaPolicyTool。召回本身不复制文件、不创建新 File，也不触发 policy。
+
+### 9.3 被动 side-query 召回
+
+被动召回只处理当前请求已经显式引用并完成识别的文件。它不从普通文本猜路径，也不
+跨文件搜索项目中的其他媒体。
+
+流程为：
+
+```text
+当前请求的显式 resourceIds
+  → 解析为当前 FileVersion
+  → 从对应文件内图生成有界 candidate manifest
+  → runSideQuery(JSON schema)
+  → side query 只返回 candidate entryId
+  → 校验 ID 必须属于 manifest
+  → Harness 按统一协议物化结果并注入主模型请求
+```
+
+candidate manifest 可以包含 entry ID、kind、role、scope、channels、coverage、简短
+description 和 producer 摘要，但不把原始媒体、完整大文本、本地路径或密钥发送给
+selector。
+
+side query 不允许返回自由文本结论，也不能要求创建新条目。未知 ID、跨 root ID、
+超出 `maxSelectedEntries` 或 schema 不合法的结果整体拒绝。
+
+为了保证实验条件确定，选中结果必须在相关主模型请求发送前完成注入；不能在模型已
+开始回答后再把迟到结果塞进后续 ToolResult turn。超时或 selector 失败时本次按空召回
+继续，并记录明确的失败原因和配置哈希。
+
+### 9.4 最小返回协议
+
+```ts
+interface MediaMemoryRecallResult {
+  status: 'hit' | 'partial' | 'miss';
+  files: Array<{
+    fileId: MediaFileId;
+    fileVersionId: MediaFileVersionId;
+    current: boolean;
+    mediaType: 'image' | 'audio' | 'video';
+  }>;
+  entries: Array<{
+    entryId: MediaMemoryEntryId;
+    kind: 'metadata' | 'derived_media' | 'policy_result' | 'execution';
+    role?: string;
+    content?: string;
+    resourceId?: string;
+    scope: MediaScope;
+    channels: MediaChannel[];
+    coverage: MediaCoverage;
+    evidenceRefs: Array<{
+      fileVersionId: MediaFileVersionId;
+      executionId?: PolicyExecutionId;
+    }>;
+    provenance: {
+      toolName?: string;
+      toolVersion?: string;
+      policyId?: string;
+      stage?: 'preprocessing' | 'transport_guard';
+      omniConfigHash: string;
+    };
+  }>;
+  gaps: Array<{
+    scope: MediaScope;
+    channels: MediaChannel[];
+    reason: 'not_processed' | 'partial_coverage' | 'artifact_unavailable';
+  }>;
+  nextPolicyActions?: Array<{
+    toolName: string;
+    resourceId: string;
+    arguments: Record<string, unknown>;
+    reason: string;
+  }>;
+}
+```
+
+`partial` 表示已有相关结果，但请求范围或 channel 仍存在缺口。`nextPolicyActions` 只
+提供可执行建议，由 Agent 决定是否调用；side query 和 Recall Service 都不能自动执行
+这些 Tool。
+
+### 9.5 Current-version-first
+
+默认查询只返回当前 `FileVersion` 及其派生图。历史版本记录可以为 provenance 保留，
+但只有主动请求或配置允许时才进入候选。
+
+如果当前版本没有结果、旧版本有结果，默认返回 `miss` 或带明确历史提示的 `partial`，
+不能把旧结果当成当前文件事实。这样文件更新后不会静默复用失效 transcript、OCR、
+关键帧或 summary。
+
+## 10. 顶层 Omni 配置
+
+Memory 配置直接放在现有实验配置的 `omni.memory` 下，不并入 Qwen Code 当前的
+managed auto-memory 配置，也不增加独立配置文件、环境变量或 CLI flag。初版没有
+`omni.enabled` 或 `memory.enabled`；收集始终按两个确定触发点执行，默认 recall 模式
+为 `active`。
+
+以下 JSONC 展示初版需要的细粒度实验控制。每个字段都在 scope 合并、默认补齐和
+校验后进入 resolved Omni config hash。
+
+```jsonc
+{
+  // Omni 实验配置的唯一顶层入口；不增加总开关。
+  "omni": {
+    // 配置结构版本，用于记录实验并兼容后续 schema 调整。
+    "schemaVersion": 1,
+
+    // 文件级多模态 Memory 的收集与召回配置。
+    "memory": {
+      // 两个固定收集触发点共用的持久内容边界。
+      "collection": {
+        // 文本不超过该字节数时可直接存入 PolicyResult；更大的文本必须由
+        // policy 产出受管 text artifact，不能静默截断后保存。
+        "maxInlineTextBytes": 65536,
+      },
+
+      // 控制已收集记录如何暴露给模型，不影响底层事实收集。
+      "recall": {
+        // active 由 Agent 调用 Recall Tool；sideQuery 由 Harness 自动选择并注入。
+        "mode": "active",
+
+        // 单次统一 RecallResult 最多返回的 entry 数量。
+        "maxEntries": 12,
+
+        // 单次返回给主模型的文本内容总字符预算；超过时按确定顺序裁剪并报告 gap。
+        "maxTextChars": 24000,
+
+        // 默认允许召回的节点类型；高优先级 settings scope 对该数组整体替换。
+        "kinds": ["metadata", "derived_media", "policy_result", "execution"],
+
+        // false 表示默认只召回当前文件版本；true 用于显式历史对照实验。
+        "includeHistoricalVersions": false,
+
+        // Agent 主动调用 Recall Tool 时的额外资源边界。
+        "active": {
+          // 一次 ToolCall 最多查询多少个当前 session 资源，防止无界批量扫描。
+          "maxFilesPerCall": 8,
+        },
+
+        // mode 为 sideQuery 时使用的 selector 参数。
+        "sideQuery": {
+          // null 表示沿用 runSideQuery 的 fast-model 优先选择；字符串可固定实验模型。
+          "model": null,
+
+          // selector 必须在该时间内返回；超时后本次空召回并继续主请求。
+          "timeoutMs": 30000,
+
+          // 发送给 selector 的候选 entry 上限；候选仍只来自当前显式文件。
+          "maxCandidateEntries": 100,
+
+          // selector 最多可以返回的合法 entryId 数量，且不能大于 maxEntries。
+          "maxSelectedEntries": 12,
+
+          // side query 的最大请求尝试次数；1 最便于控制实验成本和延迟。
+          "maxAttempts": 1,
+        },
+      },
+    },
+  },
+}
+```
+
+### 10.1 配置校验
+
+启动时至少校验：
+
+- `mode` 只能为 `active` 或 `sideQuery`；
+- 所有数量、文本和 timeout 预算必须为正数；
+- `maxSelectedEntries <= maxEntries <= maxCandidateEntries`；
+- `kinds` 只能包含已知节点类型且不能为空；
+- `model` 为 `null` 或非空字符串；
+- 未信任 workspace 的 Omni 配置不参与合并；
+- 数组整体替换，不做 concat 或 union。
+
+与前两篇设计一致，scope 优先级为
+`SystemDefaults < User < trusted Workspace < System`。无效配置启动失败，不静默回退到
+另一种召回模式。
+
+## 11. 版本、失效与复用
+
+### 11.1 文件变化
+
+同一逻辑文件得到不同完整 SHA-256 时：
+
+1. 创建新的不可变 `FileVersion`；
+2. 更新 `CURRENT_VERSION`；
+3. 旧版本及其执行和产物保留为历史 provenance；
+4. 默认 recall 排除旧版本；
+5. 新版本必须重新运行需要的 policy，不能只按路径或名称复用旧结果。
+
+### 11.2 不合并不同文件
+
+两个独立 `fileId` 即使 SHA-256 一致，也保留两个 File 和两套来源。允许复用的是：
+
+- sniff/probe/hash 的计算缓存；
+- 确定性 policy 结果及其底层 artifact；
+- 受管文件的物理存储块。
+
+复用时每个 File 仍保留自己的 root、source 和 lineage 引用，不能把一个文件的
+权限或 provenance 泄漏给另一个文件。
+
+### 11.3 Policy 结果复用键
+
+可复用 policy 结果的复用键必须与 11.2 的跨文件复用语义一致，因此以**内容身份**
+而不是 File 作用域的 version ID 为基础：
+
+```text
+source content sha256
++ tool name and implementation version
++ tool settings hash（影响结果的 Tool 级配置）
++ schema 校验后的 final arguments
++ input scope
++ resolved Omni config hash 中影响结果的部分
+```
+
+`fileVersionId` 是 File 作用域的主键，两个独立 File 的 version ID 必然不同；如果
+把它放进复用键，11.2 允许的跨文件确定性复用将永远无法命中。以 sha256 为键则
+同一份字节在任何 File 中出现都能复用底层计算，同时每个 File 仍写入自己的
+PolicyExecution 与 provenance（记录 cache hit 与 `reusedExecutionId`），不共享
+图节点。
+
+相同 `invocationId` 重放必须幂等；独立 cache hit 可以记录一次明确的
+`reusedExecutionId`/cache-hit 运行事实，但不能复制 FileVersion 或 PolicyResult
+节点。精确 cache key 的字段裁剪在实现计划中确定，不能牺牲上述 provenance。
+
+## 12. 事务与失败语义
+
+| 场景                                        | Memory 行为                                            |
+| ------------------------------------------- | ------------------------------------------------------ |
+| 普通文件识别成功                            | 幂等提交 File/FileVersion                              |
+| probe 降级但类型、hash 和基础 metadata 可用 | 提交并记录 partial/unavailable                         |
+| 下载拒绝、识别失败或非媒体                  | 不写 Memory，只记录运行状态                            |
+| Policy Tool 返回 error、timeout 或取消      | 不触发 `OmniPolicySucceeded`                           |
+| required output 缺失                        | 整个 invocation 不提交                                 |
+| 返回 artifact 未命中 descriptor             | 整个 invocation 不提交                                 |
+| 某个媒体 artifact 识别失败                  | 丢弃该 invocation 的全部 staging 结果                  |
+| 文本 artifact 无法读取或编码非法            | 整个 invocation 不提交                                 |
+| policy-origin staging 完成但进程中断        | 恢复时清理或重放，不对 recall 可见                     |
+| 相同事件重复投递                            | 通过 event/invocation ID 幂等，不重复建节点            |
+| side query 超时或返回非法 ID                | 本次空召回，主请求继续并记录原因                       |
+| 主动 Recall Tool 参数或权限非法             | Tool 返回结构化错误，不扩大查询范围                    |
+| backing artifact 已清理或不可读             | 返回 `artifact_unavailable` gap，不返回失效 resourceId |
+
+## 13. 存储与作用域要求
+
+初版逻辑 store 必须满足：
+
+- 以 project/workspace 为隔离边界，不跨 workspace 自动召回；
+- 对 `FileRecognized` 提供幂等 upsert；
+- 对 `OmniPolicySucceeded` 提供多记录原子事务；
+- 支持按 `fileId`、current `fileVersionId`、root、role、scope 和 channel 查询；
+- active graph 记录不能引用 staging 或 quarantined artifact；
+- 持久引用与真实路径分离，返回协议不泄漏受管目录；
+- artifact 生命周期不得早于仍引用它的 active Memory 记录；
+- 可以保留历史版本，但默认索引必须把它们与 current version 分开。
+
+本文不提前选择 SQLite、JSONL 或其他后端。后端选择必须证明上述事务、索引和恢复
+语义，而不是反过来改变已确定的数据边界。受管文件的物理目录布局、staging 与
+quarantine 的落盘形式、保留周期和垃圾回收由
+[Omni 受管媒体存储设计](./2026-07-30-omni-managed-media-storage.md) 定义；本节的
+"artifact 生命周期不得早于 active Memory 记录"是该设计必须满足的强约束。
+
+## 14. 与当前 Qwen Code 源码的对应关系
+
+本设计是现有 Qwen Code 能力上的增量开发：
+
+- 文件识别设计新增的 `MediaRecognitionService` 在成功结果形成后调用
+  `recordFileRecognized`；policy-origin 结果携带 invocation ID 进入 staging；
+- Policy 设计新增的 `PolicyArtifactBatch` 是 `OmniPolicySucceeded` 唯一产物入口，
+  不能消费合并后的 hook artifacts；
+- `packages/core/src/tools/tools.ts` 当前 `ToolArtifact` 继续承载文件、URL、managed
+  ID、MIME、大小和 metadata；Memory bridge 在 descriptor 约束下把它归一为
+  `NormalizedPolicyOutput`；
+- `packages/core/src/core/turn.ts` 当前 `ToolCallResponseInfo.artifacts` 只有合并后语义，
+  继续按 Policy 设计增加仅供内部使用的 `policyArtifacts` channel；
+- `packages/core/src/core/coreToolScheduler.ts` 在原始 Tool 成功、hook artifact 合并前
+  捕获 policy 输出；固定调用和模型调用都复用这一成功边界；
+- `packages/cli/src/acp-integration/session/Session.ts` 在 ACP 自己的 Tool executor 中
+  捕获相同 batch，再调用同一个 core Memory service；
+- `packages/core/src/utils/sideQuery.ts#runSideQuery()` 已支持 JSON schema、超时信号、
+  model override 和结果校验，可以直接作为 passive selector 基础；
+- `packages/core/src/memory/relevanceSelector.ts` 已验证“给模型有界 manifest、只允许
+  返回 manifest 内 ID”的 selector 模式，可以复用该约束方式，但不能复用其 Markdown
+  文件数据模型；
+- `packages/core/src/core/client.ts` 当前 managed auto-memory 已有 recall 取消、请求
+  构造和 prompt 注入经验；媒体 side query 复用生命周期原则，但必须在关联主请求发送
+  前完成，不能采用迟到后再注入 ToolResult turn 的机会式语义；
+- `packages/cli/src/config/settingsSchema.ts`、`packages/cli/src/config/config.ts` 与
+  `packages/core/src/config/config.ts` 继续加载顶层 `omni.memory` 并提供不可变 getter；
+- 当前 `packages/core/src/memory/` 的 managed auto-memory 以 Markdown、Agent
+  extraction/dream 和用户/项目主题文件为核心，不作为结构化 media graph 的存储格式，
+  也不参与本设计写入。
+
+建议把新增能力作为一个 Qwen Code Core service 放在：
+
+```text
+packages/core/src/services/media-memory/
+```
+
+目录内部可以包含 types、store、collector 和 recall，但对外只暴露一个
+`MediaMemoryService` 以及 Recall Tool 所需的类型。它不是新的 daemon、MCP server、
+进程、插件协议或独立配置系统。
+
+## 15. 安全与权限
+
+- 写入者只接受识别服务和 policy orchestrator 的 typed payload；
+- Agent 与 side query 都没有写接口；
+- active recall 只接受当前 session 已授权的 `resourceId`；
+- side query 只处理当前请求显式引用的文件；
+- project/workspace 隔离、workspace trust 和现有文件权限继续生效；
+- 不向模型、selector、日志或 telemetry 暴露鉴权 header、token 或受管本地路径；
+- 历史版本、quarantine 和已清理 artifact 不自动重新绑定为 session resource；
+- 同 hash 缓存复用不能绕过来源权限和 workspace 隔离。
+
+## 16. Observability 与实验复现
+
+每次收集至少记录：
+
+- 触发类型、event/invocation ID 和幂等结果；
+- file/root/version ID 与 hash 的脱敏引用；
+- source、parent、producer、tool、policy 和 execution origin；
+- Tool 版本、final arguments hash、scope、channels 和 coverage；
+- ingestion/processing/memory resolved config hash；
+- staging、提交、回滚、cache hit 和 artifact availability 状态；
+- 耗时、节点数、输出数和错误类别。
+
+每次召回至少记录：
+
+- mode、请求文件数、候选数、选中数、返回数；
+- hit/partial/miss、gap 类型和历史版本过滤数量；
+- selector model、timeout、attempts、耗时和失败原因；
+- 注入文本字符数与绑定出的 session resource 数；
+- resolved Omni config hash。
+
+Telemetry 默认不记录原始媒体、transcript/OCR 正文、真实路径或完整 Tool 参数值；需要
+复现时使用 hash 和本地结构化执行记录关联。
+
+## 17. 验收标准
+
+### 17.1 收集边界
+
+- 用户、普通 Tool、URL 和 inline 媒体识别成功后只通过 `FileRecognized` 入库；
+- 固定与模型 policy 成功后只通过 `OmniPolicySucceeded` 入库；
+- 不存在 `MediaTurnCompleted`、Agent write Tool 或 final-answer extraction 写路径；
+- `llmContent`、`returnDisplay` 和普通文本中的路径不会被解析为 Memory 产物；
+- `/learn` 不出现在实现接入点中。
+
+### 17.2 文件与版本
+
+- 同一显式 fileRef、相同完整 SHA-256 重复识别不会产生重复版本；
+- 同一 fileRef 内容改变后创建新版本，默认召回不返回旧结果；
+- 两个独立来源即使完整 SHA-256 相同，也保留两个 file/root graph；
+- URL 到受管本地文件的本地化 lineage 保持同一个 fileId；
+- 名称、大小、mtime、ETag 或部分 hash 相同不能合并版本。
+
+### 17.3 Policy 原子性
+
+- 多输出 policy 只有全部 required/returned artifacts 校验通过才一次性入图；
+- 任一媒体识别或文本读取失败时，不出现部分衍生物或孤立执行节点；
+- include、retain 和 source omit 不改变事实收集结果；
+- PostToolUse hook artifact 不会被登记为 policy 自身输出；
+- 相同 invocation 重放幂等，cache hit 不复制结果节点。
+
+### 17.4 主动召回
+
+- `active` 模式只暴露 Recall Tool，不自动运行 side query；
+- Tool 只能查询当前 session resource 对应的文件内图；
+- 可用衍生媒体返回新的或复用的 session resourceId，不返回真实路径；
+- status、entries、gaps、coverage、evidence 和 provenance 字段完整；
+- Agent 不能通过 Recall Tool 写入或修改 Memory。
+
+### 17.5 被动召回
+
+- `sideQuery` 模式不暴露主动 Recall Tool；
+- 候选只来自当前请求显式引用文件的 current-version graph；
+- selector 只能返回 manifest 中的 entryId，非法或跨 root ID 整体拒绝；
+- selector 不接收原始媒体、大文本或本地路径；
+- 结果在相关主请求前注入；timeout 时空召回且不阻断主请求；
+- side query 不创建任何新 File、PolicyResult 或 Agent conclusion。
+
+### 17.6 配置与隔离
+
+- `omni.memory` 没有 enabled 总开关；
+- mode、预算、数组替换和 workspace trust 合并行为可验证；
+- 不同 project/workspace 的 Memory 不会互相召回；
+- 相同输入、配置、Tool 版本和参数可以从记录完整复现收集与召回条件。
+
+## 18. 实现阶段仍需确定的细节
+
+以下是实现方案选择，不改变本文已经确定的需求边界：
+
+1. `File`、`FileVersion`、`PolicyExecution` 和 `PolicyResult` 的精确持久 schema 与
+   schema migration 方式；
+2. `NormalizedPolicyOutput.role` 的初版完整枚举及自定义 role 命名规则；
+3. store 后端、索引布局、事务和崩溃恢复实现；
+4. side-query candidate 的确定性预排序、description 生成和 token 预算；
+5. 历史版本、孤立受管文件、quarantine 与 cache 的 retention/GC；
+6. cache hit 是否单独保存轻量 execution 记录，以及 provenance 的精确引用方式。
+
+这些选择不得改变已经确认的约束：**只有 FileRecognized 与
+OmniPolicySucceeded 两个收集触发点、Harness 独占写入、文件内图、完整 SHA-256
+版本判断、policy 原子提交、active/sideQuery 共用只读协议，以及默认只召回当前
+版本**。

--- a/docs/design/2026-07-29-omni-multimodal-policy-orchestration.md
+++ b/docs/design/2026-07-29-omni-multimodal-policy-orchestration.md
@@ -1,0 +1,1862 @@
+# Omni 多模态数据处理 Policy 编排架构设计
+
+## 状态
+
+- 状态：Draft
+- 范围：Qwen Code 实验分支中的图片、音频、视频 Harness 侧处理
+- Provider：仅支持 DashScope OpenAI-compatible 路径
+- 前置设计：
+  [多模态文件识别与元数据提取架构设计](./2026-07-29-multimodal-file-recognition-and-metadata.md)
+- 后续设计：
+  [Omni 多模态 Memory 架构设计](./2026-07-29-omni-multimodal-memory.md)
+- 配套设计：
+  [Omni 受管媒体存储设计](./2026-07-30-omni-managed-media-storage.md)
+- 基线：`origin/main`，核对至 `2ce9da85bd99`
+
+## 1. 背景
+
+本功能用于探索不同图片、音频和视频处理策略对多模态模型表现的影响，并为后续
+长短视频、音频处理和训练数据生产寻找稳定策略。它不是一个独立产品，也不新增
+Qwen Code 之外的平台或插件生命周期。
+
+文件识别与 metadata 阶段已经把用户输入、工具结果、URL、base64 和 MCP 资源
+归一为本地 `MediaResource`。本文从该结果继续，设计 Harness 如何自动执行固定
+policy、如何把同一 policy 暴露为模型可调用 Tool、如何选择模型输入衍生物，以及
+如何经官方临时上传通道投递媒体并在投递前强制满足上传通道限制。
+
+本功能具有明确的实验属性：配置需要支持细粒度组合、消融和参数约束，并且每次
+执行必须能够记录完整实验条件。本文不以合入 Qwen Code 主分支和长期配置兼容为
+目标；分支、发布和最终交付方式留到整体 roadmap 阶段讨论。
+
+## 2. 目标与非目标
+
+### 2.1 目标
+
+- 每个媒体处理 policy 只实现一次，并以现有 Qwen Code Tool 形态注册；
+- 同一 Tool 同时支持 Harness 固定调用和 Agent 模型调用；
+- 所有用户 fixed policy 使用同一策略集合；省略 `when` 表示无条件执行，配置
+  `when` 表示按资源 metadata、token 估算或 session context 条件执行；
+- 用户可以为每个 fixed policy 配置匹配范围、顺序、Tool 参数、失败行为和产物投递；
+- 用户可以为每个模型可调用 Tool 配置描述、默认值、锁定值、参数约束和运行预算；
+- policy 产物成为新的媒体资源，可以继续参与后续 Fixed Policy；
+- 媒体统一经 DashScope 官方临时上传投递（oss:// URL），必须满足上传通道限制
+  （单文件 ≤ 1GB 及模型时长档位）；不保留 inline 投递模式；
+- 所有执行记录 policy ID、Tool、参数、资源 lineage 和 resolved Omni 配置哈希，支持
+  实验复现及训练数据追溯；
+- 复用 Qwen Code 现有 Tool registry、scheduler、ToolSearch、settings、artifact
+  和工具结果公共漏斗。
+
+### 2.2 非目标
+
+本文不设计：
+
+- 具体图片、音频和视频 policy 的完整产品清单；
+- 多 Provider 兼容层；
+- 跨 session media memory；
+- computation 调度平台；
+- 主分支合入、版本发布或兼容迁移策略。
+
+### 2.3 硬性运行前提
+
+作为实验分支，以下前提在启动时强制校验，不满足即启动失败：
+
+- **`ffmpeg`/`ffprobe` 可用**：音频、视频类 policy Tool 和 probe 均依赖它们，
+  不提供缺失时的降级运行（与识别设计一致）；
+- **active model 已声明全模态能力**：实验中使用的模型必须在
+  `contentGeneratorConfig.modalities` 中配置支持 image、audio 和 video。启动时
+  校验该声明覆盖 Omni 可能投递的媒体类型；若运行期 converter 仍触发
+  `unsupportedModalityPlaceholder`（编程错误或漏配），必须按投递失败记入执行
+  记录并明确告知，不得让占位文本静默替换媒体。
+
+## 3. 核心概念
+
+### 3.1 Policy Tool
+
+每个 policy 使用现有 `BaseDeclarativeTool + ToolInvocation` 实现。Tool 原生 schema
+和业务校验是固定调用与模型调用共享的最终参数契约。
+
+示例 Tool 包括：
+
+- `omni_downsample_image`；
+- `omni_extract_audio`；
+- `omni_transcribe_audio`；
+- `omni_extract_keyframes`；
+- `omni_clip_video`。
+
+Tool 名属于代码注册表，不等于用户配置的 policy ID。同一个 Tool 可以被多个 fixed
+policy
+以不同参数重复引用。
+
+每个 Policy Tool 的可配置面固定分为两部分，设计任何 Tool 时都必须同时给出：
+
+1. **调用参数 schema**（per-invocation）：单次执行的业务参数，如裁剪起止时间、
+   压缩质量、目标分辨率。固定调用来自 configured policy 的 `arguments`，模型
+   调用来自经过投影的 `parameterSchema`，两者最终都经过同一个 Tool 原生 schema
+   校验；
+2. **工具配置参数**（per-tool `settings`）：与单次调用无关的 Tool 级配置，如
+   ASR/VL 后端模型与 endpoint、默认编码器、质量档位默认值、本地二进制路径。
+   由 Tool 声明自己的 settings schema，启动时校验
+   `omni.processing.policyTools.<tool>.settings`，运行时以只读形式注入 Tool。
+
+调用远端模型的 policy（ASR、VL describe 等）的 backend 凭证沿用 Qwen Code 现有
+model provider 凭证体系，`settings` 中只引用模型/endpoint 标识，不保存密钥。
+
+### 3.2 处理披露是 Policy 输出的一部分
+
+任何有损或改变媒体表达的 policy（压缩、降采样、抽帧、裁剪、转写等），其返回
+内容必须同时包含两部分：**衍生产物本身** + **对本次处理与降质情况的文字介绍**。
+披露是每个 Policy Tool 自己的输出义务，不是 Harness 的统一后置能力：
+
+- Tool 在每个衍生 artifact 的 `metadata.omniDisclosure` 中提供披露文本，说明
+  实际生效参数、原始与输出的关键差异（分辨率/时长/帧数/码率）、损失类型与
+  未覆盖范围（例如"原图 6000x4000 已降采样至 2000x1333，文字细节可能不可读"、
+  "从 3600s 视频按场景抽取 16 帧，非关键帧画面未覆盖"）；
+- delivery 把 artifact 物化为媒体 Part 投递时，同时把披露文本作为紧邻的 text
+  Part 投递，保证模型始终知道自己看到的是什么、丢了什么；
+- 模型调用场景中，`llmContent` 本身就应承载同一份披露；
+- 披露文本随 `NormalizedPolicyOutput` 进入 Memory，供后续召回时复述。
+
+MediaPolicyTool descriptor 中声明为有损（`lossy: true`）的输出缺失
+`omniDisclosure` 时，按产物校验失败处理。
+
+### 3.3 Fixed Policy
+
+Fixed Policy 是一次可配置的固定执行绑定：
+
+```text
+policyId + match + optional when + tool + arguments + output + failure behavior
+```
+
+例如：
+
+```jsonc
+{
+  // 用户定义的 policyId。
+  "extract-video-audio": {
+    // 所有 fixed policies 中数字越大越先执行。
+    "priority": 100,
+    // 实际执行的 MediaPolicyTool 名。
+    "tool": "omni_extract_audio",
+  },
+}
+```
+
+其中：
+
+- `extract-video-audio` 是用户命名的 `policyId`；
+- `omni_extract_audio` 是实际执行的 Tool；
+- policy ID 在 `fixedPolicies` map 内全局唯一；
+- policy ID 用于配置覆盖、日志、lineage、防循环和实验复现；
+- `when` 省略时，对所有命中 `match` 的资源执行；存在时，只有条件成立才执行。
+
+### 3.4 MediaResource
+
+`MediaResource` 是单轮处理中的轻量执行对象，不是新的 artifact 平台：
+
+```ts
+interface MediaResource {
+  resourceId: string;
+  mediaType: 'image' | 'audio' | 'video';
+  metadata: MediaFileMetadata;
+  origin: 'user' | 'tool' | 'policy';
+  parentResourceId?: string;
+  rootResourceId: string;
+  producedBy?:
+    | {
+        executionOrigin: 'fixed_policy';
+        policyId: string;
+        stage: 'preprocessing' | 'transport_guard';
+        toolName: string;
+        invocationId: string;
+      }
+    | {
+        executionOrigin: 'model' | 'client';
+        toolName: string;
+        invocationId: string;
+      };
+  lineage: MediaLineageEntry[];
+}
+```
+
+真实本地路径和内容哈希保留在 Harness 内部。模型只获得 opaque `resourceId`、媒体
+类型以及经过配置投影的 metadata；模型调用 policy Tool 时使用 `resourceId`，由
+Harness 解析到受管本地文件。
+
+每个媒体 policy 输出形成不可变的新资源，非媒体 artifact 也不可原地覆盖输入。
+原资源不会被覆盖，替换只发生在“是否进入模型输入候选”的投递层。
+
+## 4. 总体架构
+
+```mermaid
+flowchart TD
+  A["用户输入或工具结果"] --> B["统一识别、本地化和 metadata"]
+  B --> C["MediaResource 队列"]
+  C --> D["fixedPolicies: match + optional when"]
+  D --> F["合并 delivery 决策"]
+  F --> G{"DashScope 投递检查"}
+  G -- "合规" --> H["构造模型输入"]
+  G -- "超限" --> I["transportGuard policies"]
+
+  K["模型 ToolCall"] --> L["modelAccess gate"]
+  L --> M["CoreToolScheduler / ACP executor"]
+  D --> M
+  I --> M
+  M --> N["同一个 Policy Tool"]
+  N --> O["PolicyArtifactBatch"]
+  O --> Q{"artifact 类型"}
+  Q -- "媒体" --> B
+  Q -- "transcript 文本" --> F
+```
+
+该结构包含两个闭环：
+
+1. policy 产出的媒体 artifact 回到统一识别和 metadata 链路；
+2. transport guard 产物回到 `fixedPolicies`，完成用户 policy 后再次检查
+   是否可投递。
+
+`transportGuard` 是模型投递边界的强制保护，不属于用户 `fixedPolicies` 的条件
+调度。用户 policy 可以先把资源处理成合规衍生物；只有最终仍准备发送超限媒体时
+才执行 transport policy。
+
+## 5. 触发位置
+
+### 5.1 用户资源
+
+用户资源沿用文件识别设计中的统一入口：
+
+```text
+输入 adapter
+  → 显式 MediaCandidate
+  → 本地化
+  → sniff / probe / hash
+  → MediaResource
+  → fixed policy orchestrator
+  → 模型 Part
+```
+
+固定 policy 必须发生在 `processSingleFileContent` 将文件转成 `inlineData` 或按
+当前 9.9/10 MiB 逻辑提前拒绝之前；Omni 媒体经识别后完全脱离现有 inline 转换
+路径，由 Omni delivery 统一上传投递。TUI、non-interactive、ACP 和 Web Shell
+只做入口适配，不复制 policy 编排器。
+
+### 5.2 工具返回资源
+
+工具结果遵循 PR #7484 已建立的公共漏斗原则：
+
+- CoreToolScheduler 在统一工具结果形成后调用共享处理器；
+- ACP `Session.runTool()` 在模型 ToolCall 的统一工具结果边界调用同一处理器；
+- MCP、Extension、Skill 和内置 Tool 只负责把 typed media、resource link 或
+  `ToolArtifact` 保留成显式候选；
+- 不在每个 Tool 实现中分别扫描和识别媒体；
+- MCP `resource_link` 必须在退化为普通文本前保留结构。
+
+对 model/client 来源的 MediaPolicyTool，原始 producer artifacts 只通过
+`PolicyArtifactBatch` 进入共享 bridge，并从通用 `artifacts → mediaCandidates` 适配
+中排除；PostToolUse hook 产物仍按普通显式候选处理。这样同一 policy artifact 不会
+同时走专用 output 语义和普通 Tool artifact 语义。
+
+模型调用 policy Tool 后产生的 artifact 也经过该入口，因此仍可命中 Fixed Policy 和
+transport guard。
+
+## 6. Policy Tool 契约
+
+### 6.1 输入
+
+Policy Tool 的原生 schema 同时服务两种来源：
+
+- 固定调用：orchestrator 只注入 `resourceId`，并从 configured policy 读取
+  `arguments`；
+- 模型调用：模型提交 `resourceId` 和允许控制的业务参数，Harness 合并默认值、
+  校验锁定值与约束，再调用 Tool 原生校验。
+
+固定配置不得自行指定本地输入路径，避免配置与实际候选脱节。模型也不能直接访问
+受管临时路径。模型提交的 `resourceId` 必须解析到当前 session 已授权、且媒体类型
+满足 Tool 输入契约的资源；Tool 在受信执行上下文中通过共享 MediaResourceResolver
+把 ID 解析为本地路径。未知、跨 session 或已清理的 ID 在执行前返回参数错误。
+
+固定配置使用从 Tool 原生 schema 删除 Harness-owned `resourceId` 后得到的
+fixed-policy argument schema：启动时只用它校验 configured policy `arguments`；运行时 orchestrator
+合并 `{ resourceId, ...arguments }` 后，再执行完整 Tool 原生 schema 与业务校验。
+因此合法 fixed policy 不需要、也不能在 settings 中伪造 `resourceId`。
+
+### 6.2 输出
+
+Policy Tool 返回现有 `ToolResult`：
+
+- `artifacts` 是衍生文件身份的权威输出；
+- `llmContent` 是模型调用场景的简短事实结果，不承担衍生物发现；
+- `returnDisplay` 用于 UI 进度和结果展示；
+- `error` 表达 Tool 执行失败。
+
+固定编排器不得解析 `llmContent` 寻找文件。每个媒体衍生物必须返回
+`ToolArtifact`，随后由统一识别服务补齐 MIME、大小、内容哈希和技术 metadata，
+再登记 parent/root/producer lineage。
+
+Scheduler 现有 `ToolCallResponseInfo.artifacts` 会合并 Tool 自身和 PostToolUse hook
+产物，无法证明 producer。为避免 hook artifact 冒充 policy 输出，本设计定义内部
+`PolicyArtifactBatch`，只包含成功 MediaPolicyTool 的原始 `toolResult.artifacts` 及
+tool/invocation/origin：Core Scheduler 通过新增的
+`ToolCallResponseInfo.policyArtifacts` 保留这批原始产物；ACP `Session.runTool()` 在
+PostToolUse hook artifact 合并或通知前直接捕获同一批原始产物。现有 `artifacts`
+仍保留合并后的 UI/记录语义。共享 Omni bridge 只消费 `PolicyArtifactBatch`，并按
+Tool 注册时的 output descriptor 校验。
+
+Policy Tool 不直接决定自己是否进入当前模型上下文；该决定属于 fixed policy 的
+`output` 或 `modelAccess.output` 配置。媒体 policy artifact 使用现有
+`ToolArtifact.kind`，并可在
+`metadata.omniRole` 中提供稳定的用途标识，例如 `transcript`、`keyframe` 或
+`proxy`，供 delivery 精确选择。
+
+首版 transcript 使用受管 `ToolArtifact` 文件表达：`kind: 'file'`、
+`mimeType: 'text/plain'`、`metadata.omniRole: 'transcript'`。它不是
+`MediaResource`，不进入媒体识别器；delivery planner 只在大小预算内读取 UTF-8
+文本并物化为 text Part。越界、非法编码或读取失败均视为该 policy 产物失败。
+
+### 6.3 Tool 标记
+
+只有明确注册为 `MediaPolicyTool` 的 Tool 才能被固定编排器引用。该标记至少用于：
+
+- 配置启动校验；
+- 固定调用 permission bypass；
+- Tool 输出契约校验；
+- 模型可见性 gate；
+- 阻止伪造执行来源调用 Shell、Edit 或普通 MCP Tool。
+
+最小 descriptor 与 bridge batch 形态为：
+
+```ts
+interface MediaPolicyToolDescriptor {
+  kind: 'media_policy';
+  inputMediaTypes: Array<'image' | 'audio' | 'video'>;
+  outputs: Array<{
+    kind: ToolArtifactKind;
+    role?: string;
+    mimeTypes: string[];
+    required: boolean;
+    /** 有损/改变表达的输出必须随附 metadata.omniDisclosure 披露文本。 */
+    lossy?: boolean;
+  }>;
+  /** Tool 级配置参数（settings）的 JSON schema；无配置项时省略。 */
+  settingsSchema?: object;
+}
+
+interface PolicyArtifactBatch {
+  toolName: string;
+  invocationId: string;
+  executionOrigin:
+    | {
+        kind: 'fixed_policy';
+        policyId: string;
+        stage: 'preprocessing' | 'transport_guard';
+      }
+    | { kind: 'model' | 'client' };
+  artifacts: ToolArtifact[];
+}
+```
+
+Descriptor 是代码注册事实，不由 configured policy、模型参数或 Tool 返回 metadata
+动态修改。
+`required` 表示成功 invocation 至少要产生一个匹配该描述的 artifact；所有返回
+artifact 仍必须命中一个允许的输出描述并通过 managed storage/path 校验。
+
+## 7. 固定调用执行路径
+
+固定调用复用现有 `executeToolCall()` 和 `CoreToolScheduler`：
+
+```text
+FixedPolicyOrchestrator
+  → ToolCallRequestInfo
+  → executeToolCall(recordToolResult: false)
+  → CoreToolScheduler
+  → ToolInvocation.execute()
+  → ToolResult
+  → CoreToolScheduler captures raw policy artifacts
+  → ToolCallResponseInfo.policyArtifacts
+  → FixedPolicyOrchestrator
+```
+
+固定执行不会伪造 assistant `functionCall`，也不会把孤立 `functionResponse` 写入
+模型历史。本文核对的 `origin/main@2ce9da85bd99` 基线中，
+`ExecuteToolCallOptions.recordToolResult` 已存在；传 `false` 只关闭 chat recording，
+schema 校验、timeout、取消、并发控制、hooks、telemetry、streaming output 和
+artifact 汇总继续复用 Scheduler。
+
+### 7.1 Execution origin
+
+`ToolCallRequestInfo` 增加明确来源，不能复用语义含混的 `isClientInitiated`：
+
+```ts
+type ToolExecutionOrigin =
+  | { kind: 'model' }
+  | { kind: 'client' }
+  | {
+      kind: 'fixed_policy';
+      policyId: string;
+      stage: 'preprocessing' | 'transport_guard';
+    };
+```
+
+该字段同时用于 permission bypass、模型可调用 gate、hooks、telemetry 和实验记录。
+不能从现有 `isClientInitiated` 推断它：当前 AgentCore 的模型授权调用也可能设置
+`isClientInitiated: true`。迁移时由每个受信构造点显式标记：Turn、AgentCore/subagent
+和 ACP 模型 function call 标记 `model`，真实 direct/client API 标记 `client`，只有
+内部 FixedPolicyOrchestrator 能标记 `fixed_policy`。兼容期缺少新字段的请求一律按
+`model` fail closed 并记录诊断，不得因为旧布尔值升级权限；旧字段只继续服务原有
+UI/调度语义。`fixed_policy` 不能从 Tool 参数、协议 payload 或模型输出反序列化。
+首版对 MediaPolicyTool 的 `client` 调用使用与 `model` 相同的 `modelAccess` gate，
+防止 direct tool API 绕过 fixed-only 限制；其 permission 行为仍沿用现有 client
+路径。
+
+### 7.2 固定调用跳过 permission
+
+配置 fixed policy 代表用户已经授权它在受管资源上执行，因此固定调用：
+
+- MediaPolicyTool factory 使用专用注册分支，跳过 `PermissionManager.isToolEnabled()`
+  的注册前 gate，保证固定编排器能解析已配置 Tool；
+- 跳过 PermissionManager deny/ask 计算；
+- 跳过 Scheduler 执行前的 PermissionManager/legacy deny gate 以及后续完整 permission
+  flow；
+- 跳过确认 UI、PLAN/AUTO approval flow 和 `requiresUserInteraction`；
+- 不允许模型伪造 `fixed_policy` 来源；
+- 不允许 Fixed Policy 引用非 `MediaPolicyTool`；
+- 输入资源必须由 orchestrator 注入；
+- 输出必须位于 Omni 管理目录。
+
+`tools.disabled` 仍是显式的 registry 禁用配置，不被固定调用绕过。如果 configured
+policy
+引用的 Policy Tool 同时出现在 `tools.disabled`，启动时作为配置冲突拒绝，而不是让
+policy 在运行时悄悄消失。
+
+专用注册只保证 fixed orchestrator 的内部可用性，不等于模型授权。Registry 的
+model-visible view 仍同时应用 `modelAccess` 和现有 PermissionManager 可见性，
+Scheduler 对 model/client origin 也继续执行完整 permission gate。
+
+PreToolUse 和 PostToolUse hooks 仍执行。PreToolUse 返回 block，或任何 hook 结果
+要求重新进入 ask/confirmation 时，固定调用都 fail closed，不弹确认框。当前
+PreToolUse 协议不修改 Tool 参数；如果后续 Hook 协议增加 updated input，必须重新
+执行 projected schema、Tool 原生 schema、resourceId 和受管输出边界校验。
+
+固定调用不计入 Agent `maxToolCalls`，但计入独立 Omni execution budget。
+
+### 7.3 固定调用结果的唯一归属
+
+`fixed_policy` 的 `ToolResult` 由发起它的 FixedPolicyOrchestrator 独占消费：Scheduler
+返回 `ToolCallResponseInfo`；orchestrator 只读取其中从原始 Tool 输出单独保留的
+`policyArtifacts`，再按当前 invocation 的 MediaPolicyTool descriptor 校验受管
+storage/path、允许类型和必需产物，缓冲后统一送入识别、lineage 与 delivery 流程。
+该结果不再经过普通 Tool result 媒体漏斗，避免同一 artifact 触发嵌套编排或被处理
+两次。
+
+模型调用和普通 Tool 调用的结果仍只在 Tool result 完整组装后进入一次公共漏斗；
+其中 MediaPolicyTool 的原始 producer artifacts 由该漏斗中的专用 bridge 分支消费，
+不再被通用 artifact adapter 重复提取。execution origin、invocation ID 和独立
+`policyArtifacts` channel 共同标记归属；普通 hook 附带的 artifact 只存在于合并后
+的 `artifacts`，不会因为与 Policy Tool 同轮返回而获得 Omni output descriptor。
+
+## 8. Fixed Policy 编排语义
+
+### 8.1 统一策略集合
+
+用户 fixed policy 只有一个 `fixedPolicies` map：
+
+- `match` 选择资源类型、来源和 producer；
+- `when` 是可选条件；省略时表示对所有命中 `match` 的资源执行；
+- 配置 `when` 时，可以判断资源 metadata、资源 token 估算、当前请求媒体 token 总量
+  以及 session context snapshot；
+- 所有 policy 使用同一个 priority 序列：数字越大越先执行，相同 priority 按
+  policy ID 字典序执行。
+
+因此，“总是执行”只是 `when` 省略后的普通 fixed policy，不再拥有独立分类或
+特殊执行阶段。`transportGuard` 仍是最终投递保护，不参与用户 fixed policy 的
+priority 排序。
+
+### 8.2 当前资源快照与衍生物回流
+
+对单个资源执行时：
+
+1. 所有 fixed policy 都基于该资源和本次调度 pass 的同一份 evaluation snapshot
+   匹配；
+2. policy 按确定顺序串行执行；
+3. policy 产物先缓冲，不会成为当前资源后续 policy 的隐式输入；
+4. 当前资源处理完成后，产物按
+   `priority(desc) → policyId → artifact index` 入队；
+5. 新媒体资源重新执行完整 `fixedPolicies` 集合。
+
+因此 priority 只代表调度顺序，不代表数据依赖。显式链式处理使用
+`match.producedBy`：
+
+```jsonc
+{
+  // 用户定义的音频转写 policyId。
+  "transcribe-extracted-audio": {
+    // 定义该 policy 可以匹配的资源。
+    "match": {
+      // 只处理音频资源。
+      "mediaTypes": ["audio"],
+      // 只处理 extract-video-audio 产生的衍生物。
+      "producedBy": ["extract-video-audio"],
+    },
+  },
+}
+```
+
+### 8.3 匹配条件
+
+`when` 使用受限条件 DSL，不接受任意 JavaScript 或 JSONPath。条件由 `all`、`any`
+和 comparison 递归组成；comparison 支持 `gt`、`gte`、`lt`、`lte`、`eq`，左右两侧
+都可以是字段或字面量：
+
+```ts
+type ConditionOperand =
+  | { field: FixedPolicyField }
+  | { value: number | string | boolean };
+
+interface ComparisonCondition {
+  left: ConditionOperand;
+  operator: 'gt' | 'gte' | 'lt' | 'lte' | 'eq';
+  right: ConditionOperand;
+}
+```
+
+可读字段分为三个自然命名空间：
+
+- `resource.*`：`sizeBytes`、`durationMs`、`width`、`height`、`maxWidth`、
+  `maxHeight`、`frameRate`、`frameCount`、`bitRate`、`sampleRateHz`、`channels`、
+  `estimatedTokenCount`；
+- `request.totalEstimatedMediaTokens`：当前调度 pass 中所有待投递媒体的估算 token
+  总和；在 pass 开始时计算，包含当前资源，并在衍生物进入下一 pass 后重新计算；
+- `session.*`：`contextWindowTokens`、`promptTokenCount`、`reservedOutputTokens`、
+  `availableContextTokens`。
+
+Session context snapshot 在 fixed policy 执行前生成，并在同一 pass 内保持不变：
+
+```text
+availableContextTokens = max(
+  0,
+  contextWindowTokens - promptTokenCount - reservedOutputTokens
+)
+```
+
+`contextWindowTokens` 来自当前 active model 的 context window；`promptTokenCount` 使用
+当前 chat 的 Provider usage 作为基线，再用 Qwen Code 现有 prompt estimator 计入
+本次尚未发送的内容；`reservedOutputTokens` 来自
+`processing.limits.reservedOutputTokens`。不能直接读取一个与当前 chat 无关的全局 UI
+计数。估算媒体 token 来自 metadata 文档定义的 versioned estimator。
+
+例如，当单个视频估算 token 已超过本轮可用 context 时执行关键帧提取：
+
+```jsonc
+{
+  "when": {
+    "all": [
+      {
+        "left": { "field": "resource.estimatedTokenCount" },
+        "operator": "gt",
+        "right": { "field": "session.availableContextTokens" },
+      },
+      {
+        "left": { "field": "session.contextWindowTokens" },
+        "operator": "gte",
+        "right": { "value": 131072 },
+      },
+    ],
+  },
+}
+```
+
+任何字段无法获得时，该 comparison 结果为 `unavailable`，不能静默当作 `false`。
+运行记录必须说明缺失字段和来源状态；policy 按 `onConditionUnavailable` 的默认
+`skip` 行为跳过，后续如有需要再开放 `abortTurn`。
+
+### 8.4 防循环与资源预算
+
+默认策略：
+
+- 同一用户 fixed policy 在同一 lineage 默认最多执行一次；transport policy 使用
+  10.2 的 per-occurrence/pass 语义；
+- 不同 policy 可以使用同一个 Tool 和不同参数；
+- 每个 provenance occurrence 保留独立 resourceId 和单一 parent lineage；
+- 相同 content hash 只复用 sniff、probe 和可复用 policy 结果缓存，不合并资源节点；
+- `maxRunsPerLineage` 可以显式允许迭代实验；
+- 输出 hash 与输入 hash 相同立即终止该 policy 的迭代；
+- 超过 lineage、policy run、artifact、derived bytes 或 transport pass 预算时停止
+  当前 root 的继续派生，并记录预算原因。
+
+同一资源的 policy 始终串行。不同资源可按 `maxConcurrentResources` 并行；即使开启
+并行，最终模型输入顺序仍按逻辑序号而不是完成时间。
+
+### 8.5 失败行为
+
+用户 fixed policy 的 `onFailure` 支持：
+
+- `continue`：记录失败，继续当前资源其他 policy，默认值；
+- `stopResource`：停止该资源后续用户 policy；
+- `abortTurn`：终止本轮。
+
+policy 失败不会应用其 output delivery 变化。无论使用哪种用户失败策略，最终
+transport guard 都不能被跳过。
+
+## 9. 产物投递语义
+
+不使用含混的 `append`、`replace`、`sidecar` 单值，而把输入资源与衍生物分别配置。
+每个 fixed/transport policy 都必须显式提供 `output.reprocessMedia`、`source` 和
+`artifacts`；`artifacts` 可以是空 map，但不能依赖隐式 source 行为：
+
+```jsonc
+{
+  // 当前 policy 的衍生物回流和模型投递配置。
+  "output": {
+    // 让已完成识别的媒体衍生物重新执行 fixedPolicies。
+    "reprocessMedia": true,
+    // 保留当前输入资源的模型投递资格。
+    "source": "keep",
+    // 按 artifact selector 配置每类衍生物的投递行为。
+    "artifacts": {
+      // 音频衍生物自动进入模型输入候选。
+      "kind:audio": "include",
+      // 其他衍生物只登记和保留。
+      "*": "retain",
+    },
+  },
+}
+```
+
+语义如下：
+
+- 所有媒体 artifact 都先进入识别和 metadata，不受 output 配置影响；
+- `reprocessMedia: true`：完成识别后重新执行 `fixedPolicies`；
+- `source: keep`：当前输入资源继续保留为模型输入候选；
+- `source: omit`：只从模型输入候选移除当前资源，不删除本地文件；
+- `include`：衍生物加入当前模型输入候选；
+- `retain`：衍生物只登记和保留，可供后续 policy、模型 Tool 或 memory 使用；
+- `kind:<kind>`：按现有 `ToolArtifact.kind` 选择，例如 `kind:audio`；
+- `role:<role>`：按 `ToolArtifact.metadata.omniRole` 选择，例如
+  `role:transcript`；
+- `*`：未被更具体 selector 匹配的默认行为；所有 output 中未配置 `*` 时，未命中
+  artifact 也默认 `retain`。
+
+同一 artifact 同时命中多个 selector 时，固定优先级为
+`role:<role> > kind:<kind> > *`，只采用最具体 selector 的结果。配置使用 map，
+同一个 role 或 kind 不可能出现同级 tie；未知 selector 在启动时拒绝。
+
+原有概念对应关系：
+
+| 原表述  | source | artifact |
+| ------- | ------ | -------- |
+| append  | keep   | include  |
+| replace | omit   | include  |
+| sidecar | keep   | retain   |
+
+多 policy 合并使用单调集合语义：
+
+- 任意 policy 对同一 source 设置 `omit` 后，该资源不再自动投递；
+- 多个 policy 的 `include` 结果取并集；
+- 不存在“最后一个 replace 获胜”；
+- `retain` artifact 仍可回流并产生被 `include` 的后代。
+
+被 `include` 的衍生物在物化为媒体 Part 时，其 `metadata.omniDisclosure` 披露文本
+同时物化为紧邻的 text Part（见 3.2）；投递层不得剥离披露只发送媒体。
+
+每次 invocation 的 delivery 变化以事务方式提交。只有 Tool 成功，且它声明的所有
+artifact descriptor 都通过受管路径、类型、识别或文本物化校验后，才同时提交
+`source` 和 `artifacts` 变化。任一必需产物失败时，不回流或投递该 invocation 的
+任何 artifact，也不执行 `source: omit`；产物文件标记为 failed/quarantined，用户
+policy 按 `onFailure` 继续，transport policy 则 fail closed。这样不会在替代产物只完成一
+半时先移除原资源。
+
+## 10. Transport guard
+
+### 10.1 与用户 fixed policy 的区别
+
+用户 fixed policy 是实验策略，可以使用大小、时长、分辨率、预估 token 和 session
+context 等条件。Transport guard 是 DashScope 投递不变量。首版投递统一采用官方
+临时上传（见 10.3），因此 guard 的度量口径是**上传通道限制**，逐个媒体文件判断：
+
+- `maxUploadFileBytes`：官方临时上传单文件硬上限 1GB，只能调低；
+- `maxDurationMs`（可选）：当前实验模型集合的时长上限（例如 qwen-vl-max 为
+  20min–2h 档、Qwen2.5-VL 为 10min 档）；`null` 表示不启用时长维度。
+
+两者使用独立配置：
+
+- 用户 fixed policy 可以启用、关闭、组合和改变条件；
+- transport guard 始终启用；
+- transport policy 集合不能为空；
+- `maxUploadFileBytes` 可以为实验调低，但不得高于官方 1GB 硬上限；
+- 处理后仍超限时 fail closed，不能发送原媒体。
+
+由于上限从 base64 <10MB 抬升到 1GB/文件，guard 的实际触发频率大幅下降：它从
+"几乎所有音视频的强制预处理入口"退化为"超大/超长媒体的边界保护"，用户 fixed
+policy 回归纯实验语义。
+
+### 10.2 反馈式执行
+
+执行过程是：
+
+```text
+用户 fixed policy 闭包
+  → 汇总 include/keep 候选
+  → 上传通道限制检查（文件大小 / 时长）
+      → 合规：上传并发送 oss:// URL
+      → 超限：运行 transport policies
+                 → 产物重新识别并进入用户 fixed policy
+                 → 再次检查
+```
+
+这样用户配置的降采样、压缩或切片已经产生合规资源时，默认 transport policy
+直接 no-op；transport 产生音频或图片时，又能自然触发“所有音频转写”或“所有图片
+降采样”等用户策略。
+
+同一 pass 中，一个超限资源会执行所有匹配的 transport policy，顺序为
+`priority(desc) → policyId`；各 policy 仍基于该 pass 开始时的同一资源 snapshot，
+产物在该 pass 全部执行结束后统一提交、识别和入队，不把前一个 transport policy 的
+产物隐式传给后一个 policy。Transport policy 对每个 resource occurrence 最多执行
+一次；它可以在下一 pass 作用于自己产生的新 occurrence，但必须同时受
+`maxTransportPasses`、lineage 和总
+执行预算约束。输出 hash 与输入相同或不能降低超限度量时，停止该分支继续迭代。
+
+“pass 末统一提交”不把多个 invocation 绑定成一个事务：每个 transport invocation
+按第 9 节独立原子校验，失败 policy 只隔离自己的 artifacts，其他成功 policy 的合规
+产物仍可进入候选。无论某条 policy 是否成功，原超限 source 都不能发送；transport
+policy 的 `output.source` 必须是 `omit`，其他值启动时拒绝。pass 末若没有任何成功且合规
+的替代产物，则生成明确 omission；这就是 transport fail closed 的含义。
+
+达到 `maxTransportPasses`、执行失败或无可投递合规产物时，移除超限媒体并产生明确
+的 omission 说明。现有分散在 ACP、TUI 和 Vision Bridge 图片路径的 inline clamp
+继续服务非 Omni 链路；Omni 媒体不再走 inline 通道。此外必须在 Omni model Part
+物化完成、进入 DashScope OpenAI converter 之前新增统一 final clamp，检查两件事：
+所有 Omni 媒体 Part 必须是受管 `oss://` 上传 URL（不允许 inlineData 或本地路径
+泄漏到 converter），且文件大小/时长在 guard 上限内。它只能 fail closed 并报告
+错误，不能替代 policy guard 或降级成 placeholder。
+
+### 10.3 DashScope OpenAI 边界
+
+首版只支持 DashScope OpenAI-compatible converter：
+
+- 图片使用 `image_url`；
+- WAV/MP3 音频使用 `input_audio`；
+- 视频使用 `video_url`；
+- Tool result 中的媒体沿用现有 split-tool-media 行为，在连续 tool response 后作为
+  follow-up user media 发送；
+- 不建设 Gemini、Anthropic 或其他 Provider 的媒体回传兼容。
+
+#### 10.3.1 DashScope 官方输入限制（2026-07-30 按官方文档核对）
+
+以下是百炼官方文档给出的多模态输入限制，作为 transport guard 度量和后续
+"大文件原生通路"决策的事实基础：
+
+| 通道                              | 限制                                                                                     |
+| --------------------------------- | ---------------------------------------------------------------------------------------- |
+| Base64 传入（所有模态）           | 编码后字符串 < 10MB                                                                      |
+| 图片公网 URL                      | 单图 ≤ 10MB（Qwen3.5+ 系列 ≤ 20MB）                                                      |
+| 视频公网 URL                      | qwen-vl-max/Qwen3-VL 及更新系列 ≤ 1–2GB；旧模型 ≤ 150MB                                  |
+| 视频时长                          | Qwen2.5-VL/QVQ：2s–10min；qwen-vl-max/Qwen3-VL：至 20min–2h（按模型）                    |
+| 音频公网 URL（Omni）              | Qwen3.5-Omni ≤ 2GB / 3h；Qwen3-Omni-Flash ≤ 100MB / 20min；Qwen-Omni-Turbo ≤ 10MB / 3min |
+| 视频公网 URL（Omni）              | Qwen3.5-Omni ≤ 2GB / 1h；Qwen3-Omni-Flash ≤ 256MB / 150s；Qwen-Omni-Turbo ≤ 150MB / 40s  |
+| 官方临时上传（`/api/v1/uploads`） | 单文件 ≤ 1GB，URL 有效期 48h，文件与模型绑定，100QPS，官方标注勿用于生产                 |
+| URL 响应头要求                    | 必须含 `Content-Length` 与正确 `Content-Type`，否则服务端下载失败                        |
+
+结论与决策：**base64 inline 的 10MB 限制远小于 URL 通道的限制**，且官方临时
+上传已经过端到端实测验证（2026-07-30，真实 API）：
+
+- 123KB / 21MB / 424MB 视频均完成"上传 → oss:// URL → qwen-vl-max 理解"全链路，
+  424MB/60s 视频消耗 35,642 video tokens 且内容理解完整；
+- 图片（`image_url`）与音频（`input_audio.data` 填 oss URL，qwen3-omni-flash）
+  同样打通；
+- 同一 oss URL 可在 48h 内跨请求复用；一份 getPolicy 凭证（300s 有效）可签发
+  多次上传；实测 `max_file_size_mb=1024`、日容量配额实际无限制；
+- 文件-模型绑定实测比文档宽松（vl-max 上传的文件 vl-plus 可用），但按文档保守
+  处理：上传缓存 key 含 model；
+- 漏加 `X-DashScope-OssResourceResolve: enable` 请求头时确定性返回 HTTP 400，
+  不会静默降级。
+
+**因此首版投递唯一采用官方临时上传通道，不保留 inline 投递模式。**外部 URL
+不透传给模型：任何来源（本地路径、URL、base64、工具产物）都先本地化为受管
+文件——本地字节是 metadata、SHA-256 身份、token 估算和 policy 加工的唯一事实
+源——再经官方上传取得 oss:// URL 投递。这同时规避了外部 URL 缺失
+`Content-Length`/`Content-Type`、鉴权、内容漂移导致的服务端拉取失败与实验不可
+复现问题。
+
+#### 10.3.2 上传服务
+
+投递前的上传由一个共享 upload service 承担：
+
+```text
+待投递媒体（受管本地文件, sha256 已知）
+  → 查上传缓存 (sha256 + model)
+      → 命中且未过期：直接复用 oss:// URL
+      → miss / 过期：
+          getPolicy(model)（凭证按 model 缓存，300s 有效期内复用）
+          → OSS multipart 表单上传（流式，记录耗时与速率）
+          → 写入上传缓存 {ossUrl, uploadedAt, expiresAt = +47h}
+  → oss:// URL 进入 Part 物化
+```
+
+约束：
+
+- 上传缓存的持久化形态由受管媒体存储设计定义；**Memory 永不持久化 oss URL**，
+  只存 sha256 引用——URL 是 48h 投递缓存，不是身份；
+- 缓存按 47h 过期（对官方 48h 留余量）；过期后从本地 `objects/` 透明重传；
+- 上传失败按可重试错误处理（`maxAttempts` 内重试）；最终失败时该媒体投递
+  fail closed，产生明确 omission，不回退到任何 inline 通道；
+- getPolicy 限流 100QPS 按主账号+模型计；凭证复用使实验负载远低于该限；
+- 每次上传记录文件大小、耗时、速率与缓存命中情况，计入实验执行记录（上传
+  时间是 harness 侧成本的一部分）；
+- 上传发生在 transport guard 通过之后，只上传最终确认投递的媒体，`retain`
+  产物不上传。
+
+#### 10.3.3 Part 物化与 converter 接入
+
+当前 `ToolArtifact` 只是 `ToolCallResponseInfo` metadata，不会自动成为模型
+`Part`。本设计必须新增共享 bridge：
+
+```text
+Core ToolCallResponseInfo.policyArtifacts ─┐
+ACP raw MediaPolicyTool artifacts ─────────┴→ PolicyArtifactBatch
+  → 验证 managed path 和 policy output descriptor
+  → MediaCandidate
+  → recognition / fixed policy / transport
+  → upload service → oss:// URL
+  → fileData Part { fileUri: "oss://…", mimeType }
+  → 原 Tool 的 FunctionResponse.parts
+  → OpenAI split-tool-media converter
+```
+
+完成该 bridge 后才是"复用现有 converter"。Omni 模式强制或启动校验
+`splitToolMedia = true`，避免 DashScope 把媒体留在不兼容的 tool message 中。
+Scheduler 合并进来的普通 hook artifact 不自动进入该 bridge；只有带有 Omni policy
+output descriptor、位于受管目录且通过候选校验的 artifact 才能回流。
+
+`fileData.fileUri` 只允许承载 `oss://dashscope-instant/` 前缀的受管上传 URL；
+本地路径和任意外部 URL 仍然禁止进入 fileData。converter 侧需要两处增量：
+
+1. **音频 fileData 分支**：现有 converter 的 fileData 只处理 image/pdf/video，
+   音频会落入 unsupported 文本，必须补 `fileData + audio → input_audio.data =
+<oss url>` 的映射；
+2. **请求头注入**：请求包含 oss:// 媒体 Part 时，为该请求附加
+   `X-DashScope-OssResourceResolve: enable`（缺失时服务端确定性 400，属于
+   final clamp 应拦截的编程错误）。
+
+官方文档未明确整请求媒体总量限制（图片数量、多媒体混合等仍有模型级约束），
+在开始真实模型 E2E 前须实测多媒体混合请求；若发现新约束，只修正 guard 的度量
+实现，不改变用户 Fixed Policy 语义。
+
+## 11. 模型调用
+
+### 11.1 模型可见性
+
+Policy Tool 始终可以注册，但只有 `modelAccess.enabled: true` 才能被模型或 direct
+client 调用。未配置 `policyTools` 条目时使用 Tool 原生 runtime 默认值，并默认
+`modelAccess.enabled: false`；fixed policy 仍可引用它。该 gate 必须同时覆盖：
+
+1. ToolRegistry 初始 declarations 和 subagent 使用的 filtered declarations；
+2. deferred Tool 摘要和 ToolSearch keyword 搜索；
+3. ToolSearch exact-select；
+4. CoreToolScheduler 对 model/client 来源 ToolCall 的执行前校验；
+5. ACP `Session.runTool()` 对模型返回 ToolCall 的执行前校验。
+
+仅使用 `shouldDefer` 不够，因为 ToolSearch 可以重新 reveal；使用 `tools.disabled`
+也不合适，因为固定编排器将无法找到 Tool。
+
+### 11.2 参数投影
+
+每个模型可调用 Tool 支持：
+
+- `description`：覆盖模型看到的 Tool 描述；
+- `defaultArguments`：模型缺省时填入；
+- `lockedArguments`：Harness 固定注入，模型 schema 中不可见；
+- `parameterSchema`：在 Tool 原生 schema 基础上进一步收窄；
+- `runtime`：timeout 和并发限制。
+
+参数处理顺序固定为：
+
+```text
+拒绝模型显式传入 lockedArguments 字段
+  → 用 projected parameterSchema 校验模型原始参数
+  → defaultArguments + model args + lockedArguments
+  → Tool 原生 schema 和业务校验
+  → execute
+```
+
+模型显式传入 lockedArguments 字段时返回参数错误，不能静默覆盖。配置 schema 只能收窄
+Tool 原生 schema，不能扩大类型、枚举、范围或额外属性集合。Projected schema 从
+Tool 原生 schema 删除 lockedArguments 字段后再应用配置约束，因此
+defaultArguments 和 lockedArguments 只在最终原生 schema 校验中出现。
+
+参数投影和归一化实现为 core shared resolver，由 CoreToolScheduler 与 ACP
+`Session.runTool()` 共同调用，不能只修改模型声明或 Core Scheduler。
+
+fixed policy 不使用 `modelAccess.defaultArguments` 或 `lockedArguments`，只使用自己的
+`arguments`，启动时先经过删除 `resourceId` 后的 fixed-policy argument schema；运行时注入资源 ID 后再
+经过完整 Tool 原生校验。
+
+### 11.3 Per-tool runtime
+
+`policyTools.<tool>.runtime` 不是只供 fixed orchestrator 使用的旁路预算。Core 增加
+shared runtime resolver/controller，由固定调用、Core Scheduler 的 model/client
+调用和 ACP 模型 ToolCall 共同使用：
+
+- `timeoutMs` 是该 MediaPolicyTool invocation 的超时；未配置时回退到现有全局 Tool
+  timeout，显式配置时覆盖全局默认，但不覆盖 turn abort 或 session cancellation；
+- `maxConcurrency` 是同一 Config/session 内该 Tool 的共享 semaphore；未配置时只受
+  现有全局 Tool 并发限制，配置后有效并发上限是 per-tool 与全局上限的较小值；
+- fixed、model 和 client origin 竞争同一个 per-tool semaphore，不能各自维护计数；
+- timeout 等待、排队时间、取消原因和最终 effective runtime 全部写入实验记录。
+
+这需要在现有全局环境变量控制之外增加 MediaPolicyTool 专用解析与接入；不能只在
+配置 schema 中声明字段而没有调用方读取。
+
+### 11.4 模型调用产物
+
+模型调用没有 configured fixed policy，因此 `modelAccess.output` 单独定义产物行为：
+
+- 当已启用的 MediaPolicyTool descriptor 声明 outputs 时，必须显式配置
+  `modelAccess.output.reprocessMedia` 和 `artifacts`；
+
+- 所有媒体 artifact 始终先经过识别和 metadata；
+- `reprocessMedia` 决定是否执行 `fixedPolicies`；
+- artifact selector 决定哪些结果进入原 Tool 的 model-visible result；
+- 被 include 的媒体继续经过 transport guard；
+- 未命中的结果默认 retain；
+- 原始 source 已存在于当前上下文，不提供 fixed policy 的 `source keep/omit`。
+
+模型调用失败时不处理或投递部分 artifacts。成功产物由共享 artifact-to-media bridge
+物化为 `FunctionResponse.parts`，然后复用 DashScope OpenAI split-tool-media。
+
+## 12. 顶层 Omni 配置
+
+实验配置直接使用 settings 顶层 `omni`，不嵌入现有 `tools`、`modelProviders` 或
+其他长期产品配置：
+
+```text
+settings.json.omni
+  → 现有 settings scope 加载与 workspace trust
+  → loadCliConfig 专用归一化和语义校验
+  → ConfigParameters.omni
+  → Config.getOmniConfig()
+```
+
+不增加独立配置文件、加载器或运行时服务。首版要求重启生效，不增加 CLI flag、
+环境变量、settings UI、migration 或 hot reload。启动时必须输出归一化后的配置
+错误，不能静默跳过无效 fixed policy。
+
+### 12.1 Scope 合并语义
+
+沿用现有 settings scope 优先级：
+`SystemDefaults < User < trusted Workspace < System`；未信任 workspace 的 `omni`
+配置不参与合并。Omni 在现有 deep merge 上为策略集合增加专用语义：
+
+- `fixedPolicies`、`transportGuard.policies` 和 `policyTools` 都是按 ID/key 合并的
+  map；
+- 高优先级 scope 出现同一个 ID 时，整条 Fixed Policy 或整个 Policy Tool 配置替换
+  低优先级条目，不递归拼接其 `arguments`、`output`、`runtime` 或
+  `modelAccess.parameterSchema`；
+- 所有数组整体替换，不做 concat 或 union；
+- 其他普通对象和 scalar 沿用现有 settings deep merge 与 last-wins 行为；
+- 高优先级 scope 可以用仅含 `enabled: false` 的同 ID tombstone 关闭低优先级用户
+  Fixed Policy；归一化后 tombstone 不进入执行计划；
+- `transportGuard` 和其中的 policy 不支持 tombstone 或关闭，覆盖后的最终集合仍须
+  通过三种媒体覆盖与非空校验；
+- `policyTools.modelAccess.enabled: false` 只关闭模型可调用性，不注销固定调用所需
+  的 Policy Tool。
+
+系统最高优先级配置可以重新声明或锁定最终策略。日志中的 resolved config hash 在
+scope 合并、tombstone 移除、默认值补齐和语义校验完成后计算，确保记录的是实际执行
+配置而不是任一原始 settings 文件。
+
+### 12.2 完整带注释示例
+
+以下 JSONC 是结构示例。具体 policy 默认参数将在逐模态策略设计中确定；所有字段
+均附带用户可理解的说明。`omni.ingestion` 的权威契约在前置的文件识别与 metadata
+设计中维护；这里复制一份仅为展示完整配置，最终实现必须复用同一个 schema 和
+normalizer，并用配置 snapshot 测试防止两处示例漂移。
+
+```jsonc
+{
+  // Omni 实验配置的唯一顶层入口；不增加 omni.enabled。
+  "omni": {
+    // 配置结构版本，用于记录实验和兼容后续结构调整。
+    "schemaVersion": 1,
+
+    // 文件本地化、识别和 metadata 提取配置。
+    "ingestion": {
+      // 将 URL、base64 等资源转为本地受管文件的配置。
+      "localization": {
+        // HTTP(S) URL 的预检和下载配置。
+        "url": {
+          // 超过该大小时必须征求用户下载许可；默认 100 MiB，只允许调低。
+          "approvalThresholdBytes": 104857600,
+          // URL 预检最多读取的响应前缀，用于判断 magic bytes。
+          "preflightBytes": 65536,
+          // HEAD 或 Range 预检的超时时间。
+          "preflightTimeoutMs": 30000,
+          // 用户许可后，完整文件下载允许的最长时间。
+          "downloadTimeoutMs": 600000,
+          // URL 下载最多允许的重定向次数；每次重定向都会重新安全检查。
+          "maxRedirects": 5,
+        },
+        // base64、data URI 和直接 bytes 输入的本地化配置。
+        "inline": {
+          // 允许解码并落盘的最大二进制大小，防止超大 inline 数据耗尽内存。
+          "maxDecodedBytes": 104857600,
+        },
+      },
+
+      // 文件内容类型识别配置。
+      "recognition": {
+        // sniff 阶段最多读取的本地文件字节数；最终类型仍以内容证据为准。
+        "sniffMaxReadBytes": 65536,
+      },
+
+      // Metadata 的内部提取与模型可见投影配置。
+      "metadata": {
+        // Harness 内部使用的完整 metadata 提取配置。
+        "extraction": {
+          // 图片 probe 的资源控制配置。
+          "image": {
+            // 图片尺寸、方向和动图信息提取的最长执行时间。
+            "timeoutMs": 10000,
+          },
+          // 音频 ffprobe 配置。
+          "audio": {
+            // 单个音频 probe 的最长执行时间。
+            "timeoutMs": 30000,
+            // 传给 ffprobe 的 probesize；null 表示使用 ffprobe 默认值。
+            "probeSizeBytes": null,
+            // 传给 ffprobe 的 analyzeduration；null 表示使用 ffprobe 默认值。
+            "analyzeDurationUs": null,
+          },
+          // 视频 ffprobe 配置。
+          "video": {
+            // 单个视频 probe 的最长执行时间。
+            "timeoutMs": 30000,
+            // 传给 ffprobe 的 probesize；可用于实验探测精度与耗时的关系。
+            "probeSizeBytes": null,
+            // 传给 ffprobe 的 analyzeduration；可用于调整流信息分析深度。
+            "analyzeDurationUs": null,
+          },
+        },
+
+        // 控制哪些 metadata 会展示给模型，不影响内部 Fixed Policy 判断。
+        "modelVisibility": {
+          // 所有媒体都可以展示的公共字段。
+          "commonFields": [
+            "displayName",
+            "sizeBytes",
+            "detectedMimeType",
+            "container",
+            "probe.status",
+            "tokenEstimate.status",
+            "tokenEstimate.estimatedTokenCount",
+            "tokenEstimate.method",
+          ],
+          // 图片可展示的技术字段。
+          "imageFields": [
+            "width",
+            "height",
+            "orientation",
+            "animated",
+            "frameCount",
+            "durationMs",
+          ],
+          // 音频文件级可展示字段。
+          "audioFields": ["durationMs", "bitRate"],
+          // 音频流级可展示字段。
+          "audioStreamFields": [
+            "codec",
+            "sampleRateHz",
+            "channels",
+            "channelLayout",
+            "bitRate",
+          ],
+          // 视频文件级可展示字段。
+          "videoFields": ["durationMs", "bitRate"],
+          // 视频流级可展示字段。
+          "videoStreamFields": [
+            "codec",
+            "width",
+            "height",
+            "frameRate",
+            "bitRate",
+          ],
+          // 是否向模型展示 MIME 冲突、probe 不完整等非致命警告。
+          "includeWarnings": true,
+          // 是否向模型展示内容哈希；默认隐藏，但内部始终保留。
+          "includeContentHash": false,
+        },
+      },
+    },
+
+    // 多模态 policy 的编排和 Tool 配置。
+    "processing": {
+      // 固定 policy 编排器的全局资源预算。
+      "limits": {
+        // 同时处理的媒体资源数量；1 最利于实验复现。
+        "maxConcurrentResources": 1,
+        // 计算 session 可用上下文时，为本轮模型输出预留的 token 数量。
+        "reservedOutputTokens": 8192,
+        // 单个原始资源允许产生的最大衍生链深度。
+        "maxLineageDepth": 8,
+        // 单个原始资源允许执行的最大 policy 次数。
+        "maxPolicyRunsPerRoot": 64,
+        // 单个原始资源允许登记的最大衍生物数量。
+        "maxArtifactsPerRoot": 256,
+        // 单个原始资源允许产生的衍生文件总大小。
+        "maxDerivedBytesPerRoot": 1073741824,
+        // Transport Guard 最多允许执行的反馈轮数。
+        "maxTransportPasses": 3,
+      },
+
+      // Harness 自动调用的 Fixed Policy；所有条目共享一个有序集合。
+      "fixedPolicies": {
+        // 用户定义的 policyId，用于日志、配置覆盖和实验复现。
+        "extract-video-audio": {
+          // 是否启用该 Fixed Policy；可用于策略消融实验。
+          "enabled": true,
+          // 全局执行优先级；数字越大越先执行。
+          "priority": 100,
+          // 定义该 Fixed Policy 可以处理哪些资源。
+          "match": {
+            // 该 Fixed Policy 只处理视频资源。
+            "mediaTypes": ["video"],
+            // 允许处理用户输入、工具结果和其他 policy 产生的资源。
+            "origins": ["user", "tool", "policy"],
+          },
+          // 未配置 when，表示匹配资源后无条件执行。
+          // 实际执行该 policy 的 Qwen Code Tool 名。
+          "tool": "omni_extract_audio",
+          // 固定调用时传给 Tool 的参数；输入 resourceId 由 Harness 注入。
+          "arguments": {
+            // 将提取结果封装为 WAV 文件。
+            "format": "wav",
+            // 使用适合 ASR 的 16-bit PCM 编码。
+            "codec": "pcm_s16le",
+            // 将输出音频采样率固定为 16 kHz。
+            "sampleRateHz": 16000,
+          },
+          // 同一衍生链中该 Fixed Policy 最多执行一次，防止重复提取。
+          "maxRunsPerLineage": 1,
+          // 失败后继续执行该资源的其他 Fixed Policy。
+          "onFailure": "continue",
+          // 定义衍生物是否回流以及如何进入模型输入。
+          "output": {
+            // 让完成识别的音频重新进入 Fixed Policy 处理。
+            "reprocessMedia": true,
+            // 保留原视频作为模型输入候选。
+            "source": "keep",
+            // 按 artifact 类型决定投递方式。
+            "artifacts": {
+              // 按 ToolArtifact.kind 选择音频，并自动加入模型输入候选。
+              "kind:audio": "include",
+              // 其他辅助产物只保留，不自动发送给模型。
+              "*": "retain",
+            },
+          },
+        },
+
+        // 用户定义的显式衍生物依赖 policyId。
+        "transcribe-extracted-audio": {
+          // 是否启用音频转写 Fixed Policy。
+          "enabled": true,
+          // 全局执行优先级。
+          "priority": 90,
+          // 只处理指定 policy 产生的音频。
+          "match": {
+            // 该 Fixed Policy 只处理音频资源。
+            "mediaTypes": ["audio"],
+            // 只匹配 extract-video-audio 产生的衍生物。
+            "producedBy": ["extract-video-audio"],
+          },
+          // 未配置 when，表示匹配资源后无条件执行。
+          // 执行音频转写的 Tool 名。
+          "tool": "omni_transcribe_audio",
+          // 固定转写调用的 Tool 参数。
+          "arguments": {
+            // 自动识别音频语言。
+            "language": "auto",
+          },
+          // 转写失败时继续保留音频资源和其他处理结果。
+          "onFailure": "continue",
+          // 定义转写结果的投递方式。
+          "output": {
+            // 文本转写不是媒体资源，不重新执行媒体 fixed policies。
+            "reprocessMedia": false,
+            // 保留输入音频的既有投递状态。
+            "source": "keep",
+            // 按 artifact 类型决定是否发送给模型。
+            "artifacts": {
+              // 按 Tool 声明的 transcript role 选择转写文本并加入模型上下文。
+              "role:transcript": "include",
+              // 其他转写辅助文件只登记，不自动发送。
+              "*": "retain",
+            },
+          },
+        },
+
+        // 仅在 when 条件命中时执行的图片降采样 Fixed Policy。
+        "downsample-image-over-2k": {
+          // 是否启用该 Fixed Policy。
+          "enabled": true,
+          // 全局执行优先级。
+          "priority": 100,
+          // 定义该 Fixed Policy 处理的媒体类型。
+          "match": {
+            // 该 Fixed Policy 只处理图片。
+            "mediaTypes": ["image"],
+          },
+          // 定义触发该 Fixed Policy 的 metadata 条件。
+          "when": {
+            // 任意一个条件成立即可执行。
+            "any": [
+              {
+                // 检查图片宽度。
+                "left": { "field": "resource.width" },
+                // 使用大于比较。
+                "operator": "gt",
+                // 宽度超过 2000 像素时命中。
+                "right": { "value": 2000 },
+              },
+              {
+                // 检查图片高度。
+                "left": { "field": "resource.height" },
+                // 使用大于比较。
+                "operator": "gt",
+                // 高度超过 2000 像素时命中。
+                "right": { "value": 2000 },
+              },
+            ],
+          },
+          // 执行图片降采样的 Tool 名。
+          "tool": "omni_downsample_image",
+          // 固定调用时使用的降采样参数。
+          "arguments": {
+            // 输出图片的最大宽度。
+            "maxWidth": 2000,
+            // 输出图片的最大高度。
+            "maxHeight": 2000,
+          },
+          // 条件所需字段不可用时跳过，并记录不可求值原因。
+          "onConditionUnavailable": "skip",
+          // 降采样失败时继续其他 Fixed Policy，最终由 Transport Guard 兜底。
+          "onFailure": "continue",
+          // 定义原图和降采样图片的投递方式。
+          "output": {
+            // 让完成识别的降采样图片重新执行 Fixed Policy。
+            "reprocessMedia": true,
+            // 从模型输入候选中移除原图，但仍在本地保留。
+            "source": "omit",
+            // 自动把降采样图片加入模型输入候选。
+            "artifacts": {
+              // 按 ToolArtifact.kind 选择图片衍生物并加入模型输入候选。
+              "kind:image": "include",
+            },
+          },
+        },
+
+        // 当本轮媒体预估 token 超过当前 session 可用上下文时提取视频关键帧。
+        "extract-keyframes-when-context-tight": {
+          // 是否启用该上下文预算策略。
+          "enabled": true,
+          // 全局执行优先级；低于显式尺寸处理策略。
+          "priority": 80,
+          // 该 Fixed Policy 只处理视频资源。
+          "match": {
+            // 只为视频执行关键帧提取。
+            "mediaTypes": ["video"],
+          },
+          // 比较本轮全部媒体的预估 token 与当前 session 可用上下文。
+          "when": {
+            // 所有条件均满足时才执行。
+            "all": [
+              {
+                // 左值是本轮待发送媒体的预估 token 总量。
+                "left": {
+                  "field": "request.totalEstimatedMediaTokens",
+                },
+                // 当预估媒体 token 大于可用上下文时命中。
+                "operator": "gt",
+                // 可用上下文由窗口、已用 prompt 和预留输出 token 计算。
+                "right": {
+                  "field": "session.availableContextTokens",
+                },
+              },
+              {
+                // 确认当前视频本身具有可用的 token 估算值。
+                "left": {
+                  "field": "resource.estimatedTokenCount",
+                },
+                // 大于零表示该资源已完成有效估算。
+                "operator": "gt",
+                // 零是估算值有效性的下界。
+                "right": { "value": 0 },
+              },
+            ],
+          },
+          // 条件依赖值不可用时跳过，不误判为条件不成立。
+          "onConditionUnavailable": "skip",
+          // 执行视频关键帧提取的 Tool 名。
+          "tool": "omni_extract_keyframes",
+          // 固定调用时使用的关键帧参数。
+          "arguments": {
+            // 单次最多生成 16 张关键帧。
+            "maxFrames": 16,
+            // 按场景变化选择代表帧。
+            "strategy": "scene",
+          },
+          // 失败时继续后续策略，最终由 Transport Guard 兜底。
+          "onFailure": "continue",
+          // 定义原视频和关键帧的投递方式。
+          "output": {
+            // 关键帧完成识别后继续执行适用于图片的 Fixed Policy。
+            "reprocessMedia": true,
+            // 原视频不再作为本轮模型输入候选，但仍保留在本地。
+            "source": "omit",
+            // 将生成的图片衍生物加入模型输入候选。
+            "artifacts": {
+              // 按 ToolArtifact.kind 选择关键帧图片。
+              "kind:image": "include",
+            },
+          },
+        },
+      },
+
+      // 模型投递前不可关闭的上传通道超限保护。
+      "transportGuard": {
+        // 官方临时上传的单文件上限；只能调低，不得高于官方 1GB 硬上限。
+        "maxUploadFileBytes": 1073741824,
+        // 当前实验模型集合的媒体时长上限（毫秒）；null 表示不启用时长维度。
+        "maxDurationMs": null,
+        // 超限时按 priority 执行的默认策略；该集合不能为空。
+        "policies": {
+          // 示例：超限图片默认进行尺寸和质量压缩。
+          "default-image-downsample": {
+            // Transport Guard 内部的执行优先级。
+            "priority": 100,
+            // 定义该默认策略处理的图片资源。
+            "match": {
+              // 只处理超过 transport 限制的图片。
+              "mediaTypes": ["image"],
+            },
+            // 执行图片降采样的 Tool 名。
+            "tool": "omni_downsample_image",
+            // 默认图片降采样参数；最终值在图片 policy 设计中确定。
+            "arguments": {
+              // 输出图片最长边不超过 1568 像素。
+              "maxDimension": 1568,
+              // 输出 JPEG 的初始质量系数。
+              "quality": 85,
+            },
+            // 定义默认处理结果的投递方式。
+            "output": {
+              // 让完成识别的降采样图片重新执行用户 Fixed Policy。
+              "reprocessMedia": true,
+              // 超限原图不再进入模型 payload。
+              "source": "omit",
+              // 降采样图片自动加入模型输入候选。
+              "artifacts": {
+                // 按 ToolArtifact.kind 选择图片衍生物并加入模型输入候选。
+                "kind:image": "include",
+              },
+            },
+          },
+
+          // 示例：超限音频默认转写为文本。
+          "default-audio-transcription": {
+            // Transport Guard 内部的执行优先级。
+            "priority": 100,
+            // 定义该默认策略处理的音频资源。
+            "match": {
+              // 只处理超过 transport 限制的音频。
+              "mediaTypes": ["audio"],
+            },
+            // 执行音频转写的 Tool 名。
+            "tool": "omni_transcribe_audio",
+            // 默认转写参数；最终值在音频 policy 设计中确定。
+            "arguments": {
+              // 自动识别音频语言。
+              "language": "auto",
+            },
+            // 定义默认处理结果的投递方式。
+            "output": {
+              // 文本不是媒体资源，不执行媒体 fixed policies。
+              "reprocessMedia": false,
+              // 超限原音频不再进入模型 payload。
+              "source": "omit",
+              // 转写文本自动加入模型输入候选。
+              "artifacts": {
+                // 按 Tool 声明的 transcript role 选择转写文本。
+                "role:transcript": "include",
+              },
+            },
+          },
+
+          // 示例：超限视频默认提取关键帧。
+          "default-video-keyframes": {
+            // Transport Guard 内部的执行优先级。
+            "priority": 100,
+            // 定义该默认策略处理的视频资源。
+            "match": {
+              // 只处理超过 transport 限制的视频。
+              "mediaTypes": ["video"],
+            },
+            // 执行关键帧提取的 Tool 名。
+            "tool": "omni_extract_keyframes",
+            // 默认关键帧提取参数。
+            "arguments": {
+              // 最多生成的关键帧数量。
+              "maxFrames": 16,
+              // 使用场景变化方式选择关键帧。
+              "strategy": "scene",
+            },
+            // 定义默认处理结果的投递方式。
+            "output": {
+              // 让完成识别的关键帧重新执行用户 Fixed Policy。
+              "reprocessMedia": true,
+              // 超限原视频不再进入模型 payload。
+              "source": "omit",
+              // 关键帧自动加入模型输入候选。
+              "artifacts": {
+                // 按 ToolArtifact.kind 选择图片衍生物并加入模型输入候选。
+                "kind:image": "include",
+              },
+            },
+          },
+        },
+      },
+
+      // 对每个 Omni policy Tool 进行运行时和模型暴露配置。
+      "policyTools": {
+        // 固定提取音频所使用的 Tool。
+        "omni_extract_audio": {
+          // 对固定调用和模型调用都有效的运行时约束。
+          "runtime": {
+            // 单次音频提取最长允许执行两分钟。
+            "timeoutMs": 120000,
+            // 该 Tool 最多允许两个 invocation 并行执行。
+            "maxConcurrency": 2,
+          },
+          // 控制该 Tool 是否暴露给模型。
+          "modelAccess": {
+            // false 表示只能由 Fixed Policy 或 Transport Guard 调用。
+            "enabled": false,
+          },
+        },
+
+        // 图片 Fixed Policy 和 Transport Guard 使用的降采样 Tool。
+        "omni_downsample_image": {
+          // 对固定调用和模型调用都有效的运行时约束。
+          "runtime": {
+            // 单次图片降采样最长允许执行一分钟。
+            "timeoutMs": 60000,
+            // 最多允许两个图片降采样 invocation 并行执行。
+            "maxConcurrency": 2,
+          },
+          // 控制该 Tool 是否暴露给模型。
+          "modelAccess": {
+            // false 表示示例中只允许 Harness 固定调用。
+            "enabled": false,
+          },
+        },
+
+        // 音频 Fixed Policy 和 Transport Guard 使用的转写 Tool。
+        "omni_transcribe_audio": {
+          // Tool 级配置参数：与单次调用无关的后端与默认行为设置。
+          "settings": {
+            // 执行转写使用的 ASR 后端模型标识；凭证走现有 provider 体系。
+            "asrModel": "qwen3-asr-flash",
+            // 转写输出是否包含分段时间戳。
+            "includeTimestamps": true,
+          },
+          // 对固定调用和模型调用都有效的运行时约束。
+          "runtime": {
+            // 单次音频转写最长允许执行十分钟。
+            "timeoutMs": 600000,
+            // 默认只并行执行一个转写 invocation，便于控制远端成本。
+            "maxConcurrency": 1,
+          },
+          // 控制该 Tool 是否暴露给模型。
+          "modelAccess": {
+            // false 表示示例中只允许 Harness 固定调用。
+            "enabled": false,
+          },
+        },
+
+        // 视频 Fixed Policy 和 Transport Guard 使用的关键帧提取 Tool。
+        "omni_extract_keyframes": {
+          // 对固定调用和模型调用都有效的运行时约束。
+          "runtime": {
+            // 单次关键帧提取最长允许执行五分钟。
+            "timeoutMs": 300000,
+            // 默认只并行处理一个视频，避免瞬时 CPU 和磁盘压力。
+            "maxConcurrency": 1,
+          },
+          // 控制该 Tool 是否暴露给模型。
+          "modelAccess": {
+            // false 表示示例中只允许 Harness 固定调用。
+            "enabled": false,
+          },
+        },
+
+        // 允许模型主动裁剪视频片段的 Tool。
+        "omni_clip_video": {
+          // 对视频裁剪 Tool 的运行时限制。
+          "runtime": {
+            // 单次裁剪最长允许执行两分钟。
+            "timeoutMs": 120000,
+            // 最多允许两个视频裁剪 invocation 并行执行。
+            "maxConcurrency": 2,
+          },
+          // 模型可调用行为的精细配置。
+          "modelAccess": {
+            // 将该 Tool 暴露给模型。
+            "enabled": true,
+            // 覆盖模型看到的 Tool 描述，可用于 Tool prompt 实验。
+            "description": "Read a selected segment of a video resource.",
+            // 模型未提供参数时补入的默认值。
+            "defaultArguments": {
+              // 默认生成 MP4 片段。
+              "format": "mp4",
+            },
+            // 模型不能修改、且不会出现在模型参数 schema 中的参数。
+            "lockedArguments": {
+              // 限制单个裁剪产物大小，控制磁盘与上传成本。
+              "maxOutputBytes": 104857600,
+            },
+            // 定义模型调用成功后如何处理和投递 Tool artifacts。
+            "output": {
+              // 让完成识别的裁剪视频继续执行用户 Fixed Policy。
+              "reprocessMedia": true,
+              // 按 artifact selector 配置模型可见产物。
+              "artifacts": {
+                // 裁剪视频自动进入原 Tool 的模型可见结果。
+                "kind:video": "include",
+                // 其他辅助文件只登记和保留。
+                "*": "retain",
+              },
+            },
+            // 在 Tool 原生 schema 基础上进一步收窄模型可用参数。
+            "parameterSchema": {
+              // 模型最终提交的参数必须是对象。
+              "type": "object",
+              // 对各个模型可控参数设置实验约束。
+              "properties": {
+                // 模型要读取的已登记视频资源。
+                "resourceId": {
+                  // 资源引用必须是字符串。
+                  "type": "string",
+                  // 说明该值来自当前上下文中的媒体资源信封。
+                  "description": "Opaque media resource ID from the current context.",
+                },
+                // 模型可以显式覆盖的输出容器格式。
+                "format": {
+                  // 输出格式必须是字符串枚举。
+                  "type": "string",
+                  // 首版只允许 DashScope 可接收的 MP4。
+                  "enum": ["mp4"],
+                },
+                // 视频裁剪起始位置，单位为毫秒。
+                "startMs": {
+                  // 起始位置必须是整数。
+                  "type": "integer",
+                  // 起始位置不能小于视频开头。
+                  "minimum": 0,
+                },
+                // 需要裁剪的视频长度，单位为毫秒。
+                "durationMs": {
+                  // 裁剪长度必须是整数。
+                  "type": "integer",
+                  // 单次至少读取一秒。
+                  "minimum": 1000,
+                  // 单次最多读取三十秒。
+                  "maximum": 30000,
+                },
+              },
+              // 模型必须显式提供资源、起始位置和裁剪长度。
+              "required": ["resourceId", "startMs", "durationMs"],
+              // 禁止模型传入未在 schema 中声明的额外参数。
+              "additionalProperties": false,
+            },
+          },
+        },
+      },
+    },
+
+    // 官方临时上传投递配置（10.3.2 上传服务）。
+    "delivery": {
+      // DashScope 官方临时上传通道。
+      "upload": {
+        // getPolicy 凭证的本地缓存时长（秒）；官方凭证有效期 300s，留余量。
+        "credentialTtlSeconds": 240,
+        // oss:// URL 的复用窗口（小时）；官方有效期 48h，留 1h 余量。
+        "urlTtlHours": 47,
+        // 单文件上传的最长允许时间。
+        "uploadTimeoutMs": 600000,
+        // 上传失败的最大尝试次数（含首次）。
+        "maxAttempts": 3,
+      },
+    },
+  },
+}
+```
+
+## 13. 配置解析与校验
+
+`loadCliConfig` 对 `omni` 执行专用归一化和语义校验，随后把不可变的
+`NormalizedOmniConfig` 传入 Core `Config`。至少检查：
+
+- schemaVersion 是否支持；
+- policy ID 是否在所属 map 内唯一；
+- priority、timeout、并发和预算是否为合法有限值；
+- `match`、condition field 和 output selector 是否使用支持的枚举；
+- `when` 引用的 resource、request 和 session 字段是否由对应 snapshot 提供；
+- Tool 是否存在并标记为 `MediaPolicyTool`；
+- `policyTools.<tool>.settings` 是否通过该 Tool 声明的 settings schema；
+- 有损输出的 descriptor 是否声明 `lossy`，运行时校验其 artifact 携带
+  `metadata.omniDisclosure`；
+- active model 的 `modalities` 声明是否覆盖 image、audio 和 video（硬性前提，
+  见 2.3）；
+- `ffmpeg`/`ffprobe` 是否可用（硬性前提，见 2.3）；
+- Fixed Policy `arguments` 是否通过删除 Harness-owned `resourceId` 后的
+  fixed-policy arguments
+  schema；
+- `producedBy` 是否引用存在的用户 Fixed Policy；
+- scope 合并后的 tombstone、整条替换和数组替换是否满足专用 merge 语义；
+- Omni 引用的 Tool 是否同时出现在 `tools.disabled`；
+- Transport Guard policy 是否覆盖模型可接受的图片、音频和视频类型；
+- `transportGuard.policies` 是否非空；
+- 每个 Transport Guard policy 的 `output.source` 是否为 `omit`；
+- `maxUploadFileBytes` 是否不高于官方临时上传 1GB 硬上限；
+- `delivery.upload` 的凭证 TTL、URL TTL、超时与重试次数是否为合法正值，且
+  `urlTtlHours` 不高于官方 48h；
+- `modelAccess.parameterSchema` 是否只收窄原生 schema；
+- `defaultArguments`、`lockedArguments` 和模型可控字段是否互相冲突；
+- 每个 output artifact selector 是否对应 Tool 可能产出的类型；
+- Fixed Policy、Transport Guard 与已启用的 `modelAccess` 是否提供各自必需的 output
+  字段；
+- transcript selector 是否只指向有界、受管的 UTF-8 `text/plain` artifact；
+- DashScope 路径是否启用了 `splitToolMedia`。
+
+配置结构错误或 Fixed Policy 引用不存在的 Tool 时启动失败。运行时单个用户策略的
+资源数据错误按 `onFailure` 处理；Transport Guard 配置错误属于程序或配置错误，不能降级为
+发送超限媒体。
+
+## 14. Metadata extraction 与 model visibility
+
+Metadata 必须分成两个独立概念：
+
+- `extraction`：Harness 内部完整事实，供 Fixed Policy、Transport Guard 和后续
+  memory 使用；
+- `modelVisibility`：模型可见投影，可通过字段 allowlist 做消融实验。
+
+`modelVisibility` 隐藏字段不能影响 Fixed Policy 判断。字段 allowlist 可以全部为空，但模型
+信封中的 `resourceId` 和 `mediaType` 始终存在。`localPath` 和鉴权 header 永不暴露；
+`contentHash` 和 warnings 只在显式配置时暴露。首版没有 source visibility 配置，
+`source` 全部保留为 Harness 内部 provenance，不向模型暴露。
+
+token estimate 与其他内部 metadata 一样始终可供条件判断；是否展示给模型由
+`modelVisibility` 单独决定。probe、估算或 session snapshot 字段不可得时，对应
+condition 记录 `unavailable`，避免把“没有数据”错误解释为“条件不成立”。
+
+## 15. Observability 与实验复现
+
+每次 fixed、model 和 client policy 调用至少记录：
+
+- Omni schemaVersion 与 resolved config hash；
+- root/source/resource ID 与内容哈希；
+- parent、producer 和完整 lineage；
+- policy ID、stage、priority 和 `when` 条件；
+- Tool 名、Tool 实现版本和 invocation ID；
+- 配置参数、模型参数以及 `defaultArguments`/`lockedArguments` 解析后的最终参数；
+- execution origin；
+- condition 命中、未命中或 unavailable 详情，以及本次 evaluation snapshot；
+- 开始时间、耗时、timeout、取消和错误类型；
+- 输入与输出 MIME、大小和关键技术 metadata；
+- delivery 变化；
+- Transport Guard pass 与最终投递/省略原因；
+- 上传缓存命中/上传耗时/速率/重试次数，以及每个投递媒体对应的 oss URL 有效期
+  快照（URL 本身可脱敏，仅保留可关联的 hash 引用）。
+
+模型 history 不包含伪造固定 ToolCall，但 UI 可以显示简洁进度。结构化执行记录与
+模型 transcript 分离保存，为策略评测和训练数据过滤提供事实依据。
+
+## 16. 与当前 Qwen Code 源码的对应关系
+
+本设计在现有链路中增加最小增量：
+
+- `packages/core/src/tools/tools.ts`：复用 `DeclarativeTool`、`ToolInvocation`、
+  `ToolResult` 和 `ToolArtifact`，增加 MediaPolicyTool 标记或 descriptor；
+- `packages/core/src/core/turn.ts`：为 `ToolCallRequestInfo` 增加明确 execution
+  origin，并为 `ToolCallResponseInfo` 增加只包含原始 MediaPolicyTool 产物的内部
+  `policyArtifacts` channel；
+- `packages/core/src/agents/runtime/agent-core.ts` 及其他 request 构造点：显式标记
+  model/client origin；不得使用 `isClientInitiated` 推断，缺省按 model fail closed；
+- `packages/core/src/core/nonInteractiveToolExecutor.ts`：固定调用继续复用
+  `executeToolCall(recordToolResult: false)`；
+- `packages/core/src/config/config.ts#createToolRegistry()`：MediaPolicyTool factory
+  使用不经过 PermissionManager 注册前 gate 的专用注册分支；
+- `packages/core/src/core/coreToolScheduler.ts`：校验 fixed origin 后跳过执行前
+  PermissionManager/legacy deny gate 和后续 permission flow，并为 model/client 来源增加
+  `modelAccess` 执行 gate；对 MediaPolicyTool 使用 shared per-tool runtime
+  resolver/controller，并在 hook artifact 合并前把原始 Tool 产物保留到
+  `policyArtifacts`，而不是只读取全局 timeout/concurrency 或依赖合并后 artifacts；
+- `packages/core/src/tools/tool-registry.ts`：模型 declarations 使用 Omni
+  model-visible view，并同时应用 `modelAccess` 与 PermissionManager 可见性；现有
+  `tools.disabled` 冲突在 Omni 启动校验中显式报错；
+- `packages/core/src/tools/tool-search.ts`：搜索和 exact-select 过滤 fixed-only policy，
+  并从 registry 的 model-visible view 返回同一份 projected description/schema，不能
+  重新序列化 Tool 原生 schema 暴露 `lockedArguments` 字段；
+- `packages/core/src/core/contentGenerator.ts`：从当前 active model 的
+  `contentGeneratorConfig.contextWindowSize` 读取 `session.contextWindowTokens`；
+- `packages/core/src/core/geminiChat.ts` 与现有 prompt estimation 路径：以当前 chat 的
+  `getLastPromptTokenCount()` 为已发送基线，再估算尚未发送内容，构造同一 pass 使用的
+  `FixedPolicyEvaluationContext`；不得读取与当前 chat 无关的全局 UI telemetry；
+- `packages/core/src/utils/fileUtils.ts`：媒体在现有 inline 转换和大小拒绝前进入
+  识别与 fixed policy；Omni 媒体此后不再回到 inline 通道，现有分散 clamp 只继续
+  服务非 Omni 链路；
+- `packages/core/src/services/media-processing/` 与 OpenAI 请求物化边界：新增
+  upload service（getPolicy 凭证缓存、OSS 表单上传、sha256+model URL 缓存），
+  并在 transport guard 之后、converter 之前新增统一 final clamp（校验 Omni 媒体
+  Part 均为受管 oss:// URL 且在上传限制内）；
+- `packages/core/src/core/openaiContentGenerator/converter.ts`：复用 DashScope
+  OpenAI 的 image/video `fileData → image_url/video_url` 与 split-tool-media
+  转换；需新增两处增量：`fileData + audio → input_audio.data = <oss url>` 分支，
+  以及请求含 oss:// 媒体 Part 时注入 `X-DashScope-OssResourceResolve: enable`
+  请求头；
+- `packages/core/src/core/openaiContentGenerator/pipeline.ts`：converter 的
+  modality gate 读取 `contentGeneratorConfig.modalities`（缺省为空对象，即全部
+  拒绝并替换 placeholder）。Omni 启动校验必须确认该配置覆盖三种媒体（见 2.3），
+  并在 placeholder 事件发生时回写执行记录；
+- `packages/cli/src/acp-integration/session/Session.ts`：ACP 在自己的输入和工具结果
+  公共漏斗调用同一 core orchestrator，并与 Core Scheduler 共用 `modelAccess`
+  gate、参数 resolver 和 per-tool runtime controller；ACP 模型 function call 显式
+  标记 model origin；模型 Policy Tool 成功后，在
+  PostToolUse artifact 合并/通知前捕获原始 `toolResult.artifacts`，构造同一
+  `PolicyArtifactBatch`，不实现第三套 policy 生命周期；
+- `packages/cli/src/config/settingsSchema.ts`、`packages/cli/src/config/config.ts` 和
+  `packages/core/src/config/config.ts`：加载顶层 `omni` 并提供只读配置 getter。
+
+建议把共享编排能力放在：
+
+```text
+packages/core/src/services/media-processing/
+```
+
+目录内部可以包含 resolver、matcher、orchestrator、delivery planner、upload
+service 和 transport guard，但它们共同组成一个 Qwen Code 媒体处理服务，不拆成
+多个平级项目。
+
+## 17. 失败语义
+
+工具结果中的 URL 如果在预检或流式下载时超过许可阈值，公共漏斗暂停该候选并返回
+`approval_required`。交互入口通过统一媒体下载确认恢复原 invocation 的后续处理；
+无交互入口返回明确的 artifact unavailable/error，不自行授权，也不把 URL 文本当成
+已处理媒体。
+
+| 场景                               | 行为                                                                 |
+| ---------------------------------- | -------------------------------------------------------------------- |
+| 用户 Fixed Policy 参数无效         | 启动时拒绝配置                                                       |
+| 模型参数违反 projected schema      | 返回 Tool 参数错误                                                   |
+| 模型调用 fixed-only Tool           | 在 Scheduler 执行前拒绝                                              |
+| Fixed Policy 引用普通 Tool         | 启动时拒绝配置                                                       |
+| Omni Tool 与 `tools.disabled` 冲突 | 启动时拒绝配置                                                       |
+| 用户 fixed policy hook deny/ask    | 作为 Tool 失败进入 `onFailure`，不弹确认框                           |
+| Transport policy hook deny/ask     | 该 policy 失败并隔离自身产物；其他成功 policy 可继续，原媒体不得发送 |
+| Tool 返回 error 及部分 artifacts   | 不识别、不回流、不投递；标记 failed/quarantined 并按失败策略处理     |
+| 产物校验或物化只完成一部分         | 回滚该 invocation 全部 delivery 变化，不提前 omit source             |
+| 用户 Fixed Policy Tool 失败        | 按 `onFailure`，不应用 output 变化                                   |
+| condition 字段缺失                 | `unavailable`，按 `onConditionUnavailable` 处理                      |
+| 衍生资源重复 hash                  | 保留独立 occurrence/resourceId，仅复用识别和可复用 policy 结果缓存   |
+| 触发 lineage 或资源预算            | 停止该 root 继续派生并记录原因                                       |
+| 单个 Transport Guard policy 失败   | 隔离自身产物；聚合其他成功 policy，原超限媒体始终不发送              |
+| Transport Guard policy 全部失败    | 移除超限媒体并生成明确 omission 说明                                 |
+| transport 多轮后仍超限             | 移除媒体并生成明确 omission 说明                                     |
+| getPolicy 或 OSS 上传失败          | 在 `maxAttempts` 内重试；最终失败则该媒体投递 fail closed 并明确说明 |
+| oss URL 过期（>48h 后复用）        | 上传缓存按 TTL 提前失效，从本地对象透明重传；不发送过期 URL          |
+| 请求含 oss:// 但漏加 resolve 头    | 服务端确定性 400；final clamp 在发送前拦截该编程错误                 |
+| DashScope 不接受已判定合规请求     | 返回 Provider 错误并记录度量，不绕过 guard 重发原媒体                |
+
+## 18. 验收标准
+
+### 18.1 Fixed Policy 条件与顺序
+
+- 所有用户 Fixed Policy 都位于同一个 `fixedPolicies` map；
+- 缺省 `when` 表示匹配资源后无条件执行；
+- `when` 可读取 resource metadata、token estimate、request media token total 和
+  session context snapshot，并支持字段间比较；
+- 数字更大的 priority 先执行，相同 priority 按 policy ID 排序；
+- 同一 pass 的全部 policy 使用同一份 evaluation snapshot；
+- 当前资源后续 policy 不会隐式读取前序 policy 产物；
+- `producedBy` 可以稳定实现视频提取音频后再转写；
+- fixed 调用不产生模型历史中的伪 function call/response；
+- Fixed Policy 的 Tool 参数经过原生 schema 校验。
+
+### 18.2 衍生物与 delivery
+
+- policy 输出登记 parent/root/producer lineage；
+- 媒体 artifact 始终识别，`reprocessMedia` 只控制是否重新执行用户 Fixed Policy；
+- `source keep/omit` 与 artifact `include/retain` 独立生效；
+- selector 冲突固定按 role、kind、默认项的具体度解析；
+- transcript 作为有界 `text/plain` artifact 物化为 text Part；
+- 有损 policy 的每个衍生物携带 `omniDisclosure`，投递媒体时披露文本随附为紧邻
+  text Part，模型可见"实际处理了什么、丢了什么"；
+- 有损输出缺失披露文本按产物校验失败处理；
+- 多个 policy 的 include 取并集、omit 单调生效；
+- 产物部分失败时不会提交半套 delivery 变化；
+- 同一 policy 默认不重复作用于自己的 lineage；
+- 并发开启后，模型输入顺序仍保持确定。
+
+### 18.3 Transport 与上传投递
+
+- 用户 policy 已生成合规产物时 Transport Guard policy 不运行；
+- 同一 pass 多个匹配 Transport Guard policy 按确定顺序全部执行并缓冲产物；
+- 超限视频运行默认 Transport Guard policy 后，关键帧重新进入图片 Fixed Policy；
+- transport 产物仍超限时按轮次继续处理，达到上限后 fail closed；
+- guard 按上传通道口径（文件字节数与可选时长）判断，任何路径都不能把超限
+  媒体上传或发送给 DashScope；
+- 所有投递媒体均以 `oss://` 上传 URL 形式进入请求；不存在 inlineData 投递路径，
+  也不存在外部 URL 透传路径；
+- 相同 sha256+model 的媒体在 TTL 内复用上传缓存，不重复上传；TTL 过期后自动
+  重传且对调用方透明；
+- `retain` 产物不上传；只有最终确认投递的媒体产生上传流量；
+- 含 oss:// Part 的请求带有 `X-DashScope-OssResourceResolve: enable` 请求头；
+- 音频经 `fileData → input_audio` 新增分支正确转换；
+- 上传耗时、速率与缓存命中写入执行记录；
+- 启动时校验 active model modalities 覆盖三种媒体；converter placeholder 替换
+  一旦发生按投递失败记录，不允许静默吞掉媒体；
+- 新增的统一 final clamp 可以捕获所有来源的漏接入口（非 oss:// 媒体 Part、超限
+  文件、缺失请求头），但正常成功路径不依赖它或 placeholder 降级。
+
+### 18.4 模型调用
+
+- `modelAccess.enabled: false` 的 policy 不出现在 declarations 或 ToolSearch；
+- 模型猜测 fixed-only Tool 名也会被 Scheduler 拒绝；
+- direct client 调用 fixed-only Policy Tool 也会被执行 gate 拒绝；
+- `defaultArguments`、`lockedArguments` 和 `parameterSchema` 按固定顺序生效；
+- `lockedArguments` 不能被模型覆盖；
+- per-tool timeout/concurrency 对 fixed、model 和 client 三种来源使用同一 resolver 与
+  计数器；
+- 模型裁剪视频后，DashScope OpenAI 收到配对后的 follow-up user video media；
+- Tool 返回的 artifact 重新经过识别、fixed policy 和 transport guard。
+
+### 18.5 Permission 与可复现性
+
+- Fixed Policy 不出现 permission 弹窗；
+- 普通模型 ToolCall 保留现有 permission 行为；
+- 固定调用不能借 execution origin 执行普通 Tool；
+- hook、timeout、取消、telemetry 和 artifact 汇总仍然生效；
+- 相同输入、resolved config 和 Tool 版本产生相同执行顺序；
+- scope 中同 ID policy 整条替换、数组替换和 tombstone 行为可验证；
+- 每次执行可由 config hash、policy、最终参数和 lineage 完整追溯。
+
+## 19. 后续设计顺序
+
+在本架构确认后，下一步分别讨论：
+
+1. 图片 policy Tool 清单、参数空间与 transport 默认策略；
+2. 音频 policy Tool 清单、ASR/转码/切分参数与 transport 默认策略；
+3. 视频 policy Tool 清单、抽帧/音轨/切片参数与 transport 默认策略；
+4. policy 产物如何进入
+   [Omni 多模态 Memory](./2026-07-29-omni-multimodal-memory.md)；
+5. 整体实验分支、交付和 roadmap。
+
+这些后续设计可以增加 Tool 和配置实例，但不得改变本文已经确定的统一 Tool 实现、
+固定编排器、模型可见性 gate、衍生物回流和 transport guard 边界。

--- a/docs/design/2026-07-30-omni-managed-media-storage.md
+++ b/docs/design/2026-07-30-omni-managed-media-storage.md
@@ -1,0 +1,270 @@
+# Omni 受管媒体存储设计
+
+## 状态
+
+- 状态：Draft
+- 范围：Qwen Code 实验分支中 Omni 多模态资源与中间产物的物理存储管理
+- 关联设计：
+  [多模态文件识别与元数据提取架构设计](./2026-07-29-multimodal-file-recognition-and-metadata.md)、
+  [Omni 多模态数据处理 Policy 编排架构设计](./2026-07-29-omni-multimodal-policy-orchestration.md)、
+  [Omni 多模态 Memory 架构设计](./2026-07-29-omni-multimodal-memory.md)
+
+## 1. 背景
+
+前三篇设计反复引用"受管本地文件 / Omni 管理目录 / managed storage"，但没有任何
+一篇定义它的物理形态。它至少要同时承载四类文件：
+
+1. URL 下载与 inline 解码的本地化结果（识别设计 §6.1、§7）；
+2. Policy Tool 的衍生产物：音轨、切片、关键帧、降采样图、转写文本（Policy 设计
+   §6.2）；
+3. Policy 执行失败后被隔离的 quarantined 产物（Policy 设计 §9）；
+4. 被 Memory active 记录长期引用、需要跨 session 存活的衍生物（Memory 设计
+   §13：_artifact 生命周期不得早于仍引用它的 active Memory 记录_）。
+
+第 4 条决定了这不能是一个"会话结束即清理的临时目录"：Memory 是跨 session 的，
+它引用的媒体文件也必须跨 session 存活。本设计定义目录布局、写入协议、生命周期
+与垃圾回收，作为其余三篇的公共物理底座。
+
+## 2. 目标与非目标
+
+### 2.1 目标
+
+- 为四类文件定义统一的、按 project 隔离的目录布局；
+- 用内容寻址（SHA-256）保证对象不可变、天然去重，与 Memory 设计 11.3 的
+  content-hash 复用键对齐；
+- 定义 staging → 提交 / 隔离的原子写入协议，与 `OmniPolicySucceeded` 的事务
+  边界一致；
+- 定义崩溃恢复：启动时清理半成品，不留下 Memory 可见的孤儿引用；
+- 定义 GC：以 Memory active 记录为根的 mark-and-sweep，加保留期与容量预算；
+- 配置进入 `omni.storage`，纳入 resolved Omni config hash。
+
+### 2.2 非目标
+
+- 不设计 Memory 图数据本身的存储后端（Memory 设计 §13 单独决定）；
+- 不改变现有 session artifact store 的职责（它仍服务 UI metadata）；
+- 不提供跨 project 共享、远端同步或多机存储；
+- 不做加密存储；实验分支按本地开发机信任模型处理。
+
+## 3. 位置与隔离
+
+存储根目录固定为 project 作用域：
+
+```text
+<projectRoot>/.qwen/omni/
+```
+
+- 与 Memory 设计 §13 的"以 project/workspace 为隔离边界"一致：不同 project 的
+  对象、staging 与 quarantine 互不可见，GC 也只在本 project 内运行；
+- 目录创建时写入自忽略文件（`.qwen/omni/.gitignore` 内容为 `*`），保证媒体
+  对象不会进入版本控制；
+- Omni 写入链路只在 trusted workspace 激活；未信任 workspace 中不创建该目录，
+  也不执行任何 fixed policy（与 Policy 设计 §12.1 的 trust 合并语义一致）；
+- 目录权限 `0700`；内部只允许普通文件与目录，发现 symlink 一律拒绝并告警。
+
+## 4. 目录布局
+
+```text
+.qwen/omni/
+├── .gitignore                 # 内容为 *，自忽略
+├── objects/                   # 内容寻址对象库（不可变，已提交内容的唯一存放地）
+│   └── sha256/
+│       └── ab/
+│           └── ab3f…e9.mp4    # <sha256 前 2 位>/<完整 sha256>.<按检测 MIME 的扩展名>
+├── downloads/                 # URL 本地化进行中的 .part 文件
+│   └── <downloadId>.part
+├── staging/                   # policy invocation 的工作目录（提交前）
+│   └── <invocationId>/
+│       ├── out-audio.wav
+│       └── out-keyframe-01.jpg
+└── quarantine/                # 失败 invocation 被隔离的产物（可调试、有界）
+    └── <invocationId>/
+```
+
+### 4.1 objects：内容寻址对象库
+
+- 对象以完整内容 SHA-256 命名，写入后不可变；扩展名取自统一识别的
+  `detectedMimeType`，便于 ffmpeg/ffprobe 与人工调试直接识别；
+- 同一份字节在任何来源出现（两个 File 内容相同、policy 结果 cache hit）都只
+  存一份物理对象——这正是 Memory 设计 11.2/11.3"跨 File 复用底层 artifact、
+  不合并图节点"的物理实现：File/lineage/provenance 属于 Memory 图，字节属于
+  对象库；
+- `ToolArtifact.managedId` 与 `artifactRef.managedId` 即对象键
+  （`sha256:<hash>`），对模型与协议层是 opaque ID，真实路径不外泄；
+- 对象写入协议：先写同目录 `.tmp` 文件，流式计算 hash，完成后原子 rename 到
+  最终 hash 路径；目标已存在（去重命中）时直接丢弃 `.tmp`。
+
+### 4.2 downloads：URL 本地化
+
+- 识别设计 §7 的 `.part` 文件统一放在此处，`downloadId` 为随机标识；
+- 下载完成、重新 sniff/probe/hash 之后按 4.1 协议晋升到 `objects/`，`.part`
+  删除；
+- 大小许可（100 MiB 门槛）中断的 `.part` 保留以支持续传，但受 §6 的启动清理
+  与保留期约束。
+
+### 4.3 staging：policy 工作目录
+
+- FixedPolicyOrchestrator / Scheduler 在每次 MediaPolicyTool invocation 前创建
+  `staging/<invocationId>/`，并把它作为 Tool 唯一允许的输出目录注入；
+- Tool 写完产物返回后，产物在 staging 内完成识别、hash 与 descriptor 校验
+  （Memory 设计 §6.4 的 staging 语义）；
+- `OmniPolicySucceeded` 提交顺序固定为：**先把全部产物晋升到 `objects/`，再
+  提交 Memory 事务**。这样 active Memory 记录引用的对象必然已存在；反向顺序
+  可能在崩溃时留下"Memory 指向不存在文件"的坏引用。晋升成功但 Memory 提交
+  失败时留下的是无引用孤儿对象，由 GC 回收，无正确性风险；
+- 提交或隔离后删除该 invocation 的 staging 目录。
+
+### 4.4 quarantine：失败隔离
+
+- invocation 失败（Tool error、产物校验失败、部分 required 缺失）时，整个
+  staging 目录移动到 `quarantine/<invocationId>/`，保留原始文件名与一份
+  `reason.json`（失败原因、tool、policyId、时间）供实验调试；
+- quarantine 永不被识别、不进入 Memory、不能被召回或重新绑定为 session
+  resource（Memory 设计 §15）；
+- 受独立的保留期与容量预算约束（§7 配置），超限时按最旧优先删除。
+
+## 5. 写入者与职责边界
+
+| 写入者              | 允许写入的区域                                           | 说明                            |
+| ------------------- | -------------------------------------------------------- | ------------------------------- |
+| 识别服务（本地化）  | `downloads/`、`objects/`                                 | URL 下载、inline 解码落盘与晋升 |
+| Policy Tool         | 仅注入的 `staging/<invocationId>/`                       | 不允许写 objects 或 workspace   |
+| Orchestrator/bridge | `objects/`、`quarantine/`                                | 晋升与隔离，唯一的状态迁移者    |
+| Memory / Recall     | 只读 `objects/`                                          | 通过 managedId 解析，不写入     |
+| GC                  | 删除 `objects/`、`downloads/`、`staging/`、`quarantine/` | 见 §6                           |
+
+用户原始输入的本地文件**不复制进对象库**：它们留在原位置，Memory 以
+`localPath + sha256` 记录身份（识别设计 §6.5）。只有"Qwen Code 自己生成或
+下载的字节"才进入 `objects/`。这避免大视频在磁盘上双份存放；代价是用户文件
+被移动/删除后 Recall 返回 `artifact_unavailable` gap，这是 Memory 设计 §12 已
+定义的正常路径。
+
+## 6. 生命周期与垃圾回收
+
+### 6.1 启动恢复
+
+每次启动（或首次触碰 Omni 链路时）执行一次恢复扫描：
+
+1. 删除 `staging/` 下所有目录——它们属于未完成的 invocation，对应的
+   `OmniPolicySucceeded` 必然未提交（提交成功即已删除 staging），Memory 中不
+   存在引用；
+2. 删除超过保留期的 `downloads/*.part`（续传窗口内的保留）；
+3. 按预算清理 `quarantine/`；
+4. 校验 `objects/` 中随机抽样对象的文件名与实际 hash 一致（廉价的损坏探测，
+   不做全库校验）。
+
+### 6.2 mark-and-sweep GC
+
+- **根集合**：Memory store 中全部 active 记录引用的 managedId（含历史版本仍
+  被 provenance 引用的对象）+ 当前运行 session 的 MediaResourceRegistry 正在
+  使用的对象；
+- **清扫对象**：不在根集合中、且自晋升起超过 `retentionDays` 的对象；宽限期
+  保证"晋升成功但 Memory 提交失败"的孤儿和跨进程 race 不被立刻误删；
+- **触发时机**：启动恢复后异步执行；超过 `maxTotalBytes` 时提前触发，仍超限
+  则从最旧的无引用对象继续删除；**有引用对象永不删除**，即使超预算——此时
+  告警并停止新的衍生物产生（等价于 Policy 设计 §8.4 的预算停止语义）；
+- GC 与 Memory 的一致性：先从 Memory 确认无引用，再删除文件；不存在"先删
+  文件再改记录"的窗口。
+
+## 7. 配置
+
+```jsonc
+{
+  "omni": {
+    // 受管媒体存储配置；全部纳入 resolved Omni config hash。
+    "storage": {
+      // 无引用对象自晋升起的保留天数；到期后可被 GC 清扫。
+      "retentionDays": 14,
+      // objects 区域的总容量软预算；超限提前触发 GC 并告警。
+      "maxTotalBytes": 21474836480,
+      // 中断下载 .part 的续传保留窗口（小时），超期启动时清理。
+      "partRetentionHours": 48,
+      // 失败隔离区配置。
+      "quarantine": {
+        // 隔离产物保留天数，供实验调试。
+        "retentionDays": 7,
+        // 隔离区容量上限，超限按最旧优先删除。
+        "maxBytes": 5368709120,
+      },
+    },
+  },
+}
+```
+
+校验：所有数值必须为正；`maxTotalBytes` 不得小于 transport guard 单媒体上限的
+10 倍（防止配置出一个装不下正常实验产物的库）。scope 合并沿用 Omni 统一语义。
+
+## 8. 上传缓存
+
+投递层统一采用 DashScope 官方临时上传（Policy 设计 §10.3），本存储为其维护
+上传缓存——对象字节到 48h 有效 oss:// URL 的映射：
+
+```text
+uploads: (sha256, model) → {
+  ossUrl: "oss://dashscope-instant/…",
+  uploadedAt: string,
+  expiresAt: string,   // uploadedAt + urlTtlHours（默认 47h，对官方 48h 留余量）
+}
+```
+
+规则：
+
+- 缓存 key 包含 model：官方文档声明文件与模型绑定（实测更宽松，但按文档保守
+  处理），换模型触发重传；
+- 缓存 miss 或过期时，upload service 从 `objects/` 读取字节重传，写回新条目；
+- **oss URL 只存在于上传缓存**，Memory、执行记录与任何持久协议都只引用
+  sha256——URL 是投递缓存，不是身份；
+- 对象被 GC 删除时，联动删除其全部 uploads 条目；反向不成立（缓存过期不影响
+  对象）；
+- 缓存的持久化形态与 Memory store 同级决定（同一后端或独立轻量表均可），但
+  必须在进程重启后存活——否则每次重启都重传全部媒体；
+- 上传缓存不参与对象引用计数：uploads 条目不能阻止 GC。
+
+## 9. 失败语义
+
+| 场景                         | 行为                                                                     |
+| ---------------------------- | ------------------------------------------------------------------------ |
+| 对象晋升时目标 hash 已存在   | 去重命中，丢弃临时文件，复用现有对象                                     |
+| 晋升成功、Memory 提交失败    | 孤儿对象留在 objects，GC 宽限期后回收                                    |
+| 晋升中途崩溃                 | 残留 `.tmp` 启动时清理；不存在半个可见对象                               |
+| staging 目录在提交前崩溃残留 | 启动时整目录删除，Memory 无引用                                          |
+| 对象文件被外部删除/损坏      | Recall 返回 `artifact_unavailable` gap；抽样校验发现损坏时同样降级并告警 |
+| quarantine 超预算            | 最旧优先删除，只影响调试可见性                                           |
+| objects 超预算且全部有引用   | 告警并拒绝新衍生物产生，不删除有引用对象                                 |
+| 上传缓存条目指向已 GC 对象   | 条目联动删除；投递时按 miss 处理                                         |
+| 缓存未过期但服务端已失效     | 投递收到 Provider 错误后使该条目失效并重传一次；仍失败则 fail closed     |
+| 发现 symlink 或非普通文件    | 拒绝该路径并告警，不跟随                                                 |
+
+## 10. 与现有机制的关系
+
+- **session artifact store**（daemon-session-artifacts）：继续承担 UI 展示与
+  session 级 metadata，其 session-scoped ID 与本存储无关；Omni artifact 的
+  UI 展示仍可经现有 `artifacts` 通道，但物理文件归本存储管理；
+- **`ToolArtifact.storage: 'managed'`**：Omni 场景下 `managedId` 语义固定为
+  本存储的对象键；
+- **workspace 文件**：Policy Tool 不写 workspace；`storage: 'workspace'` 的
+  artifact 仅用于用户显式要求落到工作区的场景，不受本存储 GC 管理；
+- **Memory store**：引用关系的唯一权威；本存储不维护独立引用计数或 manifest，
+  避免双账本漂移。
+
+## 11. 验收标准
+
+- 同一字节内容从两个来源进入，`objects/` 只存一份，两个 File 的 Memory 记录
+  各自完整；
+- policy 多产物提交是"全部晋升 + 一次 Memory 事务"，杀进程后重启不存在
+  Memory 指向缺失文件的引用；
+- 失败 invocation 的产物完整出现在 `quarantine/` 且带 reason.json，不可被召回；
+- 启动恢复清理 staging/.tmp/过期 .part，不触碰有引用对象；
+- GC 只清扫无引用且超保留期的对象；把 Memory 记录删除后对应对象在保留期后
+  被回收；
+- 超容量预算时告警并停止新衍生物，有引用对象仍在；
+- `.qwen/omni/` 不进入 git status；未信任 workspace 不创建该目录；
+- 模型与协议层可见的只有 `sha256:<hash>` 形式的 managedId，任何返回中不出现
+  真实路径。
+
+## 12. 实现阶段确认的细节
+
+- 抽样完整性校验的比例与频率；
+- `downloads/` 续传元数据（ETag/offset）的存放形式；
+- GC 与多进程并发（同一 project 开多个 Qwen Code 实例）的锁策略——初版可用
+  目录锁 + "GC 只在持锁进程执行"；
+- 对象库是否需要按媒体类型分区统计（实验报表用途）。


### PR DESCRIPTION
## What this PR does

Adds four interlinked architecture design documents for the omni multimodal experiment, serving as the design baseline for all subsequent implementation PRs on the `omni-experiment` branch:

- **File recognition & metadata** (`2026-07-29-multimodal-file-recognition-and-metadata.md`): unified `MediaRecognitionService` with exactly two normalization trigger points (user input / tool results), URL localization with a 100 MiB approval threshold, sniff → probe → SHA-256 identity pipeline, raw-resource token estimation (audio 7 tok/s; visual w×h×frames/(32×32×2)), and a two-layer metadata model (internal extraction vs model-visible projection).
- **Policy orchestration** (`2026-07-29-omni-multimodal-policy-orchestration.md`): `MediaPolicyTool` contract with two-part configuration (per-invocation argument schema + per-tool settings), a single ordered `fixedPolicies` set with a condition DSL (resource metadata / token estimate / session context), a mandatory lossy-output disclosure contract, transport guard measured on upload-channel limits, and delivery exclusively via the DashScope official temporary-upload channel (all-upload, no inline mode).
- **Memory** (`2026-07-29-omni-multimodal-memory.md`): file-scoped memory graph with exactly two collection trigger points (`FileRecognized` / `OmniPolicySucceeded`), harness-exclusive writes (agent and side query are read-only), atomic policy-output commits, and active/side-query recall modes sharing one protocol.
- **Managed media storage** (`2026-07-30-omni-managed-media-storage.md`): content-addressed object store under `.qwen/omni/`, staging/quarantine lifecycle aligned with policy transaction boundaries, upload cache (sha256+model → oss URL, 48h TTL), and mark-and-sweep GC rooted at active memory references.

## Why it's needed

The omni experiment explores how different image/audio/video processing strategies affect multimodal model performance, with the goal of stabilizing strategies for long/short media handling and eventually producing training data. This work spans file ingestion, policy execution, memory, and storage — four coupled subsystems that need agreed contracts before implementation starts. These documents capture the reviewed design decisions (requirements from the Omni Harness design doc and stakeholder comments) so implementation PRs can be validated against a stable baseline.

## Reviewer Test Plan

### How to verify

Docs-only PR — no runtime behavior changes. Suggested review path: read the four documents in dependency order (recognition → policy orchestration → memory → storage) and check that cross-references between them are consistent (trigger points, `PolicyArtifactBatch`, managed storage areas, upload cache), and that stated source-code anchors (e.g. `executeToolCall(recordToolResult: false)`, `convertToFunctionResponse`, DashScope converter media branches) match current `origin/main`.

Key claims were pre-verified: source assertions checked against `origin/main`, and the DashScope temporary-upload delivery path validated end-to-end with the real API (123KB / 21MB / 424MB video, image via `image_url`, audio via `input_audio` with oss URL; upload cap 1GB/file, URL valid 48h, credential reusable within 300s; missing `X-DashScope-OssResourceResolve` header deterministically returns HTTP 400).

### Evidence (Before & After)

N/A (documentation only)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

N/A — no code changes; documents formatted with Prettier.

## Risk & Scope

- Main risk or tradeoff: design-level only; the all-upload delivery decision depends on the DashScope temporary-upload channel (officially marked not-for-production), accepted for this experiment branch. No runtime impact until implementation PRs land.
- Not validated / out of scope: per-modality policy tool catalogs, storage backend selection, and roadmap are follow-ups; whole-request media limits on DashScope still need E2E measurement before real model experiments.
- Breaking changes / migration notes: none (docs only; experiment work stays on `omni-experiment` and is not intended for `main`).

## Linked Issues

None — design baseline for the `omni-experiment` branch.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

新增 Omni 多模态实验的四篇互相关联的架构设计文档，作为 `omni-experiment` 分支后续所有实现 PR 的设计基线：

- **文件识别与元数据**：统一 `MediaRecognitionService`，仅两个归一化触发点（用户输入/工具结果），URL 本地化（100 MiB 许可门槛），sniff → probe → SHA-256 身份链路，原始资源口径 token 估算（音频 7 tok/s；视觉 w×h×frames/(32×32×2)），metadata 内部提取与模型可见投影双层结构。
- **Policy 编排**：`MediaPolicyTool` 双部分配置契约（单次调用参数 schema + 工具级 settings）、带条件 DSL 的统一有序 `fixedPolicies` 集合、有损输出强制披露契约、按上传通道口径度量的 transport guard、统一经 DashScope 官方临时上传投递（all-upload，无 inline 模式）。
- **Memory**：文件级记忆图，仅两个收集触发点（`FileRecognized` / `OmniPolicySucceeded`），Harness 独占写入（Agent 与 side query 只读），policy 输出原子提交，active/sideQuery 双召回模式共用一套协议。
- **受管媒体存储**：`.qwen/omni/` 下内容寻址对象库、与 policy 事务边界对齐的 staging/quarantine 生命周期、上传缓存（sha256+model → oss URL，48h TTL）、以 active Memory 引用为根的 mark-and-sweep GC。

## 为什么需要

Omni 实验旨在探索不同图片/音频/视频处理策略对多模态模型表现的影响，固化长短媒体处理策略并最终用于训练数据生产。这项工作横跨文件接入、policy 执行、memory 和存储四个耦合子系统，实现开始前需要先确定契约。这些文档沉淀了经过评审的设计决策（需求来自《Omni Harness 设计方案》及需求方评论），使实现 PR 可以对照稳定基线验收。

## Reviewer 测试计划

### 如何验证

纯文档 PR，无运行时行为变化。建议按依赖顺序阅读四篇文档（识别 → policy 编排 → memory → 存储），检查交叉引用一致性（触发点、`PolicyArtifactBatch`、受管存储分区、上传缓存），并核对文中源码锚点（如 `executeToolCall(recordToolResult: false)`、`convertToFunctionResponse`、DashScope converter 媒体分支）与当前 `origin/main` 一致。

关键结论已预先验证：源码断言对照 `origin/main` 核验；DashScope 临时上传投递链路用真实 API 端到端验证（123KB / 21MB / 424MB 视频、`image_url` 图片、oss URL 走 `input_audio` 音频；单文件上限 1GB、URL 有效期 48h、凭证 300s 内可复用；漏加 `X-DashScope-OssResourceResolve` 请求头确定性返回 HTTP 400）。

### 证据（前后对比）

N/A（仅文档）

### 已测试平台

macOS ✅；Windows / Linux N/A。

### 环境（可选）

N/A —— 无代码变更；文档已通过 Prettier 格式化。

## 风险与范围

- 主要风险/权衡：仅设计层面；all-upload 投递决策依赖 DashScope 临时上传通道（官方标注不建议用于生产），实验分支已接受该权衡。实现 PR 落地前无运行时影响。
- 未验证/范围外：逐模态 policy Tool 清单、存储后端选型与 roadmap 为后续工作；真实模型实验前仍需实测 DashScope 整请求媒体总量限制。
- 破坏性变更/迁移说明：无（仅文档；实验工作保持在 `omni-experiment` 分支，不面向 `main`）。

## 关联 Issue

无 —— `omni-experiment` 分支的设计基线。

</details>