### PR TITLE
refactor(core): centralize worktree config derivation

### DIFF
--- a/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
@@ -1786,6 +1786,7 @@ describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', (
   type StubSubagentCall = {
     config: { name?: string; model?: string; disallowedTools?: string[] };
     runtimeContextSame: boolean;
+    runtimeContext: Config;
     options?: { runConfigOverrides?: unknown };
     eventEmitterAttached: boolean;
     executeAgentId?: string | null;
@@ -1843,6 +1844,11 @@ describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', (
       getTargetDir: () => '/fake/repo',
       getSessionId: () => 'sess_fake_test_id',
       getWorktreeSymlinkDirectories: () => [],
+      getFileFilteringOptions: () => ({
+        respectGitIgnore: true,
+        respectQwenIgnore: true,
+        customIgnoreFiles: ['.workflowignore'],
+      }),
       getSubagentManager: () => ({
         findSubagentByName: opts.findSubagentByName ?? (async () => null),
         createAgentHeadless: async (
@@ -1857,6 +1863,7 @@ describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', (
           const call: StubSubagentCall = {
             config: subagentConfig,
             runtimeContextSame: runtimeContext === cfg,
+            runtimeContext,
             options: { runConfigOverrides: options?.runConfigOverrides },
             eventEmitterAttached: options?.eventEmitter !== undefined,
           };
@@ -2769,6 +2776,26 @@ describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', (
     expect(calls[0].config.model).toBe('qwen3-max');
     // Default-clean stub auto-removes; no suffix expected.
     expect(String(result)).not.toMatch(/worktree preserved/);
+    expect(calls[0].runtimeContextSame).toBe(false);
+    expect(calls[0].runtimeContext.getTargetDir()).toBe(
+      '/fake/repo/.qwen/worktrees/agent-deadbe1',
+    );
+    expect(calls[0].runtimeContext.getCwd()).toBe(
+      '/fake/repo/.qwen/worktrees/agent-deadbe1',
+    );
+    expect(calls[0].runtimeContext.getWorkingDir()).toBe(
+      '/fake/repo/.qwen/worktrees/agent-deadbe1',
+    );
+    expect(calls[0].runtimeContext.getProjectRoot()).toBe(
+      '/fake/repo/.qwen/worktrees/agent-deadbe1',
+    );
+    expect(Object.hasOwn(calls[0].runtimeContext, 'workspaceContext')).toBe(
+      true,
+    );
+    expect(
+      calls[0].runtimeContext.getFileService().getQwenIgnoreFileNamesDisplay(),
+    ).toBe('.qwenignore, .workflowignore');
+    expect(config.getTargetDir()).toBe('/fake/repo');
   });
 
   it("schema + isolation:'worktree': structured payload returned, worktree info logged", async () => {

--- a/packages/core/src/agents/runtime/workflow-orchestrator.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.ts
@@ -6,7 +6,7 @@
 
 import { randomBytes } from 'node:crypto';
 import * as os from 'node:os';
-import type { Config } from '../../config/config.js';
+import { deriveWorktreeConfig, type Config } from '../../config/config.js';
 import { createWorkflowSandbox, debugLogger } from './workflow-sandbox.js';
 import type {
   WorkflowAgentOpts,
@@ -40,8 +40,6 @@ import {
   generateAgentWorktreeSlug,
   writeWorktreeSessionMarker,
 } from '../../services/gitWorktreeService.js';
-import { FileDiscoveryService } from '../../services/fileDiscoveryService.js';
-import { WorkspaceContext } from '../../utils/workspaceContext.js';
 import { SyntheticOutputTool } from '../../tools/syntheticOutput.js';
 import { rebuildToolRegistryOnOverride } from '../../tools/agent/agent.js';
 import { toModelVisibleSubagentResult } from '../subagent-result.js';
@@ -680,17 +678,16 @@ async function runOverridePath(
     ),
   };
 
-  // Provision worktree BEFORE createAgentHeadless so the override Config
+  // Provision worktree BEFORE createAgentHeadless so the derived Config
   // is in place when convertToRuntimeConfig and buildSubagentContextOverride
-  // resolve cwd-related getters via the prototype chain.
+  // resolve workspace-bound state through the prototype chain.
   let worktreeIsolation: WorkflowWorktreeIsolation | null = null;
   let effectiveContext: Config = config;
   if (opts.isolation === 'worktree') {
     worktreeIsolation = await provisionWorkflowWorktree(config);
-    effectiveContext = createWorktreeConfigOverride(
-      config,
-      worktreeIsolation.path,
-    );
+    effectiveContext = deriveWorktreeConfig(config, worktreeIsolation.path, {
+      customIgnoreFiles: config.getFileFilteringOptions().customIgnoreFiles,
+    });
   }
 
   // R3 review (wenshao T2/T5 [M1]): named parent-abort listener so the
@@ -1051,38 +1048,6 @@ async function provisionWorkflowWorktree(
     branch: created.worktree.branch,
     repoRoot: projectRoot,
   };
-}
-
-/**
- * Build a Config wrapper that rebinds every "where am I?" surface to the
- * isolated worktree path. `Object.create(base)` keeps prototype lookups
- * walking back to the parent for everything else (model config, session
- * id, MCP servers), while the own-property overrides shadow the cwd-
- * adjacent fields so the subagent's tools (Edit / Write / Read / Glob /
- * Grep / Ls / Shell) anchor inside the worktree.
- *
- * Mirrors the inline rebind block at agent.ts:2008-2024. Sets BOTH the
- * field shape (e.g. `targetDir`) AND the method shape (`getTargetDir`)
- * because JS does not promote a getter assignment to a field shadow —
- * call sites that read `this.targetDir` directly inside Config methods
- * would otherwise still resolve through the prototype to the parent.
- */
-function createWorktreeConfigOverride(base: Config, wtPath: string): Config {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const ov: any = Object.create(base);
-  ov.targetDir = wtPath;
-  ov.cwd = wtPath;
-  ov.getTargetDir = () => wtPath;
-  ov.getCwd = () => wtPath;
-  ov.getWorkingDir = () => wtPath;
-  ov.getProjectRoot = () => wtPath;
-  const wtFileService = new FileDiscoveryService(wtPath);
-  ov.fileDiscoveryService = wtFileService;
-  ov.getFileService = () => wtFileService;
-  const wtWorkspace = new WorkspaceContext(wtPath);
-  ov.workspaceContext = wtWorkspace;
-  ov.getWorkspaceContext = () => wtWorkspace;
-  return ov as Config;
 }
 
 /**

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -17,6 +17,7 @@ import {
   MCPServerConfig,
   DERIVED_CONFIG_STATE_OWNERSHIP,
   deriveConfig,
+  deriveWorktreeConfig,
   TrustGateError,
   matchesServerPattern,
   matchesAnyServerPattern,
@@ -1598,6 +1599,35 @@ describe('Server Config (config.ts)', () => {
 
       expect(child.getCwd()).toBe(parent.getCwd());
       expect(Object.hasOwn(child, 'getCwd')).toBe(false);
+    });
+
+    it('rebinds worktree getters and private field reads together', () => {
+      const parent = new Config({
+        ...baseParams,
+        fileFiltering: { customIgnoreFiles: ['.cursorignore'] },
+      });
+      const child = deriveWorktreeConfig(parent, '/tmp/worktree', {
+        customIgnoreFiles: ['.cursorignore'],
+      });
+
+      expect(child.getTargetDir()).toBe('/tmp/worktree');
+      expect(child.getCwd()).toBe('/tmp/worktree');
+      expect(child.getWorkingDir()).toBe('/tmp/worktree');
+      expect(child.getProjectRoot()).toBe('/tmp/worktree');
+      expect([...child.getWorkspaceContext().getDirectories()]).toEqual([
+        '/tmp/worktree',
+      ]);
+      expect(child.getFileService()).not.toBe(parent.getFileService());
+      expect(child.getFileService().getQwenIgnoreFileNamesDisplay()).toBe(
+        '.qwenignore, .cursorignore',
+      );
+      const workspaceState = child as unknown as Record<string, unknown>;
+      expect(workspaceState['targetDir']).toBe('/tmp/worktree');
+      expect(workspaceState['cwd']).toBe('/tmp/worktree');
+      expect(Object.hasOwn(child, 'workspaceContext')).toBe(true);
+      expect(Object.hasOwn(child, 'fileDiscoveryService')).toBe(true);
+      expect(parent.getTargetDir()).toBe(TARGET_DIR);
+      expect(parent.getWorkingDir()).toBe('/tmp');
     });
 
     it('prohibits inherited session-writer lifecycle access', async () => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1738,6 +1738,46 @@ export type DerivedConfigOverrides = Partial<
   >
 >;
 
+export interface DerivedWorktreeConfigOptions {
+  customIgnoreFiles?: string[];
+}
+
+/**
+ * Derives a Config whose workspace-bound state resolves to one worktree.
+ * Public getter overrides and Config's private field reads are rebound as a
+ * single operation so callers cannot accidentally mix parent and child paths.
+ */
+export function deriveWorktreeConfig(
+  base: Config,
+  worktreePath: string,
+  options: DerivedWorktreeConfigOptions = {},
+): Config {
+  const fileService = new FileDiscoveryService(
+    worktreePath,
+    options.customIgnoreFiles,
+  );
+  const workspaceContext = new WorkspaceContext(worktreePath);
+  const derived = deriveConfig(base, {
+    getTargetDir: () => worktreePath,
+    getCwd: () => worktreePath,
+    getWorkingDir: () => worktreePath,
+    getProjectRoot: () => worktreePath,
+    getFileService: () => fileService,
+    getWorkspaceContext: () => workspaceContext,
+  });
+  const workspaceState = derived as unknown as {
+    targetDir: string;
+    cwd: string;
+    fileDiscoveryService: FileDiscoveryService;
+    workspaceContext: WorkspaceContext;
+  };
+  workspaceState.targetDir = worktreePath;
+  workspaceState.cwd = worktreePath;
+  workspaceState.fileDiscoveryService = fileService;
+  workspaceState.workspaceContext = workspaceContext;
+  return derived;
+}
+
 /**
  * Creates a Config overlay while keeping prototype delegation inside one
  * reviewable boundary. Callers supply only public getter overrides; Config's
@@ -5904,7 +5944,12 @@ export class Config {
       fromApprovedPlanExit?: boolean;
     },
   ): void {
-    if (isDerivedConfig(this)) {
+    // Specialized execution overlays install an own method that owns
+    // child-local approval state; a bare derived Config must stay immutable.
+    if (
+      isDerivedConfig(this) &&
+      !Object.prototype.hasOwnProperty.call(this, 'setApprovalMode')
+    ) {
       throw new Error('Derived Configs cannot change approval mode');
     }
     if (

--- a/packages/core/src/tools/agent/agent-override.test.ts
+++ b/packages/core/src/tools/agent/agent-override.test.ts
@@ -5,7 +5,11 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { Config, ApprovalMode } from '../../config/config.js';
+import {
+  Config,
+  ApprovalMode,
+  deriveWorktreeConfig,
+} from '../../config/config.js';
 import { isPlanModeBlocked } from '../../core/permissionFlow.js';
 import type { ToolCallConfirmationDetails } from '../tools.js';
 import {
@@ -214,6 +218,22 @@ describe('createApprovalModeOverride bound-tool isolation', () => {
 
     child.setApprovalMode(ApprovalMode.DEFAULT);
 
+    expect(child.getApprovalMode()).toBe(ApprovalMode.DEFAULT);
+    expect(parent.getApprovalMode()).toBe(ApprovalMode.DEFAULT);
+  });
+
+  it('lets an approval override above a worktree Config change mode', async () => {
+    const parent = await createParentWithRegistry();
+    const worktree = deriveWorktreeConfig(parent, '/tmp/worktree');
+    const { config: child } = await createApprovalModeOverride(
+      worktree,
+      ApprovalMode.PLAN,
+    );
+
+    expect(() => worktree.setApprovalMode(ApprovalMode.DEFAULT)).toThrow(
+      'Derived Configs cannot change approval mode',
+    );
+    expect(() => child.setApprovalMode(ApprovalMode.DEFAULT)).not.toThrow();
     expect(child.getApprovalMode()).toBe(ApprovalMode.DEFAULT);
     expect(parent.getApprovalMode()).toBe(ApprovalMode.DEFAULT);
   });

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -54,8 +54,6 @@ import {
   GitWorktreeService,
   writeWorktreeSessionMarker,
 } from '../../services/gitWorktreeService.js';
-import { FileDiscoveryService } from '../../services/fileDiscoveryService.js';
-import { WorkspaceContext } from '../../utils/workspaceContext.js';
 import { getStartupContextLength } from '../../utils/environmentContext.js';
 import {
   childLaunchDepth,
@@ -99,6 +97,7 @@ import { toModelVisibleSubagentResult } from '../../agents/subagent-result.js';
 import {
   ApprovalMode,
   Config,
+  deriveWorktreeConfig,
   normalizeMaxSubagentDepth,
   validateMaxSessionTurns,
 } from '../../config/config.js';
@@ -2762,7 +2761,7 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
         this.config.isTrustedFolder(),
       );
       const resolvedApprovalMode = permissionModeToApprovalMode(resolvedMode);
-      // ALWAYS produce a child Config via Object.create, even when the
+      // ALWAYS produce a child Config via deriveConfig, even when the
       // approval mode is identical to the parent. Subagents must run
       // against an isolated FileReadCache so a parent's prior_read
       // entries cannot satisfy enforcement on a path the subagent's
@@ -2778,45 +2777,17 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
       // resolve `this.config` to the parent, reaching the parent's
       // FileReadCache rather than the subagent's. See
       // `createApprovalModeOverride` above for details.
+      const worktreeConfig = worktreeIsolation
+        ? deriveWorktreeConfig(this.config, worktreeIsolation.path, {
+            customIgnoreFiles:
+              this.config.getFileFilteringOptions().customIgnoreFiles,
+          })
+        : this.config;
       const { config: agentConfig, cleanup } = await createApprovalModeOverride(
-        this.config,
+        worktreeConfig,
         resolvedApprovalMode,
       );
       restoreParentPM = cleanup;
-
-      // ── Optional worktree isolation (Phase 2: rebind cwd) ─────────
-      // Rebind every "where am I?" surface on the agent's Config
-      // override to the worktree path so the subagent's tools cannot
-      // leak into the parent project tree.
-      //
-      // We override at two layers because Config getters mix direct
-      // field reads and getter calls. Shadowing only the methods would
-      // leave call sites like `this.targetDir` (e.g. inside
-      // `getProjectRoot`, `getFileService`) resolving via the
-      // prototype chain to the parent's `targetDir` — JS does not
-      // promote a getter assignment to a field shadow. Setting both
-      // `ov.targetDir` (own-property field) AND `ov.getTargetDir`
-      // (own-property method) covers both lookup paths.
-      if (worktreeIsolation) {
-        const wtPath = worktreeIsolation.path;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const ov = agentConfig as any;
-        ov.targetDir = wtPath;
-        ov.cwd = wtPath;
-        ov.getTargetDir = () => wtPath;
-        ov.getCwd = () => wtPath;
-        ov.getWorkingDir = () => wtPath;
-        ov.getProjectRoot = () => wtPath;
-        const wtFileService = new FileDiscoveryService(
-          wtPath,
-          this.config.getFileFilteringOptions().customIgnoreFiles,
-        );
-        ov.fileDiscoveryService = wtFileService;
-        ov.getFileService = () => wtFileService;
-        const wtWorkspace = new WorkspaceContext(wtPath);
-        ov.workspaceContext = wtWorkspace;
-        ov.getWorkspaceContext = () => wtWorkspace;
-      }
 
       // Date.now() alone collides when two parallel background agents of the
       // same type land in the same ms; the registry is keyed by agentId.


### PR DESCRIPTION
## What this PR does

This PR moves the Agent and Workflow worktree overlays behind the shared derived-Config factory boundary. Worktree paths, workspace context, and file discovery state now move together, including direct Config field reads and public getters.

It also preserves the approval-mode overlay above a derived worktree Config. A bare derived Config still cannot mutate approval state, while the specialized child-local approval overlay can change modes without touching the canonical parent.

## Why it's needed

The two worktree launch paths previously rebuilt the same prototype overlay independently. That duplication made it easy for target directory, cwd, workspace context, file service, custom ignore files, and tool-registry ownership to drift apart. This is the second stacked change for #8083 and depends on #8100.

## Reviewer Test Plan

### How to verify

1. Run the focused Config, Agent, Agent override, and Workflow suites. Confirm worktree children see the isolated path through every cwd/project getter, use a distinct file service with inherited custom ignore files, and leave the parent unchanged.
2. Confirm a plan-mode approval overlay layered above a worktree-derived Config can exit plan mode while a bare derived Config remains immutable.
3. Run core lint, typecheck, and build.

### Evidence (Before & After)

N/A — internal refactor with no user-visible UI change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22 workspace; focused Vitest suites, ESLint, TypeScript typecheck, and package build.

## Risk & Scope

- Main risk or tradeoff: prototype-chain ownership is unchanged; this PR centralizes only worktree-bound state and keeps explicit field shadows where Config methods read private fields directly.
- Not validated / out of scope: Windows and Linux local execution; remaining approval, agent runtime, background resume, memory, remember, and skill-review derivations are handled by later stacked PRs.
- Breaking changes / migration notes: none.

## Linked Issues

Related to #8083
Depends on #8100

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 将 Agent 和 Workflow 的 worktree Config 覆盖迁移到统一的派生 Config 工厂边界。worktree 路径、工作区上下文和文件发现状态现在作为一个整体迁移，同时覆盖 Config 内部直接字段读取和公共 getter。

它也保留了派生 worktree Config 之上的审批模式覆盖。普通派生 Config 仍然不能修改审批状态，但专用的子级审批覆盖可以切换模式且不会修改规范父 Config。

## 为什么需要

两个 worktree 启动路径此前各自维护同一套原型覆盖逻辑，容易让目标目录、cwd、工作区上下文、文件服务、自定义 ignore 文件和工具注册表所有权发生漂移。这是 #8083 的第二个堆叠变更，依赖 #8100。

## Reviewer Test Plan

### 如何验证

1. 运行聚焦的 Config、Agent、Agent override 和 Workflow 测试。确认 worktree 子 Config 的所有 cwd/project getter 都指向隔离路径，使用独立文件服务并保留自定义 ignore 文件，同时父 Config 不变。
2. 确认叠加在 worktree 派生 Config 上的 plan 模式审批覆盖可以退出 plan 模式，而普通派生 Config 仍然不可变。
3. 运行 core lint、typecheck 和 build。

### 证据（Before & After）

N/A —— 内部重构，没有用户可见 UI 变化。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Node.js 22 workspace；聚焦 Vitest 测试、ESLint、TypeScript typecheck 和包构建。

## 风险与范围

- 主要风险或取舍：原型链所有权保持不变；此 PR 只集中 worktree 相关状态，并在 Config 方法直接读取私有字段的位置保留显式字段覆盖。
- 未验证 / 不在范围内：Windows 和 Linux 本地执行；其余审批、agent runtime、后台恢复、memory、remember 和 skill-review 派生会在后续堆叠 PR 中处理。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

关联 #8083
依赖 #8100

</details>
