### PR TITLE
feat(gitlab-channel): add transient 👀 award emoji while agent is working

### DIFF
--- a/docs/users/features/channels/gitlab.md
+++ b/docs/users/features/channels/gitlab.md
@@ -156,6 +156,12 @@ The adapter uses GitLab's Todos API as the message source:
 
 The cursor (`lastProcessedId`) advances regardless of dispatch success or failure. Failed dispatches post a ⚠️ error comment on the issue/MR and are not retried — the user can re-mention the bot to trigger a new todo.
 
+## Response Feedback
+
+For an accepted comment mention (note with `#note_` anchor), the channel adds a 👀 award emoji to the note while the agent is working, then removes it when the run completes, fails, or is cancelled. Both operations are best-effort: an award emoji API or permission failure is logged and never prevents the final response.
+
+Description mentions (no `#note_` anchor) do not receive an award emoji because there is no specific note to react to.
+
 ## Known Limitations
 
 - **First start skips existing pending todos.** The cursor initializes to `{ lastProcessedId: 0, initialized: false }` on first launch. On the first poll cycle, all pre-existing pending todos are marked done without dispatch (the `initialized` flag gates this one-time drain), preventing a backlog flood.

--- a/packages/channels/gitlab/src/GitlabAdapter.test.ts
+++ b/packages/channels/gitlab/src/GitlabAdapter.test.ts
@@ -655,6 +655,16 @@ describe('GitlabChannel', () => {
   });
 
   describe('working reaction', () => {
+    class ReactingGitlabChannel extends GitlabChannel {
+      override async handleInbound(envelope: Envelope): Promise<void> {
+        this.onPromptStart(envelope.chatId, 'session-1', envelope.messageId);
+        await Promise.resolve();
+        this.onPromptEnd(envelope.chatId, 'session-1', envelope.messageId);
+      }
+
+      protected override startPollLoop(): void {}
+    }
+
     class LiveGitlabChannel extends GitlabChannel {
       setReactionForTest(
         messageId: string,
@@ -694,6 +704,74 @@ describe('GitlabChannel', () => {
       }
     }
 
+    it('drives award/remove through real pollOnce path for note mention', async () => {
+      const channel = new ReactingGitlabChannel(
+        'test-gitlab',
+        makeConfig(),
+        makeBridge(),
+      );
+      await channel.connect();
+      channel.disconnect();
+      (
+        channel as unknown as {
+          cursor: { lastProcessedId: number; initialized: boolean };
+        }
+      ).cursor = {
+        lastProcessedId: 0,
+        initialized: true,
+      };
+      mockApi.TodoLists.all.mockResolvedValueOnce([makeTodo()]);
+
+      await (
+        channel as unknown as { pollOnce: () => Promise<void> }
+      ).pollOnce();
+
+      expect(mockApi.IssueNoteAwardEmojis.award).toHaveBeenCalledWith(
+        'owner/repo',
+        42,
+        1001,
+        'eyes',
+      );
+      await vi.waitFor(() =>
+        expect(mockApi.IssueNoteAwardEmojis.remove).toHaveBeenCalledWith(
+          'owner/repo',
+          42,
+          1001,
+          9000,
+        ),
+      );
+    });
+
+    it('does not award emoji for description mention via real path', async () => {
+      const channel = new ReactingGitlabChannel(
+        'test-gitlab',
+        makeConfig(),
+        makeBridge(),
+      );
+      await channel.connect();
+      channel.disconnect();
+      (
+        channel as unknown as {
+          cursor: { lastProcessedId: number; initialized: boolean };
+        }
+      ).cursor = {
+        lastProcessedId: 0,
+        initialized: true,
+      };
+      mockApi.TodoLists.all.mockResolvedValueOnce([
+        makeTodo({
+          target_url: 'https://gitlab.com/owner/repo/-/issues/42',
+          body: 'Test Issue',
+        }),
+      ]);
+
+      await (
+        channel as unknown as { pollOnce: () => Promise<void> }
+      ).pollOnce();
+
+      expect(mockApi.IssueNoteAwardEmojis.award).not.toHaveBeenCalled();
+    });
+
     it('acknowledges a note mention with an eyes award emoji', async () => {
       const liveChannel = new LiveGitlabChannel(
         'test-gitlab',
@@ -715,21 +793,6 @@ describe('GitlabChannel', () => {
         1001,
         'eyes',
       );
-    });
-
-    it('does not acknowledge a description mention', async () => {
-      const liveChannel = new LiveGitlabChannel(
-        'test-gitlab',
-        makeConfig(),
-        makeBridge(),
-      );
-      await liveChannel.connect();
-      liveChannel.disconnect();
-
-      liveChannel.startPromptForTest('owner/repo', 'session-1', '100');
-      await Promise.resolve();
-
-      expect(mockApi.IssueNoteAwardEmojis.award).not.toHaveBeenCalled();
     });
 
     it('removes the award emoji when the prompt finishes', async () => {
@@ -799,10 +862,10 @@ describe('GitlabChannel', () => {
       });
 
       liveChannel.startPromptForTest('owner/repo', 'session-1', '100');
-      await Promise.resolve();
-      await Promise.resolve();
 
-      expect(mockApi.IssueNoteAwardEmojis.award).toHaveBeenCalled();
+      await vi.waitFor(() =>
+        expect(mockApi.IssueNoteAwardEmojis.award).toHaveBeenCalled(),
+      );
       liveChannel.endPromptForTest('owner/repo', 'session-1', '100');
       await Promise.resolve();
       expect(mockApi.IssueNoteAwardEmojis.remove).not.toHaveBeenCalled();

--- a/packages/channels/gitlab/src/GitlabAdapter.test.ts
+++ b/packages/channels/gitlab/src/GitlabAdapter.test.ts
@@ -132,6 +132,14 @@ function createMockApi() {
     MergeRequests: {
       show: vi.fn().mockResolvedValue({ description: 'MR description' }),
     },
+    IssueNoteAwardEmojis: {
+      award: vi.fn().mockResolvedValue({ id: 9000 }),
+      remove: vi.fn().mockResolvedValue(undefined),
+    },
+    MergeRequestNoteAwardEmojis: {
+      award: vi.fn().mockResolvedValue({ id: 9000 }),
+      remove: vi.fn().mockResolvedValue(undefined),
+    },
   };
 }
 
@@ -643,6 +651,218 @@ describe('GitlabChannel', () => {
       expect(mockApi.TodoLists.done).toHaveBeenCalledWith({ todoId: 1 });
       expect(mockApi.TodoLists.done).toHaveBeenCalledWith({ todoId: 2 });
       expect(channel.cursor.lastProcessedId).toBe(2);
+    });
+  });
+
+  describe('working reaction', () => {
+    class LiveGitlabChannel extends GitlabChannel {
+      setReactionForTest(
+        messageId: string,
+        entry: {
+          target: { iid: number; title: string; isMr: boolean };
+          noteId: number;
+        },
+      ): void {
+        (
+          this as unknown as {
+            reactions: Map<
+              string,
+              {
+                target: { iid: number; title: string; isMr: boolean };
+                noteId: number;
+                award?: Promise<{ awardId: number }>;
+              }
+            >;
+          }
+        ).reactions.set(messageId, entry);
+      }
+
+      startPromptForTest(
+        chatId: string,
+        sessionId: string,
+        messageId: string,
+      ): void {
+        this.onPromptStart(chatId, sessionId, messageId);
+      }
+
+      endPromptForTest(
+        chatId: string,
+        sessionId: string,
+        messageId: string,
+      ): void {
+        this.onPromptEnd(chatId, sessionId, messageId);
+      }
+    }
+
+    it('acknowledges a note mention with an eyes award emoji', async () => {
+      const liveChannel = new LiveGitlabChannel(
+        'test-gitlab',
+        makeConfig(),
+        makeBridge(),
+      );
+      await liveChannel.connect();
+      liveChannel.disconnect();
+      liveChannel.setReactionForTest('100', {
+        target: { iid: 42, title: '', isMr: false },
+        noteId: 1001,
+      });
+
+      liveChannel.startPromptForTest('owner/repo', 'session-1', '100');
+
+      expect(mockApi.IssueNoteAwardEmojis.award).toHaveBeenCalledWith(
+        'owner/repo',
+        42,
+        1001,
+        'eyes',
+      );
+    });
+
+    it('does not acknowledge a description mention', async () => {
+      const liveChannel = new LiveGitlabChannel(
+        'test-gitlab',
+        makeConfig(),
+        makeBridge(),
+      );
+      await liveChannel.connect();
+      liveChannel.disconnect();
+
+      liveChannel.startPromptForTest('owner/repo', 'session-1', '100');
+      await Promise.resolve();
+
+      expect(mockApi.IssueNoteAwardEmojis.award).not.toHaveBeenCalled();
+    });
+
+    it('removes the award emoji when the prompt finishes', async () => {
+      const liveChannel = new LiveGitlabChannel(
+        'test-gitlab',
+        makeConfig(),
+        makeBridge(),
+      );
+      await liveChannel.connect();
+      liveChannel.disconnect();
+      liveChannel.setReactionForTest('100', {
+        target: { iid: 42, title: '', isMr: false },
+        noteId: 1001,
+      });
+
+      liveChannel.startPromptForTest('owner/repo', 'session-1', '100');
+      await Promise.resolve();
+      liveChannel.endPromptForTest('owner/repo', 'session-1', '100');
+
+      await vi.waitFor(() =>
+        expect(mockApi.IssueNoteAwardEmojis.remove).toHaveBeenCalledWith(
+          'owner/repo',
+          42,
+          1001,
+          9000,
+        ),
+      );
+    });
+
+    it('uses MergeRequestNoteAwardEmojis for MR note mentions', async () => {
+      const liveChannel = new LiveGitlabChannel(
+        'test-gitlab',
+        makeConfig(),
+        makeBridge(),
+      );
+      await liveChannel.connect();
+      liveChannel.disconnect();
+      liveChannel.setReactionForTest('100', {
+        target: { iid: 99, title: '', isMr: true },
+        noteId: 2001,
+      });
+
+      liveChannel.startPromptForTest('owner/repo', 'session-1', '100');
+
+      expect(mockApi.MergeRequestNoteAwardEmojis.award).toHaveBeenCalledWith(
+        'owner/repo',
+        99,
+        2001,
+        'eyes',
+      );
+    });
+
+    it('handles award failure as best-effort', async () => {
+      mockApi.IssueNoteAwardEmojis.award.mockRejectedValueOnce(
+        new Error('403'),
+      );
+      const liveChannel = new LiveGitlabChannel(
+        'test-gitlab',
+        makeConfig(),
+        makeBridge(),
+      );
+      await liveChannel.connect();
+      liveChannel.disconnect();
+      liveChannel.setReactionForTest('100', {
+        target: { iid: 42, title: '', isMr: false },
+        noteId: 1001,
+      });
+
+      liveChannel.startPromptForTest('owner/repo', 'session-1', '100');
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockApi.IssueNoteAwardEmojis.award).toHaveBeenCalled();
+      liveChannel.endPromptForTest('owner/repo', 'session-1', '100');
+      await Promise.resolve();
+      expect(mockApi.IssueNoteAwardEmojis.remove).not.toHaveBeenCalled();
+    });
+
+    it('handles remove failure as best-effort', async () => {
+      mockApi.IssueNoteAwardEmojis.remove.mockRejectedValueOnce(
+        new Error('403'),
+      );
+      const liveChannel = new LiveGitlabChannel(
+        'test-gitlab',
+        makeConfig(),
+        makeBridge(),
+      );
+      await liveChannel.connect();
+      liveChannel.disconnect();
+      liveChannel.setReactionForTest('100', {
+        target: { iid: 42, title: '', isMr: false },
+        noteId: 1001,
+      });
+
+      liveChannel.startPromptForTest('owner/repo', 'session-1', '100');
+      await Promise.resolve();
+      liveChannel.endPromptForTest('owner/repo', 'session-1', '100');
+
+      await vi.waitFor(() =>
+        expect(mockApi.IssueNoteAwardEmojis.remove).toHaveBeenCalled(),
+      );
+    });
+
+    it('waits for pending award before removing', async () => {
+      const { promise: awardPending, resolve: resolveAward } =
+        Promise.withResolvers<{ id: number }>();
+      mockApi.IssueNoteAwardEmojis.award.mockReturnValueOnce(awardPending);
+      const liveChannel = new LiveGitlabChannel(
+        'test-gitlab',
+        makeConfig(),
+        makeBridge(),
+      );
+      await liveChannel.connect();
+      liveChannel.disconnect();
+      liveChannel.setReactionForTest('100', {
+        target: { iid: 42, title: '', isMr: false },
+        noteId: 1001,
+      });
+
+      liveChannel.startPromptForTest('owner/repo', 'session-1', '100');
+      liveChannel.endPromptForTest('owner/repo', 'session-1', '100');
+      expect(mockApi.IssueNoteAwardEmojis.remove).not.toHaveBeenCalled();
+
+      resolveAward({ id: 9001 });
+      await awardPending;
+      await vi.waitFor(() =>
+        expect(mockApi.IssueNoteAwardEmojis.remove).toHaveBeenCalledWith(
+          'owner/repo',
+          42,
+          1001,
+          9001,
+        ),
+      );
     });
   });
 });

--- a/packages/channels/gitlab/src/GitlabAdapter.test.ts
+++ b/packages/channels/gitlab/src/GitlabAdapter.test.ts
@@ -845,6 +845,25 @@ describe('GitlabChannel', () => {
       );
     });
 
+    it('does not award twice when onPromptStart is called again', async () => {
+      const liveChannel = new LiveGitlabChannel(
+        'test-gitlab',
+        makeConfig(),
+        makeBridge(),
+      );
+      await liveChannel.connect();
+      liveChannel.disconnect();
+      liveChannel.setReactionForTest('100', {
+        target: { iid: 42, title: '', isMr: false },
+        noteId: 1001,
+      });
+
+      liveChannel.startPromptForTest('owner/repo', 'session-1', '100');
+      liveChannel.startPromptForTest('owner/repo', 'session-1', '100');
+
+      expect(mockApi.IssueNoteAwardEmojis.award).toHaveBeenCalledTimes(1);
+    });
+
     it('handles award failure as best-effort', async () => {
       mockApi.IssueNoteAwardEmojis.award.mockRejectedValueOnce(
         new Error('403'),

--- a/packages/channels/gitlab/src/GitlabAdapter.ts
+++ b/packages/channels/gitlab/src/GitlabAdapter.ts
@@ -217,7 +217,7 @@ export class GitlabChannel extends PollingChannelBase<GitlabCursor> {
         await this.skipTodo(todo);
         continue;
       }
-      const raw = todo.target as { iid?: number; title?: string };
+      const raw = (todo.target || {}) as { iid?: number; title?: string };
       if (!raw.iid) {
         await this.skipTodo(todo);
         continue;
@@ -352,9 +352,8 @@ export class GitlabChannel extends PollingChannelBase<GitlabCursor> {
     }
     try {
       await this.handleInbound(envelope);
-    } catch (err) {
+    } finally {
       this.reactions.delete(messageId);
-      throw err;
     }
   }
 

--- a/packages/channels/gitlab/src/GitlabAdapter.ts
+++ b/packages/channels/gitlab/src/GitlabAdapter.ts
@@ -6,7 +6,7 @@ import type {
   Envelope,
 } from '@qwen-code/channel-base';
 import { PollingChannelBase } from '@qwen-code/channel-base';
-import { Gitlab } from '@gitbeaker/rest';
+import { Gitlab, type TodoSchema } from '@gitbeaker/rest';
 import { z } from 'zod';
 import { testBotMention, stripBotMention } from './mention.js';
 
@@ -20,16 +20,10 @@ interface GitlabCursor {
   initialized: boolean;
 }
 
-interface Todo {
-  id: number;
-  action_name: string;
-  target_type: string;
-  body: string;
-  target_url: string;
-  updated_at: string;
-  project: { path_with_namespace: string };
-  author: { username: string };
-  target: { iid: number; title: string };
+interface GitlabTarget {
+  iid: number;
+  title: string;
+  isMr: boolean;
 }
 
 const cursorSchema = z.object({
@@ -42,6 +36,14 @@ export class GitlabChannel extends PollingChannelBase<GitlabCursor> {
   private apiHost = 'https://gitlab.com';
   private botUsername = '';
   private descriptionCache = new Map<string, string>();
+  private readonly reactions = new Map<
+    string,
+    {
+      target: GitlabTarget;
+      noteId: number;
+      award?: Promise<{ awardId: number }>;
+    }
+  >();
 
   constructor(
     name: string,
@@ -127,6 +129,52 @@ export class GitlabChannel extends PollingChannelBase<GitlabCursor> {
     await this.createNote(chatId, targetType, Number(match[1]), text);
   }
 
+  protected override onPromptStart(
+    chatId: string,
+    _sessionId: string,
+    messageId?: string,
+  ): void {
+    if (!messageId) return;
+    const entry = this.reactions.get(messageId);
+    if (!entry || entry.award) return;
+    const api = entry.target.isMr
+      ? this.api.MergeRequestNoteAwardEmojis
+      : this.api.IssueNoteAwardEmojis;
+    entry.award = api
+      .award(chatId, entry.target.iid, entry.noteId, 'eyes')
+      .then((r) => ({ awardId: r.id }));
+    void entry.award.catch((err) => {
+      entry.award = undefined;
+      process.stderr.write(
+        `[Channel:${this.name}] failed to acknowledge note ${entry.noteId}: ${err}\n`,
+      );
+    });
+  }
+
+  protected override onPromptEnd(
+    chatId: string,
+    _sessionId: string,
+    messageId?: string,
+  ): void {
+    if (!messageId) return;
+    const entry = this.reactions.get(messageId);
+    if (!entry) return;
+    this.reactions.delete(messageId);
+    if (!entry.award) return;
+    const api = entry.target.isMr
+      ? this.api.MergeRequestNoteAwardEmojis
+      : this.api.IssueNoteAwardEmojis;
+    void entry.award
+      .then(({ awardId }) =>
+        api.remove(chatId, entry.target.iid, entry.noteId, awardId),
+      )
+      .catch((err) => {
+        process.stderr.write(
+          `[Channel:${this.name}] failed to remove acknowledgement from note ${entry.noteId}: ${err}\n`,
+        );
+      });
+  }
+
   protected async pollOnce(): Promise<void> {
     const templates = (this.config as GitlabConfig).action_prompt_template;
     if (!templates || Object.keys(templates).length === 0) return;
@@ -136,7 +184,7 @@ export class GitlabChannel extends PollingChannelBase<GitlabCursor> {
 
     const allTodos = (await this.api.TodoLists.all({
       state: 'pending',
-    })) as unknown as Todo[];
+    })) as TodoSchema[];
 
     // First poll: drain all pre-existing todos without processing them.
     if (!this.cursor.initialized) {
@@ -164,13 +212,21 @@ export class GitlabChannel extends PollingChannelBase<GitlabCursor> {
     for (const todo of todos) {
       if (
         !todo.project ||
-        !todo.target ||
-        !todo.target.iid ||
         (todo.target_type !== 'Issue' && todo.target_type !== 'MergeRequest')
       ) {
         await this.skipTodo(todo);
         continue;
       }
+      const raw = todo.target as { iid?: number; title?: string };
+      if (!raw.iid) {
+        await this.skipTodo(todo);
+        continue;
+      }
+      const target: GitlabTarget = {
+        iid: raw.iid,
+        title: raw.title ?? '',
+        isMr: todo.target_type === 'MergeRequest',
+      };
 
       const template = this.resolveTemplate(templates, todo.action_name);
       if (!template) {
@@ -179,11 +235,9 @@ export class GitlabChannel extends PollingChannelBase<GitlabCursor> {
       }
 
       const chatId = todo.project.path_with_namespace;
-      const targetType = todo.target_type === 'MergeRequest' ? 'mr' : 'issue';
-      const threadId = `${targetType}:${todo.target.iid}`;
 
       try {
-        await this.processTodo(todo, template, chatId, targetType, threadId);
+        await this.processTodo(todo, target, template, chatId);
       } catch (err) {
         process.stderr.write(
           `[Channel:${this.name}] error processing todo ${todo.id}: ${err}\n`,
@@ -191,8 +245,8 @@ export class GitlabChannel extends PollingChannelBase<GitlabCursor> {
         try {
           await this.createNote(
             chatId,
-            targetType,
-            todo.target.iid,
+            target.isMr ? 'mr' : 'issue',
+            target.iid,
             '⚠️ Failed to process this request. Please re-mention the bot to retry.',
           );
         } catch {
@@ -210,7 +264,7 @@ export class GitlabChannel extends PollingChannelBase<GitlabCursor> {
     }
   }
 
-  private async skipTodo(todo: Todo): Promise<void> {
+  private async skipTodo(todo: TodoSchema): Promise<void> {
     try {
       await this.api.TodoLists.done({ todoId: todo.id });
     } catch {
@@ -229,15 +283,18 @@ export class GitlabChannel extends PollingChannelBase<GitlabCursor> {
   }
 
   private async processTodo(
-    todo: Todo,
+    todo: TodoSchema,
+    target: GitlabTarget,
     template: string,
     chatId: string,
-    targetType: string,
-    threadId: string,
   ): Promise<void> {
     if (todo.author.username === this.botUsername) return;
 
-    const isNoteMention = /#note_\d+$/.test(todo.target_url);
+    const targetType = target.isMr ? 'mr' : 'issue';
+    const threadId = `${targetType}:${target.iid}`;
+    const noteMatch = todo.target_url.match(/#note_(\d+)$/);
+    const isNoteMention = noteMatch !== null;
+    const messageId = String(todo.id);
     const needsDescription =
       !isNoteMention || template.includes('%description%');
 
@@ -248,7 +305,7 @@ export class GitlabChannel extends PollingChannelBase<GitlabCursor> {
           description = await this.fetchDescription(
             chatId,
             targetType,
-            todo.target.iid,
+            target.iid,
           );
         } catch (err) {
           process.stderr.write(
@@ -259,7 +316,7 @@ export class GitlabChannel extends PollingChannelBase<GitlabCursor> {
         description = await this.fetchDescription(
           chatId,
           targetType,
-          todo.target.iid,
+          target.iid,
         );
       }
     }
@@ -274,10 +331,11 @@ export class GitlabChannel extends PollingChannelBase<GitlabCursor> {
       todo.author.username,
       chatId,
       threadId,
-      String(todo.id),
+      messageId,
       this.buildMetadata(
         template,
         todo,
+        target,
         chatId,
         todo.author.username,
         String(todo.id),
@@ -286,7 +344,18 @@ export class GitlabChannel extends PollingChannelBase<GitlabCursor> {
       true,
     );
 
-    await this.handleInbound(envelope);
+    if (isNoteMention) {
+      this.reactions.set(messageId, {
+        target,
+        noteId: Number(noteMatch![1]),
+      });
+    }
+    try {
+      await this.handleInbound(envelope);
+    } catch (err) {
+      this.reactions.delete(messageId);
+      throw err;
+    }
   }
 
   private async fetchDescription(
@@ -301,10 +370,10 @@ export class GitlabChannel extends PollingChannelBase<GitlabCursor> {
     let description: string;
     if (targetType === 'mr') {
       const mr = await this.api.MergeRequests.show(chatId, iid);
-      description = (mr as { description?: string }).description || '';
+      description = mr.description || '';
     } else {
       const issue = await this.api.Issues.show(iid, { projectId: chatId });
-      description = (issue as { description?: string }).description || '';
+      description = issue.description || '';
     }
     this.descriptionCache.set(cacheKey, description);
     return description;
@@ -338,7 +407,8 @@ export class GitlabChannel extends PollingChannelBase<GitlabCursor> {
 
   private buildMetadata(
     template: string,
-    todo: Todo,
+    todo: TodoSchema,
+    target: GitlabTarget,
     chatId: string,
     author: string,
     commentId: string,
@@ -349,8 +419,8 @@ export class GitlabChannel extends PollingChannelBase<GitlabCursor> {
       project_url: `${this.apiHost}/${chatId}`,
       author,
       target_type: todo.target_type,
-      iid: String(todo.target.iid),
-      title: todo.target.title,
+      iid: String(target.iid),
+      title: target.title,
       description,
       todo_id: commentId,
     };


### PR DESCRIPTION
## What this PR does

Adds a transient 👀 award emoji to GitLab note mentions while the agent is working, mirroring the GitHub adapter's eyes reaction ([#8061](https://github.com/QwenLM/qwen-code/pull/8061)). When `onPromptStart` fires for a note mention, the channel calls the GitLab award emoji API to add 👀 to the triggering note. When `onPromptEnd` fires (completion, failure, or cancellation), the emoji is removed. Both operations are best-effort: API errors or permission failures are logged to stderr and never block the agent's response.

Description mentions (no `#note_` anchor in `target_url`) do not receive an award emoji because there is no specific note to react to.

Implementation uses a single `reactions` Map keyed by `String(todo.id)` that stores the target info, noteId, and the award Promise. `onPromptStart` fills in the award Promise; `onPromptEnd` deletes the entry and chains `.then()` on the Promise to remove the emoji. This naturally handles the race where `onPromptEnd` fires before the award API returns — the removal waits for the award to settle.

Also replaces the custom `Todo` interface with gitbeaker's `TodoSchema` (getting proper `target_type` enum `'Issue' | 'MergeRequest' | ...` instead of `string`), introduces `GitlabTarget` to consolidate parsed target info, and simplifies `processTodo`/`buildMetadata` signatures by passing the parsed target directly instead of redundant `targetType`/`threadId` parameters.

## Why it's needed

Part of [#8117](https://github.com/QwenLM/qwen-code/issues/8117) (P0 item #4: Transient 👀 reaction / award emoji). The GitHub adapter already has this feature; the GitLab adapter needs parity. The transient emoji gives users visual feedback that the bot has accepted their mention and is working on it, and its removal signals completion.

## Reviewer Test Plan

### How to verify

1. Configure a GitLab channel with `senderPolicy: "open"`, `groupPolicy: "open"`, and an `action_prompt_template` with a `mentioned` key.
2. Start the channel: `qwen channel start <name>`
3. On a GitLab issue, add a comment mentioning the bot (e.g., `@bot-username do something`).
4. Observe: a 👀 award emoji appears on the comment within the poll interval.
5. Wait for the bot to finish and post a reply.
6. Observe: the 👀 emoji is removed from the comment after the reply is posted.
7. Verify no duplicate replies are posted.
8. Test a second mention on the same issue — emoji should appear and be removed again.

Unit tests cover: emoji creation, emoji removal, MR vs issue routing, description mention skip, award failure best-effort, remove failure best-effort, and pending award race handling.

### Evidence (Before & After)

E2E test run against a live GitLab repo (`zore3475/gl-channel-e2e-0730`):

```
TEST 1: Comment mention → 👀 emoji → bot reply → 👀 removed
  ✅ PASS: 👀 created (award_id=52768310)
  ✅ PASS: Bot replied (note_id=3622127274)
  ✅ PASS: 👀 removed
  ✅ PASS: Exactly 1 bot reply

TEST 2: Second mention on same issue
  ✅ PASS: 👀 created for second mention
  ✅ PASS: Bot replied to second mention
  ✅ PASS: Exactly 2 total bot replies

7/7 passed
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A    |
| 🪟 Windows | N/A    |
|  🐧 Linux  |   ✅   |

### Environment

Local `qwen channel start my-gitlab` with coding plan model (`qwen3-coder-plus`), poll interval 15s.

## Risk & Scope

- Main risk or tradeoff: Award emoji API calls are best-effort. If the bot's PAT lacks the `api` scope needed for award emoji endpoints, the emoji silently fails but the agent still processes the mention and posts a reply. The `api` scope is already documented as required for posting notes.
- Not validated / out of scope: Confidential note handling (documented as a known limitation — the adapter cannot filter confidential notes). Self-allowlist startup validation (#8117 item #8) is not addressed in this PR.
- Breaking changes / migration notes: None. The `messageId` format for GitLab envelopes remains `String(todo.id)`.

## Linked Issues

Part of #8117 (item 4: Transient 👀 reaction / award emoji).

<details>
<summary>中文翻译</summary>

## 本 PR 做了什么

为 GitLab 评论 mention 添加临时 👀 award emoji，在 agent 工作期间显示，完成后移除。镜像 GitHub 适配器的 eyes reaction（[#8061](https://github.com/QwenLM/qwen-code/pull/8061)）。当 `onPromptStart` 在 note mention 时触发，channel 调用 GitLab award emoji API 在触发评论上添加 👀。当 `onPromptEnd` 触发（完成、失败或取消）时，emoji 被移除。两个操作都是 best-effort：API 错误或权限失败记录到 stderr，不会阻塞 agent 的响应。

描述 mention（`target_url` 中没有 `#note_` 锚点）不会收到 award emoji，因为没有具体的评论可以添加 reaction。

实现使用单个 `reactions` Map，以 `String(todo.id)` 为 key，存储 target info、noteId 和 award Promise。`onPromptStart` 填充 award Promise；`onPromptEnd` 删除 entry 并在 Promise 上链式调用 `.then()` 来移除 emoji。这自然处理了 `onPromptEnd` 在 award API 返回之前触发的竞态——移除操作会等待 award 完成。

同时将自定义 `Todo` 接口替换为 gitbeaker 的 `TodoSchema`（获得正确的 `target_type` 枚举 `'Issue' | 'MergeRequest' | ...` 而非 `string`），引入 `GitlabTarget` 整合解析后的 target 信息，并简化了 `processTodo`/`buildMetadata` 的签名，直接传递解析后的 target 而非冗余的 `targetType`/`threadId` 参数。

## 为什么需要这个

属于 [#8117](https://github.com/QwenLM/qwen-code/issues/8117)（P0 第 4 项：临时 👀 reaction / award emoji）。GitHub 适配器已有此功能；GitLab 适配器需要对齐。临时 emoji 给用户视觉反馈，表示 bot 已接受 mention 并正在处理，移除表示完成。

## Reviewer 测试计划

### 验证方法

1. 配置 GitLab channel：`senderPolicy: "open"`、`groupPolicy: "open"`，`action_prompt_template` 包含 `mentioned` key。
2. 启动 channel：`qwen channel start <name>`
3. 在 GitLab issue 上添加评论 mention bot（如 `@bot-username do something`）。
4. 观察：在 poll 间隔内，评论上出现 👀 award emoji。
5. 等待 bot 完成并发布回复。
6. 观察：回复发布后，评论上的 👀 emoji 被移除。
7. 验证没有重复回复。
8. 在同一 issue 上测试第二次 mention——emoji 应再次出现并被移除。

单元测试覆盖：emoji 创建、emoji 移除、MR vs issue 路由、description mention 跳过、award 失败 best-effort、remove 失败 best-effort、pending award 竞态处理。

### 证据（Before & After）

针对真实 GitLab 仓库（`zore3475/gl-channel-e2e-0730`）的 E2E 测试运行：

```
TEST 1: Comment mention → 👀 emoji → bot reply → 👀 removed
  ✅ PASS: 👀 created (award_id=52768310)
  ✅ PASS: Bot replied (note_id=3622127274)
  ✅ PASS: 👀 removed
  ✅ PASS: Exactly 1 bot reply

TEST 2: Second mention on same issue
  ✅ PASS: 👀 created for second mention
  ✅ PASS: Bot replied to second mention
  ✅ PASS: Exactly 2 total bot replies

7/7 passed
```

### 测试环境

|     OS     | 状态   |
| :--------: | :----: |
|  🍏 macOS  | N/A    |
| 🪟 Windows | N/A    |
|  🐧 Linux  |   ✅   |

### 运行环境

本地 `qwen channel start my-gitlab`，使用 coding plan 模型（`qwen3-coder-plus`），poll 间隔 15 秒。

## 风险与范围

- 主要风险或取舍：Award emoji API 调用是 best-effort。如果 bot 的 PAT 缺少 award emoji 端点所需的 `api` scope，emoji 会静默失败，但 agent 仍会处理 mention 并发布回复。`api` scope 已在文档中标注为发布评论的必要条件。
- 未验证 / 超出范围：Confidential note 处理（已作为已知限制记录——适配器无法过滤 confidential notes）。Self-allowlist 启动校验（#8117 第 8 项）不在本 PR 范围内。
- 破坏性变更 / 迁移说明：无。GitLab envelope 的 `messageId` 格式保持 `String(todo.id)` 不变。

## 关联 Issue

属于 #8117（第 4 项：临时 👀 reaction / award emoji）。

</details>
