### PR TITLE
refactor(core): centralize agent config derivation

### DIFF
--- a/docs/design/derived-config-ownership.md
+++ b/docs/design/derived-config-ownership.md
@@ -2,21 +2,21 @@
 
 `Config` derivation is a state-ownership operation, not a clone. `deriveConfig` keeps the existing prototype overlay model behind one boundary while production callers are migrated incrementally.
 
-| State                      | Ownership                        | Contract                                                                                                                         |
-| -------------------------- | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| workspace path and context | shared until explicitly overlaid | Worktree profiles must override the paired public getters and private reads together.                                            |
-| file service and discovery | shared until explicitly overlaid | Worktree profiles rebind both to the target workspace.                                                                           |
-| tool registry              | shared or explicitly replaced    | Agent profiles that rebuild it own cleanup of the replacement registry.                                                          |
-| permission manager         | shared or explicitly replaced    | Agent profiles preserve the existing strip/restore lifecycle.                                                                    |
-| approval mode              | shared                           | Derived profiles may read the inherited mode but cannot mutate it until they own an independent permission-manager lifecycle.    |
-| file-read cache            | child-local                      | The first getter call installs a fresh cache on the derived Config.                                                              |
-| memory-pressure monitor    | child-local                      | The first getter call installs a new monitor using the inherited configuration snapshot.                                         |
-| active todo state          | child-local                      | The first mutation installs independent maps.                                                                                    |
-| chat recording service     | shared unless hidden             | Scoped profiles may hide it through a getter override.                                                                           |
-| goal runtime               | prohibited                       | A derived Config cannot resolve the parent conversation's runtime.                                                               |
-| session writer state       | prohibited                       | Writer ownership stays with the canonical session Config.                                                                        |
-| canonical lifecycle        | prohibited                       | A derived Config cannot initialize, start a session, relocate the workspace, or clean up inherited Team/Arena runtime resources. |
-| approval mode mutation     | prohibited                       | A derived Config cannot restore or strip rules on the canonical PermissionManager.                                               |
+| State                      | Ownership                        | Contract                                                                                                                                |
+| -------------------------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| workspace path and context | shared until explicitly overlaid | Worktree profiles must override the paired public getters and private reads together.                                                   |
+| file service and discovery | shared until explicitly overlaid | Worktree profiles rebind both to the target workspace.                                                                                  |
+| tool registry              | shared or explicitly replaced    | Agent profiles that rebuild it own cleanup of the replacement registry.                                                                 |
+| permission manager         | shared or explicitly replaced    | Agent profiles preserve the existing strip/restore lifecycle.                                                                           |
+| approval mode              | shared or explicitly copied      | Bare derived profiles cannot mutate it; agent execution profiles own child-local state and preserve the canonical permission lifecycle. |
+| file-read cache            | child-local                      | The first getter call installs a fresh cache on the derived Config.                                                                     |
+| memory-pressure monitor    | child-local                      | The first getter call installs a new monitor using the inherited configuration snapshot.                                                |
+| active todo state          | child-local                      | The first mutation installs independent maps.                                                                                           |
+| chat recording service     | shared unless hidden             | Scoped profiles may hide it through a getter override.                                                                                  |
+| goal runtime               | prohibited                       | A derived Config cannot resolve the parent conversation's runtime.                                                                      |
+| session writer state       | prohibited                       | Writer ownership stays with the canonical session Config.                                                                               |
+| canonical lifecycle        | prohibited                       | A derived Config cannot initialize, start a session, relocate the workspace, or clean up inherited Team/Arena runtime resources.        |
+| approval mode mutation     | prohibited or explicitly copied  | Only the approval-profile factory may install a child-local transition method and cleanup contract.                                     |
 
 Migration order:
 

--- a/packages/core/src/agents/backends/InProcessBackend.ts
+++ b/packages/core/src/agents/backends/InProcessBackend.ts
@@ -13,20 +13,23 @@
 
 import path from 'node:path';
 import { createDebugLogger } from '../../utils/debugLogger.js';
-import { ApprovalMode, Config } from '../../config/config.js';
+import {
+  ApprovalMode,
+  type Config,
+  type DerivedApprovalModeConfigHooks,
+  deriveApprovalModeConfig,
+  deriveAgentConfig,
+} from '../../config/config.js';
 import { Storage } from '../../config/storage.js';
 import { type ContentGenerator } from '../../core/contentGenerator.js';
 import type { RuntimeContentGeneratorView } from '../runtime/agent-context.js';
 import type { ToolRegistry } from '../../tools/tool-registry.js';
-import { WorkspaceContext } from '../../utils/workspaceContext.js';
-import { FileDiscoveryService } from '../../services/fileDiscoveryService.js';
 import { createRuntimeContentGeneratorView } from '../../models/content-generator-config.js';
 import { AgentStatus, isTerminalStatus } from '../runtime/agent-types.js';
 import { AgentCore } from '../runtime/agent-core.js';
 import { AgentEventEmitter } from '../runtime/agent-events.js';
 import { ContextState } from '../runtime/agent-headless.js';
 import { AgentInteractive } from '../runtime/agent-interactive.js';
-import { createDenialState } from '../../permissions/denialTracking.js';
 import { runWithTeammateIdentity } from '../team/identity.js';
 import type {
   Backend,
@@ -491,49 +494,34 @@ async function createPerAgentConfig(
   modelId?: string,
   authOverrides?: InProcessSpawnConfig['authOverrides'],
   approvalMode?: ApprovalMode,
-  approvalModeHooks?: ApprovalModeOverrideHooks,
+  approvalModeHooks?: DerivedApprovalModeConfigHooks,
 ): Promise<{
   config: Config;
   contentGenerator?: ContentGenerator;
   runtimeView?: RuntimeContentGeneratorView;
   cleanup: () => void;
 }> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let override = Object.create(base) as any;
-  let dedicatedContentGenerator: ContentGenerator | undefined;
-  let runtimeView: RuntimeContentGeneratorView | undefined;
-  let cleanup = () => {};
-
-  if (approvalMode !== undefined) {
-    const handle = createApprovalModeConfigOverride(
-      base,
-      approvalMode,
-      approvalModeHooks,
-    );
-    override = handle.config as unknown as Record<string, unknown>;
-    cleanup = handle.cleanup;
-  }
-
-  let agentRegistry: ToolRegistry | undefined;
-  try {
-    override.getWorkingDir = () => cwd;
-    override.getTargetDir = () => cwd;
-    override.getProjectRoot = () => cwd;
-    override.getPlanFilePath = () => {
+  const approvalHandle =
+    approvalMode === undefined
+      ? { config: base, cleanup: () => {} }
+      : deriveApprovalModeConfig(base, approvalMode, {
+          hooks: approvalModeHooks,
+        });
+  const handle = deriveAgentConfig(approvalHandle.config, cwd, {
+    customIgnoreFiles: base.getFileFilteringOptions().customIgnoreFiles,
+    getPlanFilePath: () => {
       const sessionId = Storage.sanitizePlanSessionId(base.getSessionId());
       const scopedAgentId = Storage.sanitizePlanSessionId(agentId);
       return path.join(base.getPlansDir(), `${sessionId}-${scopedAgentId}.md`);
-    };
+    },
+  });
+  const override = handle.config;
+  const cleanup = approvalHandle.cleanup;
+  let dedicatedContentGenerator: ContentGenerator | undefined;
+  let runtimeView: RuntimeContentGeneratorView | undefined;
 
-    const agentWorkspace = new WorkspaceContext(cwd);
-    override.getWorkspaceContext = () => agentWorkspace;
-
-    const agentFileService = new FileDiscoveryService(
-      cwd,
-      base.getFileFilteringOptions().customIgnoreFiles,
-    );
-    override.getFileService = () => agentFileService;
-
+  let agentRegistry: ToolRegistry | undefined;
+  try {
     const registry = await override.createToolRegistry(undefined, {
       skipDiscovery: true,
       forSubAgent: true,
@@ -583,125 +571,6 @@ async function createPerAgentConfig(
     }
     throw error;
   }
-}
-
-interface ApprovalModeOverrideHooks {
-  acquireAutoApprovalOverride(): boolean;
-  releaseAutoApprovalOverride(): void;
-}
-
-function createApprovalModeConfigOverride(
-  base: Config,
-  mode: ApprovalMode,
-  hooks?: ApprovalModeOverrideHooks,
-): { config: Config; cleanup: () => void } {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const override = Object.create(base) as any;
-  const baseApprovalMode = base.getApprovalMode();
-  const initialMode = getTrustedInitialApprovalMode(base, mode);
-  let autoOverrideAcquired = false;
-  const acquireAutoOverride = () => {
-    if (autoOverrideAcquired || base.getApprovalMode() === ApprovalMode.AUTO) {
-      return;
-    }
-    if (hooks) {
-      autoOverrideAcquired = hooks.acquireAutoApprovalOverride();
-      return;
-    }
-    base.getPermissionManager?.()?.stripDangerousRulesForAutoMode();
-    autoOverrideAcquired = true;
-  };
-  const releaseAutoOverride = () => {
-    if (!autoOverrideAcquired) {
-      return;
-    }
-    if (hooks) {
-      hooks.releaseAutoApprovalOverride();
-    } else if (base.getApprovalMode() !== ApprovalMode.AUTO) {
-      base.getPermissionManager?.()?.restoreDangerousRules();
-    }
-    autoOverrideAcquired = false;
-  };
-
-  override.approvalMode = initialMode;
-  override.manualPlanExitNoticeEventState = {
-    ...(override.manualPlanExitNoticeEventState ?? {
-      version: 0,
-      kind: 'clear',
-    }),
-  };
-  override.getApprovalMode = Config.prototype.getApprovalMode;
-  override.prePlanMode =
-    initialMode === ApprovalMode.PLAN
-      ? baseApprovalMode === ApprovalMode.PLAN
-        ? base.getPrePlanMode()
-        : baseApprovalMode
-      : undefined;
-  override.approvalModeRevision = 0;
-
-  override.setApprovalMode = (
-    nextMode: ApprovalMode,
-    options?: Parameters<Config['setApprovalMode']>[1],
-  ) => {
-    const beforeMode = (override as Config).getApprovalMode();
-    const hadOwnPermissionManager = Object.prototype.hasOwnProperty.call(
-      override,
-      'permissionManager',
-    );
-    const ownPermissionManager = override.permissionManager;
-    override.permissionManager = null;
-    try {
-      Config.prototype.setApprovalMode.call(
-        override as Config,
-        nextMode,
-        options,
-      );
-    } finally {
-      if (hadOwnPermissionManager) {
-        override.permissionManager = ownPermissionManager;
-      } else {
-        delete override.permissionManager;
-      }
-    }
-
-    const afterMode = (override as Config).getApprovalMode();
-    if (beforeMode !== ApprovalMode.AUTO && afterMode === ApprovalMode.AUTO) {
-      acquireAutoOverride();
-    } else if (
-      beforeMode === ApprovalMode.AUTO &&
-      afterMode !== ApprovalMode.AUTO
-    ) {
-      releaseAutoOverride();
-    }
-  };
-  override.autoModeDenialState = createDenialState();
-
-  const cleanup = () => {
-    releaseAutoOverride();
-  };
-
-  if (
-    initialMode === ApprovalMode.AUTO &&
-    base.getApprovalMode() !== ApprovalMode.AUTO
-  ) {
-    acquireAutoOverride();
-  }
-
-  return { config: override as Config, cleanup };
-}
-
-function getTrustedInitialApprovalMode(
-  base: Config,
-  mode: ApprovalMode,
-): ApprovalMode {
-  if (
-    !base.isTrustedFolder() &&
-    mode !== ApprovalMode.DEFAULT &&
-    mode !== ApprovalMode.PLAN
-  ) {
-    return ApprovalMode.DEFAULT;
-  }
-  return mode;
 }
 
 function createRunInContext(

--- a/packages/core/src/agents/background-agent-resume.ts
+++ b/packages/core/src/agents/background-agent-resume.ts
@@ -7,7 +7,7 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import type { Content, Part } from '@google/genai';
-import type { Config } from '../config/config.js';
+import { deriveConfig, type Config } from '../config/config.js';
 import * as jsonl from '../utils/jsonl-utils.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import {
@@ -913,9 +913,9 @@ export class BackgroundAgentResumeService {
         target.subagentConfig?.approvalMode === BUBBLE_APPROVAL_MODE &&
           this.config.isInteractive(),
       );
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const bgConfig = Object.create(activeAgentConfig) as any;
-      bgConfig.getShouldAvoidPermissionPrompts = () => !shouldBubble;
+      const bgConfig = deriveConfig(activeAgentConfig, {
+        getShouldAvoidPermissionPrompts: () => !shouldBubble,
+      });
 
       const records = await jsonl.read<ChatRecord>(outputFile);
       const recovery = recoverTranscript(records);

--- a/packages/core/src/agents/runtime/workflow-orchestrator.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.ts
@@ -547,12 +547,10 @@ function reportTokens(
  * would bypass that normalization and require us to duplicate it here.
  *
  * Why the worktree-rebound Config is passed as `runtimeContext` (not
- * `toolConfigOverride`): `SubagentManager.buildSubagentContextOverride`
- * (subagent-manager.ts:857) builds the subagent context via
- * `Object.create(runtimeContext)`. The own-property rebinds we set on the
- * worktree override propagate through the prototype chain, so all
- * `getTargetDir() / getCwd() / getFileService() / getWorkspaceContext()`
- * call sites inside the subagent see the worktree path. Subsequent
+ * `toolConfigOverride`): `SubagentManager` derives its subagent context from
+ * this worktree profile.
+ * The worktree profile's own getter and field rebinds propagate through that
+ * derivation, so workspace-bound call sites keep the selected path.
  * `rebuildToolRegistryOnOverride` re-resolves `this.config` through the
  * chain and anchors EditTool / WriteFileTool / ReadFileTool to the
  * worktree's FileReadCache, so the subagent cannot leak writes back into

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1578,7 +1578,7 @@ describe('Server Config (config.ts)', () => {
         goalRuntime: 'prohibited',
         sessionWriterState: 'prohibited',
         canonicalLifecycle: 'prohibited',
-        approvalModeMutation: 'prohibited',
+        approvalModeMutation: 'copied',
       });
     });
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1702,7 +1702,7 @@ export const DERIVED_CONFIG_STATE_OWNERSHIP = {
   goalRuntime: 'prohibited',
   sessionWriterState: 'prohibited',
   canonicalLifecycle: 'prohibited',
-  approvalModeMutation: 'prohibited',
+  approvalModeMutation: 'copied',
 } as const satisfies Record<string, DerivedConfigStateOwnership>;
 
 export type DerivedConfigOverrides = Partial<
@@ -1738,8 +1738,194 @@ export type DerivedConfigOverrides = Partial<
   >
 >;
 
+export interface DerivedApprovalModeConfigHooks {
+  acquireAutoApprovalOverride(): boolean;
+  releaseAutoApprovalOverride(): void;
+}
+
+export interface DerivedApprovalModeConfigOptions {
+  hooks?: DerivedApprovalModeConfigHooks;
+}
+
+export interface DerivedApprovalModeConfigHandle {
+  config: Config;
+  cleanup: () => void;
+}
+
+export interface DerivedAgentConfigOptions {
+  customIgnoreFiles?: string[];
+  getPlanFilePath?: Config['getPlanFilePath'];
+}
+
+export interface DerivedAgentConfigHandle {
+  config: Config;
+  fileService: FileDiscoveryService;
+  workspaceContext: WorkspaceContext;
+}
+
 export interface DerivedWorktreeConfigOptions {
   customIgnoreFiles?: string[];
+}
+
+/**
+ * Derives a Config with child-local approval state while preserving the
+ * canonical PermissionManager's AUTO strip/restore lifecycle.
+ */
+export function deriveApprovalModeConfig(
+  base: Config,
+  mode: ApprovalMode,
+  options: DerivedApprovalModeConfigOptions = {},
+): DerivedApprovalModeConfigHandle {
+  const baseApprovalMode = base.getApprovalMode();
+  const initialMode = getTrustedDerivedApprovalMode(base, mode);
+  let autoOverrideAcquired = false;
+  const acquireAutoOverride = () => {
+    if (autoOverrideAcquired || base.getApprovalMode() === ApprovalMode.AUTO) {
+      return;
+    }
+    if (options.hooks) {
+      autoOverrideAcquired = options.hooks.acquireAutoApprovalOverride();
+      return;
+    }
+    base.getPermissionManager?.()?.stripDangerousRulesForAutoMode();
+    autoOverrideAcquired = true;
+  };
+  const releaseAutoOverride = () => {
+    if (!autoOverrideAcquired) return;
+    if (options.hooks) {
+      options.hooks.releaseAutoApprovalOverride();
+    } else if (base.getApprovalMode() !== ApprovalMode.AUTO) {
+      base.getPermissionManager?.()?.restoreDangerousRules();
+    }
+    autoOverrideAcquired = false;
+  };
+
+  const derived = deriveConfig(base, {
+    getApprovalMode: Config.prototype.getApprovalMode,
+  });
+  const state = derived as unknown as {
+    approvalMode: ApprovalMode;
+    prePlanMode?: ApprovalMode;
+    approvalModeRevision: number;
+    manualPlanExitNoticeEventState: ManualPlanExitNoticeEventState;
+    autoModeDenialState: AutoModeDenialState;
+    permissionManager: PermissionManager | null;
+  };
+  state.approvalMode = initialMode;
+  state.prePlanMode =
+    initialMode === ApprovalMode.PLAN
+      ? baseApprovalMode === ApprovalMode.PLAN
+        ? base.getPrePlanMode()
+        : baseApprovalMode
+      : undefined;
+  state.approvalModeRevision = 0;
+  state.manualPlanExitNoticeEventState = {
+    ...((
+      base as unknown as {
+        manualPlanExitNoticeEventState?: ManualPlanExitNoticeEventState;
+      }
+    ).manualPlanExitNoticeEventState ?? { version: 0, kind: 'clear' }),
+  };
+  state.autoModeDenialState = createDenialState();
+
+  Object.defineProperty(derived, 'setApprovalMode', {
+    value: (
+      nextMode: ApprovalMode,
+      setOptions?: Parameters<Config['setApprovalMode']>[1],
+    ): void => {
+      const beforeMode = derived.getApprovalMode();
+      const hadOwnPermissionManager = Object.hasOwn(
+        derived,
+        'permissionManager',
+      );
+      const ownPermissionManager = state.permissionManager;
+      state.permissionManager = null;
+      try {
+        Config.prototype.setApprovalMode.call(derived, nextMode, setOptions);
+      } finally {
+        if (hadOwnPermissionManager) {
+          state.permissionManager = ownPermissionManager;
+        } else {
+          delete (state as Partial<typeof state>).permissionManager;
+        }
+      }
+
+      const afterMode = derived.getApprovalMode();
+      if (beforeMode !== ApprovalMode.AUTO && afterMode === ApprovalMode.AUTO) {
+        acquireAutoOverride();
+      } else if (
+        beforeMode === ApprovalMode.AUTO &&
+        afterMode !== ApprovalMode.AUTO
+      ) {
+        releaseAutoOverride();
+      }
+    },
+    writable: true,
+    configurable: true,
+    enumerable: true,
+  });
+
+  if (
+    initialMode === ApprovalMode.AUTO &&
+    base.getApprovalMode() !== ApprovalMode.AUTO
+  ) {
+    acquireAutoOverride();
+  }
+
+  return { config: derived, cleanup: releaseAutoOverride };
+}
+
+/**
+ * Derives the workspace and optional approval-mode state for one agent.
+ */
+export function deriveAgentConfig(
+  base: Config,
+  workingDirectory: string,
+  options: DerivedAgentConfigOptions = {},
+): DerivedAgentConfigHandle {
+  const fileService = new FileDiscoveryService(
+    workingDirectory,
+    options.customIgnoreFiles,
+  );
+  const workspaceContext = new WorkspaceContext(workingDirectory);
+  const derived = deriveConfig(base, {
+    getTargetDir: () => workingDirectory,
+    getCwd: () => workingDirectory,
+    getWorkingDir: () => workingDirectory,
+    getProjectRoot: () => workingDirectory,
+    getPlanFilePath: options.getPlanFilePath,
+    getFileService: () => fileService,
+    getWorkspaceContext: () => workspaceContext,
+  });
+  const workspaceState = derived as unknown as {
+    targetDir: string;
+    cwd: string;
+    fileDiscoveryService: FileDiscoveryService;
+    workspaceContext: WorkspaceContext;
+  };
+  workspaceState.targetDir = workingDirectory;
+  workspaceState.cwd = workingDirectory;
+  workspaceState.fileDiscoveryService = fileService;
+  workspaceState.workspaceContext = workspaceContext;
+  return {
+    config: derived,
+    fileService,
+    workspaceContext,
+  };
+}
+
+function getTrustedDerivedApprovalMode(
+  base: Config,
+  requestedMode: ApprovalMode,
+): ApprovalMode {
+  if (
+    !base.isTrustedFolder() &&
+    requestedMode !== ApprovalMode.DEFAULT &&
+    requestedMode !== ApprovalMode.PLAN
+  ) {
+    return ApprovalMode.DEFAULT;
+  }
+  return requestedMode;
 }
 
 /**

--- a/packages/core/src/subagents/subagent-manager-override.test.ts
+++ b/packages/core/src/subagents/subagent-manager-override.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { Config, ApprovalMode } from '../config/config.js';
+import { Config, ApprovalMode, deriveConfig } from '../config/config.js';
 import { SubagentManager } from './subagent-manager.js';
 import type { SubagentConfig } from './types.js';
 import { ToolNames } from '../tools/tool-names.js';
@@ -14,16 +14,9 @@ import { ReadFileTool } from '../tools/read-file.js';
 import { createApprovalModeOverride } from '../tools/agent/agent.js';
 
 /**
- * Companion to `tools/agent/agent-override.test.ts`. Same regression:
- * Object.create(parent) by itself is not enough to isolate a subagent's
- * core tools from the parent's bound `EditTool` / `WriteFileTool` /
- * `ReadFileTool`. The subagent path (which flows through
- * `SubagentManager.createAgentHeadless` →
- * `buildSubagentContextOverride`) must rebuild the tool registry on
- * the override Config so bound tools resolve `this.config` to the
- * subagent rather than the parent — otherwise mutations executed via
- * the bound tool reach the parent's FileReadCache and silently weaken
- * prior-read enforcement.
+ * Companion to `tools/agent/agent-override.test.ts`. A derived child must
+ * rebuild core tools so Edit/Write/Read resolve its child-local cache rather
+ * than the parent's recorded reads.
  */
 describe('SubagentManager.buildSubagentContextOverride bound-tool isolation', () => {
   // Bare mode keeps the registry small (ReadFile / Edit / Shell only) and
@@ -131,23 +124,7 @@ describe('SubagentManager.buildSubagentContextOverride bound-tool isolation', ()
     expect(child.getFileReadCache().size()).toBe(0);
   });
 
-  it('skips rebuild and inherits registry via prototype when an upstream wrapper has already rebuilt the registry (real-world chained-override case)', async () => {
-    // This mirrors the real-world flow: agent.ts wraps the parent in
-    // `createApprovalModeOverride` (which builds R1 on the wrapper),
-    // then passes that wrapper — sometimes wrapped one more level in
-    // `bgConfig = Object.create(agentConfig)` for the background path —
-    // through `createAgentHeadless` → `buildSubagentContextOverride`.
-    // We do NOT want the second layer to build a redundant R2 — that
-    // would (a) waste work, (b) leak listeners on every later
-    // AgentTool/SkillTool factory invocation, and (c) split the cache
-    // so client-level clears target an empty R2 cache while the bound
-    // tools (still in R1) keep using R1's.
-    //
-    // Detection is via the `TOOL_REGISTRY_REBUILT` symbol marker that
-    // `createApprovalModeOverride` sets on its return value; Symbol
-    // property lookup walks the prototype chain so even an Object.create
-    // wrapper above the rebuilt Config is correctly recognised as
-    // having an upstream rebuild.
+  it('skips rebuild and inherits registry when an upstream derived wrapper already rebuilt it', async () => {
     const parent = new Config(baseParams);
     const parentRegistry = await parent.createToolRegistry(undefined, {
       skipDiscovery: true,
@@ -162,30 +139,19 @@ describe('SubagentManager.buildSubagentContextOverride bound-tool isolation', ()
     );
     const upstreamRegistry = upstreamWrapper.getToolRegistry();
 
-    // Layer 2: simulate `bgConfig = Object.create(agentConfig)` from
-    // the background path — own properties added on this layer should
-    // not hide the marker on the prototype.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const bgWrapper = Object.create(upstreamWrapper) as any;
-    bgWrapper.getShouldAvoidPermissionPrompts = () => true;
+    // Layer 2: add the background prompt policy through the factory.
+    const bgWrapper = deriveConfig(upstreamWrapper, {
+      getShouldAvoidPermissionPrompts: () => true,
+    });
 
     const manager = new SubagentManager(parent);
 
     const child = await callBuildOverride(manager, bgWrapper as Config);
 
-    // child is still a distinct instance (Object.create) so the
-    // FileReadCache lazy-init still works, but its registry must
-    // resolve via the prototype back to upstreamRegistry — we did not
-    // build a new one.
+    // The child is distinct, but the rebuilt registry remains inherited from
+    // the approval profile so no duplicate registry lifecycle is created.
     expect(child).not.toBe(bgWrapper);
     expect(child.getToolRegistry()).toBe(upstreamRegistry);
-
-    // Critically: tools the model later instantiates from the registry
-    // are bound to upstreamWrapper, NOT the second-layer child. That
-    // is what the optimization is for — the bound tool still resolves
-    // `this.config.getFileReadCache()` to upstreamWrapper's cache,
-    // which is the cache the rest of the subagent execution actually
-    // uses.
     const childEdit = await child.getToolRegistry().ensureTool(ToolNames.EDIT);
     expect(childEdit).toBeInstanceOf(EditTool);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/core/src/subagents/subagent-manager.test.ts
+++ b/packages/core/src/subagents/subagent-manager.test.ts
@@ -2383,8 +2383,8 @@ bad`);
         const { runtimeContext, runtimeView } = destructureAgentHeadlessCall(
           mockAgentHeadlessCreate.mock.calls[0],
         );
-        // Subagents always get an `Object.create(parent)` wrapper for
-        // FileReadCache isolation — distinct instance, prototype === parent.
+        // Subagents always get a derived wrapper for child-local state.
+        // It remains a distinct instance whose prototype is the parent.
         expect(runtimeContext).not.toBe(mockConfig);
         expect(Object.getPrototypeOf(runtimeContext)).toBe(mockConfig);
         expect(runtimeView).toBeDefined();

--- a/packages/core/src/subagents/subagent-manager.ts
+++ b/packages/core/src/subagents/subagent-manager.ts
@@ -37,7 +37,7 @@ import type {
   AgentHooks,
 } from '../agents/runtime/agent-events.js';
 import type { Config, MCPServerConfig } from '../config/config.js';
-import { APPROVAL_MODES } from '../config/config.js';
+import { APPROVAL_MODES, deriveConfig } from '../config/config.js';
 import type { HookDefinition, HookEventName } from '../hooks/types.js';
 import type { RuntimeContentGeneratorView } from '../agents/runtime/agent-context.js';
 import {
@@ -959,25 +959,9 @@ export class SubagentManager {
   }
 
   /**
-   * Build the per-subagent Config override used as the AgentHeadless
-   * runtime context. The override is a thin prototype-delegation wrapper
-   * (`Object.create(runtimeContext)`): no method changes, but a distinct
-   * instance triggers the lazy own-property init in
-   * `Config.getFileReadCache()` so the subagent gets its own cache
-   * rather than inheriting the parent's recorded reads — which would
-   * silently weaken prior-read enforcement on its mutation paths.
-   *
-   * The tool registry is also rebuilt on the override so `EditTool` /
-   * `WriteFileTool` / `ReadFileTool` resolve `this.config` to the
-   * subagent — without that step, the parent's cached tool instances
-   * still reach the parent's FileReadCache. The rebuild is skipped when
-   * a wrapper above `runtimeContext` already rebuilt one (typically
-   * `agent.ts:createApprovalModeOverride`, which marks itself via a
-   * Symbol-keyed flag — Symbol lookup walks the prototype chain, so
-   * this also catches wrapper-on-wrapper layering like
-   * `bgConfig = Object.create(agentConfig)` from the background path).
-   * Rebuilding twice would waste work, leak listeners on shared
-   * managers, and split caches across registry layers.
+   * Build the per-subagent Config context. A distinct derived Config keeps
+   * child-local caches isolated; registry rebuilding preserves bound-tool and
+   * per-agent MCP ownership.
    */
   private async buildSubagentContextOverride(
     runtimeContext: Config,
@@ -997,8 +981,7 @@ export class SubagentManager {
      */
     cleanup?: () => Promise<void>;
   }> {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const subagentContext = Object.create(runtimeContext) as any as Config;
+    const subagentContext = deriveConfig(runtimeContext);
 
     // Per-agent MCP server overrides. Frontmatter `mcpServers` entries shadow
     // session-level servers on key collision (more-specific-wins, matching

--- a/packages/core/src/tools/agent/agent-override.test.ts
+++ b/packages/core/src/tools/agent/agent-override.test.ts
@@ -332,6 +332,22 @@ describe('createApprovalModeOverride bound-tool isolation', () => {
     expect(restoreDangerousRules).toHaveBeenCalledTimes(1);
   });
 
+  it('restores AUTO rules when registry setup fails', async () => {
+    const parent = await createParentWithRegistry();
+    const { stripDangerousRulesForAutoMode, restoreDangerousRules } =
+      attachFakePermissionManager(parent);
+    vi.spyOn(parent, 'createToolRegistry').mockRejectedValue(
+      new Error('registry boom'),
+    );
+
+    await expect(
+      createApprovalModeOverride(parent, ApprovalMode.AUTO),
+    ).rejects.toThrow('registry boom');
+
+    expect(stripDangerousRulesForAutoMode).toHaveBeenCalledTimes(1);
+    expect(restoreDangerousRules).toHaveBeenCalledTimes(1);
+  });
+
   it('does not need cleanup restore after a child leaves AUTO mode itself', async () => {
     const parent = await createParentWithRegistry();
     const { stripDangerousRulesForAutoMode, restoreDangerousRules } =

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -96,12 +96,13 @@ import {
 import { toModelVisibleSubagentResult } from '../../agents/subagent-result.js';
 import {
   ApprovalMode,
-  Config,
+  deriveApprovalModeConfig,
+  deriveConfig,
   deriveWorktreeConfig,
   normalizeMaxSubagentDepth,
   validateMaxSessionTurns,
+  type Config,
 } from '../../config/config.js';
-import { createDenialState } from '../../permissions/denialTracking.js';
 import { isTeammate } from '../../agents/team/identity.js';
 import { isSubagentLikeExecutionContext } from '../../agents/runtime/subagent-plan-tool-policy.js';
 import {
@@ -627,118 +628,23 @@ function capturePersistedCliFlags(
 }
 
 /**
- * Creates a Config override with a different approval mode.
- *
- * Uses prototype delegation (Object.create) to avoid mutating the parent
- * config, then delegates to {@link rebuildToolRegistryOnOverride} so the
- * override's tool registry has core tools bound to the override rather
- * than to the parent. Without that rebuild, the parent's cached tool
- * instances continue to resolve `this.config` to the parent, defeating
- * per-Config isolation of FileReadCache / approval mode for any code
- * path that goes through the bound tool.
- *
- * Returns `{ config, cleanup }`. Callers MUST invoke `cleanup` in a
- * `finally` block after the override is no longer in use, otherwise
- * the parent's PermissionManager may leak a strip across the sub-agent
- * boundary (see strip lifecycle below).
- *
- * Strip lifecycle for AUTO overrides:
- *   - parent not in AUTO, override starts in AUTO: this function strips
- *     the PARENT's PM (shared via prototype chain — the override cannot
- *     have its own PM without a much bigger refactor).
- *   - parent already in AUTO, override starts in AUTO: parent's
- *     `setApprovalMode` already stripped on its own entry, so this
- *     function does not strip again.
- *   - override enters/leaves AUTO later: `setApprovalMode` reuses Config's
- *     normal state transition, but suppresses AUTO strip/restore while the
- *     parent is already in AUTO because the parent owns that strip lifecycle.
- *     `cleanup` only restores if the child finishes still in AUTO while the
- *     parent is not in AUTO.
+ * Creates an agent approval profile, then rebuilds its tool registry so bound
+ * tools resolve the derived Config and its child-local state.
  */
 export async function createApprovalModeOverride(
   base: Config,
   mode: ApprovalMode,
   options: ApprovalModeOverrideOptions = {},
 ): Promise<ApprovalModeOverrideHandle> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const override = Object.create(base) as any;
-  const baseApprovalMode = base.getApprovalMode();
-  // These own properties intentionally mirror Config's TS-private field names.
-  // Config prototype methods read/write them at runtime on this override object.
-  override.approvalMode = mode;
-  override.manualPlanExitNoticeEventState = {
-    ...(override.manualPlanExitNoticeEventState ?? {
-      version: 0,
-      kind: 'clear',
-    }),
-  };
-  override.getApprovalMode = Config.prototype.getApprovalMode;
-  override.prePlanMode =
-    mode === ApprovalMode.PLAN
-      ? baseApprovalMode === ApprovalMode.PLAN
-        ? base.getPrePlanMode()
-        : baseApprovalMode
-      : undefined;
-  override.approvalModeRevision = 0;
-  override.autoModeDenialState = createDenialState();
-  override.setApprovalMode = (
-    nextMode: ApprovalMode,
-    setOptions?: Parameters<Config['setApprovalMode']>[1],
-  ): void => {
-    if (base.getApprovalMode() !== ApprovalMode.AUTO) {
-      Config.prototype.setApprovalMode.call(
-        override as Config,
-        nextMode,
-        setOptions,
-      );
-      return;
-    }
-
-    const hadOwnPermissionManager = Object.prototype.hasOwnProperty.call(
-      override,
-      'permissionManager',
-    );
-    const ownPermissionManager = override.permissionManager;
-    override.permissionManager = null;
-    try {
-      Config.prototype.setApprovalMode.call(
-        override as Config,
-        nextMode,
-        setOptions,
-      );
-    } finally {
-      if (hadOwnPermissionManager) {
-        override.permissionManager = ownPermissionManager;
-      } else {
-        delete override.permissionManager;
-      }
-    }
-  };
-  applyPersistedCliFlagOverrides(override as Config, options.persistedCliFlags);
-  await rebuildToolRegistryOnOverride(override as Config, base);
-
-  const cleanup = () => {
-    if (
-      (override as Config).getApprovalMode() === ApprovalMode.AUTO &&
-      base.getApprovalMode() !== ApprovalMode.AUTO
-    ) {
-      base.getPermissionManager?.()?.restoreDangerousRules();
-    }
-  };
-
-  if (mode === ApprovalMode.AUTO) {
-    const baseWasAuto = base.getApprovalMode() === ApprovalMode.AUTO;
-    if (!baseWasAuto) {
-      // This override is bringing AUTO into a non-AUTO parent. Strip
-      // dangerous allow rules so the sub-agent's classifier actually
-      // gates them. Cleanup handles restore if the child finishes in AUTO.
-      base.getPermissionManager?.()?.stripDangerousRulesForAutoMode();
-    }
-    // baseWasAuto: parent's setApprovalMode already stripped; cleanup
-    // will not restore while the parent remains in AUTO.
+  const { config: override, cleanup } = deriveApprovalModeConfig(base, mode);
+  try {
+    applyPersistedCliFlagOverrides(override, options.persistedCliFlags);
+    await rebuildToolRegistryOnOverride(override, base);
+    return { config: override, cleanup };
+  } catch (error) {
+    cleanup();
+    throw error;
   }
-
-  return { config: override as Config, cleanup };
 }
 
 /**
@@ -2812,12 +2718,10 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
       // mode while overriding only the prompt-avoidance policy used by their
       // scheduler.
       const subagentRuntimeConfig = shouldRunInBackground
-        ? (Object.create(agentConfig) as Config)
+        ? deriveConfig(agentConfig, {
+            getShouldAvoidPermissionPrompts: () => !shouldBubble,
+          })
         : agentConfig;
-      if (shouldRunInBackground) {
-        subagentRuntimeConfig.getShouldAvoidPermissionPrompts = () =>
-          !shouldBubble;
-      }
 
       // Background agents need a dedicated emitter so their transcript never
       // receives events from concurrent agents using the parent tool emitter.


### PR DESCRIPTION
## What this PR does

This PR moves agent execution Config profiles behind the shared derivation boundary. Approval-mode, in-process agent, background resume, and subagent contexts now use the same factory-owned prototype overlay while retaining child-local approval state, workspace state, prompt policy, and tool-registry behavior.

## Why it's needed

Agent execution previously repeated bare prototype derivation and private-state rebinding across several paths. That made ownership and cleanup rules implicit, especially for AUTO permission stripping, bound tool registries, background permission bubbling, and per-agent workspace state. Centralizing these profiles keeps those contracts explicit without changing provider or CLI behavior.

## Reviewer Test Plan

### How to verify

1. Confirm an approval-mode child can change modes without mutating its parent, preserves trust checks and plan-exit state, and restores AUTO permission rules both on normal cleanup and failed registry setup.
2. Confirm in-process agents retain isolated workspace, file service, plan path, approval mode, and tool registry state, including multi-child AUTO cleanup.
3. Confirm resumed and newly spawned background agents retain the expected prompt-bubbling policy without creating a redundant registry lifecycle.
4. Confirm subagents retain child-local file-read caches and per-agent MCP registry ownership.

### Evidence (Before & After)

N/A — internal refactor with no user-visible UI change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js package tests and build on macOS.

## Risk & Scope

- Main risk or tradeoff: derived Config state must preserve the existing permission-manager and replacement tool-registry cleanup lifecycles across layered agent profiles.
- Not validated / out of scope: provider behavior, CLI UI behavior, and platform-specific runtime execution are unchanged and were not exercised end to end.
- Breaking changes / migration notes: none.

## Linked Issues

Part of #8083

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 将 agent 执行相关的 Config profile 收敛到共享派生边界。approval mode、进程内 agent、后台恢复和 subagent context 现在统一通过工厂管理 prototype overlay，同时保留子级独立的 approval 状态、workspace 状态、prompt policy 和 tool registry 行为。

## 为什么需要

此前多个 agent 执行路径分别直接使用 prototype 派生并重绑定私有状态，AUTO 权限规则 strip/restore、绑定工具 registry、后台权限冒泡和每个 agent 的 workspace 状态等所有权与清理规则都依赖调用方自行理解。统一这些 profile 后，可以在不改变 provider 或 CLI 行为的前提下显式维护这些契约。

## Reviewer Test Plan

### 验证方式

1. 确认 approval-mode child 可以独立切换模式，不修改 parent，并保留 trust 检查、plan-exit 状态，以及正常清理和 registry 初始化失败时的 AUTO 权限规则恢复。
2. 确认进程内 agent 的 workspace、file service、plan path、approval mode 和 tool registry 仍然隔离，包括多个 AUTO child 的清理生命周期。
3. 确认恢复和新建的后台 agent 仍保留预期的 prompt bubbling policy，且不会创建重复的 registry 生命周期。
4. 确认 subagent 仍拥有子级独立的 file-read cache 和每个 agent 的 MCP registry 所有权。

### 证据（Before & After）

N/A —— 内部重构，没有用户可见 UI 变化。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

在 macOS 上运行 Node.js package 测试与构建。

## 风险与范围

- 主要风险或权衡：派生 Config 状态必须在多层 agent profile 中保留现有 permission manager 和替换 tool registry 的清理生命周期。
- 未验证 / 范围外：provider 行为、CLI UI 行为和平台相关运行时执行保持不变，未做端到端验证。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

#8083 的一部分。

</details>
