### PR TITLE
refactor(core): centralize scoped config profiles

### DIFF
--- a/eslint-rules/no-config-object-create.js
+++ b/eslint-rules/no-config-object-create.js
@@ -1,0 +1,55 @@
+function importsConfig(node) {
+  return node.specifiers.some(
+    (specifier) =>
+      specifier.type === 'ImportSpecifier' &&
+      specifier.imported.type === 'Identifier' &&
+      specifier.imported.name === 'Config',
+  );
+}
+
+function isObjectCreate(node) {
+  return (
+    node.callee.type === 'MemberExpression' &&
+    !node.callee.computed &&
+    node.callee.object.type === 'Identifier' &&
+    node.callee.object.name === 'Object' &&
+    node.callee.property.type === 'Identifier' &&
+    node.callee.property.name === 'create' &&
+    !(node.arguments[0]?.type === 'Literal' && node.arguments[0].value === null)
+  );
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Require Config prototype derivation to go through deriveConfig.',
+    },
+    schema: [],
+    messages: {
+      useDeriveConfig:
+        'Do not derive Config with Object.create(). Use deriveConfig() or a specialized Config factory.',
+    },
+  },
+
+  create(context) {
+    let hasConfigImport = false;
+    const objectCreateCalls = [];
+
+    return {
+      ImportDeclaration(node) {
+        if (importsConfig(node)) hasConfigImport = true;
+      },
+      CallExpression(node) {
+        if (isObjectCreate(node)) objectCreateCalls.push(node);
+      },
+      'Program:exit'() {
+        if (!hasConfigImport) return;
+        for (const node of objectCreateCalls) {
+          context.report({ node, messageId: 'useDeriveConfig' });
+        }
+      },
+    };
+  },
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,6 +16,7 @@ import globals from 'globals';
 import storybook from 'eslint-plugin-storybook';
 import checkFile from 'eslint-plugin-check-file';
 import { legacyFilenames } from './eslint.legacy-filenames.mjs';
+import noConfigObjectCreate from './eslint-rules/no-config-object-create.js';
 
 export default tseslint.config(
   {
@@ -248,6 +249,27 @@ export default tseslint.config(
     },
     rules: {
       'no-console': 'off',
+    },
+  },
+  {
+    files: ['packages/core/src/**/*.ts'],
+    ignores: [
+      'packages/core/src/config/config.ts',
+      '**/*.test.ts',
+      '**/*.spec.ts',
+      '**/__tests__/**',
+      '**/generated/**',
+      '**/*.generated.ts',
+    ],
+    plugins: {
+      'qwen-code': {
+        rules: {
+          'no-config-object-create': noConfigObjectCreate,
+        },
+      },
+    },
+    rules: {
+      'qwen-code/no-config-object-create': 'error',
     },
   },
   {

--- a/packages/core/src/agents/runtime/workflow-orchestrator.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.ts
@@ -6,7 +6,11 @@
 
 import { randomBytes } from 'node:crypto';
 import * as os from 'node:os';
-import { deriveWorktreeConfig, type Config } from '../../config/config.js';
+import {
+  deriveConfig,
+  deriveWorktreeConfig,
+  type Config,
+} from '../../config/config.js';
 import { createWorkflowSandbox, debugLogger } from './workflow-sandbox.js';
 import type {
   WorkflowAgentOpts,
@@ -1255,12 +1259,11 @@ async function createSchemaConfigOverride(
   base: Config,
   schema: Record<string, unknown>,
 ): Promise<Config> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const override: any = Object.create(base);
-  await rebuildToolRegistryOnOverride(override as Config, base);
+  const override = deriveConfig(base);
+  await rebuildToolRegistryOnOverride(override, base);
   const registry = override.getToolRegistry();
   registry.registerTool(new SyntheticOutputTool(schema));
-  return override as Config;
+  return override;
 }
 
 export class WorkflowOrchestrator {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -2040,10 +2040,8 @@ export class Config {
   private backgroundAgentResumeService?: BackgroundAgentResumeService;
   private readonly backgroundShellRegistry = new BackgroundShellRegistry();
   private readonly workflowRunRegistry = new WorkflowRunRegistry();
-  // Field initializer runs once on the parent Config; child Configs
-  // built via Object.create(parent) intentionally do NOT pick this up
-  // — see getFileReadCache() for the per-instance lazy initialization
-  // that keeps subagent caches isolated from the parent's.
+  // Derived Configs do not run field initializers. getFileReadCache()
+  // lazily installs an own cache to keep child state isolated.
   private fileReadCache: FileReadCache = new FileReadCache();
   private extensionManager!: ExtensionManager;
   private skillManager: SkillManager | null = null;
@@ -2211,8 +2209,8 @@ export class Config {
   private readonly chatRecordingFailureListeners =
     new Set<ChatRecordingFailureListener>();
   private fileCheckpointingEnabled: boolean;
-  // Object (not primitive) so sub-agents via Object.create(parentConfig)
-  // share the same budget instance through prototype lookup.
+  // Object state is intentionally shared by derived Configs through prototype
+  // lookup so every agent contributes to the same session budget.
   private readonly toolResultBudget = { bytesWritten: 0 };
   private fileHistoryService: FileHistoryService | undefined;
   private readonly proxy: string | undefined;
@@ -4050,9 +4048,8 @@ export class Config {
     // /clear or session resume would let a follow-up Read return the
     // placeholder despite the new session never having received the
     // file contents. Use the getter so the lazy own-property
-    // initialization in getFileReadCache() applies even for Configs
-    // constructed via Object.create — those should clear their own
-    // cache, not the parent's.
+    // initialization in getFileReadCache() applies even for derived Configs;
+    // each derived Config should clear its own cache, not the parent's.
     this.getFileReadCache().clear();
     this.toolResultBudget.bytesWritten = 0;
     this.getMemoryPressureMonitor()?.resetForNewSession();
@@ -6602,11 +6599,9 @@ export class Config {
   }
 
   /**
-   * Session-scoped memory pressure monitor. Child Configs created with
-   * `Object.create(parent)` inherit the parent's monitor through the prototype
-   * chain until this getter installs an own monitor backed by the inherited
-   * pressure config snapshot. This mirrors getFileReadCache()'s isolation
-   * contract while keeping type-safe direct field assignment inside the class.
+   * Session-scoped memory pressure monitor. Derived Configs inherit the
+   * parent's monitor until this getter installs an own monitor backed by the
+   * inherited pressure config snapshot. This mirrors getFileReadCache().
    */
   getMemoryPressureMonitor(): MemoryPressureMonitor | undefined {
     if (!Object.prototype.hasOwnProperty.call(this, 'memoryPressureMonitor')) {
@@ -7796,22 +7791,13 @@ export class Config {
    * subagent (which gets its own Config) does not inherit the parent's
    * recorded reads via the prototype chain.
    *
-   * The wrinkle: every subagent / scoped-agent / fork path in this
-   * codebase constructs its Config via `Object.create(parent)`. That
-   * does **not** run instance field initializers, so the parent's
-   * `fileReadCache` field is reachable on the child only by prototype
-   * lookup — i.e. child and parent end up sharing the same cache. The
-   * own-property check below detects "this instance was made by
-   * Object.create" and lazily attaches a fresh cache, ensuring
-   * isolation without requiring every Object.create site to remember
-   * to override the field.
+   * Derived Configs do not run instance field initializers, so the parent's
+   * `fileReadCache` is initially reachable through the prototype chain. The
+   * own-property check below lazily installs a fresh cache for each child.
    */
   getFileReadCache(): FileReadCache {
     if (!Object.prototype.hasOwnProperty.call(this, 'fileReadCache')) {
-      // The own-property write needs to bypass `private`'s structural
-      // check — the field is conceptually still private to the class,
-      // we just need TS to let us install an own copy on a child
-      // instance produced by `Object.create(parent)`.
+      // Install child-local state while keeping the field private to Config.
       (this as unknown as { fileReadCache: FileReadCache }).fileReadCache =
         new FileReadCache();
     }
@@ -8011,10 +7997,8 @@ export class Config {
     // in sync between them.
     //
     // Skipped when building a subagent-context registry. `this.jsonSchema`
-    // propagates to subagent overrides via prototype delegation
-    // (`Object.create(base)` in `createApprovalModeOverride` /
-    // `buildSubagentContextOverride`), but only `runNonInteractive`'s main
-    // and drain loops detect a successful structured_output call as
+    // propagates through Config derivation, but only `runNonInteractive`'s
+    // main and drain loops detect a successful structured_output call as
     // terminal. A subagent that called the tool would receive the
     // "Session will end now" llmContent, then keep running because its
     // own loop has no termination handler — wasted tokens with no

--- a/packages/core/src/memory/memory-scoped-agent-config.ts
+++ b/packages/core/src/memory/memory-scoped-agent-config.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Config } from '../config/config.js';
+import { deriveConfig, type Config } from '../config/config.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { PermissionManager } from '../permissions/permission-manager.js';
@@ -299,8 +299,7 @@ export function createMemoryScopedAgentConfig(
     },
   };
 
-  const scopedConfig = Object.create(config) as Config;
-  scopedConfig.getPermissionManager = () =>
-    scopedPm as unknown as PermissionManager;
-  return scopedConfig;
+  return deriveConfig(config, {
+    getPermissionManager: () => scopedPm as unknown as PermissionManager,
+  });
 }

--- a/packages/core/src/memory/remember.ts
+++ b/packages/core/src/memory/remember.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Config } from '../config/config.js';
+import { deriveConfig, type Config } from '../config/config.js';
 import { ToolNames } from '../tools/tool-names.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { runForkedAgent } from '../utils/forkedAgent.js';
@@ -106,15 +106,17 @@ function createHiddenRememberConfig(
   config: Config,
   options: { disableHooks?: boolean } = {},
 ): Config {
-  const hiddenConfig = Object.create(config) as Config;
-  hiddenConfig.getChatRecordingService = () => undefined;
-  hiddenConfig.getTranscriptPath = () => '';
-  if (options.disableHooks) {
-    hiddenConfig.getDisableAllHooks = () => true;
-    hiddenConfig.getHookSystem = () => undefined;
-    hiddenConfig.getMessageBus = () => undefined;
-  }
-  return hiddenConfig;
+  return deriveConfig(config, {
+    getChatRecordingService: () => undefined,
+    getTranscriptPath: () => '',
+    ...(options.disableHooks
+      ? {
+          getDisableAllHooks: () => true,
+          getHookSystem: () => undefined,
+          getMessageBus: () => undefined,
+        }
+      : {}),
+  });
 }
 
 function uniqueSortedScopes(scopes: Iterable<WorkspaceRememberScope>) {
@@ -165,14 +167,10 @@ export async function runManagedRememberByAgent(params: {
   // section — and in clean mode re-injecting parent-session memory into the
   // intended blank-slate agent. Zero it out for every mode so the section is
   // present exactly once, via the remember system prompt above.
-  const baseConfig = (() => {
-    const derived = Object.create(params.config) as Config;
-    derived.getAutoMemoryPrompt = () => '';
-    if (params.contextMode === 'clean') {
-      derived.getUserMemory = () => '';
-    }
-    return derived;
-  })();
+  const baseConfig = deriveConfig(params.config, {
+    getAutoMemoryPrompt: () => '',
+    ...(params.contextMode === 'clean' ? { getUserMemory: () => '' } : {}),
+  });
   const hiddenConfig = createHiddenRememberConfig(baseConfig, {
     disableHooks: params.contextMode === 'clean',
   });

--- a/packages/core/src/memory/skillReviewAgentPlanner.ts
+++ b/packages/core/src/memory/skillReviewAgentPlanner.ts
@@ -7,7 +7,7 @@
 import type { Content } from '@google/genai';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import type { Config } from '../config/config.js';
+import { deriveConfig, type Config } from '../config/config.js';
 import type { PermissionManager } from '../permissions/permission-manager.js';
 import type {
   PermissionCheckContext,
@@ -233,10 +233,9 @@ export function createSkillScopedAgentConfig(
     },
   };
 
-  const scopedConfig = Object.create(config) as Config;
-  scopedConfig.getPermissionManager = () =>
-    scopedPm as unknown as PermissionManager;
-  return scopedConfig;
+  return deriveConfig(config, {
+    getPermissionManager: () => scopedPm as unknown as PermissionManager,
+  });
 }
 
 // Exported for tests so the `auto-skill-` prefix instruction stays asserted

--- a/scripts/tests/no-config-object-create.test.js
+++ b/scripts/tests/no-config-object-create.test.js
@@ -1,0 +1,39 @@
+import { Linter } from 'eslint';
+import { describe, expect, it } from 'vitest';
+import rule from '../../eslint-rules/no-config-object-create.js';
+
+function verify(code) {
+  const linter = new Linter({ configType: 'eslintrc' });
+  linter.defineRule('qwen-code/no-config-object-create', rule);
+  return linter.verify(code, {
+    parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+    rules: { 'qwen-code/no-config-object-create': 'error' },
+  });
+}
+
+describe('no-config-object-create', () => {
+  it('rejects prototype derivation in a module that imports Config', () => {
+    const messages = verify(`
+      import { Config } from './config.js';
+      const child = Object.create(parent);
+    `);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.messageId).toBe('useDeriveConfig');
+  });
+
+  it('allows deriveConfig and unrelated Object.create calls', () => {
+    expect(
+      verify(`
+        import { Config, deriveConfig } from './config.js';
+        const child = deriveConfig(parent);
+        const dictionary = Object.create(null);
+      `),
+    ).toEqual([]);
+    expect(
+      verify(`
+        const error = Object.create(Object.getPrototypeOf(source));
+      `),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What this PR does

This PR moves the remaining scoped Config profiles behind the shared derivation boundary. Schema-bound workflow agents, managed-memory agents, and skill-review agents now use the same typed overlay factory, and a repository lint rule prevents new production Config prototype overlays from bypassing that boundary.

## Why it's needed

The final scoped profiles still created Config overlays directly, leaving their runtime ownership semantics outside the contract established by the earlier stack. Migrating them completes the production call-site cutover and makes future regressions fail during lint instead of reintroducing untracked prototype state.

## Reviewer Test Plan

### How to verify

1. Confirm schema-bound workflow execution still builds a child-local tool registry and registers the requested synthetic output tool.
2. Confirm managed-memory agents preserve hidden chat/transcript state, clean-context hook suppression, user-memory suppression, and scoped permission-manager behavior.
3. Confirm skill-review agents preserve their scoped permission decisions.
4. Confirm lint rejects a production module that imports Config and creates a non-null prototype with `Object.create`, while allowing `deriveConfig` and null-prototype dictionaries.

### Evidence (Before & After)

N/A — internal refactor and static enforcement with no user-visible UI change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js package tests, lint, typecheck, and build on macOS.

## Risk & Scope

- Main risk or tradeoff: layered scoped profiles must retain every getter override and continue isolating child-local runtime state after becoming recognized derived Configs.
- Not validated / out of scope: provider behavior, CLI UI behavior, and platform-specific runtime execution are unchanged and were not exercised end to end.
- Breaking changes / migration notes: production Config prototype derivation outside the central factory now fails lint.

## Linked Issues

Part of #8083

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 将剩余的 scoped Config profile 收敛到共享派生边界。schema-bound workflow agent、managed-memory agent 和 skill-review agent 现在统一使用类型安全的 overlay factory，并新增仓库 lint 规则，禁止新的生产 Config prototype overlay 绕过该边界。

## 为什么需要

最后几处 scoped profile 仍直接创建 Config overlay，使其运行时所有权语义游离在前序 PR 建立的契约之外。本次迁移完成所有生产调用点的切换，并让后续回归在 lint 阶段直接失败，而不是重新引入未追踪的 prototype 状态。

## Reviewer Test Plan

### 验证方式

1. 确认 schema-bound workflow 执行仍创建子级独立的 tool registry，并注册请求的 synthetic output tool。
2. 确认 managed-memory agent 仍保留隐藏 chat/transcript 状态、clean context 的 hook suppression、user-memory suppression 和 scoped permission-manager 行为。
3. 确认 skill-review agent 仍保留 scoped permission decision。
4. 确认 lint 会拒绝导入 Config 后通过 `Object.create` 创建非 null prototype 的生产模块，同时允许 `deriveConfig` 和 null-prototype dictionary。

### 证据（Before & After）

N/A —— 内部重构和静态约束，没有用户可见 UI 变化。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

在 macOS 上运行 Node.js package 测试、lint、typecheck 和 build。

## 风险与范围

- 主要风险或权衡：多层 scoped profile 在被识别为 derived Config 后，必须保留所有 getter override，并继续隔离子级独立的运行时状态。
- 未验证 / 范围外：provider 行为、CLI UI 行为和平台相关运行时执行保持不变，未做端到端验证。
- 破坏性变更 / 迁移说明：central factory 之外的生产 Config prototype 派生现在会导致 lint 失败。

## 关联 Issue

#8083 的一部分。

</details>
