### PR TITLE
feat(cli): run safe slash commands during streaming

### DIFF
--- a/docs/design/nonblocking-slash-commands.md
+++ b/docs/design/nonblocking-slash-commands.md
@@ -1,0 +1,55 @@
+# Non-blocking Slash Commands During Streaming
+
+## Problem
+
+The interactive input router currently queues every slash command except
+`/btw` while a model response is streaming. This makes local UI controls wait
+for the active conversation turn even when their result does not depend on that
+turn.
+
+## Design
+
+`SlashCommand` gains an opt-in `canRunDuringStreaming` capability. The default
+remains false. While the main model is responding, the input router resolves the
+submitted command through the existing slash-command tree. An opted-in command
+is sent directly to the slash-command processor; all other slash commands keep
+using the existing serialized message queue.
+
+The direct path does not go through `submitQuery`. That function owns the model
+turn lifecycle and deliberately rejects concurrent top-level turns. Keeping
+local commands outside it avoids sharing abort controllers, submission flags,
+or model-stream counters with the active response.
+
+The slash-command processor and command results already update Ink through
+React state. The initial commands therefore do not write directly to terminal
+stdout while Ink is rendering.
+
+## Initial Command Set
+
+- `/status`, `/about`, and `/status paths`: read local runtime information and
+  append an Ink history item.
+- `/settings`: opens the settings dialog; saved changes apply through the
+  existing settings hooks without replacing the active conversation turn.
+- `/help`: opens the static help dialog.
+
+The following categories remain serialized:
+
+- Commands that submit or transform a model turn, such as skills, `/summary`,
+  `/compress`, `/model <model> <prompt>`, and `/goal`.
+- Commands that replace, clear, rewind, resume, branch, or otherwise mutate
+  conversation state.
+- Commands that schedule tools or perform long-running external work.
+- Commands that read state being mutated by the active turn, such as
+  `/context`, `/stats`, `/copy`, `/diff`, and `/recap`.
+
+`/btw` keeps its specialized concurrent model-request path. `/quit` keeps its
+existing immediate cancellation path. Ctrl+Q continues to force any submission
+to wait for idle, including an otherwise opted-in command.
+
+## Verification
+
+Unit coverage verifies that opted-in commands bypass both `submitQuery` and the
+message queue during a response, while unmarked slash commands remain queued.
+Command tests pin the initial capability declarations. Interactive E2E checks
+should start a visibly streaming response, open each opted-in command, close any
+dialog, and confirm that the original response continues and completes.

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -811,6 +811,56 @@ describe('AppContainer State Management', () => {
   });
 
   describe('Context Providers', () => {
+    const renderRespondingInput = (
+      slashCommands: Array<{
+        name: string;
+        description: string;
+        kind: 'built-in';
+        canRunDuringStreaming?: boolean;
+      }>,
+    ) => {
+      const handleSlashCommand = vi.fn();
+      const submitQuery = vi.fn();
+      const addMessage = vi.fn();
+      mockedUseSlashCommandProcessor.mockReturnValue({
+        handleSlashCommand,
+        slashCommands,
+        pendingHistoryItems: [],
+        commandContext: {},
+        shellConfirmationRequest: null,
+        confirmationRequest: null,
+      });
+      mockedUseGeminiStream.mockReturnValue({
+        streamingState: 'responding',
+        submitQuery,
+        initError: null,
+        pendingHistoryItems: [],
+        thought: null,
+        cancelOngoingRequest: vi.fn(),
+        retryLastPrompt: vi.fn(),
+        streamingResponseLengthRef: { current: 0 },
+        isReceivingContent: false,
+      });
+      mockedUseMessageQueue.mockReturnValue({
+        messageQueue: [],
+        addMessage,
+        clearQueue: vi.fn(),
+        getQueuedMessagesText: vi.fn().mockReturnValue(''),
+        popAllMessages: vi.fn().mockReturnValue(null),
+        drainQueue: vi.fn().mockReturnValue([]),
+        popNextTurn: vi.fn().mockReturnValue(null),
+      });
+      render(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+      return { handleSlashCommand, submitQuery, addMessage };
+    };
+
     it('provides AppContext with correct values', () => {
       const { unmount } = render(
         <AppContainer
@@ -1391,6 +1441,66 @@ describe('AppContainer State Management', () => {
         { submittedPrompt: '/btw quick side question' },
       );
       expect(mockQueueMessage).not.toHaveBeenCalled();
+    });
+
+    it('runs opted-in slash commands outside the active turn while responding', () => {
+      const { handleSlashCommand, submitQuery, addMessage } =
+        renderRespondingInput([
+          {
+            name: 'settings',
+            description: 'Open settings',
+            kind: 'built-in',
+            canRunDuringStreaming: true,
+          },
+        ]);
+
+      capturedUIActions.handleFinalSubmit('/settings', {
+        submittedPrompt: '/settings',
+      });
+
+      expect(handleSlashCommand).toHaveBeenCalledWith('/settings');
+      expect(submitQuery).not.toHaveBeenCalled();
+      expect(addMessage).not.toHaveBeenCalled();
+    });
+
+    it('keeps opted-in slash commands queued when Ctrl+Q defers them', () => {
+      const { handleSlashCommand, submitQuery, addMessage } =
+        renderRespondingInput([
+          {
+            name: 'settings',
+            description: 'Open settings',
+            kind: 'built-in',
+            canRunDuringStreaming: true,
+          },
+        ]);
+
+      capturedUIActions.handleFinalSubmit('/settings', {
+        deferUntilIdle: true,
+        submittedPrompt: '/settings',
+      });
+
+      expect(addMessage).toHaveBeenCalledWith('/settings', true, '/settings');
+      expect(handleSlashCommand).not.toHaveBeenCalled();
+      expect(submitQuery).not.toHaveBeenCalled();
+    });
+
+    it('keeps turn-dependent slash commands queued while responding', () => {
+      const { handleSlashCommand, submitQuery, addMessage } =
+        renderRespondingInput([
+          {
+            name: 'model',
+            description: 'Change model',
+            kind: 'built-in',
+          },
+        ]);
+
+      capturedUIActions.handleFinalSubmit('/model', {
+        submittedPrompt: '/model',
+      });
+
+      expect(addMessage).toHaveBeenCalledWith('/model', false, '/model');
+      expect(handleSlashCommand).not.toHaveBeenCalled();
+      expect(submitQuery).not.toHaveBeenCalled();
     });
 
     it('submits slash commands immediately instead of queueing while idle', () => {

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -173,6 +173,7 @@ import {
   detectWorkflowKeyword,
   buildWorkflowSteeringNotice,
 } from './utils/workflow-keyword.js';
+import { parseSlashCommand } from '../utils/commands.js';
 import { type LoadedSettings, SettingScope } from '../config/settings.js';
 import { type InitializationResult } from '../core/initializer.js';
 import { ExtensionRefreshState } from '../config/extension-refresh-state.js';
@@ -2345,6 +2346,15 @@ export const AppContainer = (props: AppContainerProps) => {
       }
       if (
         streamingState === StreamingState.Responding &&
+        isSlashCommand(userPromptText) &&
+        parseSlashCommand(userPromptText, slashCommands).commandToExecute
+          ?.canRunDuringStreaming
+      ) {
+        void handleSlashCommand(userPromptText);
+        return;
+      }
+      if (
+        streamingState === StreamingState.Responding &&
         isBtwCommand(submittedValue)
       ) {
         void submitUserQuery({
@@ -2489,6 +2499,7 @@ export const AppContainer = (props: AppContainerProps) => {
       isProcessing,
       submitUserQuery,
       handleSlashCommand,
+      slashCommands,
       config,
       geminiClient,
       historyManager,

--- a/packages/cli/src/ui/commands/aboutCommand.test.ts
+++ b/packages/cli/src/ui/commands/aboutCommand.test.ts
@@ -75,6 +75,8 @@ describe('aboutCommand', () => {
     expect(aboutCommand.name).toBe('status');
     expect(aboutCommand.altNames).toEqual(['about']);
     expect(aboutCommand.description).toBe('show version info');
+    expect(aboutCommand.canRunDuringStreaming).toBe(true);
+    expect(aboutCommand.subCommands?.[0]?.canRunDuringStreaming).toBe(true);
   });
 
   it('should call addItem with all version info', async () => {

--- a/packages/cli/src/ui/commands/aboutCommand.ts
+++ b/packages/cli/src/ui/commands/aboutCommand.ts
@@ -22,6 +22,7 @@ export const aboutCommand: SlashCommand = {
   },
   kind: CommandKind.BUILT_IN,
   supportedModes: ['interactive', 'non_interactive', 'acp'] as const,
+  canRunDuringStreaming: true,
   action: async (context) => {
     const systemInfo = await getExtendedSystemInfo(context);
 
@@ -63,6 +64,7 @@ export const aboutCommand: SlashCommand = {
       },
       kind: CommandKind.BUILT_IN,
       supportedModes: ['interactive', 'non_interactive', 'acp'] as const,
+      canRunDuringStreaming: true,
       action: async (context) => {
         const info = await collectSessionPathInfo(context);
         const content = formatSessionPathInfo(info);

--- a/packages/cli/src/ui/commands/helpCommand.test.ts
+++ b/packages/cli/src/ui/commands/helpCommand.test.ts
@@ -55,5 +55,6 @@ describe('helpCommand', () => {
     expect(helpCommand.kind).toBe(CommandKind.BUILT_IN);
     expect(helpCommand.argumentHint).toBeUndefined();
     expect(helpCommand.description).toBe('for help on Qwen Code');
+    expect(helpCommand.canRunDuringStreaming).toBe(true);
   });
 });

--- a/packages/cli/src/ui/commands/helpCommand.ts
+++ b/packages/cli/src/ui/commands/helpCommand.ts
@@ -13,6 +13,7 @@ export const helpCommand: SlashCommand = {
   altNames: ['?'],
   kind: CommandKind.BUILT_IN,
   supportedModes: ['interactive'] as const,
+  canRunDuringStreaming: true,
   get description() {
     return t('for help on Qwen Code');
   },

--- a/packages/cli/src/ui/commands/settingsCommand.test.ts
+++ b/packages/cli/src/ui/commands/settingsCommand.test.ts
@@ -32,5 +32,6 @@ describe('settingsCommand', () => {
     expect(settingsCommand.description).toBe(
       'View and edit Qwen Code settings',
     );
+    expect(settingsCommand.canRunDuringStreaming).toBe(true);
   });
 });

--- a/packages/cli/src/ui/commands/settingsCommand.ts
+++ b/packages/cli/src/ui/commands/settingsCommand.ts
@@ -15,6 +15,7 @@ export const settingsCommand: SlashCommand = {
   },
   kind: CommandKind.BUILT_IN,
   supportedModes: ['interactive'] as const,
+  canRunDuringStreaming: true,
   action: (_context, _args): OpenDialogActionReturn => ({
     type: 'dialog',
     dialog: 'settings',

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -366,6 +366,13 @@ export interface SlashCommand {
    */
   supportedModes?: ExecutionMode[];
 
+  /**
+   * Whether the interactive UI may execute this command immediately while a
+   * model response is streaming. Commands opt in only when they do not submit
+   * a model turn or mutate conversation state owned by the active turn.
+   */
+  canRunDuringStreaming?: boolean;
+
   // ── Phase 1: visibility ────────────────────────────────────────────────
   /**
    * Whether users can invoke this command via a slash command.


### PR DESCRIPTION
## What this PR does

This PR lets a small, explicitly opted-in set of local slash commands run immediately while the main model response is streaming. The initial set is `/status` (including `/about` and `/status paths`), `/settings`, and `/help` (including `/?`). All commands remain serialized by default, Ctrl+Q still forces deferred execution, and the existing specialized behavior of `/btw` and `/quit` is unchanged.

## Why it's needed

Previously, nearly every slash command entered during a response was placed in the same queue as conversation turns, even when it only displayed local information or opened a UI dialog. Users therefore had to wait for a long-running response to finish before checking status, viewing paths, changing settings, or opening help. The explicit capability keeps the allowlist conservative and prevents turn-dependent, state-mutating, tool-running, and model-submitting commands from accidentally running concurrently.

## Reviewer Test Plan

### How to verify

1. Start a response that streams for several seconds, then submit `/status`, `/status paths`, `/about`, `/settings`, `/help`, and `/?` while it is still running. Each result or dialog should appear before the response finishes, and the original response should continue streaming after the command runs or the dialog closes.
2. During another streaming response, submit a normal follow-up prompt and `/compress`. Both should show as queued and should not start a new model request until the active response has ended.
3. While streaming, submit one of the opted-in commands with Ctrl+Q. It should follow the existing deferred path and run only after the active response becomes idle.

### Evidence (Before & After)

Before: interactive testing against the released CLI showed `/status`, `/settings`, and `/help` as queued messages whose output appeared only after the active stream ended.

After: interactive testing against the freshly bundled CLI used a deterministic 12-second SSE response. Every opted-in command displayed its result or dialog before `stream-end`, no opted-in command showed a queued marker, and response ticks continued afterward. A normal follow-up remained queued. `/compress` was queued at 11:14:24.553 UTC, the active stream ended at 11:14:34.788, and the compression request began at 11:14:34.832.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Local bundled CLI with sandbox disabled and a deterministic OpenAI-compatible SSE test server. Validation also included the focused CLI unit tests, ESLint, Prettier, the full build, and TypeScript type checking.

## Risk & Scope

- Main risk or tradeoff: A command that mutates active-turn state could create races if it is incorrectly opted in. This change defaults every command to serialized execution and marks only local information/dialog commands whose existing output flows through React/Ink state.
- Not validated / out of scope: Windows and Linux interactive rendering; expanding the concurrent set to conversation, tool, context, statistics, copy, diff, recap, compression, model-selection, or goal commands.
- Breaking changes / migration notes: None.

## Linked Issues

Closes #8101

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 允许一小组明确声明可并发的本地斜杠命令在主模型响应流式输出期间立即运行。首批命令包括 `/status`（含 `/about` 和 `/status paths`）、`/settings`、`/help`（含 `/?`）。所有命令默认仍保持串行，Ctrl+Q 仍会强制延迟执行，`/btw` 和 `/quit` 的现有专用行为保持不变。

## 为什么需要这个改动

此前，在响应期间输入的几乎所有斜杠命令都会和对话轮次进入同一个队列，即使该命令只是显示本地信息或打开 UI 对话框。用户因此必须等待长响应结束后，才能查看状态、路径、修改设置或打开帮助。显式能力标记让白名单保持保守，并避免依赖当前轮次、修改状态、运行工具或提交模型请求的命令意外并发执行。

## Reviewer 测试计划

### 如何验证

1. 启动一个持续数秒的流式响应，在响应仍在运行时分别提交 `/status`、`/status paths`、`/about`、`/settings`、`/help` 和 `/?`。每个结果或对话框都应在响应完成前出现，并且命令运行后或关闭对话框后，原响应应继续流式输出。
2. 在另一个流式响应期间提交普通后续提示词和 `/compress`。两者都应显示为排队状态，并且在当前响应结束前不应开始新的模型请求。
3. 在流式响应期间通过 Ctrl+Q 提交一个已声明可并发的命令。它应继续走现有延迟路径，只在当前响应进入 idle 后运行。

### 证据（改动前后）

改动前：针对已发布 CLI 的交互测试显示，`/status`、`/settings` 和 `/help` 都会成为排队消息，其输出只在当前流结束后出现。

改动后：针对最新 bundle 的交互测试使用了一个确定性的 12 秒 SSE 响应。每个白名单命令都在 `stream-end` 前显示结果或对话框，没有白名单命令出现排队标记，之后响应 tick 仍继续输出。普通后续提示词仍会排队。`/compress` 在 UTC 11:14:24.553 入队，当前流于 11:14:34.788 结束，压缩请求于 11:14:34.832 才开始。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

本地 bundle CLI，关闭 sandbox，并使用确定性的 OpenAI 兼容 SSE 测试服务器。验证还包括 CLI 定向单元测试、ESLint、Prettier、完整构建和 TypeScript 类型检查。

## 风险与范围

- 主要风险或权衡：如果错误地将修改当前轮次状态的命令加入白名单，可能产生竞态。本改动让所有命令默认串行，只标记通过 React/Ink 状态输出的本地信息和对话框命令。
- 未验证或不在范围内：Windows 和 Linux 的交互渲染；将并发范围扩展到对话、工具、上下文、统计、复制、差异、回顾、压缩、模型选择或目标命令。
- 破坏性改动或迁移说明：无。

## 关联 Issue

Closes #8101

</details>
