### PR TITLE
refactor(core): extract workflow run ownership

### DIFF
--- a/packages/core/src/agents/runtime/workflow-runner.test.ts
+++ b/packages/core/src/agents/runtime/workflow-runner.test.ts
@@ -1,0 +1,231 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Config } from '../../config/config.js';
+import { WorkflowRunRegistry } from '../workflow-run-registry.js';
+import { WorkflowRunner } from './workflow-runner.js';
+
+const { logWorkflowRunMock, writeWorkflowSnapshotMock } = vi.hoisted(() => ({
+  logWorkflowRunMock: vi.fn(),
+  writeWorkflowSnapshotMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../telemetry/loggers.js', () => ({
+  logWorkflowRun: logWorkflowRunMock,
+}));
+
+vi.mock('../workflow-snapshot.js', () => ({
+  writeWorkflowSnapshot: writeWorkflowSnapshotMock,
+}));
+
+function configWithRegistry(): {
+  config: Config;
+  registry: WorkflowRunRegistry;
+} {
+  const registry = new WorkflowRunRegistry();
+  const config = {
+    getWorkflowRunRegistry: () => registry,
+  } as unknown as Config;
+  return { config, registry };
+}
+
+function observeSettlement(registry: WorkflowRunRegistry): {
+  abortCount: () => number;
+  terminalStatuses: string[];
+} {
+  let aborts = 0;
+  const terminalStatuses: string[] = [];
+  registry.setRegisterCallback((entry) => {
+    entry.abortController.signal.addEventListener(
+      'abort',
+      () => {
+        aborts += 1;
+      },
+      { once: true },
+    );
+  });
+  registry.setStatusChangeCallback((entry) => {
+    if (entry && entry.status !== 'running') {
+      terminalStatuses.push(entry.status);
+    }
+  });
+  return { abortCount: () => aborts, terminalStatuses };
+}
+
+describe('WorkflowRunner', () => {
+  beforeEach(() => {
+    logWorkflowRunMock.mockClear();
+    writeWorkflowSnapshotMock.mockClear();
+  });
+
+  it('keeps one registry-owned handle through exactly-once completion', async () => {
+    const { config, registry } = configWithRegistry();
+    const observed = observeSettlement(registry);
+    let resolveDispatch: ((value: string) => void) | undefined;
+    const caller = new AbortController();
+    const handle = await WorkflowRunner.start({
+      config,
+      signal: caller.signal,
+      script: 'return await agent("work")',
+      args: undefined,
+      dispatch: () =>
+        new Promise<string>((resolve) => {
+          resolveDispatch = resolve;
+        }),
+    });
+
+    expect(registry.getHandle(handle.runId)).toBe(handle);
+    expect(registry.get(handle.runId)?.status).toBe('running');
+
+    await vi.waitFor(() => expect(resolveDispatch).toBeDefined());
+    resolveDispatch?.('done');
+
+    const first = await handle.completion;
+    const second = await handle.completion;
+    expect(first).toBe(second);
+    expect(first.ok).toBe(true);
+    expect(registry.get(handle.runId)?.status).toBe('completed');
+    expect(registry.getHandle(handle.runId)).toBeUndefined();
+    expect(writeWorkflowSnapshotMock).toHaveBeenCalledOnce();
+    expect(logWorkflowRunMock).toHaveBeenCalledOnce();
+    expect(observed.terminalStatuses).toEqual(['completed']);
+    expect(observed.abortCount()).toBe(1);
+
+    caller.abort();
+    registry.cancel(handle.runId, Date.now());
+    expect(registry.get(handle.runId)?.status).toBe('completed');
+    expect(writeWorkflowSnapshotMock).toHaveBeenCalledOnce();
+    expect(logWorkflowRunMock).toHaveBeenCalledOnce();
+    expect(observed.terminalStatuses).toEqual(['completed']);
+    expect(observed.abortCount()).toBe(1);
+  });
+
+  it('settles failure and caller cancellation through the same owner', async () => {
+    const failed = configWithRegistry();
+    const failedObserved = observeSettlement(failed.registry);
+    const failedHandle = await WorkflowRunner.start({
+      config: failed.config,
+      signal: new AbortController().signal,
+      script: 'throw new Error("boom")',
+      args: undefined,
+      dispatch: async () => 'unused',
+    });
+    const failedResult = await failedHandle.completion;
+    expect(failedResult.ok).toBe(false);
+    expect(failed.registry.get(failedHandle.runId)?.status).toBe('failed');
+    expect(failedObserved.terminalStatuses).toEqual(['failed']);
+    expect(failedObserved.abortCount()).toBe(1);
+
+    const cancelled = configWithRegistry();
+    const cancelledObserved = observeSettlement(cancelled.registry);
+    const caller = new AbortController();
+    let rejectDispatch: ((error: Error) => void) | undefined;
+    const cancelledHandle = await WorkflowRunner.start({
+      config: cancelled.config,
+      signal: caller.signal,
+      script: 'return await agent("work")',
+      args: undefined,
+      dispatch: () =>
+        new Promise<string>((_resolve, reject) => {
+          rejectDispatch = reject;
+        }),
+    });
+    await vi.waitFor(() => expect(rejectDispatch).toBeDefined());
+    caller.abort();
+    rejectDispatch?.(new Error('aborted'));
+    const cancelledResult = await cancelledHandle.completion;
+    expect(cancelledResult.ok).toBe(false);
+    expect(cancelled.registry.get(cancelledHandle.runId)?.status).toBe(
+      'cancelled',
+    );
+    expect(cancelledObserved.terminalStatuses).toEqual(['cancelled']);
+    expect(cancelledObserved.abortCount()).toBe(1);
+
+    expect(writeWorkflowSnapshotMock).toHaveBeenCalledTimes(2);
+    expect(logWorkflowRunMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('routes registry cancellation through each live handle', async () => {
+    const cancelCases: Array<{
+      cancel: (registry: WorkflowRunRegistry, runId: string) => void;
+    }> = [
+      {
+        cancel: (registry, runId) => registry.cancel(runId, Date.now()),
+      },
+      {
+        cancel: (registry) => registry.abortAll(),
+      },
+    ];
+
+    for (const { cancel } of cancelCases) {
+      const { config, registry } = configWithRegistry();
+      const observed = observeSettlement(registry);
+      let rejectDispatch: ((error: Error) => void) | undefined;
+      const handle = await WorkflowRunner.start({
+        config,
+        signal: new AbortController().signal,
+        script: 'return await agent("work")',
+        args: undefined,
+        dispatch: () =>
+          new Promise<string>((_resolve, reject) => {
+            rejectDispatch = reject;
+          }),
+      });
+      const abortSpy = vi.spyOn(handle, 'abort');
+      await vi.waitFor(() => expect(rejectDispatch).toBeDefined());
+
+      cancel(registry, handle.runId);
+
+      expect(abortSpy).toHaveBeenCalledOnce();
+      expect(observed.abortCount()).toBe(1);
+      expect(registry.get(handle.runId)?.status).toBe('cancelled');
+      expect(registry.getHandle(handle.runId)).toBe(handle);
+
+      rejectDispatch?.(new Error('aborted'));
+      const result = await handle.completion;
+      expect(result.ok).toBe(false);
+      expect(registry.get(handle.runId)?.status).toBe('cancelled');
+      expect(registry.getHandle(handle.runId)).toBeUndefined();
+    }
+
+    expect(writeWorkflowSnapshotMock).toHaveBeenCalledTimes(2);
+    expect(logWorkflowRunMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('classifies the internal wall-clock timeout as failed', async () => {
+    vi.useFakeTimers();
+    const originalTimeout = process.env['QWEN_CODE_MAX_WORKFLOW_SECONDS'];
+    process.env['QWEN_CODE_MAX_WORKFLOW_SECONDS'] = '1';
+    try {
+      const timedOut = configWithRegistry();
+      const observed = observeSettlement(timedOut.registry);
+      const handle = await WorkflowRunner.start({
+        config: timedOut.config,
+        signal: new AbortController().signal,
+        script: 'await new Promise(() => {})',
+        args: undefined,
+        dispatch: async () => 'unused',
+      });
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      const result = await handle.completion;
+      expect(result.ok).toBe(false);
+      expect(timedOut.registry.get(handle.runId)?.status).toBe('failed');
+      expect(observed.terminalStatuses).toEqual(['failed']);
+      expect(observed.abortCount()).toBe(1);
+      expect(writeWorkflowSnapshotMock).toHaveBeenCalledOnce();
+      expect(logWorkflowRunMock).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+      if (originalTimeout === undefined) {
+        delete process.env['QWEN_CODE_MAX_WORKFLOW_SECONDS'];
+      } else {
+        process.env['QWEN_CODE_MAX_WORKFLOW_SECONDS'] = originalTimeout;
+      }
+    }
+  });
+});

--- a/packages/core/src/agents/runtime/workflow-runner.ts
+++ b/packages/core/src/agents/runtime/workflow-runner.ts
@@ -19,7 +19,6 @@ import {
   WorkflowExecutionError,
   WorkflowOrchestrator,
   type WorkflowAgentDispatch,
-  type WorkflowMeta,
   type WorkflowOrchestratorEmitter,
   type WorkflowRunOutcome,
 } from './workflow-orchestrator.js';
@@ -38,20 +37,9 @@ export interface WorkflowRunnerOptions {
   onUpdate?: (entry: WorkflowTask) => void;
 }
 
-export interface WorkflowRunSuccess {
-  ok: true;
-  outcome: WorkflowRunOutcome;
-}
-
-export interface WorkflowRunFailure {
-  ok: false;
-  message: string;
-  phases?: string[];
-  logs?: string[];
-  meta?: WorkflowMeta;
-}
-
-export type WorkflowRunSettlement = WorkflowRunSuccess | WorkflowRunFailure;
+export type WorkflowRunSettlement =
+  | { ok: true; outcome: WorkflowRunOutcome }
+  | { ok: false; message: string; details?: WorkflowExecutionError };
 
 export class WorkflowRunHandle {
   readonly completion: Promise<WorkflowRunSettlement>;
@@ -75,46 +63,34 @@ export class WorkflowRunner {
   static async start(
     options: WorkflowRunnerOptions,
   ): Promise<WorkflowRunHandle> {
-    const controller = createChildAbortController(options.signal);
+    const config = options.config;
     const budget = WorkflowBudgetImpl.fromEnv();
-    const dispatch =
-      options.dispatch ??
-      createProductionDispatch(
-        options.config,
-        controller.signal,
-        (outputTokens) => budget.recordSpent(outputTokens),
-      );
-    const orchestrator = new WorkflowOrchestrator(dispatch);
-
-    let resolvedScript = options.script ?? '';
-    let resolvedScriptPath = options.scriptPath;
-    try {
-      if (options.scriptPath && options.script === undefined) {
-        const loaded = await resolveSavedWorkflowScript(
-          { scriptPath: options.scriptPath },
-          options.config,
-        );
-        resolvedScript = loaded.script;
-        resolvedScriptPath = loaded.scriptPath;
-      }
-    } catch (error) {
-      controller.abort();
-      throw error;
-    }
-
+    const loaded =
+      options.scriptPath && options.script === undefined
+        ? await resolveSavedWorkflowScript(
+            { scriptPath: options.scriptPath },
+            config,
+          )
+        : undefined;
+    const script = loaded?.script ?? options.script ?? '';
+    const scriptPath = loaded?.scriptPath ?? options.scriptPath;
     const runId =
       options.resumeFromRunId ?? `wf_${randomBytes(8).toString('hex')}`;
-    let journal: WorkflowJournal | undefined;
-    let resumeReplay: JournalReplay | undefined;
-    const storage = options.config.storage;
-    if (storage) {
-      journal = new WorkflowJournal(storage.getWorkflowRunJournalPath(runId));
-      if (options.resumeFromRunId) {
-        resumeReplay = await journal.load();
-      }
-    }
-
-    const registry = options.config.getWorkflowRunRegistry?.();
+    const storage = config.storage;
+    const journal = storage
+      ? new WorkflowJournal(storage.getWorkflowRunJournalPath(runId))
+      : undefined;
+    const resumeReplay: JournalReplay | undefined = options.resumeFromRunId
+      ? await journal?.load()
+      : undefined;
+    const controller = createChildAbortController(options.signal);
+    const dispatch =
+      options.dispatch ??
+      createProductionDispatch(config, controller.signal, (outputTokens) =>
+        budget.recordSpent(outputTokens),
+      );
+    const orchestrator = new WorkflowOrchestrator(dispatch);
+    const registry = config.getWorkflowRunRegistry?.();
     const entry = registry?.register({
       runId,
       meta: null,
@@ -123,170 +99,101 @@ export class WorkflowRunner {
       outputFile: '',
       abortController: controller,
       tokenBudgetTotal: budget.total,
-      script: resolvedScript,
-      scriptPath: resolvedScriptPath,
+      script,
+      scriptPath,
     });
-    const emitter = createEmitter(runId, registry, entry, options.onUpdate);
+    const emitUpdate = (): void => {
+      if (!entry || !options.onUpdate) return;
+      try {
+        options.onUpdate(entry);
+      } catch {
+        // UI refresh failures must not affect workflow execution.
+      }
+    };
+    const emitter: WorkflowOrchestratorEmitter = {
+      phaseStarted: (title) => {
+        registry?.onPhaseStarted(runId, title);
+        emitUpdate();
+      },
+      agentDispatched: () => {
+        registry?.onAgentDispatched(runId);
+        emitUpdate();
+      },
+      agentCompleted: () => registry?.onAgentCompleted(runId),
+      logAppended: () => {},
+      budgetUpdated: (spent, total) => {
+        registry?.onBudgetUpdated(runId, spent, total);
+        emitUpdate();
+      },
+    };
 
     const handle: WorkflowRunHandle = new WorkflowRunHandle(
       runId,
       budget,
       registry,
       controller,
-      (): Promise<WorkflowRunSettlement> =>
-        settleRun({
-          options,
-          handle,
-          orchestrator,
-          controller,
-          registry,
-          entry,
-          emitter,
-          budget,
-          runId,
-          resolvedScript,
-          journal,
-          resumeReplay,
-        }),
+      async (): Promise<WorkflowRunSettlement> => {
+        try {
+          const outcome = await orchestrator.run({
+            script,
+            args: options.args,
+            abortOnTimeout: controller,
+            runId,
+            emitter,
+            budget,
+            resolveSavedWorkflow: (ref) =>
+              resolveSavedWorkflowScript(ref, config),
+            journal,
+            resumeReplay,
+          });
+          if (entry) {
+            entry.meta = outcome.meta;
+            if (outcome.meta?.name && entry.description === runId) {
+              entry.description = outcome.meta.name;
+            }
+          }
+          registry?.setRecentLogs(runId, outcome.logs);
+          registry?.complete(runId, outcome.result, Date.now());
+          return { ok: true, outcome };
+        } catch (error) {
+          const details =
+            error instanceof WorkflowExecutionError ? error : undefined;
+          const message = extractErrorMessage(error);
+          if (entry && details?.meta && !entry.meta) entry.meta = details.meta;
+          if (details?.logs) registry?.setRecentLogs(runId, details.logs);
+          if (options.signal.aborted) {
+            registry?.cancel(runId, Date.now());
+          } else {
+            registry?.fail(runId, message, Date.now());
+          }
+          return { ok: false, message, details };
+        } finally {
+          controller.abort();
+          if (entry && entry.status !== 'running') {
+            await writeWorkflowSnapshot(config, entry);
+            try {
+              logWorkflowRun(
+                config,
+                new WorkflowRunEvent({
+                  status: entry.status,
+                  agents_dispatched: entry.agentsDispatched,
+                  agents_completed: entry.agentsCompleted,
+                  phase_count: entry.phases.length,
+                  tokens_spent: entry.tokensSpent,
+                  duration_ms:
+                    (entry.endTime ?? entry.startTime) - entry.startTime,
+                }),
+              );
+            } catch {
+              // Telemetry must not affect workflow execution.
+            }
+          }
+          registry?.releaseHandle(runId, handle);
+        }
+      },
     );
     registry?.attachHandle(handle);
     return handle;
-  }
-}
-
-interface SettleRunOptions {
-  options: WorkflowRunnerOptions;
-  handle: WorkflowRunHandle;
-  orchestrator: WorkflowOrchestrator;
-  controller: AbortController;
-  registry: WorkflowRunRegistry | undefined;
-  entry: WorkflowTask | undefined;
-  emitter: WorkflowOrchestratorEmitter;
-  budget: WorkflowBudgetImpl;
-  runId: string;
-  resolvedScript: string;
-  journal: WorkflowJournal | undefined;
-  resumeReplay: JournalReplay | undefined;
-}
-
-async function settleRun(
-  context: SettleRunOptions,
-): Promise<WorkflowRunSettlement> {
-  const {
-    options,
-    handle,
-    orchestrator,
-    controller,
-    registry,
-    entry,
-    emitter,
-    budget,
-    runId,
-    resolvedScript,
-    journal,
-    resumeReplay,
-  } = context;
-
-  try {
-    const outcome = await orchestrator.run({
-      script: resolvedScript,
-      args: options.args,
-      abortOnTimeout: controller,
-      runId,
-      emitter,
-      budget,
-      resolveSavedWorkflow: (ref) =>
-        resolveSavedWorkflowScript(ref, options.config),
-      journal,
-      resumeReplay,
-    });
-
-    if (entry) {
-      entry.meta = outcome.meta;
-      if (outcome.meta?.name && entry.description === runId) {
-        entry.description = outcome.meta.name;
-      }
-    }
-    registry?.setRecentLogs(runId, outcome.logs);
-    registry?.complete(runId, outcome.result, Date.now());
-    return { ok: true, outcome };
-  } catch (error) {
-    const message = extractErrorMessage(error);
-    const phases =
-      error instanceof WorkflowExecutionError ? error.phases : undefined;
-    const logs =
-      error instanceof WorkflowExecutionError ? error.logs : undefined;
-    const meta =
-      error instanceof WorkflowExecutionError
-        ? (error.meta ?? undefined)
-        : undefined;
-    if (entry && meta && !entry.meta) entry.meta = meta;
-    if (logs) registry?.setRecentLogs(runId, logs);
-    if (options.signal.aborted) {
-      registry?.cancel(runId, Date.now());
-    } else {
-      registry?.fail(runId, message, Date.now());
-    }
-    return { ok: false, message, phases, logs, meta };
-  } finally {
-    controller.abort();
-    if (entry && entry.status !== 'running') {
-      await writeWorkflowSnapshot(options.config, entry);
-      emitTelemetry(options.config, entry);
-    }
-    registry?.releaseHandle(runId, handle);
-  }
-}
-
-function createEmitter(
-  runId: string,
-  registry: WorkflowRunRegistry | undefined,
-  entry: WorkflowTask | undefined,
-  onUpdate: ((entry: WorkflowTask) => void) | undefined,
-): WorkflowOrchestratorEmitter {
-  const emitUpdate = (): void => {
-    if (!entry || !onUpdate) return;
-    try {
-      onUpdate(entry);
-    } catch {
-      // UI refresh failures must not affect workflow execution.
-    }
-  };
-  return {
-    phaseStarted: (title) => {
-      registry?.onPhaseStarted(runId, title);
-      emitUpdate();
-    },
-    agentDispatched: () => {
-      registry?.onAgentDispatched(runId);
-      emitUpdate();
-    },
-    agentCompleted: () => {
-      registry?.onAgentCompleted(runId);
-    },
-    logAppended: () => {},
-    budgetUpdated: (spent, total) => {
-      registry?.onBudgetUpdated(runId, spent, total);
-      emitUpdate();
-    },
-  };
-}
-
-function emitTelemetry(config: Config, entry: WorkflowTask): void {
-  try {
-    logWorkflowRun(
-      config,
-      new WorkflowRunEvent({
-        status: entry.status,
-        agents_dispatched: entry.agentsDispatched,
-        agents_completed: entry.agentsCompleted,
-        phase_count: entry.phases.length,
-        tokens_spent: entry.tokensSpent,
-        duration_ms: (entry.endTime ?? entry.startTime) - entry.startTime,
-      }),
-    );
-  } catch {
-    // Telemetry must not affect workflow execution.
   }
 }
 

--- a/packages/core/src/agents/runtime/workflow-runner.ts
+++ b/packages/core/src/agents/runtime/workflow-runner.ts
@@ -1,0 +1,300 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { randomBytes } from 'node:crypto';
+import type { Config } from '../../config/config.js';
+import { logWorkflowRun } from '../../telemetry/loggers.js';
+import { WorkflowRunEvent } from '../../telemetry/types.js';
+import { createChildAbortController } from '../../utils/abortController.js';
+import {
+  type WorkflowRunRegistry,
+  type WorkflowTask,
+} from '../workflow-run-registry.js';
+import { writeWorkflowSnapshot } from '../workflow-snapshot.js';
+import {
+  createProductionDispatch,
+  WorkflowExecutionError,
+  WorkflowOrchestrator,
+  type WorkflowAgentDispatch,
+  type WorkflowMeta,
+  type WorkflowOrchestratorEmitter,
+  type WorkflowRunOutcome,
+} from './workflow-orchestrator.js';
+import { WorkflowBudgetImpl } from './workflow-budget.js';
+import { WorkflowJournal, type JournalReplay } from './workflow-journal.js';
+import { resolveSavedWorkflowScript } from './workflow-saved.js';
+
+export interface WorkflowRunnerOptions {
+  config: Config;
+  signal: AbortSignal;
+  script?: string;
+  scriptPath?: string;
+  args: unknown;
+  resumeFromRunId?: string;
+  dispatch?: WorkflowAgentDispatch;
+  onUpdate?: (entry: WorkflowTask) => void;
+}
+
+export interface WorkflowRunSuccess {
+  ok: true;
+  outcome: WorkflowRunOutcome;
+}
+
+export interface WorkflowRunFailure {
+  ok: false;
+  message: string;
+  phases?: string[];
+  logs?: string[];
+  meta?: WorkflowMeta;
+}
+
+export type WorkflowRunSettlement = WorkflowRunSuccess | WorkflowRunFailure;
+
+export class WorkflowRunHandle {
+  readonly completion: Promise<WorkflowRunSettlement>;
+
+  constructor(
+    readonly runId: string,
+    readonly budget: WorkflowBudgetImpl,
+    readonly registry: WorkflowRunRegistry | undefined,
+    private readonly controller: AbortController,
+    start: () => Promise<WorkflowRunSettlement>,
+  ) {
+    this.completion = Promise.resolve().then(start);
+  }
+
+  abort(): void {
+    this.controller.abort();
+  }
+}
+
+export class WorkflowRunner {
+  static async start(
+    options: WorkflowRunnerOptions,
+  ): Promise<WorkflowRunHandle> {
+    const controller = createChildAbortController(options.signal);
+    const budget = WorkflowBudgetImpl.fromEnv();
+    const dispatch =
+      options.dispatch ??
+      createProductionDispatch(
+        options.config,
+        controller.signal,
+        (outputTokens) => budget.recordSpent(outputTokens),
+      );
+    const orchestrator = new WorkflowOrchestrator(dispatch);
+
+    let resolvedScript = options.script ?? '';
+    let resolvedScriptPath = options.scriptPath;
+    try {
+      if (options.scriptPath && options.script === undefined) {
+        const loaded = await resolveSavedWorkflowScript(
+          { scriptPath: options.scriptPath },
+          options.config,
+        );
+        resolvedScript = loaded.script;
+        resolvedScriptPath = loaded.scriptPath;
+      }
+    } catch (error) {
+      controller.abort();
+      throw error;
+    }
+
+    const runId =
+      options.resumeFromRunId ?? `wf_${randomBytes(8).toString('hex')}`;
+    let journal: WorkflowJournal | undefined;
+    let resumeReplay: JournalReplay | undefined;
+    const storage = options.config.storage;
+    if (storage) {
+      journal = new WorkflowJournal(storage.getWorkflowRunJournalPath(runId));
+      if (options.resumeFromRunId) {
+        resumeReplay = await journal.load();
+      }
+    }
+
+    const registry = options.config.getWorkflowRunRegistry?.();
+    const entry = registry?.register({
+      runId,
+      meta: null,
+      status: 'running',
+      startTime: Date.now(),
+      outputFile: '',
+      abortController: controller,
+      tokenBudgetTotal: budget.total,
+      script: resolvedScript,
+      scriptPath: resolvedScriptPath,
+    });
+    const emitter = createEmitter(runId, registry, entry, options.onUpdate);
+
+    const handle: WorkflowRunHandle = new WorkflowRunHandle(
+      runId,
+      budget,
+      registry,
+      controller,
+      (): Promise<WorkflowRunSettlement> =>
+        settleRun({
+          options,
+          handle,
+          orchestrator,
+          controller,
+          registry,
+          entry,
+          emitter,
+          budget,
+          runId,
+          resolvedScript,
+          journal,
+          resumeReplay,
+        }),
+    );
+    registry?.attachHandle(handle);
+    return handle;
+  }
+}
+
+interface SettleRunOptions {
+  options: WorkflowRunnerOptions;
+  handle: WorkflowRunHandle;
+  orchestrator: WorkflowOrchestrator;
+  controller: AbortController;
+  registry: WorkflowRunRegistry | undefined;
+  entry: WorkflowTask | undefined;
+  emitter: WorkflowOrchestratorEmitter;
+  budget: WorkflowBudgetImpl;
+  runId: string;
+  resolvedScript: string;
+  journal: WorkflowJournal | undefined;
+  resumeReplay: JournalReplay | undefined;
+}
+
+async function settleRun(
+  context: SettleRunOptions,
+): Promise<WorkflowRunSettlement> {
+  const {
+    options,
+    handle,
+    orchestrator,
+    controller,
+    registry,
+    entry,
+    emitter,
+    budget,
+    runId,
+    resolvedScript,
+    journal,
+    resumeReplay,
+  } = context;
+
+  try {
+    const outcome = await orchestrator.run({
+      script: resolvedScript,
+      args: options.args,
+      abortOnTimeout: controller,
+      runId,
+      emitter,
+      budget,
+      resolveSavedWorkflow: (ref) =>
+        resolveSavedWorkflowScript(ref, options.config),
+      journal,
+      resumeReplay,
+    });
+
+    if (entry) {
+      entry.meta = outcome.meta;
+      if (outcome.meta?.name && entry.description === runId) {
+        entry.description = outcome.meta.name;
+      }
+    }
+    registry?.setRecentLogs(runId, outcome.logs);
+    registry?.complete(runId, outcome.result, Date.now());
+    return { ok: true, outcome };
+  } catch (error) {
+    const message = extractErrorMessage(error);
+    const phases =
+      error instanceof WorkflowExecutionError ? error.phases : undefined;
+    const logs =
+      error instanceof WorkflowExecutionError ? error.logs : undefined;
+    const meta =
+      error instanceof WorkflowExecutionError
+        ? (error.meta ?? undefined)
+        : undefined;
+    if (entry && meta && !entry.meta) entry.meta = meta;
+    if (logs) registry?.setRecentLogs(runId, logs);
+    if (options.signal.aborted) {
+      registry?.cancel(runId, Date.now());
+    } else {
+      registry?.fail(runId, message, Date.now());
+    }
+    return { ok: false, message, phases, logs, meta };
+  } finally {
+    controller.abort();
+    if (entry && entry.status !== 'running') {
+      await writeWorkflowSnapshot(options.config, entry);
+      emitTelemetry(options.config, entry);
+    }
+    registry?.releaseHandle(runId, handle);
+  }
+}
+
+function createEmitter(
+  runId: string,
+  registry: WorkflowRunRegistry | undefined,
+  entry: WorkflowTask | undefined,
+  onUpdate: ((entry: WorkflowTask) => void) | undefined,
+): WorkflowOrchestratorEmitter {
+  const emitUpdate = (): void => {
+    if (!entry || !onUpdate) return;
+    try {
+      onUpdate(entry);
+    } catch {
+      // UI refresh failures must not affect workflow execution.
+    }
+  };
+  return {
+    phaseStarted: (title) => {
+      registry?.onPhaseStarted(runId, title);
+      emitUpdate();
+    },
+    agentDispatched: () => {
+      registry?.onAgentDispatched(runId);
+      emitUpdate();
+    },
+    agentCompleted: () => {
+      registry?.onAgentCompleted(runId);
+    },
+    logAppended: () => {},
+    budgetUpdated: (spent, total) => {
+      registry?.onBudgetUpdated(runId, spent, total);
+      emitUpdate();
+    },
+  };
+}
+
+function emitTelemetry(config: Config, entry: WorkflowTask): void {
+  try {
+    logWorkflowRun(
+      config,
+      new WorkflowRunEvent({
+        status: entry.status,
+        agents_dispatched: entry.agentsDispatched,
+        agents_completed: entry.agentsCompleted,
+        phase_count: entry.phases.length,
+        tokens_spent: entry.tokensSpent,
+        duration_ms: (entry.endTime ?? entry.startTime) - entry.startTime,
+      }),
+    );
+  } catch {
+    // Telemetry must not affect workflow execution.
+  }
+}
+
+function extractErrorMessage(error: unknown): string {
+  if (error && typeof error === 'object' && 'message' in error) {
+    const message = (error as { message: unknown }).message;
+    if (typeof message === 'string') return message;
+    return String(message);
+  }
+  return String(error);
+}

--- a/packages/core/src/agents/runtime/workflow-runner.ts
+++ b/packages/core/src/agents/runtime/workflow-runner.ts
@@ -119,7 +119,13 @@ export class WorkflowRunner {
         registry?.onAgentDispatched(runId);
         emitUpdate();
       },
-      agentCompleted: () => registry?.onAgentCompleted(runId),
+      agentCompleted: () => {
+        // No emitUpdate: budgetUpdated fires right after and renders both
+        // updates together (avoids 2x TUI redraws per agent).
+        registry?.onAgentCompleted(runId);
+      },
+      // Deliberate no-op: logs are snapshotted at terminal via
+      // setRecentLogs; per-line emit would cause up to 10k TUI redraws.
       logAppended: () => {},
       budgetUpdated: (spent, total) => {
         registry?.onBudgetUpdated(runId, spent, total);
@@ -197,6 +203,11 @@ export class WorkflowRunner {
   }
 }
 
+/**
+ * Duck-typed extraction so vm-realm Errors (raised inside the sandbox)
+ * don't coerce to "Error: <msg>" via toString(). See workflow-orchestrator.ts
+ * for the matching helper on the orchestrator side.
+ */
 function extractErrorMessage(error: unknown): string {
   if (error && typeof error === 'object' && 'message' in error) {
     const message = (error as { message: unknown }).message;

--- a/packages/core/src/agents/workflow-run-registry.ts
+++ b/packages/core/src/agents/workflow-run-registry.ts
@@ -283,9 +283,9 @@ export class WorkflowRunRegistry {
   }
 
   attachHandle(handle: WorkflowRunHandle): void {
-    const entry = this.entries.get(handle.runId);
-    if (!entry || entry.status !== 'running') return;
-    this.handles.set(handle.runId, handle);
+    if (this.entries.get(handle.runId)?.status === 'running') {
+      this.handles.set(handle.runId, handle);
+    }
   }
 
   getHandle(runId: string): WorkflowRunHandle | undefined {
@@ -293,9 +293,7 @@ export class WorkflowRunRegistry {
   }
 
   releaseHandle(runId: string, handle: WorkflowRunHandle): void {
-    if (this.handles.get(runId) === handle) {
-      this.handles.delete(runId);
-    }
+    if (this.handles.get(runId) === handle) this.handles.delete(runId);
   }
 
   /**
@@ -425,12 +423,7 @@ export class WorkflowRunRegistry {
     entry.endTime = endTime;
     entry.notified = true;
     try {
-      const handle = this.handles.get(runId);
-      if (handle) {
-        handle.abort();
-      } else {
-        entry.abortController.abort();
-      }
+      (this.handles.get(runId) ?? entry.abortController).abort();
     } catch (error) {
       debugLogger.error('Failed to abort workflow controller:', error);
     }
@@ -504,12 +497,7 @@ export class WorkflowRunRegistry {
       entry.endTime = endTime;
       entry.notified = true;
       try {
-        const handle = this.handles.get(entry.runId);
-        if (handle) {
-          handle.abort();
-        } else {
-          entry.abortController.abort();
-        }
+        (this.handles.get(entry.runId) ?? entry.abortController).abort();
       } catch (error) {
         debugLogger.error(
           'abortAll: failed to abort workflow controller:',

--- a/packages/core/src/agents/workflow-run-registry.ts
+++ b/packages/core/src/agents/workflow-run-registry.ts
@@ -26,6 +26,7 @@
 
 import type { TaskBase, TaskRegistration } from './tasks/types.js';
 import type { WorkflowMeta } from './runtime/workflow-sandbox.js';
+import type { WorkflowRunHandle } from './runtime/workflow-runner.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 
 const debugLogger = createDebugLogger('WORKFLOW_REGISTRY');
@@ -180,6 +181,7 @@ export type WorkflowRunNotificationCallback = (entry: WorkflowTask) => void;
 
 export class WorkflowRunRegistry {
   private readonly entries = new Map<string, WorkflowTask>();
+  private readonly handles = new Map<string, WorkflowRunHandle>();
 
   private registerCallback: WorkflowRunRegisterCallback | undefined;
   private statusChangeCallback: WorkflowRunStatusChangeCallback | undefined;
@@ -278,6 +280,22 @@ export class WorkflowRunRegistry {
     }
     this.emitStatusChange(entry);
     return entry;
+  }
+
+  attachHandle(handle: WorkflowRunHandle): void {
+    const entry = this.entries.get(handle.runId);
+    if (!entry || entry.status !== 'running') return;
+    this.handles.set(handle.runId, handle);
+  }
+
+  getHandle(runId: string): WorkflowRunHandle | undefined {
+    return this.handles.get(runId);
+  }
+
+  releaseHandle(runId: string, handle: WorkflowRunHandle): void {
+    if (this.handles.get(runId) === handle) {
+      this.handles.delete(runId);
+    }
   }
 
   /**
@@ -407,7 +425,12 @@ export class WorkflowRunRegistry {
     entry.endTime = endTime;
     entry.notified = true;
     try {
-      entry.abortController.abort();
+      const handle = this.handles.get(runId);
+      if (handle) {
+        handle.abort();
+      } else {
+        entry.abortController.abort();
+      }
     } catch (error) {
       debugLogger.error('Failed to abort workflow controller:', error);
     }
@@ -457,6 +480,7 @@ export class WorkflowRunRegistry {
       | WorkflowTask
       | undefined;
     this.entries.clear();
+    this.handles.clear();
     if (sample) this.emitStatusChange(sample);
   }
 
@@ -480,7 +504,12 @@ export class WorkflowRunRegistry {
       entry.endTime = endTime;
       entry.notified = true;
       try {
-        entry.abortController.abort();
+        const handle = this.handles.get(entry.runId);
+        if (handle) {
+          handle.abort();
+        } else {
+          entry.abortController.abort();
+        }
       } catch (error) {
         debugLogger.error(
           'abortAll: failed to abort workflow controller:',

--- a/packages/core/src/tools/workflow/workflow.ts
+++ b/packages/core/src/tools/workflow/workflow.ts
@@ -25,25 +25,9 @@ import { ToolNames, ToolDisplayNames } from '../tool-names.js';
 // error code rather than an ad-hoc bare `{ message }` object.
 import { ToolErrorType } from '../tool-error.js';
 import type { Config } from '../../config/config.js';
-import {
-  WorkflowOrchestrator,
-  WorkflowExecutionError,
-  createProductionDispatch,
-  type WorkflowAgentDispatch,
-  type WorkflowOrchestratorEmitter,
-} from '../../agents/runtime/workflow-orchestrator.js';
-import {
-  WorkflowBudgetImpl,
-  MAX_TOKENS_PER_WORKFLOW_ENV,
-} from '../../agents/runtime/workflow-budget.js';
-import { resolveSavedWorkflowScript } from '../../agents/runtime/workflow-saved.js';
-import { WorkflowJournal } from '../../agents/runtime/workflow-journal.js';
-import type { JournalReplay } from '../../agents/runtime/workflow-journal.js';
-import { writeWorkflowSnapshot } from '../../agents/workflow-snapshot.js';
-import { logWorkflowRun } from '../../telemetry/loggers.js';
-import { WorkflowRunEvent } from '../../telemetry/types.js';
-import { createChildAbortController } from '../../utils/abortController.js';
-import { randomBytes } from 'node:crypto';
+import type { WorkflowAgentDispatch } from '../../agents/runtime/workflow-orchestrator.js';
+import { MAX_TOKENS_PER_WORKFLOW_ENV } from '../../agents/runtime/workflow-budget.js';
+import { WorkflowRunner } from '../../agents/runtime/workflow-runner.js';
 import * as path from 'node:path';
 import type { WorkflowTask } from '../../agents/workflow-run-registry.js';
 
@@ -194,156 +178,25 @@ class WorkflowToolInvocation extends BaseToolInvocation<
     updateOutput?: (output: ToolResultDisplay) => void,
     _shellExecutionConfig?: ShellExecutionConfig,
   ): Promise<ToolResult> {
-    // T40 (PR #4732 R4): child controller so dispatch sees caller aborts
-    // AND sandbox.ts wall-clock aborts (see setTimeout handler).
-    const dispatchController = createChildAbortController(signal);
-    // P5: per-run token tracker. Reads `QWEN_CODE_MAX_TOKENS_PER_WORKFLOW`
-    // from the environment via the impl's `fromEnv` factory. When the env
-    // is unset (`budget.total === null`), the orchestrator's gate is a
-    // no-op and `budgetUpdated` events still fire so the registry can
-    // surface cumulative usage even on uncapped runs.
-    const budget = WorkflowBudgetImpl.fromEnv();
-    const dispatch =
-      this.toolOptions.dispatch ??
-      createProductionDispatch(
-        this.config,
-        dispatchController.signal,
-        // P5 T3: production-dispatch onTokens callback. Test-injected
-        // dispatches (`toolOptions.dispatch`) handle their own
-        // recording — they don't surface stats the same way.
-        (outputTokens) => budget.recordSpent(outputTokens),
-      );
-    const orchestrator = new WorkflowOrchestrator(dispatch);
-
-    // P7b: resolve the script source. A `/<name>` saved-workflow slash
-    // command dispatches `{scriptPath}` instead of inline `script`; read the
-    // file here (fresh, so edits to a saved workflow take effect on the next
-    // run). The resolved absolute path is recorded on the registry entry as
-    // run provenance — it is never re-read mid-run. `validateToolParamValues`
-    // has already guaranteed exactly one of `script` / `scriptPath` is set.
-    let resolvedScript = this.params.script ?? '';
-    let resolvedScriptPath = this.params.scriptPath;
-    if (this.params.scriptPath && this.params.script === undefined) {
-      const loaded = await resolveSavedWorkflowScript(
-        { scriptPath: this.params.scriptPath },
-        this.config,
-      );
-      resolvedScript = loaded.script;
-      resolvedScriptPath = loaded.scriptPath;
-    }
-
-    // P4b: pre-generate the runId so the registry record exists before
-    // the first sandbox event fires. Without this, `agentDispatched` /
-    // `phaseStarted` callbacks would have no entry to update.
-    // P6: a resume reuses the prior run's id so it appends to the same
-    // journal; a fresh run gets a new id.
-    const runId =
-      this.params.resumeFromRunId ?? `wf_${randomBytes(8).toString('hex')}`;
-    // P6: per-run resume journal. Always created (any run is resumable);
-    // the replay maps are loaded only when resuming. Production storage
-    // path is `<projectDir>/workflows/<runId>/journal.jsonl`; the tool's
-    // test-injected dispatch path leaves `config.storage` undefined, so
-    // guard and skip journaling there.
-    let journal: WorkflowJournal | undefined;
-    let resumeReplay: JournalReplay | undefined;
-    const storage = this.config.storage;
-    if (storage) {
-      journal = new WorkflowJournal(storage.getWorkflowRunJournalPath(runId));
-      if (this.params.resumeFromRunId) {
-        resumeReplay = await journal.load();
-      }
-    }
-    const registry = this.config.getWorkflowRunRegistry?.();
-    const registryEntry = registry?.register({
-      runId,
-      meta: null, // populated after meta parses; safe default until then
-      status: 'running',
-      startTime: Date.now(),
-      outputFile: '', // P4b reserves the field but doesn't materialize
-      abortController: dispatchController,
-      // P5: seed the cap so the dialog can render the `M / N` form
-      // immediately, before the first `budgetUpdated` fires. Stays
-      // `null` when no env override.
-      tokenBudgetTotal: budget.total,
-      // P7b: carry the script source so a completed run can be snapshotted
-      // to disk and saved to `.qwen/workflows/<name>.js` from the dialog.
-      // `scriptPath` is set when the run was launched from a saved file (run
-      // provenance for the snapshot).
-      script: resolvedScript,
-      scriptPath: resolvedScriptPath,
+    const handle = await WorkflowRunner.start({
+      config: this.config,
+      signal,
+      script: this.params.script,
+      scriptPath: this.params.scriptPath,
+      args: this.params.args,
+      resumeFromRunId: this.params.resumeFromRunId,
+      dispatch: this.toolOptions.dispatch,
+      onUpdate: updateOutput
+        ? (entry) => safeEmitUpdate(updateOutput, entry)
+        : undefined,
     });
-    // The emitter forwards sandbox + dispatch events into the registry
-    // AND fires `updateOutput` so the tool's renderDisplay block (a
-    // phase-tree-shaped JSON) refreshes live in the TUI. Each method
-    // is fail-safe: registry mutation errors are swallowed by the
-    // registry itself; updateOutput errors are caught here.
-    const emitter: WorkflowOrchestratorEmitter = {
-      phaseStarted: (title) => {
-        registry?.onPhaseStarted(runId, title);
-        safeEmitUpdate(updateOutput, registryEntry);
-      },
-      agentDispatched: () => {
-        registry?.onAgentDispatched(runId);
-        safeEmitUpdate(updateOutput, registryEntry);
-      },
-      agentCompleted: () => {
-        registry?.onAgentCompleted(runId);
-        // P5 R2 (#12): defer the UI re-render to the `budgetUpdated`
-        // callback that the orchestrator fires immediately after this
-        // one. Without this skip, every dispatch completion produces
-        // TWO `safeEmitUpdate` calls (one here + one in budgetUpdated)
-        // — over a 1000-agent workflow that's 2000 TUI redraws when
-        // 1000 suffices. The budget snapshot lands AFTER the agent
-        // counter increment, so the deferred render shows both updates
-        // atomically. Production callers always wire a budget
-        // (`WorkflowBudgetImpl.fromEnv()` in `execute()` above), so the
-        // deferral is unconditional; test paths that omit budget go
-        // through the injected dispatch shape and don't exercise this
-        // emitter wiring.
-      },
-      logAppended: () => {
-        // P4b: skip per-line emit; the tool snapshots logs at terminal
-        // via `registry.setRecentLogs` so the registry record reflects
-        // the final tail without per-line churn driving rerenders.
-      },
-      budgetUpdated: (spent, total) => {
-        registry?.onBudgetUpdated(runId, spent, total);
-        safeEmitUpdate(updateOutput, registryEntry);
-      },
-    };
-
-    try {
-      const outcome = await orchestrator.run({
-        script: resolvedScript,
-        args: this.params.args,
-        abortOnTimeout: dispatchController,
-        runId,
-        emitter,
-        budget,
-        // P-nested: resolve `workflow('<name>')` / `workflow({scriptPath})`
-        // against the saved-workflow scripts in `.qwen/workflows/`.
-        resolveSavedWorkflow: (ref) =>
-          resolveSavedWorkflowScript(ref, this.config),
-        // P6: resume journal (always wired) + replay maps (resume only).
-        journal,
-        resumeReplay,
-      });
-
-      // P4b: snapshot meta + logs onto the registry record so the dialog
-      // detail body reflects the final state once the run terminates.
-      if (registryEntry) {
-        registryEntry.meta = outcome.meta;
-        if (outcome.meta?.name && registryEntry.description === runId) {
-          registryEntry.description = outcome.meta.name;
-        }
-      }
-      registry?.setRecentLogs(runId, outcome.logs);
-      registry?.complete(runId, outcome.result, Date.now());
-
+    const settlement = await handle.completion;
+    if (settlement.ok) {
+      const { outcome } = settlement;
       const usageBanner = resolveUsageBanner(
         this.config,
-        registry,
-        budget.total,
+        handle.registry,
+        handle.budget.total,
       );
 
       // FIX-7 (UP-C2): unwrap the script result so the LLM receives the
@@ -376,11 +229,11 @@ class WorkflowToolInvocation extends BaseToolInvocation<
         // tokens whenever ANY usage is reported OR a cap is set, not
         // only when spend > 0. A capped-but-zero-spend run still wants
         // the cap visible so the user sees the gate engaged.
-        ...(budget.spent() > 0 || budget.total !== null
+        ...(handle.budget.spent() > 0 || handle.budget.total !== null
           ? {
               tokens: {
-                spent: budget.spent(),
-                total: budget.total,
+                spent: handle.budget.spent(),
+                total: handle.budget.total,
               },
             }
           : {}),
@@ -390,7 +243,7 @@ class WorkflowToolInvocation extends BaseToolInvocation<
         llmContent: [{ text: llmText }],
         returnDisplay: usageBanner + '```json\n' + displayJson + '\n```',
       };
-    } catch (err) {
+    } else {
       // FIX-H (Round 5 SEC Minor): surface only the message — never the
       // stack frame — to the LLM and the UI. Caller's stderr/debug log
       // can still see the full stack via standard logging mechanisms.
@@ -398,30 +251,14 @@ class WorkflowToolInvocation extends BaseToolInvocation<
       // Cross-realm `instanceof Error` is false for vm-realm Errors; use
       // duck-typed extraction so script-thrown errors aren't coerced to
       // their "Error: <msg>" toString() form.
-      const message = extractErrorMessage(err);
+      const { message, phases, logs, meta } = settlement;
       // T19 (PR #4732 R1): if the orchestrator preserved phases / logs
       // accumulated before the failure, include them in the display so
       // the user can see what ran before the error.
-      const phases =
-        err instanceof WorkflowExecutionError ? err.phases : undefined;
-      const logs = err instanceof WorkflowExecutionError ? err.logs : undefined;
       // P4: also surface the extracted meta on the failure path. The script
       // body may have thrown long after the meta declaration parsed
       // cleanly; keeping name/description/phases visible on failure helps
       // the user identify which workflow ran.
-      const meta = err instanceof WorkflowExecutionError ? err.meta : undefined;
-      // P4b: surface the failure / abort to the registry. A caller-aborted
-      // run (`signal.aborted === true`) becomes `cancelled` rather than
-      // `failed` so the dialog distinguishes user intent from script bugs.
-      if (registryEntry) {
-        if (meta && !registryEntry.meta) registryEntry.meta = meta;
-      }
-      if (logs) registry?.setRecentLogs(runId, logs);
-      if (signal.aborted) {
-        registry?.cancel(runId, Date.now());
-      } else {
-        registry?.fail(runId, message, Date.now());
-      }
       // P5 T7: banner is intentionally OMITTED on the failure path.
       // The scheduler's `createErrorResponse` (coreToolScheduler.ts:801)
       // hard-codes `resultDisplay: error.message` whenever a tool
@@ -450,37 +287,6 @@ class WorkflowToolInvocation extends BaseToolInvocation<
         // the same way as other execution-time tool errors.
         error: { message, type: ToolErrorType.EXECUTION_FAILED },
       };
-    } finally {
-      // T40: cancel any straggler subagent on natural completion.
-      dispatchController.abort();
-      // P7b: persist a snapshot of the terminal run so `/workflows` can show
-      // it after a CLI restart. Runs on every terminal path (success / fail /
-      // cancel) because the registry entry has already transitioned by here.
-      // Best-effort: the writer swallows its own errors. Skipped when there's
-      // no registry entry (test-injected configs) or the entry is somehow
-      // still running (defensive).
-      if (registryEntry && registryEntry.status !== 'running') {
-        await writeWorkflowSnapshot(this.config, registryEntry);
-        // P-telemetry: emit the terminal run event (no-op when telemetry is
-        // off). Best-effort: never let a logging failure mask the result.
-        try {
-          logWorkflowRun(
-            this.config,
-            new WorkflowRunEvent({
-              status: registryEntry.status,
-              agents_dispatched: registryEntry.agentsDispatched,
-              agents_completed: registryEntry.agentsCompleted,
-              phase_count: registryEntry.phases.length,
-              tokens_spent: registryEntry.tokensSpent,
-              duration_ms:
-                (registryEntry.endTime ?? registryEntry.startTime) -
-                registryEntry.startTime,
-            }),
-          );
-        } catch {
-          // swallow — telemetry must not affect tool output
-        }
-      }
     }
   }
 }
@@ -650,20 +456,6 @@ function safeStringifyDisplayPayload(payload: unknown): string {
     }
     return '(display payload not JSON-serializable)';
   }
-}
-
-/**
- * Duck-typed extraction so vm-realm Errors (raised inside the sandbox)
- * don't coerce to "Error: <msg>" via toString(). See workflow-orchestrator.ts
- * for the matching helper on the orchestrator side.
- */
-function extractErrorMessage(err: unknown): string {
-  if (err && typeof err === 'object' && 'message' in err) {
-    const m = (err as { message: unknown }).message;
-    if (typeof m === 'string') return m;
-    return String(m);
-  }
-  return String(err);
 }
 
 export class WorkflowTool extends BaseDeclarativeTool<

--- a/packages/core/src/tools/workflow/workflow.ts
+++ b/packages/core/src/tools/workflow/workflow.ts
@@ -251,7 +251,8 @@ class WorkflowToolInvocation extends BaseToolInvocation<
       // Cross-realm `instanceof Error` is false for vm-realm Errors; use
       // duck-typed extraction so script-thrown errors aren't coerced to
       // their "Error: <msg>" toString() form.
-      const { message, phases, logs, meta } = settlement;
+      const { message, details } = settlement;
+      const { phases, logs, meta } = details ?? {};
       // T19 (PR #4732 R1): if the orchestrator preserved phases / logs
       // accumulated before the failure, include them in the display so
       // the user can see what ran before the error.


### PR DESCRIPTION
## What this PR does

This PR extracts each Dynamic Workflow execution into a session-owned run handle that owns the orchestrator promise, cancellation controller, budget, journal, registry transitions, terminal snapshot, telemetry, and cleanup.

The workflow tool still waits for the same terminal result and produces the same model content, display payload, usage banner, failure metadata, phase list, logs, and token accounting. The session registry now retains the live handle, routes targeted and shutdown cancellation through it, and releases it only after terminal cleanup is complete.

## Why it's needed

Today the tool invocation itself owns the entire workflow lifetime, so the session cannot safely retain or manage a run independently. Establishing one authoritative owner without changing foreground behavior is the prerequisite for later opt-in background execution, cooperative pause/resume, and durable recovery.

This phase deliberately adds no background mode, approval routing, storage format, UI state, or notification channel.

## Reviewer Test Plan

### How to verify

1. Run a normal foreground workflow and confirm it still waits for completion and returns the same result and display structure.
2. Exercise success, script failure, caller cancellation, registry cancellation, session-wide cancellation, and the internal wall-clock timeout. Confirm each run reaches one terminal state and writes one snapshot and one telemetry event.
3. Confirm the registry owns the exact live handle while the run is active, keeps it through cancellation cleanup, and releases it after settlement.
4. After a successful run has settled, abort the original caller signal and attempt another cancellation. Confirm the completed state and terminal side effects do not change.

Focused verification passed with 79 tests. Repository build, typecheck, focused lint, formatting, and diff checks also passed. A mutation probe that removed live-handle attachment caused the ownership test to fail as expected and passed again after restoration.

### Evidence (Before & After)

N/A — this is a non-UI lifecycle refactor with intentionally unchanged user-visible behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local Node.js workspace with the foreground workflow test configuration.

## Risk & Scope

- Main risk or tradeoff: lifecycle ordering could regress cancellation or duplicate terminal side effects; focused tests cover ownership, settlement, timeout classification, snapshot, telemetry, and late-signal races.
- Not validated / out of scope: Windows and Linux local runs; background execution, pause/resume, approval bubbling, persistence schema changes, and UI changes.
- Breaking changes / migration notes: none; no public tool contract or storage format changes.

## Linked Issues

Part of #8105

<!-- qwen-dynamic-workflows-train:2026-07-30.v1:PR1:predecessor=9eab8bb301b07faf4ec774109069ef3b4c1124e3 -->

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 将每次 Dynamic Workflow 执行抽取为由会话持有的 run handle，统一负责 orchestrator promise、取消控制器、预算、journal、registry 状态迁移、终态 snapshot、telemetry 和清理。

Workflow 工具仍然等待同一个终态结果，并保持原有的模型内容、展示负载、用量提示、失败元数据、阶段列表、日志和 token 统计。会话 registry 现在持有 live handle，把定向取消和会话关闭取消路由到该 handle，并且只在终态清理完成后释放。

## 为什么需要

目前整次 Workflow 生命周期由工具调用本身持有，因此会话无法在工具调用之外安全地保留或管理一次运行。在不改变前台行为的前提下建立唯一权威 owner，是后续 opt-in 后台执行、协作式 pause/resume 和持久恢复的前置条件。

本阶段明确不增加后台模式、权限响应链、存储格式、UI 状态或通知通道。

## Reviewer 测试计划

### 如何验证

1. 运行一个普通前台 Workflow，确认仍会等待完成，并返回相同的结果和展示结构。
2. 分别验证成功、脚本失败、调用方取消、registry 取消、会话级取消和内部 wall-clock 超时，确认每次运行只进入一个终态，并且只写入一次 snapshot 和一次 telemetry。
3. 确认运行期间 registry 持有精确的 live handle，取消清理期间继续持有，并在结算完成后释放。
4. 成功运行结算后，再取消原始调用方 signal 并尝试再次取消，确认 completed 状态和终态副作用都不再变化。

聚焦验证共 79 项测试通过。仓库 build、typecheck、聚焦 lint、格式检查和 diff 检查也全部通过。临时移除 live-handle 挂载的变异探针会按预期触发 ownership 测试失败，恢复后重新通过。

### 前后对比证据

N/A — 这是一个明确保持用户可见行为不变的非 UI 生命周期重构。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

本地 Node.js workspace，使用前台 Workflow 测试配置。

## 风险与范围

- 主要风险或取舍：生命周期顺序变化可能导致取消回归或终态副作用重复；聚焦测试覆盖 ownership、结算、超时分类、snapshot、telemetry 和 late-signal 竞态。
- 未验证 / 不在范围内：Windows 和 Linux 本地运行；后台执行、pause/resume、权限冒泡、持久化 schema 变化和 UI 变化。
- Breaking change / 迁移说明：无；公共工具契约和存储格式均未变化。

## 关联 Issue

Part of #8105

</details>
