### PR TITLE
fix(serve): restore build by routing side-task rollback through the workspace session service

### DIFF
--- a/packages/cli/src/serve/routes/session.ts
+++ b/packages/cli/src/serve/routes/session.ts
@@ -2324,7 +2324,7 @@ export function registerSessionRoutes(
               .killSession(result.sessionId, { requireZeroAttaches: true })
               .catch(() => false);
             if (killed) {
-              await new SessionService(runtime.workspaceCwd)
+              await createWorkspaceRuntimeSessionService(runtime)
                 .removeSession(result.sessionId)
                 .catch(() => {});
             }
@@ -2341,9 +2341,9 @@ export function registerSessionRoutes(
               .killSession(result.sessionId, { requireZeroAttaches: true })
               .then((killed) => {
                 if (!killed) return undefined;
-                return new SessionService(runtime.workspaceCwd!).removeSession(
-                  result.sessionId,
-                );
+                return createWorkspaceRuntimeSessionService(
+                  runtime,
+                ).removeSession(result.sessionId);
               })
               .catch(() => {});
           } else {


### PR DESCRIPTION
## What this PR does

Routes the two rollback paths in the side-task creation endpoint through the workspace runtime session service, instead of constructing a session service directly against the workspace directory.

## Why it's needed

The daemon session maintenance writer isolation change moved every session-service construction in the session route module over to the workspace runtime helper and dropped the direct import, but two rollback paths in the side-task creation endpoint were left behind. That leaves an unbound identifier, so the CLI package no longer compiles and `main` is red — every job that installs dependencies fails during the build, including the Java daemon E2E job.

Beyond restoring the build, this is the behavior the isolation change intended: both rollbacks delete an orphaned session after a failed side-task creation, and they were still writing through the default runtime base dir rather than the workspace's own, which is exactly the cross-workspace writer overlap that change set out to remove.

## Reviewer Test Plan

### How to verify

Check out `main` and run a build — it fails with two unresolved-name errors in the session route module and the CLI package build aborts. With this change the build and the full typecheck pass.

The affected code runs when side-task creation succeeds but the request cannot be completed: either the daemon's generation guard has closed, or the client disconnected before the response could be written. In both cases the daemon kills the freshly created session and deletes its leftover session record. A reviewer can confirm the deletion now targets the workspace's own runtime directory rather than the process-default one.

Build and typecheck output:

```
$ npm run build
(clean)
$ npm run typecheck
(clean)
```

Unit tests covering multi-workspace session routing, including the side-task endpoint:

```
$ npx vitest run src/serve/multi-workspace-sessions.test.ts src/serve/routes/session-telemetry.test.ts
 Test Files  2 passed (2)
      Tests  101 passed (101)
```

### Evidence (Before & After)

N/A — no user-visible or TUI change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local build, typecheck, and unit tests only.

## Risk & Scope

- Main risk or tradeoff: none meaningful — the change is confined to two orphan-cleanup calls and makes them consistent with every other session-service use in the same module.
- Not validated / out of scope: the two rollback paths are hard to trigger from a real client (they need a closed generation guard or a mid-request disconnect), so they were not exercised end to end; they are covered by the same helper the rest of the module already uses.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #7975.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 side-task 创建接口里两处回滚路径改为通过 workspace runtime 的 session service 获取实例，而不是直接针对工作区目录构造 session service。

## 为什么需要

守护进程 session 维护写入隔离的改动，把该路由模块里所有 session service 的构造都换成了 workspace runtime 辅助函数，并删掉了原来的直接导入，但 side-task 创建接口里的两处回滚路径被漏掉了。结果是留下了未绑定的标识符，CLI 包无法编译，`main` 变红——所有会安装依赖的 job 都在构建阶段失败，包括 Java daemon E2E job。

除了修复构建，这也是隔离改动本来想要的行为：这两处回滚都是在 side-task 创建失败后删除遗留的 session，而它们仍然写到默认的 runtime 目录而非该工作区自己的目录，正是那次改动要消除的跨工作区写入重叠。

## Reviewer Test Plan

### 如何验证

在 `main` 上执行构建会失败，session 路由模块报两处标识符无法解析，CLI 包构建中止。应用本改动后，构建和完整 typecheck 均通过。

受影响的代码在 side-task 创建成功但请求无法完成时执行：要么守护进程的 generation guard 已关闭，要么客户端在响应写出前断开。两种情况下守护进程都会杀掉刚创建的 session 并删除其遗留记录。审阅者可以确认删除操作现在指向该工作区自己的 runtime 目录，而不是进程默认目录。

构建与 typecheck 输出：

```
$ npm run build
(clean)
$ npm run typecheck
(clean)
```

覆盖多工作区 session 路由（含 side-task 接口）的单元测试：

```
$ npx vitest run src/serve/multi-workspace-sessions.test.ts src/serve/routes/session-telemetry.test.ts
 Test Files  2 passed (2)
      Tests  101 passed (101)
```

### Evidence (Before & After)

N/A —— 无用户可见或 TUI 变更。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

仅本地构建、typecheck 与单元测试。

## Risk & Scope

- 主要风险或取舍：基本没有——改动仅限于两处孤儿清理调用，并使其与同模块中其他所有 session service 用法保持一致。
- 未验证 / 范围之外：这两处回滚路径很难从真实客户端触发（需要 generation guard 已关闭或请求中途断连），因此未做端到端验证；它们复用的是模块其余部分已经在用的同一个辅助函数。
- 破坏性变更 / 迁移说明：无。

## Linked Issues

#7975 的后续修复。

</details>
