### PR TITLE
fix(serve): add missing SessionService import in session routes

### DIFF
--- a/packages/cli/src/serve/routes/session.ts
+++ b/packages/cli/src/serve/routes/session.ts
@@ -13,6 +13,7 @@ import {
   GROUP_COLOR_OPTIONS,
   GitWorktreeService,
   SessionOrganizationError,
+  SessionService,
   SESSION_TRANSCRIPT_MAX_LIMIT,
   SESSION_TRANSCRIPT_MAX_PAGE_BYTES,
   SessionTranscriptPageTooLargeError,


### PR DESCRIPTION
## What this PR does

Adds the missing `SessionService` import to the daemon session routes. The class was referenced in two cleanup paths (generation-guard rejection and non-writable response) but was never imported, causing a TypeScript compilation failure.

## Why it's needed

`npm run build` fails with `TS2304: Cannot find name 'SessionService'` in the CLI package, blocking all builds.

## Reviewer Test Plan

### How to verify

Run `npm run build` from the project root. Before this fix it fails with two `TS2304` errors; after the fix it completes successfully.

### Evidence (Before & After)

N/A (build fix, no UI change)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

`npm run build` locally.

## Risk & Scope

- Main risk or tradeoff: none — single-line import addition, no logic change.
- Not validated / out of scope: Windows/Linux builds (CI will cover).
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

为守护进程会话路由补充了缺失的 `SessionService` 导入。该类在两个清理路径（generation-guard 拒绝和响应不可写）中被引用，但从未被导入，导致 TypeScript 编译失败。

## 为什么需要

`npm run build` 因 CLI 包中的两个 `TS2304: Cannot find name 'SessionService'` 错误而失败，阻塞了所有构建。

## 审阅者测试计划

### 如何验证

在项目根目录运行 `npm run build`。修复前会报两个 `TS2304` 错误；修复后构建成功完成。

### 证据（修复前后）

N/A（构建修复，无 UI 变更）

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

本地 `npm run build`。

## 风险与范围

- 主要风险或权衡：无——仅新增一行导入，无逻辑变更。
- 未验证 / 不在范围内：Windows/Linux 构建（由 CI 覆盖）。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

N/A

</details>