### PR TITLE
fix(triage): render the verify report as sanitized markdown, not an escaped pre dump

### DIFF
--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -3355,10 +3355,16 @@ jobs:
           #      & and > are left alone in prose (a decoded entity
           #      yields text, never markup, and an unescaped > cannot
           #      open a tag once < is escaped), which keeps &&, ->, and
-          #      blockquotes readable. Outside HTML blocks, inside code
-          #      spans/fences < & @ are left alone: <img> and @mentions
-          #      are inert under a code/pre ancestor, and escaping them
-          #      there only mangles the rendered text;
+          #      blockquotes readable. Code-span parity is a paragraph
+          #      property in CommonMark but a line property here, so a prose
+          #      line carrying an unmatched backtick run makes the rest of the
+          #      paragraph's code/prose split unknowable; the scanner fails
+          #      closed and prose-escapes every line until the next blank line
+          #      (over-escaping is the safe direction — a multi-line code span
+          #      shows its entities literally, inert not live). Outside HTML
+          #      blocks, inside code spans/fences < & @ are left alone: <img>
+          #      and @mentions are inert under a code/pre ancestor, and
+          #      escaping them there only mangles the rendered text;
           #   2. the comment-open token is broken EVERYWHERE, prose and code
           #      alike (<!-- becomes an escaped no-op, the autofix-proven
           #      neutralizer). The break must stay global: the upsert greps
@@ -3375,19 +3381,32 @@ jobs:
           #      counted — surplus closers are dropped (they would otherwise
           #      close the wrapping fold early) and unclosed opens are closed
           #      at the end, so a malformed report can neither swallow the
-          #      footer nor escape its wrapper. A fence still open at EOF is
-          #      a reliable signal the flat scanner diverged from GitHub's
-          #      container-aware parser (which closes a list-nested fence at
-          #      the container's end, not at EOF), so the sanitizer exits
-          #      non-zero and emit_report degrades to the escaped fallback
-          #      rather than guessing.
+          #      footer nor escape its wrapper. The flat scanner diverges
+          #      from GitHub's container-aware parser whenever a fence it
+          #      holds open cannot exist in GitHub's view, so two signals
+          #      exit non-zero (emit_report then degrades to the escaped
+          #      fallback rather than guessing): a fence still open at EOF
+          #      (GitHub closes a list-nested fence at the container's end,
+          #      not at EOF), and a non-blank line that dedents below the
+          #      fence opener's indent while it is open — the container
+          #      boundary moved, so GitHub already closed the fence and a
+          #      balancing closer later in the file would otherwise let the
+          #      scanner pass unescaped prose through escCode.
           # Accepted tradeoff (named, not accidental): rendering promotes the
           # report from inert text to parsed markdown, so [links](…) and
           # ![images](…) now render live where emit_block showed them literal.
           # report.md is agent output from a sandbox that ran PR code; images
           # are camo-proxied (mostly noise) and a phishing link under the bot
-          # identity is the residual surface. Defusing link targets is a
-          # deliberate follow-up, not done here.
+          # identity is the residual surface. That surface exists only while
+          # the four guarantees hold, so the fail-closed bails above are what
+          # keep deferring link defusing defensible; defusing link targets is
+          # a deliberate follow-up, not done here. Two safe-but-ugly display
+          # costs are named, not bugs: a code span that opens on one line and
+          # closes on the next is prose-escaped (the reader sees &lt;T&gt;
+          # inside it — the #8140 symptom relocated but inert), and escCode
+          # breaks <!-- to &lt;!\-\- which renders LITERALLY in a fence
+          # (entities do not decode there), so a fenced comment example shows
+          # as &lt;!\-\-.
           # An OVERSIZED report falls back to emit_block wholesale (cut
           # markdown dangles fences/folds), as does any sanitizer failure.
           emit_report() {
@@ -3447,7 +3466,7 @@ jobs:
                       k = m;
                     } else k += 1;
                   }
-                  if (cs === -1) { buf += line.slice(i, j); i = j; }
+                  if (cs === -1) { unmatched = true; buf += line.slice(i, j); i = j; }
                   else { flush(); out += escCode(line.slice(i, ce)); i = ce; }
                 }
                 flush();
@@ -3455,20 +3474,31 @@ jobs:
               }
               const lines = text.split("\n");
               const out = [];
-              let inFence = false, fc = "", fl = 0, inHtml = false;
+              let inFence = false, fc = "", fl = 0, fi = 0, inHtml = false;
+              let spanUnknown = false, unmatched = false;
               for (const line of lines) {
                 if (!inFence) {
-                  if (inHtml && /^\s*$/.test(line)) inHtml = false;
+                  const blank = /^\s*$/.test(line);
+                  if (inHtml && blank) inHtml = false;
+                  if (blank) spanUnknown = false;
                   const m = inHtml ? null : line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
                   if (m && !(m[1][0] === "`" && m[2].indexOf("`") !== -1)) {
-                    inFence = true; fc = m[1][0]; fl = m[1].length;
+                    inFence = true; fc = m[1][0]; fl = m[1].length; fi = line.match(/^ */)[0].length;
                     out.push(escCode(line));
                     continue;
                   }
-                  const rendered = inHtml ? balance(escProse(line)) : proseLine(line);
+                  let rendered;
+                  if (inHtml || spanUnknown) {
+                    rendered = balance(escProse(line));
+                  } else {
+                    unmatched = false;
+                    rendered = proseLine(line);
+                    if (unmatched) { spanUnknown = true; rendered = balance(escProse(line)); }
+                  }
                   if (/^\s*<\/?(details|summary)\b/.test(rendered)) inHtml = true;
                   out.push(rendered);
                 } else {
+                  if (/\S/.test(line) && line.match(/^ */)[0].length < fi) process.exit(3);
                   const cm = line.match(/^ {0,3}(`{3,}|~{3,})[ \t]*$/);
                   if (cm && cm[1][0] === fc && cm[1].length >= fl) inFence = false;
                   out.push(escCode(line));
@@ -3489,7 +3519,7 @@ jobs:
                 echo "::warning::emit_report fell back to escaped embedding (sanitize failed) for $file" >&2
               fi
               rm -f "$san_file"
-              emit_block 'Verification report (report.md, truncated)' "$file" "$max"
+              emit_block 'Verification report (report.md, escaped fallback)' "$file" "$max"
               return 0
             fi
             # Wrap in a collapsed <details> (one-line footprint, markdown when

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -3342,8 +3342,15 @@ jobs:
           # on four line-independent guarantees:
           #   1. in PROSE every < is escaped, then only the structural tags
           #      the report uses as raw HTML (details/summary) are un-escaped
-          #      back to live tags — no other tag can form, so
-          #      <img>/<script>/onerror never render. & and > are left alone
+          #      back to live tags — no other tag can form in ordinary
+          #      prose, so <img>/<script>/onerror never render there. A
+          #      line-level inHtml flag tracks raw-HTML blocks opened by
+          #      details/summary: inside one, backtick lines are NOT fences
+          #      (CommonMark/GitHub reads them as literal text), so the
+          #      sanitizer prose-escapes their content instead of passing it
+          #      through escCode — closing the divergence where GitHub saw
+          #      live HTML the sanitizer treated as inert code. & and > are
+          #      left alone
           #      in prose (a decoded entity yields text, never markup, and an
           #      unescaped > cannot open a tag once < is escaped), which keeps
           #      &&, ->, and blockquotes readable. Inside code spans/fences
@@ -3355,9 +3362,12 @@ jobs:
           #      neutralizer). The break must stay global: the upsert greps
           #      the RAW body for the running marker and a fence prints
           #      verbatim, so a forged marker inside a fence must not survive;
-          #   3. in prose @ becomes &#64; — renders identically, never fires a
-          #      mention (a mention cannot fire under a code/pre ancestor, so
-          #      code keeps a literal @);
+          #   3. in prose @ gains a zero-width space (@&#8203;) — renders
+          #      identically, never fires a mention (GitHub decodes &#64;
+          #      back to @ before the mention filter runs, so the entity
+          #      alone was inert; the ZWSP breaks the mention token). A
+          #      mention cannot fire under a code/pre ancestor, so code
+          #      keeps a literal @;
           #   4. <details> folds are balanced over PROSE only — a </details>
           #      quoted in a code span/fence is inert text and is no longer
           #      counted — surplus closers are dropped (they would otherwise
@@ -3395,7 +3405,7 @@ jobs:
                   .replace(/</g, "&lt;")
                   .replace(/&lt;(\/?)(details|summary)>/g, "<$1$2>")
                   .replace(/&lt;!--/g, "&lt;!\\-\\-")
-                  .replace(/@/g, "&#64;");
+                  .replace(/@/g, "@&#8203;");
               }
               function escCode(s) {
                 return s.replace(/<!--/g, "&lt;!\\-\\-");
@@ -3437,16 +3447,19 @@ jobs:
               }
               const lines = text.split("\n");
               const out = [];
-              let inFence = false, fc = "", fl = 0;
+              let inFence = false, fc = "", fl = 0, inHtml = false;
               for (const line of lines) {
                 if (!inFence) {
-                  const m = line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
+                  if (inHtml && /^\s*$/.test(line)) inHtml = false;
+                  const m = inHtml ? null : line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
                   if (m && !(m[1][0] === "`" && m[2].indexOf("`") !== -1)) {
                     inFence = true; fc = m[1][0]; fl = m[1].length;
                     out.push(escCode(line));
                     continue;
                   }
-                  out.push(proseLine(line));
+                  const rendered = proseLine(line);
+                  if (/^ {0,3}<\/?(details|summary)\b/.test(rendered)) inHtml = true;
+                  out.push(rendered);
                 } else {
                   const cm = line.match(/^ {0,3}(`{3,}|~{3,})[ \t]*$/);
                   if (cm && cm[1][0] === fc && cm[1].length >= fl) inFence = false;

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -3328,20 +3328,49 @@ jobs:
           # Render report.md as MARKDOWN instead of an escaped <pre> dump.
           # The report is a curated bilingual document (tables, nested
           # <details>, headings); the pre/code embedding displayed it as a
-          # wall of raw source (#8140's comment was the exhibit). Rendering
-          # keeps the same security floor via four line-independent
-          # guarantees:
-          #   1. every & < > is escaped, then ONLY the structural tags the
-          #      report legitimately uses are un-escaped back to live tags
-          #      (details/summary/pre/code/br) — no other tag can form, so
-          #      <img>/<script>/onerror never render;
-          #   2. the comment-open token is broken (<!-- becomes an escaped
-          #      no-op, the autofix-proven neutralizer), so no forged
-          #      qwen-triage:* marker can form anywhere in the body;
-          #   3. @ becomes &#64; — renders identically, never fires a
-          #      mention;
-          #   4. unbalanced <details> opens are counted and closed at the
-          #      end, so a malformed report cannot swallow the footer.
+          # wall of raw source (#8140's comment was the exhibit). The section
+          # is wrapped in a collapsed <details> so it still costs one line in
+          # the conversation but renders as real markdown when opened.
+          #
+          # A node sanitizer (not sed) does the escaping so it can tell code
+          # regions apart from prose. CommonMark does NOT decode entities in
+          # code spans or fenced blocks — they render literally there — so
+          # escaping & < > @ unconditionally showed the reader &amp;&amp;,
+          # &lt;T&gt;, &#64;pkg inside the very commands, generic types, and
+          # scoped-package paths a verification report is read to copy (the
+          # #8140 symptom, relocated into code). The security floor now rests
+          # on four line-independent guarantees:
+          #   1. in PROSE every < is escaped, then only the structural tags
+          #      the report uses as raw HTML (details/summary) are un-escaped
+          #      back to live tags — no other tag can form, so
+          #      <img>/<script>/onerror never render. & and > are left alone
+          #      in prose (a decoded entity yields text, never markup, and an
+          #      unescaped > cannot open a tag once < is escaped), which keeps
+          #      &&, ->, and blockquotes readable. Inside code spans/fences
+          #      < & @ are left alone too: <img> and @mentions are inert under
+          #      a code/pre ancestor, and escaping them there only mangles the
+          #      rendered text;
+          #   2. the comment-open token is broken EVERYWHERE, prose and code
+          #      alike (<!-- becomes an escaped no-op, the autofix-proven
+          #      neutralizer). The break must stay global: the upsert greps
+          #      the RAW body for the running marker and a fence prints
+          #      verbatim, so a forged marker inside a fence must not survive;
+          #   3. in prose @ becomes &#64; — renders identically, never fires a
+          #      mention (a mention cannot fire under a code/pre ancestor, so
+          #      code keeps a literal @);
+          #   4. <details> folds are balanced over PROSE only — a </details>
+          #      quoted in a code span/fence is inert text and is no longer
+          #      counted — surplus closers are dropped (they would otherwise
+          #      close the wrapping fold early) and unclosed opens are closed
+          #      at the end, so a malformed report can neither swallow the
+          #      footer nor escape its wrapper.
+          # Accepted tradeoff (named, not accidental): rendering promotes the
+          # report from inert text to parsed markdown, so [links](…) and
+          # ![images](…) now render live where emit_block showed them literal.
+          # report.md is agent output from a sandbox that ran PR code; images
+          # are camo-proxied (mostly noise) and a phishing link under the bot
+          # identity is the residual surface. Defusing link targets is a
+          # deliberate follow-up, not done here.
           # An OVERSIZED report falls back to emit_block wholesale (cut
           # markdown dangles fences/folds), as does any sanitizer failure.
           emit_report() {
@@ -3353,53 +3382,110 @@ jobs:
               return 0
             fi
             local san_file="${TMPDIR:-/tmp}/verify-report-$$"
-            if ! (
-              set -o pipefail
-              tr -d '\000' < "$file" |
-                sed -E -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' \
-                  -e 's/&lt;(\/{0,1})(details|summary|pre|code|br)&gt;/<\1\2>/g' \
-                  -e 's/&lt;!--/\&lt;!\\-\\-/g' \
-                  -e 's/@/\&#64;/g' > "$san_file"
-            ); then
+            # Node is present on every runner that runs this job (emit_block
+            # already shells out to it for the UTF-8-safe cut). The script
+            # rides inside a single-quoted shell string, so it uses double
+            # quotes throughout and carries no single quotes of its own.
+            if ! node -e '
+              const fs = require("node:fs");
+              const text = fs.readFileSync(process.argv[1], "utf8").replace(/\u0000/g, "");
+              function escProse(s) {
+                return s
+                  .replace(/</g, "&lt;")
+                  .replace(/&lt;(\/?)(details|summary)>/g, "<$1$2>")
+                  .replace(/&lt;!--/g, "&lt;!\\-\\-")
+                  .replace(/@/g, "&#64;");
+              }
+              function escCode(s) {
+                return s.replace(/<!--/g, "&lt;!\\-\\-");
+              }
+              let depth = 0;
+              function balance(s) {
+                return s.replace(/<\/?details>/g, function (t) {
+                  if (t === "<details>") { depth += 1; return t; }
+                  if (depth > 0) { depth -= 1; return t; }
+                  return "";
+                });
+              }
+              function proseLine(line) {
+                let out = "";
+                let buf = "";
+                let i = 0;
+                const flush = function () {
+                  if (buf) { out += balance(escProse(buf)); buf = ""; }
+                };
+                while (i < line.length) {
+                  if (line[i] !== "`") { buf += line[i]; i += 1; continue; }
+                  let j = i;
+                  while (j < line.length && line[j] === "`") j += 1;
+                  const run = j - i;
+                  let k = j, cs = -1, ce = -1;
+                  while (k < line.length) {
+                    if (line[k] === "`") {
+                      let m = k;
+                      while (m < line.length && line[m] === "`") m += 1;
+                      if (m - k === run) { cs = k; ce = m; break; }
+                      k = m;
+                    } else k += 1;
+                  }
+                  if (cs === -1) { buf += line.slice(i, j); i = j; }
+                  else { flush(); out += escCode(line.slice(i, ce)); i = ce; }
+                }
+                flush();
+                return out;
+              }
+              const lines = text.split("\n");
+              const out = [];
+              let inFence = false, fc = "", fl = 0;
+              for (const line of lines) {
+                if (!inFence) {
+                  const m = line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
+                  if (m && !(m[1][0] === "`" && m[2].indexOf("`") !== -1)) {
+                    inFence = true; fc = m[1][0]; fl = m[1].length;
+                    out.push(escCode(line));
+                    continue;
+                  }
+                  out.push(proseLine(line));
+                } else {
+                  const cm = line.match(/^ {0,3}(`{3,}|~{3,})[ \t]*$/);
+                  if (cm && cm[1][0] === fc && cm[1].length >= fl) inFence = false;
+                  out.push(escCode(line));
+                }
+              }
+              let result = out.join("\n");
+              if (depth > 0) {
+                if (result && !result.endsWith("\n")) result += "\n";
+                result += "</details>\n".repeat(depth);
+              }
+              process.stdout.write(result);
+            ' "$file" > "$san_file"; then
               echo "::warning::emit_report fell back to escaped embedding (sanitize failed) for $file" >&2
               rm -f "$san_file"
-              emit_block 'Verification report (report.md)' "$file" "$max"
-              return 0
-            fi
-            if [ "$(wc -c < "$san_file")" -gt "$max" ]; then
-              echo "::warning::emit_report fell back to escaped embedding (sanitized output exceeds size cap) for $file" >&2
-              rm -f "$san_file"
               emit_block 'Verification report (report.md, truncated)' "$file" "$max"
               return 0
             fi
-            local opens closes
-            # `|| true` inside the substitution: grep exits 1 on zero
-            # matches, and under the step's pipefail that would kill the
-            # whole composer for a report with no folds at all.
-            opens="$(grep -o '<details>' "$san_file" | wc -l || true)"
-            closes="$(grep -o '</details>' "$san_file" | wc -l || true)"
-            # The balancing loop below appends `opens - closes` closers
-            # (11 bytes each) AFTER this size gate has already passed, so a
-            # report dense in unbalanced <details> opens could be pushed past
-            # the cap — and past GitHub's 65,536-char comment limit — by the
-            # closers alone. Budget for that overhead before committing to
-            # the markdown path; otherwise fall back to the capped pre dump.
-            local deficit=$(( opens - closes ))
-            if [ "$deficit" -gt 0 ] && \
-               [ $(( $(wc -c < "$san_file") + deficit * 11 + 30 )) -gt "$max" ]; then
-              echo "::warning::emit_report fell back to escaped embedding (fold-closer overhead exceeds size cap) for $file" >&2
-              rm -f "$san_file"
-              emit_block 'Verification report (report.md, truncated)' "$file" "$max"
-              return 0
-            fi
-            printf '### Verification report\n\n'
-            cat "$san_file"
+            # Wrap in a collapsed <details> (one-line footprint, markdown when
+            # opened) and bound the WHOLE emitted section — wrapper, balanced
+            # report, appended closers — so the cap is a true bound on what
+            # lands in the comment. The old normal path skipped the header
+            # bytes the deficit branch did budget; folding the wrapper into
+            # the measured output removes that asymmetry and the separate
+            # fold-closer gate (closers now land in san_file before this gate).
+            local out_file="${TMPDIR:-/tmp}/verify-report-out-$$"
+            {
+              printf '<details>\n<summary>Verification report</summary>\n\n'
+              cat "$san_file"
+              printf '\n</details>\n'
+            } > "$out_file"
             rm -f "$san_file"
-            printf '\n'
-            while [ "$opens" -gt "$closes" ]; do
-              printf '</details>\n'
-              opens=$(( opens - 1 ))
-            done
+            if [ "$(wc -c < "$out_file")" -gt "$max" ]; then
+              echo "::warning::emit_report fell back to escaped embedding (sanitized output exceeds size cap) for $file" >&2
+              rm -f "$out_file"
+              emit_block 'Verification report (report.md, truncated)' "$file" "$max"
+              return 0
+            fi
+            cat "$out_file"
+            rm -f "$out_file"
             printf '\n'
           }
 

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -3348,6 +3348,7 @@ jobs:
             local file="$1" max="$2"
             [ -n "$file" ] && [ -f "$file" ] || return 0
             if [ "$(wc -c < "$file")" -gt "$max" ]; then
+              echo "::warning::emit_report fell back to escaped embedding (report exceeds size cap) for $file" >&2
               emit_block 'Verification report (report.md, truncated)' "$file" "$max"
               return 0
             fi
@@ -3360,11 +3361,13 @@ jobs:
                   -e 's/&lt;!--/\&lt;!\\-\\-/g' \
                   -e 's/@/\&#64;/g' > "$san_file"
             ); then
+              echo "::warning::emit_report fell back to escaped embedding (sanitize failed) for $file" >&2
               rm -f "$san_file"
               emit_block 'Verification report (report.md)' "$file" "$max"
               return 0
             fi
             if [ "$(wc -c < "$san_file")" -gt "$max" ]; then
+              echo "::warning::emit_report fell back to escaped embedding (sanitized output exceeds size cap) for $file" >&2
               rm -f "$san_file"
               emit_block 'Verification report (report.md, truncated)' "$file" "$max"
               return 0
@@ -3384,6 +3387,7 @@ jobs:
             local deficit=$(( opens - closes ))
             if [ "$deficit" -gt 0 ] && \
                [ $(( $(wc -c < "$san_file") + deficit * 11 + 30 )) -gt "$max" ]; then
+              echo "::warning::emit_report fell back to escaped embedding (fold-closer overhead exceeds size cap) for $file" >&2
               rm -f "$san_file"
               emit_block 'Verification report (report.md, truncated)' "$file" "$max"
               return 0

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -3426,11 +3426,16 @@ jobs:
             local node_status=0
             node -e '
               const fs = require("node:fs");
-              const text = fs.readFileSync(process.argv[1], "utf8").replace(/\u0000/g, "");
+              const text = fs.readFileSync(process.argv[1], "utf8").replace(/[\u0000\u0001]/g, "");
               function escProse(s) {
+                // Allowlisted tags are stashed behind a \u0001 sentinel (stripped
+                // from input) BEFORE the < pass and restored from it, so a literal
+                // &lt;details> the author typed stays escaped text instead of being
+                // promoted back to a live tag by the un-escape step.
                 return s
+                  .replace(/<(\/?)(details|summary)>/g, "\u0001$1$2>")
                   .replace(/</g, "&lt;")
-                  .replace(/&lt;(\/?)(details|summary)>/g, "<$1$2>")
+                  .replace(/\u0001(\/?)(details|summary)>/g, "<$1$2>")
                   .replace(/&lt;!--/g, "&lt;!\\-\\-")
                   .replace(/@/g, "@&#8203;");
               }
@@ -3454,6 +3459,13 @@ jobs:
                 };
                 while (i < line.length) {
                   if (line[i] !== "`") { buf += line[i]; i += 1; continue; }
+                  // A backslash-escaped backtick does not OPEN a code span (the
+                  // CommonMark escape rule consumes it first) but still CLOSES one
+                  // — an asymmetry a line-scoped scanner cannot model. Fail closed
+                  // like an unmatched run so the whole line is prose-escaped.
+                  let bs = 0, b = i - 1;
+                  while (b >= 0 && line[b] === "\\") { bs += 1; b -= 1; }
+                  if (bs % 2 === 1) { unmatched = true; buf += line[i]; i += 1; continue; }
                   let j = i;
                   while (j < line.length && line[j] === "`") j += 1;
                   const run = j - i;

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -3355,13 +3355,18 @@ jobs:
             if ! (
               set -o pipefail
               tr -d '\000' < "$file" |
-                sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' \
-                  -e 's/&lt;\(\/\{0,1\}\)\(details\|summary\|pre\|code\|br\)&gt;/<\1\2>/g' \
+                sed -E -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' \
+                  -e 's/&lt;(\/{0,1})(details|summary|pre|code|br)&gt;/<\1\2>/g' \
                   -e 's/&lt;!--/\&lt;!\\-\\-/g' \
                   -e 's/@/\&#64;/g' > "$san_file"
             ); then
               rm -f "$san_file"
               emit_block 'Verification report (report.md)' "$file" "$max"
+              return 0
+            fi
+            if [ "$(wc -c < "$san_file")" -gt "$max" ]; then
+              rm -f "$san_file"
+              emit_block 'Verification report (report.md, truncated)' "$file" "$max"
               return 0
             fi
             local opens closes

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -3374,9 +3374,13 @@ jobs:
           #      quoted in a code span/fence is inert text and is no longer
           #      counted — surplus closers are dropped (they would otherwise
           #      close the wrapping fold early) and unclosed opens are closed
-          #      at the end; a dangling code fence is closed too, so a
-          #      malformed report can neither swallow the
-          #      footer nor escape its wrapper.
+          #      at the end, so a malformed report can neither swallow the
+          #      footer nor escape its wrapper. A fence still open at EOF is
+          #      a reliable signal the flat scanner diverged from GitHub's
+          #      container-aware parser (which closes a list-nested fence at
+          #      the container's end, not at EOF), so the sanitizer exits
+          #      non-zero and emit_report degrades to the escaped fallback
+          #      rather than guessing.
           # Accepted tradeoff (named, not accidental): rendering promotes the
           # report from inert text to parsed markdown, so [links](…) and
           # ![images](…) now render live where emit_block showed them literal.
@@ -3394,12 +3398,14 @@ jobs:
               emit_block 'Verification report (report.md, truncated)' "$file" "$max"
               return 0
             fi
-            local san_file="${TMPDIR:-/tmp}/verify-report-$$"
+            local san_file
+            san_file="$(mktemp)"
             # Node is present on every runner that runs this job (emit_block
             # already shells out to it for the UTF-8-safe cut). The script
             # rides inside a single-quoted shell string, so it uses double
             # quotes throughout and carries no single quotes of its own.
-            if ! node -e '
+            local node_status=0
+            node -e '
               const fs = require("node:fs");
               const text = fs.readFileSync(process.argv[1], "utf8").replace(/\u0000/g, "");
               function escProse(s) {
@@ -3468,15 +3474,20 @@ jobs:
                   out.push(escCode(line));
                 }
               }
-              if (inFence) out.push(fc.repeat(fl));
+              if (inFence) process.exit(3);
               let result = out.join("\n");
               if (depth > 0) {
                 if (result && !result.endsWith("\n")) result += "\n";
                 result += "</details>\n".repeat(depth);
               }
               process.stdout.write(result);
-            ' "$file" > "$san_file"; then
-              echo "::warning::emit_report fell back to escaped embedding (sanitize failed) for $file" >&2
+            ' "$file" > "$san_file" || node_status=$?
+            if [ "$node_status" -ne 0 ]; then
+              if [ "$node_status" -eq 3 ]; then
+                echo "::warning::emit_report fell back to escaped embedding (report ended inside an open code fence) for $file" >&2
+              else
+                echo "::warning::emit_report fell back to escaped embedding (sanitize failed) for $file" >&2
+              fi
               rm -f "$san_file"
               emit_block 'Verification report (report.md, truncated)' "$file" "$max"
               return 0
@@ -3488,7 +3499,8 @@ jobs:
             # bytes the deficit branch did budget; folding the wrapper into
             # the measured output removes that asymmetry and the separate
             # fold-closer gate (closers now land in san_file before this gate).
-            local out_file="${TMPDIR:-/tmp}/verify-report-out-$$"
+            local out_file
+            out_file="$(mktemp)"
             {
               printf '<details>\n<summary>Verification report</summary>\n\n'
               cat "$san_file"

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -3375,6 +3375,19 @@ jobs:
             # whole composer for a report with no folds at all.
             opens="$(grep -o '<details>' "$san_file" | wc -l || true)"
             closes="$(grep -o '</details>' "$san_file" | wc -l || true)"
+            # The balancing loop below appends `opens - closes` closers
+            # (11 bytes each) AFTER this size gate has already passed, so a
+            # report dense in unbalanced <details> opens could be pushed past
+            # the cap — and past GitHub's 65,536-char comment limit — by the
+            # closers alone. Budget for that overhead before committing to
+            # the markdown path; otherwise fall back to the capped pre dump.
+            local deficit=$(( opens - closes ))
+            if [ "$deficit" -gt 0 ] && \
+               [ $(( $(wc -c < "$san_file") + deficit * 11 + 30 )) -gt "$max" ]; then
+              rm -f "$san_file"
+              emit_block 'Verification report (report.md, truncated)' "$file" "$max"
+              return 0
+            fi
             printf '### Verification report\n\n'
             cat "$san_file"
             rm -f "$san_file"

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -3345,18 +3345,20 @@ jobs:
           #      back to live tags — no other tag can form in ordinary
           #      prose, so <img>/<script>/onerror never render there. A
           #      line-level inHtml flag tracks raw-HTML blocks opened by
-          #      details/summary: inside one, backtick lines are NOT fences
-          #      (CommonMark/GitHub reads them as literal text), so the
-          #      sanitizer prose-escapes their content instead of passing it
-          #      through escCode — closing the divergence where GitHub saw
-          #      live HTML the sanitizer treated as inert code. & and > are
-          #      left alone
-          #      in prose (a decoded entity yields text, never markup, and an
-          #      unescaped > cannot open a tag once < is escaped), which keeps
-          #      &&, ->, and blockquotes readable. Inside code spans/fences
-          #      < & @ are left alone too: <img> and @mentions are inert under
-          #      a code/pre ancestor, and escaping them there only mangles the
-          #      rendered text;
+          #      details/summary (at any indent, so list-nested folds
+          #      enter the state too): inside one, neither fence lines
+          #      NOR code spans are code — CommonMark/GitHub reads both
+          #      as literal text in a raw-HTML block — so the sanitizer
+          #      prose-escapes the whole line instead of splitting it
+          #      through proseLine, closing the divergence where GitHub
+          #      saw live HTML the sanitizer treated as inert code.
+          #      & and > are left alone in prose (a decoded entity
+          #      yields text, never markup, and an unescaped > cannot
+          #      open a tag once < is escaped), which keeps &&, ->, and
+          #      blockquotes readable. Outside HTML blocks, inside code
+          #      spans/fences < & @ are left alone: <img> and @mentions
+          #      are inert under a code/pre ancestor, and escaping them
+          #      there only mangles the rendered text;
           #   2. the comment-open token is broken EVERYWHERE, prose and code
           #      alike (<!-- becomes an escaped no-op, the autofix-proven
           #      neutralizer). The break must stay global: the upsert greps
@@ -3457,8 +3459,8 @@ jobs:
                     out.push(escCode(line));
                     continue;
                   }
-                  const rendered = proseLine(line);
-                  if (/^ {0,3}<\/?(details|summary)\b/.test(rendered)) inHtml = true;
+                  const rendered = inHtml ? balance(escProse(line)) : proseLine(line);
+                  if (/^\s*<\/?(details|summary)\b/.test(rendered)) inHtml = true;
                   out.push(rendered);
                 } else {
                   const cm = line.match(/^ {0,3}(`{3,}|~{3,})[ \t]*$/);

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -3325,6 +3325,61 @@ jobs:
             printf '%s%s\n' "$esc" "$truncated"
             printf '</code></pre>\n\n</details>\n\n'
           }
+          # Render report.md as MARKDOWN instead of an escaped <pre> dump.
+          # The report is a curated bilingual document (tables, nested
+          # <details>, headings); the pre/code embedding displayed it as a
+          # wall of raw source (#8140's comment was the exhibit). Rendering
+          # keeps the same security floor via four line-independent
+          # guarantees:
+          #   1. every & < > is escaped, then ONLY the structural tags the
+          #      report legitimately uses are un-escaped back to live tags
+          #      (details/summary/pre/code/br) — no other tag can form, so
+          #      <img>/<script>/onerror never render;
+          #   2. the comment-open token is broken (<!-- becomes an escaped
+          #      no-op, the autofix-proven neutralizer), so no forged
+          #      qwen-triage:* marker can form anywhere in the body;
+          #   3. @ becomes &#64; — renders identically, never fires a
+          #      mention;
+          #   4. unbalanced <details> opens are counted and closed at the
+          #      end, so a malformed report cannot swallow the footer.
+          # An OVERSIZED report falls back to emit_block wholesale (cut
+          # markdown dangles fences/folds), as does any sanitizer failure.
+          emit_report() {
+            local file="$1" max="$2"
+            [ -n "$file" ] && [ -f "$file" ] || return 0
+            if [ "$(wc -c < "$file")" -gt "$max" ]; then
+              emit_block 'Verification report (report.md, truncated)' "$file" "$max"
+              return 0
+            fi
+            local san_file="${TMPDIR:-/tmp}/verify-report-$$"
+            if ! (
+              set -o pipefail
+              tr -d '\000' < "$file" |
+                sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' \
+                  -e 's/&lt;\(\/\{0,1\}\)\(details\|summary\|pre\|code\|br\)&gt;/<\1\2>/g' \
+                  -e 's/&lt;!--/\&lt;!\\-\\-/g' \
+                  -e 's/@/\&#64;/g' > "$san_file"
+            ); then
+              rm -f "$san_file"
+              emit_block 'Verification report (report.md)' "$file" "$max"
+              return 0
+            fi
+            local opens closes
+            # `|| true` inside the substitution: grep exits 1 on zero
+            # matches, and under the step's pipefail that would kill the
+            # whole composer for a report with no folds at all.
+            opens="$(grep -o '<details>' "$san_file" | wc -l || true)"
+            closes="$(grep -o '</details>' "$san_file" | wc -l || true)"
+            printf '### Verification report\n\n'
+            cat "$san_file"
+            rm -f "$san_file"
+            printf '\n'
+            while [ "$opens" -gt "$closes" ]; do
+              printf '</details>\n'
+              opens=$(( opens - 1 ))
+            done
+            printf '\n'
+          }
 
           # Host the agent's evidence images (if any) on a per-PR branch
           # (pr-assets/<N>-verify, matching hand-run convention) and build
@@ -3695,7 +3750,7 @@ jobs:
               if [ -n "${MISSING_REPORT_NOTE:-}" ]; then
                 printf '%s\n\n' "$MISSING_REPORT_NOTE"
               fi
-              emit_block 'Verification report (report.md)' "$REPORT" 45000
+              emit_report "$REPORT" 45000
               if [ -n "$EVIDENCE_SECTION" ]; then
                 printf '%s' "$EVIDENCE_SECTION"
               fi

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -3362,7 +3362,8 @@ jobs:
           #      quoted in a code span/fence is inert text and is no longer
           #      counted — surplus closers are dropped (they would otherwise
           #      close the wrapping fold early) and unclosed opens are closed
-          #      at the end, so a malformed report can neither swallow the
+          #      at the end; a dangling code fence is closed too, so a
+          #      malformed report can neither swallow the
           #      footer nor escape its wrapper.
           # Accepted tradeoff (named, not accidental): rendering promotes the
           # report from inert text to parsed markdown, so [links](…) and
@@ -3452,6 +3453,7 @@ jobs:
                   out.push(escCode(line));
                 }
               }
+              if (inFence) out.push(fc.repeat(fl));
               let result = out.join("\n");
               if (depth > 0) {
                 if (result && !result.endsWith("\n")) result += "\n";

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -1647,6 +1647,39 @@ describe('qwen-triage verify hardening', () => {
       const inflated = emit(dense, 45000);
       expect(inflated).toContain('<pre><code>');
       expect(inflated).toContain('Verification report (report.md, truncated)');
+
+      // The fold-counting greps carry `|| true` because grep exits 1 on zero
+      // matches, which under the step's real `set -euo pipefail` would abort
+      // the whole composer for a fold-free report. `emit` spawns without
+      // pipefail, so exercise that path explicitly: a zero-fold report under
+      // pipefail must still exit 0 and render.
+      const nofolds = join(dir, 'nofolds.md');
+      writeFileSync(nofolds, '## heading\nbody text\n');
+      const pf = spawnSync(
+        'bash',
+        [
+          '-c',
+          `set -o pipefail\n${helpers}\nemit_report "$1" 45000`,
+          '_',
+          nofolds,
+        ],
+        { encoding: 'utf8' },
+      );
+      expect(pf.status).toBe(0);
+      expect(pf.stdout).toContain('### Verification report');
+      expect(pf.stdout).toContain('## heading');
+
+      // The balancing loop appends `opens - closes` closers AFTER the size
+      // gate passes, so a report dense in unbalanced <details> opens must
+      // fall back to the capped pre dump once the closer overhead would
+      // exceed the budget — rather than shipping a section over the cap.
+      // 100 opens: raw ~1000 B and sanitized ~1000 B both clear max=2000,
+      // but 1000 + 100*11 + 30 > 2000 forces the fallback.
+      const folds = join(dir, 'folds.md');
+      writeFileSync(folds, '<details>\n'.repeat(100));
+      const over = emit(folds, 2000);
+      expect(over).toContain('<pre><code>');
+      expect(over).toContain('Verification report (report.md, truncated)');
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -1575,13 +1575,16 @@ describe('qwen-triage verify hardening', () => {
     // Each fallback branch announces itself in the Actions log (mirroring
     // emit_block's failure warning) so a degradation to the escaped pre dump
     // is attributable, not silent. The fold-closer overhead is now budgeted
-    // inside the sanitized-size gate (closers land before it), so three
+    // inside the sanitized-size gate (closers land before it), so four
     // warnings cover every degradation.
     expect(helpers).toContain(
       '::warning::emit_report fell back to escaped embedding (report exceeds size cap)',
     );
     expect(helpers).toContain(
       '::warning::emit_report fell back to escaped embedding (sanitize failed)',
+    );
+    expect(helpers).toContain(
+      '::warning::emit_report fell back to escaped embedding (report ended inside an open code fence)',
     );
     expect(helpers).toContain(
       '::warning::emit_report fell back to escaped embedding (sanitized output exceeds size cap)',
@@ -1805,20 +1808,54 @@ describe('qwen-triage verify hardening', () => {
       expect(surplusOut.split('<details>').length - 1).toBe(1);
       expect(surplusOut.split('</details>').length - 1).toBe(1);
 
-      // A report ending inside an open code fence: the sanitizer must
-      // close the fence so the wrapper's </details> and the composer's
-      // footer are not swallowed as inert code text.
+      // A report ending inside an open code fence: a fence still open at
+      // EOF means the flat scanner diverged from GitHub's container-aware
+      // parser (which closes a list-nested fence at the container's end,
+      // not at EOF). Rather than guess and ship prose GitHub parses as
+      // live, emit_report degrades to the escaped-pre fallback through its
+      // non-zero-exit branch, announcing the cause with its own warning.
       const fence = join(dir, 'fence.md');
       writeFileSync(fence, '# Title\n\n```bash\ncode here\n');
-      const fenceOut = emit(fence, 45000);
-      expect(fenceOut).toContain('<summary>Verification report</summary>');
-      expect(fenceOut).toContain('code here');
-      // The wrapper balances: its </details> is outside the fence.
-      expect(fenceOut.split('<details>').length - 1).toBe(1);
-      expect(fenceOut.split('</details>').length - 1).toBe(1);
-      // The prose (outside code) contains the wrapper closer.
-      const fenceProse = stripCode(fenceOut);
-      expect(fenceProse).toContain('</details>');
+      const fenceProc = spawnSync(
+        'bash',
+        ['-c', `${helpers}\nemit_report "$1" 45000`, '_', fence],
+        { encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 },
+      );
+      expect(fenceProc.status).toBe(0);
+      expect(fenceProc.stdout).toContain('<pre><code>');
+      expect(fenceProc.stdout).toContain(
+        'Verification report (report.md, truncated)',
+      );
+      expect(fenceProc.stderr).toContain(
+        '::warning::emit_report fell back to escaped embedding (report ended inside an open code fence)',
+      );
+
+      // Container-axis hole the review reproduced: a fence nested in a list
+      // item, never explicitly closed. CommonMark closes it at the
+      // container's end but the flat scanner stays inFence to EOF, so before
+      // the fix the trailing unindented line shipped as prose GitHub parsed
+      // as live (mention, <img>, raw <a href>). The EOF-open fence now
+      // degrades to the escaped fallback. Red before the fix (output was
+      // sanitized markdown carrying a literal <img>/<a>, not the escaped
+      // pre), green after; the @mention is inert under the pre/code ancestor.
+      const listFence = join(dir, 'list-fence.md');
+      writeFileSync(
+        listFence,
+        [
+          '- step one:',
+          '',
+          '  ```bash',
+          '  npm test',
+          '',
+          'Back at top level: @everyone <img src=x onerror=alert(1)> <a href="https://evil.example/phish">click</a>',
+          '',
+        ].join('\n'),
+      );
+      const listOut = emit(listFence, 45000);
+      expect(listOut).toContain('<pre><code>');
+      expect(listOut).toContain('Verification report (report.md, truncated)');
+      expect(listOut).not.toContain('<img');
+      expect(listOut).not.toContain('<a href');
 
       // A NUL byte in the report is stripped (parity with emit_block's
       // tr -d '\000'); it must not reach the comment body.

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -1915,6 +1915,50 @@ describe('qwen-triage verify hardening', () => {
       expect(psOut).toContain('@&#8203;everyone');
       expect(psOut).not.toContain('@everyone');
 
+      // Backslash-escaped opening backtick (review Critical): CommonMark's
+      // escape rule consumes \` before the backticks rule runs, so it does
+      // NOT open a code span — but the raw-text backtick scanner still lets it
+      // CLOSE one. Before the fix proseLine paired the escaped backtick with a
+      // later one and shipped the gap as inert code, so GitHub rendered prose:
+      // a live <a href>, an un-defused @everyone, and a </details> that
+      // balance() never saw (it went through escCode), closing the wrapper
+      // early. The scanner now fails closed on an odd backslash run. Asserted
+      // on the RAW output (parser-independent): no live <a href>/<img>, the
+      // mention is ZWSP-defused, and the injected closer is dropped so the
+      // wrapper stays 1 open / 1 close.
+      const escBt = join(dir, 'esc-bt.md');
+      writeFileSync(
+        escBt,
+        'see \\` opts </details> @everyone <a href="https://evil.example/phish">Merge instructions</a> ` end\n',
+      );
+      const escBtOut = emit(escBt, 45000);
+      expect(escBtOut).not.toContain('<a href');
+      expect(escBtOut).not.toContain('<img');
+      expect(escBtOut).toContain('@&#8203;everyone');
+      expect(escBtOut).not.toContain('@everyone');
+      expect(escBtOut.split('<details>').length - 1).toBe(1);
+      expect(escBtOut.split('</details>').length - 1).toBe(1);
+
+      // Pre-escaped entities (review Medium): escProse restores the allowlist
+      // by round-tripping through &lt;, so before the fix it could not tell a
+      // &lt; it just produced from one the author typed — a literal
+      // &lt;details> in the report was promoted to a LIVE fold and a literal
+      // &lt;/details> was silently deleted by the surplus-closer drop. The
+      // sentinel now protects only the source's OWN raw tags, so author-typed
+      // entities stay escaped text: no forged fold, nothing deleted, wrapper
+      // stays 1 open / 1 close.
+      const ent = join(dir, 'entity.md');
+      writeFileSync(
+        ent,
+        'pre-escaped: &lt;/details> and &lt;details> and &lt;img src=x>\n',
+      );
+      const entOut = emit(ent, 45000);
+      expect(entOut).toContain('&lt;/details>');
+      expect(entOut).toContain('&lt;details>');
+      expect(entOut).toContain('&lt;img src=x>');
+      expect(entOut.split('<details>').length - 1).toBe(1);
+      expect(entOut.split('</details>').length - 1).toBe(1);
+
       // A NUL byte in the report is stripped (parity with emit_block's
       // tr -d '\000'); it must not reach the comment body.
       const nul = join(dir, 'nul.md');

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -1551,14 +1551,19 @@ describe('qwen-triage verify hardening', () => {
   // (the cap is applied AFTER escaping for exactly this reason).
   it('renders report.md as sanitized markdown with an escaped-pre fallback', () => {
     // #8140's verify comment displayed the whole curated bilingual report
-    // as a wall of raw markdown source inside <pre><code> — tables, bold
-    // markers, and literal <details> tags all rendered as text. report.md
-    // now renders as MARKDOWN, holding the same security floor: only
-    // structural tags un-escape, the comment-open token is broken so no
-    // forged qwen-triage:* marker can form in the RAW body the upsert
-    // greps, @ cannot fire mentions, and unbalanced folds are closed so a
-    // malformed report cannot swallow the footer. Oversized reports fall
-    // back to the escaped <pre> wholesale (cut markdown dangles fences).
+    // as a wall of raw markdown source inside <pre><code>. report.md now
+    // renders as MARKDOWN, wrapped in a collapsed <details> so it still
+    // costs one line in the conversation. A code-region-aware node sanitizer
+    // holds the security floor: CommonMark does NOT decode entities in code
+    // spans/fences, so escaping there would show &amp;&amp; / &lt;T&gt; in
+    // the very commands and types the report is read to copy — prose is
+    // escaped, code is left alone (inert under a code/pre ancestor), the
+    // comment-open token is broken EVERYWHERE so no forged qwen-triage:*
+    // marker survives in the RAW body the upsert greps, prose @ cannot fire
+    // mentions, and folds are balanced over prose only (a </details> quoted
+    // in code is inert) so a malformed report cannot swallow the footer or
+    // escape its wrapper. Oversized reports fall back to the escaped <pre>
+    // wholesale (cut markdown dangles fences).
     const publishStep = step('Post verification report comment');
     const body = publishStep.match(/run: \|-\n([\s\S]*)$/)?.[1];
     const script = body.replace(/^ {10}/gm, '');
@@ -1569,7 +1574,9 @@ describe('qwen-triage verify hardening', () => {
     expect(helpers).toContain('emit_report()');
     // Each fallback branch announces itself in the Actions log (mirroring
     // emit_block's failure warning) so a degradation to the escaped pre dump
-    // is attributable, not silent.
+    // is attributable, not silent. The fold-closer overhead is now budgeted
+    // inside the sanitized-size gate (closers land before it), so three
+    // warnings cover every degradation.
     expect(helpers).toContain(
       '::warning::emit_report fell back to escaped embedding (report exceeds size cap)',
     );
@@ -1579,13 +1586,36 @@ describe('qwen-triage verify hardening', () => {
     expect(helpers).toContain(
       '::warning::emit_report fell back to escaped embedding (sanitized output exceeds size cap)',
     );
-    expect(helpers).toContain(
-      '::warning::emit_report fell back to escaped embedding (fold-closer overhead exceeds size cap)',
-    );
     // The report call site uses the rendering path; the tmux lane keeps
     // its escaped embedding.
     expect(script).toContain('emit_report "$REPORT" 45000');
     expect(step('Post tmux result comment')).not.toContain('emit_report');
+
+    // Mirror the sanitizer's code-region model so security assertions test
+    // PROSE only: a live-looking tag inside a fence is inert code text, not
+    // a hole, so grepping the raw output would give false positives.
+    const stripCode = (s) => {
+      const kept = [];
+      let inFence = false;
+      let fc = '';
+      let fl = 0;
+      for (const line of s.split('\n')) {
+        if (!inFence) {
+          const m = line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
+          if (m && !(m[1][0] === '`' && m[2].includes('`'))) {
+            inFence = true;
+            fc = m[1][0];
+            fl = m[1].length;
+            continue;
+          }
+          kept.push(line.replace(/`[^`]*`/g, ''));
+        } else {
+          const cm = line.match(/^ {0,3}(`{3,}|~{3,})\s*$/);
+          if (cm && cm[1][0] === fc && cm[1].length >= fl) inFence = false;
+        }
+      }
+      return kept.join('\n');
+    };
 
     const dir = mkdtempSync(join(tmpdir(), 'verify-render-'));
     try {
@@ -1596,6 +1626,17 @@ describe('qwen-triage verify hardening', () => {
           '# Deep Verification — `merge-ready`',
           '',
           '**Verdict:** pass && <T<U>> ok',
+          '',
+          'Run `npm test && Map<string> @pkg` then check `a -> b`.',
+          '',
+          '```bash',
+          'npm run build && node probe.mjs --pkg @qwen-code/core',
+          '<img src=x onerror=alert(1)>',
+          'marker: <!-- qwen-triage:verify-state=running -->',
+          'fold-quote: </details>',
+          '```',
+          '',
+          '> a blockquote && more',
           '',
           '| scenario | match |',
           '| --- | --- |',
@@ -1626,28 +1667,75 @@ describe('qwen-triage verify hardening', () => {
       };
 
       const out = emit(report, 45000);
-      // Markdown structure survives (renders), instead of an escaped dump.
-      expect(out).toContain('### Verification report');
+      // Wrapped in a collapsed <details>; markdown structure survives inside.
+      expect(out).toContain(
+        '<details>\n<summary>Verification report</summary>',
+      );
       expect(out).toContain('| scenario | match |');
       expect(out).toContain('**Verdict:**');
-      expect(out).toContain('<details>');
       expect(out).toContain('<summary>中文摘要</summary>');
       expect(out).not.toContain('<pre><code>');
-      // Security floor: no live marker in the RAW body, no mention, no
-      // non-allowlisted tag, entities escaped.
-      expect(out).not.toContain('<!-- qwen-triage');
-      expect(out).not.toContain('@everyone');
-      expect(out).not.toContain('<img');
-      expect(out).toContain('&#64;everyone');
-      expect(out).toContain('&amp;&amp;');
-      expect(out).toContain('&lt;T&lt;U&gt;&gt;');
-      expect(out.match(/<(?!\/?(details|summary|pre|code|br)\b)[a-z]/g)).toBe(
-        null,
+      // Prose fidelity: && and blockquotes survive; a prose < is escaped
+      // (renders back to <), > is left alone.
+      expect(out).toContain('pass && &lt;T&lt;U>> ok');
+      expect(out).toContain('> a blockquote && more');
+      expect(out).not.toContain('&amp;&amp;');
+      // Code fidelity: spans and fences are untouched — no entity mangling
+      // of the commands/types/paths a reader copies, and a fenced <img> or
+      // </details> stays inert code text.
+      expect(out).toContain('`npm test && Map<string> @pkg`');
+      expect(out).toContain(
+        'npm run build && node probe.mjs --pkg @qwen-code/core',
       );
-      // The unclosed fold is balanced so the footer cannot be swallowed.
-      const opens = out.split('<details>').length - 1;
-      const closes = out.split('</details>').length - 1;
+      expect(out).toContain('<img src=x onerror=alert(1)>');
+      // Security floor over the WHOLE raw body: no live comment-open token
+      // anywhere (broken globally, prose AND code), so the upsert grep for
+      // the running marker cannot be forged from a fenced quote.
+      expect(out).not.toContain('<!--');
+      // Security floor over PROSE: the mention is neutralized, no live
+      // non-allowlisted tag, and prose folds balance (the fenced </details>
+      // is NOT counted, so the genuinely unclosed fold still gets closed).
+      const prose = stripCode(out);
+      expect(prose).not.toContain('@everyone');
+      expect(prose).toContain('&#64;everyone');
+      expect(prose).not.toContain('<img');
+      expect(prose.match(/<(?!\/?(details|summary)\b)[A-Za-z]/g)).toBe(null);
+      const opens = prose.split('<details>').length - 1;
+      const closes = prose.split('</details>').length - 1;
       expect(opens).toBe(closes);
+
+      // Guarantee 4, the hole the review reproduced: one genuinely unclosed
+      // fold plus a fenced block quoting </details>. The fenced closer is
+      // inert code and must NOT balance the live fold — the prose folds
+      // still net to zero only because a closer is appended for the open.
+      const hole = join(dir, 'hole.md');
+      writeFileSync(
+        hole,
+        '<details>\n<summary>fold that never closes</summary>\n\n```html\n</details>\n```\n',
+      );
+      const holeOut = emit(hole, 45000);
+      const holeProse = stripCode(holeOut);
+      expect(holeProse.split('<details>').length).toBe(
+        holeProse.split('</details>').length,
+      );
+
+      // Mirror case: a surplus </details> with no open is dropped so it
+      // cannot close the wrapping fold early — the wrapper stays 1 open /
+      // 1 close even though the report shipped an orphan closer.
+      const surplus = join(dir, 'surplus.md');
+      writeFileSync(surplus, 'text </details> more\n');
+      const surplusOut = emit(surplus, 45000);
+      expect(surplusOut).toContain('text  more');
+      expect(surplusOut.split('<details>').length - 1).toBe(1);
+      expect(surplusOut.split('</details>').length - 1).toBe(1);
+
+      // A NUL byte in the report is stripped (parity with emit_block's
+      // tr -d '\000'); it must not reach the comment body.
+      const nul = join(dir, 'nul.md');
+      writeFileSync(nul, 'before\u0000after\n');
+      const nulOut = emit(nul, 45000);
+      expect(nulOut).toContain('beforeafter');
+      expect(nulOut).not.toContain('\u0000');
 
       // Oversize → wholesale fallback to the escaped pre embedding.
       const big = join(dir, 'big.md');
@@ -1656,18 +1744,18 @@ describe('qwen-triage verify hardening', () => {
       expect(fb).toContain('<pre><code>');
       expect(fb).toContain('Verification report (report.md, truncated)');
 
-      // Inflation: raw under the cap but sanitized over it (& -> &amp;).
+      // Inflation: raw under the cap but sanitized over it. & is no longer
+      // escaped (it is not a security control), so < drives the inflation —
+      // each < becomes the 4-byte &lt;.
       const dense = join(dir, 'dense.md');
-      writeFileSync(dense, '&'.repeat(44000));
+      writeFileSync(dense, '<'.repeat(12000));
       const inflated = emit(dense, 45000);
       expect(inflated).toContain('<pre><code>');
       expect(inflated).toContain('Verification report (report.md, truncated)');
 
-      // The fold-counting greps carry `|| true` because grep exits 1 on zero
-      // matches, which under the step's real `set -euo pipefail` would abort
-      // the whole composer for a fold-free report. `emit` spawns without
-      // pipefail, so exercise that path explicitly: a zero-fold report under
-      // pipefail must still exit 0 and render.
+      // The sanitizer runs under the step's real `set -euo pipefail`; a
+      // fold-free report must still exit 0 and render (no grep whose
+      // zero-match exit could abort the composer).
       const nofolds = join(dir, 'nofolds.md');
       writeFileSync(nofolds, '## heading\nbody text\n');
       const pf = spawnSync(
@@ -1681,15 +1769,15 @@ describe('qwen-triage verify hardening', () => {
         { encoding: 'utf8' },
       );
       expect(pf.status).toBe(0);
-      expect(pf.stdout).toContain('### Verification report');
+      expect(pf.stdout).toContain('<summary>Verification report</summary>');
       expect(pf.stdout).toContain('## heading');
 
-      // The balancing loop appends `opens - closes` closers AFTER the size
-      // gate passes, so a report dense in unbalanced <details> opens must
-      // fall back to the capped pre dump once the closer overhead would
-      // exceed the budget — rather than shipping a section over the cap.
-      // 100 opens: raw ~1000 B and sanitized ~1000 B both clear max=2000,
-      // but 1000 + 100*11 + 30 > 2000 forces the fallback.
+      // Appended fold closers land in the sanitized output BEFORE the size
+      // gate, so a report dense in unbalanced <details> opens falls back to
+      // the capped pre dump once the closers push the wrapped section over
+      // the budget — rather than shipping a section over the cap.
+      // 100 opens: raw ~900 B clears max=2000, but 900 + 100*11 closers +
+      // the ~61 B wrapper > 2000 forces the fallback.
       const folds = join(dir, 'folds.md');
       writeFileSync(folds, '<details>\n'.repeat(100));
       const over = emit(folds, 2000);
@@ -2815,10 +2903,11 @@ describe('qwen-triage verify publish fidelity', () => {
           expect(assertZh).toBeLessThan(detailsEnd);
         }
         // The report section stays outside the Chinese fold — now rendered
-        // as markdown under its own heading, not an escaped <pre> dump.
-        expect(body.indexOf('### Verification report')).toBeGreaterThan(
-          detailsEnd,
-        );
+        // as markdown inside its own collapsed <details>, not an escaped
+        // <pre> dump and not a 45 KB wall in the conversation.
+        expect(
+          body.indexOf('<summary>Verification report</summary>'),
+        ).toBeGreaterThan(detailsEnd);
         expect(body).toContain('## real report');
       } finally {
         rmSync(dir, { recursive: true, force: true });

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -1599,15 +1599,18 @@ describe('qwen-triage verify hardening', () => {
       let inFence = false;
       let fc = '';
       let fl = 0;
+      let inHtml = false;
       for (const line of s.split('\n')) {
         if (!inFence) {
-          const m = line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
+          if (inHtml && /^\s*$/.test(line)) inHtml = false;
+          const m = inHtml ? null : line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
           if (m && !(m[1][0] === '`' && m[2].includes('`'))) {
             inFence = true;
             fc = m[1][0];
             fl = m[1].length;
             continue;
           }
+          if (/^ {0,3}<\/?(details|summary)\b/.test(line)) inHtml = true;
           kept.push(line.replace(/`[^`]*`/g, ''));
         } else {
           const cm = line.match(/^ {0,3}(`{3,}|~{3,})\s*$/);
@@ -1692,12 +1695,14 @@ describe('qwen-triage verify hardening', () => {
       // anywhere (broken globally, prose AND code), so the upsert grep for
       // the running marker cannot be forged from a fenced quote.
       expect(out).not.toContain('<!--');
-      // Security floor over PROSE: the mention is neutralized, no live
-      // non-allowlisted tag, and prose folds balance (the fenced </details>
-      // is NOT counted, so the genuinely unclosed fold still gets closed).
+      // Security floor over PROSE: the mention is neutralized by a ZWSP
+      // (GitHub decodes &#64; before the mention filter, so the entity alone
+      // was inert), no live non-allowlisted tag, and prose folds balance
+      // (the fenced </details> is NOT counted, so the genuinely unclosed
+      // fold still gets closed).
       const prose = stripCode(out);
       expect(prose).not.toContain('@everyone');
-      expect(prose).toContain('&#64;everyone');
+      expect(prose).toContain('@&#8203;everyone');
       expect(prose).not.toContain('<img');
       expect(prose.match(/<(?!\/?(details|summary)\b)[A-Za-z]/g)).toBe(null);
       const opens = prose.split('<details>').length - 1;
@@ -1717,6 +1722,32 @@ describe('qwen-triage verify hardening', () => {
       const holeProse = stripCode(holeOut);
       expect(holeProse.split('<details>').length).toBe(
         holeProse.split('</details>').length,
+      );
+
+      // HTML-block divergence: a fence opener inside a <details> HTML
+      // block is literal text per CommonMark/GitHub, not a fence. The
+      // sanitizer must prose-escape the content (neutralizing <img>)
+      // rather than passing it through escCode as inert code.
+      const htmlblk = join(dir, 'htmlblk.md');
+      writeFileSync(
+        htmlblk,
+        [
+          '<details>',
+          '<summary>fold</summary>',
+          '```',
+          '<img src=x onerror=alert(1)>',
+          '```',
+          '</details>',
+          '',
+        ].join('\n'),
+      );
+      const htmlOut = emit(htmlblk, 45000);
+      // The <img> is prose-escaped, not passed through as inert code.
+      expect(htmlOut).toContain('&lt;img src=x onerror=alert(1)>');
+      expect(htmlOut).not.toContain('<img');
+      // The fold balances: wrapper 1 open / 1 close, report fold balanced.
+      expect(htmlOut.split('<details>').length - 1).toBe(
+        htmlOut.split('</details>').length - 1,
       );
 
       // Mirror case: a surplus </details> with no open is dropped so it

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -1549,6 +1549,102 @@ describe('qwen-triage verify hardening', () => {
   // tests do not cover it. Execute it: hostile content must stay literal,
   // and the escaped body must land under GitHub's 65,536-char comment cap
   // (the cap is applied AFTER escaping for exactly this reason).
+  it('renders report.md as sanitized markdown with an escaped-pre fallback', () => {
+    // #8140's verify comment displayed the whole curated bilingual report
+    // as a wall of raw markdown source inside <pre><code> — tables, bold
+    // markers, and literal <details> tags all rendered as text. report.md
+    // now renders as MARKDOWN, holding the same security floor: only
+    // structural tags un-escape, the comment-open token is broken so no
+    // forged qwen-triage:* marker can form in the RAW body the upsert
+    // greps, @ cannot fire mentions, and unbalanced folds are closed so a
+    // malformed report cannot swallow the footer. Oversized reports fall
+    // back to the escaped <pre> wholesale (cut markdown dangles fences).
+    const publishStep = step('Post verification report comment');
+    const body = publishStep.match(/run: \|-\n([\s\S]*)$/)?.[1];
+    const script = body.replace(/^ {10}/gm, '');
+    const helpers = script.slice(
+      script.indexOf('html_escape()'),
+      script.indexOf('EVIDENCE_SECTION='),
+    );
+    expect(helpers).toContain('emit_report()');
+    // The report call site uses the rendering path; the tmux lane keeps
+    // its escaped embedding.
+    expect(script).toContain('emit_report "$REPORT" 45000');
+    expect(step('Post tmux result comment')).not.toContain('emit_report');
+
+    const dir = mkdtempSync(join(tmpdir(), 'verify-render-'));
+    try {
+      const report = join(dir, 'report.md');
+      writeFileSync(
+        report,
+        [
+          '# Deep Verification — `merge-ready`',
+          '',
+          '**Verdict:** pass && <T<U>> ok',
+          '',
+          '| scenario | match |',
+          '| --- | --- |',
+          '| success | ✅ |',
+          '',
+          '<details>',
+          '<summary>中文摘要</summary>',
+          '',
+          '- 结论：通过 @everyone <img src=x onerror=alert(1)>',
+          '- marker: <!-- qwen-triage:verify -->',
+          '',
+          '</details>',
+          '',
+          '<details>',
+          '<summary>unclosed fold</summary>',
+          'tail',
+          '',
+        ].join('\n'),
+      );
+      const emit = (file, max) => {
+        const proc = spawnSync(
+          'bash',
+          ['-c', `${helpers}\nemit_report "$1" ${max}`, '_', file],
+          { encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 },
+        );
+        expect(proc.status).toBe(0);
+        return proc.stdout;
+      };
+
+      const out = emit(report, 45000);
+      // Markdown structure survives (renders), instead of an escaped dump.
+      expect(out).toContain('### Verification report');
+      expect(out).toContain('| scenario | match |');
+      expect(out).toContain('**Verdict:**');
+      expect(out).toContain('<details>');
+      expect(out).toContain('<summary>中文摘要</summary>');
+      expect(out).not.toContain('<pre><code>');
+      // Security floor: no live marker in the RAW body, no mention, no
+      // non-allowlisted tag, entities escaped.
+      expect(out).not.toContain('<!-- qwen-triage');
+      expect(out).not.toContain('@everyone');
+      expect(out).not.toContain('<img');
+      expect(out).toContain('&#64;everyone');
+      expect(out).toContain('&amp;&amp;');
+      expect(out).toContain('&lt;T&lt;U&gt;&gt;');
+      expect(out.match(/<(?!\/?(details|summary|pre|code|br)\b)[a-z]/g)).toBe(
+        null,
+      );
+      // The unclosed fold is balanced so the footer cannot be swallowed.
+      const opens = out.split('<details>').length - 1;
+      const closes = out.split('</details>').length - 1;
+      expect(opens).toBe(closes);
+
+      // Oversize → wholesale fallback to the escaped pre embedding.
+      const big = join(dir, 'big.md');
+      writeFileSync(big, `x${'y'.repeat(46000)}`);
+      const fb = emit(big, 45000);
+      expect(fb).toContain('<pre><code>');
+      expect(fb).toContain('Verification report (report.md, truncated)');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('escapes and size-caps the verify report body', () => {
     const publishStep = step('Post verification report comment');
     const body = publishStep.match(/run: \|-\n([\s\S]*)$/)?.[1];
@@ -2663,10 +2759,12 @@ describe('qwen-triage verify publish fidelity', () => {
           expect(assertZh).toBeGreaterThan(details);
           expect(assertZh).toBeLessThan(detailsEnd);
         }
-        // The report block stays outside the Chinese fold.
-        expect(body.indexOf('Verification report (report.md)')).toBeGreaterThan(
+        // The report section stays outside the Chinese fold — now rendered
+        // as markdown under its own heading, not an escaped <pre> dump.
+        expect(body.indexOf('### Verification report')).toBeGreaterThan(
           detailsEnd,
         );
+        expect(body).toContain('## real report');
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -1729,6 +1729,21 @@ describe('qwen-triage verify hardening', () => {
       expect(surplusOut.split('<details>').length - 1).toBe(1);
       expect(surplusOut.split('</details>').length - 1).toBe(1);
 
+      // A report ending inside an open code fence: the sanitizer must
+      // close the fence so the wrapper's </details> and the composer's
+      // footer are not swallowed as inert code text.
+      const fence = join(dir, 'fence.md');
+      writeFileSync(fence, '# Title\n\n```bash\ncode here\n');
+      const fenceOut = emit(fence, 45000);
+      expect(fenceOut).toContain('<summary>Verification report</summary>');
+      expect(fenceOut).toContain('code here');
+      // The wrapper balances: its </details> is outside the fence.
+      expect(fenceOut.split('<details>').length - 1).toBe(1);
+      expect(fenceOut.split('</details>').length - 1).toBe(1);
+      // The prose (outside code) contains the wrapper closer.
+      const fenceProse = stripCode(fenceOut);
+      expect(fenceProse).toContain('</details>');
+
       // A NUL byte in the report is stripped (parity with emit_block's
       // tr -d '\000'); it must not reach the comment body.
       const nul = join(dir, 'nul.md');
@@ -1783,6 +1798,27 @@ describe('qwen-triage verify hardening', () => {
       const over = emit(folds, 2000);
       expect(over).toContain('<pre><code>');
       expect(over).toContain('Verification report (report.md, truncated)');
+
+      // Sanitizer crash → escaped-pre fallback. Override node so the
+      // sanitizer's `node -e` fails; emit_block's own node call has a
+      // head -c fallback so the escaped output still renders.
+      const crash = join(dir, 'crash.md');
+      writeFileSync(crash, '# crash report\n\nbody text\n');
+      const crashProc = spawnSync(
+        'bash',
+        [
+          '-c',
+          `node() { return 1; }\n${helpers}\nemit_report "$1" 45000`,
+          '_',
+          crash,
+        ],
+        { encoding: 'utf8' },
+      );
+      expect(crashProc.status).toBe(0);
+      expect(crashProc.stdout).toContain('<pre><code>');
+      expect(crashProc.stdout).toContain(
+        'Verification report (report.md, truncated)',
+      );
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -1603,6 +1603,7 @@ describe('qwen-triage verify hardening', () => {
       for (const line of s.split('\n')) {
         if (!inFence) {
           if (inHtml && /^\s*$/.test(line)) inHtml = false;
+          const wasHtml = inHtml;
           const m = inHtml ? null : line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
           if (m && !(m[1][0] === '`' && m[2].includes('`'))) {
             inFence = true;
@@ -1610,8 +1611,8 @@ describe('qwen-triage verify hardening', () => {
             fl = m[1].length;
             continue;
           }
-          if (/^ {0,3}<\/?(details|summary)\b/.test(line)) inHtml = true;
-          kept.push(line.replace(/`[^`]*`/g, ''));
+          if (/^\s*<\/?(details|summary)\b/.test(line)) inHtml = true;
+          kept.push(wasHtml ? line : line.replace(/`[^`]*`/g, ''));
         } else {
           const cm = line.match(/^ {0,3}(`{3,}|~{3,})\s*$/);
           if (cm && cm[1][0] === fc && cm[1].length >= fl) inFence = false;
@@ -1749,6 +1750,50 @@ describe('qwen-triage verify hardening', () => {
       expect(htmlOut.split('<details>').length - 1).toBe(
         htmlOut.split('</details>').length - 1,
       );
+
+      // Code-span divergence: a backtick code span inside a <details>
+      // HTML block is literal text per CommonMark/GitHub, not code.
+      // The sanitizer must prose-escape the whole line (neutralizing
+      // <img>) rather than splitting it through proseLine and passing
+      // the span through escCode as inert code.
+      const codespan = join(dir, 'codespan.md');
+      writeFileSync(
+        codespan,
+        [
+          '<details>',
+          '<summary>fold</summary>',
+          'text `<img src=x onerror=alert(1)>` more',
+          '</details>',
+          '',
+        ].join('\n'),
+      );
+      const csOut = emit(codespan, 45000);
+      expect(csOut).toContain('&lt;img src=x onerror=alert(1)>');
+      expect(csOut).not.toContain('<img');
+      expect(csOut.split('<details>').length - 1).toBe(
+        csOut.split('</details>').length - 1,
+      );
+      const csProse = stripCode(csOut);
+      expect(csProse).not.toContain('<img');
+
+      // Indented fold: a <details> nested in a list (indent >= 4) must
+      // enter the inHtml state too — GitHub opens HTML blocks relative
+      // to the list-item content column, not just at column 0-3.
+      const indented = join(dir, 'indented.md');
+      writeFileSync(
+        indented,
+        [
+          '- list item',
+          '    <details>',
+          '    <summary>fold</summary>',
+          '    text `<img src=x>` more',
+          '    </details>',
+          '',
+        ].join('\n'),
+      );
+      const indOut = emit(indented, 45000);
+      expect(indOut).toContain('&lt;img src=x>');
+      expect(indOut).not.toContain('<img');
 
       // Mirror case: a surplus </details> with no open is dropped so it
       // cannot close the wrapping fold early — the wrapper stays 1 open /

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -1824,7 +1824,7 @@ describe('qwen-triage verify hardening', () => {
       expect(fenceProc.status).toBe(0);
       expect(fenceProc.stdout).toContain('<pre><code>');
       expect(fenceProc.stdout).toContain(
-        'Verification report (report.md, truncated)',
+        'Verification report (report.md, escaped fallback)',
       );
       expect(fenceProc.stderr).toContain(
         '::warning::emit_report fell back to escaped embedding (report ended inside an open code fence)',
@@ -1853,9 +1853,67 @@ describe('qwen-triage verify hardening', () => {
       );
       const listOut = emit(listFence, 45000);
       expect(listOut).toContain('<pre><code>');
-      expect(listOut).toContain('Verification report (report.md, truncated)');
+      expect(listOut).toContain(
+        'Verification report (report.md, escaped fallback)',
+      );
       expect(listOut).not.toContain('<img');
       expect(listOut).not.toContain('<a href');
+
+      // Container-axis hole with a BALANCING closer (review hole #2 / the
+      // inline Critical): the list-nested fence opens indented, column-0
+      // prose follows, then a column-0 fence marker balances the flat
+      // scanner so it reaches EOF with inFence false — the old EOF guard
+      // never fired and the unescaped prose (mention, <img>, raw <a href>)
+      // shipped. The dedent guard now exits non-zero the moment a non-blank
+      // line dedents below the fence opener's indent. Asserted on the RAW
+      // output (parser-independent): the fallback is the escaped pre, so no
+      // live <img>/<a href> reaches the body and the @mention is inert under
+      // the pre/code ancestor.
+      const listFenceClosed = join(dir, 'list-fence-closed.md');
+      writeFileSync(
+        listFenceClosed,
+        [
+          '- step one:',
+          '',
+          '  ```bash',
+          '  npm test',
+          '',
+          'Back at top level: @everyone <img src=x onerror=alert(1)> <a href="https://evil.example/phish">click</a>',
+          '',
+          '```',
+          'after',
+          '',
+        ].join('\n'),
+      );
+      const lfcOut = emit(listFenceClosed, 45000);
+      expect(lfcOut).toContain('<pre><code>');
+      expect(lfcOut).toContain(
+        'Verification report (report.md, escaped fallback)',
+      );
+      expect(lfcOut).not.toContain('<img');
+      expect(lfcOut).not.toContain('<a href');
+
+      // Paragraph-spanning code span (review hole #1): CommonMark matches a
+      // code span across the lines of a paragraph, but proseLine matches per
+      // line. An unmatched backtick run on one line flips the parity for the
+      // rest of the paragraph, so the span the sanitizer classified as code
+      // was prose to GitHub — a live <img>/@everyone shipped before the fix.
+      // The scanner now fails closed: an unmatched run prose-escapes the rest
+      // of the paragraph. Asserted on the RAW output (parser-independent)
+      // rather than through stripCode, which mirrors the sanitizer's own
+      // line-scoped model and so cannot see this divergence.
+      const paraSpan = join(dir, 'para-span.md');
+      writeFileSync(
+        paraSpan,
+        ['A `hint about --flag', 'See `<img src=x> @everyone` here', ''].join(
+          '\n',
+        ),
+      );
+      const psOut = emit(paraSpan, 45000);
+      expect(psOut).toContain('&lt;img src=x>');
+      expect(psOut).not.toContain('<img');
+      expect(psOut).toContain('@&#8203;everyone');
+      expect(psOut).not.toContain('@everyone');
 
       // A NUL byte in the report is stripped (parity with emit_block's
       // tr -d '\000'); it must not reach the comment body.
@@ -1930,7 +1988,7 @@ describe('qwen-triage verify hardening', () => {
       expect(crashProc.status).toBe(0);
       expect(crashProc.stdout).toContain('<pre><code>');
       expect(crashProc.stdout).toContain(
-        'Verification report (report.md, truncated)',
+        'Verification report (report.md, escaped fallback)',
       );
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -1640,6 +1640,13 @@ describe('qwen-triage verify hardening', () => {
       const fb = emit(big, 45000);
       expect(fb).toContain('<pre><code>');
       expect(fb).toContain('Verification report (report.md, truncated)');
+
+      // Inflation: raw under the cap but sanitized over it (& -> &amp;).
+      const dense = join(dir, 'dense.md');
+      writeFileSync(dense, '&'.repeat(44000));
+      const inflated = emit(dense, 45000);
+      expect(inflated).toContain('<pre><code>');
+      expect(inflated).toContain('Verification report (report.md, truncated)');
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -1567,6 +1567,21 @@ describe('qwen-triage verify hardening', () => {
       script.indexOf('EVIDENCE_SECTION='),
     );
     expect(helpers).toContain('emit_report()');
+    // Each fallback branch announces itself in the Actions log (mirroring
+    // emit_block's failure warning) so a degradation to the escaped pre dump
+    // is attributable, not silent.
+    expect(helpers).toContain(
+      '::warning::emit_report fell back to escaped embedding (report exceeds size cap)',
+    );
+    expect(helpers).toContain(
+      '::warning::emit_report fell back to escaped embedding (sanitize failed)',
+    );
+    expect(helpers).toContain(
+      '::warning::emit_report fell back to escaped embedding (sanitized output exceeds size cap)',
+    );
+    expect(helpers).toContain(
+      '::warning::emit_report fell back to escaped embedding (fold-closer overhead exceeds size cap)',
+    );
     // The report call site uses the rendering path; the tmux lane keeps
     // its escaped embedding.
     expect(script).toContain('emit_report "$REPORT" 45000');


### PR DESCRIPTION
## Problem

The sandboxed-verification comment embeds `report.md` inside `<details><pre><code>` with full HTML escaping. Secure, but unreadable: the report is a curated bilingual markdown document — tables, headings, nested `<details>` folds — and the pre/code embedding displays it as a wall of raw source. [#8140's verify comment](https://github.com/QwenLM/qwen-code/pull/8140#issuecomment-5131809819) is the exhibit: literal `**` asterisks, table pipes, `&lt;details&gt;` tag text, and `&amp;&amp;` remnants — what a reader perceives as 乱码.

## Change

`report.md` now renders as **markdown** via a new `emit_report`, holding the same security floor with four line-independent guarantees:

1. **Tag allowlist** — every `& < >` is escaped, then only the structural tags the report legitimately uses (`details`/`summary`/`pre`/`code`/`br`) are un-escaped back to live tags. No other tag can form: `<img>`, `<script>`, `onerror` never render.
2. **Marker forgery broken** — the comment-open token is neutralized (the autofix-proven `<!--` breaker), so no forged `qwen-triage:*` marker can appear in the **raw body** that the upsert/snapshot logic greps.
3. **Mentions defused** — `@` becomes `&#64;`: renders identically, can never ping.
4. **Fold balancing** — unbalanced `<details>` opens are counted and closed at the end, so a malformed report cannot swallow the comment footer.

Fallbacks: an **oversized** report (>45 KB) goes through the old escaped-`pre` embedding wholesale — truncated markdown dangles fences and folds — and so does any sanitizer pipeline failure. The tmux lane's raw-log embedding is untouched (escaped pre remains the right shape for logs).

One robustness fix surfaced by the test suite: the fold-balancer's zero-match `grep` carries `|| true`, since under the step's `pipefail` a report with no folds would otherwise kill the whole composer.

## Tests

A behavioral replay drives the real `emit_report` against a structural + hostile fixture:
- structure survives — tables, bold, nested folds render; no `<pre><code>` on the normal path;
- security floor holds — no live `<!-- qwen-triage` in the raw output, no `@everyone`, no `<img>`, entities escaped, only allowlisted tags present, folds balanced;
- oversize falls back to the escaped shape with the truncated summary;
- the report call site uses `emit_report` while the tmux lane keeps `emit_block`.

Full-render ordering pin updated to the new `### Verification report` heading. 108/108 pass; workflow YAML parses.

<details>
<summary>中文说明</summary>

## 问题

沙箱验证评论把 `report.md` 整体 HTML 转义后塞进 `<details><pre><code>`。安全，但不可读：报告本身是精排的双语 markdown 文档（表格、标题、嵌套折叠），pre/code 嵌入让它以纯源码形态显示——[#8140 的验证评论](https://github.com/QwenLM/qwen-code/pull/8140#issuecomment-5131809819)即实例：裸露的 `**` 星号、表格管道符、`&lt;details&gt;` 标签文本、`&amp;&amp;` 实体残留，读者看到的就是乱码。

## 改动

`report.md` 改经新的 `emit_report` 以 **markdown 渲染**，通过四条与行无关的保证维持同等安全底线：**标签白名单**（全量转义后仅回解 `details`/`summary`/`pre`/`code`/`br`，其余标签永远无法成形）；**标记伪造打断**（沿用 autofix 已验证的 `<!--` 中和手法，upsert 逻辑 grep 的原始 body 中不可能出现伪造的 `qwen-triage:*` 标记）；**提及熄火**（`@`→`&#64;`，显示相同、永不触发）；**折叠配平**（统计并补齐未闭合的 `<details>`，畸形报告吞不掉页脚）。

回退：超限（>45 KB）报告整体走旧的转义 pre 嵌入（截断的 markdown 会悬挂围栏与折叠），净化管道失败同样回退。tmux 原始日志嵌入保持不动（对日志而言转义 pre 本就是正确形态）。

测试套件揪出一个健壮性问题：折叠配平的零匹配 `grep` 需要 `|| true`——在步骤的 `pipefail` 下，无折叠的报告会导致整个组装器退出。

## 测试

行为回放驱动真实 `emit_report`（结构+敌意混合 fixture）：结构存活（表格/加粗/嵌套折叠渲染、常规路径无 pre/code）；安全底线成立（原始输出无活标记/提及/标签、实体转义、折叠配平）；超限回退到转义形态；报告调用点用 `emit_report` 而 tmux 通道保持 `emit_block`。全渲染顺序 pin 更新为新标题。108/108 通过；YAML 解析正常。

</details>
