### PR TITLE
fix(test): allow slow permission mode E2E responses

### DIFF
--- a/integration-tests/sdk-typescript/permission-control.test.ts
+++ b/integration-tests/sdk-typescript/permission-control.test.ts
@@ -34,7 +34,7 @@ import {
   createResultWaiter,
 } from './test-helper.js';
 
-const TEST_TIMEOUT = process.env['CI'] ? 60000 : 30000;
+const TEST_TIMEOUT = 60000;
 const SHARED_TEST_OPTIONS = createSharedTestOptions();
 
 /**
@@ -460,7 +460,7 @@ describe('Permission Control (E2E)', () => {
           new Promise((_, reject) =>
             setTimeout(
               () => reject(new Error('Timeout waiting for first response')),
-              10000,
+              TEST_TIMEOUT,
             ),
           ),
         ]);
@@ -476,7 +476,7 @@ describe('Permission Control (E2E)', () => {
           new Promise((_, reject) =>
             setTimeout(
               () => reject(new Error('Timeout waiting for second response')),
-              10000,
+              TEST_TIMEOUT,
             ),
           ),
         ]);


### PR DESCRIPTION
## What this PR does

This PR gives permission-control SDK E2E tests enough time for real model turns to complete and makes the dynamic `yolo` to `plan` permission-mode test use the shared response timeout instead of a fixed ten-second limit.

## Why it's needed

The test failed on main while waiting for its first model response, before the permission mode was changed. Local reproduction also showed that the second turn can exceed thirty seconds. These response times are normal for live-model E2E coverage, so the shorter limits caused false failures rather than detecting a permission-control regression.

## Reviewer Test Plan

### How to verify

Run the targeted permission-mode E2E test with retries disabled and confirm that both turns complete and the test passes. The verification run completed in 54.47 seconds, demonstrating why the previous ten-second and local thirty-second limits were insufficient.

```bash
env QWEN_SANDBOX=false KEEP_OUTPUT=true npx vitest run --root ./integration-tests --poolOptions.threads.maxThreads 1 --retry 0 sdk-typescript/permission-control.test.ts -t 'should change permission mode from yolo to plan' --reporter verbose
```

Expected result: one test passes without retrying.

### Evidence (Before & After)

Before: the live-model test timed out while waiting for a response, including three consecutive failures against the ten-second limit in CI and a local failure against the thirty-second limit.

After: the targeted test passes with retries disabled in 54.47 seconds.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS, no sandbox, built `dist/cli.js`, live SDK E2E model calls.

## Risk & Scope

- Main risk or tradeoff: genuinely stuck model calls take longer to fail, up to sixty seconds per response wait.
- Not validated / out of scope: the full integration suite and Windows/Linux execution were not run locally.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

本 PR 为 permission-control SDK E2E 测试中的真实模型轮次提供足够的完成时间，并让动态 `yolo` 到 `plan` 权限模式切换测试使用共享响应超时，而不是固定的十秒限制。

## Why it's needed

该测试在 main 上等待第一次模型响应时失败，尚未执行权限模式切换。本地复现还表明第二轮响应可能超过三十秒。对于真实模型 E2E 覆盖，这类响应时延属于正常情况，因此较短的限制会造成误报，而不是检测出 permission-control 回归。

## Reviewer Test Plan

### How to verify

关闭重试运行目标权限模式 E2E 测试，确认两轮响应均完成且测试通过。验证运行耗时 54.47 秒，说明此前十秒和本地三十秒的限制不足。

```bash
env QWEN_SANDBOX=false KEEP_OUTPUT=true npx vitest run --root ./integration-tests --poolOptions.threads.maxThreads 1 --retry 0 sdk-typescript/permission-control.test.ts -t 'should change permission mode from yolo to plan' --reporter verbose
```

预期结果：一个测试在不重试的情况下通过。

### Evidence (Before & After)

修改前：真实模型测试在等待响应时超时，包括 CI 中连续三次触发十秒限制，以及本地触发三十秒限制。

修改后：目标测试在关闭重试的情况下通过，耗时 54.47 秒。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS、无 sandbox、使用已构建的 `dist/cli.js`、真实 SDK E2E 模型调用。

## Risk & Scope

- 主要风险或取舍：真正卡住的模型调用需要更长时间才会失败，每次响应等待最长六十秒。
- 未验证或超出范围：未在本地运行完整 integration suite，也未在 Windows/Linux 上执行。
- 破坏性变更或迁移说明：无。

## Linked Issues

N/A

</details>
