### PR TITLE
fix(acp): isolate workspace settings and context file resolution for worktree sessions

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -3351,6 +3351,12 @@ class QwenAgent implements Agent {
   >();
   private readonly pendingConfigCleanup = new Map<string, Set<Config>>();
   private readonly initializingConfigs = new Set<Config>();
+  /**
+   * Default cwd for settings handlers when the client does not supply one.
+   * Set to the worktree path when a session inside a worktree is created;
+   * falls back to `null` (meaning `process.cwd()`) for regular sessions.
+   */
+  private defaultSettingsCwd: string | null = null;
   private managedShuttingDown = false;
   private clientCapabilities: ClientCapabilities | undefined;
   private privateParentState:
@@ -3900,6 +3906,12 @@ class QwenAgent implements Agent {
       cleanupErrors.push(error);
     }
     this.sessions.delete(sessionId);
+    if (
+      session.worktreeCwd &&
+      session.worktreeCwd === this.defaultSettingsCwd
+    ) {
+      this.defaultSettingsCwd = null;
+    }
     if (cleanupErrors.length > 0) {
       debugLogger.warn(
         `Session ${sessionId} closed after ${cleanupErrors.length} cleanup failure(s): ${cleanupErrors
@@ -7237,7 +7249,7 @@ class QwenAgent implements Agent {
   ): Promise<Record<string, unknown>> {
     const requestedCwd =
       typeof params['cwd'] === 'string' ? params['cwd'] : undefined;
-    const cwd = requestedCwd || process.cwd();
+    const cwd = requestedCwd || this.defaultSettingsCwd || process.cwd();
     const SESSION_ID_RE = /^[0-9a-fA-F-]{32,36}$/;
 
     switch (method) {
@@ -11127,6 +11139,15 @@ class QwenAgent implements Agent {
 
     const session = new Session(sessionId, config, this.connection, settings);
     this.sessions.set(sessionId, session);
+
+    const targetDir = config.getTargetDir();
+    if (targetDir !== process.cwd()) {
+      session.worktreeCwd = targetDir;
+      this.defaultSettingsCwd = targetDir;
+    } else {
+      this.defaultSettingsCwd = null;
+    }
+
     this.initializingConfigs.delete(config);
     try {
       if (sessionData?.fileHistorySnapshots?.length) {

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -1333,6 +1333,14 @@ export class Session implements SessionContext {
    */
   pendingWorktreeNotice: string | null = null;
 
+  /**
+   * Absolute path to the worktree when this session operates inside one.
+   * Set by acpAgent after session creation; `null` for regular sessions.
+   * Read by `removeStoredSessionEntry` to clear the agent-level
+   * `defaultSettingsCwd` when the owning session closes.
+   */
+  worktreeCwd: string | null = null;
+
   /** One-shot model notice for background agents restored with the session. */
   pendingRecoveredAgentsNotice: string | null = null;
 

--- a/packages/cli/src/acp-integration/session/Session.worktree.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.worktree.test.ts
@@ -375,6 +375,20 @@ describe('Session.pendingWorktreeNotice', () => {
     expect(capturedMessages.length).toBeGreaterThanOrEqual(1);
   });
 
+  it('worktreeCwd defaults to null and can be set', () => {
+    const session = new Session(
+      SESSION_ID,
+      mockConfig,
+      mockClient,
+      mockSettings,
+    );
+
+    expect(session.worktreeCwd).toBeNull();
+
+    session.worktreeCwd = '/repo/.qwen/worktrees/feat';
+    expect(session.worktreeCwd).toBe('/repo/.qwen/worktrees/feat');
+  });
+
   // VP5: ordering contract when the worktree notice, system reminders, and a
   // continuation that leads with functionResponse parts all combine. Locks the
   // `[...functionResponses, worktreeNotice, ...systemReminders, ...]` order so

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -3712,6 +3712,10 @@ async function runQwenServeImpl(
       isWorkspaceTrusted: () => trustedWorkspace,
       assertGenerationOpen: () => primaryGenerationGuard.assertOpen(),
       contextFilename: contextFilenameForInit ?? 'QWEN.md',
+      resolveContextFile: (filename, ws) => ({
+        target: path.resolve(ws, filename),
+        effectiveWorkspace: ws,
+      }),
       statusProvider,
       workspaceProvidersStatusProvider,
       workspaceSkillsStatusProvider,

--- a/packages/cli/src/serve/workspace-service/__tests__/facade.test.ts
+++ b/packages/cli/src/serve/workspace-service/__tests__/facade.test.ts
@@ -2895,5 +2895,48 @@ describe('createDaemonWorkspaceService', () => {
         /parent.*resolves outside|parent.*workspace/i,
       );
     });
+
+    it('uses resolveContextFile when provided', async () => {
+      const worktreeDir = path.join(tmpDir, 'worktree');
+      await fs.mkdir(worktreeDir, { recursive: true });
+
+      const svc = createDaemonWorkspaceService(
+        makeDeps({
+          boundWorkspace: tmpDir,
+          contextFilename: 'QWEN.md',
+          resolveContextFile: (filename, _ws) => ({
+            target: path.resolve(worktreeDir, filename),
+            effectiveWorkspace: worktreeDir,
+          }),
+        }),
+      );
+
+      const result = await svc.initWorkspace(
+        makeCtx({ workspaceCwd: tmpDir }),
+        {},
+      );
+
+      expect(result.action).toBe('created');
+      expect(result.path).toBe(path.join(worktreeDir, 'QWEN.md'));
+      const stat = await fs.stat(result.path);
+      expect(stat.isFile()).toBe(true);
+    });
+
+    it('falls back to boundWorkspace without resolveContextFile', async () => {
+      const svc = createDaemonWorkspaceService(
+        makeDeps({
+          boundWorkspace: tmpDir,
+          contextFilename: 'QWEN.md',
+        }),
+      );
+
+      const result = await svc.initWorkspace(
+        makeCtx({ workspaceCwd: tmpDir }),
+        {},
+      );
+
+      expect(result.action).toBe('created');
+      expect(result.path).toBe(path.join(tmpDir, 'QWEN.md'));
+    });
   });
 });

--- a/packages/cli/src/serve/workspace-service/index.ts
+++ b/packages/cli/src/serve/workspace-service/index.ts
@@ -215,6 +215,7 @@ export function createDaemonWorkspaceService(
     isWorkspaceTrusted,
     assertGenerationOpen,
     contextFilename,
+    resolveContextFile,
     statusProvider,
     workspaceProvidersStatusProvider,
     workspaceSkillsStatusProvider,
@@ -978,18 +979,25 @@ export function createDaemonWorkspaceService(
       assertActiveGeneration();
       // Resolve the context filename against the workspace root.
       const filename = contextFilename;
-      const target = path.resolve(boundWorkspace, filename);
+      const resolved = resolveContextFile
+        ? resolveContextFile(filename, boundWorkspace)
+        : {
+            target: path.resolve(boundWorkspace, filename),
+            effectiveWorkspace: boundWorkspace,
+          };
+      const target = resolved.target;
+      const effectiveWorkspace = resolved.effectiveWorkspace;
 
       // Textual boundary check: reject paths that escape the workspace.
       const withinWorkspace =
-        target === boundWorkspace ||
-        target.startsWith(boundWorkspace + path.sep);
+        target === effectiveWorkspace ||
+        target.startsWith(effectiveWorkspace + path.sep);
       if (!withinWorkspace) {
-        throw new WorkspaceInitPathEscapeError(filename, boundWorkspace);
+        throw new WorkspaceInitPathEscapeError(filename, effectiveWorkspace);
       }
 
       // Symlink check on parent path: canonicalize and verify.
-      const wsCanonical = await fs.realpath(boundWorkspace);
+      const wsCanonical = await fs.realpath(effectiveWorkspace);
       const parentCanonical = await canonicalizeExistingAncestor(
         path.dirname(target),
       );

--- a/packages/cli/src/serve/workspace-service/types.ts
+++ b/packages/cli/src/serve/workspace-service/types.ts
@@ -426,6 +426,17 @@ export interface DaemonWorkspaceServiceDeps {
   contextFilename: string;
 
   /**
+   * Optional resolver for the context file path. When provided, `initWorkspace`
+   * uses it to compute the target path and effective workspace root instead of
+   * resolving against `boundWorkspace` directly. This allows worktree-aware
+   * resolution where the context file lives in the worktree, not the project root.
+   */
+  resolveContextFile?: (
+    filename: string,
+    boundWorkspace: string,
+  ) => { target: string; effectiveWorkspace: string };
+
+  /**
    * Daemon-host status provider for env + preflight cells.
    * When present, `getWorkspaceEnvStatus` returns daemon-local process state
    * without querying ACP. When absent, falls back to idle placeholders.

--- a/packages/desktop/packages/shared/src/agent/backend/types.ts
+++ b/packages/desktop/packages/shared/src/agent/backend/types.ts
@@ -198,6 +198,8 @@ export interface BridgeUpdateContext {
 export interface BackendHostRuntimeContext {
   /** App root path (packaged app path or repository root in development) */
   appRootPath: string;
+  /** Worktree root path when the session operates inside a git worktree */
+  worktreeRootPath?: string;
   /** Optional resources path (needed for packaged Windows runtime resolution) */
   resourcesPath?: string;
   /** Whether the host app is running as a packaged build */

--- a/packages/desktop/packages/shared/src/agent/qwen-agent.ts
+++ b/packages/desktop/packages/shared/src/agent/qwen-agent.ts
@@ -592,7 +592,14 @@ function buildQwenAcpSpawnCommand(
 }
 
 function qwenSettingsCwd(hostRuntime: BackendHostRuntimeContext): string {
-  return hostRuntime.appRootPath || homedir() || process.cwd();
+  // TODO(#8138): populate worktreeRootPath in buildBackendHostRuntimeContext
+  // so desktop worktree sessions resolve settings against the worktree.
+  return (
+    hostRuntime.worktreeRootPath ||
+    hostRuntime.appRootPath ||
+    homedir() ||
+    process.cwd()
+  );
 }
 
 function qwenAcpWithTimeout<T>(


### PR DESCRIPTION
## What this PR does

When a session operates inside a git worktree, workspace-scoped settings (`settings.json`) and the context file (`QWEN.md`) were resolved against the project root instead of the worktree directory. File operations (read, write, shell) already worked correctly because they use `config.getTargetDir()`, but the settings and context-file paths were hardcoded to the daemon's `process.cwd()` or the desktop client's `appRootPath`.

This PR adds worktree-aware resolution for both paths without modifying the core settings or workspace-service logic. The changes bolt onto the existing extension points: a new fallback in the ACP extension-method dispatcher, an optional resolver callback in the workspace service, and a new optional field on the desktop host-runtime context. Existing behavior is fully preserved when no worktree is involved — every new code path falls through to the original resolution when the worktree fields are unset.

## Why it's needed

Users working inside a git worktree (created via `enter_worktree` or subagent `isolation: "worktree"`) expect settings changes to land in the worktree's `.qwen/settings.json`, not the main project's. Without this fix, changing a model or toggling an MCP server inside a worktree silently writes to the project root, and the context file is always created relative to the project root. This makes worktree-based workflows unreliable for isolated experimentation.

Fixes #8138

## Reviewer Test Plan

### How to verify

1. Create a worktree session (via desktop or `qwen serve` with a worktree-bound session).
2. Change a workspace-scoped setting (e.g. model name) without passing an explicit `cwd`.
3. Confirm the setting lands in `<worktree>/.qwen/settings.json`, not `<projectRoot>/.qwen/settings.json`.
4. Close the worktree session, then open a regular session and change a setting — confirm it resolves against `process.cwd()` (no stale worktree path).
5. For the context file: call `POST /workspace/init` with a `resolveContextFile` that points to a worktree subdirectory — confirm the file is created there.

Unit tests cover the `resolveContextFile` injectable (facade.test.ts, 2 new tests) and the `Session.worktreeCwd` field lifecycle (Session.worktree.test.ts, 1 new test). All 108 tests in changed files pass.

### Evidence (Before & After)

N/A — non-UI change (ACP/serve internals).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

`npm run build && npm run typecheck` on Windows. Unit tests via `npx vitest run` in `packages/cli`.

## Risk & Scope

- Main risk or tradeoff: `defaultSettingsCwd` on `QwenAgent` is agent-global state shared across sessions. It is reset when a regular session is created and when the owning worktree session closes, but two concurrent worktree sessions will last-write-wins. This is acceptable for the current single-focus-UI usage pattern; per-session resolution (via the already-present `Session.worktreeCwd` field) is the long-term path.
- Not validated / out of scope: desktop `worktreeRootPath` is declared and read but not yet populated by `buildBackendHostRuntimeContext` (marked with `TODO(#8138)`). The desktop-side wiring requires Electron host changes and is a follow-up. Integration tests for the `extMethodInternal` fallback chain require the full `runAcpAgent` mock harness and are deferred.
- Breaking changes / migration notes: none. All new fields are optional with null/undefined defaults; existing callers are unaffected.

## Linked Issues

Fixes #8138

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当会话在 git worktree 内运行时，工作区设置（`settings.json`）和上下文文件（`QWEN.md`）被解析到项目根目录而非 worktree 目录。文件操作（读、写、shell）已经正确工作（使用 `config.getTargetDir()`），但设置和上下文文件路径被硬编码为守护进程的 `process.cwd()` 或桌面客户端的 `appRootPath`。

本 PR 为两个路径添加了 worktree 感知解析，且未修改核心设置或工作区服务逻辑。变更通过现有扩展点接入：ACP 扩展方法分发器中的新回退、工作区服务中的可选解析回调、以及桌面宿主运行时上下文上的新可选字段。当不涉及 worktree 时，现有行为完全保留——所有新代码路径在 worktree 字段未设置时回退到原始解析。

## 为什么需要

在 git worktree 内工作的用户（通过 `enter_worktree` 或子代理 `isolation: "worktree"` 创建）期望设置变更写入 worktree 的 `.qwen/settings.json`，而非主项目的。没有此修复，在 worktree 内更改模型或切换 MCP 服务器会静默写入项目根目录，上下文文件也始终相对于项目根目录创建。这使得基于 worktree 的工作流对于隔离实验不可靠。

修复 #8138

## 审阅者测试计划

### 如何验证

1. 创建一个 worktree 会话（通过桌面或 `qwen serve` 绑定 worktree 的会话）。
2. 更改工作区范围设置（如模型名称），不传递显式 `cwd`。
3. 确认设置写入 `<worktree>/.qwen/settings.json`，而非 `<projectRoot>/.qwen/settings.json`。
4. 关闭 worktree 会话，然后打开常规会话并更改设置——确认其解析到 `process.cwd()`（无残留 worktree 路径）。
5. 对于上下文文件：使用指向 worktree 子目录的 `resolveContextFile` 调用 `POST /workspace/init`——确认文件在该处创建。

单元测试覆盖了 `resolveContextFile` 可注入项（facade.test.ts，2 个新测试）和 `Session.worktreeCwd` 字段生命周期（Session.worktree.test.ts，1 个新测试）。变更文件中全部 108 个测试通过。

### 证据（变更前/后）

N/A — 非 UI 变更（ACP/serve 内部）。

### 测试环境

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ 未测试 |
| 🪟 Windows | ✅ 已测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

Windows 上 `npm run build && npm run typecheck`。单元测试通过 `packages/cli` 中的 `npx vitest run`。

## 风险与范围

- 主要风险或权衡：`QwenAgent` 上的 `defaultSettingsCwd` 是跨会话共享的代理全局状态。当创建常规会话时和所属 worktree 会话关闭时会重置，但两个并发 worktree 会话会最后写入生效。这对于当前单焦点 UI 使用模式是可接受的；按会话解析（通过已存在的 `Session.worktreeCwd` 字段）是长期方案。
- 未验证/超出范围：桌面 `worktreeRootPath` 已声明和读取，但尚未由 `buildBackendHostRuntimeContext` 填充（标记为 `TODO(#8138)`）。桌面端接线需要 Electron 宿主变更，属于后续工作。`extMethodInternal` 回退链的集成测试需要完整的 `runAcpAgent` mock 框架，已推迟。
- 破坏性变更/迁移说明：无。所有新字段均为可选，默认值为 null/undefined；现有调用者不受影响。

## 关联 Issue

修复 #8138

</details>

QwenCode QwenLLM