### PR TITLE
fix(test): make auto-edit permission E2E deterministic

### DIFF
--- a/integration-tests/sdk-typescript/permission-control.test.ts
+++ b/integration-tests/sdk-typescript/permission-control.test.ts
@@ -23,6 +23,12 @@ import {
   type ToolUseBlock,
   type ContentBlock,
 } from '@qwen-code/sdk';
+import { fakeToolCall, startFakeOpenAIServer } from '../fake-openai-server.js';
+import {
+  IS_CONTAINER_SANDBOX,
+  CONTAINER_SANDBOX_NO_PROXY,
+  fakeServerHostOptions,
+} from '../test-helper.js';
 import {
   SDKTestHelper,
   createSharedTestOptions,
@@ -36,6 +42,25 @@ import {
 
 const TEST_TIMEOUT = 60000;
 const SHARED_TEST_OPTIONS = createSharedTestOptions();
+const LOCAL_OPENAI_NO_PROXY = IS_CONTAINER_SANDBOX
+  ? CONTAINER_SANDBOX_NO_PROXY
+  : '127.0.0.1,localhost';
+const FAKE_SERVER_OPTIONS = fakeServerHostOptions();
+
+function fakeModelOptions(baseUrl: string) {
+  return {
+    model: 'fake-model',
+    authType: 'openai' as const,
+    env: {
+      NO_PROXY: LOCAL_OPENAI_NO_PROXY,
+      no_proxy: LOCAL_OPENAI_NO_PROXY,
+      OPENAI_API_KEY: 'fake-key',
+      OPENAI_BASE_URL: baseUrl,
+      OPENAI_MODEL: 'fake-model',
+      QWEN_MODEL: 'fake-model',
+    },
+  };
+}
 
 /**
  * Factory function that creates a streaming input with a control point.
@@ -1157,13 +1182,28 @@ describe('Permission Control (E2E)', () => {
         'should not invoke canUseTool callback for write/edit tools',
         async () => {
           let callbackInvoked = false;
+          const fakeServer = await startFakeOpenAIServer(({ requestIndex }) => {
+            if (requestIndex === 0) {
+              return {
+                toolCalls: [
+                  fakeToolCall('write_file', {
+                    file_path: `${testDir}/test-auto-edit-no-callback.txt`,
+                    content: 'auto-edit callback test',
+                  }),
+                ],
+              };
+            }
+            return { content: 'Done.' };
+          }, FAKE_SERVER_OPTIONS);
 
           const q = query({
-            prompt: 'Create a file named test-auto-edit-no-callback.txt',
+            prompt: 'Create test-auto-edit-no-callback.txt.',
             options: {
               ...SHARED_TEST_OPTIONS,
+              ...fakeModelOptions(fakeServer.baseUrl),
               permissionMode: 'auto-edit',
               cwd: testDir,
+              coreTools: ['write_file'],
               canUseTool: async (toolName, input) => {
                 callbackInvoked = true;
                 return {
@@ -1185,6 +1225,7 @@ describe('Permission Control (E2E)', () => {
             expect(callbackInvoked).toBe(false);
           } finally {
             await q.close();
+            await fakeServer.close();
           }
         },
         TEST_TIMEOUT,


### PR DESCRIPTION
## What this PR does

This PR makes the auto-edit permission callback E2E deterministic by using the local fake OpenAI server to issue a known `write_file` tool call. The test still exercises the real SDK, CLI, write tool, and auto-edit permission path, while removing the unrelated dependency on a live model choosing to call a tool.

## Why it's needed

The main-branch E2E run after #8149 failed because the auto-edit callback test produced no successful tool result in three attempts. The test is intended to verify that auto-edit executes a write tool without invoking `canUseTool`, but its load-bearing tool call was previously left to live-model behavior. Earlier main runs also showed this test requiring a retry and taking more than eighty seconds.

This is independent of #8149: the `yolo` to `plan` test fixed there passed in the failing run, and #8149 did not change this auto-edit test or its CI timeout.

## Reviewer Test Plan

### How to verify

Run the targeted test with retries disabled and confirm that the fake model issues `write_file`, the tool succeeds, and `canUseTool` remains uncalled:

```bash
env QWEN_SANDBOX=false KEEP_OUTPUT=true npx vitest run --root ./integration-tests --poolOptions.threads.maxThreads 1 --retry 0 sdk-typescript/permission-control.test.ts -t 'should not invoke canUseTool callback for write/edit tools' --reporter verbose
```

Expected result: one test passes without retries in a few seconds.

### Evidence (Before & After)

Before: GitHub Actions run 30561891797 job 90936766106 failed the test three times because `hasSuccessfulToolResults(messages)` was false. A prompt-only local attempt could also run until the sixty-second test timeout.

After: the deterministic test passed twice without retries in 1.705 seconds and 3.059 seconds.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS, no sandbox, built `dist/cli.js`, local fake OpenAI server. Local Docker validation was unavailable because this machine has no `docker` command; the container host/no-proxy setup reuses the existing SDK E2E convention.

## Risk & Scope

- Main risk or tradeoff: this individual test no longer covers live-model tool selection, which is unrelated to the permission behavior it asserts.
- Not validated / out of scope: local Docker execution and the full integration suite.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to the failure in GitHub Actions run 30561891797.

<details>
<summary>中文说明</summary>

## What this PR does

本 PR 使用本地 fake OpenAI server 固定发出 `write_file` 工具调用，使 auto-edit 权限回调 E2E 测试具备确定性。测试仍然经过真实 SDK、CLI、写文件工具和 auto-edit 权限链路，只移除了与测试目标无关的“真实模型是否选择调用工具”依赖。

## Why it's needed

#8149 合入后的 main E2E 运行中，auto-edit 回调测试连续三次没有产生成功的工具结果。该测试实际要验证的是 auto-edit 模式执行写工具时不会调用 `canUseTool`，但此前 load-bearing 的工具调用由真实模型概率决定。更早的 main 运行也显示该测试曾依赖重试，并耗时超过八十秒。

该失败与 #8149 无关：#8149 修复的 `yolo` 到 `plan` 测试在本次失败运行中已经通过，而且 #8149 没有修改这个 auto-edit 测试或其 CI 超时。

## Reviewer Test Plan

### How to verify

关闭重试运行目标测试，确认 fake model 发出 `write_file`，工具成功执行，并且 `canUseTool` 未被调用：

```bash
env QWEN_SANDBOX=false KEEP_OUTPUT=true npx vitest run --root ./integration-tests --poolOptions.threads.maxThreads 1 --retry 0 sdk-typescript/permission-control.test.ts -t 'should not invoke canUseTool callback for write/edit tools' --reporter verbose
```

预期结果：一个测试不经过重试，在数秒内通过。

### Evidence (Before & After)

修改前：GitHub Actions run 30561891797 job 90936766106 中，该测试连续三次因 `hasSuccessfulToolResults(messages)` 为 false 而失败。仅强化提示词的本地尝试也可能一直运行到六十秒测试超时。

修改后：确定性测试两次关闭重试运行均通过，耗时分别为 1.705 秒和 3.059 秒。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS、无 sandbox、使用已构建的 `dist/cli.js` 和本地 fake OpenAI server。本机没有 `docker` 命令，因此无法本地验证 Docker；容器 host/no-proxy 设置复用了现有 SDK E2E 约定。

## Risk & Scope

- 主要风险或取舍：这个单独测试不再覆盖真实模型是否选择工具，但该行为与它断言的权限逻辑无关。
- 未验证或超出范围：本地 Docker 执行和完整 integration suite。
- 破坏性变更或迁移说明：无。

## Linked Issues

跟进 GitHub Actions run 30561891797 中的失败。

</details>
