### PR TITLE
feat(hooks): include session source in lifecycle hook payloads

### DIFF
--- a/docs/design/session-source-lifecycle-hooks.md
+++ b/docs/design/session-source-lifecycle-hooks.md
@@ -1,0 +1,41 @@
+# Session source in lifecycle hooks
+
+## Context
+
+Daemon session creation already forwards optional `sourceType` and `sourceId`
+values to ACP in `_meta['qwen.session.source']`. The ACP runtime currently uses
+the source type to disable native cron for channel sessions, but lifecycle hook
+payloads cannot observe either value. Receivers therefore cannot attribute a
+new session when `SessionStart` fires before the bridge persists its source.
+
+## Design
+
+Parse the existing source metadata once at the ACP session boundary. Store the
+two optional strings on the session's `Config`, alongside the session id and
+other session-scoped state, and expose read-only getters.
+
+The hook event handler adds present source values to its common input:
+
+- `sourceType` becomes `source_type`.
+- `sourceId` becomes `source_id`.
+
+Conditional object spreads omit absent values instead of serializing empty or
+undefined fields. Because every lifecycle event uses the common input builder,
+`SessionStart`, `UserPromptSubmit`, `Stop`, and `SessionEnd` receive the same
+attribution without event-specific wiring.
+
+## Boundaries
+
+This is a read-through of existing creation metadata. It does not change the
+REST create request, ACP bridge metadata key, capability negotiation, session
+persistence, or resume behavior. A session created without source metadata
+keeps the previous hook payload shape.
+
+## Verification
+
+- Hook handler tests cover present and absent source fields on
+  `SessionStart` payloads.
+- ACP session tests cover propagation of channel source metadata into the
+  session `Config`.
+- Existing channel worker tests continue to cover creation metadata, including
+  the channel instance name as `sourceId`.

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -3023,6 +3023,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       initialize: vi.fn().mockResolvedValue(undefined),
       shutdown: vi.fn().mockResolvedValue(undefined),
       closeSessionWriter: vi.fn().mockResolvedValue(undefined),
+      setSessionSource: vi.fn(),
       setSessionWriterReclaimPolicy: vi.fn(),
       setSessionWriterTakeoverPolicy: vi.fn(),
       waitForMcpReady: vi.fn().mockResolvedValue(undefined),
@@ -5783,6 +5784,42 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       await agentPromise;
     },
   );
+
+  it('stores ACP session source metadata on the session config', async () => {
+    const innerConfig = await setupSessionMocks('session-source');
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+
+    try {
+      await agent.newSession({
+        cwd: '/tmp',
+        mcpServers: [],
+        _meta: {
+          [SESSION_SOURCE_META_KEY]: {
+            sourceType: 'channel',
+            sourceId: 'feishu-main',
+          },
+        },
+      });
+
+      expect(innerConfig.setSessionSource).toHaveBeenCalledWith(
+        'channel',
+        'feishu-main',
+      );
+    } finally {
+      mockConnectionState.resolve();
+      await agentPromise;
+    }
+  });
 
   it('session model selectors distinguish the same model id on different endpoints', async () => {
     const sessionId = '11111111-1111-1111-1111-111111111111';
@@ -13370,6 +13407,7 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
     return {
       initialize: vi.fn().mockResolvedValue(undefined),
       shutdown: vi.fn().mockResolvedValue(undefined),
+      setSessionSource: vi.fn(),
       waitForMcpReady: vi.fn().mockResolvedValue(undefined),
       getModelsConfig: vi.fn().mockReturnValue({
         getCurrentAuthType: vi.fn().mockReturnValue('api-key'),

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -656,10 +656,25 @@ export function selectVisibleHistoryRecords(
     : records;
 }
 
-function isChannelSessionRequest(params: { _meta?: unknown }): boolean {
+interface SessionSource {
+  sourceType: string;
+  sourceId?: string;
+}
+
+function getSessionSource(params: {
+  _meta?: unknown;
+}): SessionSource | undefined {
   const meta = isObjectRecord(params._meta) ? params._meta : undefined;
   const value = meta?.[SESSION_SOURCE_META_KEY];
-  return isObjectRecord(value) && value['sourceType'] === 'channel';
+  if (!isObjectRecord(value) || typeof value['sourceType'] !== 'string') {
+    return undefined;
+  }
+  return {
+    sourceType: value['sourceType'],
+    ...(typeof value['sourceId'] === 'string'
+      ? { sourceId: value['sourceId'] }
+      : {}),
+  };
 }
 
 function shouldDeferMcpDiscovery(params: { _meta?: unknown }): boolean {
@@ -4407,7 +4422,7 @@ class QwenAgent implements Agent {
 
   async newSession(params: NewSessionRequest): Promise<NewSessionResponse> {
     const { cwd, mcpServers } = params;
-    const isChannelSession = isChannelSessionRequest(params);
+    const sessionSource = getSessionSource(params);
     const parentContext = extractDaemonTraceContext(params);
     return await withDaemonSpan(
       'qwen-code.daemon.session_start',
@@ -4429,7 +4444,7 @@ class QwenAgent implements Agent {
             cwd,
             mcpServers,
             settings,
-            isChannelSession,
+            sessionSource,
             undefined,
             undefined,
             shouldDeferMcpDiscovery(params)
@@ -4468,7 +4483,7 @@ class QwenAgent implements Agent {
   }
 
   async loadSession(params: LoadSessionRequest): Promise<LoadSessionResponse> {
-    const isChannelSession = isChannelSessionRequest(params);
+    const sessionSource = getSessionSource(params);
     // Load per-request settings BEFORE the existence check: the check must
     // resolve `advanced.runtimeOutputDir` from THIS request's cwd, not from
     // whichever settings a concurrent handler loaded last.
@@ -4561,7 +4576,7 @@ class QwenAgent implements Agent {
       // a `null`/`undefined` would otherwise throw `TypeError`.
       params.mcpServers ?? [],
       settings,
-      isChannelSession,
+      sessionSource,
       params.sessionId,
       true,
     );
@@ -4661,7 +4676,7 @@ class QwenAgent implements Agent {
   async unstable_resumeSession(
     params: ResumeSessionRequest,
   ): Promise<ResumeSessionResponse> {
-    const isChannelSession = isChannelSessionRequest(params);
+    const sessionSource = getSessionSource(params);
     // Same per-request settings discipline as `loadSession`.
     const settings = loadSettingsCached(params.cwd);
     const liveSession = this.sessions.get(params.sessionId);
@@ -4699,7 +4714,7 @@ class QwenAgent implements Agent {
       params.cwd,
       params.mcpServers ?? [],
       settings,
-      isChannelSession,
+      sessionSource,
       params.sessionId,
       true,
     );
@@ -10860,7 +10875,7 @@ class QwenAgent implements Agent {
     cwd: string,
     mcpServers: McpServer[],
     settings: LoadedSettings,
-    isChannelSession?: boolean,
+    sessionSource?: SessionSource,
     sessionId?: string,
     resume?: boolean,
     initializeOptions: ConfigInitializeOptions = {},
@@ -10877,7 +10892,7 @@ class QwenAgent implements Agent {
           cwd,
           mcpServers,
           settings,
-          isChannelSession,
+          sessionSource,
           sessionId,
           resume,
           initializeOptions,
@@ -10899,7 +10914,7 @@ class QwenAgent implements Agent {
     cwd: string,
     mcpServers: McpServer[],
     settings: LoadedSettings,
-    isChannelSession?: boolean,
+    sessionSource?: SessionSource,
     sessionId?: string,
     resume?: boolean,
     initializeOptions: ConfigInitializeOptions = {},
@@ -10969,7 +10984,7 @@ class QwenAgent implements Agent {
       experimental: {
         ...settings.merged.experimental,
         sessionWriterLease: this.sessionWriterLeaseEnabledAtStartup,
-        ...(isChannelSession ? { cron: false } : {}),
+        ...(sessionSource?.sourceType === 'channel' ? { cron: false } : {}),
       },
     };
 
@@ -11011,6 +11026,9 @@ class QwenAgent implements Agent {
       buildDisabledSkillNamesProvider(settings),
       sessionMcpServers,
     );
+    if (sessionSource) {
+      config.setSessionSource(sessionSource.sourceType, sessionSource.sourceId);
+    }
     if (chatRecording !== false) {
       this.initializingConfigs.add(config);
     }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1669,6 +1669,8 @@ class SessionWriterShutdownError extends SessionWriterUnavailableError {}
 
 export class Config {
   private sessionId: string;
+  private sessionSourceType?: string;
+  private sessionSourceId?: string;
   private sessionData?: ResumedSessionData;
   private readonly sessionRuntimeBaseDir: string;
   private sessionProjectDirRegistered = false;
@@ -3638,6 +3640,19 @@ export class Config {
 
   getSessionId(): string {
     return this.sessionId;
+  }
+
+  setSessionSource(sourceType: string, sourceId?: string): void {
+    this.sessionSourceType = sourceType;
+    this.sessionSourceId = sourceId;
+  }
+
+  getSessionSourceType(): string | undefined {
+    return this.sessionSourceType;
+  }
+
+  getSessionSourceId(): string | undefined {
+    return this.sessionSourceId;
   }
 
   /**

--- a/packages/core/src/hooks/hookEventHandler.test.ts
+++ b/packages/core/src/hooks/hookEventHandler.test.ts
@@ -49,6 +49,8 @@ describe('HookEventHandler', () => {
   beforeEach(() => {
     mockConfig = {
       getSessionId: vi.fn().mockReturnValue('test-session-id'),
+      getSessionSourceType: vi.fn().mockReturnValue(undefined),
+      getSessionSourceId: vi.fn().mockReturnValue(undefined),
       getTranscriptPath: vi.fn().mockReturnValue('/test/transcript'),
       getWorkingDir: vi.fn().mockReturnValue('/test/cwd'),
     } as unknown as Config;
@@ -568,6 +570,8 @@ describe('HookEventHandler', () => {
       // Config without registry/scheduler methods
       const bareConfig = {
         getSessionId: vi.fn().mockReturnValue('test-session-id'),
+        getSessionSourceType: vi.fn().mockReturnValue(undefined),
+        getSessionSourceId: vi.fn().mockReturnValue(undefined),
         getTranscriptPath: vi.fn().mockReturnValue('/test/transcript'),
         getWorkingDir: vi.fn().mockReturnValue('/test/cwd'),
       } as unknown as Config;
@@ -725,6 +729,62 @@ describe('HookEventHandler', () => {
       expect(input.source).toBe(SessionStartSource.Resume);
       expect(input.model).toBe('test-model');
       expect(input.agent_type).toBe(AgentType.Bash);
+    });
+
+    it('should include session source fields in the hook input', async () => {
+      vi.mocked(mockConfig.getSessionSourceType).mockReturnValue('channel');
+      vi.mocked(mockConfig.getSessionSourceId).mockReturnValue('feishu-main');
+      vi.mocked(mockHookPlanner.createExecutionPlan).mockReturnValue(
+        createMockExecutionPlan([
+          {
+            type: HookType.Command,
+            command: 'echo test',
+            source: HooksConfigSource.Project,
+          },
+        ]),
+      );
+      vi.mocked(mockHookRunner.executeHooksParallel).mockResolvedValue([]);
+      vi.mocked(mockHookAggregator.aggregateResults).mockReturnValue(
+        createMockAggregatedResult(true),
+      );
+
+      await hookEventHandler.fireSessionStartEvent(
+        SessionStartSource.Startup,
+        'test-model',
+      );
+
+      const input = (mockHookRunner.executeHooksParallel as Mock).mock
+        .calls[0][2];
+      expect(input).toMatchObject({
+        source_type: 'channel',
+        source_id: 'feishu-main',
+      });
+    });
+
+    it('should omit session source fields when unavailable', async () => {
+      vi.mocked(mockHookPlanner.createExecutionPlan).mockReturnValue(
+        createMockExecutionPlan([
+          {
+            type: HookType.Command,
+            command: 'echo test',
+            source: HooksConfigSource.Project,
+          },
+        ]),
+      );
+      vi.mocked(mockHookRunner.executeHooksParallel).mockResolvedValue([]);
+      vi.mocked(mockHookAggregator.aggregateResults).mockReturnValue(
+        createMockAggregatedResult(true),
+      );
+
+      await hookEventHandler.fireSessionStartEvent(
+        SessionStartSource.Startup,
+        'test-model',
+      );
+
+      const input = (mockHookRunner.executeHooksParallel as Mock).mock
+        .calls[0][2];
+      expect(input).not.toHaveProperty('source_type');
+      expect(input).not.toHaveProperty('source_id');
     });
 
     it('should use default permission mode when not provided', async () => {

--- a/packages/core/src/hooks/hookEventHandler.ts
+++ b/packages/core/src/hooks/hookEventHandler.ts
@@ -893,9 +893,13 @@ export class HookEventHandler {
   private createBaseInput(eventName: HookEventName): HookInput {
     // Get the transcript path from the Config
     const transcriptPath = this.config.getTranscriptPath();
+    const sourceType = this.config.getSessionSourceType();
+    const sourceId = this.config.getSessionSourceId();
 
     return {
       session_id: this.config.getSessionId(),
+      ...(sourceType !== undefined ? { source_type: sourceType } : {}),
+      ...(sourceId !== undefined ? { source_id: sourceId } : {}),
       transcript_path: transcriptPath,
       cwd: this.config.getWorkingDir(),
       hook_event_name: eventName,

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -257,6 +257,8 @@ export type HookDecision = 'ask' | 'block' | 'deny' | 'approve' | 'allow';
  */
 export interface HookInput {
   session_id: string;
+  source_type?: string;
+  source_id?: string;
   transcript_path: string;
   cwd: string;
   hook_event_name: string;


### PR DESCRIPTION
## What this PR does

Lifecycle hook payloads now include optional `source_type` and `source_id` fields copied from the daemon session's existing source metadata. The values are attached to session-scoped configuration before initialization and added through the common hook payload path, so `SessionStart`, `UserPromptSubmit`, `Stop`, and `SessionEnd` report consistent attribution. Sessions without source metadata omit both keys.

## Why it's needed

Platform receivers aggregate sessions created through multiple entry points, but a lifecycle hook currently cannot distinguish a REST/console session from a channel-worker session. Querying the session list or transcript is not a reliable workaround because `SessionStart` can fire before source persistence completes. Exposing the metadata already carried by session creation removes that race without changing the REST or ACP contracts.

## Reviewer Test Plan

### How to verify

1. Configure lifecycle hooks to record their JSON input, create a session through a channel worker named `feishu-main`, and confirm all four lifecycle payloads contain `source_type: "channel"` and `source_id: "feishu-main"`.
2. Create a session through REST without source metadata and confirm the same payloads contain neither `source_type` nor `source_id`.
3. Confirm session creation, capability negotiation, and existing hook fields are otherwise unchanged.

### Evidence (Before & After)

Before: a headless run with released `qwen 0.21.1` captured a `SessionStart` payload without `source_type` or `source_id`. After: automated event-payload coverage confirms the channel values are present and the unattributed case omits both keys; ACP propagation coverage confirms the metadata is stored before session initialization. The complete related test files passed (137 core hook tests and 353 ACP session tests), along with the full repository build and typecheck.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local macOS workspace, Node.js 26.5.0, no sandbox for the released-CLI baseline.

## Risk & Scope

- Main risk or tradeoff: Hook receivers with a strict closed JSON schema may need to allow the two additive fields.
- Not validated / out of scope: Live delivery through every channel provider, persistence of source metadata across daemon restarts, and local Windows/Linux runs.
- Breaking changes / migration notes: None. Existing sessions without source metadata keep the previous payload shape, and receivers that ignore unknown fields are unaffected.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

生命周期 hook payload 现在会包含可选的 `source_type` 和 `source_id` 字段，值来自 daemon session 已有的来源 metadata。来源会在 session 初始化前写入该 session 独立的配置，并通过公共 hook payload 路径加入，因此 `SessionStart`、`UserPromptSubmit`、`Stop` 和 `SessionEnd` 会报告一致的来源信息。没有来源 metadata 的 session 会省略这两个 key。

## 为什么需要

平台侧接收器会汇总多个入口创建的 session，但当前生命周期 hook 无法区分 REST/console session 与 channel worker session。查询 session 列表或 transcript 不是可靠的替代方案，因为 `SessionStart` 可能在来源持久化完成前触发。暴露 session 创建时已经携带的 metadata 可以消除这个竞态，同时不改变 REST 或 ACP contract。

## Reviewer Test Plan

### 如何验证

1. 配置生命周期 hook 记录其 JSON 输入，通过名为 `feishu-main` 的 channel worker 创建 session，并确认四种生命周期 payload 都包含 `source_type: "channel"` 和 `source_id: "feishu-main"`。
2. 通过 REST 创建不带来源 metadata 的 session，并确认相同 payload 中既没有 `source_type`，也没有 `source_id`。
3. 确认 session 创建、capability negotiation 和现有 hook 字段除此之外均未改变。

### 证据（Before & After）

Before：使用已发布的 `qwen 0.21.1` 进行 headless 运行，捕获到的 `SessionStart` payload 不包含 `source_type` 或 `source_id`。After：自动化事件 payload 覆盖确认 channel 值存在，未归因场景省略两个 key；ACP 传播覆盖确认 metadata 在 session 初始化前保存。相关测试文件完整通过（137 个 core hook 测试和 353 个 ACP session 测试），全仓 build 和 typecheck 也通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

本地 macOS 工作区，Node.js 26.5.0；已发布 CLI 的基线测试未使用 sandbox。

## 风险与范围

- 主要风险或取舍：使用严格封闭 JSON schema 的 hook 接收器可能需要允许这两个新增字段。
- 未验证 / 范围外：通过每一种 channel provider 的真实投递、daemon 重启后来源 metadata 的持久化，以及本地 Windows/Linux 运行。
- Breaking change / 迁移说明：无。没有来源 metadata 的现有 session 保持之前的 payload 形状，忽略未知字段的接收器不受影响。

## 关联 Issue

无。

</details>
