### PR TITLE
fix(anthropic): sanitize tool_use.id / tool_result.tool_use_id

### DIFF
--- a/packages/core/src/core/anthropicContentGenerator/converter.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.test.ts
@@ -1189,6 +1189,155 @@ describe('AnthropicContentConverter', () => {
       ]);
     });
 
+    describe('tool_use id sanitization', () => {
+      // Anthropic validates tool_use.id / tool_result.tool_use_id against
+      // ^[a-zA-Z0-9_-]+$ server-side (HTTP 400 otherwise), but the Gemini
+      // lingua-franca's functionCall.id / functionResponse.id has no such
+      // constraint. Verified live: sending an id containing characters
+      // outside that set, or an empty tool_use_id, both 400 with
+      // "String should match pattern '^[a-zA-Z0-9_-]+$'".
+      it('sanitizes a tool_use id containing characters outside [a-zA-Z0-9_-]', () => {
+        const rawId = 'call:abc.def/ghi?jkl';
+        const { messages } = converter.convertGeminiRequestToAnthropic({
+          model: 'models/test',
+          contents: [
+            { role: 'user', parts: [{ text: 'Hi' }] },
+            {
+              role: 'model',
+              parts: [
+                {
+                  functionCall: { id: rawId, name: 'tool', args: { a: 1 } },
+                },
+              ],
+            },
+            {
+              role: 'user',
+              parts: [
+                {
+                  functionResponse: {
+                    id: rawId,
+                    name: 'tool',
+                    response: { output: 'ok' },
+                  },
+                },
+              ],
+            },
+          ],
+        });
+
+        const assistantBlocks = messages[1]?.content as Array<{
+          type: string;
+          id?: string;
+        }>;
+        const userBlocks = messages[2]?.content as Array<{
+          type: string;
+          tool_use_id?: string;
+        }>;
+        const toolUse = assistantBlocks.find((b) => b.type === 'tool_use');
+        const toolResult = userBlocks.find((b) => b.type === 'tool_result');
+
+        expect(toolUse?.id).toMatch(/^[a-zA-Z0-9_-]+$/);
+        expect(toolUse?.id).not.toBe(rawId);
+        // The sanitized id links the pair back up.
+        expect(toolResult?.tool_use_id).toBe(toolUse?.id);
+      });
+
+      it('generates a non-empty fallback id when functionCall.id is missing (not an empty string)', () => {
+        const { messages } = converter.convertGeminiRequestToAnthropic({
+          model: 'models/test',
+          contents: [
+            { role: 'user', parts: [{ text: 'Hi' }] },
+            {
+              role: 'model',
+              parts: [{ functionCall: { name: 'tool', args: {} } }],
+            },
+          ],
+        });
+
+        const assistantBlocks = messages[1]?.content as Array<{
+          type: string;
+          id?: string;
+        }>;
+        const toolUse = assistantBlocks.find((b) => b.type === 'tool_use');
+        expect(toolUse?.id).toBeTruthy();
+        expect(toolUse?.id).toMatch(/^[a-zA-Z0-9_-]+$/);
+      });
+
+      // Note: there is no analogous standalone test for "functionResponse.id
+      // missing" here -- a tool_result with no id can't be linked to any
+      // tool_use by definition (which call is it responding to?), so it is
+      // always a genuine orphan and gets cleaned up by cleanOrphanedToolCalls
+      // regardless of this fix. tool_result.tool_use_id goes through the
+      // exact same resolveToolUseId/nextGeneratedToolId path exercised by
+      // the tool_use-side tests above, so the never-empty-string guarantee
+      // is already covered.
+
+      it('does not collide fallback ids generated for two different missing-id tool calls in the same request', () => {
+        const { messages } = converter.convertGeminiRequestToAnthropic({
+          model: 'models/test',
+          contents: [
+            { role: 'user', parts: [{ text: 'Hi' }] },
+            {
+              role: 'model',
+              parts: [
+                { functionCall: { name: 'tool_a', args: {} } },
+                { functionCall: { name: 'tool_b', args: {} } },
+              ],
+            },
+          ],
+        });
+
+        const assistantBlocks = messages[1]?.content as Array<{
+          type: string;
+          id?: string;
+        }>;
+        const ids = assistantBlocks
+          .filter((b) => b.type === 'tool_use')
+          .map((b) => b.id);
+        expect(ids).toHaveLength(2);
+        expect(new Set(ids).size).toBe(2);
+      });
+
+      it('resolves the same source id to the same sanitized id across tool_use and tool_result in different messages', () => {
+        const rawId = 'weird/id:1';
+        const { messages } = converter.convertGeminiRequestToAnthropic({
+          model: 'models/test',
+          contents: [
+            { role: 'user', parts: [{ text: 'Hi' }] },
+            {
+              role: 'model',
+              parts: [{ functionCall: { id: rawId, name: 'tool', args: {} } }],
+            },
+            {
+              role: 'user',
+              parts: [
+                {
+                  functionResponse: {
+                    id: rawId,
+                    name: 'tool',
+                    response: { output: 'ok' },
+                  },
+                },
+              ],
+            },
+          ],
+        });
+
+        const toolUseId = (
+          messages[1]?.content as Array<{ type: string; id?: string }>
+        ).find((b) => b.type === 'tool_use')?.id;
+        const toolResultId = (
+          messages[2]?.content as Array<{
+            type: string;
+            tool_use_id?: string;
+          }>
+        ).find((b) => b.type === 'tool_result')?.tool_use_id;
+
+        expect(toolUseId).toBeDefined();
+        expect(toolUseId).toBe(toolResultId);
+      });
+    });
+
     it('keeps tool results split across consecutive user messages', () => {
       const { messages } = converter.convertGeminiRequestToAnthropic({
         model: 'models/test',

--- a/packages/core/src/core/anthropicContentGenerator/converter.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.test.ts
@@ -1067,6 +1067,10 @@ describe('AnthropicContentConverter', () => {
     });
 
     it('cleans orphaned tool_use blocks without matching tool_result', () => {
+      // A genuine orphan requires a subsequent message that was actually
+      // scanned and found lacking a matching tool_result -- not merely the
+      // absence of any subsequent message (see the "trailing tool_use"
+      // test below for that case).
       const { messages } = converter.convertGeminiRequestToAnthropic({
         model: 'models/test',
         contents: [
@@ -1078,19 +1082,68 @@ describe('AnthropicContentConverter', () => {
               { functionCall: { id: 'orphan', name: 'tool', args: {} } },
             ],
           },
+          { role: 'user', parts: [{ text: 'never mind' }] },
         ],
       });
 
       expect(messages).toEqual([
         {
           role: 'user',
-          content: [
-            { type: 'text', text: 'Hi', cache_control: { type: 'ephemeral' } },
-          ],
+          content: [{ type: 'text', text: 'Hi' }],
         },
         {
           role: 'assistant',
           content: [{ type: 'text', text: 'Let me help' }],
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: 'never mind',
+              cache_control: { type: 'ephemeral' },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('does not strip a trailing tool_use that has no subsequent message yet (unresolved, not orphaned)', () => {
+      // "History ends on a pending tool_use" is not evidence the call is
+      // orphaned -- the tool may simply not have finished executing yet,
+      // or this conversion may be happening for a reason other than
+      // sending the completed turn to Anthropic (token counting, a
+      // resumed/replayed session snapshot, ...). Regression test for the
+      // bug where this exact shape had its tool_use silently deleted.
+      const { messages } = converter.convertGeminiRequestToAnthropic({
+        model: 'models/test',
+        contents: [
+          { role: 'user', parts: [{ text: 'What is the weather in Paris?' }] },
+          {
+            role: 'model',
+            parts: [
+              { text: 'Let me check the weather.' },
+              {
+                functionCall: {
+                  id: 'toolu_pending',
+                  name: 'get_weather',
+                  args: { city: 'Paris' },
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      const lastMsg = messages[messages.length - 1];
+      expect(lastMsg.role).toBe('assistant');
+      expect(lastMsg.content).toEqual([
+        { type: 'text', text: 'Let me check the weather.' },
+        {
+          type: 'tool_use',
+          id: 'toolu_pending',
+          name: 'get_weather',
+          input: { city: 'Paris' },
         },
       ]);
     });

--- a/packages/core/src/core/anthropicContentGenerator/converter.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.ts
@@ -127,6 +127,15 @@ export interface ConvertGeminiRequestToAnthropicOptions {
 export class AnthropicContentConverter {
   private schemaCompliance: SchemaComplianceMode;
   private enableCacheControl: boolean;
+  /**
+   * Per-request tool ID sanitization state (see {@link resolveToolUseId}).
+   * The converter instance is long-lived across requests (constructed once
+   * per generator), so this state is reset at the top of every
+   * `convertGeminiRequestToAnthropic` call rather than at construction.
+   */
+  private readonly toolIdMap = new Map<string, string>();
+  private readonly usedToolIds = new Set<string>();
+  private generatedToolIdCounter = 0;
 
   constructor(
     _model: string,
@@ -144,6 +153,7 @@ export class AnthropicContentConverter {
     system?: AnthropicTextBlockParam[] | string;
     messages: AnthropicMessageParam[];
   } {
+    this.resetToolIdState();
     let messages: AnthropicMessageParam[] = [];
 
     const systemText = this.extractTextFromContentUnion(
@@ -414,7 +424,6 @@ export class AnthropicContentConverter {
     const parts = content.parts || [];
     const role = content.role === 'model' ? 'assistant' : 'user';
     const contentBlocks: AnthropicContentBlockParam[] = [];
-    let toolCallIndex = 0;
 
     for (const part of parts) {
       if (typeof part === 'string') {
@@ -452,11 +461,10 @@ export class AnthropicContentConverter {
         if (role === 'assistant') {
           contentBlocks.push({
             type: 'tool_use',
-            id: part.functionCall.id || `tool_${toolCallIndex}`,
+            id: this.resolveToolUseId(part.functionCall.id),
             name: normalizeMcpToolName(part.functionCall.name || ''),
             input: (part.functionCall.args as Record<string, unknown>) || {},
           });
-          toolCallIndex += 1;
         }
       }
 
@@ -504,13 +512,82 @@ export class AnthropicContentConverter {
 
     return {
       type: 'tool_result',
-      tool_use_id: response.id || '',
+      tool_use_id: this.resolveToolUseId(response.id),
       content,
       ...(response.response &&
       Object.prototype.hasOwnProperty.call(response.response, 'error')
         ? { is_error: true }
         : {}),
     };
+  }
+
+  private resetToolIdState(): void {
+    this.toolIdMap.clear();
+    this.usedToolIds.clear();
+    this.generatedToolIdCounter = 0;
+  }
+
+  /**
+   * Resolve a `functionCall.id` / `functionResponse.id` into a wire-safe
+   * `tool_use.id` / `tool_result.tool_use_id`. Anthropic validates both
+   * fields against `^[a-zA-Z0-9_-]+$` server-side (HTTP 400 otherwise) and
+   * rejects the empty string the same way, since `+` requires at least one
+   * character. The Gemini lingua-franca's `id` field has no such
+   * constraint -- it can carry another provider's ID scheme, a
+   * composite/namespaced ID, or be entirely absent.
+   *
+   * The same source ID always resolves to the same wire ID within a
+   * request (memoized in `toolIdMap`), so a `tool_use`/`tool_result` pair
+   * that shares a source ID still links up correctly after sanitization.
+   * State is scoped to a single `convertGeminiRequestToAnthropic` call
+   * (reset via {@link resetToolIdState}), since the converter instance
+   * itself is long-lived across requests.
+   */
+  private resolveToolUseId(rawId?: string): string {
+    const sourceId = typeof rawId === 'string' ? rawId.trim() : '';
+    const existingId = sourceId ? this.toolIdMap.get(sourceId) : undefined;
+    if (existingId) {
+      return existingId;
+    }
+
+    const baseId = sourceId
+      ? this.sanitizeToolUseId(sourceId)
+      : this.nextGeneratedToolId();
+    const uniqueId = this.makeUniqueToolUseId(baseId);
+
+    if (sourceId) {
+      this.toolIdMap.set(sourceId, uniqueId);
+    }
+
+    return uniqueId;
+  }
+
+  private sanitizeToolUseId(id: string): string {
+    const cleaned = id.replace(/[^a-zA-Z0-9_-]/g, '_');
+    return cleaned || this.nextGeneratedToolId();
+  }
+
+  private nextGeneratedToolId(): string {
+    const id = `tool_${this.generatedToolIdCounter}`;
+    this.generatedToolIdCounter += 1;
+    return id;
+  }
+
+  private makeUniqueToolUseId(baseId: string): string {
+    if (!this.usedToolIds.has(baseId)) {
+      this.usedToolIds.add(baseId);
+      return baseId;
+    }
+
+    let suffix = 1;
+    let candidate = `${baseId}_${suffix}`;
+    while (this.usedToolIds.has(candidate)) {
+      suffix += 1;
+      candidate = `${baseId}_${suffix}`;
+    }
+
+    this.usedToolIds.add(candidate);
+    return candidate;
   }
 
   private createMediaBlockFromPart(

--- a/packages/core/src/core/anthropicContentGenerator/converter.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.ts
@@ -1079,6 +1079,15 @@ function mergeConsecutiveAssistantMessages(
  * immediately following user message, and remove tool_result blocks that
  * have no matching tool_use in the immediately preceding assistant message.
  *
+ * A `tool_use` in the very last message (no message follows it at all) is
+ * never condemned as orphaned here -- "no result yet" isn't the same as
+ * "no result ever": the tool may simply not have finished executing yet,
+ * or this conversion may not be building the completed turn to send to
+ * Anthropic at all (token counting, a resumed/replayed session snapshot,
+ * a retry issued before tool execution completes, ...). Only a `tool_use`
+ * whose subsequent message was actually scanned and found lacking a
+ * matching `tool_result` is a genuine orphan.
+ *
  * Empty messages produced by the cleanup are dropped entirely. A subsequent
  * mergeConsecutiveAssistantMessages call fixes any alternation issues
  * created by dropped messages.
@@ -1106,6 +1115,20 @@ function cleanOrphanedToolCalls(
       }
     }
     if (toolUseBlocks.size === 0) continue;
+
+    // No message follows this assistant turn at all -- these tool_use
+    // blocks are unresolved (the tool hasn't finished executing yet, or
+    // this conversion isn't building the completed turn for Anthropic at
+    // all, e.g. a token-count pass or a mid-tool-call snapshot), not
+    // orphaned. Protect them from the filter below. A genuine orphan
+    // requires a subsequent message that was actually scanned and found
+    // to lack a matching tool_result -- "history ends here" is not that.
+    if (i === messages.length - 1) {
+      for (const block of toolUseBlocks.values()) {
+        validToolUseBlocks.add(block as object);
+      }
+      continue;
+    }
 
     for (let j = i + 1; j < messages.length; j++) {
       const nextMessage = messages[j];


### PR DESCRIPTION
## What this PR does

Sanitizes `tool_use.id` / `tool_result.tool_use_id` in the Anthropic converter so they always conform to Anthropic's required character set and are never an empty string, and keeps a `tool_use`/`tool_result` pair linked to the same wire id after sanitization.

## Why it's needed

`Part.functionCall.id` / `FunctionResponse.id` — the Gemini lingua-franca's own id fields — passed straight through as `tool_use.id` / `tool_result.tool_use_id`, with only an empty-string-style fallback. Anthropic validates both fields against `^[a-zA-Z0-9_-]+$` server-side and rejects anything else, including the empty string (`+` requires at least one character). `functionCall.id` has no such constraint upstream — it can carry another provider's id scheme, a composite/namespaced MCP id, or be entirely absent.

Live-verified against the real Anthropic Messages API (corporate LiteLLM proxy in front of Vertex, `claude-sonnet-4-6`):
- `tool_use.id: "call:abc.def/ghi?jkl"` → HTTP 400, `String should match pattern '^[a-zA-Z0-9_-]+$'`.
- `tool_result.tool_use_id: ""` (the old fallback) → same 400.

## Reviewer Test Plan

### How to verify

1. `npx vitest run packages/core/src/core/anthropicContentGenerator/converter.test.ts` — see the `tool_use id sanitization` describe block: bad-char sanitization with linkage preserved, non-empty fallback generation, no id collisions across two missing-id calls in one request, and same-source-id consistency across `tool_use`/`tool_result` in different messages.
2. Live proxy round-trip (what I ran locally): drove the real `AnthropicContentConverter` with `functionCall.id: 'call:abc.def/ghi?jkl'`, confirmed it sanitizes to `call_abc_def_ghi_jkl` on both the `tool_use` and paired `tool_result`, and sent that body to the real API — HTTP 200 (previously HTTP 400 for the raw id, confirmed separately).

### Evidence (Before & After)

N/A — no UI surface; behavior change is in the outbound Anthropic request body. See the HTTP 400 → 200 transcript above and the `resolveToolUseId` test block for the exact before/after id shapes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only (`vitest`); live verification via a real HTTPS call to Anthropic's Messages API through a corporate LiteLLM proxy in front of Vertex AI (no local sandbox/Docker involved).

## Risk & Scope

- Main risk or tradeoff: changes the wire-visible `tool_use.id` string for any source id that previously passed through unsanitized (e.g. `call:abc` → `call_abc`). This id is opaque to the model and scoped to a single request, so it should be transparent in practice, but it is a behavioral change to what was on the wire.
- Not validated / out of scope: only the Anthropic-native wire path is touched; OpenAI/Gemini converters have their own id-handling (separate concern, not covered here).
- Breaking changes / migration notes: none. This only fixes cases that previously produced HTTP 400 from Anthropic — there is no matching "working" behavior being changed.

## Linked Issues

Fixes #8160

> **Depends on** #8163 (fixes #8159) — cherry-picked onto this branch because one new test needs the trailing-`tool_use` guard from that PR to observe the generated fallback id surviving conversion. This PR's net diff will shrink to just the sanitization change once #8163 merges; whoever merges should land #8163 first.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在 Anthropic 转换器中清洗 `tool_use.id` / `tool_result.tool_use_id`，使其始终符合 Anthropic 要求的字符集且永不为空字符串，并保证 `tool_use`/`tool_result` 配对在清洗后仍解析到同一个 wire id。

## 为什么需要这个改动

`Part.functionCall.id` / `FunctionResponse.id`——Gemini 通用格式自身的 id 字段——被原样传递为 `tool_use.id` / `tool_result.tool_use_id`，只有一个类似空字符串的兜底。Anthropic 在服务端按 `^[a-zA-Z0-9_-]+$` 校验这两个字段，其余一律拒绝，包括空字符串（`+` 要求至少一个字符）。而 `functionCall.id` 在上游没有这种约束——它可能携带其他 provider 的 id 方案、组合/带命名空间的 MCP id，或者根本不存在。

已针对真实 Anthropic Messages API 做了 live 验证（企业内部 LiteLLM 代理，Vertex 后端，`claude-sonnet-4-6`）：
- `tool_use.id: "call:abc.def/ghi?jkl"` → HTTP 400，`String should match pattern '^[a-zA-Z0-9_-]+$'`。
- `tool_result.tool_use_id: ""`（旧的兜底值）→ 同样的 400。

## Reviewer 测试计划

### 如何验证

1. `npx vitest run packages/core/src/core/anthropicContentGenerator/converter.test.ts`——查看 `tool_use id sanitization` describe 块：坏字符清洗且保持链接、非空兜底生成、同一请求内两个 missing-id 调用不冲突、以及跨消息的 `tool_use`/`tool_result` 在相同来源 id 下保持一致。
2. Live 代理往返（我本地运行的验证）：用 `functionCall.id: 'call:abc.def/ghi?jkl'` 驱动真实的 `AnthropicContentConverter`，确认 `tool_use` 和配对的 `tool_result` 都被清洗为 `call_abc_def_ghi_jkl`，并将该请求体发往真实 API——HTTP 200（此前对原始 id 单独确认过是 HTTP 400）。

### 证据（前后对比）

不适用——没有 UI 界面；行为变化体现在发往 Anthropic 的出站请求体中。见上方 HTTP 400 → 200 的记录，以及 `resolveToolUseId` 测试块中的具体前后 id 形态。

### 测试环境

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

仅单元测试（`vitest`）；live 验证是通过企业 LiteLLM 代理（Vertex AI 后端）对 Anthropic Messages API 发起的真实 HTTPS 调用（未涉及本地沙箱/Docker）。

## 风险与范围

- 主要风险或权衡：对此前未经清洗直接透传的 source id，会改变其在 wire 上可见的 `tool_use.id` 字符串（例如 `call:abc` → `call_abc`）。该 id 对模型不透明且仅作用于单次请求，实践中应当是透明的，但确实是对 wire 上内容的行为变更。
- 未验证 / 范围之外：仅改动了 Anthropic 原生 wire 路径；OpenAI/Gemini 转换器有各自的 id 处理逻辑（属于独立议题，本 PR 不涉及）。
- 破坏性变更 / 迁移说明：无。本改动只修复了此前会导致 Anthropic 返回 HTTP 400 的情形——不存在对应的"原本可用"行为被改变。

## 关联 Issue

Fixes #8160

> **依赖** #8163（fixes #8159）——已 cherry-pick 到本分支，因为一个新测试需要该 PR 中的尾部 `tool_use` 保护，才能观察到生成的兜底 id 在转换后存活。一旦 #8163 合并，本 PR 的净 diff 会缩小到只剩清洗改动；合并者应先落地 #8163。

</details>
