### PR TITLE
fix(anthropic): move tool_result blocks first in mixed-content user messages

### DIFF
--- a/packages/core/src/core/anthropicContentGenerator/converter.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.test.ts
@@ -1268,7 +1268,15 @@ describe('AnthropicContentConverter', () => {
       });
     });
 
-    it('drops tool results that do not lead user content', () => {
+    it('reorders a tool_result ahead of other content in the same message rather than dropping it', () => {
+      // Anthropic requires tool_result to be the first content in a user
+      // message replying to a tool_use. A text part preceding the
+      // functionResponse part within the same Gemini Content used to be
+      // treated by cleanOrphanedToolCalls's own "seenNonToolResult" gate as
+      // if the tool_result never showed up at all -- silently discarding
+      // both the tool_result AND its paired tool_use, rather than fixing
+      // the order. Now the blocks are reordered before that gate runs, so
+      // the pairing is recognized and everything survives.
       const { messages } = converter.convertGeminiRequestToAnthropic({
         model: 'models/test',
         contents: [
@@ -1294,16 +1302,68 @@ describe('AnthropicContentConverter', () => {
       });
 
       expect(messages).toEqual([
+        { role: 'user', content: [{ type: 'text', text: 'Hi' }] },
+        {
+          role: 'assistant',
+          content: [{ type: 'tool_use', id: 't1', name: 'tool', input: {} }],
+        },
         {
           role: 'user',
           content: [
-            { type: 'text', text: 'Hi' },
+            { type: 'tool_result', tool_use_id: 't1', content: 'late' },
             {
               type: 'text',
               text: 'preface',
               cache_control: { type: 'ephemeral' },
             },
           ],
+        },
+      ]);
+    });
+
+    it('preserves relative order among multiple tool_result blocks when reordering ahead of text', () => {
+      const { messages } = converter.convertGeminiRequestToAnthropic({
+        model: 'models/test',
+        contents: [
+          { role: 'user', parts: [{ text: 'Hi' }] },
+          {
+            role: 'model',
+            parts: [
+              { functionCall: { id: 't1', name: 'tool', args: {} } },
+              { functionCall: { id: 't2', name: 'tool', args: {} } },
+            ],
+          },
+          {
+            role: 'user',
+            parts: [
+              { text: 'preface' },
+              {
+                functionResponse: {
+                  id: 't1',
+                  name: 'tool',
+                  response: { output: 'first' },
+                },
+              },
+              {
+                functionResponse: {
+                  id: 't2',
+                  name: 'tool',
+                  response: { output: 'second' },
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      const lastMsg = messages[messages.length - 1];
+      expect(lastMsg.content).toEqual([
+        { type: 'tool_result', tool_use_id: 't1', content: 'first' },
+        { type: 'tool_result', tool_use_id: 't2', content: 'second' },
+        {
+          type: 'text',
+          text: 'preface',
+          cache_control: { type: 'ephemeral' },
         },
       ]);
     });

--- a/packages/core/src/core/anthropicContentGenerator/converter.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.ts
@@ -471,6 +471,24 @@ export class AnthropicContentConverter {
     }
 
     if (contentBlocks.length > 0) {
+      // Anthropic requires tool_result to be the first content in a user
+      // message replying to a tool_use -- it doesn't scan past a leading
+      // non-tool_result block to find the result later in the same
+      // message. The source Gemini parts can arrive in any order (e.g. a
+      // text part preceding the functionResponse part within the same
+      // Content), so move tool_result blocks to the front of a user
+      // message whenever any are present. A stable sort preserves the
+      // relative order of multiple tool_result blocks against each other.
+      if (
+        role === 'user' &&
+        contentBlocks.some((b) => b.type === 'tool_result')
+      ) {
+        contentBlocks.sort((a, b) => {
+          if (a.type === 'tool_result' && b.type !== 'tool_result') return -1;
+          if (a.type !== 'tool_result' && b.type === 'tool_result') return 1;
+          return 0;
+        });
+      }
       messages.push({ role, content: contentBlocks });
     }
   }


### PR DESCRIPTION
## What this PR does

Moves `tool_result` blocks ahead of any other content within a user-role message in the Anthropic converter, whenever a `tool_result` is present in that message.

## Why it's needed

When a Gemini `Content` for a user turn contains both a `functionResponse` and other parts (e.g. accompanying text), the converter emitted the resulting content blocks in whatever order the source parts happened to arrive in — it never guaranteed `tool_result` blocks come first. If a text part preceded the `functionResponse` part within the same `Content`, the resulting Anthropic user message put text before `tool_result`.

Live-verified against the real Anthropic Messages API: sending a user message shaped `[{type:'text', ...}, {type:'tool_result', ...}]` right after an assistant `tool_use` produces HTTP 400: `` `tool_use` ids were found without `tool_result` blocks immediately after: <id>. Each `tool_use` block must have a corresponding `tool_result` block in the next message. `` Anthropic doesn't scan past a leading non-`tool_result` block to find the result later in the same message — it must be first.

Worse: `cleanOrphanedToolCalls`'s own `seenNonToolResult` gate (a separate, pre-existing defensive check against exactly this ordering rule) reacts to the misordering by treating the `tool_result` as if it were never found at all — silently discarding **both** the `tool_result` and its paired `tool_use` rather than fixing the order. The previous behavior wasn't even a consistent 400, it was silent data loss of the tool call and its result — confirmed by the existing test this PR rewrites, which was named `drops tool results that do not lead user content` and pinned exactly that discard as expected.

## Reviewer Test Plan

### How to verify

1. `npx vitest run packages/core/src/core/anthropicContentGenerator/converter.test.ts` — see the rewritten `reorders a tool_result ahead of other content in the same message rather than dropping it` test (was `drops tool results that do not lead user content`, now asserts reorder-and-preserve instead of silent discard) and the new `preserves relative order among multiple tool_result blocks when reordering ahead of text` test.
2. Live proxy round-trip (what I ran locally): drove the real converter with a text-before-`functionResponse` Gemini `Content`, confirmed the resulting message reorders to `[tool_result, text]`, and sent that body to the real API — HTTP 200 (previously HTTP 400 for the unreordered shape, confirmed separately).

### Evidence (Before & After)

N/A — no UI surface; behavior change is in the outbound Anthropic request body. See the HTTP 400 → 200 transcript above and the rewritten test's before/after message shapes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only (`vitest`); live verification via a real HTTPS call to Anthropic's Messages API through a corporate LiteLLM proxy in front of Vertex AI (no local sandbox/Docker involved).

## Risk & Scope

- Main risk or tradeoff: reorders (not just filters) content blocks in any user message that carries a `tool_result`, which changes the wire block order for that message. `Array.prototype.sort` is spec-guaranteed stable since ES2019, so relative order among blocks of the same type is preserved.
- Not validated / out of scope: only the Anthropic-native wire path is touched; OpenAI/Chat and Gemini-native converters have their own block ordering and are not affected by this change.
- Breaking changes / migration notes: none. This only fixes a shape that previously either 400'd or was silently discarded by a separate defensive check — there is no matching "working" behavior being changed.

## Linked Issues

Fixes #8161

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在 Anthropic 转换器中，只要某条 user 角色消息里出现了 `tool_result`，就把 `tool_result` 块移到该消息其他内容之前。

## 为什么需要这个改动

当某个 user 轮次的 Gemini `Content` 同时包含 `functionResponse` 和其他 part（例如附带的文本）时，转换器会按源 part 到达的原始顺序输出对应的内容块——从不保证 `tool_result` 块排在最前。如果文本 part 在同一个 `Content` 中出现在 `functionResponse` part 之前，最终生成的 Anthropic user 消息就会把文本排在 `tool_result` 之前。

已针对真实 Anthropic Messages API 做了 live 验证：在一个 assistant `tool_use` 之后，发送形如 `[{type:'text', ...}, {type:'tool_result', ...}]` 的 user 消息会产生 HTTP 400：`` `tool_use` ids were found without `tool_result` blocks immediately after: <id>. Each `tool_use` block must have a corresponding `tool_result` block in the next message. ``。Anthropic 不会跳过一个排在最前的非 `tool_result` 块去寻找同一消息里靠后的结果——它必须排在最前。

更糟的是：`cleanOrphanedToolCalls` 自身的 `seenNonToolResult` 门控（一个针对该排序规则的、独立存在的既有防御检查）在遇到顺序错误时，会把该 `tool_result` 当作根本没有出现过，从而静默地把**该 `tool_result` 及其配对的 `tool_use` 一并丢弃**，而不是修正顺序。此前的行为甚至连稳定的 400 都算不上，而是工具调用及其结果的静默数据丢失——本 PR 重写的既有测试（原名 `drops tool results that do not lead user content`）恰好把这种丢弃行为断言为"预期"，印证了这一点。

## Reviewer 测试计划

### 如何验证

1. `npx vitest run packages/core/src/core/anthropicContentGenerator/converter.test.ts`——查看重写后的测试 `reorders a tool_result ahead of other content in the same message rather than dropping it`（原名 `drops tool results that do not lead user content`，现在断言的是重排并保留，而非静默丢弃），以及新增的 `preserves relative order among multiple tool_result blocks when reordering ahead of text` 测试。
2. Live 代理往返（我本地运行的验证）：用一个"文本先于 `functionResponse`"的 Gemini `Content` 驱动真实转换器，确认生成的消息被重排为 `[tool_result, text]`，并将该请求体发往真实 API——HTTP 200（此前对未重排的形态单独确认过是 HTTP 400）。

### 证据（前后对比）

不适用——没有 UI 界面；行为变化体现在发往 Anthropic 的出站请求体中。见上方 HTTP 400 → 200 的记录，以及重写测试中的前后消息形态。

### 测试环境

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

仅单元测试（`vitest`）；live 验证是通过企业 LiteLLM 代理（Vertex AI 后端）对 Anthropic Messages API 发起的真实 HTTPS 调用（未涉及本地沙箱/Docker）。

## 风险与范围

- 主要风险或权衡：对任何携带 `tool_result` 的 user 消息都会重新排序（而非仅过滤）内容块，改变该消息在 wire 上的块顺序。`Array.prototype.sort` 自 ES2019 起规范保证稳定，因此同类型块之间的相对顺序会被保留。
- 未验证 / 范围之外：仅改动了 Anthropic 原生 wire 路径；OpenAI/Chat 和 Gemini 原生转换器有各自的块排序逻辑，不受本改动影响。
- 破坏性变更 / 迁移说明：无。本改动只修复了此前要么 400、要么被另一个防御检查静默丢弃的形态——不存在对应的"原本可用"行为被改变。

## 关联 Issue

Fixes #8161

</details>
