### PR TITLE
feat(memory): configure background agent turn limits

### DIFF
--- a/docs/users/configuration/settings.md
+++ b/docs/users/configuration/settings.md
@@ -354,6 +354,7 @@ If you are experiencing performance issues with file searching (e.g., with `@` c
 | `memory.enableTeamMemory`        | boolean | Enable a project memory tier shared with collaborators via the git-tracked `.qwen/team-memory/` directory. Writes to it are secret-scanned and reviewable in the git diff.                            | `false` |
 | `memory.enableTeamMemorySync`    | boolean | When team memory is enabled, automatically commit, fast-forward-pull, and push the `.qwen/team-memory/` directory at session start so collaborators stay in sync. Requires a configured git upstream. | `false` |
 | `memory.agentTimeoutMinutes`     | number  | Max runtime in minutes for background memory agents (extraction, dream, remember, skill review). Unset uses each agent's built-in default (2–5 minutes); `0` disables the time limit.                 | unset   |
+| `memory.agentMaxTurns`           | number  | Max turns for background dream and skill-review agents. Unset uses each agent's built-in default (8); `0` disables the turn limit.                                                                    | unset   |
 
 See [Memory](../features/memory) for details on how auto-memory works and how to use the `/memory`, `/remember`, and `/dream` commands.
 

--- a/docs/users/configuration/settings.md
+++ b/docs/users/configuration/settings.md
@@ -354,7 +354,7 @@ If you are experiencing performance issues with file searching (e.g., with `@` c
 | `memory.enableTeamMemory`        | boolean | Enable a project memory tier shared with collaborators via the git-tracked `.qwen/team-memory/` directory. Writes to it are secret-scanned and reviewable in the git diff.                            | `false` |
 | `memory.enableTeamMemorySync`    | boolean | When team memory is enabled, automatically commit, fast-forward-pull, and push the `.qwen/team-memory/` directory at session start so collaborators stay in sync. Requires a configured git upstream. | `false` |
 | `memory.agentTimeoutMinutes`     | number  | Max runtime in minutes for background memory agents (extraction, dream, remember, skill review). Unset uses each agent's built-in default (2–5 minutes); `0` disables the time limit.                 | unset   |
-| `memory.agentMaxTurns`           | number  | Max turns for background dream and skill-review agents. Unset uses each agent's built-in default (8); `0` disables the turn limit.                                                                    | unset   |
+| `memory.agentMaxTurns`           | number  | Max turns for background memory agents (extraction, dream, remember, skill review). Unset uses each agent's built-in default (5–8); `0` disables the turn limit.                                      | unset   |
 
 See [Memory](../features/memory) for details on how auto-memory works and how to use the `/memory`, `/remember`, and `/dream` commands.
 
@@ -406,8 +406,7 @@ Some rule names automatically cover multiple tools:
 | `Read`    | `read_file`, `grep_search`, `glob`, `list_directory` |
 | `Edit`    | `edit`, `write_file`, `notebook_edit`                |
 
-> [!important]
-> `Read(/path/**)` matches **all four** read tools (file read, grep, glob, and directory listing).
+> [!important] > `Read(/path/**)` matches **all four** read tools (file read, grep, glob, and directory listing).
 > To restrict only file reading, use `ReadFile(/path/**)` or `read_file(/path/**)`.
 
 **Rule syntax examples:**
@@ -521,8 +520,7 @@ The precedence is `skills.disabled` > `skills.enabled` > `skills.defaultDisabled
 
 #### lsp
 
-> [!warning]
-> **Experimental Feature**: LSP support is currently experimental and disabled by default. Enable it using the `--experimental-lsp` command line flag.
+> [!warning] > **Experimental Feature**: LSP support is currently experimental and disabled by default. Enable it using the `--experimental-lsp` command line flag.
 
 Language Server Protocol (LSP) provides code intelligence features like go-to-definition, find references, and diagnostics.
 

--- a/docs/users/configuration/settings.md
+++ b/docs/users/configuration/settings.md
@@ -406,7 +406,8 @@ Some rule names automatically cover multiple tools:
 | `Read`    | `read_file`, `grep_search`, `glob`, `list_directory` |
 | `Edit`    | `edit`, `write_file`, `notebook_edit`                |
 
-> [!important] > `Read(/path/**)` matches **all four** read tools (file read, grep, glob, and directory listing).
+> [!important]
+> `Read(/path/**)` matches **all four** read tools (file read, grep, glob, and directory listing).
 > To restrict only file reading, use `ReadFile(/path/**)` or `read_file(/path/**)`.
 
 **Rule syntax examples:**
@@ -520,7 +521,8 @@ The precedence is `skills.disabled` > `skills.enabled` > `skills.defaultDisabled
 
 #### lsp
 
-> [!warning] > **Experimental Feature**: LSP support is currently experimental and disabled by default. Enable it using the `--experimental-lsp` command line flag.
+> [!warning]
+> **Experimental Feature**: LSP support is currently experimental and disabled by default. Enable it using the `--experimental-lsp` command line flag.
 
 Language Server Protocol (LSP) provides code intelligence features like go-to-definition, find references, and diagnostics.
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -2286,6 +2286,7 @@ export async function loadCliConfig(
         ? false
         : (settings.memory?.autoSkillConfirm ?? true),
     memoryAgentTimeoutMinutes: settings.memory?.agentTimeoutMinutes,
+    memoryAgentMaxTurns: settings.memory?.agentMaxTurns,
     fastModel: settings.fastModel || undefined,
     webSearch:
       bareMode || safeMode ? undefined : resolveWebSearchSettings(settings),

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1925,6 +1925,17 @@ const SETTINGS_SCHEMA = {
           "Max runtime in minutes for background memory agents (extraction, dream, remember, skill review). Unset uses each agent's built-in default (2–5 minutes); 0 disables the time limit. Useful for slow local models that need longer than the defaults.",
         showInDialog: false,
       },
+      agentMaxTurns: {
+        type: 'number',
+        label: 'Memory Agent Max Turns',
+        category: 'Memory',
+        requiresRestart: true,
+        default: undefined as number | undefined,
+        minimum: 0,
+        description:
+          "Max turns for background dream and skill-review agents. Unset uses each agent's built-in default (8); 0 disables the turn limit.",
+        showInDialog: false,
+      },
       enableTeamMemory: {
         type: 'boolean',
         label: 'Enable Team Memory',

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1933,7 +1933,7 @@ const SETTINGS_SCHEMA = {
         default: undefined as number | undefined,
         minimum: 0,
         description:
-          "Max turns for background dream and skill-review agents. Unset uses each agent's built-in default (8); 0 disables the turn limit.",
+          "Max turns for background memory agents (extraction, dream, remember, skill review). Unset uses each agent's built-in default (5–8); 0 disables the turn limit.",
         showInDialog: false,
       },
       enableTeamMemory: {

--- a/packages/core/src/agents/runtime/agent-headless.test.ts
+++ b/packages/core/src/agents/runtime/agent-headless.test.ts
@@ -2545,6 +2545,32 @@ describe('subagent.ts', () => {
         expect(scope.getTerminateMode()).toBe(AgentTerminateMode.MAX_TURNS);
       });
 
+      it('should treat max_turns 0 as an unlimited turn budget', async () => {
+        const { config } = await createMockConfig();
+        const runConfig: RunConfig = { ...defaultRunConfig, max_turns: 0 };
+
+        mockSendMessageStream.mockImplementation(
+          createMockStream([
+            [{ name: 'list_files', args: { path: '/test' } }],
+            [{ name: 'list_files', args: { path: '/test2' } }],
+            'stop',
+          ]),
+        );
+
+        const scope = await AgentHeadless.create(
+          'test-agent',
+          config,
+          promptConfig,
+          defaultModelConfig,
+          runConfig,
+        );
+
+        await scope.execute(new ContextState());
+
+        expect(mockSendMessageStream).toHaveBeenCalledTimes(3);
+        expect(scope.getTerminateMode()).toBe(AgentTerminateMode.GOAL);
+      });
+
       it('should terminate with TIMEOUT if the time limit is reached during an LLM call', async () => {
         // Use fake timers to reliably test timeouts
         vi.useFakeTimers();

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -624,6 +624,45 @@ describe('Server Config (config.ts)', () => {
     });
   });
 
+  describe('getMemoryAgentMaxTurns', () => {
+    it('returns undefined when unset', () => {
+      expect(new Config(baseParams).getMemoryAgentMaxTurns()).toBeUndefined();
+    });
+
+    it('passes through non-negative values, including 0', () => {
+      expect(
+        new Config({
+          ...baseParams,
+          memoryAgentMaxTurns: 25,
+        }).getMemoryAgentMaxTurns(),
+      ).toBe(25);
+      expect(
+        new Config({
+          ...baseParams,
+          memoryAgentMaxTurns: 0,
+        }).getMemoryAgentMaxTurns(),
+      ).toBe(0);
+    });
+
+    it('treats negative values as unset', () => {
+      expect(
+        new Config({
+          ...baseParams,
+          memoryAgentMaxTurns: -1,
+        }).getMemoryAgentMaxTurns(),
+      ).toBeUndefined();
+    });
+
+    it('treats fractional values as unset', () => {
+      expect(
+        new Config({
+          ...baseParams,
+          memoryAgentMaxTurns: 2.5,
+        }).getMemoryAgentMaxTurns(),
+      ).toBeUndefined();
+    });
+  });
+
   describe('getVisionBridgeTimeoutMs', () => {
     it('returns undefined when unset', () => {
       expect(new Config(baseParams).getVisionBridgeTimeoutMs()).toBeUndefined();

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1254,6 +1254,11 @@ export interface ConfigParameters {
    */
   memoryAgentTimeoutMinutes?: number;
   /**
+   * Max turns for background memory agents (dream and skill review). Unset
+   * means each agent uses its built-in default; 0 disables the turn limit.
+   */
+  memoryAgentMaxTurns?: number;
+  /**
    * Lightweight model for background tasks (memory extraction, dream, /btw side questions).
    * When set and valid for the current auth type, forked agents use this model instead of
    * the main session model, reducing latency and cost.
@@ -2006,6 +2011,7 @@ export class Config {
   private enableAutoSkill: boolean;
   private readonly autoSkillConfirm: boolean;
   private readonly memoryAgentTimeoutMinutes: number | undefined;
+  private readonly memoryAgentMaxTurns: number | undefined;
   private fastModel?: string;
   private readonly webSearchSettings?: WebSearchSettings;
   private webSearchNoticeEmitted = false;
@@ -2450,6 +2456,12 @@ export class Config {
       params.memoryAgentTimeoutMinutes !== undefined &&
       params.memoryAgentTimeoutMinutes >= 0
         ? params.memoryAgentTimeoutMinutes
+        : undefined;
+    this.memoryAgentMaxTurns =
+      params.memoryAgentMaxTurns !== undefined &&
+      Number.isInteger(params.memoryAgentMaxTurns) &&
+      params.memoryAgentMaxTurns >= 0
+        ? params.memoryAgentMaxTurns
         : undefined;
     this.fastModel = params.fastModel || undefined;
     this.webSearchSettings = params.webSearch;
@@ -6710,6 +6722,15 @@ export class Config {
    */
   getMemoryAgentTimeoutMinutes(): number | undefined {
     return this.memoryAgentTimeoutMinutes;
+  }
+
+  /**
+   * Max turns for background memory agents (dream and skill review). Resolves
+   * the `memory.agentMaxTurns` setting. Unset means each agent's built-in
+   * default; 0 disables the turn limit.
+   */
+  getMemoryAgentMaxTurns(): number | undefined {
+    return this.memoryAgentMaxTurns;
   }
 
   getPreventSystemSleepEnabled(): boolean {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1254,8 +1254,9 @@ export interface ConfigParameters {
    */
   memoryAgentTimeoutMinutes?: number;
   /**
-   * Max turns for background memory agents (dream and skill review). Unset
-   * means each agent uses its built-in default; 0 disables the turn limit.
+   * Max turns for background memory agents (extraction, dream, remember, and
+   * skill review). Unset means each agent uses its built-in default; 0
+   * disables the turn limit.
    */
   memoryAgentMaxTurns?: number;
   /**
@@ -6725,9 +6726,9 @@ export class Config {
   }
 
   /**
-   * Max turns for background memory agents (dream and skill review). Resolves
-   * the `memory.agentMaxTurns` setting. Unset means each agent's built-in
-   * default; 0 disables the turn limit.
+   * Max turns for background memory agents. Resolves the
+   * `memory.agentMaxTurns` setting. Unset means each agent's built-in default;
+   * 0 disables the turn limit.
    */
   getMemoryAgentMaxTurns(): number | undefined {
     return this.memoryAgentMaxTurns;

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -6843,6 +6843,9 @@ hello
             config: mockConfig,
           }),
         );
+        expect(
+          mockMemoryManager.scheduleSkillReview.mock.calls[0][0],
+        ).not.toHaveProperty('maxTurns');
       });
 
       it('should reset toolCallCount and push promise when review is scheduled', async () => {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -83,7 +83,6 @@ import { CommitAttributionService } from '../services/commitAttribution.js';
 import type { RelevantAutoMemoryPromptResult } from '../memory/manager.js';
 import { AUTO_SKILL_THRESHOLD } from '../memory/manager.js';
 import { isManagedMemoryPath } from '../memory/paths.js';
-import { DEFAULT_AUTO_SKILL_MAX_TURNS } from '../memory/skillReviewAgentPlanner.js';
 import { isProjectSkillPath } from '../skills/skill-paths.js';
 import { ToolNames } from '../tools/tool-names.js';
 
@@ -1825,7 +1824,6 @@ export class GeminiClient {
           skillsModified: this.skillsModifiedInSession,
           enabled: autoSkillEnabled,
           threshold: AUTO_SKILL_THRESHOLD,
-          maxTurns: DEFAULT_AUTO_SKILL_MAX_TURNS,
           confirmBeforePersist: this.config.getAutoSkillConfirmEnabled(),
         });
         if (skillReviewResult.status === 'scheduled') {

--- a/packages/core/src/memory/dreamAgentPlanner.test.ts
+++ b/packages/core/src/memory/dreamAgentPlanner.test.ts
@@ -51,6 +51,7 @@ describe('dreamAgentPlanner', () => {
       getModel: vi.fn().mockReturnValue('qwen-test'),
       getApprovalMode: vi.fn(),
       getMemoryAgentTimeoutMinutes: vi.fn().mockReturnValue(undefined),
+      getMemoryAgentMaxTurns: vi.fn().mockReturnValue(undefined),
     } as unknown as Config;
     vi.mocked(runForkedAgent).mockReset();
   });
@@ -153,6 +154,20 @@ describe('dreamAgentPlanner', () => {
 
     expect(runForkedAgent).toHaveBeenCalledWith(
       expect.objectContaining({ maxTimeMinutes: 30 }),
+    );
+  });
+
+  it('threads the configured memory agent turn limit into the forked agent', async () => {
+    vi.mocked(runForkedAgent).mockResolvedValue({
+      status: 'completed',
+      filesTouched: [],
+    } satisfies ForkedAgentResult);
+    vi.mocked(config.getMemoryAgentMaxTurns).mockReturnValueOnce(25);
+
+    await planManagedAutoMemoryDreamByAgent(config, projectRoot);
+
+    expect(runForkedAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ maxTurns: 25 }),
     );
   });
 

--- a/packages/core/src/memory/dreamAgentPlanner.test.ts
+++ b/packages/core/src/memory/dreamAgentPlanner.test.ts
@@ -171,6 +171,20 @@ describe('dreamAgentPlanner', () => {
     );
   });
 
+  it('preserves the zero turn limit sentinel', async () => {
+    vi.mocked(runForkedAgent).mockResolvedValue({
+      status: 'completed',
+      filesTouched: [],
+    } satisfies ForkedAgentResult);
+    vi.mocked(config.getMemoryAgentMaxTurns).mockReturnValueOnce(0);
+
+    await planManagedAutoMemoryDreamByAgent(config, projectRoot);
+
+    expect(runForkedAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ maxTurns: 0 }),
+    );
+  });
+
   it('can read transcripts while keeping writes project-memory-only', async () => {
     vi.mocked(runForkedAgent).mockResolvedValue({
       status: 'completed',

--- a/packages/core/src/memory/dreamAgentPlanner.ts
+++ b/packages/core/src/memory/dreamAgentPlanner.ts
@@ -107,7 +107,7 @@ export async function planManagedAutoMemoryDreamByAgent(
     config: scopedConfig,
     taskPrompt: buildConsolidationTaskPrompt(memoryRoot, transcriptDir),
     systemPrompt: DREAM_AGENT_SYSTEM_PROMPT,
-    maxTurns: MAX_TURNS,
+    maxTurns: config.getMemoryAgentMaxTurns() ?? MAX_TURNS,
     maxTimeMinutes: config.getMemoryAgentTimeoutMinutes() ?? MAX_TIME_MINUTES,
     tools: [
       ToolNames.READ_FILE,

--- a/packages/core/src/memory/extractionAgentPlanner.test.ts
+++ b/packages/core/src/memory/extractionAgentPlanner.test.ts
@@ -45,6 +45,7 @@ describe('runAutoMemoryExtractionByAgent', () => {
     getModel: vi.fn().mockReturnValue('qwen3-coder-plus'),
     getApprovalMode: vi.fn(),
     getMemoryAgentTimeoutMinutes: vi.fn().mockReturnValue(undefined),
+    getMemoryAgentMaxTurns: vi.fn().mockReturnValue(undefined),
   } as unknown as Config;
 
   beforeEach(() => {
@@ -135,6 +136,38 @@ describe('runAutoMemoryExtractionByAgent', () => {
 
     expect(runForkedAgent).toHaveBeenCalledWith(
       expect.objectContaining({ maxTimeMinutes: 0 }),
+    );
+  });
+
+  it('threads the configured memory agent turn limit into the forked agent', async () => {
+    vi.mocked(runForkedAgent).mockResolvedValue({
+      status: 'completed',
+      finalText: '',
+      filesTouched: [],
+      filesWritten: [],
+    });
+    vi.mocked(mockConfig.getMemoryAgentMaxTurns).mockReturnValueOnce(25);
+
+    await runAutoMemoryExtractionByAgent(mockConfig, '/tmp');
+
+    expect(runForkedAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ maxTurns: 25 }),
+    );
+  });
+
+  it('passes the zero turn-limit sentinel through to the forked agent', async () => {
+    vi.mocked(runForkedAgent).mockResolvedValue({
+      status: 'completed',
+      finalText: '',
+      filesTouched: [],
+      filesWritten: [],
+    });
+    vi.mocked(mockConfig.getMemoryAgentMaxTurns).mockReturnValueOnce(0);
+
+    await runAutoMemoryExtractionByAgent(mockConfig, '/tmp');
+
+    expect(runForkedAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ maxTurns: 0 }),
     );
   });
 

--- a/packages/core/src/memory/extractionAgentPlanner.ts
+++ b/packages/core/src/memory/extractionAgentPlanner.ts
@@ -270,7 +270,7 @@ export async function runAutoMemoryExtractionByAgent(
       topicSummaries,
     ),
     systemPrompt: EXTRACTION_AGENT_SYSTEM_PROMPT,
-    maxTurns: 5,
+    maxTurns: config.getMemoryAgentMaxTurns() ?? 5,
     maxTimeMinutes: config.getMemoryAgentTimeoutMinutes() ?? 2,
     tools: [
       ToolNames.READ_FILE,

--- a/packages/core/src/memory/remember.test.ts
+++ b/packages/core/src/memory/remember.test.ts
@@ -256,6 +256,28 @@ describe('remember memory helper', () => {
     );
   });
 
+  it('passes the zero turn-limit sentinel through to the forked agent', async () => {
+    vi.mocked(runForkedAgent).mockResolvedValue({
+      status: 'completed',
+      finalText: '',
+      filesTouched: [],
+      filesWritten: [],
+    } satisfies ForkedAgentResult);
+    const config = createConfig(projectRoot);
+    vi.mocked(config.getMemoryAgentMaxTurns).mockReturnValue(0);
+
+    await runManagedRememberByAgent({
+      config,
+      projectRoot,
+      content: 'Remember this.',
+      contextMode: 'workspace',
+    });
+
+    expect(runForkedAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ maxTurns: 0 }),
+    );
+  });
+
   it('lets managed-memory writes bypass base ask rules', async () => {
     const touched = path.join(getUserAutoMemoryRoot(), 'user.md');
     const basePm: Pick<

--- a/packages/core/src/memory/remember.test.ts
+++ b/packages/core/src/memory/remember.test.ts
@@ -47,6 +47,7 @@ function createConfig(
     getProjectRoot: vi.fn().mockReturnValue(projectRoot),
     getUserMemory: vi.fn().mockReturnValue('QWEN/AGENTS guidance'),
     getMemoryAgentTimeoutMinutes: vi.fn().mockReturnValue(undefined),
+    getMemoryAgentMaxTurns: vi.fn().mockReturnValue(undefined),
     ...overrides,
   } as unknown as Config;
 }
@@ -230,6 +231,28 @@ describe('remember memory helper', () => {
 
     expect(runForkedAgent).toHaveBeenCalledWith(
       expect.objectContaining({ maxTimeMinutes: 5 }),
+    );
+  });
+
+  it('threads the configured memory agent turn limit into the forked agent', async () => {
+    vi.mocked(runForkedAgent).mockResolvedValue({
+      status: 'completed',
+      finalText: '',
+      filesTouched: [],
+      filesWritten: [],
+    } satisfies ForkedAgentResult);
+    const config = createConfig(projectRoot);
+    vi.mocked(config.getMemoryAgentMaxTurns).mockReturnValue(25);
+
+    await runManagedRememberByAgent({
+      config,
+      projectRoot,
+      content: 'Remember this.',
+      contextMode: 'workspace',
+    });
+
+    expect(runForkedAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ maxTurns: 25 }),
     );
   });
 

--- a/packages/core/src/memory/remember.ts
+++ b/packages/core/src/memory/remember.ts
@@ -191,7 +191,7 @@ export async function runManagedRememberByAgent(params: {
       wrapUserContent: true,
     }),
     systemPrompt: buildRememberSystemPrompt(memoryPrompt),
-    maxTurns: 6,
+    maxTurns: params.config.getMemoryAgentMaxTurns() ?? 6,
     maxTimeMinutes: params.config.getMemoryAgentTimeoutMinutes() ?? 5,
     extraHistory: params.contextMode === 'clean' ? [] : undefined,
     preserveEmptyExtraHistory: params.contextMode === 'clean',

--- a/packages/core/src/memory/skillReviewAgentPlanner.test.ts
+++ b/packages/core/src/memory/skillReviewAgentPlanner.test.ts
@@ -22,6 +22,7 @@ import {
   AUTO_SKILL_DIR_PREFIX,
   buildTaskPrompt,
   createSkillScopedAgentConfig,
+  DEFAULT_AUTO_SKILL_MAX_TURNS,
   DEFAULT_AUTO_SKILL_TIMEOUT_MS,
   listExistingSkillDirNames,
   runSkillReviewByAgent,
@@ -464,6 +465,7 @@ describe('runSkillReviewByAgent timeout wiring', () => {
 
     expect(runForkedAgent).toHaveBeenCalledWith(
       expect.objectContaining({
+        maxTurns: DEFAULT_AUTO_SKILL_MAX_TURNS,
         maxTimeMinutes: DEFAULT_AUTO_SKILL_TIMEOUT_MS / 60_000,
       }),
     );

--- a/packages/core/src/memory/skillReviewAgentPlanner.test.ts
+++ b/packages/core/src/memory/skillReviewAgentPlanner.test.ts
@@ -447,6 +447,31 @@ describe('runSkillReviewByAgent limit wiring', () => {
     );
   });
 
+  it('passes the zero turn-limit sentinel through to the forked agent', async () => {
+    await runSkillReviewByAgent({
+      config: makeConfig({ maxTurns: 0 }),
+      projectRoot,
+      history: [],
+    });
+
+    expect(runForkedAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ maxTurns: 0 }),
+    );
+  });
+
+  it('lets an explicit maxTurns param override the configured value', async () => {
+    await runSkillReviewByAgent({
+      config: makeConfig({ maxTurns: 25 }),
+      projectRoot,
+      history: [],
+      maxTurns: 3,
+    });
+
+    expect(runForkedAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ maxTurns: 3 }),
+    );
+  });
+
   it('lets an explicit timeoutMs param override the configured value', async () => {
     await runSkillReviewByAgent({
       config: makeConfig({ timeoutMinutes: 30 }),

--- a/packages/core/src/memory/skillReviewAgentPlanner.test.ts
+++ b/packages/core/src/memory/skillReviewAgentPlanner.test.ts
@@ -390,11 +390,15 @@ describe('runSkillReviewByAgent timeout wiring', () => {
   let tempDir: string;
   let projectRoot: string;
 
-  function makeConfig(timeoutMinutes: number | undefined): Config {
+  function makeConfig(
+    timeoutMinutes: number | undefined,
+    maxTurns: number | undefined = undefined,
+  ): Config {
     return {
       getProjectRoot: () => projectRoot,
       getPermissionManager: () => undefined,
       getMemoryAgentTimeoutMinutes: vi.fn().mockReturnValue(timeoutMinutes),
+      getMemoryAgentMaxTurns: vi.fn().mockReturnValue(maxTurns),
     } as unknown as Config;
   }
 
@@ -423,6 +427,18 @@ describe('runSkillReviewByAgent timeout wiring', () => {
 
     expect(runForkedAgent).toHaveBeenCalledWith(
       expect.objectContaining({ maxTimeMinutes: 30 }),
+    );
+  });
+
+  it('uses the configured memory agent turn limit when maxTurns is omitted', async () => {
+    await runSkillReviewByAgent({
+      config: makeConfig(undefined, 25),
+      projectRoot,
+      history: [],
+    });
+
+    expect(runForkedAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ maxTurns: 25 }),
     );
   });
 

--- a/packages/core/src/memory/skillReviewAgentPlanner.test.ts
+++ b/packages/core/src/memory/skillReviewAgentPlanner.test.ts
@@ -387,19 +387,23 @@ describe('SKILL_REVIEW_SYSTEM_PROMPT', () => {
   });
 });
 
-describe('runSkillReviewByAgent timeout wiring', () => {
+describe('runSkillReviewByAgent limit wiring', () => {
   let tempDir: string;
   let projectRoot: string;
 
   function makeConfig(
-    timeoutMinutes: number | undefined,
-    maxTurns: number | undefined = undefined,
+    options: {
+      timeoutMinutes?: number;
+      maxTurns?: number;
+    } = {},
   ): Config {
     return {
       getProjectRoot: () => projectRoot,
       getPermissionManager: () => undefined,
-      getMemoryAgentTimeoutMinutes: vi.fn().mockReturnValue(timeoutMinutes),
-      getMemoryAgentMaxTurns: vi.fn().mockReturnValue(maxTurns),
+      getMemoryAgentTimeoutMinutes: vi
+        .fn()
+        .mockReturnValue(options.timeoutMinutes),
+      getMemoryAgentMaxTurns: vi.fn().mockReturnValue(options.maxTurns),
     } as unknown as Config;
   }
 
@@ -421,7 +425,7 @@ describe('runSkillReviewByAgent timeout wiring', () => {
 
   it('uses the configured memory agent timeout when no timeoutMs param is passed', async () => {
     await runSkillReviewByAgent({
-      config: makeConfig(30),
+      config: makeConfig({ timeoutMinutes: 30 }),
       projectRoot,
       history: [],
     });
@@ -433,7 +437,7 @@ describe('runSkillReviewByAgent timeout wiring', () => {
 
   it('uses the configured memory agent turn limit when maxTurns is omitted', async () => {
     await runSkillReviewByAgent({
-      config: makeConfig(undefined, 25),
+      config: makeConfig({ maxTurns: 25 }),
       projectRoot,
       history: [],
     });
@@ -445,7 +449,7 @@ describe('runSkillReviewByAgent timeout wiring', () => {
 
   it('lets an explicit timeoutMs param override the configured value', async () => {
     await runSkillReviewByAgent({
-      config: makeConfig(30),
+      config: makeConfig({ timeoutMinutes: 30 }),
       projectRoot,
       history: [],
       timeoutMs: 60_000,
@@ -458,7 +462,7 @@ describe('runSkillReviewByAgent timeout wiring', () => {
 
   it('falls back to the built-in default when neither is set', async () => {
     await runSkillReviewByAgent({
-      config: makeConfig(undefined),
+      config: makeConfig(),
       projectRoot,
       history: [],
     });

--- a/packages/core/src/memory/skillReviewAgentPlanner.ts
+++ b/packages/core/src/memory/skillReviewAgentPlanner.ts
@@ -371,7 +371,10 @@ export async function runSkillReviewByAgent(params: {
     config: scopedConfig,
     taskPrompt: await buildTaskPrompt(params.projectRoot),
     systemPrompt: SKILL_REVIEW_SYSTEM_PROMPT,
-    maxTurns: params.maxTurns ?? DEFAULT_AUTO_SKILL_MAX_TURNS,
+    maxTurns:
+      params.maxTurns ??
+      params.config.getMemoryAgentMaxTurns() ??
+      DEFAULT_AUTO_SKILL_MAX_TURNS,
     maxTimeMinutes:
       params.timeoutMs !== undefined
         ? params.timeoutMs / 60_000

--- a/packages/core/src/memory/skillReviewAgentPlanner.ts
+++ b/packages/core/src/memory/skillReviewAgentPlanner.ts
@@ -359,7 +359,9 @@ export async function runSkillReviewByAgent(params: {
   config: Config;
   projectRoot: string;
   history: Content[];
+  /** Per-call turn override; the shared memory setting is used otherwise. */
   maxTurns?: number;
+  /** Per-call timeout override; the shared memory setting is used otherwise. */
   timeoutMs?: number;
 }): Promise<SkillReviewExecutionResult> {
   const scopedConfig = createSkillScopedAgentConfig(

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -871,6 +871,11 @@
           "type": "number",
           "minimum": 0
         },
+        "agentMaxTurns": {
+          "description": "Max turns for background dream and skill-review agents. Unset uses each agent's built-in default (8); 0 disables the turn limit.",
+          "type": "number",
+          "minimum": 0
+        },
         "enableTeamMemory": {
           "description": "Enable a project memory tier shared with collaborators via the git-tracked `.qwen/team-memory/` directory. Off by default; writes to it are secret-scanned and reviewable in the git diff.",
           "type": "boolean",

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -872,7 +872,7 @@
           "minimum": 0
         },
         "agentMaxTurns": {
-          "description": "Max turns for background dream and skill-review agents. Unset uses each agent's built-in default (8); 0 disables the turn limit.",
+          "description": "Max turns for background memory agents (extraction, dream, remember, skill review). Unset uses each agent's built-in default (5–8); 0 disables the turn limit.",
           "type": "number",
           "minimum": 0
         },


### PR DESCRIPTION
## Summary

Fixes #8168.

This adds a shared `memory.agentMaxTurns` setting for all four managed memory agents: extraction, dream, remember, and skill review. When unset, each keeps its existing built-in default of 5, 8, 6, or 8 turns. Non-negative integers are accepted, `0` disables the turn limit, and invalid negative or fractional values fall back to the built-in defaults.

The setting is wired through the core Config, CLI settings schema, generated VS Code schema, and user settings documentation. The explicit `maxTurns` argument for skill review still takes precedence over the shared setting. The normal background paths now leave that argument unset, so the shared setting reaches all four agents.

## Testing

- Prettier check passes for all changed files
- `git diff --check` passes
- The checkout does not have the workspace Vitest dependency installed, so the targeted Vitest run could not start locally; the new coverage is in the existing core test suites for extraction, remember, skill review, and the `max_turns: 0` runtime contract

## Screenshots

Not applicable. This is a configuration and background-agent behavior change without a visual UI surface.