### PR TITLE
feat(channels): isolate daemon adapter state by workspace

### DIFF
--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -178,6 +178,10 @@ class TestChannel extends ChannelBase {
     );
   }
 
+  stateDirForTest(): string | undefined {
+    return this.stateDir;
+  }
+
   debugPayloadForTest(platform: string, payload: unknown): void {
     this.logDebugPayload(platform, payload);
   }
@@ -411,6 +415,12 @@ describe('ChannelBase', () => {
       options,
     );
   }
+
+  it('exposes runtime-owned state to adapters', () => {
+    expect(
+      createChannel({}, { stateDir: '/tmp/channel-state' }).stateDirForTest(),
+    ).toBe('/tmp/channel-state');
+  });
 
   describe('proactive delivery boundary', () => {
     it('recognizes typed delivery errors across module instances', () => {

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -208,6 +208,8 @@ interface ChannelMemoryRecallSelection {
 export interface ChannelBaseOptions {
   router?: SessionRouter;
   proxy?: string;
+  /** Adapter-owned persistent state directory. */
+  stateDir?: string;
   channelMemory?: ChannelMemoryCallbacks;
   memoryIntentClassifier?: ChannelMemoryIntentClassifier;
   channelMemoryRecallObserver?: (
@@ -359,6 +361,8 @@ export abstract class ChannelBase {
   protected readonly memoryScope: ChannelRuntimeMemoryScope;
   /** Resolved proxy URL, available to subclasses for adapter-specific clients. */
   protected proxy?: string;
+  /** Adapter-owned persistent state directory, when supplied by the runtime. */
+  protected readonly stateDir?: string;
   private readonly channelMemory?: ChannelMemoryCallbacks;
   private readonly memoryIntentClassifier?: ChannelMemoryIntentClassifier;
   private readonly channelMemoryRecallObserver?: (
@@ -789,6 +793,7 @@ export abstract class ChannelBase {
     this.config = config;
     this.bridge = bridge;
     this.proxy = options?.proxy;
+    this.stateDir = options?.stateDir;
     this.identity = Object.freeze(this.resolveIdentity(name, config));
     this.memoryScope = Object.freeze(this.resolveMemoryScope(name, config));
     this.channelMemory = options?.channelMemory;

--- a/packages/cli/src/commands/channel/daemon-worker.test.ts
+++ b/packages/cli/src/commands/channel/daemon-worker.test.ts
@@ -33,6 +33,12 @@ const mockDaemonObservedContactsPath = vi.hoisted(() =>
     () => '/tmp/qwen/channels/daemon/workspace-hash/observed-contacts.json',
   ),
 );
+const mockDaemonChannelStateDir = vi.hoisted(() =>
+  vi.fn(
+    (workspace: string, channelName: string) =>
+      `/tmp/qwen/channels/daemon/${workspace === '/workspace' ? 'workspace-hash' : 'other-hash'}/instances/${channelName}-hash`,
+  ),
+);
 const mockObserveContact = vi.hoisted(() => vi.fn());
 const mockObservedContactStore = vi.hoisted(() =>
   vi.fn(() => ({
@@ -225,6 +231,7 @@ vi.mock('./proxy.js', () => ({
 vi.mock('./runtime.js', () => ({
   createChannel: mockCreateChannel,
   daemonChannelLoopPath: mockDaemonChannelLoopPath,
+  daemonChannelStateDir: mockDaemonChannelStateDir,
   daemonObservedContactsPath: mockDaemonObservedContactsPath,
   daemonSessionRoutesPath: mockDaemonSessionRoutesPath,
   loadChannelsConfig: mockLoadChannelsConfig,
@@ -792,7 +799,13 @@ describe('runChannelDaemonWorker', () => {
         observedContacts: {
           observe: expect.any(Function),
         },
+        stateDir:
+          '/tmp/qwen/channels/daemon/workspace-hash/instances/telegram-hash',
       }),
+    );
+    expect(mockDaemonChannelStateDir).toHaveBeenCalledWith(
+      '/workspace',
+      'telegram',
     );
     expect(mockDaemonObservedContactsPath).toHaveBeenCalledWith('/workspace');
     expect(mockObservedContactStore).toHaveBeenCalledWith(

--- a/packages/cli/src/commands/channel/daemon-worker.ts
+++ b/packages/cli/src/commands/channel/daemon-worker.ts
@@ -69,6 +69,7 @@ import { resolveProxyUrl } from './proxy.js';
 import {
   createChannel,
   daemonChannelLoopPath,
+  daemonChannelStateDir,
   daemonObservedContactsPath,
   daemonSessionRoutesPath,
   loadChannelsConfig,
@@ -533,6 +534,7 @@ export async function runChannelDaemonWorker(
           createChannel(name, config, bridgeFacade, {
             ...(proxy ? { proxy } : {}),
             router: createdRouter,
+            stateDir: daemonChannelStateDir(daemonWorkspace, name),
             channelMemory: {
               readChannelMemory,
               getChannelMemoryRevision,

--- a/packages/cli/src/commands/channel/runtime.test.ts
+++ b/packages/cli/src/commands/channel/runtime.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   channelLoopPath,
   daemonChannelLoopPath,
+  daemonChannelStateDir,
   daemonObservedContactsPath,
   daemonSessionRoutesPath,
   parseConfiguredChannels,
@@ -65,6 +66,18 @@ it('isolates daemon loop stores by workspace hash', () => {
   );
   expect(daemonChannelLoopPath('/workspace')).not.toBe(channelLoopPath());
   expect(daemonChannelLoopPath('/workspace')).not.toBe(sessionsPath());
+});
+
+it('isolates daemon channel state by workspace and safe instance key', () => {
+  const stateDir = daemonChannelStateDir('/workspace', 'team/../bot');
+
+  expect(stateDir).toMatch(
+    /^\/tmp\/qwen\/channels\/daemon\/workspace-hash\/instances\/team_\.\._bot-[0-9a-f]{16}$/,
+  );
+  expect(stateDir).not.toContain('/../');
+  expect(daemonChannelStateDir('/workspace', 'team/../bot')).toBe(stateDir);
+  expect(daemonChannelStateDir('/workspace', 'team:../bot')).not.toBe(stateDir);
+  expect(daemonChannelStateDir('/other', 'team/../bot')).not.toBe(stateDir);
 });
 
 describe('parseConfiguredChannels', () => {

--- a/packages/cli/src/commands/channel/runtime.ts
+++ b/packages/cli/src/commands/channel/runtime.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { hashDaemonWorkspace, Storage } from '@qwen-code/qwen-code-core';
@@ -54,6 +55,22 @@ export function daemonObservedContactsPath(workspaceCwd: string): string {
 
 export function daemonChannelLoopPath(workspaceCwd: string): string {
   return daemonChannelStatePath(workspaceCwd, 'cron.json');
+}
+
+export function daemonChannelStateDir(
+  workspaceCwd: string,
+  channelName: string,
+): string {
+  const label =
+    channelName.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 32) || 'channel';
+  const hash = createHash('sha256')
+    .update(channelName)
+    .digest('hex')
+    .slice(0, 16);
+  return daemonChannelStatePath(
+    workspaceCwd,
+    path.join('instances', `${label}-${hash}`),
+  );
 }
 
 export function channelLoopPath(): string {


### PR DESCRIPTION
## What this PR does

Gives every daemon-managed channel instance a stable, adapter-accessible state directory under the daemon state owned by its resolved workspace. Instance directory names combine a readable sanitized prefix with a hash of the full channel name, so unsafe characters cannot traverse directories and names that sanitize alike remain distinct.

This is a small prerequisite for workspace-safe browser authentication. It does not change any adapter's current persistence behavior.

## Why it's needed

QR authentication will persist adapter credentials and login state. The daemon is now multi-workspace, so reusing process-global channel storage would allow two workspaces with the same channel name to share secrets or session state. Establishing ownership at the daemon worker boundary keeps future adapter authentication inside the selected trusted runtime.

## Reviewer Test Plan

### How to verify

Run the channel runtime and daemon worker tests and confirm that different workspace/name combinations resolve to distinct paths, unsafe channel names remain under the instance root, and the worker passes the resolved directory into the channel factory. Run the Channel base tests and confirm adapters can read a runtime-supplied directory without changing behavior when none is supplied.

### Evidence (Before & After)

N/A — this is non-UI infrastructure and does not expose new channels or authentication controls.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js v25.9.0; verified with the lockfile-installed dependency tree.

## Risk & Scope

- Main risk or tradeoff: The directory key is derived from the configured channel instance name; renaming an instance intentionally gives it a new state directory.
- Not validated / out of scope: Authentication sessions and routes, adapter credential migration, QR generation, Web Shell UI, and exposing additional manageable channels.
- Breaking changes / migration notes: None. The new runtime option is optional and existing adapters do not use it yet.

## Linked Issues

Part of #7209

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

为每个由 daemon 管理的频道实例提供一个稳定、适配器可访问的状态目录，并将其放在已解析 workspace 所拥有的 daemon 状态目录下。实例目录名由可读的安全化前缀和完整频道名的哈希组成，因此不安全字符无法造成目录穿越，安全化结果相同的频道名也不会发生冲突。

这是 workspace 安全的浏览器认证能力的一项小型前置改动，不会改变任何适配器当前的持久化行为。

## 为什么需要

扫码认证后续需要持久化适配器凭据和登录状态。daemon 现在已经支持多 workspace，如果继续复用进程级全局频道存储，两个使用相同频道名的 workspace 可能共享密钥或会话状态。在 daemon worker 边界建立状态所有权，可以保证后续适配器认证始终位于选中的可信 runtime 内。

## Reviewer Test Plan

### 如何验证

运行频道 runtime 和 daemon worker 测试，确认不同 workspace/频道名组合会得到不同路径，不安全频道名仍被限制在实例根目录内，并且 worker 会把解析后的目录传给频道工厂。运行 Channel base 测试，确认适配器能够读取 runtime 提供的目录，同时未提供目录时行为不变。

### 证据（Before & After）

N/A——这是非 UI 基础设施，不会开放新频道或认证控制入口。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Node.js v25.9.0；使用 lockfile 安装的依赖树完成验证。

## 风险与范围

- 主要风险或取舍：目录标识来自配置中的频道实例名；重命名实例会有意生成新的状态目录。
- 未验证 / 不在本次范围：认证 session 和路由、适配器凭据迁移、二维码生成、Web Shell UI，以及开放更多可管理频道。
- Breaking change / 迁移说明：无。新的 runtime 选项是可选的，现有适配器暂未使用。

## 关联 Issue

#7209 的一部分

</details>
