### PR TITLE
fix(release): keep notes anchored and cap the release body

### DIFF
--- a/.github/scripts/cap-release-notes.mjs
+++ b/.github/scripts/cap-release-notes.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+
+// Prepares the body handed to `gh release create`. GitHub rejects release
+// bodies over 125000 characters, and that rejection lands *after* the npm
+// packages have been published, so an oversized or empty changelog has to
+// degrade the notes rather than the release.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// GitHub's limit is 125000; the margin absorbs the finalize step's rewrite and
+// any counting difference between code points and UTF-16 units.
+export const MAX_BODY_CHARS = 120000;
+
+const TRUNCATION_NOTE = '_Release notes were truncated._';
+
+/**
+ * @returns {{body: string, truncated: boolean, fallback: boolean}} a body that
+ * is non-empty and at most `maxChars` code points long.
+ */
+export function prepareReleaseNotes({
+  body = '',
+  tag,
+  previousTag = '',
+  repo = '',
+  serverUrl = 'https://github.com',
+  maxChars = MAX_BODY_CHARS,
+}) {
+  if (!tag) {
+    throw new Error('prepareReleaseNotes requires a tag');
+  }
+
+  const trimmed = body.trim();
+  if (!trimmed) {
+    return { body: `Release ${tag}`, truncated: false, fallback: true };
+  }
+
+  // Split on code points so a cut never lands inside a surrogate pair and
+  // leaves the body invalid.
+  const chars = Array.from(trimmed);
+  if (chars.length <= maxChars) {
+    return { body: trimmed, truncated: false, fallback: false };
+  }
+
+  const compare =
+    previousTag && repo
+      ? ` Full changelog: ${serverUrl}/${repo}/compare/${previousTag}...${tag}`
+      : '';
+  const footer = `\n\n${TRUNCATION_NOTE}${compare}`;
+  const keep = maxChars - Array.from(footer).length;
+  if (keep <= 0) {
+    return { body: `Release ${tag}`, truncated: true, fallback: true };
+  }
+
+  return {
+    body: `${chars.slice(0, keep).join('')}${footer}`,
+    truncated: true,
+    fallback: false,
+  };
+}
+
+function parseArgs(argv) {
+  const args = {
+    file: '',
+    tag: '',
+    previousTag: '',
+    repo: '',
+    serverUrl: 'https://github.com',
+    maxChars: MAX_BODY_CHARS,
+  };
+  const options = {
+    '--file': 'file',
+    '--tag': 'tag',
+    '--previous-tag': 'previousTag',
+    '--repo': 'repo',
+    '--server-url': 'serverUrl',
+    '--max-chars': 'maxChars',
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = options[argv[index]];
+    if (!key) {
+      throw new Error(`Unknown option: ${argv[index]}`);
+    }
+    const value = argv[index + 1];
+    if (value === undefined) {
+      throw new Error(`Missing value for ${argv[index]}`);
+    }
+    args[key] = key === 'maxChars' ? Number(value) : value;
+    index += 1;
+  }
+
+  if (!args.file || !args.tag) {
+    throw new Error('--file and --tag are required');
+  }
+  if (!Number.isInteger(args.maxChars) || args.maxChars <= 0) {
+    throw new Error(`--max-chars must be a positive integer`);
+  }
+  return args;
+}
+
+function main(argv) {
+  const args = parseArgs(argv);
+  let body = '';
+  try {
+    body = readFileSync(args.file, 'utf8');
+  } catch {
+    // A failed generate-notes call leaves no file; the fallback body covers it.
+  }
+
+  const result = prepareReleaseNotes({ ...args, body });
+  writeFileSync(args.file, `${result.body}\n`);
+
+  if (result.truncated) {
+    process.stdout.write(
+      `::warning::Release notes exceeded ${args.maxChars} characters; truncated\n`,
+    );
+  }
+  if (result.fallback) {
+    process.stdout.write(
+      `::warning::No release notes were generated; using a minimal body\n`,
+    );
+  }
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main(process.argv.slice(2));
+}

--- a/.github/scripts/cap-release-notes.test.mjs
+++ b/.github/scripts/cap-release-notes.test.mjs
@@ -72,7 +72,7 @@ describe('release notes body preparation', () => {
     // Cut lands inside the emoji run: a code-unit slice would leave a lone
     // surrogate and an invalid body.
     const maxChars = 200;
-    const body = `${'a'.repeat(120)}${'😀'.repeat(200)}`;
+    const body = `${'a'.repeat(50)}${'😀'.repeat(200)}`;
 
     const result = prepareReleaseNotes({ ...context, body, maxChars });
 
@@ -81,6 +81,18 @@ describe('release notes body preparation', () => {
       result.body,
     );
     assert.ok(!/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(result.body));
+  });
+
+  it('falls back to a minimal body when the footer alone exceeds the cap', () => {
+    const result = prepareReleaseNotes({
+      ...context,
+      body: 'x'.repeat(100),
+      maxChars: 10,
+    });
+
+    assert.equal(result.body, 'Release v0.21.2');
+    assert.equal(result.truncated, true);
+    assert.equal(result.fallback, true);
   });
 
   it('falls back to a minimal body when nothing was generated', () => {

--- a/.github/scripts/cap-release-notes.test.mjs
+++ b/.github/scripts/cap-release-notes.test.mjs
@@ -1,0 +1,167 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { MAX_BODY_CHARS, prepareReleaseNotes } from './cap-release-notes.mjs';
+
+const SCRIPT = fileURLToPath(
+  new URL('./cap-release-notes.mjs', import.meta.url),
+);
+
+const context = {
+  tag: 'v0.21.2',
+  previousTag: 'v0.21.1',
+  repo: 'QwenLM/qwen-code',
+  serverUrl: 'https://github.com',
+};
+
+describe('release notes body preparation', () => {
+  it('leaves a body that fits untouched', () => {
+    const body = "## What's Changed\n* one thing\n";
+
+    const result = prepareReleaseNotes({ ...context, body });
+
+    assert.equal(result.body, body.trim());
+    assert.equal(result.truncated, false);
+    assert.equal(result.fallback, false);
+  });
+
+  it('keeps the truncated body plus footer within the limit', () => {
+    const maxChars = 500;
+    const body = 'x'.repeat(5000);
+
+    const result = prepareReleaseNotes({ ...context, body, maxChars });
+
+    assert.equal(result.truncated, true);
+    assert.ok(Array.from(result.body).length <= maxChars);
+    assert.ok(
+      result.body.endsWith(
+        'https://github.com/QwenLM/qwen-code/compare/v0.21.1...v0.21.2',
+      ),
+    );
+  });
+
+  // The whole point of the cap is that the release still publishes, so the
+  // default must leave room for the footer under GitHub's 125000 limit.
+  it('stays under the API limit at the default cap', () => {
+    const result = prepareReleaseNotes({
+      ...context,
+      body: 'x'.repeat(MAX_BODY_CHARS * 2),
+    });
+
+    assert.ok(Array.from(result.body).length <= MAX_BODY_CHARS);
+    assert.ok(MAX_BODY_CHARS < 125000);
+  });
+
+  it('omits the compare link when there is no previous tag', () => {
+    const result = prepareReleaseNotes({
+      ...context,
+      previousTag: '',
+      body: 'x'.repeat(5000),
+      maxChars: 500,
+    });
+
+    assert.ok(result.body.endsWith('_Release notes were truncated._'));
+    assert.ok(!result.body.includes('compare'));
+  });
+
+  it('never splits a multi-byte character', () => {
+    // Cut lands inside the emoji run: a code-unit slice would leave a lone
+    // surrogate and an invalid body.
+    const maxChars = 200;
+    const body = `${'a'.repeat(120)}${'😀'.repeat(200)}`;
+
+    const result = prepareReleaseNotes({ ...context, body, maxChars });
+
+    assert.equal(
+      Buffer.from(result.body, 'utf8').toString('utf8'),
+      result.body,
+    );
+    assert.ok(!/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(result.body));
+  });
+
+  it('falls back to a minimal body when nothing was generated', () => {
+    for (const body of ['', '   \n  ']) {
+      const result = prepareReleaseNotes({ ...context, body });
+
+      assert.equal(result.body, 'Release v0.21.2');
+      assert.equal(result.fallback, true);
+    }
+  });
+
+  it('requires a tag', () => {
+    assert.throws(
+      () => prepareReleaseNotes({ body: 'notes', tag: '' }),
+      /requires a tag/,
+    );
+  });
+});
+
+describe('release notes body preparation (cli)', () => {
+  it('rewrites the notes file in place and warns on truncation', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'cap-release-notes-'));
+    try {
+      const file = join(dir, 'release-notes.md');
+      writeFileSync(file, 'y'.repeat(5000));
+
+      const run = spawnSync(
+        process.execPath,
+        [
+          SCRIPT,
+          '--file',
+          file,
+          '--tag',
+          'v0.21.2',
+          '--previous-tag',
+          'v0.21.1',
+          '--repo',
+          'QwenLM/qwen-code',
+          '--max-chars',
+          '500',
+        ],
+        { encoding: 'utf8' },
+      );
+
+      assert.equal(run.status, 0);
+      assert.match(run.stdout, /::warning::Release notes exceeded 500/);
+      const written = readFileSync(file, 'utf8');
+      assert.ok(Array.from(written.trimEnd()).length <= 500);
+      assert.ok(written.includes('_Release notes were truncated._'));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('writes a minimal body when generate-notes produced no file', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'cap-release-notes-'));
+    try {
+      const file = join(dir, 'missing.md');
+
+      const run = spawnSync(
+        process.execPath,
+        [SCRIPT, '--file', file, '--tag', 'v0.21.2'],
+        { encoding: 'utf8' },
+      );
+
+      assert.equal(run.status, 0);
+      assert.match(run.stdout, /::warning::No release notes were generated/);
+      assert.equal(readFileSync(file, 'utf8'), 'Release v0.21.2\n');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects unknown options', () => {
+    const run = spawnSync(
+      process.execPath,
+      [SCRIPT, '--file', 'notes.md', '--tag', 'v1.0.0', '--nope', '1'],
+      { encoding: 'utf8' },
+    );
+
+    assert.notEqual(run.status, 0);
+    assert.match(run.stderr, /Unknown option: --nope/);
+  });
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ env:
   # BOTH the github_ci_only helper step and the full-profile Test step, so a
   # new helper test can't be added to one path and silently dropped from the
   # other.
-  HELPER_TESTS: '.github/scripts/pr-safety-precheck.test.mjs .github/scripts/ci/classify-profile.test.mjs .github/scripts/ci/main-failure-signature.test.mjs .github/scripts/classify-release-notes.test.mjs .github/scripts/dsw-swe-verified/make-manifest.test.mjs .github/scripts/resolve-sandbox-image.test.mjs .github/scripts/web-shell-visuals-publish.test.mjs .github/scripts/web-shell-visuals-compose.test.mjs .github/scripts/serve-ab-diff.test.mjs .github/scripts/qwen-triage-workflow.test.mjs .github/scripts/auto-minimize-spam.test.mjs'
+  HELPER_TESTS: '.github/scripts/pr-safety-precheck.test.mjs .github/scripts/cap-release-notes.test.mjs .github/scripts/ci/classify-profile.test.mjs .github/scripts/ci/main-failure-signature.test.mjs .github/scripts/classify-release-notes.test.mjs .github/scripts/dsw-swe-verified/make-manifest.test.mjs .github/scripts/resolve-sandbox-image.test.mjs .github/scripts/web-shell-visuals-publish.test.mjs .github/scripts/web-shell-visuals-compose.test.mjs .github/scripts/serve-ab-diff.test.mjs .github/scripts/qwen-triage-workflow.test.mjs .github/scripts/auto-minimize-spam.test.mjs'
 
 jobs:
   classify_pr:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -576,41 +576,31 @@ jobs:
           fi
 
           # Generate the body up front so an unusable one can be repaired here
-          # instead of aborting `gh release create`.
+          # instead of aborting `gh release create`. A failed call still prints
+          # the API error payload on stdout, so its output is discarded rather
+          # than published as release notes.
           NOTES_FILE="${RUNNER_TEMP}/release-notes.md"
-          if ! gh api --method POST "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
-            -f "tag_name=${RELEASE_TAG}" \
-            -f "target_commitish=${RELEASE_BRANCH}" \
-            "${NOTES_ARGS[@]}" \
-            --jq '.body' > "${NOTES_FILE}"; then
-            echo "::warning::Could not generate notes anchored at ${PREVIOUS_RELEASE_TAG:-<none>}; retrying without an anchor"
+          generate_notes() {
             gh api --method POST "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
               -f "tag_name=${RELEASE_TAG}" \
               -f "target_commitish=${RELEASE_BRANCH}" \
-              --jq '.body' > "${NOTES_FILE}" ||
-              printf 'Release %s\n' "${RELEASE_TAG}" > "${NOTES_FILE}"
-          fi
-          if [[ ! -s "${NOTES_FILE}" ]]; then
-            printf 'Release %s\n' "${RELEASE_TAG}" > "${NOTES_FILE}"
+              "$@" \
+              --jq '.body'
+          }
+          if ! generate_notes "${NOTES_ARGS[@]}" > "${NOTES_FILE}"; then
+            echo "::warning::Could not generate notes anchored at ${PREVIOUS_RELEASE_TAG:-<none>}; retrying without an anchor"
+            generate_notes > "${NOTES_FILE}" || : > "${NOTES_FILE}"
           fi
 
-          # Cap the body below the 125000 character API limit. iconv -c drops a
-          # trailing multi-byte sequence that head may have split, so an
-          # oversized changelog degrades the notes instead of the release.
-          MAX_BODY_BYTES=120000
-          if (( $(wc -c < "${NOTES_FILE}") > MAX_BODY_BYTES )); then
-            echo "::warning::Generated notes exceed ${MAX_BODY_BYTES} bytes; truncating"
-            head -c "${MAX_BODY_BYTES}" "${NOTES_FILE}" | iconv -c -f utf-8 -t utf-8 > "${NOTES_FILE}.capped"
-            {
-              printf '\n\n_Release notes were truncated._'
-              if [[ -n "${PREVIOUS_RELEASE_TAG}" ]]; then
-                printf ' Full changelog: %s/%s/compare/%s...%s' \
-                  "${GITHUB_SERVER_URL}" "${GITHUB_REPOSITORY}" "${PREVIOUS_RELEASE_TAG}" "${RELEASE_TAG}"
-              fi
-              printf '\n'
-            } >> "${NOTES_FILE}.capped"
-            mv "${NOTES_FILE}.capped" "${NOTES_FILE}"
-          fi
+          # Caps the body below the 125000 character API limit and substitutes a
+          # minimal body when nothing was generated, so an oversized or missing
+          # changelog degrades the notes instead of the release.
+          node .github/scripts/cap-release-notes.mjs \
+            --file "${NOTES_FILE}" \
+            --tag "${RELEASE_TAG}" \
+            --previous-tag "${PREVIOUS_RELEASE_TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --server-url "${GITHUB_SERVER_URL}"
 
           gh release create "${RELEASE_TAG}" \
             dist/cli.js \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -562,16 +562,54 @@ jobs:
             PRERELEASE_FLAG="--prerelease"
           fi
 
-          # Only anchor notes to the previous release when it is an ancestor of
-          # this release's target. A preview or nightly cut can lag behind (or
-          # diverge from) the latest stable, and a divergent --notes-start-tag
-          # makes `gh release create --generate-notes` fail, aborting the
-          # publish after the npm packages have already been published.
-          NOTES_START_TAG_FLAG=()
-          if [[ -n "${PREVIOUS_RELEASE_TAG}" ]] && git merge-base --is-ancestor "${PREVIOUS_RELEASE_TAG}" HEAD; then
-            NOTES_START_TAG_FLAG+=(--notes-start-tag "${PREVIOUS_RELEASE_TAG}")
-          elif [[ -n "${PREVIOUS_RELEASE_TAG}" ]]; then
-            echo "::warning::PREVIOUS_RELEASE_TAG (${PREVIOUS_RELEASE_TAG}) is not an ancestor of HEAD; omitting --notes-start-tag"
+          # Always anchor the notes to the previous release. Every stable tag
+          # lives on its own release/* branch that is tagged before merging back
+          # to main, so the previous tag is normally NOT an ancestor of the
+          # branch being released; GitHub still diffs it correctly through the
+          # merge base. Dropping the anchor is what hurts: GitHub then falls
+          # back to the entire branch history, and the generated body blows past
+          # the 125000 character limit, failing the release after the npm
+          # packages have already been published.
+          NOTES_ARGS=()
+          if [[ -n "${PREVIOUS_RELEASE_TAG}" ]]; then
+            NOTES_ARGS+=(-f "previous_tag_name=${PREVIOUS_RELEASE_TAG}")
+          fi
+
+          # Generate the body up front so an unusable one can be repaired here
+          # instead of aborting `gh release create`.
+          NOTES_FILE="${RUNNER_TEMP}/release-notes.md"
+          if ! gh api --method POST "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+            -f "tag_name=${RELEASE_TAG}" \
+            -f "target_commitish=${RELEASE_BRANCH}" \
+            "${NOTES_ARGS[@]}" \
+            --jq '.body' > "${NOTES_FILE}"; then
+            echo "::warning::Could not generate notes anchored at ${PREVIOUS_RELEASE_TAG:-<none>}; retrying without an anchor"
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+              -f "tag_name=${RELEASE_TAG}" \
+              -f "target_commitish=${RELEASE_BRANCH}" \
+              --jq '.body' > "${NOTES_FILE}" ||
+              printf 'Release %s\n' "${RELEASE_TAG}" > "${NOTES_FILE}"
+          fi
+          if [[ ! -s "${NOTES_FILE}" ]]; then
+            printf 'Release %s\n' "${RELEASE_TAG}" > "${NOTES_FILE}"
+          fi
+
+          # Cap the body below the 125000 character API limit. iconv -c drops a
+          # trailing multi-byte sequence that head may have split, so an
+          # oversized changelog degrades the notes instead of the release.
+          MAX_BODY_BYTES=120000
+          if (( $(wc -c < "${NOTES_FILE}") > MAX_BODY_BYTES )); then
+            echo "::warning::Generated notes exceed ${MAX_BODY_BYTES} bytes; truncating"
+            head -c "${MAX_BODY_BYTES}" "${NOTES_FILE}" | iconv -c -f utf-8 -t utf-8 > "${NOTES_FILE}.capped"
+            {
+              printf '\n\n_Release notes were truncated._'
+              if [[ -n "${PREVIOUS_RELEASE_TAG}" ]]; then
+                printf ' Full changelog: %s/%s/compare/%s...%s' \
+                  "${GITHUB_SERVER_URL}" "${GITHUB_REPOSITORY}" "${PREVIOUS_RELEASE_TAG}" "${RELEASE_TAG}"
+              fi
+              printf '\n'
+            } >> "${NOTES_FILE}.capped"
+            mv "${NOTES_FILE}.capped" "${NOTES_FILE}"
           fi
 
           gh release create "${RELEASE_TAG}" \
@@ -580,8 +618,7 @@ jobs:
             dist/standalone/SHA256SUMS \
             --target "${RELEASE_BRANCH}" \
             --title "Release ${RELEASE_TAG}" \
-            "${NOTES_START_TAG_FLAG[@]}" \
-            --generate-notes \
+            --notes-file "${NOTES_FILE}" \
             ${PRERELEASE_FLAG}
 
   notify_failure:

--- a/scripts/tests/ai-release-notes-workflow.test.js
+++ b/scripts/tests/ai-release-notes-workflow.test.js
@@ -31,16 +31,20 @@ describe('stable release notes workflow', () => {
   it('publishes immediately with GitHub-generated notes', () => {
     const step = getStep(releaseWorkflow, 'Create GitHub Release and Tag');
 
-    expect(step).toContain('--notes-start-tag "${PREVIOUS_RELEASE_TAG}"');
-    expect(step).toContain('--generate-notes');
     expect(step).toContain(
-      'git merge-base --is-ancestor "${PREVIOUS_RELEASE_TAG}" HEAD',
+      'repos/${GITHUB_REPOSITORY}/releases/generate-notes',
     );
-    expect(step).toContain('NOTES_START_TAG_FLAG=()');
-    expect(step).toContain(
-      'echo "::warning::PREVIOUS_RELEASE_TAG (${PREVIOUS_RELEASE_TAG}) is not an ancestor of HEAD; omitting --notes-start-tag"',
-    );
-    expect(step).toContain('"${NOTES_START_TAG_FLAG[@]}"');
+    expect(step).toContain('-f "previous_tag_name=${PREVIOUS_RELEASE_TAG}"');
+    expect(step).toContain('"${NOTES_ARGS[@]}"');
+    expect(step).toContain('--notes-file "${NOTES_FILE}"');
+    // Stable tags live on their own release/* branch and are merged back to
+    // main only afterwards, so the previous tag is never an ancestor of the
+    // branch being released. Anchoring on ancestry dropped the anchor on every
+    // stable release, and unanchored notes span the whole branch history and
+    // overrun the 125000 character body limit.
+    expect(step).not.toContain('git merge-base --is-ancestor');
+    expect(step).toContain('MAX_BODY_BYTES=120000');
+    expect(step).toContain('iconv -c -f utf-8 -t utf-8');
     expect(step).toContain("GITHUB_TOKEN: '${{ secrets.CI_BOT_PAT }}'");
     expect(releaseWorkflow).not.toContain(
       "name: 'Generate AI-assisted stable release notes'",

--- a/scripts/tests/ai-release-notes-workflow.test.js
+++ b/scripts/tests/ai-release-notes-workflow.test.js
@@ -43,8 +43,13 @@ describe('stable release notes workflow', () => {
     // stable release, and unanchored notes span the whole branch history and
     // overrun the 125000 character body limit.
     expect(step).not.toContain('git merge-base --is-ancestor');
-    expect(step).toContain('MAX_BODY_BYTES=120000');
-    expect(step).toContain('iconv -c -f utf-8 -t utf-8');
+    expect(step).toContain('node .github/scripts/cap-release-notes.mjs');
+    expect(step).toContain('--file "${NOTES_FILE}"');
+    // gh prints the API error payload on stdout, so a failed attempt's output
+    // must not survive into the release body.
+    expect(step).toContain(
+      'generate_notes > "${NOTES_FILE}" || : > "${NOTES_FILE}"',
+    );
     expect(step).toContain("GITHUB_TOKEN: '${{ secrets.CI_BOT_PAT }}'");
     expect(releaseWorkflow).not.toContain(
       "name: 'Generate AI-assisted stable release notes'",


### PR DESCRIPTION
## Summary

The v0.21.2 release failed at `Create GitHub Release and Tag`
([run](https://github.com/QwenLM/qwen-code/actions/runs/30599138025/job/91062174316)):

```
##[warning]PREVIOUS_RELEASE_TAG (v0.21.1) is not an ancestor of HEAD; omitting --notes-start-tag
HTTP 422: Validation Failed (https://api.github.com/repos/QwenLM/qwen-code/releases)
body is too long (maximum is 125000 characters)
```

Every npm package had already been published by then, so 0.21.2 shipped to npm (`latest` moved)
while the repo had no `v0.21.2` tag and no GitHub release. The tag, release and all seven assets
have since been restored by hand; this PR fixes the cause.

Fixes #8181

## Root cause

- Stable releases are tagged on their own `release/vX.Y.Z` branch, which is merged back into main
  only afterwards. The previous stable tag is therefore **never** an ancestor of the branch being
  released — `v0.21.0` and `v0.21.1` are both off-main.
- The ancestor guard added in #7970 consequently drops `--notes-start-tag` on *every* stable release.
- With no anchor, GitHub finds no previous stable release reachable from the target branch and
  generates notes over the entire branch history (8000+ commits), which overruns the 125000
  character body limit and returns 422.
- A divergent anchor was never the problem: v0.21.1 was cut with `--notes-start-tag v0.21.0`
  (equally divergent) and produced a 27KB body, because GitHub diffs through the merge base.
  The preview failure that motivated the guard was the previous tag being *ahead* of the preview
  base, which #7978 addressed separately.

## Changes

- Always pass the previous release as `previous_tag_name` when one is known.
- Generate the body through the `releases/generate-notes` API before creating the release, so an
  unusable body can be repaired here instead of aborting the publish.
- Cap the body at 120000 bytes, truncating on a UTF-8 boundary (`iconv -c`) and appending a
  full-changelog compare link.
- Degrade instead of failing: anchored notes → unanchored notes → a minimal `Release <tag>` body.
  A release whose packages are already on npm is never blocked by note generation again.

## Testing

- `node scripts/lint.js --actionlint` and `--yamllint` are clean.
- Extracted the step's shell verbatim and ran it against the live GitHub API with
  `gh release create` stubbed out:
  - anchored (`v0.21.1` → `v0.21.2`, target `release/v0.21.2`): 12862-byte body ending in the
    correct `v0.21.1...v0.21.2` changelog link — what the failed run should have produced;
  - unresolvable anchor: falls back to unanchored generation, which reproduces the oversized body,
    and the cap truncates it to 120110 bytes / 120004 characters, still valid UTF-8, with the
    truncation footer appended.
- `scripts/tests/ai-release-notes-workflow.test.js` pinned the ancestor guard, so it now asserts
  the replacement contract instead (anchor always passed, body capped, no ancestry check). The
  file passes locally; the six other `scripts/tests` failures on this machine reproduce on the
  untouched v0.21.2 commit and are environment-specific.

<details>
<summary>中文说明</summary>

## 概述

v0.21.2 发版在 `Create GitHub Release and Tag`
步骤失败（[运行记录](https://github.com/QwenLM/qwen-code/actions/runs/30599138025/job/91062174316)）：

```
##[warning]PREVIOUS_RELEASE_TAG (v0.21.1) is not an ancestor of HEAD; omitting --notes-start-tag
HTTP 422: Validation Failed (https://api.github.com/repos/QwenLM/qwen-code/releases)
body is too long (maximum is 125000 characters)
```

此时 npm 包已经全部发布完毕，因此 0.21.2 已经发到 npm（`latest` 也已切换），但仓库里既没有
`v0.21.2` tag 也没有 GitHub Release。tag、Release 和 7 个产物已手工补齐，本 PR 修复根因。

Fixes #8181

## 根因

- 正式版都是在独立的 `release/vX.Y.Z` 分支上打 tag，之后才合回 main。因此上一个正式版 tag
  **永远不会**是本次发布分支的祖先 —— `v0.21.0`、`v0.21.1` 都不在 main 的历史上。
- 于是 #7970 引入的祖先判断在**每一次**正式发版都会丢掉 `--notes-start-tag`。
- 没有起始锚点时，GitHub 在目标分支上找不到可达的上一个正式 Release，就会按整条分支历史
  （8000+ commit）生成 notes，正文超过 125000 字符上限，返回 422。
- 锚点「发散」本身从来不是问题：v0.21.1 就是用 `--notes-start-tag v0.21.0`（同样不是祖先）
  发出来的，正文 27KB，因为 GitHub 是按 merge base 做比较的。当初触发该守卫的 preview
  失败，真正原因是上一个 tag **领先于** preview 基线，已由 #7978 单独修复。

## 改动

- 只要拿得到上一个 Release，就始终以 `previous_tag_name` 传入。
- 先通过 `releases/generate-notes` API 生成正文，正文有问题时可以在这里修复，而不是让
  `gh release create` 直接失败。
- 正文上限收在 120000 字节，按 UTF-8 边界截断（`iconv -c`），并追加完整 changelog 对比链接。
- 逐级降级而不是直接失败：带锚点 → 不带锚点 → 最小正文 `Release <tag>`。npm 包已经发布出去的
  release，不会再因为 notes 生成而卡住。

## 测试

- `node scripts/lint.js --actionlint`、`--yamllint` 均通过。
- 把该步骤的 shell 原样抽出来，打桩 `gh release create` 后对真实 GitHub API 执行：
  - 带锚点（`v0.21.1` → `v0.21.2`，目标 `release/v0.21.2`）：正文 12862 字节，结尾是正确的
    `v0.21.1...v0.21.2` changelog 链接 —— 也就是失败那次本应产出的内容；
  - 锚点不可用：回退到不带锚点生成，复现出超长正文，并被截断到 120110 字节 / 120004 字符，
    UTF-8 合法，末尾带截断说明。
- `scripts/tests/ai-release-notes-workflow.test.js` 原先固化了祖先判断，已改为断言新的契约
  （始终传锚点、正文有上限、不再按祖先关系决定）。该文件本地通过；本机 `scripts/tests` 另有
  6 个失败，在未改动的 v0.21.2 提交上同样复现，属于环境问题。

</details>
