### PR TITLE
docs: worked example for a PreToolUse HTTP hook backed by an external judgment service

### DIFF
--- a/docs/users/features/hooks.md
+++ b/docs/users/features/hooks.md
@@ -151,20 +151,30 @@ By default, HTTP hooks cannot target private or link-local IP ranges. In platfor
 
 The `remote-security-check` config above expects `http://127.0.0.1:8080/hooks/pre-tool-use` to
 already be running a service that speaks this contract (POST `{tool_name, tool_input, ...}` in,
-`hookSpecificOutput.permissionDecision` out). A minimal, stdlib-only adapter, using
-[invinoveritas](https://api.babyblueviper.com)'s `/review` endpoint (an independent, signed
-verdict on the specific call — free registration, 3 calls included, no payment required to try
-it) as the judgment source:
+`hookSpecificOutput.permissionDecision` out). Here is a minimal, stdlib-only adapter that fills
+in that missing half, wired to one concrete judgment backend so the whole thing is runnable and
+testable end to end rather than a stub. Only the `review()` function is backend-specific — swap
+its body and request/response shape for whichever service you use; everything else (the server,
+the fail-open handling, the hook response shape) stays the same regardless of backend.
+
+_Disclosure: the backend used below, [invinoveritas](https://api.babyblueviper.com), is a
+service the author is affiliated with — used here because it was the one that could be
+verified end to end for this example, not an endorsement. Any HTTP service that returns a
+JSON verdict works equally well; only `review()` needs to change._
 
 ```python
 #!/usr/bin/env python3
-# qwen_review_hook.py -- run: IVV_API_KEY=... python3 qwen_review_hook.py
+# judgment_hook.py -- run: JUDGMENT_API_KEY=... python3 judgment_hook.py
 import json, os, urllib.request
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
-IVV_API_KEY = os.environ["IVV_API_KEY"]
+JUDGMENT_API_KEY = os.environ["JUDGMENT_API_KEY"]
 
 def review(tool_name, tool_input):
+    """POST the call to the judgment backend and return its verdict. This is the
+    one function to change for a different backend -- request/response shape
+    below matches invinoveritas's /review; adapt both to your own backend's
+    contract if you swap it out."""
     body = json.dumps({
         "artifact": json.dumps({"tool_name": tool_name, "tool_input": tool_input}),
         "artifact_type": "shell_command" if tool_name in ("run_shell_command", "shell") else "general",
@@ -172,10 +182,10 @@ def review(tool_name, tool_input):
     }).encode()
     req = urllib.request.Request(
         "https://api.babyblueviper.com/review", data=body,
-        headers={"Authorization": f"Bearer {IVV_API_KEY}", "Content-Type": "application/json"},
+        headers={"Authorization": f"Bearer {JUDGMENT_API_KEY}", "Content-Type": "application/json"},
     )
     with urllib.request.urlopen(req, timeout=15) as resp:
-        return json.loads(resp.read())
+        return json.loads(resp.read())  # response includes a "verdict" field: "reject" denies, anything else allows
 
 class Handler(BaseHTTPRequestHandler):
     def do_POST(self):
@@ -184,9 +194,9 @@ class Handler(BaseHTTPRequestHandler):
         try:
             verdict = review(tool_name, tool_input)
             decision = "deny" if verdict.get("verdict") == "reject" else "allow"
-            reason = verdict.get("summary", f"invinoveritas verdict: {verdict.get('verdict')}")
+            reason = verdict.get("summary", f"judgment verdict: {verdict.get('verdict')}")
         except Exception:
-            decision, reason = "allow", "invinoveritas /review unavailable, failing open"  # never block on a review-side outage
+            decision, reason = "allow", "judgment backend unavailable, failing open"  # never block on a review-side outage
         out = {"continue": True, "decision": decision, "hookSpecificOutput": {
             "hookEventName": "PreToolUse", "permissionDecision": decision, "permissionDecisionReason": reason,
         }}
@@ -202,12 +212,12 @@ if __name__ == "__main__":
     HTTPServer(("127.0.0.1", 8080), Handler).serve_forever()
 ```
 
-Verified live against the real production API: a genuinely destructive input
+Tested live end to end against the real production API above: a genuinely destructive input
 (`{"tool_name": "run_shell_command", "tool_input": {"command": "rm -rf /important_data"}}`)
-returns `permissionDecision: "deny"` with a real explanation; a benign one (`ls -la`) returns
+returned `permissionDecision: "deny"` with a real explanation; a benign one (`ls -la`) returned
 `"allow"`. Fails open on any network/timeout/malformed-response issue from the judgment
-service, so a third-party outage never blocks legitimate tool calls — same discipline the
-`command`-hook examples above apply with their own exit codes.
+backend, so an outage never blocks legitimate tool calls — same discipline the `command`-hook
+examples above apply with their own exit codes.
 
 ### Function Hooks
 

--- a/docs/users/features/hooks.md
+++ b/docs/users/features/hooks.md
@@ -147,6 +147,68 @@ By default, HTTP hooks cannot target private or link-local IP ranges. In platfor
 }
 ```
 
+**Example: External Judgment Service Adapter**
+
+The `remote-security-check` config above expects `http://127.0.0.1:8080/hooks/pre-tool-use` to
+already be running a service that speaks this contract (POST `{tool_name, tool_input, ...}` in,
+`hookSpecificOutput.permissionDecision` out). A minimal, stdlib-only adapter, using
+[invinoveritas](https://api.babyblueviper.com)'s `/review` endpoint (an independent, signed
+verdict on the specific call — free registration, 3 calls included, no payment required to try
+it) as the judgment source:
+
+```python
+#!/usr/bin/env python3
+# qwen_review_hook.py -- run: IVV_API_KEY=... python3 qwen_review_hook.py
+import json, os, urllib.request
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+IVV_API_KEY = os.environ["IVV_API_KEY"]
+
+def review(tool_name, tool_input):
+    body = json.dumps({
+        "artifact": json.dumps({"tool_name": tool_name, "tool_input": tool_input}),
+        "artifact_type": "shell_command" if tool_name in ("run_shell_command", "shell") else "general",
+        "context": f"qwen-code PreToolUse: {tool_name}",
+    }).encode()
+    req = urllib.request.Request(
+        "https://api.babyblueviper.com/review", data=body,
+        headers={"Authorization": f"Bearer {IVV_API_KEY}", "Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return json.loads(resp.read())
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        payload = json.loads(self.rfile.read(int(self.headers.get("Content-Length", 0))) or b"{}")
+        tool_name, tool_input = payload.get("tool_name", "unknown"), payload.get("tool_input", {})
+        try:
+            verdict = review(tool_name, tool_input)
+            decision = "deny" if verdict.get("verdict") == "reject" else "allow"
+            reason = verdict.get("summary", f"invinoveritas verdict: {verdict.get('verdict')}")
+        except Exception:
+            decision, reason = "allow", "invinoveritas /review unavailable, failing open"  # never block on a review-side outage
+        out = {"continue": True, "decision": decision, "hookSpecificOutput": {
+            "hookEventName": "PreToolUse", "permissionDecision": decision, "permissionDecisionReason": reason,
+        }}
+        body = json.dumps(out).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    def log_message(self, *a): pass
+
+if __name__ == "__main__":
+    HTTPServer(("127.0.0.1", 8080), Handler).serve_forever()
+```
+
+Verified live against the real production API: a genuinely destructive input
+(`{"tool_name": "run_shell_command", "tool_input": {"command": "rm -rf /important_data"}}`)
+returns `permissionDecision: "deny"` with a real explanation; a benign one (`ls -la`) returns
+`"allow"`. Fails open on any network/timeout/malformed-response issue from the judgment
+service, so a third-party outage never blocks legitimate tool calls — same discipline the
+`command`-hook examples above apply with their own exit codes.
+
 ### Function Hooks
 
 Function hooks directly call registered JavaScript/TypeScript functions. They are used internally by the Skill system and are not currently exposed as a public API for end users.

--- a/docs/users/features/hooks.md
+++ b/docs/users/features/hooks.md
@@ -162,13 +162,19 @@ service the author is affiliated with — used here because it was the one that 
 verified end to end for this example, not an endorsement. Any HTTP service that returns a
 JSON verdict works equally well; only `review()` needs to change._
 
+_Data handling: with `matcher: "*"`, the full `tool_input` of **every** tool call is sent to
+the judgment backend — treat that input as sensitive (it may contain file contents, paths, or
+secrets). Narrow the matcher (e.g. to `run_shell_command`) if you only need to judge shell
+commands._
+
 ```python
 #!/usr/bin/env python3
 # judgment_hook.py -- run: JUDGMENT_API_KEY=... python3 judgment_hook.py
-import json, os, urllib.request
+import json, os, sys, urllib.request
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 JUDGMENT_API_KEY = os.environ["JUDGMENT_API_KEY"]
+JUDGMENT_URL = os.environ.get("JUDGMENT_URL", "https://api.babyblueviper.com/review")
 
 def review(tool_name, tool_input):
     """POST the call to the judgment backend and return its verdict. This is the
@@ -181,10 +187,12 @@ def review(tool_name, tool_input):
         "context": f"qwen-code PreToolUse: {tool_name}",
     }).encode()
     req = urllib.request.Request(
-        "https://api.babyblueviper.com/review", data=body,
+        JUDGMENT_URL, data=body,
         headers={"Authorization": f"Bearer {JUDGMENT_API_KEY}", "Content-Type": "application/json"},
     )
-    with urllib.request.urlopen(req, timeout=15) as resp:
+    # Keep this below the HTTP hook's own timeout (10s in the config above), so a "deny"
+    # verdict is always returned before the hook gives up and fails open on its own.
+    with urllib.request.urlopen(req, timeout=8) as resp:
         return json.loads(resp.read())  # response includes a "verdict" field: "reject" denies, anything else allows
 
 class Handler(BaseHTTPRequestHandler):
@@ -195,8 +203,9 @@ class Handler(BaseHTTPRequestHandler):
             verdict = review(tool_name, tool_input)
             decision = "deny" if verdict.get("verdict") == "reject" else "allow"
             reason = verdict.get("summary", f"judgment verdict: {verdict.get('verdict')}")
-        except Exception:
+        except Exception as e:
             decision, reason = "allow", "judgment backend unavailable, failing open"  # never block on a review-side outage
+            print(f"judgment backend unavailable for {tool_name}, failing open: {e}", file=sys.stderr)
         out = {"continue": True, "decision": decision, "hookSpecificOutput": {
             "hookEventName": "PreToolUse", "permissionDecision": decision, "permissionDecisionReason": reason,
         }}


### PR DESCRIPTION
## What this PR does

Adds a worked, runnable example to `docs/users/features/hooks.md`'s HTTP hooks section: a minimal stdlib-only Python adapter implementing the exact request/response contract a `PreToolUse` HTTP hook expects (POST `{tool_name, tool_input, ...}` in, `hookSpecificOutput.permissionDecision` out).

## Why it's needed

The existing `remote-security-check` config example shows how to *point* a hook at an external judgment service, but not what that service looks like on the other end — a reader has to build the whole HTTP contract from scratch with no reference. This fills that gap with one fully tested, runnable ~40-line adapter, plus a short note that only its `review()` function is backend-specific (swap the request/response shape for any other judgment service).

## Reviewer Test Plan

### How to verify

Copy the adapter code from the new section, run it locally (`JUDGMENT_API_KEY=... python3 judgment_hook.py`), and POST a sample `{tool_name, tool_input}` payload at it — it forwards to the backend and returns a valid `hookSpecificOutput.permissionDecision` response.

### Evidence (Before & After)

N/A (docs-only change, no UI).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

Verified live end to end on Linux against the real backend named in the example: a destructive shell command (`rm -rf /important_data`) returned `verdict: reject` with a real explanation; a benign one (`ls -la`) returned `verdict: approve`. Both map correctly through the adapter to `permissionDecision: deny` / `allow`.

### Environment (optional)

Local Python 3, no sandbox — pure docs content, the adapter itself was run standalone to confirm correctness before writing it into the doc.

## Risk & Scope

- Main risk or tradeoff: the worked example is wired to one specific backend (disclosed inline as an affiliation, not an endorsement) so the whole thing is genuinely runnable rather than a fictional stub; only the `review()` function is backend-specific and the doc says so explicitly.
- Not validated / out of scope: no code paths changed, docs-only.
- Breaking changes / migration notes: none.

## Linked Issues

None — this documents an existing feature more completely, not tied to a specific issue.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 `docs/users/features/hooks.md` 的 HTTP hooks 章节中新增一个可运行的示例：一个最小化、仅使用标准库的 Python 适配器，实现了 `PreToolUse` HTTP hook 期望的确切请求/响应契约（POST `{tool_name, tool_input, ...}` 输入，`hookSpecificOutput.permissionDecision` 输出）。

## 为什么需要

现有的 `remote-security-check` 配置示例展示了如何将 hook *指向*一个外部判定服务，但没有展示该服务另一端应该是什么样子——读者必须从零开始构建整个 HTTP 契约，没有任何参考。这个 PR 填补了这个空白，提供一个完整测试过、可运行的约 40 行适配器，并附带简短说明：只有 `review()` 函数是与后端相关的（替换请求/响应格式即可对接任何其他判定服务）。

## Reviewer 测试计划

### 如何验证

从新章节复制适配器代码，本地运行（`JUDGMENT_API_KEY=... python3 judgment_hook.py`），然后向它 POST 一个示例 `{tool_name, tool_input}` 负载——它会转发给后端并返回一个有效的 `hookSpecificOutput.permissionDecision` 响应。

### 证据（前后对比）

不适用（纯文档改动，无 UI）。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | 不适用 |
| 🪟 Windows | 不适用 |
|  🐧 Linux  |  ✅  |

在 Linux 上针对示例中提到的真实后端进行了端到端实测：一个具有破坏性的 shell 命令（`rm -rf /important_data`）返回了 `verdict: reject` 并附带真实解释；一个无害命令（`ls -la`）返回了 `verdict: approve`。两者都通过适配器正确映射为 `permissionDecision: deny` / `allow`。

### 环境（可选）

本地 Python 3，无沙箱——纯文档内容，适配器本身在写入文档前已独立运行验证过其正确性。

## 风险与范围

- 主要风险或权衡：这个可运行示例接入了一个特定的后端（已在正文中以关联披露的方式说明，而非背书），这样整个示例才是真正可运行的，而不是一个虚构的占位符；只有 `review()` 函数是后端相关的，文档中也明确说明了这一点。
- 未验证 / 超出范围：未改动任何代码路径，纯文档改动。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无——这是对现有功能的更完整文档说明，不对应特定 issue。

</details>
