### PR TITLE
feat(ci): fail the startup bundle check when the CLI entry is hoisted into a chunk

### DIFF
--- a/scripts/check-serve-fast-path-bundle.js
+++ b/scripts/check-serve-fast-path-bundle.js
@@ -12,6 +12,8 @@ import { fileURLToPath } from 'node:url';
 const DEFAULT_METAFILE_PATH = resolve('dist/esbuild.json');
 const METAFILE_BUILD_COMMAND =
   'node scripts/clean-package-build-artifacts.js && npm run build -- --cli-only && cross-env DEV=true npm run bundle';
+const ENTRY_OUTPUT = 'dist/cli.js';
+const ENTRY_INPUT = 'packages/cli/src/cli.ts';
 const SERVE_PRE_LISTEN_ROOTS = [
   {
     label: 'serve fast path entry',
@@ -506,6 +508,32 @@ export function checkSdkImplProtocolBoundary({
   return { ok: offenders.length === 0, offenders };
 }
 
+/**
+ * `cli.ts` bootstraps only when it is the main module, comparing
+ * `import.meta.url` against `process.argv[1]`. The bundle is built with
+ * `splitting: true`, so a *static* `import ... from './cli.js'` in any module
+ * the entry loads lazily (e.g. `gemini.tsx`) makes esbuild move the entry's
+ * body into a shared chunk and leave `dist/cli.js` as a re-export stub. Inside
+ * a chunk that comparison can never hold, so the bundled CLI exits 0 without
+ * running anything — with `tsc`, eslint and every src-based unit test still
+ * green. Assert the entry module still compiles into the entry output.
+ */
+export function checkEntryBootstrapIntact({
+  metafilePath = DEFAULT_METAFILE_PATH,
+} = {}) {
+  const metafile = readMetafile(metafilePath);
+  const output = metafile?.outputs?.[ENTRY_OUTPUT];
+  if (!output) {
+    throw new Error(
+      `Missing ${ENTRY_OUTPUT} in the esbuild metafile at ${metafilePath}. ` +
+        `Run \`${METAFILE_BUILD_COMMAND}\` to regenerate it.`,
+    );
+  }
+
+  const inputs = Object.keys(output.inputs ?? {});
+  return { ok: inputs.includes(ENTRY_INPUT), inputs };
+}
+
 function main() {
   try {
     const serveResult = checkServeFastPathBundle();
@@ -535,7 +563,22 @@ function main() {
       process.exitCode = 1;
     }
 
-    if (serveResult.ok && acpResult.ok && sdkImplResult.ok) {
+    const entryResult = checkEntryBootstrapIntact();
+    if (!entryResult.ok) {
+      console.error(
+        `${ENTRY_OUTPUT} no longer contains ${ENTRY_INPUT} — esbuild code ` +
+          'splitting hoisted the entry into a shared chunk, so its\n' +
+          '`import.meta.url === pathToFileURL(process.argv[1]).href` guard ' +
+          'can never match and the bundled CLI\nwould exit 0 without running. ' +
+          'Cause: a module the entry loads lazily now statically imports ' +
+          "'./cli.js'.\nMove the shared helper into a leaf module and import " +
+          `that from both sides instead.\nCurrent ${ENTRY_OUTPUT} inputs: ` +
+          `${entryResult.inputs.length === 0 ? '(none)' : entryResult.inputs.join(', ')}`,
+      );
+      process.exitCode = 1;
+    }
+
+    if (serveResult.ok && acpResult.ok && sdkImplResult.ok && entryResult.ok) {
       console.log('Startup bundle closure checks passed.');
     }
   } catch (error) {

--- a/scripts/tests/serve-fast-path-bundle-check.test.js
+++ b/scripts/tests/serve-fast-path-bundle-check.test.js
@@ -12,6 +12,7 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   checkAcpImportBoundary,
+  checkEntryBootstrapIntact,
   checkSdkImplProtocolBoundary,
   checkServeFastPathBundle,
   findAcpImportBoundaryOffenders,
@@ -28,6 +29,8 @@ const checkScriptPath = fileURLToPath(
 function makeMetafile(outputs) {
   return {
     outputs: {
+      // A healthy bundle compiles the entry module into the entry output.
+      'dist/cli.js': output({ inputs: ['packages/cli/src/cli.ts'] }),
       'dist/chunks/fast-path.js': output({
         inputs: ['packages/cli/src/serve/fast-path.ts'],
       }),
@@ -749,6 +752,84 @@ describe('telemetry sdk-impl protocol boundary check', () => {
       ).toThrow(
         /Telemetry sdk-impl static closure includes OTLP protocol chain modules/,
       );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('bundled entry bootstrap check', () => {
+  it('accepts an entry output that still contains the entry module', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'serve-fast-path-bundle-'));
+    try {
+      const metafilePath = writeMetafile(tempDir, makeMetafile({}));
+      expect(checkEntryBootstrapIntact({ metafilePath }).ok).toBe(true);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an entry hoisted into a shared chunk by code splitting', () => {
+    // What a static `import ... from './cli.js'` inside a lazily-loaded module
+    // does to the bundle: dist/cli.js keeps no inputs of its own and becomes a
+    // re-export stub, so cli.ts's main-module bootstrap guard never fires.
+    const tempDir = mkdtempSync(join(tmpdir(), 'serve-fast-path-bundle-'));
+    try {
+      const metafilePath = writeMetafile(
+        tempDir,
+        makeMetafile({
+          'dist/cli.js': output({
+            imports: [staticImport('dist/chunks/cli-entry.js')],
+          }),
+          'dist/chunks/cli-entry.js': output({
+            inputs: ['packages/cli/src/cli.ts'],
+          }),
+        }),
+      );
+
+      expect(checkEntryBootstrapIntact({ metafilePath }).ok).toBe(false);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws when the entry output is absent from the metafile', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'serve-fast-path-bundle-'));
+    try {
+      const metafile = makeMetafile({});
+      delete metafile.outputs['dist/cli.js'];
+      const metafilePath = writeMetafile(tempDir, metafile);
+
+      expect(() => checkEntryBootstrapIntact({ metafilePath })).toThrow(
+        /Missing dist\/cli\.js in the esbuild metafile/,
+      );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('exits non-zero with CLI diagnostics for a hoisted entry', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'serve-fast-path-bundle-'));
+    try {
+      writeMetafile(
+        tempDir,
+        makeMetafile({
+          'dist/cli.js': output({
+            imports: [staticImport('dist/chunks/cli-entry.js')],
+          }),
+          'dist/chunks/cli-entry.js': output({
+            inputs: ['packages/cli/src/cli.ts'],
+          }),
+        }),
+      );
+
+      expect(() =>
+        execFileSync(process.execPath, [checkScriptPath], {
+          cwd: tempDir,
+          encoding: 'utf8',
+          stdio: 'pipe',
+        }),
+      ).toThrow(/no longer contains packages\/cli\/src\/cli\.ts/);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Problem

`packages/cli/src/cli.ts` is the esbuild entry point (`esbuild.config.js`) and bootstraps only under a main-module guard:

```ts
if (
  process.argv[1] !== undefined &&
  import.meta.url === pathToFileURL(process.argv[1]).href
) {
  void runCliEntryPoint();
}
```

The bundle is built with `splitting: true`. If any module the entry loads lazily — e.g. `gemini.tsx`, reached through `await import('./gemini.js')` — adds a **static** `import ... from './cli.js'`, esbuild moves the entry module's body into a shared chunk and leaves `dist/cli.js` as a bare re-export stub. Inside a chunk `import.meta.url` is the chunk's own URL, so the guard can never match: `runCliEntryPoint()` is never called and the bundled CLI exits 0 without doing anything.

Nothing catches this today. `tsc`, eslint and every src-based unit test stay green, because the breakage exists only in the bundle. The one CI step that executes `dist/cli.js` is the no-AK integration smoke test, and what it reports is:

```
daemon exited with 0 before listening:
stdout=
stderr=
```

from three unrelated `qwen serve` suites — a symptom that points nowhere near the import that caused it. #8088 has been stuck on exactly this: the base-update bot re-merged `main` assuming a stale base, AutoFix has burned six attempts, and the PR is still red.

## Change

`checkEntryBootstrapIntact()` asserts that `dist/cli.js` still compiles `packages/cli/src/cli.ts`. When the entry is hoisted, `dist/cli.js` keeps no inputs of its own, so the esbuild metafile that the existing closure checks already read is a precise, deterministic signal — no string matching against generated code.

It runs alongside the serve fast-path, ACP and sdk-impl closure checks in the same `npm run check:serve-fast-path-bundle` step, and the diagnostic names both the cause and the fix:

```
dist/cli.js no longer contains packages/cli/src/cli.ts — esbuild code splitting hoisted the entry
into a shared chunk, so its `import.meta.url === pathToFileURL(process.argv[1]).href` guard can
never match and the bundled CLI would exit 0 without running. Cause: a module the entry loads
lazily now statically imports './cli.js'. Move the shared helper into a leaf module and import
that from both sides instead.
Current dist/cli.js inputs: (none)
```

## Verification

Built #8088's head with the real `esbuild.config.js` options and ran this check against both bundle shapes:

| Bundle | `dist/cli.js` | metafile inputs | Check |
| --- | --- | --- | --- |
| #8088 head (cycle present) | 629 B re-export stub | `[]` | exits 1 with the diagnostic above |
| Same tree, cycle removed | 11,467 B, guard inline | `['packages/cli/src/cli.ts']` | `Startup bundle closure checks passed.` |

`scripts/tests/serve-fast-path-bundle-check.test.js`: 35 passed (31 existing + 4 new — healthy entry, hoisted entry, entry output absent from the metafile, and the CLI exit code). The shared `makeMetafile()` helper now includes a healthy `dist/cli.js` output so the existing cases keep exercising the closure checks rather than tripping the new one.

## Scope

This is the gate only. The `./cli.js` import that #8088 introduces is that PR's to fix; the fix there is to move the shared helpers into a leaf module — details posted on #8088.

<details>
<summary>中文说明</summary>

## 问题

`packages/cli/src/cli.ts` 是 esbuild 的 entry（见 `esbuild.config.js`），它只在自己是主模块时才会 bootstrap：

```ts
if (
  process.argv[1] !== undefined &&
  import.meta.url === pathToFileURL(process.argv[1]).href
) {
  void runCliEntryPoint();
}
```

bundle 开了 `splitting: true`。只要 entry 懒加载的任何模块（比如通过 `await import('./gemini.js')` 进来的 `gemini.tsx`）加一条**静态** `import ... from './cli.js'`，esbuild 就会把 entry 的模块体搬进共享 chunk，`dist/cli.js` 只剩一个 re-export 空壳。在 chunk 里 `import.meta.url` 指向 chunk 自身，守卫永远不成立：`runCliEntryPoint()` 一次都不会被调用，打包后的 CLI 什么都不做就 exit 0。

目前没有任何检查能发现它。`tsc`、eslint、所有基于 src 的单测全是绿的，因为只有 bundle 坏了。CI 里唯一真正执行 `dist/cli.js` 的是 no-AK 集成冒烟测试，而它报出来的是：

```
daemon exited with 0 before listening:
stdout=
stderr=
```

来自三个互不相干的 `qwen serve` 套件——这个症状离真正的元凶（那一行 import）十万八千里。#8088 就卡在这上面：update-branch 机器人以为是 base 过期又合了一次 main，AutoFix 烧掉了 6 次尝试，PR 至今还是红的。

## 改动

`checkEntryBootstrapIntact()` 断言 `dist/cli.js` 里仍然编译进了 `packages/cli/src/cli.ts`。entry 一旦被提到 chunk 里，`dist/cli.js` 就不再拥有自己的 inputs，所以现有闭包检查已经在读的 esbuild metafile 就是一个精确、确定的判据——不需要对生成代码做字符串匹配。

它和 serve fast-path、ACP、sdk-impl 三个闭包检查跑在同一个 `npm run check:serve-fast-path-bundle` 步骤里，报错信息同时点出成因和修法（见上方英文部分的输出示例）。

## 验证

用真实的 `esbuild.config.js` 选项构建了 #8088 的 head，再用本检查跑两种 bundle 形状：

| Bundle | `dist/cli.js` | metafile inputs | 检查结果 |
| --- | --- | --- | --- |
| #8088 head（存在环） | 629 B re-export 空壳 | `[]` | 退出 1，输出上述诊断 |
| 同一棵树、去掉环 | 11,467 B，守卫在 entry 内 | `['packages/cli/src/cli.ts']` | `Startup bundle closure checks passed.` |

`scripts/tests/serve-fast-path-bundle-check.test.js`：35 passed（31 条原有 + 4 条新增——正常 entry、被提到 chunk 的 entry、metafile 中缺少 entry 输出、以及 CLI 退出码）。共用的 `makeMetafile()` 里补了一个健康的 `dist/cli.js` 输出，这样原有用例继续考验闭包检查，而不是被新检查拦下。

## 范围

本 PR 只做门禁。#8088 引入的那条 `./cli.js` import 由该 PR 自己修——修法是把共享 helper 挪到叶子模块，细节已发在 #8088 上。

</details>
