### PR TITLE
fix(cli): allow scratch workspace without bearer token

### DIFF
--- a/packages/cli/src/serve/routes/workspace-management.test.ts
+++ b/packages/cli/src/serve/routes/workspace-management.test.ts
@@ -163,6 +163,43 @@ describe('POST /workspaces', () => {
     vi.clearAllMocks();
   });
 
+  it('allows scratch creation but protects existing paths in loopback development', async () => {
+    const parent = await mkdtemp(join(REAL_DIR, 'qws-scratch-route-'));
+    try {
+      const root = prepareManagedScratchRoot(join(parent, 'root'), []);
+      const mutate = vi.fn(
+        (options?: { strict?: boolean }) =>
+          (_req: Request, res: Response, next: () => void) => {
+            if (options?.strict) {
+              res.status(401).json({ code: 'token_required' });
+              return;
+            }
+            next();
+          },
+      );
+      const { app } = createApp({
+        workspaceRegistry: createMockRegistry([makeRuntime('/workspace')]),
+        managedScratchRoot: root,
+        runtimeRemoval: createRemovalController(),
+        mutate,
+      });
+
+      const scratch = await request(app)
+        .post('/workspaces')
+        .send({ kind: 'scratch' });
+      const existing = await request(app)
+        .post('/workspaces')
+        .send({ cwd: REAL_DIR });
+
+      expect(scratch.status).toBe(201);
+      expect(existing.status).toBe(401);
+      expect(mutate).toHaveBeenCalledWith();
+      expect(mutate).toHaveBeenCalledWith({ strict: true });
+    } finally {
+      await rm(parent, { recursive: true, force: true });
+    }
+  });
+
   it('returns 501 when createWorkspaceRuntime is not provided', async () => {
     const { app } = createApp({ createWorkspaceRuntime: undefined });
     const res = await request(app)

--- a/packages/cli/src/serve/routes/workspace-management.ts
+++ b/packages/cli/src/serve/routes/workspace-management.ts
@@ -478,9 +478,18 @@ export function registerWorkspaceManagementRoutes(
     },
   );
 
+  const protectExistingWorkspaceRegistration = mutate({ strict: true });
   app.post(
     '/workspaces',
-    mutate({ strict: true }),
+    mutate(),
+    (req, res, next) => {
+      const body = safeBody(req);
+      if (body['kind'] === 'scratch') {
+        next();
+        return;
+      }
+      protectExistingWorkspaceRegistration(req, res, next);
+    },
     async (req: Request, res: Response) => {
       const body = safeBody(req);
       if ('kind' in body) {


### PR DESCRIPTION
## What this PR does

Allows the loopback Web Shell to create daemon-managed scratch workspaces when bearer authentication is not configured, while keeping registration of arbitrary existing directories behind the strict bearer-token gate. Adds regression coverage for both sides of that authorization boundary.

## Why it's needed

Creating a new scratch session in the Web Shell currently calls the workspace registration endpoint, but the route rejects every request on the default auth-free loopback daemon before it can distinguish a managed scratch workspace from an existing filesystem path. Users therefore see a bearer-token configuration error when starting a new session, even though scratch workspaces are created in a daemon-owned directory with existing capacity and lifecycle controls.

## Reviewer Test Plan

### How to verify

Start a loopback daemon without `QWEN_SERVER_TOKEN`. Confirm that posting `{ "kind": "scratch" }` to the workspace registration endpoint succeeds with HTTP 201 and creates a trusted ephemeral workspace. Then post an existing directory path without a token and confirm it remains rejected with HTTP 401 and `token_required`. Run the focused workspace-management route test and confirm all cases pass.

### Evidence (Before & After)

Before: creating a new scratch session from the Web Shell returned `POST /workspaces: This route requires the daemon to be configured with a bearer token` on the default loopback daemon.

After: the same scratch request returns HTTP 201, while registration of an arbitrary existing path without a token still returns HTTP 401.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Verified with the bundled CLI using an isolated temporary `HOME`, `--bare --safe-mode --no-web`, loopback binding, and no bearer-token environment variables. Also passed the focused 111-test route suite, full build and bundle, CLI typecheck, and ESLint for the changed files.

## Risk & Scope

- Main risk or tradeoff: The scratch request discriminator is evaluated before the strict gate, so malformed requests containing `kind: "scratch"` reach normal request validation without bearer authentication; they cannot register a caller-selected path and remain subject to the exact scratch-body validation and daemon-managed directory controls.
- Not validated / out of scope: Windows and Linux runtime behavior were not tested locally; arbitrary existing-directory registration remains intentionally unavailable without bearer authentication.
- Breaking changes / migration notes: None.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## What this PR does

允许本机 loopback Web Shell 在未配置 bearer 认证时创建由 daemon 管理的 scratch workspace，同时继续要求注册任意已有目录时通过严格的 bearer token 鉴权。新增回归测试覆盖该鉴权边界的两侧行为。

## Why it's needed

Web Shell 创建新的 scratch 会话时会调用 workspace 注册接口，但当前路由会在默认免认证的 loopback daemon 上拒绝所有请求，尚未区分 daemon 管理的 scratch workspace 与已有文件系统路径。即使 scratch workspace 创建在 daemon 自有目录中，并受到现有容量和生命周期控制，用户启动新会话时仍会看到 bearer token 配置错误。

## Reviewer Test Plan

### How to verify

启动一个未设置 `QWEN_SERVER_TOKEN` 的 loopback daemon。确认向 workspace 注册接口提交 `{ "kind": "scratch" }` 时返回 HTTP 201，并创建可信的临时 workspace。随后在不提供 token 的情况下提交一个已有目录路径，确认仍返回 HTTP 401 和 `token_required`。运行 workspace-management 路由的聚焦测试并确认全部用例通过。

### Evidence (Before & After)

修复前：在默认 loopback daemon 中，从 Web Shell 创建新的 scratch 会话会返回 `POST /workspaces: This route requires the daemon to be configured with a bearer token`。

修复后：相同的 scratch 请求返回 HTTP 201，而未携带 token 注册任意已有路径仍返回 HTTP 401。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

使用打包后的 CLI 进行验证，采用隔离的临时 `HOME`、`--bare --safe-mode --no-web`、loopback 绑定，并显式移除 bearer token 环境变量。聚焦的 111 个路由测试、完整 build 和 bundle、CLI typecheck，以及修改文件的 ESLint 也均已通过。

## Risk & Scope

- 主要风险或权衡：scratch 请求判别发生在严格 gate 之前，因此包含 `kind: "scratch"` 的畸形请求会在无 bearer 认证时进入常规请求校验；这些请求无法注册调用方指定的路径，并且仍受精确 scratch 请求体校验及 daemon 管理目录控制。
- 未验证或范围外：未在 Windows 和 Linux 上进行本地运行时验证；注册任意已有目录在无 bearer 认证时仍按设计不可用。
- 破坏性变更或迁移说明：无。

## Linked Issues

无。

</details>
