### PR TITLE
fix(external-context): harden MCP dependencies

### DIFF
--- a/integrations/external-context/package.json
+++ b/integrations/external-context/package.json
@@ -22,7 +22,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.25.2",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "undici": "^7.28.0",
     "zod": "^3.25.0"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,7 @@
       "name": "@qwen-code/external-context",
       "version": "0.21.2",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.2",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "undici": "^7.28.0",
         "zod": "^3.25.0"
       },
@@ -2248,12 +2248,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -3620,12 +3620,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -10696,21 +10696,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -14631,9 +14644,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -28248,6 +28261,18 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "packages/mobile-mcp/node_modules/@hono/node-server": {
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "packages/mobile-mcp/node_modules/@modelcontextprotocol/sdk": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27804,7 +27804,7 @@
         "@agentclientprotocol/sdk": "^0.14.1",
         "@google/genai": "2.6.0",
         "@iarna/toml": "^2.2.5",
-        "@modelcontextprotocol/sdk": "^1.25.2",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "@qwen-code/acp-bridge": "file:../acp-bridge",
         "@qwen-code/audio-capture": "file:../audio-capture",
         "@qwen-code/channel-base": "file:../channels/base",
@@ -28055,7 +28055,7 @@
         "@anthropic-ai/sdk": "^0.36.1",
         "@google/genai": "2.6.0",
         "@iarna/toml": "^2.2.5",
-        "@modelcontextprotocol/sdk": "^1.25.2",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-logs-otlp-grpc": "^0.203.0",
         "@opentelemetry/exporter-logs-otlp-http": "^0.203.0",
@@ -28487,7 +28487,7 @@
       "version": "0.1.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.2",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "zod": "^3.25.0"
       },
       "bin": {
@@ -30932,7 +30932,7 @@
       "license": "LICENSE",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.14.1",
-        "@modelcontextprotocol/sdk": "^1.25.2",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "@qwen-code/acp-bridge": "*",
         "@qwen-code/sdk": "*",
         "@qwen-code/webui": "*",

--- a/package.json
+++ b/package.json
@@ -96,9 +96,6 @@
     "cliui": {
       "wrap-ansi": "7.0.0"
     },
-    "@modelcontextprotocol/sdk@^1.30.0": {
-      "@hono/node-server": "^2.0.5"
-    },
     "baseline-browser-mapping": "^2.9.19",
     "normalize-package-data": "^7.0.1",
     "react": "^19.2.4",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,9 @@
     "cliui": {
       "wrap-ansi": "7.0.0"
     },
+    "@modelcontextprotocol/sdk@^1.30.0": {
+      "@hono/node-server": "^2.0.5"
+    },
     "baseline-browser-mapping": "^2.9.19",
     "normalize-package-data": "^7.0.1",
     "react": "^19.2.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,7 +43,7 @@
     "@agentclientprotocol/sdk": "^0.14.1",
     "@google/genai": "2.6.0",
     "@iarna/toml": "^2.2.5",
-    "@modelcontextprotocol/sdk": "^1.25.2",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@qwen-code/acp-bridge": "file:../acp-bridge",
     "@qwen-code/audio-capture": "file:../audio-capture",
     "@qwen-code/channel-base": "file:../channels/base",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,7 +47,7 @@
     "@anthropic-ai/sdk": "^0.36.1",
     "@google/genai": "2.6.0",
     "@iarna/toml": "^2.2.5",
-    "@modelcontextprotocol/sdk": "^1.25.2",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-logs-otlp-grpc": "^0.203.0",
     "@opentelemetry/exporter-logs-otlp-http": "^0.203.0",

--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -64,7 +64,7 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.25.2",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "zod": "^3.25.0"
   },
   "devDependencies": {

--- a/packages/vscode-ide-companion/NOTICES.txt
+++ b/packages/vscode-ide-companion/NOTICES.txt
@@ -3319,7 +3319,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
 ============================================================
-@modelcontextprotocol/sdk@1.29.0
+@modelcontextprotocol/sdk@1.30.0
 (git+https://github.com/modelcontextprotocol/typescript-sdk.git)
 
 MIT License
@@ -3346,8 +3346,8 @@ SOFTWARE.
 
 
 ============================================================
-@hono/node-server@1.19.14
-(https://github.com/honojs/node-server.git)
+@hono/node-server@2.0.12
+(git+https://github.com/honojs/node-server.git)
 
 MIT License
 
@@ -3428,7 +3428,7 @@ SOFTWARE.
 
 
 ============================================================
-fast-uri@3.1.3
+fast-uri@3.1.4
 (git+https://github.com/fastify/fast-uri.git)
 
 Copyright (c) 2011-2021, Gary Court until https://github.com/garycourt/uri-js/commit/a1acf730b4bba3f1097c9f52e7d9d3aba8cdcaae
@@ -3913,7 +3913,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ============================================================
-body-parser@2.2.2
+body-parser@2.3.0
 (No repository found)
 
 (The MIT License)

--- a/packages/vscode-ide-companion/package.json
+++ b/packages/vscode-ide-companion/package.json
@@ -293,7 +293,7 @@
     "@qwen-code/acp-bridge": "*",
     "@qwen-code/sdk": "*",
     "@qwen-code/webui": "*",
-    "@modelcontextprotocol/sdk": "^1.25.2",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "cors": "^2.8.5",
     "dotenv": "^17.1.0",
     "express": "^5.1.0",


### PR DESCRIPTION
## What this PR does

This PR upgrades the direct external-context integration to MCP SDK 1.30.0 and selects the patched Hono 2 line only for consumers on MCP SDK 1.30 or newer. It also refreshes transitive request- and URI-parsing dependencies and regenerates third-party notices.

The scoped override deliberately leaves the mobile MCP package on its current Node 18-compatible MCP SDK and Hono 1 dependency tree instead of imposing Hono 2's Node 20 requirement on that package.

## Why it's needed

The external-context workspace production audit reported four advisories across the MCP SDK, Hono server, body parser, and URI parser dependency paths. After this change, that workspace's production audit reports zero vulnerabilities while preserving the repository's existing Node compatibility boundaries.

## Reviewer Test Plan

### How to verify

1. Confirm the external-context workspace resolves MCP SDK 1.30.0, Hono 2.0.12, body-parser 2.3.0, and fast-uri 3.1.4, while the mobile MCP workspace continues to resolve its existing MCP SDK 1.26 and Hono 1 line.
2. Run the external-context unit suite and confirm all provider, MCP, proxy, configuration, and auto-recall behavior remains unchanged.
3. Start the built external-context process over stdio against a loopback fake Generic HTTP provider. Confirm it lists only the expected search tool, sends the fixed authenticated search request, returns normalized context, emits no stderr, and exits cleanly.
4. Confirm an external-context production-only lockfile audit reports zero vulnerabilities and regenerated third-party notices are deterministic.
5. Confirm existing oversized HTTP request tests still return a JSON 413 response after the body-parser update.

### Evidence (Before & After)

N/A — dependency-only change with no user-visible or TUI changes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Node.js 22.22.3 and npm 10.9.8 on macOS.

## Risk & Scope

- Main risk or tradeoff: Hono 2 requires Node.js 20 or newer; this is compatible with Qwen Code's Node.js 22 minimum and is scoped away from the Node.js 18-compatible mobile MCP package.
- Not validated / out of scope: The repository-wide audit still reports the legacy MCP SDK/Hono advisory in the mobile MCP package's separately nested dependency tree. Resolving that requires a separate Node.js baseline and dependency-lifecycle decision.
- Breaking changes / migration notes: None. The external-context MCP protocol, provider request mapping, and configuration are unchanged.

## Linked Issues

Refs #7585

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 将 Direct External Context 集成升级到 MCP SDK 1.30.0，并且只对使用 MCP SDK 1.30 或更高版本的消费者选择已修复的 Hono 2 版本。同时更新传递依赖中的请求解析器和 URI 解析器，并重新生成第三方依赖声明。

该范围化 override 有意让 mobile MCP 包继续使用当前兼容 Node.js 18 的 MCP SDK 和 Hono 1 依赖树，避免把 Hono 2 的 Node.js 20 要求强加给该包。

## 为什么需要

external-context workspace 的生产依赖审计在 MCP SDK、Hono server、body parser 和 URI parser 路径上报告了四项安全告警。修改后，该 workspace 的生产依赖审计为零漏洞，同时保留仓库现有的 Node.js 兼容性边界。

## Reviewer 测试计划

### 如何验证

1. 确认 external-context workspace 解析到 MCP SDK 1.30.0、Hono 2.0.12、body-parser 2.3.0 和 fast-uri 3.1.4，同时 mobile MCP workspace 仍使用现有的 MCP SDK 1.26 和 Hono 1 版本线。
2. 运行 external-context 单元测试，确认 Provider、MCP、代理、配置和 Auto Recall 行为均未改变。
3. 使用本地回环 Fake Generic HTTP Provider，以 stdio 启动构建后的 external-context 进程。确认它只列出预期的搜索工具、发送固定且带鉴权的搜索请求、返回标准化上下文、不输出 stderr，并能正常退出。
4. 确认 external-context 的仅生产依赖锁文件审计报告零漏洞，且重新生成的第三方依赖声明具有确定性。
5. 确认 body-parser 更新后，现有超大 HTTP 请求测试仍返回 JSON 413 响应。

### 证据（修改前后）

N/A——这是纯依赖修改，没有用户可见或 TUI 变化。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

macOS，Node.js 22.22.3，npm 10.9.8。

## 风险与范围

- 主要风险或权衡：Hono 2 要求 Node.js 20 或更高版本；它符合 Qwen Code 的 Node.js 22 最低版本要求，并通过范围化配置与兼容 Node.js 18 的 mobile MCP 包隔离。
- 未验证 / 范围外：仓库级审计仍会在 mobile MCP 包独立嵌套的旧版 MCP SDK/Hono 依赖树中报告告警。解决它需要独立决定 Node.js 基线和依赖生命周期。
- 破坏性变更 / 迁移说明：无。external-context 的 MCP 协议、Provider 请求映射和配置均未改变。

## 关联 Issue

Refs #7585

</details>
