### PR TITLE
fix(test): isolate the worktree symlink test's temporary sibling directory

### DIFF
--- a/packages/core/src/services/gitWorktreeService.symlinks.integ.test.ts
+++ b/packages/core/src/services/gitWorktreeService.symlinks.integ.test.ts
@@ -21,13 +21,23 @@ import { GitWorktreeService } from './gitWorktreeService.js';
 describe('GitWorktreeService.createUserWorktree() — symlinkDirectories', () => {
   vi.setConfig({ testTimeout: 30000, hookTimeout: 30000 });
 
+  // The repo lives one level DOWN inside a per-test parent dir so that
+  // tests needing a sibling of the repo (`../foo` traversal coverage)
+  // have a private place to put it. Rooting the repo directly at
+  // `os.tmpdir()` would make `path.dirname(repoRoot)` the machine-wide
+  // temp dir, where a fixed sibling name collides with any concurrent
+  // run on the same host — and stays behind forever once a run is
+  // killed mid-test, wedging every later run on that machine.
+  let repoParent: string;
   let repoRoot: string;
 
   beforeEach(async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'qwen-wt-symlinks-'));
     // Resolve symlinks (macOS /var → /private/var) so path comparisons
     // line up with what GitWorktreeService produces internally.
-    repoRoot = await fs.realpath(dir);
+    repoParent = await fs.realpath(dir);
+    repoRoot = path.join(repoParent, 'repo');
+    await fs.mkdir(repoRoot);
     execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: repoRoot });
     execFileSync('git', ['config', 'user.email', 't@e.com'], { cwd: repoRoot });
     execFileSync('git', ['config', 'user.name', 't'], { cwd: repoRoot });
@@ -42,7 +52,8 @@ describe('GitWorktreeService.createUserWorktree() — symlinkDirectories', () =>
   });
 
   afterEach(async () => {
-    await fs.rm(repoRoot, { recursive: true, force: true });
+    // Removes the repo AND anything a test parked beside it.
+    await fs.rm(repoParent, { recursive: true, force: true });
   });
 
   it('symlinks a configured directory into the new worktree', async () => {
@@ -170,17 +181,21 @@ describe('GitWorktreeService.createUserWorktree() — symlinkDirectories', () =>
   it('rejects paths that traverse outside the repo root', async () => {
     // Put a sibling directory next to the repo so `../sibling` resolves to
     // something real — proving the guard fires on traversal shape rather
-    // than on "source missing".
+    // than on "source missing". `path.dirname(repoRoot)` is this test's
+    // own parent temp dir, so the fixed name below is private to this
+    // run: no cross-run collision, and afterEach reclaims it even if the
+    // process is killed before the cleanup below.
     const siblingDir = path.join(path.dirname(repoRoot), 'qwen-wt-sibling');
-    await fs.mkdir(siblingDir);
-    await fs.writeFile(path.join(siblingDir, 'marker'), 'outside');
-
-    const service = new GitWorktreeService(repoRoot);
-    const result = await service.createUserWorktree('traverse', 'main', {
-      symlinkDirectories: ['../qwen-wt-sibling'],
-    });
 
     try {
+      await fs.mkdir(siblingDir);
+      await fs.writeFile(path.join(siblingDir, 'marker'), 'outside');
+
+      const service = new GitWorktreeService(repoRoot);
+      const result = await service.createUserWorktree('traverse', 'main', {
+        symlinkDirectories: ['../qwen-wt-sibling'],
+      });
+
       expect(result.success).toBe(true);
       const dest = path.join(result.worktree!.path, '..', 'qwen-wt-sibling');
       // No symlink was created inside the worktree directory.


### PR DESCRIPTION
## What this PR does

Gives the worktree symlink integration test its own private slice of the temp directory. The test needs a directory that sits *beside* the repository it works on, so it can prove that a configured entry pointing at a parent directory is rejected on traversal shape rather than because the source is missing. Until now the temporary repository was created directly in the system temp directory, which made that sibling a fixed, machine-wide path. This change nests the repository one level down inside a per-test parent directory, so the sibling location is unique per run, and removes the whole parent afterwards so nothing is left in the shared temp directory. The sibling's creation also moves inside the block whose cleanup covers it.

## Why it's needed

The shared path made the test unsafe on any machine that runs more than one job at a time. Two runs racing to create the same sibling meant one of them failed outright, and because the creation happened before the cleanup block, the loser never removed anything — neither did a run that was cancelled while the test was in flight. The leftover directory then poisoned the machine permanently: every subsequent job failed at the same line with `EEXIST: file already exists`, no matter what it was changing.

That is exactly what is happening in CI right now. Across the last hundred CI runs, every run scheduled onto the newer self-hosted pool failed on this single test, while every run on the other self-hosted pool and on GitHub-hosted runners passed. Authors have been seeing red CI on unrelated pull requests — web-shell styling, provider fixes, docs-adjacent changes — with a failure in a core worktree test they never touched, and re-running only helps if the retry happens to land on a clean machine.

Note that this fixes the *recurrence*: the stale directory already sitting on the affected runners still needs to be removed (or their image rebuilt) for those machines to go green again.

## Reviewer Test Plan

### How to verify

Reproducing the failure before the change: create the fixed sibling path in the system temp directory by hand, then run the test file. It fails with `EEXIST: file already exists` at the point where the sibling is created — byte-identical to the CI failure. Alternatively, start three copies of the test file at the same time on a clean temp directory; two of the three fail the same way, which is the concurrency shape that a busy shared runner hits naturally.

With the change, both scenarios pass. The pre-existing stale directory is simply ignored because the test no longer looks there, and three simultaneous runs all pass with no collisions. Afterwards the shared temp directory holds nothing belonging to this test.

Observed locally:

- Stale directory present, before: `Tests 1 failed | 14 passed (15)` — `EEXIST: file already exists, mkdir '/tmp/qwen-wt-sibling'`
- Stale directory present, after: `Tests 15 passed (15)`
- Three concurrent runs, before: `15 passed` / `1 failed | 14 passed` / `1 failed | 14 passed`
- Three concurrent runs, after: `15 passed` three times, and no leftovers in the shared temp directory

The assertions themselves are unchanged, so the guard's coverage is the same: the whole file still passes (15 tests), as does the rest of the worktree service suite (54 tests). Type checking, lint, and formatting are clean.

### Evidence (Before & After)

N/A — not user-visible.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  ⚠️ not tested  |
| 🪟 Windows |  ⚠️ not tested  |
|  🐧 Linux  |  ✅ tested  |
