### PR TITLE
feat(triage): start the verify lane alongside /triage on a pull request

### DIFF
--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -91,6 +91,14 @@ jobs:
       # gets a pinned head OID, a pre-execution risk screen, and a full
       # workspace wipe. Empty for every non-verify event.
       verify_trust: '${{ steps.perm.outputs.verify_trust }}'
+      # Whether the verify LANE should run at all. `/verify` sets it, and so
+      # does a `/triage` comment on a PR — triage reads, verify runs, and a
+      # maintainer asking for a review usually wants both. Kept separate from
+      # should_run because the two fail differently: an unreadable author
+      # permission denies an explicit `/verify` outright (it is the input to
+      # the control selection), but must NOT take the triage down with it, so
+      # the piggybacked lane just turns itself off and triage proceeds.
+      verify_lane: '${{ steps.perm.outputs.verify_lane }}'
       # Head OID snapped AT SPONSORSHIP TIME for an external run: the
       # maintainer's /verify comment approves the code that exists now, not
       # whatever the author pushes while the job queues.
@@ -112,10 +120,25 @@ jobs:
           PR_NUMBER: '${{ github.event.pull_request.number }}'
           ISSUE_NUMBER: '${{ github.event.issue.number }}'
           TMUX_PR: '${{ github.event.inputs.tmux_pr }}'
+          # `github.event.issue.pull_request` is an object on PRs and null on
+          # issues; compare against null rather than truthiness so the shell
+          # receives a plain true/false.
+          IS_PR: '${{ github.event.issue.pull_request != null }}'
         run: |-
           set -euo pipefail
           IS_VERIFY=false
+          # VERIFY_LANE is "run the verify job"; IS_VERIFY is "the commenter
+          # typed /verify". They differ only for the piggybacked lane, where
+          # a classification failure must skip verify without denying triage.
+          VERIFY_LANE=false
           if [ "$EVENT_NAME" = "pull_request_target" ]; then
+            # Automatic per-PR triage deliberately does NOT pull the verify
+            # lane with it. Runner capacity is not the reason — the ECS pool
+            # is maintainer-provided and expandable, and cheaper than the
+            # tokens. The reason is the AGENT budget: a verify run is up to
+            # 110 minutes of model time, and every `synchronize` would spend
+            # one, including the ones that fix a typo. Commenting is what
+            # says the PR is ready to be worth that.
             echo "Automatic PR triage allowed for PR #${PR_NUMBER} after same-repo/precheck gate." >> "$GITHUB_STEP_SUMMARY"
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
@@ -147,9 +170,21 @@ jobs:
               case "$body_lc" in
                 '@qwen-code /verify'|'@qwen-code /verify '*)
                   IS_VERIFY=true
+                  VERIFY_LANE=true
                   principals="$COMMENT_USER"
                   ;;
                 '@qwen-code /tmux'|'@qwen-code /tmux '*) principals="$ISSUE_AUTHOR" ;;
+                '@qwen-code /triage'*)
+                  # /triage on a PR also starts verify, in parallel — the
+                  # two answer different questions and neither waits on the
+                  # other. On a plain ISSUE there is nothing to build, so
+                  # the lane stays off and no author lookup is spent.
+                  # `principals` is unchanged: both lanes already gate on
+                  # the commenter, so this adds a control selection, not a
+                  # new gate.
+                  [ "$IS_PR" = 'true' ] && VERIFY_LANE=true
+                  principals="$COMMENT_USER"
+                  ;;
                 *) principals="$COMMENT_USER" ;;
               esac
               ;;
@@ -220,12 +255,27 @@ jobs:
           # Fail closed on every lookup: an unreadable author permission or
           # an unresolvable head OID denies the run outright — classifying
           # a request we cannot read would silently pick a trust level.
-          if [ "$IS_VERIFY" = true ]; then
+          # For the lane piggybacked on /triage, "fail closed" means the
+          # LANE closes, not the whole run: the commenter asked for a
+          # review, and taking that away because an unrelated API call
+          # flaked would be a worse answer than shipping triage alone.
+          # Either way no code executes unclassified, which is the property
+          # the four external-only controls (head-OID pin, risk screen,
+          # pre- and post-run workspace wipes) depend on.
+          if [ "$VERIFY_LANE" = true ]; then
+            deny_verify() {
+              echo "$1" >> "$GITHUB_STEP_SUMMARY"
+              if [ "$IS_VERIFY" = true ]; then
+                echo "should_run=false" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              echo "verify_lane=false" >> "$GITHUB_OUTPUT"
+              echo "should_run=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            }
             if [ -z "$ISSUE_AUTHOR" ] ||
                ! author_perm="$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${ISSUE_AUTHOR}/permission" --jq '.permission' 2>/dev/null)"; then
-              echo "Could not resolve the PR author's permission for /verify; denying." >> "$GITHUB_STEP_SUMMARY"
-              echo "should_run=false" >> "$GITHUB_OUTPUT"
-              exit 0
+              deny_verify "Could not resolve the PR author's permission for the verify lane; skipping it."
             fi
             case "$author_perm" in
               admin|maintain|write)
@@ -234,15 +284,14 @@ jobs:
               *)
                 if ! sponsor_oid="$(gh pr view "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefOid --jq '.headRefOid' 2>/dev/null)" ||
                    [ -z "$sponsor_oid" ]; then
-                  echo "Could not snapshot the PR head for a sponsored /verify; denying." >> "$GITHUB_STEP_SUMMARY"
-                  echo "should_run=false" >> "$GITHUB_OUTPUT"
-                  exit 0
+                  deny_verify "Could not snapshot the PR head for a sponsored verify lane; skipping it."
                 fi
                 echo "verify_trust=external" >> "$GITHUB_OUTPUT"
                 echo "verify_head_oid=${sponsor_oid}" >> "$GITHUB_OUTPUT"
-                echo "Sponsored /verify for external author ${ISSUE_AUTHOR} at ${sponsor_oid} (sponsored by ${COMMENT_USER}): head pinned, risk screen and workspace wipe enabled." >> "$GITHUB_STEP_SUMMARY"
+                echo "Sponsored verify lane for external author ${ISSUE_AUTHOR} at ${sponsor_oid} (sponsored by ${COMMENT_USER}): head pinned, risk screen and workspace wipe enabled." >> "$GITHUB_STEP_SUMMARY"
                 ;;
             esac
+            echo "verify_lane=true" >> "$GITHUB_OUTPUT"
           fi
           echo "should_run=true" >> "$GITHUB_OUTPUT"
 
@@ -1828,22 +1877,25 @@ jobs:
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
       github.event.issue.state == 'open' &&
-      (github.event.comment.body == '@qwen-code /verify' ||
-       startsWith(github.event.comment.body, '@qwen-code /verify ')) &&
+      needs.authorize.outputs.verify_lane == 'true' &&
       needs.authorize.outputs.should_run == 'true' &&
       vars.MAINTAINER_ECS_RUNNER_DISABLED != 'true'
     # One verification per PR at a time, mirroring the tmux job: concurrent
     # runs would share the same self-hosted workspace and clobber each other.
     # GitHub evaluates concurrency before the job `if`, but after `needs`, so
     # keep non-runnable triggers out of the shared per-PR group.
+    #
+    # `verify_lane` is the single source of truth for "does this trigger
+    # start verify" — authorize decides it, and the command strings are
+    # matched in exactly one place. Enumerating them here too is what let
+    # the trust classification and the lane trigger drift apart.
     concurrency:
       group: >-
         ${{
           (github.event_name == 'issue_comment' &&
            github.event.issue.pull_request &&
            github.event.issue.state == 'open' &&
-           (github.event.comment.body == '@qwen-code /verify' ||
-            startsWith(github.event.comment.body, '@qwen-code /verify ')) &&
+           needs.authorize.outputs.verify_lane == 'true' &&
            needs.authorize.outputs.should_run == 'true' &&
            vars.MAINTAINER_ECS_RUNNER_DISABLED != 'true') &&
           format('{0}-verify-{1}', github.workflow, github.event.issue.number) ||

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -834,7 +834,13 @@ describe('qwen-triage verify workflow', () => {
     );
 
     let n = 0;
-    const gate = (commentBody, author, commenter, issueNumber = '1') => {
+    const gate = (
+      commentBody,
+      author,
+      commenter,
+      issueNumber = '1',
+      isPr = 'true',
+    ) => {
       const out = join(dir, `out-${n++}`);
       writeFileSync(out, '');
       spawnSync('bash', ['-c', script], {
@@ -851,6 +857,7 @@ describe('qwen-triage verify workflow', () => {
           COMMENT_USER: commenter,
           PR_NUMBER: '1',
           ISSUE_NUMBER: issueNumber,
+          IS_PR: isPr,
           TMUX_PR: '',
         },
         encoding: 'utf8',
@@ -865,6 +872,7 @@ describe('qwen-triage verify workflow', () => {
         run: val('should_run'),
         trust: val('verify_trust'),
         oid: val('verify_head_oid'),
+        lane: val('verify_lane'),
       };
     };
 
@@ -900,16 +908,49 @@ describe('qwen-triage verify workflow', () => {
       expect(gate('@qwen-code /tmux', 'alice', 'mallory').run).toBe('true');
       expect(gate('@qwen-code /tmux', 'mallory', 'bob').run).toBe('false');
       expect(gate('@qwen-code /triage', 'mallory', 'bob').run).toBe('true');
-      // Neither non-verify path emits trust outputs. Assert the REAL keys:
-      // this line read `.runner` — a name from an earlier design that
-      // `gate()` never returns — so it was `expect(undefined).toBeUndefined()`
-      // and could not fail, however badly the trust level leaked.
-      const triage = gate('@qwen-code /triage', 'mallory', 'bob');
-      expect(triage.trust).toBeUndefined();
-      expect(triage.oid).toBeUndefined();
+
+      // /triage on a PR ALSO starts the verify lane, in parallel — and the
+      // point of routing it through the same classifier is that an external
+      // author still gets the external control set. If this ever emits
+      // `trusted` (or no trust at all) for `mallory`, the head-OID pin, the
+      // risk screen and both workspace wipes silently stop firing while the
+      // lane keeps executing that author's code on the persistent pool.
+      const triagePr = gate('@qwen-code /triage', 'mallory', 'bob');
+      expect(triagePr.run).toBe('true');
+      expect(triagePr.lane).toBe('true');
+      expect(triagePr.trust).toBe('external');
+      expect(triagePr.oid).toBe('deadbeefcafe');
+      expect(gate('@qwen-code /triage', 'alice', 'bob').trust).toBe('trusted');
+
+      // The lane fails closed DIFFERENTLY from an explicit /verify. An
+      // unreadable author permission denies `/verify` outright, because the
+      // commenter asked for exactly that; on `/triage` it must only close
+      // the lane, or a flaky permission API silently costs the reviewer
+      // their triage too. Same for a failed head-OID snapshot (issue 99).
+      const laneFail = gate('@qwen-code /triage', 'charlie', 'bob');
+      expect(laneFail.run).toBe('true');
+      expect(laneFail.lane).toBe('false');
+      expect(laneFail.trust).toBeUndefined();
+      const oidFail = gate('@qwen-code /triage', 'mallory', 'bob', '99');
+      expect(oidFail.run).toBe('true');
+      expect(oidFail.lane).toBe('false');
+      expect(gate('@qwen-code /verify', 'charlie', 'bob').run).toBe('false');
+
+      // On a plain ISSUE there is nothing to build, so the lane stays off
+      // and no author lookup is spent. This assertion used to be written as
+      // "/triage emits no trust outputs" with a fixture that never set
+      // IS_PR — true for the wrong reason, and it would have stayed green
+      // through the change above.
+      const triageIssue = gate('@qwen-code /triage', 'mallory', 'bob', '1', '');
+      expect(triageIssue.run).toBe('true');
+      expect(triageIssue.lane).toBeUndefined();
+      expect(triageIssue.trust).toBeUndefined();
+      expect(triageIssue.oid).toBeUndefined();
+
       const tmux = gate('@qwen-code /tmux', 'alice', 'bob');
       expect(tmux.trust).toBeUndefined();
       expect(tmux.oid).toBeUndefined();
+      expect(tmux.lane).toBeUndefined();
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -944,6 +985,72 @@ describe('qwen-triage verify workflow', () => {
     const mk = verifyJob.indexOf('mkdir -p "$RUNNER_TEMP/verify-results"');
     expect(rm).toBeGreaterThan(-1);
     expect(mk).toBeGreaterThan(rm);
+  });
+
+  // The lane trigger was unpinned: deleting the gate from the verify job's
+  // `if` left every assertion green while the job became reachable from any
+  // comment on any open PR. Measured as a mutation before this test existed.
+  //
+  // `verify_lane` is also the single source of truth for WHICH comments
+  // start the lane. Re-enumerating the command strings in the job predicate
+  // is what let the trigger and the trust classification drift apart — the
+  // classifier keyed on `/verify` while the predicate would have keyed on
+  // `/verify` or `/triage`, so a `/triage`-started run would have executed
+  // an external author's code with `verify_trust` empty and all four
+  // external-only controls (head-OID pin, risk screen, both wipes) skipped.
+  it('gates the verify lane on authorize alone, not on re-matched commands', () => {
+    // Slice the two predicates APART. Asserting over the whole job text
+    // cannot tell them apart: the first version of this test did exactly
+    // that, and deleting the gate from `if:` still matched the copy inside
+    // `concurrency:` — the mutation survived its own regression test.
+    const raw = job('verify');
+    const ifBlock = raw.slice(
+      raw.indexOf('if: >-'),
+      raw.indexOf('concurrency:'),
+    );
+    const concBlock = raw.slice(
+      raw.indexOf('concurrency:'),
+      raw.indexOf('timeout-minutes:'),
+    );
+    expect(ifBlock).toBeTruthy();
+    expect(concBlock).toBeTruthy();
+    for (const predicate of [ifBlock, concBlock]) {
+      expect(predicate).toContain(
+        "needs.authorize.outputs.verify_lane == 'true'",
+      );
+    }
+    // Concurrency is evaluated after `needs`, so it can and must read the
+    // same output; an unguarded group would let non-runnable triggers share
+    // the per-PR group and cancel a real run.
+    expect(ifBlock).not.toContain("comment.body == '@qwen-code /verify'");
+    expect(concBlock).not.toContain("comment.body == '@qwen-code /verify'");
+
+    // And the authorize job has to actually publish it.
+    expect(job('authorize')).toContain(
+      "verify_lane: '${{ steps.perm.outputs.verify_lane }}'",
+    );
+  });
+
+  // Positive control for the mutations above: a guard this suite is known
+  // to pin, asserted per predicate. Written first as one `toContain` over
+  // the whole job, it survived its own mutation — the copy in
+  // `concurrency:` matched after the `if:` copy was deleted, which is the
+  // same coarse-assertion defect the test above documents. A control that
+  // cannot fail proves nothing about the assertions it vouches for.
+  it('pins the ECS kill switch on both verify predicates (control)', () => {
+    const raw = job('verify');
+    const ifBlock = raw.slice(
+      raw.indexOf('if: >-'),
+      raw.indexOf('concurrency:'),
+    );
+    const concBlock = raw.slice(
+      raw.indexOf('concurrency:'),
+      raw.indexOf('timeout-minutes:'),
+    );
+    expect(ifBlock).toContain("vars.MAINTAINER_ECS_RUNNER_DISABLED != 'true'");
+    expect(concBlock).toContain(
+      "vars.MAINTAINER_ECS_RUNNER_DISABLED != 'true'",
+    );
   });
 });
 


### PR DESCRIPTION
## Change

A `@qwen-code /triage` comment on a pull request now starts the sandboxed **verify** lane as well, in parallel. Triage reads; verify builds and runs. Neither waits on the other — they were already sibling jobs on `needs: ['authorize']`, so this is a trigger change, not a new pipeline.

## The trigger cannot be a second copy of the command patterns

`authorize` now publishes `verify_lane`, and both the verify job's `if` and its `concurrency` group read it. Re-matching the command strings in the job predicate is exactly what would let the trigger and the trust classification drift apart:

`authorize` computes the trust level inside `if [ "$IS_VERIFY" = true ]`, and the verify job's four external-only controls are each gated on `verify_trust == 'external'` — the sponsorship head-OID pin, the pre-execution risk screen, and the workspace wipes before and after the run. Had the job predicate learned about `/triage` while the classifier still keyed on `/verify`, a `/triage`-started run would have executed an external author's code with `verify_trust` **empty**, so all four would silently not fire.

That is not a loss of isolation — the container, the tokenless agent env, the loopback model proxy and the PR-code-free publish job are unconditional, and the pool is a separate VPC with no path to the intranet. It is the **persistence** risk this workflow already documents in its own comments: machines are reused, and the next run arrives carrying credentials that artifacts planted now could harvest. The wipes are what answer it, and they are deny-by-default where the allowlist sweep is vector-by-vector. Routing the new trigger through the same classifier is what keeps them on.

## Failing closed, differently

An unreadable author permission or a failed head-OID snapshot still denies an explicit `/verify` outright — the commenter asked for exactly that, and a request that cannot be classified must not pick a trust level. On `/triage` the same failure closes **only the lane**: the commenter asked for a review, and a flaky permission API should not cost them their triage.

Automatic per-PR triage (`pull_request_target`) deliberately does not pull the lane. The constraint is not runner capacity — the ECS pool is maintainer-provided, expandable, and cheaper than the tokens. It is the **agent budget**: a verify run is up to 110 minutes of model time, and every `synchronize` would spend one, including the ones that fix a typo. Commenting is what says the PR is worth it. On a plain issue the lane stays off and no author lookup is spent.

## Tests

The verify lane's trigger turned out to be **unpinned**: deleting the gate from the job predicate left the suite green. That gap is now closed, and closing it took two tries — worth recording, because both failures were the same shape:

- The first version asserted over the whole job text, which cannot tell `if:` from `concurrency:`. Deleting the gate from `if:` still matched the copy in `concurrency:`, so the test **survived its own mutation**.
- The positive control written to vouch for it had the identical defect and also survived. A control that cannot fail proves nothing about the assertions it backs.

Both now slice per predicate. Mutation matrix on the real workflow:

| mutation | result |
| --- | --- |
| drop the lane gate from `if:` | **caught** |
| drop the lane gate from `concurrency:` | **caught** |
| authorize's `/triage` branch never sets the lane | **caught** |
| the piggybacked lane denies triage instead of closing itself | **caught** |
| unmutated | green |
| ECS kill switch removed from `if:` (positive control) | **caught** |

The authorize step itself was **executed**, not read: extracted from the YAML and driven under a per-user permission stub across twelve branches, so the commenter gate and the author classification could be varied independently. (A first stub returned one permission for both and denied everything at the commenter gate — the harness was wrong, not the code.)

| trigger | author | result |
| --- | --- | --- |
| `/verify` | write | `trusted`, lane on |
| `/verify` | external | `external` + pinned OID, lane on |
| `/verify` | lookup fails | `should_run=false` |
| `/triage` on a PR | write | `trusted`, lane on |
| `/triage` on a PR | external | `external` + pinned OID, lane on |
| `/triage` on a PR | lookup fails | lane off, **triage proceeds** |
| `/triage` on a PR | OID snapshot fails | lane off, triage proceeds |
| `/triage` on an issue | — | no lane, no lookup spent |
| `/tmux`, plain comment | — | unchanged |
| any, commenter without write | — | denied |

One existing assertion had to be rewritten rather than kept: it read "`/triage` emits no trust outputs" with a fixture that never set the PR flag. True for the wrong reason, and it would have stayed green straight through this change.

`scripts/tests/qwen-triage-workflow.test.js` 109/109; actionlint, yamllint and eslint `--max-warnings 0` clean. The prettier warning on `qwen-triage.yml` is pre-existing — it reproduces identically with this change stashed.

<details>
<summary>中文说明</summary>

## 改动

在 pull request 上评论 `@qwen-code /triage`，现在会**并行**拉起沙箱 **verify** 通道。triage 负责读，verify 负责构建与运行，两者互不等待——它们本来就是 `needs: ['authorize']` 上的同级 job，所以这是触发条件的改动，不是新增流水线。

## 触发条件不能是命令模式的第二份副本

`authorize` 现在输出 `verify_lane`，verify job 的 `if` 与 `concurrency` 都读它。若在 job 判据里重新匹配一遍命令字符串，正是会让**触发条件**与**信任分类**脱钩的做法：

`authorize` 在 `if [ "$IS_VERIFY" = true ]` 内部计算信任等级，而 verify job 的四道"仅外部"控制各自挂在 `verify_trust == 'external'` 上——sponsorship 的 head-OID 钉定、执行前风险筛查、以及运行前与运行后的工作区擦除。如果 job 判据认识了 `/triage` 而分类器仍只认 `/verify`，那么由 `/triage` 拉起的运行会在 `verify_trust` **为空**的情况下执行外部作者的代码，四道控制会静默地全部不生效。

这并不是隔离失效——容器、无 token 的 agent 环境、loopback 模型代理、以及不接触 PR 代码的发布 job 都是无条件生效的，而且机器池位于独立 VPC，与内网不通。这里针对的是本工作流自己注释中已经写明的**持久化**风险：机器会被复用，而下一次运行会带着凭据到来，此刻被植入的产物可以窃取它们。两道擦除正是对此的回答，且不同于逐向量枚举的 allowlist sweep，它们是 deny-by-default。让新触发条件走同一个分类器，就是为了让它们继续生效。

## 失败关闭，但方式不同

作者权限不可读、或 head-OID 快照失败时，显式的 `/verify` 仍然整体拒绝——评论者要的就是这件事，而一个无法分类的请求绝不能自行挑选信任等级。而在 `/triage` 上，同样的失败**只关闭该通道**：评论者要的是评审，不该因为一次权限 API 抖动而连 triage 也失去。

自动的逐 PR triage（`pull_request_target`）刻意不拉起该通道。约束不在 runner 容量——ECS 池由维护方自建、可扩容，而且比 token 便宜。约束在**agent 预算**：一次 verify 最多 110 分钟模型时间，而每一次 `synchronize` 都会花掉一次，包括那些只改了个错别字的推送。评论这个动作，才是"这个 PR 值得跑一次"的表态。在普通 issue 上该通道保持关闭，也不会浪费一次作者权限查询。

## 测试

verify 通道的触发条件此前**根本没有被钉住**：把闸门从 job 判据里删掉，测试套件依然全绿。这个缺口现已补上，而补上它用了两次尝试——值得记录，因为两次失败是同一种形状：

- 第一版断言作用于整个 job 文本，无法区分 `if:` 与 `concurrency:`。从 `if:` 删掉闸门后，`concurrency:` 里的那份副本仍然匹配，于是该测试**在自己的变异下存活**。
- 为它背书而写的正对照有完全相同的缺陷，同样存活。一个不可能失败的对照，对它所背书的断言没有任何证明力。

现在两者都按判据分别切片。在真实工作流上的变异矩阵：

| 变异 | 结果 |
| --- | --- |
| 从 `if:` 删除通道闸门 | **被捕获** |
| 从 `concurrency:` 删除通道闸门 | **被捕获** |
| authorize 的 `/triage` 分支不再置位通道 | **被捕获** |
| 搭车通道改为拒绝 triage 而非自行关闭 | **被捕获** |
| 未变异 | 绿 |
| 从 `if:` 移除 ECS kill switch（正对照） | **被捕获** |

authorize 这一步本身是被**执行**的，不是被阅读的：从 YAML 中抽出，在按用户区分权限的桩下跑遍十二个分支，使评论者门禁与作者分类可以独立变化。（第一版桩对两者返回同一权限，导致在评论者门禁处全部被拒——错的是装置，不是代码。）

| 触发 | 作者 | 结果 |
| --- | --- | --- |
| `/verify` | write | `trusted`，通道开启 |
| `/verify` | 外部 | `external` + 钉定 OID，通道开启 |
| `/verify` | 查询失败 | `should_run=false` |
| PR 上的 `/triage` | write | `trusted`，通道开启 |
| PR 上的 `/triage` | 外部 | `external` + 钉定 OID，通道开启 |
| PR 上的 `/triage` | 查询失败 | 通道关闭，**triage 继续** |
| PR 上的 `/triage` | OID 快照失败 | 通道关闭，triage 继续 |
| issue 上的 `/triage` | — | 无通道，不浪费查询 |
| `/tmux`、普通评论 | — | 行为不变 |
| 任意，评论者无 write | — | 拒绝 |

有一条既有断言必须重写而非保留：它写的是"`/triage` 不产出 trust 输出"，但其 fixture 从未设置 PR 标志。这是"因错误的原因而成立"，并且会一路绿着穿过本次改动。

`scripts/tests/qwen-triage-workflow.test.js` 109/109；actionlint、yamllint 与 eslint `--max-warnings 0` 均干净。`qwen-triage.yml` 上的 prettier 告警是既有问题——把本次改动 stash 掉后同样复现。

</details>
