### PR TITLE
fix(webui): make long tool output collapsible

### DIFF
--- a/.qwen/e2e-tests/2026-07-31-export-collapsible-tool-output.md
+++ b/.qwen/e2e-tests/2026-07-31-export-collapsible-tool-output.md
@@ -1,0 +1,63 @@
+# Export Collapsible Tool Output
+
+## Scope
+
+Verify that long shell output and long `think` tool content keep their full
+text in the shared WebUI while remaining collapsed by default. This covers the
+HTML export viewer and the other consumers of `@qwen-code/webui`.
+
+## Baseline
+
+A released global `qwen` executable was not available in this environment, so
+the before-change `/export` dry-run could not be performed. Source inspection
+on `upstream/main` reproduces the loss: `ShellToolCall` and `ThinkToolCall`
+replace content after 500 characters with an ellipsis.
+
+## Manual Scenario
+
+1. Export a session containing a successful Bash or Execute tool call whose
+   output is longer than 500 characters and ends with a unique marker.
+2. Open the exported HTML and find the tool call.
+3. Confirm the output is collapsed and has a `Show more` control.
+4. Expand it and confirm the unique tail marker is visible, then collapse it
+   again.
+5. Repeat with a `think` tool call longer than 500 characters.
+
+## Regression Checks
+
+- Content of exactly 500 characters has no new toggle.
+- Both Bash and Execute variants preserve the full output.
+- A long single-line Shell result remains horizontally scrollable after it is
+  expanded.
+- Clicking a shell toggle does not invoke the surrounding OUT-row action.
+- Clicking the shell OUT row still opens the complete output.
+- Error, empty-output, and short-thinking paths remain unchanged.
+- Toggle buttons expose their expanded state to assistive technology.
+
+## Automated Verification
+
+```bash
+cd packages/webui
+npx vitest run \
+  src/components/toolcalls/shared/CollapsibleOutput.test.tsx \
+  src/components/toolcalls/ShellToolCall.test.tsx \
+  src/components/toolcalls/ThinkToolCall.test.tsx
+npm run typecheck
+npm run lint
+npm run build
+```
+
+## Results
+
+- Failure-first run: 3 long-output cases failed because their tail markers
+  were absent; the 500-character boundary and short-thinking cases passed.
+- Focused regression run: 3 files and 7 tests passed.
+- A headless Chrome layout probe confirmed that handing overflow from the OUT
+  `<pre>` to its scroll container changes the container from
+  `clientWidth/scrollWidth = 200/200` to `200/831` for both Bash and Execute.
+- Full WebUI run: 30 files and 398 tests passed with Node.js 24.
+- WebUI lint, typecheck, and production build passed.
+- A normal local `/export` smoke test was not used as proof because the
+  generated page loads the published WebUI package from unpkg rather than the
+  worktree bundle. Component tests and the local WebUI build cover this change
+  until a release build is available for the manual scenario.

--- a/.qwen/e2e-tests/2026-07-31-export-collapsible-tool-output.md
+++ b/.qwen/e2e-tests/2026-07-31-export-collapsible-tool-output.md
@@ -29,6 +29,8 @@ replace content after 500 characters with an ellipsis.
 - Both Bash and Execute variants preserve the full output.
 - A long single-line Shell result remains horizontally scrollable after it is
   expanded.
+- A collapsible Shell result does not widen the enclosing message container,
+  and its toggle remains inside the visible message bounds.
 - Clicking a shell toggle does not invoke the surrounding OUT-row action.
 - Clicking the shell OUT row still opens the complete output.
 - Error, empty-output, and short-thinking paths remain unchanged.
@@ -40,23 +42,41 @@ replace content after 500 characters with an ellipsis.
 cd packages/webui
 npx vitest run \
   src/components/toolcalls/shared/CollapsibleOutput.test.tsx \
+  src/components/toolcalls/GenericToolCall.test.tsx \
   src/components/toolcalls/ShellToolCall.test.tsx \
   src/components/toolcalls/ThinkToolCall.test.tsx
+npm test
 npm run typecheck
 npm run lint
 npm run build
+
+cd ../sdk-typescript
+npm run build
+
+cd ../web-shell
+npm run lint
+npm run typecheck
+npm run test:e2e:smoke
 ```
 
 ## Results
 
 - Failure-first run: 3 long-output cases failed because their tail markers
   were absent; the 500-character boundary and short-thinking cases passed.
-- Focused regression run: 3 files and 7 tests passed.
-- A headless Chrome layout probe confirmed that handing overflow from the OUT
-  `<pre>` to its scroll container changes the container from
-  `clientWidth/scrollWidth = 200/200` to `200/831` for both Bash and Execute.
-- Full WebUI run: 30 files and 398 tests passed with Node.js 24.
+- Focused component regression run: 4 files and 9 tests passed.
+- Failure-first Playwright run: both Bash and Execute failed because their
+  output boxes expanded to roughly 5.7k pixels, leaving no internal horizontal
+  overflow to scroll.
+- Post-fix Playwright run: both Bash and Execute passed in real Chromium. The
+  output scroll width exceeds its client width in collapsed and expanded
+  states, the enclosing message has no horizontal overflow, the toggle remains
+  visible, and the output accepts a non-zero horizontal scroll position.
+- Full web-shell Playwright smoke run: 26 tests passed, including both new
+  WebUI layout cases.
+- Full WebUI run: 31 files and 400 tests passed with Node.js 24.
 - WebUI lint, typecheck, and production build passed.
+- Web-shell lint and typecheck passed; the latter was run after generating the
+  SDK declarations required by that package. All changed files pass Prettier.
 - A normal local `/export` smoke test was not used as proof because the
   generated page loads the published WebUI package from unpkg rather than the
   worktree bundle. Component tests and the local WebUI build cover this change

--- a/packages/web-shell/client/e2e/webui-tool-output-layout-harness.html
+++ b/packages/web-shell/client/e2e/webui-tool-output-layout-harness.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WebUI tool output layout harness</title>
+    <style>
+      *,
+      ::before,
+      ::after {
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        margin: 0;
+        min-height: 100%;
+      }
+
+      body {
+        padding: 24px;
+      }
+
+      #root {
+        width: 600px;
+        height: 800px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script
+      type="module"
+      src="/e2e/webui-tool-output-layout-harness.tsx"
+    ></script>
+  </body>
+</html>

--- a/packages/web-shell/client/e2e/webui-tool-output-layout-harness.tsx
+++ b/packages/web-shell/client/e2e/webui-tool-output-layout-harness.tsx
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { ChatViewer, type ChatMessageData } from '@qwen-code/webui';
+
+const params = new URLSearchParams(window.location.search);
+const kind = params.get('kind') === 'execute' ? 'execute' : 'bash';
+const output = `${'0123456789'.repeat(82)}__${kind.toUpperCase()}_TAIL__`;
+
+const message: ChatMessageData = {
+  uuid: `${kind}-layout-message`,
+  timestamp: '2026-07-31T00:00:00.000Z',
+  type: 'tool_call',
+  toolCall: {
+    toolCallId: `${kind}-layout-tool-call`,
+    kind,
+    title: 'Run layout regression fixture',
+    status: 'completed',
+    rawInput: { command: 'printf long-output' },
+    content: [
+      {
+        type: 'content',
+        content: { type: 'text', text: output },
+      },
+    ],
+  },
+};
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <ChatViewer messages={[message]} autoScroll={false} theme="light" />
+  </React.StrictMode>,
+);

--- a/packages/web-shell/client/e2e/webui-tool-output-layout.spec.ts
+++ b/packages/web-shell/client/e2e/webui-tool-output-layout.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect, test, type Locator } from '@playwright/test';
+
+for (const kind of ['bash', 'execute'] as const) {
+  test(`keeps collapsible ${kind} output inside the message layout @smoke`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 800, height: 900 });
+    await page.goto(`/e2e/webui-tool-output-layout-harness.html?kind=${kind}`);
+
+    const messages = page.locator('.chat-viewer-messages');
+    const output = page.locator(`.${kind}-toolcall-output-subtle`);
+    const toggle = page.locator('button[aria-expanded]');
+
+    await expect(messages).toBeVisible();
+    await expect(output).toBeVisible();
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toHaveAttribute('aria-label', 'Expand output');
+
+    const collapsed = await readOverflowMetrics(messages, output);
+    expect(collapsed.outputScrollWidth).toBeGreaterThan(
+      collapsed.outputClientWidth,
+    );
+    expect(collapsed.messagesScrollWidth).toBe(collapsed.messagesClientWidth);
+
+    const messagesBox = await messages.boundingBox();
+    const toggleBox = await toggle.boundingBox();
+    if (!messagesBox || !toggleBox) {
+      throw new Error('Expected visible message and toggle bounding boxes.');
+    }
+    expect(toggleBox.x).toBeGreaterThanOrEqual(messagesBox.x);
+    expect(toggleBox.x + toggleBox.width).toBeLessThanOrEqual(
+      messagesBox.x + messagesBox.width,
+    );
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    const expanded = await readOverflowMetrics(messages, output);
+    expect(expanded.outputScrollWidth).toBeGreaterThan(
+      expanded.outputClientWidth,
+    );
+    expect(expanded.messagesScrollWidth).toBe(expanded.messagesClientWidth);
+
+    const reachableScrollLeft = await output.evaluate((element) => {
+      element.scrollLeft = element.scrollWidth;
+      return element.scrollLeft;
+    });
+    expect(reachableScrollLeft).toBeGreaterThan(0);
+  });
+}
+
+async function readOverflowMetrics(messages: Locator, output: Locator) {
+  const messagesMetrics = await messages.evaluate((element) => ({
+    clientWidth: element.clientWidth,
+    scrollWidth: element.scrollWidth,
+  }));
+  const outputMetrics = await output.evaluate((element) => ({
+    clientWidth: element.clientWidth,
+    scrollWidth: element.scrollWidth,
+  }));
+
+  return {
+    messagesClientWidth: messagesMetrics.clientWidth,
+    messagesScrollWidth: messagesMetrics.scrollWidth,
+    outputClientWidth: outputMetrics.clientWidth,
+    outputScrollWidth: outputMetrics.scrollWidth,
+  };
+}

--- a/packages/webui/src/components/toolcalls/GenericToolCall.test.tsx
+++ b/packages/webui/src/components/toolcalls/GenericToolCall.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { GenericToolCall } from './GenericToolCall.js';
+
+describe('GenericToolCall collapsible output', () => {
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => root?.unmount());
+      root = null;
+    }
+    if (container) {
+      container.remove();
+      container = null;
+    }
+  });
+
+  const renderOutput = (output: string) => {
+    act(() => {
+      root?.render(
+        <GenericToolCall
+          toolCall={{
+            toolCallId: 'generic-1',
+            kind: 'custom_tool',
+            title: 'Custom tool',
+            status: 'completed',
+            content: [
+              {
+                type: 'content',
+                content: { type: 'text', text: output },
+              },
+            ],
+          }}
+        />,
+      );
+    });
+  };
+
+  it('preserves and collapses output longer than 400 characters', () => {
+    const tailMarker = '__GENERIC_TAIL__';
+    renderOutput(`${'x'.repeat(401)}${tailMarker}`);
+
+    expect(container?.textContent).toContain(tailMarker);
+    const content = container?.querySelector(
+      '.toolcall-collapsible-output-content',
+    ) as HTMLDivElement;
+    expect(content.classList.contains('text-[13px]')).toBe(true);
+    expect(content.classList.contains('opacity-90')).toBe(true);
+    expect(content.style.maxHeight).toBe('200px');
+    expect(
+      container?.querySelector('button[aria-label="Expand output"]'),
+    ).not.toBeNull();
+  });
+
+  it('does not add a toggle at the 400-character boundary', () => {
+    const output = 'x'.repeat(400);
+    renderOutput(output);
+
+    expect(container?.textContent).toContain(output);
+    const content = container?.querySelector(
+      '.toolcall-collapsible-output-content',
+    ) as HTMLDivElement;
+    expect(content.classList.contains('text-[13px]')).toBe(true);
+    expect(content.classList.contains('opacity-90')).toBe(true);
+    expect(content.style.maxHeight).toBe('');
+    expect(
+      container?.querySelector('button[aria-label="Expand output"]'),
+    ).toBeNull();
+  });
+});

--- a/packages/webui/src/components/toolcalls/GenericToolCall.tsx
+++ b/packages/webui/src/components/toolcalls/GenericToolCall.tsx
@@ -6,8 +6,9 @@
  * Generic tool call component - handles all tool call types as fallback
  */
 
-import { useState, type FC } from 'react';
+import type { FC } from 'react';
 import {
+  CollapsibleOutput,
   ToolCallContainer,
   ToolCallCard,
   ToolCallRow,
@@ -20,43 +21,7 @@ import type { BaseToolCallProps } from './shared/index.js';
 import { getToolDisplayLabel } from './labelUtils.js';
 import { MarkdownRenderer } from '../messages/MarkdownRenderer/MarkdownRenderer.js';
 
-const COLLAPSED_HEIGHT = 200;
 const EXPAND_THRESHOLD = 400;
-
-const CollapsibleOutput: FC<{ content: string }> = ({ content }) => {
-  const [isExpanded, setIsExpanded] = useState(false);
-  const isLongContent = content.length > EXPAND_THRESHOLD;
-
-  return (
-    <div className="flex flex-col gap-[3px]">
-      <div
-        className="text-[13px] opacity-90 overflow-hidden"
-        style={
-          !isExpanded && isLongContent
-            ? {
-                maxHeight: `${COLLAPSED_HEIGHT}px`,
-                maskImage: `linear-gradient(to bottom, var(--app-primary-background) 140px, transparent ${COLLAPSED_HEIGHT}px)`,
-                WebkitMaskImage: `linear-gradient(to bottom, var(--app-primary-background) 140px, transparent ${COLLAPSED_HEIGHT}px)`,
-              }
-            : undefined
-        }
-      >
-        <MarkdownRenderer content={content} enableFileLinks={false} />
-      </div>
-      {isLongContent && (
-        <div className="flex justify-center border-t border-[var(--app-input-border)] pt-1">
-          <button
-            type="button"
-            onClick={() => setIsExpanded(!isExpanded)}
-            className="text-[var(--app-secondary-foreground)] text-[0.8em] hover:text-[var(--app-primary-foreground)] cursor-pointer bg-transparent border-none px-2 py-1 rounded hover:bg-[var(--app-input-background)] transition-colors"
-          >
-            {isExpanded ? '▲ Collapse' : '▼ Show more'}
-          </button>
-        </div>
-      )}
-    </div>
-  );
-};
 
 /**
  * Generic tool call component that can display any tool call type
@@ -101,7 +66,12 @@ export const GenericToolCall: FC<BaseToolCallProps> = ({
             <div>{operationText}</div>
           </ToolCallRow>
           <ToolCallRow label="Output">
-            <CollapsibleOutput content={output} />
+            <CollapsibleOutput
+              isCollapsible={output.length > EXPAND_THRESHOLD}
+              className="text-[13px] opacity-90"
+            >
+              <MarkdownRenderer content={output} enableFileLinks={false} />
+            </CollapsibleOutput>
           </ToolCallRow>
         </ToolCallCard>
       );

--- a/packages/webui/src/components/toolcalls/ShellToolCall.css
+++ b/packages/webui/src/components/toolcalls/ShellToolCall.css
@@ -65,6 +65,10 @@
   overflow: hidden;
 }
 
+.bash-toolcall-row-content.bash-toolcall-full {
+  min-width: 0;
+}
+
 .bash-toolcall-pre {
   margin-block: 0;
   overflow: hidden;
@@ -159,6 +163,10 @@
     transparent 60px
   );
   overflow: hidden;
+}
+
+.execute-toolcall-row-content.execute-toolcall-full {
+  min-width: 0;
 }
 
 .execute-toolcall-pre {

--- a/packages/webui/src/components/toolcalls/ShellToolCall.css
+++ b/packages/webui/src/components/toolcalls/ShellToolCall.css
@@ -89,6 +89,10 @@
   box-sizing: border-box;
 }
 
+.bash-toolcall-output-subtle .bash-toolcall-pre {
+  overflow: visible;
+}
+
 .bash-toolcall-error-content {
   color: #c74e39;
 }
@@ -178,6 +182,10 @@
   min-width: 0;
   width: 100%;
   box-sizing: border-box;
+}
+
+.execute-toolcall-output-subtle .execute-toolcall-pre {
+  overflow: visible;
 }
 
 .execute-toolcall-error-content {

--- a/packages/webui/src/components/toolcalls/ShellToolCall.stories.tsx
+++ b/packages/webui/src/components/toolcalls/ShellToolCall.stories.tsx
@@ -129,7 +129,7 @@ export const ExecuteWithDescription: Story = {
 };
 
 /**
- * Execute variant with long output (truncated)
+ * Execute variant with long, collapsible output
  */
 export const ExecuteLongOutput: Story = {
   args: {

--- a/packages/webui/src/components/toolcalls/ShellToolCall.test.tsx
+++ b/packages/webui/src/components/toolcalls/ShellToolCall.test.tsx
@@ -6,18 +6,11 @@
 
 // @vitest-environment jsdom
 
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PlatformProvider } from '../../context/PlatformContext.js';
 import { ShellToolCall } from './ShellToolCall.js';
-
-const shellToolCallStyles = readFileSync(
-  resolve(process.cwd(), 'src/components/toolcalls/ShellToolCall.css'),
-  'utf8',
-);
 
 describe('ShellToolCall collapsible output', () => {
   let container: HTMLDivElement | null = null;
@@ -101,15 +94,6 @@ describe('ShellToolCall collapsible output', () => {
       expect(collapsibleContent.style.maxHeight).toBe('60px');
       expect(collapsibleContent.style.maskImage).toContain('40px');
       expect(collapsibleContent.style.maskImage).toContain('60px');
-      const outputContainer = container?.querySelector(
-        `.${kind}-toolcall-output-subtle`,
-      ) as HTMLDivElement;
-      const outputPre = outputContainer.querySelector('pre') as HTMLPreElement;
-      expect(outputPre).not.toBeNull();
-      expect(shellToolCallStyles).toContain(
-        `.${kind}-toolcall-output-subtle .${kind}-toolcall-pre {\n  overflow: visible;\n}`,
-      );
-
       act(() => {
         toggle.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       });

--- a/packages/webui/src/components/toolcalls/ShellToolCall.test.tsx
+++ b/packages/webui/src/components/toolcalls/ShellToolCall.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// @vitest-environment jsdom
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PlatformProvider } from '../../context/PlatformContext.js';
+import { ShellToolCall } from './ShellToolCall.js';
+
+const shellToolCallStyles = readFileSync(
+  resolve(process.cwd(), 'src/components/toolcalls/ShellToolCall.css'),
+  'utf8',
+);
+
+describe('ShellToolCall collapsible output', () => {
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => root?.unmount());
+      root = null;
+    }
+    if (container) {
+      container.remove();
+      container = null;
+    }
+  });
+
+  const renderToolCall = (
+    kind: 'bash' | 'execute',
+    output: string,
+    openTempFile = vi.fn(),
+  ) => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() => {
+      root?.render(
+        <PlatformProvider
+          value={{
+            platform: 'web',
+            postMessage: vi.fn(),
+            onMessage: () => () => {},
+            openTempFile,
+          }}
+        >
+          <ShellToolCall
+            toolCall={{
+              toolCallId: `${kind}-1`,
+              kind,
+              title: 'Run command',
+              status: 'completed',
+              rawInput: { command: 'run-command' },
+              content: [
+                {
+                  type: 'content',
+                  content: { type: 'text', text: output },
+                },
+              ],
+            }}
+          />
+        </PlatformProvider>,
+      );
+    });
+
+    return openTempFile;
+  };
+
+  it.each(['bash', 'execute'] as const)(
+    'preserves and expands the full %s output without opening a temp file',
+    (kind) => {
+      const tailMarker = '__OUTPUT_TAIL__';
+      const output = `${'x'.repeat(501)}${tailMarker}`;
+      const openTempFile = renderToolCall(kind, output);
+
+      expect(container?.textContent).toContain(tailMarker);
+
+      const toggle = container?.querySelector(
+        'button[aria-label="Expand output"]',
+      ) as HTMLButtonElement;
+      expect(toggle).not.toBeNull();
+      expect(toggle.getAttribute('aria-expanded')).toBe('false');
+      const collapsibleContent = container?.querySelector(
+        '.toolcall-collapsible-output-content',
+      ) as HTMLDivElement;
+      expect(collapsibleContent.style.maxHeight).toBe('60px');
+      expect(collapsibleContent.style.maskImage).toContain('40px');
+      expect(collapsibleContent.style.maskImage).toContain('60px');
+      const outputContainer = container?.querySelector(
+        `.${kind}-toolcall-output-subtle`,
+      ) as HTMLDivElement;
+      const outputPre = outputContainer.querySelector('pre') as HTMLPreElement;
+      expect(outputPre).not.toBeNull();
+      expect(shellToolCallStyles).toContain(
+        `.${kind}-toolcall-output-subtle .${kind}-toolcall-pre {\n  overflow: visible;\n}`,
+      );
+
+      act(() => {
+        toggle.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+
+      expect(toggle.getAttribute('aria-expanded')).toBe('true');
+      expect(toggle.textContent).toContain('Collapse');
+      expect(collapsibleContent.style.maxHeight).toBe('');
+      expect(openTempFile).not.toHaveBeenCalled();
+
+      act(() => {
+        toggle.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+
+      expect(toggle.getAttribute('aria-expanded')).toBe('false');
+      expect(collapsibleContent.style.maxHeight).toBe('60px');
+      expect(openTempFile).not.toHaveBeenCalled();
+
+      const outRow = Array.from(
+        container?.querySelectorAll(`.${kind}-toolcall-row`) ?? [],
+      ).find((row) => row.textContent?.includes('OUT'));
+      expect(outRow).toBeDefined();
+
+      act(() => {
+        outRow?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+
+      expect(openTempFile).toHaveBeenCalledWith(
+        output,
+        `${kind}-output-${kind}-1`,
+      );
+    },
+  );
+
+  it('does not add a toggle at the 500-character boundary', () => {
+    renderToolCall('bash', 'x'.repeat(500));
+
+    expect(
+      container?.querySelector('button[aria-label="Expand output"]'),
+    ).toBeNull();
+  });
+});

--- a/packages/webui/src/components/toolcalls/ShellToolCall.tsx
+++ b/packages/webui/src/components/toolcalls/ShellToolCall.tsx
@@ -213,6 +213,11 @@ const ShellToolCallImpl: FC<BaseToolCallProps & { variant: ShellVariant }> = ({
   if (textOutputs.length > 0) {
     const output = textOutputs.join('\n');
     const isCollapsible = output.length > 500;
+    const outputContent = (
+      <div className={`${classPrefix}-toolcall-output-subtle`}>
+        <pre className={`${classPrefix}-toolcall-pre`}>{output}</pre>
+      </div>
+    );
 
     return (
       <Container
@@ -261,18 +266,10 @@ const ShellToolCallImpl: FC<BaseToolCallProps & { variant: ShellVariant }> = ({
                     collapsedHeight={60}
                     fadeStart={40}
                   >
-                    <div className={`${classPrefix}-toolcall-output-subtle`}>
-                      <pre className={`${classPrefix}-toolcall-pre`}>
-                        {output}
-                      </pre>
-                    </div>
+                    {outputContent}
                   </CollapsibleOutput>
                 ) : (
-                  <div className={`${classPrefix}-toolcall-output-subtle`}>
-                    <pre className={`${classPrefix}-toolcall-pre`}>
-                      {output}
-                    </pre>
-                  </div>
+                  outputContent
                 )}
               </div>
             </div>

--- a/packages/webui/src/components/toolcalls/ShellToolCall.tsx
+++ b/packages/webui/src/components/toolcalls/ShellToolCall.tsx
@@ -9,6 +9,7 @@
 
 import type { FC } from 'react';
 import {
+  CollapsibleOutput,
   ToolCallContainer,
   CopyButton,
   safeTitle,
@@ -211,8 +212,7 @@ const ShellToolCallImpl: FC<BaseToolCallProps & { variant: ShellVariant }> = ({
   // Success with output
   if (textOutputs.length > 0) {
     const output = textOutputs.join('\n');
-    const truncatedOutput =
-      output.length > 500 ? output.substring(0, 500) + '...' : output;
+    const isCollapsible = output.length > 500;
 
     return (
       <Container
@@ -250,12 +250,30 @@ const ShellToolCallImpl: FC<BaseToolCallProps & { variant: ShellVariant }> = ({
               style={{ cursor: 'pointer' }}
             >
               <div className={`${classPrefix}-toolcall-label`}>OUT</div>
-              <div className={`${classPrefix}-toolcall-row-content`}>
-                <div className={`${classPrefix}-toolcall-output-subtle`}>
-                  <pre className={`${classPrefix}-toolcall-pre`}>
-                    {truncatedOutput}
-                  </pre>
-                </div>
+              <div
+                className={`${classPrefix}-toolcall-row-content ${
+                  isCollapsible ? `${classPrefix}-toolcall-full` : ''
+                }`}
+              >
+                {isCollapsible ? (
+                  <CollapsibleOutput
+                    isCollapsible
+                    collapsedHeight={60}
+                    fadeStart={40}
+                  >
+                    <div className={`${classPrefix}-toolcall-output-subtle`}>
+                      <pre className={`${classPrefix}-toolcall-pre`}>
+                        {output}
+                      </pre>
+                    </div>
+                  </CollapsibleOutput>
+                ) : (
+                  <div className={`${classPrefix}-toolcall-output-subtle`}>
+                    <pre className={`${classPrefix}-toolcall-pre`}>
+                      {output}
+                    </pre>
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/packages/webui/src/components/toolcalls/ThinkToolCall.test.tsx
+++ b/packages/webui/src/components/toolcalls/ThinkToolCall.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ThinkToolCall } from './ThinkToolCall.js';
+
+describe('ThinkToolCall collapsible output', () => {
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => root?.unmount());
+      root = null;
+    }
+    if (container) {
+      container.remove();
+      container = null;
+    }
+  });
+
+  const renderThoughts = (thoughts: string) => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() => {
+      root?.render(
+        <ThinkToolCall
+          toolCall={{
+            toolCallId: 'think-1',
+            kind: 'think',
+            title: 'Thinking',
+            status: 'completed',
+            content: [
+              {
+                type: 'content',
+                content: { type: 'text', text: thoughts },
+              },
+            ],
+          }}
+        />,
+      );
+    });
+  };
+
+  it('preserves long thoughts and exposes expand and collapse controls', () => {
+    const tailMarker = '__THOUGHT_TAIL__';
+    renderThoughts(`${'x'.repeat(501)}${tailMarker}`);
+
+    expect(container?.textContent).toContain(tailMarker);
+
+    const toggle = container?.querySelector(
+      'button[aria-label="Expand output"]',
+    ) as HTMLButtonElement;
+    expect(toggle).not.toBeNull();
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    const collapsibleContent = container?.querySelector(
+      '.toolcall-collapsible-output-content',
+    ) as HTMLDivElement;
+    expect(collapsibleContent.style.maxHeight).toBe('200px');
+
+    act(() => {
+      toggle.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    expect(toggle.textContent).toContain('Collapse');
+    expect(collapsibleContent.style.maxHeight).toBe('');
+
+    act(() => {
+      toggle.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(toggle.textContent).toContain('Show more');
+    expect(collapsibleContent.style.maxHeight).toBe('200px');
+  });
+
+  it('keeps short thoughts in the compact layout without a toggle', () => {
+    renderThoughts('short thought');
+
+    expect(container?.textContent).toContain('short thought');
+    expect(container?.querySelector('.toolcall-card')).toBeNull();
+    expect(
+      container?.querySelector('button[aria-label="Expand output"]'),
+    ).toBeNull();
+  });
+});

--- a/packages/webui/src/components/toolcalls/ThinkToolCall.tsx
+++ b/packages/webui/src/components/toolcalls/ThinkToolCall.tsx
@@ -8,6 +8,7 @@
 
 import type { FC } from 'react';
 import {
+  CollapsibleOutput,
   ToolCallContainer,
   ToolCallCard,
   ToolCallRow,
@@ -50,15 +51,23 @@ export const ThinkToolCall: FC<BaseToolCallProps> = ({
     const isLong = thoughts.length > 200;
 
     if (isLong) {
-      const truncatedThoughts =
-        thoughts.length > 500 ? thoughts.substring(0, 500) + '...' : thoughts;
+      const isCollapsible = thoughts.length > 500;
 
       return (
         <ToolCallCard icon="💭">
           <ToolCallRow label="Think">
-            <div className="italic opacity-90 leading-relaxed">
-              {truncatedThoughts}
-            </div>
+            {isCollapsible ? (
+              <CollapsibleOutput
+                isCollapsible
+                className="italic opacity-90 leading-relaxed"
+              >
+                {thoughts}
+              </CollapsibleOutput>
+            ) : (
+              <div className="italic opacity-90 leading-relaxed">
+                {thoughts}
+              </div>
+            )}
           </ToolCallRow>
         </ToolCallCard>
       );

--- a/packages/webui/src/components/toolcalls/shared/CollapsibleOutput.test.tsx
+++ b/packages/webui/src/components/toolcalls/shared/CollapsibleOutput.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { CollapsibleOutput } from './CollapsibleOutput.js';
+
+describe('CollapsibleOutput', () => {
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => root?.unmount());
+      root = null;
+    }
+    if (container) {
+      container.remove();
+      container = null;
+    }
+  });
+
+  it('toggles the collapsed height while preserving all children', () => {
+    act(() => {
+      root?.render(
+        <CollapsibleOutput isCollapsible>
+          full content with __TAIL__
+        </CollapsibleOutput>,
+      );
+    });
+
+    expect(container?.textContent).toContain('__TAIL__');
+    const content = container?.querySelector(
+      '.toolcall-collapsible-output-content',
+    ) as HTMLDivElement;
+    const toggle = container?.querySelector(
+      'button[aria-label="Expand output"]',
+    ) as HTMLButtonElement;
+    expect(content.style.maxHeight).toBe('200px');
+    expect(content.style.maskImage).toContain('140px');
+    expect(content.style.maskImage).toContain('200px');
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+
+    act(() => {
+      toggle.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(content.style.maxHeight).toBe('');
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('does not clip or show a toggle when content is not collapsible', () => {
+    act(() => {
+      root?.render(
+        <CollapsibleOutput isCollapsible={false}>
+          short content
+        </CollapsibleOutput>,
+      );
+    });
+
+    const content = container?.querySelector(
+      '.toolcall-collapsible-output-content',
+    ) as HTMLDivElement;
+    expect(content.style.maxHeight).toBe('');
+    expect(container?.querySelector('button')).toBeNull();
+  });
+});

--- a/packages/webui/src/components/toolcalls/shared/CollapsibleOutput.tsx
+++ b/packages/webui/src/components/toolcalls/shared/CollapsibleOutput.tsx
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useState, type FC, type ReactNode } from 'react';
+
+interface CollapsibleOutputProps {
+  children: ReactNode;
+  isCollapsible: boolean;
+  collapsedHeight?: number;
+  fadeStart?: number;
+  className?: string;
+}
+
+/**
+ * Renderer-agnostic wrapper for long tool output.
+ */
+export const CollapsibleOutput: FC<CollapsibleOutputProps> = ({
+  children,
+  isCollapsible,
+  collapsedHeight = 200,
+  fadeStart = 140,
+  className = '',
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    <div className="flex flex-col gap-[3px]">
+      <div
+        className={`toolcall-collapsible-output-content overflow-hidden ${className}`}
+        style={
+          !isExpanded && isCollapsible
+            ? {
+                maxHeight: `${collapsedHeight}px`,
+                maskImage: `linear-gradient(to bottom, var(--app-primary-background) ${fadeStart}px, transparent ${collapsedHeight}px)`,
+                WebkitMaskImage: `linear-gradient(to bottom, var(--app-primary-background) ${fadeStart}px, transparent ${collapsedHeight}px)`,
+              }
+            : undefined
+        }
+      >
+        {children}
+      </div>
+      {isCollapsible && (
+        <div className="flex justify-center border-t border-[var(--app-input-border)] pt-1">
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              setIsExpanded((expanded) => !expanded);
+            }}
+            aria-expanded={isExpanded}
+            aria-label={isExpanded ? 'Collapse output' : 'Expand output'}
+            className="text-[var(--app-secondary-foreground)] text-[0.8em] hover:text-[var(--app-primary-foreground)] cursor-pointer bg-transparent border-none px-2 py-1 rounded hover:bg-[var(--app-input-background)] transition-colors"
+          >
+            {isExpanded ? '▲ Collapse' : '▼ Show more'}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/webui/src/components/toolcalls/shared/index.ts
+++ b/packages/webui/src/components/toolcalls/shared/index.ts
@@ -14,6 +14,7 @@ export {
   LocationsList,
 } from './LayoutComponents.js';
 export type { ToolCallContainerProps } from './LayoutComponents.js';
+export { CollapsibleOutput } from './CollapsibleOutput.js';
 
 // Copy utilities
 export { handleCopyToClipboard, CopyButton } from './copyUtils.js';


### PR DESCRIPTION
## What this PR does

This PR replaces the 500-character hard truncation for successful Bash/Execute output and long `think` content with an expandable view that keeps the complete text while remaining collapsed by default. It extracts the existing generic-tool collapse UI into a renderer-agnostic shared component, preserves GenericToolCall's current threshold and rendering, keeps Shell's OUT-row full-content action, and prevents the nested expand/collapse button from triggering that row action.

For Shell output, the OUT scroll container now owns horizontal overflow so a long single-line result remains scrollable in both Bash and Execute variants instead of being clipped by the nested `<pre>`.

## Why it's needed

The shared WebUI, including exported conversations, currently replaces everything after 500 characters with an ellipsis for these paths. That permanently removes the tail of command output and reasoning traces, so users cannot inspect the complete result even after opening the exported page. Keeping the full content behind a compact default view preserves readability without losing diagnostic information.

## Reviewer Test Plan

### How to verify

1. Render or export a completed Bash tool call with output longer than 500 characters and a unique marker at the end. Confirm it initially shows `Show more`, expanding reveals the marker, and collapsing restores the compact view.
2. Repeat with an Execute tool call and a `think` tool call longer than 500 characters.
3. Use a Shell output containing one long line without whitespace. Confirm the OUT content can scroll horizontally after expansion.
4. Click the Shell expand/collapse button and confirm it does not invoke the surrounding OUT-row action; then click the OUT row and confirm it still opens the complete output.
5. Confirm exactly 500 characters do not receive the new toggle and that error, empty-output, and short-thinking paths retain their existing behavior.

Automated verification from `packages/webui`: `npm exec vitest run src/components/toolcalls/shared/CollapsibleOutput.test.tsx src/components/toolcalls/ShellToolCall.test.tsx src/components/toolcalls/ThinkToolCall.test.tsx`; full `npm test`; `npm run lint`; `npm run typecheck`; `npm run build`.

### Evidence (Before & After)

Before: failure-first tests for the three long-output paths could not find their unique tail markers because the renderers replaced content after 500 characters with `...`. A real Chrome layout probe for a long Shell line measured the scroll container at `clientWidth/scrollWidth = 200/200` while the nested `<pre>` overflowed, so the hidden tail was not horizontally reachable.

After: the focused regression suite passes 7/7 and the full WebUI suite passes 398/398. The same Chrome probe measures `clientWidth/scrollWidth = 200/831` for both Bash and Execute, with the complete tail preserved and reachable. A local `/export` screenshot is not presented as evidence because the normal export page loads the published WebUI bundle from unpkg rather than this worktree bundle; the included E2E plan records the release-bundle manual scenario.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS 26.3.1, Node.js 24.14.0, Vitest 3.2.4, system Google Chrome in headless mode.

## Risk & Scope

- Main risk or tradeoff: the shared wrapper is consumed by multiple WebUI surfaces, so regressions could affect exported conversations and other `@qwen-code/webui` consumers; the existing GenericToolCall behavior is preserved and covered through the full WebUI suite.
- Not validated / out of scope: a global Expand All/Collapse All control, changes to the existing `<=500`/error-output collapse policy, and a release-bundle `/export` smoke test are outside this bounded fix.
- Breaking changes / migration notes: none.

## Linked Issues

Refs #8208

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 将成功的 Bash/Execute 输出和较长 `think` 内容原有的 500 字符硬截断，替换为保留完整文本的可展开视图，同时默认保持折叠。它把 GenericToolCall 现有的折叠 UI 提取为与渲染器无关的共享组件，保留 GenericToolCall 当前的阈值和渲染行为，保留 Shell 的 OUT 行全文打开操作，并阻止内层展开/收起按钮触发外层 OUT 行操作。

对于 Shell 输出，现在由 OUT 滚动容器负责横向溢出，因此无论 Bash 还是 Execute，长单行结果都能横向滚动，不再被内层 `<pre>` 裁掉。

## 为什么需要它

共享 WebUI（包括导出的会话）目前会在这些路径中把 500 字符之后的全部内容替换为省略号。这会永久丢失命令输出和思考轨迹的尾部，用户即使打开导出页面也无法检查完整结果。默认紧凑显示、按需展开完整内容，可以兼顾可读性和诊断信息的完整性。

## Reviewer 测试计划

### 如何验证

1. 渲染或导出一个输出超过 500 字符、末尾带唯一标记的已完成 Bash 工具调用。确认初始显示 `Show more`，展开后能看到尾部标记，收起后恢复紧凑视图。
2. 对 Execute 工具调用和超过 500 字符的 `think` 工具调用重复上述验证。
3. 使用一条不含空白的超长 Shell 单行输出，确认展开后 OUT 内容可以横向滚动。
4. 点击 Shell 展开/收起按钮，确认不会触发外层 OUT 行操作；再点击 OUT 行，确认仍会打开完整输出。
5. 确认恰好 500 字符时不会出现新开关，并且错误、空输出和短思考路径保持原有行为。

在 `packages/webui` 中执行的自动验证：`npm exec vitest run src/components/toolcalls/shared/CollapsibleOutput.test.tsx src/components/toolcalls/ShellToolCall.test.tsx src/components/toolcalls/ThinkToolCall.test.tsx`；完整 `npm test`；`npm run lint`；`npm run typecheck`；`npm run build`。

### 证据（修改前与修改后）

修改前：三个长输出路径的失败优先测试都找不到各自唯一的尾部标记，因为渲染器把 500 字符后的内容替换为 `...`。真实 Chrome 对长 Shell 单行内容的布局探针显示，滚动容器为 `clientWidth/scrollWidth = 200/200`，而内层 `<pre>` 已溢出，因此被隐藏的尾部无法通过横向滚动访问。

修改后：focused 回归测试 7/7 通过，完整 WebUI 测试 398/398 通过。同一个 Chrome 探针在 Bash 和 Execute 中都测得 `clientWidth/scrollWidth = 200/831`，完整尾部已保留并可访问。这里没有把本地 `/export` 截图作为证据，因为常规导出页面会从 unpkg 加载已发布的 WebUI bundle，而不是当前 worktree 的 bundle；随 PR 提交的 E2E 计划记录了发布 bundle 可用后的手动验证场景。

### 已测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS 26.3.1、Node.js 24.14.0、Vitest 3.2.4、无头模式下的系统 Google Chrome。

## 风险与范围

- 主要风险或权衡：共享包装组件会被多个 WebUI 表面使用，因此回归可能影响导出会话和其他 `@qwen-code/webui` 消费方；本 PR 保留了 GenericToolCall 的现有行为，并通过完整 WebUI 测试覆盖。
- 未验证 / 范围外：全局 Expand All/Collapse All 控件、现有 `<=500`/错误输出折叠策略的修改，以及发布 bundle 的 `/export` 冒烟测试不属于这个边界明确的修复。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Refs #8208

</details>
