### PR TITLE
fix(web-shell): isolate automatic recap by session

### DIFF
--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -2061,6 +2061,33 @@ function deferred<T>(): {
   return { promise, resolve, reject };
 }
 
+async function triggerAutoRecap(): Promise<{
+  recap: ReturnType<
+    typeof deferred<{ sessionId: string; recap: string | null }>
+  >;
+  container: HTMLElement;
+}> {
+  const recap = deferred<{ sessionId: string; recap: string | null }>();
+  mockSessionActions.recapSession.mockReturnValueOnce(recap.promise);
+  testState.blocks = [{}, {}, {}, {}];
+  let hidden = true;
+  Object.defineProperty(document, 'hidden', {
+    configurable: true,
+    get: () => hidden,
+  });
+  let now = 1;
+  vi.spyOn(Date, 'now').mockImplementation(() => now);
+
+  const { container } = renderApp();
+  await flush();
+  act(() => document.dispatchEvent(new Event('visibilitychange')));
+  now += 3 * 60 * 1000;
+  hidden = false;
+  act(() => document.dispatchEvent(new Event('visibilitychange')));
+  expect(mockSessionActions.recapSession).toHaveBeenCalledOnce();
+  return { recap, container };
+}
+
 // A transcript block shaped like extractPendingPermission() expects. Defaults to
 // a non-AskUserQuestion tool (→ pendingToolApproval); pass toolName
 // 'ask_user_question' to exercise the pendingAskUserApproval branch instead.
@@ -6518,25 +6545,7 @@ describe('App session callbacks', () => {
   );
 
   it('dispatches an automatic recap when the session remains active', async () => {
-    const recap = deferred<{ sessionId: string; recap: string | null }>();
-    mockSessionActions.recapSession.mockReturnValueOnce(recap.promise);
-    testState.blocks = [{}, {}, {}, {}];
-    let hidden = true;
-    Object.defineProperty(document, 'hidden', {
-      configurable: true,
-      get: () => hidden,
-    });
-    let now = 1;
-    vi.spyOn(Date, 'now').mockImplementation(() => now);
-
-    renderApp();
-    await flush();
-    act(() => document.dispatchEvent(new Event('visibilitychange')));
-    now += 3 * 60 * 1000;
-    hidden = false;
-    act(() => document.dispatchEvent(new Event('visibilitychange')));
-
-    expect(mockSessionActions.recapSession).toHaveBeenCalledOnce();
+    const { recap } = await triggerAutoRecap();
     await act(async () => {
       recap.resolve({ sessionId: 'session-1', recap: 'Current session recap' });
       await recap.promise;
@@ -6551,25 +6560,7 @@ describe('App session callbacks', () => {
   });
 
   it('discards an automatic recap after starting a new session', async () => {
-    const recap = deferred<{ sessionId: string; recap: string | null }>();
-    mockSessionActions.recapSession.mockReturnValueOnce(recap.promise);
-    testState.blocks = [{}, {}, {}, {}];
-    let hidden = true;
-    Object.defineProperty(document, 'hidden', {
-      configurable: true,
-      get: () => hidden,
-    });
-    let now = 1;
-    vi.spyOn(Date, 'now').mockImplementation(() => now);
-
-    const { container } = renderApp();
-    await flush();
-    act(() => document.dispatchEvent(new Event('visibilitychange')));
-    now += 3 * 60 * 1000;
-    hidden = false;
-    act(() => document.dispatchEvent(new Event('visibilitychange')));
-    expect(mockSessionActions.recapSession).toHaveBeenCalledOnce();
-
+    const { recap, container } = await triggerAutoRecap();
     await act(async () => {
       container
         .querySelector<HTMLButtonElement>('[data-testid="new-session"]')
@@ -6582,6 +6573,39 @@ describe('App session callbacks', () => {
     });
 
     expect(mockSessionActions.clearSession).toHaveBeenCalledOnce();
+    expect(mockStore.dispatch).not.toHaveBeenCalledWith([
+      expect.objectContaining({ source: 'recap' }),
+    ]);
+  });
+
+  it('discards an automatic recap tagged for a different session', async () => {
+    const { recap } = await triggerAutoRecap();
+    await act(async () => {
+      recap.resolve({ sessionId: 'session-2', recap: 'Stale recap' });
+      await recap.promise;
+    });
+
+    expect(mockStore.dispatch).not.toHaveBeenCalledWith([
+      expect.objectContaining({ source: 'recap' }),
+    ]);
+  });
+
+  it('discards an automatic recap after switching to an existing session', async () => {
+    const { recap, container } = await triggerAutoRecap();
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="load-session"]')
+        ?.click();
+      recap.resolve({
+        sessionId: 'session-1',
+        recap: 'Previous session recap',
+      });
+      await recap.promise;
+    });
+
+    expect(mockSessionActions.loadSession).toHaveBeenCalledWith('session-2', {
+      workspaceCwd: undefined,
+    });
     expect(mockStore.dispatch).not.toHaveBeenCalledWith([
       expect.objectContaining({ source: 'recap' }),
     ]);

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -6611,6 +6611,27 @@ describe('App session callbacks', () => {
     ]);
   });
 
+  it('discards an automatic recap after clearing the screen', async () => {
+    const { recap } = await triggerAutoRecap();
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          bubbles: true,
+          cancelable: true,
+          ctrlKey: true,
+          key: 'l',
+        }),
+      );
+      recap.resolve({ sessionId: 'session-1', recap: 'Stale recap' });
+      await recap.promise;
+    });
+
+    expect(mockStore.reset).toHaveBeenCalled();
+    expect(mockStore.dispatch).not.toHaveBeenCalledWith([
+      expect.objectContaining({ source: 'recap' }),
+    ]);
+  });
+
   it('focuses the composer after starting a new session', async () => {
     const { container } = renderApp();
     await flush();

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -2066,6 +2066,7 @@ async function triggerAutoRecap(): Promise<{
     typeof deferred<{ sessionId: string; recap: string | null }>
   >;
   container: HTMLElement;
+  rerender: (nextProps?: React.ComponentProps<typeof App>) => void;
 }> {
   const recap = deferred<{ sessionId: string; recap: string | null }>();
   mockSessionActions.recapSession.mockReturnValueOnce(recap.promise);
@@ -2078,14 +2079,14 @@ async function triggerAutoRecap(): Promise<{
   let now = 1;
   vi.spyOn(Date, 'now').mockImplementation(() => now);
 
-  const { container } = renderApp();
+  const { container, rerender } = renderApp();
   await flush();
   act(() => document.dispatchEvent(new Event('visibilitychange')));
   now += 3 * 60 * 1000;
   hidden = false;
   act(() => document.dispatchEvent(new Event('visibilitychange')));
   expect(mockSessionActions.recapSession).toHaveBeenCalledOnce();
-  return { recap, container };
+  return { recap, container, rerender };
 }
 
 // A transcript block shaped like extractPendingPermission() expects. Defaults to
@@ -6644,6 +6645,20 @@ describe('App session callbacks', () => {
     });
 
     expect(mockStore.reset).toHaveBeenCalled();
+    expect(mockStore.dispatch).not.toHaveBeenCalledWith([
+      expect.objectContaining({ source: 'recap' }),
+    ]);
+  });
+
+  it('discards an automatic recap when the connection session id changes', async () => {
+    const { recap, rerender } = await triggerAutoRecap();
+    await act(async () => {
+      mockConnection.sessionId = 'session-reconnected';
+      rerender();
+      recap.resolve({ sessionId: 'session-1', recap: 'Stale recap' });
+      await recap.promise;
+    });
+
     expect(mockStore.dispatch).not.toHaveBeenCalledWith([
       expect.objectContaining({ source: 'recap' }),
     ]);

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -183,6 +183,10 @@ const {
       attachSession: vi.fn().mockResolvedValue(undefined),
       clearSession: vi.fn().mockResolvedValue(undefined),
       releaseSession: vi.fn().mockResolvedValue(undefined),
+      recapSession: vi.fn().mockResolvedValue({
+        sessionId: 'session-1',
+        recap: null,
+      }),
       refreshCommands: vi.fn().mockResolvedValue(undefined),
       setModel: vi.fn().mockResolvedValue(undefined),
       setApprovalMode: vi.fn().mockResolvedValue(undefined),
@@ -2094,6 +2098,10 @@ beforeEach(() => {
   // auto-restore into the next test's App mount.
   sessionStorage.clear();
   localStorage.removeItem('qwen-code-web-shell-chat-width');
+  Object.defineProperty(document, 'hidden', {
+    configurable: true,
+    get: () => false,
+  });
   Object.defineProperty(window, 'matchMedia', {
     configurable: true,
     // Query-aware: report a large screen (min-width matches) so the Session
@@ -2220,6 +2228,10 @@ beforeEach(() => {
   mockSessionActions.attachSession.mockResolvedValue(undefined);
   mockSessionActions.clearSession.mockResolvedValue(undefined);
   mockSessionActions.releaseSession.mockResolvedValue(undefined);
+  mockSessionActions.recapSession.mockResolvedValue({
+    sessionId: 'session-1',
+    recap: null,
+  });
   mockSessionActions.loadSession.mockResolvedValue(undefined);
   mockSessionActions.reloadSession.mockResolvedValue(undefined);
   mockSessionActions.refreshCommands.mockResolvedValue(undefined);
@@ -6504,6 +6516,76 @@ describe('App session callbacks', () => {
       expect(onSessionIdChange).toHaveBeenCalledTimes(1);
     },
   );
+
+  it('dispatches an automatic recap when the session remains active', async () => {
+    const recap = deferred<{ sessionId: string; recap: string | null }>();
+    mockSessionActions.recapSession.mockReturnValueOnce(recap.promise);
+    testState.blocks = [{}, {}, {}, {}];
+    let hidden = true;
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      get: () => hidden,
+    });
+    let now = 1;
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+
+    renderApp();
+    await flush();
+    act(() => document.dispatchEvent(new Event('visibilitychange')));
+    now += 3 * 60 * 1000;
+    hidden = false;
+    act(() => document.dispatchEvent(new Event('visibilitychange')));
+
+    expect(mockSessionActions.recapSession).toHaveBeenCalledOnce();
+    await act(async () => {
+      recap.resolve({ sessionId: 'session-1', recap: 'Current session recap' });
+      await recap.promise;
+    });
+
+    expect(mockStore.dispatch).toHaveBeenCalledWith([
+      expect.objectContaining({
+        source: 'recap',
+        text: expect.stringContaining('Current session recap'),
+      }),
+    ]);
+  });
+
+  it('discards an automatic recap after starting a new session', async () => {
+    const recap = deferred<{ sessionId: string; recap: string | null }>();
+    mockSessionActions.recapSession.mockReturnValueOnce(recap.promise);
+    testState.blocks = [{}, {}, {}, {}];
+    let hidden = true;
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      get: () => hidden,
+    });
+    let now = 1;
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+
+    const { container } = renderApp();
+    await flush();
+    act(() => document.dispatchEvent(new Event('visibilitychange')));
+    now += 3 * 60 * 1000;
+    hidden = false;
+    act(() => document.dispatchEvent(new Event('visibilitychange')));
+    expect(mockSessionActions.recapSession).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="new-session"]')
+        ?.click();
+      recap.resolve({
+        sessionId: 'session-1',
+        recap: 'Previous session recap',
+      });
+      await recap.promise;
+    });
+
+    expect(mockSessionActions.clearSession).toHaveBeenCalledOnce();
+    expect(mockStore.dispatch).not.toHaveBeenCalledWith([
+      expect.objectContaining({ source: 'recap' }),
+    ]);
+  });
 
   it('focuses the composer after starting a new session', async () => {
     const { container } = renderApp();

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -6611,6 +6611,23 @@ describe('App session callbacks', () => {
     ]);
   });
 
+  it('discards an automatic recap after resuming a session by command', async () => {
+    const { recap } = await triggerAutoRecap();
+    await act(async () => {
+      testState.latestChatEditorProps?.onSubmit('/resume session-3');
+      recap.resolve({
+        sessionId: 'session-1',
+        recap: 'Previous session recap',
+      });
+      await recap.promise;
+    });
+
+    expect(mockSessionActions.loadSession).toHaveBeenCalledWith('session-3');
+    expect(mockStore.dispatch).not.toHaveBeenCalledWith([
+      expect.objectContaining({ source: 'recap' }),
+    ]);
+  });
+
   it('discards an automatic recap after clearing the screen', async () => {
     const { recap } = await triggerAutoRecap();
     await act(async () => {

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -5797,6 +5797,14 @@ export function App({
             connectionRef.current.sessionId !== sessionId ||
             result.sessionId !== sessionId
           ) {
+            console.warn('[auto-recap] discarding stale recap', {
+              captured: { sessionId, version },
+              current: {
+                sessionId: connectionRef.current.sessionId,
+                version: autoRecapVersionRef.current,
+              },
+              result: result.sessionId,
+            });
             return;
           }
           if (result.recap) {

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -5410,6 +5410,7 @@ export function App({
       store.dispatch([{ type: 'status', text: t('clear.blocked') }]);
       return;
     }
+    autoRecapVersionRef.current += 1;
     store.reset();
   }, [store, t]);
 
@@ -6394,6 +6395,7 @@ export function App({
       // Settings/Status panel (no-op when the panel is closed).
       closePanel();
       try {
+        autoRecapVersionRef.current += 1;
         await sessionActions.loadSession(sessionId, { workspaceCwd });
       } catch (error) {
         setSidebarSwitchingSessionId((current) =>
@@ -7490,6 +7492,7 @@ export function App({
               // close any open Settings/Status panel (no-op when already closed),
               // consistent with createNewSession / loadSidebarSession.
               closePanel();
+              autoRecapVersionRef.current += 1;
               sessionActions.loadSession(sessionId).catch((error: unknown) => {
                 reportError(error, 'Failed to load session');
               });
@@ -8698,6 +8701,7 @@ export function App({
                 onSelect={(sessionId) => {
                   closeMobileDrawer();
                   closePanel();
+                  autoRecapVersionRef.current += 1;
                   sessionActions
                     .loadSession(sessionId)
                     .catch((error: unknown) => {

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -5764,8 +5764,10 @@ export function App({
   // Auto-recap: fire when the user returns after being away ≥ 3 minutes
   const hiddenAtRef = useRef<number | null>(null);
   const lastRecapBlockCountRef = useRef(0);
+  const autoRecapVersionRef = useRef(0);
   useEffect(() => {
     lastRecapBlockCountRef.current = 0;
+    autoRecapVersionRef.current += 1;
   }, [connection.sessionId]);
   useEffect(() => {
     const AWAY_THRESHOLD_MS = 3 * 60 * 1000;
@@ -5785,8 +5787,17 @@ export function App({
       if (currentCount - lastRecapBlockCountRef.current < MIN_NEW_BLOCKS)
         return;
       lastRecapBlockCountRef.current = currentCount;
+      const sessionId = connection.sessionId;
+      const version = autoRecapVersionRef.current;
       sessionActions.recapSession().then(
         (result) => {
+          if (
+            autoRecapVersionRef.current !== version ||
+            connectionRef.current.sessionId !== sessionId ||
+            result.sessionId !== sessionId
+          ) {
+            return;
+          }
           if (result.recap) {
             store.dispatch([
               {
@@ -5930,6 +5941,7 @@ export function App({
       if (!opts?.keepView) setMainView('chat');
       let focusRequest: number | undefined;
       try {
+        autoRecapVersionRef.current += 1;
         const clearPromise = (
           sessionActions as typeof sessionActions & SessionActionsWithCreate
         ).clearSession();

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -5411,6 +5411,7 @@ export function App({
       return;
     }
     autoRecapVersionRef.current += 1;
+    lastRecapBlockCountRef.current = 0;
     store.reset();
   }, [store, t]);
 
@@ -5792,6 +5793,9 @@ export function App({
       const version = autoRecapVersionRef.current;
       sessionActions.recapSession().then(
         (result) => {
+          // result.sessionId only pins the daemon wire contract (the daemon
+          // echoes the id back), not a real race; the epoch/connection checks
+          // catch those. Kept so it is not simplified away as redundant.
           if (
             autoRecapVersionRef.current !== version ||
             connectionRef.current.sessionId !== sessionId ||


### PR DESCRIPTION
## What this PR does

Prevents an automatic recap requested for one Web Shell session from being inserted into the transcript after the user starts another session. Each request now records its originating session and generation, and its result is accepted only while that ownership remains current. Starting a new session invalidates in-flight recap work synchronously before the shared transcript is cleared.

Adds regression coverage for both the normal same-session result and the race where the previous session's recap completes immediately after New session is selected but before the connection state rerenders.

## Why it's needed

The Web Shell reuses its transcript store across session transitions. A recap request could start for session A, the user could clear the transcript to create session B, and the old request could then resolve and write session A's recap into the new conversation page. Checking only the rendered connection state was insufficient because clearing the store happens before React commits the connection update.

## Reviewer Test Plan

### How to verify

1. Confirm that returning to an unchanged active session after the automatic recap threshold still dispatches the generated recap.
2. Start an automatic recap, select New session, and resolve the old recap before the connection state rerenders. Confirm that the previous session's recap is not dispatched into the cleared transcript.
3. Run `cd packages/web-shell && npx vitest run client/App.test.tsx --config vitest.config.ts` and confirm all 295 tests pass.
4. Run `cd packages/web-shell && npm run lint && npm run typecheck`, then run `npm run build && npm run typecheck` from the repository root.

### Evidence (Before & After)

Before: an in-flight recap from the previous session could appear on the newly cleared conversation page.

After: recap results are accepted only for the session and generation that initiated them; stale results are discarded even in the clear-before-rerender race window.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS local workspace with Node.js package tests, ESLint, TypeScript type checking, and the full repository build.

## Risk & Scope

- Main risk or tradeoff: If starting a new session fails after recap invalidation, an informational in-flight recap for the still-active session is discarded rather than retried; conversation state is unaffected.
- Not validated / out of scope: Windows and Linux runtime behavior, changing the automatic recap away threshold, and resetting the hidden timestamp when switching sessions while the page is hidden.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

防止 Web Shell 中为某个会话发起的自动 recap 在用户新建另一个会话后写入当前 transcript。每次请求会记录其来源会话与版本，只有归属仍然有效时才接受结果。新建会话会在清空共享 transcript 前同步使所有在途 recap 失效。

新增回归测试，覆盖同一会话正常接收结果，以及用户选择“新建会话”后、connection 状态尚未 rerender 前，上一会话 recap 立即完成的竞态场景。

## 为什么需要

Web Shell 在会话切换期间复用 transcript store。session A 的 recap 请求发出后，用户可能清空 transcript 并准备创建 session B，旧请求随后完成并把 session A 的 recap 写入新会话页面。仅检查已渲染的 connection 状态并不充分，因为 store 清空发生在 React 提交 connection 更新之前。

## Reviewer 测试计划

### 验证方式

1. 确认活动会话保持不变时，达到自动 recap 条件后仍会正常 dispatch 生成的 recap。
2. 启动自动 recap，选择“新建会话”，并在 connection 状态 rerender 前完成旧 recap。确认上一会话的 recap 不会 dispatch 到已清空的 transcript。
3. 运行 `cd packages/web-shell && npx vitest run client/App.test.tsx --config vitest.config.ts`，确认 295 个测试全部通过。
4. 运行 `cd packages/web-shell && npm run lint && npm run typecheck`，然后在仓库根目录运行 `npm run build && npm run typecheck`。

### 证据（修改前后）

修改前：上一会话的在途 recap 可能出现在刚清空的新会话页面中。

修改后：仅接受与发起时会话和版本一致的 recap；即使发生先清空、后 rerender 的竞态，过期结果也会被丢弃。

### 测试系统

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS 本地工作区，执行了 Node.js package 测试、ESLint、TypeScript 类型检查以及全仓构建。

## 风险与范围

- 主要风险或取舍：如果 recap 失效后新建会话失败，仍处于活动状态的旧会话会丢弃这一次信息性 recap，而不会重试；对话状态不受影响。
- 未验证 / 范围外：Windows 和 Linux 运行时行为、修改自动 recap 离开阈值，以及页面隐藏期间切换会话时重置隐藏时间戳。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

N/A

</details>
