### PR TITLE
fix(web-shell): compact advanced tables in narrow messages

### DIFF
--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.module.css
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.module.css
@@ -594,7 +594,7 @@ tr:hover .frozenCell.selectedCell {
 
 @container table-toolbar (max-width: 500px) {
   .compactToolbarLabel,
-  .selectionStats .selectionMetric {
+  .selectionMetric:not(:first-child) {
     display: none;
   }
 
@@ -604,10 +604,6 @@ tr:hover .frozenCell.selectedCell {
     justify-content: center;
     gap: 0;
     padding-inline: 0;
-  }
-
-  .densityTrigger {
-    font-size: 0;
   }
 }
 

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.module.css
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.module.css
@@ -592,6 +592,25 @@ tr:hover .frozenCell.selectedCell {
   }
 }
 
+@container table-toolbar (max-width: 500px) {
+  .compactToolbarLabel,
+  .selectionStats .selectionMetric {
+    display: none;
+  }
+
+  .compactToolbarControl,
+  .densityTrigger {
+    width: 28px;
+    justify-content: center;
+    gap: 0;
+    padding-inline: 0;
+  }
+
+  .densityTrigger {
+    font-size: 0;
+  }
+}
+
 @container table-scroller (max-width: 320px) {
   .detailPanel {
     grid-template-columns: minmax(0, 1fr);

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
@@ -1180,6 +1180,15 @@ describe('EnhancedMarkdownTable', () => {
     expect(writeText).toHaveBeenLastCalledWith("'=1+1");
   });
 
+  it('keeps an accessible name on the custom columns trigger', () => {
+    const container = renderTable();
+
+    const trigger = button(container, 'Custom columns');
+
+    expect(trigger.getAttribute('aria-label')).toBe('Custom columns');
+    expect(trigger.textContent).toContain('Custom columns');
+  });
+
   it('hides columns and restores them from custom columns', () => {
     const container = renderTable();
 

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
@@ -1342,11 +1342,13 @@ function CustomColumnsPopover({
         <Button
           variant="ghost"
           size="sm"
-          className={styles.toolbarControl}
+          className={`${styles.toolbarControl} ${styles.compactToolbarControl}`}
           type="button"
         >
           <BoltIcon />
-          {t('markdownTable.customColumns')}
+          <span className={styles.compactToolbarLabel}>
+            {t('markdownTable.customColumns')}
+          </span>
         </Button>
       </PopoverTrigger>
       <PopoverContent

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
@@ -58,6 +58,7 @@ import {
   GripVerticalIcon,
   MinusIcon,
   PlusIcon,
+  Rows3Icon,
   XIcon,
 } from 'lucide-react';
 import {
@@ -1343,6 +1344,7 @@ function CustomColumnsPopover({
           variant="ghost"
           size="sm"
           className={`${styles.toolbarControl} ${styles.compactToolbarControl}`}
+          aria-label={t('markdownTable.customColumns')}
           type="button"
         >
           <BoltIcon />
@@ -2625,10 +2627,13 @@ export function EnhancedTable({
               className={styles.densityTrigger}
               aria-label={t('markdownTable.densityLabel')}
             >
+              <Rows3Icon className="size-4" />
               <SelectValue>
-                {t('markdownTable.densityCurrent', {
-                  density: t(`markdownTable.density.${density}`),
-                })}
+                <span className={styles.compactToolbarLabel}>
+                  {t('markdownTable.densityCurrent', {
+                    density: t(`markdownTable.density.${density}`),
+                  })}
+                </span>
               </SelectValue>
             </SelectTrigger>
             <SelectContent className={styles.densityMenu}>


### PR DESCRIPTION
## What this PR does

Compacts the advanced Markdown table toolbar when the middle message area is 500px wide or narrower. The density control and custom-column control keep their icons while dropping visible labels, and cell-selection statistics are hidden while Copy TSV, the row count, and the remaining toolbar actions stay available.

## Why it's needed

Advanced table controls and detailed selection statistics overflow narrow message panes, especially in split layouts. The behavior should follow the message area's available width rather than the browser viewport.

## Reviewer Test Plan

### How to verify

Open an advanced Markdown table, narrow only the middle message pane to 500px or less, and confirm the density and custom-column controls become icon-only. Select cells and confirm Selected, Non-empty, Numeric, Sum, Average, Min, and Max are hidden while Copy TSV, the row count, and all other toolbar actions remain visible and functional. Widen the message pane and confirm the labels and statistics return.

### Evidence (Before & After)

Before: density/custom-column labels and selection statistics consume the narrow toolbar. After: those labels and detailed statistics collapse based on message-pane width without removing actions.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Web Shell unit tests and TypeScript typecheck on macOS.

## Risk & Scope

- Main risk or tradeoff: icon-only controls rely on their existing accessible labels and familiar icons in narrow panes.
- Not validated / out of scope: browser-driven visual regression testing and basic Markdown tables.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 的改动

当中间消息区域宽度不超过 500px 时，精简高级 Markdown 表格工具栏。密度和自定义列控件保留图标并隐藏可见文案；选中单元格后隐藏详细统计，同时保留复制 TSV、总行数和其他工具栏操作。

## 改动原因

高级表格控件和详细选择统计会在狭窄消息区域中溢出，分屏布局下尤其明显。响应式行为应依据消息区域的可用宽度，而不是浏览器视口宽度。

## Reviewer 测试计划

### 验证方式

打开高级 Markdown 表格，只将中间消息区域缩窄到 500px 或以下，确认密度和自定义列控件只显示图标。选中单元格，确认已选、非空、数值、求和、平均、最小和最大统计被隐藏，同时复制 TSV、总行数及其他工具栏操作仍可见且可用。重新加宽消息区域后，确认文案和统计恢复显示。

### 前后对比

改动前：密度/自定义列文案和选择统计占用狭窄工具栏。改动后：这些文案和详细统计依据消息区域宽度收起，但不移除操作。

### 测试环境

已在 macOS 上运行 Web Shell 单元测试和 TypeScript 类型检查；未进行 Windows、Linux 和浏览器自动化视觉回归测试。

## 风险与范围

- 主要风险或权衡：窄区域中的纯图标控件依赖现有无障碍标签和易识别图标。
- 未验证或不在范围内：浏览器视觉回归测试和基础 Markdown 表格。
- 破坏性变更或迁移说明：无。

## 关联 Issue

无

</details>
