### PR TITLE
fix(triage): say what the re-run summary measured, in both languages

### DIFF
--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -826,14 +826,23 @@ jobs:
             if HEAD_SHA="$(
                  gh api "repos/$GITHUB_REPOSITORY/pulls/$NUMBER" --jq '.head.sha'
                )" && [ -n "$HEAD_SHA" ]; then
+              # Three outcomes, not two. `deferred` is the one that was
+              # missing: the skill's confidence table sends 3/5 down a defer
+              # path that posts a COMMENTED review and deliberately does not
+              # vote — a fork `refactor` hitting the approval guardrail, or a
+              # core change escalated for maintainer awareness. That is a
+              # correct terminal state, and folding it into `none` reported
+              # the routine outcome and the broken one with the same warning.
               STANDING="$(
                 printf '%s' "$REVIEWS" |
                   jq -rs \
                     --arg bot "$BOT_LOGIN" \
                     --arg sha "$HEAD_SHA" \
-                    '[.[][] | select(.user.login == $bot and .commit_id == $sha)
-                            | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED")]
-                     | if length > 0 then "own" else "none" end'
+                    '[.[][] | select(.user.login == $bot and .commit_id == $sha)]
+                     | if any(.[]; .state == "APPROVED" or .state == "CHANGES_REQUESTED")
+                       then "own"
+                       elif any(.[]; .state == "COMMENTED") then "deferred"
+                       else "none" end'
               )" || STANDING=unknown
             fi
           else
@@ -843,23 +852,39 @@ jobs:
             echo "Triage re-run posted a review; no summary comment needed."
             exit 0
           fi
+          # Say what was measured, in both languages. The old note claimed the
+          # bot had "no review of its own" whenever it had not VOTED — but a
+          # deferring run leaves a visible COMMENTED review, so a reader who
+          # could see it on the page was told it did not exist. State the
+          # review that is there, and say what the missing vote costs (`main`
+          # takes two approvals, so a maintainer's is only the first).
           case "$STANDING" in
             own)
-              NOTE="The bot already has a review of its own on \`$HEAD_SHA\`, which still stands."
+              NOTE_EN="The bot already has a review of its own on \`$HEAD_SHA\`, which still stands."
+              NOTE_ZH="机器人在 \`$HEAD_SHA\` 上已有自己的评审，且仍然有效。"
+              ;;
+            deferred)
+              NOTE_EN="⚠️ The bot's only review on \`$HEAD_SHA\` is a \`COMMENTED\` one, which **carries no vote** — so it has no verdict of its own on this commit, and \`main\` needs two approving reviews: an approval left by another account is a separate vote and does not count as the bot's own. Two different things look like this, and the stage-3 comment above says which: the triage skill **deferring on purpose** at 3/5 — a fork \`refactor\` hitting the approval guardrail, or a core change escalated for maintainer awareness, both normal outcomes — or an earlier approval that a push **dismissed**, leaving only the comment behind, which needs a fresh review."
+              NOTE_ZH="⚠️ 机器人在 \`$HEAD_SHA\` 上唯一的评审是 \`COMMENTED\`，**不带票** —— 因此它在该 commit 上没有自己的裁决，而 \`main\` 需要两个批准（其他账号的批准是另一张票）。有两种情况长这样，上方的 stage-3 评论会说明是哪一种：triage skill 在 3/5 时**有意 defer**（fork \`refactor\` 命中审批护栏，或核心改动被升级交由维护者把关，两者都是正常结果）；或者更早的批准被一次推送**作废**、只剩下这条评论，此时需要重新评审。"
+              echo "::warning title=Triage re-run left no bot review::The bot has only a COMMENTED review on $HEAD_SHA (no vote) and this re-run added none."
               ;;
             none)
-              NOTE="⚠️ The bot has **no review of its own** on \`$HEAD_SHA\`. If this re-run was meant to approve, it did not — an approval left by another account is a separate vote and does not count as the bot's own."
-              echo "::warning title=Triage re-run left no bot review::The bot has no APPROVED or CHANGES_REQUESTED review on $HEAD_SHA and this re-run added none."
+              NOTE_EN="⚠️ The bot has **neither a verdict nor a deferral** on \`$HEAD_SHA\` — no \`APPROVED\`, \`CHANGES_REQUESTED\`, or \`COMMENTED\` review of its own. A \`DISMISSED\` one does not count: \`dismiss_stale_reviews\` voids the bot's approval on every push, which is exactly when a fresh one is needed. If this re-run was meant to review or approve, it did not, and an approval left by another account is a separate vote that does not count as the bot's own."
+              NOTE_ZH="⚠️ 机器人在 \`$HEAD_SHA\` 上**既没有裁决也没有 defer** —— 没有属于它自己的 \`APPROVED\`、\`CHANGES_REQUESTED\` 或 \`COMMENTED\` 评审。\`DISMISSED\` 不算：\`dismiss_stale_reviews\` 会在每次推送时作废机器人的批准，而那恰恰是需要一次新批准的时刻。如果这次重跑本应评审或批准，那么它没有做到；而其他账号留下的批准是另一张票，不能算作机器人自己的。"
+              echo "::warning title=Triage re-run left no bot review::The bot has no APPROVED, CHANGES_REQUESTED or COMMENTED review on $HEAD_SHA and this re-run added none."
               ;;
             *)
-              NOTE="The bot's review state on the head commit could not be read."
+              NOTE_EN="The bot's review state on the head commit could not be read."
+              NOTE_ZH="无法读取机器人在 head commit 上的评审状态。"
               ;;
           esac
-          printf -v BODY '%s\n\n%s\n\n%s\n\n%s' \
+          printf -v BODY '%s\n\n%s\n\n%s\n\n%s\n\n%s\n\n%s' \
             '<!-- qwen-triage stage=rerun-summary -->' \
             'Triage re-run completed without a new review.' \
-            "$NOTE" \
-            "The stage comments above were updated with the latest result. [View workflow run]($RUN_URL)."
+            "$NOTE_EN" \
+            "$NOTE_ZH" \
+            "The stage comments above were updated with the latest result. [View workflow run]($RUN_URL)." \
+            "上方各阶段评论已更新为最新结果。[查看工作流运行]($RUN_URL)。"
           gh api "repos/$GITHUB_REPOSITORY/issues/$NUMBER/comments" \
             -f body="$BODY" >/dev/null
 

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -320,64 +320,77 @@ describe('qwen-triage tmux workflow', () => {
   // Execute the real classifier rather than matching its text: the states are
   // the contract, and a jq edit that silently reclassifies one is invisible to
   // a string assertion.
-  it('classifies a deferring COMMENTED review apart from a missing one', () => {
-    const notifyStep = step('Notify silent triage re-run');
-    const program = notifyStep.match(
-      /--arg sha "\$HEAD_SHA" \\\n\s*'([\s\S]*?)'\n/,
-    )?.[1];
-    expect(program).toBeTruthy();
+  it.skipIf(spawnSync('jq', ['--version']).status !== 0)(
+    'classifies a deferring COMMENTED review apart from a missing one',
+    () => {
+      const notifyStep = step('Notify silent triage re-run');
+      const program = notifyStep.match(
+        /--arg sha "\$HEAD_SHA" \\\n\s*'([\s\S]*?)'\n/,
+      )?.[1];
+      expect(program).toBeTruthy();
 
-    const dir = mkdtempSync(join(tmpdir(), 'rerun-standing-'));
-    const progFile = join(dir, 'standing.jq');
-    writeFileSync(progFile, program);
-    const classify = (reviews) => {
-      const r = spawnSync(
-        'jq',
-        ['-rs', '--arg', 'bot', 'bot', '--arg', 'sha', 'HEAD', '-f', progFile],
-        { input: JSON.stringify(reviews), encoding: 'utf8' },
-      );
-      expect(r.status, r.stderr).toBe(0);
-      return r.stdout.trim();
-    };
-    const rev = (state, login = 'bot', commit = 'HEAD') => ({
-      user: { login },
-      commit_id: commit,
-      state,
-    });
+      const dir = mkdtempSync(join(tmpdir(), 'rerun-standing-'));
+      const progFile = join(dir, 'standing.jq');
+      writeFileSync(progFile, program);
+      const classify = (reviews) => {
+        const r = spawnSync(
+          'jq',
+          [
+            '-rs',
+            '--arg',
+            'bot',
+            'bot',
+            '--arg',
+            'sha',
+            'HEAD',
+            '-f',
+            progFile,
+          ],
+          { input: JSON.stringify(reviews), encoding: 'utf8' },
+        );
+        expect(r.status, r.stderr).toBe(0);
+        return r.stdout.trim();
+      };
+      const rev = (state, login = 'bot', commit = 'HEAD') => ({
+        user: { login },
+        commit_id: commit,
+        state,
+      });
 
-    try {
-      // A vote of either kind stands.
-      expect(classify([rev('APPROVED')])).toBe('own');
-      expect(classify([rev('CHANGES_REQUESTED')])).toBe('own');
+      try {
+        // A vote of either kind stands.
+        expect(classify([rev('APPROVED')])).toBe('own');
+        expect(classify([rev('CHANGES_REQUESTED')])).toBe('own');
 
-      // The defer path. The second arm is the real #7948/#8141 shape: the bot
-      // deferred and a maintainer approved, which must NOT read as the bot's
-      // own vote — `main` needs two, so the PR is still one short.
-      expect(classify([rev('COMMENTED')])).toBe('deferred');
-      expect(classify([rev('COMMENTED'), rev('APPROVED', 'wenshao')])).toBe(
-        'deferred',
-      );
+        // The defer path. The second arm is the real #7948/#8141 shape: the bot
+        // deferred and a maintainer approved, which must NOT read as the bot's
+        // own vote — `main` needs two, so the PR is still one short.
+        expect(classify([rev('COMMENTED')])).toBe('deferred');
+        expect(classify([rev('COMMENTED'), rev('APPROVED', 'wenshao')])).toBe(
+          'deferred',
+        );
 
-      // DISMISSED is NOT a deferral, and this is the distinction the first
-      // draft of this change got wrong. `dismiss_stale_reviews` voids the
-      // bot's approval on every push, which is exactly when a fresh one is
-      // required — reporting that as a routine defer would say the opposite
-      // of what the maintainer needs to know. Same for an unsubmitted PENDING.
-      expect(classify([rev('DISMISSED')])).toBe('none');
-      expect(classify([rev('PENDING')])).toBe('none');
-      // ...but a real COMMENTED alongside a DISMISSED one is still a defer.
-      expect(classify([rev('DISMISSED'), rev('COMMENTED')])).toBe('deferred');
+        // DISMISSED is NOT a deferral, and this is the distinction the first
+        // draft of this change got wrong. `dismiss_stale_reviews` voids the
+        // bot's approval on every push, which is exactly when a fresh one is
+        // required — reporting that as a routine defer would say the opposite
+        // of what the maintainer needs to know. Same for an unsubmitted PENDING.
+        expect(classify([rev('DISMISSED')])).toBe('none');
+        expect(classify([rev('PENDING')])).toBe('none');
+        // ...but a real COMMENTED alongside a DISMISSED one is still a defer.
+        expect(classify([rev('DISMISSED'), rev('COMMENTED')])).toBe('deferred');
 
-      // The original incident this whole probe exists for: a human approval
-      // with no bot review must stay `none`, not be read as the bot's own.
-      expect(classify([rev('APPROVED', 'wenshao')])).toBe('none');
-      // A vote on an earlier commit does not carry over.
-      expect(classify([rev('APPROVED', 'bot', 'OLD')])).toBe('none');
-      expect(classify([])).toBe('none');
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
+        // The original incident this whole probe exists for: a human approval
+        // with no bot review must stay `none`, not be read as the bot's own.
+        expect(classify([rev('APPROVED', 'wenshao')])).toBe('none');
+        // A vote on an earlier commit does not carry over.
+        expect(classify([rev('APPROVED', 'bot', 'OLD')])).toBe('none');
+        expect(classify([])).toBe('none');
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  );
 
   // Both notes are posted in both languages, matching the status comment
   // composer in the same step. The re-run summary was the one body in this
@@ -396,9 +409,9 @@ describe('qwen-triage tmux workflow', () => {
     expect(notifyStep).toContain('"$NOTE_ZH"');
     expect(notifyStep).toMatch(/[一-鿿]/);
 
-    // The ::warning is the operator-facing signal, so it must fire on the
-    // genuinely-missing case and stay silent on the routine defer — otherwise
-    // every deferred PR raises an annotation nobody should act on.
+    // The ::warning is the operator-facing signal. Both no-vote states
+    // (deferred and none) fire it — see the note below for why silencing
+    // the defer case would be wrong.
     const noneBranch = notifyStep.slice(
       notifyStep.indexOf('none)'),
       notifyStep.indexOf('*)'),
@@ -802,6 +815,14 @@ describe('qwen-triage tmux workflow', () => {
             commit_id: 'head',
           },
         ],
+        botNone: [
+          {
+            user: { login: 'human' },
+            state: 'APPROVED',
+            submitted_at: '2026-01-01T00:00:00Z',
+            commit_id: 'head',
+          },
+        ],
       };
 
       const run = (reviews, head) => {
@@ -881,6 +902,14 @@ describe('qwen-triage tmux workflow', () => {
       expect(postedNow.status).toBe(0);
       expect(postedNow.log).toContain('no summary comment needed');
       expect(postedNow.comment).toBe('');
+
+      // A true none: the bot has no review at all on the head commit.
+      // This exercises the none) arm's bash, which the humanOnly fixture
+      // no longer reaches after its reclassification to deferred.
+      const botNone = run(REVIEWS.botNone, 'head');
+      expect(botNone.status).toBe(0);
+      expect(botNone.log).toContain('Triage re-run left no bot review');
+      expect(botNone.comment).toContain('neither a verdict nor a deferral');
 
       // An unreadable head SHA must not masquerade as either verdict.
       const noHead = run(REVIEWS.humanOnly, '');

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -309,6 +309,121 @@ describe('qwen-triage tmux workflow', () => {
     expect(notifyStep).not.toContain('-X PATCH');
   });
 
+  // The re-run summary used to have two outcomes, and the routine one was
+  // reported as the broken one. The triage skill's confidence table sends 3/5
+  // down a DEFER path that posts a COMMENTED review and deliberately does not
+  // vote — a fork `refactor` hitting the approval guardrail, or a core change
+  // escalated for maintainer awareness. Observed on #7948 and #8141: both
+  // deferred exactly as designed, and both were told the bot had "no review of
+  // its own" while its COMMENTED review was visible on the page.
+  //
+  // Execute the real classifier rather than matching its text: the states are
+  // the contract, and a jq edit that silently reclassifies one is invisible to
+  // a string assertion.
+  it('classifies a deferring COMMENTED review apart from a missing one', () => {
+    const notifyStep = step('Notify silent triage re-run');
+    const program = notifyStep.match(
+      /--arg sha "\$HEAD_SHA" \\\n\s*'([\s\S]*?)'\n/,
+    )?.[1];
+    expect(program).toBeTruthy();
+
+    const dir = mkdtempSync(join(tmpdir(), 'rerun-standing-'));
+    const progFile = join(dir, 'standing.jq');
+    writeFileSync(progFile, program);
+    const classify = (reviews) => {
+      const r = spawnSync(
+        'jq',
+        ['-rs', '--arg', 'bot', 'bot', '--arg', 'sha', 'HEAD', '-f', progFile],
+        { input: JSON.stringify(reviews), encoding: 'utf8' },
+      );
+      expect(r.status, r.stderr).toBe(0);
+      return r.stdout.trim();
+    };
+    const rev = (state, login = 'bot', commit = 'HEAD') => ({
+      user: { login },
+      commit_id: commit,
+      state,
+    });
+
+    try {
+      // A vote of either kind stands.
+      expect(classify([rev('APPROVED')])).toBe('own');
+      expect(classify([rev('CHANGES_REQUESTED')])).toBe('own');
+
+      // The defer path. The second arm is the real #7948/#8141 shape: the bot
+      // deferred and a maintainer approved, which must NOT read as the bot's
+      // own vote — `main` needs two, so the PR is still one short.
+      expect(classify([rev('COMMENTED')])).toBe('deferred');
+      expect(classify([rev('COMMENTED'), rev('APPROVED', 'wenshao')])).toBe(
+        'deferred',
+      );
+
+      // DISMISSED is NOT a deferral, and this is the distinction the first
+      // draft of this change got wrong. `dismiss_stale_reviews` voids the
+      // bot's approval on every push, which is exactly when a fresh one is
+      // required — reporting that as a routine defer would say the opposite
+      // of what the maintainer needs to know. Same for an unsubmitted PENDING.
+      expect(classify([rev('DISMISSED')])).toBe('none');
+      expect(classify([rev('PENDING')])).toBe('none');
+      // ...but a real COMMENTED alongside a DISMISSED one is still a defer.
+      expect(classify([rev('DISMISSED'), rev('COMMENTED')])).toBe('deferred');
+
+      // The original incident this whole probe exists for: a human approval
+      // with no bot review must stay `none`, not be read as the bot's own.
+      expect(classify([rev('APPROVED', 'wenshao')])).toBe('none');
+      // A vote on an earlier commit does not carry over.
+      expect(classify([rev('APPROVED', 'bot', 'OLD')])).toBe('none');
+      expect(classify([])).toBe('none');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // Both notes are posted in both languages, matching the status comment
+  // composer in the same step. The re-run summary was the one body in this
+  // workflow that shipped English only, so a Chinese reader got the bot's
+  // bilingual stage-3 review followed by an English-only summary of it.
+  it('writes the re-run summary bilingually, and warns on every no-vote state', () => {
+    const notifyStep = step('Notify silent triage re-run');
+    for (const key of ['NOTE_EN', 'NOTE_ZH']) {
+      // own / deferred / none / unreadable
+      expect(
+        (notifyStep.match(new RegExp(`${key}=`, 'g')) ?? []).length,
+        `${key} is missing a branch`,
+      ).toBe(4);
+    }
+    expect(notifyStep).toContain('"$NOTE_EN"');
+    expect(notifyStep).toContain('"$NOTE_ZH"');
+    expect(notifyStep).toMatch(/[一-鿿]/);
+
+    // The ::warning is the operator-facing signal, so it must fire on the
+    // genuinely-missing case and stay silent on the routine defer — otherwise
+    // every deferred PR raises an annotation nobody should act on.
+    const noneBranch = notifyStep.slice(
+      notifyStep.indexOf('none)'),
+      notifyStep.indexOf('*)'),
+    );
+    const deferredBranch = notifyStep.slice(
+      notifyStep.indexOf('deferred)'),
+      notifyStep.indexOf('none)'),
+    );
+    // BOTH warn. At the reviews-API level a COMMENTED-only review is
+    // indistinguishable from a deliberate 3/5 defer — the same tuple is
+    // produced by an approval a push DISMISSED — and either way the PR is one
+    // approval short with the bot not supplying it. So the operator signal
+    // fires for both and only the wording differs. Silencing the defer case
+    // would have muted a warning that exists for a real incident.
+    expect(noneBranch).toContain(
+      '::warning title=Triage re-run left no bot review',
+    );
+    expect(deferredBranch).toContain(
+      '::warning title=Triage re-run left no bot review',
+    );
+    // ...and each warning describes what was actually measured.
+    expect(noneBranch).toContain('APPROVED, CHANGES_REQUESTED or COMMENTED');
+    expect(deferredBranch).toContain('only a COMMENTED review');
+  });
+
   it('posts an early live-progress status comment and finalizes the same one', () => {
     const statusStep = step('Post triage status comment');
     // Announced up front (before the long agent step) with the live run link.
@@ -745,7 +860,13 @@ describe('qwen-triage tmux workflow', () => {
       const humanOnly = run(REVIEWS.humanOnly, 'head');
       expect(humanOnly.status).toBe(0);
       expect(humanOnly.log).toContain('Triage re-run left no bot review');
-      expect(humanOnly.comment).toContain('no review of its own');
+      // Wording fixed: the bot DOES have a review here — a COMMENTED one,
+      // visible on the page — it just carries no vote. "No review of its own"
+      // told a reader the opposite of what they could see. The warning stays:
+      // from the reviews API this state is indistinguishable from a deliberate
+      // 3/5 defer, and both mean the PR is one approval short.
+      expect(humanOnly.comment).toContain('carries no vote');
+      expect(humanOnly.comment).not.toContain('no review of its own');
       expect(humanOnly.comment).toContain('does not count as the bot');
 
       // The bot's own approval standing on the head commit is the benign case.


### PR DESCRIPTION
## Problem

Two things, both visible on [#7948](https://github.com/QwenLM/qwen-code/pull/7948#issuecomment-5149322770) and [#8141](https://github.com/QwenLM/qwen-code/pull/8141#issuecomment-5149254351).

**The note said the opposite of what the page showed.** It claimed the bot had **no review of its own** whenever the bot had not *voted*. On both PRs the bot had reviewed and deliberately deferred, leaving a `COMMENTED` review that a reader can see in the timeline. The check is right — `COMMENTED` carries no vote, and `main` needs two approvals — but the sentence dropped the qualifier and told the reader the review did not exist.

**It was the one composed body in this workflow that shipped English only.** `qwen-triage.yml` writes Chinese in 37 places, and the status-comment composer *in the same step* pairs `EN`/`ZH`. So a Chinese reader got the bot's bilingual stage-3 review followed by an English-only summary of it.

Both PRs are the skill working as designed, which is the point:

| PR | why the bot did not approve | evidence |
| --- | --- | --- |
| #8141 `refactor(cli)`, fork | the fork-`refactor` approval guardrail — *"must never be auto-approved… this rule exists because such a PR was wrongly auto-approved and merged"* | its stage-3 comment: *"3/5 纯粹是策略所致，并非存疑"* |
| #7948 `fix(core)`, fork, 665 production lines across core + 5 packages | core-scale escalation to a maintainer | its stage-3 comment: *"如果这是一个小的单包修复，我会批准。我不批准的原因纯粹是门禁"* |

Both then hit the skill's confidence table, where 3/5 means **defer — a comment, never `--request-changes`**.

## Change

Classify the head-commit state three ways instead of two, and name what is actually there.

| state | meaning | note |
| --- | --- | --- |
| `own` | bot `APPROVED` or `CHANGES_REQUESTED` on head | verdict stands |
| `deferred` | bot's only review on head is `COMMENTED` | **new** — says it carries no vote, and lists *both* causes |
| `none` | no verdict and no deferral | warns; `DISMISSED`/`PENDING` land here |

The `deferred` note names both things that produce that state, because **the reviews API cannot tell them apart**: the skill deferring on purpose at 3/5, or an earlier approval that a push `DISMISSED`, leaving only the comment behind. The stage-3 comment says which.

## The warning still fires on both — and that is a correction to my own first pass

My first version treated `deferred` as routine and silenced the warning. That would have muted a guard that exists for a real incident: the pre-existing test's fixture is *bot `DISMISSED` on the old commit, bot `COMMENTED` on head, human `APPROVED` on head* — byte-identical to the #7948/#8141 shape, but arising from a dismissed approval rather than a deliberate defer.

Since the two are indistinguishable from the API, and either way the PR is one approval short with the bot not supplying it, the operator signal fires for both and only the wording differs. `DISMISSED` and `PENDING` are explicitly **not** deferrals — a push voids the bot's approval, and that is precisely when a fresh one is required.

## Tests

The classifier is **executed**, not string-matched: the states are the contract, and a jq edit that silently reclassifies one is invisible to a `toContain`.

Real payloads, fetched from both PRs, both classify as `deferred`. Ten synthetic arms separate the states:

| arm | → |
| --- | --- |
| bot `APPROVED` / `CHANGES_REQUESTED` on head | `own` |
| bot `COMMENTED` only | `deferred` |
| bot `COMMENTED` + human `APPROVED` (the #7948/#8141 shape) | `deferred` |
| bot `DISMISSED` on head | `none` |
| bot `PENDING` on head | `none` |
| bot `DISMISSED` + `COMMENTED` on head | `deferred` |
| **human `APPROVED` only, no bot review** | `none` — the original incident |
| bot `APPROVED` on an **older** commit | `none` |
| no reviews at all | `none` |

The composed body was driven end to end through the extracted step under its own `set -euo pipefail` with a stubbed `gh`, then rendered through GitHub's own `POST /markdown`: 8 code spans, 6 bold runs, 2 links, **0 live mentions**, Chinese intact. The `deferred` and `none` arms each emit their `::warning`; the `own` arm emits none.

One pre-existing assertion was rewritten rather than kept: it pinned `'no review of its own'`, the exact wording being corrected. It now pins `'carries no vote'` and asserts the old phrasing is gone.

`scripts/tests/qwen-triage-workflow.test.js` 118/118; actionlint, yamllint, eslint `--max-warnings 0` clean.

<details>
<summary>中文说明</summary>

## 问题

两件事，在 [#7948](https://github.com/QwenLM/qwen-code/pull/7948#issuecomment-5149322770) 与 [#8141](https://github.com/QwenLM/qwen-code/pull/8141#issuecomment-5149254351) 上都能看到。

**提示语说的与页面显示的相反。** 只要机器人没有**投票**，它就宣称机器人「没有自己的评审」。而这两个 PR 上机器人都已审阅并主动 defer，留下了在时间线上清晰可见的 `COMMENTED` 评审。判据本身是对的——`COMMENTED` 不带票，而 `main` 需要两个批准——但那句话丢掉了限定词，等于告诉读者那条评审不存在。

**它是本工作流中唯一只发英文的正文。** `qwen-triage.yml` 有 37 处中文，而**同一个 step 内**的状态评论 composer 就是 `EN`/`ZH` 成对的。于是中文读者读到的是：机器人自己那条双语 stage-3 评审，紧接着一条纯英文的摘要。

这两个 PR 都是 skill 按设计工作，这恰恰是重点：

| PR | 机器人为何不批准 | 依据 |
| --- | --- | --- |
| #8141 `refactor(cli)`，fork | fork-`refactor` 审批护栏——*「绝不可自动批准……该规则的存在正是因为这类 PR 曾被错误地自动批准并合并」* | 其 stage-3 评论：*「3/5 纯粹是策略所致，并非存疑」* |
| #7948 `fix(core)`，fork，665 生产行横跨 core 加 5 个包 | 核心模块规模升级，交由维护者把关 | 其 stage-3 评论：*「如果这是一个小的单包修复，我会批准。我不批准的原因纯粹是门禁」* |

随后两者都落到 skill 的置信度表上，而 3/5 意味着 **defer —— 发评论，绝不 `--request-changes`**。

## 改动

把 head commit 上的状态从两分改为三分，并如实说明那里到底有什么。

| 状态 | 含义 | 提示语 |
| --- | --- | --- |
| `own` | 机器人在 head 上有 `APPROVED` 或 `CHANGES_REQUESTED` | 裁决仍然有效 |
| `deferred` | 机器人在 head 上唯一的评审是 `COMMENTED` | **新增**——说明它不带票，并列出**两种**成因 |
| `none` | 既无裁决也无 defer | 告警；`DISMISSED`/`PENDING` 归入此类 |

`deferred` 的提示语会同时列出产生该状态的两种情况，因为**仅凭 reviews API 无法区分它们**：skill 在 3/5 时有意 defer，或者更早的批准被一次推送 `DISMISSED`、只剩下那条评论。上方的 stage-3 评论会说明是哪一种。

## 告警在两种情况下都保留——这是对我自己第一版方案的更正

我的第一版把 `deferred` 当作常规情况并取消了告警。那会让一个为真实事故设立的守卫失声：既有测试的 fixture 正是「机器人在旧 commit 上 `DISMISSED`、在 head 上 `COMMENTED`、人类在 head 上 `APPROVED`」——与 #7948/#8141 的形状逐字节相同，但成因是批准被作废而非有意 defer。

由于二者从 API 层面不可区分，且无论哪种情况该 PR 都还差一个批准、而机器人不会提供，因此运维信号在两种情况下都会触发，仅措辞不同。`DISMISSED` 与 `PENDING` 明确**不算** defer——推送会作废机器人的批准，而那恰恰是需要一次新批准的时刻。

## 测试

分类器是被**执行**的，不是字符串匹配：状态本身才是契约，而一次悄悄改变归类的 jq 编辑对 `toContain` 是不可见的。

从两个 PR 取到的真实 payload 都归类为 `deferred`。十个合成臂将各状态区分开：

| 臂 | → |
| --- | --- |
| 机器人在 head 上 `APPROVED` / `CHANGES_REQUESTED` | `own` |
| 机器人仅有 `COMMENTED` | `deferred` |
| 机器人 `COMMENTED` + 人类 `APPROVED`（#7948/#8141 形状） | `deferred` |
| 机器人在 head 上 `DISMISSED` | `none` |
| 机器人在 head 上 `PENDING` | `none` |
| 机器人在 head 上 `DISMISSED` + `COMMENTED` | `deferred` |
| **仅人类 `APPROVED`，无机器人评审** | `none` —— 最初那次事故 |
| 机器人在**更早** commit 上 `APPROVED` | `none` |
| 完全没有评审 | `none` |

组装出的正文经抽取出的 step、在其自身的 `set -euo pipefail` 下、以打桩的 `gh` 端到端驱动，再经 GitHub 自己的 `POST /markdown` 渲染：8 个代码跨度、6 处加粗、2 个链接、**0 个活提及**，中文完整。`deferred` 与 `none` 两臂各自打出 `::warning`，`own` 臂不打。

有一条既有断言是重写而非保留：它钉的是 `'no review of its own'`——正是本次要修正的措辞。现在改为钉 `'carries no vote'`，并断言旧措辞已消失。

`scripts/tests/qwen-triage-workflow.test.js` 118/118；actionlint、yamllint、eslint `--max-warnings 0` 均干净。

</details>
