### PR TITLE
feat(github-channel): filter notification reasons

### DIFF
--- a/docs/users/features/channels/github.md
+++ b/docs/users/features/channels/github.md
@@ -26,6 +26,7 @@ Add the channel to `~/.qwen/settings.json`:
       "type": "github",
       "token": "$GITHUB_TOKEN",
       "pollInterval": 60000,
+      "reasonFilter": ["mention", "review_requested", "assign"],
       "senderPolicy": "allowlist",
       "allowedUsers": ["your-github-username"],
       "sessionScope": "chat_thread",
@@ -62,6 +63,7 @@ For GitHub Enterprise Server, set `baseUrl`:
 | `token`                   | (required)               | Classic PAT with `notifications` scope                                           |
 | `pollInterval`            | `60000`                  | Poll interval in ms                                                              |
 | `baseUrl`                 | `https://api.github.com` | API base URL (for GHE)                                                           |
+| `reasonFilter`            | all reasons              | Optional list of GitHub notification reasons to process before dispatch          |
 | `groupPolicy`             | `"disabled"`             | Must be `"open"` for notifications to flow                                       |
 | `senderPolicy`            | `"allowlist"`            | Who can trigger the bot                                                          |
 | `groups.*.requireMention` | `true`                   | Require @mentions for ordinary comments; directed notification reasons still run |

--- a/packages/channels/github/src/GithubAdapter.test.ts
+++ b/packages/channels/github/src/GithubAdapter.test.ts
@@ -823,6 +823,45 @@ describe('GithubChannel', () => {
       },
     );
 
+    it('skips notifications whose reason is not in reasonFilter', async () => {
+      await initWithoutLoop({
+        reasonFilter: ['mention', 'review_requested', 'assign'],
+      });
+      mockOctokit.paginate.mockClear();
+      mockOctokit.paginate.mockResolvedValueOnce([
+        makeNotification({
+          reason: 'author',
+          last_read_at: '2026-07-01T12:00:00.000Z',
+        }),
+      ]);
+
+      await pollOnce();
+
+      expect(channel.inboundEnvelopes).toHaveLength(0);
+      expect(mockOctokit.paginate).toHaveBeenCalledTimes(1);
+      expect(mockOctokit.rest.issues.listComments).not.toHaveBeenCalled();
+      expect(channel.cursor.lastProcessedAt).toBe('2026-07-02T10:00:00.000Z');
+    });
+
+    it('normalizes configured reasonFilter entries before matching', async () => {
+      await initWithoutLoop({
+        reasonFilter: [' COMMENT ', 123, ''],
+      });
+      mockOctokit.paginate
+        .mockResolvedValueOnce([
+          makeNotification({
+            reason: 'comment',
+            last_read_at: '2026-07-01T12:00:00.000Z',
+          }),
+        ])
+        .mockResolvedValueOnce([makeComment({ body: 'allowed comment' })]);
+
+      await pollOnce();
+
+      expect(channel.inboundEnvelopes).toHaveLength(1);
+      expect(channel.inboundEnvelopes[0]!.text).toContain('allowed comment');
+    });
+
     it('excludes comments from disallowed senders when aggregating', async () => {
       await initWithoutLoop({
         senderPolicy: 'allowlist',

--- a/packages/channels/github/src/GithubAdapter.ts
+++ b/packages/channels/github/src/GithubAdapter.ts
@@ -12,6 +12,7 @@ import { testBotMention, stripBotMention } from './mention.js';
 
 interface GithubConfig extends ChannelConfig {
   baseUrl?: string;
+  reasonFilter?: unknown;
 }
 
 interface GithubCursor {
@@ -77,10 +78,20 @@ interface NotificationContext {
   reason: string;
 }
 
+function normalizeReasonFilter(config: GithubConfig): Set<string> | null {
+  if (!Array.isArray(config.reasonFilter)) return null;
+  const reasons = config.reasonFilter
+    .filter((reason): reason is string => typeof reason === 'string')
+    .map((reason) => reason.trim().toLowerCase())
+    .filter((reason) => reason.length > 0);
+  return new Set(reasons);
+}
+
 export class GithubChannel extends PollingChannelBase<GithubCursor> {
   private octokit!: Octokit;
   private botUsername: string | null = null;
   private webOrigin = 'https://github.com';
+  private reasonFilter: Set<string> | null = null;
 
   constructor(
     name: string,
@@ -120,6 +131,7 @@ export class GithubChannel extends PollingChannelBase<GithubCursor> {
 
   async connect(): Promise<void> {
     const cfg = this.config as GithubConfig;
+    this.reasonFilter = normalizeReasonFilter(cfg);
     const baseUrl = cfg.baseUrl || 'https://api.github.com';
     this.webOrigin = baseUrl
       .replace(/\/api\/v3\/?$/, '')
@@ -230,6 +242,16 @@ export class GithubChannel extends PollingChannelBase<GithubCursor> {
 
       const { chatId, threadId, issueNumber } = extracted;
       const lastReadAt = notification.last_read_at;
+      const reason = String(notification.reason ?? '').toLowerCase();
+      if (this.reasonFilter && !this.reasonFilter.has(reason)) {
+        this.logDebugPayload('Github', {
+          event: 'reasonFilter.skip',
+          chatId,
+          threadId,
+          reason: notification.reason,
+        });
+        continue;
+      }
       const ctx: NotificationContext = {
         chatId,
         threadId,
@@ -239,11 +261,11 @@ export class GithubChannel extends PollingChannelBase<GithubCursor> {
         metaFloor: this.cursor.metaFloor,
         maxUpdatedAt,
         subjectTitle: notification.subject.title || '',
-        reason: notification.reason,
+        reason,
       };
 
       try {
-        switch (notification.reason) {
+        switch (reason) {
           case 'mention':
             await this.processCommentLane(ctx, true);
             break;


### PR DESCRIPTION
## Summary

Add an optional GitHub channel reason filter so users can limit inbound notification processing to selected GitHub notification reasons. Document the option and cover the filtering behavior in the GitHub adapter tests.

## Validation

- `npm test --workspace=@qwen-code/channel-github -- src/GithubAdapter.test.ts`
- `npm test --workspace=@qwen-code/qwen-code -- src/serve/channel-worker-group.test.ts src/ui/contexts/KeypressContext.test.tsx`