### PR TITLE
feat(review): Include CLI version in attribution

### DIFF
--- a/docs/users/features/code-review.md
+++ b/docs/users/features/code-review.md
@@ -174,7 +174,7 @@ Or, after running `/review 123`, type `post comments` to publish findings withou
 - Where the fix is a single localized edit, a ` ```suggestion ` block you can apply in one click
 - For Approve/Request changes verdicts: a review summary with the verdict
 - For Comment verdict with all inline comments posted: no separate summary (inline comments are sufficient)
-- Model attribution footer on each comment (e.g., _— qwen3-coder via Qwen Code /review_)
+- Model and CLI version attribution footer on each comment (e.g., _— qwen3-coder via Qwen Code /review (v0.21.2)_)
 
 **What stays terminal-only:**
 

--- a/packages/cli/src/commands/review/compose-review.test.ts
+++ b/packages/cli/src/commands/review/compose-review.test.ts
@@ -33,6 +33,9 @@ vi.mock('../../utils/stdioHelpers.js', () => ({
   writeStdoutLine: vi.fn(),
   writeStderrLine: vi.fn(),
 }));
+vi.mock('../../utils/version.js', () => ({
+  getCliVersion: vi.fn().mockResolvedValue('0.21.2'),
+}));
 import { writeStdoutLine, writeStderrLine } from '../../utils/stdioHelpers.js';
 
 const runComposeReviewCommand = (argv: unknown): Promise<void> =>

--- a/packages/cli/src/commands/review/compose-review.test.ts
+++ b/packages/cli/src/commands/review/compose-review.test.ts
@@ -35,6 +35,9 @@ vi.mock('../../utils/stdioHelpers.js', () => ({
 }));
 import { writeStdoutLine, writeStderrLine } from '../../utils/stdioHelpers.js';
 
+const runComposeReviewCommand = (argv: unknown): Promise<void> =>
+  Promise.resolve(composeReviewCommand.handler(argv as never) as void);
+
 const ghMock = vi.hoisted(() => vi.fn((..._args: string[]) => ''));
 vi.mock('./lib/gh.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./lib/gh.js')>();
@@ -347,7 +350,7 @@ function blindPlan(): string {
   return plan();
 }
 
-const FOOTER = `_— ${MODEL} via Qwen Code /review_`;
+const FOOTER = `_— ${MODEL} via Qwen Code /review (vunknown)_`;
 
 function base(overrides: Partial<ComposeReviewInput>): ComposeReviewInput {
   return {
@@ -369,6 +372,14 @@ describe('composeReview — the C/S table', () => {
     const r = composeReview(base({}));
     expect(r.event).toBe('APPROVE');
     expect(r.body).toBe(`No issues found. LGTM! ✅\n\n${FOOTER}`);
+  });
+
+  it('includes the injected CLI version without breaking the stable marker', () => {
+    const r = composeReview(base({}), '0.21.2');
+    expect(r.body).toContain('via Qwen Code /review');
+    expect(
+      r.body.endsWith(`_— ${MODEL} via Qwen Code /review (v0.21.2)_`),
+    ).toBe(true);
   });
 
   it('C=0, S≥1 → COMMENT with the no-blockers opener', () => {
@@ -872,7 +883,7 @@ describe('composeReview — presubmit permission gates certification even when n
 });
 
 describe('composeReviewCommand handler (the CLI glue)', () => {
-  it('reads --input, counts the drafted comments, and writes the result JSON to --out', () => {
+  it('reads --input, counts the drafted comments, and writes the result JSON to --out', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'compose-review-test-'));
     const inputPath = join(dir, 'compose.json');
     const commentsPath = join(dir, 'comments.json');
@@ -887,7 +898,7 @@ describe('composeReviewCommand handler (the CLI glue)', () => {
       ]),
       'utf8',
     );
-    (composeReviewCommand.handler as (argv: unknown) => void)({
+    await runComposeReviewCommand({
       input: inputPath,
       comments: commentsPath,
       out: outPath,
@@ -897,10 +908,12 @@ describe('composeReviewCommand handler (the CLI glue)', () => {
     ) as ComposeReviewResult;
     expect(written.event).toBe('COMMENT');
     expect(written.body).toContain('Suggestions are inline.');
-    expect(written.body.endsWith(FOOTER)).toBe(true);
+    expect(
+      written.body.endsWith(`_— ${MODEL} via Qwen Code /review (v0.21.2)_`),
+    ).toBe(true);
   });
 
-  it('routes its gh calls via the PR host — --host reaches setGhHost', () => {
+  it('routes its gh calls via the PR host — --host reaches setGhHost', async () => {
     // The bilingual body-language recovery calls `gh pr view`; on GitHub Enterprise
     // that call must hit the PR's host, or the composed body's language disagrees
     // with what `submit` (which routes by host) posts. Drop the `setGhHost(host)`
@@ -912,7 +925,7 @@ describe('composeReviewCommand handler (the CLI glue)', () => {
     writeFileSync(commentsPath, '[]', 'utf8');
     setGhHost(undefined);
     try {
-      (composeReviewCommand.handler as (argv: unknown) => void)({
+      await runComposeReviewCommand({
         input: inputPath,
         comments: commentsPath,
         host: 'github.example.com',
@@ -923,7 +936,7 @@ describe('composeReviewCommand handler (the CLI glue)', () => {
     }
   });
 
-  it('a drafted inline Critical reaches the verdict line — the report-only hole', () => {
+  it('a drafted inline Critical reaches the verdict line — the report-only hole', async () => {
     // The dogfooded failure this boundary exists for: a report-only run (no
     // submit, so nothing downstream recounts) moved its one Critical from
     // `bodyCriticals` to an inline comment, dropped the count on the way, and
@@ -947,7 +960,7 @@ describe('composeReviewCommand handler (the CLI glue)', () => {
         ]),
         'utf8',
       );
-      (composeReviewCommand.handler as (argv: unknown) => void)({
+      await runComposeReviewCommand({
         input: inputPath,
         comments: commentsPath,
         out: outPath,
@@ -969,7 +982,7 @@ describe('composeReviewCommand handler (the CLI glue)', () => {
     }
   });
 
-  it('accepts the review-payload shape too — the same file submit takes', () => {
+  it('accepts the review-payload shape too — the same file submit takes', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'compose-payload-shape-'));
     try {
       const inputPath = join(dir, 'compose.json');
@@ -984,7 +997,7 @@ describe('composeReviewCommand handler (the CLI glue)', () => {
         }),
         'utf8',
       );
-      (composeReviewCommand.handler as (argv: unknown) => void)({
+      await runComposeReviewCommand({
         input: inputPath,
         comments: commentsPath,
         out: outPath,
@@ -1003,7 +1016,7 @@ describe('composeReviewCommand handler (the CLI glue)', () => {
     ['suggestionsInline', { suggestionsInline: 2 }],
   ])(
     'refuses a state JSON carrying %s — counts are counted, not typed',
-    (_, extra) => {
+    async (_, extra) => {
       const dir = mkdtempSync(join(tmpdir(), 'compose-typed-count-'));
       try {
         const inputPath = join(dir, 'compose.json');
@@ -1014,19 +1027,19 @@ describe('composeReviewCommand handler (the CLI glue)', () => {
           'utf8',
         );
         writeFileSync(commentsPath, '[]', 'utf8');
-        expect(() =>
-          (composeReviewCommand.handler as (argv: unknown) => void)({
+        await expect(
+          runComposeReviewCommand({
             input: inputPath,
             comments: commentsPath,
           }),
-        ).toThrow(/counted from the --comments file/);
+        ).rejects.toThrow(/counted from the --comments file/);
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }
     },
   );
 
-  it('refuses a drafted comment with no severity marker — it would weigh nothing', () => {
+  it('refuses a drafted comment with no severity marker — it would weigh nothing', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'compose-unmarked-'));
     try {
       const inputPath = join(dir, 'compose.json');
@@ -1040,12 +1053,12 @@ describe('composeReviewCommand handler (the CLI glue)', () => {
         ]),
         'utf8',
       );
-      expect(() =>
-        (composeReviewCommand.handler as (argv: unknown) => void)({
+      await expect(
+        runComposeReviewCommand({
           input: inputPath,
           comments: commentsPath,
         }),
-      ).toThrow(/comments\[1\].*neither/s);
+      ).rejects.toThrow(/comments\[1\].*neither/s);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -1060,42 +1073,42 @@ describe('composeReviewCommand handler (the CLI glue)', () => {
     ],
   ])(
     'refuses %s — omission is the failure mode, not a default',
-    (_, commentsPath, pattern) => {
+    async (_, commentsPath, pattern) => {
       const dir = mkdtempSync(join(tmpdir(), 'compose-no-comments-'));
       try {
         const inputPath = join(dir, 'compose.json');
         writeFileSync(inputPath, JSON.stringify({ modelId: MODEL }), 'utf8');
-        expect(() =>
-          (composeReviewCommand.handler as (argv: unknown) => void)({
+        await expect(
+          runComposeReviewCommand({
             input: inputPath,
             comments: commentsPath,
           }),
-        ).toThrow(pattern as RegExp);
+        ).rejects.toThrow(pattern as RegExp);
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }
     },
   );
 
-  it('refuses a comments file that is not an array (nor a payload with one)', () => {
+  it('refuses a comments file that is not an array (nor a payload with one)', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'compose-bad-comments-'));
     try {
       const inputPath = join(dir, 'compose.json');
       const commentsPath = join(dir, 'comments.json');
       writeFileSync(inputPath, JSON.stringify({ modelId: MODEL }), 'utf8');
       writeFileSync(commentsPath, JSON.stringify({ criticals: 3 }), 'utf8');
-      expect(() =>
-        (composeReviewCommand.handler as (argv: unknown) => void)({
+      await expect(
+        runComposeReviewCommand({
           input: inputPath,
           comments: commentsPath,
         }),
-      ).toThrow(/must be a JSON array of comment objects/);
+      ).rejects.toThrow(/must be a JSON array of comment objects/);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  it('strips a model-supplied `env` — it cannot redirect the transcript lookup', () => {
+  it('strips a model-supplied `env` — it cannot redirect the transcript lookup', async () => {
     // The input is a JSON the model wrote. `env` decides where the harness
     // transcripts are read from; if the handler honoured it, a model could point
     // it at a directory of transcripts it fabricated — the whole gate reopened
@@ -1189,7 +1202,7 @@ describe('composeReviewCommand handler (the CLI glue)', () => {
       const prevProj = process.env['QWEN_CODE_PROJECT_DIR'];
       delete process.env['QWEN_CODE_PROJECT_DIR']; // real env cannot find transcripts
       try {
-        (composeReviewCommand.handler as (argv: unknown) => void)({
+        await runComposeReviewCommand({
           input: inputPath,
           comments: commentsPath,
           out: outPath,
@@ -1633,7 +1646,7 @@ describe('coverage is recomputed, never accepted', () => {
     expect(r.body).toContain('never opened its brief, so it reviewed without');
   });
 
-  it('the handler prints every FIX to stderr, before the verdict, never to stdout', () => {
+  it('the handler prints every FIX to stderr, before the verdict, never to stdout', async () => {
     // The array on the result is data; the command boundary is the interface the
     // orchestrator actually reads. Without this, rerouting FIX lines to stdout
     // (corrupting the JSON callers parse) or printing them after `Verdict:` (so
@@ -1662,7 +1675,7 @@ describe('coverage is recomputed, never accepted', () => {
     try {
       vi.mocked(writeStderrLine).mockClear();
       vi.mocked(writeStdoutLine).mockClear();
-      (composeReviewCommand.handler as (a: Record<string, unknown>) => void)({
+      await runComposeReviewCommand({
         input,
         comments: commentsPath,
       });
@@ -2464,7 +2477,7 @@ describe('bilingual body — recovered from the live PR when the plan omits the 
     expect(r.body).toContain('<details>\n<summary>中文说明</summary>');
   });
 
-  it('strips a model-supplied prBodyFetcher — it cannot suppress the Chinese fold', () => {
+  it('strips a model-supplied prBodyFetcher — it cannot suppress the Chinese fold', async () => {
     // The handler deletes prBodyFetcher from the input JSON (the same way it
     // deletes env). Without that delete, "suppress" reaches bilingualFromPlan,
     // is called as a function, throws, and the catch drops the fold — the exact
@@ -2489,7 +2502,7 @@ describe('bilingual body — recovered from the live PR when the plan omits the 
       const commentsPath = join(handlerDir, 'comments.json');
       writeFileSync(commentsPath, '[]', 'utf8');
       const outPath = join(handlerDir, 'out.json');
-      (composeReviewCommand.handler as (argv: unknown) => void)({
+      await runComposeReviewCommand({
         input: inputPath,
         comments: commentsPath,
         out: outPath,

--- a/packages/cli/src/commands/review/compose-review.ts
+++ b/packages/cli/src/commands/review/compose-review.ts
@@ -24,6 +24,7 @@ import type { CommandModule } from 'yargs';
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { writeStdoutLine, writeStderrLine } from '../../utils/stdioHelpers.js';
+import { getCliVersion } from '../../utils/version.js';
 import {
   coverageFromTranscripts,
   verificationGaps,
@@ -233,7 +234,10 @@ function toBool(value: unknown, field: string): boolean {
   return value;
 }
 
-export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
+export function composeReview(
+  input: ComposeReviewInput,
+  cliVersion = 'unknown',
+): ComposeReviewResult {
   const criticalsInline = toCount(input.criticalsInline, 'criticalsInline');
   const suggestionsInline = toCount(
     input.suggestionsInline,
@@ -692,7 +696,7 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
     }
   }
 
-  const footer = `_— ${modelId} via Qwen Code /review_`;
+  const footer = `_— ${modelId} via Qwen Code /review (v${cliVersion})_`;
   // Bilingual rendering: when the plan (fetch-pr's report) says the PR
   // description contains Han characters, the posted body carries the complete
   // Chinese version collapsed under the English one — the shape this repo's
@@ -1487,7 +1491,7 @@ export const composeReviewCommand: CommandModule = {
           'GitHub Enterprise host (routes gh via GH_HOST) — needed only when ' +
           'the bilingual body-language recovery has to fetch the PR description',
       }),
-  handler: (argv) => {
+  handler: async (argv) => {
     const { input, comments, out, host } =
       argv as unknown as ComposeReviewCliArgs;
     // Route this command's own `gh` call — the bilingual recovery's `gh pr view`
@@ -1540,10 +1544,13 @@ export const composeReviewCommand: CommandModule = {
       );
     }
     const drafted = readDraftedComments(comments);
-    const result = composeReview({
-      ...parsed,
-      ...countInlineFindings(drafted),
-    });
+    const result = composeReview(
+      {
+        ...parsed,
+        ...countInlineFindings(drafted),
+      },
+      await getCliVersion(),
+    );
     // The exact terminal verdict, persisted beside the fields it is computed
     // from. `event` + `cappedBy` alone cannot reconstruct it — a presubmit
     // downgrade also depends on `downgraded`/`downgradedFrom` — and Step 8's

--- a/packages/cli/src/commands/review/pr-context.test.ts
+++ b/packages/cli/src/commands/review/pr-context.test.ts
@@ -181,13 +181,18 @@ describe('fullCommentBody', () => {
 });
 
 describe('isReviewWorthShowing', () => {
-  const FOOTER = '_— qwen3.7-max via Qwen Code /review_';
+  const LEGACY_FOOTER = '_— qwen3.7-max via Qwen Code /review_';
+  const VERSIONED_FOOTER =
+    '_— qwen3.8-max-preview via Qwen Code /review (v0.21.2)_';
 
-  it('filters the exact canonical LGTM template, with or without the footer', () => {
+  it('filters the exact canonical LGTM template, with or without either footer', () => {
     expect(isReviewWorthShowing('No issues found. LGTM! ✅')).toBe(false);
-    expect(isReviewWorthShowing(`No issues found. LGTM! ✅\n\n${FOOTER}`)).toBe(
-      false,
-    );
+    expect(
+      isReviewWorthShowing(`No issues found. LGTM! ✅\n\n${LEGACY_FOOTER}`),
+    ).toBe(false);
+    expect(
+      isReviewWorthShowing(`No issues found. LGTM! ✅\n\n${VERSIONED_FOOTER}`),
+    ).toBe(false);
     expect(isReviewWorthShowing('')).toBe(false);
     expect(isReviewWorthShowing(undefined)).toBe(false);
   });

--- a/packages/cli/src/commands/review/pr-context.ts
+++ b/packages/cli/src/commands/review/pr-context.ts
@@ -419,7 +419,7 @@ export function findRootId<
  * file, letting the re-check approve past the blocker.
  */
 const CANONICAL_LGTM_RE =
-  /^No issues found\.?\s*LGTM!?\s*(?:✅\s*)?(?:_— [^\n]{0,200} via Qwen Code \/review_\s*)?$/i;
+  /^No issues found\.?\s*LGTM!?\s*(?:✅\s*)?(?:_— [^\n]{0,200} via Qwen Code \/review(?: \(v[^\n]{1,100}\))?_\s*)?$/i;
 
 /**
  * Should this review-level summary be shown to agents?

--- a/packages/cli/src/commands/review/submit.test.ts
+++ b/packages/cli/src/commands/review/submit.test.ts
@@ -393,6 +393,15 @@ describe('payload consistency — refuse before GitHub sees it', () => {
     expect(posted().comments).toEqual([]);
   });
 
+  it('posts the injected CLI version in the review footer', () => {
+    runSubmit(authorized({}), '0.21.2');
+
+    expect(posted().body).toContain('via Qwen Code /review');
+    expect(
+      posted().body.endsWith('_— qwen3.7-max via Qwen Code /review (v0.21.2)_'),
+    ).toBe(true);
+  });
+
   it('counts the blockers it is actually carrying, not the ones it was told about', () => {
     // A Critical attached inline is a Critical, whatever the state says. There is
     // no `criticalsInline` field to under-report it with — and one supplied

--- a/packages/cli/src/commands/review/submit.ts
+++ b/packages/cli/src/commands/review/submit.ts
@@ -47,6 +47,7 @@ import type { CommandModule } from 'yargs';
 import { atomicWriteFileSync } from '@qwen-code/qwen-code-core';
 import { mkdirSync, readFileSync } from 'node:fs';
 import { writeStdoutLine, writeStderrLine } from '../../utils/stdioHelpers.js';
+import { getCliVersion } from '../../utils/version.js';
 import { ghWithInput, setGhHost } from './lib/gh.js';
 import { REVIEW_TMP_DIR, tmpFile } from './lib/paths.js';
 import { parseReceiptIds } from './lib/receipt.js';
@@ -276,7 +277,10 @@ function authorization(args: SubmitArgs): { ok: boolean; why: string } {
  * handed over beside the comments, and a number beside a thing is a number that can
  * disagree with it.
  */
-function compose(payload: ReviewPayload): {
+function compose(
+  payload: ReviewPayload,
+  cliVersion: string,
+): {
   event: string;
   body: string;
   cappedBy: string[];
@@ -296,11 +300,14 @@ function compose(payload: ReviewPayload): {
   void _dropped;
   void _droppedFetcher;
 
-  const r = composeReview({
-    ...rest,
-    criticalsInline,
-    suggestionsInline,
-  });
+  const r = composeReview(
+    {
+      ...rest,
+      criticalsInline,
+      suggestionsInline,
+    },
+    cliVersion,
+  );
   return { event: r.event, body: r.body, cappedBy: r.cappedBy };
 }
 
@@ -430,7 +437,7 @@ function isRepo(repo: string): boolean {
   );
 }
 
-export function runSubmit(args: SubmitArgs): void {
+export function runSubmit(args: SubmitArgs, cliVersion = 'unknown'): void {
   setGhHost(args.host);
 
   // The repo goes straight into the API path. A malformed value does not fail
@@ -494,7 +501,7 @@ export function runSubmit(args: SubmitArgs): void {
   let body: string;
   let cappedBy: string[];
   try {
-    ({ event, body, cappedBy } = compose(payload));
+    ({ event, body, cappedBy } = compose(payload, cliVersion));
   } catch (err) {
     throw new Error(
       `The review state does not compose into a verdict; refusing to post:\n` +
@@ -637,7 +644,7 @@ export const submitCommand: CommandModule = {
         default: false,
         describe: 'Check authorisation and payload consistency, then stop.',
       }),
-  handler: (argv) => {
-    runSubmit(argv as unknown as SubmitArgs);
+  handler: async (argv) => {
+    runSubmit(argv as unknown as SubmitArgs, await getCliVersion());
   },
 };

--- a/packages/cli/src/services/BundledSkillLoader.test.ts
+++ b/packages/cli/src/services/BundledSkillLoader.test.ts
@@ -49,6 +49,7 @@ describe('BundledSkillLoader', () => {
       getSkillManager: vi.fn().mockReturnValue(mockSkillManager),
       isCronEnabled: vi.fn().mockReturnValue(false),
       getModel: vi.fn().mockReturnValue(undefined),
+      getCliVersion: vi.fn().mockReturnValue('0.21.2'),
       getPermissionManager: vi
         .fn()
         .mockReturnValue({ addSessionAllowRule: mockAddSessionAllowRule }),
@@ -338,6 +339,25 @@ describe('BundledSkillLoader', () => {
           ),
         },
       ],
+    });
+  });
+
+  it('should resolve the CLI version template variable in skill body', async () => {
+    const skill = makeSkill({
+      body: 'via Qwen Code /review (v{{cliVersion}})',
+    });
+    mockSkillManager.listSkills.mockResolvedValue([skill]);
+
+    const loader = new BundledSkillLoader(mockConfig);
+    const commands = await loader.loadCommands(signal);
+    const result = await commands[0].action!(
+      { invocation: { raw: '/review', args: '' } } as never,
+      '',
+    );
+
+    expect(result).toEqual({
+      type: 'submit_prompt',
+      content: [{ text: makeSkillPrompt('via Qwen Code /review (v0.21.2)') }],
     });
   });
 

--- a/packages/cli/src/services/BundledSkillLoader.ts
+++ b/packages/cli/src/services/BundledSkillLoader.ts
@@ -107,6 +107,8 @@ export class BundledSkillLoader implements ICommandLoader {
           // Resolve template variables in skill body
           let body = skill.body;
           const modelId = this.config?.getModel()?.trim() || '';
+          const cliVersion = this.config?.getCliVersion()?.trim() || 'unknown';
+          body = body.replaceAll('{{cliVersion}}', cliVersion);
           if (body.includes('{{model}}') || body.includes('YOUR_MODEL_ID')) {
             body = body.replaceAll('{{model}}', modelId);
             body = body.replaceAll('YOUR_MODEL_ID', modelId);

--- a/packages/core/src/skills/bundled/review/SKILL.md
+++ b/packages/core/src/skills/bundled/review/SKILL.md
@@ -860,12 +860,12 @@ Rationale: an inline comment is the only place GitHub renders a ` ```suggestion 
     {
       "path": "src/file.ts",
       "line": 42,
-      "body": "**[Critical]** issue description — Failure scenario: <trigger> → <wrong outcome>\n\n```suggestion\nfix code\n```\n\n_— YOUR_MODEL_ID via Qwen Code /review_",
+      "body": "**[Critical]** issue description — Failure scenario: <trigger> → <wrong outcome>\n\n```suggestion\nfix code\n```\n\n_— YOUR_MODEL_ID via Qwen Code /review (v{{cliVersion}})_",
     },
     {
       "path": "src/other.ts",
       "line": 88,
-      "body": "**[Suggestion]** recommended improvement — Concrete cost: <what is duplicated/wasted/fragile>\n\n```suggestion\nimproved code\n```\n\n_— YOUR_MODEL_ID via Qwen Code /review_",
+      "body": "**[Suggestion]** recommended improvement — Concrete cost: <what is duplicated/wasted/fragile>\n\n```suggestion\nimproved code\n```\n\n_— YOUR_MODEL_ID via Qwen Code /review (v{{cliVersion}})_",
     },
   ],
   "state": {
@@ -904,7 +904,7 @@ The verdict is a computed fact and this is the second place it must not be re-de
 
   When `startLine === line`, emit only `"line"` — a single-line comment needs no side (it defaults to `RIGHT`, which is what every comment here is). Do **not** send `start_line` on its own: the multi-line form that omits `start_side` is the one shape of this feature that fails, and it fails by discarding every inline blocker in the review.
 
-- Comment body format: `**[Critical]** issue description — Failure scenario: <trigger> → <wrong outcome>\n\n```suggestion\nfix\n```\n\n_— YOUR_MODEL_ID via Qwen Code /review_` — use the `**[Suggestion]**` prefix for Suggestion-level findings so the author can tell blockers from recommendations at a glance. The `description` MUST carry the finding's concrete failure scenario (the trigger and the wrong outcome, or the concrete cost) — a posted comment that says only what to change, without why it fails, has lost the evidence the finder was required to produce. The prefix must be the **first thing in the body** and the footer must be present: `.github/workflows/qwen-autofix.yml` keys off both to keep Suggestion findings out of the autofix loop. Changing either string silently makes the autofix bot start applying non-blocking suggestions.
+- Comment body format: `**[Critical]** issue description — Failure scenario: <trigger> → <wrong outcome>\n\n```suggestion\nfix\n```\n\n_— YOUR_MODEL_ID via Qwen Code /review (v{{cliVersion}})_` — use the `**[Suggestion]**` prefix for Suggestion-level findings so the author can tell blockers from recommendations at a glance. The `description` MUST carry the finding's concrete failure scenario (the trigger and the wrong outcome, or the concrete cost) — a posted comment that says only what to change, without why it fails, has lost the evidence the finder was required to produce. The prefix must be the **first thing in the body** and the footer must be present: `.github/workflows/qwen-autofix.yml` keys off both to keep Suggestion findings out of the autofix loop. Changing either string silently makes the autofix bot start applying non-blocking suggestions.
 - The model name is declared at the top of this prompt. You MUST include it in every footer. Do NOT omit the model name.
 - Use ` ```suggestion ` for one-click fixes; regular code blocks if fix spans multiple locations.
 - Only ONE comment per unique issue.


### PR DESCRIPTION
## What this PR does

Adds the running Qwen Code CLI version to `/review` attribution footers for both review summaries and inline findings while preserving the stable `via Qwen Code /review` marker used to recognize review output. The generated footer now reads like `_— qwen3.8-max-preview via Qwen Code /review (v0.21.2)_`. It also keeps historical unversioned LGTM summaries compatible with review-context filtering and updates the user documentation.

## Why it's needed

Model attribution alone cannot identify which `/review` implementation and prompt produced a finding. Including the CLI version makes review output traceable to a specific Qwen Code release, which helps diagnose regressions, false positives, and behavior changes across releases.

## Reviewer Test Plan

### How to verify

Run `/review` or invoke `qwen review compose-review` with a minimal state and comments file. Confirm that non-empty review summaries end with the model, the stable `via Qwen Code /review` marker, and the running CLI version in parentheses. Confirm that the bundled review prompt expands the CLI version in inline-comment footer examples, and that both historical unversioned and new versioned canonical LGTM summaries remain filtered from review context.

Automated verification completed locally: 259 focused unit tests passed across review composition, submission, PR context, and bundled skill loading; targeted ESLint and Prettier checks passed; `npm run build && npm run typecheck` passed; and the built CLI was exercised directly to confirm a `v0.21.2` footer.

### Evidence (Before & After)

Before: `_— qwen3.8-max-preview via Qwen Code /review_`

After: `_— qwen3.8-max-preview via Qwen Code /review (v0.21.2)_`

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS with Node.js 22.22.2. Verification used the monorepo build, focused Vitest suites, targeted ESLint/Prettier checks, and the built CLI entry point.

## Risk & Scope

- Main risk or tradeoff: Consumers that parse the entire footer as an exact string may need to tolerate the appended version, while the existing stable recognition substring is intentionally preserved.
- Not validated / out of scope: No Windows or Linux local runtime verification was performed; CI remains responsible for those platforms.
- Breaking changes / migration notes: No API or configuration migration is required. Historical unversioned review comments remain supported.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 的改动

为 `/review` 的 review summary 和 inline finding 署名增加当前运行的 Qwen Code CLI 版本，同时保留用于识别 review 输出的稳定标记 `via Qwen Code /review`。新的署名形式例如 `_— qwen3.8-max-preview via Qwen Code /review (v0.21.2)_`。同时继续兼容历史上不带版本号的 LGTM summary 过滤逻辑，并更新用户文档。

## 为什么需要

仅有模型署名无法判断一条 finding 是由哪个 `/review` 实现和 prompt 版本生成的。增加 CLI 版本后，可以把 review 输出追溯到具体的 Qwen Code 发布版本，便于诊断版本间的回归、误报和行为变化。

## Reviewer 测试计划

### 如何验证

运行 `/review`，或使用最小 state 和 comments 文件调用 `qwen review compose-review`。确认非空 review summary 以模型名、稳定标记 `via Qwen Code /review` 和括号中的当前 CLI 版本结尾。确认 bundled review prompt 会在 inline comment footer 示例中展开 CLI 版本，并确认历史无版本和新版带版本的 canonical LGTM summary 都会继续从 review context 中过滤。

本地自动验证结果：review composition、submission、PR context 和 bundled skill loading 的 259 个定向单元测试全部通过；定向 ESLint 和 Prettier 检查通过；`npm run build && npm run typecheck` 通过；并直接运行构建后的 CLI，确认输出包含 `v0.21.2` footer。

### 证据（改动前后）

改动前：`_— qwen3.8-max-preview via Qwen Code /review_`

改动后：`_— qwen3.8-max-preview via Qwen Code /review (v0.21.2)_`

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS，Node.js 22.22.2。验证包括 monorepo build、定向 Vitest、定向 ESLint/Prettier，以及构建后的 CLI 入口。

## 风险与范围

- 主要风险或取舍：如果下游按完整字符串精确解析 footer，需要兼容追加的版本号；现有稳定识别子串会继续保留。
- 未验证或不在范围内：未在本地进行 Windows 或 Linux 运行时验证，由 CI 覆盖这些平台。
- 破坏性变更或迁移说明：不需要 API 或配置迁移，历史无版本的 review comment 仍然兼容。

## 关联 Issue

N/A

</details>
