### PR TITLE
feat(verify): check the accepting end, and separate empty from unmeasured

### DIFF
--- a/.qwen/skills/verify-pr/SKILL.md
+++ b/.qwen/skills/verify-pr/SKILL.md
@@ -193,7 +193,12 @@ differs only by the change under test; the verdict is the pair of counts.
   object, and astral inputs, and lossy results (e.g. `String({})` →
   `"[object Object]"`) are called out in Findings even when every scripted
   assertion passes. A fix that holds only for the reported input shape is a
-  finding, not a pass.
+  finding, not a pass. (This overlaps the next bullet, and the overlap is
+  deliberate: the sibling-sweep text below is the one rule in this file with
+  a measured before/after behind it, so it stays byte-identical to the
+  instrument the arms actually read. Consolidating the pair means editing
+  that instrument, which is a change to make with a fresh measurement, not
+  on the way past.)
 - **A fix that closes one instance of a bug class gets its siblings
   swept.** When the mechanism is a parser, sanitizer, matcher, or state
   machine, the reported input is one door into a room with several:
@@ -328,6 +333,18 @@ differs only by the change under test; the verdict is the pair of counts.
   — lazily-created backing files (`ensureConversationFile()` writes nothing
   until the first prompt) leave a window in which a just-created entity is
   invisible to any existence check that looks on disk.
+- **A capability has two ends — check the one that accepts, not only the one
+  that issues.** Where the PR gates who may _mint_ a credential, token,
+  cookie, or permit, find the code that _accepts_ it and check that the same
+  condition guards it. The two drift because they are written at different
+  times by different concerns, and the tell is that the tests are named after
+  the gated end, which makes the ungated end look covered. Measured example:
+  a cookie→`Authorization` bridge was correctly gated to a desktop shell on
+  the minting side, while the accepting middleware was mounted
+  unconditionally — so every server instance treated that cookie as a
+  bearer. Bound it as usual: no exploit was demonstrated, but `SameSite`
+  does not separate `127.0.0.1:<other-port>` from the daemon's port, because
+  for an IP host the "site" ignores the port.
 - **Measure the blast radius on bystanders, not just on the caller.** When a
   failure path can take down shared infrastructure, the interesting number
   is what happened to everything else: an unrelated session going
@@ -374,6 +391,25 @@ differs only by the change under test; the verdict is the pair of counts.
   fix first. This is the same ordering as the concurrency rule above, where
   a race that fabricates a result outranks one that crashes: a wrong answer
   nobody is told about outranks a failure that announces itself.
+- **"Nothing found" and "could not measure" must be different values — then
+  check what consumes them.** A single sentinel covering both turns a broken
+  probe into a confident negative, and the damage is done by the consumer,
+  not the flag. Measured example: an `emptyDiff` flag was set both when a PR
+  genuinely had no changes and when the diff **capture failed**, and the
+  downstream skill responded to it by recommending the PR be closed as
+  superseded — so a transient fetch error could close live work. Trace every
+  such flag to its readers and say what each does with it; the same rule the
+  verdict contract already applies to this report (a harness that failed is
+  `inconclusive`, never `merge-ready` and never `findings`) applies to the
+  code under test.
+- **A validity control must run before the artifact it invalidates is
+  built.** When the PR adds a sanity check — a control arm, a baseline
+  probe, a health assertion — find where in the sequence it runs relative to
+  the output it is supposed to suppress. Measured example: a re-classifier
+  that demotes findings from a dead harness ran _after_ the findings list
+  was assembled, so a harness proven dead still filed `mutant-survived`
+  against the author. Order is the whole property here: a control that runs
+  late is not a weaker control, it is not a control at all.
 
 ### Scoping from the report and the plan
 

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -3114,6 +3114,28 @@ describe('qwen-triage verify hardening round 2', () => {
     expect(flat).toContain(
       'A surviving mutation needs a positive control before it becomes a',
     );
+
+    // #8132: a cookie->Authorization bridge was gated to the desktop shell
+    // on the MINTING side, while the accepting middleware was mounted
+    // unconditionally, so every server treated that cookie as a bearer. The
+    // tests were named after the gated end, which is what made the ungated
+    // end look covered.
+    expect(flat).toContain('A capability has two ends');
+    expect(flat).toContain('tests are named after the gated end');
+
+    // #8261: `emptyDiff` was set both for a genuinely empty PR and for a
+    // FAILED diff capture, and the consumer answered it by recommending the
+    // PR be closed as superseded — a transient fetch error closing live
+    // work. The flag is not the defect; the consumer is.
+    expect(flat).toContain('must be different values');
+    expect(flat).toContain('check what consumes them');
+
+    // #8261: the re-classifier that demotes a dead harness's findings ran
+    // after the findings list was assembled, so a harness proven dead still
+    // filed `mutant-survived`. A control that runs late is not a control.
+    expect(flat).toContain(
+      'A validity control must run before the artifact it invalidates',
+    );
   });
 
   // PR #7836's report said "Verdict: merge-ready — the 7 failures are all


### PR DESCRIPTION
## Why this is a separate PR

These three rules were pushed to #8242's branch at 06:53, and #8242 merged at 06:00. The commit landed on a closed branch and never reached `main` — `git merge-base --is-ancestor` says so, and none of the three phrases appear in `main`'s `SKILL.md`. Same content, re-cut on current `main`.

## Change

Three rules from maintainer verification rounds on #8132 and #8261. A deliberate subset: `SKILL.md` is 2.4× its size six days ago and nothing gates its growth, so the other techniques those rounds produced (a PR body describing a head that autofix rounds since removed, a dead CSS rule invalidating a specific test-plan step) were dropped as too close to existing bullets.

**A capability has two ends — check the one that accepts, not only the one that issues.** #8132 found a cookie→`Authorization` bridge correctly gated to the desktop shell on the *minting* side and mounted **unconditionally** on the *accepting* side, so every server instance treated that cookie as a bearer. The generalisable tell is why it hid: the tests were named after the gated end, which makes the ungated end look covered. Bounded the way the file already asks: no exploit was demonstrated, but `SameSite` does not separate `127.0.0.1:<other-port>` from the daemon's port, because for an IP host the "site" ignores the port.

**"Nothing found" and "could not measure" must be different values — then check what consumes them.** #8261 set `emptyDiff` both for a genuinely empty PR and for a diff capture that **failed**, and the consuming skill answered that flag by recommending the PR be closed as superseded. A transient fetch error could close live work. The damage is done by the consumer, not the flag — which is why the rule ends at the readers. The verdict contract already applies this to our own report (`inconclusive`, never `merge-ready`, never `findings`); the code under test gets it too.

**A validity control must run before the artifact it invalidates is built.** #8261's re-classifier demoted findings from a dead harness *after* the findings list was assembled, so a harness proven dead still filed `mutant-survived` against the author. Order is the whole property: a control that runs late is not a weaker control, it is not a control.

## The consolidation the review asked for — one done, one deliberately not

[#8242's review](https://github.com/QwenLM/qwen-code/pull/8242) named two overlapping pairs.

The first resolved itself: an autofix round moved the observability-ranking bullet next to the concurrency rule it cites, and the two are now 100 lines apart and saying different things (disproving worse readings, versus ranking variants by observability).

The second I merged and then **reverted**, with a note in the file saying why. The type-boundary bullet does overlap the sibling-sweep bullet directly below it — but sibling-sweep is the **one rule in this file with a measured before/after behind it**, and consolidating means editing that text. Verified against the staged arm copy still on disk (`skill-armB.md`, `sha256:82dff804…`): the bullet at this head is **byte-identical** to what the treatment arm read. Editing the instrument is a change to make with a fresh measurement, not on the way past. The redundancy stays and the file now says that out loud.

## Tests

Three assertions, each mutation-checked — neutering any one of the pinned phrases turns the suite red:

| mutation | result |
| --- | --- |
| `A capability has two ends` neutered | **caught** |
| `must be different values` neutered | **caught** |
| `A validity control must run before the artifact it invalidates` neutered | **caught** |
| unmutated | green |

`scripts/tests/qwen-triage-workflow.test.js` 119/119 on current `main`; prettier, eslint `--max-warnings 0` clean.

<details>
<summary>中文说明</summary>

## 为什么是一个独立 PR

这三条规则在 06:53 推到了 #8242 的分支，而 #8242 在 06:00 就已合并。该提交落在了一个已关闭的分支上，从未进入 `main`——`git merge-base --is-ancestor` 如此判定，且这三条短语在 `main` 的 `SKILL.md` 中均无命中。内容相同，在当前 `main` 上重新切出。

## 改动

取自 #8132 与 #8261 两轮维护者验证的三条规则。这是有意的取舍：`SKILL.md` 已是六天前的 2.4 倍，且没有任何东西约束其增长，因此那两轮产出的其余手法（PR 描述停留在 autofix 已删除的旧 head、死 CSS 规则导致某条 test-plan 步骤不成立）因与现有条目过于接近而未收入。

**能力有两端——检查"接收"那端，而不只是"签发"那端。** #8132 发现一个 cookie→`Authorization` 桥在**铸造**侧正确地限定给桌面外壳，在**接收**侧却是**无条件**挂载的，于是每个 server 实例都把该 cookie 当作 bearer。可推广的线索正是它得以藏身的原因：测试是按被门禁的那一端命名的，这让没有门禁的那端看起来已被覆盖。并按本文件既有要求做了有界化：未演示出可利用的攻击，但 `SameSite` 无法区分 `127.0.0.1:<其他端口>` 与守护进程端口——对 IP 主机而言，「site」忽略端口。

**「没找到」与「没测成」必须是不同的值——然后查下游拿它做什么。** #8261 的 `emptyDiff` 在「PR 确实没有改动」与「diff 捕获**失败**」两种情况下都会置位，而消费该标志的 skill 的回应是建议将该 PR 作为 superseded 关闭。一次瞬时的抓取错误就可能关掉仍在进行的工作。伤害由消费者造成，而非标志本身——这正是该规则要落到读取方的原因。裁决契约本就对我们自己的报告施加了这一条（`inconclusive`，绝不是 `merge-ready`，也绝不是 `findings`）；被验证的代码同样适用。

**有效性控制必须在它所要作废的产物**被构建**之前**运行。** #8261 的重分类器在 findings 列表组装完成**之后**才降级来自已死 harness 的发现，于是一个被证明已死的 harness 仍然向作者提交了 `mutant-survived`。顺序就是这条性质的全部：跑晚了的控制不是"弱一点的控制"，而是根本不成其为控制。

## 评审要求的两处合并——一处完成，一处刻意保留

[#8242 的评审](https://github.com/QwenLM/qwen-code/pull/8242)点名了两处重叠。

第一处自行解决了：一次 autofix 轮次把「可观测性排序」条目挪到了它所引用的并发规则旁边，如今两者相隔 100 行，且讲的是不同的事（证伪更坏的读法 vs 按可观测性对变体排序）。

第二处我先合并、随后**回退**了，并在文件中留下了说明。type-boundary 条目确实与紧随其下的 sibling-sweep 条目重叠——但 sibling-sweep 是**本文件中唯一有实测 before/after 支撑的规则**，合并就意味着编辑那段文本。对照磁盘上留存的臂副本（`skill-armB.md`，`sha256:82dff804…`）验证：本 head 上的该条目与处理臂实际读到的**逐字节一致**。改动仪器需要配一次新的测量，而不是顺手为之。冗余予以保留，且文件现在把这一点明说了出来。

## 测试

三条断言，各自做了变异检查——中和其中任意一条被钉住的短语都会让套件变红：

| 变异 | 结果 |
| --- | --- |
| 中和 `A capability has two ends` | **被捕获** |
| 中和 `must be different values` | **被捕获** |
| 中和 `A validity control must run before the artifact it invalidates` | **被捕获** |
| 未变异 | 绿 |

在当前 `main` 上 `scripts/tests/qwen-triage-workflow.test.js` 119/119；prettier、eslint `--max-warnings 0` 均干净。

</details>
