### PR TITLE
docs: document skill learning and live reload

### DIFF
--- a/docs/users/features/commands.md
+++ b/docs/users/features/commands.md
@@ -83,6 +83,7 @@ Commands for managing AI tools and models.
 | `/import-config`  | Import MCP servers from Claude configs                                                | `/import-config all`, `/import-config claude-code`, `/import-config claude-desktop --scope user\|project` |
 | `/tools`          | Display currently available tool list                                                 | `/tools`, `/tools desc`                                                                                   |
 | `/skills`         | Open the Skills panel to browse, search, toggle, and launch skills                    | `/skills`, `/<skill-name>`                                                                                |
+| `/learn`          | Create a reusable project skill from a file, directory, URL, video, or text           | `/learn https://docs.example.com/api`, `/learn ./tutorial.mp4 focus on deployment`                        |
 | `/curator`        | Inspect, pin, archive, or restore inactive project auto-skills                        | `/curator`, `/curator run --dry-run`, `/curator pin <directory>`, `/curator restore <directory>`          |
 | `/plan`           | Switch to plan mode or exit plan mode                                                 | `/plan`, `/plan <task>`, `/plan exit`                                                                     |
 | `/approval-mode`  | Change the tool-approval mode (current session only)                                  | `/approval-mode`, `/approval-mode auto-edit`                                                              |

--- a/docs/users/features/skills.md
+++ b/docs/users/features/skills.md
@@ -38,6 +38,33 @@ Start typing `/` to autocomplete and browse available Skills alongside their des
 
 Skills are stored as directories containing a `SKILL.md` file.
 
+### Generate a project Skill with `/learn`
+
+Use `/learn` to distill an existing knowledge source into a reusable project
+Skill:
+
+```text
+/learn https://docs.example.com/api
+/learn ~/projects/acme-sdk
+/learn Our deploy process: run migrate, deploy the service, then check health
+```
+
+The command runs as a normal agent turn and creates the result under
+`.qwen/skills/learned-skill-<name>/SKILL.md` with `source: learned` in its
+frontmatter. Review the generated instructions before using or sharing them.
+
+`/learn` also accepts local or direct-link `.mp4`, `.webm`, `.mov`, and `.m4v`
+videos. Add text after the path or URL to focus the generated Skill on one part
+of the tutorial:
+
+```text
+/learn ./tutorial.mp4 focus on the deployment workflow
+```
+
+Video learning requires a video-capable model on an OpenAI-compatible provider.
+YouTube page URLs are not direct video input; download the video into the
+workspace and pass its local path instead.
+
 ### Personal Skills
 
 Personal Skills are available across all your projects. Store them in `~/.qwen/skills/`:
@@ -197,6 +224,7 @@ Qwen Code discovers Skills from:
 - Personal Skills: `~/.qwen/skills/`
 - Project Skills: `.qwen/skills/`
 - Extension Skills: Skills provided by installed extensions
+- Bundled Skills: Skills shipped with Qwen Code
 
 ### Extension Skills
 
@@ -324,7 +352,10 @@ code ~/.qwen/skills/my-skill/SKILL.md
 code .qwen/skills/my-skill/SKILL.md
 ```
 
-Changes take effect the next time you start Qwen Code. If Qwen Code is already running, restart it to load the updates.
+During a normal session, Qwen Code watches personal and project Skill
+directories. Adding, editing, or removing a Skill refreshes the Skill list and
+invocation state automatically after a short delay. Bare mode does not start
+these watchers, so restart Qwen Code to load Skill changes in that mode.
 
 ## Remove a Skill
 


### PR DESCRIPTION
## What this PR does

Documents the built-in `/learn` workflow, including supported knowledge sources, the generated project Skill location and marker, video requirements, and the YouTube limitation. It also adds bundled Skills to the documented discovery sources and corrects the update guidance so personal and project Skill edits are described as hot-reloaded during normal sessions, with the restart requirement limited to bare mode. The command reference now includes `/learn`.

## Why it's needed

The documentation omitted a shipped user-facing command and one of the four Skill discovery levels. It also said every Skill edit required a restart even though normal sessions watch personal and project Skill directories. Users could therefore miss the supported Skill-generation workflow or restart Qwen Code unnecessarily.

## Reviewer Test Plan

### How to verify

1. Confirm the command reference lists `/learn` as a built-in way to create a reusable project Skill from a file, directory, URL, video, or text.
2. Compare the expanded Skill guidance with the current command behavior: generated Skills use the learned-Skill location and marker, direct video inputs support the documented extensions, video input requires a compatible model and provider, and YouTube page URLs must be downloaded first.
3. Confirm the discovery list covers personal, project, extension, and bundled Skills, and that the update guidance distinguishes normal hot reload from bare-mode restart behavior.

### Evidence (Before & After)

N/A — documentation-only change with no TUI or runtime behavior changes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

macOS with Node.js 24.18.0 in a local npm workspace.

## Risk & Scope

- Main risk or tradeoff: Documentation could drift from runtime behavior; the new claims were checked against the command implementation, Skill discovery and watcher implementation, and their focused unit tests.
- Not validated / out of scope: No live TUI capture or end-to-end model call was run because the change does not modify runtime behavior.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

补充内置 `/learn` 工作流的文档，包括支持的知识来源、生成的项目 Skill 位置与标记、视频要求以及 YouTube 限制。同时把 bundled Skills 加入已记录的发现来源，并纠正 Skill 更新说明：普通会话会热加载 personal 和 project Skill 的修改，只有 bare mode 需要重启。命令参考中也新增了 `/learn`。

## 为什么需要

现有文档遗漏了一个已经发布的用户命令，也漏掉了四种 Skill 发现层级中的 bundled 层级。此外，文档称每次编辑 Skill 都必须重启，但普通会话实际上会监听 personal 和 project Skill 目录。这会导致用户不知道已有的 Skill 生成工作流，或不必要地重启 Qwen Code。

## 审阅者测试计划

### 如何验证

1. 确认命令参考将 `/learn` 列为从文件、目录、URL、视频或文本创建可复用项目 Skill 的内置方式。
2. 将扩展后的 Skill 指南与当前命令行为对照：生成的 Skill 使用 learned-Skill 位置与标记；直接视频输入支持文档列出的扩展名；视频输入需要兼容的模型和 Provider；YouTube 页面 URL 必须先下载。
3. 确认发现来源覆盖 personal、project、extension 和 bundled Skills，并且更新说明区分普通会话热加载与 bare mode 重启行为。

### 证据（修改前后）

N/A — 仅文档变更，不涉及 TUI 或运行时行为变化。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

macOS，Node.js 24.18.0，本地 npm workspace。

## 风险与范围

- 主要风险或权衡：文档可能与运行时行为再次发生漂移；新增说明已对照命令实现、Skill 发现与监听实现，以及对应的定向单元测试。
- 未验证 / 范围外：未运行真实 TUI 录制或端到端模型调用，因为本次变更不修改运行时行为。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

N/A

</details>
