### PR TITLE
fix(core): retry leaked JSON tool protocol output

### DIFF
--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -9443,6 +9443,176 @@ describe('GeminiChat', async () => {
     },
   );
 
+  it.each(['preparation', 'function call'] as const)(
+    'retries when a %s interrupts a partial JSON protocol leak',
+    async (middleChunkType) => {
+      const recordAssistantTurn = vi.fn();
+      const chatWithRecording = new GeminiChat(
+        mockConfig,
+        config,
+        [],
+        {
+          recordAssistantTurn,
+          recordChatCompression: vi.fn(),
+        } as unknown as ConstructorParameters<typeof GeminiChat>[3],
+        uiTelemetryService,
+      );
+      const leakedText =
+        JSON.stringify([{ name: 'read_file', file_path: 'a.ts' }]) +
+        '\n</parameter>\n</function>\n';
+      const splitAt = 12;
+      let middleResponse: GenerateContentResponse;
+      if (middleChunkType === 'preparation') {
+        middleResponse = {
+          candidates: [{ content: { parts: [] } }],
+        } as unknown as GenerateContentResponse;
+        setToolCallPreparations(middleResponse, [
+          { callId: 'call-1', toolName: 'read_file' },
+        ]);
+      } else {
+        middleResponse = {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    functionCall: {
+                      id: 'call-1',
+                      name: 'read_file',
+                      args: { file_path: 'a.ts' },
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        } as unknown as GenerateContentResponse;
+      }
+      vi.mocked(mockContentGenerator.generateContentStream)
+        .mockResolvedValueOnce(
+          streamResponse(
+            {
+              candidates: [
+                {
+                  content: { parts: [{ text: leakedText.slice(0, splitAt) }] },
+                },
+              ],
+            } as unknown as GenerateContentResponse,
+            middleResponse,
+            stopResponse([{ text: leakedText.slice(splitAt) }]),
+          ),
+        )
+        .mockResolvedValueOnce(
+          streamResponse(stopResponse([{ text: 'Successful final response' }])),
+        );
+
+      const stream = await chatWithRecording.sendMessageStream(
+        'test-model',
+        { message: 'test' },
+        'prompt-id-interrupted-json-tool-protocol-leak',
+      );
+      const events: StreamEvent[] = [];
+      for await (const event of stream) events.push(event);
+
+      expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(
+        2,
+      );
+      expect(events.some((event) => event.type === StreamEventType.RETRY)).toBe(
+        true,
+      );
+      const emittedParts = events
+        .filter((event) => event.type === StreamEventType.CHUNK)
+        .flatMap((event) => event.value.candidates?.[0]?.content?.parts ?? []);
+      expect(emittedParts).toEqual([{ text: 'Successful final response' }]);
+      expect(chatWithRecording.getLastModelMessageText()).toBe(
+        'Successful final response',
+      );
+      expect(recordAssistantTurn).toHaveBeenCalledTimes(1);
+      expect(recordAssistantTurn.mock.calls[0]?.[0].message).toEqual([
+        { text: 'Successful final response' },
+      ]);
+    },
+  );
+
+  it.each([true, false])(
+    'preserves leading JSON when a tool call ends without a finish reason (tool call first: %s)',
+    async (toolCallFirst) => {
+      const recordAssistantTurn = vi.fn();
+      const chatWithRecording = new GeminiChat(
+        mockConfig,
+        config,
+        [],
+        {
+          recordAssistantTurn,
+          recordChatCompression: vi.fn(),
+        } as unknown as ConstructorParameters<typeof GeminiChat>[3],
+        uiTelemetryService,
+      );
+      const response = JSON.stringify([{ name: 'example', value: 1 }]);
+      const splitAt = 12;
+      const functionCallPart = {
+        functionCall: {
+          id: 'call-1',
+          name: 'read_file',
+          args: { file_path: 'a.ts' },
+        },
+      };
+      const functionCallResponse = {
+        candidates: [{ content: { parts: [functionCallPart] } }],
+      } as unknown as GenerateContentResponse;
+      const textResponses = [
+        response.slice(0, splitAt),
+        response.slice(splitAt),
+      ].map(
+        (text) =>
+          ({
+            candidates: [{ content: { parts: [{ text }] } }],
+          }) as unknown as GenerateContentResponse,
+      );
+      const responses = toolCallFirst
+        ? [functionCallResponse, ...textResponses]
+        : [textResponses[0]!, functionCallResponse, textResponses[1]!];
+      vi.mocked(
+        mockContentGenerator.generateContentStream,
+      ).mockResolvedValueOnce(streamResponse(...responses));
+
+      const stream = await chatWithRecording.sendMessageStream(
+        'test-model',
+        { message: 'test' },
+        `prompt-id-json-tool-call-no-finish-${toolCallFirst}`,
+      );
+      const events: StreamEvent[] = [];
+      for await (const event of stream) events.push(event);
+
+      expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(events.some((event) => event.type === StreamEventType.RETRY)).toBe(
+        false,
+      );
+      const emittedParts = events
+        .filter((event) => event.type === StreamEventType.CHUNK)
+        .flatMap((event) => event.value.candidates?.[0]?.content?.parts ?? []);
+      expect(chatWithRecording.getHistory().at(-1)?.parts).toEqual(
+        emittedParts,
+      );
+      expect(recordAssistantTurn).toHaveBeenCalledTimes(1);
+      const recordedParts = recordAssistantTurn.mock.calls[0]?.[0]
+        .message as Part[];
+      for (const parts of [emittedParts, recordedParts]) {
+        expect(parts.filter((part) => part.functionCall)).toEqual([
+          functionCallPart,
+        ]);
+        expect(
+          parts
+            .filter((part) => part.text)
+            .map((part) => part.text)
+            .join(''),
+        ).toBe(response);
+      }
+    },
+  );
+
   it.each([false, true])(
     'keeps leading JSON before a later structured tool call (preparation: %s)',
     async (withPreparation) => {

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -6480,7 +6480,7 @@ describe('GeminiChat', async () => {
       expect(mockContentGenerator.generateContentStream).not.toHaveBeenCalled();
     });
 
-    it('tries the next fallback when a fallback emits only preparation metadata', async () => {
+    it('continues fallback after usage and preparation metadata', async () => {
       vi.mocked(mockConfig.getContentGeneratorConfig).mockReturnValue({
         authType: AuthType.USE_GEMINI,
         model: 'test-model',
@@ -6537,7 +6537,14 @@ describe('GeminiChat', async () => {
       );
       vi.mocked(
         mockContentGenerator.generateContentStream,
-      ).mockRejectedValueOnce(capacityError);
+      ).mockResolvedValueOnce(
+        (async function* () {
+          yield {
+            usageMetadata: { promptTokenCount: 10, totalTokenCount: 10 },
+          } as GenerateContentResponse;
+          throw capacityError;
+        })(),
+      );
       const preparationResponse = {
         candidates: [{ content: { parts: [] } }],
       } as unknown as GenerateContentResponse;
@@ -6586,6 +6593,13 @@ describe('GeminiChat', async () => {
       expect(
         events.filter((event) => event.type === StreamEventType.MODEL_FALLBACK),
       ).toHaveLength(2);
+      expect(
+        events.some(
+          (event) =>
+            event.type === StreamEventType.CHUNK &&
+            event.value.usageMetadata?.promptTokenCount === 10,
+        ),
+      ).toBe(true);
       expect(
         events.filter((event) => event.type === StreamEventType.MODEL_FALLBACK),
       ).toEqual([
@@ -9264,94 +9278,109 @@ describe('GeminiChat', async () => {
     ]);
   });
 
-  it('retries a JSON tool protocol leak before emitting or persisting it', async () => {
-    const recordAssistantTurn = vi.fn();
-    const chatWithRecording = new GeminiChat(
-      mockConfig,
-      config,
-      [],
-      {
-        recordAssistantTurn,
-        recordChatCompression: vi.fn(),
-      } as unknown as ConstructorParameters<typeof GeminiChat>[3],
-      uiTelemetryService,
-    );
-    const leakedJson = JSON.stringify([
-      {
-        prompt: 'Create the node.',
-        name: 'create_node',
-        subagent_type: 'general-purpose',
-        run_in_background: true,
-      },
-      {
-        name: 'read_ref',
-        prompt: 'Read the reference.',
-        subagent_type: 'general-purpose',
-        run_in_background: true,
-      },
-    ]);
-    vi.mocked(mockContentGenerator.generateContentStream)
-      .mockResolvedValueOnce(
-        streamResponse(
-          {
-            candidates: [
-              {
-                content: {
-                  parts: [
-                    { text: '...', thought: true },
-                    { text: leakedJson.slice(0, 40) },
-                  ],
-                },
-              },
-            ],
-          } as unknown as GenerateContentResponse,
-          {
-            candidates: [
-              {
-                content: {
-                  parts: [
-                    {
-                      text:
-                        leakedJson.slice(40) + '\n</parameter>\n</function>\n',
-                    },
-                  ],
-                },
-              },
-            ],
-          } as unknown as GenerateContentResponse,
-          {
-            candidates: [{ finishReason: 'STOP' }],
-          } as unknown as GenerateContentResponse,
-        ),
-      )
-      .mockResolvedValueOnce(
-        streamResponse(stopResponse([{ text: 'Successful final response' }])),
+  it.each([
+    {
+      name: 'array with a different first argument key',
+      leakedJson: JSON.stringify([
+        {
+          file_path: 'a.ts',
+          prompt: 'Create the node.',
+          name: 'create_node',
+          subagent_type: 'general-purpose',
+          run_in_background: true,
+        },
+        {
+          name: 'read_ref',
+          prompt: 'Read the reference.',
+          subagent_type: 'general-purpose',
+          run_in_background: true,
+        },
+      ]),
+      trailingText: '',
+      finishWithContent: false,
+    },
+    {
+      name: 'single object with trailing prose',
+      leakedJson: JSON.stringify({ command: 'ls', name: 'run_shell_command' }),
+      trailingText: '\nLet me continue.',
+      finishWithContent: true,
+    },
+  ])(
+    'retries a JSON tool protocol leak: $name',
+    async ({ leakedJson, trailingText, finishWithContent }) => {
+      const recordAssistantTurn = vi.fn();
+      const chatWithRecording = new GeminiChat(
+        mockConfig,
+        config,
+        [],
+        {
+          recordAssistantTurn,
+          recordChatCompression: vi.fn(),
+        } as unknown as ConstructorParameters<typeof GeminiChat>[3],
+        uiTelemetryService,
       );
+      const leakedText =
+        leakedJson + '\n</parameter>\n</function>\n' + trailingText;
+      const leakedResponses = [
+        {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  { text: '...', thought: true },
+                  { text: leakedText.slice(0, 40) },
+                ],
+              },
+            },
+          ],
+        } as unknown as GenerateContentResponse,
+        {
+          candidates: [
+            {
+              content: { parts: [{ text: leakedText.slice(40) }] },
+              ...(finishWithContent ? { finishReason: 'STOP' as const } : {}),
+            },
+          ],
+        } as unknown as GenerateContentResponse,
+      ];
+      if (!finishWithContent) {
+        leakedResponses.push({
+          candidates: [{ finishReason: 'STOP' }],
+        } as unknown as GenerateContentResponse);
+      }
+      vi.mocked(mockContentGenerator.generateContentStream)
+        .mockResolvedValueOnce(streamResponse(...leakedResponses))
+        .mockResolvedValueOnce(
+          streamResponse(stopResponse([{ text: 'Successful final response' }])),
+        );
 
-    const stream = await chatWithRecording.sendMessageStream(
-      'test-model',
-      { message: 'test' },
-      'prompt-id-json-tool-protocol-leak',
-    );
-    const events: StreamEvent[] = [];
-    for await (const event of stream) events.push(event);
+      const stream = await chatWithRecording.sendMessageStream(
+        'test-model',
+        { message: 'test' },
+        'prompt-id-json-tool-protocol-leak',
+      );
+      const events: StreamEvent[] = [];
+      for await (const event of stream) events.push(event);
 
-    expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(2);
-    expect(events.some((event) => event.type === StreamEventType.RETRY)).toBe(
-      true,
-    );
-    const emittedParts = events
-      .filter((event) => event.type === StreamEventType.CHUNK)
-      .flatMap((event) => event.value.candidates?.[0]?.content?.parts ?? []);
-    expect(emittedParts).toEqual([{ text: 'Successful final response' }]);
-    expect(chatWithRecording.getLastModelMessageText()).toBe(
-      'Successful final response',
-    );
-    expect(recordAssistantTurn).toHaveBeenCalledTimes(1);
-    expect(recordAssistantTurn.mock.calls[0]?.[0].message).toEqual([
-      { text: 'Successful final response' },
-    ]);
-  });
+      expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(
+        2,
+      );
+      expect(events.some((event) => event.type === StreamEventType.RETRY)).toBe(
+        true,
+      );
+      const emittedParts = events
+        .filter((event) => event.type === StreamEventType.CHUNK)
+        .flatMap((event) => event.value.candidates?.[0]?.content?.parts ?? []);
+      expect(emittedParts).toEqual([{ text: 'Successful final response' }]);
+      expect(chatWithRecording.getLastModelMessageText()).toBe(
+        'Successful final response',
+      );
+      expect(recordAssistantTurn).toHaveBeenCalledTimes(1);
+      expect(recordAssistantTurn.mock.calls[0]?.[0].message).toEqual([
+        { text: 'Successful final response' },
+      ]);
+    },
+  );
 
   it.each([
     [JSON.stringify([{ name: 'example', value: 1 }]), 8, 1],
@@ -9424,6 +9453,9 @@ describe('GeminiChat', async () => {
       setToolCallPreparations(preparationResponse, [
         { callId: 'call-1', toolName: 'read_file' },
       ]);
+      const usageResponse = {
+        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 2 },
+      } as GenerateContentResponse;
       const responses = [
         {
           candidates: [
@@ -9432,6 +9464,7 @@ describe('GeminiChat', async () => {
             },
           ],
         } as unknown as GenerateContentResponse,
+        usageResponse,
       ];
       if (withPreparation) responses.push(preparationResponse);
       responses.push(
@@ -9463,6 +9496,14 @@ describe('GeminiChat', async () => {
       const emittedPreparations = events
         .filter((event) => event.type === StreamEventType.CHUNK)
         .flatMap((event) => getToolCallPreparations(event.value));
+      expect(
+        events.some(
+          (event) =>
+            event.type === StreamEventType.CHUNK &&
+            event.value.usageMetadata?.promptTokenCount === 10 &&
+            event.value.usageMetadata.candidatesTokenCount === 2,
+        ),
+      ).toBe(true);
       expect(emittedPreparations).toEqual(
         withPreparation ? [{ callId: 'call-1', toolName: 'read_file' }] : [],
       );

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -9443,6 +9443,51 @@ describe('GeminiChat', async () => {
     },
   );
 
+  it('releases buffered JSON through a finish-only chunk without leaked tags', async () => {
+    const response = JSON.stringify([{ name: 'example', value: 1 }]);
+    const splitAt = 12;
+    vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValueOnce(
+      streamResponse(
+        {
+          candidates: [
+            { content: { parts: [{ text: response.slice(0, splitAt) }] } },
+          ],
+        } as unknown as GenerateContentResponse,
+        {
+          candidates: [
+            { content: { parts: [{ text: response.slice(splitAt) }] } },
+          ],
+        } as unknown as GenerateContentResponse,
+        {
+          candidates: [{ finishReason: 'STOP' }],
+        } as unknown as GenerateContentResponse,
+      ),
+    );
+
+    const stream = await chat.sendMessageStream(
+      'test-model',
+      { message: 'test' },
+      'prompt-id-json-finish-only',
+    );
+    const events: StreamEvent[] = [];
+    for await (const event of stream) events.push(event);
+
+    expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(1);
+    expect(events.some((event) => event.type === StreamEventType.RETRY)).toBe(
+      false,
+    );
+    const emittedParts = events
+      .filter((event) => event.type === StreamEventType.CHUNK)
+      .flatMap((event) => event.value.candidates?.[0]?.content?.parts ?? []);
+    const emittedText = emittedParts
+      .filter((part) => !part.thought)
+      .map((part) => part.text ?? '')
+      .join('');
+    expect(emittedText).toBe(response);
+    expect(chat.getLastModelMessageText()).toBe(response);
+    expect(chat.getHistory().at(-1)?.parts).toEqual(emittedParts);
+  });
+
   it.each(['preparation', 'function call'] as const)(
     'retries when a %s interrupts a partial JSON protocol leak',
     async (middleChunkType) => {

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -9302,7 +9302,7 @@ describe('GeminiChat', async () => {
     {
       name: 'single object with trailing prose',
       leakedJson: JSON.stringify({ command: 'ls', name: 'run_shell_command' }),
-      trailingText: '\nLet me continue.',
+      trailingText: 'Let me continue.',
       finishWithContent: true,
     },
   ])(
@@ -9517,6 +9517,79 @@ describe('GeminiChat', async () => {
     },
   );
 
+  it('does not retry after a structured tool call has already been emitted', async () => {
+    const recordAssistantTurn = vi.fn();
+    const chatWithRecording = new GeminiChat(
+      mockConfig,
+      config,
+      [],
+      {
+        recordAssistantTurn,
+        recordChatCompression: vi.fn(),
+      } as unknown as ConstructorParameters<typeof GeminiChat>[3],
+      uiTelemetryService,
+    );
+    const leakedText =
+      JSON.stringify([{ name: 'read_file', file_path: 'a.ts' }]) +
+      '\n</parameter>\n</function>\n';
+    vi.mocked(mockContentGenerator.generateContentStream)
+      .mockResolvedValueOnce(
+        streamResponse(
+          {
+            candidates: [
+              {
+                content: {
+                  parts: [
+                    {
+                      functionCall: {
+                        id: 'call-1',
+                        name: 'read_file',
+                        args: { file_path: 'a.ts' },
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          } as unknown as GenerateContentResponse,
+          stopResponse([{ text: leakedText }]),
+        ),
+      )
+      .mockResolvedValueOnce(
+        streamResponse(stopResponse([{ text: 'Unexpected retry response' }])),
+      );
+
+    const stream = await chatWithRecording.sendMessageStream(
+      'test-model',
+      { message: 'test' },
+      'prompt-id-tool-call-before-json-protocol-leak',
+    );
+    const events: StreamEvent[] = [];
+    for await (const event of stream) events.push(event);
+
+    expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(1);
+    expect(events.some((event) => event.type === StreamEventType.RETRY)).toBe(
+      false,
+    );
+    const emittedParts = events
+      .filter((event) => event.type === StreamEventType.CHUNK)
+      .flatMap((event) => event.value.candidates?.[0]?.content?.parts ?? []);
+    expect(emittedParts).toEqual([
+      {
+        functionCall: {
+          id: 'call-1',
+          name: 'read_file',
+          args: { file_path: 'a.ts' },
+        },
+      },
+    ]);
+    expect(chatWithRecording.getHistory().at(-1)?.parts).toEqual(emittedParts);
+    expect(recordAssistantTurn).toHaveBeenCalledTimes(1);
+    expect(recordAssistantTurn.mock.calls[0]?.[0].message).toEqual(
+      emittedParts,
+    );
+  });
+
   it('does not reject normal HTML or protocol tag names in prose', async () => {
     const response =
       '<details><summary>Title</summary></details> ' +
@@ -9548,6 +9621,83 @@ describe('GeminiChat', async () => {
       false,
     );
     expect(chat.getLastModelMessageText()).toBe(response);
+  });
+
+  it('does not reject closing protocol tags inside a JSON string', async () => {
+    const response = JSON.stringify({
+      example: '} </parameter></function> text',
+    });
+    vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValueOnce(
+      streamResponse(stopResponse([{ text: response }])),
+    );
+
+    const stream = await chat.sendMessageStream(
+      'test-model',
+      { message: 'test' },
+      'prompt-id-json-protocol-literal',
+    );
+    const events: StreamEvent[] = [];
+    for await (const event of stream) events.push(event);
+
+    expect(events.some((event) => event.type === StreamEventType.RETRY)).toBe(
+      false,
+    );
+    expect(chat.getLastModelMessageText()).toBe(response);
+  });
+
+  it('retries leaked JSON before a structured tool call', async () => {
+    vi.useFakeTimers();
+    try {
+      const leakedText =
+        JSON.stringify([{ name: 'read_file', file_path: 'a.ts' }]) +
+        '\n</parameter>\n</function>\n';
+      vi.mocked(mockContentGenerator.generateContentStream)
+        .mockResolvedValueOnce(
+          streamResponse(
+            {
+              candidates: [{ content: { parts: [{ text: leakedText }] } }],
+            } as unknown as GenerateContentResponse,
+            stopResponse([
+              {
+                functionCall: {
+                  id: 'call-1',
+                  name: 'read_file',
+                  args: { file_path: 'a.ts' },
+                },
+              },
+            ]),
+          ),
+        )
+        .mockResolvedValueOnce(
+          streamResponse(stopResponse([{ text: 'Successful final response' }])),
+        );
+
+      const stream = await chat.sendMessageStream(
+        'test-model',
+        { message: 'test' },
+        'prompt-id-json-leak-before-tool-call',
+      );
+      const events: StreamEvent[] = [];
+      const iterator = stream[Symbol.asyncIterator]();
+      for (;;) {
+        const next = iterator.next();
+        await vi.advanceTimersByTimeAsync(5_000);
+        const result = await next;
+        if (result.done) break;
+        events.push(result.value);
+      }
+
+      expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(
+        2,
+      );
+      const emittedParts = events
+        .filter((event) => event.type === StreamEventType.CHUNK)
+        .flatMap((event) => event.value.candidates?.[0]?.content?.parts ?? []);
+      expect(emittedParts).toEqual([{ text: 'Successful final response' }]);
+      expect(chat.getHistory().at(-1)?.parts).toEqual(emittedParts);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('retries a protocol-tagged turn even when the leaked attempt also contains a tool call', async () => {

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -258,10 +258,10 @@ describe('GeminiChat', async () => {
   }
 
   function streamResponse(
-    response: GenerateContentResponse,
+    ...responses: GenerateContentResponse[]
   ): AsyncGenerator<GenerateContentResponse> {
     return (async function* () {
-      yield response;
+      yield* responses;
     })();
   }
 
@@ -9263,6 +9263,218 @@ describe('GeminiChat', async () => {
       { text: 'Successful final response' },
     ]);
   });
+
+  it('retries a JSON tool protocol leak before emitting or persisting it', async () => {
+    const recordAssistantTurn = vi.fn();
+    const chatWithRecording = new GeminiChat(
+      mockConfig,
+      config,
+      [],
+      {
+        recordAssistantTurn,
+        recordChatCompression: vi.fn(),
+      } as unknown as ConstructorParameters<typeof GeminiChat>[3],
+      uiTelemetryService,
+    );
+    const leakedJson = JSON.stringify([
+      {
+        prompt: 'Create the node.',
+        name: 'create_node',
+        subagent_type: 'general-purpose',
+        run_in_background: true,
+      },
+      {
+        name: 'read_ref',
+        prompt: 'Read the reference.',
+        subagent_type: 'general-purpose',
+        run_in_background: true,
+      },
+    ]);
+    vi.mocked(mockContentGenerator.generateContentStream)
+      .mockResolvedValueOnce(
+        streamResponse(
+          {
+            candidates: [
+              {
+                content: {
+                  parts: [
+                    { text: '...', thought: true },
+                    { text: leakedJson.slice(0, 40) },
+                  ],
+                },
+              },
+            ],
+          } as unknown as GenerateContentResponse,
+          {
+            candidates: [
+              {
+                content: {
+                  parts: [
+                    {
+                      text:
+                        leakedJson.slice(40) + '\n</parameter>\n</function>\n',
+                    },
+                  ],
+                },
+              },
+            ],
+          } as unknown as GenerateContentResponse,
+          {
+            candidates: [{ finishReason: 'STOP' }],
+          } as unknown as GenerateContentResponse,
+        ),
+      )
+      .mockResolvedValueOnce(
+        streamResponse(stopResponse([{ text: 'Successful final response' }])),
+      );
+
+    const stream = await chatWithRecording.sendMessageStream(
+      'test-model',
+      { message: 'test' },
+      'prompt-id-json-tool-protocol-leak',
+    );
+    const events: StreamEvent[] = [];
+    for await (const event of stream) events.push(event);
+
+    expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(2);
+    expect(events.some((event) => event.type === StreamEventType.RETRY)).toBe(
+      true,
+    );
+    const emittedParts = events
+      .filter((event) => event.type === StreamEventType.CHUNK)
+      .flatMap((event) => event.value.candidates?.[0]?.content?.parts ?? []);
+    expect(emittedParts).toEqual([{ text: 'Successful final response' }]);
+    expect(chatWithRecording.getLastModelMessageText()).toBe(
+      'Successful final response',
+    );
+    expect(recordAssistantTurn).toHaveBeenCalledTimes(1);
+    expect(recordAssistantTurn.mock.calls[0]?.[0].message).toEqual([
+      { text: 'Successful final response' },
+    ]);
+  });
+
+  it.each([
+    [JSON.stringify([{ name: 'example', value: 1 }]), 8, 1],
+    ['[1,2,3]', 2, 2],
+  ])(
+    'preserves an ordinary leading JSON array: %s',
+    async (response, splitAt, expectedTextChunks) => {
+      vi.mocked(
+        mockContentGenerator.generateContentStream,
+      ).mockResolvedValueOnce(
+        streamResponse(
+          {
+            candidates: [
+              {
+                content: {
+                  parts: [
+                    { text: 'thinking', thought: true },
+                    { text: response.slice(0, splitAt) },
+                  ],
+                },
+              },
+            ],
+          } as unknown as GenerateContentResponse,
+          stopResponse([{ text: response.slice(splitAt) }]),
+        ),
+      );
+
+      const stream = await chat.sendMessageStream(
+        'test-model',
+        { message: 'test' },
+        'prompt-id-json-array-literal',
+      );
+      const events: StreamEvent[] = [];
+      const streamedTextChunks: string[] = [];
+      for await (const event of stream) {
+        events.push(event);
+        if (event.type === StreamEventType.CHUNK) {
+          const text =
+            event.value.candidates?.[0]?.content?.parts
+              ?.filter((part) => !part.thought)
+              .map((part) => part.text ?? '')
+              .join('') ?? '';
+          if (text) streamedTextChunks.push(text);
+        }
+      }
+
+      expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(events.some((event) => event.type === StreamEventType.RETRY)).toBe(
+        false,
+      );
+      const emittedParts = events
+        .filter((event) => event.type === StreamEventType.CHUNK)
+        .flatMap((event) => event.value.candidates?.[0]?.content?.parts ?? []);
+      expect(streamedTextChunks).toHaveLength(expectedTextChunks);
+      expect(emittedParts.find((part) => part.thought)?.text).toBe('thinking');
+      expect(streamedTextChunks.join('')).toBe(response);
+      expect(chat.getLastModelMessageText()).toBe(response);
+    },
+  );
+
+  it.each([false, true])(
+    'keeps leading JSON before a later structured tool call (preparation: %s)',
+    async (withPreparation) => {
+      const response = JSON.stringify([{ name: 'example', value: 1 }]);
+      const preparationResponse = {
+        candidates: [{ content: { parts: [] } }],
+      } as unknown as GenerateContentResponse;
+      setToolCallPreparations(preparationResponse, [
+        { callId: 'call-1', toolName: 'read_file' },
+      ]);
+      const responses = [
+        {
+          candidates: [
+            {
+              content: { parts: [{ text: response }] },
+            },
+          ],
+        } as unknown as GenerateContentResponse,
+      ];
+      if (withPreparation) responses.push(preparationResponse);
+      responses.push(
+        stopResponse([
+          {
+            functionCall: {
+              id: 'call-1',
+              name: 'read_file',
+              args: { file_path: 'a.ts' },
+            },
+          },
+        ]),
+      );
+      vi.mocked(
+        mockContentGenerator.generateContentStream,
+      ).mockResolvedValueOnce(streamResponse(...responses));
+
+      const stream = await chat.sendMessageStream(
+        'test-model',
+        { message: 'test' },
+        'prompt-id-json-before-tool-call',
+      );
+      const events: StreamEvent[] = [];
+      for await (const event of stream) events.push(event);
+
+      const emittedParts = events
+        .filter((event) => event.type === StreamEventType.CHUNK)
+        .flatMap((event) => event.value.candidates?.[0]?.content?.parts ?? []);
+      const emittedPreparations = events
+        .filter((event) => event.type === StreamEventType.CHUNK)
+        .flatMap((event) => getToolCallPreparations(event.value));
+      expect(emittedPreparations).toEqual(
+        withPreparation ? [{ callId: 'call-1', toolName: 'read_file' }] : [],
+      );
+      for (const parts of [
+        emittedParts,
+        chat.getHistory().at(-1)?.parts ?? [],
+      ]) {
+        expect(parts.findIndex((part) => part.text === response)).toBe(0);
+        expect(parts.findIndex((part) => part.functionCall)).toBe(1);
+      }
+    },
+  );
 
   it('does not reject normal HTML or protocol tag names in prose', async () => {
     const response =

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -9915,6 +9915,69 @@ describe('GeminiChat', async () => {
     }
   });
 
+  it('retries leaked JSON without a finish reason via the post-stream leak guard', async () => {
+    vi.useFakeTimers();
+    try {
+      const leakedText =
+        JSON.stringify([{ name: 'read_file', file_path: 'a.ts' }]) +
+        '\n\n</parameter>\n</function>\n';
+      vi.mocked(mockContentGenerator.generateContentStream)
+        .mockResolvedValueOnce(
+          streamResponse(
+            {
+              candidates: [{ content: { parts: [{ text: leakedText }] } }],
+            } as unknown as GenerateContentResponse,
+            {
+              candidates: [
+                {
+                  content: {
+                    parts: [
+                      {
+                        functionCall: {
+                          id: 'call-1',
+                          name: 'read_file',
+                          args: { file_path: 'a.ts' },
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            } as unknown as GenerateContentResponse,
+          ),
+        )
+        .mockResolvedValueOnce(
+          streamResponse(stopResponse([{ text: 'Successful final response' }])),
+        );
+
+      const stream = await chat.sendMessageStream(
+        'test-model',
+        { message: 'test' },
+        'prompt-id-json-leak-no-finish-reason',
+      );
+      const events: StreamEvent[] = [];
+      const iterator = stream[Symbol.asyncIterator]();
+      for (;;) {
+        const next = iterator.next();
+        await vi.advanceTimersByTimeAsync(5_000);
+        const result = await next;
+        if (result.done) break;
+        events.push(result.value);
+      }
+
+      expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(
+        2,
+      );
+      const emittedParts = events
+        .filter((event) => event.type === StreamEventType.CHUNK)
+        .flatMap((event) => event.value.candidates?.[0]?.content?.parts ?? []);
+      expect(emittedParts).toEqual([{ text: 'Successful final response' }]);
+      expect(chat.getHistory().at(-1)?.parts).toEqual(emittedParts);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('retries a protocol-tagged turn even when the leaked attempt also contains a tool call', async () => {
     vi.useFakeTimers();
     try {

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -1181,7 +1181,28 @@ const PROTOCOL_TAG_PREFIXES = [
   '<summary',
   '</summary',
 ] as const;
-const LEAKED_TOOL_CALL_TAGS = /[}\]]\s*<\/parameter>\s*<\/function>(?:\s|$)/i;
+const LEAKED_TOOL_CALL_TAGS = /^[}\]]\s*<\/parameter>\s*<\/function>/i;
+
+function hasLeakedToolCallTags(text: string): boolean {
+  let inString = false;
+  let escaped = false;
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (char === '\\') escaped = true;
+      else if (char === '"') inString = false;
+    } else if (char === '"') {
+      inString = true;
+    } else if (
+      (char === '}' || char === ']') &&
+      LEAKED_TOOL_CALL_TAGS.test(text.slice(i))
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
 
 class LeadingProtocolTagLeakDetector {
   private state: 'detecting' | 'json' | 'clean' | 'leaked' = 'detecting';
@@ -1227,7 +1248,7 @@ class LeadingProtocolTagLeakDetector {
 
   finish(): string {
     if (this.state === 'json') {
-      if (LEAKED_TOOL_CALL_TAGS.test(this.buffer)) {
+      if (hasLeakedToolCallTags(this.buffer)) {
         this.state = 'leaked';
         this.buffer = '';
         return '';
@@ -1248,7 +1269,7 @@ class LeadingProtocolTagLeakDetector {
   }
 
   releaseJsonCandidate(): string {
-    return this.state === 'json' ? this.release() : '';
+    return this.state === 'json' ? this.finish() : '';
   }
 
   private release(): string {
@@ -4447,7 +4468,7 @@ export class GeminiChat {
       }
     }
 
-    if (streamError === null && protocolTagDetector.leaked) {
+    if (streamError === null && protocolTagDetector.leaked && !hasToolCall) {
       throw new InvalidStreamError(
         'Model response started with leaked protocol tags.',
         'PROTOCOL_TAG_LEAK',

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -1268,10 +1268,6 @@ class LeadingProtocolTagLeakDetector {
     return this.release();
   }
 
-  releaseJsonCandidate(): string {
-    return this.state === 'json' ? this.finish() : '';
-  }
-
   private release(): string {
     const output = this.buffer;
     this.state = 'clean';
@@ -4157,16 +4153,6 @@ export class GeminiChat {
               ),
             })),
           );
-          const content = chunk.candidates?.[0]?.content;
-          if (content) {
-            const text = protocolTagDetector.releaseJsonCandidate();
-            if (text) {
-              content.parts = [
-                ...takePendingProtocolParts(),
-                ...(content.parts ?? []),
-              ];
-            }
-          }
         }
 
         // Use ||= to avoid later usage-only chunks (no candidates) overwriting
@@ -4205,12 +4191,7 @@ export class GeminiChat {
                 continue;
               }
               if (typeof part.text !== 'string' || part.thought) {
-                const text = part.thought
-                  ? ''
-                  : protocolTagDetector.releaseJsonCandidate();
-                if (text) {
-                  outputParts.push(...takePendingProtocolParts(), part);
-                } else if (
+                if (
                   pendingProtocolParts.length > 0 ||
                   protocolTagDetector.leaked
                 ) {
@@ -4344,6 +4325,7 @@ export class GeminiChat {
 
         if (
           !chunk.candidates?.length ||
+          preparations.length > 0 ||
           !protocolTextWasSuppressed ||
           !protocolTagDetector.blockingOutput
         ) {
@@ -4352,6 +4334,32 @@ export class GeminiChat {
       }
     } catch (e) {
       streamError = e;
+    }
+
+    if (
+      streamError === null &&
+      pendingProtocolParts.length > 0 &&
+      (hasToolCall ||
+        pendingProtocolParts.some((part) => part.functionCall !== undefined))
+    ) {
+      protocolTagDetector.finish();
+      if (protocolTagDetector.leaked) {
+        pendingProtocolParts = [];
+      } else {
+        const parts = normalizeModelToolCallIds(
+          takePendingProtocolParts(),
+          usedToolCallIds,
+          rawToolCallIdsInCurrentTurn,
+          reservedToolCallIds,
+        );
+        const chunk = {
+          candidates: [{ content: { role: 'model', parts } }],
+        } as GenerateContentResponse;
+        syncFunctionCallsField(chunk, parts);
+        hasToolCall ||= parts.some((part) => part.functionCall);
+        allModelParts.push(...parts);
+        yield chunk;
+      }
     }
 
     let thoughtContentPart: Part | undefined;

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -1182,9 +1182,17 @@ const PROTOCOL_TAG_PREFIXES = [
   '<summary',
   '</summary',
 ] as const;
+const JSON_TOOL_CALL_PREFIXES = [
+  '[{"name":',
+  '[{"prompt":',
+  '[{"subagent_type":',
+  '[{"run_in_background":',
+] as const;
+const TOOL_CALL_CLOSING_TAGS = /<\/parameter>\s*<\/function>\s*$/i;
 
 class LeadingProtocolTagLeakDetector {
-  private state: 'detecting' | 'clean' | 'leaked' = 'detecting';
+  private state: 'detecting' | 'json' | 'json-tool' | 'clean' | 'leaked' =
+    'detecting';
   private buffer = '';
 
   accept(text: string): string {
@@ -1192,8 +1200,12 @@ class LeadingProtocolTagLeakDetector {
     if (this.state === 'leaked') return '';
 
     this.buffer += text;
+    if (this.state === 'json-tool') return '';
     const candidate = this.buffer.trimStart().toLowerCase();
     if (!candidate) return '';
+    if (this.state === 'json') {
+      return this.acceptJsonCandidate(candidate);
+    }
     if (PROTOCOL_TAG_PREFIXES.some((prefix) => prefix.startsWith(candidate))) {
       return '';
     }
@@ -1208,14 +1220,26 @@ class LeadingProtocolTagLeakDetector {
         return '';
       }
     }
+    if (candidate.startsWith('[')) {
+      this.state = 'json';
+      return this.acceptJsonCandidate(candidate);
+    }
 
-    this.state = 'clean';
-    const output = this.buffer;
-    this.buffer = '';
-    return output;
+    return this.release();
   }
 
   finish(): string {
+    if (this.state === 'json' || this.state === 'json-tool') {
+      if (
+        this.state === 'json-tool' &&
+        TOOL_CALL_CLOSING_TAGS.test(this.buffer)
+      ) {
+        this.state = 'leaked';
+        this.buffer = '';
+        return '';
+      }
+      return this.release();
+    }
     if (this.state !== 'detecting') return '';
     const candidate = this.buffer.trimStart().toLowerCase();
     if (
@@ -1226,8 +1250,34 @@ class LeadingProtocolTagLeakDetector {
       this.buffer = '';
       return '';
     }
-    this.state = 'clean';
+    return this.release();
+  }
+
+  releaseJsonCandidate(): string {
+    return this.state === 'json' || this.state === 'json-tool'
+      ? this.release()
+      : '';
+  }
+
+  private acceptJsonCandidate(candidate: string): string {
+    const normalized = candidate.replace(/\s/g, '');
+    if (
+      JSON_TOOL_CALL_PREFIXES.some((prefix) => prefix.startsWith(normalized))
+    ) {
+      return '';
+    }
+    if (
+      JSON_TOOL_CALL_PREFIXES.some((prefix) => normalized.startsWith(prefix))
+    ) {
+      this.state = 'json-tool';
+      return '';
+    }
+    return this.release();
+  }
+
+  private release(): string {
     const output = this.buffer;
+    this.state = 'clean';
     this.buffer = '';
     return output;
   }
@@ -4062,6 +4112,26 @@ export class GeminiChat {
     let hasToolCall = false;
     let hasFinishReason = false;
     const protocolTagDetector = new LeadingProtocolTagLeakDetector();
+    let pendingProtocolParts: Part[] = [];
+    const takePendingProtocolParts = (text: string): Part[] => {
+      const parts = pendingProtocolParts;
+      pendingProtocolParts = [];
+      if (parts.length === 0) return text ? [{ text }] : [];
+      const released: Part[] = [];
+      for (const part of parts) {
+        const previous = released.at(-1);
+        if (
+          previous &&
+          isValidNonThoughtTextPart(previous) &&
+          isValidNonThoughtTextPart(part)
+        ) {
+          previous.text! += part.text!;
+        } else {
+          released.push(isValidNonThoughtTextPart(part) ? { ...part } : part);
+        }
+      }
+      return released;
+    };
     let protocolTextWasSuppressed = false;
     const currentUserTurn = this.history[this.history.length - 1];
     const isToolResultContinuation =
@@ -4091,6 +4161,16 @@ export class GeminiChat {
               ),
             })),
           );
+          const content = chunk.candidates?.[0]?.content;
+          if (content) {
+            const text = protocolTagDetector.releaseJsonCandidate();
+            if (text) {
+              content.parts = [
+                ...takePendingProtocolParts(text),
+                ...(content.parts ?? []),
+              ];
+            }
+          }
         }
 
         // Use ||= to avoid later usage-only chunks (no candidates) overwriting
@@ -4101,28 +4181,69 @@ export class GeminiChat {
 
         if (isValidResponse(chunk)) {
           const candidate = chunk.candidates?.[0];
-          const content = candidate?.content;
+          let content = candidate?.content;
+          if (candidate?.finishReason && !content?.parts) {
+            const text = protocolTagDetector.finish();
+            if (protocolTagDetector.leaked) {
+              pendingProtocolParts = [];
+            } else {
+              const parts = takePendingProtocolParts(text);
+              if (parts.length > 0) {
+                content = {
+                  ...content,
+                  role: content?.role ?? 'model',
+                  parts,
+                };
+                candidate.content = content;
+              }
+            }
+          }
           if (content?.parts) {
-            content.parts = content.parts.flatMap((part) => {
+            const outputParts: Part[] = [];
+            for (const part of content.parts) {
               if (
                 isToolResultContinuation &&
                 !part.thought &&
                 part.text?.trim() === GEMINI_EMPTY_CONTENT_PLACEHOLDER
               ) {
-                return [];
+                continue;
               }
-              if (typeof part.text !== 'string' || part.thought) return [part];
+              if (typeof part.text !== 'string' || part.thought) {
+                const text = part.thought
+                  ? ''
+                  : protocolTagDetector.releaseJsonCandidate();
+                if (text) {
+                  outputParts.push(...takePendingProtocolParts(text), part);
+                } else if (
+                  pendingProtocolParts.length > 0 ||
+                  protocolTagDetector.leaked
+                ) {
+                  pendingProtocolParts.push(part);
+                } else {
+                  outputParts.push(part);
+                }
+                continue;
+              }
               const text = protocolTagDetector.accept(part.text);
-              if (text) return [{ ...part, text }];
+              if (text) {
+                if (pendingProtocolParts.length > 0) {
+                  outputParts.push(...takePendingProtocolParts(''), part);
+                } else {
+                  outputParts.push({ ...part, text });
+                }
+                continue;
+              }
+              pendingProtocolParts.push(...outputParts.splice(0), part);
               protocolTextWasSuppressed ||= part.text.length > 0;
-              const { text: _text, ...rest } = part;
-              return Object.values(rest).some((value) => value !== undefined)
-                ? [rest]
-                : [];
-            });
+            }
+            content.parts = outputParts;
             if (candidate?.finishReason) {
               const text = protocolTagDetector.finish();
-              if (text) content.parts.push({ text });
+              if (protocolTagDetector.leaked) {
+                pendingProtocolParts = [];
+              } else {
+                content.parts.push(...takePendingProtocolParts(text));
+              }
             }
             content.parts = normalizeModelToolCallIds(
               content.parts,

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -134,15 +134,14 @@ const debugLogger = createDebugLogger('QWEN_CODE_CHAT');
 // must stay in sync.
 const GEMINI_EMPTY_CONTENT_PLACEHOLDER = '(empty content)';
 
-function isToolCallPreparationOnly(response: GenerateContentResponse): boolean {
-  if (getToolCallPreparations(response).length === 0) return false;
-
-  const hasCandidateOutput = response.candidates?.some(
-    (candidate) =>
-      Boolean(candidate.finishReason) ||
-      (candidate.content?.parts?.length ?? 0) > 0,
+function hasCandidateOutput(response: GenerateContentResponse): boolean {
+  return Boolean(
+    response.candidates?.some(
+      (candidate) =>
+        Boolean(candidate.finishReason) ||
+        (candidate.content?.parts?.length ?? 0) > 0,
+    ),
   );
-  return !hasCandidateOutput && !response.usageMetadata;
 }
 
 /**
@@ -1182,17 +1181,10 @@ const PROTOCOL_TAG_PREFIXES = [
   '<summary',
   '</summary',
 ] as const;
-const JSON_TOOL_CALL_PREFIXES = [
-  '[{"name":',
-  '[{"prompt":',
-  '[{"subagent_type":',
-  '[{"run_in_background":',
-] as const;
-const TOOL_CALL_CLOSING_TAGS = /<\/parameter>\s*<\/function>\s*$/i;
+const LEAKED_TOOL_CALL_TAGS = /[}\]]\s*<\/parameter>\s*<\/function>(?:\s|$)/i;
 
 class LeadingProtocolTagLeakDetector {
-  private state: 'detecting' | 'json' | 'json-tool' | 'clean' | 'leaked' =
-    'detecting';
+  private state: 'detecting' | 'json' | 'clean' | 'leaked' = 'detecting';
   private buffer = '';
 
   accept(text: string): string {
@@ -1200,12 +1192,9 @@ class LeadingProtocolTagLeakDetector {
     if (this.state === 'leaked') return '';
 
     this.buffer += text;
-    if (this.state === 'json-tool') return '';
+    if (this.state === 'json') return '';
     const candidate = this.buffer.trimStart().toLowerCase();
     if (!candidate) return '';
-    if (this.state === 'json') {
-      return this.acceptJsonCandidate(candidate);
-    }
     if (PROTOCOL_TAG_PREFIXES.some((prefix) => prefix.startsWith(candidate))) {
       return '';
     }
@@ -1220,20 +1209,25 @@ class LeadingProtocolTagLeakDetector {
         return '';
       }
     }
-    if (candidate.startsWith('[')) {
+    if (candidate.startsWith('{')) {
       this.state = 'json';
-      return this.acceptJsonCandidate(candidate);
+      return '';
+    }
+    if (candidate.startsWith('[')) {
+      const normalized = candidate.replace(/\s/g, '');
+      if (normalized === '[') return '';
+      if (normalized.startsWith('[{')) {
+        this.state = 'json';
+        return '';
+      }
     }
 
     return this.release();
   }
 
   finish(): string {
-    if (this.state === 'json' || this.state === 'json-tool') {
-      if (
-        this.state === 'json-tool' &&
-        TOOL_CALL_CLOSING_TAGS.test(this.buffer)
-      ) {
+    if (this.state === 'json') {
+      if (LEAKED_TOOL_CALL_TAGS.test(this.buffer)) {
         this.state = 'leaked';
         this.buffer = '';
         return '';
@@ -1254,25 +1248,7 @@ class LeadingProtocolTagLeakDetector {
   }
 
   releaseJsonCandidate(): string {
-    return this.state === 'json' || this.state === 'json-tool'
-      ? this.release()
-      : '';
-  }
-
-  private acceptJsonCandidate(candidate: string): string {
-    const normalized = candidate.replace(/\s/g, '');
-    if (
-      JSON_TOOL_CALL_PREFIXES.some((prefix) => prefix.startsWith(normalized))
-    ) {
-      return '';
-    }
-    if (
-      JSON_TOOL_CALL_PREFIXES.some((prefix) => normalized.startsWith(prefix))
-    ) {
-      this.state = 'json-tool';
-      return '';
-    }
-    return this.release();
+    return this.state === 'json' ? this.release() : '';
   }
 
   private release(): string {
@@ -2562,7 +2538,7 @@ export class GeminiChat {
 
             lastFinishReason = undefined;
             for await (const chunk of stream) {
-              if (!isToolCallPreparationOnly(chunk)) {
+              if (hasCandidateOutput(chunk)) {
                 streamYieldedChunk = true;
                 streamYieldedAnyChunk = true;
               }
@@ -3399,7 +3375,7 @@ export class GeminiChat {
                   )) {
                     const emittedUserVisibleOutput =
                       event.type !== StreamEventType.CHUNK ||
-                      !isToolCallPreparationOnly(event.value);
+                      hasCandidateOutput(event.value);
                     if (emittedUserVisibleOutput) {
                       currentFallbackYieldedAnyChunk = true;
                       fallbackStreamYieldedAnyChunk = true;
@@ -4113,10 +4089,9 @@ export class GeminiChat {
     let hasFinishReason = false;
     const protocolTagDetector = new LeadingProtocolTagLeakDetector();
     let pendingProtocolParts: Part[] = [];
-    const takePendingProtocolParts = (text: string): Part[] => {
+    const takePendingProtocolParts = (): Part[] => {
       const parts = pendingProtocolParts;
       pendingProtocolParts = [];
-      if (parts.length === 0) return text ? [{ text }] : [];
       const released: Part[] = [];
       for (const part of parts) {
         const previous = released.at(-1);
@@ -4166,7 +4141,7 @@ export class GeminiChat {
             const text = protocolTagDetector.releaseJsonCandidate();
             if (text) {
               content.parts = [
-                ...takePendingProtocolParts(text),
+                ...takePendingProtocolParts(),
                 ...(content.parts ?? []),
               ];
             }
@@ -4183,11 +4158,11 @@ export class GeminiChat {
           const candidate = chunk.candidates?.[0];
           let content = candidate?.content;
           if (candidate?.finishReason && !content?.parts) {
-            const text = protocolTagDetector.finish();
+            protocolTagDetector.finish();
             if (protocolTagDetector.leaked) {
               pendingProtocolParts = [];
             } else {
-              const parts = takePendingProtocolParts(text);
+              const parts = takePendingProtocolParts();
               if (parts.length > 0) {
                 content = {
                   ...content,
@@ -4213,7 +4188,7 @@ export class GeminiChat {
                   ? ''
                   : protocolTagDetector.releaseJsonCandidate();
                 if (text) {
-                  outputParts.push(...takePendingProtocolParts(text), part);
+                  outputParts.push(...takePendingProtocolParts(), part);
                 } else if (
                   pendingProtocolParts.length > 0 ||
                   protocolTagDetector.leaked
@@ -4227,7 +4202,7 @@ export class GeminiChat {
               const text = protocolTagDetector.accept(part.text);
               if (text) {
                 if (pendingProtocolParts.length > 0) {
-                  outputParts.push(...takePendingProtocolParts(''), part);
+                  outputParts.push(...takePendingProtocolParts(), part);
                 } else {
                   outputParts.push({ ...part, text });
                 }
@@ -4238,11 +4213,11 @@ export class GeminiChat {
             }
             content.parts = outputParts;
             if (candidate?.finishReason) {
-              const text = protocolTagDetector.finish();
+              protocolTagDetector.finish();
               if (protocolTagDetector.leaked) {
                 pendingProtocolParts = [];
               } else {
-                content.parts.push(...takePendingProtocolParts(text));
+                content.parts.push(...takePendingProtocolParts());
               }
             }
             content.parts = normalizeModelToolCallIds(
@@ -4346,7 +4321,11 @@ export class GeminiChat {
           }
         }
 
-        if (!protocolTextWasSuppressed || !protocolTagDetector.blockingOutput) {
+        if (
+          !chunk.candidates?.length ||
+          !protocolTextWasSuppressed ||
+          !protocolTagDetector.blockingOutput
+        ) {
           yield chunk;
         }
       }

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -1181,7 +1181,7 @@ const PROTOCOL_TAG_PREFIXES = [
   '<summary',
   '</summary',
 ] as const;
-const LEAKED_TOOL_CALL_TAGS = /^[}\]]\s*<\/parameter>\s*<\/function>/i;
+const LEAKED_TOOL_CALL_TAGS = /[}\]]\s*<\/parameter>\s*<\/function>/iy;
 
 function hasLeakedToolCallTags(text: string): boolean {
   let inString = false;
@@ -1194,11 +1194,9 @@ function hasLeakedToolCallTags(text: string): boolean {
       else if (char === '"') inString = false;
     } else if (char === '"') {
       inString = true;
-    } else if (
-      (char === '}' || char === ']') &&
-      LEAKED_TOOL_CALL_TAGS.test(text.slice(i))
-    ) {
-      return true;
+    } else if (char === '}' || char === ']') {
+      LEAKED_TOOL_CALL_TAGS.lastIndex = i;
+      if (LEAKED_TOOL_CALL_TAGS.test(text)) return true;
     }
   }
   return false;


### PR DESCRIPTION
## What this PR does

This PR prevents a model response that contains a JSON-array tool payload followed by leaked `</parameter></function>` protocol tags from reaching the UI, conversation history, or session recording. The failed attempt is routed through the existing protocol-leak retry path instead.

Detection stays at the shared stream boundary. It buffers a leading JSON object or object array without guessing argument names, preserves part ordering while the response is ambiguous, and releases ordinary JSON or real structured tool-call events unchanged. Numeric arrays and Markdown-style bracketed text continue streaming immediately.

## Why it's needed

In a production session, the model returned `finish_reason=stop` with a plain-text JSON array containing two subagent argument objects and the closing tool protocol tags, but no structured tool call. The existing guard handled leading XML-style protocol tags, so this JSON-shaped variant was displayed and persisted as assistant text instead of being retried.

## Reviewer Test Plan

### How to verify

1. Stream a thought plus a split JSON tool payload ending in `</parameter></function>`, both with a separate terminal event and with the finish reason on the content chunk. Cover an arbitrary first argument key, a direct object, and trailing prose. Confirm that the failed attempt emits no parts, writes no history or recording entry, and the retry exposes only the successful response.
2. Stream a normal JSON object array and a numeric JSON array without protocol tags. Confirm that both are emitted and persisted unchanged, and that the numeric array starts streaming before the terminal event.
3. Stream leading JSON before a real structured tool call, both with and without tool preparation metadata. Confirm the emitted and persisted order remains JSON text, then function call, with preparation metadata preserved. Also confirm that usage-only metadata passes through without blocking a later configured model fallback.

### Evidence (Before & After)

Before: the production-shaped response was emitted as assistant text and persisted without a retry.

After: the same 905-character response produces `PROTOCOL_TAG_LEAK`, emits zero parts from the failed attempt, leaves history and recording unchanged, retries once, and exposes only the successful response.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Node.js 22, no sandbox. Verified with 321 affected unit tests, the full repository build and typecheck, ESLint, Prettier, and `git diff --check`.

## Risk & Scope

- Main risk or tradeoff: a response beginning with a JSON object or object array is buffered until it is disambiguated, so legitimate JSON with those shapes may be delivered at the terminal event rather than incrementally.
- Not validated / out of scope: other malformed provider-specific tool syntaxes that do not match this production signature.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #8207

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本 PR 防止模型将 JSON 数组形式的工具参数以及泄漏的 `</parameter></function>` 协议结束标签输出到 UI、会话历史或 session 记录中。失败轮次会复用现有的协议泄漏重试流程。

检测位于共享流处理边界，不再猜测参数名，而是暂存以 JSON 对象或对象数组开头的响应；在响应尚未判定时保持各 part 的顺序，并原样放行普通 JSON 或真实的结构化工具调用事件。数字数组和 Markdown 风格的方括号文本仍会立即流式输出。

## 为什么需要

一个生产会话中，模型以 `finish_reason=stop` 返回了包含两个 subagent 参数对象的纯文本 JSON 数组以及工具协议结束标签，但没有返回结构化工具调用。现有保护只处理以 XML 风格协议标签开头的响应，因此这个 JSON 变体被当作助手文本展示并持久化，没有触发重试。

## Reviewer Test Plan

### 验证方式

1. 流式返回 thought、分片 JSON 工具 payload 和 `</parameter></function>`，分别覆盖独立终止事件、finish reason 与内容同块、任意首个参数键、直接对象和尾随文本。确认失败轮次不输出任何 part、不写入历史或 recording，并且重试后只暴露成功响应。
2. 流式返回不带协议标签的普通 JSON 对象数组和数字数组。确认两者原样输出和持久化，并且数字数组在终止事件前就开始输出。
3. 在真实结构化工具调用前返回 JSON，分别覆盖带和不带工具 preparation 元数据的情况。确认输出与持久化顺序始终是 JSON 文本、function call，并保留 preparation 元数据；同时确认 usage-only 元数据会正常传递，且不会阻止后续配置的模型 fallback。

### 修复前后证据

修复前：生产形态的响应会直接作为助手文本输出并持久化，不触发重试。

修复后：相同的 905 字符响应触发 `PROTOCOL_TAG_LEAK`，失败轮次输出 0 个 part，history 和 recording 不变，随后重试且只暴露成功响应。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

Node.js 22，无 sandbox。已通过 321 个受影响单元测试、全仓 build 与 typecheck、ESLint、Prettier 和 `git diff --check`。

## 风险与范围

- 主要风险或权衡：以 JSON 对象或对象数组开头的响应会暂存到完成判定，因此这些形态的合法 JSON 可能在终止事件时一次性输出，而不是增量输出。
- 未验证或不在范围内：不符合本次生产特征的其他 provider 特有异常工具语法。
- 破坏性变更或迁移说明：无。

## 关联 Issue

Fixes #8207

</details>

