### PR TITLE
feat(workflows): support opt-in background runs

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -206,6 +206,7 @@ describe('useGeminiStream', () => {
   let mockCancelAllToolCalls: Mock;
   let mockMarkToolsAsSubmitted: Mock;
   let mockBackgroundShellRegistry: { setNotificationCallback: Mock };
+  let mockWorkflowRunRegistry: { setCompletionCallback: Mock };
   let mockMonitorRegistry: {
     setNotificationCallback: Mock;
     get: Mock;
@@ -241,6 +242,9 @@ describe('useGeminiStream', () => {
     };
     mockBackgroundShellRegistry = {
       setNotificationCallback: vi.fn(),
+    };
+    mockWorkflowRunRegistry = {
+      setCompletionCallback: vi.fn(),
     };
     mockMonitorRegistry = {
       setNotificationCallback: vi.fn(),
@@ -300,6 +304,7 @@ describe('useGeminiStream', () => {
       })),
       getBackgroundShellRegistry: vi.fn(() => mockBackgroundShellRegistry),
       getMonitorRegistry: vi.fn(() => mockMonitorRegistry),
+      getWorkflowRunRegistry: vi.fn(() => mockWorkflowRunRegistry),
     } as unknown as Config;
     mockOnDebugMessage = vi.fn();
     mockHandleSlashCommand = vi.fn().mockResolvedValue(false);
@@ -451,6 +456,47 @@ describe('useGeminiStream', () => {
 
     act(() => {
       callback(displayText, modelText);
+    });
+
+    await waitFor(() => {
+      expect(mockAddItem).toHaveBeenCalledWith(
+        { type: 'notification', text: displayText },
+        expect.any(Number),
+      );
+    });
+    await waitFor(() => {
+      expect(mockSendMessageStream).toHaveBeenCalledWith(
+        modelText,
+        expect.any(AbortSignal),
+        expect.any(String),
+        expect.objectContaining({
+          type: SendMessageType.Notification,
+          notificationDisplayText: displayText,
+        }),
+      );
+    });
+  });
+
+  it('queues background workflow completions for the model loop', async () => {
+    const { mockSendMessageStream } = renderTestHook();
+    const displayText = 'Background workflow "research" completed.';
+    const modelText =
+      '<task-notification>\n<kind>workflow</kind>\n<status>completed</status>\n</task-notification>';
+
+    await waitFor(() => {
+      expect(
+        mockWorkflowRunRegistry.setCompletionCallback,
+      ).toHaveBeenCalledWith(expect.any(Function));
+    });
+    const callback = mockWorkflowRunRegistry.setCompletionCallback.mock
+      .calls[0][0] as (
+      displayText: string,
+      modelText: string,
+      meta: { todoWorkChainId?: string },
+    ) => void;
+
+    act(() => {
+      callback(displayText, modelText, { todoWorkChainId: 'workflow-chain' });
     });
 
     await waitFor(() => {

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -513,6 +513,7 @@ describe('useGeminiStream', () => {
         expect.objectContaining({
           type: SendMessageType.Notification,
           notificationDisplayText: displayText,
+          todoWorkChainId: 'workflow-chain',
         }),
       );
     });

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -3978,6 +3978,24 @@ export const useGeminiStream = (
     };
   }, [config]);
 
+  // Register background workflow completions onto the shared queue. The
+  // registry keeps this separate from its terminal-bell subscriber.
+  useEffect(() => {
+    const registry = config.getWorkflowRunRegistry();
+    registry.setCompletionCallback((displayText, modelText, meta) => {
+      notificationQueueRef.current.push({
+        displayText,
+        modelText,
+        sendMessageType: SendMessageType.Notification,
+        todoWorkChainId: meta.todoWorkChainId,
+      });
+      setNotificationTrigger((n) => n + 1);
+    });
+    return () => {
+      registry.setCompletionCallback(undefined);
+    };
+  }, [config]);
+
   // Register monitor notification callback onto the shared queue.
   useEffect(() => {
     const registry = config.getMonitorRegistry();

--- a/packages/core/src/agents/runtime/workflow-runner.test.ts
+++ b/packages/core/src/agents/runtime/workflow-runner.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getEventListeners } from 'node:events';
 import type { Config } from '../../config/config.js';
 import { WorkflowRunRegistry } from '../workflow-run-registry.js';
 import { AgentEventEmitter } from './agent-events.js';
@@ -91,6 +92,7 @@ describe('WorkflowRunner', () => {
       signal: new AbortController().signal,
       script: 'return await agent("work")',
       args: undefined,
+      runInBackground: true,
     });
     await expect(productionHandle.completion).resolves.toMatchObject({
       ok: true,
@@ -213,6 +215,103 @@ describe('WorkflowRunner', () => {
     expect(logWorkflowRunMock).toHaveBeenCalledTimes(2);
   });
 
+  it('keeps background runs alive after the caller turn ends', async () => {
+    const { config, registry } = configWithRegistry();
+    const observed = observeSettlement(registry);
+    const caller = new AbortController();
+    let resolveDispatch: ((value: string) => void) | undefined;
+    const handle = await WorkflowRunner.start({
+      config,
+      signal: caller.signal,
+      script: 'return await agent("work")',
+      args: undefined,
+      runInBackground: true,
+      dispatch: () =>
+        new Promise<string>((resolve) => {
+          resolveDispatch = resolve;
+        }),
+    });
+    await vi.waitFor(() => expect(resolveDispatch).toBeDefined());
+
+    caller.abort();
+    expect(observed.abortCount()).toBe(0);
+    expect(registry.get(handle.runId)?.status).toBe('running');
+
+    resolveDispatch?.('done');
+    await expect(handle.completion).resolves.toMatchObject({ ok: true });
+    expect(registry.get(handle.runId)?.status).toBe('completed');
+    expect(observed.terminalStatuses).toEqual(['completed']);
+    expect(observed.abortCount()).toBe(1);
+  });
+
+  it('rejects a concurrent resume while the original run is active', async () => {
+    const { config, registry } = configWithRegistry();
+    const runId = 'wf_1234abcd';
+    let resolveDispatch: ((value: string) => void) | undefined;
+    const original = await WorkflowRunner.start({
+      config,
+      signal: new AbortController().signal,
+      script: 'return await agent("original")',
+      args: undefined,
+      resumeFromRunId: runId,
+      runInBackground: true,
+      dispatch: () =>
+        new Promise<string>((resolve) => {
+          resolveDispatch = resolve;
+        }),
+    });
+    await vi.waitFor(() => expect(resolveDispatch).toBeDefined());
+    const replacementCaller = new AbortController();
+    const replacementDispatch = vi.fn(async () => 'replacement');
+
+    try {
+      await expect(
+        WorkflowRunner.start({
+          config,
+          signal: replacementCaller.signal,
+          script: 'return await agent("replacement")',
+          args: undefined,
+          resumeFromRunId: runId,
+          dispatch: replacementDispatch,
+        }),
+      ).rejects.toThrow(/already active/);
+      expect(registry.getHandle(runId)).toBe(original);
+      expect(replacementDispatch).not.toHaveBeenCalled();
+      expect(getEventListeners(replacementCaller.signal, 'abort')).toHaveLength(
+        0,
+      );
+    } finally {
+      resolveDispatch?.('original');
+      await original.completion;
+    }
+
+    expect(registry.get(runId)?.result).toBe('original');
+  });
+
+  it('classifies a background failure after caller abort as failed', async () => {
+    const { config, registry } = configWithRegistry();
+    const caller = new AbortController();
+    let rejectDispatch: ((error: Error) => void) | undefined;
+    const handle = await WorkflowRunner.start({
+      config,
+      signal: caller.signal,
+      script: 'return await agent("work")',
+      args: undefined,
+      runInBackground: true,
+      dispatch: () =>
+        new Promise<string>((_resolve, reject) => {
+          rejectDispatch = reject;
+        }),
+    });
+    await vi.waitFor(() => expect(rejectDispatch).toBeDefined());
+
+    caller.abort();
+    rejectDispatch?.(new Error('background boom'));
+
+    await expect(handle.completion).resolves.toMatchObject({ ok: false });
+    expect(registry.get(handle.runId)?.status).toBe('failed');
+  });
+
   it('routes registry cancellation through each live handle', async () => {
     const cancelCases: Array<{
       cancel: (registry: WorkflowRunRegistry, runId: string) => void;
@@ -234,6 +333,7 @@ describe('WorkflowRunner', () => {
         signal: new AbortController().signal,
         script: 'return await agent("work")',
         args: undefined,
+        runInBackground: true,
         dispatch: () =>
           new Promise<string>((_resolve, reject) => {
             rejectDispatch = reject;
@@ -272,6 +372,7 @@ describe('WorkflowRunner', () => {
         signal: new AbortController().signal,
         script: 'await new Promise(() => {})',
         args: undefined,
+        runInBackground: true,
         dispatch: async () => 'unused',
       });
 

--- a/packages/core/src/agents/runtime/workflow-runner.ts
+++ b/packages/core/src/agents/runtime/workflow-runner.ts
@@ -8,7 +8,10 @@ import { randomBytes } from 'node:crypto';
 import type { Config } from '../../config/config.js';
 import { logWorkflowRun } from '../../telemetry/loggers.js';
 import { WorkflowRunEvent } from '../../telemetry/types.js';
-import { createChildAbortController } from '../../utils/abortController.js';
+import {
+  createAbortController,
+  createChildAbortController,
+} from '../../utils/abortController.js';
 import {
   type WorkflowRunRegistry,
   type WorkflowTask,
@@ -35,6 +38,7 @@ export interface WorkflowRunnerOptions {
   resumeFromRunId?: string;
   dispatch?: WorkflowAgentDispatch;
   onUpdate?: (entry: WorkflowTask) => void;
+  runInBackground?: boolean;
 }
 
 export type WorkflowRunSettlement =
@@ -64,6 +68,7 @@ export class WorkflowRunner {
     options: WorkflowRunnerOptions,
   ): Promise<WorkflowRunHandle> {
     const config = options.config;
+    const runInBackground = options.runInBackground === true;
     const budget = WorkflowBudgetImpl.fromEnv();
     const loaded =
       options.scriptPath && options.script === undefined
@@ -83,7 +88,13 @@ export class WorkflowRunner {
     const resumeReplay: JournalReplay | undefined = options.resumeFromRunId
       ? await journal?.load()
       : undefined;
-    const controller = createChildAbortController(options.signal);
+    if (runInBackground && options.signal.aborted) {
+      throw new Error('Background workflow start was cancelled.');
+    }
+    const callerWasAbortedBeforeStart = options.signal.aborted;
+    const controller = runInBackground
+      ? createAbortController()
+      : createChildAbortController(options.signal);
     const registry = config.getWorkflowRunRegistry?.();
     const dispatch =
       options.dispatch ??
@@ -96,17 +107,24 @@ export class WorkflowRunner {
           : undefined,
       );
     const orchestrator = new WorkflowOrchestrator(dispatch);
-    const entry = registry?.register({
-      runId,
-      meta: null,
-      status: 'running',
-      startTime: Date.now(),
-      outputFile: '',
-      abortController: controller,
-      tokenBudgetTotal: budget.total,
-      script,
-      scriptPath,
-    });
+    let entry: WorkflowTask | undefined;
+    try {
+      entry = registry?.register({
+        runId,
+        meta: null,
+        status: 'running',
+        startTime: Date.now(),
+        outputFile: '',
+        abortController: controller,
+        tokenBudgetTotal: budget.total,
+        script,
+        scriptPath,
+        isBackgrounded: runInBackground,
+      });
+    } catch (error) {
+      controller.abort();
+      throw error;
+    }
     const emitUpdate = (): void => {
       if (!entry || !options.onUpdate) return;
       try {
@@ -172,7 +190,11 @@ export class WorkflowRunner {
           const message = extractErrorMessage(error);
           if (entry && details?.meta && !entry.meta) entry.meta = details.meta;
           if (details?.logs) registry?.setRecentLogs(runId, details.logs);
-          if (options.signal.aborted) {
+          if (
+            callerWasAbortedBeforeStart ||
+            (!runInBackground && options.signal.aborted) ||
+            entry?.status === 'cancelled'
+          ) {
             registry?.cancel(runId, Date.now());
           } else {
             registry?.fail(runId, message, Date.now());

--- a/packages/core/src/agents/tasks/types.ts
+++ b/packages/core/src/agents/tasks/types.ts
@@ -37,13 +37,11 @@
  * they have a separate lifecycle and their inclusion is deferred to a
  * follow-up.
  *
- * `workflow` (P4b) is registered/observed via `WorkflowRunRegistry` and
- * differs from the others in that the registry NEVER emits a
- * `<task-notification>` envelope — `WorkflowTool` already returns its
- * own llmContent + returnDisplay payload to the model on terminal, so
- * a second envelope would duplicate the signal. The kind is widened
- * here so the UI surfaces (pill / dialog / detail body) can switch on
- * `entry.kind === 'workflow'`.
+ * `workflow` (P4b) is registered/observed via `WorkflowRunRegistry`.
+ * Foreground workflows return through their normal tool result; background
+ * workflows emit one terminal notification through a separate completion
+ * channel. The kind is widened here so the UI surfaces (pill / dialog /
+ * detail body) can switch on `entry.kind === 'workflow'`.
  */
 export type TaskKind = 'agent' | 'shell' | 'monitor' | 'workflow';
 

--- a/packages/core/src/agents/workflow-run-registry.test.ts
+++ b/packages/core/src/agents/workflow-run-registry.test.ts
@@ -6,11 +6,13 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { ToolConfirmationOutcome } from '../tools/tools.js';
+import { todoWorkChainContext } from '../utils/promptIdContext.js';
 import {
   AgentEventEmitter,
   AgentEventType,
   type AgentApprovalRequestEvent,
 } from './runtime/agent-events.js';
+import type { WorkflowRunHandle } from './runtime/workflow-runner.js';
 import {
   WorkflowRunRegistry,
   MAX_PENDING_WORKFLOW_APPROVALS,
@@ -677,6 +679,25 @@ describe('WorkflowRunRegistry', () => {
     expect(entry.notified).toBe(false);
   });
 
+  it('rejects a duplicate run id until its owner handle is released', () => {
+    const r = new WorkflowRunRegistry();
+    const runId = 'wf_collision';
+    r.register(reg(runId));
+
+    expect(() => r.register(reg(runId))).toThrow(/already active/);
+
+    const handle = {
+      runId,
+      abort: vi.fn(),
+    } as unknown as WorkflowRunHandle;
+    r.attachHandle(handle);
+    r.cancel(runId, 2_000);
+    expect(() => r.register(reg(runId))).toThrow(/already active/);
+
+    r.releaseHandle(runId, handle);
+    expect(r.register(reg(runId)).status).toBe('running');
+  });
+
   it('register synthesizes description from meta.name when omitted', () => {
     const r = new WorkflowRunRegistry();
     const entry = r.register(
@@ -844,6 +865,113 @@ describe('WorkflowRunRegistry', () => {
     r.register(reg('wf_cancelled'));
     r.cancel('wf_cancelled', 3_000);
     expect(cb).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps terminal bell and background model completion channels independent', () => {
+    const r = new WorkflowRunRegistry();
+    const bell = vi.fn();
+    const completion = vi.fn();
+    r.setNotificationCallback(bell);
+    r.setCompletionCallback(completion);
+    expect(r.hasCompletionCallback()).toBe(true);
+
+    const result = 'safe <value> & </task-notification>';
+    const entry = r.register(
+      reg('wf_background', {
+        isBackgrounded: true,
+        script: 'secret script',
+        description: '\u001b[31mwf\u001b[0m',
+      }),
+    );
+    r.complete(entry.runId, result, 1_000);
+    r.complete(entry.runId, 'duplicate', 1_001);
+    r.fail(entry.runId, 'duplicate failure', 1_002);
+
+    expect(bell).toHaveBeenCalledOnce();
+    expect(bell).toHaveBeenCalledWith(entry);
+    expect(completion).toHaveBeenCalledOnce();
+    const [displayText, modelText, meta] = completion.mock.calls[0];
+    expect(displayText).toBe('Background workflow "wf" completed.');
+    expect(modelText).toContain('<kind>workflow</kind>');
+    expect(modelText).toContain('<task-id>wf_background</task-id>');
+    expect(modelText).toContain('<status>completed</status>');
+    expect(modelText).toContain(
+      'safe &lt;value&gt; &amp; &lt;/task-notification&gt;',
+    );
+    expect(modelText.match(/<\/task-notification>/g)).toHaveLength(1);
+    expect(modelText).not.toContain('secret script');
+    expect(modelText).not.toContain('\u001b');
+    expect(meta).toEqual({
+      runId: 'wf_background',
+      status: 'completed',
+      todoWorkChainId: undefined,
+    });
+
+    r.register(reg('wf_foreground'));
+    r.complete('wf_foreground', 'foreground', 2_000);
+    expect(bell).toHaveBeenCalledTimes(2);
+    expect(completion).toHaveBeenCalledOnce();
+
+    r.register(reg('wf_cancelled', { isBackgrounded: true }));
+    r.cancel('wf_cancelled', 3_000);
+    expect(bell).toHaveBeenCalledTimes(2);
+    expect(completion).toHaveBeenCalledOnce();
+
+    r.register(reg('wf_shutdown', { isBackgrounded: true }));
+    r.abortAll();
+    expect(bell).toHaveBeenCalledTimes(2);
+    expect(completion).toHaveBeenCalledOnce();
+
+    r.setCompletionCallback(undefined);
+    expect(r.hasCompletionCallback()).toBe(false);
+  });
+
+  it('emits one safe background failure completion and isolates callback errors', () => {
+    const r = new WorkflowRunRegistry();
+    r.setNotificationCallback(() => {
+      throw new Error('bell subscriber failed');
+    });
+    const completion = vi.fn((_displayText: string, _modelText: string) => {
+      throw new Error('completion subscriber failed');
+    });
+    r.setCompletionCallback(completion);
+    r.register(reg('wf_bad_background', { isBackgrounded: true }));
+
+    expect(() =>
+      r.fail('wf_bad_background', 'boom <unsafe>', 1_000),
+    ).not.toThrow();
+    expect(completion).toHaveBeenCalledOnce();
+    expect(completion.mock.calls[0][1]).toContain(
+      '<result>Error: boom &lt;unsafe&gt;</result>',
+    );
+  });
+
+  it('degrades non-JSON background results without breaking settlement', () => {
+    const r = new WorkflowRunRegistry();
+    const completion = vi.fn();
+    r.setCompletionCallback(completion);
+    const circular: { self?: unknown } = {};
+    circular.self = circular;
+    r.register(reg('wf_circular', { isBackgrounded: true }));
+
+    expect(() => r.complete('wf_circular', circular, 1_000)).not.toThrow();
+    expect(completion).toHaveBeenCalledOnce();
+    expect(completion.mock.calls[0][1]).toContain(
+      'workflow returned a non-JSON-serializable value of type object',
+    );
+  });
+
+  it('captures the owning todo work chain for completion routing', () => {
+    const r = new WorkflowRunRegistry();
+    const completion = vi.fn();
+    r.setCompletionCallback(completion);
+    const entry = todoWorkChainContext.run('workflow-chain', () =>
+      r.register(reg('wf_chain', { isBackgrounded: true })),
+    );
+    r.complete(entry.runId, 'done', 1_000);
+
+    expect(entry.todoWorkChainId).toBe('workflow-chain');
+    expect(completion.mock.calls[0][2].todoWorkChainId).toBe('workflow-chain');
   });
 
   it('errors thrown by the notification callback do not break the call site', () => {

--- a/packages/core/src/agents/workflow-run-registry.ts
+++ b/packages/core/src/agents/workflow-run-registry.ts
@@ -16,12 +16,11 @@
  * Transitions out of running are one-shot — complete / fail / cancel
  * become no-ops once the entry has settled.
  *
- * Unlike `BackgroundTaskRegistry`, the workflow registry does NOT emit
- * any `<task-notification>` XML or model-facing prose — `WorkflowTool`
- * already returns its own llmContent + returnDisplay payload to the
- * model when the run terminates, so a second envelope would duplicate
- * the signal. The registry is UI-only: its callbacks drive the pill
- * counts, the dialog roster, and the per-phase detail body.
+ * Foreground runs return through the normal tool-result channel. Background
+ * runs additionally emit one terminal `<task-notification>` through a
+ * dedicated model-completion callback. That slot is separate from the
+ * terminal-bell callback so the CLI can subscribe to both without either
+ * consumer replacing the other.
  */
 
 import type { TaskBase, TaskRegistration } from './tasks/types.js';
@@ -38,6 +37,10 @@ import {
   type ToolConfirmationPayload,
 } from '../tools/tools.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
+import { todoWorkChainContext } from '../utils/promptIdContext.js';
+import { stripAnsiAndControl } from '../utils/textUtils.js';
+import { escapeXml } from '../utils/xml.js';
+import { runOutsideAgentContext } from './runtime/agent-context.js';
 
 const debugLogger = createDebugLogger('WORKFLOW_REGISTRY');
 
@@ -83,6 +86,8 @@ export interface WorkflowTask extends TaskBase {
    */
   meta: WorkflowMeta | null;
   status: WorkflowStatus;
+  /** Whether the tool returned before this run reached a terminal state. */
+  isBackgrounded?: boolean;
   /** Title of the most recent `phase(...)` call, or `null` before the first phase. */
   currentPhase: string | null;
   /**
@@ -167,6 +172,7 @@ export type WorkflowTaskRegistration = Omit<
   | 'script'
   | 'description'
   | 'pendingApprovals'
+  | 'isBackgrounded'
 > & {
   // Allow the caller to omit `description` — we synthesize it from
   // `meta?.name ?? runId` for symmetry with shell registry's `command`
@@ -183,6 +189,8 @@ export type WorkflowTaskRegistration = Omit<
    * callers / tests). Needed for run snapshots + the save-to-disk dialog.
    */
   script?: string;
+  /** Defaults to false for legacy and foreground callers. */
+  isBackgrounded?: boolean;
 };
 
 /** Fires when a new entry is registered. */
@@ -204,6 +212,16 @@ export type WorkflowRunStatusChangeCallback = (entry?: WorkflowTask) => void;
  * `useBackgroundTaskView` owns), so the two never clobber each other.
  */
 export type WorkflowRunNotificationCallback = (entry: WorkflowTask) => void;
+export interface WorkflowRunCompletionMeta {
+  runId: string;
+  status: Extract<WorkflowStatus, 'completed' | 'failed'>;
+  todoWorkChainId?: string;
+}
+export type WorkflowRunCompletionCallback = (
+  displayText: string,
+  modelText: string,
+  meta: WorkflowRunCompletionMeta,
+) => void;
 export type WorkflowApprovalChangeCallback = (entry: WorkflowTask) => void;
 export type WorkflowApprovalRequestCallback = (
   entry: WorkflowTask,
@@ -224,6 +242,7 @@ export class WorkflowRunRegistry {
   private registerCallback: WorkflowRunRegisterCallback | undefined;
   private statusChangeCallback: WorkflowRunStatusChangeCallback | undefined;
   private notificationCallback: WorkflowRunNotificationCallback | undefined;
+  private completionCallback: WorkflowRunCompletionCallback | undefined;
   private approvalChangeCallback: WorkflowApprovalChangeCallback | undefined;
   private approvalRequestCallback: WorkflowApprovalRequestCallback | undefined;
   private readonly approvalRuntimes = new Map<
@@ -271,6 +290,14 @@ export class WorkflowRunRegistry {
     this.notificationCallback = cb;
   }
 
+  setCompletionCallback(cb: WorkflowRunCompletionCallback | undefined): void {
+    this.completionCallback = cb;
+  }
+
+  hasCompletionCallback(): boolean {
+    return this.completionCallback !== undefined;
+  }
+
   setApprovalChangeCallback(
     cb: WorkflowApprovalChangeCallback | undefined,
   ): void {
@@ -293,6 +320,46 @@ export class WorkflowRunRegistry {
     }
   }
 
+  private emitCompletion(entry: WorkflowTask): void {
+    if (!entry.isBackgrounded || !this.completionCallback) return;
+    if (entry.status !== 'completed' && entry.status !== 'failed') return;
+
+    const statusText = entry.status === 'completed' ? 'completed' : 'failed';
+    const label = stripAnsiAndControl(entry.description) || entry.runId;
+    const displayText = `Background workflow "${label}" ${statusText}.`;
+    const modelParts = [
+      '<task-notification>',
+      '<kind>workflow</kind>',
+      `<task-id>${escapeXml(entry.runId)}</task-id>`,
+      `<status>${entry.status}</status>`,
+      `<summary>Background workflow "${escapeXml(label)}" ${statusText}.</summary>`,
+    ];
+    if (entry.status === 'completed' && entry.result !== undefined) {
+      modelParts.push(
+        `<result>${escapeXml(stringifyCompletionResult(entry.result))}</result>`,
+      );
+    }
+    if (entry.status === 'failed') {
+      modelParts.push(
+        `<result>Error: ${escapeXml(entry.error ?? '')}</result>`,
+      );
+    }
+    modelParts.push('</task-notification>');
+
+    const meta: WorkflowRunCompletionMeta = {
+      runId: entry.runId,
+      status: entry.status,
+      todoWorkChainId: entry.todoWorkChainId,
+    };
+    try {
+      runOutsideAgentContext(() =>
+        this.completionCallback!(displayText, modelParts.join('\n'), meta),
+      );
+    } catch (error) {
+      debugLogger.error('Failed to emit workflow completion:', error);
+    }
+  }
+
   /**
    * Register a new run. Mutates the registration in place to graduate
    * it to a `WorkflowTask` (sets `id`, `kind`, derived counters), so
@@ -300,11 +367,20 @@ export class WorkflowRunRegistry {
    * observers see updates without an extra `get()`.
    */
   register(registration: WorkflowTaskRegistration): WorkflowTask {
+    const existing = this.entries.get(registration.runId);
+    if (
+      existing?.status === 'running' ||
+      this.handles.has(registration.runId)
+    ) {
+      throw new Error(`Workflow run ${registration.runId} is already active.`);
+    }
     const entry = registration as WorkflowTask;
     entry.id = registration.runId;
     entry.kind = 'workflow';
     entry.outputOffset = 0;
     entry.notified = false;
+    entry.isBackgrounded = registration.isBackgrounded ?? false;
+    entry.todoWorkChainId ??= todoWorkChainContext.getStore();
     entry.currentPhase = null;
     entry.phases = [];
     entry.agentsDispatched = 0;
@@ -655,6 +731,7 @@ export class WorkflowRunRegistry {
     entry.notified = true;
     this.emitStatusChange(entry);
     this.emitNotification(entry);
+    this.emitCompletion(entry);
     this.evictTerminal();
   }
 
@@ -668,6 +745,7 @@ export class WorkflowRunRegistry {
     entry.notified = true;
     this.emitStatusChange(entry);
     this.emitNotification(entry);
+    this.emitCompletion(entry);
     this.evictTerminal();
   }
 
@@ -846,6 +924,15 @@ export class WorkflowRunRegistry {
     } catch (error) {
       debugLogger.error('Failed to emit workflow approval change:', error);
     }
+  }
+}
+
+function stringifyCompletionResult(result: unknown): string {
+  if (typeof result === 'string') return result;
+  try {
+    return JSON.stringify(result) ?? String(result);
+  } catch {
+    return `(workflow returned a non-JSON-serializable value of type ${typeof result})`;
   }
 }
 

--- a/packages/core/src/tools/workflow/workflow.test.ts
+++ b/packages/core/src/tools/workflow/workflow.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -12,6 +12,7 @@ import { WorkflowTool } from './workflow.js';
 import type { Config } from '../../config/config.js';
 import { ToolNames, ToolDisplayNames } from '../tool-names.js';
 import { WorkflowRunRegistry } from '../../agents/workflow-run-registry.js';
+import { WorkflowJournal } from '../../agents/runtime/workflow-journal.js';
 import { Storage } from '../../config/storage.js';
 
 function fakeConfig(): Config {
@@ -42,6 +43,10 @@ describe('WorkflowTool', () => {
     const tool = new WorkflowTool(fakeConfig());
     expect(tool.name).toBe(ToolNames.WORKFLOW);
     expect(tool.displayName).toBe(ToolDisplayNames.WORKFLOW);
+    const schema = tool.schema.parametersJsonSchema as {
+      properties: { run_in_background: { default?: boolean } };
+    };
+    expect(schema.properties.run_in_background.default).toBe(false);
   });
 
   it('rejects build() when script is missing', () => {
@@ -85,6 +90,172 @@ describe('WorkflowTool', () => {
     expect(invocation.params.scriptPath).toBe('/abs/deep-research.js');
     // Description reflects the saved-workflow filename, not a char count.
     expect(invocation.getDescription()).toContain('deep-research.js');
+  });
+
+  it('rejects background runs outside an interactive completion channel', () => {
+    const headlessRegistry = new WorkflowRunRegistry();
+    headlessRegistry.setCompletionCallback(vi.fn());
+    const headlessConfig = {
+      isInteractive: () => false,
+      getWorkflowRunRegistry: () => headlessRegistry,
+    } as unknown as Config;
+    expect(() =>
+      new WorkflowTool(headlessConfig).build({
+        script: 'return 1',
+        run_in_background: true,
+      }),
+    ).toThrow(/interactive TUI/i);
+
+    const interactiveRegistry = new WorkflowRunRegistry();
+    const interactiveConfig = {
+      isInteractive: () => true,
+      getWorkflowRunRegistry: () => interactiveRegistry,
+    } as unknown as Config;
+    expect(() =>
+      new WorkflowTool(interactiveConfig).build({
+        script: 'return 1',
+        run_in_background: true,
+      }),
+    ).toThrow(/completion channel/i);
+
+    interactiveRegistry.setCompletionCallback(vi.fn());
+    const acpConfig = {
+      isInteractive: () => true,
+      getExperimentalZedIntegration: () => true,
+      getWorkflowRunRegistry: () => interactiveRegistry,
+    } as unknown as Config;
+    expect(() =>
+      new WorkflowTool(acpConfig).build({
+        script: 'return 1',
+        run_in_background: true,
+      }),
+    ).toThrow(/interactive TUI/i);
+  });
+
+  it('does not register a background run when the caller is already aborted', async () => {
+    const registry = new WorkflowRunRegistry();
+    registry.setCompletionCallback(vi.fn());
+    const config = {
+      isInteractive: () => true,
+      getWorkflowRunRegistry: () => registry,
+    } as unknown as Config;
+    const dispatch = vi.fn(async () => 'unused');
+    const caller = new AbortController();
+    caller.abort();
+
+    const result = await new WorkflowTool(config, { dispatch })
+      .build({ script: 'return 1', run_in_background: true })
+      .execute(caller.signal);
+
+    expect(result).toEqual({
+      llmContent: 'Workflow was cancelled before it could start.',
+      returnDisplay: 'Workflow cancelled.',
+    });
+    expect(registry.list()).toHaveLength(0);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('does not register when cancellation arrives during background preflight', async () => {
+    const registry = new WorkflowRunRegistry();
+    registry.setCompletionCallback(vi.fn());
+    const config = {
+      storage: new Storage(path.join(os.tmpdir(), 'workflow-preflight-test')),
+      isInteractive: () => true,
+      getWorkflowRunRegistry: () => registry,
+    } as unknown as Config;
+    const caller = new AbortController();
+    const dispatch = vi.fn(async () => 'unused');
+    const load = vi
+      .spyOn(WorkflowJournal.prototype, 'load')
+      .mockImplementation(async () => {
+        caller.abort();
+        return { results: new Map(), started: new Map() };
+      });
+
+    try {
+      const result = await new WorkflowTool(config, { dispatch })
+        .build({
+          script: 'return 1',
+          resumeFromRunId: 'wf_1234abcd',
+          run_in_background: true,
+        })
+        .execute(caller.signal);
+
+      expect(result).toEqual({
+        llmContent: 'Workflow was cancelled before it could start.',
+        returnDisplay: 'Workflow cancelled.',
+      });
+      expect(registry.list()).toHaveLength(0);
+      expect(dispatch).not.toHaveBeenCalled();
+    } finally {
+      load.mockRestore();
+    }
+  });
+
+  it('run_in_background=true returns a live handle without late tool updates', async () => {
+    const registry = new WorkflowRunRegistry();
+    registry.setCompletionCallback(vi.fn());
+    const config = {
+      isInteractive: () => true,
+      getWorkflowRunRegistry: () => registry,
+      getSkipWorkflowUsageWarning: () => true,
+    } as unknown as Config;
+    let resolveDispatch: ((value: string) => void) | undefined;
+    const tool = new WorkflowTool(config, {
+      dispatch: () =>
+        new Promise<string>((resolve) => {
+          resolveDispatch = resolve;
+        }),
+    });
+    const updateOutput = vi.fn();
+    const execution = tool
+      .build({
+        script: `phase('slow'); return await agent('work');`,
+        run_in_background: true,
+      })
+      .execute(new AbortController().signal, updateOutput);
+
+    await vi.waitFor(() => expect(resolveDispatch).toBeDefined());
+    const result = await execution;
+    const entry = registry.list()[0]!;
+    expect(entry.status).toBe('running');
+    expect(entry.isBackgrounded).toBe(true);
+    expect(result.llmContent).toEqual([
+      {
+        text: `Workflow started in background.\nRun ID: ${entry.runId}\nStatus: running`,
+      },
+    ]);
+    expect(result.returnDisplay).toBe(
+      `Workflow ${entry.runId} started in the background (status: running). Use Background Tasks to observe or stop it.`,
+    );
+    expect(updateOutput).not.toHaveBeenCalled();
+
+    resolveDispatch?.('done');
+    await registry.getHandle(entry.runId)!.completion;
+    expect(registry.get(entry.runId)?.status).toBe('completed');
+    expect(updateOutput).not.toHaveBeenCalled();
+  });
+
+  it('run_in_background=false preserves the foreground ToolResult byte-for-byte', async () => {
+    const run = async (runInBackground: false | undefined) => {
+      const registry = new WorkflowRunRegistry();
+      const config = {
+        getWorkflowRunRegistry: () => registry,
+        getSkipWorkflowUsageWarning: () => true,
+      } as unknown as Config;
+      const params = {
+        script: `phase('one'); return { answer: 42 };`,
+        resumeFromRunId: 'wf_1234abcd',
+        ...(runInBackground === undefined
+          ? {}
+          : { run_in_background: runInBackground }),
+      };
+      return new WorkflowTool(config, { dispatch: async () => 'unused' })
+        .build(params)
+        .execute(new AbortController().signal);
+    };
+
+    await expect(run(false)).resolves.toEqual(await run(undefined));
   });
 
   it('execute() loads a saved-workflow scriptPath and records its provenance', async () => {

--- a/packages/core/src/tools/workflow/workflow.ts
+++ b/packages/core/src/tools/workflow/workflow.ts
@@ -27,7 +27,10 @@ import { ToolErrorType } from '../tool-error.js';
 import type { Config } from '../../config/config.js';
 import type { WorkflowAgentDispatch } from '../../agents/runtime/workflow-orchestrator.js';
 import { MAX_TOKENS_PER_WORKFLOW_ENV } from '../../agents/runtime/workflow-budget.js';
-import { WorkflowRunner } from '../../agents/runtime/workflow-runner.js';
+import {
+  WorkflowRunner,
+  type WorkflowRunHandle,
+} from '../../agents/runtime/workflow-runner.js';
 import * as path from 'node:path';
 import type { WorkflowTask } from '../../agents/workflow-run-registry.js';
 
@@ -55,6 +58,8 @@ export interface WorkflowParams {
    * runs live and the run goes live for the remainder.
    */
   resumeFromRunId?: string;
+  /** Return after registration and continue the run under session ownership. */
+  run_in_background?: boolean;
 }
 
 export interface WorkflowToolOptions {
@@ -139,6 +144,12 @@ const WORKFLOW_PARAM_SCHEMA = {
         'first changed/missing call onward runs live. Pass the same script ' +
         'and args as the original run for the cache to apply.',
     },
+    run_in_background: {
+      type: 'boolean',
+      default: false,
+      description:
+        'Optional. When true, start the workflow under the interactive session and return a run handle immediately. The Background Tasks view can observe or stop it, and completion is delivered to the conversation when the run settles. Interactive TUI only. Defaults to false.',
+    },
   },
   // `script` is required UNLESS `scriptPath` is supplied; this XOR can't be
   // expressed as a plain `required` list, so it's enforced in
@@ -178,18 +189,50 @@ class WorkflowToolInvocation extends BaseToolInvocation<
     updateOutput?: (output: ToolResultDisplay) => void,
     _shellExecutionConfig?: ShellExecutionConfig,
   ): Promise<ToolResult> {
-    const handle = await WorkflowRunner.start({
-      config: this.config,
-      signal,
-      script: this.params.script,
-      scriptPath: this.params.scriptPath,
-      args: this.params.args,
-      resumeFromRunId: this.params.resumeFromRunId,
-      dispatch: this.toolOptions.dispatch,
-      onUpdate: updateOutput
-        ? (entry) => safeEmitUpdate(updateOutput, entry)
-        : undefined,
-    });
+    const runInBackground = this.params.run_in_background === true;
+    if (runInBackground && signal.aborted) {
+      return backgroundStartCancelledResult();
+    }
+    let handle: WorkflowRunHandle;
+    try {
+      handle = await WorkflowRunner.start({
+        config: this.config,
+        signal,
+        script: this.params.script,
+        scriptPath: this.params.scriptPath,
+        args: this.params.args,
+        resumeFromRunId: this.params.resumeFromRunId,
+        dispatch: this.toolOptions.dispatch,
+        runInBackground,
+        onUpdate:
+          !runInBackground && updateOutput
+            ? (entry) => safeEmitUpdate(updateOutput, entry)
+            : undefined,
+      });
+    } catch (error) {
+      if (runInBackground && signal.aborted) {
+        return backgroundStartCancelledResult();
+      }
+      throw error;
+    }
+    if (runInBackground) {
+      const status = handle.registry?.get(handle.runId)?.status ?? 'running';
+      const usageBanner = resolveUsageBanner(
+        this.config,
+        handle.registry,
+        handle.budget.total,
+      );
+      return {
+        llmContent: [
+          {
+            text: `Workflow started in background.\nRun ID: ${handle.runId}\nStatus: ${status}`,
+          },
+        ],
+        returnDisplay:
+          usageBanner +
+          `Workflow ${handle.runId} started in the background (status: ${status}). Use Background Tasks to observe or stop it.`,
+      };
+    }
     const settlement = await handle.completion;
     if (settlement.ok) {
       const { outcome } = settlement;
@@ -290,6 +333,13 @@ class WorkflowToolInvocation extends BaseToolInvocation<
       };
     }
   }
+}
+
+function backgroundStartCancelledResult(): ToolResult {
+  return {
+    llmContent: 'Workflow was cancelled before it could start.',
+    returnDisplay: 'Workflow cancelled.',
+  };
 }
 
 /**
@@ -481,7 +531,9 @@ export class WorkflowTool extends BaseDeclarativeTool<
         'run — agent() calls whose rolling prefix-hash matches the journal are ' +
         'served from cache for the longest unchanged prefix. Runs are tracked ' +
         'in the background-tasks view and the `/workflows` dialog (live phase ' +
-        'tree, token usage, cancel). Scripts run in a node:vm sandbox without ' +
+        'tree, token usage, cancel). Set `run_in_background: true` to return a ' +
+        'run handle immediately in the interactive TUI and receive completion ' +
+        'through the conversation. Scripts run in a node:vm sandbox without ' +
         'access to the filesystem or shell; all I/O happens through the ' +
         'spawned agents.',
       Kind.Other,
@@ -516,6 +568,17 @@ export class WorkflowTool extends BaseDeclarativeTool<
       !/^wf_[0-9a-f]+$/.test(params.resumeFromRunId)
     ) {
       return 'WorkflowTool: `resumeFromRunId` must match the generated id format `wf_<hex>`.';
+    }
+    if (params.run_in_background === true) {
+      if (
+        !this.config.isInteractive() ||
+        this.config.getExperimentalZedIntegration?.() === true
+      ) {
+        return 'WorkflowTool: `run_in_background` is available only in the interactive TUI.';
+      }
+      if (!this.config.getWorkflowRunRegistry().hasCompletionCallback()) {
+        return 'WorkflowTool: `run_in_background` requires an active workflow completion channel.';
+      }
     }
     return null;
   }


### PR DESCRIPTION
## What this PR does

This adds an opt-in `run_in_background` mode to the Workflow tool while keeping foreground execution as the default. An interactive background workflow returns a run ID and current status after startup, remains visible and cancellable in Background Tasks, and reports its final result back to the conversation through a dedicated completion channel.

Background workflows are owned by the session instead of the completed parent turn. The existing terminal-bell subscriber remains independent from the model-completion subscriber, and background progress never calls the finished tool invocation's live-output callback.

## Why it's needed

Long workflows currently occupy the parent tool turn until every phase finishes, so the user cannot continue the main conversation while orchestration is still running. Detaching only the requested run lets the main session stay usable without changing existing foreground behavior or weakening approval handling.

The first version is deliberately limited to the interactive TUI. Headless and ACP callers reject an explicit background request, and interactive startup also requires a trusted completion channel, preventing silent loss of the final result.

## Reviewer Test Plan

### How to verify

1. Run a workflow without `run_in_background`, and confirm the tool waits for completion and returns the same result and display payload as before.
2. Run a workflow with `run_in_background: true` in the interactive TUI, and confirm the tool returns a run ID and running status before the workflow settles.
3. Continue the main conversation while the workflow is running, then confirm Background Tasks shows the run and can stop it.
4. Let a background workflow complete, and confirm the terminal notification and model-visible completion each occur once. Cancel another run and confirm no success completion is sent.
5. Trigger a subagent permission request from a background workflow, and confirm it remains blocked until the parent session explicitly approves or rejects it.
6. Attempt `run_in_background: true` through headless or ACP mode, and confirm it is rejected before registration or dispatch.

### Evidence (Before & After)

Before: the Workflow tool always waits for the full run, and the main tool turn remains occupied until orchestration settles.

After: the explicit background mode returns immediately, the main session remains usable, the run stays observable and cancellable, and completion is delivered exactly once through the existing external-input queue. Deterministic tests cover foreground byte compatibility, turn-signal detachment, preflight cancellation, session-owned cancellation, approval bridging, callback isolation, XML escaping, and queue delivery. Two consecutive bundled-CLI PTY runs returned the background handle in 51 ms and 45 ms while a deferred subagent remained active; the same session answered another turn, completion reached the model exactly once after the terminal bell, an approval stayed blocked, and stopping that run executed no command and emitted no success completion. The long-running condition used a controlled deferred provider rather than a literal three-minute wait.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS, Node.js >=22, repository fake OpenAI provider, real bundled CLI, Ink/node-pty/xterm PTY harness.

## Risk & Scope

- Main risk or tradeoff: completion delivery uses the existing in-memory interactive notification queue; process termination still cancels the session-owned run rather than persisting it.
- Not validated / out of scope: Windows/Linux real-terminal behavior, pause/resume, restart recovery, remote workflows, and tracing.
- Breaking changes / migration notes: none. `run_in_background` defaults to `false`, and omitted or explicit false follows the existing foreground path.

## Linked Issues

Part of #8105

<!-- qwen-dynamic-workflows-train:2026-07-30.v1:PR2:predecessor=f62fc76533442486ad545c15de123b797283b6aa -->

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 为 Workflow 工具增加可选的 `run_in_background` 模式，同时继续以 foreground 作为默认行为。交互式后台 Workflow 完成启动后会立即返回 run ID 和当前状态，运行期间可在 Background Tasks 中查看和取消，结束后通过独立 completion channel 将最终结果送回当前会话。

后台 Workflow 由 session 持有，不再依赖已经结束的父 turn。原有 terminal bell 订阅与模型 completion 订阅相互独立，后台进度也不会再调用已经结束的工具 invocation 的实时输出回调。

## 为什么需要

当前长 Workflow 会一直占用父工具 turn，直到所有阶段结束，用户无法在编排执行期间继续主会话。仅对显式请求的 run 做后台化，可以让主会话继续使用，同时不改变现有 foreground 行为，也不削弱权限审批。

第一版有意只开放给交互式 TUI。Headless 和 ACP 会在注册前拒绝显式后台请求，交互式启动也必须先存在可信 completion channel，从而避免最终结果被静默丢失。

## Reviewer 测试计划

### 如何验证

1. 不传 `run_in_background` 运行 Workflow，确认工具仍等待完成，并返回与之前相同的结果和展示内容。
2. 在交互式 TUI 中使用 `run_in_background: true`，确认 Workflow 尚未完成时工具已经返回 run ID 和 running 状态。
3. Workflow 运行期间继续主会话，并确认 Background Tasks 能看到并停止该 run。
4. 让一个后台 Workflow 正常完成，确认 terminal notification 和模型可见 completion 都只出现一次；再取消另一个 run，确认不会发送成功 completion。
5. 让后台 Workflow 的子 Agent 发起权限请求，确认必须由父会话显式批准或拒绝，不能自动放行。
6. 在 headless 或 ACP 模式请求 `run_in_background: true`，确认在注册和 dispatch 前明确拒绝。

### 前后证据

改动前：Workflow 工具始终等待整个 run，主工具 turn 会一直占用到编排结束。

改动后：显式后台模式立即返回，主会话可继续使用，run 可观察、可取消，并通过现有 external-input queue 恰好一次地送回 completion。确定性测试覆盖 foreground 逐字兼容、turn signal 解耦、preflight 取消、session owner 取消、审批 bubbling、callback 隔离、XML 转义和队列投递。真实 bundled CLI 连续两次 PTY 运行分别在 51 ms 和 45 ms 返回后台 handle；受控延迟的子 Agent 仍在运行时，同一会话可以继续回答，terminal bell 之后模型只收到一次 completion；审批保持阻塞，停止该 run 后命令未执行，也没有误发成功 completion。长运行条件使用受控 deferred provider 等价覆盖，没有实际等待三分钟。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境

macOS、Node.js >=22、仓库 fake OpenAI provider、真实 bundle CLI、Ink/node-pty/xterm PTY harness。

## 风险与范围

- 主要风险或取舍：completion 复用现有内存型交互通知队列；进程退出时会取消 session-owned run，不会持久化继续执行。
- 未验证或不在范围内：Windows/Linux 真实终端行为、pause/resume、重启恢复、Remote Workflow 和 tracing。
- Breaking change / 迁移：无。`run_in_background` 默认 `false`，省略或显式 false 都继续走现有 foreground 路径。

## 关联 Issue

Part of #8105

</details>
