### PR TITLE
Fix ACP startup failure when extension is loaded from a symlinked directory

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -9,6 +9,7 @@ import {
   chmodSync,
   constants,
   existsSync,
+  realpathSync,
   statSync,
 } from 'node:fs';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -541,9 +542,17 @@ export async function runCliEntryPoint(
   }
 }
 
-if (
-  process.argv[1] !== undefined &&
-  import.meta.url === pathToFileURL(process.argv[1]).href
-) {
+let isMain = false;
+if (process.argv[1] !== undefined) {
+  try {
+    const argvRealHref = pathToFileURL(realpathSync(process.argv[1])).href;
+    const argvHref = pathToFileURL(process.argv[1]).href;
+    isMain = import.meta.url === argvHref || import.meta.url === argvRealHref;
+  } catch {
+    isMain = import.meta.url === pathToFileURL(process.argv[1]).href;
+  }
+}
+
+if (isMain) {
   void runCliEntryPoint();
 }


### PR DESCRIPTION
# Title: Fix ACP startup failure when extension is loaded from a symlinked directory

**Related Issue(s):** Fixes #8308

### Description
The Qwen Code Companion ACP process (`cli.js`) fails to start and exits silently with code `0` in environments where the VS Code extensions directory is symlinked (e.g., remote containers, NixOS, or shared extension volumes). 

This PR fixes the issue by safely normalizing paths before evaluating if the script is being executed as the main module.

### Root Cause
Node.js ESM loader resolves symlinks by default. The main module guard currently compares the physical realpath (`import.meta.url`) directly against the symlinked execution path (`process.argv[1]`). When the extension runs from a symlinked directory, this equality check fails, causing the CLI to bypass initialization.

The two values that should be equal are in fact structurally different paths to the same file:

| Variable | Resolved Value |
|---|---|
| `import.meta.url` | `file:///home/user/.ide-shared/extensions/qwenlm.../cli.js` (physical) |
| `pathToFileURL(process.argv[1]).href` | `file:///home/user/.vscode-server/extensions/qwenlm.../cli.js` (symlinked) |

The guard evaluates to `false`, `runCliEntryPoint()` is never called, and the process exits cleanly with code `0`. Because no exception is thrown, the failure is completely silent from the Node.js side — making it very difficult to diagnose.

#### Why This Has Become a Problem Now

The `import.meta.url === pathToFileURL(process.argv[1]).href` pattern is a well-known, standard ESM idiom for detecting whether a module is the main entrypoint (the ESM equivalent of `require.main === module`). The pattern itself is not wrong — it is **symlink-unaware** in an ecosystem where symlinked extension paths have become a routine deployment reality:

- **Remote Dev Containers** — extensions pre-installed in a shared volume and mounted into the container via a symlinked path.
- **IDE Server setups** — a single shared extension volume symlinked to multiple user-facing paths (e.g., `~/.ide-shared/extensions` → `~/.vscode-server/extensions`).
- **NixOS / declarative environments** — the filesystem is immutable and all paths resolve through `/nix/store/` symlinks.
- **Rootless / multi-user environments** — system-wide extension installs symlinked per-user.

As Qwen Code Companion adoption grows, it is increasingly being deployed in exactly these setups.

```mermaid
graph LR
    subgraph INVOKE["① Invocation"]
        direction TB
        SH["IDE Extension Host\nspawns child process"]:::actor
        CMD["node cli.js --acp\n(via symlinked extensions dir)"]:::cmd
        SH --> CMD
    end

    subgraph RESOLVE["② Node.js ESM Resolution"]
        direction TB
        ARGV["process.argv[1]\n→ symlinked path"]:::symlink
        META["import.meta.url\n→ physical realpath\n(symlink resolved by loader)"]:::real
    end

    subgraph GUARD["③ Main Module Guard"]
        direction TB
        CMP{"argv[1]\n==\nimport.meta.url ?"}
        FAIL["FALSE\nPaths do not match"]:::fail
        CMP --> FAIL
    end

    subgraph OUTCOME["④ Outcome"]
        direction TB
        EXIT["Process exits\ncode 0 — silently"]:::fail
        ERR["IDE reports:\nFailed to connect to Qwen agent"]:::fail
        EXIT --> ERR
    end

    CMD --> ARGV
    CMD --> META
    ARGV --> CMP
    META --> CMP
    FAIL --> EXIT

    classDef actor fill:#dfe6ff,stroke:#3d5afe,stroke-width:2px,color:#1a237e
    classDef cmd fill:#ede7f6,stroke:#7e57c2,stroke-width:2px,color:#311b92
    classDef symlink fill:#fff3cd,stroke:#f0ad4e,stroke-width:2px,color:#5d4037
    classDef real fill:#cce5ff,stroke:#1565c0,stroke-width:2px,color:#0d47a1
    classDef fail fill:#f9d0c4,stroke:#c62828,stroke-width:2px,color:#b71c1c
```

### Affected User Groups

This bug impacts any user whose VS Code extensions directory is resolved through a symlink at runtime. The following environments are known to produce this condition:

| User Group | Affected Setup | Likelihood |
|---|---|---|
| **Remote Container / Devcontainer users** | Extensions pre-mounted into container at a symlinked path | High |
| **IDE Server users** (Gitpod, GitHub Codespaces, self-hosted) | Server manages extensions in a shared volume, symlinked per-workspace | High |
| **NixOS users** | All filesystem paths are symlinks into `/nix/store/` | High |
| **Shared / multi-user Linux environments** | Admin installs extensions system-wide, per-user symlinks created | Medium |
| **WSL2 / cross-filesystem mounts** | Extensions installed on Windows filesystem, accessed from Linux via symlink | Low–Medium |

> **Impact:** The extension is completely non-functional for all of the above groups. There is no graceful degradation — the ACP process exits silently, leaving users with no error message that identifies the root cause.

---

### Proposed Fix
Updated the main module guard in `packages/cli/src/cli.ts` (and compiled `cli.js`) to verify the resolved realpath. A `try/catch` block ensures that if `realpathSync` fails, we safely fall back to the original behavior without crashing the process.

```mermaid
graph TD
    subgraph BEFORE["❌ Before Fix"]
        direction TB
        B1["process.argv[1] (symlinked path)"]:::symlink
        B2["import.meta.url (physical realpath)"]:::real
        B3{"Strict equality check\nargv[1] == import.meta.url"}
        B4["❌ Always FALSE in symlinked env\ncli.js exits silently (code 0)"]:::fail

        B1 --> B3
        B2 --> B3
        B3 --> B4
    end

    subgraph AFTER["✅ After Fix"]
        direction TB
        A1["process.argv[1] (symlinked path)"]:::symlink

        subgraph TRY["try"]
            A2["fs.realpathSync(argv[1])\n→ physical realpath"]:::real
            A3{"argv[1] == import.meta.url\nOR\nrealpath(argv[1]) == import.meta.url"}
        end

        subgraph CATCH["catch (if realpathSync fails)"]
            A4{"argv[1] == import.meta.url\n(original check as fallback)"}
        end

        A5["✅ isMain = true\nrunCliEntryPoint()"]:::success
        A6["isMain = false\nSkip initialization"]:::neutral

        A1 --> TRY
        A1 --> CATCH
        A2 --> A3
        A3 -->|Match| A5
        A3 -->|No match| A6
        A4 -->|Match| A5
        A4 -->|No match| A6
    end




    classDef symlink fill:#fff3cd,stroke:#f0ad4e,stroke-width:2px,color:#5d4037
    classDef real fill:#cce5ff,stroke:#1565c0,stroke-width:2px,color:#0d47a1
    classDef fail fill:#f9d0c4,stroke:#c62828,stroke-width:2px,color:#b71c1c
    classDef success fill:#d9ead3,stroke:#2e7d32,stroke-width:2px,color:#1b5e20
    classDef neutral fill:#eeeeee,stroke:#616161,stroke-width:1px,color:#212121
```

```typescript
import { realpathSync } from "node:fs";
import { pathToFileURL } from "node:url";

let isMain = false;
if (process.argv[1] !== undefined) {
  try {
    const argvRealHref = pathToFileURL(realpathSync(process.argv[1])).href;
    const argvHref = pathToFileURL(process.argv[1]).href;
    isMain = import.meta.url === argvHref || import.meta.url === argvRealHref;
  } catch (e) {
    isMain = import.meta.url === pathToFileURL(process.argv[1]).href;
  }
}

if (isMain) {
  void runCliEntryPoint();
}
```

### Reproduction Steps
1. Create a symlinked extensions directory: `ln -s /actual/path/extensions ~/.vscode-server/extensions`
2. Install the Qwen Code Companion extension.
3. Launch the IDE and observe the extension failing to connect to the agent.
4. Manually running the CLI outputs nothing: `node ~/.vscode-server/extensions/qwenlm.../dist/qwen-cli/cli.js --help`

### Testing Environment
* **OS:** Linux Mint 22.3 (Ubuntu/Debian based) via Antigravity IDE Server
* **Node Version:** v24.18.1
* **Extension Setup:** The IDE extensions directory (`~/.antigravity-ide-server/extensions`) is symlinked to a persistent shared volume (`~/.ide-shared/extensions`).

### Fix Evaluation

#### Is this a permanent fix or a temporary workaround?
**This is a permanent fix.** It corrects the fundamental comparison logic rather than patching around it (e.g., with environment variables or shell wrappers). The solution uses only Node.js built-in APIs (`node:fs`, `node:url`) and does not introduce any new dependencies.

#### How useful is this fix?
**High value.** The bug renders the extension completely non-functional for a broad and growing category of users — anyone using remote development environments, containers, NixOS, or shared extension volumes. These are not niche setups; they represent the majority of modern cloud and enterprise development workflows. Fixing this unblocks the extension for a significant portion of the user base.

#### What are the risks?

| Risk | Severity | Mitigation |
|---|---|---|
| `realpathSync` throws on a valid path (e.g., race condition, permission error) | Low | Handled by the `catch` block, which falls back to the original behavior |
| Regression on non-symlinked installs | Very Low | The fix checks *both* the symlinked and resolved paths, so non-symlinked installs still match on the first condition (`argv[1] == import.meta.url`) |
| Synchronous `realpathSync` blocking the event loop | Negligible | This guard runs once at startup before any async work begins |
| Cross-platform path normalization edge cases (Windows) | Low | `pathToFileURL` handles platform-specific path separators consistently |

#### Does this conflict with the intended design or architecture of the system?
**No.** The intended behavior is clearly for `cli.js` to call `runCliEntryPoint()` when invoked as the main module. The original guard was simply an incomplete implementation of that intent — it did not account for the Node.js ESM loader's symlink resolution behavior. This fix makes the guard correctly honor the intended design across all supported deployment environments.

#### Could a better long-term solution exist?
Potentially. Node.js introduced `--preserve-symlinks` and `--preserve-symlinks-main` flags to prevent the ESM loader from resolving symlinks. However, configuring these flags requires modifying the Node.js invocation in the IDE extension host, which is outside the scope of `cli.ts` and would require changes from the IDE vendor side. The `realpathSync` guard in `cli.ts` is the correct, self-contained fix at the CLI level.

---
