### PR TITLE
fix(mobile-mcp): Remove legacy Hono dependency

### DIFF
--- a/docs/design/mobile-mcp-node22-baseline.md
+++ b/docs/design/mobile-mcp-node22-baseline.md
@@ -1,0 +1,55 @@
+# Mobile MCP Node.js 22 Baseline
+
+## Decision
+
+`@qwen-code/mobile-mcp` requires Node.js 22 or later, pins
+`@modelcontextprotocol/sdk` 1.30.0, and directly requires
+`@hono/node-server` 2.0.12.
+
+The package is released independently from Qwen Code, but its release workflow
+already uses the repository `.nvmrc`, which selects Node.js 22. The repository
+does not test or publish this package on Node.js 18. The upstream
+`mobile-next/mobile-mcp` package has also moved its baseline to Node.js 20.
+Keeping the fork's Node.js 18 declaration would therefore advertise an
+untested compatibility promise.
+
+## Dependency boundary
+
+MCP SDK 1.26.0 restricts `@hono/node-server` to the vulnerable 1.x line covered
+by [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9).
+MCP SDK 1.30.0 permits Hono Node Server 2.0.5 or later, whose engine requires
+Node.js 20 or later, but its compatibility range also permits Hono 1.x. An
+existing consumer lockfile can therefore retain Hono 1.x when only the SDK is
+upgraded. The direct Hono 2.0.12 requirement removes that upgrade path while
+remaining compatible with the SDK. Using the repository's Node.js 22 baseline
+makes the resulting dependency resolution supported by both the package
+declaration and the release environment.
+
+The monorepo hoists the SDK beside a different Zod installation from the Zod
+copy used by mobile-mcp. SDK 1.30.0 supports Zod 3 and 4 schemas at runtime,
+but TypeScript treats schemas from those two installations as incompatible.
+The mobile server therefore narrows this to a compile-time boundary when it
+passes its local schemas to the SDK. The boundary does not transform schemas
+or change validation behavior, and the server integration tests exercise the
+same workspace resolution used by the release workflow.
+
+This change addresses only the MCP SDK/Hono advisory tracked by #8269. Other
+production audit findings, including findings in the independently versioned
+mobilewright dependency tree, remain separate upgrade decisions.
+
+## Verification
+
+- Generate both the repository and standalone mobile package lockfiles.
+- Build in both workspace and standalone installations, then run the
+  non-device Playwright suite on Node.js 22.
+- Inspect `npm pack` and confirm the packed manifest declares Node.js 22,
+  MCP SDK 1.30.0, and Hono Node Server 2.0.12.
+- Run a production dependency audit and confirm it no longer reports
+  `@modelcontextprotocol/sdk` or `@hono/node-server` through mobile-mcp.
+
+## Compatibility and rollback
+
+Node.js 18 and 20 consumers must upgrade their runtime before installing the
+next mobile-mcp release. Rolling back the runtime baseline would also require a
+supported MCP SDK dependency path that does not restore the vulnerable Hono 1.x
+tree; forcing Hono 2 beneath MCP SDK 1.26.0 is not supported.

--- a/docs/design/mobile-mcp-node22-baseline.md
+++ b/docs/design/mobile-mcp-node22-baseline.md
@@ -4,7 +4,7 @@
 
 `@qwen-code/mobile-mcp` requires Node.js 22 or later, pins
 `@modelcontextprotocol/sdk` 1.30.0, and directly requires
-`@hono/node-server` 2.0.12.
+`@hono/node-server` `^2.0.12`.
 
 The package is released independently from Qwen Code, but its release workflow
 already uses the repository `.nvmrc`, which selects Node.js 22. The repository
@@ -20,18 +20,36 @@ by [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9).
 MCP SDK 1.30.0 permits Hono Node Server 2.0.5 or later, whose engine requires
 Node.js 20 or later, but its compatibility range also permits Hono 1.x. An
 existing consumer lockfile can therefore retain Hono 1.x when only the SDK is
-upgraded. The direct Hono 2.0.12 requirement removes that upgrade path while
-remaining compatible with the SDK. Using the repository's Node.js 22 baseline
-makes the resulting dependency resolution supported by both the package
-declaration and the release environment.
+upgraded. The direct `@hono/node-server` `^2.0.12` requirement removes that
+upgrade path while remaining compatible with the SDK. The caret range keeps
+the same "never 1.x" guarantee while still receiving future 2.x patches.
+Using the repository's Node.js 22 baseline makes the resulting dependency
+resolution supported by both the package declaration and the release
+environment.
 
-The monorepo hoists the SDK beside a different Zod installation from the Zod
-copy used by mobile-mcp. SDK 1.30.0 supports Zod 3 and 4 schemas at runtime,
-but TypeScript treats schemas from those two installations as incompatible.
-The mobile server therefore narrows this to a compile-time boundary when it
-passes its local schemas to the SDK. The boundary does not transform schemas
-or change validation behavior, and the server integration tests exercise the
-same workspace resolution used by the release workflow.
+`@hono/node-server` is declared as a resolution floor, not because the fork
+imports it directly: no source file references it. It must not be removed in a
+dependency cleanup. A `depcheck`-style pass will report it as unused, but
+dropping it reopens the Hono 1.x upgrade path that the SDK's permissive peer
+range otherwise allows.
+
+The monorepo workspace and the published package resolve Zod differently. In
+the workspace, npm hoists the SDK to the repository root, where it resolves the
+root `zod@3`, while `packages/mobile-mcp` keeps its own `zod@4`; the two
+installations are nominally incompatible in TypeScript even though SDK 1.30.0
+validates both Zod 3 and Zod 4 schemas at runtime. The mobile server therefore
+bridges the mismatch with a single compile-time cast (`sdkInputSchema` in
+`src/server.ts`) when it passes its local schemas to the SDK. The cast does not
+transform schemas or change validation behavior.
+
+The published package does not have this split. The release workflow
+(`cd-mobile-mcp.yml`) installs against the standalone
+`packages/mobile-mcp/package-lock.json`, which resolves a single `zod@4`, and
+builds and runs the non-device Playwright suites in that layout. The workspace
+cast exists only to keep the monorepo's TypeScript build green; it is never
+exercised by the configuration that ships. Aligning the workspace on a single
+Zod copy would remove the cast entirely and is follow-up work, not part of this
+security change.
 
 This change addresses only the MCP SDK/Hono advisory tracked by #8269. Other
 production audit findings, including findings in the independently versioned
@@ -43,7 +61,7 @@ mobilewright dependency tree, remain separate upgrade decisions.
 - Build in both workspace and standalone installations, then run the
   non-device Playwright suite on Node.js 22.
 - Inspect `npm pack` and confirm the packed manifest declares Node.js 22,
-  MCP SDK 1.30.0, and Hono Node Server 2.0.12.
+  MCP SDK 1.30.0, and Hono Node Server `^2.0.12`.
 - Run a production dependency audit and confirm it no longer reports
   `@modelcontextprotocol/sdk` or `@hono/node-server` through mobile-mcp.
 

--- a/docs/design/mobile-mcp-node22-baseline.md
+++ b/docs/design/mobile-mcp-node22-baseline.md
@@ -71,3 +71,20 @@ Node.js 18 and 20 consumers must upgrade their runtime before installing the
 next mobile-mcp release. Rolling back the runtime baseline would also require a
 supported MCP SDK dependency path that does not restore the vulnerable Hono 1.x
 tree; forcing Hono 2 beneath MCP SDK 1.26.0 is not supported.
+
+Because the `engines` bump is breaking for consumers, the next mobile-mcp
+release tag should be a minor bump rather than a patch.
+
+## Follow-up work
+
+Two deferred items are intentionally out of scope for this security change and
+are recorded here so they do not evaporate:
+
+- Align the monorepo workspace on a single Zod copy, then delete the
+  `sdkInputSchema` cast in `src/server.ts` that bridges the workspace's split
+  Zod resolution.
+- Add a mobile-mcp CI job that runs `tsc --noEmit` and the non-device
+  Playwright suites, closing the coverage gap that predates this change.
+
+These items do not yet have a tracking issue; one should be opened and linked
+here.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28227,7 +28227,7 @@
       "version": "0.20.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@hono/node-server": "2.0.12",
+        "@hono/node-server": "^2.0.12",
         "@modelcontextprotocol/sdk": "1.30.0",
         "ajv": "^8.18.0",
         "commander": "14.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28227,7 +28227,8 @@
       "version": "0.20.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "1.26.0",
+        "@hono/node-server": "2.0.12",
+        "@modelcontextprotocol/sdk": "1.30.0",
         "ajv": "^8.18.0",
         "commander": "14.0.0",
         "express": "5.1.0",
@@ -28260,111 +28261,7 @@
         "typescript": "5.8.2"
       },
       "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/mobile-mcp/node_modules/@hono/node-server": {
-      "version": "1.19.17",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
-      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.14.1"
-      },
-      "peerDependencies": {
-        "hono": "^4"
-      }
-    },
-    "packages/mobile-mcp/node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
-      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
-      "license": "MIT",
-      "dependencies": {
-        "@hono/node-server": "^1.19.9",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
-        "cross-spawn": "^7.0.5",
-        "eventsource": "^3.0.2",
-        "eventsource-parser": "^3.0.0",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.2.1",
-        "hono": "^4.11.4",
-        "jose": "^6.1.3",
-        "json-schema-typed": "^8.0.2",
-        "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
-          "optional": true
-        },
-        "zod": {
-          "optional": false
-        }
-      }
-    },
-    "packages/mobile-mcp/node_modules/@modelcontextprotocol/sdk/node_modules/express": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
-      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "^2.0.0",
-        "body-parser": "^2.2.1",
-        "content-disposition": "^1.0.0",
-        "content-type": "^1.0.5",
-        "cookie": "^0.7.1",
-        "cookie-signature": "^1.2.1",
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "finalhandler": "^2.1.0",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "merge-descriptors": "^2.0.0",
-        "mime-types": "^3.0.0",
-        "on-finished": "^2.4.1",
-        "once": "^1.4.0",
-        "parseurl": "^1.3.3",
-        "proxy-addr": "^2.0.7",
-        "qs": "^6.14.0",
-        "range-parser": "^1.2.1",
-        "router": "^2.2.0",
-        "send": "^1.1.0",
-        "serve-static": "^2.2.0",
-        "statuses": "^2.0.1",
-        "type-is": "^2.0.1",
-        "vary": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "packages/mobile-mcp/node_modules/@modelcontextprotocol/sdk/node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
+        "node": ">=22.0.0"
       }
     },
     "packages/mobile-mcp/node_modules/@types/node": {

--- a/packages/mobile-mcp/.vendored-patches.md
+++ b/packages/mobile-mcp/.vendored-patches.md
@@ -6,13 +6,14 @@ Upstream sync mechanism: `git subtree pull` (see `scripts/sync-from-upstream.sh`
 
 ## Local modifications
 
-| Patch                            | Description                                                                                                                                           | Touches                                           |
-| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
-| Rename to @qwen-code/mobile-mcp  | npm package name, repository field                                                                                                                    | `package.json`                                    |
-| Disable upstream telemetry       | Fork doesn't phone home to upstream PostHog                                                                                                           | `src/server.ts`                                   |
-| Relative coordinate shim         | Opt-in 0–1000 normalized coordinates (env `MOBILE_MCP_COORDINATE_SPACE`)                                                                              | `src/coord-norm.ts`, `src/server.ts`              |
-| InstallOptions + Android tools   | Extended `installApp` with options; added `dumpUiHierarchy`, `pullFile`, `pushFile`; MCP tools `mobile_ui_dump`, `mobile_adb_pull`, `mobile_adb_push` | `src/robot.ts`, `src/android.ts`, `src/server.ts` |
-| getAndroidRobotFromDevice helper | DRY extraction for Android-only tool device validation                                                                                                | `src/server.ts`                                   |
+| Patch                            | Description                                                                                                                                           | Touches                                                 |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| Rename to @qwen-code/mobile-mcp  | npm package name, repository field                                                                                                                    | `package.json`                                          |
+| Node runtime and MCP SDK         | Require Node.js 22+, pin MCP SDK 1.30.0, require Hono Node Server 2.0.12, and bridge the SDK's Zod-compatible schema type at the workspace boundary   | `package.json`, lockfiles, `src/server.ts`, `README.md` |
+| Disable upstream telemetry       | Fork doesn't phone home to upstream PostHog                                                                                                           | `src/server.ts`                                         |
+| Relative coordinate shim         | Opt-in 0–1000 normalized coordinates (env `MOBILE_MCP_COORDINATE_SPACE`)                                                                              | `src/coord-norm.ts`, `src/server.ts`                    |
+| InstallOptions + Android tools   | Extended `installApp` with options; added `dumpUiHierarchy`, `pullFile`, `pushFile`; MCP tools `mobile_ui_dump`, `mobile_adb_pull`, `mobile_adb_push` | `src/robot.ts`, `src/android.ts`, `src/server.ts`       |
+| getAndroidRobotFromDevice helper | DRY extraction for Android-only tool device validation                                                                                                | `src/server.ts`                                         |
 
 ## When syncing upstream
 

--- a/packages/mobile-mcp/.vendored-patches.md
+++ b/packages/mobile-mcp/.vendored-patches.md
@@ -6,14 +6,14 @@ Upstream sync mechanism: `git subtree pull` (see `scripts/sync-from-upstream.sh`
 
 ## Local modifications
 
-| Patch                            | Description                                                                                                                                           | Touches                                                 |
-| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| Rename to @qwen-code/mobile-mcp  | npm package name, repository field                                                                                                                    | `package.json`                                          |
-| Node runtime and MCP SDK         | Require Node.js 22+, pin MCP SDK 1.30.0, require Hono Node Server 2.0.12, and bridge the SDK's Zod-compatible schema type at the workspace boundary   | `package.json`, lockfiles, `src/server.ts`, `README.md` |
-| Disable upstream telemetry       | Fork doesn't phone home to upstream PostHog                                                                                                           | `src/server.ts`                                         |
-| Relative coordinate shim         | Opt-in 0–1000 normalized coordinates (env `MOBILE_MCP_COORDINATE_SPACE`)                                                                              | `src/coord-norm.ts`, `src/server.ts`                    |
-| InstallOptions + Android tools   | Extended `installApp` with options; added `dumpUiHierarchy`, `pullFile`, `pushFile`; MCP tools `mobile_ui_dump`, `mobile_adb_pull`, `mobile_adb_push` | `src/robot.ts`, `src/android.ts`, `src/server.ts`       |
-| getAndroidRobotFromDevice helper | DRY extraction for Android-only tool device validation                                                                                                | `src/server.ts`                                         |
+| Patch                            | Description                                                                                                                                           | Touches                                                                 |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Rename to @qwen-code/mobile-mcp  | npm package name, repository field                                                                                                                    | `package.json`                                                          |
+| Node runtime and MCP SDK         | Require Node.js 22+, pin MCP SDK 1.30.0, require Hono Node Server ^2.0.12, and bridge the SDK's Zod-compatible schema type at the workspace boundary  | `package.json`, lockfiles, `src/server.ts`, `README.md`, `CHANGELOG.md` |
+| Disable upstream telemetry       | Fork doesn't phone home to upstream PostHog                                                                                                           | `src/server.ts`                                                         |
+| Relative coordinate shim         | Opt-in 0–1000 normalized coordinates (env `MOBILE_MCP_COORDINATE_SPACE`)                                                                              | `src/coord-norm.ts`, `src/server.ts`                                    |
+| InstallOptions + Android tools   | Extended `installApp` with options; added `dumpUiHierarchy`, `pullFile`, `pushFile`; MCP tools `mobile_ui_dump`, `mobile_adb_pull`, `mobile_adb_push` | `src/robot.ts`, `src/android.ts`, `src/server.ts`                       |
+| getAndroidRobotFromDevice helper | DRY extraction for Android-only tool device validation                                                                                                | `src/server.ts`                                                         |
 
 ## When syncing upstream
 

--- a/packages/mobile-mcp/CHANGELOG.md
+++ b/packages/mobile-mcp/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
-* Breaking: Require Node.js 22 or later, matching the supported Qwen Code runtime.
-* Security: Update `@modelcontextprotocol/sdk` to 1.30.0 and require `@hono/node-server` 2.0.12, removing the vulnerable Hono 1.x dependency path.
+* Breaking: Require Node.js 22 or later, matching the supported Qwen Code runtime. The `engines` field is advisory unless `engine-strict` is enabled, so Node.js 18/20 installs emit an `EBADENGINE` warning rather than failing.
+* Security: Update `@modelcontextprotocol/sdk` to 1.30.0 and require `@hono/node-server` `^2.0.12`, removing the vulnerable Hono 1.x dependency path.
 
 ## [0.0.61](https://github.com/mobile-next/mobile-mcp/releases/tag/0.0.61) (2026-07-02)
 * Fix: Catch system signals for clean v8 exit ([#366](https://github.com/mobile-next/mobile-mcp/pull/366))

--- a/packages/mobile-mcp/CHANGELOG.md
+++ b/packages/mobile-mcp/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Breaking: Require Node.js 22 or later, matching the supported Qwen Code runtime.
+* Security: Update `@modelcontextprotocol/sdk` to 1.30.0 and require `@hono/node-server` 2.0.12, removing the vulnerable Hono 1.x dependency path.
+
 ## [0.0.61](https://github.com/mobile-next/mobile-mcp/releases/tag/0.0.61) (2026-07-02)
 * Fix: Catch system signals for clean v8 exit ([#366](https://github.com/mobile-next/mobile-mcp/pull/366))
 * Fix: Detect go-ios installed via npm (bare semver version) ([#355](https://github.com/mobile-next/mobile-mcp/pull/355)), thanks to [@ravijagga](https://github.com/ravijagga)

--- a/packages/mobile-mcp/README.md
+++ b/packages/mobile-mcp/README.md
@@ -4,6 +4,10 @@ Fork of [mobile-next/mobile-mcp](https://github.com/mobile-next/mobile-mcp) for 
 
 This package is an MCP server that enables LLM agents to interact with mobile devices (iOS and Android) through screenshots, accessibility elements, and coordinate-based touch actions. It supports simulators, emulators, and real devices.
 
+## Requirements
+
+- Node.js 22 or later
+
 ## Upstream
 
 Based on [mobile-next/mobile-mcp](https://github.com/mobile-next/mobile-mcp) v0.0.61 (`c5d7d27`). We track upstream via `git subtree` and will continue to sync updates. See [.vendored-patches.md](.vendored-patches.md) for local modifications and [scripts/sync-from-upstream.sh](scripts/sync-from-upstream.sh) for the sync mechanism.

--- a/packages/mobile-mcp/package-lock.json
+++ b/packages/mobile-mcp/package-lock.json
@@ -1,15 +1,16 @@
 {
-  "name": "@mobilenext/mobile-mcp",
-  "version": "0.0.1",
+  "name": "@qwen-code/mobile-mcp",
+  "version": "0.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@mobilenext/mobile-mcp",
-      "version": "0.0.1",
+      "name": "@qwen-code/mobile-mcp",
+      "version": "0.20.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "1.26.0",
+        "@hono/node-server": "2.0.12",
+        "@modelcontextprotocol/sdk": "1.30.0",
         "ajv": "^8.18.0",
         "commander": "14.0.0",
         "express": "5.1.0",
@@ -42,7 +43,7 @@
         "typescript": "5.8.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -231,12 +232,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -869,12 +870,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
-      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",

--- a/packages/mobile-mcp/package-lock.json
+++ b/packages/mobile-mcp/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.20.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@hono/node-server": "2.0.12",
+        "@hono/node-server": "^2.0.12",
         "@modelcontextprotocol/sdk": "1.30.0",
         "ajv": "^8.18.0",
         "commander": "14.0.0",

--- a/packages/mobile-mcp/package.json
+++ b/packages/mobile-mcp/package.json
@@ -24,7 +24,7 @@
     "lib"
   ],
   "dependencies": {
-    "@hono/node-server": "2.0.12",
+    "@hono/node-server": "^2.0.12",
     "@modelcontextprotocol/sdk": "1.30.0",
     "ajv": "^8.18.0",
     "commander": "14.0.0",

--- a/packages/mobile-mcp/package.json
+++ b/packages/mobile-mcp/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/mobile-mcp"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22.0.0"
   },
   "license": "Apache-2.0",
   "scripts": {
@@ -24,7 +24,8 @@
     "lib"
   ],
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.26.0",
+    "@hono/node-server": "2.0.12",
+    "@modelcontextprotocol/sdk": "1.30.0",
     "ajv": "^8.18.0",
     "commander": "14.0.0",
     "express": "5.1.0",

--- a/packages/mobile-mcp/src/server.ts
+++ b/packages/mobile-mcp/src/server.ts
@@ -91,8 +91,12 @@ export const createMcpServer = (): McpServer => {
 
   type ZodSchemaShape = Record<string, z.ZodType>;
 
-  // Workspaces can resolve the SDK and this package through different Zod copies.
-  // The SDK supports both at runtime; this preserves the local schema inference.
+  // In the monorepo workspace the SDK resolves the root Zod (v3) while this
+  // package resolves its own Zod (v4), so their schema types are nominally
+  // incompatible even though the SDK validates both at runtime. The published
+  // package resolves a single Zod copy and never needs this bridge; it only
+  // spans the dev-only workspace layout. Aligning the workspace on one Zod copy
+  // would let this cast be deleted entirely.
   const sdkInputSchema = <Schema extends ZodSchemaShape>(schema: Schema) =>
     schema as unknown as Schema & ZodRawShapeCompat;
 

--- a/packages/mobile-mcp/src/server.ts
+++ b/packages/mobile-mcp/src/server.ts
@@ -1,4 +1,5 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ZodRawShapeCompat } from '@modelcontextprotocol/sdk/server/zod-compat.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { z } from 'zod';
 import fs from 'node:fs';
@@ -90,6 +91,11 @@ export const createMcpServer = (): McpServer => {
 
   type ZodSchemaShape = Record<string, z.ZodType>;
 
+  // Workspaces can resolve the SDK and this package through different Zod copies.
+  // The SDK supports both at runtime; this preserves the local schema inference.
+  const sdkInputSchema = <Schema extends ZodSchemaShape>(schema: Schema) =>
+    schema as unknown as Schema & ZodRawShapeCompat;
+
   interface ToolAnnotations {
     readOnlyHint?: boolean;
     destructiveHint?: boolean;
@@ -111,7 +117,7 @@ export const createMcpServer = (): McpServer => {
       {
         title,
         description: finalDescription,
-        inputSchema: paramsSchema,
+        inputSchema: sdkInputSchema(paramsSchema),
         annotations,
       },
       (async (args: any, _extra: any) => {
@@ -945,13 +951,13 @@ export const createMcpServer = (): McpServer => {
       title: 'Take Screenshot',
       description:
         "Take a screenshot of the mobile device. Use this to understand what's on screen. Do not cache this result.",
-      inputSchema: {
+      inputSchema: sdkInputSchema({
         device: z
           .string()
           .describe(
             'The device identifier to use. Use mobile_list_available_devices to find which devices are available to you.',
           ),
-      },
+      }),
       annotations: {
         readOnlyHint: true,
       },


### PR DESCRIPTION
## What this PR does

This PR aligns the independently published `@qwen-code/mobile-mcp` package with the repository's Node.js 22 baseline, upgrades `@modelcontextprotocol/sdk` to 1.30.0, and directly requires `@hono/node-server` 2.0.12 so existing consumer lockfiles cannot retain the vulnerable Hono 1.x dependency path. It regenerates both applicable lockfiles, records the runtime and dependency decision, and adds a type-only compatibility boundary for the workspace layout where the SDK and mobile package resolve different supported Zod versions.

## Why it's needed

The mobile package declared Node.js 18 compatibility even though its release workflow already uses the repository's Node.js 22 runtime and no Node.js 18 release validation exists. Its pinned MCP SDK also restricted Hono Node Server to the 1.x line covered by GHSA-frvp-7c67-39w9. Raising the documented baseline and pinning the supported MCP SDK/Hono combination removes that scanner-visible dependency path without forcing an unsupported override beneath the old SDK.

## Reviewer Test Plan

### How to verify

Install the repository workspace on Node.js 22 and build `@qwen-code/mobile-mcp`; the TypeScript build should complete with the workspace's hoisted SDK and Zod layout. Run the four non-device Playwright suites for coordinate normalization, UI dump, payload filtering, and the server boundary; all 32 tests should pass. Then install from the standalone mobile package lockfile, build again, and inspect the packed artifact: its manifest should require Node.js 22, MCP SDK 1.30.0, and Hono Node Server 2.0.12. A production dependency audit may still report unrelated mobilewright findings, but it should no longer report the MCP SDK/Hono advisory through mobile-mcp.

### Evidence (Before & After)

N/A — dependency, type, and documentation changes only.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

macOS with Node.js 22.22.3. Verified the repository workspace build, standalone package build, 32 non-device Playwright tests, `npm pack`, packed CLI `--version` and `--help`, lockfile resolution, and production audit output.

## Risk & Scope

- Main risk or tradeoff: The MCP SDK upgrade crosses a type boundary where the monorepo and mobile package can resolve different supported Zod copies; the bridge is type-only and runtime-identical, and both workspace and standalone builds exercise the two layouts.
- Not validated / out of scope: Device-dependent Playwright coverage requiring ADB, mobilecli, or attached devices; unrelated vulnerabilities in the independently versioned mobilewright dependency tree; Windows and Linux local execution.
- Breaking changes / migration notes: Node.js 18 and 20 consumers must upgrade to Node.js 22 or later before installing the next `@qwen-code/mobile-mcp` release.

## Linked Issues

Closes #8269

Refs #7462

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本 PR 将独立发布的 `@qwen-code/mobile-mcp` 包与仓库的 Node.js 22 基线对齐，将 `@modelcontextprotocol/sdk` 升级到 1.30.0，并直接依赖 `@hono/node-server` 2.0.12，从而避免已有消费者锁文件继续保留存在漏洞的 Hono 1.x 依赖路径。同时重新生成两份适用的锁文件，记录运行时与依赖决策，并为工作区中 SDK 与 mobile 包解析到不同但均受支持的 Zod 版本这一布局增加仅类型层的兼容边界。

## 为什么需要

mobile 包此前声明兼容 Node.js 18，但其发布流程已经使用仓库的 Node.js 22 运行时，并且不存在 Node.js 18 发布验证。其固定的 MCP SDK 版本还将 Hono Node Server 限制在受 GHSA-frvp-7c67-39w9 影响的 1.x 系列。提高明确支持的运行时基线并固定受支持的 MCP SDK/Hono 组合，可以移除安全扫描器可见的依赖路径，同时避免在旧 SDK 下强制使用不受支持的覆盖版本。

## Reviewer 测试计划

### 如何验证

在 Node.js 22 下安装仓库工作区并构建 `@qwen-code/mobile-mcp`；TypeScript 构建应能在工作区提升后的 SDK 与 Zod 布局中完成。运行坐标归一化、UI dump、payload 过滤和服务端边界这四组非设备 Playwright 测试；32 个测试应全部通过。随后从 mobile 包的独立锁文件安装并再次构建，然后检查打包产物：其 manifest 应要求 Node.js 22、MCP SDK 1.30.0 和 Hono Node Server 2.0.12。生产依赖审计可能仍会报告与本 PR 无关的 mobilewright 问题，但不应再通过 mobile-mcp 报告 MCP SDK/Hono 漏洞。

### 证据（改动前后）

N/A——仅依赖、类型和文档变更。

### 测试平台

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅ 已测试   |
| 🪟 Windows |   ⚠️ 未测试   |
|  🐧 Linux  |   ⚠️ 未测试   |

### 环境（可选）

macOS，Node.js 22.22.3。已验证仓库工作区构建、独立包构建、32 个非设备 Playwright 测试、`npm pack`、打包后 CLI 的 `--version` 与 `--help`、锁文件解析和生产依赖审计输出。

## 风险与范围

- 主要风险或取舍：MCP SDK 升级跨越了一个类型边界，单仓工作区与 mobile 包可能解析到不同的受支持 Zod 副本；该桥接仅存在于类型层，运行时保持恒等，并且工作区和独立构建分别覆盖了这两种布局。
- 未验证或不在范围内：需要 ADB、mobilecli 或连接设备的设备相关 Playwright 覆盖；独立版本管理的 mobilewright 依赖树中的无关漏洞；Windows 和 Linux 本地执行。
- 破坏性变更或迁移说明：Node.js 18 和 20 用户必须先升级到 Node.js 22 或更高版本，才能安装下一版本的 `@qwen-code/mobile-mcp`。

## 关联 Issue

Closes #8269

Refs #7462

</details>
