### PR TITLE
feat(cli): adopt Goal v3 in non-interactive mode

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -8813,6 +8813,11 @@ export class Session implements SessionContext {
         throw new Error(unsupportedError);
       }
 
+      case 'goal_control':
+        throw new Error(
+          'Canonical Goal control is not available in ACP integration yet.',
+        );
+
       case 'no_command':
         // No command was found or executed, resolve the original prompt
         // through the standard path that handles all block types. promptLast

--- a/packages/cli/src/nonInteractive/io/StreamJsonOutputAdapter.test.ts
+++ b/packages/cli/src/nonInteractive/io/StreamJsonOutputAdapter.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type {
   Config,
+  GoalSnapshotV2,
   ServerGeminiStreamEvent,
 } from '@qwen-code/qwen-code-core';
 import { GeminiEventType } from '@qwen-code/qwen-code-core';
@@ -19,6 +20,23 @@ function createMockConfig(): Config {
     getModel: vi.fn().mockReturnValue('test-model'),
   } as unknown as Config;
 }
+
+const goalSnapshot: GoalSnapshotV2 = {
+  v: 2,
+  activity: 'running',
+  goal: {
+    goalId: 'goal-1',
+    revision: 2,
+    objective: 'finish the refactor',
+    status: 'active',
+    evidenceCursor: { recordId: 'record-1' },
+    turnCount: 3,
+    activeTimeMs: 12_000,
+    createdAt: 1,
+    updatedAt: 2,
+    lastReason: 'keep going',
+  },
+};
 
 describe('StreamJsonOutputAdapter', () => {
   let adapter: StreamJsonOutputAdapter;
@@ -151,6 +169,67 @@ describe('StreamJsonOutputAdapter', () => {
             },
           }),
         ]);
+      });
+
+      it('emits v2 goal_state before the gated legacy projection', () => {
+        adapter.processEvent({
+          type: GeminiEventType.GoalState,
+          value: goalSnapshot,
+          cause: 'edit',
+        });
+        adapter.processEvent({
+          type: GeminiEventType.ActiveGoal,
+          value: {
+            condition: 'finish the refactor',
+            iterations: 3,
+            setAt: 1,
+            tokensAtStart: 0,
+            hookId: 'goal-v2:goal-1:2',
+            lastReason: 'keep going',
+          },
+        });
+
+        const goalEvents = stdoutWriteSpy.mock.calls
+          .map((call: unknown[]) => JSON.parse(call[0] as string))
+          .filter(
+            (message: { type?: string; event?: { type?: string } }) =>
+              message.type === 'stream_event' &&
+              (message.event?.type === 'goal_state' ||
+                message.event?.type === 'active_goal'),
+          );
+
+        expect(
+          goalEvents.map(
+            (message: { event: { type: string } }) => message.event.type,
+          ),
+        ).toEqual(['goal_state', 'active_goal']);
+        expect(goalEvents[0]).toMatchObject({
+          session_id: 'test-session-id',
+          parent_tool_use_id: null,
+          event: {
+            type: 'goal_state',
+            goal_state: goalSnapshot,
+          },
+        });
+      });
+
+      it('does not emit duplicate v2 goal snapshots from overlapping sources', () => {
+        adapter.processEvent({
+          type: GeminiEventType.GoalState,
+          value: goalSnapshot,
+        });
+        adapter.processEvent({
+          type: GeminiEventType.GoalState,
+          value: structuredClone(goalSnapshot),
+        });
+
+        const goalEvents = stdoutWriteSpy.mock.calls
+          .map((call: unknown[]) => JSON.parse(call[0] as string))
+          .filter(
+            (message: { event?: { type?: string } }) =>
+              message.event?.type === 'goal_state',
+          );
+        expect(goalEvents).toHaveLength(1);
       });
 
       it('should emit message_start event on first content', () => {
@@ -300,6 +379,36 @@ describe('StreamJsonOutputAdapter', () => {
       );
 
       expect(activeGoalEventCall).toBeUndefined();
+    });
+
+    it('still emits v2 goal_state without the partial-message gate', () => {
+      adapter.processEvent({
+        type: GeminiEventType.GoalState,
+        value: goalSnapshot,
+        cause: 'edit',
+      });
+      adapter.processEvent({
+        type: GeminiEventType.ActiveGoal,
+        value: {
+          condition: 'finish the refactor',
+          iterations: 3,
+          setAt: 1,
+          tokensAtStart: 0,
+          hookId: 'goal-v2:goal-1:2',
+          lastReason: 'keep going',
+        },
+      });
+
+      const events = stdoutWriteSpy.mock.calls
+        .map((call: unknown[]) => JSON.parse(call[0] as string))
+        .filter(
+          (message: { type?: string }) => message.type === 'stream_event',
+        );
+      expect(events).toHaveLength(1);
+      expect(events[0].event).toEqual({
+        type: 'goal_state',
+        goal_state: goalSnapshot,
+      });
     });
 
     it('should still emit final assistant message', () => {

--- a/packages/cli/src/nonInteractive/io/StreamJsonOutputAdapter.ts
+++ b/packages/cli/src/nonInteractive/io/StreamJsonOutputAdapter.ts
@@ -40,6 +40,7 @@ export class StreamJsonOutputAdapter
   implements JsonOutputAdapterInterface
 {
   private mainTurnMessageStartEmitted = false;
+  private lastGoalStateSignature: string | undefined;
   private readonly outputStream: NodeJS.WritableStream;
 
   constructor(
@@ -126,6 +127,24 @@ export class StreamJsonOutputAdapter
   }
 
   override processEvent(event: ServerGeminiStreamEvent): void {
+    if (event.type === GeminiEventType.GoalState) {
+      const signature = JSON.stringify(event.value);
+      if (signature === this.lastGoalStateSignature) return;
+      this.lastGoalStateSignature = signature;
+      const partial: CLIPartialAssistantMessage = {
+        type: 'stream_event',
+        uuid: randomUUID(),
+        session_id: this.getSessionId(),
+        parent_tool_use_id: null,
+        event: {
+          type: 'goal_state',
+          goal_state: event.value,
+        },
+      };
+      this.emitMessageImpl(partial);
+      return;
+    }
+
     // Active goal updates are session-level metadata, not message content.
     // They intentionally bypass the base finalized guard so late goal state
     // changes can still reach stream consumers.

--- a/packages/cli/src/nonInteractive/types.ts
+++ b/packages/cli/src/nonInteractive/types.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type {
   ActiveGoal,
+  GoalSnapshotV2,
   SubagentConfig,
   McpToolProgressData,
   ShellProgressData,
@@ -254,6 +255,11 @@ export interface ActiveGoalStreamEvent {
   active_goal: ActiveGoal | null;
 }
 
+export interface GoalStateStreamEvent {
+  type: 'goal_state';
+  goal_state: GoalSnapshotV2;
+}
+
 export type StreamEvent =
   | MessageStartStreamEvent
   | ContentBlockStartEvent
@@ -261,6 +267,7 @@ export type StreamEvent =
   | ContentBlockStopEvent
   | MessageStopStreamEvent
   | ToolProgressStreamEvent
+  | GoalStateStreamEvent
   | ActiveGoalStreamEvent;
 
 export interface CLIPartialAssistantMessage {

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -923,7 +923,11 @@ describe('runNonInteractive', () => {
     setupMetricsMock();
     await prepareGoalState('active');
     vi.mocked(mockConfig.getMaxSessionTurns).mockReturnValue(0);
-    mockFinishedGoalWorker();
+    let goalStatusAtExit: string | undefined;
+    vi.mocked(process.exit).mockImplementation((code) => {
+      goalStatusAtExit = goalRuntime.getSnapshot().goal?.status;
+      throw new Error(`process.exit(${code}) called`);
+    });
 
     await expect(
       runNonInteractive(
@@ -935,6 +939,7 @@ describe('runNonInteractive', () => {
     ).rejects.toThrow('process.exit(53) called');
 
     expect(mockGeminiClient.sendMessageStream).not.toHaveBeenCalled();
+    expect(goalStatusAtExit).toBe('paused');
   });
 
   it('keeps explicit tool-call budgets on runtime Goal work', async () => {

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -1067,6 +1067,44 @@ describe('runNonInteractive', () => {
     });
   });
 
+  it('waits for an active Goal turn before admitting real user input', async () => {
+    setupMetricsMock();
+    await prepareGoalState('active');
+    const occupyingPermit = goalRuntime.beginTurn('occupying-turn');
+    expect(occupyingPermit).toBeDefined();
+    const finishOccupyingTurn = goalRuntime.finishTurn.bind(goalRuntime);
+    mockFinishedGoalWorker();
+    const beginTurn = vi.spyOn(goalRuntime, 'beginTurn');
+
+    const run = runNonInteractive(
+      mockConfig,
+      mockSettings,
+      'A queued user update',
+      'goal-queued-user',
+    );
+
+    await vi.waitFor(() =>
+      expect(beginTurn).toHaveBeenCalledWith('goal-queued-user'),
+    );
+    expect(mockGeminiClient.sendMessageStream).not.toHaveBeenCalled();
+
+    await finishOccupyingTurn(occupyingPermit!);
+    await run;
+
+    const sendOptions = mockGeminiClient.sendMessageStream.mock.calls[0]![3];
+    expect(sendOptions).toMatchObject({
+      type: SendMessageType.UserQuery,
+      goalOrigin: 'user',
+      goalTurnKey: 'goal-queued-user',
+      goalPermit: {
+        goalId: occupyingPermit!.goalId,
+        revision: occupyingPermit!.revision,
+        turnId: expect.any(String),
+      },
+    });
+    expect(sendOptions.goalPermit.turnId).not.toBe(occupyingPermit!.turnId);
+  });
+
   it('emits direct Goal v2 state before the legacy partial projection', async () => {
     setupMetricsMock();
     mockGetCommands.mockReturnValue([goalCommand]);

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -5,8 +5,13 @@
  */
 
 import type {
+  ChatRecord,
   Config,
   CronJob,
+  GoalJournal,
+  GoalRuntime,
+  GoalStateRecordPayloadV2,
+  GoalTurnPermit,
   ToolCallRequestInfo,
   ToolCallResponseInfo,
   ToolRegistry,
@@ -17,6 +22,7 @@ import type {
 import type { CLIUserMessage } from './nonInteractive/types.js';
 import {
   executeToolCall,
+  isTelemetrySdkInitialized,
   ToolErrorType,
   shutdownTelemetry,
   GeminiEventType,
@@ -37,6 +43,7 @@ import {
   ToolConfirmationOutcome,
   ToolNames,
   PLAN_MODE_ENTRY_SIBLING_SKIP_MESSAGE,
+  createGoalRuntime,
 } from '@qwen-code/qwen-code-core';
 import type { Part } from '@google/genai';
 import { EventEmitter } from 'node:events';
@@ -52,6 +59,7 @@ import type { LoadedSettings } from './config/settings.js';
 import { StreamJsonOutputAdapter } from './nonInteractive/io/StreamJsonOutputAdapter.js';
 import type { ControlService } from './nonInteractive/control/ControlService.js';
 import { CommandKind, type ExecutionMode } from './ui/commands/types.js';
+import { goalCommand } from './ui/commands/goalCommand.js';
 import { filterCommandsForMode } from './services/commandUtils.js';
 import { _resetCleanupFunctionsForTest } from './utils/cleanup.js';
 import {
@@ -95,6 +103,29 @@ vi.mock('./services/CommandService.js', () => ({
     create: mockCommandServiceCreate,
   },
 }));
+
+function createGoalJournal(): GoalJournal {
+  return {
+    getTranscriptCursor: () => ({ recordId: null }),
+    async recordGoalState(
+      recordUuid: string,
+      payload: GoalStateRecordPayloadV2,
+    ): Promise<ChatRecord> {
+      return {
+        uuid: recordUuid,
+        parentUuid: null,
+        sessionId: 'test-session-id',
+        timestamp: new Date(0).toISOString(),
+        type: 'system',
+        subtype: 'goal_state',
+        provenance: 'goal_control',
+        cwd: '/test/project',
+        version: 'test',
+        systemPayload: structuredClone(payload),
+      };
+    },
+  };
+}
 
 describe('skipHeadlessLoopSentinel', () => {
   it('deletes a recurring session loop.md sentinel job so sessionSize reaches 0', () => {
@@ -214,8 +245,10 @@ describe('runNonInteractive', () => {
     getHistoryFunctionResponseIds: Mock;
     consumePendingMemoryTaskPromises: Mock;
     recordCompletedToolCall: Mock;
+    addHistory: Mock;
   };
   let mockGetDebugResponses: Mock;
+  let goalRuntime: GoalRuntime;
 
   beforeEach(async () => {
     // Reset module-level state from any prior test in this file. Without
@@ -227,7 +260,9 @@ describe('runNonInteractive', () => {
     mockCoreExecuteToolCall = vi.mocked(executeToolCall);
     runVisionBridgeSpy.mockReset();
     mockShutdownTelemetry = vi.mocked(shutdownTelemetry);
+    vi.mocked(isTelemetrySdkInitialized).mockReturnValue(true);
     mockGetDebugResponses = vi.fn().mockReturnValue([]);
+    goalRuntime = createGoalRuntime({ journal: createGoalJournal() });
     mockGetCommandsForMode.mockImplementation((mode: ExecutionMode) =>
       filterCommandsForMode(mockGetCommands(), mode),
     );
@@ -272,6 +307,7 @@ describe('runNonInteractive', () => {
       sendMessageStream: vi.fn(),
       consumePendingMemoryTaskPromises: vi.fn().mockReturnValue([]),
       recordCompletedToolCall: vi.fn(),
+      addHistory: vi.fn(),
       stripOrphanedUserEntriesFromHistory: vi.fn(),
       getChatRecordingService: vi.fn(() => ({
         initialize: vi.fn(),
@@ -289,6 +325,10 @@ describe('runNonInteractive', () => {
       initialize: vi.fn().mockResolvedValue(undefined),
       getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
       getGeminiClient: vi.fn().mockReturnValue(mockGeminiClient),
+      getChatRecordingService: vi.fn().mockReturnValue({
+        flush: vi.fn().mockResolvedValue(undefined),
+        finalize: vi.fn().mockResolvedValue(undefined),
+      }),
       getToolRegistry: vi.fn().mockReturnValue(mockToolRegistry),
       getMaxSessionTurns: vi.fn().mockReturnValue(10),
       getMaxWallTimeSeconds: vi.fn().mockReturnValue(-1),
@@ -308,6 +348,7 @@ describe('runNonInteractive', () => {
       getJsonSchema: vi.fn().mockReturnValue(undefined),
       getFolderTrustFeature: vi.fn().mockReturnValue(false),
       getFolderTrust: vi.fn().mockReturnValue(false),
+      isTrustedFolder: vi.fn().mockReturnValue(true),
       getIncludePartialMessages: vi.fn().mockReturnValue(false),
       getSessionId: vi.fn().mockReturnValue('test-session-id'),
       getModel: vi.fn(() => currentModel),
@@ -325,6 +366,9 @@ describe('runNonInteractive', () => {
       setModelInvocableCommandsExecutor: vi.fn(),
       getAutoSkillEnabled: vi.fn().mockReturnValue(false),
       getDisabledSlashCommands: vi.fn().mockReturnValue([]),
+      getGoalRuntime: vi.fn(() => goalRuntime),
+      getGoalRuntimeReady: vi.fn(async () => goalRuntime),
+      bindGoalTurnHost: vi.fn((host) => goalRuntime.bindHost(host)),
       getBackgroundTaskRegistry: vi
         .fn()
         .mockReturnValue(mockBackgroundTaskRegistry),
@@ -431,6 +475,623 @@ describe('runNonInteractive', () => {
       yield event;
     }
   }
+
+  type GoalControlCase = {
+    name: string;
+    input: string;
+    prepare: 'none' | 'active' | 'paused';
+    expectedStatus: 'active' | 'paused' | null;
+    expectedObjective?: string;
+    expectedWorkers: number;
+    expectedText: string;
+  };
+
+  const goalControlCases: GoalControlCase[] = [
+    {
+      name: 'status',
+      input: '/goal',
+      prepare: 'active',
+      expectedStatus: 'active',
+      expectedObjective: 'existing goal',
+      expectedWorkers: 0,
+      expectedText: 'Goal active: existing goal',
+    },
+    {
+      name: 'create',
+      input: '/goal ship it',
+      prepare: 'none',
+      expectedStatus: 'active',
+      expectedObjective: 'ship it',
+      expectedWorkers: 1,
+      expectedText: 'Goal active: ship it',
+    },
+    {
+      name: 'replace',
+      input: '/goal set replacement',
+      prepare: 'active',
+      expectedStatus: 'active',
+      expectedObjective: 'replacement',
+      expectedWorkers: 1,
+      expectedText: 'Goal active: replacement',
+    },
+    {
+      name: 'edit',
+      input: '/goal edit revised goal',
+      prepare: 'active',
+      expectedStatus: 'active',
+      expectedObjective: 'revised goal',
+      expectedWorkers: 1,
+      expectedText: 'Goal active: revised goal',
+    },
+    {
+      name: 'pause',
+      input: '/goal pause',
+      prepare: 'active',
+      expectedStatus: 'paused',
+      expectedObjective: 'existing goal',
+      expectedWorkers: 0,
+      expectedText: 'Goal paused: existing goal',
+    },
+    {
+      name: 'resume',
+      input: '/goal resume',
+      prepare: 'paused',
+      expectedStatus: 'active',
+      expectedObjective: 'existing goal',
+      expectedWorkers: 1,
+      expectedText: 'Goal active: existing goal',
+    },
+    {
+      name: 'clear',
+      input: '/goal clear',
+      prepare: 'active',
+      expectedStatus: null,
+      expectedWorkers: 0,
+      expectedText: 'Goal cleared.',
+    },
+  ];
+
+  async function prepareGoalState(
+    preparation: GoalControlCase['prepare'],
+  ): Promise<void> {
+    if (preparation === 'none') return;
+    const created = await goalRuntime.dispatch({
+      action: 'create',
+      objective: 'existing goal',
+    });
+    if (preparation === 'paused') {
+      await goalRuntime.dispatch({
+        action: 'pause',
+        expectedGoalId: created.snapshot.goal!.goalId,
+        expectedRevision: created.snapshot.goal!.revision,
+      });
+    }
+  }
+
+  function mockFinishedGoalWorker(): void {
+    vi.spyOn(goalRuntime, 'finishTurn').mockResolvedValue(undefined);
+    mockGeminiClient.sendMessageStream.mockImplementation(() =>
+      createStreamFromEvents([
+        {
+          type: GeminiEventType.Finished,
+          value: {
+            reason: undefined,
+            usageMetadata: { totalTokenCount: 0 },
+          },
+        },
+      ]),
+    );
+  }
+
+  it.each(goalControlCases)(
+    'handles plain Goal $name before ordinary model input',
+    async (testCase) => {
+      setupMetricsMock();
+      mockGetCommands.mockReturnValue([goalCommand]);
+      await prepareGoalState(testCase.prepare);
+      mockFinishedGoalWorker();
+
+      const exitCode = await runNonInteractive(
+        mockConfig,
+        mockSettings,
+        testCase.input,
+        `goal-plain-${testCase.name}`,
+      );
+
+      expect(exitCode).toBe(0);
+      expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(
+        testCase.expectedWorkers,
+      );
+      expect(processStdoutSpy).toHaveBeenCalledWith(
+        `${testCase.expectedText}\n`,
+      );
+      expect(goalRuntime.getSnapshot()).toMatchObject({
+        goal:
+          testCase.expectedStatus === null
+            ? null
+            : {
+                status: testCase.expectedStatus,
+                objective: testCase.expectedObjective,
+              },
+      });
+    },
+  );
+
+  it('runs resume with the exact permit scheduled by Core', async () => {
+    setupMetricsMock();
+    mockGetCommands.mockReturnValue([goalCommand]);
+    await prepareGoalState('paused');
+    mockFinishedGoalWorker();
+
+    await runNonInteractive(
+      mockConfig,
+      mockSettings,
+      '/goal resume',
+      'goal-resume-exact',
+    );
+
+    expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledOnce();
+    const [parts, , , options] =
+      mockGeminiClient.sendMessageStream.mock.calls[0]!;
+    expect(parts[0]?.text).toContain('Continue working on the active Goal.');
+    expect(options).toMatchObject({
+      type: SendMessageType.Goal,
+      goalOrigin: 'runtime',
+      goalTurnKey: expect.stringMatching(/^goal-runtime:/),
+      goalPermit: {
+        goalId: expect.any(String),
+        revision: expect.any(Number),
+        turnId: expect.any(String),
+      },
+    });
+    expect(options.goalTurnKey).toBe(
+      `goal-runtime:${options.goalPermit.turnId}`,
+    );
+    expect(options.goalSignal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('keeps the exact Goal permit through a ToolResult continuation', async () => {
+    setupMetricsMock();
+    mockGetCommands.mockReturnValue([goalCommand]);
+    await prepareGoalState('paused');
+    vi.spyOn(goalRuntime, 'finishTurn').mockResolvedValue(undefined);
+    mockCoreExecuteToolCall.mockResolvedValue({
+      responseParts: [{ text: 'tool response' }],
+    });
+    let requestCount = 0;
+    mockGeminiClient.sendMessageStream.mockImplementation(
+      (
+        _parts: Part[],
+        _signal: AbortSignal,
+        _promptId: string,
+        sendOptions: { goalPermit?: GoalTurnPermit },
+      ) => {
+        requestCount += 1;
+        if (requestCount === 1) {
+          return createStreamFromEvents([
+            {
+              type: GeminiEventType.ToolCallRequest,
+              value: {
+                callId: 'goal-tool-1',
+                name: 'testTool',
+                args: {},
+                isClientInitiated: false,
+                prompt_id: 'goal-resume-tool-result',
+                goalContext: sendOptions.goalPermit,
+              },
+            },
+          ]);
+        }
+        return createStreamFromEvents([
+          {
+            type: GeminiEventType.Finished,
+            value: {
+              reason: undefined,
+              usageMetadata: { totalTokenCount: 0 },
+            },
+          },
+        ]);
+      },
+    );
+
+    await runNonInteractive(
+      mockConfig,
+      mockSettings,
+      '/goal resume',
+      'goal-resume-tool-result',
+    );
+
+    expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(2);
+    const firstOptions = mockGeminiClient.sendMessageStream.mock.calls[0]![3];
+    const secondOptions = mockGeminiClient.sendMessageStream.mock.calls[1]![3];
+    expect(secondOptions).toMatchObject({
+      type: SendMessageType.ToolResult,
+      goalPermit: firstOptions.goalPermit,
+      goalTurnKey: firstOptions.goalTurnKey,
+      goalOrigin: 'runtime',
+    });
+    expect(secondOptions.goalSignal).toBe(firstOptions.goalSignal);
+  });
+
+  it('ends a Goal turn without another model call after update_goal', async () => {
+    setupMetricsMock();
+    mockGetCommands.mockReturnValue([goalCommand]);
+    await prepareGoalState('paused');
+    const finishTurn = vi
+      .spyOn(goalRuntime, 'finishTurn')
+      .mockResolvedValue(undefined);
+    mockCoreExecuteToolCall.mockResolvedValue({
+      callId: 'update-goal-terminal',
+      responseParts: [{ text: 'proposal recorded' }],
+      resultDisplay: 'proposal recorded',
+      error: undefined,
+      errorType: undefined,
+      terminateTurn: true,
+    });
+    mockGeminiClient.sendMessageStream.mockImplementation(
+      (
+        _parts: Part[],
+        _signal: AbortSignal,
+        _promptId: string,
+        sendOptions: { goalPermit?: GoalTurnPermit },
+      ) =>
+        createStreamFromEvents([
+          {
+            type: GeminiEventType.ToolCallRequest,
+            value: {
+              callId: 'update-goal-terminal',
+              name: 'update_goal',
+              args: {},
+              isClientInitiated: false,
+              prompt_id: 'goal-terminal-tool-result',
+              goalContext: sendOptions.goalPermit,
+            },
+          },
+        ]),
+    );
+
+    const exitCode = await runNonInteractive(
+      mockConfig,
+      mockSettings,
+      '/goal resume',
+      'goal-terminal-tool-result',
+    );
+
+    expect(exitCode).toBe(0);
+    expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledOnce();
+    expect(mockGeminiClient.addHistory).toHaveBeenCalledWith({
+      role: 'user',
+      parts: [{ text: 'proposal recorded' }],
+    });
+    expect(finishTurn).toHaveBeenCalledOnce();
+  });
+
+  it('streams Goal state changes that happen while a headless turn settles', async () => {
+    setupMetricsMock();
+    mockGetCommands.mockReturnValue([goalCommand]);
+    await prepareGoalState('paused');
+    vi.mocked(mockConfig.getOutputFormat).mockReturnValue(
+      OutputFormat.STREAM_JSON,
+    );
+    vi.spyOn(goalRuntime, 'finishTurn').mockImplementation(async (permit) => {
+      await goalRuntime.dispatch({
+        action: 'pause',
+        expectedGoalId: permit.goalId,
+        expectedRevision: permit.revision,
+      });
+    });
+    mockCoreExecuteToolCall.mockResolvedValue({
+      responseParts: [{ text: 'proposal recorded' }],
+      terminateTurn: true,
+    });
+    mockGeminiClient.sendMessageStream.mockImplementation(
+      (
+        _parts: Part[],
+        _signal: AbortSignal,
+        _promptId: string,
+        sendOptions: { goalPermit?: GoalTurnPermit },
+      ) =>
+        createStreamFromEvents([
+          {
+            type: GeminiEventType.ToolCallRequest,
+            value: {
+              callId: 'update-goal-state-stream',
+              name: 'update_goal',
+              args: {},
+              isClientInitiated: false,
+              prompt_id: 'goal-state-stream',
+              goalContext: sendOptions.goalPermit,
+            },
+          },
+        ]),
+    );
+
+    const exitCode = await runNonInteractive(
+      mockConfig,
+      mockSettings,
+      '/goal resume',
+      'goal-state-stream',
+    );
+
+    expect(exitCode).toBe(0);
+    const statuses = processStdoutSpy.mock.calls
+      .map(
+        ([chunk]) =>
+          JSON.parse(String(chunk)) as {
+            event?: {
+              type?: string;
+              goal_state?: { goal?: { status?: string } };
+            };
+          },
+      )
+      .filter(({ event }) => event?.type === 'goal_state')
+      .map(({ event }) => event?.goal_state?.goal?.status);
+    expect(statuses).toContain('active');
+    expect(statuses).toContain('paused');
+  });
+
+  it('flushes a plain-text Goal turn before releasing its permit', async () => {
+    setupMetricsMock();
+    mockGetCommands.mockReturnValue([goalCommand]);
+    await prepareGoalState('paused');
+    const finishTurn = vi
+      .spyOn(goalRuntime, 'finishTurn')
+      .mockResolvedValue(undefined);
+    const flush = vi.fn().mockResolvedValue(undefined);
+    Object.assign(mockConfig, {
+      getChatRecordingService: vi.fn(() => ({
+        flush,
+        finalize: vi.fn().mockResolvedValue(undefined),
+      })),
+    });
+    mockGeminiClient.sendMessageStream.mockReturnValue(
+      createStreamFromEvents([
+        { type: GeminiEventType.Content, value: 'still working' },
+        {
+          type: GeminiEventType.Finished,
+          value: {
+            reason: undefined,
+            usageMetadata: { totalTokenCount: 0 },
+          },
+        },
+      ]),
+    );
+
+    await runNonInteractive(
+      mockConfig,
+      mockSettings,
+      '/goal resume',
+      'goal-plain-text',
+    );
+
+    expect(flush).toHaveBeenCalled();
+    expect(finishTurn).toHaveBeenCalledOnce();
+    expect(flush.mock.invocationCallOrder[0]).toBeLessThan(
+      finishTurn.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it('does not charge runtime Goal segments to the generic session turn cap', async () => {
+    setupMetricsMock();
+    mockGetCommands.mockReturnValue([goalCommand]);
+    await prepareGoalState('paused');
+    vi.spyOn(goalRuntime, 'finishTurn').mockResolvedValue(undefined);
+    vi.mocked(mockConfig.getMaxSessionTurns).mockReturnValue(0);
+    mockCoreExecuteToolCall.mockResolvedValue({
+      responseParts: [{ text: 'tool response' }],
+    });
+    mockGeminiClient.sendMessageStream
+      .mockReturnValueOnce(
+        createStreamFromEvents([
+          {
+            type: GeminiEventType.ToolCallRequest,
+            value: {
+              callId: 'goal-unlimited-turns-tool',
+              name: 'testTool',
+              args: {},
+              isClientInitiated: false,
+              prompt_id: 'goal-unlimited-turns',
+            },
+          },
+        ]),
+      )
+      .mockReturnValueOnce(
+        createStreamFromEvents([
+          {
+            type: GeminiEventType.Finished,
+            value: {
+              reason: undefined,
+              usageMetadata: { totalTokenCount: 0 },
+            },
+          },
+        ]),
+      );
+
+    const exitCode = await runNonInteractive(
+      mockConfig,
+      mockSettings,
+      '/goal resume',
+      'goal-unlimited-turns',
+    );
+
+    expect(exitCode).toBe(0);
+    expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(2);
+    expect(mockCoreExecuteToolCall).toHaveBeenCalledOnce();
+  });
+
+  it('still applies the generic turn cap to real user input during a Goal', async () => {
+    setupMetricsMock();
+    await prepareGoalState('active');
+    vi.mocked(mockConfig.getMaxSessionTurns).mockReturnValue(0);
+    mockFinishedGoalWorker();
+
+    await expect(
+      runNonInteractive(
+        mockConfig,
+        mockSettings,
+        'A real user update',
+        'goal-user-turn-cap',
+      ),
+    ).rejects.toThrow('process.exit(53) called');
+
+    expect(mockGeminiClient.sendMessageStream).not.toHaveBeenCalled();
+  });
+
+  it('keeps explicit tool-call budgets on runtime Goal work', async () => {
+    setupMetricsMock();
+    mockGetCommands.mockReturnValue([goalCommand]);
+    await prepareGoalState('paused');
+    vi.mocked(mockConfig.getMaxSessionTurns).mockReturnValue(0);
+    vi.mocked(mockConfig.getMaxToolCalls).mockReturnValue(0);
+    mockGeminiClient.sendMessageStream.mockReturnValueOnce(
+      createStreamFromEvents([
+        {
+          type: GeminiEventType.ToolCallRequest,
+          value: {
+            callId: 'goal-explicit-budget-tool',
+            name: 'testTool',
+            args: {},
+            isClientInitiated: false,
+            prompt_id: 'goal-explicit-budget',
+          },
+        },
+      ]),
+    );
+
+    const run = runNonInteractive(
+      mockConfig,
+      mockSettings,
+      '/goal resume',
+      'goal-explicit-budget',
+    ).catch(() => undefined);
+
+    await vi.waitFor(() =>
+      expect(processStderrSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Run aborted: tool-call budget of 0 exceeded (--max-tool-calls)',
+        ),
+      ),
+    );
+
+    expect(mockCoreExecuteToolCall).not.toHaveBeenCalled();
+    expect(goalRuntime.getSnapshot()).toMatchObject({
+      activity: 'idle',
+      goal: { status: 'paused' },
+    });
+
+    void run;
+  });
+
+  it('interrupts Goal settlement when the explicit wall-clock budget expires', async () => {
+    setupMetricsMock();
+    mockGetCommands.mockReturnValue([goalCommand]);
+    await prepareGoalState('paused');
+    vi.mocked(mockConfig.getMaxWallTimeSeconds).mockReturnValue(0.01);
+    const runAbortController = new AbortController();
+    vi.spyOn(goalRuntime, 'finishTurn').mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          runAbortController.signal.addEventListener('abort', () => resolve(), {
+            once: true,
+          });
+        }),
+    );
+    mockCoreExecuteToolCall.mockResolvedValue({
+      responseParts: [{ text: 'proposal recorded' }],
+      terminateTurn: true,
+    });
+    mockGeminiClient.sendMessageStream.mockReturnValueOnce(
+      createStreamFromEvents([
+        {
+          type: GeminiEventType.ToolCallRequest,
+          value: {
+            callId: 'goal-wall-budget',
+            name: 'update_goal',
+            args: {},
+            isClientInitiated: false,
+            prompt_id: 'goal-wall-budget',
+          },
+        },
+      ]),
+    );
+
+    const run = runNonInteractive(
+      mockConfig,
+      mockSettings,
+      '/goal resume',
+      'goal-wall-budget',
+      { abortController: runAbortController },
+    ).catch(() => undefined);
+
+    await vi.waitFor(() =>
+      expect(processStderrSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Run aborted: wall-clock budget of 0.01s exceeded (--max-wall-time)',
+        ),
+      ),
+    );
+    expect(goalRuntime.getSnapshot()).toMatchObject({
+      activity: 'idle',
+      goal: { status: 'paused' },
+    });
+
+    void run;
+  });
+
+  it('claims an active Goal for real user input before binding the host', async () => {
+    setupMetricsMock();
+    await prepareGoalState('active');
+    mockFinishedGoalWorker();
+    const beginTurn = vi.spyOn(goalRuntime, 'beginTurn');
+
+    await runNonInteractive(
+      mockConfig,
+      mockSettings,
+      'A real user update',
+      'goal-real-user',
+    );
+
+    expect(beginTurn).toHaveBeenCalledWith('goal-real-user');
+    expect(beginTurn.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(mockConfig.bindGoalTurnHost).mock.invocationCallOrder[0]!,
+    );
+    expect(mockGeminiClient.sendMessageStream.mock.calls[0]![3]).toMatchObject({
+      type: SendMessageType.UserQuery,
+      goalOrigin: 'user',
+      goalTurnKey: 'goal-real-user',
+      goalPermit: {
+        goalId: expect.any(String),
+        revision: expect.any(Number),
+        turnId: expect.any(String),
+      },
+    });
+  });
+
+  it('emits direct Goal v2 state before the legacy partial projection', async () => {
+    setupMetricsMock();
+    mockGetCommands.mockReturnValue([goalCommand]);
+    await prepareGoalState('active');
+    vi.mocked(mockConfig.getOutputFormat).mockReturnValue(
+      OutputFormat.STREAM_JSON,
+    );
+    vi.mocked(mockConfig.getIncludePartialMessages).mockReturnValue(true);
+
+    await runNonInteractive(
+      mockConfig,
+      mockSettings,
+      '/goal',
+      'goal-direct-order',
+    );
+
+    const goalEventTypes = processStdoutSpy.mock.calls
+      .map(
+        ([chunk]) => JSON.parse(String(chunk)) as { event?: { type?: string } },
+      )
+      .map(({ event }) => event?.type)
+      .filter((type) => type === 'goal_state' || type === 'active_goal');
+    expect(goalEventTypes).toEqual(['goal_state', 'active_goal']);
+    expect(mockGeminiClient.sendMessageStream).not.toHaveBeenCalled();
+  });
 
   const headlessImageParts: Part[] = [
     { text: 'inspect this image' },

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -10,6 +10,11 @@ import type {
   Config,
   CronJob,
   CronScheduler,
+  GoalRuntime,
+  GoalSnapshotV2,
+  GoalTurnHost,
+  GoalTurnPermit,
+  ActiveGoal,
   ToolCallRequestInfo,
   ToolCallResponseInfo,
   RuntimeContentGeneratorView,
@@ -59,6 +64,7 @@ import {
   runVisionBridge,
   shouldRunVisionBridge,
   splitImageParts,
+  GoalPersistenceUnavailableError,
 } from '@qwen-code/qwen-code-core';
 import type { Content, Part, PartListUnion } from '@google/genai';
 import type { CLIUserMessage, PermissionMode } from './nonInteractive/types.js';
@@ -187,6 +193,114 @@ function formatLoopDetectedMessage(loopType: LoopType | undefined): string {
         ? ' This is an always-on guard and cannot be disabled via `model.skipLoopDetection`.'
         : ' Set the `model.skipLoopDetection` setting to true to disable.';
   return `Loop detection halted the run${detail}.${hint}`;
+}
+
+interface HeadlessGoalTurn {
+  permit: GoalTurnPermit;
+  turnKey: string;
+  controller: AbortController;
+  origin: 'runtime' | 'user';
+  continuationContext: string;
+  verifierFeedback?: string;
+}
+
+function sameGoalPermit(
+  left: GoalTurnPermit | undefined,
+  right: GoalTurnPermit,
+): boolean {
+  return (
+    left?.goalId === right.goalId &&
+    left.revision === right.revision &&
+    left.turnId === right.turnId
+  );
+}
+
+function buildGoalContinuationParts(turn: HeadlessGoalTurn): Part[] {
+  return [
+    {
+      text: [
+        'Continue working on the active Goal.',
+        'Use get_goal for the authoritative objective and evidence state.',
+        "Follow the objective's requested output format exactly. Do not add progress, status, or completion commentary unless the objective asks for it.",
+        'If completion depends on content delivered in this turn, deliver only that content and call get_goal in the same response before update_goal.',
+        `Runtime continuation context: ${turn.continuationContext}`,
+        ...(turn.verifierFeedback
+          ? [`Verifier feedback: ${turn.verifierFeedback}`]
+          : []),
+      ].join('\n'),
+    },
+  ];
+}
+
+function projectLegacyActiveGoal(snapshot: GoalSnapshotV2): ActiveGoal | null {
+  const goal = snapshot.goal;
+  if (goal?.status !== 'active') return null;
+  return {
+    condition: goal.objective,
+    iterations: goal.turnCount,
+    setAt: goal.createdAt,
+    tokensAtStart: 0,
+    hookId: `goal-v2:${goal.goalId}:${goal.revision}`,
+    ...(goal.lastReason === undefined ? {} : { lastReason: goal.lastReason }),
+  };
+}
+
+function formatGoalState(
+  snapshot: GoalSnapshotV2,
+  operation: 'status' | 'set' | 'edit' | 'pause' | 'resume' | 'clear',
+): string {
+  const goal = snapshot.goal;
+  if (!goal) {
+    return operation === 'clear' ? 'Goal cleared.' : 'No Goal is set.';
+  }
+  const status =
+    goal.status === 'usage_limited' ? 'usage limited' : goal.status;
+  const summary = `Goal ${status}: ${goal.objective}`;
+  return (goal.status === 'blocked' || goal.status === 'usage_limited') &&
+    goal.lastReason
+    ? `${summary}\nReason: ${goal.lastReason}`
+    : summary;
+}
+
+async function claimUserGoalTurn(
+  runtime: GoalRuntime,
+  turnKey: string,
+  signal: AbortSignal,
+): Promise<GoalTurnPermit | undefined> {
+  const immediate =
+    runtime.permitForTurn(turnKey) ?? runtime.beginTurn(turnKey);
+  if (immediate || runtime.getSnapshot().goal?.status !== 'active') {
+    return immediate;
+  }
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let unsubscribe = () => {};
+    const finish = (permit: GoalTurnPermit | undefined, error?: unknown) => {
+      if (settled) return;
+      settled = true;
+      unsubscribe();
+      signal.removeEventListener('abort', onAbort);
+      if (error !== undefined) reject(error);
+      else resolve(permit);
+    };
+    const inspect = () => {
+      try {
+        const permit = runtime.permitForTurn(turnKey);
+        if (permit || runtime.getSnapshot().goal?.status !== 'active') {
+          finish(permit);
+        }
+      } catch (error) {
+        finish(undefined, error);
+      }
+    };
+    const onAbort = () => finish(undefined);
+
+    unsubscribe = runtime.subscribe(inspect);
+    signal.addEventListener('abort', onAbort, { once: true });
+    if (signal.aborted) onAbort();
+    else inspect();
+  });
 }
 
 /**
@@ -416,14 +530,169 @@ export async function runNonInteractive(
     );
 
     let turnCount = 0;
+    let limitedTurnCount = 0;
     let totalApiDurationMs = 0;
     const startTime = Date.now();
 
     const geminiClient = config.getGeminiClient();
     const abortController = options.abortController ?? new AbortController();
+    const queuedGoalTurns: HeadlessGoalTurn[] = [];
+    let activeGoalTurn: HeadlessGoalTurn | undefined;
+    let goalRuntimeUnsubscribe: (() => void) | undefined;
+    const emitGoalSnapshot = (snapshot: GoalSnapshotV2) => {
+      adapter.processEvent({
+        type: GeminiEventType.GoalState,
+        value: snapshot,
+      });
+      adapter.processEvent({
+        type: GeminiEventType.ActiveGoal,
+        value: projectLegacyActiveGoal(snapshot),
+      });
+    };
+    const observeGoalRuntime = (runtime: GoalRuntime) => {
+      goalRuntimeUnsubscribe ??= runtime.subscribe(emitGoalSnapshot);
+    };
+    const enforceSessionTurnLimit = async (
+      isRuntimeGoalTurn: boolean,
+    ): Promise<void> => {
+      if (isRuntimeGoalTurn) return;
+
+      limitedTurnCount++;
+      const maxSessionTurns = config.getMaxSessionTurns();
+      if (maxSessionTurns >= 0 && limitedTurnCount > maxSessionTurns) {
+        await settleBeforeTerminalOutput();
+        await handleMaxTurnsExceededError(config);
+      }
+    };
+    let goalHostUnbind: (() => void) | undefined;
+    const goalHost: GoalTurnHost = {
+      startGoalTurn: async (input) => {
+        if (
+          queuedGoalTurns.some(
+            ({ permit }) => permit.turnId === input.permit.turnId,
+          )
+        ) {
+          return;
+        }
+        queuedGoalTurns.push({
+          permit: { ...input.permit },
+          turnKey: `goal-runtime:${input.permit.turnId}`,
+          controller: new AbortController(),
+          origin: 'runtime',
+          continuationContext: input.continuationContext,
+          ...(input.verifierFeedback
+            ? { verifierFeedback: input.verifierFeedback }
+            : {}),
+        });
+      },
+      preemptGoalTurn: (reason) => {
+        for (const turn of queuedGoalTurns.splice(0)) {
+          turn.controller.abort(reason);
+        }
+        activeGoalTurn?.controller.abort(reason);
+      },
+    };
+    const bindGoalHost = () => {
+      goalHostUnbind ??= config.bindGoalTurnHost(goalHost);
+    };
+    let settlingGoalTurn: HeadlessGoalTurn | undefined;
+    let goalTurnSettlement: Promise<void> | undefined;
+    const failClosedActiveGoalTurn = (reason: string): Promise<void> => {
+      const turn = activeGoalTurn;
+      if (!turn) return Promise.resolve();
+      if (settlingGoalTurn === turn && goalTurnSettlement) {
+        return goalTurnSettlement;
+      }
+
+      settlingGoalTurn = turn;
+      goalTurnSettlement = (async () => {
+        if (!turn.controller.signal.aborted) {
+          turn.controller.abort(reason);
+        }
+
+        try {
+          const runtime = await config.getGoalRuntimeReady();
+          if (
+            !sameGoalPermit(runtime.permitForTurn(turn.turnKey), turn.permit)
+          ) {
+            return;
+          }
+
+          if (runtime.getSnapshot().goal?.status === 'active') {
+            try {
+              await runtime.dispatch({
+                action: 'pause',
+                expectedGoalId: turn.permit.goalId,
+                expectedRevision: turn.permit.revision,
+              });
+            } catch (error) {
+              debugLogger.warn('Failed to pause terminal headless Goal', error);
+            }
+          }
+
+          try {
+            await config.getChatRecordingService?.()?.flush();
+          } catch (error) {
+            debugLogger.warn('Failed to flush terminal headless Goal', error);
+          }
+
+          if (
+            sameGoalPermit(runtime.permitForTurn(turn.turnKey), turn.permit)
+          ) {
+            await runtime.finishTurn(turn.permit);
+          }
+        } catch (error) {
+          debugLogger.warn('Failed to close terminal headless Goal', error);
+        } finally {
+          if (activeGoalTurn === turn) {
+            activeGoalTurn = undefined;
+          }
+          if (settlingGoalTurn === turn) {
+            settlingGoalTurn = undefined;
+            goalTurnSettlement = undefined;
+          }
+        }
+      })();
+      return goalTurnSettlement;
+    };
+    const finishGoalTurn = async (turn: HeadlessGoalTurn): Promise<void> => {
+      const runtime = await config.getGoalRuntimeReady();
+      if (!sameGoalPermit(runtime.permitForTurn(turn.turnKey), turn.permit)) {
+        return;
+      }
+
+      let abortSettlement: Promise<void> | undefined;
+      const pauseOnAbort = () => {
+        abortSettlement ??= runtime
+          .dispatch({
+            action: 'pause',
+            expectedGoalId: turn.permit.goalId,
+            expectedRevision: turn.permit.revision,
+          })
+          .then(() => undefined)
+          .catch((error) => {
+            debugLogger.warn('Failed to pause aborted headless Goal', error);
+          });
+      };
+      abortController.signal.addEventListener('abort', pauseOnAbort, {
+        once: true,
+      });
+      if (abortController.signal.aborted) pauseOnAbort();
+
+      try {
+        if (!abortController.signal.aborted) {
+          await runtime.finishTurn(turn.permit);
+        }
+      } finally {
+        abortController.signal.removeEventListener('abort', pauseOnAbort);
+        await abortSettlement;
+      }
+    };
 
     // Run-level budget enforcement for headless / unattended runs
-    // (issue #4103). Tied to the same abortController as user-initiated
+    // (issue #4103). Explicit per-request safety limits still apply to Goal
+    // turns; only the generic session turn limit excludes runtime Goal
+    // continuations. Tied to the same abortController as user-initiated
     // SIGINT so the existing cancellation plumbing carries the abort;
     // `routeAbort` below interprets the reason so the user sees
     // "budget exceeded" instead of a generic "cancelled" envelope.
@@ -445,8 +714,11 @@ export async function runNonInteractive(
      * `unreachable` throw is only present to keep the type-checker honest.
      */
     const routeAbort = async (): Promise<never> => {
-      await settleBeforeTerminalOutput();
       const exceeded = budgetEnforcer.getExceeded();
+      await failClosedActiveGoalTurn(
+        exceeded?.message ?? 'Headless Goal execution was cancelled',
+      );
+      await settleBeforeTerminalOutput();
       if (exceeded) {
         await handleBudgetExceededError(config, exceeded);
         // Explicit unreachable — `handleBudgetExceededError` is `never`
@@ -790,6 +1062,46 @@ export async function runNonInteractive(
               }
               slashHandled = true;
               break;
+            case 'goal_control': {
+              const { snapshot } = slashCommandResult.response;
+              observeGoalRuntime(await config.getGoalRuntimeReady());
+              emitGoalSnapshot(snapshot);
+
+              const message = formatGoalState(
+                snapshot,
+                slashCommandResult.operation.kind,
+              );
+              const shouldRunGoalWorker =
+                snapshot.goal?.status === 'active' &&
+                (slashCommandResult.operation.kind === 'set' ||
+                  slashCommandResult.operation.kind === 'edit' ||
+                  slashCommandResult.operation.kind === 'resume');
+              if (!shouldRunGoalWorker) {
+                await emitNonInteractiveFinalMessage({
+                  message,
+                  isError: false,
+                  adapter,
+                  config,
+                  startTimeMs: startTime,
+                  beforeEmit: settleBeforeTerminalOutput,
+                });
+                return 0;
+              }
+
+              if (outputFormat === OutputFormat.TEXT) {
+                process.stdout.write(`${message}\n`);
+              }
+              bindGoalHost();
+              activeGoalTurn = queuedGoalTurns.shift();
+              if (!activeGoalTurn) {
+                throw new FatalInputError(
+                  'The Goal runtime did not schedule a continuation.',
+                );
+              }
+              initialPartList = buildGoalContinuationParts(activeGoalTurn);
+              slashHandled = true;
+              break;
+            }
             case 'message': {
               // systemMessage already emitted above
               await emitNonInteractiveFinalMessage({
@@ -983,6 +1295,46 @@ export async function runNonInteractive(
           }
         }
       }
+      const initialSendType =
+        continueSendType ??
+        options.sendMessageType ??
+        SendMessageType.UserQuery;
+      if (!activeGoalTurn && initialSendType === SendMessageType.UserQuery) {
+        try {
+          const runtime = await config.getGoalRuntimeReady();
+          observeGoalRuntime(runtime);
+          if (runtime.getSnapshot().goal?.status === 'active') {
+            const permit = await claimUserGoalTurn(
+              runtime,
+              prompt_id,
+              abortController.signal,
+            );
+            if (abortController.signal.aborted) {
+              await routeAbort();
+            }
+            if (permit) {
+              const goal = runtime.getSnapshot().goal;
+              if (!goal) {
+                throw new Error('Goal turn admission lost its active Goal');
+              }
+              const verifierFeedback = runtime.getVerifierFeedback(permit);
+              activeGoalTurn = {
+                permit,
+                turnKey: prompt_id,
+                controller: new AbortController(),
+                origin: 'user',
+                continuationContext: goal.objective,
+                ...(verifierFeedback ? { verifierFeedback } : {}),
+              };
+              bindGoalHost();
+            }
+          }
+        } catch (error) {
+          if (!(error instanceof GoalPersistenceUnavailableError)) {
+            throw error;
+          }
+        }
+      }
       let currentMessages: Content[] = [{ role: 'user', parts: initialParts }];
 
       // Register the callback early so background agents launched during the main
@@ -1069,6 +1421,7 @@ export async function runNonInteractive(
       }
 
       let isFirstTurn = true;
+      let isFirstGoalSegment = activeGoalTurn !== undefined;
       let hasUnsentToolResponse = false;
       let modelOverride: string | undefined =
         inlineModelOverride ?? fullTurnModelOverride;
@@ -1113,6 +1466,9 @@ export async function runNonInteractive(
       // no-op), so unconditional invocation is safe even when the drain
       // path already finalized monitors before reaching here.
       const emitStructuredSuccess = async (): Promise<0> => {
+        await failClosedActiveGoalTurn(
+          'Headless Goal ended with structured output',
+        );
         registry.abortAll();
         // `abortAll()` marks each task `cancelled` synchronously, but
         // the matching `task_notification` is emitted later by the
@@ -1149,6 +1505,9 @@ export async function runNonInteractive(
       };
 
       const emitLoopDetectedResult = async (): Promise<1> => {
+        await failClosedActiveGoalTurn(
+          'Headless Goal stopped after loop detection',
+        );
         registry.abortAll();
         flushQueuedNotificationsToSdk(localQueue);
         finalizeOneShotMonitors();
@@ -1206,6 +1565,7 @@ export async function runNonInteractive(
       type ToolCallBatchResult = {
         responseParts: Part[];
         repeatedDuplicateProviderToolCall: boolean;
+        terminateTurn: boolean;
       };
 
       const processToolCallBatch = async (
@@ -1213,6 +1573,7 @@ export async function runNonInteractive(
         setModelOverride: (override: string | undefined) => boolean,
         runtimeView?: RuntimeContentGeneratorView,
       ): Promise<ToolCallBatchResult> => {
+        let terminateTurn = false;
         const responseByRequest = new Map<
           ToolCallRequestInfo,
           ToolCallResponseInfo
@@ -1266,6 +1627,7 @@ export async function runNonInteractive(
           return {
             responseParts: [],
             repeatedDuplicateProviderToolCall: true,
+            terminateTurn: false,
           };
         }
 
@@ -1410,7 +1772,12 @@ export async function runNonInteractive(
           const response = await executeToolCall(
             config,
             requestInfo,
-            abortController.signal,
+            activeGoalTurn
+              ? AbortSignal.any([
+                  abortController.signal,
+                  activeGoalTurn.controller.signal,
+                ])
+              : abortController.signal,
             {
               recordToolResult: false,
               onToolResultFullTurnModel: (model) => {
@@ -1463,6 +1830,7 @@ export async function runNonInteractive(
 
           adapter.emitToolResult(requestInfo, toolResponse);
           responseByRequest.set(requestInfo, toolResponse);
+          terminateTurn ||= toolResponse.terminateTurn === true;
           config
             .getGeminiClient()
             .recordCompletedToolCall(
@@ -1724,6 +2092,7 @@ export async function runNonInteractive(
         return {
           responseParts: toolResponseParts,
           repeatedDuplicateProviderToolCall: false,
+          terminateTurn,
         };
       };
 
@@ -1740,7 +2109,7 @@ export async function runNonInteractive(
         if (!isFirstTurn && pendingTeammateMessages.length > 0) {
           const batch = pendingTeammateMessages.splice(0);
           const teammatePart = { text: batch.join('\n\n') };
-          if (hasUnsentToolResponse && currentMessages[0]) {
+          if ((hasUnsentToolResponse || activeGoalTurn) && currentMessages[0]) {
             currentMessages[0].parts = [
               ...(currentMessages[0].parts || []),
               teammatePart,
@@ -1762,16 +2131,17 @@ export async function runNonInteractive(
         hasUnsentToolResponse = false;
 
         turnCount++;
-        if (
-          config.getMaxSessionTurns() >= 0 &&
-          turnCount > config.getMaxSessionTurns()
-        ) {
-          await settleBeforeTerminalOutput();
-          await handleMaxTurnsExceededError(config);
-        }
+        const goalTurn = activeGoalTurn;
+        await enforceSessionTurnLimit(goalTurn?.origin === 'runtime');
 
         let sendType: SendMessageType;
-        if (isFirstTurn) {
+        if (goalTurn) {
+          sendType = isFirstGoalSegment
+            ? goalTurn.origin === 'runtime'
+              ? SendMessageType.Goal
+              : SendMessageType.UserQuery
+            : SendMessageType.ToolResult;
+        } else if (isFirstTurn) {
           sendType =
             continueSendType ??
             options.sendMessageType ??
@@ -1798,9 +2168,18 @@ export async function runNonInteractive(
               options.notificationDisplayText && {
                 notificationDisplayText: options.notificationDisplayText,
               }),
+            ...(goalTurn
+              ? {
+                  goalPermit: goalTurn.permit,
+                  goalTurnKey: goalTurn.turnKey,
+                  goalSignal: goalTurn.controller.signal,
+                  goalOrigin: goalTurn.origin,
+                }
+              : {}),
           },
         );
         isFirstTurn = false;
+        isFirstGoalSegment = false;
 
         // Start assistant message for this turn
         adapter.startAssistantMessage();
@@ -1864,6 +2243,7 @@ export async function runNonInteractive(
           return emitLoopDetectedResult();
         }
 
+        let shouldFinalizeTurn = toolCallRequests.length === 0;
         if (toolCallRequests.length > 0) {
           // Dispatch the per-turn tool-call batch through the shared
           // helper (see processToolCallBatch above). The helper handles
@@ -1879,6 +2259,7 @@ export async function runNonInteractive(
           const {
             responseParts: toolResponseParts,
             repeatedDuplicateProviderToolCall,
+            terminateTurn,
           } = await processToolCallBatch(
             toolCallRequests,
             (override) => {
@@ -1913,9 +2294,57 @@ export async function runNonInteractive(
             );
             return emitLoopDetectedResult();
           }
-          currentMessages = [{ role: 'user', parts: toolResponseParts }];
-          hasUnsentToolResponse = true;
-        } else {
+          if (terminateTurn && activeGoalTurn) {
+            geminiClient.addHistory({
+              role: 'user',
+              parts: toolResponseParts,
+            });
+            await config.getChatRecordingService?.()?.flush();
+            await finishGoalTurn(activeGoalTurn);
+            activeGoalTurn = undefined;
+            const nextGoalTurn = queuedGoalTurns.shift();
+            if (nextGoalTurn) {
+              activeGoalTurn = nextGoalTurn;
+              isFirstGoalSegment = true;
+              currentMessages = [
+                {
+                  role: 'user',
+                  parts: buildGoalContinuationParts(nextGoalTurn),
+                },
+              ];
+              hasUnsentToolResponse = false;
+              continue;
+            }
+            shouldFinalizeTurn = true;
+          }
+          if (!shouldFinalizeTurn) {
+            currentMessages = [{ role: 'user', parts: toolResponseParts }];
+            hasUnsentToolResponse = true;
+          }
+        }
+        if (shouldFinalizeTurn) {
+          if (activeGoalTurn) {
+            const completedGoalTurn = activeGoalTurn;
+            await config.getChatRecordingService?.()?.flush();
+            await finishGoalTurn(completedGoalTurn);
+            if (activeGoalTurn === completedGoalTurn) {
+              activeGoalTurn = undefined;
+            }
+            const nextGoalTurn = queuedGoalTurns.shift();
+            if (nextGoalTurn) {
+              activeGoalTurn = nextGoalTurn;
+              isFirstGoalSegment = true;
+              currentMessages = [
+                {
+                  role: 'user',
+                  parts: buildGoalContinuationParts(nextGoalTurn),
+                },
+              ];
+              hasUnsentToolResponse = false;
+              continue;
+            }
+          }
+
           // No more tool calls — check if teammates are active.
           const teamManager = config.getTeamManager();
           if (teamManager?.hasActiveTeammates()) {
@@ -1976,8 +2405,7 @@ export async function runNonInteractive(
           // immediately instead of falling through to the
           // success path.
           if (abortController.signal.aborted) {
-            await settleBeforeTerminalOutput();
-            await handleCancellationError(config);
+            await routeAbort();
           }
 
           // Force one final inbox drain before deciding to exit.
@@ -2032,13 +2460,7 @@ export async function runNonInteractive(
             };
 
             turnCount++;
-            if (
-              config.getMaxSessionTurns() >= 0 &&
-              turnCount > config.getMaxSessionTurns()
-            ) {
-              await settleBeforeTerminalOutput();
-              await handleMaxTurnsExceededError(config);
-            }
+            await enforceSessionTurnLimit(false);
 
             let itemMessages: Content[] = [
               { role: 'user', parts: [{ text: item.modelText }] },
@@ -2414,6 +2836,11 @@ export async function runNonInteractive(
         }
       }
     } catch (error) {
+      await failClosedActiveGoalTurn(
+        error instanceof Error
+          ? error.message
+          : 'Headless Goal execution failed',
+      );
       // Ensure message_start / message_stop (and content_block events) are
       // properly paired even when an error aborts the turn mid-stream.
       // The call is safe when no message was started (throws → caught) or
@@ -2498,6 +2925,13 @@ export async function runNonInteractive(
       }
       await handleError(error, config);
     } finally {
+      await failClosedActiveGoalTurn(
+        'Headless Goal host stopped before its permit was released',
+      );
+      goalRuntimeUnsubscribe?.();
+      goalRuntimeUnsubscribe = undefined;
+      goalHostUnbind?.();
+      goalHostUnbind = undefined;
       if (workflowApprovalChannelRegistered) {
         config.getWorkflowRunRegistry().setApprovalRequestCallback(undefined);
       }

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -560,6 +560,9 @@ export async function runNonInteractive(
       limitedTurnCount++;
       const maxSessionTurns = config.getMaxSessionTurns();
       if (maxSessionTurns >= 0 && limitedTurnCount > maxSessionTurns) {
+        await failClosedActiveGoalTurn(
+          'Headless Goal stopped after the session turn limit',
+        );
         await settleBeforeTerminalOutput();
         await handleMaxTurnsExceededError(config);
       }

--- a/packages/cli/src/nonInteractiveCliCommands.test.ts
+++ b/packages/cli/src/nonInteractiveCliCommands.test.ts
@@ -11,7 +11,11 @@ import {
 } from './nonInteractiveCliCommands.js';
 import {
   __resetActiveGoalStoreForTests,
+  createGoalRuntime,
+  type ChatRecord,
   type Config,
+  type GoalJournal,
+  type GoalStateRecordPayloadV2,
   uiTelemetryService,
 } from '@qwen-code/qwen-code-core';
 import type { LoadedSettings } from './config/settings.js';
@@ -42,10 +46,32 @@ describe('handleSlashCommand', () => {
   let abortController: AbortController;
   let mockFireUserPromptExpansionEvent: ReturnType<typeof vi.fn>;
 
+  const createJournal = (): GoalJournal => ({
+    getTranscriptCursor: () => ({ recordId: null }),
+    async recordGoalState(
+      recordUuid: string,
+      payload: GoalStateRecordPayloadV2,
+    ): Promise<ChatRecord> {
+      return {
+        uuid: recordUuid,
+        parentUuid: null,
+        sessionId: 'test-session',
+        timestamp: new Date(0).toISOString(),
+        type: 'system',
+        subtype: 'goal_state',
+        provenance: 'goal_control',
+        cwd: '/test/project',
+        version: 'test',
+        systemPayload: structuredClone(payload),
+      };
+    },
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     uiTelemetryService.reset();
     __resetActiveGoalStoreForTests();
+    const goalRuntime = createGoalRuntime({ journal: createJournal() });
     // getCommandsForMode applies real mode filtering on top of getCommands()
     mockGetCommandsForMode.mockImplementation((mode: ExecutionMode) =>
       filterCommandsForMode(mockGetCommands(), mode),
@@ -81,6 +107,8 @@ describe('handleSlashCommand', () => {
       setModelInvocableCommandsProvider: vi.fn(),
       setModelInvocableCommandsExecutor: vi.fn(),
       getDisabledSlashCommands: vi.fn().mockReturnValue([]),
+      getGoalRuntime: vi.fn(() => goalRuntime),
+      getGoalRuntimeReady: vi.fn(async () => goalRuntime),
       storage: {},
     } as unknown as Config;
 
@@ -227,7 +255,7 @@ describe('handleSlashCommand', () => {
     }
   });
 
-  it('should execute /goal in non-interactive mode as a submit_prompt command', async () => {
+  it('returns canonical goal_control for a non-interactive create', async () => {
     mockGetCommands.mockReturnValue([goalCommand]);
 
     const result = await handleSlashCommand(
@@ -237,25 +265,26 @@ describe('handleSlashCommand', () => {
       mockSettings,
     );
 
-    expect(result.type).toBe('submit_prompt');
-    if (result.type === 'submit_prompt') {
-      expect(result.content).toEqual([
-        expect.objectContaining({
-          text: expect.stringContaining('write a hello world script'),
-        }),
-      ]);
-      expect(result.outputHistoryItems).toEqual([
-        expect.objectContaining({
-          type: 'goal_status',
-          kind: 'set',
-          condition: 'write a hello world script',
-          setAt: expect.any(Number),
-        }),
-      ]);
-    }
+    expect(result).toMatchObject({
+      type: 'goal_control',
+      operation: {
+        kind: 'set',
+        objective: 'write a hello world script',
+      },
+      response: {
+        snapshot: {
+          v: 2,
+          activity: 'idle',
+          goal: {
+            objective: 'write a hello world script',
+            status: 'active',
+          },
+        },
+      },
+    });
   });
 
-  it('should report no active goal for empty non-interactive /goal', async () => {
+  it('returns canonical goal_control for empty non-interactive /goal status', async () => {
     mockGetCommands.mockReturnValue([goalCommand]);
 
     const result = await handleSlashCommand(
@@ -266,13 +295,15 @@ describe('handleSlashCommand', () => {
     );
 
     expect(result).toMatchObject({
-      type: 'message',
-      messageType: 'info',
-      content: 'No goal set. Usage: `/goal <condition>` (or `/goal clear`).',
+      type: 'goal_control',
+      operation: { kind: 'status' },
+      response: {
+        snapshot: { v: 2, activity: 'idle', goal: null },
+      },
     });
   });
 
-  it('should report active goal status after setting a non-interactive /goal', async () => {
+  it('returns the active v2 snapshot for status after create', async () => {
     mockGetCommands.mockReturnValue([goalCommand]);
 
     await handleSlashCommand(
@@ -289,18 +320,20 @@ describe('handleSlashCommand', () => {
     );
 
     expect(result).toMatchObject({
-      type: 'message',
-      messageType: 'info',
+      type: 'goal_control',
+      operation: { kind: 'status' },
+      response: {
+        snapshot: {
+          goal: {
+            objective: 'write a hello world script',
+            status: 'active',
+          },
+        },
+      },
     });
-    if (result.type === 'message') {
-      expect(result.content).toContain(
-        'Goal active: write a hello world script',
-      );
-      expect(result.content).toContain('not yet evaluated');
-    }
   });
 
-  it('should report cleared goal for non-interactive /goal clear', async () => {
+  it('returns the cleared v2 snapshot for non-interactive /goal clear', async () => {
     mockGetCommands.mockReturnValue([goalCommand]);
 
     await handleSlashCommand(
@@ -317,20 +350,12 @@ describe('handleSlashCommand', () => {
     );
 
     expect(result).toMatchObject({
-      type: 'message',
-      messageType: 'info',
-      content: 'Goal cleared: write a hello world script',
+      type: 'goal_control',
+      operation: { kind: 'clear' },
+      response: {
+        snapshot: { v: 2, activity: 'idle', goal: null },
+      },
     });
-    if (result.type === 'message') {
-      expect(result.outputHistoryItems).toEqual([
-        expect.objectContaining({
-          type: 'goal_status',
-          kind: 'cleared',
-          condition: 'write a hello world script',
-          durationMs: expect.any(Number),
-        }),
-      ]);
-    }
   });
 
   it('should report cleared goal for ACP /goal clear', async () => {

--- a/packages/cli/src/nonInteractiveCliCommands.ts
+++ b/packages/cli/src/nonInteractiveCliCommands.ts
@@ -13,6 +13,7 @@ import {
   Logger,
   uiTelemetryService,
   type Config,
+  type GoalStateResponse,
   createDebugLogger,
   recordSkillInvocation,
 } from '@qwen-code/qwen-code-core';
@@ -29,6 +30,7 @@ import {
 import {
   type CommandContext,
   CommandKind,
+  type GoalCommandOperation,
   type SlashCommand,
   type SlashCommandActionReturn,
   type ExecutionMode,
@@ -59,6 +61,7 @@ function getSkillCommandName(command: SlashCommand): string {
  * - 'submit_prompt': Submits content to the model (supports all modes)
  * - 'message': Returns a single message (supports non-interactive JSON/text only)
  * - 'stream_messages': Streams multiple messages (supports ACP only)
+ * - 'goal_control': Returns the canonical Goal control result
  * - 'unsupported': Command cannot be executed in this mode
  * - 'no_command': No command was found or executed
  */
@@ -85,6 +88,11 @@ export type NonInteractiveSlashCommandResult =
       >;
     }
   | {
+      type: 'goal_control';
+      operation: GoalCommandOperation;
+      response: GoalStateResponse;
+    }
+  | {
       type: 'unsupported';
       reason: string;
       originalType: string;
@@ -100,6 +108,7 @@ export type NonInteractiveSlashCommandResult =
  * - submit_prompt: Submits content to the model (all modes)
  * - message: Returns a single message (non-interactive JSON/text only)
  * - stream_messages: Streams multiple messages (ACP only)
+ * - goal_control: Returns a canonical Goal control result
  *
  * All other result types are converted to 'unsupported'.
  *
@@ -133,6 +142,13 @@ function handleCommandResult(
       return {
         type: 'stream_messages',
         messages: result.messages,
+      };
+
+    case 'goal_control':
+      return {
+        type: 'goal_control',
+        operation: result.operation,
+        response: result.response,
       };
 
     /**
@@ -185,13 +201,6 @@ function handleCommandResult(
         reason:
           'Action confirmation is not supported in non-interactive mode. Commands requiring confirmation cannot be executed.',
         originalType: 'confirm_action',
-      };
-
-    case 'goal_control':
-      return {
-        type: 'unsupported',
-        reason: 'Goal control is not supported in non-interactive mode yet.',
-        originalType: 'goal_control',
       };
 
     default: {

--- a/packages/cli/src/ui/commands/goalCommand.test.ts
+++ b/packages/cli/src/ui/commands/goalCommand.test.ts
@@ -194,6 +194,27 @@ describe('goalCommand', () => {
     },
   );
 
+  it.each(['edit revised', 'pause', 'resume'] as const)(
+    'rejects /goal %s in ACP mode',
+    async (args) => {
+      const { runtime } = makeRuntime(goalSnapshot());
+      const { context, getGoalRuntimeReady } = makeContext(runtime, {
+        executionMode: 'acp',
+      });
+
+      const result = await goalCommand.action!(context, args);
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content: expect.stringMatching(/not available in ACP mode/i),
+      });
+      expect(getGoalRuntimeReady).not.toHaveBeenCalled();
+      expect(mockRegisterGoalHook).not.toHaveBeenCalled();
+      expect(mockUnregisterGoalHook).not.toHaveBeenCalled();
+    },
+  );
+
   it('strips the set keyword before forwarding to the legacy ACP path', async () => {
     mockRegisterGoalHook.mockReturnValue({
       condition: 'Ship it',

--- a/packages/cli/src/ui/commands/goalCommand.test.ts
+++ b/packages/cli/src/ui/commands/goalCommand.test.ts
@@ -66,11 +66,23 @@ function makeRuntime(
   return { dispatch, getSnapshot, runtime };
 }
 
-function makeContext(runtime: GoalRuntime, { trusted = true } = {}) {
+function makeContext(
+  runtime: GoalRuntime,
+  {
+    trusted = true,
+    executionMode = 'interactive',
+  }: {
+    trusted?: boolean;
+    executionMode?: 'interactive' | 'non_interactive' | 'acp';
+  } = {},
+) {
   const getGoalRuntimeReady = vi.fn().mockResolvedValue(runtime);
   const isTrustedFolder = vi.fn(() => trusted);
   const config = { getGoalRuntimeReady, isTrustedFolder } as unknown as Config;
-  const context = createMockCommandContext({ services: { config } });
+  const context = createMockCommandContext({
+    executionMode,
+    services: { config },
+  });
   return { context, getGoalRuntimeReady, isTrustedFolder };
 }
 
@@ -140,22 +152,49 @@ describe('goalCommand', () => {
     ]);
   });
 
-  it.each(['pause', 'resume', 'edit revised'] as const)(
-    'rejects /goal %s in non-interactive mode',
-    async (args) => {
-      const context = createMockCommandContext({
+  it.each([
+    [
+      'edit revised',
+      {
+        action: 'edit',
+        objective: 'revised',
+        expectedGoalId: 'goal-1',
+        expectedRevision: 4,
+      },
+    ],
+    [
+      'pause',
+      {
+        action: 'pause',
+        expectedGoalId: 'goal-1',
+        expectedRevision: 4,
+      },
+    ],
+    [
+      'resume',
+      {
+        action: 'resume',
+        expectedGoalId: 'goal-1',
+        expectedRevision: 4,
+      },
+    ],
+  ] as const)(
+    'uses the canonical runtime for non-interactive /goal %s',
+    async (args, expectedRequest) => {
+      const { dispatch, runtime } = makeRuntime(goalSnapshot());
+      const { context } = makeContext(runtime, {
         executionMode: 'non_interactive',
       });
+
       const result = await goalCommand.action!(context, args);
-      expect(result).toMatchObject({
-        type: 'message',
-        messageType: 'error',
-        content: expect.stringMatching(/only available in interactive mode/i),
-      });
+
+      expect(dispatch).toHaveBeenCalledWith(expectedRequest);
+      expect(result).toMatchObject({ type: 'goal_control' });
+      expect(mockRegisterGoalHook).not.toHaveBeenCalled();
     },
   );
 
-  it('strips the set keyword before forwarding to the legacy path in non-interactive mode', async () => {
+  it('strips the set keyword before forwarding to the legacy ACP path', async () => {
     mockRegisterGoalHook.mockReturnValue({
       condition: 'Ship it',
       setAt: Date.now(),
@@ -167,7 +206,7 @@ describe('goalCommand', () => {
       getHookSystem: () => ({}),
     } as unknown as Config;
     const context = createMockCommandContext({
-      executionMode: 'non_interactive',
+      executionMode: 'acp',
       services: { config },
     });
 
@@ -179,7 +218,7 @@ describe('goalCommand', () => {
   });
 
   it.each(['clear', 'stop', 'off', 'reset', 'none', 'cancel'])(
-    'sets a literal %j objective instead of clearing in non-interactive mode',
+    'sets a literal %j objective instead of clearing in legacy ACP mode',
     async (keyword) => {
       mockRegisterGoalHook.mockReturnValue({
         condition: keyword,
@@ -192,7 +231,7 @@ describe('goalCommand', () => {
         getHookSystem: () => ({}),
       } as unknown as Config;
       const context = createMockCommandContext({
-        executionMode: 'non_interactive',
+        executionMode: 'acp',
         services: { config },
       });
 
@@ -206,7 +245,7 @@ describe('goalCommand', () => {
     },
   );
 
-  it('still clears on a bare clear keyword in non-interactive mode', async () => {
+  it('still clears on a bare clear keyword in legacy ACP mode', async () => {
     mockUnregisterGoalHook.mockReturnValue({
       condition: 'Old goal',
       iterations: 2,
@@ -219,7 +258,7 @@ describe('goalCommand', () => {
       getHookSystem: () => ({}),
     } as unknown as Config;
     const context = createMockCommandContext({
-      executionMode: 'non_interactive',
+      executionMode: 'acp',
       services: { config },
     });
 

--- a/packages/cli/src/ui/commands/goalCommand.ts
+++ b/packages/cli/src/ui/commands/goalCommand.ts
@@ -258,7 +258,7 @@ export const goalCommand: SlashCommand = {
     context: CommandContext,
     args: string,
   ): Promise<SlashCommandActionReturn> => {
-    if (context.executionMode !== 'interactive') {
+    if (context.executionMode === 'acp') {
       const operation = parseGoalCommand(args);
       if (operation.kind === 'error') return errorMessage(operation.message);
       if (
@@ -267,7 +267,7 @@ export const goalCommand: SlashCommand = {
         operation.kind !== 'set'
       ) {
         return errorMessage(
-          `'/goal ${operation.kind}' is only available in interactive mode.`,
+          `'/goal ${operation.kind}' is not available in ACP mode.`,
         );
       }
       const explicitSet = operation.kind === 'set';


### PR DESCRIPTION
## What this PR does

This PR moves non-interactive CLI `/goal` commands onto the canonical Goal v3 runtime. Status, create, replace, edit, pause, resume, and clear now return the same persisted v2 state used by the interactive clients, and `stream-json` consumers receive an ordered `goal_state` event while the legacy `active_goal` projection remains available when partial messages are enabled.

Headless Goal workers now use Core-issued permits across model and tool-result segments, flush transcript evidence before releasing a permit, stream verification and terminal transitions, and terminate cleanly after `update_goal` without an unnecessary follow-up model call. Runtime-generated Goal continuations no longer consume the generic non-interactive session-turn limit, while explicit wall-clock and tool-call budgets continue to fail closed by pausing active work.

ACP intentionally remains on the legacy Goal command path in this split PR.

## Why it's needed

The previous non-interactive path still used the legacy hook-backed Goal behavior and could not expose the canonical persisted lifecycle. It also had no consistent permit ownership or state stream for unattended clients. During E2E verification, a terminal `update_goal` additionally exposed a real exit-path defect: the worker could finish without emitting the normal success result and exit 0. This change closes that gap and aligns headless execution with the already-landed Goal v3 runtime contract.

## Reviewer Test Plan

### How to verify

Run `/goal` in non-interactive text mode with no active Goal and confirm it returns `No Goal is set.` without contacting the model. Run the same command with `stream-json` and confirm the canonical idle v2 state appears before the assistant summary and success result.

Create a Goal that requires an exact response followed by `get_goal` and `update_goal`. Confirm the worker is admitted with a Core permit, the requested content is delivered, verification and terminal states are streamed, no extra model turn follows the terminal tool call, and the process emits a success result with exit 0.

Pause and resume the same persisted session, then clear it. Confirm the same session state is restored, resume schedules a fresh exact permit, and clear completes without confirmation. Finally, apply a short explicit wall-clock budget and confirm an over-budget Goal pauses, emits the paused state, and exits with the budget-specific code rather than remaining active.

### Evidence (Before & After)

Before: non-interactive `/goal` used the legacy hook projection, did not provide canonical v2 lifecycle events, and a terminal Goal tool call could fall through without a successful result envelope.

After: the observed stream is `system/init` → canonical `goal_state` → assistant/result for status, and active → running → verifying → terminal → success for a completed worker. A verifier wait interrupted by the explicit wall-clock budget produces paused/idle state and exit 55.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 24.14.1, local production bundle, no sandbox. Focused CLI tests: 280 passed and 1 existing skip. Full repository typecheck, modified-file ESLint, full build, and root bundle completed successfully.

## Risk & Scope

- Main risk or tradeoff: non-interactive clients that parse Goal output can now observe the canonical `goal_state` event in addition to the compatibility projection.
- Not validated / out of scope: ACP conversion, Windows/Linux live E2E, verifier-provider reliability, and removal of Core's independent fixed 50-continuation cap.
- Breaking changes / migration notes: text commands keep human-readable summaries; stream clients should adopt `goal_state` as authoritative and treat `active_goal` as a compatibility projection.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 将非交互 CLI 的 `/goal` 命令迁移到 canonical Goal v3 runtime。状态查询、创建、替换、编辑、暂停、恢复和清除现在都会返回与交互端一致的持久化 v2 状态；`stream-json` 消费方会收到有序的 `goal_state` 事件，同时在开启 partial messages 时继续保留旧的 `active_goal` 兼容投影。

Headless Goal worker 现在会在模型调用和工具结果续轮之间保持 Core 签发的 permit，在释放 permit 前刷新 transcript evidence，输出验证及终态变更，并在 `update_goal` 结束当前轮后直接完成，不再额外调用一次模型。runtime 自动产生的 Goal 续轮不再消耗非交互模式的通用 session turn 限制，但显式 wall-clock 和 tool-call 预算仍然生效，并会通过暂停活跃 Goal 的方式 fail closed。

作为拆分 PR 的边界，ACP 本次仍然保留旧 Goal 命令路径。

## 为什么需要

此前非交互模式仍使用基于 hook 的旧 Goal 行为，无法提供 canonical 持久化生命周期，也缺少适用于无人值守客户端的一致 permit 所有权和状态流。E2E 验证还发现了一个真实退出路径缺陷：终态 `update_goal` 之后，worker 可能结束但没有输出正常 success result 和退出码 0。本次修改修复该问题，并让 headless 执行与已合入的 Goal v3 runtime 契约对齐。

## Reviewer 测试计划

### 如何验证

在没有活跃 Goal 时用非交互文本模式执行 `/goal`，确认输出 `No Goal is set.` 且不请求模型。再使用 `stream-json` 执行相同命令，确认 canonical idle v2 状态出现在 assistant summary 和 success result 之前。

创建一个要求先精确回复、再调用 `get_goal` 和 `update_goal` 的 Goal。确认 worker 使用 Core permit 准入，指定内容被输出，验证和终态被写入状态流，终态工具调用后没有多余模型轮次，进程最终输出 success result 并以 0 退出。

在同一持久化会话中暂停、恢复并清除 Goal。确认会话状态能够恢复，resume 调度新的精确 permit，clear 不弹确认。最后设置较短的显式 wall-clock 预算，确认超时 Goal 会暂停、输出 paused 状态，并使用预算专用退出码结束，而不是继续保持 active。

### 前后证据

修改前：非交互 `/goal` 使用旧 hook 投影，不输出 canonical v2 生命周期事件，且终态 Goal 工具调用可能漏掉成功结果封包。

修改后：状态查询的实测输出顺序为 `system/init` → canonical `goal_state` → assistant/result；完成 worker 的链路为 active → running → verifying → terminal → success。显式 wall-clock 预算中断 verifier 等待时会输出 paused/idle 状态并以 55 退出。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境

Node.js 24.14.1，本地 production bundle，无 sandbox。聚焦 CLI 测试 280 个通过、1 个既有 skip。完整仓库 typecheck、改动文件 ESLint、全量 build 和根 bundle 均通过。

## 风险与范围

- 主要风险或取舍：解析 Goal 输出的非交互客户端现在会在兼容投影之外收到 canonical `goal_state` 事件。
- 未验证或不在范围内：ACP 迁移、Windows/Linux 实机 E2E、verifier/provider 稳定性，以及移除 Core 中独立的固定 50 续轮上限。
- 破坏性变更或迁移说明：文本命令继续使用人类可读摘要；stream 客户端应以 `goal_state` 为权威状态，并将 `active_goal` 视为兼容投影。

## 关联 Issue

无

</details>
