### PR TITLE
docs: complete TUI keyboard shortcut reference

### DIFF
--- a/docs/users/reference/keyboard-shortcuts.md
+++ b/docs/users/reference/keyboard-shortcuts.md
@@ -4,18 +4,17 @@ This document lists the available keyboard shortcuts in Qwen Code.
 
 ## General
 
-| Shortcut                       | Description                                                                                                                                                                                                                                                                                               |
-| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Esc`                          | Close dialogs and suggestions.                                                                                                                                                                                                                                                                            |
-| `Ctrl+C`                       | Cancel the ongoing request and clear the input. Press twice to exit the application.                                                                                                                                                                                                                      |
-| `Ctrl+D`                       | Exit the application if the input is empty. Press twice to confirm.                                                                                                                                                                                                                                       |
-| `Ctrl+L`                       | Clear the screen.                                                                                                                                                                                                                                                                                         |
-| `Ctrl+O`                       | Toggle expanded detail mode: expand or collapse all thinking blocks and tool outputs inline. Press again to collapse. When `ui.useTerminalBuffer` is off, toggling redraws the full conversation with untruncated output into terminal scrollback.                                                        |
-| `Ctrl+S`                       | Stashes non-empty input for the current project and restores it on the next launch. With empty input, allows long responses to print fully, disabling truncation. Use your terminal's scrollback to view the entire output.                                                                               |
-| `Ctrl+T`                       | Toggle the display of tool descriptions.                                                                                                                                                                                                                                                                  |
-| `Ctrl+B`                       | While a foreground shell command is running: promote it to a background task. The child keeps running, the agent's turn unblocks, and the shell appears in `/tasks` + the Background tasks dialog. No-op when no shell is executing — Ctrl+B then falls through to its prompt-area binding (cursor-left). |
-| `Alt/Option+M`                 | Toggle Markdown output between rich rendered previews and raw/source mode. On macOS, the terminal must send Option as Meta.                                                                                                                                                                               |
-| `Shift+Tab` (`Tab` on Windows) | Cycle approval modes (`plan` → `default` → `auto-edit` → `auto` → `yolo`)                                                                                                                                                                                                                                 |
+| Shortcut                       | Description                                                                                                                                                                                                                                        |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Esc`                          | Close dialogs and suggestions. With an empty prompt, cancel an ongoing request; when idle outside IDE mode, press twice to open the rewind selector.                                                                                               |
+| `Ctrl+C`                       | Cancel the ongoing request and clear the input. Press twice to exit the application.                                                                                                                                                               |
+| `Ctrl+D`                       | Exit the application if the input is empty. Press twice to confirm.                                                                                                                                                                                |
+| `Ctrl+L`                       | Clear the screen.                                                                                                                                                                                                                                  |
+| `Ctrl+O` / `Alt/Option+T`      | Toggle expanded detail mode: expand or collapse all thinking blocks and tool outputs inline. Press again to collapse. When `ui.useTerminalBuffer` is off, toggling redraws the full conversation with untruncated output into terminal scrollback. |
+| `Ctrl+S`                       | Stashes non-empty input for the current project and restores it on the next launch. With empty input, allows long responses to print fully, disabling truncation. Use your terminal's scrollback to view the entire output.                        |
+| `Ctrl+T`                       | Toggle the display of tool descriptions.                                                                                                                                                                                                           |
+| `Alt/Option+M`                 | Toggle Markdown output between rich rendered previews and raw/source mode. On macOS, the terminal must send Option as Meta.                                                                                                                        |
+| `Shift+Tab` (`Tab` on Windows) | Cycle approval modes (`plan` → `default` → `auto-edit` → `auto` → `yolo`)                                                                                                                                                                          |
 
 ## Input Prompt
 
@@ -23,10 +22,15 @@ This document lists the available keyboard shortcuts in Qwen Code.
 | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
 | `!`                                                   | Toggle shell mode when the input is empty.                                                                                          |
 | `?`                                                   | Toggle keyboard shortcuts display when the input is empty.                                                                          |
+| `/`                                                   | Open slash-command completion.                                                                                                      |
+| `@`                                                   | Open completion for files, folders, and other context.                                                                              |
+| `Space` (empty prompt)                                | Start voice dictation when it and a voice model are configured; hold or tap behavior follows `general.voice.mode`.                  |
 | `Ctrl+Enter` / `Cmd+Enter` / `Shift+Enter` / `Ctrl+J` | Insert a newline.                                                                                                                   |
 | `Down Arrow`                                          | Row down, then snap to end, then history next.                                                                                      |
-| `Enter`                                               | Submit the current prompt.                                                                                                          |
-| `Meta+Delete` / `Ctrl+Delete`                         | Delete the word to the right of the cursor.                                                                                         |
+| `Enter`                                               | Submit the current prompt. While a response is running, steer the current turn.                                                     |
+| `Ctrl+Q`                                              | Queue the current prompt or command for the next turn instead of steering; it runs after Qwen Code returns to idle.                 |
+| `Up Arrow` (at the top) / `Esc`                       | When queued messages are present, move them back into the input for editing.                                                        |
+| `Meta+D` / `Meta+Delete` / `Ctrl+Delete`              | Delete the word to the right of the cursor.                                                                                         |
 | `Tab`                                                 | Autocomplete the current suggestion if one exists.                                                                                  |
 | `Up Arrow`                                            | Row up, then snap to start, then history prev.                                                                                      |
 | `Ctrl+A` / `Home`                                     | Move the cursor to the beginning of the line.                                                                                       |
@@ -48,14 +52,41 @@ This document lists the available keyboard shortcuts in Qwen Code.
 | `Ctrl+V` / `Option+V` (Windows: `Alt+V`)              | Paste clipboard content. If the clipboard contains an image, it will be saved and a reference to it will be inserted in the prompt. |
 | `Ctrl+W` / `Meta+Backspace` / `Ctrl+Backspace`        | Delete the word to the left of the cursor.                                                                                          |
 | `Ctrl+X`                                              | Open the current input in an external editor.                                                                                       |
+| `Ctrl+Z`                                              | Undo the last input edit.                                                                                                           |
+| `Ctrl+Shift+Z`                                        | Redo the last undone input edit.                                                                                                    |
+
+## Foreground Shell
+
+These shortcuts apply while an interactive foreground shell command is running.
+
+| Shortcut                            | Description                                                                                                                                                    |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Ctrl+F`                            | Toggle keyboard focus between the shell and the prompt. When no shell is running, `Ctrl+F` moves the prompt cursor right.                                      |
+| `Ctrl+Shift+Up` / `Ctrl+Shift+Down` | Scroll the focused shell up or down.                                                                                                                           |
+| `Ctrl+B`                            | Promote the shell to a background task. The child keeps running, the agent's turn unblocks, and the shell appears in `/tasks` and the Background tasks dialog. |
 
 ## Suggestions
 
-| Shortcut                | Description                            |
-| ----------------------- | -------------------------------------- |
-| `Down Arrow` / `Ctrl+N` | Navigate down through the suggestions. |
-| `Tab` / `Enter`         | Accept the selected suggestion.        |
-| `Up Arrow` / `Ctrl+P`   | Navigate up through the suggestions.   |
+| Shortcut                             | Description                                                              |
+| ------------------------------------ | ------------------------------------------------------------------------ |
+| `Down Arrow` / `Ctrl+N`              | Navigate down through the suggestions.                                   |
+| `Tab` / `Enter`                      | Accept the selected suggestion.                                          |
+| `Up Arrow` / `Ctrl+P`                | Navigate up through the suggestions.                                     |
+| `Right Arrow`                        | Accept a ghost-text suggestion when the prompt is empty.                 |
+| `Ctrl+Tab` / `Ctrl+Right Arrow`      | Switch to the next completion category when category tabs are shown.     |
+| `Ctrl+Shift+Tab` / `Ctrl+Left Arrow` | Switch to the previous completion category when category tabs are shown. |
+
+## History Search
+
+Press `Ctrl+R` to search prompt history, or shell history while shell mode is active.
+
+| Shortcut                     | Description                                                |
+| ---------------------------- | ---------------------------------------------------------- |
+| `Up Arrow` / `Down Arrow`    | Navigate through matching history entries.                 |
+| `Left Arrow` / `Right Arrow` | Collapse or expand a long selected entry.                  |
+| `Tab`                        | Accept the selected entry into the prompt without sending. |
+| `Enter`                      | Submit the selected entry.                                 |
+| `Esc`                        | Close history search.                                      |
 
 ## Radio Button Select
 


### PR DESCRIPTION
## What this PR does

Refreshes the keyboard shortcut reference so it matches the current TUI behavior. It documents the difference between steering the active turn with Enter and queueing the next turn with Ctrl+Q, explains how queued messages can be restored for editing, and fills gaps for prompt editing, completion categories, history search, voice input, and interactive foreground shells.

## Why it's needed

Several working and discoverable TUI shortcuts were missing from the user reference, including Ctrl+Q. Users who relied on the documentation could not tell how to queue a follow-up instead of steering, and other contextual shortcuts were only visible inside the running TUI.

## Reviewer Test Plan

### How to verify

- Confirm the input prompt section distinguishes Enter steering from Ctrl+Q queueing and explains how to retrieve queued messages for editing.
- Confirm the documented completion, history-search, voice-input, and foreground-shell shortcuts match their current contextual behavior.
- Confirm no runtime behavior or product defaults change.

Local validation completed:

- `npm run build`
- `npm run typecheck`
- `cd packages/cli && npx vitest run src/ui/keyMatchers.test.ts src/ui/components/InputPrompt.test.tsx src/ui/components/shared/text-buffer.test.ts src/ui/AppContainer.test.tsx` (547 tests passed)
- `npx prettier --check docs/users/reference/keyboard-shortcuts.md`

### Evidence (Before & After)

N/A — documentation-only change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Local macOS checkout with the repository's npm workspace dependencies.

## Risk & Scope

- Main risk or tradeoff: Shortcut documentation can drift as the TUI evolves; the entries in this change were checked against the current bindings, consumers, and focused tests.
- Not validated / out of scope: Manual terminal interaction on Windows and Linux; runtime behavior is unchanged.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 此 PR 的改动

更新快捷键参考文档，使其与当前 TUI 行为一致。文档现在说明 Enter 会引导当前轮次，而 Ctrl+Q 会将输入排到下一轮，并解释如何取回排队消息进行编辑；同时补齐输入编辑、补全分类、历史搜索、语音输入和交互式前台 shell 的快捷键遗漏。

## 为什么需要

用户参考文档遗漏了多个已实现且可在 TUI 中发现的快捷键，其中包括 Ctrl+Q。仅依赖文档的用户无法得知如何排队后续指令而不是引导当前轮次，其他上下文快捷键也只能在运行中的 TUI 内看到。

## 审阅者测试计划

### 如何验证

- 确认输入提示区域分清了 Enter 引导和 Ctrl+Q 排队，并说明了如何取回排队消息进行编辑。
- 确认补全、历史搜索、语音输入和前台 shell 快捷键与当前上下文行为一致。
- 确认没有改变运行时行为或产品默认值。

已完成本地验证：

- `npm run build`
- `npm run typecheck`
- `cd packages/cli && npx vitest run src/ui/keyMatchers.test.ts src/ui/components/InputPrompt.test.tsx src/ui/components/shared/text-buffer.test.ts src/ui/AppContainer.test.tsx`（547 项测试通过）
- `npx prettier --check docs/users/reference/keyboard-shortcuts.md`

### 证据（修改前后）

N/A — 仅文档改动。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### 环境（可选）

安装了仓库 npm workspace 依赖的本地 macOS checkout。

## 风险与范围

- 主要风险或权衡：TUI 演进后快捷键文档可能再次漂移；本次条目已对照当前绑定、消费位置和针对性测试核验。
- 未验证 / 范围外：未在 Windows 和 Linux 终端手动验证；运行时行为没有变化。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

N/A

</details>
