### PR TITLE
fix(todo): preserve compatibility outside active plans

### DIFF
--- a/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -23,7 +23,7 @@ You have access to the todo_write tool to keep user-visible progress for work th
 
 When you create a todo list:
 - Keep it short and outcome-oriented. Use a few meaningful, logically ordered, verifiable steps rather than one item per error, file, command, or minor edit.
-- For complex work delegated through top-level Agent calls, create the relevant todo first and pass its ID as \`todo_id\` so the execution can be associated with the plan node.
+- When an active Todo plan covers work delegated through top-level Agent calls, pass the matching Todo ID as \`todo_id\` so the execution can be associated with that plan node. Do not create a Todo solely to wrap a delegation that does not otherwise need task tracking.
 - Keep at most one item in_progress. Keep the list current, mark finished work completed, and revise it when the scope or approach changes. When work completes together, update multiple statuses in one tool call rather than making bookkeeping-only calls.
 - Do not repeat the full todo list in prose after calling the tool; briefly communicate only important context or the next step.
 
@@ -219,7 +219,7 @@ You have access to the todo_write tool to keep user-visible progress for work th
 
 When you create a todo list:
 - Keep it short and outcome-oriented. Use a few meaningful, logically ordered, verifiable steps rather than one item per error, file, command, or minor edit.
-- For complex work delegated through top-level Agent calls, create the relevant todo first and pass its ID as \`todo_id\` so the execution can be associated with the plan node.
+- When an active Todo plan covers work delegated through top-level Agent calls, pass the matching Todo ID as \`todo_id\` so the execution can be associated with that plan node. Do not create a Todo solely to wrap a delegation that does not otherwise need task tracking.
 - Keep at most one item in_progress. Keep the list current, mark finished work completed, and revise it when the scope or approach changes. When work completes together, update multiple statuses in one tool call rather than making bookkeeping-only calls.
 - Do not repeat the full todo list in prose after calling the tool; briefly communicate only important context or the next step.
 
@@ -431,7 +431,7 @@ You have access to the todo_write tool to keep user-visible progress for work th
 
 When you create a todo list:
 - Keep it short and outcome-oriented. Use a few meaningful, logically ordered, verifiable steps rather than one item per error, file, command, or minor edit.
-- For complex work delegated through top-level Agent calls, create the relevant todo first and pass its ID as \`todo_id\` so the execution can be associated with the plan node.
+- When an active Todo plan covers work delegated through top-level Agent calls, pass the matching Todo ID as \`todo_id\` so the execution can be associated with that plan node. Do not create a Todo solely to wrap a delegation that does not otherwise need task tracking.
 - Keep at most one item in_progress. Keep the list current, mark finished work completed, and revise it when the scope or approach changes. When work completes together, update multiple statuses in one tool call rather than making bookkeeping-only calls.
 - Do not repeat the full todo list in prose after calling the tool; briefly communicate only important context or the next step.
 
@@ -622,7 +622,7 @@ You have access to the todo_write tool to keep user-visible progress for work th
 
 When you create a todo list:
 - Keep it short and outcome-oriented. Use a few meaningful, logically ordered, verifiable steps rather than one item per error, file, command, or minor edit.
-- For complex work delegated through top-level Agent calls, create the relevant todo first and pass its ID as \`todo_id\` so the execution can be associated with the plan node.
+- When an active Todo plan covers work delegated through top-level Agent calls, pass the matching Todo ID as \`todo_id\` so the execution can be associated with that plan node. Do not create a Todo solely to wrap a delegation that does not otherwise need task tracking.
 - Keep at most one item in_progress. Keep the list current, mark finished work completed, and revise it when the scope or approach changes. When work completes together, update multiple statuses in one tool call rather than making bookkeeping-only calls.
 - Do not repeat the full todo list in prose after calling the tool; briefly communicate only important context or the next step.
 
@@ -813,7 +813,7 @@ You have access to the todo_write tool to keep user-visible progress for work th
 
 When you create a todo list:
 - Keep it short and outcome-oriented. Use a few meaningful, logically ordered, verifiable steps rather than one item per error, file, command, or minor edit.
-- For complex work delegated through top-level Agent calls, create the relevant todo first and pass its ID as \`todo_id\` so the execution can be associated with the plan node.
+- When an active Todo plan covers work delegated through top-level Agent calls, pass the matching Todo ID as \`todo_id\` so the execution can be associated with that plan node. Do not create a Todo solely to wrap a delegation that does not otherwise need task tracking.
 - Keep at most one item in_progress. Keep the list current, mark finished work completed, and revise it when the scope or approach changes. When work completes together, update multiple statuses in one tool call rather than making bookkeeping-only calls.
 - Do not repeat the full todo list in prose after calling the tool; briefly communicate only important context or the next step.
 
@@ -1004,7 +1004,7 @@ You have access to the todo_write tool to keep user-visible progress for work th
 
 When you create a todo list:
 - Keep it short and outcome-oriented. Use a few meaningful, logically ordered, verifiable steps rather than one item per error, file, command, or minor edit.
-- For complex work delegated through top-level Agent calls, create the relevant todo first and pass its ID as \`todo_id\` so the execution can be associated with the plan node.
+- When an active Todo plan covers work delegated through top-level Agent calls, pass the matching Todo ID as \`todo_id\` so the execution can be associated with that plan node. Do not create a Todo solely to wrap a delegation that does not otherwise need task tracking.
 - Keep at most one item in_progress. Keep the list current, mark finished work completed, and revise it when the scope or approach changes. When work completes together, update multiple statuses in one tool call rather than making bookkeeping-only calls.
 - Do not repeat the full todo list in prose after calling the tool; briefly communicate only important context or the next step.
 
@@ -1195,7 +1195,7 @@ You have access to the todo_write tool to keep user-visible progress for work th
 
 When you create a todo list:
 - Keep it short and outcome-oriented. Use a few meaningful, logically ordered, verifiable steps rather than one item per error, file, command, or minor edit.
-- For complex work delegated through top-level Agent calls, create the relevant todo first and pass its ID as \`todo_id\` so the execution can be associated with the plan node.
+- When an active Todo plan covers work delegated through top-level Agent calls, pass the matching Todo ID as \`todo_id\` so the execution can be associated with that plan node. Do not create a Todo solely to wrap a delegation that does not otherwise need task tracking.
 - Keep at most one item in_progress. Keep the list current, mark finished work completed, and revise it when the scope or approach changes. When work completes together, update multiple statuses in one tool call rather than making bookkeeping-only calls.
 - Do not repeat the full todo list in prose after calling the tool; briefly communicate only important context or the next step.
 
@@ -1386,7 +1386,7 @@ You have access to the todo_write tool to keep user-visible progress for work th
 
 When you create a todo list:
 - Keep it short and outcome-oriented. Use a few meaningful, logically ordered, verifiable steps rather than one item per error, file, command, or minor edit.
-- For complex work delegated through top-level Agent calls, create the relevant todo first and pass its ID as \`todo_id\` so the execution can be associated with the plan node.
+- When an active Todo plan covers work delegated through top-level Agent calls, pass the matching Todo ID as \`todo_id\` so the execution can be associated with that plan node. Do not create a Todo solely to wrap a delegation that does not otherwise need task tracking.
 - Keep at most one item in_progress. Keep the list current, mark finished work completed, and revise it when the scope or approach changes. When work completes together, update multiple statuses in one tool call rather than making bookkeeping-only calls.
 - Do not repeat the full todo list in prose after calling the tool; briefly communicate only important context or the next step.
 
@@ -1577,7 +1577,7 @@ You have access to the todo_write tool to keep user-visible progress for work th
 
 When you create a todo list:
 - Keep it short and outcome-oriented. Use a few meaningful, logically ordered, verifiable steps rather than one item per error, file, command, or minor edit.
-- For complex work delegated through top-level Agent calls, create the relevant todo first and pass its ID as \`todo_id\` so the execution can be associated with the plan node.
+- When an active Todo plan covers work delegated through top-level Agent calls, pass the matching Todo ID as \`todo_id\` so the execution can be associated with that plan node. Do not create a Todo solely to wrap a delegation that does not otherwise need task tracking.
 - Keep at most one item in_progress. Keep the list current, mark finished work completed, and revise it when the scope or approach changes. When work completes together, update multiple statuses in one tool call rather than making bookkeeping-only calls.
 - Do not repeat the full todo list in prose after calling the tool; briefly communicate only important context or the next step.
 
@@ -1768,7 +1768,7 @@ You have access to the todo_write tool to keep user-visible progress for work th
 
 When you create a todo list:
 - Keep it short and outcome-oriented. Use a few meaningful, logically ordered, verifiable steps rather than one item per error, file, command, or minor edit.
-- For complex work delegated through top-level Agent calls, create the relevant todo first and pass its ID as \`todo_id\` so the execution can be associated with the plan node.
+- When an active Todo plan covers work delegated through top-level Agent calls, pass the matching Todo ID as \`todo_id\` so the execution can be associated with that plan node. Do not create a Todo solely to wrap a delegation that does not otherwise need task tracking.
 - Keep at most one item in_progress. Keep the list current, mark finished work completed, and revise it when the scope or approach changes. When work completes together, update multiple statuses in one tool call rather than making bookkeeping-only calls.
 - Do not repeat the full todo list in prose after calling the tool; briefly communicate only important context or the next step.
 
@@ -1982,7 +1982,7 @@ You have access to the todo_write tool to keep user-visible progress for work th
 
 When you create a todo list:
 - Keep it short and outcome-oriented. Use a few meaningful, logically ordered, verifiable steps rather than one item per error, file, command, or minor edit.
-- For complex work delegated through top-level Agent calls, create the relevant todo first and pass its ID as \`todo_id\` so the execution can be associated with the plan node.
+- When an active Todo plan covers work delegated through top-level Agent calls, pass the matching Todo ID as \`todo_id\` so the execution can be associated with that plan node. Do not create a Todo solely to wrap a delegation that does not otherwise need task tracking.
 - Keep at most one item in_progress. Keep the list current, mark finished work completed, and revise it when the scope or approach changes. When work completes together, update multiple statuses in one tool call rather than making bookkeeping-only calls.
 - Do not repeat the full todo list in prose after calling the tool; briefly communicate only important context or the next step.
 
@@ -2262,7 +2262,7 @@ You have access to the todo_write tool to keep user-visible progress for work th
 
 When you create a todo list:
 - Keep it short and outcome-oriented. Use a few meaningful, logically ordered, verifiable steps rather than one item per error, file, command, or minor edit.
-- For complex work delegated through top-level Agent calls, create the relevant todo first and pass its ID as \`todo_id\` so the execution can be associated with the plan node.
+- When an active Todo plan covers work delegated through top-level Agent calls, pass the matching Todo ID as \`todo_id\` so the execution can be associated with that plan node. Do not create a Todo solely to wrap a delegation that does not otherwise need task tracking.
 - Keep at most one item in_progress. Keep the list current, mark finished work completed, and revise it when the scope or approach changes. When work completes together, update multiple statuses in one tool call rather than making bookkeeping-only calls.
 - Do not repeat the full todo list in prose after calling the tool; briefly communicate only important context or the next step.
 
@@ -2476,7 +2476,7 @@ You have access to the todo_write tool to keep user-visible progress for work th
 
 When you create a todo list:
 - Keep it short and outcome-oriented. Use a few meaningful, logically ordered, verifiable steps rather than one item per error, file, command, or minor edit.
-- For complex work delegated through top-level Agent calls, create the relevant todo first and pass its ID as \`todo_id\` so the execution can be associated with the plan node.
+- When an active Todo plan covers work delegated through top-level Agent calls, pass the matching Todo ID as \`todo_id\` so the execution can be associated with that plan node. Do not create a Todo solely to wrap a delegation that does not otherwise need task tracking.
 - Keep at most one item in_progress. Keep the list current, mark finished work completed, and revise it when the scope or approach changes. When work completes together, update multiple statuses in one tool call rather than making bookkeeping-only calls.
 - Do not repeat the full todo list in prose after calling the tool; briefly communicate only important context or the next step.
 
@@ -2752,7 +2752,7 @@ You have access to the todo_write tool to keep user-visible progress for work th
 
 When you create a todo list:
 - Keep it short and outcome-oriented. Use a few meaningful, logically ordered, verifiable steps rather than one item per error, file, command, or minor edit.
-- For complex work delegated through top-level Agent calls, create the relevant todo first and pass its ID as \`todo_id\` so the execution can be associated with the plan node.
+- When an active Todo plan covers work delegated through top-level Agent calls, pass the matching Todo ID as \`todo_id\` so the execution can be associated with that plan node. Do not create a Todo solely to wrap a delegation that does not otherwise need task tracking.
 - Keep at most one item in_progress. Keep the list current, mark finished work completed, and revise it when the scope or approach changes. When work completes together, update multiple statuses in one tool call rather than making bookkeeping-only calls.
 - Do not repeat the full todo list in prose after calling the tool; briefly communicate only important context or the next step.
 
@@ -2943,7 +2943,7 @@ You have access to the todo_write tool to keep user-visible progress for work th
 
 When you create a todo list:
 - Keep it short and outcome-oriented. Use a few meaningful, logically ordered, verifiable steps rather than one item per error, file, command, or minor edit.
-- For complex work delegated through top-level Agent calls, create the relevant todo first and pass its ID as \`todo_id\` so the execution can be associated with the plan node.
+- When an active Todo plan covers work delegated through top-level Agent calls, pass the matching Todo ID as \`todo_id\` so the execution can be associated with that plan node. Do not create a Todo solely to wrap a delegation that does not otherwise need task tracking.
 - Keep at most one item in_progress. Keep the list current, mark finished work completed, and revise it when the scope or approach changes. When work completes together, update multiple statuses in one tool call rather than making bookkeeping-only calls.
 - Do not repeat the full todo list in prose after calling the tool; briefly communicate only important context or the next step.
 
@@ -3134,7 +3134,7 @@ You have access to the todo_write tool to keep user-visible progress for work th
 
 When you create a todo list:
 - Keep it short and outcome-oriented. Use a few meaningful, logically ordered, verifiable steps rather than one item per error, file, command, or minor edit.
-- For complex work delegated through top-level Agent calls, create the relevant todo first and pass its ID as \`todo_id\` so the execution can be associated with the plan node.
+- When an active Todo plan covers work delegated through top-level Agent calls, pass the matching Todo ID as \`todo_id\` so the execution can be associated with that plan node. Do not create a Todo solely to wrap a delegation that does not otherwise need task tracking.
 - Keep at most one item in_progress. Keep the list current, mark finished work completed, and revise it when the scope or approach changes. When work completes together, update multiple statuses in one tool call rather than making bookkeeping-only calls.
 - Do not repeat the full todo list in prose after calling the tool; briefly communicate only important context or the next step.
 

--- a/packages/core/src/core/prompts.test.ts
+++ b/packages/core/src/core/prompts.test.ts
@@ -168,6 +168,12 @@ describe('Core System Prompt (prompts.ts)', () => {
     expect(prompt).toContain(
       'rather than one item per error, file, command, or minor edit',
     );
+    expect(prompt).toContain(
+      'When an active Todo plan covers work delegated through top-level Agent calls',
+    );
+    expect(prompt).not.toContain(
+      'For complex work delegated through top-level Agent calls, create the relevant todo first',
+    );
     expect(prompt).not.toContain('VERY frequently');
     expect(prompt).not.toContain('EXTREMELY helpful');
     expect(prompt).not.toContain('write 10 items to the todo list');

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -317,7 +317,7 @@ You have access to the ${ToolNames.TODO_WRITE} tool to keep user-visible progres
 
 When you create a todo list:
 - Keep it short and outcome-oriented. Use a few meaningful, logically ordered, verifiable steps rather than one item per error, file, command, or minor edit.
-- For complex work delegated through top-level Agent calls, create the relevant todo first and pass its ID as \`todo_id\` so the execution can be associated with the plan node.
+- When an active Todo plan covers work delegated through top-level Agent calls, pass the matching Todo ID as \`todo_id\` so the execution can be associated with that plan node. Do not create a Todo solely to wrap a delegation that does not otherwise need task tracking.
 - Keep at most one item in_progress. Keep the list current, mark finished work completed, and revise it when the scope or approach changes. When work completes together, update multiple statuses in one tool call rather than making bookkeeping-only calls.
 - Do not repeat the full todo list in prose after calling the tool; briefly communicate only important context or the next step.
 

--- a/packages/core/src/tools/todoWrite.test.ts
+++ b/packages/core/src/tools/todoWrite.test.ts
@@ -327,7 +327,7 @@ describe('TodoWriteTool', () => {
 
       const result = await tool
         .build({
-          todos: [{ id: '1', content: 'Still done', status: 'completed' }],
+          todos: [{ id: '1', content: 'Done', status: 'completed' }],
         })
         .execute(mockAbortSignal);
 
@@ -348,7 +348,7 @@ describe('TodoWriteTool', () => {
       mockAtomicWrite.mockResolvedValue(undefined);
 
       const result = await tool
-        .build({ todos: [{ id: '2', content: 'New', status: 'pending' }] })
+        .build({ todos: [{ id: '1', content: 'New', status: 'pending' }] })
         .execute(mockAbortSignal);
       const display = result.returnDisplay as { planId?: string };
 
@@ -368,7 +368,7 @@ describe('TodoWriteTool', () => {
 
       const result = await tool
         .build({
-          todos: [{ id: '2', content: 'Already done', status: 'completed' }],
+          todos: [{ id: '1', content: 'Already done', status: 'completed' }],
         })
         .execute(mockAbortSignal);
       const display = result.returnDisplay as { planId?: string };

--- a/packages/core/src/tools/todoWrite.test.ts
+++ b/packages/core/src/tools/todoWrite.test.ts
@@ -356,6 +356,27 @@ describe('TodoWriteTool', () => {
       expect(display.planId).not.toBe('finished-plan');
     });
 
+    it('should start a new plan for a distinct all-completed snapshot', async () => {
+      mockFs.readFile.mockResolvedValue(
+        JSON.stringify({
+          planId: 'finished-plan',
+          todos: [{ id: '1', content: 'Done', status: 'completed' }],
+        }),
+      );
+      mockFs.mkdir.mockResolvedValue(undefined);
+      mockAtomicWrite.mockResolvedValue(undefined);
+
+      const result = await tool
+        .build({
+          todos: [{ id: '2', content: 'Already done', status: 'completed' }],
+        })
+        .execute(mockAbortSignal);
+      const display = result.returnDisplay as { planId?: string };
+
+      expect(display.planId).toEqual(expect.any(String));
+      expect(display.planId).not.toBe('finished-plan');
+    });
+
     it('should clear persisted plan identity while identifying the cleared plan', async () => {
       mockFs.readFile.mockResolvedValue(
         JSON.stringify({

--- a/packages/core/src/tools/todoWrite.ts
+++ b/packages/core/src/tools/todoWrite.ts
@@ -370,7 +370,8 @@ class TodoWriteToolInvocation extends BaseToolInvocation<
         finalTodos.length > 0 &&
         (oldTodos.length === 0 ||
           (oldTodos.every((todo) => todo.status === 'completed') &&
-            finalTodos.some((todo) => todo.status !== 'completed')));
+            (finalTodos.some((todo) => todo.status !== 'completed') ||
+              finalTodos.some((todo) => !oldTodosMap.has(todo.id)))));
       const activePlanId =
         finalTodos.length === 0
           ? undefined

--- a/packages/core/src/tools/todoWrite.ts
+++ b/packages/core/src/tools/todoWrite.ts
@@ -8,6 +8,7 @@ import type { ToolResult } from './tools.js';
 import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
 import type { FunctionDeclaration } from '@google/genai';
 import { randomUUID } from 'node:crypto';
+import { isDeepStrictEqual } from 'node:util';
 import * as fs from 'fs/promises';
 import * as fsSync from 'fs';
 import * as path from 'path';
@@ -370,8 +371,7 @@ class TodoWriteToolInvocation extends BaseToolInvocation<
         finalTodos.length > 0 &&
         (oldTodos.length === 0 ||
           (oldTodos.every((todo) => todo.status === 'completed') &&
-            (finalTodos.some((todo) => todo.status !== 'completed') ||
-              finalTodos.some((todo) => !oldTodosMap.has(todo.id)))));
+            !isDeepStrictEqual(finalTodos, oldTodos)));
       const activePlanId =
         finalTodos.length === 0
           ? undefined

--- a/packages/web-shell/client/components/messages/PlanExecutionView.test.tsx
+++ b/packages/web-shell/client/components/messages/PlanExecutionView.test.tsx
@@ -135,6 +135,20 @@ describe('PlanExecutionView', () => {
     });
   });
 
+  it('does not block a todo on an unknown dependency', () => {
+    const todo: TodoItem = {
+      id: 'standalone',
+      content: 'Standalone',
+      status: 'pending',
+      blockedBy: ['missing'],
+    };
+
+    expect(getPlanNodeState(todo, new Map([[todo.id, todo]]), [], [])).toEqual({
+      status: 'ready',
+      attention: false,
+    });
+  });
+
   it('restores cancellation from replay output after the live task leaves', () => {
     const cancelled = {
       ...agentTool('build'),

--- a/packages/web-shell/client/components/messages/PlanExecutionView.tsx
+++ b/packages/web-shell/client/components/messages/PlanExecutionView.tsx
@@ -228,7 +228,7 @@ function getPlanNodeStateFromIndex(
     return { status: 'paused', attention };
   if (todo.status === 'completed') return { status: 'completed', attention };
   const blocked = (todo.blockedBy ?? []).some(
-    (id) => todosById.get(id)?.status !== 'completed',
+    (id) => todosById.has(id) && todosById.get(id)?.status !== 'completed',
   );
   if (blocked) return { status: 'blocked', attention };
   if (todo.status === 'in_progress')


### PR DESCRIPTION
## What this PR does

This follow-up preserves ordinary Todo behavior outside Session Workflow views. Agent association is now opt-in to an existing active Todo plan, a distinct all-completed snapshot receives a new plan identity, and unknown historical dependency references no longer make a plan node appear blocked.

## Why it's needed

The Session Workflow changes merged in #7580 introduced a wider prompt instruction and exposed lifecycle/UI edges that could affect normal tasks or misrepresent historical plans. The parent Session remains the owner of persisted Todo state; this PR does not expose `todo_write` to subagents or teammates.

## Reviewer Test Plan

### How to verify

1. Run `cd packages/core && npx vitest run src/core/prompts.test.ts src/tools/todoWrite.test.ts` and confirm the prompt contract and distinct completed-plan identity cases.
2. Run `cd packages/web-shell && npx vitest run client/components/messages/PlanExecutionView.test.tsx` and confirm an unknown dependency is displayed as ready rather than blocked.
3. Run `npx tsx .qwen/e2e-tests/issue-8328/run-compatibility-e2e.ts`. This starts a real daemon, deterministic local model, and production Web Shell; submit an ordinary prompt and confirm it completes without a Todo plan.

### Evidence (Before & After)

The real daemon/Web Shell run completed an ordinary task and captured the rendered result:

![Issue #8328 ordinary task E2E](https://raw.githubusercontent.com/yiliang114/img-host/main/assets/ordinary-task.png)

The detailed local report is in `.qwen/e2e-tests/issue-8328/report.md`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS arm64, Node.js v22.22.0, Chrome headless, real `qwen serve`, local deterministic OpenAI-compatible test server, `QWEN_SANDBOX=false`.

## Risk & Scope

- Main risk or tradeoff: Todo persistence remains parent-session scoped; child Todo authoring is intentionally unchanged and remains excluded to avoid sidecar clobbering.
- Not validated / out of scope: Full root build and Web Shell typecheck are currently blocked by unrelated main-branch Ink selection API and `DaemonSessionActions.removeMidTurnMessage` mismatches; these are recorded in the E2E report.
- Breaking changes / migration notes: None for ordinary tasks or existing flat Todo lists.

## Linked Issues

Fixes #8328

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

这个 follow-up 保证 Session Workflow 视图之外的普通 Todo 行为保持不变。Agent 关联现在只在已有 active Todo plan 时按需开启；独立的全 completed 快照会获得新的 plan identity；历史数据中的未知依赖不会再把节点误显示为 blocked。

## 为什么需要

#7580 合并的 Session Workflow 改造扩大了 prompt 指令范围，并暴露了可能影响普通任务或误读历史计划的生命周期/UI 边界。持久化 Todo 仍由父 Session 独占；本 PR 不会向 subagent 或 teammate 暴露 `todo_write`。

## Reviewer Test Plan

### 如何验证

1. 运行 `cd packages/core && npx vitest run src/core/prompts.test.ts src/tools/todoWrite.test.ts`，确认 prompt 契约和独立全 completed 计划 identity 场景。
2. 运行 `cd packages/web-shell && npx vitest run client/components/messages/PlanExecutionView.test.tsx`，确认未知依赖显示为 ready 而不是 blocked。
3. 运行 `npx tsx .qwen/e2e-tests/issue-8328/run-compatibility-e2e.ts`。该命令启动真实 daemon、本地确定性模型和生产 Web Shell；提交普通 prompt，确认任务完成且没有被强制创建 Todo plan。

### 证据（Before & After）

真实 daemon/Web Shell 运行完成了普通任务并捕获了渲染结果：

![Issue #8328 ordinary task E2E](https://raw.githubusercontent.com/yiliang114/img-host/main/assets/ordinary-task.png)

详细本地报告位于 `.qwen/e2e-tests/issue-8328/report.md`。

### 测试环境

macOS arm64、Node.js v22.22.0、Chrome headless、真实 `qwen serve`、本地确定性 OpenAI-compatible 测试服务、`QWEN_SANDBOX=false`。

## 风险与范围

- 主要风险或取舍：Todo 持久化继续采用父 Session 作用域；为避免 sidecar 相互覆盖，子 Agent 编写 Todo 的行为保持不变且继续隐藏。
- 未验证/范围外：完整 root build 和 Web Shell typecheck 当前被 main 分支既有的 Ink selection API 以及 `DaemonSessionActions.removeMidTurnMessage` 不匹配阻塞，已记录在 E2E 报告中。
- 破坏性变更/迁移说明：普通任务和已有 flat Todo 列表没有破坏性变更。

</details>
