### PR TITLE
fix(core): unblock history pagination on oversized transcript turns

### DIFF
--- a/packages/cli/src/serve/multi-workspace-sessions.test.ts
+++ b/packages/cli/src/serve/multi-workspace-sessions.test.ts
@@ -3043,7 +3043,7 @@ describe('multi-workspace session dispatch', () => {
         sessionId,
         cwd: SECONDARY_CWD,
         timestamp: '2026-07-08T00:00:00.000Z',
-        prompt: 'x'.repeat(4 * 1024 * 1024),
+        prompt: 'x'.repeat(33 * 1024 * 1024),
         mtime: new Date('2026-07-08T00:00:00.000Z'),
       });
       const { app, secondaryBridge } = makeHarness({
@@ -3058,11 +3058,44 @@ describe('multi-workspace session dispatch', () => {
       expect(response.body).toMatchObject({
         code: 'transcript_page_too_large',
         sessionId,
-        maxBytes: 4 * 1024 * 1024,
+        maxBytes: 32 * 1024 * 1024,
       });
       expect(response.body.pageBytes).toBeGreaterThan(
         response.body.maxBytes as number,
       );
+      expect(secondaryBridge.spawnCalls).toEqual([]);
+      expect(secondaryBridge.restoreCalls).toEqual([]);
+    });
+  });
+
+  it('serves an indivisible record that exceeds the reader page budget', async () => {
+    await withRuntimeDir(async () => {
+      const sessionId = '550e8400-e29b-41d4-a716-446655440280';
+      const prompt = 'x'.repeat(5 * 1024 * 1024);
+      await writeStoredSession({
+        sessionId,
+        cwd: SECONDARY_CWD,
+        timestamp: '2026-07-08T00:00:00.000Z',
+        prompt,
+        mtime: new Date('2026-07-08T00:00:00.000Z'),
+      });
+      const { app, secondaryBridge } = makeHarness({
+        secondaryTrusted: false,
+      });
+
+      const response = await request(app)
+        .get(`/workspaces/secondary-id/session/${sessionId}/transcript`)
+        .set('Host', host());
+
+      // A single record cannot be split, so it rides over the 4 MiB reader
+      // budget (hard ceiling remains the 32 MiB serialization cap).
+      expect(response.status).toBe(200);
+      expect(
+        response.body.events.some(
+          (event: { data?: { content?: { text?: string } } }) =>
+            event.data?.content?.text?.length === prompt.length,
+        ),
+      ).toBe(true);
       expect(secondaryBridge.spawnCalls).toEqual([]);
       expect(secondaryBridge.restoreCalls).toEqual([]);
     });

--- a/packages/core/src/services/session-transcript-reader.test.ts
+++ b/packages/core/src/services/session-transcript-reader.test.ts
@@ -31,7 +31,6 @@ import {
   resetSessionTranscriptIndexCacheForTest,
   setSessionTranscriptIndexCacheMaxBytesForTest,
   SessionTranscriptCursorCodec,
-  SessionTranscriptPageTooLargeError,
   SessionTranscriptSnapshotUnavailableError,
   SessionTranscriptReader,
 } from './session-transcript-reader.js';
@@ -229,7 +228,7 @@ describe('SessionTranscriptReader', () => {
     expect(second.hasMore).toBe(false);
   });
 
-  it('rejects a single aggregate record over the page byte budget', async () => {
+  it('returns a single aggregate record that exceeds the page byte budget', async () => {
     const first = record('u1', null, 'first');
     const second = record('u1', null, 'second fragment');
     await writeRecords([first, second, record('a1', 'u1', 'reply')]);
@@ -237,17 +236,17 @@ describe('SessionTranscriptReader', () => {
       Buffer.byteLength(JSON.stringify(first)) +
       Buffer.byteLength(JSON.stringify(second));
 
-    await expect(
-      new SessionTranscriptReader(workspaceDir).readPage(sessionId, {
+    const page = await new SessionTranscriptReader(workspaceDir).readPage(
+      sessionId,
+      {
         limit: 1,
         maxBytes: aggregateBytes - 1,
-      }),
-    ).rejects.toMatchObject({
-      name: 'SessionTranscriptPageTooLargeError',
-      sessionId,
-      pageBytes: aggregateBytes,
-      maxBytes: aggregateBytes - 1,
-    } satisfies Partial<SessionTranscriptPageTooLargeError>);
+      },
+    );
+
+    // An indivisible record rides over budget rather than dead-ending the page.
+    expect(page.records.map((item) => item.uuid)).toEqual(['u1']);
+    expect(page.hasMore).toBe(true);
   });
 
   it('pages only the active parentUuid chain and skips abandoned branches', async () => {
@@ -595,7 +594,7 @@ describe('SessionTranscriptReader', () => {
     expect(page.hasMore).toBe(false);
   });
 
-  it('rejects a backward turn that exceeds maxBytes after alignment', async () => {
+  it('returns a backward turn that exceeds maxBytes after alignment', async () => {
     const toolCall = record('a-tool', 'u1', 'call tool');
     const toolResult = {
       ...record('t1', 'a-tool', 'tool result'),
@@ -610,13 +609,23 @@ describe('SessionTranscriptReader', () => {
       record('u2', 'a-final', 'next prompt'),
     ]);
 
-    await expect(
-      new SessionTranscriptReader(workspaceDir).readPage(sessionId, {
+    const page = await new SessionTranscriptReader(workspaceDir).readPage(
+      sessionId,
+      {
         beforeRecordId: 'u2',
         limit: 2,
         maxBytes: Buffer.byteLength(JSON.stringify(finalAnswer)),
-      }),
-    ).rejects.toBeInstanceOf(SessionTranscriptPageTooLargeError);
+      },
+    );
+
+    // The turn cannot be split across pages, so it rides over budget whole.
+    expect(page.records.map((item) => item.uuid)).toEqual([
+      'u1',
+      'a-tool',
+      't1',
+      'a-final',
+    ]);
+    expect(page.hasMore).toBe(false);
   });
 
   it('rejects a backward boundary outside the active chain', async () => {
@@ -1009,12 +1018,15 @@ describe('SessionTranscriptReader', () => {
       `${gluedLine}\n${JSON.stringify(record('a1', 'u1', 'reply'))}\n`,
     );
 
-    await expect(
-      new SessionTranscriptReader(workspaceDir).readPage(sessionId, {
-        limit: 1,
-        maxBytes: Buffer.byteLength(gluedLine) * 2 - 1,
-      }),
-    ).rejects.toBeInstanceOf(SessionTranscriptPageTooLargeError);
+    const page = await new SessionTranscriptReader(workspaceDir).readPage(
+      sessionId,
+      { limit: 2, maxBytes: Buffer.byteLength(gluedLine) * 2 },
+    );
+
+    // Conservative per-fragment counting spends the whole budget on the glued
+    // aggregate, so the next record must wait for the following page.
+    expect(page.records.map((item) => item.uuid)).toEqual(['u1']);
+    expect(page.hasMore).toBe(true);
   });
 
   it('skips non-ChatRecord JSON lines while indexing', async () => {

--- a/packages/core/src/services/session-transcript-reader.ts
+++ b/packages/core/src/services/session-transcript-reader.ts
@@ -460,7 +460,6 @@ function recordSegmentBytes(index: TranscriptIndex, uuid: string): number {
 
 function selectPageUuids(
   index: TranscriptIndex,
-  sessionId: string,
   position: number,
   limit: number,
   maxBytes: number | undefined,
@@ -472,10 +471,9 @@ function selectPageUuids(
   let selectedBytes = 0;
   for (const uuid of candidates) {
     const bytes = recordSegmentBytes(index, uuid);
-    if (selected.length === 0 && bytes > maxBytes) {
-      throw new SessionTranscriptPageTooLargeError(sessionId, bytes, maxBytes);
-    }
-    if (selectedBytes + bytes > maxBytes) break;
+    // A single aggregate record may itself exceed the budget; it cannot be
+    // split, so always take at least one record or pagination dead-ends.
+    if (selected.length > 0 && selectedBytes + bytes > maxBytes) break;
     selected.push(uuid);
     selectedBytes += bytes;
   }
@@ -489,7 +487,6 @@ function isReplayTurnStart(index: TranscriptIndex, uuid: string): boolean {
 
 function selectBackwardPageUuids(
   index: TranscriptIndex,
-  sessionId: string,
   position: number,
   limit: number,
   maxBytes: number | undefined,
@@ -510,14 +507,15 @@ function selectBackwardPageUuids(
   for (let i = position - 1; i >= start; i--) {
     const uuid = index.activeUuids[i]!;
     const bytes = recordSegmentBytes(index, uuid);
+    // A turn cannot be split across pages; always take at least one record
+    // so an oversized turn cannot dead-end backward pagination.
     if (
-      selectedStart === position &&
+      selectedStart < position &&
       maxBytes !== undefined &&
-      bytes > maxBytes
+      selectedBytes + bytes > maxBytes
     ) {
-      throw new SessionTranscriptPageTooLargeError(sessionId, bytes, maxBytes);
+      break;
     }
-    if (maxBytes !== undefined && selectedBytes + bytes > maxBytes) break;
     selectedStart = i;
     selectedBytes += bytes;
   }
@@ -530,7 +528,6 @@ function selectBackwardPageUuids(
       break;
     }
   }
-  let expandedSelection = false;
   if (alignedToReplayBoundary && selectedStart > 0) {
     let previousTurnStart = selectedStart - 1;
     while (
@@ -541,7 +538,6 @@ function selectBackwardPageUuids(
     }
     if (previousTurnStart < 0) {
       selectedStart = 0;
-      expandedSelection = true;
     }
   } else if (!alignedToReplayBoundary) {
     while (
@@ -549,19 +545,6 @@ function selectBackwardPageUuids(
       !isReplayTurnStart(index, index.activeUuids[selectedStart]!)
     ) {
       selectedStart--;
-    }
-    expandedSelection = true;
-  }
-  if (expandedSelection && maxBytes !== undefined) {
-    const alignedBytes = index.activeUuids
-      .slice(selectedStart, position)
-      .reduce((total, uuid) => total + recordSegmentBytes(index, uuid), 0);
-    if (alignedBytes > maxBytes) {
-      throw new SessionTranscriptPageTooLargeError(
-        sessionId,
-        alignedBytes,
-        maxBytes,
-      );
     }
   }
 
@@ -1124,11 +1107,10 @@ export class SessionTranscriptReader {
     }
     const backwardPage =
       direction === 'backward'
-        ? selectBackwardPageUuids(index, sessionId, position, limit, maxBytes)
+        ? selectBackwardPageUuids(index, position, limit, maxBytes)
         : undefined;
     const pageUuids =
-      backwardPage?.uuids ??
-      selectPageUuids(index, sessionId, position, limit, maxBytes);
+      backwardPage?.uuids ?? selectPageUuids(index, position, limit, maxBytes);
     const nextPosition =
       backwardPage?.nextPosition ?? position + pageUuids.length;
     const records = await readAggregatedRecords(index, pageUuids);

--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -227,7 +227,7 @@ function mount(
     loadingOlderHistory?: boolean;
     historyCapacityReached?: boolean;
     historyPaginationError?: boolean;
-    onLoadOlderHistory?: () => Promise<void>;
+    onLoadOlderHistory?: (options?: { force?: boolean }) => Promise<void>;
     transcriptBlockCount?: number;
     transcriptActivity?: {
       getSnapshot(): {
@@ -1703,6 +1703,27 @@ describe('MessageList — turn collapse (DOM)', () => {
 
     // It should NOT call loadMore because paginationError blocks it
     expect(onLoadOlderHistory).not.toHaveBeenCalled();
+  });
+
+  it('retries loading older history with force when the retry button is clicked', async () => {
+    const onLoadOlderHistory = vi.fn().mockResolvedValue(undefined);
+    const c = mount([userMsg('u1')], undefined, {
+      historyPaginationError: true,
+      onLoadOlderHistory,
+    });
+
+    const button = Array.from(c.querySelectorAll('button')).find(
+      (el) => el.textContent === 'Retry',
+    );
+    expect(button).toBeDefined();
+
+    await act(async () => {
+      button!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(1);
+    expect(onLoadOlderHistory).toHaveBeenCalledWith({ force: true });
   });
 
   it('does not smooth-scroll when existing session history loads after an empty render', () => {

--- a/packages/web-shell/client/components/MessageList.module.css
+++ b/packages/web-shell/client/components/MessageList.module.css
@@ -35,6 +35,22 @@
   padding: 4px 0 12px;
 }
 
+.historyRetryButton {
+  margin-left: 8px;
+  padding: 2px 10px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  color: var(--muted-foreground);
+}
+
+.historyRetryButton:hover {
+  background: var(--subtle-bg, rgba(128, 128, 128, 0.06));
+}
+
 .list > * {
   width: min(
     100%,

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -64,7 +64,7 @@ interface MessageListProps {
   loadingOlderHistory?: boolean;
   historyCapacityReached?: boolean;
   historyPaginationError?: boolean;
-  onLoadOlderHistory?: () => Promise<void>;
+  onLoadOlderHistory?: (options?: { force?: boolean }) => Promise<void>;
   transcriptBlockCount?: number;
   transcriptActivity?: {
     getSnapshot(): {
@@ -3186,14 +3186,14 @@ export const MessageList = memo(
     }, [visibleItems, headerOffset, performScrollToRow]);
 
     const loadOlderHistory = useCallback(
-      async (allowRetry = false) => {
+      async (allowRetry = false, force = false) => {
         const el = containerRef.current;
         if (
           !el ||
           !onLoadOlderHistory ||
           loadingOlderHistory ||
           olderHistoryLoadInFlight.current ||
-          historyPaginationError ||
+          (historyPaginationError && !force) ||
           (olderHistoryRetryBlocked.current && !allowRetry)
         ) {
           return;
@@ -3205,7 +3205,7 @@ export const MessageList = memo(
         const previousTop = el.scrollTop;
         followPausedByUserRef.current = true;
         try {
-          await onLoadOlderHistory();
+          await onLoadOlderHistory(force ? { force: true } : undefined);
           setOlderHistoryAnchor({
             scrollHeight: previousHeight,
             scrollTop: previousTop,
@@ -3219,6 +3219,10 @@ export const MessageList = memo(
       },
       [loadingOlderHistory, onLoadOlderHistory, historyPaginationError],
     );
+
+    const retryOlderHistory = useCallback(() => {
+      void loadOlderHistory(true, true);
+    }, [loadOlderHistory]);
 
     // Rules 2 & 3: detect scroll direction to toggle follow mode.
     // Runs synchronously in the scroll handler — no rAF needed since
@@ -3846,8 +3850,17 @@ export const MessageList = memo(
         {historyPaginationError &&
           !showLoadingSkeleton &&
           !historyCapacityReached && (
-            <div className={styles.historyStatus} role="status">
-              {t('history.paginationError')}
+            <div className={styles.historyStatus}>
+              <span role="status">{t('history.paginationError')}</span>
+              {onLoadOlderHistory && (
+                <button
+                  type="button"
+                  className={styles.historyRetryButton}
+                  onClick={retryOlderHistory}
+                >
+                  {t('history.retry')}
+                </button>
+              )}
             </div>
           )}
         <SessionTimeline

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -893,6 +893,7 @@ const EN: Messages = {
   'history.capacityReached':
     'History display limit reached. Earlier messages remain saved.',
   'history.paginationError': 'Earlier history could not be loaded.',
+  'history.retry': 'Retry',
   'editor.shellPlaceholder': 'Enter terminal command',
   'editor.send': 'Send message',
   'editor.connectionDisconnected':
@@ -3460,6 +3461,7 @@ const ZH: Messages = {
   'history.loadingEarlier': '正在加载更早消息…',
   'history.capacityReached': '已达到历史显示上限，更早消息仍保存在会话中。',
   'history.paginationError': '无法加载更早的历史记录。',
+  'history.retry': '重试',
   'editor.shellPlaceholder': '请输入终端命令',
   'editor.send': '发送消息',
   'editor.connectionDisconnected': '连接已中断，请在恢复后重试。',

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -9638,6 +9638,76 @@ describe('DaemonSessionProvider', () => {
     expect(sdkMocks.getSessionTranscriptPage).toHaveBeenCalledTimes(1);
   });
 
+  it('retries a latched pagination failure when loadMore is forced', async () => {
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['session_transcript_pagination'],
+    });
+    const replayEvent = (id: number, text: string): DaemonEvent => ({
+      id,
+      v: 1,
+      type: 'session_update',
+      data: {
+        update: {
+          sessionUpdate: 'user_message_chunk',
+          content: { type: 'text', text },
+          _meta: { 'qwen.session.recordId': `record-${id}` },
+        },
+      },
+    });
+    const session = createMockSession({
+      sessionId: 'session-retried-history-page',
+      historyHasMore: true,
+      replaySnapshot: {
+        compactedReplay: [replayEvent(2, 'recent prompt')],
+        liveJournal: [],
+      },
+    });
+    sdkMocks.sessions.push(session);
+    sdkMocks.getSessionTranscriptPage
+      .mockRejectedValueOnce(new DaemonHttpError(403, undefined, 'Forbidden'))
+      .mockResolvedValueOnce({
+        v: 1,
+        sessionId: session.sessionId,
+        events: [replayEvent(1, 'older prompt')],
+        hasMore: false,
+      });
+    let history: ReturnType<typeof useDaemonTranscriptHistory> | undefined;
+    function Harness() {
+      history = useDaemonTranscriptHistory();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      historyPageSize: 25,
+    });
+    await act(async () => {
+      await expect(history?.loadMore()).rejects.toThrow('Forbidden');
+      await flushPromises();
+    });
+    expect(history?.paginationError).toBe(true);
+    expect(history?.hasMore).toBe(false);
+
+    await act(async () => {
+      await history?.loadMore({ force: true });
+      await flushPromises();
+    });
+
+    expect(sdkMocks.getSessionTranscriptPage).toHaveBeenCalledTimes(2);
+    expect(sdkMocks.getSessionTranscriptPage).toHaveBeenNthCalledWith(
+      2,
+      session.sessionId,
+      {
+        beforeRecordId: 'record-2',
+        limit: 25,
+        clientId: session.clientId,
+      },
+    );
+    expect(history?.paginationError).toBe(false);
+    expect(history?.hasMore).toBe(false);
+  });
+
   it('skips malformed older-page events and advances by record boundary', async () => {
     sdkMocks.capabilities.mockResolvedValue({
       workspaceCwd: '/mock-workspace',

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -121,7 +121,7 @@ export interface DaemonTranscriptHistory {
   loading: boolean;
   capacityReached: boolean;
   paginationError: boolean;
-  loadMore(): Promise<void>;
+  loadMore(options?: { force?: boolean }): Promise<void>;
 }
 
 const SESSION_TRANSCRIPT_PAGINATION_FEATURE = 'session_transcript_pagination';
@@ -2409,163 +2409,177 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
       store,
     ],
   );
-  const loadMoreTranscript = useCallback(async () => {
-    const history = transcriptHistoryRef.current;
-    const activeSession = sessionRef.current;
-    if (
-      !history.hasMore ||
-      history.loading ||
-      history.paginationError ||
-      !activeSession ||
-      activeSession.sessionId !== history.sessionId
-    ) {
-      return;
-    }
-
-    history.loading = true;
-    setTranscriptHistoryState({
-      hasMore: true,
-      loading: true,
-      capacityReached: false,
-      paginationError: false,
-    });
-    let terminalFailure = false;
-    try {
-      const page = await activeSession.client.getSessionTranscriptPage(
-        activeSession.sessionId,
-        {
-          ...(history.cursor !== undefined
-            ? { cursor: history.cursor }
-            : history.beforeRecordId !== undefined
-              ? { beforeRecordId: history.beforeRecordId }
-              : {}),
-          limit: historyPageSizeRef.current ?? 100,
-          clientId: activeSession.clientId,
-        },
-      );
+  const loadMoreTranscript = useCallback(
+    async (options?: { force?: boolean }) => {
+      const history = transcriptHistoryRef.current;
+      const activeSession = sessionRef.current;
       if (
-        sessionRef.current !== activeSession ||
-        transcriptHistoryRef.current !== history
+        history.loading ||
+        !activeSession ||
+        activeSession.sessionId !== history.sessionId
       ) {
         return;
       }
-      if (page.partial || page.replayError) {
-        terminalFailure = true;
-        throw new Error(
-          page.replayError ?? 'Earlier session history was only partially read',
-        );
-      }
-
-      const replayOpts = {
-        ...eventOptionsRef.current,
-        suppressOwnUserEcho: false,
-      };
-      const nextBeforeRecordId = page.events
-        .map(getPersistedReplayRecordId)
-        .find((recordId): recordId is string => recordId !== undefined);
-      const uiEvents: DaemonUiEvent[] = [];
-      for (const replayEvent of page.events) {
-        try {
-          const transcriptEvents = filterDaemonUiEventsForTranscript(
-            replayEvent,
-            normalizeAndFilterEvent(
-              replayEvent,
-              activeSession.clientId,
-              replayOpts,
-              setConnection,
-              { updateConnection: false },
-            ),
-            addNotice,
-            dismissNotice,
-          );
-          uiEvents.push(
-            ...(subagentTranscriptModeRef.current === 'summary'
-              ? projectMainTranscriptEvents(transcriptEvents)
-              : transcriptEvents),
-          );
-        } catch (error) {
-          const message =
-            error instanceof Error ? error.message : String(error);
-          addNotice({
-            severity: 'warning',
-            category: 'protocol',
-            operation: 'normalize_event',
-            code: 'daemon.replay_event_malformed',
-            message: 'Skipped malformed history event',
-            debugMessage: message,
-            recoverable: true,
-          });
-          console.warn(
-            '[DaemonSessionProvider] skipped malformed history event:',
-            error,
-          );
+      if (history.paginationError) {
+        if (options?.force !== true) {
+          return;
         }
-      }
-      if (
-        uiEvents.length > 0 &&
-        !prependTranscriptHistory(store, uiEvents, maxBlocks)
-      ) {
-        history.hasMore = false;
-        history.loading = false;
-        history.capacityReached = true;
-        setTranscriptHistoryState({
-          hasMore: false,
-          loading: false,
-          capacityReached: true,
-          paginationError: false,
-        });
+        // The failed page's cursor was never advanced, so clearing the
+        // latched error retries that exact page.
+        history.paginationError = false;
+        history.hasMore = true;
+      } else if (!history.hasMore) {
         return;
       }
-      const hasCapacity = store.getSnapshot().blocks.length < maxBlocks;
-      history.capacityReached = page.hasMore && !hasCapacity;
-      history.cursor =
-        nextBeforeRecordId === undefined ? page.nextCursor : undefined;
-      history.beforeRecordId = nextBeforeRecordId;
-      history.hasMore = page.hasMore && hasCapacity;
-      history.loading = false;
+
+      history.loading = true;
       setTranscriptHistoryState({
-        hasMore: history.hasMore,
-        loading: false,
-        capacityReached: history.capacityReached,
+        hasMore: true,
+        loading: true,
+        capacityReached: false,
         paginationError: false,
       });
-    } catch (error) {
-      if (
-        sessionRef.current !== activeSession ||
-        transcriptHistoryRef.current !== history
-      ) {
-        return;
-      }
-      const retryable =
-        !terminalFailure &&
-        (!(error instanceof DaemonHttpError) ||
-          error.status >= 500 ||
-          error.status === 408 ||
-          error.status === 429);
-      history.hasMore = retryable;
-      history.loading = false;
-      history.capacityReached = false;
-      history.paginationError = !retryable;
-      setTranscriptHistoryState({
-        hasMore: retryable,
-        loading: false,
-        capacityReached: false,
-        paginationError: !retryable,
-      });
-      if (retryable) {
-        addNotice({
-          severity: 'warning',
-          category: 'user_action',
-          operation: 'load_session',
-          code: 'daemon.transcript_history.failed',
-          message: 'Failed to load earlier session history',
-          debugMessage: error instanceof Error ? error.message : String(error),
-          recoverable: retryable,
+      let terminalFailure = false;
+      try {
+        const page = await activeSession.client.getSessionTranscriptPage(
+          activeSession.sessionId,
+          {
+            ...(history.cursor !== undefined
+              ? { cursor: history.cursor }
+              : history.beforeRecordId !== undefined
+                ? { beforeRecordId: history.beforeRecordId }
+                : {}),
+            limit: historyPageSizeRef.current ?? 100,
+            clientId: activeSession.clientId,
+          },
+        );
+        if (
+          sessionRef.current !== activeSession ||
+          transcriptHistoryRef.current !== history
+        ) {
+          return;
+        }
+        if (page.partial || page.replayError) {
+          terminalFailure = true;
+          throw new Error(
+            page.replayError ??
+              'Earlier session history was only partially read',
+          );
+        }
+
+        const replayOpts = {
+          ...eventOptionsRef.current,
+          suppressOwnUserEcho: false,
+        };
+        const nextBeforeRecordId = page.events
+          .map(getPersistedReplayRecordId)
+          .find((recordId): recordId is string => recordId !== undefined);
+        const uiEvents: DaemonUiEvent[] = [];
+        for (const replayEvent of page.events) {
+          try {
+            const transcriptEvents = filterDaemonUiEventsForTranscript(
+              replayEvent,
+              normalizeAndFilterEvent(
+                replayEvent,
+                activeSession.clientId,
+                replayOpts,
+                setConnection,
+                { updateConnection: false },
+              ),
+              addNotice,
+              dismissNotice,
+            );
+            uiEvents.push(
+              ...(subagentTranscriptModeRef.current === 'summary'
+                ? projectMainTranscriptEvents(transcriptEvents)
+                : transcriptEvents),
+            );
+          } catch (error) {
+            const message =
+              error instanceof Error ? error.message : String(error);
+            addNotice({
+              severity: 'warning',
+              category: 'protocol',
+              operation: 'normalize_event',
+              code: 'daemon.replay_event_malformed',
+              message: 'Skipped malformed history event',
+              debugMessage: message,
+              recoverable: true,
+            });
+            console.warn(
+              '[DaemonSessionProvider] skipped malformed history event:',
+              error,
+            );
+          }
+        }
+        if (
+          uiEvents.length > 0 &&
+          !prependTranscriptHistory(store, uiEvents, maxBlocks)
+        ) {
+          history.hasMore = false;
+          history.loading = false;
+          history.capacityReached = true;
+          setTranscriptHistoryState({
+            hasMore: false,
+            loading: false,
+            capacityReached: true,
+            paginationError: false,
+          });
+          return;
+        }
+        const hasCapacity = store.getSnapshot().blocks.length < maxBlocks;
+        history.capacityReached = page.hasMore && !hasCapacity;
+        history.cursor =
+          nextBeforeRecordId === undefined ? page.nextCursor : undefined;
+        history.beforeRecordId = nextBeforeRecordId;
+        history.hasMore = page.hasMore && hasCapacity;
+        history.loading = false;
+        setTranscriptHistoryState({
+          hasMore: history.hasMore,
+          loading: false,
+          capacityReached: history.capacityReached,
+          paginationError: false,
         });
+      } catch (error) {
+        if (
+          sessionRef.current !== activeSession ||
+          transcriptHistoryRef.current !== history
+        ) {
+          return;
+        }
+        const retryable =
+          !terminalFailure &&
+          (!(error instanceof DaemonHttpError) ||
+            error.status >= 500 ||
+            error.status === 408 ||
+            error.status === 429);
+        history.hasMore = retryable;
+        history.loading = false;
+        history.capacityReached = false;
+        history.paginationError = !retryable;
+        setTranscriptHistoryState({
+          hasMore: retryable,
+          loading: false,
+          capacityReached: false,
+          paginationError: !retryable,
+        });
+        if (retryable) {
+          addNotice({
+            severity: 'warning',
+            category: 'user_action',
+            operation: 'load_session',
+            code: 'daemon.transcript_history.failed',
+            message: 'Failed to load earlier session history',
+            debugMessage:
+              error instanceof Error ? error.message : String(error),
+            recoverable: retryable,
+          });
+        }
+        throw error;
       }
-      throw error;
-    }
-  }, [addNotice, dismissNotice, maxBlocks, store]);
+    },
+    [addNotice, dismissNotice, maxBlocks, store],
+  );
   const transcriptHistoryValue = useMemo<DaemonTranscriptHistory>(() => {
     const active =
       connection.sessionId === transcriptHistoryRef.current.sessionId &&


### PR DESCRIPTION
## What this PR does

Two related changes to loading earlier session history in the Web Shell. First, transcript pagination no longer hard-fails when a single indivisible unit — one aggregate record, or one turn that cannot be split across pages — exceeds the 4 MiB reader page budget: such pages now ride over budget so paging always makes progress, with the existing 32 MiB response serialization cap remaining the hard ceiling. Second, when loading earlier history does fail non-retryably (4xx, partial replay), the "Earlier history could not be loaded" banner now offers a retry button that re-fetches the exact same page instead of requiring a full session reload.

## Why it's needed

Sessions containing a turn larger than 4 MiB (e.g. a huge tool result) permanently showed "Earlier history could not be loaded / 无法加载更早的历史记录" when the user scrolled up. The reader threw a page-too-large error, the route returned HTTP 413, and the client latched a non-retryable pagination error — restarting the daemon, reconnecting, or scrolling again could never help because the failure was deterministic per transcript content. Reproduced against real transcripts: a 53 MiB session consistently failed on page 2 (a single 13.6 MiB turn); after the fix it paginates all the way to the oldest record.

## Reviewer Test Plan

### How to verify

- Unit (reader): `cd packages/core && npx vitest run src/services/session-transcript-reader.test.ts` — 58 tests pass; an over-budget single record or turn is now returned whole instead of throwing, while normal pages still trim at record boundaries and glued-line fragments are still counted conservatively.
- Integration (route): `cd packages/cli && npx vitest run src/serve/multi-workspace-sessions.test.ts` — 93 tests pass; a 5 MiB single record is served with 200, a 33 MiB record still returns 413 via the 32 MiB serialization cap, and untrusted workspaces still never spawn the bridge in either case.
- Provider + UI: `cd packages/webui && npx vitest run src/daemon/session/DaemonSessionProvider.test.tsx` (181 pass — a forced load clears the latched error and refetches with the same untouched cursor) and `cd packages/web-shell && npx vitest run client/components/MessageList.dom.test.tsx` (the retry button issues a forced load; scroll-triggered auto-load stays blocked while the error is latched).
- Manual: open a long session whose transcript contains a very large tool result and scroll to the top repeatedly — earlier history should page through the oversized turn instead of sticking on the error banner.

### Evidence (Before & After)

Before: `GET /workspaces/:id/session/:id/transcript` deterministically returned `413 transcript_page_too_large` once paging reached a >4 MiB turn, and the banner "Earlier history could not be loaded." offered no recovery short of reloading the session. After: the same request returns 200 carrying the oversized turn (under the 32 MiB cap) and pagination continues to the oldest record; if a page still fails non-retryably, the banner offers a working Retry button. Verified against real local transcripts: all 12 recent sessions paginate end-to-end, including the previously fatal 53 MiB transcript with a 13.6 MiB single turn.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit + integration tests; pagination replayed locally over real `~/.qwen/projects` transcripts via the reader and replay pipeline (no daemon needed).

## Risk & Scope

- Main risk or tradeoff: a single page may now exceed the 4 MiB reader budget (bounded above by the 32 MiB response cap), so pathological transcripts produce larger one-off responses — in exchange for pagination that always terminates.
- Not validated / out of scope: ACP clients' (Zed etc.) rendering of very large replay pages; Windows/Linux verification is left to CI.
- Breaking changes / migration notes: none — the HTTP surface is unchanged; an over-budget 200 simply replaces a deterministic 413.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

与 Web Shell 加载更早会话历史相关的两项改动。第一，当单个不可拆分单元（一条聚合记录，或一个无法跨页拆分的 turn）超过 4 MiB 的分页读取预算时，transcript 分页不再硬失败：这类页允许超出预算放行，保证分页始终能够前进；现有的 32 MiB 响应序列化上限仍是硬性上限。第二，当加载更早历史确实发生不可重试的失败（4xx、部分重放）时，"无法加载更早的历史记录"横幅现在提供重试按钮，可以重新获取完全相同的某一页，而无需整体重载会话。

## 为什么需要

包含大于 4 MiB turn（例如巨大的工具结果）的会话，在用户向上滚动时会永久显示"无法加载更早的历史记录"。读取器抛出页过大错误，路由返回 HTTP 413，客户端锁定为不可重试的分页错误——重启 daemon、重连或再次滚动都无济于事，因为该失败对 transcript 内容是确定性的。已在真实 transcript 上复现：一个 53 MiB 的会话稳定地在第 2 页失败（单个 13.6 MiB 的 turn）；修复后它可以一直分页到最老的记录。

## Reviewer 测试计划

### 如何验证

- 单元测试（reader）：`cd packages/core && npx vitest run src/services/session-transcript-reader.test.ts` —— 58 个测试通过；超预算的单条记录或 turn 现在整体返回而不再抛错，普通页仍按记录边界裁剪，粘连行片段仍按保守方式计数。
- 集成测试（路由）：`cd packages/cli && npx vitest run src/serve/multi-workspace-sessions.test.ts` —— 93 个测试通过；5 MiB 单记录返回 200，33 MiB 记录仍通过 32 MiB 序列化上限返回 413，且两种情况下 untrusted workspace 都不会启动 bridge。
- Provider 与 UI：`cd packages/webui && npx vitest run src/daemon/session/DaemonSessionProvider.test.tsx`（181 通过——强制加载会清除锁定的错误并用未前移的同一游标重新拉取）以及 `cd packages/web-shell && npx vitest run client/components/MessageList.dom.test.tsx`（重试按钮发起强制加载；错误锁定期间滚动触发的自动加载仍被阻止）。
- 手动：打开一个 transcript 中含巨大工具结果的长会话，反复滚动到顶部——更早历史应能翻过超大 turn，而不是卡在错误横幅上。

### 证据（前后对比）

修复前：一旦分页触及 >4 MiB 的 turn，`GET /workspaces/:id/session/:id/transcript` 确定性地返回 `413 transcript_page_too_large`，且"无法加载更早的历史记录"横幅除重载会话外没有任何恢复手段。修复后：同一请求返回 200 并携带该超大 turn（在 32 MiB 上限内），分页继续直到最老记录；若某页仍不可重试地失败，横幅提供可用的重试按钮。已在本地真实 transcript 上验证：全部 12 个近期会话端到端分页完成，包括此前必然失败的、含 13.6 MiB 单 turn 的 53 MiB transcript。

### 测试平台

macOS ✅；Windows / Linux 未本地验证（交由 CI）。

### 环境（可选）

单元 + 集成测试；通过 reader 与 replay 管线在本地真实 `~/.qwen/projects` transcript 上重放分页（无需 daemon）。

## 风险与范围

- 主要风险或权衡：单页现在可能超过 4 MiB 读取预算（上界为 32 MiB 响应上限），病态 transcript 会产生更大的一次性响应——以此换取分页必定终止。
- 未验证 / 超出范围：ACP 客户端（Zed 等）对超大重放页的渲染；Windows/Linux 交由 CI 验证。
- 破坏性变更 / 迁移说明：无——HTTP 接口不变，只是用超预算的 200 取代确定性的 413。

## 关联 Issue

N/A

</details>
