### PR TITLE
fix(core): reuse prompt cache during chat compression

### DIFF
--- a/docs/design/chat-compression-cache-sharing.md
+++ b/docs/design/chat-compression-cache-sharing.md
@@ -1,0 +1,41 @@
+# Chat Compression Cache Sharing
+
+## Context
+
+Chat compression currently sends a cold side query with a dedicated system
+instruction, no main-session tool declarations, and a media-slimmed copy of
+the conversation. Providers whose prompt-cache key starts with tools and the
+system instruction cannot reuse the main session's cached prefix.
+
+## Design
+
+Compression first attempts a specialized single-turn request when all of the
+following are true:
+
+- the compression model is the current main model;
+- the active provider is Anthropic or DashScope and cache control is enabled;
+- slimming found no media that would change the provider-facing history.
+
+The request uses the current chat's generation config, including its system
+instruction and tool declarations, and the complete curated history. The
+existing compression instruction is appended as the final user message.
+Nothing consumes or executes function calls from this request. A response
+containing a function call, an empty response, a malformed state snapshot, or
+a request error is discarded and retried once through the existing cold side
+query. Cancellation does not trigger the fallback.
+
+Using the current `GeminiChat` keeps the request scoped to the live session.
+The process-global fork cache is intentionally not used because it retains
+only a short history tail and can belong to another concurrent session.
+
+Histories containing media and sessions using a distinct compaction model stay
+on the existing path. This keeps the first version limited to requests whose
+cache identity can be established without changing media or provider routing.
+
+## Verification
+
+Unit tests assert exact system, tools, full-history, and trailing-directive
+construction; provider/model/media gates; tool-call and malformed-response
+fallback; and cancellation behavior. Provider testing should compare the
+serialized request prefix and cached-token usage for the main turn and
+compression request.

--- a/docs/design/chat-compression-cache-sharing.md
+++ b/docs/design/chat-compression-cache-sharing.md
@@ -16,9 +16,10 @@ following are true:
 - the active provider is Anthropic or DashScope and cache control is enabled;
 - slimming found no media that would change the provider-facing history.
 
-The request uses the current chat's generation config, including its system
-instruction and tool declarations, and the complete curated history. The
-existing compression instruction is appended as the final user message.
+The request uses the current turn's effective generation config, including
+per-request tool overrides used by subagents, and the complete curated
+history. The existing compression instruction is appended as the final user
+message.
 Nothing consumes or executes function calls from this request. A response
 containing a function call, an empty response, a malformed state snapshot, or
 a request error is discarded and retried once through the existing cold side

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
@@ -1517,6 +1517,45 @@ describe('AnthropicContentGenerator', () => {
       expect(convertResponseSpy).toHaveBeenCalledTimes(1);
     });
 
+    it('caps an effort-derived thinking budget with the request budget', async () => {
+      const { AnthropicContentGenerator } = await importGenerator();
+      anthropicState.createImpl.mockResolvedValue({
+        id: 'anthropic-1',
+        model: 'claude-test',
+        content: [{ type: 'text', text: 'hi' }],
+      });
+
+      const generator = new AnthropicContentGenerator(
+        {
+          model: 'claude-test',
+          apiKey: 'test-key',
+          baseUrl: 'https://api.anthropic.com',
+          timeout: 10_000,
+          maxRetries: 2,
+          samplingParams: { max_tokens: 200 },
+          schemaCompliance: 'auto',
+          reasoning: { effort: 'high' },
+        },
+        mockConfig,
+      );
+
+      await generator.generateContent({
+        model: 'models/ignored',
+        contents: 'Hello',
+        config: { thinkingConfig: { thinkingBudget: 199 } },
+      } as unknown as GenerateContentParameters);
+
+      const [anthropicRequest] =
+        anthropicState.lastCreateArgs as AnthropicCreateArgs;
+      expect(anthropicRequest).toEqual(
+        expect.objectContaining({
+          max_tokens: 200,
+          thinking: { type: 'enabled', budget_tokens: 199 },
+          output_config: { effort: 'high' },
+        }),
+      );
+    });
+
     // DeepSeek extends reasoning_effort with a 'max' tier; the Anthropic
     // converter passes it through to output_config.effort and bumps the
     // thinking budget accordingly.

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
@@ -1472,6 +1472,7 @@ describe('AnthropicContentGenerator', () => {
         config: {
           temperature: 0.1,
           maxOutputTokens: 200,
+          thinkingConfig: { thinkingBudget: 199 },
           topP: 0.5,
           topK: 5,
           abortSignal: abortController.signal,
@@ -1503,7 +1504,7 @@ describe('AnthropicContentGenerator', () => {
           temperature: 0.7,
           top_p: 0.9,
           top_k: 20,
-          thinking: { type: 'enabled', budget_tokens: 1000 },
+          thinking: { type: 'enabled', budget_tokens: 199 },
           output_config: { effort: 'high' },
         }),
       );

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
@@ -1042,16 +1042,22 @@ export class AnthropicContentGenerator implements ContentGenerator {
     }
 
     const reasoning = this.contentGeneratorConfig.reasoning;
+    const requestBudgetCap = request.config?.thinkingConfig?.thinkingBudget;
+    const applyRequestBudgetCap = (budgetTokens: number): number =>
+      typeof requestBudgetCap === 'number' && requestBudgetCap > 0
+        ? Math.min(budgetTokens, requestBudgetCap)
+        : budgetTokens;
 
     if (reasoning === false) {
       return undefined;
     }
 
     // Explicit budget_tokens is an escape hatch from the effort ladder: honor
-    // exactly what the user asked for, without re-clamping to track the
-    // (possibly clamped) effort label — the budget field is just an integer the
-    // server accepts within its context window, so an explicit override stays
-    // explicit. This only applies to models that still accept the manual
+    // what the user asked for without re-clamping to the effort label. A caller
+    // may still provide a smaller per-request thinkingBudget when it also sets
+    // a lower maxOutputTokens; Anthropic requires budget_tokens < max_tokens,
+    // so that request-local ceiling keeps bounded side queries valid. This only
+    // applies to models that still accept the manual
     // `{ type: 'enabled', budget_tokens }` shape (Opus 4.5/4.6, Sonnet 4.6,
     // older 4.x, and unknown/unversioned ids). Opus 4.7+ and every 5.x family
     // reject manual thinking with a 400 and require adaptive thinking, so on
@@ -1068,7 +1074,7 @@ export class AnthropicContentGenerator implements ContentGenerator {
     ) {
       return {
         type: 'enabled',
-        budget_tokens: reasoning.budget_tokens,
+        budget_tokens: applyRequestBudgetCap(reasoning.budget_tokens),
       };
     }
 
@@ -1124,7 +1130,7 @@ export class AnthropicContentGenerator implements ContentGenerator {
 
     return {
       type: 'enabled',
-      budget_tokens: budgetTokens,
+      budget_tokens: applyRequestBudgetCap(budgetTokens),
     };
   }
 

--- a/packages/core/src/core/baseLlmClient.test.ts
+++ b/packages/core/src/core/baseLlmClient.test.ts
@@ -719,6 +719,7 @@ describe('BaseLlmClient', () => {
       mockGenerateContent.mockResolvedValue(
         createMockTextResponse('  plain  '),
       );
+      vi.mocked(getFunctionCalls).mockReturnValueOnce(undefined);
 
       const result = await client.generateText({
         contents: [{ role: 'user', parts: [{ text: 'hi' }] }],
@@ -730,6 +731,27 @@ describe('BaseLlmClient', () => {
       expect(mockGenerateContent).toHaveBeenCalledTimes(1);
       expect(mockGenerateContentStream).not.toHaveBeenCalled();
       expect(result.text).toBe('plain');
+      expect(result.hadToolCall).toBe(false);
+    });
+
+    it('reports function calls from the non-streaming response', async () => {
+      const response = createMockResponseWithFunctionCall({});
+      mockGenerateContent.mockResolvedValue(response);
+      vi.mocked(getFunctionCalls).mockReturnValueOnce([
+        { name: 'respond_in_schema', args: {} },
+      ]);
+
+      const result = await client.generateText({
+        contents: [{ role: 'user', parts: [{ text: 'hi' }] }],
+        model: 'test-model',
+        abortSignal: abortController.signal,
+        promptId: 'p',
+      });
+
+      expect(mockGenerateContent).toHaveBeenCalledTimes(1);
+      expect(mockGenerateContentStream).not.toHaveBeenCalled();
+      expect(getFunctionCalls).toHaveBeenCalledWith(response);
+      expect(result.hadToolCall).toBe(true);
     });
 
     it('propagates a mid-stream error and never returns the partial text', async () => {

--- a/packages/core/src/core/baseLlmClient.test.ts
+++ b/packages/core/src/core/baseLlmClient.test.ts
@@ -622,6 +622,7 @@ describe('BaseLlmClient', () => {
       mockGenerateContentStream.mockImplementation(async () =>
         mockTextStream(['  Hello', ', ', 'world  '], usage),
       );
+      vi.mocked(getFunctionCalls).mockReturnValue(undefined);
 
       const result = await client.generateText({
         contents: [{ role: 'user', parts: [{ text: 'hi' }] }],
@@ -648,6 +649,7 @@ describe('BaseLlmClient', () => {
       // Deltas are concatenated, then trimmed once at the end.
       expect(result.text).toBe('Hello, world');
       expect(result.usage).toEqual(usage);
+      expect(result.hadToolCall).toBe(false);
     });
 
     it('forwards tool declarations and reports function calls without executing them', async () => {

--- a/packages/core/src/core/baseLlmClient.test.ts
+++ b/packages/core/src/core/baseLlmClient.test.ts
@@ -650,6 +650,38 @@ describe('BaseLlmClient', () => {
       expect(result.usage).toEqual(usage);
     });
 
+    it('forwards tool declarations and reports function calls without executing them', async () => {
+      const tools = [
+        {
+          functionDeclarations: [
+            { name: 'read_file', description: 'Read a file' },
+          ],
+        },
+      ];
+      mockGenerateContentStream.mockImplementation(async () =>
+        mockTextStream(['summary']),
+      );
+      vi.mocked(getFunctionCalls).mockReturnValueOnce([
+        { name: 'read_file', args: { path: 'README.md' } },
+      ]);
+
+      const result = await client.generateText({
+        contents: [{ role: 'user', parts: [{ text: 'summarize' }] }],
+        model: 'test-model',
+        abortSignal: abortController.signal,
+        stream: true,
+        config: { tools },
+      });
+
+      expect(mockGenerateContentStream).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({ tools }),
+        }),
+        '',
+      );
+      expect(result.hadToolCall).toBe(true);
+    });
+
     it('drops thought parts and tolerates a stream that omits usage', async () => {
       async function* streamWithThought(): AsyncGenerator<GenerateContentResponse> {
         yield createMockTextResponse('answer');

--- a/packages/core/src/core/baseLlmClient.ts
+++ b/packages/core/src/core/baseLlmClient.ts
@@ -84,14 +84,12 @@ export interface GenerateTextOptions {
    * content generator without the geminiClient main-prompt fallback or
    * user-memory wrapping that `getCustomSystemPrompt` applies.
    */
-  systemInstruction?: string | Part | Part[] | Content;
+  systemInstruction?: GenerateContentConfig['systemInstruction'];
   /**
-   * Overrides for generation configuration (e.g., temperature, thinkingConfig).
+   * Overrides for generation configuration (e.g., temperature, thinkingConfig,
+   * or cache-prefix-preserving tool declarations).
    */
-  config?: Omit<
-    GenerateContentConfig,
-    'systemInstruction' | 'tools' | 'abortSignal'
-  >;
+  config?: Omit<GenerateContentConfig, 'systemInstruction' | 'abortSignal'>;
   /** Signal for cancellation. */
   abortSignal: AbortSignal;
   /**
@@ -127,6 +125,8 @@ export interface GenerateTextOptions {
 export interface GenerateTextResult {
   text: string;
   usage: GenerateContentResponseUsageMetadata | undefined;
+  /** Whether the response contained a function call. No call is executed here. */
+  hadToolCall?: boolean;
 }
 
 /**
@@ -418,13 +418,15 @@ export class BaseLlmClient {
             // the final chunk (last one wins), matching the non-streaming read.
             let text = '';
             let usage: GenerateContentResponseUsageMetadata | undefined;
+            let hadToolCall = false;
             for await (const chunk of responseStream) {
               text += getResponseText(chunk) ?? '';
+              hadToolCall ||= (getFunctionCalls(chunk)?.length ?? 0) > 0;
               if (chunk.usageMetadata) {
                 usage = chunk.usageMetadata;
               }
             }
-            return { text, usage };
+            return { text, usage, hadToolCall };
           }
         : async () => {
             const result = await contentGenerator.generateContent(
@@ -434,6 +436,7 @@ export class BaseLlmClient {
             return {
               text: getResponseText(result) ?? '',
               usage: result.usageMetadata,
+              hadToolCall: (getFunctionCalls(result)?.length ?? 0) > 0,
             };
           };
 
@@ -467,6 +470,7 @@ export class BaseLlmClient {
       return {
         text: result.text.trim(),
         usage: result.usage,
+        hadToolCall: result.hadToolCall,
       };
     } catch (error) {
       if (abortSignal.aborted) {

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -3207,7 +3207,7 @@ describe('GeminiChat', async () => {
       ).toBe(200);
     });
 
-    it('forwards the pending user message to the compression cheap-gate', async () => {
+    it('forwards the pending user message and request config to compression', async () => {
       // The cheap-gate inside ChatCompressionService.compress uses
       // estimatePromptTokens(history, pendingUserMessage, lastPromptTokenCount)
       // so the very first send after inherited history (where
@@ -3235,9 +3235,16 @@ describe('GeminiChat', async () => {
       );
 
       const userMessageText = 'next user prompt';
+      const requestTools = [
+        {
+          functionDeclarations: [
+            { name: 'subagent_tool', description: 'Subagent-only tool' },
+          ],
+        },
+      ];
       const stream = await chat.sendMessageStream(
         'test-model',
-        { message: userMessageText },
+        { message: userMessageText, config: { tools: requestTools } },
         'prompt-id-first-turn',
       );
       // The first event in the stream should be COMPRESSED because the
@@ -3260,6 +3267,9 @@ describe('GeminiChat', async () => {
           (part) => part.text === userMessageText,
         ),
       ).toBe(true);
+      expect(compressSpy.mock.calls[0][1].requestGenerationConfig?.tools).toBe(
+        requestTools,
+      );
     });
 
     it('triggers compaction end-to-end through the real ChatCompressionService when lastPromptTokenCount === 0 and inherited history is large (R3.4)', async () => {

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -461,6 +461,8 @@ interface TryCompressOptions {
    * `getHistory(true)` clone per send. (review #4168 R1.3 / R1.4)
    */
   precomputedEffectiveTokens?: number;
+  /** Per-request overrides needed to preserve the main request cache prefix. */
+  requestGenerationConfig?: GenerateContentConfig;
   /**
    * Delay writing the compression checkpoint until the caller has run any
    * post-compression guards that may roll the in-memory chat state back.
@@ -1850,6 +1852,7 @@ export class GeminiChat {
         options?.originalTokenCountOverride ?? this.lastPromptTokenCount,
       pendingUserMessage: options?.pendingUserMessage,
       precomputedEffectiveTokens: options?.precomputedEffectiveTokens,
+      requestGenerationConfig: options?.requestGenerationConfig,
       trigger: options?.trigger,
       customInstructions: options?.customInstructions,
       signal,
@@ -2214,6 +2217,7 @@ export class GeminiChat {
           {
             pendingUserMessage: userContent,
             precomputedEffectiveTokens: effectiveTokens,
+            requestGenerationConfig: params.config,
             deferChatCompressionRecord: shouldForceFromHard,
             // Hard-rescue is force=true to bypass the cheap-gate breaker
             // but it remains a semantically AUTOMATIC trigger. Tag the
@@ -2695,6 +2699,7 @@ export class GeminiChat {
                     params.config?.abortSignal,
                     {
                       originalTokenCountOverride: reactiveOriginalTokenCount,
+                      requestGenerationConfig: params.config,
                       trigger: 'auto',
                     },
                   );

--- a/packages/core/src/core/openaiContentGenerator/index.ts
+++ b/packages/core/src/core/openaiContentGenerator/index.ts
@@ -38,19 +38,6 @@ export {
 export { OpenAIContentConverter } from './converter.js';
 
 /**
- * Whether an OpenAI-compatible provider can reuse an unchanged prompt prefix.
- * Keep provider detection here so services consume a capability query instead
- * of depending on a concrete provider implementation.
- */
-export function supportsOpenAIPrefixCaching(
-  contentGeneratorConfig: ContentGeneratorConfig,
-): boolean {
-  return DashScopeOpenAICompatibleProvider.isDashScopeProvider(
-    contentGeneratorConfig,
-  );
-}
-
-/**
  * Create an OpenAI-compatible content generator with the appropriate provider
  */
 export function createOpenAIContentGenerator(

--- a/packages/core/src/core/openaiContentGenerator/index.ts
+++ b/packages/core/src/core/openaiContentGenerator/index.ts
@@ -38,6 +38,19 @@ export {
 export { OpenAIContentConverter } from './converter.js';
 
 /**
+ * Whether an OpenAI-compatible provider can reuse an unchanged prompt prefix.
+ * Keep provider detection here so services consume a capability query instead
+ * of depending on a concrete provider implementation.
+ */
+export function supportsOpenAIPrefixCaching(
+  contentGeneratorConfig: ContentGeneratorConfig,
+): boolean {
+  return DashScopeOpenAICompatibleProvider.isDashScopeProvider(
+    contentGeneratorConfig,
+  );
+}
+
+/**
  * Create an OpenAI-compatible content generator with the appropriate provider
  */
 export function createOpenAIContentGenerator(

--- a/packages/core/src/core/openaiContentGenerator/prefix-caching.ts
+++ b/packages/core/src/core/openaiContentGenerator/prefix-caching.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ContentGeneratorConfig } from '../contentGenerator.js';
+import { DashScopeOpenAICompatibleProvider } from './provider/dashscope.js';
+
+export function supportsOpenAIPrefixCaching(
+  contentGeneratorConfig: ContentGeneratorConfig,
+): boolean {
+  return DashScopeOpenAICompatibleProvider.isDashScopeProvider(
+    contentGeneratorConfig,
+  );
+}

--- a/packages/core/src/services/chatCompressionService.test.ts
+++ b/packages/core/src/services/chatCompressionService.test.ts
@@ -2430,8 +2430,7 @@ describe('ChatCompressionService.compress cache sharing', () => {
   it('does not fall back after cancellation', async () => {
     const { chat, config, generateText } = makeFixture();
     const controller = new AbortController();
-    controller.abort();
-    generateText.mockRejectedValue(new DOMException('Aborted', 'AbortError'));
+    controller.abort(new DOMException('Aborted', 'AbortError'));
     const coldSpy = vi.spyOn(sideQueryModule, 'runSideQuery');
 
     await expect(
@@ -2444,6 +2443,7 @@ describe('ChatCompressionService.compress cache sharing', () => {
         signal: controller.signal,
       }),
     ).rejects.toThrow('Aborted');
+    expect(generateText).not.toHaveBeenCalled();
     expect(coldSpy).not.toHaveBeenCalled();
   });
 

--- a/packages/core/src/services/chatCompressionService.test.ts
+++ b/packages/core/src/services/chatCompressionService.test.ts
@@ -2265,6 +2265,31 @@ describe('ChatCompressionService.compress cache sharing', () => {
     expect(coldSpy).not.toHaveBeenCalled();
   });
 
+  it('preserves per-request tool overrides used by subagent turns', async () => {
+    const { chat, config, generateText } = makeFixture();
+    const requestTools = [
+      {
+        functionDeclarations: [
+          { name: 'subagent_tool', description: 'Subagent-only tool' },
+        ],
+      },
+    ];
+
+    await new ChatCompressionService().compress(chat, {
+      promptId: 'p',
+      force: true,
+      config,
+      consecutiveFailures: 0,
+      originalTokenCount: 180_000,
+      requestGenerationConfig: { tools: requestTools },
+    });
+
+    const request = generateText.mock.calls[0]![0] as {
+      config?: { tools?: unknown };
+    };
+    expect(request.config?.tools).toBe(requestTools);
+  });
+
   it.each([AuthType.QWEN_OAUTH, AuthType.USE_OPENAI])(
     'uses cache sharing for DashScope through %s',
     async (authType) => {
@@ -2419,6 +2444,28 @@ describe('ChatCompressionService.compress cache sharing', () => {
         signal: controller.signal,
       }),
     ).rejects.toThrow('Aborted');
+    expect(coldSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not fall back when cancellation lands with an unusable shared response', async () => {
+    const { chat, config, generateText } = makeFixture();
+    const controller = new AbortController();
+    generateText.mockImplementation(async () => {
+      controller.abort();
+      return { text: 'plain summary', usage: {}, hadToolCall: false };
+    });
+    const coldSpy = vi.spyOn(sideQueryModule, 'runSideQuery');
+
+    await expect(
+      new ChatCompressionService().compress(chat, {
+        promptId: 'p',
+        force: true,
+        config,
+        consecutiveFailures: 0,
+        originalTokenCount: 180_000,
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow();
     expect(coldSpy).not.toHaveBeenCalled();
   });
 

--- a/packages/core/src/services/chatCompressionService.test.ts
+++ b/packages/core/src/services/chatCompressionService.test.ts
@@ -2251,13 +2251,19 @@ describe('ChatCompressionService.compress cache sharing', () => {
       systemInstruction?: string;
       config?: {
         tools?: unknown;
-        thinkingConfig?: { includeThoughts?: boolean };
+        thinkingConfig?: {
+          includeThoughts?: boolean;
+          thinkingBudget?: number;
+        };
         maxOutputTokens?: number;
       };
     };
     expect(request.systemInstruction).toBe(mainSystemInstruction);
     expect(request.config?.tools).toBe(tools);
     expect(request.config?.thinkingConfig?.includeThoughts).toBe(true);
+    expect(request.config?.thinkingConfig?.thinkingBudget).toBe(
+      COMPACT_MAX_OUTPUT_TOKENS - 1,
+    );
     expect(request.config?.maxOutputTokens).toBe(COMPACT_MAX_OUTPUT_TOKENS);
     expect(request.contents.slice(0, -1)).toEqual(history);
     expect(request.contents).toHaveLength(43);

--- a/packages/core/src/services/chatCompressionService.test.ts
+++ b/packages/core/src/services/chatCompressionService.test.ts
@@ -24,6 +24,7 @@ import { AuthType } from '../core/contentGenerator.js';
 import { PreCompactTrigger, PostCompactTrigger } from '../hooks/types.js';
 import * as sideQueryModule from '../utils/sideQuery.js';
 import * as postCompactModule from './postCompactAttachments.js';
+import { logChatCompression } from '../telemetry/loggers.js';
 
 vi.mock('../telemetry/uiTelemetry.js');
 vi.mock('../core/tokenLimits.js');
@@ -2271,6 +2272,13 @@ describe('ChatCompressionService.compress cache sharing', () => {
       'Keep the exact command output.',
     );
     expect(coldSpy).not.toHaveBeenCalled();
+    expect(logChatCompression).toHaveBeenLastCalledWith(
+      config,
+      expect.objectContaining({
+        cache_sharing_attempted: true,
+        cache_sharing_used: true,
+      }),
+    );
   });
 
   it('preserves per-request tool overrides used by subagent turns', async () => {
@@ -2437,6 +2445,14 @@ describe('ChatCompressionService.compress cache sharing', () => {
         hadToolCall: false,
       },
     },
+    {
+      name: 'whitespace-only snapshot',
+      response: {
+        text: '<state_snapshot> </state_snapshot>',
+        usage: {},
+        hadToolCall: false,
+      },
+    },
   ])(
     'falls back once when the shared response contains a $name',
     async ({ response }) => {
@@ -2463,6 +2479,13 @@ describe('ChatCompressionService.compress cache sharing', () => {
 
       expect(generateText).toHaveBeenCalledTimes(1);
       expect(coldSpy).toHaveBeenCalledTimes(1);
+      expect(logChatCompression).toHaveBeenLastCalledWith(
+        config,
+        expect.objectContaining({
+          cache_sharing_attempted: true,
+          cache_sharing_used: false,
+        }),
+      );
     },
   );
 
@@ -2562,6 +2585,25 @@ describe('ChatCompressionService.compress cache sharing', () => {
             parts: [{ inlineData: { mimeType: 'image/png', data: 'base64' } }],
           },
           { role: 'model', parts: [{ text: 'image received' }] },
+        ],
+      },
+    },
+    {
+      name: 'document-bearing history',
+      options: {
+        history: [
+          {
+            role: 'user',
+            parts: [
+              {
+                inlineData: {
+                  mimeType: 'application/pdf',
+                  data: 'base64',
+                },
+              },
+            ],
+          },
+          { role: 'model', parts: [{ text: 'document received' }] },
         ],
       },
     },

--- a/packages/core/src/services/chatCompressionService.test.ts
+++ b/packages/core/src/services/chatCompressionService.test.ts
@@ -20,6 +20,7 @@ import type { GeminiChat } from '../core/geminiChat.js';
 import type { Config } from '../config/config.js';
 import { ApprovalMode } from '../config/config.js';
 import type { BaseLlmClient } from '../core/baseLlmClient.js';
+import { AuthType } from '../core/contentGenerator.js';
 import { PreCompactTrigger, PostCompactTrigger } from '../hooks/types.js';
 import * as sideQueryModule from '../utils/sideQuery.js';
 import * as postCompactModule from './postCompactAttachments.js';
@@ -2149,6 +2150,351 @@ describe('ChatCompressionService.compress sideQuery config', () => {
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('COMPACT_MAX_OUTPUT_TOKENS'),
     );
+  });
+});
+
+describe('ChatCompressionService.compress cache sharing', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const mainSystemInstruction = 'main system instruction';
+  const tools = [
+    {
+      functionDeclarations: [{ name: 'read_file', description: 'Read a file' }],
+    },
+  ];
+
+  function makeHistory(length = 4): Content[] {
+    return Array.from({ length }, (_, index) => ({
+      role: index % 2 === 0 ? 'user' : 'model',
+      parts: [{ text: `message-${index}` }],
+    }));
+  }
+
+  function makeFixture(options?: {
+    history?: Content[];
+    authType?: AuthType;
+    compactionModel?: string;
+    enableCacheControl?: boolean;
+  }): {
+    chat: GeminiChat;
+    config: Config;
+    generateText: ReturnType<typeof vi.fn>;
+  } {
+    const history = options?.history ?? makeHistory();
+    const getHistory = vi.fn().mockReturnValue(history);
+    const generateText = vi.fn().mockResolvedValue({
+      text: '<state_snapshot>shared summary</state_snapshot>',
+      usage: {
+        promptTokenCount: 170_000,
+        candidatesTokenCount: 500,
+        totalTokenCount: 170_500,
+        cachedContentTokenCount: 160_000,
+      },
+      hadToolCall: false,
+    });
+    const baseLlmClient = { generateText } as unknown as BaseLlmClient;
+    const chat = {
+      getHistory,
+      getHistoryShallow: getHistory,
+      getGenerationConfig: vi.fn().mockReturnValue({
+        systemInstruction: mainSystemInstruction,
+        tools,
+        thinkingConfig: { includeThoughts: true },
+      }),
+    } as unknown as GeminiChat;
+    const config = {
+      getChatCompression: vi.fn(),
+      getAutoCompactThreshold: vi.fn(),
+      getBaseLlmClient: vi.fn().mockReturnValue(baseLlmClient),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({
+        model: 'test-model',
+        authType: options?.authType ?? AuthType.USE_ANTHROPIC,
+        contextWindowSize: 200_000,
+        enableCacheControl: options?.enableCacheControl ?? true,
+      }),
+      getHookSystem: vi.fn().mockReturnValue({
+        firePreCompactEvent: vi.fn().mockResolvedValue(undefined),
+        firePostCompactEvent: vi.fn().mockResolvedValue(undefined),
+      }),
+      getModel: () => 'test-model',
+      getCompactionModel: vi.fn().mockReturnValue(options?.compactionModel),
+      getAllConfiguredModels: vi.fn().mockReturnValue([]),
+      getApprovalMode: () => 'default',
+      getDebugLogger: () => ({ warn: vi.fn(), debug: vi.fn() }),
+      getTargetDir: () => '/tmp/test-workspace',
+    } as unknown as Config;
+
+    return { chat, config, generateText };
+  }
+
+  it('preserves the main system, tools, and complete history before the compression directive', async () => {
+    const history = makeHistory(42);
+    const { chat, config, generateText } = makeFixture({ history });
+    const coldSpy = vi.spyOn(sideQueryModule, 'runSideQuery');
+
+    await new ChatCompressionService().compress(chat, {
+      promptId: 'p',
+      force: true,
+      config,
+      consecutiveFailures: 0,
+      originalTokenCount: 180_000,
+      customInstructions: 'Keep the exact command output.',
+    });
+
+    expect(generateText).toHaveBeenCalledTimes(1);
+    const request = generateText.mock.calls[0]![0] as {
+      contents: Content[];
+      systemInstruction?: string;
+      config?: {
+        tools?: unknown;
+        thinkingConfig?: { includeThoughts?: boolean };
+        maxOutputTokens?: number;
+      };
+    };
+    expect(request.systemInstruction).toBe(mainSystemInstruction);
+    expect(request.config?.tools).toBe(tools);
+    expect(request.config?.thinkingConfig?.includeThoughts).toBe(true);
+    expect(request.config?.maxOutputTokens).toBe(COMPACT_MAX_OUTPUT_TOKENS);
+    expect(request.contents.slice(0, -1)).toEqual(history);
+    expect(request.contents).toHaveLength(43);
+    expect(request.contents.at(-1)?.parts?.[0]?.text).toContain(
+      'Keep the exact command output.',
+    );
+    expect(coldSpy).not.toHaveBeenCalled();
+  });
+
+  it.each([AuthType.QWEN_OAUTH, AuthType.USE_OPENAI])(
+    'uses cache sharing for DashScope through %s',
+    async (authType) => {
+      const { chat, config, generateText } = makeFixture({ authType });
+      const coldSpy = vi.spyOn(sideQueryModule, 'runSideQuery');
+
+      await new ChatCompressionService().compress(chat, {
+        promptId: 'p',
+        force: true,
+        config,
+        consecutiveFailures: 0,
+        originalTokenCount: 180_000,
+      });
+
+      expect(generateText).toHaveBeenCalledTimes(1);
+      expect(coldSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  it('appends a pending tool result after the cached history and before the directive', async () => {
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'read the file' }] },
+      {
+        role: 'model',
+        parts: [
+          {
+            functionCall: {
+              id: 'call-1',
+              name: 'read_file',
+              args: { path: 'README.md' },
+            },
+          },
+        ],
+      },
+    ];
+    const pendingUserMessage: Content = {
+      role: 'user',
+      parts: [
+        {
+          functionResponse: {
+            id: 'call-1',
+            name: 'read_file',
+            response: { output: 'contents' },
+          },
+        },
+      ],
+    };
+    const { chat, config, generateText } = makeFixture({ history });
+
+    await new ChatCompressionService().compress(chat, {
+      promptId: 'p',
+      force: true,
+      trigger: 'auto',
+      config,
+      consecutiveFailures: 0,
+      originalTokenCount: 180_000,
+      pendingUserMessage,
+    });
+
+    const request = generateText.mock.calls[0]![0] as {
+      contents: Content[];
+    };
+    expect(request.contents.slice(0, -1)).toEqual([
+      ...history,
+      pendingUserMessage,
+    ]);
+  });
+
+  it('preserves non-visible system and tool tokens in the post-compression count', async () => {
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'x'.repeat(40_000) }] },
+      { role: 'model', parts: [{ text: 'y'.repeat(40_000) }] },
+    ];
+    const { chat, config } = makeFixture({ history });
+
+    const result = await new ChatCompressionService().compress(chat, {
+      promptId: 'p',
+      force: true,
+      config,
+      consecutiveFailures: 0,
+      originalTokenCount: 180_000,
+    });
+
+    expect(result.info.compressionStatus).toBe(CompressionStatus.COMPRESSED);
+    expect(result.info.newTokenCount).toBeGreaterThan(100_000);
+  });
+
+  it.each([
+    {
+      name: 'tool call',
+      response: {
+        text: '<state_snapshot>shared summary</state_snapshot>',
+        usage: {},
+        hadToolCall: true,
+      },
+    },
+    {
+      name: 'malformed snapshot',
+      response: { text: 'plain summary', usage: {}, hadToolCall: false },
+    },
+    {
+      name: 'empty snapshot',
+      response: {
+        text: '<state_snapshot></state_snapshot>',
+        usage: {},
+        hadToolCall: false,
+      },
+    },
+  ])(
+    'falls back once when the shared response contains a $name',
+    async ({ response }) => {
+      const { chat, config, generateText } = makeFixture();
+      generateText.mockResolvedValue(response);
+      const coldSpy = vi
+        .spyOn(sideQueryModule, 'runSideQuery')
+        .mockResolvedValue({
+          text: '<state_snapshot>cold summary</state_snapshot>',
+          usage: {
+            promptTokenCount: 170_000,
+            candidatesTokenCount: 500,
+            totalTokenCount: 170_500,
+          },
+        } as never);
+
+      await new ChatCompressionService().compress(chat, {
+        promptId: 'p',
+        force: true,
+        config,
+        consecutiveFailures: 0,
+        originalTokenCount: 180_000,
+      });
+
+      expect(generateText).toHaveBeenCalledTimes(1);
+      expect(coldSpy).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('does not fall back after cancellation', async () => {
+    const { chat, config, generateText } = makeFixture();
+    const controller = new AbortController();
+    controller.abort();
+    generateText.mockRejectedValue(new DOMException('Aborted', 'AbortError'));
+    const coldSpy = vi.spyOn(sideQueryModule, 'runSideQuery');
+
+    await expect(
+      new ChatCompressionService().compress(chat, {
+        promptId: 'p',
+        force: true,
+        config,
+        consecutiveFailures: 0,
+        originalTokenCount: 180_000,
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow('Aborted');
+    expect(coldSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back once when the cache-sharing request fails', async () => {
+    const { chat, config, generateText } = makeFixture();
+    generateText.mockRejectedValue(new Error('provider failed'));
+    const coldSpy = vi
+      .spyOn(sideQueryModule, 'runSideQuery')
+      .mockResolvedValue({
+        text: '<state_snapshot>cold summary</state_snapshot>',
+        usage: {
+          promptTokenCount: 170_000,
+          candidatesTokenCount: 500,
+          totalTokenCount: 170_500,
+        },
+      } as never);
+
+    await new ChatCompressionService().compress(chat, {
+      promptId: 'p',
+      force: true,
+      config,
+      consecutiveFailures: 0,
+      originalTokenCount: 180_000,
+    });
+
+    expect(coldSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    {
+      name: 'a distinct compaction model',
+      options: { compactionModel: 'compact-model' },
+    },
+    {
+      name: 'a provider without explicit cache support',
+      options: { authType: AuthType.USE_GEMINI },
+    },
+    {
+      name: 'disabled cache control',
+      options: { enableCacheControl: false },
+    },
+    {
+      name: 'media-bearing history',
+      options: {
+        history: [
+          {
+            role: 'user',
+            parts: [{ inlineData: { mimeType: 'image/png', data: 'base64' } }],
+          },
+          { role: 'model', parts: [{ text: 'image received' }] },
+        ],
+      },
+    },
+  ])('keeps $name on the cold path', async ({ options }) => {
+    const { chat, config, generateText } = makeFixture(options);
+    const coldSpy = vi
+      .spyOn(sideQueryModule, 'runSideQuery')
+      .mockResolvedValue({
+        text: '<state_snapshot>cold summary</state_snapshot>',
+        usage: {
+          promptTokenCount: 170_000,
+          candidatesTokenCount: 500,
+          totalTokenCount: 170_500,
+        },
+      } as never);
+
+    await new ChatCompressionService().compress(chat, {
+      promptId: 'p',
+      force: true,
+      config,
+      consecutiveFailures: 0,
+      originalTokenCount: 180_000,
+    });
+
+    expect(generateText).not.toHaveBeenCalled();
+    expect(coldSpy).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/core/src/services/chatCompressionService.test.ts
+++ b/packages/core/src/services/chatCompressionService.test.ts
@@ -2175,6 +2175,7 @@ describe('ChatCompressionService.compress cache sharing', () => {
   function makeFixture(options?: {
     history?: Content[];
     authType?: AuthType;
+    baseUrl?: string;
     compactionModel?: string;
     enableCacheControl?: boolean;
   }): {
@@ -2211,6 +2212,7 @@ describe('ChatCompressionService.compress cache sharing', () => {
       getContentGeneratorConfig: vi.fn().mockReturnValue({
         model: 'test-model',
         authType: options?.authType ?? AuthType.USE_ANTHROPIC,
+        baseUrl: options?.baseUrl,
         contextWindowSize: 200_000,
         enableCacheControl: options?.enableCacheControl ?? true,
       }),
@@ -2377,6 +2379,37 @@ describe('ChatCompressionService.compress cache sharing', () => {
     expect(result.info.newTokenCount).toBeGreaterThan(100_000);
   });
 
+  it('accepts a complete shared summary when thinking reaches the output cap', async () => {
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'x'.repeat(40_000) }] },
+      { role: 'model', parts: [{ text: 'y'.repeat(40_000) }] },
+    ];
+    const { chat, config, generateText } = makeFixture({ history });
+    generateText.mockResolvedValue({
+      text: '<analysis>long reasoning</analysis><state_snapshot>complete summary</state_snapshot>',
+      usage: {
+        promptTokenCount: 170_000,
+        candidatesTokenCount: COMPACT_MAX_OUTPUT_TOKENS,
+        totalTokenCount: 190_000,
+        cachedContentTokenCount: 160_000,
+      },
+      hadToolCall: false,
+    });
+    const coldSpy = vi.spyOn(sideQueryModule, 'runSideQuery');
+
+    const result = await new ChatCompressionService().compress(chat, {
+      promptId: 'p',
+      force: true,
+      config,
+      consecutiveFailures: 0,
+      originalTokenCount: 180_000,
+    });
+
+    expect(result.info.compressionStatus).toBe(CompressionStatus.COMPRESSED);
+    expect(result.newHistory).not.toBeNull();
+    expect(coldSpy).not.toHaveBeenCalled();
+  });
+
   it.each([
     {
       name: 'tool call',
@@ -2502,6 +2535,13 @@ describe('ChatCompressionService.compress cache sharing', () => {
     {
       name: 'a provider without explicit cache support',
       options: { authType: AuthType.USE_GEMINI },
+    },
+    {
+      name: 'a non-DashScope OpenAI-compatible provider',
+      options: {
+        authType: AuthType.USE_OPENAI,
+        baseUrl: 'https://api.openai.com/v1',
+      },
     },
     {
       name: 'disabled cache control',

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Content } from '@google/genai';
+import type { Content, GenerateContentConfig } from '@google/genai';
 import type { Config } from '../config/config.js';
 import { ApprovalMode } from '../config/config.js';
 import type { GenerateTextResult } from '../core/baseLlmClient.js';
@@ -245,6 +245,8 @@ export interface CompressOptions {
    * (review #4168 R1.3 / R1.4)
    */
   precomputedEffectiveTokens?: number;
+  /** Per-request overrides used by the main turn, including transient tools. */
+  requestGenerationConfig?: GenerateContentConfig;
   /**
    * User-supplied focus directives passed to the compression side-query.
    * Appended to the system prompt as an `Additional Instructions:` block.
@@ -643,7 +645,10 @@ export class ChatCompressionService {
       supportsCompressionCacheSharing(config);
     if (canShareCache) {
       try {
-        const generationConfig = chat.getGenerationConfig();
+        const generationConfig = {
+          ...chat.getGenerationConfig(),
+          ...opts.requestGenerationConfig,
+        };
         const mainSystemInstruction = generationConfig.systemInstruction;
         delete generationConfig.systemInstruction;
         delete generationConfig.abortSignal;
@@ -703,7 +708,10 @@ export class ChatCompressionService {
       }
     }
 
-    summaryResult ??= await runColdCompression();
+    if (!summaryResult) {
+      abortSignal.throwIfAborted();
+      summaryResult = await runColdCompression();
+    }
     const summary = summaryResult.text;
     // Check the PROCESSED summary: postProcessSummary strips <analysis>
     // blocks, so a response that is ONLY <analysis>...</analysis> (no

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -594,6 +594,7 @@ export class ChatCompressionService {
     }
 
     const abortSignal = signal ?? new AbortController().signal;
+    abortSignal.throwIfAborted();
     const runColdCompression = () =>
       runSideQuery(config, {
         purpose: 'chat-compression',

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -19,7 +19,7 @@ import { DEFAULT_TOKEN_LIMIT } from '../core/tokenLimits.js';
 import { getCompressionPrompt } from '../core/prompts.js';
 import { runSideQuery } from '../utils/sideQuery.js';
 import { resolveModelId } from '../utils/modelId.js';
-import { DashScopeOpenAICompatibleProvider } from '../core/openaiContentGenerator/provider/dashscope.js';
+import { supportsOpenAIPrefixCaching } from '../core/openaiContentGenerator/index.js';
 import { logChatCompression } from '../telemetry/loggers.js';
 import { makeChatCompressionEvent } from '../telemetry/types.js';
 import { PreCompactTrigger, PostCompactTrigger } from '../hooks/types.js';
@@ -324,7 +324,7 @@ function supportsCompressionCacheSharing(config: Config): boolean {
   return (
     (provider.authType === AuthType.QWEN_OAUTH ||
       provider.authType === AuthType.USE_OPENAI) &&
-    DashScopeOpenAICompatibleProvider.isDashScopeProvider(provider)
+    supportsOpenAIPrefixCaching(provider)
   );
 }
 
@@ -672,6 +672,18 @@ export class ChatCompressionService {
           systemInstruction: mainSystemInstruction,
           config: {
             ...generationConfig,
+            ...(config.getContentGeneratorConfig().authType ===
+            AuthType.USE_ANTHROPIC
+              ? {
+                  thinkingConfig: {
+                    ...generationConfig.thinkingConfig,
+                    // Manual Anthropic thinking requires budget_tokens to be
+                    // strictly below max_tokens. Preserve thinking for cache
+                    // compatibility while keeping this bounded request valid.
+                    thinkingBudget: COMPACT_MAX_OUTPUT_TOKENS - 1,
+                  },
+                }
+              : {}),
             maxOutputTokens: COMPACT_MAX_OUTPUT_TOKENS,
           },
           abortSignal,
@@ -983,6 +995,8 @@ export class ChatCompressionService {
         tokens_after: newTokenCount,
         compression_input_token_count: compressionInputTokenCount,
         compression_output_token_count: compressionOutputTokenCount,
+        cache_sharing_attempted: canShareCache,
+        cache_sharing_used: usedCacheSharing,
       }),
     );
 

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -752,9 +752,10 @@ export class ChatCompressionService {
         );
     }
 
-    // Defensive guard: if the side-query hit COMPACT_MAX_OUTPUT_TOKENS, the
-    // summary is likely truncated mid-content and unsafe to persist. Drop it
-    // and surface as a failure so the consecutive-failure breaker counts it —
+    // Defensive guard: if the dedicated side-query hit
+    // COMPACT_MAX_OUTPUT_TOKENS, the summary is likely truncated mid-content
+    // and unsafe to persist. Drop it and surface as a failure so the
+    // consecutive-failure breaker counts it —
     // if the model consistently produces max-length summaries we want to stop
     // trying after MAX_CONSECUTIVE_FAILURES strikes rather than burn an API
     // call on every send. Reactive overflow still catches the catastrophic
@@ -766,6 +767,7 @@ export class ChatCompressionService {
     // `MAX_TOKENS` (Gemini), but `runSideQuery` doesn't surface it today.
     // Plumb it through and tighten this guard when that's available.
     if (
+      !usedCacheSharing &&
       !isSummaryEmpty &&
       typeof compressionOutputTokenCount === 'number' &&
       compressionOutputTokenCount >= COMPACT_MAX_OUTPUT_TOKENS

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -7,6 +7,8 @@
 import type { Content } from '@google/genai';
 import type { Config } from '../config/config.js';
 import { ApprovalMode } from '../config/config.js';
+import type { GenerateTextResult } from '../core/baseLlmClient.js';
+import { AuthType } from '../core/contentGenerator.js';
 import type { GeminiChat } from '../core/geminiChat.js';
 import {
   type ChatCompressionInfo,
@@ -17,6 +19,7 @@ import { DEFAULT_TOKEN_LIMIT } from '../core/tokenLimits.js';
 import { getCompressionPrompt } from '../core/prompts.js';
 import { runSideQuery } from '../utils/sideQuery.js';
 import { resolveModelId } from '../utils/modelId.js';
+import { DashScopeOpenAICompatibleProvider } from '../core/openaiContentGenerator/provider/dashscope.js';
 import { logChatCompression } from '../telemetry/loggers.js';
 import { makeChatCompressionEvent } from '../telemetry/types.js';
 import { PreCompactTrigger, PostCompactTrigger } from '../hooks/types.js';
@@ -44,9 +47,11 @@ import {
 const debugLogger = createDebugLogger('COMPRESSION');
 
 /**
- * Hard cap on the compression sideQuery output (summary text only, since
- * thinking is disabled). Mirrors claude-code's MAX_OUTPUT_TOKENS_FOR_SUMMARY
- * (autoCompact.ts:30) which is based on p99.99 of real compaction outputs.
+ * Hard cap on compression generation. The cold path disables thinking; the
+ * cache-sharing path inherits the main request's cache-sensitive thinking
+ * setting while keeping this same provider output ceiling. Mirrors
+ * claude-code's MAX_OUTPUT_TOKENS_FOR_SUMMARY (autoCompact.ts:30), which is
+ * based on p99.99 of real compaction outputs.
  */
 export const COMPACT_MAX_OUTPUT_TOKENS = 20_000;
 
@@ -60,8 +65,8 @@ export const DEFAULT_PCT = 0.85;
 
 /**
  * Token budget reserved from the window for compression output. Matches
- * COMPACT_MAX_OUTPUT_TOKENS because thinking is disabled (see Task 1) and
- * maxOutputTokens is therefore the hard ceiling on total summary output.
+ * COMPACT_MAX_OUTPUT_TOKENS, the hard provider output ceiling for both
+ * compression request shapes.
  */
 export const SUMMARY_RESERVE = COMPACT_MAX_OUTPUT_TOKENS; // 20_000
 
@@ -308,6 +313,29 @@ function buildCompressionSystemPrompt(
   }
   if (parts.length === 0) return base;
   return `${base}\n\nAdditional Instructions:\n${parts.join('\n\n')}`;
+}
+
+function supportsCompressionCacheSharing(config: Config): boolean {
+  const provider = config.getContentGeneratorConfig();
+  if (provider.enableCacheControl === false) return false;
+  if (provider.authType === AuthType.USE_ANTHROPIC) return true;
+  return (
+    (provider.authType === AuthType.QWEN_OAUTH ||
+      provider.authType === AuthType.USE_OPENAI) &&
+    DashScopeOpenAICompatibleProvider.isDashScopeProvider(provider)
+  );
+}
+
+function hasStateSnapshot(summary: string): boolean {
+  const stripped = stripAnalysisBlock(summary);
+  const startTag = '<state_snapshot>';
+  const start = stripped.indexOf(startTag);
+  const end = stripped.indexOf('</state_snapshot>', start + startTag.length);
+  return (
+    start >= 0 &&
+    end > start + startTag.length &&
+    stripped.slice(start + startTag.length, end).trim().length > 0
+  );
 }
 
 export class ChatCompressionService {
@@ -563,46 +591,119 @@ export class ChatCompressionService {
       }
     }
 
-    const summaryResult = await runSideQuery(config, {
-      purpose: 'chat-compression',
-      skipOutputLanguagePreference: true,
-      model: effectiveCompactionModel,
-      // Compression uses the compaction model (config.getCompactionModel?.()) to reduce cost.
-      // Falls back to the main model if not set or if the payload exceeds the
-      // compaction model's context window.
-      // See https://github.com/QwenLM/qwen-code/issues/5956
-      // Stream so a slow compression inference keeps the HTTP connection alive.
-      // Non-streaming returns no bytes until the whole summary is generated, so
-      // behind a BFF gateway with a short `proxy_read_timeout` a long inference
-      // is killed with a 504 (surfaced as a 422) mid-compression, breaking the
-      // session. See https://github.com/QwenLM/qwen-code/issues/5861.
-      stream: true,
-      // Best-effort: failures fall back to NOOP and the next turn re-triggers
-      // compression anyway, so don't burn 7 retries blocking the user mid-turn.
-      maxAttempts: 1,
-      systemInstruction,
-      contents: [
-        ...slim.slimmedHistory,
-        {
-          role: 'user',
-          parts: [
+    const abortSignal = signal ?? new AbortController().signal;
+    const runColdCompression = () =>
+      runSideQuery(config, {
+        purpose: 'chat-compression',
+        skipOutputLanguagePreference: true,
+        model: effectiveCompactionModel,
+        // Compression uses the compaction model (config.getCompactionModel?.()) to reduce cost.
+        // Falls back to the main model if not set or if the payload exceeds the
+        // compaction model's context window.
+        // See https://github.com/QwenLM/qwen-code/issues/5956
+        // Stream so a slow compression inference keeps the HTTP connection alive.
+        // Non-streaming returns no bytes until the whole summary is generated, so
+        // behind a BFF gateway with a short `proxy_read_timeout` a long inference
+        // is killed with a 504 (surfaced as a 422) mid-compression, breaking the
+        // session. See https://github.com/QwenLM/qwen-code/issues/5861.
+        stream: true,
+        // Best-effort: failures fall back to NOOP and the next turn re-triggers
+        // compression anyway, so don't burn 7 retries blocking the user mid-turn.
+        maxAttempts: 1,
+        systemInstruction,
+        contents: [
+          ...slim.slimmedHistory,
+          {
+            role: 'user',
+            parts: [
+              {
+                text: 'First, reason in your <analysis> block. Then, produce the <state_snapshot> XML.',
+              },
+            ],
+          },
+        ],
+        // Compression output is bounded by maxOutputTokens to guarantee a predictable
+        // reserve across providers (see docs/design/auto-compaction-threshold-redesign.md).
+        // Thinking is disabled because per-provider thinking-budget semantics are
+        // inconsistent (Anthropic/OpenAI count it separately, Gemini varies by model).
+        config: {
+          thinkingConfig: { includeThoughts: false },
+          maxOutputTokens: COMPACT_MAX_OUTPUT_TOKENS,
+        },
+        abortSignal,
+        promptId,
+      });
+
+    let summaryResult: GenerateTextResult | undefined;
+    let usedCacheSharing = false;
+    const canShareCache =
+      effectiveCompactionModel === config.getModel() &&
+      slim.stats.imagesStripped === 0 &&
+      slim.stats.documentsStripped === 0 &&
+      supportsCompressionCacheSharing(config);
+    if (canShareCache) {
+      try {
+        const generationConfig = chat.getGenerationConfig();
+        const mainSystemInstruction = generationConfig.systemInstruction;
+        delete generationConfig.systemInstruction;
+        delete generationConfig.abortSignal;
+        const sharedResult = await config.getBaseLlmClient().generateText({
+          contents: [
+            ...sideQueryHistory,
             {
-              text: 'First, reason in your <analysis> block. Then, produce the <state_snapshot> XML.',
+              role: 'user',
+              parts: [
+                {
+                  text:
+                    `${systemInstruction}\n\n` +
+                    'Do not call tools; tool execution is disabled for this request. ' +
+                    'First, reason in your <analysis> block. Then, produce the <state_snapshot> XML.',
+                },
+              ],
             },
           ],
-        },
-      ],
-      // Compression output is bounded by maxOutputTokens to guarantee a predictable
-      // reserve across providers (see docs/design/auto-compaction-threshold-redesign.md).
-      // Thinking is disabled because per-provider thinking-budget semantics are
-      // inconsistent (Anthropic/OpenAI count it separately, Gemini varies by model).
-      config: {
-        thinkingConfig: { includeThoughts: false },
-        maxOutputTokens: COMPACT_MAX_OUTPUT_TOKENS,
-      },
-      abortSignal: signal ?? new AbortController().signal,
-      promptId,
-    });
+          model: effectiveCompactionModel,
+          systemInstruction: mainSystemInstruction,
+          config: {
+            ...generationConfig,
+            maxOutputTokens: COMPACT_MAX_OUTPUT_TOKENS,
+          },
+          abortSignal,
+          promptId,
+          stream: true,
+          maxAttempts: 1,
+        });
+        if (!sharedResult.hadToolCall && hasStateSnapshot(sharedResult.text)) {
+          summaryResult = sharedResult;
+          usedCacheSharing = true;
+          config
+            .getDebugLogger()
+            .debug(
+              `[chat-compression] cache-sharing request succeeded; ` +
+                `cachedContentTokenCount=` +
+                `${sharedResult.usage?.cachedContentTokenCount ?? 0}`,
+            );
+        } else {
+          config
+            .getDebugLogger()
+            .warn(
+              `[chat-compression] cache-sharing response was unusable ` +
+                `(${sharedResult.hadToolCall ? 'tool call' : 'invalid state snapshot'}); ` +
+                `falling back to the dedicated summarizer.`,
+            );
+        }
+      } catch (error) {
+        if (abortSignal.aborted) throw error;
+        config
+          .getDebugLogger()
+          .warn(
+            `[chat-compression] cache-sharing request failed; falling back ` +
+              `to the dedicated summarizer: ${String(error)}`,
+          );
+      }
+    }
+
+    summaryResult ??= await runColdCompression();
     const summary = summaryResult.text;
     // Check the PROCESSED summary: postProcessSummary strips <analysis>
     // blocks, so a response that is ONLY <analysis>...</analysis> (no
@@ -775,7 +876,10 @@ export class ChatCompressionService {
       // can still shrink the history instead of failing with a token-count
       // error.
       //
-      // Note: compressionInputTokenCount includes the entire compression
+      // The cache-sharing request also includes the main system and tools, so
+      // its input count cannot isolate visible history with a fixed subtraction;
+      // that path uses the local visible-history delta below. On the cold path,
+      // compressionInputTokenCount includes the entire compression
       // system prompt (the <state_snapshot> instructions, ~900 tokens) PLUS
       // the short kick-off user turn ("First, reason in your <analysis>
       // block. Then, produce the <state_snapshot> XML.", ~20 tokens) — the
@@ -788,6 +892,7 @@ export class ChatCompressionService {
       // suggests. We accept that inaccuracy in favor of avoiding local
       // token estimation.
       if (
+        !usedCacheSharing &&
         typeof compressionInputTokenCount === 'number' &&
         compressionInputTokenCount > 0 &&
         typeof compressionOutputTokenCount === 'number' &&
@@ -845,7 +950,11 @@ export class ChatCompressionService {
           config
             .getDebugLogger()
             .debug(
-              `[chat-compression] usage metadata missing; estimated ` +
+              `[chat-compression] ${
+                usedCacheSharing
+                  ? 'cache-sharing token accounting'
+                  : 'usage metadata missing'
+              }; estimated ` +
                 `post-compression token count by preserving the ` +
                 `API-reported non-visible remainder ` +
                 `(${estimatedNonVisibleTokenCount}) and replacing the ` +

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -19,7 +19,7 @@ import { DEFAULT_TOKEN_LIMIT } from '../core/tokenLimits.js';
 import { getCompressionPrompt } from '../core/prompts.js';
 import { runSideQuery } from '../utils/sideQuery.js';
 import { resolveModelId } from '../utils/modelId.js';
-import { supportsOpenAIPrefixCaching } from '../core/openaiContentGenerator/index.js';
+import { supportsOpenAIPrefixCaching } from '../core/openaiContentGenerator/prefix-caching.js';
 import { logChatCompression } from '../telemetry/loggers.js';
 import { makeChatCompressionEvent } from '../telemetry/types.js';
 import { PreCompactTrigger, PostCompactTrigger } from '../hooks/types.js';

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -142,6 +142,8 @@ describe('loggers', () => {
       const event = makeChatCompressionEvent({
         tokens_before: 9001,
         tokens_after: 9000,
+        cache_sharing_attempted: true,
+        cache_sharing_used: false,
       });
 
       logChatCompression(mockConfig, event);

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -559,6 +559,8 @@ export interface ChatCompressionEvent extends BaseTelemetryEvent {
   tokens_after: number;
   compression_input_token_count?: number;
   compression_output_token_count?: number;
+  cache_sharing_attempted?: boolean;
+  cache_sharing_used?: boolean;
 }
 
 export function makeChatCompressionEvent({
@@ -566,6 +568,8 @@ export function makeChatCompressionEvent({
   tokens_after,
   compression_input_token_count,
   compression_output_token_count,
+  cache_sharing_attempted,
+  cache_sharing_used,
 }: Omit<ChatCompressionEvent, CommonFields>): ChatCompressionEvent {
   return {
     'event.name': 'chat_compression',
@@ -578,6 +582,10 @@ export function makeChatCompressionEvent({
     ...(compression_output_token_count !== undefined
       ? { compression_output_token_count }
       : {}),
+    ...(cache_sharing_attempted !== undefined
+      ? { cache_sharing_attempted }
+      : {}),
+    ...(cache_sharing_used !== undefined ? { cache_sharing_used } : {}),
   };
 }
 


### PR DESCRIPTION
## What this PR does

This change lets chat compression reuse the main conversation's prompt-cache prefix when the active compression model is also the main model and the provider supports Anthropic- or DashScope-style caching. The compression request preserves the current system instruction, tool declarations, generation settings, and complete curated history, then appends the compression directive as the final user message.

The cache-sharing attempt never executes tools. A tool call, malformed state snapshot, provider error, or incompatible request shape falls back once to the existing dedicated summarizer. Cancellation continues to abort immediately.

## Why it's needed

Chat compression previously used a separate system instruction and omitted the main tool declarations. Because those fields are part of the prompt-cache key, the provider could not reuse the cached conversation prefix and had to process the full compression input again. This makes compression unnecessarily expensive for long-running sessions. The change addresses #8279 while retaining the existing cold path for unsupported providers, distinct compaction models, and media-slimmed histories.

## Reviewer Test Plan

### How to verify

1. Configure an Anthropic or DashScope-compatible model with prompt caching enabled and leave the compaction model unset so compression uses the main model.
2. Start an interactive session, add a long text-only prompt, and wait for the model response.
3. Run `/compress` and confirm that compression completes without a tool execution.
4. In debug or provider usage data, confirm that the cache-sharing request succeeds and reports non-zero cached input tokens.
5. Ask a short follow-up about the pre-compression input and confirm that the compressed history retained the answer.
6. Optionally repeat with a distinct compaction model, disabled cache control, or media-bearing history and confirm that the existing dedicated summarizer remains in use.

### Evidence (Before & After)

Using the same `qwen3.8-max-preview` Token Plan endpoint and the same 60,589-byte text fixture:

| Version | Compression input | Cached input | Uncached input | Cache hit rate |
| --- | ---: | ---: | ---: | ---: |
| Before (`74dc5547f`) | 13,684 | 0 | 13,684 | 0% |
| After (`39fcc86ce`) | 40,548 | 39,208 | 1,340 | 96.70% |

The cache-sharing request carries the main system and tools, so its total input is intentionally larger. The comparable uncached input fell by 12,344 tokens, or 90.21%. Compression completed from 39,214 to 26,433 tokens, and a post-compression follow-up correctly recovered the source path from the summarized history.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local `npm run dev`, no sandbox, `qwen3.8-max-preview` through the Token Plan OpenAI-compatible endpoint recognized as DashScope-compatible. Targeted tests: 164 passed. Build, typecheck, ESLint, Prettier, and diff checks passed.

## Risk & Scope

- Main risk or tradeoff: The cache-sharing request includes the main tool declarations and thinking configuration, which increases total prompt size and may cause a model to emit a tool call. Such responses are rejected and retried through the existing cold path.
- Not validated / out of scope: Live Anthropic-provider validation, Windows and Linux interactive validation, media-slimmed compression, and sessions intentionally using a distinct compaction model.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #8279

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当实际压缩模型与主模型相同，并且当前 provider 支持 Anthropic 或 DashScope 风格的缓存时，本改动允许聊天压缩复用主会话的 prompt cache 前缀。压缩请求会保留当前系统指令、工具声明、生成配置和完整的整理后历史，然后把压缩指令追加为最后一条用户消息。

缓存复用请求不会执行工具。若模型返回工具调用、格式错误的状态快照，或者请求失败、请求形态不兼容，则只回退一次到现有的独立摘要路径。取消操作仍会立即终止，不触发回退。

## 为什么需要它

此前聊天压缩使用独立的系统指令，并且不携带主会话的工具声明。由于这些字段属于 prompt cache key，provider 无法复用已缓存的会话前缀，只能重新处理完整的压缩输入，导致长会话的压缩成本不必要地升高。本改动解决 #8279，同时让不支持的 provider、独立压缩模型以及经过媒体瘦身的历史继续使用原有 cold path。

## Reviewer 测试计划

### 如何验证

1. 配置启用 prompt cache 的 Anthropic 或 DashScope 兼容模型，并保持压缩模型未设置，使压缩使用主模型。
2. 启动交互会话，加入较长的纯文本输入并等待模型响应。
3. 执行 `/compress`，确认压缩完成且没有执行工具。
4. 在 debug 或 provider usage 数据中确认 cache-sharing 请求成功，并且 cached input tokens 大于零。
5. 针对压缩前的输入提出一个简短追问，确认压缩后的历史仍保留正确答案。
6. 可选：分别使用独立压缩模型、关闭缓存控制或包含媒体的历史重复测试，确认仍使用现有独立摘要路径。

### Before / After 证据

使用相同的 `qwen3.8-max-preview` Token Plan 端点和相同的 60,589-byte 文本输入：

| 版本 | 压缩输入 | 缓存输入 | 未缓存输入 | 缓存命中率 |
| --- | ---: | ---: | ---: | ---: |
| 改动前（`74dc5547f`） | 13,684 | 0 | 13,684 | 0% |
| 改动后（`39fcc86ce`） | 40,548 | 39,208 | 1,340 | 96.70% |

缓存复用请求会携带主会话 system 和 tools，因此总输入按设计会更大。可比的未缓存输入减少了 12,344 tokens，即 90.21%。压缩从 39,214 tokens 降至 26,433 tokens；压缩后的追问也能从摘要历史中正确恢复源文件路径。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

本地 `npm run dev`、无 sandbox，模型为 `qwen3.8-max-preview`，使用被识别为 DashScope 兼容端点的 Token Plan OpenAI 兼容接口。目标测试共 164 项通过；build、typecheck、ESLint、Prettier 和 diff 检查均通过。

## 风险与范围

- 主要风险或权衡：缓存复用请求会携带主会话的工具声明和 thinking 配置，从而增加总 prompt 大小，并可能让模型返回工具调用。此类响应会被拒绝，并通过原有 cold path 重试。
- 未验证 / 范围外：Anthropic provider 的真实请求验证、Windows 和 Linux 交互验证、媒体瘦身压缩，以及明确使用独立压缩模型的会话。
- Breaking changes / 迁移说明：无。

## 关联 Issue

Fixes #8279

</details>
