### PR TITLE
feat(serve): make sub-session concurrency caps configurable

### DIFF
--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -17,6 +17,10 @@ import {
   type Settings,
   type SettingsSchema,
 } from './settingsSchema.js';
+import {
+  MAX_CONCURRENT_SUB_SESSIONS_PER_CALLER,
+  MAX_CONCURRENT_SUB_SESSIONS_TOTAL,
+} from '../serve/create-sub-session.js';
 
 describe('SettingsSchema', () => {
   describe('getSettingsSchema', () => {
@@ -480,6 +484,16 @@ describe('SettingsSchema', () => {
       expect(responseTokensPerSecond.default).toBe(false);
       expect(responseTokensPerSecond.showInDialog).toBe(true);
       expect(responseTokensPerSecond.requiresRestart).toBe(true);
+    });
+
+    it('should pin serve sub-session caps to the runtime defaults', () => {
+      const serve = getSettingsSchema().serve.properties;
+      expect(serve.maxConcurrentSubSessionsPerCaller.default).toBe(
+        MAX_CONCURRENT_SUB_SESSIONS_PER_CALLER,
+      );
+      expect(serve.maxConcurrentSubSessionsTotal.default).toBe(
+        MAX_CONCURRENT_SUB_SESSIONS_TOTAL,
+      );
     });
 
     it('should infer Settings type correctly', () => {

--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -20,6 +20,7 @@ import {
 import {
   MAX_CONCURRENT_SUB_SESSIONS_PER_CALLER,
   MAX_CONCURRENT_SUB_SESSIONS_TOTAL,
+  MAX_TRACKED_SPAWNED_SESSIONS,
 } from '../serve/create-sub-session.js';
 
 describe('SettingsSchema', () => {
@@ -493,6 +494,12 @@ describe('SettingsSchema', () => {
       );
       expect(serve.maxConcurrentSubSessionsTotal.default).toBe(
         MAX_CONCURRENT_SUB_SESSIONS_TOTAL,
+      );
+      // The runtime clamps the total cap to the tracked-id set size; the
+      // schema maximum must match so editors reject values that the daemon
+      // would otherwise silently clamp.
+      expect(serve.maxConcurrentSubSessionsTotal.maximum).toBe(
+        MAX_TRACKED_SPAWNED_SESSIONS,
       );
     });
 

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -310,10 +310,45 @@ const SETTINGS_SCHEMA = {
     label: 'Serve',
     category: 'Advanced',
     requiresRestart: true,
-    default: {} as { channels?: string[] },
+    default: {},
     description: 'Persistent qwen serve settings.',
     showInDialog: false,
     mergeStrategy: MergeStrategy.SHALLOW_MERGE,
+    properties: {
+      channels: {
+        type: 'array',
+        label: 'Startup Channels',
+        category: 'Advanced',
+        requiresRestart: true,
+        default: [] as string[],
+        description:
+          'Messaging channels to start automatically when the daemon boots.',
+        showInDialog: false,
+        items: { type: 'string' },
+      },
+      maxConcurrentSubSessionsPerCaller: {
+        type: 'integer',
+        label: 'Max Concurrent Sub-Sessions Per Caller',
+        category: 'Advanced',
+        requiresRestart: true,
+        default: 16,
+        minimum: 1,
+        description:
+          'Per-session ceiling on concurrent in-flight sub-sessions spawned via the create_sub_session tool.',
+        showInDialog: false,
+      },
+      maxConcurrentSubSessionsTotal: {
+        type: 'integer',
+        label: 'Max Concurrent Sub-Sessions Total',
+        category: 'Advanced',
+        requiresRestart: true,
+        default: 24,
+        minimum: 1,
+        description:
+          'Workspace-wide ceiling on concurrent in-flight sub-sessions across all callers.',
+        showInDialog: false,
+      },
+    },
   },
 
   // Model providers configuration grouped by authType

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -344,6 +344,7 @@ const SETTINGS_SCHEMA = {
         requiresRestart: true,
         default: 24,
         minimum: 1,
+        maximum: 1024,
         description:
           'Workspace-wide ceiling on concurrent in-flight sub-sessions across all callers.',
         showInDialog: false,

--- a/packages/cli/src/serve/create-sub-session.test.ts
+++ b/packages/cli/src/serve/create-sub-session.test.ts
@@ -17,6 +17,7 @@ const {
   createSubSessionLauncher,
   MAX_CONCURRENT_SUB_SESSIONS_PER_CALLER,
   MAX_CONCURRENT_SUB_SESSIONS_TOTAL,
+  MAX_TRACKED_SPAWNED_SESSIONS,
 } = await import('./create-sub-session.js');
 
 type FakeEvent = { type: string; data: unknown };
@@ -582,6 +583,30 @@ describe('sub-session launcher', () => {
       }),
     ).rejects.toThrow(/cap 3/);
     expect(fake.spawns).toHaveLength(3);
+    launcher.stop();
+  });
+
+  it('clamps the total cap to the tracked-id set size', async () => {
+    const fake = makeFakeBridge({ events: () => [], blockAfterEvents: true });
+    const launcher = createSubSessionLauncher({
+      getBridge: () => fake.bridge,
+      boundWorkspace: WS,
+      maxConcurrentTotal: MAX_TRACKED_SPAWNED_SESSIONS + 100,
+    });
+    for (let i = 0; i < MAX_TRACKED_SPAWNED_SESSIONS; i++) {
+      await launcher.launch({
+        prompt: `p${i}`,
+        completion: 'sent',
+        callerSessionId: `c-${i}`,
+      });
+    }
+    await expect(
+      launcher.launch({
+        prompt: 'overflow',
+        completion: 'sent',
+        callerSessionId: 'c-overflow',
+      }),
+    ).rejects.toThrow(`cap ${MAX_TRACKED_SPAWNED_SESSIONS}`);
     launcher.stop();
   });
 

--- a/packages/cli/src/serve/create-sub-session.test.ts
+++ b/packages/cli/src/serve/create-sub-session.test.ts
@@ -304,6 +304,34 @@ describe('sub-session launcher', () => {
     expect(fake.spawns).toHaveLength(MAX_CONCURRENT_SUB_SESSIONS_PER_CALLER);
   });
 
+  it('honors a custom per-caller cap from launcher options', async () => {
+    const fake = makeFakeBridge({ blockAfterEvents: true });
+    const launcher = createSubSessionLauncher({
+      getBridge: () => fake.bridge,
+      boundWorkspace: WS,
+      firstTurnTimeoutMs: 80, // held runs settle via timeout so the test ends
+      maxConcurrentPerCaller: 2,
+    });
+
+    const promises = [];
+    for (let i = 0; i < 3; i++) {
+      promises.push(
+        launcher.launch({
+          prompt: `p${i}`,
+          completion: 'first-turn',
+          callerSessionId: 'same-caller',
+        }),
+      );
+    }
+    const settled = await Promise.allSettled(promises);
+    const rejected = settled.filter((s) => s.status === 'rejected');
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason.message).toContain(
+      'cap 2',
+    );
+    expect(fake.spawns).toHaveLength(2);
+  });
+
   it('rejects when the bridge is unavailable', async () => {
     const launcher = createSubSessionLauncher({
       getBridge: () => undefined,
@@ -532,9 +560,35 @@ describe('sub-session launcher', () => {
     launcher.stop();
   });
 
+  it('honors a custom workspace-wide cap from launcher options', async () => {
+    const fake = makeFakeBridge({ events: () => [], blockAfterEvents: true });
+    const launcher = createSubSessionLauncher({
+      getBridge: () => fake.bridge,
+      boundWorkspace: WS,
+      maxConcurrentTotal: 3,
+    });
+    for (let i = 0; i < 3; i++) {
+      await launcher.launch({
+        prompt: `p${i}`,
+        completion: 'sent',
+        callerSessionId: `rotated-${i}`, // a fresh bucket every time
+      });
+    }
+    await expect(
+      launcher.launch({
+        prompt: 'overflow',
+        completion: 'sent',
+        callerSessionId: 'rotated-fresh',
+      }),
+    ).rejects.toThrow(/cap 3/);
+    expect(fake.spawns).toHaveLength(3);
+    launcher.stop();
+  });
+
   it('refuses to spawn from a session it already spawned (depth-1 gate)', async () => {
     // Every daemon session wires a spawner, sub-sessions included, and each
-    // gets its own cap-sized bucket. Without this gate one prompt fans out 5ⁿ.
+    // gets its own cap-sized bucket. Without this gate one prompt fans out
+    // capⁿ.
     const fake = makeFakeBridge({ events: (pid) => [turnComplete(pid)] });
     const launcher = createSubSessionLauncher({
       getBridge: () => fake.bridge,

--- a/packages/cli/src/serve/create-sub-session.ts
+++ b/packages/cli/src/serve/create-sub-session.ts
@@ -46,15 +46,16 @@ import { writeStderrLine } from '../utils/stdioHelpers.js';
 
 const log = createDebugLogger('SUB_SESSION');
 
-/** Per-caller ceiling on concurrent in-flight sub-sessions. A `first-turn`
- * request holds a slot until its turn finishes; parallel tool calls from one
- * caller must not spawn unbounded sub-sessions. Over the cap the request is
- * rejected (surfaced as the tool's error), never silently dropped. */
-export const MAX_CONCURRENT_SUB_SESSIONS_PER_CALLER = 5;
+/** Default per-caller ceiling on concurrent in-flight sub-sessions. A
+ * `first-turn` request holds a slot until its turn finishes; parallel tool
+ * calls from one caller must not spawn unbounded sub-sessions. Over the cap
+ * the request is rejected (surfaced as the tool's error), never silently
+ * dropped. Overridable via `serve.maxConcurrentSubSessionsPerCaller`. */
+export const MAX_CONCURRENT_SUB_SESSIONS_PER_CALLER = 16;
 
 /**
- * Ceiling on concurrent in-flight sub-sessions across ALL callers of this
- * workspace's launcher.
+ * Default ceiling on concurrent in-flight sub-sessions across ALL callers of
+ * this workspace's launcher.
  *
  * The per-caller cap is keyed on `callerSessionId`, and the daemon can only
  * authenticate that id as "a session on this channel" — every session of a
@@ -62,9 +63,15 @@ export const MAX_CONCURRENT_SUB_SESSIONS_PER_CALLER = 5;
  * *which* of them issued the call. A child running attacker code could rotate
  * ids to open a fresh bucket per launch, or charge them to a sibling. This
  * bound does not depend on the id being honest: it holds whichever bucket the
- * launch is charged to.
+ * launch is charged to. Overridable via
+ * `serve.maxConcurrentSubSessionsTotal`.
+ *
+ * Kept below the bridge's default `maxSessions` (32): a finished sub-session
+ * stays registered (idle) for up to `sessionIdleTimeoutMs`, so a total cap at
+ * the session-table limit would make the next fan-out wave fail at bridge
+ * admission instead of this cap, and starve interactive sessions of slots.
  */
-export const MAX_CONCURRENT_SUB_SESSIONS_TOTAL = 20;
+export const MAX_CONCURRENT_SUB_SESSIONS_TOTAL = 24;
 
 /** Wall-clock ceiling for `first-turn`: a hung sub-session turn must not block
  * the caller forever. On timeout we return whatever text accumulated so far. */
@@ -105,6 +112,12 @@ export interface CreateSubSessionLauncherOptions {
   /** Sent-mode background-drain ceiling; defaults to
    * {@link SENT_MODE_DRAIN_TIMEOUT_MS}. Exposed for tests. */
   sentModeDrainTimeoutMs?: number;
+  /** Per-caller concurrency cap; defaults to
+   * {@link MAX_CONCURRENT_SUB_SESSIONS_PER_CALLER}. */
+  maxConcurrentPerCaller?: number;
+  /** Workspace-wide concurrency cap; defaults to
+   * {@link MAX_CONCURRENT_SUB_SESSIONS_TOTAL}. */
+  maxConcurrentTotal?: number;
 }
 
 /** A readable, control-char-free session name (the bridge's title guard rejects
@@ -250,6 +263,10 @@ export function createSubSessionLauncher(
   const firstTurnTimeoutMs = opts.firstTurnTimeoutMs ?? FIRST_TURN_TIMEOUT_MS;
   const sentModeDrainTimeoutMs =
     opts.sentModeDrainTimeoutMs ?? SENT_MODE_DRAIN_TIMEOUT_MS;
+  const maxConcurrentPerCaller =
+    opts.maxConcurrentPerCaller ?? MAX_CONCURRENT_SUB_SESSIONS_PER_CALLER;
+  const maxConcurrentTotal =
+    opts.maxConcurrentTotal ?? MAX_CONCURRENT_SUB_SESSIONS_TOTAL;
   const inflight = new Map<string, number>();
   // Ids of the sub-sessions this launcher spawned — the depth-1 gate reads it.
   // Insertion-ordered and evicted FIFO past the cap so a long-lived daemon
@@ -295,9 +312,9 @@ export function createSubSessionLauncher(
     }
 
     // Depth-1 gate. Every daemon session wires a spawner, sub-sessions included,
-    // and each gets its own 5-slot bucket — so without this a sub-session can
-    // spawn 5 more, each of which spawns 5 more (5ⁿ), exhausting `maxSessions`
-    // from one prompt. `callerSessionId` is required and authenticated at the
+    // and each gets its own bucket — so without this a sub-session can spawn
+    // more, each of which spawns more (capⁿ), exhausting `maxSessions` from
+    // one prompt. `callerSessionId` is required and authenticated at the
     // bridge (`ownsSession`), so it can neither be forged nor omitted to
     // sidestep this gate or the per-caller cap below.
     if (spawnedSessionIds.has(info.callerSessionId)) {
@@ -312,18 +329,18 @@ export function createSubSessionLauncher(
     // own bucket, which is the same as having no cap at all.
     const key = info.callerSessionId;
     const current = inflight.get(key) ?? 0;
-    if (current >= MAX_CONCURRENT_SUB_SESSIONS_PER_CALLER) {
+    if (current >= maxConcurrentPerCaller) {
       throw new Error(
         `Too many concurrent sub-sessions for this session ` +
-          `(cap ${MAX_CONCURRENT_SUB_SESSIONS_PER_CALLER}); wait for one to finish.`,
+          `(cap ${maxConcurrentPerCaller}); wait for one to finish.`,
       );
     }
     // Forge-proof backstop: the per-caller cap above trusts `callerSessionId`,
     // this one does not. See MAX_CONCURRENT_SUB_SESSIONS_TOTAL.
-    if (inflightTotal >= MAX_CONCURRENT_SUB_SESSIONS_TOTAL) {
+    if (inflightTotal >= maxConcurrentTotal) {
       throw new Error(
         `Too many concurrent sub-sessions in this workspace ` +
-          `(cap ${MAX_CONCURRENT_SUB_SESSIONS_TOTAL}); wait for one to finish.`,
+          `(cap ${maxConcurrentTotal}); wait for one to finish.`,
       );
     }
     inflight.set(key, current + 1);

--- a/packages/cli/src/serve/create-sub-session.ts
+++ b/packages/cli/src/serve/create-sub-session.ts
@@ -66,7 +66,7 @@ export const MAX_CONCURRENT_SUB_SESSIONS_PER_CALLER = 16;
  * launch is charged to. Overridable via
  * `serve.maxConcurrentSubSessionsTotal`.
  *
- * Kept below the bridge's default `maxSessions` (32): a finished sub-session
+ * The default is kept below the bridge's default `maxSessions` (32): a finished sub-session
  * stays registered (idle) for up to `sessionIdleTimeoutMs`, so a total cap at
  * the session-table limit would make the next fan-out wave fail at bridge
  * admission instead of this cap, and starve interactive sessions of slots.

--- a/packages/cli/src/serve/create-sub-session.ts
+++ b/packages/cli/src/serve/create-sub-session.ts
@@ -265,8 +265,11 @@ export function createSubSessionLauncher(
     opts.sentModeDrainTimeoutMs ?? SENT_MODE_DRAIN_TIMEOUT_MS;
   const maxConcurrentPerCaller =
     opts.maxConcurrentPerCaller ?? MAX_CONCURRENT_SUB_SESSIONS_PER_CALLER;
-  // Clamped to the tracked-id set size so the depth-1 gate's FIFO eviction
-  // never discards a still-alive sub-session id.
+  // Clamped to the tracked-id set size so the in-flight population can never
+  // exceed it. This bounds concurrency, not the depth-1 gate: ids leave
+  // `spawnedSessionIds` only by FIFO eviction past that cap (finished ids are
+  // never removed), so once cumulative spawns pass it a still-alive id can
+  // still be evicted and the gate degrades to best-effort.
   const maxConcurrentTotal = Math.min(
     opts.maxConcurrentTotal ?? MAX_CONCURRENT_SUB_SESSIONS_TOTAL,
     MAX_TRACKED_SPAWNED_SESSIONS,

--- a/packages/cli/src/serve/create-sub-session.ts
+++ b/packages/cli/src/serve/create-sub-session.ts
@@ -93,7 +93,7 @@ const MAX_NAME_LENGTH = 60;
 /** How many spawned sub-session ids the depth-1 gate remembers. Far above any
  * plausible live sub-session count (`maxSessions` defaults to 32), so eviction
  * only ever discards long-reaped sessions. */
-const MAX_TRACKED_SPAWNED_SESSIONS = 1024;
+export const MAX_TRACKED_SPAWNED_SESSIONS = 1024;
 
 export interface SubSessionLauncher {
   /** The `onCreateSubSession` callback wired into the bridge. Returns a Promise
@@ -265,8 +265,12 @@ export function createSubSessionLauncher(
     opts.sentModeDrainTimeoutMs ?? SENT_MODE_DRAIN_TIMEOUT_MS;
   const maxConcurrentPerCaller =
     opts.maxConcurrentPerCaller ?? MAX_CONCURRENT_SUB_SESSIONS_PER_CALLER;
-  const maxConcurrentTotal =
-    opts.maxConcurrentTotal ?? MAX_CONCURRENT_SUB_SESSIONS_TOTAL;
+  // Clamped to the tracked-id set size so the depth-1 gate's FIFO eviction
+  // never discards a still-alive sub-session id.
+  const maxConcurrentTotal = Math.min(
+    opts.maxConcurrentTotal ?? MAX_CONCURRENT_SUB_SESSIONS_TOTAL,
+    MAX_TRACKED_SPAWNED_SESSIONS,
+  );
   const inflight = new Map<string, number>();
   // Ids of the sub-sessions this launcher spawned — the depth-1 gate reads it.
   // Insertion-ordered and evicted FIFO past the cap so a long-lived daemon

--- a/packages/cli/src/serve/run-qwen-serve.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.test.ts
@@ -22,6 +22,7 @@ import {
   resolveRuntimeStartupTimeoutMs,
   runQwenServe,
   type RunHandle,
+  subSessionConcurrencyCapsFromSettings,
   validatePolicyConfig,
   waitForRuntimeStartingForShutdown,
 } from './run-qwen-serve.js';
@@ -776,6 +777,47 @@ describe('extractContextFilename (#4297 fold-in 7 P2-1 helper)', () => {
     expect(extractContextFilename(42)).toBeUndefined();
     expect(extractContextFilename(true)).toBeUndefined();
     expect(extractContextFilename({ fileName: 'AGENTS.md' })).toBeUndefined();
+  });
+});
+
+describe('subSessionConcurrencyCapsFromSettings', () => {
+  it('passes through positive integer caps', () => {
+    expect(
+      subSessionConcurrencyCapsFromSettings({
+        maxConcurrentSubSessionsPerCaller: 8,
+        maxConcurrentSubSessionsTotal: 12,
+      }),
+    ).toEqual({ maxConcurrentPerCaller: 8, maxConcurrentTotal: 12 });
+  });
+
+  it('omits absent keys so launcher defaults apply', () => {
+    expect(subSessionConcurrencyCapsFromSettings({})).toEqual({});
+  });
+
+  it('rejects values outside positive integers', () => {
+    // Hand-edited settings.json could land any of these; coercing (e.g.
+    // accepting 0 or "10") would silently disable or misread a resource cap.
+    expect(
+      subSessionConcurrencyCapsFromSettings({
+        maxConcurrentSubSessionsPerCaller: 0,
+        maxConcurrentSubSessionsTotal: -1,
+      }),
+    ).toEqual({});
+    expect(
+      subSessionConcurrencyCapsFromSettings({
+        maxConcurrentSubSessionsPerCaller: 2.5,
+        maxConcurrentSubSessionsTotal: '10',
+      }),
+    ).toEqual({});
+  });
+
+  it('keeps a valid cap when the sibling key is invalid', () => {
+    expect(
+      subSessionConcurrencyCapsFromSettings({
+        maxConcurrentSubSessionsPerCaller: 8,
+        maxConcurrentSubSessionsTotal: Number.NaN,
+      }),
+    ).toEqual({ maxConcurrentPerCaller: 8 });
   });
 });
 

--- a/packages/cli/src/serve/run-qwen-serve.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.test.ts
@@ -797,27 +797,60 @@ describe('subSessionConcurrencyCapsFromSettings', () => {
   it('rejects values outside positive integers', () => {
     // Hand-edited settings.json could land any of these; coercing (e.g.
     // accepting 0 or "10") would silently disable or misread a resource cap.
+    const onWarning = vi.fn();
     expect(
-      subSessionConcurrencyCapsFromSettings({
-        maxConcurrentSubSessionsPerCaller: 0,
-        maxConcurrentSubSessionsTotal: -1,
-      }),
+      subSessionConcurrencyCapsFromSettings(
+        {
+          maxConcurrentSubSessionsPerCaller: 0,
+          maxConcurrentSubSessionsTotal: -1,
+        },
+        onWarning,
+      ),
     ).toEqual({});
     expect(
-      subSessionConcurrencyCapsFromSettings({
-        maxConcurrentSubSessionsPerCaller: 2.5,
-        maxConcurrentSubSessionsTotal: '10',
-      }),
+      subSessionConcurrencyCapsFromSettings(
+        {
+          maxConcurrentSubSessionsPerCaller: 2.5,
+          maxConcurrentSubSessionsTotal: '10',
+        },
+        onWarning,
+      ),
     ).toEqual({});
+    expect(onWarning).toHaveBeenCalledTimes(4);
   });
 
   it('keeps a valid cap when the sibling key is invalid', () => {
     expect(
-      subSessionConcurrencyCapsFromSettings({
-        maxConcurrentSubSessionsPerCaller: 8,
-        maxConcurrentSubSessionsTotal: Number.NaN,
-      }),
+      subSessionConcurrencyCapsFromSettings(
+        {
+          maxConcurrentSubSessionsPerCaller: 8,
+          maxConcurrentSubSessionsTotal: Number.NaN,
+        },
+        () => {},
+      ),
     ).toEqual({ maxConcurrentPerCaller: 8 });
+  });
+
+  it('warns naming a present-but-invalid cap', () => {
+    const onWarning = vi.fn();
+    expect(
+      subSessionConcurrencyCapsFromSettings(
+        { maxConcurrentSubSessionsTotal: '50' },
+        onWarning,
+      ),
+    ).toEqual({});
+    expect(onWarning).toHaveBeenCalledTimes(1);
+    expect(onWarning.mock.calls[0][0]).toContain(
+      'maxConcurrentSubSessionsTotal',
+    );
+    // JSON.stringify keeps the quotes, revealing the value is a string.
+    expect(onWarning.mock.calls[0][0]).toContain('"50"');
+  });
+
+  it('does not warn when the keys are absent', () => {
+    const onWarning = vi.fn();
+    subSessionConcurrencyCapsFromSettings({}, onWarning);
+    expect(onWarning).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -685,23 +685,42 @@ function sessionArtifactsPersistenceAvailableFromSettings(
 /**
  * Reads the optional `serve.maxConcurrentSubSessions*` overrides. Only
  * positive integers are honored; anything else falls back to the launcher's
- * built-in defaults. Caps are a daemon-resource control, so an untrusted
+ * built-in defaults. A present-but-invalid value is reported through
+ * `onWarning` (matching the other settings-load fallback sites in this file)
+ * so an operator who mistypes a cap sees the fallback instead of silently
+ * running on the default. Caps are a daemon-resource control, so an untrusted
  * workspace's settings (skipped at load time) must not raise them — the
  * caller passes the already trust-filtered merged settings.
  */
-export function subSessionConcurrencyCapsFromSettings(serve: {
-  maxConcurrentSubSessionsPerCaller?: unknown;
-  maxConcurrentSubSessionsTotal?: unknown;
-}): {
+export function subSessionConcurrencyCapsFromSettings(
+  serve: {
+    maxConcurrentSubSessionsPerCaller?: unknown;
+    maxConcurrentSubSessionsTotal?: unknown;
+  },
+  onWarning: (message: string) => void = writeStderrLine,
+): {
   maxConcurrentPerCaller?: number;
   maxConcurrentTotal?: number;
 } {
-  const asCap = (value: unknown): number | undefined =>
-    typeof value === 'number' && Number.isInteger(value) && value >= 1
-      ? value
-      : undefined;
-  const maxConcurrentPerCaller = asCap(serve.maxConcurrentSubSessionsPerCaller);
-  const maxConcurrentTotal = asCap(serve.maxConcurrentSubSessionsTotal);
+  const asCap = (key: string, value: unknown): number | undefined => {
+    if (value === undefined) return undefined;
+    if (typeof value === 'number' && Number.isInteger(value) && value >= 1) {
+      return value;
+    }
+    onWarning(
+      `qwen serve: ignoring invalid ${key} (${JSON.stringify(value)}); ` +
+        `expected a positive integer, falling back to the built-in default.`,
+    );
+    return undefined;
+  };
+  const maxConcurrentPerCaller = asCap(
+    'maxConcurrentSubSessionsPerCaller',
+    serve.maxConcurrentSubSessionsPerCaller,
+  );
+  const maxConcurrentTotal = asCap(
+    'maxConcurrentSubSessionsTotal',
+    serve.maxConcurrentSubSessionsTotal,
+  );
   return {
     ...(maxConcurrentPerCaller !== undefined ? { maxConcurrentPerCaller } : {}),
     ...(maxConcurrentTotal !== undefined ? { maxConcurrentTotal } : {}),

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -683,6 +683,34 @@ function sessionArtifactsPersistenceAvailableFromSettings(
 }
 
 /**
+ * Reads the optional `serve.maxConcurrentSubSessions*` overrides. Only
+ * positive integers are honored; anything else falls back to the launcher's
+ * built-in defaults. Caps are a daemon-resource control, so an untrusted
+ * workspace's settings (skipped at load time) must not raise them — the
+ * caller passes the already trust-filtered merged settings.
+ */
+export function subSessionConcurrencyCapsFromSettings(serve: {
+  maxConcurrentSubSessionsPerCaller?: unknown;
+  maxConcurrentSubSessionsTotal?: unknown;
+}): {
+  maxConcurrentPerCaller?: number;
+  maxConcurrentTotal?: number;
+} {
+  const asCap = (value: unknown): number | undefined =>
+    typeof value === 'number' && Number.isInteger(value) && value >= 1
+      ? value
+      : undefined;
+  const maxConcurrentPerCaller = asCap(
+    serve?.maxConcurrentSubSessionsPerCaller,
+  );
+  const maxConcurrentTotal = asCap(serve?.maxConcurrentSubSessionsTotal);
+  return {
+    ...(maxConcurrentPerCaller !== undefined ? { maxConcurrentPerCaller } : {}),
+    ...(maxConcurrentTotal !== undefined ? { maxConcurrentTotal } : {}),
+  };
+}
+
+/**
  * Per-workspace promise chain that serializes settings read-modify-write
  * cycles inside this process.
  *
@@ -3682,6 +3710,9 @@ async function runQwenServeImpl(
     const subSessionLauncher = createSubSessionLauncher({
       getBridge: () => bridgeRef,
       boundWorkspace,
+      ...subSessionConcurrencyCapsFromSettings(
+        runtimeBootSettings?.merged.serve ?? {},
+      ),
     });
     const bridge =
       deps.bridge ??
@@ -4077,6 +4108,9 @@ async function runQwenServeImpl(
       const secondarySubSessionLauncher = createSubSessionLauncher({
         getBridge: () => secondaryBridgeRef,
         boundWorkspace: workspaceInput.cwd,
+        ...subSessionConcurrencyCapsFromSettings(
+          secondarySettings?.merged.serve ?? {},
+        ),
       });
       const secondaryBridge = runtime.createAcpSessionBridge({
         clientMcpSender: secondaryClientMcpSenderRegistry.lookup,
@@ -4575,6 +4609,9 @@ async function runQwenServeImpl(
       const wsSubSessionLauncher = createSubSessionLauncher({
         getBridge: () => wsBridgeRef,
         boundWorkspace: cwd,
+        ...subSessionConcurrencyCapsFromSettings(
+          wsSettings?.merged.serve ?? {},
+        ),
       });
       let wsBridge: ReturnType<typeof runtime.createAcpSessionBridge>;
       try {

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -700,10 +700,8 @@ export function subSessionConcurrencyCapsFromSettings(serve: {
     typeof value === 'number' && Number.isInteger(value) && value >= 1
       ? value
       : undefined;
-  const maxConcurrentPerCaller = asCap(
-    serve?.maxConcurrentSubSessionsPerCaller,
-  );
-  const maxConcurrentTotal = asCap(serve?.maxConcurrentSubSessionsTotal);
+  const maxConcurrentPerCaller = asCap(serve.maxConcurrentSubSessionsPerCaller);
+  const maxConcurrentTotal = asCap(serve.maxConcurrentSubSessionsTotal);
   return {
     ...(maxConcurrentPerCaller !== undefined ? { maxConcurrentPerCaller } : {}),
     ...(maxConcurrentTotal !== undefined ? { maxConcurrentTotal } : {}),

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -16,7 +16,27 @@
     "serve": {
       "description": "Persistent qwen serve settings.",
       "type": "object",
-      "additionalProperties": true
+      "properties": {
+        "channels": {
+          "description": "Messaging channels to start automatically when the daemon boots.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "maxConcurrentSubSessionsPerCaller": {
+          "description": "Per-session ceiling on concurrent in-flight sub-sessions spawned via the create_sub_session tool.",
+          "type": "integer",
+          "default": 16,
+          "minimum": 1
+        },
+        "maxConcurrentSubSessionsTotal": {
+          "description": "Workspace-wide ceiling on concurrent in-flight sub-sessions across all callers.",
+          "type": "integer",
+          "default": 24,
+          "minimum": 1
+        }
+      }
     },
     "modelProviders": {
       "description": "Model providers configuration keyed by provider id (a built-in AuthType such as \"openai\" or \"gemini\", or a custom id mapped via providerProtocol). Each entry is an array of model configurations.",

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -34,7 +34,8 @@
           "description": "Workspace-wide ceiling on concurrent in-flight sub-sessions across all callers.",
           "type": "integer",
           "default": 24,
-          "minimum": 1
+          "minimum": 1,
+          "maximum": 1024
         }
       }
     },


### PR DESCRIPTION
## What this PR does

Makes the two concurrency ceilings on `create_sub_session` sub-sessions configurable through `serve.maxConcurrentSubSessionsPerCaller` and `serve.maxConcurrentSubSessionsTotal` in settings.json, and raises the built-in defaults from 5 to 16 (per caller) and 20 to 24 (workspace-wide). Both settings are restart-required, validated as positive integers with anything else falling back to the defaults, and applied uniformly to the primary workspace, secondary workspaces, and dynamically registered workspaces. Because caps are a daemon-resource control, they are read from trust-filtered settings — an untrusted workspace's settings file cannot raise them.

## Why it's needed

The per-caller cap of 5 was hardcoded and too tight for legitimate parallel fan-out: a single batch-style workflow with 6–8 workers plus a research agent already exhausts it, and the only remedy was waiting. The workspace-total default of 24 is deliberately kept below the bridge's default session-table size (32): a finished sub-session stays registered until idle-reaped (up to 30 minutes by default), so a total cap at the table limit would make the next fan-out wave fail at bridge admission with a confusing error instead of the clear "cap N; wait for one to finish" rejection, and would starve interactive sessions of slots.

## Reviewer Test Plan

### How to verify

1. Unit level: run `cd packages/cli && npx vitest run src/serve/create-sub-session.test.ts` (two new tests prove custom launcher caps are honored, including the exact "cap 2" / "cap 3" wording in rejection messages) and `npx vitest run src/serve/run-qwen-serve.test.ts -t subSessionConcurrencyCapsFromSettings` (settings parsing: positive integers pass through; 0, negatives, fractions, strings, and NaN fall back to defaults).
2. Behavior level: start `qwen serve` with `"serve": { "maxConcurrentSubSessionsPerCaller": 2 }` in settings.json, then from any session trigger three parallel `create_sub_session` calls with `completion: "first-turn"` — the third should fail immediately with `Too many concurrent sub-sessions for this session (cap 2)`. Without the setting, the same experiment now admits 16 before rejecting.
3. Confirm `npm run generate:settings-schema` produces no diff (the committed JSON schema is in sync).

### Evidence (Before & After)

N/A — daemon-behavior change with no UI surface; coverage is at the unit level (20 launcher tests, 212 serve tests, settings-schema tests all green locally).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests, build, typecheck, and lint only (`npm run build`, `npm run typecheck`, eslint on changed files). Not yet exercised against a live daemon with real model fan-out.

## Risk & Scope

- Main risk or tradeoff: the higher per-caller default admits up to 16 concurrent model turns from one session, increasing API rate-limit pressure; worst case is visible 429-style tool errors for the caller, never daemon damage — the depth-1 nesting gate and the workspace-wide total still bound overall growth.
- Not validated / out of scope: live-daemon E2E with real model calls; raising the bridge session-table size alongside very large totals is left to the existing `maxSessions` knob.
- Breaking changes / migration notes: none. Additive settings with safe fallback parsing; defaults only loosen, never tighten.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

将 `create_sub_session` 子会话的两道并发上限改为可通过 settings.json 中的 `serve.maxConcurrentSubSessionsPerCaller` 和 `serve.maxConcurrentSubSessionsTotal` 配置，并把内置默认值从 5 提高到 16（单会话）、从 20 提高到 24（整个 workspace）。两个设置均为重启后生效，按正整数校验，非法值回落到默认值，并统一应用于主 workspace、secondary workspace 和动态注册的 workspace。由于上限属于 daemon 资源控制，读取的是经过信任过滤的设置——未受信任的 workspace 的设置文件无法抬高它。

## 为什么需要

单会话上限 5 是写死的，对正常的并行 fan-out 来说太紧：一个 6–8 个 worker 的批处理工作流再加一个 research agent 就会把它打满，唯一的办法就是等待。workspace 总上限默认值 24 刻意保持在 bridge 默认会话表大小（32）之下：结束的子会话在被 idle 回收前（默认最长 30 分钟）会一直占用会话表槽位，如果总上限顶到表大小，下一波 fan-out 会在 bridge 准入处失败并报出难以理解的错误，而不是清晰的“cap N；等待一个完成”拒绝，同时还会饿死交互会话的槽位。

## 评审者测试计划

### 如何验证

1. 单元层面：运行 `cd packages/cli && npx vitest run src/serve/create-sub-session.test.ts`（两个新测试证明自定义 launcher 上限生效，包括拒绝消息中精确的“cap 2”/“cap 3”措辞），以及 `npx vitest run src/serve/run-qwen-serve.test.ts -t subSessionConcurrencyCapsFromSettings`（设置解析：正整数透传；0、负数、小数、字符串和 NaN 回落默认值）。
2. 行为层面：在 settings.json 中配置 `"serve": { "maxConcurrentSubSessionsPerCaller": 2 }` 后启动 `qwen serve`，然后从任意会话触发三个并行的 `create_sub_session` 调用（`completion: "first-turn"`）——第三个应立即失败并提示 `Too many concurrent sub-sessions for this session (cap 2)`。不配置时，同样实验现在允许 16 个之后才会拒绝。
3. 确认 `npm run generate:settings-schema` 无 diff（提交的 JSON schema 保持同步）。

### 证据（前后对比）

N/A——daemon 行为变更，无 UI 界面；覆盖在单元层面（20 个 launcher 测试、212 个 serve 测试、settings-schema 测试本地全绿）。

### 测试平台

macOS ✅；Windows ⚠️ 未测；Linux ⚠️ 未测。

### 环境（可选）

仅单元测试、构建、类型检查和 lint（`npm run build`、`npm run typecheck`、对改动文件的 eslint）。尚未在真实 daemon 上用真实模型 fan-out 验证。

## 风险与范围

- 主要风险或取舍：更高的单会话默认值允许一个会话最多 16 个并发模型轮次，增加 API 限流压力；最坏情况是调用方看到 429 类工具错误，绝不会损伤 daemon——depth-1 嵌套门和 workspace 总上限仍然约束总体增长。
- 未验证 / 超出范围：真实模型调用的 live daemon E2E；在配置很大总上限时需要一并调大 bridge 会话表，这留给现有的 `maxSessions` 配置。
- 破坏性变更 / 迁移说明：无。新增设置带安全回落解析；默认值只放宽不收紧。

## 关联 Issue

N/A

</details>
