### PR TITLE
fix(cli): allow pasting sensitive extension settings

### DIFF
--- a/packages/cli/src/ui/components/SettingInputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/SettingInputPrompt.test.tsx
@@ -108,9 +108,9 @@ describe('SettingInputPrompt', () => {
     expect(lastFrame()).toContain('Enter your password');
   });
 
-  it('sanitizes and appends pasted sensitive values', () => {
+  it('keeps printable ASCII boundaries and ignores control-only pastes', () => {
     const prefix = 'X';
-    const secret = 'AIza-test-key';
+    const secret = 'AIza~ test-key';
     const { lastFrame } = render(
       <SettingInputPrompt
         settingName="API_KEY"
@@ -128,11 +128,19 @@ describe('SettingInputPrompt', () => {
 
     act(() => {
       mockedUseKeypress.mock.calls.at(-1)?.[0](
-        makeKey({ paste: true, sequence: `${secret}\r\n\x1b` }),
+        makeKey({ paste: true, sequence: `${secret}\x1f\x7f\r\n\x1b` }),
       );
     });
 
     expect(lastFrame()).not.toContain(secret);
+    expect(lastFrame()).toContain('*'.repeat(prefix.length + secret.length));
+
+    act(() => {
+      mockedUseKeypress.mock.calls.at(-1)?.[0](
+        makeKey({ paste: true, sequence: '\x1f\x7f\r\n\x1b' }),
+      );
+    });
+
     expect(lastFrame()).toContain('*'.repeat(prefix.length + secret.length));
 
     act(() => {

--- a/packages/cli/src/ui/components/SettingInputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/SettingInputPrompt.test.tsx
@@ -108,7 +108,7 @@ describe('SettingInputPrompt', () => {
     expect(lastFrame()).toContain('Enter your password');
   });
 
-  it('accepts pasted sensitive values', () => {
+  it('sanitizes pasted sensitive values', () => {
     const secret = 'AIza-test-key';
     const { lastFrame } = render(
       <SettingInputPrompt
@@ -123,7 +123,7 @@ describe('SettingInputPrompt', () => {
 
     act(() => {
       mockedUseKeypress.mock.calls.at(-1)?.[0](
-        makeKey({ paste: true, sequence: secret }),
+        makeKey({ paste: true, sequence: `${secret}\r\n\x1b` }),
       );
     });
 

--- a/packages/cli/src/ui/components/SettingInputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/SettingInputPrompt.test.tsx
@@ -108,7 +108,8 @@ describe('SettingInputPrompt', () => {
     expect(lastFrame()).toContain('Enter your password');
   });
 
-  it('sanitizes pasted sensitive values', () => {
+  it('sanitizes and appends pasted sensitive values', () => {
+    const prefix = 'X';
     const secret = 'AIza-test-key';
     const { lastFrame } = render(
       <SettingInputPrompt
@@ -122,13 +123,17 @@ describe('SettingInputPrompt', () => {
     );
 
     act(() => {
+      mockedUseKeypress.mock.calls.at(-1)?.[0](makeKey({ sequence: prefix }));
+    });
+
+    act(() => {
       mockedUseKeypress.mock.calls.at(-1)?.[0](
         makeKey({ paste: true, sequence: `${secret}\r\n\x1b` }),
       );
     });
 
     expect(lastFrame()).not.toContain(secret);
-    expect(lastFrame()).toContain('*'.repeat(secret.length));
+    expect(lastFrame()).toContain('*'.repeat(prefix.length + secret.length));
 
     act(() => {
       mockedUseKeypress.mock.calls.at(-1)?.[0](
@@ -136,7 +141,7 @@ describe('SettingInputPrompt', () => {
       );
     });
 
-    expect(onSubmit).toHaveBeenCalledWith(secret);
+    expect(onSubmit).toHaveBeenCalledWith(prefix + secret);
   });
 
   it('displays help text for submit and cancel', () => {

--- a/packages/cli/src/ui/components/SettingInputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/SettingInputPrompt.test.tsx
@@ -6,8 +6,10 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from 'ink-testing-library';
+import { act } from 'react';
 import { SettingInputPrompt } from './SettingInputPrompt.js';
 import { TextInput } from './shared/TextInput.js';
+import { useKeypress, type Key } from '../hooks/useKeypress.js';
 
 vi.mock('./shared/TextInput.js', () => ({
   TextInput: vi.fn(() => null),
@@ -18,6 +20,19 @@ vi.mock('../hooks/useKeypress.js', () => ({
 }));
 
 const MockedTextInput = vi.mocked(TextInput);
+const mockedUseKeypress = vi.mocked(useKeypress);
+
+function makeKey(overrides: Partial<Key>): Key {
+  return {
+    name: '',
+    ctrl: false,
+    meta: false,
+    shift: false,
+    paste: false,
+    sequence: '',
+    ...overrides,
+  };
+}
 
 describe('SettingInputPrompt', () => {
   const onSubmit = vi.fn();
@@ -91,6 +106,37 @@ describe('SettingInputPrompt', () => {
     // Should show the sensitive placeholder hint
     expect(lastFrame()).toContain('PASSWORD');
     expect(lastFrame()).toContain('Enter your password');
+  });
+
+  it('accepts pasted sensitive values', () => {
+    const secret = 'AIza-test-key';
+    const { lastFrame } = render(
+      <SettingInputPrompt
+        settingName="API_KEY"
+        settingDescription="Enter your API key"
+        sensitive={true}
+        onSubmit={onSubmit}
+        onCancel={onCancel}
+        terminalWidth={terminalWidth}
+      />,
+    );
+
+    act(() => {
+      mockedUseKeypress.mock.calls.at(-1)?.[0](
+        makeKey({ paste: true, sequence: secret }),
+      );
+    });
+
+    expect(lastFrame()).not.toContain(secret);
+    expect(lastFrame()).toContain('*'.repeat(secret.length));
+
+    act(() => {
+      mockedUseKeypress.mock.calls.at(-1)?.[0](
+        makeKey({ name: 'return', sequence: '\r' }),
+      );
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith(secret);
   });
 
   it('displays help text for submit and cancel', () => {

--- a/packages/cli/src/ui/components/SettingInputPrompt.tsx
+++ b/packages/cli/src/ui/components/SettingInputPrompt.tsx
@@ -37,6 +37,14 @@ const PasswordInput = ({
 }) => {
   useKeypress(
     (key: Key) => {
+      if (key.paste) {
+        const pastedValue = key.sequence.replace(/[^\x20-\x7e]/g, '');
+        if (pastedValue) {
+          onChange(value + pastedValue);
+        }
+        return;
+      }
+
       // Handle submit
       if (key.name === 'return') {
         onSubmit();

--- a/packages/cli/src/ui/components/SettingInputPrompt.tsx
+++ b/packages/cli/src/ui/components/SettingInputPrompt.tsx
@@ -21,6 +21,11 @@ type SettingInputPromptProps = {
   terminalWidth: number;
 };
 
+const isPrintableAscii = (character: string) => {
+  const charCode = character.charCodeAt(0);
+  return charCode >= 32 && charCode <= 126;
+};
+
 /**
  * A simple password input component that masks the input with asterisks.
  */
@@ -38,7 +43,10 @@ const PasswordInput = ({
   useKeypress(
     (key: Key) => {
       if (key.paste) {
-        const pastedValue = key.sequence.replace(/[^\x20-\x7e]/g, '');
+        const pastedValue = key.sequence
+          .split('')
+          .filter(isPrintableAscii)
+          .join('');
         if (pastedValue) {
           onChange(value + pastedValue);
         }
@@ -65,9 +73,7 @@ const PasswordInput = ({
 
       // Handle printable characters
       if (key.sequence && !key.ctrl && !key.meta && key.sequence.length === 1) {
-        const charCode = key.sequence.charCodeAt(0);
-        // Only accept printable ASCII characters (32-126)
-        if (charCode >= 32 && charCode <= 126) {
+        if (isPrintableAscii(key.sequence)) {
           onChange(value + key.sequence);
         }
       }


### PR DESCRIPTION
## What this PR does

This PR allows sensitive extension-setting prompts to accept multi-character paste events while continuing to display only masked characters. Pasted control characters are discarded so the prompt preserves its existing printable-ASCII input policy.

## Why it's needed

Windows terminals deliver bracketed paste as one event containing the complete value. The sensitive prompt previously accepted only single-character key events, so a pasted API key was silently ignored and the extension installation could not continue. This fixes the user-visible failure reported in issue 2383 without changing ordinary typing, backspace, or clear-input behavior.

## Reviewer Test Plan

### How to verify

Open an extension installation flow that requests a sensitive API key, paste a multi-character value into the prompt, and confirm that one mask character appears for every pasted character. Press Enter and confirm that the original value is submitted unchanged. Also confirm that the plaintext value never appears in the rendered terminal output and that normal typing, backspace, and Ctrl+U continue to work.

### Evidence (Before & After)

Before: a complete bracketed-paste event left the prompt on its empty placeholder, and the regression test failed because no mask characters were rendered.

After: the same event renders 13 mask characters for the 13-character test value, keeps the plaintext absent from the UI, and submits the exact value on Enter. The focused component suite passes 7/7 tests, and the Windows paste-parser regression passes 1/1.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested directly; automated Windows paste-path coverage passed   |
|  🐧 Linux  |   ⚠️ not tested directly   |

### Environment (optional)

Node.js v24.18.0, npm 11.16.0, no sandbox.

## Risk & Scope

- Main risk or tradeoff: pasted non-printable characters are removed to match the prompt's existing printable-ASCII policy.
- Not validated / out of scope: manual testing in a physical Windows terminal; non-sensitive text inputs are unchanged.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #2383

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本 PR 让扩展敏感设置输入框能够接收包含多个字符的粘贴事件，同时继续只显示掩码字符。粘贴内容中的控制字符会被丢弃，从而保持输入框原有的仅允许可打印 ASCII 字符的策略。

## 为什么需要此改动

Windows 终端会把括号粘贴作为一个包含完整值的事件发送。敏感输入框此前只接受单字符按键事件，因此粘贴的 API key 会被静默忽略，扩展安装无法继续。本修复解决 issue 2383 中报告的用户可见故障，同时不改变普通输入、退格或清空输入的行为。

## Reviewer Test Plan

### 验证方法

打开一个需要敏感 API key 的扩展安装流程，将多字符值粘贴到输入框中，并确认每个粘贴字符都会显示一个掩码字符。按 Enter 后确认提交的是未改变的原始值。同时确认终端渲染内容中从不出现明文值，并确认普通输入、退格和 Ctrl+U 仍然正常工作。

### 证据（修复前后）

修复前：完整的括号粘贴事件会让输入框停留在空占位符状态，回归测试因为没有渲染任何掩码字符而失败。

修复后：相同事件会为 13 个字符的测试值渲染 13 个掩码字符，UI 中不出现明文，并在按 Enter 后提交完全一致的值。定向组件测试 7/7 通过，Windows 粘贴解析回归测试 1/1 通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅ 已测试   |
| 🪟 Windows |   ⚠️ 未直接测试；自动化 Windows 粘贴路径测试已通过   |
|  🐧 Linux  |   ⚠️ 未直接测试   |

### 环境（可选）

Node.js v24.18.0，npm 11.16.0，无沙箱。

## 风险与范围

- 主要风险或权衡：粘贴内容中的不可打印字符会被移除，以匹配输入框现有的可打印 ASCII 策略。
- 未验证 / 范围外：未在实体 Windows 终端中手动测试；非敏感文本输入框不受影响。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #2383

</details>
