### PR TITLE
ci: auto-update ECS runners on stable publish and harden update job

### DIFF
--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -575,15 +575,16 @@ jobs:
           sed -i "s/qwen3\.7-max/${ESCAPED}/g" "$TARGET"
 
       - name: 'Ensure qwen CLI'
+        id: 'ensure_qwen'
         run: |-
           set -euo pipefail
           if command -v qwen >/dev/null 2>&1; then
             echo "qwen already installed:"
-            qwen --version
           else
             npm install -g --loglevel=error --no-audit @qwen-code/qwen-code@latest
-            qwen --version
           fi
+          qwen --version
+          echo "version=$(qwen --version)" >> "${GITHUB_OUTPUT}"
 
       - name: 'Run Qwen Triage'
         id: 'triage'
@@ -600,6 +601,12 @@ jobs:
           OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
           OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'
           OPENAI_MODEL: '${{ vars.QWEN_TRIAGE_MODEL || vars.QWEN_PR_REVIEW_MODEL }}'
+          # Pin the action's unconditional global reinstall to the version
+          # this job already runs. Left at `latest`, the action installs with
+          # --prefer-offline and resolves the dist-tag from the runner's
+          # persistent npm cache, which lags npm publishes and has downgraded
+          # the shared ECS box back to a stale release.
+          qwen_cli_version: '${{ steps.ensure_qwen.outputs.version }}'
           # The input name is `settings` — this action version has no
           # `settings_json` input. The old `settings_json:` block was silently
           # dropped ("Unexpected input(s) 'settings_json'" in the run log), so

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -611,6 +611,28 @@ jobs:
             --notes-file "${NOTES_FILE}" \
             ${PRERELEASE_FLAG}
 
+      - name: 'Trigger ECS runner qwen update'
+        # Stable releases only: nightly/preview must not move the fleet.
+        if: |-
+          ${{ github.repository == 'QwenLM/qwen-code' &&
+              needs.prepare.outputs.is_dry_run == 'false' &&
+              needs.prepare.outputs.npm_tag == 'latest' }}
+        # The packages are already published; a dispatch failure must not
+        # fail the release — warn and let maintainers re-run the update
+        # workflow manually instead.
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: '${{ secrets.CI_BOT_PAT }}'
+          RELEASE_VERSION: '${{ needs.prepare.outputs.release_version }}'
+        run: |-
+          gh api "repos/${GITHUB_REPOSITORY}/dispatches" \
+            --method POST \
+            -f 'event_type=npm-published' \
+            -f "client_payload[version]=${RELEASE_VERSION}" || {
+              echo "::warning::npm-published dispatch failed; run the 'Update ECS Runner Qwen' workflow manually."
+              exit 1
+            }
+
   notify_failure:
     name: 'Notify Release Failure'
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -618,7 +618,7 @@ jobs:
               needs.prepare.outputs.is_dry_run == 'false' &&
               needs.prepare.outputs.npm_tag == 'latest' }}
         # The packages are already published; a dispatch failure must not
-        # fail the release — warn and let maintainers re-run the update
+        # fail the release — report it and let maintainers re-run the update
         # workflow manually instead.
         continue-on-error: true
         env:
@@ -629,7 +629,7 @@ jobs:
             --method POST \
             -f 'event_type=npm-published' \
             -f "client_payload[version]=${RELEASE_VERSION}" || {
-              echo "::warning::npm-published dispatch failed; run the 'Update ECS Runner Qwen' workflow manually."
+              echo "::error::npm-published dispatch failed; run the 'Update ECS Runner Qwen' workflow manually."
               exit 1
             }
 

--- a/.github/workflows/update-ecs-runner-qwen.yml
+++ b/.github/workflows/update-ecs-runner-qwen.yml
@@ -55,7 +55,20 @@ jobs:
           # carry a runner user's custom npm prefix into the sudo install.
           (
             cd "${RUNNER_TEMP:?}"
-            sudo env -u NPM_CONFIG_PREFIX npm install -g --registry=https://registry.npmjs.org "@qwen-code/qwen-code@${VERSION}"
+            # All runner processes of a region share one machine, so another
+            # job's concurrent `npm install -g` can race npm's rename of the
+            # package dir (ENOTEMPTY). Clear trash left by crashed installs
+            # and retry through the seconds-long race window.
+            PKG_DIR='/usr/local/lib/node_modules/@qwen-code'
+            for attempt in 1 2 3; do
+              sudo rm -rf "${PKG_DIR}"/.qwen-code-* 2>/dev/null || true
+              if sudo env -u NPM_CONFIG_PREFIX npm install -g --registry=https://registry.npmjs.org "@qwen-code/qwen-code@${VERSION}"; then
+                exit 0
+              fi
+              echo "::warning::npm install attempt ${attempt} failed; retrying"
+              sleep $((attempt * 10))
+            done
+            exit 1
           )
 
       - name: 'Verify version'

--- a/.github/workflows/update-ecs-runner-qwen.yml
+++ b/.github/workflows/update-ecs-runner-qwen.yml
@@ -65,8 +65,12 @@ jobs:
               if sudo env -u NPM_CONFIG_PREFIX npm install -g --registry=https://registry.npmjs.org "@qwen-code/qwen-code@${VERSION}"; then
                 exit 0
               fi
-              echo "::warning::npm install attempt ${attempt} failed; retrying"
-              sleep $((attempt * 10))
+              if [[ "${attempt}" -lt 3 ]]; then
+                echo "::warning::npm install attempt ${attempt} failed; retrying"
+                sleep $((attempt * 10))
+              else
+                echo "::error::npm install of @qwen-code/qwen-code@${VERSION} failed after 3 attempts"
+              fi
             done
             exit 1
           )

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -219,6 +219,16 @@ describe('qwen-triage tmux workflow', () => {
     expect(runStep).toContain("QWEN_HOME: '${{ runner.temp }}/qwen-home'");
   });
 
+  it('pins the action reinstall to the version the job already runs', () => {
+    expect(workflow).toContain("id: 'ensure_qwen'");
+    expect(workflow).toContain(
+      'echo "version=$(qwen --version)" >> "${GITHUB_OUTPUT}"',
+    );
+    expect(workflow).toContain(
+      "qwen_cli_version: '${{ steps.ensure_qwen.outputs.version }}'",
+    );
+  });
+
   it('passes triage output through env before bash reads it', () => {
     const checkStep = step('Check triage response');
 

--- a/scripts/tests/release-workflow.test.js
+++ b/scripts/tests/release-workflow.test.js
@@ -23,13 +23,20 @@ describe('release workflow', () => {
         "              needs.prepare.outputs.npm_tag == 'latest' }}",
     );
     expect(workflow).toContain("-f 'event_type=npm-published'");
+    expect(workflow).toContain(
+      '-f "client_payload[version]=${RELEASE_VERSION}"',
+    );
   });
 
   it('keeps a dispatch failure from failing an already-published release', () => {
     // The packages are published before this step runs, so it must not fail
     // the release; but the failure must still surface (as an error, not a
     // warning) so the fleet can be reconciled via a manual re-run.
-    expect(workflow).toContain('continue-on-error: true');
+    expect(workflow).toContain(
+      'continue-on-error: true\n' +
+        '        env:\n' +
+        "          GITHUB_TOKEN: '${{ secrets.CI_BOT_PAT }}'",
+    );
     expect(workflow).toContain('echo "::error::npm-published dispatch failed;');
   });
 });

--- a/scripts/tests/release-workflow.test.js
+++ b/scripts/tests/release-workflow.test.js
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const workflow = readFileSync('.github/workflows/release.yml', 'utf8');
+
+describe('release workflow', () => {
+  it('fires the fleet-moving npm-published dispatch on stable releases only', () => {
+    // This gate is the sole protection keeping a nightly/preview/dry-run
+    // release from moving the ECS fleet; the triggered update workflow
+    // installs whatever version it is handed, so there is no downstream
+    // guard. Pin all three clauses together so dropping or inverting one
+    // fails review instead of silently shipping a non-stable fleet.
+    expect(workflow).toContain(
+      'if: |-\n' +
+        "          ${{ github.repository == 'QwenLM/qwen-code' &&\n" +
+        "              needs.prepare.outputs.is_dry_run == 'false' &&\n" +
+        "              needs.prepare.outputs.npm_tag == 'latest' }}",
+    );
+    expect(workflow).toContain("-f 'event_type=npm-published'");
+  });
+
+  it('keeps a dispatch failure from failing an already-published release', () => {
+    // The packages are published before this step runs, so it must not fail
+    // the release; but the failure must still surface (as an error, not a
+    // warning) so the fleet can be reconciled via a manual re-run.
+    expect(workflow).toContain('continue-on-error: true');
+    expect(workflow).toContain('echo "::error::npm-published dispatch failed;');
+  });
+});

--- a/scripts/tests/update-ecs-runner-qwen-workflow.test.js
+++ b/scripts/tests/update-ecs-runner-qwen-workflow.test.js
@@ -17,4 +17,15 @@ describe('ECS runner qwen update workflow', () => {
     expect(workflow).toContain('cd "${RUNNER_TEMP:?}"');
     expect(workflow).toContain('sudo env -u NPM_CONFIG_PREFIX npm install -g');
   });
+
+  it('annotates a retry and a terminal failure distinctly', () => {
+    // The final attempt must not log a "retrying" warning that never
+    // retries; a sustained failure ends with an explicit exhausted error.
+    expect(workflow).toContain(
+      'echo "::warning::npm install attempt ${attempt} failed; retrying"',
+    );
+    expect(workflow).toContain(
+      'echo "::error::npm install of @qwen-code/qwen-code@${VERSION} failed after 3 attempts"',
+    );
+  });
 });

--- a/scripts/tests/update-ecs-runner-qwen-workflow.test.js
+++ b/scripts/tests/update-ecs-runner-qwen-workflow.test.js
@@ -27,5 +27,8 @@ describe('ECS runner qwen update workflow', () => {
     expect(workflow).toContain(
       'echo "::error::npm install of @qwen-code/qwen-code@${VERSION} failed after 3 attempts"',
     );
+    expect(workflow).toContain('for attempt in 1 2 3; do');
+    expect(workflow).toContain('if [[ "${attempt}" -lt 3 ]]; then');
+    expect(workflow).toContain('sudo rm -rf "${PKG_DIR}"/.qwen-code-*');
   });
 });


### PR DESCRIPTION
## What this PR does

Three changes that keep the self-hosted ECS runners' qwen CLI current and stop them from being silently downgraded. First, the Release workflow now emits a `repository_dispatch` (`npm-published`, carrying the released version) after a successful stable publish, so the existing Update ECS Runner Qwen workflow fires automatically instead of waiting for a manual run; the step is gated to real stable publishes (`npm_tag == 'latest'`, non-dry-run, QwenLM/qwen-code only), excludes nightly/preview so the fleet is never moved to a prerelease, and is `continue-on-error` with a warning so an already-published release can never be failed by it. Second, the update job now clears stale npm trash dirs (`/usr/local/lib/node_modules/@qwen-code/.qwen-code-*`) and retries the global install up to three times with backoff, so leftover trash from crashed installs and concurrent-install races can no longer block it with `ENOTEMPTY`. Third, the triage job now pins the qwen-code-action's unconditional global reinstall to the exact version the job already runs (captured from the Ensure qwen CLI step added by #8337), so the action can never downgrade the shared runner.

## Why it's needed

Investigation into why the runners kept serving 0.21.2 after 0.21.3 shipped found a three-part failure chain. (1) The `repository_dispatch: ['npm-published']` trigger on the update workflow has never had a sender anywhere in the repo — all ~30 historical runs were manual `workflow_dispatch`, so after every npm publish the runners kept serving the previous version until someone ran the update by hand. (2) The qwen-code-action used by the triage job runs `npm install --global --prefer-offline @qwen-code/qwen-code@latest` unconditionally on every run; on the shared ECS box `--prefer-offline` resolves the `latest` dist-tag from the persistent npm cache, which lags npm publishes — after the box was updated to 0.21.3 at 17:28 UTC (verified by a job at 18:17), triage jobs resolved `latest` as the cached 0.21.2 and downgraded the box again (every job from 21:05 onward printed 0.21.2 on the same machine `iZt4ne2fxw78cka1n2cbkoZ`). #8337 added an if-missing pre-step but the action's internal install still runs unconditionally, so it does not stop the downgrade. (3) Each downgrade/re-upgrade cycle leaves npm trash dirs behind, and the trash name npm generates for a given package is deterministic — the 17:58 and 23:43 update failures both died on the identical rename target `.qwen-code-g9EoLCuD`, so once that stale dir exists the update workflow is blocked forever (`ENOTEMPTY`, exit 217) and cannot self-recover.

## Reviewer Test Plan

### How to verify

Confirm the dispatch step gating: it fires only for real stable publishes from QwenLM/qwen-code (`npm_tag == 'latest'`, non-dry-run) and is `continue-on-error`, and the payload matches what the update workflow reads (`github.event.client_payload.version` ← `client_payload[version]=<release_version>`; an empty version falls back to npm `latest`). Confirm the update job's retry loop exits 0 on first success, cleans `/usr/local/lib/node_modules/@qwen-code/.qwen-code-*` before each attempt, and fails the step after three failed attempts, with the existing Verify version step still asserting the final version. Confirm the triage job captures the installed version in the Ensure qwen CLI step (`id: ensure_qwen`, `version` output) and passes it as `qwen_cli_version`, so the action's reinstall targets an exact version (no dist-tag resolution, no cache-driven downgrade) — this composes with #8337's step rather than replacing it. After merge: re-run the Update ECS Runner Qwen workflow once to clear the stale trash dir and restore 0.21.3 on both machines; the next stable release should then dispatch the update automatically, and triage jobs must never change the installed version again.

### Evidence (Before & After)

N/A — CI/workflow-only change with no user-visible UI. Before: 0.21.3 published at 17:22 UTC, manual update at 17:28 verified 0.21.3, triage jobs downgraded the box back to 0.21.2 by 21:05 (stale npm cache + `--prefer-offline`), and the 17:58 and 23:43 manual update re-runs both failed with the identical `ENOTEMPTY ... '.qwen-code-g9EoLCuD'` rename error (runs 30711479656, 30723886544). After: stable publishes dispatch the update automatically, the update job clears stale trash and retries through concurrent-install races, and the triage action's reinstall is pinned to the installed version.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested (validation only) |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A — takes effect on the ECS runners after merge |

### Environment (optional)

Local validation: `yaml.safe_load` on all three workflows, `actionlint` (only pre-existing shellcheck style warnings, identical count before/after on each file), `bash -n` on the changed run scripts, and `gh api --help` confirming the `key[subkey]=value` nested-parameter syntax.

## Risk & Scope

- Main risk or tradeoff: the dispatch step uses CI_BOT_PAT at the very end of the publish job; a failure only warns (continue-on-error), so the worst case is the pre-existing behavior — someone runs the update workflow manually. The triage pin means triage jobs no longer self-upgrade a stale box; recovery is the update workflow's job (which this PR unblocks).
- Not validated / out of scope: an actual stable publish exercising the dispatch end-to-end (only happens on the next release); the qwen-code-action itself (separate repo) still installs unconditionally — a skip-if-installed option there would be the upstream fix; the tmux/verify lanes' own unconditional `npm install -g @latest` steps can still race concurrent installs, but they resolve fresh metadata (no `--prefer-offline`) so they upgrade rather than downgrade.
- Breaking changes / migration notes: none.

## Linked Issues

N/A — stems from maintainer investigation of stale runner versions after the v0.21.3 release. Complements #8337.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

三处改动，让自建 ECS runner 上的 qwen CLI 保持最新、并阻止其被静默降级。第一，Release workflow 在 stable 发布成功后发送 `repository_dispatch`（`npm-published`，携带发布版本号），自动触发已有的 Update ECS Runner Qwen workflow，不再需要手动运行；该步骤仅限真实 stable 发布（`npm_tag == 'latest'`、非 dry-run、仅 QwenLM/qwen-code），排除 nightly/preview 以免 runner 集群被切到预发布版本，并设置 `continue-on-error` 仅告警，确保已发布的 release 不会被它拖败。第二，update job 现在会清理 npm 残留临时目录（`/usr/local/lib/node_modules/@qwen-code/.qwen-code-*`）并重试全局安装最多三次（带退避），使崩溃残留和并发安装竞态不再以 `ENOTEMPTY` 阻塞更新。第三，triage job 现在把 qwen-code-action 的无条件全局重装固定到本 job 已在运行的确切版本（取自 #8337 新增的 Ensure qwen CLI 步骤），使该 action 永远无法降级共享 runner。

## 为什么需要

排查"0.21.3 发布后 runner 仍提供 0.21.2"发现三段式故障链。(1) update workflow 声明的 `repository_dispatch: ['npm-published']` 触发器在全仓库没有任何发送方——历史约 30 次运行全部是手动 `workflow_dispatch`，因此每次 npm 发布后 runner 都停留在旧版本，直到有人手动跑更新。(2) triage job 使用的 qwen-code-action 每次运行都无条件执行 `npm install --global --prefer-offline @qwen-code/qwen-code@latest`；在共享 ECS 机器上，`--prefer-offline` 从持久化 npm 缓存解析 `latest` dist-tag，而缓存滞后于 npm 发布——机器在 UTC 17:28 被更新到 0.21.3（18:17 的 job 验证过）之后，triage job 把 `latest` 解析成缓存里的 0.21.2 并把机器降级回去（21:05 起同一台机器 `iZt4ne2fxw78cka1n2cbkoZ` 上每个 job 都打印 0.21.2）。#8337 加了"缺失才装"的预步骤，但 action 内部安装依旧无条件执行，挡不住降级。(3) 每次降级/升级循环都会留下 npm 临时目录，而 npm 对给定包生成的临时目录名是确定的——17:58 与 23:43 两次 update 失败都死在完全相同的 rename 目标 `.qwen-code-g9EoLCuD` 上，因此一旦这个残留目录存在，update workflow 就被永久阻塞（`ENOTEMPTY`，exit 217），无法自愈。

## Reviewer 测试计划

### 如何验证

确认 dispatch 步骤的门控：仅对来自 QwenLM/qwen-code 的真实 stable 发布触发（`npm_tag == 'latest'`、非 dry-run）且为 `continue-on-error`；payload 与 update workflow 读取的字段一致（`github.event.client_payload.version` ← `client_payload[version]=<release_version>`；版本为空时回退 npm `latest`）。确认 update job 的重试循环首次成功即退出 0、每次尝试前清理 `/usr/local/lib/node_modules/@qwen-code/.qwen-code-*`、三次失败后让步骤失败，且现有的 Verify version 步骤仍校验最终版本。确认 triage job 在 Ensure qwen CLI 步骤捕获已安装版本（`id: ensure_qwen`、`version` 输出）并以 `qwen_cli_version` 传入，使 action 的重装针对确切版本（不解析 dist-tag、不会被缓存驱动降级）——与 #8337 的步骤组合而非替换。合并后：手动重跑一次 Update ECS Runner Qwen workflow 以清除残留临时目录、把两台机器恢复到 0.21.3；此后下一次 stable 发布应自动派发更新，且 triage job 不再改变已安装版本。

### 证据（前后对比）

N/A——纯 CI/workflow 改动，无用户可见 UI。改动前：0.21.3 于 UTC 17:22 发布，17:28 手动更新验证到 0.21.3，triage job 在 21:05 前把机器降级回 0.21.2（陈旧 npm 缓存 + `--prefer-offline`），17:58 与 23:43 两次手动重跑都失败于完全相同的 `ENOTEMPTY ... '.qwen-code-g9EoLCuD'` rename 错误（run 30711479656、30723886544）。改动后：stable 发布自动派发更新，update job 清理残留并重试穿过并发安装竞态，triage action 的重装被固定到已安装版本。

### 测试平台

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试（仅校验） |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A——合并后在 ECS runner 上生效 |

### 环境（可选）

本地校验：三个 workflow 通过 `yaml.safe_load`，`actionlint` 仅报预存的 shellcheck 风格告警（每个文件改动前后数量一致），改动的 run 脚本通过 `bash -n`，并通过 `gh api --help` 确认 `key[subkey]=value` 嵌套参数语法。

## 风险与范围

- 主要风险/权衡：dispatch 步骤在 publish job 末尾使用 CI_BOT_PAT；失败仅告警（continue-on-error），最坏情况退化为现状——手动运行 update workflow。triage 固定版本意味着 triage job 不再自行升级陈旧机器，恢复工作由 update workflow 负责（本 PR 已为其解阻）。
- 未验证/范围外：真实 stable 发布端到端触发 dispatch（要等下一次发版）；qwen-code-action 本身（独立仓库）依旧无条件安装——在那里加"已装则跳过"才是上游修复；tmux/verify lane 自己的无条件 `npm install -g @latest` 步骤仍可能与并发安装竞争，但它们解析新鲜元数据（无 `--prefer-offline`），只会升级而非降级。
- 破坏性变更/迁移说明：无。

## 关联 Issue

N/A——源于 maintainer 对 v0.21.3 发布后 runner 版本滞后的排查。与 #8337 互补。

</details>
