### PR TITLE
fix(core): redact sibling directives from forked subagent history

### DIFF
--- a/packages/core/src/tools/agent/agent.test.ts
+++ b/packages/core/src/tools/agent/agent.test.ts
@@ -10,7 +10,7 @@ import {
   type AgentParams,
   resolveSubagentApprovalMode,
 } from './agent.js';
-import type { Part, PartListUnion } from '@google/genai';
+import type { Content, Part, PartListUnion } from '@google/genai';
 import type { ToolResultDisplay, AgentResultDisplay } from '../tools.js';
 import { ToolConfirmationOutcome } from '../tools.js';
 import { ToolNames } from '../tool-names.js';
@@ -3699,6 +3699,78 @@ describe('AgentTool', () => {
           ],
         }),
       );
+    });
+
+    it("does not seed a fork with its siblings' directives", async () => {
+      // When the model launches several forks in one response, the last model
+      // message holds one functionCall per sibling, each carrying that
+      // sibling's directive in `args.prompt`. Replaying it verbatim would leak
+      // every sibling directive into this fork's seed history. Pin the
+      // end-to-end path: the seed must not contain a sibling's directive.
+      const startup = {
+        role: 'user' as const,
+        parts: [{ text: '<system-reminder>\nstartup\n</system-reminder>' }],
+      };
+      const firstUser = {
+        role: 'user' as const,
+        parts: [{ text: 'launch two forks' }],
+      };
+      const forkLaunch = {
+        role: 'model' as const,
+        parts: [
+          { text: 'Launching two forks.' },
+          {
+            functionCall: {
+              id: 'call-a',
+              name: 'agent',
+              args: { subagent_type: 'fork', prompt: 'do the thing' },
+            },
+          },
+          {
+            functionCall: {
+              id: 'call-b',
+              name: 'agent',
+              args: {
+                subagent_type: 'fork',
+                prompt: 'SIBLING_SECRET_DIRECTIVE',
+              },
+            },
+          },
+        ],
+      };
+      const getHistoryShallow = vi
+        .fn()
+        .mockReturnValue([startup, firstUser, forkLaunch]);
+      vi.mocked(config.getGeminiClient).mockReturnValue({
+        getHistoryShallow,
+        getChat: vi.fn().mockReturnValue({
+          getGenerationConfig: vi.fn().mockReturnValue({}),
+        }),
+      } as unknown as ReturnType<Config['getGeminiClient']>);
+
+      const invocation = (
+        agentTool as AgentToolWithProtectedMethods
+      ).createInvocation({
+        description: 'some task',
+        prompt: 'do the thing',
+        subagent_type: 'fork',
+        fork_turns: 'all',
+      });
+
+      await invocation.execute();
+
+      const promptConfig = vi.mocked(AgentHeadless.create).mock
+        .calls[0]?.[2] as { initialMessages?: Content[] } | undefined;
+      const initialMessages = promptConfig?.initialMessages ?? [];
+      // The sibling's directive must appear nowhere in the fork's seed history.
+      expect(JSON.stringify(initialMessages)).not.toContain(
+        'SIBLING_SECRET_DIRECTIVE',
+      );
+      // The seed still ends on a model message so the task_prompt can follow.
+      expect(initialMessages.at(-1)).toEqual({
+        role: 'model',
+        parts: [{ text: 'Understood. Executing directive now.' }],
+      });
     });
 
     it('falls back to uncurated getHistory() when getHistoryForForkWindow is unavailable', async () => {

--- a/packages/core/src/tools/agent/fork-subagent.test.ts
+++ b/packages/core/src/tools/agent/fork-subagent.test.ts
@@ -8,6 +8,8 @@ import type { Content } from '@google/genai';
 import { describe, expect, it } from 'vitest';
 import { ToolNames } from '../tool-names.js';
 import {
+  buildForkedMessages,
+  FORK_PLACEHOLDER_RESULT,
   normalizeForkTurns,
   resolveForkExecutionAllowedTools,
   selectForkHistory,
@@ -249,5 +251,89 @@ describe('selectForkHistory', () => {
 
     expect(inheritedNestedImage).toEqual(nestedImage);
     expect(inheritedNestedImage).not.toBe(nestedImage);
+  });
+});
+
+describe('buildForkedMessages', () => {
+  // A model launching several forks in one response: the last model message
+  // carries one functionCall per sibling fork, each with its own directive in
+  // `args.prompt`.
+  const launch: Content = {
+    role: 'model',
+    parts: [
+      { text: 'Launching two forks.' },
+      {
+        functionCall: {
+          id: 'call-a',
+          name: 'agent',
+          args: {
+            subagent_type: 'fork',
+            prompt: 'ALPHA_DIRECTIVE',
+            description: 'task a',
+          },
+        },
+      },
+      {
+        functionCall: {
+          id: 'call-b',
+          name: 'agent',
+          args: {
+            subagent_type: 'fork',
+            prompt: 'BETA_DIRECTIVE',
+            description: 'task b',
+          },
+        },
+      },
+    ],
+  };
+
+  it('does not leak sibling fork directives into the forked history', () => {
+    const messages = buildForkedMessages('ALPHA_DIRECTIVE', launch);
+
+    // Fork A must not see fork B's directive anywhere in its seed history.
+    expect(JSON.stringify(messages)).not.toContain('BETA_DIRECTIVE');
+
+    // The replayed model message carries no directive text at all — the fork's
+    // own directive is delivered separately, so no `args.prompt` should survive.
+    const [assistant] = messages;
+    expect(JSON.stringify(assistant)).not.toContain('ALPHA_DIRECTIVE');
+  });
+
+  it('preserves function-call pairing and delivers the own directive once', () => {
+    const [assistant, toolResult] = buildForkedMessages(
+      'ALPHA_DIRECTIVE',
+      launch,
+    );
+
+    // Non-functionCall parts pass through unchanged.
+    expect(assistant.parts?.[0]?.text).toBe('Launching two forks.');
+
+    // Both calls are retained by id + name so the API can pair the responses.
+    const calls = assistant.parts
+      ?.filter((part) => part.functionCall)
+      .map((part) => part.functionCall);
+    expect(calls?.map((call) => call?.id)).toEqual(['call-a', 'call-b']);
+    expect(calls?.map((call) => call?.name)).toEqual(['agent', 'agent']);
+
+    // Every retained call has a matching placeholder response.
+    const responses = toolResult.parts
+      ?.filter((part) => part.functionResponse)
+      .map((part) => part.functionResponse);
+    expect(responses?.map((response) => response?.id)).toEqual([
+      'call-a',
+      'call-b',
+    ]);
+    expect(
+      responses?.every(
+        (response) =>
+          response?.response?.['output'] === FORK_PLACEHOLDER_RESULT,
+      ),
+    ).toBe(true);
+
+    // The fork's own directive is still delivered, exactly once, via the text.
+    const directiveText =
+      toolResult.parts?.find((part) => typeof part.text === 'string')?.text ??
+      '';
+    expect(directiveText).toContain('Directive: ALPHA_DIRECTIVE');
   });
 });

--- a/packages/core/src/tools/agent/fork-subagent.ts
+++ b/packages/core/src/tools/agent/fork-subagent.ts
@@ -265,7 +265,8 @@ export function selectForkHistory(
  * When the last model message has function calls, we must include matching
  * function responses in a user message (Gemini API requirement). The
  * directive is embedded in this same user message to avoid consecutive
- * user messages.
+ * user messages. Each replayed functionCall's `args` are redacted so a fork
+ * launched alongside siblings does not inherit the siblings' directives.
  *
  * When there are no function calls, we return [] — the parent history
  * already ends with a model text message and the directive will be sent
@@ -290,10 +291,28 @@ export function buildForkedMessages(
     return [];
   }
 
-  // Clone the assistant message to avoid mutating the original
+  // Clone the assistant message to avoid mutating the original, redacting the
+  // `args` of every functionCall. When a model launches several forks in one
+  // response, this message holds one functionCall per sibling fork, each with
+  // that sibling's directive in `args.prompt` — replaying them verbatim leaks
+  // every sibling's directive into this fork's history. Only `id` and `name`
+  // are needed to pair the placeholder responses built below; the fork's own
+  // directive is delivered separately via buildChildMessage. Empty args
+  // serialize identically to absent args (JSON.stringify(args || {})).
   const fullAssistantMessage: Content = {
     role: assistantMessage.role,
-    parts: [...(assistantMessage.parts || [])],
+    parts: (assistantMessage.parts || []).map((part) =>
+      part.functionCall
+        ? {
+            ...part,
+            functionCall: {
+              id: part.functionCall.id,
+              name: part.functionCall.name,
+              args: {},
+            },
+          }
+        : part,
+    ),
   };
 
   // Build tool_result blocks for every tool_use, all with identical placeholder text.


### PR DESCRIPTION
## What this PR does

Stops a forked subagent from seeing the directives of the *other* forks launched in the same turn. When the model launches several `fork` subagents in one response, the fork-launch model message holds one `functionCall` per fork, each carrying that fork's directive in `args.prompt`. That message was replayed into every fork's inherited history verbatim, so each fork could read its siblings' directives. This redacts each replayed `functionCall`'s `args` in `buildForkedMessages`, keeping only the `id` and `name` needed to pair the placeholder function responses.

## Why it's needed

Each fork is meant to work only on its own directive — a fork can even be launched with `fork_tools: []` to run with no tool access at all. Leaking the sibling directives pollutes the fork's context with unrelated tasks and can expose sensitive prompt text the fork was never meant to see. In #8326 a third fork produced a meta-response describing all three forks, despite having no way to observe the others except through the leaked history.

The fork's own directive is unaffected: it is delivered separately via `buildChildMessage`, so redacting the replayed `args` removes only the sibling cross-talk.

## Reviewer Test Plan

### How to verify

The leak and the fix both live in `buildForkedMessages` (`packages/core/src/tools/agent/fork-subagent.ts`), a pure function, so it is unit-provable without a live model. Two new unit tests assert a sibling's directive never appears in the fork's seed history; a third, integration-level test drives the real `AgentTool` fork-dispatch path and asserts the same on the `initialMessages` actually handed to `AgentHeadless.create`.

```bash
cd packages/core
npx vitest run src/tools/agent/fork-subagent.test.ts src/tools/agent/agent.test.ts -t "buildForkedMessages|does not seed a fork with its siblings"
```

### Evidence (Before & After)

**Before (negative control on unmodified source)** — the two leak tests fail; the structure-guard test passes, so the failures are caused only by the leak:

```
 ❯ src/tools/agent/fork-subagent.test.ts (21 tests | 1 failed | 19 skipped)
   × buildForkedMessages > does not leak sibling fork directives into the forked history
   ✓ buildForkedMessages > preserves function-call pairing and delivers the own directive once
 ❯ src/tools/agent/agent.test.ts (250 tests | 1 failed | 249 skipped)
   × AgentTool > Fork dispatch (subagent_type: "fork") > does not seed a fork with its siblings' directives
 Tests  2 failed | 1 passed | 268 skipped (271)
```

The failing assertion shows fork A's seed history literally contains fork B's directive:

```
AssertionError: expected '[{"role":"model","parts":[{"text":"La…' not to contain 'BETA_DIRECTIVE'
...  {"functionCall":{"id":"call-b","name":"agent","args":{...,"prompt":"BETA_DIRECTIVE",...}}} ...
```

**After (fix applied)** — all pass:

```
 ✓ src/tools/agent/fork-subagent.test.ts (21 tests | 19 skipped)
 ✓ src/tools/agent/agent.test.ts (250 tests | 249 skipped)
 Tests  3 passed | 268 skipped (271)
```

Full affected suites — fork-subagent, agent, and the two memory planners that share the placeholder-response helper — all green: **369 passed**.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

Pure Node logic with no platform-specific behavior; verified on macOS with Node 22.22.3.

### Environment

Unit tests only.

## Risk & Scope

- **Main risk / tradeoff:** the replayed fork-launch calls now carry empty `args`. This is byte-identical to absent args in both serializers (`JSON.stringify(part.functionCall.args || {})` in the OpenAI converter), and the placeholder function responses still pair by `id`/`name`, so the model-visible request is unchanged apart from the removed sibling prompts.
- **Not validated / out of scope:** prior-turn tool calls already resolved in history remain inherited under `fork_turns: "all"` — the fix targets the current fork-launch model message (the "last model message" named in the issue), not earlier history.
- **Breaking changes:** none. The public signature of `buildForkedMessages` is unchanged; the change is test-covered and additive.

## Linked Issues

Refs #8326

<sub>AI-assisted: planning and implementation reviewed against source; RED→GREEN and negative-control proof included above.</sub>

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

阻止一个 fork 子代理看到同一轮里启动的**其他** fork 的指令。当模型在一次响应中启动多个 `fork` 子代理时,启动 fork 的那条 model 消息里每个 fork 各有一个 `functionCall`,每个 `functionCall` 的 `args.prompt` 携带着该 fork 的指令。这条消息被原样回放进每个 fork 继承的历史,于是每个 fork 都能读到兄弟 fork 的指令。本 PR 在 `buildForkedMessages` 中把每个被回放的 `functionCall` 的 `args` 清空,只保留配对占位响应所需的 `id` 和 `name`。

## 为什么需要

每个 fork 只应处理自己的指令 —— fork 甚至可以用 `fork_tools: []` 启动,完全没有工具权限。泄露兄弟指令会用无关任务污染 fork 的上下文,并可能暴露该 fork 本不该看到的敏感提示文本。在 #8326 中,第三个 fork 生成了描述全部三个 fork 的元回复,而它除了通过泄露的历史外无法观察到其他 fork。

fork 自己的指令不受影响:它通过 `buildChildMessage` 单独传递,因此清空被回放的 `args` 只移除了兄弟之间的串扰。

## 如何验证

泄露与修复都位于纯函数 `buildForkedMessages`(`packages/core/src/tools/agent/fork-subagent.ts`),无需真实模型即可用单元测试证明。两个新单元测试断言兄弟指令不会出现在 fork 的种子历史中;第三个集成测试驱动真实的 `AgentTool` fork 派发路径,对实际传给 `AgentHeadless.create` 的 `initialMessages` 做同样断言。

```bash
cd packages/core
npx vitest run src/tools/agent/fork-subagent.test.ts src/tools/agent/agent.test.ts -t "buildForkedMessages|does not seed a fork with its siblings"
```

修复前(在未修改源码上作为反向对照),两个泄露测试失败、结构守护测试通过;修复后三个测试全部通过。受影响的完整测试套件(fork-subagent、agent,以及共享占位响应辅助函数的两个 memory planner)共 **369 个通过**。

## 风险与范围

- **主要风险 / 取舍:** 被回放的 fork 启动调用现在携带空 `args`。在两个序列化器中这与缺省 `args` 逐字节一致(OpenAI 转换器中的 `JSON.stringify(part.functionCall.args || {})`),占位响应仍按 `id`/`name` 配对,因此除去移除的兄弟提示外,模型可见的请求不变。
- **未验证 / 范围之外:** 历史中已解析的上一轮工具调用在 `fork_turns: "all"` 下仍被继承 —— 本修复只针对当前这条启动 fork 的 model 消息(即 issue 所指的"最后一条 model 消息")。
- **破坏性变更:** 无。`buildForkedMessages` 的公开签名不变,改动有测试覆盖且为增量。

## 关联 Issue

Refs #8326

</details>
