### PR TITLE
fix(review): a mutant whose own test was red is not a survivor either

### DIFF
--- a/packages/cli/src/commands/review/test-efficacy.integration.test.ts
+++ b/packages/cli/src/commands/review/test-efficacy.integration.test.ts
@@ -961,6 +961,112 @@ process.stdout.write(JSON.stringify({
     expect(out.findings).toEqual([]);
   });
 
+  it('holds a mutant at inconclusive when its OWN test was red in the baseline', async () => {
+    // Measured live on PR #8213: six hunks in `bridge.ts` were correctly held
+    // at `inconclusive` because `bridge.test.ts` never ran green, while eight
+    // mutants in the SAME file were scored `survived` and shipped as findings.
+    // A mutant runs against `greenProbes` only, so the red collocated test is
+    // excluded from the run, and "every affected test still passed" is then
+    // computed over a set that omits the one test most likely to catch the
+    // deletion. Two files here: `f.ts` whose own test is red, and `g.ts`
+    // whose own test is green — the second is what shows the guard is
+    // targeted rather than a blanket refusal.
+    write('package.json', '{"private":true,"workspaces":["packages/*"]}\n');
+    write('packages/lib/src/f.ts', 'export const a = new Map();\n');
+    write('packages/lib/src/g.ts', 'export const b = new Map();\n');
+    const base = commitAll('base');
+    write(
+      'packages/lib/src/f.ts',
+      'export const a = new Map();\nexport function fReset() {\n  a.clear();\n}\n',
+    );
+    write(
+      'packages/lib/src/g.ts',
+      'export const b = new Map();\nexport function gReset() {\n  b.clear();\n}\n',
+    );
+    write(
+      'packages/lib/src/f.test.ts',
+      'import { fReset } from "./f.js"; import { it, expect } from "vitest"; it("t", () => expect(typeof fReset).toBe("function"));\n',
+    );
+    write(
+      'packages/lib/src/g.test.ts',
+      'import { gReset } from "./g.js"; import { it, expect } from "vitest"; it("t", () => expect(typeof gReset).toBe("function"));\n',
+    );
+    commitAll('pr');
+    const wt = join(repo, 'wt');
+    git(repo, 'worktree', 'add', '-q', '--detach', wt, 'HEAD');
+    writeFileSync(
+      join(repo, 'report.json'),
+      JSON.stringify({
+        files: [
+          { path: 'packages/lib/src/f.ts', kind: 'source' },
+          { path: 'packages/lib/src/g.ts', kind: 'source' },
+          { path: 'packages/lib/src/f.test.ts', kind: 'test' },
+          { path: 'packages/lib/src/g.test.ts', kind: 'test' },
+        ],
+      }),
+    );
+    // `f.test.ts` is red from the start — the baseline shape this is about.
+    // Everything else is green, and the injected control still turns the run
+    // red, so the harness is validated and survivors would be licensed.
+    writeFileSync(
+      vitestScript(),
+      `#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+const files = process.argv.slice(2).filter((a) => a.includes('.test.'));
+const st = (f) => {
+  try {
+    if (fs.readFileSync(f, 'utf8').includes('QWEN-REVIEW-POSITIVE-CONTROL')) return 'failed';
+  } catch {}
+  return path.basename(f) === 'f.test.ts' ? 'failed' : 'passed';
+};
+const results = files.map((f) => ({
+  name: path.resolve(f),
+  assertionResults: [{ status: st(f) }],
+}));
+const nf = results.filter((r) => r.assertionResults[0].status === 'failed').length;
+process.stdout.write(JSON.stringify({
+  numPassedTests: results.length - nf,
+  numFailedTests: nf,
+  testResults: results,
+}));
+`,
+    );
+    await runHandler({
+      report: join(repo, 'report.json'),
+      worktree: wt,
+      base,
+      out: join(repo, 'out.json'),
+    });
+
+    const out = JSON.parse(readFileSync(join(repo, 'out.json'), 'utf8'));
+    expect(out.harnessValidated).toBe(true);
+    const forF = out.mutants.probed.filter((m: { file: string }) =>
+      m.file.endsWith('f.ts'),
+    );
+    expect(forF.length).toBeGreaterThan(0);
+    for (const m of forF) {
+      expect(m.verdict).toBe('inconclusive');
+      expect(m.detail).toContain('f.test.ts');
+      expect(m.detail).toContain('did not run green');
+    }
+    // ...and nothing a reader acts on carries a survivor claim for that file.
+    expect(
+      (out.findings as Array<{ kind: string; file: string }>).filter(
+        (f) => f.kind === 'mutant-survived' && f.file.endsWith('f.ts'),
+      ),
+    ).toEqual([]);
+    // The guard is targeted: `g.ts`, whose own test IS green, still gets a
+    // real verdict rather than being swept up with it.
+    const forG = out.mutants.probed.filter((m: { file: string }) =>
+      m.file.endsWith('g.ts'),
+    );
+    expect(forG.length).toBeGreaterThan(0);
+    expect(
+      forG.every((m: { verdict: string }) => m.verdict !== 'inconclusive'),
+    ).toBe(true);
+  });
+
   it('a control that could not be SET UP leaves the window spendable', async () => {
     // `null` is not `false`, and this is where the difference is observable.
     // A control that never ran demonstrated nothing about the runner, so the

--- a/packages/cli/src/commands/review/test-efficacy.ts
+++ b/packages/cli/src/commands/review/test-efficacy.ts
@@ -1998,6 +1998,31 @@ async function runTestEfficacy(args: TestEfficacyArgs): Promise<void> {
             );
           }
           for (const c of harnessValidated === false ? [] : candidates) {
+            // The hunk loop's rule, which the mutants needed just as much.
+            // A mutant runs against `greenProbes` only, so a file whose OWN
+            // test was red in the unmutated baseline has that test excluded
+            // from the run — and then "every affected test still passed"
+            // is computed over a set that omits the one test most likely to
+            // catch the deletion. Measured live on PR #8213: six hunks in
+            // `bridge.ts` were correctly held at `inconclusive` because
+            // `bridge.test.ts` was not green, while eight mutants in the SAME
+            // file were scored `survived` and shipped as findings.
+            //
+            // The comment below this loop framed the asymmetry as "mutants
+            // guard the killed direction, hunks guard the survived one". That
+            // is true of an inconclusive RUN; it left the survived direction
+            // of a mutant unguarded against an absent covering test. Checked
+            // before the budget, because a candidate that cannot yield a
+            // verdict should not spend a suite run to say so.
+            const own = collocatedProbe(c.file, probes);
+            if (own && !greenProbes.includes(own)) {
+              mutantResults.push({
+                ...c,
+                verdict: 'inconclusive' as const,
+                detail: `this mutant's collocated test ${own} did not run green in the unmutated baseline (likely a compile or import error in the probe tree), so the remaining probes passing cannot show the statement is uncovered`,
+              });
+              continue;
+            }
             const remaining = mutantDeadline - now();
             if (!fitsAnotherMutantRun(remaining, estimatedRunMs)) {
               mutantsSkippedForBudget =
@@ -2027,9 +2052,12 @@ async function runTestEfficacy(args: TestEfficacyArgs): Promise<void> {
             // case this exists for: a probe-tree import error that collected
             // nothing) cannot be scored `survived`: the other probes passing
             // shows only that THEY do not cover it, not that nothing does, since
-            // the one test that would catch it never ran. Same asymmetry the
-            // mutants hold, pointed the other way: there an inconclusive run is
-            // never `killed`, here an absent covering test is never `survived`.
+            // the one test that would catch it never ran. The mutants hold
+            // BOTH halves of this now: an inconclusive run is never `killed`,
+            // and — since the loop above gained the same collocated check —
+            // an absent covering test is never `survived` there either. The
+            // two halves are separate guards; having one was read as having
+            // the rule, and eight mutant survivors shipped through the gap.
             const own = collocatedProbe(h.file, probes);
             if (own && !greenProbes.includes(own)) {
               const { patch: _patch, ...meta } = h;


### PR DESCRIPTION
## What this PR does

Applies the hunk loop's collocated-test guard to the mutant loop, so a mutant in a file whose **own** test was red in the unmutated baseline is held at `inconclusive` instead of being scored `survived`.

Found by dogfooding — running `/review` against #8213 with `qwen3.8-max-preview`. In one run, `packages/acp-bridge/src/bridge.ts` produced:

| | verdict | why |
| --- | --- | --- |
| 6 hunk probes | `inconclusive` | collocated `bridge.test.ts` did not run green in the baseline |
| 8 mutants (same file) | **`survived`** → 8 findings | "every affected test still PASSED with this statement deleted" |

Same file, same cause, opposite conclusions — and the eight became findings an author would act on.

**Mechanism.** A mutant runs against `greenProbes` only, so a red collocated test is excluded from the run. "Every affected test still passed" is then computed over a set that omits the one test most likely to catch the deletion — exactly the inference the hunk loop refuses in its own words: *the other probes passing shows only that THEY do not cover it, not that nothing does*.

**How the gap survived review.** The comment under the hunk guard framed the asymmetry as "mutants guard the `killed` direction, hunks guard the `survived` one". That is true of an inconclusive *run*, and it left a mutant's `survived` direction unguarded against an absent covering test. Two separate guards, one of which read as the whole rule. That comment is corrected here too.

The check runs **before** the budget test, so a candidate that cannot yield a verdict does not spend a suite run to say so.

## Reviewer Test Plan

### How to verify

- Run `cd packages/cli && npx vitest run src/commands/review src/commands/review.test.ts`; expect 47 files / 1436 tests green.
- The new case is `holds a mutant at inconclusive when its OWN test was red in the baseline` in `test-efficacy.integration.test.ts`. Delete the guard in `test-efficacy.ts` and it fails with `expected 'survived' to be 'inconclusive'` — the same sentence #8213 produced live.

### Evidence (Before & After)

Before, on #8213: `mutants -> {killed: 0, survived: 8}` on `bridge.ts`, alongside `hunks -> {inconclusive: 6}` on the same file for the stated reason. After: those mutants report `inconclusive` naming `bridge.test.ts`, and no `mutant-survived` finding is emitted for the file.

The regression test carries **both** halves — a file whose own test is red (`f.ts`) and one whose own test is green (`g.ts`) — because a guard that swept up the second would be no better than the gap it closes. Non-UI: N/A.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

## Risk & Scope

- Strictly silence-biased: it can only turn a `survived` into an `inconclusive`, never the reverse, so no new finding can be produced by this change.
- Costs nothing — the check is before the budget gate, so held candidates return their suite run to the window.
- Breaking changes: none.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

把 hunk 循环里的「同位测试」守卫补到变异体循环上：若某文件**自身**的测试在未变异基线中就是红的，该文件里的变异体判为 `inconclusive`，而不是 `survived`。

这是 dogfooding 发现的 —— 用 `qwen3.8-max-preview` 对 #8213 实跑 `/review`。同一次运行里，`packages/acp-bridge/src/bridge.ts` 产出了：6 个 hunk 判 `inconclusive`（理由：同位的 `bridge.test.ts` 基线未跑绿），而**同一文件**的 8 个变异体判 `survived` 并发出了 8 条 finding。同一文件、同一原因、相反结论 —— 而那 8 条会被作者当作"这些语句没有测试覆盖"去处理。

**机制**：变异体只在 `greenProbes` 上运行，红的同位测试被排除在运行之外；于是"每个受影响的测试删掉该语句后仍然通过"是在一个**缺少了最可能抓住它的那个测试**的集合上算出来的 —— 正是 hunk 循环用自己的话拒绝过的推理：*其他探针通过只说明它们不覆盖它，不说明没有东西覆盖它*。

**这个缺口是怎么通过评审的**：hunk 守卫下方的注释把这种不对称表述为"变异体守 `killed` 方向，hunk 守 `survived` 方向"。这对"不确定的**运行**"是成立的，但它让变异体的 `survived` 方向对"缺失的覆盖测试"毫无防护。两道独立的守卫，其中一道被当成了整条规则。该注释一并修正。

检查放在预算判定**之前**，因此一个无法得出结论的候选不会为了说这句话而花掉一次套件运行。

## Reviewer 测试计划

- 执行 `cd packages/cli && npx vitest run src/commands/review src/commands/review.test.ts`；预期 47 文件 / 1436 测试全绿。
- 新增用例为 `test-efficacy.integration.test.ts` 中的 `holds a mutant at inconclusive when its OWN test was red in the baseline`。删掉 `test-efficacy.ts` 里的守卫，它会以 `expected 'survived' to be 'inconclusive'` 变红 —— 与 #8213 实跑时产生的是同一句话。

### 证据（前后对比）

修复前在 #8213 上：`bridge.ts` 报 `mutants -> {killed: 0, survived: 8}`，同一文件的 `hunks -> {inconclusive: 6}` 且理由如上。修复后：这些变异体报 `inconclusive` 并点名 `bridge.test.ts`，该文件不再产出 `mutant-survived` finding。

回归测试同时包含**两半** —— 自身测试为红的 `f.ts` 与自身测试为绿的 `g.ts` —— 因为一个会把后者也一并扫掉的守卫，并不比它所修补的缺口更好。非 UI 改动：不适用。

## 风险与影响范围

- 严格偏静默：只能把 `survived` 变成 `inconclusive`，不能反向，因此这个改动不会**产生**任何新 finding。
- 无额外开销：检查在预算门之前，被拦下的候选会把套件运行的额度还给窗口。
- 破坏性变更：无。

</details>
