### PR TITLE
feat(ci): expand code owner pool for packages/core

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,10 +3,10 @@
 # ============================================================
 
 # --- CODEOWNERS file itself ---
-/.github/CODEOWNERS    @pomelo-nwu
+/.github/CODEOWNERS    @pomelo-nwu @wenshao
 
 # --- Core package ---
-/packages/core/        @wenshao @tanzhenxin @yiliang114 @LaZzyMan
+/packages/core/        @wenshao @tanzhenxin @yiliang114 @LaZzyMan @doudouOUC
 
 # --- CUA Driver & Mobile MCP ---
 /packages/cua-driver/  @LaZzyMan


### PR DESCRIPTION
## What this PR does

Expands the code owner pool to reduce blocking when a specific maintainer is unavailable:

| Path | Before | After |
|------|--------|-------|
| `/packages/core/` | `@wenshao @tanzhenxin @yiliang114 @LaZzyMan` | + `@doudouOUC` |
| `/.github/CODEOWNERS` | `@pomelo-nwu` | + `@wenshao` |

## Why it's needed

Maintainer PRs touching `packages/core/` require code owner approval (ruleset `require_code_owner_review: true`). With only 3 potential approvers (excluding the author), it's common to be blocked when all of them are offline, on leave, or away. Adding `@doudouOUC` — the most active non-maintainer core contributor (14 commits in the last 3 months) — gives one more person who can approve.

Adding `@wenshao` to the CODEOWNERS file entry avoids a single-person bottleneck on CODEOWNERS changes themselves.

## Reviewer Test Plan

### How to verify

1. Confirm `@doudouOUC` appears on the `/packages/core/` line
2. Open a test PR touching one core file and confirm `@doudouOUC` is auto-assigned as a code owner reviewer

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

## Risk & Scope

- No workflow or script changes — pure CODEOWNERS edit.
- `@doudouOUC` gains code owner approval rights for `packages/core/`.

## Linked Issues

Supersedes #7469. Follow-up to #7376.

<details>
<summary>中文说明</summary>

扩大 code owner 池，减少因特定 maintainer 不在线而被阻塞的概率。`@doudouOUC` 是近 3 个月最活跃的非 maintainer core 贡献者（14 次提交），加入后 maintainer 开 PR 时有 4 个潜在 approver 可找。同时将 `@wenshao` 加入 CODEOWNERS 文件自身的 owner 列表，避免改 CODEOWNERS 时只能等一个人。

</details>