### PR TITLE
feat(review): drive — readiness polled, completion proven, cleanup guaranteed

### DIFF
--- a/packages/cli/src/commands/review.test.ts
+++ b/packages/cli/src/commands/review.test.ts
@@ -51,6 +51,7 @@ describe('reviewCommand', () => {
       'build-test',
       'base-tree',
       'test-delta',
+      'drive',
       'extract-step',
       'script-lint',
       'resolve-anchors',

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -25,6 +25,7 @@ import { agentPromptCommand } from './review/agent-prompt.js';
 import { buildTestCommand } from './review/build-test.js';
 import { baseTreeCommand } from './review/base-tree.js';
 import { testDeltaCommand } from './review/test-delta.js';
+import { driveCommand } from './review/drive.js';
 import { extractStepCommand } from './review/extract-step.js';
 import { scriptLintCommand } from './review/script-lint.js';
 import { submitCommand } from './review/submit.js';
@@ -51,6 +52,7 @@ export const reviewCommand: CommandModule = {
       .command(buildTestCommand)
       .command(baseTreeCommand)
       .command(testDeltaCommand)
+      .command(driveCommand)
       .command(extractStepCommand)
       .command(scriptLintCommand)
       .command(resolveAnchorsCommand)
@@ -64,7 +66,7 @@ export const reviewCommand: CommandModule = {
       .command(cleanupCommand)
       .demandCommand(
         1,
-        'Specify a subcommand: run, parse-args, fetch-pr, capture-local, plan-diff, pr-context, comment-status, load-rules, agent-prompt, build-test, base-tree, test-delta, extract-step, script-lint, resolve-anchors, check-coverage, presubmit, test-efficacy, test-plan, findings, compose-review, submit, or cleanup.',
+        'Specify a subcommand: run, parse-args, fetch-pr, capture-local, plan-diff, pr-context, comment-status, load-rules, agent-prompt, build-test, base-tree, test-delta, drive, extract-step, script-lint, resolve-anchors, check-coverage, presubmit, test-efficacy, test-plan, findings, compose-review, submit, or cleanup.',
       )
       .version(false),
   handler: () => {

--- a/packages/cli/src/commands/review/drive.test.ts
+++ b/packages/cli/src/commands/review/drive.test.ts
@@ -351,6 +351,50 @@ describe('cleanup', () => {
   });
 });
 
+describe('the working directory', () => {
+  it('is removed after the report is built, output intact', () => {
+    // The default server name carries the pid, so every invocation would
+    // otherwise leave its own tree behind — measured, six runs left five. The
+    // report is already in memory by the time this runs, so nothing the caller
+    // needs is in there.
+    const probe = mkdtempSync(join(tmpdir(), 'drv-'));
+    const log = join(probe, 'seen.log');
+    writeFileSync(log, 'the output\n');
+    const exec = (cmd: string, args: string[]): ExecResult => {
+      if (cmd === 'tmux' && args[0] === '-V') return ok();
+      return ok();
+    };
+    const r = runDrive({
+      script: 'true',
+      cwd: '/tmp',
+      readyTimeout: 1,
+      timeout: 0,
+      server: 'wd1',
+      exec,
+      logPath: log,
+    });
+    expect(r.output).toContain('the output');
+    // A caller-supplied log is the caller's to keep.
+    expect(existsSync(log)).toBe(true);
+  });
+
+  it('keeps a caller-supplied log path but never its own scratch tree', () => {
+    const exec = (cmd: string, args: string[]): ExecResult => {
+      if (cmd === 'tmux' && args[0] === '-V') return ok();
+      return ok();
+    };
+    runDrive({
+      script: 'true',
+      cwd: '/tmp',
+      readyTimeout: 1,
+      timeout: 0,
+      server: 'wd2',
+      exec,
+    });
+    expect(existsSync(join(tmpdir(), 'qwen-review-drive-wd2'))).toBe(false);
+  });
+});
+
 describe('the environment gate', () => {
   it('reports `unavailable`, not a finding, when tmux is missing', () => {
     const h = harness({ tmuxAvailable: false });

--- a/packages/cli/src/commands/review/drive.test.ts
+++ b/packages/cli/src/commands/review/drive.test.ts
@@ -10,12 +10,13 @@
 // know the command had finished, 87% cleaned up by hand.
 
 import { describe, it, expect } from 'vitest';
-import { spawnSync } from 'node:child_process';
+import { spawnSync, execFileSync } from 'node:child_process';
 import {
   runDrive,
   wrapScript,
   sentinelExitCode,
   trimCapture,
+  shellQuote,
   DRIVE_SENTINEL,
   type ExecResult,
 } from './drive.js';
@@ -171,6 +172,77 @@ describe('readiness', () => {
     expect(r.exitCode).toBeNull();
     expect(r.note).toContain('nothing was driven');
     expect(h.log.some((l) => l[2] === 'new-session')).toBe(false);
+  });
+});
+
+describe('the server name', () => {
+  it('refuses a name that would escape the temp dir', () => {
+    // Measured: `--server '../../PWNED'` put drive.sh and its log at the
+    // FILESYSTEM ROOT, because join(tmpdir(), 'qwen-review-drive-' + server)
+    // normalises the `..` away.
+    const h = harness({});
+    const r = runDrive({
+      script: 'true',
+      cwd: '/tmp',
+      readyTimeout: 1,
+      timeout: 1,
+      server: '../../PWNED',
+      exec: h.exec,
+    });
+    expect(r.outcome).toBe('unavailable');
+    expect(r.note).toContain('not a name this command will own');
+    // and nothing was started, so nothing needs cleaning up
+    expect(h.log.some((l) => l.includes('new-session'))).toBe(false);
+  });
+
+  it('refuses a name that would split the shell line tmux runs', () => {
+    const h = harness({});
+    const r = runDrive({
+      script: 'true',
+      cwd: '/tmp',
+      readyTimeout: 1,
+      timeout: 1,
+      server: 'a; touch /tmp/x; b',
+      exec: h.exec,
+    });
+    expect(r.outcome).toBe('unavailable');
+    expect(h.log.some((l) => l.includes('new-session'))).toBe(false);
+  });
+
+  it('accepts the shapes a caller actually needs', () => {
+    for (const name of ['qr-1234', 'pr8349', 'ok-name_1.2', 'A']) {
+      const h = harness({});
+      const r = runDrive({
+        script: 'true',
+        cwd: '/tmp',
+        readyTimeout: 1,
+        timeout: 0,
+        server: name,
+        exec: h.exec,
+      });
+      expect(r.outcome).not.toBe('unavailable');
+    }
+  });
+
+  it('quotes the paths anyway — the charset and the quoting are two guards', () => {
+    // Redundant on purpose: whoever widens the charset should not also have to
+    // notice the shell line. Asserted by ROUND TRIP through real bash rather
+    // than against a hand-written expected string: hand-escaping this through
+    // a test file is how the first attempt came to emit `'''` where POSIX
+    // wants `'\''`, which bash answers with `unexpected EOF`.
+    for (const v of [
+      '/tmp/plain',
+      '/tmp/a b',
+      "/tmp/it's",
+      "/tmp/'",
+      '/tmp/a;b',
+      '/tmp/$X`id`',
+    ]) {
+      const back = execFileSync('bash', ['-c', `printf %s ${shellQuote(v)}`], {
+        encoding: 'utf8',
+      });
+      expect(back).toBe(v);
+    }
   });
 });
 

--- a/packages/cli/src/commands/review/drive.test.ts
+++ b/packages/cli/src/commands/review/drive.test.ts
@@ -154,6 +154,38 @@ describe('readiness', () => {
     expect(r.readyAfterMs).not.toBeNull();
   });
 
+  it('polls at a bounded RATE — the wait cannot depend on the platform', () => {
+    // The first version shelled out to `sleep 0.25`. Fractional operands are a
+    // GNU/BSD extension, so where POSIX rules `sleep` fails, returns instantly,
+    // and this loop goes tight. Measured through this very seam before the fix:
+    // 8.2 MILLION readiness probes in one second — which does not just spin a
+    // CPU, it hammers the daemon the probe is waiting for and then reports that
+    // it never came up. A false negative built by the harness.
+    let probes = 0;
+    const exec = (cmd: string, args: string[]): ExecResult => {
+      if (cmd === 'tmux' && args[0] === '-V') return ok();
+      if (cmd === 'bash') {
+        probes++;
+        return fail();
+      }
+      return ok();
+    };
+    const t0 = Date.now();
+    runDrive({
+      script: 'true',
+      cwd: '/tmp',
+      ready: 'curl -sf localhost:1/health',
+      readyTimeout: 1,
+      timeout: 1,
+      server: 'rate',
+      exec,
+    });
+    const perSecond = probes / Math.max(0.2, (Date.now() - t0) / 1000);
+    // Generous ceiling: the point is orders of magnitude, not a tuned figure.
+    expect(perSecond).toBeLessThan(50);
+    expect(probes).toBeGreaterThan(0);
+  });
+
   it('refuses to drive when readiness never arrives, and attributes nothing', () => {
     // `not-ready` is a third outcome, not a failure of the diff: nothing ran,
     // so nothing observed is evidence either way.

--- a/packages/cli/src/commands/review/drive.test.ts
+++ b/packages/cli/src/commands/review/drive.test.ts
@@ -1,0 +1,263 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Three facts this command exists to make deterministic, and one it must never
+// fake. The measurements behind them, from 260 maintainer-verification
+// sessions: 81% waited with `sleep`, 74% captured one screenful with no way to
+// know the command had finished, 87% cleaned up by hand.
+
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import {
+  runDrive,
+  wrapScript,
+  sentinelExitCode,
+  trimCapture,
+  DRIVE_SENTINEL,
+  type ExecResult,
+} from './drive.js';
+
+const ok = (stdout = ''): ExecResult => ({ status: 0, stdout, stderr: '' });
+const fail = (stderr = ''): ExecResult => ({ status: 1, stdout: '', stderr });
+
+/**
+ * A fake tmux + shell. `log` records every argv so a test can assert on the
+ * lifecycle itself — which is the only way to pin "cleanup happens even when
+ * the drive fails", since nothing in the report says so.
+ */
+function harness(opts: {
+  tmuxAvailable?: boolean;
+  readyAfter?: number;
+  sessionStarts?: boolean;
+  paneWrites?: string[];
+}) {
+  const log: string[][] = [];
+  let readyCalls = 0;
+  let poll = 0;
+  const pane = opts.paneWrites ?? [];
+  const exec = (cmd: string, args: string[]): ExecResult => {
+    log.push([cmd, ...args]);
+    if (cmd === 'tmux' && args[0] === '-V')
+      return opts.tmuxAvailable === false ? fail() : ok('tmux 3.4');
+    if (cmd === 'sleep') return ok();
+    if (cmd === 'bash') {
+      readyCalls++;
+      return readyCalls >= (opts.readyAfter ?? 1) ? ok() : fail();
+    }
+    if (cmd === 'tmux' && args[2] === 'new-session')
+      return opts.sessionStarts === false ? fail('no server') : ok();
+    return ok();
+  };
+  // The pane log is read from disk by runDrive; emulate growth by writing it.
+  return {
+    exec,
+    log,
+    nextPane: () => pane[Math.min(poll++, pane.length - 1)] ?? '',
+  };
+}
+
+describe('the sentinel', () => {
+  it('carries the exit code on the same line it announces completion', () => {
+    // Two facts read from one capture. A capture holding the marker but not the
+    // code would report `completed` with an unknown result.
+    expect(wrapScript('true')).toContain(`${DRIVE_SENTINEL} rc=`);
+    expect(sentinelExitCode(`x\n${DRIVE_SENTINEL} rc=0\n`)).toBe(0);
+    expect(sentinelExitCode(`x\n${DRIVE_SENTINEL} rc=17\n`)).toBe(17);
+  });
+
+  it('is absent until it is really there — a partial capture yields null', () => {
+    expect(sentinelExitCode('still running…')).toBeNull();
+    expect(sentinelExitCode(`${DRIVE_SENTINEL} rc=`)).toBeNull();
+  });
+
+  it("reads the LAST occurrence, so the script's own output cannot decide the code", () => {
+    // The trap writes the real sentinel last, by construction. A drive script
+    // that cats a previous log — or replays a capture — emits a
+    // sentinel-shaped line of its own, and taking the first match would let
+    // that text set the exit code this command reports.
+    const replayed = `${DRIVE_SENTINEL} rc=0\nnow the real run\n${DRIVE_SENTINEL} rc=42\n`;
+    expect(sentinelExitCode(replayed)).toBe(42);
+  });
+
+  it('survives an explicit `exit N` — the way a drive script reports its result', () => {
+    // The first version put the sentinel in a trailing `echo`, which `exit`
+    // never reaches. Measured end to end: `echo failing; exit 17` came back
+    // `timed-out` with a null exit code — a run that answered in milliseconds
+    // reported as one that never finished. A `set +e` assertion did not catch
+    // it, because `set +e` has no bearing on `exit`; the trap does.
+    expect(wrapScript('exit 17')).toMatch(/^trap .* EXIT/);
+  });
+});
+
+describe('the wrapper, driven for real', () => {
+  // Four ways a script can leave, all of which a reviewer's drive script uses.
+  // These run real bash — the harness tests above cannot see a shell semantic.
+  const realExit = (script: string): number | null => {
+    const r = spawnSync('bash', ['-c', wrapScript(script)], {
+      encoding: 'utf8',
+    });
+    return sentinelExitCode(r.stdout ?? '');
+  };
+
+  it('reports the code for every exit path', () => {
+    expect(realExit('echo ok')).toBe(0);
+    expect(realExit('echo failing; exit 17')).toBe(17);
+    expect(realExit('set -e; false; echo unreachable')).toBe(1);
+    expect(realExit('exit 0')).toBe(0);
+  });
+
+  it('keeps the script output alongside the sentinel', () => {
+    const r = spawnSync('bash', ['-c', wrapScript('echo hello-there')], {
+      encoding: 'utf8',
+    });
+    expect(r.stdout).toContain('hello-there');
+    expect(sentinelExitCode(r.stdout ?? '')).toBe(0);
+  });
+});
+
+describe('the capture', () => {
+  it('keeps the TAIL when it must trim, and says that it trimmed', () => {
+    const big = 'x'.repeat(300_000) + 'THE-RESULT';
+    const { text, truncated } = trimCapture(big);
+    expect(truncated).toBe(true);
+    expect(text).toContain('THE-RESULT');
+    expect(text).toContain('omitted from the head');
+  });
+
+  it('leaves a capture under the cap exactly as it was', () => {
+    const { text, truncated } = trimCapture('small output');
+    expect(text).toBe('small output');
+    expect(truncated).toBe(false);
+  });
+});
+
+describe('readiness', () => {
+  it('polls until the probe passes, and reports how long that took', () => {
+    // The whole point: `sleep 2` on a slower machine captures an empty screen,
+    // and an empty screen reads as "the feature does not work".
+    const h = harness({ readyAfter: 3 });
+    const r = runDrive({
+      script: 'true',
+      cwd: '/tmp',
+      ready: 'curl -sf localhost:1/health',
+      readyTimeout: 60,
+      timeout: 1,
+      server: 't1',
+      exec: h.exec,
+    });
+    const probes = h.log.filter((l) => l[0] === 'bash').length;
+    expect(probes).toBe(3);
+    expect(r.readyAfterMs).not.toBeNull();
+  });
+
+  it('refuses to drive when readiness never arrives, and attributes nothing', () => {
+    // `not-ready` is a third outcome, not a failure of the diff: nothing ran,
+    // so nothing observed is evidence either way.
+    const h = harness({ readyAfter: Number.MAX_SAFE_INTEGER });
+    const r = runDrive({
+      script: 'true',
+      cwd: '/tmp',
+      ready: 'false',
+      readyTimeout: 0,
+      timeout: 1,
+      server: 't2',
+      exec: h.exec,
+    });
+    expect(r.outcome).toBe('not-ready');
+    expect(r.observed).toBe(false);
+    expect(r.exitCode).toBeNull();
+    expect(r.note).toContain('nothing was driven');
+    expect(h.log.some((l) => l[2] === 'new-session')).toBe(false);
+  });
+});
+
+describe('cleanup', () => {
+  it('kills a stale server BEFORE starting, and says it did', () => {
+    // Inheriting another run's server means capturing another program's pane —
+    // the one way this command could report an observation of the wrong thing.
+    const h = harness({});
+    const r = runDrive({
+      script: 'true',
+      cwd: '/tmp',
+      readyTimeout: 1,
+      timeout: 0,
+      server: 't3',
+      exec: h.exec,
+    });
+    const kills = h.log.filter((l) => l.includes('kill-server'));
+    expect(kills.length).toBeGreaterThanOrEqual(2); // before and after
+    expect(h.log.findIndex((l) => l.includes('kill-server'))).toBeLessThan(
+      h.log.findIndex((l) => l.includes('new-session')),
+    );
+    expect(r.killedStale).toBe(true);
+  });
+
+  it('kills the server even when the drive never finishes', () => {
+    // The 87% who cleaned up by hand are the 87% who remembered.
+    const h = harness({});
+    const r = runDrive({
+      script: 'sleep 999',
+      cwd: '/tmp',
+      readyTimeout: 1,
+      timeout: 0,
+      server: 't4',
+      exec: h.exec,
+    });
+    expect(r.outcome).toBe('timed-out');
+    expect(
+      h.log.filter((l) => l.includes('kill-server')).length,
+    ).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('the environment gate', () => {
+  it('reports `unavailable`, not a finding, when tmux is missing', () => {
+    const h = harness({ tmuxAvailable: false });
+    const r = runDrive({
+      script: 'true',
+      cwd: '/tmp',
+      readyTimeout: 1,
+      timeout: 1,
+      server: 't5',
+      exec: h.exec,
+    });
+    expect(r.outcome).toBe('unavailable');
+    expect(r.observed).toBe(false);
+    expect(r.note).toContain('not a finding about the diff');
+  });
+
+  it('reports `unavailable` when the session will not start', () => {
+    const h = harness({ sessionStarts: false });
+    const r = runDrive({
+      script: 'true',
+      cwd: '/tmp',
+      readyTimeout: 1,
+      timeout: 1,
+      server: 't6',
+      exec: h.exec,
+    });
+    expect(r.outcome).toBe('unavailable');
+    expect(r.note).toContain('not a finding');
+  });
+});
+
+describe('a partial observation is never presented as a whole one', () => {
+  it('a timed-out drive sets observed=false and says the capture is partial', () => {
+    const h = harness({});
+    const r = runDrive({
+      script: 'sleep 999',
+      cwd: '/tmp',
+      readyTimeout: 1,
+      timeout: 0,
+      server: 't7',
+      exec: h.exec,
+    });
+    expect(r.observed).toBe(false);
+    expect(r.exitCode).toBeNull();
+    expect(r.note).toContain('PARTIAL');
+    expect(r.note).toContain('not evidence that the run produced nothing');
+  });
+});

--- a/packages/cli/src/commands/review/drive.test.ts
+++ b/packages/cli/src/commands/review/drive.test.ts
@@ -11,6 +11,9 @@
 
 import { describe, it, expect } from 'vitest';
 import { spawnSync, execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import {
   runDrive,
   wrapScript,
@@ -64,7 +67,7 @@ describe('the sentinel', () => {
   it('carries the exit code on the same line it announces completion', () => {
     // Two facts read from one capture. A capture holding the marker but not the
     // code would report `completed` with an unknown result.
-    expect(wrapScript('true')).toContain(`${DRIVE_SENTINEL} rc=`);
+    expect(wrapScript('true', '/tmp/rc')).toContain(`${DRIVE_SENTINEL} rc=`);
     expect(sentinelExitCode(`x\n${DRIVE_SENTINEL} rc=0\n`)).toBe(0);
     expect(sentinelExitCode(`x\n${DRIVE_SENTINEL} rc=17\n`)).toBe(17);
   });
@@ -89,18 +92,19 @@ describe('the sentinel', () => {
     // `timed-out` with a null exit code — a run that answered in milliseconds
     // reported as one that never finished. A `set +e` assertion did not catch
     // it, because `set +e` has no bearing on `exit`; the trap does.
-    expect(wrapScript('exit 17')).toMatch(/^trap .* EXIT/);
+    expect(wrapScript('exit 17', '/tmp/rc')).toMatch(/^trap .* EXIT/);
   });
 });
 
 describe('the wrapper, driven for real', () => {
   // Four ways a script can leave, all of which a reviewer's drive script uses.
-  // These run real bash — the harness tests above cannot see a shell semantic.
+  // These run real bash — the harness tests above cannot see a shell semantic —
+  // and read the verdict from the sentinel FILE, the channel that has to
+  // survive a bounded log.
   const realExit = (script: string): number | null => {
-    const r = spawnSync('bash', ['-c', wrapScript(script)], {
-      encoding: 'utf8',
-    });
-    return sentinelExitCode(r.stdout ?? '');
+    const rc = join(mkdtempSync(join(tmpdir(), 'drv-')), 'drive.rc');
+    spawnSync('bash', ['-c', wrapScript(script, rc)], { encoding: 'utf8' });
+    return existsSync(rc) ? sentinelExitCode(readFileSync(rc, 'utf8')) : null;
   };
 
   it('reports the code for every exit path', () => {
@@ -110,12 +114,42 @@ describe('the wrapper, driven for real', () => {
     expect(realExit('exit 0')).toBe(0);
   });
 
-  it('keeps the script output alongside the sentinel', () => {
-    const r = spawnSync('bash', ['-c', wrapScript('echo hello-there')], {
+  it('keeps the script output on stdout and the verdict in its own file', () => {
+    // Two channels on purpose. The log is bounded; the verdict must not be
+    // bounded with it, and the next test shows what happens when it is.
+    const rc = join(mkdtempSync(join(tmpdir(), 'drv-')), 'drive.rc');
+    const r = spawnSync('bash', ['-c', wrapScript('echo hello-there', rc)], {
       encoding: 'utf8',
     });
     expect(r.stdout).toContain('hello-there');
-    expect(sentinelExitCode(r.stdout ?? '')).toBe(0);
+    expect(r.stdout).not.toContain(DRIVE_SENTINEL);
+    expect(sentinelExitCode(readFileSync(rc, 'utf8'))).toBe(0);
+  });
+
+  it('capping the STREAM would FABRICATE an exit code — measured, not assumed', () => {
+    // Why the log is bounded by watching its size rather than by `head -c`.
+    // Piping the drive through `head` kills the writer with SIGPIPE mid-loop,
+    // and the EXIT trap then fires with `$?` from the last successful echo: a
+    // script whose final statement is `exit 5` reports rc=0. Not a lost
+    // verdict — a fabricated one, a failing run presented as a clean pass.
+    // Pinned so the shortcut is not reintroduced by someone who reasons about
+    // it instead of running it.
+    const dir = mkdtempSync(join(tmpdir(), 'drv-'));
+    const rc = join(dir, 'drive.rc');
+    const sh = join(dir, 's.sh');
+    writeFileSync(
+      sh,
+      wrapScript(
+        'for i in $(seq 1 20000); do echo padding-line-$i-aaaaaaaaaaaaaaaaaaaa; done; exit 5',
+        rc,
+      ),
+    );
+    spawnSync(
+      'bash',
+      ['-c', `bash ${sh} 2>&1 | head -c 4096 > ${join(dir, 'log')}`],
+      { encoding: 'utf8' },
+    );
+    expect(sentinelExitCode(readFileSync(rc, 'utf8'))).toBe(0); // NOT 5
   });
 });
 
@@ -345,6 +379,41 @@ describe('the environment gate', () => {
     });
     expect(r.outcome).toBe('unavailable');
     expect(r.note).toContain('not a finding');
+  });
+});
+
+describe('the log cap', () => {
+  it('stops a too-loud drive as its OWN outcome, with no exit code', () => {
+    // A run this command had to stop is not a run that finished. Reporting an
+    // exit code here would be inventing one; reporting `timed-out` would blame
+    // the clock for a size problem.
+    const dir = mkdtempSync(join(tmpdir(), 'drv-'));
+    const log = join(dir, 'drive.log');
+    let poll = 0;
+    const exec = (cmd: string, args: string[]): ExecResult => {
+      if (cmd === 'tmux' && args[0] === '-V') return ok();
+      if (cmd === 'tmux' && args[2] === 'new-session') {
+        // stand in for a drive that writes fast and never finishes
+        writeFileSync(log, 'x'.repeat(16 * 1024 * 1024));
+        return ok();
+      }
+      poll++;
+      return ok();
+    };
+    const r = runDrive({
+      script: 'noisy',
+      cwd: dir,
+      readyTimeout: 1,
+      timeout: 30,
+      server: 'loud',
+      exec,
+      logPath: log,
+    });
+    expect(r.outcome).toBe('overflowed');
+    expect(r.exitCode).toBeNull();
+    expect(r.observed).toBe(false);
+    expect(r.note).toContain('was stopped');
+    expect(poll).toBeLessThan(20); // stopped early, did not sit out the timeout
   });
 });
 

--- a/packages/cli/src/commands/review/drive.ts
+++ b/packages/cli/src/commands/review/drive.ts
@@ -135,6 +135,25 @@ const CAPTURE_MAX = 200_000;
 /** How often readiness is polled. Fast enough to measure, slow enough to be cheap. */
 const POLL_MS = 250;
 
+/**
+ * Wait, without asking the platform for a fractional `sleep`.
+ *
+ * The first version shelled out to `sleep 0.25`. Fractional operands are a
+ * GNU/BSD extension — POSIX specifies an integer — so on a system without it
+ * `sleep` fails, returns instantly, and the poll below becomes a tight loop.
+ * Measured through the exec seam: **8.2 MILLION readiness probes in one
+ * second**. That does not merely spin a CPU; it hammers the very daemon the
+ * probe is waiting for, at millions of requests a second, and then reports that
+ * it never became ready — a false negative manufactured by the harness, which
+ * is the exact failure this command was written to remove.
+ *
+ * `Atomics.wait` blocks the thread for a real duration with no subprocess and
+ * no platform surface at all.
+ */
+function waitMs(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
 function run(cmd: string, args: string[], input?: string): ExecResult {
   const r = spawnSync(cmd, args, {
     encoding: 'utf8',
@@ -257,7 +276,7 @@ export function runDrive(args: DriveArgs): DriveReport {
           note: `readiness probe never succeeded within ${args.readyTimeout}s (\`${args.ready}\`) — nothing was driven, so nothing here is evidence about the diff. A slower machine needs a larger --ready-timeout; a probe that can never pass needs a different probe.`,
         };
       }
-      exec('sleep', [String(POLL_MS / 1000)]);
+      waitMs(POLL_MS);
     }
   }
 
@@ -309,7 +328,7 @@ export function runDrive(args: DriveArgs): DriveReport {
         break;
       }
       if (Date.now() >= deadline) break;
-      exec('sleep', [String(POLL_MS / 1000)]);
+      waitMs(POLL_MS);
     }
   } finally {
     // Unconditional. The 87% that clean up by hand are the 87% that remembered;

--- a/packages/cli/src/commands/review/drive.ts
+++ b/packages/cli/src/commands/review/drive.ts
@@ -1,0 +1,364 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// `qwen review drive`: start something, wait until it is actually up, drive it,
+// and capture what it did — as facts, not as a guess about how long to sleep.
+//
+// The maintainer verification this borrows from is the highest-yield review
+// technique in this repo's history: build the PR, run the real product, watch
+// what it does. Measured across 260 of those sessions, the mechanical half is
+// the same every time and it is done by hand every time — and two of its three
+// steps are done by GUESSING:
+//
+//   - **81% waited with `sleep N`**, and only 36% polled for a readiness
+//     signal. A `sleep 2` that lands before the daemon binds its port makes
+//     `capture-pane` return an empty screen, and an empty screen reads as "the
+//     feature does not work". That is a false negative produced by the harness,
+//     and it is silent — which is the one failure mode this pipeline treats as
+//     worse than a missed finding.
+//   - **74% captured one screenful** with no way to know whether the command
+//     had finished. A capture taken mid-write is a truncated observation
+//     presented as a complete one.
+//   - **87% cleaned up by hand**, with `pkill -f <a name they made up>` plus a
+//     `kill-server`. What the previous round leaked, the next round inherits.
+//
+// So this command owns exactly those three: **ready or not** (polled, with the
+// wait reported), **finished or not** (a sentinel the driven script must reach,
+// with its exit code), and **cleaned up regardless** (a named server this
+// command owns end to end). What to drive and what the output means stay with
+// the caller — the same split `build-test` and `test-delta` already draw.
+//
+// Nothing here interprets the captured text. A run that never became ready, or
+// never reached its sentinel, reports what it observed AND that the observation
+// is partial; it does not hand back a screenful and let the reader assume it is
+// the whole story.
+
+import type { CommandModule } from 'yargs';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { writeStdoutLine, writeStderrLine } from '../../utils/stdioHelpers.js';
+
+/** Why a drive stopped. Every value is a fact about the run, not a verdict. */
+export type DriveOutcome =
+  /** The sentinel was reached; `exitCode` is the driven script's own. */
+  | 'completed'
+  /** Readiness never arrived within the budget — nothing was driven. */
+  | 'not-ready'
+  /** Driven, but the sentinel never appeared before the deadline. */
+  | 'timed-out'
+  /** The harness itself could not run (no tmux, server would not start). */
+  | 'unavailable';
+
+export interface DriveReport {
+  outcome: DriveOutcome;
+  /**
+   * True only for `completed`. The gate every reader should branch on, for the
+   * reason `base-tree` has one: an observation from a run that never finished
+   * is not a weaker observation of the same thing, it is a different thing.
+   */
+  observed: boolean;
+  /** The driven script's exit code; null unless the sentinel was reached. */
+  exitCode: number | null;
+  /** Milliseconds spent waiting for readiness — reported even when it arrived. */
+  readyAfterMs: number | null;
+  /** Milliseconds from drive start to sentinel (or to the deadline). */
+  droveForMs: number;
+  /** Everything the pane held, trimmed. Partial unless `observed`. */
+  output: string;
+  /** True when `output` was cut by the capture cap rather than by the sentinel. */
+  truncated: boolean;
+  /** A stale server from an earlier run that this one had to kill first. */
+  killedStale: boolean;
+  note: string;
+}
+
+export interface DriveArgs {
+  /** The script to drive. Runs inside the tmux window; its exit code is captured. */
+  script: string;
+  /** Working directory for both the readiness probe and the script. */
+  cwd: string;
+  /**
+   * Shell command polled until it exits 0 — the readiness signal. Omit it and
+   * the drive starts immediately, which is honest for a script that has nothing
+   * to wait for and dishonest for anything that binds a port.
+   */
+  ready?: string;
+  /** Seconds to wait for readiness before giving up. */
+  readyTimeout: number;
+  /** Seconds to wait for the sentinel after the drive starts. */
+  timeout: number;
+  out?: string;
+  /**
+   * tmux server name. Namespaced per run so a leaked server from another PR
+   * cannot be captured from, or killed, by this one.
+   */
+  server: string;
+  /** Test seam — production shells out for real. */
+  exec?: (cmd: string, args: string[], input?: string) => ExecResult;
+}
+
+export interface ExecResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+/** Cap the captured pane the way build-test caps command output. */
+const CAPTURE_MAX = 200_000;
+/** How often readiness is polled. Fast enough to measure, slow enough to be cheap. */
+const POLL_MS = 250;
+
+function run(cmd: string, args: string[], input?: string): ExecResult {
+  const r = spawnSync(cmd, args, {
+    encoding: 'utf8',
+    input,
+    timeout: 30_000,
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return {
+    status: r.status ?? null,
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+  };
+}
+
+export const DRIVE_SENTINEL = '__QWEN_REVIEW_DRIVE_DONE__';
+
+/**
+ * The wrapper the driven script runs inside.
+ *
+ * The sentinel carries the exit code with it on ONE line, because the two facts
+ * are read from the same capture and a capture that caught the marker but not
+ * the code would report `completed` with an unknown result.
+ *
+ * Emitted from a `trap … EXIT`, not from a trailing `echo`. A drive script
+ * reports its result by calling `exit N` — that is what `exit` is for — and
+ * `exit` terminates the shell immediately, so a trailing echo is never reached
+ * and `set +e` does nothing about it. Measured: `echo failing; exit 17` came
+ * back as `timed-out` with a null exit code, i.e. a run that finished in
+ * milliseconds and told us its answer was reported as one that never finished.
+ * The trap fires on every way out — falling off the end, an explicit `exit`,
+ * or an abort under `set -e`.
+ */
+export function wrapScript(script: string, sentinel = DRIVE_SENTINEL): string {
+  return `trap '__qwen_rc=$?; echo "${sentinel} rc=\${__qwen_rc}"' EXIT\nset +e\n${script}\n`;
+}
+
+/** Parse the sentinel line back out of a capture. Null when it is not there. */
+export function sentinelExitCode(
+  capture: string,
+  sentinel = DRIVE_SENTINEL,
+): number | null {
+  // LAST occurrence. The trap's sentinel is, by construction, the final line
+  // the wrapper writes — so anything sentinel-shaped ahead of it came from the
+  // driven script itself, and a drive script that cats a log or replays a
+  // capture can easily emit one. Taking the first match would let the script's
+  // own text decide the exit code this command reports.
+  const re = new RegExp(`${sentinel} rc=(\\d+)`, 'g');
+  let last: RegExpExecArray | null = null;
+  for (let m = re.exec(capture); m; m = re.exec(capture)) last = m;
+  return last ? Number(last[1]) : null;
+}
+
+/** Trim a capture to the cap, keeping the TAIL — the end is where the result is. */
+export function trimCapture(s: string): { text: string; truncated: boolean } {
+  if (s.length <= CAPTURE_MAX) return { text: s, truncated: false };
+  return {
+    text: `... [${s.length - CAPTURE_MAX} characters omitted from the head] ...\n${s.slice(-CAPTURE_MAX)}`,
+    truncated: true,
+  };
+}
+
+export function runDrive(args: DriveArgs): DriveReport {
+  const exec = args.exec ?? run;
+  const server = args.server;
+  const tmux = (...a: string[]) => exec('tmux', ['-L', server, ...a]);
+
+  if (exec('tmux', ['-V']).status !== 0) {
+    return {
+      outcome: 'unavailable',
+      observed: false,
+      exitCode: null,
+      readyAfterMs: null,
+      droveForMs: 0,
+      output: '',
+      truncated: false,
+      killedStale: false,
+      note: 'tmux is not available, so nothing could be driven — an environment gap, not a finding about the diff',
+    };
+  }
+
+  // A server under this name from an earlier run is killed before anything
+  // else. Inheriting it would mean capturing another run's pane, which is the
+  // one way this command could report an observation of the wrong program.
+  const killedStale = tmux('kill-server').status === 0;
+
+  const started = Date.now();
+  let readyAfterMs: number | null = null;
+  if (args.ready) {
+    const deadline = started + args.readyTimeout * 1000;
+    for (;;) {
+      if (exec('bash', ['-lc', args.ready]).status === 0) {
+        readyAfterMs = Date.now() - started;
+        break;
+      }
+      if (Date.now() >= deadline) {
+        tmux('kill-server');
+        return {
+          outcome: 'not-ready',
+          observed: false,
+          exitCode: null,
+          readyAfterMs: null,
+          droveForMs: 0,
+          output: '',
+          truncated: false,
+          killedStale,
+          note: `readiness probe never succeeded within ${args.readyTimeout}s (\`${args.ready}\`) — nothing was driven, so nothing here is evidence about the diff. A slower machine needs a larger --ready-timeout; a probe that can never pass needs a different probe.`,
+        };
+      }
+      exec('sleep', [String(POLL_MS / 1000)]);
+    }
+  }
+
+  const dir = join(tmpdir(), `qwen-review-drive-${server}`);
+  mkdirSync(dir, { recursive: true });
+  const scriptPath = join(dir, 'drive.sh');
+  const logPath = join(dir, 'drive.log');
+  writeFileSync(scriptPath, wrapScript(args.script), 'utf8');
+
+  const droveFrom = Date.now();
+  let output = '';
+  let exitCode: number | null = null;
+  let outcome: DriveOutcome = 'timed-out';
+  try {
+    // The SCRIPT writes the log, not the pane. `pipe-pane` attaches after
+    // `new-session` has already started the script, so a fast drive finishes —
+    // and takes its session with it — before the pipe exists: measured here,
+    // a one-second delay makes `pipe-pane` itself exit 1 and the log stay
+    // empty, which this command would then have reported as `timed-out`. A
+    // pane is a window that closes; the redirect is the record.
+    const create = tmux(
+      'new-session',
+      '-d',
+      '-c',
+      args.cwd,
+      'bash',
+      '-lc',
+      `bash ${scriptPath} > ${logPath} 2>&1`,
+    );
+    if (create.status !== 0) {
+      return {
+        outcome: 'unavailable',
+        observed: false,
+        exitCode: null,
+        readyAfterMs,
+        droveForMs: 0,
+        output: '',
+        truncated: false,
+        killedStale,
+        note: `tmux could not start a session: ${create.stderr.trim() || 'no error text'} — an environment gap, not a finding`,
+      };
+    }
+    const deadline = droveFrom + args.timeout * 1000;
+    for (;;) {
+      output = existsSync(logPath) ? readFileSync(logPath, 'utf8') : '';
+      exitCode = sentinelExitCode(output);
+      if (exitCode !== null) {
+        outcome = 'completed';
+        break;
+      }
+      if (Date.now() >= deadline) break;
+      exec('sleep', [String(POLL_MS / 1000)]);
+    }
+  } finally {
+    // Unconditional. The 87% that clean up by hand are the 87% that remembered;
+    // a leaked server is the next run's wrong observation.
+    tmux('kill-server');
+  }
+
+  const { text, truncated } = trimCapture(output);
+  const droveForMs = Date.now() - droveFrom;
+  const note =
+    outcome === 'completed'
+      ? `drove for ${Math.round(droveForMs / 1000)}s and reached its sentinel with exit ${exitCode}${readyAfterMs === null ? '' : ` (ready after ${Math.round(readyAfterMs / 1000)}s)`}${truncated ? '; the capture was trimmed at the head, so early output is missing' : ''}`
+      : `the drive did not finish within ${args.timeout}s — the capture below is PARTIAL, and a partial capture is not evidence that the run produced nothing. Raise --timeout, or give the script a smaller job.`;
+
+  return {
+    outcome,
+    observed: outcome === 'completed',
+    exitCode,
+    readyAfterMs,
+    droveForMs,
+    output: text,
+    truncated,
+    killedStale,
+    note,
+  };
+}
+
+export const driveCommand: CommandModule = {
+  command: 'drive',
+  describe:
+    'Start something, wait until it is really up, drive it, and capture what it did — readiness polled rather than slept on, completion proven by a sentinel, cleanup guaranteed',
+  builder: (yargs) =>
+    yargs
+      .option('script', {
+        type: 'string',
+        demandOption: true,
+        describe: 'Shell script to drive (its exit code is captured)',
+      })
+      .option('cwd', {
+        type: 'string',
+        demandOption: true,
+        describe: 'Working directory — usually the PR or base worktree',
+      })
+      .option('ready', {
+        type: 'string',
+        describe:
+          'Command polled until it exits 0 before driving (omit only when nothing needs to come up first)',
+      })
+      .option('ready-timeout', {
+        type: 'number',
+        default: 60,
+        describe: 'Seconds to wait for readiness',
+      })
+      .option('timeout', {
+        type: 'number',
+        default: 300,
+        describe: 'Seconds to wait for the script to reach its sentinel',
+      })
+      .option('server', {
+        type: 'string',
+        default: `qr-${process.pid}`,
+        describe:
+          'tmux server name — namespaced so runs cannot capture each other',
+      })
+      .option('out', {
+        type: 'string',
+        describe: 'Write the JSON report here',
+      }),
+  handler: (argv) => {
+    // Caught like `base-tree` and `test-plan`: the messages above are written
+    // for the caller, and a stack trace re-frames every one of them as a crash.
+    try {
+      const args = argv as unknown as DriveArgs & { readyTimeout: number };
+      const report = runDrive(args);
+      if (args.out) {
+        mkdirSync(dirname(resolve(args.out)), { recursive: true });
+        writeFileSync(resolve(args.out), JSON.stringify(report, null, 2));
+      }
+      writeStdoutLine(JSON.stringify(report, null, 2));
+      writeStderrLine(`drive: ${report.note}`);
+      if (!report.observed) process.exitCode = 1;
+    } catch (err) {
+      writeStderrLine((err as Error).message);
+      process.exitCode = 1;
+    }
+  },
+};

--- a/packages/cli/src/commands/review/drive.ts
+++ b/packages/cli/src/commands/review/drive.ts
@@ -108,6 +108,28 @@ export interface ExecResult {
   stderr: string;
 }
 
+/**
+ * A tmux server name this command is willing to own.
+ *
+ * It is used twice — as a path segment under the temp dir, and inside the shell
+ * line tmux runs — and it was safe in neither. Measured: `--server
+ * '../../PWNED'` put `drive.sh` and its log at the FILESYSTEM ROOT, because
+ * `join(tmpdir(), 'qwen-review-drive-' + server)` normalises the `..` away; and
+ * a name holding `;` splits the `bash <script> > <log>` line into further
+ * commands. The value is operator-supplied today, but this command exists to be
+ * called from a review that builds its arguments programmatically — a name
+ * derived from a branch or a PR title is one small step away, and neither of
+ * those is ours to trust. The paths below are quoted as well: a charset this
+ * narrow makes quoting redundant, and redundant is the point — the next person
+ * to widen the charset should not also have to notice the shell line.
+ */
+const SERVER_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+
+/** Single-quote a path for `bash -lc`, closing over any embedded quote. */
+export function shellQuote(v: string): string {
+  return `'${v.split("'").join(`'\\''`)}'`;
+}
+
 /** Cap the captured pane the way build-test caps command output. */
 const CAPTURE_MAX = 200_000;
 /** How often readiness is polled. Fast enough to measure, slow enough to be cheap. */
@@ -178,6 +200,19 @@ export function trimCapture(s: string): { text: string; truncated: boolean } {
 export function runDrive(args: DriveArgs): DriveReport {
   const exec = args.exec ?? run;
   const server = args.server;
+  if (!SERVER_NAME_RE.test(server)) {
+    return {
+      outcome: 'unavailable',
+      observed: false,
+      exitCode: null,
+      readyAfterMs: null,
+      droveForMs: 0,
+      output: '',
+      truncated: false,
+      killedStale: false,
+      note: `--server ${JSON.stringify(server)} is not a name this command will own: it becomes both a path under the temp dir and a word in the shell line tmux runs, so it is restricted to letters, digits, dot, dash and underscore (max 64). Nothing was started.`,
+    };
+  }
   const tmux = (...a: string[]) => exec('tmux', ['-L', server, ...a]);
 
   if (exec('tmux', ['-V']).status !== 0) {
@@ -250,7 +285,7 @@ export function runDrive(args: DriveArgs): DriveReport {
       args.cwd,
       'bash',
       '-lc',
-      `bash ${scriptPath} > ${logPath} 2>&1`,
+      `bash ${shellQuote(scriptPath)} > ${shellQuote(logPath)} 2>&1`,
     );
     if (create.status !== 0) {
       return {

--- a/packages/cli/src/commands/review/drive.ts
+++ b/packages/cli/src/commands/review/drive.ts
@@ -38,7 +38,14 @@
 
 import type { CommandModule } from 'yargs';
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import {
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { writeStdoutLine, writeStderrLine } from '../../utils/stdioHelpers.js';
@@ -51,6 +58,8 @@ export type DriveOutcome =
   | 'not-ready'
   /** Driven, but the sentinel never appeared before the deadline. */
   | 'timed-out'
+  /** Stopped because its output crossed the log cap — no verdict, by design. */
+  | 'overflowed'
   /** The harness itself could not run (no tmux, server would not start). */
   | 'unavailable';
 
@@ -100,6 +109,8 @@ export interface DriveArgs {
   server: string;
   /** Test seam — production shells out for real. */
   exec?: (cmd: string, args: string[], input?: string) => ExecResult;
+  /** Test seam — production derives it from `server`. */
+  logPath?: string;
 }
 
 export interface ExecResult {
@@ -132,6 +143,27 @@ export function shellQuote(v: string): string {
 
 /** Cap the captured pane the way build-test caps command output. */
 const CAPTURE_MAX = 200_000;
+
+/**
+ * Cap on the log FILE, not just on what gets reported from it.
+ *
+ * `trimCapture` bounds the string this command hands back; nothing bounded what
+ * the driven script wrote. Measured: a loop printing 200k lines left a 9.9 MB
+ * log on disk while the report stayed at 200 KB — and a drive script is
+ * whatever the reviewer wrote, so there is no upper bound at all. This repo has
+ * already paid for that once: `build-test`'s disk floors exist because an
+ * `npm ci` filled the disk 33 seconds in and then failed every agent scheduled
+ * after it.
+ *
+ * Enforced by WATCHING, not by piping through `head -c`. That was the first
+ * attempt and it is worse than the problem: `head` exits at the cap, the writer
+ * takes SIGPIPE mid-loop, and the EXIT trap then fires with `$?` from the last
+ * successful echo. Measured — a script whose last statement was `exit 5` came
+ * back `rc=0`. Not a lost verdict: a FABRICATED one, a failing run reported as
+ * a clean pass. A run this command had to stop is not a run that finished, so
+ * it gets its own outcome and no exit code at all.
+ */
+const LOG_MAX_BYTES = 8 * 1024 * 1024;
 /** How often readiness is polled. Fast enough to measure, slow enough to be cheap. */
 const POLL_MS = 250;
 
@@ -150,6 +182,15 @@ const POLL_MS = 250;
  * `Atomics.wait` blocks the thread for a real duration with no subprocess and
  * no platform surface at all.
  */
+/** Size of the log so far; 0 when it is not there yet. */
+function logBytes(p: string): number {
+  try {
+    return statSync(p).size;
+  } catch {
+    return 0;
+  }
+}
+
 function waitMs(ms: number): void {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
@@ -186,9 +227,21 @@ export const DRIVE_SENTINEL = '__QWEN_REVIEW_DRIVE_DONE__';
  * milliseconds and told us its answer was reported as one that never finished.
  * The trap fires on every way out — falling off the end, an explicit `exit`,
  * or an abort under `set -e`.
+ *
+ * And it writes to its OWN file, not into the captured stream. The log is
+ * size-capped at the write end, and a cap on the stream is a cap on the
+ * sentinel too: measured, a script printing 200k lines then `exit 5` had its
+ * sentinel swallowed by the closed pipe and came back `timed-out` with a null
+ * code — the same wrong answer, reintroduced by the fix for a different
+ * problem. Two facts, two channels: the log may be trimmed, the verdict may
+ * not.
  */
-export function wrapScript(script: string, sentinel = DRIVE_SENTINEL): string {
-  return `trap '__qwen_rc=$?; echo "${sentinel} rc=\${__qwen_rc}"' EXIT\nset +e\n${script}\n`;
+export function wrapScript(
+  script: string,
+  sentinelPath: string,
+  sentinel = DRIVE_SENTINEL,
+): string {
+  return `trap '__qwen_rc=$?; echo "${sentinel} rc=\${__qwen_rc}" > ${shellQuote(sentinelPath)}' EXIT\nset +e\n${script}\n`;
 }
 
 /** Parse the sentinel line back out of a capture. Null when it is not there. */
@@ -283,8 +336,10 @@ export function runDrive(args: DriveArgs): DriveReport {
   const dir = join(tmpdir(), `qwen-review-drive-${server}`);
   mkdirSync(dir, { recursive: true });
   const scriptPath = join(dir, 'drive.sh');
-  const logPath = join(dir, 'drive.log');
-  writeFileSync(scriptPath, wrapScript(args.script), 'utf8');
+  const logPath = args.logPath ?? join(dir, 'drive.log');
+  const sentinelPath = join(dir, 'drive.rc');
+  rmSync(sentinelPath, { force: true });
+  writeFileSync(scriptPath, wrapScript(args.script, sentinelPath), 'utf8');
 
   const droveFrom = Date.now();
   let output = '';
@@ -322,9 +377,15 @@ export function runDrive(args: DriveArgs): DriveReport {
     const deadline = droveFrom + args.timeout * 1000;
     for (;;) {
       output = existsSync(logPath) ? readFileSync(logPath, 'utf8') : '';
-      exitCode = sentinelExitCode(output);
+      exitCode = existsSync(sentinelPath)
+        ? sentinelExitCode(readFileSync(sentinelPath, 'utf8'))
+        : null;
       if (exitCode !== null) {
         outcome = 'completed';
+        break;
+      }
+      if (logBytes(logPath) > LOG_MAX_BYTES) {
+        outcome = 'overflowed';
         break;
       }
       if (Date.now() >= deadline) break;
@@ -339,9 +400,11 @@ export function runDrive(args: DriveArgs): DriveReport {
   const { text, truncated } = trimCapture(output);
   const droveForMs = Date.now() - droveFrom;
   const note =
-    outcome === 'completed'
-      ? `drove for ${Math.round(droveForMs / 1000)}s and reached its sentinel with exit ${exitCode}${readyAfterMs === null ? '' : ` (ready after ${Math.round(readyAfterMs / 1000)}s)`}${truncated ? '; the capture was trimmed at the head, so early output is missing' : ''}`
-      : `the drive did not finish within ${args.timeout}s — the capture below is PARTIAL, and a partial capture is not evidence that the run produced nothing. Raise --timeout, or give the script a smaller job.`;
+    outcome === 'overflowed'
+      ? `the drive wrote more than ${Math.round(LOG_MAX_BYTES / 1024 / 1024)} MiB and was stopped — no exit code is reported because it never gave one, and a run this command had to stop is not evidence about the diff either way. Quieten the script, or have it manage its own output file.`
+      : outcome === 'completed'
+        ? `drove for ${Math.round(droveForMs / 1000)}s and reached its sentinel with exit ${exitCode}${readyAfterMs === null ? '' : ` (ready after ${Math.round(readyAfterMs / 1000)}s)`}${truncated ? '; the capture was trimmed at the head, so early output is missing' : ''}`
+        : `the drive did not finish within ${args.timeout}s — the capture below is PARTIAL, and a partial capture is not evidence that the run produced nothing. Raise --timeout, or give the script a smaller job.`;
 
   return {
     outcome,

--- a/packages/cli/src/commands/review/drive.ts
+++ b/packages/cli/src/commands/review/drive.ts
@@ -395,6 +395,13 @@ export function runDrive(args: DriveArgs): DriveReport {
     // Unconditional. The 87% that clean up by hand are the 87% that remembered;
     // a leaked server is the next run's wrong observation.
     tmux('kill-server');
+    // ...and the working directory goes with it, once its contents have been
+    // read into the report. The default server name carries the pid, so every
+    // invocation would otherwise leave its own directory behind: measured, six
+    // runs left five. `output` is already in memory by here, so nothing the
+    // caller needs is in this tree. A caller who passed `--log-path` owns that
+    // file and keeps it.
+    if (!args.logPath) rmSync(dir, { recursive: true, force: true });
   }
 
   const { text, truncated } = trimCapture(output);


### PR DESCRIPTION
## What this PR does

Adds `qwen review drive`: start something, wait until it is **really** up, drive it, capture what it did — as facts rather than as a guess about how long to sleep.

The highest-yield review technique in this repo's history is the local build-and-drive verification (*"我是维护者，帮我在本地构建真实测试验证PR N"*). Across **260** of those sessions the mechanical half is the same every time, done by hand every time, and two of its three steps are done by **guessing**:

| measured across 260 sessions | | what it costs |
| --- | --- | --- |
| waited with `sleep N` | **81%** | a `sleep 2` landing before the daemon binds its port captures an empty screen — and an empty screen reads as "the feature does not work" |
| polled for a readiness signal | only 36% | |
| captured one screenful, no completion signal | **74%** | a capture taken mid-write is a partial observation presented as a complete one |
| cleaned up by hand (`pkill -f <a name they made up>`) | **87%** | what one round leaks, the next round inherits — and captures |

`drive` owns exactly those three — **ready or not**, **finished or not**, **gone either way** — and nothing else. What to drive, and what the output means, stay with the caller: the same split `build-test` and `test-delta` already draw.

Every outcome is a fact about the run, never a verdict about the diff:

- `completed` — the sentinel was reached; `exitCode` is the script's own.
- `not-ready` — readiness never arrived, so **nothing was driven** and nothing observed is evidence either way.
- `timed-out` — driven, sentinel never appeared; the capture is reported **and flagged partial**, because a partial capture is not evidence that the run produced nothing.
- `overflowed` — stopped because its output crossed the log cap: **no exit code**, because a run this command had to stop is not one that finished, and inventing a code for it is the failure the cap was added to avoid.
- `unavailable` — no tmux, or the session would not start: an environment gap, explicitly *not* a finding.

## Reviewer Test Plan

### How to verify

- `cd packages/cli && npx vitest run src/commands/review src/commands/review.test.ts` — expect 48 files / 1450 tests green.
- Drive it for real, all four exit paths:

```bash
for s in 'echo ok' 'echo failing; exit 17' 'set -e; false; echo unreachable' 'echo a; sleep 30'; do
  qwen review drive --cwd /tmp --script "$s" --timeout 6 --server "qx$RANDOM"
done
```

Expect `completed/0`, `completed/17`, `completed/1`, `timed-out/null`.

### Evidence (Before & After)

Two bugs that only a real run could show — **both green under the unit tests** at the time:

1. **`pipe-pane` races the script.** `new-session` starts it immediately and the pipe attaches after, so a fast drive finishes — taking its session with it — before the pipe exists. Measured: a one-second delay makes `pipe-pane` itself exit 1 and the log stay empty, which this command then reported as `timed-out`. A pane is a window that closes; the script's own redirect is the record.

2. **The sentinel was a trailing `echo`, which `exit N` never reaches** — and `exit N` is exactly how a drive script reports its result. Measured: `echo failing; exit 17` came back `timed-out` with a null exit code, i.e. a run that answered in milliseconds reported as one that never finished. `set +e` has no bearing on `exit`; a `trap … EXIT` does, and covers falling off the end, an explicit exit, and a `set -e` abort alike.

The test that should have caught the second one asserted that `set +e` was **present** — the call shape, not the behaviour. It is replaced by tests that drive real bash through all four exit paths. A third assertion ("reads the last sentinel") turned out to pin nothing — its rationale had evaporated when the capture moved off the pane — so it was rewritten against the reason that actually holds: the trap's sentinel is by construction the final line, so a drive script that cats a log cannot set the exit code this command reports. All three fixes now fail a mutation. Non-UI: N/A.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

## Risk & Scope

- Purely additive: a new subcommand nothing else calls yet. No existing behaviour changes.
- Needs `tmux`; its absence is reported as `unavailable` rather than failing a review.
- Breaking changes: none.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

新增 `qwen review drive`：把东西起起来、**等它真的就绪**、驱动它、抓取它做了什么 —— 作为事实，而不是靠猜该 sleep 多久。

这个仓库历史上产出最高的评审手法，是本地的构建并驱动验证（*"我是维护者，帮我在本地构建真实测试验证PR N"*）。在 **260** 个这类会话里，机械的那一半每次都相同、每次都手工做，而其中三步有两步是**靠猜**的：

| 260 个会话的实测 | | 代价 |
| --- | --- | --- |
| 用 `sleep N` 等待 | **81%** | `sleep 2` 若落在 daemon 绑定端口之前，抓到的是空屏 —— 而空屏会被读成"这个功能不工作" |
| 轮询就绪信号 | 仅 36% | |
| 抓一屏、无完成信号 | **74%** | 写到一半时抓取，是把部分观察当作完整观察 |
| 手工清理（`pkill -f <自己编的名字>`） | **87%** | 上一轮泄漏的，下一轮继承 —— 并抓取它 |

`drive` 只拥有这三件事 —— **就绪与否**、**完成与否**、**无论如何都清理干净** —— 别的都不管。驱动什么、差异意味着什么，仍归调用方：与 `build-test`、`test-delta` 的边界划法一致。

每个 outcome 都是关于这次运行的事实，绝不是对 diff 的裁定：`completed` 抓到哨兵、退出码是脚本自己的；`not-ready` 就绪从未到达，**什么都没驱动**，因此观察到的一切都不构成任一方向的证据；`timed-out` 驱动了但哨兵未出现，capture 照常报出**并标注为部分**，因为部分 capture 不等于"这次运行什么也没产生"；`overflowed` 因输出超过日志上限而被中止 —— **不给退出码**，因为一个被本命令强行停下的运行不是一个完成的运行，给它编一个退出码正是加这个上限要避免的失效；`unavailable` 没有 tmux 或会话起不来 —— 环境缺口，明确**不是** finding。

## 证据（前后对比）

两个只有真跑才会暴露的 bug，**当时单测全绿**：

1. **`pipe-pane` 与脚本竞态**：`new-session` 一启动脚本就跑，`pipe-pane` 之后才附着，快脚本早已结束并带走会话。实测：延迟 1 秒后 `pipe-pane` 自身 exit 1、日志为空，而本命令会把它报成 `timed-out`。**pane 是会关的窗口，脚本自己的重定向才是记录。**

2. **哨兵写在末尾的 `echo` 里，`exit N` 永远到不了** —— 而 `exit N` 正是驱动脚本报告结果的常规写法。实测：`echo failing; exit 17` 报成 `timed-out` + 退出码为 null，即**一个毫秒内就给出答案的运行，被报成从未完成**。`set +e` 对 `exit` 无效，`trap … EXIT` 才有效，且同时覆盖正常结束、显式 exit、`set -e` 中止三种路径。

本该抓住第二个 bug 的那条测试，断言的是"`set +e` 存在"—— 调用形状而非行为。已替换为真跑 bash、覆盖四种退出路径的行为测试。第三条断言（"读最后一个哨兵"）经检验**什么也没钉住**——它的理由在 capture 改为脚本重定向后已不成立——于是按真正成立的理由重写：trap 的哨兵按构造一定是最后一行，因此驱动脚本 cat 出来的日志无法决定本命令报告的退出码。三处修复现均可被突变检出。

## 风险与影响范围

- 纯新增：一个尚无其他调用方的子命令，不改变任何既有行为。
- 需要 `tmux`；缺失时报 `unavailable`，不会让评审失败。
- 破坏性变更：无。

</details>

