### PR TITLE
fix(external-context): Dispose of Auto Recall proxy dispatcher

### DIFF
--- a/docs/design/direct-external-context-auto-recall.md
+++ b/docs/design/direct-external-context-auto-recall.md
@@ -21,7 +21,7 @@ The deployment profiles are mutually exclusive:
 
 Auto-recall remains disabled in the extension manifest. An administrator must opt in by installing the dedicated user-settings Hook in a managed `QWEN_HOME`.
 
-The shared configuration loader and MCP entry point intentionally understand v2 for forward compatibility. Version selection therefore does not enforce profile isolation: the managed Auto Profile must omit the external-context extension and MCP configuration.
+The shared configuration loader accepts v1 and v2, but the MCP process entry point requires v1 and the Hook requires v2. Supplying the same v2 configuration to the MCP fails startup. The managed Auto Profile must still omit the external-context extension and MCP configuration because a separately configured v1 MCP process would permit duplicate retrieval.
 
 ## Why a separate profile
 
@@ -79,7 +79,7 @@ sequenceDiagram
     Q->>M: User prompt plus user-layer context
 ```
 
-Each Hook invocation is a new Node process. It reads configuration once, constructs one explicit adapter, performs at most one search, writes one JSON object to stdout, and exits. Hook and MCP entry points share configuration parsing, provider adapters, proxy setup, and rendering code but no mutable state.
+Each Hook invocation is a new Node process. It reads configuration once, constructs one explicit adapter, performs at most one search, writes one JSON object to stdout, and exits. The Hook owns and destroys its environment-aware proxy dispatcher after the attempted search; the long-running MCP process retains its dispatcher for its process lifetime. Hook and MCP entry points share configuration parsing, provider adapters, proxy setup, and rendering code but no mutable state.
 
 ## Configuration
 
@@ -100,7 +100,7 @@ Version 1 remains the exact on-demand schema. Version 2 is the auto-recall schem
 }
 ```
 
-`autoRecall.timeoutMs` defaults to 1500 milliseconds and must be from 1 through 5000; it is the only timeout the auto-recall Hook reads. A top-level `timeoutMs` is still accepted for forward compatibility with the on-demand MCP profile, but has no effect on auto recall. `repositoryRoot` must be an existing absolute directory. Startup resolves it through `realpath` and rejects a filesystem root. The event `cwd` is also resolved through `realpath`; retrieval runs only when it is the configured root or a descendant. Textual prefix comparisons are never used for containment.
+`autoRecall.timeoutMs` defaults to 1500 milliseconds and must be from 1 through 5000; it is the only timeout the auto-recall Hook reads. A top-level `timeoutMs` remains in the v2 schema for compatibility with existing v2 configuration files, but has no current runtime consumer: auto recall ignores it and the MCP process rejects v2. `repositoryRoot` must be an existing absolute directory. Startup resolves it through `realpath` and rejects a filesystem root. The event `cwd` is also resolved through `realpath`; retrieval runs only when it is the configured root or a descendant. Textual prefix comparisons are never used for containment.
 
 The repository root is an accidental-misrouting guard, not authorization. The provider credential, project, index, or corpus remains the security boundary. The configuration file, its path, credential, and binding must be administrator-controlled and immutable for the Qwen session. Switching repositories or corpora requires a new process. Rolling back to a binary that understands only v1 requires restoring the preserved v1 file.
 
@@ -132,7 +132,7 @@ If the result is empty, retrieval is skipped. These rules reduce accidental forw
 
 ## Search, timeout, and failure semantics
 
-The Hook installs the same environment-aware HTTP proxy dispatcher as Phase 1 and calls the selected adapter once with a limit of five. There is no retry or cache.
+The Hook installs the same environment-aware HTTP proxy dispatcher as Phase 1 and calls the selected adapter once with a limit of five. The dispatcher belongs to that Hook invocation and is destroyed in a `finally` path after successful, empty, or failed retrieval so a stalled proxy connection cannot retain the child process. There is no retry or cache.
 
 Timeouts are nested:
 

--- a/integrations/external-context/README.md
+++ b/integrations/external-context/README.md
@@ -174,12 +174,16 @@ shapes are removed from the submitted text, but this is not DLP.
 Do not link or enable the external-context Extension Manifest and do not
 install `examples/managed-mcp.json` in the auto-recall process; either action
 would add the on-demand MCP surface and permit duplicate retrieval. The
-shared configuration loader and MCP entry point intentionally understand v2
-for forward compatibility, so the schema version does not enforce this
-deployment separation. The profile supports only a fresh interactive TTY
-session. The managed system settings explicitly disable speculative execution
-because accepted speculation can bypass the normal `UserPromptSubmit` path. It
-does not support
+shared configuration loader accepts v1 and v2, but the MCP process entry point
+requires v1 and the Hook requires v2. Supplying the same v2 configuration to
+the MCP therefore fails startup. The managed Auto Profile must still omit the
+extension and MCP configuration because a separately configured v1 MCP process
+would permit duplicate retrieval. In v2, `autoRecall.timeoutMs` is the only
+request timeout the Hook reads; the top-level `timeoutMs` remains for schema
+compatibility and has no current runtime consumer. The profile supports only a
+fresh interactive TTY session. The managed system settings explicitly disable
+speculative execution because accepted speculation can bypass the normal
+`UserPromptSubmit` path. It does not support
 `-p`, stream-json, ACP, `serve`, YOLO, `--continue`, `--resume`, arbitrary
 launcher arguments, or switching repositories in one process. Mid-turn
 steering messages do not fire `UserPromptSubmit` and therefore do not trigger
@@ -191,7 +195,9 @@ fails open as `{}` after the Node entry point starts. Failure to spawn the
 pinned Node process and a Qwen outer command timeout retain Qwen's blocking
 command-Hook semantics. The Provider timeout defaults to 1500ms and is capped
 at 5000ms; the internal Hook wall-clock budget is 6500ms and the managed Qwen
-command timeout is 8000ms.
+command timeout is 8000ms. Each Hook invocation destroys its own proxy
+dispatcher after the attempted retrieval so stalled proxy connections cannot
+retain the child process; the long-running MCP process keeps its dispatcher.
 
 Retrieved results are sent to the model provider as user-layer additional
 context. The managed profile disables Qwen chat recording, native memory,

--- a/integrations/external-context/src/auto-recall.test.ts
+++ b/integrations/external-context/src/auto-recall.test.ts
@@ -14,7 +14,12 @@ import {
   writeFile,
 } from 'node:fs/promises';
 import { createServer } from 'node:http';
-import type { AddressInfo } from 'node:net';
+import {
+  type AddressInfo,
+  createServer as createNetServer,
+  type Server as NetServer,
+  type Socket,
+} from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { PassThrough, Readable } from 'node:stream';
@@ -28,14 +33,23 @@ import type {
 const loadConfig = vi.hoisted(() => vi.fn());
 const search = vi.hoisted(() => vi.fn());
 const createProvider = vi.hoisted(() => vi.fn(() => ({ search })));
-const installEnvironmentProxy = vi.hoisted(() => vi.fn());
+const PROXY_ENVIRONMENT_KEYS = new Set([
+  'ALL_PROXY',
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'NO_PROXY',
+]);
+const proxyMocks = vi.hoisted(() => ({
+  destroy: vi.fn(),
+  install: vi.fn(),
+}));
 
 vi.mock('./config.js', async (importOriginal) => ({
   ...(await importOriginal<typeof import('./config.js')>()),
   loadConfig,
 }));
 vi.mock('./providers.js', () => ({ createProvider }));
-vi.mock('./proxy.js', () => ({ installEnvironmentProxy }));
+vi.mock('./proxy.js', () => ({ installEnvironmentProxy: proxyMocks.install }));
 
 const temporaryDirectories: string[] = [];
 
@@ -43,7 +57,10 @@ beforeEach(() => {
   loadConfig.mockReset();
   search.mockReset();
   createProvider.mockClear();
-  installEnvironmentProxy.mockReset();
+  proxyMocks.destroy.mockReset().mockResolvedValue(undefined);
+  proxyMocks.install.mockReset().mockReturnValue({
+    destroy: proxyMocks.destroy,
+  });
 });
 
 afterEach(async () => {
@@ -201,7 +218,8 @@ describe('runAutoRecall', () => {
       cwd: fixture.child,
     });
 
-    expect(installEnvironmentProxy).toHaveBeenCalledOnce();
+    expect(proxyMocks.install).toHaveBeenCalledOnce();
+    expect(proxyMocks.destroy).toHaveBeenCalledOnce();
     expect(createProvider).toHaveBeenCalledOnce();
     expect(search).toHaveBeenCalledOnce();
     expect(search).toHaveBeenCalledWith({
@@ -270,13 +288,14 @@ describe('runAutoRecall', () => {
         }),
       ).resolves.toEqual({});
       expect(loadConfig).not.toHaveBeenCalled();
-      expect(installEnvironmentProxy).not.toHaveBeenCalled();
+      expect(proxyMocks.install).not.toHaveBeenCalled();
+      expect(proxyMocks.destroy).not.toHaveBeenCalled();
       expect(createProvider).not.toHaveBeenCalled();
       expect(search).not.toHaveBeenCalled();
     },
   );
 
-  it('skips malformed events, v1 configs, and directories outside the root', async () => {
+  it('skips malformed events, empty queries, v1 configs, and directories outside the root', async () => {
     const fixture = await createRepositoryFixture();
     const outside = await mkdtemp(`${fixture.root}-outside-`);
     temporaryDirectories.push(outside);
@@ -286,6 +305,15 @@ describe('runAutoRecall', () => {
       {},
     );
     expect(loadConfig).not.toHaveBeenCalled();
+
+    loadConfig.mockResolvedValue(config(fixture.root));
+    await expect(
+      runAutoRecall({
+        hook_event_name: 'UserPromptSubmit',
+        submitted_prompt: '```text\nonly code\n```',
+        cwd: fixture.root,
+      }),
+    ).resolves.toEqual({});
 
     const provider = config(fixture.root).provider;
     loadConfig.mockResolvedValue({
@@ -310,6 +338,8 @@ describe('runAutoRecall', () => {
       }),
     ).resolves.toEqual({});
     expect(search).not.toHaveBeenCalled();
+    expect(proxyMocks.install).not.toHaveBeenCalled();
+    expect(proxyMocks.destroy).not.toHaveBeenCalled();
   });
 
   it.skipIf(process.platform === 'win32')(
@@ -349,6 +379,7 @@ describe('runAutoRecall', () => {
         cwd: fixture.root,
       }),
     ).resolves.toEqual({});
+    expect(proxyMocks.destroy).toHaveBeenCalledOnce();
   });
 });
 
@@ -356,7 +387,12 @@ describe('runAutoRecallCli', () => {
   it('runs as a child process and exits without stderr or a retained timer', async () => {
     const result = await runAutoRecallProcess('{');
 
-    expect(result).toEqual({ exitCode: 0, stdout: '{}', stderr: '' });
+    expect(result).toEqual({
+      exitCode: 0,
+      signal: null,
+      stdout: '{}',
+      stderr: '',
+    });
   });
 
   it.skipIf(process.platform === 'win32')(
@@ -374,6 +410,7 @@ describe('runAutoRecallCli', () => {
 
       await expect(runAutoRecallProcess('{', link)).resolves.toEqual({
         exitCode: 0,
+        signal: null,
         stdout: '{}',
         stderr: '',
       });
@@ -411,10 +448,7 @@ describe('runAutoRecallCli', () => {
         }),
       );
     });
-    await new Promise<void>((resolve, reject) => {
-      server.once('error', reject);
-      server.listen(0, '127.0.0.1', resolve);
-    });
+    await listen(server);
 
     try {
       const address = server.address() as AddressInfo;
@@ -453,6 +487,7 @@ describe('runAutoRecallCli', () => {
       );
 
       expect(result.exitCode).toBe(0);
+      expect(result.signal).toBeNull();
       expect(result.stderr).toBe('');
       expect(requests).toEqual([
         {
@@ -478,11 +513,81 @@ describe('runAutoRecallCli', () => {
         },
       });
     } finally {
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
+      await closeServer(server);
     }
   });
+
+  it('exits after a provider timeout leaves a proxy CONNECT stalled', async () => {
+    const fixture = await createRepositoryFixture();
+    const proxyConnects: string[] = [];
+    const proxySockets = new Set<Socket>();
+    const proxy = createNetServer((socket) => {
+      proxySockets.add(socket);
+      socket.on('error', () => undefined);
+      socket.once('close', () => proxySockets.delete(socket));
+      let request = '';
+      let recorded = false;
+      socket.on('data', (chunk: Buffer) => {
+        request += chunk.toString('latin1');
+        if (!recorded && request.includes('\r\n\r\n')) {
+          recorded = true;
+          const [method, authority] = request.split('\r\n', 1)[0]!.split(' ');
+          proxyConnects.push(`${method} ${authority}`);
+        }
+      });
+    });
+
+    try {
+      await listen(proxy);
+      const proxyAddress = proxy.address() as AddressInfo;
+      const configPath = join(fixture.root, 'auto-recall.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          version: 2,
+          autoRecall: {
+            repositoryRoot: fixture.root,
+            timeoutMs: 1000,
+          },
+          provider: {
+            type: 'generic-http-search-v1',
+            baseUrl: 'https://context.invalid',
+            tokenEnv: 'FAKE_CONTEXT_TOKEN',
+          },
+        }),
+      );
+      const proxyUrl = `http://127.0.0.1:${proxyAddress.port}`;
+
+      const result = await runAutoRecallProcess(
+        JSON.stringify({
+          hook_event_name: 'UserPromptSubmit',
+          submitted_prompt: 'repository question',
+          cwd: fixture.root,
+        }),
+        undefined,
+        {
+          QWEN_EXTERNAL_CONTEXT_CONFIG: configPath,
+          FAKE_CONTEXT_TOKEN: 'bound-credential',
+          HTTP_PROXY: proxyUrl,
+          HTTPS_PROXY: proxyUrl,
+          NO_PROXY: '',
+        },
+      );
+
+      expect(result).toEqual({
+        exitCode: 0,
+        signal: null,
+        stdout: '{}',
+        stderr: '',
+      });
+      expect(proxyConnects).toEqual(['CONNECT context.invalid:443']);
+    } finally {
+      for (const socket of proxySockets) {
+        socket.destroy();
+      }
+      await closeServer(proxy);
+    }
+  }, 12_000);
 
   it.each([
     ['invalid JSON', '{'],
@@ -513,6 +618,7 @@ describe('runAutoRecallCli', () => {
     expect(output).toBe('{}');
     expect(output).not.toContain('secret provider response');
     expect(search).toHaveBeenCalledOnce();
+    expect(proxyMocks.destroy).toHaveBeenCalledOnce();
   });
 
   it('aborts an in-flight request at the configured provider timeout', async () => {
@@ -656,12 +762,15 @@ async function runAutoRecallProcess(
   envOverrides: NodeJS.ProcessEnv = {},
 ): Promise<{
   exitCode: number | null;
+  signal: NodeJS.Signals | null;
   stdout: string;
   stderr: string;
 }> {
   const child = spawn(process.execPath, ['--import', 'tsx/esm', entryPoint], {
-    env: { ...process.env, ...envOverrides, NODE_NO_WARNINGS: '1' },
+    env: childEnvironment(envOverrides),
+    killSignal: 'SIGKILL',
     stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: 8000,
   });
   let stdout = '';
   let stderr = '';
@@ -674,17 +783,39 @@ async function runAutoRecallProcess(
   child.stdin.end(input);
 
   return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      child.kill();
-      reject(new Error('Auto-recall child process did not exit.'));
-    }, 5000);
-    child.on('error', (error) => {
-      clearTimeout(timeout);
-      reject(error);
+    child.on('error', reject);
+    child.on('close', (exitCode, signal) => {
+      resolve({ exitCode, signal, stdout, stderr });
     });
-    child.on('close', (exitCode) => {
-      clearTimeout(timeout);
-      resolve({ exitCode, stdout, stderr });
+  });
+}
+
+function childEnvironment(overrides: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const [name, value] of Object.entries(process.env)) {
+    if (!PROXY_ENVIRONMENT_KEYS.has(name.toUpperCase())) {
+      env[name] = value;
+    }
+  }
+  return { ...env, ...overrides, NODE_NO_WARNINGS: '1' };
+}
+
+async function listen(server: NetServer): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => reject(error);
+    server.once('error', onError);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', onError);
+      resolve();
     });
+  });
+}
+
+async function closeServer(server: NetServer): Promise<void> {
+  if (!server.listening) {
+    return;
+  }
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
   });
 }

--- a/integrations/external-context/src/auto-recall.ts
+++ b/integrations/external-context/src/auto-recall.ts
@@ -78,26 +78,30 @@ export async function runAutoRecall(
     return {};
   }
 
-  installEnvironmentProxy();
-  const provider = createProvider(config.provider);
-  const items = await provider.search({
-    query,
-    limit: 5,
-    signal: AbortSignal.any([
-      signal,
-      AbortSignal.timeout(config.autoRecall.timeoutMs),
-    ]),
-  });
-  if (items.length === 0) {
-    return {};
-  }
+  const dispatcher = installEnvironmentProxy();
+  try {
+    const provider = createProvider(config.provider);
+    const items = await provider.search({
+      query,
+      limit: 5,
+      signal: AbortSignal.any([
+        signal,
+        AbortSignal.timeout(config.autoRecall.timeoutMs),
+      ]),
+    });
+    if (items.length === 0) {
+      return {};
+    }
 
-  return {
-    hookSpecificOutput: {
-      hookEventName: 'UserPromptSubmit',
-      additionalContext: renderExternalContext(items),
-    },
-  };
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'UserPromptSubmit',
+        additionalContext: renderExternalContext(items),
+      },
+    };
+  } finally {
+    await dispatcher.destroy();
+  }
 }
 
 export function createAutoRecallQuery(

--- a/integrations/external-context/src/config.ts
+++ b/integrations/external-context/src/config.ts
@@ -44,8 +44,8 @@ const configSchema = z.discriminatedUnion('version', [
   z
     .object({
       version: z.literal(2),
-      // Read only by the on-demand MCP path; the auto-recall Hook uses
-      // autoRecall.timeoutMs. Kept on the v2 schema for forward compatibility.
+      // Retained for compatibility with existing v2 configuration files. The
+      // auto-recall Hook uses autoRecall.timeoutMs, and the MCP rejects v2.
       timeoutMs: z.number().int().min(1).max(30_000).default(5000),
       autoRecall: z
         .object({

--- a/integrations/external-context/src/proxy.test.ts
+++ b/integrations/external-context/src/proxy.test.ts
@@ -22,11 +22,11 @@ describe('installEnvironmentProxy', () => {
   it('installs an environment-aware HTTP dispatcher', async () => {
     const { installEnvironmentProxy } = await import('./proxy.js');
 
-    installEnvironmentProxy();
+    const dispatcher = installEnvironmentProxy();
 
-    expect(setGlobalDispatcher).toHaveBeenCalledWith(
-      expect.any(EnvHttpProxyAgent),
-    );
+    expect(dispatcher).toBeInstanceOf(EnvHttpProxyAgent);
+    expect(setGlobalDispatcher).toHaveBeenCalledWith(dispatcher);
+    await dispatcher.destroy();
   });
 
   it('converts dispatcher failures to a sanitized configuration error', async () => {

--- a/integrations/external-context/src/proxy.ts
+++ b/integrations/external-context/src/proxy.ts
@@ -7,9 +7,11 @@
 import { EnvHttpProxyAgent, setGlobalDispatcher } from 'undici';
 import { ConfigurationError } from './config.js';
 
-export function installEnvironmentProxy(): void {
+export function installEnvironmentProxy(): EnvHttpProxyAgent {
   try {
-    setGlobalDispatcher(new EnvHttpProxyAgent());
+    const dispatcher = new EnvHttpProxyAgent();
+    setGlobalDispatcher(dispatcher);
+    return dispatcher;
   } catch {
     throw new ConfigurationError(
       'Proxy environment configuration is invalid. Check HTTP_PROXY, HTTPS_PROXY, and NO_PROXY.',


### PR DESCRIPTION
<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item on one long line.
-->

## What this PR does

This PR makes each one-shot Auto Recall Hook destroy the exact environment-aware proxy dispatcher it installed after retrieval finishes. Cleanup runs after successful retrieval, empty results, provider failures, and rendering failures, while the long-running on-demand MCP process continues to retain its dispatcher for the process lifetime.

It adds a real child-process regression test with a black-hole CONNECT proxy, keeps early no-op paths from creating a dispatcher, and corrects the Direct External Context documentation to describe the actual v1/v2 entry-point contract and timeout ownership.

## Why it's needed

Aborting a provider request at its configured timeout did not release a CONNECT socket retained by the globally installed `EnvHttpProxyAgent`. The Hook could already print `{}` while its Node process remained alive beyond Qwen's 8000ms outer command-Hook timeout. Destroying the Hook-owned dispatcher closes pending and running requests so the one-shot process can terminate naturally without changing the MCP lifecycle.

The documentation also incorrectly implied that the MCP entry point accepted v2 and that v2's top-level timeout had an on-demand consumer. The shared loader accepts both versions, but the MCP entry point requires v1, the Hook requires v2, and only `autoRecall.timeoutMs` controls Hook requests.

## Reviewer Test Plan

### How to verify

1. Run the external-context workspace tests and confirm all 97 tests pass. The proxy lifecycle regression must observe exactly one `CONNECT context.invalid:443`, receive `{}` on stdout with empty stderr, and see the child exit with code 0 and no signal before the 8000ms guard.
2. Run the external-context build, typecheck, and lint, then run the repository build, typecheck, and lint. All commands should complete without errors.
3. Inspect the one-shot Hook path and confirm the installed dispatcher is awaited in a `finally` block after provider construction/search/rendering, while validation, v1 configuration, cwd mismatch, and empty-query paths return before proxy installation.
4. Inspect the on-demand MCP startup path and confirm it still installs one global dispatcher and keeps it for the long-running process rather than disposing it per request.

### Evidence (Before & After)

N/A — this is a non-UI lifecycle fix. Before the fix, a black-hole proxy received CONNECT and the Hook remained alive beyond 9 seconds after emitting `{}`. After the fix, two independent built-artifact runs closed the proxy socket and exited naturally in approximately 1.45 seconds with stdout `{}`, empty stderr, exit code 0, and no signal.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS 26.4.1 arm64; Node.js v26.0.0 and npm 11.12.1 for the local workspace/repository verification; Node.js v22.22.3 for the independent built-artifact black-hole proxy verification.

## Risk & Scope

- Main risk or tradeoff: Dispatcher cleanup is awaited before a successful Hook result is emitted; if cleanup itself fails, the existing CLI fail-open wrapper returns `{}` instead of injecting the retrieved context.
- Not validated / out of scope: Windows and Linux are left to CI. This PR does not change providers, request protocols, write support, query behavior, or Hook semantics beyond releasing the one-shot proxy dispatcher.
- Breaking changes / migration notes: None. There are no public API, configuration schema, dependency, MCP protocol, or Qwen Core changes. Existing v1 and v2 configuration files remain valid.

## Linked Issues

Refs #7585

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 让每次一次性 Auto Recall Hook 在检索结束后销毁其安装的准确环境代理 dispatcher。无论检索成功、结果为空、Provider 失败还是渲染失败，都会执行清理；长驻的按需 MCP 进程仍在整个进程生命周期内保留其 dispatcher。

同时新增一个使用黑洞 CONNECT 代理的真实子进程回归测试，确保早期 no-op 路径不会创建 dispatcher，并修正 Direct External Context 文档，使其准确描述 v1/v2 入口契约和超时归属。

## 为什么需要

在配置的 Provider 超时触发后，中止请求并不会释放由全局 `EnvHttpProxyAgent` 持有的 CONNECT socket。Hook 虽然已经输出 `{}`，其 Node 进程仍可能存活超过 Qwen 的 8000ms 外层 command-Hook 超时。销毁 Hook 自己拥有的 dispatcher 会关闭等待中和运行中的请求，使一次性进程自然退出，同时不改变 MCP 的生命周期。

文档此前还错误暗示 MCP 入口接受 v2，并且 v2 顶层 timeout 存在按需运行时消费者。实际情况是：共享 loader 接受两个版本，但 MCP 入口只接受 v1，Hook 只接受 v2，且只有 `autoRecall.timeoutMs` 控制 Hook 请求。

## Reviewer 测试计划

### 如何验证

1. 运行 external-context workspace 测试并确认全部 97 个测试通过。代理生命周期回归必须观察到且仅观察到一次 `CONNECT context.invalid:443`，stdout 为 `{}`、stderr 为空，并且子进程在 8000ms guard 前以退出码 0、无 signal 的方式自然退出。
2. 运行 external-context 的 build、typecheck 和 lint，再运行仓库级 build、typecheck 和 lint，所有命令都应无错误完成。
3. 检查一次性 Hook 路径，确认安装的 dispatcher 在 Provider 构造、搜索和渲染之后通过 `finally` 等待销毁；而输入校验、v1 配置、cwd 越界和空查询会在安装代理前直接返回。
4. 检查按需 MCP 启动路径，确认它仍只安装一个全局 dispatcher 并在长驻进程内持续持有，不会按请求销毁。

### 证据（Before & After）

N/A——这是非 UI 生命周期修复。修复前，黑洞代理收到 CONNECT 后，Hook 即使已输出 `{}`，进程在 9 秒后仍未退出。修复后，两次独立的构建产物验证均关闭代理 socket，并在约 1.45 秒自然退出，stdout 为 `{}`、stderr 为空、退出码为 0 且无 signal。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS 26.4.1 arm64；本地 workspace/仓库验证使用 Node.js v26.0.0 和 npm 11.12.1；独立的构建产物黑洞代理验证使用 Node.js v22.22.3。

## 风险与范围

- 主要风险或权衡：成功的 Hook 结果会等待 dispatcher 清理后再输出；如果清理本身失败，现有 CLI fail-open 包装会返回 `{}`，而不会注入已检索的上下文。
- 未验证/不在范围内：Windows 和 Linux 留给 CI。本 PR 不改变 Provider、请求协议、写入支持、查询行为，也不改变 Hook 语义，唯一行为变化是释放一次性代理 dispatcher。
- 破坏性变更/迁移说明：无。没有公共 API、配置 schema、依赖、MCP 协议或 Qwen Core 变更，现有 v1/v2 配置文件仍然有效。

## 关联 Issue

Refs #7585

</details>
