### PR TITLE
fix(sdk-java): accept ERROR terminal in teardown E2E to fix flaky race

### DIFF
--- a/packages/sdk-java/qwencode/src/test/java/com/alibaba/qwen/code/daemon/DaemonServeE2ETest.java
+++ b/packages/sdk-java/qwencode/src/test/java/com/alibaba/qwen/code/daemon/DaemonServeE2ETest.java
@@ -178,8 +178,12 @@ class DaemonServeE2ETest {
 
                 PromptTerminal terminal = call.completionFuture()
                         .get(10, TimeUnit.SECONDS);
-                assertEquals(PromptTerminal.Kind.COMPLETE, terminal.getKind());
-                assertEquals("cancelled", terminal.getStopReason());
+                if (terminal.getKind() == PromptTerminal.Kind.COMPLETE) {
+                    assertEquals("cancelled", terminal.getStopReason());
+                } else {
+                    assertEquals(PromptTerminal.Kind.ERROR,
+                            terminal.getKind());
+                }
             } finally {
                 session.destroySession();
             }


### PR DESCRIPTION
## Motivation

The `teardownDeliversTerminalBeforeSessionFailure` Java daemon E2E test is flaky under CI load. It DELETEs the session while a prompt is pending on a permission request, then asserts the terminal must be `COMPLETE` with `stopReason=cancelled`. However, there is a race: the session can be destroyed before the daemon delivers the cancelled terminal, producing an `ERROR` terminal instead.

This was observed in [run 30726976387](https://github.com/QwenLM/qwen-code/actions/runs/30726976387/job/91440382521?pr=8350) where the test failed with `expected: <COMPLETE> but was: <ERROR>` on an unrelated PR.

## Changes

Accept both `COMPLETE/cancelled` and `ERROR` as valid teardown outcomes, matching the pattern already established by `cancelledPromptReceivesReliableTerminal` in the same file for the identical race condition.

## Reviewer Test Plan

- Verify the `Real daemon E2E / Java 11` CI job passes on this PR.
- The change only relaxes the assertion to accept the same two outcomes the cancel test already accepts; no production code is modified.