### PR TITLE
fix(ci): classify mixed AutoFix feedback per item

### DIFF
--- a/.qwen/skills/autofix/SKILL.md
+++ b/.qwen/skills/autofix/SKILL.md
@@ -285,6 +285,12 @@ Read `git diff origin/<base>...HEAD` first, then `<workdir>/feedback.md`.
 
 Classify every feedback point:
 
+Treat merge readiness and each feedback point's actionability as independent
+decisions. An overall `APPROVE` verdict or wording such as "non-blocking",
+"follow-up", or "not a regression" does not make every item optional. A
+reproduced current correctness defect remains Required. Classify adjacent
+diagnostics, comments, tests, and hardening independently.
+
 Address each the way AGENTS.md's Simplicity First and Comments rules demand:
 the smallest change that resolves the point, no error handling for a condition
 that cannot occur, no comment that restates the code. Review rounds ratchet
@@ -402,6 +408,8 @@ Finish with exactly one outcome:
   disposition and the reason in a sentence or two, plus the question you need
   answered when you escalated. Each body is bilingual per GitHub Actions Rules.
   Omit the file when every inline finding was resolved.
-- No change: write `<workdir>/no-action.md` (bilingual per GitHub Actions Rules).
+- No change: write `<workdir>/no-action.md` only after every actionable
+  feedback point has an explicit disposition and no verified Required item
+  remains unresolved. Follow GitHub Actions Rules' bilingual requirement.
 - The GitHub Actions Rules' objective stop condition applies: write
   `<workdir>/failure.md` and do not commit.

--- a/docs/plans/2026-08-02-autofix-mixed-feedback.md
+++ b/docs/plans/2026-08-02-autofix-mixed-feedback.md
@@ -1,0 +1,45 @@
+# AutoFix Mixed-Feedback Classification Plan
+
+## Goal
+
+Prevent takeover review rounds from treating an overall approval or
+non-blocking merge verdict as a reason to ignore a reproduced current
+correctness defect in the same feedback batch.
+
+## Root cause
+
+The PR feedback scanner already included the issue-level review comment from
+PR #8301 in `feedback.md`. The address-review agent then applied the review's
+overall `APPROVE` verdict to the whole batch and emitted `no-action.md`, instead
+of classifying the reproduced correctness defect separately from the adjacent
+logging, comment, and coverage suggestions.
+
+## Implementation
+
+1. In the shared `address-review` instructions, make review-level merge
+   readiness and item-level actionability independent decisions.
+2. Keep a reproduced current correctness defect Required even when it is
+   described as non-blocking, a follow-up, or not a regression. Continue to
+   classify adjacent diagnostics, comments, tests, and hardening independently.
+3. Permit the no-change outcome only after every actionable feedback point has
+   an explicit disposition and no verified Required item remains unresolved.
+4. Add focused contract assertions that pin these rules in the existing AutoFix
+   workflow test without adding a second parser or duplicating workflow policy.
+
+## Non-goals
+
+- Do not change feedback ingestion, watermarking, round budgets, or takeover
+  lifecycle logic; the reported comment already reached the agent.
+- Do not make formal `APPROVED` review bodies trigger AutoFix. Ordinary approval
+  text such as `LGTM` should not create no-op rounds.
+- Do not automatically implement every suggestion in an approved review.
+
+## Verification
+
+- Prove the new contract test fails against the current skill text, then passes
+  after the instruction change.
+- Run the focused AutoFix workflow test and the full workflow test file.
+- Run Prettier, targeted ESLint, `git diff --check`, repository build, and
+  typecheck.
+- Review the final diff for correctness, security, maintainability, test value,
+  and unnecessary scope.

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -4581,6 +4581,20 @@ describe('qwen-autofix workflow', () => {
     expect(flat).toContain('Simplicity First');
     expect(flat).toContain('added no bloat');
     expect(flat).toContain('never a reason to bloat the code');
+    // Merge readiness applies to the review as a whole, while actionability
+    // applies to each finding. An approval must not hide a verified defect.
+    expect(flat).toContain(
+      "Treat merge readiness and each feedback point's actionability as independent decisions",
+    );
+    expect(flat).toContain(
+      'A reproduced current correctness defect remains Required',
+    );
+    expect(flat).toContain(
+      'Classify adjacent diagnostics, comments, tests, and hardening independently',
+    );
+    expect(flat).toContain(
+      'write `<workdir>/no-action.md` only after every actionable feedback point has an explicit disposition and no verified Required item remains unresolved',
+    );
     // The rationale is structural, not etiquette: the gate re-runs the same
     // commands, so skipping them only moves the rejection later. Pin that
     // framing so the requirement is not softened back into "please verify".


### PR DESCRIPTION
## What this PR does

Separates an AutoFix review's overall merge-readiness verdict from the actionability of each feedback point. A reproduced current correctness defect remains Required even when the reviewer approves the PR or describes it as non-blocking, a follow-up, or not a regression; adjacent diagnostics, comments, tests, and hardening requests are still classified independently. A no-change result is now allowed only after every actionable point has an explicit disposition and no verified Required item remains unresolved.

## Why it's needed

On PR #8301, a trusted issue-level review comment reached the takeover agent with an overall approval, one probe-confirmed current correctness defect, and three separate optional follow-ups. AutoFix applied the approval to the whole batch and published a no-action result, so merge readiness incorrectly overrode the per-item correctness classification.

## Reviewer Test Plan

### How to verify

Run `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-autofix-workflow.test.js -t 'requires the address path to run verification'` and confirm the contract test passes. Review the address-review outcome rules and confirm that removing any of the four new guarantees—independent decisions, reproduced correctness remaining Required, independent adjacent-item classification, or the no-action precondition—makes the test fail.

### Evidence (Before & After)

Before: [the mixed review feedback](https://github.com/QwenLM/qwen-code/pull/8301#issuecomment-5152637666) reached AutoFix, which then [published a batch-level no-action result](https://github.com/QwenLM/qwen-code/pull/8301#issuecomment-5152957155). After: the focused contract test passes and pins the item-level decision policy; the full workflow test file completed all 109 assertions, although Vitest reported an `onTaskUpdate` timeout during worker teardown.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js 22.22.0 on macOS arm64. Prettier, targeted ESLint, the focused test, and `git diff --check` pass. Local build/typecheck reach existing untouched Ink selection API errors on current `main`; no TypeScript or workflow source is changed by this PR.

## Risk & Scope

- Main risk or tradeoff: this is an agent-policy fix rather than a deterministic semantic parser, so deployed behavior still depends on the configured model following the contract.
- Not validated / out of scope: feedback ingestion, trust gates, watermarking, Critical-only budgets, and formal `APPROVED` review-body ingestion are unchanged. A deployed takeover round is required for post-merge E2E verification.
- Breaking changes / migration notes: none.

## Linked Issues

Resolves #8358  
Related to #8071 and PR #8301

<details>
<summary>中文说明</summary>

## 本 PR 的内容

将 AutoFix 评审的整体合并就绪结论与每个反馈点的可执行性分开判断。即使评审者同意合并，或将问题描述为非阻断、后续项、非回归，一个已复现的当前正确性缺陷仍保持为 Required；相邻的诊断、注释、测试和加固请求仍分别分类。只有每个可执行反馈点都有明确处置，且没有已验证的 Required 项仍未解决时，才允许输出无需改动。

## 为什么需要

在 PR #8301 中，一条受信的 issue-level 评审评论已经进入 takeover agent，其中包含整体同意结论、一个经探针确认的当前正确性缺陷，以及三个独立的可选后续项。AutoFix 将整体同意套用到整批反馈并发布无需改动结果，导致合并就绪错误地覆盖了逐项正确性分类。

## 审阅者测试方案

### 如何验证

运行 `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-autofix-workflow.test.js -t 'requires the address path to run verification'`，确认契约测试通过。检查 address-review 的结果规则，并确认删除四项新增保证中的任一项——独立决策、已复现 correctness 仍为 Required、相邻项目独立分类、或 no-action 前置条件——都会使测试失败。

### 前后证据

变更前：[混合评审反馈](https://github.com/QwenLM/qwen-code/pull/8301#issuecomment-5152637666) 已进入 AutoFix，随后它[发布了整批无需处理的结果](https://github.com/QwenLM/qwen-code/pull/8301#issuecomment-5152957155)。变更后：聚焦契约测试通过并固定逐项决策策略；完整 workflow 测试文件的 109 个断言全部完成，但 Vitest 在 worker teardown 阶段报告 `onTaskUpdate` timeout。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境

macOS arm64，Node.js 22.22.0。Prettier、目标 ESLint、聚焦测试和 `git diff --check` 均通过。本地 build/typecheck 在当前 `main` 的未触碰 Ink selection API 错误处停止；本 PR 不修改 TypeScript 或 workflow 源码。

## 风险与范围

- 主要风险或权衡：这是 agent 策略修复，不是确定性的语义解析器，因此部署后的行为仍依赖配置模型遵守该契约。
- 未验证 / 超出范围：反馈采集、信任门、水位线、Critical-only 预算和正式 `APPROVED` review body 的采集均保持不变。合并后仍需通过一次部署后的 takeover round 做 E2E 验证。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Resolves #8358  
Related to #8071 and PR #8301

</details>
