### PR TITLE
test(extension): stop a hand-written projection from racing the store's clock

### DIFF
--- a/packages/core/src/extension/extensionManager.test.ts
+++ b/packages/core/src/extension/extensionManager.test.ts
@@ -1185,10 +1185,24 @@ describe('extension tests', () => {
 
       // Triggered by the enablement file moving, so the first refresh does not
       // observe ext-b.
-      fs.writeFileSync(
-        path.join(userExtensionsDir, 'extension-enablement.json'),
-        JSON.stringify({ touched: true }),
+      //
+      // Its mtime is pushed a second into the past on purpose. Hand-writing
+      // this file is how the test simulates "something outside the store
+      // changed the legacy projection", and that is precisely the condition
+      // `ExtensionStore` fails closed on when the two timestamps cannot be
+      // ordered. Left at `now`, the write lands in the same tick as the
+      // store's own often enough to trip that guard: measured, 3 failures in 6
+      // runs here and on unrelated branches, blocking CI on PRs that never
+      // touch extensions. An explicitly older projection is orderable, which
+      // is what this test needs and all it needs — the guard itself is doing
+      // its job and is left alone.
+      const enablementFile = path.join(
+        userExtensionsDir,
+        'extension-enablement.json',
       );
+      fs.writeFileSync(enablementFile, JSON.stringify({ touched: true }));
+      const older = new Date(Date.now() - 1_000);
+      fs.utimesSync(enablementFile, older, older);
       expect(await manager.refreshCacheIfSourcesChanged()).toBe(true);
       expect(manager.getLoadedExtensions()).toHaveLength(1);
 


### PR DESCRIPTION
## What this PR does

Fixes a flaky test that has blocked CI on unrelated PRs twice.

`extensionManager.test.ts` → `does not mask a change that lands while a refresh is running` fails with `ExtensionStoreCorruptError` **3 runs in 6**, on `main` and on branches that never touch extensions.

### The guard is not the bug

`ExtensionStore.legacyProjectionIsNewerThanState` fails closed when the legacy projection's content disagrees with `state.json` **and** the two mtimes cannot be ordered. It deliberately does not overwrite the projection in that case — the file may hold a user's own edits, and a tie means this comparison cannot tell whose write was last. `extension-store.test.ts` asserts exactly that, *including* that the file is left untouched:

```ts
await expect(store.ensureInitialized(...)).rejects.toBeInstanceOf(ExtensionStoreCorruptError);
expect(JSON.parse(await fsp.readFile(enablementPath, 'utf8'))).toEqual({});
```

And the tie is never the store's own doing: the caller reaches this only after `legacyProjectionHash !== projectionHash(legacy)`, which the store's own writes never produce.

### The test is what is unreliable

It hand-writes `extension-enablement.json` to trigger a refresh — which is how it simulates "something outside the store changed the projection", the very condition the guard exists for — and then leaves the mtime to whenever `now` happens to be. Whether it trips the guard is decided by clock granularity.

Its mtime is pushed a second into the past now. That is orderable, which is all this test needs.

## Reviewer Test Plan

### How to verify

```bash
cd packages/core
for i in $(seq 1 10); do
  npx vitest run src/extension/extensionManager.test.ts \
    -t "does not mask a change that lands while a refresh is running"
done
```

Ten passes. Before: three failures in six.

- `npx vitest run src/extension/` — 21 files / 581 tests green, with the guard untouched.

### Evidence (Before & After)

| | before | after |
| --- | --- | --- |
| target test, 10 runs | 3 failures in 6 | **10 / 10 pass** |
| `src/extension/` suite | 1 failed / 580 passed | **581 / 581** |
| production code changed | — | **none** |

An earlier attempt did change the guard — returning `false` on a tie instead of throwing — and `extension-store.test.ts` caught it immediately: that path rewrites the user's projection from `state.json`, so weakening it would silently discard a hand-edited file. The fix is in the test only. Non-UI: N/A.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

## Risk & Scope

- One test file. No production code, no behaviour change.
- Breaking changes: none.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修一个已经两次拦住无关 PR 的 flaky 测试。

`extensionManager.test.ts` 的 `does not mask a change that lands while a refresh is running` 会以 `ExtensionStoreCorruptError` 失败 —— **6 跑 3 挂**，在 `main` 上和从不碰 extension 的分支上都一样。

### 守卫不是 bug

`ExtensionStore.legacyProjectionIsNewerThanState` 在"projection 内容与 `state.json` 不符 **且** 两个 mtime 无法排序"时失败关闭，并且**刻意不覆盖** projection —— 该文件可能保存着用户自己的编辑，而时间戳打平意味着这次比较无法判断谁是最后写入者。`extension-store.test.ts` 正是这样断言的，且**包括文件必须原样保留**。

而且这个平局绝不是 store 自己造成的：调用点只在 `legacyProjectionHash !== projectionHash(legacy)` 之后才问它，而 store 自己的写入不会产生哈希不一致。

### 不可靠的是测试

它**手工写入** `extension-enablement.json` 来触发刷新 —— 这正是它模拟"store 之外的东西改了 projection"的方式，也正是守卫存在的理由 —— 却把时间戳交给了 `now` 的运气。是否撞上守卫，由时钟粒度决定。

现在把它的 mtime 显式推到一秒之前。可排序，而这就是这个测试全部需要的。

### 证据

| | 修前 | 修后 |
| --- | --- | --- |
| 目标测试跑 10 次 | 6 跑 3 挂 | **10 / 10 通过** |
| `src/extension/` 套件 | 1 失败 / 580 通过 | **581 / 581** |
| 生产代码改动 | — | **无** |

我最初的改法确实动了守卫（平局时返回 `false` 而非抛错），`extension-store.test.ts` 当场抓住了它：那条路径会用 `state.json` 重写用户的 projection，削弱守卫等于静默丢弃用户手工编辑的文件。最终修改只在测试内。

## 风险与影响范围

- 单个测试文件，无生产代码改动、无行为变化。
- 破坏性变更：无。

</details>
