### PR TITLE
test(review): pin drive's capped-stream case to its invariant, not to bash 5.2

### DIFF
--- a/packages/cli/src/commands/review/drive.test.ts
+++ b/packages/cli/src/commands/review/drive.test.ts
@@ -126,14 +126,23 @@ describe('the wrapper, driven for real', () => {
     expect(sentinelExitCode(readFileSync(rc, 'utf8'))).toBe(0);
   });
 
-  it('capping the STREAM would FABRICATE an exit code — measured, not assumed', () => {
+  it('capping the STREAM never yields the true exit code — measured, not assumed', () => {
     // Why the log is bounded by watching its size rather than by `head -c`.
     // Piping the drive through `head` kills the writer with SIGPIPE mid-loop,
-    // and the EXIT trap then fires with `$?` from the last successful echo: a
-    // script whose final statement is `exit 5` reports rc=0. Not a lost
-    // verdict — a fabricated one, a failing run presented as a clean pass.
-    // Pinned so the shortcut is not reintroduced by someone who reasons about
-    // it instead of running it.
+    // and what survives is bash-version-dependent — measured, per version:
+    //   - bash 5.2 (CI's ubuntu): the EXIT trap fires with `$?` from the last
+    //     successful echo — rc=0, a FABRICATED clean pass;
+    //   - bash 5.3 (homebrew macOS): the trap's redirect creates the sentinel
+    //     file but the write is LOST — an empty file, no verdict;
+    //   - bash 3.2 (stock macOS): the trap records the echo's EPIPE write
+    //     error — rc=1, a fabricated FAILURE code, with a stray padding line
+    //     leaked into the sentinel file for good measure.
+    // Three shells, three different wrong answers — which is why the
+    // assertion pins the one invariant they share instead of any version's
+    // flavor of wrong: the script's real `exit 5` NEVER survives the cap.
+    // (The first draft of this fix enumerated the wrong answers and was
+    // immediately falsified by running it on a fourth shell; the enumeration
+    // is a moving target, the invariant is not.)
     const dir = mkdtempSync(join(tmpdir(), 'drv-'));
     const rc = join(dir, 'drive.rc');
     const sh = join(dir, 's.sh');
@@ -149,7 +158,13 @@ describe('the wrapper, driven for real', () => {
       ['-c', `bash ${sh} 2>&1 | head -c 4096 > ${join(dir, 'log')}`],
       { encoding: 'utf8' },
     );
-    expect(sentinelExitCode(readFileSync(rc, 'utf8'))).toBe(0); // NOT 5
+    const reported = existsSync(rc)
+      ? sentinelExitCode(readFileSync(rc, 'utf8'))
+      : null;
+    // Fabricated (0, 1, …) or lost (null) — any of them is an untrustworthy
+    // verdict, and all prove the design point. What must never appear is the
+    // truth.
+    expect(reported).not.toBe(5);
   });
 });
 


### PR DESCRIPTION
## What this PR does

Fixes the one `drive.test.ts` case that fails on macOS: the SIGPIPE fabricated-exit-code test pinned the specific wrong answer CI's bash 5.2 produces (`rc=0`), and every other shell produces a *different* wrong answer. The assertion now pins the invariant all shells share — the script's real `exit 5` never survives piping the drive through `head -c` — which is the design point the test exists to defend. The sentinel read also goes through `existsSync` like the suite's own `realExit` helper, so a shell that never creates the file reports `null` instead of throwing.

## Why it's needed

Measured, per version, same script, same pipe:

| Shell | What the sentinel records | Flavor of wrong |
| --- | --- | --- |
| bash 5.2 (CI ubuntu) | `rc=0` | fabricated clean pass |
| bash 5.3 (homebrew macOS) | empty file | sentinel created, write lost |
| bash 3.2 (stock macOS) | `rc=1` + a stray padding line leaked into the file | fabricated *failure* code |

Three shells, three different wrong answers — so `expect(...).toBe(0)` is a pin on bash 5.2's behavior, not on the design rule ("bound the log by watching its size, never by capping the stream"). Anyone running the suite on macOS hits a stable red that has nothing to do with their change (found while resolving a conflict on #8351: three consecutive local runs failed identically). A first draft of this fix enumerated the wrong answers as an allowed set and was immediately falsified by the third shell — the enumeration is a moving target, the invariant (`reported !== 5`) is not, and the test's own comment now records the measured matrix so the next reader doesn't re-derive it.

## Reviewer Test Plan

### How to verify

```bash
npx vitest run packages/cli/src/commands/review/drive.test.ts
```

Expected: 24/24 on both Linux and macOS (observed locally on macOS with homebrew bash 5.3 first in PATH, three consecutive runs; the same probe script run explicitly under `/bin/bash` 3.2 confirms the rc=1 row of the table). On main, the same suite fails this one case on macOS with `expected null to be +0`.

### Evidence (Before & After)

Before (main, macOS): `AssertionError: expected null to be +0` — three consecutive runs. After: 24/24, three consecutive runs. Non-UI change, no screenshots.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A（用例本身仅在 POSIX shell 下有意义） |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only, macOS, Node v24; bash 5.3 (homebrew) and /bin/bash 3.2 both probed.

## Risk & Scope

- Main risk or tradeoff: the assertion is deliberately weaker (`not.toBe(5)` instead of `toBe(0)`) — it no longer notices if bash changes *which* wrong answer it gives, only that the true code never survives. That is exactly the property the design depends on; the per-version matrix lives in the comment for archaeology.
- Not validated / out of scope: Windows (the case exercises POSIX pipe semantics); no behavior change to `drive.ts` itself.
- Breaking changes / migration notes: none — test-only.

## Linked Issues

None. Surfaced while resolving a merge conflict on #8351; introduced by #8349.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修复 `drive.test.ts` 在 macOS 上必红的一个用例：SIGPIPE 伪造退出码测试钉死了 CI bash 5.2 的特定错误答案（`rc=0`），而其他 shell 各给出*不同的*错误答案。断言改为钉住所有 shell 共享的不变量——把 drive 管道进 `head -c` 后，脚本真实的 `exit 5` 永远不会存活——这正是该测试要守卫的设计点。哨兵读取同时改走 `existsSync`（与套件自己的 `realExit` 辅助函数一致），不创建文件的 shell 报 `null` 而非抛 ENOENT。

## 为什么需要

同一脚本、同一管道，逐版本实测：

| Shell | 哨兵记录 | 错误形态 |
| --- | --- | --- |
| bash 5.2（CI ubuntu） | `rc=0` | 伪造的干净通过 |
| bash 5.3（homebrew macOS） | 空文件 | 哨兵文件已建、写入丢失 |
| bash 3.2（原生 macOS） | `rc=1` + 一行 padding 泄漏进文件 | 伪造的*失败*码 |

三个 shell 三种错法——`expect(...).toBe(0)` 钉的是 bash 5.2 的行为，不是设计规则（"用监视文件大小来限制日志，绝不 cap 流"）。任何在 macOS 上跑套件的人都会遇到与自己改动无关的稳定红（在解决 #8351 冲突时发现：本地连跑三次失败形态一致）。本修复的第一稿把错误答案枚举成允许集合，立刻被第三个 shell 证伪——枚举是移动靶，不变量（`reported !== 5`）不是；实测矩阵已写进测试注释，后来者无需重新推导。

## Reviewer 测试计划

### 如何验证

```bash
npx vitest run packages/cli/src/commands/review/drive.test.ts
```

预期：Linux 与 macOS 均 24/24（本地 macOS、homebrew bash 5.3 在 PATH 首位，连跑三次；同一探针脚本显式用 `/bin/bash` 3.2 跑，证实表中 rc=1 一行）。在 main 上，同套件在 macOS 红这一个用例：`expected null to be +0`。

### 证据（Before & After）

Before（main，macOS）：`AssertionError: expected null to be +0`，连续三次。After：24/24，连续三次。非 UI 改动，无截图。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  N/A（用例仅在 POSIX shell 下有意义） |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

仅单元测试，macOS，Node v24；homebrew bash 5.3 与 /bin/bash 3.2 均已探测。

## 风险与范围

- 主要风险/权衡：断言刻意变弱（`not.toBe(5)` 而非 `toBe(0)`）——不再关心 bash 给出*哪种*错误答案，只关心真实退出码永不存活。这正是设计所依赖的性质；逐版本矩阵留在注释里供考古。
- 未验证/范围外：Windows（用例行使 POSIX 管道语义）；`drive.ts` 本身行为无改动。
- 破坏性变更/迁移说明：无——仅测试。

## 关联 Issue

无。解决 #8351 合并冲突时发现；由 #8349 引入。

</details>
