### PR TITLE
fix(ci): ask GitHub what the PR changed, not what the base gained

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -879,6 +879,7 @@ jobs:
     timeout-minutes: 45
     permissions:
       contents: 'read'
+      pull-requests: 'read'
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
@@ -886,22 +887,41 @@ jobs:
           ref: "${{ github.event.inputs.branch_ref || (github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number)) || (github.event_name == 'merge_group' && github.event.merge_group.head_sha) || github.ref }}"
           fetch-depth: 1
 
-      # Fail open: any uncertainty (non-PR event, fetch failure) runs the job.
+      # Fail open: any uncertainty (non-PR event, API failure) runs the job.
+      #
+      # Ask GitHub which files the PR changed, the same call the CI profile
+      # classifier makes above. The two-tree `git diff BASE HEAD` this replaced
+      # is not the PR's diff: it reports everything the base gained since the
+      # branch point as a change on the PR's side. #8132 added
+      # packages/desktop-shell, so every branch older than it saw 78 phantom
+      # desktop-shell paths, ran this job, and failed in a checkout of
+      # refs/pull/N/head that has no such directory.
       - name: 'Detect desktop-shell changes'
         id: 'filter'
         env:
-          EVENT_NAME: '${{ github.event_name }}'
-          BASE_REF: '${{ github.base_ref }}'
+          GH_TOKEN: '${{ github.token }}'
+          PR_NUMBER: "${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}"
         run: |-
           changed=true
-          if [[ "${EVENT_NAME}" == "pull_request" && -n "${BASE_REF}" ]]; then
-            if git fetch --depth=1 origin "${BASE_REF}" >/dev/null 2>&1; then
-              if git diff --name-only FETCH_HEAD HEAD | grep -Eq '^(packages/desktop-shell/|\.github/scripts/create-desktop-update-manifest\.mjs|\.github/workflows/ci\.yml)'; then
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" && -n "${PR_NUMBER}" ]]; then
+            # `previous_filename` too: renaming a file out of the crate changes
+            # it, and only the old path says so.
+            if files="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --jq '.[] | .filename, (.previous_filename // empty)')"; then
+              if grep -Eq '^(packages/desktop-shell/|\.github/scripts/create-desktop-update-manifest\.mjs|\.github/workflows/ci\.yml)' <<<"${files}"; then
                 changed=true
               else
                 changed=false
               fi
+            else
+              echo "::warning::Unable to list the PR's changed files; compiling the crate."
             fi
+          fi
+          # Whatever the filter decided, a tree without the crate cannot have
+          # regressed it, and cargo has no manifest to run against — the job
+          # would report a missing working directory as a failure of the PR.
+          if [[ "${changed}" == "true" && ! -f packages/desktop-shell/src-tauri/Cargo.toml ]]; then
+            echo "::notice::packages/desktop-shell/src-tauri is absent from this head; nothing to compile."
+            changed=false
           fi
           echo "changed=${changed}" >> "${GITHUB_OUTPUT}"
           echo "desktop-shell changed: ${changed}"


### PR DESCRIPTION
`Desktop Shell (ubuntu-22.04)` fails on every PR branched before #8132, on a step that never ran:

```
Error: The cwd: /home/runner/work/qwen-code/qwen-code/packages/desktop-shell/src-tauri does not exist!
```

Two things combine. The job checks out `refs/pull/{N}/head` — the PR head, not the merge — and its path filter asks `git diff --name-only FETCH_HEAD HEAD` against a depth-1 fetch of the base. That is a **two-tree diff, not the PR's diff**: everything the base gained since the branch point reads as a change on the PR's side. #8132 added `packages/desktop-shell`, so from then on an older branch sees 78 phantom paths under it, concludes the crate changed, and runs a `cargo` step in a checkout that has no such directory.

Measured on such a branch:

| | `packages/desktop-shell/*` paths |
|---|---|
| `git diff --name-only BASE HEAD` (what the filter did) | **78** |
| `git diff --name-only BASE...HEAD` (the PR's own diff) | **0** |

and the job's own log agreeing with the wrong one — `desktop-shell changed: true` for a PR that changed two files, neither of them the crate.

**Ask the API what the PR changed.** This is the same call the CI profile classifier makes a few hundred lines above in this file, so `ci.yml` now answers this question one way rather than two. `previous_filename` is included: renaming a file out of the crate changes it, and only the old path says so.

**Fail-open needed a floor.** "Any uncertainty runs the job" is right until the tree has no crate to compile, where it produces a red check rather than a cautious one. A head without `src-tauri/Cargo.toml` cannot have regressed the crate, so the filter reports no change and says why in a notice.

Beyond the fix, the filter was also wrong in the ordinary case — it fired whenever `main` had moved on desktop-shell files, not when the PR touched them, spending up to 45 minutes compiling a Tauri crate the PR never touched.

### Verification

The step was lifted out verbatim and driven with `gh` stubbed:

| scenario | `changed` |
|---|---|
| docs-only PR, crate present | `false` |
| PR touches the crate | `true` |
| docs-only PR, crate absent (the failure above) | `false` |
| API fails, crate absent | `false` + warning |
| API fails, crate present | `true` + warning |
| rename out of the crate | `true` |

And the new query against the real API for the PR that was failing returns its two files, matching nothing:

```
$ gh api --paginate repos/QwenLM/qwen-code/pulls/8369/files --jq '.[] | .filename, (.previous_filename // empty)'
packages/cli/src/commands/review/lib/agent-briefs.ts
packages/core/src/skills/bundled/review/SKILL.md
```

`shellcheck` and `yamllint` clean.

<details><summary>中文说明</summary>

`Desktop Shell (ubuntu-22.04)` 会让**每一个在 #8132 之前分叉的 PR** 失败，而且失败在一个从未执行的步骤上：目录不存在。

两件事叠加。该 job checkout 的是 `refs/pull/{N}/head`（PR 头，非 merge 结果），而它的路径过滤器用 `git diff --name-only FETCH_HEAD HEAD` 对 base 的 depth-1 浅取做比较 —— 这是**两树 diff，不是 PR 的 diff**：base 自分叉点以来新增的一切，都会被读成 PR 这侧的改动。#8132 引入了 `packages/desktop-shell`，此后任何更老的分支都会看到该目录下 78 个幽灵路径，判定 crate 有变更，然后在一棵根本没有该目录的树里执行 `cargo`。

实测：两树 diff 得到 **78** 个 desktop-shell 路径，而 PR 真正的 `BASE...HEAD` diff 是 **0**；job 日志里 `desktop-shell changed: true` 对应的是一个只改了两个文件、且都不是该 crate 的 PR。

**改为向 API 询问 PR 改了什么** —— 这正是本文件上方几百行处 CI profile 分类器已在用的同一个调用，`ci.yml` 从此对这个问题只有一种答法。包含 `previous_filename`：把文件重命名移出该 crate 也是对它的改动，而只有旧路径能说明这一点。

**fail-open 需要一个底线**。"任何不确定都跑这个 job"在树里根本没有 crate 可编译时就不再成立 —— 那时它产出的是一个红叉，而不是一次谨慎。没有 `src-tauri/Cargo.toml` 的 head 不可能让该 crate 回归，于是过滤器报告无变更，并用 notice 说明原因。

除修复外，该过滤器在常规情形下同样是错的：它是在 `main` 动过 desktop-shell 文件时触发，而非在 PR 动过时触发，可能白白花 45 分钟去编译一个 PR 从未碰过的 Tauri crate。

验证：把该步骤原样提取出来，桩掉 `gh`，跑了上表六种场景，结果均如预期；并用真实 API 对出问题的那个 PR 执行了新查询，返回其两个文件，无一匹配。`shellcheck`、`yamllint` 均无告警。

</details>
