### PR TITLE
fix(ci): trigger ECS runner reconciliation after updater changes

### DIFF
--- a/.github/workflows/update-ecs-runner-qwen.yml
+++ b/.github/workflows/update-ecs-runner-qwen.yml
@@ -1,6 +1,9 @@
 name: 'Update ECS Runner Qwen'
 
 on:
+  push:
+    branches: ['main']
+    paths: ['.github/workflows/update-ecs-runner-qwen.yml']
   workflow_dispatch:
     inputs:
       version:

--- a/scripts/tests/update-ecs-runner-qwen-workflow.test.js
+++ b/scripts/tests/update-ecs-runner-qwen-workflow.test.js
@@ -18,6 +18,12 @@ describe('ECS runner qwen update workflow', () => {
     expect(workflow).toContain('sudo env -u NPM_CONFIG_PREFIX npm install -g');
   });
 
+  it('runs only when this workflow changes on main', () => {
+    expect(workflow).toContain(
+      "  push:\n    branches: ['main']\n    paths: ['.github/workflows/update-ecs-runner-qwen.yml']",
+    );
+  });
+
   it('annotates a retry and a terminal failure distinctly', () => {
     // The final attempt must not log a "retrying" warning that never
     // retries; a sustained failure ends with an explicit exhausted error.


### PR DESCRIPTION
## What this PR does

Adds a push trigger for the Update ECS Runner Qwen workflow when that workflow itself is pushed to `main`, while retaining the existing manual and repository-dispatch triggers. Adds a regression test for the scoped trigger.

## Why it's needed

Issue #8371 reports that the existing ECS runner fleet remained on Qwen 0.21.2 after #8343 merged and no updater run reconciled it. This PR makes the merge itself trigger the hardened updater once, and ensures future changes to the updater deploy automatically.

The older Qwen Code releases are not the defect. After 0.21.3 was published and successfully installed, a job ran `npm install --global --prefer-offline @qwen-code/qwen-code@latest`. Persistent npm registry metadata still mapped `latest` to 0.21.2, so npm legitimately resolved the request to that older version and overwrote the shared system-wide 0.21.3 installation. The replacement left a deterministic `.qwen-code-*` trash directory, which then blocked the old updater with `ENOTEMPTY`.

A read-only sample of the latest 100 Review jobs that acquired a runner showed the impact of that shared-host drift:

| Runner pool | Jobs | Observed versions |
| --- | ---: | --- |
| SG | 45 | `0.21.3 × 45` |
| 64c | 55 | `0.21.2 × 49`, `0.21.3 × 5`, `0.21.0 × 1` |

Across both pools the distribution was `0.21.3 × 50`, `0.21.2 × 49`, and `0.21.0 × 1`. Of the 100 jobs, 88 completed jobs were read directly from logs and 12 in-progress jobs were inferred from their shared host's current version. This is evidence that jobs were rewriting a shared installation after 0.21.3 was published, not evidence that 0.21.0 or 0.21.2 were defective releases.

#8343 fixes the root-cause paths: stable releases dispatch an exact version, triage pins the action reinstall to an exact installed version instead of a cached `latest`, and the updater clears npm trash and retries. This PR closes the remaining deployment gap by causing the hardened updater to run after its own workflow changes reach `main`.

## Reviewer Test Plan

### How to verify

Confirm the workflow runs for a push to `main` that changes `.github/workflows/update-ecs-runner-qwen.yml`, but not for another branch or a push that changes only another path. Confirm `workflow_dispatch` and `repository_dispatch` remain present. On a push, absent dispatch inputs resolve to an empty value and the existing resolver falls back to `@qwen-code/qwen-code@latest`; manual and repository-dispatch version inputs remain supported. The push-triggered reconciliation uses a normal online `npm view`, while stable-release dispatches carry the exact published version.

Local verification: `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/update-ecs-runner-qwen-workflow.test.js` (3 passed), `actionlint .github/workflows/update-ecs-runner-qwen.yml`, YAML parsing with PyYAML, `npm run lint`, `npm run typecheck`, `npm run build`, and `git diff --check` all pass.

### Evidence (Before & After)

N/A — workflow-only change with no user-visible UI.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A — runner execution occurs after merge |

### Environment (optional)

Local macOS validation with Node.js v22.22.0 and npm 10.9.4.

## Risk & Scope

- Main risk or tradeoff: merging this PR intentionally starts one update run on the two self-hosted ECS runners; existing repository and concurrency guards remain unchanged.
- Not validated / out of scope: an actual ECS runner update run before merge; the post-merge run must confirm both runners report the current stable version.
- Breaking changes / migration notes: none.

## Linked Issues

Resolves #8371

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

为 Update ECS Runner Qwen 工作流增加 push 触发器：仅当该工作流文件自身被推送到 `main` 时触发，同时保留现有的手动触发和 repository dispatch 触发。新增一个回归测试，校验触发范围受到严格限制。

## 为什么需要

Issue #8371 反馈，#8343 合并后现有 ECS runner 集群仍停留在 Qwen 0.21.2，且没有新的更新工作流运行来完成集群对齐。本 PR 让本次合并自身触发一次已加固的更新流程，并确保以后更新流程发生变化时能够自动部署。

问题不在 0.21.0 或 0.21.2 版本本身。0.21.3 发布并成功安装后，后续任务执行了 `npm install --global --prefer-offline @qwen-code/qwen-code@latest`。持久化 npm registry 缓存仍将 `latest` 映射到 0.21.2，因此 npm 将请求正常解析为这个较旧版本，并覆盖了共享的系统级 0.21.3 安装。覆盖过程中留下确定性的 `.qwen-code-*` 临时目录，随后使旧 updater 报 `ENOTEMPTY`。

最近 100 个实际获得 runner 的 Review job 中，SG 的 45 个任务全部使用 0.21.3；64c 的 55 个任务分别使用 `0.21.2 × 49`、`0.21.3 × 5`、`0.21.0 × 1`。其中 88 个已完成任务来自日志实测，12 个进行中任务按共享主机当前版本推定。这个分布用于证明 0.21.3 发布后共享主机发生了版本漂移，不代表旧版本本身存在缺陷。

#8343 修复根因路径：稳定版发布传递明确版本、triage 固定使用已安装的明确版本而不是缓存中的 `latest`、updater 清理 npm 临时目录并重试。本 PR 补齐剩余的部署缺口：updater workflow 自身的修改进入 `main` 后，自动运行加固后的 updater。

## Reviewer 测试计划

### 如何验证

确认当 `.github/workflows/update-ecs-runner-qwen.yml` 在 `main` 分支发生变化并被推送时，工作流会运行；当推送到其他分支，或只修改其他路径时，不会因该 push 触发。确认 `workflow_dispatch` 和 `repository_dispatch` 仍然存在。对于 push 事件，缺少的 dispatch 输入会解析为空值，现有版本解析逻辑会回退到 `@qwen-code/qwen-code@latest`；手动触发和 repository dispatch 传入版本的能力仍然保留。push 触发的收敛通过普通在线 `npm view` 解析版本，稳定版发布触发则直接携带本次发布的明确版本。

本地验证：`npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/update-ecs-runner-qwen-workflow.test.js`（3 个测试通过）、`actionlint .github/workflows/update-ecs-runner-qwen.yml`、PyYAML YAML 解析、`npm run lint`、`npm run typecheck`、`npm run build` 和 `git diff --check` 均通过。

### 证据（前后对比）

N/A——仅修改工作流，无用户可见界面。

### 测试平台

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | N/A |
|  🐧 Linux | N/A——runner 执行发生在合并后 |

### 环境（可选）

使用 Node.js v22.22.0 和 npm 10.9.4 在本地 macOS 完成验证。

## 风险与范围

- 主要风险/权衡：合并本 PR 会有意在两台自建 ECS runner 上启动一次更新；现有的仓库校验和并发控制保持不变。
- 未验证/范围外：合并前无法实际运行 ECS runner 更新；合并后的运行需要确认两台 runner 都报告当前 stable 版本。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Resolves #8371

</details>
