### PR TITLE
feat(ci): size-aware default timeout for the PR review job

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -347,7 +347,10 @@ jobs:
          startsWith(github.event.review.body, '@qwen-code /review ') ||
          startsWith(github.event.review.body, format('@qwen-code /review{0}', '\n'))) &&
         needs.authorize.outputs.should_review == 'true'))
-    timeout-minutes: 260
+    # 300 (not 260): the per-review budget auto-scales to 240 minutes for any
+    # non-small PR (see "Run review"), and the shared retry budget plus comment
+    # posting need headroom above that within the job-level cap.
+    timeout-minutes: 300
     runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'') && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     permissions:
       contents: 'read'
@@ -415,12 +418,17 @@ jobs:
           set -euo pipefail
           DEFAULT_TIMEOUT_MINUTES=180
           TIMEOUT_MINUTES="$DEFAULT_TIMEOUT_MINUTES"
+          # Tracks whether the caller chose a timeout explicitly (workflow_dispatch
+          # input or a /review --timeout=N comment). When false, "Run review"
+          # replaces this default with a PR-size-aware tier instead.
+          TIMEOUT_EXPLICIT=false
           TRIGGER_COMMAND="${TRIGGER_BODY%%$'\n'*}"
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             PR_NUMBER="${{ github.event.inputs.pr_number }}"
             REVIEW_MODE="${{ github.event.inputs.review_mode }}"
             TIMEOUT_MINUTES="${{ github.event.inputs.timeout_minutes || '180' }}"
+            TIMEOUT_EXPLICIT=true
           elif [ "${{ github.event_name }}" = "issue_comment" ]; then
             if ! printf '%s\n' "$TRIGGER_COMMAND" | grep -Eq '^@qwen-code[[:space:]]+/review([[:space:]]|$)'; then
               echo "should_run=false" >> "$GITHUB_OUTPUT"
@@ -449,9 +457,11 @@ jobs:
               case "$token" in
                 --timeout=*)
                   TIMEOUT_MINUTES="${token#--timeout=}"
+                  TIMEOUT_EXPLICIT=true
                   ;;
                 timeout=*)
                   TIMEOUT_MINUTES="${token#timeout=}"
+                  TIMEOUT_EXPLICIT=true
                   ;;
               esac
             done
@@ -463,6 +473,7 @@ jobs:
             echo "pr_number=$PR_NUMBER"
             echo "review_mode=$REVIEW_MODE"
             echo "timeout_minutes=$TIMEOUT_MINUTES"
+            echo "timeout_explicit=$TIMEOUT_EXPLICIT"
           } >> "$GITHUB_OUTPUT"
 
       - name: 'Setup Node.js for hosted review'
@@ -493,6 +504,7 @@ jobs:
           PR_NUMBER: '${{ steps.context.outputs.pr_number }}'
           REVIEW_MODE: '${{ steps.context.outputs.review_mode }}'
           TIMEOUT_MINUTES: '${{ steps.context.outputs.timeout_minutes }}'
+          TIMEOUT_EXPLICIT: '${{ steps.context.outputs.timeout_explicit }}'
           # Per-run agent home so this review's session/memory cannot leak into
           # the next on the reused self-hosted workspace (reset in "Clean stale
           # agent state"). Must match the QWEN_HOME computed there.
@@ -713,6 +725,37 @@ jobs:
             fail "timeout_minutes must not exceed 240 minutes"
           fi
 
+          # Size-aware default timeout. A fixed 180-minute default times out
+          # non-trivial PRs whose deep review (chunked passes, two reverse-audit
+          # rounds, test-efficacy probes that run real builds) legitimately
+          # needs longer — e.g. #8241 (+1577) died on the clock at 180, and the
+          # same PR had finished in ~90 minutes on a less loaded runner, so the
+          # variance alone argues for a wide budget. When the caller did not
+          # pass an explicit --timeout, give any non-small PR (> 300 changed
+          # lines, additions + deletions) the full 240 cap; small PRs keep the
+          # proven 180. An explicit --timeout always wins. A size lookup failure
+          # falls back to the 180 default rather than failing the review.
+          EFFECTIVE_TIMEOUT_MINUTES="$TIMEOUT_MINUTES"
+          if [ "${TIMEOUT_EXPLICIT:-false}" != "true" ]; then
+            PR_SIZE_LINES=''
+            if PR_SIZE_DATA="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json additions,deletions --jq '.additions + .deletions' 2>/dev/null)"; then
+              case "$PR_SIZE_DATA" in
+                ''|*[!0-9]*) ;;
+                *) PR_SIZE_LINES="$PR_SIZE_DATA" ;;
+              esac
+            fi
+            if [ -n "$PR_SIZE_LINES" ]; then
+              if [ "$PR_SIZE_LINES" -le 300 ]; then
+                EFFECTIVE_TIMEOUT_MINUTES=180
+              else
+                EFFECTIVE_TIMEOUT_MINUTES=240
+              fi
+              echo "PR #${PR_NUMBER} changed ${PR_SIZE_LINES} lines; auto timeout ${EFFECTIVE_TIMEOUT_MINUTES} minutes."
+            else
+              echo "Could not determine PR #${PR_NUMBER} size; using default ${EFFECTIVE_TIMEOUT_MINUTES} minutes."
+            fi
+          fi
+
           if ! PR_DATA="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state,headRefOid --jq '[.state, .headRefOid] | @tsv')"; then
             fail "Failed to determine state for PR #${PR_NUMBER}."
           fi
@@ -733,7 +776,10 @@ jobs:
           export QWEN_CI_REVIEW_REPO="$REPO"
           export QWEN_CI_REVIEW_PR_NUMBER="$PR_NUMBER"
           export QWEN_CI_REVIEW_EXPECTED_HEAD_SHA="$EXPECTED_HEAD_SHA"
-          echo "expected_head_sha=$EXPECTED_HEAD_SHA" >> "$GITHUB_OUTPUT"
+          {
+            echo "expected_head_sha=$EXPECTED_HEAD_SHA"
+            echo "effective_timeout_minutes=$EFFECTIVE_TIMEOUT_MINUTES"
+          } >> "$GITHUB_OUTPUT"
 
           PROMPT="/review ${REVIEW_URL}"
           if [ "$REVIEW_MODE" = "comment" ]; then
@@ -745,7 +791,7 @@ jobs:
             MODEL_ARGS=(--model "$OPENAI_MODEL")
           fi
 
-          QWEN_TIMEOUT="$TIMEOUT_MINUTES"
+          QWEN_TIMEOUT="$EFFECTIVE_TIMEOUT_MINUTES"
 
           # One attempt of the qwen review. Sets OUTCOME (success | retryable |
           # quota | timeout | fatal), plus REASON/KIND for the failure paths.
@@ -901,7 +947,9 @@ jobs:
           FAILURE_REASON: "${{ steps.review.outputs.failure_reason || 'Run review failed. See workflow logs for details.' }}"
           PR_NUMBER: '${{ steps.context.outputs.pr_number }}'
           RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
-          TIMEOUT_MINUTES: '${{ steps.context.outputs.timeout_minutes }}'
+          # The size-aware budget actually used by "Run review" (falls back to
+          # the raw context value if the review step failed before setting it).
+          TIMEOUT_MINUTES: '${{ steps.review.outputs.effective_timeout_minutes || steps.context.outputs.timeout_minutes }}'
         run: |-
           pr_data="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state,headRefOid --jq '[.state, .headRefOid] | @tsv')" || {
             echo "Could not verify PR #${PR_NUMBER}; skipping fallback comment." >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/tests/qwen-resolve-workflow.test.js
+++ b/scripts/tests/qwen-resolve-workflow.test.js
@@ -346,7 +346,7 @@ describe('qwen resolve workflow', () => {
     const contextStep = step(reviewJob, 'Resolve PR context');
     const runStep = step(reviewJob, 'Run review');
 
-    expect(reviewJob).toContain('timeout-minutes: 260');
+    expect(reviewJob).toContain('timeout-minutes: 300');
     expect(contextStep).toContain('DEFAULT_TIMEOUT_MINUTES=180');
     expect(contextStep).toContain('case "$token" in');
     expect(contextStep).toContain('--timeout=*)');
@@ -355,8 +355,37 @@ describe('qwen resolve workflow', () => {
     expect(contextStep).toContain('TIMEOUT_MINUTES="${token#timeout=}"');
     expect(runStep).toContain('if [ "${#TIMEOUT_MINUTES}" -gt 3 ]; then');
     expect(runStep).toContain('timeout_minutes must not exceed 240 minutes');
-    expect(runStep).toContain('QWEN_TIMEOUT="$TIMEOUT_MINUTES"');
+    expect(runStep).toContain('QWEN_TIMEOUT="$EFFECTIVE_TIMEOUT_MINUTES"');
     expect(runStep).not.toContain('QWEN_TIMEOUT=$((TIMEOUT_MINUTES - 5))');
+  });
+
+  it('tiers the default review timeout by PR size unless overridden', () => {
+    const contextStep = step(reviewJob, 'Resolve PR context');
+    const runStep = step(reviewJob, 'Run review');
+
+    // The context step records whether the caller chose a timeout explicitly.
+    expect(contextStep).toContain('TIMEOUT_EXPLICIT=false');
+    expect(contextStep).toContain('TIMEOUT_EXPLICIT=true');
+    expect(contextStep).toContain('echo "timeout_explicit=$TIMEOUT_EXPLICIT"');
+    expect(runStep).toContain(
+      "TIMEOUT_EXPLICIT: '${{ steps.context.outputs.timeout_explicit }}'",
+    );
+
+    // Auto-tiering only applies without an explicit --timeout, keys off
+    // additions + deletions, and never exceeds the 240 cap: small PRs keep 180,
+    // anything larger gets the full 240.
+    expect(runStep).toContain('EFFECTIVE_TIMEOUT_MINUTES="$TIMEOUT_MINUTES"');
+    expect(runStep).toContain(
+      'if [ "${TIMEOUT_EXPLICIT:-false}" != "true" ]; then',
+    );
+    expect(runStep).toContain('--json additions,deletions');
+    expect(runStep).toContain('if [ "$PR_SIZE_LINES" -le 300 ]; then');
+    expect(runStep).toContain('EFFECTIVE_TIMEOUT_MINUTES=180');
+    expect(runStep).toContain('EFFECTIVE_TIMEOUT_MINUTES=240');
+    expect(runStep).not.toContain('EFFECTIVE_TIMEOUT_MINUTES=210');
+    expect(runStep).toContain(
+      'echo "effective_timeout_minutes=$EFFECTIVE_TIMEOUT_MINUTES"',
+    );
   });
 
   it('tells maintainers how to retry timed-out reviews with more time', () => {
@@ -371,6 +400,9 @@ describe('qwen resolve workflow', () => {
     expect(runStep).toContain('[ "$qwen_status" -eq 137 ]');
     expect(fallbackStep).toContain('FAILURE_KIND:');
     expect(fallbackStep).toContain('TIMEOUT_MINUTES:');
+    expect(fallbackStep).toContain(
+      "TIMEOUT_MINUTES: '${{ steps.review.outputs.effective_timeout_minutes || steps.context.outputs.timeout_minutes }}'",
+    );
     expect(fallbackStep).toContain('@qwen-code /review --timeout=240');
     expect(fallbackStep).toContain(
       'This run already used the maximum 240 minute timeout.',
@@ -425,9 +457,7 @@ describe('qwen resolve workflow', () => {
     expect(runStep).toContain(
       'QWEN_CI_REVIEW_EXPECTED_HEAD_SHA="$EXPECTED_HEAD_SHA"',
     );
-    expect(runStep).toContain(
-      'echo "expected_head_sha=$EXPECTED_HEAD_SHA" >> "$GITHUB_OUTPUT"',
-    );
+    expect(runStep).toContain('echo "expected_head_sha=$EXPECTED_HEAD_SHA"');
     expect(fallbackStep).toContain('EXPECTED_HEAD_SHA:');
     expect(fallbackStep).toContain(
       'Skipping fallback comment: PR #${PR_NUMBER} is ${pr_state}.',


### PR DESCRIPTION
## What this PR does

The automated PR review job sized every review with a fixed 180-minute default budget. This change makes that default depend on the size of the PR being reviewed, measured as additions plus deletions. Small PRs (300 changed lines or fewer) keep the existing 180-minute default; anything larger is given the full 240-minute cap automatically. A timeout passed explicitly through a `/review --timeout=N` comment (or the workflow dispatch input) still takes precedence, and if the size lookup fails the job falls back to the 180 default rather than failing. The job-level timeout is raised from 260 to 300 minutes so the higher per-review budget plus the shared retry and comment posting fit with headroom.

## Why it's needed

A medium PR (#8241, +1577/-57 across 6 files) recently ran the review for the full 180 minutes and was killed by the timeout without ever posting its review comment. The deep review flow (chunked passes, two reverse-audit rounds, and test-efficacy probes that run real builds) legitimately needs longer on non-trivial PRs, and its wall time varies a lot with runner load — the same PR had finished in roughly 90 minutes on an earlier run. A single fixed default either wastes runner time on small PRs or times out medium ones; sizing the budget by diff size gives medium and large PRs enough room without changing anything for small ones.

## Reviewer Test Plan

### How to verify

Run the workflow guard tests: `npx vitest run --config ./scripts/tests/vitest.config.ts qwen-resolve-workflow` — 29 tests pass, including a new case pinning the size tiers and the explicit-override path. The workflow YAML parses cleanly (`js-yaml`), and the tier logic was exercised in bash: 120 and 300 changed lines resolve to 180 minutes, while 301, 1634 (PR #8241's size), and 5000 resolve to 240. On merge, the next automatic review of a non-small PR should log `auto timeout 240 minutes` in the "Run review" step, and a small PR should log 180.

### Evidence (Before & After)

N/A — CI workflow logic, no TUI.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Unit tests only (`npm run test:scripts` suite: 42 files, 860 tests passing).

## Risk & Scope

- Main risk or tradeoff: non-small PRs now hold a self-hosted runner for up to 240 minutes by default (previously 180). Reviews usually finish well before the budget, and the PR-scoped concurrency group still allows only one review per PR at a time, so this trades runner occupancy for fewer timed-out reviews.
- Not validated / out of scope: the exact 300-line small/large cutoff is a heuristic and can be retuned later; the underlying review latency (serial foreground subagents, long test probes) is not addressed here.
- Breaking changes / migration notes: none. Explicit `--timeout=N` behavior and the 240 cap are unchanged.

## Linked Issues

No linked issue. Motivated by the #8241 review timing out at 180 minutes (run 30731154414).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

自动 PR 评审 job 此前对所有评审统一使用固定的 180 分钟默认预算。本次改动让该默认值随被评审 PR 的规模（新增行 + 删除行）变化：小 PR（改动 ≤ 300 行）沿用现有的 180 分钟默认；更大的 PR 自动获得满额 240 分钟上限。通过 `/review --timeout=N` 评论（或 workflow dispatch 输入）显式指定的超时仍然优先；若获取 PR 规模失败，则回退到 180 默认而非让评审失败。job 级超时从 260 提升到 300 分钟，以便更高的评审预算加上共享重试与评论发布仍有充足余量。

## 为什么需要

最近一个中等规模 PR（#8241，6 个文件 +1577/-57）评审跑满 180 分钟后被超时杀掉，始终没有发出评审评论。深度评审流程（分块审查、两轮反向审计、以及跑真实构建的测试有效性探针）在非平凡 PR 上确实需要更久，且耗时随 runner 负载波动很大——同一个 PR 在更早一次运行中约 90 分钟就跑完了。单一固定默认值要么在小 PR 上浪费 runner 时间，要么让中等 PR 超时；按 diff 规模分档能在不改变小 PR 行为的前提下，给中等和大 PR 足够余量。

## 评审者测试计划

### 如何验证

运行 workflow 守护测试：`npx vitest run --config ./scripts/tests/vitest.config.ts qwen-resolve-workflow`——29 个测试通过，其中新增用例钉死了规模分档与显式覆盖路径。workflow YAML 可正常解析（`js-yaml`），分档逻辑已用 bash 验证：改动 120 和 300 行解析为 180 分钟，301、1634（PR #8241 的规模）、5000 行解析为 240。合并后，下一次对非小 PR 的自动评审应在 "Run review" 步骤打印 `auto timeout 240 minutes`，小 PR 打印 180。

### 证据（前后对比）

N/A——CI workflow 逻辑，无 TUI。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

仅单元测试（`npm run test:scripts` 套件：42 个文件、860 个测试通过）。

## 风险与范围

- 主要风险或权衡：非小 PR 现在默认最多占用 self-hosted runner 240 分钟（此前为 180）。评审通常远早于预算结束，且 PR 维度的 concurrency group 仍保证每个 PR 同一时间只有一个评审，因此这是用 runner 占用换取更少的超时评审。
- 未验证 / 不在范围：300 行的小/大分界是经验值，后续可调；评审本身的耗时（串行前台子代理、耗时的测试探针）不在本次处理。
- 破坏性变更 / 迁移说明：无。显式 `--timeout=N` 行为与 240 上限均不变。

## 关联 Issue

无关联 issue。起因是 #8241 的评审在 180 分钟超时（run 30731154414）。

</details>
