### PR TITLE
fix(serve): detect lineEnding across the file, not the returned slice

### DIFF
--- a/docs/design/serve-large-text-range-consistency.md
+++ b/docs/design/serve-large-text-range-consistency.md
@@ -58,9 +58,12 @@ checked between reads. A future scan-cost policy needs a cursor or equivalent
 continuation contract instead of silently making valid deep offsets
 unreachable.
 
-Serve derives `lineEnding` from the returned content, matching its existing
-full-snapshot behavior. Core can continue reporting file-level metadata for its
-other consumers.
+Serve's full-snapshot reads derive `lineEnding` from the whole decoded file.
+The large-file window paths still derive it from the returned window, except
+that a byte-cursor page also counts the terminator it resumes after, so an
+unterminated tail page agrees with the page before it (unifying the paths is
+tracked as a follow-up). Core can continue reporting file-level metadata for
+its other consumers.
 
 Every large-file window keeps `truncated: true`, even when the scan happens to
 reach EOF. This boundary uses the flag to distinguish a window without a

--- a/docs/design/serve-large-text-range-consistency.md
+++ b/docs/design/serve-large-text-range-consistency.md
@@ -61,9 +61,10 @@ unreachable.
 Serve's full-snapshot reads derive `lineEnding` from the whole decoded file.
 The large-file window paths still derive it from the returned window, except
 that a byte-cursor page also counts the terminator it resumes after, so an
-unterminated tail page agrees with the page before it (unifying the paths is
-tracked as a follow-up). Core can continue reporting file-level metadata for
-its other consumers.
+unterminated tail page agrees with the page before it in a file with uniform
+line endings (mixed-ending files can still flip between pages; unifying the
+paths is tracked as a follow-up). Core can continue reporting file-level
+metadata for its other consumers.
 
 Every large-file window keeps `truncated: true`, even when the scan happens to
 reach EOF. This boundary uses the flag to distinguish a window without a

--- a/docs/design/serve-large-text-range-consistency.md
+++ b/docs/design/serve-large-text-range-consistency.md
@@ -87,8 +87,9 @@ full-snapshot refusal.
 
 ## Verification
 
-- A mixed-EOL large file reports the ending style present in the returned
-  slice.
+- A mixed-EOL large file's line window reports the ending style present in
+  the returned slice; a byte-cursor page may also report a terminator
+  outside its returned slice (see Decision).
 - Concurrent append, truncation, pathname replacement, and symlink replacement
   are rejected. A same-size in-place rewrite is rejected whenever the change
   lands in a later timestamp quantum: the checks compare modification time and

--- a/docs/design/serve-large-text-range-consistency.md
+++ b/docs/design/serve-large-text-range-consistency.md
@@ -60,11 +60,13 @@ unreachable.
 
 Serve's full-snapshot reads derive `lineEnding` from the whole decoded file.
 The large-file window paths still derive it from the returned window, except
-that a byte-cursor page also counts the terminator it resumes after, so an
-unterminated tail page agrees with the page before it in a file with uniform
-line endings (mixed-ending files can still flip between pages; unifying the
-paths is tracked as a follow-up). Core can continue reporting file-level
-metadata for its other consumers.
+that a byte-cursor page also counts a terminator outside its returned slice —
+the one it resumes after, and, when its first line is cut by the byte budget,
+the one the re-snap walks over — so an unterminated tail page agrees with the
+page before it, and a byte-truncated page with the page after it, in a file
+with uniform line endings (mixed-ending files can still flip between pages;
+unifying the paths is a candidate follow-up — no tracking issue exists yet).
+Core can continue reporting file-level metadata for its other consumers.
 
 Every large-file window keeps `truncated: true`, even when the scan happens to
 reach EOF. This boundary uses the flag to distinguish a window without a

--- a/docs/design/serve-large-text-range-consistency.md
+++ b/docs/design/serve-large-text-range-consistency.md
@@ -64,9 +64,11 @@ that a byte-cursor page also counts a terminator outside its returned slice —
 the one it resumes after, and, when its first line is cut by the byte budget,
 the one the re-snap walks over — so an unterminated tail page agrees with the
 page before it, and a byte-truncated page with the page after it, in a file
-with uniform line endings (mixed-ending files can still flip between pages;
-unifying the paths is a candidate follow-up — no tracking issue exists yet).
-Core can continue reporting file-level metadata for its other consumers.
+with uniform line endings (mixed-ending files can still flip between pages,
+and a large-file line window of a uniform file can disagree with a
+byte-cursor page of the same bytes; unifying the paths is a candidate
+follow-up — no tracking issue exists yet). Core can continue reporting
+file-level metadata for its other consumers.
 
 Every large-file window keeps `truncated: true`, even when the scan happens to
 reach EOF. This boundary uses the flag to distinguish a window without a

--- a/packages/cli/src/serve/fs/workspace-file-system.test.ts
+++ b/packages/cli/src/serve/fs/workspace-file-system.test.ts
@@ -279,7 +279,13 @@ describe('WorkspaceFileSystem - readText', () => {
     });
     expect(second.content).toBe('bb\r');
     expect(second.meta.lineEnding).toBe('crlf');
+
+    const trunc = await h.fs.readText(r, { maxBytes: 3 });
+    expect(trunc.content).toBe('aa\r');
+    expect(trunc.meta.truncated).toBe(true);
+    expect(trunc.meta.lineEnding).toBe('crlf');
   });
+
   it('pages a large log by cursor and reassembles it exactly', async () => {
     const target = path.join(h.workspace, 'cursor-page.log');
     const lines = Array.from(

--- a/packages/cli/src/serve/fs/workspace-file-system.test.ts
+++ b/packages/cli/src/serve/fs/workspace-file-system.test.ts
@@ -261,6 +261,25 @@ describe('WorkspaceFileSystem - readText', () => {
     expect((err as { hint?: string }).hint).toMatch(/readBytes/);
   });
 
+  it('reports the same lineEnding on every page of a CRLF file', async () => {
+    // A one-line slice arrives as text ending in '\r' — the '\n' was consumed
+    // as its terminator — so detecting on the slice would call page 1 'lf'
+    // while the cursor path called page 2 'crlf', for one file.
+    const target = path.join(h.workspace, 'crlf-pages.txt');
+    await fsp.writeFile(target, 'aa\r\nbb\r\ncc\r\n');
+    const r = await h.fs.resolve('crlf-pages.txt', 'read');
+
+    const first = await h.fs.readText(r, { limit: 1 });
+    expect(first.content).toBe('aa\r');
+    expect(first.meta.lineEnding).toBe('crlf');
+
+    const second = await h.fs.readText(r, {
+      cursor: first.meta.nextCursor!,
+      limit: 1,
+    });
+    expect(second.content).toBe('bb\r');
+    expect(second.meta.lineEnding).toBe('crlf');
+  });
   it('pages a large log by cursor and reassembles it exactly', async () => {
     const target = path.join(h.workspace, 'cursor-page.log');
     const lines = Array.from(

--- a/packages/cli/src/serve/fs/workspace-file-system.test.ts
+++ b/packages/cli/src/serve/fs/workspace-file-system.test.ts
@@ -286,6 +286,23 @@ describe('WorkspaceFileSystem - readText', () => {
     expect(trunc.meta.lineEnding).toBe('crlf');
   });
 
+  it('keeps an unterminated CRLF tail page consistent with page one', async () => {
+    // The tail page holds only `bb` — no terminator to test — so detection
+    // must come from the CRLF pair the cursor resumed after, or the two pages
+    // of one file disagree, the exact symptom fixed above.
+    const target = path.join(h.workspace, 'crlf-no-final.txt');
+    await fsp.writeFile(target, 'aa\r\nbb');
+    const r = await h.fs.resolve('crlf-no-final.txt', 'read');
+
+    const first = await h.fs.readText(r, { limit: 1 });
+    expect(first.content).toBe('aa\r');
+    expect(first.meta.lineEnding).toBe('crlf');
+
+    const tail = await h.fs.readText(r, { cursor: first.meta.nextCursor! });
+    expect(tail.content).toBe('bb');
+    expect(tail.meta.lineEnding).toBe('crlf');
+  });
+
   it('pages a large log by cursor and reassembles it exactly', async () => {
     const target = path.join(h.workspace, 'cursor-page.log');
     const lines = Array.from(

--- a/packages/cli/src/serve/fs/workspace-file-system.ts
+++ b/packages/cli/src/serve/fs/workspace-file-system.ts
@@ -1494,7 +1494,12 @@ async function readTextSnapshotFromResolvedFile(
   const meta: TextSnapshot['meta'] = {
     encoding: decoded.encoding,
     bom: decoded.bom,
-    lineEnding: detectLineEnding(content),
+    // Detected across the whole decoded file, not the returned slice. A slice
+    // holding one CRLF line arrives as text ending in '\r' with the '\n'
+    // consumed as its terminator, so testing the slice reports 'lf' — and one
+    // page of a cursor sequence would then disagree with the next about the
+    // same file.
+    lineEnding: detectLineEnding(decoded.content),
     sizeBytes: raw.length,
     originalLineCount: sliced.originalLineCount,
     hash: hashBuffer(raw),
@@ -1503,7 +1508,6 @@ async function readTextSnapshotFromResolvedFile(
   const output = Buffer.from(content, 'utf-8');
   if (output.length > maxOutputBytes) {
     content = safeUtf8Truncate(output, maxOutputBytes).toString('utf-8');
-    meta.lineEnding = detectLineEnding(content);
     meta.truncated = true;
     byteTruncated = true;
   }

--- a/packages/core/src/utils/read-text-range.test.ts
+++ b/packages/core/src/utils/read-text-range.test.ts
@@ -939,6 +939,46 @@ describe('readTextCursorWindowFromHandle', () => {
     });
   });
 
+  it('seeds an unterminated tail page from the terminator it resumes after', async () => {
+    // The tail page of 'aa\r\nbb' holds only 'bb' — no terminator to test —
+    // so without the byte pair before the window it would report 'lf' while
+    // the first page reported 'crlf' for the same file.
+    await withHandle('crlf-no-final.log', 'aa\r\nbb', async (fh, size) => {
+      const first = await readTextCursorWindowFromHandle(fh, {
+        startOffset: 0,
+        fileSize: size,
+        limit: 1,
+        maxOutputBytes: 1_024,
+        maxSnapBytes: 1_024,
+      });
+      expect(first.content).toBe('aa\r');
+      expect(first.lineEnding).toBe('crlf');
+      expect(first.nextOffset).toBe(4);
+
+      const tail = await readTextCursorWindowFromHandle(fh, {
+        startOffset: first.nextOffset!,
+        fileSize: size,
+        maxOutputBytes: 1_024,
+        maxSnapBytes: 1_024,
+      });
+      expect(tail.content).toBe('bb');
+      expect(tail.nextOffset).toBeUndefined();
+      expect(tail.lineEnding).toBe('crlf');
+    });
+
+    // The LF counterpart stays 'lf': the peek only confirms a CRLF pair.
+    await withHandle('lf-no-final.log', 'aa\nbb', async (fh, size) => {
+      const tail = await readTextCursorWindowFromHandle(fh, {
+        startOffset: 3,
+        fileSize: size,
+        maxOutputBytes: 1_024,
+        maxSnapBytes: 1_024,
+      });
+      expect(tail.content).toBe('bb');
+      expect(tail.lineEnding).toBe('lf');
+    });
+  });
+
   it('does not let a budget-excluded CRLF line flip lineEnding', async () => {
     // "aaa" (3) + sep (1) + "bbb" (3) = 7 <= 8; "ccc\r" would need 7+1+4 = 12 > 8.
     await withHandle(

--- a/packages/core/src/utils/read-text-range.test.ts
+++ b/packages/core/src/utils/read-text-range.test.ts
@@ -979,6 +979,78 @@ describe('readTextCursorWindowFromHandle', () => {
     });
   });
 
+  it('seeds from the snapped offset, not the requested one', async () => {
+    // The request lands between '\r' and '\n'; the reader snaps to the next
+    // line start and must seed from there. Seeding from the raw request would
+    // probe 'a','\r' instead of the CRLF pair and misreport 'lf'.
+    await withHandle('crlf-snap.log', 'aa\r\nbb', async (fh, size) => {
+      const page = await readTextCursorWindowFromHandle(fh, {
+        startOffset: 3, // between the '\r' and the '\n'
+        fileSize: size,
+        maxOutputBytes: 1_024,
+        maxSnapBytes: 1_024,
+      });
+      expect(page.startOffset).toBe(4);
+      expect(page.content).toBe('bb');
+      expect(page.lineEnding).toBe('crlf');
+    });
+  });
+
+  it('seeds at the minimum probe offset', async () => {
+    // startOffset 2 is the earliest window that can probe — bytes 0-1 are the
+    // terminator itself. Anything stricter skips the only line-ending evidence
+    // the tail page of '\r\nbb' has.
+    await withHandle('crlf-empty-first.log', '\r\nbb', async (fh, size) => {
+      const first = await readTextCursorWindowFromHandle(fh, {
+        startOffset: 0,
+        fileSize: size,
+        limit: 1,
+        maxOutputBytes: 1_024,
+        maxSnapBytes: 1_024,
+      });
+      expect(first.content).toBe('\r');
+      expect(first.nextOffset).toBe(2);
+
+      const tail = await readTextCursorWindowFromHandle(fh, {
+        startOffset: first.nextOffset!,
+        fileSize: size,
+        maxOutputBytes: 1_024,
+        maxSnapBytes: 1_024,
+      });
+      expect(tail.content).toBe('bb');
+      expect(tail.lineEnding).toBe('crlf');
+    });
+  });
+
+  it('counts the terminator a byte-truncated giant line is cut from', async () => {
+    // A line longer than one read chunk (512 KiB) reaches the byte cut before
+    // its terminator is ever decoded, so the cut cannot test it for '\r'. The
+    // re-snap then steps over that terminator; counting it is what keeps this
+    // page's lineEnding equal to the next page's, which seeds from the pair.
+    const body = `${'x'.repeat(600 * 1024)}\r\nbb`;
+    await withHandle('giant-crlf.log', body, async (fh, size) => {
+      const first = await readTextCursorWindowFromHandle(fh, {
+        startOffset: 0,
+        fileSize: size,
+        maxOutputBytes: 100,
+        maxSnapBytes: 1_024,
+      });
+      expect(first.truncatedByBytes).toBe(true);
+      expect(first.content).toBe('x'.repeat(100));
+      expect(first.nextOffset).toBe(600 * 1024 + 2);
+      expect(first.lineEnding).toBe('crlf');
+
+      const second = await readTextCursorWindowFromHandle(fh, {
+        startOffset: first.nextOffset!,
+        fileSize: size,
+        maxOutputBytes: 1_024,
+        maxSnapBytes: 1_024,
+      });
+      expect(second.content).toBe('bb');
+      expect(second.lineEnding).toBe('crlf');
+    });
+  });
+
   it('does not let a budget-excluded CRLF line flip lineEnding', async () => {
     // "aaa" (3) + sep (1) + "bbb" (3) = 7 <= 8; "ccc\r" would need 7+1+4 = 12 > 8.
     await withHandle(

--- a/packages/core/src/utils/read-text-range.ts
+++ b/packages/core/src/utils/read-text-range.ts
@@ -391,6 +391,12 @@ export async function readTextCursorWindowFromHandle(
       true,
     );
     consumedBytes = resumeAt - startOffset;
+    // The skip walked over the cut line's terminator without decoding it —
+    // the same pair the next page's seed reads — so count it here too or the
+    // two pages of one file disagree.
+    if (!sawCrlf) {
+      sawCrlf = await precededByCrlfTerminator(fileHandle, resumeAt);
+    }
   }
 
   const content = lines.join('\n');

--- a/packages/core/src/utils/read-text-range.ts
+++ b/packages/core/src/utils/read-text-range.ts
@@ -278,8 +278,11 @@ export async function readTextCursorWindowFromHandle(
   let skipRestOfLine = false;
   // A CRLF line arrives here as text ending in '\r' with the '\n' consumed as
   // its terminator, so the returned text never contains the pair — testing
-  // `content` for '\r\n' would report 'lf' for every single-line page.
-  let sawCrlf = false;
+  // `content` for '\r\n' would report 'lf' for every single-line page. A
+  // window that resumes right after a CRLF terminator carries no evidence of
+  // the pair at all — the tail page of a file without a final newline is the
+  // case in practice — so seed the flag from the two bytes before the window.
+  let sawCrlf = await precededByCrlfTerminator(fileHandle, startOffset);
 
   const emit = (line: string, hadNewline: boolean): void => {
     const separator = lines.length > 0 ? 1 : 0;
@@ -407,6 +410,25 @@ const UTF8_BOM_BYTES = 3;
 
 /** Byte 0x0A never appears inside a multi-byte UTF-8 sequence. */
 const LINE_FEED = 0x0a;
+const CARRIAGE_RETURN = 0x0d;
+
+/**
+ * Whether the two bytes just before `startOffset` form a CRLF terminator. A
+ * cursor this reader mints always resumes at the line start after a '\n', so
+ * this is one bounded two-byte read; it is the only line-ending evidence a
+ * window whose own lines carry no terminator can have.
+ */
+async function precededByCrlfTerminator(
+  fileHandle: FileHandle,
+  startOffset: number,
+): Promise<boolean> {
+  if (startOffset < 2) return false;
+  const probe = Buffer.alloc(2);
+  const { bytesRead } = await fileHandle.read(probe, 0, 2, startOffset - 2);
+  return (
+    bytesRead === 2 && probe[0] === CARRIAGE_RETURN && probe[1] === LINE_FEED
+  );
+}
 
 async function hasUtf8Bom(
   fileHandle: FileHandle,


### PR DESCRIPTION
## What this PR does

`readText` reported `meta.lineEnding` from the slice it was about to return rather than from the file. A slice holding a single CRLF line arrives as text ending in `\r` — the `\n` was consumed as that line's terminator — so detecting on it answers `lf`.

The visible effect is that page one of a cursor sequence disagrees with page two about the same file. The truncation branch re-detected on the truncated slice for the same reason and had the same flaw.

Detect once across the whole decoded file, which is what the field describes.

## Why it's needed

A client that trusts the first page's `lineEnding` will rewrite CRLF content as LF on save. The disagreement is silent — both pages look internally consistent.

## Reviewer Test Plan

### How to verify

- Read a CRLF file with `limit: 1`, then follow `nextCursor` for the second page. Both pages should report `crlf`; before this change the first reported `lf`.
- Run `cd packages/cli && npx vitest run src/serve/fs/workspace-file-system.test.ts`.

The added test fails against `main` with `expected 'lf' to be 'crlf'` — verified by reverting the one-line change with the test in place.

### Evidence (Before & After)

N/A — no TUI surface. The behaviour change is the `meta.lineEnding` value on a sliced read.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Linux, Node.js v22.22.1. 119 tests in the touched suite.

## Risk & Scope

- Main risk or tradeoff: `lineEnding` now describes the file rather than the returned bytes. That is the intended meaning — the field sits in `meta` alongside `encoding`, `bom`, and `sizeBytes`, which are all file-level — but any caller that was relying on it describing the slice would see a change.
- Not validated / out of scope: only tested on Linux locally.
- Breaking changes / migration notes: none.

<details>
<summary>中文说明</summary>

## 本 PR 的改动

`readText` 用即将返回的**切片**来判定 `meta.lineEnding`，而不是用文件。只含一行 CRLF 的切片，其 `\n` 已被当作该行的终止符消费掉，切片本身以 `\r` 结尾——于是判定结果是 `lf`。

外部可见的后果是：游标翻页时第一页和第二页对**同一个文件**给出不同的 `lineEnding`。截断分支出于同样的原因在截断后的切片上重新判定，有同样的缺陷。

改为对整个解码后的文件判定一次，这才是该字段描述的东西。

## 为什么需要

信任第一页 `lineEnding` 的客户端，会在保存时把 CRLF 内容改写成 LF。而且这个分歧是静默的——两页各自看起来都自洽。

## Reviewer 测试计划

### 如何验证

- 用 `limit: 1` 读一个 CRLF 文件，再沿 `nextCursor` 取第二页。两页都应报 `crlf`；改动前第一页报 `lf`。
- 运行 `cd packages/cli && npx vitest run src/serve/fs/workspace-file-system.test.ts`。

新增测试在 `main` 上会失败并报 `expected 'lf' to be 'crlf'`——保留测试、还原那一行改动实测确认过。

### 证据（Before & After）

N/A —— 无 TUI 界面。行为变化体现在切片读取时的 `meta.lineEnding` 取值。

### 已测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ⚠️  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ✅  |

### 环境（可选）

Linux，Node.js v22.22.1。所改动测试套件 119 个用例。

## 风险与范围

- 主要风险或取舍：`lineEnding` 现在描述的是文件而非返回的字节。这正是它应有的含义——该字段与 `encoding`、`bom`、`sizeBytes` 并列在 `meta` 中，那些都是文件级的——但如果有调用方依赖它描述切片，会感知到变化。
- 未验证／范围外：本地仅在 Linux 测试。
- Breaking changes／迁移说明：无。

</details>