### PR TITLE
docs: document serve sub-session concurrency settings

### DIFF
--- a/docs/users/configuration/settings.md
+++ b/docs/users/configuration/settings.md
@@ -553,6 +553,15 @@ LSP server configuration is done through `.lsp.json` files in your project root 
 | `security.auth.apiKey`         | string  | **Deprecated.** API key for OpenAI-compatible authentication. Migrate to `modelProviders` with `envKey` instead — see [Model Providers](./model-providers). | `undefined` |
 | `security.auth.baseUrl`        | string  | **Deprecated.** Base URL for the OpenAI-compatible API. Migrate to `modelProviders` instead — see [Model Providers](./model-providers).                     | `undefined` |
 
+#### serve
+
+Persistent settings for [`qwen serve`](../qwen-serve). Changes require restarting the daemon. Non-positive or non-integer concurrency limits produce a warning and fall back to their built-in defaults.
+
+| Setting                                   | Type    | Description                                                                                                                     | Default |
+| ----------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `serve.maxConcurrentSubSessionsPerCaller` | integer | Maximum number of in-flight sub-sessions that one caller session can create through `create_sub_session`. Must be at least `1`. | `16`    |
+| `serve.maxConcurrentSubSessionsTotal`     | integer | Maximum number of in-flight sub-sessions across all callers in one workspace. Must be an integer from `1` through `1024`.       | `24`    |
+
 #### advanced
 
 | Setting                        | Type             | Description                                                                                                                                                                                                                                                                                                                              | Default                  |

--- a/docs/users/configuration/settings.md
+++ b/docs/users/configuration/settings.md
@@ -555,12 +555,12 @@ LSP server configuration is done through `.lsp.json` files in your project root 
 
 #### serve
 
-Persistent settings for [`qwen serve`](../qwen-serve). Changes require restarting the daemon. Non-positive or non-integer concurrency limits produce a warning and fall back to their built-in defaults.
+Persistent sub-session concurrency settings for [`qwen serve`](../qwen-serve). Changes require restarting the daemon. Non-positive or non-integer concurrency limits produce a warning and fall back to their built-in defaults.
 
-| Setting                                   | Type    | Description                                                                                                                     | Default |
-| ----------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `serve.maxConcurrentSubSessionsPerCaller` | integer | Maximum number of in-flight sub-sessions that one caller session can create through `create_sub_session`. Must be at least `1`. | `16`    |
-| `serve.maxConcurrentSubSessionsTotal`     | integer | Maximum number of in-flight sub-sessions across all callers in one workspace. Must be an integer from `1` through `1024`.       | `24`    |
+| Setting                                   | Type    | Description                                                                                                                                                                            | Default |
+| ----------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `serve.maxConcurrentSubSessionsPerCaller` | integer | Maximum number of in-flight sub-sessions that one caller session can create through `create_sub_session`. Must be at least `1`.                                                        | `16`    |
+| `serve.maxConcurrentSubSessionsTotal`     | integer | Maximum number of in-flight sub-sessions across all callers in one workspace. Must be an integer from `1` through `1024`. Values above `1024` are clamped to `1024` without a warning. | `24`    |
 
 #### advanced
 


### PR DESCRIPTION
## What this PR does

Documents the two persistent `qwen serve` controls for sub-session concurrency. The reference now explains their per-caller and workspace-wide scopes, defaults, accepted ranges, restart requirement, and fallback behavior for non-positive or non-integer values.

## Why it's needed

The daemon already honors these controls, but the comprehensive settings reference did not list them. Operators therefore lacked discoverable guidance for tuning sub-session fan-out while preserving bounded workspace resource use.

## Reviewer Test Plan

### How to verify

Review the new `serve` settings section and confirm that the two keys describe the same scopes, defaults, accepted ranges, restart behavior, and invalid-value fallback as the configuration schema and daemon runtime.

### Evidence (Before & After)

N/A — documentation-only change with no UI behavior change.

Validation completed successfully: Prettier formatting check, diff whitespace check, 39 schema tests, 6 selected settings-loading tests, 3 selected launcher concurrency tests, `npm run build`, and `npm run typecheck`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 27.0 (26A5388g), Node.js v24.18.0, npm 11.16.0; local repository build, typecheck, formatting, and targeted Vitest runs.

## Risk & Scope

- Main risk or tradeoff: The wording could become stale if the daemon defaults or validation rules change later.
- Not validated / out of scope: Runtime behavior and Windows/Linux execution were not changed or tested.
- Breaking changes / migration notes: None; this PR changes documentation only.

## Linked Issues

N/A — no linked issue.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

记录用于控制子会话并发的两个持久化 `qwen serve` 配置项。配置参考现在说明了它们各自的单调用方与 workspace 级作用域、默认值、允许范围、重启要求，以及非正整数或非整数值的回退行为。

## 为什么需要

daemon 已经支持这些控制项，但完整配置参考此前没有列出它们。因此，运维者缺少可发现的指引，无法在限制 workspace 资源占用的同时调整子会话并发规模。

## 审阅者测试计划

### 如何验证

审阅新增的 `serve` 配置部分，并确认两个键所描述的作用域、默认值、允许范围、重启行为和非法值回退均与配置 schema 及 daemon 运行时一致。

### 证据（修改前后）

N/A — 仅文档变更，不涉及 UI 行为变化。

已成功完成以下验证：Prettier 格式检查、diff 空白检查、39 项 schema 测试、6 项选定的配置加载测试、3 项选定的启动器并发测试、`npm run build` 和 `npm run typecheck`。

### 已测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|  🍏 macOS        | ✅ 已测试 |
| 🪟 Windows       | ⚠️ 未测试 |
|  🐧 Linux        | ⚠️ 未测试 |

### 环境（可选）

macOS 27.0（26A5388g）、Node.js v24.18.0、npm 11.16.0；在本地仓库完成构建、类型检查、格式检查和定向 Vitest 测试。

## 风险与范围

- 主要风险或取舍：如果 daemon 的默认值或校验规则后续变化，这些表述可能过时。
- 未验证或范围外事项：未改变运行时行为，也未在 Windows/Linux 上执行测试。
- 破坏性变更或迁移说明：无；本 PR 仅修改文档。

## 关联 Issue

N/A — 无关联 Issue。

</details>
