### PR TITLE
fix(review): deprioritize Maven generated test sources

### DIFF
--- a/packages/cli/src/commands/review/lib/path-rules.test.ts
+++ b/packages/cli/src/commands/review/lib/path-rules.test.ts
@@ -298,6 +298,14 @@ describe('pathRulesFor — the Java/JVM rule', () => {
       ),
     ],
     [
+      'Maven generated test output',
+      Array.from(
+        { length: 11 },
+        (_, i) =>
+          `target/generated-test-sources/test-annotations/com/x/S${i}.java`,
+      ),
+    ],
+    [
       'Gradle generated output',
       Array.from({ length: 11 }, (_, i) => `build/generated/com/x/S${i}.java`),
     ],

--- a/packages/cli/src/commands/review/lib/path-rules.ts
+++ b/packages/cli/src/commands/review/lib/path-rules.ts
@@ -132,7 +132,9 @@ function isOutOfScope(p: string): boolean {
       p,
     ) ||
     /(?:^|\/)(?:package-info|module-info)\.java$/i.test(p) ||
-    /(?:^|\/)(?:target|build)\/(?:generated-sources|generated)\//i.test(p)
+    /(?:^|\/)(?:target|build)\/(?:generated-sources|generated-test-sources|generated)\//i.test(
+      p,
+    )
   );
 }
 


### PR DESCRIPTION
## What this PR does

Treats Maven Compiler Plugin generated test sources as generated output when `/review` prioritizes Java paths for the rule heading. It also adds a cap-sensitive regression case with more than ten generated test paths plus one production path.

## Why it's needed

Maven writes generated test annotation sources under `target/generated-test-sources/test-annotations/**`. These paths were previously treated as production sources, so a generated-test-heavy change could consume all ten named heading slots and hide the actual production Java path behind the truncation count.

## Reviewer Test Plan

### How to verify

Run `cd packages/cli && npx vitest run src/commands/review/lib/path-rules.test.ts`. Confirm all 43 tests pass. In the Maven generated test output case, confirm the heading retains `Hot.java` and truncates a generated test path after the ten-path cap. Removing the `generated-test-sources` classifier alternative should make that regression test fail because the generated paths occupy every named slot.

### Evidence (Before & After)

N/A — non-UI path-prioritization change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS Darwin, Node.js 22.22.2. Focused Vitest suite: 43/43 passed. Prettier, ESLint, and `git diff --check` passed. Repository and CLI build/typecheck were attempted but are currently blocked by unrelated baseline dependency and type errors in channel, ACP, and Ink selection code.

## Risk & Scope

- Main risk or tradeoff: Any path under a `target` or `build` directory named `generated-test-sources` is deprioritized in the Java rule heading; this is consistent with treating build output as non-production source.
- Not validated / out of scope: Windows and Linux execution; unrelated repository-wide build and typecheck failures.
- Breaking changes / migration notes: None.

## Linked Issues

Follow-up to #8379 and https://github.com/QwenLM/qwen-code/pull/8379#discussion_r3700729787.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当 `/review` 为 Java 规则标题排列路径优先级时，将 Maven Compiler Plugin 生成的测试源码视为生成产物。同时增加一个对上限敏感的回归用例：超过十条生成测试路径，再加一条生产路径。

## 为什么需要

Maven 会把测试注解处理生成的源码写入 `target/generated-test-sources/test-annotations/**`。此前这些路径会被当成生产源码，因此当变更包含大量生成测试文件时，它们可能占满标题中十个可见路径槽位，把真正的生产 Java 路径隐藏在截断计数之后。

## Reviewer Test Plan

### 如何验证

运行 `cd packages/cli && npx vitest run src/commands/review/lib/path-rules.test.ts`，确认 43 个测试全部通过。在 Maven generated test output 用例中，确认标题保留 `Hot.java`，并在十条路径上限之后截断生成测试路径。删除分类器中的 `generated-test-sources` 分支后，该回归测试应失败，因为生成路径会占满全部可见槽位。

### 证据（Before & After）

N/A — 非 UI 的路径优先级改动。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS Darwin，Node.js 22.22.2。定向 Vitest：43/43 通过。Prettier、ESLint 和 `git diff --check` 通过。已尝试仓库及 CLI 的 build/typecheck，但目前被 channel、ACP 和 Ink selection 代码中与本改动无关的基线依赖及类型错误阻断。

## 风险与范围

- 主要风险或取舍：位于 `target` 或 `build` 目录下、名为 `generated-test-sources` 的路径会在 Java 规则标题中降级；这与将构建产物视为非生产源码的现有行为一致。
- 未验证 / 范围外：Windows 和 Linux 执行；与本改动无关的全仓 build/typecheck 失败。
- 破坏性变更 / 迁移说明：无。

## 关联问题

#8379 的 follow-up，对应 https://github.com/QwenLM/qwen-code/pull/8379#discussion_r3700729787。

</details>
