### PR TITLE
fix(web-shell): prevent table dialog close scroll jump

### DIFF
--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
@@ -1016,13 +1016,15 @@ describe('EnhancedMarkdownTable', () => {
     expect(cellDialog()).toBeNull();
   });
 
-  it('restores focus when closing the cell value dialog', () => {
+  it('restores focus without scrolling when closing the cell value dialog', () => {
     const container = renderTable();
     const scroller = container.querySelector<HTMLElement>('[tabindex="0"]');
     expect(scroller).not.toBeNull();
+    const focus = vi.spyOn(scroller!, 'focus');
     act(() => {
       scroller!.focus();
     });
+    focus.mockClear();
 
     doubleClick(dataCell(container, 0, 0));
     expect(document.activeElement).not.toBe(scroller);
@@ -1030,6 +1032,7 @@ describe('EnhancedMarkdownTable', () => {
     click(textButton(document.body, 'Close'));
 
     expect(document.activeElement).toBe(scroller);
+    expect(focus).toHaveBeenCalledWith({ preventScroll: true });
   });
 
   it('focuses the cell value dialog instead of the close button', () => {

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
@@ -1927,7 +1927,7 @@ export function EnhancedTable({
     return () => {
       const focusReturn = cellDialogFocusReturnRef.current;
       cellDialogFocusReturnRef.current = null;
-      if (focusReturn?.isConnected) focusReturn.focus();
+      if (focusReturn?.isConnected) focusReturn.focus({ preventScroll: true });
     };
   }, [cellDialog]);
 


### PR DESCRIPTION
## What this PR does

Prevents the page from scrolling when focus returns to an enhanced Markdown table after its cell-value dialog closes. Keyboard focus restoration remains intact, and the regression coverage now verifies that the restoration explicitly avoids scrolling.

## Why it's needed

Closing a cell-value dialog restored focus with a plain focus call. Browsers may scroll the focused table container into view, which caused the transcript behind the dialog to visibly jump even though the user had not requested navigation. This makes a lightweight close action feel disruptive: it breaks the user's reading context and can create the false impression that the page position or underlying content changed.

## Reviewer Test Plan

### How to verify

Open a response containing an enhanced Markdown table far enough down a scrollable transcript that page movement is visible. Double-click a cell to open its full-value dialog, then close the dialog with the Close button. Confirm that keyboard focus returns to the table while the transcript viewport stays at the same position. Repeat with Escape if desired; the viewport should remain stable in both cases.

### Evidence (Before & After)

| Before | After |
| --- | --- |
| Closing the dialog can reposition the transcript to bring the table focus target into view. | Closing the dialog preserves the transcript viewport while restoring table focus. |

The updated enhanced-table test suite passes all 121 cases, including the regression assertion for non-scrolling focus restoration. The reported interaction was also manually verified in the local Web Shell on macOS.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local Web Shell development server connected to a token-authenticated local daemon.

## Risk & Scope

- Main risk or tradeoff: The change relies on the standard focus option that suppresses browser scrolling while preserving accessibility focus behavior.
- Not validated / out of scope: Manual browser verification was not run on Windows or Linux.
- Breaking changes / migration notes: None.

## Linked Issues

No linked issue.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修复增强 Markdown 表格的单元格详情弹窗关闭后，焦点返回表格时带动页面滚动的问题。键盘焦点恢复行为保持不变，回归测试同时确认焦点恢复不会触发滚动。

## 为什么需要

单元格详情弹窗关闭时原先使用普通的焦点恢复调用。浏览器可能为了让表格焦点目标进入视口而自动滚动，导致弹窗后的会话页面出现非用户预期的重新定位跳动。关闭弹窗本应是一个轻量操作，这种跳动会打断用户当前的阅读上下文，还可能让用户误以为页面位置或底层内容发生了变化，带来不必要的困惑。

## Reviewer Test Plan

### 如何验证

在一个足够长、能明显观察页面位置变化的会话里打开包含增强 Markdown 表格的回复。双击单元格打开完整内容弹窗，然后点击“关闭”。确认键盘焦点回到表格，同时会话视口保持原位。也可以用 Escape 重复验证，两种关闭方式下视口都应保持稳定。

### 证据（修复前后）

| 修复前 | 修复后 |
| --- | --- |
| 关闭弹窗时可能为了显示表格焦点目标而重新定位会话页面。 | 关闭弹窗时恢复表格焦点，但会话视口保持不变。 |

增强表格测试套件更新后 121 个用例全部通过，其中包含焦点恢复不触发滚动的回归断言。该交互也已在 macOS 本地 Web Shell 中手动验证。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

本地 Web Shell 开发服务器，连接到使用 token 认证的本地 daemon。

## 风险与范围

- 主要风险或取舍：本次改动使用标准焦点选项阻止浏览器滚动，同时保留无障碍焦点行为。
- 未验证或范围外：没有在 Windows 或 Linux 上执行手动浏览器验证。
- 破坏性变更或迁移说明：无。

## 关联 Issue

没有关联 Issue。

</details>
