### PR TITLE
fix(web-shell): keep pending background agents active

### DIFF
--- a/packages/web-shell/client/adapters/toolClassification.test.ts
+++ b/packages/web-shell/client/adapters/toolClassification.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import type { ACPToolCall } from './types';
-import { isBackgroundSubAgentToolCall } from './toolClassification';
+import {
+  isActiveToolStatus,
+  isBackgroundSubAgentToolCall,
+} from './toolClassification';
 
 function agentTool(args: Record<string, unknown> = {}): ACPToolCall {
   return {
@@ -10,6 +13,19 @@ function agentTool(args: Record<string, unknown> = {}): ACPToolCall {
     status: 'completed',
   };
 }
+
+describe('isActiveToolStatus', () => {
+  it.each(['pending', 'in_progress', 'running'])(
+    'treats %s as active',
+    (status) => {
+      expect(isActiveToolStatus(status)).toBe(true);
+    },
+  );
+
+  it.each(['completed', 'failed'])('treats %s as terminal', (status) => {
+    expect(isActiveToolStatus(status)).toBe(false);
+  });
+});
 
 describe('isBackgroundSubAgentToolCall', () => {
   it('treats an ordinary agent as background when the flag is omitted', () => {

--- a/packages/web-shell/client/adapters/toolClassification.ts
+++ b/packages/web-shell/client/adapters/toolClassification.ts
@@ -7,6 +7,14 @@ function getRecord(value: unknown): Record<string, unknown> | undefined {
   return value as Record<string, unknown>;
 }
 
+export function isActiveToolStatus(
+  status: ACPToolCall['status'] | string,
+): boolean {
+  return (
+    status === 'pending' || status === 'running' || status === 'in_progress'
+  );
+}
+
 export function isTaskExecutionRaw(raw: unknown): boolean {
   return getRecord(raw)?.['type'] === 'task_execution';
 }

--- a/packages/web-shell/client/adapters/toolClassification.ts
+++ b/packages/web-shell/client/adapters/toolClassification.ts
@@ -15,6 +15,10 @@ export function isActiveToolStatus(
   );
 }
 
+export function hasActiveAgents(agents: readonly ACPToolCall[]): boolean {
+  return agents.some((agent) => isActiveToolStatus(agent.status));
+}
+
 export function isTaskExecutionRaw(raw: unknown): boolean {
   return getRecord(raw)?.['type'] === 'task_execution';
 }

--- a/packages/web-shell/client/components/MessageList.test.ts
+++ b/packages/web-shell/client/components/MessageList.test.ts
@@ -1188,6 +1188,29 @@ describe('applyTurnCollapse', () => {
     });
   });
 
+  it('keeps a completed main turn expanded while a background agent is pending', () => {
+    const firstAgent = makeBackgroundAgentToolGroup('a1');
+    const secondAgent = makeBackgroundAgentToolGroup('a2');
+    if (firstAgent.role !== 'tool_group' || secondAgent.role !== 'tool_group') {
+      throw new Error('Expected background agent tool groups');
+    }
+    firstAgent.tools[0] = {
+      ...firstAgent.tools[0],
+      status: 'completed',
+    };
+
+    const items = groupParallelAgents([
+      makeUserMessage('u1'),
+      firstAgent,
+      secondAgent,
+      makeAssistantMessage('a1'),
+    ]);
+    const out = collapseItems(items);
+
+    expect(rowIds(out)).toEqual(['u1', 'tc-u1', 'par-a1', 'a1']);
+    expect(collapseOf(out, 'u1')?.collapsed).toBe(false);
+  });
+
   it('still allows manually collapsing a turn with no final answer', () => {
     const items = groupParallelAgents([
       makeUserMessage('u1'),

--- a/packages/web-shell/client/components/MessageList.test.ts
+++ b/packages/web-shell/client/components/MessageList.test.ts
@@ -1224,6 +1224,78 @@ describe('applyTurnCollapse', () => {
     expect(collapseOf(out, 'u1')?.collapsed).toBe(false);
   });
 
+  it('collapses a completed main turn once its only background agent finishes', () => {
+    const agent = makeBackgroundAgentToolGroup('a1');
+    if (agent.role !== 'tool_group') {
+      throw new Error('Expected a background agent tool group');
+    }
+    agent.tools[0] = { ...agent.tools[0], status: 'completed' };
+
+    const items = groupParallelAgents([
+      makeUserMessage('u1'),
+      agent,
+      makeAssistantMessage('a1'),
+    ]);
+    const out = collapseItems(items);
+
+    expect(collapseOf(out, 'u1')?.collapsed).toBe(true);
+    expect(rowIds(out)).toEqual(['u1', 'tc-u1', 'a1']);
+  });
+
+  it('lets an explicit user collapse win over an active background agent', () => {
+    const items = groupParallelAgents([
+      makeUserMessage('u1'),
+      makeBackgroundAgentToolGroup('a1'),
+      makeAssistantMessage('a1'),
+    ]);
+    const out = collapseItems(items, {
+      overrides: new Map([['u1', false]]),
+    });
+
+    expect(collapseOf(out, 'u1')?.collapsed).toBe(true);
+    expect(rowIds(out)).toEqual(['u1', 'tc-u1', 'a1']);
+  });
+
+  it('does not pin a completed turn open for a pending non-agent tool', () => {
+    const items = groupParallelAgents([
+      makeUserMessage('u1'),
+      {
+        id: 'g1',
+        role: 'tool_group',
+        tools: [{ callId: 'c1', toolName: 'Read', status: 'pending' }],
+      },
+      makeAssistantMessage('a1'),
+    ]);
+    const out = collapseItems(items);
+
+    expect(collapseOf(out, 'u1')?.collapsed).toBe(true);
+    expect(rowIds(out)).toEqual(['u1', 'tc-u1', 'a1']);
+  });
+
+  it('keeps an earlier turn open for a pending agent while later turns complete', () => {
+    const items = groupParallelAgents([
+      makeUserMessage('u1'),
+      makeBackgroundAgentToolGroup('a1'),
+      makeAssistantMessage('ans1'),
+      makeUserMessage('u2'),
+      makeMultiToolGroup('g2'),
+      makeAssistantMessage('ans2'),
+    ]);
+    const out = collapseItems(items);
+
+    expect(collapseOf(out, 'u1')?.collapsed).toBe(false);
+    expect(rowIds(out)).toEqual([
+      'u1',
+      'tc-u1',
+      'a1',
+      'ans1',
+      'u2',
+      'tc-u2',
+      'ans2',
+    ]);
+    expect(collapseOf(out, 'u2')?.collapsed).toBe(true);
+  });
+
   it('still allows manually collapsing a turn with no final answer', () => {
     const items = groupParallelAgents([
       makeUserMessage('u1'),

--- a/packages/web-shell/client/components/MessageList.test.ts
+++ b/packages/web-shell/client/components/MessageList.test.ts
@@ -1211,6 +1211,19 @@ describe('applyTurnCollapse', () => {
     expect(collapseOf(out, 'u1')?.collapsed).toBe(false);
   });
 
+  it('keeps a completed main turn expanded while one background agent is pending', () => {
+    const agent = makeBackgroundAgentToolGroup('a1');
+    const items = groupParallelAgents([
+      makeUserMessage('u1'),
+      agent,
+      makeAssistantMessage('a1'),
+    ]);
+    const out = collapseItems(items);
+
+    expect(rowIds(out)).toEqual(['u1', 'tc-u1', 'a1', 'a1']);
+    expect(collapseOf(out, 'u1')?.collapsed).toBe(false);
+  });
+
   it('still allows manually collapsing a turn with no final answer', () => {
     const items = groupParallelAgents([
       makeUserMessage('u1'),

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -22,6 +22,7 @@ import type { DaemonSessionArtifact } from '@qwen-code/sdk/daemon';
 import type { Message, ACPToolCall, TurnCollapseHead } from '../adapters/types';
 import type { PermissionRequest } from '../adapters/types';
 import {
+  hasActiveAgents,
   isBackgroundSubAgentToolCall,
   isSubAgentToolCall,
 } from '../adapters/toolClassification';
@@ -1314,7 +1315,7 @@ function turnHasActiveAgent(
   for (let i = start; i <= end; i++) {
     const item = items[i];
     if (item.type === 'parallel_agents') {
-      if (item.agents.some((agent) => isActiveToolStatus(agent.status))) {
+      if (hasActiveAgents(item.agents)) {
         return true;
       }
     } else if (item.type === 'message' && item.message.role === 'tool_group') {

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -22,7 +22,6 @@ import type { DaemonSessionArtifact } from '@qwen-code/sdk/daemon';
 import type { Message, ACPToolCall, TurnCollapseHead } from '../adapters/types';
 import type { PermissionRequest } from '../adapters/types';
 import {
-  hasActiveAgents,
   isBackgroundSubAgentToolCall,
   isSubAgentToolCall,
 } from '../adapters/toolClassification';
@@ -1284,6 +1283,24 @@ export function getSessionTimelineRangeForIndexes(
  * remains. Returns the original array untouched when disabled or when there is
  * nothing to collapse.
  */
+/** Does any tool-carrying row in [start, end] hold a tool matching `pred`? */
+function someTurnToolCall(
+  items: DisplayItem[],
+  start: number,
+  end: number,
+  pred: (tool: ACPToolCall) => boolean,
+): boolean {
+  for (let i = start; i <= end; i++) {
+    const item = items[i];
+    if (item.type === 'parallel_agents') {
+      if (item.agents.some(pred)) return true;
+    } else if (item.type === 'message' && item.message.role === 'tool_group') {
+      if (item.message.tools.some(pred)) return true;
+    }
+  }
+  return false;
+}
+
 /** Does any tool group / parallel-agents row in [start, end] own `callId`? */
 function turnOwnsCallId(
   items: DisplayItem[],
@@ -1292,19 +1309,9 @@ function turnOwnsCallId(
   callId: string | null | undefined,
 ): boolean {
   if (!callId) return false;
-  for (let i = start; i <= end; i++) {
-    const item = items[i];
-    if (item.type === 'parallel_agents') {
-      if (item.agents.some((agent) => toolContainsCallId(agent, callId))) {
-        return true;
-      }
-    } else if (item.type === 'message' && item.message.role === 'tool_group') {
-      if (item.message.tools.some((tool) => toolContainsCallId(tool, callId))) {
-        return true;
-      }
-    }
-  }
-  return false;
+  return someTurnToolCall(items, start, end, (tool) =>
+    toolContainsCallId(tool, callId),
+  );
 }
 
 function turnHasActiveAgent(
@@ -1312,23 +1319,12 @@ function turnHasActiveAgent(
   start: number,
   end: number,
 ): boolean {
-  for (let i = start; i <= end; i++) {
-    const item = items[i];
-    if (item.type === 'parallel_agents') {
-      if (hasActiveAgents(item.agents)) {
-        return true;
-      }
-    } else if (item.type === 'message' && item.message.role === 'tool_group') {
-      if (
-        item.message.tools.some(
-          (tool) => isSubAgentToolCall(tool) && isActiveToolStatus(tool.status),
-        )
-      ) {
-        return true;
-      }
-    }
-  }
-  return false;
+  return someTurnToolCall(
+    items,
+    start,
+    end,
+    (tool) => isSubAgentToolCall(tool) && isActiveToolStatus(tool.status),
+  );
 }
 
 export function applyTurnCollapse(

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -43,7 +43,10 @@ import {
 } from './artifacts/TurnOutputs';
 import { ParallelAgentsGroup } from './messages/tools/ParallelAgentsGroup';
 import { useSharedNow } from '../hooks/useSharedNow';
-import { toolContainsCallId } from './messages/toolFormatting';
+import {
+  isActiveToolStatus,
+  toolContainsCallId,
+} from './messages/toolFormatting';
 import turnCollapseStyles from './TurnCollapseRow.module.css';
 import flashStyles from './MessageLocateFlash.module.css';
 import styles from './MessageList.module.css';
@@ -1037,12 +1040,6 @@ function isExecutionWorkStep(item: DisplayItem): boolean {
   return item.message.role === 'tool_group' || item.message.role === 'plan';
 }
 
-function isActiveToolStatus(status: ACPToolCall['status'] | string): boolean {
-  return (
-    status === 'pending' || status === 'running' || status === 'in_progress'
-  );
-}
-
 function activeExecutionKey(item: DisplayItem): string | null {
   if (item.type === 'turn_outputs') return null;
 
@@ -1309,6 +1306,30 @@ function turnOwnsCallId(
   return false;
 }
 
+function turnHasActiveAgent(
+  items: DisplayItem[],
+  start: number,
+  end: number,
+): boolean {
+  for (let i = start; i <= end; i++) {
+    const item = items[i];
+    if (item.type === 'parallel_agents') {
+      if (item.agents.some((agent) => isActiveToolStatus(agent.status))) {
+        return true;
+      }
+    } else if (item.type === 'message' && item.message.role === 'tool_group') {
+      if (
+        item.message.tools.some(
+          (tool) => isSubAgentToolCall(tool) && isActiveToolStatus(tool.status),
+        )
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 export function applyTurnCollapse(
   items: DisplayItem[],
   {
@@ -1343,6 +1364,7 @@ export function applyTurnCollapse(
     const turnId = head.message.id;
     const promptTs = head.message.timestamp;
     const isActiveTurn = k === userIdxs.length - 1 && isResponding;
+    const hasActiveAgent = turnHasActiveAgent(items, start, end);
     const hasPendingApproval = turnOwnsCallId(
       items,
       start,
@@ -1433,7 +1455,8 @@ export function applyTurnCollapse(
     // otherwise it collapses once complete. A step-less turn (e.g. a plain "hi"
     // reply) has nothing to fold, so it stays expanded and shows a chevron-less
     // metrics line. An explicit user toggle always wins.
-    const shouldStayOpen = isActiveTurn || hasTurnError || answerIdx < 0;
+    const shouldStayOpen =
+      isActiveTurn || hasActiveAgent || hasTurnError || answerIdx < 0;
     const expanded =
       hiddenCount === 0
         ? true

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -1451,10 +1451,11 @@ export function applyTurnCollapse(
     }
 
     // A turn with foldable steps gets a chevron and defaults to expanded while
-    // streaming, when the turn errored, or when there is no final answer;
-    // otherwise it collapses once complete. A step-less turn (e.g. a plain "hi"
-    // reply) has nothing to fold, so it stays expanded and shows a chevron-less
-    // metrics line. An explicit user toggle always wins.
+    // streaming, while a subagent is still active, when the turn errored, or
+    // when there is no final answer; otherwise it collapses once complete. A
+    // step-less turn (e.g. a plain "hi" reply) has nothing to fold, so it stays
+    // expanded and shows a chevron-less metrics line. An explicit user toggle
+    // always wins.
     const shouldStayOpen =
       isActiveTurn || hasActiveAgent || hasTurnError || answerIdx < 0;
     const expanded =

--- a/packages/web-shell/client/components/messages/ToolGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import type { ACPToolCall } from '../../adapters/types';
+import { hasActiveAgents } from '../../adapters/toolClassification';
 import { I18nProvider } from '../../i18n';
 import { WebShellCustomizationProvider } from '../../customization';
 import { TranscriptRenderModeProvider } from '../../transcriptRenderMode';
@@ -27,7 +28,6 @@ const {
   getActiveTool,
   getRawFileDiff,
   getToolHeaderKind,
-  hasActiveTool,
   hasExpandableContent,
   isWebFetchToolName,
   languageForPath,
@@ -148,7 +148,7 @@ describe('tool group summary logic', () => {
       }),
     ];
 
-    expect(hasActiveTool(tools)).toBe(true);
+    expect(hasActiveAgents(tools)).toBe(true);
     expect(getActiveTool(tools).callId).toBe('active');
     expect(formatToolGroupSummary(tools, t)).toBe('Running ReadFile · 2 tools');
   });
@@ -229,7 +229,7 @@ describe('tool group summary logic', () => {
       }),
     ];
 
-    expect(hasActiveTool(tools)).toBe(false);
+    expect(hasActiveAgents(tools)).toBe(false);
     expect(getActiveTool(tools).callId).toBe('ask');
     expect(formatToolGroupSummary(tools, t)).toBe(
       'Edited 1 files Ran 1 commands Read 1 files Searched 1 times Updated todos 1 times Asked 2 questions',

--- a/packages/web-shell/client/components/messages/ToolGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.test.tsx
@@ -29,7 +29,6 @@ const {
   getToolHeaderKind,
   hasActiveTool,
   hasExpandableContent,
-  isActiveToolStatus,
   isWebFetchToolName,
   languageForPath,
   shouldAutoExpand,
@@ -139,14 +138,6 @@ const zhT = (key: string, values?: Record<string, string | number>): string => {
 };
 
 describe('tool group summary logic', () => {
-  it('detects active tool statuses', () => {
-    expect(isActiveToolStatus('pending')).toBe(true);
-    expect(isActiveToolStatus('in_progress')).toBe(true);
-    expect(isActiveToolStatus('running')).toBe(true);
-    expect(isActiveToolStatus('completed')).toBe(false);
-    expect(isActiveToolStatus('failed')).toBe(false);
-  });
-
   it('uses the active tool in running summaries', () => {
     const tools = [
       makeTool({ callId: 'done', status: 'completed' }),

--- a/packages/web-shell/client/components/messages/ToolGroup.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.tsx
@@ -52,6 +52,7 @@ import {
   getToolSummaryDescription,
   getToolResultSummary,
   isAskUserQuestionToolName,
+  isActiveToolStatus,
   isSkillToolName,
   isShellToolName,
   localizeAgentTypeName,
@@ -67,6 +68,8 @@ import {
 } from '../../customization';
 import flashStyles from '../MessageLocateFlash.module.css';
 import styles from './tools/ToolChrome.module.css';
+
+export { isActiveToolStatus } from './toolFormatting';
 
 interface ToolGroupProps {
   tools: ACPToolCall[];
@@ -575,14 +578,6 @@ function isDescriptionExpandable(description: string): boolean {
   return (
     description.length > DESCRIPTION_EXPAND_THRESHOLD ||
     description.includes('\n')
-  );
-}
-
-export function isActiveToolStatus(
-  status: ACPToolCall['status'] | string,
-): boolean {
-  return (
-    status === 'in_progress' || status === 'pending' || status === 'running'
   );
 }
 

--- a/packages/web-shell/client/components/messages/ToolGroup.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.tsx
@@ -13,6 +13,7 @@ import type {
   TodoItem,
 } from '../../adapters/types';
 import {
+  hasActiveAgents,
   isBackgroundSubAgentToolCall,
   isSubAgentToolCall,
 } from '../../adapters/toolClassification';
@@ -591,7 +592,7 @@ export function formatToolGroupSummary(
   t: ReturnType<typeof useI18n>['t'],
   duration?: string,
 ): string {
-  if (hasActiveTool(tools)) {
+  if (hasActiveAgents(tools)) {
     const foregroundActiveTool = tools.find(
       (tool) =>
         isActiveToolStatus(tool.status) && !isBackgroundSubAgentToolCall(tool),
@@ -771,10 +772,6 @@ function getAskUserQuestionCount(tool: ACPToolCall): number {
   return Array.isArray(questions) && questions.length > 0
     ? questions.length
     : 1;
-}
-
-export function hasActiveTool(tools: ACPToolCall[]): boolean {
-  return tools.some((tool) => isActiveToolStatus(tool.status));
 }
 
 function PencilIcon() {
@@ -1528,7 +1525,7 @@ export const ToolGroup = memo(function ToolGroup({
     useState(false);
   const [chatExpanded, setChatExpanded] = useState(false);
   const monitorDetailsRequestRef = useRef<object | null>(null);
-  const hasRunningTool = hasActiveTool(tools);
+  const hasRunningTool = hasActiveAgents(tools);
   const hasFailedTool = tools.some((tool) => tool.status === 'failed');
   const activeTool = tools.length > 0 ? getActiveTool(tools) : undefined;
   const singleTool = tools.length === 1 ? tools[0] : undefined;

--- a/packages/web-shell/client/components/messages/ToolGroup.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.tsx
@@ -69,8 +69,6 @@ import {
 import flashStyles from '../MessageLocateFlash.module.css';
 import styles from './tools/ToolChrome.module.css';
 
-export { isActiveToolStatus } from './toolFormatting';
-
 interface ToolGroupProps {
   tools: ACPToolCall[];
   pendingApproval?: PermissionRequest | null;

--- a/packages/web-shell/client/components/messages/toolFormatting.ts
+++ b/packages/web-shell/client/components/messages/toolFormatting.ts
@@ -1,12 +1,6 @@
 import type { ACPToolCall } from '../../adapters/types';
 
-export function isActiveToolStatus(
-  status: ACPToolCall['status'] | string,
-): boolean {
-  return (
-    status === 'pending' || status === 'running' || status === 'in_progress'
-  );
-}
+export { isActiveToolStatus } from '../../adapters/toolClassification';
 
 /**
  * Internal-tool-name → display-name lookup. This is a standalone copy of

--- a/packages/web-shell/client/components/messages/toolFormatting.ts
+++ b/packages/web-shell/client/components/messages/toolFormatting.ts
@@ -1,5 +1,13 @@
 import type { ACPToolCall } from '../../adapters/types';
 
+export function isActiveToolStatus(
+  status: ACPToolCall['status'] | string,
+): boolean {
+  return (
+    status === 'pending' || status === 'running' || status === 'in_progress'
+  );
+}
+
 /**
  * Internal-tool-name → display-name lookup. This is a standalone copy of
  * core's `ToolDisplayNames` (mapped to wire names, as the CLI's shared

--- a/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.test.tsx
@@ -145,27 +145,92 @@ describe('computeAgentsTimeline', () => {
 });
 
 describe('ParallelAgentsGroup timeline rendering', () => {
-  it('shows live progress while a background agent is pending', () => {
+  it('shows live progress while background agents are pending', () => {
     vi.useFakeTimers();
     vi.setSystemTime(10_000);
     try {
-      const container = renderExpandedGroup([
+      const agents = [
         agent({ callId: 'done', startTime: 1_000, endTime: 5_000 }),
-        agent({ callId: 'pending', status: 'pending', startTime: 2_000 }),
-      ]);
+        agent({
+          callId: 'pending-early',
+          status: 'pending',
+          startTime: 2_000,
+        }),
+        agent({
+          callId: 'pending-late',
+          status: 'pending',
+          startTime: 4_000,
+        }),
+      ];
+      const container = renderExpandedGroup(agents);
 
-      expect(container.textContent).toContain('Parallel agents 8s·1/2 done');
-      const pendingRow = computeAgentsTimeline(
-        [
-          agent({ callId: 'done', startTime: 1_000, endTime: 5_000 }),
-          agent({ callId: 'pending', status: 'pending', startTime: 2_000 }),
-        ],
-        10_000,
-      )?.rows.get('pending');
-      expect(pendingRow?.running).toBe(true);
-      expect(
-        (pendingRow?.leftPct ?? 0) + (pendingRow?.widthPct ?? 0),
-      ).toBeCloseTo(100);
+      // The header clock anchors at the earliest ACTIVE agent's start (2s),
+      // not the latest (4s) nor mount time, and both pending bars reach now.
+      expect(container.textContent).toContain('Parallel agents 8s·1/3 done');
+      const timeline = computeAgentsTimeline(agents, 10_000);
+      for (const callId of ['pending-early', 'pending-late']) {
+        const row = timeline?.rows.get(callId);
+        expect(row?.running).toBe(true);
+        expect((row?.leftPct ?? 0) + (row?.widthPct ?? 0)).toBeCloseTo(100);
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps the header clock monotonic when the earliest agent finishes', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(150_000);
+    try {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const root = createRoot(container);
+      const early = agent({
+        callId: 'early',
+        status: 'pending',
+        startTime: 0,
+      });
+      const late = agent({
+        callId: 'late',
+        status: 'pending',
+        startTime: 100_000,
+      });
+      act(() => {
+        root.render(
+          <I18nProvider language="en">
+            <ParallelAgentsGroup agents={[early, late]} />
+          </I18nProvider>,
+        );
+      });
+      mounted.push({ root, container });
+      // A live tick surfaces the anchored elapsed time.
+      act(() => {
+        vi.advanceTimersByTime(1_000);
+      });
+      expect(container.textContent).toContain(
+        'Parallel agents 2m 31s·0/2 done',
+      );
+
+      act(() => {
+        root.render(
+          <I18nProvider language="en">
+            <ParallelAgentsGroup
+              agents={[
+                { ...early, status: 'completed', endTime: 151_000 },
+                late,
+              ]}
+            />
+          </I18nProvider>,
+        );
+      });
+      act(() => {
+        vi.advanceTimersByTime(1_000);
+      });
+      // The earliest agent finishing must not rewind the header clock to the
+      // later sibling's start time.
+      expect(container.textContent).toContain(
+        'Parallel agents 2m 32s·1/2 done',
+      );
     } finally {
       vi.useRealTimers();
     }

--- a/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.test.tsx
@@ -145,6 +145,30 @@ describe('computeAgentsTimeline', () => {
 });
 
 describe('ParallelAgentsGroup timeline rendering', () => {
+  it('shows live progress while a background agent is pending', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    try {
+      const container = renderExpandedGroup([
+        agent({ callId: 'done', startTime: 1_000, endTime: 5_000 }),
+        agent({ callId: 'pending', status: 'pending', startTime: 2_000 }),
+      ]);
+
+      expect(container.textContent).toMatch(/Parallel agents \d+s·1\/2 done/);
+      expect(
+        computeAgentsTimeline(
+          [
+            agent({ callId: 'done', startTime: 1_000, endTime: 5_000 }),
+            agent({ callId: 'pending', status: 'pending', startTime: 2_000 }),
+          ],
+          10_000,
+        )?.rows.get('pending')?.running,
+      ).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('keeps nested agents inspectable without a details provider', () => {
     const container = renderExpandedGroup([
       agent({ callId: 'nested', subContent: 'nested agent output' }),

--- a/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.test.tsx
@@ -154,16 +154,18 @@ describe('ParallelAgentsGroup timeline rendering', () => {
         agent({ callId: 'pending', status: 'pending', startTime: 2_000 }),
       ]);
 
-      expect(container.textContent).toMatch(/Parallel agents \d+s·1\/2 done/);
+      expect(container.textContent).toContain('Parallel agents 8s·1/2 done');
+      const pendingRow = computeAgentsTimeline(
+        [
+          agent({ callId: 'done', startTime: 1_000, endTime: 5_000 }),
+          agent({ callId: 'pending', status: 'pending', startTime: 2_000 }),
+        ],
+        10_000,
+      )?.rows.get('pending');
+      expect(pendingRow?.running).toBe(true);
       expect(
-        computeAgentsTimeline(
-          [
-            agent({ callId: 'done', startTime: 1_000, endTime: 5_000 }),
-            agent({ callId: 'pending', status: 'pending', startTime: 2_000 }),
-          ],
-          10_000,
-        )?.rows.get('pending')?.running,
-      ).toBe(true);
+        (pendingRow?.leftPct ?? 0) + (pendingRow?.widthPct ?? 0),
+      ).toBeCloseTo(100);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.test.tsx
@@ -236,6 +236,78 @@ describe('ParallelAgentsGroup timeline rendering', () => {
     }
   });
 
+  it('re-anchors the header clock when a second wave of agents starts', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(20_000);
+    try {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const root = createRoot(container);
+      const first = agent({
+        callId: 'first',
+        status: 'pending',
+        startTime: 10_000,
+      });
+      const second = agent({
+        callId: 'second',
+        status: 'pending',
+        startTime: 15_000,
+      });
+      act(() => {
+        root.render(
+          <I18nProvider language="en">
+            <ParallelAgentsGroup agents={[first, second]} />
+          </I18nProvider>,
+        );
+      });
+      mounted.push({ root, container });
+      act(() => {
+        vi.advanceTimersByTime(1_000);
+      });
+      expect(container.textContent).toContain('Parallel agents 11s·0/2 done');
+
+      // The first wave finishes entirely and the live clock disappears.
+      const finished = [
+        { ...first, status: 'completed' as const, endTime: 21_000 },
+        { ...second, status: 'completed' as const, endTime: 21_500 },
+      ];
+      act(() => {
+        root.render(
+          <I18nProvider language="en">
+            <ParallelAgentsGroup agents={finished} />
+          </I18nProvider>,
+        );
+      });
+      expect(container.textContent).toContain('Parallel agents·2/2 done');
+
+      // A second wave starts much later: the clock must re-anchor to the new
+      // agent's start, not keep accumulating from the first wave's anchor.
+      vi.setSystemTime(60_000);
+      act(() => {
+        root.render(
+          <I18nProvider language="en">
+            <ParallelAgentsGroup
+              agents={[
+                ...finished,
+                agent({
+                  callId: 'third',
+                  status: 'pending',
+                  startTime: 55_000,
+                }),
+              ]}
+            />
+          </I18nProvider>,
+        );
+      });
+      act(() => {
+        vi.advanceTimersByTime(1_000);
+      });
+      expect(container.textContent).toContain('Parallel agents 6s·2/3 done');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('keeps nested agents inspectable without a details provider', () => {
     const container = renderExpandedGroup([
       agent({ callId: 'nested', subContent: 'nested agent output' }),

--- a/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.tsx
+++ b/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.tsx
@@ -16,6 +16,7 @@ import {
   formatTokenCount,
   getAgentCancellationReason,
   getAgentDisplayStatus,
+  isActiveToolStatus,
   localizeAgentTypeName,
   toolContainsCallId,
 } from '../toolFormatting';
@@ -69,7 +70,7 @@ export function computeAgentsTimeline(
     starts.push(agent.startTime);
   }
   const ends = agents.map((agent, i) =>
-    agent.status === 'in_progress'
+    isActiveToolStatus(agent.status)
       ? Math.max(now, starts[i])
       : Math.max(agent.endTime ?? starts[i], starts[i]),
   );
@@ -86,7 +87,7 @@ export function computeAgentsTimeline(
     rows.set(agent.callId, {
       leftPct: left * 100,
       widthPct: width * 100,
-      running: agent.status === 'in_progress',
+      running: isActiveToolStatus(agent.status),
     });
   });
 
@@ -168,20 +169,20 @@ export function ParallelAgentsGroup({
   const [now, setNow] = useState(() => Date.now());
   const liveStartedAtRef = useRef(Date.now());
 
-  const hasRunning = agents.some((a) => a.status === 'in_progress');
+  const hasActive = agents.some((agent) => isActiveToolStatus(agent.status));
 
   useEffect(() => {
-    if (!hasRunning) return;
+    if (!hasActive) return;
     liveStartedAtRef.current = Date.now();
     setNow(Date.now());
-  }, [hasRunning]);
+  }, [hasActive]);
 
   useEffect(() => {
-    if (!hasRunning) return;
+    if (!hasActive) return;
     const id = setInterval(() => setNow(Date.now()), 1000);
     return () => clearInterval(id);
-  }, [hasRunning]);
-  const runningDuration = hasRunning
+  }, [hasActive]);
+  const runningDuration = hasActive
     ? formatLiveElapsed(now - liveStartedAtRef.current)
     : '';
 
@@ -199,7 +200,7 @@ export function ParallelAgentsGroup({
     (a) => getAgentDisplayStatus(a) === 'failed',
   )
     ? 'failed'
-    : hasRunning
+    : hasActive
       ? 'in_progress'
       : 'completed';
 
@@ -223,7 +224,7 @@ export function ParallelAgentsGroup({
         )}
         <span
           className={
-            hasRunning
+            hasActive
               ? `${styles.summaryText} ${styles.summaryTextActive}`
               : styles.summaryText
           }

--- a/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.tsx
+++ b/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.tsx
@@ -170,12 +170,26 @@ export function ParallelAgentsGroup({
   const liveStartedAtRef = useRef(Date.now());
 
   const hasActive = agents.some((agent) => isActiveToolStatus(agent.status));
+  const activeStartedAt = agents.reduce<number | undefined>(
+    (earliest, agent) => {
+      if (
+        !isActiveToolStatus(agent.status) ||
+        typeof agent.startTime !== 'number'
+      ) {
+        return earliest;
+      }
+      return earliest === undefined
+        ? agent.startTime
+        : Math.min(earliest, agent.startTime);
+    },
+    undefined,
+  );
 
   useEffect(() => {
     if (!hasActive) return;
-    liveStartedAtRef.current = Date.now();
+    liveStartedAtRef.current = activeStartedAt ?? Date.now();
     setNow(Date.now());
-  }, [hasActive]);
+  }, [activeStartedAt, hasActive]);
 
   useEffect(() => {
     if (!hasActive) return;

--- a/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.tsx
+++ b/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import type { ACPToolCall, PermissionRequest } from '../../../adapters/types';
+import { hasActiveAgents } from '../../../adapters/toolClassification';
 import { useI18n } from '../../../i18n';
 import { useSubagentDetails } from '../../../subagentDetailsContext';
 import {
@@ -169,7 +170,7 @@ export function ParallelAgentsGroup({
   const [now, setNow] = useState(() => Date.now());
   const liveStartedAtRef = useRef(Date.now());
 
-  const hasActive = agents.some((agent) => isActiveToolStatus(agent.status));
+  const hasActive = hasActiveAgents(agents);
   const activeStartedAt = agents.reduce<number | undefined>(
     (earliest, agent) => {
       if (
@@ -185,10 +186,15 @@ export function ParallelAgentsGroup({
     undefined,
   );
 
+  const wasActiveRef = useRef(false);
   useEffect(() => {
-    if (!hasActive) return;
-    liveStartedAtRef.current = activeStartedAt ?? Date.now();
-    setNow(Date.now());
+    // Latch the anchor on the false->true edge: re-anchoring while agents
+    // finish would rewind the header clock to a later start time.
+    if (hasActive && !wasActiveRef.current) {
+      liveStartedAtRef.current = activeStartedAt ?? Date.now();
+      setNow(Date.now());
+    }
+    wasActiveRef.current = hasActive;
   }, [activeStartedAt, hasActive]);
 
   useEffect(() => {

--- a/packages/web-shell/client/hooks/useMessages.ts
+++ b/packages/web-shell/client/hooks/useMessages.ts
@@ -7,7 +7,10 @@ import {
 } from '@qwen-code/webui/daemon-react-sdk';
 import { transcriptBlocksToDaemonMessages } from '../adapters/transcriptToMessages';
 import type { Message } from '../adapters/types';
-import { isBackgroundSubAgentToolCall } from '../adapters/toolClassification';
+import {
+  isActiveToolStatus,
+  isBackgroundSubAgentToolCall,
+} from '../adapters/toolClassification';
 
 type Translator = (
   key: string,
@@ -31,12 +34,6 @@ export function transcriptBlocksToLocalizedMessages(
       modelStreamInterrupted: t('error.modelStreamInterrupted'),
     },
   });
-}
-
-function isActiveStatus(status: string): boolean {
-  return (
-    status === 'pending' || status === 'in_progress' || status === 'running'
-  );
 }
 
 function isTerminalBackgroundAgentStatus(status: string): boolean {
@@ -82,7 +79,10 @@ export function getPendingBackgroundAgentKey(
   for (const message of messages) {
     if (message.role !== 'tool_group') continue;
     for (const tool of message.tools) {
-      if (isActiveStatus(tool.status) && isBackgroundSubAgentToolCall(tool)) {
+      if (
+        isActiveToolStatus(tool.status) &&
+        isBackgroundSubAgentToolCall(tool)
+      ) {
         callIds.push(tool.callId);
       }
     }
@@ -105,7 +105,7 @@ export function reconcileBackgroundAgentResolutions(
       if (
         !resolution ||
         !isTerminalBackgroundAgentStatus(resolution.status) ||
-        !isActiveStatus(tool.status) ||
+        !isActiveToolStatus(tool.status) ||
         !isBackgroundSubAgentToolCall(tool)
       ) {
         return tool;


### PR DESCRIPTION
## What this PR does

This PR keeps a Web Shell turn expanded while any background subagent in that turn is still active. Pending, running, and in-progress subagent states now share the same active-state semantics across turn collapsing, the parallel-agent summary, and its timeline, while preserving the existing public helper export used by tool rendering.

It also adds regression coverage for the transition where one parallel subagent has completed while another remains pending.

## Why it's needed

When the main agent became idle after launching background subagents, the Web Shell treated the turn as complete even if a background subagent was still pending. The conversation could collapse after the first subagent returned, then appear to resume or enter loading again when another subagent produced an update. This made ongoing work look finished and caused confusing visual transitions.

The root cause was inconsistent active-state handling: transcript replay represents a launched background subagent as pending, but parts of the parallel-agent UI only treated in-progress as active and turn collapsing only considered the main agent's streaming state.

## Reviewer Test Plan

### How to verify

1. Launch two background subagents from one turn, with one task completing noticeably earlier than the other.
2. After the first subagent completes, confirm the turn remains expanded, the parallel-agent summary remains active, its elapsed time continues advancing, and the second subagent is still represented as running work.
3. After the second subagent completes, confirm the group reports both agents done and the turn can return to its normal completed/collapsible state.
4. Confirm a user can still manually collapse an active turn and that completed, failed, single-agent, and ordinary foreground-tool rendering retain their existing behavior.

### Evidence (Before & After)

Before: after one background subagent returned, the main turn could collapse and look finished while another background subagent was still pending; a later update made the interface visibly become active again.

After: the turn stays expanded and the parallel-agent summary and timeline remain visibly active until every background subagent reaches a terminal state.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local Web Shell and daemon development environment. Four focused test files passed with 266 tests, targeted ESLint passed, Prettier checks passed, and the staged diff passed whitespace validation.

## Risk & Scope

- Main risk or tradeoff: A stale non-terminal background-agent record will intentionally keep its turn expanded, preferring visible unfinished work over a false completed state.
- Not validated / out of scope: Windows and Linux manual verification; a persistent global status above the composer for background subagent activity. That broader experience should be implemented as a separate follow-up feature rather than expanding this bug fix.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 会在某个对话轮次中仍有后台 subagent 活跃时保持该轮次展开。pending、running 和 in-progress 状态现在会在轮次收起、并行 agent 摘要和时间线中共享同一套活跃状态语义，同时保留工具渲染所使用的现有公开 helper 导出。

同时增加了回归覆盖，验证一个并行 subagent 已完成、另一个仍处于 pending 状态时的转换过程。

## 为什么需要

主 agent 启动后台 subagent 后进入 idle 时，即使仍有后台 subagent 处于 pending，Web Shell 也会把该轮次当作已经完成。第一个 subagent 返回后，对话可能自动收起并呈现为已经结束；另一个 subagent 稍后产生更新时，界面又会突然恢复或重新进入 loading，造成正在进行的工作看起来已经结束以及令人困惑的视觉跳变。

根因是活跃状态处理不一致：transcript 回放会把已启动的后台 subagent 表示为 pending，但并行 agent UI 的部分逻辑只把 in-progress 视为活跃，同时轮次收起逻辑只考虑主 agent 的 streaming 状态。

## Reviewer 测试计划

### 如何验证

1. 在同一个轮次中启动两个后台 subagent，让其中一个任务明显早于另一个完成。
2. 第一个 subagent 完成后，确认轮次仍然展开，并行 agent 摘要仍处于活跃状态、耗时继续增长，并且第二个 subagent 仍被表示为正在执行的工作。
3. 第二个 subagent 完成后，确认分组显示两个 agent 均已完成，并且轮次恢复为正常的已完成、可收起状态。
4. 确认用户仍可以手动收起活跃轮次，并且已完成、失败、单 agent 和普通前台工具的渲染保持原有行为。

### 证据（修改前与修改后）

修改前：一个后台 subagent 返回后，即使另一个仍处于 pending，主轮次也可能自动收起并表现为已经结束；稍后的更新又会让界面明显恢复为活跃状态。

修改后：在所有后台 subagent 到达终态之前，轮次保持展开，并行 agent 摘要和时间线持续显示为活跃状态。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

本地 Web Shell 与 daemon 开发环境。4 个聚焦测试文件共 266 个测试通过，目标 ESLint 检查通过，Prettier 检查通过，暂存 diff 的空白字符检查通过。

## 风险与范围

- 主要风险或权衡：如果存在陈旧的非终态后台 agent 记录，对应轮次会有意保持展开；这里优先选择展示未完成工作，而不是错误地呈现为已完成。
- 未验证或不在范围内：Windows 和 Linux 手工验证；在输入框上方持续展示后台 subagent 活动的全局状态。更完整的体验应作为独立后续 feat 实现，而不是扩大本次 bug fix 的范围。
- 破坏性变更或迁移说明：无。

## 关联 Issue

无。

</details>
