### PR TITLE
fix(webui): recover complete turns after live journal truncation

### DIFF
--- a/docs/design/live-journal-truncation-recovery.md
+++ b/docs/design/live-journal-truncation-recovery.md
@@ -22,7 +22,7 @@ Recovery performs one same-session `session/load` with in-memory replay and no c
 
 On success, WebUI rebuilds the target suffix from the earliest matching user input through the fresh snapshot tail. It starts from the checkpoint when the marker block is still retained; otherwise it rebuilds a bounded full snapshot. Replayed events rebuild transcript state, including `assistant.done`, but events at or below the episode watermark do not repeat notices, workspace signals, pending-prompt publications, follow-up publications, or other side effects. Newer event IDs retain their normal effects.
 
-The resulting state is committed with one store reset. Retained history block IDs, pagination cursor, loaded depth, and capacity state remain stable. A fresh suffix that ends with another recoverable live marker creates a separate episode for that prompt.
+The resulting state is committed with one store reset. When the complete suffix fits within the checkpoint's `maxBlocks`, retained history block IDs, pagination cursor, loaded depth, and capacity state remain stable. If it crosses that limit, the existing store policy may trim the oldest loaded blocks rather than create an unbounded repair exception. A fresh suffix that ends with another recoverable live marker creates a separate episode for that prompt.
 
 ## Concurrency and lifecycle
 

--- a/docs/design/live-journal-truncation-recovery.md
+++ b/docs/design/live-journal-truncation-recovery.md
@@ -1,0 +1,43 @@
+# Live journal truncation recovery
+
+## Context
+
+The daemon keeps a bounded in-memory live journal for an unfinished turn. When the journal exceeds 10,000 events or 8 MiB, it discards the oldest replay events and prepends a `history_truncated` marker. The persisted transcript and turn-boundary compaction remain authoritative, so the complete turn becomes available again after a formal terminal event.
+
+The marker previously had no prompt ownership, the SDK rendered a generic message, and WebUI either hid the marker behind history pagination or left the retained tail permanently visible. This design keeps the existing resource limits and eviction policy while making the loss precise and repairing the visible tail without another model request.
+
+## Protocol and SDK
+
+For a live-journal marker returned by `session/load`, the bridge copies the session's authoritative `activePromptId` to the marker envelope as optional `promptId`. The persisted event and event schema version do not change. An older daemon without this field is repairable only when the retained live events have exactly one prompt ID.
+
+`DaemonHistoryTruncatedData` exposes the existing optional `scope` and `maxEvents` fields. Validation rejects malformed optional values. Normalized status data retains the complete daemon payload. The text distinguishes replay-history truncation from live-turn truncation, states that the newest events were retained and older replay events were discarded, and promises post-terminal recovery only when `fullTranscriptAvailable` is true.
+
+## WebUI recovery episode
+
+During snapshot replay, a recoverable live marker creates an episode checkpoint immediately before the marker. The checkpoint reuses immutable transcript blocks and retains the session ID, target prompt ID, snapshot event watermark, marker block ID, and a deterministic episode signature. Older history pages and provider-local status blocks are mirrored into the checkpoint while the marker is active.
+
+Only a matching `turn_complete` or `turn_error` arms recovery. Cancellation is represented by a formal terminal event with a cancelled stop reason and follows the same path. Buffered transcript events are flushed and prompt state is settled before recovery is attempted. An in-flight session load, history page request, navigation, or local prompt delays the attempt until the next idle point.
+
+Recovery performs one same-session `session/load` with in-memory replay and no configured history page size. The current transcript stays attached and visible until validation succeeds. The fresh snapshot must not be degraded and must contain both the target prompt's user input and a matching formal terminal. A validation or retriable transport failure rejects the replacement, resumes the previous session handle from its SSE cursor, preserves the transcript, and emits one recoverable `daemon.live_journal_repair.failed` notice. Authentication failures and a missing session also preserve the transcript and emit the notice, but retain the provider's existing disconnected or reauthentication state because that SSE stream cannot safely resume.
+
+On success, WebUI rebuilds the target suffix from the earliest matching user input through the fresh snapshot tail. It starts from the checkpoint when the marker block is still retained; otherwise it rebuilds a bounded full snapshot. Replayed events rebuild transcript state, including `assistant.done`, but events at or below the episode watermark do not repeat notices, workspace signals, pending-prompt publications, follow-up publications, or other side effects. Newer event IDs retain their normal effects.
+
+The resulting state is committed with one store reset. Retained history block IDs, pagination cursor, loaded depth, and capacity state remain stable. A fresh suffix that ends with another recoverable live marker creates a separate episode for that prompt.
+
+## Concurrency and lifecycle
+
+An episode is attempted automatically at most once. A configured reload, session switch, page unmount, or explicit session clear aborts and removes it. A repair reload preserves it until success or failure. The reload pauses the old SSE subscription without detaching its session registration. A rejected candidate is detached and the previous handle resumes from its existing cursor; a validated candidate becomes the new subscription owner.
+
+The checkpoint inherits the current transcript store's effective `maxBlocks`, while the marker-trimmed fallback uses the configured `maxBlocks`. This preserves the existing oversized-initial-replay behavior without creating a new exception for repair. Blocks are shared rather than copying text payloads, and no unbounded journal or second transcript cache is introduced.
+
+## Compatibility
+
+- The marker `promptId`, `scope`, and `maxEvents` fields are optional.
+- Old clients ignore the marker envelope extension.
+- New clients accept old payloads and safely decline ambiguous automatic repair.
+- Default `reloadSession` behavior remains configured replay; only the internal repair path requests memory replay.
+- Daemon persistence, transcript APIs, journal limits, and oldest-first eviction are unchanged.
+
+## Verification
+
+Unit coverage exercises marker ownership, post-terminal compaction, payload validation, precise status text, prompt matching, replay validation, atomic suffix replacement, duplicate-side-effect suppression, history preservation, failure fallback, and reload-source propagation. Daemon integration tests use a deterministic mock ACP agent and a three-event journal to observe the live marker from a second client, verify the complete compacted turn after terminal, and mount the real WebUI provider to prove that recovery adds one load and no model request.

--- a/integration-tests/cli/qwen-serve-live-journal-recovery.test.ts
+++ b/integration-tests/cli/qwen-serve-live-journal-recovery.test.ts
@@ -1,0 +1,138 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+import { DaemonSessionClient, type DaemonEvent } from '@qwen-code/sdk';
+import {
+  makeTempWorkspace,
+  spawnDaemon,
+  type SpawnedDaemon,
+} from './_daemon-harness.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MOCK_AGENT_PATH = path.resolve(
+  __dirname,
+  '../fixtures/mock-acp-child/agent.mjs',
+);
+
+let activeDaemon: SpawnedDaemon | undefined;
+
+afterEach(async () => {
+  await activeDaemon?.dispose();
+  activeDaemon = undefined;
+});
+
+function updateKind(event: DaemonEvent): unknown {
+  if (event.type !== 'session_update' || !event.data) return undefined;
+  return (event.data as { update?: { sessionUpdate?: unknown } }).update
+    ?.sessionUpdate;
+}
+
+describe('qwen serve live journal recovery', () => {
+  it('attributes a truncated live tail and exposes the complete turn after terminal', async () => {
+    const workspace = makeTempWorkspace('live-journal-recovery');
+    try {
+      activeDaemon = await spawnDaemon({
+        workspaceCwd: workspace,
+        extraArgs: [
+          '--max-journal-events',
+          '3',
+          '--max-journal-bytes',
+          String(8 * 1024 * 1024),
+        ],
+        env: {
+          QWEN_CLI_ENTRY: MOCK_AGENT_PATH,
+          MOCK_ACP_MODE: 'echo',
+          MOCK_ACP_EMIT_CHUNKS: '20',
+          MOCK_ACP_PROMPT_DELAY_MS: '1500',
+        },
+      });
+      const created = await activeDaemon.client.createOrAttachSession({
+        sessionScope: 'thread',
+      });
+      const prompt = activeDaemon.client.prompt(created.sessionId, {
+        prompt: [{ type: 'text', text: 'recover this complete turn' }],
+      });
+
+      let duringTurn: DaemonSessionClient | undefined;
+      const deadline = Date.now() + 5_000;
+      while (Date.now() < deadline) {
+        const loaded = await DaemonSessionClient.load(
+          activeDaemon.client,
+          created.sessionId,
+          {},
+          'live-journal-observer',
+        );
+        if (
+          loaded.replaySnapshot.liveJournal.some(
+            (event) => event.type === 'history_truncated',
+          )
+        ) {
+          duringTurn = loaded;
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+
+      expect(duringTurn).toBeDefined();
+      const marker = duringTurn!.replaySnapshot.liveJournal.find(
+        (event) => event.type === 'history_truncated',
+      );
+      expect(marker).toMatchObject({
+        promptId: expect.any(String),
+        data: {
+          scope: 'live_journal',
+          maxEvents: 3,
+          fullTranscriptAvailable: true,
+        },
+      });
+      expect(duringTurn!.replaySnapshot.liveJournal).not.toContainEqual(
+        expect.objectContaining({
+          type: 'session_update',
+          data: expect.objectContaining({
+            update: expect.objectContaining({
+              content: expect.objectContaining({ text: 'chunk-0' }),
+            }),
+          }),
+        }),
+      );
+
+      await prompt;
+      const repaired = await DaemonSessionClient.load(
+        activeDaemon.client,
+        created.sessionId,
+        {},
+        'live-journal-observer',
+      );
+      const completeReplay = repaired.replaySnapshot.compactedReplay;
+      expect(repaired.replaySnapshot.liveJournal).toEqual([]);
+      expect(
+        completeReplay.find(
+          (event) => updateKind(event) === 'user_message_chunk',
+        ),
+      ).toMatchObject({ promptId: marker?.promptId });
+      expect(completeReplay).toContainEqual(
+        expect.objectContaining({
+          type: 'turn_complete',
+          promptId: marker?.promptId,
+        }),
+      );
+      const replayText = JSON.stringify(completeReplay);
+      expect(replayText).toContain('chunk-0');
+      expect(replayText).toContain('chunk-19');
+      expect(completeReplay).not.toContainEqual(
+        expect.objectContaining({ type: 'history_truncated' }),
+      );
+    } finally {
+      await activeDaemon?.dispose();
+      activeDaemon = undefined;
+      fs.rmSync(workspace, { recursive: true, force: true });
+    }
+  }, 30_000);
+});

--- a/integration-tests/cli/qwen-serve-webui-live-journal-recovery.test.ts
+++ b/integration-tests/cli/qwen-serve-webui-live-journal-recovery.test.ts
@@ -109,6 +109,16 @@ describe('qwen serve WebUI live journal recovery', () => {
     const originalFetch = globalThis.fetch;
     const requestPaths: string[] = [];
     try {
+      globalThis.fetch = async (input, init) => {
+        const url =
+          typeof input === 'string'
+            ? input
+            : input instanceof URL
+              ? input.href
+              : input.url;
+        requestPaths.push(new URL(url, 'http://localhost').pathname);
+        return await originalFetch(input, init);
+      };
       activeDaemon = await spawnDaemon({
         workspaceCwd: workspace,
         extraArgs: ['--max-journal-events', '3'],
@@ -134,16 +144,6 @@ describe('qwen serve WebUI live journal recovery', () => {
       const prompt = activeDaemon.client.prompt(created.sessionId, {
         prompt: [{ type: 'text', text: 'repair this turn in WebUI' }],
       });
-      globalThis.fetch = async (input, init) => {
-        const url =
-          typeof input === 'string'
-            ? input
-            : input instanceof URL
-              ? input.href
-              : input.url;
-        requestPaths.push(new URL(url).pathname);
-        return await originalFetch(input, init);
-      };
       await sawLastChunk;
       observerAbort.abort();
 
@@ -197,7 +197,7 @@ describe('qwen serve WebUI live journal recovery', () => {
       ).toHaveLength(2);
       expect(
         requestPaths.filter((pathname) => pathname.endsWith('/prompt')),
-      ).toHaveLength(0);
+      ).toHaveLength(1);
       expect(JSON.stringify(blocks).match(/chunk-0/g)).toHaveLength(1);
     } finally {
       globalThis.fetch = originalFetch;

--- a/integration-tests/cli/qwen-serve-webui-live-journal-recovery.test.ts
+++ b/integration-tests/cli/qwen-serve-webui-live-journal-recovery.test.ts
@@ -1,0 +1,213 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { act, createElement } from 'react';
+import type { Root } from 'react-dom/client';
+import { JSDOM } from 'jsdom';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import type { DaemonEvent, DaemonTranscriptBlock } from '@qwen-code/sdk/daemon';
+import {
+  makeTempWorkspace,
+  spawnDaemon,
+  type SpawnedDaemon,
+} from './_daemon-harness.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MOCK_AGENT_PATH = path.resolve(
+  __dirname,
+  '../fixtures/mock-acp-child/agent.mjs',
+);
+
+let activeDaemon: SpawnedDaemon | undefined;
+let root: Root | undefined;
+let dom: JSDOM;
+let createRoot: typeof import('react-dom/client').createRoot;
+let DaemonSessionProvider: typeof import('@qwen-code/webui/daemon-react-sdk').DaemonSessionProvider;
+let useTranscriptBlocks: typeof import('@qwen-code/webui/daemon-react-sdk').useTranscriptBlocks;
+const originalGlobalDescriptors = new Map(
+  ['window', 'document', 'navigator', 'IS_REACT_ACT_ENVIRONMENT'].map(
+    (key) => [key, Object.getOwnPropertyDescriptor(globalThis, key)] as const,
+  ),
+);
+
+beforeAll(async () => {
+  dom = new JSDOM('<!doctype html><html><body></body></html>', {
+    url: 'http://localhost',
+  });
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: dom.window,
+  });
+  Object.defineProperty(globalThis, 'document', {
+    configurable: true,
+    value: dom.window.document,
+  });
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: dom.window.navigator,
+  });
+  Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+    configurable: true,
+    value: true,
+  });
+  ({ createRoot } = await import('react-dom/client'));
+  ({ DaemonSessionProvider, useTranscriptBlocks } = await import(
+    '@qwen-code/webui/daemon-react-sdk'
+  ));
+});
+
+afterAll(() => {
+  dom.window.close();
+  for (const [key, descriptor] of originalGlobalDescriptors) {
+    if (descriptor) {
+      Object.defineProperty(globalThis, key, descriptor);
+    } else {
+      Reflect.deleteProperty(globalThis, key);
+    }
+  }
+});
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => root?.unmount());
+    root = undefined;
+  }
+  await activeDaemon?.dispose();
+  activeDaemon = undefined;
+});
+
+function eventText(event: DaemonEvent): string | undefined {
+  if (event.type !== 'session_update' || !event.data) return undefined;
+  return (event.data as { update?: { content?: { text?: string } } }).update
+    ?.content?.text;
+}
+
+async function waitFor(
+  condition: () => boolean,
+  description: string,
+  timeoutMs = 5_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (condition()) return;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+  }
+  throw new Error(`Timed out waiting for ${description}`);
+}
+
+describe('qwen serve WebUI live journal recovery', () => {
+  it('repairs once after terminal without another model request', async () => {
+    const workspace = makeTempWorkspace('webui-live-journal-recovery');
+    const originalFetch = globalThis.fetch;
+    const requestPaths: string[] = [];
+    try {
+      activeDaemon = await spawnDaemon({
+        workspaceCwd: workspace,
+        extraArgs: ['--max-journal-events', '3'],
+        env: {
+          QWEN_CLI_ENTRY: MOCK_AGENT_PATH,
+          MOCK_ACP_MODE: 'echo',
+          MOCK_ACP_EMIT_CHUNKS: '20',
+          MOCK_ACP_PROMPT_DELAY_MS: '1500',
+        },
+      });
+      const created = await activeDaemon.client.createOrAttachSession({
+        sessionScope: 'thread',
+      });
+      const observerAbort = new AbortController();
+      const sawLastChunk = (async () => {
+        for await (const event of activeDaemon!.client.subscribeEvents(
+          created.sessionId,
+          { signal: observerAbort.signal },
+        )) {
+          if (eventText(event) === 'chunk-19') return;
+        }
+      })();
+      const prompt = activeDaemon.client.prompt(created.sessionId, {
+        prompt: [{ type: 'text', text: 'repair this turn in WebUI' }],
+      });
+      globalThis.fetch = async (input, init) => {
+        const url =
+          typeof input === 'string'
+            ? input
+            : input instanceof URL
+              ? input.href
+              : input.url;
+        requestPaths.push(new URL(url).pathname);
+        return await originalFetch(input, init);
+      };
+      await sawLastChunk;
+      observerAbort.abort();
+
+      let blocks: readonly DaemonTranscriptBlock[] = [];
+      function Harness() {
+        blocks = useTranscriptBlocks();
+        return null;
+      }
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      root = createRoot(container);
+      await act(async () => {
+        root?.render(
+          createElement(
+            DaemonSessionProvider,
+            {
+              autoConnect: true,
+              baseUrl: activeDaemon!.base,
+              token: activeDaemon!.token,
+              sessionId: created.sessionId,
+            },
+            createElement(Harness),
+          ),
+        );
+      });
+
+      await waitFor(
+        () =>
+          blocks.some(
+            (block) =>
+              'source' in block && block.source === 'history_truncated',
+          ),
+        'visible live journal marker',
+      );
+      await act(async () => {
+        await prompt;
+      });
+      await waitFor(
+        () =>
+          JSON.stringify(blocks).includes('chunk-0') &&
+          JSON.stringify(blocks).includes('chunk-19') &&
+          !blocks.some(
+            (block) =>
+              'source' in block && block.source === 'history_truncated',
+          ),
+        'atomically repaired complete turn',
+      );
+
+      expect(
+        requestPaths.filter((pathname) => pathname.endsWith('/load')),
+      ).toHaveLength(2);
+      expect(
+        requestPaths.filter((pathname) => pathname.endsWith('/prompt')),
+      ).toHaveLength(0);
+      expect(JSON.stringify(blocks).match(/chunk-0/g)).toHaveLength(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (root) {
+        await act(async () => root?.unmount());
+        root = undefined;
+      }
+      await activeDaemon?.dispose();
+      activeDaemon = undefined;
+      fs.rmSync(workspace, { recursive: true, force: true });
+    }
+  }, 30_000);
+});

--- a/integration-tests/vitest.config.ts
+++ b/integration-tests/vitest.config.ts
@@ -37,6 +37,10 @@ export default defineConfig({
   resolve: {
     alias: {
       // Use built SDK bundle for e2e tests
+      '@qwen-code/sdk/daemon': resolve(
+        __dirname,
+        '../packages/sdk-typescript/dist/daemon/index.js',
+      ),
       '@qwen-code/sdk': resolve(
         __dirname,
         '../packages/sdk-typescript/dist/index.mjs',

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -3570,6 +3570,115 @@ describe('createAcpSessionBridge', () => {
     await bridge.shutdown();
   });
 
+  it('attributes live journal markers across queued prompts to the active prompt', async () => {
+    const firstPromptGate = deferred<void>();
+    const secondPromptGate = deferred<void>();
+    const handle = makeChannel({
+      promptImpl: async (req) => {
+        const text = (req.prompt[0] as { text?: string } | undefined)?.text;
+        await (text === 'first turn'
+          ? firstPromptGate.promise
+          : secondPromptGate.promise);
+        return { stopReason: 'end_turn' };
+      },
+    });
+    const bridge = makeBridge({
+      channelFactory: async () => handle.channel,
+      maxJournalEvents: 2,
+    });
+    const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+    const firstPrompt = bridge.sendPrompt(
+      session.sessionId,
+      {
+        sessionId: session.sessionId,
+        prompt: [{ type: 'text', text: 'first turn' }],
+      },
+      undefined,
+      { clientId: session.clientId, promptId: 'prompt-first' },
+    );
+    const secondPrompt = bridge.sendPrompt(
+      session.sessionId,
+      {
+        sessionId: session.sessionId,
+        prompt: [{ type: 'text', text: 'second turn' }],
+      },
+      undefined,
+      { clientId: session.clientId, promptId: 'prompt-second' },
+    );
+    await vi.waitFor(() => expect(handle.agent.promptCalls).toHaveLength(1));
+    for (const text of ['first-a', 'first-b', 'first-c']) {
+      await handle.agentConnection.sessionUpdate({
+        sessionId: session.sessionId,
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text },
+        },
+      });
+    }
+
+    const duringTurn = await bridge.loadSession({
+      sessionId: session.sessionId,
+      workspaceCwd: WS_A,
+      historyReplay: 'response',
+    });
+    expect(
+      duringTurn.liveJournal?.find(
+        (event) => event.type === 'history_truncated',
+      ),
+    ).toMatchObject({
+      promptId: 'prompt-first',
+      data: { scope: 'live_journal' },
+    });
+
+    firstPromptGate.resolve();
+    await firstPrompt;
+    await vi.waitFor(() => expect(handle.agent.promptCalls).toHaveLength(2));
+    for (const text of ['second-a', 'second-b', 'second-c']) {
+      await handle.agentConnection.sessionUpdate({
+        sessionId: session.sessionId,
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text },
+        },
+      });
+    }
+    const duringSecondTurn = await bridge.loadSession({
+      sessionId: session.sessionId,
+      workspaceCwd: WS_A,
+      historyReplay: 'response',
+    });
+    expect(
+      duringSecondTurn.liveJournal?.find(
+        (event) => event.type === 'history_truncated',
+      ),
+    ).toMatchObject({
+      promptId: 'prompt-second',
+      data: { scope: 'live_journal' },
+    });
+
+    secondPromptGate.resolve();
+    await secondPrompt;
+    const afterTurn = await bridge.loadSession({
+      sessionId: session.sessionId,
+      workspaceCwd: WS_A,
+      historyReplay: 'response',
+    });
+    expect(afterTurn.liveJournal).not.toContainEqual(
+      expect.objectContaining({ type: 'history_truncated' }),
+    );
+    expect(afterTurn.compactedReplay).not.toContainEqual(
+      expect.objectContaining({ type: 'history_truncated' }),
+    );
+    expect(JSON.stringify(afterTurn.compactedReplay)).toContain(
+      'first-afirst-bfirst-c',
+    );
+    expect(JSON.stringify(afterTurn.compactedReplay)).toContain(
+      'second-asecond-bsecond-c',
+    );
+
+    await bridge.shutdown();
+  });
+
   it('backfills historyAnchorRecordId from the transcript when the truncation marker carries no recordId', async () => {
     // Live-session regression: recordId is only stamped during replay of
     // the persisted transcript, never on the live stream. A seeded replay

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -4145,6 +4145,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       | 'restoreReplayPartial'
       | 'restoreReplayError'
       | 'restoreHistoryHasMore'
+      | 'activePromptId'
     >,
     action: 'load' | 'resume',
   ): Pick<
@@ -4180,9 +4181,21 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       };
     }
     if (action === 'load') {
+      const liveJournal = snapshot.liveJournal.map((event) => {
+        if (
+          !entry.activePromptId ||
+          event.type !== 'history_truncated' ||
+          !event.data ||
+          typeof event.data !== 'object' ||
+          (event.data as { scope?: unknown }).scope !== 'live_journal'
+        ) {
+          return event;
+        }
+        return { ...event, promptId: entry.activePromptId };
+      });
       return {
         compactedReplay: snapshot.compactedTurns,
-        liveJournal: snapshot.liveJournal,
+        liveJournal,
         lastEventId: snapshot.lastEventId,
         eventEpoch,
         ...replayStatus,

--- a/packages/sdk-typescript/src/daemon/events.ts
+++ b/packages/sdk-typescript/src/daemon/events.ts
@@ -425,9 +425,11 @@ export interface DaemonStateResyncRequiredData {
 
 export interface DaemonHistoryTruncatedData {
   reason: 'replay_window_exceeded';
+  scope?: 'live_journal' | (string & {});
   truncatedEvents: number;
   retainedEvents: number;
   maxBytes: number;
+  maxEvents?: number;
   truncatedTurns?: number;
   /**
    * Pagination anchor: the last `qwen.session.recordId` observed by the
@@ -2775,10 +2777,14 @@ function isHistoryTruncatedData(
     return false;
   }
   const truncatedTurns = value['truncatedTurns'];
+  const scope = value['scope'];
+  const maxEvents = value['maxEvents'];
   return (
     isNonNegativeInteger(value['truncatedEvents']) &&
     isNonNegativeInteger(value['retainedEvents']) &&
     isNonNegativeInteger(value['maxBytes']) &&
+    (scope === undefined || isNonEmptyString(scope)) &&
+    (maxEvents === undefined || isNonNegativeInteger(maxEvents)) &&
     (truncatedTurns === undefined || isNonNegativeInteger(truncatedTurns))
   );
 }

--- a/packages/sdk-typescript/src/daemon/ui/normalizer.ts
+++ b/packages/sdk-typescript/src/daemon/ui/normalizer.ts
@@ -443,6 +443,7 @@ function normalizeHistoryTruncated(
   const truncatedEvents = numberField(event.data, 'truncatedEvents');
   const retainedEvents = numberField(event.data, 'retainedEvents');
   const maxBytes = numberField(event.data, 'maxBytes');
+  const maxEvents = numberField(event.data, 'maxEvents');
   if (
     reason !== 'replay_window_exceeded' ||
     truncatedEvents === undefined ||
@@ -453,12 +454,48 @@ function normalizeHistoryTruncated(
   ) {
     return fallbackDebug(event, base, 'malformed history_truncated payload');
   }
+  const scope = getString(event.data, 'scope');
+  if (
+    (event.data['scope'] !== undefined && !scope) ||
+    (event.data['maxEvents'] !== undefined &&
+      (maxEvents === undefined ||
+        !Number.isInteger(maxEvents) ||
+        maxEvents < 0))
+  ) {
+    return fallbackDebug(event, base, 'malformed history_truncated payload');
+  }
+  const fullTranscriptAvailable = event.data['fullTranscriptAvailable'];
+  const limits = [
+    maxEvents === undefined ? undefined : `${maxEvents} events`,
+    `${maxBytes} bytes`,
+  ]
+    .filter((limit): limit is string => limit !== undefined)
+    .join(' / ');
+  const text =
+    scope === 'live_journal'
+      ? `History truncated for live turn replay: kept the latest ${retainedEvents} events and dropped ${truncatedEvents} older replay events (limits: ${limits}). ${
+          fullTranscriptAvailable
+            ? 'Complete content remains available after the turn finishes.'
+            : 'Complete content is not available for automatic recovery.'
+        }`
+      : scope === undefined
+        ? `History truncated in replay history: kept the latest ${retainedEvents} events and dropped ${truncatedEvents} older replay events (limits: ${limits}). ${
+            fullTranscriptAvailable
+              ? 'Older content remains available from the full transcript.'
+              : 'Older content is not available from a full transcript.'
+          }`
+        : `History truncated: kept the latest ${retainedEvents} events and dropped ${truncatedEvents} older replay events (limits: ${limits}). ${
+            fullTranscriptAvailable
+              ? 'Full transcript content remains available.'
+              : 'Full transcript content is not available.'
+          }`;
   return [
     {
       ...base,
       type: 'status',
-      text: `History truncated: retained ${retainedEvents}, dropped ${truncatedEvents} (window ${maxBytes} bytes).`,
+      text,
       source: 'history_truncated',
+      data: event.data,
     },
   ];
 }

--- a/packages/sdk-typescript/test/unit/daemonEvents.test.ts
+++ b/packages/sdk-typescript/test/unit/daemonEvents.test.ts
@@ -2852,6 +2852,8 @@ describe('PR 21 — auth device-flow events', () => {
           truncatedEvents: 4,
           retainedEvents: 2,
           maxBytes: 512,
+          scope: 'live_journal',
+          maxEvents: 10_000,
           truncatedTurns: 2,
           fullTranscriptAvailable: true,
         },
@@ -2891,6 +2893,27 @@ describe('PR 21 — auth device-flow events', () => {
           },
         }),
       ).toBeUndefined();
+      for (const extra of [
+        { scope: '' },
+        { scope: 42 },
+        { maxEvents: -1 },
+        { maxEvents: 1.5 },
+      ]) {
+        expect(
+          asKnownDaemonEvent({
+            v: 1,
+            type: 'history_truncated',
+            data: {
+              reason: 'replay_window_exceeded',
+              truncatedEvents: 4,
+              retainedEvents: 2,
+              maxBytes: 512,
+              fullTranscriptAvailable: true,
+              ...extra,
+            },
+          }),
+        ).toBeUndefined();
+      }
       expect(
         asKnownDaemonEvent({
           v: 1,

--- a/packages/sdk-typescript/test/unit/daemonUi.test.ts
+++ b/packages/sdk-typescript/test/unit/daemonUi.test.ts
@@ -3539,7 +3539,10 @@ describe('daemon UI reducer state machine (PR-E)', () => {
       expect.objectContaining({
         type: 'status',
         source: 'history_truncated',
-        text: expect.stringContaining('History truncated') as string,
+        text: expect.stringContaining(
+          'History truncated in replay history',
+        ) as string,
+        data: expect.objectContaining({ truncatedTurns: 2 }),
       }),
     ]);
 
@@ -3562,6 +3565,77 @@ describe('daemon UI reducer state machine (PR-E)', () => {
     );
   });
 
+  it('describes live truncation precisely and preserves structured data', () => {
+    const data = {
+      reason: 'replay_window_exceeded',
+      scope: 'live_journal',
+      truncatedEvents: 16_371,
+      retainedEvents: 10_000,
+      maxBytes: 8_388_608,
+      maxEvents: 10_000,
+      fullTranscriptAvailable: true,
+    };
+    const [event] = normalizeDaemonEvent({
+      v: 1,
+      type: 'history_truncated',
+      data,
+    } as never);
+
+    expect(event).toMatchObject({
+      type: 'status',
+      source: 'history_truncated',
+      data,
+      text: expect.stringContaining(
+        'kept the latest 10000 events and dropped 16371 older replay events',
+      ) as string,
+    });
+    expect((event as { text: string }).text).toContain(
+      'Complete content remains available after the turn finishes.',
+    );
+  });
+
+  it('does not promise recovery when a full transcript is unavailable', () => {
+    const [event] = normalizeDaemonEvent({
+      v: 1,
+      type: 'history_truncated',
+      data: {
+        reason: 'replay_window_exceeded',
+        scope: 'live_journal',
+        truncatedEvents: 1,
+        retainedEvents: 2,
+        maxBytes: 512,
+        maxEvents: 2,
+        fullTranscriptAvailable: false,
+      },
+    } as never);
+
+    expect((event as { text: string }).text).toContain(
+      'not available for automatic recovery',
+    );
+    expect((event as { text: string }).text).not.toContain(
+      'remains available after the turn finishes',
+    );
+  });
+
+  it('does not infer replay ownership for a future truncation scope', () => {
+    const [event] = normalizeDaemonEvent({
+      v: 1,
+      type: 'history_truncated',
+      data: {
+        reason: 'replay_window_exceeded',
+        scope: 'future_scope',
+        truncatedEvents: 1,
+        retainedEvents: 2,
+        maxBytes: 512,
+        fullTranscriptAvailable: true,
+      },
+    } as never);
+
+    expect((event as { text: string }).text).toContain('History truncated:');
+    expect((event as { text: string }).text).not.toContain('live turn');
+    expect((event as { text: string }).text).not.toContain('replay history');
+  });
+
   it('routes malformed history truncation payloads to debug', () => {
     const events = normalizeDaemonEvent({
       v: 1,
@@ -3581,6 +3655,29 @@ describe('daemon UI reducer state machine (PR-E)', () => {
         text: 'history_truncated: malformed history_truncated payload',
       }),
     ]);
+  });
+
+  it('routes malformed optional history truncation fields to debug', () => {
+    for (const extra of [{ scope: 5 }, { maxEvents: -1 }, { maxEvents: 1.5 }]) {
+      const events = normalizeDaemonEvent({
+        v: 1,
+        type: 'history_truncated',
+        data: {
+          reason: 'replay_window_exceeded',
+          truncatedEvents: 4,
+          retainedEvents: 2,
+          maxBytes: 512,
+          fullTranscriptAvailable: true,
+          ...extra,
+        },
+      } as never);
+      expect(events).toEqual([
+        expect.objectContaining({
+          type: 'debug',
+          text: 'history_truncated: malformed history_truncated payload',
+        }),
+      ]);
+    }
   });
 
   it('mirrors approval mode from session.approval_mode.changed event', async () => {

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -4674,6 +4674,25 @@ describe('DaemonSessionProvider', () => {
   });
 
   it('uses a bounded full-snapshot fallback after the marker block is trimmed', async () => {
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['session_transcript_pagination'],
+    });
+    sdkMocks.getSessionTranscriptPage
+      .mockResolvedValueOnce({
+        v: 1,
+        sessionId: 'session-live-trimmed-marker',
+        events: [],
+        nextCursor: 'stale-cursor',
+        hasMore: true,
+      })
+      .mockResolvedValueOnce({
+        v: 1,
+        sessionId: 'session-live-trimmed-marker',
+        events: [],
+        hasMore: false,
+      });
+    const toolGate = createDeferred<void>();
     const terminalGate = createDeferred<void>();
     const toolEvent: DaemonEvent = {
       id: 6,
@@ -4689,8 +4708,22 @@ describe('DaemonSessionProvider', () => {
         },
       },
     };
-    const terminalEvent: DaemonEvent = {
+    const secondToolEvent: DaemonEvent = {
       id: 7,
+      v: 1,
+      type: 'session_update',
+      promptId: 'prompt-live',
+      data: {
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'call-live-2',
+          title: 'another long tool',
+          status: 'running',
+        },
+      },
+    };
+    const terminalEvent: DaemonEvent = {
+      id: 8,
       v: 1,
       type: 'turn_complete',
       promptId: 'prompt-live',
@@ -4715,6 +4748,7 @@ describe('DaemonSessionProvider', () => {
               maxBytes: 512,
               maxEvents: 1,
               fullTranscriptAvailable: true,
+              recordId: 'record-stale-anchor',
             },
           },
           {
@@ -4734,7 +4768,10 @@ describe('DaemonSessionProvider', () => {
       events: async function* trimMarkerThenFinish(
         options: { signal?: AbortSignal } = {},
       ) {
+        await toolGate.promise;
+        if (options.signal?.aborted) return;
         yield toolEvent;
+        yield secondToolEvent;
         await terminalGate.promise;
         if (options.signal?.aborted) return;
         yield terminalEvent;
@@ -4747,7 +4784,7 @@ describe('DaemonSessionProvider', () => {
     });
     const repairedSession = createMockSession({
       sessionId: initialSession.sessionId,
-      lastEventId: 7,
+      lastEventId: 8,
       replaySnapshot: {
         compactedReplay: [
           {
@@ -4759,10 +4796,12 @@ describe('DaemonSessionProvider', () => {
               update: {
                 sessionUpdate: 'user_message_chunk',
                 content: { type: 'text', text: 'complete prompt' },
+                _meta: { 'qwen.session.recordId': 'record-fresh-anchor' },
               },
             },
           },
           toolEvent,
+          secondToolEvent,
           {
             id: 2,
             v: 1,
@@ -4782,15 +4821,33 @@ describe('DaemonSessionProvider', () => {
     });
     sdkMocks.sessions.push(initialSession, repairedSession);
     let blocks: readonly DaemonTranscriptBlock[] = [];
+    let history: ReturnType<typeof useDaemonTranscriptHistory> | undefined;
 
     function Harness() {
       blocks = useDaemonTranscriptBlocks();
+      history = useDaemonTranscriptHistory();
       return null;
     }
 
     await renderWithProvider(<Harness />, {
       autoConnect: true,
-      maxBlocks: 2,
+      maxBlocks: 3,
+    });
+    await act(async () => {
+      await vi.waitFor(() => expect(history?.hasMore).toBe(true));
+      await history?.loadMore();
+    });
+    expect(sdkMocks.getSessionTranscriptPage).toHaveBeenNthCalledWith(
+      1,
+      initialSession.sessionId,
+      {
+        beforeRecordId: 'record-stale-anchor',
+        limit: 100,
+        clientId: initialSession.clientId,
+      },
+    );
+    await act(async () => {
+      toolGate.resolve();
     });
     await act(async () => {
       await vi.waitFor(() =>
@@ -4814,8 +4871,19 @@ describe('DaemonSessionProvider', () => {
       );
     });
 
-    expect(blocks.length).toBeLessThanOrEqual(2);
+    expect(blocks.length).toBeLessThanOrEqual(3);
     expect(JSON.stringify(blocks)).not.toContain('partial tail');
+    expect(history?.hasMore).toBe(true);
+    await act(async () => history?.loadMore());
+    expect(sdkMocks.getSessionTranscriptPage).toHaveBeenNthCalledWith(
+      2,
+      initialSession.sessionId,
+      {
+        beforeRecordId: 'record-fresh-anchor',
+        limit: 100,
+        clientId: initialSession.clientId,
+      },
+    );
   });
 
   it.each([

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -4237,6 +4237,7 @@ describe('DaemonSessionProvider', () => {
   ] as const)(
     'repairs a truncated live turn after a matching %s terminal',
     async (_label, terminalType, stopReason) => {
+      clearSidechannelMidTurnInjected();
       sdkMocks.capabilities.mockResolvedValue({
         workspaceCwd: '/mock-workspace',
         features: ['session_transcript_pagination'],
@@ -4244,7 +4245,7 @@ describe('DaemonSessionProvider', () => {
       const terminalGate = createDeferred<void>();
       const localPromptAcceptance = createDeferred<NonBlockingPromptAccepted>();
       const terminalEvent: DaemonEvent = {
-        id: 10,
+        id: 11,
         v: 1,
         type: terminalType,
         promptId: 'prompt-live',
@@ -4253,8 +4254,20 @@ describe('DaemonSessionProvider', () => {
             ? { promptId: 'prompt-live', stopReason }
             : { promptId: 'prompt-live', message: 'model failed' },
       };
+      const observedMidTurnEvent: DaemonEvent = {
+        id: 10,
+        v: 1,
+        type: 'mid_turn_message_injected',
+        promptId: 'prompt-live',
+        originatorClientId: 'client-live',
+        data: {
+          sessionId: 'session-live-repair',
+          messages: ['observed queued message'],
+          messageIds: ['observed-message'],
+        },
+      };
       const followupUserEvent: DaemonEvent = {
-        id: 11,
+        id: 12,
         v: 1,
         type: 'session_update',
         promptId: 'prompt-next',
@@ -4269,7 +4282,7 @@ describe('DaemonSessionProvider', () => {
         },
       };
       const metadataEvent: DaemonEvent = {
-        id: 12,
+        id: 13,
         v: 1,
         type: 'session_metadata_updated',
         promptId: 'prompt-next',
@@ -4373,6 +4386,7 @@ describe('DaemonSessionProvider', () => {
             ),
           ]);
           if (options.signal?.aborted) return;
+          yield observedMidTurnEvent;
           yield terminalEvent;
           await new Promise<void>((resolve) =>
             options.signal?.addEventListener('abort', () => resolve(), {
@@ -4411,6 +4425,18 @@ describe('DaemonSessionProvider', () => {
           },
         },
         {
+          id: 6,
+          v: 1,
+          type: 'mid_turn_message_injected',
+          promptId: 'prompt-live',
+          originatorClientId: 'client-live',
+          data: {
+            sessionId: 'session-live-repair',
+            messages: ['evicted queued message'],
+            messageIds: ['evicted-message'],
+          },
+        },
+        {
           id: 8,
           v: 1,
           type: 'memory_changed',
@@ -4422,12 +4448,13 @@ describe('DaemonSessionProvider', () => {
             bytesWritten: 12,
           },
         },
+        observedMidTurnEvent,
         terminalEvent,
       ];
       const repairedSession = createMockSession({
         sessionId: 'session-live-repair',
         hasActivePrompt: true,
-        lastEventId: 12,
+        lastEventId: 13,
         replaySnapshot: {
           compactedReplay: [...prefix, ...targetTurn],
           liveJournal: [followupUserEvent, metadataEvent],
@@ -4592,6 +4619,22 @@ describe('DaemonSessionProvider', () => {
       ).not.toHaveProperty('historyPageSize');
       expect(initialSession.prompt).not.toHaveBeenCalled();
       expect(repairedSession.prompt).not.toHaveBeenCalled();
+      const midTurnInjected = getSidechannelMidTurnInjected();
+      clearSidechannelMidTurnInjected();
+      expect(midTurnInjected).toEqual([
+        {
+          sessionId: 'session-live-repair',
+          messages: ['observed queued message'],
+          messageIds: ['observed-message'],
+          originatorClientId: 'client-live',
+        },
+        {
+          sessionId: 'session-live-repair',
+          messages: ['evicted queued message'],
+          messageIds: ['evicted-message'],
+          originatorClientId: 'client-live',
+        },
+      ]);
     },
   );
 

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -55,6 +55,7 @@ interface MockSession {
   hasActivePrompt?: boolean;
   historyHasMore?: boolean;
   historyAnchorRecordId?: string;
+  replayDegraded?: boolean;
   client?: MockClient;
   lastEventId?: number;
   setLastEventId: (lastEventId: number | undefined) => void;
@@ -3792,87 +3793,102 @@ describe('DaemonSessionProvider', () => {
     ]);
   });
 
-  it('uses bounded replay truncation to enable history pagination without rendering it', async () => {
-    sdkMocks.capabilities.mockResolvedValue({
-      workspaceCwd: '/mock-workspace',
-      features: ['session_transcript_pagination'],
-    });
-    const session = createMockSession({
-      replaySnapshot: {
-        compactedReplay: [
-          {
-            v: 1,
-            type: 'history_truncated',
-            data: {
-              reason: 'replay_window_exceeded',
-              truncatedEvents: 4,
-              retainedEvents: 2,
-              maxBytes: 512,
-              fullTranscriptAvailable: true,
-            },
-          },
-          {
-            id: 5,
-            v: 1,
-            type: 'session_update',
-            data: {
-              update: {
-                sessionUpdate: 'agent_message_chunk',
-                content: { type: 'text', text: 'retained replay' },
-                _meta: { 'qwen.session.recordId': 'record-retained' },
+  it.each([
+    [undefined, false],
+    ['future_scope', true],
+  ] as const)(
+    'uses bounded replay truncation for pagination without hiding scope %s incorrectly',
+    async (scope, markerVisible) => {
+      sdkMocks.capabilities.mockResolvedValue({
+        workspaceCwd: '/mock-workspace',
+        features: ['session_transcript_pagination'],
+      });
+      const session = createMockSession({
+        replaySnapshot: {
+          compactedReplay: [
+            {
+              v: 1,
+              type: 'history_truncated',
+              data: {
+                reason: 'replay_window_exceeded',
+                ...(scope ? { scope } : {}),
+                truncatedEvents: 4,
+                retainedEvents: 2,
+                maxBytes: 512,
+                fullTranscriptAvailable: true,
               },
             },
-          },
-        ],
-        liveJournal: [],
-      },
-    });
-    sdkMocks.sessions.push(session);
-    sdkMocks.getSessionTranscriptPage.mockResolvedValue({
-      v: 1,
-      sessionId: session.sessionId,
-      events: [],
-      hasMore: false,
-    });
-    let blocks: readonly DaemonTranscriptBlock[] = [];
-    let awaitingResync = false;
-    let history: ReturnType<typeof useDaemonTranscriptHistory> | undefined;
+            {
+              id: 5,
+              v: 1,
+              type: 'session_update',
+              data: {
+                update: {
+                  sessionUpdate: 'agent_message_chunk',
+                  content: { type: 'text', text: 'retained replay' },
+                  _meta: { 'qwen.session.recordId': 'record-retained' },
+                },
+              },
+            },
+          ],
+          liveJournal: [],
+        },
+      });
+      sdkMocks.sessions.push(session);
+      sdkMocks.getSessionTranscriptPage.mockResolvedValue({
+        v: 1,
+        sessionId: session.sessionId,
+        events: [],
+        hasMore: false,
+      });
+      let blocks: readonly DaemonTranscriptBlock[] = [];
+      let awaitingResync = false;
+      let history: ReturnType<typeof useDaemonTranscriptHistory> | undefined;
 
-    function Harness() {
-      blocks = useDaemonTranscriptBlocks();
-      awaitingResync = useDaemonTranscriptState().awaitingResync;
-      history = useDaemonTranscriptHistory();
-      return null;
-    }
+      function Harness() {
+        blocks = useDaemonTranscriptBlocks();
+        awaitingResync = useDaemonTranscriptState().awaitingResync;
+        history = useDaemonTranscriptHistory();
+        return null;
+      }
 
-    await renderWithProvider(<Harness />, {
-      autoConnect: true,
-      reconnectDelayMs: 1,
-      maxReconnectDelayMs: 1,
-      historyPageSize: 25,
-    });
-    await act(async () => {
-      await flushPromises();
-    });
+      await renderWithProvider(<Harness />, {
+        autoConnect: true,
+        reconnectDelayMs: 1,
+        maxReconnectDelayMs: 1,
+        historyPageSize: 25,
+      });
+      await act(async () => {
+        await flushPromises();
+      });
 
-    expect(awaitingResync).toBe(false);
-    expect(blocks).toEqual([
-      expect.objectContaining({
-        kind: 'assistant',
-        text: 'retained replay',
-      }),
-    ]);
-    expect(history?.hasMore).toBe(true);
-    await act(async () => history?.loadMore());
-    expect(sdkMocks.getSessionTranscriptPage).toHaveBeenCalledWith(
-      session.sessionId,
-      {
-        beforeRecordId: 'record-retained',
-        limit: 25,
-        clientId: session.clientId,
-      },
-    );
-  });
+      expect(awaitingResync).toBe(false);
+      expect(blocks).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kind: 'assistant',
+            text: 'retained replay',
+          }),
+        ]),
+      );
+      expect(
+        blocks.some(
+          (block) =>
+            block.kind === 'status' && block.source === 'history_truncated',
+        ),
+      ).toBe(markerVisible);
+      expect(history?.hasMore).toBe(true);
+      await act(async () => history?.loadMore());
+      expect(sdkMocks.getSessionTranscriptPage).toHaveBeenCalledWith(
+        session.sessionId,
+        {
+          beforeRecordId: 'record-retained',
+          limit: 25,
+          clientId: session.clientId,
+        },
+      );
+    },
+  );
 
   it('uses history_truncated marker recordId as pagination anchor when session_updates lack one', async () => {
     // Regression coverage: a live-journal truncation during a single long
@@ -3953,9 +3969,9 @@ describe('DaemonSessionProvider', () => {
       await flushPromises();
     });
 
-    // Banner is NOT rendered: marker's recordId unlocked historyHasMore.
+    // Live journal loss stays visible even when persisted history can page.
     expect(history?.hasMore).toBe(true);
-    expect(blocks).not.toEqual(
+    expect(blocks).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           kind: 'status',
@@ -4193,9 +4209,9 @@ describe('DaemonSessionProvider', () => {
       await flushPromises();
     });
 
-    // Banner is NOT rendered: daemon anchor unlocked historyHasMore.
+    // Live journal loss stays visible even when the daemon supplied an anchor.
     expect(history?.hasMore).toBe(true);
-    expect(blocks).not.toEqual(
+    expect(blocks).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           kind: 'status',
@@ -4213,6 +4229,794 @@ describe('DaemonSessionProvider', () => {
       },
     );
   });
+
+  it.each([
+    ['complete', 'turn_complete', 'end_turn'],
+    ['cancelled', 'turn_complete', 'cancelled'],
+    ['error', 'turn_error', undefined],
+  ] as const)(
+    'repairs a truncated live turn after a matching %s terminal',
+    async (_label, terminalType, stopReason) => {
+      sdkMocks.capabilities.mockResolvedValue({
+        workspaceCwd: '/mock-workspace',
+        features: ['session_transcript_pagination'],
+      });
+      const terminalGate = createDeferred<void>();
+      const localPromptAcceptance = createDeferred<NonBlockingPromptAccepted>();
+      const terminalEvent: DaemonEvent = {
+        id: 10,
+        v: 1,
+        type: terminalType,
+        promptId: 'prompt-live',
+        data:
+          terminalType === 'turn_complete'
+            ? { promptId: 'prompt-live', stopReason }
+            : { promptId: 'prompt-live', message: 'model failed' },
+      };
+      const followupUserEvent: DaemonEvent = {
+        id: 11,
+        v: 1,
+        type: 'session_update',
+        promptId: 'prompt-next',
+        data: {
+          update: {
+            sessionUpdate: 'user_message_chunk',
+            content: {
+              type: 'text',
+              text: 'follow-up created during reload',
+            },
+          },
+        },
+      };
+      const metadataEvent: DaemonEvent = {
+        id: 12,
+        v: 1,
+        type: 'session_metadata_updated',
+        promptId: 'prompt-next',
+        data: {
+          sessionId: 'session-live-repair',
+          displayName: 'Updated during repair',
+        },
+      };
+      const prefix: DaemonEvent[] = [
+        {
+          id: 1,
+          v: 1,
+          type: 'session_update',
+          promptId: 'prompt-old',
+          data: {
+            update: {
+              sessionUpdate: 'user_message_chunk',
+              content: { type: 'text', text: 'older prompt' },
+              _meta: { 'qwen.session.recordId': 'record-old' },
+            },
+          },
+        },
+        {
+          id: 2,
+          v: 1,
+          type: 'session_update',
+          promptId: 'prompt-old',
+          data: {
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              content: { type: 'text', text: 'older answer' },
+            },
+          },
+        },
+        {
+          id: 3,
+          v: 1,
+          type: 'turn_complete',
+          promptId: 'prompt-old',
+          data: { promptId: 'prompt-old', stopReason: 'end_turn' },
+        },
+      ];
+      const initialSession = createMockSession({
+        sessionId: 'session-live-repair',
+        hasActivePrompt: true,
+        historyHasMore: true,
+        lastEventId: 9,
+        replaySnapshot: {
+          compactedReplay: prefix,
+          liveJournal: [
+            {
+              v: 1,
+              type: 'history_truncated',
+              promptId: 'prompt-live',
+              data: {
+                reason: 'replay_window_exceeded',
+                scope: 'live_journal',
+                truncatedEvents: 8,
+                retainedEvents: 1,
+                maxBytes: 1024,
+                maxEvents: 1,
+                fullTranscriptAvailable: true,
+                recordId: 'record-old',
+              },
+            },
+            {
+              id: 8,
+              v: 1,
+              type: 'memory_changed',
+              promptId: 'prompt-live',
+              data: {
+                scope: 'workspace',
+                filePath: '/mock-workspace/QWEN.md',
+                mode: 'append',
+                bytesWritten: 12,
+              },
+            },
+            {
+              id: 9,
+              v: 1,
+              type: 'session_update',
+              promptId: 'prompt-live',
+              data: {
+                update: {
+                  sessionUpdate: 'agent_message_chunk',
+                  content: { type: 'text', text: 'partial tail' },
+                },
+              },
+            },
+          ],
+        },
+        events: async function* terminalEvents(
+          options: { signal?: AbortSignal } = {},
+        ) {
+          await Promise.race([
+            terminalGate.promise,
+            new Promise<void>((resolve) =>
+              options.signal?.addEventListener('abort', () => resolve(), {
+                once: true,
+              }),
+            ),
+          ]);
+          if (options.signal?.aborted) return;
+          yield terminalEvent;
+          await new Promise<void>((resolve) =>
+            options.signal?.addEventListener('abort', () => resolve(), {
+              once: true,
+            }),
+          );
+        },
+        submitPrompt: vi.fn(() => localPromptAcceptance.promise),
+        supportedCommands: vi.fn(async () => {
+          throw new Error('commands unavailable');
+        }),
+      });
+      const targetTurn: DaemonEvent[] = [
+        {
+          id: 4,
+          v: 1,
+          type: 'session_update',
+          promptId: 'prompt-live',
+          data: {
+            update: {
+              sessionUpdate: 'user_message_chunk',
+              content: { type: 'text', text: 'long prompt' },
+            },
+          },
+        },
+        {
+          id: 5,
+          v: 1,
+          type: 'session_update',
+          promptId: 'prompt-live',
+          data: {
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              content: { type: 'text', text: `complete ${_label} answer` },
+            },
+          },
+        },
+        {
+          id: 8,
+          v: 1,
+          type: 'memory_changed',
+          promptId: 'prompt-live',
+          data: {
+            scope: 'workspace',
+            filePath: '/mock-workspace/QWEN.md',
+            mode: 'append',
+            bytesWritten: 12,
+          },
+        },
+        terminalEvent,
+      ];
+      const repairedSession = createMockSession({
+        sessionId: 'session-live-repair',
+        hasActivePrompt: true,
+        lastEventId: 12,
+        replaySnapshot: {
+          compactedReplay: [...prefix, ...targetTurn],
+          liveJournal: [followupUserEvent, metadataEvent],
+        },
+        supportedCommands: vi.fn(async () => {
+          throw new Error('commands unavailable');
+        }),
+      });
+      sdkMocks.sessions.push(initialSession, repairedSession);
+      const historyPageGate = createDeferred<unknown>();
+      const historyPage = {
+        v: 1,
+        sessionId: initialSession.sessionId,
+        events: [
+          {
+            id: 0,
+            v: 1,
+            type: 'session_update',
+            promptId: 'prompt-earliest',
+            data: {
+              update: {
+                sessionUpdate: 'user_message_chunk',
+                content: { type: 'text', text: 'earliest loaded prompt' },
+                _meta: { 'qwen.session.recordId': 'record-earliest' },
+              },
+            },
+          },
+        ],
+        hasMore: true,
+      };
+      sdkMocks.getSessionTranscriptPage.mockReturnValue(
+        historyPageGate.promise,
+      );
+      let blocks: readonly DaemonTranscriptBlock[] = [];
+      let history: ReturnType<typeof useDaemonTranscriptHistory> | undefined;
+      let signals: DaemonWorkspaceEventSignals | undefined;
+      let connection: DaemonConnectionState | undefined;
+      let actions: DaemonSessionActions | undefined;
+
+      function Harness() {
+        blocks = useDaemonTranscriptBlocks();
+        history = useDaemonTranscriptHistory();
+        signals = useDaemonWorkspaceEventSignals();
+        connection = useDaemonConnection();
+        actions = useDaemonActions();
+        return null;
+      }
+
+      await renderWithProvider(<Harness />, {
+        autoConnect: true,
+        historyPageSize: 25,
+        loadWarnings: { commands: 'Commands are temporarily unavailable.' },
+      });
+      await act(async () => flushPromises());
+      expect(blocks).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kind: 'status',
+            source: 'history_truncated',
+          }),
+        ]),
+      );
+      const prefixBlockId = blocks.find(
+        (block) => block.kind === 'user' && block.text === 'older prompt',
+      )?.id;
+      let historyLoad: Promise<void> | undefined;
+      await act(async () => {
+        historyLoad = history?.loadMore();
+        await flushPromises();
+      });
+      expect(historyLoad).toBeDefined();
+      expect(sdkMocks.getSessionTranscriptPage).toHaveBeenCalledOnce();
+
+      await act(async () => {
+        terminalGate.resolve();
+        await flushPromises();
+      });
+      expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(1);
+      let localPrompt: Promise<unknown> | undefined;
+      if (_label === 'complete') {
+        await act(async () => {
+          localPrompt = requireActions(actions).sendPrompt(
+            'next local prompt',
+            { optimisticUserMessage: false },
+          );
+          await vi.waitFor(() =>
+            expect(initialSession.submitPrompt).toHaveBeenCalledOnce(),
+          );
+        });
+      }
+
+      await act(async () => {
+        historyPageGate.resolve(historyPage);
+        await historyLoad;
+        await flushPromises();
+      });
+      const loadedHistoryBlockId = blocks.find(
+        (block) =>
+          block.kind === 'user' && block.text === 'earliest loaded prompt',
+      )?.id;
+      expect(loadedHistoryBlockId).toBeDefined();
+      if (_label === 'complete') {
+        expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(1);
+        await act(async () => {
+          localPromptAcceptance.reject(new Error('next prompt rejected'));
+          await expect(localPrompt).rejects.toThrow('next prompt rejected');
+          await flushPromises();
+        });
+      }
+
+      await act(async () => {
+        await vi.waitFor(() =>
+          expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(
+            2,
+          ),
+        );
+        await vi.waitFor(() =>
+          expect(JSON.stringify(blocks)).toContain(`complete ${_label} answer`),
+        );
+        await flushPromises();
+      });
+
+      expect(
+        blocks.find(
+          (block) => block.kind === 'user' && block.text === 'older prompt',
+        )?.id,
+      ).toBe(prefixBlockId);
+      expect(
+        blocks.find(
+          (block) =>
+            block.kind === 'user' && block.text === 'earliest loaded prompt',
+        )?.id,
+      ).toBe(loadedHistoryBlockId);
+      expect(history?.hasMore).toBe(true);
+      expect(signals?.memoryVersion).toBe(1);
+      expect(connection?.displayName).toBe('Updated during repair');
+      expect(JSON.stringify(blocks)).not.toContain('partial tail');
+      expect(JSON.stringify(blocks)).toContain(
+        'follow-up created during reload',
+      );
+      expect(
+        blocks.filter(
+          (block) =>
+            block.kind === 'assistant' &&
+            block.text === `complete ${_label} answer`,
+        ),
+      ).toHaveLength(1);
+      expect(blocks).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ source: 'history_truncated' }),
+        ]),
+      );
+      expect(
+        blocks.filter(
+          (block) =>
+            block.kind === 'status' &&
+            block.text === 'Commands are temporarily unavailable.',
+        ),
+      ).toHaveLength(1);
+      expect(
+        sdkMocks.MockDaemonSessionClient.load.mock.calls[1]?.[2],
+      ).not.toHaveProperty('historyPageSize');
+      expect(initialSession.prompt).not.toHaveBeenCalled();
+      expect(repairedSession.prompt).not.toHaveBeenCalled();
+    },
+  );
+
+  it('does not repair a live marker for a non-matching queued terminal', async () => {
+    const terminalGate = createDeferred<void>();
+    const session = createMockSession({
+      sessionId: 'session-live-mismatch',
+      hasActivePrompt: true,
+      lastEventId: 5,
+      replaySnapshot: {
+        compactedReplay: [],
+        liveJournal: [
+          {
+            v: 1,
+            type: 'history_truncated',
+            promptId: 'prompt-live',
+            data: {
+              reason: 'replay_window_exceeded',
+              scope: 'live_journal',
+              truncatedEvents: 2,
+              retainedEvents: 1,
+              maxBytes: 512,
+              maxEvents: 1,
+              fullTranscriptAvailable: true,
+            },
+          },
+          {
+            id: 5,
+            v: 1,
+            type: 'session_update',
+            promptId: 'prompt-live',
+            data: {
+              update: {
+                sessionUpdate: 'agent_message_chunk',
+                content: { type: 'text', text: 'retained tail' },
+              },
+            },
+          },
+        ],
+      },
+      events: async function* mismatchedTerminal(
+        options: { signal?: AbortSignal } = {},
+      ) {
+        await terminalGate.promise;
+        yield {
+          id: 6,
+          v: 1,
+          type: 'turn_complete',
+          promptId: 'prompt-queued',
+          data: { promptId: 'prompt-queued', stopReason: 'end_turn' },
+        } satisfies DaemonEvent;
+        await new Promise<void>((resolve) =>
+          options.signal?.addEventListener('abort', () => resolve(), {
+            once: true,
+          }),
+        );
+      },
+    });
+    sdkMocks.sessions.push(session);
+    let blocks: readonly DaemonTranscriptBlock[] = [];
+
+    function Harness() {
+      blocks = useDaemonTranscriptBlocks();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    await act(async () => {
+      terminalGate.resolve();
+      await flushPromises();
+      await flushTranscriptDispatch();
+    });
+
+    expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(1);
+    expect(blocks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ source: 'history_truncated' }),
+      ]),
+    );
+  });
+
+  it('uses a bounded full-snapshot fallback after the marker block is trimmed', async () => {
+    const terminalGate = createDeferred<void>();
+    const toolEvent: DaemonEvent = {
+      id: 6,
+      v: 1,
+      type: 'session_update',
+      promptId: 'prompt-live',
+      data: {
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'call-live',
+          title: 'long tool',
+          status: 'running',
+        },
+      },
+    };
+    const terminalEvent: DaemonEvent = {
+      id: 7,
+      v: 1,
+      type: 'turn_complete',
+      promptId: 'prompt-live',
+      data: { promptId: 'prompt-live', stopReason: 'end_turn' },
+    };
+    const initialSession = createMockSession({
+      sessionId: 'session-live-trimmed-marker',
+      hasActivePrompt: true,
+      lastEventId: 5,
+      replaySnapshot: {
+        compactedReplay: [],
+        liveJournal: [
+          {
+            v: 1,
+            type: 'history_truncated',
+            promptId: 'prompt-live',
+            data: {
+              reason: 'replay_window_exceeded',
+              scope: 'live_journal',
+              truncatedEvents: 4,
+              retainedEvents: 1,
+              maxBytes: 512,
+              maxEvents: 1,
+              fullTranscriptAvailable: true,
+            },
+          },
+          {
+            id: 5,
+            v: 1,
+            type: 'session_update',
+            promptId: 'prompt-live',
+            data: {
+              update: {
+                sessionUpdate: 'agent_message_chunk',
+                content: { type: 'text', text: 'partial tail' },
+              },
+            },
+          },
+        ],
+      },
+      events: async function* trimMarkerThenFinish(
+        options: { signal?: AbortSignal } = {},
+      ) {
+        yield toolEvent;
+        await terminalGate.promise;
+        if (options.signal?.aborted) return;
+        yield terminalEvent;
+        await new Promise<void>((resolve) =>
+          options.signal?.addEventListener('abort', () => resolve(), {
+            once: true,
+          }),
+        );
+      },
+    });
+    const repairedSession = createMockSession({
+      sessionId: initialSession.sessionId,
+      lastEventId: 7,
+      replaySnapshot: {
+        compactedReplay: [
+          {
+            id: 1,
+            v: 1,
+            type: 'session_update',
+            promptId: 'prompt-live',
+            data: {
+              update: {
+                sessionUpdate: 'user_message_chunk',
+                content: { type: 'text', text: 'complete prompt' },
+              },
+            },
+          },
+          toolEvent,
+          {
+            id: 2,
+            v: 1,
+            type: 'session_update',
+            promptId: 'prompt-live',
+            data: {
+              update: {
+                sessionUpdate: 'agent_message_chunk',
+                content: { type: 'text', text: 'complete bounded answer' },
+              },
+            },
+          },
+          terminalEvent,
+        ],
+        liveJournal: [],
+      },
+    });
+    sdkMocks.sessions.push(initialSession, repairedSession);
+    let blocks: readonly DaemonTranscriptBlock[] = [];
+
+    function Harness() {
+      blocks = useDaemonTranscriptBlocks();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      maxBlocks: 2,
+    });
+    await act(async () => {
+      await vi.waitFor(() =>
+        expect(
+          blocks.some(
+            (block) =>
+              'source' in block && block.source === 'history_truncated',
+          ),
+        ).toBe(false),
+      );
+    });
+    await act(async () => {
+      terminalGate.resolve();
+    });
+    await act(async () => {
+      await vi.waitFor(() =>
+        expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(2),
+      );
+      await vi.waitFor(() =>
+        expect(JSON.stringify(blocks)).toContain('complete bounded answer'),
+      );
+    });
+
+    expect(blocks.length).toBeLessThanOrEqual(2);
+    expect(JSON.stringify(blocks)).not.toContain('partial tail');
+  });
+
+  it.each([
+    'missing input',
+    'missing terminal',
+    'degraded',
+    'network error',
+    'auth error',
+    'missing session',
+    'server error',
+  ] as const)(
+    'keeps the retained transcript and reports one repair failure for %s',
+    async (invalidCase) => {
+      const terminalGate = createDeferred<void>();
+      let streamAttempt = 0;
+      const terminalEvent: DaemonEvent = {
+        id: 6,
+        v: 1,
+        type: 'turn_complete',
+        promptId: 'prompt-live',
+        data: { promptId: 'prompt-live', stopReason: 'end_turn' },
+      };
+      const session = createMockSession({
+        sessionId: 'session-live-invalid-repair',
+        hasActivePrompt: true,
+        lastEventId: 5,
+        replaySnapshot: {
+          compactedReplay: [],
+          liveJournal: [
+            {
+              v: 1,
+              type: 'history_truncated',
+              promptId: 'prompt-live',
+              data: {
+                reason: 'replay_window_exceeded',
+                scope: 'live_journal',
+                truncatedEvents: 2,
+                retainedEvents: 1,
+                maxBytes: 512,
+                maxEvents: 1,
+                fullTranscriptAvailable: true,
+              },
+            },
+            {
+              id: 5,
+              v: 1,
+              type: 'session_update',
+              promptId: 'prompt-live',
+              data: {
+                update: {
+                  sessionUpdate: 'agent_message_chunk',
+                  content: { type: 'text', text: 'retained tail' },
+                },
+              },
+            },
+          ],
+        },
+        events: async function* matchingTerminal(
+          options: { signal?: AbortSignal } = {},
+        ) {
+          streamAttempt += 1;
+          if (streamAttempt > 1) {
+            yield {
+              id: 7,
+              v: 1,
+              type: 'session_update',
+              promptId: 'prompt-live',
+              data: {
+                update: {
+                  sessionUpdate: 'agent_message_chunk',
+                  content: { type: 'text', text: 'old SSE resumed' },
+                },
+              },
+            } satisfies DaemonEvent;
+            await new Promise<void>((resolve) =>
+              options.signal?.addEventListener('abort', () => resolve(), {
+                once: true,
+              }),
+            );
+            return;
+          }
+          await terminalGate.promise;
+          if (options.signal?.aborted) return;
+          yield terminalEvent;
+          await new Promise<void>((resolve) =>
+            options.signal?.addEventListener('abort', () => resolve(), {
+              once: true,
+            }),
+          );
+        },
+      });
+      const freshUserEvent: DaemonEvent = {
+        id: 4,
+        v: 1,
+        type: 'session_update',
+        promptId: 'prompt-live',
+        data: {
+          update: {
+            sessionUpdate: 'user_message_chunk',
+            content: { type: 'text', text: 'complete prompt' },
+          },
+        },
+      };
+      const invalidFreshSession = createMockSession({
+        sessionId: session.sessionId,
+        lastEventId: 6,
+        replayDegraded: invalidCase === 'degraded',
+        replaySnapshot: {
+          compactedReplay:
+            invalidCase === 'missing input'
+              ? [terminalEvent]
+              : invalidCase === 'missing terminal'
+                ? [freshUserEvent]
+                : [freshUserEvent, terminalEvent],
+          liveJournal: [],
+        },
+      });
+      sdkMocks.sessions.push(session, invalidFreshSession);
+      let blocks: readonly DaemonTranscriptBlock[] = [];
+      let notices: readonly DaemonSessionNotice[] = [];
+      let connection: DaemonConnectionState | undefined;
+
+      function Harness() {
+        blocks = useDaemonTranscriptBlocks();
+        notices = useDaemonSessionNotices().notices;
+        connection = useDaemonConnection();
+        return null;
+      }
+
+      await renderWithProvider(<Harness />, { autoConnect: true });
+      if (invalidCase === 'network error') {
+        sdkMocks.MockDaemonSessionClient.load.mockRejectedValueOnce(
+          new Error('repair load unavailable'),
+        );
+      } else if (invalidCase === 'auth error') {
+        sdkMocks.MockDaemonSessionClient.load.mockRejectedValueOnce(
+          new DaemonHttpError(401, undefined, 'Unauthorized'),
+        );
+      } else if (invalidCase === 'missing session') {
+        sdkMocks.MockDaemonSessionClient.load.mockRejectedValueOnce(
+          new DaemonHttpError(404, undefined, 'Session not found'),
+        );
+      } else if (invalidCase === 'server error') {
+        sdkMocks.MockDaemonSessionClient.load.mockRejectedValueOnce(
+          new DaemonHttpError(500, undefined, 'Server unavailable'),
+        );
+      }
+      await act(async () => {
+        terminalGate.resolve();
+      });
+      await act(async () => {
+        await vi.waitFor(() =>
+          expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(
+            2,
+          ),
+        );
+        await vi.waitFor(() =>
+          expect(
+            notices.some(
+              (notice) => notice.code === 'daemon.live_journal_repair.failed',
+            ),
+          ).toBe(true),
+        );
+        if (invalidCase !== 'auth error' && invalidCase !== 'missing session') {
+          await vi.waitFor(() =>
+            expect(JSON.stringify(blocks)).toContain('old SSE resumed'),
+          );
+        }
+      });
+
+      expect(JSON.stringify(blocks)).toContain('retained tail');
+      expect(
+        notices.filter(
+          (notice) => notice.code === 'daemon.live_journal_repair.failed',
+        ),
+      ).toHaveLength(1);
+      if (
+        invalidCase === 'network error' ||
+        invalidCase === 'auth error' ||
+        invalidCase === 'missing session' ||
+        invalidCase === 'server error'
+      ) {
+        expect(invalidFreshSession.detach).not.toHaveBeenCalled();
+      } else {
+        expect(invalidFreshSession.detach).toHaveBeenCalledOnce();
+      }
+      if (invalidCase === 'auth error') {
+        expect(connection).toMatchObject({
+          status: 'error',
+          sessionId: undefined,
+          missingSession: false,
+        });
+      } else if (invalidCase === 'missing session') {
+        expect(connection).toMatchObject({
+          status: 'disconnected',
+          sessionId: undefined,
+          missingSession: true,
+        });
+      }
+    },
+  );
 
   it('keeps replayed non-turn events from marking a prompt as waiting', async () => {
     const session = createMockSession({
@@ -10143,6 +10947,7 @@ function createMockSession(opts: Partial<MockSession> = {}): MockSession {
     hasActivePrompt: opts.hasActivePrompt ?? false,
     historyHasMore: opts.historyHasMore ?? false,
     historyAnchorRecordId: opts.historyAnchorRecordId,
+    replayDegraded: opts.replayDegraded ?? false,
     lastEventId: opts.lastEventId,
     setLastEventId:
       opts.setLastEventId ??

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -136,6 +136,8 @@ interface LiveJournalRepairEpisode {
   target: LiveJournalRepairTarget;
   checkpoint: DaemonTranscriptState;
   markerBlockId?: string;
+  observedSnapshotEventIds: ReadonlySet<number>;
+  snapshotLastEventId: number;
   lastObservedEventId: number;
   terminalSeen: boolean;
   attempted: boolean;
@@ -1426,7 +1428,13 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
               const isNewRepairEvent =
                 repairingEpisode !== undefined &&
                 replayEvent.id !== undefined &&
-                replayEvent.id > repairingEpisode.lastObservedEventId;
+                !repairingEpisode.observedSnapshotEventIds.has(
+                  replayEvent.id,
+                ) &&
+                !(
+                  replayEvent.id > repairingEpisode.snapshotLastEventId &&
+                  replayEvent.id <= repairingEpisode.lastObservedEventId
+                );
               try {
                 const replayUiEvents = normalizeAndFilterEvent(
                   replayEvent,
@@ -1583,6 +1591,12 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                         ...(markerBlock
                           ? { markerBlockId: markerBlock.id }
                           : {}),
+                        observedSnapshotEventIds: new Set(
+                          liveJournal.flatMap((event) =>
+                            event.id === undefined ? [] : [event.id],
+                          ),
+                        ),
+                        snapshotLastEventId: activeSession.lastEventId ?? 0,
                         lastObservedEventId: activeSession.lastEventId ?? 0,
                         terminalSeen: false,
                         attempted: false,

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -1329,6 +1329,13 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           // only fires once with the fully-populated state.
           const { compactedReplay, liveJournal } = activeSession.replaySnapshot;
           const replayEvents = [...compactedReplay, ...liveJournal];
+          const markerStillVisible =
+            repairingEpisode?.markerBlockId !== undefined &&
+            store
+              .getSnapshot()
+              .blocks.some(
+                (block) => block.id === repairingEpisode?.markerBlockId,
+              );
           // Prefer a recordId carried by an actual `session_update` in the
           // retained window; fall back to the `history_truncated` marker's
           // stamped anchor only when no session_update has one. The marker
@@ -1378,6 +1385,13 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
               capacityReached: false,
               paginationError: false,
             });
+          } else if (
+            !markerStillVisible &&
+            firstPersistedRecordId !== undefined
+          ) {
+            transcriptHistoryRef.current.beforeRecordId =
+              firstPersistedRecordId;
+            transcriptHistoryRef.current.cursor = undefined;
           }
           const replayInjected =
             shouldInjectReplaySnapshot && replayEvents.length > 0;
@@ -1391,13 +1405,6 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
               ...eventOptionsRef.current,
               suppressOwnUserEcho: false,
             };
-            const markerStillVisible =
-              repairingEpisode?.markerBlockId !== undefined &&
-              store
-                .getSnapshot()
-                .blocks.some(
-                  (block) => block.id === repairingEpisode?.markerBlockId,
-                );
             const sourceEvents =
               repairingEpisode && repairSuffix && markerStillVisible
                 ? repairSuffix.events

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -34,6 +34,13 @@ import {
 } from '@qwen-code/sdk/daemon';
 import { createDaemonSessionActions, getPromptSettledKey } from './actions.js';
 import {
+  eventPromptId,
+  findLiveJournalRepairSuffix,
+  findLiveJournalRepairTarget,
+  type LiveJournalRepairSuffix,
+  type LiveJournalRepairTarget,
+} from './live-journal-repair.js';
+import {
   detachDaemonClient,
   getStableClientId,
   persistStableClientId,
@@ -124,6 +131,24 @@ export interface DaemonTranscriptHistory {
   loadMore(options?: { force?: boolean }): Promise<void>;
 }
 
+interface LiveJournalRepairEpisode {
+  sessionId: string;
+  target: LiveJournalRepairTarget;
+  checkpoint: DaemonTranscriptState;
+  markerBlockId?: string;
+  lastObservedEventId: number;
+  terminalSeen: boolean;
+  attempted: boolean;
+  controller?: AbortController;
+}
+
+interface TranscriptHistoryMaterialization {
+  blocks: readonly DaemonTranscriptBlock[];
+  nextOrdinal: number;
+  toolBlockByCallId: Record<string, string>;
+  permissionBlockByRequestId: Record<string, string>;
+}
+
 const SESSION_TRANSCRIPT_PAGINATION_FEATURE = 'session_transcript_pagination';
 const WORKSPACE_ACP_PREHEAT_FEATURE = 'workspace_acp_preheat';
 const WORKSPACE_ACP_STATUS_FEATURE = 'workspace_acp_status';
@@ -179,12 +204,19 @@ function hasFullTranscriptBeforeReplay(event: DaemonEvent): boolean {
   );
 }
 
-function prependTranscriptHistory(
-  store: DaemonTranscriptStore,
+function isHistoricalReplayMarker(event: DaemonEvent): boolean {
+  return (
+    hasFullTranscriptBeforeReplay(event) &&
+    isRecord(event.data) &&
+    event.data['scope'] === undefined
+  );
+}
+
+function materializeTranscriptHistory(
+  current: DaemonTranscriptState,
   events: DaemonUiEvent[],
   maxBlocks: number,
-): boolean {
-  const current = store.getSnapshot();
+): TranscriptHistoryMaterialization | undefined {
   // Drop fetched events whose source records are already displayed.
   // `beforeRecordId` pagination is exclusive of the anchor but the anchor
   // can sit inside the retained window (e.g. the daemon's transcript
@@ -214,9 +246,21 @@ function prependTranscriptHistory(
   historyStore.dispatch(freshEvents);
   const history = historyStore.getSnapshot();
   if (history.blocks.length + current.blocks.length > maxBlocks) {
-    return false;
+    return undefined;
   }
-  store.reset({
+  return {
+    blocks: history.blocks,
+    nextOrdinal: history.nextOrdinal,
+    toolBlockByCallId: history.toolBlockByCallId,
+    permissionBlockByRequestId: history.permissionBlockByRequestId,
+  };
+}
+
+function applyTranscriptHistory(
+  current: DaemonTranscriptState,
+  history: TranscriptHistoryMaterialization,
+): DaemonTranscriptState {
+  return {
     ...current,
     blocks: [...history.blocks, ...current.blocks],
     nextOrdinal: history.nextOrdinal,
@@ -228,8 +272,7 @@ function prependTranscriptHistory(
       ...history.permissionBlockByRequestId,
       ...current.permissionBlockByRequestId,
     },
-  });
-  return true;
+  };
 }
 
 function boundedString(value: unknown, maxLength: number): string | undefined {
@@ -513,6 +556,13 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
     undefined,
   );
   const pendingSessionLoadIdRef = useRef(0);
+  const liveJournalRepairRef = useRef<LiveJournalRepairEpisode | undefined>(
+    undefined,
+  );
+  const repairReloadRef = useRef<
+    DaemonSessionActions['reloadSession'] | undefined
+  >(undefined);
+  const tryLiveJournalRepairRef = useRef<(() => void) | undefined>(undefined);
   const passiveAssistantDoneTimerRef = useRef<
     ReturnType<typeof setTimeout> | undefined
   >(undefined);
@@ -608,6 +658,9 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
     mountedRef.current = true;
     return () => {
       mountedRef.current = false;
+      liveJournalRepairRef.current?.controller?.abort();
+      liveJournalRepairRef.current = undefined;
+      tryLiveJournalRepairRef.current = undefined;
     };
   }, []);
 
@@ -692,6 +745,45 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
       cancelTranscriptFlush();
       pendingTranscriptEvents = [];
     };
+    const tryLiveJournalRepair = () => {
+      if (disposed || abort.signal.aborted) return;
+      const repair = liveJournalRepairRef.current;
+      if (
+        !repair ||
+        repair.attempted ||
+        !repair.terminalSeen ||
+        pendingSessionLoadRef.current ||
+        transcriptHistoryRef.current.loading ||
+        sessionRef.current?.sessionId !== repair.sessionId ||
+        hasCurrentSessionActivePromptRef.current()
+      ) {
+        return;
+      }
+      const reload = repairReloadRef.current;
+      if (!reload) return;
+      repair.attempted = true;
+      const controller = new AbortController();
+      repair.controller = controller;
+      void reload(controller.signal, { replaySource: 'memory' }).catch(
+        (error: unknown) => {
+          if (liveJournalRepairRef.current !== repair) return;
+          addNotice({
+            id: `daemon.live_journal_repair.failed:${repair.target.signature}`,
+            severity: 'warning',
+            category: 'connection',
+            operation: 'load_session',
+            code: 'daemon.live_journal_repair.failed',
+            message:
+              'Could not restore the complete turn. The retained replay remains visible.',
+            debugMessage:
+              error instanceof Error ? error.message : String(error),
+            recoverable: true,
+          });
+          liveJournalRepairRef.current = undefined;
+        },
+      );
+    };
+    tryLiveJournalRepairRef.current = tryLiveJournalRepair;
 
     const run = async () => {
       const client =
@@ -765,6 +857,8 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           // usage may be older than the in-memory count.
           let replayTokenUsage: DaemonConnectionState['tokenUsage'];
           let replayTokenCount: number | undefined;
+          let repairingEpisode: LiveJournalRepairEpisode | undefined;
+          let repairSuffix: LiveJournalRepairSuffix | undefined;
           if (!session) {
             const existingSession = sessionRef.current;
             if (
@@ -980,6 +1074,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                     workspaceCwd: effectWorkspaceCwd,
                     ...(historyPaginationSupported &&
                     restoreMode === 'load' &&
+                    attemptedLoad?.replaySource !== 'memory' &&
                     historyPageSizeRef.current !== undefined
                       ? { historyPageSize: historyPageSizeRef.current }
                       : {}),
@@ -1073,6 +1168,62 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                 continue;
               }
               return;
+            }
+            if (attemptedLoad?.replaySource === 'memory') {
+              const episode = liveJournalRepairRef.current;
+              const freshReplayEvents = [
+                ...nextSession.replaySnapshot.compactedReplay,
+                ...nextSession.replaySnapshot.liveJournal,
+              ];
+              const suffix = episode
+                ? findLiveJournalRepairSuffix(
+                    freshReplayEvents,
+                    episode.target.promptId,
+                  )
+                : undefined;
+              if (
+                !episode ||
+                episode.sessionId !== nextSession.sessionId ||
+                nextSession.replayDegraded === true ||
+                !suffix
+              ) {
+                const previousSession = sessionRef.current;
+                if (nextSession !== previousSession) {
+                  await nextSession.detach().catch((error: unknown) => {
+                    console.warn(
+                      '[DaemonSessionProvider] detach rejected repair load failed:',
+                      error,
+                    );
+                  });
+                }
+                if (pendingSessionLoadRef.current === attemptedLoad) {
+                  pendingSessionLoadRef.current = undefined;
+                  clearTimeout(attemptedLoad.timeout);
+                  attemptedLoad.reject(
+                    new Error(
+                      nextSession.replayDegraded === true
+                        ? 'Fresh replay is degraded'
+                        : 'Fresh replay does not contain the complete target turn',
+                    ),
+                  );
+                }
+                if (
+                  skipNextCleanupDetachSessionIdRef.current ===
+                  nextSession.sessionId
+                ) {
+                  skipNextCleanupDetachSessionIdRef.current = undefined;
+                }
+                if (previousSession?.sessionId === nextSession.sessionId) {
+                  session = previousSession;
+                  reconnectSessionId = previousSession.sessionId;
+                  reconnectAttempt = 0;
+                  skipMetadataRefresh = true;
+                  continue;
+                }
+                return;
+              }
+              repairingEpisode = episode;
+              repairSuffix = suffix;
             }
             const previousSessionId = lastSessionIdRef.current;
             if (previousSessionId !== nextSession.sessionId) {
@@ -1202,29 +1353,32 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           const replayHistoryWasTruncated = replayEvents.some(
             hasFullTranscriptBeforeReplay,
           );
-          const historyHasMore =
-            Array.isArray(capabilities?.features) &&
-            capabilities.features.includes(
-              SESSION_TRANSCRIPT_PAGINATION_FEATURE,
-            ) &&
-            (activeSession.historyHasMore || replayHistoryWasTruncated) &&
-            firstPersistedRecordId !== undefined;
-          transcriptHistoryRef.current = {
-            sessionId: activeSession.sessionId,
-            ...(firstPersistedRecordId !== undefined
-              ? { beforeRecordId: firstPersistedRecordId }
-              : {}),
-            hasMore: historyHasMore,
-            loading: false,
-            capacityReached: false,
-            paginationError: false,
-          };
-          setTranscriptHistoryState({
-            hasMore: historyHasMore,
-            loading: false,
-            capacityReached: false,
-            paginationError: false,
-          });
+          const historyHasMore = repairingEpisode
+            ? transcriptHistoryRef.current.hasMore
+            : Array.isArray(capabilities?.features) &&
+              capabilities.features.includes(
+                SESSION_TRANSCRIPT_PAGINATION_FEATURE,
+              ) &&
+              (activeSession.historyHasMore || replayHistoryWasTruncated) &&
+              firstPersistedRecordId !== undefined;
+          if (!repairingEpisode) {
+            transcriptHistoryRef.current = {
+              sessionId: activeSession.sessionId,
+              ...(firstPersistedRecordId !== undefined
+                ? { beforeRecordId: firstPersistedRecordId }
+                : {}),
+              hasMore: historyHasMore,
+              loading: false,
+              capacityReached: false,
+              paginationError: false,
+            };
+            setTranscriptHistoryState({
+              hasMore: historyHasMore,
+              loading: false,
+              capacityReached: false,
+              paginationError: false,
+            });
+          }
           const replayInjected =
             shouldInjectReplaySnapshot && replayEvents.length > 0;
           if (needsStoreReset && !replayInjected) {
@@ -1237,77 +1391,209 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
               ...eventOptionsRef.current,
               suppressOwnUserEcho: false,
             };
-            const allUiEvents: DaemonUiEvent[] = [];
-            for (const replayEvent of replayEvents) {
+            const markerStillVisible =
+              repairingEpisode?.markerBlockId !== undefined &&
+              store
+                .getSnapshot()
+                .blocks.some(
+                  (block) => block.id === repairingEpisode?.markerBlockId,
+                );
+            const sourceEvents =
+              repairingEpisode && repairSuffix && markerStillVisible
+                ? repairSuffix.events
+                : replayEvents;
+            const replayTarget = findLiveJournalRepairTarget(
+              activeSession.sessionId,
+              liveJournal,
+              activeSession.lastEventId,
+              activeSession.replayDegraded,
+            );
+            const markerIndex = replayTarget
+              ? sourceEvents.indexOf(replayTarget.marker)
+              : -1;
+            const eventGroups: Array<{
+              transcript: DaemonUiEvent[];
+              sideEffects: DaemonUiEvent[];
+            }> = [];
+            for (const replayEvent of sourceEvents) {
+              const isNewRepairEvent =
+                repairingEpisode !== undefined &&
+                replayEvent.id !== undefined &&
+                replayEvent.id > repairingEpisode.lastObservedEventId;
               try {
                 const replayUiEvents = normalizeAndFilterEvent(
                   replayEvent,
                   activeSession.clientId,
                   replayOpts,
                   setConnection,
-                  { updateConnection: false },
+                  {
+                    updateConnection:
+                      repairingEpisode !== undefined && isNewRepairEvent,
+                    suppressLog:
+                      repairingEpisode !== undefined && !isNewRepairEvent,
+                  },
                 );
                 const transcriptEvents = filterDaemonUiEventsForTranscript(
                   replayEvent,
                   replayUiEvents,
                   addNotice,
                   dismissNotice,
-                  { hideHistoryTruncation: historyHasMore },
+                  {
+                    hideHistoryTruncation: historyHasMore,
+                    suppressSideEffects:
+                      repairingEpisode !== undefined && !isNewRepairEvent,
+                  },
                 );
-                allUiEvents.push(
-                  ...(subagentTranscriptModeRef.current === 'summary'
+                const projectedEvents =
+                  subagentTranscriptModeRef.current === 'summary'
                     ? projectMainTranscriptEvents(transcriptEvents)
-                    : transcriptEvents),
-                );
+                    : transcriptEvents;
+                const groupEvents = [...projectedEvents];
                 if (replayEvent.type === 'turn_complete') {
                   const stopReason =
                     (replayEvent.data as DaemonTurnCompleteData | undefined)
                       ?.stopReason ?? 'end_turn';
-                  allUiEvents.push(
+                  groupEvents.push(
                     assistantDoneFromTurnEvent(replayEvent, stopReason),
                   );
                 } else if (replayEvent.type === 'turn_error') {
-                  allUiEvents.push(
+                  groupEvents.push(
                     assistantDoneFromTurnEvent(replayEvent, 'error'),
                   );
+                }
+                eventGroups.push({
+                  transcript: groupEvents,
+                  sideEffects:
+                    repairingEpisode === undefined
+                      ? projectedEvents
+                      : isNewRepairEvent
+                        ? replayUiEvents
+                        : [],
+                });
+                if (isNewRepairEvent) {
+                  const followupSuggestion =
+                    parseSidechannelFollowupSuggestion(replayEvent);
+                  if (followupSuggestion) {
+                    publishSidechannelFollowupSuggestion(followupSuggestion);
+                  }
+                  const midTurnInjected =
+                    parseSidechannelMidTurnInjected(replayEvent);
+                  if (midTurnInjected) {
+                    publishSidechannelMidTurnInjected(midTurnInjected);
+                  }
+                  if (isPendingPromptEvent(replayEvent)) {
+                    publishPendingPromptEvent(replayEvent);
+                  }
                 }
               } catch (error) {
                 const message =
                   error instanceof Error ? error.message : String(error);
-                addNotice({
-                  severity: 'warning',
-                  category: 'protocol',
-                  operation: 'normalize_event',
-                  code: 'daemon.replay_event_malformed',
-                  message: 'Skipped malformed replay event',
-                  debugMessage: message,
-                  recoverable: true,
-                });
-                console.warn(
-                  '[DaemonSessionProvider] skipped malformed replay event:',
-                  error,
-                );
+                if (repairingEpisode === undefined || isNewRepairEvent) {
+                  addNotice({
+                    severity: 'warning',
+                    category: 'protocol',
+                    operation: 'normalize_event',
+                    code: 'daemon.replay_event_malformed',
+                    message: 'Skipped malformed replay event',
+                    debugMessage: message,
+                    recoverable: true,
+                  });
+                  console.warn(
+                    '[DaemonSessionProvider] skipped malformed replay event:',
+                    error,
+                  );
+                }
+                eventGroups.push({ transcript: [], sideEffects: [] });
               }
             }
+            const allUiEvents = eventGroups.flatMap(
+              (group) => group.transcript,
+            );
             let replayExceededCapacity = false;
-            if (needsStoreReset || store.getSnapshot().blocks.length === 0) {
-              const replayStore = createDaemonTranscriptStore({
-                maxBlocks: Number.MAX_SAFE_INTEGER,
-                retainSubagentBlocks:
-                  subagentTranscriptModeRef.current === 'full',
-              });
-              replayStore.dispatch(allUiEvents);
+            const rebuildReplay =
+              repairingEpisode !== undefined ||
+              replayTarget !== undefined ||
+              needsStoreReset ||
+              store.getSnapshot().blocks.length === 0;
+            if (rebuildReplay) {
+              const replayMaxBlocks = repairingEpisode
+                ? markerStillVisible
+                  ? repairingEpisode.checkpoint.maxBlocks
+                  : maxBlocks
+                : Number.MAX_SAFE_INTEGER;
+              const replayStore = createDaemonTranscriptStore(
+                repairingEpisode && markerStillVisible
+                  ? {
+                      ...repairingEpisode.checkpoint,
+                      maxBlocks: replayMaxBlocks,
+                    }
+                  : {
+                      maxBlocks: replayMaxBlocks,
+                      retainSubagentBlocks:
+                        subagentTranscriptModeRef.current === 'full',
+                    },
+              );
+              let nextCheckpoint: DaemonTranscriptState | undefined;
+              for (const [index, group] of eventGroups.entries()) {
+                if (index === markerIndex) {
+                  nextCheckpoint = replayStore.getSnapshot();
+                }
+                replayStore.dispatch(group.transcript);
+              }
               const replayState = replayStore.getSnapshot();
-              replayExceededCapacity = replayState.blocks.length > maxBlocks;
+              replayExceededCapacity =
+                repairingEpisode === undefined &&
+                replayState.blocks.length > maxBlocks;
+              const committedMaxBlocks = repairingEpisode
+                ? replayMaxBlocks
+                : Math.max(maxBlocks, replayState.blocks.length);
               store.reset({
                 ...replayState,
-                maxBlocks: Math.max(maxBlocks, replayState.blocks.length),
+                maxBlocks: committedMaxBlocks,
               });
+              if (replayTarget && nextCheckpoint) {
+                const markerBlock = store
+                  .getSnapshot()
+                  .blocks.find(
+                    (block) =>
+                      block.kind === 'status' &&
+                      block.source === 'history_truncated' &&
+                      isRecord(block.data) &&
+                      block.data['scope'] === 'live_journal',
+                  );
+                const existingRepair = liveJournalRepairRef.current;
+                liveJournalRepairRef.current =
+                  existingRepair?.target.signature === replayTarget.signature &&
+                  existingRepair.attempted
+                    ? existingRepair
+                    : {
+                        sessionId: activeSession.sessionId,
+                        target: replayTarget,
+                        checkpoint: {
+                          ...nextCheckpoint,
+                          maxBlocks: committedMaxBlocks,
+                        },
+                        ...(markerBlock
+                          ? { markerBlockId: markerBlock.id }
+                          : {}),
+                        lastObservedEventId: activeSession.lastEventId ?? 0,
+                        terminalSeen: false,
+                        attempted: false,
+                      };
+              } else if (repairingEpisode) {
+                liveJournalRepairRef.current = undefined;
+              }
             } else if (allUiEvents.length > 0) {
               store.dispatch(allUiEvents);
             }
-            if (allUiEvents.length > 0) {
-              bumpWorkspaceEventSignals(allUiEvents, setWorkspaceEventSignals);
+            const sideEffectEvents = eventGroups.flatMap(
+              (group) => group.sideEffects,
+            );
+            if (sideEffectEvents.length > 0) {
+              bumpWorkspaceEventSignals(
+                sideEffectEvents,
+                setWorkspaceEventSignals,
+              );
             }
             if (replayExceededCapacity && historyHasMore) {
               transcriptHistoryRef.current.hasMore = false;
@@ -1502,12 +1788,36 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
             };
           });
           if (loadWarningTexts.length > 0) {
-            store.dispatch(
-              loadWarningTexts.map((text) => ({
+            const existingWarningTexts = repairingEpisode
+              ? new Set(
+                  store
+                    .getSnapshot()
+                    .blocks.flatMap((block) =>
+                      block.kind === 'status' ? [block.text] : [],
+                    ),
+                )
+              : undefined;
+            const warningEvents = loadWarningTexts
+              .filter((text) => !existingWarningTexts?.has(text))
+              .map((text) => ({
                 type: 'status' as const,
                 text,
-              })),
-            );
+              }));
+            if (warningEvents.length > 0) {
+              store.dispatch(warningEvents);
+            }
+            const repair = liveJournalRepairRef.current;
+            if (
+              warningEvents.length > 0 &&
+              repair?.sessionId === activeSession.sessionId
+            ) {
+              const checkpointStore = createDaemonTranscriptStore({
+                ...repair.checkpoint,
+                maxBlocks: repair.checkpoint.maxBlocks,
+              });
+              checkpointStore.dispatch(warningEvents);
+              repair.checkpoint = checkpointStore.getSnapshot();
+            }
           }
           let sawEvent = false;
           let resyncRequested = false;
@@ -1568,6 +1878,16 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
             if (!sawEvent) {
               sawEvent = true;
               reconnectAttempt = 0;
+            }
+            const currentRepair = liveJournalRepairRef.current;
+            if (
+              currentRepair?.sessionId === activeSession.sessionId &&
+              event.id !== undefined
+            ) {
+              currentRepair.lastObservedEventId = Math.max(
+                currentRepair.lastObservedEventId,
+                event.id,
+              );
             }
             try {
               const followupSuggestion =
@@ -1774,6 +2094,18 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                   3000,
                   () => setPromptStatus('idle'),
                 );
+              }
+              const pendingRepair = liveJournalRepairRef.current;
+              if (
+                pendingRepair?.sessionId === activeSession.sessionId &&
+                (event.type === 'turn_complete' ||
+                  event.type === 'turn_error') &&
+                eventPromptId(event) === pendingRepair.target.promptId
+              ) {
+                pendingRepair.terminalSeen = true;
+                queueMicrotask(tryLiveJournalRepair);
+              } else if (pendingRepair?.terminalSeen) {
+                queueMicrotask(tryLiveJournalRepair);
               }
               // ── state_resync_required handling ──────────────────────
               // Resyncs are transcript recovery signals, not prompt terminal
@@ -2399,6 +2731,10 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
         setRestoreSessionNonce,
         setAttachSessionNonce,
         setNewSessionNonce,
+        clearLiveJournalRepair: () => {
+          liveJournalRepairRef.current?.controller?.abort();
+          liveJournalRepairRef.current = undefined;
+        },
       }),
     [
       addNotice,
@@ -2409,6 +2745,11 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
       store,
     ],
   );
+  repairReloadRef.current = actions.reloadSession;
+  useEffect(() => {
+    if (promptStatus !== 'idle') return;
+    queueMicrotask(() => tryLiveJournalRepairRef.current?.());
+  }, [promptStatus]);
   const loadMoreTranscript = useCallback(
     async (options?: { force?: boolean }) => {
       const history = transcriptHistoryRef.current;
@@ -2512,10 +2853,15 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
             );
           }
         }
-        if (
-          uiEvents.length > 0 &&
-          !prependTranscriptHistory(store, uiEvents, maxBlocks)
-        ) {
+        const historyMaterialization =
+          uiEvents.length > 0
+            ? materializeTranscriptHistory(
+                store.getSnapshot(),
+                uiEvents,
+                maxBlocks,
+              )
+            : undefined;
+        if (uiEvents.length > 0 && !historyMaterialization) {
           history.hasMore = false;
           history.loading = false;
           history.capacityReached = true;
@@ -2526,6 +2872,18 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
             paginationError: false,
           });
           return;
+        }
+        if (historyMaterialization) {
+          store.reset(
+            applyTranscriptHistory(store.getSnapshot(), historyMaterialization),
+          );
+          const repair = liveJournalRepairRef.current;
+          if (repair?.sessionId === activeSession.sessionId) {
+            repair.checkpoint = applyTranscriptHistory(
+              repair.checkpoint,
+              historyMaterialization,
+            );
+          }
         }
         const hasCapacity = store.getSnapshot().blocks.length < maxBlocks;
         history.capacityReached = page.hasMore && !hasCapacity;
@@ -2576,6 +2934,8 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           });
         }
         throw error;
+      } finally {
+        tryLiveJournalRepairRef.current?.();
       }
     },
     [addNotice, dismissNotice, maxBlocks, store],
@@ -2716,9 +3076,11 @@ function normalizeAndFilterEvent(
   clientId: string | undefined,
   opts: { suppressOwnUserEcho: boolean; includeRawEvent: boolean },
   setConnection: Dispatch<SetStateAction<DaemonConnectionState>>,
-  behavior: { updateConnection?: boolean } = {},
+  behavior: { updateConnection?: boolean; suppressLog?: boolean } = {},
 ): DaemonUiEvent[] {
-  logSettingsReloadEvent(event);
+  if (!behavior.suppressLog) {
+    logSettingsReloadEvent(event);
+  }
   if (behavior.updateConnection !== false) {
     updateConnectionFromDaemonEvent(event, setConnection);
   }
@@ -2786,15 +3148,16 @@ function filterDaemonUiEventsForTranscript(
   events: DaemonUiEvent[],
   addNotice: AddDaemonSessionNotice,
   dismissNotice: (id: string) => void,
-  behavior: { hideHistoryTruncation?: boolean } = {},
+  behavior: {
+    hideHistoryTruncation?: boolean;
+    suppressSideEffects?: boolean;
+  } = {},
 ): DaemonUiEvent[] {
-  if (
-    behavior.hideHistoryTruncation &&
-    hasFullTranscriptBeforeReplay(sourceEvent)
-  ) {
+  if (behavior.hideHistoryTruncation && isHistoricalReplayMarker(sourceEvent)) {
     return [];
   }
   if (
+    !behavior.suppressSideEffects &&
     sourceEvent.type === 'session_snapshot' &&
     isRecord(sourceEvent.data) &&
     sourceEvent.data['recordingDegraded'] === false
@@ -2814,6 +3177,7 @@ function filterDaemonUiEventsForTranscript(
       filtered.push(event);
       continue;
     }
+    if (behavior.suppressSideEffects) continue;
     const notice = addNotice(
       daemonErrorEventToNotice(sourceEvent, event as DaemonUiErrorEvent),
     );

--- a/packages/webui/src/daemon/session/actions.test.ts
+++ b/packages/webui/src/daemon/session/actions.test.ts
@@ -374,14 +374,39 @@ describe('createDaemonSessionActions', () => {
 
   it('keeps the reload abort signal with the pending load', () => {
     const controller = new AbortController();
+    const clearLiveJournalRepair = vi.fn();
     const { actions, pendingSessionLoadRef } = createActionsHarness({
+      clearLiveJournalRepair,
+      connection: { status: 'connected', sessionId: 'session-a' },
+      session: createMockSession('session-a'),
+    });
+
+    void actions
+      .reloadSession(controller.signal, { replaySource: 'memory' })
+      .catch(() => undefined);
+
+    expect(pendingSessionLoadRef.current?.signal).toBe(controller.signal);
+    expect(pendingSessionLoadRef.current?.replaySource).toBe('memory');
+    expect(clearLiveJournalRepair).not.toHaveBeenCalled();
+    clearTimeout(pendingSessionLoadRef.current?.timeout);
+    pendingSessionLoadRef.current?.reject(
+      new DOMException('Test cleanup', 'AbortError'),
+    );
+    pendingSessionLoadRef.current = undefined;
+  });
+
+  it('clears live journal repair state for a configured reload', () => {
+    const controller = new AbortController();
+    const clearLiveJournalRepair = vi.fn();
+    const { actions, pendingSessionLoadRef } = createActionsHarness({
+      clearLiveJournalRepair,
       connection: { status: 'connected', sessionId: 'session-a' },
       session: createMockSession('session-a'),
     });
 
     void actions.reloadSession(controller.signal).catch(() => undefined);
 
-    expect(pendingSessionLoadRef.current?.signal).toBe(controller.signal);
+    expect(clearLiveJournalRepair).toHaveBeenCalledOnce();
     clearTimeout(pendingSessionLoadRef.current?.timeout);
     pendingSessionLoadRef.current?.reject(
       new DOMException('Test cleanup', 'AbortError'),
@@ -751,6 +776,7 @@ function createActionsHarness(
   opts: {
     activePrompts?: Map<string, ActivePrompt>;
     addNotice?: ReturnType<typeof vi.fn>;
+    clearLiveJournalRepair?: ReturnType<typeof vi.fn>;
     connection?: DaemonConnectionState;
     createDetachedSession?: ReturnType<typeof vi.fn>;
     manualSessionClearRef?: { current: boolean };
@@ -805,6 +831,7 @@ function createActionsHarness(
     resetCurrentSessionActivePrompt: vi.fn(),
     restartEventStream: opts.restartEventStream ?? vi.fn(),
     addNotice: opts.addNotice ?? vi.fn(),
+    clearLiveJournalRepair: opts.clearLiveJournalRepair,
     setConnection: (update) => {
       connection = typeof update === 'function' ? update(connection) : update;
     },

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -84,6 +84,7 @@ export interface CreateDaemonSessionActionsArgs {
   setRestoreSessionNonce: Dispatch<SetStateAction<number>>;
   setAttachSessionNonce: Dispatch<SetStateAction<number>>;
   setNewSessionNonce: Dispatch<SetStateAction<number>>;
+  clearLiveJournalRepair?: () => void;
 }
 
 export function getConnectionAfterSessionClear(
@@ -148,10 +149,12 @@ export function createDaemonSessionActions({
   setRestoreSessionNonce,
   setAttachSessionNonce,
   setNewSessionNonce,
+  clearLiveJournalRepair = () => undefined,
 }: CreateDaemonSessionActionsArgs): DaemonSessionActions {
   const silentHardFailureNoticeKeys = new Set<string>();
 
   function clearActiveSessionState() {
+    clearLiveJournalRepair();
     silentHardFailureNoticeKeys.clear();
     for (const [, active] of activePromptsRef.current) {
       active.controller.abort();
@@ -182,6 +185,7 @@ export function createDaemonSessionActions({
     sessionId: string,
     mode: PendingSessionLoad['mode'],
     signal?: AbortSignal,
+    replaySource?: PendingSessionLoad['replaySource'],
   ): Promise<void> {
     const loadId = pendingSessionLoadIdRef.current + 1;
     pendingSessionLoadIdRef.current = loadId;
@@ -216,6 +220,7 @@ export function createDaemonSessionActions({
         resolve,
         reject,
         ...(signal ? { signal } : {}),
+        ...(replaySource ? { replaySource } : {}),
       };
     });
     return loadPromise;
@@ -226,14 +231,23 @@ export function createDaemonSessionActions({
     mode: 'load' | 'resume',
     workspaceCwd?: string,
     signal?: AbortSignal,
+    replaySource?: PendingSessionLoad['replaySource'],
   ): Promise<void> {
+    if (replaySource !== 'memory') {
+      clearLiveJournalRepair();
+    }
     if (signal?.aborted) {
       return Promise.reject(
         new DOMException('Session load cancelled', 'AbortError'),
       );
     }
     manualSessionClearRef.current = false;
-    const loadPromise = startPendingSessionLoad(sessionId, mode, signal);
+    const loadPromise = startPendingSessionLoad(
+      sessionId,
+      mode,
+      signal,
+      replaySource,
+    );
     const currentSession = sessionRef.current;
     const currentSessionId = currentSession?.sessionId;
     const activePrompt = currentSessionId
@@ -641,7 +655,7 @@ export function createDaemonSessionActions({
       return startSessionSwitch(sessionId, 'load', options?.workspaceCwd);
     },
 
-    async reloadSession(signal) {
+    async reloadSession(signal, options) {
       const session = requireSessionForAction(
         addNotice,
         sessionRef.current,
@@ -653,6 +667,7 @@ export function createDaemonSessionActions({
         'load',
         session.workspaceCwd,
         signal,
+        options?.replaySource,
       );
     },
 

--- a/packages/webui/src/daemon/session/live-journal-repair.test.ts
+++ b/packages/webui/src/daemon/session/live-journal-repair.test.ts
@@ -1,0 +1,141 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { DaemonEvent } from '@qwen-code/sdk/daemon';
+import {
+  findLiveJournalRepairSuffix,
+  findLiveJournalRepairTarget,
+} from './live-journal-repair.js';
+
+const marker = (promptId?: string): DaemonEvent => ({
+  v: 1,
+  type: 'history_truncated',
+  ...(promptId ? { promptId } : {}),
+  data: {
+    reason: 'replay_window_exceeded',
+    scope: 'live_journal',
+    truncatedEvents: 4,
+    retainedEvents: 2,
+    maxBytes: 1024,
+    maxEvents: 2,
+    fullTranscriptAvailable: true,
+  },
+});
+
+const update = (
+  id: number,
+  promptId: string,
+  sessionUpdate: 'user_message_chunk' | 'agent_message_chunk',
+): DaemonEvent => ({
+  id,
+  v: 1,
+  type: 'session_update',
+  promptId,
+  data: {
+    update: {
+      sessionUpdate,
+      content: { type: 'text', text: `${sessionUpdate}-${id}` },
+    },
+  },
+});
+
+describe('live journal repair validation', () => {
+  it('prefers marker promptId and falls back only to a unique retained prompt', () => {
+    expect(
+      findLiveJournalRepairTarget(
+        'session-1',
+        [
+          marker('prompt-authoritative'),
+          update(5, 'prompt-other', 'agent_message_chunk'),
+        ],
+        5,
+        false,
+      )?.promptId,
+    ).toBe('prompt-authoritative');
+    expect(
+      findLiveJournalRepairTarget(
+        'session-1',
+        [marker(), update(5, 'prompt-fallback', 'agent_message_chunk')],
+        5,
+        false,
+      )?.promptId,
+    ).toBe('prompt-fallback');
+    expect(
+      findLiveJournalRepairTarget(
+        'session-1',
+        [
+          marker(),
+          update(5, 'prompt-a', 'agent_message_chunk'),
+          update(6, 'prompt-b', 'agent_message_chunk'),
+        ],
+        6,
+        false,
+      ),
+    ).toBeUndefined();
+  });
+
+  it('rejects degraded or non-recoverable live markers', () => {
+    expect(
+      findLiveJournalRepairTarget('session-1', [marker('prompt-1')], 5, true),
+    ).toBeUndefined();
+    const unavailableMarker = marker('prompt-1');
+    unavailableMarker.data = {
+      reason: 'replay_window_exceeded',
+      scope: 'live_journal',
+      truncatedEvents: 4,
+      retainedEvents: 2,
+      maxBytes: 1024,
+      maxEvents: 2,
+      fullTranscriptAvailable: false,
+    };
+    expect(
+      findLiveJournalRepairTarget('session-1', [unavailableMarker], 5, false),
+    ).toBeUndefined();
+
+    for (const malformedData of [
+      { maxEvents: -1 },
+      { maxEvents: 1.5 },
+      { truncatedEvents: '4' },
+    ]) {
+      const malformedMarker = marker('prompt-1');
+      malformedMarker.data = {
+        ...(malformedMarker.data as Record<string, unknown>),
+        ...malformedData,
+      };
+      expect(
+        findLiveJournalRepairTarget('session-1', [malformedMarker], 5, false),
+      ).toBeUndefined();
+    }
+  });
+
+  it('requires the target user input and matching formal terminal', () => {
+    const replay = [
+      update(1, 'prompt-1', 'user_message_chunk'),
+      update(2, 'prompt-1', 'agent_message_chunk'),
+      {
+        id: 3,
+        v: 1,
+        type: 'turn_complete',
+        promptId: 'prompt-1',
+        data: { promptId: 'prompt-1', stopReason: 'end_turn' },
+      },
+      update(4, 'prompt-2', 'user_message_chunk'),
+    ] satisfies DaemonEvent[];
+
+    expect(findLiveJournalRepairSuffix(replay, 'prompt-1')).toEqual({
+      events: replay,
+      terminal: replay[2],
+    });
+    expect(
+      findLiveJournalRepairSuffix(replay.slice(1), 'prompt-1'),
+    ).toBeUndefined();
+    expect(
+      findLiveJournalRepairSuffix(replay.slice(0, 2), 'prompt-1'),
+    ).toBeUndefined();
+    expect(findLiveJournalRepairSuffix(replay, 'prompt-2')).toBeUndefined();
+  });
+});

--- a/packages/webui/src/daemon/session/live-journal-repair.ts
+++ b/packages/webui/src/daemon/session/live-journal-repair.ts
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { asKnownDaemonEvent, type DaemonEvent } from '@qwen-code/sdk/daemon';
+import { isRecord } from './httpErrors.js';
+
+export interface LiveJournalRepairTarget {
+  marker: DaemonEvent;
+  promptId: string;
+  signature: string;
+}
+
+export interface LiveJournalRepairSuffix {
+  events: DaemonEvent[];
+  terminal: DaemonEvent;
+}
+
+export function findLiveJournalRepairTarget(
+  sessionId: string,
+  liveJournal: readonly DaemonEvent[],
+  lastEventId: number | undefined,
+  replayDegraded: boolean,
+): LiveJournalRepairTarget | undefined {
+  if (replayDegraded) return undefined;
+  const marker = liveJournal.find(isRecoverableLiveJournalMarker);
+  if (!marker) return undefined;
+  const promptId =
+    nonEmptyString(marker.promptId) ?? uniqueRetainedPromptId(liveJournal);
+  if (!promptId) return undefined;
+  const truncatedEvents = isRecord(marker.data)
+    ? marker.data['truncatedEvents']
+    : undefined;
+  return {
+    marker,
+    promptId,
+    signature: [
+      sessionId,
+      promptId,
+      lastEventId ?? 'unknown',
+      typeof truncatedEvents === 'number' ? truncatedEvents : 'unknown',
+    ].join(':'),
+  };
+}
+
+export function findLiveJournalRepairSuffix(
+  replayEvents: readonly DaemonEvent[],
+  promptId: string,
+): LiveJournalRepairSuffix | undefined {
+  const start = replayEvents.findIndex(
+    (event) => eventPromptId(event) === promptId && isUserMessageChunk(event),
+  );
+  if (start < 0) return undefined;
+  const terminal = replayEvents.find(
+    (event, index) =>
+      index >= start &&
+      eventPromptId(event) === promptId &&
+      (event.type === 'turn_complete' || event.type === 'turn_error'),
+  );
+  if (!terminal) return undefined;
+  return { events: replayEvents.slice(start), terminal };
+}
+
+export function eventPromptId(event: DaemonEvent): string | undefined {
+  const envelopePromptId = nonEmptyString(event.promptId);
+  if (envelopePromptId) return envelopePromptId;
+  return isRecord(event.data)
+    ? nonEmptyString(event.data['promptId'])
+    : undefined;
+}
+
+export function isLiveJournalMarker(event: DaemonEvent): boolean {
+  return (
+    event.type === 'history_truncated' &&
+    isRecord(event.data) &&
+    event.data['scope'] === 'live_journal'
+  );
+}
+
+function isRecoverableLiveJournalMarker(event: DaemonEvent): boolean {
+  const knownEvent = asKnownDaemonEvent(event);
+  return (
+    knownEvent?.type === 'history_truncated' &&
+    isLiveJournalMarker(event) &&
+    isRecord(event.data) &&
+    event.data['fullTranscriptAvailable'] === true
+  );
+}
+
+function uniqueRetainedPromptId(
+  liveJournal: readonly DaemonEvent[],
+): string | undefined {
+  const promptIds = new Set<string>();
+  for (const event of liveJournal) {
+    if (isLiveJournalMarker(event)) continue;
+    const promptId = eventPromptId(event);
+    if (promptId) promptIds.add(promptId);
+    if (promptIds.size > 1) return undefined;
+  }
+  return promptIds.size === 1 ? [...promptIds][0] : undefined;
+}
+
+function isUserMessageChunk(event: DaemonEvent): boolean {
+  if (event.type !== 'session_update' || !isRecord(event.data)) return false;
+  const update = event.data['update'];
+  return isRecord(update) && update['sessionUpdate'] === 'user_message_chunk';
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}

--- a/packages/webui/src/daemon/session/types.ts
+++ b/packages/webui/src/daemon/session/types.ts
@@ -356,6 +356,7 @@ export interface DaemonSessionActions {
     sessionId: string,
     options?: { workspaceCwd?: string },
   ): Promise<void>;
+  /** `memory` replay is reserved for the provider's live-journal repair. */
   reloadSession(
     signal: AbortSignal,
     options?: { replaySource?: 'configured' | 'memory' },

--- a/packages/webui/src/daemon/session/types.ts
+++ b/packages/webui/src/daemon/session/types.ts
@@ -356,7 +356,10 @@ export interface DaemonSessionActions {
     sessionId: string,
     options?: { workspaceCwd?: string },
   ): Promise<void>;
-  reloadSession(signal: AbortSignal): Promise<void>;
+  reloadSession(
+    signal: AbortSignal,
+    options?: { replaySource?: 'configured' | 'memory' },
+  ): Promise<void>;
   resumeSession(
     sessionId: string,
     options?: { workspaceCwd?: string },
@@ -496,4 +499,5 @@ export interface PendingSessionLoad {
   resolve: () => void;
   reject: (error: unknown) => void;
   signal?: AbortSignal;
+  replaySource?: 'configured' | 'memory';
 }


### PR DESCRIPTION
## What this PR does

This PR makes bounded live-journal truncation precise and recoverable without changing the existing 10,000-event or 8 MiB limits. Live truncation markers now carry optional authoritative prompt ownership, SDK consumers receive validated scope and limit metadata with wording that explicitly says the newest events were retained, and WebUI creates a bounded checkpoint before the partial live tail.

After the matching prompt reaches a formal complete, error, or cancelled terminal event, WebUI performs at most one read-only in-memory session load, validates the returned prompt input and terminal, rebuilds the complete suffix, and atomically replaces the marker and partial tail. The repair preserves visible content until commit, previously loaded history and pagination state, and suppresses duplicate notices, workspace signals, token accounting, and other external side effects. Ambiguous legacy markers, degraded snapshots, transport failures, navigation, explicit reloads, and concurrent session activity fail or defer safely.

The change also adds deterministic protocol and real-provider integration coverage plus a design document describing compatibility, lifecycle, validation, and resource boundaries.

## Why it's needed

The daemon intentionally drops the oldest raw replay events when an unfinished turn exceeds its bounded live journal, while the persisted transcript and turn-boundary compaction remain authoritative. Previously the generic marker did not identify which side of the journal was removed or which prompt owned it, and a WebUI client joining mid-turn could keep displaying an apparently permanent partial answer after the complete compacted turn became available. Users therefore saw misleading data-loss semantics even though the answer could be recovered without rerunning the model or tools.

## Reviewer Test Plan

### How to verify

1. Run a deterministic daemon with a three-event live-journal limit, start a prompt that emits many numbered chunks, and load the same session from a second client while the prompt is paused. Confirm the marker belongs to the active prompt, says older replay events were discarded while the newest were retained, and the partial tail contains only the newest chunks.
2. Let the prompt complete, error, or terminate as cancelled. Confirm the second WebUI client performs exactly one additional session load, sends no additional prompt, and atomically replaces the marker and partial tail with the complete turn including the first and last chunks.
3. Repeat with a non-matching queued terminal, an ambiguous legacy marker, degraded or incomplete replay, navigation, history pagination, a local active prompt, explicit reload, and transport/authentication failures. Confirm recovery does not cross prompt or session ownership, existing transcript and history state remain visible, and a failed episode emits one recoverable notice without retrying.
4. Confirm the targeted Bridge, SDK, and WebUI suites pass together with the deterministic daemon/WebUI integration fixtures, root build, and typecheck.

### Evidence (Before & After)

Before: the UI displayed a generic message such as `History truncated: retained 10000, dropped 16371 (window 8388608 bytes).` and could leave the retained live tail visible after terminal.

After: the status explicitly identifies live-turn replay, states that the newest events were retained and older replay events were discarded, and promises restoration only when a full transcript is available. The deterministic WebUI integration test observes one initial load, one post-terminal repair load, zero extra model prompts, and one complete answer.

Validation results: Bridge/compaction 546 tests passed; SDK event/UI 392 tests passed; WebUI session recovery 239 tests passed; live-journal daemon and real-provider integration 2 tests passed; root build and typecheck passed.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS local checkout with Node.js 26, deterministic mock ACP child process, `qwen serve`, and an artificially low three-event journal limit for integration coverage.

## Risk & Scope

- Main risk or tradeoff: The repair coordinates snapshot loading, SSE ownership, transcript checkpoints, and history pagination across package boundaries. It is limited to one validated same-session read per truncation episode and keeps the previous stream and transcript recoverable until atomic commit.
- Not validated / out of scope: Windows and Linux were not tested locally; production rollout with the default 10,000-event and 8 MiB thresholds remains for CI and downstream staging. Raising limits, changing oldest-first eviction, replaying model/tool execution, and changing daemon persistence are intentionally out of scope.
- Breaking changes / migration notes: None. Marker ownership and SDK fields are optional, old clients ignore them, new clients safely decline ambiguous legacy repair, and configured reload behavior remains unchanged.

## Linked Issues

Fixes #8412

<details>
<summary>中文说明</summary>

## 此 PR 的作用

此 PR 在不改变现有 10,000 事件或 8 MiB 上限的前提下，让有界 live journal 截断的语义更精确并可恢复。live 截断 marker 现在会携带可选的权威 prompt 归属；SDK 消费方会收到经过校验的 scope 和上限元数据，文案明确说明保留的是最新事件；WebUI 则会在残缺 live tail 之前建立有界 checkpoint。

当匹配的 prompt 到达正式的 complete、error 或 cancelled terminal 事件后，WebUI 最多执行一次只读的内存 session load，校验返回结果中存在 prompt 输入和 terminal，重建完整 suffix，并原子替换 marker 与残缺 tail。修复会在提交前保持当前内容可见，保留已加载历史和分页状态，并抑制重复的 notice、workspace signal、token 计数及其他外部副作用。对于旧 daemon 的歧义 marker、degraded snapshot、传输失败、导航、主动 reload 和并发 session 活动，流程都会安全失败或延后。

本改动还增加了确定性的协议集成测试、真实 provider 集成测试，以及说明兼容性、生命周期、校验和资源边界的设计文档。

## 为什么需要

当未完成轮次超过有界 live journal 时，daemon 会有意丢弃最老的原始 replay 事件，而持久化 transcript 和 turn-boundary compaction 仍然是权威数据。此前通用 marker 没有说明 journal 的哪一端被移除，也没有标识其所属 prompt；中途加入的 WebUI 客户端即使在完整 compacted turn 已经可用后，仍可能持续显示看似永久残缺的回答。因此，用户会看到误导性的数据丢失语义，尽管无需重新运行模型或工具即可恢复回答。

## Reviewer 测试计划

### 如何验证

1. 使用三事件 live-journal 上限启动确定性 daemon，让一个 prompt 输出大量带编号 chunk 并在 terminal 前暂停，再从第二个客户端加载同一 session。确认 marker 归属于 active prompt，文案说明丢弃了更老 replay 事件并保留最新事件，且残缺 tail 只包含最新 chunk。
2. 让 prompt 分别以 complete、error 或 cancelled 结束。确认第二个 WebUI 客户端只增加一次 session load，不发送额外 prompt，并原子地用包含首尾 chunk 的完整轮次替换 marker 与残缺 tail。
3. 使用不匹配的 queued terminal、歧义的旧 marker、degraded 或不完整 replay、导航、历史分页、本地 active prompt、主动 reload，以及传输或鉴权失败重复验证。确认修复不会跨越 prompt 或 session 归属，现有 transcript 和历史状态持续可见，失败 episode 只发出一次可恢复通知且不会重试。
4. 确认定向 Bridge、SDK、WebUI 测试，以及确定性的 daemon/WebUI 集成 fixture、根目录 build 和 typecheck 全部通过。

### 证据（修改前后）

修改前：UI 显示类似 `History truncated: retained 10000, dropped 16371 (window 8388608 bytes).` 的通用消息，并可能在 terminal 后继续保留残缺 live tail。

修改后：status 明确标识 live-turn replay，说明保留的是最新事件、丢弃的是更老 replay 事件，并且只有在完整 transcript 可用时才承诺恢复。确定性 WebUI 集成测试观测到一次初始 load、一次 terminal 后 repair load、零次额外模型 prompt，以及一份完整回答。

验证结果：Bridge/compaction 546 项测试通过；SDK event/UI 392 项测试通过；WebUI session recovery 239 项测试通过；live-journal daemon 与真实 provider 集成 2 项测试通过；根目录 build 和 typecheck 通过。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

macOS 本地代码库，Node.js 26，确定性 mock ACP 子进程，`qwen serve`，并在集成测试中使用人为降低的三事件 journal 上限。

## 风险与范围

- 主要风险或权衡：修复需要跨 package 协调 snapshot load、SSE 归属、transcript checkpoint 和历史分页。每个截断 episode 最多执行一次经过校验的同 session 读取，并在原子提交前保持旧 stream 和 transcript 可恢复。
- 未验证或范围外：未在本地测试 Windows 和 Linux；使用默认 10,000 事件与 8 MiB 阈值的生产灰度仍需由 CI 和下游预发完成。提高上限、改变最老事件优先淘汰策略、重放模型或工具执行，以及修改 daemon 持久化都明确不在范围内。
- 破坏性变更或迁移说明：无。marker 归属和 SDK 字段均为可选，旧客户端会忽略它们，新客户端会安全拒绝歧义的旧版修复，配置式 reload 的行为保持不变。

## 关联 Issue

Fixes #8412

</details>
