### PR TITLE
fix(core): reuse prompt cache for multimodal compression

### DIFF
--- a/docs/design/chat-compression-cache-sharing.md
+++ b/docs/design/chat-compression-cache-sharing.md
@@ -13,30 +13,33 @@ Compression first attempts a specialized single-turn request when all of the
 following are true:
 
 - the compression model is the current main model;
-- the active provider is Anthropic or DashScope and cache control is enabled;
-- slimming found no media that would change the provider-facing history.
+- the active provider is Anthropic or DashScope and cache control is enabled.
 
 The request uses the current turn's effective generation config, including
 per-request tool overrides used by subagents, and the complete curated
-history. The existing compression instruction is appended as the final user
-message.
+history, including media. The normal model-modality filtering is applied when
+the request is sent, so supported media remains unchanged and unsupported
+media uses the same placeholders as other model requests. The existing
+compression instruction is appended as the final user message.
 Nothing consumes or executes function calls from this request. A response
 containing a function call, an empty response, a malformed state snapshot, or
 a request error is discarded and retried once through the existing cold side
-query. Cancellation does not trigger the fallback.
+query. Its media-slimmed input is built lazily only when that fallback is
+needed. Cancellation does not trigger the fallback.
 
 Using the current `GeminiChat` keeps the request scoped to the live session.
 The process-global fork cache is intentionally not used because it retains
 only a short history tail and can belong to another concurrent session.
 
-Histories containing media and sessions using a distinct compaction model stay
-on the existing path. This keeps the first version limited to requests whose
-cache identity can be established without changing media or provider routing.
+Sessions using a distinct compaction model stay on the existing path because
+their cache identity differs from the main session. Media-bearing histories
+use the shared path first so the unchanged provider-facing prefix can reuse the
+main session's cache.
 
 ## Verification
 
 Unit tests assert exact system, tools, full-history, and trailing-directive
-construction; provider/model/media gates; tool-call and malformed-response
-fallback; and cancellation behavior. Provider testing should compare the
-serialized request prefix and cached-token usage for the main turn and
-compression request.
+construction; provider/model gates; media preservation on the shared path;
+media slimming after fallback; tool-call and malformed-response fallback; and
+cancellation behavior. Provider testing should compare the serialized request
+prefix and cached-token usage for the main turn and compression request.

--- a/docs/design/chat-compression-cache-sharing.md
+++ b/docs/design/chat-compression-cache-sharing.md
@@ -13,7 +13,9 @@ Compression first attempts a specialized single-turn request when all of the
 following are true:
 
 - the compression model is the current main model;
-- the active provider is Anthropic or DashScope and cache control is enabled.
+- the active provider is Anthropic or DashScope and cache control is enabled;
+- the effective prompt token count plus the bounded compression output reserve
+  fits the model's context window.
 
 The request uses the current turn's effective generation config, including
 per-request tool overrides used by subagents, and the complete curated
@@ -40,6 +42,7 @@ main session's cache.
 
 Unit tests assert exact system, tools, full-history, and trailing-directive
 construction; provider/model gates; media preservation on the shared path;
-media slimming after fallback; tool-call and malformed-response fallback; and
-cancellation behavior. Provider testing should compare the serialized request
-prefix and cached-token usage for the main turn and compression request.
+window preflight; media slimming after fallback; tool-call and
+malformed-response fallback; and cancellation behavior. Provider testing
+should compare the serialized request prefix and cached-token usage for the
+main turn and compression request.

--- a/docs/design/chat-compression-cache-sharing.md
+++ b/docs/design/chat-compression-cache-sharing.md
@@ -14,6 +14,7 @@ following are true:
 
 - the compression model is the current main model;
 - the active provider is Anthropic or DashScope and cache control is enabled;
+- the chat has a provider-reported prompt token count to anchor the estimate;
 - the effective prompt token count plus the bounded compression output reserve
   fits the model's context window.
 

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -3453,6 +3453,9 @@ describe('GeminiChat', async () => {
       expect(compressSpy.mock.calls[1][1].force).toBe(true);
       expect(compressSpy.mock.calls[1][1].trigger).toBe('auto');
       expect(compressSpy.mock.calls[1][1].originalTokenCount).toBe(135_000);
+      expect(compressSpy.mock.calls[1][1].precomputedEffectiveTokens).toBe(
+        135_000,
+      );
       expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(
         2,
       );

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -1827,6 +1827,11 @@ export class GeminiChat {
     return this.lastPromptTokenCount;
   }
 
+  /** Previous model-response tokens used by the next prompt estimate. */
+  getLastOutputTokenCount(): number {
+    return this.lastOutputTokenCount;
+  }
+
   /**
    * Builds request contents for the content generator without deep-cloning the
    * whole chat history. This is an internal hot path: long sessions can make a

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -455,9 +455,10 @@ interface TryCompressOptions {
    */
   pendingUserMessage?: Content;
   /**
-   * Pre-computed `estimatePromptTokens` value from the caller. When set,
-   * the cheap-gate uses this instead of recomputing — avoids a second
-   * `getHistory(true)` clone per send. (review #4168 R1.3 / R1.4)
+   * Pre-computed all-inclusive effective prompt count from the caller. When
+   * set, the cheap-gate uses this instead of recomputing — avoids a second
+   * `getHistory(true)` clone per send and prevents provider-reported overflow
+   * counts from double-counting the previous model output.
    */
   precomputedEffectiveTokens?: number;
   /** Per-request overrides needed to preserve the main request cache prefix. */
@@ -2986,6 +2987,7 @@ export class GeminiChat {
                     params.config?.abortSignal,
                     {
                       originalTokenCountOverride: reactiveOriginalTokenCount,
+                      precomputedEffectiveTokens: reactiveOriginalTokenCount,
                       requestGenerationConfig: params.config,
                       trigger: 'auto',
                     },

--- a/packages/core/src/services/chatCompressionService.test.ts
+++ b/packages/core/src/services/chatCompressionService.test.ts
@@ -20,7 +20,7 @@ import type { GeminiChat } from '../core/geminiChat.js';
 import type { Config } from '../config/config.js';
 import { ApprovalMode } from '../config/config.js';
 import type { BaseLlmClient } from '../core/baseLlmClient.js';
-import { AuthType, type InputModalities } from '../core/contentGenerator.js';
+import { AuthType } from '../core/contentGenerator.js';
 import { PreCompactTrigger, PostCompactTrigger } from '../hooks/types.js';
 import * as sideQueryModule from '../utils/sideQuery.js';
 import * as postCompactModule from './postCompactAttachments.js';
@@ -2197,7 +2197,6 @@ describe('ChatCompressionService.compress cache sharing', () => {
     baseUrl?: string;
     compactionModel?: string;
     enableCacheControl?: boolean;
-    modalities?: InputModalities;
   }): {
     chat: GeminiChat;
     config: Config;
@@ -2235,7 +2234,6 @@ describe('ChatCompressionService.compress cache sharing', () => {
         baseUrl: options?.baseUrl,
         contextWindowSize: 200_000,
         enableCacheControl: options?.enableCacheControl ?? true,
-        modalities: options?.modalities,
       }),
       getHookSystem: vi.fn().mockReturnValue({
         firePreCompactEvent: vi.fn().mockResolvedValue(undefined),
@@ -2326,12 +2324,9 @@ describe('ChatCompressionService.compress cache sharing', () => {
     expect(request.config?.tools).toBe(requestTools);
   });
 
-  it('attempts cache sharing with supported media still in the history', async () => {
+  it('attempts cache sharing with media still in the history', async () => {
     const history = makeMediaHistory();
-    const { chat, config, generateText } = makeFixture({
-      history,
-      modalities: { image: true, pdf: true },
-    });
+    const { chat, config, generateText } = makeFixture({ history });
     const coldSpy = vi.spyOn(sideQueryModule, 'runSideQuery');
 
     await new ChatCompressionService().compress(chat, {
@@ -2604,10 +2599,7 @@ describe('ChatCompressionService.compress cache sharing', () => {
 
   it('slims media only after the cache-sharing request fails', async () => {
     const history = makeMediaHistory();
-    const { chat, config, generateText } = makeFixture({
-      history,
-      modalities: { image: true, pdf: true },
-    });
+    const { chat, config, generateText } = makeFixture({ history });
     generateText.mockRejectedValue(new Error('provider failed'));
     const coldSpy = vi
       .spyOn(sideQueryModule, 'runSideQuery')

--- a/packages/core/src/services/chatCompressionService.test.ts
+++ b/packages/core/src/services/chatCompressionService.test.ts
@@ -2698,16 +2698,25 @@ describe('ChatCompressionService.compress cache sharing', () => {
     const { chat, config, generateText } = makeFixture({
       contextWindowSize: null,
     });
+    const coldSpy = vi.spyOn(sideQueryModule, 'runSideQuery');
 
     await new ChatCompressionService().compress(chat, {
       promptId: 'p',
       force: true,
       config,
       consecutiveFailures: 0,
-      originalTokenCount: 180_000,
+      originalTokenCount: 150_000,
     });
 
     expect(generateText).toHaveBeenCalledTimes(1);
+    expect(coldSpy).not.toHaveBeenCalled();
+    expect(logChatCompression).toHaveBeenLastCalledWith(
+      config,
+      expect.objectContaining({
+        cache_sharing_attempted: true,
+        cache_sharing_used: true,
+      }),
+    );
   });
 
   it('includes the previous model output in the shared-request window check', async () => {
@@ -2737,6 +2746,27 @@ describe('ChatCompressionService.compress cache sharing', () => {
 
     expect(generateText).not.toHaveBeenCalled();
     expect(coldSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not add previous output to an all-inclusive prompt count', async () => {
+    const { chat, config, generateText } = makeFixture({
+      contextWindowSize: 200_000,
+      lastPromptTokenCount: 170_000,
+      lastOutputTokenCount: 20_000,
+    });
+    const coldSpy = vi.spyOn(sideQueryModule, 'runSideQuery');
+
+    await new ChatCompressionService().compress(chat, {
+      promptId: 'p',
+      force: true,
+      config,
+      consecutiveFailures: 0,
+      originalTokenCount: 170_000,
+      precomputedEffectiveTokens: 170_000,
+    });
+
+    expect(generateText).toHaveBeenCalledTimes(1);
+    expect(coldSpy).not.toHaveBeenCalled();
   });
 
   it('skips cache sharing when the chat has no provider token-count anchor', async () => {

--- a/packages/core/src/services/chatCompressionService.test.ts
+++ b/packages/core/src/services/chatCompressionService.test.ts
@@ -2197,6 +2197,7 @@ describe('ChatCompressionService.compress cache sharing', () => {
     baseUrl?: string;
     compactionModel?: string;
     enableCacheControl?: boolean;
+    contextWindowSize?: number;
   }): {
     chat: GeminiChat;
     config: Config;
@@ -2232,7 +2233,7 @@ describe('ChatCompressionService.compress cache sharing', () => {
         model: 'test-model',
         authType: options?.authType ?? AuthType.USE_ANTHROPIC,
         baseUrl: options?.baseUrl,
-        contextWindowSize: 200_000,
+        contextWindowSize: options?.contextWindowSize ?? 200_000,
         enableCacheControl: options?.enableCacheControl ?? true,
       }),
       getHookSystem: vi.fn().mockReturnValue({
@@ -2627,6 +2628,61 @@ describe('ChatCompressionService.compress cache sharing', () => {
       { text: '[document: application/pdf]' },
     ]);
   });
+
+  it.each([
+    {
+      name: 'provider prompt count',
+      originalTokenCount: 180_001,
+      precomputedEffectiveTokens: undefined,
+    },
+    {
+      name: 'hard-tier effective count',
+      originalTokenCount: 160_000,
+      precomputedEffectiveTokens: 180_001,
+    },
+  ])(
+    'skips a shared request when the $name cannot fit its output reserve',
+    async ({ originalTokenCount, precomputedEffectiveTokens }) => {
+      const history = makeMediaHistory();
+      const { chat, config, generateText } = makeFixture({
+        history,
+        contextWindowSize: 200_000,
+      });
+      const coldSpy = vi
+        .spyOn(sideQueryModule, 'runSideQuery')
+        .mockResolvedValue({
+          text: '<state_snapshot>cold summary</state_snapshot>',
+          usage: {
+            promptTokenCount: 170_000,
+            candidatesTokenCount: 500,
+            totalTokenCount: 170_500,
+          },
+        } as never);
+
+      await new ChatCompressionService().compress(chat, {
+        promptId: 'p',
+        force: true,
+        config,
+        consecutiveFailures: 0,
+        originalTokenCount,
+        precomputedEffectiveTokens,
+      });
+
+      expect(generateText).not.toHaveBeenCalled();
+      expect(coldSpy).toHaveBeenCalledTimes(1);
+      expect(coldSpy.mock.calls[0]![1].contents[0]?.parts).toEqual([
+        { text: '[image: image/png]' },
+        { text: '[document: application/pdf]' },
+      ]);
+      expect(logChatCompression).toHaveBeenLastCalledWith(
+        config,
+        expect.objectContaining({
+          cache_sharing_attempted: false,
+          cache_sharing_used: false,
+        }),
+      );
+    },
+  );
 
   it.each([
     {

--- a/packages/core/src/services/chatCompressionService.test.ts
+++ b/packages/core/src/services/chatCompressionService.test.ts
@@ -2197,7 +2197,9 @@ describe('ChatCompressionService.compress cache sharing', () => {
     baseUrl?: string;
     compactionModel?: string;
     enableCacheControl?: boolean;
-    contextWindowSize?: number;
+    contextWindowSize?: number | null;
+    lastPromptTokenCount?: number;
+    lastOutputTokenCount?: number;
   }): {
     chat: GeminiChat;
     config: Config;
@@ -2224,6 +2226,12 @@ describe('ChatCompressionService.compress cache sharing', () => {
         tools,
         thinkingConfig: { includeThoughts: true },
       }),
+      getLastPromptTokenCount: vi
+        .fn()
+        .mockReturnValue(options?.lastPromptTokenCount ?? 180_000),
+      getLastOutputTokenCount: vi
+        .fn()
+        .mockReturnValue(options?.lastOutputTokenCount ?? 0),
     } as unknown as GeminiChat;
     const config = {
       getChatCompression: vi.fn(),
@@ -2233,7 +2241,9 @@ describe('ChatCompressionService.compress cache sharing', () => {
         model: 'test-model',
         authType: options?.authType ?? AuthType.USE_ANTHROPIC,
         baseUrl: options?.baseUrl,
-        contextWindowSize: options?.contextWindowSize ?? 200_000,
+        ...(options?.contextWindowSize === null
+          ? {}
+          : { contextWindowSize: options?.contextWindowSize ?? 220_000 }),
         enableCacheControl: options?.enableCacheControl ?? true,
       }),
       getHookSystem: vi.fn().mockReturnValue({
@@ -2632,7 +2642,7 @@ describe('ChatCompressionService.compress cache sharing', () => {
   it.each([
     {
       name: 'provider prompt count',
-      originalTokenCount: 180_001,
+      originalTokenCount: 179_999,
       precomputedEffectiveTokens: undefined,
     },
     {
@@ -2683,6 +2693,79 @@ describe('ChatCompressionService.compress cache sharing', () => {
       );
     },
   );
+
+  it('uses the default context window when the provider omits its size', async () => {
+    const { chat, config, generateText } = makeFixture({
+      contextWindowSize: null,
+    });
+
+    await new ChatCompressionService().compress(chat, {
+      promptId: 'p',
+      force: true,
+      config,
+      consecutiveFailures: 0,
+      originalTokenCount: 180_000,
+    });
+
+    expect(generateText).toHaveBeenCalledTimes(1);
+  });
+
+  it('includes the previous model output in the shared-request window check', async () => {
+    const { chat, config, generateText } = makeFixture({
+      contextWindowSize: 200_000,
+      lastPromptTokenCount: 170_000,
+      lastOutputTokenCount: 20_000,
+    });
+    const coldSpy = vi
+      .spyOn(sideQueryModule, 'runSideQuery')
+      .mockResolvedValue({
+        text: '<state_snapshot>cold summary</state_snapshot>',
+        usage: {
+          promptTokenCount: 170_000,
+          candidatesTokenCount: 500,
+          totalTokenCount: 170_500,
+        },
+      } as never);
+
+    await new ChatCompressionService().compress(chat, {
+      promptId: 'p',
+      force: true,
+      config,
+      consecutiveFailures: 0,
+      originalTokenCount: 170_000,
+    });
+
+    expect(generateText).not.toHaveBeenCalled();
+    expect(coldSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips cache sharing when the chat has no provider token-count anchor', async () => {
+    const { chat, config, generateText } = makeFixture({
+      lastPromptTokenCount: 0,
+    });
+    const coldSpy = vi
+      .spyOn(sideQueryModule, 'runSideQuery')
+      .mockResolvedValue({
+        text: '<state_snapshot>cold summary</state_snapshot>',
+        usage: {
+          promptTokenCount: 170_000,
+          candidatesTokenCount: 500,
+          totalTokenCount: 170_500,
+        },
+      } as never);
+
+    await new ChatCompressionService().compress(chat, {
+      promptId: 'p',
+      force: true,
+      config,
+      consecutiveFailures: 0,
+      originalTokenCount: 0,
+      precomputedEffectiveTokens: 170_000,
+    });
+
+    expect(generateText).not.toHaveBeenCalled();
+    expect(coldSpy).toHaveBeenCalledTimes(1);
+  });
 
   it.each([
     {

--- a/packages/core/src/services/chatCompressionService.test.ts
+++ b/packages/core/src/services/chatCompressionService.test.ts
@@ -20,7 +20,7 @@ import type { GeminiChat } from '../core/geminiChat.js';
 import type { Config } from '../config/config.js';
 import { ApprovalMode } from '../config/config.js';
 import type { BaseLlmClient } from '../core/baseLlmClient.js';
-import { AuthType } from '../core/contentGenerator.js';
+import { AuthType, type InputModalities } from '../core/contentGenerator.js';
 import { PreCompactTrigger, PostCompactTrigger } from '../hooks/types.js';
 import * as sideQueryModule from '../utils/sideQuery.js';
 import * as postCompactModule from './postCompactAttachments.js';
@@ -2173,12 +2173,31 @@ describe('ChatCompressionService.compress cache sharing', () => {
     }));
   }
 
+  function makeMediaHistory(): Content[] {
+    return [
+      {
+        role: 'user',
+        parts: [
+          { inlineData: { mimeType: 'image/png', data: 'image-bytes' } },
+          {
+            inlineData: {
+              mimeType: 'application/pdf',
+              data: 'pdf-bytes',
+            },
+          },
+        ],
+      },
+      { role: 'model', parts: [{ text: 'media received' }] },
+    ];
+  }
+
   function makeFixture(options?: {
     history?: Content[];
     authType?: AuthType;
     baseUrl?: string;
     compactionModel?: string;
     enableCacheControl?: boolean;
+    modalities?: InputModalities;
   }): {
     chat: GeminiChat;
     config: Config;
@@ -2216,6 +2235,7 @@ describe('ChatCompressionService.compress cache sharing', () => {
         baseUrl: options?.baseUrl,
         contextWindowSize: 200_000,
         enableCacheControl: options?.enableCacheControl ?? true,
+        modalities: options?.modalities,
       }),
       getHookSystem: vi.fn().mockReturnValue({
         firePreCompactEvent: vi.fn().mockResolvedValue(undefined),
@@ -2304,6 +2324,32 @@ describe('ChatCompressionService.compress cache sharing', () => {
       config?: { tools?: unknown };
     };
     expect(request.config?.tools).toBe(requestTools);
+  });
+
+  it('attempts cache sharing with supported media still in the history', async () => {
+    const history = makeMediaHistory();
+    const { chat, config, generateText } = makeFixture({
+      history,
+      modalities: { image: true, pdf: true },
+    });
+    const coldSpy = vi.spyOn(sideQueryModule, 'runSideQuery');
+
+    await new ChatCompressionService().compress(chat, {
+      promptId: 'p',
+      force: true,
+      config,
+      consecutiveFailures: 0,
+      originalTokenCount: 180_000,
+    });
+
+    expect(generateText).toHaveBeenCalledTimes(1);
+    const request = generateText.mock.calls[0]![0] as {
+      contents: Content[];
+    };
+    expect(request.contents.slice(0, -1)).toEqual(history);
+    expect(JSON.stringify(request.contents)).toContain('image-bytes');
+    expect(JSON.stringify(request.contents)).toContain('pdf-bytes');
+    expect(coldSpy).not.toHaveBeenCalled();
   });
 
   it.each([AuthType.QWEN_OAUTH, AuthType.USE_OPENAI])(
@@ -2556,6 +2602,40 @@ describe('ChatCompressionService.compress cache sharing', () => {
     expect(coldSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('slims media only after the cache-sharing request fails', async () => {
+    const history = makeMediaHistory();
+    const { chat, config, generateText } = makeFixture({
+      history,
+      modalities: { image: true, pdf: true },
+    });
+    generateText.mockRejectedValue(new Error('provider failed'));
+    const coldSpy = vi
+      .spyOn(sideQueryModule, 'runSideQuery')
+      .mockResolvedValue({
+        text: '<state_snapshot>cold summary</state_snapshot>',
+        usage: {
+          promptTokenCount: 170_000,
+          candidatesTokenCount: 500,
+          totalTokenCount: 170_500,
+        },
+      } as never);
+
+    await new ChatCompressionService().compress(chat, {
+      promptId: 'p',
+      force: true,
+      config,
+      consecutiveFailures: 0,
+      originalTokenCount: 180_000,
+    });
+
+    expect(generateText).toHaveBeenCalledTimes(1);
+    expect(coldSpy).toHaveBeenCalledTimes(1);
+    expect(coldSpy.mock.calls[0]![1].contents[0]?.parts).toEqual([
+      { text: '[image: image/png]' },
+      { text: '[document: application/pdf]' },
+    ]);
+  });
+
   it.each([
     {
       name: 'a distinct compaction model',
@@ -2575,37 +2655,6 @@ describe('ChatCompressionService.compress cache sharing', () => {
     {
       name: 'disabled cache control',
       options: { enableCacheControl: false },
-    },
-    {
-      name: 'media-bearing history',
-      options: {
-        history: [
-          {
-            role: 'user',
-            parts: [{ inlineData: { mimeType: 'image/png', data: 'base64' } }],
-          },
-          { role: 'model', parts: [{ text: 'image received' }] },
-        ],
-      },
-    },
-    {
-      name: 'document-bearing history',
-      options: {
-        history: [
-          {
-            role: 'user',
-            parts: [
-              {
-                inlineData: {
-                  mimeType: 'application/pdf',
-                  data: 'base64',
-                },
-              },
-            ],
-          },
-          { role: 'model', parts: [{ text: 'document received' }] },
-        ],
-      },
     },
   ])('keeps $name on the cold path', async ({ options }) => {
     const { chat, config, generateText } = makeFixture(options);

--- a/packages/core/src/services/chatCompressionService.test.ts
+++ b/packages/core/src/services/chatCompressionService.test.ts
@@ -24,6 +24,7 @@ import { AuthType } from '../core/contentGenerator.js';
 import { PreCompactTrigger, PostCompactTrigger } from '../hooks/types.js';
 import * as sideQueryModule from '../utils/sideQuery.js';
 import * as postCompactModule from './postCompactAttachments.js';
+import * as slimmingModule from './compactionInputSlimming.js';
 import { logChatCompression } from '../telemetry/loggers.js';
 
 vi.mock('../telemetry/uiTelemetry.js');
@@ -2339,6 +2340,7 @@ describe('ChatCompressionService.compress cache sharing', () => {
     const history = makeMediaHistory();
     const { chat, config, generateText } = makeFixture({ history });
     const coldSpy = vi.spyOn(sideQueryModule, 'runSideQuery');
+    const slimSpy = vi.spyOn(slimmingModule, 'slimCompactionInput');
 
     await new ChatCompressionService().compress(chat, {
       promptId: 'p',
@@ -2356,6 +2358,7 @@ describe('ChatCompressionService.compress cache sharing', () => {
     expect(JSON.stringify(request.contents)).toContain('image-bytes');
     expect(JSON.stringify(request.contents)).toContain('pdf-bytes');
     expect(coldSpy).not.toHaveBeenCalled();
+    expect(slimSpy).not.toHaveBeenCalled();
   });
 
   it.each([AuthType.QWEN_OAUTH, AuthType.USE_OPENAI])(
@@ -2612,6 +2615,7 @@ describe('ChatCompressionService.compress cache sharing', () => {
     const history = makeMediaHistory();
     const { chat, config, generateText } = makeFixture({ history });
     generateText.mockRejectedValue(new Error('provider failed'));
+    const slimSpy = vi.spyOn(slimmingModule, 'slimCompactionInput');
     const coldSpy = vi
       .spyOn(sideQueryModule, 'runSideQuery')
       .mockResolvedValue({
@@ -2632,6 +2636,7 @@ describe('ChatCompressionService.compress cache sharing', () => {
     });
 
     expect(generateText).toHaveBeenCalledTimes(1);
+    expect(slimSpy).toHaveBeenCalledTimes(1);
     expect(coldSpy).toHaveBeenCalledTimes(1);
     expect(coldSpy.mock.calls[0]![1].contents[0]?.parts).toEqual([
       { text: '[image: image/png]' },

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -363,6 +363,9 @@ export class ChatCompressionService {
     const chatCompressionSettings = config.getChatCompression();
     const slimmingConfig = resolveSlimmingConfig(chatCompressionSettings);
     const tuning = resolveCompactionTuning(chatCompressionSettings);
+    const contentGeneratorConfig = config.getContentGeneratorConfig();
+    const contextLimit =
+      contentGeneratorConfig.contextWindowSize ?? DEFAULT_TOKEN_LIMIT;
 
     // Cheap gates first — these don't need the curated history. Forward
     // originalTokenCount on NOOP (matching the threshold-gate branch below)
@@ -384,9 +387,6 @@ export class ChatCompressionService {
       // guarantees `prompt + max_tokens ≤ window`, so no output budget needs
       // to be reserved out of the window here (this replaced the
       // #5957/#6266 reservedOutputTokens machinery).
-      const contextLimit =
-        config.getContentGeneratorConfig()?.contextWindowSize ??
-        DEFAULT_TOKEN_LIMIT;
       const { auto } = computeThresholds(
         contextLimit,
         config.getAutoCompactThreshold(),
@@ -646,15 +646,42 @@ export class ChatCompressionService {
 
     let summaryResult: GenerateTextResult | undefined;
     let usedCacheSharing = false;
-    const contextWindowSize =
-      config.getContentGeneratorConfig().contextWindowSize ??
-      DEFAULT_TOKEN_LIMIT;
+    const sharedRequestText =
+      `${systemInstruction}\n\n` +
+      'Do not call tools; tool execution is disabled for this request. ' +
+      'First, reason in your <analysis> block. Then, produce the <state_snapshot> XML.';
     const sharedPromptTokenCount =
-      opts.precomputedEffectiveTokens ?? originalTokenCount;
+      opts.precomputedEffectiveTokens ??
+      originalTokenCount + (chat.getLastOutputTokenCount?.() ?? 0);
+    const sharedDirectiveTokenCount = Math.ceil(
+      sharedRequestText.length / CHARS_PER_TOKEN,
+    );
+    const usesMainModel = effectiveCompactionModel === config.getModel();
+    const providerSupportsCacheSharing =
+      supportsCompressionCacheSharing(config);
+    const hasProviderTokenCount = (chat.getLastPromptTokenCount?.() ?? 0) > 0;
+    const sharedRequestFits =
+      sharedPromptTokenCount +
+        sharedDirectiveTokenCount +
+        COMPACT_MAX_OUTPUT_TOKENS <=
+      contextLimit;
     const canShareCache =
-      effectiveCompactionModel === config.getModel() &&
-      supportsCompressionCacheSharing(config) &&
-      sharedPromptTokenCount + COMPACT_MAX_OUTPUT_TOKENS <= contextWindowSize;
+      usesMainModel &&
+      providerSupportsCacheSharing &&
+      hasProviderTokenCount &&
+      sharedRequestFits;
+    if (!canShareCache) {
+      const reason = !usesMainModel
+        ? 'distinct compaction model'
+        : !providerSupportsCacheSharing
+          ? 'provider does not support cache sharing'
+          : !hasProviderTokenCount
+            ? 'no provider token-count anchor'
+            : `shared request exceeds context window: prompt=${sharedPromptTokenCount}, ` +
+              `directive=${sharedDirectiveTokenCount}, reserve=${COMPACT_MAX_OUTPUT_TOKENS}, ` +
+              `window=${contextLimit}`;
+      debugLogger.debug(`[compaction] skipping cache sharing: ${reason}`);
+    }
     if (canShareCache) {
       try {
         const generationConfig = {
@@ -671,10 +698,7 @@ export class ChatCompressionService {
               role: 'user',
               parts: [
                 {
-                  text:
-                    `${systemInstruction}\n\n` +
-                    'Do not call tools; tool execution is disabled for this request. ' +
-                    'First, reason in your <analysis> block. Then, produce the <state_snapshot> XML.',
+                  text: sharedRequestText,
                 },
               ],
             },
@@ -683,8 +707,7 @@ export class ChatCompressionService {
           systemInstruction: mainSystemInstruction,
           config: {
             ...generationConfig,
-            ...(config.getContentGeneratorConfig().authType ===
-            AuthType.USE_ANTHROPIC
+            ...(contentGeneratorConfig.authType === AuthType.USE_ANTHROPIC
               ? {
                   thinkingConfig: {
                     ...generationConfig.thinkingConfig,

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -55,6 +55,9 @@ const debugLogger = createDebugLogger('COMPRESSION');
  */
 export const COMPACT_MAX_OUTPUT_TOKENS = 20_000;
 
+const COMPRESSION_REQUEST_DIRECTIVE =
+  'First, reason in your <analysis> block. Then, produce the <state_snapshot> XML.';
+
 /**
  * Default proportional auto-compaction threshold — the preferred trigger and an
  * upper bound on how high it can sit. See computeThresholds for how it combines
@@ -237,12 +240,10 @@ export interface CompressOptions {
    */
   pendingUserMessage?: Content;
   /**
-   * Pre-computed effective-token count from `estimatePromptTokens()`. When
-   * provided, the cheap-gate skips its own estimation pass (and the
-   * accompanying `chat.getHistoryShallow(true)` clone). Callers that already
-   * computed this value upstream — primarily `sendMessageStream` for the
-   * hard-tier rescue — pass it through to avoid duplicate work.
-   * (review #4168 R1.3 / R1.4)
+   * Pre-computed all-inclusive effective-token count. This is normally from
+   * `estimatePromptTokens()`, or from a provider-reported count after reactive
+   * overflow. When provided, the cheap-gate skips its estimation pass and the
+   * cache-sharing preflight does not add the previous model output again.
    */
   precomputedEffectiveTokens?: number;
   /** Per-request overrides used by the main turn, including transient tools. */
@@ -626,7 +627,7 @@ export class ChatCompressionService {
             role: 'user',
             parts: [
               {
-                text: 'First, reason in your <analysis> block. Then, produce the <state_snapshot> XML.',
+                text: COMPRESSION_REQUEST_DIRECTIVE,
               },
             ],
           },
@@ -649,7 +650,7 @@ export class ChatCompressionService {
     const sharedRequestText =
       `${systemInstruction}\n\n` +
       'Do not call tools; tool execution is disabled for this request. ' +
-      'First, reason in your <analysis> block. Then, produce the <state_snapshot> XML.';
+      COMPRESSION_REQUEST_DIRECTIVE;
     const sharedPromptTokenCount =
       opts.precomputedEffectiveTokens ??
       originalTokenCount + (chat.getLastOutputTokenCount?.() ?? 0);

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -533,6 +533,10 @@ export class ChatCompressionService {
         )
       : 0;
 
+    // Lazy: the cold fallback input is slimmed on demand. The original
+    // history keeps its media: the shared request needs it for cache-prefix
+    // identity, and the post-compact image restoration block reads it
+    // afterwards.
     let coldInput: ReturnType<typeof slimCompactionInput> | undefined;
     const getColdInput = () => {
       coldInput ??= slimCompactionInput(sideQueryHistory);
@@ -642,9 +646,15 @@ export class ChatCompressionService {
 
     let summaryResult: GenerateTextResult | undefined;
     let usedCacheSharing = false;
+    const contextWindowSize =
+      config.getContentGeneratorConfig().contextWindowSize ??
+      DEFAULT_TOKEN_LIMIT;
+    const sharedPromptTokenCount =
+      opts.precomputedEffectiveTokens ?? originalTokenCount;
     const canShareCache =
       effectiveCompactionModel === config.getModel() &&
-      supportsCompressionCacheSharing(config);
+      supportsCompressionCacheSharing(config) &&
+      sharedPromptTokenCount + COMPACT_MAX_OUTPUT_TOKENS <= contextWindowSize;
     if (canShareCache) {
       try {
         const generationConfig = {

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -533,18 +533,11 @@ export class ChatCompressionService {
         )
       : 0;
 
-    // Slim the side-query input: replace inlineData with placeholders.
-    // The original history (with images) is preserved separately for
-    // the post-compact image restoration block.
-    const slim = slimCompactionInput(sideQueryHistory);
-    if (slim.stats.imagesStripped > 0 || slim.stats.documentsStripped > 0) {
-      config
-        .getDebugLogger()
-        .debug(
-          `[chat-compression] slimmed ${slim.stats.imagesStripped} image(s) ` +
-            `and ${slim.stats.documentsStripped} document(s) from side-query payload`,
-        );
-    }
+    let coldInput: ReturnType<typeof slimCompactionInput> | undefined;
+    const getColdInput = () => {
+      coldInput ??= slimCompactionInput(sideQueryHistory);
+      return coldInput;
+    };
 
     // Hoist the system prompt so the guard can include it in the estimate.
     const systemInstruction = buildCompressionSystemPrompt(
@@ -574,7 +567,7 @@ export class ChatCompressionService {
         // prompt + max_tokens <= window, so all three terms count.
         const slimmedTokenEstimate =
           estimateContentTokens(
-            slim.slimmedHistory,
+            getColdInput().slimmedHistory,
             slimmingConfig.imageTokenEstimate,
           ) +
           Math.ceil(systemInstruction.length / CHARS_PER_TOKEN) +
@@ -595,8 +588,17 @@ export class ChatCompressionService {
 
     const abortSignal = signal ?? new AbortController().signal;
     abortSignal.throwIfAborted();
-    const runColdCompression = () =>
-      runSideQuery(config, {
+    const runColdCompression = () => {
+      const slim = getColdInput();
+      if (slim.stats.imagesStripped > 0 || slim.stats.documentsStripped > 0) {
+        config
+          .getDebugLogger()
+          .debug(
+            `[chat-compression] slimmed ${slim.stats.imagesStripped} image(s) ` +
+              `and ${slim.stats.documentsStripped} document(s) from side-query payload`,
+          );
+      }
+      return runSideQuery(config, {
         purpose: 'chat-compression',
         skipOutputLanguagePreference: true,
         model: effectiveCompactionModel,
@@ -636,13 +638,12 @@ export class ChatCompressionService {
         abortSignal,
         promptId,
       });
+    };
 
     let summaryResult: GenerateTextResult | undefined;
     let usedCacheSharing = false;
     const canShareCache =
       effectiveCompactionModel === config.getModel() &&
-      slim.stats.imagesStripped === 0 &&
-      slim.stats.documentsStripped === 0 &&
       supportsCompressionCacheSharing(config);
     if (canShareCache) {
       try {


### PR DESCRIPTION
## What this PR does

Chat compression now attempts the cache-sharing request for media-bearing histories instead of routing them directly to the dedicated summarizer. The request keeps the current session's system instruction, tool declarations, and complete history, including supported images and documents. Media slimming is deferred until the cache-sharing request actually needs to fall back.

The existing safety behavior remains intact: unusable snapshots, tool calls, and provider errors fall back once to the dedicated summarizer, while cancellation still aborts without a second request. Sessions using a distinct compaction model or a provider without the existing cache-sharing support remain on their previous path.

## Why it's needed

The initial cache-sharing implementation excluded every history containing media because the dedicated summarizer replaced media with placeholders before sending its request. For a multimodal main model, that means compression always takes the cold path even when the provider-facing system, tools, conversation, and media prefix could be reused. Preserving that prefix first avoids paying an uncached prefill solely because an image or document appeared earlier in the conversation.

## Reviewer Test Plan

### How to verify

Start a cache-enabled Anthropic or DashScope-compatible session with a multimodal model, send an image or PDF followed by enough context to compress, and run `/compress`. The first compression request should keep the complete media-bearing history and report a cache-sharing attempt. If that request returns a valid state snapshot, no dedicated side query should run. If the shared request fails or returns an unusable snapshot, exactly one dedicated side query should run with media replaced by placeholders.

Run the focused compression and base LLM client tests to confirm supported media remains in the shared request, unsupported media still follows normal modality filtering, and fallback performs media slimming only after the shared request fails.

### Evidence (Before & After)

Before: any media-bearing history bypassed cache sharing and immediately used the dedicated media-slimmed summarizer request. After: media-bearing histories use the cache-sharing request first, while the existing media-slimmed request is retained as the fallback. A live baseline/candidate cache-hit report will be posted as a separate PR comment.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local macOS worktree, Node.js 24, no sandbox. Focused tests: 171 passed. Full workspace build and typecheck passed. Targeted ESLint, Prettier, and `git diff --check` passed.

## Risk & Scope

- Main risk or tradeoff: Preserving supported media can increase the shared compression request's input size; provider rejection or an unusable response falls back once to the existing media-slimmed request.
- Not validated / out of scope: Windows and Linux were not tested locally. Live provider A/B cache measurements are reported separately in a PR comment.
- Breaking changes / migration notes: None.

## Linked Issues

Refs #8279

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

聊天压缩现在会让包含媒体的历史先尝试共享缓存请求，而不是直接路由到独立摘要器。请求会保留当前会话的系统指令、工具声明和完整历史，其中包括模型支持的图片与文档。只有共享缓存请求确实需要降级时，才会执行媒体瘦身。

原有安全行为保持不变：不可用的状态快照、工具调用和 provider 错误会降级一次到独立摘要器，取消操作仍会直接中止而不会发出第二个请求。使用独立压缩模型，或 provider 不在现有缓存共享支持范围内的会话，仍保持原有路径。

## 为什么需要它

最初的缓存共享实现会排除所有包含媒体的历史，因为独立摘要器会在发送请求前把媒体替换成占位符。对于多模态主模型，这意味着只要对话中出现过图片或文档，压缩就必然走冷路径，即使 provider 侧的系统指令、工具、对话和媒体前缀原本可以复用。先保留这个前缀，可以避免仅仅因为历史里存在媒体就支付一次未缓存的 prefill。

## Reviewer 测试计划

### 如何验证

使用多模态模型启动一个开启缓存的 Anthropic 或 DashScope-compatible 会话，发送图片或 PDF，再发送足够多的上下文并执行 `/compress`。第一次压缩请求应保留完整的含媒体历史，并记录一次缓存共享尝试。如果请求返回有效状态快照，则不应调用独立 side query。如果共享请求失败或返回不可用快照，则应恰好调用一次独立 side query，并将媒体替换为占位符。

运行聚焦的压缩与基础 LLM client 测试，确认模型支持的媒体会保留在共享请求中，不支持的媒体仍遵循正常的 modality 过滤，并且只有共享请求失败后 fallback 才执行媒体瘦身。

### 证据（修改前后）

修改前：任何包含媒体的历史都会绕过缓存共享，立即使用媒体瘦身后的独立摘要请求。修改后：包含媒体的历史会先使用缓存共享请求，同时保留原有媒体瘦身请求作为 fallback。真实 provider 的 baseline/candidate 缓存命中率报告会作为独立 PR 评论发布。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

本地 macOS worktree，Node.js 24，无 sandbox。聚焦测试 171 个通过。全仓 build 和 typecheck 通过。目标 ESLint、Prettier 和 `git diff --check` 通过。

## 风险与范围

- 主要风险或权衡：保留模型支持的媒体会增加共享压缩请求的输入大小；如果 provider 拒绝请求或响应不可用，会降级一次到现有的媒体瘦身请求。
- 未验证 / 范围外：未在本地测试 Windows 和 Linux。真实 provider 的 A/B 缓存测量会通过单独的 PR 评论报告。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Refs #8279

</details>
