### PR TITLE
fix(core): Clarify write_file prior-read guidance

### DIFF
--- a/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -167,6 +167,9 @@ Okay, I can write those tests. First, I'll read someFile.ts to understand its fu
 Now I'll look for existing or related test files to understand current testing conventions and dependencies.
 [tool_call: read_file for file_path '/path/to/existingTest.test.ts']
 (After reviewing existing tests and the file content)
+I'll check whether the intended test file already exists.
+[tool_call: read_file for file_path '/path/to/someFile.test.ts']
+(After read_file reports that /path/to/someFile.test.ts does not exist)
 [tool_call: write_file for file_path '/path/to/someFile.test.ts' with content '(test code content)']
 I've written the tests. Now I'll run the project's test command to verify them.
 [tool_call: run_shell_command for 'npm run test']
@@ -384,6 +387,9 @@ Okay, I can write those tests. First, I'll read someFile.ts to understand its fu
 Now I'll look for existing or related test files to understand current testing conventions and dependencies.
 [tool_call: read_file for file_path '/path/to/existingTest.test.ts']
 (After reviewing existing tests and the file content)
+I'll check whether the intended test file already exists.
+[tool_call: read_file for file_path '/path/to/someFile.test.ts']
+(After read_file reports that /path/to/someFile.test.ts does not exist)
 [tool_call: write_file for file_path '/path/to/someFile.test.ts' with content '(test code content)']
 I've written the tests. Now I'll run the project's test command to verify them.
 [tool_call: run_shell_command for 'npm run test']
@@ -575,6 +581,9 @@ Okay, I can write those tests. First, I'll read someFile.ts to understand its fu
 Now I'll look for existing or related test files to understand current testing conventions and dependencies.
 [tool_call: read_file for file_path '/path/to/existingTest.test.ts']
 (After reviewing existing tests and the file content)
+I'll check whether the intended test file already exists.
+[tool_call: read_file for file_path '/path/to/someFile.test.ts']
+(After read_file reports that /path/to/someFile.test.ts does not exist)
 [tool_call: write_file for file_path '/path/to/someFile.test.ts' with content '(test code content)']
 I've written the tests. Now I'll run the project's test command to verify them.
 [tool_call: run_shell_command for 'npm run test']
@@ -766,6 +775,9 @@ Okay, I can write those tests. First, I'll read someFile.ts to understand its fu
 Now I'll look for existing or related test files to understand current testing conventions and dependencies.
 [tool_call: read_file for file_path '/path/to/existingTest.test.ts']
 (After reviewing existing tests and the file content)
+I'll check whether the intended test file already exists.
+[tool_call: read_file for file_path '/path/to/someFile.test.ts']
+(After read_file reports that /path/to/someFile.test.ts does not exist)
 [tool_call: write_file for file_path '/path/to/someFile.test.ts' with content '(test code content)']
 I've written the tests. Now I'll run the project's test command to verify them.
 [tool_call: run_shell_command for 'npm run test']
@@ -957,6 +969,9 @@ Okay, I can write those tests. First, I'll read someFile.ts to understand its fu
 Now I'll look for existing or related test files to understand current testing conventions and dependencies.
 [tool_call: read_file for file_path '/path/to/existingTest.test.ts']
 (After reviewing existing tests and the file content)
+I'll check whether the intended test file already exists.
+[tool_call: read_file for file_path '/path/to/someFile.test.ts']
+(After read_file reports that /path/to/someFile.test.ts does not exist)
 [tool_call: write_file for file_path '/path/to/someFile.test.ts' with content '(test code content)']
 I've written the tests. Now I'll run the project's test command to verify them.
 [tool_call: run_shell_command for 'npm run test']
@@ -1148,6 +1163,9 @@ Okay, I can write those tests. First, I'll read someFile.ts to understand its fu
 Now I'll look for existing or related test files to understand current testing conventions and dependencies.
 [tool_call: read_file for file_path '/path/to/existingTest.test.ts']
 (After reviewing existing tests and the file content)
+I'll check whether the intended test file already exists.
+[tool_call: read_file for file_path '/path/to/someFile.test.ts']
+(After read_file reports that /path/to/someFile.test.ts does not exist)
 [tool_call: write_file for file_path '/path/to/someFile.test.ts' with content '(test code content)']
 I've written the tests. Now I'll run the project's test command to verify them.
 [tool_call: run_shell_command for 'npm run test']
@@ -1339,6 +1357,9 @@ Okay, I can write those tests. First, I'll read someFile.ts to understand its fu
 Now I'll look for existing or related test files to understand current testing conventions and dependencies.
 [tool_call: read_file for file_path '/path/to/existingTest.test.ts']
 (After reviewing existing tests and the file content)
+I'll check whether the intended test file already exists.
+[tool_call: read_file for file_path '/path/to/someFile.test.ts']
+(After read_file reports that /path/to/someFile.test.ts does not exist)
 [tool_call: write_file for file_path '/path/to/someFile.test.ts' with content '(test code content)']
 I've written the tests. Now I'll run the project's test command to verify them.
 [tool_call: run_shell_command for 'npm run test']
@@ -1530,6 +1551,9 @@ Okay, I can write those tests. First, I'll read someFile.ts to understand its fu
 Now I'll look for existing or related test files to understand current testing conventions and dependencies.
 [tool_call: read_file for file_path '/path/to/existingTest.test.ts']
 (After reviewing existing tests and the file content)
+I'll check whether the intended test file already exists.
+[tool_call: read_file for file_path '/path/to/someFile.test.ts']
+(After read_file reports that /path/to/someFile.test.ts does not exist)
 [tool_call: write_file for file_path '/path/to/someFile.test.ts' with content '(test code content)']
 I've written the tests. Now I'll run the project's test command to verify them.
 [tool_call: run_shell_command for 'npm run test']
@@ -1721,6 +1745,9 @@ Okay, I can write those tests. First, I'll read someFile.ts to understand its fu
 Now I'll look for existing or related test files to understand current testing conventions and dependencies.
 [tool_call: read_file for file_path '/path/to/existingTest.test.ts']
 (After reviewing existing tests and the file content)
+I'll check whether the intended test file already exists.
+[tool_call: read_file for file_path '/path/to/someFile.test.ts']
+(After read_file reports that /path/to/someFile.test.ts does not exist)
 [tool_call: write_file for file_path '/path/to/someFile.test.ts' with content '(test code content)']
 I've written the tests. Now I'll run the project's test command to verify them.
 [tool_call: run_shell_command for 'npm run test']
@@ -1929,6 +1956,11 @@ Now I'll look for existing or related test files to understand current testing c
 {"name": "read_file", "arguments": {"file_path": "/path/to/existingTest.test.ts"}}
 </tool_call>
 (After reviewing existing tests and the file content)
+I'll check whether the intended test file already exists.
+<tool_call>
+{"name": "read_file", "arguments": {"file_path": "/path/to/someFile.test.ts"}}
+</tool_call>
+(After read_file reports that /path/to/someFile.test.ts does not exist)
 <tool_call>
 {"name": "write_file", "arguments": {"file_path": "/path/to/someFile.test.ts", "content": "(test code content)"}}
 </tool_call>
@@ -2190,6 +2222,15 @@ Now I'll look for existing or related test files to understand current testing c
 </function>
 </tool_call>
 (After reviewing existing tests and the file content)
+I'll check whether the intended test file already exists.
+<tool_call>
+<function=read_file>
+<parameter=file_path>
+/path/to/someFile.test.ts
+</parameter>
+</function>
+</tool_call>
+(After read_file reports that /path/to/someFile.test.ts does not exist)
 <tool_call>
 <function=write_file>
 <parameter=file_path>
@@ -2423,6 +2464,11 @@ Now I'll look for existing or related test files to understand current testing c
 {"name": "read_file", "arguments": {"file_path": "/path/to/existingTest.test.ts"}}
 </tool_call>
 (After reviewing existing tests and the file content)
+I'll check whether the intended test file already exists.
+<tool_call>
+{"name": "read_file", "arguments": {"file_path": "/path/to/someFile.test.ts"}}
+</tool_call>
+(After read_file reports that /path/to/someFile.test.ts does not exist)
 <tool_call>
 {"name": "write_file", "arguments": {"file_path": "/path/to/someFile.test.ts", "content": "(test code content)"}}
 </tool_call>
@@ -2684,6 +2730,15 @@ Now I'll look for existing or related test files to understand current testing c
 </function>
 </tool_call>
 (After reviewing existing tests and the file content)
+I'll check whether the intended test file already exists.
+<tool_call>
+<function=read_file>
+<parameter=file_path>
+/path/to/someFile.test.ts
+</parameter>
+</function>
+</tool_call>
+(After read_file reports that /path/to/someFile.test.ts does not exist)
 <tool_call>
 <function=write_file>
 <parameter=file_path>
@@ -2896,6 +2951,9 @@ Okay, I can write those tests. First, I'll read someFile.ts to understand its fu
 Now I'll look for existing or related test files to understand current testing conventions and dependencies.
 [tool_call: read_file for file_path '/path/to/existingTest.test.ts']
 (After reviewing existing tests and the file content)
+I'll check whether the intended test file already exists.
+[tool_call: read_file for file_path '/path/to/someFile.test.ts']
+(After read_file reports that /path/to/someFile.test.ts does not exist)
 [tool_call: write_file for file_path '/path/to/someFile.test.ts' with content '(test code content)']
 I've written the tests. Now I'll run the project's test command to verify them.
 [tool_call: run_shell_command for 'npm run test']
@@ -3087,6 +3145,9 @@ Okay, I can write those tests. First, I'll read someFile.ts to understand its fu
 Now I'll look for existing or related test files to understand current testing conventions and dependencies.
 [tool_call: read_file for file_path '/path/to/existingTest.test.ts']
 (After reviewing existing tests and the file content)
+I'll check whether the intended test file already exists.
+[tool_call: read_file for file_path '/path/to/someFile.test.ts']
+(After read_file reports that /path/to/someFile.test.ts does not exist)
 [tool_call: write_file for file_path '/path/to/someFile.test.ts' with content '(test code content)']
 I've written the tests. Now I'll run the project's test command to verify them.
 [tool_call: run_shell_command for 'npm run test']
@@ -3278,6 +3339,9 @@ Okay, I can write those tests. First, I'll read someFile.ts to understand its fu
 Now I'll look for existing or related test files to understand current testing conventions and dependencies.
 <|tool_call>call:read_file{file_path:<|"|>/path/to/existingTest.test.ts<|"|>}<tool_call|>
 (After reviewing existing tests and the file content)
+I'll check whether the intended test file already exists.
+<|tool_call>call:read_file{file_path:<|"|>/path/to/someFile.test.ts<|"|>}<tool_call|>
+(After read_file reports that /path/to/someFile.test.ts does not exist)
 <|tool_call>call:write_file{file_path:<|"|>/path/to/someFile.test.ts<|"|>,content:<|"|>(test code content)<|"|>}<tool_call|>
 I've written the tests. Now I'll run the project's test command to verify them.
 <|tool_call>call:run_shell_command{command:<|"|>npm run test<|"|>}<tool_call|>

--- a/packages/core/src/core/prompts.test.ts
+++ b/packages/core/src/core/prompts.test.ts
@@ -574,6 +574,35 @@ describe('Model-specific tool call formats', () => {
     vi.stubEnv('SANDBOX', undefined);
   });
 
+  it.each([
+    ['generic', 'gpt-4'],
+    ['qwen-coder', 'qwen3-coder-7b'],
+    ['qwen-vl', 'qwen-vl-max'],
+    ['gemma4', 'gemma-4'],
+  ])(
+    'reads the write target before establishing absence in the %s tool-call example',
+    (_style, model) => {
+      vi.mocked(isGitRepository).mockReturnValue(false);
+      const prompt = getCoreSystemPrompt(undefined, model);
+      const exampleStart = prompt.indexOf('user: Write tests for someFile.ts');
+      const exampleEnd = prompt.indexOf('</example>', exampleStart);
+      const example = prompt.slice(exampleStart, exampleEnd);
+      const targetPath = example.indexOf('/path/to/someFile.test.ts');
+      const targetReadCall = example.lastIndexOf('read_file', targetPath);
+      const absenceResult = example.indexOf(
+        'After read_file reports that /path/to/someFile.test.ts does not exist',
+      );
+      const writeCall = example.indexOf('write_file');
+
+      expect(exampleStart).toBeGreaterThanOrEqual(0);
+      expect(exampleEnd).toBeGreaterThan(exampleStart);
+      expect(targetReadCall).toBeGreaterThanOrEqual(0);
+      expect(targetPath).toBeGreaterThan(targetReadCall);
+      expect(absenceResult).toBeGreaterThan(targetPath);
+      expect(writeCall).toBeGreaterThan(absenceResult);
+    },
+  );
+
   it('should use XML format for qwen3-coder model', () => {
     vi.mocked(isGitRepository).mockReturnValue(false);
     const prompt = getCoreSystemPrompt(undefined, 'qwen3-coder-7b');

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -690,6 +690,9 @@ Okay, I can write those tests. First, I'll read someFile.ts to understand its fu
 Now I'll look for existing or related test files to understand current testing conventions and dependencies.
 [tool_call: ${ToolNames.READ_FILE} for file_path '/path/to/existingTest.test.ts']
 (After reviewing existing tests and the file content)
+I'll check whether the intended test file already exists.
+[tool_call: ${ToolNames.READ_FILE} for file_path '/path/to/someFile.test.ts']
+(After read_file reports that /path/to/someFile.test.ts does not exist)
 [tool_call: ${ToolNames.WRITE_FILE} for file_path '/path/to/someFile.test.ts' with content '(test code content)']
 I've written the tests. Now I'll run the project's test command to verify them.
 [tool_call: ${ToolNames.SHELL} for 'npm run test']
@@ -830,6 +833,15 @@ Now I'll look for existing or related test files to understand current testing c
 </function>
 </tool_call>
 (After reviewing existing tests and the file content)
+I'll check whether the intended test file already exists.
+<tool_call>
+<function=${ToolNames.READ_FILE}>
+<parameter=file_path>
+/path/to/someFile.test.ts
+</parameter>
+</function>
+</tool_call>
+(After read_file reports that /path/to/someFile.test.ts does not exist)
 <tool_call>
 <function=${ToolNames.WRITE_FILE}>
 <parameter=file_path>
@@ -943,6 +955,11 @@ Now I'll look for existing or related test files to understand current testing c
 {"name": "${ToolNames.READ_FILE}", "arguments": {"file_path": "/path/to/existingTest.test.ts"}}
 </tool_call>
 (After reviewing existing tests and the file content)
+I'll check whether the intended test file already exists.
+<tool_call>
+{"name": "${ToolNames.READ_FILE}", "arguments": {"file_path": "/path/to/someFile.test.ts"}}
+</tool_call>
+(After read_file reports that /path/to/someFile.test.ts does not exist)
 <tool_call>
 {"name": "${ToolNames.WRITE_FILE}", "arguments": {"file_path": "/path/to/someFile.test.ts", "content": "(test code content)"}}
 </tool_call>
@@ -1025,6 +1042,9 @@ Okay, I can write those tests. First, I'll read someFile.ts to understand its fu
 Now I'll look for existing or related test files to understand current testing conventions and dependencies.
 <|tool_call>call:${ToolNames.READ_FILE}{file_path:<|"|>/path/to/existingTest.test.ts<|"|>}<tool_call|>
 (After reviewing existing tests and the file content)
+I'll check whether the intended test file already exists.
+<|tool_call>call:${ToolNames.READ_FILE}{file_path:<|"|>/path/to/someFile.test.ts<|"|>}<tool_call|>
+(After read_file reports that /path/to/someFile.test.ts does not exist)
 <|tool_call>call:${ToolNames.WRITE_FILE}{file_path:<|"|>/path/to/someFile.test.ts<|"|>,content:<|"|>(test code content)<|"|>}<tool_call|>
 I've written the tests. Now I'll run the project's test command to verify them.
 <|tool_call>call:${ToolNames.SHELL}{command:<|"|>npm run test<|"|>}<tool_call|>

--- a/packages/core/src/tools/write-file.test.ts
+++ b/packages/core/src/tools/write-file.test.ts
@@ -153,6 +153,26 @@ describe('WriteFileTool', () => {
     });
   }
 
+  describe('description', () => {
+    it('requires uncertain targets to be read before writing', () => {
+      const description = tool.schema.description;
+
+      expect(description).toContain(
+        'A request to create or generate a file does not establish that the target path is new.',
+      );
+      expect(description).toContain(
+        "Unless the target's absence or current text contents have already been established in this session",
+      );
+      expect(description).toContain('MUST use the read_file tool first');
+      expect(description).toContain(
+        'if the file does not exist, then create it',
+      );
+      expect(description).toContain(
+        'With prior-read enforcement enabled, blind overwrites are rejected.',
+      );
+    });
+  });
+
   describe('build', () => {
     it('should return an invocation for a valid absolute path within root', () => {
       const params = {

--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -775,7 +775,7 @@ export class WriteFileTool
     super(
       WriteFileTool.Name,
       ToolDisplayNames.WRITE_FILE,
-      `Writes content to a specified file in the local filesystem. The file_path argument MUST be an absolute path. Always construct it by combining the project root with the file's relative path (e.g. project root '/path/to/project/' + relative 'foo/bar.txt' = '/path/to/project/foo/bar.txt'). If the user provides a relative path, resolve it against the project root first.
+      `Writes content to a specified file in the local filesystem. A request to create or generate a file does not establish that the target path is new. Unless the target's absence or current text contents have already been established in this session, you MUST use the ${ToolNames.READ_FILE} tool first; if the file does not exist, then create it. With prior-read enforcement enabled, blind overwrites are rejected. The file_path argument MUST be an absolute path. Always construct it by combining the project root with the file's relative path (e.g. project root '/path/to/project/' + relative 'foo/bar.txt' = '/path/to/project/foo/bar.txt'). If the user provides a relative path, resolve it against the project root first.
 
 The user has the ability to modify \`content\`. If modified, this will be stated in the response.`,
       Kind.Edit,


### PR DESCRIPTION
## What this PR does

This PR makes the model-facing `write_file` contract explicit: a request to create or generate a path does not prove that the target is new, and a target with unknown existence or contents must be read before writing. It also aligns the generic, Qwen Coder, Qwen VL, and Gemma 4 tool-call examples with an exact-target `read_file → not found → write_file` sequence and adds deterministic schema and ordering coverage. The existing runtime enforcement remains unchanged.

## Why it's needed

The runtime already rejects blind overwrites with `EDIT_REQUIRES_PRIOR_READ`, but the previous tool description did not tell the model about that requirement and the built-in examples demonstrated writing an unknown target directly. As a result, create or generate requests could cause a failure-first `write_file → read_file → write_file` sequence. Exposing a consistent contract reduces avoidable tool failures while preserving direct creation for targets whose absence is already established.

## Reviewer Test Plan

### How to verify

Inspect the model-facing `write_file` schema and confirm that it distinguishes unknown targets from targets already established as absent or read. Generate the core system prompt for generic, Qwen Coder, Qwen VL, and Gemma 4 models and confirm that each test-file example reads the exact destination before treating it as absent and writing it. Run `cd packages/core && npx vitest run src/tools/write-file.test.ts src/core/prompts.test.ts src/core/prompt-tool-examples.test.ts`; all 172 tests should pass. Targeted ESLint, Prettier, core typecheck, and the repository build should also pass.

### Evidence (Before & After)

Before: in three isolated collision runs where an existing fixed path was described as a create or generate task, the model attempted `write_file` first in all three sessions and received `EDIT_REQUIRES_PRIOR_READ`.

After: with the strengthened description and aligned examples, one of three equivalent collision runs performed `read_file → write_file` without a prior-read error; the other two still recovered after an initial rejected write. Explicitly existing targets continued to use `read_file → write_file`, and an explicitly new target was created after `read_file` returned not found. This is a measurable but partial prompt-level improvement and does not claim to eliminate the runtime collision failure.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 26.4.1, Node.js v22.22.3, npm 10.9.8. Behavioral evidence used the repository-local development CLI with safe mode and stream-json output against `claude-opus-4-6`.

## Risk & Scope

- Main risk or tradeoff: Model behavior remains stochastic, and an uncertain genuinely new target may incur an additional `read_file` not-found round trip before creation.
- Not validated / out of scope: The final behavioral matrix could not be repeated with `qwen3.7-max` or `deepseek-v4-pro` because the local environment had an invalid API key for one and no available model for the other. Shell bypasses, runtime governance, and temporary-file naming are out of scope.
- Breaking changes / migration notes: None. No runtime policy, public API, configuration, error code, or migration changes are included.

## Linked Issues

Closes #8427

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 明确了模型可见的 `write_file` 契约：要求创建或生成路径并不能证明目标是新文件；当目标是否存在或当前内容尚未确定时，必须先读取再写入。同时将通用、Qwen Coder、Qwen VL 和 Gemma 4 的工具调用示例统一为精确目标的 `read_file → 不存在 → write_file` 顺序，并增加确定性的 schema 与调用顺序测试。现有运行时校验保持不变。

## 为什么需要

运行时已经会用 `EDIT_REQUIRES_PRIOR_READ` 拒绝盲覆盖，但此前工具描述没有向模型说明这一要求，内置示例还示范了直接写入未知目标。因此，创建或生成请求可能触发先失败再恢复的 `write_file → read_file → write_file` 序列。公开并统一这一契约可以减少可避免的工具失败，同时保留对已确认不存在目标的直接创建能力。

## Reviewer 测试计划

### 如何验证

检查模型收到的 `write_file` schema，确认其区分未知目标与已经确认不存在或已经读取的目标。分别生成通用、Qwen Coder、Qwen VL 和 Gemma 4 的核心系统提示，确认每个测试文件示例都会先读取精确目标，再根据不存在结果执行写入。运行 `cd packages/core && npx vitest run src/tools/write-file.test.ts src/core/prompts.test.ts src/core/prompt-tool-examples.test.ts`，应有 172 项测试全部通过。定向 ESLint、Prettier、core typecheck 和仓库 build 也应通过。

### 证据（修改前后）

修改前：在三个隔离碰撞会话中，实际已有的固定路径被描述为创建或生成任务，模型三次都首先调用 `write_file`，并收到 `EDIT_REQUIRES_PRIOR_READ`。

修改后：使用加强的描述和一致的示例后，三个等价碰撞会话中有一个执行了无 prior-read 错误的 `read_file → write_file`；另外两个仍在首次写入被拒绝后恢复。明确已有的目标继续执行 `read_file → write_file`，明确的新目标在 `read_file` 返回不存在后创建成功。这说明提示层有可测量但有限的改善，并不声称已经消除运行时碰撞失败。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

macOS 26.4.1、Node.js v22.22.3、npm 10.9.8。行为证据使用仓库本地开发 CLI、safe mode、stream-json 输出以及 `claude-opus-4-6` 模型。

## 风险与范围

- 主要风险或权衡：模型行为仍具有随机性；对于实际为新文件但状态未知的目标，创建前可能增加一次返回不存在的 `read_file` 往返。
- 未验证或范围外：由于本地环境对 `qwen3.7-max` 的 API key 无效且没有可用的 `deepseek-v4-pro` 模型，最终行为矩阵未能在这两个模型上重复。Shell 绕过、运行时治理和临时文件命名不在本次范围内。
- 破坏性变更或迁移说明：无。本 PR 不修改运行时策略、公共 API、配置、错误码或迁移。

## 关联 Issue

Closes #8427

</details>