### PR TITLE
ci: reduce SDK Java runner queueing

### DIFF
--- a/.github/workflows/sdk-java.yml
+++ b/.github/workflows/sdk-java.yml
@@ -48,7 +48,7 @@ concurrency:
 jobs:
   test:
     name: '${{ matrix.os }} / Java ${{ matrix.java }}'
-    runs-on: '${{ matrix.os }}'
+    runs-on: '${{ (matrix.os == ''ubuntu-latest'' && github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event_name == ''push'' || github.event.pull_request.head.repo.full_name == github.repository)) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(format(''["{0}"]'', matrix.os)) }}'
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -65,8 +65,33 @@ jobs:
           - os: 'windows-latest'
             java: '21'
     steps:
+      - name: 'Restore workspace ownership'
+        if: "${{ runner.environment == 'self-hosted' }}"
+        run: |-
+          set -uo pipefail
+          RUNNER_UID="$(id -u)"
+          RUNNER_GID="$(id -g)"
+          if [ "$RUNNER_UID" != "0" ]; then
+            chown -R "$RUNNER_UID:$RUNNER_GID" "$GITHUB_WORKSPACE" 2>/dev/null || sudo -n chown -R "$RUNNER_UID:$RUNNER_GID" "$GITHUB_WORKSPACE" || echo "::warning::could not restore workspace ownership; checkout may fail on leftover root-owned files"
+          fi
+          chmod -R u+rwX "$GITHUB_WORKSPACE" 2>/dev/null || sudo -n chmod -R u+rwX "$GITHUB_WORKSPACE" || echo "::warning::could not restore workspace write permissions; checkout may fail on leftover read-only files"
+
       - name: 'Checkout'
         uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
+        with:
+          ref: "${{ (runner.environment == 'self-hosted' && github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number)) || github.ref }}"
+          fetch-depth: 1
+
+      - name: 'Verify checkout includes expected head commit'
+        if: "${{ runner.environment == 'self-hosted' && github.event_name == 'pull_request' }}"
+        env:
+          EXPECTED_SHA: '${{ github.event.pull_request.head.sha }}'
+        run: |-
+          if ! git merge-base --is-ancestor "${EXPECTED_SHA}" HEAD; then
+            echo "::error::Checked out ref does not contain expected head ${EXPECTED_SHA}."
+            git log --oneline --decorate -5
+            exit 1
+          fi
 
       - name: 'Set up Java'
         uses: 'actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654' # v5.2.0
@@ -92,17 +117,56 @@ jobs:
 
   daemon-e2e:
     name: 'Real daemon E2E / Java 11'
-    runs-on: 'ubuntu-latest'
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event_name == ''push'' || github.event.pull_request.head.repo.full_name == github.repository)) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     timeout-minutes: 30
     steps:
+      - name: 'Restore workspace ownership'
+        if: "${{ runner.environment == 'self-hosted' }}"
+        run: |-
+          set -uo pipefail
+          RUNNER_UID="$(id -u)"
+          RUNNER_GID="$(id -g)"
+          if [ "$RUNNER_UID" != "0" ]; then
+            chown -R "$RUNNER_UID:$RUNNER_GID" "$GITHUB_WORKSPACE" 2>/dev/null || sudo -n chown -R "$RUNNER_UID:$RUNNER_GID" "$GITHUB_WORKSPACE" || echo "::warning::could not restore workspace ownership; checkout may fail on leftover root-owned files"
+          fi
+          chmod -R u+rwX "$GITHUB_WORKSPACE" 2>/dev/null || sudo -n chmod -R u+rwX "$GITHUB_WORKSPACE" || echo "::warning::could not restore workspace write permissions; checkout may fail on leftover read-only files"
+
       - name: 'Checkout'
         uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
+        with:
+          ref: "${{ (runner.environment == 'self-hosted' && github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number)) || github.ref }}"
+          fetch-depth: 1
 
-      - name: 'Set up Node.js'
+      - name: 'Verify checkout includes expected head commit'
+        if: "${{ runner.environment == 'self-hosted' && github.event_name == 'pull_request' }}"
+        env:
+          EXPECTED_SHA: '${{ github.event.pull_request.head.sha }}'
+        run: |-
+          if ! git merge-base --is-ancestor "${EXPECTED_SHA}" HEAD; then
+            echo "::error::Checked out ref does not contain expected head ${EXPECTED_SHA}."
+            git log --oneline --decorate -5
+            exit 1
+          fi
+
+      # Self-hosted can't reach nodejs.org reliably; reuse the machine's Node.
+      - name: 'Set up Node.js 22 (hosted)'
+        if: "${{ runner.environment == 'github-hosted' }}"
         uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # v6.4.0
         with:
           node-version: '22'
           cache: 'npm'
+
+      - name: 'Use pre-installed Node.js (self-hosted)'
+        if: "${{ runner.environment == 'self-hosted' }}"
+        run: |-
+          if ! command -v node >/dev/null 2>&1; then
+            echo "::error::Node.js is not on PATH for this self-hosted runner. Provision Node 22.x or set MAINTAINER_ECS_RUNNER_DISABLED=true."
+            exit 1
+          fi
+          echo "Using pre-installed Node $(node -v) / npm $(npm -v)"
+          if [[ "$(node -p 'process.versions.node.split(".")[0]')" != "22" ]]; then
+            echo "::warning::Expected Node 22.x but found $(node -v); daemon E2E will run against the runner's Node."
+          fi
 
       - name: 'Set up Java'
         uses: 'actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654' # v5.2.0

--- a/.github/workflows/sdk-java.yml
+++ b/.github/workflows/sdk-java.yml
@@ -42,8 +42,8 @@ permissions:
   contents: 'read'
 
 concurrency:
-  group: 'sdk-java-${{ github.event.pull_request.number || github.ref }}'
-  cancel-in-progress: "${{ github.event_name == 'pull_request' }}"
+  group: 'sdk-java-${{ github.event.pull_request.number || github.run_id }}'
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/.github/workflows/sdk-java.yml
+++ b/.github/workflows/sdk-java.yml
@@ -41,6 +41,10 @@ on:
 permissions:
   contents: 'read'
 
+concurrency:
+  group: 'sdk-java-${{ github.event.pull_request.number || github.ref }}'
+  cancel-in-progress: "${{ github.event_name == 'pull_request' }}"
+
 jobs:
   test:
     name: '${{ matrix.os }} / Java ${{ matrix.java }}'

--- a/.github/workflows/sdk-java.yml
+++ b/.github/workflows/sdk-java.yml
@@ -48,7 +48,7 @@ concurrency:
 jobs:
   test:
     name: '${{ matrix.os }} / Java ${{ matrix.java }}'
-    runs-on: '${{ (matrix.os == ''ubuntu-latest'' && github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event_name == ''push'' || github.event.pull_request.head.repo.full_name == github.repository)) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(format(''["{0}"]'', matrix.os)) }}'
+    runs-on: '${{ (matrix.os == ''ubuntu-latest'' && github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event_name == ''push'' || github.event.pull_request.head.repo.full_name == github.repository)) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || matrix.os }}'
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -80,7 +80,6 @@ jobs:
         uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
         with:
           ref: "${{ (runner.environment == 'self-hosted' && github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number)) || github.ref }}"
-          fetch-depth: 1
 
       - name: 'Verify checkout includes expected head commit'
         if: "${{ runner.environment == 'self-hosted' && github.event_name == 'pull_request' }}"
@@ -117,7 +116,7 @@ jobs:
 
   daemon-e2e:
     name: 'Real daemon E2E / Java 11'
-    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event_name == ''push'' || github.event.pull_request.head.repo.full_name == github.repository)) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event_name == ''push'' || github.event.pull_request.head.repo.full_name == github.repository)) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || ''ubuntu-latest'' }}'
     timeout-minutes: 30
     steps:
       - name: 'Restore workspace ownership'
@@ -135,7 +134,6 @@ jobs:
         uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
         with:
           ref: "${{ (runner.environment == 'self-hosted' && github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number)) || github.ref }}"
-          fetch-depth: 1
 
       - name: 'Verify checkout includes expected head commit'
         if: "${{ runner.environment == 'self-hosted' && github.event_name == 'pull_request' }}"


### PR DESCRIPTION
## What this PR does

Cancel stale SDK Java pull request runs when a newer commit is pushed to the same PR, and route trusted Linux Java jobs to the ECS runner pool. Fork pull requests, macOS, and Windows continue using GitHub-hosted runners.

The ECS path restores persistent workspace permissions before checkout, verifies the expected pull request head, reuses the runner's pre-installed Node.js 22 for daemon E2E, and retains the existing repository kill switch.

## Why it's needed

Superseded SDK Java runs currently remain queued or consume hosted Ubuntu capacity alongside the latest run. Even the newest run then spends roughly 20 minutes waiting for tests that execute in about one minute. The daemon E2E similarly spends substantial time queued before roughly nine minutes of work.

## Reviewer Test Plan

### How to verify

For a same-repository pull request that touches the SDK Java paths, confirm the Linux Java 11/17/21 jobs and real daemon E2E select the ECS runner pool. Confirm a fork pull request still selects GitHub-hosted Ubuntu, while macOS and Windows remain hosted. Push a newer commit to the same pull request and confirm the older SDK Java run is cancelled.

Set `MAINTAINER_ECS_RUNNER_DISABLED=true` and confirm Linux jobs fall back to GitHub-hosted Ubuntu.

### Evidence (Before & After)

A manual same-repository ECS smoke run exercised Java 11/17/21 Maven tests and the complete daemon E2E path: https://github.com/QwenLM/qwen-code/actions/runs/30794611067

- Java 11: 1m13s
- Java 17: 59s
- Java 21: 1m32s
- Real daemon E2E: 7m07s

The temporary smoke branch was deleted after the successful run.

### Tested on

| OS | Status |
| :--: | :--: |
| 🍏 macOS | Hosted routing unchanged; workflow validation passed |
| 🪟 Windows | Hosted routing unchanged; workflow validation passed |
| 🐧 Linux | ✅ ECS Java matrix and daemon E2E smoke; `actionlint`, `yamllint`, ShellCheck, Prettier, and `git diff --check` |

### Environment (optional)

QwenLM `ecs-qwen` self-hosted Linux runner pool.

## Risk & Scope

- Fork pull requests remain on GitHub-hosted runners; only QwenLM same-repository pull requests and trusted main/release pushes use ECS.
- `MAINTAINER_ECS_RUNNER_DISABLED=true` restores hosted Linux routing.
- Persistent runner workspace ownership and stale checkout risks use the same guards as the existing main CI workflow.
- The repository-wide policy allowing previously approved fork contributors to modify workflow files is pre-existing and is not changed here; stronger isolation would require base-controlled workflows or ephemeral untrusted runners.
- This PR itself is cross-repository, so its regular SDK Java checks remain hosted; the ECS path was validated separately with the linked manual run.
- No production code or release workflow changes.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

本 PR 同时处理两类 SDK Java 排队浪费：同一 PR 有新提交时取消旧运行；仓库内可信 PR 及 main/release push 的 Linux Java 任务改走 ECS。fork PR、macOS 和 Windows 仍使用 GitHub Hosted Runner。

已通过同仓临时分支在 ECS 上实测 Java 11/17/21 Maven 测试及完整 daemon E2E，全部通过；临时分支随后已删除。

</details>