### PR TITLE
fix(core): stop Goal retries after evidence catalog exhaustion

### DIFF
--- a/packages/core/src/goals/goal-evidence.ts
+++ b/packages/core/src/goals/goal-evidence.ts
@@ -5,10 +5,11 @@
  */
 
 import type { Part } from '@google/genai';
-import type {
-  GoalRecord,
-  GoalTerminalProposal,
-  GoalTurnPermit,
+import {
+  GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON,
+  type GoalRecord,
+  type GoalTerminalProposal,
+  type GoalTurnPermit,
 } from './goal-protocol.js';
 
 const CATALOG_PREVIEW_LIMIT = 240;
@@ -179,7 +180,7 @@ export function validateGoalEvidenceReferences(
   if (input.proposal.status === 'complete' && analysis.catalogTruncated) {
     throw new InvalidGoalEvidenceReferenceError(
       'catalog_truncated',
-      'A complete Goal proposal requires an exhaustive bounded evidence catalog.',
+      GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON,
     );
   }
   const evidenceBytes = citedRecords.reduce(

--- a/packages/core/src/goals/goal-protocol.ts
+++ b/packages/core/src/goals/goal-protocol.ts
@@ -7,6 +7,8 @@
 export const GOAL_STATE_VERSION = 2 as const;
 export const GOAL_PROPOSAL_REASON_MAX_CHARACTERS = 8_000;
 export const GOAL_PROPOSAL_REASON_MAX_BYTES = 16_000;
+export const GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON =
+  'The current Goal revision exceeded the bounded evidence catalog. Automatic retries cannot recover. Edit or replace the Goal before resuming it.';
 
 export const PAUSED_GOAL_SYSTEM_REMINDER =
   '<system-reminder>\nThe Goal is paused. Do not continue its objective unless the user resumes it. Treat this message as ordinary conversation.\n</system-reminder>';

--- a/packages/core/src/goals/goal-reducer.ts
+++ b/packages/core/src/goals/goal-reducer.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON,
   GOAL_STATE_VERSION,
   type GoalControlRequest,
   type GoalRecord,
@@ -119,6 +120,15 @@ export function reduceGoalControl(
   if (current.status === 'active') {
     throw new GoalInvalidTransitionError(
       'An active Goal cannot be resumed',
+      snapshotOf(current),
+    );
+  }
+  if (
+    current.status === 'usage_limited' &&
+    current.lastReason === GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON
+  ) {
+    throw new GoalInvalidTransitionError(
+      'An evidence-limited Goal cannot be resumed; edit or replace the Goal first',
       snapshotOf(current),
     );
   }

--- a/packages/core/src/goals/goal-runtime.test.ts
+++ b/packages/core/src/goals/goal-runtime.test.ts
@@ -371,6 +371,87 @@ describe('goal runtime', () => {
     expect(host.started).toHaveLength(2);
   });
 
+  it('stops continuations when completion evidence exceeds the catalog', async () => {
+    const journal = fakeGoalJournal();
+    let records: readonly RuntimeRecord[] = [];
+    const evidenceSource = fakeEvidenceSource(() => records);
+    const verifier: GoalVerifier = vi.fn();
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal, evidenceSource, verifier });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'deliver result' });
+    const permit = host.started[0];
+    const cursorId = runtime.getSnapshot().goal!.evidenceCursor.recordId!;
+    records = [
+      verifierEvidenceRecords(permit, cursorId)[0]!,
+      ...Array.from({ length: 101 }, (_, index) => ({
+        ...verifierEvidenceRecords(
+          permit,
+          cursorId,
+          `assistant-evidence-${index}`,
+        )[1]!,
+        message: {
+          role: 'model',
+          parts: [{ text: `Delivered result ${index}` }],
+        },
+      })),
+    ];
+    runtime.recordTerminalProposal(permit, {
+      status: 'complete',
+      reason: 'Delivered',
+      evidenceRefs: ['assistant-evidence-100'],
+    });
+    const causes: Array<GoalStateCause | undefined> = [];
+    runtime.subscribe((_snapshot, cause) => causes.push(cause));
+
+    await runtime.finishTurn(permit);
+
+    expect(verifier).not.toHaveBeenCalled();
+    expect(runtime.getSnapshot()).toMatchObject({
+      activity: 'idle',
+      goal: {
+        status: 'usage_limited',
+        lastReason: expect.stringContaining('bounded evidence catalog'),
+      },
+    });
+    expect(journal.appended.map((payload) => payload.cause)).toEqual([
+      'create',
+      'turn_finished',
+      'usage_limited',
+    ]);
+    expect(causes).toEqual(['turn_finished', 'usage_limited']);
+    expect(host.started).toHaveLength(1);
+
+    await expect(
+      runtime.dispatch({
+        action: 'resume',
+        expectedGoalId: permit.goalId,
+        expectedRevision: permit.revision,
+      }),
+    ).rejects.toThrow('edit or replace');
+    expect(host.started).toHaveLength(1);
+
+    const edited = await runtime.dispatch({
+      action: 'edit',
+      objective: 'deliver result',
+      expectedGoalId: permit.goalId,
+      expectedRevision: permit.revision,
+    });
+    expect(edited.snapshot.goal).toMatchObject({
+      status: 'usage_limited',
+      revision: 2,
+      lastReason: undefined,
+    });
+    expect(edited.snapshot.goal?.evidenceCursor.recordId).not.toBe(cursorId);
+    await runtime.dispatch({
+      action: 'resume',
+      expectedGoalId: permit.goalId,
+      expectedRevision: 2,
+    });
+    expect(runtime.getSnapshot().goal?.status).toBe('active');
+    expect(host.started).toHaveLength(2);
+  });
+
   it.each([
     ['flush', new Error('flush failed')],
     ['read', new Error('read failed')],

--- a/packages/core/src/goals/goal-runtime.ts
+++ b/packages/core/src/goals/goal-runtime.ts
@@ -583,10 +583,13 @@ export function createGoalRuntime(
     } catch (error) {
       if (attempt.controller.signal.aborted) return;
       if (error instanceof InvalidGoalEvidenceReferenceError) {
-        outcome = {
-          kind: 'decision',
-          result: { decision: 'reject', reason: error.message },
-        };
+        outcome =
+          error.code === 'catalog_truncated'
+            ? { kind: 'usage_limited', reason: error.message }
+            : {
+                kind: 'decision',
+                result: { decision: 'reject', reason: error.message },
+              };
       } else {
         const reason =
           error instanceof EvidenceSourceUnavailableError

--- a/packages/core/src/goals/goal-tools.test.ts
+++ b/packages/core/src/goals/goal-tools.test.ts
@@ -387,8 +387,11 @@ describe('UpdateGoalTool', () => {
     expect(recordTerminalProposal).not.toHaveBeenCalled();
   });
 
-  it('rejects completion when the evidence catalog is truncated', async () => {
-    const recordTerminalProposal = vi.fn();
+  it('queues truncated completion for boundary classification', async () => {
+    const recordTerminalProposal = vi.fn(() => ({
+      recorded: true,
+      readyForVerification: true,
+    }));
     const runtime = {
       getGoalForWorker: vi.fn().mockResolvedValue({
         goalId: permit.goalId,
@@ -437,11 +440,11 @@ describe('UpdateGoalTool', () => {
     const result = await invocation.execute(new AbortController().signal);
 
     expect(JSON.parse(String(result.llmContent))).toMatchObject({
-      proposalRecorded: false,
-      readyForVerification: false,
-      error: expect.stringContaining('not provably exhaustive'),
+      proposalRecorded: true,
+      readyForVerification: true,
     });
-    expect(recordTerminalProposal).not.toHaveBeenCalled();
+    expect(result.terminateTurn).toBe(true);
+    expect(recordTerminalProposal).toHaveBeenCalledOnce();
   });
 
   it('records one proposal while leaving the Goal active', async () => {

--- a/packages/core/src/goals/goal-tools.ts
+++ b/packages/core/src/goals/goal-tools.ts
@@ -183,12 +183,6 @@ class UpdateGoalInvocation extends BaseToolInvocation<
         };
       }
       const citedEvidenceRefs = new Set(normalizedEvidenceRefs);
-      if (
-        this.params.status === 'complete' &&
-        view.evidenceCatalog?.truncated
-      ) {
-        return truncatedCatalogResult();
-      }
       const uncitedCurrentDeliveredOutput = evidenceEntries
         .filter(
           (entry) =>
@@ -379,21 +373,6 @@ async function workerViewForPermit(
   } finally {
     if (onAbort) signal.removeEventListener('abort', onAbort);
   }
-}
-
-function truncatedCatalogResult(): GoalToolResult {
-  const error =
-    'The bounded evidence catalog is truncated, so current-turn output is not provably exhaustive. Continue in a new Goal turn with a smaller evidence set.';
-  return {
-    llmContent: JSON.stringify({
-      proposalRecorded: false,
-      readyForVerification: false,
-      goalLifecycleChanged: false,
-      error,
-    }),
-    returnDisplay:
-      'Goal proposal was not recorded because its evidence catalog is truncated.',
-  };
 }
 
 function recordTerminalProposalForPermit(


### PR DESCRIPTION
## What this PR does

This PR stops Goal mode from scheduling endless synthetic continuation turns after a completion attempt exceeds the bounded evidence catalog. The completion proposal now reaches the verification boundary, where catalog exhaustion transitions the Goal to `usage_limited`; direct resume is rejected until the user edits the Goal revision or replaces the Goal.

## Why it's needed

In long-running Goal sessions, the evidence catalog can exceed its entry or byte limit. The previous worker-side check rejected every completion proposal while leaving the Goal active, and each automatic continuation added more transcript evidence, making recovery impossible and creating an unbounded retry loop.

## Reviewer Test Plan

### How to verify

- Create an active Goal with more than 100 eligible evidence records, submit a completion proposal using a currently visible evidence reference, and finish the turn. Confirm the Goal becomes idle with status `usage_limited`, the verifier is not called, and no second synthetic continuation starts.
- Attempt to resume the same revision and confirm it is rejected with guidance to edit or replace the Goal.
- Edit the objective, confirm the revision and evidence cursor change, then resume and confirm exactly one fresh Goal turn starts.
- Confirm other invalid evidence-reference failures continue to use the existing verifier-rejection path.

### Evidence (Before & After)

Before: completion returned `proposalRecorded: false` because the catalog was truncated, the Goal remained active, and automatic continuation retried indefinitely.

After: the proposal terminates the current turn once, catalog exhaustion records `usage_limited`, and the host does not start another continuation. Focused verification passed with 159 tests across the evidence, tool, runtime, and reducer suites.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Node.js 24.14.1; focused Vitest suites, Core typecheck/build, ESLint, Prettier, and `git diff --check` passed locally.

## Risk & Scope

- Main risk or tradeoff: a completion proposal with a truncated catalog now stops autonomously instead of retrying; recovery intentionally requires a new evidence revision through edit or replacement.
- Not validated / out of scope: end-to-end TUI rendering on Windows and Linux; unrelated existing CLI workspace typecheck failures.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 修复 Goal 模式在完成提案超过有界证据目录后不断创建 synthetic continuation turn 的问题。现在完成提案会进入验证边界，目录耗尽会把 Goal 转为 `usage_limited`；同一 revision 不能直接恢复，用户需要编辑 Goal revision 或替换 Goal。

## 为什么需要

长时间运行的 Goal 会话可能超过证据目录的条数或字节限制。此前 worker 侧会拒绝每一次完成提案，但仍保持 Goal active；每次自动续跑又会增加 transcript 证据，使会话无法恢复并形成无界重试循环。

## Reviewer 测试计划

### 如何验证

- 创建包含超过 100 条有效证据记录的 active Goal，使用当前可见的证据引用提交完成提案并结束 turn。确认 Goal 进入 idle / `usage_limited`，verifier 未被调用，且不会启动第二个 synthetic continuation。
- 尝试直接恢复同一 revision，确认系统拒绝并提示编辑或替换 Goal。
- 编辑目标，确认 revision 和 evidence cursor 更新；随后恢复并确认只启动一个新的 Goal turn。
- 确认其他无效 evidence reference 仍沿用原有 verifier rejection 路径。

### Before / After 证据

修复前：目录截断时完成提案返回 `proposalRecorded: false`，Goal 保持 active，自动续跑会无限重试。

修复后：提案只结束当前 turn 一次，目录耗尽被记录为 `usage_limited`，host 不再启动后续 continuation。证据、工具、runtime 和 reducer 的 159 个聚焦测试全部通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境

Node.js 24.14.1；聚焦 Vitest、Core typecheck/build、ESLint、Prettier 和 `git diff --check` 均在本地通过。

## 风险与范围

- 主要风险或取舍：目录已截断的完成提案现在会停止自治重试；恢复必须通过编辑或替换创建新的证据 revision。
- 未验证 / 范围外：Windows 和 Linux 的端到端 TUI 展示；CLI workspace 中与本次修改无关的既有 typecheck 错误。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

N/A

</details>
