### PR TITLE
fix(autofix): normalize paginated fetches to one flat array per file

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2103,7 +2103,18 @@ jobs:
             # mutable head commit date: a base-sync HEAD would recreate the burial.
             CREATED_WM="$(jq -r '.createdAt // ""' <<< "${PR_META}")"
 
-            gh api "repos/${REPO}/issues/${PR}/comments" --paginate > "${WORKDIR}/ic.json"
+            # PAGINATION INVARIANT: gh api --paginate emits one JSON array PER
+            # PAGE (a >100-item PR produces "[…][…]"), so every fetch that
+            # lands in a WORKDIR json file is normalized to ONE flat array
+            # here at the fetch site — plain jq consumers then stay correct
+            # past 100 items, and slurp-style readers (jq -s add, --slurpfile
+            # + add) are unaffected because add is idempotent over a single
+            # array. Do NOT redirect --paginate output straight into a file:
+            # a takeover PR at the round cap has 100+ bot comments alone, and
+            # a multi-doc ic.json turns ROUND/EVAL_WM/REARM_KEY into
+            # multi-line strings that break the cap arithmetic silently.
+            gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
+              | jq -s 'add // []' > "${WORKDIR}/ic.json"
             # First-pickup engage ack: fork label events carry no secrets and
             # manual labels may race the ack job, so a takeover PR with NO
             # engage ack yet gets one here (identity-verified) — it is also
@@ -2124,7 +2135,8 @@ jobs:
                 add | [.[] | select((.user.login // "") == $ab)
                      | select(.body // "" | contains("<!-- takeover-ack engaged -->"))
                      | .created_at] | sort | last // ""' "${WORKDIR}/ic.json")"
-              gh api "repos/${REPO}/issues/${PR}/events" --paginate > "${WORKDIR}/pr-events.json" 2> /dev/null \
+              gh api "repos/${REPO}/issues/${PR}/events" --paginate 2> /dev/null \
+                | jq -s 'add // []' > "${WORKDIR}/pr-events.json" \
                 || echo '[]' > "${WORKDIR}/pr-events.json"
               LAST_LABELED_TS="$(jq -rs --arg lb "${TAKEOVER_LABEL}" '
                 add | [.[] | select(.event == "labeled")
@@ -2175,7 +2187,8 @@ jobs:
               fi
               if [[ "${SCAN_BOT_ACTOR}" == "${AUTOFIX_BOT}" ]]; then
                 if gh pr comment "${PR}" --repo "${REPO}" --body "$(printf '🤝 Takeover engaged: the autofix loop now manages this PR — it will address new review feedback and resolve base conflicts until the label is removed or the round cap is reached. Remove the `%s` label (or comment `%s stop`) to release.\n\n<details>\n<summary>中文说明</summary>\n\n🤝 已接管：autofix 循环现在管理此 PR —— 将持续处理新的评审反馈与 base 冲突，直到移除标签或达到轮次上限。移除 `%s` 标签（或评论 `%s stop`）即可释放。\n\n</details>\n\n<!-- takeover-ack engaged -->' "${TAKEOVER_LABEL}" "${TAKEOVER_COMMAND}" "${TAKEOVER_LABEL}" "${TAKEOVER_COMMAND}")"; then
-                  gh api "repos/${REPO}/issues/${PR}/comments" --paginate > "${WORKDIR}/ic.json" \
+                  gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
+                    | jq -s 'add // []' > "${WORKDIR}/ic.json" \
                     || echo "::warning::ic re-fetch after engage ack failed for #${PR}"
                 else
                   echo "::warning::first-pickup engage ack failed for #${PR}; window anchors on a later scan"
@@ -2461,8 +2474,10 @@ jobs:
               ' <<< "${CHECKS_JSON}")"
             fi
 
-            gh api "repos/${REPO}/pulls/${PR}/reviews" --paginate > "${WORKDIR}/rv.json"
-            gh api "repos/${REPO}/pulls/${PR}/comments" --paginate > "${WORKDIR}/rc.json"
+            gh api "repos/${REPO}/pulls/${PR}/reviews" --paginate \
+              | jq -s 'add // []' > "${WORKDIR}/rv.json"
+            gh api "repos/${REPO}/pulls/${PR}/comments" --paginate \
+              | jq -s 'add // []' > "${WORKDIR}/rc.json"
             N_REVIEWS="$(jq --arg wm "${EFF_WM}" --arg rb "${REVIEW_BOT}" --arg ab "${AUTOFIX_BOT}" \
               --argjson trust "${TRUSTED_ASSOC}" '
               [ .[]
@@ -2887,9 +2902,17 @@ jobs:
           echo "conflict=${CONFLICT}" >> "${GITHUB_OUTPUT}"
           echo "🔀 Conflict with base: ${CONFLICT}"
 
-          gh api "repos/${REPO}/pulls/${PR}/reviews" --paginate > "${WORKDIR}/rv.json"
-          gh api "repos/${REPO}/pulls/${PR}/comments" --paginate > "${WORKDIR}/rc.json"
-          gh api "repos/${REPO}/issues/${PR}/comments" --paginate > "${WORKDIR}/ic.json"
+          # Normalized to ONE flat array per file at the fetch site — gh api
+          # --paginate emits one array per page past 100 items, and NEWEST /
+          # LIVE_NEW below bind these files POSITIONALLY (.[0]..[3]): a
+          # multi-doc rv.json would shift rc/ic/checks into the wrong slots.
+          # See the scan step's PAGINATION INVARIANT comment.
+          gh api "repos/${REPO}/pulls/${PR}/reviews" --paginate \
+            | jq -s 'add // []' > "${WORKDIR}/rv.json"
+          gh api "repos/${REPO}/pulls/${PR}/comments" --paginate \
+            | jq -s 'add // []' > "${WORKDIR}/rc.json"
+          gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
+            | jq -s 'add // []' > "${WORKDIR}/ic.json"
           gh pr view "${PR}" --repo "${REPO}" \
             --json statusCheckRollup --jq '.statusCheckRollup // []' > "${WORKDIR}/checks.json" \
             2> /dev/null || echo '[]' > "${WORKDIR}/checks.json"
@@ -4456,7 +4479,7 @@ jobs:
               if [[ -f "${WORKDIR}/ic.json" ]]; then
                 COMMENTS_JSON="$(cat "${WORKDIR}/ic.json")"
               else
-                COMMENTS_JSON="$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate 2> /dev/null || true)"
+                COMMENTS_JSON="$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate 2> /dev/null | jq -s 'add // []' || true)"
               fi
               PRIOR_HEADS="$(jq -r --arg ab "${AUTOFIX_BOT}" --arg win "${WINDOW:-none}" '
                 [.[] | select((.user.login // "") == $ab)

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2183,9 +2183,19 @@ jobs:
               fi
               if [[ "${SCAN_BOT_ACTOR}" == "${AUTOFIX_BOT}" ]]; then
                 if gh pr comment "${PR}" --repo "${REPO}" --body "$(printf '🤝 Takeover engaged: the autofix loop now manages this PR — it will address new review feedback and resolve base conflicts until the label is removed or the round cap is reached. Remove the `%s` label (or comment `%s stop`) to release.\n\n<details>\n<summary>中文说明</summary>\n\n🤝 已接管：autofix 循环现在管理此 PR —— 将持续处理新的评审反馈与 base 冲突，直到移除标签或达到轮次上限。移除 `%s` 标签（或评论 `%s stop`）即可释放。\n\n</details>\n\n<!-- takeover-ack engaged -->' "${TAKEOVER_LABEL}" "${TAKEOVER_COMMAND}" "${TAKEOVER_LABEL}" "${TAKEOVER_COMMAND}")"; then
-                  gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
-                    | jq -s 'add // []' > "${WORKDIR}/ic.json" \
-                    || echo "::warning::ic re-fetch after engage ack failed for #${PR}"
+                  # Atomic re-fetch: ic.json already holds a successful full
+                  # fetch from above; a truncated stream must not leave it 0
+                  # bytes (jq -s fails only AFTER the redirect truncates) —
+                  # MARKERS on an empty file exits 0 with '' and the round
+                  # cap silently resets. Empty history must still never
+                  # masquerade as "no markers", so swap in the fresh copy
+                  # only when the whole pipeline succeeded.
+                  if gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
+                    | jq -s 'add // []' > "${WORKDIR}/ic.next.json"; then
+                    mv "${WORKDIR}/ic.next.json" "${WORKDIR}/ic.json"
+                  else
+                    echo "::warning::ic re-fetch after engage ack failed for #${PR}; window anchors on a later scan"
+                  fi
                 else
                   echo "::warning::first-pickup engage ack failed for #${PR}; window anchors on a later scan"
                 fi
@@ -4473,6 +4483,11 @@ jobs:
               if [[ -f "${WORKDIR}/ic.json" ]]; then
                 COMMENTS_JSON="$(cat "${WORKDIR}/ic.json")"
               else
+                # Truncated stream: jq -s fails and || true yields '' where
+                # the old code kept partial JSON — PRIOR_HEADS empties and
+                # duplicate-report suppression weakens for one round (a
+                # redundant comment at worst, never a cap reset); a total gh
+                # failure now yields '[]' instead of the old ''.
                 COMMENTS_JSON="$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate 2> /dev/null | jq -s 'add // []' || true)"
               fi
               PRIOR_HEADS="$(jq -r --arg ab "${AUTOFIX_BOT}" --arg win "${WINDOW:-none}" '

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2103,16 +2103,12 @@ jobs:
             # mutable head commit date: a base-sync HEAD would recreate the burial.
             CREATED_WM="$(jq -r '.createdAt // ""' <<< "${PR_META}")"
 
-            # PAGINATION INVARIANT: gh api --paginate emits one JSON array PER
-            # PAGE (a >100-item PR produces "[…][…]"), so every fetch that
-            # lands in a WORKDIR json file is normalized to ONE flat array
-            # here at the fetch site — plain jq consumers then stay correct
-            # past 100 items, and slurp-style readers (jq -s add, --slurpfile
-            # + add) are unaffected because add is idempotent over a single
-            # array. Do NOT redirect --paginate output straight into a file:
-            # a takeover PR at the round cap has 100+ bot comments alone, and
-            # a multi-doc ic.json turns ROUND/EVAL_WM/REARM_KEY into
-            # multi-line strings that break the cap arithmetic silently.
+            # PAGINATION NOTE: gh >= v2.31.0 merges all pages of a REST array
+            # endpoint into ONE flat JSON array (cli/cli#7190), so the WORKDIR
+            # files below are single arrays on every hosted runner. The jq
+            # normalizer pipes are retained as cheap defense-in-depth:
+            # idempotent over a flat array, and they would also normalize the
+            # per-page "[…][…]" shape that older gh versions emitted.
             gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
               | jq -s 'add // []' > "${WORKDIR}/ic.json"
             # First-pickup engage ack: fork label events carry no secrets and
@@ -2902,11 +2898,9 @@ jobs:
           echo "conflict=${CONFLICT}" >> "${GITHUB_OUTPUT}"
           echo "🔀 Conflict with base: ${CONFLICT}"
 
-          # Normalized to ONE flat array per file at the fetch site — gh api
-          # --paginate emits one array per page past 100 items, and NEWEST /
-          # LIVE_NEW below bind these files POSITIONALLY (.[0]..[3]): a
-          # multi-doc rv.json would shift rc/ic/checks into the wrong slots.
-          # See the scan step's PAGINATION INVARIANT comment.
+          # Same flat-array normalization as the scan step (see its PAGINATION
+          # NOTE). NEWEST / LIVE_NEW below bind these files POSITIONALLY
+          # (.[0]..[3]), so each must remain a single well-formed array.
           gh api "repos/${REPO}/pulls/${PR}/reviews" --paginate \
             | jq -s 'add // []' > "${WORKDIR}/rv.json"
           gh api "repos/${REPO}/pulls/${PR}/comments" --paginate \

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -2312,7 +2312,7 @@ describe('qwen-autofix workflow', () => {
     // candidate's file mis-dedups; a missing file kills the scan step under
     // -eo pipefail). Same textual-order technique as the hooks-severed pins.
     const icFetchAt = reviewScanJob.indexOf(
-      'gh api "repos/${REPO}/issues/${PR}/comments" --paginate > "${WORKDIR}/ic.json"',
+      'gh api "repos/${REPO}/issues/${PR}/comments" --paginate \\\n              | jq -s \'add // []\' > "${WORKDIR}/ic.json"',
     );
     const ackReadAt = reviewScanJob.indexOf('LAST_ENGAGE_ACK_TS=');
     expect(icFetchAt).toBeGreaterThan(-1);
@@ -2409,6 +2409,142 @@ describe('qwen-autofix workflow', () => {
     expect(workflow.split('test("^\\\\s*@qwen-code /") | not').length - 1).toBe(
       5,
     );
+  });
+
+  it('normalizes every paginated WORKDIR fetch to one flat array (>100-item PRs)', () => {
+    // gh api --paginate emits one JSON array PER PAGE, so a PR past 100
+    // comments/reviews produces "[…][…]". Every fetch that lands in a
+    // WORKDIR json file must pipe through the flat-array normalizer: the
+    // plain-jq consumers (MARKERS/REARM_KEY/ROUND, CAP_NOTICED,
+    // BASE_UPDATE_RECENT, LAST_REJECTION, PRIOR_TIMEOUTS, the milestone
+    // census) mis-aggregate on a multi-doc file — ROUND becomes a
+    // multi-line string and the cap arithmetic dies silently — while
+    // NEWEST/LIVE_NEW additionally bind rv/rc/ic/checks POSITIONALLY, so
+    // one multi-page file shifts every later slot. Slurp-style readers
+    // (jq -rs add, --slurpfile + add) are unaffected: add is idempotent
+    // over a single flat array.
+    expect(workflow).not.toContain('--paginate > "');
+    // scan ic + pr-events + ic re-fetch + scan rv/rc + prepare rv/rc/ic +
+    // report COMMENTS_JSON fallback = nine normalized fetch sites.
+    expect(workflow.split("jq -s 'add // []'").length - 1).toBe(9);
+
+    // Behavioral, against real jq: markers split across two pages. The raw
+    // page stream BREAKS the plain consumer (two outputs — the negative
+    // control), the normalized stream aggregates across the page boundary.
+    const markersProgram = reviewScanJob.match(
+      /MARKERS="\$\(jq -c --arg ab "\$\{AUTOFIX_BOT\}" '([\s\S]*?)' "\$\{WORKDIR\}\/ic\.json"\)"/,
+    )?.[1];
+    expect(markersProgram).toBeTruthy();
+    const roundProgram = reviewScanJob.match(
+      /ROUND="\$\(jq -r --arg key "\$\{REARM_KEY\}" '([\s\S]*?)' <<< "\$\{MARKERS\}"\)"/,
+    )?.[1];
+    expect(roundProgram).toBeTruthy();
+    const pageOne = JSON.stringify([
+      {
+        user: { login: 'bot' },
+        body: 'r3 <!-- autofix-eval ts=2026-07-01T00:00:00Z acted=true round=3 -->',
+        created_at: '2026-07-01T00:00:00Z',
+      },
+    ]);
+    const pageTwo = JSON.stringify([
+      {
+        user: { login: 'bot' },
+        body: 'r7 <!-- autofix-eval ts=2026-07-06T00:00:00Z acted=true round=7 -->',
+        created_at: '2026-07-06T00:00:00Z',
+      },
+    ]);
+    const rawMarkers = execFileSync(
+      'jq',
+      ['-c', '--arg', 'ab', 'bot', markersProgram],
+      { encoding: 'utf8', input: pageOne + pageTwo },
+    ).trim();
+    expect(rawMarkers.split('\n')).toHaveLength(2); // the pre-fix corruption
+    const flat = execFileSync('jq', ['-cs', 'add // []'], {
+      encoding: 'utf8',
+      input: pageOne + pageTwo,
+    });
+    const markers = execFileSync(
+      'jq',
+      ['-c', '--arg', 'ab', 'bot', markersProgram],
+      { encoding: 'utf8', input: flat },
+    ).trim();
+    expect(markers.split('\n')).toHaveLength(1);
+    const round = execFileSync(
+      'jq',
+      ['-r', '--arg', 'key', 'none', roundProgram],
+      { encoding: 'utf8', input: markers },
+    ).trim();
+    expect(round).toBe('7'); // max round crosses the page boundary
+
+    // Positional binding: NEWEST reads rv/rc/ic/checks as .[0]..[3]. With a
+    // normalized rv.json the page-2 review is found; feeding the RAW
+    // two-page rv.json instead shifts rc/ic into the wrong slots and the
+    // page-2 review timestamp is silently lost (negative control).
+    const newestProgram = workflow.match(
+      /NEWEST="\$\(jq -rs \\\n[\s\S]*?--argjson trust "\$\{TRUSTED_ASSOC\}" '([\s\S]*?)' "\$\{WORKDIR\}\/rv\.json"/,
+    )?.[1];
+    expect(newestProgram).toBeTruthy();
+    const rvPages =
+      JSON.stringify([
+        {
+          submitted_at: '2026-07-01T00:00:00Z',
+          user: { login: 'maint' },
+          author_association: 'MEMBER',
+          state: 'COMMENTED',
+        },
+      ]) +
+      JSON.stringify([
+        {
+          submitted_at: '2026-07-09T00:00:00Z',
+          user: { login: 'maint' },
+          author_association: 'MEMBER',
+          state: 'CHANGES_REQUESTED',
+        },
+      ]);
+    const dir = mkdtempSync(join(tmpdir(), 'autofix-paginate-'));
+    try {
+      const newestArgs = (rv) => [
+        '-rs',
+        '--arg',
+        'wm',
+        '',
+        '--arg',
+        'rb',
+        'qwen-code-ci-bot',
+        '--arg',
+        'ab',
+        'bot',
+        '--argjson',
+        'trust',
+        '["OWNER", "MEMBER", "COLLABORATOR"]',
+        newestProgram,
+        rv,
+        join(dir, 'rc.json'),
+        join(dir, 'ic.json'),
+        join(dir, 'checks.json'),
+      ];
+      writeFileSync(
+        join(dir, 'rv.json'),
+        execFileSync('jq', ['-cs', 'add // []'], {
+          encoding: 'utf8',
+          input: rvPages,
+        }),
+      );
+      writeFileSync(join(dir, 'rv-raw.json'), rvPages);
+      writeFileSync(join(dir, 'rc.json'), '[]');
+      writeFileSync(join(dir, 'ic.json'), '[]');
+      writeFileSync(join(dir, 'checks.json'), '[]');
+      const newest = execFileSync('jq', newestArgs(join(dir, 'rv.json')), {
+        encoding: 'utf8',
+      }).trim();
+      expect(newest).toBe('2026-07-09T00:00:00Z');
+      const shifted = execFileSync('jq', newestArgs(join(dir, 'rv-raw.json')), {
+        encoding: 'utf8',
+      }).trim();
+      expect(shifted).toBe('2026-07-01T00:00:00Z'); // page 2 lost pre-fix
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('raises the round cap to TAKEOVER_MAX_ROUNDS while the label is present', () => {
@@ -4627,7 +4763,7 @@ describe('qwen-autofix workflow', () => {
     expect(reviewScanStep).toContain('"${N_ISSUE_COMMENTS}" -eq 0');
     // review-address must also fetch ic.json and render issue-level comments.
     expect(workflow).toContain(
-      'repos/${REPO}/issues/${PR}/comments" --paginate > "${WORKDIR}/ic.json"',
+      'repos/${REPO}/issues/${PR}/comments" --paginate \\\n            | jq -s \'add // []\' > "${WORKDIR}/ic.json"',
     );
     expect(prepareBranchAndFeedbackStep).toContain(
       '2> /dev/null || echo \'[]\' > "${WORKDIR}/checks.json"',

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -116,6 +116,10 @@ const prepareBranchAndFeedbackStep =
   workflow.match(
     /- name: 'Prepare branch and feedback'[\s\S]*?(?=\n[ ]{6}- name: 'Post autofix status comment')/,
   )?.[0] ?? '';
+// Whitespace-tolerant shape of a normalized ic.json fetch: re-indenting or
+// re-wrapping the block must not break the presence/order pins using it.
+const normalizedIcFetch =
+  /issues\/\$\{PR\}\/comments" --paginate\s*\\?\s*\|\s*jq -s 'add \/\/ \[\]' > "\$\{WORKDIR\}\/ic\.json"/;
 const postStatusCommentStep =
   workflow.match(
     /- name: 'Post autofix status comment'[\s\S]*?(?=\n[ ]{6}- name: 'Triage and address')/,
@@ -2311,9 +2315,7 @@ describe('qwen-autofix workflow', () => {
     // ic.json fetch BEFORE the first ack-timestamp read (reading a previous
     // candidate's file mis-dedups; a missing file kills the scan step under
     // -eo pipefail). Same textual-order technique as the hooks-severed pins.
-    const icFetchAt = reviewScanJob.indexOf(
-      'gh api "repos/${REPO}/issues/${PR}/comments" --paginate \\\n              | jq -s \'add // []\' > "${WORKDIR}/ic.json"',
-    );
+    const icFetchAt = reviewScanJob.search(normalizedIcFetch);
     const ackReadAt = reviewScanJob.indexOf('LAST_ENGAGE_ACK_TS=');
     expect(icFetchAt).toBeGreaterThan(-1);
     expect(ackReadAt).toBeGreaterThan(icFetchAt);
@@ -2429,7 +2431,9 @@ describe('qwen-autofix workflow', () => {
     // its consumers, not the wire format current gh produces.
     expect(workflow).not.toContain('--paginate > "');
     // Pin the total --paginate code-site count so ANY new paginated site
-    // forces a deliberate test update, however it is spaced or line-wrapped.
+    // forces a deliberate test update, however it is spaced or line-wrapped:
+    // bump this count AND pipe the new site through the normalizer (bumping
+    // the count below too) — bumping this pin alone leaves toBe(9) green.
     expect(workflow.split('--paginate').length - 1).toBe(13);
     // scan ic + pr-events + ic re-fetch + scan rv/rc + prepare rv/rc/ic +
     // report COMMENTS_JSON fallback = nine normalized fetch sites.
@@ -4769,9 +4773,7 @@ describe('qwen-autofix workflow', () => {
     // The "nothing new" gate must check all three feedback sources.
     expect(reviewScanStep).toContain('"${N_ISSUE_COMMENTS}" -eq 0');
     // review-address must also fetch ic.json and render issue-level comments.
-    expect(workflow).toContain(
-      'repos/${REPO}/issues/${PR}/comments" --paginate \\\n            | jq -s \'add // []\' > "${WORKDIR}/ic.json"',
-    );
+    expect(prepareBranchAndFeedbackStep).toMatch(normalizedIcFetch);
     expect(prepareBranchAndFeedbackStep).toContain(
       '2> /dev/null || echo \'[]\' > "${WORKDIR}/checks.json"',
     );

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -2412,22 +2412,25 @@ describe('qwen-autofix workflow', () => {
   });
 
   it('normalizes every paginated WORKDIR fetch to one flat array (>100-item PRs)', () => {
-    // gh api --paginate emits one JSON array PER PAGE, so a PR past 100
-    // comments/reviews produces "[…][…]". Every fetch that lands in a
-    // WORKDIR json file must pipe through the flat-array normalizer: the
-    // plain-jq consumers (MARKERS/REARM_KEY/ROUND, CAP_NOTICED,
-    // BASE_UPDATE_RECENT, LAST_REJECTION, PRIOR_TIMEOUTS, the milestone
-    // census) mis-aggregate on a multi-doc file — ROUND becomes a
-    // multi-line string and the cap arithmetic dies silently — while
-    // NEWEST/LIVE_NEW additionally bind rv/rc/ic/checks POSITIONALLY, so
-    // one multi-page file shifts every later slot. Slurp-style readers
-    // (jq -rs add, --slurpfile + add) are unaffected: add is idempotent
-    // over a single flat array.
+    // gh >= v2.31.0 merges all pages of a REST array endpoint into ONE flat
+    // JSON array (cli/cli#7190), so on every hosted runner the WORKDIR files
+    // are already single arrays; the jq -s 'add // []' pipes are retained as
+    // cheap defense-in-depth. Every fetch that lands in a WORKDIR json file
+    // must still pipe through the normalizer: plain-jq consumers
+    // (MARKERS/REARM_KEY/ROUND, CAP_NOTICED, BASE_UPDATE_RECENT,
+    // LAST_REJECTION, PRIOR_TIMEOUTS, the milestone census) would
+    // mis-aggregate on a multi-doc file — ROUND becomes a multi-line string
+    // and the cap arithmetic dies silently — while NEWEST/LIVE_NEW
+    // additionally bind rv/rc/ic/checks POSITIONALLY, so one multi-page file
+    // shifts every later slot. Slurp-style readers (jq -rs add, --slurpfile
+    // + add) are unaffected: add is idempotent over a single flat array.
+    // The two-page fixtures below are synthetic (the per-page shape gh <
+    // v2.31.0 emitted): they exercise the jq mechanics of the normalizer and
+    // its consumers, not the wire format current gh produces.
     expect(workflow).not.toContain('--paginate > "');
-    // Pin the total --paginate occurrence count (13 code sites + 3 comment
-    // lines today) so ANY new paginated site forces a deliberate test
-    // update, however it is spaced or line-wrapped.
-    expect(workflow.split('--paginate').length - 1).toBe(16);
+    // Pin the total --paginate code-site count so ANY new paginated site
+    // forces a deliberate test update, however it is spaced or line-wrapped.
+    expect(workflow.split('--paginate').length - 1).toBe(13);
     // scan ic + pr-events + ic re-fetch + scan rv/rc + prepare rv/rc/ic +
     // report COMMENTS_JSON fallback = nine normalized fetch sites.
     expect(workflow.split("jq -s 'add // []'").length - 1).toBe(9);

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -2424,6 +2424,10 @@ describe('qwen-autofix workflow', () => {
     // (jq -rs add, --slurpfile + add) are unaffected: add is idempotent
     // over a single flat array.
     expect(workflow).not.toContain('--paginate > "');
+    // Pin the total --paginate occurrence count (13 code sites + 3 comment
+    // lines today) so ANY new paginated site forces a deliberate test
+    // update, however it is spaced or line-wrapped.
+    expect(workflow.split('--paginate').length - 1).toBe(16);
     // scan ic + pr-events + ic re-fetch + scan rv/rc + prepare rv/rc/ic +
     // report COMMENTS_JSON fallback = nine normalized fetch sites.
     expect(workflow.split("jq -s 'add // []'").length - 1).toBe(9);

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -2225,6 +2225,56 @@ describe('qwen-autofix workflow', () => {
     // under the fresh key.
     expect(reviewScanJob).toContain('takeover-ack engaged');
     expect(reviewScanJob).toContain('ic re-fetch after engage ack failed');
+    // The re-fetch must stay ATOMIC — write ic.next.json, then mv it onto
+    // ic.json only when the whole pipeline succeeded: ic.json already holds
+    // a successful full fetch, and a direct redirect truncates it BEFORE the
+    // pipeline runs, so a mid-stream jq failure would leave 0 bytes —
+    // MARKERS on empty input exits 0 with '' and the round cap silently
+    // resets. The other pins (--paginate count, normalizer count,
+    // not.toContain('--paginate > ')) all survive a 'simplification' to
+    // '> ic.json' under the if-guard, so pin the temp-file + swap shape.
+    expect(reviewScanJob).toMatch(
+      /issues\/\$\{PR\}\/comments" --paginate\s*\\?\s*\|\s*jq -s 'add \/\/ \[\]' > "\$\{WORKDIR\}\/ic\.next\.json"; then\s+mv "\$\{WORKDIR\}\/ic\.next\.json" "\$\{WORKDIR\}\/ic\.json"/,
+    );
+    // Behavioral, against real bash + jq: the truncation race the atomic
+    // pattern defends against. A direct redirect destroys the prior good
+    // fetch when the stream is truncated mid-page; the temp-file pattern
+    // keeps it on failure and still swaps in a fresh copy on success.
+    const priorFetch = JSON.stringify([
+      { user: { login: 'bot' }, body: 'prior fetch', id: 1 },
+    ]);
+    const truncatedStream = '[{"id":2'; // network cut mid-page
+    const atomicRefetch =
+      "if jq -s 'add // []' > ic.next.json; then mv ic.next.json ic.json; fi";
+    const atomicDir = mkdtempSync(join(tmpdir(), 'autofix-ic-atomic-'));
+    try {
+      writeFileSync(join(atomicDir, 'ic.json'), priorFetch);
+      // jq fails on the truncated stream…
+      expect(() =>
+        execFileSync('bash', ['-c', "jq -s 'add // []' > ic.json"], {
+          cwd: atomicDir,
+          input: truncatedStream,
+        }),
+      ).toThrow();
+      // …but only after the redirect already zeroed the good fetch.
+      expect(readFileSync(join(atomicDir, 'ic.json'), 'utf8')).toBe('');
+      writeFileSync(join(atomicDir, 'ic.json'), priorFetch);
+      execFileSync('bash', ['-c', atomicRefetch], {
+        cwd: atomicDir,
+        input: truncatedStream,
+      });
+      expect(readFileSync(join(atomicDir, 'ic.json'), 'utf8')).toBe(priorFetch);
+      const freshFetch = JSON.stringify([{ id: 3 }]);
+      execFileSync('bash', ['-c', atomicRefetch], {
+        cwd: atomicDir,
+        input: freshFetch,
+      });
+      expect(
+        JSON.parse(readFileSync(join(atomicDir, 'ic.json'), 'utf8')),
+      ).toEqual([{ id: 3 }]);
+    } finally {
+      rmSync(atomicDir, { recursive: true, force: true });
+    }
     // Ack dedup is author-filtered (a forged human marker must not suppress
     // the real ack) and re-armable: a takeover-label application newer than
     // the latest bot ack posts a fresh ack, resetting the round window.
@@ -2438,6 +2488,49 @@ describe('qwen-autofix workflow', () => {
     // scan ic + pr-events + ic re-fetch + scan rv/rc + prepare rv/rc/ic +
     // report COMMENTS_JSON fallback = nine normalized fetch sites.
     expect(workflow.split("jq -s 'add // []'").length - 1).toBe(9);
+    // Empty-input semantics: a total gh failure feeds the fallback an EMPTY
+    // stream, where the normalizer filter must yield '[]' and not 'null' —
+    // the PRIOR_HEADS consumer below iterates the result with .[], which
+    // dies on null ("Cannot iterate over null"). Every existing behavioral
+    // fixture is non-empty, where 'add // []' and bare 'add' are
+    // indistinguishable, so run the fallback's ACTUAL filter against empty
+    // stdin and pin the empty case explicitly.
+    const fallbackFilter = reviewAddressReportStep.match(
+      /COMMENTS_JSON="\$\(gh api "repos\/\$\{REPO\}\/issues\/\$\{PR\}\/comments" --paginate 2> \/dev\/null \| jq -s '([\s\S]*?)' \|\| true\)"/,
+    )?.[1];
+    expect(fallbackFilter).toBeTruthy();
+    expect(
+      execFileSync('jq', ['-s', fallbackFilter], {
+        encoding: 'utf8',
+        input: '',
+      }).trim(),
+    ).toBe('[]');
+    expect(
+      execFileSync('jq', ['-s', 'add'], {
+        encoding: 'utf8',
+        input: '',
+      }).trim(),
+    ).toBe('null'); // what dropping '// []' would silently produce
+    const priorHeadsProgram = reviewAddressReportStep
+      .match(
+        /PRIOR_HEADS="\$\(jq -r --arg ab "\$\{AUTOFIX_BOT\}" --arg win "\$\{WINDOW:-none\}" '([\s\S]*?)' <<< "\$\{COMMENTS_JSON\}"/,
+      )?.[1]
+      ?.replace(/\n {16}/g, '\n');
+    expect(priorHeadsProgram).toBeTruthy();
+    expect(() =>
+      execFileSync(
+        'jq',
+        ['-r', '--arg', 'ab', 'bot', '--arg', 'win', 'none', priorHeadsProgram],
+        { encoding: 'utf8', input: 'null' },
+      ),
+    ).toThrow(); // Cannot iterate over null
+    expect(
+      execFileSync(
+        'jq',
+        ['-r', '--arg', 'ab', 'bot', '--arg', 'win', 'none', priorHeadsProgram],
+        { encoding: 'utf8', input: '[]' },
+      ),
+    ).toBe(''); // cleanly empty — duplicate-report suppression stays intact
 
     // Behavioral, against real jq: markers split across two pages. The raw
     // page stream BREAKS the plain consumer (two outputs — the negative


### PR DESCRIPTION
## Summary

`gh api --paginate` emits **one JSON array per page**, so any PR past 100 comments / reviews / events produces a multi-document stream (`[…][…]`). `qwen-autofix.yml` already handles this correctly in a few readers (`jq -rs add`, `--slurpfile + add` — and `scripts/tests/qwen-autofix-workflow.test.js` has multi-page fixtures for exactly two of them), but **more than a dozen plain-jq consumers of the `WORKDIR` files silently mis-aggregate** on a multi-doc input:

- `MARKERS` / `REARM_AT` / `RED_HEAD` / `REARM_KEY` in the scan, and their `LIVE_*` mirrors in prepare, emit one result **per page**. `ROUND` then becomes a multi-line string, `[[ … -ge … ]]` arithmetic fails, and the **round cap silently stops holding** — on exactly the PRs (takeover, 100-round cap, ≥1 report comment per round) that reach page two first. Watermark comparisons and the `win=` marker fields corrupt the same way.
- `CAP_NOTICED`, `BASE_UPDATE_RECENT`, `LAST_REJECTION`, `PRIOR_TIMEOUTS`, the milestone census and the report-step consecutive-failure census all degrade identically.
- `NEWEST` and `LIVE_NEW` bind `rv/rc/ic/checks` **positionally** (`.[0]..[3]`): a two-page `rv.json` shifts `rc`/`ic` into the wrong slots and later feedback is silently lost.

## Fix

Normalize **at the fetch site**: every `--paginate` that lands in a `WORKDIR` json file (scan `ic.json` + re-fetch, `pr-events.json`, scan `rv/rc.json`, prepare `rv/rc/ic.json`, and the report step's `COMMENTS_JSON` fallback — nine sites) now pipes through `jq -s 'add // []'`, so each file holds ONE flat array.

- Existing slurp-style readers are unaffected: `add` is idempotent over a single flat array (`-s` re-wraps, `add` unwraps).
- Every plain consumer becomes correct past 100 items **with no program changes**, and future consumers can't get it wrong.
- Failure semantics preserved: the workflow's `defaults.run.shell: bash` gives `-eo pipefail`, so a failed `gh` fails the pipeline exactly where the bare redirect failed before; the `pr-events` / `COMMENTS_JSON` fallbacks keep their `'[]'` paths (fallback verified under `set -eo pipefail`).
- The check-runs / annotations / status-comment reads stay raw on purpose — they aggregate per page via `--jq` + slurp, line streams, or `.[][]` and were already pagination-safe.

## Tests

New behavioral case in `scripts/tests/qwen-autofix-workflow.test.js` (style matches the existing multi-page ack fixtures):

- runs the real extracted `MARKERS` → `ROUND` pipeline over a two-page fixture through the normalizer — markers on both pages survive and the max round crosses the page boundary; **negative control**: the raw stream yields two `MARKERS` lines (the pre-fix corruption).
- runs the real extracted positional `NEWEST` program with a normalized two-page `rv.json` — the page-2 review timestamp is found; **negative control**: the raw two-page file loses it to slot shift.
- shape assertions pin all nine normalized fetch sites and ban raw `--paginate` file redirects.

`npm run test:scripts` — 44 files, 895 passed / 9 skipped (baseline).

<details><summary>中文说明</summary>

## 摘要

`gh api --paginate` **每页输出一个独立 JSON 数组**，超过 100 条评论/评审/事件的 PR 会产生多文档流（`[…][…]`）。`qwen-autofix.yml` 中少数读取方处理正确（`jq -rs add`、`--slurpfile + add`），但 **十几处直接用 jq 消费 `WORKDIR` 文件的地方在多页输入下静默出错**：

- scan 的 `MARKERS` / `REARM_AT` / `RED_HEAD` / `REARM_KEY` 及 prepare 的 `LIVE_*` 镜像会**每页输出一份结果**，`ROUND` 变成多行字符串、`[[ … -ge … ]]` 算术失败、**轮次上限静默失效**——而最先到达第二页的恰恰是 takeover 长 PR（100 轮上限、每轮至少一条报告评论）。水位线比较与 `win=` 字段同样损坏。
- `CAP_NOTICED`、`BASE_UPDATE_RECENT`、`LAST_REJECTION`、`PRIOR_TIMEOUTS`、里程碑统计与 report 步骤的连败统计同样退化。
- `NEWEST` 与 `LIVE_NEW` **按位置**绑定 `rv/rc/ic/checks`（`.[0]..[3]`）：两页的 `rv.json` 会把 `rc`/`ic` 挤到错误的槽位，后续反馈被静默丢失。

## 修复

在**抓取点归一化**：所有落盘到 `WORKDIR` json 文件的 `--paginate`（共九处）统一经 `jq -s 'add // []'`，每个文件恒为单一扁平数组。

- 现有 slurp 型读取方不受影响（`add` 对单一数组幂等）；
- 所有普通消费者无需改动即对 100+ 条目正确，未来新增消费者也不会踩坑；
- 失败语义保持：工作流级 `defaults.run.shell: bash` 自带 `-eo pipefail`，`gh` 失败仍在原处失败；`pr-events` / `COMMENTS_JSON` 的 `'[]'` 兜底路径保留（已在 `set -eo pipefail` 下实测）；
- check-runs / annotations / status-comment 的读取方式本就分页安全（`--jq` 逐页 + slurp、行流、`.[][]`），刻意保持原样。

## 测试

- 行为级：用真实抽取的 `MARKERS` → `ROUND` 管道和位置绑定的 `NEWEST` 程序回放两页 fixture，含**负向对照**（未归一化时 `MARKERS` 输出两行、page-2 评审时间戳因槽位偏移丢失）；
- 形状断言钉住全部九个归一化抓取点，并禁止裸 `--paginate` 重定向落盘。

`npm run test:scripts` — 44 个文件，895 通过 / 9 跳过（与基线一致）。

</details>
