### PR TITLE
ci: bump qwen-code-action to 05f8171 (skip redundant install, surface install errors)

### DIFF
--- a/.github/workflows/qwen-ci-flaky-rerun.yml
+++ b/.github/workflows/qwen-ci-flaky-rerun.yml
@@ -84,7 +84,7 @@ jobs:
         env:
           GH_TOKEN: ''
           GITHUB_TOKEN: ''
-        uses: 'QwenLM/qwen-code-action@6d08e91aa807257b9c8af60edb5bb6bb2d7d951f'
+        uses: 'QwenLM/qwen-code-action@05f81718976f3b7da657422e6e8e4d372b8621d7'
         with:
           OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
           OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -1211,7 +1211,7 @@ jobs:
       - name: 'Resolve conflicts'
         if: "steps.prepare.outputs.decision == 'run'"
         id: 'resolve_conflicts'
-        uses: 'QwenLM/qwen-code-action@6d08e91aa807257b9c8af60edb5bb6bb2d7d951f'
+        uses: 'QwenLM/qwen-code-action@05f81718976f3b7da657422e6e8e4d372b8621d7'
         env:
           PR_NUMBER: '${{ steps.resolve.outputs.pr_number }}'
           BASE_REF: '${{ steps.prepare.outputs.base_ref }}'

--- a/.github/workflows/qwen-issue-followup-bot.yml
+++ b/.github/workflows/qwen-issue-followup-bot.yml
@@ -281,7 +281,7 @@ jobs:
           echo "Issue follow-up state: event=${EVENT_NAME} dispatch_dry=${DISPATCH_DRY_RUN} schedule_dry=${SCHEDULE_DRY_RUN} resolved_dry_run=${dry_run} scheduled_limit=${SCHEDULED_LIMIT_INPUT}"
 
       - name: 'Run Qwen issue follow-up'
-        uses: 'QwenLM/qwen-code-action@6d08e91aa807257b9c8af60edb5bb6bb2d7d951f'
+        uses: 'QwenLM/qwen-code-action@05f81718976f3b7da657422e6e8e4d372b8621d7'
         env:
           GITHUB_TOKEN: '${{ env.BOT_GITHUB_TOKEN }}'
           GH_TOKEN: '${{ env.BOT_GITHUB_TOKEN }}'

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -588,7 +588,7 @@ jobs:
 
       - name: 'Run Qwen Triage'
         id: 'triage'
-        uses: 'QwenLM/qwen-code-action@6d08e91aa807257b9c8af60edb5bb6bb2d7d951f'
+        uses: 'QwenLM/qwen-code-action@05f81718976f3b7da657422e6e8e4d372b8621d7'
         env:
           GITHUB_TOKEN: '${{ secrets.QWEN_CODE_BOT_TOKEN || secrets.CI_BOT_PAT }}'
           GH_TOKEN: '${{ secrets.QWEN_CODE_BOT_TOKEN || secrets.CI_BOT_PAT }}'


### PR DESCRIPTION
### What is this change?

Bump the pinned `QwenLM/qwen-code-action` SHA from `6d08e91a` to `05f81718` in all four consuming workflows:

- `qwen-triage.yml`
- `qwen-code-pr-review.yml`
- `qwen-issue-followup-bot.yml`
- `qwen-ci-flaky-rerun.yml`

### Why is it needed?

The new action main includes two fixes that address today's triage failure (run 30794379088, issue #8437):

1. **Skip install when the qwen CLI already exists** — avoids the redundant global `npm install` on runners that already have the CLI, removing a whole class of install failures (QwenLM/qwen-code-action#14, #13)
2. **Always emit stderr and warn on empty response** — the previous `npm --silent` swallowed the real error, leaving only an unexplained exit code 217 (QwenLM/qwen-code-action#12)

### Additional context

Failure example: the `Install Qwen Code` step died with exit code 217 and zero npm output; the workflow's own error handler flagged it as an infrastructure/install problem. This bump both avoids and diagnoses that failure mode.