### PR TITLE
feat(core): guide recording of PR, issue, and comment URLs as artifacts

### DIFF
--- a/packages/core/src/tools/record-artifact.ts
+++ b/packages/core/src/tools/record-artifact.ts
@@ -28,7 +28,7 @@ export interface RecordArtifactParams {
   metadata?: Record<string, string | number | boolean | null>;
 }
 
-const DESCRIPTION = `Registers a session artifact so clients can show it in an artifacts panel. Use it after creating a useful file, URL, image, report, notebook, or other intermediate result that the user may want to open later, unless the producing tool already returned artifact metadata. For example, write_file automatically records HTML, image, PDF, and notebook files it writes inside the workspace, so do not call record_artifact again for the same workspacePath; still call it for other formats such as Markdown, CSV, JSON, and plain text, and for files produced outside write_file.
+const DESCRIPTION = `Registers a session artifact so clients can show it in an artifacts panel. Use it after creating a useful file, URL, image, report, notebook, or other intermediate result that the user may want to open later, unless the producing tool already returned artifact metadata. For example, write_file automatically records HTML, image, PDF, and notebook files it writes inside the workspace, so do not call record_artifact again for the same workspacePath; still call it for other formats such as Markdown, CSV, JSON, and plain text, and for files produced outside write_file. When the session creates a remote resource, such as a pull request, issue, or comment submitted via gh, record its URL with kind "link" and the url locator so the user can reopen it later.
 
 This tool only records metadata. It does not publish, upload, read, write, or verify the referenced resource. Provide exactly one locator: workspacePath, managedId, or url. Use the Artifact tool, not record_artifact, for published interactive HTML artifacts.`;
 


### PR DESCRIPTION
## What this PR does

Extends the `record_artifact` tool description with explicit guidance to register URLs of remote resources the session creates — such as a pull request, issue, or comment submitted via `gh` — as link artifacts. This is a prompt-text-only change with no logic changes.

## Why it's needed

The daemon artifact design treats link artifacts as declarative, explicitly registered resources, and PR/issue/comment URLs are exactly the kind of resource entry a user wants to reopen later from the artifacts panel. Automatic URL extraction from shell stdout was intentionally excluded as semantically unreliable, so explicit registration is the only path — but nothing previously prompted the model to take it: the tool description only mentioned "URL" in passing. As a result, PR links created during a Web Shell session rarely showed up in the artifacts panel. This closes that guidance gap with concrete examples, consistent with the design doc's declarative-only principle.

## Reviewer Test Plan

### How to verify

- I ran the `record_artifact` unit tests (15/15 pass), `npm run typecheck`, ESLint, and Prettier on the changed file; all green.
- Reviewer: confirm the added sentence matches the tool's validation logic (`kind: 'link'` is a valid enum value, and a `url`-only locator infers `storage: 'external_url'`) and the daemon session artifacts design doc (declarative link artifacts only, no automatic extraction).
- Optional behavioral check: in a session, ask the agent to submit a PR via `gh` and observe whether it now calls `record_artifact` for the resulting PR URL.

### Evidence (Before & After)

N/A (prompt-text-only change, non-UI)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests via `npx vitest run src/tools/record-artifact.test.ts`; `npm run typecheck`; ESLint + Prettier checks.

## Risk & Scope

- Main risk or tradeoff: prompt text only; may slightly increase artifact registrations for gh-created URLs, which is the intended behavior.
- Not validated / out of scope: automatic URL extraction from shell output remains intentionally excluded by the artifact design; no end-to-end model-behavior measurement in this PR.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

扩展 `record_artifact` 工具描述，明确引导模型将会话中创建的远程资源 URL（例如通过 `gh` 提交的 pull request、issue 或 comment）登记为 link artifact。纯 prompt 文本改动，无逻辑变更。

## 为什么需要

Daemon artifact 设计将 link artifact 定位为“显式登记的声明式资源”，而 PR/issue/comment 的 URL 正是用户最希望以后从产物面板随时点开的资源入口。由于设计上明确排除了从 shell stdout 自动抽取 URL（语义不可靠），显式登记是唯一通道——但此前没有任何提示引导模型这么做：工具描述只笼统提到过 “URL”。结果就是 Web Shell 会话中创建的 PR 链接很少出现在产物面板里。本次改动通过具体示例补上这一引导缺口，且与设计文档的“仅声明式登记”原则一致。

## 评审测试计划

### 如何验证

- 已运行 `record_artifact` 单元测试（15/15 通过）、`npm run typecheck`、ESLint 和 Prettier，全部通过。
- 评审者：确认新增语句与工具校验逻辑一致（`kind: 'link'` 是合法枚举值；只传 `url` 时 `storage` 自动推断为 `external_url`），并与 daemon session artifacts 设计文档一致（仅声明式 link artifact，不做自动抽取）。
- 可选行为验证：在会话中让 agent 通过 `gh` 提交 PR，观察其是否会对得到的 PR URL 调用 `record_artifact`。

### 前后对比证据

N/A（纯 prompt 文本改动，非 UI 变更）

### 测试环境

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

通过 `npx vitest run src/tools/record-artifact.test.ts` 运行单元测试；`npm run typecheck`；ESLint + Prettier 检查。

## 风险与范围

- 主要风险或权衡：仅 prompt 文本；可能略微增加对 gh 创建的 URL 的 artifact 登记，这正是预期行为。
- 未验证 / 超出范围：shell 输出的 URL 自动抽取仍按 artifact 设计明确排除；本 PR 不做端到端模型行为度量。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
