### PR TITLE
fix(core): align MCP reconnect timeout test with safe replay policy

### DIFF
--- a/packages/core/src/tools/mcp-tool.test.ts
+++ b/packages/core/src/tools/mcp-tool.test.ts
@@ -2309,10 +2309,13 @@ describe('DiscoveredMCPTool', () => {
         serverToolName,
         baseDescription,
         inputSchema,
-        undefined,
+        true,
         undefined,
         undefined,
         newMockMcpClient,
+        undefined,
+        undefined,
+        idempotentAnnotations,
       );
       const discoverToolsForServer = vi.fn().mockResolvedValue(undefined);
       const mockConfig = {
@@ -2333,10 +2336,13 @@ describe('DiscoveredMCPTool', () => {
         serverToolName,
         baseDescription,
         inputSchema,
-        undefined,
+        true,
         undefined,
         mockConfig as any,
         mockMcpClient,
+        undefined,
+        undefined,
+        idempotentAnnotations,
       );
 
       await reconnectTool.build(params).execute(new AbortController().signal);


### PR DESCRIPTION
## What this PR does

The unit test covering MCP connection-loss recovery on a known disconnected server still built its mock tools without server trust and without tool annotations. The recent safe replay change made automatic replay after a connection failure conditional on both, so the test now deterministically fails with the "unsafe replay" error instead of exercising the reconnect path it was written for. This PR updates that test's fixtures to declare a trusted server with idempotent annotations, exactly the way the surrounding reconnect tests were already updated by the same change.

## Why it's needed

The failing test breaks the workspace test step of the Quality Checks job on `main`, which blocks release runs and every subsequent CI run until fixed. The test's original purpose — verifying that a request timeout against a server known to be disconnected is routed through the reconnect path rather than reported as an execution timeout — is preserved and now executes under the current replay safety policy. No production code is changed.

## Reviewer Test Plan

### How to verify

On `main` before this change, the affected test fails deterministically:

```
cd packages/core && npx vitest run src/tools/mcp-tool.test.ts
# FAIL ... reconnects instead of reporting a timeout when the server is known disconnected
# Tests  1 failed | 90 passed (91)
```

With this change applied, the same command passes the whole file:

```
✓ src/tools/mcp-tool.test.ts (91 tests)
Tests  91 passed (91)
```

Expected: the test reaches the reconnect path (tool discovery is invoked) and the replayed call succeeds, instead of throwing the unsafe replay error. `npm run typecheck`, ESLint, and Prettier are all clean.

### Evidence (Before & After)

N/A — test-only change, no user-visible behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only (`npx vitest run`), no runtime environment involved.

## Risk & Scope

- Main risk or tradeoff: none — test fixtures only; production behavior is untouched.
- Not validated / out of scope: no production logic is covered by this change.
- Breaking changes / migration notes: none.

## Linked Issues

Failure reference: Release run [30832542428](https://github.com/QwenLM/qwen-code/actions/runs/30832542428/job/91750152834) (Quality Checks → Run Workspace Tests). The fixture was missed when the safe replay change updated the sibling reconnect tests.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

覆盖"MCP 服务器已知断开时连接丢失恢复"的单元测试，其 mock 工具仍然没有声明服务器信任（trust）和工具注解（annotations）。而最近的安全重放改动已把"连接失败后自动重放"设为必须同时满足这两个条件，因此该测试现在确定性地以 "unsafe replay" 错误失败，无法再走到它原本要验证的重连路径。本 PR 更新该测试的夹具，声明受信任的服务器和幂等注解——与安全重放改动对周边其他重连测试的更新方式完全一致。

## 为什么需要

该失败测试导致 `main` 分支 Quality Checks 任务的 workspace 测试步骤失败，阻塞 release 运行及其后的所有 CI 运行。测试的原始目的——验证"对已知断开的服务器发出的请求超时应走重连路径，而不是被报告为执行超时"——得到保留，并且在当前的重放安全策略下执行。不改动任何生产代码。

## 评审者测试计划

### 如何验证

在本改动之前的 `main` 上，该测试确定性失败：

```
cd packages/core && npx vitest run src/tools/mcp-tool.test.ts
# FAIL ... reconnects instead of reporting a timeout when the server is known disconnected
# Tests  1 failed | 90 passed (91)
```

应用本改动后，同一命令整个文件通过：

```
✓ src/tools/mcp-tool.test.ts (91 tests)
Tests  91 passed (91)
```

预期：测试走到重连路径（工具发现被调用）且重放调用成功，而不是抛出 unsafe replay 错误。`npm run typecheck`、ESLint、Prettier 均通过。

### 前后对比证据

N/A —— 仅测试改动，无用户可见行为变化。

### 测试环境

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

仅单元测试（`npx vitest run`），不涉及运行时环境。

## 风险与范围

- 主要风险或权衡：无 —— 仅测试夹具，不影响生产行为。
- 未验证 / 超出范围：本改动不涉及任何生产逻辑。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

失败参考：Release 运行 [30832542428](https://github.com/QwenLM/qwen-code/actions/runs/30832542428/job/91750152834)（Quality Checks → Run Workspace Tests）。该夹具在安全重放改动更新兄弟重连测试时被遗漏。

</details>
