### PR TITLE
fix(test): add trust + idempotentHint to MCP reconnect test for canSafelyReplay gate

### DIFF
--- a/packages/core/src/tools/mcp-tool.test.ts
+++ b/packages/core/src/tools/mcp-tool.test.ts
@@ -2310,9 +2310,13 @@ describe('DiscoveredMCPTool', () => {
         baseDescription,
         inputSchema,
         undefined,
+        true, // trust: propagated to new invocation for canSafelyReplay
         undefined,
         undefined,
         newMockMcpClient,
+        undefined, // mcpTimeout
+        undefined, // mcpToolIdleTimeoutMs
+        { idempotentHint: true }, // annotations: propagated for canSafelyReplay
       );
       const discoverToolsForServer = vi.fn().mockResolvedValue(undefined);
       const mockConfig = {
@@ -2334,9 +2338,13 @@ describe('DiscoveredMCPTool', () => {
         baseDescription,
         inputSchema,
         undefined,
-        undefined,
+        true, // trust: required for canSafelyReplay
         mockConfig as any,
+        mockConfig as any, // cliConfig: has isTrustedFolder + getToolRegistry
         mockMcpClient,
+        undefined, // mcpTimeout
+        undefined, // mcpToolIdleTimeoutMs
+        { idempotentHint: true }, // annotations: required for canSafelyReplay
       );
 
       await reconnectTool.build(params).execute(new AbortController().signal);


### PR DESCRIPTION
## What this PR does

Fixes the 1 test failure blocking the v0.21.5 release (19158 pass / 1 fail in `packages/core`).

The test `reconnects instead of reporting a timeout when the server is known disconnected` in `mcp-tool.test.ts` was written before #8387 added the `canSafelyReplay()` safety gate. The gate requires:
- `trust === true`
- `cliConfig.isTrustedFolder() === true`
- `annotations` with `idempotentHint === true` or `readOnlyHint === true`

The test fixture previously passed `undefined` for trust and annotations, so the reconnect path now hits `UNSAFE_REPLAY_ERROR` instead of exercising the reconnect as intended.

## Fix

Adds `trust: true` and `{ idempotentHint: true }` annotations to both the initial tool and the reconnected tool in the test fixture, so the reconnect path is exercised as intended.

## Why this is safe

- Test-only change — no production code modified
- The test's `mockConfig` already has `isTrustedFolder: () => true`
- The reconnect behavior being tested is unchanged; only the fixture now satisfies the safety gate that was added after the test was written

## Verification

```bash
cd packages/core && npx vitest run src/tools/mcp-tool.test.ts
```

Expected: the previously failing test now passes, all other tests unchanged.