### PR TITLE
fix(ci): align review workflow tests with externalized timeout variables

### DIFF
--- a/scripts/tests/qwen-resolve-workflow.test.js
+++ b/scripts/tests/qwen-resolve-workflow.test.js
@@ -346,7 +346,9 @@ describe('qwen resolve workflow', () => {
     const contextStep = step(reviewJob, 'Resolve PR context');
     const runStep = step(reviewJob, 'Run review');
 
-    expect(reviewJob).toContain('timeout-minutes: 300');
+    expect(reviewJob).toContain(
+      "timeout-minutes: '${{ fromJSON(vars.QWEN_REVIEW_JOB_TIMEOUT_MINUTES) }}'",
+    );
     expect(contextStep).toContain('DEFAULT_TIMEOUT_MINUTES=180');
     expect(contextStep).toContain('case "$token" in');
     expect(contextStep).toContain('--timeout=*)');
@@ -354,7 +356,15 @@ describe('qwen resolve workflow', () => {
     expect(contextStep).toContain('timeout=*)');
     expect(contextStep).toContain('TIMEOUT_MINUTES="${token#timeout=}"');
     expect(runStep).toContain('if [ "${#TIMEOUT_MINUTES}" -gt 3 ]; then');
-    expect(runStep).toContain('timeout_minutes must not exceed 240 minutes');
+    expect(runStep).toContain(
+      'MAX_TIMEOUT_MINUTES="${{ vars.QWEN_REVIEW_MAX_TIMEOUT_MINUTES }}"',
+    );
+    expect(runStep).toContain(
+      'if [ "$TIMEOUT_MINUTES" -gt "$MAX_TIMEOUT_MINUTES" ]; then',
+    );
+    expect(runStep).toContain(
+      'fail "timeout_minutes must not exceed ${MAX_TIMEOUT_MINUTES} minutes"',
+    );
     expect(runStep).toContain('QWEN_TIMEOUT="$EFFECTIVE_TIMEOUT_MINUTES"');
     expect(runStep).not.toContain('QWEN_TIMEOUT=$((TIMEOUT_MINUTES - 5))');
   });
@@ -372,8 +382,8 @@ describe('qwen resolve workflow', () => {
     );
 
     // Auto-tiering only applies without an explicit --timeout, keys off
-    // additions + deletions, and never exceeds the 240 cap: small PRs keep 180,
-    // anything larger gets the full 240.
+    // additions + deletions, and never exceeds the QWEN_REVIEW_MAX_TIMEOUT_MINUTES
+    // cap: small PRs keep 180, anything larger gets the full cap.
     expect(runStep).toContain('EFFECTIVE_TIMEOUT_MINUTES="$TIMEOUT_MINUTES"');
     expect(runStep).toContain(
       'if [ "${TIMEOUT_EXPLICIT:-false}" != "true" ]; then',
@@ -381,7 +391,9 @@ describe('qwen resolve workflow', () => {
     expect(runStep).toContain('--json additions,deletions');
     expect(runStep).toContain('if [ "$PR_SIZE_LINES" -le 300 ]; then');
     expect(runStep).toContain('EFFECTIVE_TIMEOUT_MINUTES=180');
-    expect(runStep).toContain('EFFECTIVE_TIMEOUT_MINUTES=240');
+    expect(runStep).toContain(
+      'EFFECTIVE_TIMEOUT_MINUTES="${{ vars.QWEN_REVIEW_MAX_TIMEOUT_MINUTES }}"',
+    );
     expect(runStep).not.toContain('EFFECTIVE_TIMEOUT_MINUTES=210');
     expect(runStep).toContain(
       'echo "effective_timeout_minutes=$EFFECTIVE_TIMEOUT_MINUTES"',
@@ -403,9 +415,17 @@ describe('qwen resolve workflow', () => {
     expect(fallbackStep).toContain(
       "TIMEOUT_MINUTES: '${{ steps.review.outputs.effective_timeout_minutes || steps.context.outputs.timeout_minutes }}'",
     );
-    expect(fallbackStep).toContain('@qwen-code /review --timeout=240');
     expect(fallbackStep).toContain(
-      'This run already used the maximum 240 minute timeout.',
+      'MAX_TIMEOUT_MINUTES="${{ vars.QWEN_REVIEW_MAX_TIMEOUT_MINUTES }}"',
+    );
+    expect(fallbackStep).toContain(
+      'if [ "$TIMEOUT_MINUTES" -lt "$MAX_TIMEOUT_MINUTES" ]; then',
+    );
+    expect(fallbackStep).toContain(
+      '@qwen-code /review --timeout=${MAX_TIMEOUT_MINUTES}',
+    );
+    expect(fallbackStep).toContain(
+      'This run already used the maximum ${MAX_TIMEOUT_MINUTES} minute timeout.',
     );
     expect(fallbackStep).toContain('**Qwen Code review timed out.**');
     expect(fallbackStep).not.toContain(


### PR DESCRIPTION
## What this PR does

Updates the workflow-text assertions in the PR review workflow test suite so they match the timeout handling that was externalized to repository variables. The assertions previously pinned the hardcoded timeout values (the 300-minute job cap and the 240-minute per-review cap) in the rendered workflow steps; they now assert the `QWEN_REVIEW_JOB_TIMEOUT_MINUTES` and `QWEN_REVIEW_MAX_TIMEOUT_MINUTES` variable forms instead. No workflow changes.

## Why it's needed

#8460 moved the review timeouts into repository variables but did not update the matching test assertions, so the workspace test suite fails. This broke the Release workflow's Quality Checks job ([run 30837042556](https://github.com/QwenLM/qwen-code/actions/runs/30837042556/job/91765330438)), and the `Test (ubuntu-latest)` check on #8460 itself was already red for the same reason. This PR restores the suite to green and re-pins the assertions to the variable-based form.

## Reviewer Test Plan

### How to verify

Run `npx vitest run --config ./scripts/tests/vitest.config.ts qwen-resolve-workflow`. Before: 3 tests fail, e.g. `expected '…' to contain '@qwen-code /review --timeout=240'`. After: 29/29 pass. The full `npm run test:scripts` suite is also green (45 files, 896 passed).

### Evidence (Before & After)

N/A (test-only change)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Unit tests only (`npm run test:scripts`).

## Risk & Scope

- Main risk or tradeoff: none — test-only change, no workflow or runtime behavior touched.
- Not validated / out of scope: the actual values configured for the two repository variables on GitHub.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #8460. Fixes the failing workspace tests in [run 30837042556](https://github.com/QwenLM/qwen-code/actions/runs/30837042556).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

更新 PR review workflow 测试套件中对 workflow 文本的断言，使其与已外部化到仓库变量（repository variables）的超时配置一致。原有断言固定检查渲染后 workflow 中的硬编码超时值（job 级 300 分钟上限、单次 review 240 分钟上限），现在改为断言 `QWEN_REVIEW_JOB_TIMEOUT_MINUTES` 和 `QWEN_REVIEW_MAX_TIMEOUT_MINUTES` 变量形式。不改动任何 workflow。

## 为什么需要

#8460 将 review 超时外部化为仓库变量，但没有同步更新对应的测试断言，导致 workspace 测试套件失败：Release workflow 的 Quality Checks job 因此挂掉（[run 30837042556](https://github.com/QwenLM/qwen-code/actions/runs/30837042556/job/91765330438)），#8460 自身的 `Test (ubuntu-latest)` 检查当时也是红的。本 PR 让测试套件恢复绿色，并把断言重新固定到变量形式上。

## 评审验证计划

### 如何验证

运行 `npx vitest run --config ./scripts/tests/vitest.config.ts qwen-resolve-workflow`。修复前：3 个测试失败，例如 `expected '…' to contain '@qwen-code /review --timeout=240'`；修复后：29/29 全部通过。完整的 `npm run test:scripts` 套件也是绿的（45 个文件，896 通过）。

### 前后对比证据

N/A（纯测试改动）

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

仅单元测试（`npm run test:scripts`）。

## 风险与范围

- 主要风险或权衡：无 —— 纯测试改动，不涉及 workflow 或运行时行为。
- 未验证 / 不在范围内：GitHub 上两个仓库变量实际配置的值。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

#8460 的后续修复。修复 [run 30837042556](https://github.com/QwenLM/qwen-code/actions/runs/30837042556) 中失败的 workspace 测试。

</details>
