### PR TITLE
fix(core): report signal-terminated shell commands as errors

### DIFF
--- a/packages/cli/src/services/prompt-processors/shellProcessor.test.ts
+++ b/packages/cli/src/services/prompt-processors/shellProcessor.test.ts
@@ -524,6 +524,25 @@ describe('ShellProcessor', () => {
       ]);
     });
 
+    it('should not report PTY signal 0 as a termination', async () => {
+      const processor = new ShellProcessor('test-command');
+      const prompt: PromptPipelineContent =
+        createPromptPipelineContent('!{cmd}');
+      mockShellExecute.mockReturnValue({
+        result: Promise.resolve({
+          ...SUCCESS_RESULT,
+          output: 'output',
+          stderr: '',
+          exitCode: 0,
+          signal: 0,
+        }),
+      });
+
+      const result = await processor.process(prompt, context);
+
+      expect(result).toEqual([{ text: 'output' }]);
+    });
+
     it('should throw a detailed error if the shell fails to spawn', async () => {
       const processor = new ShellProcessor('test-command');
       const prompt: PromptPipelineContent =

--- a/packages/cli/src/services/prompt-processors/shellProcessor.ts
+++ b/packages/cli/src/services/prompt-processors/shellProcessor.ts
@@ -218,7 +218,10 @@ export class ShellProcessor implements IPromptProcessor {
           executionResult.exitCode !== null
         ) {
           processedPrompt += `\n[Shell command '${injection.resolvedCommand}' exited with code ${executionResult.exitCode}]`;
-        } else if (executionResult.signal !== null) {
+        } else if (
+          executionResult.signal !== null &&
+          executionResult.signal !== 0
+        ) {
           processedPrompt += `\n[Shell command '${injection.resolvedCommand}' terminated by signal ${executionResult.signal}]`;
         }
       }

--- a/packages/cli/src/services/prompt-processors/shellProcessor.ts
+++ b/packages/cli/src/services/prompt-processors/shellProcessor.ts
@@ -10,6 +10,7 @@ import {
   escapeShellArg,
   getShellConfiguration,
   ShellExecutionService,
+  isSignalTermination,
   flatMapTextParts,
   checkArgumentSafety,
 } from '@qwen-code/qwen-code-core';
@@ -218,10 +219,7 @@ export class ShellProcessor implements IPromptProcessor {
           executionResult.exitCode !== null
         ) {
           processedPrompt += `\n[Shell command '${injection.resolvedCommand}' exited with code ${executionResult.exitCode}]`;
-        } else if (
-          executionResult.signal !== null &&
-          executionResult.signal !== 0
-        ) {
+        } else if (isSignalTermination(executionResult.signal)) {
           processedPrompt += `\n[Shell command '${injection.resolvedCommand}' terminated by signal ${executionResult.signal}]`;
         }
       }

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.test.ts
@@ -282,6 +282,29 @@ describe('useShellCommandProcessor', () => {
     expect(setShellInputFocusedMock).toHaveBeenCalledWith(false);
   });
 
+  it('should treat PTY clean-exit signal 0 as a successful command', async () => {
+    const { result } = renderProcessorHook();
+
+    act(() => {
+      result.current.handleShellCommand(
+        'pty-clean-exit',
+        new AbortController().signal,
+      );
+    });
+    const execPromise = onExecMock.mock.calls[0][0];
+
+    act(() => {
+      resolveExecutionPromise(createMockServiceResult({ signal: 0 }));
+    });
+    await act(async () => await execPromise);
+
+    const finalHistoryItem = addItemToHistoryMock.mock.calls[1][0];
+    expect(finalHistoryItem.tools[0].status).toBe(ToolCallStatus.Success);
+    expect(finalHistoryItem.tools[0].resultDisplay).not.toContain(
+      'terminated by signal',
+    );
+  });
+
   describe('UI Streaming and Throttling', () => {
     beforeEach(() => {
       vi.useFakeTimers({ toFake: ['Date'] });

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.ts
@@ -19,6 +19,7 @@ import type {
 import {
   compactToolResultDisplayForHistory,
   createDebugLogger,
+  isSignalTermination,
   isBinary,
   ShellExecutionService,
 } from '@qwen-code/qwen-code-core';
@@ -288,7 +289,7 @@ export const useShellCommandProcessor = (
               } else if (result.aborted) {
                 finalStatus = ToolCallStatus.Canceled;
                 finalOutput = `Command was cancelled.\n${finalOutput}`;
-              } else if (result.signal) {
+              } else if (isSignalTermination(result.signal)) {
                 finalStatus = ToolCallStatus.Error;
                 finalOutput = `Command terminated by signal: ${result.signal}.\n${finalOutput}`;
               } else if (result.exitCode !== 0) {

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -377,6 +377,15 @@ describe('ShellExecutionService', () => {
       });
     });
 
+    it('normalizes node-pty clean-exit signal 0 to null', async () => {
+      const { result } = await simulateExecution('echo clean', (pty) => {
+        pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: 0 });
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.signal).toBeNull();
+    });
+
     it('disposes PTY terminal resources on natural exit', async () => {
       const terminalDisposeSpy = vi.spyOn(Terminal.prototype, 'dispose');
       const removeListenerSpy = vi.spyOn(mockPtyProcess, 'removeListener');
@@ -1051,13 +1060,14 @@ describe('ShellExecutionService', () => {
       );
       expect(result.promoted).toBe(true);
       // After promote, drive the PTY's onExit to simulate natural
-      // completion. The service attaches a new exit listener for
+      // completion with its raw clean-exit signal metadata. The service
+      // attaches a new exit listener for
       // post-promote settle — find the most-recently-registered.
       const onExitRegistrations = mockPtyProcess.onExit.mock.calls;
       expect(onExitRegistrations.length).toBeGreaterThanOrEqual(2);
       const postPromoteExitHandler =
         onExitRegistrations[onExitRegistrations.length - 1][0];
-      postPromoteExitHandler({ exitCode: 0, signal: undefined });
+      postPromoteExitHandler({ exitCode: 0, signal: 0 });
       expect(settleCalls).toHaveLength(1);
       expect(settleCalls[0].exitCode).toBe(0);
       expect(settleCalls[0].signal).toBeNull();

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -296,7 +296,8 @@ export interface ShellPostPromoteHandlers {
   onData?: (event: ShellOutputEvent) => void;
   /**
    * Fired exactly once when the post-promote child settles — natural
-   * exit (including PTY `signal: 0`), signal kill (which may carry
+   * child-process exit (`exitCode` set, `signal: null`), natural PTY
+   * exit (`exitCode` set, `signal: 0`), signal kill (which may carry
    * `exitCode: 0` with a non-zero signal on PTY, or `exitCode: null`
    * with a string signal from `child_process`), or spawn-side error
    * (`error` set). NOT

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -296,8 +296,10 @@ export interface ShellPostPromoteHandlers {
   onData?: (event: ShellOutputEvent) => void;
   /**
    * Fired exactly once when the post-promote child settles — natural
-   * exit (`exitCode` set, `signal: null`), signal kill (`exitCode:
-   * null`, `signal` set), or spawn-side error (`error` set). NOT
+   * exit (including PTY `signal: 0`), signal kill (which may carry
+   * `exitCode: 0` with a non-zero signal on PTY, or `exitCode: null`
+   * with a string signal from `child_process`), or spawn-side error
+   * (`error` set). NOT
    * fired for the promote-time resolve itself (that's the
    * `result.promoted` Promise resolution). Callers wire this to the
    * registry's `complete` / `fail` transitions.

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -150,6 +150,18 @@ export type ShellAbortReason =
   | { kind: 'cancel' }
   | { kind: 'background'; shellId?: string };
 
+/**
+ * Returns true only for a real process-signal termination.
+ * node-pty reports signal 0 for a clean exit; the service normalizes that
+ * value to null at its boundary, while this predicate remains defensive for
+ * legacy or mocked result objects.
+ */
+export function isSignalTermination(
+  signal: number | NodeJS.Signals | null,
+): boolean {
+  return signal !== null && signal !== 0;
+}
+
 /** A structured result from a shell command execution. */
 export interface ShellExecutionResult {
   /**
@@ -161,9 +173,15 @@ export interface ShellExecutionResult {
   rawOutput: Buffer;
   /** The combined, decoded output as a string. */
   output: string;
-  /** The process exit code, or null if terminated by a signal. */
+  /**
+   * The process exit code. Child-process signal termination reports null;
+   * PTY signal termination may still carry a numeric exit code.
+   */
   exitCode: number | null;
-  /** The signal that terminated the process, if any. */
+  /**
+   * The non-zero signal that terminated the process, if any. A node-pty
+   * clean-exit signal of 0 is normalized to null at the service boundary.
+   */
   signal: number | null;
   /** An error object if the process failed to spawn. */
   error: Error | null;
@@ -297,7 +315,7 @@ export interface ShellPostPromoteHandlers {
   /**
    * Fired exactly once when the post-promote child settles — natural
    * child-process exit (`exitCode` set, `signal: null`), natural PTY
-   * exit (`exitCode` set, `signal: 0`), signal kill (which may carry
+   * exit (`exitCode` set, clean-exit signal normalized to `null`), signal kill (which may carry
    * `exitCode: 0` with a non-zero signal on PTY, or `exitCode: null`
    * with a string signal from `child_process`), or spawn-side error
    * (`error` set). NOT
@@ -1891,7 +1909,7 @@ export class ShellExecutionService {
                   rawOutput: finalBuffer,
                   output: fullOutput,
                   exitCode,
-                  signal: signal ?? null,
+                  signal: signal === 0 ? null : (signal ?? null),
                   error,
                   aborted: abortSignal.aborted,
                   pid: ptyProcess.pid,
@@ -2135,7 +2153,7 @@ export class ShellExecutionService {
                 }) => {
                   firePostSettle({
                     exitCode,
-                    signal: signal ?? null,
+                    signal: signal === 0 ? null : (signal ?? null),
                     endTime: Date.now(),
                   });
                 },

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -2900,7 +2900,7 @@ describe('ShellTool', () => {
       });
     });
 
-    it('keeps a successful PTY exit code successful when signal metadata is present', async () => {
+    it('keeps a successful PTY exit code successful with signal 0 metadata', async () => {
       const invocation = shellTool.build({
         command: 'pty-cleanup-command',
         is_background: false,
@@ -2909,7 +2909,7 @@ describe('ShellTool', () => {
       resolveShellExecution({
         output: 'completed',
         exitCode: 0,
-        signal: 15,
+        signal: 0,
         aborted: false,
       });
 
@@ -2917,6 +2917,48 @@ describe('ShellTool', () => {
 
       expect(result.error).toBeUndefined();
       expect(result.llmContent).toContain('Output: completed');
+    });
+
+    it('reports a PTY signal termination as a tool error', async () => {
+      const invocation = shellTool.build({
+        command: 'pty-signal-terminated-command',
+        is_background: false,
+      });
+      const promise = invocation.execute(mockAbortSignal);
+      resolveShellExecution({
+        output: '',
+        exitCode: 0,
+        signal: 15,
+        error: null,
+        aborted: false,
+      });
+
+      const result = await promise;
+
+      expect(result.error).toEqual({
+        message: expect.stringContaining('Signal: 15'),
+        type: ToolErrorType.SHELL_EXECUTE_ERROR,
+      });
+    });
+
+    it('does not report a user-cancelled signal as a tool error', async () => {
+      const invocation = shellTool.build({
+        command: 'cancelled-command',
+        is_background: false,
+      });
+      const promise = invocation.execute(mockAbortSignal);
+      resolveShellExecution({
+        output: '',
+        exitCode: null,
+        signal: 15,
+        error: null,
+        aborted: true,
+      });
+
+      const result = await promise;
+
+      expect(result.error).toBeUndefined();
+      expect(result.llmContent).toContain('Command was cancelled');
     });
 
     it.each([

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -21,6 +21,8 @@ const mockDebugLogger = vi.hoisted(() => ({
 }));
 vi.mock('../services/shellExecutionService.js', () => ({
   ShellExecutionService: { execute: mockShellExecutionService },
+  isSignalTermination: (signal: number | NodeJS.Signals | null) =>
+    signal !== null && signal !== 0,
   getShellAbortReasonKind: (reason: unknown) =>
     typeof reason === 'object' &&
     reason !== null &&
@@ -2898,6 +2900,9 @@ describe('ShellTool', () => {
         message: expect.stringContaining('Signal: 15'),
         type: ToolErrorType.SHELL_EXECUTE_ERROR,
       });
+      expect(result.returnDisplay).toContain(
+        'Command terminated by signal: 15',
+      );
     });
 
     it('keeps a successful PTY exit code successful with signal 0 metadata', async () => {

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -6209,6 +6209,46 @@ describe('ShellTool', () => {
         expect(registry.fail).toHaveBeenCalledWith(entry.shellId, 'ENOENT', 3);
       });
 
+      it('keeps a task_stop cancellation from being reclassified as a signal failure', async () => {
+        const registry = mockConfig.getBackgroundShellRegistry();
+        const invocation = shellTool.build({
+          command: 'sleep 1',
+          is_background: false,
+        });
+        const promise = invocation.execute(mockAbortSignal);
+        resolveShellExecution({
+          output: '',
+          exitCode: null,
+          signal: null,
+          aborted: false,
+          promoted: true,
+        });
+        await promise;
+
+        const serviceCall = mockShellExecutionService.mock.calls[0];
+        const onSettle = (
+          serviceCall[6] as {
+            postPromote: {
+              onSettle: (info: {
+                exitCode: number | null;
+                signal: number | null;
+                error?: Error;
+                endTime: number;
+              }) => void;
+            };
+          }
+        ).postPromote.onSettle;
+        const entry = (registry.register as Mock).mock.calls[0][0];
+
+        // `task_stop` aborts the fresh registry controller before the
+        // child reports its SIGTERM/SIGKILL settle event.
+        entry.abortController.abort();
+        onSettle({ exitCode: 0, signal: 15, endTime: 4 });
+
+        expect(registry.cancel).toHaveBeenCalledWith(entry.shellId, 4);
+        expect(registry.fail).not.toHaveBeenCalled();
+      });
+
       it('queued-settle race: onSettle fires BEFORE handlePromotedForeground completes — entry settles + llmContent reflects final status', async () => {
         // Pin the queued-settle path: a very fast command can exit
         // between the service-side promote-resolve and the

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -2900,6 +2900,25 @@ describe('ShellTool', () => {
       });
     });
 
+    it('keeps a successful PTY exit code successful when signal metadata is present', async () => {
+      const invocation = shellTool.build({
+        command: 'pty-cleanup-command',
+        is_background: false,
+      });
+      const promise = invocation.execute(mockAbortSignal);
+      resolveShellExecution({
+        output: 'completed',
+        exitCode: 0,
+        signal: 15,
+        aborted: false,
+      });
+
+      const result = await promise;
+
+      expect(result.error).toBeUndefined();
+      expect(result.llmContent).toContain('Output: completed');
+    });
+
     it.each([
       'grep pattern file',
       'rg pattern file',

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -6191,6 +6191,14 @@ describe('ShellTool', () => {
           2,
         );
 
+        // node-pty can preserve exitCode 0 alongside a non-zero signal.
+        onSettle({ exitCode: 0, signal: 15, endTime: 2.5 });
+        expect(registry.fail).toHaveBeenCalledWith(
+          entry.shellId,
+          'Terminated by signal 15',
+          2.5,
+        );
+
         // Spawn-side error → fail with err.message.
         onSettle({
           exitCode: null,

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -3294,6 +3294,23 @@ describe('ShellTool', () => {
         expect(result.llmContent).not.toContain('foreground command ran for');
       });
 
+      it('appends the hint when PTY reports a clean exit with signal 0', async () => {
+        const invocation = shellTool.build({
+          command: 'echo hi',
+          is_background: false,
+        });
+        const promise = invocation.execute(mockAbortSignal);
+        await vi.advanceTimersByTimeAsync(60_000);
+        resolveShellExecution({
+          output: 'hi',
+          exitCode: 0,
+          signal: 0,
+          aborted: false,
+        });
+        const result = await promise;
+        expect(result.llmContent).toContain('foreground command ran for 60s');
+      });
+
       it('off-by-one: omits the hint at threshold − 1ms', async () => {
         // Pin the boundary so a regression that flips `>=` to `>` would
         // fail loudly. Pairs with the existing 60_000ms-exactly test
@@ -6073,9 +6090,10 @@ describe('ShellTool', () => {
         );
       });
 
-      it('natural child exit transitions the registry entry to "completed" (exitCode 0)', async () => {
+      it('clean PTY exit transitions the registry entry to "completed" (exitCode 0, signal 0)', async () => {
         // Pin the PR-2.5 settle path: after promote, when the
-        // service's post-promote exit listener fires with exitCode=0,
+        // service's post-promote exit listener fires with exitCode=0 and
+        // node-pty's clean-exit signal=0,
         // `registry.complete(shellId, 0, ...)` is called and the
         // stream closes.
         const writeStreamMock = {
@@ -6120,7 +6138,7 @@ describe('ShellTool', () => {
           postPromote?: {
             onSettle?: (info: {
               exitCode: number | null;
-              signal: number | null;
+              signal: number | NodeJS.Signals | null;
               error?: Error;
               endTime: number;
             }) => void;
@@ -6129,7 +6147,7 @@ describe('ShellTool', () => {
         expect(opts?.postPromote?.onSettle).toBeDefined();
         opts.postPromote!.onSettle!({
           exitCode: 0,
-          signal: null,
+          signal: 0,
           endTime: 1700000000000,
         });
 
@@ -6166,7 +6184,7 @@ describe('ShellTool', () => {
             postPromote: {
               onSettle: (info: {
                 exitCode: number | null;
-                signal: number | null;
+                signal: number | NodeJS.Signals | null;
                 error?: Error;
                 endTime: number;
               }) => void;
@@ -6209,10 +6227,10 @@ describe('ShellTool', () => {
         expect(registry.fail).toHaveBeenCalledWith(entry.shellId, 'ENOENT', 3);
       });
 
-      it('keeps a task_stop cancellation from being reclassified as a signal failure', async () => {
+      it('treats a child-process signal string as a failed settle', async () => {
         const registry = mockConfig.getBackgroundShellRegistry();
         const invocation = shellTool.build({
-          command: 'sleep 1',
+          command: 'cmd',
           is_background: false,
         });
         const promise = invocation.execute(mockAbortSignal);
@@ -6222,16 +6240,16 @@ describe('ShellTool', () => {
           signal: null,
           aborted: false,
           promoted: true,
+          pid: 33334,
         });
         await promise;
-
         const serviceCall = mockShellExecutionService.mock.calls[0];
         const onSettle = (
           serviceCall[6] as {
             postPromote: {
               onSettle: (info: {
                 exitCode: number | null;
-                signal: number | null;
+                signal: number | NodeJS.Signals | null;
                 error?: Error;
                 endTime: number;
               }) => void;
@@ -6240,13 +6258,67 @@ describe('ShellTool', () => {
         ).postPromote.onSettle;
         const entry = (registry.register as Mock).mock.calls[0][0];
 
-        // `task_stop` aborts the fresh registry controller before the
-        // child reports its SIGTERM/SIGKILL settle event.
-        entry.abortController.abort();
-        onSettle({ exitCode: 0, signal: 15, endTime: 4 });
+        onSettle({ exitCode: null, signal: 'SIGTERM', endTime: 3.5 });
 
-        expect(registry.cancel).toHaveBeenCalledWith(entry.shellId, 4);
-        expect(registry.fail).not.toHaveBeenCalled();
+        expect(registry.fail).toHaveBeenCalledWith(
+          entry.shellId,
+          'Terminated by signal SIGTERM',
+          3.5,
+        );
+      });
+
+      it('keeps a task_stop cancellation from being reclassified as a signal failure', async () => {
+        vi.useFakeTimers();
+        const processKillSpy = vi
+          .spyOn(process, 'kill')
+          .mockImplementation(() => true);
+        try {
+          const registry = mockConfig.getBackgroundShellRegistry();
+          const invocation = shellTool.build({
+            command: 'sleep 1',
+            is_background: false,
+          });
+          const promise = invocation.execute(mockAbortSignal);
+          resolveShellExecution({
+            output: '',
+            exitCode: null,
+            signal: null,
+            aborted: false,
+            promoted: true,
+            pid: 12345,
+          });
+          await promise;
+
+          const serviceCall = mockShellExecutionService.mock.calls[0];
+          const onSettle = (
+            serviceCall[6] as {
+              postPromote: {
+                onSettle: (info: {
+                  exitCode: number | null;
+                  signal: number | NodeJS.Signals | null;
+                  error?: Error;
+                  endTime: number;
+                }) => void;
+              };
+            }
+          ).postPromote.onSettle;
+          const entry = (registry.register as Mock).mock.calls[0][0];
+
+          // `task_stop` aborts the fresh registry controller before the
+          // child reports its SIGTERM/SIGKILL settle event.
+          entry.abortController.abort();
+          await Promise.resolve();
+          expect(processKillSpy).toHaveBeenCalledWith(-12345, 'SIGTERM');
+          await vi.advanceTimersByTimeAsync(250);
+          expect(processKillSpy).toHaveBeenCalledWith(-12345, 'SIGKILL');
+          onSettle({ exitCode: 0, signal: 15, endTime: 4 });
+
+          expect(registry.cancel).toHaveBeenCalledWith(entry.shellId, 4);
+          expect(registry.fail).not.toHaveBeenCalled();
+        } finally {
+          processKillSpy.mockRestore();
+          vi.useRealTimers();
+        }
       });
 
       it('queued-settle race: onSettle fires BEFORE handlePromotedForeground completes — entry settles + llmContent reflects final status', async () => {

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -2878,6 +2878,28 @@ describe('ShellTool', () => {
       expect(result.error?.message).toContain('failed output');
     });
 
+    it('reports a foreground signal termination as a tool error', async () => {
+      const invocation = shellTool.build({
+        command: 'signal-terminated-command',
+        is_background: false,
+      });
+      const promise = invocation.execute(mockAbortSignal);
+      resolveShellExecution({
+        output: '',
+        exitCode: null,
+        signal: 15,
+        error: null,
+        aborted: false,
+      });
+
+      const result = await promise;
+
+      expect(result.error).toEqual({
+        message: expect.stringContaining('Signal: 15'),
+        type: ToolErrorType.SHELL_EXECUTE_ERROR,
+      });
+    });
+
     it.each([
       'grep pattern file',
       'rg pattern file',

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -3016,7 +3016,9 @@ export class ShellToolInvocation extends BaseToolInvocation<
               type: ToolErrorType.SHELL_EXECUTE_ERROR,
             },
           }
-        : (!result.aborted && result.signal !== null && result.signal !== 0) ||
+        : // node-pty reports signal 0 (not null) for clean PTY exits; only a
+          // non-zero signal represents an actual signal termination.
+          (!result.aborted && result.signal !== null && result.signal !== 0) ||
             isShellExitError(this.params.command, result.exitCode)
           ? {
               error: {
@@ -3390,11 +3392,18 @@ export class ShellToolInvocation extends BaseToolInvocation<
     const classifySettle = (
       info: ShellPostPromoteSettleInfo,
     ): { status: 'completed' | 'failed'; failMsg: string | null } => {
-      // Decision table: `error` → fail (spawn-side failure); `exitCode
-      // === 0` → complete; non-zero exitCode → fail; signal-killed
-      // (no exitCode, signal set) → fail with descriptive message;
-      // everything-null → fail with generic message.
+      // Decision table: `error` → fail (spawn-side failure); a non-zero
+      // signal means the process was killed (including node-pty's
+      // `exitCode: 0, signal: N` shape), then `exitCode === 0` → complete;
+      // non-zero exitCode → fail; everything-null → fail with a generic
+      // message.
       if (info.error) return { status: 'failed', failMsg: info.error.message };
+      if (info.signal !== null && info.signal !== 0) {
+        return {
+          status: 'failed',
+          failMsg: `Terminated by signal ${info.signal}`,
+        };
+      }
       if (info.exitCode === 0) return { status: 'completed', failMsg: null };
       if (info.exitCode !== null)
         return {

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -421,6 +421,12 @@ function isShellExitError(command: string, exitCode: number | null) {
   return !EXIT_ONE_IS_NOT_ERROR_COMMANDS.has(commandName);
 }
 
+function isSignalTermination(signal: number | NodeJS.Signals | null): boolean {
+  // node-pty reports signal 0 for a clean exit; only a non-zero signal
+  // represents an actual signal termination.
+  return signal !== null && signal !== 0;
+}
+
 const SUDO_FLAGS_WITH_VALUE = new Set([
   '-u',
   '-g',
@@ -2836,7 +2842,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
     const shouldAppendLongRunHint =
       longRunThreshold !== null &&
       !result.aborted &&
-      result.signal === null &&
+      !isSignalTermination(result.signal) &&
       elapsedMs >= longRunThreshold;
     // Observability: the hint decision is otherwise invisible. If a
     // user reports "my 65s command didn't get the hint" or "5s command
@@ -2877,7 +2883,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
             : wasPromoteRefused
               ? 'Command finished before background-promote could be honoured.'
               : 'Command cancelled by user.';
-        } else if (result.signal) {
+        } else if (isSignalTermination(result.signal)) {
           returnDisplayMessage = `Command terminated by signal: ${result.signal}`;
         } else if (result.error) {
           returnDisplayMessage = `Command failed: ${getErrorMessage(
@@ -3016,9 +3022,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
               type: ToolErrorType.SHELL_EXECUTE_ERROR,
             },
           }
-        : // node-pty reports signal 0 (not null) for clean PTY exits; only a
-          // non-zero signal represents an actual signal termination.
-          (!result.aborted && result.signal !== null && result.signal !== 0) ||
+        : (!result.aborted && isSignalTermination(result.signal)) ||
             isShellExitError(this.params.command, result.exitCode)
           ? {
               error: {
@@ -3398,7 +3402,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
       // non-zero exitCode → fail; everything-null → fail with a generic
       // message.
       if (info.error) return { status: 'failed', failMsg: info.error.message };
-      if (info.signal !== null && info.signal !== 0) {
+      if (isSignalTermination(info.signal)) {
         return {
           status: 'failed',
           failMsg: `Terminated by signal ${info.signal}`,
@@ -3727,7 +3731,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
           } else if (
             result.error ||
             (result.exitCode !== null && result.exitCode !== 0) ||
-            result.signal !== null
+            isSignalTermination(result.signal)
           ) {
             // Non-zero exit / killed by signal / spawn error all count as failed.
             // Treating them as `completed` would let `/tasks` (and any future

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -45,6 +45,7 @@ import type {
 } from '../services/shellExecutionService.js';
 import {
   getShellAbortReasonKind,
+  isSignalTermination,
   ShellExecutionService,
 } from '../services/shellExecutionService.js';
 import {
@@ -419,12 +420,6 @@ function isShellExitError(command: string, exitCode: number | null) {
     .basename(path.win32.basename(executable))
     .replace(/\.(?:exe|cmd|bat)$/i, '');
   return !EXIT_ONE_IS_NOT_ERROR_COMMANDS.has(commandName);
-}
-
-function isSignalTermination(signal: number | NodeJS.Signals | null): boolean {
-  // node-pty reports signal 0 for a clean exit; only a non-zero signal
-  // represents an actual signal termination.
-  return signal !== null && signal !== 0;
 }
 
 const SUDO_FLAGS_WITH_VALUE = new Set([
@@ -2815,10 +2810,12 @@ export class ShellToolInvocation extends BaseToolInvocation<
     //         cancel). Their own messaging is enough; a "should have
     //         been background" reminder when the agent already knows
     //         the command didn't complete is noise.
-    //       * Suppressed on external signal kills (`result.signal !=
-    //         null` with `aborted: false`, e.g. SIGTERM from container
-    //         shutdown, k8s eviction, OOM killer, sibling reaping the
-    //         process group). `shellExecutionService` only sets
+    //       * Suppressed on external signal kills
+    //         (`isSignalTermination(result.signal)` with `aborted: false`,
+    //         e.g. SIGTERM from container shutdown, k8s eviction, OOM
+    //         killer, or sibling reaping the process group). node-pty's
+    //         clean-exit signal 0 is normalized to null and does not
+    //         suppress this hint. The service only sets
     //         `aborted` when the AbortSignal we passed was triggered,
     //         so external signals fall through to the non-aborted
     //         branch — same rationale as timeout.
@@ -3739,7 +3736,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
             // `false` command as a success.
             const reason = result.error
               ? result.error.message
-              : result.signal !== null
+              : isSignalTermination(result.signal)
                 ? `terminated by signal ${result.signal}`
                 : `exited with code ${result.exitCode}`;
             registry.fail(shellId, reason, endTime);

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -3016,7 +3016,8 @@ export class ShellToolInvocation extends BaseToolInvocation<
               type: ToolErrorType.SHELL_EXECUTE_ERROR,
             },
           }
-        : isShellExitError(this.params.command, result.exitCode)
+        : result.signal !== null ||
+            isShellExitError(this.params.command, result.exitCode)
           ? {
               error: {
                 // Schedulers use error.message as the model-facing response.

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -3016,7 +3016,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
               type: ToolErrorType.SHELL_EXECUTE_ERROR,
             },
           }
-        : (result.exitCode === null && result.signal !== null) ||
+        : (!result.aborted && result.signal !== null && result.signal !== 0) ||
             isShellExitError(this.params.command, result.exitCode)
           ? {
               error: {

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -3410,11 +3410,6 @@ export class ShellToolInvocation extends BaseToolInvocation<
           status: 'failed',
           failMsg: `Exited with code ${info.exitCode}`,
         };
-      if (info.signal !== null)
-        return {
-          status: 'failed',
-          failMsg: `Terminated by signal ${info.signal}`,
-        };
       // PR-2.5 wave-3: this branch is meant to
       // be unreachable — the service always populates one of
       // `error` / `exitCode` / `signal`. Hitting it means the
@@ -3436,6 +3431,13 @@ export class ShellToolInvocation extends BaseToolInvocation<
       };
     };
     const transitionRegistry = (info: ShellPostPromoteSettleInfo) => {
+      // `task_stop` aborts the entry before the child necessarily reports
+      // its signal. Preserve the user-intended `cancelled` state instead of
+      // allowing the later signal settle to overwrite it as `failed`.
+      if (entryAc.signal.aborted) {
+        registry.cancel(shellId, info.endTime);
+        return;
+      }
       const cls = classifySettle(info);
       if (cls.status === 'completed') {
         registry.complete(shellId, info.exitCode as number, info.endTime);

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -3016,7 +3016,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
               type: ToolErrorType.SHELL_EXECUTE_ERROR,
             },
           }
-        : result.signal !== null ||
+        : (result.exitCode === null && result.signal !== null) ||
             isShellExitError(this.params.command, result.exitCode)
           ? {
               error: {


### PR DESCRIPTION
## What this PR does

Reports signal-terminated foreground shell commands as tool errors while preserving normal PTY exits and user cancellation semantics, including promoted foreground shells.

## Problem

A signal-terminated foreground command can resolve as `{ exitCode: null, signal: 15, aborted: false }`. The result formatter displayed the signal, but the scheduler could treat the command as successful. A promoted foreground shell stopped through `task_stop` could also report its later SIGTERM/SIGKILL settle event as a failure after cancellation. PTY clean exits additionally report `signal: 0`, which must not be treated as a termination.

## Root Cause

Signal classification was repeated across foreground execution, promoted-shell settlement, background settlement, long-run hints, and CLI prompt injection. The paths did not share one non-zero-signal predicate, and the prompt processor treated every non-null signal as termination. The promoted-foreground settle transition also needed to give an already-aborted cancellation state priority over a later signal callback.

## Solution

Use one module-private predicate that treats only non-zero signals as termination. Apply it consistently to foreground and promoted/background classification, long-run hints, and prompt status injection. Preserve `signal: 0` as the node-pty clean-exit convention, and keep an aborted promoted entry in `cancelled` when its signal settle arrives later.

## Changes

- Added consistent non-zero signal classification to foreground, promoted, and background shell paths.
- Preserved `task_stop` cancellation over delayed promoted-shell signal settlement.
- Avoided reporting PTY `signal: 0` as a failure, signal termination, or prompt status error.
- Documented node-pty and child_process settle shapes.
- Added regression coverage for signal-only, PTY signal-with-exit-code, clean PTY, long-run hint, prompt injection, child-process signal strings, and post-`task_stop` promoted results.

## Testing

- `npm test --workspace=@qwen-code/qwen-code-core -- src/tools/shell.test.ts --run` — passed 294/294.
- `npm test --workspace=@qwen-code/qwen-code -- src/services/prompt-processors/shellProcessor.test.ts --run` — passed 35/35.
- `npx prettier --check ...` on all 5 changed files — passed.
- `npx eslint ...` on all 5 changed files — passed.
- `npm run typecheck --workspace=@qwen-code/qwen-code-core` — passed.
- `npm run typecheck --workspace=@qwen-code/qwen-code` — not verified: the checkout has pre-existing missing `@qwen-code/acp-bridge` exports/modules and Ink selection type errors outside this diff.
- `git diff --check` — passed.
- `npm run test:integration:no-ak:sandbox:none` — not verified: this Windows checkout lacks the built `dist/cli.js` required by the integration runner, so E2E cases stop at the executable precondition.

## Compatibility / Risk

The change is limited to shell result classification, prompt status formatting, documentation, and promoted-shell lifecycle settlement. Non-zero signal termination is surfaced as failure on the relevant paths; clean PTY exits with `signal: 0`, normal child-process exits, timeouts, and user cancellation retain their existing semantics. No dependencies or public APIs changed. Full CLI typecheck and integration behavior remain unverified because of checkout-wide environment/dependency preconditions.

## Notes for Reviewer

Please review the shared non-zero-signal predicate, the signal-before-exit-code ordering, the `task_stop` cancellation guard, and the fixtures modeling node-pty `{ exitCode: 0, signal: 0 }` clean exit versus `{ exitCode: 0, signal: N }` termination. The follow-up remains within the same shell signal-classification and cancellation bug family.

## Linked Issue

Fixes #8491