### PR TITLE
ci: route trusted-author fork PRs and no-checkout jobs to the ECS pool

### DIFF
--- a/.github/scripts/ci-runner-routing.test.mjs
+++ b/.github/scripts/ci-runner-routing.test.mjs
@@ -1,0 +1,199 @@
+// Runner-routing regression guards for ci.yml and serve-ab.yml.
+//
+// classify_pr carries the routing logic TWICE — the `runs-on` expression
+// (which selects the classify job's own runner) and the `pick_runner` shell
+// step (which publishes `ubuntu_runner` for every downstream Linux job). If
+// they drift, classify and the Test job land on different pools. These tests
+// evaluate BOTH against the same event matrix — including the negative
+// associations that must stay hosted — and assert they agree.
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { parse } from 'yaml';
+
+const workflowsDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'workflows',
+);
+const ciDoc = parse(readFileSync(join(workflowsDir, 'ci.yml'), 'utf8'));
+const serveAbDoc = parse(
+  readFileSync(join(workflowsDir, 'serve-ab.yml'), 'utf8'),
+);
+
+const TRUSTED = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+const ECS = '["self-hosted", "linux", "x64", "ecs-qwen"]';
+const HOSTED = '["ubuntu-latest"]';
+
+const classifyRunsOn = String(ciDoc.jobs.classify_pr['runs-on']);
+const pickRunner = ciDoc.jobs.classify_pr.steps.find(
+  (s) => s.id === 'pick_runner',
+);
+
+// GitHub expression semantics for the classify runs-on, restricted to the
+// routing-relevant inputs: contains(list, '') is false, a missing
+// pull_request (merge_group / dispatch) yields '' for both head.repo and
+// author_association.
+function simulateRunsOn({ ecsDisabled, sameRepo, assoc, mergeGroup }) {
+  const trusted = TRUSTED.includes(assoc);
+  const ecs =
+    !ecsDisabled && (sameRepo || trusted || mergeGroup);
+  return ecs ? ECS : HOSTED;
+}
+
+// Executes the real pick_runner shell with the same inputs and returns the
+// selected runner exactly as CI would publish it.
+function runPickRunner({ ecsDisabled, sameRepo, assoc, eventName, dispatch }) {
+  const tmp = mkdtempSync(join(tmpdir(), 'pick-runner-'));
+  const outputFile = join(tmp, 'github_output');
+  const result = spawnSync('bash', ['-c', pickRunner.run], {
+    env: {
+      SAME_REPO: sameRepo ? 'true' : 'false',
+      AUTHOR_ASSOCIATION: assoc,
+      ECS_DISABLED: ecsDisabled ? 'true' : '',
+      EVENT_NAME: eventName,
+      DISPATCH_LINUX_RUNNER: dispatch ?? '',
+      GITHUB_OUTPUT: outputFile,
+    },
+    encoding: 'utf8',
+  });
+  rmSync(tmp, { recursive: true, force: true });
+  assert.equal(result.status, 0, `pick_runner failed: ${result.stderr}`);
+  const line = result.stdout
+    .split('\n')
+    .find((l) => l.startsWith('Selected Linux runner: '));
+  assert.ok(line, `no selection in pick_runner output: ${result.stdout}`);
+  return line.slice('Selected Linux runner: '.length);
+}
+
+describe('ci.yml classify_pr runner routing', () => {
+  it('the expression and the shell step agree on every association', () => {
+    const associations = [
+      ...TRUSTED,
+      'CONTRIBUTOR',
+      'FIRST_TIME_CONTRIBUTOR',
+      'FIRST_TIMER',
+      'NONE',
+      '',
+    ];
+    for (const sameRepo of [true, false]) {
+      for (const assoc of associations) {
+        const expected = simulateRunsOn({
+          ecsDisabled: false,
+          sameRepo,
+          assoc,
+          mergeGroup: false,
+        });
+        const actual = runPickRunner({
+          ecsDisabled: false,
+          sameRepo,
+          assoc,
+          eventName: 'pull_request',
+        });
+        assert.equal(
+          actual,
+          expected,
+          `drift for sameRepo=${sameRepo} assoc='${assoc}'`,
+        );
+      }
+    }
+  });
+
+  it('only write-access associations leave the hosted pool', () => {
+    for (const assoc of ['CONTRIBUTOR', 'FIRST_TIME_CONTRIBUTOR', 'NONE', '']) {
+      assert.equal(
+        runPickRunner({
+          ecsDisabled: false,
+          sameRepo: false,
+          assoc,
+          eventName: 'pull_request',
+        }),
+        HOSTED,
+        `assoc '${assoc}' must stay hosted`,
+      );
+    }
+    for (const assoc of TRUSTED) {
+      assert.equal(
+        runPickRunner({
+          ecsDisabled: false,
+          sameRepo: false,
+          assoc,
+          eventName: 'pull_request',
+        }),
+        ECS,
+        `assoc '${assoc}' must route to ECS`,
+      );
+    }
+  });
+
+  it('merge queue and explicit dispatch still reach ECS; the kill-switch wins', () => {
+    assert.equal(
+      runPickRunner({
+        ecsDisabled: false,
+        sameRepo: false,
+        assoc: '',
+        eventName: 'merge_group',
+      }),
+      ECS,
+    );
+    assert.equal(
+      runPickRunner({
+        ecsDisabled: false,
+        sameRepo: false,
+        assoc: '',
+        eventName: 'workflow_dispatch',
+        dispatch: 'self-hosted',
+      }),
+      ECS,
+    );
+    assert.equal(
+      runPickRunner({
+        ecsDisabled: true,
+        sameRepo: true,
+        assoc: 'OWNER',
+        eventName: 'pull_request',
+      }),
+      HOSTED,
+      'kill-switch must revert even trusted runs to hosted',
+    );
+  });
+
+  it('the runs-on expression keeps the trusted clause and kill-switch', () => {
+    // Structural pins for the expression half of the drift guard — the
+    // simulation above re-implements it, so pin the real text too.
+    assert.match(
+      classifyRunsOn,
+      /contains\(fromJSON\('\["OWNER","MEMBER","COLLABORATOR"\]'\), github\.event\.pull_request\.author_association\)/,
+    );
+    assert.match(classifyRunsOn, /vars\.MAINTAINER_ECS_RUNNER_DISABLED != 'true'/);
+    assert.match(classifyRunsOn, /github\.event_name == 'merge_group'/);
+  });
+});
+
+describe('serve-ab.yml runner routing', () => {
+  const runsOn = String(serveAbDoc.jobs.ab['runs-on']);
+
+  it('admits same-repo and write-access fork PRs, guarded by the kill-switch', () => {
+    assert.match(runsOn, /head\.repo\.full_name == github\.repository/);
+    assert.match(
+      runsOn,
+      /contains\(fromJSON\('\["OWNER","MEMBER","COLLABORATOR"\]'\), github\.event\.pull_request\.author_association\)/,
+    );
+    assert.match(runsOn, /vars\.MAINTAINER_ECS_RUNNER_DISABLED != 'true'/);
+    assert.match(runsOn, /ecs-qwen/);
+    assert.match(runsOn, /ubuntu-latest/);
+  });
+
+  it('wipes the reused workspace before checking out PR code', () => {
+    const wipe = serveAbDoc.jobs.ab.steps.find(
+      (s) => s.name === 'Wipe stale workspace before checkout',
+    );
+    assert.ok(wipe, 'self-hosted reuse must not bleed one PR into the next');
+    assert.equal(wipe.if, "${{ runner.environment == 'self-hosted' }}");
+    assert.match(wipe.run, /find "\$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 -exec rm -rf/);
+  });
+});

--- a/.github/scripts/qwen-triage-workflow.test.mjs
+++ b/.github/scripts/qwen-triage-workflow.test.mjs
@@ -199,16 +199,47 @@ describe('qwen-triage: agent tool/permission settings', () => {
 
 describe('qwen-triage: fork-PR runner routing', () => {
   const runsOn = String(triageJob['runs-on']);
+  const authorizeJob = doc.jobs.authorize;
+  const authorizeRunsOn = String(authorizeJob['runs-on']);
 
-  it('gates the persistent ECS pool on same-repo or write-access authors', () => {
+  it('routes the ECS pool on same-repo or a REAL write-permission check', () => {
     assert.match(runsOn, /head\.repo\.full_name == github\.repository/);
-    // A write-access author (OWNER/MEMBER/COLLABORATOR association) is as
-    // trusted as an in-repo branch, so their fork PRs use ECS too.
+    // The boundary is the collaborator-permission lookup authorize computes,
+    // NOT the coarse author_association: MEMBER admits any org member and
+    // COLLABORATOR admits read-only invitees — neither implies write access
+    // on this repo, and this job's agent loads bot PATs and a model key.
     assert.match(
       runsOn,
-      /contains\(fromJSON\('\["OWNER", "MEMBER", "COLLABORATOR"\]'\), github\.event\.pull_request\.author_association\)/,
+      /needs\.authorize\.outputs\.author_can_write == 'true'/,
     );
+    assert.doesNotMatch(runsOn, /author_association/);
     assert.match(runsOn, /ecs-qwen/);
+  });
+
+  it('keeps the authorize gate itself on the same-repo guard', () => {
+    // authorize IS the permission check (and loads CI_BOT_PAT); it cannot
+    // route on its own output and must not widen to association-based trust.
+    assert.match(authorizeRunsOn, /head\.repo\.full_name == github\.repository/);
+    assert.doesNotMatch(authorizeRunsOn, /author_association/);
+    assert.doesNotMatch(authorizeRunsOn, /needs\./);
+  });
+
+  it('computes author_can_write from the collaborator-permission API', () => {
+    assert.equal(
+      authorizeJob.outputs.author_can_write,
+      '${{ steps.perm.outputs.author_can_write }}',
+    );
+    const perm = authorizeJob.steps.find((s) => s.id === 'perm');
+    assert.ok(
+      String(perm.env.PR_AUTHOR).includes(
+        'github.event.pull_request.user.login',
+      ),
+    );
+    assert.match(perm.run, /collaborators\/\$\{PR_AUTHOR\}\/permission/);
+    assert.match(
+      perm.run,
+      /admin\|maintain\|write\) echo "author_can_write=true"/,
+    );
   });
 
   it('falls back to an ephemeral hosted runner', () => {

--- a/.github/scripts/qwen-triage-workflow.test.mjs
+++ b/.github/scripts/qwen-triage-workflow.test.mjs
@@ -200,8 +200,14 @@ describe('qwen-triage: agent tool/permission settings', () => {
 describe('qwen-triage: fork-PR runner routing', () => {
   const runsOn = String(triageJob['runs-on']);
 
-  it('gates the persistent ECS pool on same-repo (fork code never persists)', () => {
+  it('gates the persistent ECS pool on same-repo or write-access authors', () => {
     assert.match(runsOn, /head\.repo\.full_name == github\.repository/);
+    // A write-access author (OWNER/MEMBER/COLLABORATOR association) is as
+    // trusted as an in-repo branch, so their fork PRs use ECS too.
+    assert.match(
+      runsOn,
+      /contains\(fromJSON\('\["OWNER", "MEMBER", "COLLABORATOR"\]'\), github\.event\.pull_request\.author_association\)/,
+    );
     assert.match(runsOn, /ecs-qwen/);
   });
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,11 +56,12 @@ jobs:
   classify_pr:
     name: 'Classify PR'
     if: "${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' }}"
-    # Gate runs on ECS for in-repo PRs and for the merge queue (which runs in the
-    # base-repo context), else a busy hosted pool delays it and blocks the
-    # ECS-bound jobs. The kill-switch is read here, so flipping it reverts
-    # everything to hosted.
-    runs-on: '${{ (vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == ''merge_group'')) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
+    # Gate runs on ECS for in-repo PRs, fork PRs whose author has write access
+    # (OWNER/MEMBER/COLLABORATOR association — a write-access author is as
+    # trusted as an in-repo branch), and the merge queue (base-repo context),
+    # else a busy hosted pool delays it and blocks the ECS-bound jobs. The
+    # kill-switch is read here, so flipping it reverts everything to hosted.
+    runs-on: '${{ (vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association) || github.event_name == ''merge_group'')) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     continue-on-error: true
     outputs:
       skip_ci: '${{ steps.release_sync.outputs.skip_ci }}'
@@ -102,23 +103,29 @@ jobs:
           echo "skip_ci=${skip_ci}" >> "${GITHUB_OUTPUT}"
           echo "skip_ci=${skip_ci}"
 
-      # In-repo PR (head branch in this repo => author has write access) and the
-      # merge queue (base-repo context) run the Linux jobs on ECS; fork PRs stay
+      # In-repo PRs, fork PRs whose author has write access
+      # (OWNER/MEMBER/COLLABORATOR association), and the merge queue
+      # (base-repo context) run the Linux jobs on ECS; other fork PRs stay
       # hosted. Disable via repo var MAINTAINER_ECS_RUNNER_DISABLED=true.
       - name: 'Select Linux runner'
         id: 'pick_runner'
         env:
           SAME_REPO: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
+          AUTHOR_ASSOCIATION: '${{ github.event.pull_request.author_association }}'
           ECS_DISABLED: '${{ vars.MAINTAINER_ECS_RUNNER_DISABLED }}'
           EVENT_NAME: '${{ github.event_name }}'
           DISPATCH_LINUX_RUNNER: '${{ github.event.inputs.linux_runner }}'
         run: |-
           ubuntu_runner='["ubuntu-latest"]'
+          trusted_author=false
+          case "${AUTHOR_ASSOCIATION}" in
+            OWNER|MEMBER|COLLABORATOR) trusted_author=true ;;
+          esac
           if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
             if [[ "${ECS_DISABLED}" != "true" && "${DISPATCH_LINUX_RUNNER}" == "self-hosted" ]]; then
               ubuntu_runner='["self-hosted", "linux", "x64", "ecs-qwen"]'
             fi
-          elif [[ "${ECS_DISABLED}" != "true" && ( "${SAME_REPO}" == "true" || "${EVENT_NAME}" == "merge_group" ) ]]; then
+          elif [[ "${ECS_DISABLED}" != "true" && ( "${SAME_REPO}" == "true" || "${trusted_author}" == "true" || "${EVENT_NAME}" == "merge_group" ) ]]; then
             ubuntu_runner='["self-hosted", "linux", "x64", "ecs-qwen"]'
           fi
           echo "ubuntu_runner=${ubuntu_runner}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ env:
   # BOTH the github_ci_only helper step and the full-profile Test step, so a
   # new helper test can't be added to one path and silently dropped from the
   # other.
-  HELPER_TESTS: '.github/scripts/pr-safety-precheck.test.mjs .github/scripts/cap-release-notes.test.mjs .github/scripts/ci/classify-profile.test.mjs .github/scripts/ci/main-failure-signature.test.mjs .github/scripts/classify-release-notes.test.mjs .github/scripts/dsw-swe-verified/make-manifest.test.mjs .github/scripts/resolve-sandbox-image.test.mjs .github/scripts/web-shell-visuals-publish.test.mjs .github/scripts/web-shell-visuals-compose.test.mjs .github/scripts/serve-ab-diff.test.mjs .github/scripts/qwen-triage-workflow.test.mjs .github/scripts/auto-minimize-spam.test.mjs'
+  HELPER_TESTS: '.github/scripts/pr-safety-precheck.test.mjs .github/scripts/cap-release-notes.test.mjs .github/scripts/ci/classify-profile.test.mjs .github/scripts/ci/main-failure-signature.test.mjs .github/scripts/classify-release-notes.test.mjs .github/scripts/dsw-swe-verified/make-manifest.test.mjs .github/scripts/resolve-sandbox-image.test.mjs .github/scripts/web-shell-visuals-publish.test.mjs .github/scripts/web-shell-visuals-compose.test.mjs .github/scripts/serve-ab-diff.test.mjs .github/scripts/qwen-triage-workflow.test.mjs .github/scripts/auto-minimize-spam.test.mjs .github/scripts/ci-runner-routing.test.mjs'
 
 jobs:
   classify_pr:
@@ -61,7 +61,9 @@ jobs:
     # trusted as an in-repo branch), and the merge queue (base-repo context),
     # else a busy hosted pool delays it and blocks the ECS-bound jobs. The
     # kill-switch is read here, so flipping it reverts everything to hosted.
-    runs-on: '${{ (vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association) || github.event_name == ''merge_group'')) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
+    # This runs-on and the pick_runner step below are the canonical home of
+    # the association routing; sdk-java.yml and serve-ab.yml mirror it.
+    runs-on: '${{ (vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON(''["OWNER","MEMBER","COLLABORATOR"]''), github.event.pull_request.author_association) || github.event_name == ''merge_group'')) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     continue-on-error: true
     outputs:
       skip_ci: '${{ steps.release_sync.outputs.skip_ci }}'

--- a/.github/workflows/comment-attachment-guard.yml
+++ b/.github/workflows/comment-attachment-guard.yml
@@ -57,7 +57,10 @@ jobs:
         github.event.comment.author_association ||
         github.event.review.author_association
       )
-    runs-on: 'ubuntu-latest'
+    # Checks out nothing and runs no repository code (comment/review events
+    # use base-repo YAML), so the persistent ECS pool is safe and skips the
+    # saturated hosted queue. Kill-switch: MAINTAINER_ECS_RUNNER_DISABLED.
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'') && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     steps:
       - name: 'Remove suspicious attachment comments'
         uses: 'actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3' # v9.0.0

--- a/.github/workflows/docs-page-action.yml
+++ b/.github/workflows/docs-page-action.yml
@@ -46,6 +46,9 @@ jobs:
     # base-repo YAML), so the persistent ECS pool is safe.
     # Kill-switch: MAINTAINER_ECS_RUNNER_DISABLED.
     runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'') && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
+    # One API deploy; a hang must not pin a persistent pool machine for the
+    # 360-minute default.
+    timeout-minutes: 5
     needs: 'build'
     steps:
       - name: 'Deploy to GitHub Pages'

--- a/.github/workflows/docs-page-action.yml
+++ b/.github/workflows/docs-page-action.yml
@@ -42,7 +42,10 @@ jobs:
     environment:
       name: 'github-pages'
       url: '${{ steps.deployment.outputs.page_url }}'
-    runs-on: 'ubuntu-latest'
+    # Checks out nothing and runs no repository code (push/dispatch use
+    # base-repo YAML), so the persistent ECS pool is safe.
+    # Kill-switch: MAINTAINER_ECS_RUNNER_DISABLED.
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'') && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     needs: 'build'
     steps:
       - name: 'Deploy to GitHub Pages'

--- a/.github/workflows/main-ci-failure-issue.yml
+++ b/.github/workflows/main-ci-failure-issue.yml
@@ -144,7 +144,9 @@ jobs:
   file_issue:
     name: 'Create autofix issue'
     needs: 'analyze'
-    runs-on: 'ubuntu-latest'
+    # Checks out nothing (workflow_run events use base-repo YAML), so the
+    # persistent ECS pool is safe. Kill-switch: MAINTAINER_ECS_RUNNER_DISABLED.
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'') && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     timeout-minutes: 5
     permissions:
       issues: 'write'

--- a/.github/workflows/main-ci-failure-issue.yml
+++ b/.github/workflows/main-ci-failure-issue.yml
@@ -144,9 +144,10 @@ jobs:
   file_issue:
     name: 'Create autofix issue'
     needs: 'analyze'
-    # Checks out nothing (workflow_run events use base-repo YAML), so the
-    # persistent ECS pool is safe. Kill-switch: MAINTAINER_ECS_RUNNER_DISABLED.
-    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'') && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
+    # Deliberately hosted, NOT the ECS pool: this job reports that CI broke,
+    # and the pool being the REASON CI broke would queue the report behind
+    # the very failure it documents.
+    runs-on: 'ubuntu-latest'
     timeout-minutes: 5
     permissions:
       issues: 'write'

--- a/.github/workflows/pr-force-push-reminder.yml
+++ b/.github/workflows/pr-force-push-reminder.yml
@@ -24,7 +24,10 @@ jobs:
     timeout-minutes: 5
     if: |-
       ${{ github.repository == 'QwenLM/qwen-code' }}
-    runs-on: 'ubuntu-latest'
+    # Checks out nothing and runs no repository code (pull_request_target
+    # events use base-repo YAML), so the persistent ECS pool is safe and
+    # skips the saturated hosted queue. Kill-switch: MAINTAINER_ECS_RUNNER_DISABLED.
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'') && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     steps:
       - name: 'Detect force-push and post reminder'
         uses: 'actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3' # v9.0.0

--- a/.github/workflows/pr-self-report-label.yml
+++ b/.github/workflows/pr-self-report-label.yml
@@ -24,7 +24,10 @@ jobs:
   label:
     if: |-
       ${{ github.repository == 'QwenLM/qwen-code' }}
-    runs-on: 'ubuntu-latest'
+    # Checks out nothing and runs no repository code (pull_request_target
+    # events use base-repo YAML), so the persistent ECS pool is safe and
+    # skips the saturated hosted queue. Kill-switch: MAINTAINER_ECS_RUNNER_DISABLED.
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'') && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     timeout-minutes: 5
     steps:
       - name: 'Label a self-reported PR'

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -226,12 +226,12 @@ jobs:
         startsWith(github.event.comment.body, '@qwen-code /review')) ||
        (github.event_name == 'pull_request_review' &&
         startsWith(github.event.review.body, '@qwen-code /review')))
-    # Canonical trusted-author guard: this job loads CI_BOT_PAT, so runs
-    # triggered by untrusted fork PRs stay on hosted (ephemeral); in-repo PR
-    # events and fork PRs whose author has write access (OWNER/MEMBER/
-    # COLLABORATOR association) on QwenLM/qwen-code use the persistent ECS
-    # runner.
-    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && github.event.pull_request && (github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association))) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
+    # Canonical same-repo guard: this job loads CI_BOT_PAT, so fork-triggered
+    # runs stay on hosted (ephemeral); only in-repo PR events on QwenLM/qwen-code
+    # use the persistent ECS runner. The job IS the write-permission check, so
+    # it cannot route on its own output; downstream jobs already route on the
+    # repository guard alone.
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     timeout-minutes: 5
     permissions:
       contents: 'read'

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -226,10 +226,12 @@ jobs:
         startsWith(github.event.comment.body, '@qwen-code /review')) ||
        (github.event_name == 'pull_request_review' &&
         startsWith(github.event.review.body, '@qwen-code /review')))
-    # Canonical same-repo guard: this job loads CI_BOT_PAT, so fork-triggered
-    # runs stay on hosted (ephemeral); only in-repo PR events on QwenLM/qwen-code
-    # use the persistent ECS runner.
-    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
+    # Canonical trusted-author guard: this job loads CI_BOT_PAT, so runs
+    # triggered by untrusted fork PRs stay on hosted (ephemeral); in-repo PR
+    # events and fork PRs whose author has write access (OWNER/MEMBER/
+    # COLLABORATOR association) on QwenLM/qwen-code use the persistent ECS
+    # runner.
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && github.event.pull_request && (github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association))) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     timeout-minutes: 5
     permissions:
       contents: 'read'

--- a/.github/workflows/qwen-fleet-shepherd.yml
+++ b/.github/workflows/qwen-fleet-shepherd.yml
@@ -65,10 +65,13 @@ jobs:
   shepherd:
     if: |-
       ${{ github.repository == 'QwenLM/qwen-code' && vars.FLEET_SHEPHERD_DISABLED != 'true' }}
-    # Checks out nothing and runs no repository code (schedule/dispatch use
-    # base-repo YAML), so the persistent ECS pool is safe.
-    # Kill-switch: MAINTAINER_ECS_RUNNER_DISABLED.
-    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'') && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
+    # Deliberately hosted, NOT the ECS pool: the shepherd is the watchdog FOR
+    # that pool. When the pool is wedged, drained, or offline — exactly when
+    # the shepherd is needed — a pool-routed shepherd would queue behind the
+    # failure it exists to fix, and recovery would need the manual kill-switch
+    # flip the shepherd exists to avoid. One 15-minute hosted job per tick is
+    # a negligible queue cost for that independence.
+    runs-on: 'ubuntu-latest'
     timeout-minutes: 15
     steps:
       - name: 'Shepherd the fleet'

--- a/.github/workflows/qwen-fleet-shepherd.yml
+++ b/.github/workflows/qwen-fleet-shepherd.yml
@@ -65,7 +65,10 @@ jobs:
   shepherd:
     if: |-
       ${{ github.repository == 'QwenLM/qwen-code' && vars.FLEET_SHEPHERD_DISABLED != 'true' }}
-    runs-on: 'ubuntu-latest'
+    # Checks out nothing and runs no repository code (schedule/dispatch use
+    # base-repo YAML), so the persistent ECS pool is safe.
+    # Kill-switch: MAINTAINER_ECS_RUNNER_DISABLED.
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'') && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     timeout-minutes: 15
     steps:
       - name: 'Shepherd the fleet'

--- a/.github/workflows/qwen-issue-followup-bot.yml
+++ b/.github/workflows/qwen-issue-followup-bot.yml
@@ -51,7 +51,10 @@ jobs:
         github.repository == 'QwenLM/qwen-code' &&
         (github.event_name == 'workflow_dispatch' || vars.QWEN_ISSUE_FOLLOWUP_BOT_ENABLED == 'true')
       }}
-    runs-on: 'ubuntu-latest'
+    # Checks out nothing and runs no repository code (schedule/dispatch use
+    # base-repo YAML), so the persistent ECS pool is safe.
+    # Kill-switch: MAINTAINER_ECS_RUNNER_DISABLED.
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'') && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     steps:
       - name: 'Prepare issue follow-up runtime'
         id: 'runtime'

--- a/.github/workflows/qwen-triage-finalize.yml
+++ b/.github/workflows/qwen-triage-finalize.yml
@@ -66,7 +66,10 @@ jobs:
     if: >-
       github.event.workflow_run.event == 'pull_request' &&
       github.repository == 'QwenLM/qwen-code'
-    runs-on: 'ubuntu-latest'
+    # Checks out nothing and runs no repository code (workflow_run events use
+    # base-repo YAML), so the persistent ECS pool is safe and skips the
+    # saturated hosted queue. Kill-switch: MAINTAINER_ECS_RUNNER_DISABLED.
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'') && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     timeout-minutes: 10
     steps:
       - name: 'Finalize CI evidence and deferred approval'

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -74,17 +74,24 @@ jobs:
          startsWith(github.event.comment.body, '@qwen-code /verify '))) ||
        (github.event_name == 'workflow_dispatch' &&
         github.event.inputs.tmux_pr != ''))
-    # Canonical trusted-author guard: this job loads CI_BOT_PAT, so runs
-    # triggered by untrusted fork PRs stay on hosted (ephemeral); in-repo PR
-    # events and fork PRs whose author has write access (OWNER/MEMBER/
-    # COLLABORATOR association) on QwenLM/qwen-code use the persistent ECS
-    # runner.
-    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && github.event.pull_request && (github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association))) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
+    # Canonical same-repo guard: this job loads CI_BOT_PAT, so fork-triggered
+    # runs stay on hosted (ephemeral); only in-repo PR events on QwenLM/qwen-code
+    # use the persistent ECS runner. The job IS the write-permission check, so
+    # it cannot route on its own output; downstream jobs (triage, tmux, verify)
+    # route on what it finds instead.
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     timeout-minutes: 5
     permissions:
       contents: 'read'
     outputs:
       should_run: '${{ steps.perm.outputs.should_run }}'
+      # Real write-permission check on the PR AUTHOR (collaborator-permission
+      # API, not the coarse author_association), computed only on
+      # pull_request_target events; empty on every other event. Consumed by
+      # the triage job's runner routing so a maintainer's fork PR uses the
+      # ECS pool while a read-only collaborator's or org member's fork PR
+      # stays on ephemeral hosted runners.
+      author_can_write: '${{ steps.perm.outputs.author_can_write }}'
       # /verify trust level: 'trusted' when the PR author has write,
       # 'external' when they do not. Both run on the persistent ECS pool
       # (maintainer decision, 2026-07-29: the pool is network-isolated and
@@ -126,6 +133,7 @@ jobs:
           # issues; compare against null rather than truthiness so the shell
           # receives a plain true/false.
           IS_PR: '${{ github.event.issue.pull_request != null }}'
+          PR_AUTHOR: '${{ github.event.pull_request.user.login }}'
         run: |-
           set -euo pipefail
           IS_VERIFY=false
@@ -143,6 +151,18 @@ jobs:
             # says the PR is ready to be worth that.
             echo "Automatic PR triage allowed for PR #${PR_NUMBER} after same-repo/precheck gate." >> "$GITHUB_STEP_SUMMARY"
             echo "should_run=true" >> "$GITHUB_OUTPUT"
+            # Runner-routing input for the triage job: the REAL author write
+            # check (author_association admits org members and read-only
+            # collaborators). Fail OPEN on purpose — unlike the deny gates
+            # below, this selects a runner pool, not a decision: an API
+            # hiccup merely routes the triage to a hosted runner, it must
+            # never skip or fail the triage itself.
+            if [ -n "$PR_AUTHOR" ] &&
+               author_perm="$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${PR_AUTHOR}/permission" --jq '.permission' 2>/dev/null)"; then
+              case "$author_perm" in
+                admin|maintain|write) echo "author_can_write=true" >> "$GITHUB_OUTPUT" ;;
+              esac
+            fi
             exit 0
           fi
           case "$EVENT_NAME" in
@@ -391,13 +411,17 @@ jobs:
     # foreign code off the persistent pool.
     # Runner routing: the persistent ECS pool serves events whose payload
     # carries no foreign code — issue triage and same-repo PR events — plus
-    # fork PRs whose author has write access (OWNER/MEMBER/COLLABORATOR
-    # association: a write-access author is as trusted as an in-repo branch,
-    # and the pool is network-isolated). PRs by other fork authors, and
+    # fork PRs whose author REALLY has write access, per the collaborator-
+    # permission lookup the authorize job already performs (the coarse
+    # author_association would admit org members and read-only collaborators
+    # to this secret-bearing agent; the pool is network-isolated, but a
+    # write-access author is the trust bar for reusing it). authorize is
+    # skipped on the issues/dispatch paths, so the explicit `issues` clause
+    # must stay; there its output is ''. PRs by other fork authors, and
     # comment/dispatch-triggered reruns (which may target fork PRs), go to
     # ephemeral hosted runners so a steered agent cannot persist anything
     # across runs. Forks of this repo fall back to ubuntu-latest as before.
-    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event_name == ''issues'' || (github.event.pull_request && (github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association))))) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event_name == ''issues'' || (github.event.pull_request && (github.event.pull_request.head.repo.full_name == github.repository || needs.authorize.outputs.author_can_write == ''true'')))) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     # startsWith (not contains) prevents false triggers from comments that
     # mention the phrase in quoted text or mid-sentence descriptions.
     # always() so the job still evaluates when the upstream `authorize` job is

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -74,10 +74,12 @@ jobs:
          startsWith(github.event.comment.body, '@qwen-code /verify '))) ||
        (github.event_name == 'workflow_dispatch' &&
         github.event.inputs.tmux_pr != ''))
-    # Canonical same-repo guard: this job loads CI_BOT_PAT, so fork-triggered
-    # runs stay on hosted (ephemeral); only in-repo PR events on QwenLM/qwen-code
-    # use the persistent ECS runner.
-    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
+    # Canonical trusted-author guard: this job loads CI_BOT_PAT, so runs
+    # triggered by untrusted fork PRs stay on hosted (ephemeral); in-repo PR
+    # events and fork PRs whose author has write access (OWNER/MEMBER/
+    # COLLABORATOR association) on QwenLM/qwen-code use the persistent ECS
+    # runner.
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && github.event.pull_request && (github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association))) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     timeout-minutes: 5
     permissions:
       contents: 'read'
@@ -387,13 +389,15 @@ jobs:
     # (.qwen/skills/triage/SKILL.md Rules), the `settings` deny rules block the
     # direct interpreter/build/network invocations, and the routing below keeps
     # foreign code off the persistent pool.
-    # Runner routing: the persistent ECS pool is reserved for events whose
-    # payload carries no foreign code — issue triage and same-repo PR events.
-    # Fork PRs, and comment/dispatch-triggered reruns (which may target fork
-    # PRs), go to ephemeral hosted runners so a steered agent cannot persist
-    # anything across runs. Forks of this repo fall back to ubuntu-latest as
-    # before.
-    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event_name == ''issues'' || (github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository))) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
+    # Runner routing: the persistent ECS pool serves events whose payload
+    # carries no foreign code — issue triage and same-repo PR events — plus
+    # fork PRs whose author has write access (OWNER/MEMBER/COLLABORATOR
+    # association: a write-access author is as trusted as an in-repo branch,
+    # and the pool is network-isolated). PRs by other fork authors, and
+    # comment/dispatch-triggered reruns (which may target fork PRs), go to
+    # ephemeral hosted runners so a steered agent cannot persist anything
+    # across runs. Forks of this repo fall back to ubuntu-latest as before.
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event_name == ''issues'' || (github.event.pull_request && (github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association))))) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     # startsWith (not contains) prevents false triggers from comments that
     # mention the phrase in quoted text or mid-sentence descriptions.
     # always() so the job still evaluates when the upstream `authorize` job is
@@ -1739,10 +1743,24 @@ jobs:
     # inherit the 360-minute default and a hung gh call could hold a hosted
     # runner for six hours. Same bound as publish-verify.
     timeout-minutes: 10
-    runs-on: 'ubuntu-latest'
+    # Checks out nothing and runs no repository code (base-repo YAML events),
+    # so the persistent ECS pool is safe.
+    # Kill-switch: MAINTAINER_ECS_RUNNER_DISABLED.
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'') && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     permissions:
       pull-requests: 'write'
     steps:
+      - name: 'Restore workspace ownership'
+        if: "${{ runner.environment == 'self-hosted' }}"
+        run: |-
+          set -uo pipefail
+          RUNNER_UID="$(id -u)"
+          RUNNER_GID="$(id -g)"
+          if [ "$RUNNER_UID" != "0" ]; then
+            chown -R "$RUNNER_UID:$RUNNER_GID" "$GITHUB_WORKSPACE" 2>/dev/null || sudo -n chown -R "$RUNNER_UID:$RUNNER_GID" "$GITHUB_WORKSPACE" || echo "::warning::could not restore workspace ownership; artifact download may fail on leftover root-owned files"
+          fi
+          chmod -R u+rwX "$GITHUB_WORKSPACE" 2>/dev/null || sudo -n chmod -R u+rwX "$GITHUB_WORKSPACE" || echo "::warning::could not restore workspace write permissions; artifact download may fail on leftover read-only files"
+
       - name: 'Download tmux results'
         uses: 'actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c' # v5.0.0
         with:
@@ -3400,10 +3418,24 @@ jobs:
     # inherit the 360-minute default and a hung gh call could hold a hosted
     # runner for six hours.
     timeout-minutes: 10
-    runs-on: 'ubuntu-latest'
+    # Checks out nothing and runs no repository code (base-repo YAML events),
+    # so the persistent ECS pool is safe.
+    # Kill-switch: MAINTAINER_ECS_RUNNER_DISABLED.
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'') && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     permissions:
       pull-requests: 'write'
     steps:
+      - name: 'Restore workspace ownership'
+        if: "${{ runner.environment == 'self-hosted' }}"
+        run: |-
+          set -uo pipefail
+          RUNNER_UID="$(id -u)"
+          RUNNER_GID="$(id -g)"
+          if [ "$RUNNER_UID" != "0" ]; then
+            chown -R "$RUNNER_UID:$RUNNER_GID" "$GITHUB_WORKSPACE" 2>/dev/null || sudo -n chown -R "$RUNNER_UID:$RUNNER_GID" "$GITHUB_WORKSPACE" || echo "::warning::could not restore workspace ownership; artifact download may fail on leftover root-owned files"
+          fi
+          chmod -R u+rwX "$GITHUB_WORKSPACE" 2>/dev/null || sudo -n chmod -R u+rwX "$GITHUB_WORKSPACE" || echo "::warning::could not restore workspace write permissions; artifact download may fail on leftover read-only files"
+
       - name: 'Download verify results'
         id: 'download'
         uses: 'actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c' # v5.0.0

--- a/.github/workflows/repo-hygiene.yml
+++ b/.github/workflows/repo-hygiene.yml
@@ -37,7 +37,10 @@ jobs:
   dedup:
     name: 'Dedup'
     if: "${{ github.repository == 'QwenLM/qwen-code' }}"
-    runs-on: 'ubuntu-latest'
+    # Checks out nothing and runs no repository code (schedule/dispatch use
+    # base-repo YAML), so the persistent ECS pool is safe.
+    # Kill-switch: MAINTAINER_ECS_RUNNER_DISABLED.
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'') && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     timeout-minutes: 5
     permissions:
       contents: 'read'

--- a/.github/workflows/sdk-java.yml
+++ b/.github/workflows/sdk-java.yml
@@ -52,7 +52,7 @@ concurrency:
 jobs:
   test:
     name: '${{ matrix.os }} / Java ${{ matrix.java }}'
-    runs-on: '${{ (matrix.os == ''ubuntu-latest'' && github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event_name == ''push'' || github.event.pull_request.head.repo.full_name == github.repository)) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || matrix.os }}'
+    runs-on: '${{ (matrix.os == ''ubuntu-latest'' && github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event_name == ''push'' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association))) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || matrix.os }}'
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -129,7 +129,7 @@ jobs:
 
   daemon-e2e:
     name: 'Real daemon E2E / Java 11'
-    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event_name == ''push'' || github.event.pull_request.head.repo.full_name == github.repository)) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || ''ubuntu-latest'' }}'
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event_name == ''push'' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association))) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || ''ubuntu-latest'' }}'
     timeout-minutes: 30
     steps:
       - name: 'Restore workspace ownership'

--- a/.github/workflows/sdk-java.yml
+++ b/.github/workflows/sdk-java.yml
@@ -52,7 +52,7 @@ concurrency:
 jobs:
   test:
     name: '${{ matrix.os }} / Java ${{ matrix.java }}'
-    runs-on: '${{ (matrix.os == ''ubuntu-latest'' && github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event_name == ''push'' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association))) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || matrix.os }}'
+    runs-on: '${{ (matrix.os == ''ubuntu-latest'' && github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event_name == ''push'' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON(''["OWNER","MEMBER","COLLABORATOR"]''), github.event.pull_request.author_association))) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || matrix.os }}'
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -129,7 +129,7 @@ jobs:
 
   daemon-e2e:
     name: 'Real daemon E2E / Java 11'
-    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event_name == ''push'' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association))) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || ''ubuntu-latest'' }}'
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event_name == ''push'' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON(''["OWNER","MEMBER","COLLABORATOR"]''), github.event.pull_request.author_association))) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || ''ubuntu-latest'' }}'
     timeout-minutes: 30
     steps:
       - name: 'Restore workspace ownership'

--- a/.github/workflows/serve-ab-publish.yml
+++ b/.github/workflows/serve-ab-publish.yml
@@ -32,9 +32,23 @@ jobs:
       github.repository == 'QwenLM/qwen-code' &&
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
-    runs-on: 'ubuntu-latest'
+    # Checks out nothing and runs no repository code (workflow_run events use
+    # base-repo YAML), so the persistent ECS pool is safe.
+    # Kill-switch: MAINTAINER_ECS_RUNNER_DISABLED.
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'') && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     timeout-minutes: 10
     steps:
+      - name: 'Restore workspace ownership'
+        if: "${{ runner.environment == 'self-hosted' }}"
+        run: |-
+          set -uo pipefail
+          RUNNER_UID="$(id -u)"
+          RUNNER_GID="$(id -g)"
+          if [ "$RUNNER_UID" != "0" ]; then
+            chown -R "$RUNNER_UID:$RUNNER_GID" "$GITHUB_WORKSPACE" 2>/dev/null || sudo -n chown -R "$RUNNER_UID:$RUNNER_GID" "$GITHUB_WORKSPACE" || echo "::warning::could not restore workspace ownership; artifact download may fail on leftover root-owned files"
+          fi
+          chmod -R u+rwX "$GITHUB_WORKSPACE" 2>/dev/null || sudo -n chmod -R u+rwX "$GITHUB_WORKSPACE" || echo "::warning::could not restore workspace write permissions; artifact download may fail on leftover read-only files"
+
       - name: 'Download serve-ab artifact'
         id: 'download'
         continue-on-error: true

--- a/.github/workflows/serve-ab.yml
+++ b/.github/workflows/serve-ab.yml
@@ -44,9 +44,24 @@ jobs:
   ab:
     name: 'Serve A/B (ubuntu-latest, Node 22.x)'
     if: "${{ github.repository == 'QwenLM/qwen-code' }}"
-    runs-on: 'ubuntu-latest'
+    # Same-repo PRs and fork PRs whose author has write access
+    # (OWNER/MEMBER/COLLABORATOR association) run on the persistent ECS pool;
+    # other fork PRs stay on ephemeral hosted runners.
+    # Kill-switch: MAINTAINER_ECS_RUNNER_DISABLED.
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association))) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     timeout-minutes: 30
     steps:
+      - name: 'Restore workspace ownership'
+        if: "${{ runner.environment == 'self-hosted' }}"
+        run: |-
+          set -uo pipefail
+          RUNNER_UID="$(id -u)"
+          RUNNER_GID="$(id -g)"
+          if [ "$RUNNER_UID" != "0" ]; then
+            chown -R "$RUNNER_UID:$RUNNER_GID" "$GITHUB_WORKSPACE" 2>/dev/null || sudo -n chown -R "$RUNNER_UID:$RUNNER_GID" "$GITHUB_WORKSPACE" || echo "::warning::could not restore workspace ownership; checkout may fail on leftover root-owned files"
+          fi
+          chmod -R u+rwX "$GITHUB_WORKSPACE" 2>/dev/null || sudo -n chmod -R u+rwX "$GITHUB_WORKSPACE" || echo "::warning::could not restore workspace write permissions; checkout may fail on leftover read-only files"
+
       - name: 'Checkout PR head'
         uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
         with:

--- a/.github/workflows/serve-ab.yml
+++ b/.github/workflows/serve-ab.yml
@@ -7,12 +7,21 @@ name: 'Serve A/B'
 # the daemon analog of the web-shell visual before/after preview.
 #
 # Security model: this workflow BUILDS AND RUNS untrusted PR code, so it runs on
-# the `pull_request` trigger (fork PRs get a read-only token and NO secrets), on
-# an ephemeral runner, with `contents: read`. It produces only JSON captures +
-# a markdown body as an artifact. The privileged step that needs a write token —
-# posting the comment — lives in the separate workflow_run publisher, which
-# never checks out PR code. The daemon is driven with dummy OpenAI creds, so no
-# model is contacted and the responses are deterministic + safe to diff.
+# the `pull_request` trigger (fork PRs get a read-only token and NO secrets) and
+# with `contents: read`. It produces only JSON captures + a markdown body as an
+# artifact. The privileged step that needs a write token — posting the comment —
+# lives in the separate workflow_run publisher, which never checks out PR code.
+# The daemon is driven with dummy OpenAI creds, so no model is contacted and the
+# responses are deterministic + safe to diff.
+#
+# Runner routing: in-repo PRs, and fork PRs whose author has write access
+# (OWNER/MEMBER/COLLABORATOR association), run on the persistent ECS pool —
+# a write-access author could push the same code to this repo directly, so the
+# pool grants them nothing new, and the pre-checkout wipe below keeps one PR's
+# build from bleeding into the next. Other fork PRs stay on ephemeral hosted
+# runners. NOTE: this trigger reads its YAML from the fork, so the association
+# clause is routing convenience, not a security boundary — the boundary for
+# fork code is the repo's fork-PR workflow-approval setting.
 on:
   pull_request:
     branches:
@@ -46,9 +55,9 @@ jobs:
     if: "${{ github.repository == 'QwenLM/qwen-code' }}"
     # Same-repo PRs and fork PRs whose author has write access
     # (OWNER/MEMBER/COLLABORATOR association) run on the persistent ECS pool;
-    # other fork PRs stay on ephemeral hosted runners.
-    # Kill-switch: MAINTAINER_ECS_RUNNER_DISABLED.
-    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON(''["OWNER", "MEMBER", "COLLABORATOR"]''), github.event.pull_request.author_association))) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
+    # other fork PRs stay on ephemeral hosted runners. Keep in sync with
+    # ci.yml's classify_pr routing. Kill-switch: MAINTAINER_ECS_RUNNER_DISABLED.
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON(''["OWNER","MEMBER","COLLABORATOR"]''), github.event.pull_request.author_association))) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     timeout-minutes: 30
     steps:
       - name: 'Restore workspace ownership'
@@ -61,6 +70,17 @@ jobs:
             chown -R "$RUNNER_UID:$RUNNER_GID" "$GITHUB_WORKSPACE" 2>/dev/null || sudo -n chown -R "$RUNNER_UID:$RUNNER_GID" "$GITHUB_WORKSPACE" || echo "::warning::could not restore workspace ownership; checkout may fail on leftover root-owned files"
           fi
           chmod -R u+rwX "$GITHUB_WORKSPACE" 2>/dev/null || sudo -n chmod -R u+rwX "$GITHUB_WORKSPACE" || echo "::warning::could not restore workspace write permissions; checkout may fail on leftover read-only files"
+
+      - name: 'Wipe stale workspace before checkout'
+        if: "${{ runner.environment == 'self-hosted' }}"
+        run: |-
+          set -uo pipefail
+          # The two checkouts clone into head/ and base/ subdirectories;
+          # leftovers there from a previous run on the same reusable runner
+          # could bleed into the builds and silently change the posted A/B
+          # diff. Hosted runners are ephemeral and never see this. After the
+          # ownership-restore step everything is user-owned, so no sudo.
+          find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
 
       - name: 'Checkout PR head'
         uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,6 +14,9 @@ jobs:
     # base-repo YAML), so the persistent ECS pool is safe.
     # Kill-switch: MAINTAINER_ECS_RUNNER_DISABLED.
     runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'') && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
+    # A hung sweep must not pin a persistent pool machine for the 360-minute
+    # default; the sweep itself finishes in well under this.
+    timeout-minutes: 10
     permissions:
       issues: 'write'
       pull-requests: 'write'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,10 @@ on:
 
 jobs:
   stale:
-    runs-on: 'ubuntu-latest'
+    # Checks out nothing and runs no repository code (schedule/dispatch use
+    # base-repo YAML), so the persistent ECS pool is safe.
+    # Kill-switch: MAINTAINER_ECS_RUNNER_DISABLED.
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'') && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     permissions:
       issues: 'write'
       pull-requests: 'write'

--- a/.github/workflows/web-shell-visuals-cleanup.yml
+++ b/.github/workflows/web-shell-visuals-cleanup.yml
@@ -19,7 +19,10 @@ permissions:
 jobs:
   delete-asset-branch:
     if: "${{ github.repository == 'QwenLM/qwen-code' }}"
-    runs-on: 'ubuntu-latest'
+    # Checks out nothing and runs no repository code (pull_request_target
+    # events use base-repo YAML), so the persistent ECS pool is safe.
+    # Kill-switch: MAINTAINER_ECS_RUNNER_DISABLED.
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'') && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     timeout-minutes: 5
     steps:
       - name: 'Delete the PR asset branches'

--- a/scripts/tests/comment-attachment-guard-workflow.test.js
+++ b/scripts/tests/comment-attachment-guard-workflow.test.js
@@ -107,9 +107,12 @@ describe('comment attachment guard workflow', () => {
   // its own checks. So the only unsafe direction is skipping a scan that
   // should have run, and every ambiguity must resolve toward running.
   describe('job-level gate', () => {
+    const startIdx = workflow.indexOf('  remove-suspicious-attachments:');
+    // Search from the job start: a file-global indexOf would silently change
+    // the slice's meaning if a job were ever added above this one.
     const gate = workflow.slice(
-      workflow.indexOf('  remove-suspicious-attachments:'),
-      workflow.indexOf('runs-on:'),
+      startIdx,
+      workflow.indexOf('runs-on:', startIdx),
     );
 
     it('gates on association and sender before a runner is allocated', () => {

--- a/scripts/tests/comment-attachment-guard-workflow.test.js
+++ b/scripts/tests/comment-attachment-guard-workflow.test.js
@@ -109,7 +109,7 @@ describe('comment attachment guard workflow', () => {
   describe('job-level gate', () => {
     const gate = workflow.slice(
       workflow.indexOf('  remove-suspicious-attachments:'),
-      workflow.indexOf("runs-on: 'ubuntu-latest'"),
+      workflow.indexOf('runs-on:'),
     );
 
     it('gates on association and sender before a runner is allocated', () => {

--- a/scripts/tests/sdk-java-workflow.test.js
+++ b/scripts/tests/sdk-java-workflow.test.js
@@ -15,6 +15,10 @@ describe('SDK Java self-hosted workflow guards', () => {
       "github.repository == ''QwenLM/qwen-code''",
       'github.event.pull_request.head.repo.full_name == github.repository',
       "vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true''",
+      // Write-access fork authors route to ECS too; the association list is
+      // the repo's established trusted set. Negative associations (CONTRIBUTOR,
+      // NONE, '') fail contains() and stay hosted.
+      'contains(fromJSON(\'\'["OWNER","MEMBER","COLLABORATOR"]\'\'), github.event.pull_request.author_association)',
       'fromJSON(\'\'["self-hosted", "linux", "x64", "ecs-qwen"]\'\')',
       "format('refs/pull/{0}/head', github.event.pull_request.number)",
       "EXPECTED_SHA: '${{ github.event.pull_request.head.sha }}'",


### PR DESCRIPTION
## What this PR does

Two runner-routing changes, both behind the existing `MAINTAINER_ECS_RUNNER_DISABLED` kill-switch:

1. Fork PRs whose author has write access now run their Linux CI on the self-hosted ECS pool, the same as in-repo PRs. Where the workflow YAML is base-repo-controlled and the expression is the security boundary (`pull_request_target` triage agent), routing keys on a REAL write-permission check — the collaborator-permission API lookup the authorize job performs, exposed as `author_can_write` — because `author_association` over-admits (MEMBER is any org member; COLLABORATOR includes read-only invitees). Where the YAML comes from the fork anyway (`pull_request` workflows: main CI, SDK Java, Serve A/B), an OWNER/MEMBER/COLLABORATOR association clause routes trusted authors off the hosted queue — convenience, not a boundary. The permission-gate jobs themselves stay on the same-repo guard. This also moves same-repo Serve A/B runs to ECS (disclosed: broader than fork parity), with a pre-checkout workspace wipe so one PR's build cannot bleed into the next.
2. Bot workflows that check out no code and execute no repository code (labeling, force-push reminders, triage finalize, stale, asset-branch cleanup, evidence publishing, attachment guard, docs deploy, autofix issue filing) move to the ECS pool unconditionally. Their events all use base-repo YAML, so there is no foreign code to isolate. Two jobs stay hosted on purpose for independence: the fleet watchdog (a wedged pool would queue the job that recovers it) and the CI-failure reporter (it must file even when the pool is why CI broke).

Jobs newly routed to ECS that check out code or download artifacts get the same workspace-ownership restore pre-step the existing ECS-bound jobs use; newly routed jobs also get explicit timeouts so a hang cannot pin a persistent machine for the 360-minute default.

## Why it's needed

The GitHub-hosted runner quota (shared org-wide) is saturated: 100+ queued runs while ~35 run, with PR CI waiting over an hour. Meanwhile the 55-machine self-hosted ECS pool sits ~60% idle because only in-repo branches may use it. The queue is dominated by (a) bot workflows hardcoded to hosted runners and (b) fork PRs from the maintainers themselves. Trust is keyed to write access, not to where the branch lives: an author who can push to the repo gains nothing new from running on the pool (which is also network-isolated, per the existing verify-lane decision). macOS/Windows jobs stay hosted — there is no self-hosted pool for them.

Deliberately out of scope: autofix routing/command jobs (reachable from fork-YAML label events and secret-bearing — separate review), the web-shell visuals capture job (Playwright browser install needs a hosted environment), release/CD pipelines, and anything requiring a container runtime the ECS pool lacks.

## Reviewer Test Plan

### How to verify

- Confirm the new routing expressions parse: `node scripts/lint.js --actionlint` and yamllint both pass locally; CI's lint job will re-run them.
- Workflow tests: `npx vitest run --config ./scripts/tests/vitest.config.ts` over the workflow suites (392 passed) and `node --test` over the helper suites (144 + 56 triage + 6 new routing passed). The new `ci-runner-routing.test.mjs` executes the real pick_runner shell and simulates the runs-on expression over the full association matrix, asserting they agree (drift guard) and that non-write associations stay hosted (negative cases).
- After merge, watch a maintainer fork PR: its Classify/Test jobs should land on `ecs-qwen` runners (check the job's runner labels), and the next cron/comment burst of bot workflows should skip the hosted queue. Flipping `MAINTAINER_ECS_RUNNER_DISABLED=true` must revert everything to hosted.
- Untrusted fork PRs must still route to `ubuntu-latest` — the association check only admits OWNER/MEMBER/COLLABORATOR, which GitHub computes from the event payload (not attacker-controllable from the fork).

### Evidence (Before & After)

N/A (CI infrastructure change; evidence is the test output above and post-merge runner labels).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Local lint + workflow test suites only; runtime behavior verifies in CI after merge.

## Risk & Scope

- Main risk or tradeoff: a bug in a newly migrated job surfaces on persistent runners instead of ephemeral ones; mitigated by the per-repo guard, the kill-switch, the workspace-restore/wipe pre-steps, and explicit timeouts. On the `pull_request_target` boundary the trust decision is the real collaborator-permission check, not `author_association`.
- Not validated / out of scope: real ECS execution (verifies post-merge), autofix jobs, visuals capture, release pipelines. Deferred to a follow-up (recorded in the review thread): collapsing the duplicated workspace-ownership blocks into a composite action, and the ECS-capacity runbook note.
- Breaking changes / migration notes: none; job names (required status contexts) are unchanged. The fork-PR workflow-approval setting (Settings → Actions → General) should be on “Require approval for all outside collaborators”; it is not API-readable for public repos, so confirm it in the UI.

## Linked Issues

Follow-up to the queue investigation on PR #8496 (maintainer fork PR stuck behind the hosted-runner quota).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

两处 runner 路由调整,均受现有 `MAINTAINER_ECS_RUNNER_DISABLED` 开关控制:

1. 作者拥有仓库写权限的 fork PR,其 Linux CI 现在与仓库内分支一样跑在自建 ECS 池上。在 YAML 由 base 仓库控制、表达式即安全边界的场景(pull_request_target 的 triage agent),路由依据是真实的写权限检查——authorize job 本来就会调用的 collaborator-permission API,新增 `author_can_write` 输出——因为 `author_association` 过度放行(MEMBER 是任意 org 成员,COLLABORATOR 含只读受邀者)。在 YAML 本来就来自 fork 的场景(pull_request 类 workflow:主 CI、SDK Java、Serve A/B),用 OWNER/MEMBER/COLLABORATOR association 条款把可信作者送出 hosted 队列——是便利而非边界。权限门禁 job 本身保持同仓库守卫。同时披露:这也会把同仓库的 Serve A/B 迁到 ECS(比"fork 对等"更宽),并加了 checkout 前 workspace 清理,避免上一个 PR 的构建污染下一个 A/B diff。
2. 不 checkout 代码、不执行仓库代码的 bot workflow(打标签、force-push 提醒、triage finalize、stale、资源分支清理、证据发布、附件守卫、文档部署、autofix 建 issue)无条件迁到 ECS 池。它们的触发事件都使用 base 仓库 YAML,没有外来代码需要隔离。两个 job 为保持独立性故意留在 hosted:fleet 看门狗(池卡死时恢复它的 job 不能排在它后面)、CI 失败上报(池本身就是故障原因时报告也必须能发出)。

新迁入 ECS 且需要 checkout 或下载 artifact 的 job,补上了现有 ECS job 同款的 workspace 属主恢复前置步骤;新迁入的 job 还补了显式 timeout,避免挂起时按 360 分钟默认值占用持久化机器。

## 为什么需要

GitHub-hosted runner 配额(全 org 共享)已饱和:100+ run 排队、仅 ~35 个在跑,PR CI 等待超过 1 小时;而 55 台自建 ECS 池约 60% 空闲,因为只允许仓库内分支使用。队列大头正是 (a) 硬编码 hosted 的 bot workflow 和 (b) 维护者自己 fork 提的 PR。信任边界应按写权限划分,而不是分支在哪:能直接推仓库的作者跑在 ECS 上不会获得任何新能力(且该池已是网络隔离的,与现有 verify lane 的决策一致)。macOS/Windows job 保持 hosted——没有对应的自建池。

明确不在本次范围:autofix 的路由/命令 job(可经 fork-YAML 的 label 事件触达且携带 secrets,需单独评审)、web-shell 截图采集 job(Playwright 浏览器安装依赖 hosted 环境)、发布/CD 流水线,以及依赖 ECS 池所没有的容器运行时的任务。

## 审阅者测试计划

### 如何验证

- 路由表达式解析:`node scripts/lint.js --actionlint` 与 yamllint 本地通过,CI lint 会再跑一遍。
- workflow 测试:vitest 各 workflow 套件 392 通过;`node --test` helper 套件 144 + triage 56 + 新增路由 6 全部通过。新增的 `ci-runner-routing.test.mjs` 会真实执行 pick_runner shell 并对 runs-on 表达式做全 association 矩阵模拟,断言两者一致(防漂移),且非写权限 association 一律留在 hosted(负例)。
- 合并后观察维护者 fork PR:Classify/Test 应落在 `ecs-qwen` runner(查看 job 的 runner 标签),下一轮 cron/评论触发的 bot workflow 应绕过 hosted 队列。将 `MAINTAINER_ECS_RUNNER_DISABLED=true` 后必须全部回退 hosted。
- 非可信 fork PR 仍须走 `ubuntu-latest`——association 检查只放行 OWNER/MEMBER/COLLABORATOR,该值由 GitHub 从事件载荷计算,fork 无法伪造。

### 前后对比证据

N/A(CI 基建改动;证据为上述测试输出与合并后的 runner 标签)。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 运行环境(可选)

仅本地 lint + workflow 测试套件;运行时行为合并后由 CI 验证。

## 风险与范围

- 主要风险/权衡:新迁移 job 若有问题会暴露在持久化 runner 而非一次性 runner 上;通过仓库守卫、kill-switch、workspace 恢复/清理前置步骤和显式 timeout 缓解。pull_request_target 边界上的信任决策是真实的 collaborator-permission 检查,而不是 `author_association`。
- 未验证/超出范围:ECS 上的真实运行(合并后验证)、autofix job、截图采集、发布流水线。已记录在评审线程的后续项:把重复的 workspace 属主恢复块收敛为 composite action、ECS 容量 runbook 备注。
- 破坏性变更/迁移说明:无;job 名称(必需状态上下文)未变。fork PR 审批设置(Settings → Actions → General)应处于“Require approval for all outside collaborators”;该设置对公开仓库无 API 可读,请在 UI 确认。

## 关联 Issue

源自 #8496 的队列排查(维护者 fork PR 卡在 hosted runner 配额之后)。

</details>
