### PR TITLE
docs: document headless Goal workflows

### DIFF
--- a/docs/users/features/headless.md
+++ b/docs/users/features/headless.md
@@ -58,6 +58,37 @@ qwen --resume 123e4567-e89b-12d3-a456-426614174000 -p "Apply the follow-up refac
 > - Session data is project-scoped JSONL under `~/.qwen/projects/<sanitized-cwd>/chats`.
 > - Restores conversation history, tool outputs, and chat-compression checkpoints before sending the new prompt.
 
+## Run a Persistent Goal
+
+Headless mode accepts `/goal` as the entire prompt. Goal state is stored with the session, so use `--continue` or `--resume <sessionId>` to inspect or control the same Goal from a later process. This requires `general.chatRecording` to remain enabled (the default).
+
+```bash
+# Create a Goal and start its worker
+qwen -p "/goal Finish the release checklist"
+
+# Inspect its saved state in the same session
+qwen --continue -p "/goal"
+```
+
+Use the same `qwen --continue -p "<control>"` pattern for the other operations:
+
+| Control                              | Behavior                                                                                 |
+| ------------------------------------ | ---------------------------------------------------------------------------------------- |
+| `/goal`                              | Report the stored state without calling the model.                                       |
+| `/goal <objective>` or `/goal set …` | Create or replace the Goal and start headless Goal work.                                 |
+| `/goal edit <objective>`             | Revise a non-completed Goal; work starts immediately when the resulting state is active. |
+| `/goal pause`                        | Pause an active Goal without calling the model.                                          |
+| `/goal resume`                       | Resume an eligible Goal and start headless Goal work.                                    |
+| `/goal clear`                        | Clear the Goal without confirmation or a model call.                                     |
+
+Runtime-scheduled Goal continuation segments do not count against `--max-session-turns`, but real user prompts still do. Explicit `--max-wall-time` and `--max-tool-calls` budgets continue to apply; exceeding either pauses active Goal work before the run exits with the budget-specific error.
+
+With `--output-format stream-json`, each Goal status change emits a `stream_event` whose `event.type` is `goal_state`. This canonical state event is emitted even without `--include-partial-messages`. When partial messages are enabled, the older `active_goal` event follows as a compatibility projection; automation should treat `goal_state` as authoritative.
+
+> [!note]
+>
+> This behavior applies to standard headless CLI runs. ACP still uses the legacy Goal command path.
+
 ## Customize the Main Session Prompt
 
 You can change the main session system prompt for a single CLI run without editing shared memory files.


### PR DESCRIPTION
## What this PR does

Documents the Goal v3 lifecycle for non-interactive CLI runs, including persisted control across processes, valid state transitions, autonomous continuation behavior, safety-budget boundaries, streaming event compatibility, and the current ACP limitation.

## Why it's needed

Headless Goal support is implemented and tested, but its user-facing contract was absent from the headless guide. Automation authors need to know how to resume and control stored Goal state, which limits apply to autonomous work, and which streaming event is authoritative.

## Reviewer Test Plan

### How to verify

Compare the documented controls with the non-interactive command behavior and Goal state-transition rules. Confirm that status, pause, and clear complete without model work; creating, editing an active Goal, and resuming an eligible Goal start the worker; runtime continuations do not consume the generic session-turn limit; explicit wall-time and tool-call budgets still pause active work; and the canonical streaming state event precedes the compatibility projection.

The focused non-interactive command, runtime, and streaming suites passed with 221 tests passing and one existing test skipped. The repository build, workspace typecheck, formatting check, and diff whitespace check also passed.

### Evidence (Before & After)

N/A — documentation-only change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 27.0 (arm64), Node.js 24.18.0, and npm 11.16.0 in a local worktree without sandboxing.

## Risk & Scope

- Main risk or tradeoff: The guidance could become stale if Goal lifecycle or streaming compatibility behavior changes; every documented claim was checked against current implementation and focused tests.
- Not validated / out of scope: Windows and Linux were not tested locally, and no live-model end-to-end run was performed. README and non-documentation behavior are unchanged.
- Breaking changes / migration notes: None.

## Linked Issues

N/A.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

记录非交互 CLI 运行中的 Goal v3 生命周期，包括跨进程持久化控制、有效状态转换、自动续跑行为、安全预算边界、流式事件兼容性，以及当前 ACP 的限制。

## 为什么需要

Headless Goal 支持已经实现并有测试覆盖，但面向用户的行为契约未出现在 headless 指南中。自动化使用者需要知道如何恢复和控制已保存的 Goal 状态、哪些限制适用于自动工作，以及哪个流式事件是权威状态来源。

## Reviewer 测试计划

### 如何验证

将文档中的控制操作与非交互命令行为及 Goal 状态转换规则逐项比较。确认状态查询、暂停和清除不会触发模型工作；创建、编辑处于活跃状态的 Goal 以及恢复符合条件的 Goal 会启动 worker；运行时续跑不会消耗通用会话回合限制；显式墙钟时间和工具调用预算仍会暂停活跃工作；权威的流式状态事件先于兼容投影事件发出。

聚焦的非交互命令、运行时与流式测试套件共有 221 个测试通过，1 个既有测试跳过。仓库构建、workspace 类型检查、格式检查和 diff 空白检查也均通过。

### 前后证据

N/A——仅文档改动。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

macOS 27.0（arm64）、Node.js 24.18.0、npm 11.16.0，本地 worktree，未启用 sandbox。

## 风险与范围

- 主要风险或取舍：如果 Goal 生命周期或流式兼容行为发生变化，说明可能过时；本次已将每项文档声明与当前实现和聚焦测试核对。
- 未验证或不在范围内：未在本地测试 Windows 和 Linux，也未执行真实模型端到端运行。README 与非文档行为均未改动。
- 破坏性变更或迁移说明：无。

## 关联 Issue

N/A。

</details>
