### PR TITLE
fix(cli): keep stream-json sessions alive after interrupt

### DIFF
--- a/integration-tests/sdk-typescript/abort-and-lifecycle.test.ts
+++ b/integration-tests/sdk-typescript/abort-and-lifecycle.test.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   query,
   AbortError,
@@ -13,6 +13,7 @@ import {
   isSDKAssistantMessage,
   isSDKPartialAssistantMessage,
   isSDKResultMessage,
+  type SDKMessage,
   type TextBlock,
   type SDKUserMessage,
 } from '@qwen-code/sdk';
@@ -326,6 +327,102 @@ describe('AbortController and Process Lifecycle (E2E)', () => {
         expect(receivedResponse).toBe(true);
         expect(endInputCalled).toBe(true);
       } finally {
+        await q.close();
+        await fakeServer.close();
+      }
+    });
+
+    it('keeps a reusable query alive after interrupting the active turn', async () => {
+      let releaseFirstResponse: () => void = () => {};
+      const firstResponseReady = new Promise<void>((resolve) => {
+        releaseFirstResponse = resolve;
+      });
+      const fakeServer = await startFakeOpenAIServer(
+        async ({ requestIndex }) => {
+          if (requestIndex === 0) {
+            await firstResponseReady;
+            return { content: 'STALE_FIRST_TURN_RESPONSE' };
+          }
+          return { content: 'SECOND_TURN_SURVIVED' };
+        },
+        FAKE_SERVER_OPTIONS,
+      );
+
+      let releaseSecondPrompt: () => void = () => {};
+      const secondPromptReady = new Promise<void>((resolve) => {
+        releaseSecondPrompt = resolve;
+      });
+      const sessionId = crypto.randomUUID();
+      async function* createPrompt(): AsyncIterable<SDKUserMessage> {
+        yield {
+          type: 'user',
+          session_id: sessionId,
+          message: { role: 'user', content: 'first prompt: wait' },
+          parent_tool_use_id: null,
+        };
+        await secondPromptReady;
+        yield {
+          type: 'user',
+          session_id: sessionId,
+          message: { role: 'user', content: 'second prompt: prove reuse' },
+          parent_tool_use_id: null,
+        };
+      }
+
+      const q = query({
+        prompt: createPrompt(),
+        options: {
+          ...SHARED_TEST_OPTIONS,
+          ...fakeModelOptions(fakeServer.baseUrl),
+          cwd: testDir,
+          debug: false,
+        },
+      });
+      const messages: SDKMessage[] = [];
+      let consumeTimeout: ReturnType<typeof setTimeout> | undefined;
+
+      try {
+        const consume = (async () => {
+          for await (const message of q) {
+            messages.push(message);
+          }
+        })();
+
+        await vi.waitFor(
+          () => {
+            expect(fakeServer.requests.length).toBeGreaterThanOrEqual(1);
+          },
+          { timeout: 30_000 },
+        );
+        await q.interrupt();
+        releaseFirstResponse();
+        releaseSecondPrompt();
+        await Promise.race([
+          consume,
+          new Promise<never>((_, reject) => {
+            consumeTimeout = setTimeout(
+              () =>
+                reject(
+                  new Error('Reusable query did not finish after interrupt'),
+                ),
+              30_000,
+            );
+          }),
+        ]);
+
+        const successfulResults = messages.filter(
+          (message) => isSDKResultMessage(message) && !message.is_error,
+        );
+        expect(
+          successfulResults.some((message) =>
+            message.result.includes('SECOND_TURN_SURVIVED'),
+          ),
+        ).toBe(true);
+        expect(fakeServer.requests.length).toBeGreaterThanOrEqual(2);
+      } finally {
+        if (consumeTimeout) clearTimeout(consumeTimeout);
+        releaseFirstResponse();
+        releaseSecondPrompt();
         await q.close();
         await fakeServer.close();
       }

--- a/packages/cli/src/nonInteractive/control/ControlContext.ts
+++ b/packages/cli/src/nonInteractive/control/ControlContext.ts
@@ -31,6 +31,7 @@ export interface IControlContext {
   readonly streamJson: StreamJsonOutputAdapter;
   readonly sessionId: string;
   readonly abortSignal: AbortSignal;
+  readonly getActiveTurnAbortSignal?: () => AbortSignal | undefined;
   readonly debugMode: boolean;
   readonly settings: LoadedSettings;
 
@@ -57,6 +58,7 @@ export class ControlContext implements IControlContext {
   readonly streamJson: StreamJsonOutputAdapter;
   readonly sessionId: string;
   readonly abortSignal: AbortSignal;
+  readonly getActiveTurnAbortSignal?: () => AbortSignal | undefined;
   readonly debugMode: boolean;
   readonly settings: LoadedSettings;
 
@@ -74,6 +76,7 @@ export class ControlContext implements IControlContext {
     streamJson: StreamJsonOutputAdapter;
     sessionId: string;
     abortSignal: AbortSignal;
+    getActiveTurnAbortSignal?: () => AbortSignal | undefined;
     settings: LoadedSettings;
     permissionMode?: PermissionMode;
     onInterrupt?: () => void;
@@ -83,6 +86,7 @@ export class ControlContext implements IControlContext {
     this.streamJson = options.streamJson;
     this.sessionId = options.sessionId;
     this.abortSignal = options.abortSignal;
+    this.getActiveTurnAbortSignal = options.getActiveTurnAbortSignal;
     this.debugMode = options.config.getDebugMode();
     this.settings = options.settings;
     this.permissionMode = options.permissionMode || 'default';

--- a/packages/cli/src/nonInteractive/control/ControlDispatcher.test.ts
+++ b/packages/cli/src/nonInteractive/control/ControlDispatcher.test.ts
@@ -887,8 +887,9 @@ describe('ControlDispatcher', () => {
       vi.mocked(mockSystemController.cleanup).mockImplementation(() => {});
 
       dispatcher.shutdown();
+      dispatcher.shutdown();
 
-      expect(mockSystemController.cleanup).toHaveBeenCalled();
+      expect(mockSystemController.cleanup).toHaveBeenCalledTimes(1);
     });
 
     it('should shutdown in debug mode without throwing', () => {

--- a/packages/cli/src/nonInteractive/control/ControlDispatcher.ts
+++ b/packages/cli/src/nonInteractive/control/ControlDispatcher.ts
@@ -78,6 +78,7 @@ export class ControlDispatcher implements IPendingRequestRegistry {
     new Map();
 
   private abortHandler: (() => void) | null = null;
+  private isShutdown = false;
 
   constructor(context: IControlContext) {
     this.context = context;
@@ -237,6 +238,10 @@ export class ControlDispatcher implements IPendingRequestRegistry {
    * Stops all pending requests and cleans up all controllers
    */
   shutdown(): void {
+    if (this.isShutdown) {
+      return;
+    }
+    this.isShutdown = true;
     debugLogger.debug('[ControlDispatcher] Shutting down');
 
     // Remove abort listener to prevent memory leak

--- a/packages/cli/src/nonInteractive/control/controllers/baseController.ts
+++ b/packages/cli/src/nonInteractive/control/controllers/baseController.ts
@@ -73,6 +73,19 @@ export abstract class BaseController {
   }
 
   /**
+   * Capture cancellation for a request owned by the current turn. Session
+   * cancellation always applies; when a turn is active, interrupting that
+   * turn also cancels the request. Call this when creating each request so a
+   * later active turn cannot take ownership of work already in flight.
+   */
+  protected getTurnRequestAbortSignal(): AbortSignal {
+    const activeTurnSignal = this.context.getActiveTurnAbortSignal?.();
+    return activeTurnSignal
+      ? AbortSignal.any([this.context.abortSignal, activeTurnSignal])
+      : this.context.abortSignal;
+  }
+
+  /**
    * Handle an incoming control request
    *
    * Manages lifecycle: register -> process -> deregister

--- a/packages/cli/src/nonInteractive/control/controllers/permissionController.test.ts
+++ b/packages/cli/src/nonInteractive/control/controllers/permissionController.test.ts
@@ -420,6 +420,66 @@ describe('PermissionController', () => {
     });
   });
 
+  it('binds an outgoing permission request to the turn that created it', async () => {
+    const firstTurn = new AbortController();
+    const secondTurn = new AbortController();
+    let activeTurnSignal = firstTurn.signal;
+    const context = {
+      ...createContext(120_000),
+      getActiveTurnAbortSignal: () => activeTurnSignal,
+    } satisfies IControlContext;
+    const controller = new PermissionController(
+      context,
+      createRegistry(),
+      'PermissionController',
+    );
+    let requestSignal: AbortSignal | undefined;
+    vi.spyOn(controller, 'sendControlRequest').mockImplementation(
+      (_payload, _timeout, signal) => {
+        requestSignal = signal;
+        return new Promise((_, reject) => {
+          signal?.addEventListener(
+            'abort',
+            () => reject(new Error('Request aborted')),
+            { once: true },
+          );
+        });
+      },
+    );
+    const onConfirm = vi.fn();
+
+    const updateToolCalls = controller.getToolCallUpdateCallback();
+    activeTurnSignal = secondTurn.signal;
+    updateToolCalls([
+      {
+        status: 'awaiting_approval',
+        request: {
+          callId: 'tool-call-turn-owned',
+          name: 'run_shell_command',
+          args: { command: 'sleep 10' },
+        },
+        confirmationDetails: {
+          type: 'exec',
+          title: 'Run command',
+          onConfirm,
+        },
+      },
+    ]);
+
+    await vi.waitFor(() => {
+      expect(requestSignal).toBeDefined();
+    });
+    firstTurn.abort();
+
+    await vi.waitFor(() => {
+      expect(requestSignal?.aborted).toBe(true);
+      expect(onConfirm).toHaveBeenCalledWith(ToolConfirmationOutcome.Cancel, {
+        cancelMessage: 'Error: Request aborted',
+      });
+    });
+    expect(secondTurn.signal.aborted).toBe(false);
+  });
+
   it('routes ask_user_question answers from updatedInput into the confirmation payload', async () => {
     const context = createContext(120_000);
     const controller = new PermissionController(

--- a/packages/cli/src/nonInteractive/control/controllers/permissionController.ts
+++ b/packages/cli/src/nonInteractive/control/controllers/permissionController.ts
@@ -43,13 +43,6 @@ const DEFAULT_CAN_USE_TOOL_TIMEOUT_MS = 60_000;
 export class PermissionController extends BaseController {
   private pendingOutgoingRequests = new Set<string>();
 
-  private getTurnRequestAbortSignal(): AbortSignal {
-    const activeTurnSignal = this.context.getActiveTurnAbortSignal?.();
-    return activeTurnSignal
-      ? AbortSignal.any([this.context.abortSignal, activeTurnSignal])
-      : this.context.abortSignal;
-  }
-
   /**
    * Handle permission control requests
    */

--- a/packages/cli/src/nonInteractive/control/controllers/permissionController.ts
+++ b/packages/cli/src/nonInteractive/control/controllers/permissionController.ts
@@ -43,6 +43,13 @@ const DEFAULT_CAN_USE_TOOL_TIMEOUT_MS = 60_000;
 export class PermissionController extends BaseController {
   private pendingOutgoingRequests = new Set<string>();
 
+  private getTurnRequestAbortSignal(): AbortSignal {
+    const activeTurnSignal = this.context.getActiveTurnAbortSignal?.();
+    return activeTurnSignal
+      ? AbortSignal.any([this.context.abortSignal, activeTurnSignal])
+      : this.context.abortSignal;
+  }
+
   /**
    * Handle permission control requests
    */
@@ -258,6 +265,7 @@ export class PermissionController extends BaseController {
    * This is passed to executeToolCall to hook into CoreToolScheduler updates
    */
   getToolCallUpdateCallback(): (toolCalls: unknown[]) => void {
+    const turnSignal = this.getTurnRequestAbortSignal();
     return (toolCalls: unknown[]) => {
       for (const call of toolCalls) {
         if (
@@ -271,7 +279,7 @@ export class PermissionController extends BaseController {
             !this.pendingOutgoingRequests.has(awaiting.request.callId)
           ) {
             this.pendingOutgoingRequests.add(awaiting.request.callId);
-            void this.handleOutgoingPermissionRequest(awaiting);
+            void this.handleOutgoingPermissionRequest(awaiting, turnSignal);
           }
         }
       }
@@ -330,7 +338,7 @@ export class PermissionController extends BaseController {
     event: TeammateApprovalRequestEvent,
   ): Promise<void> {
     try {
-      if (this.context.abortSignal?.aborted) {
+      if (this.context.abortSignal.aborted) {
         await event.respond(ToolConfirmationOutcome.Cancel);
         return;
       }
@@ -504,6 +512,7 @@ export class PermissionController extends BaseController {
    */
   private async handleOutgoingPermissionRequest(
     toolCall: WaitingToolCall,
+    signal: AbortSignal,
   ): Promise<void> {
     const requiresUserInteraction =
       toolCall.invocation?.requiresUserInteraction?.() === true;
@@ -513,7 +522,7 @@ export class PermissionController extends BaseController {
         : `The host could not present the required approval for "${toolCall.request.name}".`;
     try {
       // Check if already aborted
-      if (this.context.abortSignal?.aborted) {
+      if (signal.aborted) {
         await toolCall.confirmationDetails.onConfirm(
           ToolConfirmationOutcome.Cancel,
         );
@@ -557,7 +566,7 @@ export class PermissionController extends BaseController {
           blocked_path: null,
         } as CLIControlPermissionRequest,
         this.context.sdkCanUseToolTimeoutMs ?? DEFAULT_CAN_USE_TOOL_TIMEOUT_MS,
-        this.context.abortSignal,
+        signal,
       );
 
       if (response.subtype !== 'success') {

--- a/packages/cli/src/nonInteractive/control/controllers/sdkMcpController.test.ts
+++ b/packages/cli/src/nonInteractive/control/controllers/sdkMcpController.test.ts
@@ -84,5 +84,28 @@ describe('SdkMcpController', () => {
     expect(requestSignal?.aborted).toBe(true);
     expect(session.signal.aborted).toBe(false);
     expect(secondTurn.signal.aborted).toBe(false);
+
+    requestSignal = undefined;
+    const sessionRequest = sendMcpMessage('sdk-server', {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/list',
+    } as JSONRPCMessage);
+    const sessionResult = sessionRequest.then(
+      () => ({ status: 'fulfilled' as const }),
+      (error: unknown) => ({ status: 'rejected' as const, error }),
+    );
+    await vi.waitFor(() => {
+      expect(requestSignal).toBeDefined();
+    });
+    const sessionOwnedSignal = requestSignal as AbortSignal | undefined;
+    session.abort();
+
+    await expect(sessionResult).resolves.toMatchObject({
+      status: 'rejected',
+      error: expect.objectContaining({ message: 'Request aborted' }),
+    });
+    expect(sessionOwnedSignal?.aborted).toBe(true);
+    expect(secondTurn.signal.aborted).toBe(false);
   });
 });

--- a/packages/cli/src/nonInteractive/control/controllers/sdkMcpController.test.ts
+++ b/packages/cli/src/nonInteractive/control/controllers/sdkMcpController.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
+import { createMinimalSettings } from '../../../config/settings.js';
+import type { StreamJsonOutputAdapter } from '../../io/StreamJsonOutputAdapter.js';
+import type { IControlContext } from '../ControlContext.js';
+import type { IPendingRequestRegistry } from './baseController.js';
+import { SdkMcpController } from './sdkMcpController.js';
+
+function createRegistry(): IPendingRequestRegistry {
+  return {
+    registerIncomingRequest: vi.fn(),
+    deregisterIncomingRequest: vi.fn(),
+    registerOutgoingRequest: vi.fn(),
+    deregisterOutgoingRequest: vi.fn(),
+  };
+}
+
+describe('SdkMcpController', () => {
+  it('binds an SDK MCP request to the turn that created it', async () => {
+    const session = new AbortController();
+    const firstTurn = new AbortController();
+    const secondTurn = new AbortController();
+    let activeTurnSignal = firstTurn.signal;
+    const context: IControlContext = {
+      config: {
+        getDebugMode: vi.fn().mockReturnValue(false),
+      } as unknown as IControlContext['config'],
+      streamJson: { send: vi.fn() } as unknown as StreamJsonOutputAdapter,
+      sessionId: 'test-session-id',
+      abortSignal: session.signal,
+      getActiveTurnAbortSignal: () => activeTurnSignal,
+      debugMode: false,
+      settings: createMinimalSettings(),
+      permissionMode: 'default',
+      sdkMcpServers: new Set<string>(),
+      mcpClients: new Map(),
+      inputClosed: false,
+    };
+    const controller = new SdkMcpController(
+      context,
+      createRegistry(),
+      'SdkMcpController',
+    );
+    let requestSignal: AbortSignal | undefined;
+    vi.spyOn(controller, 'sendControlRequest').mockImplementation(
+      (_payload, _timeout, signal) => {
+        requestSignal = signal;
+        return new Promise((_, reject) => {
+          signal?.addEventListener(
+            'abort',
+            () => reject(new Error('Request aborted')),
+            { once: true },
+          );
+        });
+      },
+    );
+    const sendMcpMessage = controller.createSendSdkMcpMessage();
+    const request = sendMcpMessage('sdk-server', {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/list',
+    } as JSONRPCMessage);
+    const result = request.then(
+      () => ({ status: 'fulfilled' as const }),
+      (error: unknown) => ({ status: 'rejected' as const, error }),
+    );
+
+    await vi.waitFor(() => {
+      expect(requestSignal).toBeDefined();
+    });
+    activeTurnSignal = secondTurn.signal;
+    firstTurn.abort();
+
+    await expect(result).resolves.toMatchObject({
+      status: 'rejected',
+      error: expect.objectContaining({ message: 'Request aborted' }),
+    });
+    expect(requestSignal?.aborted).toBe(true);
+    expect(session.signal.aborted).toBe(false);
+    expect(secondTurn.signal.aborted).toBe(false);
+  });
+});

--- a/packages/cli/src/nonInteractive/control/controllers/sdkMcpController.ts
+++ b/packages/cli/src/nonInteractive/control/controllers/sdkMcpController.ts
@@ -90,10 +90,7 @@ export class SdkMcpController extends BaseController {
     // Capture the current turn now. A later turn may become active while this
     // request is still pending, but interrupt must continue to target the turn
     // that created the request.
-    const activeTurnSignal = this.context.getActiveTurnAbortSignal?.();
-    const signal = activeTurnSignal
-      ? AbortSignal.any([this.context.abortSignal, activeTurnSignal])
-      : this.context.abortSignal;
+    const signal = this.getTurnRequestAbortSignal();
 
     // Send control request to SDK with the MCP message
     const response = await this.sendControlRequest(

--- a/packages/cli/src/nonInteractive/control/controllers/sdkMcpController.ts
+++ b/packages/cli/src/nonInteractive/control/controllers/sdkMcpController.ts
@@ -87,6 +87,14 @@ export class SdkMcpController extends BaseController {
       JSON.stringify(message),
     );
 
+    // Capture the current turn now. A later turn may become active while this
+    // request is still pending, but interrupt must continue to target the turn
+    // that created the request.
+    const activeTurnSignal = this.context.getActiveTurnAbortSignal?.();
+    const signal = activeTurnSignal
+      ? AbortSignal.any([this.context.abortSignal, activeTurnSignal])
+      : this.context.abortSignal;
+
     // Send control request to SDK with the MCP message
     const response = await this.sendControlRequest(
       {
@@ -95,7 +103,7 @@ export class SdkMcpController extends BaseController {
         message: message as CLIControlMcpMessageRequest['message'],
       },
       MCP_REQUEST_TIMEOUT,
-      this.context.abortSignal,
+      signal,
     );
 
     // Extract MCP response from control response

--- a/packages/cli/src/nonInteractive/session.test.ts
+++ b/packages/cli/src/nonInteractive/session.test.ts
@@ -25,6 +25,12 @@ const runNonInteractiveMock = vi.fn();
 // Mock dependencies
 vi.mock('../nonInteractiveCli.js', () => ({
   runNonInteractive: (...args: unknown[]) => runNonInteractiveMock(...args),
+  TurnInterruptedError: class TurnInterruptedError extends Error {
+    constructor() {
+      super('Operation cancelled.');
+      this.name = 'TurnInterruptedError';
+    }
+  },
 }));
 
 vi.mock('./io/StreamJsonInputReader.js', () => ({
@@ -262,6 +268,8 @@ describe('runNonInteractiveStreamJson', () => {
   type CapturedControlContext = {
     onContinueLastTurn?: () => Promise<Record<string, unknown>>;
     onInterrupt?: () => void;
+    abortSignal?: AbortSignal;
+    getActiveTurnAbortSignal?: () => AbortSignal | undefined;
   };
 
   function installContinueDispatch(): {
@@ -487,7 +495,7 @@ describe('runNonInteractiveStreamJson', () => {
     );
   });
 
-  it('rejects continue_last_turn after the session has been interrupted', async () => {
+  it('keeps continue_last_turn available after an interrupt with no active turn', async () => {
     const { continueResults, getControlContext } = installContinueDispatch();
     createInitializedGeminiClient([
       { role: 'user', parts: [{ text: 'resume me' }] },
@@ -506,9 +514,65 @@ describe('runNonInteractiveStreamJson', () => {
     await runNonInteractiveStreamJson(config, '');
 
     expect(continueResults).toEqual([
-      { accepted: false, interruption: 'none' },
+      { accepted: true, interruption: 'interrupted_prompt' },
     ]);
-    expect(runNonInteractiveMock).not.toHaveBeenCalled();
+    expect(runNonInteractiveMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('interrupts only the active turn and accepts a later prompt', async () => {
+    let controlContext: CapturedControlContext | undefined;
+    (ControlContext as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (options: CapturedControlContext) => {
+        controlContext = options;
+        return {};
+      },
+    );
+
+    const turnControllers: AbortController[] = [];
+    runNonInteractiveMock.mockImplementation(
+      (
+        _config: Config,
+        _settings: unknown,
+        _input: string,
+        _promptId: string,
+        options: { abortController: AbortController },
+      ) => {
+        const turnController = options.abortController;
+        turnControllers.push(turnController);
+        if (turnControllers.length > 1) {
+          return Promise.resolve();
+        }
+        return new Promise<void>((resolve) => {
+          turnController.signal.addEventListener('abort', () => resolve(), {
+            once: true,
+          });
+        });
+      },
+    );
+
+    mockInputReader.read = async function* () {
+      yield createControlRequest('initialize');
+      yield createUserMessage('first prompt');
+      await vi.waitFor(() => {
+        expect(turnControllers).toHaveLength(1);
+        expect(controlContext).toBeDefined();
+      });
+
+      expect(controlContext?.getActiveTurnAbortSignal?.()).toBe(
+        turnControllers[0]?.signal,
+      );
+      controlContext?.onInterrupt?.();
+      expect(turnControllers[0]?.signal.aborted).toBe(true);
+      expect(controlContext?.abortSignal?.aborted).toBe(false);
+
+      yield createUserMessage('second prompt');
+    };
+
+    await runNonInteractiveStreamJson(config, '');
+
+    expect(runNonInteractiveMock).toHaveBeenCalledTimes(2);
+    expect(turnControllers[1]).not.toBe(turnControllers[0]);
+    expect(turnControllers[1]?.signal.aborted).toBe(false);
   });
 
   it('emits a terminal error result when an accepted continuation is abandoned by shutdown', async () => {
@@ -541,9 +605,9 @@ describe('runNonInteractiveStreamJson', () => {
       // pending yet, so pendingContinueTurn becomes true. ensureProcessingStarted
       // is a no-op because the user-message work loop is already running.
       continueResults.push(await getControlContext()?.onContinueLastTurn?.());
-      // Begin shutdown before the continuation can run, then let the work loop
-      // unwind. Its abort guard skips the still-pending continuation.
-      getControlContext()?.onInterrupt?.();
+      // Begin a real session shutdown before the continuation can run, then
+      // let the work loop unwind. Its abort guard skips the pending work.
+      process.emit('SIGTERM', 'SIGTERM');
       releaseFirstTurn();
     };
 
@@ -1431,6 +1495,15 @@ describe('runNonInteractiveStreamJson', () => {
     let releaseProcessing: (() => void) | undefined;
     const callOrder: string[] = [];
     const streamError = new Error('Stream error');
+    let sessionSignal: AbortSignal | undefined;
+    let turnSignal: AbortSignal | undefined;
+
+    (ControlContext as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (options: { abortSignal: AbortSignal }) => {
+        sessionSignal = options.abortSignal;
+        return {};
+      },
+    );
 
     mockMonitorRegistry.abortAll.mockImplementation(() => {
       callOrder.push('monitor:abortAll');
@@ -1443,8 +1516,15 @@ describe('runNonInteractiveStreamJson', () => {
     });
 
     runNonInteractiveMock.mockImplementationOnce(
-      () =>
+      (
+        _config: Config,
+        _settings: unknown,
+        _input: string,
+        _promptId: string,
+        options: { abortController: AbortController },
+      ) =>
         new Promise<void>((resolve) => {
+          turnSignal = options.abortController.signal;
           callOrder.push('run:start');
           releaseProcessing = () => {
             callOrder.push('run:end');
@@ -1462,6 +1542,8 @@ describe('runNonInteractiveStreamJson', () => {
     const sessionPromise = runNonInteractiveStreamJson(config, '');
     await vi.waitFor(() => {
       expect(releaseProcessing).toBeDefined();
+      expect(sessionSignal?.aborted).toBe(true);
+      expect(turnSignal?.aborted).toBe(true);
     });
 
     expect(mockMonitorRegistry.abortAll).toHaveBeenCalledTimes(1);

--- a/packages/cli/src/nonInteractive/session.ts
+++ b/packages/cli/src/nonInteractive/session.ts
@@ -38,7 +38,10 @@ import {
 } from './types.js';
 import { createMinimalSettings } from '../config/settings.js';
 import type { LoadedSettings } from '../config/settings.js';
-import { runNonInteractive } from '../nonInteractiveCli.js';
+import {
+  runNonInteractive,
+  TurnInterruptedError,
+} from '../nonInteractiveCli.js';
 import {
   finalizeStartupProfile,
   profileCheckpoint,
@@ -72,7 +75,8 @@ class Session {
   private monitorQueue: MonitorQueueItem[] = [];
   private pendingContinueTurn: boolean = false;
   private continueTurnInProgress: boolean = false;
-  private abortController: AbortController;
+  private readonly sessionAbortController: AbortController;
+  private activeTurnAbortController: AbortController | null = null;
   private config: Config;
   private sessionId: string;
   private promptIdCounter: number = 0;
@@ -106,7 +110,7 @@ class Session {
     this.config = config;
     this.settings = settings;
     this.sessionId = config.getSessionId();
-    this.abortController = new AbortController();
+    this.sessionAbortController = new AbortController();
     this.initialPrompt = initialPrompt ?? null;
 
     this.inputReader = new StreamJsonInputReader();
@@ -220,7 +224,7 @@ class Session {
 
     const registry = this.config.getMonitorRegistry();
     registry.setNotificationCallback((displayText, modelText, meta) => {
-      if (this.isShuttingDown || this.abortController.signal.aborted) {
+      if (this.isShuttingDown || this.sessionAbortController.signal.aborted) {
         return;
       }
       if (meta.status === 'running' && typeof registry.get === 'function') {
@@ -247,7 +251,7 @@ class Session {
 
     const registry = this.config.getMonitorRegistry();
     registry.setRegisterCallback((entry) => {
-      if (this.isShuttingDown || this.abortController.signal.aborted) {
+      if (this.isShuttingDown || this.sessionAbortController.signal.aborted) {
         return;
       }
       this.enqueueMonitorStarted({
@@ -301,7 +305,8 @@ class Session {
       config: this.config,
       streamJson: this.outputAdapter,
       sessionId: this.sessionId,
-      abortSignal: this.abortController.signal,
+      abortSignal: this.sessionAbortController.signal,
+      getActiveTurnAbortSignal: () => this.activeTurnAbortController?.signal,
       settings: this.settings,
       permissionMode: this.config.getApprovalMode(),
       onInterrupt: () => this.handleInterrupt(),
@@ -473,17 +478,21 @@ class Session {
     await this.waitForInitialization();
 
     const promptId = this.getNextPromptId();
+    const turnAbortController = this.startTurn();
 
     try {
       await runNonInteractive(this.config, this.settings, input, promptId, {
-        abortController: this.abortController,
+        abortController: turnAbortController,
         adapter: this.outputAdapter,
         controlService: this.controlService ?? undefined,
         captureMonitorNotifications: false,
         captureMonitorRegistrations: false,
+        recoverableCancellation: true,
       });
     } catch (error) {
       debugLogger.error('[Session] Query execution error:', error);
+    } finally {
+      this.finishTurn(turnAbortController);
     }
   }
 
@@ -496,7 +505,7 @@ class Session {
   private async requestContinueLastTurn(): Promise<Record<string, unknown>> {
     await this.waitForInitialization();
 
-    if (this.isShuttingDown || this.abortController.signal.aborted) {
+    if (this.isShuttingDown || this.sessionAbortController.signal.aborted) {
       debugLogger.debug(
         '[Session] continue_last_turn rejected: session is shutting down',
       );
@@ -559,17 +568,20 @@ class Session {
   private async processContinueTurn(): Promise<void> {
     this.continueTurnInProgress = true;
     let resultAlreadyEmitted = false;
+    let turnAbortController: AbortController | null = null;
     try {
       await this.waitForInitialization();
 
       const promptId = this.getNextPromptId();
+      turnAbortController = this.startTurn();
       await runNonInteractive(this.config, this.settings, '', promptId, {
-        abortController: this.abortController,
+        abortController: turnAbortController,
         adapter: this.outputAdapter,
         controlService: this.controlService ?? undefined,
         continueInterrupted: true,
         captureMonitorNotifications: false,
         captureMonitorRegistrations: false,
+        recoverableCancellation: true,
         onResultEmitted: () => {
           resultAlreadyEmitted = true;
         },
@@ -589,6 +601,9 @@ class Session {
       }
       throw new Error(`Continue turn failed: ${message}`, { cause: error });
     } finally {
+      if (turnAbortController) {
+        this.finishTurn(turnAbortController);
+      }
       this.continueTurnInProgress = false;
     }
   }
@@ -623,25 +638,31 @@ class Session {
     const combinedDisplayText = batch.map((n) => n.displayText).join('; ');
 
     const promptId = this.getNextPromptId();
-    await runNonInteractive(
-      this.config,
-      this.settings,
-      combinedModelText,
-      promptId,
-      {
-        abortController: this.abortController,
-        adapter: this.outputAdapter,
-        controlService: this.controlService ?? undefined,
-        sendMessageType: SendMessageType.Notification,
-        notificationDisplayText: combinedDisplayText,
-        captureMonitorNotifications: false,
-        captureMonitorRegistrations: false,
-      },
-    );
+    const turnAbortController = this.startTurn();
+    try {
+      await runNonInteractive(
+        this.config,
+        this.settings,
+        combinedModelText,
+        promptId,
+        {
+          abortController: turnAbortController,
+          adapter: this.outputAdapter,
+          controlService: this.controlService ?? undefined,
+          sendMessageType: SendMessageType.Notification,
+          notificationDisplayText: combinedDisplayText,
+          captureMonitorNotifications: false,
+          captureMonitorRegistrations: false,
+          recoverableCancellation: true,
+        },
+      );
+    } finally {
+      this.finishTurn(turnAbortController);
+    }
   }
 
   private async processPendingWork(): Promise<void> {
-    if (this.isShuttingDown || this.abortController.signal.aborted) {
+    if (this.isShuttingDown || this.sessionAbortController.signal.aborted) {
       return;
     }
 
@@ -651,7 +672,7 @@ class Session {
         this.monitorStartedQueue.length > 0 ||
         this.monitorQueue.length > 0) &&
       !this.isShuttingDown &&
-      !this.abortController.signal.aborted
+      !this.sessionAbortController.signal.aborted
     ) {
       if (this.pendingContinueTurn) {
         this.pendingContinueTurn = false;
@@ -725,7 +746,7 @@ class Session {
           this.monitorStartedQueue.length > 0 ||
           this.monitorQueue.length > 0) &&
         !this.isShuttingDown &&
-        !this.abortController.signal.aborted
+        !this.sessionAbortController.signal.aborted
       ) {
         this.ensureProcessingStarted();
       }
@@ -752,16 +773,34 @@ class Session {
 
   private handleInterrupt(): void {
     debugLogger.info('[Session] Interrupt requested');
-    this.abortController.abort();
-    // Do not create a new AbortController to prevent listener leaks.
-    // Subsequent queries will check signal.aborted and fail immediately.
+    this.activeTurnAbortController?.abort(new TurnInterruptedError());
+  }
+
+  private startTurn(): AbortController {
+    const controller = new AbortController();
+    if (this.sessionAbortController.signal.aborted) {
+      controller.abort(this.sessionAbortController.signal.reason);
+    }
+    this.activeTurnAbortController = controller;
+    return controller;
+  }
+
+  private finishTurn(controller: AbortController): void {
+    if (this.activeTurnAbortController === controller) {
+      this.activeTurnAbortController = null;
+    }
+  }
+
+  private abortSession(): void {
+    this.activeTurnAbortController?.abort();
+    this.sessionAbortController.abort();
   }
 
   private setupSignalHandlers(): void {
     this.shutdownHandler = () => {
       debugLogger.info('[Session] Shutdown signal received');
       this.isShuttingDown = true;
-      this.abortController.abort();
+      this.abortSession();
     };
 
     process.on('SIGINT', this.shutdownHandler);
@@ -819,6 +858,7 @@ class Session {
     debugLogger.debug('[Session] Shutting down');
 
     this.isShuttingDown = true;
+    this.abortSession();
     this.abortTaskRegistries();
     this.stopMonitorCallbacks();
 
@@ -849,6 +889,7 @@ class Session {
   }
 
   private finishShutdown(): void {
+    this.abortSession();
     this.dispatcher?.shutdown();
     this.cleanupSignalHandlers();
   }
@@ -910,7 +951,7 @@ class Session {
 
       try {
         for await (const message of this.inputReader.read()) {
-          if (this.abortController.signal.aborted) {
+          if (this.sessionAbortController.signal.aborted) {
             break;
           }
 

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -50,6 +50,7 @@ import { EventEmitter } from 'node:events';
 import {
   runNonInteractive,
   skipHeadlessLoopSentinel,
+  TurnInterruptedError,
 } from './nonInteractiveCli.js';
 import { vi, type Mock, type MockInstance } from 'vitest';
 import * as fs from 'node:fs/promises';
@@ -4518,6 +4519,54 @@ describe('runNonInteractive', () => {
       type: 'result',
       is_error: false,
       num_turns: 1,
+    });
+  });
+
+  it('returns from a recoverably interrupted stream-json turn without exiting', async () => {
+    (mockConfig.getOutputFormat as Mock).mockReturnValue('stream-json');
+    (mockConfig.getIncludePartialMessages as Mock).mockReturnValue(false);
+    setupMetricsMock();
+
+    const writes: string[] = [];
+    processStdoutSpy.mockImplementation((chunk: string | Uint8Array) => {
+      writes.push(
+        typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'),
+      );
+      return true;
+    });
+    const turnAbortController = new AbortController();
+    mockGeminiClient.sendMessageStream.mockReturnValue(
+      (async function* () {
+        turnAbortController.abort(new TurnInterruptedError());
+        yield {
+          type: GeminiEventType.Finished,
+          value: { reason: undefined, usageMetadata: { totalTokenCount: 0 } },
+        } as ServerGeminiStreamEvent;
+      })(),
+    );
+
+    const exitCode = await runNonInteractive(
+      mockConfig,
+      mockSettings,
+      'interrupt me',
+      'prompt-recoverable-interrupt',
+      {
+        abortController: turnAbortController,
+        recoverableCancellation: true,
+      },
+    );
+
+    const envelopes = writes
+      .join('')
+      .split('\n')
+      .filter((line) => line.trim().length > 0)
+      .map((line) => JSON.parse(line));
+    expect(exitCode).toBe(130);
+    expect(process.exit).not.toHaveBeenCalled();
+    expect(envelopes.at(-1)).toMatchObject({
+      type: 'result',
+      is_error: true,
+      error: { message: 'Operation cancelled.' },
     });
   });
 

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -93,6 +93,13 @@ import { cleanupReviewWorktreeLeases } from './services/review-worktree-lease.js
 
 const debugLogger = createDebugLogger('NON_INTERACTIVE_CLI');
 
+export class TurnInterruptedError extends Error {
+  constructor() {
+    super('Operation cancelled.');
+    this.name = 'TurnInterruptedError';
+  }
+}
+
 const restoredBackgroundAgentSessions = new WeakMap<Config, Set<string>>();
 
 /**
@@ -426,6 +433,13 @@ export interface RunNonInteractiveOptions {
   captureMonitorRegistrations?: boolean;
   onResultEmitted?: () => void;
   /**
+   * Emit a terminal result and return from this turn when its controller is
+   * aborted with {@link TurnInterruptedError}, instead of exiting the process.
+   * Reusable stream-json sessions use this so a protocol interrupt does not
+   * tear down the session; one-shot callers retain the process-level default.
+   */
+  recoverableCancellation?: boolean;
+  /**
    * Continue the most recent unfinished turn from chat history instead of
    * submitting `input` (which is ignored). No new user message enters the
    * transcript: an orphaned trailing user entry is re-submitted with Retry
@@ -731,6 +745,12 @@ export async function runNonInteractive(
         // so the outer catch's `errorMessage` field stays actionable
         // (vs. a useless literal "unreachable").
         throw new Error(exceeded.message);
+      }
+      if (
+        options.recoverableCancellation === true &&
+        abortController.signal.reason instanceof TurnInterruptedError
+      ) {
+        throw abortController.signal.reason;
       }
       await handleCancellationError(config);
       throw new Error('Operation cancelled.');
@@ -2870,13 +2890,19 @@ export async function runNonInteractive(
       // exit with the budget handler's exit code 55 instead of the
       // generic `handleError` exit code 1 from a raw "AbortError".
       const budgetExceeded = budgetEnforcer.getExceeded();
+      const recoverableCancellation =
+        !budgetExceeded &&
+        options.recoverableCancellation === true &&
+        abortController.signal.reason instanceof TurnInterruptedError;
 
       // For JSON and STREAM_JSON modes, compute usage from metrics
       const message = budgetExceeded
         ? budgetExceeded.message
-        : error instanceof Error
-          ? error.message
-          : String(error);
+        : recoverableCancellation
+          ? abortController.signal.reason.message
+          : error instanceof Error
+            ? error.message
+            : String(error);
       const metrics = uiTelemetryService.getMetrics();
       const usage = computeUsageFromMetrics(metrics);
       // Get stats for JSON format output
@@ -2929,6 +2955,9 @@ export async function runNonInteractive(
         // Always exit AFTER emitResult so STREAM_JSON / JSON consumers
         // see a terminal result envelope before the process dies.
         await handleBudgetExceededError(config, budgetExceeded);
+      }
+      if (recoverableCancellation) {
+        return 130;
       }
       await handleError(error, config);
     } finally {


### PR DESCRIPTION
## What this PR does

This separates reusable stream-json session lifetime from active-turn cancellation. Every user, continuation, and monitor turn now gets a fresh abort controller; protocol `interrupt` aborts only that controller, while stdin close and SIGINT/SIGTERM still abort both the active turn and the session control plane.

Turn-owned permission and SDK MCP requests capture the signal of the turn that created them, so a later turn cannot accidentally take ownership. Reusable-session cancellation is explicitly recoverable in `runNonInteractive`: it emits the terminal interrupted result for that turn and returns without terminating the CLI process. One-shot cancellation behavior remains unchanged, and dispatcher shutdown is idempotent during full teardown.

The PR includes focused lifecycle/controller tests and a real SDK integration regression that gates the first model response, interrupts while that turn is active, and proves a second prompt completes on the same spawned production CLI.

## Why it's needed

Reusable stream-json sessions previously shared one `AbortController` across the session dispatcher and every model turn. Calling `interrupt()` permanently aborted that lifetime controller, shut down control dispatch, dropped later prompts, and could route cancellation through `process.exit(130)`. This contradicted the reusable-session contract and made ownership of pending permission/MCP requests ambiguous.

## Reviewer Test Plan

### How to verify

Build the production bundle, then run the committed regression:

```sh
npm run build -- --cli-only
npm run bundle
npm run test:integration:sandbox:none -- sdk-typescript/abort-and-lifecycle.test.ts -t 'keeps a reusable query alive after interrupting the active turn'
```

The test must report one pass. It holds the first fake-model request open, calls SDK `interrupt()`, releases a second prompt on the same async-generator query, and requires the successful result to contain `SECOND_TURN_SURVIVED` without a code-130 process exit.

Focused regression command:

```sh
npm test --workspace packages/cli -- --run src/nonInteractive/session.test.ts src/nonInteractiveCli.test.ts src/nonInteractive/control/ControlDispatcher.test.ts src/nonInteractive/control/controllers/permissionController.test.ts src/nonInteractive/control/controllers/sdkMcpController.test.ts --coverage.enabled=false
```

Observed locally: 5 files passed; 221 tests passed and 1 skipped.

### Evidence (Before & After)

Before: the focused session regression had 2 failures out of 39 tests—the lifetime signal stayed aborted, `continue_last_turn` was rejected, and a later prompt timed out. The first real-process attempt exited the reusable CLI with code 130.

After: the production `dist/cli.js` real-process harness returned `{ "outcome": "PASS", "interruptDurationMs": 11, "resultCount": 2, "secondTurnResult": "SECOND_TURN_SURVIVED" }`. This is a headless lifecycle change with no visual UI, so screenshots are N/A; the gated process transcript and committed integration test are the direct evidence.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS 26.3.2, Node.js v22.23.2, npm 10.9.8, no sandbox, production `dist/cli.js` spawned through `@qwen-code/sdk` against a local fake OpenAI HTTP server.

Additional checks passed: CLI-only build, production bundle, all-workspace typecheck, ESLint with zero warnings, Prettier, `git diff --check`, and two clean code-audit passes. The full CLI suite reached 17,102 tests (17,082 passed, 6 skipped); its only failing file was the unrelated auth UI navigation suite (`AuthDialog.test.tsx`, 14 failures plus a Vitest worker RPC timeout), which also reproduced when run alone and does not intersect the changed paths.

## Risk & Scope

- Main risk or tradeoff: cancellation now has separate lifetime and turn scopes; this is contained behind a reusable-session-only marker/option, while full teardown and one-shot cancellation retain process-level behavior.
- Not validated / out of scope: Windows and Linux were not tested locally; their CI jobs should exercise the same platform-neutral `AbortController` logic. The unrelated `AuthDialog.test.tsx` failures were not changed.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #8495

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 将可复用 stream-json 会话的生命周期与当前轮次取消拆分开来。每个用户消息、续接轮次和监控通知轮次都会获得新的 abort controller；协议层的 `interrupt` 只中止当前轮次，而 stdin 关闭及 SIGINT/SIGTERM 仍会同时中止当前轮次和会话控制面。

属于轮次的权限请求和 SDK MCP 请求会捕获创建它们的轮次信号，因此后续轮次不会意外接管旧请求。`runNonInteractive` 对可复用会话的取消采用显式可恢复路径：为当前轮次发出终止结果后返回，不再结束 CLI 进程。单次调用的取消行为保持不变，完整 teardown 中的 dispatcher shutdown 也改为幂等。

PR 包含聚焦的生命周期/控制器测试，以及一个真实 SDK 集成回归：它阻塞第一条模型响应，在该轮次仍活跃时执行中断，并证明同一个生产 CLI 进程仍能完成第二条 prompt。

## 为什么需要这个改动

此前，可复用 stream-json 会话的 dispatcher 和所有模型轮次共享同一个 `AbortController`。调用 `interrupt()` 会永久中止这个会话级 controller、关闭控制分发、丢弃后续 prompt，并可能通过 `process.exit(130)` 结束进程。这违背了可复用会话契约，也使挂起的权限/MCP 请求归属不明确。

## Reviewer 测试计划

### 验证方法

先构建生产 bundle，再运行提交进仓库的回归测试：

```sh
npm run build -- --cli-only
npm run bundle
npm run test:integration:sandbox:none -- sdk-typescript/abort-and-lifecycle.test.ts -t 'keeps a reusable query alive after interrupting the active turn'
```

测试应报告 1 个通过。它会保持第一个假模型请求处于阻塞状态，调用 SDK `interrupt()`，随后在同一个 async-generator query 中释放第二条 prompt，并要求成功结果包含 `SECOND_TURN_SURVIVED`，且进程不能以代码 130 退出。

聚焦回归命令：

```sh
npm test --workspace packages/cli -- --run src/nonInteractive/session.test.ts src/nonInteractiveCli.test.ts src/nonInteractive/control/ControlDispatcher.test.ts src/nonInteractive/control/controllers/permissionController.test.ts src/nonInteractive/control/controllers/sdkMcpController.test.ts --coverage.enabled=false
```

本地结果：5 个测试文件通过；221 个测试通过，1 个跳过。

### 修复前后证据

修复前：聚焦 session 回归的 39 个测试中有 2 个失败——会话级信号保持 aborted，`continue_last_turn` 被拒绝，后续 prompt 超时。第一次真实进程测试还显示可复用 CLI 以代码 130 退出。

修复后：针对生产 `dist/cli.js` 的真实进程脚本返回 `{ "outcome": "PASS", "interruptDurationMs": 11, "resultCount": 2, "secondTurnResult": "SECOND_TURN_SURVIVED" }`。这是无可视 UI 的 headless 生命周期改动，因此截图不适用；带闸门的进程输出和已提交的集成测试是最直接的证据。

### 已测试平台

|     系统     | 状态 |
| :----------: | :--: |
|  🍏 macOS    |  ✅  |
| 🪟 Windows   |  ⚠️  |
|  🐧 Linux    |  ⚠️  |

### 环境

macOS 26.3.2、Node.js v22.23.2、npm 10.9.8、无 sandbox；通过 `@qwen-code/sdk` 启动生产 `dist/cli.js`，连接本地假的 OpenAI HTTP 服务。

其他已通过检查：CLI-only 构建、生产 bundle、全部 workspace typecheck、零 warning 的 ESLint、Prettier、`git diff --check`，以及连续两轮无发现的代码审计。完整 CLI 套件共运行 17,102 个测试（17,082 个通过、6 个跳过）；唯一失败文件是无关的认证 UI 导航套件（`AuthDialog.test.tsx`，14 个失败并伴随一次 Vitest worker RPC 超时），该失败在单独运行时也能复现，与本次修改路径没有交集。

## 风险与范围

- 主要风险或权衡：取消现在区分会话生命周期和轮次范围；该变化由仅供可复用会话使用的 marker/option 限定，完整 teardown 与单次调用仍保留进程级取消行为。
- 未验证/范围外：未在本地测试 Windows 和 Linux；CI 应覆盖同一套平台无关的 `AbortController` 逻辑。未修改无关的 `AuthDialog.test.tsx` 失败。
- 破坏性改动/迁移说明：无。

## 关联 Issue

Fixes #8495

</details>
