### PR TITLE
fix(web-shell): scope artifact actions to owning workspace

### DIFF
--- a/.qwen/e2e-tests/2026-08-04-secondary-artifact-workspace-ownership.md
+++ b/.qwen/e2e-tests/2026-08-04-secondary-artifact-workspace-ownership.md
@@ -1,0 +1,117 @@
+# Secondary artifact workspace ownership
+
+Issue: https://github.com/QwenLM/qwen-code/issues/8494
+
+## Baseline
+
+- Global CLI: `qwen 0.21.3`
+- `qwen serve --help` confirms repeated `--workspace` registration and Web
+  Shell serving are available.
+- Current component behavior is captured failure-first: an artifact tab with
+  no owner uses root workspace actions, and scheduled-task detail omits the
+  secondary `workspaceId`.
+
+## Local setup
+
+1. Create isolated primary and secondary temporary workspaces.
+2. Put the same relative sentinel filename in both workspaces with different
+   contents.
+3. Create distinct durable scheduled-task fixtures for both runtimes.
+4. Start the built `dist/cli.js serve` on loopback with both `--workspace`
+   flags and the production Web Shell bundle.
+
+## Scenarios
+
+### Secondary file action
+
+Open a secondary-session artifact and download/preview its sentinel.
+
+Expected:
+
+- The request targets `/workspaces/<secondary>/file...`.
+- The returned bytes are the secondary sentinel, never the primary sentinel.
+
+### Secondary scheduled task
+
+Open the secondary durable task, toggle it, edit it, and delete the test copy.
+
+Expected:
+
+- Every request targets `/workspaces/<secondary>/scheduled-tasks...`.
+- The primary task and primary task file are unchanged.
+
+### Ownership loss
+
+Keep an artifact tab open, then remove or mark the secondary workspace
+unavailable in the capability fixture before a delayed read resolves.
+
+Expected:
+
+- The panel displays the localized workspace-unavailable state.
+- The delayed response is ignored.
+- No request is retried against the primary route.
+
+## Evidence
+
+- Focused test output for resolver, turn outputs, artifact panel, nested
+  subagent, and app tab propagation.
+- Production build/typecheck/lint output.
+- Captured two-workspace HTTP route log and sentinel hashes.
+- Browser screenshot of the secondary artifact panel and the fail-closed
+  ownership-loss state when the local browser harness can represent it.
+
+## Results (2026-08-04)
+
+Result: PASS
+
+### Automated verification
+
+- Failure-first run: 3 expected failures and 29 existing passes. The primary
+  sentinel leaked into an ownerless tab, the secondary qualified client was
+  unused, and scheduled-task list omitted `workspaceId`.
+- Focused ownership suite: 413/413 tests passed across the six affected test
+  files.
+- Full Web Shell suite: 167 files and 2,777 tests passed.
+- Web Shell lint and TypeScript typecheck passed.
+- Package Web Shell build and repository root production build passed.
+- The changed files pass Prettier. The package-wide format check still reports
+  five unchanged baseline files:
+  `BranchPickerPopover.module.css`, `GitModePopover.module.css`,
+  `GitDialog.module.css`, `PlanExecutionView.module.css`, and `index.html`.
+
+### Production two-workspace verification
+
+The built CLI served the copied production bundle with two trusted workspaces.
+`GET /capabilities` advertised distinct primary and secondary runtime IDs, and
+the served JavaScript contained the new stale-owner guard.
+
+The same relative file was read through both routes:
+
+- `GET /file?path=artifact-owner.txt` returned
+  `PRIMARY_WORKSPACE_SENTINEL_8494`, SHA-256
+  `818d5f4f1fb9c7e3f9bdfd9a3ad39361c93a23ca3f3d0ba5e4a7c889b33b9127`.
+- `GET /workspaces/<secondary-id>/file?path=artifact-owner.txt` returned
+  `SECONDARY_WORKSPACE_SENTINEL_8494`, SHA-256
+  `0e9fac7909b16ff8b17014ea103ed5018c8b4e9ad21d2f95e128fef3a3544a12`.
+- The secondary bytes route returned only the secondary sentinel bytes.
+
+Durable task CRUD was exercised against isolated primary and secondary task
+fixtures:
+
+- Secondary list, update, and delete requests all used
+  `/workspaces/<secondary-id>/scheduled-tasks...`.
+- The secondary update changed only the secondary name/enabled state.
+- The primary task remained present, enabled, and unchanged after that update.
+- Deleting the secondary task emptied only the secondary list; the primary
+  task was still present. Both test tasks were then removed.
+
+The daemon request log independently recorded the qualified file, bytes,
+scheduled-task POST/GET/PATCH/DELETE routes and their successful statuses.
+
+### Visual evidence
+
+The in-app browser runtime reported no available browser instance, so a UI
+screenshot could not be captured in this environment. No synthetic screenshot
+was substituted. The production server returned the current Web Shell bundle
+with HTTP 200, and the DOM behavior is covered by the focused and full suites
+above.

--- a/docs/design/web-shell-artifact-workspace-ownership.md
+++ b/docs/design/web-shell-artifact-workspace-ownership.md
@@ -1,0 +1,101 @@
+# Web Shell artifact workspace ownership
+
+Status: implemented and verified
+
+Issue: https://github.com/QwenLM/qwen-code/issues/8494
+
+## Problem
+
+The Web Shell has one app-level `DaemonWorkspaceProvider`. Its default
+workspace actions target the primary workspace. Session providers can attach to
+secondary workspaces, but artifact surfaces currently retain or fall back to
+the app-level actions. A file preview, download, review, nested subagent
+artifact, or scheduled-task mutation can therefore reach the primary runtime
+even though the producing session belongs to a secondary workspace.
+
+The unsafe fallback also survives ownership changes: action objects are stored
+in right-panel tabs, so removing or distrusting a workspace does not invalidate
+an already-open tab.
+
+## Ownership contract
+
+The producing session owns every turn output. Its `workspaceCwd`, resolved by
+the session connection, is the source of the owner claim. The current daemon
+capabilities are the authority that accepts or rejects that claim.
+
+A target is usable only when one of these cases holds:
+
+1. Exactly one advertised workspace has the same cwd and is trusted.
+2. For a legacy single-workspace daemon with no workspace list, the cwd exactly
+   matches `capabilities.workspaceCwd`.
+
+Unknown, duplicate, untrusted, removed, or identity-mismatched targets fail
+closed. They never fall back to the primary workspace.
+
+## Design
+
+### Resolve at use time
+
+Turn-output requests and right-panel tabs carry immutable owner identity
+(`workspaceCwd` and the advertised `workspaceId`) instead of long-lived action
+objects. `ArtifactPanel` resolves that identity against current capabilities on
+every render. This makes workspace removal, trust loss, and runtime replacement
+invalidate open tabs immediately.
+
+The resolver returns a small artifact action surface only:
+
+- `readWorkspaceFile`
+- `readFileBytes`
+- `stat`
+- scheduled-task list/update/delete operations
+
+Primary targets reuse the provider's primary actions. Trusted secondary
+targets use `client.workspaceByCwd(cwd)` for file operations. Scheduled-task
+operations still use the Web UI REST actions, but always receive the resolved
+workspace id explicitly.
+
+### Propagation
+
+- `TurnOutputs` derives the owner from its session `workspaceCwd`, uses the
+  scoped file actions for direct downloads, and stamps owner identity onto
+  review, artifact, and scheduled-task open requests.
+- `ChatPane` and `SubagentDetail` preserve the request identity and add only the
+  producing session id. They no longer stamp root workspace actions onto the
+  request or artifact snapshot.
+- `App` stores owner identity on each right-panel tab. Pane artifact snapshots
+  contain artifacts only; they no longer retain workspace clients.
+- `ArtifactPanel` renders the existing workspace-unavailable state when the
+  owner cannot be resolved or no longer matches. It never substitutes
+  `useWorkspaceActions()` for a missing owner.
+- Durable scheduled-task snapshots carry `workspaceId`, and every list,
+  update, toggle, and delete request passes that id.
+
+### Async invalidation
+
+Scoped action wrappers check that their captured owner is still current before
+starting an operation and again after each response. Effects and scheduled-task
+mutations also ignore results after unmount or owner replacement. A response
+started for one runtime cannot populate a tab after that runtime is removed or
+replaced.
+
+## Non-goals
+
+- No daemon route or workspace-registry semantics change.
+- No primary fallback for compatibility on multi-workspace daemons.
+- No redesign of artifact storage, session attachment, or scheduled-task data.
+- No attempt to make arbitrary app-level workspace actions session-scoped;
+  only the artifact surfaces in issue #8494 are changed.
+
+## Verification
+
+1. Failure-first component tests pin the current primary fallback and missing
+   scheduled-task workspace id.
+2. Resolver tests cover primary, trusted secondary, unknown, duplicate,
+   untrusted, removed, and runtime-replaced targets.
+3. Turn-output tests verify secondary downloads and open requests use the
+   secondary owner.
+4. Artifact-panel tests verify missing/stale ownership fails closed and all
+   durable scheduled-task operations include `workspaceId`.
+5. A production bundle is run against two registered local workspaces with
+   distinct sentinel files/tasks. Captured requests must use the secondary
+   workspace-qualified routes and leave the primary sentinels unchanged.

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -239,6 +239,9 @@ const {
       addScratchWorkspace: vi.fn(),
       suggestWorkspacePaths: vi.fn(),
       pickWorkspaceDirectory: vi.fn(),
+      listScheduledTasks: vi.fn(),
+      updateScheduledTask: vi.fn(),
+      deleteScheduledTask: vi.fn(),
     },
     mockMcp: {
       initialize: vi.fn().mockResolvedValue({ accepted: true }),
@@ -942,6 +945,35 @@ vi.doMock('./components/SplitView', async () => {
         ...updatedArtifact,
         status: 'changed',
       };
+      const mainArtifact = {
+        id: 'main-artifact',
+        kind: 'report',
+        storage: 'memory',
+        source: 'tool',
+        status: 'available',
+        title: 'Main artifact',
+        updatedAt: '2026-07-10T00:00:00Z',
+        sizeBytes: 10,
+      };
+      const paneScheduledTask = {
+        id: 'pane-cron',
+        toolCallId: 'pane-cron-call',
+        title: 'Pane task',
+        cron: '0 9 * * *',
+        prompt: 'pane task prompt',
+        recurring: true,
+        durable: true,
+        workspaceId: 'pane-ws',
+      };
+      const paneReviewChanges = [
+        {
+          path: 'notes.md',
+          status: 'modified',
+          toolCallId: 'tool-notes',
+          isArtifact: false,
+          diffs: [],
+        },
+      ];
       return React.createElement(
         'div',
         { 'data-testid': 'split-view-mock' },
@@ -1027,6 +1059,63 @@ vi.doMock('./components/SplitView', async () => {
               }),
           },
           'open artifact',
+        ),
+        React.createElement(
+          'button',
+          {
+            'data-testid': 'split-open-main-artifact',
+            type: 'button',
+            onClick: () =>
+              props.onRightPanelOpen?.({
+                id: 'artifact:main-artifact',
+                kind: 'artifact',
+                title: mainArtifact.title,
+                turnId: 'turn-1',
+                artifactId: mainArtifact.id,
+                artifact: mainArtifact,
+                workspaceCwd: '/tmp/project',
+                workspaceId: 'primary',
+              }),
+          },
+          'open main artifact',
+        ),
+        React.createElement(
+          'button',
+          {
+            'data-testid': 'split-open-scheduled-task',
+            type: 'button',
+            onClick: () =>
+              props.onRightPanelOpen?.({
+                id: 'scheduled-task:pane-cron-call',
+                kind: 'scheduled_task',
+                title: 'Scheduled Tasks',
+                turnId: 'turn-1',
+                task: paneScheduledTask,
+                workspaceCwd: '/tmp/pane',
+                workspaceId: 'pane-ws',
+                sourceSessionId: 'pane-session',
+              }),
+          },
+          'open scheduled task',
+        ),
+        React.createElement(
+          'button',
+          {
+            'data-testid': 'split-open-review',
+            type: 'button',
+            onClick: () =>
+              props.onRightPanelOpen?.({
+                id: 'review',
+                kind: 'review',
+                title: 'Review',
+                turnId: 'turn-1',
+                changes: paneReviewChanges,
+                workspaceCwd: '/tmp/pane',
+                workspaceId: 'pane-ws',
+                sourceSessionId: 'pane-session',
+              }),
+          },
+          'open review',
         ),
         React.createElement(
           'button',
@@ -2334,6 +2423,9 @@ beforeEach(() => {
   mockWorkspaceActions.addScratchWorkspace.mockReset();
   mockWorkspaceActions.suggestWorkspacePaths.mockReset();
   mockWorkspaceActions.pickWorkspaceDirectory.mockReset();
+  mockWorkspaceActions.listScheduledTasks.mockReset();
+  mockWorkspaceActions.updateScheduledTask.mockReset();
+  mockWorkspaceActions.deleteScheduledTask.mockReset();
   mockMcp.initialize.mockClear();
   mockMcp.initialize.mockResolvedValue({ accepted: true });
   mockMcp.reloadConfig.mockClear();
@@ -9890,7 +9982,7 @@ describe('App session callbacks', () => {
     ).toBe('s1,s2,s3');
   });
 
-  it('replaces an extra artifact with its split pane snapshot', async () => {
+  it('updates an open artifact tab from pane snapshots and keeps it after the pane clears', async () => {
     mockWorkspace.capabilities = {
       workspaceCwd: '/tmp/project',
       workspaces: [
@@ -9960,7 +10052,232 @@ describe('App session callbacks', () => {
       await Promise.resolve();
     });
 
-    expect(document.body.textContent).toContain('Artifact not found.');
+    // The pane snapshot is gone, but the extra pushed on open keeps the
+    // still-open tab renderable instead of orphaning it.
+    expect(document.body.textContent).toContain('Pane artifact');
+    expect(document.body.textContent).toContain('10 B');
+    expect(document.body.textContent).not.toContain('Artifact not found.');
+  });
+
+  it('routes a split pane scheduled task through its stamped workspace identity', async () => {
+    mockWorkspace.capabilities = {
+      workspaceCwd: '/tmp/project',
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/tmp/project',
+          primary: true,
+          trusted: true,
+        },
+        {
+          id: 'pane-ws',
+          cwd: '/tmp/pane',
+          primary: false,
+          trusted: true,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+    mockWorkspaceActions.listScheduledTasks.mockResolvedValue([
+      {
+        id: 'pane-cron',
+        name: 'Pane task',
+        cron: '0 9 * * *',
+        prompt: 'pane task prompt',
+        recurring: true,
+        enabled: true,
+        createdAt: 1_700_000_000_000,
+        lastFiredAt: null,
+        nextRunAt: null,
+        sessionId: null,
+        runs: [],
+      },
+    ]);
+    const { container } = renderApp();
+    await flush();
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="open-split-view"]')
+        ?.click();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="split-open-scheduled-task"]',
+        )
+        ?.click();
+      await Promise.resolve();
+    });
+
+    expect(mockWorkspaceActions.listScheduledTasks).toHaveBeenCalledWith(
+      'pane-ws',
+    );
+    expect(document.body.textContent).toContain('Pane task');
+    expect(document.body.textContent).not.toContain(
+      'This workspace may have been removed',
+    );
+  });
+
+  it('routes a split pane review download through its stamped workspace identity', async () => {
+    mockWorkspace.capabilities = {
+      workspaceCwd: '/tmp/project',
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/tmp/project',
+          primary: true,
+          trusted: true,
+        },
+        {
+          id: 'pane-ws',
+          cwd: '/tmp/pane',
+          primary: false,
+          trusted: true,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+    const paneFileStat = vi.fn().mockResolvedValue({
+      sizeBytes: 5,
+      modifiedMs: 1,
+    });
+    const paneReadBytes = vi.fn().mockResolvedValue({
+      contentBase64: btoa('notes'),
+      offset: 0,
+      returnedBytes: 5,
+      sizeBytes: 5,
+    });
+    const paneWorkspaceClient = {
+      workspaceGit: vi.fn().mockResolvedValue({ branch: 'main' }),
+      workspaceSkills: mockWorkspaceActions.loadSkillsStatus,
+      workspaceGitHubPullRequests: vi.fn().mockResolvedValue({
+        v: 1,
+        workspaceCwd: '/tmp/pane',
+        available: true,
+        pullRequests: [],
+      }),
+      fileStat: paneFileStat,
+      readWorkspaceFileBytes: paneReadBytes,
+    };
+    mockWorkspace.client.workspaceByCwd.mockImplementation(
+      () => paneWorkspaceClient,
+    );
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: vi.fn(() => 'blob:pane-review'),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    const { container } = renderApp();
+    await flush();
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="open-split-view"]')
+        ?.click();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="split-open-review"]')
+        ?.click();
+      await Promise.resolve();
+    });
+
+    const download = Array.from(document.body.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Download',
+    );
+    expect(download).toBeDefined();
+    await act(async () => {
+      download?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockWorkspace.client.workspaceByCwd).toHaveBeenCalledWith(
+      '/tmp/pane',
+    );
+    expect(paneFileStat).toHaveBeenCalledWith('notes.md');
+    expect(paneReadBytes).toHaveBeenCalledWith(
+      'notes.md',
+      expect.objectContaining({ offset: 0 }),
+    );
+  });
+
+  it('keeps a main-session artifact tab renderable across a live-list gap', async () => {
+    mockWorkspace.capabilities = {
+      workspaceCwd: '/tmp/project',
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/tmp/project',
+          primary: true,
+          trusted: true,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+    mockConnection.capabilities = {
+      ...mockConnection.capabilities,
+      features: ['session_artifacts'],
+    };
+    const mainArtifactRow = {
+      id: 'main-artifact',
+      kind: 'report',
+      storage: 'memory',
+      source: 'tool',
+      status: 'available',
+      title: 'Main artifact',
+      updatedAt: '2026-07-10T00:00:00Z',
+      sizeBytes: 10,
+    };
+    mockSessionActions.loadArtifacts.mockResolvedValue({
+      artifacts: [mainArtifactRow],
+    });
+    const { container, rerender } = renderApp();
+    await flush();
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="open-split-view"]')
+        ?.click();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="split-open-main-artifact"]',
+        )
+        ?.click();
+      await Promise.resolve();
+    });
+
+    expect(document.body.textContent).toContain('Main artifact');
+    expect(document.body.textContent).toContain('10 B');
+
+    // A transient disconnect empties the live artifact list; the cached
+    // open-time row keeps the tab renderable through the gap.
+    mockConnection.status = 'disconnected';
+    await act(async () => {
+      rerender();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(document.body.textContent).toContain('Main artifact');
+    expect(document.body.textContent).not.toContain('Artifact not found.');
+
+    // Reconnecting restores the live list and reconciles the cached copy.
+    mockConnection.status = 'connected';
+    await act(async () => {
+      rerender();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(document.body.textContent).toContain('Main artifact');
+    mockSessionActions.loadArtifacts.mockResolvedValue({ artifacts: [] });
   });
 
   it('opens a split pane monitor in the right panel', async () => {

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -9890,7 +9890,7 @@ describe('App session callbacks', () => {
     ).toBe('s1,s2,s3');
   });
 
-  it('reconciles split pane artifact snapshots in the right panel', async () => {
+  it('replaces an extra artifact with its split pane snapshot', async () => {
     mockWorkspace.capabilities = {
       workspaceCwd: '/tmp/project',
       workspaces: [
@@ -9913,15 +9913,15 @@ describe('App session callbacks', () => {
     });
     await act(async () => {
       container
-        .querySelector<HTMLButtonElement>(
-          '[data-testid="split-report-artifact"]',
-        )
+        .querySelector<HTMLButtonElement>('[data-testid="split-open-artifact"]')
         ?.click();
       await Promise.resolve();
     });
     await act(async () => {
       container
-        .querySelector<HTMLButtonElement>('[data-testid="split-open-artifact"]')
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="split-report-artifact"]',
+        )
         ?.click();
       await Promise.resolve();
     });
@@ -9989,6 +9989,17 @@ describe('App session callbacks', () => {
   });
 
   it('clears split pane artifact snapshots when switching sessions', async () => {
+    mockWorkspace.capabilities = {
+      workspaceCwd: '/tmp/project',
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/tmp/project',
+          primary: true,
+          trusted: true,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
     const { container, rerender } = renderApp();
     await flush();
 
@@ -10014,6 +10025,10 @@ describe('App session callbacks', () => {
     });
 
     expect(document.body.textContent).toContain('Pane artifact');
+    expect(document.body.textContent).toContain('10 B');
+    expect(document.body.textContent).not.toContain(
+      'This workspace may have been removed',
+    );
 
     await act(async () => {
       mockConnection.sessionId = 'session-2';

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -909,11 +909,7 @@ vi.doMock('./components/SplitView', async () => {
       onExit?: () => void;
       sessionIds?: string[];
       onPanesChange?: (ids: string[]) => void;
-      onPaneArtifactsChange?: (
-        sessionId: string,
-        artifacts: unknown[],
-        workspaceActions: unknown,
-      ) => void;
+      onPaneArtifactsChange?: (sessionId: string, artifacts: unknown[]) => void;
       onRightPanelOpen?: (request: unknown) => void;
       onOpenMonitor?: (
         task: DaemonSessionMonitorTaskStatus,
@@ -926,9 +922,6 @@ vi.doMock('./components/SplitView', async () => {
       }) => unknown;
       voiceWorkspaces?: readonly unknown[];
     }) => {
-      const paneActions = {
-        readWorkspaceFile: vi.fn().mockResolvedValue('<p>pane</p>'),
-      };
       const artifact = {
         id: 'pane-artifact',
         kind: 'report',
@@ -981,11 +974,7 @@ vi.doMock('./components/SplitView', async () => {
             'data-testid': 'split-report-artifact',
             type: 'button',
             onClick: () =>
-              props.onPaneArtifactsChange?.(
-                'pane-session',
-                [artifact],
-                paneActions,
-              ),
+              props.onPaneArtifactsChange?.('pane-session', [artifact]),
           },
           'artifact',
         ),
@@ -995,11 +984,7 @@ vi.doMock('./components/SplitView', async () => {
             'data-testid': 'split-report-updated-artifact',
             type: 'button',
             onClick: () =>
-              props.onPaneArtifactsChange?.(
-                'pane-session',
-                [updatedArtifact],
-                paneActions,
-              ),
+              props.onPaneArtifactsChange?.('pane-session', [updatedArtifact]),
           },
           'updated artifact',
         ),
@@ -1009,11 +994,7 @@ vi.doMock('./components/SplitView', async () => {
             'data-testid': 'split-report-changed-artifact',
             type: 'button',
             onClick: () =>
-              props.onPaneArtifactsChange?.(
-                'pane-session',
-                [changedArtifact],
-                paneActions,
-              ),
+              props.onPaneArtifactsChange?.('pane-session', [changedArtifact]),
           },
           'changed artifact',
         ),
@@ -1022,8 +1003,7 @@ vi.doMock('./components/SplitView', async () => {
           {
             'data-testid': 'split-clear-artifacts',
             type: 'button',
-            onClick: () =>
-              props.onPaneArtifactsChange?.('pane-session', [], paneActions),
+            onClick: () => props.onPaneArtifactsChange?.('pane-session', []),
           },
           'clear artifacts',
         ),
@@ -1040,7 +1020,9 @@ vi.doMock('./components/SplitView', async () => {
                 turnId: 'turn-1',
                 artifactId: artifact.id,
                 artifact,
-                workspaceActions: paneActions,
+                workspaceCwd: '/tmp/project',
+                workspaceId: 'primary',
+                sourceSessionId: 'pane-session',
                 previewContent: '<p>stale</p>',
               }),
           },
@@ -4554,6 +4536,17 @@ describe('App session callbacks', () => {
   });
 
   it('opens the latest reviewable turn from the empty right panel', () => {
+    mockWorkspace.capabilities = {
+      workspaceCwd: '/tmp/project',
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/tmp/project',
+          primary: true,
+          trusted: true,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
     testState.messages = [
       {
         id: 'user-1',
@@ -9898,6 +9891,17 @@ describe('App session callbacks', () => {
   });
 
   it('reconciles split pane artifact snapshots in the right panel', async () => {
+    mockWorkspace.capabilities = {
+      workspaceCwd: '/tmp/project',
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/tmp/project',
+          primary: true,
+          trusted: true,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
     const { container } = renderApp();
     await flush();
 

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -2242,17 +2242,18 @@ export function App({
       return;
     }
     const artifactIds = new Set(artifacts.map((artifact) => artifact.id));
-    const paneArtifactIds = new Set(
+    // Extras referenced by open artifact tabs must survive the reconcile:
+    // they keep those tabs renderable through transient gaps in the live
+    // list, and stay inert while the live list (merged first) covers them.
+    const openArtifactIds = new Set(
       artifactPanelTabs
-        .filter(
-          (tab) => tab.kind === 'artifact' && tab.sourceSessionId !== undefined,
-        )
+        .filter((tab) => tab.kind === 'artifact')
         .map((tab) => (tab.kind === 'artifact' ? tab.artifactId : '')),
     );
     setArtifactPanelExtraArtifacts((previous) => {
       const next = previous.filter(
         (artifact) =>
-          !artifactIds.has(artifact.id) || paneArtifactIds.has(artifact.id),
+          !artifactIds.has(artifact.id) || openArtifactIds.has(artifact.id),
       );
       return next.length === previous.length ? previous : next;
     });
@@ -2272,9 +2273,11 @@ export function App({
       return artifacts;
     }
     const merged = [...artifacts];
+    // Pane snapshots outrank open-time extras so a retained extra never
+    // shadows a fresher pane report for the same artifact id.
     for (const artifact of [
-      ...artifactPanelExtraArtifacts,
       ...paneArtifactExtras,
+      ...artifactPanelExtraArtifacts,
     ]) {
       const index = merged.findIndex((item) => item.id === artifact.id);
       if (index < 0) {
@@ -2292,9 +2295,18 @@ export function App({
         const paneArtifactIds = new Set(
           paneArtifacts.map((artifact) => artifact.id),
         );
+        // Keep extras whose artifact tab is still open: once the pane closes
+        // and its snapshot is dropped, the extra is the tab's only copy.
+        const openArtifactIds = new Set(
+          artifactPanelTabsRef.current
+            .filter((tab) => tab.kind === 'artifact')
+            .map((tab) => (tab.kind === 'artifact' ? tab.artifactId : '')),
+        );
         setArtifactPanelExtraArtifacts((current) => {
           const next = current.filter(
-            (artifact) => !paneArtifactIds.has(artifact.id),
+            (artifact) =>
+              !paneArtifactIds.has(artifact.id) ||
+              openArtifactIds.has(artifact.id),
           );
           return next.length === current.length ? current : next;
         });
@@ -3030,17 +3042,19 @@ export function App({
         );
         return;
       }
-      if (request.sourceSessionId) {
-        setArtifactPanelExtraArtifacts((current) => {
-          const index = current.findIndex(
-            (artifact) => artifact.id === request.artifact.id,
-          );
-          if (index < 0) return [...current, request.artifact];
-          const next = [...current];
-          next[index] = request.artifact;
-          return next;
-        });
-      }
+      // Cache the opened row so the tab keeps rendering through transient
+      // gaps in the live artifact lists (an SSE reconnect, or the source
+      // pane closing); the snapshot/live-list reconciles drop the copy once
+      // a fresher source covers the artifact again.
+      setArtifactPanelExtraArtifacts((current) => {
+        const index = current.findIndex(
+          (artifact) => artifact.id === request.artifact.id,
+        );
+        if (index < 0) return [...current, request.artifact];
+        const next = [...current];
+        next[index] = request.artifact;
+        return next;
+      });
       const tab: ArtifactPanelTab = {
         id: request.sourceSessionId
           ? `${request.sourceSessionId}:${request.id}`

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -26,7 +26,6 @@ import {
   useWorkspaceActions,
   useWorkspaceEventSignals,
   type DaemonSessionActions,
-  type DaemonWorkspaceActions,
   type DaemonSessionNotice,
   type DaemonStreamingState,
 } from '@qwen-code/webui/daemon-react-sdk';
@@ -124,6 +123,7 @@ import {
   getFileChangePreviewContent,
   TURN_OUTPUT_KINDS,
 } from './components/artifacts/TurnOutputs';
+import { useArtifactWorkspaceTarget } from './components/artifacts/useArtifactWorkspaceTarget';
 import {
   getArtifactsByTurn,
   getFileChangesByTurn,
@@ -386,7 +386,6 @@ interface ArtifactPanelSessionState {
 }
 interface PaneArtifactSnapshot {
   artifacts: readonly DaemonSessionArtifact[];
-  workspaceActions: DaemonWorkspaceActions;
 }
 // Cap on how long a manual "run now" waits for its bound session to become
 // active before giving up, so the scheduled-tasks UI can't stay stuck disabled
@@ -1883,6 +1882,9 @@ export function App({
     ) === true;
   const { notices, dismissNotice } = useSessionNotices();
   const workspaceActions = useWorkspaceActions();
+  const artifactWorkspaceTarget = useArtifactWorkspaceTarget(
+    connection.workspaceCwd,
+  );
   const dynamicWorkspaceRegistrationSupported =
     workspace.capabilities?.features?.includes(
       'dynamic_workspace_registration',
@@ -2242,7 +2244,9 @@ export function App({
     const artifactIds = new Set(artifacts.map((artifact) => artifact.id));
     const paneArtifactIds = new Set(
       artifactPanelTabs
-        .filter((tab) => tab.kind === 'artifact' && tab.workspaceActions)
+        .filter(
+          (tab) => tab.kind === 'artifact' && tab.sourceSessionId !== undefined,
+        )
         .map((tab) => (tab.kind === 'artifact' ? tab.artifactId : '')),
     );
     setArtifactPanelExtraArtifacts((previous) => {
@@ -2283,13 +2287,22 @@ export function App({
     (
       paneSessionId: string,
       paneArtifacts: readonly DaemonSessionArtifact[],
-      paneWorkspaceActions: DaemonWorkspaceActions,
     ) => {
+      if (paneArtifacts.length > 0) {
+        const paneArtifactIds = new Set(
+          paneArtifacts.map((artifact) => artifact.id),
+        );
+        setArtifactPanelExtraArtifacts((current) => {
+          const next = current.filter(
+            (artifact) => !paneArtifactIds.has(artifact.id),
+          );
+          return next.length === current.length ? current : next;
+        });
+      }
       setPaneArtifactSnapshots((current) => {
         const previous = current.get(paneSessionId);
         const unchanged =
-          previous?.workspaceActions === paneWorkspaceActions &&
-          previous.artifacts.length === paneArtifacts.length &&
+          previous?.artifacts.length === paneArtifacts.length &&
           previous.artifacts.every((artifact, index) => {
             const nextArtifact = paneArtifacts[index];
             // `metadata` is deliberately not compared: artifact events carry
@@ -2311,31 +2324,9 @@ export function App({
         } else {
           next.set(paneSessionId, {
             artifacts: [...paneArtifacts],
-            workspaceActions: paneWorkspaceActions,
           });
         }
         return next;
-      });
-      const artifactIds = new Set(paneArtifacts.map((artifact) => artifact.id));
-      setArtifactPanelTabs((tabs) => {
-        let changed = false;
-        const next = tabs.map((tab) => {
-          if (tab.kind !== 'artifact' || !artifactIds.has(tab.artifactId)) {
-            return tab;
-          }
-          const updated = {
-            id: tab.id,
-            kind: 'artifact' as const,
-            title: tab.title,
-            artifactId: tab.artifactId,
-            workspaceActions: tab.workspaceActions ?? paneWorkspaceActions,
-          };
-          if (tab.previewContent !== undefined) changed = true;
-          if (tab.workspaceActions) return updated;
-          changed = true;
-          return updated;
-        });
-        return changed ? next : tabs;
       });
     },
     [],
@@ -2750,6 +2741,12 @@ export function App({
         kind: 'artifact',
         artifactId,
         title: artifact?.title ?? 'Artifact',
+        ...(connection.workspaceCwd
+          ? { workspaceCwd: connection.workspaceCwd }
+          : {}),
+        ...(artifactWorkspaceTarget?.workspaceId
+          ? { workspaceId: artifactWorkspaceTarget.workspaceId }
+          : {}),
         ...(previewContent !== undefined ? { previewContent } : {}),
       };
       setArtifactPanelTabs((tabs) =>
@@ -2765,14 +2762,19 @@ export function App({
       );
       setArtifactPanelOpen(true);
     },
-    [artifactPanelArtifacts, getDefaultReviewPanelWidth],
+    [
+      artifactPanelArtifacts,
+      artifactWorkspaceTarget?.workspaceId,
+      connection.workspaceCwd,
+      getDefaultReviewPanelWidth,
+    ],
   );
   const openReviewPanel = useCallback(
     (
       changes: readonly TurnOutputFileChange[],
       selectedPath?: string,
-      workspaceActions?: DaemonWorkspaceActions,
       reviewWorkspaceCwd?: string,
+      reviewWorkspaceId?: string,
       tabId = 'review',
     ) => {
       const reviewTab: ArtifactPanelTab = {
@@ -2781,8 +2783,8 @@ export function App({
         title: t('turnOutputs.review'),
         changes,
         ...(selectedPath ? { selectedPath } : {}),
-        ...(workspaceActions ? { workspaceActions } : {}),
         ...(reviewWorkspaceCwd ? { workspaceCwd: reviewWorkspaceCwd } : {}),
+        ...(reviewWorkspaceId ? { workspaceId: reviewWorkspaceId } : {}),
       };
       setArtifactPanelTabs((tabs) =>
         tabs.some((item) => item.id === reviewTab.id)
@@ -2801,12 +2803,23 @@ export function App({
   );
   const openLatestReviewPanel = useCallback(() => {
     if (latestReviewChanges.length === 0) return;
-    openReviewPanel(latestReviewChanges);
-  }, [latestReviewChanges, openReviewPanel]);
+    openReviewPanel(
+      latestReviewChanges,
+      undefined,
+      connection.workspaceCwd,
+      artifactWorkspaceTarget?.workspaceId,
+    );
+  }, [
+    artifactWorkspaceTarget?.workspaceId,
+    connection.workspaceCwd,
+    latestReviewChanges,
+    openReviewPanel,
+  ]);
   const openScheduledTaskPanel = useCallback(
     (
       task: TurnOutputScheduledTask,
-      tabWorkspaceActions?: ReturnType<typeof useWorkspaceActions>,
+      tabWorkspaceCwd?: string,
+      tabWorkspaceId?: string,
       sourceSessionId?: string,
     ) => {
       const tab: ArtifactPanelTab = {
@@ -2815,10 +2828,9 @@ export function App({
           : `scheduled-task:${task.toolCallId}`,
         kind: 'scheduled_task',
         title: t('scheduledTasks.title'),
-        task,
-        ...(tabWorkspaceActions
-          ? { workspaceActions: tabWorkspaceActions }
-          : {}),
+        task: tabWorkspaceId ? { ...task, workspaceId: tabWorkspaceId } : task,
+        ...(tabWorkspaceCwd ? { workspaceCwd: tabWorkspaceCwd } : {}),
+        ...(tabWorkspaceId ? { workspaceId: tabWorkspaceId } : {}),
       };
       setArtifactPanelTabs((tabs) =>
         tabs.some((item) => item.id === tab.id)
@@ -2993,8 +3005,8 @@ export function App({
         openReviewPanel(
           request.changes,
           request.selectedPath,
-          request.workspaceActions,
           request.workspaceCwd,
+          request.workspaceId,
           request.sourceSessionId
             ? `review:${request.sourceSessionId}:${request.turnId}`
             : undefined,
@@ -3004,7 +3016,8 @@ export function App({
       if (request.kind === 'scheduled_task') {
         openScheduledTaskPanel(
           request.task,
-          request.workspaceActions,
+          request.workspaceCwd,
+          request.workspaceId,
           request.sourceSessionId,
         );
         return;
@@ -3017,7 +3030,7 @@ export function App({
         );
         return;
       }
-      if (!request.workspaceActions || request.sourceSessionId) {
+      if (request.sourceSessionId) {
         setArtifactPanelExtraArtifacts((current) => {
           const index = current.findIndex(
             (artifact) => artifact.id === request.artifact.id,
@@ -3035,8 +3048,10 @@ export function App({
         kind: 'artifact',
         title: request.title,
         artifactId: request.artifactId,
-        ...(request.workspaceActions
-          ? { workspaceActions: request.workspaceActions }
+        ...(request.workspaceCwd ? { workspaceCwd: request.workspaceCwd } : {}),
+        ...(request.workspaceId ? { workspaceId: request.workspaceId } : {}),
+        ...(request.sourceSessionId
+          ? { sourceSessionId: request.sourceSessionId }
           : {}),
         ...(request.previewContent !== undefined
           ? { previewContent: request.previewContent }
@@ -3066,8 +3081,8 @@ export function App({
   const openFilePreview = useCallback(
     (
       change: TurnOutputFileChange,
-      workspaceActions: DaemonWorkspaceActions,
       previewWorkspaceCwd?: string,
+      previewWorkspaceId?: string,
     ) => {
       const previewContent = getFileChangePreviewContent(change);
       const tab: ArtifactPanelTab = {
@@ -3075,7 +3090,8 @@ export function App({
         kind: 'file',
         title: displayPath(change.path, previewWorkspaceCwd),
         workspacePath: change.path,
-        workspaceActions,
+        ...(previewWorkspaceCwd ? { workspaceCwd: previewWorkspaceCwd } : {}),
+        ...(previewWorkspaceId ? { workspaceId: previewWorkspaceId } : {}),
         ...(previewContent !== undefined ? { previewContent } : {}),
       };
       setArtifactPanelTabs((tabs) =>

--- a/packages/web-shell/client/components/ChatPane.test.tsx
+++ b/packages/web-shell/client/components/ChatPane.test.tsx
@@ -706,11 +706,9 @@ describe('ChatPane', () => {
       await Promise.resolve();
     });
 
-    expect(onPaneArtifactsChange).toHaveBeenLastCalledWith(
-      'sess-1',
-      [artifact],
-      expect.any(Object),
-    );
+    expect(onPaneArtifactsChange).toHaveBeenLastCalledWith('sess-1', [
+      artifact,
+    ]);
   });
 
   it('suppresses the rotating loading phrase in its compact status', () => {

--- a/packages/web-shell/client/components/ChatPane.test.tsx
+++ b/packages/web-shell/client/components/ChatPane.test.tsx
@@ -144,6 +144,21 @@ vi.mock('./MessageList', () => ({
       data-approval={props.pendingApproval ? 'yes' : 'no'}
     >
       {props.messages.length}
+      <button
+        data-testid="pane-open-turn-output"
+        type="button"
+        onClick={() =>
+          props.onTurnOutputOpen?.({
+            id: 'artifact:turn-artifact',
+            kind: 'artifact',
+            title: 'Turn artifact',
+            turnId: 'turn-1',
+            artifactId: 'turn-artifact',
+            artifact: { id: 'turn-artifact', title: 'Turn artifact' },
+            workspaceCwd: '/w',
+          })
+        }
+      />
     </div>
   ),
 }));
@@ -709,6 +724,26 @@ describe('ChatPane', () => {
     expect(onPaneArtifactsChange).toHaveBeenLastCalledWith('sess-1', [
       artifact,
     ]);
+  });
+
+  it('stamps its session identity on turn-output open requests', () => {
+    const onRightPanelOpen = vi.fn();
+    render({ onRightPanelOpen });
+
+    act(() => {
+      testid('pane-open-turn-output')?.click();
+    });
+
+    expect(onRightPanelOpen).toHaveBeenCalledWith({
+      id: 'artifact:turn-artifact',
+      kind: 'artifact',
+      title: 'Turn artifact',
+      turnId: 'turn-1',
+      artifactId: 'turn-artifact',
+      artifact: { id: 'turn-artifact', title: 'Turn artifact' },
+      workspaceCwd: '/w',
+      sourceSessionId: 'sess-1',
+    });
   });
 
   it('suppresses the rotating loading phrase in its compact status', () => {

--- a/packages/web-shell/client/components/ChatPane.tsx
+++ b/packages/web-shell/client/components/ChatPane.tsx
@@ -14,9 +14,7 @@ import {
   useTranscriptHistory,
   useTranscriptStore,
   useWorkspace,
-  useWorkspaceActions,
   type DaemonSessionActions,
-  type DaemonWorkspaceActions,
 } from '@qwen-code/webui/daemon-react-sdk';
 import type {
   DaemonSessionArtifact,
@@ -171,7 +169,6 @@ export interface ChatPaneProps {
   onPaneArtifactsChange?: (
     sessionId: string,
     artifacts: readonly DaemonSessionArtifact[],
-    workspaceActions: DaemonWorkspaceActions,
   ) => void;
   messageTurnOutputs?: readonly TurnOutputKind[];
   /** Allow prompt admission to recover a disconnected SSE stream. */
@@ -221,7 +218,6 @@ export function ChatPane({
     useWebShellCustomization();
   const connection = useConnection();
   const actions = useActions();
-  const workspaceActions = useWorkspaceActions();
   const workspace = useWorkspace();
   const blocks = useAnimationFrameTranscriptBlocks();
   const messages = useMessagesFromBlocks(t, blocks);
@@ -292,16 +288,11 @@ export function ChatPane({
   useEffect(() => {
     const sessionId = connection.sessionId;
     if (!sessionId) return;
-    onPaneArtifactsChange?.(sessionId, artifacts, workspaceActions);
+    onPaneArtifactsChange?.(sessionId, artifacts);
     return () => {
-      onPaneArtifactsChange?.(sessionId, [], workspaceActions);
+      onPaneArtifactsChange?.(sessionId, []);
     };
-  }, [
-    artifacts,
-    connection.sessionId,
-    onPaneArtifactsChange,
-    workspaceActions,
-  ]);
+  }, [artifacts, connection.sessionId, onPaneArtifactsChange]);
   const streamingStateRef = useRef(streamingState);
   streamingStateRef.current = streamingState;
   const firstPromptAdmittedRef = useRef(false);
@@ -539,20 +530,12 @@ export function ChatPane({
   const handleRightPanelOpen = useCallback(
     (request: TurnOutputOpenRequest) => {
       if (!onRightPanelOpen) return;
-      if (request.kind === 'subagent') {
-        onRightPanelOpen({
-          ...request,
-          sourceSessionId: connection.sessionId,
-        });
-        return;
-      }
       onRightPanelOpen({
         ...request,
-        workspaceActions,
         sourceSessionId: connection.sessionId,
       });
     },
-    [connection.sessionId, onRightPanelOpen, workspaceActions],
+    [connection.sessionId, onRightPanelOpen],
   );
 
   // Composer wiring, all scoped to THIS pane's own DaemonSession context. The

--- a/packages/web-shell/client/components/SplitView.tsx
+++ b/packages/web-shell/client/components/SplitView.tsx
@@ -9,7 +9,6 @@ import {
   DaemonSessionProvider,
   useConnection,
   type DaemonSessionActions,
-  type DaemonWorkspaceActions,
 } from '@qwen-code/webui/daemon-react-sdk';
 import type {
   DaemonSessionArtifact,
@@ -67,7 +66,6 @@ export interface SplitViewProps {
   onPaneArtifactsChange?: (
     sessionId: string,
     artifacts: readonly DaemonSessionArtifact[],
-    workspaceActions: DaemonWorkspaceActions,
   ) => void;
   messageTurnOutputs?: readonly TurnOutputKind[];
   /**

--- a/packages/web-shell/client/components/artifacts/ArtifactPanel.test.tsx
+++ b/packages/web-shell/client/components/artifacts/ArtifactPanel.test.tsx
@@ -7,26 +7,68 @@ import type {
   DaemonSessionMonitorTaskStatus,
   DaemonSessionShellTaskStatus,
 } from '@qwen-code/sdk/daemon';
-import type { DaemonSessionActions } from '@qwen-code/webui/daemon-react-sdk';
+import type {
+  DaemonScheduledTask,
+  DaemonSessionActions,
+} from '@qwen-code/webui/daemon-react-sdk';
 import { I18nProvider } from '../../i18n';
 
-const { mockActions, mockWorkspaceActions } = vi.hoisted(() => ({
-  mockActions: {
-    cancelTask: vi.fn(),
-    getTasks: vi.fn(),
-  },
-  mockWorkspaceActions: {
-    readFileBytes: vi.fn(),
+const {
+  mockActions,
+  mockWorkspace,
+  mockWorkspaceActions,
+  mockSecondaryWorkspaceActions,
+} = vi.hoisted(() => {
+  const mockSecondaryWorkspaceActions = {
     readWorkspaceFile: vi.fn(),
-    stat: vi.fn(),
-  },
-}));
+    readWorkspaceFileBytes: vi.fn(),
+    fileStat: vi.fn(),
+  };
+  return {
+    mockActions: {
+      cancelTask: vi.fn(),
+      getTasks: vi.fn(),
+    },
+    mockWorkspaceActions: {
+      readFileBytes: vi.fn(),
+      readWorkspaceFile: vi.fn(),
+      stat: vi.fn(),
+      listScheduledTasks: vi.fn(),
+      updateScheduledTask: vi.fn(),
+      deleteScheduledTask: vi.fn(),
+    },
+    mockSecondaryWorkspaceActions,
+    mockWorkspace: {
+      capabilities: {
+        workspaceCwd: '/primary',
+        workspaces: [
+          {
+            id: 'primary-id',
+            cwd: '/primary',
+            primary: true,
+            trusted: true,
+          },
+          {
+            id: 'secondary-id',
+            cwd: '/secondary',
+            primary: false,
+            trusted: true,
+          },
+        ],
+      },
+      client: {
+        workspaceByCwd: vi.fn(() => mockSecondaryWorkspaceActions),
+      },
+    },
+  };
+});
 
 vi.mock(
   '@qwen-code/webui/daemon-react-sdk',
   async (importOriginal: () => Promise<Record<string, unknown>>) => ({
     ...(await importOriginal()),
     useActions: () => mockActions,
+    useWorkspace: () => mockWorkspace,
     useWorkspaceActions: () => mockWorkspaceActions,
   }),
 );
@@ -113,7 +155,13 @@ function codeReviewArtifact(
   };
 }
 
-function artifactPanel(artifact: DaemonSessionArtifact) {
+function artifactPanel(
+  artifact: DaemonSessionArtifact,
+  owner: { workspaceCwd: string; workspaceId: string } | null = {
+    workspaceCwd: '/primary',
+    workspaceId: 'primary-id',
+  },
+) {
   return (
     <I18nProvider language="en">
       <ArtifactPanel
@@ -124,9 +172,60 @@ function artifactPanel(artifact: DaemonSessionArtifact) {
             kind: 'artifact',
             title: artifact.title,
             artifactId: artifact.id,
+            ...(owner ?? {}),
           },
         ]}
         activeTabId="artifact:review-artifact"
+        reviewChanges={[]}
+        selectedReviewPath={null}
+        onSelectTab={() => {}}
+        onCloseTab={() => {}}
+        onOpenFilePreview={() => {}}
+        onClose={() => {}}
+      />
+    </I18nProvider>
+  );
+}
+
+const secondaryScheduledTask: DaemonScheduledTask = {
+  id: 'cron-secondary',
+  name: 'Secondary task',
+  cron: '0 9 * * *',
+  prompt: 'secondary only',
+  recurring: true,
+  enabled: true,
+  createdAt: 1_700_000_000_000,
+  lastFiredAt: null,
+  nextRunAt: null,
+  sessionId: null,
+  runs: [],
+};
+
+function scheduledTaskPanel() {
+  return (
+    <I18nProvider language="en">
+      <ArtifactPanel
+        artifacts={[]}
+        tabs={[
+          {
+            id: 'scheduled-task:secondary:cron-call',
+            kind: 'scheduled_task',
+            title: 'Scheduled Tasks',
+            workspaceCwd: '/secondary',
+            workspaceId: 'secondary-id',
+            task: {
+              id: 'cron-secondary',
+              toolCallId: 'cron-call',
+              title: 'Secondary task',
+              cron: '0 9 * * *',
+              prompt: 'secondary only',
+              recurring: true,
+              durable: true,
+              workspaceId: 'secondary-id',
+            },
+          },
+        ]}
+        activeTabId="scheduled-task:secondary:cron-call"
         reviewChanges={[]}
         selectedReviewPath={null}
         onSelectTab={() => {}}
@@ -149,6 +248,30 @@ afterEach(() => {
   mockWorkspaceActions.readFileBytes.mockReset();
   mockWorkspaceActions.readWorkspaceFile.mockReset();
   mockWorkspaceActions.stat.mockReset();
+  mockWorkspaceActions.listScheduledTasks.mockReset();
+  mockWorkspaceActions.updateScheduledTask.mockReset();
+  mockWorkspaceActions.deleteScheduledTask.mockReset();
+  mockSecondaryWorkspaceActions.readWorkspaceFile.mockReset();
+  mockSecondaryWorkspaceActions.readWorkspaceFileBytes.mockReset();
+  mockSecondaryWorkspaceActions.fileStat.mockReset();
+  mockWorkspace.client.workspaceByCwd.mockClear();
+  mockWorkspace.capabilities = {
+    workspaceCwd: '/primary',
+    workspaces: [
+      {
+        id: 'primary-id',
+        cwd: '/primary',
+        primary: true,
+        trusted: true,
+      },
+      {
+        id: 'secondary-id',
+        cwd: '/secondary',
+        primary: false,
+        trusted: true,
+      },
+    ],
+  };
 });
 
 function openAddMenu(container: HTMLElement) {
@@ -171,6 +294,27 @@ async function flush() {
 }
 
 describe('ArtifactPanel code review artifacts', () => {
+  it('fails closed when an artifact tab has no workspace owner', async () => {
+    mockWorkspaceActions.readWorkspaceFile.mockResolvedValue({
+      content: 'PRIMARY_WORKSPACE_SECRET',
+      truncated: false,
+    });
+    const artifact = codeReviewArtifact({ metadata: {} });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+
+    act(() => root.render(artifactPanel(artifact, null)));
+    await flush();
+
+    expect(container.textContent).toContain(
+      'This workspace may have been removed or the link is no longer valid.',
+    );
+    expect(mockWorkspaceActions.readWorkspaceFile).not.toHaveBeenCalled();
+    expect(container.textContent).not.toContain('PRIMARY_WORKSPACE_SECRET');
+  });
+
   it('dispatches an available workspace artifact to the dedicated renderer', async () => {
     mockWorkspaceActions.readWorkspaceFile.mockResolvedValue({
       content: JSON.stringify({
@@ -280,6 +424,124 @@ describe('ArtifactPanel code review artifacts', () => {
     expect(container.textContent).not.toContain('Authoritative verdict');
     expect(mockWorkspaceActions.readWorkspaceFile).toHaveBeenCalledWith(
       '.qwen/reviews/review.json',
+    );
+  });
+
+  it('discards a pending read when its workspace owner is replaced', async () => {
+    let resolveRead:
+      | ((file: { content: string; truncated: boolean }) => void)
+      | undefined;
+    mockSecondaryWorkspaceActions.readWorkspaceFile.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRead = resolve;
+      }),
+    );
+    const artifact = codeReviewArtifact({ metadata: {} });
+    const owner = {
+      workspaceCwd: '/secondary',
+      workspaceId: 'secondary-id',
+    };
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+
+    act(() => root.render(artifactPanel(artifact, owner)));
+    await flush();
+    expect(mockWorkspace.client.workspaceByCwd).toHaveBeenCalledWith(
+      '/secondary',
+    );
+
+    mockWorkspace.capabilities = {
+      ...mockWorkspace.capabilities,
+      workspaces: [
+        mockWorkspace.capabilities.workspaces[0]!,
+        {
+          id: 'secondary-replacement-id',
+          cwd: '/secondary',
+          primary: false,
+          trusted: true,
+        },
+      ],
+    };
+    act(() => root.render(artifactPanel(artifact, owner)));
+    await flush();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      'removed',
+    );
+
+    await act(async () => {
+      resolveRead?.({ content: 'REMOVED_WORKSPACE_SECRET', truncated: false });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).not.toContain('REMOVED_WORKSPACE_SECRET');
+    expect(mockWorkspaceActions.readWorkspaceFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('ArtifactPanel scheduled-task ownership', () => {
+  it('loads a durable task through its secondary workspace route', async () => {
+    mockWorkspaceActions.listScheduledTasks.mockResolvedValue([]);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+
+    act(() => root.render(scheduledTaskPanel()));
+    await flush();
+
+    expect(mockWorkspaceActions.listScheduledTasks).toHaveBeenCalledWith(
+      'secondary-id',
+    );
+  });
+
+  it('updates and deletes only through the task workspace id', async () => {
+    mockWorkspaceActions.listScheduledTasks.mockResolvedValue([
+      secondaryScheduledTask,
+    ]);
+    mockWorkspaceActions.updateScheduledTask.mockResolvedValue({
+      ...secondaryScheduledTask,
+      enabled: false,
+    });
+    mockWorkspaceActions.deleteScheduledTask.mockResolvedValue(undefined);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+
+    act(() => root.render(scheduledTaskPanel()));
+    await flush();
+
+    const disable = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Disable',
+    );
+    await act(async () => {
+      disable?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(mockWorkspaceActions.updateScheduledTask).toHaveBeenCalledWith(
+      'cron-secondary',
+      { enabled: false },
+      'secondary-id',
+    );
+
+    const openDelete = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Delete',
+    );
+    act(() => openDelete?.click());
+    const confirmDelete = Array.from(document.body.querySelectorAll('button'))
+      .filter((button) => button.textContent?.trim() === 'Delete')
+      .at(-1);
+    await act(async () => {
+      confirmDelete?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(mockWorkspaceActions.deleteScheduledTask).toHaveBeenCalledWith(
+      'cron-secondary',
+      'secondary-id',
     );
   });
 });
@@ -564,7 +826,15 @@ describe('ArtifactPanel add menu', () => {
         <I18nProvider language="en">
           <ArtifactPanel
             artifacts={[]}
-            tabs={[{ id: 'review', kind: 'review', title: 'Review' }]}
+            tabs={[
+              {
+                id: 'review',
+                kind: 'review',
+                title: 'Review',
+                workspaceCwd: '/primary',
+                workspaceId: 'primary-id',
+              },
+            ]}
             activeTabId="review"
             reviewChanges={[]}
             selectedReviewPath={null}
@@ -604,6 +874,8 @@ describe('ArtifactPanel add menu', () => {
                 kind: 'artifact',
                 title: 'Report',
                 artifactId: 'report',
+                workspaceCwd: '/primary',
+                workspaceId: 'primary-id',
               },
             ]}
             activeTabId="artifact"
@@ -669,6 +941,8 @@ describe('ArtifactPanel review downloads', () => {
                 kind: 'review',
                 title: 'Review',
                 changes,
+                workspaceCwd: '/primary',
+                workspaceId: 'primary-id',
               },
             ]}
             activeTabId="review"
@@ -737,6 +1011,8 @@ describe('ArtifactPanel review downloads', () => {
                 kind: 'review',
                 title: 'Review',
                 changes,
+                workspaceCwd: '/primary',
+                workspaceId: 'primary-id',
               },
             ]}
             activeTabId="review"
@@ -796,6 +1072,8 @@ describe('ArtifactPanel review downloads', () => {
                 kind: 'review',
                 title: 'Review',
                 changes,
+                workspaceCwd: '/primary',
+                workspaceId: 'primary-id',
               },
             ]}
             activeTabId="review"

--- a/packages/web-shell/client/components/artifacts/ArtifactPanel.test.tsx
+++ b/packages/web-shell/client/components/artifacts/ArtifactPanel.test.tsx
@@ -13,6 +13,7 @@ import type {
 } from '@qwen-code/webui/daemon-react-sdk';
 import { I18nProvider } from '../../i18n';
 import type { ArtifactWorkspaceTarget } from './useArtifactWorkspaceTarget';
+import type { TurnOutputScheduledTask } from './TurnOutputs';
 
 const {
   mockActions,
@@ -238,7 +239,29 @@ const secondaryScheduledTask: DaemonScheduledTask = {
   runs: [],
 };
 
-function scheduledTaskPanel() {
+function scheduledTaskPanel(
+  options: {
+    workspaceCwd?: string;
+    workspaceId?: string;
+    task?: Partial<TurnOutputScheduledTask>;
+  } = {},
+) {
+  const workspaceCwd = options.workspaceCwd ?? '/secondary';
+  const workspaceId = Object.hasOwn(options, 'workspaceId')
+    ? options.workspaceId
+    : 'secondary-id';
+  const taskPatch = options.task ?? {};
+  const task: TurnOutputScheduledTask = {
+    id: 'cron-secondary',
+    toolCallId: 'cron-call',
+    title: 'Secondary task',
+    cron: '0 9 * * *',
+    prompt: 'secondary only',
+    recurring: true,
+    durable: true,
+    workspaceId,
+    ...taskPatch,
+  };
   return (
     <I18nProvider language="en">
       <ArtifactPanel
@@ -248,18 +271,9 @@ function scheduledTaskPanel() {
             id: 'scheduled-task:secondary:cron-call',
             kind: 'scheduled_task',
             title: 'Scheduled Tasks',
-            workspaceCwd: '/secondary',
-            workspaceId: 'secondary-id',
-            task: {
-              id: 'cron-secondary',
-              toolCallId: 'cron-call',
-              title: 'Secondary task',
-              cron: '0 9 * * *',
-              prompt: 'secondary only',
-              recurring: true,
-              durable: true,
-              workspaceId: 'secondary-id',
-            },
+            workspaceCwd,
+            workspaceId,
+            task,
           },
         ]}
         activeTabId="scheduled-task:secondary:cron-call"
@@ -385,10 +399,81 @@ describe('artifact workspace authority', () => {
       ],
     };
     act(() => root.render(<ArtifactWorkspaceTargetProbe revision={2} />));
+    expect(latestArtifactWorkspaceTarget).toBeDefined();
     expect(latestArtifactWorkspaceTarget?.actions).not.toBe(initialActions);
 
     resolveRead?.({ content: 'stale-secret', truncated: false });
     await expect(read).rejects.toThrow(
+      'Workspace artifact owner is no longer available',
+    );
+  });
+
+  it('revokes every pending file read when its owner is removed', async () => {
+    let resolveText:
+      | ((file: { content: string; truncated: boolean }) => void)
+      | undefined;
+    let resolveBytes:
+      | ((file: {
+          contentBase64: string;
+          offset: number;
+          returnedBytes: number;
+          sizeBytes: number;
+        }) => void)
+      | undefined;
+    let resolveStat:
+      | ((stat: { sizeBytes: number; modifiedMs: number }) => void)
+      | undefined;
+    mockSecondaryWorkspaceActions.readWorkspaceFile.mockReturnValue(
+      new Promise((resolve) => {
+        resolveText = resolve;
+      }),
+    );
+    mockSecondaryWorkspaceActions.readWorkspaceFileBytes.mockReturnValue(
+      new Promise((resolve) => {
+        resolveBytes = resolve;
+      }),
+    );
+    mockSecondaryWorkspaceActions.fileStat.mockReturnValue(
+      new Promise((resolve) => {
+        resolveStat = resolve;
+      }),
+    );
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+
+    act(() => root.render(<ArtifactWorkspaceTargetProbe revision={0} />));
+    const actions = latestArtifactWorkspaceTarget?.actions;
+    expect(actions).toBeDefined();
+    const textRead = actions?.readWorkspaceFile('report.txt');
+    const bytesRead = actions?.readFileBytes('report.bin', {
+      offset: 0,
+      maxBytes: 1024,
+    });
+    const statRead = actions?.stat('report.bin');
+
+    mockWorkspace.capabilities = {
+      ...mockWorkspace.capabilities,
+      workspaces: [mockWorkspace.capabilities.workspaces[0]!],
+    };
+    act(() => root.render(<ArtifactWorkspaceTargetProbe revision={1} />));
+
+    resolveText?.({ content: 'stale-text', truncated: false });
+    resolveBytes?.({
+      contentBase64: btoa('stale-bytes'),
+      offset: 0,
+      returnedBytes: 11,
+      sizeBytes: 11,
+    });
+    resolveStat?.({ sizeBytes: 11, modifiedMs: 1 });
+    await expect(textRead).rejects.toThrow(
+      'Workspace artifact owner is no longer available',
+    );
+    await expect(bytesRead).rejects.toThrow(
+      'Workspace artifact owner is no longer available',
+    );
+    await expect(statRead).rejects.toThrow(
       'Workspace artifact owner is no longer available',
     );
   });
@@ -659,6 +744,277 @@ describe('ArtifactPanel scheduled-task ownership', () => {
     });
     expect(mockWorkspaceActions.deleteScheduledTask).toHaveBeenCalledWith(
       'cron-secondary',
+      'secondary-id',
+    );
+  });
+
+  it('fails closed for a durable task whose workspace owner is unavailable', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+
+    act(() =>
+      root.render(
+        scheduledTaskPanel({
+          workspaceCwd: '/unknown',
+          workspaceId: 'missing-id',
+          task: { workspaceId: 'missing-id' },
+        }),
+      ),
+    );
+    await flush();
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      'This workspace may have been removed',
+    );
+    expect(mockWorkspaceActions.listScheduledTasks).not.toHaveBeenCalled();
+    expect(mockWorkspaceActions.updateScheduledTask).not.toHaveBeenCalled();
+    expect(mockWorkspaceActions.deleteScheduledTask).not.toHaveBeenCalled();
+  });
+
+  it('shows a session-scoped task snapshot without a workspace owner', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+
+    act(() =>
+      root.render(
+        scheduledTaskPanel({
+          workspaceCwd: '/unknown',
+          workspaceId: 'missing-id',
+          task: {
+            id: 'session-task',
+            durable: false,
+            prompt: 'local session snapshot',
+            workspaceId: 'missing-id',
+          },
+        }),
+      ),
+    );
+    await flush();
+
+    expect(container.textContent).toContain('session-scoped scheduled task');
+    expect(container.textContent).toContain('local session snapshot');
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+    expect(mockWorkspaceActions.listScheduledTasks).not.toHaveBeenCalled();
+  });
+
+  it('keeps legacy single-workspace scheduled-task routes unqualified', async () => {
+    mockWorkspace.capabilities = {
+      workspaceCwd: '/primary',
+    } as typeof mockWorkspace.capabilities;
+    mockWorkspaceActions.listScheduledTasks.mockResolvedValue([
+      secondaryScheduledTask,
+    ]);
+    mockWorkspaceActions.updateScheduledTask.mockResolvedValue({
+      ...secondaryScheduledTask,
+      enabled: false,
+    });
+    mockWorkspaceActions.deleteScheduledTask.mockResolvedValue(undefined);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+
+    act(() =>
+      root.render(
+        scheduledTaskPanel({
+          workspaceCwd: '/primary',
+          workspaceId: undefined,
+          task: { workspaceId: undefined },
+        }),
+      ),
+    );
+    await flush();
+    expect(mockWorkspaceActions.listScheduledTasks).toHaveBeenCalledWith(
+      undefined,
+    );
+
+    const disable = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Disable',
+    );
+    await act(async () => {
+      disable?.click();
+      await Promise.resolve();
+    });
+    expect(mockWorkspaceActions.updateScheduledTask).toHaveBeenCalledWith(
+      'cron-secondary',
+      { enabled: false },
+      undefined,
+    );
+
+    const openDelete = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Delete',
+    );
+    act(() => openDelete?.click());
+    const confirmDelete = Array.from(document.body.querySelectorAll('button'))
+      .filter((button) => button.textContent?.trim() === 'Delete')
+      .at(-1);
+    await act(async () => {
+      confirmDelete?.click();
+      await Promise.resolve();
+    });
+    expect(mockWorkspaceActions.deleteScheduledTask).toHaveBeenCalledWith(
+      'cron-secondary',
+      undefined,
+    );
+  });
+
+  it.each(['save', 'toggle', 'delete'] as const)(
+    'settles a pending reload after a %s mutation',
+    async (mutation) => {
+      let resolveReload: ((tasks: DaemonScheduledTask[]) => void) | undefined;
+      mockWorkspaceActions.listScheduledTasks
+        .mockResolvedValueOnce([secondaryScheduledTask])
+        .mockReturnValueOnce(
+          new Promise((resolve) => {
+            resolveReload = resolve;
+          }),
+        );
+      const updatedTask = {
+        ...secondaryScheduledTask,
+        name: `${mutation} result`,
+        enabled: false,
+      };
+      mockWorkspaceActions.updateScheduledTask.mockResolvedValue(updatedTask);
+      mockWorkspaceActions.deleteScheduledTask.mockResolvedValue(undefined);
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const root = createRoot(container);
+      mounted.push({ root, container });
+
+      act(() => root.render(scheduledTaskPanel()));
+      await flush();
+      act(() =>
+        root.render(
+          scheduledTaskPanel({ task: { prompt: `reload ${mutation}` } }),
+        ),
+      );
+      await flush();
+      expect(container.textContent).toContain('Loading…');
+
+      if (mutation === 'save') {
+        const edit = Array.from(container.querySelectorAll('button')).find(
+          (button) => button.textContent?.trim() === 'Edit',
+        );
+        act(() => edit?.click());
+        const save = Array.from(document.body.querySelectorAll('button')).find(
+          (button) => button.textContent?.trim() === 'Save',
+        );
+        await act(async () => {
+          save?.click();
+          await Promise.resolve();
+        });
+      } else if (mutation === 'toggle') {
+        const disable = Array.from(container.querySelectorAll('button')).find(
+          (button) => button.textContent?.trim() === 'Disable',
+        );
+        await act(async () => {
+          disable?.click();
+          await Promise.resolve();
+        });
+      } else {
+        const openDelete = Array.from(
+          container.querySelectorAll('button'),
+        ).find((button) => button.textContent?.trim() === 'Delete');
+        act(() => openDelete?.click());
+        const confirmDelete = Array.from(
+          document.body.querySelectorAll('button'),
+        )
+          .filter((button) => button.textContent?.trim() === 'Delete')
+          .at(-1);
+        await act(async () => {
+          confirmDelete?.click();
+          await Promise.resolve();
+        });
+      }
+
+      await act(async () => {
+        resolveReload?.([secondaryScheduledTask]);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(container.textContent).not.toContain('Loading…');
+      if (mutation === 'delete') {
+        expect(container.textContent).toContain('has been deleted');
+      } else {
+        expect(container.textContent).toContain(`${mutation} result`);
+      }
+    },
+  );
+
+  it('discards a pending mutation when the task scope changes', async () => {
+    const replacementTask: DaemonScheduledTask = {
+      ...secondaryScheduledTask,
+      id: 'cron-replacement',
+      name: 'Replacement task',
+      prompt: 'replacement only',
+    };
+    let resolveStaleMutation: ((task: DaemonScheduledTask) => void) | undefined;
+    mockWorkspaceActions.listScheduledTasks
+      .mockResolvedValueOnce([secondaryScheduledTask])
+      .mockResolvedValueOnce([replacementTask]);
+    mockWorkspaceActions.updateScheduledTask.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveStaleMutation = resolve;
+      }),
+    );
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+
+    act(() => root.render(scheduledTaskPanel()));
+    await flush();
+    const disable = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Disable',
+    );
+    act(() => disable?.click());
+    await flush();
+
+    act(() =>
+      root.render(
+        scheduledTaskPanel({
+          task: {
+            id: replacementTask.id,
+            title: replacementTask.name ?? replacementTask.prompt,
+            prompt: replacementTask.prompt,
+          },
+        }),
+      ),
+    );
+    await flush();
+    expect(container.textContent).toContain('Replacement task');
+
+    await act(async () => {
+      resolveStaleMutation?.({
+        ...secondaryScheduledTask,
+        name: 'Stale mutation result',
+        enabled: false,
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).not.toContain('Stale mutation result');
+    expect(container.textContent).toContain('Replacement task');
+
+    mockWorkspaceActions.updateScheduledTask.mockResolvedValueOnce({
+      ...replacementTask,
+      enabled: false,
+    });
+    const replacementDisable = Array.from(
+      container.querySelectorAll('button'),
+    ).find((button) => button.textContent?.trim() === 'Disable');
+    await act(async () => {
+      replacementDisable?.click();
+      await Promise.resolve();
+    });
+    expect(mockWorkspaceActions.updateScheduledTask).toHaveBeenLastCalledWith(
+      'cron-replacement',
+      { enabled: false },
       'secondary-id',
     );
   });

--- a/packages/web-shell/client/components/artifacts/ArtifactPanel.test.tsx
+++ b/packages/web-shell/client/components/artifacts/ArtifactPanel.test.tsx
@@ -948,6 +948,11 @@ describe('ArtifactPanel scheduled-task ownership', () => {
           save?.click();
           await Promise.resolve();
         });
+        expect(mockWorkspaceActions.updateScheduledTask).toHaveBeenCalledWith(
+          'cron-secondary',
+          expect.objectContaining({ prompt: expect.any(String) }),
+          'secondary-id',
+        );
       } else if (mutation === 'toggle') {
         const disable = Array.from(container.querySelectorAll('button')).find(
           (button) => button.textContent?.trim() === 'Disable',

--- a/packages/web-shell/client/components/artifacts/ArtifactPanel.test.tsx
+++ b/packages/web-shell/client/components/artifacts/ArtifactPanel.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { act } from 'react';
+import { act, StrictMode } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import type {
   DaemonSessionArtifact,
@@ -12,6 +12,7 @@ import type {
   DaemonSessionActions,
 } from '@qwen-code/webui/daemon-react-sdk';
 import { I18nProvider } from '../../i18n';
+import type { ArtifactWorkspaceTarget } from './useArtifactWorkspaceTarget';
 
 const {
   mockActions,
@@ -74,12 +75,21 @@ vi.mock(
 );
 
 const { ArtifactPanel } = await import('./ArtifactPanel');
+const { useArtifactWorkspaceTarget } = await import(
+  './useArtifactWorkspaceTarget'
+);
 
 (
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
 const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+let latestArtifactWorkspaceTarget: ArtifactWorkspaceTarget | undefined;
+
+function ArtifactWorkspaceTargetProbe({ revision }: { revision: number }) {
+  latestArtifactWorkspaceTarget = useArtifactWorkspaceTarget('/secondary');
+  return <span data-revision={revision} />;
+}
 
 function monitorPanel(
   task: DaemonSessionMonitorTaskStatus,
@@ -154,6 +164,33 @@ function codeReviewArtifact(
     ...patch,
   };
 }
+
+const validCodeReviewDocument = JSON.stringify({
+  schemaVersion: 1,
+  target: 'local',
+  effort: 'high',
+  verdict: {
+    event: 'APPROVE',
+    verdictLine: 'Verdict: Approve',
+    baseEvent: 'APPROVE',
+    cappedBy: [],
+    downgraded: false,
+    downgradedFrom: null,
+  },
+  findings: [],
+  counts: {
+    total: 0,
+    bySeverity: {
+      Critical: 0,
+      Suggestion: 0,
+      'Nice to have': 0,
+    },
+    byConfidence: { high: 0, low: 0 },
+    held: 0,
+  },
+  outcomesRecorded: false,
+  markdownReportPath: '.qwen/reviews/review.md',
+});
 
 function artifactPanel(
   artifact: DaemonSessionArtifact,
@@ -255,6 +292,7 @@ afterEach(() => {
   mockSecondaryWorkspaceActions.readWorkspaceFileBytes.mockReset();
   mockSecondaryWorkspaceActions.fileStat.mockReset();
   mockWorkspace.client.workspaceByCwd.mockClear();
+  latestArtifactWorkspaceTarget = undefined;
   mockWorkspace.capabilities = {
     workspaceCwd: '/primary',
     workspaces: [
@@ -272,6 +310,88 @@ afterEach(() => {
       },
     ],
   };
+});
+
+describe('artifact workspace authority', () => {
+  it('keeps an in-flight read across an equivalent capabilities refresh', async () => {
+    let resolveRead:
+      | ((file: { content: string; truncated: boolean }) => void)
+      | undefined;
+    mockSecondaryWorkspaceActions.readWorkspaceFile.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRead = resolve;
+      }),
+    );
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+
+    act(() => root.render(<ArtifactWorkspaceTargetProbe revision={0} />));
+    const initialActions = latestArtifactWorkspaceTarget?.actions;
+    const read = initialActions?.readWorkspaceFile('report.json');
+
+    mockWorkspace.capabilities = {
+      ...mockWorkspace.capabilities,
+      workspaces: mockWorkspace.capabilities.workspaces.map((entry) => ({
+        ...entry,
+      })),
+    };
+    act(() => root.render(<ArtifactWorkspaceTargetProbe revision={1} />));
+
+    expect(latestArtifactWorkspaceTarget?.actions).toBe(initialActions);
+    resolveRead?.({ content: 'still-owned', truncated: false });
+    await expect(read).resolves.toEqual({
+      content: 'still-owned',
+      truncated: false,
+    });
+  });
+
+  it('does not revive an old read after the same owner is removed and re-added', async () => {
+    let resolveRead:
+      | ((file: { content: string; truncated: boolean }) => void)
+      | undefined;
+    mockSecondaryWorkspaceActions.readWorkspaceFile.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRead = resolve;
+      }),
+    );
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+
+    act(() => root.render(<ArtifactWorkspaceTargetProbe revision={0} />));
+    const initialActions = latestArtifactWorkspaceTarget?.actions;
+    const read = initialActions?.readWorkspaceFile('report.json');
+
+    mockWorkspace.capabilities = {
+      ...mockWorkspace.capabilities,
+      workspaces: [mockWorkspace.capabilities.workspaces[0]!],
+    };
+    act(() => root.render(<ArtifactWorkspaceTargetProbe revision={1} />));
+    expect(latestArtifactWorkspaceTarget).toBeUndefined();
+
+    mockWorkspace.capabilities = {
+      ...mockWorkspace.capabilities,
+      workspaces: [
+        mockWorkspace.capabilities.workspaces[0]!,
+        {
+          id: 'secondary-id',
+          cwd: '/secondary',
+          primary: false,
+          trusted: true,
+        },
+      ],
+    };
+    act(() => root.render(<ArtifactWorkspaceTargetProbe revision={2} />));
+    expect(latestArtifactWorkspaceTarget?.actions).not.toBe(initialActions);
+
+    resolveRead?.({ content: 'stale-secret', truncated: false });
+    await expect(read).rejects.toThrow(
+      'Workspace artifact owner is no longer available',
+    );
+  });
 });
 
 function openAddMenu(container: HTMLElement) {
@@ -317,32 +437,7 @@ describe('ArtifactPanel code review artifacts', () => {
 
   it('dispatches an available workspace artifact to the dedicated renderer', async () => {
     mockWorkspaceActions.readWorkspaceFile.mockResolvedValue({
-      content: JSON.stringify({
-        schemaVersion: 1,
-        target: 'local',
-        effort: 'high',
-        verdict: {
-          event: 'APPROVE',
-          verdictLine: 'Verdict: Approve',
-          baseEvent: 'APPROVE',
-          cappedBy: [],
-          downgraded: false,
-          downgradedFrom: null,
-        },
-        findings: [],
-        counts: {
-          total: 0,
-          bySeverity: {
-            Critical: 0,
-            Suggestion: 0,
-            'Nice to have': 0,
-          },
-          byConfidence: { high: 0, low: 0 },
-          held: 0,
-        },
-        outcomesRecorded: false,
-        markdownReportPath: '.qwen/reviews/review.md',
-      }),
+      content: validCodeReviewDocument,
       truncated: false,
     });
     const container = document.createElement('div');
@@ -358,6 +453,29 @@ describe('ArtifactPanel code review artifacts', () => {
     expect(container.querySelector('.cm-editor')).toBeNull();
     expect(mockWorkspaceActions.readWorkspaceFile).toHaveBeenCalledWith(
       '.qwen/reviews/review.json',
+    );
+  });
+
+  it('loads an artifact under StrictMode effect replay', async () => {
+    mockWorkspaceActions.readWorkspaceFile.mockResolvedValue({
+      content: validCodeReviewDocument,
+      truncated: false,
+    });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+
+    act(() =>
+      root.render(
+        <StrictMode>{artifactPanel(codeReviewArtifact())}</StrictMode>,
+      ),
+    );
+    await flush();
+
+    expect(container.textContent).toContain('Authoritative verdict');
+    expect(container.textContent).not.toContain(
+      'Workspace artifact owner is no longer available',
     );
   });
 

--- a/packages/web-shell/client/components/artifacts/ArtifactPanel.test.tsx
+++ b/packages/web-shell/client/components/artifacts/ArtifactPanel.test.tsx
@@ -520,6 +520,47 @@ describe('ArtifactPanel code review artifacts', () => {
     expect(container.textContent).not.toContain('PRIMARY_WORKSPACE_SECRET');
   });
 
+  it('fails closed when a file tab has no workspace owner', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+
+    act(() =>
+      root.render(
+        <I18nProvider language="en">
+          <ArtifactPanel
+            artifacts={[]}
+            tabs={[
+              {
+                id: 'file:missing-owner',
+                kind: 'file',
+                title: 'Missing owner',
+                workspacePath: 'secret.txt',
+                workspaceCwd: '/unknown',
+                workspaceId: 'missing-id',
+              },
+            ]}
+            activeTabId="file:missing-owner"
+            reviewChanges={[]}
+            selectedReviewPath={null}
+            onSelectTab={() => {}}
+            onCloseTab={() => {}}
+            onOpenFilePreview={() => {}}
+            onClose={() => {}}
+          />
+        </I18nProvider>,
+      ),
+    );
+    await flush();
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      'This workspace may have been removed',
+    );
+    expect(mockWorkspaceActions.readFileBytes).not.toHaveBeenCalled();
+    expect(mockWorkspaceActions.stat).not.toHaveBeenCalled();
+  });
+
   it('dispatches an available workspace artifact to the dedicated renderer', async () => {
     mockWorkspaceActions.readWorkspaceFile.mockResolvedValue({
       content: validCodeReviewDocument,

--- a/packages/web-shell/client/components/artifacts/ArtifactPanel.tsx
+++ b/packages/web-shell/client/components/artifacts/ArtifactPanel.tsx
@@ -595,7 +595,9 @@ export function ArtifactPanel({
                 </DropdownMenu>
               ))}
           </div>
-        ) : isWorkspaceScopedTab(activeTab) && !activeWorkspaceActions ? (
+        ) : isWorkspaceScopedTab(activeTab) &&
+          (activeTab.kind !== 'scheduled_task' || activeTab.task.durable) &&
+          !activeWorkspaceActions ? (
           <div className={styles.empty} role="alert">
             {t('workspace.notFoundDescription')}
           </div>
@@ -886,6 +888,7 @@ function ScheduledTaskDetail({
   const [submitting, setSubmitting] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
   const requestRef = useRef(0);
+  const loadRequestRef = useRef(0);
   const requestScopeRef = useRef({
     actions,
     taskId: task.id,
@@ -913,9 +916,27 @@ function ScheduledTaskDetail({
     },
     [],
   );
+  const isCurrentLoad = useCallback(
+    (
+      request: number,
+      requestActions: ArtifactWorkspaceActions,
+      taskId: string,
+      workspaceId: string | undefined,
+    ) => {
+      const scope = requestScopeRef.current;
+      return (
+        request === loadRequestRef.current &&
+        scope.actions === requestActions &&
+        scope.taskId === taskId &&
+        scope.workspaceId === workspaceId
+      );
+    },
+    [],
+  );
   useEffect(
     () => () => {
       requestRef.current += 1;
+      loadRequestRef.current += 1;
     },
     [],
   );
@@ -927,6 +948,7 @@ function ScheduledTaskDetail({
 
   const loadTask = useCallback(async () => {
     const request = ++requestRef.current;
+    const loadRequest = ++loadRequestRef.current;
     const taskId = task.id;
     const workspaceId = task.workspaceId;
     if (!task.durable) {
@@ -955,16 +977,17 @@ function ScheduledTaskDetail({
         setBuilder(parseCronToBuilder(task.cron));
       }
     } catch (err) {
-      if (isCurrentRequest(request, actions, taskId, workspaceId)) {
+      if (isCurrentLoad(loadRequest, actions, taskId, workspaceId)) {
         setLoadError(err instanceof Error ? err.message : String(err));
       }
     } finally {
-      if (isCurrentRequest(request, actions, taskId, workspaceId)) {
+      if (isCurrentLoad(loadRequest, actions, taskId, workspaceId)) {
         setLoading(false);
       }
     }
   }, [
     actions,
+    isCurrentLoad,
     isCurrentRequest,
     task.cron,
     task.durable,

--- a/packages/web-shell/client/components/artifacts/ArtifactPanel.tsx
+++ b/packages/web-shell/client/components/artifacts/ArtifactPanel.tsx
@@ -6,9 +6,7 @@ import type {
 import type { ACPToolCall } from '../../adapters/types';
 import type { WebShellRightPanelItem } from '../../customization';
 import {
-  useWorkspaceActions,
   type DaemonSessionActions,
-  type DaemonWorkspaceActions,
   type DaemonScheduledTask,
 } from '@qwen-code/webui/daemon-react-sdk';
 import { EditorState } from '@codemirror/state';
@@ -80,6 +78,10 @@ import { CodeReviewArtifactDetail } from './CodeReviewArtifactDetail';
 import { SubagentDetail } from './SubagentDetail';
 import { SideTaskPanel } from './SideTaskPanel';
 import {
+  useArtifactWorkspaceTarget,
+  type ArtifactWorkspaceActions,
+} from './useArtifactWorkspaceTarget';
+import {
   MonitorTaskDetail,
   ShellTaskDetail,
 } from '../messages/TasksStatusMessage';
@@ -108,8 +110,8 @@ export type ArtifactPanelTab =
       id: string;
       kind: 'review';
       title: string;
-      workspaceActions?: DaemonWorkspaceActions;
       workspaceCwd?: string;
+      workspaceId?: string;
       changes?: readonly TurnOutputFileChange[];
       selectedPath?: string;
     }
@@ -118,7 +120,8 @@ export type ArtifactPanelTab =
       kind: 'file';
       title: string;
       workspacePath: string;
-      workspaceActions?: DaemonWorkspaceActions;
+      workspaceCwd?: string;
+      workspaceId?: string;
       previewContent?: string;
     }
   | {
@@ -126,7 +129,9 @@ export type ArtifactPanelTab =
       kind: 'artifact';
       title: string;
       artifactId: string;
-      workspaceActions?: DaemonWorkspaceActions;
+      workspaceCwd?: string;
+      workspaceId?: string;
+      sourceSessionId?: string;
       previewContent?: string;
     }
   | {
@@ -134,7 +139,8 @@ export type ArtifactPanelTab =
       kind: 'scheduled_task';
       title: string;
       task: TurnOutputScheduledTask;
-      workspaceActions?: DaemonWorkspaceActions;
+      workspaceCwd?: string;
+      workspaceId?: string;
     }
   | {
       id: string;
@@ -172,6 +178,22 @@ export type ArtifactPanelTab =
       initialPrompt?: string;
     };
 
+type WorkspaceScopedArtifactPanelTab = Extract<
+  ArtifactPanelTab,
+  { kind: 'review' | 'file' | 'artifact' | 'scheduled_task' }
+>;
+
+function isWorkspaceScopedTab(
+  tab: ArtifactPanelTab,
+): tab is WorkspaceScopedArtifactPanelTab {
+  return (
+    tab.kind === 'review' ||
+    tab.kind === 'file' ||
+    tab.kind === 'artifact' ||
+    tab.kind === 'scheduled_task'
+  );
+}
+
 export interface SideTaskListItem {
   sessionId: string;
   title: string;
@@ -198,8 +220,8 @@ interface ArtifactPanelProps {
   onCloseTab: (tabId: string) => void;
   onOpenFilePreview: (
     change: TurnOutputFileChange,
-    workspaceActions: DaemonWorkspaceActions,
     workspaceCwd?: string,
+    workspaceId?: string,
   ) => void;
   latestReviewAvailable?: boolean;
   onOpenLatestReview?: () => void;
@@ -224,7 +246,6 @@ interface ArtifactPanelProps {
   onNestedArtifactsChange?: (
     sessionId: string,
     artifacts: readonly DaemonSessionArtifact[],
-    workspaceActions: DaemonWorkspaceActions,
   ) => void;
   onError?: (error: unknown, fallback: string) => void;
   sessionWorkflowEnabled?: boolean;
@@ -301,11 +322,20 @@ export function ArtifactPanel({
     Boolean(onCreateSideTask);
   const showAddMenu =
     Boolean(activeTab) && (showReviewMenuItem || showSideTaskMenuItems);
-  const defaultWorkspaceActions = useWorkspaceActions();
+  const activeWorkspaceIdentity =
+    activeTab && isWorkspaceScopedTab(activeTab)
+      ? {
+          workspaceCwd: activeTab.workspaceCwd,
+          workspaceId: activeTab.workspaceId,
+        }
+      : undefined;
+  const activeWorkspaceTarget = useArtifactWorkspaceTarget(
+    activeWorkspaceIdentity?.workspaceCwd,
+  );
   const activeWorkspaceActions =
-    activeTab && 'workspaceActions' in activeTab
-      ? (activeTab.workspaceActions ?? defaultWorkspaceActions)
-      : defaultWorkspaceActions;
+    activeWorkspaceTarget?.workspaceId === activeWorkspaceIdentity?.workspaceId
+      ? activeWorkspaceTarget?.actions
+      : undefined;
 
   return (
     <aside
@@ -565,6 +595,10 @@ export function ArtifactPanel({
                 </DropdownMenu>
               ))}
           </div>
+        ) : isWorkspaceScopedTab(activeTab) && !activeWorkspaceActions ? (
+          <div className={styles.empty} role="alert">
+            {t('workspace.notFoundDescription')}
+          </div>
         ) : activeTab.kind === 'review' ? (
           <ReviewChanges
             changes={activeTab.changes ?? reviewChanges}
@@ -573,13 +607,13 @@ export function ArtifactPanel({
             onOpenFilePreview={(change) =>
               onOpenFilePreview(
                 change,
-                activeWorkspaceActions,
                 activeTab.workspaceCwd ?? workspaceCwd,
+                activeTab.workspaceId,
               )
             }
             onDownloadFile={(change, isCancelled) =>
               downloadWorkspaceFile(
-                activeWorkspaceActions,
+                activeWorkspaceActions!,
                 change.path,
                 getReviewDownloadMimeType(change.path),
                 isCancelled,
@@ -600,7 +634,7 @@ export function ArtifactPanel({
           <WorkspaceFilePreview
             key={activeTab.id}
             workspacePath={activeTab.workspacePath}
-            workspaceActions={activeWorkspaceActions}
+            workspaceActions={activeWorkspaceActions!}
             previewContent={activeTab.previewContent}
           />
         ) : activeTab.kind === 'artifact' ? (
@@ -608,7 +642,7 @@ export function ArtifactPanel({
             key={activeTab.id}
             artifacts={artifacts}
             artifactId={activeTab.artifactId}
-            workspaceActions={activeWorkspaceActions}
+            workspaceActions={activeWorkspaceActions!}
             previewContent={activeTab.previewContent}
             loading={loading}
             error={error}
@@ -659,7 +693,7 @@ export function ArtifactPanel({
           <ScheduledTaskDetail
             key={activeTab.id}
             task={activeTab.task}
-            actions={activeWorkspaceActions}
+            actions={activeWorkspaceActions!}
           />
         )}
       </div>
@@ -804,7 +838,7 @@ function ArtifactDetailTab({
 }: {
   artifacts: readonly DaemonSessionArtifact[];
   artifactId: string;
-  workspaceActions: DaemonWorkspaceActions;
+  workspaceActions: ArtifactWorkspaceActions;
   previewContent?: string;
   loading?: boolean;
   error?: string | null;
@@ -833,7 +867,7 @@ function ScheduledTaskDetail({
   actions,
 }: {
   task: TurnOutputScheduledTask;
-  actions: DaemonWorkspaceActions;
+  actions: ArtifactWorkspaceActions;
 }) {
   const { t } = useI18n();
   const [loadedTask, setLoadedTask] = useState<DaemonScheduledTask | null>(
@@ -851,8 +885,50 @@ function ScheduledTaskDetail({
   const [busy, setBusy] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
+  const requestRef = useRef(0);
+  const requestScopeRef = useRef({
+    actions,
+    taskId: task.id,
+    workspaceId: task.workspaceId,
+  });
+  requestScopeRef.current = {
+    actions,
+    taskId: task.id,
+    workspaceId: task.workspaceId,
+  };
+  const isCurrentRequest = useCallback(
+    (
+      request: number,
+      requestActions: ArtifactWorkspaceActions,
+      taskId: string,
+      workspaceId: string | undefined,
+    ) => {
+      const scope = requestScopeRef.current;
+      return (
+        request === requestRef.current &&
+        scope.actions === requestActions &&
+        scope.taskId === taskId &&
+        scope.workspaceId === workspaceId
+      );
+    },
+    [],
+  );
+  useEffect(
+    () => () => {
+      requestRef.current += 1;
+    },
+    [],
+  );
+  useEffect(() => {
+    setBusy(false);
+    setSubmitting(false);
+    setFormError(null);
+  }, [actions, task.id, task.workspaceId]);
 
   const loadTask = useCallback(async () => {
+    const request = ++requestRef.current;
+    const taskId = task.id;
+    const workspaceId = task.workspaceId;
     if (!task.durable) {
       setLoadedTask(null);
       setName('');
@@ -865,7 +941,8 @@ function ScheduledTaskDetail({
     setLoading(true);
     setLoadError(null);
     try {
-      const tasks = await actions.listScheduledTasks();
+      const tasks = await actions.listScheduledTasks(workspaceId);
+      if (!isCurrentRequest(request, actions, taskId, workspaceId)) return;
       const match = tasks.find((item) => item.id === task.id) ?? null;
       setLoadedTask(match);
       if (match) {
@@ -878,11 +955,23 @@ function ScheduledTaskDetail({
         setBuilder(parseCronToBuilder(task.cron));
       }
     } catch (err) {
-      setLoadError(err instanceof Error ? err.message : String(err));
+      if (isCurrentRequest(request, actions, taskId, workspaceId)) {
+        setLoadError(err instanceof Error ? err.message : String(err));
+      }
     } finally {
-      setLoading(false);
+      if (isCurrentRequest(request, actions, taskId, workspaceId)) {
+        setLoading(false);
+      }
     }
-  }, [actions, task.cron, task.durable, task.id, task.prompt]);
+  }, [
+    actions,
+    isCurrentRequest,
+    task.cron,
+    task.durable,
+    task.id,
+    task.prompt,
+    task.workspaceId,
+  ]);
 
   useEffect(() => {
     void loadTask();
@@ -926,56 +1015,98 @@ function ScheduledTaskDetail({
       setFormError(t('scheduledTasks.error.emptyPrompt'));
       return;
     }
+    const request = ++requestRef.current;
+    const taskId = task.id;
+    const workspaceId = task.workspaceId;
     setSubmitting(true);
     setFormError(null);
     try {
-      const updated = await actions.updateScheduledTask(loadedTask.id, {
-        cron,
-        prompt: prompt.trim(),
-        name: name.trim() || null,
-      });
+      const updated = await actions.updateScheduledTask(
+        loadedTask.id,
+        {
+          cron,
+          prompt: prompt.trim(),
+          name: name.trim() || null,
+        },
+        workspaceId,
+      );
+      if (!isCurrentRequest(request, actions, taskId, workspaceId)) return;
       setLoadedTask(updated);
       setName(updated.name ?? '');
       setPrompt(updated.prompt);
       setBuilder(parseCronToBuilder(updated.cron));
       setShowForm(false);
     } catch (err) {
-      setFormError(err instanceof Error ? err.message : String(err));
+      if (isCurrentRequest(request, actions, taskId, workspaceId)) {
+        setFormError(err instanceof Error ? err.message : String(err));
+      }
     } finally {
-      setSubmitting(false);
+      if (isCurrentRequest(request, actions, taskId, workspaceId)) {
+        setSubmitting(false);
+      }
     }
-  }, [actions, builder, loadedTask, name, prompt, t]);
+  }, [
+    actions,
+    builder,
+    isCurrentRequest,
+    loadedTask,
+    name,
+    prompt,
+    t,
+    task.id,
+    task.workspaceId,
+  ]);
 
   const handleToggle = useCallback(async () => {
     if (!loadedTask) return;
+    const request = ++requestRef.current;
+    const taskId = task.id;
+    const workspaceId = task.workspaceId;
     setBusy(true);
     setFormError(null);
     try {
-      const updated = await actions.updateScheduledTask(loadedTask.id, {
-        enabled: !loadedTask.enabled,
-      });
+      const updated = await actions.updateScheduledTask(
+        loadedTask.id,
+        {
+          enabled: !loadedTask.enabled,
+        },
+        workspaceId,
+      );
+      if (!isCurrentRequest(request, actions, taskId, workspaceId)) return;
       setLoadedTask(updated);
     } catch (err) {
-      setFormError(err instanceof Error ? err.message : String(err));
+      if (isCurrentRequest(request, actions, taskId, workspaceId)) {
+        setFormError(err instanceof Error ? err.message : String(err));
+      }
     } finally {
-      setBusy(false);
+      if (isCurrentRequest(request, actions, taskId, workspaceId)) {
+        setBusy(false);
+      }
     }
-  }, [actions, loadedTask]);
+  }, [actions, isCurrentRequest, loadedTask, task.id, task.workspaceId]);
 
   const handleDelete = useCallback(async () => {
     if (!loadedTask) return;
+    const request = ++requestRef.current;
+    const taskId = task.id;
+    const workspaceId = task.workspaceId;
     setBusy(true);
     setFormError(null);
     try {
-      await actions.deleteScheduledTask(loadedTask.id);
+      await actions.deleteScheduledTask(loadedTask.id, workspaceId);
+      if (!isCurrentRequest(request, actions, taskId, workspaceId)) return;
       setLoadedTask(null);
       setShowDeleteConfirm(false);
     } catch (err) {
-      setFormError(err instanceof Error ? err.message : String(err));
+      if (isCurrentRequest(request, actions, taskId, workspaceId)) {
+        setFormError(err instanceof Error ? err.message : String(err));
+      }
     } finally {
-      setBusy(false);
+      if (isCurrentRequest(request, actions, taskId, workspaceId)) {
+        setBusy(false);
+      }
     }
-  }, [actions, loadedTask]);
+  }, [actions, isCurrentRequest, loadedTask, task.id, task.workspaceId]);
 
   const previewCron = buildCron(builder);
   const previewLabel = previewCron ? describeCron(previewCron, t) : null;
@@ -2110,7 +2241,7 @@ function ArtifactDetail({
   previewContent,
 }: {
   artifact: DaemonSessionArtifact;
-  workspaceActions: DaemonWorkspaceActions;
+  workspaceActions: ArtifactWorkspaceActions;
   previewContent?: string;
 }) {
   const location = getArtifactLocation(artifact);
@@ -2272,7 +2403,7 @@ function WorkspaceFilePreview({
 }: {
   workspacePath: string;
   artifactVersion?: string;
-  workspaceActions: DaemonWorkspaceActions;
+  workspaceActions: ArtifactWorkspaceActions;
   previewContent?: string;
   imageMimeType?: string;
   previewKind?: 'html' | 'markdown' | 'image' | 'source';
@@ -2336,7 +2467,7 @@ function ImageArtifactPreview({
 }: {
   workspacePath: string;
   artifactVersion?: string;
-  workspaceActions: DaemonWorkspaceActions;
+  workspaceActions: ArtifactWorkspaceActions;
   mimeType: string;
 }) {
   const [src, setSrc] = useState<string | null>(null);
@@ -2407,7 +2538,7 @@ function useWorkspaceFileContent({
 }: {
   workspacePath: string;
   artifactVersion?: string;
-  workspaceActions: DaemonWorkspaceActions;
+  workspaceActions: ArtifactWorkspaceActions;
   previewContent?: string;
   truncatedMessage: string;
 }) {
@@ -2451,7 +2582,7 @@ function HtmlArtifactPreview({
 }: {
   workspacePath: string;
   artifactVersion?: string;
-  workspaceActions: DaemonWorkspaceActions;
+  workspaceActions: ArtifactWorkspaceActions;
   previewContent?: string;
 }) {
   const { content, error } = useWorkspaceFileContent({
@@ -2487,7 +2618,7 @@ function FileArtifactPreview({
 }: {
   workspacePath: string;
   artifactVersion?: string;
-  workspaceActions: DaemonWorkspaceActions;
+  workspaceActions: ArtifactWorkspaceActions;
 }) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const [renderError, setRenderError] = useState<string | null>(null);
@@ -2544,7 +2675,7 @@ function MarkdownArtifactPreview({
 }: {
   workspacePath: string;
   artifactVersion?: string;
-  workspaceActions: DaemonWorkspaceActions;
+  workspaceActions: ArtifactWorkspaceActions;
   previewContent?: string;
 }) {
   const { content, error } = useWorkspaceFileContent({

--- a/packages/web-shell/client/components/artifacts/ArtifactPanel.tsx
+++ b/packages/web-shell/client/components/artifacts/ArtifactPanel.tsx
@@ -695,7 +695,7 @@ export function ArtifactPanel({
           <ScheduledTaskDetail
             key={activeTab.id}
             task={activeTab.task}
-            actions={activeWorkspaceActions!}
+            actions={activeWorkspaceActions}
           />
         )}
       </div>
@@ -869,7 +869,7 @@ function ScheduledTaskDetail({
   actions,
 }: {
   task: TurnOutputScheduledTask;
-  actions: ArtifactWorkspaceActions;
+  actions: ArtifactWorkspaceActions | undefined;
 }) {
   const { t } = useI18n();
   const [loadedTask, setLoadedTask] = useState<DaemonScheduledTask | null>(
@@ -951,7 +951,7 @@ function ScheduledTaskDetail({
     const loadRequest = ++loadRequestRef.current;
     const taskId = task.id;
     const workspaceId = task.workspaceId;
-    if (!task.durable) {
+    if (!task.durable || !actions) {
       setLoadedTask(null);
       setName('');
       setPrompt(task.prompt);
@@ -1028,7 +1028,7 @@ function ScheduledTaskDetail({
   }, [loadedTask]);
 
   const handleSave = useCallback(async () => {
-    if (!loadedTask) return;
+    if (!loadedTask || !actions) return;
     const cron = buildCron(builder);
     if (!cron) {
       setFormError(t('scheduledTasks.error.invalidSchedule'));
@@ -1081,7 +1081,7 @@ function ScheduledTaskDetail({
   ]);
 
   const handleToggle = useCallback(async () => {
-    if (!loadedTask) return;
+    if (!loadedTask || !actions) return;
     const request = ++requestRef.current;
     const taskId = task.id;
     const workspaceId = task.workspaceId;
@@ -1109,7 +1109,7 @@ function ScheduledTaskDetail({
   }, [actions, isCurrentRequest, loadedTask, task.id, task.workspaceId]);
 
   const handleDelete = useCallback(async () => {
-    if (!loadedTask) return;
+    if (!loadedTask || !actions) return;
     const request = ++requestRef.current;
     const taskId = task.id;
     const workspaceId = task.workspaceId;

--- a/packages/web-shell/client/components/artifacts/CodeReviewArtifactDetail.tsx
+++ b/packages/web-shell/client/components/artifacts/CodeReviewArtifactDetail.tsx
@@ -1,4 +1,3 @@
-import type { DaemonWorkspaceActions } from '@qwen-code/webui/daemon-react-sdk';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useI18n } from '../../i18n';
 import { isSafeHref, Markdown } from '../messages/Markdown';
@@ -7,6 +6,7 @@ import {
   readWorkspaceFileAsBlob,
 } from './artifactUtils';
 import styles from './CodeReviewArtifactDetail.module.css';
+import type { ArtifactWorkspaceActions } from './useArtifactWorkspaceTarget';
 
 // Hand-duplicated from the CLI's canonical lists in
 // packages/cli/src/commands/review/findings.ts. The parser below fails closed
@@ -306,7 +306,7 @@ export function CodeReviewArtifactDetail({
 }: {
   workspacePath: string;
   artifactVersion?: string;
-  workspaceActions: DaemonWorkspaceActions;
+  workspaceActions: ArtifactWorkspaceActions;
 }) {
   const { t } = useI18n();
   const [content, setContent] = useState<string | null>(null);
@@ -671,7 +671,7 @@ function EvidenceFile({
   workspaceActions,
 }: {
   path: string;
-  workspaceActions: DaemonWorkspaceActions;
+  workspaceActions: ArtifactWorkspaceActions;
 }) {
   const mimeType = getImageMimeTypeFromPath(path);
   const [src, setSrc] = useState<string | null>(null);

--- a/packages/web-shell/client/components/artifacts/SideTaskPanel.tsx
+++ b/packages/web-shell/client/components/artifacts/SideTaskPanel.tsx
@@ -12,7 +12,6 @@ import {
 } from '../../constants/sessions';
 import type { TurnOutputOpenRequest } from './TurnOutputs';
 import type { DaemonSessionArtifact } from '@qwen-code/sdk/daemon';
-import type { DaemonWorkspaceActions } from '@qwen-code/webui/daemon-react-sdk';
 import { useI18n } from '../../i18n';
 import { ChatPane } from '../ChatPane';
 import { Button } from '../ui/button';
@@ -41,7 +40,6 @@ interface SideTaskPanelProps {
   onArtifactsChange?: (
     sessionId: string,
     artifacts: readonly DaemonSessionArtifact[],
-    workspaceActions: DaemonWorkspaceActions,
   ) => void;
   onError?: (error: unknown, fallback: string) => void;
   sessionWorkflowEnabled?: boolean;

--- a/packages/web-shell/client/components/artifacts/SubagentDetail.integration.test.tsx
+++ b/packages/web-shell/client/components/artifacts/SubagentDetail.integration.test.tsx
@@ -125,6 +125,8 @@ it('opens subagent and fork transcript outputs in source-scoped panel tabs', asy
     title: string;
     turnId: string;
     changes: [];
+    workspaceCwd: string;
+    workspaceId: string;
   }) => void;
   act(() => {
     openOutput({
@@ -133,6 +135,8 @@ it('opens subagent and fork transcript outputs in source-scoped panel tabs', asy
       title: 'Review',
       turnId: 'turn-1',
       changes: [],
+      workspaceCwd: '/work/project',
+      workspaceId: 'project-id',
     });
   });
 
@@ -143,6 +147,7 @@ it('opens subagent and fork transcript outputs in source-scoped panel tabs', asy
     turnId: 'turn-1',
     changes: [],
     sourceSessionId: 'subagent-session',
-    workspaceActions,
+    workspaceCwd: '/work/project',
+    workspaceId: 'project-id',
   });
 });

--- a/packages/web-shell/client/components/artifacts/SubagentDetail.tsx
+++ b/packages/web-shell/client/components/artifacts/SubagentDetail.tsx
@@ -3,8 +3,6 @@ import {
   DaemonSessionProvider,
   useConnection,
   useWorkspace,
-  useWorkspaceActions,
-  type DaemonWorkspaceActions,
 } from '@qwen-code/webui/daemon-react-sdk';
 import type { DaemonSessionArtifact } from '@qwen-code/sdk/daemon';
 import type { ACPToolCall, Message } from '../../adapters/types';
@@ -139,13 +137,11 @@ function SubagentDetailContent({
   onArtifactsChange?: (
     sessionId: string,
     artifacts: readonly DaemonSessionArtifact[],
-    workspaceActions: DaemonWorkspaceActions,
   ) => void;
   onError?: (error: unknown, fallback: string) => void;
 }) {
   const { t } = useI18n();
   const connection = useConnection();
-  const workspaceActions = useWorkspaceActions();
   const messages = useMessages(t);
   const { artifacts } = useSessionArtifacts();
   const artifactsByTurn = useMemo(
@@ -176,23 +172,15 @@ function SubagentDetailContent({
   useEffect(() => {
     const sessionId = connection.sessionId;
     if (!sessionId) return;
-    onArtifactsChange?.(sessionId, artifacts, workspaceActions);
+    onArtifactsChange?.(sessionId, artifacts);
     return () => {
-      onArtifactsChange?.(sessionId, [], workspaceActions);
+      onArtifactsChange?.(sessionId, []);
     };
-  }, [artifacts, connection.sessionId, onArtifactsChange, workspaceActions]);
+  }, [artifacts, connection.sessionId, onArtifactsChange]);
 
   const handleRightPanelOpen = (request: TurnOutputOpenRequest) => {
-    if (request.kind === 'subagent') {
-      onRightPanelOpen?.({
-        ...request,
-        sourceSessionId: connection.sessionId,
-      });
-      return;
-    }
     onRightPanelOpen?.({
       ...request,
-      workspaceActions,
       sourceSessionId: connection.sessionId,
     });
   };
@@ -286,7 +274,6 @@ export function SubagentDetail({
   onArtifactsChange?: (
     sessionId: string,
     artifacts: readonly DaemonSessionArtifact[],
-    workspaceActions: DaemonWorkspaceActions,
   ) => void;
   onError?: (error: unknown, fallback: string) => void;
 }) {

--- a/packages/web-shell/client/components/artifacts/TurnOutputs.dom.test.tsx
+++ b/packages/web-shell/client/components/artifacts/TurnOutputs.dom.test.tsx
@@ -1,19 +1,51 @@
 // @vitest-environment jsdom
-import { act } from 'react';
+import { act, StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { DaemonSessionArtifact } from '@qwen-code/sdk/daemon';
 import { I18nProvider } from '../../i18n';
 
-const { readFileBytes, stat } = vi.hoisted(() => ({
+const {
+  readFileBytes,
+  stat,
+  secondaryReadFileBytes,
+  secondaryReadWorkspaceFile,
+  secondaryStat,
+  workspaceByCwd,
+} = vi.hoisted(() => ({
   readFileBytes: vi.fn(),
   stat: vi.fn(),
+  secondaryReadFileBytes: vi.fn(),
+  secondaryReadWorkspaceFile: vi.fn(),
+  secondaryStat: vi.fn(),
+  workspaceByCwd: vi.fn(),
 }));
 
 vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
   useWorkspaceActions: () => ({
     readFileBytes,
     stat,
+  }),
+  useWorkspace: () => ({
+    actions: { readFileBytes, stat },
+    client: { workspaceByCwd },
+    capabilities: {
+      workspaceCwd: '/primary',
+      workspaces: [
+        {
+          id: 'primary-id',
+          cwd: '/primary',
+          primary: true,
+          trusted: true,
+        },
+        {
+          id: 'secondary-id',
+          cwd: '/secondary',
+          primary: false,
+          trusted: true,
+        },
+      ],
+    },
   }),
 }));
 
@@ -34,6 +66,18 @@ beforeEach(() => {
     returnedBytes: 3,
     sizeBytes: 3,
   });
+  secondaryStat.mockResolvedValue({ sizeBytes: 9, modifiedMs: 2 });
+  secondaryReadFileBytes.mockResolvedValue({
+    contentBase64: btoa('secondary'),
+    offset: 0,
+    returnedBytes: 9,
+    sizeBytes: 9,
+  });
+  workspaceByCwd.mockReturnValue({
+    readWorkspaceFile: secondaryReadWorkspaceFile,
+    readWorkspaceFileBytes: secondaryReadFileBytes,
+    fileStat: secondaryStat,
+  });
   Object.defineProperty(URL, 'createObjectURL', {
     configurable: true,
     value: vi.fn((blob: Blob) => {
@@ -52,6 +96,10 @@ afterEach(() => {
   vi.restoreAllMocks();
   readFileBytes.mockReset();
   stat.mockReset();
+  secondaryReadFileBytes.mockReset();
+  secondaryReadWorkspaceFile.mockReset();
+  secondaryStat.mockReset();
+  workspaceByCwd.mockReset();
 });
 
 describe('TurnOutputs artifact downloads', () => {
@@ -87,6 +135,7 @@ describe('TurnOutputs artifact downloads', () => {
         <I18nProvider language="en">
           <TurnOutputs
             turnId="turn-1"
+            workspaceCwd="/primary"
             changes={[]}
             artifacts={artifacts}
             scheduledTasks={[]}
@@ -120,6 +169,7 @@ describe('TurnOutputs artifact downloads', () => {
         <I18nProvider language="en">
           <TurnOutputs
             turnId="turn-1"
+            workspaceCwd="/primary"
             changes={[]}
             artifacts={[
               {
@@ -161,6 +211,155 @@ describe('TurnOutputs artifact downloads', () => {
     act(() => root.unmount());
   });
 
+  it('routes a secondary workspace download through its qualified client', async () => {
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => {});
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <StrictMode>
+          <I18nProvider language="en">
+            <TurnOutputs
+              turnId="turn-secondary"
+              workspaceCwd="/secondary"
+              changes={[]}
+              artifacts={[
+                {
+                  id: 'secondary-artifact',
+                  kind: 'file',
+                  storage: 'workspace',
+                  status: 'available',
+                  title: 'Secondary report',
+                  workspacePath: 'report.txt',
+                } as DaemonSessionArtifact,
+              ]}
+              scheduledTasks={[]}
+              onReviewChanges={() => {}}
+              onOpenArtifact={() => {}}
+              onOpenScheduledTask={() => {}}
+            />
+          </I18nProvider>
+        </StrictMode>,
+      );
+    });
+
+    await act(async () => {
+      const download = Array.from(container.querySelectorAll('button')).find(
+        (button) => button.textContent?.trim() === 'Download',
+      );
+      download?.click();
+      await Promise.resolve();
+    });
+
+    expect(workspaceByCwd).toHaveBeenCalledWith('/secondary');
+    expect(secondaryReadFileBytes).toHaveBeenCalledWith('report.txt', {
+      offset: 0,
+      maxBytes: 100 * 1024,
+    });
+    expect(readFileBytes).not.toHaveBeenCalled();
+    expect(click).toHaveBeenCalledOnce();
+
+    act(() => root.unmount());
+  });
+
+  it('stamps secondary ownership onto every panel open request', () => {
+    const onOpenRequest = vi.fn();
+    const artifact = {
+      id: 'secondary-artifact',
+      kind: 'file',
+      storage: 'workspace',
+      status: 'available',
+      title: 'Secondary artifact',
+      workspacePath: 'report.txt',
+    } as DaemonSessionArtifact;
+    const scheduledTask = {
+      id: 'secondary-task',
+      toolCallId: 'task-call',
+      title: 'Secondary schedule',
+      cron: '0 9 * * *',
+      prompt: 'secondary only',
+      recurring: true,
+      durable: true,
+    };
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <I18nProvider language="en">
+          <TurnOutputs
+            turnId="turn-secondary"
+            workspaceCwd="/secondary"
+            changes={[
+              {
+                path: 'changed.ts',
+                status: 'modified',
+                toolCallId: 'change-call',
+                isArtifact: false,
+                diffs: [],
+              },
+            ]}
+            artifacts={[artifact]}
+            scheduledTasks={[scheduledTask]}
+            onOpenRequest={onOpenRequest}
+            onReviewChanges={() => {}}
+            onOpenArtifact={() => {}}
+            onOpenScheduledTask={() => {}}
+          />
+        </I18nProvider>,
+      );
+    });
+
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('button[title="changed.ts"]')
+        ?.click();
+      container
+        .querySelector<HTMLButtonElement>('button[title="Secondary artifact"]')
+        ?.click();
+      container
+        .querySelector<HTMLButtonElement>('button[title="Secondary schedule"]')
+        ?.click();
+    });
+
+    expect(onOpenRequest).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        kind: 'review',
+        workspaceCwd: '/secondary',
+        workspaceId: 'secondary-id',
+      }),
+    );
+    expect(onOpenRequest).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        kind: 'artifact',
+        artifact,
+        workspaceCwd: '/secondary',
+        workspaceId: 'secondary-id',
+      }),
+    );
+    expect(onOpenRequest).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        kind: 'scheduled_task',
+        task: expect.objectContaining({
+          id: 'secondary-task',
+          workspaceId: 'secondary-id',
+        }),
+        workspaceCwd: '/secondary',
+        workspaceId: 'secondary-id',
+      }),
+    );
+
+    act(() => root.unmount());
+  });
+
   it('disables repeated downloads and reports failures through the toast callback', async () => {
     let rejectStat: ((error: Error) => void) | undefined;
     stat.mockReturnValue(
@@ -178,6 +377,7 @@ describe('TurnOutputs artifact downloads', () => {
         <I18nProvider language="en">
           <TurnOutputs
             turnId="turn-1"
+            workspaceCwd="/primary"
             changes={[]}
             artifacts={[
               {
@@ -265,6 +465,7 @@ describe('TurnOutputs artifact downloads', () => {
         <I18nProvider language="en">
           <TurnOutputs
             turnId="turn-1"
+            workspaceCwd="/primary"
             changes={[]}
             artifacts={artifacts}
             scheduledTasks={[]}
@@ -304,6 +505,7 @@ describe('TurnOutputs artifact downloads', () => {
         <I18nProvider language="en">
           <TurnOutputs
             turnId="turn-1"
+            workspaceCwd="/primary"
             changes={[]}
             artifacts={[
               {

--- a/packages/web-shell/client/components/artifacts/TurnOutputs.dom.test.tsx
+++ b/packages/web-shell/client/components/artifacts/TurnOutputs.dom.test.tsx
@@ -266,6 +266,49 @@ describe('TurnOutputs artifact downloads', () => {
     act(() => root.unmount());
   });
 
+  it('hides Download when the artifact workspace cannot be resolved', () => {
+    workspaceByCwd.mockReturnValue(undefined);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <I18nProvider language="en">
+          <TurnOutputs
+            turnId="turn-unknown"
+            workspaceCwd="/unknown"
+            changes={[]}
+            artifacts={[
+              {
+                id: 'unknown-artifact',
+                kind: 'file',
+                storage: 'workspace',
+                status: 'available',
+                title: 'Unknown report',
+                workspacePath: 'report.txt',
+              } as DaemonSessionArtifact,
+            ]}
+            scheduledTasks={[]}
+            onReviewChanges={() => {}}
+            onOpenArtifact={() => {}}
+            onOpenScheduledTask={() => {}}
+          />
+        </I18nProvider>,
+      );
+    });
+
+    expect(
+      Array.from(container.querySelectorAll('button')).find(
+        (button) => button.textContent?.trim() === 'Download',
+      ),
+    ).toBeUndefined();
+    expect(readFileBytes).not.toHaveBeenCalled();
+    expect(secondaryReadFileBytes).not.toHaveBeenCalled();
+
+    act(() => root.unmount());
+  });
+
   it('stamps secondary ownership onto every panel open request', () => {
     const onOpenRequest = vi.fn();
     const artifact = {

--- a/packages/web-shell/client/components/artifacts/TurnOutputs.tsx
+++ b/packages/web-shell/client/components/artifacts/TurnOutputs.tsx
@@ -1,7 +1,5 @@
 import type { DaemonSessionArtifact } from '@qwen-code/sdk/daemon';
 import type { ACPToolCall } from '../../adapters/types';
-import type { DaemonWorkspaceActions } from '@qwen-code/webui/daemon-react-sdk';
-import { useWorkspaceActions } from '@qwen-code/webui/daemon-react-sdk';
 import {
   DownloadIcon,
   FileAudioIcon,
@@ -28,6 +26,7 @@ import {
   stripWorkspacePath,
 } from './artifactUtils';
 import { LineStats, sumLineStats } from './LineStats';
+import { useArtifactWorkspaceTarget } from './useArtifactWorkspaceTarget';
 import styles from './TurnOutputs.module.css';
 
 export interface TurnOutputFileChange {
@@ -55,6 +54,7 @@ export interface TurnOutputScheduledTask {
   prompt: string;
   recurring: boolean;
   durable: boolean;
+  workspaceId?: string;
   display?: string;
 }
 
@@ -74,8 +74,8 @@ export type TurnOutputOpenRequest = (
       turnId: string;
       changes: readonly TurnOutputFileChange[];
       selectedPath?: string;
-      workspaceActions?: DaemonWorkspaceActions;
       workspaceCwd?: string;
+      workspaceId?: string;
     }
   | {
       id: string;
@@ -85,7 +85,8 @@ export type TurnOutputOpenRequest = (
       artifactId: string;
       managedId?: string;
       artifact: DaemonSessionArtifact;
-      workspaceActions?: DaemonWorkspaceActions;
+      workspaceCwd?: string;
+      workspaceId?: string;
       previewContent?: string;
     }
   | {
@@ -94,7 +95,8 @@ export type TurnOutputOpenRequest = (
       title: string;
       turnId: string;
       task: TurnOutputScheduledTask;
-      workspaceActions?: DaemonWorkspaceActions;
+      workspaceCwd?: string;
+      workspaceId?: string;
     }
   | {
       id: string;
@@ -139,7 +141,8 @@ function TurnOutputsComponent({
   onError,
 }: TurnOutputsProps) {
   const { t } = useI18n();
-  const workspaceActions = useWorkspaceActions();
+  const workspaceTarget = useArtifactWorkspaceTarget(workspaceCwd);
+  const workspaceActions = workspaceTarget?.actions;
   const [showAllChanges, setShowAllChanges] = useState(false);
   if (
     changes.length === 0 &&
@@ -160,6 +163,9 @@ function TurnOutputsComponent({
         turnId,
         changes,
         ...(workspaceCwd ? { workspaceCwd } : {}),
+        ...(workspaceTarget?.workspaceId
+          ? { workspaceId: workspaceTarget.workspaceId }
+          : {}),
         ...(selectedPath ? { selectedPath } : {}),
       });
       return;
@@ -181,6 +187,10 @@ function TurnOutputsComponent({
         artifactId: artifact.id,
         ...(artifact.managedId ? { managedId: artifact.managedId } : {}),
         artifact,
+        ...(workspaceCwd ? { workspaceCwd } : {}),
+        ...(workspaceTarget?.workspaceId
+          ? { workspaceId: workspaceTarget.workspaceId }
+          : {}),
         ...(previewContent !== undefined ? { previewContent } : {}),
       });
       return;
@@ -194,7 +204,13 @@ function TurnOutputsComponent({
         kind: 'scheduled_task',
         title: t('scheduledTasks.title'),
         turnId,
-        task,
+        task: workspaceTarget?.workspaceId
+          ? { ...task, workspaceId: workspaceTarget.workspaceId }
+          : task,
+        ...(workspaceCwd ? { workspaceCwd } : {}),
+        ...(workspaceTarget?.workspaceId
+          ? { workspaceId: workspaceTarget.workspaceId }
+          : {}),
       });
       return;
     }
@@ -323,7 +339,7 @@ function TurnOutputsComponent({
           onOpen={() => openArtifact(artifact)}
           onError={onError}
           onDownload={
-            canDownloadArtifact(artifact)
+            canDownloadArtifact(artifact) && workspaceActions
               ? (isCancelled) =>
                   downloadWorkspaceFile(
                     workspaceActions,

--- a/packages/web-shell/client/components/artifacts/useArtifactWorkspaceTarget.test.ts
+++ b/packages/web-shell/client/components/artifacts/useArtifactWorkspaceTarget.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  DaemonCapabilities,
+  DaemonWorkspaceCapability,
+} from '@qwen-code/sdk/daemon';
+import { resolveArtifactWorkspaceOwner } from './useArtifactWorkspaceTarget';
+
+function capabilities(
+  workspaces?: DaemonWorkspaceCapability[],
+): DaemonCapabilities {
+  return {
+    v: 1,
+    mode: 'http-bridge',
+    features: [],
+    modelServices: [],
+    workspaceCwd: '/primary',
+    ...(workspaces ? { workspaces } : {}),
+  };
+}
+
+const primary: DaemonWorkspaceCapability = {
+  id: 'primary-id',
+  cwd: '/primary',
+  primary: true,
+  trusted: true,
+};
+const secondary: DaemonWorkspaceCapability = {
+  id: 'secondary-id',
+  cwd: '/secondary',
+  primary: false,
+  trusted: true,
+};
+
+describe('resolveArtifactWorkspaceOwner', () => {
+  it('resolves one exact trusted workspace owner', () => {
+    expect(
+      resolveArtifactWorkspaceOwner(
+        capabilities([primary, secondary]),
+        '/secondary',
+      ),
+    ).toMatchObject({
+      cwd: '/secondary',
+      id: 'secondary-id',
+      primary: false,
+    });
+  });
+
+  it('supports only an exact primary match for legacy capabilities', () => {
+    expect(
+      resolveArtifactWorkspaceOwner(capabilities(), '/primary'),
+    ).toMatchObject({ cwd: '/primary', primary: true });
+    expect(
+      resolveArtifactWorkspaceOwner(capabilities(), '/secondary'),
+    ).toBeUndefined();
+  });
+
+  it.each([
+    {
+      name: 'unknown cwd',
+      caps: capabilities([primary, secondary]),
+      cwd: '/unknown',
+    },
+    {
+      name: 'explicit empty workspace list',
+      caps: capabilities([]),
+      cwd: '/primary',
+    },
+    {
+      name: 'untrusted owner',
+      caps: capabilities([primary, { ...secondary, trusted: false }]),
+      cwd: '/secondary',
+    },
+    {
+      name: 'empty owner id',
+      caps: capabilities([primary, { ...secondary, id: '' }]),
+      cwd: '/secondary',
+    },
+    {
+      name: 'duplicate cwd',
+      caps: capabilities([
+        primary,
+        secondary,
+        { ...secondary, id: 'other-id' },
+      ]),
+      cwd: '/secondary',
+    },
+    {
+      name: 'duplicate id',
+      caps: capabilities([primary, secondary, { ...secondary, cwd: '/other' }]),
+      cwd: '/secondary',
+    },
+    {
+      name: 'inconsistent primary marker',
+      caps: capabilities([primary, { ...secondary, primary: true }]),
+      cwd: '/secondary',
+    },
+  ])('fails closed for $name', ({ caps, cwd }) => {
+    expect(resolveArtifactWorkspaceOwner(caps, cwd)).toBeUndefined();
+  });
+});

--- a/packages/web-shell/client/components/artifacts/useArtifactWorkspaceTarget.ts
+++ b/packages/web-shell/client/components/artifacts/useArtifactWorkspaceTarget.ts
@@ -1,0 +1,168 @@
+import type {
+  DaemonCapabilities,
+  DaemonWorkspaceCapability,
+} from '@qwen-code/sdk/daemon';
+import {
+  useWorkspace,
+  useWorkspaceActions,
+  type DaemonFileStat,
+  type DaemonWorkspaceActions,
+} from '@qwen-code/webui/daemon-react-sdk';
+import { useEffect, useMemo, useRef } from 'react';
+
+export type ArtifactWorkspaceActions = Pick<
+  DaemonWorkspaceActions,
+  | 'readWorkspaceFile'
+  | 'readFileBytes'
+  | 'stat'
+  | 'listScheduledTasks'
+  | 'updateScheduledTask'
+  | 'deleteScheduledTask'
+>;
+
+interface ArtifactWorkspaceOwner {
+  cwd: string;
+  id?: string;
+  primary: boolean;
+}
+
+export interface ArtifactWorkspaceTarget {
+  workspaceCwd: string;
+  workspaceId?: string;
+  actions: ArtifactWorkspaceActions;
+}
+
+export function resolveArtifactWorkspaceOwner(
+  capabilities: DaemonCapabilities | undefined,
+  workspaceCwd: string | undefined,
+): ArtifactWorkspaceOwner | undefined {
+  if (!capabilities || !workspaceCwd) return undefined;
+  const advertised = capabilities.workspaces;
+  if (advertised) {
+    const matches = advertised.filter((entry) => entry.cwd === workspaceCwd);
+    const match = matches[0];
+    if (matches.length !== 1 || !match?.id || match.trusted !== true) {
+      return undefined;
+    }
+    if (advertised.filter((entry) => entry.id === match.id).length !== 1) {
+      return undefined;
+    }
+    if (match.primary !== (match.cwd === capabilities.workspaceCwd)) {
+      return undefined;
+    }
+    return workspaceOwner(match);
+  }
+  if (capabilities.workspaceCwd !== workspaceCwd) return undefined;
+  return {
+    cwd: workspaceCwd,
+    primary: true,
+  };
+}
+
+function workspaceOwner(
+  workspace: DaemonWorkspaceCapability,
+): ArtifactWorkspaceOwner {
+  return {
+    cwd: workspace.cwd,
+    id: workspace.id,
+    primary: workspace.primary,
+  };
+}
+
+export function useArtifactWorkspaceTarget(
+  workspaceCwd: string | undefined,
+): ArtifactWorkspaceTarget | undefined {
+  const workspace = useWorkspace();
+  const primaryActions = useWorkspaceActions();
+  const owner = useMemo(
+    () => resolveArtifactWorkspaceOwner(workspace.capabilities, workspaceCwd),
+    [workspace.capabilities, workspaceCwd],
+  );
+  const ownerRef = useRef(owner);
+  ownerRef.current = owner;
+  useEffect(() => {
+    ownerRef.current = owner;
+    return () => {
+      if (ownerRef.current === owner) ownerRef.current = undefined;
+    };
+  }, [owner]);
+
+  const actions = useMemo<ArtifactWorkspaceActions | undefined>(() => {
+    if (!owner) return undefined;
+    const expectedOwner = owner;
+    const requireOwner = () => {
+      const current = ownerRef.current;
+      if (current !== expectedOwner) {
+        throw new Error('Workspace artifact owner is no longer available');
+      }
+      return current;
+    };
+    const requireScheduledTaskOwner = (workspaceId: string | undefined) => {
+      const current = requireOwner();
+      if (current.id !== workspaceId) {
+        throw new Error('Scheduled task workspace owner no longer matches');
+      }
+      return current;
+    };
+    return {
+      async readWorkspaceFile(filePath) {
+        const current = requireOwner();
+        const result = await (current.primary
+          ? primaryActions.readWorkspaceFile(filePath)
+          : workspace.client
+              .workspaceByCwd(current.cwd)
+              .readWorkspaceFile(filePath));
+        requireOwner();
+        return result;
+      },
+      async readFileBytes(filePath, options) {
+        const current = requireOwner();
+        const result = await (current.primary
+          ? primaryActions.readFileBytes(filePath, options)
+          : workspace.client
+              .workspaceByCwd(current.cwd)
+              .readWorkspaceFileBytes(filePath, options));
+        requireOwner();
+        return result;
+      },
+      async stat(filePath) {
+        const current = requireOwner();
+        const result = await (current.primary
+          ? primaryActions.stat(filePath)
+          : (workspace.client
+              .workspaceByCwd(current.cwd)
+              .fileStat(filePath) as Promise<DaemonFileStat>));
+        requireOwner();
+        return result;
+      },
+      async listScheduledTasks(workspaceId) {
+        requireScheduledTaskOwner(workspaceId);
+        const result = await primaryActions.listScheduledTasks(workspaceId);
+        requireScheduledTaskOwner(workspaceId);
+        return result;
+      },
+      async updateScheduledTask(id, update, workspaceId) {
+        requireScheduledTaskOwner(workspaceId);
+        const result = await primaryActions.updateScheduledTask(
+          id,
+          update,
+          workspaceId,
+        );
+        requireScheduledTaskOwner(workspaceId);
+        return result;
+      },
+      async deleteScheduledTask(id, workspaceId) {
+        requireScheduledTaskOwner(workspaceId);
+        await primaryActions.deleteScheduledTask(id, workspaceId);
+        requireScheduledTaskOwner(workspaceId);
+      },
+    };
+  }, [owner, primaryActions, workspace.client]);
+
+  if (!owner || !actions) return undefined;
+  return {
+    workspaceCwd: owner.cwd,
+    ...(owner.id ? { workspaceId: owner.id } : {}),
+    actions,
+  };
+}

--- a/packages/web-shell/client/components/artifacts/useArtifactWorkspaceTarget.ts
+++ b/packages/web-shell/client/components/artifacts/useArtifactWorkspaceTarget.ts
@@ -26,6 +26,10 @@ interface ArtifactWorkspaceOwner {
   primary: boolean;
 }
 
+interface ArtifactWorkspaceAuthority {
+  owner: ArtifactWorkspaceOwner;
+}
+
 export interface ArtifactWorkspaceTarget {
   workspaceCwd: string;
   workspaceId?: string;
@@ -69,6 +73,17 @@ function workspaceOwner(
   };
 }
 
+function isSameWorkspaceOwner(
+  current: ArtifactWorkspaceOwner | undefined,
+  expected: ArtifactWorkspaceOwner,
+): current is ArtifactWorkspaceOwner {
+  return (
+    current?.cwd === expected.cwd &&
+    current.id === expected.id &&
+    current.primary === expected.primary
+  );
+}
+
 export function useArtifactWorkspaceTarget(
   workspaceCwd: string | undefined,
 ): ArtifactWorkspaceTarget | undefined {
@@ -78,24 +93,47 @@ export function useArtifactWorkspaceTarget(
     () => resolveArtifactWorkspaceOwner(workspace.capabilities, workspaceCwd),
     [workspace.capabilities, workspaceCwd],
   );
-  const ownerRef = useRef(owner);
-  ownerRef.current = owner;
+  const authorityRef = useRef<ArtifactWorkspaceAuthority | undefined>(
+    undefined,
+  );
+  if (!owner) {
+    authorityRef.current = undefined;
+  } else if (!isSameWorkspaceOwner(authorityRef.current?.owner, owner)) {
+    authorityRef.current = { owner };
+  }
+  const authority = authorityRef.current;
+  const authorityLifetimeRef = useRef<object | undefined>(undefined);
   useEffect(() => {
-    ownerRef.current = owner;
+    if (!authority) {
+      authorityLifetimeRef.current = undefined;
+      return undefined;
+    }
+    const lifetime = {};
+    authorityLifetimeRef.current = lifetime;
     return () => {
-      if (ownerRef.current === owner) ownerRef.current = undefined;
+      // StrictMode immediately replays setup after cleanup. Defer revocation so
+      // that replay can replace the lifetime token; a real unmount still
+      // revokes the authority as soon as that replay window closes.
+      queueMicrotask(() => {
+        if (
+          authorityLifetimeRef.current === lifetime &&
+          authorityRef.current === authority
+        ) {
+          authorityRef.current = undefined;
+        }
+      });
     };
-  }, [owner]);
+  }, [authority]);
 
   const actions = useMemo<ArtifactWorkspaceActions | undefined>(() => {
-    if (!owner) return undefined;
-    const expectedOwner = owner;
+    if (!authority) return undefined;
+    const expectedAuthority = authority;
     const requireOwner = () => {
-      const current = ownerRef.current;
-      if (current !== expectedOwner) {
+      const current = authorityRef.current;
+      if (current !== expectedAuthority) {
         throw new Error('Workspace artifact owner is no longer available');
       }
-      return current;
+      return current.owner;
     };
     const requireScheduledTaskOwner = (workspaceId: string | undefined) => {
       const current = requireOwner();
@@ -157,12 +195,12 @@ export function useArtifactWorkspaceTarget(
         requireScheduledTaskOwner(workspaceId);
       },
     };
-  }, [owner, primaryActions, workspace.client]);
+  }, [authority, primaryActions, workspace.client]);
 
-  if (!owner || !actions) return undefined;
+  if (!authority || !actions) return undefined;
   return {
-    workspaceCwd: owner.cwd,
-    ...(owner.id ? { workspaceId: owner.id } : {}),
+    workspaceCwd: authority.owner.cwd,
+    ...(authority.owner.id ? { workspaceId: authority.owner.id } : {}),
     actions,
   };
 }


### PR DESCRIPTION
## What this PR does

This PR binds artifact previews, downloads, code-review reports, file reviews, and durable scheduled-task actions to the registered workspace that produced each turn output. It carries immutable workspace identity (`workspaceCwd` and, when advertised, `workspaceId`) through primary chat, split panes, nested subagents, and side tasks; secondary file access uses the workspace-qualified daemon client, and scheduled-task operations always use the owning workspace ID.

The owner is resolved against the daemon's current capabilities and fails closed after removal, trust loss, duplicate identity, replacement, or remove-and-re-add. A stable authority token preserves valid in-flight work across semantically equivalent capability refreshes and React StrictMode effect replay without allowing an old request to regain access after its owner was revoked.

## Why it's needed

Turn outputs from a secondary workspace previously retained or reused primary-workspace action objects. When two repositories had the same relative artifact path, opening or downloading the secondary output could read the primary repository's file, and durable task controls could target the wrong workspace. Passing live actions through nested panes also allowed stale authority to survive workspace removal or runtime replacement.

The first ownership fix exposed a React StrictMode edge case in the repository's real visual scenario: effect cleanup briefly revoked a still-valid owner, so the code-review artifact panel rendered “Workspace artifact owner is no longer available.” The authority-token lifecycle fixes that regression while retaining the original fail-closed security boundary.

## Reviewer Test Plan

### How to verify

1. Run a Web Shell daemon with two trusted registered workspaces. Put different contents at the same relative sentinel path in each workspace, create an artifact from the secondary workspace, then open and download it from its turn output. Confirm the secondary sentinel is returned and the request uses the secondary workspace-qualified route.
2. Open a secondary-workspace code-review/file-review output and confirm preview and download operations stay scoped to the secondary workspace. Create, list, update, and delete a durable scheduled task from that output and confirm every operation carries the secondary workspace ID.
3. Keep a secondary file read pending and refresh capabilities with equivalent workspace records; the read must complete. Remove or replace the owner, including removing and re-advertising the same ID/CWD, and confirm the old read rejects without retrying against the primary workspace.
4. Exercise the code-review visual scenario under React StrictMode in both themes and confirm the right panel renders “Authoritative verdict” instead of the unavailable-owner alert.
5. Run `npm test`, `npm run build`, `npm run typecheck`, `npm run lint`, and `npm run test:e2e:visuals -- --grep "code review artifact"` from `packages/web-shell`.

### Evidence (Before & After)

Before the ownership change, the failure-first route probes produced 3 failures and 29 passes: secondary artifact/file reads and scheduled-task mutations reached primary actions. Before the StrictMode follow-up, the real Playwright visual scenario failed in both dark and light themes at `screenshots.spec.ts:848`; the panel showed “Unable to display code review — Workspace artifact owner is no longer available.” The same failure was reproduced locally and in [visual workflow run 30879548937](https://github.com/QwenLM/qwen-code/actions/runs/30879548937).

After the change, the focused ownership suites pass 413/413, the complete Web Shell suite passes 2,780/2,780, and the StrictMode visual scenario passes 2/2 with real Chromium screenshots in dark and light themes. The generated local screenshots were visually inspected and show the complete “Authoritative verdict” panel; this environment has no authenticated interactive browser available for uploading those local PNGs, so the repository's visual-preview workflow is the shareable image source for this head.

Production two-workspace validation used primary workspace ID `35f375e336aa5962` and secondary workspace ID `2162ccb7ea97c9ec`. The same relative sentinel path returned distinct SHA-256 values (`818d5f…b9127` primary, `0e9fac…4a12` secondary), and file, byte-range, and scheduled-task CRUD requests all used the expected owner route.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not locally tested |
|  🐧 Linux  | ⚠️ not locally tested |

### Environment (optional)

macOS arm64; repository Node/npm toolchain; Playwright Chromium 149. Linux behavior is additionally covered by the repository's Ubuntu CI, but was not counted as a local test.

## Risk & Scope

- Main risk or tradeoff: Workspace operations now reject when ownership metadata is missing, ambiguous, untrusted, or changes during a request. This is intentional fail-closed behavior; equivalent capability refreshes keep the same authority token, while removal/replacement/re-add creates a new token.
- Not validated / out of scope: Windows and Linux were not exercised locally. No daemon routes or persistence formats are changed. The package-wide format check still reports five unchanged baseline CSS/HTML files; every file changed by this PR passes Prettier.
- Breaking changes / migration notes: Host integrations that manually construct the exported `TurnOutputOpenRequest` with a retained `workspaceActions` object should pass `workspaceCwd` and, for registered workspaces, `workspaceId` instead. Normal Web Shell consumers require no migration.

## Linked Issues

Fixes #8494

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 将产物预览、下载、代码审查报告、文件审查和持久化定时任务操作绑定到实际生成对应 turn output 的已注册工作区。它在主聊天、分屏、嵌套子代理和 side task 之间传递不可变的工作区身份（`workspaceCwd`，以及 daemon 已公告时的 `workspaceId`）；次工作区文件访问使用带工作区限定的 daemon 客户端，定时任务操作始终使用所有者工作区 ID。

所有者会依据 daemon 当前 capabilities 重新解析；工作区被移除、失去信任、出现重复身份、被替换，或被移除后重新加入时均会 fail closed。稳定的 authority token 允许语义等价的 capabilities 刷新和 React StrictMode effect 重放期间的合法进行中操作继续完成，同时禁止旧请求在其所有者被撤销后重新获得访问权。

## 为什么需要它

来自次工作区的 turn output 以前会保留或复用主工作区 action 对象。当两个仓库拥有相同的相对产物路径时，打开或下载次工作区输出可能读取主仓库文件，持久化任务控件也可能操作错误的工作区。在嵌套面板间传递实时 action 还会使过期权限在工作区移除或运行时替换后继续存活。

第一版所有权修复暴露了仓库真实视觉场景中的 React StrictMode 边界情况：effect cleanup 会短暂撤销仍然有效的所有者，使代码审查产物面板显示“Workspace artifact owner is no longer available”。authority-token 生命周期修复了该回归，同时保留原有的 fail-closed 安全边界。

## 审查者测试计划

### 如何验证

1. 启动包含两个可信已注册工作区的 Web Shell daemon。在两个工作区的同一相对 sentinel 路径写入不同内容，从次工作区创建产物，再从 turn output 打开并下载它。确认返回的是次工作区 sentinel，且请求使用带次工作区限定的路由。
2. 打开次工作区的代码审查/文件审查输出，确认预览和下载始终限定在次工作区。通过该输出创建、列出、更新和删除持久化定时任务，确认每个操作都携带次工作区 ID。
3. 保持一次次工作区文件读取处于 pending 状态，用语义等价的工作区记录刷新 capabilities；读取必须成功完成。随后移除或替换所有者（包括移除后以相同 ID/CWD 再次公告），确认旧读取被拒绝且不会回退重试主工作区。
4. 在 React StrictMode 下分别以深色和浅色主题运行代码审查视觉场景，确认右侧面板显示“Authoritative verdict”，而不是所有者不可用告警。
5. 在 `packages/web-shell` 目录运行 `npm test`、`npm run build`、`npm run typecheck`、`npm run lint` 和 `npm run test:e2e:visuals -- --grep "code review artifact"`。

### 证据（修复前后）

所有权修复前，failure-first 路由探针结果为 3 个失败、29 个通过：次工作区产物/文件读取和定时任务修改会命中主工作区 action。StrictMode 跟进修复前，真实 Playwright 视觉场景的深色和浅色主题都在 `screenshots.spec.ts:848` 失败；面板显示“Unable to display code review — Workspace artifact owner is no longer available”。同一失败已在本地和[视觉工作流运行 30879548937](https://github.com/QwenLM/qwen-code/actions/runs/30879548937)中复现。

修复后，所有权聚焦测试 413/413 通过，Web Shell 完整测试 2,780/2,780 通过，StrictMode 视觉场景使用真实 Chromium 在深色和浅色主题下 2/2 通过。本地生成的截图已目视检查，完整显示“Authoritative verdict”面板；当前环境没有可用于上传本地 PNG 的已认证交互式浏览器，因此此 head 的可共享图片来源是仓库视觉预览工作流。

生产双工作区验证使用主工作区 ID `35f375e336aa5962` 和次工作区 ID `2162ccb7ea97c9ec`。同一相对 sentinel 路径返回不同的 SHA-256（主工作区 `818d5f…b9127`，次工作区 `0e9fac…4a12`），文件、字节区间和定时任务 CRUD 请求均使用预期的所有者路由。

### 测试平台

|     系统     | 状态 |
| :----------: | :--: |
|  🍏 macOS    | ✅ 已测试 |
| 🪟 Windows   | ⚠️ 未在本地测试 |
|  🐧 Linux    | ⚠️ 未在本地测试 |

### 环境（可选）

macOS arm64；仓库规定的 Node/npm 工具链；Playwright Chromium 149。仓库 Ubuntu CI 也覆盖 Linux 行为，但未计为本地测试。

## 风险与范围

- 主要风险或权衡：工作区所有权元数据缺失、存在歧义、不可信，或在请求期间变化时，工作区操作现在会被拒绝。这是有意的 fail-closed 行为；语义等价的 capabilities 刷新会保留同一 authority token，而移除、替换或移除后重加会生成新 token。
- 未验证/范围之外：未在本地运行 Windows 和 Linux。未修改任何 daemon 路由或持久化格式。包级完整格式检查仍会报告 5 个未修改的历史 CSS/HTML 文件；本 PR 修改的每个文件都通过 Prettier。
- 破坏性变更/迁移说明：手动构造导出的 `TurnOutputOpenRequest` 且保留 `workspaceActions` 对象的宿主集成，应改为传递 `workspaceCwd`，并为已注册工作区传递 `workspaceId`。普通 Web Shell 使用方无需迁移。

## 关联 Issue

Fixes #8494

</details>
