### PR TITLE
fix(desktop): rotate Tauri updater signing key

### DIFF
--- a/packages/desktop-shell/src-tauri/tauri.conf.json
+++ b/packages/desktop-shell/src-tauri/tauri.conf.json
@@ -57,7 +57,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IENEREE1N0EwMkY5OUNDMzAKUldRd3pKa3ZvRmZhemRMb3Y0M3gzMytEZEtQZk5tWlNWWWhqTWM0ZUxiTHNzSHA4SUZJOFV5cnAK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDkzMTlFNDMyRTVFNkUyNUMKUldSYzR1YmxNdVFaa3pJWjBPMERVVUw0akFvU3ZxS0pNMTFrcUhCbDlUaEVuRkVEVEcxaDBHNEcK",
       "endpoints": [
         "https://github.com/QwenLM/qwen-code/releases/download/desktop-latest/desktop-latest.json"
       ]


### PR DESCRIPTION
## What this PR does

Replaces the Tauri updater public key in the desktop shell configuration with a freshly generated minisign keypair, and configures the matching private key as a GitHub Secret.

## Why it's needed

The original minisign private key paired with the public key in the Tauri configuration (key ID `CDDA57A02F99CC30`) was lost during development — it was not saved to any local worktree, branch, or shell history. Without the matching private key, the `TAURI_SIGNING_PRIVATE_KEY` GitHub Secret cannot be configured, and the release workflow hard-blocks any published release run that lacks it (the `Require updater signing key for publishing` step exits with an error). This is the only remaining blocker for the first stable Tauri macOS desktop release.

## Reviewer Test Plan

### How to verify

1. Confirm the new public key in `tauri.conf.json` decodes to minisign public key ID `9319E432E5E6E25C`.
2. Confirm the `TAURI_SIGNING_PRIVATE_KEY` secret exists in the QwenLM/qwen-code repository (check via `gh secret list`).
3. After merge, trigger a Desktop Release workflow with `draft=true, dry_run=false` — the `Require updater signing key for publishing` step should pass, and the build should produce signed `.app.tar.gz.sig` updater artifacts.

### Evidence (Before & After)

N/A — no user-visible change; single config field replacement.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

N/A — single field change in Tauri configuration, verified by key generation output.

## Risk & Scope

- Main risk or tradeoff: any Tauri desktop installation that previously checked for updates using the old public key will reject signatures made with the new key. Since no stable Tauri release has been published yet (only dry runs with `--no-sign`), there are no existing Tauri clients to break.
- Not validated / out of scope: end-to-end signed build verification is deferred to the post-merge `draft=true, dry_run=false` release run. Windows and Linux signing secrets are not affected.
- Breaking changes / migration notes: none. The old Electron 0.0.5 release uses a separate `latest-mac.yml` updater feed and is unaffected.

## Linked Issues

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

将桌面壳 Tauri 配置中的 updater 公钥替换为新生成的 minisign 密钥对，并将对应的私钥配置为 GitHub Secret。

## 为什么需要

Tauri 配置中原来的公钥（minisign key ID `CDDA57A02F99CC30`）对应的私钥在开发过程中丢失——没有保存到任何本地 worktree、分支或 shell history 中。没有配对的私钥，就无法配置 `TAURI_SIGNING_PRIVATE_KEY` GitHub Secret，而 release workflow 在 `dry_run=false` 时会硬阻塞（`Require updater signing key for publishing` 步骤直接报错退出）。这是 Tauri 桌面应用首次稳定发布的唯一剩余阻塞项。

## 验证计划

### 如何验证

1. 确认 `tauri.conf.json` 中新公钥解码后 minisign key ID 为 `9319E432E5E6E25C`。
2. 确认 QwenLM/qwen-code 仓库中存在 `TAURI_SIGNING_PRIVATE_KEY` secret（通过 `gh secret list` 查看）。
3. 合并后触发一次 `draft=true, dry_run=false` 的 Desktop Release workflow——`Require updater signing key for publishing` 步骤应通过，构建应生成签名的 `.app.tar.gz.sig` updater 产物。

### 证据（前后对比）

N/A——无用户可见变更，仅替换单个配置字段。

### 测试环境

|     OS     | 状态  |
| :--------: | :---: |
|  🍏 macOS  |  N/A  |
| 🪟 Windows |  N/A  |
|  🐧 Linux  |  N/A  |

### 环境（可选）

N/A——Tauri 配置单字段变更，通过密钥生成输出验证。

## 风险与范围

- 主要风险/权衡：任何之前使用旧公钥检查更新的 Tauri 桌面安装将拒绝新密钥的签名。由于尚未发布过任何稳定 Tauri 版本（仅有过 `--no-sign` 的 dry run），不存在会被破坏的现有 Tauri 客户端。
- 未验证/超出范围：端到端签名构建验证推迟到合并后的 `draft=true, dry_run=false` 发布运行。Windows 和 Linux 签名 secret 不受影响。
- 破坏性变更/迁移说明：无。旧的 Electron 0.0.5 发布使用独立的 `latest-mac.yml` updater feed，不受影响。

## 关联 Issue

</details>
