### PR TITLE
fix(core): prevent cancelled file tools from mutating files

### DIFF
--- a/packages/core/src/tools/edit.test.ts
+++ b/packages/core/src/tools/edit.test.ts
@@ -632,6 +632,43 @@ describe('EditTool', () => {
       );
     });
 
+    it('rejects without modifying a file when aborted during trackEdit', async () => {
+      const initialContent = 'This is some old text.';
+      fs.writeFileSync(filePath, initialContent, 'utf8');
+      seedPriorRead(filePath);
+
+      const abortController = new AbortController();
+      const abortError = new Error('Abort requested during trackEdit');
+      let releaseTrackEdit!: () => void;
+      let signalTrackEditStarted!: () => void;
+      const trackEditStarted = new Promise<void>((resolve) => {
+        signalTrackEditStarted = resolve;
+      });
+
+      mockFileHistoryService.trackEdit.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseTrackEdit = resolve;
+            signalTrackEditStarted();
+          }),
+      );
+
+      const execution = tool
+        .build({
+          file_path: filePath,
+          old_string: 'old',
+          new_string: 'new',
+        })
+        .execute(abortController.signal);
+
+      await trackEditStarted;
+      abortController.abort(abortError);
+      releaseTrackEdit();
+
+      await expect(execution).rejects.toBe(abortError);
+      expect(fs.readFileSync(filePath, 'utf8')).toBe(initialContent);
+    });
+
     // Pin the upstream-aligned ordering: trackEdit MUST run before the
     // pre-write checkPriorRead. The upstream `claude-code/src/tools/
     // FileEditTool` comment on the equivalent block says:

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -590,6 +590,8 @@ class EditToolInvocation implements ToolInvocation<EditToolParams, ToolResult> {
         }
       }
 
+      signal.throwIfAborted();
+
       // Create parent directories AFTER the pre-write enforcement
       // check passes. Doing it before would leak intermediate
       // directories on the failure path — a real (if minor) FS
@@ -722,6 +724,9 @@ class EditToolInvocation implements ToolInvocation<EditToolParams, ToolResult> {
         returnDisplay: displayResult,
       };
     } catch (error) {
+      if (signal.aborted) {
+        throw error;
+      }
       const errorMsg = getErrorMessage(error);
       return {
         llmContent: `Error executing edit: ${errorMsg}`,

--- a/packages/core/src/tools/notebook-edit.test.ts
+++ b/packages/core/src/tools/notebook-edit.test.ts
@@ -984,4 +984,44 @@ describe('NotebookEditTool', () => {
     const updated = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
     expect(updated.cells[0].source).toEqual(['x = 100']);
   });
+
+  it('rejects without modifying a notebook when aborted during trackEdit', async () => {
+    const filePath = writeNotebook('abort-during-track-edit.ipynb', {
+      nbformat: 4,
+      nbformat_minor: 5,
+      cells: [{ cell_type: 'code', id: 'a', source: ['x = 1'], metadata: {} }],
+      metadata: {},
+    });
+    seedNotebookRead(filePath);
+
+    const abortController = new AbortController();
+    const abortError = new Error('Abort requested during trackEdit');
+    let releaseTrackEdit!: () => void;
+    let signalTrackEditStarted!: () => void;
+    const trackEditStarted = new Promise<void>((resolve) => {
+      signalTrackEditStarted = resolve;
+    });
+
+    mockFileHistoryService.trackEdit.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseTrackEdit = resolve;
+          signalTrackEditStarted();
+        }),
+    );
+
+    const execution = buildInvocation({
+      notebook_path: filePath,
+      cell_id: 'a',
+      new_source: 'x = 2',
+    }).execute(abortController.signal);
+
+    await trackEditStarted;
+    abortController.abort(abortError);
+    releaseTrackEdit();
+
+    await expect(execution).rejects.toBe(abortError);
+    const updated = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    expect(updated.cells[0].source).toEqual(['x = 1']);
+  });
 });

--- a/packages/core/src/tools/notebook-edit.ts
+++ b/packages/core/src/tools/notebook-edit.ts
@@ -619,6 +619,8 @@ class NotebookEditInvocation extends BaseToolInvocation<
         };
       }
 
+      signal.throwIfAborted();
+
       await this.config.getFileSystemService().writeTextFile({
         path: this.params.notebook_path,
         content: prepared.updatedContent,
@@ -706,6 +708,9 @@ class NotebookEditInvocation extends BaseToolInvocation<
         resultFilePaths: [this.params.notebook_path],
       };
     } catch (error) {
+      if (signal.aborted) {
+        throw error;
+      }
       const message = error instanceof Error ? error.message : String(error);
       return {
         llmContent: `Error writing notebook: ${message}`,

--- a/packages/core/src/tools/write-file.test.ts
+++ b/packages/core/src/tools/write-file.test.ts
@@ -729,6 +729,41 @@ describe('WriteFileTool', () => {
       expect(writtenContent).toBe(proposedContent);
     });
 
+    it('rejects without creating a file when aborted during trackEdit', async () => {
+      const filePath = path.join(
+        rootDir,
+        'abort-during-track-edit',
+        'new-file.txt',
+      );
+      const abortController = new AbortController();
+      const abortError = new Error('Abort requested during trackEdit');
+      let releaseTrackEdit!: () => void;
+      let signalTrackEditStarted!: () => void;
+      const trackEditStarted = new Promise<void>((resolve) => {
+        signalTrackEditStarted = resolve;
+      });
+
+      mockFileHistoryService.trackEdit.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseTrackEdit = resolve;
+            signalTrackEditStarted();
+          }),
+      );
+
+      const execution = tool
+        .build({ file_path: filePath, content: 'new content' })
+        .execute(abortController.signal);
+
+      await trackEditStarted;
+      abortController.abort(abortError);
+      releaseTrackEdit();
+
+      await expect(execution).rejects.toBe(abortError);
+      expect(fs.existsSync(filePath)).toBe(false);
+      expect(fs.existsSync(path.dirname(filePath))).toBe(false);
+    });
+
     // Pin the upstream-aligned ordering: trackEdit MUST run before the
     // pre-write checkPriorRead. The upstream `claude-code/src/tools/
     // FileEditTool` comment on the equivalent block says:

--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -275,7 +275,7 @@ class WriteFileToolInvocation extends BaseToolInvocation<
     return confirmationDetails;
   }
 
-  async execute(_abortSignal: AbortSignal): Promise<ToolResult> {
+  async execute(signal: AbortSignal): Promise<ToolResult> {
     const { file_path, content, ai_proposed_content, modified_by_user } =
       this.params;
 
@@ -495,6 +495,8 @@ class WriteFileToolInvocation extends BaseToolInvocation<
         };
       }
     }
+
+    signal.throwIfAborted();
 
     // Create parent directories AFTER the pre-write enforcement
     // check passes. Doing it before would leak intermediate


### PR DESCRIPTION
## What this PR does

Adds cooperative cancellation checks to file mutation operations so a cancelled invocation stops before the first irreversible filesystem mutation and does not continue into directory creation or file writing.

## Why it's needed

File mutation operations perform asynchronous preparation and edit-history tracking before writing. If cancellation occurs while that work is pending, the invocation can currently continue after the pending step and still create or modify the target file. This change makes cancellation effective at the write boundary, preventing cancelled operations from mutating the filesystem when cancellation has already been requested.

## Reviewer Test Plan

### How to verify

Run `npm run test --workspace=packages/core -- src/tools/write-file.test.ts src/tools/edit.test.ts src/tools/notebook-edit.test.ts`. The regression tests delay the edit-history tracking step, abort the invocation while that step is pending, then release the delayed operation. Reviewers should confirm that the invocation rejects as aborted, a new target file is not created, and an existing target file or notebook remains unchanged. The focused test run completed with 185 tests passed and 8 tests skipped.

### Evidence (Before & After)

N/A

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | N/A |

### Environment (optional)

Windows 11 with the local Node.js development environment and focused Vitest tests under `packages/core`.

## Risk & Scope

- Main risk or tradeoff: Cancellation is cooperative and only prevents filesystem mutations that have not started yet; it does not interrupt a write operation that has already begun.
- Not validated / out of scope: Scheduler-level cancellation redesign, atomic file writes, and closing the remaining stat-to-write race window are outside the scope of this PR. The full core package typecheck is currently blocked by pre-existing `sharp` module-resolution errors in unrelated image-handling files.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #8493

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

为文件变更操作增加协作式取消检查，确保已取消的调用在第一次不可逆文件系统变更之前停止，不会继续创建目录或写入文件。

## 为什么需要这个改动

文件变更操作在写入之前会执行异步准备工作和编辑历史跟踪。如果取消发生在这些异步步骤仍处于等待状态时，当前调用在异步步骤完成后仍可能继续执行，并创建或修改目标文件。本改动使取消逻辑在写入边界生效：一旦已经请求取消，已取消的操作就不会继续修改文件系统。

## 审阅者测试计划

### 如何验证

运行 `npm run test --workspace=packages/core -- src/tools/write-file.test.ts src/tools/edit.test.ts src/tools/notebook-edit.test.ts`。回归测试会延迟编辑历史跟踪步骤，在该步骤仍处于等待状态时取消调用，然后释放延迟的操作。审阅者应确认调用会以 aborted 状态 reject，新目标文件不会被创建，并且已有目标文件或 notebook 文件保持不变。本地 focused 测试共通过 185 个测试，跳过 8 个测试。

### Before & After 证据

不适用。本 PR 不涉及用户界面或 TUI 变化。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :----: |
|  🍏 macOS  | 不适用 |
| 🪟 Windows | ✅ 已测试 |
|  🐧 Linux  | 不适用 |

### 环境（可选）

Windows 11，本地 Node.js 开发环境，在 `packages/core` 下运行 focused Vitest 测试。

## 风险与范围

- 主要风险或取舍：取消机制是协作式的，只能阻止尚未开始的文件系统变更；如果写入操作已经开始，本 PR 不会中断该写入操作。
- 未验证内容 / 不在范围内：调度器级别的取消机制重构、原子文件写入，以及关闭剩余的 stat 到 write 之间的竞态窗口都不在本 PR 范围内。完整的 core package 类型检查目前被无关图片处理文件中已有的 `sharp` 模块解析错误阻塞。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #8493

</details>