### PR TITLE
test: isolate ambient runtime output configuration

### DIFF
--- a/packages/cli/test-setup.ts
+++ b/packages/cli/test-setup.ts
@@ -9,6 +9,9 @@ if (process.env['NO_COLOR'] !== undefined) {
   delete process.env['NO_COLOR'];
 }
 
+// Ignore ambient runtime routing so tests control their own output paths.
+delete process.env['QWEN_RUNTIME_DIR'];
+
 // Avoid writing per-session debug log files during CLI tests.
 // Individual tests can still opt in by overriding this env var explicitly.
 if (process.env['QWEN_DEBUG_LOG_FILE'] === undefined) {

--- a/packages/core/test-setup.ts
+++ b/packages/core/test-setup.ts
@@ -9,6 +9,9 @@ if (process.env['NO_COLOR'] !== undefined) {
   delete process.env['NO_COLOR'];
 }
 
+// Ignore ambient runtime routing so tests control their own output paths.
+delete process.env['QWEN_RUNTIME_DIR'];
+
 import { setSimulate429 } from './src/utils/testUtils.js';
 
 // Avoid writing per-session debug log files during tests.


### PR DESCRIPTION
## What this PR does

Makes Core and CLI unit tests discard an inherited `QWEN_RUNTIME_DIR` before test modules load. Tests that exercise this environment variable can still set it explicitly inside their own setup.

## Why it's needed

The self-hosted ECS runner's job-start hook exports a per-job runtime directory to every subsequent step. Because the environment variable intentionally takes priority over runtime directories selected by the application, unit-test fixtures were redirected away from their temporary directories. That broke cleanup and isolation, producing 45 cascading failures across logging, memory, session, and configuration tests.

Unit tests should control their runtime output paths rather than inherit machine-level routing. The runner hook and normal Qwen processes remain unchanged.

## Reviewer Test Plan

### How to verify

Run the affected Core and CLI suites while the parent process has a non-empty `QWEN_RUNTIME_DIR`. The suites should continue using their own temporary runtime paths, while tests that explicitly set `QWEN_RUNTIME_DIR` should still confirm that it takes priority.

### Evidence (Before & After)

Before: the injected runner value reproduced 44 failures in the affected Core suites and the CLI runtime-context failures seen in CI.

After: under the same non-empty injected value, the affected Core suites completed with 193 passed, 3 platform-skipped, and 0 failed; the focused configuration checks passed 2/2; and the CLI runtime-context checks passed 3/3. The full repository build and typecheck also passed.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22.22.0 on macOS. Linux validation is delegated to PR CI on the affected ECS runner fleet.

## Risk & Scope

- Main risk or tradeoff: a unit test that intentionally needs an inherited runtime directory must set it explicitly in that test.
- Not validated / out of scope: changing or disabling the ECS runner's job-start hook and JSONL collection.
- Breaking changes / migration notes: none.

## Linked Issues

Observed in [GitHub Actions run 30892023504](https://github.com/QwenLM/qwen-code/actions/runs/30892023504).

<details>
<summary>中文说明</summary>

## 此 PR 的改动

Core 和 CLI 单元测试会在测试模块加载前清除继承到的 `QWEN_RUNTIME_DIR`。需要验证该环境变量的测试仍然可以在自己的 setup 中显式设置它。

## 为什么需要

Self-hosted ECS runner 的 job-start hook 会把每个任务的 runtime 目录导出到所有后续步骤。该环境变量按照设计会覆盖应用选择的 runtime 目录，因此单元测试 fixture 被重定向到各自临时目录之外，清理和隔离随之失效，最终在日志、memory、session 和配置测试中产生 45 个级联失败。

单元测试应该自行控制 runtime 输出路径，而不是继承机器级路由。本改动不修改 runner hook，也不影响正常的 Qwen 进程。

## Reviewer Test Plan

### 验证方式

在父进程设置非空 `QWEN_RUNTIME_DIR` 的情况下运行受影响的 Core 和 CLI 测试。测试应继续使用各自的临时 runtime 路径；显式设置 `QWEN_RUNTIME_DIR` 的测试仍应证明该变量保持最高优先级。

### 证据（Before & After）

改动前：注入 runner 环境变量后，受影响的 Core 测试稳定复现 44 个失败，同时复现 CI 中的 CLI runtime context 失败。

改动后：在相同的非空注入值下，受影响的 Core 测试为 193 通过、3 条平台跳过、0 失败；配置定向检查 2/2 通过；CLI runtime context 检查 3/3 通过。全仓 build 和 typecheck 也通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境

macOS，Node.js 22.22.0。Linux 验证交给受影响 ECS runner fleet 上的 PR CI。

## 风险和范围

- 主要风险或取舍：如果某个单元测试确实需要继承 runtime 目录，它必须在测试中显式设置。
- 未验证或不在范围内：修改或禁用 ECS runner 的 job-start hook 和 JSONL 采集。
- 破坏性变更或迁移说明：无。

## 关联问题

问题出现在 [GitHub Actions run 30892023504](https://github.com/QwenLM/qwen-code/actions/runs/30892023504)。

</details>
