### PR TITLE
fix(cli): hide statusline child console window on Windows

### DIFF
--- a/packages/cli/src/ui/hooks/useStatusLine.ts
+++ b/packages/cli/src/ui/hooks/useStatusLine.ts
@@ -356,7 +356,12 @@ export function useStatusLine(): {
       try {
         child = exec(
           PULL_REQUEST_LOOKUP_COMMAND,
-          { cwd: currentDir, timeout: 2000, maxBuffer: 1024 },
+          {
+            cwd: currentDir,
+            timeout: 2000,
+            maxBuffer: 1024,
+            windowsHide: true,
+          },
           (error, stdout) => {
             if (
               generation !== pullRequestLookupGenerationRef.current ||
@@ -507,7 +512,12 @@ export function useStatusLine(): {
     try {
       child = exec(
         cmd!,
-        { cwd: cfg.getTargetDir(), timeout: 5000, maxBuffer: 1024 * 10 },
+        {
+          cwd: cfg.getTargetDir(),
+          timeout: 5000,
+          maxBuffer: 1024 * 10,
+          windowsHide: true,
+        },
         (error, stdout) => {
           if (gen !== generationRef.current) return; // stale
           activeChildRef.current = undefined;


### PR DESCRIPTION
## Problem

On Windows, when a custom command `statusLine` is configured, the CLI flashes
a visible console window every time the statusline renders. `useStatusLine.ts`
spawns the statusline command via `child_process.exec` without the
`windowsHide` option, so Node allocates a console window for the child (the
shell that runs the command). Statusline updates are event-driven (token
counts, streaming state, branch changes, ... with a 300ms debounce) or driven
by `refreshInterval`, so that console flashes continuously while a session is
active.

The preset path's `gh pr view` lookup (`ensurePullRequestNumber`) spawns the
same way and has the same problem.

## Fix

Add `windowsHide: true` to the exec options at both spawn sites. The option
is Windows-only and a no-op on other platforms.

## Verification

Windows 11 with a custom command statusline: a console window flashed on
every render before the change; nothing visible after it.
