### PR TITLE
fix(cli): stop review test-efficacy tests depending on ambient tmpdir vitest

### DIFF
--- a/packages/cli/src/commands/review/test-efficacy.test.ts
+++ b/packages/cli/src/commands/review/test-efficacy.test.ts
@@ -183,8 +183,20 @@ describe('planTestEfficacy', () => {
 describe('findVitestBin', () => {
   it('names the search root when vitest cannot be resolved', () => {
     const worktree = mkdtempSync(join(tmpdir(), 'no-vitest-'));
+    // A bare tmpdir answers "not found" only when nothing up-tree happens to
+    // provide vitest — a node_modules above the runner's TMPDIR (observed on
+    // self-hosted CI) would resolve one and the throw never fires. Inject the
+    // MODULE_NOT_FOUND itself so the test asks the same question on every
+    // host instead of depending on the ambient filesystem.
+    const vitestNotInstalled = () => {
+      const err = new Error(
+        "Cannot find module 'vitest/package.json'",
+      ) as NodeJS.ErrnoException;
+      err.code = 'MODULE_NOT_FOUND';
+      throw err;
+    };
 
-    expect(() => findVitestBin(worktree)).toThrow(
+    expect(() => findVitestBin(worktree, vitestNotInstalled)).toThrow(
       `vitest not found searching up from ${worktree}`,
     );
   });
@@ -314,11 +326,26 @@ describe('runControlMutant', () => {
     try {
       const original = 'import { it } from "vitest";\nit("t", () => {});\n';
       writeFileSync(join(dir, 'a.test.ts'), original);
-      // No vitest resolvable from this tmpdir, so the run THROWS out of the
-      // suite helper — which is the point: the restore lives in a `finally`
-      // and has to survive that path, or the control leaves an injected
+      // The control throws only when the vitest run never starts. A bare
+      // tmpdir has no vitest only when nothing up-tree provides one — a
+      // node_modules above the runner's TMPDIR (observed on self-hosted CI)
+      // would resolve vitest and the run would actually execute. Plant a
+      // shadow vitest whose `exports` hides its package.json: the innermost
+      // node_modules wins resolution on every host, so findVitestBin surfaces
+      // the ERR_PACKAGE_PATH_NOT_EXPORTED and the restore's `finally` has to
+      // survive exactly that path — or the control leaves an injected
       // always-failing test behind in a file every later mutant run uses.
       // (The caller's outer catch is what turns the throw into inconclusive.)
+      const vitestDir = join(dir, 'node_modules', 'vitest');
+      mkdirSync(vitestDir, { recursive: true });
+      writeFileSync(
+        join(vitestDir, 'package.json'),
+        JSON.stringify({
+          name: 'vitest',
+          exports: { '.': './index.js' },
+        }),
+      );
+      writeFileSync(join(vitestDir, 'index.js'), '');
       expect(() => runControlMutant(dir, 'a.test.ts')).toThrow();
       expect(readFileSync(join(dir, 'a.test.ts'), 'utf8')).toBe(original);
     } finally {

--- a/packages/cli/src/commands/review/test-efficacy.ts
+++ b/packages/cli/src/commands/review/test-efficacy.ts
@@ -1258,11 +1258,15 @@ function gitOut(cwd: string, ...args: string[]): string {
  * same up-tree walk Node uses for the probe's own imports, so it also survives
  * non-hoisted layouts.
  */
-export function findVitestBin(worktree: string): string {
-  const req = createRequire(join(worktree, 'noop.js'));
+export function findVitestBin(
+  worktree: string,
+  resolveModule: (specifier: string) => string = createRequire(
+    join(worktree, 'noop.js'),
+  ).resolve,
+): string {
   let pkgPath: string;
   try {
-    pkgPath = req.resolve('vitest/package.json');
+    pkgPath = resolveModule('vitest/package.json');
   } catch (error) {
     // Only a genuine MODULE_NOT_FOUND is "vitest not found". A present vitest
     // whose `exports` no longer exposes `./package.json` throws


### PR DESCRIPTION
## What this PR does

Stabilizes two environment-dependent tests in `packages/cli/src/commands/review/test-efficacy.test.ts` that fail on hosts where vitest resolves up-tree from `os.tmpdir()`. Both tests keep every assertion verbatim; only the way the failure condition is produced becomes host-deterministic. The `findVitestBin` helper gains an optional resolver parameter whose default is exactly the previous inline behavior, and one test plants a local shadow package instead of relying on a bare tmpdir having no vitest anywhere above it.

## Why it's needed

CI's ubuntu Test job fails with `AssertionError: expected [Function] to throw an error` in two cases: `findVitestBin > names the search root when vitest cannot be resolved` and `runControlMutant > leaves the probe file byte-identical when it cannot run` (PR run 30909672420; the same signature appears on the latest main run 30893612230). Both tests assumed nothing up-tree of `os.tmpdir()` provides a `vitest/package.json` — true on macOS dev machines, false on the project's self-hosted runner where a `node_modules` above TMPDIR supplies one. In that environment the first test never throws and the second actually executes the probe suite instead of throwing.

## Reviewer Test Plan

### How to verify

1. Reproduce the CI condition locally: `mkdir -p /tmp/qwen-fake-tmp/node_modules && ln -s <repo>/node_modules/vitest /tmp/qwen-fake-tmp/node_modules/vitest`, then run `cd packages/cli && TMPDIR=/tmp/qwen-fake-tmp npx vitest run src/commands/review/test-efficacy.test.ts`. With the old code both tests fail exactly as on CI; with this PR the full file passes (128/128).
2. Confirm the production call path is untouched: `findVitestBin` is called without the new parameter at its only production call site, so the default resolver (anchored `createRequire`) is identical to before.
3. Confirm no assertion changed: both tests still assert the same `toThrow(...)` messages and the same byte-identical probe file restore.
4. `cd packages/cli && npm run typecheck` plus ESLint/Prettier on the two touched files — all clean locally.

### Evidence (Before & After)

Before: both tests fail on the self-hosted ubuntu runner (and locally under the fake TMPDIR harness above). After: full file passes 128/128 in the repro environment and in 4 consecutive runs in the normal environment. Full evidence is in the e2e report comment below.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

macOS local runs plus a fake TMPDIR harness that simulates the Linux self-hosted runner's ambient vitest; the real ubuntu runner validates via this PR's own CI run.

## Risk & Scope

- Main risk or tradeoff: `findVitestBin` gains an optional parameter used only by tests; its default is the previous inline `createRequire` anchor, so production behavior is unchanged.
- Not validated / out of scope: other tests in the same file that plant their own packages were already shadow-deterministic and are untouched; the runner's ambient node_modules itself is left as-is.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

稳定 `packages/cli/src/commands/review/test-efficacy.test.ts` 中两个依赖环境的测试——它们在能从 `os.tmpdir()` 向上解析到 vitest 的主机上会失败。两个测试的断言全部逐字保留，只把失败条件的构造方式改为在任何宿主上都确定。`findVitestBin` 增加一个可选解析器参数，其默认值与之前的内联行为完全一致；另一个测试改为种植本地 shadow 包，不再依赖裸 tmpdir 上方恰好没有 vitest。

## 为什么需要

CI 的 ubuntu Test 任务以 `AssertionError: expected [Function] to throw an error` 失败于两个用例：`findVitestBin > names the search root when vitest cannot be resolved` 和 `runControlMutant > leaves the probe file byte-identical when it cannot run`（PR run 30909672420；最新 main run 30893612230 同签名）。两个测试都假设 `os.tmpdir()` 向上没有任何 `vitest/package.json`——在 macOS 开发机上成立，在项目自托管 runner 上不成立（TMPDIR 之上的 node_modules 提供了 vitest）。该环境下第一个测试从不抛错，第二个则真实执行了探针套件而非抛错。

## Reviewer Test Plan

### 如何验证

1. 本地复现 CI 条件：`mkdir -p /tmp/qwen-fake-tmp/node_modules && ln -s <repo>/node_modules/vitest /tmp/qwen-fake-tmp/node_modules/vitest`，然后 `cd packages/cli && TMPDIR=/tmp/qwen-fake-tmp npx vitest run src/commands/review/test-efficacy.test.ts`。旧代码下两个测试与 CI 完全一致地失败；本 PR 下整文件通过（128/128）。
2. 确认生产调用路径未动：`findVitestBin` 在唯一生产调用点不传新参数，默认解析器（锚定 createRequire）与之前完全相同。
3. 确认断言未变：两个测试仍断言相同的 `toThrow(...)` 消息与相同的探针文件字节恢复。
4. `cd packages/cli && npm run typecheck` 加两个改动文件的 ESLint/Prettier——本地全部通过。

### Evidence (Before & After)

改动前：两个测试在自托管 ubuntu runner 上失败（本地用上述 fake TMPDIR 装置同样复现）。改动后：整文件在复现环境与常规环境 4 轮连续通过（128/128）。完整证据见下方 e2e report 评论。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

macOS 本地运行，外加模拟 Linux 自托管 runner 环境 vitest 的 fake TMPDIR 装置；真实 ubuntu runner 由本 PR 自身的 CI 运行验证。

## Risk & Scope

- 主要风险或权衡：`findVitestBin` 新增仅测试使用的可选参数；默认值即原先内联的 createRequire 锚定，生产行为不变。
- 未验证 / 不在范围内：同文件中其他自种包的测试本就具备 shadow 确定性，未改动；runner 上的环境 node_modules 维持原样。
- 破坏性变更 / 迁移说明：无。

## Linked Issues

无。

</details>
