### PR TITLE
test: capture expected disk-full logs

### DIFF
--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -3085,24 +3085,36 @@ describe('createAcpSessionBridge', () => {
       }
       return undefined;
     })();
+    const stderr = vi
+      .spyOn(process.stderr, 'write')
+      .mockReturnValue(true as never);
 
-    await expect(
-      bridge.rewindSession(
-        session.sessionId,
-        { promptId: 'prompt-1' },
-        { clientId: session.clientId },
-      ),
-    ).resolves.toMatchObject({
-      targetTurnIndex: 0,
-      warnings: ['artifact snapshot not persisted'],
-    });
-    await expect(rewoundEvent).resolves.toMatchObject({
-      type: 'session_rewound',
-      data: { warnings: ['artifact snapshot not persisted'] },
-    });
-    abort.abort();
-
-    await bridge.shutdown();
+    try {
+      await expect(
+        bridge.rewindSession(
+          session.sessionId,
+          { promptId: 'prompt-1' },
+          { clientId: session.clientId },
+        ),
+      ).resolves.toMatchObject({
+        targetTurnIndex: 0,
+        warnings: ['artifact snapshot not persisted'],
+      });
+      await expect(rewoundEvent).resolves.toMatchObject({
+        type: 'session_rewound',
+        data: { warnings: ['artifact snapshot not persisted'] },
+      });
+      expect(stderr).toHaveBeenCalledWith(
+        expect.stringContaining('action=snapshot_failed'),
+      );
+      expect(stderr).toHaveBeenCalledWith(
+        expect.stringContaining('action=rewind_snapshot_warning'),
+      );
+    } finally {
+      abort.abort();
+      await bridge.shutdown();
+      stderr.mockRestore();
+    }
   });
 
   it('loads history replay from response metadata when requested', async () => {

--- a/packages/acp-bridge/src/sessionArtifacts.test.ts
+++ b/packages/acp-bridge/src/sessionArtifacts.test.ts
@@ -2940,25 +2940,38 @@ describe('SessionArtifactStore', () => {
     const durableId = created.changes[0]!.artifactId;
 
     failWrites = true;
-    await expect(
-      store.upsertMany(
-        [
-          {
-            title: 'Ephemeral published replacement',
-            storage: 'published',
-            managedId: 'published-replacement',
-            url,
-            retention: 'ephemeral',
-          },
+    const stderr = vi
+      .spyOn(process.stderr, 'write')
+      .mockReturnValue(true as never);
+    try {
+      await expect(
+        store.upsertMany(
+          [
+            {
+              title: 'Ephemeral published replacement',
+              storage: 'published',
+              managedId: 'published-replacement',
+              url,
+              retention: 'ephemeral',
+            },
+          ],
+          { trustedPublisher: true },
+        ),
+      ).resolves.toMatchObject({
+        changes: [],
+        warnings: [
+          'artifact durable removal not persisted; live changes rolled back',
         ],
-        { trustedPublisher: true },
-      ),
-    ).resolves.toMatchObject({
-      changes: [],
-      warnings: [
-        'artifact durable removal not persisted; live changes rolled back',
-      ],
-    });
+      });
+      expect(stderr).toHaveBeenCalledWith(
+        expect.stringContaining('action=upsert_rollback'),
+      );
+      expect(stderr).toHaveBeenCalledWith(
+        expect.stringContaining('error="disk full"'),
+      );
+    } finally {
+      stderr.mockRestore();
+    }
 
     await expect(store.list()).resolves.toMatchObject({
       artifacts: [
@@ -3852,17 +3865,30 @@ describe('SessionArtifactStore', () => {
     );
 
     failNext = true;
-    const downgraded = await store.upsertMany([
-      {
-        title: 'Durable',
-        url: 'https://example.com/downgraded',
-        metadata: { phase: 'updated' },
-      },
-    ]);
-    expect(downgraded.changes[0]?.artifact).toMatchObject({
-      retention: 'ephemeral',
-      persistenceWarning: 'persistence_unavailable',
-    });
+    const stderr = vi
+      .spyOn(process.stderr, 'write')
+      .mockReturnValue(true as never);
+    try {
+      const downgraded = await store.upsertMany([
+        {
+          title: 'Durable',
+          url: 'https://example.com/downgraded',
+          metadata: { phase: 'updated' },
+        },
+      ]);
+      expect(stderr).toHaveBeenCalledWith(
+        expect.stringContaining('action=persist_failed'),
+      );
+      expect(stderr).toHaveBeenCalledWith(
+        expect.stringContaining('reason="disk full"'),
+      );
+      expect(downgraded.changes[0]?.artifact).toMatchObject({
+        retention: 'ephemeral',
+        persistenceWarning: 'persistence_unavailable',
+      });
+    } finally {
+      stderr.mockRestore();
+    }
 
     await store.remove(created.changes[0]!.artifactId);
 
@@ -3899,13 +3925,26 @@ describe('SessionArtifactStore', () => {
     );
 
     failNext = true;
-    await store.upsertMany([
-      {
-        title: 'Durable',
-        url: 'https://example.com/downgraded-eviction',
-        metadata: { phase: 'updated' },
-      },
-    ]);
+    const stderr = vi
+      .spyOn(process.stderr, 'write')
+      .mockReturnValue(true as never);
+    try {
+      await store.upsertMany([
+        {
+          title: 'Durable',
+          url: 'https://example.com/downgraded-eviction',
+          metadata: { phase: 'updated' },
+        },
+      ]);
+      expect(stderr).toHaveBeenCalledWith(
+        expect.stringContaining('action=persist_failed'),
+      );
+      expect(stderr).toHaveBeenCalledWith(
+        expect.stringContaining('reason="disk full"'),
+      );
+    } finally {
+      stderr.mockRestore();
+    }
 
     await store.upsertMany(
       [{ title: 'Overflow', url: 'https://example.com/overflow' }],

--- a/packages/channels/qqbot/src/persistence.test.ts
+++ b/packages/channels/qqbot/src/persistence.test.ts
@@ -448,12 +448,22 @@ describe('backupGlobalSessions / restoreGlobalSessions', () => {
   });
 
   it('backup/restore failures do not crash (caught by try/catch)', () => {
+    const stderr = vi
+      .spyOn(process.stderr, 'write')
+      .mockReturnValue(true as never);
     vi.mocked(writeFileSync).mockImplementationOnce(() => {
       throw new Error('disk full');
     });
     fsStore[sessionsPath] = JSON.stringify({ key: 'data' });
     const ch = makeChannel();
-    expect(() => ch.disconnect()).not.toThrow();
+    try {
+      expect(() => ch.disconnect()).not.toThrow();
+      expect(stderr).toHaveBeenCalledWith(
+        expect.stringContaining('flushQQState write failed: disk full'),
+      );
+    } finally {
+      stderr.mockRestore();
+    }
   });
 });
 

--- a/packages/cli/src/serve/run-qwen-serve.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.test.ts
@@ -8798,6 +8798,9 @@ describe('runQwenServe channel worker supervisor', () => {
   });
 
   it('keeps serve running when worker pidfile metadata cannot be written', async () => {
+    const stderr = vi
+      .spyOn(process.stderr, 'write')
+      .mockReturnValue(true as never);
     tmpDir = fs.realpathSync(
       fs.mkdtempSync(path.join(os.tmpdir(), 'qws-channel-worker-pidfile-')),
     );
@@ -8832,8 +8835,14 @@ describe('runQwenServe channel worker supervisor', () => {
       await handle.runtimeReady;
       expect(worker.start).toHaveBeenCalled();
       expect(pidfile.writeServeServiceInfo).toHaveBeenCalled();
+      expect(stderr).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'failed to write channel worker pidfile metadata: disk full',
+        ),
+      );
     } finally {
       await handle.close();
+      stderr.mockRestore();
     }
   });
 

--- a/packages/vscode-ide-companion/src/webview/utils/imageHandler.test.ts
+++ b/packages/vscode-ide-companion/src/webview/utils/imageHandler.test.ts
@@ -108,12 +108,17 @@ describe('imageHandler', () => {
   });
 
   it('returns null when file write throws', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
     mockWriteFile.mockRejectedValueOnce(new Error('disk full'));
     const result = await saveImageToFile(
       'data:image/png;base64,YWJj',
       'image/png',
     );
     expect(result).toBeNull();
+    expect(error).toHaveBeenCalledWith(
+      '[ImageHandler] Failed to save image:',
+      expect.objectContaining({ message: 'disk full' }),
+    );
   });
 
   it('returns saved prompt image metadata for validated attachments', async () => {


### PR DESCRIPTION
## What this PR does

Captures and asserts the expected error output from unit tests that deliberately inject `new Error("disk full")`. The production logging paths remain unchanged, while the test fixtures no longer emit unqualified disk-full messages into shared CI logs.

## Why it is needed

Expected-failure tests currently print production-looking disk-full errors. Those lines can make unrelated CI failures look like runner ENOSPC incidents. Capturing the output in the tests preserves coverage of the logging behavior and makes real disk-full failures easier to distinguish.

## Reviewer Test Plan

### How to verify

Run the focused suites:

- `cd packages/acp-bridge && npx vitest run src/sessionArtifacts.test.ts src/bridge.test.ts`
- `cd packages/cli && npx vitest run src/serve/run-qwen-serve.test.ts`
- `cd packages/vscode-ide-companion && npx vitest run src/webview/utils/imageHandler.test.ts`
- `cd packages/channels/qqbot && npx vitest run src/persistence.test.ts`

Confirm that all suites pass and that their output contains no unqualified `disk full` lines. The affected tests now also assert that the expected logger or stderr call occurred.

### Evidence (Before & After)

Before: the passing suites printed messages such as `[ImageHandler] Failed to save image: Error: disk full`, `flushQQState write failed: disk full`, and artifact persistence failures containing `disk full`.

After: the same error paths remain covered and their log payloads are asserted, but the focused suite output contains zero `disk full` occurrences.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | N/A |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Ubuntu 26.04, Node.js v22.22.2, npm 10.9.7.

Additional checks passed: Prettier, ESLint on all changed files, ACP Bridge and CLI typechecks, VS Code companion typecheck, QQBot build, and the repository build run by `npm ci`.

## Risk & Scope

- Main risk or tradeoff: Test-local stderr/logger spies must be restored; each new spy is scoped to its test and restored after use.
- Not validated / out of scope: Other intentional warning output unrelated to the injected disk-full fixtures.
- Breaking changes / migration notes: None. Production code is unchanged.

## Linked Issues

Fixes #8532

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

捕获并断言单元测试中故意注入 `new Error("disk full")` 时产生的预期错误输出。生产日志逻辑保持不变，同时测试夹具不再向共享 CI 日志输出没有测试上下文的磁盘已满信息。

## 为什么需要

预期失败测试目前会打印看起来像生产故障的磁盘已满错误，容易让无关的 CI 失败被误判为 runner 的 ENOSPC 问题。由测试捕获并断言这些输出，既保留日志行为覆盖，也让真实磁盘故障更容易识别。

## 审阅者测试计划

### 如何验证

运行以下针对性测试：

- `cd packages/acp-bridge && npx vitest run src/sessionArtifacts.test.ts src/bridge.test.ts`
- `cd packages/cli && npx vitest run src/serve/run-qwen-serve.test.ts`
- `cd packages/vscode-ide-companion && npx vitest run src/webview/utils/imageHandler.test.ts`
- `cd packages/channels/qqbot && npx vitest run src/persistence.test.ts`

确认所有测试通过，且输出中不再出现没有测试上下文的 `disk full`。受影响测试现在也会断言预期的 logger 或 stderr 调用确实发生。

### Before 与 After 证据

Before：通过的测试仍会打印 `[ImageHandler] Failed to save image: Error: disk full`、`flushQQState write failed: disk full` 以及包含 `disk full` 的 artifact 持久化失败信息。

After：相同错误路径仍被覆盖，日志内容也被断言，但针对性测试输出中的 `disk full` 出现次数为零。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | N/A |
|  🐧 Linux  | ✅ 已测试 |

### 环境

Ubuntu 26.04、Node.js v22.22.2、npm 10.9.7。

额外通过的检查：全部变更文件的 Prettier 与 ESLint、ACP Bridge 和 CLI 类型检查、VS Code companion 类型检查、QQBot 构建，以及 `npm ci` 触发的仓库构建。

## 风险与范围

- 主要风险或取舍：测试内的 stderr/logger spy 必须恢复；所有新增 spy 都限定在单个测试内并在使用后恢复。
- 未验证或范围外：与注入磁盘已满夹具无关的其他预期 warning 输出。
- 破坏性变更或迁移说明：无。生产代码未修改。

## 关联 Issue

Fixes #8532

</details>