### PR TITLE
docs: add Korean to the README language bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@
 <a href="https://qwenlm.github.io/qwen-code-docs/fr/users/overview">français</a> |
 <a href="https://qwenlm.github.io/qwen-code-docs/ja/users/overview">日本語</a> |
 <a href="https://qwenlm.github.io/qwen-code-docs/ru/users/overview">Русский</a> |
-<a href="https://qwenlm.github.io/qwen-code-docs/pt-BR/users/overview">Português (Brasil)</a>
+<a href="https://qwenlm.github.io/qwen-code-docs/pt-BR/users/overview">Português (Brasil)</a> |
+<a href="https://qwenlm.github.io/qwen-code-docs/ko/users/overview">한국어</a>
 
 </div>
 


### PR DESCRIPTION
## TLDR

Adds **한국어** to the language bar at the top of `README.md`, pointing at
`https://qwenlm.github.io/qwen-code-docs/ko/users/overview`.

Issue: #8551

## Dive Deeper

One line, matching the six existing localized links:

```html
<a href="https://qwenlm.github.io/qwen-code-docs/ko/users/overview">한국어</a>
```

**Prerequisite — now satisfied.** Every entry in that bar points at the docs site, which
is built from `QwenLM/qwen-code-docs`. Korean was not a registered locale there, so
`/ko/users/overview` returned 404 when this PR was first opened as a draft.

- QwenLM/qwen-code-docs#181 registered the `ko` locale across the site and the
  translator — **merged 2026-08-07**
- The `daily-translate` workflow has since generated and deployed `content/ko/**`
- `https://qwenlm.github.io/qwen-code-docs/ko/users/overview` now returns **200**

Rebased onto latest `main`. `README.md` moved in the meantime (#8710, Ecosystem
section), but the language bar itself was untouched, so the change applies cleanly.

## Reviewer Test Plan

- `npx prettier --check README.md` — passes
- `curl -sIL https://qwenlm.github.io/qwen-code-docs/ko/users/overview` — returns 200
  (`ja` and `pt-BR` return 200 for comparison)
- Rendered README: **한국어** appears at the end of the language bar and resolves to the
  Korean overview page

## Screenshot / Video Demo

N/A — a single text link appended to an existing list. The rendered change is the word
**한국어** at the end of the language bar:

> 中文 | Deutsch | français | 日本語 | Русский | Português (Brasil) | **한국어**
