### PR TITLE
fix(web-shell): discard stale automatic recaps

### DIFF
--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -6888,6 +6888,22 @@ describe('App session callbacks', () => {
     ]);
   });
 
+  it('discards an automatic recap when the session becomes active without a new user block', async () => {
+    const { recap, rerender } = await triggerAutoRecap();
+    testState.streamingState = 'responding';
+    rerender();
+    await flush();
+
+    await act(async () => {
+      recap.resolve({ sessionId: 'session-1', recap: 'Previous turn recap' });
+      await recap.promise;
+    });
+
+    expect(mockStore.dispatch).not.toHaveBeenCalledWith([
+      expect.objectContaining({ source: 'recap' }),
+    ]);
+  });
+
   it('discards an automatic recap after starting a new session', async () => {
     const { recap, container } = await triggerAutoRecap();
     await act(async () => {

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -6871,6 +6871,23 @@ describe('App session callbacks', () => {
     ]);
   });
 
+  it('discards an automatic recap after a new turn starts in the same session', async () => {
+    const { recap } = await triggerAutoRecap();
+    testState.blocks = [
+      ...testState.blocks,
+      { id: 'new-turn', kind: 'user', text: 'Start another turn' },
+    ];
+
+    await act(async () => {
+      recap.resolve({ sessionId: 'session-1', recap: 'Previous turn recap' });
+      await recap.promise;
+    });
+
+    expect(mockStore.dispatch).not.toHaveBeenCalledWith([
+      expect.objectContaining({ source: 'recap' }),
+    ]);
+  });
+
   it('discards an automatic recap after starting a new session', async () => {
     const { recap, container } = await triggerAutoRecap();
     await act(async () => {

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -5823,21 +5823,27 @@ export function App({
       lastRecapBlockCountRef.current = currentCount;
       const sessionId = connection.sessionId;
       const version = autoRecapVersionRef.current;
+      const userBlockId = getLatestUserBlockId(store.getSnapshot().blocks);
       sessionActions.recapSession().then(
         (result) => {
+          const currentUserBlockId = getLatestUserBlockId(
+            store.getSnapshot().blocks,
+          );
           // result.sessionId only pins the daemon wire contract (the daemon
           // echoes the id back), not a real race; the epoch/connection checks
           // catch those. Kept so it is not simplified away as redundant.
           if (
             autoRecapVersionRef.current !== version ||
             connectionRef.current.sessionId !== sessionId ||
-            result.sessionId !== sessionId
+            result.sessionId !== sessionId ||
+            currentUserBlockId !== userBlockId
           ) {
             console.warn('[auto-recap] discarding stale recap', {
-              captured: { sessionId, version },
+              captured: { sessionId, version, userBlockId },
               current: {
                 sessionId: connectionRef.current.sessionId,
                 version: autoRecapVersionRef.current,
+                userBlockId: currentUserBlockId,
               },
               result: result.sessionId,
             });

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -5823,6 +5823,8 @@ export function App({
       lastRecapBlockCountRef.current = currentCount;
       const sessionId = connection.sessionId;
       const version = autoRecapVersionRef.current;
+      // Local-only commands also append user blocks. Treat any new visible user
+      // activity as invalidating the recap rather than risk placing it too late.
       const userBlockId = getLatestUserBlockId(store.getSnapshot().blocks);
       sessionActions.recapSession().then(
         (result) => {
@@ -5836,7 +5838,8 @@ export function App({
             autoRecapVersionRef.current !== version ||
             connectionRef.current.sessionId !== sessionId ||
             result.sessionId !== sessionId ||
-            currentUserBlockId !== userBlockId
+            currentUserBlockId !== userBlockId ||
+            streamingStateRef.current !== 'idle'
           ) {
             console.warn('[auto-recap] discarding stale recap', {
               captured: { sessionId, version, userBlockId },
@@ -5844,6 +5847,7 @@ export function App({
                 sessionId: connectionRef.current.sessionId,
                 version: autoRecapVersionRef.current,
                 userBlockId: currentUserBlockId,
+                streamingState: streamingStateRef.current,
               },
               result: result.sessionId,
             });


### PR DESCRIPTION
## What this PR does

Discards an automatic recap result when a new user turn starts in the same session while the recap request is still in flight. This keeps recap status from being appended to the newly started turn's message stream.

## Why it's needed

Automatic recap already rejected results after a session switch, but it did not distinguish between different turns within the same session. Because the recap request is asynchronous, a user could return to the app, trigger recap, submit a new message, and then receive the older recap inside the new turn. The change captures the current user-message boundary when recap begins and verifies that it is unchanged before inserting the result.

## Reviewer Test Plan

### How to verify

Create a session with enough transcript activity to trigger automatic recap, leave the page hidden for at least three minutes, then return and immediately submit a new message while the recap request is pending. Confirm that the new turn starts normally and that the pending recap is discarded instead of appearing after the new user message. Also confirm that recap still appears when no new turn or session switch occurs.

### Evidence (Before & After)

Before: a recap response completing after a same-session prompt could appear in that prompt's new turn.

After: the stale recap is discarded when the latest user-message boundary changes; unchanged-session and session-switch behavior remain covered by the automatic recap tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Web Shell unit tests and package-local build, typecheck, ESLint, and Prettier checks. The focused automatic recap tests passed (8/8), and the full App test file passed (307/307).

## Risk & Scope

- Main risk or tradeoff: a recap is intentionally dropped if a new user turn starts before the request completes.
- Not validated / out of scope: Windows and Linux were not tested locally. Full-repository build/typecheck remain blocked by pre-existing, unrelated CLI Ink typing errors.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当自动 recap 请求仍在进行、同一 session 内又开始了新的用户 turn 时，丢弃该 recap 结果，避免 recap 状态被追加到新 turn 的消息流中。

## 为什么需要

自动 recap 原本会在 session 切换后拒绝旧结果，但无法区分同一 session 内的不同 turn。由于 recap 请求是异步的，用户可能在返回应用并触发 recap 后立即发送新消息，随后旧 recap 被写入新 turn。本修改在 recap 开始时记录当前用户消息边界，并在插入结果前确认该边界没有变化。

## Reviewer 测试计划

### 如何验证

创建一个 transcript 活动足够触发自动 recap 的 session，将页面隐藏至少三分钟，然后返回页面，并在 recap 请求仍未完成时立即发送一条新消息。确认新 turn 正常开始，pending recap 被丢弃，不会出现在新用户消息之后。同时确认没有新 turn 或 session 切换时，recap 仍会正常显示。

### 证据（修改前后）

修改前：同一 session 内发送 prompt 后才返回的 recap 可能出现在该 prompt 开启的新 turn 中。

修改后：最新用户消息边界发生变化时，旧 recap 会被丢弃；自动 recap 测试仍覆盖边界未变化和 session 切换场景。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

运行了 Web Shell 单元测试以及 package 范围的 build、typecheck、ESLint 和 Prettier 检查。自动 recap 聚焦测试通过（8/8），完整 App 测试通过（307/307）。

## 风险与范围

- 主要风险或权衡：如果 recap 请求完成前开始了新的用户 turn，该 recap 会被有意丢弃。
- 未验证或范围外：未在 Windows 和 Linux 上进行本地测试。全仓 build/typecheck 仍被已有且无关的 CLI Ink 类型错误阻塞。
- Breaking changes / 迁移说明：无。

## 关联 Issue

N/A

</details>

