### PR TITLE
fix(release): reuse configured Apple signing secrets

### DIFF
--- a/.github/workflows/live-host-release.yml
+++ b/.github/workflows/live-host-release.yml
@@ -120,21 +120,32 @@ jobs:
         env:
           APPLE_CERTIFICATE: '${{ secrets.APPLE_CERTIFICATE }}'
           APPLE_CERTIFICATE_PASSWORD: '${{ secrets.APPLE_CERTIFICATE_PASSWORD }}'
+          LEGACY_APPLE_CERTIFICATE: '${{ secrets.MAC_CSC_LINK }}'
+          LEGACY_APPLE_CERTIFICATE_PASSWORD: '${{ secrets.MAC_CSC_KEY_PASSWORD }}'
           KEYCHAIN_PASSWORD: '${{ secrets.APPLE_KEYCHAIN_PASSWORD }}'
         run: |
           set -euo pipefail
-          for name in APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD KEYCHAIN_PASSWORD; do
-            if [ -z "${!name}" ]; then echo "::error::$name is required for published Qwen Live Host releases."; exit 1; fi
-          done
+          if [ -n "$APPLE_CERTIFICATE" ] && [ -n "$APPLE_CERTIFICATE_PASSWORD" ]; then
+            certificate_data="$APPLE_CERTIFICATE"
+            certificate_password="$APPLE_CERTIFICATE_PASSWORD"
+          elif [ -n "$LEGACY_APPLE_CERTIFICATE" ] && [ -n "$LEGACY_APPLE_CERTIFICATE_PASSWORD" ]; then
+            certificate_data="$LEGACY_APPLE_CERTIFICATE"
+            certificate_password="$LEGACY_APPLE_CERTIFICATE_PASSWORD"
+          else
+            echo '::error::A complete APPLE_CERTIFICATE pair or MAC_CSC pair is required for published Qwen Live Host releases.'
+            exit 1
+          fi
+          keychain_password="${KEYCHAIN_PASSWORD:-$(openssl rand -hex 32)}"
           certificate="$RUNNER_TEMP/qwen-live-host.p12"
           keychain="$RUNNER_TEMP/qwen-live-host.keychain-db"
-          printf '%s' "$APPLE_CERTIFICATE" | base64 --decode > "$certificate"
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$keychain"
+          certificate_data="${certificate_data#*base64,}"
+          printf '%s' "$certificate_data" | base64 --decode > "$certificate"
+          security create-keychain -p "$keychain_password" "$keychain"
           security set-keychain-settings -lut 21600 "$keychain"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$keychain"
-          security import "$certificate" -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$keychain"
+          security unlock-keychain -p "$keychain_password" "$keychain"
+          security import "$certificate" -P "$certificate_password" -A -t cert -f pkcs12 -k "$keychain"
           security list-keychains -d user -s "$keychain" login.keychain-db
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$keychain"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$keychain_password" "$keychain"
           identity="$(security find-identity -v -p codesigning "$keychain" | sed -n 's/.*"\(Developer ID Application:.*\)"/\1/p' | head -n 1)"
           if [ -z "$identity" ]; then echo '::error::Developer ID Application identity was not found.'; exit 1; fi
           {
@@ -149,18 +160,31 @@ jobs:
           APPLE_API_ISSUER: '${{ secrets.APPLE_API_ISSUER }}'
           APPLE_API_KEY_ID: '${{ secrets.APPLE_API_KEY }}'
           APPLE_API_KEY_P8: '${{ secrets.APPLE_API_KEY_P8 }}'
+          LEGACY_APPLE_API_ISSUER: '${{ secrets.APPLE_NOTARY_ISSUER_ID }}'
+          LEGACY_APPLE_API_KEY_ID: '${{ secrets.APPLE_NOTARY_KEY_ID }}'
+          LEGACY_APPLE_API_KEY_P8: '${{ secrets.APPLE_NOTARY_API_KEY_P8_BASE64 }}'
           APPLE_TEAM_ID: '${{ secrets.APPLE_TEAM_ID }}'
         run: |
           set -euo pipefail
-          for name in APPLE_API_ISSUER APPLE_API_KEY_ID APPLE_API_KEY_P8 APPLE_TEAM_ID; do
-            if [ -z "${!name}" ]; then echo "::error::$name is required for Qwen Live Host notarization."; exit 1; fi
-          done
-          key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
-          printf '%s' "$APPLE_API_KEY_P8" > "$key_path"
+          if [ -n "$APPLE_API_ISSUER" ] && [ -n "$APPLE_API_KEY_ID" ] && [ -n "$APPLE_API_KEY_P8" ]; then
+            api_issuer="$APPLE_API_ISSUER"
+            api_key_id="$APPLE_API_KEY_ID"
+            key_path="$RUNNER_TEMP/AuthKey_${api_key_id}.p8"
+            printf '%s' "$APPLE_API_KEY_P8" > "$key_path"
+          elif [ -n "$LEGACY_APPLE_API_ISSUER" ] && [ -n "$LEGACY_APPLE_API_KEY_ID" ] && [ -n "$LEGACY_APPLE_API_KEY_P8" ]; then
+            api_issuer="$LEGACY_APPLE_API_ISSUER"
+            api_key_id="$LEGACY_APPLE_API_KEY_ID"
+            key_path="$RUNNER_TEMP/AuthKey_${api_key_id}.p8"
+            printf '%s' "$LEGACY_APPLE_API_KEY_P8" | base64 --decode > "$key_path"
+          else
+            echo '::error::A complete APPLE_API notarization set or APPLE_NOTARY set is required for Qwen Live Host notarization.'
+            exit 1
+          fi
+          if [ -z "$APPLE_TEAM_ID" ]; then echo '::error::APPLE_TEAM_ID is required for Qwen Live Host notarization.'; exit 1; fi
           {
             echo "APPLE_API_KEY=$key_path"
-            echo "APPLE_API_KEY_ID=$APPLE_API_KEY_ID"
-            echo "APPLE_API_ISSUER=$APPLE_API_ISSUER"
+            echo "APPLE_API_KEY_ID=$api_key_id"
+            echo "APPLE_API_ISSUER=$api_issuer"
             echo "APPLE_TEAM_ID=$APPLE_TEAM_ID"
           } >> "$GITHUB_ENV"
 

--- a/scripts/tests/release-workflow.test.js
+++ b/scripts/tests/release-workflow.test.js
@@ -90,6 +90,32 @@ describe('Live Host release workflow', () => {
       'https://github.com/QwenLM/qwen-code/releases/download/live-host-latest',
     );
   });
+
+  it('accepts the repository macOS signing and notarization secrets', () => {
+    for (const secret of [
+      'MAC_CSC_LINK',
+      'MAC_CSC_KEY_PASSWORD',
+      'APPLE_NOTARY_ISSUER_ID',
+      'APPLE_NOTARY_KEY_ID',
+      'APPLE_NOTARY_API_KEY_P8_BASE64',
+      'APPLE_TEAM_ID',
+    ]) {
+      expect(liveHostReleaseWorkflow).toContain(`secrets.${secret}`);
+    }
+    expect(liveHostReleaseWorkflow).toContain(
+      'keychain_password="${KEYCHAIN_PASSWORD:-$(openssl rand -hex 32)}"',
+    );
+    expect(liveHostReleaseWorkflow).toContain(
+      'certificate_data="${certificate_data#*base64,}"',
+    );
+    expect(liveHostReleaseWorkflow).toContain(
+      'printf \'%s\' "$LEGACY_APPLE_API_KEY_P8" | base64 --decode > "$key_path"',
+    );
+    expect(liveHostReleaseWorkflow).toContain('echo "APPLE_API_KEY=$key_path"');
+    expect(liveHostReleaseWorkflow).toContain(
+      'echo "APPLE_API_KEY_ID=$api_key_id"',
+    );
+  });
 });
 
 describe('Live Host CI workflow', () => {


### PR DESCRIPTION
## What this PR does

Allows the independent Qwen Live Host release workflow to use the macOS signing and notarization credentials that are already configured for the repository, while retaining support for the newer credential names. It also generates an ephemeral keychain password when no dedicated password secret is configured.

## Why it's needed

The first stable Qwen Live Host release failed before packaging because the workflow required credential names that are not configured in this repository. The existing Desktop release already supports the configured legacy names, so this applies the same compatibility contract to Live Host without adding, moving, or exposing signing material.

## Reviewer Test Plan

### How to verify

Run the release-workflow unit test and validate the workflow with actionlint. Confirm that a published Live Host dispatch accepts the existing certificate pair and notarization trio, decodes their stored formats correctly, maps the notarization values to Electron Builder's expected environment variables, and still fails closed when neither credential set is complete.

### Evidence (Before & After)

N/A — release infrastructure only. Before: run 30990708152 stopped at certificate import because all newly named secrets were empty. After: the workflow resolves the already configured repository credentials through the same fallback rules used by the Desktop release.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

macOS; Vitest 5/5 passed, Prettier passed, actionlint passed, and the workflow YAML parsed successfully.

## Risk & Scope

- Main risk or tradeoff: A credential-format mismatch would still fail the release before publishing; no application runtime behavior changes.
- Not validated / out of scope: A second signed release run requires this change to be merged into `main`.
- Breaking changes / migration notes: None. Both modern and existing credential names remain supported.

## Linked Issues

Follow-up to #7859.

<details>
<summary>中文说明</summary>

## 本 PR 的改动

让独立的 Qwen Live Host 发布工作流复用仓库已经配置的 macOS 签名与公证凭据，同时继续支持新凭据名称。若没有配置专用 keychain 密码，则生成一次性的临时密码。

## 为什么需要

首次稳定版 Qwen Live Host 发布在打包前失败，因为工作流强制要求了仓库中并未配置的凭据名称。现有 Desktop 发布已经兼容仓库当前使用的旧名称，因此这里为 Live Host 应用相同的兼容约定，不新增、不迁移、也不暴露任何签名材料。

## Reviewer Test Plan

### 验证方式

运行发布工作流单测并使用 actionlint 校验工作流。确认正式 Live Host 发布可以使用现有证书二元组和公证三元组，正确解码存储格式并映射为 Electron Builder 期望的环境变量；当两组凭据都不完整时仍然失败关闭。

### 前后证据

不适用——仅涉及发布基础设施。修改前：run 30990708152 因新命名的 secrets 全部为空而停止在证书导入。修改后：工作流使用与 Desktop 发布相同的回退规则解析仓库已经配置的凭据。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境

macOS；Vitest 5/5 通过，Prettier 通过，actionlint 通过，工作流 YAML 解析通过。

## 风险与范围

- 主要风险或权衡：如果凭据格式仍不匹配，发布会继续在正式上传前失败；不改变应用运行时行为。
- 未验证或不在范围内：第二次签名发布必须在此修复合入 `main` 后运行。
- 破坏性变更或迁移说明：无，同时支持现代与现有凭据名称。

## 关联事项

#7859 的后续修复。

</details>
