### PR TITLE
fix(cli): switch @ completion category tabs with bare arrow keys

### DIFF
--- a/docs/users/reference/keyboard-shortcuts.md
+++ b/docs/users/reference/keyboard-shortcuts.md
@@ -34,12 +34,12 @@ This document lists the available keyboard shortcuts in Qwen Code.
 | `Tab`                                                 | Autocomplete the current suggestion if one exists.                                                                                                                                                                                                                                                                        |
 | `Up Arrow`                                            | Row up, then snap to start, then history prev.                                                                                                                                                                                                                                                                            |
 | `Ctrl+A` / `Home`                                     | Move the cursor to the beginning of the line.                                                                                                                                                                                                                                                                             |
-| `Ctrl+B` / `Left Arrow`                               | Move the cursor one character to the left.                                                                                                                                                                                                                                                                                |
+| `Ctrl+B` / `Left Arrow`                               | Move the cursor one character to the left. While the `@` completion menu shows category tabs, use `Ctrl+B` (the arrow switches tabs).                                                                                                                                                                                     |
 | `Ctrl+C`                                              | Clear the input prompt                                                                                                                                                                                                                                                                                                    |
 | `Esc` (double press)                                  | Clear the input prompt.                                                                                                                                                                                                                                                                                                   |
 | `Ctrl+D` / `Delete`                                   | Delete the character to the right of the cursor.                                                                                                                                                                                                                                                                          |
 | `Ctrl+E` / `End`                                      | Move the cursor to the end of the line.                                                                                                                                                                                                                                                                                   |
-| `Ctrl+F` / `Right Arrow`                              | Move the cursor one character to the right.                                                                                                                                                                                                                                                                               |
+| `Ctrl+F` / `Right Arrow`                              | Move the cursor one character to the right. While the `@` completion menu shows category tabs, use `Ctrl+F` (the arrow switches tabs).                                                                                                                                                                                    |
 | `Ctrl+H` / `Backspace`                                | Delete the character to the left of the cursor.                                                                                                                                                                                                                                                                           |
 | `Ctrl+K`                                              | Delete from the cursor to the end of the line.                                                                                                                                                                                                                                                                            |
 | `Ctrl+Left Arrow` / `Meta+Left Arrow` / `Meta+B`      | Move the cursor one word to the left.                                                                                                                                                                                                                                                                                     |
@@ -81,14 +81,18 @@ Focus the Background tasks pill in the footer (use `Down Arrow` from an empty co
 
 ## Suggestions
 
-| Shortcut                             | Description                                                              |
-| ------------------------------------ | ------------------------------------------------------------------------ |
-| `Down Arrow` / `Ctrl+N`              | Navigate down through the suggestions.                                   |
-| `Tab` / `Enter`                      | Accept the selected suggestion.                                          |
-| `Up Arrow` / `Ctrl+P`                | Navigate up through the suggestions.                                     |
-| `Right Arrow`                        | Accept a ghost-text suggestion when the prompt is empty.                 |
-| `Ctrl+Tab` / `Ctrl+Right Arrow`      | Switch to the next completion category when category tabs are shown.     |
-| `Ctrl+Shift+Tab` / `Ctrl+Left Arrow` | Switch to the previous completion category when category tabs are shown. |
+| Shortcut                | Description                                                                                                                         |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `Down Arrow` / `Ctrl+N` | Navigate down through the suggestions.                                                                                              |
+| `Tab` / `Enter`         | Accept the selected suggestion.                                                                                                     |
+| `Up Arrow` / `Ctrl+P`   | Navigate up through the suggestions.                                                                                                |
+| `Right Arrow`           | Switch to the next completion category when category tabs are shown. Also accepts a ghost-text suggestion when the prompt is empty. |
+| `Left Arrow`            | Switch to the previous completion category when category tabs are shown.                                                            |
+
+> Note: while the `@` completion menu is showing category tabs, `Left Arrow` and
+> `Right Arrow` switch categories instead of moving the cursor. Press `Esc` to
+> dismiss the menu first if you need to move the cursor. `Alt/Option+Arrow` word
+> movement is unaffected.
 
 ## History Search
 

--- a/packages/cli/src/config/keyBindings.ts
+++ b/packages/cli/src/config/keyBindings.ts
@@ -185,20 +185,24 @@ export const defaultKeyBindings: KeyBindingConfig = {
     { key: 'n', ctrl: true },
   ],
   // Completion category tab switching (for the tabbed @ completion UI).
-  // Bound to Ctrl+arrows rather than plain arrows so the bare arrow keys keep
-  // moving the caret in the editable input buffer (plain arrows only switch
-  // tabs in modal dialogs, which have no text buffer). Alt/Option+arrows still
-  // perform word movement.
-  // Ctrl+←/→ is the primary binding but many terminals intercept it for
-  // word-jump. Ctrl+Tab / Ctrl+Shift+Tab are alternatives that are less
-  // commonly intercepted (#8069).
+  // Bound to the BARE arrow keys: Ctrl+←/→ was the original binding but many
+  // terminals intercept it for word-jump, and on macOS the system claims it
+  // for Mission Control, so the documented gesture was unreachable for most
+  // users (#8069).
+  //
+  // Tradeoff, accepted deliberately: while the `@` category tabs are visible,
+  // the bare arrows no longer move the caret in the input buffer — press Esc
+  // to dismiss the menu first. InputPrompt only renders and handles the tabs
+  // when they own the arrows, so search and attachment navigation keep their
+  // normal behavior.
+  //
+  // Modifiers are pinned false so Alt/Option+arrow word movement and any
+  // Ctrl+arrow terminal binding fall through untouched.
   [Command.COMPLETION_TAB_LEFT]: [
-    { key: 'left', shift: false, ctrl: true, command: false },
-    { key: 'tab', shift: true, ctrl: true, command: false },
+    { key: 'left', shift: false, ctrl: false, meta: false },
   ],
   [Command.COMPLETION_TAB_RIGHT]: [
-    { key: 'right', shift: false, ctrl: true, command: false },
-    { key: 'tab', shift: false, ctrl: true, command: false },
+    { key: 'right', shift: false, ctrl: false, meta: false },
   ],
 
   // Text input

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -2709,7 +2709,7 @@ describe('InputPrompt', () => {
     unmount();
   });
 
-  it('should NOT switch category on Ctrl+left/right when availableCategories is exactly 2', async () => {
+  it('should NOT switch category on left/right when availableCategories is exactly 2', async () => {
     const switchCategory = vi.fn();
     mockedUseCommandCompletion.mockReturnValue({
       ...mockCommandCompletion,
@@ -2726,18 +2726,18 @@ describe('InputPrompt', () => {
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
     await wait();
 
-    stdin.write('\x1b[1;5C'); // Ctrl+right arrow
+    stdin.write('\x1b[C'); // right arrow
     await wait();
-    stdin.write('\x1b[1;5D'); // Ctrl+left arrow
+    stdin.write('\x1b[D'); // left arrow
     await wait();
 
     // With only 2 entries (all + one real category) the tab bar is hidden,
-    // so Ctrl+arrows must not trigger category switching.
+    // so the arrows must not trigger category switching.
     expect(switchCategory).not.toHaveBeenCalled();
     unmount();
   });
 
-  it('should switch category on Ctrl+left/right when availableCategories > 2', async () => {
+  it('should switch category on plain arrows before Vim handling', async () => {
     const switchCategory = vi.fn();
     mockedUseCommandCompletion.mockReturnValue({
       ...mockCommandCompletion,
@@ -2753,49 +2753,125 @@ describe('InputPrompt', () => {
       switchCategory,
     });
     props.buffer.setText('@');
-
-    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
-    await wait();
-
-    stdin.write('\x1b[1;5C'); // Ctrl+right arrow
-    await wait();
-
-    expect(switchCategory).toHaveBeenCalledWith(1);
-
-    stdin.write('\x1b[1;5D'); // Ctrl+left arrow
-    await wait();
-
-    expect(switchCategory).toHaveBeenCalledWith(-1);
-    unmount();
-  });
-
-  it('should NOT switch category on plain left/right when availableCategories > 2 (caret stays free)', async () => {
-    const switchCategory = vi.fn();
-    mockedUseCommandCompletion.mockReturnValue({
-      ...mockCommandCompletion,
-      completionMode: CompletionMode.AT,
-      showSuggestions: true,
-      suggestions: [
-        { label: 'file.ts', value: 'file.ts', category: 'file' },
-        { label: 'sess', value: 'sess', category: 'session' },
-      ],
-      activeSuggestionIndex: 0,
-      isPerfectMatch: false,
-      availableCategories: ['all', 'file', 'session'],
-      switchCategory,
-    });
-    props.buffer.setText('@');
+    props.vimHandleInput = vi.fn().mockReturnValue(true);
 
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
     await wait();
 
     stdin.write('\x1b[C'); // plain right arrow
     await wait();
+
+    expect(switchCategory).toHaveBeenCalledWith(1);
+
     stdin.write('\x1b[D'); // plain left arrow
     await wait();
 
-    // Plain arrows must not be hijacked for tab switching, so they remain
-    // available to move the caret in the editable buffer.
+    expect(switchCategory).toHaveBeenCalledWith(-1);
+    expect(props.vimHandleInput).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('should NOT switch category on bare arrows while command search is active', async () => {
+    props.shellModeActive = false;
+    const switchCategory = vi.fn();
+    mockedUseCommandCompletion.mockReturnValue({
+      ...mockCommandCompletion,
+      completionMode: CompletionMode.AT,
+      showSuggestions: true,
+      suggestions: [
+        { label: 'file.ts', value: 'file.ts', category: 'file' },
+        { label: 'sess', value: 'sess', category: 'session' },
+      ],
+      activeSuggestionIndex: 0,
+      isPerfectMatch: false,
+      availableCategories: ['all', 'file', 'session'],
+      switchCategory,
+    });
+    props.buffer.setText('@ses');
+
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    await wait();
+
+    stdin.write('\x12');
+    await wait();
+    stdin.write('\x1b[C');
+    await wait();
+    stdin.write('\x1b[D');
+    await wait();
+
+    expect(switchCategory).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('should hide category tabs and keep bare arrows for attachments', async () => {
+    const isWindows = process.platform === 'win32';
+    vi.mocked(clipboardUtils.clipboardHasImage).mockResolvedValue(true);
+    vi.mocked(clipboardUtils.saveClipboardImage).mockResolvedValue(
+      path.join('test', 'project', '.qwen', 'tmp', 'clipboard.png'),
+    );
+    vi.mocked(clipboardUtils.cleanupOldClipboardImages).mockResolvedValue(
+      undefined,
+    );
+
+    const switchCategory = vi.fn();
+    mockedUseCommandCompletion.mockReturnValue({
+      ...mockCommandCompletion,
+      completionMode: CompletionMode.AT,
+      showSuggestions: true,
+      suggestions: [{ label: 'file.ts', value: 'file.ts', category: 'file' }],
+      activeSuggestionIndex: 0,
+      isPerfectMatch: false,
+      availableCategories: ['all', 'file', 'session'],
+      switchCategory,
+    });
+    props.buffer.setText('@');
+
+    const { stdin, lastFrame, unmount } = renderWithProviders(
+      <InputPrompt {...props} />,
+    );
+    await wait();
+
+    stdin.write(isWindows ? '\x1Bv' : '\x16');
+    await wait();
+    stdin.write('\x1b[A');
+    await wait();
+    stdin.write('\x1b[C');
+    await wait();
+    stdin.write('\x1b[D');
+    await wait();
+
+    expect(switchCategory).not.toHaveBeenCalled();
+    expect(stripAnsi(lastFrame() ?? '')).not.toContain('(←/→ to switch)');
+    unmount();
+  });
+
+  it('should NOT consume Ctrl+left/right for category switching (#8069)', async () => {
+    const switchCategory = vi.fn();
+    mockedUseCommandCompletion.mockReturnValue({
+      ...mockCommandCompletion,
+      completionMode: CompletionMode.AT,
+      showSuggestions: true,
+      suggestions: [
+        { label: 'file.ts', value: 'file.ts', category: 'file' },
+        { label: 'sess', value: 'sess', category: 'session' },
+      ],
+      activeSuggestionIndex: 0,
+      isPerfectMatch: false,
+      availableCategories: ['all', 'file', 'session'],
+      switchCategory,
+    });
+    props.buffer.setText('@');
+
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    await wait();
+
+    stdin.write('\x1b[1;5C'); // Ctrl+right arrow
+    await wait();
+    stdin.write('\x1b[1;5D'); // Ctrl+left arrow
+    await wait();
+
+    // Ctrl+arrows are no longer bound: terminals and macOS Mission Control
+    // intercept them, so they are left to fall through to the terminal.
     expect(switchCategory).not.toHaveBeenCalled();
     unmount();
   });

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -382,6 +382,12 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   );
   const showCompletionSuggestions =
     completion.showSuggestions && !isHistoryRestoredText;
+  const categoryTabsVisible =
+    !exportCompletion.suggestionDisplayProps &&
+    !commandSearchActive &&
+    !reverseSearchActive &&
+    !isAttachmentMode &&
+    (completion.availableCategories?.length ?? 0) > 2;
 
   // Ref so renderLineWithHighlighting (stable useCallback) can access fresh ghost text
   const midInputGhostTextRef = useRef<{
@@ -1081,6 +1087,21 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         return true;
       }
 
+      // The visible category tabs own the bare arrows, including in Vim mode.
+      // All other states fall through to their existing input owner.
+      if (showCompletionSuggestions && categoryTabsVisible) {
+        if (keyMatchers[Command.COMPLETION_TAB_RIGHT](key)) {
+          completion.switchCategory(1);
+          setExpandedSuggestionIndex(-1);
+          return true;
+        }
+        if (keyMatchers[Command.COMPLETION_TAB_LEFT](key)) {
+          completion.switchCategory(-1);
+          setExpandedSuggestionIndex(-1);
+          return true;
+        }
+      }
+
       if (vimHandleInput && vimHandleInput(key)) {
         return true;
       }
@@ -1442,23 +1463,6 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       }
 
       if (showCompletionSuggestions) {
-        // Category tab switching for the tabbed `@` completion UI. Only consume
-        // Ctrl+←/→ (per the COMPLETION_TAB_* bindings) and only when there are
-        // more than two tabs (at least 3 entries including 'all'). Plain ←/→ are
-        // never consumed here, so they always move the caret in the editable buffer.
-        if ((completion.availableCategories?.length ?? 0) > 2) {
-          if (keyMatchers[Command.COMPLETION_TAB_RIGHT](key)) {
-            completion.switchCategory(1);
-            setExpandedSuggestionIndex(-1);
-            return true;
-          }
-          if (keyMatchers[Command.COMPLETION_TAB_LEFT](key)) {
-            completion.switchCategory(-1);
-            setExpandedSuggestionIndex(-1);
-            return true;
-          }
-        }
-
         if (completion.suggestions.length > 1) {
           const isCompletionUpKey = keyMatchers[Command.COMPLETION_UP](key);
           const isCompletionDownKey = keyMatchers[Command.COMPLETION_DOWN](key);
@@ -1907,6 +1911,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       exportCompletion,
       isHistoryRestoredText,
       showCompletionSuggestions,
+      categoryTabsVisible,
       voiceInput,
       targetDir,
     ],
@@ -2308,11 +2313,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
                 : completion.activeCategory
             }
             availableCategories={
-              suggestionsFromExport ||
-              commandSearchActive ||
-              reverseSearchActive
-                ? undefined
-                : completion.availableCategories
+              categoryTabsVisible ? completion.availableCategories : undefined
             }
             onHoverIndex={
               suggestionsFromExport ? undefined : handleSuggestionHover

--- a/packages/cli/src/ui/components/SuggestionsDisplay.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.tsx
@@ -187,12 +187,10 @@ export function SuggestionsDisplay({
               </Box>
             );
           })}
-          {/* Mention Ctrl+Tab as an alternative since many terminals
-              intercept Ctrl+←/→ for word-jump (#8069). */}
+          {/* Bare ←/→: the original Ctrl+←/→ was unreachable because terminals
+              and macOS Mission Control intercept it (#8069). */}
           <Box marginLeft={2}>
-            <Text color={theme.text.secondary}>
-              {t('(Ctrl+Tab / Ctrl+Shift+Tab or Ctrl+←/→ to switch)')}
-            </Text>
+            <Text color={theme.text.secondary}>{t('(←/→ to switch)')}</Text>
           </Box>
         </Box>
       )}

--- a/packages/cli/src/ui/keyMatchers.test.ts
+++ b/packages/cli/src/ui/keyMatchers.test.ts
@@ -47,9 +47,9 @@ describe('keyMatchers', () => {
     [Command.COMPLETION_DOWN]: (key: Key) =>
       (key.name === 'down' && !key.shift) || (key.ctrl && key.name === 'n'),
     [Command.COMPLETION_TAB_LEFT]: (key: Key) =>
-      key.name === 'left' && !key.shift && key.ctrl && !key.meta,
+      key.name === 'left' && !key.shift && !key.ctrl && !key.meta,
     [Command.COMPLETION_TAB_RIGHT]: (key: Key) =>
-      key.name === 'right' && !key.shift && key.ctrl && !key.meta,
+      key.name === 'right' && !key.shift && !key.ctrl && !key.meta,
     [Command.ESCAPE]: (key: Key) => key.name === 'escape',
     [Command.SUBMIT]: (key: Key) =>
       key.name === 'return' && !key.ctrl && !key.meta && !key.paste,
@@ -243,22 +243,26 @@ describe('keyMatchers', () => {
     },
     {
       command: Command.COMPLETION_TAB_LEFT,
-      positive: [createKey('left', { ctrl: true })],
+      positive: [createKey('left')],
       negative: [
-        createKey('left'),
-        createKey('left', { shift: true, ctrl: true }),
-        createKey('left', { ctrl: true, meta: true }),
-        createKey('right', { ctrl: true }),
+        createKey('left', { ctrl: true }),
+        createKey('left', { shift: true }),
+        createKey('left', { meta: true }),
+        createKey('right'),
+        createKey('tab'),
+        createKey('tab', { ctrl: true, shift: true }),
       ],
     },
     {
       command: Command.COMPLETION_TAB_RIGHT,
-      positive: [createKey('right', { ctrl: true })],
+      positive: [createKey('right')],
       negative: [
-        createKey('right'),
-        createKey('right', { shift: true, ctrl: true }),
-        createKey('right', { ctrl: true, meta: true }),
-        createKey('left', { ctrl: true }),
+        createKey('right', { ctrl: true }),
+        createKey('right', { shift: true }),
+        createKey('right', { meta: true }),
+        createKey('left'),
+        createKey('tab'),
+        createKey('tab', { ctrl: true }),
       ],
     },
 
@@ -515,46 +519,6 @@ describe('keyMatchers', () => {
           createKey('tab', { ctrl: true }),
         ),
       ).toBe(true); // modifiers ignored
-    });
-  });
-
-  // The Ctrl+Tab / Ctrl+Shift+Tab alternatives intentionally diverge from the
-  // original hard-coded matchers (which only knew Ctrl+←/→), so they are
-  // asserted against the data-driven matchers here rather than in the
-  // comparison block above (#8069).
-  describe('Completion tab-switching alternative bindings (#8069)', () => {
-    it('should match Ctrl+Tab as COMPLETION_TAB_RIGHT', () => {
-      expect(
-        keyMatchers[Command.COMPLETION_TAB_RIGHT](
-          createKey('tab', { ctrl: true }),
-        ),
-      ).toBe(true);
-      // Bare Tab accepts the suggestion; Ctrl+Shift+Tab switches left.
-      expect(keyMatchers[Command.COMPLETION_TAB_RIGHT](createKey('tab'))).toBe(
-        false,
-      );
-      expect(
-        keyMatchers[Command.COMPLETION_TAB_RIGHT](
-          createKey('tab', { ctrl: true, shift: true }),
-        ),
-      ).toBe(false);
-    });
-
-    it('should match Ctrl+Shift+Tab as COMPLETION_TAB_LEFT', () => {
-      expect(
-        keyMatchers[Command.COMPLETION_TAB_LEFT](
-          createKey('tab', { ctrl: true, shift: true }),
-        ),
-      ).toBe(true);
-      // Bare Tab accepts the suggestion; Ctrl+Tab switches right.
-      expect(keyMatchers[Command.COMPLETION_TAB_LEFT](createKey('tab'))).toBe(
-        false,
-      );
-      expect(
-        keyMatchers[Command.COMPLETION_TAB_LEFT](
-          createKey('tab', { ctrl: true }),
-        ),
-      ).toBe(false);
     });
   });
 


### PR DESCRIPTION
## What this PR does

Makes bare Left and Right switch the visible category tabs in `@` completion, replacing the Ctrl+arrow and Ctrl+Tab bindings. The arrows are consumed only when the tab bar is actually shown. Vim mode follows the same visible-tab contract, while command search, reverse search, export suggestions, attachment selection, and completion menus with at most two categories retain their existing arrow behavior.

While the category tabs are visible, Ctrl+B and Ctrl+F remain available for character-wise caret movement. Esc dismisses the menu and restores normal bare-arrow caret movement. Alt/Option+arrow word movement and terminal-owned Ctrl+arrow behavior are unaffected.

The on-screen hint and keyboard shortcut reference are updated to match.

## Why it's needed

The previous Ctrl+arrow gesture was commonly intercepted for word movement or by macOS Mission Control, and Ctrl+Tab is also intercepted by many terminals. Bare arrows restore the interaction originally promised by the category-tab UI while limiting the ownership change to the state where users can see those tabs.

## Reviewer Test Plan

### How to verify

1. Open `@` completion with at least three available categories and confirm the hint reads `(←/→ to switch)`.
2. Press Left and Right and confirm the active category changes, including with Vim mode enabled.
3. Confirm Ctrl+Left, Ctrl+Right, Ctrl+Tab, and Ctrl+Shift+Tab do not switch categories; Ctrl+B and Ctrl+F continue to move the caret.
4. Enter command search or reverse search and confirm Left and Right do not change a hidden completion category.
5. Enter attachment selection and confirm Left and Right select attachments rather than changing completion categories.
6. Confirm the tabs are hidden and arrows retain their prior behavior for export suggestions and menus with at most two categories.

### Evidence (Before & After)

Before: the tab bar advertised Ctrl+arrow and Ctrl+Tab gestures that were commonly intercepted before reaching the application. After: it advertises `(←/→ to switch)`, and bare arrows switch only while the category tabs are visible. Automated interaction tests cover Vim precedence, hidden search tabs, attachment ownership, two-category behavior, removed modified-arrow bindings, and the visible hint. No screenshot or recording was captured.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ focused tests (266), build, typecheck, lint |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Node.js 22 in a local macOS worktree.

## Risk & Scope

- Main risk or tradeoff: while visible category tabs own bare Left and Right, those keys do not move the caret; Ctrl+B, Ctrl+F, or dismissing the menu remain available.
- Not validated / out of scope: manual Windows and Linux interaction testing and mouse-based category switching.
- Breaking changes / migration notes: Ctrl+arrow and Ctrl+Tab no longer switch categories.

## Linked Issues

Related to #8069 and #8330. Follow-up to #7302 and complementary to #8395.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让 `@` 补全在分类标签可见时使用裸 Left 和 Right 切换分类，替换 Ctrl+方向键与 Ctrl+Tab 绑定。只有标签栏真实显示时才会消费方向键。Vim 模式遵循同一可见标签合同；命令搜索、反向搜索、导出补全、附件选择，以及最多只有两个分类的补全菜单都保留原有方向键行为。

分类标签可见期间，Ctrl+B 和 Ctrl+F 仍可逐字符移动光标；按 Esc 关闭菜单后，裸方向键恢复常规光标移动。Alt/Option+方向键的按词移动以及终端自身处理的 Ctrl+方向键不受影响。

界面提示与键盘快捷键文档同步更新。

## 为什么需要

此前的 Ctrl+方向键通常会被终端用于按词移动，或被 macOS 调度中心拦截；Ctrl+Tab 也经常被终端占用。裸方向键恢复分类标签界面最初承诺的交互，并把按键所有权变化严格限制在用户能看到这些标签的状态。

## Reviewer 测试计划

### 如何验证

1. 打开至少包含三个可用分类的 `@` 补全，确认提示为 `(←/→ to switch)`。
2. 按 Left 和 Right，确认激活分类切换；Vim 模式下也应如此。
3. 确认 Ctrl+Left、Ctrl+Right、Ctrl+Tab 和 Ctrl+Shift+Tab 不会切换分类；Ctrl+B 和 Ctrl+F 仍可移动光标。
4. 进入命令搜索或反向搜索，确认 Left 和 Right 不会切换隐藏的补全分类。
5. 进入附件选择，确认 Left 和 Right 选择附件，而不是切换补全分类。
6. 确认导出补全和最多只有两个分类的菜单不显示标签，方向键保持原行为。

### 证据（Before & After）

Before：标签栏提示 Ctrl+方向键与 Ctrl+Tab，但这些按键通常在抵达应用前就被拦截。After：提示为 `(←/→ to switch)`，且裸方向键只在分类标签可见时切换分类。自动交互测试覆盖 Vim 优先级、搜索状态的隐藏标签、附件按键所有权、双分类行为、已移除的修饰键绑定和可见提示。本次没有录制截图或视频。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 定向测试（266）、构建、类型检查、lint |
| 🪟 Windows | ⚠️ 未在本地测试 |
|  🐧 Linux  | ⚠️ 未在本地测试 |

### 环境（可选）

Node.js 22，本地 macOS worktree。

## 风险与范围

- 主要风险或取舍：分类标签可见时，裸 Left 和 Right 归标签所有，不能移动光标；仍可使用 Ctrl+B、Ctrl+F，或先关闭菜单。
- 未验证或不在范围内：Windows 与 Linux 的手动交互验证，以及鼠标切换分类。
- 破坏性改动或迁移说明：Ctrl+方向键与 Ctrl+Tab 不再切换分类。

## 关联 Issue

关联 #8069 与 #8330；为 #7302 的后续修复，并与 #8395 互补。

</details>
