### PR TITLE
fix(release): normalize Live Host signing identity

### DIFF
--- a/.github/workflows/live-host-release.yml
+++ b/.github/workflows/live-host-release.yml
@@ -148,8 +148,9 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$keychain_password" "$keychain"
           identity="$(security find-identity -v -p codesigning "$keychain" | sed -n 's/.*"\(Developer ID Application:.*\)"/\1/p' | head -n 1)"
           if [ -z "$identity" ]; then echo '::error::Developer ID Application identity was not found.'; exit 1; fi
+          identity_name="${identity#Developer ID Application: }"
           {
-            echo "CSC_NAME=$identity"
+            echo "CSC_NAME=$identity_name"
             echo 'CSC_IDENTITY_AUTO_DISCOVERY=true'
           } >> "$GITHUB_ENV"
 

--- a/scripts/tests/release-workflow.test.js
+++ b/scripts/tests/release-workflow.test.js
@@ -115,6 +115,11 @@ describe('Live Host release workflow', () => {
     expect(liveHostReleaseWorkflow).toContain(
       'echo "APPLE_API_KEY_ID=$api_key_id"',
     );
+    expect(liveHostReleaseWorkflow).toContain(
+      'identity_name="${identity#Developer ID Application: }"',
+    );
+    expect(liveHostReleaseWorkflow).toContain('echo "CSC_NAME=$identity_name"');
+    expect(liveHostReleaseWorkflow).not.toContain('echo "CSC_NAME=$identity"');
   });
 });
 


### PR DESCRIPTION
## What this PR does

Normalizes the validated Developer ID certificate name before passing it to Electron Builder during a published Qwen Live Host release.

## Why it's needed

The first credential-compatible release run successfully imported the repository certificate and configured notarization, but Electron Builder rejected the signing qualifier because it included the reserved `Developer ID Application:` type prefix. Electron Builder expects only the certificate-name remainder and selects the certificate type itself.

## Reviewer Test Plan

### How to verify

Run the release-workflow unit test and validate the workflow with actionlint. Confirm that the workflow still discovers and validates a full Developer ID identity, strips only the exact type prefix, and exports the normalized certificate name rather than the full identity.

### Evidence (Before & After)

Before: run 30993064678 passed certificate import and notarization setup, then failed in Electron Builder with `Please remove prefix "Developer ID Application:"`. After: a local two-architecture Electron Builder 26.4.0 run used the normalized qualifier, selected the expected Developer ID identity, signed both apps, and produced both ZIP and DMG artifacts.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

macOS; Vitest release workflow 5/5, installer 7/7, release architecture 2/2, Prettier, actionlint, and the PR dry-run passed. Both built apps and both extracted ZIP apps passed strict deep signature verification; arm64/x64 executable architecture, the universal native Appshot module, both DMG checksums, and both manifest ZIP hashes were verified.

## Risk & Scope

- Main risk or tradeoff: The change only removes Electron Builder's reserved certificate-type prefix from an already validated identity.
- Not validated / out of scope: Apple's notarization service and GitHub release publication require the final workflow run from `main`; their configuration, fail-closed verification, artifact contract, stable feed, and installer consumption path were reviewed end to end before this PR was marked ready.
- Breaking changes / migration notes: None.

## Linked Issues

Follow-up to #7859 and #8574.

<details>
<summary>中文说明</summary>

## 本 PR 的改动

在正式发布 Qwen Live Host 时，将已验证的 Developer ID 证书名称规范化后再传给 Electron Builder。

## 为什么需要

首次兼容仓库现有凭据的发布已经成功导入证书并配置公证，但 Electron Builder 拒绝了包含保留类型前缀 `Developer ID Application:` 的签名 qualifier。Electron Builder 只接受证书名称剩余部分，并自行选择证书类型。

## Reviewer Test Plan

### 验证方式

运行发布工作流单测并使用 actionlint 校验工作流。确认工作流仍然发现并验证完整 Developer ID identity，只移除精确的类型前缀，并导出规范化后的证书名称而不是完整 identity。

### 前后证据

修改前：run 30993064678 已通过证书导入和公证配置，随后 Electron Builder 报错 `Please remove prefix "Developer ID Application:"`。修改后：本机 Electron Builder 26.4.0 双架构构建使用规范化 qualifier，选中了预期 Developer ID identity，签署了两个 App，并生成了两个 ZIP 和两个 DMG。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境

macOS；发布工作流 Vitest 5/5、安装器 7/7、发布架构 2/2、Prettier、actionlint 和 PR dry-run 通过。两个构建目录 App 和两个 ZIP 解压后的 App 均通过严格深层签名校验；同时核验了 arm64/x64 主程序架构、universal 原生 Appshot、两个 DMG 校验和以及 manifest 中两个 ZIP 的哈希。

## 风险与范围

- 主要风险或权衡：本改动只从已验证 identity 中移除 Electron Builder 保留的证书类型前缀。
- 未验证或不在范围内：Apple 公证服务和 GitHub release 发布仍需要从 `main` 完成最终工作流；在将 PR 标记为 ready 前，已端到端审查其配置、fail-closed 校验、产物契约、stable feed 和安装器消费链路。
- 破坏性变更或迁移说明：无。

## 关联事项

#7859 和 #8574 的后续修复。

</details>
