### PR TITLE
fix(desktop): allow trusted response copy

### DIFF
--- a/packages/desktop/apps/electron/src/main/__tests__/default-session-permissions.test.ts
+++ b/packages/desktop/apps/electron/src/main/__tests__/default-session-permissions.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'bun:test';
+import { canUseDefaultSessionClipboard } from '../default-session-permissions';
+
+const trustedRequest = {
+  permission: 'clipboard-sanitized-write',
+  isMainFrame: true,
+  isWorkspaceWindow: true,
+  requestingUrl: 'file:///app/index.html',
+  devServerUrl: undefined,
+};
+
+describe('default session permissions', () => {
+  it('allows clipboard writes from the packaged app renderer', () => {
+    expect(canUseDefaultSessionClipboard(trustedRequest)).toBe(true);
+  });
+
+  it('allows clipboard writes from the configured Vite dev origin', () => {
+    expect(
+      canUseDefaultSessionClipboard({
+        ...trustedRequest,
+        requestingUrl: 'http://localhost:5173/chat',
+        devServerUrl: 'http://localhost:5173',
+      }),
+    ).toBe(true);
+  });
+
+  it.each([
+    ['clipboard reads', { permission: 'clipboard-read' }],
+    ['unrelated permissions', { permission: 'geolocation' }],
+    ['subframes', { isMainFrame: false }],
+    ['unregistered windows', { isWorkspaceWindow: false }],
+    ['external pages', { requestingUrl: 'https://example.com' }],
+    [
+      'a different dev port',
+      {
+        requestingUrl: 'http://localhost:5174/chat',
+        devServerUrl: 'http://localhost:5173',
+      },
+    ],
+    ['requests without a URL', { requestingUrl: undefined }],
+  ])('rejects %s', (_label, overrides) => {
+    expect(
+      canUseDefaultSessionClipboard({
+        ...trustedRequest,
+        ...overrides,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/desktop/apps/electron/src/main/default-session-permissions.ts
+++ b/packages/desktop/apps/electron/src/main/default-session-permissions.ts
@@ -1,0 +1,24 @@
+import { isTrustedRendererFrameUrl } from './voice/frame-trust';
+
+export interface DefaultSessionClipboardRequest {
+  permission: string;
+  isMainFrame: boolean;
+  isWorkspaceWindow: boolean;
+  requestingUrl: string | undefined;
+  devServerUrl: string | undefined;
+}
+
+export function canUseDefaultSessionClipboard({
+  permission,
+  isMainFrame,
+  isWorkspaceWindow,
+  requestingUrl,
+  devServerUrl,
+}: DefaultSessionClipboardRequest): boolean {
+  return (
+    permission === 'clipboard-sanitized-write' &&
+    isMainFrame &&
+    isWorkspaceWindow &&
+    isTrustedRendererFrameUrl(requestingUrl, devServerUrl)
+  );
+}

--- a/packages/desktop/apps/electron/src/main/index.ts
+++ b/packages/desktop/apps/electron/src/main/index.ts
@@ -116,6 +116,7 @@ import { initNotificationService, initBadgeIcon, initInstanceBadge, updateBadgeC
 import { checkForUpdatesOnLaunch, setAutoUpdateEventSink, isUpdating } from './auto-update'
 import type { EventSink } from '@craft-agent/server-core/transport'
 import { validateGitBashPath, checkVCRedistInstalled } from '@craft-agent/server-core/services'
+import { canUseDefaultSessionClipboard } from './default-session-permissions'
 
 // Initialize electron-log for renderer process support
 log.initialize()
@@ -457,8 +458,25 @@ app.whenReady().then(async () => {
     isAudioOnlyMediaRequest(permission, details) &&
     windowManager?.getWorkspaceForWindow(wc.id) != null,
   )
+  const canWriteClipboard = (
+    wc: { id: number } | null | undefined,
+    permission: string,
+    details: { isMainFrame?: boolean; requestingUrl?: string } | undefined,
+  ) => canUseDefaultSessionClipboard({
+    permission,
+    isMainFrame: details?.isMainFrame === true,
+    isWorkspaceWindow: Boolean(
+      wc && windowManager?.getWorkspaceForWindow(wc.id) != null,
+    ),
+    requestingUrl: details?.requestingUrl,
+    devServerUrl: process.env.VITE_DEV_SERVER_URL,
+  })
   session.defaultSession.setPermissionRequestHandler(
     (wc, permission, callback, details) => {
+      if (canWriteClipboard(wc, permission, details)) {
+        callback(true)
+        return
+      }
       if (!VOICE_PERMISSIONS.has(permission)) {
         mainLog.debug(`defaultSession: denied non-voice permission '${permission}'`)
         callback(false)
@@ -472,6 +490,9 @@ app.whenReady().then(async () => {
     },
   )
   session.defaultSession.setPermissionCheckHandler((wc, permission, _origin, details) => {
+    if (canWriteClipboard(wc, permission, details)) {
+      return true
+    }
     if (!VOICE_PERMISSIONS.has(permission)) {
       mainLog.debug(`defaultSession: denied non-voice permission check '${permission}'`)
       return false

--- a/packages/desktop/packages/ui/src/components/chat/TurnCard.tsx
+++ b/packages/desktop/packages/ui/src/components/chat/TurnCard.tsx
@@ -39,6 +39,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from '../tooltip'
 import { parseDiffFromFile, type FileContents } from '@pierre/diffs'
 import { getDiffStats, getUnifiedDiffStats } from '../code-viewer'
 import { TurnCardActionsMenu } from './TurnCardActionsMenu'
+import { copyResponseText } from './copy-response'
 import { computeLastChildSet, groupActivitiesByParent, isActivityGroup, formatDuration, formatTokens, deriveTurnPhase, shouldShowThinkingIndicator, type ActivityGroup, type AssistantTurn } from './turn-utils'
 import {
   buildTurnTimelineItems,
@@ -1815,7 +1816,7 @@ export function ResponseCard({
   const [displayedText, setDisplayedText] = useState(text)
   const lastUpdateRef = useRef(Date.now())
   // Copy to clipboard state
-  const [copied, setCopied] = useState(false)
+  const [copyStatus, setCopyStatus] = useState<'idle' | 'copied' | 'failed'>('idle')
   // Fullscreen state
   const [isFullscreen, setIsFullscreen] = useState(false)
   // Dark mode detection - scroll fade only shown in dark mode
@@ -1910,12 +1911,14 @@ export function ResponseCard({
   })
 
   const handleCopy = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(text)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    } catch (err) {
-      console.error('Failed to copy:', err)
+    const result = await copyResponseText(
+      text,
+      (value) => navigator.clipboard.writeText(value),
+    )
+    setCopyStatus(result.status)
+    setTimeout(() => setCopyStatus('idle'), 2000)
+    if (result.status === 'failed') {
+      console.error('Failed to copy response:', result.error)
     }
   }, [text])
 
@@ -2650,14 +2653,19 @@ export function ResponseCard({
                     onClick={handleCopy}
                     className={cn(
                       "turn-action-btn flex items-center gap-1.5 transition-colors select-none",
-                      copied ? "text-success" : "text-muted-foreground hover:text-foreground",
+                      copyStatus === 'copied' ? "text-success" : copyStatus === 'failed' ? "text-destructive" : "text-muted-foreground hover:text-foreground",
                       "focus:outline-none focus-visible:underline",
                     )}
                   >
-                    {copied ? (
+                    {copyStatus === 'copied' ? (
                       <>
                         <Check className={SIZE_CONFIG.iconSize} />
                         <span>{t('common.copied')}</span>
+                      </>
+                    ) : copyStatus === 'failed' ? (
+                      <>
+                        <XCircle className={SIZE_CONFIG.iconSize} />
+                        <span>{t('toast.copyFailed')}</span>
                       </>
                     ) : (
                       <>
@@ -2712,13 +2720,15 @@ export function ResponseCard({
           {!compactMode && !isPlan && showResponseActions && (
             <div className="flex h-5 items-center justify-start gap-1.5 pl-[22px] pr-0.5 text-[11px] font-medium text-muted-foreground/70 opacity-0 pointer-events-none transition-opacity duration-150 select-none group-hover/response:pointer-events-auto group-hover/response:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100">
               <ResponseActionButton
-                label={copied ? t('common.copied') : t('common.copy')}
+                label={copyStatus === 'copied' ? t('common.copied') : copyStatus === 'failed' ? t('toast.copyFailed') : t('common.copy')}
                 onClick={() => {
                   void handleCopy()
                 }}
               >
-                {copied ? (
+                {copyStatus === 'copied' ? (
                   <Check className="size-3.5 text-success" />
+                ) : copyStatus === 'failed' ? (
+                  <XCircle className="size-3.5 text-destructive" />
                 ) : (
                   <Copy className="size-3.5" />
                 )}

--- a/packages/desktop/packages/ui/src/components/chat/__tests__/copy-response.test.ts
+++ b/packages/desktop/packages/ui/src/components/chat/__tests__/copy-response.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { copyResponseText } from '../copy-response';
+
+describe('copyResponseText', () => {
+  it('writes the complete response and reports success', async () => {
+    const writeText = mock(async () => {});
+
+    await expect(
+      copyResponseText('complete response', writeText),
+    ).resolves.toEqual({ status: 'copied' });
+    expect(writeText).toHaveBeenCalledWith('complete response');
+  });
+
+  it('reports clipboard failures', async () => {
+    const writeText = mock(async () => {
+      throw new Error('permission denied');
+    });
+
+    await expect(
+      copyResponseText('response', writeText),
+    ).resolves.toMatchObject({
+      status: 'failed',
+      error: expect.any(Error),
+    });
+  });
+});

--- a/packages/desktop/packages/ui/src/components/chat/copy-response.ts
+++ b/packages/desktop/packages/ui/src/components/chat/copy-response.ts
@@ -1,0 +1,11 @@
+export async function copyResponseText(
+  text: string,
+  writeText: (value: string) => Promise<void>,
+): Promise<{ status: 'copied' } | { status: 'failed'; error: unknown }> {
+  try {
+    await writeText(text);
+    return { status: 'copied' };
+  } catch (error) {
+    return { status: 'failed', error };
+  }
+}


### PR DESCRIPTION
## What this PR does

Allows the Desktop app renderer to request `clipboard-sanitized-write` from the default Electron session while keeping clipboard reads and unrelated permissions denied. The grant is limited to a registered workspace window, its top-level frame, and the trusted packaged or configured Vite renderer origin. Failed response-copy attempts now show a localized failure state on the copy action instead of failing only in the console.

## Why it is needed

The response copy button calls `navigator.clipboard.writeText()`, but the default-session handlers currently deny every non-voice permission. Chromium therefore rejects the clipboard write before the response reaches the system clipboard.

## Reviewer Test Plan

### How to verify

1. On Qwen Code Desktop for Windows, open a conversation containing an assistant response.
2. Click the copy action below the response and paste into a text editor. Confirm the complete response is pasted and the action briefly shows the copied state.
3. Deny or stub the Clipboard API and confirm the action briefly shows the localized copy-failed state.
4. Run the focused policy and copy tests:
   - `cd packages/desktop/apps/electron && bun test src/main/__tests__/default-session-permissions.test.ts`
   - `cd packages/desktop/packages/ui && bun test src/components/chat/__tests__/copy-response.test.ts`

The policy tests confirm that clipboard read, subframes, unregistered windows, external origins, mismatched dev origins, and unrelated permissions remain denied.

### Evidence (Before & After)

Before: clicking the response copy action leaves the Windows clipboard unchanged because `clipboard-sanitized-write` is denied; failures are console-only.

After: the trusted top-level Desktop renderer can write the complete response, and a rejected write produces a visible localized failure state. Runtime Windows verification is still requested because this environment only provided Linux desktop access.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ unit/type/build tested |

### Environment (optional)

Ubuntu 26.04. Verified 9 permission-policy tests and 2 copy-behavior tests, Electron and shared UI TypeScript checks, Electron main-process bundling, renderer production build, and `git diff --check`. A live Linux Clipboard API probe was inconclusive because the automated Electron document could not acquire desktop focus.

## Risk & Scope

- Main risk or tradeoff: Clipboard write is newly available to the trusted main renderer; the policy deliberately requires the registered top-level app frame and trusted renderer URL.
- Not validated / out of scope: Live Windows Electron verification; clipboard read; the ACP `/copy` command.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #8538

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

允许 Desktop 应用 renderer 向 Electron 默认会话请求 `clipboard-sanitized-write`，同时继续拒绝剪贴板读取和其他无关权限。该授权仅适用于已登记工作区窗口的顶层 frame，以及可信的打包页面或已配置的 Vite renderer 来源。回复复制失败时，复制操作现在会显示本地化失败状态，而不再只在控制台中静默失败。

## 为什么需要

回复复制按钮调用 `navigator.clipboard.writeText()`，但默认会话权限处理器目前拒绝所有非语音权限，因此 Chromium 会在内容写入系统剪贴板前拒绝请求。

## 审阅者测试计划

### 如何验证

1. 在 Windows 的 Qwen Code Desktop 中打开一段包含助手回复的对话。
2. 点击回复下方的复制操作并粘贴到文本编辑器，确认完整回复可以粘贴，且操作短暂显示已复制状态。
3. 拒绝或 stub Clipboard API，确认操作短暂显示本地化的复制失败状态。
4. 运行针对性的权限策略测试和复制测试：
   - `cd packages/desktop/apps/electron && bun test src/main/__tests__/default-session-permissions.test.ts`
   - `cd packages/desktop/packages/ui && bun test src/components/chat/__tests__/copy-response.test.ts`

权限策略测试确认剪贴板读取、子 frame、未登记窗口、外部来源、不匹配的开发来源和其他权限仍被拒绝。

### Before 与 After 证据

Before：由于 `clipboard-sanitized-write` 被拒绝，点击回复复制操作后 Windows 剪贴板保持不变；失败只写入控制台。

After：可信的顶层 Desktop renderer 可以写入完整回复；写入被拒绝时会显示用户可见的本地化失败状态。由于当前环境仅提供 Linux 桌面，仍请审阅者补充 Windows 运行验证。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ 未测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ✅ 单元、类型和构建验证 |

### 环境

Ubuntu 26.04。已验证 9 项权限策略测试、2 项复制行为测试、Electron 与共享 UI TypeScript 检查、Electron 主进程打包、renderer 生产构建和 `git diff --check`。Linux 上的实时 Clipboard API 探测因自动化 Electron document 无法取得桌面焦点而无法得出结论。

## 风险与范围

- 主要风险或取舍：可信主 renderer 新增剪贴板写入能力；策略明确要求已登记的顶层应用 frame 和可信 renderer URL。
- 未验证或范围外：真实 Windows Electron 验证、剪贴板读取、ACP `/copy` 命令。
- 破坏性变更或迁移说明：无。

## 关联 Issue

Fixes #8538

</details>