### PR TITLE
ci: add hk ECS runners to update-ecs-runner matrix

### DIFF
--- a/.github/workflows/update-ecs-runner-qwen.yml
+++ b/.github/workflows/update-ecs-runner-qwen.yml
@@ -23,7 +23,7 @@ jobs:
     if: "${{ github.repository == 'QwenLM/qwen-code' }}"
     strategy:
       matrix:
-        runner: ['ecs-update-sg', 'ecs-update-64c']
+        runner: ['ecs-update-sg', 'ecs-update-64c', 'ecs-update-hk-1', 'ecs-update-hk-2']
       fail-fast: false
     runs-on: ['self-hosted', 'linux', 'x64', '${{ matrix.runner }}']
     concurrency:


### PR DESCRIPTION
## What this PR does

Adds the two already-existing hk runner labels (`ecs-update-hk-1`, `ecs-update-hk-2`) to the `update-ecs-runner-qwen` workflow's update matrix, so the two hk machines receive the automatic post-release qwen update alongside the already-covered 64c and sg machines.

## Why it's needed

The matrix only listed `ecs-update-sg` and `ecs-update-64c`. The two hk machines already carry distinct labels (`ecs-update-hk-1` / `ecs-update-hk-2`) but were absent from the matrix, so the post-release `repository_dispatch` (npm-published) update never scheduled a job on them and they stayed on old qwen versions. 64c and sg are each a single machine with several co-located runner processes, so their shared labels are correct as-is; only the hk entries were missing.

## Reviewer Test Plan

### How to verify

After merge, dispatch `update-ecs-runner-qwen.yml` with `version=0.21.6`. The run should fan out to 4 jobs (sg, 64c, hk-1, hk-2) instead of 2, and each job's "Verify version" step asserts `qwen --version` equals the resolved 0.21.6 — all 4 succeeding confirms every machine updated.

### Evidence (Before & After)

N/A (CI workflow change). Before: release-triggered run 31022904130 produced 2 jobs (sg, 64c). After: 4 jobs expected (sg, 64c, hk-1, hk-2).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | N/A |
|  🐧 Linux  | ✅ |

### Environment (optional)

N/A — workflow-only change; validated by the update run on the self-hosted Linux runners post-merge.

## Risk & Scope

- Main risk or tradeoff: none functional; only widens the update matrix. If a listed label had no online runner that job would queue/fail — both hk labels were confirmed present on online runners before adding.
- Not validated / out of scope: the actual hk update run (executed via post-merge dispatch); relabeling or adding further machines.
- Breaking changes / migration notes: none.

## Linked Issues

N/A — follow-up to the ECS runner auto-update gap discussed during the v0.21.6 release.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把两个已存在的 hk runner 标签（`ecs-update-hk-1`、`ecs-update-hk-2`）加入 `update-ecs-runner-qwen` workflow 的更新矩阵，使两台 hk 机器能和已覆盖的 64c、sg 机器一样，在发版后自动更新 qwen。

## 为什么需要

矩阵原先只列了 `ecs-update-sg` 和 `ecs-update-64c`。两台 hk 机器虽然已带独立标签，但不在矩阵里，因此发版后的 `repository_dispatch`（npm-published）更新从不会调度到它们，导致停留在旧版本。64c 和 sg 各是一台机器、多个 runner 进程同机，共享标签本身没问题；缺的只是 hk 两项。

## 审查者测试计划

### 如何验证

merge 后以 `version=0.21.6` 触发 `update-ecs-runner-qwen.yml`，run 应从 2 个 job 变为 4 个（sg、64c、hk-1、hk-2），且每个 job 的 "Verify version" 步骤断言 `qwen --version` 等于 0.21.6——4 个全 success 即代表 4 台都更新成功。

### 证据（前后对比）

N/A（CI workflow 改动）。之前：release 触发的 run 31022904130 只有 2 个 job；之后：预期 4 个。

### 测试平台

macOS N/A；Windows N/A；Linux ✅（self-hosted runner 上验证）。

## 风险与范围

- 主要风险：无功能性风险，仅扩大更新矩阵；若某标签无在线 runner 该 job 会排队/失败——添加前已确认两个 hk 标签均在线。
- 未验证/超出范围：hk 的实际更新 run（merge 后 dispatch 执行）、后续再加机器或改标签。
- 破坏性变更/迁移说明：无。

## 关联 Issue

N/A——v0.21.6 发布期间发现的 ECS runner 自动更新缺口的后续。

</details>
