### PR TITLE
fix(web-shell): Refresh sidebar branch chip immediately after checkout

### DIFF
--- a/packages/web-shell/client/components/sidebar/WorkspaceSection.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WorkspaceSection.test.tsx
@@ -11,9 +11,39 @@ import type {
 } from '@qwen-code/sdk/daemon';
 import gitStyles from '../ChatEditor.module.css';
 
-const { workspaceGit } = vi.hoisted(() => ({
-  workspaceGit: vi.fn(),
-}));
+const {
+  workspaceGit,
+  workspaceGitBranches,
+  workspaceGitCheckout,
+  pickerWorkspaceClient,
+} = vi.hoisted(() => {
+  const workspaceGit = vi.fn();
+  const workspaceGitBranches = vi.fn();
+  const workspaceGitCheckout = vi.fn();
+  // A stable client so the popover's memoized workspace handle (and thus its
+  // fetch effect) stays referentially stable across renders.
+  const pickerWorkspaceClient = {
+    workspaceByCwd: () => ({
+      workspaceGit,
+      workspaceGitBranches,
+      workspaceGitCheckout,
+      workspaceGitCreateBranch: vi.fn().mockResolvedValue(undefined),
+      workspaceGitPush: vi
+        .fn()
+        .mockResolvedValue({ success: true, output: '' }),
+      workspaceGitPull: vi
+        .fn()
+        .mockResolvedValue({ success: true, output: '' }),
+      listWorkspaceSessions: vi.fn().mockResolvedValue([]),
+    }),
+  };
+  return {
+    workspaceGit,
+    workspaceGitBranches,
+    workspaceGitCheckout,
+    pickerWorkspaceClient,
+  };
+});
 
 // Mock useWorkspace so BranchPickerPopover can render without a real provider.
 vi.mock('@qwen-code/webui/daemon-react-sdk', async (importOriginal) => {
@@ -22,50 +52,7 @@ vi.mock('@qwen-code/webui/daemon-react-sdk', async (importOriginal) => {
   return {
     ...actual,
     useWorkspace: () => ({
-      client: {
-        workspaceGitBranches: vi.fn().mockResolvedValue({
-          v: 1,
-          workspaceCwd: '/tmp/project',
-          available: true,
-          local: [],
-          remote: [],
-          tags: [],
-          recent: [],
-          head: 'main',
-          detached: false,
-        }),
-        workspaceGitCheckout: vi.fn().mockResolvedValue(undefined),
-        workspaceGitCreateBranch: vi.fn().mockResolvedValue(undefined),
-        workspaceGitPush: vi
-          .fn()
-          .mockResolvedValue({ success: true, output: '' }),
-        workspaceGitPull: vi
-          .fn()
-          .mockResolvedValue({ success: true, output: '' }),
-        workspaceByCwd: () => ({
-          workspaceGit,
-          workspaceGitBranches: vi.fn().mockResolvedValue({
-            v: 1,
-            workspaceCwd: '/tmp/project',
-            available: true,
-            local: [],
-            remote: [],
-            tags: [],
-            recent: [],
-            head: 'main',
-            detached: false,
-          }),
-          workspaceGitCheckout: vi.fn().mockResolvedValue(undefined),
-          workspaceGitCreateBranch: vi.fn().mockResolvedValue(undefined),
-          workspaceGitPush: vi
-            .fn()
-            .mockResolvedValue({ success: true, output: '' }),
-          workspaceGitPull: vi
-            .fn()
-            .mockResolvedValue({ success: true, output: '' }),
-          listWorkspaceSessions: vi.fn().mockResolvedValue([]),
-        }),
-      },
+      client: pickerWorkspaceClient,
       capabilities: { features: [] },
     }),
   };
@@ -78,18 +65,8 @@ function makeClient(): DaemonClient {
   return {
     workspaceByCwd: vi.fn(() => ({
       workspaceGit,
-      workspaceGitBranches: vi.fn().mockResolvedValue({
-        v: 1,
-        workspaceCwd: '/tmp/project',
-        available: true,
-        local: [],
-        remote: [],
-        tags: [],
-        recent: [],
-        head: 'main',
-        detached: false,
-      }),
-      workspaceGitCheckout: vi.fn().mockResolvedValue(undefined),
+      workspaceGitBranches,
+      workspaceGitCheckout,
       workspaceGitCreateBranch: vi.fn().mockResolvedValue(undefined),
       workspaceGitPush: vi
         .fn()
@@ -189,6 +166,20 @@ beforeEach(() => {
   document.body.appendChild(container);
   root = createRoot(container);
   workspaceGit.mockReset();
+  workspaceGitBranches.mockReset();
+  workspaceGitBranches.mockResolvedValue({
+    v: 1,
+    workspaceCwd: '/tmp/project',
+    available: true,
+    local: [],
+    remote: [],
+    tags: [],
+    recent: [],
+    head: 'main',
+    detached: false,
+  });
+  workspaceGitCheckout.mockReset();
+  workspaceGitCheckout.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -274,6 +265,56 @@ describe('WorkspaceSection git chip', () => {
     // directly. The diff dialog is accessible via "View Changes" inside the
     // popover.
     expect(button?.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('re-fetches git status right after a picker checkout instead of waiting for the poll', async () => {
+    // The sidebar chip only polls every 60s, so without the onBranchChanged
+    // wiring it would keep showing the old branch for up to a minute after a
+    // checkout made through the branch picker.
+    workspaceGit.mockResolvedValue({
+      v: 2,
+      workspaceCwd: '/tmp/project',
+      branch: 'feat/demo',
+    });
+    workspaceGitBranches.mockResolvedValue({
+      v: 1,
+      workspaceCwd: '/tmp/project',
+      available: true,
+      local: [
+        { name: 'feat/demo', isHead: true },
+        { name: 'main', isHead: false },
+      ],
+      remote: [],
+      tags: [],
+      recent: [],
+      head: 'feat/demo',
+      detached: false,
+    });
+    const client = makeClient();
+
+    renderSection({ client, onOpenGitDiff: vi.fn() });
+    await flush();
+    expect(workspaceGit).toHaveBeenCalledTimes(1);
+
+    const chipButton = gitChip()?.closest('button');
+    expect(chipButton).not.toBeNull();
+    act(() => {
+      chipButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flush();
+
+    // The picker content is portaled outside the section container.
+    const mainItem = Array.from(document.body.querySelectorAll('button')).find(
+      (button) => button.textContent === 'main',
+    );
+    expect(mainItem).toBeTruthy();
+    act(() => {
+      mainItem?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flush();
+
+    expect(workspaceGitCheckout).toHaveBeenCalledWith('main', undefined);
+    expect(workspaceGit).toHaveBeenCalledTimes(2);
   });
 
   it('hides the chip for an untrusted workspace and never queries git', async () => {

--- a/packages/web-shell/client/components/sidebar/WorkspaceSection.tsx
+++ b/packages/web-shell/client/components/sidebar/WorkspaceSection.tsx
@@ -376,6 +376,7 @@ export function WorkspaceSection({
             open={branchPickerOpen}
             onOpenChange={setBranchPickerOpen}
             workspaceCwd={workspace.cwd}
+            onBranchChanged={() => void loadGitStatus()}
             onOpenDiff={() => onOpenGitDiff(workspace.cwd)}
             onOpenCommit={
               onOpenCommit ? () => onOpenCommit(workspace.cwd) : undefined


### PR DESCRIPTION
## What this PR does

The Web Shell sidebar shows a git branch chip on each project workspace row, and clicking it opens a branch picker where you can switch branches, create branches, pull/push/commit, and view changes. Until now, after a checkout performed from that picker, the sidebar chip kept showing the old branch name for up to a minute, because the sidebar only refreshes its git status on a slow poll and on window focus. This change makes the sidebar re-fetch git status immediately after a branch switch made through the picker, so the chip reflects the new branch right away — matching the composer's branch chip, which already updates in realtime through session events.

## Why it's needed

A common workflow is to finish a task on a freshly created branch and then switch back to the base branch from the sidebar. With the stale chip, that switch appeared to silently fail: the picker closed and the sidebar kept showing the old branch until the next poll tick (up to 60 seconds). Users had no visible confirmation that the checkout happened, which made the existing branch-switching feature look broken or missing.

## Reviewer Test Plan

### How to verify

1. Open Web Shell against a git workspace that has at least two local branches, with the current branch being something other than the base branch.
2. In the sidebar, click the branch chip on the workspace row to open the branch picker.
3. Click another local branch (e.g. main).
4. Expected: the picker closes and the sidebar chip immediately shows the new branch name. Before this change, the chip kept showing the previous branch for up to 60 seconds.

Unit-test coverage: the sidebar test file gains a regression test that opens the picker from the chip, clicks a branch, and asserts the checkout fires plus an immediate status refetch. Without the fix it fails with `expected "spy" to be called 2 times, but got 1 times`; with the fix it passes. Run with `cd packages/web-shell && npx vitest run client/components/sidebar/WorkspaceSection.test.tsx`.

### Evidence (Before & After)

N/A — this is a refresh-timing change covered by the regression test above; no visual layout change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only (`npx vitest run` in `packages/web-shell`). ESLint and Prettier clean on the changed files.

## Risk & Scope

- Main risk or tradeoff: one extra git status request right after a sidebar-initiated branch switch; the daemon already dedupes concurrent status computations, and the same refetch path runs on every window focus.
- Not validated / out of scope: the composer chip and environment panel share the same picker but already refresh through realtime session events, so they are intentionally untouched.
- Breaking changes / migration notes: none

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

Web Shell 左侧栏的每个项目 workspace 行上都有一个 git 分支胶囊，点击它会打开分支选择器，可以切换分支、新建分支、pull/push/commit、查看变更。此前，从这个选择器执行 checkout 之后，侧边栏胶囊上的旧分支名最长会停留一分钟，因为侧边栏的 git 状态只靠慢速轮询和窗口 focus 刷新。本 PR 让侧边栏在通过选择器切换分支后立即重新获取 git 状态，胶囊马上显示新分支——与 composer 的分支胶囊行为一致（后者已通过会话事件实时更新）。

## 为什么需要

一个常见工作流是：在新建的分支上完成任务后，从侧边栏切换回基础分支。由于胶囊状态滞后，切换看起来像是静默失败了：选择器关闭后，侧边栏最长 60 秒仍显示旧分支。用户看不到任何切换成功的反馈，导致已有的分支切换功能看起来像是坏了或不存在。

## 评审测试计划

### 如何验证

1. 用一个至少有两个本地分支的 git workspace 打开 Web Shell，当前分支不是基础分支。
2. 在侧边栏点击 workspace 行上的分支胶囊，打开分支选择器。
3. 点击另一个本地分支（例如 main）。
4. 预期：选择器关闭，侧边栏胶囊立即显示新分支名。改动前，胶囊最长 60 秒仍显示旧分支。

单元测试：侧边栏测试文件新增了一个回归测试——从胶囊打开选择器、点击分支、断言 checkout 被调用且状态立即重取。去掉修复后该测试以 `expected "spy" to be called 2 times, but got 1 times` 失败；修复后通过。运行方式：`cd packages/web-shell && npx vitest run client/components/sidebar/WorkspaceSection.test.tsx`。

### 证据（前后对比）

N/A——这是刷新时机的改动，由上述回归测试覆盖，无视觉布局变化。

### 测试环境

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

仅单元测试（在 `packages/web-shell` 下 `npx vitest run`）。改动文件的 ESLint 与 Prettier 均通过。

## 风险与范围

- 主要风险或权衡：侧边栏发起的分支切换后会多一次 git status 请求；daemon 端已对并发的状态计算做去重，且同样的重取路径在每次窗口 focus 时也会执行。
- 未验证 / 超出范围：composer 胶囊和环境面板使用同一个选择器，但它们已通过实时会话事件刷新，因此有意不做改动。
- 破坏性变更 / 迁移说明：无

## 关联 Issue

N/A

</details>
