### PR TITLE
test(core): deflake glob external-path test — dedicated empty dir, not /tmp

### DIFF
--- a/packages/core/src/tools/glob.test.ts
+++ b/packages/core/src/tools/glob.test.ts
@@ -293,13 +293,23 @@ describe('GlobTool', () => {
     });
 
     it('should allow path outside workspace (external path support)', async () => {
-      const params: GlobToolParams = { pattern: '*.txt', path: '/tmp' };
-      const invocation = globTool.build(params);
-      // External path is now allowed - it should not return a workspace error
-      const result = await invocation.execute(abortSignal);
-      expect(result.returnDisplay).not.toContain(
-        'Path is not within workspace',
-      );
+      // A dedicated EMPTY dir outside the workspace, never literal /tmp:
+      // the glob really walks the path, and a loaded CI runner's littered
+      // /tmp made this time out at 15s repeatedly. The claim under test is
+      // only "no workspace-boundary refusal", which an empty outside dir
+      // proves deterministically.
+      const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'glob-ext-'));
+      try {
+        const params: GlobToolParams = { pattern: '*.txt', path: outside };
+        const invocation = globTool.build(params);
+        // External path is now allowed - it should not return a workspace error
+        const result = await invocation.execute(abortSignal);
+        expect(result.returnDisplay).not.toContain(
+          'Path is not within workspace',
+        );
+      } finally {
+        await fs.rm(outside, { recursive: true, force: true });
+      }
     });
 
     it('should return a GLOB_EXECUTION_ERROR on glob failure', async () => {

--- a/packages/core/src/tools/glob.test.ts
+++ b/packages/core/src/tools/glob.test.ts
@@ -293,17 +293,17 @@ describe('GlobTool', () => {
     });
 
     it('should allow path outside workspace (external path support)', async () => {
-      // A dedicated EMPTY dir outside the workspace, never literal /tmp:
-      // the glob really walks the path, and a loaded CI runner's littered
-      // /tmp made this time out at 15s repeatedly. The claim under test is
-      // only "no workspace-boundary refusal", which an empty outside dir
-      // proves deterministically.
-      const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'glob-ext-'));
+      // Shared /tmp made this walk time out on loaded runners — keep this
+      // dir dedicated and empty.
+      const outside = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'glob-external-'),
+      );
       try {
         const params: GlobToolParams = { pattern: '*.txt', path: outside };
         const invocation = globTool.build(params);
         // External path is now allowed - it should not return a workspace error
         const result = await invocation.execute(abortSignal);
+        expect(result.error).toBeUndefined();
         expect(result.returnDisplay).not.toContain(
           'Path is not within workspace',
         );


### PR DESCRIPTION
## What this PR does

Makes `glob.test.ts`'s external-path test glob a dedicated empty `mkdtemp` directory instead of literal `/tmp`.

## Why it's needed

The test really walks the path it names. On loaded self-hosted runners a littered `/tmp` makes the walk exceed the 15s test timeout — observed three separate times on #8388's CI runs alone, each turning the required Test check red for a test whose claim is only "an external path is not refused as outside the workspace". An empty directory outside the workspace proves that claim deterministically and in milliseconds.

## Reviewer Test Plan

### How to verify

```bash
npx vitest run --root packages/core src/tools/glob.test.ts
```

60 passed locally. The changed test still exercises the real (unmocked-path) flow — only the target directory changed.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ➖ (os.tmpdir()-based, platform-neutral) |
|  🐧 Linux  |   ➖ (CI) |

## Risk & Scope

Test-only; no production code touched.

## Linked Issues

Recurring flake observed on #8388 (three CI runs).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 `glob.test.ts` 的外部路径测试改为 glob 一个专用的空 `mkdtemp` 目录，而不是字面 `/tmp`。

## 为什么需要

该测试真实遍历其命名的路径。在负载较高的 self-hosted runner 上，堆满杂物的 `/tmp` 使遍历超过 15 秒测试超时——仅在 #8388 的 CI 运行中就出现三次，每次都把 required Test check 染红，而该测试的主张只是"外部路径不被拒为工作区之外"。工作区之外的空目录以毫秒级确定性证明该主张。

## 风险与范围

仅测试改动；不触碰生产代码。

</details>
