### PR TITLE
fix(autofix): ship core dist in the review CLI bundle

### DIFF
--- a/.github/scripts/run-autofix-review-verification.sh
+++ b/.github/scripts/run-autofix-review-verification.sh
@@ -84,6 +84,21 @@ if [[ -n "$(git status --porcelain)" ]]; then
 fi
 VERIFICATION_HEAD="$(git rev-parse HEAD)"
 
+# The schema generator resolves '@qwen-code/qwen-code-core' to core's DIST
+# entry point, which the CLI bundle restored from the TRUSTED BASE. When the
+# branch itself changed core's sources, that base-built dist can disagree
+# with the branch's committed schema (changed runtime constants) or crash
+# the generator (changed exports) — the same false "settings schema is
+# stale" rejection class this gate exists to prevent. Rebuild core from
+# branch sources in that case: the gate already runs a full `npm run build`
+# on branch sources for every commit path, so this widens no trust surface,
+# and the build's git-ignored output cannot trip the dirty-tree asserts.
+if git diff --name-only "origin/main...${BRANCH}" \
+  | grep -Eq '^packages/core/(src/|index\.ts$)'; then
+  run_check 'core rebuild failed on the agent-committed fix' \
+    npm run build --workspace packages/core
+fi
+
 # Settings-schema freshness is a STRUCTURAL guard, checked BEFORE the
 # no-op/unchanged return: on a stale-schema PR the agent can wrongly
 # write no-action.md, and without this the no-op path would report the

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2664,17 +2664,24 @@ jobs:
           PATH="${qwen_bin}:${PATH}"
           qwen --version
 
-      # Only the repo-root dist/ is shipped: copy_bundle_assets.js already
-      # gathers every runtime asset (chunks, vendor, web-shell, locales)
-      # under it. packages/*/dist would triple the artifact size and is
-      # never read by the legs — the verify gate's full `npm run build`
-      # wipes and rebuilds each package's dist from branch sources
-      # (build_package.js rms it first, so no staleness leaks through).
+      # The repo-root dist/ plus packages/core/dist are shipped:
+      # copy_bundle_assets.js already gathers every runtime asset (chunks,
+      # vendor, web-shell, locales) under the root dist/, and the remaining
+      # packages/*/dist would triple the artifact size without ever being
+      # read by the legs — the verify gate's full `npm run build` wipes and
+      # rebuilds each package's dist from branch sources (build_package.js
+      # rms it first, so no staleness leaks through). packages/core/dist is
+      # the exception: the verify gate's settings-schema and i18n checks run
+      # BEFORE any build (on every path, including no-action), and their
+      # tsx-transpiled cli sources import '@qwen-code/qwen-code-core', which
+      # resolves through the workspace symlink to core's dist entry point.
+      # Without it the generator crashes with ERR_MODULE_NOT_FOUND and the
+      # gate misreports a deterministic "settings schema is stale" rejection.
       - name: 'Upload CLI bundle'
         id: 'meta'
         run: |-
           echo "base_sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
-          tar -czf "${RUNNER_TEMP}/qwen-cli-dist.tar.gz" dist
+          tar -czf "${RUNNER_TEMP}/qwen-cli-dist.tar.gz" dist packages/core/dist
 
       - name: 'Publish CLI bundle artifact'
         uses: 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' # v7.0.1
@@ -2853,7 +2860,7 @@ jobs:
       # npm ci only — the build itself ran ONCE in build-cli. The legs still
       # need node_modules: the agent builds/tests the PR branch, and the
       # verify gate rebuilds from branch sources (wiping the restored
-      # packages/*/dist via build_package.js, so no base staleness leaks
+      # packages/core/dist via build_package.js, so no base staleness leaks
       # into branch verification). The retry recipe (and the shim below) is
       # duplicated in issue-autofix and build-cli; the workflow contract
       # tests pin every copy in lockstep — edit them together.
@@ -2882,6 +2889,11 @@ jobs:
         run: |-
           tar -xzf "${RUNNER_TEMP}/cli-dist/qwen-cli-dist.tar.gz"
           test -f dist/cli.js
+          # The verify gate's pre-build settings-schema and i18n checks
+          # resolve '@qwen-code/qwen-code-core' through the workspace
+          # symlink to this entry point; a bundle without it would make
+          # every gate crash with ERR_MODULE_NOT_FOUND.
+          test -f packages/core/dist/index.js
 
       - name: 'Prepare Qwen Code CLI'
         run: |-

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2671,12 +2671,15 @@ jobs:
       # read by the legs — the verify gate's full `npm run build` wipes and
       # rebuilds each package's dist from branch sources (build_package.js
       # rms it first, so no staleness leaks through). packages/core/dist is
-      # the exception: the verify gate's settings-schema and i18n checks run
-      # BEFORE any build (on every path, including no-action), and their
-      # tsx-transpiled cli sources import '@qwen-code/qwen-code-core', which
-      # resolves through the workspace symlink to core's dist entry point.
-      # Without it the generator crashes with ERR_MODULE_NOT_FOUND and the
-      # gate misreports a deterministic "settings schema is stale" rejection.
+      # the exception: the settings-schema check runs BEFORE any build (on
+      # every path, including no-action), and its generator — tsx run from
+      # the repo root, whose tsconfig has NO `paths` — imports cli sources
+      # that resolve '@qwen-code/qwen-code-core' through the workspace
+      # symlink to core's dist entry point. Without it the generator crashes
+      # with ERR_MODULE_NOT_FOUND and the gate misreports a deterministic
+      # "settings schema is stale" rejection. The i18n check needs no dist:
+      # it runs with cwd packages/cli, whose tsconfig `paths` map the
+      # specifier to core's sources instead.
       - name: 'Upload CLI bundle'
         id: 'meta'
         run: |-
@@ -2889,10 +2892,12 @@ jobs:
         run: |-
           tar -xzf "${RUNNER_TEMP}/cli-dist/qwen-cli-dist.tar.gz"
           test -f dist/cli.js
-          # The verify gate's pre-build settings-schema and i18n checks
-          # resolve '@qwen-code/qwen-code-core' through the workspace
-          # symlink to this entry point; a bundle without it would make
-          # every gate crash with ERR_MODULE_NOT_FOUND.
+          # The verify gate's pre-build settings-schema check resolves
+          # '@qwen-code/qwen-code-core' through the workspace symlink to
+          # this entry point (the root tsconfig has no `paths`; the i18n
+          # check instead resolves core to sources via the packages/cli
+          # `paths` map); a bundle without it makes the schema generator
+          # crash with ERR_MODULE_NOT_FOUND.
           test -f packages/core/dist/index.js
 
       - name: 'Prepare Qwen Code CLI'

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -5383,12 +5383,16 @@ describe('qwen-autofix workflow', () => {
     // copy_bundle_assets.js already gathers every runtime asset under the
     // root dist/, and the remaining packages/*/dist would triple the size
     // and are rebuilt from branch sources by the verify gate. core's dist
-    // is the exception: the verify gate's settings-schema and i18n checks
-    // run BEFORE any build (on every path, including no-action) and their
-    // tsx-transpiled cli sources import '@qwen-code/qwen-code-core', which
-    // resolves through the workspace symlink to core's dist entry point.
-    expect(buildCliJob).toContain(
-      'tar -czf "${RUNNER_TEMP}/qwen-cli-dist.tar.gz" dist packages/core/dist',
+    // is the exception: the settings-schema check runs BEFORE any build
+    // (on every path, including no-action) and its generator — tsx run
+    // from the repo root, whose tsconfig has NO `paths` — imports cli
+    // sources that resolve '@qwen-code/qwen-code-core' through the
+    // workspace symlink to core's dist entry point (the i18n check
+    // instead resolves core to sources via the packages/cli `paths` map).
+    // The regex anchors the line end, so appending another path to the
+    // tarball fails here — a substring pin would let additive drift pass.
+    expect(buildCliJob).toMatch(
+      /tar -czf "\$\{RUNNER_TEMP\}\/qwen-cli-dist\.tar\.gz" dist packages\/core\/dist\n/,
     );
     expect(buildCliJob).toContain("name: 'qwen-autofix-cli-dist'");
     expect(buildCliJob).toContain('retention-days: 1');
@@ -5399,8 +5403,9 @@ describe('qwen-autofix workflow', () => {
       'tar -xzf "${RUNNER_TEMP}/cli-dist/qwen-cli-dist.tar.gz"',
     );
     expect(restoreStep).toContain('test -f dist/cli.js');
-    // A bundle without core's dist entry point makes every pre-build gate
-    // crash with ERR_MODULE_NOT_FOUND — pin the restore-side assertion.
+    // A bundle without core's dist entry point makes the pre-build
+    // settings-schema generator crash with ERR_MODULE_NOT_FOUND — pin the
+    // restore-side assertion.
     expect(restoreStep).toContain('test -f packages/core/dist/index.js');
     const downloadStep = stepOf(addressJob, 'Download CLI bundle');
     expect(downloadStep).toContain("name: 'qwen-autofix-cli-dist'");
@@ -6753,6 +6758,9 @@ describe('qwen-autofix workflow', () => {
     const contractCheck = reviewVerificationRunner.indexOf(
       "run_check 'cross-package contract verification failed'",
     );
+    const coreRebuild = reviewVerificationRunner.indexOf(
+      "run_check 'core rebuild failed on the agent-committed fix'",
+    );
     const noOpCheck = reviewVerificationRunner.indexOf(
       'if git diff --quiet "origin/${BRANCH}...${BRANCH}"; then',
     );
@@ -6771,6 +6779,19 @@ describe('qwen-autofix workflow', () => {
     expect(verificationHeadCapture).toBeGreaterThan(-1);
     expect(schemaCheck).toBeGreaterThan(verificationHeadCapture);
     expect(contractCheck).toBeGreaterThan(schemaCheck);
+    // The conditional core rebuild sits between the HEAD capture and the
+    // schema check: the generator must read a branch-built core dist when
+    // the branch itself changed core sources (base-restored dist would
+    // disagree with the branch's committed schema or crash the generator),
+    // and it only fires when the branch diff touches core's sources.
+    expect(coreRebuild).toBeGreaterThan(verificationHeadCapture);
+    expect(schemaCheck).toBeGreaterThan(coreRebuild);
+    expect(reviewVerificationRunner).toContain(
+      'npm run build --workspace packages/core',
+    );
+    expect(reviewVerificationRunner).toContain(
+      "grep -Eq '^packages/core/(src/|index\\.ts$)'",
+    );
     expect(assertions).toHaveLength(2);
     expect(assertions[0]).toBeGreaterThan(contractCheck);
     expect(noOpCheck).toBeGreaterThan(assertions[0]);
@@ -7838,6 +7859,7 @@ describe('qwen-autofix workflow', () => {
     // calls reject_fix on failure - so the verdict is declared AND the reason
     // is captured for the retry.
     for (const check of [
+      "run_check 'core rebuild failed on the agent-committed fix'",
       "run_check 'settings schema is stale on the agent-committed fix'",
       "run_check 'cross-package contract verification failed'",
       "run_check 'build failed on the agent-committed fix' npm run build",

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -5379,11 +5379,16 @@ describe('qwen-autofix workflow', () => {
       addressJob.indexOf("- name: 'Checkout trusted base'"),
     );
 
-    // The artifact is the repo-root dist/ only — copy_bundle_assets.js
-    // already gathers every runtime asset under it; packages/*/dist would
-    // triple the size and is rebuilt from branch sources by the verify gate.
+    // The artifact is the repo-root dist/ plus packages/core/dist —
+    // copy_bundle_assets.js already gathers every runtime asset under the
+    // root dist/, and the remaining packages/*/dist would triple the size
+    // and are rebuilt from branch sources by the verify gate. core's dist
+    // is the exception: the verify gate's settings-schema and i18n checks
+    // run BEFORE any build (on every path, including no-action) and their
+    // tsx-transpiled cli sources import '@qwen-code/qwen-code-core', which
+    // resolves through the workspace symlink to core's dist entry point.
     expect(buildCliJob).toContain(
-      'tar -czf "${RUNNER_TEMP}/qwen-cli-dist.tar.gz" dist',
+      'tar -czf "${RUNNER_TEMP}/qwen-cli-dist.tar.gz" dist packages/core/dist',
     );
     expect(buildCliJob).toContain("name: 'qwen-autofix-cli-dist'");
     expect(buildCliJob).toContain('retention-days: 1');
@@ -5394,6 +5399,9 @@ describe('qwen-autofix workflow', () => {
       'tar -xzf "${RUNNER_TEMP}/cli-dist/qwen-cli-dist.tar.gz"',
     );
     expect(restoreStep).toContain('test -f dist/cli.js');
+    // A bundle without core's dist entry point makes every pre-build gate
+    // crash with ERR_MODULE_NOT_FOUND — pin the restore-side assertion.
+    expect(restoreStep).toContain('test -f packages/core/dist/index.js');
     const downloadStep = stepOf(addressJob, 'Download CLI bundle');
     expect(downloadStep).toContain("name: 'qwen-autofix-cli-dist'");
     // Download directory and restore extract path are one contract — pin


### PR DESCRIPTION
## What this PR does

This PR adds the core package's build output to the CLI bundle artifact that is built once and fanned out to the review-phase legs, and asserts its entry point is present when a leg restores the bundle. The workflow contract tests are updated in lockstep to pin the new archive contents and the restore-side assertion.

## Why it's needed

Since the review fan-out optimization landed, review legs no longer build the trusted base themselves — they install dependencies and restore the shared root bundle. But the deterministic verification gate runs its settings-schema freshness check and its i18n check BEFORE any build, on every path including no-action runs, and both execute cli sources that import the core package through the workspace symlink. That symlink resolves to the core package's built entry point, which nothing on the leg host produces anymore. The generator then crashes with `ERR_MODULE_NOT_FOUND`, the gate misreports a deterministic "settings schema is stale" rejection, and the workflow burns a full 18-minute repair-agent budget on an environment problem no agent can fix. Observed in run 31031063525 for PR 8600: the agent had correctly concluded no changes were needed, yet the job failed. This restores exactly the pre-fan-out state — legs used to build the trusted base before the PR branch checkout, so the gate always ran against a base-built core dist.

## Reviewer Test Plan

### How to verify

1. Reproduce locally (pre-fix state): on a fresh `npm ci` checkout, `rm -rf packages/core/dist && npm run generate:settings-schema` fails with `ERR_MODULE_NOT_FOUND ... @qwen-code/qwen-code-core/dist/index.js`; with `npm run build --workspace packages/core` first it passes. Both directions verified on this branch.
2. Workflow contract suite: `npm run test:scripts` — 112 tests pass here, including the new pins on the archive command and the restore assertion.
3. After merge: the next review fan-out run's legs should pass "Restore CLI bundle" and a no-action target should report `outcome=noop` instead of the schema-stale rejection.

### Evidence (Before & After)

Before (run 31031063525, review-address for PR 8600):

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../node_modules/@qwen-code/qwen-code-core/dist/index.js' imported from .../packages/cli/src/config/settings.ts
❌ Settings schema generator failed to run.
❌ settings schema is stale on the agent-committed fix
```

followed by an 18-minute repair round ending in `Qwen failed during address-review: timeout (1080000ms)`.

After: local reproduction with the core dist restored passes both pre-build gates (schema generator, i18n check); contract suite 112/112 green.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local reproduction with `npm ci` plus a targeted workspace build; no sandbox involved. Linux behavior is covered by the next fan-out run after merge.

## Risk & Scope

- Main risk or tradeoff: the fan-out artifact grows by ~8.5 MB gzipped (retention remains 1 day); if the producer build ever failed to create the core dist, legs would now fail loud at the restore step instead of degrading silently at the gate.
- Not validated / out of scope: a full fan-out run until this is merged; the issue phase is untouched (it still builds itself).
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #8548; fixes the failure observed in run 31031063525 (PR 8600).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 在"构建一次、分发给 review 阶段各 leg"的 CLI bundle 产物中加入了 core 包的构建产物,并在 leg 恢复 bundle 时断言其入口文件存在。workflow 契约测试同步更新,固定新的归档内容与恢复侧断言。

## 为什么需要

自 review 分发优化上线后,review leg 不再自行构建 trusted base —— 只安装依赖并恢复共享的根 bundle。但确定性验证 gate 在任何构建之前就运行 settings-schema 新鲜度检查和 i18n 检查(包括 no-action 路径在内的所有路径),这两处都会执行通过 workspace 符号链接导入 core 包的 cli 源码。该符号链接解析到 core 包的构建入口文件,而 leg 宿主机上现在没有任何步骤产出它。于是生成器以 `ERR_MODULE_NOT_FOUND` 崩溃,gate 误报为确定性的 "settings schema is stale" 拒绝,workflow 随后在一个 agent 无法修复的环境问题上烧掉整整 18 分钟的修复 agent 预算。该问题见于 run 31031063525(PR 8600):agent 已正确判定无需改动,job 却仍然失败。本 PR 精确恢复了分发优化之前的状态 —— 此前 leg 会在检出 PR 分支前自行构建 trusted base,gate 始终能解析到 base 构建出的 core dist。

## 评审测试计划

### 如何验证

1. 本地复现(修复前状态):在全新 `npm ci` 的检出上,`rm -rf packages/core/dist && npm run generate:settings-schema` 会以 `ERR_MODULE_NOT_FOUND ... @qwen-code/qwen-code-core/dist/index.js` 失败;先执行 `npm run build --workspace packages/core` 后则通过。两个方向均已在本分支验证。
2. workflow 契约测试:`npm run test:scripts` —— 本分支 112 项全部通过,包括对归档命令与恢复断言的新固定项。
3. 合入后:下一次 review 分发运行的各 leg 应通过 "Restore CLI bundle" 步骤,no-action 目标应报告 `outcome=noop` 而不是 schema-stale 拒绝。

### 证据(修复前后)

修复前(run 31031063525,PR 8600 的 review-address):

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../node_modules/@qwen-code/qwen-code-core/dist/index.js' imported from .../packages/cli/src/config/settings.ts
❌ Settings schema generator failed to run.
❌ settings schema is stale on the agent-committed fix
```

随后是 18 分钟的修复轮次,以 `Qwen failed during address-review: timeout (1080000ms)` 结束。

修复后:恢复 core dist 的本地复现通过两个构建前 gate(schema 生成器、i18n 检查);契约测试 112/112 全绿。

### 测试环境

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ⚠️   |

### 环境(可选)

本地复现使用 `npm ci` 加定向 workspace 构建;不涉及沙箱。Linux 行为由合入后的下一次分发运行覆盖。

## 风险与范围

- 主要风险或权衡:分发产物增加约 8.5 MB(gzip 后,保留期仍为 1 天);若生产者构建未能产出 core dist,leg 现在会在恢复步骤就响亮地失败,而不是在 gate 处隐性退化。
- 未验证 / 超出范围:合入前无法跑完整的分发运行;issue 阶段不受影响(它仍然自行构建)。
- 破坏性变更 / 迁移说明:无。

## 关联 Issue

#8548 的后续修复;修复 run 31031063525(PR 8600)观察到的失败。

</details>
