### PR TITLE
ci(release): fail publish if bundle loses hook dispatch (#8622 guard)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -427,6 +427,23 @@ jobs:
           npm run bundle
           npm run prepare:package
 
+      # Regression guard for #8622: a mis-built/tree-shaken bundle can silently
+      # drop hook dispatch (only some events fire). Fail the release if the built
+      # bundle lacks the hook execution path, so a hook-stripped artifact can never
+      # be published again.
+      - name: 'Verify bundle retains hook dispatch'
+        run: |-
+          set -euo pipefail
+          if ! grep -rq 'PreToolUse' dist/ 2>/dev/null; then
+            echo '::error::Built bundle is missing PreToolUse hook dispatch (#8622 regression); aborting release.'
+            exit 1
+          fi
+          if ! grep -rqE 'hook_execution_request|HOOK_EXECUTION' dist/ 2>/dev/null; then
+            echo '::error::Built bundle is missing hook execution bus wiring (#8622 regression); aborting release.'
+            exit 1
+          fi
+          echo 'bundle retains hook dispatch markers'
+
       - name: 'Build Standalone Archives'
         env:
           RELEASE_VERSION: '${{ needs.prepare.outputs.release_version }}'


### PR DESCRIPTION
Follow-up guard for #8622 (0.21.6 hooks regression). Verification showed the v0.21.6 tagged SOURCE is correct (hook dispatch identical to 0.21.5) but a released artifact shipped without hook dispatch, and 0.21.6 never landed on npm. Since the source is right, the failure was in build/publish; this adds a release-time guard so a hook-stripped bundle can never be published again: after 'Build Bundle and Prepare Package', a step greps dist/ for the hook dispatch markers (PreToolUse and the hook-execution bus wiring) and exits 1 if absent, aborting the release before any npm publish or GitHub release. Non-invasive: read-only grep, no behavior change when the bundle is healthy.