### PR TITLE
docs: add qwen-audio-agent voice frontend to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ If you know Claude Code, you already know Qwen Code — and then some. We've put
 - [**Qwen Code Desktop**](https://github.com/QwenLM/qwen-code/releases/tag/desktop-latest) — Official desktop app for macOS, Windows, and Linux
 - [**AionUi**](https://github.com/iOfficeAI/AionUi) — A modern GUI for command-line AI tools including Qwen Code
 - [**Gemini CLI Desktop**](https://github.com/Piebald-AI/gemini-cli-desktop) — A cross-platform desktop/web/mobile UI for Qwen Code
+- [**qwen-audio-agent**](https://github.com/QwenAudio/qwen-audio-agent) — Realtime full-duplex voice frontend for Qwen Code over ACP — talk hands-free with barge-in and a local wake word
 
 - [**🦞 Qwen Code Claw**](https://github.com/openclaw/acpx) — Let other agents (Claude, Codex, etc.) delegate coding tasks to Qwen Code via ACP. Paste this prompt into your agent:
 


### PR DESCRIPTION
## What this PR does

Adds a single entry for [qwen-audio-agent](https://github.com/QwenAudio/qwen-audio-agent) to the README Ecosystem section, placed after Gemini CLI Desktop, following the existing `- [**Name**](url) — description` format exactly.

## Why it's needed

qwen-audio-agent is an open-source realtime full-duplex voice frontend that connects to Qwen Code through its native `--acp` stdio mode — no adapter required (`ACP_COMMAND=qwen`, `ACP_ARGS=["--acp"]` in the generic ACP backend). The proposal was triaged in #8629 and accepted for exploration ✅, with the caveat about our compatibility table answered in that thread: the generic ACP entry is shipped and documented, so the listing matches actual support. Listing it in the Ecosystem section makes the voice option discoverable for Qwen Code users who want hands-free operation.

## Reviewer Test Plan

### How to verify

Docs-only change (one README bullet). Confirm: (1) the bullet follows the existing Ecosystem formatting and alphabetical/placement conventions of its neighbors; (2) the link https://github.com/QwenAudio/qwen-audio-agent resolves; (3) the description matches shipped support — qwen-audio-agent's generic ACP backend accepts `ACP_COMMAND=qwen` + `ACP_ARGS=["--acp"]`, which launches Qwen Code's existing stdio ACP mode.

### Evidence (Before & After)

N/A — documentation change; rendered bullet: `- [**qwen-audio-agent**](https://github.com/QwenAudio/qwen-audio-agent) — Realtime full-duplex voice frontend for Qwen Code over ACP — talk hands-free with barge-in and a local wake word`

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

N/A — README-only change, no runtime involved.

## Risk & Scope

- Main risk or tradeoff: none identified; one-line README addition in a section that already lists third-party frontends.
- Not validated / out of scope: end-to-end voice session testing belongs to qwen-audio-agent's own repo; the connection path described is its documented generic ACP backend.
- Breaking changes / migration notes: none.

## Linked Issues

Relates to #8629 (proposal accepted for exploration by triage; caveat addressed in-thread).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在 README 的 Ecosystem 章节新增一条 [qwen-audio-agent](https://github.com/QwenAudio/qwen-audio-agent) 条目，位于 Gemini CLI Desktop 之后，严格沿用现有 `- [**Name**](url) — description` 格式。

## 为什么需要

qwen-audio-agent 是一个开源的实时全双工语音前台，通过 Qwen Code 原生的 `--acp` stdio 模式直连——无需适配器（在其通用 ACP 后台中配置 `ACP_COMMAND=qwen`、`ACP_ARGS=["--acp"]` 即可）。该提案在 #8629 中经 Triage 审核通过（accept for exploration ✅），其中关于兼容性表格的疑问已在该线程中答复：通用 ACP 入口为已发布且有文档的能力，因此条目描述与实际支持相符。收录到 Ecosystem 章节可让希望免提操作的 Qwen Code 用户发现语音选项。

## 审阅者测试计划

### 如何验证

纯文档变更（README 一行）。请确认：(1) 条目遵循现有 Ecosystem 格式与相邻条目的放置惯例；(2) 链接 https://github.com/QwenAudio/qwen-audio-agent 可访问；(3) 描述与实际支持相符——qwen-audio-agent 的通用 ACP 后台接受 `ACP_COMMAND=qwen` + `ACP_ARGS=["--acp"]`，即启动 Qwen Code 现有的 stdio ACP 模式。

### 证据（变更前后）

N/A——文档变更；渲染后的条目见上。

### 测试平台

N/A（纯 README 变更，三个平台均不涉及运行时）。

### 环境

N/A——仅 README 变更，无运行时。

## 风险与范围

- 主要风险或权衡：未发现；仅在该章节（已收录多个第三方前端）新增一行。
- 未验证 / 超出范围：端到端语音会话测试属于 qwen-audio-agent 自身仓库；所述连接方式即其文档化的通用 ACP 后台。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

关联 #8629（提案已通过 Triage 审核，相关疑问已在线程中答复）。

</details>
