### PR TITLE
feat(omni): S3 delivery reliability — upload cache, credential reuse, failure semantics, startup recovery

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -2195,6 +2195,7 @@ export async function loadCliConfig(
     omniUploadMaxFileBytes: settings.omni?.upload?.maxFileBytes,
     omniMaxEstimatedTokens: settings.omni?.transport?.maxEstimatedTokens,
     omniDownloadMaxFileBytes: settings.omni?.download?.maxFileBytes,
+    omniUploadCacheTtlHours: settings.omni?.upload?.cacheTtlHours,
     // CDP tunnel (Plan C, #5626): with the tunnel on, browser automation goes
     // through the CDP tunnel (far lighter than the OS-level computer-use
     // driver), so disable computer-use to keep the agent off that heavy path.

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -3676,6 +3676,23 @@ const SETTINGS_SCHEMA = {
               default: 1073741824,
             },
           },
+          cacheTtlHours: {
+            type: 'number',
+            label: 'Upload Cache TTL (hours)',
+            category: 'Experimental',
+            requiresRestart: true,
+            default: 47,
+            description:
+              'Validity horizon for cached oss:// upload URLs. DashScope ' +
+              'temporary uploads live 48h; the default keeps a 1h margin. ' +
+              '0 disables the upload cache (every delivery re-uploads).',
+            showInDialog: false,
+            jsonSchemaOverride: {
+              type: 'number',
+              minimum: 0,
+              default: 47,
+            },
+          },
         },
       },
       transport: {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1108,6 +1108,8 @@ export interface ConfigParameters {
   omniMaxEstimatedTokens?: number;
   /** Byte ceiling for omni URL downloads (unset = follow upload cap). */
   omniDownloadMaxFileBytes?: number;
+  /** Upload cache TTL in hours (0 disables the cache; default 47). */
+  omniUploadCacheTtlHours?: number;
   /** Image generation model selected through `/model --image`. */
   imageModel?: string;
   /**
@@ -1937,6 +1939,7 @@ export class Config {
   private readonly omniUploadMaxFileBytes?: number;
   private readonly omniMaxEstimatedTokens?: number;
   private readonly omniDownloadMaxFileBytes?: number;
+  private readonly omniUploadCacheTtlHours?: number;
   private workflowsEnabled = false;
   private readonly skipWorkflowUsageWarning: boolean = false;
   private readonly computerUseEnabled: boolean = true;
@@ -2216,6 +2219,7 @@ export class Config {
     this.omniUploadMaxFileBytes = params.omniUploadMaxFileBytes;
     this.omniMaxEstimatedTokens = params.omniMaxEstimatedTokens;
     this.omniDownloadMaxFileBytes = params.omniDownloadMaxFileBytes;
+    this.omniUploadCacheTtlHours = params.omniUploadCacheTtlHours;
     this.workflowsEnabled = params.workflowsEnabled ?? false;
     this.skipWorkflowUsageWarning = params.skipWorkflowUsageWarning ?? false;
     this.computerUseEnabled = params.computerUseEnabled ?? true;
@@ -6386,6 +6390,10 @@ export class Config {
 
   getOmniDownloadMaxFileBytes(): number | undefined {
     return this.omniDownloadMaxFileBytes;
+  }
+
+  getOmniUploadCacheTtlHours(): number | undefined {
+    return this.omniUploadCacheTtlHours;
   }
 
   resolveImageGenerationModel(

--- a/packages/core/src/core/openaiContentGenerator/pipeline.omniCacheInvalidation.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.omniCacheInvalidation.test.ts
@@ -1,0 +1,314 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Mock } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type OpenAI from 'openai';
+import type { GenerateContentParameters } from '@google/genai';
+import { GenerateContentResponse } from '@google/genai';
+import type { ErrorHandler, PipelineConfig } from './types.js';
+import { ContentGenerationPipeline } from './pipeline.js';
+import { OpenAIContentConverter } from './converter.js';
+import type { Config } from '../../config/config.js';
+import type { AuthType, ContentGeneratorConfig } from '../contentGenerator.js';
+import type { OpenAICompatibleProvider } from './provider/index.js';
+
+const mockInvalidateByUrl = vi.hoisted(() => vi.fn());
+const mockUploadCacheCtor = vi.hoisted(() => vi.fn());
+const mockObjectStoreCtor = vi.hoisted(() => vi.fn());
+
+vi.mock('openai');
+vi.mock('./converter.js', () => ({
+  OpenAIContentConverter: {
+    convertGeminiRequestToOpenAI: vi.fn(),
+    convertOpenAIResponseToGemini: vi.fn(),
+    convertOpenAIChunkToGemini: vi.fn(),
+    convertGeminiToolsToOpenAI: vi.fn(),
+  },
+}));
+vi.mock('../../telemetry/loggers.js', () => ({
+  logProtocolTagSanitized: vi.fn(),
+}));
+vi.mock('../../telemetry/gen-ai-request.js', () => ({
+  reportOpenAiRequest: vi.fn(),
+  reportOpenAiResponse: vi.fn(),
+  reportOpenAiChunk: vi.fn(),
+}));
+vi.mock('../../omni/upload-cache.js', () => ({
+  OmniUploadCache: class {
+    constructor(...args: unknown[]) {
+      mockUploadCacheCtor(...args);
+    }
+
+    invalidateByUrl = mockInvalidateByUrl;
+  },
+}));
+vi.mock('../../omni/storage.js', () => ({
+  OmniObjectStore: class {
+    constructor(...args: unknown[]) {
+      mockObjectStoreCtor(...args);
+    }
+
+    getOmniRootDir() {
+      return '/tmp/omni-root';
+    }
+  },
+}));
+
+describe('ContentGenerationPipeline omni oss cache invalidation', () => {
+  let pipeline: ContentGenerationPipeline;
+  let mockConfig: PipelineConfig;
+  let mockProvider: OpenAICompatibleProvider;
+  let mockClient: OpenAI;
+  let mockConverter: typeof OpenAIContentConverter;
+  let mockErrorHandler: ErrorHandler;
+  let mockContentGeneratorConfig: ContentGeneratorConfig;
+  let mockCliConfig: Config;
+
+  const request: GenerateContentParameters = {
+    model: 'test-model',
+    contents: [{ parts: [{ text: 'Describe the media' }], role: 'user' }],
+  };
+  const userPromptId = 'omni-prompt-id';
+
+  /** Messages carrying oss:// media in all three OpenAI part shapes. */
+  const ossMediaMessages = [
+    {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'Describe the media' },
+        { type: 'image_url', image_url: { url: 'oss://bucket/image.png' } },
+        { type: 'video_url', video_url: { url: 'oss://bucket/video.mp4' } },
+        {
+          type: 'input_audio',
+          input_audio: { data: 'oss://bucket/audio.wav', format: 'wav' },
+        },
+      ],
+    },
+  ] as unknown as OpenAI.Chat.ChatCompletionMessageParam[];
+
+  const nonOssMediaMessages = [
+    {
+      role: 'user',
+      content: [
+        {
+          type: 'image_url',
+          image_url: { url: 'https://example.com/image.png' },
+        },
+        {
+          type: 'input_audio',
+          input_audio: { data: 'data:audio/wav;base64,AAAA', format: 'wav' },
+        },
+      ],
+    },
+  ] as unknown as OpenAI.Chat.ChatCompletionMessageParam[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockClient = {
+      chat: {
+        completions: {
+          create: vi.fn(),
+        },
+      },
+    } as unknown as OpenAI;
+
+    mockConverter = OpenAIContentConverter;
+
+    mockProvider = {
+      buildClient: vi.fn().mockReturnValue(mockClient),
+      buildRequest: vi.fn().mockImplementation((req) => req),
+      buildHeaders: vi.fn().mockReturnValue({}),
+      getDefaultGenerationConfig: vi.fn().mockReturnValue({}),
+    };
+
+    mockErrorHandler = {
+      handle: vi.fn().mockImplementation((error: unknown) => {
+        throw error;
+      }),
+      shouldSuppressErrorLogging: vi.fn().mockReturnValue(false),
+    } as unknown as ErrorHandler;
+
+    mockCliConfig = {
+      isOmniEnabled: () => true,
+      storage: { getQwenDir: () => '/tmp/qwen' },
+    } as unknown as Config;
+
+    mockContentGeneratorConfig = {
+      model: 'test-model',
+      authType: 'openai' as AuthType,
+    } as ContentGeneratorConfig;
+
+    mockConfig = {
+      cliConfig: mockCliConfig,
+      provider: mockProvider,
+      contentGeneratorConfig: mockContentGeneratorConfig,
+      errorHandler: mockErrorHandler,
+    };
+
+    pipeline = new ContentGenerationPipeline(mockConfig);
+  });
+
+  it('invalidates each distinct oss:// URL when a non-streaming request fails with a media download error', async () => {
+    (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue(
+      ossMediaMessages,
+    );
+    (mockClient.chat.completions.create as Mock).mockRejectedValue(
+      new Error('Download the media resource timed out'),
+    );
+
+    await expect(pipeline.execute(request, userPromptId)).rejects.toThrow(
+      'Download the media resource timed out',
+    );
+
+    expect(mockInvalidateByUrl).toHaveBeenCalledTimes(3);
+    expect(mockInvalidateByUrl).toHaveBeenCalledWith('oss://bucket/image.png');
+    expect(mockInvalidateByUrl).toHaveBeenCalledWith('oss://bucket/video.mp4');
+    expect(mockInvalidateByUrl).toHaveBeenCalledWith('oss://bucket/audio.wav');
+    // The cache is constructed without a scope: invalidation scans all
+    // entries by URL.
+    expect(mockUploadCacheCtor).toHaveBeenCalledWith('/tmp/omni-root');
+  });
+
+  it('invalidates when the stream fails mid-iteration with an oss-naming error', async () => {
+    (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue(
+      ossMediaMessages,
+    );
+    const emptyResponse = new GenerateContentResponse();
+    (mockConverter.convertOpenAIChunkToGemini as Mock).mockReturnValue(
+      emptyResponse,
+    );
+    const stream = {
+      async *[Symbol.asyncIterator]() {
+        yield {
+          id: 'chunk-1',
+          choices: [{ delta: { content: 'partial' }, finish_reason: null }],
+        } as OpenAI.Chat.ChatCompletionChunk;
+        throw new Error(
+          'Failed to resolve oss://bucket/image.png: resource not found',
+        );
+      },
+    };
+    (mockClient.chat.completions.create as Mock).mockResolvedValue(stream);
+
+    const generator = await pipeline.executeStream(request, userPromptId);
+    await expect(
+      (async () => {
+        for await (const _ of generator) {
+          // Drain until the mid-stream error surfaces.
+        }
+      })(),
+    ).rejects.toThrow('Failed to resolve oss://bucket/image.png');
+
+    expect(mockInvalidateByUrl).toHaveBeenCalledTimes(3);
+    expect(mockInvalidateByUrl).toHaveBeenCalledWith('oss://bucket/image.png');
+  });
+
+  it('invalidates when the stream reports an error_finish chunk naming the oss media', async () => {
+    (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue(
+      ossMediaMessages,
+    );
+    const stream = {
+      async *[Symbol.asyncIterator]() {
+        yield {
+          id: 'chunk-1',
+          choices: [
+            {
+              delta: {
+                content: 'Download the media resource timed out',
+              },
+              finish_reason: 'error_finish',
+            },
+          ],
+        } as unknown as OpenAI.Chat.ChatCompletionChunk;
+      },
+    };
+    (mockClient.chat.completions.create as Mock).mockResolvedValue(stream);
+
+    const generator = await pipeline.executeStream(request, userPromptId);
+    await expect(
+      (async () => {
+        for await (const _ of generator) {
+          // Drain until the error_finish chunk surfaces as an error.
+        }
+      })(),
+    ).rejects.toThrow('Download the media resource timed out');
+
+    expect(mockInvalidateByUrl).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not invalidate on 429/RESOURCE_EXHAUSTED even with oss media present', async () => {
+    (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue(
+      ossMediaMessages,
+    );
+    (mockClient.chat.completions.create as Mock).mockRejectedValue(
+      Object.assign(
+        new Error('RESOURCE_EXHAUSTED: quota exceeded for oss:// media'),
+        { status: 429 },
+      ),
+    );
+
+    await expect(pipeline.execute(request, userPromptId)).rejects.toThrow(
+      'RESOURCE_EXHAUSTED',
+    );
+
+    expect(mockInvalidateByUrl).not.toHaveBeenCalled();
+  });
+
+  it('does not invalidate when the error merely contains the letters "oss" without the scheme', async () => {
+    (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue(
+      ossMediaMessages,
+    );
+    (mockClient.chat.completions.create as Mock).mockRejectedValue(
+      new Error('connection loss detected'),
+    );
+
+    await expect(pipeline.execute(request, userPromptId)).rejects.toThrow(
+      'connection loss detected',
+    );
+
+    expect(mockInvalidateByUrl).not.toHaveBeenCalled();
+  });
+
+  it('does not invalidate when the request carries no oss:// URLs', async () => {
+    (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue(
+      nonOssMediaMessages,
+    );
+    (mockClient.chat.completions.create as Mock).mockRejectedValue(
+      new Error('Failed to resolve oss://bucket/other.png'),
+    );
+
+    await expect(pipeline.execute(request, userPromptId)).rejects.toThrow(
+      'Failed to resolve',
+    );
+
+    expect(mockInvalidateByUrl).not.toHaveBeenCalled();
+  });
+
+  it('does not invalidate when omni is disabled', async () => {
+    mockCliConfig = {
+      isOmniEnabled: () => false,
+      storage: { getQwenDir: () => '/tmp/qwen' },
+    } as unknown as Config;
+    pipeline = new ContentGenerationPipeline({
+      ...mockConfig,
+      cliConfig: mockCliConfig,
+    });
+    (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue(
+      ossMediaMessages,
+    );
+    (mockClient.chat.completions.create as Mock).mockRejectedValue(
+      new Error('Download the media resource timed out'),
+    );
+
+    await expect(pipeline.execute(request, userPromptId)).rejects.toThrow(
+      'Download the media resource timed out',
+    );
+
+    expect(mockInvalidateByUrl).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -1144,6 +1144,13 @@ export class ContentGenerationPipeline {
     try {
       return await executeAttempt();
     } catch (error) {
+      // Omni delivery-cache hygiene: when a request carrying oss:// media
+      // fails with a provider-side resolution error, drop the cached URL(s)
+      // so the user's retry re-uploads instead of resending a dead
+      // reference. Deliberately no automatic in-pipeline resend — the next
+      // interaction is the retry (design: omni-s3 D2). Conservative
+      // matching; never throws.
+      void this.invalidateOmniOssCacheOnError(openaiRequest, error);
       const model = context.model.toLowerCase();
       const wireRequest = openaiRequest as Record<string, unknown> | undefined;
       const chatTemplateKwargs = wireRequest?.['chat_template_kwargs'] as
@@ -1175,6 +1182,59 @@ export class ContentGenerationPipeline {
    * Shared error handling logic for both executeWithErrorHandling and processStreamWithLogging
    * This centralizes the common error processing steps to avoid duplication
    */
+  /** Fire-and-forget upload-cache invalidation for failed oss deliveries. */
+  private async invalidateOmniOssCacheOnError(
+    openaiRequest: OpenAI.Chat.ChatCompletionCreateParams | undefined,
+    error: unknown,
+  ): Promise<void> {
+    try {
+      if (!this.config.cliConfig.isOmniEnabled?.()) return;
+      // Throttling must never churn the cache: a 429 on a request that
+      // happens to carry oss media says nothing about the media's health
+      // (and some providers phrase quota errors as RESOURCE_EXHAUSTED).
+      if (getErrorStatus(error) === 429) return;
+      const message = getErrorMessage(error) ?? '';
+      // Dead-media provider errors either name the oss scheme outright or
+      // describe the media download step (DashScope: "Download the media
+      // resource timed out"). Anything else must not nuke the cache.
+      if (
+        !/oss/i.test(message) &&
+        !(/download/i.test(message) && /resource|media/i.test(message))
+      ) {
+        return;
+      }
+      const urls = new Set<string>();
+      for (const m of openaiRequest?.messages ?? []) {
+        const content = (m as { content?: unknown }).content;
+        if (!Array.isArray(content)) continue;
+        for (const part of content) {
+          const p = part as {
+            image_url?: { url?: string };
+            video_url?: { url?: string };
+            input_audio?: { data?: string };
+          };
+          for (const u of [
+            p.image_url?.url,
+            p.video_url?.url,
+            p.input_audio?.data,
+          ]) {
+            if (typeof u === 'string' && u.startsWith('oss://')) urls.add(u);
+          }
+        }
+      }
+      if (urls.size === 0) return;
+      const { OmniUploadCache } = await import('../../omni/upload-cache.js');
+      const { OmniObjectStore } = await import('../../omni/storage.js');
+      const store = new OmniObjectStore(
+        this.config.cliConfig.storage.getQwenDir(),
+      );
+      const cache = new OmniUploadCache(store.getOmniRootDir());
+      for (const u of urls) await cache.invalidateByUrl(u);
+    } catch {
+      // Hygiene only — never mask the original error.
+    }
+  }
+
   private async handleError(
     error: unknown,
     context: RequestContext,

--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -464,6 +464,7 @@ export class ContentGenerationPipeline {
           guarded,
           context,
           request,
+          openaiRequest,
           userPromptId,
           telemetryAttempt,
         );
@@ -491,6 +492,7 @@ export class ContentGenerationPipeline {
     stream: AsyncIterable<OpenAI.Chat.ChatCompletionChunk>,
     context: RequestContext,
     request: GenerateContentParameters,
+    openaiRequest: OpenAI.Chat.ChatCompletionCreateParams,
     userPromptId: string,
     telemetryAttempt: GenAiAttemptHandle | undefined,
   ): AsyncGenerator<GenerateContentResponse> {
@@ -671,6 +673,15 @@ export class ContentGenerationPipeline {
         yield pendingFinishResponse;
       }
     } catch (error) {
+      // Omni delivery-cache hygiene for mid-stream failures: DashScope
+      // reports dead oss:// media after the 200 OK — either as an
+      // error_finish SSE chunk (surfaced as StreamContentError above) or as
+      // a stream error — so the non-streaming catch in
+      // executeWithErrorHandling never sees it. Run the same conservative
+      // invalidation here before any rethrow. Never throws; awaiting keeps
+      // a fast retry from racing the cache file write.
+      await this.invalidateOmniOssCacheOnError(openaiRequest, error);
+
       if (error instanceof InvalidStreamError) {
         throw error;
       }
@@ -1149,8 +1160,9 @@ export class ContentGenerationPipeline {
       // so the user's retry re-uploads instead of resending a dead
       // reference. Deliberately no automatic in-pipeline resend — the next
       // interaction is the retry (design: omni-s3 D2). Conservative
-      // matching; never throws.
-      void this.invalidateOmniOssCacheOnError(openaiRequest, error);
+      // matching; never throws, so awaiting cannot mask the original error,
+      // and it must complete before a fast retry can race the file write.
+      await this.invalidateOmniOssCacheOnError(openaiRequest, error);
       const model = context.model.toLowerCase();
       const wireRequest = openaiRequest as Record<string, unknown> | undefined;
       const chatTemplateKwargs = wireRequest?.['chat_template_kwargs'] as
@@ -1182,7 +1194,11 @@ export class ContentGenerationPipeline {
    * Shared error handling logic for both executeWithErrorHandling and processStreamWithLogging
    * This centralizes the common error processing steps to avoid duplication
    */
-  /** Fire-and-forget upload-cache invalidation for failed oss deliveries. */
+  /**
+   * Upload-cache invalidation for failed oss deliveries. Never throws
+   * (internal try/catch), so callers can await it without masking the
+   * original error.
+   */
   private async invalidateOmniOssCacheOnError(
     openaiRequest: OpenAI.Chat.ChatCompletionCreateParams | undefined,
     error: unknown,
@@ -1193,12 +1209,17 @@ export class ContentGenerationPipeline {
       // happens to carry oss media says nothing about the media's health
       // (and some providers phrase quota errors as RESOURCE_EXHAUSTED).
       if (getErrorStatus(error) === 429) return;
-      const message = getErrorMessage(error) ?? '';
-      // Dead-media provider errors either name the oss scheme outright or
-      // describe the media download step (DashScope: "Download the media
-      // resource timed out"). Anything else must not nuke the cache.
+      const message = getErrorMessage(error);
+      // Dead-media provider errors either quote the oss URL — the cached
+      // URLs always carry the scheme — or describe the media download step
+      // (DashScope: "Download the media resource timed out"). Require the
+      // full "oss://" scheme rather than the bare word so messages like
+      // "connection loss" or "across" cannot nuke healthy cache entries.
+      // This trades conservative false negatives: a phrasing like "Failed
+      // to fetch the media resource" (no URL, no "download") is
+      // deliberately missed.
       if (
-        !/oss/i.test(message) &&
+        !/oss:\/\//i.test(message) &&
         !(/download/i.test(message) && /resource|media/i.test(message))
       ) {
         return;

--- a/packages/core/src/omni/index.test.ts
+++ b/packages/core/src/omni/index.test.ts
@@ -312,6 +312,9 @@ describe('readMediaViaOmniDelivery result shape', () => {
         getOmniRootDir() {
           return tmpDir;
         }
+        getObjectsDir() {
+          return path.join(tmpDir, 'objects');
+        }
       },
     }));
     vi.doMock('./upload.js', () => ({
@@ -370,7 +373,10 @@ describe('readMediaViaOmniDelivery result shape', () => {
       OmniObjectStore: class {
         putFile = putFileMock;
         getOmniRootDir() {
-          return '/tmp/omni-test-qwen/omni';
+          return tmpDir;
+        }
+        getObjectsDir() {
+          return path.join(tmpDir, 'objects');
         }
       },
     }));
@@ -417,7 +423,10 @@ describe('readMediaViaOmniDelivery result shape', () => {
           return { objectPath: '/tmp/obj.mp3', deduped: false };
         }
         getOmniRootDir() {
-          return '/tmp/omni-test-qwen/omni';
+          return tmpDir;
+        }
+        getObjectsDir() {
+          return path.join(tmpDir, 'objects');
         }
       },
     }));
@@ -496,5 +505,186 @@ describe('readMediaViaOmniDelivery result shape', () => {
         expect(String(field)).not.toContain(parentFragment);
       }
     }
+  });
+});
+
+describe('processMediaForOmniDelivery upload cache integration', () => {
+  // The REAL upload-cache.js and recovery.js modules run against a temp omni
+  // root; only the leaf deps (ffmpeg/recognition/storage/upload) are mocked.
+  // This pins the wiring itself: hit skips store+upload, miss persists,
+  // ttl 0 disables, scope isolates credentials, recovery runs.
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'omni-cache-int-'));
+  });
+
+  afterEach(async () => {
+    vi.resetAllMocks();
+    vi.doUnmock('./ffmpeg.js');
+    vi.doUnmock('./recognition.js');
+    vi.doUnmock('./storage.js');
+    vi.doUnmock('./upload.js');
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  function cacheConfig(overrides?: {
+    cgc?: Record<string, unknown>;
+    ttlHours?: number;
+  }): Config {
+    return {
+      isOmniEnabled: vi.fn().mockReturnValue(true),
+      isTrustedFolder: vi.fn().mockReturnValue(true),
+      getContentGeneratorConfig: vi
+        .fn()
+        .mockReturnValue(overrides?.cgc ?? DASHSCOPE_CGC),
+      getModel: vi.fn().mockReturnValue('qwen3.5-omni-plus'),
+      getOmniUploadMaxFileBytes: vi.fn().mockReturnValue(0),
+      getOmniMaxEstimatedTokens: vi.fn().mockReturnValue(0),
+      getOmniUploadCacheTtlHours: vi.fn().mockReturnValue(overrides?.ttlHours),
+      storage: { getQwenDir: () => tmpDir },
+    } as unknown as Config;
+  }
+
+  /** Installs leaf mocks around a shared pair of spies and imports the
+   * pipeline. The mocked store roots at tmpDir, so the real cache file
+   * lands at tmpDir/upload-cache.json. */
+  async function armPipeline() {
+    const putFileMock = vi
+      .fn()
+      .mockResolvedValue({ objectPath: '/tmp/obj.mp3', deduped: false });
+    const uploadFileMock = vi.fn().mockResolvedValue('oss://bucket/cached');
+    vi.doMock('./ffmpeg.js', () => ({
+      isFfmpegAvailable: vi.fn().mockResolvedValue(true),
+      isFfprobeAvailable: vi.fn().mockResolvedValue(true),
+    }));
+    vi.doMock('./recognition.js', () => ({
+      recognizeMediaFile: vi
+        .fn()
+        .mockResolvedValue(mockRecognizedFor('audio', { durationMs: 60_000 })),
+      hashFileSha256: vi.fn().mockResolvedValue('b'.repeat(64)),
+      extensionForMime: vi.fn().mockReturnValue('.mp3'),
+    }));
+    const objectsDir = path.join(tmpDir, 'objects');
+    vi.doMock('./storage.js', () => ({
+      OmniObjectStore: class {
+        putFile = putFileMock;
+        getOmniRootDir() {
+          return tmpDir;
+        }
+        getObjectsDir() {
+          return objectsDir;
+        }
+      },
+    }));
+    vi.doMock('./upload.js', () => ({
+      DashScopeUploader: class {
+        uploadFile = uploadFileMock;
+      },
+      OSS_URL_PREFIX: 'oss://',
+    }));
+    const mod = await import('./index.js');
+    return { putFileMock, uploadFileMock, mod };
+  }
+
+  function mockRecognizedFor(
+    modality: 'audio',
+    metadata: Record<string, unknown>,
+  ) {
+    return {
+      modality,
+      detectedMimeType: 'audio/mpeg',
+      sizeBytes: 1234,
+      metadata,
+    };
+  }
+
+  async function realFile(name: string): Promise<string> {
+    const filePath = path.join(tmpDir, name);
+    await fs.writeFile(filePath, 'not really media');
+    return filePath;
+  }
+
+  it('serves a repeat delivery from the cache: no second store copy or upload', async () => {
+    const { putFileMock, uploadFileMock, mod } = await armPipeline();
+    const filePath = await realFile('song.mp3');
+    const config = cacheConfig();
+
+    const first = await mod.processMediaForOmniDelivery(filePath, config);
+    expect(first.uploadCacheHit).toBe(false);
+    expect(putFileMock).toHaveBeenCalledTimes(1);
+    expect(uploadFileMock).toHaveBeenCalledTimes(1);
+
+    const second = await mod.processMediaForOmniDelivery(filePath, config);
+    expect(second.uploadCacheHit).toBe(true);
+    expect(second.fileUri).toBe(first.fileUri);
+    expect(second.deduped).toBe(true);
+    // Hit path must run BEFORE store promotion and upload.
+    expect(putFileMock).toHaveBeenCalledTimes(1);
+    expect(uploadFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists the miss: the oss URL lands in upload-cache.json on disk', async () => {
+    const { mod } = await armPipeline();
+    await mod.processMediaForOmniDelivery(
+      await realFile('song.mp3'),
+      cacheConfig(),
+    );
+    const raw = await fs.readFile(
+      path.join(tmpDir, 'upload-cache.json'),
+      'utf8',
+    );
+    expect(raw).toContain('oss://bucket/cached');
+    expect(raw).toContain('b'.repeat(64));
+  });
+
+  it('re-uploads every time when the cache TTL is configured to 0', async () => {
+    const { uploadFileMock, mod } = await armPipeline();
+    const filePath = await realFile('song.mp3');
+    const config = cacheConfig({ ttlHours: 0 });
+
+    const first = await mod.processMediaForOmniDelivery(filePath, config);
+    const second = await mod.processMediaForOmniDelivery(filePath, config);
+    expect(first.uploadCacheHit).toBe(false);
+    expect(second.uploadCacheHit).toBe(false);
+    expect(uploadFileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('never serves a URL cached under a different credential or endpoint', async () => {
+    // An oss:// URL is minted for one (origin, apiKey) pair; switching
+    // accounts must re-upload rather than reuse a URL the new credential
+    // may not own.
+    const { uploadFileMock, mod } = await armPipeline();
+    const filePath = await realFile('song.mp3');
+
+    await mod.processMediaForOmniDelivery(filePath, cacheConfig());
+    const otherKey = await mod.processMediaForOmniDelivery(
+      filePath,
+      cacheConfig({ cgc: { ...DASHSCOPE_CGC, apiKey: 'sk-other-key' } }),
+    );
+    expect(otherKey.uploadCacheHit).toBe(false);
+    expect(uploadFileMock).toHaveBeenCalledTimes(2);
+
+    // Same credential again: both prior entries coexist; still a hit.
+    const back = await mod.processMediaForOmniDelivery(filePath, cacheConfig());
+    expect(back.uploadCacheHit).toBe(true);
+    expect(uploadFileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('runs startup recovery: an expired download .part is swept on first delivery', async () => {
+    const downloadsDir = path.join(tmpDir, 'downloads');
+    await fs.mkdir(downloadsDir, { recursive: true });
+    const expired = path.join(downloadsDir, 'stale.part');
+    await fs.writeFile(expired, 'partial');
+    const old = new Date(Date.now() - 49 * 3600_000);
+    await fs.utimes(expired, old, old);
+
+    const { mod } = await armPipeline();
+    await mod.processMediaForOmniDelivery(
+      await realFile('song.mp3'),
+      cacheConfig(),
+    );
+    await expect(fs.stat(expired)).rejects.toMatchObject({ code: 'ENOENT' });
   });
 });

--- a/packages/core/src/omni/index.test.ts
+++ b/packages/core/src/omni/index.test.ts
@@ -255,6 +255,9 @@ describe('readMediaViaOmniDelivery result shape', () => {
         async putFile() {
           return { objectPath: '/tmp/obj.png', deduped: false };
         }
+        getOmniRootDir() {
+          return tmpDir;
+        }
       },
     }));
     vi.doMock('./upload.js', () => ({
@@ -305,6 +308,9 @@ describe('readMediaViaOmniDelivery result shape', () => {
       OmniObjectStore: class {
         async putFile() {
           return { objectPath: '/tmp/obj.mp3', deduped: false };
+        }
+        getOmniRootDir() {
+          return tmpDir;
         }
       },
     }));

--- a/packages/core/src/omni/index.ts
+++ b/packages/core/src/omni/index.ts
@@ -28,6 +28,11 @@ import {
 } from './recognition.js';
 import { OmniObjectStore } from './storage.js';
 import { DashScopeUploader } from './upload.js';
+import {
+  OmniUploadCache,
+  DEFAULT_UPLOAD_CACHE_TTL_HOURS,
+} from './upload-cache.js';
+import { runStartupRecoveryOnce } from './recovery.js';
 
 export {
   assertOmniRuntimeDependencies,
@@ -63,6 +68,15 @@ export {
 // Circular-safe (both modules only bind functions): lets the ./omni
 // subpath entry serve the tool-result funnel without the big barrel.
 export { processToolResultOmniMedia } from './tool-result-media.js';
+export {
+  OmniUploadCache,
+  DEFAULT_UPLOAD_CACHE_TTL_HOURS,
+} from './upload-cache.js';
+export {
+  runStartupRecoveryOnce,
+  resetRecoveryLatchForTests,
+} from './recovery.js';
+export { resetCredentialCacheForTests } from './upload.js';
 
 const debugLogger = createDebugLogger('omni');
 
@@ -121,6 +135,9 @@ export interface OmniMediaDelivery {
   tokenEstimate: OmniTokenEstimate;
   /** Whether the object store already held this content. */
   deduped: boolean;
+  /** True when the oss URL came from the persistent upload cache (no
+   * network transfer happened for this delivery). */
+  uploadCacheHit: boolean;
 }
 
 /** Thrown for omni pipeline failures. The pipeline fails closed: callers
@@ -263,6 +280,16 @@ export async function processMediaForOmniDelivery(
   }
 
   const store = new OmniObjectStore(config.storage.getQwenDir());
+  const configuredTtl = config.getOmniUploadCacheTtlHours?.();
+  const uploadCache = new OmniUploadCache(
+    store.getOmniRootDir(),
+    configuredTtl === undefined
+      ? DEFAULT_UPLOAD_CACHE_TTL_HOURS
+      : configuredTtl,
+  );
+  // Lazy one-time hygiene scan (expired .part files, promotion orphans,
+  // sampled object verification). Never throws.
+  await runStartupRecoveryOnce(store, uploadCache);
   const extension = extensionForMime(recognized.detectedMimeType);
   let objectPath: string;
   let deduped: boolean;
@@ -279,6 +306,23 @@ export async function processMediaForOmniDelivery(
     );
   }
 
+  const model = config.getModel();
+  const cachedUrl = await uploadCache.get(sha256, model);
+  if (cachedUrl) {
+    debugLogger.debug(
+      `omni upload cache hit: sha256=${sha256.slice(0, 12)}… model=${model}`,
+    );
+    return {
+      fileUri: cachedUrl,
+      mimeType: recognized.detectedMimeType,
+      sha256,
+      recognized,
+      tokenEstimate,
+      deduped,
+      uploadCacheHit: true,
+    };
+  }
+
   const cgc = config.getContentGeneratorConfig();
   const uploader = new DashScopeUploader({
     apiKey: cgc.apiKey ?? '',
@@ -288,7 +332,7 @@ export async function processMediaForOmniDelivery(
   try {
     fileUri = await uploader.uploadFile({
       filePath: objectPath,
-      model: config.getModel(),
+      model,
       mimeType: recognized.detectedMimeType,
       signal,
     });
@@ -309,6 +353,7 @@ export async function processMediaForOmniDelivery(
       `size=${recognized.sizeBytes} est=${tokenEstimate.estimatedTokenCount}(${tokenEstimate.status}) ` +
       `deduped=${deduped} uri=${fileUri}`,
   );
+  await uploadCache.put(sha256, model, fileUri);
   return {
     fileUri,
     mimeType: recognized.detectedMimeType,
@@ -316,6 +361,7 @@ export async function processMediaForOmniDelivery(
     recognized,
     tokenEstimate,
     deduped,
+    uploadCacheHit: false,
   };
 }
 

--- a/packages/core/src/omni/index.ts
+++ b/packages/core/src/omni/index.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { createHash } from 'node:crypto';
 import path from 'node:path';
 import fs from 'node:fs/promises';
 import type { Config } from '../config/config.js';
@@ -133,7 +134,8 @@ export interface OmniMediaDelivery {
   recognized: RecognizedMedia;
   /** Raw-resource token estimate (attached even when the guard is off). */
   tokenEstimate: OmniTokenEstimate;
-  /** Whether the object store already held this content. */
+  /** Whether the content was already known to the system — object-store
+   * dedup on the miss path, always true on an upload-cache hit. */
   deduped: boolean;
   /** True when the oss URL came from the persistent upload cache (no
    * network transfer happened for this delivery). */
@@ -204,9 +206,12 @@ export function isOmniDeliveryActive(config: Config): boolean {
  *
  * All modalities are uploaded AS-IS — no resizing, no transcoding.
  * Degradation is the job of S4 policies (which must disclose); the default
- * path never silently alters content. No caching yet (S3 adds the
- * (sha256, model) upload cache). Throws OmniDeliveryError /
- * OmniTransportGuardError on failure; user aborts propagate untouched.
+ * path never silently alters content. Successful uploads are remembered in
+ * the persistent upload cache (`.qwen/omni/upload-cache.json`, keyed by
+ * sha256 + model + endpoint scope) for the oss URL validity window, so a
+ * re-read of unchanged content skips both the store copy and the network
+ * transfer. Throws OmniDeliveryError / OmniTransportGuardError on failure;
+ * user aborts propagate untouched.
  */
 export async function processMediaForOmniDelivery(
   filePath: string,
@@ -280,16 +285,50 @@ export async function processMediaForOmniDelivery(
   }
 
   const store = new OmniObjectStore(config.storage.getQwenDir());
+  const cgc = config.getContentGeneratorConfig();
+  // Scope the cache to the endpoint credential: an oss:// URL minted for one
+  // (origin, apiKey) pair must never be served for another — switching
+  // accounts or endpoints yields URLs the new credential may not own. The
+  // fingerprint keeps raw key material out of the cache file.
+  const cacheScope = createHash('sha256')
+    .update(`${cgc.baseUrl ?? ''}|${cgc.apiKey ?? ''}`)
+    .digest('hex')
+    .slice(0, 16);
   const configuredTtl = config.getOmniUploadCacheTtlHours?.();
   const uploadCache = new OmniUploadCache(
     store.getOmniRootDir(),
     configuredTtl === undefined
       ? DEFAULT_UPLOAD_CACHE_TTL_HOURS
       : configuredTtl,
+    cacheScope,
   );
   // Lazy one-time hygiene scan (expired .part files, promotion orphans,
   // sampled object verification). Never throws.
   await runStartupRecoveryOnce(store, uploadCache);
+
+  // Cache lookup BEFORE store promotion: a hit means the server already
+  // holds these bytes for this model+endpoint, so neither the local copy
+  // nor the upload is needed (zoom_image reads the original path, not the
+  // store). Checking after putFile would pay a full-file copy per hit.
+  const model = config.getModel();
+  const cachedUrl = await uploadCache.get(sha256, model);
+  if (cachedUrl) {
+    debugLogger.debug(
+      `omni upload cache hit: sha256=${sha256.slice(0, 12)}… model=${model}`,
+    );
+    return {
+      fileUri: cachedUrl,
+      mimeType: recognized.detectedMimeType,
+      sha256,
+      recognized,
+      tokenEstimate,
+      // No new copy was made: the content is already known to the system
+      // (a prior delivery both stored and uploaded it).
+      deduped: true,
+      uploadCacheHit: true,
+    };
+  }
+
   const extension = extensionForMime(recognized.detectedMimeType);
   let objectPath: string;
   let deduped: boolean;
@@ -306,24 +345,6 @@ export async function processMediaForOmniDelivery(
     );
   }
 
-  const model = config.getModel();
-  const cachedUrl = await uploadCache.get(sha256, model);
-  if (cachedUrl) {
-    debugLogger.debug(
-      `omni upload cache hit: sha256=${sha256.slice(0, 12)}… model=${model}`,
-    );
-    return {
-      fileUri: cachedUrl,
-      mimeType: recognized.detectedMimeType,
-      sha256,
-      recognized,
-      tokenEstimate,
-      deduped,
-      uploadCacheHit: true,
-    };
-  }
-
-  const cgc = config.getContentGeneratorConfig();
   const uploader = new DashScopeUploader({
     apiKey: cgc.apiKey ?? '',
     baseUrl: cgc.baseUrl,

--- a/packages/core/src/omni/recovery.test.ts
+++ b/packages/core/src/omni/recovery.test.ts
@@ -372,5 +372,74 @@ describe('runStartupRecoveryOnce', () => {
         await fs.rm(outside, { recursive: true, force: true });
       }
     });
+
+    /** Build a full omni-shaped layout inside an external dir: victims in
+     * downloads/, in an objects/sha256 shard, and .tmp orphans — so if a
+     * root-level or intermediate-level symlink is followed, EVERY sweep
+     * finds deletable-looking targets. */
+    async function makeOmniShapedVictimTree(): Promise<{
+      outside: string;
+      victims: string[];
+    }> {
+      const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'omni-outside-'));
+      const old = new Date(Date.now() - 72 * 3600_000);
+      const downloads = path.join(outside, 'downloads');
+      const shard = path.join(outside, 'objects', 'sha256', 'aa');
+      await fs.mkdir(downloads, { recursive: true });
+      await fs.mkdir(shard, { recursive: true });
+      const victims = [
+        path.join(downloads, 'movie.mp4.part'),
+        path.join(shard, `${'a'.repeat(64)}.pdf`),
+        path.join(shard, '.tmp-orphan'),
+      ];
+      for (const p of victims) {
+        await fs.writeFile(p, 'external-bytes-recovery-must-not-touch');
+        await fs.utimes(p, old, old);
+      }
+      return { outside, victims };
+    }
+
+    it('a symlinked OMNI ROOT is never swept (intermediate components must be real)', async () => {
+      const { outside, victims } = await makeOmniShapedVictimTree();
+      try {
+        const root = store.getOmniRootDir();
+        await fs.rm(root, { recursive: true, force: true });
+        // The reviewer's probe: a repo ships `.qwen/omni` itself as a
+        // symlink; every per-directory guard lstats only the final
+        // component and would pass through this link.
+        await fs.symlink(outside, root);
+
+        await runStartupRecoveryOnce(store, undefined, {
+          sampleVerifyLimit: 100,
+        });
+
+        await expectAllSurvive(victims);
+        expect((await fs.lstat(root)).isSymbolicLink()).toBe(true);
+      } finally {
+        await fs.rm(outside, { recursive: true, force: true });
+      }
+    });
+
+    it('a symlinked objects/ INTERMEDIATE directory is never traversed', async () => {
+      const { outside, victims } = await makeOmniShapedVictimTree();
+      try {
+        // Link the `objects/` level (the parent of `objects/sha256`): the
+        // sha256-root guard lstats only `objects/sha256` — resolved through
+        // this link it IS a real directory, so only an explicit
+        // intermediate-chain check stops the traversal.
+        const objectsParent = path.join(store.getOmniRootDir(), 'objects');
+        await fs.rm(objectsParent, { recursive: true, force: true });
+        await fs.symlink(path.join(outside, 'objects'), objectsParent);
+
+        await runStartupRecoveryOnce(store, undefined, {
+          sampleVerifyLimit: 100,
+        });
+
+        await expectAllSurvive(victims);
+        expect((await fs.lstat(objectsParent)).isSymbolicLink()).toBe(true);
+      } finally {
+        await fs.rm(outside, { recursive: true, force: true });
+      }
+    });
   });
 });

--- a/packages/core/src/omni/recovery.test.ts
+++ b/packages/core/src/omni/recovery.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createHash } from 'node:crypto';
 import fs from 'node:fs/promises';
 import os from 'node:os';
@@ -27,18 +27,23 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  vi.useRealTimers();
   resetRecoveryLatchForTests();
   await fs.rm(qwenDir, { recursive: true, force: true });
 });
 
-async function putObject(content: string): Promise<{
+async function putObject(
+  content: string,
+  dir = qwenDir,
+  s = store,
+): Promise<{
   sha256: string;
   objectPath: string;
 }> {
-  const src = path.join(qwenDir, `src-${content.length}.bin`);
+  const src = path.join(dir, `src-${content.length}.bin`);
   await fs.writeFile(src, content);
   const sha256 = createHash('sha256').update(content).digest('hex');
-  const { objectPath } = await store.putFile(src, sha256, '.mp4');
+  const { objectPath } = await s.putFile(src, sha256, '.mp4');
   return { sha256, objectPath };
 }
 
@@ -57,6 +62,38 @@ describe('runStartupRecoveryOnce', () => {
 
     await expect(fs.access(oldPart)).rejects.toThrow();
     await expect(fs.access(newPart)).resolves.toBeUndefined();
+  });
+
+  it('.part cutoff boundary: just older than 48h removed, just younger kept', async () => {
+    const downloads = path.join(store.getOmniRootDir(), 'downloads');
+    await fs.mkdir(downloads, { recursive: true });
+    const justOlder = path.join(downloads, 'just-older.part');
+    const justYounger = path.join(downloads, 'just-younger.part');
+    await fs.writeFile(justOlder, 'x');
+    await fs.writeFile(justYounger, 'y');
+    // Straddle the retention cutoff by a minute either side — pins the
+    // comparison direction (mtime < cutoff → remove), not the exact value.
+    const older = new Date(Date.now() - 48 * 3600_000 - 60_000);
+    const younger = new Date(Date.now() - 48 * 3600_000 + 60_000);
+    await fs.utimes(justOlder, older, older);
+    await fs.utimes(justYounger, younger, younger);
+
+    await runStartupRecoveryOnce(store);
+
+    await expect(fs.access(justOlder)).rejects.toThrow();
+    await expect(fs.access(justYounger)).resolves.toBeUndefined();
+  });
+
+  it('keeps a DIRECTORY named like a .part (isFile guard)', async () => {
+    const downloads = path.join(store.getOmniRootDir(), 'downloads');
+    const dirPart = path.join(downloads, 'stale-dir.part');
+    await fs.mkdir(dirPart, { recursive: true });
+    const old = new Date(Date.now() - 72 * 3600_000);
+    await fs.utimes(dirPart, old, old);
+
+    await runStartupRecoveryOnce(store);
+
+    await expect(fs.access(dirPart)).resolves.toBeUndefined();
   });
 
   it('removes aged promotion .tmp orphans, keeps fresh ones (grace window)', async () => {
@@ -100,5 +137,107 @@ describe('runStartupRecoveryOnce', () => {
     await fs.writeFile(orphan, 'x');
     await runStartupRecoveryOnce(store);
     await expect(fs.access(orphan)).resolves.toBeUndefined();
+  });
+
+  it('latches per omni root: a second store with a different root still sweeps', async () => {
+    // Sweep the first root…
+    await runStartupRecoveryOnce(store);
+
+    // …then a second store with its OWN root must get its own scan (a
+    // process-global latch would silently skip it).
+    const qwenDir2 = await fs.mkdtemp(path.join(os.tmpdir(), 'omni-recov2-'));
+    try {
+      const store2 = new OmniObjectStore(qwenDir2);
+      await store2.ensureLayout();
+      const { objectPath } = await putObject('other-root', qwenDir2, store2);
+      const orphan = path.join(path.dirname(objectPath), '.tmp-orphan2');
+      await fs.writeFile(orphan, 'x');
+      const old = new Date(Date.now() - 2 * 3600_000);
+      await fs.utimes(orphan, old, old);
+
+      await runStartupRecoveryOnce(store2);
+
+      await expect(fs.access(orphan)).rejects.toThrow();
+    } finally {
+      await fs.rm(qwenDir2, { recursive: true, force: true });
+    }
+  });
+
+  it('verifies exactly `limit` objects per run and rotates coverage across days', async () => {
+    // 10 tiny objects, all corrupted: every verified object gets deleted,
+    // so deletions == verifications.
+    const objects: string[] = [];
+    for (let i = 0; i < 10; i++) {
+      const { objectPath } = await putObject(`stride-object-${i}`);
+      await fs.writeFile(objectPath, `tampered-${i}`);
+      objects.push(objectPath);
+    }
+    const missing = async () => {
+      const gone: string[] = [];
+      for (const p of objects) {
+        try {
+          await fs.access(p);
+        } catch {
+          gone.push(p);
+        }
+      }
+      return gone;
+    };
+
+    // Fake only Date: the verifier pipes streams, which need real timers.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2025-06-01T12:00:00Z'));
+    await runStartupRecoveryOnce(store, undefined, { sampleVerifyLimit: 3 });
+    const day1Deleted = await missing();
+    expect(day1Deleted).toHaveLength(3);
+
+    // Restore the deleted (still-corrupt) objects, advance one day, and
+    // reset the latch: the day-seeded stride must pick DIFFERENT objects.
+    for (const p of day1Deleted) await fs.writeFile(p, 'tampered-again');
+    resetRecoveryLatchForTests();
+    vi.setSystemTime(new Date('2025-06-02T12:00:00Z'));
+    await runStartupRecoveryOnce(store, undefined, { sampleVerifyLimit: 3 });
+    const day2Deleted = await missing();
+    expect(day2Deleted).toHaveLength(3);
+    for (const p of day2Deleted) {
+      expect(day1Deleted).not.toContain(p);
+    }
+  });
+
+  it('skips verification of objects above the size budget (object AND cache entry survive)', async () => {
+    const content = 'corrupt-but-too-big-to-hash';
+    const { sha256, objectPath } = await putObject(content);
+    await fs.writeFile(objectPath, 'tampered-large-object-bytes');
+    const cache = new OmniUploadCache(store.getOmniRootDir());
+    await cache.put(sha256, 'm', 'oss://bucket/live');
+
+    await runStartupRecoveryOnce(store, cache, {
+      sampleVerifyLimit: 3,
+      sampleVerifyMaxBytes: 4, // everything is "too big"
+    });
+
+    await expect(fs.access(objectPath)).resolves.toBeUndefined();
+    expect(await cache.get(sha256, 'm')).toBe('oss://bucket/live');
+  });
+
+  it('never throws — even when getOmniRootDir() itself throws, and the latch is not poisoned', async () => {
+    const throwingStore = {
+      getOmniRootDir(): string {
+        throw new Error('boom');
+      },
+      getObjectsDir(): string {
+        throw new Error('boom');
+      },
+    } as unknown as OmniObjectStore;
+
+    await expect(
+      runStartupRecoveryOnce(throwingStore),
+    ).resolves.toBeUndefined();
+    // A second call must also resolve (no poisoned/cached rejection).
+    await expect(
+      runStartupRecoveryOnce(throwingStore),
+    ).resolves.toBeUndefined();
+    // And a healthy store afterwards still works.
+    await expect(runStartupRecoveryOnce(store)).resolves.toBeUndefined();
   });
 });

--- a/packages/core/src/omni/recovery.test.ts
+++ b/packages/core/src/omni/recovery.test.ts
@@ -240,4 +240,137 @@ describe('runStartupRecoveryOnce', () => {
     // And a healthy store afterwards still works.
     await expect(runStartupRecoveryOnce(store)).resolves.toBeUndefined();
   });
+
+  describe('symlink containment (recovery must never leave the omni root)', () => {
+    /** External dir with a victim file whose NAME makes recovery want to
+     * delete it through every code path: hash-mismatched "object", expired
+     * ".part", and aged ".tmp-*". Returns the paths for survival checks. */
+    async function makeVictims(): Promise<{
+      outside: string;
+      victims: string[];
+    }> {
+      const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'omni-outside-'));
+      const old = new Date(Date.now() - 72 * 3600_000);
+      // Name shaped like a store object (64-hex sha) whose hash will NOT
+      // match its content → the sampler would delete it if it reached it.
+      const fakeObject = path.join(outside, `${'a'.repeat(64)}.mp4`);
+      const expiredPart = path.join(outside, 'victim.part');
+      const agedTmp = path.join(outside, '.tmp-victim');
+      for (const p of [fakeObject, expiredPart, agedTmp]) {
+        await fs.writeFile(p, 'external-bytes-recovery-must-not-touch');
+        await fs.utimes(p, old, old);
+      }
+      return { outside, victims: [fakeObject, expiredPart, agedTmp] };
+    }
+
+    async function expectAllSurvive(victims: string[]): Promise<void> {
+      for (const p of victims) {
+        await expect(fs.access(p)).resolves.toBeUndefined();
+        await expect(fs.readFile(p, 'utf8')).resolves.toBe(
+          'external-bytes-recovery-must-not-touch',
+        );
+      }
+    }
+
+    it('a symlinked SHARD under objects/sha256 is never traversed', async () => {
+      const { outside, victims } = await makeVictims();
+      try {
+        const objectsDir = store.getObjectsDir();
+        await fs.mkdir(objectsDir, { recursive: true });
+        // The reviewer's repro: shard name → symlink escaping the store.
+        await fs.symlink(outside, path.join(objectsDir, 'aa'));
+
+        await runStartupRecoveryOnce(store, undefined, {
+          sampleVerifyLimit: 100,
+        });
+
+        await expectAllSurvive(victims);
+      } finally {
+        await fs.rm(outside, { recursive: true, force: true });
+      }
+    });
+
+    it('a symlinked downloads/ directory is never swept', async () => {
+      const { outside, victims } = await makeVictims();
+      try {
+        const downloads = path.join(store.getOmniRootDir(), 'downloads');
+        await fs.rm(downloads, { recursive: true, force: true });
+        await fs.symlink(outside, downloads);
+
+        await runStartupRecoveryOnce(store);
+
+        await expectAllSurvive(victims);
+        // The symlink itself must also survive (nothing rm'd through it).
+        expect((await fs.lstat(downloads)).isSymbolicLink()).toBe(true);
+      } finally {
+        await fs.rm(outside, { recursive: true, force: true });
+      }
+    });
+
+    it('a symlinked objects/sha256 ROOT is never traversed', async () => {
+      const { outside, victims } = await makeVictims();
+      try {
+        // Give the external dir a shard-shaped inner layout so a traversal
+        // WOULD find the victims if the root guard were missing.
+        const innerShard = path.join(outside, 'aa');
+        await fs.mkdir(innerShard);
+        const old = new Date(Date.now() - 72 * 3600_000);
+        const innerNames: string[] = [];
+        for (const name of await fs.readdir(outside)) {
+          const src = path.join(outside, name);
+          if ((await fs.lstat(src)).isFile()) {
+            await fs.copyFile(src, path.join(innerShard, name));
+            await fs.utimes(path.join(innerShard, name), old, old);
+            innerNames.push(name);
+          }
+        }
+        expect(innerNames.length).toBeGreaterThan(0);
+        const objectsDir = store.getObjectsDir();
+        await fs.rm(objectsDir, { recursive: true, force: true });
+        await fs.symlink(outside, objectsDir);
+
+        await runStartupRecoveryOnce(store, undefined, {
+          sampleVerifyLimit: 100,
+        });
+
+        await expectAllSurvive(victims);
+        // Pin the EXACT surviving set — reading back "whatever remains"
+        // would pass vacuously if the sweep had deleted entries.
+        for (const name of innerNames) {
+          await expect(
+            fs.readFile(path.join(innerShard, name), 'utf8'),
+          ).resolves.toBe('external-bytes-recovery-must-not-touch');
+        }
+      } finally {
+        await fs.rm(outside, { recursive: true, force: true });
+      }
+    });
+
+    it('a symlinked CANDIDATE inside a real shard is never hashed or deleted', async () => {
+      const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'omni-outside-'));
+      try {
+        const victim = path.join(outside, 'victim.bin');
+        await fs.writeFile(victim, 'external-candidate-bytes');
+        // Real object pins the shard dir; the symlink poses as a second
+        // object whose name can never hash-match the external content.
+        const { objectPath } = await putObject('legit-neighbor');
+        const shard = path.dirname(objectPath);
+        const link = path.join(shard, `${'b'.repeat(64)}.mp4`);
+        await fs.symlink(victim, link);
+
+        await runStartupRecoveryOnce(store, undefined, {
+          sampleVerifyLimit: 100,
+        });
+
+        // External target intact, and the link itself not removed either
+        // (a hash of external bytes must never have happened).
+        await expect(fs.readFile(victim, 'utf8')).resolves.toBe(
+          'external-candidate-bytes',
+        );
+        expect((await fs.lstat(link)).isSymbolicLink()).toBe(true);
+      } finally {
+        await fs.rm(outside, { recursive: true, force: true });
+      }
+    });
+  });
 });

--- a/packages/core/src/omni/recovery.test.ts
+++ b/packages/core/src/omni/recovery.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { OmniObjectStore } from './storage.js';
+import { OmniUploadCache } from './upload-cache.js';
+import {
+  runStartupRecoveryOnce,
+  resetRecoveryLatchForTests,
+} from './recovery.js';
+
+let qwenDir: string;
+let store: OmniObjectStore;
+
+beforeEach(async () => {
+  resetRecoveryLatchForTests();
+  qwenDir = await fs.mkdtemp(path.join(os.tmpdir(), 'omni-recovery-'));
+  store = new OmniObjectStore(qwenDir);
+  await store.ensureLayout();
+});
+
+afterEach(async () => {
+  resetRecoveryLatchForTests();
+  await fs.rm(qwenDir, { recursive: true, force: true });
+});
+
+async function putObject(content: string): Promise<{
+  sha256: string;
+  objectPath: string;
+}> {
+  const src = path.join(qwenDir, `src-${content.length}.bin`);
+  await fs.writeFile(src, content);
+  const sha256 = createHash('sha256').update(content).digest('hex');
+  const { objectPath } = await store.putFile(src, sha256, '.mp4');
+  return { sha256, objectPath };
+}
+
+describe('runStartupRecoveryOnce', () => {
+  it('removes expired .part files, keeps recent ones', async () => {
+    const downloads = path.join(store.getOmniRootDir(), 'downloads');
+    await fs.mkdir(downloads, { recursive: true });
+    const oldPart = path.join(downloads, 'old.part');
+    const newPart = path.join(downloads, 'new.part');
+    await fs.writeFile(oldPart, 'x');
+    await fs.writeFile(newPart, 'y');
+    const old = new Date(Date.now() - 72 * 3600_000);
+    await fs.utimes(oldPart, old, old);
+
+    await runStartupRecoveryOnce(store);
+
+    await expect(fs.access(oldPart)).rejects.toThrow();
+    await expect(fs.access(newPart)).resolves.toBeUndefined();
+  });
+
+  it('removes aged promotion .tmp orphans, keeps fresh ones (grace window)', async () => {
+    const { objectPath } = await putObject('real-object');
+    const shard = path.dirname(objectPath);
+    const aged = path.join(shard, '.tmp-deadbeef');
+    const fresh = path.join(shard, '.tmp-inflight');
+    await fs.writeFile(aged, 'partial');
+    await fs.writeFile(fresh, 'partial');
+    const old = new Date(Date.now() - 2 * 3600_000);
+    await fs.utimes(aged, old, old);
+
+    await runStartupRecoveryOnce(store);
+
+    await expect(fs.access(aged)).rejects.toThrow();
+    // A young .tmp may be another process's in-flight promotion.
+    await expect(fs.access(fresh)).resolves.toBeUndefined();
+    await expect(fs.access(objectPath)).resolves.toBeUndefined();
+  });
+
+  it('deletes corrupt objects and cascades their cache entries', async () => {
+    const { sha256, objectPath } = await putObject('will-corrupt');
+    await fs.writeFile(objectPath, 'tampered-bytes'); // break hash==name
+    const cache = new OmniUploadCache(store.getOmniRootDir());
+    await cache.put(sha256, 'm', 'oss://bucket/dead');
+
+    await runStartupRecoveryOnce(store, cache);
+
+    await expect(fs.access(objectPath)).rejects.toThrow();
+    expect(await cache.get(sha256, 'm')).toBeNull();
+  });
+
+  it('keeps intact objects and runs only once per process', async () => {
+    const { objectPath } = await putObject('intact');
+    await runStartupRecoveryOnce(store);
+    await expect(fs.access(objectPath)).resolves.toBeUndefined();
+
+    // Second call must be the same latched promise (no re-scan): plant an
+    // orphan after the first run — it must survive because the latch holds.
+    const orphan = path.join(path.dirname(objectPath), '.tmp-late');
+    await fs.writeFile(orphan, 'x');
+    await runStartupRecoveryOnce(store);
+    await expect(fs.access(orphan)).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/omni/recovery.ts
+++ b/packages/core/src/omni/recovery.ts
@@ -15,7 +15,11 @@ import type { OmniUploadCache } from './upload-cache.js';
 
 const debugLogger = createDebugLogger('omni:recovery');
 
-/** Resume window for interrupted downloads (storage design §6.1). */
+/** How long crash-orphaned `downloads/*.part` files are retained before
+ * the sweep removes them. Nothing ever resumes a .part — staging names
+ * are random per attempt and there is no Range/resume logic — so this is
+ * purely a debugging window for inspecting what an interrupted download
+ * left behind (storage design §6.1). */
 const PART_RETENTION_MS = 48 * 3600_000;
 /** Sampled integrity verification budget per recovery run. */
 const SAMPLE_VERIFY_LIMIT = 3;
@@ -28,11 +32,21 @@ const SAMPLE_VERIFY_MAX_BYTES = 64 * 1024 * 1024;
  * fail that process's rename. Older survivors are crash leftovers. */
 const TMP_GRACE_MS = 3600_000;
 
-let recoveryOnce: Promise<void> | undefined;
+/** Tunables for {@link runStartupRecoveryOnce}; production callers use
+ * the defaults, tests inject small values. */
+export interface StartupRecoveryOptions {
+  sampleVerifyLimit?: number;
+  sampleVerifyMaxBytes?: number;
+}
+
+/** One latch per omni root: distinct stores in one process (multi-project
+ * setups, tests) each get their own scan instead of the first root's scan
+ * suppressing all others. */
+const recoveryOnce = new Map<string, Promise<void>>();
 
 /** Test-only: allow re-running recovery within one process. */
 export function resetRecoveryLatchForTests(): void {
-  recoveryOnce = undefined;
+  recoveryOnce.clear();
 }
 
 async function sweepDownloads(downloadsDir: string): Promise<void> {
@@ -97,6 +111,7 @@ async function sampleVerifyObjects(
   objectsDir: string,
   uploadCache: OmniUploadCache | undefined,
   limit: number,
+  maxBytes: number,
 ): Promise<void> {
   const candidates: string[] = [];
   let shards: string[];
@@ -116,20 +131,27 @@ async function sampleVerifyObjects(
       if (!name.startsWith('.')) candidates.push(path.join(shard, name));
     }
   }
-  // Day-seeded stride sampling: coverage rotates across runs (a fixed
-  // offset would verify the same objects forever). Cheap corruption
-  // detection, not an audit.
-  const stride = Math.max(1, Math.floor(candidates.length / limit));
-  const seed = Math.floor(Date.now() / 86_400_000) % stride;
-  const sample = candidates
-    .filter((_, i) => i % stride === seed)
-    .slice(0, limit);
-  for (const rel of sample) {
+  if (candidates.length === 0 || limit <= 0) return;
+  // Day-seeded stride sampling over a SORTED candidate list (readdir order
+  // is filesystem-dependent): pick (seed + k*stride) % N so coverage
+  // rotates across days and wraps — a filter+slice would leave a
+  // permanent blind spot at the tail. Cheap corruption detection, not an
+  // audit.
+  candidates.sort();
+  const n = candidates.length;
+  const stride = Math.max(1, Math.floor(n / limit));
+  const seed = Math.floor(Date.now() / 86_400_000) % n;
+  const picked = new Set<number>();
+  for (let k = 0; k < limit && picked.size < n; k++) {
+    picked.add((seed + k * stride) % n);
+  }
+  for (const i of picked) {
+    const rel = candidates[i]!;
     const full = path.join(objectsDir, rel);
     const expected = path.basename(rel).split('.')[0]!;
     try {
       const st = await fs.lstat(full);
-      if (st.size > SAMPLE_VERIFY_MAX_BYTES) continue;
+      if (st.size > maxBytes) continue;
       const hash = createHash('sha256');
       await pipeline(createReadStream(full), hash);
       if (hash.digest('hex') !== expected) {
@@ -146,33 +168,51 @@ async function sampleVerifyObjects(
 }
 
 /**
- * One-time-per-process recovery scan (storage design §6.1), run lazily the
- * first time the omni pipeline is touched — zero cost when omni is unused.
+ * One-time-per-process-per-root recovery scan (storage design §6.1), run
+ * lazily the first time the omni pipeline is touched — zero cost when
+ * omni is unused.
  *
- * 1. expired `downloads/*.part` (resume window 48h) are removed;
+ * 1. crash-orphaned `downloads/*.part` older than the 48h debugging
+ *    retention window are removed;
  * 2. `objects/…/.tmp-*` promotion orphans are removed (crash leftovers);
  * 3. a small sample of objects is hash-verified; corrupt objects are
  *    deleted with their upload-cache entries cascaded.
  *
- * Never throws: recovery is hygiene, not a gate.
+ * Never throws: recovery is hygiene, not a gate. That covers the latch
+ * key lookup too — a store whose getOmniRootDir() throws yields a
+ * resolved promise and does not poison the latch for later calls.
  */
 export function runStartupRecoveryOnce(
   store: OmniObjectStore,
   uploadCache?: OmniUploadCache,
+  options?: StartupRecoveryOptions,
 ): Promise<void> {
-  recoveryOnce ??= (async () => {
-    const root = store.getOmniRootDir();
-    await sweepDownloads(path.join(root, 'downloads'));
-    await sweepTmpFiles(store.getObjectsDir());
-    await sampleVerifyObjects(
-      store.getObjectsDir(),
-      uploadCache,
-      SAMPLE_VERIFY_LIMIT,
-    );
-  })().catch((err) => {
+  let root: string;
+  try {
+    root = store.getOmniRootDir();
+  } catch (err) {
     debugLogger.debug(
       `recovery scan failed (ignored): ${err instanceof Error ? err.message : err}`,
     );
-  });
-  return recoveryOnce;
+    return Promise.resolve();
+  }
+  let scan = recoveryOnce.get(root);
+  if (!scan) {
+    scan = (async () => {
+      await sweepDownloads(path.join(root, 'downloads'));
+      await sweepTmpFiles(store.getObjectsDir());
+      await sampleVerifyObjects(
+        store.getObjectsDir(),
+        uploadCache,
+        options?.sampleVerifyLimit ?? SAMPLE_VERIFY_LIMIT,
+        options?.sampleVerifyMaxBytes ?? SAMPLE_VERIFY_MAX_BYTES,
+      );
+    })().catch((err) => {
+      debugLogger.debug(
+        `recovery scan failed (ignored): ${err instanceof Error ? err.message : err}`,
+      );
+    });
+    recoveryOnce.set(root, scan);
+  }
+  return scan;
 }

--- a/packages/core/src/omni/recovery.ts
+++ b/packages/core/src/omni/recovery.ts
@@ -49,7 +49,25 @@ export function resetRecoveryLatchForTests(): void {
   recoveryOnce.clear();
 }
 
+/**
+ * True only for a REAL directory (lstat, so a symlink to a directory is
+ * rejected). Recovery deletes files under the paths it traverses, so every
+ * directory it descends into — downloads/, the objects root, and each
+ * shard — must be a genuine directory inside the omni root: a symlinked
+ * intermediate directory would redirect readdir+rm at arbitrary paths
+ * outside `.qwen/omni`. The store's own symlink guard (putFile) runs later
+ * and does not protect this pre-delivery scan.
+ */
+async function isRealDirectory(p: string): Promise<boolean> {
+  try {
+    return (await fs.lstat(p)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
 async function sweepDownloads(downloadsDir: string): Promise<void> {
+  if (!(await isRealDirectory(downloadsDir))) return;
   let names: string[];
   try {
     names = await fs.readdir(downloadsDir);
@@ -74,6 +92,7 @@ async function sweepDownloads(downloadsDir: string): Promise<void> {
 }
 
 async function sweepTmpFiles(objectsDir: string): Promise<void> {
+  if (!(await isRealDirectory(objectsDir))) return;
   let shards: string[];
   try {
     shards = await fs.readdir(objectsDir);
@@ -82,6 +101,7 @@ async function sweepTmpFiles(objectsDir: string): Promise<void> {
   }
   for (const shard of shards) {
     const shardDir = path.join(objectsDir, shard);
+    if (!(await isRealDirectory(shardDir))) continue;
     let names: string[];
     try {
       names = await fs.readdir(shardDir);
@@ -114,6 +134,7 @@ async function sampleVerifyObjects(
   maxBytes: number,
 ): Promise<void> {
   const candidates: string[] = [];
+  if (!(await isRealDirectory(objectsDir))) return;
   let shards: string[];
   try {
     shards = await fs.readdir(objectsDir);
@@ -121,6 +142,9 @@ async function sampleVerifyObjects(
     return;
   }
   for (const shard of shards) {
+    // Symlinked shard = redirection outside the store; skip it entirely so
+    // its "candidates" (external files!) never enter the sample pool.
+    if (!(await isRealDirectory(path.join(objectsDir, shard)))) continue;
     let names: string[] = [];
     try {
       names = await fs.readdir(path.join(objectsDir, shard));
@@ -151,6 +175,11 @@ async function sampleVerifyObjects(
     const expected = path.basename(rel).split('.')[0]!;
     try {
       const st = await fs.lstat(full);
+      // Only regular files are store objects: a symlinked candidate would
+      // make the hash read — and the mismatch-delete below act on — a file
+      // outside the omni root. (rm on the symlink itself would only unlink
+      // the link, but the hash must not read external content either.)
+      if (!st.isFile()) continue;
       if (st.size > maxBytes) continue;
       const hash = createHash('sha256');
       await pipeline(createReadStream(full), hash);

--- a/packages/core/src/omni/recovery.ts
+++ b/packages/core/src/omni/recovery.ts
@@ -1,0 +1,178 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { createDebugLogger } from '../utils/debugLogger.js';
+import type { OmniObjectStore } from './storage.js';
+import type { OmniUploadCache } from './upload-cache.js';
+
+const debugLogger = createDebugLogger('omni:recovery');
+
+/** Resume window for interrupted downloads (storage design §6.1). */
+const PART_RETENTION_MS = 48 * 3600_000;
+/** Sampled integrity verification budget per recovery run. */
+const SAMPLE_VERIFY_LIMIT = 3;
+/** Skip sampled verification for objects above this size — the scan runs
+ * inline before the session's first delivery, and hashing multi-GiB
+ * videos there would stall the user for the sake of hygiene. */
+const SAMPLE_VERIFY_MAX_BYTES = 64 * 1024 * 1024;
+/** Grace window for promotion temp files: a .tmp younger than this may
+ * belong to a promotion in flight in ANOTHER process — deleting it would
+ * fail that process's rename. Older survivors are crash leftovers. */
+const TMP_GRACE_MS = 3600_000;
+
+let recoveryOnce: Promise<void> | undefined;
+
+/** Test-only: allow re-running recovery within one process. */
+export function resetRecoveryLatchForTests(): void {
+  recoveryOnce = undefined;
+}
+
+async function sweepDownloads(downloadsDir: string): Promise<void> {
+  let names: string[];
+  try {
+    names = await fs.readdir(downloadsDir);
+  } catch {
+    return;
+  }
+  const cutoff = Date.now() - PART_RETENTION_MS;
+  for (const name of names) {
+    if (!name.endsWith('.part')) continue;
+    const p = path.join(downloadsDir, name);
+    try {
+      const st = await fs.lstat(p);
+      if (!st.isFile()) continue;
+      if (st.mtimeMs < cutoff) {
+        await fs.rm(p, { force: true });
+        debugLogger.debug(`recovery: removed expired download ${name}`);
+      }
+    } catch {
+      // Best-effort sweep.
+    }
+  }
+}
+
+async function sweepTmpFiles(objectsDir: string): Promise<void> {
+  let shards: string[];
+  try {
+    shards = await fs.readdir(objectsDir);
+  } catch {
+    return;
+  }
+  for (const shard of shards) {
+    const shardDir = path.join(objectsDir, shard);
+    let names: string[];
+    try {
+      names = await fs.readdir(shardDir);
+    } catch {
+      continue;
+    }
+    for (const name of names) {
+      if (!name.startsWith('.tmp-')) continue;
+      const p = path.join(shardDir, name);
+      try {
+        // Same-process writers clean up on every soft failure, so an old
+        // survivor means a crash — but a YOUNG .tmp may be another
+        // process's in-flight promotion; deleting it would fail that
+        // rename. Grace window keeps the sweep multi-process safe.
+        const st = await fs.lstat(p);
+        if (Date.now() - st.mtimeMs < TMP_GRACE_MS) continue;
+        await fs.rm(p, { force: true });
+        debugLogger.debug(`recovery: removed orphan temp ${shard}/${name}`);
+      } catch {
+        // Best-effort sweep.
+      }
+    }
+  }
+}
+
+async function sampleVerifyObjects(
+  objectsDir: string,
+  uploadCache: OmniUploadCache | undefined,
+  limit: number,
+): Promise<void> {
+  const candidates: string[] = [];
+  let shards: string[];
+  try {
+    shards = await fs.readdir(objectsDir);
+  } catch {
+    return;
+  }
+  for (const shard of shards) {
+    let names: string[] = [];
+    try {
+      names = await fs.readdir(path.join(objectsDir, shard));
+    } catch {
+      continue;
+    }
+    for (const name of names) {
+      if (!name.startsWith('.')) candidates.push(path.join(shard, name));
+    }
+  }
+  // Day-seeded stride sampling: coverage rotates across runs (a fixed
+  // offset would verify the same objects forever). Cheap corruption
+  // detection, not an audit.
+  const stride = Math.max(1, Math.floor(candidates.length / limit));
+  const seed = Math.floor(Date.now() / 86_400_000) % stride;
+  const sample = candidates
+    .filter((_, i) => i % stride === seed)
+    .slice(0, limit);
+  for (const rel of sample) {
+    const full = path.join(objectsDir, rel);
+    const expected = path.basename(rel).split('.')[0]!;
+    try {
+      const st = await fs.lstat(full);
+      if (st.size > SAMPLE_VERIFY_MAX_BYTES) continue;
+      const hash = createHash('sha256');
+      await pipeline(createReadStream(full), hash);
+      if (hash.digest('hex') !== expected) {
+        await fs.rm(full, { force: true });
+        await uploadCache?.removeBySha256(expected);
+        debugLogger.debug(
+          `recovery: removed corrupt object ${rel} (hash mismatch)`,
+        );
+      }
+    } catch {
+      // Unreadable object: leave it; the read path fails closed anyway.
+    }
+  }
+}
+
+/**
+ * One-time-per-process recovery scan (storage design §6.1), run lazily the
+ * first time the omni pipeline is touched — zero cost when omni is unused.
+ *
+ * 1. expired `downloads/*.part` (resume window 48h) are removed;
+ * 2. `objects/…/.tmp-*` promotion orphans are removed (crash leftovers);
+ * 3. a small sample of objects is hash-verified; corrupt objects are
+ *    deleted with their upload-cache entries cascaded.
+ *
+ * Never throws: recovery is hygiene, not a gate.
+ */
+export function runStartupRecoveryOnce(
+  store: OmniObjectStore,
+  uploadCache?: OmniUploadCache,
+): Promise<void> {
+  recoveryOnce ??= (async () => {
+    const root = store.getOmniRootDir();
+    await sweepDownloads(path.join(root, 'downloads'));
+    await sweepTmpFiles(store.getObjectsDir());
+    await sampleVerifyObjects(
+      store.getObjectsDir(),
+      uploadCache,
+      SAMPLE_VERIFY_LIMIT,
+    );
+  })().catch((err) => {
+    debugLogger.debug(
+      `recovery scan failed (ignored): ${err instanceof Error ? err.message : err}`,
+    );
+  });
+  return recoveryOnce;
+}

--- a/packages/core/src/omni/recovery.ts
+++ b/packages/core/src/omni/recovery.ts
@@ -228,7 +228,16 @@ export function runStartupRecoveryOnce(
   let scan = recoveryOnce.get(root);
   if (!scan) {
     scan = (async () => {
+      // The per-directory guards below lstat only the FINAL path component
+      // of each directory they enter — every intermediate component is
+      // still followed. Verify the shared prefix chain up front: a symlink
+      // planted at the omni root itself, or at the `objects/` level above
+      // `objects/sha256`, would otherwise redirect every sweep outside the
+      // managed tree. (An absent directory fails the check too, which is
+      // fine — there is nothing to sweep beneath it.)
+      if (!(await isRealDirectory(root))) return;
       await sweepDownloads(path.join(root, 'downloads'));
+      if (!(await isRealDirectory(path.join(root, 'objects')))) return;
       await sweepTmpFiles(store.getObjectsDir());
       await sampleVerifyObjects(
         store.getObjectsDir(),

--- a/packages/core/src/omni/upload-cache.test.ts
+++ b/packages/core/src/omni/upload-cache.test.ts
@@ -17,10 +17,25 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  // Restore permissions first so cleanup can proceed after chmod tests.
+  await fs.chmod(root, 0o700).catch(() => {});
+  await fs.chmod(path.join(root, 'upload-cache.json'), 0o600).catch(() => {});
   await fs.rm(root, { recursive: true, force: true });
 });
 
 const SHA = 'a'.repeat(64);
+
+// chmod-based denial tests are meaningless on Windows and as root (root
+// bypasses file permission bits).
+const canDropPermissions =
+  process.platform !== 'win32' &&
+  (typeof process.getuid !== 'function' || process.getuid() !== 0);
+
+async function listCorruptBackups(): Promise<string[]> {
+  return (await fs.readdir(root)).filter((n) =>
+    n.startsWith('upload-cache.json.corrupt-'),
+  );
+}
 
 describe('OmniUploadCache', () => {
   it('round-trips an entry and persists across instances', async () => {
@@ -40,20 +55,30 @@ describe('OmniUploadCache', () => {
     expect(await cache.get(SHA, 'model-b')).toBeNull();
   });
 
+  it('keys by scope — a different scope is a miss, same scope hits', async () => {
+    const cacheA = new OmniUploadCache(root, 47, 'scope-a');
+    const cacheB = new OmniUploadCache(root, 47, 'scope-b');
+    await cacheA.put(SHA, 'm', 'oss://bucket/a');
+    expect(await cacheB.get(SHA, 'm')).toBeNull();
+    // A separate instance with the SAME scope shares the entry.
+    const cacheA2 = new OmniUploadCache(root, 47, 'scope-a');
+    expect(await cacheA2.get(SHA, 'm')).toBe('oss://bucket/a');
+  });
+
   it('expired entries are misses and are pruned lazily', async () => {
     const cache = new OmniUploadCache(root);
     await cache.put(SHA, 'm', 'oss://bucket/x');
     // Rewrite the file with an expired timestamp.
     const file = path.join(root, 'upload-cache.json');
     const data = JSON.parse(await fs.readFile(file, 'utf8'));
-    data.entries[`${SHA}|m`].expiresAt = new Date(
+    data.entries[`${SHA}|m|`].expiresAt = new Date(
       Date.now() - 1000,
     ).toISOString();
     await fs.writeFile(file, JSON.stringify(data));
 
     expect(await cache.get(SHA, 'm')).toBeNull();
     const after = JSON.parse(await fs.readFile(file, 'utf8'));
-    expect(after.entries[`${SHA}|m`]).toBeUndefined(); // pruned
+    expect(after.entries[`${SHA}|m|`]).toBeUndefined(); // pruned
   });
 
   it('invalidateByUrl drops every entry with that URL', async () => {
@@ -67,6 +92,17 @@ describe('OmniUploadCache', () => {
     expect(await cache.get('b'.repeat(64), 'm1')).toBe('oss://bucket/other');
   });
 
+  it('invalidateByUrl works even with ttlHours 0 (clears pre-disable entries)', async () => {
+    // Entries persisted while the cache was enabled…
+    const enabled = new OmniUploadCache(root);
+    await enabled.put(SHA, 'm', 'oss://bucket/stale');
+    // …must still be clearable after the user disables the cache: the
+    // server-side invalidation cascade may run for ttl-0 users too.
+    const disabled = new OmniUploadCache(root, 0);
+    await disabled.invalidateByUrl('oss://bucket/stale');
+    expect(await enabled.get(SHA, 'm')).toBeNull();
+  });
+
   it('removeBySha256 cascades all models for the object', async () => {
     const cache = new OmniUploadCache(root);
     await cache.put(SHA, 'm1', 'oss://bucket/1');
@@ -76,6 +112,16 @@ describe('OmniUploadCache', () => {
     expect(await cache.get(SHA, 'm2')).toBeNull();
   });
 
+  it('removeBySha256 cascades across scopes (corrupt object is corrupt everywhere)', async () => {
+    const cacheA = new OmniUploadCache(root, 47, 'scope-a');
+    const cacheB = new OmniUploadCache(root, 47, 'scope-b');
+    await cacheA.put(SHA, 'm', 'oss://bucket/a');
+    await cacheB.put(SHA, 'm', 'oss://bucket/b');
+    await cacheA.removeBySha256(SHA);
+    expect(await cacheA.get(SHA, 'm')).toBeNull();
+    expect(await cacheB.get(SHA, 'm')).toBeNull();
+  });
+
   it('backs up a corrupt cache file and starts fresh', async () => {
     const file = path.join(root, 'upload-cache.json');
     await fs.writeFile(file, 'not json at all {{{');
@@ -83,18 +129,67 @@ describe('OmniUploadCache', () => {
     expect(await cache.get(SHA, 'm')).toBeNull();
     await cache.put(SHA, 'm', 'oss://bucket/fresh');
     expect(await cache.get(SHA, 'm')).toBe('oss://bucket/fresh');
-    const names = await fs.readdir(root);
-    expect(names.some((n) => n.startsWith('upload-cache.json.corrupt-'))).toBe(
-      true,
-    );
+    expect(await listCorruptBackups()).not.toHaveLength(0);
   });
+
+  it('treats entries: null as corrupt (backup + rebuild, no TypeError)', async () => {
+    const file = path.join(root, 'upload-cache.json');
+    await fs.writeFile(file, '{"version":1,"entries":null}');
+    const cache = new OmniUploadCache(root);
+    expect(await cache.get(SHA, 'm')).toBeNull();
+    expect(await listCorruptBackups()).not.toHaveLength(0);
+  });
+
+  it('treats entries as array as corrupt (backup + rebuild)', async () => {
+    const file = path.join(root, 'upload-cache.json');
+    await fs.writeFile(file, '{"version":1,"entries":[]}');
+    const cache = new OmniUploadCache(root);
+    expect(await cache.get(SHA, 'm')).toBeNull();
+    expect(await listCorruptBackups()).not.toHaveLength(0);
+  });
+
+  it('keeps at most 2 .corrupt-* backups', async () => {
+    const file = path.join(root, 'upload-cache.json');
+    const cache = new OmniUploadCache(root);
+    for (let i = 0; i < 3; i++) {
+      await fs.writeFile(file, `corrupt #${i} {{{`);
+      expect(await cache.get(SHA, 'm')).toBeNull();
+      // Backup names are Date.now()-stamped; keep them distinct.
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    const backups = await listCorruptBackups();
+    expect(backups.length).toBeGreaterThan(0);
+    expect(backups.length).toBeLessThanOrEqual(2);
+  });
+
+  it.runIf(canDropPermissions)(
+    'a transient read failure must not wipe previously persisted entries',
+    async () => {
+      const cache = new OmniUploadCache(root);
+      await cache.put(SHA, 'm', 'oss://bucket/precious');
+      const file = path.join(root, 'upload-cache.json');
+      const before = await fs.readFile(file, 'utf8');
+
+      await fs.chmod(file, 0o000); // simulate EACCES on read
+      // put must become a no-op (NOT "empty cache + save one entry").
+      await cache.put('b'.repeat(64), 'm', 'oss://bucket/new');
+      // get during the failure window is a miss, not a throw.
+      expect(await cache.get(SHA, 'm')).toBeNull();
+      await fs.chmod(file, 0o600);
+
+      // Original entries survived untouched.
+      expect(await fs.readFile(file, 'utf8')).toBe(before);
+      expect(await cache.get(SHA, 'm')).toBe('oss://bucket/precious');
+      expect(await cache.get('b'.repeat(64), 'm')).toBeNull();
+    },
+  );
 
   it('treats malformed expiresAt as expired (never immortal)', async () => {
     const cache = new OmniUploadCache(root);
     await cache.put(SHA, 'm', 'oss://bucket/x');
     const file = path.join(root, 'upload-cache.json');
     const data = JSON.parse(await fs.readFile(file, 'utf8'));
-    data.entries[`${SHA}|m`].expiresAt = 'not-a-date';
+    data.entries[`${SHA}|m|`].expiresAt = 'not-a-date';
     await fs.writeFile(file, JSON.stringify(data));
     expect(await cache.get(SHA, 'm')).toBeNull();
   });
@@ -111,6 +206,32 @@ describe('OmniUploadCache', () => {
     expect(await cache.get('c'.repeat(64), 'm')).toBe('oss://bucket/c');
   });
 
+  it('serializes concurrent puts ACROSS instances on the same root', async () => {
+    // Cache instances are constructed per delivery; the serializer must
+    // live at file scope, not instance scope, or concurrent deliveries
+    // would drop each other's entries via load-modify-save races.
+    const cache1 = new OmniUploadCache(root);
+    const cache2 = new OmniUploadCache(root);
+    await Promise.all([
+      cache1.put('a'.repeat(64), 'm', 'oss://bucket/a'),
+      cache2.put('b'.repeat(64), 'm', 'oss://bucket/b'),
+      cache1.put('c'.repeat(64), 'm', 'oss://bucket/c'),
+      cache2.put('d'.repeat(64), 'm', 'oss://bucket/d'),
+    ]);
+    const check = new OmniUploadCache(root);
+    expect(await check.get('a'.repeat(64), 'm')).toBe('oss://bucket/a');
+    expect(await check.get('b'.repeat(64), 'm')).toBe('oss://bucket/b');
+    expect(await check.get('c'.repeat(64), 'm')).toBe('oss://bucket/c');
+    expect(await check.get('d'.repeat(64), 'm')).toBe('oss://bucket/d');
+  });
+
+  it('re-put of the same (sha, model, scope) refreshes the URL', async () => {
+    const cache = new OmniUploadCache(root, 47, 's');
+    await cache.put(SHA, 'm', 'oss://bucket/old');
+    await cache.put(SHA, 'm', 'oss://bucket/new');
+    expect(await cache.get(SHA, 'm')).toBe('oss://bucket/new');
+  });
+
   it('ttl 0 disables the cache entirely', async () => {
     const cache = new OmniUploadCache(root, 0);
     expect(cache.enabled).toBe(false);
@@ -120,4 +241,60 @@ describe('OmniUploadCache', () => {
       fs.access(path.join(root, 'upload-cache.json')),
     ).rejects.toThrow(); // nothing written
   });
+
+  it('negative ttl also disables the cache', async () => {
+    const cache = new OmniUploadCache(root, -5);
+    expect(cache.enabled).toBe(false);
+    await cache.put(SHA, 'm', 'oss://bucket/x');
+    expect(await cache.get(SHA, 'm')).toBeNull();
+  });
+
+  it('clamps a configured ttl above 48h to 48h (server URL lifetime)', async () => {
+    const cache = new OmniUploadCache(root, 168);
+    expect(cache.enabled).toBe(true);
+    await cache.put(SHA, 'm', 'oss://bucket/x');
+    const data = JSON.parse(
+      await fs.readFile(path.join(root, 'upload-cache.json'), 'utf8'),
+    );
+    const entry = data.entries[`${SHA}|m|`];
+    const lifetimeMs =
+      Date.parse(entry.expiresAt) - Date.parse(entry.uploadedAt);
+    expect(lifetimeMs).toBe(48 * 3600_000);
+  });
+
+  it('writes atomically: no .tmp litter, 0600 file mode', async () => {
+    const cache = new OmniUploadCache(root);
+    await cache.put('a'.repeat(64), 'm', 'oss://bucket/a');
+    await cache.put('b'.repeat(64), 'm', 'oss://bucket/b');
+    await cache.put('c'.repeat(64), 'm', 'oss://bucket/c');
+    const names = await fs.readdir(root);
+    expect(names).toEqual(['upload-cache.json']);
+    if (process.platform !== 'win32') {
+      const st = await fs.stat(path.join(root, 'upload-cache.json'));
+      expect(st.mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it.runIf(canDropPermissions)(
+    'save failure leaves the previous file intact and no .tmp litter',
+    async () => {
+      const cache = new OmniUploadCache(root);
+      await cache.put(SHA, 'm', 'oss://bucket/original');
+      const file = path.join(root, 'upload-cache.json');
+      const before = await fs.readFile(file, 'utf8');
+
+      await fs.chmod(root, 0o500); // dir readable but not writable
+      // Must resolve (best-effort persistence), not throw.
+      await cache.put('b'.repeat(64), 'm', 'oss://bucket/lost');
+      await fs.chmod(root, 0o700);
+
+      // A direct write to filePath (skipping tmp+rename) would have
+      // either partially clobbered or emptied the file; the previous
+      // content must be byte-identical.
+      expect(await fs.readFile(file, 'utf8')).toBe(before);
+      const names = await fs.readdir(root);
+      expect(names.filter((n) => n.includes('.tmp-'))).toEqual([]);
+      expect(await cache.get(SHA, 'm')).toBe('oss://bucket/original');
+    },
+  );
 });

--- a/packages/core/src/omni/upload-cache.test.ts
+++ b/packages/core/src/omni/upload-cache.test.ts
@@ -194,6 +194,35 @@ describe('OmniUploadCache', () => {
     expect(await cache.get(SHA, 'm')).toBeNull();
   });
 
+  it('put() sweeps ALL expired entries, not just the written key', async () => {
+    const cache = new OmniUploadCache(root);
+    const deadSha = 'b'.repeat(64);
+    const malformedSha = 'c'.repeat(64);
+    const liveSha = 'd'.repeat(64);
+    await cache.put(deadSha, 'm', 'oss://bucket/dead');
+    await cache.put(malformedSha, 'm', 'oss://bucket/malformed');
+    await cache.put(liveSha, 'm', 'oss://bucket/live');
+    // Force-expire one entry and corrupt another's timestamp — neither
+    // key is ever read again, so only a wholesale sweep can remove them.
+    const file = path.join(root, 'upload-cache.json');
+    const data = JSON.parse(await fs.readFile(file, 'utf8'));
+    data.entries[`${deadSha}|m|`].expiresAt = new Date(
+      Date.now() - 1000,
+    ).toISOString();
+    data.entries[`${malformedSha}|m|`].expiresAt = 'not-a-date';
+    await fs.writeFile(file, JSON.stringify(data));
+
+    // A put of a DIFFERENT key must evict both stale entries.
+    await cache.put(SHA, 'm', 'oss://bucket/fresh');
+
+    const after = JSON.parse(await fs.readFile(file, 'utf8'));
+    expect(after.entries[`${deadSha}|m|`]).toBeUndefined();
+    expect(after.entries[`${malformedSha}|m|`]).toBeUndefined();
+    // Live neighbors and the fresh write survive.
+    expect(after.entries[`${liveSha}|m|`]).toBeDefined();
+    expect(after.entries[`${SHA}|m|`]).toBeDefined();
+  });
+
   it('serializes concurrent puts without losing entries', async () => {
     const cache = new OmniUploadCache(root);
     await Promise.all([

--- a/packages/core/src/omni/upload-cache.test.ts
+++ b/packages/core/src/omni/upload-cache.test.ts
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { OmniUploadCache } from './upload-cache.js';
+
+let root: string;
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), 'omni-ucache-'));
+});
+
+afterEach(async () => {
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+const SHA = 'a'.repeat(64);
+
+describe('OmniUploadCache', () => {
+  it('round-trips an entry and persists across instances', async () => {
+    const cache = new OmniUploadCache(root);
+    await cache.put(SHA, 'qwen3.5-omni-plus', 'oss://bucket/key1');
+    expect(await cache.get(SHA, 'qwen3.5-omni-plus')).toBe('oss://bucket/key1');
+    // Fresh instance reads the same file (cross-restart survival).
+    const cache2 = new OmniUploadCache(root);
+    expect(await cache2.get(SHA, 'qwen3.5-omni-plus')).toBe(
+      'oss://bucket/key1',
+    );
+  });
+
+  it('keys by model — a different model is a miss', async () => {
+    const cache = new OmniUploadCache(root);
+    await cache.put(SHA, 'model-a', 'oss://bucket/a');
+    expect(await cache.get(SHA, 'model-b')).toBeNull();
+  });
+
+  it('expired entries are misses and are pruned lazily', async () => {
+    const cache = new OmniUploadCache(root);
+    await cache.put(SHA, 'm', 'oss://bucket/x');
+    // Rewrite the file with an expired timestamp.
+    const file = path.join(root, 'upload-cache.json');
+    const data = JSON.parse(await fs.readFile(file, 'utf8'));
+    data.entries[`${SHA}|m`].expiresAt = new Date(
+      Date.now() - 1000,
+    ).toISOString();
+    await fs.writeFile(file, JSON.stringify(data));
+
+    expect(await cache.get(SHA, 'm')).toBeNull();
+    const after = JSON.parse(await fs.readFile(file, 'utf8'));
+    expect(after.entries[`${SHA}|m`]).toBeUndefined(); // pruned
+  });
+
+  it('invalidateByUrl drops every entry with that URL', async () => {
+    const cache = new OmniUploadCache(root);
+    await cache.put(SHA, 'm1', 'oss://bucket/shared');
+    await cache.put(SHA, 'm2', 'oss://bucket/shared');
+    await cache.put('b'.repeat(64), 'm1', 'oss://bucket/other');
+    await cache.invalidateByUrl('oss://bucket/shared');
+    expect(await cache.get(SHA, 'm1')).toBeNull();
+    expect(await cache.get(SHA, 'm2')).toBeNull();
+    expect(await cache.get('b'.repeat(64), 'm1')).toBe('oss://bucket/other');
+  });
+
+  it('removeBySha256 cascades all models for the object', async () => {
+    const cache = new OmniUploadCache(root);
+    await cache.put(SHA, 'm1', 'oss://bucket/1');
+    await cache.put(SHA, 'm2', 'oss://bucket/2');
+    await cache.removeBySha256(SHA);
+    expect(await cache.get(SHA, 'm1')).toBeNull();
+    expect(await cache.get(SHA, 'm2')).toBeNull();
+  });
+
+  it('backs up a corrupt cache file and starts fresh', async () => {
+    const file = path.join(root, 'upload-cache.json');
+    await fs.writeFile(file, 'not json at all {{{');
+    const cache = new OmniUploadCache(root);
+    expect(await cache.get(SHA, 'm')).toBeNull();
+    await cache.put(SHA, 'm', 'oss://bucket/fresh');
+    expect(await cache.get(SHA, 'm')).toBe('oss://bucket/fresh');
+    const names = await fs.readdir(root);
+    expect(names.some((n) => n.startsWith('upload-cache.json.corrupt-'))).toBe(
+      true,
+    );
+  });
+
+  it('treats malformed expiresAt as expired (never immortal)', async () => {
+    const cache = new OmniUploadCache(root);
+    await cache.put(SHA, 'm', 'oss://bucket/x');
+    const file = path.join(root, 'upload-cache.json');
+    const data = JSON.parse(await fs.readFile(file, 'utf8'));
+    data.entries[`${SHA}|m`].expiresAt = 'not-a-date';
+    await fs.writeFile(file, JSON.stringify(data));
+    expect(await cache.get(SHA, 'm')).toBeNull();
+  });
+
+  it('serializes concurrent puts without losing entries', async () => {
+    const cache = new OmniUploadCache(root);
+    await Promise.all([
+      cache.put('a'.repeat(64), 'm', 'oss://bucket/a'),
+      cache.put('b'.repeat(64), 'm', 'oss://bucket/b'),
+      cache.put('c'.repeat(64), 'm', 'oss://bucket/c'),
+    ]);
+    expect(await cache.get('a'.repeat(64), 'm')).toBe('oss://bucket/a');
+    expect(await cache.get('b'.repeat(64), 'm')).toBe('oss://bucket/b');
+    expect(await cache.get('c'.repeat(64), 'm')).toBe('oss://bucket/c');
+  });
+
+  it('ttl 0 disables the cache entirely', async () => {
+    const cache = new OmniUploadCache(root, 0);
+    expect(cache.enabled).toBe(false);
+    await cache.put(SHA, 'm', 'oss://bucket/x');
+    expect(await cache.get(SHA, 'm')).toBeNull();
+    await expect(
+      fs.access(path.join(root, 'upload-cache.json')),
+    ).rejects.toThrow(); // nothing written
+  });
+});

--- a/packages/core/src/omni/upload-cache.ts
+++ b/packages/core/src/omni/upload-cache.ts
@@ -75,7 +75,9 @@ interface UploadCacheFile {
  *   design — the pipeline only knows the URL the server rejected, not
  *   which scope minted it. Pre-scope 2-part keys simply never match again
  *   and age out via TTL;
- * - expired entries are misses and are lazily pruned;
+ * - expired entries are misses; they are pruned on read and swept
+ *   wholesale on every {@link put} (so never-read-again entries cannot
+ *   accumulate forever);
  * - a corrupt cache file is backed up and rebuilt empty (never fatal),
  *   keeping at most the newest {@link MAX_CORRUPT_BACKUPS} backups;
  * - a cache file that exists but cannot be READ (EACCES, EMFILE, …) makes
@@ -235,6 +237,15 @@ export class OmniUploadCache {
         uploadedAt: new Date(now).toISOString(),
         expiresAt: new Date(now + this.ttlMs).toISOString(),
       };
+      // Wholesale sweep of expired entries: `get()` prunes only the key it
+      // was asked about, so entries that are never read again would
+      // otherwise accumulate forever — every load/save re-parses and
+      // rewrites the whole table, monotonically slowing with dead history.
+      // put() is the natural hook: it already holds the serialized write.
+      for (const [k, v] of Object.entries(data.entries)) {
+        const t = Date.parse(v.expiresAt);
+        if (!Number.isFinite(t) || t <= now) delete data.entries[k];
+      }
       await this.save(data);
     });
   }

--- a/packages/core/src/omni/upload-cache.ts
+++ b/packages/core/src/omni/upload-cache.ts
@@ -1,0 +1,195 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { randomBytes } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { createDebugLogger } from '../utils/debugLogger.js';
+
+const debugLogger = createDebugLogger('omni:upload-cache');
+
+/** Per-cache-file operation serializer: cache instances are constructed
+ * per delivery, and safe-tool batches run deliveries concurrently in one
+ * process — unserialized load-modify-save would drop entries (worst case
+ * one extra re-upload, but cheap to prevent). Cross-process writes remain
+ * last-writer-wins (documented). */
+const fileOps = new Map<string, Promise<unknown>>();
+
+function serialize<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const prev = fileOps.get(key) ?? Promise.resolve();
+  const run = prev.then(fn, fn);
+  fileOps.set(
+    key,
+    run.then(
+      () => {},
+      () => {},
+    ),
+  );
+  return run;
+}
+
+/** Default oss:// URL validity horizon: 47h (official 48h minus margin). */
+export const DEFAULT_UPLOAD_CACHE_TTL_HOURS = 47;
+
+interface UploadCacheEntry {
+  ossUrl: string;
+  uploadedAt: string;
+  expiresAt: string;
+}
+
+interface UploadCacheFile {
+  version: 1;
+  /** Key: `<sha256>|<model>`. */
+  entries: Record<string, UploadCacheEntry>;
+}
+
+/**
+ * Persistent map from object identity to a still-valid DashScope temporary
+ * URL: `(sha256, model) → { ossUrl, uploadedAt, expiresAt }` (storage
+ * design §8). Lives at `.qwen/omni/upload-cache.json`.
+ *
+ * Invariants:
+ * - the cache file is the ONLY place an oss:// URL is persisted by omni —
+ *   the URL is a delivery cache, never an identity;
+ * - keys include the model: the docs declare uploads model-bound (looser
+ *   in practice, but honored conservatively);
+ * - expired entries are misses and are lazily pruned;
+ * - a corrupt cache file is backed up and rebuilt empty (never fatal);
+ * - writes are atomic (tmp + rename, 0600) and last-writer-wins across
+ *   processes — acceptable for the experiment (worst case: a lost entry
+ *   causes one extra re-upload).
+ */
+export class OmniUploadCache {
+  private readonly filePath: string;
+  private readonly ttlMs: number;
+
+  constructor(omniRootDir: string, ttlHours = DEFAULT_UPLOAD_CACHE_TTL_HOURS) {
+    this.filePath = path.join(omniRootDir, 'upload-cache.json');
+    this.ttlMs = ttlHours * 3600_000;
+  }
+
+  /** TTL of 0 (or negative) disables the cache entirely. */
+  get enabled(): boolean {
+    return this.ttlMs > 0;
+  }
+
+  private async load(): Promise<UploadCacheFile> {
+    let raw: string;
+    try {
+      raw = await fs.readFile(this.filePath, 'utf8');
+    } catch {
+      return { version: 1, entries: {} };
+    }
+    try {
+      const parsed = JSON.parse(raw) as UploadCacheFile;
+      if (parsed?.version === 1 && typeof parsed.entries === 'object') {
+        return parsed;
+      }
+      throw new Error('unexpected shape');
+    } catch {
+      // Corrupt cache: preserve for inspection, start fresh. Losing the
+      // cache only costs re-uploads — never fail the pipeline over it.
+      const backup = `${this.filePath}.corrupt-${Date.now()}`;
+      await fs.rename(this.filePath, backup).catch(() => {});
+      debugLogger.debug(`corrupt upload cache backed up to ${backup}`);
+      return { version: 1, entries: {} };
+    }
+  }
+
+  private async save(data: UploadCacheFile): Promise<void> {
+    const tmp = `${this.filePath}.tmp-${randomBytes(4).toString('hex')}`;
+    try {
+      await fs.mkdir(path.dirname(this.filePath), {
+        recursive: true,
+        mode: 0o700,
+      });
+      await fs.writeFile(tmp, JSON.stringify(data, null, 1), { mode: 0o600 });
+      await fs.rename(tmp, this.filePath);
+    } catch (err) {
+      await fs.rm(tmp, { force: true }).catch(() => {});
+      // Cache persistence is best-effort by design.
+      debugLogger.debug(
+        `upload cache write failed: ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }
+
+  private key(sha256: string, model: string): string {
+    return `${sha256}|${model}`;
+  }
+
+  /** Valid cached URL or null. Expired entries are pruned on read. */
+  async get(sha256: string, model: string): Promise<string | null> {
+    if (!this.enabled) return null;
+    return serialize(this.filePath, () => this.getInner(sha256, model));
+  }
+
+  private async getInner(
+    sha256: string,
+    model: string,
+  ): Promise<string | null> {
+    const data = await this.load();
+    const k = this.key(sha256, model);
+    const entry = data.entries[k];
+    if (!entry) return null;
+    const expiresAtMs = Date.parse(entry.expiresAt);
+    // Malformed timestamps (NaN) must expire, not live forever.
+    if (!Number.isFinite(expiresAtMs) || expiresAtMs <= Date.now()) {
+      delete data.entries[k];
+      await this.save(data);
+      return null;
+    }
+    return entry.ossUrl;
+  }
+
+  async put(sha256: string, model: string, ossUrl: string): Promise<void> {
+    if (!this.enabled) return;
+    return serialize(this.filePath, async () => {
+      const data = await this.load();
+      const now = Date.now();
+      data.entries[this.key(sha256, model)] = {
+        ossUrl,
+        uploadedAt: new Date(now).toISOString(),
+        expiresAt: new Date(now + this.ttlMs).toISOString(),
+      };
+      await this.save(data);
+    });
+  }
+
+  /** Drop every entry pointing at a server-side-invalidated URL. */
+  async invalidateByUrl(ossUrl: string): Promise<void> {
+    return serialize(this.filePath, async () => {
+      const data = await this.load();
+      let changed = false;
+      for (const [k, v] of Object.entries(data.entries)) {
+        if (v.ossUrl === ossUrl) {
+          delete data.entries[k];
+          changed = true;
+        }
+      }
+      if (changed) {
+        debugLogger.debug(`invalidated upload cache entries for ${ossUrl}`);
+        await this.save(data);
+      }
+    });
+  }
+
+  /** Drop all entries for an object (GC/corruption cascade). */
+  async removeBySha256(sha256: string): Promise<void> {
+    return serialize(this.filePath, async () => {
+      const data = await this.load();
+      const prefix = `${sha256}|`;
+      let changed = false;
+      for (const k of Object.keys(data.entries)) {
+        if (k.startsWith(prefix)) {
+          delete data.entries[k];
+          changed = true;
+        }
+      }
+      if (changed) await this.save(data);
+    });
+  }
+}

--- a/packages/core/src/omni/upload-cache.ts
+++ b/packages/core/src/omni/upload-cache.ts
@@ -14,25 +14,38 @@ const debugLogger = createDebugLogger('omni:upload-cache');
 /** Per-cache-file operation serializer: cache instances are constructed
  * per delivery, and safe-tool batches run deliveries concurrently in one
  * process — unserialized load-modify-save would drop entries (worst case
- * one extra re-upload, but cheap to prevent). Cross-process writes remain
- * last-writer-wins (documented). */
+ * one extra re-upload, but cheap to prevent). Module scope is deliberate:
+ * two instances on the same root must share the chain. Cross-process
+ * writes remain last-writer-wins (documented). */
 const fileOps = new Map<string, Promise<unknown>>();
 
 function serialize<T>(key: string, fn: () => Promise<T>): Promise<T> {
   const prev = fileOps.get(key) ?? Promise.resolve();
   const run = prev.then(fn, fn);
-  fileOps.set(
-    key,
-    run.then(
-      () => {},
-      () => {},
-    ),
+  const settled = run.then(
+    () => {},
+    () => {},
   );
+  fileOps.set(key, settled);
+  void settled.then(() => {
+    // Drop the tail once it settles — otherwise the map grows with every
+    // distinct cache file touched over the process lifetime. Only delete
+    // when OUR promise is still the tail: a later op may have chained on.
+    if (fileOps.get(key) === settled) fileOps.delete(key);
+  });
   return run;
 }
 
 /** Default oss:// URL validity horizon: 47h (official 48h minus margin). */
 export const DEFAULT_UPLOAD_CACHE_TTL_HOURS = 47;
+
+/** Hard ceiling for any configured TTL: the server-side URL dies at 48h,
+ * so a longer local TTL would confidently serve dead URLs. */
+const MAX_UPLOAD_CACHE_TTL_HOURS = 48;
+
+/** Keep at most this many `.corrupt-*` backups (newest wins): a crash
+ * loop over a corrupt file must not litter the directory without bound. */
+const MAX_CORRUPT_BACKUPS = 2;
 
 interface UploadCacheEntry {
   ossUrl: string;
@@ -42,22 +55,33 @@ interface UploadCacheEntry {
 
 interface UploadCacheFile {
   version: 1;
-  /** Key: `<sha256>|<model>`. */
+  /** Key: `<sha256>|<model>|<scope>`. */
   entries: Record<string, UploadCacheEntry>;
 }
 
 /**
  * Persistent map from object identity to a still-valid DashScope temporary
- * URL: `(sha256, model) → { ossUrl, uploadedAt, expiresAt }` (storage
- * design §8). Lives at `.qwen/omni/upload-cache.json`.
+ * URL: `(sha256, model, scope) → { ossUrl, uploadedAt, expiresAt }`
+ * (storage design §8). Lives at `.qwen/omni/upload-cache.json`.
  *
  * Invariants:
  * - the cache file is the ONLY place an oss:// URL is persisted by omni —
  *   the URL is a delivery cache, never an identity;
  * - keys include the model: the docs declare uploads model-bound (looser
  *   in practice, but honored conservatively);
+ * - keys include a caller-supplied scope: the pipeline passes a
+ *   fingerprint of (baseUrl, apiKey), so entries never cross endpoints or
+ *   credentials. `invalidateByUrl` scans by URL and is scope-agnostic by
+ *   design — the pipeline only knows the URL the server rejected, not
+ *   which scope minted it. Pre-scope 2-part keys simply never match again
+ *   and age out via TTL;
  * - expired entries are misses and are lazily pruned;
- * - a corrupt cache file is backed up and rebuilt empty (never fatal);
+ * - a corrupt cache file is backed up and rebuilt empty (never fatal),
+ *   keeping at most the newest {@link MAX_CORRUPT_BACKUPS} backups;
+ * - a cache file that exists but cannot be READ (EACCES, EMFILE, …) makes
+ *   the current operation a no-op instead of an empty-file rebuild — a
+ *   transient read failure must never lead to a save that wipes every
+ *   previously persisted entry;
  * - writes are atomic (tmp + rename, 0600) and last-writer-wins across
  *   processes — acceptable for the experiment (worst case: a lost entry
  *   causes one extra re-upload).
@@ -65,10 +89,18 @@ interface UploadCacheFile {
 export class OmniUploadCache {
   private readonly filePath: string;
   private readonly ttlMs: number;
+  private readonly scope: string;
 
-  constructor(omniRootDir: string, ttlHours = DEFAULT_UPLOAD_CACHE_TTL_HOURS) {
+  constructor(
+    omniRootDir: string,
+    ttlHours = DEFAULT_UPLOAD_CACHE_TTL_HOURS,
+    scope = '',
+  ) {
     this.filePath = path.join(omniRootDir, 'upload-cache.json');
-    this.ttlMs = ttlHours * 3600_000;
+    // Positive TTLs are clamped to the 48h server URL lifetime — a
+    // configured 168 must not outlive the URL. 0/negative still disables.
+    this.ttlMs = Math.min(ttlHours, MAX_UPLOAD_CACHE_TTL_HOURS) * 3600_000;
+    this.scope = scope;
   }
 
   /** TTL of 0 (or negative) disables the cache entirely. */
@@ -76,16 +108,42 @@ export class OmniUploadCache {
     return this.ttlMs > 0;
   }
 
-  private async load(): Promise<UploadCacheFile> {
+  /**
+   * Load the cache file. Returns null when the file exists but could not
+   * be read (EACCES, EMFILE, …): the caller must skip its operation for
+   * this call — proceeding with an empty snapshot and later saving it
+   * would overwrite N valid entries with one (self-inflicted cache wipe).
+   * Only a genuinely missing file means empty-and-writable.
+   */
+  private async load(): Promise<UploadCacheFile | null> {
     let raw: string;
     try {
       raw = await fs.readFile(this.filePath, 'utf8');
-    } catch {
-      return { version: 1, entries: {} };
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      // ENOENT: no cache file yet (POSIX and Windows). ENOTDIR: a parent
+      // path component is a plain file — POSIX raises ENOTDIR where
+      // Windows reports ENOENT for the same condition.
+      if (code === 'ENOENT' || code === 'ENOTDIR') {
+        return { version: 1, entries: {} };
+      }
+      debugLogger.debug(
+        `upload cache read failed, operation skipped: ${err instanceof Error ? err.message : err}`,
+      );
+      return null;
     }
     try {
       const parsed = JSON.parse(raw) as UploadCacheFile;
-      if (parsed?.version === 1 && typeof parsed.entries === 'object') {
+      // `entries` must be a plain non-null object: `typeof null` and
+      // `typeof []` are both 'object', and either shape would throw raw
+      // TypeErrors from every accessor below (escaping the never-fatal
+      // contract and skipping backup+rebuild).
+      if (
+        parsed?.version === 1 &&
+        typeof parsed.entries === 'object' &&
+        parsed.entries !== null &&
+        !Array.isArray(parsed.entries)
+      ) {
         return parsed;
       }
       throw new Error('unexpected shape');
@@ -94,8 +152,28 @@ export class OmniUploadCache {
       // cache only costs re-uploads — never fail the pipeline over it.
       const backup = `${this.filePath}.corrupt-${Date.now()}`;
       await fs.rename(this.filePath, backup).catch(() => {});
+      await this.pruneCorruptBackups();
       debugLogger.debug(`corrupt upload cache backed up to ${backup}`);
       return { version: 1, entries: {} };
+    }
+  }
+
+  /** Best-effort: keep only the newest {@link MAX_CORRUPT_BACKUPS}. */
+  private async pruneCorruptBackups(): Promise<void> {
+    const dir = path.dirname(this.filePath);
+    const prefix = `${path.basename(this.filePath)}.corrupt-`;
+    try {
+      const backups = (await fs.readdir(dir))
+        .filter((n) => n.startsWith(prefix))
+        // Millisecond timestamps are fixed-width for centuries, so the
+        // lexicographic sort is chronological; newest first.
+        .sort()
+        .reverse();
+      for (const name of backups.slice(MAX_CORRUPT_BACKUPS)) {
+        await fs.rm(path.join(dir, name), { force: true }).catch(() => {});
+      }
+    } catch {
+      // Pruning is hygiene; never let it affect the read path.
     }
   }
 
@@ -118,7 +196,7 @@ export class OmniUploadCache {
   }
 
   private key(sha256: string, model: string): string {
-    return `${sha256}|${model}`;
+    return `${sha256}|${model}|${this.scope}`;
   }
 
   /** Valid cached URL or null. Expired entries are pruned on read. */
@@ -132,6 +210,7 @@ export class OmniUploadCache {
     model: string,
   ): Promise<string | null> {
     const data = await this.load();
+    if (!data) return null;
     const k = this.key(sha256, model);
     const entry = data.entries[k];
     if (!entry) return null;
@@ -149,6 +228,7 @@ export class OmniUploadCache {
     if (!this.enabled) return;
     return serialize(this.filePath, async () => {
       const data = await this.load();
+      if (!data) return;
       const now = Date.now();
       data.entries[this.key(sha256, model)] = {
         ossUrl,
@@ -159,10 +239,19 @@ export class OmniUploadCache {
     });
   }
 
-  /** Drop every entry pointing at a server-side-invalidated URL. */
+  /**
+   * Drop every entry pointing at a server-side-invalidated URL.
+   *
+   * Deliberately ignores the `enabled` flag: even for ttlHours-0 users
+   * this must clear stale entries persisted before the cache was
+   * disabled, and it serves the recovery cascade. The URL scan is
+   * scope-agnostic on purpose — the caller only knows the rejected URL,
+   * not which endpoint scope minted it.
+   */
   async invalidateByUrl(ossUrl: string): Promise<void> {
     return serialize(this.filePath, async () => {
       const data = await this.load();
+      if (!data) return;
       let changed = false;
       for (const [k, v] of Object.entries(data.entries)) {
         if (v.ossUrl === ossUrl) {
@@ -177,10 +266,16 @@ export class OmniUploadCache {
     });
   }
 
-  /** Drop all entries for an object (GC/corruption cascade). */
+  /**
+   * Drop all entries for an object (GC/corruption cascade). Ignores the
+   * `enabled` flag for the same reason as {@link invalidateByUrl}. The
+   * prefix match spans models AND scopes — intended: a corrupt object is
+   * corrupt for every endpoint.
+   */
   async removeBySha256(sha256: string): Promise<void> {
     return serialize(this.filePath, async () => {
       const data = await this.load();
+      if (!data) return;
       const prefix = `${sha256}|`;
       let changed = false;
       for (const k of Object.keys(data.entries)) {

--- a/packages/core/src/omni/upload.test.ts
+++ b/packages/core/src/omni/upload.test.ts
@@ -8,7 +8,12 @@ import { describe, expect, it, vi } from 'vitest';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { DashScopeUploader, type FetchFn } from './upload.js';
+import {
+  DashScopeUploader,
+  resetCredentialCacheForTests,
+  type FetchFn,
+} from './upload.js';
+import { beforeEach } from 'vitest';
 
 const POLICY = {
   policy: 'cG9saWN5',
@@ -40,6 +45,8 @@ async function withTempFile<T>(
     await fs.rm(dir, { recursive: true, force: true });
   }
 }
+
+beforeEach(() => resetCredentialCacheForTests());
 
 describe('DashScopeUploader', () => {
   it('requests a policy bound to the model with bearer auth', async () => {
@@ -212,5 +219,62 @@ describe('DashScopeUploader', () => {
         mimeType: 'video/mp4',
       }),
     ).rejects.toThrow(/Failed to open file for upload/);
+  });
+});
+
+describe('credential cache', () => {
+  beforeEach(() => resetCredentialCacheForTests());
+
+  it('reuses one getPolicy across multiple uploads within the TTL', async () => {
+    const fetchFn = vi.fn<FetchFn>().mockImplementation(async (url) => {
+      if (String(url).includes('getPolicy')) return policyResponse();
+      return new Response('', { status: 200 });
+    });
+    const uploader = new DashScopeUploader({ apiKey: 'k', fetchFn });
+    await withTempFile('a', (f) =>
+      uploader.uploadFile({ filePath: f, model: 'm', mimeType: 'video/mp4' }),
+    );
+    await withTempFile('b', (f) =>
+      uploader.uploadFile({ filePath: f, model: 'm', mimeType: 'video/mp4' }),
+    );
+    const policyCalls = fetchFn.mock.calls.filter((c) =>
+      String(c[0]).includes('getPolicy'),
+    );
+    expect(policyCalls).toHaveLength(1);
+  });
+
+  it('separates credentials per model and per origin', async () => {
+    const fetchFn = vi
+      .fn<FetchFn>()
+      .mockImplementation(async () => policyResponse());
+    const uploader = new DashScopeUploader({ apiKey: 'k', fetchFn });
+    await uploader.getPolicy('model-a');
+    await uploader.getPolicy('model-b');
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('shares in-flight fetches between concurrent callers', async () => {
+    let resolveIt: (r: Response) => void;
+    const gate = new Promise<Response>((r) => (resolveIt = r));
+    const fetchFn = vi.fn<FetchFn>().mockReturnValue(gate as Promise<Response>);
+    const uploader = new DashScopeUploader({ apiKey: 'k', fetchFn });
+    const p1 = uploader.getPolicy('m');
+    const p2 = uploader.getPolicy('m');
+    resolveIt!(policyResponse());
+    await Promise.all([p1, p2]);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not cache a failed credential fetch', async () => {
+    const fetchFn = vi
+      .fn<FetchFn>()
+      .mockResolvedValueOnce(new Response('boom', { status: 500 }))
+      .mockResolvedValueOnce(policyResponse());
+    const uploader = new DashScopeUploader({ apiKey: 'k', fetchFn });
+    await expect(uploader.getPolicy('m')).rejects.toThrow(/HTTP 500/);
+    await expect(uploader.getPolicy('m')).resolves.toMatchObject({
+      upload_dir: POLICY.upload_dir,
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/core/src/omni/upload.test.ts
+++ b/packages/core/src/omni/upload.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -13,7 +13,6 @@ import {
   resetCredentialCacheForTests,
   type FetchFn,
 } from './upload.js';
-import { beforeEach } from 'vitest';
 
 const POLICY = {
   policy: 'cG9saWN5',
@@ -251,6 +250,37 @@ describe('credential cache', () => {
     await uploader.getPolicy('model-a');
     await uploader.getPolicy('model-b');
     expect(fetchFn).toHaveBeenCalledTimes(2);
+
+    // Same key + model but a different baseUrl origin must refetch: a
+    // policy is bound to the endpoint that issued it.
+    const intlUploader = new DashScopeUploader({
+      apiKey: 'k',
+      baseUrl: 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
+      fetchFn,
+    });
+    await intlUploader.getPolicy('model-a');
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+    const origins = fetchFn.mock.calls.map((c) => new URL(String(c[0])).origin);
+    expect(origins).toEqual([
+      'https://dashscope.aliyuncs.com',
+      'https://dashscope.aliyuncs.com',
+      'https://dashscope-intl.aliyuncs.com',
+    ]);
+  });
+
+  it('separates credentials per API key on the same origin and model', async () => {
+    const fetchFn = vi
+      .fn<FetchFn>()
+      .mockImplementation(async () => policyResponse());
+    const uploaderA = new DashScopeUploader({ apiKey: 'sk-alpha', fetchFn });
+    const uploaderB = new DashScopeUploader({ apiKey: 'sk-beta', fetchFn });
+    await uploaderA.getPolicy('m');
+    await uploaderB.getPolicy('m');
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    const authHeaders = fetchFn.mock.calls.map((c) =>
+      new Headers(c[1]?.headers as HeadersInit).get('authorization'),
+    );
+    expect(authHeaders).toEqual(['Bearer sk-alpha', 'Bearer sk-beta']);
   });
 
   it('shares in-flight fetches between concurrent callers', async () => {
@@ -272,6 +302,109 @@ describe('credential cache', () => {
       .mockResolvedValueOnce(policyResponse());
     const uploader = new DashScopeUploader({ apiKey: 'k', fetchFn });
     await expect(uploader.getPolicy('m')).rejects.toThrow(/HTTP 500/);
+    await expect(uploader.getPolicy('m')).resolves.toMatchObject({
+      upload_dir: POLICY.upload_dir,
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  describe('TTL expiry', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('refetches once the TTL has elapsed', async () => {
+      const fetchFn = vi
+        .fn<FetchFn>()
+        .mockImplementation(async () => policyResponse());
+      const uploader = new DashScopeUploader({ apiKey: 'k', fetchFn });
+      await uploader.getPolicy('m');
+      await vi.advanceTimersByTimeAsync(241_000);
+      await uploader.getPolicy('m');
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('reuses the credential just inside the TTL', async () => {
+      const fetchFn = vi
+        .fn<FetchFn>()
+        .mockImplementation(async () => policyResponse());
+      const uploader = new DashScopeUploader({ apiKey: 'k', fetchFn });
+      await uploader.getPolicy('m');
+      await vi.advanceTimersByTimeAsync(239_000);
+      await uploader.getPolicy('m');
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('measures the TTL from fetch start, not from resolve', async () => {
+      let resolveIt!: (r: Response) => void;
+      const gate = new Promise<Response>((r) => (resolveIt = r));
+      const fetchFn = vi
+        .fn<FetchFn>()
+        .mockReturnValueOnce(gate)
+        .mockImplementation(async () => policyResponse());
+      const uploader = new DashScopeUploader({ apiKey: 'k', fetchFn });
+      const first = uploader.getPolicy('m');
+      // The policy clock starts server-side when the request is issued, so
+      // 30s spent in flight counts against the validity window.
+      await vi.advanceTimersByTimeAsync(30_000);
+      resolveIt(policyResponse());
+      await first;
+      // 211s after resolve = 241s after fetch start: past the 240s TTL
+      // from start, but still inside it if measured from resolve time.
+      await vi.advanceTimersByTimeAsync(211_000);
+      await uploader.getPolicy('m');
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('keeps one caller abort from poisoning the shared in-flight fetch', async () => {
+    let resolveIt!: (r: Response) => void;
+    const gate = new Promise<Response>((r) => (resolveIt = r));
+    const fetchFn = vi.fn<FetchFn>().mockReturnValue(gate);
+    const uploaderA = new DashScopeUploader({ apiKey: 'k', fetchFn });
+    const uploaderB = new DashScopeUploader({ apiKey: 'k', fetchFn });
+    const controllerA = new AbortController();
+
+    const pA = uploaderA.getPolicy('m', controllerA.signal);
+    const pB = uploaderB.getPolicy('m');
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    controllerA.abort();
+    const errA = await pA.catch((e: unknown) => e);
+    expect((errA as Error).name).toBe('AbortError');
+
+    resolveIt(policyResponse());
+    await expect(pB).resolves.toMatchObject({
+      upload_dir: POLICY.upload_dir,
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches successfully after an aborted first call', async () => {
+    const controller = new AbortController();
+    const abortError = Object.assign(new Error('This operation was aborted'), {
+      name: 'AbortError',
+    });
+    const fetchFn = vi
+      .fn<FetchFn>()
+      .mockImplementationOnce(async () => {
+        controller.abort();
+        throw abortError;
+      })
+      .mockImplementation(async () => policyResponse());
+    const uploader = new DashScopeUploader({ apiKey: 'k', fetchFn });
+
+    const err = await uploader
+      .getPolicy('m', controller.signal)
+      .catch((e: unknown) => e);
+    expect((err as Error).name).toBe('AbortError');
+
+    // Let the shared fetch's rejection propagate through cache eviction
+    // before retrying.
+    await new Promise((r) => setTimeout(r, 0));
     await expect(uploader.getPolicy('m')).resolves.toMatchObject({
       upload_dir: POLICY.upload_dir,
     });

--- a/packages/core/src/omni/upload.ts
+++ b/packages/core/src/omni/upload.ts
@@ -115,6 +115,43 @@ function rethrowIfAborted(err: unknown, signal: AbortSignal | undefined): void {
   if (signal?.aborted) throw err;
 }
 
+/** Abort-shaped rejection reason for a caller whose signal fired. */
+function abortReason(signal: AbortSignal): unknown {
+  return (
+    signal.reason ??
+    new DOMException('This operation was aborted', 'AbortError')
+  );
+}
+
+/**
+ * Settle with `shared` unless `signal` aborts first. The shared promise is
+ * never cancelled — it keeps running for the other cache consumers — while
+ * this caller rejects with its own abort reason. The abort listener is
+ * removed as soon as the shared promise settles, so racing against a
+ * long-lived caller signal does not accumulate listeners.
+ */
+function raceWithSignal<T>(
+  shared: Promise<T>,
+  signal: AbortSignal | undefined,
+): Promise<T> {
+  if (!signal) return shared;
+  if (signal.aborted) return Promise.reject(abortReason(signal));
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = (): void => reject(abortReason(signal));
+    signal.addEventListener('abort', onAbort, { once: true });
+    shared.then(
+      (value) => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      (err) => {
+        signal.removeEventListener('abort', onAbort);
+        reject(err);
+      },
+    );
+  });
+}
+
 /**
  * Client for DashScope's official temporary upload channel:
  * getPolicy → OSS multipart form POST → `oss://` URL usable as a media
@@ -152,27 +189,33 @@ export class DashScopeUploader {
     const cacheKey = `${this.origin}|${model}|${keyDigest}`;
     const cached = credentialCache.get(cacheKey);
     if (cached && Date.now() - cached.fetchedAt < CREDENTIAL_TTL_MS) {
-      return cached.policy;
+      return raceWithSignal(cached.policy, signal);
     }
+    // The shared fetch runs under the internal timeout only — never a
+    // caller's signal. A caller-owned signal aborting a shared promise
+    // would poison it for every other caller awaiting the same entry;
+    // instead each caller races the shared promise against its own
+    // signal below, so an abort rejects that caller alone.
     const entry: CachedPolicy = {
       fetchedAt: Date.now(),
-      policy: this.fetchPolicy(model, signal),
+      policy: this.fetchPolicy(model),
     };
     credentialCache.set(cacheKey, entry);
     entry.policy.catch(() => {
-      // Never cache a failed credential fetch.
+      // Never cache a failed credential fetch. This handler also keeps an
+      // abandoned shared rejection (all racers already aborted) from
+      // surfacing as an unhandled rejection.
       if (credentialCache.get(cacheKey) === entry) {
         credentialCache.delete(cacheKey);
       }
     });
-    return entry.policy;
+    return raceWithSignal(entry.policy, signal);
   }
 
-  /** Uncached policy fetch. */
-  private async fetchPolicy(
-    model: string,
-    signal?: AbortSignal,
-  ): Promise<DashScopeUploadPolicy> {
+  /** Uncached policy fetch. Runs solely under the internal timeout; caller
+   * signals are handled per-caller in getPolicy so one caller's abort never
+   * contaminates the shared cached promise. */
+  private async fetchPolicy(model: string): Promise<DashScopeUploadPolicy> {
     const url = new URL('/api/v1/uploads', this.origin);
     url.searchParams.set('action', 'getPolicy');
     url.searchParams.set('model', model);
@@ -181,7 +224,7 @@ export class DashScopeUploader {
     // consumed, not just until headers arrive — undici cancels in-flight
     // body reads through the request signal, so cleaning up earlier would
     // leave a stalled body read unabortable (no timeout, no ESC).
-    const combined = combineAbortSignals([signal], {
+    const combined = combineAbortSignals([], {
       timeoutMs: GET_POLICY_TIMEOUT_MS,
     });
     let failureSummary: string | undefined;
@@ -203,7 +246,6 @@ export class DashScopeUploader {
         failureSummary = await summarizeHttpFailure(res);
       }
     } catch (err) {
-      rethrowIfAborted(err, signal);
       throw new Error(
         `DashScope upload getPolicy request failed: ${
           err instanceof Error ? err.message : String(err)

--- a/packages/core/src/omni/upload.ts
+++ b/packages/core/src/omni/upload.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { openAsBlob } from 'node:fs';
 import path from 'node:path';
 import { combineAbortSignals } from '../utils/abortController.js';
@@ -45,6 +45,26 @@ export interface DashScopeUploaderOptions {
 const DEFAULT_ORIGIN = 'https://dashscope.aliyuncs.com';
 const GET_POLICY_TIMEOUT_MS = 30_000;
 const UPLOAD_TIMEOUT_MS = 15 * 60_000;
+/** Credential reuse window: official policy validity is 300s; 240s keeps
+ * a safety margin for the slowest accepted upload start. */
+const CREDENTIAL_TTL_MS = 240_000;
+
+interface CachedPolicy {
+  policy: Promise<DashScopeUploadPolicy>;
+  fetchedAt: number;
+}
+
+/** Module-level getPolicy cache: uploader instances are created per
+ * delivery, so an instance-level cache would never hit. Keyed by
+ * origin|model; in-flight promises are shared so N concurrent uploads
+ * spawn one credential request (same pattern as the ffmpeg availability
+ * cache). Rejections are evicted immediately. */
+const credentialCache = new Map<string, CachedPolicy>();
+
+/** Test-only. */
+export function resetCredentialCacheForTests(): void {
+  credentialCache.clear();
+}
 
 /** Strip everything but safe filename characters for the OSS object key. */
 function sanitizeFileName(name: string): string {
@@ -116,8 +136,40 @@ export class DashScopeUploader {
     this.fetchFn = options.fetchFn ?? fetch;
   }
 
-  /** Fetch a short-lived upload policy bound to `model`. */
+  /** Fetch a short-lived upload policy bound to `model`, reusing a cached
+   * credential within its validity window. */
   async getPolicy(
+    model: string,
+    signal?: AbortSignal,
+  ): Promise<DashScopeUploadPolicy> {
+    // Include the credential identity: two API keys on the same origin
+    // must not share upload policies (each policy scopes an account's
+    // upload_dir).
+    const keyDigest = createHash('sha256')
+      .update(this.apiKey)
+      .digest('hex')
+      .slice(0, 16);
+    const cacheKey = `${this.origin}|${model}|${keyDigest}`;
+    const cached = credentialCache.get(cacheKey);
+    if (cached && Date.now() - cached.fetchedAt < CREDENTIAL_TTL_MS) {
+      return cached.policy;
+    }
+    const entry: CachedPolicy = {
+      fetchedAt: Date.now(),
+      policy: this.fetchPolicy(model, signal),
+    };
+    credentialCache.set(cacheKey, entry);
+    entry.policy.catch(() => {
+      // Never cache a failed credential fetch.
+      if (credentialCache.get(cacheKey) === entry) {
+        credentialCache.delete(cacheKey);
+      }
+    });
+    return entry.policy;
+  }
+
+  /** Uncached policy fetch. */
+  private async fetchPolicy(
     model: string,
     signal?: AbortSignal,
   ): Promise<DashScopeUploadPolicy> {

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -3277,6 +3277,12 @@
               "minimum": 1,
               "default": 1073741824,
               "description": "Per-file byte ceiling for omni media uploads. Defaults to 1 GiB, the DashScope temporary-upload per-file cap. Inputs above the limit fail closed with an explanatory error."
+            },
+            "cacheTtlHours": {
+              "type": "number",
+              "minimum": 0,
+              "default": 47,
+              "description": "Validity horizon for cached oss:// upload URLs. DashScope temporary uploads live 48h; the default keeps a 1h margin. 0 disables the upload cache (every delivery re-uploads)."
             }
           }
         },


### PR DESCRIPTION
## What this PR does

Implements the S3 delivery-reliability slice of the omni experiment: repeat deliveries of unchanged media become free, server-invalidated URLs are dropped so the NEXT attempt transparently re-uploads (the failing request itself fails closed — design D2, no in-request replay), and crash residue is swept after its grace window instead of accumulating forever.

- **Persistent upload cache** (`.qwen/omni/upload-cache.json`): `(sha256, model, endpoint-scope) → oss:// URL` with a 47h TTL (server URLs live 48h; positive configured TTLs are clamped to 48). A hit short-circuits BEFORE store promotion, so a re-read of a large file skips both the local copy and the network transfer. Atomic tmp+rename writes (0600), corrupt file → backup (capped at 2) + rebuild, only ENOENT treated as an empty cache (a transient read error skips the operation instead of persisting a wiped file). Entries are scoped by a fingerprint of (baseUrl, apiKey) so a URL minted under one credential is never served to another.
- **Credential reuse** (`DashScopeUploader.getPolicy`): module-level cache keyed by `origin|model|apiKeyHash`, 240s TTL (official validity 300s), shared in-flight promise. The shared fetch uses only its internal timeout; each caller races it against its own AbortSignal, so one caller's cancel cannot poison concurrent uploads.
- **Failure-semantics invalidation** (openai pipeline): provider errors whose message names an `oss://` failure (or a media-download failure) drop the matching cache entries — on both the non-streaming and the streaming error path (the CLI default). No automatic request replay: the user's next attempt naturally misses and re-uploads (design decision D2).
- **Startup recovery** (`recovery.ts`): lazy once-per-root scan on first pipeline touch — sweeps `downloads/*.part` older than 48h and `.tmp-*` promotion orphans past a 1h multi-process grace window, and hash-verifies a small day-rotated sample of objects (≤3, ≤64MiB each), deleting corrupt ones with their cache entries cascaded. The scan is confined to the managed omni root: symlinked directories and non-regular-file candidates are rejected before any traversal, hash, or delete. Never throws.
- **Settings**: `omni.upload.cacheTtlHours` (default 47, 0 disables) threaded through all four hops.

Design mapping: `.qwen/design/omni-s3-delivery-reliability.md` (decisions D1–D5).

## Why it's needed

Closes #8185. After S2, every `@file` mention re-uploads from scratch — a 424MB video costs ~105s per mention, every time, plus one `getPolicy` round-trip per file. Server-side URL expiry surfaces as an opaque model error with no self-healing, and a crash mid-promotion leaves `.part`/`.tmp-*` orphans forever. S3 makes repeat delivery free within the URL validity window, shares credentials across a batch, invalidates dead URLs so the next attempt transparently re-uploads (the erroring request is not replayed), and bounds crash residue (`.tmp-*` swept after a 1h multi-process grace window, `.part` after a 48h debugging retention window).

## Reviewer Test Plan

### How to verify

Unit suites (all green, 496 tests across the touched areas):

```
cd packages/core
npx vitest run src/omni/ src/core/openaiContentGenerator/pipeline.test.ts src/core/openaiContentGenerator/pipeline.omniCacheInvalidation.test.ts src/core/openaiContentGenerator/pipeline.concurrent.test.ts src/utils/fileUtils.test.ts
```

E2E acceptance (issue #8185 criteria, DashScope key + `qwen3.5-omni-plus`):

1. **Restart → zero re-upload**: mention a video via `@`, quit, restart, mention the same file — the second delivery returns instantly (`uploadCacheHit`), no upload traffic; `.qwen/omni/upload-cache.json` holds the entry.
2. **Manual expiry → transparent re-upload**: edit the entry's `expiresAt` into the past, re-ask — one re-upload, answer unaffected.
3. **Credential sharing**: mention several media files in one message — exactly one `getPolicy` request (visible with `--openai-logging`).
4. **Crash residue**: `kill -9` during a large upload, restart, mention any media — stale `.tmp-*`/expired `.part` are swept on the first delivery.

Edge cases pinned by tests worth spot-checking in review: `{"version":1,"entries":null}` cache file routes through backup+rebuild instead of a permanent TypeError; aborting one concurrent upload does not fail the other's `getPolicy`; a mid-stream provider error naming an `oss://` URL invalidates the entry while `"connection loss"` does not; switching `apiKey` misses the cache instead of reusing the other credential's URL.

### Evidence (Before & After)

N/A (no UI change; behavior evidenced by the unit suites above).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local vitest + tsc; e2e against DashScope with `qwen3.5-omni-plus`.

## Risk & Scope

- Main risk or tradeoff: cache staleness — the server could drop a URL before our TTL. Mitigated by the 1h safety margin, error-driven invalidation, and the retry-once-naturally semantics (D2). Cross-process cache writes are last-writer-wins (documented; worst case one extra re-upload).
- Not validated / out of scope: staging/quarantine sweeps (S4), GC/capacity budget (S6), history URL rewriting (S5), resumable uploads (no official protocol).
- Breaking changes / migration notes: none. New optional setting `omni.upload.cacheTtlHours`. Cache file keys gained a scope segment; old-format entries simply never match and age out via TTL.

