### PR TITLE
fix(core): Resolve symlinks before granting read permission

### DIFF
--- a/packages/core/src/memory/paths.ts
+++ b/packages/core/src/memory/paths.ts
@@ -7,7 +7,12 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { Storage } from '../config/storage.js';
-import { QWEN_DIR, resolvePath, sanitizeCwd } from '../utils/paths.js';
+import {
+  QWEN_DIR,
+  realpathNearestExisting,
+  resolvePath,
+  sanitizeCwd,
+} from '../utils/paths.js';
 import type { AutoMemoryType } from './types.js';
 import { MEMORY_PROJECT_SCOPES } from './scopes.js';
 
@@ -336,71 +341,6 @@ export function isManagedMemoryPath(
     const rel = path.relative(resolvedRoot, resolvedPath);
     return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
   });
-}
-
-/**
- * Follow a leading symlink chain at `inputPath` to its eventual target, even
- * when that target does not exist yet (a dangling link).
- *
- * Security-load-bearing: `fs.existsSync` follows links and reports a dangling
- * symlink as "missing". Relying on it lets an attacker pre-place
- * `decoy.md -> .qwen/team-memory/leak.md` (target absent) so the path classifies
- * OUTSIDE team memory and the secret scanner is skipped — while the real write
- * follows the link INTO team memory. lstat/readlink (no-follow) resolve the link
- * target so classification matches where the bytes will actually land.
- */
-function resolveLeafSymlink(inputPath: string): string {
-  const maxHops = 40; // POSIX SYMLOOP_MAX
-  let current = path.resolve(inputPath);
-  for (let i = 0; i < maxHops; i++) {
-    let stat: fs.Stats;
-    try {
-      stat = fs.lstatSync(current);
-    } catch {
-      return current; // missing or unreadable — nothing left to follow
-    }
-    if (!stat.isSymbolicLink()) {
-      return current;
-    }
-    const target = fs.readlinkSync(current);
-    if (path.isAbsolute(target)) {
-      current = target;
-    } else {
-      // Resolve relative targets against the link's real parent so an
-      // intermediate directory symlink can't mis-resolve the target.
-      let parent: string;
-      try {
-        parent = fs.realpathSync(path.dirname(current));
-      } catch {
-        parent = path.dirname(current);
-      }
-      current = path.resolve(parent, target);
-    }
-  }
-  return current; // chain too deep — caller still range-checks the result
-}
-
-function realpathNearestExisting(inputPath: string): string {
-  // Resolve a leading (possibly dangling) symlink first so a dangling link into
-  // team memory is classified by its target, not treated as a plain missing file.
-  const resolved = resolveLeafSymlink(inputPath);
-  const missingSegments: string[] = [];
-  let current = resolved;
-
-  while (!fs.existsSync(current)) {
-    const parent = path.dirname(current);
-    if (parent === current) {
-      return resolved;
-    }
-    missingSegments.unshift(path.basename(current));
-    current = parent;
-  }
-
-  try {
-    return path.join(fs.realpathSync(current), ...missingSegments);
-  } catch {
-    return resolved;
-  }
 }
 
 /**

--- a/packages/core/src/tools/file-read-permission.test.ts
+++ b/packages/core/src/tools/file-read-permission.test.ts
@@ -1,0 +1,232 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import type { Config } from '../config/config.js';
+import { Storage } from '../config/storage.js';
+import { clearAutoMemoryRootCache } from '../memory/paths.js';
+import { WorkspaceContext } from '../utils/workspaceContext.js';
+import { getFileReadDefaultPermission } from './file-read-permission.js';
+
+const skipOnWindows = process.platform === 'win32';
+
+/**
+ * Layout built once for the whole suite. The temp base is realpath'd up front
+ * so assertions do not depend on macOS resolving `/var` to `/private/var`
+ * partway through a comparison.
+ */
+interface Layout {
+  base: string;
+  workspace: string;
+  projectTempDir: string;
+  projectDir: string;
+  globalTempDir: string;
+  userSkillsDir: string;
+  userExtensionsDir: string;
+  plansDir: string;
+  memoryBaseDir: string;
+  /** Outside the workspace and outside every allow-listed root. */
+  secretsDir: string;
+  secretFile: string;
+}
+
+let layout: Layout;
+let originalMemoryBaseDir: string | undefined;
+
+function makeConfig(overrides: { plansDir?: string } = {}): Config {
+  const workspaceContext = new WorkspaceContext(layout.workspace);
+  return {
+    getWorkspaceContext: () => workspaceContext,
+    getTargetDir: () => layout.workspace,
+    getPlansDir: () => overrides.plansDir ?? layout.plansDir,
+    storage: {
+      getProjectTempDir: () => layout.projectTempDir,
+      getProjectDir: () => layout.projectDir,
+      getUserSkillsDirs: () => [layout.userSkillsDir],
+    },
+  } as unknown as Config;
+}
+
+function permissionFor(requestedPath: string) {
+  return getFileReadDefaultPermission(makeConfig(), requestedPath);
+}
+
+beforeAll(() => {
+  const base = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'qwen-file-read-perm-')),
+  );
+  layout = {
+    base,
+    workspace: path.join(base, 'workspace'),
+    projectTempDir: path.join(base, 'runtime', 'projects', 'p1', 'tmp'),
+    projectDir: path.join(base, 'runtime', 'projects', 'p1'),
+    globalTempDir: path.join(base, 'runtime', 'tmp'),
+    userSkillsDir: path.join(base, 'runtime', 'skills'),
+    userExtensionsDir: path.join(base, 'runtime', 'extensions'),
+    plansDir: path.join(base, 'runtime', 'plans'),
+    memoryBaseDir: path.join(base, 'runtime', 'memory-base'),
+    secretsDir: path.join(base, 'secrets'),
+    secretFile: path.join(base, 'secrets', 'credentials'),
+  };
+
+  for (const dir of [
+    layout.workspace,
+    layout.projectTempDir,
+    path.join(layout.projectDir, 'subagents'),
+    layout.globalTempDir,
+    layout.userSkillsDir,
+    layout.userExtensionsDir,
+    layout.plansDir,
+    layout.memoryBaseDir,
+    layout.secretsDir,
+  ]) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.writeFileSync(layout.secretFile, 'SENTINEL-SECRET', 'utf8');
+
+  // Keep the auto-memory branch hermetic: point it at an empty temp base so no
+  // candidate below can accidentally land inside a real ~/.qwen/memories.
+  originalMemoryBaseDir = process.env['QWEN_CODE_MEMORY_BASE_DIR'];
+  process.env['QWEN_CODE_MEMORY_BASE_DIR'] = layout.memoryBaseDir;
+  clearAutoMemoryRootCache();
+});
+
+afterAll(() => {
+  if (originalMemoryBaseDir === undefined) {
+    delete process.env['QWEN_CODE_MEMORY_BASE_DIR'];
+  } else {
+    process.env['QWEN_CODE_MEMORY_BASE_DIR'] = originalMemoryBaseDir;
+  }
+  clearAutoMemoryRootCache();
+  fs.rmSync(layout.base, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  vi.spyOn(Storage, 'getGlobalTempDir').mockReturnValue(layout.globalTempDir);
+  vi.spyOn(Storage, 'getUserExtensionsDir').mockReturnValue(
+    layout.userExtensionsDir,
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('getFileReadDefaultPermission', () => {
+  describe('baseline containment', () => {
+    it('allows a real file inside the workspace', () => {
+      const file = path.join(layout.workspace, 'src.ts');
+      fs.writeFileSync(file, 'x', 'utf8');
+      expect(permissionFor(file)).toBe('allow');
+    });
+
+    it('allows a real file inside an allow-listed root', () => {
+      const file = path.join(layout.projectTempDir, 'scratch.txt');
+      fs.writeFileSync(file, 'x', 'utf8');
+      expect(permissionFor(file)).toBe('allow');
+    });
+
+    it('allows a not-yet-created file under a real allow-listed root', () => {
+      // The nearest-existing walk must not downgrade a legitimate root just
+      // because the leaf is absent — write/edit pre-reads hit this constantly.
+      expect(
+        permissionFor(path.join(layout.projectTempDir, 'absent.txt')),
+      ).toBe('allow');
+    });
+
+    it('asks for a plain file outside every root', () => {
+      expect(permissionFor(layout.secretFile)).toBe('ask');
+    });
+
+    it('asks for a missing file outside every root', () => {
+      expect(permissionFor(path.join(layout.secretsDir, 'absent'))).toBe('ask');
+    });
+  });
+
+  // The regression this suite exists for. A lexical `path.resolve` classifies
+  // a symlink by where it SITS, and every root below is agent-writable — so
+  // the old check handed out a silent `allow` for any file on the host, with
+  // no confirmation prompt at all.
+  describe.skipIf(skipOnWindows)(
+    'symlinks planted inside an allow-listed root',
+    () => {
+      const roots: Array<[string, () => string]> = [
+        ['project-temp-dir', () => layout.projectTempDir],
+        ['subagents-dir', () => path.join(layout.projectDir, 'subagents')],
+        ['global-temp-dir', () => layout.globalTempDir],
+        ['user-skills-dir', () => layout.userSkillsDir],
+        ['user-extensions-dir', () => layout.userExtensionsDir],
+        ['plans-dir', () => layout.plansDir],
+      ];
+
+      it.each(roots)('asks for a file symlink under the %s', (name, root) => {
+        const link = path.join(root(), `escape-${name}`);
+        fs.symlinkSync(layout.secretFile, link);
+        expect(permissionFor(link)).toBe('ask');
+      });
+
+      it('asks when a directory symlink is traversed', () => {
+        const link = path.join(layout.globalTempDir, 'dirlink');
+        fs.symlinkSync(layout.secretsDir, link, 'dir');
+        expect(permissionFor(path.join(link, 'credentials'))).toBe('ask');
+      });
+
+      it('asks for a dangling symlink whose target is outside', () => {
+        // fs.existsSync() follows links and reports a dangling one as missing,
+        // so a naive nearest-existing walk would stop at the root and allow it.
+        const link = path.join(layout.plansDir, 'dangling');
+        fs.symlinkSync(path.join(layout.secretsDir, 'not-yet-created'), link);
+        expect(permissionFor(link)).toBe('ask');
+      });
+
+      it('asks for a not-yet-created file behind an escaping dir symlink', () => {
+        const realNested = path.join(layout.base, 'real-nested');
+        fs.mkdirSync(realNested, { recursive: true });
+        const link = path.join(layout.globalTempDir, 'nested');
+        fs.symlinkSync(realNested, link, 'dir');
+        expect(permissionFor(path.join(link, 'new.txt'))).toBe('ask');
+      });
+    },
+  );
+
+  describe.skipIf(skipOnWindows)(
+    'symlinked roots still match, because both sides are canonicalized',
+    () => {
+      it('allows a file reached through a symlinked allow-listed root', () => {
+        const realRoot = path.join(layout.base, 'real-plans');
+        fs.mkdirSync(realRoot, { recursive: true });
+        const file = path.join(realRoot, 'plan.md');
+        fs.writeFileSync(file, 'x', 'utf8');
+
+        const linkedPlans = path.join(layout.base, 'linked-plans');
+        fs.symlinkSync(realRoot, linkedPlans, 'dir');
+        const config = makeConfig({ plansDir: linkedPlans });
+
+        // Requested by real path while the configured root is the symlink.
+        expect(getFileReadDefaultPermission(config, file)).toBe('allow');
+        // ...and by the symlink while the file resolves to the real path.
+        expect(
+          getFileReadDefaultPermission(
+            config,
+            path.join(linkedPlans, 'plan.md'),
+          ),
+        ).toBe('allow');
+      });
+    },
+  );
+});

--- a/packages/core/src/tools/file-read-permission.ts
+++ b/packages/core/src/tools/file-read-permission.ts
@@ -9,18 +9,28 @@ import type { Config } from '../config/config.js';
 import { Storage } from '../config/storage.js';
 import { isAnyAutoMemPath } from '../memory/paths.js';
 import type { PermissionDecision } from '../permissions/types.js';
-import { isSubpaths } from '../utils/paths.js';
+import { isSubpaths, realpathNearestExisting } from '../utils/paths.js';
 
 export function getFileReadDefaultPermission(
   config: Config,
   requestedPath: string,
 ): PermissionDecision {
-  const filePath = path.resolve(requestedPath);
+  // Every allowed root below is agent-writable, so a lexical check classifies
+  // a planted `link -> ~/.aws/credentials` by where it sits and grants 'allow'
+  // with no prompt. Keep the leading path.resolve: it collapses `..` before any
+  // link is followed, matching how the read tools resolve before opening, so
+  // the decision and the open agree on which bytes are meant.
+  const filePath = realpathNearestExisting(path.resolve(requestedPath));
   const workspaceContext = config.getWorkspaceContext();
 
   // SYNC: Keep these base roots and the auto-memory check below aligned with
   // AcpAgent.buildAcpLocalReadRoots' mirrored ReadFileTool group. ACP may
   // append fallback-only roots after that group.
+  //
+  // Roots are canonicalized too: resolving only the candidate would cost an
+  // extra prompt whenever a root sits behind a symlink (macOS /var). Safe here
+  // because these roots are anchored in the user's home / runtime dir, never
+  // derived from repo-tracked contents.
   const allowedRoots = [
     config.storage.getProjectTempDir(),
     // Background subagent transcripts live under <projectDir>/subagents/ and
@@ -35,7 +45,7 @@ export function getFileReadDefaultPermission(
     // back must not stall on a confirmation prompt. The dir holds only
     // session plan files, never credentials or settings.
     config.getPlansDir(),
-  ];
+  ].map(realpathNearestExisting);
 
   if (
     workspaceContext.isPathWithinWorkspace(filePath) ||
@@ -44,6 +54,13 @@ export function getFileReadDefaultPermission(
     // (per-project + user-level under ~/.qwen/memories/) — never the
     // broad getMemoryBaseDir() — to avoid exposing sensitive ~/.qwen
     // files such as settings.json or OAuth credentials.
+    //
+    // Asymmetric with allowedRoots on purpose: the candidate is canonicalized
+    // but the memory roots stay lexical. In local-memory mode that root sits
+    // under a repo-tracked `.qwen/`, so canonicalizing it would let a checked-in
+    // `.qwen -> /outside` relocate the allowed root — see
+    // getAutoMemoryTrustedAnchor. Candidate-only is fail-closed and still
+    // refuses a link planted inside the root.
     isAnyAutoMemPath(filePath, config.getTargetDir())
   ) {
     return 'allow';

--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -28,6 +28,7 @@ import {
   tildeifyPath,
   expandHomeDir,
   getProjectHash,
+  realpathNearestExisting,
   _resetValidatePathCacheForTest,
 } from './paths.js';
 import type { Config } from '../config/config.js';
@@ -773,6 +774,102 @@ describe('formatDisplayPath', () => {
     expect(result).toContain('...');
     expect(result).toContain('file.ts');
   });
+});
+
+describe('realpathNearestExisting', () => {
+  let root: string;
+
+  beforeAll(() => {
+    // realpathSync the base itself so assertions do not trip over macOS's
+    // /var -> /private/var symlink.
+    root = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'realpath-nearest-')),
+    );
+    fs.mkdirSync(path.join(root, 'real'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'real', 'file.txt'), 'x', 'utf8');
+  });
+
+  afterAll(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('returns an existing path canonicalized', () => {
+    const target = path.join(root, 'real', 'file.txt');
+    expect(realpathNearestExisting(target)).toBe(target);
+  });
+
+  it('appends segments that do not exist yet to the resolved prefix', () => {
+    expect(realpathNearestExisting(path.join(root, 'real', 'a', 'b.txt'))).toBe(
+      path.join(root, 'real', 'a', 'b.txt'),
+    );
+  });
+
+  it('returns the lexical path when no ancestor can be resolved', () => {
+    const absent = path.resolve(path.sep, 'no', 'such', 'ancestor', 'x');
+    expect(realpathNearestExisting(absent)).toBe(absent);
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'follows a symlink to its target',
+    () => {
+      const link = path.join(root, 'link-to-file');
+      fs.symlinkSync(path.join(root, 'real', 'file.txt'), link);
+      expect(realpathNearestExisting(link)).toBe(
+        path.join(root, 'real', 'file.txt'),
+      );
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'follows a dangling symlink to its non-existent target',
+    () => {
+      // fs.existsSync() follows links and reports a dangling one as missing,
+      // so a naive nearest-existing walk would classify this by where the
+      // link sits rather than where it points.
+      const link = path.join(root, 'dangling');
+      fs.symlinkSync(path.join(root, 'real', 'absent.txt'), link);
+      expect(realpathNearestExisting(link)).toBe(
+        path.join(root, 'real', 'absent.txt'),
+      );
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'resolves an intermediate directory symlink',
+    () => {
+      const dirLink = path.join(root, 'dirlink');
+      fs.symlinkSync(path.join(root, 'real'), dirLink, 'dir');
+      expect(realpathNearestExisting(path.join(dirLink, 'file.txt'))).toBe(
+        path.join(root, 'real', 'file.txt'),
+      );
+      expect(realpathNearestExisting(path.join(dirLink, 'absent.txt'))).toBe(
+        path.join(root, 'real', 'absent.txt'),
+      );
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'resolves a relative symlink target against the real parent of the link',
+    () => {
+      const link = path.join(root, 'real', 'rel-link');
+      fs.symlinkSync('file.txt', link);
+      expect(realpathNearestExisting(link)).toBe(
+        path.join(root, 'real', 'file.txt'),
+      );
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'gives up safely on a symlink cycle instead of looping forever',
+    () => {
+      const a = path.join(root, 'cycle-a');
+      const b = path.join(root, 'cycle-b');
+      fs.symlinkSync(b, a);
+      fs.symlinkSync(a, b);
+      // Bounded by SYMLOOP_MAX hops; the caller still range-checks the result.
+      expect(() => realpathNearestExisting(a)).not.toThrow();
+    },
+  );
 });
 
 describe('shortenPath', () => {

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -413,6 +413,80 @@ export function isSubpaths(parentPath: string[], childPath: string): boolean {
 }
 
 /**
+ * Follow a leading symlink chain at `inputPath` to its eventual target, even
+ * when that target does not exist yet (a dangling link).
+ *
+ * Security-load-bearing: `fs.existsSync` follows links and reports a dangling
+ * symlink as "missing". Relying on it lets an attacker pre-place
+ * `decoy -> /outside/secret` (target absent) so the path classifies OUTSIDE the
+ * allowed root — while the real operation follows the link INTO it. lstat/readlink
+ * (no-follow) resolve the link target so classification matches where the bytes
+ * actually come from or land.
+ */
+function resolveLeafSymlink(inputPath: string): string {
+  const maxHops = 40; // POSIX SYMLOOP_MAX
+  let current = path.resolve(inputPath);
+  for (let i = 0; i < maxHops; i++) {
+    let stat: fs.Stats;
+    try {
+      stat = fs.lstatSync(current);
+    } catch {
+      return current; // missing or unreadable — nothing left to follow
+    }
+    if (!stat.isSymbolicLink()) {
+      return current;
+    }
+    const target = fs.readlinkSync(current);
+    if (path.isAbsolute(target)) {
+      current = target;
+    } else {
+      // Resolve relative targets against the link's real parent so an
+      // intermediate directory symlink can't mis-resolve the target.
+      let parent: string;
+      try {
+        parent = fs.realpathSync(path.dirname(current));
+      } catch {
+        parent = path.dirname(current);
+      }
+      current = path.resolve(parent, target);
+    }
+  }
+  return current; // chain too deep — caller still range-checks the result
+}
+
+/**
+ * Canonicalize `inputPath` as far as the filesystem allows: resolve symlinks
+ * across the existing prefix, then re-append the segments that do not exist
+ * yet. Never throws — an unresolvable path degrades to its lexical form.
+ *
+ * Callers deciding containment must canonicalize the root the same way unless
+ * that root is partly derived from repo-tracked contents, in which case
+ * resolving it would let a checked-in symlink relocate the boundary.
+ */
+export function realpathNearestExisting(inputPath: string): string {
+  // Resolve a leading (possibly dangling) symlink first so a dangling link into
+  // an allowed root is classified by its target, not treated as a missing file.
+  const resolved = resolveLeafSymlink(inputPath);
+  const missingSegments: string[] = [];
+  let current = resolved;
+
+  while (!fs.existsSync(current)) {
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return resolved;
+    }
+    missingSegments.unshift(path.basename(current));
+    current = parent;
+  }
+
+  try {
+    return path.join(fs.realpathSync(current), ...missingSegments);
+  } catch {
+    return resolved;
+  }
+}
+
+/**
  * Resolves a path with tilde (~) expansion and relative path resolution.
  * Handles tilde expansion for home directory and resolves relative paths
  * against the provided base directory or current working directory.


### PR DESCRIPTION
## What this PR does

Read permission for a file is decided by testing the requested path against the workspace and against a small set of always-allow roots. That test was lexical: it classified a symbolic link by where the link sits rather than by where it points. This change canonicalizes the path first, so the decision is made about the bytes that will actually be read.

The two halves of the check are canonicalized differently, on purpose. For the always-allow roots, both the requested path and the roots are resolved — resolving only one side would produce a spurious confirmation prompt whenever a root itself sits behind a symbolic link, which is the everyday situation on macOS. Those roots are all anchored under the user's home or runtime directory and never derived from repository contents, so resolving them cannot be influenced by a hostile checkout. The managed-memory branch resolves only the requested path, because in local-memory mode that root lives under a repository-tracked directory and the write boundary deliberately refuses to resolve it, so that a checked-in link cannot relocate the boundary.

The lexical resolution that already ran first is kept ahead of the new step. It collapses parent-directory segments before any link is followed, which is weaker than the platform's own canonicalization order but matches how the read tools resolve a path before opening it. Keeping the two in agreement matters more than resolving in the stricter order, because a permission decision made about a different path than the one that gets opened is the more dangerous failure.

The helper that performs this "resolve as far as the filesystem allows" walk already existed in the memory module, where it correctly handles a dangling link — a case a naive existence walk gets wrong, because existence checks follow links and report a dangling one as missing. It is promoted to a shared path utility and reused rather than reimplemented; its behavior is unchanged for the memory callers.

## Why it's needed

Every always-allow root is writable by the agent itself, and one of them is populated from repository-supplied skills. A link created inside any of them was therefore enough to read any file the user can read, with no confirmation prompt — bypassing the only user-facing gate on reading outside the workspace. The sibling branch of the very same condition already canonicalized, so one condition disagreed with itself about what a path means.

The gap has existed in the interactive CLI for some time. It becomes materially worse for the daemon once text reads are served locally in the child process: before that, a delegated read was canonicalized at the workspace boundary and rejected, and the local fallback accepted only paths whose resolved form was inside its managed read roots, so the daemon failed closed on exactly this input.

## Reviewer Test Plan

### How to verify

1. Create a file outside the workspace and outside every managed root, then create a symbolic link to it inside the project temp directory. Ask for a read of the link. Expect a confirmation prompt; before this change the read was auto-approved and the contents appeared in the model's context with no prompt.
2. Repeat with a link whose target does not exist yet. Expect a prompt — a link pointing out of a root must not be privileged just because the target is absent.
3. Confirm ordinary reads still do not prompt: a file inside the workspace, a real file inside an always-allow root, and a not-yet-created file inside one (write and edit pre-reads depend on this).
4. Confirm a root that is itself reached through a symbolic link still matches, in both directions — requesting by the real path with the link configured as the root, and requesting through the link.
5. Confirm managed-memory reads are unaffected for ordinary paths, and that a link planted inside a memory root now prompts.

Unit coverage is added for each of the above, including every always-allow root individually, directory-link traversal, and dangling links. Link-based cases are skipped on Windows, where creating symbolic links needs elevation.

### Evidence (Before & After)

The added suite was run against the unfixed code as a negative control. Ten cases fail there and pass after the change, which is what establishes them as regression coverage rather than decoration.

Before (fix reverted, same tests): nine escape cases report `expected 'allow' to be 'ask'` — the permission check silently authorized reading a file outside every root through a planted link — and the symlinked-root case reports `expected 'ask' to be 'allow'`, confirming that resolving only one side of the comparison would break legitimate matches. The five baseline containment cases pass either way, as they should.

After: 15 passed in the new suite; 157 passed and 1 skipped across it plus the shared path utility suite; 10 passed in the suite covering the promoted helper's existing callers, confirming the move changed nothing for them.

### Tested on

|     OS     |    Status     |
| :--------: | :-----------: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  |   ✅ tested   |

### Environment (optional)

Unit tests only. Link-based cases skip on Windows, where creating symbolic links needs elevation.

## Risk & Scope

- Main risk or tradeoff: this is a core permission boundary. It has exactly two consumers — the file read tool and the image zoom tool — and both call it the same way. The change can only turn a previous `allow` into `ask`; it never turns an `ask` into an `allow`. The cost is a small number of additional path resolutions per tool confirmation, on the same order as the workspace check already performed alongside it. The shared helper is promoted, not modified, so the memory callers keep their current behavior.
- Not validated / out of scope: the read and write asymmetry in the daemon, resource limits on shared pre-reads, and the parent-directory-before-link resolution order are all left as they are; the last is deliberate and explained above. Windows is not verified locally, and link-based cases skip there.
- Breaking changes / migration notes: none. A path that reaches outside an always-allow root through a link now prompts instead of being read silently. That is the intended behavior of the prompt, but a workflow that relied on the previous silence will see a confirmation.

## Linked Issues

Fixes #8635

Found while reviewing #8620; that PR removes the daemon-side defense that previously masked this in `qwen serve`, so this should land first.

<details>
<summary>中文说明</summary>

## 此 PR 做了什么

文件的读取权限是通过将请求路径与 workspace 以及一小组"始终允许"的根目录做比较来决定的。此前该比较是词法的：它按符号链接**所在位置**而非**指向位置**来分类。本改动先对路径做规范化，使权限判定针对的是真正会被读取的内容。

判定的两个部分被有意地采用不同的规范化策略。对于始终允许的根目录，请求路径与根目录**两侧**都做解析——只解析一侧会在根目录自身位于符号链接之后时产生多余的确认提示，而这在 macOS 上是日常情况。这些根目录全部锚定在用户 home 或 runtime 目录之下，绝不由仓库内容派生，因此解析它们不会被恶意 checkout 操纵。托管 memory 分支则**只**解析请求路径，因为在 local-memory 模式下该根目录位于仓库跟踪的目录之下，而写边界正是有意拒绝解析它，以防签入的链接挪动边界。

原本已存在的词法解析仍保留在新步骤之前。它会在跟随任何链接之前折叠上级目录片段，这弱于平台自身的规范化顺序，但与读取工具打开文件前的解析方式一致。保持两者一致比采用更严格的解析顺序更重要，因为"权限判定所针对的路径"与"实际被打开的路径"不一致才是更危险的失败模式。

执行这种"在文件系统允许的范围内尽量解析"的辅助函数原本就存在于 memory 模块中，它正确处理了悬空链接——这是朴素的存在性查找会出错的情况，因为存在性检查会跟随链接并把悬空链接报告为"不存在"。本 PR 将其提升为共享路径工具并复用，而非重新实现；对 memory 侧调用方的行为没有变化。

## 为什么需要

每一个始终允许的根目录都是 agent 自身可写的，其中之一还会由仓库提供的 skill 填充。因此只要在其中任意一个里创建一个链接，就足以读取用户能读取的任何文件，且没有确认提示——绕过了读取 workspace 之外内容时唯一面向用户的关卡。而同一个条件中的兄弟分支本就做了规范化，等于同一个条件对"路径是什么"这件事自相矛盾。

该缺口在交互式 CLI 中已存在一段时间。而当 daemon 将文本读取改为在 child 进程本地执行后，问题明显加重：在此之前，被委托的读取会在 workspace 边界被规范化并拒绝，本地 fallback 也只接受解析后位于其托管读取根内的路径，因此 daemon 对这一输入是 fail-closed 的。

## Reviewer 测试计划

### 如何验证

1. 在 workspace 之外、且不属于任何托管根目录的位置创建一个文件，然后在项目临时目录内创建指向它的符号链接。请求读取该链接。预期弹出确认提示；改动前该读取会被自动批准，内容直接进入模型上下文且无任何提示。
2. 用一个目标尚不存在的链接重复上述步骤。预期仍弹出提示——指向根目录之外的链接不应仅因目标不存在就获得特权。
3. 确认常规读取仍不弹提示：workspace 内的文件、始终允许根目录内的真实文件，以及其中尚未创建的文件（write 和 edit 的预读依赖这一点）。
4. 确认经由符号链接抵达的根目录仍能匹配，且双向均可——以真实路径请求而根目录配置为链接，以及经由链接请求。
5. 确认托管 memory 的常规路径读取不受影响，而植入 memory 根目录内部的链接现在会弹出提示。

以上每一条都补充了单元测试，包括逐个覆盖每一个始终允许的根目录、目录链接穿越以及悬空链接。涉及链接的用例在 Windows 上跳过，因为在该平台创建符号链接需要提权。

### 证据（改动前后）

新增测试套件在未修复的代码上做了反向对照运行。其中 10 条在改动前失败、改动后通过，这才使它们成为真正的回归覆盖而非装饰。

改动前（回退修复、同一批测试）：9 条逃逸用例报 `expected 'allow' to be 'ask'`——即权限检查经由植入的链接静默授权了对所有根目录之外文件的读取；symlink 根目录那条报 `expected 'ask' to be 'allow'`，确认只规范化比较的一侧会破坏合法匹配。5 条基线包含性用例在两种情况下都通过，符合预期。

改动后：新套件 15 条通过；连同共享路径工具套件共 157 通过、1 跳过；覆盖被提升辅助函数原有调用方的套件 10 条通过，确认该搬移对它们没有任何行为影响。

### 已测试平台

|     操作系统     |    状态     |
| :--------------: | :---------: |
|    🍏 macOS      |  ⚠️ 未测试  |
|   🪟 Windows     |  ⚠️ 未测试  |
|    🐧 Linux      |  ✅ 已测试  |

### 环境（可选）

仅单元测试。涉及链接的用例在 Windows 上跳过，因为该平台创建符号链接需要提权。

## 风险与范围

- 主要风险或取舍：这是一个核心权限边界。它恰好有两个使用方——文件读取工具和图像放大工具——且两者调用方式相同。该改动只可能把原先的 `allow` 变为 `ask`，绝不会把 `ask` 变为 `allow`。代价是每次工具确认时增加少量路径解析，量级与其旁边本就执行的 workspace 检查相当。共享辅助函数是被提升而非被修改，因此 memory 侧调用方保持现有行为。
- 未验证或范围外：daemon 的读写不对称、共享预读的资源上限，以及"先折叠上级目录再跟随链接"的解析顺序均保持原样；最后一项是有意为之，理由见上文。Windows 未在本地验证，涉及链接的用例在该平台跳过。
- 破坏性变更或迁移说明：无。经由链接指向始终允许根目录之外的路径，现在会弹出提示而不再被静默读取。这正是该提示的预期行为，但依赖此前静默行为的工作流会看到一次确认。

## 关联 Issue

Fixes #8635

该问题在 review #8620 时发现；那个 PR 移除了此前在 `qwen serve` 中掩盖此问题的 daemon 侧防线，因此本 PR 应先行合入。

</details>
