### PR TITLE
feat(cli): mirror Live Host downloads through OSS

### DIFF
--- a/.github/workflows/live-host-release.yml
+++ b/.github/workflows/live-host-release.yml
@@ -278,6 +278,8 @@ jobs:
     env:
       GH_REPO: '${{ github.repository }}'
     steps:
+      - uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
+
       - uses: 'actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c' # v8.0.1
         with:
           path: 'release-assets'
@@ -286,6 +288,17 @@ jobs:
       - name: 'Generate checksums'
         working-directory: 'release-assets'
         run: 'sha256sum -- * > SHA256SUMS.txt'
+
+      - name: 'Check immutable OSS prefix before publishing'
+        if: '${{ inputs.draft == false && inputs.prerelease == false }}'
+        env:
+          ALIYUN_OSS_PUBLIC_BASE_URL: "${{ vars.ALIYUN_OSS_PUBLIC_BASE_URL || 'https://qwen-code-assets.oss-cn-hangzhou.aliyuncs.com' }}"
+          RELEASE_VERSION: '${{ needs.prepare.outputs.version }}'
+        run: |
+          node scripts/check-live-host-oss-state.js prefix \
+            --base-url "$ALIYUN_OSS_PUBLIC_BASE_URL" \
+            --version "$RELEASE_VERSION" \
+            --manifest release-assets/Qwen-Live-Host-manifest.json
 
       - name: 'Create GitHub release'
         id: 'release'
@@ -371,4 +384,3 @@ jobs:
       version: '${{ needs.prepare.outputs.version }}'
       dry_run: false
       source: 'artifact'
-    secrets: 'inherit'

--- a/.github/workflows/live-host-release.yml
+++ b/.github/workflows/live-host-release.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/live-host-release.yml'
+      - '.github/workflows/sync-live-host-to-oss.yml'
       - 'packages/desktop/apps/live-host/**'
       - 'packages/desktop/bun.lock'
       - 'packages/desktop/package.json'
@@ -345,3 +346,29 @@ jobs:
             echo "Version: $RELEASE_VERSION"
             echo "Release: $RELEASE_URL"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  oss-dry-run:
+    name: 'Dry-run Live Host OSS sync'
+    if: "${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.dry_run) }}"
+    needs:
+      - 'prepare'
+      - 'build'
+    uses: './.github/workflows/sync-live-host-to-oss.yml'
+    with:
+      version: '${{ needs.prepare.outputs.version }}'
+      dry_run: true
+      source: 'artifact'
+
+  sync-oss:
+    name: 'Sync stable Live Host release to OSS'
+    if: "${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == false && inputs.draft == false && inputs.prerelease == false && github.repository == 'QwenLM/qwen-code' }}"
+    needs:
+      - 'prepare'
+      - 'build'
+      - 'publish'
+    uses: './.github/workflows/sync-live-host-to-oss.yml'
+    with:
+      version: '${{ needs.prepare.outputs.version }}'
+      dry_run: false
+      source: 'artifact'
+    secrets: 'inherit'

--- a/.github/workflows/sync-live-host-to-oss.yml
+++ b/.github/workflows/sync-live-host-to-oss.yml
@@ -41,7 +41,7 @@ permissions:
   contents: 'read'
 
 concurrency:
-  group: 'sync-live-host-to-oss-${{ inputs.version }}'
+  group: 'sync-live-host-to-oss'
   cancel-in-progress: false
 
 env:
@@ -62,8 +62,8 @@ jobs:
           VERSION: '${{ inputs.version }}'
         run: |
           set -euo pipefail
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-            echo "::error::Invalid Qwen Live Host version: $VERSION"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Only a stable Qwen Live Host version can be mirrored: $VERSION"
             exit 1
           fi
           if [ "$SOURCE" != 'artifact' ] && [ "$SOURCE" != 'release' ]; then
@@ -123,6 +123,16 @@ jobs:
           }
           NODE
 
+      - name: 'Check immutable version prefix without writing'
+        env:
+          ALIYUN_OSS_PUBLIC_BASE_URL: "${{ vars.ALIYUN_OSS_PUBLIC_BASE_URL || 'https://qwen-code-assets.oss-cn-hangzhou.aliyuncs.com' }}"
+          VERSION: '${{ inputs.version }}'
+        run: |
+          node scripts/check-live-host-oss-state.js prefix \
+            --base-url "$ALIYUN_OSS_PUBLIC_BASE_URL" \
+            --version "$VERSION" \
+            --manifest release-assets/Qwen-Live-Host-manifest.json
+
       - name: 'Report planned OSS objects'
         env:
           VERSION: '${{ inputs.version }}'
@@ -157,8 +167,8 @@ jobs:
           VERSION: '${{ inputs.version }}'
         run: |
           set -euo pipefail
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-            echo "::error::Invalid Qwen Live Host version: $VERSION"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Only a stable Qwen Live Host version can be mirrored: $VERSION"
             exit 1
           fi
           if [ "$SOURCE" != 'artifact' ] && [ "$SOURCE" != 'release' ]; then
@@ -228,11 +238,13 @@ jobs:
           base="${ALIYUN_OSS_PUBLIC_BASE_URL%/}/live-host/v${VERSION}"
           existing="$RUNNER_TEMP/existing-live-host"
           mkdir -p "$existing"
-          if curl -fsSL --connect-timeout 15 --max-time 60 "$base/Qwen-Live-Host-manifest.json" -o "$existing/Qwen-Live-Host-manifest.json"; then
-            if ! cmp -s release-assets/Qwen-Live-Host-manifest.json "$existing/Qwen-Live-Host-manifest.json"; then
-              echo '::error::The immutable OSS version manifest already exists with different contents.'
-              exit 1
-            fi
+          sealed="$(node scripts/check-live-host-oss-state.js prefix \
+            --base-url "$ALIYUN_OSS_PUBLIC_BASE_URL" \
+            --version "$VERSION" \
+            --manifest release-assets/Qwen-Live-Host-manifest.json)"
+          if [ "$sealed" = 'true' ]; then
+            cp release-assets/Qwen-Live-Host-manifest.json \
+              "$existing/Qwen-Live-Host-manifest.json"
             for architecture in arm64 x64; do
               curl -fsSL --connect-timeout 15 --max-time 3600 \
                 "$base/Qwen-Live-Host-${architecture}.zip" \
@@ -255,10 +267,8 @@ jobs:
                 }
               }
             '
-            echo 'sealed=true' >> "$GITHUB_OUTPUT"
-          else
-            echo 'sealed=false' >> "$GITHUB_OUTPUT"
           fi
+          echo "sealed=$sealed" >> "$GITHUB_OUTPUT"
 
       - name: 'Install ossutil'
         env:
@@ -345,7 +355,18 @@ jobs:
           }
           NODE
 
+      - name: 'Check latest manifest version'
+        id: 'latest'
+        env:
+          ALIYUN_OSS_PUBLIC_BASE_URL: "${{ vars.ALIYUN_OSS_PUBLIC_BASE_URL || 'https://qwen-code-assets.oss-cn-hangzhou.aliyuncs.com' }}"
+        run: |
+          update="$(node scripts/check-live-host-oss-state.js latest \
+            --base-url "$ALIYUN_OSS_PUBLIC_BASE_URL" \
+            --manifest release-assets/Qwen-Live-Host-manifest.json)"
+          echo "update=$update" >> "$GITHUB_OUTPUT"
+
       - name: 'Update latest manifest'
+        if: "${{ steps.latest.outputs.update == 'true' }}"
         env:
           ALIYUN_OSS_BUCKET: "${{ vars.ALIYUN_OSS_BUCKET || 'qwen-code-assets' }}"
         run: |
@@ -356,6 +377,7 @@ jobs:
             release-assets/Qwen-Live-Host-manifest.json
 
       - name: 'Verify latest manifest'
+        if: "${{ steps.latest.outputs.update == 'true' }}"
         env:
           ALIYUN_OSS_PUBLIC_BASE_URL: "${{ vars.ALIYUN_OSS_PUBLIC_BASE_URL || 'https://qwen-code-assets.oss-cn-hangzhou.aliyuncs.com' }}"
         run: |

--- a/.github/workflows/sync-live-host-to-oss.yml
+++ b/.github/workflows/sync-live-host-to-oss.yml
@@ -1,0 +1,370 @@
+name: 'Sync Qwen Live Host to Aliyun OSS'
+
+run-name: "Qwen Live Host OSS ${{ inputs.dry_run && 'dry run' || 'sync' }} v${{ inputs.version }}"
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Qwen Live Host version.'
+        required: true
+        type: 'string'
+      dry_run:
+        description: 'Verify assets and planned object keys without uploading.'
+        required: true
+        type: 'boolean'
+      source:
+        description: 'Read assets from this workflow run or a GitHub release.'
+        required: false
+        default: 'artifact'
+        type: 'string'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Stable Qwen Live Host version, for example 0.1.0.'
+        required: true
+        type: 'string'
+      dry_run:
+        description: 'Verify without uploading to OSS.'
+        required: true
+        default: true
+        type: 'boolean'
+      source:
+        description: 'Asset source.'
+        required: true
+        default: 'release'
+        type: 'choice'
+        options:
+          - 'release'
+
+permissions:
+  contents: 'read'
+
+concurrency:
+  group: 'sync-live-host-to-oss-${{ inputs.version }}'
+  cancel-in-progress: false
+
+env:
+  LIVE_HOST_ARTIFACT: 'qwen-live-host-macos'
+
+jobs:
+  dry-run:
+    name: 'Dry-run Live Host OSS sync'
+    if: '${{ inputs.dry_run }}'
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 20
+    steps:
+      - uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
+
+      - name: 'Validate sync inputs'
+        env:
+          SOURCE: '${{ inputs.source }}'
+          VERSION: '${{ inputs.version }}'
+        run: |
+          set -euo pipefail
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Invalid Qwen Live Host version: $VERSION"
+            exit 1
+          fi
+          if [ "$SOURCE" != 'artifact' ] && [ "$SOURCE" != 'release' ]; then
+            echo "::error::Invalid Qwen Live Host asset source: $SOURCE"
+            exit 1
+          fi
+
+      - uses: 'actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c' # v8.0.1
+        if: "${{ inputs.source == 'artifact' }}"
+        with:
+          name: '${{ env.LIVE_HOST_ARTIFACT }}'
+          path: 'release-assets'
+
+      - name: 'Download stable GitHub release assets'
+        if: "${{ inputs.source == 'release' }}"
+        env:
+          GH_TOKEN: '${{ github.token }}'
+          VERSION: '${{ inputs.version }}'
+        run: |
+          set -euo pipefail
+          release="$(gh release view "live-host-v${VERSION}" --json isDraft,isPrerelease)"
+          if [ "$(jq -r '.isDraft' <<<"$release")" != 'false' ] || [ "$(jq -r '.isPrerelease' <<<"$release")" != 'false' ]; then
+            echo '::error::Only a published stable Qwen Live Host release can be mirrored.'
+            exit 1
+          fi
+          mkdir -p release-assets
+          gh release download "live-host-v${VERSION}" \
+            --dir release-assets \
+            --pattern 'Qwen-Live-Host-manifest.json' \
+            --pattern 'Qwen-Live-Host-arm64.zip' \
+            --pattern 'Qwen-Live-Host-x64.zip'
+
+      - name: 'Verify source assets'
+        env:
+          RELEASE_VERSION: '${{ inputs.version }}'
+          VERIFY_DIR: 'release-assets'
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import { createHash } from 'node:crypto';
+          import { readFileSync, statSync } from 'node:fs';
+          import { join } from 'node:path';
+
+          const manifestPath = join(process.env.VERIFY_DIR, 'Qwen-Live-Host-manifest.json');
+          const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+          if (manifest.version !== process.env.RELEASE_VERSION) {
+            throw new Error(`Manifest version ${manifest.version} does not match ${process.env.RELEASE_VERSION}.`);
+          }
+          for (const architecture of ['arm64', 'x64']) {
+            const name = `Qwen-Live-Host-${architecture}.zip`;
+            const file = join(process.env.VERIFY_DIR, name);
+            const bytes = readFileSync(file);
+            const asset = manifest.assets?.[architecture];
+            if (asset?.name !== name || asset.size !== statSync(file).size || asset.sha256 !== createHash('sha256').update(bytes).digest('hex')) {
+              throw new Error(`Manifest asset verification failed for ${architecture}.`);
+            }
+          }
+          NODE
+
+      - name: 'Report planned OSS objects'
+        env:
+          VERSION: '${{ inputs.version }}'
+        run: |
+          {
+            echo '## Qwen Live Host OSS dry run'
+            echo
+            echo "Validated version: $VERSION"
+            echo
+            echo 'Planned immutable objects:'
+            echo "- live-host/v$VERSION/Qwen-Live-Host-arm64.zip"
+            echo "- live-host/v$VERSION/Qwen-Live-Host-x64.zip"
+            echo "- live-host/v$VERSION/Qwen-Live-Host-manifest.json"
+            echo
+            echo 'Latest pointer updated only after public mirror verification:'
+            echo '- live-host/latest/Qwen-Live-Host-manifest.json'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  sync:
+    name: 'Sync Live Host assets to OSS'
+    if: "${{ !inputs.dry_run && github.repository == 'QwenLM/qwen-code' }}"
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 60
+    environment:
+      name: 'production-release'
+    steps:
+      - uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
+
+      - name: 'Validate sync inputs'
+        env:
+          SOURCE: '${{ inputs.source }}'
+          VERSION: '${{ inputs.version }}'
+        run: |
+          set -euo pipefail
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Invalid Qwen Live Host version: $VERSION"
+            exit 1
+          fi
+          if [ "$SOURCE" != 'artifact' ] && [ "$SOURCE" != 'release' ]; then
+            echo "::error::Invalid Qwen Live Host asset source: $SOURCE"
+            exit 1
+          fi
+
+      - uses: 'actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c' # v8.0.1
+        if: "${{ inputs.source == 'artifact' }}"
+        with:
+          name: '${{ env.LIVE_HOST_ARTIFACT }}'
+          path: 'release-assets'
+
+      - name: 'Download stable GitHub release assets'
+        if: "${{ inputs.source == 'release' }}"
+        env:
+          GH_TOKEN: '${{ github.token }}'
+          VERSION: '${{ inputs.version }}'
+        run: |
+          set -euo pipefail
+          release="$(gh release view "live-host-v${VERSION}" --json isDraft,isPrerelease)"
+          if [ "$(jq -r '.isDraft' <<<"$release")" != 'false' ] || [ "$(jq -r '.isPrerelease' <<<"$release")" != 'false' ]; then
+            echo '::error::Only a published stable Qwen Live Host release can be mirrored.'
+            exit 1
+          fi
+          mkdir -p release-assets
+          gh release download "live-host-v${VERSION}" \
+            --dir release-assets \
+            --pattern 'Qwen-Live-Host-manifest.json' \
+            --pattern 'Qwen-Live-Host-arm64.zip' \
+            --pattern 'Qwen-Live-Host-x64.zip'
+
+      - name: 'Verify source assets'
+        env:
+          RELEASE_VERSION: '${{ inputs.version }}'
+          VERIFY_DIR: 'release-assets'
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import { createHash } from 'node:crypto';
+          import { readFileSync, statSync } from 'node:fs';
+          import { join } from 'node:path';
+
+          const manifestPath = join(process.env.VERIFY_DIR, 'Qwen-Live-Host-manifest.json');
+          const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+          if (manifest.version !== process.env.RELEASE_VERSION) {
+            throw new Error(`Manifest version ${manifest.version} does not match ${process.env.RELEASE_VERSION}.`);
+          }
+          for (const architecture of ['arm64', 'x64']) {
+            const name = `Qwen-Live-Host-${architecture}.zip`;
+            const file = join(process.env.VERIFY_DIR, name);
+            const bytes = readFileSync(file);
+            const asset = manifest.assets?.[architecture];
+            if (asset?.name !== name || asset.size !== statSync(file).size || asset.sha256 !== createHash('sha256').update(bytes).digest('hex')) {
+              throw new Error(`Manifest asset verification failed for ${architecture}.`);
+            }
+          }
+          NODE
+
+      - name: 'Check immutable version prefix'
+        id: 'version-prefix'
+        env:
+          ALIYUN_OSS_PUBLIC_BASE_URL: "${{ vars.ALIYUN_OSS_PUBLIC_BASE_URL || 'https://qwen-code-assets.oss-cn-hangzhou.aliyuncs.com' }}"
+          VERSION: '${{ inputs.version }}'
+        run: |
+          set -euo pipefail
+          base="${ALIYUN_OSS_PUBLIC_BASE_URL%/}/live-host/v${VERSION}"
+          existing="$RUNNER_TEMP/existing-live-host"
+          mkdir -p "$existing"
+          if curl -fsSL --connect-timeout 15 --max-time 60 "$base/Qwen-Live-Host-manifest.json" -o "$existing/Qwen-Live-Host-manifest.json"; then
+            if ! cmp -s release-assets/Qwen-Live-Host-manifest.json "$existing/Qwen-Live-Host-manifest.json"; then
+              echo '::error::The immutable OSS version manifest already exists with different contents.'
+              exit 1
+            fi
+            for architecture in arm64 x64; do
+              curl -fsSL --connect-timeout 15 --max-time 3600 \
+                "$base/Qwen-Live-Host-${architecture}.zip" \
+                -o "$existing/Qwen-Live-Host-${architecture}.zip"
+            done
+            # shellcheck disable=SC2016
+            VERIFY_DIR="$existing" RELEASE_VERSION="$VERSION" node --input-type=module -e '
+              import { createHash } from "node:crypto";
+              import { readFileSync, statSync } from "node:fs";
+              import { join } from "node:path";
+              const manifest = JSON.parse(readFileSync(join(process.env.VERIFY_DIR, "Qwen-Live-Host-manifest.json"), "utf8"));
+              if (manifest.version !== process.env.RELEASE_VERSION) throw new Error("Existing OSS manifest version is invalid.");
+              for (const architecture of ["arm64", "x64"]) {
+                const name = `Qwen-Live-Host-${architecture}.zip`;
+                const file = join(process.env.VERIFY_DIR, name);
+                const bytes = readFileSync(file);
+                const asset = manifest.assets?.[architecture];
+                if (asset?.name !== name || asset.size !== statSync(file).size || asset.sha256 !== createHash("sha256").update(bytes).digest("hex")) {
+                  throw new Error(`Existing OSS asset verification failed for ${architecture}.`);
+                }
+              }
+            '
+            echo 'sealed=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'sealed=false' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: 'Install ossutil'
+        env:
+          OSSUTIL_URL: "${{ vars.OSSUTIL_URL || 'https://gosspublic.alicdn.com/ossutil/1.7.19/ossutil-v1.7.19-linux-amd64.zip' }}"
+          OSSUTIL_SHA256: "${{ vars.OSSUTIL_SHA256 || 'dcc512e4a893e16bbee63bc769339d8e56b21744fd83c8212a9d8baf28767343' }}"
+        run: |
+          set -euo pipefail
+          tmp_dir="$(mktemp -d)"
+          curl -fsSL --connect-timeout 15 --max-time 300 "$OSSUTIL_URL" -o "$tmp_dir/ossutil.zip"
+          echo "$OSSUTIL_SHA256  $tmp_dir/ossutil.zip" | sha256sum -c -
+          unzip -q "$tmp_dir/ossutil.zip" -d "$tmp_dir"
+          ossutil_path="$(find "$tmp_dir" -type f \( -name 'ossutil' -o -name 'ossutil64' \) -print -quit)"
+          if [ -z "$ossutil_path" ]; then echo '::error::ossutil binary not found.'; exit 1; fi
+          mkdir -p "$HOME/.local/bin"
+          install -m 0755 "$ossutil_path" "$HOME/.local/bin/ossutil"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          rm -rf "$tmp_dir"
+
+      - name: 'Configure Aliyun OSS credentials'
+        env:
+          ALIYUN_OSS_ACCESS_KEY_ID: '${{ secrets.ALIYUN_OSS_ACCESS_KEY_ID }}'
+          ALIYUN_OSS_ACCESS_KEY_SECRET: '${{ secrets.ALIYUN_OSS_ACCESS_KEY_SECRET }}'
+          ALIYUN_OSS_ENDPOINT: "${{ vars.ALIYUN_OSS_ENDPOINT || 'https://oss-cn-hangzhou.aliyuncs.com' }}"
+        run: |
+          set -euo pipefail
+          if [ -z "$ALIYUN_OSS_ACCESS_KEY_ID" ] || [ -z "$ALIYUN_OSS_ACCESS_KEY_SECRET" ]; then
+            echo '::error::Missing Aliyun OSS credentials in the production-release environment.'
+            exit 1
+          fi
+          ossutil config \
+            -e "$ALIYUN_OSS_ENDPOINT" \
+            -i "$ALIYUN_OSS_ACCESS_KEY_ID" \
+            -k "$ALIYUN_OSS_ACCESS_KEY_SECRET" \
+            -L EN \
+            -c "$RUNNER_TEMP/.ossutilconfig"
+
+      - name: 'Upload immutable version assets'
+        if: "${{ steps.version-prefix.outputs.sealed != 'true' }}"
+        env:
+          ALIYUN_OSS_BUCKET: "${{ vars.ALIYUN_OSS_BUCKET || 'qwen-code-assets' }}"
+          VERSION: '${{ inputs.version }}'
+        run: |
+          node scripts/upload-aliyun-oss-assets.js \
+            --bucket "$ALIYUN_OSS_BUCKET" \
+            --config "$RUNNER_TEMP/.ossutilconfig" \
+            --prefix "live-host/v${VERSION}" \
+            release-assets/Qwen-Live-Host-arm64.zip \
+            release-assets/Qwen-Live-Host-x64.zip \
+            release-assets/Qwen-Live-Host-manifest.json
+
+      - name: 'Verify public immutable assets'
+        env:
+          ALIYUN_OSS_PUBLIC_BASE_URL: "${{ vars.ALIYUN_OSS_PUBLIC_BASE_URL || 'https://qwen-code-assets.oss-cn-hangzhou.aliyuncs.com' }}"
+          VERSION: '${{ inputs.version }}'
+        run: |
+          set -euo pipefail
+          base="${ALIYUN_OSS_PUBLIC_BASE_URL%/}/live-host/v${VERSION}"
+          mirrored="$RUNNER_TEMP/mirrored-live-host"
+          mkdir -p "$mirrored"
+          curl -fsSL --connect-timeout 15 --max-time 60 \
+            "$base/Qwen-Live-Host-manifest.json" \
+            -o "$mirrored/Qwen-Live-Host-manifest.json"
+          cmp -s release-assets/Qwen-Live-Host-manifest.json "$mirrored/Qwen-Live-Host-manifest.json"
+          for architecture in arm64 x64; do
+            curl -fsSL --connect-timeout 15 --max-time 3600 \
+              "$base/Qwen-Live-Host-${architecture}.zip" \
+              -o "$mirrored/Qwen-Live-Host-${architecture}.zip"
+          done
+          VERIFY_DIR="$mirrored" RELEASE_VERSION="$VERSION" node --input-type=module <<'NODE'
+          import { createHash } from 'node:crypto';
+          import { readFileSync, statSync } from 'node:fs';
+          import { join } from 'node:path';
+
+          const manifest = JSON.parse(readFileSync(join(process.env.VERIFY_DIR, 'Qwen-Live-Host-manifest.json'), 'utf8'));
+          if (manifest.version !== process.env.RELEASE_VERSION) throw new Error('Mirrored manifest version is invalid.');
+          for (const architecture of ['arm64', 'x64']) {
+            const name = `Qwen-Live-Host-${architecture}.zip`;
+            const file = join(process.env.VERIFY_DIR, name);
+            const bytes = readFileSync(file);
+            const asset = manifest.assets?.[architecture];
+            if (asset?.name !== name || asset.size !== statSync(file).size || asset.sha256 !== createHash('sha256').update(bytes).digest('hex')) {
+              throw new Error(`Mirrored asset verification failed for ${architecture}.`);
+            }
+          }
+          NODE
+
+      - name: 'Update latest manifest'
+        env:
+          ALIYUN_OSS_BUCKET: "${{ vars.ALIYUN_OSS_BUCKET || 'qwen-code-assets' }}"
+        run: |
+          node scripts/upload-aliyun-oss-assets.js \
+            --bucket "$ALIYUN_OSS_BUCKET" \
+            --config "$RUNNER_TEMP/.ossutilconfig" \
+            --prefix 'live-host/latest' \
+            release-assets/Qwen-Live-Host-manifest.json
+
+      - name: 'Verify latest manifest'
+        env:
+          ALIYUN_OSS_PUBLIC_BASE_URL: "${{ vars.ALIYUN_OSS_PUBLIC_BASE_URL || 'https://qwen-code-assets.oss-cn-hangzhou.aliyuncs.com' }}"
+        run: |
+          set -euo pipefail
+          curl -fsSL --connect-timeout 15 --max-time 60 \
+            "${ALIYUN_OSS_PUBLIC_BASE_URL%/}/live-host/latest/Qwen-Live-Host-manifest.json" \
+            -o "$RUNNER_TEMP/latest-live-host-manifest.json"
+          cmp -s release-assets/Qwen-Live-Host-manifest.json "$RUNNER_TEMP/latest-live-host-manifest.json"
+
+      - name: 'Cleanup Aliyun OSS credentials'
+        if: '${{ always() }}'
+        run: 'rm -f "$RUNNER_TEMP/.ossutilconfig"'

--- a/.github/workflows/sync-live-host-to-oss.yml
+++ b/.github/workflows/sync-live-host-to-oss.yml
@@ -131,7 +131,8 @@ jobs:
           node scripts/check-live-host-oss-state.js prefix \
             --base-url "$ALIYUN_OSS_PUBLIC_BASE_URL" \
             --version "$VERSION" \
-            --manifest release-assets/Qwen-Live-Host-manifest.json
+            --manifest release-assets/Qwen-Live-Host-manifest.json \
+            --allow-hidden-missing
 
       - name: 'Report planned OSS objects'
         env:

--- a/docs/design/web-shell-live-voice-codex-parity-refactor.md
+++ b/docs/design/web-shell-live-voice-codex-parity-refactor.md
@@ -313,15 +313,16 @@ Stable release publishing mirrors only the installer ZIPs and manifest to the
 public `qwen-code-assets` OSS bucket. Each version is sealed under
 `live-host/v<version>/`; an existing version manifest makes that prefix
 immutable. The workflow re-downloads and verifies both public ZIPs before it
-updates `live-host/latest/Qwen-Live-Host-manifest.json`. The installer resolves
-the latest manifest from OSS before GitHub, then resolves the selected
-versioned OSS ZIP before the GitHub stable-feed ZIP. A failed response,
+updates `live-host/latest/Qwen-Live-Host-manifest.json`. The installer tries the
+OSS latest manifest and its versioned ZIP as one source, then the GitHub
+stable-feed manifest and ZIP as the independent fallback. A failed response,
 truncated download, size mismatch, or checksum mismatch removes the temporary
 archive and advances to the next source. Bundle identity, Developer ID,
 Gatekeeper, protocol, version, size, and SHA-256 verification remain mandatory
 regardless of source. The workflow changes the latest pointer only after the
-versioned assets pass public verification, so earlier failures leave the
-previous pointer intact. GitHub remains the independent release origin.
+versioned assets pass public verification and never points it to an older
+version, so earlier failures and old-version re-mirrors leave the previous
+pointer intact. GitHub remains the independent release origin.
 
 Enabling or disabling Live is hot-applied. A user must not restart the daemon:
 the same process publishes or removes Host discovery, creates the projectless

--- a/docs/design/web-shell-live-voice-codex-parity-refactor.md
+++ b/docs/design/web-shell-live-voice-codex-parity-refactor.md
@@ -274,10 +274,10 @@ The complete first-use path is:
    `qwen3.5-omni-plus-realtime` and optionally change the global shortcut.
 3. Turn on Live Voice and confirm that the signed native Host will be
    installed.
-4. The daemon downloads the architecture-matching release from the fixed
-   Qwen Code release origin, verifies its manifest checksum, bundle identity,
-   signature, and Gatekeeper acceptance, installs it atomically in
-   `/Applications`, and launches it.
+4. The daemon downloads the architecture-matching release from the Qwen Code
+   OSS mirror with the independent GitHub release feed as fallback, verifies
+   its manifest checksum, bundle identity, signature, and Gatekeeper
+   acceptance, installs it atomically in `/Applications`, and launches it.
 5. The Host guides the user through Microphone, Accessibility, and Screen
    Recording authorization. macOS remains the sole grant authority; the
    application cannot pre-grant or bypass TCC permissions.
@@ -308,6 +308,20 @@ a machine-readable manifest containing the protocol version, application
 version, architecture, fixed asset name, size, and SHA-256 checksum. The
 installer never accepts a caller-provided URL, path, executable, or shell
 command and never falls back to an unsigned/development build.
+
+Stable release publishing mirrors only the installer ZIPs and manifest to the
+public `qwen-code-assets` OSS bucket. Each version is sealed under
+`live-host/v<version>/`; an existing version manifest makes that prefix
+immutable. The workflow re-downloads and verifies both public ZIPs before it
+updates `live-host/latest/Qwen-Live-Host-manifest.json`. The installer resolves
+the latest manifest from OSS before GitHub, then resolves the selected
+versioned OSS ZIP before the GitHub stable-feed ZIP. A failed response,
+truncated download, size mismatch, or checksum mismatch removes the temporary
+archive and advances to the next source. Bundle identity, Developer ID,
+Gatekeeper, protocol, version, size, and SHA-256 verification remain mandatory
+regardless of source. The workflow changes the latest pointer only after the
+versioned assets pass public verification, so earlier failures leave the
+previous pointer intact. GitHub remains the independent release origin.
 
 Enabling or disabling Live is hot-applied. A user must not restart the daemon:
 the same process publishes or removes Host discovery, creates the projectless

--- a/packages/cli/src/serve/live/live-host-installer.test.ts
+++ b/packages/cli/src/serve/live/live-host-installer.test.ts
@@ -4,13 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { createHash } from 'node:crypto';
+import * as fsp from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import { LIVE_HOST_PROTOCOL_VERSION } from './types.js';
 import {
+  downloadLiveHostAssetForTesting,
+  fetchLiveHostManifestForTesting,
   isExpectedLiveHostSignature,
   LiveHostInstaller,
+  LIVE_HOST_FETCH_TIMEOUT_MS,
+  LIVE_HOST_OSS_BASE_URL,
   LIVE_HOST_RELEASE_BASE_URL,
   parseLiveHostReleaseManifest,
+  resolveLiveHostAssetUrls,
+  resolveLiveHostManifestUrls,
 } from './live-host-installer.js';
 
 const sha = 'a'.repeat(64);
@@ -37,10 +47,83 @@ function manifest() {
 }
 
 describe('LiveHostInstaller', () => {
-  it('downloads only from the independent stable Live Host feed', () => {
+  it('prefers OSS and retains the independent GitHub release fallback', () => {
+    expect(LIVE_HOST_OSS_BASE_URL).toBe(
+      'https://qwen-code-assets.oss-cn-hangzhou.aliyuncs.com/live-host',
+    );
     expect(LIVE_HOST_RELEASE_BASE_URL).toBe(
       'https://github.com/QwenLM/qwen-code/releases/download/live-host-latest',
     );
+    expect(resolveLiveHostManifestUrls()).toEqual([
+      `${LIVE_HOST_OSS_BASE_URL}/latest/Qwen-Live-Host-manifest.json`,
+      `${LIVE_HOST_RELEASE_BASE_URL}/Qwen-Live-Host-manifest.json`,
+    ]);
+    expect(
+      resolveLiveHostAssetUrls('0.1.0', 'Qwen-Live-Host-arm64.zip'),
+    ).toEqual([
+      `${LIVE_HOST_OSS_BASE_URL}/v0.1.0/Qwen-Live-Host-arm64.zip`,
+      `${LIVE_HOST_RELEASE_BASE_URL}/Qwen-Live-Host-arm64.zip`,
+    ]);
+  });
+
+  it('allows slow Live Host downloads to finish', () => {
+    expect(LIVE_HOST_FETCH_TIMEOUT_MS).toBe(60 * 60 * 1000);
+  });
+
+  it('falls back to GitHub when the OSS manifest is unavailable', async () => {
+    const expected = manifest();
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(Response.json(expected));
+
+    await expect(fetchLiveHostManifestForTesting(fetchImpl)).resolves.toEqual(
+      expected,
+    );
+    expect(fetchImpl.mock.calls.map(([url]) => String(url))).toEqual(
+      resolveLiveHostManifestUrls(),
+    );
+  });
+
+  it('removes a corrupt OSS download before falling back to GitHub', async () => {
+    const bytes = Buffer.from('signed-live-host-archive');
+    const asset = {
+      name: 'Qwen-Live-Host-arm64.zip',
+      size: bytes.byteLength,
+      sha256: createHash('sha256').update(bytes).digest('hex'),
+    };
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(Buffer.alloc(bytes.byteLength), {
+          headers: { 'content-length': String(bytes.byteLength) },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(bytes, {
+          headers: { 'content-length': String(bytes.byteLength) },
+        }),
+      );
+    const directory = await fsp.mkdtemp(
+      path.join(os.tmpdir(), 'live-host-download-test-'),
+    );
+    const destination = path.join(directory, asset.name);
+
+    try {
+      await downloadLiveHostAssetForTesting(
+        '0.1.0',
+        asset,
+        destination,
+        () => {},
+        fetchImpl,
+      );
+      await expect(fsp.readFile(destination)).resolves.toEqual(bytes);
+      expect(fetchImpl.mock.calls.map(([url]) => String(url))).toEqual(
+        resolveLiveHostAssetUrls('0.1.0', asset.name),
+      );
+    } finally {
+      await fsp.rm(directory, { recursive: true, force: true });
+    }
   });
 
   it('accepts only the Qwen Developer ID team', () => {

--- a/packages/cli/src/serve/live/live-host-installer.test.ts
+++ b/packages/cli/src/serve/live/live-host-installer.test.ts
@@ -11,11 +11,11 @@ import * as path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import { LIVE_HOST_PROTOCOL_VERSION } from './types.js';
 import {
-  downloadLiveHostAssetForTesting,
-  fetchLiveHostManifestForTesting,
+  downloadLiveHostReleaseForTesting,
   isExpectedLiveHostSignature,
   LiveHostInstaller,
-  LIVE_HOST_FETCH_TIMEOUT_MS,
+  LIVE_HOST_DOWNLOAD_TIMEOUT_MS,
+  LIVE_HOST_MANIFEST_FETCH_TIMEOUT_MS,
   LIVE_HOST_OSS_BASE_URL,
   LIVE_HOST_RELEASE_BASE_URL,
   parseLiveHostReleaseManifest,
@@ -46,6 +46,26 @@ function manifest() {
   };
 }
 
+function manifestForBytes(version: string, bytes: Buffer) {
+  const checksum = createHash('sha256').update(bytes).digest('hex');
+  return {
+    ...manifest(),
+    version,
+    assets: {
+      arm64: {
+        name: 'Qwen-Live-Host-arm64.zip',
+        size: bytes.byteLength,
+        sha256: checksum,
+      },
+      x64: {
+        name: 'Qwen-Live-Host-x64.zip',
+        size: bytes.byteLength,
+        sha256: checksum,
+      },
+    },
+  };
+}
+
 describe('LiveHostInstaller', () => {
   it('prefers OSS and retains the independent GitHub release fallback', () => {
     expect(LIVE_HOST_OSS_BASE_URL).toBe(
@@ -66,64 +86,141 @@ describe('LiveHostInstaller', () => {
     ]);
   });
 
-  it('allows slow Live Host downloads to finish', () => {
-    expect(LIVE_HOST_FETCH_TIMEOUT_MS).toBe(60 * 60 * 1000);
-  });
-
-  it('falls back to GitHub when the OSS manifest is unavailable', async () => {
-    const expected = manifest();
-    const fetchImpl = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(new Response(null, { status: 503 }))
-      .mockResolvedValueOnce(Response.json(expected));
-
-    await expect(fetchLiveHostManifestForTesting(fetchImpl)).resolves.toEqual(
-      expected,
-    );
-    expect(fetchImpl.mock.calls.map(([url]) => String(url))).toEqual(
-      resolveLiveHostManifestUrls(),
-    );
-  });
-
-  it('removes a corrupt OSS download before falling back to GitHub', async () => {
+  it('uses bounded manifest requests and allows slow archive downloads', async () => {
     const bytes = Buffer.from('signed-live-host-archive');
-    const asset = {
-      name: 'Qwen-Live-Host-arm64.zip',
-      size: bytes.byteLength,
-      sha256: createHash('sha256').update(bytes).digest('hex'),
-    };
+    const expected = manifestForBytes('0.1.0', bytes);
     const fetchImpl = vi
       .fn<typeof fetch>()
-      .mockResolvedValueOnce(
-        new Response(Buffer.alloc(bytes.byteLength), {
-          headers: { 'content-length': String(bytes.byteLength) },
-        }),
-      )
+      .mockResolvedValueOnce(Response.json(expected))
       .mockResolvedValueOnce(
         new Response(bytes, {
           headers: { 'content-length': String(bytes.byteLength) },
         }),
       );
+    const timeout = vi.spyOn(AbortSignal, 'timeout');
     const directory = await fsp.mkdtemp(
       path.join(os.tmpdir(), 'live-host-download-test-'),
     );
-    const destination = path.join(directory, asset.name);
+    const destination = path.join(directory, 'host.zip');
 
     try {
-      await downloadLiveHostAssetForTesting(
-        '0.1.0',
-        asset,
+      await downloadLiveHostReleaseForTesting(
+        'arm64',
         destination,
         () => {},
         fetchImpl,
       );
-      await expect(fsp.readFile(destination)).resolves.toEqual(bytes);
-      expect(fetchImpl.mock.calls.map(([url]) => String(url))).toEqual(
-        resolveLiveHostAssetUrls('0.1.0', asset.name),
+      expect(timeout).toHaveBeenNthCalledWith(
+        1,
+        LIVE_HOST_MANIFEST_FETCH_TIMEOUT_MS,
       );
+      expect(timeout).toHaveBeenNthCalledWith(2, LIVE_HOST_DOWNLOAD_TIMEOUT_MS);
+    } finally {
+      timeout.mockRestore();
+      await fsp.rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back with a matching GitHub manifest and asset pair', async () => {
+    const ossBytes = Buffer.from('sealed-oss-archive');
+    const githubBytes = Buffer.from('current-github-archive');
+    const ossManifest = manifestForBytes('0.1.0', ossBytes);
+    const githubManifest = manifestForBytes('0.2.0', githubBytes);
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(Response.json(ossManifest))
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(Response.json(githubManifest))
+      .mockResolvedValueOnce(
+        new Response(githubBytes, {
+          headers: { 'content-length': String(githubBytes.byteLength) },
+        }),
+      );
+    const directory = await fsp.mkdtemp(
+      path.join(os.tmpdir(), 'live-host-download-test-'),
+    );
+    const destination = path.join(directory, 'host.zip');
+
+    try {
+      const release = await downloadLiveHostReleaseForTesting(
+        'arm64',
+        destination,
+        () => {},
+        fetchImpl,
+      );
+      expect(release.manifest).toEqual(githubManifest);
+      await expect(fsp.readFile(destination)).resolves.toEqual(githubBytes);
+      expect(fetchImpl.mock.calls.map(([url]) => String(url))).toEqual([
+        resolveLiveHostManifestUrls()[0],
+        resolveLiveHostAssetUrls(
+          ossManifest.version,
+          ossManifest.assets.arm64.name,
+        )[0],
+        resolveLiveHostManifestUrls()[1],
+        resolveLiveHostAssetUrls(
+          githubManifest.version,
+          githubManifest.assets.arm64.name,
+        )[1],
+      ]);
     } finally {
       await fsp.rm(directory, { recursive: true, force: true });
     }
+  });
+
+  it('removes a partial archive after all sources fail', async () => {
+    const bytes = Buffer.from('signed-live-host-archive');
+    const expected = manifestForBytes('0.1.0', bytes);
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(Response.json(expected))
+      .mockResolvedValueOnce(
+        new Response(Buffer.alloc(bytes.byteLength), {
+          headers: { 'content-length': String(bytes.byteLength) },
+        }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 503 }));
+    const directory = await fsp.mkdtemp(
+      path.join(os.tmpdir(), 'live-host-download-test-'),
+    );
+    const destination = path.join(directory, 'host.zip');
+
+    try {
+      await expect(
+        downloadLiveHostReleaseForTesting(
+          'arm64',
+          destination,
+          () => {},
+          fetchImpl,
+        ),
+      ).rejects.toBeInstanceOf(AggregateError);
+      await expect(fsp.stat(destination)).rejects.toMatchObject({
+        code: 'ENOENT',
+      });
+    } finally {
+      await fsp.rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('surfaces the failure from each release source', async () => {
+    const installer = new LiveHostInstaller({
+      platform: 'darwin',
+      architecture: 'arm64',
+      inspectInstalled: async () => undefined,
+      installLatest: async () => {
+        throw new AggregateError(
+          [
+            new Error('OSS: checksum mismatch.'),
+            new Error('GitHub: HTTP 503.'),
+          ],
+          'Live Host download failed from all sources.',
+        );
+      },
+      launch: async () => {},
+    });
+
+    const status = await installer.ensureInstalled();
+    expect(status.message).toContain('OSS: checksum mismatch.');
+    expect(status.message).toContain('GitHub: HTTP 503.');
   });
 
   it('accepts only the Qwen Developer ID team', () => {

--- a/packages/cli/src/serve/live/live-host-installer.ts
+++ b/packages/cli/src/serve/live/live-host-installer.ts
@@ -25,7 +25,8 @@ export const LIVE_HOST_RELEASE_BASE_URL =
 export const LIVE_HOST_OSS_BASE_URL =
   'https://qwen-code-assets.oss-cn-hangzhou.aliyuncs.com/live-host';
 export const LIVE_HOST_MANIFEST_NAME = 'Qwen-Live-Host-manifest.json';
-export const LIVE_HOST_FETCH_TIMEOUT_MS = 60 * 60 * 1000;
+export const LIVE_HOST_MANIFEST_FETCH_TIMEOUT_MS = 5 * 60 * 1000;
+export const LIVE_HOST_DOWNLOAD_TIMEOUT_MS = 60 * 60 * 1000;
 
 const LIVE_HOST_APP_NAME = 'Qwen Live Host.app';
 const MAX_DOWNLOAD_BYTES = 512 * 1024 * 1024;
@@ -67,21 +68,40 @@ export interface LiveHostReleaseManifest {
   assets: Record<LiveHostArchitecture, LiveHostReleaseAsset>;
 }
 
-export function resolveLiveHostManifestUrls(): string[] {
+interface LiveHostReleaseSource {
+  name: 'OSS' | 'GitHub';
+  manifestUrl: string;
+  assetUrl: (version: string, assetName: string) => string;
+}
+
+function liveHostReleaseSources(): LiveHostReleaseSource[] {
   return [
-    `${LIVE_HOST_OSS_BASE_URL}/latest/${LIVE_HOST_MANIFEST_NAME}`,
-    `${LIVE_HOST_RELEASE_BASE_URL}/${LIVE_HOST_MANIFEST_NAME}`,
+    {
+      name: 'OSS',
+      manifestUrl: `${LIVE_HOST_OSS_BASE_URL}/latest/${LIVE_HOST_MANIFEST_NAME}`,
+      assetUrl: (version, assetName) =>
+        `${LIVE_HOST_OSS_BASE_URL}/v${version}/${assetName}`,
+    },
+    {
+      name: 'GitHub',
+      manifestUrl: `${LIVE_HOST_RELEASE_BASE_URL}/${LIVE_HOST_MANIFEST_NAME}`,
+      assetUrl: (_version, assetName) =>
+        `${LIVE_HOST_RELEASE_BASE_URL}/${assetName}`,
+    },
   ];
+}
+
+export function resolveLiveHostManifestUrls(): string[] {
+  return liveHostReleaseSources().map(({ manifestUrl }) => manifestUrl);
 }
 
 export function resolveLiveHostAssetUrls(
   version: string,
   assetName: string,
 ): string[] {
-  return [
-    `${LIVE_HOST_OSS_BASE_URL}/v${version}/${assetName}`,
-    `${LIVE_HOST_RELEASE_BASE_URL}/${assetName}`,
-  ];
+  return liveHostReleaseSources().map(({ assetUrl }) =>
+    assetUrl(version, assetName),
+  );
 }
 
 interface InstalledLiveHost {
@@ -232,29 +252,18 @@ async function inspectInstalledHost(): Promise<InstalledLiveHost | undefined> {
   }
 }
 
-async function fetchManifest(
-  fetchImpl: typeof fetch = fetch,
+async function fetchManifestFromUrl(
+  url: string,
+  fetchImpl: typeof fetch,
 ): Promise<LiveHostReleaseManifest> {
-  let lastError: unknown;
-  for (const url of resolveLiveHostManifestUrls()) {
-    try {
-      const response = await fetchImpl(url, {
-        signal: AbortSignal.timeout(LIVE_HOST_FETCH_TIMEOUT_MS),
-      });
-      if (!response.ok) {
-        await response.body?.cancel().catch(() => {});
-        throw new Error(
-          `Live Host manifest download failed (${response.status}).`,
-        );
-      }
-      return parseLiveHostReleaseManifest(await response.json());
-    } catch (error) {
-      lastError = error;
-    }
-  }
-  throw new Error('Live Host manifest download failed from all sources.', {
-    cause: lastError,
+  const response = await fetchImpl(url, {
+    signal: AbortSignal.timeout(LIVE_HOST_MANIFEST_FETCH_TIMEOUT_MS),
   });
+  if (!response.ok) {
+    await response.body?.cancel().catch(() => {});
+    throw new Error(`Live Host manifest download failed (${response.status}).`);
+  }
+  return parseLiveHostReleaseManifest(await response.json());
 }
 
 async function downloadAssetFromUrl(
@@ -265,7 +274,7 @@ async function downloadAssetFromUrl(
   fetchImpl: typeof fetch,
 ): Promise<void> {
   const response = await fetchImpl(url, {
-    signal: AbortSignal.timeout(LIVE_HOST_FETCH_TIMEOUT_MS),
+    signal: AbortSignal.timeout(LIVE_HOST_DOWNLOAD_TIMEOUT_MS),
   });
   if (!response.ok || !response.body) {
     await response.body?.cancel().catch(() => {});
@@ -304,49 +313,56 @@ async function downloadAssetFromUrl(
   }
 }
 
-async function downloadAsset(
-  version: string,
-  asset: LiveHostReleaseAsset,
+async function downloadRelease(
+  currentArchitecture: LiveHostArchitecture,
   destination: string,
   onProgress: (progress: number) => void,
   fetchImpl: typeof fetch = fetch,
-): Promise<void> {
-  let lastError: unknown;
-  for (const url of resolveLiveHostAssetUrls(version, asset.name)) {
+): Promise<{
+  manifest: LiveHostReleaseManifest;
+  asset: LiveHostReleaseAsset;
+}> {
+  const errors: Error[] = [];
+  for (const source of liveHostReleaseSources()) {
     await fsp.rm(destination, { force: true }).catch(() => {});
     onProgress(0);
     try {
+      const manifest = await fetchManifestFromUrl(
+        source.manifestUrl,
+        fetchImpl,
+      );
+      const asset = manifest.assets[currentArchitecture];
       await downloadAssetFromUrl(
-        url,
+        source.assetUrl(manifest.version, asset.name),
         asset,
         destination,
         onProgress,
         fetchImpl,
       );
-      return;
+      return { manifest, asset };
     } catch (error) {
-      lastError = error;
+      errors.push(
+        new Error(`${source.name}: ${errorMessage(error)}`, { cause: error }),
+      );
     }
   }
   await fsp.rm(destination, { force: true }).catch(() => {});
-  throw new Error('Live Host download failed from all sources.', {
-    cause: lastError,
-  });
+  throw new AggregateError(
+    errors,
+    'Live Host download failed from all sources.',
+  );
 }
 
-export const fetchLiveHostManifestForTesting = fetchManifest;
-export const downloadLiveHostAssetForTesting = downloadAsset;
+export const downloadLiveHostReleaseForTesting = downloadRelease;
 
 async function installLatestHost(
   currentArchitecture: LiveHostArchitecture,
   onStatus: (status: LiveHostInstallStatus) => void,
 ): Promise<InstalledLiveHost> {
-  const manifest = await fetchManifest();
-  const asset = manifest.assets[currentArchitecture];
   const temporaryDirectory = await fsp.mkdtemp(
     path.join(os.tmpdir(), 'qwen-live-host-'),
   );
-  const archivePath = path.join(temporaryDirectory, asset.name);
+  const archivePath = path.join(temporaryDirectory, 'Qwen-Live-Host.zip');
   const extractedPath = path.join(temporaryDirectory, 'extracted');
   const candidatePath = path.join(extractedPath, LIVE_HOST_APP_NAME);
   const stagingPath = `/Applications/.Qwen Live Host.install-${randomUUID()}.app`;
@@ -355,9 +371,13 @@ async function installLatestHost(
   let installedCandidate = false;
   try {
     onStatus({ state: 'downloading', progress: 0 });
-    await downloadAsset(manifest.version, asset, archivePath, (progress) => {
-      onStatus({ state: 'downloading', progress });
-    });
+    const { manifest } = await downloadRelease(
+      currentArchitecture,
+      archivePath,
+      (progress) => {
+        onStatus({ state: 'downloading', progress });
+      },
+    );
     onStatus({ state: 'verifying' });
     await fsp.mkdir(extractedPath, { mode: 0o700 });
     await run('/usr/bin/ditto', ['-x', '-k', archivePath, extractedPath]);
@@ -403,6 +423,12 @@ async function launchInstalledHost(): Promise<void> {
 }
 
 function errorMessage(error: unknown): string {
+  if (error instanceof AggregateError) {
+    const details = error.errors
+      .map((item) => (item instanceof Error ? item.message : String(item)))
+      .filter(Boolean);
+    return [error.message, ...details].join(' ');
+  }
   if (error instanceof Error && error.message) return error.message;
   return 'Qwen Live Host setup failed.';
 }

--- a/packages/cli/src/serve/live/live-host-installer.ts
+++ b/packages/cli/src/serve/live/live-host-installer.ts
@@ -22,11 +22,13 @@ export const LIVE_HOST_TEAM_IDENTIFIER = 'NF4574S59H';
 export const LIVE_HOST_APP_PATH = '/Applications/Qwen Live Host.app';
 export const LIVE_HOST_RELEASE_BASE_URL =
   'https://github.com/QwenLM/qwen-code/releases/download/live-host-latest';
+export const LIVE_HOST_OSS_BASE_URL =
+  'https://qwen-code-assets.oss-cn-hangzhou.aliyuncs.com/live-host';
 export const LIVE_HOST_MANIFEST_NAME = 'Qwen-Live-Host-manifest.json';
+export const LIVE_HOST_FETCH_TIMEOUT_MS = 60 * 60 * 1000;
 
 const LIVE_HOST_APP_NAME = 'Qwen Live Host.app';
 const MAX_DOWNLOAD_BYTES = 512 * 1024 * 1024;
-const FETCH_TIMEOUT_MS = 5 * 60 * 1000;
 const COMMAND_TIMEOUT_MS = 2 * 60 * 1000;
 const SHA256_PATTERN = /^[a-f0-9]{64}$/;
 const VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
@@ -63,6 +65,23 @@ export interface LiveHostReleaseManifest {
   protocolVersion: number;
   bundleId: string;
   assets: Record<LiveHostArchitecture, LiveHostReleaseAsset>;
+}
+
+export function resolveLiveHostManifestUrls(): string[] {
+  return [
+    `${LIVE_HOST_OSS_BASE_URL}/latest/${LIVE_HOST_MANIFEST_NAME}`,
+    `${LIVE_HOST_RELEASE_BASE_URL}/${LIVE_HOST_MANIFEST_NAME}`,
+  ];
+}
+
+export function resolveLiveHostAssetUrls(
+  version: string,
+  assetName: string,
+): string[] {
+  return [
+    `${LIVE_HOST_OSS_BASE_URL}/v${version}/${assetName}`,
+    `${LIVE_HOST_RELEASE_BASE_URL}/${assetName}`,
+  ];
 }
 
 interface InstalledLiveHost {
@@ -213,25 +232,40 @@ async function inspectInstalledHost(): Promise<InstalledLiveHost | undefined> {
   }
 }
 
-async function fetchManifest(): Promise<LiveHostReleaseManifest> {
-  const response = await fetch(
-    `${LIVE_HOST_RELEASE_BASE_URL}/${LIVE_HOST_MANIFEST_NAME}`,
-    { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) },
-  );
-  if (!response.ok) {
-    await response.body?.cancel().catch(() => {});
-    throw new Error(`Live Host manifest download failed (${response.status}).`);
+async function fetchManifest(
+  fetchImpl: typeof fetch = fetch,
+): Promise<LiveHostReleaseManifest> {
+  let lastError: unknown;
+  for (const url of resolveLiveHostManifestUrls()) {
+    try {
+      const response = await fetchImpl(url, {
+        signal: AbortSignal.timeout(LIVE_HOST_FETCH_TIMEOUT_MS),
+      });
+      if (!response.ok) {
+        await response.body?.cancel().catch(() => {});
+        throw new Error(
+          `Live Host manifest download failed (${response.status}).`,
+        );
+      }
+      return parseLiveHostReleaseManifest(await response.json());
+    } catch (error) {
+      lastError = error;
+    }
   }
-  return parseLiveHostReleaseManifest(await response.json());
+  throw new Error('Live Host manifest download failed from all sources.', {
+    cause: lastError,
+  });
 }
 
-async function downloadAsset(
+async function downloadAssetFromUrl(
+  url: string,
   asset: LiveHostReleaseAsset,
   destination: string,
   onProgress: (progress: number) => void,
+  fetchImpl: typeof fetch,
 ): Promise<void> {
-  const response = await fetch(`${LIVE_HOST_RELEASE_BASE_URL}/${asset.name}`, {
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  const response = await fetchImpl(url, {
+    signal: AbortSignal.timeout(LIVE_HOST_FETCH_TIMEOUT_MS),
   });
   if (!response.ok || !response.body) {
     await response.body?.cancel().catch(() => {});
@@ -270,6 +304,39 @@ async function downloadAsset(
   }
 }
 
+async function downloadAsset(
+  version: string,
+  asset: LiveHostReleaseAsset,
+  destination: string,
+  onProgress: (progress: number) => void,
+  fetchImpl: typeof fetch = fetch,
+): Promise<void> {
+  let lastError: unknown;
+  for (const url of resolveLiveHostAssetUrls(version, asset.name)) {
+    await fsp.rm(destination, { force: true }).catch(() => {});
+    onProgress(0);
+    try {
+      await downloadAssetFromUrl(
+        url,
+        asset,
+        destination,
+        onProgress,
+        fetchImpl,
+      );
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  await fsp.rm(destination, { force: true }).catch(() => {});
+  throw new Error('Live Host download failed from all sources.', {
+    cause: lastError,
+  });
+}
+
+export const fetchLiveHostManifestForTesting = fetchManifest;
+export const downloadLiveHostAssetForTesting = downloadAsset;
+
 async function installLatestHost(
   currentArchitecture: LiveHostArchitecture,
   onStatus: (status: LiveHostInstallStatus) => void,
@@ -288,7 +355,7 @@ async function installLatestHost(
   let installedCandidate = false;
   try {
     onStatus({ state: 'downloading', progress: 0 });
-    await downloadAsset(asset, archivePath, (progress) => {
+    await downloadAsset(manifest.version, asset, archivePath, (progress) => {
       onStatus({ state: 'downloading', progress });
     });
     onStatus({ state: 'verifying' });

--- a/packages/desktop/apps/live-host/README.md
+++ b/packages/desktop/apps/live-host/README.md
@@ -19,9 +19,10 @@ daemon 和其他操作系统不会显示入口。
 1. 在 WebShell 打开 **设置 → 实验性功能 → Qwen Live**。
 2. 输入专用于 Realtime 模型的 DashScope API key；快捷键默认是
    `Command+E`，可在同一处修改。
-3. 打开开关并确认安装。WebShell 会从独立的 `live-host-latest` release 下载当前
-   架构的签名 Host，校验 manifest、SHA-256、bundle identity、Developer ID 签名
-   和 Gatekeeper，然后原子安装到 `/Applications/Qwen Live Host.app` 并启动。
+3. 打开开关并确认安装。WebShell 会优先从 OSS 镜像下载当前架构的签名 Host，失败时
+   使用独立的 `live-host-latest` release 作为完整回退来源。每个来源的 manifest 和
+   ZIP 成对校验 SHA-256、bundle identity、Developer ID 签名和 Gatekeeper，然后原子
+   安装到 `/Applications/Qwen Live Host.app` 并启动。
 4. 按 Host 引导完成麦克风、辅助功能和屏幕录制授权。授权只能由用户在 macOS
    完成；全部 readiness 通过前 Live 不可使用。
 
@@ -54,8 +55,9 @@ Developer ID 签名、notarization、Gatekeeper 和 stapler 验证。
 
 版本发布使用 `live-host-vX.Y.Z` tag，包含两个 DMG、两个 ZIP、
 `Qwen-Live-Host-manifest.json` 和 `SHA256SUMS.txt`。非 draft、非 prerelease 的
-正式版本还会更新固定的 `live-host-latest` feed；WebShell 自动安装只读取该 feed
-中的 manifest 和两个 ZIP。
+正式版本还会更新固定的 `live-host-latest` feed，并将 manifest 和两个 ZIP 镜像到
+OSS。WebShell 自动安装优先读取 OSS 的 latest manifest 和对应版本 ZIP；完整 OSS
+来源不可用时，再读取 GitHub feed 的 manifest 和 ZIP。
 
 构建会把仓库内的 Objective-C++ Appshot 源码编译成一个 universal N-API 模块，
 并随 Host 一起签名。模块在 Host 主进程内调用 macOS 截屏与 AX API；没有额外 Appshot

--- a/scripts/check-live-host-oss-state.js
+++ b/scripts/check-live-host-oss-state.js
@@ -12,6 +12,7 @@ import { fail, isMainModule, parseArgs } from './release-script-utils.js';
 const MANIFEST_NAME = 'Qwen-Live-Host-manifest.json';
 const REQUEST_TIMEOUT_MS = 60 * 1000;
 const VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
+const DRY_RUN_VERSION_PATTERN = /^0\.0\.\d+$/;
 
 if (isMainModule(import.meta.url)) {
   main(process.argv.slice(2)).catch((error) => {
@@ -23,6 +24,7 @@ if (isMainModule(import.meta.url)) {
 async function main(argv) {
   const command = argv[0];
   const args = parseArgs(argv.slice(1), {
+    '--allow-hidden-missing': { key: 'allowHiddenMissing', type: 'flag' },
     '--base-url': { key: 'baseUrl', type: 'value' },
     '--manifest': { key: 'manifestPath', type: 'value' },
     '--version': { key: 'version', type: 'value' },
@@ -39,6 +41,7 @@ async function main(argv) {
     console.log(
       await checkImmutablePrefix({
         baseUrl: args.baseUrl,
+        allowHiddenMissing: args.allowHiddenMissing,
         manifestPath: args.manifestPath,
         version: args.version,
       }),
@@ -59,12 +62,12 @@ async function main(argv) {
 
 function printUsage() {
   console.log(`Usage:
-  node scripts/check-live-host-oss-state.js prefix --base-url URL --version X.Y.Z --manifest PATH
+  node scripts/check-live-host-oss-state.js prefix --base-url URL --version X.Y.Z --manifest PATH [--allow-hidden-missing]
   node scripts/check-live-host-oss-state.js latest --base-url URL --manifest PATH
 `);
 }
 
-async function fetchManifest(url, fetchImpl) {
+async function fetchManifest(url, fetchImpl, hiddenMissingProbe) {
   let response;
   try {
     response = await fetchImpl(url, {
@@ -75,6 +78,20 @@ async function fetchManifest(url, fetchImpl) {
   }
   if (response.status === 404) {
     await response.body?.cancel().catch(() => {});
+    return undefined;
+  }
+  if (response.status === 403 && hiddenMissingProbe) {
+    await response.body?.cancel().catch(() => {});
+    const probe = await fetchImpl(hiddenMissingProbe, {
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    if (!probe.ok) {
+      await probe.body?.cancel().catch(() => {});
+      throw new Error(
+        `OSS public-read probe failed with HTTP ${probe.status} at ${hiddenMissingProbe}.`,
+      );
+    }
+    await probe.body?.cancel().catch(() => {});
     return undefined;
   }
   if (!response.ok) {
@@ -88,14 +105,25 @@ async function fetchManifest(url, fetchImpl) {
 
 async function checkImmutablePrefix({
   baseUrl,
+  allowHiddenMissing = false,
   version,
   manifestPath,
   fetchImpl = fetch,
 }) {
   if (!VERSION_PATTERN.test(version)) fail(`Invalid version: ${version}`);
+  if (allowHiddenMissing && !DRY_RUN_VERSION_PATTERN.test(version)) {
+    fail('--allow-hidden-missing requires a synthetic 0.0.<PR> version');
+  }
   const localManifest = await readFile(manifestPath);
   const url = `${baseUrl.replace(/\/+$/, '')}/live-host/v${version}/${MANIFEST_NAME}`;
-  const remoteManifest = await fetchManifest(url, fetchImpl);
+  const publicBaseUrl = baseUrl.replace(/\/+$/, '');
+  const remoteManifest = await fetchManifest(
+    url,
+    fetchImpl,
+    allowHiddenMissing
+      ? `${publicBaseUrl}/releases/qwen-code/latest/VERSION`
+      : undefined,
+  );
   if (!remoteManifest) return false;
   if (!localManifest.equals(remoteManifest)) {
     fail('The immutable OSS version manifest has different contents');

--- a/scripts/check-live-host-oss-state.js
+++ b/scripts/check-live-host-oss-state.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFile } from 'node:fs/promises';
+import { fail, isMainModule, parseArgs } from './release-script-utils.js';
+
+const MANIFEST_NAME = 'Qwen-Live-Host-manifest.json';
+const REQUEST_TIMEOUT_MS = 60 * 1000;
+const VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
+
+if (isMainModule(import.meta.url)) {
+  main(process.argv.slice(2)).catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}
+
+async function main(argv) {
+  const command = argv[0];
+  const args = parseArgs(argv.slice(1), {
+    '--base-url': { key: 'baseUrl', type: 'value' },
+    '--manifest': { key: 'manifestPath', type: 'value' },
+    '--version': { key: 'version', type: 'value' },
+  });
+  if (args.help || !command) {
+    printUsage();
+    return;
+  }
+  if (!args.baseUrl || !args.manifestPath) {
+    fail('--base-url and --manifest are required');
+  }
+  if (command === 'prefix') {
+    if (!args.version) fail('--version is required for prefix checks');
+    console.log(
+      await checkImmutablePrefix({
+        baseUrl: args.baseUrl,
+        manifestPath: args.manifestPath,
+        version: args.version,
+      }),
+    );
+    return;
+  }
+  if (command === 'latest') {
+    console.log(
+      await shouldUpdateLatest({
+        baseUrl: args.baseUrl,
+        manifestPath: args.manifestPath,
+      }),
+    );
+    return;
+  }
+  fail(`Unknown command: ${command}`);
+}
+
+function printUsage() {
+  console.log(`Usage:
+  node scripts/check-live-host-oss-state.js prefix --base-url URL --version X.Y.Z --manifest PATH
+  node scripts/check-live-host-oss-state.js latest --base-url URL --manifest PATH
+`);
+}
+
+async function fetchManifest(url, fetchImpl) {
+  let response;
+  try {
+    response = await fetchImpl(url, {
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+  } catch (error) {
+    throw new Error(`Unable to read OSS manifest at ${url}.`, { cause: error });
+  }
+  if (response.status === 404) {
+    await response.body?.cancel().catch(() => {});
+    return undefined;
+  }
+  if (!response.ok) {
+    await response.body?.cancel().catch(() => {});
+    throw new Error(
+      `OSS manifest request failed with HTTP ${response.status} at ${url}.`,
+    );
+  }
+  return Buffer.from(await response.arrayBuffer());
+}
+
+async function checkImmutablePrefix({
+  baseUrl,
+  version,
+  manifestPath,
+  fetchImpl = fetch,
+}) {
+  if (!VERSION_PATTERN.test(version)) fail(`Invalid version: ${version}`);
+  const localManifest = await readFile(manifestPath);
+  const url = `${baseUrl.replace(/\/+$/, '')}/live-host/v${version}/${MANIFEST_NAME}`;
+  const remoteManifest = await fetchManifest(url, fetchImpl);
+  if (!remoteManifest) return false;
+  if (!localManifest.equals(remoteManifest)) {
+    fail('The immutable OSS version manifest has different contents');
+  }
+  return true;
+}
+
+async function shouldUpdateLatest({
+  baseUrl,
+  manifestPath,
+  fetchImpl = fetch,
+}) {
+  const localManifest = await readFile(manifestPath);
+  const nextVersion = readVersion(localManifest, 'local');
+  const url = `${baseUrl.replace(/\/+$/, '')}/live-host/latest/${MANIFEST_NAME}`;
+  const currentManifest = await fetchManifest(url, fetchImpl);
+  if (!currentManifest) return true;
+
+  const currentVersion = readVersion(currentManifest, 'current OSS latest');
+  const comparison = compareVersions(nextVersion, currentVersion);
+  if (comparison < 0) return false;
+  if (comparison === 0) {
+    if (!localManifest.equals(currentManifest)) {
+      fail(
+        'The OSS latest manifest has different contents for the same version',
+      );
+    }
+    return false;
+  }
+  return true;
+}
+
+function readVersion(bytes, source) {
+  let manifest;
+  try {
+    manifest = JSON.parse(bytes.toString('utf8'));
+  } catch {
+    fail(`The ${source} manifest is not valid JSON`);
+  }
+  if (!VERSION_PATTERN.test(manifest?.version)) {
+    fail(`The ${source} manifest version is invalid`);
+  }
+  return manifest.version;
+}
+
+function compareVersions(left, right) {
+  const leftParts = left.split('.').map(Number);
+  const rightParts = right.split('.').map(Number);
+  for (let index = 0; index < leftParts.length; index += 1) {
+    if (leftParts[index] !== rightParts[index]) {
+      return leftParts[index] - rightParts[index];
+    }
+  }
+  return 0;
+}
+
+export { checkImmutablePrefix, shouldUpdateLatest };

--- a/scripts/tests/check-live-host-oss-state.test.js
+++ b/scripts/tests/check-live-host-oss-state.test.js
@@ -55,6 +55,49 @@ describe('Live Host OSS state checks', () => {
     }
   });
 
+  it('accepts OSS-hidden missing keys only after a public-read probe', async () => {
+    const hidden = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 403 }))
+      .mockResolvedValueOnce(new Response('v0.21.7'));
+    await expect(
+      checkImmutablePrefix({
+        baseUrl: 'https://assets.example',
+        version: '0.0.123',
+        manifestPath,
+        allowHiddenMissing: true,
+        fetchImpl: hidden,
+      }),
+    ).resolves.toBe(false);
+    expect(hidden.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://assets.example/live-host/v0.0.123/Qwen-Live-Host-manifest.json',
+      'https://assets.example/releases/qwen-code/latest/VERSION',
+    ]);
+
+    await expect(
+      checkImmutablePrefix({
+        baseUrl: 'https://assets.example',
+        version: '0.0.123',
+        manifestPath,
+        allowHiddenMissing: true,
+        fetchImpl: vi
+          .fn()
+          .mockResolvedValueOnce(new Response(null, { status: 403 }))
+          .mockResolvedValueOnce(new Response(null, { status: 503 })),
+      }),
+    ).rejects.toThrow(/public-read probe failed/);
+
+    await expect(
+      checkImmutablePrefix({
+        baseUrl: 'https://assets.example',
+        version: '1.2.3',
+        manifestPath,
+        allowHiddenMissing: true,
+        fetchImpl: hidden,
+      }),
+    ).rejects.toThrow(/synthetic 0[.]0/);
+  });
+
   it('accepts only byte-identical immutable manifests', async () => {
     const bytes = await readFile(manifestPath);
     await expect(

--- a/scripts/tests/check-live-host-oss-state.test.js
+++ b/scripts/tests/check-live-host-oss-state.test.js
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  checkImmutablePrefix,
+  shouldUpdateLatest,
+} from '../check-live-host-oss-state.js';
+
+describe('Live Host OSS state checks', () => {
+  let directory;
+  let manifestPath;
+
+  beforeEach(async () => {
+    directory = await mkdtemp(path.join(tmpdir(), 'live-host-oss-state-'));
+    manifestPath = path.join(directory, 'Qwen-Live-Host-manifest.json');
+    await writeManifest(manifestPath, '1.2.3');
+  });
+
+  afterEach(async () => {
+    await rm(directory, { recursive: true, force: true });
+  });
+
+  it('treats only a missing immutable manifest as unsealed', async () => {
+    const missing = vi.fn(async () => new Response(null, { status: 404 }));
+    await expect(
+      checkImmutablePrefix({
+        baseUrl: 'https://assets.example',
+        version: '1.2.3',
+        manifestPath,
+        fetchImpl: missing,
+      }),
+    ).resolves.toBe(false);
+
+    for (const failure of [
+      vi.fn(async () => new Response(null, { status: 503 })),
+      vi.fn(async () => {
+        throw new Error('network unavailable');
+      }),
+    ]) {
+      await expect(
+        checkImmutablePrefix({
+          baseUrl: 'https://assets.example',
+          version: '1.2.3',
+          manifestPath,
+          fetchImpl: failure,
+        }),
+      ).rejects.toThrow(/OSS manifest/);
+    }
+  });
+
+  it('accepts only byte-identical immutable manifests', async () => {
+    const bytes = await readFile(manifestPath);
+    await expect(
+      checkImmutablePrefix({
+        baseUrl: 'https://assets.example/',
+        version: '1.2.3',
+        manifestPath,
+        fetchImpl: async () => new Response(bytes),
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      checkImmutablePrefix({
+        baseUrl: 'https://assets.example',
+        version: '1.2.3',
+        manifestPath,
+        fetchImpl: async () => Response.json({ version: '1.2.3' }),
+      }),
+    ).rejects.toThrow(/different contents/);
+  });
+
+  it('advances latest monotonically and rejects same-version divergence', async () => {
+    const fetchVersion = (version) => async () =>
+      Response.json({ version, marker: version });
+    await expect(
+      shouldUpdateLatest({
+        baseUrl: 'https://assets.example',
+        manifestPath,
+        fetchImpl: fetchVersion('1.2.2'),
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      shouldUpdateLatest({
+        baseUrl: 'https://assets.example',
+        manifestPath,
+        fetchImpl: fetchVersion('1.2.4'),
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      shouldUpdateLatest({
+        baseUrl: 'https://assets.example',
+        manifestPath,
+        fetchImpl: fetchVersion('1.2.3'),
+      }),
+    ).rejects.toThrow(/different contents/);
+  });
+
+  it('does not rewrite an identical latest manifest', async () => {
+    const bytes = await readFile(manifestPath);
+    await expect(
+      shouldUpdateLatest({
+        baseUrl: 'https://assets.example',
+        manifestPath,
+        fetchImpl: async () => new Response(bytes),
+      }),
+    ).resolves.toBe(false);
+  });
+});
+
+async function writeManifest(file, version) {
+  await writeFile(file, `${JSON.stringify({ version })}\n`);
+}

--- a/scripts/tests/live-host-release-workflow.test.js
+++ b/scripts/tests/live-host-release-workflow.test.js
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const releaseWorkflow = readFileSync(
+  '.github/workflows/live-host-release.yml',
+  'utf8',
+);
+const syncWorkflow = readFileSync(
+  '.github/workflows/sync-live-host-to-oss.yml',
+  'utf8',
+);
+
+describe('Live Host release workflows', () => {
+  it('runs the immutable-prefix check before mutating GitHub releases', () => {
+    const preflight = releaseWorkflow.indexOf(
+      "- name: 'Check immutable OSS prefix before publishing'",
+    );
+    const publish = releaseWorkflow.indexOf("- name: 'Create GitHub release'");
+    expect(preflight).toBeGreaterThanOrEqual(0);
+    expect(publish).toBeGreaterThan(preflight);
+  });
+
+  it('serializes latest updates and never inherits unrelated secrets', () => {
+    expect(syncWorkflow).toContain("group: 'sync-live-host-to-oss'");
+    expect(syncWorkflow).not.toContain(
+      "group: 'sync-live-host-to-oss-${{ inputs.version }}'",
+    );
+    expect(releaseWorkflow).not.toContain("secrets: 'inherit'");
+    expect(syncWorkflow).toContain(
+      'if: "${{ steps.latest.outputs.update == \'true\' }}"',
+    );
+  });
+
+  it('exercises the read-only OSS state check during PR dry runs', () => {
+    expect(releaseWorkflow).toContain(
+      "- '.github/workflows/sync-live-host-to-oss.yml'",
+    );
+    const dryRun = syncWorkflow.slice(
+      syncWorkflow.indexOf('  dry-run:'),
+      syncWorkflow.indexOf('  sync:'),
+    );
+    expect(dryRun).toContain(
+      "- name: 'Check immutable version prefix without writing'",
+    );
+    expect(dryRun).toContain(
+      'node scripts/check-live-host-oss-state.js prefix',
+    );
+    expect(syncWorkflow).toContain(
+      'cp release-assets/Qwen-Live-Host-manifest.json',
+    );
+  });
+});

--- a/scripts/tests/live-host-release-workflow.test.js
+++ b/scripts/tests/live-host-release-workflow.test.js
@@ -51,6 +51,10 @@ describe('Live Host release workflows', () => {
     expect(dryRun).toContain(
       'node scripts/check-live-host-oss-state.js prefix',
     );
+    expect(dryRun).toContain('--allow-hidden-missing');
+    expect(syncWorkflow.slice(syncWorkflow.indexOf('  sync:'))).not.toContain(
+      '--allow-hidden-missing',
+    );
     expect(syncWorkflow).toContain(
       'cp release-assets/Qwen-Live-Host-manifest.json',
     );


### PR DESCRIPTION
## What this PR does

This change makes macOS Live Host onboarding prefer the public Qwen Code OSS mirror and retain the independent GitHub stable feed as fallback. Downloads now allow up to 60 minutes for slow 100 MB-class assets. Mirror failures, truncated files, size mismatches, and checksum mismatches remove the temporary archive before the installer tries GitHub; the existing bundle identity, Developer ID, Gatekeeper, protocol, version, size, and SHA-256 gates remain mandatory.

Stable Live Host publishing now invokes a separate reusable OSS workflow. It seals each version under an immutable version prefix, uploads both architecture ZIPs before the manifest, re-downloads and verifies the public objects, and only then updates the latest manifest. Pull requests and release dry runs execute the same source-asset verification without production credentials or uploads.

## Why it's needed

The signed Live Host ZIPs are roughly 100–115 MB, and direct GitHub downloads can exceed the previous fixed five-minute timeout on slower networks. A Qwen-owned OSS primary source improves onboarding reliability in China while preserving GitHub as an independent fallback and preserving the complete signed-install trust chain.

## Reviewer Test Plan

### How to verify

Confirm the installer resolves the OSS latest manifest and versioned ZIP before the GitHub stable feed, retries GitHub after an unavailable or corrupt OSS response, and keeps the 60-minute download timeout. Confirm the Qwen Live Host Release PR workflow builds the unsigned macOS packages and its OSS dry-run validates both generated ZIPs against the generated manifest without requesting production credentials. For a later stable release, confirm the production workflow verifies the public immutable version objects before replacing the latest manifest.

### Evidence (Before & After)

N/A — release distribution and installer transport only; no UI changes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

macOS arm64, Node.js 22. Focused installer tests: 10/10 passed. Full repository build, typecheck, focused ESLint, Prettier, and actionlint passed. The remote unsigned Host build and OSS dry-run are intentionally left to this PR's GitHub Actions run.

## Risk & Scope

- Main risk or tradeoff: A reachable but stale OSS latest manifest keeps clients on the previous valid Host until the mirror is updated or unavailable; integrity failures still fall back to GitHub.
- Not validated / out of scope: No production OSS write is performed from a pull request. The PR dry-run validates real generated release assets without production credentials.
- Breaking changes / migration notes: None. Installation path, app identity, permissions, protocol, and GitHub release assets are unchanged.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 此 PR 做了什么

本变更让 macOS Live Host onboarding 优先使用 Qwen Code 公共 OSS 镜像，并保留独立的 GitHub stable feed 作为回退。对于约 100 MB 的慢速下载，总超时提高到 60 分钟。镜像不可用、下载截断、大小不符或 SHA 校验失败时，会先删除临时归档再尝试 GitHub；现有 Bundle ID、Developer ID、Gatekeeper、协议版本、应用版本、大小和 SHA-256 校验全部保留。

稳定版 Live Host 发布现在会调用独立、可复用的 OSS workflow。每个版本写入不可变版本目录，先上传两种架构的 ZIP，再上传 manifest；随后从公共 OSS 重新下载并校验全部对象，只有验证成功后才更新 latest manifest。PR 和 release dry-run 会执行相同的源产物校验，但不会读取生产凭证或上传文件。

## 为什么需要

签名后的 Live Host ZIP 约为 100–115 MB，在较慢网络下直接从 GitHub 下载可能超过此前固定的五分钟超时。使用 Qwen 自有 OSS 作为主下载源可以提高中国网络下的 onboarding 可靠性，同时继续保留 GitHub 独立回退和完整的签名安装信任链。

## Reviewer 测试计划

### 如何验证

确认安装器依次解析 OSS latest manifest、OSS 版本化 ZIP 和 GitHub stable feed；确认 OSS 不可用或返回损坏文件时能够回退 GitHub，并保持 60 分钟下载超时。确认 PR 的 Qwen Live Host Release workflow 能构建未签名的 macOS 包，其 OSS dry-run 会根据生成的 manifest 校验两份生成 ZIP，且不请求生产凭证。后续发布稳定版本时，确认 production workflow 在替换 latest manifest 之前先验证公共不可变版本对象。

### Before & After 证据

N/A——仅涉及发布分发与安装器传输，不包含 UI 变化。

### 测试平台

|     OS     | 状态  |
| :--------: | :---: |
|  🍏 macOS  |  ✅   |
| 🪟 Windows |  N/A  |
|  🐧 Linux  |  N/A  |

### 环境（可选）

macOS arm64，Node.js 22。安装器定向测试 10/10 通过；全仓构建、typecheck、定向 ESLint、Prettier 和 actionlint 均通过。远端未签名 Host 构建和 OSS dry-run 由此 PR 的 GitHub Actions 运行完成。

## 风险与范围

- 主要风险或权衡：可访问但陈旧的 OSS latest manifest 会让客户端继续使用上一个有效 Host，直到镜像完成更新或变得不可用；完整性失败仍会回退 GitHub。
- 未验证或范围外：PR 不执行生产 OSS 写入；PR dry-run 使用真实生成的 release 产物验证，但不使用生产凭证。
- 破坏性变更或迁移说明：无。安装路径、应用身份、权限、协议和 GitHub release 产物均未改变。

## 关联 Issue

N/A

</details>
