### PR TITLE
fix(cli): preserve slash command names in narrow terminals

### DIFF
--- a/packages/cli/src/ui/components/SuggestionsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.test.tsx
@@ -169,6 +169,41 @@ describe('SuggestionsDisplay', () => {
     expect(lines[0]).toMatch(/^ {2}pr/);
     expect(lines[1]).toMatch(/^> issue-to-pr/);
   });
+
+  it('keeps slash command names intact when argument hints overflow', () => {
+    const { lastFrame } = render(
+      <SuggestionsDisplay
+        suggestions={[
+          {
+            label: 'review',
+            value: 'review',
+            argumentHint:
+              '[pr-number|file-path] [--effort low|medium|high] [--comment] [--fix]',
+            sourceBadge: '[Skill]',
+            description: 'Review changed code.',
+          },
+          {
+            label: 'doctor',
+            value: 'doctor',
+            argumentHint:
+              '[memory|cpu-profile|rollback] [--sample] [--snapshot] [--duration]',
+            description: 'Diagnose Qwen Code environment.',
+          },
+        ]}
+        activeIndex={0}
+        isLoading={false}
+        width={120}
+        scrollOffset={0}
+        userInput="/rev"
+        mode="slash"
+      />,
+    );
+
+    const lines = (lastFrame() ?? '').split('\n');
+
+    expect(lines).toContainEqual(expect.stringMatching(/^> review(?: |$)/));
+    expect(lines).toContainEqual(expect.stringMatching(/^ {2}doctor(?: |$)/));
+  });
 });
 
 describe('SuggestionsDisplay tabs', () => {

--- a/packages/cli/src/ui/components/SuggestionsDisplay.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.tsx
@@ -237,7 +237,7 @@ export function SuggestionsDisplay({
                 : { flexShrink: 1 as const })}
             >
               <Box>
-                {labelElement}
+                <Box flexShrink={0}>{labelElement}</Box>
                 {suggestion.argumentHint && (
                   <Text color={theme.text.secondary}>
                     {' '}


### PR DESCRIPTION
## What this PR does

Keeps slash-command names intact when the completion menu has limited horizontal space. Argument hints continue to yield space by wrapping, so the actionable command token remains trustworthy.

## Why it's needed

The command name, argument hint, and source badge previously shared a shrinkable row. On narrower terminals this could render `review` as `revie` and `doctor` as `docto`, misleading users into typing a command that does not exist.

## Reviewer Test Plan

### How to verify

Open the interactive CLI in a narrow terminal, type `/rev` and `/doc`, and confirm the completion list always shows the complete `review` and `doctor` command names while long argument hints wrap onto following lines.

### Evidence (Before & After)

Before: at width 120, `review` rendered as `revie` and `doctor` rendered as `docto`.
<img width="1944" height="452" alt="image" src="https://github.com/user-attachments/assets/2141ebd6-d506-43cb-a6a5-334cb753177f" />


After: at width 120, both command names render completely and their argument hints wrap to preserve the names.
<img width="1570" height="450" alt="image" src="https://github.com/user-attachments/assets/3cdd85a5-dad7-4d7b-8296-0f2eb709935b" />


### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

Node.js v24.14.0, Ink 7.0.3. Focused component tests pass 10/10; build, bundle, and targeted ESLint pass. Repository-wide typecheck remains blocked by pre-existing upstream Ink type errors involving selection APIs.

## Risk & Scope

- Main risk or tradeoff: Long argument hints may occupy additional lines in narrow terminals so command names remain complete.
- Not validated / out of scope: Windows and Linux interactive terminal rendering.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 的改动

在补全菜单横向空间不足时保持斜杠命令名称完整。参数提示仍可通过换行让出空间，确保用户看到的可执行命令名称可信。

## 改动原因

此前命令名称、参数提示和来源标识位于同一个可收缩布局中。在较窄的终端里，`review` 可能显示成 `revie`，`doctor` 可能显示成 `docto`，从而误导用户输入不存在的命令。

## Reviewer Test Plan

### 验证方式

在较窄的终端中启动交互式 CLI，分别输入 `/rev` 和 `/doc`，确认补全列表始终完整显示 `review` 和 `doctor`，较长的参数提示则换行显示。

### 前后对比证据

修复前：宽度为 120 时，`review` 显示为 `revie`，`doctor` 显示为 `docto`。

修复后：宽度为 120 时，两个命令名称都完整显示，参数提示通过换行保留命令名称。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

Node.js v24.14.0，Ink 7.0.3。定向组件测试 10/10 通过；构建、bundle 和目标 ESLint 均通过。仓库级 typecheck 仍被 upstream 已存在的 Ink selection API 类型错误阻塞。

## 风险与范围

- 主要风险或权衡：为了保持命令名称完整，较长的参数提示可能在窄终端中占用额外行。
- 未验证或不在范围内：Windows 和 Linux 的交互式终端渲染。
- 破坏性变更或迁移说明：无。

## 关联 Issue

N/A

</details>
