### PR TITLE
fix(ci): prevent npm cache producer from poisoning runners

### DIFF
--- a/.github/scripts/qwen-triage-workflow.test.mjs
+++ b/.github/scripts/qwen-triage-workflow.test.mjs
@@ -755,8 +755,8 @@ describe('qwen-triage: npm cache producer workflow', () => {
   it('runs on the same target as the consumers so the cache version matches', () => {
     // actions/cache scopes an entry by a hash of the literal cache path plus
     // the compression method. A producer on a different runner or outside the
-    // container computes a different version, so every restore misses even
-    // when the key and path strings match — pin runs-on + container to the
+    // container image computes a different version, so every restore misses
+    // even when the key and path strings match — pin runs-on + image to the
     // consumers' so both match by construction.
     for (const [jobName, jobDef] of [
       ['verify', verifyJob],
@@ -767,11 +767,16 @@ describe('qwen-triage: npm cache producer workflow', () => {
         jobDef['runs-on'],
         `producer runs-on must match ${jobName}`,
       );
-      assert.deepEqual(
-        saveJob.container,
-        jobDef.container,
-        `producer container must match ${jobName}`,
+      assert.equal(
+        saveJob.container.image,
+        jobDef.container.image,
+        `producer container image must match ${jobName}`,
       );
     }
+    assert.equal(
+      saveJob.container.options,
+      '--init --user node',
+      'producer must not leave root-owned files on the self-hosted runner',
+    );
   });
 });

--- a/.github/workflows/npm-cache.yml
+++ b/.github/workflows/npm-cache.yml
@@ -30,7 +30,8 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'x64', 'ecs-qwen']
     container:
       image: 'node:22-bookworm'
-      options: '--init'
+      # Match the host runner UID/GID so bind-mounted files stay writable.
+      options: '--init --user node'
     timeout-minutes: 15
     steps:
       - uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -5370,6 +5370,7 @@ describe('qwen-triage npm cache producer', () => {
       "runs-on: ['self-hosted', 'linux', 'x64', 'ecs-qwen']",
     );
     expect(cacheProducerWorkflow).toContain("image: 'node:22-bookworm'");
+    expect(cacheProducerWorkflow).toContain("options: '--init --user node'");
     for (const jobName of ['verify', 'tmux-testing']) {
       expect(job(jobName)).toContain(
         "runs-on: ['self-hosted', 'linux', 'x64', 'ecs-qwen']",


### PR DESCRIPTION
## What this PR does

Runs the npm cache producer as the `node` user inside its existing job container. The ECS runner target, container image, cache path, and compression environment stay unchanged, so producer and consumer cache versions remain compatible. The workflow guards now pin the producer-only non-root option while continuing to require the same runner target and image as the consumers.

## Why it's needed

The job container previously used its default root user. On persistent self-hosted runners, checkout and `npm ci` therefore created root-owned files in the bind-mounted workspace. Later jobs run as `github-runner` and could not remove those files, causing unrelated checkouts to fail with `EACCES`. Running the producer as `node` fixes the ownership at the source; both current ECS hosts map `node` and `github-runner` to UID/GID `1000:1000`.

## Reviewer Test Plan

### How to verify

Run the npm cache producer on a cleaned ECS runner and confirm that checkout, dependency installation, and cache saving complete successfully. After the job, files created under the runner workspace should be owned by the runner account rather than root, and a subsequent non-container checkout should be able to clean the workspace normally.

### Evidence (Before & After)

Before: the producer left root-owned workspace entries and subsequent checkouts failed while unlinking repository files. After: the producer is pinned to the matching non-root UID/GID, and both workflow guard suites pass. This is a non-UI change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ targeted workflow tests |
| 🪟 Windows | N/A |
|  🐧 Linux  | ✅ container/runner UID and workspace ownership validation |

### Environment (optional)

Self-hosted ECS runners using `node:22-bookworm`; both current runner hosts use UID/GID `1000:1000` for `github-runner`, matching the image's `node` user.

## Risk & Scope

- Main risk or tradeoff: future ECS runners must keep the runner account aligned with the container's UID/GID.
- Not validated / out of scope: a production workflow dispatch from this branch; the PR checks provide the authoritative end-to-end validation.
- Breaking changes / migration notes: none.

## Linked Issues

Regression from #7885.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让 npm 缓存 producer 在现有 job container 中使用 `node` 用户运行。ECS runner 目标、容器镜像、缓存路径和压缩环境均保持不变，因此 producer 与 consumer 的缓存版本仍然兼容。workflow 守卫现在会固定 producer 专用的非 root 配置，同时继续要求它与 consumer 使用相同的 runner 目标和镜像。

## 为什么需要

此前 job container 使用默认 root 用户。在持久化 self-hosted runner 上，checkout 和 `npm ci` 因此会在挂载的工作区内创建 root 属主文件。后续任务以 `github-runner` 运行，无法删除这些文件，导致无关任务的 checkout 报 `EACCES`。让 producer 使用 `node` 用户可以从源头修复属主问题；当前两台 ECS 上的 `node` 和 `github-runner` 都映射为 UID/GID `1000:1000`。

## Reviewer 测试计划

### 验证方式

在已清理的 ECS runner 上运行 npm 缓存 producer，确认 checkout、依赖安装和缓存保存成功。任务结束后，runner 工作区中新建文件应属于 runner 账号而不是 root，后续非容器 checkout 应能正常清理工作区。

### 前后证据

修复前：producer 留下 root 属主的工作区内容，后续 checkout 在删除仓库文件时失败。修复后：producer 固定使用匹配的非 root UID/GID，两套 workflow 守卫均通过。这不是 UI 改动。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ 定向 workflow 测试 |
| 🪟 Windows | N/A |
|  🐧 Linux  | ✅ 容器/runner UID 与工作区属主验证 |

环境：使用 `node:22-bookworm` 的 self-hosted ECS runner；当前两台宿主的 `github-runner` 均为 UID/GID `1000:1000`，与镜像中的 `node` 用户一致。

## 风险与范围

- 主要风险：未来新增 ECS runner 时需要保持 runner 账号与容器 UID/GID 一致。
- 未验证/范围外：尚未从该分支手动触发生产 workflow；PR checks 是最终端到端验证。
- 破坏性变更/迁移说明：无。

## 关联问题

#7885 引入的回归。

</details>
