### PR TITLE
fix(autofix): skip the PAT-backed jobs when the run has no secrets

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -368,30 +368,28 @@ jobs:
                     echo "🧭 review event ignored: PR author '${PR_AUTHOR}' is not ${AUTOFIX_BOT}"
                   fi
                 else
-                  # Fork PR. The scheduled scan already admits these for
-                  # takeover, so real-time pickup applies the SAME admission
-                  # (allow-edits on, and either the bot's own fork or an
-                  # explicit TAKEOVER_LABEL) rather than making the takeover
-                  # PRs — the ones a maintainer is actively waiting on — sit
-                  # through a throttled schedule. This event runs in BASE-repo
-                  # context, and review-address independently re-verifies
-                  # allow-edits, a live write+ author and a matching live head
-                  # repo before it touches the branch, so this only decides
-                  # WHEN that same gated work happens, never whether it may.
-                  fork_meta=''
-                  if fork_meta="$(gh pr view "${PR_NUMBER_EVENT}" --repo "${REPO}" --json labels,maintainerCanModify 2> /dev/null)"; then
-                    fork_allows_edits="$(jq -r '.maintainerCanModify == true' <<< "${fork_meta}")"
-                    fork_has_takeover="$(jq -r --arg t "${TAKEOVER_LABEL}" '[.labels[]?.name] | index($t) != null' <<< "${fork_meta}")"
-                    if [[ "${fork_allows_edits}" != 'true' ]]; then
-                      echo "🧭 review event ignored: fork PR #${PR_NUMBER_EVENT} does not allow maintainer edits"
-                    elif [[ "${PR_AUTHOR}" == "${AUTOFIX_BOT}" || "${fork_has_takeover}" == 'true' ]]; then
-                      pr_is_managed=true
-                    else
-                      echo "🧭 review event ignored: fork PR #${PR_NUMBER_EVENT} is neither ${AUTOFIX_BOT}'s own fork nor ${TAKEOVER_LABEL}-labeled"
-                    fi
-                  else
-                    echo "🧭 review event ignored: could not read fork PR #${PR_NUMBER_EVENT} metadata"
-                  fi
+                  # Fork PR — decline, and say so. This event carries NO
+                  # repository secrets: GitHub withholds them from every run
+                  # tied to a pull request whose head lives in a fork, and the
+                  # run header states it outright (`Secret source: None`). So
+                  # CI_DEV_BOT_PAT arrives EMPTY and neither review-scan nor
+                  # review-address could authenticate from here — the earlier
+                  # claim that "this event runs in BASE-repo context" held for
+                  # the workflow FILE, which is read from base, but not for the
+                  # credentials.
+                  # Admitting the PR anyway spent two API reads to decide it,
+                  # then three more failing inside the scan, which exited 1 on
+                  # `metadata_fetch_failed` — a reason whose blocked comment
+                  # promises "a later scheduled scan will retry", true for a
+                  # 5xx and false for a credential this run was never handed.
+                  # Every review of a fork PR reddened the workflow while
+                  # changing nothing, and that noise buried the failures that
+                  # do need a human.
+                  # The label and the feedback both keep working: the scheduled
+                  # scan runs in repo context and admits fork takeover PRs on
+                  # its own. This mirrors the pull_request label branch below,
+                  # which already declines forks for exactly this reason.
+                  echo "🧭 fork review noted for #${PR_NUMBER_EVENT} — this event carries no repository secrets, so nothing here could authenticate; the next scheduled scan engages (author write+ and allow-edits required)"
                 fi
                 if [[ "${pr_is_managed}" == 'true' ]]; then
                   # Verify the reviewer/commenter is trusted (prompt-injection gate).
@@ -1905,6 +1903,22 @@ jobs:
           DRY_RUN: '${{ needs.route.outputs.dry_run }}'
           EVENT_NAME: '${{ github.event_name }}'
         run: |-
+          # Every lane that reaches this scan is supposed to hold the PAT:
+          # route now declines the one event GitHub is known to run without
+          # secrets (a fork PR's own review) before it can set do_review. An
+          # empty PAT here is therefore a deleted or renamed secret, or a lane
+          # nobody has modelled yet — neither repaired by a later tick, and
+          # neither visible to a job `if:`, which cannot read the `secrets`
+          # context at all.
+          # It must not be quiet. With no credential every `gh` call below
+          # answers as if the repository held no PRs, so the scan would walk an
+          # empty candidate list and report a healthy fleet of zero — green,
+          # forever, while the whole loop is dead.
+          if [[ -z "${GITHUB_TOKEN}" ]]; then
+            echo "::error::CI_DEV_BOT_PAT is empty in this ${EVENT_NAME} scan — every API call would be unauthenticated and the scan would report an empty fleet; check the repository secret"
+            exit 1
+          fi
+
           # Fleet visibility: every per-PR decision below also records a row so
           # the run summary shows the WHOLE managed fleet in one table.
           # Reconstructing this by hand (list bot PRs, regex each one's eval

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -1804,13 +1804,13 @@ describe('qwen-autofix workflow', () => {
     expect(routeStep).toContain(
       'if [[ "${EVENT_NAME}" == \'pull_request_review\' ]]; then',
     );
-    // In-repo PRs are managed only when the bot authored them; forks only
-    // under the scan's takeover rules (allow-edits + bot fork or the label).
+    // In-repo PRs are managed only when the bot authored them. Forks are not
+    // managed from this event at all — it carries no repository secrets, so
+    // nothing downstream of it could authenticate ('declines fork PRs at the
+    // real-time review trigger' replays that).
     expect(routeStep).toContain('"${PR_AUTHOR}" == "${AUTOFIX_BOT}"');
     expect(routeStep).toContain('"${PR_HEAD_REPO}" == "${REPO}"');
     expect(routeStep).toContain('"${PR_BASE_REF}" != "main"');
-    expect(routeStep).toContain('.maintainerCanModify == true');
-    expect(routeStep).toContain('index($t) != null');
     expect(routeStep).toContain(
       'ROUTE_PR="$(sanitize_number "${PR_NUMBER_EVENT}")',
     );
@@ -1818,7 +1818,7 @@ describe('qwen-autofix workflow', () => {
       "review event ignored: PR author '${PR_AUTHOR}' is not ${AUTOFIX_BOT}",
     );
     expect(routeStep).toContain(
-      'review event ignored: fork PR #${PR_NUMBER_EVENT} does not allow maintainer edits',
+      'fork review noted for #${PR_NUMBER_EVENT} — this event carries no repository secrets',
     );
   });
 
@@ -4425,11 +4425,12 @@ exit 1
     expect(routeStep).toContain(
       'gh api "repos/${REPO}/collaborators/${SENDER_LOGIN}/permission"',
     );
-    // Non-main targets are rejected; forks are admitted only under the scan's
-    // own takeover rules (allow-edits + bot fork or takeover label).
+    // Non-main targets are rejected, and so is every fork — this event holds
+    // no repository secrets, so an admitted fork PR reaches a scan that cannot
+    // authenticate. The scheduled scan owns them instead.
     expect(routeStep).toContain('"${PR_BASE_REF}" != "main"');
     expect(routeStep).toContain('"${PR_HEAD_REPO}" == "${REPO}"');
-    expect(routeStep).toContain('--json labels,maintainerCanModify');
+    expect(routeStep).toContain('fork review noted for #${PR_NUMBER_EVENT}');
     // Must set ROUTE_PR from the event payload.
     expect(routeStep).toContain(
       'ROUTE_PR="$(sanitize_number "${PR_NUMBER_EVENT}")"',
@@ -4449,13 +4450,18 @@ exit 1
     );
   });
 
-  it('admits managed fork PRs to the real-time review trigger, not just in-repo bot PRs', () => {
-    // The */10 schedule is throttled to 40-70min on this repo, so a takeover PR
-    // that only the scan could pick up waited up to an hour for feedback the
-    // event already carried. Real-time pickup now applies the scan's OWN fork
-    // admission (allow-edits + the bot's own fork or an explicit takeover
-    // label); review-address still re-verifies allow-edits, a live write+
-    // author and a matching head repo before touching the branch.
+  it('declines fork PRs at the real-time review trigger, admits in-repo bot PRs', () => {
+    // Real-time pickup for fork PRs was intended to spare a takeover PR the
+    // 40-70min the throttled */10 schedule really takes — but it could never
+    // work: GitHub gives a run tied to a fork PR NO repository secrets
+    // (`Secret source: None`), so CI_DEV_BOT_PAT was empty and the admitted
+    // PR reached a review-scan that failed three unauthenticated metadata
+    // reads and exited 1 on metadata_fetch_failed. Every review of a fork PR
+    // reddened the workflow while changing nothing.
+    // Route declines here instead, mirroring the pull_request label branch,
+    // which already refuses forks for the same reason. The latency it was
+    // trying to remove comes back until a credentialed lane exists; nothing
+    // that ever functioned is lost.
     const block = routeStep.match(
       /if \[\[ "\$\{EVENT_NAME\}" == 'pull_request_review' \]\]; then[\s\S]*?\n {14}fi/,
     )?.[0];
@@ -4533,41 +4539,80 @@ exit 1
     expect(run({ headRepo: IN_REPO, author: 'someone' })).toContain(
       'DO_REVIEW=false',
     );
-    // NEW: the bot's own fork, and a takeover-labelled human fork, are admitted
-    // in real time and route to that exact PR.
-    expect(run({ headRepo: FORK, author: 'qwen-code-dev-bot' })).toContain(
-      'DO_REVIEW=true',
-    );
-    expect(
-      run({ headRepo: FORK, author: 'wenshao', labels: ['autofix/takeover'] }),
-    ).toContain('DO_REVIEW=true');
-    expect(run({ headRepo: FORK, author: 'qwen-code-dev-bot' })).toContain(
-      'ROUTE_PR=7259',
-    );
-    // Still rejected: no allow-edits, an unlabelled human fork, a non-main
-    // base, and an untrusted sender.
-    expect(
-      run({ headRepo: FORK, author: 'qwen-code-dev-bot', allowEdits: false }),
-    ).toContain('DO_REVIEW=false');
-    expect(run({ headRepo: FORK, author: 'wenshao' })).toContain(
-      'DO_REVIEW=false',
-    );
+    // Every fork shape is declined now — including the two that used to be
+    // admitted. The bot's own fork and a takeover-labelled human fork were the
+    // whole point of the removed branch, so they are the cases that prove it
+    // is gone rather than merely narrowed.
+    for (const forkCase of [
+      { headRepo: FORK, author: 'qwen-code-dev-bot' },
+      { headRepo: FORK, author: 'wenshao', labels: ['autofix/takeover'] },
+      { headRepo: FORK, author: 'wenshao' },
+      { headRepo: FORK, author: 'qwen-code-dev-bot', allowEdits: false },
+    ]) {
+      const out = run(forkCase);
+      expect(out).toContain('DO_REVIEW=false');
+      expect(out).toContain('ROUTE_PR=');
+      expect(out).not.toContain('ROUTE_PR=7259');
+    }
+    // Declined without asking the API anything. The removed branch spent a
+    // `gh pr view` and a collaborator-permission call to reach a verdict this
+    // event can never act on; a decline that still paid for them would be the
+    // same waste with a quieter log.
+    expect(routeStep).not.toContain('--json labels,maintainerCanModify');
+    expect(routeStep).toContain('fork review noted for #${PR_NUMBER_EVENT}');
+    // In-repo routing is untouched: a non-main base and an untrusted sender
+    // are still refused, so this change narrowed the fork case alone.
     expect(
       run({ headRepo: IN_REPO, author: 'qwen-code-dev-bot', base: 'release' }),
     ).toContain('DO_REVIEW=false');
     expect(
-      run({
-        headRepo: FORK,
-        author: 'wenshao',
-        labels: ['autofix/takeover'],
-        perm: 'read',
-      }),
+      run({ headRepo: IN_REPO, author: 'qwen-code-dev-bot', perm: 'read' }),
     ).toContain('DO_REVIEW=false');
-    // A metadata read failure fails CLOSED: the event is ignored rather than
-    // admitting a fork whose allow-edits/labels could not be verified.
-    expect(
-      run({ headRepo: FORK, author: 'qwen-code-dev-bot', metaOk: false }),
-    ).toContain('DO_REVIEW=false');
+  });
+
+  it('reds an unauthenticated scan instead of reporting an empty fleet', () => {
+    // Route declines the one event GitHub is known to run without secrets, but
+    // no job `if:` can read the `secrets` context, so a deleted or renamed
+    // CI_DEV_BOT_PAT — or a lane nobody has modelled — is invisible until the
+    // step itself looks. It must stop there: unauthenticated `gh pr list`
+    // answers as if the repository held no PRs, and the scan would read that
+    // as a healthy fleet of zero and stay green while the loop is dead.
+    const credGuard = reviewScanJob.match(
+      /(if \[\[ -z "\$\{GITHUB_TOKEN\}" \]\]; then[\s\S]*?\n {10}fi)/,
+    )?.[1];
+    expect(credGuard).toBeTruthy();
+    // Worthless once an API call has already been made and believed.
+    expect(reviewScanJob.indexOf(credGuard)).toBeLessThan(
+      reviewScanJob.indexOf('gh pr view'),
+    );
+
+    const runGuard = (token) =>
+      spawnSync(
+        'bash',
+        [
+          '-c',
+          [
+            'set -eo pipefail',
+            credGuard.replace(/\n {10}/g, '\n'),
+            // Reached only by a guard that falls through.
+            'echo SCANNED',
+          ].join('\n'),
+        ],
+        {
+          env: { ...process.env, EVENT_NAME: 'schedule', GITHUB_TOKEN: token },
+          encoding: 'utf8',
+        },
+      );
+
+    const missing = runGuard('');
+    expect(missing.status).toBe(1);
+    expect(missing.stdout).toContain('::error::CI_DEV_BOT_PAT is empty');
+    expect(missing.stdout).not.toContain('SCANNED');
+    // Negative control: a present PAT falls straight through, so the guard
+    // cannot swallow a scan that was going to work.
+    const present = runGuard('ghp_stub');
+    expect(present.status).toBe(0);
+    expect(present.stdout).toContain('SCANNED');
   });
 
   it('refuses a takeover on a non-main base out loud instead of only in the job log', () => {


### PR DESCRIPTION
## Summary

GitHub hands **no repository secrets** to a workflow run tied to a pull request whose head lives in a fork. The run header says so:

```
Secret source: None
```

`secrets.CI_DEV_BOT_PAT` therefore arrives **empty** and every `gh` call made with it is unauthenticated.

Route admitted those PRs to the real-time review lane anyway. The fork branch spent two API reads deciding it, then `review-scan` spent three more failing and exited 1:

```
##[warning]Forced PR #8436 metadata lookup failed (attempt 1/3 … 3/3)
##[error]Forced PR #8436 admission blocked: metadata_fetch_failed
```

`metadata_fetch_failed` promises "a later scheduled scan will retry the API" — true for a 5xx, false for a credential the run was never handed. Every `pull_request_review` on a fork PR reddened this workflow while changing nothing.

The admitting branch explained itself with *"This event runs in BASE-repo context"*. That holds for the workflow **file**, which is read from base — verified: run `31152873061` executed a version of `qwen-autofix.yml` its own PR branch does not contain — but not for the **credentials**.

Measured, from one morning's runs:

| forced PR | head | Secret source | review-scan |
| --- | --- | --- | --- |
| #8663 / #8665 / #8667 | `QwenLM/qwen-code` | `Actions` | ✅ |
| #8436 / #8320 / #8525 / #8394 / #8455 / #8639 / #8440 / #8578 / #8365 / #8332 | fork | **`None`** | ❌ `metadata_fetch_failed` |

It is the **event**, not the PR and not the author. `issue_comment` on the very same fork PRs (#8365, #8418, #8425, #8525, #8639) reads `Secret source: Actions`, because that run is not bound to the PR head. #8436's author holds `admin` here and the run still got `None`.

The condition is not new; #8410 only made it loud. Before it, the unauthenticated `gh pr view` returned empty and the scan soft-rejected with a **misleading** reason and exited 0 — run `31123457895`, PR #8619, same empty PAT:

```
❌ #8619 is not an open main-targeting PR owned by qwen-code-dev-bot or labeled autofix/takeover …
```

## Changes

**Route declines fork PRs at the `pull_request_review` trigger**, mirroring the `pull_request` label branch one screen below, which already refuses forks for exactly this reason. `pr_is_managed` stays false, so `do_review` stays false and the existing job condition and concurrency expression skip `review-scan` with nothing new added. The two API reads that funded the old verdict go away with it.

**`review-scan` gains a hard guard on an empty PAT.** No job `if:` can read the `secrets` context, so a deleted or renamed secret — or a lane nobody has modelled — is invisible until the step looks. It stops there: unauthenticated `gh pr list` answers as if the repository held no PRs, and the scan would read that as a healthy fleet of zero and stay green while the loop is dead.

### What is lost, stated plainly

Real-time pickup for fork PRs is removed, not fixed. It never worked — the admitted PR reached a scan that could not authenticate — so no behaviour regresses, but the *intent* (spare a takeover PR the 40-70 minutes the throttled `*/10` schedule really takes) is not served here. Restoring it needs a credentialed lane; a `workflow_run` bridge does that in a separate PR. Until then fork PRs are handled by the scheduled scan, which already admits them:

```
🌿 fork takeover candidate #8320 admitted (author qqqys=write)
🌿 fork takeover candidate #8394 admitted (author wenshao=admin)
```

### Rejected alternative

Reading the metadata with `github.token` does not help. `review-address` still needs the PAT to push and comment, and it is empty for the whole run — the round would fail later, after a checkout, an `npm ci`, a build and an agent run.

## Verification

- `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-autofix-workflow.test.js` — 121/121 pass
- Sibling suites that read this workflow: `qwen-resolve-workflow`, `qwen-fleet-shepherd-workflow`, `package-scripts` — 56/56 pass; `node --test .github/scripts/classify-release-notes.test.mjs` — 3/3 pass
- The fork-admission replay becomes a fork-**decline** replay over the same shapes, including the two the removed branch existed to admit (the bot's own fork, and a takeover-labelled human fork), and pins that the decline costs no API call. The new guard is replayed under `bash` with a present-PAT negative control.
- Mutation-tested — all 5 fail as they should: restore the fork admission; decline but still call the API; reword the decline; drop the guard; make the guard exit 0.

<details><summary>中文说明</summary>

## 摘要

GitHub 不会把仓库 secrets 发给「绑定在 fork PR head 上」的 workflow run，run 日志头部直接写明：

```
Secret source: None
```

因此 `secrets.CI_DEV_BOT_PAT` 是**空的**，用它发出的每个 `gh` 调用都未认证。

而 route 仍然把这些 PR 放进了实时评审车道。fork 分支先花两次 API 读取做判定，`review-scan` 再连烧三次后 exit 1：

```
##[warning]Forced PR #8436 metadata lookup failed (attempt 1/3 … 3/3)
##[error]Forced PR #8436 admission blocked: metadata_fetch_failed
```

`metadata_fetch_failed` 的承诺是「稍后的定时扫描会重试 API」——对 5xx 成立，对一个从未下发给这个 run 的凭据不成立。于是每次 review 一个 fork PR 都把工作流刷红，却什么也没改变。

那段放行逻辑的注释理由是 *"This event runs in BASE-repo context"*。这对 workflow **文件**成立（文件确实从 base 读取——已验证：run `31152873061` 执行的 `qwen-autofix.yml` 版本并不存在于它自己的 PR 分支上），但对**凭据**不成立。

一个上午的实测：

| forced PR | head | Secret source | review-scan |
| --- | --- | --- | --- |
| #8663 / #8665 / #8667 | `QwenLM/qwen-code` | `Actions` | ✅ |
| #8436 / #8320 / #8525 / #8394 / #8455 / #8639 / #8440 / #8578 / #8365 / #8332 | fork | **`None`** | ❌ `metadata_fetch_failed` |

决定因素是**事件**，既不是 PR 也不是作者。`issue_comment` 作用在同一批 fork PR（#8365、#8418、#8425、#8525、#8639）上读到的是 `Secret source: Actions`，因为那种 run 不绑定 PR head。#8436 的作者在本仓是 `admin`，run 依然是 `None`。

这个状况并非新出现，#8410 只是让它变响了。在那之前，未认证的 `gh pr view` 返回空，扫描以一个**误导性**理由软拒绝并 exit 0 —— run `31123457895`，PR #8619，同样是空 PAT：

```
❌ #8619 is not an open main-targeting PR owned by qwen-code-dev-bot or labeled autofix/takeover …
```

## 变更

**route 在 `pull_request_review` 触发处直接拒绝 fork PR**，与下方 `pull_request` 标签分支的写法一致——那里早已出于同样原因拒绝 fork。`pr_is_managed` 保持 false，于是 `do_review` 为 false，现有的 job 条件与 concurrency 表达式自然跳过 `review-scan`，无需新增任何东西。原先为那个判定支付的两次 API 读取也一并消失。

**`review-scan` 新增一个空 PAT 硬闸门。** job `if:` 读不到 `secrets` 上下文，所以被删除或改名的 secret（以及任何尚未建模的车道）在步骤真正去看之前都是不可见的。它必须在此停下：未认证的 `gh pr list` 会表现得像仓库里一个 PR 都没有，扫描会把它读成「零 PR 的健康车队」，在整个循环已死的情况下永远显示绿色。

### 明确说明失去了什么

fork PR 的实时接管是被**移除**，不是被修复。它从来没能工作过——被放行的 PR 进入的是一个无法认证的扫描——所以没有行为回归，但它的**本意**（让接管中的 PR 不必等那个实测 40-70 分钟的 `*/10` 定时任务）在本 PR 中没有被满足。要恢复它需要一条有凭据的车道，`workflow_run` 桥接会在另一个 PR 中提供。在那之前，fork PR 由定时扫描处理，而它本来就在接管这些 PR：

```
🌿 fork takeover candidate #8320 admitted (author qqqys=write)
🌿 fork takeover candidate #8394 admitted (author wenshao=admin)
```

### 被否决的方案

改用 `github.token` 读元数据没有用。`review-address` 仍然需要 PAT 来 push 和发评论，而整个 run 里它都是空的——只会把失败推迟到 checkout、`npm ci`、构建和跑完 agent 之后。

## 验证

- `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-autofix-workflow.test.js` —— 121/121 通过
- 其他读取本工作流的测试套件：`qwen-resolve-workflow`、`qwen-fleet-shepherd-workflow`、`package-scripts` —— 56/56 通过；`node --test .github/scripts/classify-release-notes.test.mjs` —— 3/3 通过
- 原先的 fork 放行行为回放改为 fork **拒绝**回放，覆盖同样的输入形状，包括被移除分支专门为之存在的两种（bot 自己的 fork、带接管标签的人类 fork），并钉住拒绝路径不产生任何 API 调用。新闸门用 `bash` 真实回放，并带一个「PAT 存在」的负对照。
- 变异测试 —— 5 个全部如期失败：恢复 fork 放行；拒绝但仍调用 API；改写拒绝文案；删除闸门；把闸门改成 exit 0。

</details>
