### PR TITLE
fix(ci): give review runs upstream-timeout headroom

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -391,6 +391,18 @@ jobs:
           QWEN_HOME="${RUNNER_TEMP:?}/qwen-home"
           rm -rf "$QWEN_HOME" 2>/dev/null || true
           mkdir -p "$QWEN_HOME"
+          # Raise the SDK request timeout (connect + time-to-first-byte) from
+          # the 120s default: a large-PR review turn carries a million-token
+          # (mostly cached) context plus a long thinking phase, and under
+          # upstream load the first byte alone can exceed 120s — measured on
+          # PR 8507 (2026-08-07): the SDK's internal retries turned three
+          # ~120s TTFB timeouts into a 483s visible abort on an early, small
+          # turn. `model.generationConfig.timeout` is the settings path into
+          # ContentGeneratorConfig.timeout; there is no env knob for it, which
+          # is why this file exists. A higher ceiling costs nothing when the
+          # upstream is fast — it is a timeout, not a delay.
+          printf '%s\n' '{ "model": { "generationConfig": { "timeout": 600000 } } }' \
+            > "$QWEN_HOME/settings.json"
           rm -f /tmp/stage-*.md 2>/dev/null || true
           # Stale per-run capture-tools dirs: 'Install capture tools' creates
           # them under RUNNER_TEMP (the promoted tool dir every run, plus a
@@ -686,6 +698,19 @@ jobs:
           REVIEW_MODE: '${{ steps.context.outputs.review_mode }}'
           TIMEOUT_MINUTES: '${{ steps.context.outputs.timeout_minutes }}'
           TIMEOUT_EXPLICIT: '${{ steps.context.outputs.timeout_explicit }}'
+          # Stream-guard headroom for CI reviews, measured against the PR 8507
+          # double-abort (2026-08-07): the 17-agent fan-out generation on a
+          # ~1.27M-token context stalled chunk delivery past the 240s idle
+          # default while the upstream was degraded, and the pipeline-level
+          # retry doubled the loss (~16 minutes) before aborting the run.
+          # Idle at 10 minutes tolerates a long thinking phase between chunks;
+          # the lifetime cap at 30 minutes stays the hard bound for drip-fed
+          # streams and MUST exceed the idle window (a single legitimate gap
+          # is charged against both). The outer GNU timeout and the review
+          # deadline still bound the job — these knobs trade hang-detection
+          # latency for survival on slow-but-alive upstreams.
+          QWEN_STREAM_IDLE_TIMEOUT_MS: '600000'
+          QWEN_STREAM_MAX_LIFETIME_MS: '1800000'
           # Evidence-image destination for `qwen review publish-assets` —
           # OPT-IN by design: the command refuses to push images anywhere the
           # user did not designate, so with the repository variable unset the

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -391,18 +391,6 @@ jobs:
           QWEN_HOME="${RUNNER_TEMP:?}/qwen-home"
           rm -rf "$QWEN_HOME" 2>/dev/null || true
           mkdir -p "$QWEN_HOME"
-          # Raise the SDK request timeout (connect + time-to-first-byte) from
-          # the 120s default: a large-PR review turn carries a million-token
-          # (mostly cached) context plus a long thinking phase, and under
-          # upstream load the first byte alone can exceed 120s — measured on
-          # PR 8507 (2026-08-07): the SDK's internal retries turned three
-          # ~120s TTFB timeouts into a 483s visible abort on an early, small
-          # turn. `model.generationConfig.timeout` is the settings path into
-          # ContentGeneratorConfig.timeout; there is no env knob for it, which
-          # is why this file exists. A higher ceiling costs nothing when the
-          # upstream is fast — it is a timeout, not a delay.
-          printf '%s\n' '{ "model": { "generationConfig": { "timeout": 600000 } } }' \
-            > "$QWEN_HOME/settings.json"
           rm -f /tmp/stage-*.md 2>/dev/null || true
           # Stale per-run capture-tools dirs: 'Install capture tools' creates
           # them under RUNNER_TEMP (the promoted tool dir every run, plus a
@@ -698,17 +686,35 @@ jobs:
           REVIEW_MODE: '${{ steps.context.outputs.review_mode }}'
           TIMEOUT_MINUTES: '${{ steps.context.outputs.timeout_minutes }}'
           TIMEOUT_EXPLICIT: '${{ steps.context.outputs.timeout_explicit }}'
-          # Stream-guard headroom for CI reviews, measured against the PR 8507
-          # double-abort (2026-08-07): the 17-agent fan-out generation on a
-          # ~1.27M-token context stalled chunk delivery past the 240s idle
-          # default while the upstream was degraded, and the pipeline-level
-          # retry doubled the loss (~16 minutes) before aborting the run.
-          # Idle at 10 minutes tolerates a long thinking phase between chunks;
-          # the lifetime cap at 30 minutes stays the hard bound for drip-fed
-          # streams and MUST exceed the idle window (a single legitimate gap
-          # is charged against both). The outer GNU timeout and the review
-          # deadline still bound the job — these knobs trade hang-detection
-          # latency for survival on slow-but-alive upstreams.
+          # Timeout headroom for CI reviews, measured against the PR 8507
+          # double-abort (2026-08-07):
+          # - Request timeout (connect + TTFB), 120s default -> 10 minutes:
+          #   a large-PR review turn carries a million-token (mostly cached)
+          #   context plus a long thinking phase, and under upstream load the
+          #   first byte alone can exceed 120s; the SDK's internal retries
+          #   turned three ~120s TTFB timeouts into a 483s visible abort on
+          #   an early, small turn. QWEN_CODE_API_TIMEOUT_MS is the env knob
+          #   for ContentGeneratorConfig.timeout and outranks settings, so no
+          #   settings.json write is needed.
+          # - Stream idle window, 240s default -> 10 minutes: tolerates a
+          #   long thinking phase between chunks; the PR 8507 fan-out
+          #   generation on a ~1.27M-token context stalled past the default
+          #   while the upstream was degraded, and the pipeline-level retry
+          #   doubled the loss (~16 minutes) before aborting the run.
+          # - Lifetime cap at 30 minutes: the hard bound for drip-fed
+          #   streams; MUST exceed the idle window (a single legitimate gap
+          #   is charged against both).
+          # Accepted trade-offs: a dead-but-accepting upstream now costs up
+          # to 4 x 10 minutes per SDK call (DEFAULT_MAX_RETRIES = 3),
+          # doubled again by the pipeline retry, before a visible abort —
+          # hang-detection latency degrades for that rare case; and
+          # LoggingContentGenerator's hardcoded 5-minute stream-span idle
+          # timer fires before these guards, closing the LLM request span as
+          # an idle-timeout failure and skipping its api_response log even
+          # when the generation succeeds. The outer GNU timeout and the
+          # review deadline still bound the job — these knobs trade
+          # hang-detection latency for survival on slow-but-alive upstreams.
+          QWEN_CODE_API_TIMEOUT_MS: '600000'
           QWEN_STREAM_IDLE_TIMEOUT_MS: '600000'
           QWEN_STREAM_MAX_LIFETIME_MS: '1800000'
           # Evidence-image destination for `qwen review publish-assets` —

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -705,8 +705,11 @@ jobs:
           #   streams; MUST exceed the idle window (a single legitimate gap
           #   is charged against both).
           # Accepted trade-offs: a dead-but-accepting upstream now costs up
-          # to 4 x 10 minutes per SDK call (DEFAULT_MAX_RETRIES = 3),
-          # doubled again by the pipeline retry, before a visible abort —
+          # to ~4 x 30 minutes per LLM turn for a drip-fed generation (the
+          # lifetime cap bounds one attempt; the guard's ETIMEDOUT rides the
+          # transport replay/continuation budget) or ~4 x 10 minutes per
+          # TTFB-hung SDK call (DEFAULT_MAX_RETRIES = 3), with the pipeline
+          # retry on top, before a visible abort —
           # hang-detection latency degrades for that rare case; and
           # LoggingContentGenerator's hardcoded 5-minute stream-span idle
           # timer fires before these guards, closing the LLM request span as

--- a/scripts/tests/qwen-pr-review-workflow.test.js
+++ b/scripts/tests/qwen-pr-review-workflow.test.js
@@ -1232,3 +1232,31 @@ describe('capture-tools step wiring', () => {
     ).toBe('${{ vars.QWEN_REVIEW_ASSETS_REPO }}');
   });
 });
+
+describe('upstream-timeout headroom (PR 8507 incident)', () => {
+  // Three knobs, three failure modes: the SDK request timeout covers
+  // connect+TTFB (three ~120s internal retries produced the 483s visible
+  // abort on a small turn), the idle window covers a stalled generation
+  // (the 17-agent fan-out on a ~1.27M-token context), and the lifetime cap
+  // must exceed the idle window or a single legitimate gap trips the
+  // drip-feed guard first.
+  const doc = parse(workflow);
+  const steps = doc.jobs['review-pr'].steps;
+
+  it('writes the SDK request timeout into the per-run settings.json', () => {
+    const setup = steps.find((s) =>
+      (s.run ?? '').includes('Fresh per-run agent home'),
+    );
+    expect(setup.run).toContain('"generationConfig": { "timeout": 600000 }');
+    expect(setup.run).toContain('> "$QWEN_HOME/settings.json"');
+  });
+
+  it('raises the stream guards with lifetime strictly above idle', () => {
+    const env = steps.find((s) => s.name === 'Run review').env;
+    const idle = Number(env.QWEN_STREAM_IDLE_TIMEOUT_MS);
+    const lifetime = Number(env.QWEN_STREAM_MAX_LIFETIME_MS);
+    expect(idle).toBe(600000);
+    expect(lifetime).toBe(1800000);
+    expect(lifetime).toBeGreaterThan(idle);
+  });
+});

--- a/scripts/tests/qwen-pr-review-workflow.test.js
+++ b/scripts/tests/qwen-pr-review-workflow.test.js
@@ -1253,10 +1253,10 @@ describe('upstream-timeout headroom (PR 8507 incident)', () => {
   });
 
   it('raises the stream guards with lifetime strictly above idle', () => {
-    const idle = Number(env.QWEN_STREAM_IDLE_TIMEOUT_MS);
-    const lifetime = Number(env.QWEN_STREAM_MAX_LIFETIME_MS);
-    expect(idle).toBe(600000);
-    expect(lifetime).toBe(1800000);
-    expect(lifetime).toBeGreaterThan(idle);
+    expect(env.QWEN_STREAM_IDLE_TIMEOUT_MS).toBe('600000');
+    expect(env.QWEN_STREAM_MAX_LIFETIME_MS).toBe('1800000');
+    expect(Number(env.QWEN_STREAM_MAX_LIFETIME_MS)).toBeGreaterThan(
+      Number(env.QWEN_STREAM_IDLE_TIMEOUT_MS),
+    );
   });
 });

--- a/scripts/tests/qwen-pr-review-workflow.test.js
+++ b/scripts/tests/qwen-pr-review-workflow.test.js
@@ -1239,20 +1239,20 @@ describe('upstream-timeout headroom (PR 8507 incident)', () => {
   // abort on a small turn), the idle window covers a stalled generation
   // (the 17-agent fan-out on a ~1.27M-token context), and the lifetime cap
   // must exceed the idle window or a single legitimate gap trips the
-  // drip-feed guard first.
+  // drip-feed guard first. All three ride step env on 'Run review':
+  // QWEN_CODE_API_TIMEOUT_MS outranks settings in model-config resolution
+  // (so no settings.json write is needed) and step env outranks any stray
+  // runner-level env of the same name.
   const doc = parse(workflow);
-  const steps = doc.jobs['review-pr'].steps;
+  const env = doc.jobs['review-pr'].steps.find(
+    (s) => s.name === 'Run review',
+  ).env;
 
-  it('writes the SDK request timeout into the per-run settings.json', () => {
-    const setup = steps.find((s) =>
-      (s.run ?? '').includes('Fresh per-run agent home'),
-    );
-    expect(setup.run).toContain('"generationConfig": { "timeout": 600000 }');
-    expect(setup.run).toContain('> "$QWEN_HOME/settings.json"');
+  it('raises the SDK request timeout via QWEN_CODE_API_TIMEOUT_MS', () => {
+    expect(env.QWEN_CODE_API_TIMEOUT_MS).toBe('600000');
   });
 
   it('raises the stream guards with lifetime strictly above idle', () => {
-    const env = steps.find((s) => s.name === 'Run review').env;
     const idle = Number(env.QWEN_STREAM_IDLE_TIMEOUT_MS);
     const lifetime = Number(env.QWEN_STREAM_MAX_LIFETIME_MS);
     expect(idle).toBe(600000);


### PR DESCRIPTION
## What this PR does

Gives CI review runs headroom against a slow-but-alive upstream, on three knobs:

- **SDK request timeout** (connect + time-to-first-byte): `model.generationConfig.timeout: 600000` written into the per-run `QWEN_HOME/settings.json` — there is no env knob for this value, which is why the setup step now writes a one-line settings file.
- **Stream idle window**: `QWEN_STREAM_IDLE_TIMEOUT_MS: 600000` (up from the 240s default) — tolerates a long thinking phase between chunks on a million-token context.
- **Stream lifetime cap**: `QWEN_STREAM_MAX_LIFETIME_MS: 1800000` — stays the hard bound for drip-fed streams, kept strictly above the idle window (a single legitimate gap is charged against both guards).

A test pins all three values and the `lifetime > idle` ordering.

## Why it's needed

PR 8507's automatic review aborted twice on 2026-08-07 (run 31151676274, attempt 1) with `Request timeout after 483s`. That message is a classification wrapper printing **elapsed time**, not a configured threshold — the log timeline shows two distinct guards firing under a degraded upstream:

1. **Try 1** (05:51–06:15): setup completed normally; the 17-agent fan-out generation for a 3B review (1270 source lines, round 3, ~1.27M-token context) stalled chunk delivery past the 240s idle default. The pipeline-level retry doubled the loss: 05:58 → 06:15 is ~2 × (stream + idle window) before the visible abort.
2. **Try 2** (06:18–06:27): a fresh start died on an early, small turn (~197K tokens) at 483s elapsed ≈ three ~120s connect/TTFB timeouts through the SDK's internal retries — proof the upstream itself was degraded, not just the message size.

The guards behaved as designed post-8602 (visible, classified, 35-minute failure instead of a silent 6-hour burn); what remained wrong was the ceilings being sized for a healthy upstream. Raising them costs nothing when the upstream is fast — they are timeouts, not delays — and the outer GNU timeout plus the review deadline still bound the job either way.

## Reviewer Test Plan

### How to verify

- `npx vitest run scripts/tests/qwen-pr-review-workflow.test.js` — 51 passed, including the new pin (three values + ordering).
- `yamllint .github/workflows/qwen-code-pr-review.yml` — clean; the setup step's bash passes `bash -n`; the settings JSON literal parses.
- Settings path sanity: `model.generationConfig.timeout` flows into `ContentGeneratorConfig.timeout` via the resolved CLI generation config (`createContentGeneratorConfig`), which is the SDK request timeout the OpenAI pipeline passes to the client.

### Evidence (Before & After)

Before: run 31151676274 attempt 1 — two aborts, both `Request timeout after 483s`, fallback comment posted at 06:27. After: counterfactual — try 1's stall needed >240s idle tolerance mid-generation (now 600s); try 2's TTFB chain needed >120s per attempt (now 600s).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A — CI   |
| 🪟 Windows |   N/A — CI   |
|  🐧 Linux  |   ✅   |

## Risk & Scope

- CI-only: local runs and other environments keep the shipped defaults; the settings file lives in the ephemeral per-run `QWEN_HOME`.
- A genuinely hung stream is now detected in up to 10 minutes (idle) or 30 minutes (drip-feed) instead of 4/15 — the trade is hang-detection latency, and the job-level GNU timeout plus `QWEN_REVIEW_DEADLINE_EPOCH` remain the outer bounds.
- Touches the same workflow as the open 8648; whichever lands second rebases (different regions: the QWEN_HOME setup step and the Run review `env:` block).

## Linked Issues

Incident: the failed automatic review on 8507 (run 31151676274).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

给 CI 评审运行在"上游慢但活着"的场景下的三个超时旋钮加余量：

- **SDK 请求超时**（连接 + 首字节）：向每次运行的临时 `QWEN_HOME/settings.json` 写入 `model.generationConfig.timeout: 600000`——该值没有环境变量旋钮，这正是 setup 步骤新增一行 settings 文件的原因；
- **流空闲窗口**：`QWEN_STREAM_IDLE_TIMEOUT_MS: 600000`（默认 240s）——容忍百万 token 上下文上 chunk 之间的长思考段；
- **流总时长上限**：`QWEN_STREAM_MAX_LIFETIME_MS: 1800000`——仍是滴注流的硬界，且严格高于空闲窗口（一次合法间隙会同时计入两个守卫）。

测试钉住三个值与 `lifetime > idle` 的次序。

## 为什么需要

8507 的自动评审在 2026-08-07（run 31151676274，attempt 1）两次以 `Request timeout after 483s` 中止。该消息是分类包装、打印的是**总耗时**而非配置阈值——日志时间线显示退化上游下两个不同守卫先后触发：

1. **第一次**（05:51–06:15）：setup 正常；3B 评审（1270 源码行、第 3 轮、~127 万 token 上下文）的 17-agent 扇出生成让 chunk 投递停滞超过 240s 空闲默认值，管线级重试把损失翻倍（05:58→06:15 ≈ 2×(流+空闲窗口)）后可见中止；
2. **第二次**（06:18–06:27）：从头重启后，一个早期小轮次（~19.7 万 token）在 483s 处死亡 ≈ SDK 内部重试链上三次 ~120s 连接/首字节超时——证明是上游本身退化，而非消息过大。

守卫在 8602 合入后按设计工作（35 分钟内可见、可分类地失败，而非静默烧 6 小时）；剩下的问题是阈值按健康上游定的。调高在上游快时零成本——它们是超时不是延迟——且外层 GNU timeout 与评审 deadline 仍然兜底。

## 风险与范围

- 仅 CI：本地与其他环境保持默认值；settings 文件在临时的每次运行 `QWEN_HOME` 里。
- 真挂死的流的检出时间从 4/15 分钟变为最多 10/30 分钟——代价是挂死检出延迟，job 级 GNU timeout 与 `QWEN_REVIEW_DEADLINE_EPOCH` 仍是外界。
- 与开放中的 8648 触同一 workflow（不同区域），后合者 rebase 即可。

## 关联

事故：8507 的自动评审失败（run 31151676274）。

</details>
