### PR TITLE
feat(cli): mirror Live Host releases through OSS

### DIFF
--- a/.github/workflows/live-host-release.yml
+++ b/.github/workflows/live-host-release.yml
@@ -345,3 +345,15 @@ jobs:
             echo "Version: $RELEASE_VERSION"
             echo "Release: $RELEASE_URL"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  sync-oss:
+    name: 'Mirror stable Qwen Live Host release to Aliyun OSS'
+    if: "${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == false && inputs.draft == false && inputs.prerelease == false && github.repository == 'QwenLM/qwen-code' }}"
+    needs:
+      - 'prepare'
+      - 'build'
+      - 'publish'
+    uses: './.github/workflows/sync-live-host-to-oss.yml'
+    with:
+      version: '${{ needs.prepare.outputs.version }}'
+      source: 'artifact'

--- a/.github/workflows/sync-live-host-to-oss.yml
+++ b/.github/workflows/sync-live-host-to-oss.yml
@@ -1,0 +1,203 @@
+name: 'Sync Qwen Live Host to Aliyun OSS'
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: 'string'
+      source:
+        required: true
+        type: 'string'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Stable Live Host version to mirror, for example 0.1.0 or v0.1.0.'
+        required: true
+        type: 'string'
+      source:
+        description: 'Download the assets from the matching GitHub release.'
+        required: true
+        default: 'release'
+        type: 'choice'
+        options:
+          - 'release'
+
+concurrency:
+  group: 'sync-live-host-to-oss-${{ inputs.version }}'
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: 'Mirror Qwen Live Host to Aliyun OSS'
+    if: "${{ github.repository == 'QwenLM/qwen-code' }}"
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 30
+    environment:
+      name: 'production-release'
+    permissions:
+      actions: 'read'
+      contents: 'read'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
+
+      - name: 'Resolve release'
+        id: 'release'
+        env:
+          INPUT_VERSION: '${{ inputs.version }}'
+          INPUT_SOURCE: '${{ inputs.source }}'
+        run: |
+          set -euo pipefail
+          version="${INPUT_VERSION#v}"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Live Host OSS mirrors require a stable X.Y.Z version (got '$INPUT_VERSION')."
+            exit 1
+          fi
+          if [[ "$INPUT_SOURCE" != 'artifact' && "$INPUT_SOURCE" != 'release' ]]; then
+            echo "::error::Live Host mirror source must be artifact or release (got '$INPUT_SOURCE')."
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "source=$INPUT_SOURCE" >> "$GITHUB_OUTPUT"
+
+      - name: 'Download release workflow artifact'
+        if: "${{ steps.release.outputs.source == 'artifact' }}"
+        uses: 'actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c' # v8.0.1
+        with:
+          name: 'qwen-live-host-macos'
+          path: 'dist/live-host'
+
+      - name: 'Download GitHub release assets'
+        if: "${{ steps.release.outputs.source == 'release' }}"
+        env:
+          GH_TOKEN: '${{ github.token }}'
+          VERSION: '${{ steps.release.outputs.version }}'
+        run: |
+          set -euo pipefail
+          metadata="$(gh release view "live-host-v${VERSION}" --json isDraft,isPrerelease)"
+          if ! jq -e '.isDraft == false and .isPrerelease == false' <<<"$metadata" >/dev/null; then
+            echo "::error::live-host-v${VERSION} is not a published stable release."
+            exit 1
+          fi
+          mkdir -p dist/live-host
+          gh release download "live-host-v${VERSION}" \
+            --dir dist/live-host \
+            --pattern 'Qwen-Live-Host-manifest.json' \
+            --pattern 'Qwen-Live-Host-arm64.zip' \
+            --pattern 'Qwen-Live-Host-x64.zip'
+
+      - name: 'Verify release assets'
+        env:
+          VERSION: '${{ steps.release.outputs.version }}'
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC2016
+          node --input-type=module -e '
+            import { createHash } from "node:crypto";
+            import { readFileSync, statSync } from "node:fs";
+            const directory = "dist/live-host";
+            const manifest = JSON.parse(readFileSync(`${directory}/Qwen-Live-Host-manifest.json`, "utf8"));
+            if (manifest.version !== process.env.VERSION) throw new Error(`Manifest version ${manifest.version} does not match ${process.env.VERSION}.`);
+            for (const architecture of ["arm64", "x64"]) {
+              const name = `Qwen-Live-Host-${architecture}.zip`;
+              const file = `${directory}/${name}`;
+              const asset = manifest.assets?.[architecture];
+              const checksum = createHash("sha256").update(readFileSync(file)).digest("hex");
+              if (asset?.name !== name || asset.size !== statSync(file).size || asset.sha256 !== checksum) throw new Error(`Manifest asset verification failed for ${architecture}.`);
+            }
+          '
+
+      - name: 'Install ossutil'
+        env:
+          OSSUTIL_URL: "${{ vars.OSSUTIL_URL || 'https://gosspublic.alicdn.com/ossutil/1.7.19/ossutil-v1.7.19-linux-amd64.zip' }}"
+          OSSUTIL_SHA256: "${{ vars.OSSUTIL_SHA256 || 'dcc512e4a893e16bbee63bc769339d8e56b21744fd83c8212a9d8baf28767343' }}"
+        run: |
+          set -euo pipefail
+          tmp_dir="$(mktemp -d)"
+          curl -fsSL --connect-timeout 15 --max-time 300 "$OSSUTIL_URL" -o "$tmp_dir/ossutil.zip"
+          echo "$OSSUTIL_SHA256  $tmp_dir/ossutil.zip" | sha256sum -c -
+          unzip -q "$tmp_dir/ossutil.zip" -d "$tmp_dir"
+          ossutil_path="$(find "$tmp_dir" -type f \( -name 'ossutil' -o -name 'ossutil64' \) -print -quit)"
+          if [[ -z "$ossutil_path" ]]; then echo '::error::ossutil binary not found'; exit 1; fi
+          chmod +x "$ossutil_path"
+          mkdir -p "$HOME/.local/bin"
+          install -m 0755 "$ossutil_path" "$HOME/.local/bin/ossutil"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          rm -rf "$tmp_dir"
+
+      - name: 'Configure Aliyun OSS credentials'
+        env:
+          ALIYUN_OSS_ACCESS_KEY_ID: '${{ secrets.ALIYUN_OSS_ACCESS_KEY_ID }}'
+          ALIYUN_OSS_ACCESS_KEY_SECRET: '${{ secrets.ALIYUN_OSS_ACCESS_KEY_SECRET }}'
+          ALIYUN_OSS_ENDPOINT: "${{ vars.ALIYUN_OSS_ENDPOINT || 'https://oss-cn-hangzhou.aliyuncs.com' }}"
+        run: |
+          set -euo pipefail
+          if [[ -z "$ALIYUN_OSS_ACCESS_KEY_ID" || -z "$ALIYUN_OSS_ACCESS_KEY_SECRET" ]]; then
+            echo '::error::Missing Aliyun OSS credentials in the production-release environment.'
+            exit 1
+          fi
+          ossutil config -e "$ALIYUN_OSS_ENDPOINT" -i "$ALIYUN_OSS_ACCESS_KEY_ID" -k "$ALIYUN_OSS_ACCESS_KEY_SECRET" -L EN -c "$RUNNER_TEMP/.ossutilconfig"
+
+      - name: 'Upload versioned assets to Aliyun OSS'
+        env:
+          ALIYUN_OSS_BUCKET: "${{ vars.ALIYUN_OSS_BUCKET || 'qwen-code-assets' }}"
+          VERSION: '${{ steps.release.outputs.version }}'
+        run: |
+          set -euo pipefail
+          node scripts/upload-aliyun-oss-assets.js \
+            --bucket "$ALIYUN_OSS_BUCKET" \
+            --config "$RUNNER_TEMP/.ossutilconfig" \
+            --prefix "live-host/v${VERSION}" \
+            dist/live-host/Qwen-Live-Host-arm64.zip \
+            dist/live-host/Qwen-Live-Host-x64.zip \
+            dist/live-host/Qwen-Live-Host-manifest.json
+
+      - name: 'Verify versioned assets on Aliyun OSS'
+        env:
+          ALIYUN_OSS_PUBLIC_BASE_URL: "${{ vars.ALIYUN_OSS_PUBLIC_BASE_URL || 'https://qwen-code-assets.oss-cn-hangzhou.aliyuncs.com' }}"
+          VERSION: '${{ steps.release.outputs.version }}'
+        run: |
+          set -euo pipefail
+          base="$ALIYUN_OSS_PUBLIC_BASE_URL/live-host/v${VERSION}"
+          directory="$(mktemp -d)"
+          trap 'rm -rf "$directory"' EXIT
+          for asset in Qwen-Live-Host-manifest.json Qwen-Live-Host-arm64.zip Qwen-Live-Host-x64.zip; do
+            curl -fsSL --connect-timeout 15 --max-time 3600 "$base/$asset" -o "$directory/$asset"
+          done
+          # shellcheck disable=SC2016
+          VERSION="$VERSION" DIRECTORY="$directory" node --input-type=module -e '
+            import { createHash } from "node:crypto";
+            import { readFileSync, statSync } from "node:fs";
+            const manifest = JSON.parse(readFileSync(`${process.env.DIRECTORY}/Qwen-Live-Host-manifest.json`, "utf8"));
+            if (manifest.version !== process.env.VERSION) throw new Error("Mirrored manifest version mismatch.");
+            for (const architecture of ["arm64", "x64"]) {
+              const name = `Qwen-Live-Host-${architecture}.zip`;
+              const file = `${process.env.DIRECTORY}/${name}`;
+              const asset = manifest.assets?.[architecture];
+              const checksum = createHash("sha256").update(readFileSync(file)).digest("hex");
+              if (asset?.name !== name || asset.size !== statSync(file).size || asset.sha256 !== checksum) throw new Error(`Mirrored asset verification failed for ${architecture}.`);
+            }
+          '
+
+      - name: 'Publish latest manifest to Aliyun OSS'
+        env:
+          ALIYUN_OSS_BUCKET: "${{ vars.ALIYUN_OSS_BUCKET || 'qwen-code-assets' }}"
+        run: |
+          node scripts/upload-aliyun-oss-assets.js \
+            --bucket "$ALIYUN_OSS_BUCKET" \
+            --config "$RUNNER_TEMP/.ossutilconfig" \
+            --prefix 'live-host/latest' \
+            dist/live-host/Qwen-Live-Host-manifest.json
+
+      - name: 'Verify latest manifest on Aliyun OSS'
+        env:
+          ALIYUN_OSS_PUBLIC_BASE_URL: "${{ vars.ALIYUN_OSS_PUBLIC_BASE_URL || 'https://qwen-code-assets.oss-cn-hangzhou.aliyuncs.com' }}"
+        run: |
+          set -euo pipefail
+          curl -fsSL --connect-timeout 15 --max-time 300 "$ALIYUN_OSS_PUBLIC_BASE_URL/live-host/latest/Qwen-Live-Host-manifest.json" -o "$RUNNER_TEMP/Qwen-Live-Host-manifest.json"
+          cmp dist/live-host/Qwen-Live-Host-manifest.json "$RUNNER_TEMP/Qwen-Live-Host-manifest.json"
+
+      - name: 'Cleanup Aliyun OSS credentials'
+        if: '${{ always() }}'
+        run: 'rm -f "$RUNNER_TEMP/.ossutilconfig"'

--- a/.github/workflows/sync-live-host-to-oss.yml
+++ b/.github/workflows/sync-live-host-to-oss.yml
@@ -24,7 +24,7 @@ on:
           - 'release'
 
 concurrency:
-  group: 'sync-live-host-to-oss-${{ inputs.version }}'
+  group: 'sync-live-host-to-oss'
   cancel-in-progress: false
 
 jobs:
@@ -125,6 +125,7 @@ jobs:
           install -m 0755 "$ossutil_path" "$HOME/.local/bin/ossutil"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           rm -rf "$tmp_dir"
+          "$HOME/.local/bin/ossutil" >/dev/null
 
       - name: 'Configure Aliyun OSS credentials'
         env:
@@ -179,6 +180,19 @@ jobs:
               if (asset?.name !== name || asset.size !== statSync(file).size || asset.sha256 !== checksum) throw new Error(`Mirrored asset verification failed for ${architecture}.`);
             }
           '
+
+      - name: 'Confirm latest manifest matches GitHub stable feed'
+        env:
+          GH_TOKEN: '${{ github.token }}'
+        run: |
+          set -euo pipefail
+          directory="$(mktemp -d)"
+          trap 'rm -rf "$directory"' EXIT
+          gh release download 'live-host-latest' \
+            --dir "$directory" \
+            --pattern 'Qwen-Live-Host-manifest.json'
+          cmp dist/live-host/Qwen-Live-Host-manifest.json \
+            "$directory/Qwen-Live-Host-manifest.json"
 
       - name: 'Publish latest manifest to Aliyun OSS'
         env:

--- a/docs/design/web-shell-live-voice-codex-parity-refactor.md
+++ b/docs/design/web-shell-live-voice-codex-parity-refactor.md
@@ -274,10 +274,10 @@ The complete first-use path is:
    `qwen3.5-omni-plus-realtime` and optionally change the global shortcut.
 3. Turn on Live Voice and confirm that the signed native Host will be
    installed.
-4. The daemon downloads the architecture-matching release from the fixed
-   Qwen Code release origin, verifies its manifest checksum, bundle identity,
-   signature, and Gatekeeper acceptance, installs it atomically in
-   `/Applications`, and launches it.
+4. The daemon downloads the architecture-matching release from the Aliyun OSS
+   mirror, with the fixed Qwen Code GitHub release feed as fallback. It verifies
+   the manifest checksum, bundle identity, signature, and Gatekeeper acceptance,
+   installs it atomically in `/Applications`, and launches it.
 5. The Host guides the user through Microphone, Accessibility, and Screen
    Recording authorization. macOS remains the sole grant authority; the
    application cannot pre-grant or bypass TCC permissions.

--- a/packages/cli/src/serve/live/live-host-installer.test.ts
+++ b/packages/cli/src/serve/live/live-host-installer.test.ts
@@ -132,6 +132,73 @@ describe('LiveHostInstaller', () => {
     }
   });
 
+  it('removes a checksum-invalid OSS archive before falling back', async () => {
+    const expectedOssBytes = Buffer.from('expected-oss-archive');
+    const corruptOssBytes = Buffer.alloc(expectedOssBytes.byteLength, 0x78);
+    const githubBytes = Buffer.from('github-archive');
+    const ossManifest = manifestForBytes('0.1.0', expectedOssBytes);
+    const githubManifest = manifestForBytes('0.2.0', githubBytes);
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(Response.json(ossManifest))
+      .mockResolvedValueOnce(
+        new Response(corruptOssBytes, {
+          headers: { 'content-length': String(corruptOssBytes.byteLength) },
+        }),
+      )
+      .mockResolvedValueOnce(Response.json(githubManifest))
+      .mockResolvedValueOnce(
+        new Response(githubBytes, {
+          headers: { 'content-length': String(githubBytes.byteLength) },
+        }),
+      );
+    const directory = await fsp.mkdtemp(
+      path.join(os.tmpdir(), 'live-host-download-test-'),
+    );
+    const destination = path.join(directory, 'host.zip');
+
+    try {
+      const release = await downloadLiveHostRelease(
+        'arm64',
+        destination,
+        () => {},
+        fetchImpl,
+      );
+      expect(release.manifest).toEqual(githubManifest);
+      await expect(fsp.readFile(destination)).resolves.toEqual(githubBytes);
+    } finally {
+      await fsp.rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('reports both source failures and removes the destination', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(null, { status: 503 }));
+    const directory = await fsp.mkdtemp(
+      path.join(os.tmpdir(), 'live-host-download-test-'),
+    );
+    const destination = path.join(directory, 'host.zip');
+
+    try {
+      await expect(
+        downloadLiveHostRelease('arm64', destination, () => {}, fetchImpl),
+      ).rejects.toMatchObject({
+        message:
+          'Qwen Live Host download failed. OSS: Live Host manifest download failed (503). GitHub: Live Host manifest download failed (503).',
+        errors: [
+          { message: 'OSS: Live Host manifest download failed (503).' },
+          { message: 'GitHub: Live Host manifest download failed (503).' },
+        ],
+      });
+      await expect(fsp.stat(destination)).rejects.toMatchObject({
+        code: 'ENOENT',
+      });
+    } finally {
+      await fsp.rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it('passes separate bounded signals to manifest and archive requests', async () => {
     const bytes = Buffer.from('signed-live-host-archive');
     const expected = manifestForBytes('0.1.0', bytes);

--- a/packages/cli/src/serve/live/live-host-installer.test.ts
+++ b/packages/cli/src/serve/live/live-host-installer.test.ts
@@ -4,13 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { createHash } from 'node:crypto';
+import * as fsp from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import { LIVE_HOST_PROTOCOL_VERSION } from './types.js';
 import {
+  downloadLiveHostRelease,
   isExpectedLiveHostSignature,
   LiveHostInstaller,
+  LIVE_HOST_DOWNLOAD_TIMEOUT_MS,
+  LIVE_HOST_MANIFEST_FETCH_TIMEOUT_MS,
+  LIVE_HOST_OSS_BASE_URL,
   LIVE_HOST_RELEASE_BASE_URL,
   parseLiveHostReleaseManifest,
+  resolveLiveHostAssetUrls,
+  resolveLiveHostManifestUrls,
 } from './live-host-installer.js';
 
 const sha = 'a'.repeat(64);
@@ -36,11 +46,120 @@ function manifest() {
   };
 }
 
+function manifestForBytes(version: string, bytes: Buffer) {
+  const checksum = createHash('sha256').update(bytes).digest('hex');
+  return {
+    ...manifest(),
+    version,
+    assets: {
+      arm64: {
+        name: 'Qwen-Live-Host-arm64.zip',
+        size: bytes.byteLength,
+        sha256: checksum,
+      },
+      x64: {
+        name: 'Qwen-Live-Host-x64.zip',
+        size: bytes.byteLength,
+        sha256: checksum,
+      },
+    },
+  };
+}
+
 describe('LiveHostInstaller', () => {
-  it('downloads only from the independent stable Live Host feed', () => {
+  it('prefers the OSS mirror and retains the independent GitHub fallback', () => {
+    expect(LIVE_HOST_OSS_BASE_URL).toBe(
+      'https://qwen-code-assets.oss-cn-hangzhou.aliyuncs.com/live-host',
+    );
     expect(LIVE_HOST_RELEASE_BASE_URL).toBe(
       'https://github.com/QwenLM/qwen-code/releases/download/live-host-latest',
     );
+    expect(resolveLiveHostManifestUrls()).toEqual([
+      `${LIVE_HOST_OSS_BASE_URL}/latest/Qwen-Live-Host-manifest.json`,
+      `${LIVE_HOST_RELEASE_BASE_URL}/Qwen-Live-Host-manifest.json`,
+    ]);
+    expect(
+      resolveLiveHostAssetUrls('0.1.0', 'Qwen-Live-Host-arm64.zip'),
+    ).toEqual([
+      `${LIVE_HOST_OSS_BASE_URL}/v0.1.0/Qwen-Live-Host-arm64.zip`,
+      `${LIVE_HOST_RELEASE_BASE_URL}/Qwen-Live-Host-arm64.zip`,
+    ]);
+  });
+
+  it('falls back with a matching GitHub manifest and asset pair', async () => {
+    const ossBytes = Buffer.from('oss-archive');
+    const githubBytes = Buffer.from('github-archive');
+    const ossManifest = manifestForBytes('0.1.0', ossBytes);
+    const githubManifest = manifestForBytes('0.2.0', githubBytes);
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(Response.json(ossManifest))
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(Response.json(githubManifest))
+      .mockResolvedValueOnce(
+        new Response(githubBytes, {
+          headers: { 'content-length': String(githubBytes.byteLength) },
+        }),
+      );
+    const directory = await fsp.mkdtemp(
+      path.join(os.tmpdir(), 'live-host-download-test-'),
+    );
+    const destination = path.join(directory, 'host.zip');
+
+    try {
+      const release = await downloadLiveHostRelease(
+        'arm64',
+        destination,
+        () => {},
+        fetchImpl,
+      );
+      expect(release.manifest).toEqual(githubManifest);
+      await expect(fsp.readFile(destination)).resolves.toEqual(githubBytes);
+      expect(fetchImpl.mock.calls.map(([url]) => String(url))).toEqual([
+        resolveLiveHostManifestUrls()[0],
+        resolveLiveHostAssetUrls(
+          ossManifest.version,
+          ossManifest.assets.arm64.name,
+        )[0],
+        resolveLiveHostManifestUrls()[1],
+        resolveLiveHostAssetUrls(
+          githubManifest.version,
+          githubManifest.assets.arm64.name,
+        )[1],
+      ]);
+    } finally {
+      await fsp.rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('passes separate bounded signals to manifest and archive requests', async () => {
+    const bytes = Buffer.from('signed-live-host-archive');
+    const expected = manifestForBytes('0.1.0', bytes);
+    const manifestSignal = AbortSignal.abort('manifest');
+    const downloadSignal = AbortSignal.abort('download');
+    const timeout = vi
+      .spyOn(AbortSignal, 'timeout')
+      .mockReturnValueOnce(manifestSignal)
+      .mockReturnValueOnce(downloadSignal);
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(Response.json(expected))
+      .mockResolvedValueOnce(new Response(bytes));
+    const directory = await fsp.mkdtemp(
+      path.join(os.tmpdir(), 'live-host-download-test-'),
+    );
+    const destination = path.join(directory, 'host.zip');
+
+    try {
+      await downloadLiveHostRelease('arm64', destination, () => {}, fetchImpl);
+      expect(LIVE_HOST_MANIFEST_FETCH_TIMEOUT_MS).toBe(5 * 60 * 1000);
+      expect(LIVE_HOST_DOWNLOAD_TIMEOUT_MS).toBe(60 * 60 * 1000);
+      expect(fetchImpl.mock.calls[0]?.[1]?.signal).toBe(manifestSignal);
+      expect(fetchImpl.mock.calls[1]?.[1]?.signal).toBe(downloadSignal);
+    } finally {
+      timeout.mockRestore();
+      await fsp.rm(directory, { recursive: true, force: true });
+    }
   });
 
   it('accepts only the Qwen Developer ID team', () => {

--- a/packages/cli/src/serve/live/live-host-installer.ts
+++ b/packages/cli/src/serve/live/live-host-installer.ts
@@ -20,13 +20,16 @@ const execFileAsync = promisify(execFile);
 export const LIVE_HOST_BUNDLE_ID = 'com.alibaba.qwen-code.live-host';
 export const LIVE_HOST_TEAM_IDENTIFIER = 'NF4574S59H';
 export const LIVE_HOST_APP_PATH = '/Applications/Qwen Live Host.app';
+export const LIVE_HOST_OSS_BASE_URL =
+  'https://qwen-code-assets.oss-cn-hangzhou.aliyuncs.com/live-host';
 export const LIVE_HOST_RELEASE_BASE_URL =
   'https://github.com/QwenLM/qwen-code/releases/download/live-host-latest';
 export const LIVE_HOST_MANIFEST_NAME = 'Qwen-Live-Host-manifest.json';
+export const LIVE_HOST_MANIFEST_FETCH_TIMEOUT_MS = 5 * 60 * 1000;
+export const LIVE_HOST_DOWNLOAD_TIMEOUT_MS = 60 * 60 * 1000;
 
 const LIVE_HOST_APP_NAME = 'Qwen Live Host.app';
 const MAX_DOWNLOAD_BYTES = 512 * 1024 * 1024;
-const FETCH_TIMEOUT_MS = 5 * 60 * 1000;
 const COMMAND_TIMEOUT_MS = 2 * 60 * 1000;
 const SHA256_PATTERN = /^[a-f0-9]{64}$/;
 const VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
@@ -213,11 +216,30 @@ async function inspectInstalledHost(): Promise<InstalledLiveHost | undefined> {
   }
 }
 
-async function fetchManifest(): Promise<LiveHostReleaseManifest> {
-  const response = await fetch(
+export function resolveLiveHostManifestUrls(): [string, string] {
+  return [
+    `${LIVE_HOST_OSS_BASE_URL}/latest/${LIVE_HOST_MANIFEST_NAME}`,
     `${LIVE_HOST_RELEASE_BASE_URL}/${LIVE_HOST_MANIFEST_NAME}`,
-    { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) },
-  );
+  ];
+}
+
+export function resolveLiveHostAssetUrls(
+  version: string,
+  assetName: string,
+): [string, string] {
+  return [
+    `${LIVE_HOST_OSS_BASE_URL}/v${version}/${assetName}`,
+    `${LIVE_HOST_RELEASE_BASE_URL}/${assetName}`,
+  ];
+}
+
+async function fetchManifest(
+  url: string,
+  fetchImpl: typeof fetch,
+): Promise<LiveHostReleaseManifest> {
+  const response = await fetchImpl(url, {
+    signal: AbortSignal.timeout(LIVE_HOST_MANIFEST_FETCH_TIMEOUT_MS),
+  });
   if (!response.ok) {
     await response.body?.cancel().catch(() => {});
     throw new Error(`Live Host manifest download failed (${response.status}).`);
@@ -227,11 +249,13 @@ async function fetchManifest(): Promise<LiveHostReleaseManifest> {
 
 async function downloadAsset(
   asset: LiveHostReleaseAsset,
+  url: string,
   destination: string,
   onProgress: (progress: number) => void,
+  fetchImpl: typeof fetch,
 ): Promise<void> {
-  const response = await fetch(`${LIVE_HOST_RELEASE_BASE_URL}/${asset.name}`, {
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  const response = await fetchImpl(url, {
+    signal: AbortSignal.timeout(LIVE_HOST_DOWNLOAD_TIMEOUT_MS),
   });
   if (!response.ok || !response.body) {
     await response.body?.cancel().catch(() => {});
@@ -270,16 +294,48 @@ async function downloadAsset(
   }
 }
 
+export async function downloadLiveHostRelease(
+  currentArchitecture: LiveHostArchitecture,
+  destination: string,
+  onProgress: (progress: number) => void,
+  fetchImpl: typeof fetch = fetch,
+): Promise<{
+  manifest: LiveHostReleaseManifest;
+  asset: LiveHostReleaseAsset;
+}> {
+  const manifestUrls = resolveLiveHostManifestUrls();
+  const labels = ['OSS', 'GitHub'];
+  const errors: Error[] = [];
+
+  for (let index = 0; index < manifestUrls.length; index += 1) {
+    try {
+      await fsp.rm(destination, { force: true });
+      const manifest = await fetchManifest(manifestUrls[index], fetchImpl);
+      const asset = manifest.assets[currentArchitecture];
+      const assetUrl = resolveLiveHostAssetUrls(manifest.version, asset.name)[
+        index
+      ];
+      await downloadAsset(asset, assetUrl, destination, onProgress, fetchImpl);
+      return { manifest, asset };
+    } catch (error) {
+      errors.push(
+        new Error(`${labels[index]}: ${errorMessage(error)}`, { cause: error }),
+      );
+    }
+  }
+
+  await fsp.rm(destination, { force: true });
+  throw new AggregateError(errors, 'Qwen Live Host download failed.');
+}
+
 async function installLatestHost(
   currentArchitecture: LiveHostArchitecture,
   onStatus: (status: LiveHostInstallStatus) => void,
 ): Promise<InstalledLiveHost> {
-  const manifest = await fetchManifest();
-  const asset = manifest.assets[currentArchitecture];
   const temporaryDirectory = await fsp.mkdtemp(
     path.join(os.tmpdir(), 'qwen-live-host-'),
   );
-  const archivePath = path.join(temporaryDirectory, asset.name);
+  const archivePath = path.join(temporaryDirectory, 'Qwen-Live-Host.zip');
   const extractedPath = path.join(temporaryDirectory, 'extracted');
   const candidatePath = path.join(extractedPath, LIVE_HOST_APP_NAME);
   const stagingPath = `/Applications/.Qwen Live Host.install-${randomUUID()}.app`;
@@ -288,9 +344,13 @@ async function installLatestHost(
   let installedCandidate = false;
   try {
     onStatus({ state: 'downloading', progress: 0 });
-    await downloadAsset(asset, archivePath, (progress) => {
-      onStatus({ state: 'downloading', progress });
-    });
+    const { manifest } = await downloadLiveHostRelease(
+      currentArchitecture,
+      archivePath,
+      (progress) => {
+        onStatus({ state: 'downloading', progress });
+      },
+    );
     onStatus({ state: 'verifying' });
     await fsp.mkdir(extractedPath, { mode: 0o700 });
     await run('/usr/bin/ditto', ['-x', '-k', archivePath, extractedPath]);

--- a/packages/cli/src/serve/live/live-host-installer.ts
+++ b/packages/cli/src/serve/live/live-host-installer.ts
@@ -325,7 +325,12 @@ export async function downloadLiveHostRelease(
   }
 
   await fsp.rm(destination, { force: true });
-  throw new AggregateError(errors, 'Qwen Live Host download failed.');
+  throw new AggregateError(
+    errors,
+    `Qwen Live Host download failed. ${errors
+      .map((error) => error.message)
+      .join(' ')}`,
+  );
 }
 
 async function installLatestHost(

--- a/packages/desktop/apps/live-host/README.md
+++ b/packages/desktop/apps/live-host/README.md
@@ -19,9 +19,10 @@ daemon 和其他操作系统不会显示入口。
 1. 在 WebShell 打开 **设置 → 实验性功能 → Qwen Live**。
 2. 输入专用于 Realtime 模型的 DashScope API key；快捷键默认是
    `Command+E`，可在同一处修改。
-3. 打开开关并确认安装。WebShell 会从独立的 `live-host-latest` release 下载当前
-   架构的签名 Host，校验 manifest、SHA-256、bundle identity、Developer ID 签名
-   和 Gatekeeper，然后原子安装到 `/Applications/Qwen Live Host.app` 并启动。
+3. 打开开关并确认安装。WebShell 优先从阿里云 OSS 镜像下载当前架构的签名 Host；
+   镜像不可用时回退到独立的 GitHub `live-host-latest` feed。下载后校验 manifest、
+   SHA-256、bundle identity、Developer ID 签名和 Gatekeeper，然后原子安装到
+   `/Applications/Qwen Live Host.app` 并启动。
 4. 按 Host 引导完成麦克风、辅助功能和屏幕录制授权。授权只能由用户在 macOS
    完成；全部 readiness 通过前 Live 不可使用。
 
@@ -54,8 +55,10 @@ Developer ID 签名、notarization、Gatekeeper 和 stapler 验证。
 
 版本发布使用 `live-host-vX.Y.Z` tag，包含两个 DMG、两个 ZIP、
 `Qwen-Live-Host-manifest.json` 和 `SHA256SUMS.txt`。非 draft、非 prerelease 的
-正式版本还会更新固定的 `live-host-latest` feed；WebShell 自动安装只读取该 feed
-中的 manifest 和两个 ZIP。
+正式版本还会更新固定的 GitHub `live-host-latest` feed，并在发布成功后调用一次
+独立的 OSS 镜像 workflow。镜像保存版本化 ZIP 和 manifest，再发布一个 latest
+manifest；需要重传时可手工运行同一镜像 workflow。WebShell 自动安装优先读取 OSS，
+失败时使用 GitHub feed。
 
 构建会把仓库内的 Objective-C++ Appshot 源码编译成一个 universal N-API 模块，
 并随 Host 一起签名。模块在 Host 主进程内调用 macOS 截屏与 AX API；没有额外 Appshot

--- a/scripts/tests/live-host-oss-workflow.test.js
+++ b/scripts/tests/live-host-oss-workflow.test.js
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { getWorkflowJob, getWorkflowStep } from './workflow-helpers.js';
+
+const releaseWorkflow = readFileSync(
+  '.github/workflows/live-host-release.yml',
+  'utf8',
+);
+const syncWorkflow = readFileSync(
+  '.github/workflows/sync-live-host-to-oss.yml',
+  'utf8',
+);
+
+describe('Live Host OSS mirror workflow', () => {
+  it('runs only after a stable Live Host release or a manual re-run', () => {
+    expect(syncWorkflow).not.toContain('pull_request:');
+    expect(syncWorkflow).not.toContain('dry_run');
+
+    const syncOss = getWorkflowJob(releaseWorkflow, 'sync-oss');
+    expect(syncOss).toContain(
+      "if: \"${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == false && inputs.draft == false && inputs.prerelease == false && github.repository == 'QwenLM/qwen-code' }}\"",
+    );
+    expect(syncOss).toContain("- 'publish'");
+    expect(syncOss).toContain("source: 'artifact'");
+  });
+
+  it('uploads and verifies one release without an OSS state machine', () => {
+    const sync = getWorkflowJob(syncWorkflow, 'sync');
+    expect(sync).toContain("name: 'production-release'");
+    expect(sync).not.toContain('check-live-host-oss-state');
+    expect(sync).not.toContain('allow-hidden-missing');
+
+    const versionUpload = getWorkflowStep(
+      sync,
+      'Upload versioned assets to Aliyun OSS',
+    );
+    expect(versionUpload).toContain('--prefix "live-host/v${VERSION}"');
+
+    const latestUpload = getWorkflowStep(
+      sync,
+      'Publish latest manifest to Aliyun OSS',
+    );
+    expect(latestUpload).toContain("--prefix 'live-host/latest'");
+    expect(latestUpload).toContain('Qwen-Live-Host-manifest.json');
+    expect(latestUpload).not.toContain('Qwen-Live-Host-arm64.zip');
+  });
+});

--- a/scripts/tests/live-host-oss-workflow.test.js
+++ b/scripts/tests/live-host-oss-workflow.test.js
@@ -50,4 +50,28 @@ describe('Live Host OSS mirror workflow', () => {
     expect(latestUpload).toContain('Qwen-Live-Host-manifest.json');
     expect(latestUpload).not.toContain('Qwen-Live-Host-arm64.zip');
   });
+
+  it('serializes latest updates and checks the GitHub stable feed', () => {
+    expect(syncWorkflow).toContain("group: 'sync-live-host-to-oss'");
+    expect(syncWorkflow).not.toContain(
+      "group: 'sync-live-host-to-oss-${{ inputs.version }}'",
+    );
+
+    const latestCheck = getWorkflowStep(
+      getWorkflowJob(syncWorkflow, 'sync'),
+      'Confirm latest manifest matches GitHub stable feed',
+    );
+    expect(latestCheck).toContain("gh release download 'live-host-latest'");
+    expect(latestCheck).toContain(
+      'cmp dist/live-host/Qwen-Live-Host-manifest.json',
+    );
+  });
+
+  it('smoke-tests the installed ossutil binary', () => {
+    const install = getWorkflowStep(
+      getWorkflowJob(syncWorkflow, 'sync'),
+      'Install ossutil',
+    );
+    expect(install).toContain('"$HOME/.local/bin/ossutil" >/dev/null');
+  });
 });


### PR DESCRIPTION
## What this PR does

Adds a release-triggered Aliyun OSS mirror for stable Qwen Live Host packages. The installer prefers the mirrored manifest and versioned architecture ZIP, retries the complete manifest-and-ZIP pair from the existing GitHub stable feed when OSS is unavailable, and allows up to one hour for an archive download.

The mirror is deliberately linear: a stable Live Host release supplies one version, the workflow verifies and uploads that version, verifies the public objects, and finally publishes the latest manifest. It has no pull-request OSS run, dry-run branch, version state machine, rollback logic, or hidden-object inference.

## Why it's needed

GitHub downloads can time out for users in China. Mirroring the same signed and checksummed Host artifacts to OSS improves onboarding reliability while retaining the independent GitHub feed as a fallback.

## Reviewer Test Plan

### How to verify

Confirm the pull request runs the existing unsigned Live Host release dry run while the OSS mirror job remains skipped. Run the focused installer and workflow tests and confirm that OSS failures restart from the GitHub manifest rather than mixing manifests and assets. Confirm a stable non-draft, non-prerelease release invokes the mirror once after publish.

### Evidence (Before & After)

N/A — distribution and installer transport only; no UI changes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Node.js 22; focused unit tests, workflow tests, actionlint, ESLint, full repository build, and full repository typecheck.

## Risk & Scope

- Main risk or tradeoff: the first production OSS mirror requires the existing `production-release` credentials; until it succeeds, installation continues through the verified GitHub fallback.
- Not validated / out of scope: no production OSS write was performed from this pull request, because the mirror intentionally runs only for a stable Live Host release or an explicit manual re-run.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

为稳定版 Qwen Live Host 增加发布后触发的阿里云 OSS 镜像。安装器优先读取 OSS 的 latest manifest 和对应版本、对应架构的 ZIP；OSS 不可用时，从 GitHub 稳定 feed 重新读取 manifest 并下载匹配的 ZIP，避免混用两套版本。压缩包下载超时提高到一小时。

镜像流程保持线性：稳定版 Live Host 发布提供一个版本，workflow 校验并上传该版本，回读验证公开对象，最后发布 latest manifest。没有 PR OSS 运行、dry-run 分支、版本状态机、回滚逻辑或隐藏对象推断。

## 为什么需要

中国用户从 GitHub 下载时可能超时。OSS 镜像提升首次启用的可靠性，同时保留独立 GitHub feed 作为后备。

## Reviewer 测试计划

### 如何验证

确认 PR 仍运行原有的未签名 Live Host release dry run，同时 OSS 镜像 job 保持跳过。运行安装器与 workflow 的聚焦测试，确认 OSS 失败后会从 GitHub manifest 重新开始，而不是混用 manifest 和资产。确认稳定、非 draft、非 prerelease 的发布只在 publish 成功后调用一次镜像。

### 前后证据

N/A——仅修改分发与安装下载链，没有 UI 变化。

### 测试平台

|     OS     | 状态  |
| :--------: | :---: |
|  🍏 macOS  |  ✅   |
| 🪟 Windows |  N/A  |
|  🐧 Linux  |  N/A  |

### 环境

Node.js 22；安装器聚焦单测、workflow 测试、actionlint、ESLint、全仓 build 和全仓 typecheck 均通过。

## 风险与范围

- 主要风险或取舍：第一次生产 OSS 镜像需要现有 `production-release` 凭据；镜像成功前，安装仍通过已验证的 GitHub fallback 完成。
- 未验证 / 范围外：本 PR 不执行生产 OSS 写入，因为镜像按要求只在稳定版 Live Host 发布后或显式手工重跑时执行。
- 破坏性变更 / 迁移说明：无。

## 关联问题

N/A

</details>
