### PR TITLE
fix(tests): avoid blocking the Vitest worker during directory E2E

### DIFF
--- a/integration-tests/cli/list_directory.test.ts
+++ b/integration-tests/cli/list_directory.test.ts
@@ -25,7 +25,6 @@ describe('list_directory', () => {
     await rig.setup('should be able to list a directory');
     rig.createFile('file1.txt', 'file 1 content');
     rig.mkdir('subdir');
-    rig.sync();
 
     await rig.poll(
       () => {

--- a/integration-tests/test-helper.ts
+++ b/integration-tests/test-helper.ts
@@ -246,11 +246,6 @@ export class TestRig {
     mkdirSync(join(this.testDir!, dir), { recursive: true });
   }
 
-  sync() {
-    // ensure file system is done before spawning
-    execSync('sync', { cwd: this.testDir! });
-  }
-
   /**
    * The command and args to use to invoke Qwen Code CLI. Allows us to switch
    * between using the bundled gemini.js (the default) and using the installed


### PR DESCRIPTION
## What this PR does

Removes an unnecessary full-system disk flush from the directory-listing integration test while preserving synchronous fixture creation, the existing readiness poll, and every behavioral assertion. The unused test helper entry point is removed as well.

## Why it's needed

On a busy self-hosted Linux runner, the synchronous `sync` command can block the Vitest worker event loop for more than birpc's 60-second RPC timeout. The test itself can still pass, but Vitest then reports `[vitest-worker]: Timeout calling "onTaskUpdate"` and fails the required no-AK gate. The existing filesystem operations already complete synchronously, and the test separately waits for both created paths to be visible, so the global flush adds latency without adding correctness.

## Reviewer Test Plan

### How to verify

Build and bundle the CLI, then run `npx vitest run --root ./integration-tests --maxWorkers 2 ./cli/list_directory.test.ts` repeatedly. Confirm the test continues to validate the tool call and both directory entries without invoking the system-wide `sync` command. Run the required no-AK integration gate in an isolated HOME with credential variables cleared and confirm the directory-listing test completes promptly without the Vitest worker RPC timeout.

Local evidence: the focused test passed 5/5 runs at about 1.3 seconds per run. In a CI-shaped full-gate run it passed in 1.625 seconds and the prior RPC timeout did not recur. The full local gate was still red because two unrelated permission-control assertions fail consistently on the current local main baseline (128/130 tests passed); those failures are outside this change.

### Evidence (Before & After)

Before: the affected CI run completed the directory-listing test after about 83 seconds, then failed with an unhandled `[vitest-worker]: Timeout calling "onTaskUpdate"` despite all 130 assertions passing.

After: five focused runs completed in about 1.3 seconds each, and the CI-shaped full-gate run completed the directory-listing test in 1.625 seconds without the worker RPC timeout.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS 15, Node.js 22.22.2, Vitest 3.2.4, no sandbox. Linux behavior is represented by the original GitHub Actions failure but was not rerun locally on Linux.

## Risk & Scope

- Main risk or tradeoff: The test no longer forces a global disk flush; synchronous file creation plus the existing real-condition poll remain the readiness boundary.
- Not validated / out of scope: Windows execution and a fully green local no-AK gate; two unrelated permission-control assertions fail on the current local main baseline.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

移除目录列表 integration test 中不必要的全系统磁盘刷新，同时保留同步创建测试夹具、现有就绪条件轮询以及全部行为断言，并删除不再使用的测试 helper 入口。

## Why it's needed

在繁忙的 self-hosted Linux runner 上，同步 `sync` 命令可能阻塞 Vitest worker 事件循环超过 birpc 的 60 秒 RPC timeout。测试本身仍可通过，但 Vitest 随后会报告 `[vitest-worker]: Timeout calling "onTaskUpdate"`，导致 required no-AK gate 失败。现有文件系统操作本身已经同步完成，而且测试还会单独等待两个创建路径真实可见，因此全局刷新只增加延迟，不增加正确性保障。

## Reviewer Test Plan

### How to verify

构建并 bundle CLI，然后重复运行 `npx vitest run --root ./integration-tests --maxWorkers 2 ./cli/list_directory.test.ts`。确认测试在不调用系统级 `sync` 的情况下，仍验证工具调用和两个目录条目。使用隔离 HOME 并清空凭据环境变量运行 required no-AK integration gate，确认目录列表测试快速完成，且不再出现 Vitest worker RPC timeout。

本地证据：目标测试连续运行 5 次全部通过，每次约 1.3 秒。在 CI 形态的完整 gate 中，该测试耗时 1.625 秒且未再出现原 RPC timeout。完整本地 gate 仍为红色，因为当前本地主线上的两个无关 permission-control 断言稳定失败（130 个测试中 128 个通过）；这些失败不在本次改动范围内。

### Evidence (Before & After)

Before：受影响 CI run 中目录列表测试约 83 秒后完成；尽管 130 个断言全部通过，随后仍因未处理的 `[vitest-worker]: Timeout calling "onTaskUpdate"` 而失败。

After：目标测试连续五次均约 1.3 秒完成；CI 形态的完整 gate 中该测试耗时 1.625 秒，未出现 worker RPC timeout。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS 15、Node.js 22.22.2、Vitest 3.2.4、无 sandbox。Linux 行为证据来自原始 GitHub Actions 失败，未在本地 Linux 环境重新运行。

## Risk & Scope

- 主要风险或取舍：测试不再强制执行全局磁盘刷新；同步文件创建和现有真实条件轮询仍作为就绪边界。
- 未验证 / 范围外：Windows 执行以及本地完整 no-AK gate 全绿；当前本地主线有两个无关 permission-control 断言失败。
- Breaking changes / migration notes：无。

## Linked Issues

N/A

</details>
