### PR TITLE
docs(users): add evidence-based-conclusions recipe to common workflows

### DIFF
--- a/docs/users/common-workflow.md
+++ b/docs/users/common-workflow.md
@@ -594,11 +594,7 @@ Treat these rules as mandatory in investigations, troubleshooting, reviews, and 
 
 **2. Choose the right scope**
 
-| File                      | Use when                                                   |
-| ------------------------- | ---------------------------------------------------------- |
-| `QWEN.md` in project root | The policy applies to the whole team (commit it)           |
-| `~/.qwen/QWEN.md`         | The policy applies to you personally, across all projects  |
-| `.qwen/QWEN.local.md`     | The policy is personal to you and specific to this project |
+See [Where to create QWEN.md](./features/memory.md#where-to-create-qwenmd) for which file applies to whom — commit the project-root `QWEN.md` copy so the policy covers the whole team.
 
 > [!tip]
 >

--- a/docs/users/common-workflow.md
+++ b/docs/users/common-workflow.md
@@ -569,3 +569,39 @@ what are the limitations of Qwen Code?
 > - Qwen Code always has access to the latest Qwen Code documentation, regardless of the version you're using
 > - Ask specific questions to get detailed answers
 > - Qwen Code can explain complex features like MCP integration, enterprise configurations, and advanced workflows
+
+## Enforce evidence-based conclusions
+
+When Qwen Code does high-stakes work — code review, incident troubleshooting, audits, or investigating production data — a confident but wrong conclusion costs more than no conclusion at all. You can encode your team's verification policy in QWEN.md (see [Memory](./features/memory.md)) so it applies to every session, without changing anyone's defaults.
+
+The rules below are adapted from a production retrospective of a multi-agent deployment, where confident-but-wrong conclusions repeatedly traced back to the same failure modes: inferring state from code instead of querying it, treating one satisfied condition as proof, and repeating earlier statements as facts.
+
+**1. Add a verification policy to your project QWEN.md**
+
+Put this template in `QWEN.md` at your repository root and commit it, so the policy applies to the whole team:
+
+```markdown
+# Verification policy
+
+Treat these rules as mandatory in investigations, troubleshooting, reviews, and any task that draws conclusions:
+
+1. Verify before concluding. Back claims about data or system state with evidence from the authoritative source (database, API, logs, command output). Conclusions drawn from reading code alone must be labeled "unverified inference".
+2. Verify the full chain. Enumerate the causal chain and check every link; one satisfied necessary condition does not prove a conclusion.
+3. Treat conversation history as leads, not facts. Statements in earlier transcripts — including your own prior assertions — are leads. Re-verify them at the source before repeating them as facts.
+4. Troubleshoot in order: your own recent changes first, then docs and known issues, and only then external dependencies.
+5. 100% evidence rule in reviews. In review and audit tasks, report no conclusion without evidence; attach verifiable evidence (file:line, query result, log excerpt) to every claim.
+```
+
+**2. Choose the right scope**
+
+| File                      | Use when                                                   |
+| ------------------------- | ---------------------------------------------------------- |
+| `QWEN.md` in project root | The policy applies to the whole team (commit it)           |
+| `~/.qwen/QWEN.md`         | The policy applies to you personally, across all projects  |
+| `.qwen/QWEN.local.md`     | The policy is personal to you and specific to this project |
+
+> [!tip]
+>
+> - Keep the rules specific and actionable: "back every claim with a query result" works better than "be careful".
+> - Keep the policy short — QWEN.md is followed more reliably when it is concise (see [Memory](./features/memory.md)).
+> - Adapt the rules to your stack: name the actual query tools, dashboards, or log commands your team treats as authoritative sources.

--- a/docs/users/features/memory.md
+++ b/docs/users/features/memory.md
@@ -19,6 +19,7 @@ Add things you'd otherwise have to repeat every session:
 - Coding conventions your team follows ("all new files must have JSDoc comments")
 - Architectural decisions ("we use the repository pattern, never call the database directly from controllers")
 - Personal preferences ("always use pnpm, not npm")
+- A verification policy for high-stakes work — for example "verify against the database before concluding" (see [Enforce evidence-based conclusions](../common-workflow.md#enforce-evidence-based-conclusions) for a ready-made template)
 
 Don't include things Qwen can figure out by reading your code. QWEN.md works best when it's short and specific — the longer it gets, the less reliably Qwen follows it.
 


### PR DESCRIPTION
## Summary

Implements the "docs recipe" that the triage of #8701 recommended as the first step.

- `docs/users/common-workflow.md`: new section **Enforce evidence-based conclusions** — a copy-pasteable QWEN.md verification-policy template (verify before concluding, verify the full chain, treat transcripts as leads not facts, troubleshooting order, 100% evidence rule in reviews), plus scoping guidance (team vs personal) and tips for keeping the policy effective.
- `docs/users/features/memory.md`: cross-reference to the template from "What to put in QWEN.md".

## Why

The triage on #8701 confirmed the problem is real but noted that baking the rules into the default system prompt would tax every session's context (#6097), and an opt-in mode would add config surface for behavior that is hard to measure. It stated "a docs recipe is a reasonable first step either way" — this PR is exactly that step: it makes the pattern shareable without changing anyone's defaults.

The rules are adapted from a production retrospective of a multi-agent deployment; the failure-mode stats are in #8701.

## Validation

- Docs-only change, 37 insertions.
- `prettier --check` passes on both files (repo's prettier 3.5.3, same as CI's `lint.js --prettier`).