### PR TITLE
fix(telemetry): ignore unsupported OTel exporter selectors

### DIFF
--- a/packages/core/src/telemetry/sdk-impl.ts
+++ b/packages/core/src/telemetry/sdk-impl.ts
@@ -425,7 +425,11 @@ export async function startTelemetrySdk(
     // `configureMetricProviderFromEnv()` unconditionally, so env-based readers
     // are only suppressed when an explicit reader is provided. This is
     // intentionally asymmetric with `spanProcessors`/`logRecordProcessors`,
-    // where an empty array disables env fallback for those signals.
+    // where an empty array disables env fallback for those signals. Those two
+    // must stay unconditional arrays: omitting them re-enables sdk-node's
+    // env-based fallback, and the logs fallback runs in the NodeSDK
+    // constructor — outside the env-var scrub window around `start()` in
+    // sdk.ts (`startSdkWithExplicitExporters`).
     ...(metricReader && { metricReader }),
     instrumentations: [
       new HttpInstrumentation({

--- a/packages/core/src/telemetry/sdk.test.ts
+++ b/packages/core/src/telemetry/sdk.test.ts
@@ -202,17 +202,57 @@ describe('Telemetry SDK', () => {
       Object.assign(process.env, exporterEnv);
       expect(isTelemetrySdkInitialized()).toBe(false);
       let startCalled = false;
+      const observedDuringStart: Record<string, string | undefined> = {};
 
       vi.mocked(NodeSDK.prototype.start).mockImplementationOnce(() => {
         startCalled = true;
         for (const name of Object.keys(exporterEnv)) {
-          expect(process.env[name]).toBeUndefined();
+          observedDuringStart[name] = process.env[name];
         }
       });
 
       try {
         await initializeTelemetry(mockConfig);
         expect(startCalled).toBe(true);
+        // Assert here, not inside the mocked start(): initializeTelemetry
+        // catches start() failures, so an assertion thrown there would be
+        // swallowed as an init failure and the test would still pass.
+        for (const name of Object.keys(exporterEnv)) {
+          expect(observedDuringStart[name]).toBeUndefined();
+          expect(process.env[name]).toBe(
+            exporterEnv[name as keyof typeof exporterEnv],
+          );
+        }
+      } finally {
+        for (const name of Object.keys(exporterEnv)) {
+          const previousValue = previousValues[name];
+          if (previousValue === undefined) {
+            delete process.env[name];
+          } else {
+            process.env[name] = previousValue;
+          }
+        }
+      }
+    });
+
+    it('restores external exporter selectors when sdk.start() throws', async () => {
+      const exporterEnv = {
+        OTEL_TRACES_EXPORTER: 'console',
+        OTEL_LOGS_EXPORTER: 'none',
+        OTEL_METRICS_EXPORTER: 'otlp',
+      } as const;
+      const previousValues = Object.fromEntries(
+        Object.keys(exporterEnv).map((name) => [name, process.env[name]]),
+      );
+      Object.assign(process.env, exporterEnv);
+
+      vi.mocked(NodeSDK.prototype.start).mockImplementationOnce(() => {
+        throw new Error('start failed');
+      });
+
+      try {
+        await initializeTelemetry(mockConfig);
+        expect(isTelemetrySdkInitialized()).toBe(false);
         for (const name of Object.keys(exporterEnv)) {
           expect(process.env[name]).toBe(
             exporterEnv[name as keyof typeof exporterEnv],

--- a/packages/core/src/telemetry/sdk.test.ts
+++ b/packages/core/src/telemetry/sdk.test.ts
@@ -190,6 +190,46 @@ describe('Telemetry SDK', () => {
       expect(NodeSDK.prototype.start).toHaveBeenCalledTimes(1);
     });
 
+    it('ignores external exporter selectors while starting explicit exporters', async () => {
+      const exporterEnv = {
+        OTEL_TRACES_EXPORTER: 'console',
+        OTEL_LOGS_EXPORTER: 'none',
+        OTEL_METRICS_EXPORTER: 'otlp',
+      } as const;
+      const previousValues = Object.fromEntries(
+        Object.keys(exporterEnv).map((name) => [name, process.env[name]]),
+      );
+      Object.assign(process.env, exporterEnv);
+      expect(isTelemetrySdkInitialized()).toBe(false);
+      let startCalled = false;
+
+      vi.mocked(NodeSDK.prototype.start).mockImplementationOnce(() => {
+        startCalled = true;
+        for (const name of Object.keys(exporterEnv)) {
+          expect(process.env[name]).toBeUndefined();
+        }
+      });
+
+      try {
+        await initializeTelemetry(mockConfig);
+        expect(startCalled).toBe(true);
+        for (const name of Object.keys(exporterEnv)) {
+          expect(process.env[name]).toBe(
+            exporterEnv[name as keyof typeof exporterEnv],
+          );
+        }
+      } finally {
+        for (const name of Object.keys(exporterEnv)) {
+          const previousValue = previousValues[name];
+          if (previousValue === undefined) {
+            delete process.env[name];
+          } else {
+            process.env[name] = previousValue;
+          }
+        }
+      }
+    });
+
     it('clears the in-flight promise so a failed init can be retried', async () => {
       vi.mocked(NodeSDK.prototype.start).mockImplementationOnce(() => {
         throw new Error('start failed');

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -55,6 +55,39 @@ let telemetryInitPromise: Promise<void> | undefined;
 let telemetryShutdownPromise: Promise<void> | undefined;
 let activeMetricReader: PeriodicExportingMetricReader | undefined;
 
+const OTEL_EXPORTER_ENV_VARS = [
+  'OTEL_TRACES_EXPORTER',
+  'OTEL_LOGS_EXPORTER',
+  'OTEL_METRICS_EXPORTER',
+] as const;
+
+function startSdkWithExplicitExporters(currentSdk: NodeSDK): void {
+  const previousValues = new Map<
+    (typeof OTEL_EXPORTER_ENV_VARS)[number],
+    string | undefined
+  >();
+  for (const name of OTEL_EXPORTER_ENV_VARS) {
+    previousValues.set(name, process.env[name]);
+    delete process.env[name];
+  }
+
+  try {
+    // qwen-code supplies explicit exporters for every enabled signal. Prevent
+    // sdk-node's OTEL_*_EXPORTER auto-configuration from constructing a second
+    // exporter (the bundled CLI intentionally omits those packages).
+    currentSdk.start();
+  } finally {
+    for (const name of OTEL_EXPORTER_ENV_VARS) {
+      const previousValue = previousValues.get(name);
+      if (previousValue === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = previousValue;
+      }
+    }
+  }
+}
+
 export function isTelemetrySdkInitialized(): boolean {
   return telemetryInitialized;
 }
@@ -82,7 +115,7 @@ export function initializeTelemetry(
       const started = await startTelemetrySdk(config);
       if (!started) return;
       sdk = started.sdk;
-      sdk.start();
+      startSdkWithExplicitExporters(sdk);
       debugLogger.debug('OpenTelemetry SDK started successfully.');
       telemetryInitialized = true;
       activeMetricReader = started.metricReader;


### PR DESCRIPTION
## What this PR does

This PR prevents sdk-node from reading the standard `OTEL_TRACES_EXPORTER`, `OTEL_LOGS_EXPORTER`, and `OTEL_METRICS_EXPORTER` selector variables while Qwen Code starts its telemetry SDK. The variables are restored immediately after the synchronous SDK start call.

## Why it's needed

Qwen Code already supplies explicit exporters for each enabled signal. In the bundled CLI, sdk-node's environment auto-configuration can nevertheless construct an omitted OTLP exporter when `OTEL_METRICS_EXPORTER=otlp` is present. That constructor throws after partial SDK setup, so Qwen Code's own telemetry remains uninitialized and metrics are silently lost while unrelated instrumentation can continue exporting.

Fixes #8697

## Reviewer Test Plan

### How to verify

1. Build the CLI bundle with `npm run build -- --cli-only && npm run bundle`.
2. Set `OTEL_METRICS_EXPORTER=otlp` and an explicit Qwen Code gRPC OTLP endpoint.
3. Start telemetry through the bundled SDK facade.
4. Confirm initialization succeeds and the caller's `OTEL_*_EXPORTER` values are unchanged after startup.

Before this change, the bundled SDK fails with `qwen-code bundles @opentelemetry/sdk-node without @opentelemetry/exporter-metrics-otlp-proto ... Attempted to construct: OTLPMetricExporter`. After this change, the same invocation reports `initialized:true`.

### Evidence (Before & After)

N/A — this is a non-visual telemetry startup behavior. Exact command output and test results are included in the verification report below.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

- macOS arm64
- Node.js v22.23.1
- npm 10.9.8

## Risk & Scope

- Main risk or tradeoff: Qwen Code intentionally ignores external OTel exporter selector variables because its settings already select explicit exporters; this preserves the existing Qwen Code telemetry configuration rather than merging two exporter-selection surfaces.
- Not validated / out of scope: honoring external exporter selectors as an alternative way to configure Qwen Code; Windows/Linux runtime execution; a live collector connection.
- Breaking changes / migration notes: none. The three environment variables remain visible to the caller and are restored after synchronous SDK startup.

## Linked Issues

Fixes #8697

<details>
<summary>中文说明</summary>

## What this PR does

本 PR 防止 sdk-node 在 Qwen Code 启动 telemetry SDK 时读取标准的 `OTEL_TRACES_EXPORTER`、`OTEL_LOGS_EXPORTER` 和 `OTEL_METRICS_EXPORTER` 选择变量。变量会在同步 SDK 启动调用结束后立即恢复。

## Why it's needed

Qwen Code 已经为每个启用的信号显式提供 exporter，但在 bundle CLI 中，即使设置了 `OTEL_METRICS_EXPORTER=otlp`，sdk-node 的环境变量自动配置仍可能构造一个被 bundle 排除的 OTLP exporter。该构造器会在 SDK 部分初始化后抛错，导致 Qwen Code 自身的 telemetry 未初始化，metrics 静默丢失，而无关的 instrumentation 仍可能继续导出。

Fixes #8697

## Reviewer Test Plan

### How to verify

1. 使用 `npm run build -- --cli-only && npm run bundle` 构建 CLI bundle。
2. 设置 `OTEL_METRICS_EXPORTER=otlp` 和显式的 Qwen Code gRPC OTLP endpoint。
3. 通过 bundle SDK facade 启动 telemetry。
4. 确认初始化成功，并确认调用方的 `OTEL_*_EXPORTER` 值在启动后保持不变。

修复前，bundle SDK 报错：`qwen-code bundles @opentelemetry/sdk-node without @opentelemetry/exporter-metrics-otlp-proto ... Attempted to construct: OTLPMetricExporter`。修复后，同一调用输出 `initialized:true`。

### Evidence (Before & After)

不适用——这是非视觉 telemetry 启动行为。精确命令输出和测试结果会在下面的验证报告中列出。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | 不适用 |
|  🐧 Linux  | 不适用 |

### Environment (optional)

- macOS arm64
- Node.js v22.23.1
- npm 10.9.8

## Risk & Scope

- Main risk or tradeoff：Qwen Code 有自己的 settings 来选择显式 exporter，因此有意忽略外部 OTel exporter 选择变量；这保留了现有 Qwen Code telemetry 配置，而不是合并两套 exporter 选择入口。
- Not validated / out of scope：将外部 exporter 选择变量作为 Qwen Code 的替代配置入口；Windows/Linux 运行时验证；真实 collector 连接。
- Breaking changes / migration notes：无。三个环境变量对调用方仍可见，并会在同步 SDK 启动后恢复。

## Linked Issues

Fixes #8697

</details>
