### PR TITLE
fix(cli): expand static VP items on Ctrl+S

### DIFF
--- a/packages/cli/src/ui/components/MainContent.test.tsx
+++ b/packages/cli/src/ui/components/MainContent.test.tsx
@@ -1120,6 +1120,65 @@ describe('<MainContent />', () => {
       expect(secondRenderItem).toBe(firstRenderItem);
     });
 
+    it('releases static item height caps when show-more mode is enabled', () => {
+      scrollableListPropsSpy.mockClear();
+      historyItemDisplayPropsSpy.mockClear();
+
+      const stableHistory: UIState['history'] = [
+        { id: 1, type: 'gemini_content', text: 'long output' },
+      ];
+      const stablePending: UIState['pendingHistoryItems'] = [];
+      const stableSlashCommands: UIState['slashCommands'] = [];
+      const { rerender } = renderMainContent(
+        createUIState({
+          useTerminalBuffer: true,
+          constrainHeight: true,
+          history: stableHistory,
+          pendingHistoryItems: stablePending,
+          slashCommands: stableSlashCommands,
+        }),
+      );
+
+      const firstRenderItem =
+        scrollableListPropsSpy.mock.calls.at(-1)?.[0].renderItem;
+      expect(historyItemDisplayPropsSpy.mock.calls.at(-1)?.[0]).toEqual(
+        expect.objectContaining({
+          availableTerminalHeight: 100,
+          availableTerminalHeightGemini: 65536,
+        }),
+      );
+
+      rerender(
+        <AppContext.Provider value={{ version: '1.2.3', startupWarnings: [] }}>
+          <UIActionsContext.Provider value={createUIActions()}>
+            <UIStateContext.Provider
+              value={createUIState({
+                useTerminalBuffer: true,
+                constrainHeight: false,
+                history: stableHistory,
+                pendingHistoryItems: stablePending,
+                slashCommands: stableSlashCommands,
+              })}
+            >
+              <OverflowProvider>
+                <MainContent />
+              </OverflowProvider>
+            </UIStateContext.Provider>
+          </UIActionsContext.Provider>
+        </AppContext.Provider>,
+      );
+
+      const secondRenderItem =
+        scrollableListPropsSpy.mock.calls.at(-1)?.[0].renderItem;
+      expect(secondRenderItem).not.toBe(firstRenderItem);
+      expect(historyItemDisplayPropsSpy.mock.calls.at(-1)?.[0]).toEqual(
+        expect.objectContaining({
+          availableTerminalHeight: undefined,
+          availableTerminalHeightGemini: undefined,
+        }),
+      );
+    });
+
     it('re-renders pending items when virtual viewport height constraints change', () => {
       scrollableListPropsSpy.mockClear();
       historyItemDisplayPropsSpy.mockClear();

--- a/packages/cli/src/ui/components/MainContent.tsx
+++ b/packages/cli/src/ui/components/MainContent.tsx
@@ -406,8 +406,12 @@ export const MainContent = () => {
         <VirtualHistoryItem
           terminalWidth={terminalWidth}
           mainAreaWidth={mainAreaWidth}
-          availableTerminalHeight={staticAreaMaxItemHeight}
-          availableTerminalHeightGemini={MAX_GEMINI_MESSAGE_LINES}
+          availableTerminalHeight={
+            uiState.constrainHeight ? staticAreaMaxItemHeight : undefined
+          }
+          availableTerminalHeightGemini={
+            uiState.constrainHeight ? MAX_GEMINI_MESSAGE_LINES : undefined
+          }
           item={item}
           isPending={false}
           commands={uiState.slashCommands}
@@ -426,6 +430,7 @@ export const MainContent = () => {
       sourceCopyOffsetsByHistoryItem,
       fullDetail,
       pendingAvailableTerminalHeight,
+      uiState.constrainHeight,
     ],
   );
 


### PR DESCRIPTION
## What this PR does

When VP mode is showing committed history items, Ctrl+S now removes both height limits from static items and invalidates the item renderer so the virtualized list measures and displays their full content.

## Why it's needed

Ctrl+S hid the “Press ctrl-s to show more lines” hint, but committed VP items stayed memoized with their previous height cap, leaving long tables and other output truncated. This makes the show-more action expand the content as expected.

## Reviewer Test Plan

### How to verify

Run `npm -w packages/cli run test -- src/ui/components/MainContent.test.tsx`. The regression test renders a static VP item with height constraints, toggles `constrainHeight` off, and verifies the renderer is recreated and both height props become `undefined`.

Expected behavior: after Ctrl+S/show-more mode, committed VP output is no longer capped by the static item height limits.

### Evidence (Before & After)

N/A — the behavior is covered by the deterministic Ink component regression test; no screenshot or recording is applicable in the headless test environment.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

macOS, Node.js v22.23.2, npm workspace test runner.

## Risk & Scope

- Main risk or tradeoff: static VP items intentionally render without height caps only after show-more mode is enabled.
- Not validated / out of scope: Windows/Linux runtime behavior and interactive terminal recording.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #8634

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在 VP 模式显示已提交历史项时，Ctrl+S 现在会同时移除静态项的高度限制，并使项渲染器失效重建，从而让虚拟化列表重新测量并显示完整内容。

## 为什么需要这个改动

Ctrl+S 会隐藏“按 Ctrl-S 显示更多行”的提示，但已提交的 VP 项仍被 memo 复用并保留之前的高度限制，导致长表格和其他输出继续被截断。此改动使“显示更多”操作按预期展开内容。

## Reviewer Test Plan

### 如何验证

运行 `npm -w packages/cli run test -- src/ui/components/MainContent.test.tsx`。回归测试先以受限高度渲染静态 VP 项，再关闭 `constrainHeight`，验证渲染器被重新创建且两个高度属性都变为 `undefined`。

预期行为：进入 Ctrl+S/显示更多模式后，已提交的 VP 输出不再受静态项高度限制。

### 证据（前后对比）

不适用——该行为由确定性的 Ink 组件回归测试覆盖；当前无头测试环境无法提供截图或录屏。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | 不适用 |
|  🐧 Linux  | 不适用 |

### 环境（可选）

macOS、Node.js v22.23.2、npm workspace 测试运行器。

## 风险与范围

- 主要风险或权衡：只有进入显示更多模式后，静态 VP 项才会取消高度限制。
- 未验证/不在范围内：Windows/Linux 运行时行为以及交互式终端录屏。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Fixes #8634

</details>
