### PR TITLE
fix(core): use Singapore Token Plan DeepSeek model id

### DIFF
--- a/packages/core/src/providers/__tests__/presets/alibaba-token-plan.test.ts
+++ b/packages/core/src/providers/__tests__/presets/alibaba-token-plan.test.ts
@@ -41,7 +41,7 @@ describe('token plan provider', () => {
       'qwen3.8-max-preview',
       'qwen3.6-flash',
       'deepseek-v4-pro',
-      'deepseek-v4-flash',
+      'deepseek-v4-flash-0731',
       'deepseek-v3.2',
       'kimi-k2.7-code',
       'kimi-k2.6',

--- a/packages/core/src/providers/presets/alibaba-token-plan.ts
+++ b/packages/core/src/providers/presets/alibaba-token-plan.ts
@@ -45,7 +45,7 @@ const TOKEN_PLAN_MODELS: ModelSpec[] = [
     enableThinking: true,
   },
   { id: 'deepseek-v4-pro', contextWindowSize: 1000000 },
-  { id: 'deepseek-v4-flash', contextWindowSize: 1000000 },
+  { id: 'deepseek-v4-flash-0731', contextWindowSize: 1000000 },
   { id: 'deepseek-v3.2', contextWindowSize: 131072 },
   {
     id: 'kimi-k2.7-code',


### PR DESCRIPTION
## What this PR does

Updates the Alibaba ModelStudio Token Plan preset to use the available Singapore-region DeepSeek Flash model ID, `deepseek-v4-flash-0731`.

## Why it's needed

The preset currently offers `deepseek-v4-flash`, but the Singapore Token Plan endpoint grants access to `deepseek-v4-flash-0731`. Selecting the preset model therefore produces a user-facing HTTP 403 instead of a working model.

## Reviewer Test Plan

### How to verify

Run `cd packages/core && npx vitest run src/providers/__tests__/presets/alibaba-token-plan.test.ts src/providers/__tests__/provider-config.test.ts`. Confirm the generated Token Plan model list contains `deepseek-v4-flash-0731` and that the provider configuration tests remain green.

The pre-fix source-level baseline generated `deepseek-v4-flash`; the updated preset generates `deepseek-v4-flash-0731` for the Token Plan model list.

### Evidence (Before & After)

N/A — this is a provider metadata correction; deterministic preset output and provider configuration tests are the relevant evidence.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

macOS, Node.js v22.23.2, npm workspace tests.

## Risk & Scope

- Main risk or tradeoff: existing users who selected the old unavailable preset ID will receive the corrected model ID when the provider template is regenerated.
- Not validated / out of scope: live Singapore Token Plan API access; no credential was available, so the endpoint was not called.
- Breaking changes / migration notes: none; manually configured custom model IDs are unaffected.

## Linked Issues

Fixes #8650

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

将 Alibaba ModelStudio Token Plan preset 更新为使用新加坡区域可用的 DeepSeek Flash 模型 ID：`deepseek-v4-flash-0731`。

## 为什么需要这个改动

当前 preset 提供的是 `deepseek-v4-flash`，但新加坡 Token Plan endpoint 实际授权的是 `deepseek-v4-flash-0731`。因此用户选择该 preset 模型时会收到 HTTP 403，而不是获得可用模型。

## Reviewer Test Plan

### 如何验证

运行 `cd packages/core && npx vitest run src/providers/__tests__/presets/alibaba-token-plan.test.ts src/providers/__tests__/provider-config.test.ts`。确认生成的 Token Plan 模型列表包含 `deepseek-v4-flash-0731`，且 provider 配置测试保持通过。

修复前的源码基线生成的是 `deepseek-v4-flash`；更新后的 preset 为 Token Plan 模型列表生成 `deepseek-v4-flash-0731`。

### 证据（前后对比）

不适用——这是 provider 元数据修正；确定性的 preset 输出和 provider 配置测试是相关证据。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | 不适用 |
|  🐧 Linux  | 不适用 |

### 环境（可选）

macOS、Node.js v22.23.2、npm workspace 测试。

## 风险与范围

- 主要风险或权衡：之前选择了不可用 preset ID 的现有用户，在 provider template 重新生成时会获得修正后的模型 ID。
- 未验证/不在范围内：新加坡 Token Plan API 的实时访问；由于没有凭据，未调用该 endpoint。
- 破坏性变更/迁移说明：无；手动配置的自定义模型 ID 不受影响。

## 关联 Issue

Fixes #8650

</details>
