### PR TITLE
fix(cli): respect trusted env boundaries

### DIFF
--- a/packages/cli/src/config/environment.test.ts
+++ b/packages/cli/src/config/environment.test.ts
@@ -10,6 +10,7 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { buildRuntimeEnvironment, loadEnvironment } from './environment.js';
 import type { Settings } from './settingsSchema.js';
+import { TrustLevel } from './trustedFolders.js';
 
 const TRACKED_ENV = [
   'CLOUD_SHELL',
@@ -26,6 +27,7 @@ const TRACKED_ENV = [
   'NODE_DISABLE_COMPILE_CACHE',
   'QWEN_HOME',
   'QWEN_CODE_PENDING_COMPILE_CACHE',
+  'QWEN_CODE_TRUSTED_FOLDERS_PATH',
   'QWEN_RUNTIME_DIR',
   'QWEN_SERVER_TOKEN',
 ] as const;
@@ -168,6 +170,34 @@ describe('buildRuntimeEnvironment', () => {
       }),
     ]);
     expect(snapshot.effectiveEnv['RUNTIME_DOTENV']).toBeUndefined();
+  });
+
+  it('does not load a distrusted parent .env for a trusted child workspace', () => {
+    const parent = makeWorkspace();
+    const child = path.join(parent, 'child');
+    fs.mkdirSync(child);
+    fs.writeFileSync(
+      path.join(parent, '.env'),
+      'QWEN_SERVER_TOKEN=from-distrusted-parent-env\n',
+    );
+    const trustedFoldersPath = path.join(parent, 'trustedFolders.json');
+    fs.writeFileSync(
+      trustedFoldersPath,
+      JSON.stringify({
+        [parent]: TrustLevel.DO_NOT_TRUST,
+        [child]: TrustLevel.TRUST_FOLDER,
+      }),
+    );
+    process.env['QWEN_CODE_TRUSTED_FOLDERS_PATH'] = trustedFoldersPath;
+
+    const snapshot = buildRuntimeEnvironment(
+      testSettings({ security: { folderTrust: { enabled: true } } }),
+      child,
+      {},
+    );
+
+    expect(snapshot.envFilePaths).not.toContain(path.join(parent, '.env'));
+    expect(snapshot.effectiveEnv['QWEN_SERVER_TOKEN']).toBeUndefined();
   });
 });
 

--- a/packages/cli/src/config/environment.ts
+++ b/packages/cli/src/config/environment.ts
@@ -212,18 +212,26 @@ export function findEnvFiles(
   } catch {
     // Match loadSettings(): use the resolved path when realpath is unavailable.
   }
-  const isTrusted =
-    workspaceTrusted ??
-    isWorkspaceTrusted(settings, undefined, realStartDir).isTrusted;
-
   const globalQwenDir = Storage.getGlobalQwenDir();
   const legacyQwenDir = path.normalize(path.join(homeDir, QWEN_DIR));
   const hasCustomConfigDir = path.normalize(globalQwenDir) !== legacyQwenDir;
   const found: string[] = [];
   const seen = new Set<string>();
 
-  const canUseEnvFile = (filePath: string): boolean =>
-    isTrusted !== false || userLevelPaths.has(path.normalize(filePath));
+  const canUseEnvFile = (filePath: string): boolean => {
+    const normalized = path.normalize(filePath);
+    if (userLevelPaths.has(normalized)) return true;
+    const dirPath = path.dirname(normalized);
+    const workspaceDir =
+      path.basename(dirPath) === SETTINGS_DIRECTORY_NAME
+        ? path.dirname(dirPath)
+        : dirPath;
+    const trusted =
+      workspaceTrusted !== undefined && workspaceDir === realStartDir
+        ? workspaceTrusted
+        : isWorkspaceTrusted(settings, undefined, workspaceDir).isTrusted;
+    return trusted !== false;
+  };
 
   // Home-dir candidates in priority order: globalQwenDir/.env, then legacy
   // ~/.qwen/.env (only when QWEN_HOME redirects), then ~/.env.

--- a/packages/cli/src/serve/fast-path-settings.ts
+++ b/packages/cli/src/serve/fast-path-settings.ts
@@ -149,8 +149,6 @@ function findEnvFilesFastPath(
   } catch {
     // Match loadSettings(): use the resolved path when realpath is unavailable.
   }
-  const isTrusted = isWorkspaceTrustedFastPath(settings, realStartDir);
-
   const globalQwenDir = getGlobalQwenDirLite();
   const legacyQwenDir = path.normalize(
     path.join(homeDir, SETTINGS_DIRECTORY_NAME),
@@ -159,8 +157,16 @@ function findEnvFilesFastPath(
   const found: string[] = [];
   const seen = new Set<string>();
 
-  const canUseEnvFile = (filePath: string): boolean =>
-    isTrusted !== false || userLevelPaths.has(path.normalize(filePath));
+  const canUseEnvFile = (filePath: string): boolean => {
+    const normalized = path.normalize(filePath);
+    if (userLevelPaths.has(normalized)) return true;
+    const dirPath = path.dirname(normalized);
+    const workspaceDir =
+      path.basename(dirPath) === SETTINGS_DIRECTORY_NAME
+        ? path.dirname(dirPath)
+        : dirPath;
+    return isWorkspaceTrustedFastPath(settings, workspaceDir) !== false;
+  };
 
   const pushCandidate = (filePath: string): boolean => {
     const normalized = path.normalize(filePath);

--- a/packages/cli/src/serve/fast-path.test.ts
+++ b/packages/cli/src/serve/fast-path.test.ts
@@ -1804,6 +1804,39 @@ describe('serve fast path environment bootstrap', () => {
     expect(process.env['QWEN_SERVER_TOKEN']).toBe('from-trusted-child-env');
   });
 
+  it('does not load a distrusted parent .env for a trusted child workspace', async () => {
+    delete process.env['QWEN_SERVER_TOKEN'];
+    const qwenHome = useTempQwenHome();
+    tempWorkspace = realpathSync(
+      mkdtempSync(join(os.tmpdir(), 'qws-fast-path-trusted-child-')),
+    );
+    const childWorkspace = join(tempWorkspace, 'child');
+    mkdirSync(childWorkspace);
+    writeFileSync(
+      join(tempWorkspace, '.env'),
+      'QWEN_SERVER_TOKEN=from-distrusted-parent-env\n',
+    );
+    writeFileSync(
+      join(qwenHome, 'settings.json'),
+      JSON.stringify({ security: { folderTrust: { enabled: true } } }),
+    );
+    process.env['QWEN_CODE_TRUSTED_FOLDERS_PATH'] = join(
+      qwenHome,
+      'trustedFolders.json',
+    );
+    writeFileSync(
+      process.env['QWEN_CODE_TRUSTED_FOLDERS_PATH'],
+      JSON.stringify({
+        [tempWorkspace]: TrustLevel.DO_NOT_TRUST,
+        [childWorkspace]: TrustLevel.TRUST_FOLDER,
+      }),
+    );
+
+    await bootstrapServeFastPathEnvironment(childWorkspace);
+
+    expect(process.env['QWEN_SERVER_TOKEN']).toBeUndefined();
+  });
+
   it('treats TRUST_PARENT as trusting the containing folder', async () => {
     delete process.env['QWEN_SERVER_TOKEN'];
     const qwenHome = useTempQwenHome();


### PR DESCRIPTION
## What this PR does

Fixes #8643 by evaluating workspace trust separately for every discovered project `.env` file in both the full environment loader and the serve fast path. User-level files (`~/.env`, `~/.qwen/.env`, and `<QWEN_HOME>/.env`) remain allowed unconditionally.

## Why it's needed

The loaders previously evaluated trust once for the launch directory and reused that result while walking ancestors. A trusted child workspace could therefore load secrets from a `DO_NOT_TRUST` parent `.env`.

## Reviewer Test Plan

### How to verify

Create a parent directory containing `QWEN_SERVER_TOKEN=from-distrusted-parent-env` in `.env`; create a child workspace; enable folder trust; mark the parent `DO_NOT_TRUST` and child `TRUST_FOLDER`. Run the focused tests below. Before this fix, the new regression reproduced the parent secret being loaded; after this fix, both loaders omit the parent file.

### Evidence (Before & After)

Non-visual CLI security behavior. Before the patch, the fast-path regression observed `from-distrusted-parent-env`; after the patch, the fast-path and full-loader tests assert `undefined`. No screenshot is applicable.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |    ✅ tested |
| 🪟 Windows |    ⚠️ not tested |
|  🐧 Linux  |    ⚠️ not tested |

### Environment (optional)

macOS, Node.js 22, local Vitest fixtures.

## Risk & Scope

- Main risk or tradeoff: trust is now evaluated per candidate directory, so an ancestor `.env` is accepted only when that ancestor is trusted; this intentionally closes the credential boundary.
- Explicit `workspaceTrusted` overrides still apply to the starting workspace only; ancestor candidates use the shared trust-precedence evaluation.
- Not validated / out of scope: Windows/Linux runtime execution and external provider credentials.
- Breaking changes / migration notes: none; user-level `.env` loading semantics are unchanged.

## Linked Issues

Fixes #8643

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修复 #8643：完整环境加载器和 serve fast path 现在会对每个发现的项目 `.env` 文件分别检查工作区信任状态；用户级文件（`~/.env`、`~/.qwen/.env` 和 `<QWEN_HOME>/.env`）仍按原规则无条件允许。

## 为什么需要它

此前加载器只对启动目录检查一次信任状态，并在向上遍历父目录时复用该结果，因此可信子目录可能读取 `DO_NOT_TRUST` 父目录 `.env` 中的秘密。

## 评审测试计划

### 如何验证

创建一个父目录，在其 `.env` 中写入 `QWEN_SERVER_TOKEN=from-distrusted-parent-env`；创建子工作区；启用目录信任；将父目录标记为 `DO_NOT_TRUST`、子目录标记为 `TRUST_FOLDER`。运行下方聚焦测试。修复前回归测试会复现父目录秘密被加载；修复后两条加载路径都会忽略父目录文件。

### 证据（修复前与修复后）

这是非视觉的 CLI 安全行为修复。修复前 fast path 回归测试观察到 `from-distrusted-parent-env`；修复后 fast path 和完整加载器测试均断言结果为 `undefined`。不适用截图。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
| 🍏 macOS | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
| 🐧 Linux | ⚠️ 未测试 |

### 环境

macOS、Node.js 22、本地 Vitest 测试 fixture。

## 风险与范围

- 主要风险或取舍：现在按候选文件所属目录检查信任状态；父目录 `.env` 只有在父目录可信时才会加载，这是有意关闭凭据边界漏洞。
- 显式 `workspaceTrusted` 覆盖只作用于起始工作区；父目录候选使用共享的信任优先级计算。
- 未验证/不在范围内：Windows/Linux 实机运行和外部 provider 凭据。
- 破坏性变更/迁移说明：无；用户级 `.env` 加载语义不变。

## 关联 Issue

Fixes #8643

</details>