### PR TITLE
docs: add Aliyun Model Studio CLI (bailian-cli) to Ecosystem section

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ https://raw.githubusercontent.com/QwenLM/qwen-code/refs/heads/main/.qwen/skills/
 Then follow the instructions inside to install, authenticate, and use Qwen Code via acpx for all coding tasks.
 ```
 
+- [**Aliyun Model Studio CLI**](https://github.com/modelstudioai/cli) — Official CLI for Aliyun's AI platform (`bailian-cli`). Extends Qwen Code with image/video generation, knowledge retrieval, app orchestration, and model deployment. Qwen Code acts as the "brain" for intent understanding and task orchestration; the CLI acts as the "hands" for executing AI capabilities. Install with `npm install -g bailian-cli && npx skills add modelstudioai/cli --all -g`.
+
 ## Contributing
 
 Contributions are welcome! See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines.

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ https://raw.githubusercontent.com/QwenLM/qwen-code/refs/heads/main/.qwen/skills/
 Then follow the instructions inside to install, authenticate, and use Qwen Code via acpx for all coding tasks.
 ```
 
-- [**Aliyun Model Studio CLI**](https://github.com/modelstudioai/cli) — Official CLI for Aliyun's AI platform (`bailian-cli`). Extends Qwen Code with image/video generation, knowledge retrieval, app orchestration, and model deployment. Qwen Code acts as the "brain" for intent understanding and task orchestration; the CLI acts as the "hands" for executing AI capabilities. Install with `npm install -g bailian-cli && npx skills add modelstudioai/cli --all -g`.
+- [**Aliyun Model Studio CLI**](https://github.com/modelstudioai/cli) — Official CLI for Aliyun's AI platform (`bailian-cli`). Extends Qwen Code with image/video generation, knowledge retrieval, app orchestration, and model deployment
 
 ## Contributing
 


### PR DESCRIPTION
## What this PR does

Adds [Aliyun Model Studio CLI](https://github.com/modelstudioai/cli) (`bailian-cli`) to the **Ecosystem** section of `README.md`, as a new bullet point after the Qwen Code Claw entry.

## Why it is needed

`bailian-cli` is the official CLI for the Aliyun AI platform (DashScope / 百炼). It extends Qwen Code with capabilities that Qwen Code alone does not provide: image/video generation (HappyHorse, WAN models), knowledge retrieval (Bailian knowledge bases), app orchestration (deploy and call hosted Agents), and model deployment (fine-tune and deploy custom models). Qwen Code acts as the brain (intent understanding + task orchestration); `bailian-cli` acts as the hands (executing AI capabilities). Listing it in the Ecosystem section helps users discover this companion tool.

## Reviewer Test Plan

### How to verify

Open the PR diff and confirm the new bullet appears in the `## Ecosystem` section, after the Qwen Code Claw code block and before `## Contributing`. Verify the link points to https://github.com/modelstudioai/cli and the description matches the linked repo.

### Evidence (Before & After)

N/A (documentation change)

### Tested on

| OS | Status |
|:--:|:--:|
| 🍏 macOS | N/A |
| 🪟 Windows | N/A |
| 🐧 Linux | N/A |

## Risk & Scope

- Main risk or tradeoff: Minimal — adds one bullet point to README, no code changes.
- Not validated / out of scope: The install command is intentionally omitted to match the style of other Ecosystem entries; users can find it in the linked repo.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在 `README.md` 的 **Ecosystem** 章节新增 [Aliyun Model Studio CLI](https://github.com/modelstudioai/cli)（`bailian-cli`）条目，位于 Qwen Code Claw 条目之后。

## 为什么需要

`bailian-cli` 是阿里云 AI 平台（DashScope / 百炼）的官方 CLI。它扩展了 Qwen Code 单独不具备的能力：图片/视频生成（HappyHorse、WAN 模型）、知识检索（百炼知识库）、应用编排（部署和调用托管 Agent）、模型部署（微调和部署自定义模型）。Qwen Code 是"大脑"（意图理解+任务编排），`bailian-cli` 是"手脚"（执行 AI 能力调用）。在 Ecosystem 章节列出它有助于用户发现这个配套工具。

## 审查者测试计划

### 如何验证

打开 PR diff，确认新 bullet 出现在 `## Ecosystem` 章节中 Qwen Code Claw 代码块之后、`## Contributing` 之前。验证链接指向 https://github.com/modelstudioai/cli 且描述与链接仓库一致。

### 证据（前后对比）

N/A（文档变更）

### 测试环境

| OS | Status |
|:--:|:--:|
| 🍏 macOS | N/A |
| 🪟 Windows | N/A |
| 🐧 Linux | N/A |

## 风险与范围

- 主要风险或权衡：极小 — 仅在 README 中新增一条 bullet，无代码变更。
- 未验证/超出范围：安装命令有意省略以匹配其他 Ecosystem 条目的风格，用户可在链接仓库中找到。
- 破坏性变更/迁移说明：无。

## 关联 Issue

N/A

</details>