### PR TITLE
docs: clarify reusable SDK queries after interruption

### DIFF
--- a/docs/developers/sdk-typescript.md
+++ b/docs/developers/sdk-typescript.md
@@ -157,6 +157,11 @@ const detail = await q.getContextUsage(true);
 await q.close();
 ```
 
+`interrupt()` cancels only the active turn. For a multi-turn query created with
+an async iterable prompt, the query and its input stream remain open, so later
+messages from the iterable are processed normally. Use `close()` or abort the
+configured `AbortController` when you want to end the entire session.
+
 ## Permission Modes
 
 The SDK supports different permission modes for controlling tool execution:


### PR DESCRIPTION
## What this PR does

This PR clarifies the lifecycle semantics of interruptions in reusable TypeScript SDK queries. It explains that interrupting an active turn leaves a multi-turn query and its input stream open for later prompts, while session close or controller cancellation ends the entire session.

## Why it's needed

The SDK guide previously said only that an interruption cancels the current operation. That wording left integrators unsure whether a reusable query could safely process another prompt afterward, even though the current implementation and integration coverage guarantee that behavior.

## Reviewer Test Plan

### How to verify

Create a multi-turn query backed by an asynchronous prompt source, interrupt a delayed first turn, then provide a second prompt. Confirm that the second prompt completes in the same query and that the guide clearly distinguishes turn interruption from ending the full session.

Local verification passed the complete build, bundle, type check, formatting and diff checks, plus the targeted SDK integration scenario with one test passed and sixteen unrelated tests skipped.

### Evidence (Before & After)

N/A — documentation-only change.

### Tested on

|     OS     | Status         |
| :--------: | :------------: |
|  🍏 macOS  | ✅ tested      |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 27.0 on arm64 with Node.js 24.18.0, npm 11.16.0, and sandboxing disabled for the targeted integration scenario.

## Risk & Scope

- Main risk or tradeoff: The explanation must stay aligned with the lifecycle contract if interruption behavior changes later.
- Not validated / out of scope: Windows and Linux were not tested locally; this PR does not change runtime behavior or other SDKs.
- Breaking changes / migration notes: None.

## Linked Issues

N/A.

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本 PR 阐明 TypeScript SDK 可复用查询中的中断生命周期语义：中断当前轮次后，多轮查询及其输入流仍保持打开并可处理后续提示，而关闭会话或通过控制器取消会结束整个会话。

## 为什么需要此改动

此前 SDK 指南只说明中断会取消当前操作，导致集成方无法确认可复用查询之后是否还能安全处理新的提示，尽管当前实现和集成测试已经保证了这一行为。

## 审阅者测试计划

### 如何验证

使用异步提示源创建多轮查询，中断一个被延迟的首轮请求，然后提供第二个提示。确认第二个提示可在同一查询中完成，并确认指南清楚区分了轮次中断与结束整个会话。

本地验证已通过完整构建、bundle、类型检查、格式与 diff 检查，以及针对性的 SDK 集成场景；其中一项测试通过，十六项无关测试被跳过。

### 证据（改动前后）

不适用——仅文档改动。

### 测试平台

|     操作系统     | 状态       |
| :--------------: | :--------: |
|    🍏 macOS      | ✅ 已测试   |
|   🪟 Windows     | ⚠️ 未测试   |
|    🐧 Linux      | ⚠️ 未测试   |

### 环境（可选）

macOS 27.0、arm64、Node.js 24.18.0、npm 11.16.0；针对性集成场景禁用沙箱。

## 风险与范围

- 主要风险或权衡：如果后续中断行为发生变化，此说明也必须同步更新以保持生命周期契约一致。
- 未验证或范围外内容：未在 Windows 和 Linux 上进行本地测试；本 PR 不改变运行时行为，也不涉及其他 SDK。
- 破坏性变更或迁移说明：无。

## 关联问题

不适用。

</details>
