### PR TITLE
fix(cli): require exact attribution marker values

### DIFF
--- a/packages/cli/src/config/acp-channel-fallback.test.ts
+++ b/packages/cli/src/config/acp-channel-fallback.test.ts
@@ -35,11 +35,11 @@ describe('resolveAcpChannelFallback', () => {
     ).toBe('desktop');
   });
 
-  it('ignores empty marker values', () => {
+  it.each(['', '0', 'false'])('ignores marker value %j', (value) => {
     expect(
       resolveAcpChannelFallback({
-        [QWEN_CODE_SERVE_ENV]: '',
-        [QWEN_CODE_DESKTOP_ENV]: '',
+        [QWEN_CODE_SERVE_ENV]: value,
+        [QWEN_CODE_DESKTOP_ENV]: value,
       }),
     ).toBe('ACP');
   });

--- a/packages/cli/src/config/acp-channel-fallback.ts
+++ b/packages/cli/src/config/acp-channel-fallback.ts
@@ -29,10 +29,10 @@ export function resolveAcpChannelFallback(
 ): string {
   // The desktop marker wins: Tauri sessions are daemon-spawned too, but the
   // launcher identity is the finer-grained signal.
-  if (env[QWEN_CODE_DESKTOP_ENV]) {
+  if (env[QWEN_CODE_DESKTOP_ENV] === '1') {
     return 'desktop';
   }
-  if (env[QWEN_CODE_SERVE_ENV]) {
+  if (env[QWEN_CODE_SERVE_ENV] === '1') {
     return 'daemon';
   }
   return 'ACP';


### PR DESCRIPTION
## What this PR does

This PR treats the daemon and desktop attribution markers as enabled only when their value is exactly `1`. Values such as `0` and `false` now fall back to `ACP` instead of reporting `daemon` or `desktop`.

## Why it's needed

#8670 introduced `QWEN_CODE_SERVE=1` and `QWEN_CODE_DESKTOP=1` as internal launcher markers, but the fallback checked them by JavaScript truthiness. A non-empty disabled value such as `QWEN_CODE_DESKTOP=0` therefore reported the session as `desktop`. The trusted launchers already write the exact value `1`, so matching that contract fixes the misattribution without changing any supported launch path.

## Reviewer Test Plan

### How to verify

- Run `cd packages/cli && npx vitest run src/config/acp-channel-fallback.test.ts src/config/config.test.ts`; expect 332 tests to pass.
- Confirm `QWEN_CODE_SERVE=1` still resolves to `daemon`, `QWEN_CODE_DESKTOP=1` still resolves to `desktop`, and explicit `--channel` behavior is unchanged.
- Confirm empty, `0`, and `false` marker values resolve to `ACP`.

### Evidence (Before & After)

Before: the new regression cases failed because `0` and `false` resolved to `desktop`. After: all six fallback cases and the full neighboring config suite pass.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests on macOS arm64. CLI typecheck, targeted ESLint and Prettier checks, and the CLI package build also pass.

## Risk & Scope

- Main risk or tradeoff: manually supplied non-`1` marker values no longer opt into attribution; repository launchers already use `1` exclusively.
- Not validated / out of scope: per-client identity inside daemon sessions; channel schema, spawn paths, sandbox propagation, and telemetry payload construction are unchanged.
- Breaking changes / migration notes: none for supported launchers.

## Linked Issues

Follow-up to #8670 and #8660.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 仅在 daemon 与 desktop 归因标记的值精确等于 `1` 时将其视为启用。`0`、`false` 等值现在会回退为 `ACP`，而不会误报为 `daemon` 或 `desktop`。

## 为什么需要

#8670 引入了 `QWEN_CODE_SERVE=1` 和 `QWEN_CODE_DESKTOP=1` 作为内部启动器标记，但回退逻辑使用 JavaScript truthy 判断。因此，`QWEN_CODE_DESKTOP=0` 这类非空禁用值仍会把会话上报为 `desktop`。可信启动器本来就只写入精确值 `1`，因此按该契约匹配可以修复误归因，同时不改变任何受支持的启动路径。

## 评审测试计划

### 如何验证

- 运行 `cd packages/cli && npx vitest run src/config/acp-channel-fallback.test.ts src/config/config.test.ts`，预期 332 个测试全部通过。
- 确认 `QWEN_CODE_SERVE=1` 仍解析为 `daemon`，`QWEN_CODE_DESKTOP=1` 仍解析为 `desktop`，显式 `--channel` 行为不变。
- 确认空值、`0` 和 `false` 均解析为 `ACP`。

### 前后对比证据

修改前：新增回归用例失败，因为 `0` 与 `false` 被解析为 `desktop`。修改后：六个 fallback 用例及完整的相邻 config 测试均通过。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

在 macOS arm64 上运行单元测试。CLI typecheck、针对改动文件的 ESLint 与 Prettier 检查，以及 CLI package build 也均通过。

## 风险与范围

- 主要风险或权衡：手动提供的非 `1` marker 不再启用归因；仓库内的启动器始终只使用 `1`。
- 未验证 / 不在范围：daemon 会话内的 per-client identity；channel schema、spawn 路径、sandbox 透传与 telemetry payload 构造均未改变。
- 破坏性变更 / 迁移说明：对受支持的启动器无影响。

## 关联 Issue

#8670 与 #8660 的 follow-up。

</details>
