### PR TITLE
fix(ci): keep the review workflow under the expression-length limit

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -748,6 +748,16 @@ jobs:
           # the next on the reused self-hosted workspace (reset in "Clean stale
           # agent state"). Must match the QWEN_HOME computed there.
           QWEN_HOME: '${{ runner.temp }}/qwen-home'
+          # KEEP THE `run` BODY BELOW FREE OF `${{ }}`. A run block containing
+          # one is evaluated as a single expression template, capped at 21000
+          # characters — and this script is far past that. Every value it needs
+          # from the workflow context is passed as an environment variable, so
+          # the body is plain bash the runner never templates. See the
+          # workflow-expression-length test in
+          # scripts/tests/qwen-pr-review-workflow.test.js.
+          EVENT_NAME: '${{ github.event_name }}'
+          EVENT_HEAD_SHA: '${{ github.event.pull_request.head.sha }}'
+          MAX_TIMEOUT_MINUTES_VAR: '${{ vars.QWEN_REVIEW_MAX_TIMEOUT_MINUTES }}'
         run: |-
           set -euo pipefail
           fail() {
@@ -960,7 +970,7 @@ jobs:
           if [ "$TIMEOUT_MINUTES" -le 5 ]; then
             fail "timeout_minutes must be greater than 5"
           fi
-          MAX_TIMEOUT_MINUTES="${{ vars.QWEN_REVIEW_MAX_TIMEOUT_MINUTES }}"
+          MAX_TIMEOUT_MINUTES="$MAX_TIMEOUT_MINUTES_VAR"
           if [ "$TIMEOUT_MINUTES" -gt "$MAX_TIMEOUT_MINUTES" ]; then
             fail "timeout_minutes must not exceed ${MAX_TIMEOUT_MINUTES} minutes"
           fi
@@ -989,7 +999,7 @@ jobs:
               if [ "$PR_SIZE_LINES" -le 300 ]; then
                 EFFECTIVE_TIMEOUT_MINUTES=180
               else
-                EFFECTIVE_TIMEOUT_MINUTES="${{ vars.QWEN_REVIEW_MAX_TIMEOUT_MINUTES }}"
+                EFFECTIVE_TIMEOUT_MINUTES="$MAX_TIMEOUT_MINUTES_VAR"
               fi
               echo "PR #${PR_NUMBER} changed ${PR_SIZE_LINES} lines; auto timeout ${EFFECTIVE_TIMEOUT_MINUTES} minutes."
             else
@@ -1056,8 +1066,7 @@ jobs:
             exit 0
           fi
           EXPECTED_HEAD_SHA="$CURRENT_HEAD_SHA"
-          if [ "${{ github.event_name }}" = "pull_request_target" ]; then
-            EVENT_HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          if [ "$EVENT_NAME" = "pull_request_target" ]; then
             if [ "$CURRENT_HEAD_SHA" != "$EVENT_HEAD_SHA" ]; then
               echo "Skipping stale review run: event head ${EVENT_HEAD_SHA} is no longer current (current head ${CURRENT_HEAD_SHA})." | tee -a "$GITHUB_STEP_SUMMARY"
               exit 0

--- a/scripts/tests/qwen-pr-review-workflow.test.js
+++ b/scripts/tests/qwen-pr-review-workflow.test.js
@@ -2161,3 +2161,49 @@ describe('upstream-timeout headroom (PR 8507 incident)', () => {
     );
   });
 });
+
+describe('workflow expression length', () => {
+  // A `run:` body containing `${{ }}` is evaluated as ONE expression template,
+  // and GitHub caps a single expression at 21000 characters. Blowing that cap
+  // does not fail a job — it makes the whole workflow file *invalid*, so no
+  // event triggers it at all and no run is even created for the ones that
+  // matter. That is how every automatic review and every `@qwen-code /review`
+  // in this repository silently stopped for ~12h on 2026-08-07: #8648 pushed
+  // the "Run review" body from 17705 to 22282 characters, and from that merge
+  // onward the only runs left were startup failures reading
+  // `Invalid workflow file: … (Line: 751, Col: 14): Exceeded max expression
+  // length 21000` (e.g. run 31239579253). CI stayed green the whole time — no
+  // test covered this, which is why it is covered here.
+  const LIMIT = 21000;
+  const dir = '.github/workflows';
+  const files = readdirSync(dir).filter((f) => /\.ya?ml$/.test(f));
+
+  it('keeps every templated run block under the limit', () => {
+    expect(files.length).toBeGreaterThan(0);
+    const over = [];
+    for (const file of files) {
+      const doc = parse(readFileSync(join(dir, file), 'utf8'));
+      for (const [jobId, job] of Object.entries(doc?.jobs ?? {})) {
+        for (const step of job?.steps ?? []) {
+          const body = step?.run;
+          if (typeof body !== 'string' || !body.includes('${{')) continue;
+          if (body.length > LIMIT) {
+            over.push(
+              `${file} › ${jobId} › ${step.name}: ${body.length} chars`,
+            );
+          }
+        }
+      }
+    }
+    expect(over).toEqual([]);
+  });
+
+  it('keeps the review script free of ${{ }} so its length cannot break it', () => {
+    // This one body is ~24000 characters — already past the limit — so it stays
+    // valid only while nothing templates it. Every context value it needs is
+    // passed through the step's `env:` instead. A single `${{ }}` added back
+    // here takes the entire workflow down, which the test above would also
+    // catch; this asserts the actual invariant a contributor has to preserve.
+    expect(runReviewStep()).not.toContain('${{');
+  });
+});

--- a/scripts/tests/qwen-resolve-workflow.test.js
+++ b/scripts/tests/qwen-resolve-workflow.test.js
@@ -356,8 +356,13 @@ describe('qwen resolve workflow', () => {
     expect(contextStep).toContain('timeout=*)');
     expect(contextStep).toContain('TIMEOUT_MINUTES="${token#timeout=}"');
     expect(runStep).toContain('if [ "${#TIMEOUT_MINUTES}" -gt 3 ]; then');
+    // The cap still comes from the repository variable, but reaches the script
+    // through the step's env: the run body must stay free of `${{ }}` or the
+    // whole workflow exceeds the 21000-character expression limit and becomes
+    // invalid. Both halves are asserted so neither can drift alone.
+    expect(runStep).toContain('MAX_TIMEOUT_MINUTES="$MAX_TIMEOUT_MINUTES_VAR"');
     expect(runStep).toContain(
-      'MAX_TIMEOUT_MINUTES="${{ vars.QWEN_REVIEW_MAX_TIMEOUT_MINUTES }}"',
+      "MAX_TIMEOUT_MINUTES_VAR: '${{ vars.QWEN_REVIEW_MAX_TIMEOUT_MINUTES }}'",
     );
     expect(runStep).toContain(
       'if [ "$TIMEOUT_MINUTES" -gt "$MAX_TIMEOUT_MINUTES" ]; then',
@@ -403,7 +408,10 @@ describe('qwen resolve workflow', () => {
     expect(sizeGuardArm).toContain('if [ "$PR_SIZE_LINES" -le 300 ]; then');
     expect(runStep).toContain('EFFECTIVE_TIMEOUT_MINUTES=180');
     expect(runStep).toContain(
-      'EFFECTIVE_TIMEOUT_MINUTES="${{ vars.QWEN_REVIEW_MAX_TIMEOUT_MINUTES }}"',
+      'EFFECTIVE_TIMEOUT_MINUTES="$MAX_TIMEOUT_MINUTES_VAR"',
+    );
+    expect(runStep).toContain(
+      "MAX_TIMEOUT_MINUTES_VAR: '${{ vars.QWEN_REVIEW_MAX_TIMEOUT_MINUTES }}'",
     );
     // Slice the small-PR arm so a swap of the two assignments between the
     // branches fails: unordered containment keeps both texts present.
@@ -416,7 +424,7 @@ describe('qwen resolve workflow', () => {
       runStep.indexOf('else', smallPrStart),
     );
     expect(smallPrArm).toContain('EFFECTIVE_TIMEOUT_MINUTES=180');
-    expect(smallPrArm).not.toContain('vars.QWEN_REVIEW_MAX_TIMEOUT_MINUTES');
+    expect(smallPrArm).not.toContain('MAX_TIMEOUT_MINUTES_VAR');
     expect(runStep).not.toContain('EFFECTIVE_TIMEOUT_MINUTES=210');
     expect(runStep).toContain(
       'echo "effective_timeout_minutes=$EFFECTIVE_TIMEOUT_MINUTES"',
@@ -532,15 +540,26 @@ describe('qwen resolve workflow', () => {
 
   it('skips stale automatic review runs before invoking qwen', () => {
     const runStep = step(reviewJob, 'Run review');
+    const staleHeadStart = runStep.indexOf(
+      'if [ "$EVENT_NAME" = "pull_request_target" ]; then',
+    );
+    // Without this, a reworded guard makes `indexOf` return -1 and the slice
+    // below silently degrades instead of failing.
+    expect(staleHeadStart).toBeGreaterThan(-1);
     const staleHeadCheck = runStep.slice(
-      runStep.indexOf(
-        'if [ "${{ github.event_name }}" = "pull_request_target" ]; then',
-      ),
+      staleHeadStart,
       runStep.indexOf('PROMPT="/review ${REVIEW_URL}"'),
     );
 
+    // Both context values arrive as step env so the run body carries no
+    // `${{ }}` — see the expression-length test in
+    // qwen-pr-review-workflow.test.js for why that is load-bearing.
+    expect(runStep).toContain("EVENT_NAME: '${{ github.event_name }}'");
+    expect(runStep).toContain(
+      "EVENT_HEAD_SHA: '${{ github.event.pull_request.head.sha }}'",
+    );
     expect(staleHeadCheck).toContain(
-      'EVENT_HEAD_SHA="${{ github.event.pull_request.head.sha }}"',
+      'if [ "$CURRENT_HEAD_SHA" != "$EVENT_HEAD_SHA" ]; then',
     );
     expect(runStep).toContain(
       'PR_DATA="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state,headRefOid --jq \'[.state, .headRefOid] | @tsv\')"',


### PR DESCRIPTION
## What this PR does

Passes the three workflow-context values the review script reads through the step's `env:`, so the `run:` body contains no `${{ }}`.

## Why it's needed

**The review workflow is invalid right now, and has been for ~12 hours.** Every run since #8648 merged is a startup failure:

```
Invalid workflow file: .github/workflows/qwen-code-pr-review.yml#L1
(Line: 751, Col: 14): Exceeded max expression length 21000
```

A `run:` body that contains `${{ }}` is evaluated as **one** expression template, and GitHub caps a single expression at 21000 characters. Line 751 is the `run: |-` of `review-pr` › `Run review`:

| commit | `Run review` body | |
| --- | ---: | --- |
| `efc7ec7a85` (before #8648) | 17,705 | ok |
| `f4802031d0` (**#8648**, 2026-08-07 17:00:32) | 22,282 | over by 1,282 |
| `ee2e5be666` (#8683) | 24,042 | over by 3,042 |

The first startup failure is stamped **17:00:50** — 18 seconds after #8648 merged.

An over-limit expression does not fail a job. It invalidates the whole file, so for the events that matter **no run is created at all**. Across the 400 runs since that merge:

| event | runs | conclusion |
| --- | ---: | --- |
| `pull_request_target` (automatic review) | **0** | never triggered |
| `issue_comment` (`@qwen-code /review`) | **0** | never triggered |
| `push` | 103 | all startup failure |
| `pull_request` | 59 | all startup failure |

Zero successes. Both the automatic review and the manual `@qwen-code /review` escape hatch were unreachable, and CI stayed green the entire time because nothing covered this.

## Reviewer Test Plan

### How to verify

```
npx vitest run --config ./scripts/tests/vitest.config.ts \
  scripts/tests/qwen-pr-review-workflow.test.js \
  scripts/tests/qwen-resolve-workflow.test.js
```

Expected: 129/129. Full scripts suite: 1053 passed, 50 files.

To see the live failure, check out `main` and run the same command — the new tests fail and name it:

```
- []
+ [ "qwen-code-pr-review.yml › review-pr › Run review: 24042 chars" ]
```

To see GitHub's own error, any recent run of this workflow will do, e.g. [31239579253](https://github.com/QwenLM/qwen-code/actions/runs/31239579253).

### Evidence (Before & After)

N/A for UI. Before is the error above and the run census; after is 129/129 with the `Run review` body at 23,930 characters and **0** `${{ }}` inside it, so the limit no longer applies to it at all.

Mutation-tested — 4 of 4 caught:

| mutation | tests failed |
| --- | ---: |
| put a `${{ }}` back in the run body | 3 |
| `env` stops reading `vars.QWEN_REVIEW_MAX_TIMEOUT_MINUTES` | 2 |
| drop the `EVENT_HEAD_SHA` env binding | 1 |
| hardcode the value the env used to carry | 1 |

The first is the one that matters: it is the exact regression this PR fixes, and it is now caught three ways.

The two new tests are complementary. One walks **every** workflow in `.github/workflows` and fails any templated `run` block over 21000 — a repo-wide net (nothing else is currently above half the limit, so this is a guard, not a backlog). The other keeps this specific body untemplated, because at ~24,000 characters it is past the limit on its own: one `${{ }}` added back takes the whole workflow down again.

Three assertions in `qwen-resolve-workflow.test.js` pinned the old literals and were updated to assert both halves — the body reading `$MAX_TIMEOUT_MINUTES_VAR` **and** the env binding it to the repository variable — so neither can drift alone. One of them sliced on an `indexOf` with no `-1` guard; that is fixed too.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

## Risk & Scope

- **Main risk or tradeoff:** none behavioural. Each of the three substitutions passes the same value under a new name; `set -u` is unaffected because a step `env:` entry is always defined (empty when the context value is empty, exactly as the inline expansion was). The `EVENT_HEAD_SHA` env is visible for the whole script rather than only inside the `pull_request_target` branch, but all three of its uses are inside that branch, unchanged.
- **Not validated / out of scope:** this PR does not shorten the script. `Run review` stays ~24,000 characters; it is simply no longer templated. Extracting it to a helper script remains worth doing separately.
- **Breaking changes / migration notes:** none.

## Linked Issues

Regression from #8648. Surfaced while investigating why #8708 never got an automatic review — it never could have, and neither could any other open PR.

<details>
<summary>中文说明</summary>

## What this PR does

把评审脚本用到的三个 workflow 上下文值改为通过 step 的 `env:` 传入，使 `run:` 正文中不再含有 `${{ }}`。

## Why it's needed

**这个评审 workflow 目前是无效状态，且已持续约 12 小时。** 自 #8648 合入以来，每一次 run 都是启动失败：

```
Invalid workflow file: .github/workflows/qwen-code-pr-review.yml#L1
(Line: 751, Col: 14): Exceeded max expression length 21000
```

含有 `${{ }}` 的 `run:` 正文会被当作**一个**表达式模板求值，而 GitHub 对单个表达式的上限是 21000 字符。第 751 行正是 `review-pr` › `Run review` 的 `run: |-`：

| commit | `Run review` 正文 | |
| --- | ---: | --- |
| `efc7ec7a85`（#8648 之前） | 17,705 | 正常 |
| `f4802031d0`（**#8648**，2026-08-07 17:00:32） | 22,282 | 超出 1,282 |
| `ee2e5be666`（#8683） | 24,042 | 超出 3,042 |

第一条启动失败的时间戳是 **17:00:50**——#8648 合入后 18 秒。

超限的表达式并不会让某个 job 失败，而是让整个文件失效，因此对关键事件而言**根本不会创建 run**。自那次合入以来的 400 条 run 中：

| 事件 | 数量 | 结论 |
| --- | ---: | --- |
| `pull_request_target`（自动评审） | **0** | 从未触发 |
| `issue_comment`（`@qwen-code /review`） | **0** | 从未触发 |
| `push` | 103 | 全部启动失败 |
| `pull_request` | 59 | 全部启动失败 |

零成功。自动评审和手动 `@qwen-code /review` 这条兜底路径同时不可达，而 CI 全程是绿的——因为此前没有任何测试覆盖这一点。

## Reviewer Test Plan

### How to verify

```
npx vitest run --config ./scripts/tests/vitest.config.ts \
  scripts/tests/qwen-pr-review-workflow.test.js \
  scripts/tests/qwen-resolve-workflow.test.js
```

预期 129/129。scripts 全量套件：50 个文件，1053 passed。

想看到线上的真实失败，切到 `main` 跑同样的命令——新测试会失败并直接点名：

```
- []
+ [ "qwen-code-pr-review.yml › review-pr › Run review: 24042 chars" ]
```

想看 GitHub 自己给出的报错，随便打开这个 workflow 最近的任意一条 run 即可，例如 [31239579253](https://github.com/QwenLM/qwen-code/actions/runs/31239579253)。

### Evidence (Before & After)

界面部分 N/A。Before 即上面的报错与 run 统计；After 是 129/129，`Run review` 正文 23,930 字符、其中 `${{ }}` 数量为 **0**，因此该上限对它完全不再适用。

变异测试 —— 4 个全部被捕获：

| 变异 | 失败测试数 |
| --- | ---: |
| 把 `${{ }}` 加回 run 正文 | 3 |
| `env` 不再读取 `vars.QWEN_REVIEW_MAX_TIMEOUT_MINUTES` | 2 |
| 删掉 `EVENT_HEAD_SHA` 的 env 绑定 | 1 |
| 把原本由 env 携带的值写死 | 1 |

第一个才是重点：它正是本 PR 修复的那个回归，现在有三重拦截。

两个新测试互补。一个遍历 `.github/workflows` 下**所有** workflow，任何被模板化且超过 21000 的 `run` 块都会失败——这是仓库级的兜底网（目前没有其他 run 块超过上限的一半，所以它是守卫而非待办清单）。另一个专门保证这段正文不被模板化，因为它本身约 24,000 字符已经超限：只要加回一个 `${{ }}`，整个 workflow 就会再次失效。

`qwen-resolve-workflow.test.js` 中有三处断言钉的是旧字面量，已更新为同时断言两半——正文读取 `$MAX_TIMEOUT_MINUTES_VAR` **以及** env 绑定到仓库变量——这样任何一半都无法单独漂移。其中一处用 `indexOf` 切片且没有 `-1` 保护，一并修好。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

## Risk & Scope

- **主要风险与取舍：** 行为上无风险。三处替换都是同一个值换个名字传递；`set -u` 不受影响，因为 step `env:` 条目总是有定义（上下文值为空时即空串，与原先的内联展开完全一致）。`EVENT_HEAD_SHA` 这个 env 在整个脚本可见，而不再局限于 `pull_request_target` 分支内，但它的三处使用都在该分支内，未作改动。
- **未验证 / 范围之外：** 本 PR 并不缩短脚本。`Run review` 仍是约 24,000 字符，只是不再被模板化。把它抽成独立的辅助脚本仍然值得单独去做。
- **破坏性变更 / 迁移说明：** 无。

## Linked Issues

#8648 引入的回归。是在排查 #8708 为何一直没有自动评审时发现的——它根本不可能有，其他任何 open PR 也一样。

</details>
