### PR TITLE
fix(ci): match /review commands followed by a newline

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -78,6 +78,15 @@ jobs:
     # KEEP IN SYNC with review-pr.if (explicit-trigger branches).
     # Authorization is delegated to the `authorize` job (write+ permission);
     # this `if` only matches the /review command shape.
+    #
+    # The command may be followed by a newline and a body, so the shape match
+    # accepts that — via fromJSON, because expression string literals are NOT
+    # escape-processed: '\n' there is a literal backslash + n, and the branch
+    # written that way never matched anything. fromJSON('"\n"') is JSON, which
+    # IS escape-processed, so it yields a real newline. Both line endings are
+    # listed: the API sends LF, the web UI sends CRLF, and startsWith with an
+    # LF pattern does not match a CRLF body. Measured on a live runner, not
+    # assumed — see the PR that introduced this.
     needs: ['authorize']
     if: |-
       !cancelled() &&
@@ -87,17 +96,20 @@ jobs:
         github.event.issue.state == 'open' &&
         (github.event.comment.body == '@qwen-code /review' ||
          startsWith(github.event.comment.body, '@qwen-code /review ') ||
-         startsWith(github.event.comment.body, format('@qwen-code /review{0}', '\n')))) ||
+         startsWith(github.event.comment.body, format('@qwen-code /review{0}', fromJSON('"\n"'))) ||
+         startsWith(github.event.comment.body, format('@qwen-code /review{0}', fromJSON('"\r"'))))) ||
       (github.event_name == 'pull_request_review_comment' &&
         github.event.pull_request.state == 'open' &&
         (github.event.comment.body == '@qwen-code /review' ||
          startsWith(github.event.comment.body, '@qwen-code /review ') ||
-         startsWith(github.event.comment.body, format('@qwen-code /review{0}', '\n')))) ||
+         startsWith(github.event.comment.body, format('@qwen-code /review{0}', fromJSON('"\n"'))) ||
+         startsWith(github.event.comment.body, format('@qwen-code /review{0}', fromJSON('"\r"'))))) ||
       (github.event_name == 'pull_request_review' &&
         github.event.pull_request.state == 'open' &&
         (github.event.review.body == '@qwen-code /review' ||
          startsWith(github.event.review.body, '@qwen-code /review ') ||
-         startsWith(github.event.review.body, format('@qwen-code /review{0}', '\n')))))
+         startsWith(github.event.review.body, format('@qwen-code /review{0}', fromJSON('"\n"'))) ||
+         startsWith(github.event.review.body, format('@qwen-code /review{0}', fromJSON('"\r"'))))))
     concurrency:
       group: 'qwen-pr-ack-${{ github.event.issue.number || github.event.pull_request.number }}'
       cancel-in-progress: false
@@ -315,7 +327,8 @@ jobs:
     # review_requested events check the requester and skip delay):
     # - opened/synchronize uses delay-automatic-review
     # - reopened/ready_for_review runs immediately
-    # KEEP IN SYNC with ack-review-request.if (explicit-trigger branches).
+    # KEEP IN SYNC with ack-review-request.if (explicit-trigger branches) —
+    # including the fromJSON newline/CR pair, explained there.
     if: |-
       !cancelled() &&
       ((github.event_name == 'workflow_dispatch' &&
@@ -335,19 +348,22 @@ jobs:
         github.event.issue.state == 'open' &&
         (github.event.comment.body == '@qwen-code /review' ||
          startsWith(github.event.comment.body, '@qwen-code /review ') ||
-         startsWith(github.event.comment.body, format('@qwen-code /review{0}', '\n'))) &&
+         startsWith(github.event.comment.body, format('@qwen-code /review{0}', fromJSON('"\n"'))) ||
+         startsWith(github.event.comment.body, format('@qwen-code /review{0}', fromJSON('"\r"')))) &&
         needs.authorize.outputs.should_review == 'true') ||
       (github.event_name == 'pull_request_review_comment' &&
         github.event.pull_request.state == 'open' &&
         (github.event.comment.body == '@qwen-code /review' ||
          startsWith(github.event.comment.body, '@qwen-code /review ') ||
-         startsWith(github.event.comment.body, format('@qwen-code /review{0}', '\n'))) &&
+         startsWith(github.event.comment.body, format('@qwen-code /review{0}', fromJSON('"\n"'))) ||
+         startsWith(github.event.comment.body, format('@qwen-code /review{0}', fromJSON('"\r"')))) &&
         needs.authorize.outputs.should_review == 'true') ||
       (github.event_name == 'pull_request_review' &&
         github.event.pull_request.state == 'open' &&
         (github.event.review.body == '@qwen-code /review' ||
          startsWith(github.event.review.body, '@qwen-code /review ') ||
-         startsWith(github.event.review.body, format('@qwen-code /review{0}', '\n'))) &&
+         startsWith(github.event.review.body, format('@qwen-code /review{0}', fromJSON('"\n"'))) ||
+         startsWith(github.event.review.body, format('@qwen-code /review{0}', fromJSON('"\r"')))) &&
         needs.authorize.outputs.should_review == 'true'))
     # The per-review budget auto-scales to QWEN_REVIEW_MAX_TIMEOUT_MINUTES
     # for any non-small PR (see "Run review"), and the shared retry budget
@@ -450,7 +466,13 @@ jobs:
           # review" is an explicit ask (authorize write-permission-checks the
           # requester for exactly that action), so it is excluded below.
           AUTO_REVIEW=false
+          # First line only, then drop a trailing CR: comments written in the
+          # GitHub web UI arrive CRLF-terminated, so without this the command
+          # line keeps a `\r`. That rides through word splitting (IFS has no
+          # CR) into tokens like `--timeout=300<CR>`, which then fails the
+          # numeric check for no visible reason.
           TRIGGER_COMMAND="${TRIGGER_BODY%%$'\n'*}"
+          TRIGGER_COMMAND="${TRIGGER_COMMAND%$'\r'}"
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             PR_NUMBER="${{ github.event.inputs.pr_number }}"
@@ -1604,6 +1626,8 @@ jobs:
 
   resolve-pr:
     needs: ['authorize']
+    # The /resolve shape match uses the same fromJSON newline/CR pair as
+    # ack-review-request.if, and for the same reason — see the note there.
     if: |-
       !cancelled() &&
       github.repository == 'QwenLM/qwen-code' &&
@@ -1616,7 +1640,8 @@ jobs:
          github.event.issue.state == 'open' &&
          (github.event.comment.body == '@qwen-code /resolve' ||
           startsWith(github.event.comment.body, '@qwen-code /resolve ') ||
-          startsWith(github.event.comment.body, format('@qwen-code /resolve{0}', '\n'))))
+          startsWith(github.event.comment.body, format('@qwen-code /resolve{0}', fromJSON('"\n"'))) ||
+          startsWith(github.event.comment.body, format('@qwen-code /resolve{0}', fromJSON('"\r"')))))
       )
     # Pinned to an ephemeral hosted runner. The conflict-resolution agent step
     # runs with `sandbox: true`, which on Linux needs docker or podman to launch

--- a/scripts/tests/qwen-pr-review-workflow.test.js
+++ b/scripts/tests/qwen-pr-review-workflow.test.js
@@ -2207,3 +2207,70 @@ describe('workflow expression length', () => {
     expect(runReviewStep()).not.toContain('${{');
   });
 });
+
+describe('command shape matching', () => {
+  // A comment may be `@qwen-code /review` followed by a newline and a body.
+  // The `if`s tried to accept that with format('…{0}', '\n'), but expression
+  // string literals are NOT escape-processed: that '\n' is a literal
+  // backslash + n, so the branch matched nothing and every multi-line command
+  // was silently ignored — no run, no feedback. Measured on a live runner:
+  //   startsWith(<LF body>, format('…{0}', '\n'))            => false
+  //   startsWith(<LF body>, format('…{0}', fromJSON('"\n"'))) => true
+  //   startsWith(<CRLF body>, format('…{0}', fromJSON('"\n"'))) => false
+  //   startsWith(<CRLF body>, format('…{0}', fromJSON('"\r"'))) => true
+  // Hence fromJSON (JSON *is* escape-processed) and both line endings: the
+  // REST API sends LF, the web UI sends CRLF.
+  const doc = parse(workflow);
+  const ifs = Object.entries(doc.jobs)
+    .filter(([, job]) => typeof job?.if === 'string')
+    .map(([id, job]) => [id, job.if]);
+
+  it('never matches a command shape with a non-escaped literal newline', () => {
+    const broken = ifs.filter(([, cond]) => /'\\[nr]'/.test(cond));
+    expect(broken.map(([id]) => id)).toEqual([]);
+  });
+
+  it('accepts both LF and CRLF after the command in every shape match', () => {
+    // `authorize` deliberately matches only a loose prefix — it is a filter to
+    // avoid spawning a job per comment, and delegates the exact shape to the
+    // downstream jobs. Jobs that do the shape match are the ones that use
+    // format('@qwen-code /<cmd>{0}', …), so key off that.
+    const withShape = ifs.filter(([, cond]) =>
+      cond.includes("format('@qwen-code /"),
+    );
+    expect(withShape.length).toBeGreaterThan(0);
+    const missing = [];
+    for (const [id, cond] of withShape) {
+      for (const cmd of ['review', 'resolve']) {
+        // Only check commands this job actually matches on.
+        if (!cond.includes(`format('@qwen-code /${cmd}{0}'`)) continue;
+        const lf = cond.includes(
+          `format('@qwen-code /${cmd}{0}', fromJSON('"\\n"'))`,
+        );
+        const cr = cond.includes(
+          `format('@qwen-code /${cmd}{0}', fromJSON('"\\r"'))`,
+        );
+        if (!lf || !cr) missing.push(`${id}/${cmd} (LF:${lf} CR:${cr})`);
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it('strips a trailing CR before parsing command tokens', () => {
+    // Word splitting uses IFS, which has no CR, so a CRLF comment would carry
+    // `\r` into tokens like `--timeout=300` and fail the numeric check.
+    // The command is parsed in "Resolve PR context", not in "Run review".
+    const run = parse(workflow).jobs['review-pr'].steps.find(
+      (s) => s.id === 'context',
+    ).run;
+    const firstLine = run.indexOf(
+      'TRIGGER_COMMAND="${TRIGGER_BODY%%$\'\\n\'*}"',
+    );
+    const stripCr = run.indexOf(
+      'TRIGGER_COMMAND="${TRIGGER_COMMAND%$\'\\r\'}"',
+    );
+    expect(firstLine).toBeGreaterThan(-1);
+    expect(stripCr).toBeGreaterThan(-1);
+    expect(stripCr).toBeGreaterThan(firstLine);
+  });
+});


### PR DESCRIPTION
## What this PR does

Makes `@qwen-code /review` followed by a newline and a body actually trigger a review, and strips the trailing CR that CRLF comments leave on the parsed command line.

## Why it's needed

This shape has never worked:

```
@qwen-code /review

please focus on the retry loop
```

The `if`s tried to accept it with:

```yaml
startsWith(github.event.comment.body, format('@qwen-code /review{0}', '\n'))
```

GitHub expression string literals are **not** escape-processed — that `'\n'` is a literal backslash + `n`. The branch matched nothing, so a multi-line command was accepted by `authorize`, then silently dropped by `review-pr` and `ack-review-request`: no run, no comment, no error. Silent failure in the one path that exists as the manual escape hatch when the automatic review does not fire.

I hit this for real while re-triggering the 40 PRs stranded by the #8648 outage: the first 19 trigger comments were written command-then-body and every one was a no-op (`authorize` succeeded with `should_review=true`, `review-pr` skipped).

### Measured, not assumed

A probe workflow on a live runner ([deleted branch, results reproduced here](https://github.com/QwenLM/qwen-code/actions)):

| expression | result |
| --- | --- |
| `startsWith(<LF body>, format('…{0}', '\n'))` | **false** |
| `startsWith(<LF body>, format('…{0}', fromJSON('"\n"')))` | **true** |
| `startsWith(<CRLF body>, format('…{0}', fromJSON('"\n"')))` | **false** |
| `startsWith(<CRLF body>, format('…{0}', fromJSON('"\r"')))` | **true** |

`fromJSON` parses JSON, which *is* escape-processed, so it yields a real newline. Both line endings are required: the REST API sends LF, the web UI sends CRLF, and an LF pattern does not match a CRLF body. Applied to all 7 shape matches (6 × `/review`, 1 × `/resolve`).

`authorize` is deliberately left alone — its loose `startsWith` prefix is a filter to avoid spawning a job per comment, and it says so.

### The shell half

`TRIGGER_COMMAND` is everything before the first LF, which on a CRLF comment keeps a trailing CR. `IFS` contains no CR, so word splitting yielded tokens like `--timeout=300<CR>`, failing the numeric check with nothing to explain it. Fixing only the `if` would have made that reachable for the first time, so it is fixed here too.

## Reviewer Test Plan

### How to verify

```
npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-pr-review-workflow.test.js
```

Expected: 103/103. Full scripts suite: 50 files, 1056 passed. `.github/scripts/qwen-triage-workflow.test.mjs`: 56/56.

Check out `main`'s workflow with this branch's tests and all three new tests fail:

```
× never matches a command shape with a non-escaped literal newline
× accepts both LF and CRLF after the command in every shape match
× strips a trailing CR before parsing command tokens
```

End-to-end confirmation is available after merge: comment `@qwen-code /review` with a body on the next line and `review-pr` should reach `in_progress` — on `main` today it silently skips.

### Evidence (Before & After)

N/A for UI. Before is the probe table above plus 19 real no-op trigger comments; after is 103/103 and every shape match carrying both endings.

Mutation-tested — each fails exactly its own test, nothing over-broad:

| mutation | tests failed |
| --- | ---: |
| drop the 7 CR branches | 1 |
| drop the shell CR strip | 1 |
| revert to `main`'s literal `'\n'` form | 3 |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

## Risk & Scope

- **Main risk or tradeoff:** the shape match gets strictly wider — bodies it previously rejected now match. It stays anchored at `startsWith`, so `@qwen-code /reviewers …` is still not a command, and the exact-match and space-suffix branches are untouched. Every widened path still passes `authorize` (write+ permission) and the `context` step's own `^@qwen-code[[:space:]]+/review([[:space:]]|$)` grep.
- **Not validated / out of scope:** the probe measured the expression semantics on a real runner, but the end-to-end multi-line trigger can only be exercised once this is on the default branch, since `issue_comment` resolves the workflow from there. Called out rather than claimed.
- **Breaking changes / migration notes:** none. Every command form that worked before still works.

## Linked Issues

Surfaced while recovering from the #8648 / #8720 review outage.

<details>
<summary>中文说明</summary>

## What this PR does

让 `@qwen-code /review` 后面跟换行和正文的评论真正触发评审，并去掉 CRLF 评论在命令行尾部残留的回车符。

## Why it's needed

下面这种写法从来就没生效过：

```
@qwen-code /review

please focus on the retry loop
```

`if` 里试图用这个来接受它：

```yaml
startsWith(github.event.comment.body, format('@qwen-code /review{0}', '\n'))
```

但 GitHub 表达式的字符串字面量**不做转义处理**——那个 `'\n'` 是字面的反斜杠加 `n`。该分支什么都匹配不到，于是多行命令会被 `authorize` 放行，再被 `review-pr` 和 `ack-review-request` 静默丢弃：没有 run，没有评论，也没有报错。而这条路径的全部意义，恰恰是自动评审没触发时的手动兜底。

我是在重新触发被 #8648 停摆卡住的 40 个 PR 时真实踩到的：最先发的 19 条触发评论都写成了"命令 + 正文"，全部是空操作（`authorize` 成功且 `should_review=true`，`review-pr` 却 skip）。

### 实测，而非假设

在真实 runner 上跑的探针 workflow（分支已删除，结果如下）：

| 表达式 | 结果 |
| --- | --- |
| `startsWith(<LF body>, format('…{0}', '\n'))` | **false** |
| `startsWith(<LF body>, format('…{0}', fromJSON('"\n"')))` | **true** |
| `startsWith(<CRLF body>, format('…{0}', fromJSON('"\n"')))` | **false** |
| `startsWith(<CRLF body>, format('…{0}', fromJSON('"\r"')))` | **true** |

`fromJSON` 解析的是 JSON，而 JSON *会*做转义处理，因此能得到真正的换行符。两种行尾都必须列出：REST API 发送的是 LF，网页 UI 发送的是 CRLF，而 LF 模式匹配不上 CRLF 的正文。已应用到全部 7 处形态匹配（6 处 `/review`，1 处 `/resolve`）。

`authorize` 有意保持原样——它那个宽松的 `startsWith` 前缀只是一个过滤器，用来避免每条评论都起一个 job，注释里也是这么写的。

### shell 那一半

`TRIGGER_COMMAND` 取的是第一个 LF 之前的全部内容，在 CRLF 评论下会保留尾部的 CR。`IFS` 不含 CR，因此分词会产出 `--timeout=300<CR>` 这样的 token，数字校验失败却没有任何可解释的现象。只修 `if` 会让这个坑第一次变得可达，所以一并修掉。

## Reviewer Test Plan

### How to verify

```
npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-pr-review-workflow.test.js
```

预期 103/103。scripts 全量套件：50 个文件、1056 passed。`.github/scripts/qwen-triage-workflow.test.mjs`：56/56。

用 `main` 的 workflow 配本分支的测试，三条新测试全部失败：

```
× never matches a command shape with a non-escaped literal newline
× accepts both LF and CRLF after the command in every shape match
× strips a trailing CR before parsing command tokens
```

端到端确认要等合入之后：发一条 `@qwen-code /review` 且下一行带正文的评论，`review-pr` 应当进入 `in_progress`——在今天的 `main` 上它会静默 skip。

### Evidence (Before & After)

界面部分 N/A。Before 是上面的探针表格，外加 19 条真实的空操作触发评论；After 是 103/103，且每处形态匹配都带上了两种行尾。

变异测试 —— 每个变异都只让它对应的那条测试失败，没有过宽：

| 变异 | 失败测试数 |
| --- | ---: |
| 删掉 7 个 CR 分支 | 1 |
| 删掉 shell 里的 CR 剥离 | 1 |
| 回退成 `main` 的字面量 `'\n'` 形式 | 3 |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

## Risk & Scope

- **主要风险与取舍：** 形态匹配严格变宽——以前被拒绝的正文现在能匹配上。它仍然锚定在 `startsWith`，所以 `@qwen-code /reviewers …` 依然不算命令，精确匹配和空格后缀两个分支也未改动。所有被放宽的路径仍然要过 `authorize`（write+ 权限）以及 `context` step 自己的 `^@qwen-code[[:space:]]+/review([[:space:]]|$)` grep。
- **未验证 / 范围之外：** 探针在真实 runner 上测到的是表达式语义，而端到端的多行触发只能在本 PR 进入默认分支之后才能验证，因为 `issue_comment` 是从默认分支解析 workflow 的。这里如实说明，而不是宣称已验证。
- **破坏性变更 / 迁移说明：** 无。此前能用的每种命令形式都继续可用。

## Linked Issues

在从 #8648 / #8720 的评审停摆中恢复时发现。

</details>
