### PR TITLE
perf(ci): make the autofix fleet caps operator-tunable and raise them

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -164,14 +164,27 @@ env:
   INFRA_FAILURE_SIGNATURES: 'lost communication with the server|No space left on device|ENOSPC|received a shutdown signal|The runner has received|Failed to initialize container|runner (was|has been) (lost|terminated)|invalid index-pack output|RPC failed'
   # Upper bound on review targets emitted per scan (fan-out defense-in-depth;
   # excess is logged and deferred to the next scan).
-  MAX_TARGETS_PER_SCAN: '10'
+  # TUNABLE WITHOUT A CODE CHANGE: set the repository variable to re-size the
+  # loop as the takeover pool grows — Settings → Variables, no PR, no deploy.
+  # The literal here is only the fallback when the variable is unset.
+  # Why 30: 37 PRs carried autofix/takeover on 2026-08-08, so the previous
+  # budget of 10 emitted at most 27% of the eligible set per tick and pushed
+  # the rest a scan further out every time. It must also stay strictly above
+  # the address matrix's max-parallel or the matrix can never fill, and the
+  # same-repo candidate pool was 51, so 30 still bounds a pathological
+  # backlog. RAISE BOTH TOGETHER: this must stay above QWEN_AUTOFIX_MAX_PARALLEL.
+  MAX_TARGETS_PER_SCAN: '${{ vars.QWEN_AUTOFIX_MAX_TARGETS_PER_SCAN || 30 }}'
   # Upper bound on candidates INSPECTED per scan: idle candidates consume
   # serial API calls even when they emit nothing, and takeover widens the
   # candidate pool. Candidates are inspected NEWEST-first; past the budget
   # the oldest tail defers — old quiet PRs are the least likely to hold new
   # feedback, and a deferred PR with a live conflict is still picked up by
   # the shepherd's conflict lever.
-  MAX_CANDIDATE_INSPECTIONS: '60'
+  # TUNABLE WITHOUT A CODE CHANGE, for the same reason as the two above: this
+  # one gates whether a PR is even LOOKED AT, so it has to grow ahead of the
+  # candidate pool or the oldest PRs starve. The pool was 51 same-repo open
+  # PRs on 2026-08-08, still under the 60 fallback.
+  MAX_CANDIDATE_INSPECTIONS: '${{ vars.QWEN_AUTOFIX_MAX_CANDIDATE_INSPECTIONS || 60 }}'
   # Maintainer-facing engagement labels (applying labels requires GitHub
   # triage+, so the permission gate is GitHub's own): TAKEOVER opts a PR —
   # including a human-authored one — into the loop; SKIP opts any PR out
@@ -3277,14 +3290,29 @@ jobs:
       # Measured at 3, on the scan that selected 7 PRs: the legs started
       # 3-at-a-time and each new one began 3-4s after a slot freed, so the
       # 7th PR waited 81 minutes for a slot it could have had immediately.
-      # 5 halves that tail while staying a real bound — the point of the cap
-      # is that a backlog cannot open an unbounded number of agent runs at
-      # once, not the specific number. The 300-minute job cap raises the
-      # worst-case hold to 5 runner-hours per slot (25 across the fleet) and
-      # holds the per-PR head-write concurrency group for the same window.
-      # The cap itself does not lengthen the queueing tail above; the raised
-      # 120-minute budget does, for the PRs that exhaust it.
-      max-parallel: 5
+      # 5 halved that tail — the point of the cap is that a backlog cannot
+      # open an unbounded number of agent runs at once, not the specific
+      # number.
+      # TUNABLE WITHOUT A CODE CHANGE: set QWEN_AUTOFIX_MAX_PARALLEL in
+      # Settings → Variables to re-size the fleet as the takeover pool grows;
+      # the literal below is only the fallback when the variable is unset.
+      # Verified on a live runner that `max-parallel` accepts this expression
+      # and schedules by it — a 6-leg matrix at 3 started 3, then began the
+      # 4th only once a slot freed.
+      # Why 20: 37 PRs carried the label on 2026-08-08, so 5 slots served
+      # ~14% of them at a time and the tail measured at 3 simply reappeared
+      # at a larger scale. The ecs-qwen fleet is 84 runners, so 20 concurrent
+      # legs occupy under a quarter of it, and the executed legs sampled that
+      # day finished in 3-28 minutes.
+      # The 300-minute job cap puts the worst case at 5 runner-hours per slot
+      # (100 across the fleet at 20) and holds the per-PR head-write
+      # concurrency group for the same window. Different PRs never share that
+      # group, so raising this does not add push contention.
+      # RAISE BOTH TOGETHER: this must stay strictly below
+      # MAX_TARGETS_PER_SCAN, or the scan cannot emit enough legs to fill the
+      # matrix and the extra slots sit idle. A test pins that for the
+      # fallbacks; for the variables it is an operator invariant.
+      max-parallel: '${{ fromJSON(vars.QWEN_AUTOFIX_MAX_PARALLEL || 20) }}'
       matrix:
         target: '${{ fromJSON(needs.review-scan.outputs.targets) }}'
     # Serialises every writer of THIS PR's head branch, across workflows.

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -413,11 +413,19 @@ describe('qwen-autofix workflow', () => {
     // that it exists AND still binds below MAX_TARGETS_PER_SCAN is pinned by
     // 'bounds fleet-wide simultaneity below the per-scan target budget'.
     // Asserting the literal number here only detected edits, not breakage.
-    expect(workflow).toMatch(/max-parallel: \d+/);
+    expect(workflow).toMatch(
+      /max-parallel: '\$\{\{ fromJSON\(vars\.QWEN_AUTOFIX_MAX_PARALLEL \|\| \d+\) \}\}'/,
+    );
     // Pathological-backlog bound: the budget BREAKS the candidate loop (so it
     // bounds runtime and API usage, not just matrix size), the deferral is
     // LOGGED, and the next scan picks up the remainder.
-    expect(workflow).toContain("MAX_TARGETS_PER_SCAN: '10'");
+    // Operator-tunable via a repository variable so the loop can be re-sized
+    // as the takeover pool grows without a code change; the literal is the
+    // fallback. Both halves are asserted so the knob cannot silently lose
+    // either its variable or its default.
+    expect(workflow).toMatch(
+      /MAX_TARGETS_PER_SCAN: '\$\{\{ vars\.QWEN_AUTOFIX_MAX_TARGETS_PER_SCAN \|\| \d+ \}\}'/,
+    );
     expect(reviewScanJob).toContain(
       'deferring the remaining candidates to the next scan',
     );
@@ -1387,10 +1395,17 @@ describe('qwen-autofix workflow', () => {
     // raising it to the target budget, both let one backlog open every agent
     // run at once — which is the thing the cap exists to prevent, and neither
     // would fail any other test.
+    // Both are repository variables now, so what is checkable here is the
+    // FALLBACK pair — the values that apply until an operator sets them.
+    // Keeping the relation true for the fallbacks means an unconfigured repo
+    // is still correctly bounded; for configured ones it is an operator
+    // invariant, stated at both definitions.
     expect(reviewAddressJob).toContain('matrix:');
-    const parallel = Number(reviewAddressJob.match(/max-parallel: (\d+)/)?.[1]);
+    const parallel = Number(
+      reviewAddressJob.match(/max-parallel:.*?\|\|\s*(\d+)/)?.[1],
+    );
     const targetBudget = Number(
-      workflow.match(/MAX_TARGETS_PER_SCAN: '(\d+)'/)?.[1],
+      workflow.match(/MAX_TARGETS_PER_SCAN:.*?\|\|\s*(\d+)/)?.[1],
     );
     expect(Number.isInteger(parallel)).toBe(true);
     expect(parallel).toBeGreaterThan(0);


### PR DESCRIPTION
## What this PR does

Backs the three autofix fleet caps with repository variables and raises their defaults, so the loop is re-sized in **Settings → Variables** instead of by editing the workflow.

| variable | fallback | was |
| --- | ---: | ---: |
| `QWEN_AUTOFIX_MAX_PARALLEL` | 20 | 5 |
| `QWEN_AUTOFIX_MAX_TARGETS_PER_SCAN` | 30 | 10 |
| `QWEN_AUTOFIX_MAX_CANDIDATE_INSPECTIONS` | 60 | 60 (unchanged) |

## Why it's needed

The takeover pool is not static — **37 PRs** carried `autofix/takeover` on 2026-08-08 and the number keeps growing. Every previous resize meant editing the workflow, opening a PR, and waiting for review. Making the caps operator-tunable removes that loop entirely; the literals stay as fallbacks so an unconfigured repository is still correctly bounded.

The defaults are raised because the old ones were sized for a much smaller pool:

- **`max-parallel: 5`** served ~14% of the takeover pool at a time, reproducing at a larger scale the tail that was measured back when it was 3 (a scan selecting 7 PRs left the 7th waiting **81 minutes** for a slot).
- **`MAX_TARGETS_PER_SCAN: 10`** emitted at most **27%** of the eligible set per tick, deferring the rest by a full scan every time. It also has to stay above `max-parallel`, or the scan cannot emit enough legs to fill the matrix.

Sized against measurements rather than a guess: the `ecs-qwen` fleet is **84 runners**, so 20 concurrent legs occupy under a quarter of it, and the executed legs sampled that day finished in **3–28 minutes**. Worst case rises to 100 runner-hours across the fleet (20 slots × the 300-minute job cap). Per-PR head-write concurrency groups are per-PR, so raising this adds no push contention.

### `max-parallel` accepting an expression was verified, not assumed

An invalid expression here makes the **entire workflow file invalid** — the failure mode this repository just paid 12.9 hours of dead review automation for (#8720). So it was measured on a live runner before being written: a 6-leg matrix whose `max-parallel` resolved through `fromJSON(vars.X || 3)`

```
probe (1,2,3)  08:16:54–55   ← exactly 3 started
probe (4)      08:17:24      ← began only after a slot freed
probe (5,6)    08:17:32
```

That also confirms the `|| fallback` path works when the variable is unset, which is how this ships.

## Reviewer Test Plan

### How to verify

```
npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-autofix-workflow.test.js
```

Expected: 122/122. Full scripts suite: 50 files, 1053 passed. `.github/scripts/qwen-triage-workflow.test.mjs`: 56/56. `yamllint` clean.

To exercise a knob after merge, set `QWEN_AUTOFIX_MAX_PARALLEL` in Settings → Variables and watch the next scan's matrix; no deploy is involved.

### Evidence (Before & After)

N/A for UI. Before/after is the cap table above plus the probe scheduling trace.

Mutation-tested — 4 of 4 caught:

| mutation | tests failed |
| --- | ---: |
| fallback equal to the target budget | 1 |
| fallback above the target budget | 1 |
| drop the `max-parallel` variable back to a literal | 2 |
| drop the `MAX_TARGETS_PER_SCAN` variable back to a literal | 2 |

The existing invariant test — *bounds fleet-wide simultaneity below the per-scan target budget* — was kept meaningful by pointing it at the **fallback** pair, so an unconfigured repo is still provably bounded. For configured repos the relation becomes an operator invariant, stated at both definitions.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

## Risk & Scope

- **Main risk or tradeoff:** more agent runs execute at once, so the model-API concurrency rises with it. Worth naming explicitly: on 2026-08-08 an autofix leg on #8663 produced **zero output for two hours** after entering its sandbox and was killed by its own budget — a shape consistent with API-side throttling rather than slow work. Raising concurrency cannot cause that, but it can surface it more often, and a silently hung leg is worse than a queued one (it holds a runner to the 300-minute cap with nothing to show). The variables are the mitigation: if that shape becomes common, dial `QWEN_AUTOFIX_MAX_PARALLEL` back down without a code change.
- **Not validated / out of scope:** the raised ceiling has not been exercised at full width yet — the largest fan-out observed in 150 sampled scans was 3 legs, and that sample spans the review outage, when little new feedback existed. The first real test is the backlog currently draining. `MAX_CANDIDATE_INSPECTIONS` is variable-backed but its value is unchanged: the same-repo candidate pool was 51, still under 60.
- **Breaking changes / migration notes:** none. With no variables set, behaviour is exactly the raised fallbacks.

## Linked Issues

Follow-up to the #8648 / #8720 review outage: draining that backlog is what made the fleet caps the next bottleneck.

<details>
<summary>中文说明</summary>

## What this PR does

把 autofix 的三个 fleet 上限改为由仓库变量提供，并提高其默认值，这样以后在 **Settings → Variables** 里调整即可，不必再改 workflow。

| 变量 | 兜底值 | 原值 |
| --- | ---: | ---: |
| `QWEN_AUTOFIX_MAX_PARALLEL` | 20 | 5 |
| `QWEN_AUTOFIX_MAX_TARGETS_PER_SCAN` | 30 | 10 |
| `QWEN_AUTOFIX_MAX_CANDIDATE_INSPECTIONS` | 60 | 60（未变） |

## Why it's needed

takeover 池并不是静态的——2026-08-08 有 **37 个** PR 带着 `autofix/takeover` 标签，而且还在增长。此前每一次调整都意味着改 workflow、开 PR、等评审。把这些上限交给运维变量之后，这个循环就彻底消失了；字面量保留为兜底值，因此未做任何配置的仓库依然处在正确的边界之内。

默认值之所以要提高，是因为原值是按远小于当前规模的池子设定的：

- **`max-parallel: 5`** 同一时刻只服务 takeover 池的约 14%，把当年在 3 时测到的尾部效应在更大规模上重演了一遍（一次选中 7 个 PR 的 scan，第 7 个等了 **81 分钟** 才拿到槽位）。
- **`MAX_TARGETS_PER_SCAN: 10`** 每个 tick 最多只能 emit 合格集合的 **27%**，其余每次都被顺延一整个 scan。它还必须高于 `max-parallel`，否则 scan 根本 emit 不出足够的腿来填满矩阵。

数值是按实测而非猜测确定的：`ecs-qwen` 池共 **84 台 runner**，因此 20 条并发腿占用不到四分之一；当天采样到的实际执行腿耗时在 **3–28 分钟**。最坏情况上升到整个 fleet 100 runner-小时（20 槽 × 300 分钟的 job 上限）。per-PR 的 head-write 并发组是按 PR 划分的，所以提高该值不会增加 push 争用。

### `max-parallel` 能否接受表达式是实测的，不是假设

这里写错一个表达式会让**整个 workflow 文件失效**——本仓库刚刚为这种故障付出了 12.9 小时评审自动化全停的代价（#8720）。所以在落笔之前先在真实 runner 上量过：一个 6 条腿的矩阵，其 `max-parallel` 经由 `fromJSON(vars.X || 3)` 求值

```
probe (1,2,3)  08:16:54–55   ← 恰好起了 3 条
probe (4)      08:17:24      ← 槽位释放后才开始
probe (5,6)    08:17:32
```

这同时验证了变量未设置时 `|| 兜底值` 这条路径是有效的，而本 PR 正是以这种形态发布的。

## Reviewer Test Plan

### How to verify

```
npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-autofix-workflow.test.js
```

预期 122/122。scripts 全量套件：50 个文件、1053 passed。`.github/scripts/qwen-triage-workflow.test.mjs`：56/56。`yamllint` 干净。

合入后想验证某个旋钮，在 Settings → Variables 里设置 `QWEN_AUTOFIX_MAX_PARALLEL`，然后观察下一次 scan 的矩阵即可，全程不涉及任何部署。

### Evidence (Before & After)

界面部分 N/A。Before/After 即上面的上限对照表，加上探针的调度轨迹。

变异测试 —— 4 个全部被捕获：

| 变异 | 失败测试数 |
| --- | ---: |
| 兜底值等于 target budget | 1 |
| 兜底值大于 target budget | 1 |
| 把 `max-parallel` 变量退回字面量 | 2 |
| 把 `MAX_TARGETS_PER_SCAN` 变量退回字面量 | 2 |

既有的不变量测试——*bounds fleet-wide simultaneity below the per-scan target budget*——通过指向**兜底值**这一对而继续有效，因此未做配置的仓库依然可证明是有界的。对已做配置的仓库，该关系转为运维不变量，并在两处定义点均已写明。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

## Risk & Scope

- **主要风险与取舍：** 同时执行的 agent run 变多，模型 API 的并发也随之上升。有一点必须点明：2026-08-08 有一条针对 #8663 的 autofix 腿在进入沙箱后**整整两小时零输出**，最终被自身预算杀掉——这个形态更像是 API 侧限流，而不是任务本身慢。提高并发并不会制造这种问题，但会让它更频繁地暴露，而一条静默挂起的腿比一条排队的腿更糟（它会占住 runner 直到 300 分钟上限，且毫无产出）。这些变量本身就是缓解手段：如果该形态变得常见，直接调低 `QWEN_AUTOFIX_MAX_PARALLEL` 即可，无需改代码。
- **未验证 / 范围之外：** 提高后的上限尚未被真正跑满——在采样的 150 次 scan 中，观察到的最大扇出只有 3 条腿，而该样本区间恰好覆盖了评审停摆期，那段时间几乎没有新反馈产生。第一次真实检验就是当前正在消化的积压。`MAX_CANDIDATE_INSPECTIONS` 虽已变量化但取值未变：同仓候选池为 51，仍在 60 以内。
- **破坏性变更 / 迁移说明：** 无。不设置任何变量时，行为就等同于提高后的兜底值。

## Linked Issues

#8648 / #8720 评审停摆的后续：正是在消化那批积压时，fleet 上限成为了下一个瓶颈。

</details>
