### PR TITLE
fix(release): align external-context workspace version

### DIFF
--- a/integrations/external-context/package.json
+++ b/integrations/external-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/external-context",
-  "version": "0.20.1",
+  "version": "0.21.7",
   "private": true,
   "description": "Provider-bound external context for Qwen Code",
   "type": "module",


### PR DESCRIPTION
## What this PR does

Fixes #8722 by updating `integrations/external-context/package.json` from `0.20.1` to the current workspace release version `0.21.7`.

## Why it's needed

The package manifest lagged behind the root workspace and `package-lock.json`. Running `npm install` reconciled the mismatch by downgrading the lockfile entry and dirtying the working tree. Aligning the manifest prevents that drift.

## Reviewer Test Plan

### How to verify

Compare the package manifest, root workspace version, and lockfile entry; then run the package checks below.

### Evidence (Before & After)

Before: package manifest `0.20.1`, lockfile `0.21.7`. After: all three report `0.21.7`; `npm install --package-lock-only --ignore-scripts` leaves the lockfile unchanged. No visual evidence applies to this release metadata fix.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |    ✅ tested |
| 🪟 Windows |    ⚠️ not tested |
|  🐧 Linux  |    ⚠️ not tested |

### Environment (optional)

macOS, Node.js 22, npm workspace commands.

## Risk & Scope

- Main risk or tradeoff: none beyond making the manifest agree with the existing lockfile and release version.
- Not validated / out of scope: release automation across every historical version and external publishing.
- Breaking changes / migration notes: none; the package is private and its source is unchanged.

## Linked Issues

Fixes #8722

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修复 #8722：将 `integrations/external-context/package.json` 的版本从 `0.20.1` 更新为当前 workspace 发布版本 `0.21.7`。

## 为什么需要它

该包清单版本落后于根 workspace 和 `package-lock.json`。运行 `npm install` 时，npm 会协调这个不一致并将 lockfile 条目降级，导致工作树产生无关修改。对齐清单版本可以避免漂移。

## 评审测试计划

### 如何验证

比较包清单、根 workspace 版本和 lockfile 条目，然后运行下方包级检查。

### 证据（修复前与修复后）

修复前：包清单为 `0.20.1`，lockfile 为 `0.21.7`。修复后：三者均为 `0.21.7`；`npm install --package-lock-only --ignore-scripts` 后 lockfile 保持不变。本版本元数据修复不适用视觉证据。

### 测试平台

| 操作系统 | 状态 |
| :------: | :--: |
| 🍏 macOS | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
| 🐧 Linux | ⚠️ 未测试 |

### 环境

macOS、Node.js 22、npm workspace 命令。

## 风险与范围

- 主要风险或取舍：无，仅使包清单与现有 lockfile 及发布版本一致。
- 未验证/不在范围内：所有历史版本的发布自动化和外部发布流程。
- 破坏性变更/迁移说明：无；该包为 private，源码未修改。

## 关联 Issue

Fixes #8722

</details>