### PR TITLE
docs(cli): correct inline image reviewer steps

### DIFF
--- a/.qwen/e2e-tests/terminal-inline-images.md
+++ b/.qwen/e2e-tests/terminal-inline-images.md
@@ -32,7 +32,7 @@ baseline is grounded in issue #8090 and the unchanged `main` event mapping.
 3. Return a PNG in a successful tool's top-level and nested
    `functionResponse.parts`.
 4. Confirm the successful tool row retains its images.
-5. Open Ctrl+O and resume the session; confirm successful tool image order is
+5. Use `/resume` (or `--continue`) to resume the session; confirm successful tool image order is
    reconstructed from persisted parts. Assistant output resumes its persisted
    text; assistant inline images are not persisted by the current Core recorder.
 6. Return six images in one assistant output and one tool response; confirm the
@@ -66,7 +66,7 @@ baseline is grounded in issue #8090 and the unchanged `main` event mapping.
 4. Confirm no raw image sequence is written. Confirm the oversized payload is
    dropped before UI history, while admitted malformed/non-PNG data uses a
    deterministic placeholder.
-5. Repeat with `INK_SCREEN_READER=true`; confirm only the placeholder is
+5. Repeat with `--screen-reader` (or `ui.accessibility.screenReader: true`); confirm only the placeholder is
    emitted.
 
 ### Stream lifecycle


### PR DESCRIPTION
## What this PR does

Fixes #8611 by correcting two reviewer steps in `.qwen/e2e-tests/terminal-inline-images.md`: session resume now uses `/resume` or `--continue`, and screen-reader verification uses `--screen-reader` or `ui.accessibility.screenReader`.

## Why it's needed

Ctrl+O toggles expanded thinking/tool details; it does not resume a session. `INK_SCREEN_READER` is not a Qwen Code control and the CLI passes an explicit screen-reader option, so the old steps could not exercise the intended behaviors.

## Reviewer Test Plan

### How to verify

Read the two updated steps and follow them against the current CLI controls. `/resume` opens session selection, `--continue` resumes the latest session, and `--screen-reader` enables the screen-reader rendering branch.

### Evidence (Before & After)

Before: the plan instructed reviewers to use Ctrl+O and `INK_SCREEN_READER=true`. After: it names the supported resume and accessibility controls. This is documentation-only; no screenshot applies.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |    ✅ tested |
| 🪟 Windows |    ⚠️ not tested |
|  🐧 Linux  |    ⚠️ not tested |

### Environment (optional)

Static source verification on macOS, Node.js 22.

## Risk & Scope

- Main risk or tradeoff: none; only reviewer instructions change.
- Not validated / out of scope: running the full image E2E flow; this PR does not change product code.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #8611

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修复 #8611：更正 `.qwen/e2e-tests/terminal-inline-images.md` 中两处评审步骤：会话恢复使用 `/resume` 或 `--continue`，屏幕阅读器验证使用 `--screen-reader` 或 `ui.accessibility.screenReader`。

## 为什么需要它

Ctrl+O 用于切换思考/工具详情展开，不会恢复会话。`INK_SCREEN_READER` 不是 Qwen Code 支持的控制项，而 CLI 会传入显式屏幕阅读器选项，因此旧步骤无法测试目标行为。

## 评审测试计划

### 如何验证

阅读更新后的两处步骤，并按当前 CLI 控制项执行。`/resume` 打开会话选择，`--continue` 恢复最近会话，`--screen-reader` 开启屏幕阅读器渲染分支。

### 证据（修复前与修复后）

修复前计划要求使用 Ctrl+O 和 `INK_SCREEN_READER=true`；修复后改为支持的会话恢复与无障碍控制项。本 PR 仅修改文档，不适用截图。

### 测试平台

| 操作系统 | 状态 |
| :------: | :--: |
| 🍏 macOS | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
| 🐧 Linux | ⚠️ 未测试 |

### 环境

macOS、Node.js 22，静态源码核验。

## 风险与范围

- 主要风险或取舍：无，仅修改评审说明。
- 未验证/不在范围内：完整 inline image E2E 流程；本 PR 不修改产品代码。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Fixes #8611

</details>