### PR TITLE
fix(ci): enter Critical-only mode after five change rounds

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -117,12 +117,15 @@ env:
   # exists to stop an unproductive LOOP, not to ration ordinary iteration —
   # a genuinely stuck PR still stops, just later.
   MAX_ROUNDS: '10'
-  # Suggestions may improve a PR, but continuing to implement them after ten
+  # Suggestions may improve a PR, but continuing to implement them after five
   # change-producing rounds expands the diff and creates fresh review churn.
-  # From round 11 onward, only Critical findings, formally requested changes,
+  # From round 6 onward, only Critical findings, formally requested changes,
   # failed checks, and base conflicts may drive code changes; lower-severity
-  # feedback is recorded and left open.
-  CRITICAL_ONLY_AFTER_ROUND: '10'
+  # feedback is recorded and left open. Lowered from 10: at 10 the threshold
+  # only ever bound takeover PRs (the strict cap discards a plain PR at round
+  # 10 before Critical-only could engage), so long-running managed PRs spent
+  # ten rounds growing their diff on suggestions before the brake applied.
+  CRITICAL_ONLY_AFTER_ROUND: '5'
   # Per-author tail budget inside Critical-only mode. An account is an
   # ACCOUNTABILITY unit, not a throttle: a human login can host an automated
   # reviewer loop with the exact regeneration property the review bot has

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -5116,10 +5116,10 @@ exit 1
     );
   });
 
-  it('switches to Critical-only feedback after ten change rounds', () => {
-    // ROUND counts change-producing rounds, so 9 still starts the tenth
-    // suggestion-capable change while 10 starts the first Critical-only round.
-    expect(workflow).toContain("CRITICAL_ONLY_AFTER_ROUND: '10'");
+  it('switches to Critical-only feedback after five change rounds', () => {
+    // ROUND counts change-producing rounds, so 4 still starts the fifth
+    // suggestion-capable change while 5 starts the first Critical-only round.
+    expect(workflow).toContain("CRITICAL_ONLY_AFTER_ROUND: '5'");
     expect(workflow).not.toContain('TAKEOVER_CRITICAL_ONLY_AFTER_ROUND');
     expect(prepareBranchAndFeedbackStep).toContain(
       '[[ "${ROUND}" -ge "${CRITICAL_ONLY_AFTER_ROUND}" ]]',
@@ -5133,12 +5133,12 @@ exit 1
         'bash',
         [
           '-c',
-          `ROUND=${round}\nCRITICAL_ONLY_AFTER_ROUND=10\n${modeBlock}\nprintf '%s' "$CRITICAL_ONLY"`,
+          `ROUND=${round}\nCRITICAL_ONLY_AFTER_ROUND=5\n${modeBlock}\nprintf '%s' "$CRITICAL_ONLY"`,
         ],
         { encoding: 'utf8' },
       );
-    expect(modeAt(9)).toBe('false');
-    expect(modeAt(10)).toBe('true');
+    expect(modeAt(4)).toBe('false');
+    expect(modeAt(5)).toBe('true');
 
     // Once the boundary is crossed, only an explicit Critical inline finding
     // or a formal changes-requested review is actionable. Suggestion and


### PR DESCRIPTION
## What this PR does

Moves the autofix loop's suggestion cutoff from ten change-producing rounds to five. From the fifth round onward, only Critical findings, formally requested changes, failed checks, and base conflicts may drive code changes; everything of lower severity is still collected and rendered as an audit record for human follow-up instead of being implemented.

## Why it's needed

The cutoff was set at ten, but the strict round cap also sits at ten and is evaluated first — a plain PR is discarded at round ten before the Critical-only switch can ever engage. So the threshold in practice only ever bound PRs under takeover, whose cap is much higher, and those PRs spent ten full rounds growing their diff on suggestions and nits before any brake applied. That is exactly the churn the mode exists to prevent: late-round suggestion work widens the diff, which regenerates review feedback, which produces more rounds.

Five rounds still leaves ample room for ordinary iteration — the mode exists to stop an unproductive loop, not to ration normal review turns — while the diff is still small enough for a reviewer to hold in their head. The bundled autofix skill already described the boundary as five rounds; the workflow now matches what the agent has been told.

## Reviewer Test Plan

### How to verify

The threshold is a single workflow-level knob shared by both the ordinary and the takeover paths, and the mode switch reads it directly, so the behavior change is fully described by the constant plus the comparison around it. The workflow test suite replays that comparison in a real shell at the new boundary and confirms a fourth-round PR still accepts suggestions while a fifth-round PR does not; it also pins the constant so a future edit cannot silently drift it back. Run the autofix workflow test file and confirm the Critical-only case passes.

Reviewers should also confirm the user-facing deferral notices, in both English and Chinese, report the new number — they interpolate the constant rather than hardcoding it, so no message text needed changing.

Note for reviewers: three unrelated cases in this file (stale-base auto-update, the eligibility recheck replay, and the takeover-command toggle replay) time out at the 5s default on a slow machine. They fail identically on an unmodified checkout of main and are not affected by this change.

### Evidence (Before & After)

N/A — not user-visible in the TUI. The only visible surface is the PR comment the loop posts when the mode engages, and its wording is unchanged apart from the interpolated round number.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local unit tests only.

## Risk & Scope

- Main risk or tradeoff: the constant is global, so ordinary (non-takeover) PRs now also enter Critical-only from round five through nine, where previously they never entered it at all before hitting the cap. That is intended — the rationale for capping suggestion work applies to both paths — but it does mean a plain PR's last few rounds become narrower. A maintainer who wants suggestion work to continue can still tag an item `**[Critical]**`, file a Request changes review, or re-arm a fresh counting window with `@qwen-code /retry`.
- Not validated / out of scope: no live run against a real takeover PR; the change is a constant plus the test that replays the comparison it feeds.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

把 autofix 循环处理 suggestion 的截止点从「十个产生改动的轮次」下调为五个。从第五轮起，只有 Critical findings、正式的 Request changes、失败的检查以及 base 冲突可以驱动代码改动；低于该级别的反馈仍会被收集并渲染成审计记录，留待人工跟进，而不再被实施。

## 为什么需要

截止点原本设为十，但严格的轮次上限同样是十，并且先于它被判断——普通 PR 在第十轮就被丢弃，Critical-only 开关根本没有机会生效。于是这个阈值实际上只对上限高得多的 takeover PR 起作用，而这些 PR 会用整整十轮在 suggestion 和 nit 上扩大 diff，之后才有刹车。这恰恰是该模式要防止的搅动：后期的 suggestion 改动会扩大 diff，扩大的 diff 会重新生成评审反馈，进而产生更多轮次。

五轮仍为常规迭代留出充足空间——该模式的目的是终止无效循环，而不是限制正常的评审往返——同时 diff 还小到评审者能整体把握。内置的 autofix skill 早已把这个边界描述为五轮；现在 workflow 与告知 agent 的内容一致了。

## 评审者测试计划

### 如何验证

该阈值是普通路径与 takeover 路径共用的单一 workflow 级常量，模式开关直接读取它，因此行为变化完全由这个常量及其周围的比较语句描述。workflow 测试套件会在真实 shell 中按新边界回放该比较，确认第四轮的 PR 仍接受 suggestion、第五轮的 PR 不再接受；同时它也钉住了常量取值，使日后的改动无法悄悄改回去。运行 autofix workflow 测试文件，确认 Critical-only 用例通过。

评审者还可确认中英文两份面向用户的延后提示都报告了新的数字——它们插值引用该常量而非硬编码，因此文案本身无需改动。

给评审者的说明：该文件中另有三个无关用例（stale-base 自动更新、eligibility recheck 回放、takeover-command toggle 回放）在较慢的机器上会超过 5 秒默认超时。它们在未修改的 main 检出上同样失败，与本次改动无关。

### 证据（前后对比）

N/A —— 不涉及 TUI 可见变化。唯一的可见界面是模式生效时循环发布的 PR 评论，除插值的轮次数字外文案未变。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

仅本地单元测试。

## 风险与范围

- 主要风险或取舍：该常量是全局的，因此普通（非 takeover）PR 现在在第五到第九轮也会进入 Critical-only，而此前它们在触及上限前从不会进入。这是有意为之——限制 suggestion 改动的理由对两条路径同样成立——但确实意味着普通 PR 的最后几轮会变窄。若维护者希望继续推进 suggestion 改动，仍可给条目打 `**[Critical]**`、提交 Request changes 评审，或用 `@qwen-code /retry` 重开一个计数窗口。
- 未验证 / 范围之外：没有针对真实 takeover PR 的线上运行验证；本次改动是一个常量，加上回放其所驱动比较逻辑的测试。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
