### PR TITLE
fix(cli): stop bare-URL hyperlinks at full-width CJK punctuation

### DIFF
--- a/packages/cli/src/ui/utils/InlineMarkdownRenderer.test.tsx
+++ b/packages/cli/src/ui/utils/InlineMarkdownRenderer.test.tsx
@@ -280,6 +280,14 @@ math then literal: $x^2\$$`;
       expect(stripAnsi(out)).toContain(`${secondUrl}_`);
     });
 
+    it('preserves dunder identifiers as visible text', () => {
+      const { lastFrame } = renderWithProviders(
+        <RenderInline text="Python 的 __init__ 方法" />,
+      );
+
+      expect(stripAnsi(lastFrame() ?? '')).toContain('__init__');
+    });
+
     it('leaves bare URLs unwrapped when unsupported', () => {
       const url = 'https://example.com/plain';
       const { lastFrame } = renderWithProviders(

--- a/packages/cli/src/ui/utils/InlineMarkdownRenderer.test.tsx
+++ b/packages/cli/src/ui/utils/InlineMarkdownRenderer.test.tsx
@@ -5,6 +5,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import stripAnsi from 'strip-ansi';
 import { renderWithProviders } from '../../test-utils/render.js';
 import { getPlainTextLength, RenderInline } from './InlineMarkdownRenderer.js';
 import { HYPERLINK_ENV_KEYS } from './osc8.js';
@@ -262,6 +263,21 @@ math then literal: $x^2\$$`;
       expect(out).not.toContain(`\x1b]8;;${url}（`);
       // The glued-on punctuation renders as plain text after the link.
       expect(out.replace(/\s+/g, ' ')).toContain('（2 commits，等 CI）');
+    });
+
+    it('does not treat underscores around a later URL as emphasis', () => {
+      enableHyperlinks();
+      const firstUrl = 'https://a.com/x';
+      const secondUrl = 'https://b.com/y';
+      const { lastFrame } = renderWithProviders(
+        <RenderInline text={`见 ${firstUrl}（说明_1）和 ${secondUrl}_。`} />,
+      );
+
+      const out = lastFrame() ?? '';
+      expect(out).toContain(`\x1b]8;;${firstUrl}\x07`);
+      expect(out).toContain(`\x1b]8;;${secondUrl}\x07`);
+      expect(out.replace(/\s+/g, ' ')).toContain('（说明_1）和');
+      expect(stripAnsi(out)).toContain(`${secondUrl}_`);
     });
 
     it('leaves bare URLs unwrapped when unsupported', () => {

--- a/packages/cli/src/ui/utils/InlineMarkdownRenderer.test.tsx
+++ b/packages/cli/src/ui/utils/InlineMarkdownRenderer.test.tsx
@@ -248,6 +248,22 @@ math then literal: $x^2\$$`;
       expect(out).not.toContain(`\x1b]8;;${url}.\x07`);
     });
 
+    it('stops the bare-URL hyperlink at glued-on full-width CJK punctuation', () => {
+      enableHyperlinks();
+      const url = 'https://github.com/QwenLM/qwen-code/pull/8742';
+      const { lastFrame } = renderWithProviders(
+        <RenderInline text={`PR：${url}（2 commits，等 CI）`} />,
+      );
+
+      const out = lastFrame() ?? '';
+      // OSC 8 target is exactly the URL — the （2 run is not swallowed into
+      // the link (https://github.com/QwenLM/qwen-code/issues/8750).
+      expect(out).toContain(`\x1b]8;;${url}\x07`);
+      expect(out).not.toContain(`\x1b]8;;${url}（`);
+      // The glued-on punctuation renders as plain text after the link.
+      expect(out.replace(/\s+/g, ' ')).toContain('（2 commits，等 CI）');
+    });
+
     it('leaves bare URLs unwrapped when unsupported', () => {
       const url = 'https://example.com/plain';
       const { lastFrame } = renderWithProviders(

--- a/packages/cli/src/ui/utils/InlineMarkdownRenderer.tsx
+++ b/packages/cli/src/ui/utils/InlineMarkdownRenderer.tsx
@@ -11,6 +11,7 @@ import stringWidth from 'string-width';
 import { createDebugLogger } from '@qwen-code/qwen-code-core';
 import { renderInlineLatex } from './latexRenderer.js';
 import {
+  BARE_URL_PATTERN,
   MD_LINK_CAPTURE,
   MD_LINK_PATTERN,
   isSafeOscScheme,
@@ -38,7 +39,7 @@ const UNDERLINE_TAG_START_LENGTH = 3; // For "<u>"
 const UNDERLINE_TAG_END_LENGTH = 4; // For "</u>"
 const INLINE_MARKDOWN_REGEX = new RegExp(
   String.raw`(\*\*.*?\*\*|\*.*?\*|_.*?_|~~.*?~~|${MD_LINK_PATTERN}|` +
-    String.raw`${INLINE_CODE_SPAN_PATTERN_SOURCE}|<u>.*?<\/u>|https?:\/\/\S+)`,
+    String.raw`${INLINE_CODE_SPAN_PATTERN_SOURCE}|<u>.*?<\/u>|${BARE_URL_PATTERN})`,
   'g',
 );
 

--- a/packages/cli/src/ui/utils/InlineMarkdownRenderer.tsx
+++ b/packages/cli/src/ui/utils/InlineMarkdownRenderer.tsx
@@ -38,7 +38,7 @@ const INLINE_CODE_MARKER_LENGTH = 1; // For "`"
 const UNDERLINE_TAG_START_LENGTH = 3; // For "<u>"
 const UNDERLINE_TAG_END_LENGTH = 4; // For "</u>"
 const INLINE_MARKDOWN_REGEX = new RegExp(
-  String.raw`(\*\*.*?\*\*|\*.*?\*|(?<![\w\u3400-\u9fff])_.*?_(?![\w\u3400-\u9fff])|~~.*?~~|${MD_LINK_PATTERN}|` +
+  String.raw`(\*\*.*?\*\*|\*.*?\*|(?<![\w\u3400-\u9fff])_(?!_)[^_]*_(?![\w\u3400-\u9fff])|~~.*?~~|${MD_LINK_PATTERN}|` +
     String.raw`${INLINE_CODE_SPAN_PATTERN_SOURCE}|<u>.*?<\/u>|${BARE_URL_PATTERN})`,
   'g',
 );

--- a/packages/cli/src/ui/utils/InlineMarkdownRenderer.tsx
+++ b/packages/cli/src/ui/utils/InlineMarkdownRenderer.tsx
@@ -38,7 +38,7 @@ const INLINE_CODE_MARKER_LENGTH = 1; // For "`"
 const UNDERLINE_TAG_START_LENGTH = 3; // For "<u>"
 const UNDERLINE_TAG_END_LENGTH = 4; // For "</u>"
 const INLINE_MARKDOWN_REGEX = new RegExp(
-  String.raw`(\*\*.*?\*\*|\*.*?\*|_.*?_|~~.*?~~|${MD_LINK_PATTERN}|` +
+  String.raw`(\*\*.*?\*\*|\*.*?\*|(?<![\w\u3400-\u9fff])_.*?_(?![\w\u3400-\u9fff])|~~.*?~~|${MD_LINK_PATTERN}|` +
     String.raw`${INLINE_CODE_SPAN_PATTERN_SOURCE}|<u>.*?<\/u>|${BARE_URL_PATTERN})`,
   'g',
 );
@@ -250,7 +250,10 @@ const RenderInlineInternal: React.FC<RenderInlineProps> = ({
         // alternative is anchored on `https?://`, so `isSafeOscScheme` is
         // redundant but kept as a cheap defense-in-depth assertion.
         const trimmedUrl = canHyperlink
-          ? trimTrailingUrlPunctuation(fullMatch)
+          ? trimTrailingUrlPunctuation(
+              fullMatch,
+              text[index + fullMatch.length],
+            )
           : fullMatch;
         const wrapOsc8 = canHyperlink && isSafeOscScheme(trimmedUrl);
         renderedNode = (

--- a/packages/cli/src/ui/utils/TableRenderer.test.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.test.tsx
@@ -675,6 +675,12 @@ describe('<TableRenderer />', () => {
       expect(stripAnsi(output)).toContain(`${secondUrl}_。`);
     });
 
+    it('preserves dunder identifiers as visible text', () => {
+      const output = renderTable(['Value'], [['Python 的 __init__ 方法']], 60);
+
+      expect(stripAnsi(output)).toContain('__init__');
+    });
+
     it('falls back to legacy `label (url)` in cells on unsupported terminals', () => {
       // isTTY=false from the suite-wide beforeEach disables hyperlinks.
       const url = 'https://example.com/page';

--- a/packages/cli/src/ui/utils/TableRenderer.test.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.test.tsx
@@ -649,6 +649,16 @@ describe('<TableRenderer />', () => {
       expectAllLinesToHaveSameVisibleWidth(output);
     });
 
+    it('stops a bare URL before glued-on CJK punctuation', () => {
+      enableHyperlinks();
+      const url = 'https://github.com/QwenLM/qwen-code/pull/8742';
+      const suffix = '（2 commits，等 CI）';
+      const output = renderTable(['PR'], [[`PR：${url}${suffix}`]], 100);
+      expect(output).toContain(`\x1b]8;;${url}\x07`);
+      expect(output).not.toContain(`\x1b]8;;${url}（`);
+      expect(stripAnsi(output)).toContain(suffix);
+    });
+
     it('falls back to legacy `label (url)` in cells on unsupported terminals', () => {
       // isTTY=false from the suite-wide beforeEach disables hyperlinks.
       const url = 'https://example.com/page';

--- a/packages/cli/src/ui/utils/TableRenderer.test.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.test.tsx
@@ -659,6 +659,22 @@ describe('<TableRenderer />', () => {
       expect(stripAnsi(output)).toContain(suffix);
     });
 
+    it('does not treat underscores around a later URL as emphasis', () => {
+      enableHyperlinks();
+      const firstUrl = 'https://a.com/x';
+      const secondUrl = 'https://b.com/y';
+      const output = renderTable(
+        ['PR'],
+        [[`见 ${firstUrl}（说明_1）和 ${secondUrl}_。`]],
+        100,
+      );
+
+      expect(output).toContain(`\x1b]8;;${firstUrl}\x07`);
+      expect(output).toContain(`\x1b]8;;${secondUrl}\x07`);
+      expect(stripAnsi(output)).toContain('（说明_1）和');
+      expect(stripAnsi(output)).toContain(`${secondUrl}_。`);
+    });
+
     it('falls back to legacy `label (url)` in cells on unsupported terminals', () => {
       // isTTY=false from the suite-wide beforeEach disables hyperlinks.
       const url = 'https://example.com/page';

--- a/packages/cli/src/ui/utils/TableRenderer.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.tsx
@@ -19,6 +19,7 @@ import {
   unescapeMarkdownDollars,
 } from './inline-math.js';
 import {
+  BARE_URL_PATTERN,
   MD_LINK_CAPTURE,
   MD_LINK_PATTERN,
   isSafeOscScheme,
@@ -50,7 +51,7 @@ const SAFETY_MARGIN = 4;
 
 const INLINE_MARKDOWN_REGEX = new RegExp(
   String.raw`(\*\*.*?\*\*|\*.*?\*|_.*?_|~~.*?~~|${MD_LINK_PATTERN}|` +
-    String.raw`${INLINE_CODE_SPAN_PATTERN_SOURCE}|<u>.*?<\/u>|https?:\/\/\S+)`,
+    String.raw`${INLINE_CODE_SPAN_PATTERN_SOURCE}|<u>.*?<\/u>|${BARE_URL_PATTERN})`,
   'g',
 );
 

--- a/packages/cli/src/ui/utils/TableRenderer.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.tsx
@@ -50,7 +50,7 @@ const ABSOLUTE_MIN_HORIZONTAL_TABLE_WIDTH = 24;
 const SAFETY_MARGIN = 4;
 
 const INLINE_MARKDOWN_REGEX = new RegExp(
-  String.raw`(\*\*.*?\*\*|\*.*?\*|_.*?_|~~.*?~~|${MD_LINK_PATTERN}|` +
+  String.raw`(\*\*.*?\*\*|\*.*?\*|(?<![\w\u3400-\u9fff])_.*?_(?![\w\u3400-\u9fff])|~~.*?~~|${MD_LINK_PATTERN}|` +
     String.raw`${INLINE_CODE_SPAN_PATTERN_SOURCE}|<u>.*?<\/u>|${BARE_URL_PATTERN})`,
   'g',
 );
@@ -372,7 +372,10 @@ function renderMarkdownToAnsi(text: string, enableInlineMath = false): string {
     } else if (/^https?:\/\//.test(fullMatch)) {
       const visible = applyColor(fullMatch, theme.text.link);
       if (canHyperlink) {
-        const trimmedUrl = trimTrailingUrlPunctuation(fullMatch);
+        const trimmedUrl = trimTrailingUrlPunctuation(
+          fullMatch,
+          text[index + fullMatch.length],
+        );
         rendered = isSafeOscScheme(trimmedUrl)
           ? `${osc8Open(trimmedUrl)}${visible}${osc8Close()}`
           : visible;

--- a/packages/cli/src/ui/utils/TableRenderer.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.tsx
@@ -50,7 +50,7 @@ const ABSOLUTE_MIN_HORIZONTAL_TABLE_WIDTH = 24;
 const SAFETY_MARGIN = 4;
 
 const INLINE_MARKDOWN_REGEX = new RegExp(
-  String.raw`(\*\*.*?\*\*|\*.*?\*|(?<![\w\u3400-\u9fff])_.*?_(?![\w\u3400-\u9fff])|~~.*?~~|${MD_LINK_PATTERN}|` +
+  String.raw`(\*\*.*?\*\*|\*.*?\*|(?<![\w\u3400-\u9fff])_(?!_)[^_]*_(?![\w\u3400-\u9fff])|~~.*?~~|${MD_LINK_PATTERN}|` +
     String.raw`${INLINE_CODE_SPAN_PATTERN_SOURCE}|<u>.*?<\/u>|${BARE_URL_PATTERN})`,
   'g',
 );

--- a/packages/cli/src/ui/utils/osc8.test.ts
+++ b/packages/cli/src/ui/utils/osc8.test.ts
@@ -313,12 +313,22 @@ describe('osc8 helpers', () => {
       expect(new RegExp(BARE_URL_PATTERN).exec(url)?.[0]).toBe(url);
     });
 
-    it('stops before common CJK punctuation', () => {
-      expect(
-        new RegExp(BARE_URL_PATTERN).exec(
-          'https://example.com/page。下一步',
-        )?.[0],
-      ).toBe('https://example.com/page');
+    it.each([
+      ['https://example.com/page。下一步', 'https://example.com/page'],
+      ['https://example.com/page、続き', 'https://example.com/page'],
+      ['https://example.com/page：説明', 'https://example.com/page'],
+      ['https://example.com/page？質問', 'https://example.com/page'],
+      ['https://example.com/page！注意', 'https://example.com/page'],
+    ])('stops before CJK punctuation in %s', (input, expected) => {
+      expect(new RegExp(BARE_URL_PATTERN).exec(input)?.[0]).toBe(expected);
+    });
+
+    it.each([
+      ['https://example.com/x﹙備註﹚', 'https://example.com/x'],
+      ['https://example.com/a︒後続', 'https://example.com/a'],
+      ['https://example.com/p﹖説明', 'https://example.com/p'],
+    ])('stops before CJK compat/vertical forms in %s', (input, expected) => {
+      expect(new RegExp(BARE_URL_PATTERN).exec(input)?.[0]).toBe(expected);
     });
   });
 

--- a/packages/cli/src/ui/utils/osc8.test.ts
+++ b/packages/cli/src/ui/utils/osc8.test.ts
@@ -6,6 +6,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  BARE_URL_PATTERN,
   HYPERLINK_ENV_KEYS,
   isSafeOscScheme,
   labelMayDeceive,
@@ -266,19 +267,8 @@ describe('osc8 helpers', () => {
       ['https://example.com?q=1)', 'https://example.com?q=1'],
       ['https://example.com:::', 'https://example.com'],
       ['https://example.com).', 'https://example.com'],
-      // Full-width CJK punctuation glues onto URLs in Chinese prose.
-      ['https://example.com。', 'https://example.com'],
-      ['https://example.com，', 'https://example.com'],
-      ['https://example.com（', 'https://example.com'],
-      ['https://example.com）', 'https://example.com'],
-      ['https://example.com、', 'https://example.com'],
     ])('trims sentence punctuation: %s -> %s', (input, expected) => {
       expect(trimTrailingUrlPunctuation(input)).toBe(expected);
-    });
-
-    it('preserves a trailing full-width close-paren when balanced inside the URL', () => {
-      const url = 'https://example.com/wiki/Foo（bar）';
-      expect(trimTrailingUrlPunctuation(url)).toBe(url);
     });
 
     it('preserves a trailing close-paren when balanced inside the URL', () => {
@@ -302,6 +292,16 @@ describe('osc8 helpers', () => {
       expect(trimTrailingUrlPunctuation('https://example.com/x')).toBe(
         'https://example.com/x',
       );
+    });
+  });
+
+  describe('BARE_URL_PATTERN', () => {
+    it.each([
+      'https://ja.wikipedia.org/wiki/人々',
+      'https://example.com/二〇二六年報',
+      'https://zh.wikipedia.org/wiki/北京',
+    ])('keeps word-forming CJK characters in %s', (url) => {
+      expect(new RegExp(BARE_URL_PATTERN).exec(url)?.[0]).toBe(url);
     });
   });
 

--- a/packages/cli/src/ui/utils/osc8.test.ts
+++ b/packages/cli/src/ui/utils/osc8.test.ts
@@ -266,8 +266,19 @@ describe('osc8 helpers', () => {
       ['https://example.com?q=1)', 'https://example.com?q=1'],
       ['https://example.com:::', 'https://example.com'],
       ['https://example.com).', 'https://example.com'],
+      // Full-width CJK punctuation glues onto URLs in Chinese prose.
+      ['https://example.com。', 'https://example.com'],
+      ['https://example.com，', 'https://example.com'],
+      ['https://example.com（', 'https://example.com'],
+      ['https://example.com）', 'https://example.com'],
+      ['https://example.com、', 'https://example.com'],
     ])('trims sentence punctuation: %s -> %s', (input, expected) => {
       expect(trimTrailingUrlPunctuation(input)).toBe(expected);
+    });
+
+    it('preserves a trailing full-width close-paren when balanced inside the URL', () => {
+      const url = 'https://example.com/wiki/Foo（bar）';
+      expect(trimTrailingUrlPunctuation(url)).toBe(url);
     });
 
     it('preserves a trailing close-paren when balanced inside the URL', () => {

--- a/packages/cli/src/ui/utils/osc8.test.ts
+++ b/packages/cli/src/ui/utils/osc8.test.ts
@@ -305,6 +305,14 @@ describe('osc8 helpers', () => {
       expect(new RegExp(BARE_URL_PATTERN).exec(url)?.[0]).toBe(url);
     });
 
+    it.each([
+      'https://en.wikipedia.org/wiki/Mexico–United_States_border',
+      'https://example.com/it’s',
+      'https://example.com/thing…',
+    ])('keeps typographic punctuation inside %s', (url) => {
+      expect(new RegExp(BARE_URL_PATTERN).exec(url)?.[0]).toBe(url);
+    });
+
     it('stops before common CJK punctuation', () => {
       expect(
         new RegExp(BARE_URL_PATTERN).exec(

--- a/packages/cli/src/ui/utils/osc8.test.ts
+++ b/packages/cli/src/ui/utils/osc8.test.ts
@@ -298,10 +298,19 @@ describe('osc8 helpers', () => {
   describe('BARE_URL_PATTERN', () => {
     it.each([
       'https://ja.wikipedia.org/wiki/人々',
+      'https://ja.wikipedia.org/wiki/〆切',
       'https://example.com/二〇二六年報',
       'https://zh.wikipedia.org/wiki/北京',
     ])('keeps word-forming CJK characters in %s', (url) => {
       expect(new RegExp(BARE_URL_PATTERN).exec(url)?.[0]).toBe(url);
+    });
+
+    it('stops before common CJK punctuation', () => {
+      expect(
+        new RegExp(BARE_URL_PATTERN).exec(
+          'https://example.com/page。下一步',
+        )?.[0],
+      ).toBe('https://example.com/page');
     });
   });
 

--- a/packages/cli/src/ui/utils/osc8.test.ts
+++ b/packages/cli/src/ui/utils/osc8.test.ts
@@ -300,6 +300,9 @@ describe('osc8 helpers', () => {
       'https://ja.wikipedia.org/wiki/人々',
       'https://ja.wikipedia.org/wiki/〆切',
       'https://example.com/二〇二六年報',
+      'https://ja.example.com/〼道と〻次',
+      'https://example.com/〱〢',
+      'https://example.com/a︳b︴c',
       'https://zh.wikipedia.org/wiki/北京',
     ])('keeps word-forming CJK characters in %s', (url) => {
       expect(new RegExp(BARE_URL_PATTERN).exec(url)?.[0]).toBe(url);

--- a/packages/cli/src/ui/utils/osc8.ts
+++ b/packages/cli/src/ui/utils/osc8.ts
@@ -101,7 +101,10 @@ export function isSafeOscScheme(url: string): boolean {
  * the URL so URLs that legitimately end with `)` (Wikipedia disambiguation,
  * MSDN) aren't truncated.
  */
-export function trimTrailingUrlPunctuation(url: string): string {
+export function trimTrailingUrlPunctuation(
+  url: string,
+  nextCharacter = '',
+): string {
   // Count `( [ {` opens once up-front; we then
   // decrement running `)`/`]`/`}` close counts as we trim, keeping the whole
   // trim O(n) instead of O(n²) for adversarial inputs like `https://x.com))))…`.
@@ -122,6 +125,14 @@ export function trimTrailingUrlPunctuation(url: string): string {
   }
 
   let end = url.length;
+  if (
+    url.charCodeAt(end - 1) === 0x5f &&
+    /[\u3001-\u3004\u3008-\u303f\uff01-\uff0f\uff1a-\uff20\uff3b-\uff40\uff5b-\uff65\ufe10-\ufe1f\ufe30-\ufe6f]/.test(
+      nextCharacter,
+    )
+  ) {
+    end--;
+  }
   while (end > 0) {
     const c = url.charCodeAt(end - 1);
     // .,;:!?'"`> — `>` covers CommonMark autolinks (`<https://x.com>`)

--- a/packages/cli/src/ui/utils/osc8.ts
+++ b/packages/cli/src/ui/utils/osc8.ts
@@ -97,14 +97,16 @@ export function isSafeOscScheme(url: string): boolean {
  * is unchanged.
  *
  * The set of trimmable trailing characters matches GitHub / GitLab linkifier
- * behavior. We additionally rebalance a trailing `)` against opening `(` in
+ * behavior, extended with the full-width CJK equivalents (`。`、`，`；`：`！`？`
+ * etc.) because Chinese prose glues those onto URLs exactly like ASCII ones.
+ * We additionally rebalance a trailing `)`/`）` against opening `(`/`（` in
  * the URL so URLs that legitimately end with `)` (Wikipedia disambiguation,
  * MSDN) aren't truncated.
  */
 export function trimTrailingUrlPunctuation(url: string): string {
-  // Count `( [ {` opens once up-front; we then decrement running `)`/`]`/`}`
-  // close counts as we trim, keeping the whole trim O(n) instead of O(n²)
-  // for adversarial inputs like `https://x.com))))…`.
+  // Count `( [ {` opens (ASCII and full-width) once up-front; we then
+  // decrement running `)`/`]`/`}` close counts as we trim, keeping the whole
+  // trim O(n) instead of O(n²) for adversarial inputs like `https://x.com))))…`.
   let openParen = 0;
   let openBracket = 0;
   let openBrace = 0;
@@ -113,12 +115,12 @@ export function trimTrailingUrlPunctuation(url: string): string {
   let closeBrace = 0;
   for (let i = 0; i < url.length; i++) {
     const cc = url.charCodeAt(i);
-    if (cc === 0x28) openParen++;
-    else if (cc === 0x5b) openBracket++;
-    else if (cc === 0x7b) openBrace++;
-    else if (cc === 0x29) closeParen++;
-    else if (cc === 0x5d) closeBracket++;
-    else if (cc === 0x7d) closeBrace++;
+    if (cc === 0x28 || cc === 0xff08) openParen++;
+    else if (cc === 0x5b || cc === 0xff3b) openBracket++;
+    else if (cc === 0x7b || cc === 0xff5b) openBrace++;
+    else if (cc === 0x29 || cc === 0xff09) closeParen++;
+    else if (cc === 0x5d || cc === 0xff3d) closeBracket++;
+    else if (cc === 0x7d || cc === 0xff5d) closeBrace++;
   }
 
   let end = url.length;
@@ -136,23 +138,42 @@ export function trimTrailingUrlPunctuation(url: string): string {
       c === 0x27 ||
       c === 0x22 ||
       c === 0x60 ||
-      c === 0x3e
+      c === 0x3e ||
+      // Full-width CJK punctuation: 。 、 ， ； ： ！ ？ ＇ ＂ ｀ ＞ … – — ―
+      // plus opening （ ［ ｛ (a URL never legitimately ends with one).
+      c === 0x3002 ||
+      c === 0x3001 ||
+      c === 0xff08 ||
+      c === 0xff3b ||
+      c === 0xff5b ||
+      c === 0xff0c ||
+      c === 0xff1b ||
+      c === 0xff1a ||
+      c === 0xff01 ||
+      c === 0xff1f ||
+      c === 0xff07 ||
+      c === 0xff02 ||
+      c === 0xff40 ||
+      c === 0xff1e ||
+      c === 0x2026 ||
+      (c >= 0x2013 && c <= 0x2015)
     ) {
       end--;
       continue;
     }
-    // Trailing `)`/`]`/`}` only when unbalanced against opens in the prefix.
-    if (c === 0x29 && closeParen > openParen) {
+    // Trailing `)`/`]`/`}` (ASCII or full-width) only when unbalanced
+    // against opens in the prefix.
+    if ((c === 0x29 || c === 0xff09) && closeParen > openParen) {
       closeParen--;
       end--;
       continue;
     }
-    if (c === 0x5d && closeBracket > openBracket) {
+    if ((c === 0x5d || c === 0xff3d) && closeBracket > openBracket) {
       closeBracket--;
       end--;
       continue;
     }
-    if (c === 0x7d && closeBrace > openBrace) {
+    if ((c === 0x7d || c === 0xff5d) && closeBrace > openBrace) {
       closeBrace--;
       end--;
       continue;
@@ -177,6 +198,19 @@ export const MD_LINK_PATTERN = String.raw`\[.*?\]\((?:[^()]|\([^()]*\))*\)`;
  * with `^...$` because callers pass the whole match string.
  */
 export const MD_LINK_CAPTURE = /^\[(.*?)\]\(((?:[^()]|\([^()]*\))*)\)$/;
+
+/**
+ * Bare-URL pattern shared between the React and ANSI renderers. Unlike a
+ * plain `\S+` run it stops at CJK / full-width punctuation: Chinese prose
+ * routinely glues `（…）`/`。` onto a URL with no space
+ * (`https://x.com（2 commits）`), and `\S` swallows the punctuation plus
+ * everything up to the next ASCII space, turning the OSC 8 target into a
+ * 404. Raw CJK ideographs stay in the match — un-percent-encoded IRI paths
+ * are plausible; full-width punctuation never is. ASCII trailing punctuation
+ * is still matched and left to `trimTrailingUrlPunctuation` so visible bytes
+ * stay unchanged on unsupported terminals.
+ */
+export const BARE_URL_PATTERN = String.raw`https?:\/\/[^\s\u00a0\u2013-\u2015\u2018-\u201f\u2026\u3000-\u303f\uff01-\uff0f\uff1a-\uff20\uff3b-\uff40\uff5b-\uff65]+`;
 
 /**
  * Should the markdown renderers wrap a `[label](url)` token in an OSC 8

--- a/packages/cli/src/ui/utils/osc8.ts
+++ b/packages/cli/src/ui/utils/osc8.ts
@@ -184,12 +184,13 @@ export const MD_LINK_CAPTURE = /^\[(.*?)\]\(((?:[^()]|\([^()]*\))*)\)$/;
  * routinely glues `（…）`/`。` onto a URL with no space
  * (`https://x.com（2 commits）`), and `\S` swallows the punctuation plus
  * everything up to the next ASCII space, turning the OSC 8 target into a
- * 404. Raw CJK ideographs, U+3005 々, and U+3007 〇 stay in the match because
- * they are word-forming IRI characters. ASCII and typographic trailing
- * punctuation stays matched and is left to `trimTrailingUrlPunctuation` so
- * valid raw IRIs and visible bytes remain unchanged.
+ * 404. Raw CJK ideographs, U+3005 々, U+3006 〆, and U+3007 〇 stay in the
+ * match because they are word-forming IRI characters. The exclusion also
+ * covers CJK Compatibility Forms (U+FE30–U+FE6F) and Vertical Forms
+ * (U+FE10–U+FE1F). ASCII and other typographic punctuation stays matched and
+ * is left to `trimTrailingUrlPunctuation`.
  */
-export const BARE_URL_PATTERN = String.raw`https?:\/\/[^\s\u00a0\u3000-\u3004\u3008-\u303f\uff01-\uff0f\uff1a-\uff20\uff3b-\uff40\uff5b-\uff65]+`;
+export const BARE_URL_PATTERN = String.raw`https?:\/\/[^\s\u3001-\u3004\u3008-\u303f\uff01-\uff0f\uff1a-\uff20\uff3b-\uff40\uff5b-\uff65\ufe10-\ufe1f\ufe30-\ufe6f]+`;
 
 /**
  * Should the markdown renderers wrap a `[label](url)` token in an OSC 8

--- a/packages/cli/src/ui/utils/osc8.ts
+++ b/packages/cli/src/ui/utils/osc8.ts
@@ -191,7 +191,7 @@ export const MD_LINK_CAPTURE = /^\[(.*?)\]\(((?:[^()]|\([^()]*\))*)\)$/;
  * still matched and left to `trimTrailingUrlPunctuation` so visible bytes stay
  * unchanged on unsupported terminals.
  */
-export const BARE_URL_PATTERN = String.raw`https?:\/\/[^\s\u00a0\u2013-\u2015\u2018-\u201f\u2026\u3000-\u3004\u3006\u3008-\u303f\uff01-\uff0f\uff1a-\uff20\uff3b-\uff40\uff5b-\uff65]+`;
+export const BARE_URL_PATTERN = String.raw`https?:\/\/[^\s\u00a0\u2013-\u2015\u2018-\u201f\u2026\u3000-\u3004\u3008-\u303f\uff01-\uff0f\uff1a-\uff20\uff3b-\uff40\uff5b-\uff65]+`;
 
 /**
  * Should the markdown renderers wrap a `[label](url)` token in an OSC 8

--- a/packages/cli/src/ui/utils/osc8.ts
+++ b/packages/cli/src/ui/utils/osc8.ts
@@ -185,13 +185,11 @@ export const MD_LINK_CAPTURE = /^\[(.*?)\]\(((?:[^()]|\([^()]*\))*)\)$/;
  * (`https://x.com（2 commits）`), and `\S` swallows the punctuation plus
  * everything up to the next ASCII space, turning the OSC 8 target into a
  * 404. Raw CJK ideographs, U+3005 々, and U+3007 〇 stay in the match because
- * they are word-forming IRI characters. Typographic dashes and curly quotes
- * are excluded to terminate URLs in spaceless prose, so raw IRIs containing
- * those characters are an accepted trade-off. ASCII trailing punctuation is
- * still matched and left to `trimTrailingUrlPunctuation` so visible bytes stay
- * unchanged on unsupported terminals.
+ * they are word-forming IRI characters. ASCII and typographic trailing
+ * punctuation stays matched and is left to `trimTrailingUrlPunctuation` so
+ * valid raw IRIs and visible bytes remain unchanged.
  */
-export const BARE_URL_PATTERN = String.raw`https?:\/\/[^\s\u00a0\u2013-\u2015\u2018-\u201f\u2026\u3000-\u3004\u3008-\u303f\uff01-\uff0f\uff1a-\uff20\uff3b-\uff40\uff5b-\uff65]+`;
+export const BARE_URL_PATTERN = String.raw`https?:\/\/[^\s\u00a0\u3000-\u3004\u3008-\u303f\uff01-\uff0f\uff1a-\uff20\uff3b-\uff40\uff5b-\uff65]+`;
 
 /**
  * Should the markdown renderers wrap a `[label](url)` token in an OSC 8

--- a/packages/cli/src/ui/utils/osc8.ts
+++ b/packages/cli/src/ui/utils/osc8.ts
@@ -88,6 +88,11 @@ export function isSafeOscScheme(url: string): boolean {
   return SAFE_OSC8_SCHEMES.has(match[1]!.toLowerCase());
 }
 
+const BARE_URL_BREAK_CHARACTERS = String.raw`\u3001-\u3004\u3008-\u3020\u302e-\u3030\u3036-\u3037\u303d-\u303f\uff01-\uff0f\uff1a-\uff20\uff3b-\uff40\uff5b-\uff65\ufe10-\ufe1f\ufe30-\ufe32\ufe35-\ufe6f`;
+// The escaped CJK ranges do not contain literal combining characters.
+// eslint-disable-next-line no-misleading-character-class
+const BARE_URL_BREAK_PATTERN = new RegExp(`[${BARE_URL_BREAK_CHARACTERS}]`);
+
 /**
  * Trim trailing sentence punctuation off a bare URL run before it becomes
  * an OSC 8 target. Models routinely produce `see https://example.com.` and
@@ -127,9 +132,7 @@ export function trimTrailingUrlPunctuation(
   let end = url.length;
   if (
     url.charCodeAt(end - 1) === 0x5f &&
-    /[\u3001-\u3004\u3008-\u303f\uff01-\uff0f\uff1a-\uff20\uff3b-\uff40\uff5b-\uff65\ufe10-\ufe1f\ufe30-\ufe6f]/.test(
-      nextCharacter,
-    )
+    BARE_URL_BREAK_PATTERN.test(nextCharacter)
   ) {
     end--;
   }
@@ -197,11 +200,12 @@ export const MD_LINK_CAPTURE = /^\[(.*?)\]\(((?:[^()]|\([^()]*\))*)\)$/;
  * everything up to the next ASCII space, turning the OSC 8 target into a
  * 404. Raw CJK ideographs, U+3005 々, U+3006 〆, and U+3007 〇 stay in the
  * match because they are word-forming IRI characters. The exclusion also
- * covers CJK Compatibility Forms (U+FE30–U+FE6F) and Vertical Forms
- * (U+FE10–U+FE1F). ASCII and other typographic punctuation stays matched and
- * is left to `trimTrailingUrlPunctuation`.
+ * covers punctuation in CJK Compatibility Forms and Vertical Forms while
+ * preserving their word-forming repeat marks and vertical low lines. ASCII
+ * and other typographic punctuation stays matched and is left to
+ * `trimTrailingUrlPunctuation`.
  */
-export const BARE_URL_PATTERN = String.raw`https?:\/\/[^\s\u3001-\u3004\u3008-\u303f\uff01-\uff0f\uff1a-\uff20\uff3b-\uff40\uff5b-\uff65\ufe10-\ufe1f\ufe30-\ufe6f]+`;
+export const BARE_URL_PATTERN = String.raw`https?:\/\/[^\s${BARE_URL_BREAK_CHARACTERS}]+`;
 
 /**
  * Should the markdown renderers wrap a `[label](url)` token in an OSC 8

--- a/packages/cli/src/ui/utils/osc8.ts
+++ b/packages/cli/src/ui/utils/osc8.ts
@@ -97,14 +97,12 @@ export function isSafeOscScheme(url: string): boolean {
  * is unchanged.
  *
  * The set of trimmable trailing characters matches GitHub / GitLab linkifier
- * behavior, extended with the full-width CJK equivalents (`。`、`，`；`：`！`？`
- * etc.) because Chinese prose glues those onto URLs exactly like ASCII ones.
- * We additionally rebalance a trailing `)`/`）` against opening `(`/`（` in
+ * behavior. We additionally rebalance a trailing `)` against opening `(` in
  * the URL so URLs that legitimately end with `)` (Wikipedia disambiguation,
  * MSDN) aren't truncated.
  */
 export function trimTrailingUrlPunctuation(url: string): string {
-  // Count `( [ {` opens (ASCII and full-width) once up-front; we then
+  // Count `( [ {` opens once up-front; we then
   // decrement running `)`/`]`/`}` close counts as we trim, keeping the whole
   // trim O(n) instead of O(n²) for adversarial inputs like `https://x.com))))…`.
   let openParen = 0;
@@ -115,12 +113,12 @@ export function trimTrailingUrlPunctuation(url: string): string {
   let closeBrace = 0;
   for (let i = 0; i < url.length; i++) {
     const cc = url.charCodeAt(i);
-    if (cc === 0x28 || cc === 0xff08) openParen++;
-    else if (cc === 0x5b || cc === 0xff3b) openBracket++;
-    else if (cc === 0x7b || cc === 0xff5b) openBrace++;
-    else if (cc === 0x29 || cc === 0xff09) closeParen++;
-    else if (cc === 0x5d || cc === 0xff3d) closeBracket++;
-    else if (cc === 0x7d || cc === 0xff5d) closeBrace++;
+    if (cc === 0x28) openParen++;
+    else if (cc === 0x5b) openBracket++;
+    else if (cc === 0x7b) openBrace++;
+    else if (cc === 0x29) closeParen++;
+    else if (cc === 0x5d) closeBracket++;
+    else if (cc === 0x7d) closeBrace++;
   }
 
   let end = url.length;
@@ -138,42 +136,23 @@ export function trimTrailingUrlPunctuation(url: string): string {
       c === 0x27 ||
       c === 0x22 ||
       c === 0x60 ||
-      c === 0x3e ||
-      // Full-width CJK punctuation: 。 、 ， ； ： ！ ？ ＇ ＂ ｀ ＞ … – — ―
-      // plus opening （ ［ ｛ (a URL never legitimately ends with one).
-      c === 0x3002 ||
-      c === 0x3001 ||
-      c === 0xff08 ||
-      c === 0xff3b ||
-      c === 0xff5b ||
-      c === 0xff0c ||
-      c === 0xff1b ||
-      c === 0xff1a ||
-      c === 0xff01 ||
-      c === 0xff1f ||
-      c === 0xff07 ||
-      c === 0xff02 ||
-      c === 0xff40 ||
-      c === 0xff1e ||
-      c === 0x2026 ||
-      (c >= 0x2013 && c <= 0x2015)
+      c === 0x3e
     ) {
       end--;
       continue;
     }
-    // Trailing `)`/`]`/`}` (ASCII or full-width) only when unbalanced
-    // against opens in the prefix.
-    if ((c === 0x29 || c === 0xff09) && closeParen > openParen) {
+    // Trailing `)`/`]`/`}` only when unbalanced against opens in the prefix.
+    if (c === 0x29 && closeParen > openParen) {
       closeParen--;
       end--;
       continue;
     }
-    if ((c === 0x5d || c === 0xff3d) && closeBracket > openBracket) {
+    if (c === 0x5d && closeBracket > openBracket) {
       closeBracket--;
       end--;
       continue;
     }
-    if ((c === 0x7d || c === 0xff5d) && closeBrace > openBrace) {
+    if (c === 0x7d && closeBrace > openBrace) {
       closeBrace--;
       end--;
       continue;
@@ -205,12 +184,14 @@ export const MD_LINK_CAPTURE = /^\[(.*?)\]\(((?:[^()]|\([^()]*\))*)\)$/;
  * routinely glues `（…）`/`。` onto a URL with no space
  * (`https://x.com（2 commits）`), and `\S` swallows the punctuation plus
  * everything up to the next ASCII space, turning the OSC 8 target into a
- * 404. Raw CJK ideographs stay in the match — un-percent-encoded IRI paths
- * are plausible; full-width punctuation never is. ASCII trailing punctuation
- * is still matched and left to `trimTrailingUrlPunctuation` so visible bytes
- * stay unchanged on unsupported terminals.
+ * 404. Raw CJK ideographs, U+3005 々, and U+3007 〇 stay in the match because
+ * they are word-forming IRI characters. Typographic dashes and curly quotes
+ * are excluded to terminate URLs in spaceless prose, so raw IRIs containing
+ * those characters are an accepted trade-off. ASCII trailing punctuation is
+ * still matched and left to `trimTrailingUrlPunctuation` so visible bytes stay
+ * unchanged on unsupported terminals.
  */
-export const BARE_URL_PATTERN = String.raw`https?:\/\/[^\s\u00a0\u2013-\u2015\u2018-\u201f\u2026\u3000-\u303f\uff01-\uff0f\uff1a-\uff20\uff3b-\uff40\uff5b-\uff65]+`;
+export const BARE_URL_PATTERN = String.raw`https?:\/\/[^\s\u00a0\u2013-\u2015\u2018-\u201f\u2026\u3000-\u3004\u3006\u3008-\u303f\uff01-\uff0f\uff1a-\uff20\uff3b-\uff40\uff5b-\uff65]+`;
 
 /**
  * Should the markdown renderers wrap a `[label](url)` token in an OSC 8


### PR DESCRIPTION
## What this PR does

This replaces the duplicated bare-URL matcher in the React inline markdown renderer and ANSI table renderer with one shared boundary that stops at CJK / full-width punctuation while preserving word-forming CJK IRI characters such as `〆`. The existing ASCII trailing-punctuation behavior remains unchanged.

## Why it's needed

Chinese prose routinely glues full-width punctuation directly onto URLs — `https://x.com（2 commits）`, `见 https://x.com。` — and `\S` matches full-width characters, so the bare-URL linkifier swallowed the punctuation plus everything up to the next ASCII space into both the visible hyperlink region and the OSC 8 click target; clicking opened a 404. Reported in #8750 with a real-session screenshot (underline ran past the URL into `（2`).

## Reviewer Test Plan

### How to verify

- Unit: `cd packages/cli && npx vitest run src/ui/utils/osc8.test.ts src/ui/utils/InlineMarkdownRenderer.test.tsx src/ui/utils/TableRenderer.test.tsx` — confirm the shared matcher stops before glued-on punctuation such as `（` and `。`, preserves word-forming CJK IRI characters such as `〆`, and keeps both renderers aligned.
- TUI: run the built CLI in a hyperlink-capable terminal (or `FORCE_HYPERLINK=1`), have the model emit `PR：https://github.com/QwenLM/qwen-code/pull/8742（2 commits，等 CI）` as a bare URL, and confirm the clickable region / OSC 8 target is exactly the URL.

### Evidence (Before & After)

Real TTY sessions driven via `script(1)` with `FORCE_HYPERLINK=1`; model asked to echo `PR：https://github.com/QwenLM/qwen-code/pull/8742（2 commits，等 CI）` verbatim. OSC 8 targets extracted from the terminal log:

- **Before** (main @ `9e8745349`): `https://github.com/QwenLM/qwen-code/pull/8742` **and** `https://github.com/QwenLM/qwen-code/pull/8742（2` — the reply line's hyperlink target swallowed `（2`, the broken click target from #8750.
- **After** (this branch): only `https://github.com/QwenLM/qwen-code/pull/8742`; `（2 commits，等 CI）` renders as plain text after the link.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node v22.22.0, `npm run build`, CLI driven in a `script(1)` pty with `FORCE_HYPERLINK=1`.

## Risk & Scope

- Main risk or tradeoff: a URL that legitimately contains raw full-width punctuation would now be cut there — such characters must be percent-encoded on the wire anyway, so real-world URLs don't carry them raw.
- Not validated / out of scope: desktop/webui linkification (already uses linkify-it, unaffected); bare URLs followed by CJK ideographs with no punctuation remain matched (same as GitHub's linkifier).
- Breaking changes / migration notes: none; visible bytes for ASCII trailing punctuation are unchanged.

## Linked Issues

Resolves #8750

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 React 行内 Markdown 渲染器和 ANSI 表格渲染器里重复的裸 URL 匹配替换为一个共享边界，使匹配在 CJK / 全角标点处停止，同时保留像 `〆` 这样的构词 CJK IRI 字符。现有 ASCII 尾部标点处理保持不变。

## 为什么需要

中文文本常把全角标点直接贴在 URL 后面，例如 `https://x.com（2 commits）`、`见 https://x.com。`。由于 `\S` 会匹配全角字符，旧的裸 URL 链接化会把标点及其后直到下一个 ASCII 空格的内容一起吞进可见的下划线区域和 OSC 8 点击目标，点击后会打开 404。#8750 的真实会话截图中，下划线已越过 URL 并包含 `（2`。

## Reviewer 测试计划

### 如何验证

- 单元测试：运行 `cd packages/cli && npx vitest run src/ui/utils/osc8.test.ts src/ui/utils/InlineMarkdownRenderer.test.tsx src/ui/utils/TableRenderer.test.tsx`。确认共享匹配会在 `（`、`。` 等粘连标点前停止，保留 `〆` 等构词 CJK IRI 字符，并让两个渲染器保持一致。
- TUI：在支持超链接的终端中运行构建后的 CLI（或设置 `FORCE_HYPERLINK=1`），让模型以裸 URL 形式输出 `PR：https://github.com/QwenLM/qwen-code/pull/8742（2 commits，等 CI）`，确认可点击区域和 OSC 8 目标严格等于 URL。

### 证据（修改前后）

使用 `script(1)` 和 `FORCE_HYPERLINK=1` 驱动真实 TTY，会话中要求模型原样回显 `PR：https://github.com/QwenLM/qwen-code/pull/8742（2 commits，等 CI）`，并从终端日志中提取 OSC 8 目标：

- **修改前**（main @ `9e8745349`）：同时出现 `https://github.com/QwenLM/qwen-code/pull/8742` 和 `https://github.com/QwenLM/qwen-code/pull/8742（2`；回复行的链接目标错误地吞入了 `（2`，即 #8750 中的坏链接。
- **修改后**（本分支）：仅出现 `https://github.com/QwenLM/qwen-code/pull/8742`；`（2 commits，等 CI）` 在链接后作为普通文本渲染。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Node v22.22.0，执行 `npm run build`，并在 `script(1)` pty 中设置 `FORCE_HYPERLINK=1` 驱动 CLI。

## 风险与范围

- 主要风险或权衡：如果 URL 合法地包含未编码的全角标点，现在会在该字符处截断；但这类字符在线路上本就应进行百分号编码，因此真实 URL 通常不会原样携带它们。
- 未验证 / 范围外：Desktop/WebUI 的链接化（已使用 linkify-it，不受影响）；裸 URL 后直接跟随、且没有标点分隔的 CJK 表意文字仍会被匹配，这与 GitHub 的链接化行为一致。
- Breaking Change / 迁移说明：无；ASCII 尾部标点的可见字节保持不变。

## 关联 Issue

Resolves #8750

</details>