### PR TITLE
perf(review): file-scope a micro diff's own suite with vitest related

### DIFF
--- a/packages/cli/src/commands/review/build-test.test.ts
+++ b/packages/cli/src/commands/review/build-test.test.ts
@@ -773,6 +773,136 @@ describe('runBuildTest', () => {
     expect(rep.ok).toBe(true);
   });
 
+  it('file-scopes a micro diff in a vitest workspace, disclosed in the caveat', () => {
+    // The measured incident: a 23-line one-file diff ran the whole cli suite,
+    // hit three unrelated environmental failures, and paid five minutes of
+    // merge-base dance to prove them pre-existing. `vitest related` answers
+    // the same question with exactly the suites that import the change.
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({ name: 'r', workspaces: ['packages/*'] }),
+    );
+    pkg('packages/app', {
+      name: '@x/app',
+      scripts: { build: 'exit 0', test: 'vitest run' },
+    });
+    pkg('packages/other', {
+      name: '@x/other',
+      scripts: { build: 'exit 0', test: 'exit 0' },
+    });
+    mkdirSync(join(root, 'packages/app/src'), { recursive: true });
+    writeFileSync(join(root, 'packages/app/src/a.ts'), 'export const a = 1;');
+    writeFileSync(join(root, 'packages/app/src/b.ts'), 'export const b = 1;');
+    writePlan(['packages/app/src/a.ts', 'packages/app/src/b.ts']);
+
+    const rep = runBuildTest({
+      plan: planPath,
+      worktree: root,
+      timeout: 60,
+      install: false,
+      exec: okExec,
+    });
+    expect(rep.test.map((t) => t.command)).toEqual([
+      'npm exec --workspace="packages/app" -- ' +
+        'vitest related --run "src/a.ts" "src/b.ts"',
+    ]);
+    expect(rep.testScope?.caveat).toContain(
+      'packages/app ran only the suites vitest traces to its 2 changed file(s)',
+    );
+    expect(rep.ok).toBe(true);
+  });
+
+  it('file-scopes only the affected workspace — dependents keep their full suites', () => {
+    // A dependent's suite imports the package's BUILT output; vitest's module
+    // graph over there traces nothing back to the changed sources, so a
+    // narrowed dependent run would skip everything and call it coverage.
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({ name: 'r', workspaces: ['packages/*'] }),
+    );
+    pkg('packages/core', {
+      name: '@x/core',
+      scripts: { build: 'exit 0', test: 'vitest run' },
+    });
+    pkg('packages/leaf', {
+      name: '@x/leaf',
+      dependencies: { '@x/core': '*' },
+      scripts: { build: 'exit 0', test: 'vitest run' },
+    });
+    for (const island of ['island1', 'island2', 'island3']) {
+      pkg(`packages/${island}`, {
+        name: `@x/${island}`,
+        scripts: { build: 'exit 0', test: 'exit 0' },
+      });
+    }
+    mkdirSync(join(root, 'packages/core/src'), { recursive: true });
+    writeFileSync(join(root, 'packages/core/src/a.ts'), 'export const a = 1;');
+    writePlan(['packages/core/src/a.ts']);
+
+    const rep = runBuildTest({
+      plan: planPath,
+      worktree: root,
+      timeout: 60,
+      install: false,
+      exec: okExec,
+    });
+    expect(rep.test.map((t) => t.command)).toEqual([
+      'npm exec --workspace="packages/core" -- vitest related --run "src/a.ts"',
+      'npm test --workspace="packages/leaf"',
+    ]);
+  });
+
+  it.each([
+    [
+      'more changed files than the cap',
+      ['src/a.ts', 'src/b.ts', 'src/c.ts', 'src/d.ts'],
+      true,
+      'vitest run',
+    ],
+    [
+      'a deleted file the graph cannot trace',
+      ['src/gone.ts'],
+      false,
+      'vitest run',
+    ],
+    ['a test script that does not run vitest', ['src/a.ts'], true, 'jest'],
+  ])(
+    'falls back to the full suite for %s',
+    (_name, files, materialize, testScript) => {
+      writeFileSync(
+        join(root, 'package.json'),
+        JSON.stringify({ name: 'r', workspaces: ['packages/*'] }),
+      );
+      pkg('packages/app', {
+        name: '@x/app',
+        scripts: { build: 'exit 0', test: testScript },
+      });
+      pkg('packages/other', {
+        name: '@x/other',
+        scripts: { build: 'exit 0', test: 'exit 0' },
+      });
+      mkdirSync(join(root, 'packages/app/src'), { recursive: true });
+      if (materialize) {
+        for (const f of files) {
+          writeFileSync(join(root, 'packages/app', f), 'export const x = 1;');
+        }
+      }
+      writePlan(files.map((f) => `packages/app/${f}`));
+
+      const rep = runBuildTest({
+        plan: planPath,
+        worktree: root,
+        timeout: 60,
+        install: false,
+        exec: okExec,
+      });
+      expect(rep.test.map((t) => t.command)).toEqual([
+        'npm test --workspace="packages/app"',
+      ]);
+      expect(rep.testScope?.caveat ?? '').not.toContain('vitest traces');
+    },
+  );
+
   it('tests the TRANSITIVE dependents of a changed workspace, not just direct ones', () => {
     // core <- mid <- top: a behaviour change in core can surface in top's suite
     // with mid unchanged in between. The closure must follow the chain.

--- a/packages/cli/src/commands/review/build-test.ts
+++ b/packages/cli/src/commands/review/build-test.ts
@@ -88,6 +88,73 @@ function testCommand(dir: string): string {
   return dir === '.' ? 'npm test' : `npm test --workspace=${shellArg(dir)}`;
 }
 
+/**
+ * At or below this many changed files in an affected workspace, its own
+ * suite is FILE-scoped: `vitest related --run <files>` — exactly the suites
+ * vitest's module graph traces to the change — instead of the whole suite.
+ *
+ * Measured on a 23-line, one-file `/demo`-page diff: the full `packages/cli`
+ * suite ran for minutes, failed on three suites unrelated to the change
+ * (environmental), and that failure then forced the merge-base
+ * build/test-delta dance — over five minutes of Agent 7's wall clock spent
+ * proving that pre-existing failures pre-existed, on a diff no test
+ * imports. The file-scoped run answers the same question in seconds, and a
+ * green scoped run never triggers the base measurement at all.
+ *
+ * The narrowing is deliberately confined to where it cannot under-test:
+ * only the AFFECTED workspace's own suite (a dependent's suite imports the
+ * package's BUILT output, not its source files, so `vitest related` over
+ * there would trace nothing — dependents keep their full suites), only when
+ * every changed file still exists (a deletion breaks tests no import graph
+ * can trace back to it), only when the workspace's test script runs vitest,
+ * and always disclosed through `testScope.caveat`.
+ */
+const FILE_SCOPE_MAX_CHANGED = 3;
+
+/** Does this workspace's `test` script run vitest? Any doubt reads as no. */
+function vitestTestScript(root: string, dir: string): boolean {
+  try {
+    const parsed = JSON.parse(
+      readFileSync(join(root, dir, 'package.json'), 'utf8'),
+    ) as { scripts?: Record<string, unknown> };
+    const t = parsed?.scripts?.['test'];
+    return typeof t === 'string' && /\bvitest\b/.test(t);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The workspace-relative changed files a file-scoped run would hand vitest,
+ * or `null` when the narrowing does not apply and the full suite runs.
+ */
+function fileScopedChanges(
+  root: string,
+  dir: string,
+  changed: string[],
+): string[] | null {
+  if (dir === '.') return null;
+  const prefix = dir.endsWith('/') ? dir : `${dir}/`;
+  const mine = changed.filter((f) => f.startsWith(prefix));
+  if (mine.length === 0 || mine.length > FILE_SCOPE_MAX_CHANGED) return null;
+  if (!mine.every((f) => existsSync(join(root, f)))) return null;
+  if (!vitestTestScript(root, dir)) return null;
+  return mine.map((f) => f.slice(prefix.length));
+}
+
+/**
+ * The file-scoped test command. `npm exec --workspace` runs from the
+ * workspace's own directory with its local vitest and config — the same
+ * resolution `npm test --workspace` gets — and `test-delta` reruns this
+ * exact string on the merge base when it fails, same as any suite command.
+ */
+function relatedTestCommand(dir: string, files: string[]): string {
+  return (
+    `npm exec --workspace=${shellArg(dir)} -- ` +
+    `vitest related --run ${files.map(shellArg).join(' ')}`
+  );
+}
+
 /** A command this run actually executed, and what it did. */
 export interface CommandResult {
   command: string;
@@ -935,6 +1002,19 @@ export function runBuildTest(args: BuildTestArgs): BuildTestReport {
       ? new Set(reverseDependencyClosure(notBuilt, scopeGraph))
       : new Set<string>();
   const notRun: string[] = [];
+  // File-scoping decisions, made up front so the command construction and
+  // the caveat below cannot disagree about what ran. Affected workspaces
+  // only — a dependent's suite imports BUILT output, which vitest's module
+  // graph cannot trace to the changed sources, so narrowing it would skip
+  // everything and call it coverage.
+  const fileScoped = new Map<string, string[]>();
+  if (testScope) {
+    for (const dir of runnableDirs) {
+      if (!affectedSet.has(dir)) continue;
+      const files = fileScopedChanges(root, dir, changed);
+      if (files) fileScoped.set(dir, files);
+    }
+  }
   for (let i = 0; i < runnableDirs.length; i++) {
     const dir = runnableDirs[i];
     if (untestable.has(dir)) {
@@ -948,10 +1028,35 @@ export function runBuildTest(args: BuildTestArgs): BuildTestReport {
       notRun.push(...runnableDirs.slice(i).filter((d) => !untestable.has(d)));
       break;
     }
-    const r = exec(testCommand(dir), root, Math.min(perCommandMs, remaining));
+    const scoped = fileScoped.get(dir);
+    const r = exec(
+      scoped ? relatedTestCommand(dir, scoped) : testCommand(dir),
+      root,
+      Math.min(perCommandMs, remaining),
+    );
     results.test.push(r);
     if (r.timedOut) results.timedOut.push(r.command);
     if (r.exitCode !== 0) results.ok = false;
+  }
+
+  // The narrowed scope is a claim the report must not make silently: the
+  // caveat names each file-scoped suite so the review can state what was
+  // NOT run (the rest of that workspace's suite), exactly as every other
+  // incomplete scope is disclosed.
+  if (testScope && fileScoped.size > 0) {
+    const scopedNote = [...fileScoped.entries()]
+      .map(
+        ([d, files]) =>
+          `${d} ran only the suites vitest traces to its ` +
+          `${files.length} changed file(s), not its whole suite`,
+      )
+      .join('; ');
+    testScope = {
+      ...testScope,
+      caveat: testScope.caveat
+        ? `${testScope.caveat}; ${scopedNote}`
+        : scopedNote,
+    };
   }
 
   // A budget stop is STRUCTURAL, not just prose: `testScope.workspaces` is


### PR DESCRIPTION
## What this PR does

`review build-test` file-scopes a micro diff's own test suite: at or below **three changed files** in an affected workspace, that workspace's test command becomes `npm exec --workspace=<dir> -- vitest related --run <files>` — exactly the suites vitest's module graph traces to the change — instead of `npm test --workspace=<dir>`.

The narrowing is confined to where it cannot under-test:

- **Affected workspace only.** A dependent's suite imports the package's *built* output, which the module graph cannot trace back to changed sources — a narrowed dependent run would skip everything and call it coverage. Dependents keep their full suites.
- **Every changed file must still exist** — a deletion breaks tests no import graph traces back to it.
- **The workspace's test script must run vitest**; anything else keeps the full suite.
- **Always disclosed** through `testScope.caveat`, so the review body states what was not run.

`test-delta` reruns the recorded command verbatim on the merge base, so a failing scoped run gets the same netNew measurement as any suite command.

## Why it's needed

Measured on the motivating diff (a 23-line, one-file `/demo`-page change, PR #8762): Agent 7 was the fan-out wave's critical path at 11.7 of 13 minutes — the full `packages/cli` suite (**796 test files / 18,612 tests**) ran for a diff whose related set is **53 files / 4,430 tests** (−76%), hit three unrelated environmental failures, and that forced the merge-base build + test-delta dance: five more minutes spent proving pre-existing failures pre-existed.

## Reviewer Test Plan

### How to verify

- `cd packages/cli && npx vitest run src/commands/review/build-test.test.ts src/commands/review/test-delta.test.ts` — 97 passed. New cases pin: the related command + caveat for a micro vitest diff; dependents keeping full suites; fallback to the full suite for >3 files, a deleted file, and a non-vitest test script.
- Real-repo probe: `npm exec --workspace=packages/cli -- vitest related --run "src/serve/demo.ts"` runs 53 files / 4,430 tests vs the package's 796 / 18,612.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

## Risk & Scope

- Over-inclusion is the failure direction `related` errs toward: a hub file traces to a large share of the suite (measured: `shell-quote.ts` → 3,831 tests) and simply saves less. Under-inclusion is fenced by the four gates above.
- No behavior change for diffs above the cap, non-vitest workspaces, single-package repos, or build-only probes.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

`review build-test` 对微型 diff 的自有套件做文件级收窄:受影响 workspace 内变更文件 ≤3 时,该 workspace 的测试命令从整套件换成 `vitest related --run <files>`——恰好是 vitest 模块图能追溯到变更的那些套件。

收窄被限制在不可能漏测的范围:仅受影响 workspace 自身(依赖方套件导入的是构建产物,模块图追不到源文件——依赖方保持全套件);所有变更文件必须仍存在(删除的文件没有导入图可追);test 脚本必须是 vitest;并始终通过 `testScope.caveat` 披露。`test-delta` 在 merge base 上原样重跑记录的命令,失败的收窄运行获得与任何套件相同的 netNew 测量。

## 为什么需要

实测动机 diff(#8762,23 行单文件 /demo 页改动):Agent 7 以 13 分钟扇出波里的 11.7 分钟成为关键路径——为一个 related 集只有 **53 文件 / 4,430 测试**的 diff 跑了 **796 文件 / 18,612 测试**的全套件(−76%),还撞上 3 个无关的环境性失败,进而触发 merge-base 构建 + test-delta 舞蹈:又花 5 分钟证明预存失败确实预存。

## 风险与范围

- `related` 的误差方向是过度包含:枢纽文件会追到大半套件(实测 `shell-quote.ts` → 3,831 测试),只是省得少。漏测方向被上述四道门挡住。
- 超过上限的 diff、非 vitest workspace、单包仓库、build-only 探测均无行为变化。

</details>
