### PR TITLE
fix(core): exclude hook context from auto titles

### DIFF
--- a/packages/core/src/services/sessionTitle.test.ts
+++ b/packages/core/src/services/sessionTitle.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Content } from '@google/genai';
 import type { Config } from '../config/config.js';
+import { wrapUserPromptSubmitContext } from '../utils/transcript-records.js';
 import {
   SYSTEM_REMINDER_CLOSE,
   SYSTEM_REMINDER_OPEN,
@@ -283,6 +284,41 @@ describe('tryGenerateSessionTitle', () => {
 
     expect(captured).not.toContain('MID_SESSION_TOOL_METADATA');
     expect(captured).toContain('please add a regression test');
+  });
+
+  it('excludes UserPromptSubmit hook context from the title prompt', async () => {
+    const history: Content[] = [
+      {
+        role: 'user',
+        parts: [
+          { text: 'Diagnose the parser CI failure.' },
+          {
+            text: wrapUserPromptSubmitContext(
+              'UNRELATED_MEMORY_TOPIC '.repeat(80),
+            ),
+          },
+        ],
+      },
+      {
+        role: 'model',
+        parts: [{ text: 'I will inspect the parser workflow.' }],
+      },
+    ];
+
+    let captured = '';
+    const { config } = makeConfig({
+      fastModel: 'qwen-turbo',
+      history,
+      generateJsonResult: async (opts: unknown) => {
+        captured = JSON.stringify((opts as { contents: Content[] }).contents);
+        return { title: 'Diagnose parser CI failure' };
+      },
+    });
+
+    await tryGenerateSessionTitle(config, new AbortController().signal);
+
+    expect(captured).toContain('Diagnose the parser CI failure.');
+    expect(captured).not.toContain('UNRELATED_MEMORY_TOPIC');
   });
 
   it('drops pure system-reminder messages from the title prompt', async () => {

--- a/packages/core/src/services/sessionTitle.ts
+++ b/packages/core/src/services/sessionTitle.ts
@@ -6,6 +6,7 @@
 
 import type { Content, Part } from '@google/genai';
 import type { Config } from '../config/config.js';
+import { stripTrailingUserPromptSubmitContextPart } from '../hooks/user-prompt-submit-context.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import {
   getStartupContextLength,
@@ -212,7 +213,8 @@ function filterToDialog(history: Content[]): Content[] {
   for (const msg of history.slice(getStartupContextLength(history))) {
     if (msg.role !== 'user' && msg.role !== 'model') continue;
     const textParts: Part[] = [];
-    for (const part of msg.parts ?? []) {
+    const parts = stripTrailingUserPromptSubmitContextPart(msg.parts ?? []);
+    for (const part of parts) {
       if (
         typeof part?.text !== 'string' ||
         part.text.trim() === '' ||


### PR DESCRIPTION
## What this PR does

Keeps UserPromptSubmit hook context out of automatic session-title generation while preserving the user's submitted prompt and ordinary conversation text.

## Why it's needed

Hook context is intentionally appended as a separate tagged part of the model-bound user message. The title side query currently keeps that part, so a long generic context block can fill its 1,000-character tail and displace the user's actual request.

## Reviewer Test Plan

### How to verify

Configure a UserPromptSubmit hook that returns a long `additionalContext` value, then generate an automatic title for a distinct user request. The title input should contain the request and exclude the tagged hook context. Existing title behavior without hook context should remain unchanged.

### Evidence (Before & After)

N/A — non-UI behavior covered by a focused regression test.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS arm64, Node.js v22.23.2, core package tests.

## Risk & Scope

- Main risk or tradeoff: Only a whole, trailing tagged UserPromptSubmit context part is removed; user-authored text and other dialog parts are preserved.
- Not validated / out of scope: No live model request or screenshot; this is a title-input preprocessing change.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #8758

<details>
<summary>中文说明</summary>

## 此 PR 的内容

在自动生成会话标题时排除 UserPromptSubmit hook 上下文，同时保留用户提交的原始请求和普通对话文本。

## 修复原因

Hook 上下文会作为带标签的独立 part 有意追加到发送给模型的用户消息中。当前标题 side query 也会保留这部分内容，因此长篇通用上下文可能填满 1,000 字符尾部，并挤掉用户真正的请求。

## 评审验证计划

### 验证方法

配置一个返回长 `additionalContext` 的 UserPromptSubmit hook，然后针对明确的用户请求生成自动标题。标题输入应包含该请求，并排除带标签的 hook 上下文；没有 hook 上下文时的既有标题行为应保持不变。

### 证据（修复前与修复后）

不适用——这是由聚焦回归测试覆盖的非 UI 行为修复。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|  🍏 macOS         | ✅ 已测试 |
| 🪟 Windows        | ⚠️ 未测试 |
|  🐧 Linux         | ⚠️ 未测试 |

### 环境（可选）

macOS arm64、Node.js v22.23.2、core 包测试。

## 风险与范围

- 主要风险或权衡：只移除完整且位于末尾的 UserPromptSubmit 上下文标签 part；用户文本和其他对话 part 都会保留。
- 未验证或不在范围内：没有使用真实模型请求，也没有截图；这是标题输入预处理修改。
- 破坏性变更或迁移说明：无。

## 关联 Issue

Fixes #8758

</details>
