### PR TITLE
fix(sdk): hide ACP usage updates from transcripts

### DIFF
--- a/packages/sdk-typescript/src/daemon/ui/normalizer.ts
+++ b/packages/sdk-typescript/src/daemon/ui/normalizer.ts
@@ -839,6 +839,7 @@ function normalizeSessionUpdate(
     case 'plan':
       return [normalizePlanUpdate(update, base)];
     case 'current_mode_update':
+    case 'usage_update':
       return [];
     default:
       return [

--- a/packages/sdk-typescript/test/unit/daemonUi.test.ts
+++ b/packages/sdk-typescript/test/unit/daemonUi.test.ts
@@ -2509,6 +2509,19 @@ describe('daemon UI normalizer — Wave 3/4 event coverage (PR-A)', () => {
     ]);
   });
 
+  it('does not surface usage_update as a debug transcript event', () => {
+    const events = normalizeDaemonEvent(
+      envelopeOf('session_update', {
+        update: {
+          sessionUpdate: 'usage_update',
+          used: 46_351,
+          size: 1_000_000,
+        },
+      }),
+    );
+    expect(events).toEqual([]);
+  });
+
   it('normalizes memory_changed with closed-enum scope + mode', () => {
     const events = normalizeDaemonEvent(
       envelopeOf('memory_changed', {


### PR DESCRIPTION
## What this PR does

This PR prevents the standard ACP `usage_update` notification from appearing as a raw debug row in daemon-backed transcripts. The notification remains available on the ACP wire for clients such as JetBrains, while Qwen's existing private usage metadata continues to drive detailed token accounting in Web Shell and other first-party consumers.

## Why it's needed

Qwen Code recently began emitting `usage_update` after live main-session model rounds so standard ACP clients can display context-window occupancy. The daemon UI normalizer did not recognize that update kind and fell through to its unknown-event debug projection, causing Web Shell to display internal JSON such as `usage_update: {"size":1000000,"used":46351,...}` in the conversation. This is a presentation-layer classification bug rather than an ACP emission problem, so the fix keeps the protocol event and excludes it only from transcript projection.

The regression was introduced by #8528 (`c2026882b7`, `fix(acp): emit context usage updates`), which correctly added the standard notification for JetBrains and other ACP clients. That change updated the ACP emitter and bridge behavior, but the daemon UI normalizer had no matching `usage_update` case, so it treated the newly known protocol frame as an unknown debug event.

## Reviewer Test Plan

### How to verify

Start a daemon-backed Web Shell session and send a prompt that triggers at least one model round, such as launching parallel subagents. Confirm that no raw `usage_update` JSON row appears in the transcript, while the normal assistant, thought, tool, and subagent content remains visible. Also confirm that private usage metadata still produces the existing token usage state.

### Evidence (Before & After)

Before: each live main-agent model round could add a visible debug transcript row containing the raw `usage_update` payload.
<img width="1250" height="290" alt="image" src="https://github.com/user-attachments/assets/7e64e765-3ca6-444e-ba7b-156f65105a22" />


After: the standard ACP notification is silently excluded from transcript messages, and the existing `_meta.usage` path remains unchanged. The regression test reproduces the exact standard payload shape and asserts that it produces no daemon UI transcript event.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS, local Node.js workspace, focused SDK unit tests and package validation.

## Risk & Scope

- Main risk or tradeoff: daemon UI transcript consumers no longer receive `usage_update` as a debug block; raw daemon event subscribers and standard ACP clients still receive the original notification.
- Not validated / out of scope: changing ACP usage semantics, adding `usage_update` as a Web Shell connection-state fallback, JetBrains UI rendering, and per-subagent token reporting.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本 PR 防止 ACP 标准 `usage_update` 通知在 daemon 驱动的会话中显示成原始调试信息。该通知仍保留在 ACP 线协议中，供 JetBrains 等客户端消费；Qwen 现有的私有 usage metadata 也保持不变，继续为 Web Shell 和其他第一方消费者提供详细 token 统计。

## 为什么需要

Qwen Code 最近开始在主会话的实时模型轮次结束后发送 `usage_update`，使标准 ACP 客户端可以显示上下文窗口占用。但是 daemon UI normalizer 不认识这种 update，因而落入未知事件的 debug 投影，导致 Web Shell 在对话中显示 `usage_update: {"size":1000000,"used":46351,...}` 之类的内部 JSON。这是展示层的事件分类问题，而不是 ACP 发送问题，因此本修复保留协议事件，只将它从 transcript 投影中排除。

这个回归由 #8528（`c2026882b7`，`fix(acp): emit context usage updates`）引入。该改动正确地为 JetBrains 和其他 ACP 客户端增加了标准通知，并更新了 ACP emitter 与 bridge 行为，但 daemon UI normalizer 没有同步增加 `usage_update` 分支，因此把这个新出现的已知协议帧当成未知 debug 事件处理。

## 审查者测试计划

### 验证方法

启动 daemon 驱动的 Web Shell 会话，发送一个会触发至少一轮模型调用的请求，例如启动并行 subagent。确认 transcript 中不再出现原始 `usage_update` JSON 行，同时正常的 assistant、thought、tool 和 subagent 内容仍然可见。还应确认私有 usage metadata 仍会更新现有 token usage 状态。

### 证据（修复前与修复后）

修复前：主 agent 每轮实时模型调用都可能在 transcript 中增加一行可见的 `usage_update` 原始 payload。

修复后：ACP 标准通知会被静默排除在 transcript 消息之外，现有 `_meta.usage` 路径保持不变。回归测试使用真实的标准 payload 形状复现问题，并断言其不会产生 daemon UI transcript 事件。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS、本地 Node.js workspace、聚焦的 SDK 单元测试与 package 验证。

## 风险与范围

- 主要风险或权衡：daemon UI transcript 消费者不再把 `usage_update` 收到为 debug block；原始 daemon event 订阅者和标准 ACP 客户端仍会收到原通知。
- 未验证 / 范围外：改变 ACP usage 语义、把 `usage_update` 增加为 Web Shell connection state 的回退来源、JetBrains UI 渲染以及每个 subagent 的 token 统计。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>


