### PR TITLE
fix(tests): await rig setup in Qoder plugin install integration test

### DIFF
--- a/integration-tests/cli/extensions-install.test.ts
+++ b/integration-tests/cli/extensions-install.test.ts
@@ -53,7 +53,7 @@ test('installs a local extension, verifies a command, and updates it', async () 
 
 test('installs a local Qoder plugin', async () => {
   const rig = new TestRig();
-  rig.setup('qoder plugin install test');
+  await rig.setup('qoder plugin install test');
   const manifestDir = join(rig.testDir!, '.qoder-plugin');
   mkdirSync(manifestDir, { recursive: true });
   writeFileSync(


### PR DESCRIPTION
## What this PR does

Awaits the test-rig setup call in the Qoder plugin install integration test, matching the sibling extension install test which already awaits it. The setup routine clears and recreates the test directory before each case; without the await, that recursive delete runs concurrently with the test body writing the plugin manifest fixtures, so on a loaded runner the delete can land after the fixtures exist and wipe them out.

## Why it's needed

The nightly release and main CI keep failing on this test with `Configuration file not found` for the extension manifest. The failure is a load-dependent race inside the test itself — the install code path works correctly whenever the fixtures survive — so it flaps across runs and blocks releases without any product defect. This was the root cause behind the #8766 CI failure and the failed v0.21.8 nightly release tracked in #8771.

## Reviewer Test Plan

### How to verify

Build the bundle and run the affected integration test without sandbox: `npm run build && npm run bundle`, then `cd integration-tests && QWEN_SANDBOX=false npx vitest run cli/extensions-install.test.ts`. Both cases should pass deterministically. Verified locally: 2 passed (2), the Qoder plugin case in ~2.2s.

### Evidence (Before & After)

N/A — test-only change, no user-visible behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local integration test run against the bundled CLI with `QWEN_SANDBOX=false`.

## Risk & Scope

- Main risk or tradeoff: none — the change only makes the test wait for its own directory reset to finish, which is what the sibling test already does.
- Not validated / out of scope: repeated-load reproduction on CI runners; the race is timing-dependent, but awaiting the setup removes the ordering hazard entirely.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #8766
Related: #8771 (same root cause behind the failed nightly release)

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

给 Qoder 插件安装集成测试中的测试夹具初始化调用补上缺失的 `await`，与旁边已经正确 await 的扩展安装测试保持一致。夹具初始化会在每个用例开始前清空并重建测试目录；不 await 的话，这个递归删除会与测试体写入插件 manifest 夹具的操作并发执行，在负载较高的 runner 上，删除可能落在夹具写入之后，把刚写好的文件删掉。

## 为什么需要

nightly release 和主 CI 反复因为这个测试报 `Configuration file not found`（找不到扩展 manifest）。这是测试自身的负载敏感竞态——只要夹具存活，安装路径本身完全正常——所以它在不同 run 之间时好时坏，在没有产品缺陷的情况下阻塞发布。#8766 的 CI 失败和 #8771 跟踪的 v0.21.8 nightly release 失败，根因都是它。

## 评审验证计划

### 如何验证

构建 bundle 后在无沙箱模式下运行受影响的集成测试：`npm run build && npm run bundle`，然后 `cd integration-tests && QWEN_SANDBOX=false npx vitest run cli/extensions-install.test.ts`。两个用例应稳定通过。本地已验证：2 passed (2)，其中 Qoder 插件用例约 2.2 秒。

### 前后对比证据

N/A——纯测试改动，无用户可见行为变化。

### 测试环境

macOS 已验证；Windows / Linux 依赖 CI。

### 运行环境（可选）

本地以 `QWEN_SANDBOX=false` 对打包后的 CLI 运行集成测试。

## 风险与范围

- 主要风险或权衡：无——改动只是让测试等待自身目录重置完成，旁边的兄弟测试本来就是这么做的。
- 未验证 / 不在范围内：在高负载 CI runner 上反复复现；竞态依赖时序，但 await 初始化已从根本上消除了该顺序隐患。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #8766
相关：#8771（nightly release 失败的同一根因）

</details>
