### PR TITLE
fix(test): deflake three CI-load-sensitive tests

### DIFF
--- a/packages/cli/src/commands/review/lib/manifest-repository-context.test.ts
+++ b/packages/cli/src/commands/review/lib/manifest-repository-context.test.ts
@@ -32,12 +32,15 @@ function temp(): string {
 }
 
 // Several fixtures hold 16k-entry trees; leaking them exhausts a tmpfs
-// /tmp within a handful of runs.
+// /tmp within a handful of runs. Deleting them is tens of thousands of
+// unlinks, which has blown past the default 10s hook timeout on a loaded
+// CI runner — give the teardown the time it needs rather than failing a
+// green suite on cleanup.
 afterAll(() => {
   for (const root of worktrees) {
     rmSync(root, { recursive: true, force: true });
   }
-});
+}, 120_000);
 
 function write(path: string, content = ''): void {
   mkdirSync(dirname(path), { recursive: true });

--- a/packages/core/src/memory/extract.test.ts
+++ b/packages/core/src/memory/extract.test.ts
@@ -44,13 +44,20 @@ function deferred<T>() {
 }
 
 async function waitForMockCall(mock: { mock: { calls: unknown[] } }) {
-  for (let i = 0; i < 10; i++) {
+  // Wall-clock deadline, not a fixed tick count: the mock is invoked after
+  // real async work (index reads, cursor I/O), and ten zero-delay turns can
+  // elapse before that work completes on a loaded CI runner — the poll spun
+  // through its turns without waiting any actual time.
+  const deadline = Date.now() + 2000;
+  for (;;) {
     if (mock.mock.calls.length > 0) {
       return;
     }
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    if (Date.now() >= deadline) {
+      throw new Error('Expected mock to be called');
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
   }
-  throw new Error('Expected mock to be called');
 }
 
 describe('auto-memory extraction', () => {

--- a/packages/core/src/services/backgroundShellRegistry.test.ts
+++ b/packages/core/src/services/backgroundShellRegistry.test.ts
@@ -669,73 +669,95 @@ describe('BackgroundShellRegistry', () => {
     });
   });
 
+  // Every register/complete in these loop tests also writes the status
+  // sidecar through atomicWriteFileSync, and a loaded CI runner has been
+  // measured spending ~700ms per sidecar write — ~50s for the ~70 writes
+  // of the longest loop, past the 15s default. The explicit timeout buys
+  // the I/O the time it costs; the assertions are unchanged.
+  const SIDECAR_IO_TIMEOUT = 120_000;
   describe('terminal-entry retention cap', () => {
-    it('retains only a bounded number of terminal entries (oldest by endTime evicted)', () => {
-      const reg = new BackgroundShellRegistry();
-      // Register and complete one more entry than the cap allows. Use
-      // strictly increasing endTimes so eviction order is deterministic.
-      for (let i = 0; i < MAX_RETAINED_TERMINAL_SHELLS + 2; i++) {
-        reg.register(makeEntry({ shellId: `s-${i}`, startTime: i * 10 }));
-        reg.complete(`s-${i}`, 0, i * 10 + 5);
-      }
-      expect(reg.getAll()).toHaveLength(MAX_RETAINED_TERMINAL_SHELLS);
-      // The two oldest (`s-0`, `s-1`) get pruned; the newest survives.
-      expect(reg.get('s-0')).toBeUndefined();
-      expect(reg.get('s-1')).toBeUndefined();
-      expect(reg.get(`s-${MAX_RETAINED_TERMINAL_SHELLS + 1}`)).toBeDefined();
-    });
+    it(
+      'retains only a bounded number of terminal entries (oldest by endTime evicted)',
+      () => {
+        const reg = new BackgroundShellRegistry();
+        // Register and complete one more entry than the cap allows. Use
+        // strictly increasing endTimes so eviction order is deterministic.
+        for (let i = 0; i < MAX_RETAINED_TERMINAL_SHELLS + 2; i++) {
+          reg.register(makeEntry({ shellId: `s-${i}`, startTime: i * 10 }));
+          reg.complete(`s-${i}`, 0, i * 10 + 5);
+        }
+        expect(reg.getAll()).toHaveLength(MAX_RETAINED_TERMINAL_SHELLS);
+        // The two oldest (`s-0`, `s-1`) get pruned; the newest survives.
+        expect(reg.get('s-0')).toBeUndefined();
+        expect(reg.get('s-1')).toBeUndefined();
+        expect(reg.get(`s-${MAX_RETAINED_TERMINAL_SHELLS + 1}`)).toBeDefined();
+      },
+      SIDECAR_IO_TIMEOUT,
+    );
 
-    it('never evicts running entries even when the cap is exceeded', () => {
-      const reg = new BackgroundShellRegistry();
-      // Register one extra terminal entry beyond the cap, then a single
-      // running entry. The running entry must be retained regardless of
-      // its launch order — pruning a still-running shell would lose the
-      // user's only handle on a live process.
-      reg.register(makeEntry({ shellId: 'live', startTime: 1 }));
-      for (let i = 0; i < MAX_RETAINED_TERMINAL_SHELLS + 1; i++) {
+    it(
+      'never evicts running entries even when the cap is exceeded',
+      () => {
+        const reg = new BackgroundShellRegistry();
+        // Register one extra terminal entry beyond the cap, then a single
+        // running entry. The running entry must be retained regardless of
+        // its launch order — pruning a still-running shell would lose the
+        // user's only handle on a live process.
+        reg.register(makeEntry({ shellId: 'live', startTime: 1 }));
+        for (let i = 0; i < MAX_RETAINED_TERMINAL_SHELLS + 1; i++) {
+          reg.register(
+            makeEntry({ shellId: `done-${i}`, startTime: 100 + i * 10 }),
+          );
+          reg.complete(`done-${i}`, 0, 100 + i * 10 + 5);
+        }
+        // Cap-of-32 terminals + 1 running survivor = 33 entries kept.
+        expect(reg.getAll()).toHaveLength(MAX_RETAINED_TERMINAL_SHELLS + 1);
+        expect(reg.get('live')?.status).toBe('running');
+        // The oldest terminal entry (lowest endTime) is the one evicted.
+        expect(reg.get('done-0')).toBeUndefined();
+      },
+      SIDECAR_IO_TIMEOUT,
+    );
+
+    it(
+      'prunes after fail() too, not just complete()',
+      () => {
+        const reg = new BackgroundShellRegistry();
+        for (let i = 0; i < MAX_RETAINED_TERMINAL_SHELLS; i++) {
+          reg.register(makeEntry({ shellId: `done-${i}`, startTime: i * 10 }));
+          reg.complete(`done-${i}`, 0, i * 10 + 5);
+        }
+        const overflowStart = MAX_RETAINED_TERMINAL_SHELLS * 10 + 100;
         reg.register(
-          makeEntry({ shellId: `done-${i}`, startTime: 100 + i * 10 }),
+          makeEntry({ shellId: 'overflow', startTime: overflowStart }),
         );
-        reg.complete(`done-${i}`, 0, 100 + i * 10 + 5);
-      }
-      // Cap-of-32 terminals + 1 running survivor = 33 entries kept.
-      expect(reg.getAll()).toHaveLength(MAX_RETAINED_TERMINAL_SHELLS + 1);
-      expect(reg.get('live')?.status).toBe('running');
-      // The oldest terminal entry (lowest endTime) is the one evicted.
-      expect(reg.get('done-0')).toBeUndefined();
-    });
+        reg.fail('overflow', 'boom', overflowStart + 5);
+        expect(reg.getAll()).toHaveLength(MAX_RETAINED_TERMINAL_SHELLS);
+        expect(reg.get('done-0')).toBeUndefined();
+        expect(reg.get('overflow')?.status).toBe('failed');
+      },
+      SIDECAR_IO_TIMEOUT,
+    );
 
-    it('prunes after fail() too, not just complete()', () => {
-      const reg = new BackgroundShellRegistry();
-      for (let i = 0; i < MAX_RETAINED_TERMINAL_SHELLS; i++) {
-        reg.register(makeEntry({ shellId: `done-${i}`, startTime: i * 10 }));
-        reg.complete(`done-${i}`, 0, i * 10 + 5);
-      }
-      const overflowStart = MAX_RETAINED_TERMINAL_SHELLS * 10 + 100;
-      reg.register(
-        makeEntry({ shellId: 'overflow', startTime: overflowStart }),
-      );
-      reg.fail('overflow', 'boom', overflowStart + 5);
-      expect(reg.getAll()).toHaveLength(MAX_RETAINED_TERMINAL_SHELLS);
-      expect(reg.get('done-0')).toBeUndefined();
-      expect(reg.get('overflow')?.status).toBe('failed');
-    });
-
-    it('prunes after cancel() too, not just complete()', () => {
-      const reg = new BackgroundShellRegistry();
-      for (let i = 0; i < MAX_RETAINED_TERMINAL_SHELLS; i++) {
-        reg.register(makeEntry({ shellId: `done-${i}`, startTime: i * 10 }));
-        reg.complete(`done-${i}`, 0, i * 10 + 5);
-      }
-      const overflowStart = MAX_RETAINED_TERMINAL_SHELLS * 10 + 100;
-      reg.register(
-        makeEntry({ shellId: 'overflow', startTime: overflowStart }),
-      );
-      reg.cancel('overflow', overflowStart + 5);
-      expect(reg.getAll()).toHaveLength(MAX_RETAINED_TERMINAL_SHELLS);
-      expect(reg.get('done-0')).toBeUndefined();
-      expect(reg.get('overflow')?.status).toBe('cancelled');
-    });
+    it(
+      'prunes after cancel() too, not just complete()',
+      () => {
+        const reg = new BackgroundShellRegistry();
+        for (let i = 0; i < MAX_RETAINED_TERMINAL_SHELLS; i++) {
+          reg.register(makeEntry({ shellId: `done-${i}`, startTime: i * 10 }));
+          reg.complete(`done-${i}`, 0, i * 10 + 5);
+        }
+        const overflowStart = MAX_RETAINED_TERMINAL_SHELLS * 10 + 100;
+        reg.register(
+          makeEntry({ shellId: 'overflow', startTime: overflowStart }),
+        );
+        reg.cancel('overflow', overflowStart + 5);
+        expect(reg.getAll()).toHaveLength(MAX_RETAINED_TERMINAL_SHELLS);
+        expect(reg.get('done-0')).toBeUndefined();
+        expect(reg.get('overflow')?.status).toBe('cancelled');
+      },
+      SIDECAR_IO_TIMEOUT,
+    );
   });
 
   describe('cancel', () => {


### PR DESCRIPTION
## What this PR does

Deflakes two test-infrastructure failure modes that only appear under CI load, both observed on PR #8773's `Test (ubuntu-latest, Node 22.x)` runs. Product code is untouched.

- **Auto-memory extract tests** (`packages/core/src/memory/extract.test.ts`): `waitForMockCall` now waits against a 2 s wall-clock deadline instead of ten zero-delay event-loop turns. The fast path is unchanged — the helper still returns on the first check when the mock has already fired.
- **Manifest-context fixture teardown** (`packages/cli/src/commands/review/lib/manifest-repository-context.test.ts`): the `afterAll` that deletes several 16k-entry fixture trees gets an explicit 120 s hook timeout instead of vitest's 10 s default.
- **Shell-registry retention-cap tests** (`packages/core/src/services/backgroundShellRegistry.test.ts`): the four eviction-loop tests get an explicit 120 s test timeout — each loop iteration also writes the status sidecar through `atomicWriteFileSync`, and loaded runners were measured at ~700 ms per sidecar write, putting the longest loop (~70 writes) near 50 s against the 15 s default.

## Why it's needed

Three independent green-suite-killed-by-infrastructure flakes:

- `waitForMockCall` polled `setTimeout(0)` ten times and gave up. The mocks it waits for fire only after real async work (index rebuilds, cursor I/O), so on a loaded runner the poll spun through its ten turns without waiting any actual time, and two rebuild-isolation tests failed with `Expected mock to be called` ([run](https://github.com/QwenLM/qwen-code/actions/runs/31290408997/job/93186484900)). The same file passes locally in ~3 s repeatedly.
- The manifest-context suite passed all 59 of its tests, then failed on teardown: deleting the 16k-entry trees is tens of thousands of unlinks, which blew past the default 10 s hook timeout on a loaded runner ([run](https://github.com/QwenLM/qwen-code/actions/runs/31300894297/job/93213384675)). The cleanup itself must stay — leaking the fixtures exhausts a tmpfs `/tmp` within a handful of runs — it just needs the time it takes.
- The four retention-cap tests timed out at 15 s on two consecutive runs on two *different* runners ([hk](https://github.com/QwenLM/qwen-code/actions/runs/31300894297/job/93215250035), [runner-17](https://github.com/QwenLM/qwen-code/actions/runs/31300894297/job/93217949737)), at ~23 s each, while every neighbouring single-write test in the suite ran ~700 ms — the per-sidecar-write cost under load, times the loop length. Locally the whole suite finishes in well under a second. (That ~700 ms per atomic write to `/tmp` is itself worth a look at the runner infrastructure, but the tests should not be the canary.)

## Reviewer Test Plan

### How to verify

- `cd packages/core && npx vitest run src/memory/extract.test.ts` — 18 passed.
- `cd packages/cli && npx vitest run src/commands/review/lib/manifest-repository-context.test.ts` — 59 passed, 1 skipped.
- `cd packages/core && npx vitest run src/services/backgroundShellRegistry.test.ts` — 57 passed.
- Failure modes are preserved: a mock that never fires still throws `Expected mock to be called` (after 2 s); a genuinely wedged teardown still times out (after 120 s).

### Evidence (Before & After)

N/A — test-only change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

## Risk & Scope

- Main risk or tradeoff: genuine failures in these spots now take longer to surface (2 s / 120 s instead of milliseconds / defaults) — bounded, test-only.
- Not validated / out of scope: the extraction and manifest-context production code paths are untouched.
- Breaking changes / migration notes: none.

## Linked Issues

Both flakes first observed on #8773's CI runs.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修复两个仅在 CI 高负载下出现的测试基建性失败,均见于 PR #8773 的 `Test (ubuntu-latest, Node 22.x)` 运行。产品代码零改动。

- **auto-memory 抽取测试**(`packages/core/src/memory/extract.test.ts`):`waitForMockCall` 改为按 2 秒真实时钟截止等待,替代十次零延迟事件循环轮询。快速路径不变——mock 已触发时仍在第一次检查即返回。
- **manifest-context fixture 清理**(`packages/cli/src/commands/review/lib/manifest-repository-context.test.ts`):删除多个 1.6 万条目 fixture 树的 `afterAll` 获得显式 120 秒钩子超时,替代 vitest 默认的 10 秒。

## 为什么需要

三个相互独立的「套件全绿、被基建杀死」的 flake:

- `waitForMockCall` 以 `setTimeout(0)` 轮询十次即放弃。它等待的 mock 在真实异步工作(索引重建、游标 I/O)完成后才触发,高负载 runner 上轮询在未等待任何实际时间的情况下耗尽十轮,两个 rebuild-isolation 测试以 `Expected mock to be called` 失败。同一文件本地反复运行约 3 秒全部通过。
- manifest-context 套件 59 个测试全部通过后在清理阶段失败:删除 1.6 万条目的树是数万次 unlink,高负载 runner 上超过默认 10 秒钩子超时。清理本身必须保留——泄漏 fixture 几次运行就会耗尽 tmpfs 的 `/tmp`——它只是需要它实际所需的时间。
- 四个 retention-cap 测试在两个*不同* runner 上连续两次以 15 秒超时失败(每个约 23 秒),而同套件中相邻的单次写入测试各约 700ms——即高负载下每次 sidecar 原子写的成本乘以循环长度;本地整个套件不到一秒跑完。(对 `/tmp` 的原子写要 700ms 这件事本身值得排查 runner 基建,但测试不应当这只金丝雀。)

## 风险与范围

- 主要权衡:这些位置的真实失败暴露得更慢(2 秒/120 秒,原为毫秒级/默认值)——有界且仅限测试。
- 未验证/范围外:抽取与 manifest-context 的产品代码路径未改动。
- 破坏性变更:无。

</details>
