### PR TITLE
fix(desktop): keep Local Control controls above the fold

### DIFF
--- a/packages/desktop-shell/bootstrap/local-control.html
+++ b/packages/desktop-shell/bootstrap/local-control.html
@@ -19,7 +19,7 @@
         box-sizing: border-box;
       }
       body {
-        min-width: 420px;
+        min-width: 400px;
         min-height: 100vh;
         margin: 0;
         background:
@@ -34,8 +34,8 @@
       .card {
         display: flex;
         flex-direction: column;
-        gap: 12px;
-        padding: 18px;
+        gap: 10px;
+        padding: 16px;
         border: 1px solid #ffffff16;
         border-radius: 22px;
         background: #111827e8;
@@ -76,18 +76,18 @@
       #inactive,
       #active {
         display: grid;
-        gap: 10px;
+        gap: 8px;
       }
       .qr {
         display: grid;
         place-items: center;
-        min-height: 210px;
+        min-height: 184px;
         border-radius: 18px;
         background: #ffffff;
       }
       .qr svg {
-        width: 190px;
-        height: 190px;
+        width: 168px;
+        height: 168px;
       }
       .url {
         padding: 9px 10px;
@@ -149,7 +149,7 @@
         <header>
           <div>
             <h1>Local Control</h1>
-            <p>Continue the same Qwen Code session from your phone.</p>
+            <p>Continue this session from your phone.</p>
           </div>
           <span id="badge" class="badge">Off</span>
         </header>

--- a/packages/desktop-shell/bootstrap/local-control.js
+++ b/packages/desktop-shell/bootstrap/local-control.js
@@ -26,8 +26,8 @@ function render(state) {
   qr.innerHTML = enabled ? state.qrSvg || '' : '';
   url.textContent = enabled ? state.url || '' : '';
   sleep.textContent = state.sleepInhibited
-    ? 'Private network only · Unencrypted · Disconnect before changing networks · Computer stays awake'
-    : 'Private network only · Unencrypted · Disconnect before changing networks · Computer may sleep';
+    ? 'Trusted Wi-Fi · Unencrypted · Re-enable after network changes'
+    : 'Trusted Wi-Fi · Unencrypted · May sleep · Re-enable after network changes';
   error.hidden = true;
   error.textContent = '';
 }

--- a/packages/desktop-shell/src-tauri/src/main.rs
+++ b/packages/desktop-shell/src-tauri/src/main.rs
@@ -537,8 +537,8 @@ fn show_local_control_window(app: &AppHandle) -> Result<(), String> {
         WebviewUrl::App("local-control.html".into()),
     )
     .title("Qwen Code Local Control")
-    .inner_size(460.0, 720.0)
-    .min_inner_size(420.0, 560.0)
+    .inner_size(440.0, 500.0)
+    .min_inner_size(400.0, 500.0)
     .resizable(false)
     .build()
     .map(|_| ())


### PR DESCRIPTION
## What this PR does

Compacts the Local Control dialog so the QR code, pairing link, network warning, and disconnect action stay visible together without vertical scrolling. It reduces unused spacing and window height while keeping the full pairing link available.

## Why it's needed

After #8727 merged, the Local Control window could take more vertical space than necessary, making the primary disconnect action easy to miss on a smaller display.

## Reviewer Test Plan

### How to verify

Open Local Control from the Desktop menu and enable it. Confirm that the QR code, complete pairing URL, trusted-network warning, and Disconnect phone access button are all visible at once. The default content viewport is 440 x 500; the compact 400 x 500 render also remains free of vertical scrolling.

### Evidence (Before & After)

A separate UI verification comment includes the credential-redacted compact-state screenshot and measured viewport results.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ packaged app bundle built and layout verified |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS arm64, packaged Tauri app. Desktop release helper, 26 Rust tests, Cargo clippy, Prettier, and JavaScript syntax checks pass. The updater archive was not signed locally because the release signing private key is unavailable.

## Risk & Scope

- Main risk or tradeoff: the QR is rendered slightly smaller but remains a crisp SVG; the complete pairing URL is still shown.
- Not validated / out of scope: phone scanning distance and Windows/Linux native window rendering.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #8727 and #8595.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

压缩 Local Control 弹框，让二维码、完整配对链接、网络提示和断开按钮可以同时显示，不需要纵向滚动。减少了多余间距和窗口高度，同时保留完整配对链接。

## 为什么需要

#8727 合入后，Local Control 窗口占用的纵向空间仍然偏多，在较小屏幕上容易让主要的断开操作不够显眼。

## Reviewer 测试计划

### 如何验证

从 Desktop 菜单打开并启用 Local Control，确认二维码、完整配对 URL、可信网络提示和 Disconnect phone access 按钮可以同时看到。默认内容视口为 440 x 500；400 x 500 的紧凑视口也不会出现纵向滚动。

### 前后证据

单独的 UI 验证评论会附上已遮蔽凭证的紧凑状态截图和视口测量结果。

### 验证平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | ✅ 已生成打包 App，并完成布局验证 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境

macOS arm64，Tauri 打包 App。Desktop release helper、26 个 Rust 测试、Cargo clippy、Prettier 和 JavaScript 语法检查均通过。本地没有发布签名私钥，因此未签名 updater 归档。

## 风险与范围

- 主要风险或取舍：二维码显示尺寸略有减小，但仍为清晰的 SVG；完整配对链接仍然保留。
- 未验证或不在范围内：手机扫码距离，以及 Windows/Linux 原生窗口渲染。
- 破坏性变更或迁移说明：无。

## 关联事项

#8727 和 #8595 的后续修正。

</details>
