### PR TITLE
fix(memory): recall relevant topics beyond scan cap

### DIFF
--- a/docs/design/2026-08-09-bounded-memory-recall-candidates.md
+++ b/docs/design/2026-08-09-bounded-memory-recall-candidates.md
@@ -1,0 +1,56 @@
+# Bounded Memory Recall Candidates
+
+## Problem
+
+The project and user memory scanners enumerate, read, and parse every topic,
+then return only the 200 most recent documents. Recall uses those shared scanner
+APIs, so an older relevant document outside either 200-document window cannot
+reach the heuristic or model selector even though the expensive scan work has
+already happened.
+
+The same capped APIs are also used by Forget, Indexer, Status, and Extraction.
+Removing their limit globally would widen unrelated behavior.
+
+## Decision
+
+Keep the existing scanner APIs and their 200-document limit unchanged. Add
+explicit all-topic variants used only by recall.
+
+Recall ranks the combined project and user pool before model selection:
+
+- retain up to 180 documents with a lexical match using the existing scorer;
+- fill the remaining candidate slots by recency, preserving at least 20 recent
+  opportunities when enough lexical matches exist;
+- send at most 200 candidates to the model selector;
+- append manifest entries only while their cumulative UTF-8 size remains at or
+  below 25,000 bytes;
+- validate selector output only against documents actually present in that
+  bounded manifest.
+
+The heuristic fallback continues to score the complete recall pool and still
+returns at most five documents. Existing body and prompt limits remain
+unchanged.
+
+## Failure and compatibility boundaries
+
+Project scanning remains required. User scanning remains best-effort. Invalid
+or unreadable files keep the existing skip behavior. Empty candidate manifests
+return no model selection rather than sending an unbounded request.
+
+There is no public setting, persistent index, new dependency, provider API, or
+Fast/Refined state machine. Recall still performs an O(n) local pass over the
+already parsed documents; a persistent catalog requires separate measurement
+and evidence.
+
+## Verification
+
+- A deliberately old relevant topic beyond the regular 200-document result is
+  recalled from a real temporary memory tree.
+- The regular scanner still returns 200 documents and omits that topic.
+- The model candidate set contains the lexical target and recent reserve while
+  remaining at 200 documents.
+- A manifest built from large multibyte descriptions stays within 25,000 UTF-8
+  bytes.
+- The deterministic CLI E2E selects the overflow topic and exposes its unique
+  marker at the ToolResult delivery point after the bounded initial wait
+  expires.

--- a/packages/core/src/memory/memoryLifecycle.integration.test.ts
+++ b/packages/core/src/memory/memoryLifecycle.integration.test.ts
@@ -229,4 +229,65 @@ describe('managed auto-memory lifecycle integration', () => {
     expect(recall.prompt).toContain('user/');
     expect(recall.prompt).toContain('reference/');
   });
+
+  it('recalls a relevant topic beyond the general 200-document scan cap', async () => {
+    const referenceDir = path.dirname(
+      getAutoMemoryFilePath(projectRoot, 'reference/filler-000.md'),
+    );
+    await fs.mkdir(referenceDir, { recursive: true });
+    await Promise.all(
+      Array.from({ length: 200 }, (_, index) =>
+        fs.writeFile(
+          path.join(
+            referenceDir,
+            `filler-${String(index).padStart(3, '0')}.md`,
+          ),
+          [
+            '---',
+            'type: reference',
+            `name: Filler ${index}`,
+            'description: Unrelated historical note',
+            '---',
+            '',
+            'No matching content.',
+          ].join('\n'),
+          'utf-8',
+        ),
+      ),
+    );
+
+    const targetPath = getAutoMemoryFilePath(
+      projectRoot,
+      'reference/overflow-target.md',
+    );
+    await fs.writeFile(
+      targetPath,
+      [
+        '---',
+        'type: reference',
+        'name: Overflow Zephyr Marker',
+        'description: Unique recall target beyond the general scan cap',
+        '---',
+        '',
+        'The saved codeword is OVERFLOW-ZEPHYR-7040.',
+      ].join('\n'),
+      'utf-8',
+    );
+    await fs.utimes(targetPath, new Date(0), new Date(0));
+
+    const cappedDocs = await scanAutoMemoryTopicDocuments(projectRoot);
+    expect(cappedDocs).toHaveLength(200);
+    expect(cappedDocs.some((doc) => doc.filePath === targetPath)).toBe(false);
+
+    const recall = await resolveRelevantAutoMemoryPromptForQuery(
+      projectRoot,
+      'What is the overflow zephyr codeword?',
+    );
+
+    expect(recall.strategy).toBe('heuristic');
+    expect(recall.selectedDocs.map((doc) => doc.filePath)).toContain(
+      targetPath,
+    );
+    expect(recall.prompt).toContain('OVERFLOW-ZEPHYR-7040');
+  });
 });

--- a/packages/core/src/memory/recall.test.ts
+++ b/packages/core/src/memory/recall.test.ts
@@ -514,14 +514,10 @@ describe('auto-memory relevant recall', () => {
     vi.mocked(scanAllAutoMemoryTopicDocuments).mockResolvedValue(
       activeToolDocs,
     );
+    let modelCandidates: ScannedAutoMemoryDocument[] = [];
     vi.mocked(selectRelevantAutoMemoryDocumentsByModel).mockImplementation(
       async (_config, _query, candidates) => {
-        expect(candidates.map((doc) => doc.filePath)).not.toContain(
-          '/tmp/ata-tool.md',
-        );
-        expect(candidates.map((doc) => doc.filePath)).toContain(
-          '/tmp/ata-gotcha.md',
-        );
+        modelCandidates = candidates;
         throw new Error('selector failed');
       },
     );
@@ -535,6 +531,12 @@ describe('auto-memory relevant recall', () => {
       },
     );
 
+    expect(modelCandidates.map((doc) => doc.filePath)).not.toContain(
+      '/tmp/ata-tool.md',
+    );
+    expect(modelCandidates.map((doc) => doc.filePath)).toContain(
+      '/tmp/ata-gotcha.md',
+    );
     expect(result.strategy).toBe('heuristic');
     expect(result.selectedDocs.map((doc) => doc.filePath)).not.toContain(
       '/tmp/ata-tool.md',

--- a/packages/core/src/memory/recall.test.ts
+++ b/packages/core/src/memory/recall.test.ts
@@ -481,8 +481,8 @@ describe('auto-memory relevant recall', () => {
     const modelCandidates = vi.mocked(selectRelevantAutoMemoryDocumentsByModel)
       .mock.calls[0]![2];
     expect(modelCandidates).toHaveLength(200);
-    expect(modelCandidates.slice(0, 20)).toEqual(recentDocs);
-    expect(modelCandidates[20]).toBe(lexicalTarget);
+    expect(modelCandidates[0]).toBe(lexicalTarget);
+    expect(modelCandidates.slice(-20)).toEqual(recentDocs);
     expect(result.selectedDocs).toEqual([lexicalTarget]);
   });
 

--- a/packages/core/src/memory/recall.test.ts
+++ b/packages/core/src/memory/recall.test.ts
@@ -12,19 +12,19 @@ import {
 } from './recall.js';
 import type { ScannedAutoMemoryDocument } from './scan.js';
 import type { Config } from '../config/config.js';
-import { scanAutoMemoryTopicDocuments } from './scan.js';
+import { scanAllAutoMemoryTopicDocuments } from './scan.js';
 import { selectRelevantAutoMemoryDocumentsByModel } from './relevanceSelector.js';
 
 vi.mock('./scan.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./scan.js')>();
   return {
     ...actual,
-    scanAutoMemoryTopicDocuments: vi.fn(),
+    scanAllAutoMemoryTopicDocuments: vi.fn(),
     // Explicit mock — recall now unions user-level docs into the pool, so
     // leaving this on the real implementation would silently fall through
     // to the filesystem (only "works" because the path doesn't exist and
     // listMarkdownFiles swallows ENOENT). Defaults to an empty pool.
-    scanUserAutoMemoryTopicDocuments: vi.fn().mockResolvedValue([]),
+    scanAllUserAutoMemoryTopicDocuments: vi.fn().mockResolvedValue([]),
   };
 });
 
@@ -413,7 +413,7 @@ describe('auto-memory relevant recall', () => {
   });
 
   it('uses model-driven selection when config is provided', async () => {
-    vi.mocked(scanAutoMemoryTopicDocuments).mockResolvedValue(docs);
+    vi.mocked(scanAllAutoMemoryTopicDocuments).mockResolvedValue(docs);
     vi.mocked(selectRelevantAutoMemoryDocumentsByModel).mockResolvedValue([
       docs[0],
     ]);
@@ -431,8 +431,52 @@ describe('auto-memory relevant recall', () => {
     expect(result.prompt).toContain('Reference Memory (reference.md)');
   });
 
+  it('bounds model candidates while retaining lexical and recent documents', async () => {
+    const recentDocs = Array.from({ length: 230 }, (_, index) => ({
+      ...memoryDoc(
+        `candidate-${String(index).padStart(3, '0')}.md`,
+        'reference',
+        `General memory ${index}`,
+        'Unrelated historical context',
+        '',
+      ),
+      mtimeMs: 230 - index,
+    }));
+    const lexicalTarget = {
+      ...memoryDoc(
+        'overflow-target.md',
+        'reference',
+        'Overflow Zephyr Marker',
+        'Unique semantic target',
+        '',
+      ),
+      mtimeMs: 0,
+    };
+    vi.mocked(scanAllAutoMemoryTopicDocuments).mockResolvedValue([
+      ...recentDocs,
+      lexicalTarget,
+    ]);
+    vi.mocked(selectRelevantAutoMemoryDocumentsByModel).mockImplementation(
+      async (_config, _query, candidates) =>
+        candidates.includes(lexicalTarget) ? [lexicalTarget] : [],
+    );
+
+    const result = await resolveRelevantAutoMemoryPromptForQuery(
+      '/tmp/project',
+      'find the overflow zephyr marker',
+      { config: {} as Config },
+    );
+
+    const modelCandidates = vi.mocked(selectRelevantAutoMemoryDocumentsByModel)
+      .mock.calls[0]![2];
+    expect(modelCandidates).toHaveLength(200);
+    expect(modelCandidates).toContain(lexicalTarget);
+    expect(modelCandidates).toContain(recentDocs[0]);
+    expect(result.selectedDocs).toEqual([lexicalTarget]);
+  });
+
   it('falls back to heuristic selection when model-driven selection fails', async () => {
-    vi.mocked(scanAutoMemoryTopicDocuments).mockResolvedValue(docs);
+    vi.mocked(scanAllAutoMemoryTopicDocuments).mockResolvedValue(docs);
     vi.mocked(selectRelevantAutoMemoryDocumentsByModel).mockRejectedValue(
       new Error('selector failed'),
     );
@@ -456,7 +500,9 @@ describe('auto-memory relevant recall', () => {
   });
 
   it('keeps active tool schemas out of heuristic fallback', async () => {
-    vi.mocked(scanAutoMemoryTopicDocuments).mockResolvedValue(activeToolDocs);
+    vi.mocked(scanAllAutoMemoryTopicDocuments).mockResolvedValue(
+      activeToolDocs,
+    );
     vi.mocked(selectRelevantAutoMemoryDocumentsByModel).mockRejectedValue(
       new Error('selector failed'),
     );

--- a/packages/core/src/memory/recall.test.ts
+++ b/packages/core/src/memory/recall.test.ts
@@ -432,15 +432,25 @@ describe('auto-memory relevant recall', () => {
   });
 
   it('bounds model candidates while retaining lexical and recent documents', async () => {
-    const recentDocs = Array.from({ length: 230 }, (_, index) => ({
+    const lexicalDocs = Array.from({ length: 200 }, (_, index) => ({
       ...memoryDoc(
-        `candidate-${String(index).padStart(3, '0')}.md`,
+        `lexical-${String(index).padStart(3, '0')}.md`,
         'reference',
-        `General memory ${index}`,
-        'Unrelated historical context',
+        `Overflow memory ${index}`,
+        'Matching historical context',
         '',
       ),
-      mtimeMs: 230 - index,
+      mtimeMs: 0,
+    }));
+    const recentDocs = Array.from({ length: 20 }, (_, index) => ({
+      ...memoryDoc(
+        `recent-${String(index).padStart(2, '0')}.md`,
+        'reference',
+        `General memory ${index}`,
+        'Unrelated recent context',
+        '',
+      ),
+      mtimeMs: 20 - index,
     }));
     const lexicalTarget = {
       ...memoryDoc(
@@ -453,6 +463,7 @@ describe('auto-memory relevant recall', () => {
       mtimeMs: 0,
     };
     vi.mocked(scanAllAutoMemoryTopicDocuments).mockResolvedValue([
+      ...lexicalDocs,
       ...recentDocs,
       lexicalTarget,
     ]);
@@ -470,9 +481,8 @@ describe('auto-memory relevant recall', () => {
     const modelCandidates = vi.mocked(selectRelevantAutoMemoryDocumentsByModel)
       .mock.calls[0]![2];
     expect(modelCandidates).toHaveLength(200);
-    expect(modelCandidates[0]).toBe(lexicalTarget);
-    expect(modelCandidates).toContain(lexicalTarget);
-    expect(modelCandidates).toContain(recentDocs[0]);
+    expect(modelCandidates.slice(0, 20)).toEqual(recentDocs);
+    expect(modelCandidates[20]).toBe(lexicalTarget);
     expect(result.selectedDocs).toEqual([lexicalTarget]);
   });
 
@@ -504,8 +514,16 @@ describe('auto-memory relevant recall', () => {
     vi.mocked(scanAllAutoMemoryTopicDocuments).mockResolvedValue(
       activeToolDocs,
     );
-    vi.mocked(selectRelevantAutoMemoryDocumentsByModel).mockRejectedValue(
-      new Error('selector failed'),
+    vi.mocked(selectRelevantAutoMemoryDocumentsByModel).mockImplementation(
+      async (_config, _query, candidates) => {
+        expect(candidates.map((doc) => doc.filePath)).not.toContain(
+          '/tmp/ata-tool.md',
+        );
+        expect(candidates.map((doc) => doc.filePath)).toContain(
+          '/tmp/ata-gotcha.md',
+        );
+        throw new Error('selector failed');
+      },
     );
 
     const result = await resolveRelevantAutoMemoryPromptForQuery(

--- a/packages/core/src/memory/recall.test.ts
+++ b/packages/core/src/memory/recall.test.ts
@@ -470,6 +470,7 @@ describe('auto-memory relevant recall', () => {
     const modelCandidates = vi.mocked(selectRelevantAutoMemoryDocumentsByModel)
       .mock.calls[0]![2];
     expect(modelCandidates).toHaveLength(200);
+    expect(modelCandidates[0]).toBe(lexicalTarget);
     expect(modelCandidates).toContain(lexicalTarget);
     expect(modelCandidates).toContain(recentDocs[0]);
     expect(result.selectedDocs).toEqual([lexicalTarget]);

--- a/packages/core/src/memory/recall.ts
+++ b/packages/core/src/memory/recall.ts
@@ -241,12 +241,7 @@ function selectModelCandidateDocuments(
     .filter((doc) => !selected.has(doc.filePath))
     .sort((a, b) => b.mtimeMs - a.mtimeMs)
     .slice(0, MAX_MODEL_CANDIDATE_DOCS - lexical.length);
-  const reservedRecent = recent.slice(0, RECENT_MODEL_CANDIDATE_RESERVE);
-  return [
-    ...reservedRecent,
-    ...lexical,
-    ...recent.slice(reservedRecent.length),
-  ];
+  return [...lexical, ...recent];
 }
 
 function truncateBody(body: string): string {

--- a/packages/core/src/memory/recall.ts
+++ b/packages/core/src/memory/recall.ts
@@ -226,18 +226,27 @@ export function selectRelevantAutoMemoryDocuments(
 function selectModelCandidateDocuments(
   query: string,
   docs: ScannedAutoMemoryDocument[],
+  recentTools: readonly string[],
 ): ScannedAutoMemoryDocument[] {
+  const eligible = docs.filter(
+    (doc) => !isActiveToolUsageMemory(doc, recentTools),
+  );
   const lexical = selectRelevantAutoMemoryDocuments(
     query,
-    docs,
+    eligible,
     MAX_MODEL_CANDIDATE_DOCS - RECENT_MODEL_CANDIDATE_RESERVE,
   );
   const selected = new Set(lexical.map((doc) => doc.filePath));
-  const recent = docs
+  const recent = eligible
     .filter((doc) => !selected.has(doc.filePath))
     .sort((a, b) => b.mtimeMs - a.mtimeMs)
     .slice(0, MAX_MODEL_CANDIDATE_DOCS - lexical.length);
-  return [...lexical, ...recent];
+  const reservedRecent = recent.slice(0, RECENT_MODEL_CANDIDATE_RESERVE);
+  return [
+    ...reservedRecent,
+    ...lexical,
+    ...recent.slice(reservedRecent.length),
+  ];
 }
 
 function truncateBody(body: string): string {
@@ -326,11 +335,8 @@ export async function resolveRelevantAutoMemoryPromptForQuery(
       return [];
     }),
   ]);
-  // Project-level docs come first as a soft hint to the model-based
-  // selector and, in the heuristic fallback (`selectRelevantAutoMemoryDocuments`),
-  // as the stable-sort tie-breaker — matching the PR's "project shadows
-  // user" precedence. The model selector ranks by its own judgement so
-  // this ordering is advisory there, not enforced.
+  // Project-level docs come first as the stable tie-break when later ranking
+  // keys match.
   const docs = filterExcludedAutoMemoryDocuments(
     [...projectDocs, ...userDocs],
     options.excludedFilePaths,
@@ -359,7 +365,11 @@ export async function resolveRelevantAutoMemoryPromptForQuery(
 
   if (options.config) {
     try {
-      const modelCandidates = selectModelCandidateDocuments(query, docs);
+      const modelCandidates = selectModelCandidateDocuments(
+        query,
+        docs,
+        options.recentTools ?? [],
+      );
       const selectedDocs = await selectRelevantAutoMemoryDocumentsByModel(
         options.config,
         query,

--- a/packages/core/src/memory/recall.ts
+++ b/packages/core/src/memory/recall.ts
@@ -8,8 +8,8 @@ import * as path from 'node:path';
 import type { Config } from '../config/config.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import {
-  scanAutoMemoryTopicDocuments,
-  scanUserAutoMemoryTopicDocuments,
+  scanAllAutoMemoryTopicDocuments,
+  scanAllUserAutoMemoryTopicDocuments,
   type ScannedAutoMemoryDocument,
 } from './scan.js';
 import { memoryAge, memoryFreshnessText } from './memoryAge.js';
@@ -19,6 +19,8 @@ import { logMemoryRecall, MemoryRecallEvent } from '../telemetry/index.js';
 const MAX_RELEVANT_DOCS = 5;
 const MAX_DOC_BODY_CHARS = 1_200;
 const MAX_HEURISTIC_QUERY_TOKENS = 64;
+const MAX_MODEL_CANDIDATE_DOCS = 200;
+const RECENT_MODEL_CANDIDATE_RESERVE = 20;
 const debugLogger = createDebugLogger('AUTO_MEMORY_RECALL');
 
 const ACTIVE_TOOL_USAGE_MEMORY_MARKERS = [
@@ -221,6 +223,23 @@ export function selectRelevantAutoMemoryDocuments(
     .map(({ doc }) => doc);
 }
 
+function selectModelCandidateDocuments(
+  query: string,
+  docs: ScannedAutoMemoryDocument[],
+): ScannedAutoMemoryDocument[] {
+  const lexical = selectRelevantAutoMemoryDocuments(
+    query,
+    docs,
+    MAX_MODEL_CANDIDATE_DOCS - RECENT_MODEL_CANDIDATE_RESERVE,
+  );
+  const selected = new Set(lexical.map((doc) => doc.filePath));
+  const recent = docs
+    .filter((doc) => !selected.has(doc.filePath))
+    .sort((a, b) => b.mtimeMs - a.mtimeMs)
+    .slice(0, MAX_MODEL_CANDIDATE_DOCS - lexical.length);
+  return [...lexical, ...recent];
+}
+
 function truncateBody(body: string): string {
   const normalized = normalizeBody(body);
   if (normalized.length <= MAX_DOC_BODY_CHARS) {
@@ -299,8 +318,8 @@ export async function resolveRelevantAutoMemoryPromptForQuery(
   // recall returns nothing at all for the rest of the session. Project-
   // level scan failures still bubble — they're the only mandatory side.
   const [projectDocs, userDocs] = await Promise.all([
-    scanAutoMemoryTopicDocuments(projectRoot),
-    scanUserAutoMemoryTopicDocuments().catch((error: unknown) => {
+    scanAllAutoMemoryTopicDocuments(projectRoot),
+    scanAllUserAutoMemoryTopicDocuments().catch((error: unknown) => {
       debugLogger.warn(
         `User-level auto-memory scan failed; project-level recall continues: ${error instanceof Error ? error.message : String(error)}`,
       );
@@ -340,10 +359,11 @@ export async function resolveRelevantAutoMemoryPromptForQuery(
 
   if (options.config) {
     try {
+      const modelCandidates = selectModelCandidateDocuments(query, docs);
       const selectedDocs = await selectRelevantAutoMemoryDocumentsByModel(
         options.config,
         query,
-        docs,
+        modelCandidates,
         limit,
         options.recentTools ?? [],
         options.abortSignal,

--- a/packages/core/src/memory/relevanceSelector.test.ts
+++ b/packages/core/src/memory/relevanceSelector.test.ts
@@ -307,4 +307,28 @@ describe('selectRelevantAutoMemoryDocumentsByModel', () => {
     expect(manifest).toContain('/tmp/bounded-0.md');
     expect(Buffer.byteLength(manifest, 'utf8')).toBeLessThanOrEqual(25_000);
   });
+
+  it('does not let long descriptions starve later candidates', async () => {
+    const longDocs = Array.from({ length: 20 }, (_, index) => ({
+      ...docs[0],
+      filePath: `/tmp/recent-${index}.md`,
+      description: 'x'.repeat(1_190),
+    }));
+    const lexicalDoc = {
+      ...docs[1],
+      filePath: '/tmp/lexical-target.md',
+    };
+    vi.mocked(runSideQuery).mockResolvedValue({
+      selected_memories: [lexicalDoc.filePath],
+    });
+
+    await expect(
+      selectRelevantAutoMemoryDocumentsByModel(
+        mockConfig,
+        'find the lexical target',
+        [...longDocs, lexicalDoc],
+        5,
+      ),
+    ).resolves.toEqual([lexicalDoc]);
+  });
 });

--- a/packages/core/src/memory/relevanceSelector.test.ts
+++ b/packages/core/src/memory/relevanceSelector.test.ts
@@ -308,11 +308,11 @@ describe('selectRelevantAutoMemoryDocumentsByModel', () => {
     expect(Buffer.byteLength(manifest, 'utf8')).toBeLessThanOrEqual(25_000);
   });
 
-  it('does not let long descriptions starve later candidates', async () => {
+  it('does not let long descriptions starve lexical-first candidates', async () => {
     const longDocs = Array.from({ length: 20 }, (_, index) => ({
       ...docs[0],
       filePath: `/tmp/recent-${index}.md`,
-      description: 'x'.repeat(1_190),
+      description: '界'.repeat(512),
     }));
     const lexicalDoc = {
       ...docs[1],
@@ -326,9 +326,12 @@ describe('selectRelevantAutoMemoryDocumentsByModel', () => {
       selectRelevantAutoMemoryDocumentsByModel(
         mockConfig,
         'find the lexical target',
-        [...longDocs, lexicalDoc],
+        [lexicalDoc, ...longDocs],
         5,
       ),
     ).resolves.toEqual([lexicalDoc]);
+
+    const content = vi.mocked(runSideQuery).mock.calls[0]![1].contents[0];
+    expect(content?.parts?.[0]?.text).toContain(lexicalDoc.filePath);
   });
 });

--- a/packages/core/src/memory/relevanceSelector.test.ts
+++ b/packages/core/src/memory/relevanceSelector.test.ts
@@ -272,4 +272,29 @@ describe('selectRelevantAutoMemoryDocumentsByModel', () => {
       '/qwen/memories/user/role.md',
     ]);
   });
+
+  it('bounds the model manifest by UTF-8 bytes', async () => {
+    const largeDocs = Array.from({ length: 200 }, (_, index) => ({
+      ...docs[0],
+      filePath: `/tmp/bounded-${index}.md`,
+      relativePath: `bounded-${index}.md`,
+      filename: `bounded-${index}.md`,
+      description: '界'.repeat(500),
+      mtimeMs: index,
+    }));
+    vi.mocked(runSideQuery).mockResolvedValue({ selected_memories: [] });
+
+    await selectRelevantAutoMemoryDocumentsByModel(
+      mockConfig,
+      'semantic-only request',
+      largeDocs,
+      5,
+    );
+
+    const content = vi.mocked(runSideQuery).mock.calls[0]![1].contents[0];
+    const text = content?.parts?.[0]?.text ?? '';
+    const manifest = text.split('Available memories:\n')[1] ?? '';
+    expect(manifest).toContain('/tmp/bounded-0.md');
+    expect(Buffer.byteLength(manifest, 'utf8')).toBeLessThanOrEqual(25_000);
+  });
 });

--- a/packages/core/src/memory/relevanceSelector.test.ts
+++ b/packages/core/src/memory/relevanceSelector.test.ts
@@ -282,14 +282,24 @@ describe('selectRelevantAutoMemoryDocumentsByModel', () => {
       description: '界'.repeat(500),
       mtimeMs: index,
     }));
-    vi.mocked(runSideQuery).mockResolvedValue({ selected_memories: [] });
+    vi.mocked(runSideQuery).mockImplementation(async (_config, options) => {
+      const error = options.validate?.({
+        selected_memories: ['/tmp/bounded-199.md'],
+      });
+      if (error) {
+        throw new Error(error);
+      }
+      return { selected_memories: [] };
+    });
 
-    await selectRelevantAutoMemoryDocumentsByModel(
-      mockConfig,
-      'semantic-only request',
-      largeDocs,
-      5,
-    );
+    await expect(
+      selectRelevantAutoMemoryDocumentsByModel(
+        mockConfig,
+        'semantic-only request',
+        largeDocs,
+        5,
+      ),
+    ).rejects.toThrow('Recall selector returned unknown file path');
 
     const content = vi.mocked(runSideQuery).mock.calls[0]![1].contents[0];
     const text = content?.parts?.[0]?.text ?? '';

--- a/packages/core/src/memory/relevanceSelector.test.ts
+++ b/packages/core/src/memory/relevanceSelector.test.ts
@@ -279,7 +279,7 @@ describe('selectRelevantAutoMemoryDocumentsByModel', () => {
       filePath: `/tmp/bounded-${index}.md`,
       relativePath: `bounded-${index}.md`,
       filename: `bounded-${index}.md`,
-      description: '界'.repeat(500),
+      description: `${'界'.repeat(511)}😀${'x'.repeat(2_000)}`,
       mtimeMs: index,
     }));
     vi.mocked(runSideQuery).mockImplementation(async (_config, options) => {
@@ -305,6 +305,8 @@ describe('selectRelevantAutoMemoryDocumentsByModel', () => {
     const text = content?.parts?.[0]?.text ?? '';
     const manifest = text.split('Available memories:\n')[1] ?? '';
     expect(manifest).toContain('/tmp/bounded-0.md');
+    expect(manifest).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
+    expect(manifest).not.toContain('x');
     expect(Buffer.byteLength(manifest, 'utf8')).toBeLessThanOrEqual(25_000);
   });
 

--- a/packages/core/src/memory/relevanceSelector.ts
+++ b/packages/core/src/memory/relevanceSelector.ts
@@ -63,7 +63,7 @@ function formatMemoryManifest(docs: ScannedAutoMemoryDocument[]): {
     const tag = `[${doc.type}] `;
     const ts = new Date(doc.mtimeMs).toISOString();
     const line = doc.description
-      ? `- ${tag}${doc.filePath} (${ts}): ${doc.description}`
+      ? `- ${tag}${doc.filePath} (${ts}): ${doc.description.slice(0, 512)}`
       : `- ${tag}${doc.filePath} (${ts})`;
     const nextBytes = Buffer.byteLength(
       `${lines.length > 0 ? '\n' : ''}${line}`,

--- a/packages/core/src/memory/relevanceSelector.ts
+++ b/packages/core/src/memory/relevanceSelector.ts
@@ -63,7 +63,7 @@ function formatMemoryManifest(docs: ScannedAutoMemoryDocument[]): {
     const tag = `[${doc.type}] `;
     const ts = new Date(doc.mtimeMs).toISOString();
     const line = doc.description
-      ? `- ${tag}${doc.filePath} (${ts}): ${doc.description.slice(0, 512)}`
+      ? `- ${tag}${doc.filePath} (${ts}): ${doc.description.slice(0, 512).replace(/[\uD800-\uDBFF]$/, '')}`
       : `- ${tag}${doc.filePath} (${ts})`;
     const nextBytes = Buffer.byteLength(
       `${lines.length > 0 ? '\n' : ''}${line}`,

--- a/packages/core/src/memory/relevanceSelector.ts
+++ b/packages/core/src/memory/relevanceSelector.ts
@@ -35,6 +35,8 @@ interface RecallSelectorResponse {
   selected_memories: string[];
 }
 
+const MAX_MODEL_MANIFEST_BYTES = 25_000;
+
 /**
  * Format memory headers as a text manifest: one line per file with
  * [type] filePath (ISO-timestamp): description.
@@ -49,16 +51,32 @@ interface RecallSelectorResponse {
  * Selector sees only the header (type, path, age, description), not the
  * body content.
  */
-function formatMemoryManifest(docs: ScannedAutoMemoryDocument[]): string {
-  return docs
-    .map((doc) => {
-      const tag = `[${doc.type}] `;
-      const ts = new Date(doc.mtimeMs).toISOString();
-      return doc.description
-        ? `- ${tag}${doc.filePath} (${ts}): ${doc.description}`
-        : `- ${tag}${doc.filePath} (${ts})`;
-    })
-    .join('\n');
+function formatMemoryManifest(docs: ScannedAutoMemoryDocument[]): {
+  manifest: string;
+  includedDocs: ScannedAutoMemoryDocument[];
+} {
+  const lines: string[] = [];
+  const includedDocs: ScannedAutoMemoryDocument[] = [];
+  let bytes = 0;
+
+  for (const doc of docs) {
+    const tag = `[${doc.type}] `;
+    const ts = new Date(doc.mtimeMs).toISOString();
+    const line = doc.description
+      ? `- ${tag}${doc.filePath} (${ts}): ${doc.description}`
+      : `- ${tag}${doc.filePath} (${ts})`;
+    const nextBytes = Buffer.byteLength(
+      `${lines.length > 0 ? '\n' : ''}${line}`,
+    );
+    if (bytes + nextBytes > MAX_MODEL_MANIFEST_BYTES) {
+      continue;
+    }
+    lines.push(line);
+    includedDocs.push(doc);
+    bytes += nextBytes;
+  }
+
+  return { manifest: lines.join('\n'), includedDocs };
 }
 
 export async function selectRelevantAutoMemoryDocumentsByModel(
@@ -73,7 +91,10 @@ export async function selectRelevantAutoMemoryDocumentsByModel(
     return [];
   }
 
-  const manifest = formatMemoryManifest(docs);
+  const { manifest, includedDocs } = formatMemoryManifest(docs);
+  if (includedDocs.length === 0) {
+    return [];
+  }
 
   // When the assistant is actively using a tool, surfacing that tool's
   // reference docs is noise.  Pass the tool list so the selector can skip them.
@@ -93,8 +114,8 @@ export async function selectRelevantAutoMemoryDocumentsByModel(
     },
   ];
 
-  const validFilePaths = new Set(docs.map((doc) => doc.filePath));
-  const byFilePath = new Map(docs.map((doc) => [doc.filePath, doc]));
+  const validFilePaths = new Set(includedDocs.map((doc) => doc.filePath));
+  const byFilePath = new Map(includedDocs.map((doc) => [doc.filePath, doc]));
 
   const response = await runSideQuery<RecallSelectorResponse>(config, {
     purpose: 'auto-memory-recall',

--- a/packages/core/src/memory/scan.ts
+++ b/packages/core/src/memory/scan.ts
@@ -111,7 +111,7 @@ async function listMarkdownFiles(root: string): Promise<string[]> {
 
 async function scanAutoMemoryDocumentsFromRoot(
   root: string,
-  opts: { deterministic?: boolean } = {},
+  opts: { deterministic?: boolean; uncapped?: boolean } = {},
 ): Promise<ScannedAutoMemoryDocument[]> {
   const relativePaths = await listMarkdownFiles(root);
   const docs = await Promise.all(
@@ -159,13 +159,23 @@ async function scanAutoMemoryDocumentsFromRoot(
     : valid.sort(
         (a, b) => b.mtimeMs - a.mtimeMs || a.filename.localeCompare(b.filename),
       );
-  return ordered.slice(0, MAX_SCANNED_MEMORY_FILES);
+  return opts.uncapped ? ordered : ordered.slice(0, MAX_SCANNED_MEMORY_FILES);
 }
 
 export async function scanAutoMemoryTopicDocuments(
   projectRoot: string,
 ): Promise<ScannedAutoMemoryDocument[]> {
   return scanAutoMemoryDocumentsFromRoot(getAutoMemoryRoot(projectRoot));
+}
+
+export async function scanAllAutoMemoryTopicDocuments(
+  projectRoot: string,
+): Promise<ScannedAutoMemoryDocument[]> {
+  // ponytail: reuse the existing O(n) parsed scan; add a catalog only if
+  // measured topic counts make recall scanning too slow.
+  return scanAutoMemoryDocumentsFromRoot(getAutoMemoryRoot(projectRoot), {
+    uncapped: true,
+  });
 }
 
 /**
@@ -177,6 +187,14 @@ export async function scanUserAutoMemoryTopicDocuments(): Promise<
   ScannedAutoMemoryDocument[]
 > {
   return scanAutoMemoryDocumentsFromRoot(getUserAutoMemoryRoot());
+}
+
+export async function scanAllUserAutoMemoryTopicDocuments(): Promise<
+  ScannedAutoMemoryDocument[]
+> {
+  return scanAutoMemoryDocumentsFromRoot(getUserAutoMemoryRoot(), {
+    uncapped: true,
+  });
 }
 
 /**


### PR DESCRIPTION
## What this PR does

This PR lets native memory recall consider relevant project and user topics beyond the shared 200-document scan window, while keeping model selection bounded. Recall ranks the complete parsed pool, sends at most 200 candidates with a lexical/recent balance, and limits the selector manifest to 25,000 UTF-8 bytes. Forget, Indexer, Status, Extraction, and team-memory scanning keep their existing limits.

## Why it's needed

Before this change, the scanner parsed every topic and then returned only the 200 most recent documents. Recall consumed that capped result, so an older but directly relevant memory could never reach either the heuristic fallback or the model selector. This preserves the existing safety bounds at the model boundary without discarding relevant topics before ranking.

## Reviewer Test Plan

### How to verify

1. Create more than 200 project memory topics and make the relevant topic older than every filler topic. Confirm the regular scanner still returns 200 documents and omits the old target.
2. Ask a query containing the target's unique terms. Confirm heuristic recall can surface the old target from the complete pool.
3. Run model-backed selection over more than 200 topics. Confirm no more than 200 candidates reach the selector, including the old lexical target and recent fallback candidates.
4. Use multibyte descriptions large enough to exceed the prompt budget. Confirm the selector manifest remains at or below 25,000 UTF-8 bytes and returned paths are accepted only when they were included in that manifest.

Local verification completed:

- `npx vitest run src/memory/recall.test.ts src/memory/relevanceSelector.test.ts src/memory/memoryLifecycle.integration.test.ts src/memory/scan.test.ts` — 61/61 passed
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run bundle`
- deterministic headless CLI E2E using a local bundle, an isolated memory home, 201 real topic files, and an OpenAI-compatible mock endpoint

### Evidence (Before & After)

Before: the regular 200-document scan excludes the deliberately old target topic.

After, the bundled CLI receives the recalled marker at the next safe delivery point after the bounded initial wait:

```text
tool=run_shell_command
assistant=MEMORY_PRESENT
result=MEMORY_PRESENT
selector manifest: 120 candidates, 24987 bytes
```

The E2E is headless and has no visual UI surface, so there is no meaningful screenshot to attach.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local bundled CLI with an isolated memory home and an OpenAI-compatible mock endpoint.

## Risk & Scope

- Main risk or tradeoff: recall performs lexical ranking over the complete already-parsed topic pool; a persistent catalog remains out of scope until topic counts show that this local pass is too slow.
- Not validated / out of scope: Windows and Linux E2E, persistent indexing, provider integration, and changes to non-recall scanner consumers.
- Breaking changes / migration notes: none.

## Linked Issues

Refs #7040

Depends on #8716. This PR is stacked on `codex/7040-memory-recall` and should be retargeted to `main` after #8716 merges.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 让原生记忆召回可以考虑共享 200 文档扫描窗口之外的相关项目级和用户级主题，同时保持模型选择有界。召回会对完整的已解析候选池排序，以词法相关性和近期文档相结合的方式最多向模型选择器发送 200 个候选，并把选择器 manifest 限制在 25,000 UTF-8 字节以内。Forget、Indexer、Status、Extraction 和团队记忆扫描继续保留原有上限。

## 为什么需要它

改动前，扫描器会解析全部主题，但最终只返回最近的 200 个文档。召回直接使用这个有上限的结果，因此较旧但明确相关的记忆无法进入启发式回退或模型选择器。这个改动在模型边界继续保留已有安全上限，同时避免在排序前丢弃相关主题。

## Reviewer 测试计划

### 如何验证

1. 创建超过 200 个项目记忆主题，并让相关主题比所有填充主题都旧。确认常规扫描器仍只返回 200 个文档，并排除这个旧目标。
2. 使用包含目标唯一关键词的查询。确认启发式召回可以从完整候选池中找到旧目标。
3. 对超过 200 个主题运行模型选择。确认到达选择器的候选不超过 200 个，并同时包含旧的词法相关目标和近期回退候选。
4. 使用足以超过提示预算的多字节描述。确认选择器 manifest 不超过 25,000 UTF-8 字节，并且只有实际包含在 manifest 中的路径才会被接受。

已完成本地验证：

- `npx vitest run src/memory/recall.test.ts src/memory/relevanceSelector.test.ts src/memory/memoryLifecycle.integration.test.ts src/memory/scan.test.ts` — 61/61 通过
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run bundle`
- 使用本地 bundle、隔离的记忆目录、201 个真实主题文件和 OpenAI 兼容 mock 端点完成确定性的 headless CLI E2E

### Before & After 证据

改动前：常规 200 文档扫描会排除刻意设为较旧的目标主题。

改动后：在有界初始等待结束后的下一个安全注入点，bundle CLI 收到了召回标记：

```text
tool=run_shell_command
assistant=MEMORY_PRESENT
result=MEMORY_PRESENT
selector manifest: 120 candidates, 24987 bytes
```

这个 E2E 是 headless 流程，没有可视 UI 界面，因此没有有意义的截图可附加。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

本地 bundle CLI、隔离的记忆目录和 OpenAI 兼容 mock 端点。

## 风险与范围

- 主要风险或取舍：召回会在完整的已解析主题池上执行词法排序；在主题数量证明本地扫描过慢之前，持久化目录仍不在本次范围内。
- 未验证 / 范围外：Windows 和 Linux E2E、持久化索引、Provider 集成，以及对非召回扫描消费者的改动。
- 破坏性改动 / 迁移说明：无。

## 关联 Issue

Refs #7040

依赖 #8716。这个 PR 堆叠在 `codex/7040-memory-recall` 上，应在 #8716 合并后把 base 改回 `main`。

</details>
