### PR TITLE
fix(desktop): open Local Control on the active session

### DIFF
--- a/packages/desktop-shell/src-tauri/src/local_control.rs
+++ b/packages/desktop-shell/src-tauri/src/local_control.rs
@@ -52,7 +52,11 @@ pub struct LocalControlSession {
 }
 
 impl LocalControlSession {
-    pub fn start(runtime_url: &Url, runtime_token: &str) -> Result<Self, String> {
+    pub fn start(
+        runtime_url: &Url,
+        runtime_token: &str,
+        current_url: &Url,
+    ) -> Result<Self, String> {
         let target = runtime_socket_addr(runtime_url)?;
         let lan_ip = primary_lan_ipv4()?;
         let listener = TcpListener::bind((lan_ip, 0))
@@ -66,7 +70,7 @@ impl LocalControlSession {
             .port();
         let public_origin = format!("http://{lan_ip}:{port}");
         let pair_token = random_token();
-        let url = format!("{public_origin}/#token={pair_token}");
+        let url = local_control_url(current_url, lan_ip, port, &pair_token)?;
         let qr_svg = QrCode::new(url.as_bytes())
             .map_err(|error| format!("Failed to generate Local Control QR code: {error}"))?
             .render::<svg::Color>()
@@ -402,15 +406,33 @@ fn runtime_socket_addr(url: &Url) -> Result<SocketAddr, String> {
     Ok(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port))
 }
 
+fn local_control_url(
+    current_url: &Url,
+    lan_ip: Ipv4Addr,
+    port: u16,
+    pair_token: &str,
+) -> Result<String, String> {
+    let workspace = current_url
+        .query_pairs()
+        .find(|(name, value)| name == "workspace" && !value.is_empty())
+        .map(|(_, value)| value.into_owned());
+    let mut url = current_url.clone();
+    url.set_host(Some(&lan_ip.to_string()))
+        .map_err(|error| format!("Failed to construct the Local Control URL: {error}"))?;
+    url.set_port(Some(port))
+        .map_err(|_| "Failed to construct the Local Control URL.".to_string())?;
+    url.set_query(None);
+    if let Some(workspace) = workspace {
+        url.query_pairs_mut().append_pair("workspace", &workspace);
+    }
+    url.set_fragment(Some(&format!("token={pair_token}")));
+    Ok(url.into())
+}
+
 fn primary_lan_ipv4() -> Result<Ipv4Addr, String> {
     let routed = routed_ipv4().ok();
-    let interfaces = match NetworkInterface::show() {
-        Ok(interfaces) => interfaces,
-        Err(_) => {
-            return routed
-                .ok_or_else(|| "Local Control could not find a usable IPv4 network.".to_string())
-        }
-    };
+    let interfaces = NetworkInterface::show()
+        .map_err(|_| "Local Control could not inspect IPv4 networks.".to_string())?;
     let physical = interfaces
         .into_iter()
         .filter(|interface| {
@@ -441,10 +463,10 @@ fn choose_lan_ipv4(
 ) -> Result<Ipv4Addr, String> {
     physical.sort_unstable();
     physical.dedup();
+    physical.retain(|address| address.is_private() || address.is_link_local());
     if let Some(routed) = routed.filter(|address| physical.contains(address)) {
         return Ok(routed);
     }
-    physical.retain(|address| address.is_private() || address.is_link_local());
     match physical.as_slice() {
         [address] => Ok(*address),
         [] => Err("Local Control could not find a usable IPv4 network.".to_string()),
@@ -526,8 +548,8 @@ fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
 #[cfg(test)]
 mod tests {
     use super::{
-        choose_lan_ipv4, find_header_end, rewrite_request, runtime_socket_addr, spawn_proxy,
-        Connections,
+        choose_lan_ipv4, find_header_end, local_control_url, rewrite_request, runtime_socket_addr,
+        spawn_proxy, Connections,
     };
     use std::collections::HashMap;
     use std::io::{Read, Write};
@@ -541,7 +563,7 @@ mod tests {
     use url::Url;
 
     #[test]
-    fn prefers_the_physical_lan_over_a_vpn_route() {
+    fn selects_only_a_private_physical_lan() {
         assert_eq!(
             choose_lan_ipv4(
                 Some("10.8.0.2".parse::<Ipv4Addr>().expect("VPN address")),
@@ -551,6 +573,29 @@ mod tests {
             "192.168.1.20"
                 .parse::<Ipv4Addr>()
                 .expect("expected address"),
+        );
+        assert!(choose_lan_ipv4(
+            Some("203.0.113.10".parse().expect("public route")),
+            vec!["203.0.113.10".parse().expect("public interface")],
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn shares_only_the_current_local_session() {
+        let url = local_control_url(
+            &Url::parse(
+                "http://127.0.0.1:4170/session/a%20b?workspace=work%2Ftree&token=runtime&theme=light#old",
+            )
+            .expect("current URL"),
+            "192.168.1.20".parse().expect("LAN address"),
+            49152,
+            "pair-token",
+        )
+        .expect("Local Control URL");
+        assert_eq!(
+            url,
+            "http://192.168.1.20:49152/session/a%20b?workspace=work%2Ftree#token=pair-token"
         );
     }
 

--- a/packages/desktop-shell/src-tauri/src/local_control.rs
+++ b/packages/desktop-shell/src-tauri/src/local_control.rs
@@ -307,7 +307,19 @@ fn rewrite_request(
     pair_token: &str,
     runtime_token: &str,
 ) -> Result<Vec<u8>, u16> {
-    let header = std::str::from_utf8(&request[..header_end]).map_err(|_| 400_u16)?;
+    let header_bytes = &request[..header_end];
+    if header_bytes
+        .iter()
+        .enumerate()
+        .any(|(index, &byte)| match byte {
+            b'\r' => header_bytes.get(index + 1) != Some(&b'\n'),
+            b'\n' => index == 0 || header_bytes[index - 1] != b'\r',
+            _ => false,
+        })
+    {
+        return Err(400);
+    }
+    let header = std::str::from_utf8(header_bytes).map_err(|_| 400_u16)?;
     let public_authority = public_origin.strip_prefix("http://").ok_or(500_u16)?;
     let pair_protocol = format!("qwen-bearer.{}", URL_SAFE_NO_PAD.encode(pair_token));
     let runtime_protocol = format!("qwen-bearer.{}", URL_SAFE_NO_PAD.encode(runtime_token));
@@ -686,6 +698,20 @@ mod tests {
                 "runtime-token",
             ),
             Err(403),
+        );
+
+        let request = b"GET / HTTP/1.1\nHost: 127.0.0.1:4170\n\n\r\n\r\n";
+        assert_eq!(
+            rewrite_request(
+                request,
+                find_header_end(request).expect("header"),
+                "http://192.168.1.10:49152",
+                "http://127.0.0.1:4170",
+                "127.0.0.1:4170",
+                "pair-token",
+                "runtime-token",
+            ),
+            Err(400),
         );
 
         let pair = URL_SAFE_NO_PAD.encode("pair-token");

--- a/packages/desktop-shell/src-tauri/src/local_control.rs
+++ b/packages/desktop-shell/src-tauri/src/local_control.rs
@@ -442,9 +442,15 @@ fn local_control_url(
 }
 
 fn primary_lan_ipv4() -> Result<Ipv4Addr, String> {
-    let routed = routed_ipv4().ok();
-    let interfaces = NetworkInterface::show()
-        .map_err(|_| "Local Control could not inspect IPv4 networks.".to_string())?;
+    select_lan_ipv4(routed_ipv4().ok(), NetworkInterface::show().ok())
+}
+
+fn select_lan_ipv4(
+    routed: Option<Ipv4Addr>,
+    interfaces: Option<Vec<NetworkInterface>>,
+) -> Result<Ipv4Addr, String> {
+    let interfaces =
+        interfaces.ok_or_else(|| "Local Control could not inspect IPv4 networks.".to_string())?;
     let physical = interfaces
         .into_iter()
         .filter(|interface| {
@@ -561,7 +567,7 @@ fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
 mod tests {
     use super::{
         choose_lan_ipv4, find_header_end, local_control_url, rewrite_request, runtime_socket_addr,
-        spawn_proxy, Connections,
+        select_lan_ipv4, spawn_proxy, Connections,
     };
     use std::collections::HashMap;
     use std::io::{Read, Write};
@@ -591,13 +597,25 @@ mod tests {
             vec!["203.0.113.10".parse().expect("public interface")],
         )
         .is_err());
+        let routed = Ipv4Addr::new(192, 168, 1, 20);
+        assert_eq!(
+            choose_lan_ipv4(Some(routed), vec![routed, Ipv4Addr::new(192, 168, 2, 5)],)
+                .expect("routed LAN"),
+            routed,
+        );
+    }
+
+    #[test]
+    fn rejects_unverified_networks_when_interface_enumeration_fails() {
+        let routed = Ipv4Addr::new(192, 168, 1, 20);
+        assert!(select_lan_ipv4(Some(routed), None).is_err());
     }
 
     #[test]
     fn shares_only_the_current_local_session() {
         let url = local_control_url(
             &Url::parse(
-                "http://127.0.0.1:4170/session/a%20b?workspace=work%2Ftree&token=runtime&theme=light#old",
+                "http://127.0.0.1:4170/session/a%20b?token=runtime&workspace=work%2Ftree&theme=light#old",
             )
             .expect("current URL"),
             "192.168.1.20".parse().expect("LAN address"),
@@ -609,6 +627,15 @@ mod tests {
             url,
             "http://192.168.1.20:49152/session/a%20b?workspace=work%2Ftree#token=pair-token"
         );
+
+        let url = local_control_url(
+            &Url::parse("http://127.0.0.1:4170/").expect("runtime URL"),
+            "192.168.1.20".parse().expect("LAN address"),
+            49152,
+            "pair-token",
+        )
+        .expect("Local Control URL");
+        assert_eq!(url, "http://192.168.1.20:49152/#token=pair-token");
     }
 
     #[test]

--- a/packages/desktop-shell/src-tauri/src/local_control.rs
+++ b/packages/desktop-shell/src-tauri/src/local_control.rs
@@ -636,6 +636,19 @@ mod tests {
         )
         .expect("Local Control URL");
         assert_eq!(url, "http://192.168.1.20:49152/#token=pair-token");
+
+        let url = local_control_url(
+            &Url::parse("http://127.0.0.1:4170/session/x?workspace=")
+                .expect("current URL"),
+            "192.168.1.20".parse().expect("LAN address"),
+            49152,
+            "pair-token",
+        )
+        .expect("Local Control URL");
+        assert_eq!(
+            url,
+            "http://192.168.1.20:49152/session/x#token=pair-token"
+        );
     }
 
     #[test]
@@ -728,6 +741,21 @@ mod tests {
         );
 
         let request = b"GET / HTTP/1.1\nHost: 127.0.0.1:4170\n\n\r\n\r\n";
+        assert_eq!(
+            rewrite_request(
+                request,
+                find_header_end(request).expect("header"),
+                "http://192.168.1.10:49152",
+                "http://127.0.0.1:4170",
+                "127.0.0.1:4170",
+                "pair-token",
+                "runtime-token",
+            ),
+            Err(400),
+        );
+
+        let request =
+            b"GET / HTTP/1.1\r\nHost: 192.168.1.10:49152\r\nX-Inject: a\r\r\n\r\n";
         assert_eq!(
             rewrite_request(
                 request,

--- a/packages/desktop-shell/src-tauri/src/main.rs
+++ b/packages/desktop-shell/src-tauri/src/main.rs
@@ -304,7 +304,12 @@ fn enable_local_control(
         .as_ref()
         .map(|runtime| (runtime.base_url().clone(), runtime.token().to_string()))
         .ok_or_else(|| "Start a Desktop workspace before enabling Local Control.".to_string())?;
-    let session = LocalControlSession::start(&runtime_url, &runtime_token)?;
+    let current_url = app
+        .get_webview_window("main")
+        .and_then(|window| window.url().ok())
+        .filter(|url| is_same_origin(url, &runtime_url))
+        .unwrap_or_else(|| runtime_url.clone());
+    let session = LocalControlSession::start(&runtime_url, &runtime_token, &current_url)?;
     let info = session.info();
     *local_control = Some(session);
     set_local_control_menu_state(&app, true);


### PR DESCRIPTION
## What this PR does

Local Control now captures the active Desktop session when it is enabled, so the QR code opens that same session on the phone instead of always opening a blank Web Shell. The handoff keeps only the session path and its workspace identifier, replaces the private runtime credential with the pairing token, and falls back to the Web Shell root if the main window has not finished navigating yet.

The Desktop gateway also fails closed unless it can verify a private or link-local physical IPv4 address. A public default-route address can no longer win before the LAN filter, and interface enumeration failure no longer exposes an unverified routed address.

## Why it's needed

The first Local Control implementation authenticated the phone but did not take it into the session visible on the Mac, leaving users to find that session manually. Its address selection also accepted a routed physical address before checking whether it belonged to a private network, which could make a LAN-only gateway listen on a publicly routed interface.

## Reviewer Test Plan

### How to verify

1. Open an existing Desktop session, enable Local Control, and confirm the generated URL contains that session path and workspace while carrying only the pairing token.
2. Scan the QR code from a phone on the same private network and confirm it opens the Desktop session rather than a new-session screen.
3. Confirm a private physical address is preferred over a VPN route, while a machine exposing only a public IPv4 is rejected instead of starting Local Control.

### Evidence (Before & After)

Before: the QR always encoded the Web Shell root, and a public routed physical IPv4 was accepted before private-network filtering.

After: the focused Rust checks cover the session/workspace handoff, credential stripping, private address selection, pairing boundary, and proxy relay. `cargo clippy --manifest-path packages/desktop-shell/src-tauri/Cargo.toml -- -D warnings` and `cargo test --manifest-path packages/desktop-shell/src-tauri/Cargo.toml local_control::tests` pass (`5 passed, 0 failed`).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

macOS arm64, Rust desktop-shell unit and Clippy checks.

## Risk & Scope

- Main risk or tradeoff: the QR captures the active session when Local Control is enabled. If the Desktop switches sessions while Local Control remains on, turn it off and on again to generate a link for the new session.
- Not validated / out of scope: real-phone QR scanning and mobile secure-context APIs; Local Control remains an explicitly opt-in, unencrypted trusted-LAN feature.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #8595. Refs #8092.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

开启 Local Control 时会记录 Desktop 当前会话，二维码在手机上直接打开同一个会话，不再总是进入空白 Web Shell。交接链接只保留会话路径和对应的 workspace 标识，将内部 runtime 凭证替换成配对 token；如果主窗口仍在导航，则安全回退到 Web Shell 根页面。

Desktop 网关现在还会严格校验可用地址，只允许私网或 link-local 的物理 IPv4。公网默认路由不能再绕过 LAN 过滤，接口枚举失败时也不会回退到未经验证的路由地址。

## 为什么需要

第一版 Local Control 虽然可以让手机完成认证，但不会进入 Mac 当前显示的会话，用户仍需手动查找。地址选择逻辑也会在私网过滤前接受默认路由对应的物理地址，可能让声明为 LAN-only 的网关监听公网接口。

## Reviewer Test Plan

### 如何验证

1. 在 Desktop 打开已有会话并启用 Local Control，确认链接包含当前 session 路径和 workspace，同时只携带配对 token。
2. 使用同一私网内的手机扫码，确认直接打开 Desktop 会话而不是新会话页面。
3. 确认私网物理地址优先于 VPN 路由；如果机器只有公网 IPv4，Local Control 应拒绝启动。

### 修复前后证据

修复前：二维码始终指向 Web Shell 根页面；公网路由对应的物理 IPv4 会在私网过滤前被接受。

修复后：聚焦的 Rust 检查覆盖会话/workspace 交接、旧凭证清理、私网地址选择、配对边界和代理转发。`cargo clippy --manifest-path packages/desktop-shell/src-tauri/Cargo.toml -- -D warnings` 与 `cargo test --manifest-path packages/desktop-shell/src-tauri/Cargo.toml local_control::tests` 均通过（`5 passed, 0 failed`）。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境

macOS arm64，Rust desktop-shell 单元测试与 Clippy 检查。

## 风险与范围

- 主要取舍：二维码记录的是开启 Local Control 时的会话。如果保持开启后在 Desktop 切换会话，需要关闭再开启一次来生成新会话链接。
- 未验证/不在范围：真实手机扫码与移动端 secure-context API；Local Control 仍是显式开启、未加密、仅用于可信局域网的功能。
- 破坏性变更/迁移：无。

## 关联 Issue

#8595 的后续修复。关联 #8092。

</details>