### PR TITLE
fix(desktop): surface automatic update failures

### DIFF
--- a/packages/desktop-shell/src-tauri/src/main.rs
+++ b/packages/desktop-shell/src-tauri/src/main.rs
@@ -614,6 +614,7 @@ fn check_updates_silently(app: AppHandle) {
         let version = update.version.clone();
         let confirmed = tauri::async_runtime::spawn_blocking({
             let app = app.clone();
+            let version = version.clone();
             move || {
                 app.dialog()
                     .message(format!(
@@ -632,12 +633,28 @@ fn check_updates_silently(app: AppHandle) {
         if !matches!(confirmed, Ok(true)) {
             return;
         }
-        if update
-            .download_and_install(|_, _| {}, || {})
-            .await
-            .is_err()
-        {
-            return;
+        while let Err(error) = update.download_and_install(|_, _| {}, || {}).await {
+            let retry = tauri::async_runtime::spawn_blocking({
+                let app = app.clone();
+                let version = version.clone();
+                move || {
+                    app.dialog()
+                        .message(format!(
+                            "Qwen Code Desktop {version} could not be installed.\n\n{error}\n\nQwen Code remains usable. Check your connection and try again."
+                        ))
+                        .title("Qwen Code update failed")
+                        .kind(MessageDialogKind::Error)
+                        .buttons(MessageDialogButtons::OkCancelCustom(
+                            "Try again".to_string(),
+                            "Later".to_string(),
+                        ))
+                        .blocking_show()
+                }
+            })
+            .await;
+            if !matches!(retry, Ok(true)) {
+                return;
+            }
         }
         app.request_restart();
     });

--- a/packages/desktop-shell/src-tauri/src/main.rs
+++ b/packages/desktop-shell/src-tauri/src/main.rs
@@ -633,28 +633,22 @@ fn check_updates_silently(app: AppHandle) {
         if !matches!(confirmed, Ok(true)) {
             return;
         }
-        while let Err(error) = update.download_and_install(|_, _| {}, || {}).await {
-            let retry = tauri::async_runtime::spawn_blocking({
+        if let Err(error) = update.download_and_install(|_, _| {}, || {}).await {
+            let _ = tauri::async_runtime::spawn_blocking({
                 let app = app.clone();
                 let version = version.clone();
                 move || {
                     app.dialog()
                         .message(format!(
-                            "Qwen Code Desktop {version} could not be installed.\n\n{error}\n\nQwen Code remains usable. Check your connection and try again."
+                            "Qwen Code Desktop {version} could not be installed.\n\n{error}\n\nSave your work before quitting. Reinstall Qwen Code if it does not reopen."
                         ))
                         .title("Qwen Code update failed")
                         .kind(MessageDialogKind::Error)
-                        .buttons(MessageDialogButtons::OkCancelCustom(
-                            "Try again".to_string(),
-                            "Later".to_string(),
-                        ))
                         .blocking_show()
                 }
             })
             .await;
-            if !matches!(retry, Ok(true)) {
-                return;
-            }
+            return;
         }
         app.request_restart();
     });


### PR DESCRIPTION
## What this PR does

The automatic Desktop update prompt now reports download, signature, or installation failures instead of silently returning. A failed attempt shows the version and error once, does not retry an installation that may already have changed the application bundle, and never restarts the app; only a successful installation reaches restart.

## Why it's needed

Before this change, selecting `Install and restart` could appear to do nothing when the update failed. Users received no error and no recovery guidance. Retrying the combined updater operation is unsafe on macOS because an installation failure can occur after the existing application bundle has already moved, so this PR surfaces the failure without starting another installation attempt.

## Reviewer Test Plan

### How to verify

1. Make a newer signed Desktop update available, then force its download, signature verification, or installation to fail.
2. Confirm Qwen Code displays the failed version and error exactly once and does not restart.
3. Confirm the dialog tells the user to save work before quitting and reinstall if the application cannot reopen.
4. Restore the update source, start a fresh update attempt, and confirm a successful installation still restarts the app.

### Evidence (Before & After)

Before: the background update path discarded the error and returned without feedback.

After: a failed combined update attempt shows one native error dialog and returns without retrying or restarting. `cargo check --manifest-path packages/desktop-shell/src-tauri/Cargo.toml`, `cargo clippy --manifest-path packages/desktop-shell/src-tauri/Cargo.toml -- -D warnings`, and `git diff --check` pass.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

macOS arm64 compile and Clippy verification. A signed higher-version updater artifact was not available for the failure-dialog E2E.

## Risk & Scope

- Main risk or tradeoff: the updater dependency may leave the macOS application bundle unavailable after a partial installation failure; the dialog warns the user to save work and reinstall if reopening fails.
- Not validated / out of scope: a real signed failure-and-recovery pass and transactional restoration of a partially replaced application bundle.
- Breaking changes / migration notes: none.

## Linked Issues

Refs #8092.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

Desktop 自动更新的下载、签名校验或安装失败时不再静默返回。一次失败会显示版本和错误；由于安装失败可能已经修改应用包，本 PR 不会再次重试该安装，也不会重启应用。只有安装成功后才会重启。

## 为什么需要

修复前，用户点击 `Install and restart` 后，如果更新失败，界面看起来没有任何反应，用户既看不到错误，也没有恢复提示。在 macOS 上，组合 updater 操作可能在旧应用包已被移动后才失败，因此直接重试并不安全。本 PR 只负责可靠地展示失败，不启动第二次安装。

## Reviewer Test Plan

### 如何验证

1. 提供一个版本更高且已签名的 Desktop 更新，并让下载、签名校验或安装失败。
2. 确认 Qwen Code 只显示一次失败版本和错误，并且不会重启。
3. 确认弹窗提示用户退出前保存工作；若应用无法重新打开，则重新安装。
4. 恢复更新源，重新发起一次新的更新，确认安装成功后仍会重启应用。

### 修复前后证据

修复前：后台更新路径丢弃错误并直接返回，没有任何反馈。

修复后：组合更新失败时显示一次原生错误弹窗，然后返回，不重试也不重启。`cargo check --manifest-path packages/desktop-shell/src-tauri/Cargo.toml`、`cargo clippy --manifest-path packages/desktop-shell/src-tauri/Cargo.toml -- -D warnings` 和 `git diff --check` 均通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ⚠️  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境

macOS arm64 编译与 Clippy 验证。当前没有可用于失败弹窗 E2E 的高版本签名 updater artifact。

## 风险与范围

- 主要风险或权衡：updater 依赖在部分安装失败后可能使 macOS 应用包不可用；弹窗会提醒用户保存工作，并在无法重新打开时重新安装。
- 未验证/不在范围：真实签名 artifact 的失败恢复闭环，以及部分替换后事务性恢复旧应用包。
- 破坏性变更/迁移：无。

## 关联 Issue

关联 #8092。

</details>