### PR TITLE
fix(sdk): hide A2UI bridge frames from transcripts

### DIFF
--- a/packages/sdk-typescript/src/daemon/ui/normalizer.ts
+++ b/packages/sdk-typescript/src/daemon/ui/normalizer.ts
@@ -841,6 +841,15 @@ function normalizeSessionUpdate(
     case 'current_mode_update':
     case 'usage_update':
       return [];
+    // Qwen-private A2UI frame. The bridge splits A2UI command payloads out of
+    // the tool result precisely so raw command JSON never reaches transcripts
+    // (`prepareSessionUpdateFrames` in acp-bridge), then republishes them here
+    // for renderer clients. No first-party renderer consumes the frame yet, so
+    // the debug projection below would put that same JSON straight back into
+    // the transcript it was split out of. Drop it from transcript projection;
+    // raw daemon event subscribers still receive the frame unchanged.
+    case 'a2ui':
+      return [];
     default:
       return [
         {

--- a/packages/sdk-typescript/test/unit/daemonUi.test.ts
+++ b/packages/sdk-typescript/test/unit/daemonUi.test.ts
@@ -2522,6 +2522,40 @@ describe('daemon UI normalizer — Wave 3/4 event coverage (PR-A)', () => {
     expect(events).toEqual([]);
   });
 
+  it('does not surface a2ui bridge frames as debug transcript events', () => {
+    // Exact shape published by acp-bridge `prepareSessionUpdateFrames` when an
+    // A2UI-over-MCP tool result is split out of the tool frame.
+    const events = normalizeDaemonEvent(
+      envelopeOf('session_update', {
+        update: {
+          sessionUpdate: 'a2ui',
+          a2ui: {
+            surfaceId: 'surface-1',
+            callId: 'call_a2ui_0',
+            commands: [
+              { createSurface: { surfaceId: 'surface-1', root: 'root-col' } },
+              {
+                updateComponents: {
+                  surfaceId: 'surface-1',
+                  components: [
+                    {
+                      id: 'root-col',
+                      componentProperties: {
+                        text: { text: 'A2UI surface' },
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          _meta: { serverTimestamp: 1_786_268_283_279, source: 'a2ui-bridge' },
+        },
+      }),
+    );
+    expect(events).toEqual([]);
+  });
+
   it('normalizes memory_changed with closed-enum scope + mode', () => {
     const events = normalizeDaemonEvent(
       envelopeOf('memory_changed', {


### PR DESCRIPTION
## What this PR does

This PR stops the Qwen-private `sessionUpdate: 'a2ui'` bridge frame from appearing as a raw debug row in daemon-backed transcripts. The frame stays on the daemon event stream unchanged for raw subscribers and for the A2UI renderer that will eventually consume it; it is only excluded from transcript projection.

## Why it's needed

`prepareSessionUpdateFrames` in `packages/acp-bridge/src/bridgeClient.ts` extracts A2UI-over-MCP command payloads out of the `tool_call_update` result and republishes them as a separate `sessionUpdate: 'a2ui'` frame — explicitly so that "raw command JSON never reaches transcripts/SSE", and it sanitizes the original tool frame accordingly. But the daemon UI normalizer has no `a2ui` case, so the newly split frame falls through to the unknown-event debug projection and Web Shell renders the exact JSON the bridge had just sanitized away.

`grep surfaceId` across the repo shows no first-party renderer consumes the frame today (only `acp-bridge` and `cli/serve/routes/a2ui-action.ts` reference it), so the debug projection is the only thing that surfaces it — as an unreadable JSON blob in the middle of the conversation.

This is the same presentation-layer classification bug as #8790 (`usage_update`), in the same `switch` default. Web Shell is the only surface where it shows: webui's ChatViewer drops `kind === 'debug'` blocks (`packages/webui/src/daemon/transcriptAdapter.ts:56`), while Web Shell renders `status` and `debug` blocks together as system info (`packages/web-shell/client/adapters/transcriptToMessages.ts`).

## Reviewer Test Plan

### How to verify

1. Register a stdio MCP server whose name contains `a2ui`, exposing a tool that returns an A2UI command array followed by fallback text (`[{"createSurface":{...}},{"updateComponents":{...}}]\nRendered an A2UI surface.`).
2. Set `tools.toolSearch.enabled: false` so the MCP tool is declared upfront rather than deferred behind ToolSearch.
3. Start a daemon-backed Web Shell session and prompt the model to call that tool.
4. Confirm no raw `a2ui: {...}` JSON row appears in the transcript, while the tool call, assistant text and token accounting remain visible.
5. Confirm the frame is still on the wire: subscribe to `GET /session/:id/events` and check that a `"sessionUpdate":"a2ui"` frame is still delivered.

### Evidence (Before & After)

Verified against a real `qwen serve` daemon with an isolated `QWEN_HOME`, a recording mock OpenAI-compatible provider, a stdio MCP server named `a2ui`, and the real Web Shell in Chrome.

Raw SSE frames from the daemon (unchanged by this PR):

```
session_update tool_call_update  {"_meta":{"toolName":"mcp__a2ui__present_ui","serverId":"a2ui"},"status":"in_progress",...}
session_update a2ui              {"sessionUpdate":"a2ui","a2ui":{"surfaceId":"surface-verify-1","callId":"call_a2ui_3","commands":[...]}}
session_update tool_call_update  {"content":[{"content":{"text":"Rendered an A2UI surface."}}],"status":"completed",...}
```

Before: the transcript carries a full `a2ui: { "sessionUpdate": "a2ui", "a2ui": { "surfaceId": ..., "commands": [...] } }` debug row.

<img width="1558" height="784" alt="Before: raw a2ui JSON row in the Web Shell transcript" src="https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/8808-verify/before-a2ui-debug-row.jpg" />

After: same prompt, header still reports one tool call, and only `Surface presented.` remains. A follow-up SSE capture confirms the `a2ui` frame is still emitted once.

<img width="1558" height="784" alt="After: the JSON row is gone, only the assistant message remains" src="https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/8808-verify/after-a2ui-hidden.jpg" />

The regression test uses the exact frame shape produced by the bridge and asserts it yields no daemon UI transcript event. Removing the `case 'a2ui'` line makes the test fail (mutation-checked).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS, local Node.js workspace, real `qwen serve` daemon + real Web Shell, focused SDK unit tests, lint and typecheck.

## Risk & Scope

- Main risk or tradeoff: daemon UI transcript consumers no longer receive `a2ui` as a debug block. Raw daemon event subscribers and any future A2UI renderer still receive the original frame.
- Not validated / out of scope: rendering A2UI surfaces in Web Shell, the `a2ui-action` route, and the broader root cause — Web Shell displaying `debug` blocks at all, which is what makes every unrecognized event kind leak here (`isIgnoredWebShellStatus` already suppresses `language_changed` and `session_cwd_changed` by string prefix). That deserves its own change: a structured `debugReason` on the normalizer's debug events plus splitting `case 'debug'` from `case 'status'` in Web Shell.
- Breaking changes / migration notes: none.

## Linked Issues

Follows #8790, which fixed the same classification bug for `usage_update`.

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本 PR 阻止 Qwen 私有的 `sessionUpdate: 'a2ui'` bridge 帧在 daemon 驱动的会话中显示成原始调试信息。该帧仍原样保留在 daemon 事件流上,供原始事件订阅者以及将来的 A2UI 渲染器消费,只是不再进入 transcript 投影。

## 为什么需要

`packages/acp-bridge/src/bridgeClient.ts` 的 `prepareSessionUpdateFrames` 会把 A2UI-over-MCP 的命令载荷从 `tool_call_update` 结果中拆出来,单独发成 `sessionUpdate: 'a2ui'` 帧,注释里写明这样做正是为了"原始命令 JSON 永远不会进入 transcript/SSE",并相应地把原工具帧做了 sanitize。但 daemon UI normalizer 没有 `a2ui` 分支,于是这个刚拆出来的帧落入未知事件的 debug 投影,Web Shell 把 bridge 刚刚清理掉的那段 JSON 又原样显示了出来。

全仓 `grep surfaceId` 显示目前没有任何第一方渲染器消费这个帧(只有 `acp-bridge` 和 `cli/serve/routes/a2ui-action.ts` 引用),所以 debug 投影是它唯一的露出方式——一段夹在对话中间、无法阅读的 JSON。

这与 #8790(`usage_update`)是同一个展示层分类问题,落在同一个 `switch` 的 default 分支。只有 Web Shell 会显示出来:webui 的 ChatViewer 会丢弃 `kind === 'debug'` 块(`packages/webui/src/daemon/transcriptAdapter.ts:56`),而 Web Shell 把 `status` 和 `debug` 一起渲染成 system 信息(`packages/web-shell/client/adapters/transcriptToMessages.ts`)。

## 审查者测试计划

### 验证方法

1. 配置一个名字含 `a2ui` 的 stdio MCP server,提供一个返回 A2UI 命令数组 + fallback 文本的工具(`[{"createSurface":{...}},{"updateComponents":{...}}]\nRendered an A2UI surface.`)。
2. 设置 `tools.toolSearch.enabled: false`,让 MCP 工具直接声明,而不是延迟在 ToolSearch 之后。
3. 启动 daemon 驱动的 Web Shell 会话,提示模型调用该工具。
4. 确认 transcript 中不再出现原始 `a2ui: {...}` JSON 行,同时工具调用、助手文本和 token 统计仍然可见。
5. 确认帧仍在线上:订阅 `GET /session/:id/events`,检查 `"sessionUpdate":"a2ui"` 帧仍被投递。

### 证据(修复前与修复后)

在真实 `qwen serve` daemon(隔离 `QWEN_HOME`)、记录型 mock OpenAI 兼容服务、名为 `a2ui` 的 stdio MCP server 以及 Chrome 中的真实 Web Shell 上验证。

daemon 的原始 SSE 帧(本 PR 不改变它们):

```
session_update tool_call_update  {"_meta":{"toolName":"mcp__a2ui__present_ui","serverId":"a2ui"},"status":"in_progress",...}
session_update a2ui              {"sessionUpdate":"a2ui","a2ui":{"surfaceId":"surface-verify-1","callId":"call_a2ui_3","commands":[...]}}
session_update tool_call_update  {"content":[{"content":{"text":"Rendered an A2UI surface."}}],"status":"completed",...}
```

修复前:transcript 中出现完整的 `a2ui: { "sessionUpdate": "a2ui", "a2ui": { "surfaceId": ..., "commands": [...] } }` 调试行。

修复后:同一条 prompt,头部仍显示一次工具调用,transcript 中只剩 `Surface presented.`。随后再抓一次 SSE,确认 `a2ui` 帧仍然发出一次。

回归测试使用 bridge 实际产生的帧形状,断言它不会产生 daemon UI transcript 事件。删掉 `case 'a2ui'` 那一行,测试即失败(已做变异验证)。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境(可选)

macOS、本地 Node.js workspace、真实 `qwen serve` daemon + 真实 Web Shell、聚焦的 SDK 单元测试、lint 与 typecheck。

## 风险与范围

- 主要风险或权衡:daemon UI transcript 消费者不再把 `a2ui` 收到为 debug block;原始 daemon event 订阅者和将来的 A2UI 渲染器仍会收到原帧。
- 未验证 / 范围外:在 Web Shell 中渲染 A2UI surface、`a2ui-action` 路由,以及更根本的问题——Web Shell 会显示 `debug` 块本身,这正是每个未识别事件类型都会从这里泄漏的原因(`isIgnoredWebShellStatus` 已经用字符串前缀屏蔽了 `language_changed` 和 `session_cwd_changed`)。这值得单独改:给 normalizer 的 debug 事件加结构化的 `debugReason`,并在 Web Shell 中把 `case 'debug'` 从 `case 'status'` 拆开。
- 破坏性变更 / 迁移说明:无。

## 关联 Issue

承接 #8790,该 PR 修复了 `usage_update` 上的同一个分类问题。

</details>
