### PR TITLE
test(memory): Cover context refresh marker carry-over turns

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -20542,6 +20542,12 @@ describe('Session', () => {
           _meta: meta,
         } as Parameters<typeof session.prompt>[0]);
 
+        // Pin that the continuation turn reached the model: one send from the
+        // marking turn and one from the continuation. Without this, a future
+        // recovery-plan classifier change could make the turn return before
+        // the intent-clearing gate while this test stays green.
+        expect(mockChat.sendMessageStream).toHaveBeenCalledTimes(2);
+
         allowAcpWriteFile();
         await runAcpWriteFile(
           '/repo/QWEN.md',

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -20522,6 +20522,39 @@ describe('Session', () => {
       expect(refreshMemoryInstructionSpy).not.toHaveBeenCalled();
     });
 
+    it.each([
+      ['retry', { 'qwen.daemon.retry': true }, false],
+      ['continue', { 'qwen.daemon.continueLastTurn': true }, true],
+    ])(
+      'preserves context-file refresh intent across an ACP %s turn',
+      async (_label, meta, seedInterruptedHistory) => {
+        await markAcpContextRefreshIntent();
+        refreshMemoryInstructionSpy.mockClear();
+        if (seedInterruptedHistory) {
+          vi.mocked(mockChat.getHistory).mockReturnValue([
+            { role: 'user', parts: [{ text: 'unanswered question' }] },
+          ]);
+        }
+
+        await session.prompt({
+          sessionId: 'test-session-id',
+          prompt: [{ type: 'text', text: 'continue remembered fact write' }],
+          _meta: meta,
+        } as Parameters<typeof session.prompt>[0]);
+
+        allowAcpWriteFile();
+        await runAcpWriteFile(
+          '/repo/QWEN.md',
+          'prompt-preserved-context-write',
+        );
+
+        expect(refreshMemoryInstructionSpy).toHaveBeenCalledWith(mockConfig, {
+          logContext:
+            'ACP session test-session-id context-file memory tool batch',
+        });
+      },
+    );
+
     it('does not refresh context-file instructions for ordinary ACP QWEN.md writes', async () => {
       const execute = vi.fn().mockResolvedValue({
         llmContent: 'wrote context',

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -9469,6 +9469,10 @@ describe('useGeminiStream', () => {
       const onComplete = mockUseReactToolScheduler.mock.calls.at(-1)?.[0] as
         | ((completedTools: TrackedToolCall[]) => Promise<void>)
         | undefined;
+      expect(
+        onComplete,
+        'useReactToolScheduler onComplete was never registered',
+      ).toBeDefined();
       await act(async () => {
         await onComplete?.([completedToolCall]);
       });

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -9449,29 +9449,72 @@ describe('useGeminiStream', () => {
       };
     }
 
-    async function submitSlashCommandAndCompleteTool(
-      completedToolCall: TrackedCompletedToolCall,
-      refreshContextFilesOnWrite?: boolean,
-    ) {
-      mockHandleSlashCommand.mockResolvedValue({
+    async function markContextRefreshIntent() {
+      mockHandleSlashCommand.mockResolvedValueOnce({
         type: 'submit_prompt',
-        content: refreshContextFilesOnWrite ? 'remember this' : 'write docs',
-        ...(refreshContextFilesOnWrite
-          ? { refreshContextFilesOnWrite: true }
-          : {}),
+        content: 'remember this',
+        refreshContextFilesOnWrite: true,
       });
 
       const { result } = renderTestHook();
       await act(async () => {
-        await result.current.submitQuery(
-          refreshContextFilesOnWrite ? '/remember fact' : '/write-docs',
-        );
+        await result.current.submitQuery('/remember fact');
       });
+      mockRefreshMemoryInstruction.mockClear();
+      return result;
+    }
+
+    async function completeToolWrite(
+      completedToolCall: TrackedCompletedToolCall,
+    ) {
       const onComplete = mockUseReactToolScheduler.mock.calls.at(-1)?.[0] as
         | ((completedTools: TrackedToolCall[]) => Promise<void>)
         | undefined;
       await act(async () => {
         await onComplete?.([completedToolCall]);
+      });
+    }
+
+    async function submitSlashCommandAndCompleteTool(
+      completedToolCall: TrackedCompletedToolCall,
+      refreshContextFilesOnWrite?: boolean,
+    ) {
+      if (refreshContextFilesOnWrite) {
+        await markContextRefreshIntent();
+      } else {
+        mockHandleSlashCommand.mockResolvedValue({
+          type: 'submit_prompt',
+          content: 'write docs',
+        });
+        const { result } = renderTestHook();
+        await act(async () => {
+          await result.current.submitQuery('/write-docs');
+        });
+      }
+      await completeToolWrite(completedToolCall);
+    }
+
+    async function submitContinuationAndCompleteTool(
+      result: ReturnType<typeof renderTestHook>['result'],
+      text: string,
+      submitType: SendMessageType,
+      promptId?: string,
+      extra?: { goal?: QueuedGoalTurn },
+    ) {
+      await act(async () => {
+        await result.current.submitQuery(text, submitType, promptId, extra);
+      });
+      // Pin that the continuation turn was admitted and reached the model;
+      // submitQuery can silently reject via its lease/streaming-state guards.
+      await waitFor(() => {
+        expect(mockSendMessageStream).toHaveBeenCalledTimes(2);
+      });
+      await completeToolWrite(
+        createCompletedFileWrite({ filePath: '/test/dir/QWEN.md' }),
+      );
+
+      expect(mockRefreshMemoryInstruction).toHaveBeenCalledWith(mockConfig, {
+        logContext: 'interactive context-file memory tool batch',
       });
     }
 
@@ -9487,39 +9530,23 @@ describe('useGeminiStream', () => {
     });
 
     it('keeps refreshing context-file instructions for later writes in a marked turn', async () => {
-      mockHandleSlashCommand.mockResolvedValue({
-        type: 'submit_prompt',
-        content: 'remember this',
-        refreshContextFilesOnWrite: true,
-      });
+      await markContextRefreshIntent();
 
-      const { result } = renderTestHook();
-      await act(async () => {
-        await result.current.submitQuery('/remember fact');
-      });
-      const onComplete = mockUseReactToolScheduler.mock.calls.at(-1)?.[0] as
-        | ((completedTools: TrackedToolCall[]) => Promise<void>)
-        | undefined;
-
-      await act(async () => {
-        await onComplete?.([
-          createCompletedFileWrite({
-            callId: 'write-context-call-1',
-            filePath: '/test/dir/QWEN.md',
-          }),
-        ]);
-      });
+      await completeToolWrite(
+        createCompletedFileWrite({
+          callId: 'write-context-call-1',
+          filePath: '/test/dir/QWEN.md',
+        }),
+      );
       await waitFor(() => {
         expect(mockSendMessageStream).toHaveBeenCalledTimes(2);
       });
-      await act(async () => {
-        await onComplete?.([
-          createCompletedFileWrite({
-            callId: 'write-context-call-2',
-            filePath: '/test/dir/QWEN.md',
-          }),
-        ]);
-      });
+      await completeToolWrite(
+        createCompletedFileWrite({
+          callId: 'write-context-call-2',
+          filePath: '/test/dir/QWEN.md',
+        }),
+      );
 
       expect(mockRefreshMemoryInstruction).toHaveBeenCalledTimes(2);
     });
@@ -9569,86 +9596,24 @@ describe('useGeminiStream', () => {
     });
 
     it('clears unmatched context-file refresh intent on the next ordinary turn', async () => {
-      mockHandleSlashCommand.mockResolvedValue({
-        type: 'submit_prompt',
-        content: 'remember this',
-        refreshContextFilesOnWrite: true,
-      });
-
-      const { result } = renderTestHook();
-      await act(async () => {
-        await result.current.submitQuery('/remember fact');
-      });
-      const markedOnComplete = mockUseReactToolScheduler.mock.calls.at(
-        -1,
-      )?.[0] as
-        | ((completedTools: TrackedToolCall[]) => Promise<void>)
-        | undefined;
-      await act(async () => {
-        await markedOnComplete?.([
-          createCompletedFileWrite({ filePath: '/test/dir/notes.md' }),
-        ]);
-      });
+      const result = await markContextRefreshIntent();
+      await completeToolWrite(
+        createCompletedFileWrite({ filePath: '/test/dir/notes.md' }),
+      );
 
       mockHandleSlashCommand.mockResolvedValue(false);
       await act(async () => {
         await result.current.submitQuery('ordinary turn');
       });
-      const ordinaryOnComplete = mockUseReactToolScheduler.mock.calls.at(
-        -1,
-      )?.[0] as
-        | ((completedTools: TrackedToolCall[]) => Promise<void>)
-        | undefined;
-      await act(async () => {
-        await ordinaryOnComplete?.([
-          createCompletedFileWrite({
-            callId: 'ordinary-write-context-call',
-            filePath: '/test/dir/QWEN.md',
-          }),
-        ]);
-      });
+      await completeToolWrite(
+        createCompletedFileWrite({
+          callId: 'ordinary-write-context-call',
+          filePath: '/test/dir/QWEN.md',
+        }),
+      );
 
       expect(mockRefreshMemoryInstruction).not.toHaveBeenCalled();
     });
-
-    async function markContextRefreshIntent() {
-      mockHandleSlashCommand.mockResolvedValueOnce({
-        type: 'submit_prompt',
-        content: 'remember this',
-        refreshContextFilesOnWrite: true,
-      });
-
-      const { result } = renderTestHook();
-      await act(async () => {
-        await result.current.submitQuery('/remember fact');
-      });
-      mockRefreshMemoryInstruction.mockClear();
-      return result;
-    }
-
-    async function submitContinuationAndCompleteTool(
-      result: ReturnType<typeof renderTestHook>['result'],
-      text: string,
-      submitType: SendMessageType,
-      promptId?: string,
-      extra?: { goal?: QueuedGoalTurn },
-    ) {
-      await act(async () => {
-        await result.current.submitQuery(text, submitType, promptId, extra);
-      });
-      const onComplete = mockUseReactToolScheduler.mock.calls.at(-1)?.[0] as
-        | ((completedTools: TrackedToolCall[]) => Promise<void>)
-        | undefined;
-      await act(async () => {
-        await onComplete?.([
-          createCompletedFileWrite({ filePath: '/test/dir/QWEN.md' }),
-        ]);
-      });
-
-      expect(mockRefreshMemoryInstruction).toHaveBeenCalledWith(mockConfig, {
-        logContext: 'interactive context-file memory tool batch',
-      });
-    }
 
     it.each([
       ['Retry', SendMessageType.Retry],

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -9460,7 +9460,6 @@ describe('useGeminiStream', () => {
       await act(async () => {
         await result.current.submitQuery('/remember fact');
       });
-      mockRefreshMemoryInstruction.mockClear();
       return result;
     }
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -9611,6 +9611,81 @@ describe('useGeminiStream', () => {
       expect(mockRefreshMemoryInstruction).not.toHaveBeenCalled();
     });
 
+    async function markContextRefreshIntent() {
+      mockHandleSlashCommand.mockResolvedValueOnce({
+        type: 'submit_prompt',
+        content: 'remember this',
+        refreshContextFilesOnWrite: true,
+      });
+
+      const { result } = renderTestHook();
+      await act(async () => {
+        await result.current.submitQuery('/remember fact');
+      });
+      mockRefreshMemoryInstruction.mockClear();
+      return result;
+    }
+
+    async function submitContinuationAndCompleteTool(
+      result: ReturnType<typeof renderTestHook>['result'],
+      text: string,
+      submitType: SendMessageType,
+      promptId?: string,
+      extra?: { goal?: QueuedGoalTurn },
+    ) {
+      await act(async () => {
+        await result.current.submitQuery(text, submitType, promptId, extra);
+      });
+      const onComplete = mockUseReactToolScheduler.mock.calls.at(-1)?.[0] as
+        | ((completedTools: TrackedToolCall[]) => Promise<void>)
+        | undefined;
+      await act(async () => {
+        await onComplete?.([
+          createCompletedFileWrite({ filePath: '/test/dir/QWEN.md' }),
+        ]);
+      });
+
+      expect(mockRefreshMemoryInstruction).toHaveBeenCalledWith(mockConfig, {
+        logContext: 'interactive context-file memory tool batch',
+      });
+    }
+
+    it.each([
+      ['Retry', SendMessageType.Retry],
+      ['Notification', SendMessageType.Notification],
+    ])(
+      'preserves context-file refresh intent across a %s turn',
+      async (_label, submitType) => {
+        const result = await markContextRefreshIntent();
+        await submitContinuationAndCompleteTool(
+          result,
+          'retry remember write',
+          submitType,
+        );
+      },
+    );
+
+    it('preserves context-file refresh intent across a Goal turn', async () => {
+      const result = await markContextRefreshIntent();
+      const goal: QueuedGoalTurn = {
+        kind: 'goal',
+        permit: {
+          goalId: 'goal-memory-refresh',
+          revision: 1,
+          turnId: 'turn-memory-refresh',
+        },
+        turnKey: 'goal-runtime:turn-memory-refresh',
+        continuationContext: 'continue remembered fact write',
+      };
+      await submitContinuationAndCompleteTool(
+        result,
+        goal.continuationContext,
+        SendMessageType.Goal,
+        'prompt-id-goal-memory-refresh',
+        { goal },
+      );
+    });
+
     it('does not run the legacy save_memory refresh when managed-memory writes refresh the batch', async () => {
       mockRefreshMemoryAfterManagedWrite.mockResolvedValueOnce(true);
       const mockPerformMemoryRefresh = vi.fn();


### PR DESCRIPTION
Title: test(memory): Cover context refresh marker carry-over turns

## What this PR does

This PR adds focused regression coverage for the context-file refresh marker introduced by the `/remember` memory refresh fix. It verifies that marked context-file refresh intent survives the synthetic or retry-style turns that intentionally do not represent a new ordinary user turn: interactive Retry, interactive Notification, interactive Goal, ACP daemon retry, and ACP daemon continue.

## Why it's needed

PR #8640 fixed the stale live-instruction path by keeping a marked `/remember` turn armed until a successful project context-file write can refresh the system instruction. The final review noted that the ordinary-turn reset was covered, but the carry-over exceptions were not pinned by tests. Without these tests, a future refactor could clear the marker on retry or continuation paths and silently reintroduce the original stale-memory behavior for failed `/remember` turns that are retried or continued.

## Reviewer Test Plan

### How to verify

Review the added tests and confirm they first mark a `/remember` turn with context-file refresh intent, then submit the corresponding retry/continuation turn, then complete a successful `QWEN.md` write and assert that the live memory instruction refresh runs.

### Evidence (Before & After)

N/A — test-only regression coverage.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local Node is `v26.2.0`. Focused tests and formatting were run locally; root build/typecheck currently fail on latest `origin/main` in this worktree due unrelated CLI type issues around `qrcode-terminal` / `jsdom` declarations and implicit-any errors.

## Risk & Scope

- Main risk or tradeoff: Very low; this PR changes tests only and does not change runtime behavior.
- Not validated / out of scope: This does not broaden the context-file matcher to global, ancestor, local, extension, shell-written, or case-insensitive context-file paths. Those are broader behavior/design follow-ups.
- Breaking changes / migration notes: None.

## Linked Issues

Follow-up to #8640 and #6487.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 为 `/remember` 记忆刷新修复中引入的 context-file refresh marker 补充聚焦回归测试。它验证被标记的上下文文件刷新意图会在几类“不是普通新用户 turn”的合成或重试路径中保留下来：交互式 Retry、交互式 Notification、交互式 Goal、ACP daemon retry，以及 ACP daemon continue。

## 为什么需要

PR #8640 通过让被标记的 `/remember` turn 在成功写入项目上下文文件之前保持 armed，修复了 live instruction 陈旧的问题。最终 review 里指出：普通 turn 清除标记的方向已经有测试，但这些 carry-over 例外路径没有被测试钉住。没有这些测试的话，未来重构可能会在 retry 或 continuation 路径上误清除标记，从而让失败后重试或继续的 `/remember` turn 重新出现原来的 stale-memory 行为。

## Reviewer Test Plan

### How to verify

查看新增测试，确认它们都会先通过 `/remember` 标记 context-file refresh intent，然后提交对应的 retry/continuation turn，最后模拟一次成功的 `QWEN.md` 写入，并断言 live memory instruction refresh 被调用。

### Evidence (Before & After)

N/A —— 这是纯测试回归覆盖。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 Node 是 `v26.2.0`。已在本地运行 focused tests 和格式检查；当前最新 `origin/main` 在这个 worktree 里 root build/typecheck 会因为与本改动无关的 CLI 类型问题失败，主要是 `qrcode-terminal` / `jsdom` declaration 缺失以及 implicit-any 错误。

## Risk & Scope

- 主要风险或取舍：很低；这个 PR 只改测试，不改运行时行为。
- 未验证 / 不在范围内：本 PR 不扩展 context-file matcher 到 global、ancestor、local、extension、shell 写入或大小写不敏感路径；这些属于更宽的行为和设计 follow-up。
- Breaking changes / migration notes：无。

## Linked Issues

#8640 和 #6487 的 follow-up。

</details>
