### PR TITLE
fix(cli): require exact daemon marker before env scrub

### DIFF
--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -541,25 +541,37 @@ describe('gemini.tsx main function', () => {
   // only daemon-stamped children (QWEN_CODE_SERVE) scrub, direct editor ACP
   // integrations and non-ACP launches keep their own loader vars.
   it.each([
-    ['scrubs for a daemon-spawned child', { acp: true } as CliArgs, true, true],
+    ['scrubs for a daemon-spawned child', { acp: true } as CliArgs, '1', true],
     [
       'keeps for a direct (editor) ACP child',
       { acp: true } as CliArgs,
-      false,
+      undefined,
       false,
     ],
-    ['keeps for a non-ACP launch', {} as CliArgs, false, false],
+    [
+      'keeps when the daemon marker is zero',
+      { acp: true } as CliArgs,
+      '0',
+      false,
+    ],
+    [
+      'keeps when the daemon marker is false',
+      { acp: true } as CliArgs,
+      'false',
+      false,
+    ],
+    ['keeps for a non-ACP launch', {} as CliArgs, undefined, false],
   ])(
     'inherited loader env vars past the ACP handoff (%s)',
-    async (_mode, argv, daemonStamped, expectScrubbed) => {
+    async (_mode, argv, daemonMarker, expectScrubbed) => {
       vi.stubEnv(
         'NODE_OPTIONS',
         '--import file:///other-checkout/register.mjs',
       );
       vi.stubEnv('NODE_PATH', '/other-checkout/node_modules');
       vi.stubEnv('QWEN_CODE_NO_RELAUNCH', 'true');
-      if (daemonStamped) {
-        vi.stubEnv('QWEN_CODE_SERVE', '1');
+      if (daemonMarker !== undefined) {
+        vi.stubEnv('QWEN_CODE_SERVE', daemonMarker);
       }
 
       const { parseArguments, loadCliConfig } = await import(

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -545,7 +545,7 @@ describe('gemini.tsx main function', () => {
     [
       'keeps for a direct (editor) ACP child',
       { acp: true } as CliArgs,
-      undefined,
+      '',
       false,
     ],
     [
@@ -560,7 +560,7 @@ describe('gemini.tsx main function', () => {
       'false',
       false,
     ],
-    ['keeps for a non-ACP launch', {} as CliArgs, undefined, false],
+    ['keeps for a non-ACP launch', {} as CliArgs, '', false],
   ])(
     'inherited loader env vars past the ACP handoff (%s)',
     async (_mode, argv, daemonMarker, expectScrubbed) => {

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -669,7 +669,7 @@ export async function main() {
     }
   }
 
-  if (isAcpMode && process.env[QWEN_CODE_SERVE_ENV]) {
+  if (isAcpMode && process.env[QWEN_CODE_SERVE_ENV] === '1') {
     // A daemon-spawned ACP child hosts sessions for arbitrary workspaces.
     // Loader vars from the daemon's launch environment were only needed to
     // boot this process (e.g. the dev harness tsx loader); left in


### PR DESCRIPTION
## What this PR does

This PR requires `QWEN_CODE_SERVE` to equal the literal value `1` before applying daemon-only loader environment cleanup. It also extends the existing ACP startup regression table so `0` and `false` are verified as ordinary non-daemon values.

## Why it's needed

The channel attribution fallback already accepts only `QWEN_CODE_SERVE=1`, but the loader environment cleanup still used a truthy check. As a result, a direct ACP launch with `QWEN_CODE_SERVE=0` or `QWEN_CODE_SERVE=false` reported `channel=ACP` while unexpectedly removing `NODE_OPTIONS` and `NODE_PATH`. This aligns both consumers on the same exact marker contract. Normal daemon launches are unchanged because every in-repository daemon producer writes `1` explicitly.

## Reviewer Test Plan

### How to verify

- Run `cd packages/cli && npx vitest run src/gemini.test.tsx` and confirm all startup tests pass, including the `0` and `false` marker cases.
- Run `cd packages/cli && npx vitest run src/config/acp-channel-fallback.test.ts` and confirm attribution still rejects non-`1` marker values.
- Confirm a daemon-stamped ACP launch still removes inherited loader variables, while a direct ACP launch with `QWEN_CODE_SERVE=0` or `false` preserves them.

### Evidence (Before & After)

Before: the direct-ACP regression test failed with `expected undefined to be '--import file:///other-checkout/register.mjs'` when the ambient marker was `0` or `false`.

After: the complete startup test file passes with explicit coverage for both values.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22, local unit tests and repository build.

## Risk & Scope

- Main risk or tradeoff: none for daemon-managed sessions; their launchers overwrite the marker with `1`.
- Not validated / out of scope: no end-to-end daemon client session was needed because this change only narrows an already tested startup gate.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #8712 and #8663. Related to #8660.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

本 PR 要求 `QWEN_CODE_SERVE` 必须严格等于字面量 `1`，才执行 daemon 专属的 loader 环境清理。同时扩展现有 ACP 启动回归测试，确认 `0` 和 `false` 都按普通非 daemon 值处理。

## 为什么需要

channel 归因回退已经只接受 `QWEN_CODE_SERVE=1`，但 loader 环境清理仍使用 truthy 判断。因此，直接 ACP 启动如果设置了 `QWEN_CODE_SERVE=0` 或 `QWEN_CODE_SERVE=false`，会上报 `channel=ACP`，却意外删除 `NODE_OPTIONS` 和 `NODE_PATH`。本次修复让两个 consumer 遵循同一个精确 marker 约定。正常 daemon 启动不受影响，因为仓库内所有 daemon 生产者都会显式写入 `1`。

## Reviewer Test Plan

### 如何验证

- 运行 `cd packages/cli && npx vitest run src/gemini.test.tsx`，确认全部启动测试通过，包括 `0` 和 `false` marker 用例。
- 运行 `cd packages/cli && npx vitest run src/config/acp-channel-fallback.test.ts`，确认归因逻辑仍拒绝非 `1` marker。
- 确认 daemon 标记的 ACP 启动仍会移除继承的 loader 变量，而设置 `QWEN_CODE_SERVE=0` 或 `false` 的直接 ACP 启动会保留这些变量。

### 前后对比证据

修复前：ambient marker 为 `0` 或 `false` 时，直接 ACP 回归测试失败，错误为 `expected undefined to be '--import file:///other-checkout/register.mjs'`。

修复后：完整启动测试文件通过，并显式覆盖这两个值。

### 测试环境

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

Node.js 22，本地单元测试与仓库构建。

## 风险与范围

- 主要风险或权衡：daemon 管理的会话没有变化，其 launcher 会将 marker 覆盖为 `1`。
- 未验证 / 不在范围内：不需要额外运行端到端 daemon client 会话，因为本次改动只收紧了已有测试覆盖的启动判断。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

#8712 和 #8663 的后续修复，与 #8660 相关。

</details>
