### PR TITLE
feat(desktop): create default workspace on first launch

### DIFF
--- a/docs/design/2026-08-09-desktop-default-workspace.md
+++ b/docs/design/2026-08-09-desktop-default-workspace.md
@@ -1,0 +1,21 @@
+# Desktop default workspace
+
+## Motivation
+
+The Tauri app currently blocks first launch on a folder picker because its bundled `qwen serve` process needs a primary workspace. The previous Electron app instead created a protected `Qwen` conversation workspace and let users add projects after entering the app.
+
+## Design
+
+Desktop resolves its primary workspace in this order:
+
+1. `QWEN_DESKTOP_WORKSPACE`
+2. The workspace saved in `desktop-state.json`
+3. `~/Documents/Qwen`, matching the Electron app and created on first launch
+
+Only the default directory is created automatically. A missing environment-provided or saved workspace continues through the existing recovery page rather than recreating a user project path.
+
+The default remains the stable daemon primary. Project directories continue to use the Web Shell's existing dynamic workspace registration and switching, so adding a project does not restart Node. The bootstrap folder picker remains available only for recovery.
+
+## Compatibility
+
+Existing Tauri users retain their saved primary workspace. Existing `Documents/Qwen` content is reused without migration or deletion. The runtime command, daemon, Web Shell, and Local Control lifecycle remain unchanged.

--- a/packages/desktop-shell/README.md
+++ b/packages/desktop-shell/README.md
@@ -25,7 +25,7 @@ npm test --workspaces=false
 npm run dev --workspaces=false
 ```
 
-Use `QWEN_DESKTOP_WORKSPACE=/absolute/path` to override the initial workspace. The app otherwise restores its saved primary workspace or creates `~/Documents/Qwen` on first launch. Add and switch project workspaces from the Web Shell after startup.
+Use `QWEN_DESKTOP_WORKSPACE=/absolute/path` to override the initial workspace. The app otherwise restores its saved primary workspace or creates `~/Documents/Qwen` on first launch. `QWEN_DEFAULT_WORKSPACE_DIR=/absolute/path` relocates that first-launch default, matching the Electron shell. Add and switch project workspaces from the Web Shell after startup.
 
 ## Releases
 

--- a/packages/desktop-shell/README.md
+++ b/packages/desktop-shell/README.md
@@ -25,7 +25,7 @@ npm test --workspaces=false
 npm run dev --workspaces=false
 ```
 
-Use `QWEN_DESKTOP_WORKSPACE=/absolute/path` to choose the initial workspace. Without it, the app shows a workspace picker on first launch.
+Use `QWEN_DESKTOP_WORKSPACE=/absolute/path` to override the initial workspace. The app otherwise restores its saved primary workspace or creates `~/Documents/Qwen` on first launch. Add and switch project workspaces from the Web Shell after startup.
 
 ## Releases
 

--- a/packages/desktop-shell/bootstrap/bootstrap.js
+++ b/packages/desktop-shell/bootstrap/bootstrap.js
@@ -27,6 +27,7 @@ function setStatus(kind, heading, message, failure = '') {
   error.style.display = failure ? 'block' : 'none';
   error.textContent = failure;
   retry.hidden = kind !== 'error';
+  choose.hidden = kind === 'starting';
   choose.disabled = kind === 'starting';
 }
 
@@ -40,7 +41,8 @@ async function chooseWorkspace() {
   try {
     const path = await invoke('choose_workspace');
     if (path) setWorkspace(path);
-    else setStatus('idle', 'Choose where to work', 'No folder was selected.');
+    else
+      setStatus('idle', 'Choose another workspace', 'No folder was selected.');
   } catch (failure) {
     setStatus(
       'error',
@@ -120,13 +122,6 @@ async function initialize() {
   }
 
   await Promise.all([
-    listen('workspace-required', () => {
-      setStatus(
-        'idle',
-        'Choose where to work',
-        'Qwen Code runs locally and keeps the existing Web Shell as the only interface.',
-      );
-    }),
     listen('runtime-starting', ({ payload }) => {
       setWorkspace(payload);
       setStatus(
@@ -175,8 +170,8 @@ async function initialize() {
   } else {
     setStatus(
       'idle',
-      'Choose where to work',
-      'Qwen Code runs locally and keeps the existing Web Shell as the only interface.',
+      'Choose another workspace',
+      'The automatic workspace did not start.',
     );
   }
 }

--- a/packages/desktop-shell/bootstrap/index.html
+++ b/packages/desktop-shell/bootstrap/index.html
@@ -243,19 +243,20 @@
           </div>
         </div>
         <div class="status">
-          <div id="pulse" class="pulse idle"></div>
+          <div id="pulse" class="pulse"></div>
           <div>
-            <h2 id="title">Choose where to work</h2>
+            <h2 id="title">Starting Qwen Code</h2>
             <p id="detail">
-              Qwen Code runs locally and keeps the existing Web Shell as the
-              only interface.
+              Preparing the local workspace and bundled runtime…
             </p>
             <div id="workspace" class="workspace" hidden></div>
             <pre id="error"></pre>
           </div>
         </div>
         <div class="actions">
-          <button id="choose" class="primary">Choose workspace</button>
+          <button id="choose" class="primary" hidden>
+            Choose another workspace
+          </button>
           <button id="retry" hidden>Retry</button>
           <button id="logs">Open logs</button>
           <button id="update" hidden>Install update</button>

--- a/packages/desktop-shell/src-tauri/Info.plist
+++ b/packages/desktop-shell/src-tauri/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+  <key>NSDocumentsFolderUsageDescription</key>
+  <string>Qwen Code uses a folder in Documents as its default local workspace.</string>
   <key>NSMicrophoneUsageDescription</key>
   <string>Qwen Code uses the microphone for voice dictation in the prompt composer.</string>
 </dict>

--- a/packages/desktop-shell/src-tauri/src/main.rs
+++ b/packages/desktop-shell/src-tauri/src/main.rs
@@ -55,6 +55,7 @@ struct RuntimeStopped {
 // so a stop during that window kills the in-flight daemon instead of
 // orphaning it in its own process group.
 struct PendingRuntime {
+    generation: u64,
     child: Arc<Mutex<Option<GroupChild>>>,
     stopping: Arc<AtomicBool>,
 }
@@ -409,6 +410,7 @@ async fn install_update(webview: WebviewWindow, app: AppHandle) -> Result<(), St
 }
 
 fn start_runtime_async(app: AppHandle, workspace: PathBuf, create_if_missing: bool) {
+    stop_runtime(&app);
     let generation = {
         let state = app.state::<ApplicationState>();
         *lock(&state.last_workspace) = Some(workspace.clone());
@@ -416,7 +418,6 @@ fn start_runtime_async(app: AppHandle, workspace: PathBuf, create_if_missing: bo
         state.starting.store(generation, Ordering::SeqCst);
         generation
     };
-    stop_runtime(&app);
     *lock(&app.state::<ApplicationState>().last_error) = None;
     let _ = app.emit("runtime-starting", workspace.to_string_lossy().into_owned());
     tauri::async_runtime::spawn_blocking(move || {
@@ -443,18 +444,31 @@ fn start_runtime_async(app: AppHandle, workspace: PathBuf, create_if_missing: bo
         }
         let registered = app.clone();
         match DesktopRuntime::start(&app, &canonical, &state.log_path, move |child, stopping| {
-            *lock(&registered.state::<ApplicationState>().pending_runtime) =
-                Some(PendingRuntime { child, stopping });
+            let state = registered.state::<ApplicationState>();
+            let pending = PendingRuntime {
+                generation,
+                child,
+                stopping,
+            };
+            let mut slot = lock(&state.pending_runtime);
+            if state.start_generation.load(Ordering::SeqCst) == generation {
+                *slot = Some(pending);
+            } else {
+                drop(slot);
+                pending.stop();
+            }
         }) {
             Ok(runtime) => {
                 if state.start_generation.load(Ordering::SeqCst) != generation {
                     runtime.stop();
+                    clear_pending_runtime(&state, generation);
                     return;
                 }
                 let origin = match origin_of(runtime.base_url()) {
                     Ok(origin) => origin,
                     Err(error) => {
                         runtime.stop();
+                        clear_pending_runtime(&state, generation);
                         emit_runtime_failure(&app, generation, error);
                         return;
                     }
@@ -462,6 +476,7 @@ fn start_runtime_async(app: AppHandle, workspace: PathBuf, create_if_missing: bo
                 *lock(&state.origin) = Some(origin);
                 let Some(window) = app.get_webview_window("main") else {
                     runtime.stop();
+                    clear_pending_runtime(&state, generation);
                     emit_runtime_failure(
                         &app,
                         generation,
@@ -471,6 +486,7 @@ fn start_runtime_async(app: AppHandle, workspace: PathBuf, create_if_missing: bo
                 };
                 if let Err(error) = window.navigate(runtime.authenticated_web_url()) {
                     runtime.stop();
+                    clear_pending_runtime(&state, generation);
                     emit_runtime_failure(
                         &app,
                         generation,
@@ -478,15 +494,28 @@ fn start_runtime_async(app: AppHandle, workspace: PathBuf, create_if_missing: bo
                     );
                     return;
                 }
-                *lock(&state.runtime) = Some(runtime);
-                *lock(&state.pending_runtime) = None;
-                state
+                let mut runtime_slot = lock(&state.runtime);
+                if state.start_generation.load(Ordering::SeqCst) != generation {
+                    drop(runtime_slot);
+                    runtime.stop();
+                    clear_pending_runtime(&state, generation);
+                    return;
+                }
+                *runtime_slot = Some(runtime);
+                drop(runtime_slot);
+                clear_pending_runtime(&state, generation);
+                if state
                     .starting
                     .compare_exchange(generation, 0, Ordering::SeqCst, Ordering::SeqCst)
-                    .ok();
-                let _ = app.emit("runtime-ready", canonical.to_string_lossy().into_owned());
+                    .is_ok()
+                {
+                    let _ = app.emit("runtime-ready", canonical.to_string_lossy().into_owned());
+                }
             }
-            Err(error) => emit_runtime_failure(&app, generation, error),
+            Err(error) => {
+                clear_pending_runtime(&state, generation);
+                emit_runtime_failure(&app, generation, error);
+            }
         }
     });
 }
@@ -509,6 +538,8 @@ fn emit_runtime_failure(app: &AppHandle, generation: u64, error: String) {
 fn stop_runtime(app: &AppHandle) {
     stop_local_control(app);
     let state = app.state::<ApplicationState>();
+    state.start_generation.fetch_add(1, Ordering::SeqCst);
+    state.starting.store(0, Ordering::SeqCst);
     let runtime = lock(&state.runtime).take();
     if let Some(runtime) = runtime {
         runtime.stop();
@@ -519,6 +550,13 @@ fn stop_runtime(app: &AppHandle) {
     let pending = lock(&state.pending_runtime).take();
     if let Some(pending) = pending {
         pending.stop();
+    }
+}
+
+fn clear_pending_runtime(state: &ApplicationState, generation: u64) {
+    let mut pending = lock(&state.pending_runtime);
+    if pending.as_ref().map(|runtime| runtime.generation) == Some(generation) {
+        pending.take();
     }
 }
 

--- a/packages/desktop-shell/src-tauri/src/main.rs
+++ b/packages/desktop-shell/src-tauri/src/main.rs
@@ -8,6 +8,7 @@ use desktop_state::{default_window_size, restore_window, SettingsStore};
 use local_control::{LocalControlInfo, LocalControlSession};
 use runtime::{resolve_workspace, DesktopRuntime};
 use serde::{Deserialize, Serialize};
+use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -26,6 +27,10 @@ use url::Url;
 const BOOTSTRAP_URL: &str = "http://tauri.localhost";
 #[cfg(not(target_os = "windows"))]
 const BOOTSTRAP_URL: &str = "tauri://localhost";
+// Keep the default first-launch workspace aligned with the Electron shell's
+// getDefaultConversationWorkspacePath() in
+// packages/desktop/packages/shared/src/config/storage.ts: ~/Documents/Qwen,
+// relocatable through QWEN_DEFAULT_WORKSPACE_DIR (see default_workspace).
 const DEFAULT_WORKSPACE_DIRECTORY: &str = "Qwen";
 
 #[derive(Clone, Serialize)]
@@ -501,15 +506,30 @@ fn initial_workspace(app: &AppHandle) -> Result<PathBuf, String> {
 }
 
 fn default_workspace(app: &AppHandle) -> Result<PathBuf, String> {
+    // Matches the Electron shell, where an empty override falls back to the
+    // ~/Documents/Qwen default.
+    let override_dir =
+        default_workspace_override_dir(std::env::var_os("QWEN_DEFAULT_WORKSPACE_DIR"));
     let home = app
         .path()
         .home_dir()
         .map_err(|error| format!("Failed to resolve the home directory: {error}"))?;
-    create_default_workspace(&home)
+    create_default_workspace(&home, override_dir.as_deref())
 }
 
-fn create_default_workspace(home: &Path) -> Result<PathBuf, String> {
-    let workspace = home.join("Documents").join(DEFAULT_WORKSPACE_DIRECTORY);
+// An empty override is treated as unset so the ~/Documents/Qwen default wins,
+// mirroring the Electron shell's `||` fallback.
+fn default_workspace_override_dir(value: Option<OsString>) -> Option<PathBuf> {
+    value
+        .map(PathBuf::from)
+        .filter(|path| !path.as_os_str().is_empty())
+}
+
+fn create_default_workspace(home: &Path, override_dir: Option<&Path>) -> Result<PathBuf, String> {
+    let workspace = match override_dir {
+        Some(dir) => dir.to_path_buf(),
+        None => home.join("Documents").join(DEFAULT_WORKSPACE_DIRECTORY),
+    };
     fs::create_dir_all(&workspace).map_err(|error| {
         format!(
             "Failed to create the default workspace {}: {error}",
@@ -685,10 +705,12 @@ fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
 #[cfg(test)]
 mod tests {
     use super::{
-        create_default_workspace, is_allowed_navigation, is_bootstrap_url, is_safe_external_url,
-        is_same_origin, origin_of, BOOTSTRAP_URL,
+        create_default_workspace, default_workspace_override_dir, is_allowed_navigation,
+        is_bootstrap_url, is_safe_external_url, is_same_origin, origin_of, BOOTSTRAP_URL,
     };
+    use std::ffi::OsString;
     use std::fs;
+    use std::path::PathBuf;
     use std::sync::Mutex;
     use url::Url;
 
@@ -717,8 +739,8 @@ mod tests {
         ));
         let _ = fs::remove_dir_all(&home);
 
-        let first = create_default_workspace(&home).expect("create workspace");
-        let second = create_default_workspace(&home).expect("reuse workspace");
+        let first = create_default_workspace(&home, None).expect("create workspace");
+        let second = create_default_workspace(&home, None).expect("reuse workspace");
 
         assert_eq!(first, home.join("Documents/Qwen"));
         assert_eq!(second, first);
@@ -736,8 +758,47 @@ mod tests {
         fs::create_dir_all(&home).expect("create home");
         fs::write(home.join("Documents"), b"not a directory").expect("block Documents");
 
-        assert!(create_default_workspace(&home).is_err());
+        assert!(create_default_workspace(&home, None).is_err());
         fs::remove_dir_all(home).expect("cleanup");
+    }
+
+    #[test]
+    fn treats_an_unset_or_empty_workspace_override_as_absent() {
+        assert_eq!(default_workspace_override_dir(None), None);
+        assert_eq!(default_workspace_override_dir(Some(OsString::new())), None);
+    }
+
+    #[test]
+    fn uses_a_non_empty_workspace_override_verbatim() {
+        let custom = PathBuf::from("/tmp/qwen-custom-workspace");
+        assert_eq!(
+            default_workspace_override_dir(Some(OsString::from(custom.clone()))),
+            Some(custom)
+        );
+    }
+
+    #[test]
+    fn honors_the_default_workspace_directory_override() {
+        let home = std::env::temp_dir().join(format!(
+            "qwen-desktop-default-workspace-override-home-{}",
+            std::process::id()
+        ));
+        let custom = std::env::temp_dir().join(format!(
+            "qwen-desktop-default-workspace-override-target-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&home);
+        let _ = fs::remove_dir_all(&custom);
+        fs::create_dir_all(&home).expect("create home");
+
+        let workspace =
+            create_default_workspace(&home, Some(&custom)).expect("create override workspace");
+
+        assert_eq!(workspace, custom);
+        assert!(custom.is_dir());
+        assert!(!home.join("Documents").exists());
+        fs::remove_dir_all(home).expect("cleanup home");
+        fs::remove_dir_all(custom).expect("cleanup override");
     }
 
     #[test]

--- a/packages/desktop-shell/src-tauri/src/main.rs
+++ b/packages/desktop-shell/src-tauri/src/main.rs
@@ -727,6 +727,20 @@ mod tests {
     }
 
     #[test]
+    fn reports_an_uncreatable_default_workspace() {
+        let home = std::env::temp_dir().join(format!(
+            "qwen-desktop-default-workspace-error-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&home);
+        fs::create_dir_all(&home).expect("create home");
+        fs::write(home.join("Documents"), b"not a directory").expect("block Documents");
+
+        assert!(create_default_workspace(&home).is_err());
+        fs::remove_dir_all(home).expect("cleanup");
+    }
+
+    #[test]
     fn allows_platform_bootstrap_origins() {
         assert!(is_bootstrap_url(
             &Url::parse("tauri://localhost/").expect("tauri bootstrap")

--- a/packages/desktop-shell/src-tauri/src/main.rs
+++ b/packages/desktop-shell/src-tauri/src/main.rs
@@ -9,7 +9,7 @@ use local_control::{LocalControlInfo, LocalControlSession};
 use runtime::{resolve_workspace, DesktopRuntime};
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use tauri::menu::{Menu, MenuItem, MenuItemBuilder, SubmenuBuilder};
@@ -26,6 +26,7 @@ use url::Url;
 const BOOTSTRAP_URL: &str = "http://tauri.localhost";
 #[cfg(not(target_os = "windows"))]
 const BOOTSTRAP_URL: &str = "tauri://localhost";
+const DEFAULT_WORKSPACE_DIRECTORY: &str = "Qwen";
 
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -52,6 +53,7 @@ struct ApplicationState {
     log_path: PathBuf,
     origin: Arc<Mutex<Option<Url>>>,
     last_error: Mutex<Option<String>>,
+    last_workspace: Mutex<Option<PathBuf>>,
     window_dirty: AtomicBool,
     start_generation: AtomicU64,
     starting: AtomicU64,
@@ -198,15 +200,18 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         log_path,
         origin,
         last_error: Mutex::new(None),
+        last_workspace: Mutex::new(None),
         window_dirty: AtomicBool::new(false),
         start_generation: AtomicU64::new(0),
         starting: AtomicU64::new(0),
     });
 
-    if let Some(workspace) = initial_workspace(&handle) {
-        start_runtime_async(handle.clone(), workspace);
-    } else {
-        let _ = handle.emit("workspace-required", ());
+    match initial_workspace(&handle) {
+        Ok(workspace) => start_runtime_async(handle.clone(), workspace),
+        Err(error) => {
+            *lock(&handle.state::<ApplicationState>().last_error) = Some(error.clone());
+            let _ = handle.emit("runtime-failed", error);
+        }
     }
     check_updates_silently(handle.clone());
     spawn_window_state_flusher(handle);
@@ -268,11 +273,10 @@ async fn choose_workspace(
 #[tauri::command]
 fn restart_runtime(webview: WebviewWindow, app: AppHandle) -> Result<(), String> {
     require_bootstrap_origin(&webview)?;
-    let workspace = app
-        .state::<ApplicationState>()
-        .settings
-        .workspace()
-        .ok_or_else(|| "Choose a workspace before starting Qwen Code.".to_string())?;
+    let workspace = lock(&app.state::<ApplicationState>().last_workspace)
+        .clone()
+        .map(Ok)
+        .unwrap_or_else(|| initial_workspace(&app))?;
     start_runtime_async(app, workspace);
     Ok(())
 }
@@ -380,6 +384,7 @@ async fn install_update(webview: WebviewWindow, app: AppHandle) -> Result<(), St
 fn start_runtime_async(app: AppHandle, workspace: PathBuf) {
     let generation = {
         let state = app.state::<ApplicationState>();
+        *lock(&state.last_workspace) = Some(workspace.clone());
         let generation = state.start_generation.fetch_add(1, Ordering::SeqCst) + 1;
         state.starting.store(generation, Ordering::SeqCst);
         generation
@@ -485,10 +490,33 @@ fn set_local_control_menu_state(app: &AppHandle, active: bool) {
     let _ = state.local_control_off_menu.set_enabled(active);
 }
 
-fn initial_workspace(app: &AppHandle) -> Option<PathBuf> {
-    std::env::var_os("QWEN_DESKTOP_WORKSPACE")
-        .map(PathBuf::from)
-        .or_else(|| app.state::<ApplicationState>().settings.workspace())
+fn initial_workspace(app: &AppHandle) -> Result<PathBuf, String> {
+    if let Some(workspace) = std::env::var_os("QWEN_DESKTOP_WORKSPACE") {
+        return Ok(PathBuf::from(workspace));
+    }
+    if let Some(workspace) = app.state::<ApplicationState>().settings.workspace() {
+        return Ok(workspace);
+    }
+    default_workspace(app)
+}
+
+fn default_workspace(app: &AppHandle) -> Result<PathBuf, String> {
+    let home = app
+        .path()
+        .home_dir()
+        .map_err(|error| format!("Failed to resolve the home directory: {error}"))?;
+    create_default_workspace(&home)
+}
+
+fn create_default_workspace(home: &Path) -> Result<PathBuf, String> {
+    let workspace = home.join("Documents").join(DEFAULT_WORKSPACE_DIRECTORY);
+    fs::create_dir_all(&workspace).map_err(|error| {
+        format!(
+            "Failed to create the default workspace {}: {error}",
+            workspace.display()
+        )
+    })?;
+    Ok(workspace)
 }
 
 fn desktop_log_path(app: &AppHandle) -> Result<PathBuf, String> {
@@ -657,9 +685,10 @@ fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
 #[cfg(test)]
 mod tests {
     use super::{
-        is_allowed_navigation, is_bootstrap_url, is_safe_external_url, is_same_origin, origin_of,
-        BOOTSTRAP_URL,
+        create_default_workspace, is_allowed_navigation, is_bootstrap_url, is_safe_external_url,
+        is_same_origin, origin_of, BOOTSTRAP_URL,
     };
+    use std::fs;
     use std::sync::Mutex;
     use url::Url;
 
@@ -678,6 +707,23 @@ mod tests {
             &Url::parse("https://example.com/").expect("external"),
             &origin,
         ));
+    }
+
+    #[test]
+    fn creates_and_reuses_the_default_workspace() {
+        let home = std::env::temp_dir().join(format!(
+            "qwen-desktop-default-workspace-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&home);
+
+        let first = create_default_workspace(&home).expect("create workspace");
+        let second = create_default_workspace(&home).expect("reuse workspace");
+
+        assert_eq!(first, home.join("Documents/Qwen"));
+        assert_eq!(second, first);
+        assert!(first.is_dir());
+        fs::remove_dir_all(home).expect("cleanup");
     }
 
     #[test]

--- a/packages/desktop-shell/src-tauri/src/main.rs
+++ b/packages/desktop-shell/src-tauri/src/main.rs
@@ -77,7 +77,7 @@ struct ApplicationState {
     log_path: PathBuf,
     origin: Arc<Mutex<Option<Url>>>,
     last_error: Mutex<Option<String>>,
-    last_workspace: Mutex<Option<PathBuf>>,
+    last_workspace: Mutex<Option<(PathBuf, bool)>>,
     window_dirty: AtomicBool,
     start_generation: AtomicU64,
     starting: AtomicU64,
@@ -302,7 +302,7 @@ fn restart_runtime(webview: WebviewWindow, app: AppHandle) -> Result<(), String>
     require_bootstrap_origin(&webview)?;
     let last_workspace = lock(&app.state::<ApplicationState>().last_workspace).clone();
     let (workspace, create_if_missing) = match last_workspace {
-        Some(workspace) => (workspace, false),
+        Some(workspace) => workspace,
         None => initial_workspace(&app)?,
     };
     start_runtime_async(app, workspace, create_if_missing);
@@ -413,7 +413,7 @@ fn start_runtime_async(app: AppHandle, workspace: PathBuf, create_if_missing: bo
     stop_runtime(&app);
     let generation = {
         let state = app.state::<ApplicationState>();
-        *lock(&state.last_workspace) = Some(workspace.clone());
+        *lock(&state.last_workspace) = Some((workspace.clone(), create_if_missing));
         let generation = state.start_generation.fetch_add(1, Ordering::SeqCst) + 1;
         state.starting.store(generation, Ordering::SeqCst);
         generation

--- a/packages/desktop-shell/src-tauri/src/main.rs
+++ b/packages/desktop-shell/src-tauri/src/main.rs
@@ -4,9 +4,10 @@ mod desktop_state;
 mod local_control;
 mod runtime;
 
+use command_group::GroupChild;
 use desktop_state::{default_window_size, restore_window, SettingsStore};
 use local_control::{LocalControlInfo, LocalControlSession};
-use runtime::{resolve_workspace, DesktopRuntime};
+use runtime::{resolve_workspace, stop_runtime_handle, DesktopRuntime};
 use serde::{Deserialize, Serialize};
 use std::ffi::OsString;
 use std::fs;
@@ -49,8 +50,25 @@ struct RuntimeStopped {
     status: String,
 }
 
+// A runtime that has spawned but may still be inside DesktopRuntime::start's
+// startup wait. Shares the child handle with the DesktopRuntime it becomes,
+// so a stop during that window kills the in-flight daemon instead of
+// orphaning it in its own process group.
+struct PendingRuntime {
+    child: Arc<Mutex<Option<GroupChild>>>,
+    stopping: Arc<AtomicBool>,
+}
+
+impl PendingRuntime {
+    fn stop(&self) {
+        self.stopping.store(true, Ordering::SeqCst);
+        stop_runtime_handle(&self.child);
+    }
+}
+
 struct ApplicationState {
     runtime: Mutex<Option<DesktopRuntime>>,
+    pending_runtime: Mutex<Option<PendingRuntime>>,
     local_control: Mutex<Option<LocalControlSession>>,
     local_control_menu: MenuItem<tauri::Wry>,
     local_control_off_menu: MenuItem<tauri::Wry>,
@@ -198,6 +216,7 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
 
     handle.manage(ApplicationState {
         runtime: Mutex::new(None),
+        pending_runtime: Mutex::new(None),
         local_control: Mutex::new(None),
         local_control_menu,
         local_control_off_menu,
@@ -212,7 +231,9 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     });
 
     match initial_workspace(&handle) {
-        Ok(workspace) => start_runtime_async(handle.clone(), workspace),
+        Ok((workspace, create_if_missing)) => {
+            start_runtime_async(handle.clone(), workspace, create_if_missing)
+        }
         Err(error) => {
             *lock(&handle.state::<ApplicationState>().last_error) = Some(error.clone());
             let _ = handle.emit("runtime-failed", error);
@@ -271,18 +292,19 @@ async fn choose_workspace(
     let workspace = folder
         .into_path()
         .map_err(|error| format!("Failed to read selected workspace: {error}"))?;
-    start_runtime_async(app, workspace.clone());
+    start_runtime_async(app, workspace.clone(), false);
     Ok(Some(workspace.to_string_lossy().into_owned()))
 }
 
 #[tauri::command]
 fn restart_runtime(webview: WebviewWindow, app: AppHandle) -> Result<(), String> {
     require_bootstrap_origin(&webview)?;
-    let workspace = lock(&app.state::<ApplicationState>().last_workspace)
-        .clone()
-        .map(Ok)
-        .unwrap_or_else(|| initial_workspace(&app))?;
-    start_runtime_async(app, workspace);
+    let last_workspace = lock(&app.state::<ApplicationState>().last_workspace).clone();
+    let (workspace, create_if_missing) = match last_workspace {
+        Some(workspace) => (workspace, false),
+        None => initial_workspace(&app)?,
+    };
+    start_runtime_async(app, workspace, create_if_missing);
     Ok(())
 }
 
@@ -386,7 +408,7 @@ async fn install_update(webview: WebviewWindow, app: AppHandle) -> Result<(), St
     Ok(())
 }
 
-fn start_runtime_async(app: AppHandle, workspace: PathBuf) {
+fn start_runtime_async(app: AppHandle, workspace: PathBuf, create_if_missing: bool) {
     let generation = {
         let state = app.state::<ApplicationState>();
         *lock(&state.last_workspace) = Some(workspace.clone());
@@ -399,6 +421,15 @@ fn start_runtime_async(app: AppHandle, workspace: PathBuf) {
     let _ = app.emit("runtime-starting", workspace.to_string_lossy().into_owned());
     tauri::async_runtime::spawn_blocking(move || {
         let state = app.state::<ApplicationState>();
+        // Creating the default workspace touches ~/Documents, which can raise
+        // the macOS TCC prompt, so it runs here (off the main thread) instead
+        // of during setup.
+        if create_if_missing {
+            if let Err(error) = ensure_workspace_dir(&workspace) {
+                emit_runtime_failure(&app, generation, error);
+                return;
+            }
+        }
         let canonical = match resolve_workspace(&workspace) {
             Ok(path) => path,
             Err(error) => {
@@ -410,7 +441,11 @@ fn start_runtime_async(app: AppHandle, workspace: PathBuf) {
             emit_runtime_failure(&app, generation, error);
             return;
         }
-        match DesktopRuntime::start(&app, &canonical, &state.log_path) {
+        let registered = app.clone();
+        match DesktopRuntime::start(&app, &canonical, &state.log_path, move |child, stopping| {
+            *lock(&registered.state::<ApplicationState>().pending_runtime) =
+                Some(PendingRuntime { child, stopping });
+        }) {
             Ok(runtime) => {
                 if state.start_generation.load(Ordering::SeqCst) != generation {
                     runtime.stop();
@@ -444,6 +479,7 @@ fn start_runtime_async(app: AppHandle, workspace: PathBuf) {
                     return;
                 }
                 *lock(&state.runtime) = Some(runtime);
+                *lock(&state.pending_runtime) = None;
                 state
                     .starting
                     .compare_exchange(generation, 0, Ordering::SeqCst, Ordering::SeqCst)
@@ -472,8 +508,17 @@ fn emit_runtime_failure(app: &AppHandle, generation: u64, error: String) {
 
 fn stop_runtime(app: &AppHandle) {
     stop_local_control(app);
-    if let Some(runtime) = lock(&app.state::<ApplicationState>().runtime).take() {
+    let state = app.state::<ApplicationState>();
+    let runtime = lock(&state.runtime).take();
+    if let Some(runtime) = runtime {
         runtime.stop();
+    }
+    // Kill any daemon still inside DesktopRuntime::start's startup wait.
+    // Shares the child handle with a live runtime, so the take() inside
+    // stop_runtime_handle keeps this idempotent.
+    let pending = lock(&state.pending_runtime).take();
+    if let Some(pending) = pending {
+        pending.stop();
     }
 }
 
@@ -495,17 +540,21 @@ fn set_local_control_menu_state(app: &AppHandle, active: bool) {
     let _ = state.local_control_off_menu.set_enabled(active);
 }
 
-fn initial_workspace(app: &AppHandle) -> Result<PathBuf, String> {
+// Resolves the initial workspace and whether it is the derived first-launch
+// default that must be created before starting the runtime. Path resolution
+// only: directory creation happens off the main thread in start_runtime_async
+// because the first touch of ~/Documents can trigger the macOS TCC prompt.
+fn initial_workspace(app: &AppHandle) -> Result<(PathBuf, bool), String> {
     if let Some(workspace) = std::env::var_os("QWEN_DESKTOP_WORKSPACE") {
-        return Ok(PathBuf::from(workspace));
+        return Ok((PathBuf::from(workspace), false));
     }
     if let Some(workspace) = app.state::<ApplicationState>().settings.workspace() {
-        return Ok(workspace);
+        return Ok((workspace, false));
     }
     default_workspace(app)
 }
 
-fn default_workspace(app: &AppHandle) -> Result<PathBuf, String> {
+fn default_workspace(app: &AppHandle) -> Result<(PathBuf, bool), String> {
     // Matches the Electron shell, where an empty override falls back to the
     // ~/Documents/Qwen default.
     let override_dir =
@@ -514,7 +563,10 @@ fn default_workspace(app: &AppHandle) -> Result<PathBuf, String> {
         .path()
         .home_dir()
         .map_err(|error| format!("Failed to resolve the home directory: {error}"))?;
-    create_default_workspace(&home, override_dir.as_deref())
+    Ok((
+        default_workspace_path(&home, override_dir.as_deref()),
+        true,
+    ))
 }
 
 // An empty override is treated as unset so the ~/Documents/Qwen default wins,
@@ -525,18 +577,22 @@ fn default_workspace_override_dir(value: Option<OsString>) -> Option<PathBuf> {
         .filter(|path| !path.as_os_str().is_empty())
 }
 
-fn create_default_workspace(home: &Path, override_dir: Option<&Path>) -> Result<PathBuf, String> {
-    let workspace = match override_dir {
+fn default_workspace_path(home: &Path, override_dir: Option<&Path>) -> PathBuf {
+    match override_dir {
         Some(dir) => dir.to_path_buf(),
         None => home.join("Documents").join(DEFAULT_WORKSPACE_DIRECTORY),
-    };
-    fs::create_dir_all(&workspace).map_err(|error| {
+    }
+}
+
+// Creates the default workspace directory. Kept separate from path
+// resolution so it can run off the main thread and be tested on its own.
+fn ensure_workspace_dir(workspace: &Path) -> Result<(), String> {
+    fs::create_dir_all(workspace).map_err(|error| {
         format!(
             "Failed to create the default workspace {}: {error}",
             workspace.display()
         )
-    })?;
-    Ok(workspace)
+    })
 }
 
 fn desktop_log_path(app: &AppHandle) -> Result<PathBuf, String> {
@@ -705,8 +761,9 @@ fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
 #[cfg(test)]
 mod tests {
     use super::{
-        create_default_workspace, default_workspace_override_dir, is_allowed_navigation,
-        is_bootstrap_url, is_safe_external_url, is_same_origin, origin_of, BOOTSTRAP_URL,
+        default_workspace_override_dir, default_workspace_path, ensure_workspace_dir,
+        is_allowed_navigation, is_bootstrap_url, is_safe_external_url, is_same_origin, origin_of,
+        BOOTSTRAP_URL,
     };
     use std::ffi::OsString;
     use std::fs;
@@ -739,12 +796,12 @@ mod tests {
         ));
         let _ = fs::remove_dir_all(&home);
 
-        let first = create_default_workspace(&home, None).expect("create workspace");
-        let second = create_default_workspace(&home, None).expect("reuse workspace");
+        let workspace = default_workspace_path(&home, None);
+        assert_eq!(workspace, home.join("Documents/Qwen"));
+        ensure_workspace_dir(&workspace).expect("create workspace");
+        ensure_workspace_dir(&workspace).expect("reuse workspace");
 
-        assert_eq!(first, home.join("Documents/Qwen"));
-        assert_eq!(second, first);
-        assert!(first.is_dir());
+        assert!(workspace.is_dir());
         fs::remove_dir_all(home).expect("cleanup");
     }
 
@@ -758,7 +815,8 @@ mod tests {
         fs::create_dir_all(&home).expect("create home");
         fs::write(home.join("Documents"), b"not a directory").expect("block Documents");
 
-        assert!(create_default_workspace(&home, None).is_err());
+        let workspace = default_workspace_path(&home, None);
+        assert!(ensure_workspace_dir(&workspace).is_err());
         fs::remove_dir_all(home).expect("cleanup");
     }
 
@@ -791,10 +849,10 @@ mod tests {
         let _ = fs::remove_dir_all(&custom);
         fs::create_dir_all(&home).expect("create home");
 
-        let workspace =
-            create_default_workspace(&home, Some(&custom)).expect("create override workspace");
-
+        let workspace = default_workspace_path(&home, Some(&custom));
         assert_eq!(workspace, custom);
+        ensure_workspace_dir(&workspace).expect("create override workspace");
+
         assert!(custom.is_dir());
         assert!(!home.join("Documents").exists());
         fs::remove_dir_all(home).expect("cleanup home");

--- a/packages/desktop-shell/src-tauri/src/runtime.rs
+++ b/packages/desktop-shell/src-tauri/src/runtime.rs
@@ -528,13 +528,16 @@ fn runtime_arguments(workspace: &Path) -> Vec<OsString> {
 mod tests {
     use super::{
         append_failure_output, parse_listening_url, resolve_workspace, runtime_arguments,
-        stop_runtime_handle, wait_for_listening, DesktopRuntime, RuntimeStopped,
-        FAILURE_OUTPUT_LIMIT,
+        DesktopRuntime, RuntimeStopped, FAILURE_OUTPUT_LIMIT,
     };
+    #[cfg(unix)]
+    use super::{stop_runtime_handle, wait_for_listening};
     use std::path::Path;
     #[cfg(windows)]
     use std::path::PathBuf;
-    use std::sync::{Arc, Mutex};
+    #[cfg(unix)]
+    use std::sync::Arc;
+    use std::sync::Mutex;
     use url::Url;
 
     #[test]

--- a/packages/desktop-shell/src-tauri/src/runtime.rs
+++ b/packages/desktop-shell/src-tauri/src/runtime.rs
@@ -41,7 +41,12 @@ impl DesktopRuntime {
         self.id
     }
 
-    pub fn start(app: &AppHandle, workspace: &Path, log_path: &Path) -> Result<Self, String> {
+    pub fn start(
+        app: &AppHandle,
+        workspace: &Path,
+        log_path: &Path,
+        on_spawned: impl FnOnce(Arc<Mutex<Option<GroupChild>>>, Arc<AtomicBool>),
+    ) -> Result<Self, String> {
         let id = NEXT_RUNTIME_ID.fetch_add(1, Ordering::Relaxed);
         let layout = RuntimeLayout::resolve(app)?;
         // Callers pass a workspace already resolved by resolve_workspace.
@@ -85,17 +90,20 @@ impl DesktopRuntime {
         );
         capture_stderr(stderr, Arc::clone(&failure_output), log);
 
-        let base_url =
-            match wait_for_listening(&mut child, listen_receiver, &token, &failure_output) {
-                Ok(url) => url,
-                Err(error) => {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    return Err(error);
-                }
-            };
+        // Share the child before blocking on startup so a concurrent stop
+        // (app exit, restart, or a newer start) can kill an in-flight daemon
+        // instead of orphaning it in its own process group.
         let child = Arc::new(Mutex::new(Some(child)));
         let stopping = Arc::new(AtomicBool::new(false));
+        on_spawned(Arc::clone(&child), Arc::clone(&stopping));
+
+        let base_url = match wait_for_listening(&child, listen_receiver, &token, &failure_output) {
+            Ok(url) => url,
+            Err(error) => {
+                stop_runtime_handle(&child);
+                return Err(error);
+            }
+        };
         monitor_runtime(app.clone(), id, Arc::clone(&child), Arc::clone(&stopping));
 
         Ok(Self {
@@ -109,14 +117,7 @@ impl DesktopRuntime {
 
     pub fn stop(&self) {
         self.stopping.store(true, Ordering::SeqCst);
-        let child = match self.child.lock() {
-            Ok(mut guard) => guard.take(),
-            Err(poisoned) => poisoned.into_inner().take(),
-        };
-        if let Some(mut child) = child {
-            let _ = child.kill();
-            let _ = child.wait();
-        }
+        stop_runtime_handle(&self.child);
     }
 
     pub fn base_url(&self) -> &Url {
@@ -292,6 +293,19 @@ fn stop_runtime_child(child: &mut GroupChild) {
     let _ = child.wait();
 }
 
+// Kills and reaps the child behind a shared startup/runtime handle. The
+// `Option::take` makes concurrent stops (pending stop vs `DesktopRuntime::stop`)
+// idempotent: whichever runs first owns the kill.
+pub(crate) fn stop_runtime_handle(child: &Mutex<Option<GroupChild>>) {
+    let taken = match child.lock() {
+        Ok(mut guard) => guard.take(),
+        Err(poisoned) => poisoned.into_inner().take(),
+    };
+    if let Some(mut child) = taken {
+        stop_runtime_child(&mut child);
+    }
+}
+
 fn append_log(log: &Mutex<File>, stream: &str, line: &str) {
     let mut log = match log.lock() {
         Ok(guard) => guard,
@@ -362,22 +376,51 @@ fn parse_listening_url(line: &str) -> Option<Url> {
     }
 }
 
+enum StartupChildState {
+    Running,
+    Exited(String),
+    // A concurrent stop took the child out of the shared handle while startup
+    // was still in flight.
+    Stopped,
+}
+
+fn startup_child_state(child: &Mutex<Option<GroupChild>>) -> Result<StartupChildState, String> {
+    let mut guard = match child.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let Some(process) = guard.as_mut() else {
+        return Ok(StartupChildState::Stopped);
+    };
+    match process.try_wait() {
+        Ok(Some(status)) => Ok(StartupChildState::Exited(status.to_string())),
+        Ok(None) => Ok(StartupChildState::Running),
+        Err(error) => Err(format!("Failed to inspect bundled runtime: {error}")),
+    }
+}
+
 fn wait_for_listening(
-    child: &mut GroupChild,
+    child: &Mutex<Option<GroupChild>>,
     listen_receiver: std::sync::mpsc::Receiver<Url>,
     token: &str,
     failure_output: &Mutex<String>,
 ) -> Result<Url, String> {
     let deadline = Instant::now() + STARTUP_TIMEOUT;
     loop {
-        if let Some(status) = child
-            .try_wait()
-            .map_err(|error| format!("Failed to inspect bundled runtime: {error}"))?
-        {
-            return Err(startup_error(
-                &format!("Bundled runtime exited with status {status}."),
-                failure_output,
-            ));
+        match startup_child_state(child)? {
+            StartupChildState::Running => {}
+            StartupChildState::Exited(status) => {
+                return Err(startup_error(
+                    &format!("Bundled runtime exited with status {status}."),
+                    failure_output,
+                ));
+            }
+            StartupChildState::Stopped => {
+                return Err(startup_error(
+                    "Runtime startup was stopped before the daemon was ready.",
+                    failure_output,
+                ));
+            }
         }
         match listen_receiver.recv_timeout(HEALTH_RETRY_INTERVAL) {
             Ok(url) => return wait_for_health(child, url, token, deadline, failure_output),
@@ -399,7 +442,7 @@ fn wait_for_listening(
 }
 
 fn wait_for_health(
-    child: &mut GroupChild,
+    child: &Mutex<Option<GroupChild>>,
     base_url: Url,
     token: &str,
     deadline: Instant,
@@ -418,14 +461,20 @@ fn wait_for_health(
         .build()
         .into();
     while Instant::now() < deadline {
-        if let Some(status) = child
-            .try_wait()
-            .map_err(|error| format!("Failed to inspect bundled runtime: {error}"))?
-        {
-            return Err(startup_error(
-                &format!("Bundled runtime exited with status {status}."),
-                failure_output,
-            ));
+        match startup_child_state(child)? {
+            StartupChildState::Running => {}
+            StartupChildState::Exited(status) => {
+                return Err(startup_error(
+                    &format!("Bundled runtime exited with status {status}."),
+                    failure_output,
+                ));
+            }
+            StartupChildState::Stopped => {
+                return Err(startup_error(
+                    "Runtime startup was stopped before the daemon was ready.",
+                    failure_output,
+                ));
+            }
         }
         let response = agent
             .get(health_url.as_str())
@@ -479,12 +528,13 @@ fn runtime_arguments(workspace: &Path) -> Vec<OsString> {
 mod tests {
     use super::{
         append_failure_output, parse_listening_url, resolve_workspace, runtime_arguments,
-        DesktopRuntime, RuntimeStopped, FAILURE_OUTPUT_LIMIT,
+        stop_runtime_handle, wait_for_listening, DesktopRuntime, RuntimeStopped,
+        FAILURE_OUTPUT_LIMIT,
     };
     use std::path::Path;
     #[cfg(windows)]
     use std::path::PathBuf;
-    use std::sync::Mutex;
+    use std::sync::{Arc, Mutex};
     use url::Url;
 
     #[test]
@@ -610,5 +660,53 @@ mod tests {
             output.lock().expect("output").len(),
             FAILURE_OUTPUT_LIMIT - 1
         );
+    }
+
+    #[cfg(unix)]
+    fn spawn_sleep(seconds: &str) -> command_group::GroupChild {
+        use command_group::CommandGroup;
+        std::process::Command::new("sleep")
+            .arg(seconds)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .group_spawn()
+            .expect("spawn sleep")
+    }
+
+    // A pending stop (app exit / restart while startup is still in flight)
+    // must reap the child it took from the shared handle.
+    #[cfg(unix)]
+    #[test]
+    fn pending_stop_reaps_a_child_taken_from_the_shared_handle() {
+        let handle = Arc::new(Mutex::new(Some(spawn_sleep("30"))));
+        let started = std::time::Instant::now();
+        stop_runtime_handle(&handle);
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(10),
+            "stop blocked, so the child was not killed"
+        );
+        assert!(handle.lock().expect("handle").is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn wait_for_listening_reports_a_stop_during_startup() {
+        let handle = Arc::new(Mutex::new(Some(spawn_sleep("30"))));
+        let failure_output = Mutex::new(String::new());
+        let (_listen_sender, listen_receiver) = std::sync::mpsc::channel::<Url>();
+        let stopper = Arc::clone(&handle);
+        let stopper_thread = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(200));
+            stop_runtime_handle(&stopper);
+        });
+
+        let error = wait_for_listening(&handle, listen_receiver, "token", &failure_output)
+            .expect_err("startup should fail when stopped in flight");
+        assert!(
+            error.contains("stopped before the daemon was ready"),
+            "unexpected startup error: {error}"
+        );
+        stopper_thread.join().expect("stopper thread joins");
     }
 }


### PR DESCRIPTION
## What this PR does

Desktop now derives `~/Documents/Qwen` and starts the bundled runtime automatically when there is no environment override or saved primary workspace. Creation of that default directory happens inside the blocking runtime-start task instead of Tauri setup, so the first macOS Documents access and any permission prompt do not block the main thread. Existing `QWEN_DESKTOP_WORKSPACE`, saved-workspace precedence, and the legacy `QWEN_DEFAULT_WORKSPACE_DIR` default-directory override remain unchanged, while the folder picker stays available as a recovery action after startup failure.

Retry reuses the last workspace that was actually attempted, and the macOS bundle declares why it accesses Documents. Desktop also owns the spawned runtime process as soon as it exists: exit, restart, or a newer startup generation cancels, kills, and reaps a runtime that is still waiting for readiness. Generation-tagged handoff prevents a stale startup worker from replacing the current pending process or announcing a stale ready state.

## Why it's needed

The bundled Node.js process needs a primary working directory, but that implementation detail should not force users to choose a project before entering the app. This restores the previous Electron first-launch behavior while keeping project addition and switching in the existing Web Shell flow. Moving directory creation off the UI thread avoids freezing startup around the macOS Documents permission boundary, and owning the child during readiness prevents app exit or restart from leaving an orphaned daemon.

## Reviewer Test Plan

### How to verify

1. Launch Desktop with neither `QWEN_DESKTOP_WORKSPACE` nor `QWEN_DEFAULT_WORKSPACE_DIR`, and no saved Desktop state. It should create `~/Documents/Qwen` and open the Web Shell without showing a folder picker or blocking the UI while the default directory is prepared.
2. Relaunch the app. It should restore the same primary workspace directly.
3. Add another project from the Web Shell. The project should be registered and switched without restarting the Desktop process.
4. Make the configured workspace unavailable. The recovery page should still offer Retry, Choose another workspace, and Open logs.
5. Delay runtime readiness, then quit the app or request a restart while startup is pending. The spawned runtime process group should be terminated and reaped; after a restart, only the newest startup generation should reach ready.

All 33 Rust tests pass on macOS, including focused checks that stopping a pending runtime reaps its child and causes the readiness wait to exit.

### Evidence (Before & After)

Before: first launch blocked on the workspace picker, default-directory creation could run on the main thread, and the spawned daemon was not owned until readiness completed.

After: the packaged app opens the Web Shell with the automatically created `Qwen` workspace. A separate E2E test report comment includes the app-only screenshot and runtime evidence. Startup cancellation is non-UI behavior covered by the Rust regression tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Packaged unsigned macOS `.app`, bundled Node.js runtime, and an isolated HOME with no workspace override or saved state; Rust test binary on macOS.

## Risk & Scope

- Main risk or tradeoff: first launch now accesses `~/Documents`, so macOS may show the normal Documents permission prompt; runtime startup now has an explicit generation-aware ownership handoff.
- Not validated / out of scope: signed/notarized distribution and Windows/Linux UI launch behavior.
- Breaking changes / migration notes: none. Existing environment overrides and saved primary workspaces keep their current precedence.

## Linked Issues

No closing issue; this follows the Desktop startup UX work tracked around #8092.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

当没有环境变量覆盖项或已保存的主工作区时，Desktop 现在会推导 `~/Documents/Qwen` 并自动启动内置运行时。默认目录的创建发生在阻塞式 runtime 启动任务中，而不是 Tauri setup 阶段，因此 macOS 首次访问 Documents 及其可能出现的权限提示不会阻塞主线程。现有 `QWEN_DESKTOP_WORKSPACE`、已保存工作区优先级，以及旧版 `QWEN_DEFAULT_WORKSPACE_DIR` 默认目录覆盖项保持不变，目录选择器则保留为启动失败后的恢复操作。

Retry 会复用上一次实际尝试的工作区，macOS 安装包也声明了访问 Documents 的原因。Desktop 还会在 runtime 进程一生成时就取得所有权：退出、重启或新的启动 generation 会取消、终止并回收仍在等待 ready 的 runtime。带 generation 的交接可防止过期启动 worker 覆盖当前 pending 进程或发送过期的 ready 状态。

## 为什么需要

内置 Node.js 进程需要一个主工作目录，但这个实现细节不应该迫使用户在进入 App 前先选择项目。这个改动恢复了旧 Electron App 的首次启动行为，同时继续复用 Web Shell 现有的项目添加和切换流程。把目录创建移出 UI 线程可以避免在 macOS Documents 权限边界附近冻结启动，而在 readiness 阶段持有子进程则能防止退出或重启 App 后遗留孤儿 daemon。

## Reviewer 测试计划

### 如何验证

1. 在既没有 `QWEN_DESKTOP_WORKSPACE`、也没有 `QWEN_DEFAULT_WORKSPACE_DIR`，且没有已保存 Desktop 状态的情况下启动 Desktop。它应该创建 `~/Documents/Qwen` 并直接打开 Web Shell，不显示目录选择器，准备默认目录时 UI 也不应阻塞。
2. 重新启动 App。它应该直接恢复同一个主工作区。
3. 从 Web Shell 添加另一个项目。项目应该被注册并切换，Desktop 进程不重启。
4. 让配置的工作区不可用。恢复页仍应提供 Retry、Choose another workspace 和 Open logs。
5. 延迟 runtime ready，然后在启动仍 pending 时退出 App 或请求重启。已生成的 runtime 进程组应被终止并回收；重启后只有最新启动 generation 能进入 ready。

macOS 上 33 项 Rust 测试全部通过，其中包括停止 pending runtime 会回收子进程、并使 readiness 等待退出的聚焦检查。

### 证据（前后对比）

之前：首次启动会阻塞在工作区选择器上，默认目录创建可能运行在主线程，并且已生成的 daemon 要到 readiness 完成后才会被持有。

之后：打包后的 App 会直接打开 Web Shell，并使用自动创建的 `Qwen` 工作区。单独的 E2E 测试报告评论包含仅 App 窗口截图和运行时证据。启动取消属于非 UI 行为，由 Rust 回归测试覆盖。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

未签名的 macOS `.app`、内置 Node.js 运行时、没有工作区覆盖项或已保存状态的隔离 HOME，以及 macOS 上运行的 Rust test binary。

## 风险与范围

- 主要风险或取舍：首次启动现在会访问 `~/Documents`，macOS 可能显示正常的 Documents 权限提示；runtime 启动现在包含显式且感知 generation 的所有权交接。
- 未验证 / 范围外：签名、公证后的发布包，以及 Windows/Linux UI 启动行为。
- 破坏性变更 / 迁移说明：无。现有环境变量覆盖项和已保存主工作区保持当前优先级。

## 关联 Issue

没有自动关闭的 Issue；这个改动延续了 #8092 周边的 Desktop 启动体验工作。

</details>
