### PR TITLE
feat(workflows): add a cwd option to agent()

### DIFF
--- a/packages/core/src/agents/runtime/workflow-journal.test.ts
+++ b/packages/core/src/agents/runtime/workflow-journal.test.ts
@@ -53,6 +53,23 @@ describe('canonicalizeAgentOpts', () => {
   it('empty opts → {}', () => {
     expect(canonicalizeAgentOpts({})).toBe('{}');
   });
+
+  // `cwd` decides which tree the subagent reads, so it must bust the resume
+  // cache. Were it projected out, a resumed run would serve one directory's
+  // cached result for an identical prompt aimed at a different directory —
+  // silently reviewing the wrong tree.
+  it('projects cwd, so two directories are two dispatches', () => {
+    const a = canonicalizeAgentOpts({ cwd: '/repo/wt-a' });
+    const b = canonicalizeAgentOpts({ cwd: '/repo/wt-b' });
+    expect(a).toBe(JSON.stringify({ cwd: '/repo/wt-a' }));
+    expect(a).not.toBe(b);
+  });
+
+  it('derives distinct agent keys for the same prompt in different cwds', () => {
+    const k1 = deriveAgentKey('', 'review the diff', { cwd: '/repo/wt-a' });
+    const k2 = deriveAgentKey('', 'review the diff', { cwd: '/repo/wt-b' });
+    expect(k1).not.toBe(k2);
+  });
 });
 
 describe('deriveAgentKey', () => {

--- a/packages/core/src/agents/runtime/workflow-journal.ts
+++ b/packages/core/src/agents/runtime/workflow-journal.ts
@@ -21,9 +21,9 @@
  * key, and so on — so the cache naturally invalidates from the edit point.
  *
  * The `canonicalOpts` projection keeps only the dispatch-affecting opts
- * (`schema`, `model`, `isolation`, `agentType`) with object keys sorted, so
- * cosmetic opt differences (a re-ordered schema, a `label` change) don't
- * bust the cache.
+ * (`schema`, `model`, `isolation`, `agentType`, `cwd`) with object keys
+ * sorted, so cosmetic opt differences (a re-ordered schema, a `label` change)
+ * don't bust the cache.
  *
  * Determinism requirement: workflow scripts are deterministic (`Date.now`
  * / `Math.random` throw in the sandbox), so the sequence of `agent()`
@@ -66,14 +66,25 @@ export interface JournalReplay {
 
 /**
  * Project the dispatch-affecting opts into a stable canonical string. Only
- * `schema` / `model` / `isolation` / `agentType` change what the dispatch
- * does; `label` / `phase` / `stallMs` are cosmetic or operational and must
- * NOT bust the cache. Object keys are sorted recursively so a re-serialized
- * schema with reordered keys hashes the same.
+ * `schema` / `model` / `isolation` / `agentType` / `cwd` change what the
+ * dispatch does; `label` / `phase` / `stallMs` are cosmetic or operational and
+ * must NOT bust the cache. Object keys are sorted recursively so a
+ * re-serialized schema with reordered keys hashes the same.
+ *
+ * `cwd` is projected because it decides which tree the subagent reads: the
+ * same prompt run against two directories is two different dispatches, and
+ * omitting it would let a resume serve one directory's cached result for the
+ * other.
  */
 export function canonicalizeAgentOpts(opts: WorkflowAgentOpts): string {
   const projected: Record<string, unknown> = {};
-  for (const k of ['schema', 'model', 'isolation', 'agentType'] as const) {
+  for (const k of [
+    'schema',
+    'model',
+    'isolation',
+    'agentType',
+    'cwd',
+  ] as const) {
     const v = opts[k];
     if (v === undefined || typeof v === 'function') continue;
     projected[k] = v;

--- a/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
@@ -7,7 +7,9 @@
 // T7 (PR #4732 R1): the `vi as vitest` alias diverges from every other
 // test file in the repo. Use `vi` directly.
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fsSync from 'node:fs';
 import * as os from 'node:os';
+import * as path from 'node:path';
 import {
   WorkflowOrchestrator,
   WorkflowExecutionError,
@@ -2500,6 +2502,8 @@ describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', (
   type StubSubagentCall = {
     config: { name?: string; model?: string; disallowedTools?: string[] };
     runtimeContextSame: boolean;
+    /** The Config actually handed to createAgentHeadless — the override, when one was built. */
+    runtimeContext: unknown;
     options?: { runConfigOverrides?: unknown };
     eventEmitterAttached: boolean;
     executeAgentId?: string | null;
@@ -2557,6 +2561,10 @@ describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', (
       getTargetDir: () => '/fake/repo',
       getSessionId: () => 'sess_fake_test_id',
       getWorktreeSymlinkDirectories: () => [],
+      // agent({cwd}) validates containment through the workspace. Default to
+      // permissive so the tests that do not exercise `cwd` are unaffected;
+      // the containment test replaces this method on its own config.
+      getWorkspaceContext: () => ({ isPathWithinWorkspace: () => true }),
       getSubagentManager: () => ({
         findSubagentByName: opts.findSubagentByName ?? (async () => null),
         createAgentHeadless: async (
@@ -2571,6 +2579,7 @@ describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', (
           const call: StubSubagentCall = {
             config: subagentConfig,
             runtimeContextSame: runtimeContext === cfg,
+            runtimeContext,
             options: { runConfigOverrides: options?.runConfigOverrides },
             eventEmitterAttached: options?.eventEmitter !== undefined,
           };
@@ -3388,6 +3397,113 @@ describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', (
   // {success:false}, returns {success:true, branchPreserved:true}, or
   // throws synchronously. Each path produces a different preserved
   // suffix and was previously untested.
+
+  // --- agent({cwd}) -------------------------------------------------------
+  // `cwd` pins a subagent to a directory that already exists. It is the case
+  // isolation:'worktree' structurally cannot serve: that mode provisions a
+  // NEW worktree from the current tree and refuses when the parent has
+  // uncommitted changes — so a caller whose subject IS the uncommitted
+  // changes, or who wants a tree it prepared earlier, has no option today.
+  describe('agent({cwd})', () => {
+    let cwdDir: string;
+
+    beforeEach(() => {
+      cwdDir = fsSync.mkdtempSync(path.join(os.tmpdir(), 'wf-cwd-'));
+    });
+
+    afterEach(() => {
+      fsSync.rmSync(cwdDir, { recursive: true, force: true });
+    });
+
+    it('rebinds the subagent runtime context to the directory', async () => {
+      const { config, calls } = fakeConfigWithMgr({
+        onCreate: async () => ({ finalText: 'done', terminateMode: 'GOAL' }),
+      });
+      const dispatch = createProductionDispatch(config);
+      await dispatch('hi', { cwd: cwdDir });
+      expect(calls).toHaveLength(1);
+      // A distinct Config override reached createAgentHeadless, and every
+      // "where am I?" surface answers the requested directory.
+      expect(calls[0].runtimeContextSame).toBe(false);
+      const ctx = calls[0].runtimeContext as unknown as Config;
+      expect(ctx.getTargetDir()).toBe(cwdDir);
+      expect(ctx.getWorkingDir()).toBe(cwdDir);
+      expect(ctx.getProjectRoot()).toBe(cwdDir);
+    });
+
+    // The fast path builds no Config override at all, so a `cwd` that reached
+    // it would be dropped in silence and the subagent would read the parent's
+    // tree while the script believed otherwise — results that look plausible
+    // and describe the wrong directory.
+    it('forces the override path even with no other override opts', async () => {
+      const { config, calls } = fakeConfigWithMgr({
+        onCreate: async () => ({ finalText: 'done', terminateMode: 'GOAL' }),
+      });
+      const dispatch = createProductionDispatch(config);
+      await dispatch('hi', { cwd: cwdDir });
+      // Reaching the stubbed SubagentManager at all proves the fast path
+      // (which goes through AgentHeadless.create directly) was not taken.
+      expect(calls).toHaveLength(1);
+    });
+
+    it('rejects a relative path', async () => {
+      const { config } = fakeConfigWithMgr({
+        onCreate: async () => ({ finalText: 'done', terminateMode: 'GOAL' }),
+      });
+      const dispatch = createProductionDispatch(config);
+      await expect(dispatch('hi', { cwd: 'relative/dir' })).rejects.toThrow(
+        /must be an absolute path/,
+      );
+    });
+
+    it('rejects a directory that does not exist', async () => {
+      const { config } = fakeConfigWithMgr({
+        onCreate: async () => ({ finalText: 'done', terminateMode: 'GOAL' }),
+      });
+      const dispatch = createProductionDispatch(config);
+      await expect(
+        dispatch('hi', { cwd: path.join(cwdDir, 'nope') }),
+      ).rejects.toThrow(/no such directory/);
+    });
+
+    it('rejects a file', async () => {
+      const filePath = path.join(cwdDir, 'a-file.txt');
+      fsSync.writeFileSync(filePath, 'x');
+      const { config } = fakeConfigWithMgr({
+        onCreate: async () => ({ finalText: 'done', terminateMode: 'GOAL' }),
+      });
+      const dispatch = createProductionDispatch(config);
+      await expect(dispatch('hi', { cwd: filePath })).rejects.toThrow(
+        /is not a directory/,
+      );
+    });
+
+    it('rejects a directory outside the workspace', async () => {
+      const { config } = fakeConfigWithMgr({
+        onCreate: async () => ({ finalText: 'done', terminateMode: 'GOAL' }),
+      });
+      (
+        config as unknown as { getWorkspaceContext: () => unknown }
+      ).getWorkspaceContext = () => ({ isPathWithinWorkspace: () => false });
+      const dispatch = createProductionDispatch(config);
+      await expect(dispatch('hi', { cwd: cwdDir })).rejects.toThrow(
+        /outside the workspace/,
+      );
+    });
+
+    // The sandbox refuses this combination at authoring time; dispatch is
+    // also reachable directly from tests and SDK embedders, so the host
+    // re-checks rather than picking a precedence rule nobody would remember.
+    it('refuses cwd together with isolation at the dispatch boundary', async () => {
+      const { config } = fakeConfigWithMgr({
+        onCreate: async () => ({ finalText: 'done', terminateMode: 'GOAL' }),
+      });
+      const dispatch = createProductionDispatch(config);
+      await expect(
+        dispatch('hi', { cwd: cwdDir, isolation: 'worktree' }),
+      ).rejects.toThrow(/mutually exclusive/);
+    });
+  });
 
   it("isolation:'worktree' cleanup: removeUserWorktree failure preserves path+branch", async () => {
     const { GitWorktreeService } = await import(

--- a/packages/core/src/agents/runtime/workflow-orchestrator.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.ts
@@ -5,7 +5,9 @@
  */
 
 import { randomBytes } from 'node:crypto';
+import * as fs from 'node:fs';
 import * as os from 'node:os';
+import * as path from 'node:path';
 import type { Config } from '../../config/config.js';
 import {
   createWorkflowSandbox,
@@ -439,11 +441,15 @@ async function runSingleDispatch(
   const workflowAgentId = `workflow-agent-${randomBytes(8).toString('hex')}`;
   debugLogger.debug(`[workflow] Dispatch ${workflowAgentId}`);
 
+  // `cwd` joins this gate: the fast path builds no Config override, so a
+  // `cwd` that reached it would be silently dropped and the subagent would
+  // run in the parent's directory while the script believed otherwise.
   if (
     opts.agentType === undefined &&
     opts.model === undefined &&
     opts.isolation === undefined &&
-    opts.schema === undefined
+    opts.schema === undefined &&
+    opts.cwd === undefined
   ) {
     const subagent = await AgentHeadless.create(
       opts.label ?? 'workflow-agent',
@@ -696,14 +702,26 @@ async function runOverridePath(
 
   // Provision worktree BEFORE createAgentHeadless so the override Config
   // is in place when convertToRuntimeConfig and buildSubagentContextOverride
-  // resolve cwd-related getters via the prototype chain.
+  // resolve cwd-related getters via the prototype chain. `cwd` rebinds the
+  // same surfaces without provisioning anything — the caller owns that
+  // directory, so there is nothing to clean up afterwards. The two are
+  // mutually exclusive (rejected in the sandbox; re-checked here because
+  // dispatch is also reachable directly from tests and SDK embedders).
   let worktreeIsolation: WorkflowWorktreeIsolation | null = null;
   let effectiveContext: Config = config;
+  if (opts.isolation === 'worktree' && opts.cwd !== undefined) {
+    throw new Error(
+      'agent({cwd, isolation}): mutually exclusive. `cwd` runs the subagent ' +
+        'in an existing directory; `isolation` creates a new one. Pass exactly one.',
+    );
+  }
   if (opts.isolation === 'worktree') {
     worktreeIsolation = await provisionWorkflowWorktree(config);
-    effectiveContext = createWorktreeConfigOverride(
+    effectiveContext = createDirConfigOverride(config, worktreeIsolation.path);
+  } else if (opts.cwd !== undefined) {
+    effectiveContext = createDirConfigOverride(
       config,
-      worktreeIsolation.path,
+      resolveAgentCwd(config, opts.cwd),
     );
   }
 
@@ -1068,12 +1086,58 @@ async function provisionWorkflowWorktree(
 }
 
 /**
- * Build a Config wrapper that rebinds every "where am I?" surface to the
- * isolated worktree path. `Object.create(base)` keeps prototype lookups
- * walking back to the parent for everything else (model config, session
- * id, MCP servers), while the own-property overrides shadow the cwd-
- * adjacent fields so the subagent's tools (Edit / Write / Read / Glob /
- * Grep / Ls / Shell) anchor inside the worktree.
+ * Resolve and validate `agent({cwd})` on the host side. The vm realm has
+ * already checked the shape (non-empty string, not combined with
+ * `isolation`); the filesystem and workspace checks can only happen here.
+ *
+ * Every branch fails closed. A `cwd` that does not name an existing directory
+ * inside the workspace is a script bug, and silently falling back to the
+ * parent's directory would hide it behind results that look plausible while
+ * describing the wrong tree — the exact failure `cwd` exists to prevent.
+ *
+ * `isPathWithinWorkspace` resolves symlinks and returns false on any error,
+ * so a symlink pointing out of the workspace is rejected rather than followed.
+ */
+function resolveAgentCwd(config: Config, rawCwd: string): string {
+  if (!path.isAbsolute(rawCwd)) {
+    throw new Error(
+      `agent({cwd}): must be an absolute path, received '${sanitizeForErrorMessage(rawCwd)}'.`,
+    );
+  }
+  const resolved = path.resolve(rawCwd);
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(resolved);
+  } catch {
+    throw new Error(
+      `agent({cwd}): no such directory '${sanitizeForErrorMessage(resolved)}'.`,
+    );
+  }
+  if (!stat.isDirectory()) {
+    throw new Error(
+      `agent({cwd}): '${sanitizeForErrorMessage(resolved)}' is not a directory.`,
+    );
+  }
+  if (!config.getWorkspaceContext().isPathWithinWorkspace(resolved)) {
+    throw new Error(
+      `agent({cwd}): '${sanitizeForErrorMessage(resolved)}' is outside the workspace. ` +
+        `Add the directory to the workspace before pointing an agent at it.`,
+    );
+  }
+  return resolved;
+}
+
+/**
+ * Build a Config wrapper that rebinds every "where am I?" surface to `dir`.
+ * `Object.create(base)` keeps prototype lookups walking back to the parent
+ * for everything else (model config, session id, MCP servers), while the
+ * own-property overrides shadow the cwd-adjacent fields so the subagent's
+ * tools (Edit / Write / Read / Glob / Grep / Ls / Shell) anchor inside `dir`.
+ *
+ * Shared by both directory-changing paths: `isolation: 'worktree'` (where
+ * `dir` is a worktree this dispatch just provisioned) and `agent({cwd})`
+ * (where `dir` is a directory the caller already had). The rebinding is
+ * identical; only who owns the directory's lifecycle differs.
  *
  * Mirrors the inline rebind block at agent.ts:2008-2024. Sets BOTH the
  * field shape (e.g. `targetDir`) AND the method shape (`getTargetDir`)
@@ -1081,21 +1145,21 @@ async function provisionWorkflowWorktree(
  * call sites that read `this.targetDir` directly inside Config methods
  * would otherwise still resolve through the prototype to the parent.
  */
-function createWorktreeConfigOverride(base: Config, wtPath: string): Config {
+function createDirConfigOverride(base: Config, dir: string): Config {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const ov: any = Object.create(base);
-  ov.targetDir = wtPath;
-  ov.cwd = wtPath;
-  ov.getTargetDir = () => wtPath;
-  ov.getCwd = () => wtPath;
-  ov.getWorkingDir = () => wtPath;
-  ov.getProjectRoot = () => wtPath;
-  const wtFileService = new FileDiscoveryService(wtPath);
-  ov.fileDiscoveryService = wtFileService;
-  ov.getFileService = () => wtFileService;
-  const wtWorkspace = new WorkspaceContext(wtPath);
-  ov.workspaceContext = wtWorkspace;
-  ov.getWorkspaceContext = () => wtWorkspace;
+  ov.targetDir = dir;
+  ov.cwd = dir;
+  ov.getTargetDir = () => dir;
+  ov.getCwd = () => dir;
+  ov.getWorkingDir = () => dir;
+  ov.getProjectRoot = () => dir;
+  const dirFileService = new FileDiscoveryService(dir);
+  ov.fileDiscoveryService = dirFileService;
+  ov.getFileService = () => dirFileService;
+  const dirWorkspace = new WorkspaceContext(dir);
+  ov.workspaceContext = dirWorkspace;
+  ov.getWorkspaceContext = () => dirWorkspace;
   return ov as Config;
 }
 

--- a/packages/core/src/agents/runtime/workflow-sandbox.test.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.test.ts
@@ -1634,6 +1634,60 @@ describe('createWorkflowSandbox security', () => {
     ).rejects.toThrow(/unknown isolation mode/);
   });
 
+  // `cwd` pins a subagent to a directory that already exists — the case
+  // `isolation:'worktree'` cannot serve, since it provisions a NEW worktree
+  // and refuses outright when the parent tree is dirty. The sandbox owns the
+  // shape checks; path existence and workspace containment are host-side.
+  it('agent({cwd}) is passed through to dispatch', async () => {
+    const seen: Array<{ prompt: string; opts: unknown }> = [];
+    const sandbox = createWorkflowSandbox({
+      args: undefined,
+      dispatch: async (prompt, opts) => {
+        seen.push({ prompt, opts });
+        return 'ok';
+      },
+    });
+    await sandbox.run(`return agent("hi", { cwd: "/repo/wt" });`);
+    expect(seen).toHaveLength(1);
+    expect((seen[0].opts as { cwd?: string }).cwd).toBe('/repo/wt');
+  });
+
+  it('agent({cwd}) rejects a non-string', async () => {
+    const sandbox = createWorkflowSandbox({
+      args: undefined,
+      dispatch: async () => 'ignored',
+    });
+    await expect(
+      sandbox.run(`return agent("hi", { cwd: 42 });`),
+    ).rejects.toThrow(/agent\(\{cwd\}\): must be a non-empty string/);
+  });
+
+  it('agent({cwd}) rejects an empty string', async () => {
+    const sandbox = createWorkflowSandbox({
+      args: undefined,
+      dispatch: async () => 'ignored',
+    });
+    await expect(
+      sandbox.run(`return agent("hi", { cwd: "" });`),
+    ).rejects.toThrow(/agent\(\{cwd\}\): must be a non-empty string/);
+  });
+
+  // Passing both leaves the subagent's directory ambiguous. A /review run that
+  // set a working directory alongside worktree isolation failed all 11 of its
+  // agents, so this is refused at authoring time rather than resolved by a
+  // precedence rule nobody would remember.
+  it('agent({cwd, isolation}) is refused as mutually exclusive', async () => {
+    const sandbox = createWorkflowSandbox({
+      args: undefined,
+      dispatch: async () => 'ignored',
+    });
+    await expect(
+      sandbox.run(
+        `return agent("hi", { cwd: "/repo/wt", isolation: "worktree" });`,
+      ),
+    ).rejects.toThrow(/mutually exclusive/);
+  });
+
   it('agent({isolation:"worktree"}) is passed through to dispatch in P3', async () => {
     const seen: Array<{ prompt: string; opts: unknown }> = [];
     const sandbox = createWorkflowSandbox({

--- a/packages/core/src/agents/runtime/workflow-sandbox.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.ts
@@ -396,6 +396,17 @@ export interface WorkflowAgentOpts {
   isolation?: 'worktree' | 'remote';
   agentType?: string;
   /**
+   * Absolute path the subagent runs in. Unlike `isolation: 'worktree'` — which
+   * *creates* a fresh worktree from the current tree and refuses when the
+   * parent has uncommitted changes — `cwd` points the subagent at a directory
+   * that already exists, so a script can review or build a tree it did not
+   * create. The two are mutually exclusive.
+   *
+   * The path must be absolute, must resolve to an existing directory, and must
+   * lie inside the run's workspace.
+   */
+  cwd?: string;
+  /**
    * P-stall: per-call stall-watchdog timeout in milliseconds. The dispatch
    * is aborted + retried (up to 3 attempts) after this many ms of no
    * subagent progress (with no tool in flight). Defaults to 60_000 (env
@@ -1348,7 +1359,7 @@ export function createWorkflowSandbox(opts: SandboxOptions): WorkflowSandbox {
       // FIX-Round1-T13: throw on any opts key not in the allowlist — catches
       // typos like { scema: ... } that previously slipped through the
       // [key:string]: unknown index signature.
-      const KNOWN_AGENT_OPTS = ['label', 'phase', 'schema', 'model', 'isolation', 'agentType', 'stallMs'];
+      const KNOWN_AGENT_OPTS = ['label', 'phase', 'schema', 'model', 'isolation', 'agentType', 'stallMs', 'cwd'];
       globalThis.agent = vmAsync(function (prompt, agentOpts) {
         agentOpts = agentOpts || {};
         const keys = Object.keys(agentOpts);
@@ -1377,6 +1388,28 @@ export function createWorkflowSandbox(opts: SandboxOptions): WorkflowSandbox {
             "agent({isolation: '" + agentOpts.isolation + "'}): unknown isolation mode. " +
             "Known modes are: 'worktree', 'remote'."
           );
+        }
+        // cwd points at a directory that already exists; isolation creates a
+        // new one. Passing both leaves the subagent's directory ambiguous,
+        // and the ambiguity is not theoretical: a /review run that set both a
+        // working directory and worktree isolation failed all 11 of its agents.
+        // The remaining validation (absolute, exists, inside the workspace) is
+        // host-side — the vm realm has no filesystem to check against.
+        // NOTE: no backticks anywhere below — this whole init script is a host
+        // template literal, so a backtick here terminates it at parse time.
+        if (agentOpts.cwd !== undefined) {
+          if (typeof agentOpts.cwd !== 'string' || agentOpts.cwd.length === 0) {
+            throw new Error(
+              'agent({cwd}): must be a non-empty string (an absolute path).'
+            );
+          }
+          if (agentOpts.isolation !== undefined) {
+            throw new Error(
+              "agent({cwd, isolation}): mutually exclusive. 'cwd' runs the " +
+              "subagent in an existing directory; 'isolation' creates a new " +
+              "one. Pass exactly one."
+            );
+          }
         }
         if (typeof agentOpts.phase === 'string' && agentOpts.phase.length > 0) {
           if (__b.lastPhase() !== agentOpts.phase) {

--- a/packages/core/src/tools/workflow/workflow.ts
+++ b/packages/core/src/tools/workflow/workflow.ts
@@ -79,7 +79,7 @@ const WORKFLOW_PARAM_SCHEMA = {
         'JavaScript source of the workflow. Wrapped as an async IIFE. ' +
         'May call the injected globals `phase(title)`, `log(msg)`, ' +
         '`agent(prompt, opts?)`, and read `args`. ' +
-        'agent() opts: `{ label?, phase?, schema?, model?, agentType?, isolation? }`. ' +
+        'agent() opts: `{ label?, phase?, schema?, model?, agentType?, isolation?, cwd? }`. ' +
         '`schema` (JSON Schema object): the subagent must deliver its result ' +
         'by calling `structured_output` with arguments matching the schema; ' +
         'agent() resolves to the validated object. Two failed attempts produce ' +
@@ -101,6 +101,12 @@ const WORKFLOW_PARAM_SCHEMA = {
         'in this build" (parity with upstream). isolation=worktree refuses to ' +
         'run when the parent working tree has uncommitted changes (the subagent ' +
         'would see a stale HEAD). ' +
+        '`cwd` (absolute path): runs the subagent in a directory that already ' +
+        'exists — use it when the tree to work in was prepared beforehand, or ' +
+        "when the subject IS the parent tree's uncommitted changes, both of " +
+        'which `isolation` cannot serve. The path must resolve to a directory ' +
+        'inside the workspace; anything else throws. `cwd` and `isolation` are ' +
+        'mutually exclusive — pass exactly one. ' +
         'Workflow subagents always have SendMessage / Monitor / EnterPlanMode / ExitPlanMode ' +
         'in their disallowed-tool floor regardless of agentType. ' +
         'Concurrency: `parallel([() => agent(...), ...])` runs thunks ' +


### PR DESCRIPTION
## What this PR does

Adds a `cwd` option to `agent()`, so a workflow script can run a subagent in a directory that already exists.

`isolation: 'worktree'` cannot serve that case. It *provisions* a new worktree from the current tree, and refuses outright when the parent working tree has uncommitted changes (`workflow-orchestrator.ts:1017-1039`) — so a script whose subject **is** those uncommitted changes, or one that wants a tree it prepared earlier in the same run, has no option at all today. `cwd` fills that gap; the two are mutually exclusive.

### Why this stands on its own

This is a general capability gap in the workflow runtime, not a feature for one consumer. Any script that needs an agent anchored somewhere other than the session's directory hits it, and the only existing mechanism refuses precisely when the interesting state is uncommitted. The change is additive: omitting `cwd` leaves every existing dispatch on exactly the path it takes today.

### Changes

- **`workflow-sandbox.ts`** — `cwd` joins `KNOWN_AGENT_OPTS` and `WorkflowAgentOpts`. The vm realm checks the shape (non-empty string) and refuses `cwd` alongside `isolation`, since passing both leaves the subagent's directory ambiguous.
- **`workflow-orchestrator.ts`** — `createWorktreeConfigOverride` becomes `createDirConfigOverride`, shared by both directory-changing paths. The rebinding is identical; only lifecycle ownership differs, so `cwd` provisions nothing and cleans up nothing.
- **`workflow-orchestrator.ts`** — new `resolveAgentCwd()` validates host-side and fails closed on every branch: absolute, exists, is a directory, lies inside the workspace. `isPathWithinWorkspace` resolves symlinks and returns false on error, so a symlink out of the workspace is rejected rather than followed.
- **`workflow-orchestrator.ts`** — `cwd` joins the fast-path gate. The fast path builds no Config override, so a `cwd` reaching it would be dropped in silence and the subagent would read the parent's tree while the script believed otherwise — the exact failure the option exists to prevent.
- **`workflow-journal.ts`** — `canonicalizeAgentOpts` now projects `cwd`. Without this a resume would serve one directory's cached result for an identical prompt aimed at another, because the key could not tell them apart. This is the subtle one: it is a correctness fix for the resume cache, not bookkeeping.
- **`tools/workflow/workflow.ts`** — the tool description lists `cwd`. An option the model cannot see is an option that does not exist.

### A note for future edits to `workflow-sandbox.ts`

The vm init script is a host template literal, so a backtick anywhere inside it — including inside a comment — terminates it at parse time (`TS1005`). I hit this while writing the validation comment; there is now an inline warning at that spot.

## Tests

13 new cases:

- **sandbox** (4) — pass-through to dispatch, non-string rejected, empty string rejected, mutual exclusion with `isolation`.
- **orchestrator** (7) — runtime context rebinding (`getTargetDir` / `getWorkingDir` / `getProjectRoot` all answer the requested directory), forced override path, and each validation failure: relative path, missing directory, a file, outside the workspace, plus the host-side mutual-exclusion re-check.
- **journal** (2) — `cwd` is projected, and two directories derive distinct agent keys for the same prompt.

```
npx vitest run src/agents/ src/tools/workflow/ src/config/config.workflows.test.ts src/config/config.workflow-registration.test.ts

 Test Files  41 passed | 1 skipped (42)
      Tests  1380 passed | 6 skipped (1386)
```

`tsc --noEmit`, `eslint`, and `prettier --check` all clean on the touched files.

## Rollback boundary

Self-contained. Reverting the commit removes the option; no persisted state, journal format, or existing dispatch path changes shape. Journals written before this change keep resolving identically, because an absent `cwd` is projected out exactly as it was.

## Linked Issues

Part of #8769 — this is P0 #1 of that proposal's Phase 0 (runtime prerequisites). It does not touch `/review` or any Phase 1+ work, and the issue stays open.
