### PR TITLE
feat(workflows): make the per-subagent ceilings operator-tunable

### DIFF
--- a/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
@@ -15,6 +15,11 @@ import {
   DEFAULT_MAX_AGENTS_PER_RUN,
   resolveMaxAgentsPerRun,
   resolveConcurrencyLimit,
+  resolveSubagentRunConfig,
+  DEFAULT_WORKFLOW_SUBAGENT_MAX_TURNS,
+  DEFAULT_WORKFLOW_SUBAGENT_MAX_TIME_MINUTES,
+  HARD_MAX_SUBAGENT_TURNS_CEILING,
+  HARD_MAX_SUBAGENT_MINUTES_CEILING,
 } from './workflow-orchestrator.js';
 import type { Config } from '../../config/config.js';
 import { AgentEventType, type AgentEventEmitter } from './agent-events.js';
@@ -1881,6 +1886,29 @@ describe('createProductionDispatch', () => {
     });
   });
 
+  // The ceilings are forced over any agentType's own runConfig, so they bind
+  // every workflow agent. An operator running a long dispatch (build-and-test,
+  // whole-file analysis) needs to raise them — and truncation is not a loud
+  // failure: it ends the subagent in a non-GOAL mode, which becomes a thrown
+  // dispatch and, under parallel(), a `null` element that reads as an agent
+  // silently missing from the fan-out.
+  it('honors the env overrides for the subagent ceilings', async () => {
+    // This config has no `unstubEnvs`, so the stubs are undone explicitly —
+    // a leaked ceiling would silently change every sibling test's runConfig.
+    vi.stubEnv('QWEN_CODE_WORKFLOW_SUBAGENT_MAX_TURNS', '200');
+    vi.stubEnv('QWEN_CODE_WORKFLOW_SUBAGENT_MAX_MINUTES', '45');
+    try {
+      const dispatch = createProductionDispatch(fakeConfig());
+      await dispatch('hello', { label: 'h1' });
+      expect(created[0]!.runConfig).toEqual({
+        max_turns: 200,
+        max_time_minutes: 45,
+      });
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
   // T11: disallow SendMessage plus tools that break workflow return/cleanup
   // contracts.
   it('disallows workflow-only floor tools for workflow subagents', async () => {
@@ -2420,6 +2448,68 @@ describe('WorkflowOrchestrator P2 — parallel() / pipeline() / caps', () => {
       expect(
         resolveMaxAgentsPerRun({ QWEN_CODE_MAX_WORKFLOW_AGENTS: '9999' }),
       ).toBe(9999);
+    });
+
+    // The per-subagent ceilings bind every workflow agent (they are forced
+    // over any agentType's own runConfig), so they need the same operator
+    // escape hatch — and the same protection from a fat-fingered value — as
+    // the per-run agent cap above.
+    it('resolveSubagentRunConfig defaults to 50 turns / 10 minutes', () => {
+      expect(resolveSubagentRunConfig({})).toEqual({
+        max_turns: DEFAULT_WORKFLOW_SUBAGENT_MAX_TURNS,
+        max_time_minutes: DEFAULT_WORKFLOW_SUBAGENT_MAX_TIME_MINUTES,
+      });
+    });
+
+    it('resolveSubagentRunConfig honors valid overrides', () => {
+      expect(
+        resolveSubagentRunConfig({
+          QWEN_CODE_WORKFLOW_SUBAGENT_MAX_TURNS: '200',
+          QWEN_CODE_WORKFLOW_SUBAGENT_MAX_MINUTES: '45',
+        }),
+      ).toEqual({ max_turns: 200, max_time_minutes: 45 });
+    });
+
+    it('resolveSubagentRunConfig rejects non-decimal-integer values', () => {
+      for (const raw of ['0', '-1', 'abc', '2.5', '0x10', '1e3', '1.0', '']) {
+        expect(
+          resolveSubagentRunConfig({
+            QWEN_CODE_WORKFLOW_SUBAGENT_MAX_TURNS: raw,
+          }).max_turns,
+        ).toBe(DEFAULT_WORKFLOW_SUBAGENT_MAX_TURNS);
+      }
+    });
+
+    it('resolveSubagentRunConfig clamps over-ceiling overrides', () => {
+      expect(
+        resolveSubagentRunConfig({
+          QWEN_CODE_WORKFLOW_SUBAGENT_MAX_TURNS: '999999',
+          QWEN_CODE_WORKFLOW_SUBAGENT_MAX_MINUTES: '999999',
+        }),
+      ).toEqual({
+        max_turns: HARD_MAX_SUBAGENT_TURNS_CEILING,
+        max_time_minutes: HARD_MAX_SUBAGENT_MINUTES_CEILING,
+      });
+      // Just under each ceiling is preserved.
+      expect(
+        resolveSubagentRunConfig({
+          QWEN_CODE_WORKFLOW_SUBAGENT_MAX_TURNS: String(
+            HARD_MAX_SUBAGENT_TURNS_CEILING - 1,
+          ),
+        }).max_turns,
+      ).toBe(HARD_MAX_SUBAGENT_TURNS_CEILING - 1);
+    });
+
+    // The two knobs are independent: raising turns must not disturb minutes.
+    it('resolveSubagentRunConfig resolves each ceiling independently', () => {
+      expect(
+        resolveSubagentRunConfig({
+          QWEN_CODE_WORKFLOW_SUBAGENT_MAX_TURNS: '120',
+        }),
+      ).toEqual({
+        max_turns: 120,
+        max_time_minutes: DEFAULT_WORKFLOW_SUBAGENT_MAX_TIME_MINUTES,
+      });
     });
 
     it('resolveConcurrencyLimit honors a valid override and clamps the cpu default to [1,16]', () => {

--- a/packages/core/src/agents/runtime/workflow-orchestrator.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.ts
@@ -152,9 +152,93 @@ export function resolveConcurrencyLimit(
  * Bound the resource ceiling for workflow subagents so a single `agent()`
  * call cannot loop the model indefinitely. Values mirror conservative
  * upstream defaults; P5 will refine via `budget` once it exists.
+ *
+ * These are forced over whatever runConfig an `agentType` declares, because
+ * they are workflow-level safety bounds rather than subagent preferences.
+ * That makes them the binding constraint for every workflow agent, which is
+ * why they are operator-tunable: 50 turns / 10 minutes is right for a typical
+ * dispatch and wrong for a long one (a build-and-test pass, an analysis of a
+ * multi-thousand-line file), and there was previously no way to say so.
+ *
+ * Truncation here is not a visible failure. A subagent stopped by `max_turns`
+ * or `max_time_minutes` ends in a non-GOAL terminate mode, which the dispatch
+ * turns into a throw — and under `parallel()`'s errors-as-data contract that
+ * becomes a `null` element the script must notice. An agent silently missing
+ * from a fan-out is the failure mode these knobs exist to let operators avoid.
  */
-const WORKFLOW_SUBAGENT_MAX_TURNS = 50;
-const WORKFLOW_SUBAGENT_MAX_TIME_MINUTES = 10;
+export const DEFAULT_WORKFLOW_SUBAGENT_MAX_TURNS = 50;
+export const DEFAULT_WORKFLOW_SUBAGENT_MAX_TIME_MINUTES = 10;
+export const WORKFLOW_SUBAGENT_MAX_TURNS_ENV =
+  'QWEN_CODE_WORKFLOW_SUBAGENT_MAX_TURNS';
+export const WORKFLOW_SUBAGENT_MAX_MINUTES_ENV =
+  'QWEN_CODE_WORKFLOW_SUBAGENT_MAX_MINUTES';
+/**
+ * Absolute upper bounds on the env overrides, in the same spirit as
+ * `HARD_MAX_AGENTS_PER_RUN_CEILING`: the knobs are operator-facing, so a
+ * fat-fingered value must not effectively uncap a runaway agent. 500 turns is
+ * 10× the default. 240 minutes matches the longest budget a workflow run is
+ * realistically given; past that the run-level wall clock
+ * (`QWEN_CODE_MAX_WORKFLOW_SECONDS`) is the right control, not a per-agent cap.
+ */
+export const HARD_MAX_SUBAGENT_TURNS_CEILING = 500;
+export const HARD_MAX_SUBAGENT_MINUTES_CEILING = 240;
+
+/**
+ * Shared resolver for both per-subagent ceilings. Mirrors
+ * `resolveMaxAgentsPerRun`: parse through `parsePositiveIntegerEnv` so only
+ * plain decimal integers are accepted (`Number()` alone would admit `"0x10"`
+ * / `"1e3"` / `"1.0"`), fall back to the default with a debug warning on an
+ * invalid value, and clamp with a warning above the hard ceiling.
+ */
+function resolvePositiveEnvLimit(
+  env: Record<string, string | undefined>,
+  envName: string,
+  fallback: number,
+  ceiling: number,
+): number {
+  const raw = env[envName];
+  if (raw === undefined || raw.trim() === '') {
+    return fallback;
+  }
+  const parsed = parsePositiveIntegerEnv(raw, 0);
+  if (parsed < 1) {
+    debugLogger.warn(
+      `Invalid ${envName}=${JSON.stringify(raw)}, using default (${fallback})`,
+    );
+    return fallback;
+  }
+  if (parsed > ceiling) {
+    debugLogger.warn(
+      `${envName}=${parsed} exceeds hard ceiling (${ceiling}); clamping.`,
+    );
+    return ceiling;
+  }
+  return parsed;
+}
+
+/**
+ * The `runConfigOverrides` forced onto every workflow subagent. Resolved per
+ * dispatch rather than once at module load so an embedder that adjusts the
+ * environment mid-session — and the tests — see the current value.
+ */
+export function resolveSubagentRunConfig(
+  env: Record<string, string | undefined> = process.env,
+): { max_turns: number; max_time_minutes: number } {
+  return {
+    max_turns: resolvePositiveEnvLimit(
+      env,
+      WORKFLOW_SUBAGENT_MAX_TURNS_ENV,
+      DEFAULT_WORKFLOW_SUBAGENT_MAX_TURNS,
+      HARD_MAX_SUBAGENT_TURNS_CEILING,
+    ),
+    max_time_minutes: resolvePositiveEnvLimit(
+      env,
+      WORKFLOW_SUBAGENT_MAX_MINUTES_ENV,
+      DEFAULT_WORKFLOW_SUBAGENT_MAX_TIME_MINUTES,
+      HARD_MAX_SUBAGENT_MINUTES_CEILING,
+    ),
+  };
+}
 
 /**
  * disallowedTools mirror the upstream `Tg8` workflow-subagent config. These
@@ -456,10 +540,7 @@ async function runSingleDispatch(
       // cannot loop the model indefinitely. Without this, runConfig was {}
       // and the loop guards never tripped — combined with the cancellation
       // bug below, workflows were effectively unkillable.
-      {
-        max_turns: WORKFLOW_SUBAGENT_MAX_TURNS,
-        max_time_minutes: WORKFLOW_SUBAGENT_MAX_TIME_MINUTES,
-      },
+      resolveSubagentRunConfig(),
       // T11 (PR #4732 R1): disallow SendMessage / ExitPlanMode to align with
       // upstream Tg8 — closes the back-channel that would let a subagent
       // deliver its answer via user message instead of the script's read.
@@ -777,10 +858,7 @@ async function runOverridePath(
         // Workflow always bounds resource ceiling regardless of agentType's
         // own runConfig / maxTurns — these are workflow-level safety bounds,
         // not subagent-level preferences. P5 will refine via budget.
-        runConfigOverrides: {
-          max_turns: WORKFLOW_SUBAGENT_MAX_TURNS,
-          max_time_minutes: WORKFLOW_SUBAGENT_MAX_TIME_MINUTES,
-        },
+        runConfigOverrides: resolveSubagentRunConfig(),
         eventEmitter,
       },
     );

--- a/packages/core/src/tools/workflow/workflow.ts
+++ b/packages/core/src/tools/workflow/workflow.ts
@@ -117,6 +117,16 @@ const WORKFLOW_PARAM_SCHEMA = {
         'THUNKS to parallel, not eager calls: `parallel([() => agent(...)])`, ' +
         'not `parallel([agent(...)])`. At most 1000 agent() calls per run ' +
         '(override via `QWEN_CODE_MAX_WORKFLOW_AGENTS`). ' +
+        'Time bounds — three independent limits, all of which must fit a long ' +
+        'dispatch, so raising only one has no effect: per-agent turns and ' +
+        'minutes (50 / 10 by default, forced over any agentType runConfig; ' +
+        'override via `QWEN_CODE_WORKFLOW_SUBAGENT_MAX_TURNS` and ' +
+        '`QWEN_CODE_WORKFLOW_SUBAGENT_MAX_MINUTES`), the per-call stall ' +
+        'watchdog (60s of no progress; `agent({stallMs})` or ' +
+        '`QWEN_CODE_WORKFLOW_STALL_SECONDS`), and the whole-run wall clock ' +
+        '(30 min; `QWEN_CODE_MAX_WORKFLOW_SECONDS`). An agent stopped by a ' +
+        'turn/minute ceiling ends in a non-GOAL mode, which throws — under ' +
+        'parallel() that surfaces as a `null` element, not an error message. ' +
         '`Date.now()` and `Math.random()` both throw — workflow scripts ' +
         'must be deterministic for resume. ' +
         '`export const meta = {...}` declarations are stripped before execution.',


### PR DESCRIPTION
## What this PR does

Makes the two per-subagent resource ceilings operator-tunable via environment variables, with hard ceilings. Defaults are unchanged.

`WORKFLOW_SUBAGENT_MAX_TURNS` (50) and `WORKFLOW_SUBAGENT_MAX_TIME_MINUTES` (10) are hard-coded constants applied at `workflow-orchestrator.ts:780-783`, where the comment is explicit that they override whatever runConfig an `agentType` declares. That makes them the binding constraint for **every** workflow agent, with no way to raise them — right for a typical dispatch, wrong for a long one (a build-and-test pass, an analysis of a multi-thousand-line file).

### Why this stands on its own

Every other comparable bound in the runtime already has an operator escape hatch — `QWEN_CODE_MAX_WORKFLOW_AGENTS`, `QWEN_CODE_MAX_WORKFLOW_CONCURRENCY`, `QWEN_CODE_WORKFLOW_STALL_SECONDS`, `QWEN_CODE_MAX_WORKFLOW_SECONDS`. These two are the exception, and they are the ones that bind first for a long-running agent.

What makes it worth fixing rather than living with: **truncation here is not a visible failure**. An agent stopped by either ceiling ends in a non-GOAL terminate mode, which the dispatch turns into a throw, and under `parallel()`'s errors-as-data contract that becomes a `null` element the script must notice. The observable symptom is an agent missing from a fan-out — not an error naming the cause. Raising the run wall clock alone does nothing about it, which is easy to get wrong because the wall clock is the knob people find first.

`workflow-orchestrator.ts:154` notes *"P5 will refine via `budget` once it exists"*. This is deliberately a stopgap in that direction and not a competing design — if P5 lands, these resolvers are the natural thing for it to subsume. **If P5 is already owned by someone, say so and I'll close this.**

### Changes

- `QWEN_CODE_WORKFLOW_SUBAGENT_MAX_TURNS` and `QWEN_CODE_WORKFLOW_SUBAGENT_MAX_MINUTES` override the defaults, resolved through the same `parsePositiveIntegerEnv` path as `QWEN_CODE_MAX_WORKFLOW_AGENTS` — only plain decimal integers are accepted (`Number()` alone would admit `0x10` / `1e3` / `1.0`), and an invalid value falls back to the default with a debug warning.
- Hard ceilings clamp a fat-fingered override, mirroring `HARD_MAX_AGENTS_PER_RUN_CEILING`'s intent: **500 turns** (10× default) and **240 minutes**. Past 240 minutes the run-level wall clock is the right control, not a per-agent cap.
- Resolved per dispatch rather than at module load, so an embedder that adjusts the environment mid-session sees the current value. Both dispatch paths (fast and override) now share one resolver instead of two inline literals.
- The tool description states all three time bounds **together** — per-agent turns/minutes, the per-call stall watchdog, and the run wall clock — because they are independent and raising only one has no effect on a long dispatch. That interaction was previously written down nowhere.

## Tests

6 new cases: defaults, valid overrides, rejection of non-decimal-integer values (`0`, `-1`, `abc`, `2.5`, `0x10`, `1e3`, `1.0`, empty), clamping at both ceilings, independence of the two knobs, and the resolved config reaching the subagent through a real dispatch.

The dispatch-level case unstubs its env in a `finally` — this vitest config sets no `unstubEnvs`, so a leaked ceiling would silently change every sibling test's `runConfig`.

```
npx vitest run src/agents/ src/tools/workflow/ src/config/config.workflows.test.ts src/config/config.workflow-registration.test.ts

 Test Files  41 passed | 1 skipped (42)
      Tests  1373 passed | 6 skipped (1379)
```

`tsc --noEmit`, `eslint`, and `prettier --check` all clean on the touched files.

## Rollback boundary

Self-contained, and inert unless an operator opts in: with neither variable set, `resolveSubagentRunConfig()` returns exactly the previous `{max_turns: 50, max_time_minutes: 10}`. No persisted state or journal format changes.

## Linked Issues

Part of #8769. This one is not in the proposal's original text — it came out of a code fact-check on that thread ([comment](https://github.com/QwenLM/qwen-code/issues/8769#issuecomment-5231993320), §3), which found that §6's P1 row raises the 30-minute wall clock but not these two, so a workflow that raises only `QWEN_CODE_MAX_WORKFLOW_SECONDS` still gets its long agents cut off. Refs #8105.
