### PR TITLE
test(workflows): pin the unattended approval path for WorkflowTool

### DIFF
--- a/packages/core/src/tools/workflow/workflow.test.ts
+++ b/packages/core/src/tools/workflow/workflow.test.ts
@@ -5,6 +5,11 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
+import {
+  needsConfirmation,
+  isAutoEditApproved,
+} from '../../core/permissionFlow.js';
+import { ApprovalMode } from '../../config/approval-mode.js';
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -307,6 +312,86 @@ describe('WorkflowTool', () => {
     const tool = new WorkflowTool(fakeConfig());
     const invocation = tool.build({ script: 'return 1' });
     expect(await invocation.getDefaultPermission()).toBe('ask');
+  });
+
+  // The headless / CI path.
+  //
+  // WorkflowTool defaults to `'ask'`, and an unattended run cannot answer a
+  // confirmation prompt: `review run` spawns the CLI with stdin closed and
+  // `--approval-mode yolo`. So whether a workflow can run in CI at all comes
+  // down to how that `'ask'` resolves against the approval mode — a decision
+  // that lives in `permissionFlow`, not in this tool, and was pinned by no
+  // test on either side.
+  //
+  // These cases exist so a change to the tool's confirmation surface cannot
+  // silently make unattended runs hang. That failure would not look like a
+  // test failure; it would look like CI timing out.
+  describe('unattended approval path', () => {
+    it('YOLO resolves the "ask" default to no confirmation', () => {
+      expect(
+        needsConfirmation('ask', ApprovalMode.YOLO, ToolNames.WORKFLOW),
+      ).toBe(false);
+    });
+
+    // AUTO_EDIT auto-approves on `confirmationDetails.type`, and WorkflowTool
+    // overrides neither `getConfirmationDetails` nor `requiresUserInteraction`
+    // — so it inherits BaseToolInvocation's generic `'info'` dialog, which is
+    // exactly what `isAutoEditApproved` accepts. That inheritance is
+    // load-bearing but incidental: giving WorkflowTool a richer confirmation
+    // UI later would flip AUTO_EDIT back to prompting. Assert the actual
+    // details object rather than a hard-coded 'info' so the link is tested.
+    it('AUTO_EDIT auto-approves via the inherited info dialog', async () => {
+      const tool = new WorkflowTool(fakeConfig());
+      const invocation = tool.build({ script: 'return 1' });
+      const details = await invocation.getConfirmationDetails(
+        new AbortController().signal,
+      );
+      expect(details.type).toBe('info');
+      expect(isAutoEditApproved(ApprovalMode.AUTO_EDIT, details)).toBe(true);
+    });
+
+    it('does not demand user interaction, which would force a prompt in every mode', () => {
+      const tool = new WorkflowTool(fakeConfig());
+      const invocation = tool.build({ script: 'return 1' });
+      // Optional on the interface; an absent method means the same thing,
+      // since callers default the flag to false.
+      expect(invocation.requiresUserInteraction?.() ?? false).toBe(false);
+      // requiresUserInteraction short-circuits ahead of the YOLO branch, so
+      // were it true the mode would not matter.
+      expect(
+        needsConfirmation(
+          'ask',
+          ApprovalMode.YOLO,
+          ToolNames.WORKFLOW,
+          /* requiresUserInteraction */ true,
+        ),
+      ).toBe(true);
+    });
+
+    // DEFAULT still prompts — recorded as the expected contract, not a bug.
+    // An unattended caller is responsible for choosing a non-interactive
+    // approval mode; `review run` defaults to `yolo` for exactly this reason.
+    it('DEFAULT still requires confirmation', () => {
+      expect(
+        needsConfirmation('ask', ApprovalMode.DEFAULT, ToolNames.WORKFLOW),
+      ).toBe(true);
+    });
+
+    // The end-to-end shape of an unattended run: a bare Config exposing none
+    // of the interactive surface (no isInteractive, no approval bridge, no
+    // completion channel), a foreground call, and no stdin. It must complete
+    // and return a result rather than block waiting for something to answer.
+    it('a foreground run completes against a config with no interactive surface', async () => {
+      const tool = new WorkflowTool(fakeConfig(), {
+        dispatch: async (prompt) => `T:${prompt}`,
+      });
+      const invocation = tool.build({
+        script: `const r = await agent("do work"); return r;`,
+      });
+      const result = await invocation.execute(new AbortController().signal);
+      expect(result.error).toBeUndefined();
+      expect(JSON.stringify(result.llmContent)).toContain('T:do work');
+    });
   });
 
   it('execute() runs the script via WorkflowOrchestrator with injected dispatch and returns a ToolResult', async () => {


### PR DESCRIPTION
## What this PR does

Adds regression coverage for WorkflowTool's unattended (headless / CI) approval path. **Tests only — no production change.**

`WorkflowTool.getDefaultPermission()` returns `'ask'` (`workflow.ts:183-185`), and an unattended run cannot answer a confirmation prompt: `review run` spawns the CLI with stdin closed (`run.ts:285-288`) and `--approval-mode yolo` (`run.ts:504-511`). So whether a workflow can run in CI at all comes down to how that `'ask'` resolves against the approval mode — a decision that lives in `core/permissionFlow.ts`, not in this tool, and that was pinned by no test on either side.

### The finding

**The path already works.** I checked this before writing anything:

- **YOLO** — `needsConfirmation` short-circuits at `permissionFlow.ts:140` for every tool except `ask_user_question`, so the `'ask'` default never blocks. This is the CI path.
- **AUTO_EDIT** — `isAutoEditApproved` (`permissionFlow.ts:189-193`) auto-approves when `confirmationDetails.type` is `'edit'` or `'info'`. WorkflowTool overrides neither `getConfirmationDetails` nor `requiresUserInteraction`, so it inherits `BaseToolInvocation`'s generic `'info'` dialog and qualifies.
- **DEFAULT** — still prompts, which is the correct contract: choosing a non-interactive approval mode is the unattended caller's responsibility.

So no approval bridge needs building. This PR is the coverage that keeps it true.

### Why this is worth a PR rather than nothing

The AUTO_EDIT case rests on an inheritance that is **load-bearing but incidental**. Nothing in `workflow.ts` says "we depend on getting the generic `'info'` dialog" — but giving WorkflowTool a richer confirmation UI later (an entirely reasonable change, and one several other tools have made) would flip AUTO_EDIT back to prompting.

That regression would not present as a test failure. It would present as CI timing out, on a job whose logs show a workflow that started and never finished. The test asserts the actual `getConfirmationDetails()` result and feeds it to `isAutoEditApproved`, rather than hard-coding `'info'`, so the dependency itself is what is covered.

This also satisfies #8105's cross-cutting criterion — *"Headless and ACP modes either expose a complete interaction contract or fail clearly"* — for this tool, with evidence rather than assertion.

## Tests

5 cases in the new `unattended approval path` block:

1. YOLO resolves the `'ask'` default to no confirmation.
2. AUTO_EDIT auto-approves via the inherited info dialog (asserted through the real details object).
3. The tool does not demand user interaction — plus the short-circuit showing that were it to, the approval mode would stop mattering.
4. DEFAULT still requires confirmation (recorded as the expected contract, not a bug).
5. A foreground run completes against a `Config` exposing no interactive surface at all — no `isInteractive`, no approval bridge, no completion channel — the shape an unattended caller actually presents.

The `run_in_background` half of the headless contract was already covered (`rejects background runs outside an interactive completion channel`), so this PR does not duplicate it.

```
npx vitest run src/tools/workflow/workflow.test.ts

 Test Files  1 passed (1)
      Tests  44 passed (44)
```

`tsc --noEmit`, `eslint`, `prettier --check` clean.

## Rollback boundary

Test-only. Reverting removes coverage and changes no behavior.

## Linked Issues

Part of #8769 — P0 #2 of that proposal's Phase 0, which listed the headless path as *"the riskiest prerequisite"*. The evidence here downgrades it: the prerequisite is already met, and what was missing was a test saying so. Refs #8105.
