### PR TITLE
fix(web-shell): gate the floating todo entry behind the session workflow setting

### DIFF
--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -300,6 +300,7 @@ const {
       latestChatEditorProps: null as ChatEditorTestProps | null,
       latestToastHostElevated: false,
       latestStatusBarTasks: null as DaemonSessionMonitorTaskStatus[] | null,
+      latestStatusBarOnOpenTasks: null as (() => void) | null,
       latestMessageListProps: null as {
         failedPromptMessageId?: string;
         onRetryFailedPrompt?: () => void;
@@ -894,8 +895,12 @@ function mockComponent(path: string, exportName: string): void {
 vi.doMock('./components/StatusBar', async () => {
   const React = await import('react');
   return {
-    StatusBar: (props: { tasks?: DaemonSessionMonitorTaskStatus[] }) => {
+    StatusBar: (props: {
+      tasks?: DaemonSessionMonitorTaskStatus[];
+      onOpenTasks?: () => void;
+    }) => {
       testState.latestStatusBarTasks = props.tasks ?? [];
+      testState.latestStatusBarOnOpenTasks = props.onOpenTasks ?? null;
       return React.createElement('div');
     },
   };
@@ -4278,6 +4283,7 @@ beforeEach(() => {
   testState.latestChatEditorProps = null;
   testState.latestToastHostElevated = false;
   testState.latestStatusBarTasks = null;
+  testState.latestStatusBarOnOpenTasks = null;
   testState.latestMessageListProps = null;
   testState.latestAddWorkspaceDialogProps = null;
   testState.latestToolApprovalKeyboardActive = null;
@@ -4604,7 +4610,7 @@ describe('App plan todos', () => {
     await flush();
 
     await act(async () => {
-      testState.latestTodoPanelOnOpen?.();
+      testState.latestStatusBarOnOpenTasks?.();
       await Promise.resolve();
     });
 
@@ -4615,6 +4621,26 @@ describe('App plan todos', () => {
         .querySelector('[data-testid="dialog-shell"]')
         ?.getAttribute('data-dialog-title'),
     ).toBe('Background tasks');
+  });
+
+  it('only binds the todo panel entry when session workflow is enabled', async () => {
+    testState.messages = [
+      {
+        id: 'plan',
+        role: 'plan',
+        todos: [{ id: 'work', content: 'Work', status: 'in_progress' }],
+      },
+    ];
+    const { rerender } = renderApp();
+    await flush();
+
+    expect(testState.latestTodoPanelOnOpen).toBeNull();
+
+    testState.settings = [sessionWorkflowSetting()];
+    rerender();
+    await flush();
+
+    expect(testState.latestTodoPanelOnOpen).not.toBeNull();
   });
 });
 

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -10453,7 +10453,9 @@ export function App({
                             todos={showFloatingTodos ? floatingTodos : []}
                             statusItems={floatingBottomStatusItems}
                             onOpen={
-                              showFloatingTodos ? openTasksPanel : undefined
+                              sessionWorkflowEnabled && showFloatingTodos
+                                ? openTasksPanel
+                                : undefined
                             }
                           />
                         </div>


### PR DESCRIPTION
## What this PR does

The floating Todo panel at the bottom of the chat view used to open the plan-and-tasks dialog when clicked. That entry is now aligned with the Session Workflow experimental setting: when the setting is off, the Todo panel renders as plain, non-interactive progress; when it is on, clicking the panel opens the plan execution view as before.

## Why it's needed

The plan execution visualization originally reused the background tasks dialog to show how Todos relate to running agents. When Session Workflow was later moved behind an experimental setting that defaults to off, the plan content inside that dialog was hidden, but the Todo click entry was left wired up. As a result, with the default configuration, clicking the Todo panel opened a dialog that only showed background tasks — content unrelated to the Todos. Background tasks remain reachable through the dedicated status bar entry, which is unaffected.

## Reviewer Test Plan

### How to verify

1. With the default configuration (`experimental.sessionWorkflow` not enabled), run a Web Shell session that produces Todos: the floating panel shows progress and steps but is not clickable (no button affordance).
2. Enable `experimental.sessionWorkflow` in the workspace settings: the Todo panel becomes clickable again and opens the plan-and-tasks dialog with plan steps and linked agents.
3. In both states, the background tasks entry in the status bar still opens the tasks dialog as usual.

Unit tests cover the gating directly (new case in `App.test.tsx`: the Todo panel receives no `onOpen` binding while the setting is off, and receives one once enabled); all 349 related tests pass.

### Evidence (Before & After)

N/A — the gating behavior is asserted by the unit test rather than a visual change worth screenshotting.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests via `npx vitest` inside `packages/web-shell`.

## Risk & Scope

- Main risk or tradeoff: with the setting off, the Todo panel loses its clickability — this is intentional, since the plan content in the dialog is equally hidden in that state.
- Not validated / out of scope: the background tasks dialog itself and its other entry points are unchanged.
- Breaking changes / migration notes: none.

## Linked Issues

Related to #7580 and #8391 (no closing keyword).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

聊天区底部的 Todo 浮窗之前点击后会打开"计划与任务"弹窗。这个入口现在与 Session Workflow 实验开关保持一致：开关关闭时，Todo 浮窗变为纯展示，不再是可点击入口；开关打开时，恢复原有的点击查看计划执行视图的行为。

## 为什么需要

计划执行可视化最初复用后台任务弹窗来展示 Todo 与 Agent 的执行关系。后来 Session Workflow 被收进默认关闭的实验开关后，弹窗里的计划内容被隐藏了，但 Todo 的点击入口没有同步处理，导致默认配置下点击 Todo 浮窗只会打开一个只剩"后台任务"内容的弹窗，与 Todo 本身无关。后台任务仍可从状态栏的专用入口打开，不受影响。

## 评审验证计划

### 如何验证

1. 默认配置（不开启 `experimental.sessionWorkflow`）下运行 Web Shell，让会话产生 Todo：底部浮窗显示进度和步骤，但不可点击（无按钮态）。
2. 在工作区设置中开启 `experimental.sessionWorkflow`：Todo 浮窗恢复可点击，点击后打开"计划与任务"弹窗，包含计划步骤与关联的 Agent。
3. 两种情况下，状态栏的后台任务入口均正常打开后台任务弹窗。

单测直接覆盖门控行为（`App.test.tsx` 新增用例：开关关闭时 TodoPanel 不绑定 `onOpen`，开启后绑定），349 个相关测试全部通过。

### 前后对比证据

N/A —— 门控行为已由单测断言，不属于需要截图的视觉变化。

### 测试环境

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

在 `packages/web-shell` 内通过 `npx vitest` 运行单测。

## 风险与范围

- 主要风险/权衡：开关关闭时 Todo 浮窗失去点击能力——这正是预期行为，因为弹窗中的计划内容在该状态下同样不可见。
- 未验证/超出范围：未改动后台任务弹窗本身及其他打开入口。
- 破坏性变更/迁移说明：无。

## 关联 Issue

关联 #7580 与 #8391（不使用关闭关键词）。

</details>
