### PR TITLE
fix(cli): enable DEC synchronized output on Warp to reduce redraw flicker

### DIFF
--- a/packages/cli/src/ui/utils/synchronizedOutput.test.ts
+++ b/packages/cli/src/ui/utils/synchronizedOutput.test.ts
@@ -31,7 +31,10 @@ function createStdout(write: NodeJS.WriteStream['write']): NodeJS.WriteStream {
 describe('terminalSupportsSynchronizedOutput', () => {
   it.each([
     [{ TERM_PROGRAM: 'WezTerm' }, true],
+    [{ TERM_PROGRAM: 'WarpTerminal' }, true],
+    [{ TERM_PROGRAM: 'ghostty' }, true],
     [{ TERM_PROGRAM: 'iTerm.app' }, true],
+    [{ TERM_PROGRAM: 'WarpTerminal' }, true],
     [{ TERM: 'xterm-kitty' }, true],
     [{ KITTY_WINDOW_ID: '1' }, true],
     [{ TERM_PROGRAM: 'Apple_Terminal' }, false],

--- a/packages/cli/src/ui/utils/synchronizedOutput.ts
+++ b/packages/cli/src/ui/utils/synchronizedOutput.ts
@@ -53,7 +53,16 @@ export function terminalSupportsSynchronizedOutput(
   }
 
   const termProgram = env['TERM_PROGRAM'];
-  if (termProgram === 'WezTerm' || termProgram === 'iTerm.app') {
+  // Warp's DECRQM 2026 probe answers status 2 (recognized, reset), so
+  // synchronized updates are available there; without them Warp renders the
+  // erase-then-rewrite pattern as flicker (issue #8557). Ghostty implements
+  // synchronized output natively.
+  if (
+    termProgram === 'WezTerm' ||
+    termProgram === 'iTerm.app' ||
+    termProgram === 'WarpTerminal' ||
+    termProgram === 'ghostty'
+  ) {
     return true;
   }
 


### PR DESCRIPTION
## What this PR does

Adds Warp and Ghostty to the allowlist of terminals that receive DEC 2026 synchronized updates around each frame write, so both get the same atomic erase-then-rewrite treatment as WezTerm and iTerm.

## Why it's needed

The renderer's frame update erases the previous frame and rewrites it; terminals that paint intermediate states show that as flicker, most visible during resize drags (issue #8557). Warp answers a DECRQM 2026 probe with status 2 (mode recognized, currently reset) and Ghostty implements synchronized output natively, but both were outside the allowlist. With updates enabled, each erase+draw pair applies atomically and the drag flicker collapses to clean relayouts. The existing `QWEN_CODE_DISABLE_SYNCHRONIZED_OUTPUT=1` escape hatch covers any regression.

## Reviewer Test Plan

### How to verify

In Warp or Ghostty, run `npm run dev`, send a prompt and watch streaming, then resize the window: expected frame updates without erase/rewrite tearing; with `QWEN_CODE_DISABLE_SYNCHRONIZED_OUTPUT=1` the previous flicker returns. A DECRQM probe (`printf '\e[?2026$p'` in Warp) returns `CSI ? 2026 ; 2 $ y`. Non-allowlisted terminals are unaffected.

### Evidence (Before & After)

Capability proven by the DECRQM probe (Warp) and Ghostty's documented DEC 2026 support; author-observed on Ghostty: drag flicker reduced to atomic relayouts when combined with the repaint fix in the companion PR.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`npm run dev` in Warp and Ghostty on macOS.

## Risk & Scope

- Main risk or tradeoff: if a terminal build implements DEC 2026 incompletely, worst case equals today's behavior; the escape hatch disables the feature entirely.
- Not validated / out of scope: the Warp resize-duplication half of #8557 (platform snapshot behavior; addressed by the companion repaint PR where possible).
- Breaking changes / migration notes: none.

## Linked Issues

References #8557. Does not close it.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 Warp 与 Ghostty 加入 DEC 2026 synchronized updates 白名单，与 WezTerm/iTerm 同等获得原子化帧更新。

## 为什么需要

渲染器每帧先擦后写；会把中间态画出来的终端表现为闪烁，resize 拖拽时最明显（#8557）。Warp 的 DECRQM 2026 探针返回 status 2，Ghostty 原生支持 2026，但二者此前不在白名单。启用后擦+写原子应用，拖拽闪烁收敛为干净的重排。逃生门 `QWEN_CODE_DISABLE_SYNCHRONIZED_OUTPUT=1` 覆盖回归。

## 评审测试计划

Warp/Ghostty 中 `npm run dev`，流式输出并拖拽：期望无擦/写撕裂；设逃生门后旧闪烁复现。非白名单终端不受影响。

## 风险与范围

- 主要风险：终端 2026 实现不完整时最坏等于现状；逃生门可关闭。
- 超范围：#8557 的 Warp resize 重复半边（伴生重绘 PR 处理）。
- 无破坏性变更。

## 关联 issue

参考 #8557，不关闭。

</details>