### PR TITLE
fix(webui): Fence stale session work by attachment identity

### DIFF
--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -6934,6 +6934,173 @@ describe('DaemonSessionProvider', () => {
     expect(blocks).toEqual([]);
   });
 
+  it('ignores streamed events from a replaced same-id attachment', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    const streamStarted = createDeferred<void>();
+    const releaseOldEvent = createDeferred<void>();
+    const source = createMockSession({
+      sessionId: 'session-a',
+      clientId: 'client-a',
+      events: async function* staleEvents() {
+        streamStarted.resolve();
+        await releaseOldEvent.promise;
+        yield {
+          id: 1,
+          v: 1,
+          type: 'session_update',
+          sessionId: 'session-a',
+          data: {
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              content: { type: 'text', text: 'stale output' },
+            },
+          },
+        };
+      },
+    });
+    const target = createMockSession({
+      sessionId: 'session-a',
+      clientId: 'client-b',
+      replaySnapshot: createTextReplaySnapshot('replacement transcript'),
+      events: createIdleEvents(),
+    });
+    sdkMocks.sessions.push(source, target);
+    let blocks: readonly DaemonTranscriptBlock[] = [];
+    let connection: DaemonConnectionState | undefined;
+
+    function Harness() {
+      blocks = useDaemonTranscriptBlocks();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      sessionId: 'session-a',
+      clientId: 'client-a',
+    });
+    await act(async () => {
+      await streamStarted.promise;
+      await flushPromises();
+    });
+
+    act(() => {
+      root?.render(
+        <DaemonSessionProvider
+          baseUrl="http://127.0.0.1:4170"
+          autoConnect={true}
+          sessionId="session-a"
+          clientId="client-b"
+        >
+          <Harness />
+        </DaemonSessionProvider>,
+      );
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+    expect(connection).toMatchObject({
+      sessionId: 'session-a',
+      clientId: 'client-b',
+    });
+    expect(blocks).toMatchObject([
+      { kind: 'assistant', text: 'replacement transcript' },
+    ]);
+
+    releaseOldEvent.resolve();
+    await act(async () => {
+      await flushPromises();
+      await flushTranscriptDispatch();
+    });
+
+    expect(JSON.stringify(blocks)).not.toContain('stale output');
+    expect(blocks).toMatchObject([
+      { kind: 'assistant', text: 'replacement transcript' },
+    ]);
+  });
+
+  it('ignores session_closed from a replaced same-id attachment', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    const streamStarted = createDeferred<void>();
+    const releaseOldEvent = createDeferred<void>();
+    const source = createMockSession({
+      sessionId: 'session-a',
+      clientId: 'client-a',
+      events: async function* staleEvents() {
+        streamStarted.resolve();
+        await releaseOldEvent.promise;
+        yield {
+          id: 1,
+          v: 1,
+          type: 'session_closed',
+          sessionId: 'session-a',
+          data: { reason: 'client_close' },
+        };
+      },
+    });
+    const target = createMockSession({
+      sessionId: 'session-a',
+      clientId: 'client-b',
+      replaySnapshot: createTextReplaySnapshot('replacement transcript'),
+      events: createIdleEvents(),
+    });
+    sdkMocks.sessions.push(source, target);
+    let blocks: readonly DaemonTranscriptBlock[] = [];
+    let connection: DaemonConnectionState | undefined;
+
+    function Harness() {
+      blocks = useDaemonTranscriptBlocks();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      sessionId: 'session-a',
+      clientId: 'client-a',
+    });
+    await act(async () => {
+      await streamStarted.promise;
+      await flushPromises();
+    });
+
+    act(() => {
+      root?.render(
+        <DaemonSessionProvider
+          baseUrl="http://127.0.0.1:4170"
+          autoConnect={true}
+          sessionId="session-a"
+          clientId="client-b"
+        >
+          <Harness />
+        </DaemonSessionProvider>,
+      );
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+
+    releaseOldEvent.resolve();
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(connection).toMatchObject({
+      status: 'connected',
+      sessionId: 'session-a',
+      clientId: 'client-b',
+    });
+    expect(blocks).toMatchObject([
+      { kind: 'assistant', text: 'replacement transcript' },
+    ]);
+  });
+
   it('clears connection state before detach resolves', async () => {
     const detached = createDeferred<void>();
     const firstSession = createMockSession({
@@ -7303,6 +7470,90 @@ describe('DaemonSessionProvider', () => {
       status: 'disconnected',
       error: 'heartbeat lost',
     });
+  });
+
+  it('ignores a late heartbeat failure from a replaced same-id attachment', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    sdkMocks.capabilities.mockResolvedValue({
+      v: 1,
+      mode: 'http-bridge',
+      features: ['client_heartbeat'],
+      modelServices: [],
+      workspaceCwd: '/mock-workspace',
+    });
+    const releaseHeartbeat = createDeferred<void>();
+    const sourceHeartbeat = vi.fn(async () => {
+      await releaseHeartbeat.promise;
+      throw Object.assign(new Error('source session gone'), { status: 410 });
+    });
+    sdkMocks.sessions.push(
+      createMockSession({
+        sessionId: 'session-a',
+        clientId: 'client-a',
+        heartbeat: sourceHeartbeat,
+        events: createIdleEvents(),
+      }),
+      createMockSession({
+        sessionId: 'session-a',
+        clientId: 'client-b',
+        events: createIdleEvents(),
+      }),
+    );
+    let connection: DaemonConnectionState | undefined;
+
+    function Harness() {
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      sessionId: 'session-a',
+      clientId: 'client-a',
+      heartbeatIntervalMs: 20,
+      heartbeatFailureThreshold: 1,
+    });
+    await vi.waitFor(() => expect(sourceHeartbeat).toHaveBeenCalled());
+
+    act(() => {
+      root?.render(
+        <DaemonSessionProvider
+          baseUrl="http://127.0.0.1:4170"
+          autoConnect={true}
+          sessionId="session-a"
+          clientId="client-b"
+          heartbeatIntervalMs={20}
+          heartbeatFailureThreshold={1}
+        >
+          <Harness />
+        </DaemonSessionProvider>,
+      );
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+    expect(connection).toMatchObject({
+      status: 'connected',
+      sessionId: 'session-a',
+      clientId: 'client-b',
+    });
+
+    releaseHeartbeat.resolve();
+    await act(async () => {
+      await wait(30);
+      await flushPromises();
+    });
+
+    expect(connection).toMatchObject({
+      status: 'connected',
+      sessionId: 'session-a',
+      clientId: 'client-b',
+      missingSession: false,
+    });
+    expect(connection?.error).toBeUndefined();
   });
 
   it('clears stale sessions on terminal HTTP heartbeat errors', async () => {
@@ -7694,6 +7945,10 @@ describe('DaemonSessionProvider', () => {
   });
 
   it('keeps the current transcript when a same-session reload is aborted', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
     const replacement = createDeferred<MockSession>();
     const currentSession = createMockSession({
       sessionId: 'session-a',
@@ -7717,27 +7972,164 @@ describe('DaemonSessionProvider', () => {
       async () => replacement.promise,
     );
     const controller = new AbortController();
-    const reload = requireActions(actions).reloadSession(controller.signal);
+    let reloadOutcome: Promise<unknown> | undefined;
+    act(() => {
+      reloadOutcome = requireActions(actions)
+        .reloadSession(controller.signal)
+        .then(
+          () => undefined,
+          (error: unknown) => error,
+        );
+    });
     await act(async () => {
       await flushPromises();
     });
 
-    controller.abort();
     const refreshedSession = createMockSession({
       sessionId: 'session-a',
       replaySnapshot: createTextReplaySnapshot('replacement transcript'),
     });
-    replacement.resolve(refreshedSession);
+    let outcome: unknown;
     await act(async () => {
-      await expect(reload).rejects.toMatchObject({ name: 'AbortError' });
+      controller.abort();
+      replacement.resolve(refreshedSession);
+      outcome = await reloadOutcome;
       await flushPromises();
     });
+    expect(outcome).toMatchObject({ name: 'AbortError' });
 
     expect(blocks).toMatchObject([
       { kind: 'assistant', text: 'current transcript' },
     ]);
     expect(currentSession.detach).not.toHaveBeenCalled();
     expect(refreshedSession.detach).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      root?.unmount();
+      root = null;
+      await flushPromises();
+    });
+  });
+
+  it('detaches the source attachment once after a same-session reload', async () => {
+    const detachFetch = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(null, { status: 204 }),
+    );
+    vi.stubGlobal('fetch', detachFetch);
+    const currentSession = createMockSession({
+      sessionId: 'session-a',
+      clientId: 'client-a',
+      events: createIdleEvents(),
+    });
+    const replacementSession = createMockSession({
+      sessionId: 'session-a',
+      clientId: 'client-b',
+      events: createIdleEvents(),
+    });
+    sdkMocks.sessions.push(currentSession);
+    let actions: DaemonSessionActions | undefined;
+
+    function Harness() {
+      actions = useDaemonActions();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    await act(async () => {
+      await flushPromises();
+    });
+    sdkMocks.MockDaemonSessionClient.load.mockResolvedValueOnce(
+      replacementSession,
+    );
+
+    let reload: Promise<void> | undefined;
+    act(() => {
+      reload = requireActions(actions).reloadSession(
+        new AbortController().signal,
+      );
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+    await expect(reload).resolves.toBeUndefined();
+
+    await act(async () => {
+      root?.unmount();
+      root = null;
+      await flushPromises();
+    });
+
+    expect(currentSession.detach).toHaveBeenCalledOnce();
+    expect(detachFetch).toHaveBeenCalledOnce();
+    expect(
+      new Headers(detachFetch.mock.calls[0][1]?.headers).get(
+        'X-Qwen-Client-Id',
+      ),
+    ).toBe('client-b');
+  });
+
+  it('retires both attachments when unmounted during a same-session reload', async () => {
+    const detachFetch = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(null, { status: 204 }),
+    );
+    vi.stubGlobal('fetch', detachFetch);
+    const replacement = createDeferred<MockSession>();
+    const source = createMockSession({
+      sessionId: 'session-a',
+      clientId: 'client-a',
+      events: createIdleEvents(),
+    });
+    const target = createMockSession({
+      sessionId: 'session-a',
+      clientId: 'client-b',
+      events: createIdleEvents(),
+    });
+    sdkMocks.sessions.push(source);
+    let actions: DaemonSessionActions | undefined;
+
+    function Harness() {
+      actions = useDaemonActions();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(
+      async () => replacement.promise,
+    );
+    let reloadOutcome: Promise<unknown> | undefined;
+    act(() => {
+      reloadOutcome = requireActions(actions)
+        .reloadSession(new AbortController().signal)
+        .then(
+          () => undefined,
+          (error: unknown) => error,
+        );
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+    expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      root?.unmount();
+      root = null;
+    });
+    await expect(reloadOutcome).resolves.toMatchObject({ name: 'AbortError' });
+
+    replacement.resolve(target);
+    await act(async () => {
+      await flushPromises();
+    });
+
+    const detachedClientIds = detachFetch.mock.calls.map(([, init]) =>
+      new Headers(init?.headers).get('X-Qwen-Client-Id'),
+    );
+    expect(detachedClientIds).toEqual(
+      expect.arrayContaining(['client-a', 'client-b']),
+    );
   });
 
   it('clears transcript immediately for default session switches', async () => {
@@ -7926,7 +8318,11 @@ describe('DaemonSessionProvider', () => {
     });
   });
 
-  it('ignores stale metadata after switching to another session', async () => {
+  it('ignores stale metadata from a replaced same-id attachment', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
     const providersA = createDeferred<unknown>();
     const commandsA =
       createDeferred<Awaited<ReturnType<MockSession['supportedCommands']>>>();
@@ -7936,13 +8332,15 @@ describe('DaemonSessionProvider', () => {
     sdkMocks.sessions.push(
       createMockSession({
         sessionId: 'session-a',
+        clientId: 'client-a',
         replaySnapshot: createTextReplaySnapshot('session a transcript'),
         supportedCommands: vi.fn(() => commandsA.promise),
         context: vi.fn(() => contextA.promise),
       }),
       createMockSession({
-        sessionId: 'session-b',
-        replaySnapshot: createTextReplaySnapshot('session b transcript'),
+        sessionId: 'session-a',
+        clientId: 'client-b',
+        replaySnapshot: createTextReplaySnapshot('replacement transcript'),
       }),
     );
     let blocks: readonly DaemonTranscriptBlock[] = [];
@@ -7957,6 +8355,7 @@ describe('DaemonSessionProvider', () => {
     await renderWithProvider(<Harness />, {
       autoConnect: true,
       sessionId: 'session-a',
+      clientId: 'client-a',
     });
     await act(async () => {
       await flushPromises();
@@ -7971,7 +8370,8 @@ describe('DaemonSessionProvider', () => {
         <DaemonSessionProvider
           baseUrl="http://127.0.0.1:4170"
           autoConnect={true}
-          sessionId="session-b"
+          sessionId="session-a"
+          clientId="client-b"
         >
           <Harness />
         </DaemonSessionProvider>,
@@ -7981,11 +8381,12 @@ describe('DaemonSessionProvider', () => {
       await flushPromises();
     });
     expect(connection).toMatchObject({
-      sessionId: 'session-b',
+      sessionId: 'session-a',
+      clientId: 'client-b',
       loadingTranscript: undefined,
     });
     expect(blocks).toMatchObject([
-      { kind: 'assistant', text: 'session b transcript' },
+      { kind: 'assistant', text: 'replacement transcript' },
     ]);
 
     providersA.resolve({
@@ -8010,10 +8411,13 @@ describe('DaemonSessionProvider', () => {
       await flushPromises();
     });
 
-    expect(connection).toMatchObject({ sessionId: 'session-b' });
+    expect(connection).toMatchObject({
+      sessionId: 'session-a',
+      clientId: 'client-b',
+    });
     expect(connection?.currentModel).not.toBe('stale-model');
     expect(blocks).toMatchObject([
-      { kind: 'assistant', text: 'session b transcript' },
+      { kind: 'assistant', text: 'replacement transcript' },
     ]);
   });
 

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -444,7 +444,7 @@ const TERMINAL_SESSION_HTTP_STATUSES = new Set([
 ]);
 
 interface HeartbeatFailureState {
-  sessionId?: string;
+  session?: DaemonSessionClient;
   consecutiveFailures: number;
   lastHttpError?: { status: number; message: string };
 }
@@ -578,9 +578,9 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
     consecutiveFailures: 0,
   });
   const manualSessionClearRef = useRef(false);
-  const skipNextCleanupDetachSessionIdRef = useRef<string | undefined>(
-    undefined,
-  );
+  const skipNextCleanupDetachSessionRef = useRef<
+    DaemonSessionClient | undefined
+  >(undefined);
   const settledRestoredActivePromptSessionsRef = useRef<
     WeakSet<DaemonSessionClient>
   >(new WeakSet());
@@ -687,7 +687,8 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
       restoreMode === 'load' &&
       restoreSessionId !== undefined &&
       restoreSessionId === sessionRef.current?.sessionId &&
-      restoreSessionId === skipNextCleanupDetachSessionIdRef.current;
+      sessionRef.current === skipNextCleanupDetachSessionRef.current;
+    let runnerSession = sessionRef.current;
 
     // ── Batched transcript dispatch ────────────────────────────────
     // The live SSE loop dispatches transcript events through this batcher
@@ -706,9 +707,17 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
     // streaming stays at ~one dispatch per network chunk.
     let pendingTranscriptEvents: DaemonUiEvent[] = [];
     let transcriptFlushTimer: ReturnType<typeof setTimeout> | undefined;
-    const runTranscriptFlush = () => {
+    const runTranscriptFlush = (force = false) => {
       transcriptFlushTimer = undefined;
       if (pendingTranscriptEvents.length === 0) return;
+      if (
+        !force &&
+        runnerSession !== undefined &&
+        sessionRef.current !== runnerSession
+      ) {
+        pendingTranscriptEvents = [];
+        return;
+      }
       const batch = pendingTranscriptEvents;
       pendingTranscriptEvents = [];
       // Swallow a reducer throw (log it) so it cannot escape as an uncaught
@@ -740,7 +749,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
     // buffered content stays correctly ordered ahead of it.
     const flushTranscriptSync = () => {
       cancelTranscriptFlush();
-      runTranscriptFlush();
+      runTranscriptFlush(true);
     };
     const dispatchTranscriptNow = (events: DaemonUiEvent | DaemonUiEvent[]) => {
       flushTranscriptSync();
@@ -1168,11 +1177,8 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                   new DOMException('Session load cancelled', 'AbortError'),
                 );
               }
-              if (
-                skipNextCleanupDetachSessionIdRef.current ===
-                nextSession.sessionId
-              ) {
-                skipNextCleanupDetachSessionIdRef.current = undefined;
+              if (skipNextCleanupDetachSessionRef.current === previousSession) {
+                skipNextCleanupDetachSessionRef.current = undefined;
               }
               loadingRequestedSession = false;
               if (previousSession?.sessionId === nextSession.sessionId) {
@@ -1225,10 +1231,9 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                   );
                 }
                 if (
-                  skipNextCleanupDetachSessionIdRef.current ===
-                  nextSession.sessionId
+                  skipNextCleanupDetachSessionRef.current === previousSession
                 ) {
-                  skipNextCleanupDetachSessionIdRef.current = undefined;
+                  skipNextCleanupDetachSessionRef.current = undefined;
                 }
                 if (previousSession?.sessionId === nextSession.sessionId) {
                   session = previousSession;
@@ -1297,6 +1302,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           }
 
           const activeSession = session;
+          runnerSession = activeSession;
           // Prompt activity is session state returned by /load. Surface it
           // immediately so a refreshed page shows the running state without
           // waiting for auxiliary data such as providers, commands, or context.
@@ -1692,11 +1698,8 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
             if (pendingLoadToResolve.timeout !== undefined) {
               clearTimeout(pendingLoadToResolve.timeout);
             }
-            if (
-              skipNextCleanupDetachSessionIdRef.current ===
-              activeSession.sessionId
-            ) {
-              skipNextCleanupDetachSessionIdRef.current = undefined;
+            if (skipNextCleanupDetachSessionRef.current === activeSession) {
+              skipNextCleanupDetachSessionRef.current = undefined;
             }
             pendingLoadToResolve.resolve();
           }
@@ -1726,6 +1729,13 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                 : activeSession.context(),
               gitPromise,
             ]);
+          if (
+            disposed ||
+            abort.signal.aborted ||
+            sessionRef.current !== activeSession
+          ) {
+            return;
+          }
           const providers =
             providerResult?.status === 'fulfilled'
               ? providerResult.value
@@ -1778,7 +1788,12 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
             getCurrentMode(context) ?? providerModelStatus.currentMode;
 
           setConnection((current) => {
-            if (current.sessionId !== activeSession.sessionId) return current;
+            if (
+              sessionRef.current !== activeSession ||
+              current.sessionId !== activeSession.sessionId
+            ) {
+              return current;
+            }
             return {
               ...current,
               status: 'connected',
@@ -1914,7 +1929,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
             maxQueued,
             ...(sseConnectReason ? { sseConnectReason } : {}),
           })) {
-            if (sessionRef.current?.sessionId !== activeSession.sessionId) {
+            if (sessionRef.current !== activeSession) {
               break;
             }
             if (!sawEvent) {
@@ -1943,9 +1958,11 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                 // Keep the sidechannel for queue dedupe, but still normalize the
                 // event below so chat UIs can render the inserted-message status.
                 publishSidechannelMidTurnInjected(midTurnInjected);
+                if (sessionRef.current !== activeSession) break;
               }
               if (isPendingPromptEvent(event)) {
                 publishPendingPromptEvent(event);
+                if (sessionRef.current !== activeSession) break;
                 if (event.type === 'pending_prompt_started') {
                   clearPassiveAssistantDoneTimer(passiveAssistantDoneTimerRef);
                   setPromptStatus('waiting');
@@ -2219,6 +2236,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                 break;
               }
             } catch (error) {
+              if (sessionRef.current !== activeSession) break;
               const message =
                 error instanceof Error ? error.message : String(error);
               addNotice({
@@ -2235,6 +2253,15 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                 error,
               );
             }
+          }
+          if (
+            sessionRef.current !== activeSession &&
+            !resyncRequested &&
+            !userDeletedSession
+          ) {
+            clearPendingTranscriptEvents();
+            clearEventStream();
+            return;
           }
           // The stream ended or broke: apply any buffered transcript events now
           // so post-loop handling (and consumers reading the snapshot) see a
@@ -2281,7 +2308,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
             nextSseConnectReason = 'stream_end';
             // Keep the session handle after a normal SSE close so the next
             // subscription can resume from DaemonSessionClient.lastEventId.
-            if (sessionRef.current?.sessionId === activeSession.sessionId) {
+            if (sessionRef.current === activeSession) {
               console.debug('[DaemonSessionProvider] SSE stream ended');
               if (!hasSessionActivePrompt()) {
                 // A transport close is only a safe "done" signal for passive
@@ -2310,6 +2337,10 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
         } catch (error) {
           const restartRequested = eventStream?.restartRequested === true;
           clearEventStream();
+          if (session && sessionRef.current !== session) {
+            clearPendingTranscriptEvents();
+            return;
+          }
           if (restartRequested && !disposed && !abort.signal.aborted) {
             flushTranscriptSync();
             nextSseConnectReason = 'prompt_restart';
@@ -2351,10 +2382,10 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
               pendingLoad.sessionId === reconnectSessionId)
           ) {
             if (
-              skipNextCleanupDetachSessionIdRef.current ===
+              skipNextCleanupDetachSessionRef.current?.sessionId ===
               pendingLoad.sessionId
             ) {
-              skipNextCleanupDetachSessionIdRef.current = undefined;
+              skipNextCleanupDetachSessionRef.current = undefined;
             }
             pendingSessionLoadRef.current = undefined;
             if (pendingLoad.timeout !== undefined) {
@@ -2499,26 +2530,34 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
 
     void run();
     return () => {
-      const session = sessionRef.current;
+      const session = runnerSession;
       disposed = true;
       abort.abort();
-      // Apply buffered transcript events before tearing down (do NOT drop them).
-      // The SSE client advances lastSeenEventId as each event is *yielded* —
-      // before our batched dispatch runs — so dropping here would make a
-      // same-session incremental resume (the keepSessionForNextEffect path)
-      // skip them permanently. Flushing is free and safe: the store notifies
-      // via queueMicrotask, so there is no synchronous setState; on unmount it
-      // is an orphaned dispatch and on a session switch the next run resets the
-      // store anyway.
-      flushTranscriptSync();
-      hasCurrentSessionActivePromptRef.current = () => false;
-      setPromptStatus('idle');
-      clearPassiveAssistantDoneTimer(passiveAssistantDoneTimerRef);
+      const ownsCurrentSession =
+        session !== undefined && sessionRef.current === session;
+      const ownsEmptyState =
+        session === undefined && sessionRef.current === undefined;
       const keepSessionForNextEffect =
-        session?.sessionId === skipNextCleanupDetachSessionIdRef.current;
+        ownsCurrentSession &&
+        session === skipNextCleanupDetachSessionRef.current;
       const isUnmounting = !mountedRef.current;
+      if (ownsCurrentSession || ownsEmptyState) {
+        // A same-attachment effect restart must flush events already yielded by
+        // the SSE client, because its resume cursor has advanced past them.
+        flushTranscriptSync();
+      } else {
+        // A replacement attachment owns the store now. Never let the old
+        // runner's pending macrotask append its buffered events to that owner.
+        clearPendingTranscriptEvents();
+      }
+      if (ownsCurrentSession && (!keepSessionForNextEffect || isUnmounting)) {
+        hasCurrentSessionActivePromptRef.current = () => false;
+        setPromptStatus('idle');
+        clearPassiveAssistantDoneTimer(passiveAssistantDoneTimerRef);
+      }
       if (
         pendingSessionLoadRef.current &&
+        (ownsCurrentSession || ownsEmptyState) &&
         (!keepSessionForNextEffect || isUnmounting)
       ) {
         if (pendingSessionLoadRef.current.timeout !== undefined) {
@@ -2529,7 +2568,11 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
         );
         pendingSessionLoadRef.current = undefined;
       }
-      if ((!keepSessionForNextEffect || isUnmounting) && session?.clientId) {
+      if (
+        ownsCurrentSession &&
+        (!keepSessionForNextEffect || isUnmounting) &&
+        session.clientId
+      ) {
         void detachDaemonClient({
           baseUrl: resolvedBaseUrl!,
           token: resolvedToken,
@@ -2539,7 +2582,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           console.warn('[DaemonSessionProvider] detach failed:', err),
         );
       }
-      if (!keepSessionForNextEffect || isUnmounting) {
+      if (ownsCurrentSession && (!keepSessionForNextEffect || isUnmounting)) {
         sessionRef.current = undefined;
       }
     };
@@ -2577,21 +2620,27 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
     ) {
       return undefined;
     }
-    if (heartbeatFailureStateRef.current.sessionId !== connection.sessionId) {
-      heartbeatFailureStateRef.current = {
-        sessionId: connection.sessionId,
-        consecutiveFailures: 0,
-      };
-    }
-    const heartbeatFailureState = heartbeatFailureStateRef.current;
     let disposed = false;
     const timer = setInterval(() => {
       const session = sessionRef.current;
       if (!session) return;
+      if (heartbeatFailureStateRef.current.session !== session) {
+        heartbeatFailureStateRef.current = {
+          session,
+          consecutiveFailures: 0,
+        };
+      }
+      const heartbeatFailureState = heartbeatFailureStateRef.current;
       session
         .heartbeat()
         .then(() => {
-          if (disposed) return;
+          if (
+            disposed ||
+            sessionRef.current !== session ||
+            heartbeatFailureStateRef.current !== heartbeatFailureState
+          ) {
+            return;
+          }
           if (
             heartbeatFailureState.consecutiveFailures >=
             heartbeatFailureThreshold
@@ -2611,7 +2660,13 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           heartbeatFailureState.lastHttpError = undefined;
         })
         .catch((error: unknown) => {
-          if (disposed) return;
+          if (
+            disposed ||
+            sessionRef.current !== session ||
+            heartbeatFailureStateRef.current !== heartbeatFailureState
+          ) {
+            return;
+          }
           heartbeatFailureState.consecutiveFailures += 1;
           const message =
             error instanceof Error ? error.message : 'Session heartbeat failed';
@@ -2660,7 +2715,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
             activePromptsRef.current.delete(deadSessionId);
             clearPassiveAssistantDoneTimer(passiveAssistantDoneTimerRef);
             setPromptStatus('idle');
-            if (sessionRef.current?.sessionId === deadSessionId) {
+            if (sessionRef.current === session) {
               if (missingSession) {
                 manualSessionClearRef.current = true;
               }
@@ -2712,7 +2767,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
         pendingSessionLoadIdRef,
         heartbeatSupportedRef,
         manualSessionClearRef,
-        skipNextCleanupDetachSessionIdRef,
+        skipNextCleanupDetachSessionRef,
         passiveAssistantDoneTimerRef,
         hasSessionActivePrompt: () =>
           hasCurrentSessionActivePromptRef.current(),

--- a/packages/webui/src/daemon/session/actions.test.ts
+++ b/packages/webui/src/daemon/session/actions.test.ts
@@ -852,6 +852,147 @@ describe('createDaemonSessionActions', () => {
     await expect(prompt).resolves.toEqual({ stopReason: 'cancelled' });
     expect(restartEventStream).not.toHaveBeenCalled();
   });
+
+  it('does not apply a late model update to a replacement attachment', async () => {
+    const source = createMockSession('session-a', 'client-a');
+    const target = createMockSession('session-a', 'client-b');
+    const result = { applied: true };
+    const deferred = createDeferred<typeof result>();
+    source.setModel.mockReturnValueOnce(deferred.promise);
+    const { actions, getConnection, replaceConnection, sessionRef } =
+      createActionsHarness({
+        connection: {
+          status: 'connected',
+          sessionId: source.sessionId,
+          clientId: source.clientId,
+          currentModel: 'source-model',
+        },
+        session: source,
+      });
+
+    const pending = actions.setModel('late-source-model');
+    sessionRef.current = target as unknown as DaemonSessionClient;
+    replaceConnection({
+      status: 'connected',
+      sessionId: target.sessionId,
+      clientId: target.clientId,
+      currentModel: 'target-model',
+    });
+    deferred.resolve(result);
+
+    await expect(pending).resolves.toBe(result);
+    expect(getConnection()).toMatchObject({
+      clientId: 'client-b',
+      currentModel: 'target-model',
+    });
+  });
+
+  it('does not apply a late approval mode to a replacement attachment', async () => {
+    const source = createMockSession('session-a', 'client-a');
+    const target = createMockSession('session-a', 'client-b');
+    const result = {
+      sessionId: 'session-a',
+      mode: 'yolo',
+      previous: 'default',
+      persisted: false,
+    };
+    const deferred = createDeferred<typeof result>();
+    source.client.setSessionApprovalMode.mockReturnValueOnce(deferred.promise);
+    const { actions, getConnection, replaceConnection, sessionRef } =
+      createActionsHarness({
+        connection: {
+          status: 'connected',
+          sessionId: source.sessionId,
+          clientId: source.clientId,
+          currentMode: 'default',
+        },
+        session: source,
+      });
+
+    const pending = actions.setApprovalMode('yolo');
+    sessionRef.current = target as unknown as DaemonSessionClient;
+    replaceConnection({
+      status: 'connected',
+      sessionId: target.sessionId,
+      clientId: target.clientId,
+      currentMode: 'plan',
+    });
+    deferred.resolve(result);
+
+    await expect(pending).resolves.toBe(result);
+    expect(getConnection()).toMatchObject({
+      clientId: 'client-b',
+      currentMode: 'plan',
+    });
+  });
+
+  it('does not apply late commands to a replacement attachment', async () => {
+    const source = createMockSession('session-a', 'client-a');
+    const target = createMockSession('session-a', 'client-b');
+    const status = supportedCommandsStatus('session-a', 'source-command');
+    const deferred = createDeferred<typeof status>();
+    source.supportedCommands.mockReturnValueOnce(deferred.promise);
+    const targetStatus = supportedCommandsStatus('session-a', 'target-command');
+    const { actions, getConnection, replaceConnection, sessionRef } =
+      createActionsHarness({ session: source });
+
+    const pending = actions.refreshCommands();
+    sessionRef.current = target as unknown as DaemonSessionClient;
+    replaceConnection({
+      status: 'connected',
+      sessionId: target.sessionId,
+      clientId: target.clientId,
+      commands: [commandInfo('target-command')],
+      skills: ['target-skill'],
+      supportedCommands: targetStatus,
+    });
+    deferred.resolve(status);
+
+    await expect(pending).resolves.toBeUndefined();
+    expect(getConnection()).toMatchObject({
+      clientId: 'client-b',
+      commands: [commandInfo('target-command')],
+      skills: ['target-skill'],
+      supportedCommands: targetStatus,
+    });
+  });
+
+  it('does not apply late context to a replacement attachment', async () => {
+    const source = createMockSession('session-a', 'client-a');
+    const target = createMockSession('session-a', 'client-b');
+    const context = {
+      ...contextStatus('session-a'),
+      state: {
+        models: { currentModelId: 'source-model' },
+        modes: { currentModeId: 'source-mode' },
+      },
+    };
+    const deferred = createDeferred<typeof context>();
+    source.context.mockReturnValueOnce(deferred.promise);
+    const targetContext = contextStatus('session-a');
+    const { actions, getConnection, replaceConnection, sessionRef } =
+      createActionsHarness({ session: source });
+
+    const pending = actions.getContext();
+    sessionRef.current = target as unknown as DaemonSessionClient;
+    replaceConnection({
+      status: 'connected',
+      sessionId: target.sessionId,
+      clientId: target.clientId,
+      context: targetContext,
+      currentModel: 'target-model',
+      currentMode: 'target-mode',
+    });
+    deferred.resolve(context);
+
+    await expect(pending).resolves.toBe(context);
+    expect(getConnection()).toMatchObject({
+      clientId: 'client-b',
+      context: targetContext,
+      currentModel: 'target-model',
+      currentMode: 'target-mode',
+    });
+  });
 });
 
 function createActionsHarness(
@@ -872,6 +1013,9 @@ function createActionsHarness(
   let connection: DaemonConnectionState = opts.connection ?? {
     status: 'connected',
     workspaceCwd: '/workspace',
+  };
+  const replaceConnection = (next: DaemonConnectionState) => {
+    connection = next;
   };
   const sessionRef = {
     current: opts.session as unknown as DaemonSessionClient | undefined,
@@ -898,7 +1042,7 @@ function createActionsHarness(
     pendingSessionLoadIdRef: { current: 0 },
     heartbeatSupportedRef: { current: false },
     manualSessionClearRef: opts.manualSessionClearRef ?? { current: false },
-    skipNextCleanupDetachSessionIdRef: { current: undefined },
+    skipNextCleanupDetachSessionRef: { current: undefined },
     passiveAssistantDoneTimerRef: { current: undefined },
     getCreateSessionRequest: () => ({ workspaceCwd: '/workspace' }),
     createDetachedSession: (opts.createDetachedSession ??
@@ -930,25 +1074,37 @@ function createActionsHarness(
     activePromptsRef,
     getConnection: () => connection,
     pendingSessionLoadRef,
+    replaceConnection,
     sessionRef,
     store,
   };
 }
 
-function createMockSession(sessionId: string) {
+function createMockSession(
+  sessionId: string,
+  clientId = `client-${sessionId}`,
+) {
   return {
     sessionId,
     workspaceCwd: '/workspace',
-    clientId: `client-${sessionId}`,
+    clientId,
     client: {
       createOrAttachSession: vi.fn(),
-      setSessionApprovalMode: vi.fn(),
+      setSessionApprovalMode: vi.fn(async () => ({
+        sessionId,
+        mode: 'default',
+        previous: 'default',
+        persisted: false,
+      })),
       listWorkspaceSessions: vi.fn(),
       closeSession: vi.fn(),
     },
     cancel: vi.fn(async () => undefined),
+    context: vi.fn(async () => contextStatus(sessionId)),
     detach: vi.fn(async () => undefined),
+    setModel: vi.fn(async () => ({})),
     submitPrompt: vi.fn(async () => ({ promptId: 'prompt-1' })),
+    supportedCommands: vi.fn(async () => supportedCommandsStatus(sessionId)),
     tasks: vi.fn(async () => ({ v: 1 as const, sessionId, tasks: [] })),
   };
 }

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -92,7 +92,7 @@ export interface CreateDaemonSessionActionsArgs {
   pendingSessionLoadIdRef: RefBox<number>;
   heartbeatSupportedRef: RefBox<boolean>;
   manualSessionClearRef: RefBox<boolean>;
-  skipNextCleanupDetachSessionIdRef: RefBox<string | undefined>;
+  skipNextCleanupDetachSessionRef: RefBox<DaemonSessionClient | undefined>;
   passiveAssistantDoneTimerRef: TimerRef;
   getCreateSessionRequest: () => CreateSessionRequest;
   createDetachedSession: (
@@ -163,7 +163,7 @@ export function createDaemonSessionActions({
   pendingSessionLoadIdRef,
   heartbeatSupportedRef,
   manualSessionClearRef,
-  skipNextCleanupDetachSessionIdRef,
+  skipNextCleanupDetachSessionRef,
   passiveAssistantDoneTimerRef,
   getCreateSessionRequest,
   createDetachedSession,
@@ -196,10 +196,10 @@ export function createDaemonSessionActions({
     clearPassiveAssistantDoneTimer(passiveAssistantDoneTimerRef);
     if (pendingSessionLoadRef.current) {
       if (
-        skipNextCleanupDetachSessionIdRef.current ===
+        skipNextCleanupDetachSessionRef.current?.sessionId ===
         pendingSessionLoadRef.current.sessionId
       ) {
-        skipNextCleanupDetachSessionIdRef.current = undefined;
+        skipNextCleanupDetachSessionRef.current = undefined;
       }
       clearPendingLoadTimeout(pendingSessionLoadRef.current);
       pendingSessionLoadRef.current.reject(
@@ -315,8 +315,14 @@ export function createDaemonSessionActions({
           );
         });
       if (reloadingCurrentSession) {
-        skipNextCleanupDetachSessionIdRef.current = sessionId;
-        void loadPromise.then(detachCurrentSession, () => undefined);
+        skipNextCleanupDetachSessionRef.current = currentSession;
+        void loadPromise
+          .then(detachCurrentSession, () => undefined)
+          .finally(() => {
+            if (skipNextCleanupDetachSessionRef.current === currentSession) {
+              skipNextCleanupDetachSessionRef.current = undefined;
+            }
+          });
       } else {
         void detachCurrentSession();
       }
@@ -575,7 +581,9 @@ export function createDaemonSessionActions({
           session.setModel(modelId),
           'Set model timed out',
         );
-        setConnection((current) => ({ ...current, currentModel: modelId }));
+        if (sessionRef.current === session) {
+          setConnection((current) => ({ ...current, currentModel: modelId }));
+        }
         return result;
       } catch (error) {
         throw dispatchActionError(
@@ -602,10 +610,12 @@ export function createDaemonSessionActions({
           }),
           'Set approval mode timed out',
         );
-        setConnection((current) => ({
-          ...current,
-          currentMode: result.mode || mode,
-        }));
+        if (sessionRef.current === session) {
+          setConnection((current) => ({
+            ...current,
+            currentMode: result.mode || mode,
+          }));
+        }
         return result;
       } catch (error) {
         throw dispatchActionError(
@@ -786,7 +796,7 @@ export function createDaemonSessionActions({
         }
         persistStableClientId(nextSession.clientId, nextSession.sessionId);
         sessionRef.current = nextSession;
-        skipNextCleanupDetachSessionIdRef.current = nextSession.sessionId;
+        skipNextCleanupDetachSessionRef.current = nextSession;
         setConnection((current) => ({
           ...current,
           status: 'connected',
@@ -904,13 +914,15 @@ export function createDaemonSessionActions({
           session.supportedCommands(),
           'Refresh commands timed out',
         );
-        const { commands, skills } = mapSupportedCommands(status);
-        setConnection((current) => ({
-          ...current,
-          commands,
-          skills,
-          supportedCommands: status,
-        }));
+        if (sessionRef.current === session) {
+          const { commands, skills } = mapSupportedCommands(status);
+          setConnection((current) => ({
+            ...current,
+            commands,
+            skills,
+            supportedCommands: status,
+          }));
+        }
       } catch (error) {
         throw dispatchActionError(
           addNotice,
@@ -933,14 +945,16 @@ export function createDaemonSessionActions({
           session.context(),
           'Load context timed out',
         );
-        setConnection((current) => ({
-          ...current,
-          context,
-          currentMode:
-            getModeFromSessionContext(context) ?? current.currentMode,
-          currentModel:
-            getModelFromSessionContext(context) ?? current.currentModel,
-        }));
+        if (sessionRef.current === session) {
+          setConnection((current) => ({
+            ...current,
+            context,
+            currentMode:
+              getModeFromSessionContext(context) ?? current.currentMode,
+            currentModel:
+              getModelFromSessionContext(context) ?? current.currentModel,
+          }));
+        }
         return context;
       } catch (error) {
         throw dispatchActionError(


### PR DESCRIPTION
## What this PR does

This PR fences session-owned asynchronous work by the exact attachment object instead of only by `sessionId`. Metadata refreshes, streamed events, terminal stream frames, heartbeat failures, transcript batches, and runner cleanup from a replaced attachment can no longer mutate or detach a newer attachment that happens to use the same session ID. Same-session reload handoff now preserves and retires the intended attachment exactly once, including when the provider unmounts before the replacement load settles.

The existing detach-first session switching behavior remains unchanged. This is the independently releasable PR3a hardening slice extracted from #8824; transactional visible-state switching, WebShell coordination, resync/repair staging, and branch adoption remain follow-up work.

## Why it's needed

The provider previously treated a session ID as sufficient ownership identity. Reattaching or reloading the same persisted session can create a new client attachment with the same session ID, so late work from the old attachment could overwrite the new model/context/commands, append stale transcript events, turn a late `session_closed` or heartbeat 410 into a false disconnect, or clean up the replacement attachment. These races were reproduced deterministically on the pre-fix commit and could corrupt an otherwise successful same-session restore.

## Reviewer Test Plan

### How to verify

Run `cd packages/webui && npx vitest run src/daemon/session/actions.test.ts src/daemon/session/DaemonSessionProvider.test.tsx`. Confirm that all 250 tests pass, including same-ID replacement cases for metadata, SSE, `session_closed`, heartbeat, reload cleanup, and unmount with a late replacement result.

Run `cd packages/webui && npm run typecheck && npm run lint && npm run build`. Confirm that type checking, linting, declaration generation, and the production bundle complete successfully.

The focused regressions use two attachment objects with the same `sessionId` and different `clientId` values. Before this fix they deterministically show stale metadata, stale SSE output, a false disconnect from `session_closed`, and a false missing-session state from heartbeat 410; after this fix the replacement remains connected and unchanged.

### Evidence (Before & After)

N/A — this is non-visual concurrency and ownership hardening covered by deterministic unit tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS, Node.js v22.22.3, npm 10.9.8. Verified with the WebUI unit suite, typecheck, ESLint, and Vite production build.

## Risk & Scope

- Main risk or tradeoff: Cleanup and late-result guards now depend on attachment object identity. The regression suite covers same-ID replacement, normal same-session reload, interrupted reload, terminal events, heartbeat failures, and unmount settlement.
- Not validated / out of scope: This PR does not preserve the old session while a target restore is pending, change restore performance, introduce a global attachment scheduler, or change branch, resync/repair, SDK self-heal, daemon, or WebShell behavior. Windows and Linux were not tested locally; CI provides cross-platform coverage.
- Breaking changes / migration notes: None. There are no public API, SDK, daemon, or wire-protocol changes.

## Linked Issues

Refs #8678. Extracted from #8824 as the independently releasable PR3a slice.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 使用精确的 attachment 对象而不再只依赖 `sessionId` 来隔离会话所属的异步工作。被替换 attachment 的 metadata 刷新、流式事件、终止帧、heartbeat 失败、transcript 批次和 runner cleanup，不能再修改或 detach 使用相同 session ID 的新 attachment。same-session reload handoff 现在会准确保留并只回收一次目标 attachment，包括 Provider 在 replacement load 结束前卸载的情况。

现有的 detach-first 会话切换行为保持不变。这是从 #8824 拆出的、可独立发布的 PR3a 加固切片；可见状态事务切换、WebShell 协调、resync/repair staging 和 branch adoption 仍作为后续工作。

## 为什么需要

Provider 之前把 session ID 当作充分的 ownership identity。重新 attach 或 reload 同一个持久化会话时，可能生成具有相同 session ID 的新 client attachment，因此旧 attachment 的迟到工作可能覆盖新会话的 model/context/commands、追加过期 transcript 事件、将迟到的 `session_closed` 或 heartbeat 410 误判为断连，或清理 replacement attachment。这些竞态已经在修复前的提交上被确定性复现，并可能破坏原本成功的 same-session restore。

## Reviewer 测试计划

### 如何验证

运行 `cd packages/webui && npx vitest run src/daemon/session/actions.test.ts src/daemon/session/DaemonSessionProvider.test.tsx`。确认 250 个测试全部通过，其中包括 metadata、SSE、`session_closed`、heartbeat、reload cleanup，以及卸载后 replacement 迟到返回等 same-ID replacement 场景。

运行 `cd packages/webui && npm run typecheck && npm run lint && npm run build`。确认类型检查、lint、声明生成和生产 bundle 均成功完成。

聚焦回归测试使用两个具有相同 `sessionId`、不同 `clientId` 的 attachment 对象。修复前可确定性观察到旧 metadata、旧 SSE 输出、`session_closed` 导致的误断连，以及 heartbeat 410 导致的错误 missing-session 状态；修复后 replacement 会保持 connected 且内容不变。

### 证据（Before & After）

N/A —— 这是由确定性单元测试覆盖的非可视化并发与 ownership 加固。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS、Node.js v22.22.3、npm 10.9.8。已通过 WebUI 单测、typecheck、ESLint 和 Vite 生产构建验证。

## 风险与范围

- 主要风险或权衡：cleanup 和迟到结果 guard 现在依赖 attachment 对象身份。回归测试覆盖 same-ID replacement、正常 same-session reload、中断 reload、终止事件、heartbeat 失败和卸载 settlement。
- 未验证 / 范围外：本 PR 不会在目标 restore pending 时保留旧会话，不改变 restore 性能，不引入全局 attachment scheduler，也不改变 branch、resync/repair、SDK self-heal、daemon 或 WebShell 行为。Windows 和 Linux 未在本地测试；跨平台覆盖依赖 CI。
- Breaking changes / 迁移说明：无。没有 public API、SDK、daemon 或 wire protocol 变更。

## 关联 Issue

Refs #8678。本 PR 是从 #8824 拆出的、可独立发布的 PR3a 切片。

</details>
