### PR TITLE
docs(readme): add Korean to the documentation language bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@
 <a href="https://qwenlm.github.io/qwen-code-docs/fr/users/overview">français</a> |
 <a href="https://qwenlm.github.io/qwen-code-docs/ja/users/overview">日本語</a> |
 <a href="https://qwenlm.github.io/qwen-code-docs/ru/users/overview">Русский</a> |
-<a href="https://qwenlm.github.io/qwen-code-docs/pt-BR/users/overview">Português (Brasil)</a>
+<a href="https://qwenlm.github.io/qwen-code-docs/pt-BR/users/overview">Português (Brasil)</a> |
+<a href="https://qwenlm.github.io/qwen-code-docs/ko/users/overview">한국어</a>
 
 </div>
 


### PR DESCRIPTION
## What this PR does

Adds 한국어 to the language bar at the top of the README, pointing at the Korean documentation overview. The entry uses the native language name like every other entry in the bar, and is appended last so the existing order is untouched. This is a one-line documentation change with no code impact.

## Why it's needed

Korean was the only documentation locale the site ships that the README could not link to. The Korean docs are now live — `QwenLM/qwen-code-docs#181` registered the locale and `QwenLM/qwen-code-docs#212` fixed the two things that kept it from rendering (the `/[lang]` route gate was missing `ko`, and a malformed translated file was failing the docs build outright). Before those landed, `/ko/users/overview` returned 404, so linking it would have been broken. It resolves now, so the bar can finally be complete.

## Reviewer Test Plan

### How to verify

Confirm the link target resolves the same way the existing entries do. Every link in the bar is written without a trailing slash and relies on the docs site redirecting, so `ko` should behave identically to `zh`:

```
$ for l in zh ko; do echo -n "$l: "; curl -s -o /dev/null -w "%{http_code}\n" "https://qwenlm.github.io/qwen-code-docs/$l/users/overview"; done
zh: 301
ko: 301

$ curl -s -o /dev/null -w "%{http_code}\n" -L "https://qwenlm.github.io/qwen-code-docs/ko/users/overview/"
200
```

The served page is genuinely Korean rather than an English fallback:

```
$ curl -s -L "https://qwenlm.github.io/qwen-code-docs/ko/" | grep -o '<html[^>]*lang="[^"]*"'
<html lang="ko"
```

Formatting was checked with the repo's pinned Prettier and config, since `README.md` is not in `.prettierignore`:

```
$ npx prettier@3.5.3 --check README.md
Checking formatting...
All matched files use Prettier code style!
```

### Evidence (Before & After)

N/A for screenshots — this is a docs-only change. The rendered bar goes from:

> 中文 | Deutsch | français | 日本語 | Русский | Português (Brasil)

to:

> 中文 | Deutsch | français | 日本語 | Русский | Português (Brasil) | 한국어

The full diff is one added link, plus the `|` separator on the preceding line.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

Nothing here is OS-specific: the change is Markdown text, and verification is HTTP requests plus a Prettier check.

### Environment (optional)

N/A — no local runtime needed.

## Risk & Scope

- Main risk or tradeoff: essentially none. If the Korean docs were ever taken down the link would break, but that risk is identical for the six locales already listed.
- Not validated / out of scope: the translated Korean pages themselves are machine-generated by the docs repo's `daily-translate` workflow, and this PR does not review their wording. I am a native Korean speaker and am happy to follow up with polish in the docs repo.
- Breaking changes / migration notes: none.

## Linked Issues

None. Related context in the docs repo: `QwenLM/qwen-code-docs#181` (locale registration) and `QwenLM/qwen-code-docs#212` (the fixes that made `/ko/` actually render).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在 README 顶部的语言栏中添加 한국어，指向韩语文档的 overview 页面。该条目与语言栏中其他条目一样使用该语言的本地名称，并追加在最后，因此不改动现有顺序。这是一处一行的文档改动，不影响任何代码。

## 为什么需要

韩语是文档站已发布、但 README 却无法链接的唯一语言。现在韩语文档已经上线——`QwenLM/qwen-code-docs#181` 注册了该 locale，`QwenLM/qwen-code-docs#212` 修复了导致其无法渲染的两个问题（`/[lang]` 路由的白名单缺少 `ko`，以及一个格式损坏的翻译文件直接导致文档构建失败）。在这些合并之前，`/ko/users/overview` 返回 404，此时加链接只会是坏链。现在它可以正常访问了，语言栏终于可以补齐。

## 复核测试方案

### 如何验证

确认链接目标的解析方式与现有条目一致。语言栏中所有链接都不带结尾斜杠，依赖文档站的重定向，因此 `ko` 的行为应与 `zh` 完全相同：

```
$ for l in zh ko; do echo -n "$l: "; curl -s -o /dev/null -w "%{http_code}\n" "https://qwenlm.github.io/qwen-code-docs/$l/users/overview"; done
zh: 301
ko: 301

$ curl -s -o /dev/null -w "%{http_code}\n" -L "https://qwenlm.github.io/qwen-code-docs/ko/users/overview/"
200
```

实际返回的页面确实是韩语，而不是回退到英语：

```
$ curl -s -L "https://qwenlm.github.io/qwen-code-docs/ko/" | grep -o '<html[^>]*lang="[^"]*"'
<html lang="ko"
```

由于 `README.md` 不在 `.prettierignore` 中，已使用仓库锁定的 Prettier 版本和配置检查格式：

```
$ npx prettier@3.5.3 --check README.md
Checking formatting...
All matched files use Prettier code style!
```

### 证据（改动前后）

截图部分为 N/A——这是纯文档改动。渲染后的语言栏由：

> 中文 | Deutsch | français | 日本語 | Русский | Português (Brasil)

变为：

> 中文 | Deutsch | français | 日本語 | Русский | Português (Brasil) | 한국어

完整 diff 只有新增的一个链接，以及上一行末尾补上的 `|` 分隔符。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

此改动不涉及任何与操作系统相关的行为：内容是 Markdown 文本，验证方式为 HTTP 请求和 Prettier 检查。

### 运行环境（可选）

N/A——无需本地运行时。

## 风险与范围

- 主要风险或权衡：基本没有。如果韩语文档下线，该链接会失效，但这一风险与已列出的其他六种语言完全相同。
- 未验证 / 不在本次范围内：韩语翻译页面本身由文档仓库的 `daily-translate` 流程机器生成，本 PR 不审阅其措辞。我是韩语母语者，后续很乐意在文档仓库中提交润色。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。文档仓库中的相关背景：`QwenLM/qwen-code-docs#181`（locale 注册）与 `QwenLM/qwen-code-docs#212`（使 `/ko/` 真正可渲染的修复）。

</details>
