### PR TITLE
[webshell]retry session switch while closing

### DIFF
--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -7246,6 +7246,67 @@ describe('DaemonSessionProvider', () => {
     expect(loadCalls[1]?.[3]).toBe('client-a');
   });
 
+  it('retries a session switch while the target session is closing', async () => {
+    const firstSession = createMockSession({ sessionId: 'session-a' });
+    const secondSession = createMockSession({ sessionId: 'session-b' });
+    sdkMocks.sessions.push(firstSession);
+    let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+    let notices: readonly DaemonSessionNotice[] = [];
+
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      notices = useDaemonSessionNotices().notices;
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      sessionId: 'session-a',
+      reconnectDelayMs: 1,
+      maxReconnectDelayMs: 1,
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    sdkMocks.MockDaemonSessionClient.load.mockRejectedValueOnce(
+      new DaemonHttpError(
+        404,
+        {
+          error:
+            'No session with id "session-b". The session is closing; retry after close completes',
+          sessionId: 'session-b',
+        },
+        'POST /session/:id/load: No session with id "session-b". The session is closing; retry after close completes',
+      ),
+    );
+    sdkMocks.sessions.push(secondSession);
+
+    let switched: Promise<void> | undefined;
+    act(() => {
+      switched = requireActions(actions).loadSession('session-b');
+    });
+    if (!switched) throw new Error('Session switch was not started');
+    await act(async () => {
+      await wait(10);
+      await flushPromises();
+    });
+
+    await act(async () => {
+      await expect(switched).resolves.toBeUndefined();
+      await flushPromises();
+    });
+    expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(2);
+    expect(connection).toMatchObject({
+      status: 'connected',
+      sessionId: 'session-b',
+      missingSession: false,
+    });
+    expect(notices).toEqual([]);
+  });
+
   it('reuses the branched session client when switching after branch', async () => {
     window.sessionStorage.clear();
     const sourceSession = createMockSession({

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -7264,8 +7264,81 @@ describe('DaemonSessionProvider', () => {
     await renderWithProvider(<Harness />, {
       autoConnect: true,
       sessionId: 'session-a',
-      reconnectDelayMs: 1,
-      maxReconnectDelayMs: 1,
+      reconnectDelayMs: 10,
+      maxReconnectDelayMs: 100,
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    const closingError = new DaemonHttpError(
+      404,
+      {
+        error:
+          'No session with id "session-b". The session is closing; retry after close completes',
+        sessionId: 'session-b',
+      },
+      'POST /session/:id/load: No session with id "session-b". The session is closing; retry after close completes',
+    );
+    sdkMocks.MockDaemonSessionClient.load
+      .mockRejectedValueOnce(closingError)
+      .mockRejectedValueOnce(closingError);
+    sdkMocks.sessions.push(secondSession);
+
+    const random = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    vi.useFakeTimers();
+    try {
+      let switched: Promise<void> | undefined;
+      act(() => {
+        switched = requireActions(actions).loadSession('session-b');
+      });
+      if (!switched) throw new Error('Session switch was not started');
+      await act(async () => {
+        await flushPromises();
+      });
+      expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10);
+        await flushPromises();
+      });
+      expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20);
+        await flushPromises();
+      });
+      expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(3);
+
+      await act(async () => {
+        await expect(switched).resolves.toBeUndefined();
+        await flushPromises();
+      });
+      expect(connection).toMatchObject({
+        status: 'connected',
+        sessionId: 'session-b',
+        missingSession: false,
+      });
+      expect(notices).toEqual([]);
+    } finally {
+      random.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not retry a closing session when auto-reconnect is disabled', async () => {
+    sdkMocks.sessions.push(createMockSession({ sessionId: 'session-a' }));
+    let actions: DaemonSessionActions | undefined;
+
+    function Harness() {
+      actions = useDaemonActions();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      sessionId: 'session-a',
+      autoReconnect: false,
     });
     await act(async () => {
       await flushPromises();
@@ -7282,29 +7355,70 @@ describe('DaemonSessionProvider', () => {
         'POST /session/:id/load: No session with id "session-b". The session is closing; retry after close completes',
       ),
     );
-    sdkMocks.sessions.push(secondSession);
 
-    let switched: Promise<void> | undefined;
-    act(() => {
-      switched = requireActions(actions).loadSession('session-b');
+    await expect(
+      requireActions(actions).loadSession('session-b'),
+    ).rejects.toThrow();
+    expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry a closing session after a newer switch', async () => {
+    sdkMocks.sessions.push(createMockSession({ sessionId: 'session-a' }));
+    let actions: DaemonSessionActions | undefined;
+
+    function Harness() {
+      actions = useDaemonActions();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      sessionId: 'session-a',
+      reconnectDelayMs: 50,
+      maxReconnectDelayMs: 50,
     });
-    if (!switched) throw new Error('Session switch was not started');
     await act(async () => {
-      await wait(10);
       await flushPromises();
     });
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    sdkMocks.MockDaemonSessionClient.load.mockRejectedValueOnce(
+      new DaemonHttpError(
+        404,
+        {
+          error:
+            'No session with id "session-b". The session is closing; retry after close completes',
+          sessionId: 'session-b',
+        },
+        'POST /session/:id/load: No session with id "session-b". The session is closing; retry after close completes',
+      ),
+    );
+    sdkMocks.sessions.push(createMockSession({ sessionId: 'session-c' }));
 
-    await act(async () => {
-      await expect(switched).resolves.toBeUndefined();
-      await flushPromises();
-    });
-    expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(2);
-    expect(connection).toMatchObject({
-      status: 'connected',
-      sessionId: 'session-b',
-      missingSession: false,
-    });
-    expect(notices).toEqual([]);
+    vi.useFakeTimers();
+    try {
+      const loadB = requireActions(actions)
+        .loadSession('session-b')
+        .catch(() => undefined);
+      await act(async () => {
+        await flushPromises();
+      });
+      const loadC = requireActions(actions).loadSession('session-c');
+      await act(async () => {
+        await flushPromises();
+      });
+      await expect(loadC).resolves.toBeUndefined();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(50);
+        await flushPromises();
+      });
+      await loadB;
+
+      expect(
+        sdkMocks.MockDaemonSessionClient.load.mock.calls.map((call) => call[1]),
+      ).toEqual(['session-b', 'session-c']);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('reuses the branched session client when switching after branch', async () => {

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -688,6 +688,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
       restoreSessionId !== undefined &&
       restoreSessionId === sessionRef.current?.sessionId &&
       sessionRef.current === skipNextCleanupDetachSessionRef.current;
+    const effectPendingSessionLoad = pendingSessionLoadRef.current;
     let runnerSession = sessionRef.current;
 
     // ── Batched transcript dispatch ────────────────────────────────
@@ -2366,6 +2367,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
               ? error.body
               : undefined;
           if (
+            autoReconnect &&
             loadingRequestedSession &&
             pendingLoad?.sessionId === restoreSessionId &&
             error instanceof DaemonHttpError &&
@@ -2583,7 +2585,8 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
         clearPassiveAssistantDoneTimer(passiveAssistantDoneTimerRef);
       }
       if (
-        pendingSessionLoadRef.current &&
+        effectPendingSessionLoad !== undefined &&
+        pendingSessionLoadRef.current === effectPendingSessionLoad &&
         (ownsCurrentSession || ownsEmptyState) &&
         (!keepSessionForNextEffect || isUnmounting)
       ) {

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -2360,6 +2360,34 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           const message =
             error instanceof Error ? error.message : String(error);
           const errorStatus = extractHttpStatus(error);
+          const pendingLoad = pendingSessionLoadRef.current;
+          const errorBody =
+            error instanceof DaemonHttpError && isRecord(error.body)
+              ? error.body
+              : undefined;
+          if (
+            loadingRequestedSession &&
+            pendingLoad?.sessionId === restoreSessionId &&
+            error instanceof DaemonHttpError &&
+            error.status === 404 &&
+            typeof errorBody?.['error'] === 'string' &&
+            errorBody['error'].endsWith(
+              'The session is closing; retry after close completes',
+            )
+          ) {
+            reconnectAttempt += 1;
+            const reconnectConfig = reconnectConfigRef.current;
+            await delay(
+              getReconnectDelayMs(
+                reconnectAttempt,
+                reconnectConfig.reconnectDelayMs,
+                reconnectConfig.maxReconnectDelayMs,
+              ),
+              abort.signal,
+            );
+            if (pendingSessionLoadRef.current !== pendingLoad) return;
+            continue;
+          }
           const failedSessionId = session?.sessionId;
           const isAuthFailure = isAuthFailureHttpError(error);
           const isTerminal = isTerminalSessionHttpError(error);
@@ -2375,7 +2403,6 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
             clearPassiveAssistantDoneTimer(passiveAssistantDoneTimerRef);
             setPromptStatus('idle');
           }
-          const pendingLoad = pendingSessionLoadRef.current;
           if (
             pendingLoad &&
             (pendingLoad.sessionId === restoreSessionId ||

--- a/packages/webui/src/daemon/session/actions.test.ts
+++ b/packages/webui/src/daemon/session/actions.test.ts
@@ -529,11 +529,7 @@ describe('createDaemonSessionActions', () => {
         loadingTranscript: true,
       });
 
-      // Split the boundary, and observe pendingness rather than connection
-      // status — the status stays 'connecting' after a rejection, so asserting
-      // it would stay green for any watchdog ≤ 75s, including the 30s attach
-      // value. A 30s load watchdog abandons a load the daemon's 60s budget
-      // still completes, recreating the #8678 symptom in the browser.
+      // Split the boundary so a shorter watchdog cannot pass this test.
       let settledEarly = false;
       void loadPromise.catch(() => {
         settledEarly = true;
@@ -544,6 +540,7 @@ describe('createDaemonSessionActions', () => {
 
       await expect(loadPromise).rejects.toThrow('Session load timed out');
       expect(getConnection()).toMatchObject({
+        status: 'disconnected',
         sessionId: 'session-b',
         loadingTranscript: undefined,
         catchingUp: undefined,

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -243,6 +243,19 @@ export function createDaemonSessionActions({
           : setTimeout(() => {
               if (pendingSessionLoadRef.current?.id === loadId) {
                 pendingSessionLoadRef.current = undefined;
+                if (sessionRef.current?.sessionId !== sessionId) {
+                  setConnection((current) =>
+                    current.status === 'connecting' &&
+                    current.sessionId === sessionId
+                      ? {
+                          ...current,
+                          status: 'disconnected',
+                          loadingTranscript: undefined,
+                          catchingUp: undefined,
+                        }
+                      : current,
+                  );
+                }
                 reject(
                   dispatchActionError(
                     addNotice,


### PR DESCRIPTION
## What this PR does

Keeps an explicit session switch pending when the daemon reports that the target session is still closing, then retries it with the existing reconnect backoff. Watchdog expiry now settles a stranded switch as disconnected, a newer switch supersedes the old retry cleanly, and `autoReconnect={false}` still fails fast. Other missing-session responses keep their current terminal behavior.

## Why it's needed

Switching away from a session starts an asynchronous teardown. Switching back before that teardown finishes returns a transient 404, but the Web Shell treated it as a permanently missing session and showed both an error toast and the “current session does not exist” screen.

## Reviewer Test Plan

### How to verify

Open two persisted sessions and switch between them repeatedly without waiting between switches. A transient closing response may occur internally, but the requested session should eventually open without an error toast or missing-session screen.

### Evidence (Before & After)

| Before | After |
| --- | --- |
| ![](https://cdn.jsdelivr.net/gh/yiliang114/img-host@main/assets/codex-clipboard-e06fe067-2d9e-4ac9-a82c-69af95d9d3d9.png) | ![](https://cdn.jsdelivr.net/gh/yiliang114/img-host@main/assets/session-switch-fixed.png) |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Locally built macOS Desktop app bundle and its packaged runtime with the production Web Shell.

## Risk & Scope

- Main risk or tradeoff: only explicit action-driven switches retry the daemon's exact close-in-progress response, and only while auto-reconnect is enabled; initial restore/attach and all other 404/410 handling are unchanged.
- Not validated / out of scope: native Windows and Linux packages.
- Breaking changes / migration notes: none.

## Linked Issues

Related to #8092.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

当 daemon 返回目标会话仍在关闭中时，保持显式的会话切换请求，并使用现有的重连退避机制重试。watchdog 到期时，滞留的切换会确定性进入 disconnected；新切换会干净地取代旧重试；`autoReconnect={false}` 仍会快速失败。其他会话不存在响应保持当前终止行为。

## 为什么需要

切离一个会话会启动异步清理。如果在清理结束前切回，daemon 会返回临时 404，但 Web Shell 之前会把它当作会话永久不存在，同时显示错误提示和“当前会话不存在”页面。

## Reviewer Test Plan

### 如何验证

打开两个已保存的会话，并在不额外等待的情况下反复切换。内部可能短暂出现 closing 响应，但目标会话最终应正常打开，且不显示错误提示或会话不存在页面。

### 证据（修复前后）

| 修复前 | 修复后 |
| --- | --- |
| ![](https://cdn.jsdelivr.net/gh/yiliang114/img-host@main/assets/codex-clipboard-e06fe067-2d9e-4ac9-a82c-69af95d9d3d9.png) | ![](https://cdn.jsdelivr.net/gh/yiliang114/img-host@main/assets/session-switch-fixed.png) |

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

本地构建的 macOS Desktop APP bundle、其内置 runtime 和生产 Web Shell。

## 风险与范围

- 主要风险或取舍：只有显式操作触发的会话切换会重试 daemon 明确返回的“关闭进行中”响应，而且仅在启用自动重连时；初始恢复/attach 和其他 404/410 处理保持不变。
- 未验证 / 范围外：Windows 和 Linux 原生安装包。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

关联 #8092。

</details>
