### PR TITLE
fix(cli): keep the selected model when refreshing another provider's template

### DIFF
--- a/packages/cli/src/ui/hooks/useProviderUpdates.test.ts
+++ b/packages/cli/src/ui/hooks/useProviderUpdates.test.ts
@@ -455,6 +455,107 @@ describe('useProviderUpdates', () => {
     );
   });
 
+  it('does not move the user off a model owned by another provider', async () => {
+    // The user is on a self-hosted gateway model that Coding Plan does not own.
+    // Refreshing the Coding Plan template must leave model.name/model.baseUrl
+    // untouched. (#8863)
+    const foreignModel = {
+      id: 'my-own-model',
+      baseUrl: 'https://my-own-gateway.example.com/v1',
+      envKey: 'MY_OWN_KEY',
+      name: '[Mine] my-own-model',
+    };
+    mockConfig.getModel.mockReturnValue('my-own-model');
+    mockConfig.getContentGeneratorConfig.mockReturnValue({
+      authType: AuthType.USE_OPENAI,
+      baseUrl: foreignModel.baseUrl,
+      apiKeyEnvKey: foreignModel.envKey,
+    });
+    (mockSettings.merged[PROVIDER_METADATA_NS] as Record<string, unknown>)[
+      METADATA_KEY
+    ] = {
+      baseUrl: CODING_PLAN_CHINA_BASE_URL,
+      version: 'old-version-hash',
+    };
+    mockSettings.merged['modelProviders'] = {
+      [AuthType.USE_OPENAI]: [foreignModel, ...chinaTemplate],
+    };
+
+    const { result } = renderHook(() =>
+      useProviderUpdates(
+        mockSettings as never,
+        mockConfig as never,
+        mockAddItem,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(result.current.providerUpdateRequest).toBeDefined();
+    });
+
+    await result.current.providerUpdateRequest!.onConfirm('update');
+
+    await waitFor(() => {
+      expect(mockConfig.reloadModelProvidersConfig).toHaveBeenCalled();
+    });
+
+    expect(mockSettings.setValue).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'model.name',
+      expect.anything(),
+    );
+    expect(mockSettings.setValue).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'model.baseUrl',
+      expect.anything(),
+    );
+    expect(mockModelsConfig.syncAfterAuthRefresh).not.toHaveBeenCalled();
+  });
+
+  it('reports no model switch when the selection is left alone', async () => {
+    const foreignModel = {
+      id: 'my-own-model',
+      baseUrl: 'https://my-own-gateway.example.com/v1',
+      envKey: 'MY_OWN_KEY',
+      name: '[Mine] my-own-model',
+    };
+    mockConfig.getModel.mockReturnValue('my-own-model');
+    (mockSettings.merged[PROVIDER_METADATA_NS] as Record<string, unknown>)[
+      METADATA_KEY
+    ] = {
+      baseUrl: CODING_PLAN_CHINA_BASE_URL,
+      version: 'old-version-hash',
+    };
+    mockSettings.merged['modelProviders'] = {
+      [AuthType.USE_OPENAI]: [foreignModel, ...chinaTemplate],
+    };
+
+    const { result } = renderHook(() =>
+      useProviderUpdates(
+        mockSettings as never,
+        mockConfig as never,
+        mockAddItem,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(result.current.providerUpdateRequest).toBeDefined();
+    });
+
+    await result.current.providerUpdateRequest!.onConfirm('update');
+
+    await waitFor(() => {
+      expect(mockAddItem).toHaveBeenCalled();
+    });
+
+    const texts = mockAddItem.mock.calls.map(
+      (call) => (call[0] as { text: string }).text,
+    );
+    expect(texts.some((text) => text.includes('Model switched to'))).toBe(
+      false,
+    );
+  });
+
   it('dismisses without persisting when user chooses "later"', async () => {
     (mockSettings.merged[PROVIDER_METADATA_NS] as Record<string, unknown>)[
       METADATA_KEY

--- a/packages/cli/src/ui/hooks/useProviderUpdates.test.ts
+++ b/packages/cli/src/ui/hooks/useProviderUpdates.test.ts
@@ -87,7 +87,7 @@ describe('useProviderUpdates', () => {
       apiKeyEnvKey: CODING_PLAN_ENV_KEY,
     });
     mockConfig.getModel.mockReturnValue('qwen3.5-plus');
-    mockModelsConfig.syncAfterAuthRefresh.mockClear();
+    mockModelsConfig.syncAfterAuthRefresh.mockReset();
     delete process.env[CODING_PLAN_ENV_KEY];
   });
 
@@ -315,39 +315,65 @@ describe('useProviderUpdates', () => {
     expect(mockConfig.reloadModelProvidersConfig).toHaveBeenCalled();
     expect(mockModelsConfig.syncAfterAuthRefresh).not.toHaveBeenCalled();
     expect(mockConfig.refreshAuth).toHaveBeenCalledWith(AuthType.USE_OPENAI);
-  });
-
-  it('does not refresh auth when updating an inactive provider on the same protocol', async () => {
-    mockConfig.getContentGeneratorConfig.mockReturnValue({
-      authType: AuthType.USE_OPENAI,
-      baseUrl: TOKEN_PLAN_BASE_URL,
-      apiKeyEnvKey: TOKEN_PLAN_ENV_KEY,
-    });
-    (mockSettings.merged[PROVIDER_METADATA_NS] as Record<string, unknown>)[
-      METADATA_KEY
-    ] = {
-      baseUrl: CODING_PLAN_CHINA_BASE_URL,
-      version: 'old-version-hash',
-    };
-    mockSettings.merged['modelProviders'] = {
-      [AuthType.USE_OPENAI]: chinaTemplate,
-    };
-
-    const { result } = renderHook(() =>
-      useProviderUpdates(
-        mockSettings as never,
-        mockConfig as never,
-        mockAddItem,
-      ),
+    expect(mockSettings.setValue).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'security.auth.selectedType',
+      expect.anything(),
     );
-
-    await waitFor(() => {
-      expect(result.current.providerUpdateRequest).toBeDefined();
-    });
-    await result.current.providerUpdateRequest!.onConfirm('update');
-
-    expect(mockConfig.refreshAuth).not.toHaveBeenCalled();
   });
+
+  it.each([
+    {
+      name: 'on the same protocol',
+      activeConfig: {
+        authType: AuthType.USE_OPENAI,
+        baseUrl: TOKEN_PLAN_BASE_URL,
+        apiKeyEnvKey: TOKEN_PLAN_ENV_KEY,
+      },
+    },
+    {
+      name: 'on a different protocol',
+      activeConfig: {
+        authType: AuthType.USE_GEMINI,
+        baseUrl: 'https://generativelanguage.googleapis.com',
+        apiKeyEnvKey: 'GEMINI_API_KEY',
+      },
+    },
+  ])(
+    'does not change auth when updating an inactive provider $name',
+    async ({ activeConfig }) => {
+      mockConfig.getContentGeneratorConfig.mockReturnValue(activeConfig);
+      (mockSettings.merged[PROVIDER_METADATA_NS] as Record<string, unknown>)[
+        METADATA_KEY
+      ] = {
+        baseUrl: CODING_PLAN_CHINA_BASE_URL,
+        version: 'old-version-hash',
+      };
+      mockSettings.merged['modelProviders'] = {
+        [AuthType.USE_OPENAI]: chinaTemplate,
+      };
+
+      const { result } = renderHook(() =>
+        useProviderUpdates(
+          mockSettings as never,
+          mockConfig as never,
+          mockAddItem,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(result.current.providerUpdateRequest).toBeDefined();
+      });
+      await result.current.providerUpdateRequest!.onConfirm('update');
+
+      expect(mockConfig.refreshAuth).not.toHaveBeenCalled();
+      expect(mockSettings.setValue).not.toHaveBeenCalledWith(
+        expect.anything(),
+        'security.auth.selectedType',
+        expect.anything(),
+      );
+    },
+  );
 
   it('does not refresh auth before auth initialization completes', async () => {
     mockConfig.getContentGeneratorConfig.mockReturnValue(undefined as never);
@@ -418,7 +444,13 @@ describe('useProviderUpdates', () => {
   });
 
   it('switches model when previous model is no longer available', async () => {
-    mockConfig.getModel.mockReturnValue('removed-model');
+    let activeModel = 'removed-model';
+    mockConfig.getModel.mockImplementation(() => activeModel);
+    mockModelsConfig.syncAfterAuthRefresh.mockImplementation(
+      (_authType, modelId) => {
+        activeModel = modelId;
+      },
+    );
     (mockSettings.merged[PROVIDER_METADATA_NS] as Record<string, unknown>)[
       METADATA_KEY
     ] = {
@@ -453,12 +485,19 @@ describe('useProviderUpdates', () => {
       'qwen3.5-plus',
       undefined,
     );
+    expect(mockAddItem).toHaveBeenCalledWith(
+      {
+        type: 'info',
+        text: 'Coding Plan configuration updated successfully. Model switched to "qwen3.5-plus".',
+      },
+      expect.any(Number),
+    );
   });
 
-  it('does not move the user off a model owned by another provider', async () => {
-    // The user is on a self-hosted gateway model that Coding Plan does not own.
-    // Refreshing the Coding Plan template must leave model.name/model.baseUrl
-    // untouched. (#8863)
+  it.each([
+    { name: 'registered under the same protocol', registered: true },
+    { name: 'provided by the active runtime config only', registered: false },
+  ])('does not move the user off a model $name', async ({ registered }) => {
     const foreignModel = {
       id: 'my-own-model',
       baseUrl: 'https://my-own-gateway.example.com/v1',
@@ -478,7 +517,9 @@ describe('useProviderUpdates', () => {
       version: 'old-version-hash',
     };
     mockSettings.merged['modelProviders'] = {
-      [AuthType.USE_OPENAI]: [foreignModel, ...chinaTemplate],
+      [AuthType.USE_OPENAI]: registered
+        ? [foreignModel, ...chinaTemplate]
+        : chinaTemplate,
     };
 
     const { result } = renderHook(() =>
@@ -510,49 +551,12 @@ describe('useProviderUpdates', () => {
       expect.anything(),
     );
     expect(mockModelsConfig.syncAfterAuthRefresh).not.toHaveBeenCalled();
-  });
-
-  it('reports no model switch when the selection is left alone', async () => {
-    const foreignModel = {
-      id: 'my-own-model',
-      baseUrl: 'https://my-own-gateway.example.com/v1',
-      envKey: 'MY_OWN_KEY',
-      name: '[Mine] my-own-model',
-    };
-    mockConfig.getModel.mockReturnValue('my-own-model');
-    (mockSettings.merged[PROVIDER_METADATA_NS] as Record<string, unknown>)[
-      METADATA_KEY
-    ] = {
-      baseUrl: CODING_PLAN_CHINA_BASE_URL,
-      version: 'old-version-hash',
-    };
-    mockSettings.merged['modelProviders'] = {
-      [AuthType.USE_OPENAI]: [foreignModel, ...chinaTemplate],
-    };
-
-    const { result } = renderHook(() =>
-      useProviderUpdates(
-        mockSettings as never,
-        mockConfig as never,
-        mockAddItem,
-      ),
-    );
-
-    await waitFor(() => {
-      expect(result.current.providerUpdateRequest).toBeDefined();
-    });
-
-    await result.current.providerUpdateRequest!.onConfirm('update');
-
-    await waitFor(() => {
-      expect(mockAddItem).toHaveBeenCalled();
-    });
-
-    const texts = mockAddItem.mock.calls.map(
-      (call) => (call[0] as { text: string }).text,
-    );
-    expect(texts.some((text) => text.includes('Model switched to'))).toBe(
-      false,
+    expect(mockAddItem).toHaveBeenCalledWith(
+      {
+        type: 'info',
+        text: 'Coding Plan configuration updated successfully.',
+      },
+      expect.any(Number),
     );
   });
 

--- a/packages/cli/src/ui/hooks/useProviderUpdates.ts
+++ b/packages/cli/src/ui/hooks/useProviderUpdates.ts
@@ -171,6 +171,24 @@ function readInstalledOwnedIds(
     : allModels.map((m) => m.id);
 }
 
+/**
+ * Every model id installed under this provider's protocol, regardless of which
+ * provider owns it. Used to tell "the model belongs to a different provider"
+ * apart from "the model is not installed at all".
+ */
+function readInstalledProtocolIds(
+  settings: LoadedSettings,
+  provider: ProviderConfig,
+): string[] {
+  const protocol = provider.protocol;
+  if (!protocol) return [];
+  const mergedSettings = settings.merged as Record<string, unknown>;
+  const modelProviders = mergedSettings['modelProviders'] as
+    | Record<string, ProviderModelConfig[]>
+    | undefined;
+  return (modelProviders?.[protocol] ?? []).map((m) => m.id);
+}
+
 function getInstalledOwnedModelIds(
   settings: LoadedSettings,
   provider: ProviderConfig,
@@ -241,9 +259,8 @@ export function useProviderUpdates(
         // must be carried through so they are not deleted by the
         // prepend-and-remove-owned merge.
         const defaultIds = getDefaultModelIds(providerCfg);
-        const customIds = readInstalledOwnedIds(settings, providerCfg).filter(
-          (id) => !defaultIds.includes(id),
-        );
+        const ownedIds = readInstalledOwnedIds(settings, providerCfg);
+        const customIds = ownedIds.filter((id) => !defaultIds.includes(id));
         const installPlan = buildInstallPlan(providerCfg, {
           baseUrl: resolved,
           apiKey: '',
@@ -255,7 +272,19 @@ export function useProviderUpdates(
         const previousModelStillAvailable = newConfigs.some(
           (cfg) => cfg.id === previousModel,
         );
-        if (previousModelStillAvailable) {
+        // `buildInstallPlan` always carries a first-time-install default
+        // selection. A template refresh must not act on it when the current
+        // model belongs to a *different* provider — that silently moves the
+        // user off their model and clears model.baseUrl, surfacing only on the
+        // next launch. A model not installed under this protocol at all is
+        // still migrated, otherwise the user is left pointing at nothing.
+        // (#8863)
+        const previousModelOwnedByOther =
+          !ownedIds.includes(previousModel) &&
+          readInstalledProtocolIds(settings, providerCfg).includes(
+            previousModel,
+          );
+        if (previousModelStillAvailable || previousModelOwnedByOther) {
           delete installPlan.modelSelection;
         }
         const activeConfig = config.getContentGeneratorConfig();
@@ -282,7 +311,7 @@ export function useProviderUpdates(
         const activeModel = config.getModel();
         const displayName = t(providerCfg.label);
 
-        if (previousModelStillAvailable && activeModel === previousModel) {
+        if (activeModel === previousModel) {
           addItem(
             {
               type: 'info',

--- a/packages/cli/src/ui/hooks/useProviderUpdates.ts
+++ b/packages/cli/src/ui/hooks/useProviderUpdates.ts
@@ -171,24 +171,6 @@ function readInstalledOwnedIds(
     : allModels.map((m) => m.id);
 }
 
-/**
- * Every model id installed under this provider's protocol, regardless of which
- * provider owns it. Used to tell "the model belongs to a different provider"
- * apart from "the model is not installed at all".
- */
-function readInstalledProtocolIds(
-  settings: LoadedSettings,
-  provider: ProviderConfig,
-): string[] {
-  const protocol = provider.protocol;
-  if (!protocol) return [];
-  const mergedSettings = settings.merged as Record<string, unknown>;
-  const modelProviders = mergedSettings['modelProviders'] as
-    | Record<string, ProviderModelConfig[]>
-    | undefined;
-  return (modelProviders?.[protocol] ?? []).map((m) => m.id);
-}
-
 function getInstalledOwnedModelIds(
   settings: LoadedSettings,
   provider: ProviderConfig,
@@ -259,8 +241,9 @@ export function useProviderUpdates(
         // must be carried through so they are not deleted by the
         // prepend-and-remove-owned merge.
         const defaultIds = getDefaultModelIds(providerCfg);
-        const ownedIds = readInstalledOwnedIds(settings, providerCfg);
-        const customIds = ownedIds.filter((id) => !defaultIds.includes(id));
+        const customIds = readInstalledOwnedIds(settings, providerCfg).filter(
+          (id) => !defaultIds.includes(id),
+        );
         const installPlan = buildInstallPlan(providerCfg, {
           baseUrl: resolved,
           apiKey: '',
@@ -268,25 +251,6 @@ export function useProviderUpdates(
         });
         delete installPlan.env;
         const previousModel = config.getModel();
-        const newConfigs = installPlan.modelProviders?.[0]?.models ?? [];
-        const previousModelStillAvailable = newConfigs.some(
-          (cfg) => cfg.id === previousModel,
-        );
-        // `buildInstallPlan` always carries a first-time-install default
-        // selection. A template refresh must not act on it when the current
-        // model belongs to a *different* provider — that silently moves the
-        // user off their model and clears model.baseUrl, surfacing only on the
-        // next launch. A model not installed under this protocol at all is
-        // still migrated, otherwise the user is left pointing at nothing.
-        // (#8863)
-        const previousModelOwnedByOther =
-          !ownedIds.includes(previousModel) &&
-          readInstalledProtocolIds(settings, providerCfg).includes(
-            previousModel,
-          );
-        if (previousModelStillAvailable || previousModelOwnedByOther) {
-          delete installPlan.modelSelection;
-        }
         const activeConfig = config.getContentGeneratorConfig();
         const updatesActiveProvider =
           activeConfig?.authType === providerCfg.protocol &&
@@ -295,9 +259,26 @@ export function useProviderUpdates(
             activeConfig.baseUrl,
             activeConfig.apiKeyEnvKey,
           );
+        const newConfigs = installPlan.modelProviders?.[0]?.models ?? [];
+        const previousModelStillAvailable = newConfigs.some(
+          (cfg) => cfg.id === previousModel,
+        );
+        // Only the active provider may migrate model selection.
+        if (!updatesActiveProvider || previousModelStillAvailable) {
+          delete installPlan.modelSelection;
+        }
+        const settingsAdapter = createLoadedSettingsAdapter(settings);
 
         await applyProviderInstallPlan(installPlan, {
-          settings: createLoadedSettingsAdapter(settings),
+          settings: {
+            ...settingsAdapter,
+            setValue: (key, value) => {
+              // Template updates never change the selected auth method.
+              if (key !== 'security.auth.selectedType') {
+                settingsAdapter.setValue(key, value);
+              }
+            },
+          },
           reloadModelProviders: (mp) => config.reloadModelProvidersConfig(mp),
           syncAuthState: (authType, modelId, baseUrl) =>
             config


### PR DESCRIPTION
## What this PR does

A built-in provider template refresh no longer changes which model the user has selected when that model belongs to a different provider. The install plan that a refresh reuses always carries a first-time-install default selection — pick the provider's first model — and until now a refresh acted on it whenever the current model was absent from the refreshed list. Because a model owned by any other provider is by definition absent from that list, accepting a refresh silently rewrote the user's selected model and wiped the base URL that disambiguated it.

The refresh path now leaves the selection alone when the current model is installed under the same protocol but owned by a different provider. A model that is not installed at all is still migrated, so a user is never left pointing at nothing.

The accompanying confirmation message was also wrong: it reported `Model switched to "<the user's old model>"` in exactly the case where the selection had just been overwritten, because it read the runtime model, which the refresh does not touch. It now reports a switch only when the active model actually changed.

## Why it's needed

Anyone who mixes a built-in provider with a self-hosted gateway, an internal proxy, or another vendor's provider loses their model selection and their custom base URL the first time they accept a provider update. Nothing signals it: the current session keeps running the old model, the footer keeps showing it, and the confirmation message claims nothing changed. The new value only takes effect on the next launch — by which point the update prompt that caused it is long gone from the user's mind.

All eleven built-in providers share this path, and each one substitutes its own first model, most of which are the flagship, highest-priced tier: `qwen3.5-plus`, `qwen3.7-plus`, `qwen3.6-plus`, `deepseek-v4-pro`, `grok-4.5`, `MiniMax-M3`, `GLM-5.2`, and so on. When several providers are stale at once the loop applies each in turn and the last one wins, so the resulting model bears no relation to anything the user chose.

This is the unfinished half of #5819, where the reporter was moved from a cheap model to the expensive one and only discovered it when their prepaid balance ran out. The guard added for that issue asks the same question as the one it was backing up — "is the current model in this plan?" — so both miss together on a model this provider never owned.

Fixes #8863

## Reviewer Test Plan

### How to verify

Point `model.name` at a model that a built-in provider does not own, mark that provider's stored version stale, then accept the update prompt. The startup check only compares the version string for equality, so any stale value works and no real API key is needed.

```bash
export REPRO_HOME=/tmp/qwen-repro
rm -rf "$REPRO_HOME" && mkdir -p "$REPRO_HOME/.qwen" "$REPRO_HOME/workdir"
cat > "$REPRO_HOME/.qwen/settings.json" <<'JSON'
{
  "security": { "auth": { "selectedType": "openai" } },
  "model": { "name": "my-own-model", "baseUrl": "https://my-own-gateway.example.com/v1" },
  "modelProviders": {
    "openai": [
      { "id": "my-own-model", "name": "[Mine] my-own-model", "baseUrl": "https://my-own-gateway.example.com/v1", "envKey": "MY_OWN_KEY" },
      { "id": "tp-custom", "name": "[ModelStudio Token Plan] tp-custom", "baseUrl": "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1", "envKey": "BAILIAN_TOKEN_PLAN_API_KEY" }
    ]
  },
  "providerMetadata": {
    "token-plan": { "version": "stale-version", "baseUrl": "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1" }
  },
  "env": { "BAILIAN_TOKEN_PLAN_API_KEY": "sk-dummy", "MY_OWN_KEY": "sk-dummy" }
}
JSON
cd "$REPRO_HOME/workdir" && HOME="$REPRO_HOME" node /path/to/dist/cli.js
```

Choose `1. Update all`, then inspect the file:

```bash
node -e 'const s=require(process.env.REPRO_HOME+"/.qwen/settings.json"); console.log(s.model)'
```

A reviewer should confirm that `model.name` stays `my-own-model` and `model.baseUrl` keeps the gateway URL, that the built-in models were still installed and the custom model preserved (the refresh itself must keep working), and that the confirmation message reads `configuration updated successfully.` with no `Model switched to` clause.

Three neighbouring cases are worth checking as well, since they are what bounds the fix: a model the provider owns is untouched, a model absent from every installed list is still migrated (covered by the pre-existing `switches model when previous model is no longer available` test), and the update prompt itself is unchanged — the prompt reappearing on every launch is a separate defect tracked in #8504 and deliberately out of scope here.

Unit tests:

```bash
cd packages/cli && npx vitest run src/ui/hooks/useProviderUpdates.test.ts
# Test Files  1 passed (1)
#      Tests  19 passed (19)
```

Both new tests were checked against a reverted fix: each one fails on its own when the corresponding guard is rolled back, so neither passes for the wrong reason.

### Evidence (Before & After)

Same fixture, same keystroke, reading the file on disk right after the prompt was accepted.

Before:

```
UI:   Token Plan configuration updated successfully. Model switched to "my-own-model".
disk: model.name    = qwen3.7-plus            (was my-own-model)
      model.baseUrl = ""                      (was https://my-own-gateway.example.com/v1)
```

After:

```
UI:   Token Plan configuration updated successfully.
disk: model.name    = my-own-model            (unchanged)
      model.baseUrl = https://my-own-gateway.example.com/v1   (unchanged)
      built-in models installed: yes
      custom model preserved:    yes
```

With two providers stale at once, the before case ends on `grok-4.5` rather than `qwen3.7-plus` while both confirmation lines claim the old model was kept — the same fixture is clean after the fix.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`npm run build && npm run bundle`, then the bundled `dist/cli.js` driven against an isolated `HOME`.

## Risk & Scope

- Main risk or tradeoff: the refresh path now declines to migrate in one more situation, so a user whose current model is owned by another provider keeps that selection even if they expected the accepted update to move them onto the refreshed provider. That is the intended reading — a template refresh is not a request to change models — and `/model` remains the way to switch.
- Not validated / out of scope: the prompt reappearing on every launch (#8504, addressed by #8830) is untouched. The runtime and on-disk model can still diverge when a migration legitimately happens, because the refresh only rebuilds the content generator config for the active provider; that divergence predates this change and is not widened by it. Windows and Linux were not exercised locally.
- Breaking changes / migration notes: none. No settings shape or public API changes; users already moved onto a substituted model keep it until they change it themselves.
