### PR TITLE
fix(cli): keep the user's model selection intact on provider template updates

### DIFF
--- a/packages/cli/src/ui/hooks/useProviderUpdates.test.ts
+++ b/packages/cli/src/ui/hooks/useProviderUpdates.test.ts
@@ -417,7 +417,13 @@ describe('useProviderUpdates', () => {
     expect(process.env[CODING_PLAN_ENV_KEY]).toBe('sk-sp-existing-key');
   });
 
-  it('switches model when previous model is no longer available', async () => {
+  it('does not adopt the provider default when the previous model is gone from the plan', async () => {
+    // Inverted from the pre-#8863 'switches model when previous model is no
+    // longer available': the update path never applies the plan's model
+    // selection, even when the current model is absent from the refreshed
+    // list — a removed built-in the user still sits on is carried into the
+    // plan as a custom entry, so an absent model here means it was never
+    // this provider's to migrate.
     mockConfig.getModel.mockReturnValue('removed-model');
     (mockSettings.merged[PROVIDER_METADATA_NS] as Record<string, unknown>)[
       METADATA_KEY
@@ -448,11 +454,172 @@ describe('useProviderUpdates', () => {
       expect(mockSettings.setValue).toHaveBeenCalled();
     });
 
-    expect(mockModelsConfig.syncAfterAuthRefresh).toHaveBeenCalledWith(
-      AuthType.USE_OPENAI,
-      'qwen3.5-plus',
-      undefined,
+    expect(mockModelsConfig.syncAfterAuthRefresh).not.toHaveBeenCalled();
+    const modelWrites = mockSettings.setValue.mock.calls.filter(
+      (call: unknown[]) =>
+        call[1] === 'model.name' || call[1] === 'model.baseUrl',
     );
+    expect(modelWrites).toEqual([]);
+  });
+
+  it('does not rewrite the model selection when the current model belongs to another provider', async () => {
+    // #8863: a template update carries no model-selection intent. When the
+    // user's current model is not one of this provider's models (e.g. a
+    // self-hosted gateway entry), the update must not move them onto this
+    // provider's first built-in model and must not clear model.baseUrl.
+    mockConfig.getModel.mockReturnValue('my-own-model');
+    (mockSettings.merged[PROVIDER_METADATA_NS] as Record<string, unknown>)[
+      METADATA_KEY
+    ] = {
+      baseUrl: CODING_PLAN_CHINA_BASE_URL,
+      version: 'old-version-hash',
+    };
+    mockSettings.merged['modelProviders'] = {
+      [AuthType.USE_OPENAI]: [
+        ...chinaTemplate,
+        {
+          id: 'my-own-model',
+          baseUrl: 'https://my-own-gateway.example.com/v1',
+          envKey: 'MY_OWN_KEY',
+          name: '[Mine] my-own-model',
+        },
+      ],
+    };
+    mockConfig.refreshAuth.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() =>
+      useProviderUpdates(
+        mockSettings as never,
+        mockConfig as never,
+        mockAddItem,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(result.current.providerUpdateRequest).toBeDefined();
+    });
+
+    await result.current.providerUpdateRequest!.onConfirm('update');
+
+    await waitFor(() => {
+      expect(mockSettings.setValue).toHaveBeenCalled();
+    });
+
+    const modelWrites = mockSettings.setValue.mock.calls.filter(
+      (call: unknown[]) =>
+        call[1] === 'model.name' || call[1] === 'model.baseUrl',
+    );
+    expect(modelWrites).toEqual([]);
+    expect(mockModelsConfig.syncAfterAuthRefresh).not.toHaveBeenCalled();
+  });
+
+  it('does not claim a model switch in the update toast when nothing changed', async () => {
+    // #8863 symptom 2: the toast used to read the unchanged runtime model
+    // and announce 'Model switched to "<old model>"' while the overwrite
+    // landed on disk. With the selection untouched there is no switch to
+    // report.
+    mockConfig.getModel.mockReturnValue('my-own-model');
+    (mockSettings.merged[PROVIDER_METADATA_NS] as Record<string, unknown>)[
+      METADATA_KEY
+    ] = {
+      baseUrl: CODING_PLAN_CHINA_BASE_URL,
+      version: 'old-version-hash',
+    };
+    mockSettings.merged['modelProviders'] = {
+      [AuthType.USE_OPENAI]: [
+        ...chinaTemplate,
+        {
+          id: 'my-own-model',
+          baseUrl: 'https://my-own-gateway.example.com/v1',
+          envKey: 'MY_OWN_KEY',
+          name: '[Mine] my-own-model',
+        },
+      ],
+    };
+    mockConfig.refreshAuth.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() =>
+      useProviderUpdates(
+        mockSettings as never,
+        mockConfig as never,
+        mockAddItem,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(result.current.providerUpdateRequest).toBeDefined();
+    });
+
+    await result.current.providerUpdateRequest!.onConfirm('update');
+
+    await waitFor(() => {
+      expect(mockAddItem).toHaveBeenCalled();
+    });
+
+    const switchToasts = mockAddItem.mock.calls.filter(
+      (call: unknown[]) =>
+        typeof (call[0] as { text?: string })?.text === 'string' &&
+        (call[0] as { text: string }).text.includes('Model switched'),
+    );
+    expect(switchToasts).toEqual([]);
+  });
+
+  it('leaves the model selection alone across a multi-provider batch update', async () => {
+    // #8863 worst case: several providers update in one confirmation and
+    // each executeUpdate used to rewrite model.name in turn, the last
+    // provider in registry order winning. None of them may touch it.
+    mockConfig.getModel.mockReturnValue('my-own-model');
+    const metadataNs = mockSettings.merged[PROVIDER_METADATA_NS] as Record<
+      string,
+      unknown
+    >;
+    metadataNs[METADATA_KEY] = {
+      baseUrl: CODING_PLAN_CHINA_BASE_URL,
+      version: 'old-version-hash',
+    };
+    metadataNs[TOKEN_METADATA_KEY] = {
+      baseUrl: TOKEN_PLAN_BASE_URL,
+      version: 'old-version-hash',
+    };
+    mockSettings.merged['modelProviders'] = {
+      [AuthType.USE_OPENAI]: [
+        ...chinaTemplate,
+        ...tokenTemplate,
+        {
+          id: 'my-own-model',
+          baseUrl: 'https://my-own-gateway.example.com/v1',
+          envKey: 'MY_OWN_KEY',
+          name: '[Mine] my-own-model',
+        },
+      ],
+    };
+    mockConfig.refreshAuth.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() =>
+      useProviderUpdates(
+        mockSettings as never,
+        mockConfig as never,
+        mockAddItem,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(result.current.providerUpdateRequest).toBeDefined();
+    });
+    expect(result.current.providerUpdateRequest!.entries.length).toBe(2);
+
+    await result.current.providerUpdateRequest!.onConfirm('update');
+
+    await waitFor(() => {
+      expect(mockSettings.setValue).toHaveBeenCalled();
+    });
+
+    const modelWrites = mockSettings.setValue.mock.calls.filter(
+      (call: unknown[]) =>
+        call[1] === 'model.name' || call[1] === 'model.baseUrl',
+    );
+    expect(modelWrites).toEqual([]);
+    expect(mockModelsConfig.syncAfterAuthRefresh).not.toHaveBeenCalled();
   });
 
   it('dismisses without persisting when user chooses "later"', async () => {

--- a/packages/cli/src/ui/hooks/useProviderUpdates.ts
+++ b/packages/cli/src/ui/hooks/useProviderUpdates.ts
@@ -251,13 +251,13 @@ export function useProviderUpdates(
         });
         delete installPlan.env;
         const previousModel = config.getModel();
-        const newConfigs = installPlan.modelProviders?.[0]?.models ?? [];
-        const previousModelStillAvailable = newConfigs.some(
-          (cfg) => cfg.id === previousModel,
-        );
-        if (previousModelStillAvailable) {
-          delete installPlan.modelSelection;
-        }
+        // A template update is not first-time setup and carries no
+        // model-selection intent: never let the refreshed plan move the
+        // user off their current model or clear model.baseUrl. Models this
+        // provider owns are already carried into the plan above (including
+        // removed built-ins the user still sits on), and a model owned by
+        // another provider is not this update's to touch (#8863, #5819).
+        delete installPlan.modelSelection;
         const activeConfig = config.getContentGeneratorConfig();
         const updatesActiveProvider =
           activeConfig?.authType === providerCfg.protocol &&
@@ -282,7 +282,7 @@ export function useProviderUpdates(
         const activeModel = config.getModel();
         const displayName = t(providerCfg.label);
 
-        if (previousModelStillAvailable && activeModel === previousModel) {
+        if (activeModel === previousModel) {
           addItem(
             {
               type: 'info',


### PR DESCRIPTION
## What this PR does

Makes the built-in provider template update path leave the user's model selection alone. `executeUpdate` now drops the install plan's `modelSelection` unconditionally, so choosing `Update all` refreshes the provider's model list and version metadata without ever rewriting `model.name` or clearing `model.baseUrl`. The completion toast now reports a model switch only when the active model actually changed, instead of predicting one from the plan — which is how the old code could announce `Model switched to "<old model>"` while writing a different model to disk.

The previous conditional (`delete modelSelection` only when the plan still offers the current model) was a no-op in every legitimate case and live only in the buggy one: models the provider owns are already carried into the refreshed plan as custom entries — including removed built-ins the user still sits on — so a current model that is absent from the plan is precisely a model that was never this provider's to migrate.

## Why it's needed

Fixes #8863 (P1): when the current `model.name` belongs to another provider (a self-hosted gateway, another vendor on the same protocol), `Update all` silently rewrote it to the updating provider's first built-in model and cleared `model.baseUrl`, while the toast claimed the opposite. All 11 built-in providers hit this with different overwrite targets, and with several providers updating in one confirmation each rewrote `model.name` in turn — the last one in registry order won. This is the unfinished half of #5819 (which caused real monetary damage); the #5835 guard in `applyProviderInstallPlan` only matches models the plan itself offers, so it never protected models owned elsewhere. The first-install path (`/auth`, where adopting the provider default is genuine intent) is untouched — this PR changes only the update path in `useProviderUpdates.ts`.

## Reviewer Test Plan

### How to verify

- `vitest run src/ui/hooks/useProviderUpdates.test.ts` in `packages/cli` — 20/20. Three new tests cover the single-provider overwrite, the misleading toast, and the multi-provider last-writer-wins case; the pre-existing `switches model when previous model is no longer available` test pinned the buggy migration and is inverted into `does not adopt the provider default when the previous model is gone from the plan` (rationale above).
- Mutation checks: commenting out the `delete installPlan.modelSelection` fails 4 tests (the 3 new ones + the inverted one); flipping the toast condition (`===` → `!==`) fails exactly the toast test.
- Full `src/ui/hooks/` slice: 69 files, 1448/1448. `tsc --noEmit` on `packages/cli`: clean.
- Live repro (issue #8863 script, `npm run bundle` build, isolated `$HOME`, real TUI dialog via tmux): see Evidence.

### Evidence (Before & After)

**Before (main @ 4bc75c2b)** — dialog confirmed with `Update all`, current model `my-own-model` owned by no built-in provider:

```
UI:   ●︎ Token Plan configuration updated successfully. Model switched to "my-own-model".
disk: model.name = "qwen3.7-plus"   (was "my-own-model")
      model.baseUrl = ""            (was "https://my-own-gateway.example.com/v1")
```

**After (this branch)** — same script, same dialog, same confirmation:

```
UI:   ●︎ Token Plan configuration updated successfully.
disk: model.name = "my-own-model"   (unchanged)
      model.baseUrl = "https://my-own-gateway.example.com/v1"   (unchanged)
```

The update itself still lands in both runs; verified after the fix: `providerMetadata.token-plan.version` advanced from the stale marker to the current hash, the provider's 15 refreshed built-ins are installed, and both the user's own entry and the provider-prefixed custom (`tp-custom`) are preserved (17 models total).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

`node dist/cli.js` from `npm run bundle`, driven in tmux with an isolated `$HOME` and the issue's dummy-key settings fixture; no real API traffic.

## Risk & Scope

- Main risk or tradeoff: the update path loses the "adopt the provider default when the current model vanished" migration — deliberately, since the carry of owned models into the plan makes that case unreachable except for models the provider never owned. If a genuine ownership-aware migration is wanted later, it needs the dialog to announce it explicitly (issue #8863's expected-behavior note); that is additive on top of this fix.
- Not validated / out of scope: the dialog's diff display still computes `currentModelAffected`/`fallbackModel` from built-in ids only (display-only, pre-existing); the `Model switched to` toast branch is kept for the case where `refreshAuth` genuinely changes the active model.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #8863. Refs #5819, #5835.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让内置 provider 模板更新路径不再触碰用户的模型选择。`executeUpdate` 现在无条件丢弃 install plan 的 `modelSelection`：选择 `Update all` 只刷新该 provider 的模型列表与版本元数据，任何情况下都不再改写 `model.name`、不再清空 `model.baseUrl`。完成提示改为只在活动模型真的变化时才报告切换，而不是按 plan 预测——旧代码正因此一边宣称 `Model switched to "<旧模型>"`，一边把另一个模型写进磁盘。

原来的条件删除（仅当 plan 仍提供当前模型时删 `modelSelection`）在所有正当情形下都是空操作、只在缺陷情形下生效：该 provider 名下的模型（包括用户仍在使用的已移除内置模型）都会作为自定义条目被携带进刷新后的 plan，因此「当前模型不在 plan 里」恰恰意味着它从来不归本 provider 管、更轮不到本次更新迁移。

## 为什么需要

修复 #8863（P1）：当前 `model.name` 属于其他 provider（自建网关、同协议下别家厂商）时，`Update all` 会把它静默改写为该 provider 内置列表第一个模型并清空 `model.baseUrl`，提示文案却反着说。全部 11 个内置 provider 都有此问题、覆写目标各不相同；多个 provider 在同一次确认里更新时逐个改写 `model.name`，注册表顺序最后的胜出。这是 #5819（造成过实际资金损失）的未完成修复：#5835 在 `applyProviderInstallPlan` 加的保护只匹配 plan 自己提供的模型，从未保护过别家模型。首次安装路径（`/auth`，采纳 provider 默认模型是真实意图）不受影响——本 PR 只改 `useProviderUpdates.ts` 的更新路径。

## 验证方式

- `packages/cli` 下 `vitest run src/ui/hooks/useProviderUpdates.test.ts` —— 20/20。三个新测试覆盖单 provider 覆写、误导性提示、多 provider 最后写入者胜出；既有的 `switches model when previous model is no longer available` 测试钉住的是缺陷迁移行为，已反转为 `does not adopt the provider default when the previous model is gone from the plan`（理由见上）。
- 变异检查：注释掉 `delete installPlan.modelSelection` 导致 4 个测试失败（3 个新测试 + 反转测试）；翻转提示条件（`===` → `!==`）恰好导致提示测试失败。
- `src/ui/hooks/` 全量切片：69 文件 1448/1448；`packages/cli` 的 `tsc --noEmit` 干净。
- 真实复现（issue #8863 脚本、`npm run bundle` 构建、隔离 `$HOME`、tmux 驱动真实 TUI 弹窗）：见证据一节。

## 风险与范围

- 主要取舍：更新路径不再有「当前模型消失时采纳 provider 默认」的迁移——这是有意的：owned 模型会被携带进 plan，该情形只在模型本就不归该 provider 时可达。若日后需要真正所有权感知的迁移，须让弹窗显式告知（issue 期望行为注记），可在本修复之上增量实现。
- 未验证/范围外：弹窗 diff 展示仍只按内置 id 计算 `currentModelAffected`/`fallbackModel`（纯展示、先前已有）；保留 `Model switched to` 提示分支以覆盖 `refreshAuth` 真的改变活动模型的情形。
- 破坏性变更：无。

## 关联 Issue

Fixes #8863；参考 #5819、#5835。

</details>
