### PR TITLE
fix(web-shell): improve ask user question keyboard interactions

### DIFF
--- a/docs/design/2026-08-10-web-shell-ask-user-question-keyboard.md
+++ b/docs/design/2026-08-10-web-shell-ask-user-question-keyboard.md
@@ -1,0 +1,39 @@
+# Web Shell Ask User Question Keyboard Interaction
+
+## Problem
+
+The Web Shell question overlay supports keyboard navigation within one option
+list, but keyboard flow breaks when users move between questions, enter a custom
+answer, or reach the final action. Returning to an answered question can also
+place focus on a different option than the checked answer.
+
+## Interaction contract
+
+- Opening the topmost question focuses its current answer, or the first option
+  when the question has not been visited.
+- Up/Down and j/k move through options. In a single-select question, focus and
+  the checked answer move together. Space toggles the focused multi-select
+  option.
+- Enter advances to the next question. On the last question, it focuses Submit
+  so submission remains an explicit action.
+- Previous and Next move focus into the destination question, preserving its
+  checked option or custom-answer trigger.
+- Command/Ctrl+Enter submits when every question has an answer.
+- Escape while editing a custom answer exits editing, preserves the text, and
+  restores focus to the Other trigger. Escape elsewhere cancels the request, so
+  pressing Escape a second time after leaving the input cancels.
+- A short contextual hint makes the available keys visible.
+
+## Accessibility
+
+The overlay is a non-modal multi-step form rather than a brief urgent alert, so
+it uses `role="dialog"` without `aria-modal`. Existing `radiogroup` and toggle
+button semantics remain. The current question continues to label the dialog and
+its option group.
+
+## Scope
+
+The change is limited to the Web Shell question component, its styles,
+translations, and focused component tests. The permission payload and daemon
+protocol do not change. Split-view panes keep their existing `keyboardActive`
+focus guard.

--- a/docs/design/2026-08-10-web-shell-ask-user-question-keyboard.md
+++ b/docs/design/2026-08-10-web-shell-ask-user-question-keyboard.md
@@ -14,15 +14,18 @@ place focus on a different option than the checked answer.
 - Up/Down and j/k move through options. In a single-select question, focus and
   the checked answer move together. Space toggles the focused multi-select
   option.
-- Enter advances to the next question. On the last question, it focuses Submit
-  so submission remains an explicit action.
+- Enter advances to the next question. On the last question, it submits the
+  current answers.
 - Previous and Next move focus into the destination question, preserving its
   checked option or custom-answer trigger.
-- Command/Ctrl+Enter submits when every question has an answer.
+- Left and Right perform the same navigation from any non-editable dialog
+  control.
+- Command/Ctrl+Enter submits the current answers from anywhere in the dialog.
 - Escape while editing a custom answer exits editing, preserves the text, and
   restores focus to the Other trigger. Escape elsewhere cancels the request, so
   pressing Escape a second time after leaving the input cancels.
 - A short contextual hint makes the available keys visible.
+- Action shortcuts are inactive while the dialog is collapsed.
 
 ## Accessibility
 

--- a/packages/web-shell/client/components/messages/AskUserQuestion.module.css
+++ b/packages/web-shell/client/components/messages/AskUserQuestion.module.css
@@ -1,5 +1,6 @@
 .question {
   position: relative;
+  container-type: inline-size;
   margin: 12px auto;
   width: 100%;
   max-width: min(800px, var(--chat-content-width, 800px));
@@ -182,7 +183,7 @@
   appearance: none;
 }
 
-.option:hover {
+.option:hover:not(.optionSelected) {
   background: var(--accent);
 }
 
@@ -196,15 +197,15 @@
   outline-offset: -2px;
 }
 
-.optionActive,
 .optionSelected {
-  background: var(--accent);
+  background: color-mix(in srgb, var(--primary) 8%, transparent);
+  box-shadow: inset 0 0 0 1px
+    color-mix(in srgb, var(--primary) 22%, transparent);
   color: var(--foreground);
 }
 
-.optionActive .optionLabel {
-  font-weight: 500;
-  color: var(--foreground);
+.optionSelected:hover {
+  background: color-mix(in srgb, var(--primary) 12%, transparent);
 }
 
 .pointer {
@@ -248,13 +249,11 @@
   stroke-width: 1.25;
 }
 
-.optionActive .optionNum,
 .optionSelected .optionNum {
   background: var(--primary);
   color: var(--primary-foreground);
 }
 
-.optionActive .editIcon,
 .optionSelected .editIcon {
   background: var(--primary);
   color: var(--primary-foreground);
@@ -291,13 +290,16 @@
 .customInput {
   flex: 1;
   min-width: 0;
-  padding: 4px 0;
+  height: 22px;
+  box-sizing: border-box;
+  padding: 0;
   background: transparent;
   border: none;
   border-bottom: 1px solid var(--border);
   color: var(--foreground);
   font-family: var(--font-sans, system-ui, sans-serif);
   font-size: 14px;
+  line-height: 22px;
   outline: none;
 }
 
@@ -388,12 +390,28 @@
   border-color: transparent;
 }
 
+.actions > [data-shortcut]::after {
+  height: 16px;
+  box-sizing: border-box;
+  padding: 0 4px;
+  border: 1px solid color-mix(in srgb, currentColor 25%, transparent);
+  border-radius: 4px;
+  content: attr(data-shortcut);
+  font-size: 9px;
+  font-weight: 500;
+  line-height: 14px;
+  opacity: 0.65;
+}
+
 .submitSpinner {
   width: 14px;
   height: 14px;
 }
 
 .ignoreButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   height: 28px;
   padding: 0;
   border: 0;
@@ -413,4 +431,10 @@
 .ignoreButton:disabled {
   cursor: not-allowed;
   opacity: 0.6;
+}
+
+@container (max-width: 420px) {
+  .actions > [data-shortcut]::after {
+    display: none;
+  }
 }

--- a/packages/web-shell/client/components/messages/AskUserQuestion.module.css
+++ b/packages/web-shell/client/components/messages/AskUserQuestion.module.css
@@ -345,7 +345,7 @@
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  gap: 16px;
+  gap: 8px;
   margin-top: 24px;
 }
 

--- a/packages/web-shell/client/components/messages/AskUserQuestion.module.css
+++ b/packages/web-shell/client/components/messages/AskUserQuestion.module.css
@@ -330,10 +330,15 @@
 }
 
 .shortcuts {
-  margin: 12px 0 0;
+  flex: 0 1 auto;
+  min-width: 0;
+  margin: 0 auto 0 0;
+  overflow: hidden;
   color: var(--muted-foreground);
   font-size: 11px;
   line-height: 16px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .actions {
@@ -342,6 +347,10 @@
   align-items: center;
   gap: 16px;
   margin-top: 24px;
+}
+
+.actions > button {
+  flex: 0 0 auto;
 }
 
 .button {

--- a/packages/web-shell/client/components/messages/AskUserQuestion.module.css
+++ b/packages/web-shell/client/components/messages/AskUserQuestion.module.css
@@ -329,6 +329,13 @@
   border-bottom-color: var(--agent-blue-500);
 }
 
+.shortcuts {
+  margin: 12px 0 0;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  line-height: 16px;
+}
+
 .actions {
   display: flex;
   justify-content: flex-end;

--- a/packages/web-shell/client/components/messages/AskUserQuestion.test.tsx
+++ b/packages/web-shell/client/components/messages/AskUserQuestion.test.tsx
@@ -462,6 +462,16 @@ describe('AskUserQuestion accessibility', () => {
     expect(event.defaultPrevented).toBe(false);
     expect(container!.querySelector('input')).toBe(input);
     expect(onConfirm).not.toHaveBeenCalled();
+
+    const keyCodeEvent = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+    });
+    Object.defineProperty(keyCodeEvent, 'keyCode', { value: 229 });
+    act(() => input.dispatchEvent(keyCodeEvent));
+    expect(keyCodeEvent.defaultPrevented).toBe(false);
+    expect(container!.querySelector('input')).toBe(input);
   });
 
   it('does not apply option shortcuts when focus is on an action button', () => {
@@ -670,6 +680,24 @@ describe('AskUserQuestion multiple questions', () => {
       'Enter confirm · Esc stop editing',
     );
   });
+
+  it('confirms a custom answer with Enter and advances', () => {
+    render(undefined, multipleQuestionsRequest);
+    act(() => optionButtons()[2]!.click());
+    const input = container!.querySelector<HTMLInputElement>('input')!;
+    act(() => {
+      Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        'value',
+      )?.set?.call(input, 'Purple');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    pressKey(input, 'Enter');
+
+    expect(container!.textContent).toContain('Pick a size');
+    expect(document.activeElement).toBe(optionButtons()[0]);
+  });
 });
 
 describe('AskUserQuestion multi-select', () => {
@@ -733,6 +761,10 @@ describe('AskUserQuestion multi-select', () => {
     pressKey(first, 'Enter');
 
     expect(container!.textContent).toContain('Pick a color');
-    expect(first.getAttribute('aria-pressed')).toBe('true');
+    const previous = Array.from(
+      container!.querySelectorAll<HTMLButtonElement>('button'),
+    ).find((button) => button.textContent === 'previous')!;
+    act(() => previous.click());
+    expect(optionButtons()[0]!.getAttribute('aria-pressed')).toBe('true');
   });
 });

--- a/packages/web-shell/client/components/messages/AskUserQuestion.test.tsx
+++ b/packages/web-shell/client/components/messages/AskUserQuestion.test.tsx
@@ -501,6 +501,17 @@ describe('AskUserQuestion accessibility', () => {
     expect(onConfirm).toHaveBeenCalledWith('req-1', 'cancel', undefined);
   });
 
+  it('submits a single question directly with Enter', () => {
+    render();
+    act(() => optionButtons()[1]!.click());
+
+    pressKey(optionButtons()[1]!, 'Enter');
+
+    expect(onConfirm).toHaveBeenCalledWith('req-1', 'submit', {
+      '0': 'Blue',
+    });
+  });
+
   it('keeps an accepted submission locked while awaiting resolution', async () => {
     const pending = deferred<boolean>();
     onConfirm.mockReturnValue(pending.promise);
@@ -644,13 +655,15 @@ describe('AskUserQuestion multiple questions', () => {
     expect(document.activeElement).toBe(restoredOptions[1]);
   });
 
-  it('focuses Submit instead of submitting when Enter is pressed on the last question', () => {
+  it('submits directly when Enter is pressed on the last question', () => {
     render(undefined, multipleQuestionsRequest);
     pressKey(optionButtons()[0]!, 'Enter');
     pressKey(optionButtons()[0]!, 'Enter');
 
-    expect(onConfirm).not.toHaveBeenCalled();
-    expect(document.activeElement).toBe(submitButton());
+    expect(onConfirm).toHaveBeenCalledWith('req-multiple', 'submit', {
+      '0': 'Red',
+      '1': 'Small',
+    });
   });
 
   it('submits all answers with Command/Ctrl+Enter when complete', () => {
@@ -678,10 +691,22 @@ describe('AskUserQuestion multiple questions', () => {
   });
 
   it('shows contextual keyboard hints', () => {
+    render();
+    expect(container!.textContent).toContain(
+      '↑↓ select · Enter submit · Esc ignore',
+    );
+    expect(container!.textContent).not.toContain('⌘/Ctrl+Enter');
+
+    act(() => root?.unmount());
+    container?.remove();
+    root = null;
+    container = null;
+
     render(undefined, multipleQuestionsRequest);
     expect(container!.textContent).toContain(
       '↑↓ select · Enter next · Esc ignore',
     );
+    expect(container!.textContent).toContain('⌘/Ctrl+Enter submit');
 
     act(() => optionButtons()[2]!.click());
     expect(container!.textContent).toContain(

--- a/packages/web-shell/client/components/messages/AskUserQuestion.test.tsx
+++ b/packages/web-shell/client/components/messages/AskUserQuestion.test.tsx
@@ -738,6 +738,24 @@ describe('AskUserQuestion multiple questions', () => {
     expect(container!.textContent).toContain('Enter next · Esc stop editing');
   });
 
+  it('keeps the shortcut footer hidden while the dialog is collapsed', () => {
+    render();
+    const panel = container!.querySelector('[data-web-shell-ask-panel]')!;
+    const collapse = container!.querySelector<HTMLButtonElement>(
+      '[aria-label="Collapse"]',
+    )!;
+
+    act(() => collapse.click());
+
+    expect(panel.getAttribute('aria-labelledby')).toBeNull();
+    expect(container!.textContent).not.toContain('Enter submit');
+    const expand = container!.querySelector<HTMLButtonElement>(
+      '[aria-label="Expand"]',
+    )!;
+    act(() => expand.click());
+    expect(container!.textContent).toContain('Enter submit');
+  });
+
   it('does not advertise the global submit shortcut on the last question', () => {
     render(undefined, multipleQuestionsRequest);
     pressKey(optionButtons()[0]!, 'Enter');

--- a/packages/web-shell/client/components/messages/AskUserQuestion.test.tsx
+++ b/packages/web-shell/client/components/messages/AskUserQuestion.test.tsx
@@ -381,6 +381,16 @@ describe('AskUserQuestion accessibility', () => {
     expect(document.activeElement).toBe(optionButtons()[0]);
   });
 
+  it('handles a shorter new request while viewing a later question', () => {
+    render(undefined, multipleQuestionsRequest);
+    pressKey(optionButtons()[0]!, 'Enter');
+
+    expect(() =>
+      rerender(undefined, { ...request, id: 'req-shorter' }),
+    ).not.toThrow();
+    expect(container!.textContent).toContain('Pick a color');
+  });
+
   it('advances on rapid repeated ArrowDown without a re-render in between', () => {
     // Regression: moveSelection must write selectedIdxRef synchronously, else a
     // held key (repeating faster than React re-renders) reads a stale ref and

--- a/packages/web-shell/client/components/messages/AskUserQuestion.test.tsx
+++ b/packages/web-shell/client/components/messages/AskUserQuestion.test.tsx
@@ -58,6 +58,26 @@ const multiRequest: PermissionRequest = {
   },
 };
 
+const multipleQuestionsRequest: PermissionRequest = {
+  ...request,
+  id: 'req-multiple',
+  rawInput: {
+    questions: [
+      ...(request.rawInput?.questions as NonNullable<
+        PermissionRequest['rawInput']
+      >['questions']),
+      {
+        question: 'Pick a size',
+        header: 'Size',
+        options: [
+          { label: 'Small', description: 'compact' },
+          { label: 'Large', description: 'roomy' },
+        ],
+      },
+    ],
+  },
+};
+
 let root: Root | null = null;
 let container: HTMLDivElement | null = null;
 let onConfirm: ReturnType<typeof vi.fn>;
@@ -123,9 +143,15 @@ function submitButton(): HTMLButtonElement | null {
   );
 }
 
-function pressKey(target: Element, key: string): void {
+function pressKey(
+  target: Element,
+  key: string,
+  init: Omit<KeyboardEventInit, 'key' | 'bubbles'> = {},
+): void {
   act(() => {
-    target.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+    target.dispatchEvent(
+      new KeyboardEvent('keydown', { key, bubbles: true, ...init }),
+    );
   });
 }
 
@@ -144,10 +170,11 @@ function deferred<T>(): {
 }
 
 describe('AskUserQuestion accessibility', () => {
-  it('exposes an alertdialog of real buttons and focuses the first option', () => {
+  it('exposes a non-modal dialog of real buttons and focuses the first option', () => {
     render(undefined);
     const panel = container!.querySelector('[data-web-shell-ask-panel]');
-    expect(panel?.getAttribute('role')).toBe('alertdialog');
+    expect(panel?.getAttribute('role')).toBe('dialog');
+    expect(panel?.hasAttribute('aria-modal')).toBe(false);
 
     // Two answer options + the "Other" trigger.
     const opts = optionButtons();
@@ -391,40 +418,73 @@ describe('AskUserQuestion accessibility', () => {
     expect(event.defaultPrevented).toBe(false);
   });
 
-  it('ignores option shortcuts when focus is on an action button, not an option', () => {
+  it('exits custom-input editing on Escape, then cancels on a second Escape', () => {
     render(undefined);
-    // Click Blue so it is the committed single-select answer (arrow keys only
-    // move the highlight; they don't change the answer).
+    act(() => {
+      optionButtons()[2]!.click();
+    });
+    const input = container!.querySelector<HTMLInputElement>('input')!;
+    act(() => {
+      Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        'value',
+      )?.set?.call(input, 'Purple');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    pressKey(input, 'Escape');
+
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(container!.querySelector('input')).toBeNull();
+    const other = optionButtons()[2]!;
+    expect(other.textContent).toContain('Purple');
+    expect(document.activeElement).toBe(other);
+
+    pressKey(other, 'Escape');
+    expect(onConfirm).toHaveBeenCalledWith('req-1', 'cancel', undefined);
+  });
+
+  it('leaves custom-input Escape to an active IME composition', () => {
+    render(undefined);
+    act(() => {
+      optionButtons()[2]!.click();
+    });
+    const input = container!.querySelector<HTMLInputElement>('input')!;
+    const event = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+    });
+    Object.defineProperty(event, 'isComposing', { value: true });
+
+    act(() => input.dispatchEvent(event));
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(container!.querySelector('input')).toBe(input);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('does not apply option shortcuts when focus is on an action button', () => {
+    render(undefined);
     act(() => {
       optionButtons()[1]!.click();
     });
     const submit = submitButton()!;
     submit.focus();
 
-    // Escape on Submit must not cancel the question...
-    act(() =>
-      submit.dispatchEvent(
-        new KeyboardEvent('keydown', {
-          key: 'Escape',
-          bubbles: true,
-          cancelable: true,
-        }),
-      ),
-    );
-    expect(onConfirm).not.toHaveBeenCalled();
-
-    // ...and a digit must not silently overwrite the selected answer.
-    act(() =>
-      submit.dispatchEvent(
-        new KeyboardEvent('keydown', {
-          key: '1',
-          bubbles: true,
-          cancelable: true,
-        }),
-      ),
-    );
+    pressKey(submit, '1', { cancelable: true });
     act(() => submit.click());
     expect(onConfirm).toHaveBeenCalledWith('req-1', 'submit', { '0': 'Blue' });
+  });
+
+  it('cancels on Escape from an action button', () => {
+    render(undefined);
+    const submit = submitButton()!;
+    submit.focus();
+
+    pressKey(submit, 'Escape', { cancelable: true });
+
+    expect(onConfirm).toHaveBeenCalledWith('req-1', 'cancel', undefined);
   });
 
   it('keeps an accepted submission locked while awaiting resolution', async () => {
@@ -540,6 +600,78 @@ describe('AskUserQuestion accessibility', () => {
   });
 });
 
+describe('AskUserQuestion multiple questions', () => {
+  it('advances with Enter and focuses the destination answer', () => {
+    render(undefined, multipleQuestionsRequest);
+    const firstQuestionOptions = optionButtons();
+    pressKey(firstQuestionOptions[0]!, 'ArrowDown');
+
+    pressKey(firstQuestionOptions[1]!, 'Enter');
+
+    expect(container!.textContent).toContain('Pick a size');
+    expect(document.activeElement).toBe(optionButtons()[0]);
+  });
+
+  it('restores focus to the checked answer when returning to a question', () => {
+    render(undefined, multipleQuestionsRequest);
+    pressKey(optionButtons()[0]!, 'ArrowDown');
+    const next = Array.from(
+      container!.querySelectorAll<HTMLButtonElement>('button'),
+    ).find((button) => button.textContent === 'next')!;
+    act(() => next.click());
+    const previous = Array.from(
+      container!.querySelectorAll<HTMLButtonElement>('button'),
+    ).find((button) => button.textContent === 'previous')!;
+
+    act(() => previous.click());
+
+    const restoredOptions = optionButtons();
+    expect(restoredOptions[1]!.getAttribute('aria-checked')).toBe('true');
+    expect(document.activeElement).toBe(restoredOptions[1]);
+  });
+
+  it('focuses Submit instead of submitting when Enter is pressed on the last question', () => {
+    render(undefined, multipleQuestionsRequest);
+    pressKey(optionButtons()[0]!, 'Enter');
+    pressKey(optionButtons()[0]!, 'Enter');
+
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(submitButton());
+  });
+
+  it('submits all answers with Command/Ctrl+Enter when complete', () => {
+    render(undefined, multipleQuestionsRequest);
+    pressKey(optionButtons()[0]!, 'Enter');
+
+    pressKey(optionButtons()[1]!, 'Enter', { ctrlKey: true });
+
+    expect(onConfirm).toHaveBeenCalledWith('req-multiple', 'submit', {
+      '0': 'Red',
+      '1': 'Small',
+    });
+  });
+
+  it('does not submit incomplete answers with Command/Ctrl+Enter', () => {
+    render(undefined, multipleQuestionsRequest);
+
+    pressKey(optionButtons()[0]!, 'Enter', { metaKey: true });
+
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('shows contextual keyboard hints', () => {
+    render(undefined, multipleQuestionsRequest);
+    expect(container!.textContent).toContain(
+      '↑↓ select · Enter next · Esc ignore',
+    );
+
+    act(() => optionButtons()[2]!.click());
+    expect(container!.textContent).toContain(
+      'Enter confirm · Esc stop editing',
+    );
+  });
+});
+
 describe('AskUserQuestion multi-select', () => {
   it('uses group + toggle-button semantics, not radiogroup', () => {
     render(undefined, multiRequest);
@@ -578,5 +710,29 @@ describe('AskUserQuestion multi-select', () => {
     expect(onConfirm).toHaveBeenCalledWith('req-multi', 'submit', {
       '0': 'Option B',
     });
+  });
+
+  it('uses Space to toggle and Enter to advance without toggling', () => {
+    const requestWithNextQuestion: PermissionRequest = {
+      ...multipleQuestionsRequest,
+      rawInput: {
+        questions: [
+          ...(multiRequest.rawInput?.questions as NonNullable<
+            PermissionRequest['rawInput']
+          >['questions']),
+          ...(request.rawInput?.questions as NonNullable<
+            PermissionRequest['rawInput']
+          >['questions']),
+        ],
+      },
+    };
+    render(undefined, requestWithNextQuestion);
+    const first = optionButtons()[0]!;
+    expect(first.getAttribute('aria-pressed')).toBe('true');
+
+    pressKey(first, 'Enter');
+
+    expect(container!.textContent).toContain('Pick a color');
+    expect(first.getAttribute('aria-pressed')).toBe('true');
   });
 });

--- a/packages/web-shell/client/components/messages/AskUserQuestion.test.tsx
+++ b/packages/web-shell/client/components/messages/AskUserQuestion.test.tsx
@@ -864,6 +864,7 @@ describe('AskUserQuestion multi-select', () => {
       'Space toggle · Enter submit · Esc ignore',
     );
     expect(container!.textContent).not.toContain('⌘/Ctrl+Enter');
+    act(() => optionButtons()[0]!.click());
     pressKey(optionButtons()[0]!, 'Enter');
 
     expect(onConfirm).toHaveBeenCalledWith('req-multi', 'submit', {
@@ -879,23 +880,52 @@ describe('AskUserQuestion multi-select', () => {
 
     // Multi-select options are toggle buttons (aria-pressed), not radios.
     const opts = optionButtons();
-    expect(opts[0]!.getAttribute('aria-pressed')).toBe('true'); // default: first
+    expect(opts[0]!.getAttribute('aria-pressed')).toBe('false');
+    expect(opts[0]!.tabIndex).toBe(0);
+    expect(submitButton()!.disabled).toBe(true);
     expect(opts[0]!.hasAttribute('aria-checked')).toBe(false);
     expect(opts[0]!.getAttribute('role')).not.toBe('radio');
+  });
+
+  it('does not select the first option when navigating to a multi-select question', () => {
+    const requestWithMultiSecond: PermissionRequest = {
+      ...multipleQuestionsRequest,
+      rawInput: {
+        questions: [
+          ...(request.rawInput?.questions as NonNullable<
+            PermissionRequest['rawInput']
+          >['questions']),
+          ...(multiRequest.rawInput?.questions as NonNullable<
+            PermissionRequest['rawInput']
+          >['questions']),
+        ],
+      },
+    };
+    render(undefined, requestWithMultiSecond);
+
+    pressKey(optionButtons()[0]!, 'Enter');
+
+    const opts = optionButtons();
+    expect(opts[0]!.getAttribute('aria-pressed')).toBe('false');
+    expect(opts[0]!.tabIndex).toBe(0);
+    expect(submitButton()!.disabled).toBe(true);
   });
 
   it('toggles options and submits the joined selection', () => {
     render(undefined, multiRequest);
     const opts = optionButtons();
-    // First option is selected by default.
-    expect(opts[0]!.getAttribute('aria-pressed')).toBe('true');
+    expect(opts[0]!.getAttribute('aria-pressed')).toBe('false');
     expect(opts[1]!.getAttribute('aria-pressed')).toBe('false');
 
-    // Toggle Option B on, then Option A off.
+    // Toggle Option B on, then Option A on and off.
     act(() => {
       opts[1]!.click();
     });
     expect(opts[1]!.getAttribute('aria-pressed')).toBe('true');
+    act(() => {
+      opts[0]!.click();
+    });
+    expect(opts[0]!.getAttribute('aria-pressed')).toBe('true');
     act(() => {
       opts[0]!.click();
     });
@@ -931,12 +961,12 @@ describe('AskUserQuestion multi-select', () => {
       options[2]!.click();
     });
 
-    expect(options[0]!.getAttribute('aria-pressed')).toBe('true');
+    expect(options[0]!.getAttribute('aria-pressed')).toBe('false');
     expect(options[1]!.getAttribute('aria-pressed')).toBe('true');
     expect(options[2]!.getAttribute('aria-pressed')).toBe('true');
   });
 
-  it('uses Space to toggle and Enter to advance without toggling', () => {
+  it('uses Enter to advance without toggling the selected option', () => {
     const requestWithNextQuestion: PermissionRequest = {
       ...multipleQuestionsRequest,
       rawInput: {
@@ -952,6 +982,9 @@ describe('AskUserQuestion multi-select', () => {
     };
     render(undefined, requestWithNextQuestion);
     const first = optionButtons()[0]!;
+    expect(first.getAttribute('aria-pressed')).toBe('false');
+
+    act(() => first.click());
     expect(first.getAttribute('aria-pressed')).toBe('true');
 
     pressKey(first, 'Enter');

--- a/packages/web-shell/client/components/messages/AskUserQuestion.test.tsx
+++ b/packages/web-shell/client/components/messages/AskUserQuestion.test.tsx
@@ -522,6 +522,43 @@ describe('AskUserQuestion accessibility', () => {
     });
   });
 
+  it('restores option navigation with arrows from another dialog control', () => {
+    render(undefined);
+    const submit = submitButton()!;
+    submit.focus();
+
+    pressKey(submit, 'ArrowDown');
+
+    expect(document.activeElement).toBe(optionButtons()[0]);
+    expect(optionButtons()[0]!.getAttribute('aria-checked')).toBe('true');
+
+    pressKey(optionButtons()[0]!, 'ArrowDown');
+    expect(document.activeElement).toBe(optionButtons()[1]);
+  });
+
+  it('keeps keyboard navigation scoped after clicking dialog content', () => {
+    render(undefined);
+    const panel = container!.querySelector<HTMLElement>(
+      '[data-web-shell-ask-panel]',
+    )!;
+    const questionText = Array.from(panel.querySelectorAll('p')).find(
+      (element) => element.textContent === 'Pick a color',
+    )!;
+
+    act(() => {
+      questionText.dispatchEvent(
+        new MouseEvent('mousedown', { bubbles: true }),
+      );
+    });
+    expect(document.activeElement).toBe(panel);
+
+    pressKey(panel, 'ArrowDown');
+    expect(document.activeElement).toBe(optionButtons()[0]);
+
+    pressKey(optionButtons()[0]!, 'ArrowDown');
+    expect(document.activeElement).toBe(optionButtons()[1]);
+  });
+
   it('submits a custom answer for a single question with Enter', () => {
     render();
     act(() => optionButtons()[2]!.click());
@@ -684,6 +721,21 @@ describe('AskUserQuestion multiple questions', () => {
     expect(document.activeElement).toBe(restoredOptions[1]);
   });
 
+  it('moves between questions with horizontal arrows from an option', () => {
+    render(undefined, multipleQuestionsRequest);
+    pressKey(optionButtons()[0]!, 'Enter');
+
+    expect(container!.textContent).toContain('← previous · ↑↓ select');
+    pressKey(optionButtons()[0]!, 'ArrowLeft');
+
+    expect(container!.textContent).toContain('Pick a color');
+    expect(container!.textContent).not.toContain('← previous');
+
+    pressKey(optionButtons()[0]!, 'ArrowRight');
+    expect(container!.textContent).toContain('Pick a size');
+    expect(container!.textContent).not.toContain('→ next');
+  });
+
   it('submits directly when Enter is pressed on the last question', () => {
     render(undefined, multipleQuestionsRequest);
     pressKey(optionButtons()[0]!, 'Enter');
@@ -707,7 +759,7 @@ describe('AskUserQuestion multiple questions', () => {
     });
   });
 
-  it('does not submit incomplete answers with Command/Ctrl+Enter', () => {
+  it('submits incomplete answers with Command/Ctrl+Enter', () => {
     render(undefined, multipleQuestionsRequest);
 
     const event = pressKey(optionButtons()[0]!, 'Enter', {
@@ -716,14 +768,32 @@ describe('AskUserQuestion multiple questions', () => {
     });
 
     expect(event.defaultPrevented).toBe(true);
-    expect(onConfirm).not.toHaveBeenCalled();
+    expect(onConfirm).toHaveBeenCalledWith('req-multiple', 'submit', {
+      '0': 'Red',
+      '1': '',
+    });
+  });
+
+  it('associates global shortcuts with their action buttons', () => {
+    render();
+
+    const ignore = Array.from(container!.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Ignore',
+    )!;
+    expect(ignore.getAttribute('aria-keyshortcuts')).toBe('Escape');
+    expect(ignore.dataset.shortcut).toBe('Esc');
+
+    const submit = submitButton()!;
+    expect(submit.getAttribute('aria-keyshortcuts')).toBe(
+      'Control+Enter Meta+Enter',
+    );
+    expect(submit.dataset.shortcut).toMatch(/^(Ctrl↵|⌘↵)$/);
   });
 
   it('shows contextual keyboard hints', () => {
     render();
-    expect(container!.textContent).toContain(
-      '↑↓ select · Enter submit · Esc ignore',
-    );
+    expect(container!.textContent).toContain('↑↓ select · Enter submit');
+    expect(container!.textContent).not.toContain('Esc ignore');
     expect(container!.textContent).not.toContain('⌘/Ctrl+Enter');
     const singleHint = Array.from(container!.querySelectorAll('p')).find(
       (element) => element.textContent?.includes('Enter submit'),
@@ -739,22 +809,21 @@ describe('AskUserQuestion multiple questions', () => {
     container = null;
 
     render(undefined, multipleQuestionsRequest);
-    expect(container!.textContent).toContain(
-      '↑↓ select · Enter next · Esc ignore',
-    );
-    expect(container!.textContent).toContain('⌘/Ctrl+Enter submit');
+    expect(container!.textContent).toContain('↑↓ select · Enter next');
+    expect(container!.textContent).not.toContain('Esc ignore');
+    expect(container!.textContent).not.toContain('⌘/Ctrl+Enter');
 
     act(() => optionButtons()[2]!.click());
     expect(container!.textContent).toContain('Enter next · Esc stop editing');
+    expect(container!.textContent).not.toContain('⌘/Ctrl+Enter');
   });
 
   it('describes Enter as editing when the empty custom row is focused', () => {
     render();
     pressKey(optionButtons()[0]!, 'End');
 
-    expect(container!.textContent).toContain(
-      '↑↓ select · Enter edit · Esc ignore',
-    );
+    expect(container!.textContent).toContain('↑↓ select · Enter edit');
+    expect(container!.textContent).not.toContain('Esc ignore');
     expect(container!.textContent).not.toContain('Enter submit');
 
     pressKey(optionButtons()[2]!, 'Enter');
@@ -783,9 +852,8 @@ describe('AskUserQuestion multiple questions', () => {
     render(undefined, multipleQuestionsRequest);
     pressKey(optionButtons()[0]!, 'Enter');
 
-    expect(container!.textContent).toContain(
-      '↑↓ select · Enter submit · Esc ignore',
-    );
+    expect(container!.textContent).toContain('↑↓ select · Enter submit');
+    expect(container!.textContent).not.toContain('Esc ignore');
     expect(container!.textContent).not.toContain('⌘/Ctrl+Enter');
 
     act(() => optionButtons()[2]!.click());
@@ -852,7 +920,7 @@ describe('AskUserQuestion multi-select', () => {
     pressKey(optionButtons()[0]!, 'Enter');
 
     expect(container!.textContent).toContain(
-      'Space toggle · Enter submit · Esc ignore',
+      '↑↓ move · Space select/deselect · Enter select & submit',
     );
     expect(container!.textContent).not.toContain('⌘/Ctrl+Enter');
   });
@@ -861,10 +929,9 @@ describe('AskUserQuestion multi-select', () => {
     render(undefined, multiRequest);
 
     expect(container!.textContent).toContain(
-      'Space toggle · Enter submit · Esc ignore',
+      '↑↓ move · Space select/deselect · Enter select & submit',
     );
     expect(container!.textContent).not.toContain('⌘/Ctrl+Enter');
-    act(() => optionButtons()[0]!.click());
     pressKey(optionButtons()[0]!, 'Enter');
 
     expect(onConfirm).toHaveBeenCalledWith('req-multi', 'submit', {
@@ -882,7 +949,7 @@ describe('AskUserQuestion multi-select', () => {
     const opts = optionButtons();
     expect(opts[0]!.getAttribute('aria-pressed')).toBe('false');
     expect(opts[0]!.tabIndex).toBe(0);
-    expect(submitButton()!.disabled).toBe(true);
+    expect(submitButton()!.disabled).toBe(false);
     expect(opts[0]!.hasAttribute('aria-checked')).toBe(false);
     expect(opts[0]!.getAttribute('role')).not.toBe('radio');
   });
@@ -908,7 +975,7 @@ describe('AskUserQuestion multi-select', () => {
     const opts = optionButtons();
     expect(opts[0]!.getAttribute('aria-pressed')).toBe('false');
     expect(opts[0]!.tabIndex).toBe(0);
-    expect(submitButton()!.disabled).toBe(true);
+    expect(submitButton()!.disabled).toBe(false);
   });
 
   it('toggles options and submits the joined selection', () => {
@@ -966,6 +1033,31 @@ describe('AskUserQuestion multi-select', () => {
     expect(options[2]!.getAttribute('aria-pressed')).toBe('true');
   });
 
+  it('keeps mouse focus changes separate from multi-select state', () => {
+    render(undefined, multiRequest);
+    const options = optionButtons();
+
+    act(() => {
+      options[1]!.focus();
+      options[1]!.click();
+    });
+    act(() => {
+      options[2]!.focus();
+      options[2]!.click();
+    });
+
+    expect(options[1]!.getAttribute('aria-pressed')).toBe('true');
+    expect(options[2]!.getAttribute('aria-pressed')).toBe('true');
+
+    act(() => {
+      options[1]!.focus();
+      options[1]!.click();
+    });
+
+    expect(options[1]!.getAttribute('aria-pressed')).toBe('false');
+    expect(options[2]!.getAttribute('aria-pressed')).toBe('true');
+  });
+
   it('uses Enter to advance without toggling the selected option', () => {
     const requestWithNextQuestion: PermissionRequest = {
       ...multipleQuestionsRequest,
@@ -995,5 +1087,70 @@ describe('AskUserQuestion multi-select', () => {
     ).find((button) => button.textContent === 'previous')!;
     act(() => previous.click());
     expect(optionButtons()[0]!.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('selects an unselected option with Enter before advancing', () => {
+    const requestWithNextQuestion: PermissionRequest = {
+      ...multipleQuestionsRequest,
+      rawInput: {
+        questions: [
+          ...(multiRequest.rawInput?.questions as NonNullable<
+            PermissionRequest['rawInput']
+          >['questions']),
+          ...(request.rawInput?.questions as NonNullable<
+            PermissionRequest['rawInput']
+          >['questions']),
+        ],
+      },
+    };
+    render(undefined, requestWithNextQuestion);
+
+    expect(container!.textContent).toContain(
+      '↑↓ move · Space select/deselect · Enter select & next',
+    );
+    expect(container!.textContent).not.toContain('⌘/Ctrl+Enter');
+    expect(container!.textContent).not.toContain('Esc ignore');
+    expect(optionButtons()[0]!.getAttribute('aria-pressed')).toBe('false');
+
+    pressKey(optionButtons()[0]!, 'Enter');
+
+    expect(container!.textContent).toContain('Pick a color');
+    const previous = Array.from(
+      container!.querySelectorAll<HTMLButtonElement>('button'),
+    ).find((button) => button.textContent === 'previous')!;
+    act(() => previous.click());
+    expect(optionButtons()[0]!.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('submits from the final multi-select question when an earlier answer is missing', () => {
+    const requestWithMultiFinal: PermissionRequest = {
+      ...multipleQuestionsRequest,
+      rawInput: {
+        questions: [
+          ...(request.rawInput?.questions as NonNullable<
+            PermissionRequest['rawInput']
+          >['questions']),
+          ...(multiRequest.rawInput?.questions as NonNullable<
+            PermissionRequest['rawInput']
+          >['questions']),
+        ],
+      },
+    };
+    render(undefined, requestWithMultiFinal);
+
+    pressKey(optionButtons()[0]!, 'End');
+    act(() => {
+      Array.from(container!.querySelectorAll<HTMLButtonElement>('button'))
+        .find((button) => button.textContent === 'next')!
+        .click();
+    });
+    pressKey(optionButtons()[0]!, 'Enter');
+
+    expect(optionButtons()[0]!.getAttribute('aria-pressed')).toBe('true');
+    expect(onConfirm).toHaveBeenCalledWith('req-multiple', 'submit', {
+      '0': '',
+      '1': 'Option A',
+    });
+    expect(submitButton()!.disabled).toBe(true);
   });
 });

--- a/packages/web-shell/client/components/messages/AskUserQuestion.test.tsx
+++ b/packages/web-shell/client/components/messages/AskUserQuestion.test.tsx
@@ -738,6 +738,19 @@ describe('AskUserQuestion multiple questions', () => {
     expect(container!.textContent).toContain('Enter next · Esc stop editing');
   });
 
+  it('describes Enter as editing when the empty custom row is focused', () => {
+    render();
+    pressKey(optionButtons()[0]!, 'End');
+
+    expect(container!.textContent).toContain(
+      '↑↓ select · Enter edit · Esc ignore',
+    );
+    expect(container!.textContent).not.toContain('Enter submit');
+
+    pressKey(optionButtons()[2]!, 'Enter');
+    expect(container!.querySelector('input')).not.toBeNull();
+  });
+
   it('keeps the shortcut footer hidden while the dialog is collapsed', () => {
     render();
     const panel = container!.querySelector('[data-web-shell-ask-panel]')!;

--- a/packages/web-shell/client/components/messages/AskUserQuestion.test.tsx
+++ b/packages/web-shell/client/components/messages/AskUserQuestion.test.tsx
@@ -910,6 +910,32 @@ describe('AskUserQuestion multi-select', () => {
     });
   });
 
+  it('cancels a selection when the same option is clicked twice rapidly', () => {
+    render(undefined, multiRequest);
+    const optionB = optionButtons()[1]!;
+
+    act(() => {
+      optionB.click();
+      optionB.click();
+    });
+
+    expect(optionB.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('preserves each selection when different options are clicked rapidly', () => {
+    render(undefined, multiRequest);
+    const options = optionButtons();
+
+    act(() => {
+      options[1]!.click();
+      options[2]!.click();
+    });
+
+    expect(options[0]!.getAttribute('aria-pressed')).toBe('true');
+    expect(options[1]!.getAttribute('aria-pressed')).toBe('true');
+    expect(options[2]!.getAttribute('aria-pressed')).toBe('true');
+  });
+
   it('uses Space to toggle and Enter to advance without toggling', () => {
     const requestWithNextQuestion: PermissionRequest = {
       ...multipleQuestionsRequest,

--- a/packages/web-shell/client/components/messages/AskUserQuestion.test.tsx
+++ b/packages/web-shell/client/components/messages/AskUserQuestion.test.tsx
@@ -715,6 +715,10 @@ describe('AskUserQuestion multiple questions', () => {
       '↑↓ select · Enter submit · Esc ignore',
     );
     expect(container!.textContent).not.toContain('⌘/Ctrl+Enter');
+    const singleHint = Array.from(container!.querySelectorAll('p')).find(
+      (element) => element.textContent?.includes('Enter submit'),
+    );
+    expect(singleHint?.parentElement).toBe(submitButton()?.parentElement);
     act(() => optionButtons()[2]!.click());
     expect(container!.textContent).toContain('Enter submit · Esc stop editing');
     expect(container!.textContent).not.toContain('⌘/Ctrl+Enter');
@@ -732,6 +736,20 @@ describe('AskUserQuestion multiple questions', () => {
 
     act(() => optionButtons()[2]!.click());
     expect(container!.textContent).toContain('Enter next · Esc stop editing');
+  });
+
+  it('does not advertise the global submit shortcut on the last question', () => {
+    render(undefined, multipleQuestionsRequest);
+    pressKey(optionButtons()[0]!, 'Enter');
+
+    expect(container!.textContent).toContain(
+      '↑↓ select · Enter submit · Esc ignore',
+    );
+    expect(container!.textContent).not.toContain('⌘/Ctrl+Enter');
+
+    act(() => optionButtons()[2]!.click());
+    expect(container!.textContent).toContain('Enter submit · Esc stop editing');
+    expect(container!.textContent).not.toContain('⌘/Ctrl+Enter');
   });
 
   it('confirms a custom answer with Enter and advances', () => {
@@ -775,6 +793,29 @@ describe('AskUserQuestion multiple questions', () => {
 });
 
 describe('AskUserQuestion multi-select', () => {
+  it('does not advertise the global submit shortcut on a final multi-select question', () => {
+    const requestWithMultiFinal: PermissionRequest = {
+      ...multipleQuestionsRequest,
+      rawInput: {
+        questions: [
+          ...(request.rawInput?.questions as NonNullable<
+            PermissionRequest['rawInput']
+          >['questions']),
+          ...(multiRequest.rawInput?.questions as NonNullable<
+            PermissionRequest['rawInput']
+          >['questions']),
+        ],
+      },
+    };
+    render(undefined, requestWithMultiFinal);
+    pressKey(optionButtons()[0]!, 'Enter');
+
+    expect(container!.textContent).toContain(
+      'Space toggle · Enter submit · Esc ignore',
+    );
+    expect(container!.textContent).not.toContain('⌘/Ctrl+Enter');
+  });
+
   it('submits a single multi-select question with Enter without advertising the global shortcut', () => {
     render(undefined, multiRequest);
 

--- a/packages/web-shell/client/components/messages/AskUserQuestion.test.tsx
+++ b/packages/web-shell/client/components/messages/AskUserQuestion.test.tsx
@@ -261,6 +261,33 @@ describe('AskUserQuestion accessibility', () => {
     expect(container!.querySelector('input')).not.toBeNull();
   });
 
+  it('keeps the custom input focused when its row padding is clicked', () => {
+    render(undefined);
+    act(() => optionButtons()[2]!.click());
+    const input = container!.querySelector<HTMLInputElement>('input')!;
+    const row = input.parentElement!;
+    expect(document.activeElement).toBe(input);
+
+    const inputMouseDown = new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    });
+    act(() => input.dispatchEvent(inputMouseDown));
+    expect(inputMouseDown.defaultPrevented).toBe(false);
+
+    const rowMouseDown = new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    });
+    act(() => {
+      row.dispatchEvent(rowMouseDown);
+    });
+
+    expect(rowMouseDown.defaultPrevented).toBe(true);
+    expect(container!.querySelector('input')).toBe(input);
+    expect(document.activeElement).toBe(input);
+  });
+
   it('names the expanded dialog with both the tool name and the question', () => {
     render(undefined);
     const panel = container!.querySelector('[data-web-shell-ask-panel]')!;
@@ -389,6 +416,37 @@ describe('AskUserQuestion accessibility', () => {
       rerender(undefined, { ...request, id: 'req-shorter' }),
     ).not.toThrow();
     expect(container!.textContent).toContain('Pick a color');
+    expect(document.activeElement).toBe(optionButtons()[0]);
+  });
+
+  it('focuses the first question when a same-length new request arrives', () => {
+    render(undefined, multipleQuestionsRequest);
+    pressKey(optionButtons()[0]!, 'Enter');
+    expect(container!.textContent).toContain('Pick a size');
+
+    const replacementRequest: PermissionRequest = {
+      ...multipleQuestionsRequest,
+      id: 'req-replacement',
+      rawInput: {
+        questions: [
+          {
+            question: 'Pick a shape',
+            header: 'Shape',
+            options: [{ label: 'Circle', description: 'round' }],
+          },
+          {
+            question: 'Pick a speed',
+            header: 'Speed',
+            options: [{ label: 'Fast', description: 'quick' }],
+          },
+        ],
+      },
+    };
+    rerender(undefined, replacementRequest);
+
+    expect(container!.textContent).toContain('Pick a shape');
+    expect(optionButtons()[0]!.textContent).toContain('Circle');
+    expect(document.activeElement).toBe(optionButtons()[0]);
   });
 
   it('advances on rapid repeated ArrowDown without a re-render in between', () => {
@@ -488,6 +546,45 @@ describe('AskUserQuestion accessibility', () => {
     expect(container!.querySelector('input')).toBe(input);
   });
 
+  it('leaves custom-input Enter to an active IME composition', () => {
+    render(undefined);
+    act(() => {
+      optionButtons()[2]!.click();
+    });
+    const input = container!.querySelector<HTMLInputElement>('input')!;
+    act(() => {
+      Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        'value',
+      )?.set?.call(input, 'Purple');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    const composingEvent = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+      cancelable: true,
+    });
+    Object.defineProperty(composingEvent, 'isComposing', { value: true });
+    act(() => input.dispatchEvent(composingEvent));
+
+    expect(composingEvent.defaultPrevented).toBe(false);
+    expect(container!.querySelector('input')).toBe(input);
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    const keyCodeEvent = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+      cancelable: true,
+    });
+    Object.defineProperty(keyCodeEvent, 'keyCode', { value: 229 });
+    act(() => input.dispatchEvent(keyCodeEvent));
+
+    expect(keyCodeEvent.defaultPrevented).toBe(false);
+    expect(container!.querySelector('input')).toBe(input);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
   it('does not apply option shortcuts when focus is on an action button', () => {
     render(undefined);
     act(() => {
@@ -576,6 +673,83 @@ describe('AskUserQuestion accessibility', () => {
     expect(onConfirm).toHaveBeenCalledWith('req-1', 'submit', {
       '0': 'Purple',
     });
+  });
+
+  it('restores focus to the custom answer after Enter submission fails', async () => {
+    onConfirm.mockRejectedValueOnce(new Error('network unavailable'));
+    render();
+    act(() => optionButtons()[2]!.click());
+    const input = container!.querySelector<HTMLInputElement>('input')!;
+    act(() => {
+      Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        'value',
+      )?.set?.call(input, 'Purple');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    pressKey(input, 'Enter');
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const other = optionButtons()[2]!;
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'network unavailable' }),
+      'Failed to submit answer',
+    );
+    expect(other.textContent).toContain('Purple');
+    expect(document.activeElement).toBe(other);
+  });
+
+  it('does not restore custom answer focus after focus moves elsewhere', async () => {
+    const pending = deferred<boolean>();
+    onConfirm.mockReturnValueOnce(pending.promise);
+    const outsideButton = document.createElement('button');
+    document.body.appendChild(outsideButton);
+    render();
+    act(() => optionButtons()[2]!.click());
+    const input = container!.querySelector<HTMLInputElement>('input')!;
+    act(() => {
+      Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        'value',
+      )?.set?.call(input, 'Purple');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    pressKey(input, 'Enter');
+    outsideButton.focus();
+    await act(async () => {
+      pending.reject(new Error('network unavailable'));
+      await Promise.resolve();
+    });
+
+    expect(document.activeElement).toBe(outsideButton);
+    outsideButton.remove();
+  });
+
+  it('reopens a whitespace-only custom answer instead of submitting it', () => {
+    render();
+    act(() => optionButtons()[2]!.click());
+    const input = container!.querySelector<HTMLInputElement>('input')!;
+    act(() => {
+      Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        'value',
+      )?.set?.call(input, '   ');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    pressKey(input, 'Escape', { cancelable: true });
+    const other = optionButtons()[2]!;
+    pressKey(other, 'Enter', { cancelable: true });
+
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(container!.querySelector('input')).not.toBeNull();
+    expect(document.activeElement).toBe(
+      container!.querySelector<HTMLInputElement>('input'),
+    );
   });
 
   it('keeps an accepted submission locked while awaiting resolution', async () => {
@@ -736,6 +910,50 @@ describe('AskUserQuestion multiple questions', () => {
     expect(container!.textContent).not.toContain('→ next');
   });
 
+  it('moves between questions with horizontal arrows from an action button', () => {
+    render(undefined, multipleQuestionsRequest);
+    const next = Array.from(
+      container!.querySelectorAll<HTMLButtonElement>('button'),
+    ).find((button) => button.textContent === 'next')!;
+    act(() => next.click());
+    const submit = submitButton()!;
+    submit.focus();
+
+    pressKey(submit, 'ArrowLeft', { cancelable: true });
+    expect(container!.textContent).toContain('Pick a color');
+
+    submit.focus();
+    pressKey(submit, 'ArrowRight', { cancelable: true });
+    expect(container!.textContent).toContain('Pick a size');
+  });
+
+  it('does not restore the default answer when returning to empty Other', () => {
+    render(undefined, multipleQuestionsRequest);
+    pressKey(optionButtons()[0]!, 'End');
+    const next = Array.from(
+      container!.querySelectorAll<HTMLButtonElement>('button'),
+    ).find((button) => button.textContent === 'next')!;
+    act(() => next.click());
+    const previous = Array.from(
+      container!.querySelectorAll<HTMLButtonElement>('button'),
+    ).find((button) => button.textContent === 'previous')!;
+    act(() => previous.click());
+
+    const restoredOptions = optionButtons();
+    expect(document.activeElement).toBe(restoredOptions[2]);
+    expect(restoredOptions[0]!.getAttribute('aria-checked')).toBe('false');
+    expect(restoredOptions[1]!.getAttribute('aria-checked')).toBe('false');
+
+    pressKey(restoredOptions[2]!, 'Enter', {
+      ctrlKey: true,
+      cancelable: true,
+    });
+    expect(onConfirm).toHaveBeenCalledWith('req-multiple', 'submit', {
+      '0': '',
+      '1': 'Small',
+    });
+  });
+
   it('submits directly when Enter is pressed on the last question', () => {
     render(undefined, multipleQuestionsRequest);
     pressKey(optionButtons()[0]!, 'Enter');
@@ -774,6 +992,36 @@ describe('AskUserQuestion multiple questions', () => {
     });
   });
 
+  it.each([
+    ['Control', { ctrlKey: true }],
+    ['Command', { metaKey: true }],
+  ] as const)(
+    'submits from an intermediate custom input with %s+Enter',
+    (_modifier, modifierInit) => {
+      render(undefined, multipleQuestionsRequest);
+      act(() => optionButtons()[2]!.click());
+      const input = container!.querySelector<HTMLInputElement>('input')!;
+      act(() => {
+        Object.getOwnPropertyDescriptor(
+          HTMLInputElement.prototype,
+          'value',
+        )?.set?.call(input, 'Purple');
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+      });
+
+      const event = pressKey(input, 'Enter', {
+        ...modifierInit,
+        cancelable: true,
+      });
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(onConfirm).toHaveBeenCalledWith('req-multiple', 'submit', {
+        '0': 'Purple',
+        '1': '',
+      });
+    },
+  );
+
   it('associates global shortcuts with their action buttons', () => {
     render();
 
@@ -800,6 +1048,17 @@ describe('AskUserQuestion multiple questions', () => {
     );
     expect(singleHint?.parentElement).toBe(submitButton()?.parentElement);
     act(() => optionButtons()[2]!.click());
+    expect(container!.textContent).toContain(
+      'Type an answer · Esc stop editing',
+    );
+    const input = container!.querySelector<HTMLInputElement>('input')!;
+    act(() => {
+      Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        'value',
+      )?.set?.call(input, 'Purple');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
     expect(container!.textContent).toContain('Enter submit · Esc stop editing');
     expect(container!.textContent).not.toContain('⌘/Ctrl+Enter');
 
@@ -814,7 +1073,9 @@ describe('AskUserQuestion multiple questions', () => {
     expect(container!.textContent).not.toContain('⌘/Ctrl+Enter');
 
     act(() => optionButtons()[2]!.click());
-    expect(container!.textContent).toContain('Enter next · Esc stop editing');
+    expect(container!.textContent).toContain(
+      'Type an answer · Esc stop editing',
+    );
     expect(container!.textContent).not.toContain('⌘/Ctrl+Enter');
   });
 
@@ -848,6 +1109,28 @@ describe('AskUserQuestion multiple questions', () => {
     expect(container!.textContent).toContain('Enter submit');
   });
 
+  it('keeps action shortcuts inert while the dialog is collapsed', () => {
+    render(undefined, multipleQuestionsRequest);
+    const collapse = container!.querySelector<HTMLButtonElement>(
+      '[aria-label="Collapse"]',
+    )!;
+    act(() => collapse.click());
+    const expand = container!.querySelector<HTMLButtonElement>(
+      '[aria-label="Expand"]',
+    )!;
+
+    const escapeEvent = pressKey(expand, 'Escape', { cancelable: true });
+    const submitEvent = pressKey(expand, 'Enter', {
+      ctrlKey: true,
+      cancelable: true,
+    });
+
+    expect(escapeEvent.defaultPrevented).toBe(true);
+    expect(submitEvent.defaultPrevented).toBe(true);
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(container!.querySelector('[aria-label="Expand"]')).not.toBeNull();
+  });
+
   it('does not advertise the global submit shortcut on the last question', () => {
     render(undefined, multipleQuestionsRequest);
     pressKey(optionButtons()[0]!, 'Enter');
@@ -857,7 +1140,9 @@ describe('AskUserQuestion multiple questions', () => {
     expect(container!.textContent).not.toContain('⌘/Ctrl+Enter');
 
     act(() => optionButtons()[2]!.click());
-    expect(container!.textContent).toContain('Enter submit · Esc stop editing');
+    expect(container!.textContent).toContain(
+      'Type an answer · Esc stop editing',
+    );
     expect(container!.textContent).not.toContain('⌘/Ctrl+Enter');
   });
 
@@ -877,6 +1162,30 @@ describe('AskUserQuestion multiple questions', () => {
 
     expect(container!.textContent).toContain('Pick a size');
     expect(document.activeElement).toBe(optionButtons()[0]);
+  });
+
+  it('restores a custom answer and its focus when returning to a question', () => {
+    render(undefined, multipleQuestionsRequest);
+    act(() => optionButtons()[2]!.click());
+    const input = container!.querySelector<HTMLInputElement>('input')!;
+    act(() => {
+      Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        'value',
+      )?.set?.call(input, 'Purple');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    pressKey(input, 'Enter');
+    const previous = Array.from(
+      container!.querySelectorAll<HTMLButtonElement>('button'),
+    ).find((button) => button.textContent === 'previous')!;
+    act(() => previous.click());
+
+    const other = optionButtons()[2]!;
+    expect(other.textContent).toBe('Purple');
+    expect(other.getAttribute('aria-checked')).toBe('true');
+    expect(document.activeElement).toBe(other);
   });
 
   it('submits a custom answer with Enter on the last question', () => {
@@ -902,6 +1211,14 @@ describe('AskUserQuestion multiple questions', () => {
 });
 
 describe('AskUserQuestion multi-select', () => {
+  it('describes moving when the empty custom row is focused', () => {
+    render(undefined, multiRequest);
+    pressKey(optionButtons()[0]!, 'End');
+
+    expect(container!.textContent).toContain('↑↓ move · Enter edit');
+    expect(container!.textContent).not.toContain('↑↓ select · Enter edit');
+  });
+
   it('does not advertise the global submit shortcut on a final multi-select question', () => {
     const requestWithMultiFinal: PermissionRequest = {
       ...multipleQuestionsRequest,
@@ -1004,6 +1321,26 @@ describe('AskUserQuestion multi-select', () => {
     });
     expect(onConfirm).toHaveBeenCalledWith('req-multi', 'submit', {
       '0': 'Option B',
+    });
+  });
+
+  it('submits regular and custom multi-select answers together with Enter', () => {
+    render(undefined, multiRequest);
+    act(() => optionButtons()[1]!.click());
+    act(() => optionButtons()[3]!.click());
+    const input = container!.querySelector<HTMLInputElement>('input')!;
+    act(() => {
+      Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        'value',
+      )?.set?.call(input, 'Custom option');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    pressKey(input, 'Enter');
+
+    expect(onConfirm).toHaveBeenCalledWith('req-multi', 'submit', {
+      '0': 'Option B, Custom option',
     });
   });
 

--- a/packages/web-shell/client/components/messages/AskUserQuestion.test.tsx
+++ b/packages/web-shell/client/components/messages/AskUserQuestion.test.tsx
@@ -512,6 +512,25 @@ describe('AskUserQuestion accessibility', () => {
     });
   });
 
+  it('submits a custom answer for a single question with Enter', () => {
+    render();
+    act(() => optionButtons()[2]!.click());
+    const input = container!.querySelector<HTMLInputElement>('input')!;
+    act(() => {
+      Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        'value',
+      )?.set?.call(input, 'Purple');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    pressKey(input, 'Enter');
+
+    expect(onConfirm).toHaveBeenCalledWith('req-1', 'submit', {
+      '0': 'Purple',
+    });
+  });
+
   it('keeps an accepted submission locked while awaiting resolution', async () => {
     const pending = deferred<boolean>();
     onConfirm.mockReturnValue(pending.promise);
@@ -696,6 +715,9 @@ describe('AskUserQuestion multiple questions', () => {
       '↑↓ select · Enter submit · Esc ignore',
     );
     expect(container!.textContent).not.toContain('⌘/Ctrl+Enter');
+    act(() => optionButtons()[2]!.click());
+    expect(container!.textContent).toContain('Enter submit · Esc stop editing');
+    expect(container!.textContent).not.toContain('⌘/Ctrl+Enter');
 
     act(() => root?.unmount());
     container?.remove();
@@ -709,9 +731,7 @@ describe('AskUserQuestion multiple questions', () => {
     expect(container!.textContent).toContain('⌘/Ctrl+Enter submit');
 
     act(() => optionButtons()[2]!.click());
-    expect(container!.textContent).toContain(
-      'Enter confirm · Esc stop editing',
-    );
+    expect(container!.textContent).toContain('Enter next · Esc stop editing');
   });
 
   it('confirms a custom answer with Enter and advances', () => {
@@ -731,9 +751,44 @@ describe('AskUserQuestion multiple questions', () => {
     expect(container!.textContent).toContain('Pick a size');
     expect(document.activeElement).toBe(optionButtons()[0]);
   });
+
+  it('submits a custom answer with Enter on the last question', () => {
+    render(undefined, multipleQuestionsRequest);
+    pressKey(optionButtons()[0]!, 'Enter');
+    act(() => optionButtons()[2]!.click());
+    const input = container!.querySelector<HTMLInputElement>('input')!;
+    act(() => {
+      Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        'value',
+      )?.set?.call(input, 'Medium');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    pressKey(input, 'Enter');
+
+    expect(onConfirm).toHaveBeenCalledWith('req-multiple', 'submit', {
+      '0': 'Red',
+      '1': 'Medium',
+    });
+  });
 });
 
 describe('AskUserQuestion multi-select', () => {
+  it('submits a single multi-select question with Enter without advertising the global shortcut', () => {
+    render(undefined, multiRequest);
+
+    expect(container!.textContent).toContain(
+      'Space toggle · Enter submit · Esc ignore',
+    );
+    expect(container!.textContent).not.toContain('⌘/Ctrl+Enter');
+    pressKey(optionButtons()[0]!, 'Enter');
+
+    expect(onConfirm).toHaveBeenCalledWith('req-multi', 'submit', {
+      '0': 'Option A',
+    });
+  });
+
   it('uses group + toggle-button semantics, not radiogroup', () => {
     render(undefined, multiRequest);
     const panel = container!.querySelector('[data-web-shell-ask-panel]')!;

--- a/packages/web-shell/client/components/messages/AskUserQuestion.test.tsx
+++ b/packages/web-shell/client/components/messages/AskUserQuestion.test.tsx
@@ -147,12 +147,16 @@ function pressKey(
   target: Element,
   key: string,
   init: Omit<KeyboardEventInit, 'key' | 'bubbles'> = {},
-): void {
-  act(() => {
-    target.dispatchEvent(
-      new KeyboardEvent('keydown', { key, bubbles: true, ...init }),
-    );
+): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    bubbles: true,
+    ...init,
   });
+  act(() => {
+    target.dispatchEvent(event);
+  });
+  return event;
 }
 
 function deferred<T>(): {
@@ -664,8 +668,12 @@ describe('AskUserQuestion multiple questions', () => {
   it('does not submit incomplete answers with Command/Ctrl+Enter', () => {
     render(undefined, multipleQuestionsRequest);
 
-    pressKey(optionButtons()[0]!, 'Enter', { metaKey: true });
+    const event = pressKey(optionButtons()[0]!, 'Enter', {
+      metaKey: true,
+      cancelable: true,
+    });
 
+    expect(event.defaultPrevented).toBe(true);
     expect(onConfirm).not.toHaveBeenCalled();
   });
 

--- a/packages/web-shell/client/components/messages/AskUserQuestion.tsx
+++ b/packages/web-shell/client/components/messages/AskUserQuestion.tsx
@@ -519,29 +519,35 @@ export function AskUserQuestion({
   const displayIdx = Math.min(currentIdx, questions.length - 1);
   const isLastQuestion = currentIdx === questions.length - 1;
   const isSingleQuestion = questions.length === 1;
-  const shortcutHint = customFocused
-    ? t(
-        isSingleQuestion
-          ? 'askUser.shortcuts.inputSingle'
-          : isLastQuestion
-            ? 'askUser.shortcuts.inputFinal'
-            : 'askUser.shortcuts.inputNext',
-      )
-    : isMulti
+  const isEmptyCustomTrigger =
+    !customFocused &&
+    selectedIdx === current.options.length &&
+    !customInputs[currentIdx];
+  const shortcutHint = isEmptyCustomTrigger
+    ? t('askUser.shortcuts.customTrigger')
+    : customFocused
       ? t(
           isSingleQuestion
-            ? 'askUser.shortcuts.multiSingle'
+            ? 'askUser.shortcuts.inputSingle'
             : isLastQuestion
-              ? 'askUser.shortcuts.multiFinal'
-              : 'askUser.shortcuts.multiNext',
+              ? 'askUser.shortcuts.inputFinal'
+              : 'askUser.shortcuts.inputNext',
         )
-      : t(
-          isSingleQuestion
-            ? 'askUser.shortcuts.optionsSingle'
-            : isLastQuestion
-              ? 'askUser.shortcuts.optionsFinal'
-              : 'askUser.shortcuts.optionsNext',
-        );
+      : isMulti
+        ? t(
+            isSingleQuestion
+              ? 'askUser.shortcuts.multiSingle'
+              : isLastQuestion
+                ? 'askUser.shortcuts.multiFinal'
+                : 'askUser.shortcuts.multiNext',
+          )
+        : t(
+            isSingleQuestion
+              ? 'askUser.shortcuts.optionsSingle'
+              : isLastQuestion
+                ? 'askUser.shortcuts.optionsFinal'
+                : 'askUser.shortcuts.optionsNext',
+          );
 
   return (
     <div

--- a/packages/web-shell/client/components/messages/AskUserQuestion.tsx
+++ b/packages/web-shell/client/components/messages/AskUserQuestion.tsx
@@ -40,6 +40,10 @@ interface AskUserQuestionProps {
   keyboardActive?: boolean;
 }
 
+function hasCustomAnswer(value: string | undefined): boolean {
+  return Boolean(value?.trim());
+}
+
 export function AskUserQuestion({
   request,
   onConfirm,
@@ -80,6 +84,7 @@ export function AskUserQuestion({
   const selectedIdxByQuestionRef = useRef<Record<number, number | null>>({});
   const focusAfterQuestionChangeRef = useRef(false);
   const focusCustomTriggerAfterEditRef = useRef(false);
+  const focusCustomTriggerAfterSubmitFailureRef = useRef(false);
   selectedIdxRef.current = selectedIdx;
   const questionTextId = useId();
   const headingId = useId();
@@ -105,6 +110,7 @@ export function AskUserQuestion({
     setCustomInputs({});
     setSelectedMulti({});
     setCustomFocused(false);
+    focusCustomTriggerAfterSubmitFailureRef.current = false;
   }, [questions, request.id]);
 
   const current = questions[currentIdx];
@@ -130,10 +136,12 @@ export function AskUserQuestion({
         if (q.multiSelect) {
           const multi = multiSelections[i] || [];
           const custom = customInputs[i];
-          const all = custom ? [...multi, custom] : multi;
+          const all = hasCustomAnswer(custom) ? [...multi, custom] : multi;
           result[String(i)] = all.join(', ');
         } else {
-          result[String(i)] = answers[i] || customInputs[i] || '';
+          const custom = customInputs[i];
+          result[String(i)] =
+            answers[i] || (hasCustomAnswer(custom) ? custom : '');
         }
       }
       return result;
@@ -329,7 +337,9 @@ export function AskUserQuestion({
       }
       const question = questions[questionIdx];
       if (!question) return null;
-      if (customInputs[questionIdx]) return question.options.length;
+      if (hasCustomAnswer(customInputs[questionIdx])) {
+        return question.options.length;
+      }
       if (!question.multiSelect) {
         const answer = answers[questionIdx];
         const answerIdx = question.options.findIndex(
@@ -356,7 +366,10 @@ export function AskUserQuestion({
 
       if (question.multiSelect) return;
       setAnswers((prev) =>
-        prev[nextIdx] || customInputs[nextIdx] || !question.options[0]
+        prev[nextIdx] ||
+        hasCustomAnswer(customInputs[nextIdx]) ||
+        nextSelectedIdx === question.options.length ||
+        !question.options[0]
           ? prev
           : { ...prev, [nextIdx]: question.options[0].label },
       );
@@ -381,9 +394,19 @@ export function AskUserQuestion({
         selectQuestion(currentIdx + 1);
         return;
       }
+      if (customFocused) {
+        focusCustomTriggerAfterSubmitFailureRef.current = true;
+      }
       if (!submitting) handleSubmit(submittedAnswers);
     },
-    [currentIdx, handleSubmit, questions.length, selectQuestion, submitting],
+    [
+      currentIdx,
+      customFocused,
+      handleSubmit,
+      questions.length,
+      selectQuestion,
+      submitting,
+    ],
   );
 
   useEffect(() => {
@@ -400,6 +423,23 @@ export function AskUserQuestion({
     customRef.current?.focus();
   }, [customFocused]);
 
+  useEffect(() => {
+    if (
+      customFocused ||
+      submitting ||
+      !focusCustomTriggerAfterSubmitFailureRef.current
+    ) {
+      return;
+    }
+    focusCustomTriggerAfterSubmitFailureRef.current = false;
+    if (
+      document.activeElement === document.body ||
+      document.activeElement === document.documentElement
+    ) {
+      customRef.current?.focus();
+    }
+  }, [customFocused, submitting]);
+
   const handleCustomInputKeyDown = useCallback(
     (e: ReactKeyboardEvent<HTMLInputElement>) => {
       if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
@@ -409,7 +449,10 @@ export function AskUserQuestion({
         e.stopPropagation();
         focusCustomTriggerAfterEditRef.current = true;
         setCustomFocused(false);
-      } else if (e.key === 'Enter' && (customInputs[currentIdx] || '').trim()) {
+      } else if (
+        e.key === 'Enter' &&
+        hasCustomAnswer(customInputs[currentIdx])
+      ) {
         e.preventDefault();
         e.stopPropagation();
         advanceQuestion();
@@ -423,6 +466,15 @@ export function AskUserQuestion({
   const handleKeyDown = useCallback(
     (e: ReactKeyboardEvent<HTMLDivElement>) => {
       if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
+      if (collapsed) {
+        if (
+          e.key === 'Escape' ||
+          (e.key === 'Enter' && (e.ctrlKey || e.metaKey))
+        ) {
+          e.preventDefault();
+        }
+        return;
+      }
       if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
         e.preventDefault();
         if (!submitting) handleSubmit();
@@ -438,11 +490,14 @@ export function AskUserQuestion({
         '[data-web-shell-ask-option]',
       );
       if (!isOptionTarget) {
-        if (
-          !collapsed &&
-          current &&
-          (e.key === 'ArrowDown' || e.key === 'ArrowUp')
-        ) {
+        if (!current) return;
+        if (e.key === 'ArrowLeft') {
+          e.preventDefault();
+          handlePrevious();
+        } else if (e.key === 'ArrowRight') {
+          e.preventDefault();
+          handleNext();
+        } else if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
           e.preventDefault();
           selectIndex(selectedIdxRef.current ?? 0);
         }
@@ -471,7 +526,10 @@ export function AskUserQuestion({
       } else if (e.key === 'Enter') {
         e.preventDefault();
         const idx = selectedIdxRef.current ?? 0;
-        if (idx === current.options.length && !customInputs[currentIdx]) {
+        if (
+          idx === current.options.length &&
+          !hasCustomAnswer(customInputs[currentIdx])
+        ) {
           chooseOption(idx);
         } else {
           if (isMulti && idx < current.options.length) {
@@ -522,55 +580,63 @@ export function AskUserQuestion({
   // ToolApproval's matching effect for the prev-flag reasoning.
   const prevKeyboardActiveRef = useRef(false);
   const prevRequestIdRef = useRef(request.id);
-  const optionCountRef = useRef(current?.options.length ?? 0);
-  optionCountRef.current = current?.options.length ?? 0;
   useEffect(() => {
     const wasActive = prevKeyboardActiveRef.current;
     const prevRequestId = prevRequestIdRef.current;
     prevKeyboardActiveRef.current = keyboardActive;
+    if (!keyboardActive || !current) return;
+    const requestChanged = request.id !== prevRequestId;
+    if (requestChanged && currentIdx !== 0) return;
+    if (wasActive && !requestChanged) return;
     prevRequestIdRef.current = request.id;
-    if (!keyboardActive) return;
-    if (wasActive && request.id === prevRequestId) return;
     const idx = selectedIdxRef.current ?? 0;
-    if (idx === optionCountRef.current) customRef.current?.focus();
+    if (idx === current.options.length) customRef.current?.focus();
     else optionRefs.current[idx]?.focus();
-  }, [keyboardActive, request.id]);
+  }, [current, currentIdx, keyboardActive, request.id]);
 
   if (questions.length === 0) return null;
 
   const displayIdx = Math.min(currentIdx, questions.length - 1);
   const isLastQuestion = currentIdx === questions.length - 1;
   const isSingleQuestion = questions.length === 1;
+  const hasCurrentCustomAnswer = hasCustomAnswer(customInputs[currentIdx]);
   const isEmptyCustomTrigger =
     current !== undefined &&
     !customFocused &&
     selectedIdx === current.options.length &&
-    !customInputs[currentIdx];
-  const contextualShortcutHint = isEmptyCustomTrigger
-    ? t('askUser.shortcuts.customTrigger')
-    : customFocused
-      ? t(
-          isSingleQuestion
-            ? 'askUser.shortcuts.inputSingle'
-            : isLastQuestion
-              ? 'askUser.shortcuts.inputFinal'
-              : 'askUser.shortcuts.inputNext',
-        )
-      : isMulti
+    !hasCurrentCustomAnswer;
+  const contextualShortcutHint =
+    customFocused && !hasCurrentCustomAnswer
+      ? t('askUser.shortcuts.inputEmpty')
+      : isEmptyCustomTrigger
         ? t(
-            isSingleQuestion
-              ? 'askUser.shortcuts.multiSingle'
-              : isLastQuestion
-                ? 'askUser.shortcuts.multiFinal'
-                : 'askUser.shortcuts.multiNext',
+            isMulti
+              ? 'askUser.shortcuts.customTriggerMulti'
+              : 'askUser.shortcuts.customTrigger',
           )
-        : t(
-            isSingleQuestion
-              ? 'askUser.shortcuts.optionsSingle'
-              : isLastQuestion
-                ? 'askUser.shortcuts.optionsFinal'
-                : 'askUser.shortcuts.optionsNext',
-          );
+        : customFocused
+          ? t(
+              isSingleQuestion
+                ? 'askUser.shortcuts.inputSingle'
+                : isLastQuestion
+                  ? 'askUser.shortcuts.inputFinal'
+                  : 'askUser.shortcuts.inputNext',
+            )
+          : isMulti
+            ? t(
+                isSingleQuestion
+                  ? 'askUser.shortcuts.multiSingle'
+                  : isLastQuestion
+                    ? 'askUser.shortcuts.multiFinal'
+                    : 'askUser.shortcuts.multiNext',
+              )
+            : t(
+                isSingleQuestion
+                  ? 'askUser.shortcuts.optionsSingle'
+                  : isLastQuestion
+                    ? 'askUser.shortcuts.optionsFinal'
+                    : 'askUser.shortcuts.optionsNext',
+              );
   const shortcutHint =
     currentIdx > 0 && !customFocused
       ? `${t('askUser.shortcuts.previous')} · ${contextualShortcutHint}`
@@ -696,8 +762,8 @@ export function AskUserQuestion({
                         optionRefs.current[i] = el;
                       }}
                       className={`${styles.option} ${
-                        isActive ? styles.optionActive : ''
-                      } ${isSelected ? styles.optionSelected : ''}`}
+                        isSelected ? styles.optionSelected : ''
+                      }`}
                       data-web-shell-ask-option
                       tabIndex={isActive ? 0 : -1}
                       role={isMulti ? undefined : 'radio'}
@@ -729,12 +795,14 @@ export function AskUserQuestion({
                 {/* Other / custom input option */}
                 {(() => {
                   const isCustomActive = selectedIdx === current.options.length;
-                  const hasCustomValue = !!customInputs[currentIdx];
+                  const hasCustomValue = hasCustomAnswer(
+                    customInputs[currentIdx],
+                  );
                   return (
                     <div
                       className={`${styles.option} ${
-                        isCustomActive ? styles.optionActive : ''
-                      } ${hasCustomValue ? styles.optionSelected : ''}`}
+                        hasCustomValue ? styles.optionSelected : ''
+                      }`}
                       // The whole row is clickable (it carries cursor:pointer via
                       // styles.option), so clicks on the padding — not just the
                       // inner trigger/input — activate the "Other" option. The
@@ -742,6 +810,13 @@ export function AskUserQuestion({
                       // native Enter/Space activation) bubbles up to here.
                       onClick={() => {
                         if (!submitting) chooseOption(current.options.length);
+                      }}
+                      onMouseDown={(e) => {
+                        if (!customFocused || isEditableTarget(e.target)) {
+                          return;
+                        }
+                        e.preventDefault();
+                        e.stopPropagation();
                       }}
                     >
                       <span className={styles.pointer} aria-hidden="true">
@@ -788,9 +863,7 @@ export function AskUserQuestion({
                           type="button"
                           ref={customRef}
                           className={`${styles.customTrigger} ${
-                            customInputs[currentIdx]
-                              ? ''
-                              : styles.optionPlaceholder
+                            hasCustomValue ? '' : styles.optionPlaceholder
                           }`}
                           data-web-shell-ask-option
                           tabIndex={isCustomActive ? 0 : -1}
@@ -807,8 +880,9 @@ export function AskUserQuestion({
                             rememberSelectedIndex(current.options.length)
                           }
                         >
-                          {customInputs[currentIdx] ||
-                            t('askUser.typePlaceholder')}
+                          {hasCustomValue
+                            ? customInputs[currentIdx]
+                            : t('askUser.typePlaceholder')}
                         </button>
                       )}
                     </div>

--- a/packages/web-shell/client/components/messages/AskUserQuestion.tsx
+++ b/packages/web-shell/client/components/messages/AskUserQuestion.tsx
@@ -47,6 +47,11 @@ export function AskUserQuestion({
   variant = 'inline',
   keyboardActive = true,
 }: AskUserQuestionProps) {
+  const submitShortcutLabel =
+    typeof navigator !== 'undefined' &&
+    /Mac|iPhone|iPad|iPod/i.test(navigator.platform ?? '')
+      ? '⌘↵'
+      : 'Ctrl↵';
   const { t } = useI18n();
   const questions = useMemo(
     () =>
@@ -105,17 +110,6 @@ export function AskUserQuestion({
   const current = questions[currentIdx];
   const isMulti = current?.multiSelect ?? false;
 
-  const hasAnswer = (i: number): boolean => {
-    const question = questions[i];
-    if (!question) return false;
-    if (question.multiSelect) {
-      return (selectedMulti[i] || []).length > 0 || !!customInputs[i];
-    }
-    return !!answers[i] || !!customInputs[i];
-  };
-
-  const canSubmit = questions.every((_, i) => hasAnswer(i));
-
   const rememberSelectedIndex = useCallback(
     (idx: number | null) => {
       selectedIdxByQuestionRef.current[currentIdx] = idx;
@@ -125,22 +119,27 @@ export function AskUserQuestion({
     [currentIdx],
   );
 
-  const buildResult = useCallback((): Record<string, string> => {
-    const result: Record<string, string> = {};
-    for (let i = 0; i < questions.length; i++) {
-      const q = questions[i];
-      if (!q) continue;
-      if (q.multiSelect) {
-        const multi = selectedMulti[i] || [];
-        const custom = customInputs[i];
-        const all = custom ? [...multi, custom] : multi;
-        result[String(i)] = all.join(', ');
-      } else {
-        result[String(i)] = answers[i] || customInputs[i] || '';
+  const buildResult = useCallback(
+    (
+      multiSelections: Record<number, string[]> = selectedMulti,
+    ): Record<string, string> => {
+      const result: Record<string, string> = {};
+      for (let i = 0; i < questions.length; i++) {
+        const q = questions[i];
+        if (!q) continue;
+        if (q.multiSelect) {
+          const multi = multiSelections[i] || [];
+          const custom = customInputs[i];
+          const all = custom ? [...multi, custom] : multi;
+          result[String(i)] = all.join(', ');
+        } else {
+          result[String(i)] = answers[i] || customInputs[i] || '';
+        }
       }
-    }
-    return result;
-  }, [questions, selectedMulti, customInputs, answers]);
+      return result;
+    },
+    [questions, selectedMulti, customInputs, answers],
+  );
 
   const submitDecision = useCallback(
     async (
@@ -168,16 +167,19 @@ export function AskUserQuestion({
     [onConfirm, onError, request.id, t],
   );
 
-  const handleSubmit = useCallback(() => {
-    if (submittedRef.current) return;
-    const submitOption = request.options.find((o) => o.kind === 'allow_once');
-    if (!submitOption) {
-      const message = t('askUser.submitOptionUnavailable');
-      onError(new Error(message), message);
-      return;
-    }
-    void submitDecision(submitOption.id, buildResult());
-  }, [buildResult, onError, request.options, submitDecision, t]);
+  const handleSubmit = useCallback(
+    (submittedAnswers?: Record<string, string>) => {
+      if (submittedRef.current) return;
+      const submitOption = request.options.find((o) => o.kind === 'allow_once');
+      if (!submitOption) {
+        const message = t('askUser.submitOptionUnavailable');
+        onError(new Error(message), message);
+        return;
+      }
+      void submitDecision(submitOption.id, submittedAnswers ?? buildResult());
+    },
+    [buildResult, onError, request.options, submitDecision, t],
+  );
 
   const handleCancel = useCallback(() => {
     if (submittedRef.current) return;
@@ -372,21 +374,17 @@ export function AskUserQuestion({
     selectQuestion(currentIdx + 1);
   }, [currentIdx, questions.length, selectQuestion]);
 
-  const advanceQuestion = useCallback(() => {
-    setCustomFocused(false);
-    if (currentIdx < questions.length - 1) {
-      selectQuestion(currentIdx + 1);
-      return;
-    }
-    if (canSubmit && !submitting) handleSubmit();
-  }, [
-    canSubmit,
-    currentIdx,
-    handleSubmit,
-    questions.length,
-    selectQuestion,
-    submitting,
-  ]);
+  const advanceQuestion = useCallback(
+    (submittedAnswers?: Record<string, string>) => {
+      setCustomFocused(false);
+      if (currentIdx < questions.length - 1) {
+        selectQuestion(currentIdx + 1);
+        return;
+      }
+      if (!submitting) handleSubmit(submittedAnswers);
+    },
+    [currentIdx, handleSubmit, questions.length, selectQuestion, submitting],
+  );
 
   useEffect(() => {
     if (!focusAfterQuestionChangeRef.current || !current) return;
@@ -420,16 +418,14 @@ export function AskUserQuestion({
     [advanceQuestion, currentIdx, customInputs],
   );
 
-  // Panel-wide Escape and submit shortcuts stay consistent across controls;
+  // Panel-wide action shortcuts stay consistent across controls;
   // option navigation remains scoped to the roving-tabindex option group.
   const handleKeyDown = useCallback(
     (e: ReactKeyboardEvent<HTMLDivElement>) => {
       if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
       if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
         e.preventDefault();
-        if (canSubmit && !submitting) {
-          handleSubmit();
-        }
+        if (!submitting) handleSubmit();
         return;
       }
       if (isEditableTarget(e.target)) return;
@@ -438,12 +434,29 @@ export function AskUserQuestion({
         handleCancel();
         return;
       }
-      if (!(e.target as HTMLElement).closest('[data-web-shell-ask-option]')) {
+      const isOptionTarget = (e.target as HTMLElement).closest(
+        '[data-web-shell-ask-option]',
+      );
+      if (!isOptionTarget) {
+        if (
+          !collapsed &&
+          current &&
+          (e.key === 'ArrowDown' || e.key === 'ArrowUp')
+        ) {
+          e.preventDefault();
+          selectIndex(selectedIdxRef.current ?? 0);
+        }
         return;
       }
       if (!current) return;
       const total = current.options.length + 1;
-      if (e.key === 'ArrowDown' || e.key === 'j') {
+      if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        handlePrevious();
+      } else if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        handleNext();
+      } else if (e.key === 'ArrowDown' || e.key === 'j') {
         e.preventDefault();
         moveSelection(1);
       } else if (e.key === 'ArrowUp' || e.key === 'k') {
@@ -461,6 +474,19 @@ export function AskUserQuestion({
         if (idx === current.options.length && !customInputs[currentIdx]) {
           chooseOption(idx);
         } else {
+          if (isMulti && idx < current.options.length) {
+            const label = current.options[idx].label;
+            const selected = selectedMulti[currentIdx] || [];
+            if (!selected.includes(label)) {
+              const nextSelectedMulti = {
+                ...selectedMulti,
+                [currentIdx]: [...selected, label],
+              };
+              setSelectedMulti(nextSelectedMulti);
+              advanceQuestion(buildResult(nextSelectedMulti));
+              return;
+            }
+          }
           advanceQuestion();
         }
       } else if (e.key >= '1' && e.key <= '9') {
@@ -473,14 +499,19 @@ export function AskUserQuestion({
     },
     [
       advanceQuestion,
-      canSubmit,
+      buildResult,
       chooseOption,
+      collapsed,
       current,
       currentIdx,
       customInputs,
       handleCancel,
+      handleNext,
+      handlePrevious,
       handleSubmit,
+      isMulti,
       moveSelection,
+      selectedMulti,
       selectIndex,
       submitting,
     ],
@@ -515,7 +546,7 @@ export function AskUserQuestion({
     !customFocused &&
     selectedIdx === current.options.length &&
     !customInputs[currentIdx];
-  const shortcutHint = isEmptyCustomTrigger
+  const contextualShortcutHint = isEmptyCustomTrigger
     ? t('askUser.shortcuts.customTrigger')
     : customFocused
       ? t(
@@ -540,6 +571,10 @@ export function AskUserQuestion({
                 ? 'askUser.shortcuts.optionsFinal'
                 : 'askUser.shortcuts.optionsNext',
           );
+  const shortcutHint =
+    currentIdx > 0 && !customFocused
+      ? `${t('askUser.shortcuts.previous')} · ${contextualShortcutHint}`
+      : contextualShortcutHint;
 
   return (
     <div
@@ -548,12 +583,20 @@ export function AskUserQuestion({
       } ${collapsed ? styles.collapsed : ''}`}
       data-web-shell-ask-panel
       role="dialog"
+      tabIndex={-1}
       aria-label={localizeToolDisplayName('ask_user_question', t)}
       // aria-labelledby wins over aria-label, so when expanded name the dialog
       // with BOTH the tool name and the question (otherwise the tool-name
       // context is dropped). The tool-name span is display:none but accname
       // still uses a directly-referenced hidden element's text.
       aria-labelledby={collapsed ? undefined : `${headingId} ${questionTextId}`}
+      onMouseDown={(e) => {
+        const target = e.target as HTMLElement;
+        if (isEditableTarget(target) || target.closest('button, a[href]')) {
+          return;
+        }
+        e.currentTarget.focus();
+      }}
       onKeyDown={handleKeyDown}
     >
       {/* Header line like CLI */}
@@ -782,6 +825,8 @@ export function AskUserQuestion({
               type="button"
               className={styles.ignoreButton}
               disabled={submitting}
+              aria-keyshortcuts="Escape"
+              data-shortcut="Esc"
               onClick={handleCancel}
             >
               {t('askUser.ignore')}
@@ -809,10 +854,11 @@ export function AskUserQuestion({
             <button
               type="button"
               className={`${styles.button} ${styles.submitButton}`}
-              disabled={submitting || !canSubmit}
+              disabled={submitting}
               aria-busy={submitting}
               aria-keyshortcuts="Control+Enter Meta+Enter"
-              onClick={handleSubmit}
+              data-shortcut={submitShortcutLabel}
+              onClick={() => handleSubmit()}
             >
               {submitting ? (
                 <>

--- a/packages/web-shell/client/components/messages/AskUserQuestion.tsx
+++ b/packages/web-shell/client/components/messages/AskUserQuestion.tsx
@@ -71,7 +71,11 @@ export function AskUserQuestion({
   // "Other" trigger that reveals the custom input.
   const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const customRef = useRef<HTMLButtonElement | null>(null);
+  const submitButtonRef = useRef<HTMLButtonElement | null>(null);
   const selectedIdxRef = useRef<number | null>(selectedIdx);
+  const selectedIdxByQuestionRef = useRef<Record<number, number | null>>({});
+  const focusAfterQuestionChangeRef = useRef(false);
+  const focusCustomTriggerAfterEditRef = useRef(false);
   selectedIdxRef.current = selectedIdx;
   const questionTextId = useId();
   const headingId = useId();
@@ -85,8 +89,10 @@ export function AskUserQuestion({
     setCurrentIdx(0);
     // Sync the ref too so the focus effect (which runs in this same commit on a
     // new request) reads the fresh index, not the previous request's selection.
-    selectedIdxRef.current = firstQuestion?.options.length ? 0 : null;
-    setSelectedIdx(firstQuestion?.options.length ? 0 : null);
+    const firstSelectedIdx = firstQuestion ? 0 : null;
+    selectedIdxByQuestionRef.current = { 0: firstSelectedIdx };
+    selectedIdxRef.current = firstSelectedIdx;
+    setSelectedIdx(firstSelectedIdx);
     setAnswers(
       firstQuestion && !firstQuestion.multiSelect && firstQuestion.options[0]
         ? { 0: firstQuestion.options[0].label }
@@ -103,6 +109,26 @@ export function AskUserQuestion({
 
   const current = questions[currentIdx];
   const isMulti = current?.multiSelect ?? false;
+
+  const hasAnswer = (i: number): boolean => {
+    const question = questions[i];
+    if (!question) return false;
+    if (question.multiSelect) {
+      return (selectedMulti[i] || []).length > 0 || !!customInputs[i];
+    }
+    return !!answers[i] || !!customInputs[i];
+  };
+
+  const canSubmit = questions.every((_, i) => hasAnswer(i));
+
+  const rememberSelectedIndex = useCallback(
+    (idx: number | null) => {
+      selectedIdxByQuestionRef.current[currentIdx] = idx;
+      selectedIdxRef.current = idx;
+      setSelectedIdx(idx);
+    },
+    [currentIdx],
+  );
 
   const buildResult = useCallback((): Record<string, string> => {
     const result: Record<string, string> = {};
@@ -237,8 +263,7 @@ export function AskUserQuestion({
   const chooseOption = useCallback(
     (idx: number) => {
       if (!current) return;
-      selectedIdxRef.current = idx;
-      setSelectedIdx(idx);
+      rememberSelectedIndex(idx);
       if (idx === current.options.length) {
         focusCustomInput();
         return;
@@ -246,7 +271,14 @@ export function AskUserQuestion({
       if (isMulti) handleToggle(idx);
       else handleSelectOption(idx);
     },
-    [current, isMulti, focusCustomInput, handleToggle, handleSelectOption],
+    [
+      current,
+      isMulti,
+      focusCustomInput,
+      handleToggle,
+      handleSelectOption,
+      rememberSelectedIndex,
+    ],
   );
 
   // Move the selection to a specific option index, keeping focus, the roving
@@ -258,8 +290,7 @@ export function AskUserQuestion({
   const selectIndex = useCallback(
     (idx: number) => {
       if (!current) return;
-      selectedIdxRef.current = idx;
-      setSelectedIdx(idx);
+      rememberSelectedIndex(idx);
       if (idx === current.options.length) {
         customRef.current?.focus();
         if (!isMulti) {
@@ -275,7 +306,7 @@ export function AskUserQuestion({
         if (!isMulti) handleSelectOption(idx);
       }
     },
-    [current, currentIdx, isMulti, handleSelectOption],
+    [current, currentIdx, isMulti, handleSelectOption, rememberSelectedIndex],
   );
 
   const moveSelection = useCallback(
@@ -290,20 +321,126 @@ export function AskUserQuestion({
     [current, selectIndex],
   );
 
-  // Focus-scoped keyboard nav (fires only while focus is inside this question):
-  // arrows/j/k move between options and the "Other" row, Home/End jump to the
-  // ends, digits pick by position, Escape ignores. Enter/Space activate the
-  // focused control natively; the custom <input> keeps its own arrow/caret keys
-  // (guarded by isEditableTarget above).
+  const getSelectedIndexForQuestion = useCallback(
+    (questionIdx: number): number | null => {
+      if (Object.hasOwn(selectedIdxByQuestionRef.current, questionIdx)) {
+        return selectedIdxByQuestionRef.current[questionIdx] ?? null;
+      }
+      const question = questions[questionIdx];
+      if (!question) return null;
+      if (customInputs[questionIdx]) return question.options.length;
+      if (!question.multiSelect) {
+        const answer = answers[questionIdx];
+        const answerIdx = question.options.findIndex(
+          (option) => option.label === answer,
+        );
+        if (answerIdx >= 0) return answerIdx;
+      }
+      return 0;
+    },
+    [answers, customInputs, questions],
+  );
+
+  const selectQuestion = useCallback(
+    (nextIdx: number) => {
+      const question = questions[nextIdx];
+      if (!question) return;
+      const nextSelectedIdx = getSelectedIndexForQuestion(nextIdx);
+      selectedIdxByQuestionRef.current[nextIdx] = nextSelectedIdx;
+      selectedIdxRef.current = nextSelectedIdx;
+      setSelectedIdx(nextSelectedIdx);
+      setCustomFocused(false);
+      focusAfterQuestionChangeRef.current = true;
+      setCurrentIdx(nextIdx);
+
+      if (question.multiSelect) {
+        setSelectedMulti((prev) =>
+          (prev[nextIdx] || []).length > 0 || customInputs[nextIdx]
+            ? prev
+            : question.options[0]
+              ? { ...prev, [nextIdx]: [question.options[0].label] }
+              : prev,
+        );
+        return;
+      }
+      setAnswers((prev) =>
+        prev[nextIdx] || customInputs[nextIdx] || !question.options[0]
+          ? prev
+          : { ...prev, [nextIdx]: question.options[0].label },
+      );
+    },
+    [customInputs, getSelectedIndexForQuestion, questions],
+  );
+
+  const handlePrevious = useCallback(() => {
+    if (currentIdx <= 0) return;
+    selectQuestion(currentIdx - 1);
+  }, [currentIdx, selectQuestion]);
+
+  const handleNext = useCallback(() => {
+    if (currentIdx >= questions.length - 1) return;
+    selectQuestion(currentIdx + 1);
+  }, [currentIdx, questions.length, selectQuestion]);
+
+  const advanceQuestion = useCallback(() => {
+    setCustomFocused(false);
+    if (currentIdx < questions.length - 1) {
+      selectQuestion(currentIdx + 1);
+      return;
+    }
+    submitButtonRef.current?.focus();
+  }, [currentIdx, questions.length, selectQuestion]);
+
+  useEffect(() => {
+    if (!focusAfterQuestionChangeRef.current || !current) return;
+    focusAfterQuestionChangeRef.current = false;
+    const idx = selectedIdxRef.current ?? 0;
+    if (idx === current.options.length) customRef.current?.focus();
+    else optionRefs.current[idx]?.focus();
+  }, [current, currentIdx]);
+
+  useEffect(() => {
+    if (customFocused || !focusCustomTriggerAfterEditRef.current) return;
+    focusCustomTriggerAfterEditRef.current = false;
+    customRef.current?.focus();
+  }, [customFocused]);
+
+  const handleCustomInputKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLInputElement>) => {
+      if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
+      if (e.ctrlKey || e.metaKey) return;
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        focusCustomTriggerAfterEditRef.current = true;
+        setCustomFocused(false);
+      } else if (e.key === 'Enter' && (customInputs[currentIdx] || '').trim()) {
+        e.preventDefault();
+        e.stopPropagation();
+        advanceQuestion();
+      }
+    },
+    [advanceQuestion, currentIdx, customInputs],
+  );
+
+  // Panel-wide Escape and submit shortcuts stay consistent across controls;
+  // option navigation remains scoped to the roving-tabindex option group.
   const handleKeyDown = useCallback(
     (e: ReactKeyboardEvent<HTMLDivElement>) => {
+      if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
+      if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+        if (canSubmit && !submitting) {
+          e.preventDefault();
+          handleSubmit();
+        }
+        return;
+      }
       if (isEditableTarget(e.target)) return;
-      // Only react when focus is on an option (a roving-tabindex button or the
-      // "Other" trigger) — not on the action buttons (Submit/Previous/Next) or
-      // the collapse toggle. Otherwise a digit / j-k / Escape pressed while
-      // focused there would silently pick an option or cancel the question; when
-      // collapsed the options aren't even rendered, so the toggle is the only
-      // focusable element and must not trigger any of this.
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        handleCancel();
+        return;
+      }
       if (!(e.target as HTMLElement).closest('[data-web-shell-ask-option]')) {
         return;
       }
@@ -321,9 +458,14 @@ export function AskUserQuestion({
       } else if (e.key === 'End') {
         e.preventDefault();
         selectIndex(total - 1);
-      } else if (e.key === 'Escape') {
+      } else if (e.key === 'Enter') {
         e.preventDefault();
-        handleCancel();
+        const idx = selectedIdxRef.current ?? 0;
+        if (idx === current.options.length && !customInputs[currentIdx]) {
+          chooseOption(idx);
+        } else {
+          advanceQuestion();
+        }
       } else if (e.key >= '1' && e.key <= '9') {
         const idx = parseInt(e.key, 10) - 1;
         if (idx < total) {
@@ -332,7 +474,19 @@ export function AskUserQuestion({
         }
       }
     },
-    [current, moveSelection, selectIndex, handleCancel, chooseOption],
+    [
+      advanceQuestion,
+      canSubmit,
+      chooseOption,
+      current,
+      currentIdx,
+      customInputs,
+      handleCancel,
+      handleSubmit,
+      moveSelection,
+      selectIndex,
+      submitting,
+    ],
   );
 
   // Pull focus to the current option (or the custom input while editing) when
@@ -356,49 +510,21 @@ export function AskUserQuestion({
 
   if (questions.length === 0) return null;
 
-  // Check which questions have answers
-  const hasAnswer = (i: number): boolean => {
-    const q = questions[i];
-    if (!q) return false;
-    if (q.multiSelect) {
-      return (selectedMulti[i] || []).length > 0 || !!customInputs[i];
-    }
-    return !!answers[i] || !!customInputs[i];
-  };
-
-  const canSubmit = questions.every((_, i) => hasAnswer(i));
   const displayIdx = Math.min(currentIdx, questions.length - 1);
-  const selectQuestion = (nextIdx: number) => {
-    const question = questions[nextIdx];
-    setCurrentIdx(nextIdx);
-    setCustomFocused(false);
-    if (!question?.options.length) {
-      setSelectedIdx(null);
-      return;
-    }
-    setSelectedIdx(0);
-    if (question.multiSelect) {
-      setSelectedMulti((prev) =>
-        (prev[nextIdx] || []).length > 0 || customInputs[nextIdx]
-          ? prev
-          : { ...prev, [nextIdx]: [question.options[0].label] },
-      );
-      return;
-    }
-    setAnswers((prev) =>
-      prev[nextIdx] || customInputs[nextIdx]
-        ? prev
-        : { ...prev, [nextIdx]: question.options[0].label },
-    );
-  };
-  const handlePrevious = () => {
-    if (currentIdx <= 0) return;
-    selectQuestion(currentIdx - 1);
-  };
-  const handleNext = () => {
-    if (currentIdx >= questions.length - 1) return;
-    selectQuestion(currentIdx + 1);
-  };
+  const isLastQuestion = currentIdx === questions.length - 1;
+  const shortcutHint = customFocused
+    ? t('askUser.shortcuts.input')
+    : isMulti
+      ? t(
+          isLastQuestion
+            ? 'askUser.shortcuts.multiFinal'
+            : 'askUser.shortcuts.multiNext',
+        )
+      : t(
+          isLastQuestion
+            ? 'askUser.shortcuts.optionsFinal'
+            : 'askUser.shortcuts.optionsNext',
+        );
 
   return (
     <div
@@ -406,7 +532,7 @@ export function AskUserQuestion({
         variant === 'floating' ? styles.floating : ''
       } ${collapsed ? styles.collapsed : ''}`}
       data-web-shell-ask-panel
-      role="alertdialog"
+      role="dialog"
       aria-label={localizeToolDisplayName('ask_user_question', t)}
       // aria-labelledby wins over aria-label, so when expanded name the dialog
       // with BOTH the tool name and the question (otherwise the tool-name
@@ -522,7 +648,7 @@ export function AskUserQuestion({
                       aria-keyshortcuts={i < 9 ? String(i + 1) : undefined}
                       disabled={submitting}
                       onClick={() => chooseOption(i)}
-                      onFocus={() => setSelectedIdx(i)}
+                      onFocus={() => rememberSelectedIndex(i)}
                     >
                       <span className={styles.pointer} aria-hidden="true">
                         {isActive ? '›' : ' '}
@@ -592,8 +718,11 @@ export function AskUserQuestion({
                           // let it bubble to the row's onClick and re-trigger the
                           // option choice.
                           onClick={(e) => e.stopPropagation()}
-                          onFocus={() => setSelectedIdx(current.options.length)}
+                          onFocus={() =>
+                            rememberSelectedIndex(current.options.length)
+                          }
                           onBlur={() => setCustomFocused(false)}
+                          onKeyDown={handleCustomInputKeyDown}
                           autoFocus
                         />
                       ) : (
@@ -616,7 +745,9 @@ export function AskUserQuestion({
                               : undefined
                           }
                           disabled={submitting}
-                          onFocus={() => setSelectedIdx(current.options.length)}
+                          onFocus={() =>
+                            rememberSelectedIndex(current.options.length)
+                          }
                         >
                           {customInputs[currentIdx] ||
                             t('askUser.typePlaceholder')}
@@ -628,6 +759,7 @@ export function AskUserQuestion({
               </div>
             </>
           ) : null}
+          <p className={styles.shortcuts}>{shortcutHint}</p>
           <div className={styles.actions}>
             <button
               type="button"
@@ -659,9 +791,11 @@ export function AskUserQuestion({
             )}
             <button
               type="button"
+              ref={submitButtonRef}
               className={`${styles.button} ${styles.submitButton}`}
               disabled={submitting || !canSubmit}
               aria-busy={submitting}
+              aria-keyshortcuts="Control+Enter Meta+Enter"
               onClick={handleSubmit}
             >
               {submitting ? (

--- a/packages/web-shell/client/components/messages/AskUserQuestion.tsx
+++ b/packages/web-shell/client/components/messages/AskUserQuestion.tsx
@@ -220,11 +220,13 @@ export function AskUserQuestion({
       }
       const label = current.options[idx].label;
       if (isMulti) {
-        const prev = selectedMulti[currentIdx] || [];
-        const next = prev.includes(label)
-          ? prev.filter((l) => l !== label)
-          : [...prev, label];
-        setSelectedMulti({ ...selectedMulti, [currentIdx]: next });
+        setSelectedMulti((prev) => {
+          const selected = prev[currentIdx] || [];
+          const next = selected.includes(label)
+            ? selected.filter((l) => l !== label)
+            : [...selected, label];
+          return { ...prev, [currentIdx]: next };
+        });
       } else {
         const nextAnswers = { ...answers, [currentIdx]: label };
         setAnswers(nextAnswers);
@@ -236,7 +238,7 @@ export function AskUserQuestion({
         });
       }
     },
-    [current, currentIdx, isMulti, selectedMulti, answers, focusCustomInput],
+    [current, currentIdx, isMulti, answers, focusCustomInput],
   );
 
   const handleToggle = useCallback(
@@ -247,13 +249,15 @@ export function AskUserQuestion({
         return;
       }
       const label = current.options[idx].label;
-      const prev = selectedMulti[currentIdx] || [];
-      const next = prev.includes(label)
-        ? prev.filter((l) => l !== label)
-        : [...prev, label];
-      setSelectedMulti({ ...selectedMulti, [currentIdx]: next });
+      setSelectedMulti((prev) => {
+        const selected = prev[currentIdx] || [];
+        const next = selected.includes(label)
+          ? selected.filter((l) => l !== label)
+          : [...selected, label];
+        return { ...prev, [currentIdx]: next };
+      });
     },
-    [current, isMulti, selectedMulti, currentIdx, focusCustomInput],
+    [current, isMulti, currentIdx, focusCustomInput],
   );
 
   // Unified option activation for click, native Enter/Space, and digit

--- a/packages/web-shell/client/components/messages/AskUserQuestion.tsx
+++ b/packages/web-shell/client/components/messages/AskUserQuestion.tsx
@@ -520,6 +520,7 @@ export function AskUserQuestion({
   const isLastQuestion = currentIdx === questions.length - 1;
   const isSingleQuestion = questions.length === 1;
   const isEmptyCustomTrigger =
+    current !== undefined &&
     !customFocused &&
     selectedIdx === current.options.length &&
     !customInputs[currentIdx];

--- a/packages/web-shell/client/components/messages/AskUserQuestion.tsx
+++ b/packages/web-shell/client/components/messages/AskUserQuestion.tsx
@@ -429,8 +429,8 @@ export function AskUserQuestion({
     (e: ReactKeyboardEvent<HTMLDivElement>) => {
       if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
       if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
         if (canSubmit && !submitting) {
-          e.preventDefault();
           handleSubmit();
         }
         return;

--- a/packages/web-shell/client/components/messages/AskUserQuestion.tsx
+++ b/packages/web-shell/client/components/messages/AskUserQuestion.tsx
@@ -98,11 +98,7 @@ export function AskUserQuestion({
         : {},
     );
     setCustomInputs({});
-    setSelectedMulti(
-      firstQuestion?.multiSelect && firstQuestion.options[0]
-        ? { 0: [firstQuestion.options[0].label] }
-        : {},
-    );
+    setSelectedMulti({});
     setCustomFocused(false);
   }, [questions, request.id]);
 
@@ -356,16 +352,7 @@ export function AskUserQuestion({
       focusAfterQuestionChangeRef.current = true;
       setCurrentIdx(nextIdx);
 
-      if (question.multiSelect) {
-        setSelectedMulti((prev) =>
-          (prev[nextIdx] || []).length > 0 || customInputs[nextIdx]
-            ? prev
-            : question.options[0]
-              ? { ...prev, [nextIdx]: [question.options[0].label] }
-              : prev,
-        );
-        return;
-      }
+      if (question.multiSelect) return;
       setAnswers((prev) =>
         prev[nextIdx] || customInputs[nextIdx] || !question.options[0]
           ? prev

--- a/packages/web-shell/client/components/messages/AskUserQuestion.tsx
+++ b/packages/web-shell/client/components/messages/AskUserQuestion.tsx
@@ -71,7 +71,6 @@ export function AskUserQuestion({
   // "Other" trigger that reveals the custom input.
   const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const customRef = useRef<HTMLButtonElement | null>(null);
-  const submitButtonRef = useRef<HTMLButtonElement | null>(null);
   const selectedIdxRef = useRef<number | null>(selectedIdx);
   const selectedIdxByQuestionRef = useRef<Record<number, number | null>>({});
   const focusAfterQuestionChangeRef = useRef(false);
@@ -388,8 +387,15 @@ export function AskUserQuestion({
       selectQuestion(currentIdx + 1);
       return;
     }
-    submitButtonRef.current?.focus();
-  }, [currentIdx, questions.length, selectQuestion]);
+    if (canSubmit && !submitting) handleSubmit();
+  }, [
+    canSubmit,
+    currentIdx,
+    handleSubmit,
+    questions.length,
+    selectQuestion,
+    submitting,
+  ]);
 
   useEffect(() => {
     if (!focusAfterQuestionChangeRef.current || !current) return;
@@ -512,18 +518,29 @@ export function AskUserQuestion({
 
   const displayIdx = Math.min(currentIdx, questions.length - 1);
   const isLastQuestion = currentIdx === questions.length - 1;
+  const isSingleQuestion = questions.length === 1;
   const shortcutHint = customFocused
-    ? t('askUser.shortcuts.input')
+    ? t(
+        isSingleQuestion
+          ? 'askUser.shortcuts.inputSingle'
+          : isLastQuestion
+            ? 'askUser.shortcuts.inputFinal'
+            : 'askUser.shortcuts.inputNext',
+      )
     : isMulti
       ? t(
-          isLastQuestion
-            ? 'askUser.shortcuts.multiFinal'
-            : 'askUser.shortcuts.multiNext',
+          isSingleQuestion
+            ? 'askUser.shortcuts.multiSingle'
+            : isLastQuestion
+              ? 'askUser.shortcuts.multiFinal'
+              : 'askUser.shortcuts.multiNext',
         )
       : t(
-          isLastQuestion
-            ? 'askUser.shortcuts.optionsFinal'
-            : 'askUser.shortcuts.optionsNext',
+          isSingleQuestion
+            ? 'askUser.shortcuts.optionsSingle'
+            : isLastQuestion
+              ? 'askUser.shortcuts.optionsFinal'
+              : 'askUser.shortcuts.optionsNext',
         );
 
   return (
@@ -791,7 +808,6 @@ export function AskUserQuestion({
             )}
             <button
               type="button"
-              ref={submitButtonRef}
               className={`${styles.button} ${styles.submitButton}`}
               disabled={submitting || !canSubmit}
               aria-busy={submitting}

--- a/packages/web-shell/client/components/messages/AskUserQuestion.tsx
+++ b/packages/web-shell/client/components/messages/AskUserQuestion.tsx
@@ -776,8 +776,10 @@ export function AskUserQuestion({
               </div>
             </>
           ) : null}
-          <p className={styles.shortcuts}>{shortcutHint}</p>
           <div className={styles.actions}>
+            <p className={styles.shortcuts} title={shortcutHint}>
+              {shortcutHint}
+            </p>
             <button
               type="button"
               className={styles.ignoreButton}

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -572,6 +572,8 @@ const EN: Messages = {
   'askUser.shortcuts.multiFinal':
     '↑↓ move · Space select/deselect · Enter select & submit',
   'askUser.shortcuts.customTrigger': '↑↓ select · Enter edit',
+  'askUser.shortcuts.customTriggerMulti': '↑↓ move · Enter edit',
+  'askUser.shortcuts.inputEmpty': 'Type an answer · Esc stop editing',
   'askUser.shortcuts.inputSingle': 'Enter submit · Esc stop editing',
   'askUser.shortcuts.inputNext': 'Enter next · Esc stop editing',
   'askUser.shortcuts.inputFinal': 'Enter submit · Esc stop editing',
@@ -3405,6 +3407,8 @@ const ZH: Messages = {
   'askUser.shortcuts.multiFinal':
     '↑↓ 移动 · Space 选中/取消 · Enter 选中并提交',
   'askUser.shortcuts.customTrigger': '↑↓ 选择 · Enter 编辑',
+  'askUser.shortcuts.customTriggerMulti': '↑↓ 移动 · Enter 编辑',
+  'askUser.shortcuts.inputEmpty': '输入答案 · Esc 退出编辑',
   'askUser.shortcuts.inputSingle': 'Enter 提交 · Esc 退出编辑',
   'askUser.shortcuts.inputNext': 'Enter 下一步 · Esc 退出编辑',
   'askUser.shortcuts.inputFinal': 'Enter 提交 · Esc 退出编辑',

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -564,19 +564,17 @@ const EN: Messages = {
   'askUser.shortcuts.optionsSingle': '↑↓ select · Enter submit · Esc ignore',
   'askUser.shortcuts.optionsNext':
     '↑↓ select · Enter next · Esc ignore · ⌘/Ctrl+Enter submit',
-  'askUser.shortcuts.optionsFinal':
-    '↑↓ select · Enter submit · Esc ignore · ⌘/Ctrl+Enter submit',
+  'askUser.shortcuts.optionsFinal': '↑↓ select · Enter submit · Esc ignore',
   'askUser.shortcuts.multiSingle':
     '↑↓ select · Space toggle · Enter submit · Esc ignore',
   'askUser.shortcuts.multiNext':
     '↑↓ select · Space toggle · Enter next · Esc ignore · ⌘/Ctrl+Enter submit',
   'askUser.shortcuts.multiFinal':
-    '↑↓ select · Space toggle · Enter submit · Esc ignore · ⌘/Ctrl+Enter submit',
+    '↑↓ select · Space toggle · Enter submit · Esc ignore',
   'askUser.shortcuts.inputSingle': 'Enter submit · Esc stop editing',
   'askUser.shortcuts.inputNext':
     'Enter next · Esc stop editing · ⌘/Ctrl+Enter submit',
-  'askUser.shortcuts.inputFinal':
-    'Enter submit · Esc stop editing · ⌘/Ctrl+Enter submit',
+  'askUser.shortcuts.inputFinal': 'Enter submit · Esc stop editing',
   'copy.failedFallback': 'Failed to copy to the clipboard',
   'copy.inlineLatexMissing':
     'No matching inline LaTeX expression found in the last AI output.',
@@ -3399,19 +3397,17 @@ const ZH: Messages = {
   'askUser.shortcuts.optionsSingle': '↑↓ 选择 · Enter 提交 · Esc 忽略',
   'askUser.shortcuts.optionsNext':
     '↑↓ 选择 · Enter 下一题 · Esc 忽略 · ⌘/Ctrl+Enter 提交',
-  'askUser.shortcuts.optionsFinal':
-    '↑↓ 选择 · Enter 提交 · Esc 忽略 · ⌘/Ctrl+Enter 提交',
+  'askUser.shortcuts.optionsFinal': '↑↓ 选择 · Enter 提交 · Esc 忽略',
   'askUser.shortcuts.multiSingle':
     '↑↓ 选择 · Space 切换 · Enter 提交 · Esc 忽略',
   'askUser.shortcuts.multiNext':
     '↑↓ 选择 · Space 切换 · Enter 下一题 · Esc 忽略 · ⌘/Ctrl+Enter 提交',
   'askUser.shortcuts.multiFinal':
-    '↑↓ 选择 · Space 切换 · Enter 提交 · Esc 忽略 · ⌘/Ctrl+Enter 提交',
+    '↑↓ 选择 · Space 切换 · Enter 提交 · Esc 忽略',
   'askUser.shortcuts.inputSingle': 'Enter 提交 · Esc 退出编辑',
   'askUser.shortcuts.inputNext':
     'Enter 下一题 · Esc 退出编辑 · ⌘/Ctrl+Enter 提交',
-  'askUser.shortcuts.inputFinal':
-    'Enter 提交 · Esc 退出编辑 · ⌘/Ctrl+Enter 提交',
+  'askUser.shortcuts.inputFinal': 'Enter 提交 · Esc 退出编辑',
   'copy.failedFallback': '复制到剪贴板失败',
   'copy.inlineLatexMissing': '最后一条 AI 输出中没有匹配的行内 LaTeX 表达式。',
   'copy.latexMissing': '最后一条 AI 输出中没有匹配的 LaTeX 块。',

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -561,20 +561,19 @@ const EN: Messages = {
   'askUser.progress': (v) => `${v?.current ?? 0}/${v?.total ?? 0} questions`,
   'askUser.selectAnswer': 'Select an answer',
   'askUser.typePlaceholder': 'Type something...',
-  'askUser.shortcuts.optionsSingle': '↑↓ select · Enter submit · Esc ignore',
-  'askUser.shortcuts.optionsNext':
-    '↑↓ select · Enter next · Esc ignore · ⌘/Ctrl+Enter submit',
-  'askUser.shortcuts.optionsFinal': '↑↓ select · Enter submit · Esc ignore',
+  'askUser.shortcuts.previous': '← previous',
+  'askUser.shortcuts.optionsSingle': '↑↓ select · Enter submit',
+  'askUser.shortcuts.optionsNext': '↑↓ select · Enter next',
+  'askUser.shortcuts.optionsFinal': '↑↓ select · Enter submit',
   'askUser.shortcuts.multiSingle':
-    '↑↓ select · Space toggle · Enter submit · Esc ignore',
+    '↑↓ move · Space select/deselect · Enter select & submit',
   'askUser.shortcuts.multiNext':
-    '↑↓ select · Space toggle · Enter next · Esc ignore · ⌘/Ctrl+Enter submit',
+    '↑↓ move · Space select/deselect · Enter select & next',
   'askUser.shortcuts.multiFinal':
-    '↑↓ select · Space toggle · Enter submit · Esc ignore',
-  'askUser.shortcuts.customTrigger': '↑↓ select · Enter edit · Esc ignore',
+    '↑↓ move · Space select/deselect · Enter select & submit',
+  'askUser.shortcuts.customTrigger': '↑↓ select · Enter edit',
   'askUser.shortcuts.inputSingle': 'Enter submit · Esc stop editing',
-  'askUser.shortcuts.inputNext':
-    'Enter next · Esc stop editing · ⌘/Ctrl+Enter submit',
+  'askUser.shortcuts.inputNext': 'Enter next · Esc stop editing',
   'askUser.shortcuts.inputFinal': 'Enter submit · Esc stop editing',
   'copy.failedFallback': 'Failed to copy to the clipboard',
   'copy.inlineLatexMissing':
@@ -3395,20 +3394,19 @@ const ZH: Messages = {
   'askUser.progress': (v) => `${v?.current ?? 0}/${v?.total ?? 0} 个问题`,
   'askUser.selectAnswer': '选择一个答案',
   'askUser.typePlaceholder': '输入内容...',
-  'askUser.shortcuts.optionsSingle': '↑↓ 选择 · Enter 提交 · Esc 忽略',
-  'askUser.shortcuts.optionsNext':
-    '↑↓ 选择 · Enter 下一题 · Esc 忽略 · ⌘/Ctrl+Enter 提交',
-  'askUser.shortcuts.optionsFinal': '↑↓ 选择 · Enter 提交 · Esc 忽略',
+  'askUser.shortcuts.previous': '← 上一步',
+  'askUser.shortcuts.optionsSingle': '↑↓ 选择 · Enter 提交',
+  'askUser.shortcuts.optionsNext': '↑↓ 选择 · Enter 下一步',
+  'askUser.shortcuts.optionsFinal': '↑↓ 选择 · Enter 提交',
   'askUser.shortcuts.multiSingle':
-    '↑↓ 选择 · Space 切换 · Enter 提交 · Esc 忽略',
+    '↑↓ 移动 · Space 选中/取消 · Enter 选中并提交',
   'askUser.shortcuts.multiNext':
-    '↑↓ 选择 · Space 切换 · Enter 下一题 · Esc 忽略 · ⌘/Ctrl+Enter 提交',
+    '↑↓ 移动 · Space 选中/取消 · Enter 选中并下一步',
   'askUser.shortcuts.multiFinal':
-    '↑↓ 选择 · Space 切换 · Enter 提交 · Esc 忽略',
-  'askUser.shortcuts.customTrigger': '↑↓ 选择 · Enter 编辑 · Esc 忽略',
+    '↑↓ 移动 · Space 选中/取消 · Enter 选中并提交',
+  'askUser.shortcuts.customTrigger': '↑↓ 选择 · Enter 编辑',
   'askUser.shortcuts.inputSingle': 'Enter 提交 · Esc 退出编辑',
-  'askUser.shortcuts.inputNext':
-    'Enter 下一题 · Esc 退出编辑 · ⌘/Ctrl+Enter 提交',
+  'askUser.shortcuts.inputNext': 'Enter 下一步 · Esc 退出编辑',
   'askUser.shortcuts.inputFinal': 'Enter 提交 · Esc 退出编辑',
   'copy.failedFallback': '复制到剪贴板失败',
   'copy.inlineLatexMissing': '最后一条 AI 输出中没有匹配的行内 LaTeX 表达式。',

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -561,16 +561,22 @@ const EN: Messages = {
   'askUser.progress': (v) => `${v?.current ?? 0}/${v?.total ?? 0} questions`,
   'askUser.selectAnswer': 'Select an answer',
   'askUser.typePlaceholder': 'Type something...',
+  'askUser.shortcuts.optionsSingle': '↑↓ select · Enter submit · Esc ignore',
   'askUser.shortcuts.optionsNext':
     '↑↓ select · Enter next · Esc ignore · ⌘/Ctrl+Enter submit',
   'askUser.shortcuts.optionsFinal':
-    '↑↓ select · Enter focus Submit · Esc ignore · ⌘/Ctrl+Enter submit',
+    '↑↓ select · Enter submit · Esc ignore · ⌘/Ctrl+Enter submit',
+  'askUser.shortcuts.multiSingle':
+    '↑↓ select · Space toggle · Enter submit · Esc ignore',
   'askUser.shortcuts.multiNext':
     '↑↓ select · Space toggle · Enter next · Esc ignore · ⌘/Ctrl+Enter submit',
   'askUser.shortcuts.multiFinal':
-    '↑↓ select · Space toggle · Enter focus Submit · Esc ignore · ⌘/Ctrl+Enter submit',
-  'askUser.shortcuts.input':
-    'Enter confirm · Esc stop editing · ⌘/Ctrl+Enter submit',
+    '↑↓ select · Space toggle · Enter submit · Esc ignore · ⌘/Ctrl+Enter submit',
+  'askUser.shortcuts.inputSingle': 'Enter submit · Esc stop editing',
+  'askUser.shortcuts.inputNext':
+    'Enter next · Esc stop editing · ⌘/Ctrl+Enter submit',
+  'askUser.shortcuts.inputFinal':
+    'Enter submit · Esc stop editing · ⌘/Ctrl+Enter submit',
   'copy.failedFallback': 'Failed to copy to the clipboard',
   'copy.inlineLatexMissing':
     'No matching inline LaTeX expression found in the last AI output.',
@@ -3390,15 +3396,22 @@ const ZH: Messages = {
   'askUser.progress': (v) => `${v?.current ?? 0}/${v?.total ?? 0} 个问题`,
   'askUser.selectAnswer': '选择一个答案',
   'askUser.typePlaceholder': '输入内容...',
+  'askUser.shortcuts.optionsSingle': '↑↓ 选择 · Enter 提交 · Esc 忽略',
   'askUser.shortcuts.optionsNext':
     '↑↓ 选择 · Enter 下一题 · Esc 忽略 · ⌘/Ctrl+Enter 提交',
   'askUser.shortcuts.optionsFinal':
-    '↑↓ 选择 · Enter 聚焦提交 · Esc 忽略 · ⌘/Ctrl+Enter 提交',
+    '↑↓ 选择 · Enter 提交 · Esc 忽略 · ⌘/Ctrl+Enter 提交',
+  'askUser.shortcuts.multiSingle':
+    '↑↓ 选择 · Space 切换 · Enter 提交 · Esc 忽略',
   'askUser.shortcuts.multiNext':
     '↑↓ 选择 · Space 切换 · Enter 下一题 · Esc 忽略 · ⌘/Ctrl+Enter 提交',
   'askUser.shortcuts.multiFinal':
-    '↑↓ 选择 · Space 切换 · Enter 聚焦提交 · Esc 忽略 · ⌘/Ctrl+Enter 提交',
-  'askUser.shortcuts.input': 'Enter 确认 · Esc 退出编辑 · ⌘/Ctrl+Enter 提交',
+    '↑↓ 选择 · Space 切换 · Enter 提交 · Esc 忽略 · ⌘/Ctrl+Enter 提交',
+  'askUser.shortcuts.inputSingle': 'Enter 提交 · Esc 退出编辑',
+  'askUser.shortcuts.inputNext':
+    'Enter 下一题 · Esc 退出编辑 · ⌘/Ctrl+Enter 提交',
+  'askUser.shortcuts.inputFinal':
+    'Enter 提交 · Esc 退出编辑 · ⌘/Ctrl+Enter 提交',
   'copy.failedFallback': '复制到剪贴板失败',
   'copy.inlineLatexMissing': '最后一条 AI 输出中没有匹配的行内 LaTeX 表达式。',
   'copy.latexMissing': '最后一条 AI 输出中没有匹配的 LaTeX 块。',

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -571,6 +571,7 @@ const EN: Messages = {
     '↑↓ select · Space toggle · Enter next · Esc ignore · ⌘/Ctrl+Enter submit',
   'askUser.shortcuts.multiFinal':
     '↑↓ select · Space toggle · Enter submit · Esc ignore',
+  'askUser.shortcuts.customTrigger': '↑↓ select · Enter edit · Esc ignore',
   'askUser.shortcuts.inputSingle': 'Enter submit · Esc stop editing',
   'askUser.shortcuts.inputNext':
     'Enter next · Esc stop editing · ⌘/Ctrl+Enter submit',
@@ -3404,6 +3405,7 @@ const ZH: Messages = {
     '↑↓ 选择 · Space 切换 · Enter 下一题 · Esc 忽略 · ⌘/Ctrl+Enter 提交',
   'askUser.shortcuts.multiFinal':
     '↑↓ 选择 · Space 切换 · Enter 提交 · Esc 忽略',
+  'askUser.shortcuts.customTrigger': '↑↓ 选择 · Enter 编辑 · Esc 忽略',
   'askUser.shortcuts.inputSingle': 'Enter 提交 · Esc 退出编辑',
   'askUser.shortcuts.inputNext':
     'Enter 下一题 · Esc 退出编辑 · ⌘/Ctrl+Enter 提交',

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -561,6 +561,16 @@ const EN: Messages = {
   'askUser.progress': (v) => `${v?.current ?? 0}/${v?.total ?? 0} questions`,
   'askUser.selectAnswer': 'Select an answer',
   'askUser.typePlaceholder': 'Type something...',
+  'askUser.shortcuts.optionsNext':
+    '↑↓ select · Enter next · Esc ignore · ⌘/Ctrl+Enter submit',
+  'askUser.shortcuts.optionsFinal':
+    '↑↓ select · Enter focus Submit · Esc ignore · ⌘/Ctrl+Enter submit',
+  'askUser.shortcuts.multiNext':
+    '↑↓ select · Space toggle · Enter next · Esc ignore · ⌘/Ctrl+Enter submit',
+  'askUser.shortcuts.multiFinal':
+    '↑↓ select · Space toggle · Enter focus Submit · Esc ignore · ⌘/Ctrl+Enter submit',
+  'askUser.shortcuts.input':
+    'Enter confirm · Esc stop editing · ⌘/Ctrl+Enter submit',
   'copy.failedFallback': 'Failed to copy to the clipboard',
   'copy.inlineLatexMissing':
     'No matching inline LaTeX expression found in the last AI output.',
@@ -3380,6 +3390,15 @@ const ZH: Messages = {
   'askUser.progress': (v) => `${v?.current ?? 0}/${v?.total ?? 0} 个问题`,
   'askUser.selectAnswer': '选择一个答案',
   'askUser.typePlaceholder': '输入内容...',
+  'askUser.shortcuts.optionsNext':
+    '↑↓ 选择 · Enter 下一题 · Esc 忽略 · ⌘/Ctrl+Enter 提交',
+  'askUser.shortcuts.optionsFinal':
+    '↑↓ 选择 · Enter 聚焦提交 · Esc 忽略 · ⌘/Ctrl+Enter 提交',
+  'askUser.shortcuts.multiNext':
+    '↑↓ 选择 · Space 切换 · Enter 下一题 · Esc 忽略 · ⌘/Ctrl+Enter 提交',
+  'askUser.shortcuts.multiFinal':
+    '↑↓ 选择 · Space 切换 · Enter 聚焦提交 · Esc 忽略 · ⌘/Ctrl+Enter 提交',
+  'askUser.shortcuts.input': 'Enter 确认 · Esc 退出编辑 · ⌘/Ctrl+Enter 提交',
   'copy.failedFallback': '复制到剪贴板失败',
   'copy.inlineLatexMissing': '最后一条 AI 输出中没有匹配的行内 LaTeX 表达式。',
   'copy.latexMissing': '最后一条 AI 输出中没有匹配的 LaTeX 块。',


### PR DESCRIPTION
## What this PR does

Improves the Web Shell ask-user-question dialog for keyboard and mouse users. The dialog now keeps a per-question focus cursor, restores focus predictably after moving between questions, supports contextual Enter behavior, and provides Ctrl/Cmd+Enter as a direct submit shortcut where it adds value. Left and right arrows move between questions, while an arrow key pressed after focus leaves the option list first restores focus to the current selection instead of unexpectedly changing it.

Multi-select questions no longer preselect the first option. Mouse clicks and Space reliably toggle the intended option, Enter selects the focused option before moving to the next step or submitting, and hover and selected states are visually distinct. The custom-answer row keeps a stable height and alignment while entering edit mode, and Escape first exits editing before a subsequent Escape ignores the question.

The dialog uses regular dialog semantics, allows partially answered multi-question forms to be submitted, and moves compact shortcut hints into the footer. Ignore and Submit expose their shortcuts directly on the buttons, while contextual hints avoid repeating redundant actions or overflowing narrow split panes.

## Why it's needed

The previous interaction model had several ambiguous or unreliable states: focus could disappear between questions, revisiting a question could leave the keyboard cursor out of sync with the selected answer, rapid mouse clicks could toggle a different multi-select option, and hover styling made a cancelled selection still look selected. Shortcut copy also described actions that differed from the focused control, occupied an extra line, and duplicated equivalent submit paths.

These changes make the visible state match the action that will occur, preserve familiar native behavior for custom text input, and keep the dialog usable in narrow split panes without changing daemon or session APIs.

## Reviewer Test Plan

### How to verify

1. Trigger a single-choice question. Move with Up/Down, choose an option, and press Enter; the answer should submit immediately. Focus the empty custom-answer row and press Enter; it should enter editing rather than submit.
2. Trigger multiple questions. Use Enter to move forward, Left to return to the previous question, and Right to move forward again. Each question should restore its prior focused option and selected answer.
3. Move focus from the option list to another control inside the dialog, then press Up or Down. The first press should restore focus to the current selection without changing it; the next press should move the selection.
4. Trigger a multi-select question. Confirm nothing is selected initially. Rapidly click different options and click a selected option again; only the clicked option should toggle. Repeat with Space. Hover should remain visually different from selection.
5. On a multi-select question, focus an unselected option and press Enter. It should select that option before advancing or submitting.
6. Enter a custom answer, press Escape, and confirm the text is preserved while editing closes and focus returns to the custom-answer row. Press Escape again to ignore the question.
7. Submit a partially answered multi-question form and confirm it is accepted. Verify shortcut badges and hints remain compact in a narrow split pane.

Automated validation: all 56 focused AskUserQuestion tests pass. Changed TypeScript, TSX, localization, and CSS-related source passed targeted ESLint/format checks. Both Web Shell Vite application and library builds pass.

### Evidence (Before & After)

**Before:** Keyboard focus and selection could diverge across questions; multi-select mouse clicks could toggle stale state; the first multi-select option appeared selected by default; hover obscured cancellation; custom editing changed row geometry; and the shortcut line was long and sometimes contradicted the focused control.
<img width="1612" height="776" alt="image" src="https://github.com/user-attachments/assets/47ddc4e6-7007-4398-bcdc-949f92764f77" />

**After:** Live Web Shell checks confirmed stable option focus, predictable directional navigation, correct mouse and keyboard toggling, distinct hover/selected visuals, stable custom-input layout, and compact contextual shortcut hints.
<img width="1612" height="782" alt="image" src="https://github.com/user-attachments/assets/d203a469-66f2-4576-928d-b1e120f790a7" />

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS, local Web Shell daemon/runtime, dark theme.

## Risk & Scope

- Main risk or tradeoff: Enter is intentionally contextual: it edits an empty custom-answer row, selects and advances a multi-select option, advances intermediate questions, and submits the final answer.
- Not validated / out of scope: Windows and Linux visual checks were not run. The full repository build and Web Shell declaration build remain blocked by pre-existing type errors in unchanged CLI/Ink and Web Shell files; the affected Vite builds, focused tests, and changed-file lint checks pass.
- Breaking changes / migration notes: None. This is limited to the Web Shell ask-user-question UI and its localization.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

优化 Web Shell ask-user-question 弹窗的键盘和鼠标交互。弹窗会按题目保存焦点游标，在题目之间移动后稳定恢复焦点，并根据上下文处理 Enter；在有意义的场景中仍支持 Ctrl/Cmd+Enter 直接提交。左右方向键可以在题目之间移动；当选项列表失焦后，第一次按上下方向键只会把焦点恢复到当前选项，不会意外改变选择。

多选题不再默认选中第一项。鼠标点击和 Space 都会可靠地切换目标选项，Enter 会先选中当前选项，再进入下一步或提交；hover 与选中状态也使用不同视觉样式。自定义答案进入编辑状态时保持高度和图标对齐，Escape 会先退出编辑，再次按 Escape 才忽略问题。

弹窗改用普通 dialog 语义，允许提交部分完成的多题答案，并把紧凑的快捷键提示放到 footer。忽略和提交按钮直接展示快捷键，按上下文变化的提示不再重复相同行为，也不会撑破窄分屏。

## 为什么需要

此前交互存在多种不明确或不可靠的状态：题目切换后焦点可能丢失，返回上一题时键盘游标可能与已选答案不同步，连续鼠标点击可能切换到错误的多选项，hover 样式也会让已经取消的选项看起来仍处于选中状态。快捷键文案还可能与当前焦点的真实行为不一致，占用额外一行，并重复展示等价的提交方式。

这些调整让界面状态与实际动作保持一致，保留自定义文本输入的常规行为，并确保弹窗在窄分屏中仍然可用；daemon 和 session API 不受影响。

## Reviewer 测试计划

### 如何验证

1. 触发一道单选题。使用上下键移动并选中答案，按 Enter 后应直接提交。焦点位于空的自定义答案行时按 Enter，应进入编辑而不是提交。
2. 触发多道题。用 Enter 前进、左方向键返回、右方向键再次前进。每道题都应恢复之前的焦点项和已选答案。
3. 将焦点从选项列表移动到弹窗内的其他控件，再按上下键。第一次应只恢复到当前选项且不改变选择，第二次才移动选择。
4. 触发多选题，确认初始没有选中项。快速点击不同选项，再次点击已选项；只有被点击的目标项切换状态。用 Space 重复验证。hover 与选中效果应可区分。
5. 在多选题中聚焦未选项并按 Enter，应先选中该项，再进入下一步或提交。
6. 输入自定义答案后按 Escape，确认文字保留、编辑关闭且焦点回到自定义答案行；再次按 Escape 才忽略问题。
7. 提交只完成部分题目的多题表单并确认可以提交。在窄分屏中确认按钮快捷键和提示保持紧凑。

自动验证：AskUserQuestion 的 56 个定向测试全部通过。变更涉及的 TypeScript、TSX、本地化与样式相关源码通过定向 ESLint/格式检查；Web Shell 的 Vite 应用构建和库构建均通过。

### 证据（Before & After）

**Before：** 题目切换后键盘焦点可能与选中状态不同步；多选题鼠标点击可能基于旧状态切换错误选项；第一项会被默认选中；hover 会掩盖取消结果；自定义输入进入编辑时布局高度变化；快捷键提示过长且有时与当前焦点行为矛盾。

**After：** 在真实 Web Shell 中验证了稳定的选项焦点、可预测的方向键导航、正确的鼠标与键盘多选切换、可区分的 hover/选中视觉、稳定的自定义输入布局，以及紧凑的上下文快捷键提示。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS，本地 Web Shell daemon/runtime，深色主题。

## 风险与范围

- 主要风险或权衡：Enter 有明确的上下文行为——空自定义答案行进入编辑；多选项先选中再前进；中间题进入下一步；最后一题提交。
- 未验证 / 范围外：未执行 Windows 与 Linux 视觉检查。完整仓库构建和 Web Shell declaration build 仍被未修改的 CLI/Ink 与 Web Shell 文件中的既有类型错误阻塞；受影响的 Vite 构建、定向测试和变更文件 lint 均通过。
- Breaking changes / 迁移说明：无。改动仅限 Web Shell ask-user-question UI 及其本地化文案。

## 关联 Issue

N/A

</details>