### PR TITLE
fix(cli): give sandbox containers collision-proof names

### DIFF
--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -637,16 +637,16 @@ export async function start_sandbox(
     )}`;
     writeStderrLine(`ContainerName: ${containerName}`);
   } else {
-    let index = 0;
-    const containerNameCheck = execSync(
-      `${config.command} ps -a --format "{{.Names}}"`,
-    )
-      .toString()
-      .trim();
-    while (containerNameCheck.includes(`${imageName}-${index}`)) {
-      index++;
-    }
-    containerName = `${imageName}-${index}`;
+    // Random suffix, NOT a counted index: several runner registrations can
+    // share one docker daemon (the CI pool packs multiple runners per
+    // host), and the old count-then-run window let concurrent launches
+    // pick the same index — docker then rejects the loser's `docker run`
+    // with a name Conflict (exit 125). Observed at scale: 7 of 14 legs of
+    // one autofix scan lost that race in a single tick. Consumers that
+    // need the name parse it from the line below rather than predicting
+    // it, and cleanup tooling matches on the image-name prefix, so the
+    // suffix shape is free to be collision-proof.
+    containerName = `${imageName}-${randomBytes(4).toString('hex')}`;
     writeStderrLine(`ContainerName (regular): ${containerName}`);
   }
   args.push('--name', containerName, '--hostname', containerName);


### PR DESCRIPTION
## What this PR does

Replaces the sandbox container's counted name (`qwen-code-<ver>-<index>`) with a random 8-hex suffix — the same scheme the integration-test branch has always used.

## Why it's needed

The regular-run name was allocated check-then-run: count `docker ps -a`, take the first free index, then `docker run --name` — with nothing holding the name in between. On a daemon shared by several runner registrations (the CI pool packs multiple runners per host), simultaneous launches pick the same index and the loser gets:

```
docker: Error response from daemon: Conflict. The container name "/qwen-code-0.21.8-0"
is already in use by container "41d0274c1…"   (exit 125)
```

Measured at scale in [run 31389561905](https://github.com/QwenLM/qwen-code/actions/runs/31389561905): a dense autofix scan launched 14 legs across sibling registrations within seconds — **7 lost the race**, each failing one second into its agent step, burning a round, and pushing items toward their round caps. The failure clusters exactly by host: all losers shared a host prefix with a surviving winner (`hk-…s6t-12/-15/-18` lost where `-17` won; `64c-2/-5/-19` lost where `-8/-14` won).

Nothing predicts the name, so the suffix shape is free to change: `run-agent.mjs` parses the actual name from the `ContainerName (regular):` stderr line, and the stale-container reaper matches on the image-name prefix, which the suffix preserves. The `docker ps` call goes with the counter — one less `execSync` on the launch path.

## Reviewer Test Plan

```
cd packages/cli && npx vitest run src/utils/sandbox.test.ts
```

Expected: 25/25. The collision itself needs two simultaneous launches on one daemon to reproduce — the run above is the live evidence; with a 32-bit random suffix the birthday bound for the pool's launch rates is negligible.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

## Risk & Scope

- **Main risk or tradeoff:** container names are no longer sequential, so a human listing containers sees `qwen-code-0.21.8-a1b2c3d4` instead of `-0` — the prefix still identifies image and version. Anything that *predicted* the counted name would break, but the repo's consumers all parse or prefix-match (verified: run-agent's regex, the reaper's filter).
- **Not validated / out of scope:** the shared-daemon topology itself (several registrations per host) is taken as operational fact from the failure clustering; per-runner daemon isolation would also fix this class but is an infra decision.
- **Breaking changes / migration notes:** none.

## Linked Issues

Diagnosed from the 7-leg mass failure in run 31389561905.

<details>
<summary>中文说明</summary>

## What this PR does

把沙箱容器的计数命名(`qwen-code-<版本>-<序号>`)替换为随机 8 位十六进制后缀——与集成测试分支一贯的方案相同。

## Why it's needed

常规运行的名字是"先查后跑"分配的:数一遍 `docker ps -a`、取第一个空闲序号、再 `docker run --name`——两步之间没有任何东西占住这个名字。在多个 runner 注册共享一个 daemon 的宿主机上(CI 池每台宿主机部署多个 runner),同时启动的沙箱会选中同一序号,输家得到:

```
docker: Error response from daemon: Conflict. The container name "/qwen-code-0.21.8-0"
is already in use by container "41d0274c1…"   (exit 125)
```

在 [run 31389561905](https://github.com/QwenLM/qwen-code/actions/runs/31389561905) 中成规模实测:一次密集 autofix scan 在数秒内跨兄弟注册启动 14 条 leg——**7 条输掉竞争**,各自在 agent 步骤开始 1 秒内失败、烧掉一轮、把条目推向轮次上限。失败精确按宿主机聚类:所有输家都与某个存活的赢家共享宿主机前缀(`hk-…s6t-12/-15/-18` 输、`-17` 赢;`64c-2/-5/-19` 输、`-8/-14` 赢)。

没有任何组件预测这个名字,因此后缀形状可以自由改变:`run-agent.mjs` 从 `ContainerName (regular):` stderr 行解析真实名字,残留容器收割器按镜像名前缀匹配,后缀保留了前缀。计数器连同那次 `docker ps` 调用一起移除——启动路径少一次 `execSync`。

## Reviewer Test Plan

```
cd packages/cli && npx vitest run src/utils/sandbox.test.ts
```

预期 25/25。碰撞本身需要同一 daemon 上的两次同时启动才能复现——上面的 run 就是活证据;32 位随机后缀下,以该池的启动频率计生日碰撞概率可忽略。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

## Risk & Scope

- **主要风险与取舍:** 容器名不再连号,人工列容器时看到 `qwen-code-0.21.8-a1b2c3d4` 而非 `-0`——前缀仍标识镜像与版本。任何*预测*计数名的组件会破坏,但仓库内的消费方全部是解析或前缀匹配(已核实:run-agent 的正则、收割器的过滤器)。
- **未验证 / 范围之外:** 共享 daemon 的拓扑(每宿主机多注册)取自失败聚类的运维事实;按 runner 隔离 daemon 也能修此类问题,但那是基础设施决策。
- **破坏性变更 / 迁移说明:** 无。

## Linked Issues

从 run 31389561905 的 7-leg 集体失败诊断而来。

</details>
