### PR TITLE
test(acp): make exit plan mode test tolerant to LLM timeout

### DIFF
--- a/integration-tests/cli/acp-integration.test.ts
+++ b/integration-tests/cli/acp-integration.test.ts
@@ -778,12 +778,15 @@ function setupAcpTest(
           ],
         });
         expect(promptResult).toBeDefined();
-      } catch (_e) {
+      } catch (e) {
         if (stderr.length) {
           console.error('Agent stderr:', stderr.join(''));
         }
-        // Timeout is acceptable — LLM behavior is non-deterministic.
-        // Still proceed to verify whatever notifications were received.
+        // Only timeouts are acceptable — LLM behavior is non-deterministic.
+        // JSON-RPC errors indicate a real problem and must be surfaced.
+        if (!(e instanceof Error) || !e.message.includes('timed out')) {
+          throw e;
+        }
       }
 
       // Give time for all notifications to be processed

--- a/integration-tests/cli/acp-integration.test.ts
+++ b/integration-tests/cli/acp-integration.test.ts
@@ -310,6 +310,7 @@ function setupAcpTest(
     stderr,
     sessionUpdates,
     permissionRequests,
+    agent,
   };
 }
 
@@ -722,7 +723,7 @@ function setupAcpTest(
     // Track which permission requests we've seen
     const planModeRequests: PermissionRequest[] = [];
 
-    const { sendRequest, cleanup, stderr, sessionUpdates, permissionRequests } =
+    const { sendRequest, cleanup, stderr, sessionUpdates, permissionRequests, agent } =
       setupAcpTest(rig, {
         permissionHandler: (request) => {
           // Track all permission requests for later verification
@@ -784,22 +785,29 @@ function setupAcpTest(
         if (!(e instanceof Error) || !e.message.includes('timed out')) {
           throw e;
         }
+        // A dead agent also manifests as a timeout. Surface the crash instead
+        // of swallowing it as an acceptable slow-LLM path.
+        if (agent.exitCode !== null || agent.signalCode !== null) {
+          throw e;
+        }
       }
 
       // Poll for mode_update notification after switch_mode, bounded at 5 s.
       // A fixed delay races the slow-LLM path: switch_mode can arrive just
       // after the timeout, and mode_update may land after the wait window.
-      for (let i = 0; i < 20; i++) {
-        await delay(250);
-        const hasSwitchMode = permissionRequests.some(
-          (req) => req.toolCall?.kind === 'switch_mode',
-        );
-        if (!hasSwitchMode) continue;
-        const hasModeUpdate = sessionUpdates.some(
-          (update) => update.update?.sessionUpdate === 'current_mode_update',
-        );
-        if (hasModeUpdate) break;
-      }
+      await rig.poll(
+        () => {
+          const hasSwitchMode = permissionRequests.some(
+            (req) => req.toolCall?.kind === 'switch_mode',
+          );
+          if (!hasSwitchMode) return false;
+          return sessionUpdates.some(
+            (update) => update.update?.sessionUpdate === 'current_mode_update',
+          );
+        },
+        5000,
+        250,
+      );
 
       // Verify: If exit_plan_mode was called, we should have received:
       // 1. A permission request with kind: "switch_mode"

--- a/integration-tests/cli/acp-integration.test.ts
+++ b/integration-tests/cli/acp-integration.test.ts
@@ -780,9 +780,14 @@ function setupAcpTest(
         });
         expect(promptResult).toBeDefined();
       } catch (e) {
-        // Only timeouts are acceptable — LLM behavior is non-deterministic.
-        // JSON-RPC errors indicate a real problem and must be surfaced.
-        if (!(e instanceof Error) || !e.message.includes('timed out')) {
+        // Only the harness's own 60s request timeout is acceptable — LLM
+        // behavior is non-deterministic. JSON-RPC errors (errors with a
+        // `response` property) indicate a real problem and must be surfaced.
+        if (
+          !(e instanceof Error) ||
+          'response' in e ||
+          !/^Request \d+ \(session\/prompt\) timed out$/.test(e.message)
+        ) {
           throw e;
         }
         // A dead agent also manifests as a timeout. Surface the crash instead
@@ -790,6 +795,10 @@ function setupAcpTest(
         if (agent.exitCode !== null || agent.signalCode !== null) {
           throw e;
         }
+        console.error(
+          'session/prompt did not complete (continuing with partial verification):',
+          e,
+        );
       }
 
       // Poll for mode_update notification after switch_mode, bounded at 5 s.

--- a/integration-tests/cli/acp-integration.test.ts
+++ b/integration-tests/cli/acp-integration.test.ts
@@ -779,9 +779,6 @@ function setupAcpTest(
         });
         expect(promptResult).toBeDefined();
       } catch (e) {
-        if (stderr.length) {
-          console.error('Agent stderr:', stderr.join(''));
-        }
         // Only timeouts are acceptable — LLM behavior is non-deterministic.
         // JSON-RPC errors indicate a real problem and must be surfaced.
         if (!(e instanceof Error) || !e.message.includes('timed out')) {
@@ -789,8 +786,20 @@ function setupAcpTest(
         }
       }
 
-      // Give time for all notifications to be processed
-      await delay(1000);
+      // Poll for mode_update notification after switch_mode, bounded at 5 s.
+      // A fixed delay races the slow-LLM path: switch_mode can arrive just
+      // after the timeout, and mode_update may land after the wait window.
+      for (let i = 0; i < 20; i++) {
+        await delay(250);
+        const hasSwitchMode = permissionRequests.some(
+          (req) => req.toolCall?.kind === 'switch_mode',
+        );
+        if (!hasSwitchMode) continue;
+        const hasModeUpdate = sessionUpdates.some(
+          (update) => update.update?.sessionUpdate === 'current_mode_update',
+        );
+        if (hasModeUpdate) break;
+      }
 
       // Verify: If exit_plan_mode was called, we should have received:
       // 1. A permission request with kind: "switch_mode"

--- a/integration-tests/cli/acp-integration.test.ts
+++ b/integration-tests/cli/acp-integration.test.ts
@@ -762,18 +762,29 @@ function setupAcpTest(
       })) as unknown;
       expect(setModeResult).toEqual({});
 
-      // Send a prompt that should trigger the LLM to call exit_plan_mode
-      // The prompt is designed to trigger planning behavior
-      const promptResult = await sendRequest('session/prompt', {
-        sessionId: newSession.sessionId,
-        prompt: [
-          {
-            type: 'text',
-            text: 'Create a simple hello world function in Python. Make a brief plan and when ready, use the exit_plan_mode tool to present it for approval.',
-          },
-        ],
-      });
-      expect(promptResult).toBeDefined();
+      // Send a prompt that should trigger the LLM to call exit_plan_mode.
+      // The prompt is designed to trigger planning behavior, but LLM
+      // behavior is non-deterministic — it may take too long or never call
+      // exit_plan_mode. Catch timeouts so the test can still verify any
+      // notifications that were received.
+      try {
+        const promptResult = await sendRequest('session/prompt', {
+          sessionId: newSession.sessionId,
+          prompt: [
+            {
+              type: 'text',
+              text: 'Create a simple hello world function in Python. Make a brief plan and when ready, use the exit_plan_mode tool to present it for approval.',
+            },
+          ],
+        });
+        expect(promptResult).toBeDefined();
+      } catch (_e) {
+        if (stderr.length) {
+          console.error('Agent stderr:', stderr.join(''));
+        }
+        // Timeout is acceptable — LLM behavior is non-deterministic.
+        // Still proceed to verify whatever notifications were received.
+      }
 
       // Give time for all notifications to be processed
       await delay(1000);


### PR DESCRIPTION
## What this PR does

Wraps the `session/prompt` call in the exit plan mode ACP integration test with `try/catch` so a slow LLM response (timeout) does not fail the test. The test was already designed to tolerate the case where the LLM does not call `exit_plan_mode`; this PR extends that tolerance to also cover the case where the LLM takes longer than 60 seconds to complete the prompt.

## Why it's needed

The E2E Test - macOS - shard 2/2 job on `main` failed at run 31389207021 because the macOS runner's LLM call for `session/prompt` exceeded the hard 60-second timeout. The test already documents that LLM behavior is non-deterministic and treats missing `exit_plan_mode` calls as acceptable, but a timeout was not handled and caused a hard test failure.

## Reviewer Test Plan

### How to verify

Confirm that deterministic ACP setup failures still fail the test, while a timeout from the non-deterministic `session/prompt` call is logged and the test continues to validate any notifications already received. A response that completes within the timeout should preserve the existing behavior.

### Evidence (Before & After)

Before: an LLM response exceeding 60 seconds failed the integration test even though the test already tolerated the model not calling `exit_plan_mode`.

After: the prompt timeout follows the same tolerated non-deterministic path; deterministic initialization and handshake failures remain test failures.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

The original failure was observed in macOS CI. Exact-head Ubuntu CI is still running; no green exact-head result is claimed here.

## Risk & Scope

- Main risk or tradeoff: the prompt catch also tolerates non-timeout failures from the same non-deterministic LLM request.
- Not validated / out of scope: the underlying LLM latency on macOS CI and deterministic reproduction of a slow provider response.
- Breaking changes / migration notes: none; this changes one integration test only.

## Linked Issues

N/A — CI flake fix with no corresponding issue.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

将 exit plan mode ACP 集成测试中的 `session/prompt` 调用包裹在 `try/catch` 中，使 LLM 响应过慢（超时）时不再直接导致测试失败。该测试原本就允许 LLM 不调用 `exit_plan_mode`；本 PR 将相同的容忍范围扩展到 LLM 完成 prompt 超过 60 秒的场景。

## 为什么需要

`main` 分支的 E2E Test - macOS - shard 2/2 在 run 31389207021 失败，因为 macOS runner 上的 `session/prompt` LLM 调用超过了 60 秒硬超时。测试已经说明 LLM 行为具有不确定性，并允许模型不调用 `exit_plan_mode`，但此前没有处理超时，因此产生硬失败。

## Reviewer 测试计划

### 如何验证

确认确定性的 ACP 初始化失败仍会让测试失败，而非确定性的 `session/prompt` 超时会被记录，测试继续校验已经收到的通知。若模型在超时前完成响应，行为应保持不变。

### 证据（修改前后）

之前：LLM 响应超过 60 秒会让集成测试失败，尽管该测试已经允许模型不调用 `exit_plan_mode`。

之后：prompt 超时进入同一条可容忍的不确定路径；确定性的初始化与握手失败仍然是测试失败。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ⚠️  |
| 🪟 Windows | N/A  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

原始失败来自 macOS CI。exact-head Ubuntu CI 仍在运行，本描述不声称当前 head 已获得绿色结果。

## 风险与范围

- 主要风险或取舍：prompt catch 也会容忍来自同一非确定性 LLM 请求的非超时错误。
- 未验证 / 范围外：macOS CI 的底层 LLM 延迟，以及对慢 provider 响应的确定性复现。
- 破坏性变更 / 迁移说明：无；本 PR 只修改一个集成测试。

## 关联 Issue

N/A — 没有关联 issue 的 CI flake 修复。

</details>
