### PR TITLE
fix(webui): Make cross-session switching transactional

### DIFF
--- a/docs/design/2026-08-10-transactional-webui-session-switching.md
+++ b/docs/design/2026-08-10-transactional-webui-session-switching.md
@@ -1,0 +1,37 @@
+# Transactional cross-session switching
+
+## Problem
+
+The WebUI historically detached the current session, stopped its event stream, and cleared its transcript before a target `loadSession` or `resumeSession` completed. A slow or failed restore therefore left the user without the still-healthy source session. The WebShell also keyed its main provider by the requested session, so controlled navigation remounted the provider before the target was usable.
+
+## Scope
+
+This change makes only cross-logical-session load and resume transactional. A logical target is the normalized `(sessionId, workspaceCwd)` pair. Initial bootstrap, same-logical reload, client-id replacement, full resync, memory repair, and branch adoption retain their existing behavior and are follow-up work.
+
+Modern transactional behavior requires a successful capability snapshot that advertises `client_identity` and concrete client IDs for both attachments. A daemon that explicitly lacks the feature retains the legacy destructive path. Unknown capabilities or malformed modern responses fail closed and preserve the source.
+
+## Coordinator
+
+Each provider owns one raw restore slot and one desired intent. Equivalent requests coalesce. A newer target rejects the prior public intent and replaces the queued intent, while an already-running SDK request continues to settlement because it is not cancellable. Its result is adopted only when it still matches the latest target; otherwise its attachment is detached once on a best-effort basis. The queued deadline begins when the caller requests the switch, so an expired target never starts a restore.
+
+Commit is guarded by the desired intent, absolute deadline, provider environment, local lifecycle, source logical identity, and restored target identity. Timeout, SDK failure, supersede, staging failure, and commit are explicit competing terminal states rather than an implicit `Promise.race`.
+
+## Staging and commit
+
+Replay is normalized into an unsubscribed shadow transcript store in batches of at most 512 events. The compacted replay and live journal arrays are traversed directly and are not concatenated. Only bounded summaries of notices and side-channel events are retained. Staging never writes the visible transcript, connection, prompt maps, notices, or workspace signals.
+
+After the final guard succeeds, one synchronous commit flushes the source runner's legal buffered events, stops its stream, installs the target transcript/history/session/workspace/client and connection ref, notifies the WebShell wrapper, publishes staged side effects, and settles source-local prompt waiters. The public load promise resolves only after those synchronous owners agree. Target metadata and SSE start afterward without a second restore. Source detach is asynchronous, single-attempt, and never blocks the public result or the next restore.
+
+## WebShell ownership
+
+For modern daemons, the main workspace wrapper keeps one provider instance and separates the desired target from the committed target. Workspace resolution and restore failures continue rendering the committed source. A synchronous commit callback advances wrapper ownership before the public promise resolves. Stable failed targets are latched so unrelated renders do not retry them; a controlled failure rolls the host back only while the failed desired generation is still current.
+
+Session transition state gates new prompt and mutation entry points while preserving the source event stream, existing prompt completion, cancellation, permissions, and read-only controls. UI navigation uses an invocation token plus an attachment-identity snapshot so stale completion handlers cannot clear or focus a newer request. Session-owned worktree, branch, git intent, and recap state are not cleared until ownership commits.
+
+## Compatibility and risks
+
+Legacy daemons keep the old keyed/destructive behavior. Cleanup is deliberately best effort: a failed detach can leave an invisible client reference until the existing reaper runs. Staging temporarily holds the source transcript and target replay at once, and CPU-heavy restore work in a shared ACP child can still delay source events. This change does not optimize JSONL reading, selective replay, or daemon capacity.
+
+## Verification
+
+Unit coverage exercises delayed success/failure, exact-target coalescing, latest-only serialization, controlled switching, malformed ownership, write gating, synchronous commit ownership, source events during preparation, wrapper remount compatibility, workspace resolution failure, invocation fencing, and post-commit catch-up timeout behavior. A focused JSDOM/real-daemon test delays delivery of an already-completed target restore response and verifies that the source remains usable until atomic commit; a structured 504 must leave the source intact.

--- a/integration-tests/cli/qwen-serve-webui-session-switching.test.ts
+++ b/integration-tests/cli/qwen-serve-webui-session-switching.test.ts
@@ -1,0 +1,334 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { act, createElement } from 'react';
+import type { Root } from 'react-dom/client';
+import { JSDOM } from 'jsdom';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import {
+  DaemonHttpError,
+  type DaemonTranscriptBlock,
+} from '@qwen-code/sdk/daemon';
+import {
+  makeTempWorkspace,
+  spawnDaemon,
+  type SpawnedDaemon,
+} from './_daemon-harness.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MOCK_AGENT_PATH = path.resolve(
+  __dirname,
+  '../fixtures/mock-acp-child/agent.mjs',
+);
+
+let activeDaemon: SpawnedDaemon | undefined;
+let root: Root | undefined;
+let dom: JSDOM;
+let createRoot: typeof import('react-dom/client').createRoot;
+let DaemonSessionProvider: typeof import('@qwen-code/webui/daemon-react-sdk').DaemonSessionProvider;
+let useActions: typeof import('@qwen-code/webui/daemon-react-sdk').useActions;
+let useConnection: typeof import('@qwen-code/webui/daemon-react-sdk').useConnection;
+let useTranscriptBlocks: typeof import('@qwen-code/webui/daemon-react-sdk').useTranscriptBlocks;
+const originalGlobalDescriptors = new Map(
+  ['window', 'document', 'navigator', 'IS_REACT_ACT_ENVIRONMENT'].map(
+    (key) => [key, Object.getOwnPropertyDescriptor(globalThis, key)] as const,
+  ),
+);
+
+beforeAll(async () => {
+  dom = new JSDOM('<!doctype html><html><body></body></html>', {
+    url: 'http://localhost',
+  });
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: dom.window,
+  });
+  Object.defineProperty(globalThis, 'document', {
+    configurable: true,
+    value: dom.window.document,
+  });
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: dom.window.navigator,
+  });
+  Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+    configurable: true,
+    value: true,
+  });
+  ({ createRoot } = await import('react-dom/client'));
+  ({ DaemonSessionProvider, useActions, useConnection, useTranscriptBlocks } =
+    await import('@qwen-code/webui/daemon-react-sdk'));
+});
+
+afterAll(() => {
+  dom.window.close();
+  for (const [key, descriptor] of originalGlobalDescriptors) {
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else Reflect.deleteProperty(globalThis, key);
+  }
+});
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => root?.unmount());
+    root = undefined;
+  }
+  await activeDaemon?.dispose();
+  activeDaemon = undefined;
+});
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function waitFor(
+  condition: () => boolean,
+  description: string,
+  timeoutMs = 8_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (condition()) return;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+  }
+  throw new Error(`Timed out waiting for ${description}`);
+}
+
+describe('qwen serve WebUI transactional session switching', () => {
+  async function setup() {
+    const workspace = makeTempWorkspace('webui-session-switching');
+    activeDaemon = await spawnDaemon({
+      workspaceCwd: workspace,
+      env: {
+        QWEN_CLI_ENTRY: MOCK_AGENT_PATH,
+        MOCK_ACP_MODE: 'echo',
+      },
+    });
+    const source = await activeDaemon.client.createOrAttachSession({
+      sessionScope: 'thread',
+    });
+    const resolvedWorkspace = source.workspaceCwd ?? workspace;
+    await activeDaemon.client.prompt(source.sessionId, {
+      prompt: [{ type: 'text', text: 'source transcript' }],
+    });
+    const target = await activeDaemon.client.createOrAttachSession({
+      sessionScope: 'thread',
+    });
+    await activeDaemon.client.prompt(target.sessionId, {
+      prompt: [{ type: 'text', text: 'target transcript' }],
+    });
+    let actions: ReturnType<typeof useActions> | undefined;
+    let connection: ReturnType<typeof useConnection> | undefined;
+    let blocks: readonly DaemonTranscriptBlock[] = [];
+    function Harness() {
+      actions = useActions();
+      connection = useConnection();
+      blocks = useTranscriptBlocks();
+      return null;
+    }
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(
+        createElement(
+          DaemonSessionProvider,
+          {
+            autoConnect: true,
+            baseUrl: activeDaemon!.base,
+            token: activeDaemon!.token,
+            sessionId: source.sessionId,
+            workspaceCwd: resolvedWorkspace,
+          },
+          createElement(Harness),
+        ),
+      );
+    });
+    await waitFor(
+      () =>
+        connection?.status === 'connected' &&
+        connection.sessionId === source.sessionId &&
+        connection.capabilities?.features.includes('client_identity') ===
+          true &&
+        JSON.stringify(blocks).includes('source transcript'),
+      'source session bootstrap',
+    );
+    return {
+      workspace: resolvedWorkspace,
+      source,
+      target,
+      getActions: () => {
+        if (!actions) throw new Error('session actions unavailable');
+        return actions;
+      },
+      getConnection: () => connection,
+      getBlocks: () => blocks,
+    };
+  }
+
+  it('keeps the source usable until a completed target response is released', async () => {
+    const originalFetch = globalThis.fetch;
+    const state = await setup();
+    const responseReady = deferred();
+    const releaseResponse = deferred();
+    let loadOutcome: Promise<unknown> | undefined;
+    try {
+      globalThis.fetch = async (input, init) => {
+        const request =
+          input instanceof Request ? input : new Request(input, init);
+        const response = await originalFetch(request);
+        if (
+          request.method === 'POST' &&
+          new URL(request.url).pathname.endsWith(
+            `/session/${encodeURIComponent(state.target.sessionId)}/load`,
+          )
+        ) {
+          responseReady.resolve();
+          await releaseResponse.promise;
+        }
+        return response;
+      };
+      act(() => {
+        loadOutcome = state
+          .getActions()
+          .loadSession(state.target.sessionId, {
+            workspaceCwd: state.workspace,
+          })
+          .then(
+            () => undefined,
+            (error: unknown) => error,
+          );
+      });
+      await responseReady.promise;
+
+      expect(state.getConnection()).toMatchObject({
+        status: 'connected',
+        sessionId: state.source.sessionId,
+        sessionTransition: { phase: 'preparing' },
+      });
+      await expect(state.getActions().cancel()).resolves.toBeUndefined();
+      await activeDaemon!.client.prompt(state.source.sessionId, {
+        prompt: [{ type: 'text', text: 'source remains live' }],
+      });
+      await waitFor(
+        () => JSON.stringify(state.getBlocks()).includes('source remains live'),
+        'source event while target response is held',
+      );
+
+      await act(async () => {
+        releaseResponse.resolve();
+        expect(await loadOutcome).toBeUndefined();
+      });
+      expect(state.getConnection()).toMatchObject({
+        status: 'connected',
+        sessionId: state.target.sessionId,
+      });
+      expect(JSON.stringify(state.getBlocks())).toContain('target transcript');
+      expect(JSON.stringify(state.getBlocks())).not.toContain(
+        'source remains live',
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      releaseResponse.resolve();
+      await loadOutcome?.catch(() => undefined);
+      if (root) {
+        await act(async () => root?.unmount());
+        root = undefined;
+      }
+      await activeDaemon?.dispose();
+      activeDaemon = undefined;
+      fs.rmSync(state.workspace, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it('preserves the source after a structured target timeout', async () => {
+    const originalFetch = globalThis.fetch;
+    const state = await setup();
+    try {
+      globalThis.fetch = async (input, init) => {
+        const request =
+          input instanceof Request ? input : new Request(input, init);
+        if (
+          request.method === 'POST' &&
+          new URL(request.url).pathname.endsWith(
+            `/session/${encodeURIComponent(state.target.sessionId)}/load`,
+          )
+        ) {
+          return new Response(
+            JSON.stringify({
+              code: 'session_restore_timeout',
+              error: 'Session restore timed out',
+              retryable: true,
+            }),
+            {
+              status: 504,
+              headers: {
+                'Content-Type': 'application/json',
+                'Retry-After': '5',
+              },
+            },
+          );
+        }
+        return originalFetch(request);
+      };
+      let restoreError: unknown;
+      await act(async () => {
+        try {
+          await state.getActions().loadSession(state.target.sessionId, {
+            workspaceCwd: state.workspace,
+          });
+        } catch (error) {
+          restoreError = error;
+        }
+      });
+      expect(restoreError).toBeInstanceOf(DaemonHttpError);
+      expect(restoreError).toMatchObject({
+        status: 504,
+        body: {
+          code: 'session_restore_timeout',
+          retryable: true,
+        },
+      });
+      expect(state.getConnection()).toMatchObject({
+        status: 'connected',
+        sessionId: state.source.sessionId,
+        sessionTransition: {
+          phase: 'failed',
+          error: { code: 'session_restore_timeout', status: 504 },
+        },
+      });
+      expect(JSON.stringify(state.getBlocks())).toContain('source transcript');
+      await activeDaemon!.client.prompt(state.source.sessionId, {
+        prompt: [{ type: 'text', text: 'source after timeout' }],
+      });
+      await waitFor(
+        () =>
+          JSON.stringify(state.getBlocks()).includes('source after timeout'),
+        'source event after target timeout',
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (root) {
+        await act(async () => root?.unmount());
+        root = undefined;
+      }
+      await activeDaemon?.dispose();
+      activeDaemon = undefined;
+      fs.rmSync(state.workspace, { recursive: true, force: true });
+    }
+  }, 30_000);
+});

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -274,6 +274,7 @@ const {
       listScheduledTasks: vi.fn(),
       updateScheduledTask: vi.fn(),
       deleteScheduledTask: vi.fn(),
+      deleteModel: vi.fn().mockResolvedValue(undefined),
     },
     mockMcp: {
       initialize: vi.fn().mockResolvedValue({ accepted: true }),
@@ -363,6 +364,15 @@ const {
       settings: [] as DaemonSettingDescriptor[],
       latestSettingsState: null as {
         settings: DaemonSettingDescriptor[];
+      } | null,
+      latestModelManagement: null as {
+        busy?: boolean;
+        onSelectModel?: (modelId: string) => void;
+        onDeleteModel?: (target: {
+          authType: string;
+          modelId: string;
+          baseUrl?: string;
+        }) => void;
       } | null,
       latestScheduledTasksProps: null as {
         onRunPrompt?: (
@@ -722,8 +732,18 @@ vi.mock('./components/messages/SettingsMessage', async () => {
         language: string,
         scope: 'user' | 'workspace',
       ) => void;
+      modelManagement?: {
+        busy?: boolean;
+        onSelectModel?: (modelId: string) => void;
+        onDeleteModel?: (target: {
+          authType: string;
+          modelId: string;
+          baseUrl?: string;
+        }) => void;
+      };
     }) => {
       testState.latestSettingsState = props.settingsState;
+      testState.latestModelManagement = props.modelManagement ?? null;
       return React.createElement(
         'div',
         { 'data-testid': 'settings-message' },
@@ -4453,6 +4473,7 @@ beforeEach(() => {
   testState.latestMonitorDetailsOnOpen = null;
   testState.settings = [];
   testState.latestSettingsState = null;
+  testState.latestModelManagement = null;
   testState.latestScheduledTasksProps = null;
   testState.latestGoalsProps = null;
   rawEnqueuePrompt.mockClear();
@@ -4556,6 +4577,8 @@ beforeEach(() => {
   mockWorkspaceActions.listScheduledTasks.mockReset();
   mockWorkspaceActions.updateScheduledTask.mockReset();
   mockWorkspaceActions.deleteScheduledTask.mockReset();
+  mockWorkspaceActions.deleteModel.mockReset();
+  mockWorkspaceActions.deleteModel.mockResolvedValue(undefined);
   mockMcp.initialize.mockClear();
   mockMcp.initialize.mockResolvedValue({ accepted: true });
   mockMcp.reloadConfig.mockClear();
@@ -11284,6 +11307,46 @@ describe('App session callbacks', () => {
     });
   });
 
+  it('preserves the turn-error retry while session writes are blocked', async () => {
+    const { container, rerender } = renderApp();
+    await flush();
+
+    testState.prompt = 'recover this stream';
+    await clickSubmit(container);
+    mockSessionActions.sendPrompt.mockClear();
+    act(() => {
+      testState.blocks = [
+        {
+          kind: 'error',
+          source: 'turn_error',
+          id: 'turn-error-switching',
+          errorKind: 'model_stream_interrupted',
+          text: 'terminated',
+        },
+      ];
+      rerender({ desiredSessionTargetPending: true });
+    });
+
+    const retry = container.querySelector<HTMLButtonElement>(
+      '[data-testid="retry"]',
+    );
+    expect(retry).not.toBeNull();
+    act(() => retry?.click());
+
+    expect(mockSessionActions.sendPrompt).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
+
+    act(() => rerender({ desiredSessionTargetPending: false }));
+    await flush();
+    const unblockedRetry = container.querySelector<HTMLButtonElement>(
+      '[data-testid="retry"]',
+    );
+    expect(unblockedRetry).not.toBeNull();
+    act(() => unblockedRetry?.click());
+    await flush();
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledOnce();
+  });
+
   it('does not settle a turn-error retry into a different workspace', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const retrySend = deferred<void>();
@@ -11835,6 +11898,71 @@ describe('App session callbacks', () => {
     });
 
     expect(mockSessionActions.sendPrompt).not.toHaveBeenCalled();
+    expect(testState.latestChatEditorProps?.isPreparing).toBe(false);
+  });
+
+  it('clears deferred plan preparation after a same-session reattach', async () => {
+    const approval = deferred<void>();
+    mockSessionActions.setApprovalMode.mockReturnValueOnce(approval.promise);
+    const { container, rerender } = renderApp();
+    await flush();
+
+    testState.prompt = '/plan explain the migration';
+    await clickSubmit(container);
+    expect(testState.latestChatEditorProps?.isPreparing).toBe(true);
+
+    act(() => {
+      testState.ownerVersion += 1;
+      rerender();
+    });
+    await act(async () => {
+      approval.resolve();
+      await approval.promise;
+    });
+
+    expect(mockSessionActions.sendPrompt).not.toHaveBeenCalled();
+    expect(testState.latestChatEditorProps?.isPreparing).toBe(false);
+  });
+
+  it('does not let an A-to-B-to-A plan completion clear newer preparation', async () => {
+    const firstApproval = deferred<void>();
+    const secondApproval = deferred<void>();
+    mockSessionActions.setApprovalMode
+      .mockReturnValueOnce(firstApproval.promise)
+      .mockReturnValueOnce(secondApproval.promise);
+    const { container, rerender } = renderApp();
+    await flush();
+
+    testState.prompt = '/plan first';
+    await clickSubmit(container);
+
+    act(() => {
+      testState.ownerVersion += 1;
+      mockConnection.sessionId = 'session-2';
+      rerender();
+    });
+    await flush();
+    act(() => {
+      testState.ownerVersion += 1;
+      mockConnection.sessionId = 'session-1';
+      rerender();
+    });
+    await flush();
+
+    testState.prompt = '/plan second';
+    await clickSubmit(container);
+    expect(testState.latestChatEditorProps?.isPreparing).toBe(true);
+
+    await act(async () => {
+      firstApproval.resolve();
+      await firstApproval.promise;
+    });
+    expect(testState.latestChatEditorProps?.isPreparing).toBe(true);
+
+    await act(async () => {
+      secondApproval.resolve();
+      await secondApproval.promise;
+    });
     expect(testState.latestChatEditorProps?.isPreparing).toBe(false);
   });
 
@@ -14600,6 +14728,124 @@ describe('App session callbacks', () => {
     ).toBe(true);
     expect(container.querySelector('[data-testid="inline-panel"]')).toBeNull();
     expect(settingsReload).toHaveBeenCalled();
+  });
+
+  it('clears model selection busy state after a same-session reattach', async () => {
+    const selection = deferred<void>();
+    mockSessionActions.setModel.mockReturnValueOnce(selection.promise);
+    const { container, rerender } = renderApp();
+    await flush();
+    testState.prompt = '/settings';
+    await clickSubmit(container);
+    await flush();
+
+    act(() => testState.latestModelManagement?.onSelectModel?.('qwen-next'));
+    expect(testState.latestModelManagement?.busy).toBe(true);
+
+    act(() => {
+      testState.ownerVersion += 1;
+      rerender();
+    });
+    await act(async () => {
+      selection.resolve();
+      await selection.promise;
+    });
+
+    expect(testState.latestModelManagement?.busy).toBe(false);
+  });
+
+  it('does not let an A-to-B-to-A model completion clear a newer selection', async () => {
+    const firstSelection = deferred<void>();
+    const secondSelection = deferred<void>();
+    mockSessionActions.setModel
+      .mockReturnValueOnce(firstSelection.promise)
+      .mockReturnValueOnce(secondSelection.promise);
+    const { container, rerender } = renderApp();
+    await flush();
+    testState.prompt = '/settings';
+    await clickSubmit(container);
+    await flush();
+    act(() => testState.latestModelManagement?.onSelectModel?.('model-a'));
+
+    act(() => {
+      testState.ownerVersion += 1;
+      mockConnection.sessionId = 'session-2';
+      rerender();
+    });
+    await flush();
+    act(() => {
+      testState.ownerVersion += 1;
+      mockConnection.sessionId = 'session-1';
+      rerender();
+    });
+    await flush();
+
+    testState.prompt = '/settings';
+    await clickSubmit(container);
+    await flush();
+    act(() => testState.latestModelManagement?.onSelectModel?.('model-b'));
+    expect(testState.latestModelManagement?.busy).toBe(true);
+
+    await act(async () => {
+      firstSelection.resolve();
+      await firstSelection.promise;
+    });
+    expect(testState.latestModelManagement?.busy).toBe(true);
+
+    await act(async () => {
+      secondSelection.resolve();
+      await secondSelection.promise;
+    });
+    expect(testState.latestModelManagement?.busy).toBe(false);
+  });
+
+  it('does not let an A-to-B-to-A deletion clear a newer selection', async () => {
+    const deletion = deferred<undefined>();
+    const selection = deferred<void>();
+    mockWorkspaceActions.deleteModel.mockReturnValueOnce(deletion.promise);
+    mockSessionActions.setModel.mockReturnValueOnce(selection.promise);
+    const { container, rerender } = renderApp();
+    await flush();
+    testState.prompt = '/settings';
+    await clickSubmit(container);
+    await flush();
+    act(() =>
+      testState.latestModelManagement?.onDeleteModel?.({
+        authType: 'api-key',
+        modelId: 'old-model',
+      }),
+    );
+
+    act(() => {
+      testState.ownerVersion += 1;
+      mockConnection.sessionId = 'session-2';
+      rerender();
+    });
+    await flush();
+    act(() => {
+      testState.ownerVersion += 1;
+      mockConnection.sessionId = 'session-1';
+      rerender();
+    });
+    await flush();
+
+    testState.prompt = '/settings';
+    await clickSubmit(container);
+    await flush();
+    act(() => testState.latestModelManagement?.onSelectModel?.('model-b'));
+    expect(testState.latestModelManagement?.busy).toBe(true);
+
+    await act(async () => {
+      deletion.resolve(undefined);
+      await deletion.promise;
+    });
+    expect(testState.latestModelManagement?.busy).toBe(true);
+
+    await act(async () => {
+      selection.resolve();
+      await selection.promise;
+    });
+    expect(testState.latestModelManagement?.busy).toBe(false);
   });
 
   it('sends /model --fast with --global when the fast-model picker is opened from the User tab', async () => {

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -316,10 +316,21 @@ const {
       latestStatusBarTasks: null as DaemonSessionMonitorTaskStatus[] | null,
       latestStatusBarOnOpenTasks: null as (() => void) | null,
       latestMessageListProps: null as {
+        messages?: Array<{
+          role?: string;
+          content?: string;
+          answer?: string;
+          isPending?: boolean;
+        }>;
         failedPromptMessageId?: string;
         onRetryFailedPrompt?: () => void;
         isResponding?: boolean;
         activeTurnStartedAt?: number;
+      } | null,
+      latestBtwMessageProps: null as {
+        question: string;
+        answer: string;
+        isPending: boolean;
       } | null,
       latestAddWorkspaceDialogProps: null as AddWorkspaceDialogTestProps | null,
       latestToolApprovalKeyboardActive: null as boolean | null,
@@ -646,6 +657,12 @@ vi.mock('./components/MessageList', async () => {
   return {
     MessageList: React.forwardRef(function MessageList(
       props: {
+        messages?: Array<{
+          role?: string;
+          content?: string;
+          answer?: string;
+          isPending?: boolean;
+        }>;
         showRetryHint?: boolean;
         onRetryClick?: () => void;
         failedPromptMessageId?: string;
@@ -1459,7 +1476,19 @@ vi.doMock('./monitorDetailsContext', async () => {
     },
   };
 });
-mockComponent('./components/messages/BtwMessage', 'BtwMessage');
+vi.doMock('./components/messages/BtwMessage', async () => {
+  const React = await import('react');
+  return {
+    BtwMessage: (props: {
+      question: string;
+      answer: string;
+      isPending: boolean;
+    }) => {
+      testState.latestBtwMessageProps = props;
+      return React.createElement('div');
+    },
+  };
+});
 mockComponent('./components/QueuedPromptDisplay', 'QueuedPromptDisplay');
 
 const {
@@ -4408,6 +4437,7 @@ beforeEach(() => {
   testState.latestStatusBarTasks = null;
   testState.latestStatusBarOnOpenTasks = null;
   testState.latestMessageListProps = null;
+  testState.latestBtwMessageProps = null;
   testState.latestAddWorkspaceDialogProps = null;
   testState.latestToolApprovalKeyboardActive = null;
   testState.toolApprovalKeyboardActiveHistory = [];
@@ -11254,6 +11284,57 @@ describe('App session callbacks', () => {
     });
   });
 
+  it('does not settle a turn-error retry into a different workspace', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const retrySend = deferred<void>();
+    const { container, rerender } = renderApp();
+    await flush();
+
+    testState.prompt = 'recover this stream';
+    await clickSubmit(container);
+    mockSessionActions.sendPrompt.mockClear();
+    act(() => {
+      testState.blocks = [
+        {
+          kind: 'error',
+          source: 'turn_error',
+          id: 'turn-error-cross-workspace',
+          errorKind: 'model_stream_interrupted',
+          text: 'terminated',
+        },
+      ];
+      rerender();
+    });
+    mockSessionActions.sendPrompt.mockReturnValueOnce(retrySend.promise);
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+        ?.click();
+      await Promise.resolve();
+    });
+    const retryOptions = mockSessionActions.sendPrompt.mock.calls[0]?.[1];
+    act(() => {
+      retryOptions?.onAdmissionStarted?.();
+      mockConnection.workspaceCwd = '/other-workspace';
+      testState.ownerVersion += 1;
+      rerender();
+    });
+    await act(async () => {
+      retrySend.reject(new Error('response lost'));
+      await Promise.resolve();
+    });
+
+    expect(
+      container.querySelector('[data-testid="prompt-admission-unknown"]'),
+    ).toBeNull();
+    expect(warn).not.toHaveBeenCalledWith(
+      '[WebShell] post-turn retry admission outcome is unknown',
+      expect.anything(),
+    );
+    warn.mockRestore();
+  });
+
   it('locks an image retry when its admission response is lost', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const retrySend = deferred<void>();
@@ -11473,6 +11554,65 @@ describe('App session callbacks', () => {
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
     expect(container.querySelector('button[title="Side task"]')).toBeNull();
+  });
+
+  it('settles visible recap after a same-id attachment replacement', async () => {
+    const recap = deferred<{ sessionId: string; recap: string | null }>();
+    mockSessionActions.recapSession.mockReturnValueOnce(recap.promise);
+    const { container, rerender } = renderApp();
+    await flush();
+
+    testState.prompt = '/recap';
+    await clickSubmit(container);
+    expect(
+      testState.latestMessageListProps?.messages?.some((message) =>
+        message.content?.includes('Generating recap'),
+      ),
+    ).toBe(true);
+
+    act(() => {
+      testState.ownerVersion += 1;
+      rerender();
+    });
+    await act(async () => {
+      recap.resolve({ sessionId: 'session-1', recap: 'Reconnect-safe recap' });
+      await recap.promise;
+    });
+
+    expect(
+      testState.latestMessageListProps?.messages?.some((message) =>
+        message.content?.includes('Reconnect-safe recap'),
+      ),
+    ).toBe(true);
+  });
+
+  it('settles visible btw after a same-id attachment replacement', async () => {
+    const btw = deferred<{ answer: string }>();
+    mockSessionActions.btwSession.mockReturnValueOnce(btw.promise);
+    const { container, rerender } = renderApp();
+    await flush();
+
+    testState.prompt = '/btw keep this answer';
+    await clickSubmit(container);
+    expect(testState.latestBtwMessageProps).toMatchObject({
+      question: 'keep this answer',
+      isPending: true,
+    });
+
+    act(() => {
+      testState.ownerVersion += 1;
+      rerender();
+    });
+    await act(async () => {
+      btw.resolve({ answer: 'Reconnect-safe answer' });
+      await btw.promise;
+    });
+
+    expect(testState.latestBtwMessageProps).toMatchObject({
+      question: 'keep this answer',
+      answer: 'Reconnect-safe answer',
+      isPending: false,
+    });
   });
 
   it('opens a new side task for /btw side when the capability is available', async () => {
@@ -15129,6 +15269,67 @@ describe('App prompt send failure retry', () => {
       rerender();
       await Promise.resolve();
     });
+  });
+
+  it('settles a prompt retry after a same-id attachment replacement', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const firstSend = deferred<void>();
+    const retrySend = deferred<void>();
+    let retryAdmitted: (() => void) | undefined;
+    mockSessionActions.sendPrompt
+      .mockImplementationOnce(() => {
+        testState.blocks = [{ id: 'u1', kind: 'user' }];
+        return firstSend.promise;
+      })
+      .mockImplementationOnce(
+        (
+          _text: string,
+          options?: {
+            onAdmitted?: () => void;
+          },
+        ) => {
+          retryAdmitted = options?.onAdmitted;
+          return retrySend.promise;
+        },
+      );
+    const { container, rerender } = renderApp();
+    await flush();
+
+    act(() => {
+      testState.latestChatEditorProps?.onSubmit('hello');
+    });
+    testState.messages = [{ id: 'u1', role: 'user', content: 'hello' }];
+    await act(async () => {
+      firstSend.reject(new DaemonHttpError(413, {}, 'Prompt too large'));
+      await Promise.resolve();
+    });
+    act(() =>
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="failed-prompt-retry"]')
+        ?.click(),
+    );
+
+    act(() => {
+      testState.ownerVersion += 1;
+      rerender();
+      retryAdmitted?.();
+    });
+    await act(async () => {
+      retrySend.resolve();
+      await retrySend.promise;
+      testState.streamingState = 'idle';
+      rerender();
+      await Promise.resolve();
+    });
+    act(() => {
+      testState.streamingState = 'responding';
+      rerender();
+    });
+
+    expect(testState.latestMessageListProps?.isResponding).toBe(true);
+    expect(
+      container.querySelector('[data-testid="streaming-status"]'),
+    ).not.toBeNull();
   });
 
   it('shows processing only after retry admission and restarts its timer', async () => {

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -301,6 +301,7 @@ const {
       onDismissFollowup: vi.fn(),
     },
     testState: {
+      ownerVersion: 0,
       prompt: 'hello',
       inputAnnotations: undefined as DaemonInputAnnotation[] | undefined,
       promptImages: undefined as
@@ -392,51 +393,60 @@ const {
   };
 });
 
-vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
-  DAEMON_APPROVAL_MODES: ['default', 'plan', 'auto-edit', 'auto', 'yolo'],
-  DaemonSessionProvider: ({ children }: { children: ReactNode }) => children,
-  useActions: () => mockSessionActions,
-  useConnection: () => mockConnection,
-  useDaemonFollowupSuggestion: () => ({
-    followupState: null,
-    clear: mockFollowup.clear,
-    onAcceptFollowup: mockFollowup.onAcceptFollowup,
-    onDismissFollowup: mockFollowup.onDismissFollowup,
-  }),
-  useSessionNotices: () => ({ notices: [], dismissNotice: vi.fn() }),
-  usePromptStatus: () => 'idle',
-  useSettings: () => ({
-    settings: testState.settings,
-    setValue: settingsSetValue,
-    reload: settingsReload,
-    loading: false,
-  }),
-  useProviders: () => ({
-    providers: [],
-    current: undefined,
-    loading: false,
-    error: undefined,
-    reload: vi.fn().mockResolvedValue(undefined),
-  }),
-  useStreamingState: () => testState.streamingState,
-  useTranscriptBlocks: () => testState.blocks,
-  useTranscriptHistory: () => ({
-    hasMore: false,
-    loading: false,
-    capacityReached: false,
-    paginationError: false,
-    loadMore: vi.fn(),
-    release: vi.fn(),
-  }),
-  useTranscriptStore: () => mockStore,
-  useWorkspace: () => mockWorkspace,
-  useWorkspaceActions: () => mockWorkspaceActions,
-  useMcp: () => mockMcp,
-  useWorkspaceEventSignals: () => ({
-    artifactsVersion: 0,
-    extensionsVersion: 0,
-  }),
-}));
+vi.mock('@qwen-code/webui/daemon-react-sdk', () => {
+  const ownerGuard = {
+    capture: () => {
+      const ownerVersion = testState.ownerVersion;
+      return { isCurrent: () => testState.ownerVersion === ownerVersion };
+    },
+  };
+  return {
+    DAEMON_APPROVAL_MODES: ['default', 'plan', 'auto-edit', 'auto', 'yolo'],
+    DaemonSessionProvider: ({ children }: { children: ReactNode }) => children,
+    useActions: () => mockSessionActions,
+    useConnection: () => mockConnection,
+    useDaemonSessionOwnerGuard: () => ownerGuard,
+    useDaemonFollowupSuggestion: () => ({
+      followupState: null,
+      clear: mockFollowup.clear,
+      onAcceptFollowup: mockFollowup.onAcceptFollowup,
+      onDismissFollowup: mockFollowup.onDismissFollowup,
+    }),
+    useSessionNotices: () => ({ notices: [], dismissNotice: vi.fn() }),
+    usePromptStatus: () => 'idle',
+    useSettings: () => ({
+      settings: testState.settings,
+      setValue: settingsSetValue,
+      reload: settingsReload,
+      loading: false,
+    }),
+    useProviders: () => ({
+      providers: [],
+      current: undefined,
+      loading: false,
+      error: undefined,
+      reload: vi.fn().mockResolvedValue(undefined),
+    }),
+    useStreamingState: () => testState.streamingState,
+    useTranscriptBlocks: () => testState.blocks,
+    useTranscriptHistory: () => ({
+      hasMore: false,
+      loading: false,
+      capacityReached: false,
+      paginationError: false,
+      loadMore: vi.fn(),
+      release: vi.fn(),
+    }),
+    useTranscriptStore: () => mockStore,
+    useWorkspace: () => mockWorkspace,
+    useWorkspaceActions: () => mockWorkspaceActions,
+    useMcp: () => mockMcp,
+    useWorkspaceEventSignals: () => ({
+      artifactsVersion: 0,
+      extensionsVersion: 0,
+    }),
+  };
+});
 
 vi.mock('@qwen-code/sdk/daemon', () => ({
   DaemonHttpError: class DaemonHttpError extends Error {
@@ -4347,6 +4357,7 @@ beforeEach(() => {
   };
   mockConnection.gitBranch = undefined;
   mockConnection.gitStatus = undefined;
+  testState.ownerVersion = 0;
   mockWorkspace.capabilities = {
     workspaces: [{ id: 'primary', cwd: '/workspace', primary: true }],
   };
@@ -6937,6 +6948,59 @@ describe('App session callbacks', () => {
           ?.textContent,
       ).toContain('Real session title');
     });
+  });
+
+  it('does not expose cached metadata after a same-id workspace switch', async () => {
+    mockConnection.displayName = undefined;
+    const sourceStatus = deferred<{
+      workspaceCwd: string;
+      displayName: string;
+    }>();
+    mockWorkspace.client.sessionStatus.mockReturnValueOnce(
+      sourceStatus.promise,
+    );
+    const sourceList = deferred<never[]>();
+    mockWorkspace.client.listWorkspaceSessions.mockReturnValueOnce(
+      sourceList.promise,
+    );
+    const targetStatus = deferred<{ workspaceCwd: string }>();
+    mockWorkspace.client.sessionStatus.mockReturnValueOnce(
+      targetStatus.promise,
+    );
+    const { container, rerender } = renderApp();
+
+    await act(async () => {
+      sourceStatus.resolve({
+        workspaceCwd: '/work/a',
+        displayName: 'Session A title',
+      });
+      sourceList.resolve([]);
+      await Promise.all([sourceStatus.promise, sourceList.promise]);
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        container.querySelector('[data-testid="chat-context-header"]')
+          ?.textContent,
+      ).toContain('Session A title');
+    });
+
+    testState.ownerVersion += 1;
+    mockConnection.workspaceCwd = '/work/b';
+    rerender();
+    await flush();
+    rerender();
+
+    expect(
+      container.querySelector('[data-testid="chat-context-header"]')
+        ?.textContent,
+    ).not.toContain('Session A title');
+
+    await act(async () => {
+      targetStatus.resolve({ workspaceCwd: '/work/b' });
+      await targetStatus.promise;
+    });
+    await flush();
   });
 
   it('keeps the persistent chat header opt-in for existing integrations', () => {
@@ -9633,6 +9697,9 @@ describe('App session callbacks', () => {
 
   it('discards an automatic recap after switching to an existing session', async () => {
     const { recap, container } = await triggerAutoRecap();
+    mockSessionActions.loadSession.mockImplementationOnce(async () => {
+      testState.ownerVersion += 1;
+    });
     await act(async () => {
       container
         .querySelector<HTMLButtonElement>('[data-testid="load-session"]')
@@ -9652,8 +9719,36 @@ describe('App session callbacks', () => {
     ]);
   });
 
+  it('keeps an automatic recap when an existing-session switch fails', async () => {
+    const { recap } = await triggerAutoRecap();
+    mockSessionActions.loadSession.mockRejectedValueOnce(
+      new Error('target restore failed'),
+    );
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent('qwen:open-session', { detail: 'session-2' }),
+      );
+      await Promise.resolve();
+    });
+    await act(async () => {
+      recap.resolve({ sessionId: 'session-1', recap: 'Current session recap' });
+      await recap.promise;
+    });
+
+    expect(mockStore.dispatch).toHaveBeenCalledWith([
+      expect.objectContaining({
+        source: 'recap',
+        text: expect.stringContaining('Current session recap'),
+      }),
+    ]);
+  });
+
   it('discards an automatic recap after resuming a session by command', async () => {
     const { recap } = await triggerAutoRecap();
+    mockSessionActions.loadSession.mockImplementationOnce(async () => {
+      testState.ownerVersion += 1;
+    });
     await act(async () => {
       testState.latestChatEditorProps?.onSubmit('/resume session-3');
       recap.resolve({
@@ -9663,7 +9758,9 @@ describe('App session callbacks', () => {
       await recap.promise;
     });
 
-    expect(mockSessionActions.loadSession).toHaveBeenCalledWith('session-3');
+    expect(mockSessionActions.loadSession).toHaveBeenCalledWith('session-3', {
+      workspaceCwd: undefined,
+    });
     expect(mockStore.dispatch).not.toHaveBeenCalledWith([
       expect.objectContaining({ source: 'recap' }),
     ]);
@@ -9763,6 +9860,49 @@ describe('App session callbacks', () => {
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
+    expect(editorFocus).toHaveBeenCalledOnce();
+  });
+
+  it('does not finish a same-id workspace switch before commit', async () => {
+    const load = deferred<void>();
+    mockSessionActions.loadSession.mockImplementationOnce(() => {
+      mockConnection.sessionTransition = {
+        phase: 'preparing',
+        operation: 'load',
+        origin: 'action',
+        targetSessionId: 'session-1',
+        targetWorkspaceCwd: '/work/b',
+      };
+      return load.promise;
+    });
+    const { rerender } = renderApp();
+    await flush();
+    editorFocus.mockClear();
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent('qwen:open-session', {
+          detail: { sessionId: 'session-1', workspaceCwd: '/work/b' },
+        }),
+      );
+      await Promise.resolve();
+    });
+    await act(async () => new Promise((resolve) => setTimeout(resolve, 0)));
+    expect(editorFocus).not.toHaveBeenCalled();
+    expect(testState.latestChatEditorProps?.disabled).toBe(true);
+    expect(testState.latestChatEditorProps?.onSubmit('must stay on A')).toBe(
+      false,
+    );
+    expect(mockSessionActions.sendPrompt).not.toHaveBeenCalled();
+
+    await act(async () => {
+      mockConnection.workspaceCwd = '/work/b';
+      mockConnection.sessionTransition = undefined;
+      load.resolve();
+      rerender();
+      await load.promise;
+    });
+    await act(async () => new Promise((resolve) => setTimeout(resolve, 0)));
     expect(editorFocus).toHaveBeenCalledOnce();
   });
 
@@ -11532,6 +11672,30 @@ describe('App session callbacks', () => {
         inputAnnotations: [annotation],
       }),
     );
+  });
+
+  it('does not send a deferred plan prompt into a replacement owner', async () => {
+    const approval = deferred<void>();
+    mockSessionActions.setApprovalMode.mockReturnValueOnce(approval.promise);
+    const { container, rerender } = renderApp();
+    await flush();
+
+    testState.prompt = '/plan explain the migration';
+    await clickSubmit(container);
+    expect(mockSessionActions.setApprovalMode).toHaveBeenCalledWith('plan');
+
+    act(() => {
+      testState.ownerVersion += 1;
+      mockConnection.sessionId = 'session-2';
+      rerender();
+    });
+    await act(async () => {
+      approval.resolve();
+      await approval.promise;
+    });
+
+    expect(mockSessionActions.sendPrompt).not.toHaveBeenCalled();
+    expect(testState.latestChatEditorProps?.isPreparing).toBe(false);
   });
 
   it('dispatches turn_complete only for the session that was streaming', async () => {
@@ -14481,7 +14645,9 @@ describe('App session callbacks', () => {
     await flush();
 
     expect(container.querySelector('[data-testid="inline-panel"]')).toBeNull();
-    expect(mockSessionActions.loadSession).toHaveBeenCalledWith('session-2');
+    expect(mockSessionActions.loadSession).toHaveBeenCalledWith('session-2', {
+      workspaceCwd: undefined,
+    });
   });
 
   it('dispatches rename only after the current session name changes', async () => {
@@ -14668,8 +14834,9 @@ describe('App prompt send failure retry', () => {
   it('keeps an unknown lazy-session admission scoped to its allocated session', async () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     mockConnection.sessionId = undefined;
-    mockSessionActions.createSession.mockResolvedValueOnce({
-      sessionId: 'session-created',
+    mockSessionActions.createSession.mockImplementationOnce(async () => {
+      testState.ownerVersion += 1;
+      return { sessionId: 'session-created' };
     });
     const firstSend = deferred<void>();
     mockSessionActions.sendPrompt.mockReturnValueOnce(firstSend.promise);
@@ -14687,8 +14854,8 @@ describe('App prompt send failure retry', () => {
       expect(mockSessionActions.sendPrompt).toHaveBeenCalledOnce();
     });
     const firstSendOptions = mockSessionActions.sendPrompt.mock.calls[0]?.[1];
-    act(() => firstSendOptions?.onAdmissionStarted?.());
     act(() => {
+      firstSendOptions?.onAdmissionStarted?.();
       mockConnection.sessionId = 'session-created';
       rerender();
     });
@@ -15664,22 +15831,103 @@ describe('App manual-run orchestration (scheduled tasks)', () => {
     void second;
   });
 
-  it('rejects a bound run when the session switch times out', async () => {
+  it('does not let an old same-target failure clear a newer bound run', async () => {
+    admitOnSend();
+    const { container, rerender } = renderApp();
+    await flush();
+    const run = await openRunHandler(container);
+    const firstRestore = deferred<void>();
+    const secondRestore = deferred<void>();
+    mockSessionActions.loadSession
+      .mockReturnValueOnce(firstRestore.promise)
+      .mockReturnValueOnce(secondRestore.promise);
+    let firstError: unknown;
+    let secondSettled = false;
+
+    await act(async () => {
+      void run('first', 'same-target').catch((error) => {
+        firstError = error;
+      });
+      void run('second', 'same-target').then(
+        () => {
+          secondSettled = true;
+        },
+        () => {
+          secondSettled = true;
+        },
+      );
+      await Promise.resolve();
+    });
+    expect((firstError as Error | undefined)?.message).toMatch(/superseded/);
+
+    await act(async () => {
+      firstRestore.reject(new Error('old restore failed'));
+      await Promise.resolve();
+    });
+    expect(secondSettled).toBe(false);
+
+    mockConnection.sessionId = 'same-target';
+    await act(async () => {
+      secondRestore.resolve();
+      rerender();
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => expect(secondSettled).toBe(true));
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledWith(
+      'second',
+      expect.any(Object),
+    );
+  });
+
+  it('does not apply the catch-up timeout while restore is pending', async () => {
     const { container } = renderApp();
     await flush();
     const run = await openRunHandler(container);
+    const restore = deferred<void>();
+    mockSessionActions.loadSession.mockReturnValueOnce(restore.promise);
     vi.useFakeTimers();
     let err: unknown;
     await act(async () => {
       void run('do the thing', 'never-active').catch((e) => {
         err = e;
       });
-      await Promise.resolve(); // loadSidebarSession resolves; no fire (not current)
+      await Promise.resolve();
     });
     await act(async () => {
       vi.advanceTimersByTime(30_000);
     });
-    expect((err as Error | undefined)?.message).toMatch(/Timed out switching/);
+    expect(err).toBeUndefined();
+    await act(async () => {
+      restore.reject(new Error('restore timed out'));
+      await Promise.resolve();
+    });
+    expect((err as Error | undefined)?.message).toBe('restore timed out');
+  });
+
+  it('starts the 30 second timeout only after commit while catching up', async () => {
+    const { container } = renderApp();
+    await flush();
+    const run = await openRunHandler(container);
+    mockSessionActions.loadSession.mockImplementationOnce(async () => {
+      mockConnection.sessionId = 'bound-session';
+      mockConnection.catchingUp = true;
+    });
+    vi.useFakeTimers();
+    let err: unknown;
+    await act(async () => {
+      void run('do the thing', 'bound-session').catch((error) => {
+        err = error;
+      });
+      await Promise.resolve();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(29_999);
+    });
+    expect(err).toBeUndefined();
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+    });
+    expect((err as Error | undefined)?.message).toMatch(/session replay/);
   });
 
   it('"create via chat" starts a fresh session and primes the composer', async () => {

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -15158,6 +15158,40 @@ describe('App session callbacks', () => {
     });
   });
 
+  it('reconciles a confirmed rename after its source attachment is replaced', async () => {
+    const rename = deferred<void>();
+    mockSessionActions.renameSession.mockReturnValueOnce(rename.promise);
+    const { container, rerender } = renderApp();
+    await flush();
+
+    testState.prompt = '/rename Delayed title';
+    await clickSubmit(container);
+    await vi.waitFor(() => {
+      expect(mockSessionActions.renameSession).toHaveBeenCalledWith(
+        'Delayed title',
+      );
+    });
+
+    act(() => {
+      testState.ownerVersion += 1;
+      mockConnection.sessionId = 'session-2';
+      mockConnection.workspaceCwd = '/tmp/other';
+      rerender();
+    });
+    sessionCatalogController.renamed.mockClear();
+
+    await act(async () => {
+      rename.resolve();
+      await rename.promise;
+    });
+
+    expect(sessionCatalogController.renamed).toHaveBeenCalledWith(
+      '/tmp/project',
+      'session-1',
+      'Delayed title',
+    );
+  });
+
   it('reconciles a name reused after the session loaded a different title', async () => {
     const { container, rerender } = renderApp();
     await flush();

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -8493,7 +8493,6 @@ export function App({
             sessionActions
               .renameSession(displayName)
               .then(() => {
-                if (!owner.isCurrent()) return;
                 if (renamedSessionId) {
                   reconcileCatalogRename(
                     renamedWorkspaceCwd,
@@ -8501,6 +8500,7 @@ export function App({
                     displayName,
                   );
                 }
+                if (!owner.isCurrent()) return;
                 store.dispatch([
                   {
                     type: 'status',
@@ -8509,12 +8509,12 @@ export function App({
                 ]);
               })
               .catch((error: unknown) => {
-                if (!owner.isCurrent()) return;
                 if (renamedWorkspaceCwd) {
                   sessionCatalogController.invalidateWorkspace(
                     renamedWorkspaceCwd,
                   );
                 }
+                if (!owner.isCurrent()) return;
                 reportError(error, 'Failed to rename session');
               });
             return true;

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -21,6 +21,7 @@ import {
   useSettings,
   useProviders,
   useSessionNotices,
+  useDaemonSessionOwnerGuard,
   useStreamingState,
   useTranscriptHistory,
   useTranscriptStore,
@@ -29,6 +30,7 @@ import {
   useWorkspaceEventSignals,
   type DaemonSessionActions,
   type DaemonSessionNotice,
+  type DaemonSessionOwnerSnapshot,
   type DaemonStreamingState,
 } from '@qwen-code/webui/daemon-react-sdk';
 import { DaemonHttpError, isDaemonTurnError } from '@qwen-code/sdk/daemon';
@@ -442,9 +444,6 @@ interface ArtifactPanelSessionState {
 interface PaneArtifactSnapshot {
   artifacts: readonly DaemonSessionArtifact[];
 }
-// Cap on how long a manual "run now" waits for its bound session to become
-// active before giving up, so the scheduled-tasks UI can't stay stuck disabled
-// if the switch never completes.
 const BOUND_RUN_SWITCH_TIMEOUT_MS = 30_000;
 
 function availableSkillInfos(status: {
@@ -645,6 +644,7 @@ export type WebShellSlashCommandHandler = (
 ) => boolean | void;
 
 export interface WebShellProps {
+  desiredSessionTargetPending?: boolean;
   /** Called whenever the attached daemon session or workspace changes. */
   onSessionIdChange?: (
     sessionId: string | undefined,
@@ -1566,6 +1566,7 @@ function readScopedModelSetting(
 }
 
 export function App({
+  desiredSessionTargetPending = false,
   onSessionIdChange,
   onSessionCreated,
   theme: providedTheme,
@@ -1872,6 +1873,16 @@ export function App({
   const store = useTranscriptStore();
   const blocks = useAnimationFrameTranscriptBlocks();
   const connection = useConnection();
+  const logicalSessionKey = connection.sessionId
+    ? `${connection.workspaceCwd ?? ''}\0${connection.sessionId}`
+    : undefined;
+  const sessionWriteBlocked =
+    desiredSessionTargetPending ||
+    connection.sessionTransition?.phase === 'queued' ||
+    connection.sessionTransition?.phase === 'preparing';
+  const sessionWriteBlockedRef = useRef(sessionWriteBlocked);
+  sessionWriteBlockedRef.current = sessionWriteBlocked;
+  const sessionOwnerGuard = useDaemonSessionOwnerGuard();
   const transcriptHistory = useTranscriptHistory();
   const workspace = useWorkspace();
   const sessionCatalogController = useSessionCatalogController(
@@ -2030,12 +2041,17 @@ export function App({
   const [sessionStatusDisplayName, setSessionStatusDisplayName] = useState<
     string | undefined
   >(undefined);
-  // Tracks the session id from the latest effect run. In-flight fetches
-  // compare their captured sid against this ref on resolve: a match means
+  // Tracks the logical session from the latest effect run. In-flight fetches
+  // compare their captured key against this ref on resolve: a match means
   // the response is still relevant and may set OR clear the worktree state;
   // a mismatch means connection.sessionId moved on (reconnect cycling or a
   // user-initiated switch) and the stale response is dropped.
-  const worktreeSessionIdRef = useRef<string | undefined>(undefined);
+  const worktreeSessionKeyRef = useRef<string | undefined>(undefined);
+  useLayoutEffect(() => {
+    setSessionWorktree(undefined);
+    setSessionBranch(undefined);
+    setSessionStatusDisplayName(undefined);
+  }, [logicalSessionKey]);
   // Restore worktree info from the server when switching to an existing
   // session. The effect intentionally does NOT cancel in-flight fetches on
   // cleanup: connection.sessionId can cycle through several sessions during
@@ -2043,18 +2059,14 @@ export function App({
   // discard the one response we actually need.
   useEffect(() => {
     const sid = connection.sessionId;
-    const previousSid = worktreeSessionIdRef.current;
-    worktreeSessionIdRef.current = sid;
+    const sessionKey = logicalSessionKey;
+    const owner = sessionOwnerGuard.capture();
+    worktreeSessionKeyRef.current = sessionKey;
     if (!sid) {
       setSessionWorktree(undefined);
       setSessionBranch(undefined);
       setSessionStatusDisplayName(undefined);
       return;
-    }
-    if (previousSid !== sid) {
-      setSessionWorktree(undefined);
-      setSessionBranch(undefined);
-      setSessionStatusDisplayName(undefined);
     }
     if (
       connection.status !== 'connected' ||
@@ -2066,7 +2078,7 @@ export function App({
     workspace.client
       .sessionStatus(sid)
       .then((summary) => {
-        if (worktreeSessionIdRef.current === sid) {
+        if (worktreeSessionKeyRef.current === sessionKey && owner.isCurrent()) {
           setSessionWorktree(summary.worktree);
           setSessionBranch(summary.branch);
           setSessionStatusDisplayName(summary.displayName);
@@ -2081,7 +2093,12 @@ export function App({
           { fresh: true },
         )
           .then((page) => {
-            if (worktreeSessionIdRef.current !== sid) return;
+            if (
+              worktreeSessionKeyRef.current !== sessionKey ||
+              !owner.isCurrent()
+            ) {
+              return;
+            }
             const listedSession = page.sessions.find(
               (session) => session.sessionId === sid,
             );
@@ -2092,7 +2109,7 @@ export function App({
           .catch(() => undefined);
       })
       .catch(() => {
-        if (worktreeSessionIdRef.current === sid) {
+        if (worktreeSessionKeyRef.current === sessionKey && owner.isCurrent()) {
           setSessionWorktree(undefined);
           setSessionBranch(undefined);
           setSessionStatusDisplayName(undefined);
@@ -2100,9 +2117,13 @@ export function App({
       });
   }, [
     connection.catchingUp,
+    connection.clientId,
     connection.loadingTranscript,
     connection.sessionId,
     connection.status,
+    connection.workspaceCwd,
+    logicalSessionKey,
+    sessionOwnerGuard,
     workspace.client,
   ]);
   // Active workspace: the connected session's workspace, else the workspace
@@ -2260,6 +2281,11 @@ export function App({
     failedPromptRef.current = next;
     setFailedPrompt(next);
   }, []);
+  useLayoutEffect(() => {
+    updateFailedPrompt(null);
+    setFailedPromptRetry(null);
+    updateUnknownPromptAdmission(null);
+  }, [logicalSessionKey, updateFailedPrompt, updateUnknownPromptAdmission]);
   const [recapMessage, setRecapMessage] = useState<LocalAnchoredMessage | null>(
     null,
   );
@@ -2274,7 +2300,6 @@ export function App({
   const lastNotifiedSessionIdRef = useRef<string | undefined>(undefined);
   const lastNotifiedWorkspaceIdRef = useRef<string | undefined>(undefined);
   const lastNotifiedWorkspaceCwdRef = useRef<string | undefined>(undefined);
-  const lastGoalSessionIdRef = useRef(connection.sessionId);
   const displayMessages = useMemo(() => {
     const localMessages = [recapMessage].filter(
       (message): message is LocalAnchoredMessage => message !== null,
@@ -2482,7 +2507,7 @@ export function App({
   useLayoutEffect(() => {
     preserveEnvironmentPanelOnArtifactOpenRef.current = false;
     setEnvironmentPanelOpen(false);
-  }, [connection.sessionId]);
+  }, [logicalSessionKey]);
   const artifactPanelOpenRef = useRef(artifactPanelOpen);
   artifactPanelOpenRef.current = artifactPanelOpen;
   const [activeArtifactPanelTabId, setActiveArtifactPanelTabId] = useState<
@@ -2525,7 +2550,7 @@ export function App({
   const artifactPanelStateBySessionRef = useRef(
     new Map<string, ArtifactPanelSessionState>(),
   );
-  const artifactPanelSessionIdRef = useRef(connection.sessionId);
+  const artifactPanelSessionIdRef = useRef(logicalSessionKey);
   artifactPanelSessionStateRef.current = {
     open: artifactPanelOpen,
     tabs: artifactPanelTabs,
@@ -2558,7 +2583,7 @@ export function App({
       }
     }
 
-    const nextSessionId = connection.sessionId;
+    const nextSessionId = logicalSessionKey;
     artifactPanelSessionIdRef.current = nextSessionId;
     const savedState = nextSessionId
       ? artifactPanelStateBySessionRef.current.get(nextSessionId)
@@ -2585,7 +2610,7 @@ export function App({
     setPaneArtifactSnapshots(new Map());
     setArtifactPanelWidth(savedState.width);
     setArtifactPanelFullscreen(false);
-  }, [connection.sessionId]);
+  }, [logicalSessionKey]);
   const sideTasksAvailable =
     Boolean(connection.sessionId && connection.workspaceCwd) &&
     connection.capabilities?.features.includes(SESSION_SIDE_TASK_FEATURE) ===
@@ -2594,6 +2619,9 @@ export function App({
     items: [],
     loaded: false,
   });
+  useLayoutEffect(() => {
+    setSideTaskCatalog({ items: [], loaded: false });
+  }, [logicalSessionKey]);
   const optimisticSideTaskIdsRef = useRef(new Set<string>());
   const visibleSideTasks =
     sideTaskCatalog.parentSessionId === connection.sessionId
@@ -3550,9 +3578,11 @@ export function App({
     async (tool: ACPToolCall): Promise<boolean> => {
       const sessionId = monitorDetailsSessionIdRef.current;
       if (!sessionId) return false;
+      const owner = sessionOwnerGuard.capture();
       try {
         const snapshot = await sessionActions.getTasks();
         if (
+          !owner.isCurrent() ||
           monitorDetailsSessionIdRef.current !== sessionId ||
           snapshot.sessionId !== sessionId
         ) {
@@ -3567,7 +3597,7 @@ export function App({
         return false;
       }
     },
-    [openMonitorPanel, sessionActions],
+    [openMonitorPanel, sessionActions, sessionOwnerGuard],
   );
   useEffect(() => {
     const monitors = new Map(
@@ -3672,6 +3702,7 @@ export function App({
     assignComposerRef(composerRef, editorRef.current ?? emptyComposerApi);
   }, [composerRef]);
   const [activeGoal, setActiveGoal] = useState<ActiveGoalStatus | null>(null);
+  useLayoutEffect(() => setActiveGoal(null), [logicalSessionKey]);
   const [isCreatingMissingSession, setIsCreatingMissingSession] =
     useState(false);
   const creatingMissingSessionRef = useRef(false);
@@ -4552,6 +4583,7 @@ export function App({
   const refreshActiveSessionDisplayName = useCallback(async () => {
     const activeConnection = connectionRef.current;
     if (!activeConnection.sessionId || !activeConnection.workspaceCwd) return;
+    const owner = sessionOwnerGuard.capture();
     try {
       const page = await loadSessionCatalogOnce(
         workspace.client,
@@ -4563,6 +4595,7 @@ export function App({
         { fresh: true },
       );
       if (
+        !owner.isCurrent() ||
         connectionRef.current.sessionId !== activeConnection.sessionId ||
         connectionRef.current.workspaceCwd !== activeConnection.workspaceCwd ||
         connectionRef.current.displayName
@@ -4576,7 +4609,7 @@ export function App({
     } catch {
       // The live session_metadata_updated event remains the primary path.
     }
-  }, [workspace.client]);
+  }, [sessionOwnerGuard, workspace.client]);
   const refreshActiveSessionDisplayNameRef = useRef(
     refreshActiveSessionDisplayName,
   );
@@ -4648,6 +4681,7 @@ export function App({
     setCurrentMode(modeId);
   }, []);
   const [isPreparingPrompt, setIsPreparingPrompt] = useState(false);
+  useLayoutEffect(() => setIsPreparingPrompt(false), [logicalSessionKey]);
   const createSessionPromiseRef = useRef<Promise<string | undefined> | null>(
     null,
   );
@@ -4844,8 +4878,15 @@ export function App({
         onAdmissionStarted?: (sessionId: string | undefined) => void;
         onAdmitted?: () => void;
         onOptimisticUserMessage?: (message: OptimisticUserMessage) => void;
+        ownerRef?: { current: DaemonSessionOwnerSnapshot };
       },
     ) => {
+      if (sessionWriteBlockedRef.current) {
+        throw new DOMException(
+          'Session switch is still preparing',
+          'InvalidStateError',
+        );
+      }
       const isUserPrompt = !text.trimStart().startsWith('/');
       const previousLastSubmittedPrompt = lastSubmittedPromptRef.current;
       const previousLastSubmittedImages = lastSubmittedImagesRef.current;
@@ -4918,6 +4959,7 @@ export function App({
       let allocatedSessionId: string | undefined;
       try {
         allocatedSessionId = await ensureSessionForPrompt();
+        if (opts?.ownerRef) opts.ownerRef.current = sessionOwnerGuard.capture();
       } finally {
         if (shouldShowPreparing) {
           setIsPreparingPrompt(false);
@@ -5010,6 +5052,7 @@ export function App({
       getComposerWorkspaceCwd,
       sessionCatalogController,
       sessionActions,
+      sessionOwnerGuard,
       store,
     ],
   );
@@ -5204,12 +5247,14 @@ export function App({
       updateFailedPrompt(null);
       return;
     }
+    const retryAttachment = sessionOwnerGuard.capture();
     const retryOwner = {
       sourceVersion: composerSourceVersionRef.current,
       sessionId: connectionRef.current.sessionId,
       workspaceCwd: getComposerWorkspaceCwd(),
     };
     const retryOwnerIsCurrent = () =>
+      retryAttachment.isCurrent() &&
       composerSourceVersionRef.current === retryOwner.sourceVersion &&
       connectionRef.current.sessionId === retryOwner.sessionId &&
       getComposerWorkspaceCwd() === retryOwner.workspaceCwd;
@@ -5283,6 +5328,7 @@ export function App({
     pushToast,
     reportError,
     sendPrompt,
+    sessionOwnerGuard,
     store,
     t,
     updateFailedPrompt,
@@ -5308,6 +5354,7 @@ export function App({
     discardUnknownQueuedPrompt,
   } = useQueuedPrompts({
     connected,
+    writeBlocked: sessionWriteBlocked,
     sessionId: connection.sessionId,
     clientId: connection.clientId,
     canMutateMidTurn,
@@ -5426,14 +5473,16 @@ export function App({
     setBtwMessage(null);
     setTasksDialogMessage(null);
     lastRecapBlockCountRef.current = 0;
-  }, [connection.sessionId]);
+  }, [connection.sessionId, connection.workspaceCwd]);
 
   const runVisibleRecap = useCallback(() => {
+    if (sessionWriteBlocked) return;
     if (!requireActiveSessionForLocalCommand()) return;
     const messageId = `local-recap-${nextRecapMessageIdRef.current++}`;
     const anchorIndex = messages.length;
     const anchorAfterId = messages.at(-1)?.id;
     const sessionId = connection.sessionId;
+    const owner = sessionOwnerGuard.capture();
     setRecapMessage({
       anchorAfterId,
       anchorIndex,
@@ -5447,7 +5496,8 @@ export function App({
     });
     sessionActions.recapSession().then(
       (result) => {
-        if (currentSessionIdRef.current !== sessionId) return;
+        if (!owner.isCurrent() || currentSessionIdRef.current !== sessionId)
+          return;
         setRecapMessage({
           anchorAfterId,
           anchorIndex,
@@ -5463,7 +5513,8 @@ export function App({
         });
       },
       (error: unknown) => {
-        if (currentSessionIdRef.current !== sessionId) return;
+        if (!owner.isCurrent() || currentSessionIdRef.current !== sessionId)
+          return;
         setRecapMessage(null);
         if (!isAbortError(error) && !isAlreadyDispatched(error)) {
           console.warn('[web-shell] unhandled recap failure', error);
@@ -5474,12 +5525,15 @@ export function App({
     connection.sessionId,
     messages,
     requireActiveSessionForLocalCommand,
+    sessionWriteBlocked,
     sessionActions,
+    sessionOwnerGuard,
     t,
   ]);
 
   const runVisibleBtw = useCallback(
     (rawQuestion: string) => {
+      if (sessionWriteBlocked) return;
       const question = rawQuestion.trim();
       if (!question) {
         pushToast('error', t('btw.empty'));
@@ -5489,6 +5543,7 @@ export function App({
 
       const messageId = `local-btw-${nextBtwMessageIdRef.current++}`;
       const sessionId = connection.sessionId;
+      const owner = sessionOwnerGuard.capture();
       btwAbortControllerRef.current?.abort();
       const abortController = new AbortController();
       btwAbortControllerRef.current = abortController;
@@ -5504,7 +5559,8 @@ export function App({
         .btwSession(question, { signal: abortController.signal })
         .then(
           (result) => {
-            if (currentSessionIdRef.current !== sessionId) return;
+            if (!owner.isCurrent() || currentSessionIdRef.current !== sessionId)
+              return;
             if (btwAbortControllerRef.current !== abortController) return;
             btwAbortControllerRef.current = null;
             setBtwMessage({
@@ -5516,7 +5572,8 @@ export function App({
             });
           },
           (error: unknown) => {
-            if (currentSessionIdRef.current !== sessionId) return;
+            if (!owner.isCurrent() || currentSessionIdRef.current !== sessionId)
+              return;
             if (btwAbortControllerRef.current !== abortController) return;
             btwAbortControllerRef.current = null;
             setBtwMessage(null);
@@ -5530,7 +5587,9 @@ export function App({
       connection.sessionId,
       pushToast,
       requireActiveSessionForLocalCommand,
+      sessionWriteBlocked,
       sessionActions,
+      sessionOwnerGuard,
       t,
     ],
   );
@@ -5661,6 +5720,7 @@ export function App({
   // re-creating on every render (and without an exhaustive-deps warning).
   const reloadProviders = providersState.reload;
   const [modelActionBusy, setModelActionBusy] = useState(false);
+  useEffect(() => setModelActionBusy(false), [logicalSessionKey]);
   const {
     settings: workspaceSettings,
     setValue: setWorkspaceSetting,
@@ -6017,6 +6077,8 @@ export function App({
 
   const handleSettingsLanguageChange = useCallback(
     (nextLanguage: WebShellLanguage, scope: 'user' | 'workspace' = 'user') => {
+      if (sessionWriteBlocked) return;
+      const owner = { current: sessionOwnerGuard.capture() };
       const previousLanguage = selectedLanguage;
       // Forward the settings tab's scope to the command so a Workspace-tab edit
       // persists to workspace settings instead of always writing user scope
@@ -6026,8 +6088,9 @@ export function App({
       const scopeFlag = scope === 'workspace' ? ' --project' : ' --global';
       const command = `/language ui ${nextLanguage}${scopeFlag}`;
       handleLanguageChange(nextLanguage);
-      const refreshSettings = () => {
-        return Promise.all([
+      const refreshSettings = async () => {
+        if (!owner.current.isCurrent()) return;
+        await Promise.all([
           sessionActions.refreshCommands(),
           reloadWorkspaceSettings(),
         ]);
@@ -6037,9 +6100,10 @@ export function App({
         blockLocalCommandDuringTurn();
         return;
       }
-      sendPrompt(command, undefined)
+      sendPrompt(command, undefined, { ownerRef: owner })
         .then(refreshSettings)
         .catch((error: unknown) => {
+          if (!owner.current.isCurrent()) return;
           handleLanguageChange(previousLanguage);
           reportError(error, 'Failed to sync /language command');
         });
@@ -6049,9 +6113,11 @@ export function App({
       handleLanguageChange,
       reloadWorkspaceSettings,
       reportError,
+      sessionWriteBlocked,
       sendPrompt,
       selectedLanguage,
       sessionActions,
+      sessionOwnerGuard,
     ],
   );
 
@@ -6079,6 +6145,7 @@ export function App({
 
   const handleSetMode = useCallback(
     (modeId: string) => {
+      if (sessionWriteBlocked) return;
       if (!isDaemonApprovalMode(modeId)) {
         reportError(
           new Error(`Unsupported approval mode: ${modeId}`),
@@ -6090,9 +6157,11 @@ export function App({
         setPendingMode(modeId);
         return;
       }
+      const owner = sessionOwnerGuard.capture();
       sessionActions
         .setApprovalMode(modeId)
         .then((result) => {
+          if (!owner.isCurrent()) return;
           const effectiveMode = result.mode || modeId;
           setCurrentMode(effectiveMode);
           const approval = pendingApprovalRef.current;
@@ -6121,10 +6190,19 @@ export function App({
           }
         })
         .catch((error: unknown) => {
+          if (!owner.isCurrent()) return;
           reportError(error, t('local.approvalMode'));
         });
     },
-    [sessionActions, reportError, store, t, setPendingMode],
+    [
+      sessionWriteBlocked,
+      reportError,
+      sessionActions,
+      sessionOwnerGuard,
+      setPendingMode,
+      store,
+      t,
+    ],
   );
 
   useEffect(() => {
@@ -6133,10 +6211,10 @@ export function App({
 
   // Drop queued commands on a session switch so the drain never runs a
   // command against a different workspace's daemon (mirrors useQueuedPrompts).
-  const prevQueueSessionIdRef = useRef(connection.sessionId);
+  const prevQueueSessionIdRef = useRef(logicalSessionKey);
   useEffect(() => {
-    if (prevQueueSessionIdRef.current === connection.sessionId) return;
-    prevQueueSessionIdRef.current = connection.sessionId;
+    if (prevQueueSessionIdRef.current === logicalSessionKey) return;
+    prevQueueSessionIdRef.current = logicalSessionKey;
     const dropped = queuedShellCommandsRef.current.length;
     queuedShellCommandsRef.current = [];
     // Skip the bump when the transition is into the session that
@@ -6149,7 +6227,7 @@ export function App({
     if (dropped > 0) {
       pushToast('warning', t('queue.shellDropped', { count: dropped }));
     }
-  }, [connection.sessionId, pushToast, t]);
+  }, [connection.sessionId, logicalSessionKey, pushToast, t]);
 
   // Declared after the session-switch wipe effect above: React runs effects in
   // declaration order, so the queue is already cleared before this drain sees it.
@@ -6172,6 +6250,7 @@ export function App({
     const generation = ++drainGenerationRef.current;
     const drainSessionId = connectionRef.current.sessionId;
     const drainWorkspaceCwd = getComposerWorkspaceCwd();
+    const drainOwner = sessionOwnerGuard.capture();
     void (async () => {
       try {
         let batch = cmds;
@@ -6180,6 +6259,7 @@ export function App({
             const generationChanged = drainGenerationRef.current !== generation;
             if (
               generationChanged ||
+              !drainOwner.isCurrent() ||
               connectionRef.current.sessionId !== drainSessionId ||
               connectionRef.current.status !== 'connected'
             ) {
@@ -6231,6 +6311,7 @@ export function App({
     reportError,
     sessionActions,
     sessionCatalogController,
+    sessionOwnerGuard,
     streamingState,
     t,
   ]);
@@ -6345,23 +6426,15 @@ export function App({
     }
   }, [connection.error, onError]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     setCurrentModel(connection.currentModel ?? '');
-  }, [connection.currentModel, connection.sessionId]);
+  }, [connection.currentModel, logicalSessionKey]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     setCurrentMode(connection.currentMode ?? 'default');
-  }, [connection.currentMode, connection.sessionId]);
+  }, [connection.currentMode, logicalSessionKey]);
 
   useEffect(() => {
-    const previousGoalSessionId = lastGoalSessionIdRef.current;
-    if (
-      connection.sessionId &&
-      connection.sessionId !== previousGoalSessionId
-    ) {
-      setActiveGoal(null);
-    }
-    lastGoalSessionIdRef.current = connection.sessionId;
     if (!connection.sessionId && connection.missingSession) {
       // Keep the dead-session route visible until the user explicitly starts a
       // new chat; clearing it here would immediately hide the recovery state.
@@ -6370,12 +6443,9 @@ export function App({
       lastNotifiedWorkspaceCwdRef.current = undefined;
       return;
     }
-    // After a session is cleared the connection's workspaceCwd is a leftover
-    // from the previous session; reporting it would misroute the host back to
-    // the old workspace. activeWorkspaceCwd resolves the workspace picked for
-    // the next session (locked / selected / primary) and is what the composer
-    // chip reports, so the host and the chip stay in agreement.
-    const reportedWorkspaceCwd = activeWorkspaceCwd ?? connection.workspaceCwd;
+    const reportedWorkspaceCwd = connection.sessionId
+      ? connection.workspaceCwd
+      : activeWorkspaceCwd;
     const activeWorkspace = workspaces.find(
       (entry) => entry.cwd === reportedWorkspaceCwd,
     );
@@ -6410,7 +6480,6 @@ export function App({
   ]);
 
   const lastRenameSessionRef = useRef<string | undefined>(undefined);
-  const lastRenameWorkspaceCwdRef = useRef<string | undefined>(undefined);
   const lastRenameNameRef = useRef<string | undefined>(undefined);
   const lastReconciledRenameRef = useRef<
     | {
@@ -6441,12 +6510,8 @@ export function App({
     const sessionId = connection.sessionId;
     const displayName = connection.displayName;
     if (!sessionId || !displayName) return;
-    if (
-      sessionId !== lastRenameSessionRef.current ||
-      connection.workspaceCwd !== lastRenameWorkspaceCwdRef.current
-    ) {
-      lastRenameSessionRef.current = sessionId;
-      lastRenameWorkspaceCwdRef.current = connection.workspaceCwd;
+    if (logicalSessionKey !== lastRenameSessionRef.current) {
+      lastRenameSessionRef.current = logicalSessionKey;
       lastRenameNameRef.current = displayName;
       lastReconciledRenameRef.current = undefined;
       return;
@@ -6478,6 +6543,7 @@ export function App({
     connection.displayName,
     connection.sessionId,
     connection.workspaceCwd,
+    logicalSessionKey,
     sessionCatalogController,
   ]);
 
@@ -6527,7 +6593,7 @@ export function App({
   useEffect(() => {
     lastRecapBlockCountRef.current = 0;
     autoRecapVersionRef.current += 1;
-  }, [connection.sessionId]);
+  }, [logicalSessionKey]);
   useEffect(() => {
     const AWAY_THRESHOLD_MS = 3 * 60 * 1000;
     const MIN_NEW_BLOCKS = 4;
@@ -6540,6 +6606,7 @@ export function App({
       hiddenAtRef.current = null;
       if (hiddenAt === null) return;
       if (Date.now() - hiddenAt < AWAY_THRESHOLD_MS) return;
+      if (sessionWriteBlocked) return;
       if (streamingStateRef.current !== 'idle') return;
       if (!connection.sessionId) return;
       const currentCount = store.getSnapshot().blocks.length;
@@ -6548,6 +6615,7 @@ export function App({
       lastRecapBlockCountRef.current = currentCount;
       const sessionId = connection.sessionId;
       const version = autoRecapVersionRef.current;
+      const owner = sessionOwnerGuard.capture();
       // Local-only commands also append user blocks. Treat any new visible user
       // activity as invalidating the recap rather than risk placing it too late.
       const userBlockId = getLatestUserBlockId(store.getSnapshot().blocks);
@@ -6561,6 +6629,7 @@ export function App({
           // catch those. Kept so it is not simplified away as redundant.
           if (
             autoRecapVersionRef.current !== version ||
+            !owner.isCurrent() ||
             connectionRef.current.sessionId !== sessionId ||
             result.sessionId !== sessionId ||
             currentUserBlockId !== userBlockId ||
@@ -6596,7 +6665,14 @@ export function App({
     document.addEventListener('visibilitychange', onVisibilityChange);
     return () =>
       document.removeEventListener('visibilitychange', onVisibilityChange);
-  }, [connection.sessionId, sessionActions, store, t]);
+  }, [
+    connection.sessionId,
+    sessionActions,
+    sessionOwnerGuard,
+    sessionWriteBlocked,
+    store,
+    t,
+  ]);
 
   const handleCycleMode = useCallback(() => {
     const idx = isDaemonApprovalMode(currentMode)
@@ -6617,13 +6693,16 @@ export function App({
       // "context detail" click) runs immediately, even mid-turn — only the
       // echo is skipped while streaming so the active turn is not split.
       if (!requireActiveSessionForLocalCommand()) return;
+      const owner = sessionOwnerGuard.capture();
       echoLocalCommandIfIdle(commandText);
       sessionActions
         .getContextUsage({ detail })
         .then((result) => {
+          if (!owner.isCurrent()) return;
           dispatchReadOnlyStatus(serializeContextUsageMessage(result));
         })
         .catch((error: unknown) => {
+          if (!owner.isCurrent()) return;
           reportError(error, 'Failed to load context usage');
         });
     },
@@ -6632,6 +6711,7 @@ export function App({
       dispatchReadOnlyStatus,
       requireActiveSessionForLocalCommand,
       sessionActions,
+      sessionOwnerGuard,
       reportError,
     ],
   );
@@ -6650,6 +6730,7 @@ export function App({
 
   const branchCurrentSession = useCallback(
     (name?: string) => {
+      if (sessionWriteBlocked) return;
       if (!requireActiveSessionForLocalCommand()) return;
       sessionActions
         .branchSession(name || undefined)
@@ -6670,6 +6751,7 @@ export function App({
     [
       reportError,
       requireActiveSessionForLocalCommand,
+      sessionWriteBlocked,
       sessionActions,
       store,
       t,
@@ -6963,6 +7045,13 @@ export function App({
     },
     [],
   );
+  const generateSuggestionContent = useCallback(
+    (prompt: string, options?: { signal?: AbortSignal }) => {
+      void logicalSessionKey;
+      return sessionActions.generateSessionContent(prompt, options);
+    },
+    [logicalSessionKey, sessionActions],
+  );
 
   const {
     suggestion: newSessionSuggestion,
@@ -6981,7 +7070,7 @@ export function App({
     isRunning: streamingState !== 'idle',
     dialogOpen: interactionBlocked || approvalOverlayActive,
     hasAttachments: hasComposerAttachments,
-    generateContent: sessionActions.generateSessionContent,
+    generateContent: generateSuggestionContent,
   });
 
   const handleComposerTextChange = useCallback(
@@ -7161,27 +7250,25 @@ export function App({
     }
   }, [createNewSession, onSessionIdChange]);
 
+  const sessionOpenInvocationRef = useRef(0);
   const loadSidebarSession = useCallback(
     async (sessionId: string, workspaceCwd?: string) => {
-      composerSourceVersionRef.current += 1;
+      const invocation = ++sessionOpenInvocationRef.current;
       composerFocusRequestRef.current += 1;
       setSidebarSwitchingSessionId(sessionId);
-      setGitModeIntent({ mode: 'current' });
-      setSessionWorktree(undefined);
-      setSessionBranch(undefined);
-      // Close the drawer before awaiting the load; the transcript clears
-      // immediately and shows its loading skeleton for the selected session.
       closeMobileDrawer();
       // Loading another session should reveal its chat, not stay on the
       // Settings/Status panel (no-op when the panel is closed).
       closePanel();
       try {
-        autoRecapVersionRef.current += 1;
         await sessionActions.loadSession(sessionId, { workspaceCwd });
+        if (sessionOpenInvocationRef.current === invocation) {
+          composerSourceVersionRef.current += 1;
+        }
       } catch (error) {
-        setSidebarSwitchingSessionId((current) =>
-          current === sessionId ? null : current,
-        );
+        if (sessionOpenInvocationRef.current === invocation) {
+          setSidebarSwitchingSessionId(null);
+        }
         throw error;
       }
     },
@@ -7232,7 +7319,8 @@ export function App({
       sidebarSwitchingSessionId !== null &&
       connection.sessionId === sidebarSwitchingSessionId &&
       !connection.loadingTranscript &&
-      !connection.catchingUp
+      !connection.catchingUp &&
+      !sessionWriteBlocked
     ) {
       setSidebarSwitchingSessionId(null);
       scheduleComposerFocus(sidebarSwitchingSessionId);
@@ -7242,6 +7330,7 @@ export function App({
     connection.loadingTranscript,
     connection.sessionId,
     scheduleComposerFocus,
+    sessionWriteBlocked,
     sidebarSwitchingSessionId,
   ]);
 
@@ -7259,12 +7348,13 @@ export function App({
     prompt: string;
     resolve: () => void;
     reject: (err: unknown) => void;
-    timer: ReturnType<typeof setTimeout>;
+    timer?: ReturnType<typeof setTimeout>;
+    owner?: { isCurrent(): boolean };
   } | null>(null);
   const clearPendingBoundRun = useCallback((sessionId: string) => {
     const cur = pendingBoundRunRef.current;
     if (cur && cur.sessionId === sessionId) {
-      clearTimeout(cur.timer);
+      if (cur.timer !== undefined) clearTimeout(cur.timer);
       pendingBoundRunRef.current = null;
     }
   }, []);
@@ -7319,12 +7409,27 @@ export function App({
     if (
       !pending ||
       conn.sessionId !== pending.sessionId ||
-      conn.loadingTranscript ||
-      conn.catchingUp
+      conn.loadingTranscript
     ) {
       return;
     }
-    clearTimeout(pending.timer);
+    if (conn.catchingUp) {
+      if (pending.timer === undefined) {
+        pending.timer = setTimeout(() => {
+          clearPendingBoundRun(pending.sessionId);
+          pending.reject(new Error('Timed out waiting for session replay'));
+        }, BOUND_RUN_SWITCH_TIMEOUT_MS);
+      }
+      return;
+    }
+    if (pending.owner && !pending.owner.isCurrent()) {
+      clearPendingBoundRun(pending.sessionId);
+      pending.reject(
+        new DOMException('Bound run session was replaced', 'AbortError'),
+      );
+      return;
+    }
+    if (pending.timer !== undefined) clearTimeout(pending.timer);
     pendingBoundRunRef.current = null;
     // Resolves at prompt admission (see enqueueManualRun); the switch-timeout was
     // cleared above, so a long turn can't trip it. Recording happens in the
@@ -7333,7 +7438,7 @@ export function App({
       () => pending.resolve(),
       (error: unknown) => pending.reject(error),
     );
-  }, [enqueueManualRun]);
+  }, [clearPendingBoundRun, enqueueManualRun]);
   const runTaskManually = useCallback(
     (prompt: string, sessionId: string | null): Promise<void> => {
       setMainView('chat');
@@ -7345,28 +7450,29 @@ export function App({
       // reject the old promise so its caller doesn't record a dropped run.
       const prev = pendingBoundRunRef.current;
       if (prev) {
-        clearTimeout(prev.timer);
+        if (prev.timer !== undefined) clearTimeout(prev.timer);
         pendingBoundRunRef.current = null;
         prev.reject(new Error('superseded by another run'));
       }
       return new Promise<void>((resolve, reject) => {
-        const timer = setTimeout(() => {
-          clearPendingBoundRun(sessionId);
-          reject(new Error('Timed out switching to the task session'));
-        }, BOUND_RUN_SWITCH_TIMEOUT_MS);
-        pendingBoundRunRef.current = {
+        const pending: NonNullable<typeof pendingBoundRunRef.current> = {
           sessionId,
           prompt,
           resolve,
           reject,
-          timer,
         };
+        pendingBoundRunRef.current = pending;
         loadSidebarSession(sessionId)
           // Fire immediately when the session was already active (no dep change
           // to trigger the effect); a no-op if the load is still settling, in
           // which case the effect picks it up.
-          .then(() => tryFireBoundRun())
+          .then(() => {
+            if (pendingBoundRunRef.current !== pending) return;
+            pending.owner = sessionOwnerGuard.capture();
+            tryFireBoundRun();
+          })
           .catch((error: unknown) => {
+            if (pendingBoundRunRef.current !== pending) return;
             clearPendingBoundRun(sessionId);
             reject(error);
           });
@@ -7376,6 +7482,7 @@ export function App({
       enqueueManualRun,
       loadSidebarSession,
       clearPendingBoundRun,
+      sessionOwnerGuard,
       tryFireBoundRun,
     ],
   );
@@ -7390,16 +7497,24 @@ export function App({
 
   const openTasksPanel = useCallback(() => {
     if (!requireActiveSessionForLocalCommand()) return;
+    const owner = sessionOwnerGuard.capture();
     sessionActions
       .getTasks()
       .then((snapshot) => {
+        if (!owner.isCurrent()) return;
         setTasksDialogMessage({ snapshot });
       })
       .catch((error: unknown) => {
+        if (!owner.isCurrent()) return;
         if (isSessionDisconnectedError(error)) return;
         reportError(error, 'Failed to load tasks');
       });
-  }, [reportError, requireActiveSessionForLocalCommand, sessionActions]);
+  }, [
+    reportError,
+    requireActiveSessionForLocalCommand,
+    sessionActions,
+    sessionOwnerGuard,
+  ]);
   const openEnvironmentTasksPanel = useCallback(() => {
     if (!requireActiveSessionForLocalCommand()) return;
     setEnvironmentPanelOpen(true);
@@ -7460,14 +7575,24 @@ export function App({
 
   const handleBusyGoalClear = useCallback(
     (text: string) => {
+      if (sessionWriteBlocked) return false;
       if (!requireActiveSessionForLocalCommand()) return false;
+      const owner = sessionOwnerGuard.capture();
       store.appendLocalUserMessage(text);
       sessionActions.clearGoal().catch((error: unknown) => {
+        if (!owner.isCurrent()) return;
         reportError(error, 'Failed to clear /goal');
       });
       return true;
     },
-    [reportError, requireActiveSessionForLocalCommand, sessionActions, store],
+    [
+      reportError,
+      requireActiveSessionForLocalCommand,
+      sessionWriteBlocked,
+      sessionActions,
+      sessionOwnerGuard,
+      store,
+    ],
   );
 
   const loadRewindSnapshots = useCallback(
@@ -7504,15 +7629,18 @@ export function App({
       const goalArg = goalArgOf(text);
       const sendToDaemon = opts?.sendToDaemon ?? true;
       const sendGoalPrompt = () => {
+        const owner = { current: sessionOwnerGuard.capture() };
         const deferComposerCommit = Boolean(onSubmitBeforeRef.current);
         const clearComposerOnPromptStart =
           !connectionRef.current.sessionId || deferComposerCommit;
         sendPrompt(text, images, {
+          ownerRef: owner,
           clearComposerOnPromptStart,
           commitComposerAccepted: clearComposerOnPromptStart
             ? opts?.commitComposerAccepted
             : undefined,
         }).catch((error: unknown) => {
+          if (!owner.current.isCurrent()) return;
           reportError(error, 'Failed to send /goal command');
         });
         return clearComposerOnPromptStart ? false : true;
@@ -7547,6 +7675,7 @@ export function App({
       openGoals,
       reportError,
       sendPrompt,
+      sessionOwnerGuard,
       store,
       connectionRef,
     ],
@@ -7568,6 +7697,7 @@ export function App({
       commitComposerAccepted?: ComposerSubmitCommit,
       metadata?: { inputAnnotations?: DaemonInputAnnotation[] },
     ) => {
+      if (sessionWriteBlockedRef.current) return false;
       if (
         unknownPromptAdmissionRef.current?.payloadAvailable &&
         unknownPromptAdmissionRef.current.sessionId ===
@@ -7606,12 +7736,16 @@ export function App({
           trackSendFailure?: boolean;
         },
       ) => {
+        const admissionAttachment = {
+          current: sessionOwnerGuard.capture(),
+        };
         const admissionOwner = {
           sourceVersion: composerSourceVersionRef.current,
           sessionId: connectionRef.current.sessionId,
           workspaceCwd: getComposerWorkspaceCwd(),
         };
         const admissionOwnerIsCurrent = () =>
+          admissionAttachment.current.isCurrent() &&
           composerSourceVersionRef.current === admissionOwner.sourceVersion &&
           (admissionOwner.sessionId === undefined ||
             (connectionRef.current.sessionId === admissionOwner.sessionId &&
@@ -7625,6 +7759,7 @@ export function App({
         let admissionStarted = false;
         let admissionSessionId: string | undefined;
         sendPrompt(promptText, promptImages, {
+          ownerRef: admissionAttachment,
           ...sendOptions,
           clearComposerOnPromptStart,
           commitComposerAccepted: clearComposerOnPromptStart
@@ -7834,19 +7969,25 @@ export function App({
                 return true;
               }
               const nextLanguage = normalizeLanguage(languageArg);
+              const owner = { current: sessionOwnerGuard.capture() };
               handleLanguageChange(nextLanguage);
               if (!promptBlocked) {
                 const deferComposerCommit = Boolean(onSubmitBeforeRef.current);
                 const clearComposerOnPromptStart =
                   !connectionRef.current.sessionId || deferComposerCommit;
                 sendPrompt(`/language ui ${nextLanguage}`, undefined, {
+                  ownerRef: owner,
                   clearComposerOnPromptStart,
                   commitComposerAccepted: clearComposerOnPromptStart
                     ? commitComposerAccepted
                     : undefined,
                 })
-                  .then(() => sessionActions.refreshCommands())
+                  .then(() => {
+                    if (!owner.current.isCurrent()) return;
+                    return sessionActions.refreshCommands();
+                  })
                   .catch((error: unknown) => {
+                    if (!owner.current.isCurrent()) return;
                     reportError(error, 'Failed to sync /language command');
                   });
                 return clearComposerOnPromptStart ? false : true;
@@ -7897,9 +8038,11 @@ export function App({
               pushToast('error', t('fork.empty'));
               return true;
             }
+            const owner = sessionOwnerGuard.capture();
             sessionActions
               .forkSession(directive)
               .then((result) => {
+                if (!owner.isCurrent()) return;
                 if (!result.launched) {
                   pushToast('warning', t('fork.notStarted'));
                   return;
@@ -7911,6 +8054,7 @@ export function App({
                 );
               })
               .catch((error: unknown) => {
+                if (!owner.isCurrent()) return;
                 const reason =
                   error instanceof Error ? error.message : String(error);
                 reportError(error, t('fork.failed', { reason }));
@@ -7976,12 +8120,15 @@ export function App({
                 setPendingModel(modelArg);
                 return true;
               }
+              const owner = sessionOwnerGuard.capture();
               sessionActions
                 .setModel(modelArg)
                 .then(() => {
+                  if (!owner.isCurrent()) return;
                   setPendingModel(modelArg);
                 })
                 .catch((error: unknown) => {
+                  if (!owner.isCurrent()) return;
                   reportError(error, t('model.switch'));
                 });
             } else {
@@ -8005,9 +8152,11 @@ export function App({
               return true;
             }
             if (prompt) setIsPreparingPrompt(true);
+            const owner = sessionOwnerGuard.capture();
             sessionActions
               .setApprovalMode('plan')
               .then(() => {
+                if (!owner.isCurrent()) return;
                 setPendingMode('plan');
                 if (prompt) {
                   return sendPrompt(prompt, images, {
@@ -8019,10 +8168,11 @@ export function App({
                 }
               })
               .catch((error: unknown) => {
+                if (!owner.isCurrent()) return;
                 reportError(error, t('mode.plan'));
               })
               .finally(() => {
-                if (prompt) setIsPreparingPrompt(false);
+                if (prompt && owner.isCurrent()) setIsPreparingPrompt(false);
               });
             return prompt ? false : true;
           }
@@ -8313,9 +8463,11 @@ export function App({
             if (!requireActiveSessionForLocalCommand()) return false;
             const renamedSessionId = connectionRef.current.sessionId;
             const renamedWorkspaceCwd = connectionRef.current.workspaceCwd;
+            const owner = sessionOwnerGuard.capture();
             sessionActions
               .renameSession(displayName)
               .then(() => {
+                if (!owner.isCurrent()) return;
                 if (renamedSessionId) {
                   reconcileCatalogRename(
                     renamedWorkspaceCwd,
@@ -8331,6 +8483,7 @@ export function App({
                 ]);
               })
               .catch((error: unknown) => {
+                if (!owner.isCurrent()) return;
                 if (renamedWorkspaceCwd) {
                   sessionCatalogController.invalidateWorkspace(
                     renamedWorkspaceCwd,
@@ -8343,13 +8496,7 @@ export function App({
           if (cmd === 'resume') {
             const sessionId = text.slice(match[0].length).trim();
             if (sessionId) {
-              closeMobileDrawer();
-              // Resuming a session means the user wants to see that chat, so
-              // close any open Settings/Status panel (no-op when already closed),
-              // consistent with createNewSession / loadSidebarSession.
-              closePanel();
-              autoRecapVersionRef.current += 1;
-              sessionActions.loadSession(sessionId).catch((error: unknown) => {
+              loadSidebarSession(sessionId).catch((error: unknown) => {
                 reportError(error, 'Failed to load session');
               });
             } else {
@@ -8385,15 +8532,18 @@ export function App({
             if (statsArg === 'model') statsView = 'model';
             else if (statsArg === 'tools') statsView = 'tools';
             if (!requireActiveSessionForLocalCommand()) return false;
+            const owner = sessionOwnerGuard.capture();
             echoLocalCommandIfIdle(text);
             sessionActions
               .getStats()
               .then((result) => {
+                if (!owner.isCurrent()) return;
                 dispatchReadOnlyStatus(
                   serializeStatsMessage(result, statsView),
                 );
               })
               .catch((error: unknown) => {
+                if (!owner.isCurrent()) return;
                 reportError(error, 'Failed to load stats');
               });
             return true;
@@ -8610,6 +8760,7 @@ export function App({
     [
       sendPrompt,
       sessionActions,
+      sessionOwnerGuard,
       store,
       enqueuePrompt,
       echoOrDeferLocalCommand,
@@ -8617,7 +8768,6 @@ export function App({
       dispatchReadOnlyStatus,
       branchCurrentSession,
       closeMobileDrawer,
-      closePanel,
       openPanel,
       openScheduledTasks,
       openGoals,
@@ -8638,6 +8788,7 @@ export function App({
       sideTasksAvailable,
       openEnvironmentTasksPanel,
       hiddenCommands,
+      loadSidebarSession,
       pushToast,
       reportError,
       runVisibleRecap,
@@ -8685,13 +8836,15 @@ export function App({
 
   const handleConfirm = useCallback(
     (id: string, selectedOption: string, answers?: Record<string, string>) => {
+      const owner = sessionOwnerGuard.capture();
       sessionActions
         .submitPermission(id, selectedOption, answers)
         .catch((error: unknown) => {
+          if (!owner.isCurrent()) return;
           reportError(error, 'Failed to submit permission choice');
         });
     },
-    [sessionActions, reportError],
+    [sessionActions, reportError, sessionOwnerGuard],
   );
   const handleAskUserConfirm = useCallback(
     (id: string, selectedOption: string, answers?: Record<string, string>) =>
@@ -8700,6 +8853,7 @@ export function App({
   );
 
   const handleCancel = useCallback(() => {
+    const owner = sessionOwnerGuard.capture();
     const dropped = queuedShellCommandsRef.current.length;
     queuedShellCommandsRef.current = [];
     drainGenerationRef.current++;
@@ -8709,9 +8863,10 @@ export function App({
       pushToast('warning', t('queue.shellDropped', { count: dropped }));
     }
     sessionActions.cancel().catch((error: unknown) => {
+      if (!owner.isCurrent()) return;
       reportError(error, 'Failed to cancel request');
     });
-  }, [sessionActions, reportError, pushToast, t]);
+  }, [sessionActions, reportError, pushToast, sessionOwnerGuard, t]);
 
   const handleFocusTaskPill = useCallback((): boolean => {
     if (interactionBlocked) return false;
@@ -8785,6 +8940,7 @@ export function App({
       (lastSubmittedPromptRef.current ||
         (lastSubmittedImagesRef.current?.length ?? 0) > 0)
     ) {
+      const retryAttachment = sessionOwnerGuard.capture();
       const retryErrorId = retryableTurnErrorIdRef.current;
       const retrySessionId = connectionRef.current.sessionId;
       const retrySourceVersion = composerSourceVersionRef.current;
@@ -8792,6 +8948,7 @@ export function App({
       const retryImages = lastSubmittedImagesRef.current;
       const retryInputAnnotations = lastSubmittedInputAnnotationsRef.current;
       const retryOwnerIsCurrent = () =>
+        retryAttachment.isCurrent() &&
         composerSourceVersionRef.current === retrySourceVersion &&
         connectionRef.current.sessionId === retrySessionId;
       retriedTurnErrorIdRef.current = retryErrorId;
@@ -8861,6 +9018,7 @@ export function App({
     pushToast,
     reportError,
     sendPrompt,
+    sessionOwnerGuard,
     store,
     t,
     updateUnknownPromptAdmission,
@@ -9042,11 +9200,13 @@ export function App({
     };
   }, [resetEscapeState]);
 
-  const isDisabled = shouldDisableComposerInput({
-    catchingUp: Boolean(connection.catchingUp),
-    pendingApproval: pendingApproval !== null,
-    isPreparingPrompt,
-  });
+  const isDisabled =
+    sessionWriteBlocked ||
+    shouldDisableComposerInput({
+      catchingUp: Boolean(connection.catchingUp),
+      pendingApproval: pendingApproval !== null,
+      isPreparingPrompt,
+    });
   const composerPlaceholderInputState = {
     catchingUp: Boolean(connection.catchingUp),
     isPreparingPrompt,
@@ -9063,6 +9223,7 @@ export function App({
 
   const handleModelSelect = useCallback(
     (modelId: string) => {
+      if (sessionWriteBlocked) return;
       if (!connectionRef.current.sessionId) {
         setPendingModel(modelId);
         return;
@@ -9071,10 +9232,12 @@ export function App({
       // selection is in flight — rapid Set current clicks would otherwise launch
       // concurrent setModel calls that can resolve out of order and leave a
       // model other than the user's last click active.
+      const owner = sessionOwnerGuard.capture();
       setModelActionBusy(true);
       sessionActions
         .setModel(modelId)
         .then((result) => {
+          if (!owner.isCurrent()) return;
           const summary = getModelSwitchSummary(result);
           setPendingModel(summary?.modelId ?? modelId);
           if (summary) {
@@ -9087,11 +9250,22 @@ export function App({
           }
         })
         .catch((error: unknown) => {
+          if (!owner.isCurrent()) return;
           reportError(error, t('model.switch'));
         })
-        .finally(() => setModelActionBusy(false));
+        .finally(() => {
+          if (owner.isCurrent()) setModelActionBusy(false);
+        });
     },
-    [sessionActions, store, reportError, t, setPendingModel],
+    [
+      sessionWriteBlocked,
+      reportError,
+      sessionActions,
+      sessionOwnerGuard,
+      setPendingModel,
+      store,
+      t,
+    ],
   );
 
   const handleDeleteModel = useCallback(
@@ -9215,8 +9389,12 @@ export function App({
       // and ignore the user's User-vs-Workspace choice.
       const scopeFlag =
         modelSettingScope === 'user' ? ' --global' : ' --project';
-      sendPrompt(`/model --fast ${modelId}${scopeFlag}`)
+      const owner = { current: sessionOwnerGuard.capture() };
+      sendPrompt(`/model --fast ${modelId}${scopeFlag}`, undefined, {
+        ownerRef: owner,
+      })
         .then(() => {
+          if (!owner.current.isCurrent()) return;
           // sendPrompt resolves only after the `/model --fast` turn *completes*
           // (actions.ts → waitForAcceptedPromptCompletion), so the change is
           // already applied here — this reload reads the new value, not a stale
@@ -9233,6 +9411,7 @@ export function App({
           });
         })
         .catch((error: unknown) => {
+          if (!owner.current.isCurrent()) return;
           reportError(error, 'Failed to switch fast model');
         });
     },
@@ -9244,6 +9423,7 @@ export function App({
       reportError,
       reloadWorkspaceSettings,
       modelSettingScope,
+      sessionOwnerGuard,
     ],
   );
 
@@ -9715,14 +9895,9 @@ export function App({
               <ResumeDialog
                 workspaceCwd={lockedWorkspaceCwd}
                 onSelect={(sessionId) => {
-                  closeMobileDrawer();
-                  closePanel();
-                  autoRecapVersionRef.current += 1;
-                  sessionActions
-                    .loadSession(sessionId)
-                    .catch((error: unknown) => {
-                      reportError(error, 'Failed to load session');
-                    });
+                  loadSidebarSession(sessionId).catch((error: unknown) => {
+                    reportError(error, 'Failed to load session');
+                  });
                 }}
                 onClose={() => setShowResumeDialog(false)}
               />
@@ -10629,17 +10804,24 @@ export function App({
                         // would land in an empty session with no explanation.
                         // Letting this reject keeps the error in the form the
                         // user is looking at.
+                        const owner = {
+                          current: sessionOwnerGuard.capture(),
+                        };
                         try {
                           await sendPrompt(`/goal ${condition}`, undefined, {
                             clearComposerOnPromptStart: true,
+                            ownerRef: owner,
                           });
+                          if (!owner.current.isCurrent()) return false;
                         } catch (error) {
                           // `sendPrompt` creates the session lazily, so by now
                           // one may exist even though the prompt never landed.
                           // Remember it so the retry reuses it rather than
                           // stranding it.
-                          strandedGoalSessionRef.current =
-                            connectionRef.current.sessionId;
+                          if (owner.current.isCurrent()) {
+                            strandedGoalSessionRef.current =
+                              connectionRef.current.sessionId;
+                          }
                           throw error;
                         }
                         strandedGoalSessionRef.current = undefined;

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -4681,7 +4681,11 @@ export function App({
     setCurrentMode(modeId);
   }, []);
   const [isPreparingPrompt, setIsPreparingPrompt] = useState(false);
-  useLayoutEffect(() => setIsPreparingPrompt(false), [logicalSessionKey]);
+  const planPreparationTokenRef = useRef(0);
+  useLayoutEffect(() => {
+    planPreparationTokenRef.current += 1;
+    setIsPreparingPrompt(false);
+  }, [logicalSessionKey]);
   const createSessionPromiseRef = useRef<Promise<string | undefined> | null>(
     null,
   );
@@ -5353,6 +5357,7 @@ export function App({
     connected,
     writeBlocked: sessionWriteBlocked,
     sessionId: connection.sessionId,
+    workspaceCwd: connection.workspaceCwd,
     clientId: connection.clientId,
     canMutateMidTurn,
     canQueryMidTurn,
@@ -5729,7 +5734,11 @@ export function App({
   // re-creating on every render (and without an exhaustive-deps warning).
   const reloadProviders = providersState.reload;
   const [modelActionBusy, setModelActionBusy] = useState(false);
-  useEffect(() => setModelActionBusy(false), [logicalSessionKey]);
+  const modelActionTokenRef = useRef(0);
+  useLayoutEffect(() => {
+    modelActionTokenRef.current += 1;
+    setModelActionBusy(false);
+  }, [logicalSessionKey]);
   const {
     settings: workspaceSettings,
     setValue: setWorkspaceSetting,
@@ -8160,6 +8169,9 @@ export function App({
               }
               return true;
             }
+            const planPreparationToken = prompt
+              ? ++planPreparationTokenRef.current
+              : undefined;
             if (prompt) setIsPreparingPrompt(true);
             const owner = sessionOwnerGuard.capture();
             sessionActions
@@ -8181,7 +8193,12 @@ export function App({
                 reportError(error, t('mode.plan'));
               })
               .finally(() => {
-                if (prompt && owner.isCurrent()) setIsPreparingPrompt(false);
+                if (
+                  prompt &&
+                  planPreparationTokenRef.current === planPreparationToken
+                ) {
+                  setIsPreparingPrompt(false);
+                }
               });
             return prompt ? false : true;
           }
@@ -8940,6 +8957,7 @@ export function App({
   );
 
   const handleRetry = useCallback(() => {
+    if (sessionWriteBlockedRef.current) return;
     if (
       showRetryHintRef.current &&
       connected &&
@@ -9242,6 +9260,7 @@ export function App({
       // concurrent setModel calls that can resolve out of order and leave a
       // model other than the user's last click active.
       const owner = sessionOwnerGuard.capture();
+      const modelActionToken = ++modelActionTokenRef.current;
       setModelActionBusy(true);
       sessionActions
         .setModel(modelId)
@@ -9263,7 +9282,9 @@ export function App({
           reportError(error, t('model.switch'));
         })
         .finally(() => {
-          if (owner.isCurrent()) setModelActionBusy(false);
+          if (modelActionTokenRef.current === modelActionToken) {
+            setModelActionBusy(false);
+          }
         });
     },
     [
@@ -9279,6 +9300,7 @@ export function App({
 
   const handleDeleteModel = useCallback(
     (target: { authType: string; modelId: string; baseUrl?: string }) => {
+      const modelActionToken = ++modelActionTokenRef.current;
       setModelActionBusy(true);
       workspaceActions
         .deleteModel(target)
@@ -9309,7 +9331,11 @@ export function App({
         .catch((error: unknown) => {
           reportError(error, t('settings.models.deleteFailed'));
         })
-        .finally(() => setModelActionBusy(false));
+        .finally(() => {
+          if (modelActionTokenRef.current === modelActionToken) {
+            setModelActionBusy(false);
+          }
+        });
     },
     // Depend on the stable `reload` fn, not the whole providersState object,
     // which useProviders returns fresh each render (would defeat the memo).

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -5247,14 +5247,12 @@ export function App({
       updateFailedPrompt(null);
       return;
     }
-    const retryAttachment = sessionOwnerGuard.capture();
     const retryOwner = {
       sourceVersion: composerSourceVersionRef.current,
       sessionId: connectionRef.current.sessionId,
       workspaceCwd: getComposerWorkspaceCwd(),
     };
     const retryOwnerIsCurrent = () =>
-      retryAttachment.isCurrent() &&
       composerSourceVersionRef.current === retryOwner.sourceVersion &&
       connectionRef.current.sessionId === retryOwner.sessionId &&
       getComposerWorkspaceCwd() === retryOwner.workspaceCwd;
@@ -5328,7 +5326,6 @@ export function App({
     pushToast,
     reportError,
     sendPrompt,
-    sessionOwnerGuard,
     store,
     t,
     updateFailedPrompt,
@@ -5482,7 +5479,7 @@ export function App({
     const anchorIndex = messages.length;
     const anchorAfterId = messages.at(-1)?.id;
     const sessionId = connection.sessionId;
-    const owner = sessionOwnerGuard.capture();
+    const workspaceCwd = connection.workspaceCwd;
     setRecapMessage({
       anchorAfterId,
       anchorIndex,
@@ -5496,7 +5493,10 @@ export function App({
     });
     sessionActions.recapSession().then(
       (result) => {
-        if (!owner.isCurrent() || currentSessionIdRef.current !== sessionId)
+        if (
+          currentSessionIdRef.current !== sessionId ||
+          connectionRef.current.workspaceCwd !== workspaceCwd
+        )
           return;
         setRecapMessage({
           anchorAfterId,
@@ -5513,7 +5513,10 @@ export function App({
         });
       },
       (error: unknown) => {
-        if (!owner.isCurrent() || currentSessionIdRef.current !== sessionId)
+        if (
+          currentSessionIdRef.current !== sessionId ||
+          connectionRef.current.workspaceCwd !== workspaceCwd
+        )
           return;
         setRecapMessage(null);
         if (!isAbortError(error) && !isAlreadyDispatched(error)) {
@@ -5523,11 +5526,11 @@ export function App({
     );
   }, [
     connection.sessionId,
+    connection.workspaceCwd,
     messages,
     requireActiveSessionForLocalCommand,
     sessionWriteBlocked,
     sessionActions,
-    sessionOwnerGuard,
     t,
   ]);
 
@@ -5543,7 +5546,7 @@ export function App({
 
       const messageId = `local-btw-${nextBtwMessageIdRef.current++}`;
       const sessionId = connection.sessionId;
-      const owner = sessionOwnerGuard.capture();
+      const workspaceCwd = connection.workspaceCwd;
       btwAbortControllerRef.current?.abort();
       const abortController = new AbortController();
       btwAbortControllerRef.current = abortController;
@@ -5559,7 +5562,10 @@ export function App({
         .btwSession(question, { signal: abortController.signal })
         .then(
           (result) => {
-            if (!owner.isCurrent() || currentSessionIdRef.current !== sessionId)
+            if (
+              currentSessionIdRef.current !== sessionId ||
+              connectionRef.current.workspaceCwd !== workspaceCwd
+            )
               return;
             if (btwAbortControllerRef.current !== abortController) return;
             btwAbortControllerRef.current = null;
@@ -5572,7 +5578,10 @@ export function App({
             });
           },
           (error: unknown) => {
-            if (!owner.isCurrent() || currentSessionIdRef.current !== sessionId)
+            if (
+              currentSessionIdRef.current !== sessionId ||
+              connectionRef.current.workspaceCwd !== workspaceCwd
+            )
               return;
             if (btwAbortControllerRef.current !== abortController) return;
             btwAbortControllerRef.current = null;
@@ -5585,11 +5594,11 @@ export function App({
     },
     [
       connection.sessionId,
+      connection.workspaceCwd,
       pushToast,
       requireActiveSessionForLocalCommand,
       sessionWriteBlocked,
       sessionActions,
-      sessionOwnerGuard,
       t,
     ],
   );
@@ -8940,17 +8949,17 @@ export function App({
       (lastSubmittedPromptRef.current ||
         (lastSubmittedImagesRef.current?.length ?? 0) > 0)
     ) {
-      const retryAttachment = sessionOwnerGuard.capture();
       const retryErrorId = retryableTurnErrorIdRef.current;
       const retrySessionId = connectionRef.current.sessionId;
+      const retryWorkspaceCwd = getComposerWorkspaceCwd();
       const retrySourceVersion = composerSourceVersionRef.current;
       const retryText = lastSubmittedPromptRef.current;
       const retryImages = lastSubmittedImagesRef.current;
       const retryInputAnnotations = lastSubmittedInputAnnotationsRef.current;
       const retryOwnerIsCurrent = () =>
-        retryAttachment.isCurrent() &&
         composerSourceVersionRef.current === retrySourceVersion &&
-        connectionRef.current.sessionId === retrySessionId;
+        connectionRef.current.sessionId === retrySessionId &&
+        getComposerWorkspaceCwd() === retryWorkspaceCwd;
       retriedTurnErrorIdRef.current = retryErrorId;
       setShowRetryHint(false);
       setFailedPromptRetry({
@@ -9015,10 +9024,10 @@ export function App({
     }
   }, [
     connected,
+    getComposerWorkspaceCwd,
     pushToast,
     reportError,
     sendPrompt,
-    sessionOwnerGuard,
     store,
     t,
     updateUnknownPromptAdmission,

--- a/packages/web-shell/client/components/ChatPane.test.tsx
+++ b/packages/web-shell/client/components/ChatPane.test.tsx
@@ -110,6 +110,9 @@ vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
     workspaceCwd: '/primary',
   }),
   useWorkspaceEventSignals: () => ({ artifactsVersion: 0 }),
+  useDaemonSessionOwnerGuard: () => ({
+    capture: () => ({ isCurrent: () => true }),
+  }),
 }));
 
 vi.mock('../session-catalog/session-catalog-hooks', () => ({

--- a/packages/web-shell/client/components/ChatPane.tsx
+++ b/packages/web-shell/client/components/ChatPane.tsx
@@ -538,6 +538,7 @@ export function ChatPane({
   } = useQueuedPrompts({
     connected: connection.status === 'connected',
     sessionId: connection.sessionId,
+    workspaceCwd: connection.workspaceCwd,
     clientId: connection.clientId,
     canMutateMidTurn,
     canQueryMidTurn,

--- a/packages/web-shell/client/components/WorkspaceSessionProvider.test.tsx
+++ b/packages/web-shell/client/components/WorkspaceSessionProvider.test.tsx
@@ -1,0 +1,360 @@
+// @vitest-environment jsdom
+
+import { act, type ReactNode, useEffect } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  connection: {
+    status: 'connected',
+    sessionId: 'session-a',
+    workspaceCwd: '/work/a',
+  } as Record<string, unknown>,
+  workspace: {
+    status: 'connected',
+    capabilities: {
+      workspaceCwd: '/work/a',
+      features: ['client_identity'],
+      workspaces: [
+        { id: 'a', cwd: '/work/a', primary: true, trusted: true },
+        { id: 'b', cwd: '/work/b', primary: false, trusted: true },
+      ],
+    },
+    refreshCapabilities: vi.fn(async () => undefined),
+  } as Record<string, unknown>,
+  addWorkspace: vi.fn(),
+  providerMounts: 0,
+  providerUnmounts: 0,
+  providerProps: [] as Array<Record<string, unknown>>,
+  appProps: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
+  DaemonSessionProvider: ({
+    children,
+    ...props
+  }: Record<string, unknown> & { children: ReactNode }) => {
+    mocks.providerProps.push(props);
+    useEffect(() => {
+      mocks.providerMounts += 1;
+      return () => {
+        mocks.providerUnmounts += 1;
+      };
+    }, []);
+    return children;
+  },
+  useWorkspace: () => mocks.workspace,
+  useConnection: () => mocks.connection,
+  useWorkspaceActions: () => ({ addWorkspace: mocks.addWorkspace }),
+}));
+
+vi.mock('../App', () => ({
+  App: (props: Record<string, unknown>) => {
+    mocks.appProps.push(props);
+    return (
+      <output>{String(props['initialSelectedWorkspaceCwd'] ?? '')}</output>
+    );
+  },
+}));
+
+import { WorkspaceSessionProvider } from './WorkspaceSessionProvider';
+
+describe('WorkspaceSessionProvider transactional targets', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    mocks.connection = {
+      status: 'connected',
+      sessionId: 'session-a',
+      workspaceCwd: '/work/a',
+    };
+    mocks.workspace = {
+      status: 'connected',
+      capabilities: {
+        workspaceCwd: '/work/a',
+        features: ['client_identity'],
+        workspaces: [
+          { id: 'a', cwd: '/work/a', primary: true, trusted: true },
+          { id: 'b', cwd: '/work/b', primary: false, trusted: true },
+        ],
+      },
+      refreshCapabilities: vi.fn(async () => undefined),
+    };
+    mocks.addWorkspace.mockReset();
+    mocks.providerMounts = 0;
+    mocks.providerUnmounts = 0;
+    mocks.providerProps = [];
+    mocks.appProps = [];
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  async function renderTarget(
+    sessionId: string,
+    workspaceCwd: string,
+    onSessionIdChange = vi.fn(),
+  ) {
+    await act(async () => {
+      root.render(
+        <WorkspaceSessionProvider
+          sessionId={sessionId}
+          workspaceCwd={workspaceCwd}
+          webShellProps={{ onSessionIdChange }}
+        />,
+      );
+    });
+    return onSessionIdChange;
+  }
+
+  it('keeps the modern provider mounted until the desired target commits', async () => {
+    const onSessionIdChange = await renderTarget('session-a', '/work/a');
+    expect(mocks.providerMounts).toBe(1);
+    expect(container.textContent).toBe('/work/a');
+
+    await renderTarget('session-b', '/work/b', onSessionIdChange);
+    expect(mocks.providerMounts).toBe(1);
+    expect(mocks.providerUnmounts).toBe(0);
+    expect(mocks.providerProps.at(-1)).toMatchObject({
+      sessionId: 'session-b',
+      workspaceCwd: '/work/b',
+    });
+    expect(mocks.appProps.at(-1)).toMatchObject({
+      desiredSessionTargetPending: true,
+      initialSelectedWorkspaceCwd: '/work/a',
+    });
+
+    await act(async () => {
+      const commit = mocks.providerProps.at(-1)?.[
+        'onSessionTransitionCommit'
+      ] as (target: { sessionId: string; workspaceCwd: string }) => void;
+      commit({ sessionId: 'session-b', workspaceCwd: '/work/b' });
+    });
+    expect(container.textContent).toBe('/work/b');
+    expect(mocks.providerProps.at(-1)).toMatchObject({
+      sessionId: 'session-b',
+      workspaceCwd: '/work/b',
+    });
+    expect(mocks.appProps.at(-1)).toMatchObject({
+      desiredSessionTargetPending: false,
+    });
+    const appReport = mocks.appProps.at(-1)?.['onSessionIdChange'] as (
+      sessionId: string,
+      workspaceId: string,
+      workspaceCwd: string,
+    ) => void;
+    appReport('session-b', 'b', '/work/b');
+    expect(onSessionIdChange).toHaveBeenCalledTimes(1);
+    expect(onSessionIdChange).toHaveBeenCalledWith('session-b', 'b', '/work/b');
+  });
+
+  it('does not feed stale host props back after an action-driven commit', async () => {
+    const onSessionIdChange = await renderTarget('session-a', '/work/a');
+
+    await act(async () => {
+      const commit = mocks.providerProps.at(-1)?.[
+        'onSessionTransitionCommit'
+      ] as (target: { sessionId: string; workspaceCwd: string }) => void;
+      commit({ sessionId: 'session-b', workspaceCwd: '/work/b' });
+    });
+
+    expect(mocks.providerProps.at(-1)).toMatchObject({
+      sessionId: 'session-b',
+      workspaceCwd: '/work/b',
+    });
+    expect(onSessionIdChange).not.toHaveBeenCalled();
+    const appReport = mocks.appProps.at(-1)?.['onSessionIdChange'] as (
+      sessionId: string,
+      workspaceId: string,
+      workspaceCwd: string,
+    ) => void;
+    appReport('session-b', 'b', '/work/b');
+    expect(onSessionIdChange).toHaveBeenCalledWith('session-b', 'b', '/work/b');
+  });
+
+  it('keeps the committed app visible while a workspace target is unresolved', async () => {
+    const onSessionIdChange = await renderTarget('session-a', '/work/a');
+    mocks.workspace = {
+      ...mocks.workspace,
+      capabilities: undefined,
+    };
+
+    await renderTarget('session-b', '/work/missing', onSessionIdChange);
+    expect(mocks.providerMounts).toBe(1);
+    expect(container.textContent).toBe('/work/a');
+    expect(mocks.providerProps.at(-1)).toMatchObject({
+      sessionId: 'session-a',
+      workspaceCwd: '/work/a',
+    });
+    expect(mocks.appProps.at(-1)).toMatchObject({
+      desiredSessionTargetPending: true,
+    });
+  });
+
+  it('unblocks the committed session after workspace resolution fails', async () => {
+    const onSessionIdChange = await renderTarget('session-a', '/work/a');
+    onSessionIdChange.mockClear();
+    mocks.workspace = {
+      ...mocks.workspace,
+      status: 'error',
+      capabilities: {
+        workspaceCwd: '/work/a',
+        features: ['client_identity'],
+        workspaces: [{ id: 'a', cwd: '/work/a', primary: true, trusted: true }],
+      },
+    };
+
+    await renderTarget('session-b', '/work/missing', onSessionIdChange);
+
+    expect(mocks.providerMounts).toBe(1);
+    expect(container.textContent).toBe('/work/a');
+    expect(mocks.appProps.at(-1)).toMatchObject({
+      desiredSessionTargetPending: false,
+    });
+    expect(onSessionIdChange).toHaveBeenCalledTimes(1);
+    expect(onSessionIdChange).toHaveBeenCalledWith('session-a', 'a', '/work/a');
+
+    await renderTarget('session-b', '/work/missing', onSessionIdChange);
+    expect(onSessionIdChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not preserve a target that never connected', async () => {
+    mocks.connection = { status: 'error' };
+    const onSessionIdChange = await renderTarget('session-a', '/work/a');
+    mocks.workspace = {
+      ...mocks.workspace,
+      capabilities: {
+        workspaceCwd: '/work/a',
+        features: ['client_identity'],
+        workspaces: [{ id: 'a', cwd: '/work/a', primary: true, trusted: true }],
+      },
+    };
+
+    await renderTarget('session-b', '/work/missing', onSessionIdChange);
+
+    expect(mocks.providerUnmounts).toBe(1);
+    expect(container.textContent).not.toContain('/work/a');
+  });
+
+  it('rolls a still-current controlled target back after restore failure', async () => {
+    const onSessionIdChange = await renderTarget('session-a', '/work/a');
+    onSessionIdChange.mockClear();
+    await renderTarget('session-b', '/work/b', onSessionIdChange);
+    mocks.connection = {
+      status: 'connected',
+      sessionId: 'session-a',
+      workspaceCwd: '/work/a',
+      sessionTransition: {
+        phase: 'failed',
+        operation: 'load',
+        origin: 'controlled',
+        targetSessionId: 'session-b',
+        targetWorkspaceCwd: '/work/b',
+      },
+    };
+    await renderTarget('session-b', '/work/b', onSessionIdChange);
+    expect(onSessionIdChange).toHaveBeenCalledTimes(1);
+    expect(onSessionIdChange).toHaveBeenCalledWith('session-a', 'a', '/work/a');
+    expect(mocks.appProps.at(-1)).toMatchObject({
+      desiredSessionTargetPending: false,
+    });
+  });
+
+  it('rolls back a primary-workspace target when workspace props are omitted', async () => {
+    const onSessionIdChange = vi.fn();
+    await act(async () => {
+      root.render(
+        <WorkspaceSessionProvider
+          sessionId="session-a"
+          webShellProps={{ onSessionIdChange }}
+        />,
+      );
+    });
+    onSessionIdChange.mockClear();
+
+    await act(async () => {
+      root.render(
+        <WorkspaceSessionProvider
+          sessionId="session-b"
+          webShellProps={{ onSessionIdChange }}
+        />,
+      );
+    });
+    mocks.connection = {
+      status: 'connected',
+      sessionId: 'session-a',
+      workspaceCwd: '/work/a',
+      sessionTransition: {
+        phase: 'failed',
+        operation: 'load',
+        origin: 'controlled',
+        targetSessionId: 'session-b',
+        targetWorkspaceCwd: '/work/a',
+      },
+    };
+    await act(async () => {
+      root.render(
+        <WorkspaceSessionProvider
+          sessionId="session-b"
+          webShellProps={{ onSessionIdChange }}
+        />,
+      );
+    });
+
+    expect(onSessionIdChange).toHaveBeenCalledWith('session-a', 'a', '/work/a');
+  });
+
+  it('preserves keyed remounts for legacy daemons', async () => {
+    mocks.workspace = {
+      ...mocks.workspace,
+      capabilities: {
+        workspaceCwd: '/work/a',
+        features: [],
+        workspaces: [
+          { id: 'a', cwd: '/work/a', primary: true, trusted: true },
+          { id: 'b', cwd: '/work/b', primary: false, trusted: true },
+        ],
+      },
+    };
+    const onSessionIdChange = await renderTarget('session-a', '/work/a');
+    await renderTarget('session-b', '/work/b', onSessionIdChange);
+    expect(mocks.providerMounts).toBe(2);
+    expect(mocks.providerUnmounts).toBe(1);
+    expect(mocks.appProps.at(-1)).toMatchObject({
+      initialSelectedWorkspaceCwd: '/work/b',
+    });
+  });
+
+  it('does not remount when an unknown daemon resolves as modern', async () => {
+    mocks.workspace = { ...mocks.workspace, capabilities: undefined };
+    await act(async () => {
+      root.render(
+        <WorkspaceSessionProvider sessionId="session-a" webShellProps={{}} />,
+      );
+    });
+    expect(mocks.providerMounts).toBe(1);
+
+    mocks.workspace = {
+      ...mocks.workspace,
+      capabilities: {
+        workspaceCwd: '/work/a',
+        features: ['client_identity'],
+        workspaces: [{ id: 'a', cwd: '/work/a', primary: true, trusted: true }],
+      },
+    };
+    await act(async () => {
+      root.render(
+        <WorkspaceSessionProvider sessionId="session-a" webShellProps={{}} />,
+      );
+    });
+
+    expect(mocks.providerMounts).toBe(1);
+    expect(mocks.providerUnmounts).toBe(0);
+  });
+});

--- a/packages/web-shell/client/components/WorkspaceSessionProvider.tsx
+++ b/packages/web-shell/client/components/WorkspaceSessionProvider.tsx
@@ -1,10 +1,12 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { WifiOffIcon } from 'lucide-react';
 import {
   DaemonSessionProvider,
+  useConnection,
   useWorkspace,
   useWorkspaceActions,
 } from '@qwen-code/webui/daemon-react-sdk';
+import type { DaemonConnectionState } from '@qwen-code/webui/daemon-react-sdk';
 import type { DaemonWorkspaceCapability } from '@qwen-code/sdk/daemon';
 import { App, type WebShellProps } from '../App';
 import {
@@ -14,6 +16,17 @@ import {
 import { getTranslator, normalizeLanguage } from '../i18n';
 import { Spinner } from './ui/spinner';
 import { WorkspaceUnavailableState } from './WorkspaceUnavailableState';
+const CLIENT_IDENTITY_FEATURE = 'client_identity';
+type CommittedSessionTarget = { sessionId: string; workspaceCwd?: string };
+function SessionStateObserver({
+  onChange,
+}: {
+  onChange: (connection: DaemonConnectionState) => void;
+}) {
+  const connection = useConnection();
+  useEffect(() => onChange(connection), [connection, onChange]);
+  return null;
+}
 
 interface WorkspaceSessionProviderProps {
   sessionId?: string;
@@ -91,10 +104,168 @@ export function WorkspaceSessionProvider({
     : workspace.capabilities?.workspaces?.find(
         (entry) => entry.id === effectiveWorkspaceId,
       );
+  const desiredWorkspace =
+    targetWorkspace ??
+    (!effectiveWorkspaceCwd && !effectiveWorkspaceId
+      ? workspace.capabilities?.workspaces?.find(
+          (entry) =>
+            entry.primary || entry.cwd === workspace.capabilities?.workspaceCwd,
+        )
+      : undefined);
   const t = useMemo(
     () => getTranslator(normalizeLanguage(webShellProps.language)),
     [webShellProps.language],
   );
+  const onSessionIdChange = webShellProps.onSessionIdChange;
+  const transactionalRef = useRef<boolean | undefined>(undefined);
+  if (workspace.capabilities) {
+    transactionalRef.current = workspace.capabilities.features.includes(
+      CLIENT_IDENTITY_FEATURE,
+    );
+  }
+  const transactional = transactionalRef.current === true;
+  const desiredKey = `${effectiveSessionId ?? ''}\0${effectiveWorkspaceCwd ?? effectiveWorkspaceId ?? ''}`;
+  const [, setCommittedTarget] = useState<CommittedSessionTarget>();
+  const committedTargetRef = useRef<CommittedSessionTarget | undefined>(
+    undefined,
+  );
+  const pendingHostCommitKeyRef = useRef<string | undefined>(undefined);
+  if (
+    pendingHostCommitKeyRef.current !== undefined &&
+    pendingHostCommitKeyRef.current !== desiredKey
+  ) {
+    pendingHostCommitKeyRef.current = undefined;
+  }
+  const installCommittedTarget = useCallback(
+    (target: CommittedSessionTarget) => {
+      committedTargetRef.current = target;
+      setCommittedTarget(target);
+    },
+    [],
+  );
+  const commitTarget = useCallback(
+    (target: CommittedSessionTarget) => {
+      pendingHostCommitKeyRef.current =
+        target.sessionId !== effectiveSessionId ||
+        target.workspaceCwd !== desiredWorkspace?.cwd
+          ? desiredKey
+          : undefined;
+      installCommittedTarget(target);
+    },
+    [
+      desiredKey,
+      desiredWorkspace?.cwd,
+      effectiveSessionId,
+      installCommittedTarget,
+    ],
+  );
+  const canKeepCommitted =
+    transactional && committedTargetRef.current !== undefined;
+  const desiredTargetResolved =
+    (!effectiveWorkspaceCwd && !effectiveWorkspaceId) ||
+    targetWorkspace !== undefined;
+  const failureLatchRef = useRef<string | undefined>(undefined);
+  const desiredTargetFailed =
+    workspace.status === 'error' ||
+    (!desiredTargetResolved &&
+      ((lockWorkspaceCwd !== undefined &&
+        registrationErrorCwd === lockWorkspaceCwd) ||
+        (workspace.capabilities !== undefined && !lockWorkspaceCwd)));
+  const desiredTargetReady = desiredTargetResolved && !desiredTargetFailed;
+  const controlledTargetUncommitted =
+    effectiveSessionId !== undefined &&
+    pendingHostCommitKeyRef.current !== desiredKey &&
+    (effectiveSessionId !== committedTargetRef.current?.sessionId ||
+      desiredWorkspace?.cwd !== committedTargetRef.current?.workspaceCwd);
+  const desiredTargetPending =
+    canKeepCommitted &&
+    failureLatchRef.current !== desiredKey &&
+    !desiredTargetFailed &&
+    (!desiredTargetReady || controlledTargetUncommitted);
+  const reportCommittedTarget = useCallback(() => {
+    const committed = committedTargetRef.current;
+    if (!committed) return;
+    const workspaceId = workspace.capabilities?.workspaces?.find(
+      (entry) => entry.cwd === committed.workspaceCwd,
+    )?.id;
+    onSessionIdChange?.(
+      committed.sessionId,
+      workspaceId,
+      committed.workspaceCwd,
+    );
+  }, [onSessionIdChange, workspace.capabilities?.workspaces]);
+  const observeSessionState = useCallback(
+    (connection: DaemonConnectionState) => {
+      if (
+        transactional &&
+        connection.status === 'connected' &&
+        connection.sessionId
+      ) {
+        installCommittedTarget({
+          sessionId: connection.sessionId,
+          workspaceCwd: connection.workspaceCwd,
+        });
+      }
+      const transition = connection.sessionTransition;
+      if (
+        transition?.phase === 'failed' &&
+        transition.targetSessionId === effectiveSessionId &&
+        transition.targetWorkspaceCwd === desiredWorkspace?.cwd &&
+        failureLatchRef.current !== desiredKey
+      ) {
+        failureLatchRef.current = desiredKey;
+        reportCommittedTarget();
+      }
+    },
+    [
+      desiredKey,
+      effectiveSessionId,
+      installCommittedTarget,
+      reportCommittedTarget,
+      desiredWorkspace?.cwd,
+      transactional,
+    ],
+  );
+
+  useEffect(() => {
+    if (!canKeepCommitted || desiredTargetReady) {
+      if (failureLatchRef.current !== desiredKey) {
+        failureLatchRef.current = undefined;
+      }
+      return;
+    }
+    if (!desiredTargetFailed || failureLatchRef.current === desiredKey) return;
+    failureLatchRef.current = desiredKey;
+    reportCommittedTarget();
+  }, [
+    canKeepCommitted,
+    desiredKey,
+    desiredTargetFailed,
+    desiredTargetReady,
+    reportCommittedTarget,
+  ]);
+  const keepCommittedTarget =
+    canKeepCommitted &&
+    (!desiredTargetReady || pendingHostCommitKeyRef.current === desiredKey);
+  const providerSessionId = keepCommittedTarget
+    ? committedTargetRef.current!.sessionId
+    : effectiveSessionId;
+  const providerWorkspaceCwd = keepCommittedTarget
+    ? committedTargetRef.current!.workspaceCwd
+    : desiredWorkspace?.cwd;
+  const visibleWorkspaceCwd = canKeepCommitted
+    ? committedTargetRef.current!.workspaceCwd
+    : desiredWorkspace?.cwd;
+  const visibleWorkspace =
+    (desiredWorkspace?.cwd === visibleWorkspaceCwd
+      ? desiredWorkspace
+      : undefined) ??
+    workspace.capabilities?.workspaces?.find(
+      (entry) => entry.cwd === visibleWorkspaceCwd,
+    ) ??
+    (registeredLockedWorkspace?.cwd === visibleWorkspaceCwd
+      ? registeredLockedWorkspace
+      : undefined);
 
   useEffect(() => {
     if (!lockWorkspaceCwd || !workspace.capabilities || pathWorkspace) return;
@@ -151,7 +322,8 @@ export function WorkspaceSessionProvider({
 
   if (
     (effectiveWorkspaceCwd || effectiveWorkspaceId) &&
-    workspace.status === 'error'
+    workspace.status === 'error' &&
+    !canKeepCommitted
   ) {
     return (
       <WorkspaceUnavailableState
@@ -168,7 +340,8 @@ export function WorkspaceSessionProvider({
   }
   if (
     (effectiveWorkspaceCwd || effectiveWorkspaceId) &&
-    !workspace.capabilities
+    !workspace.capabilities &&
+    !canKeepCommitted
   ) {
     return (
       <div
@@ -183,7 +356,11 @@ export function WorkspaceSessionProvider({
       </div>
     );
   }
-  if (lockWorkspaceCwd && registrationErrorCwd === lockWorkspaceCwd) {
+  if (
+    lockWorkspaceCwd &&
+    registrationErrorCwd === lockWorkspaceCwd &&
+    !canKeepCommitted
+  ) {
     return (
       <WorkspaceUnavailableState
         title={t('workspace.loadFailed')}
@@ -198,7 +375,7 @@ export function WorkspaceSessionProvider({
       />
     );
   }
-  if (lockWorkspaceCwd && !targetWorkspace) {
+  if (lockWorkspaceCwd && !targetWorkspace && !canKeepCommitted) {
     return (
       <div
         data-web-shell-root
@@ -212,7 +389,11 @@ export function WorkspaceSessionProvider({
       </div>
     );
   }
-  if ((effectiveWorkspaceCwd || effectiveWorkspaceId) && !targetWorkspace) {
+  if (
+    (effectiveWorkspaceCwd || effectiveWorkspaceId) &&
+    !targetWorkspace &&
+    !canKeepCommitted
+  ) {
     return (
       <WorkspaceUnavailableState
         title={t('workspace.notFound')}
@@ -229,26 +410,33 @@ export function WorkspaceSessionProvider({
 
   return (
     <DaemonSessionProvider
-      key={`${targetWorkspace?.id ?? effectiveWorkspaceId ?? 'primary'}:${effectiveSessionId ?? 'new'}`}
-      sessionId={effectiveSessionId}
-      workspaceCwd={targetWorkspace?.cwd}
+      key={
+        transactionalRef.current !== false
+          ? 'transactional-main-session'
+          : `${targetWorkspace?.id ?? effectiveWorkspaceId ?? 'primary'}:${effectiveSessionId ?? 'new'}`
+      }
+      sessionId={providerSessionId}
+      workspaceCwd={providerWorkspaceCwd}
       clientId={clientId}
       historyPageSize={historyPageSize}
       subagentTranscriptMode="summary"
       maxBlocks={WEB_SHELL_MAX_TRANSCRIPT_BLOCKS}
       suppressOwnUserEcho
       restartEventStreamOnPrompt={restartSseOnPrompt}
+      onSessionTransitionCommit={commitTarget}
     >
+      <SessionStateObserver onChange={observeSessionState} />
       <App
         {...webShellProps}
+        desiredSessionTargetPending={desiredTargetPending}
         historyPageSize={historyPageSize}
         restartSseOnPrompt={restartSseOnPrompt}
         initialSelectedWorkspaceCwd={
-          !lockWorkspaceCwd && targetWorkspace ? targetWorkspace.cwd : undefined
+          !lockWorkspaceCwd ? visibleWorkspaceCwd : undefined
         }
-        lockedWorkspaceCwd={lockWorkspaceCwd ? targetWorkspace?.cwd : undefined}
+        lockedWorkspaceCwd={lockWorkspaceCwd ? visibleWorkspaceCwd : undefined}
         lockedWorkspaceCapability={
-          lockWorkspaceCwd ? targetWorkspace : undefined
+          lockWorkspaceCwd ? visibleWorkspace : undefined
         }
       />
     </DaemonSessionProvider>

--- a/packages/web-shell/client/hooks/useBackgroundTasks.test.tsx
+++ b/packages/web-shell/client/hooks/useBackgroundTasks.test.tsx
@@ -22,6 +22,8 @@ interface Deferred<T> {
 }
 
 const sdkMock = vi.hoisted(() => ({
+  ownerVersion: 0,
+  ownerGuard: { capture: vi.fn() },
   actions: {
     getTasks: vi.fn(),
   },
@@ -29,6 +31,7 @@ const sdkMock = vi.hoisted(() => ({
 
 vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
   useActions: () => sdkMock.actions,
+  useDaemonSessionOwnerGuard: () => sdkMock.ownerGuard,
 }));
 
 let root: Root | null = null;
@@ -109,6 +112,11 @@ beforeEach(() => {
   refreshTrigger = 0;
   latestTasks = [];
   sdkMock.actions.getTasks.mockReset();
+  sdkMock.ownerVersion = 0;
+  sdkMock.ownerGuard.capture.mockImplementation(() => {
+    const version = sdkMock.ownerVersion;
+    return { isCurrent: () => sdkMock.ownerVersion === version };
+  });
 });
 
 afterEach(async () => {
@@ -205,6 +213,7 @@ describe('useBackgroundTasks', () => {
     });
 
     sessionId = 'session-b';
+    sdkMock.ownerVersion += 1;
     await rerenderHarness();
     expect(sdkMock.actions.getTasks).toHaveBeenCalledTimes(2);
     expect(sdkMock.actions.getTasks).toHaveBeenLastCalledWith({
@@ -233,5 +242,46 @@ describe('useBackgroundTasks', () => {
     expect(sdkMock.actions.getTasks).toHaveBeenLastCalledWith({
       silent: true,
     });
+  });
+
+  it('ignores an old attachment response when the session id is unchanged', async () => {
+    const request = deferred<DaemonSessionTasksStatus>();
+    sdkMock.actions.getTasks.mockReturnValueOnce(request.promise);
+    await renderHarness();
+
+    sdkMock.ownerVersion += 1;
+    await act(async () => {
+      request.resolve(
+        snapshot('session-a', [monitor('stale-monitor', 'running')]),
+      );
+      await request.promise;
+    });
+
+    expect(latestTasks).toEqual([]);
+  });
+
+  it('starts polling a replacement attachment while the old request hangs', async () => {
+    const oldRequest = deferred<DaemonSessionTasksStatus>();
+    const runningMonitor = monitor('replacement-monitor', 'running');
+    sdkMock.actions.getTasks
+      .mockReturnValueOnce(oldRequest.promise)
+      .mockResolvedValueOnce(snapshot('session-a', [runningMonitor]));
+
+    await renderHarness();
+    expect(sdkMock.actions.getTasks).toHaveBeenCalledTimes(1);
+
+    sdkMock.ownerVersion += 1;
+    await rerenderHarness();
+
+    expect(sdkMock.actions.getTasks).toHaveBeenCalledTimes(2);
+    expect(latestTasks).toEqual([runningMonitor]);
+
+    await act(async () => {
+      oldRequest.resolve(
+        snapshot('session-a', [monitor('stale-monitor', 'completed')]),
+      );
+      await oldRequest.promise;
+    });
+    expect(latestTasks).toEqual([runningMonitor]);
   });
 });

--- a/packages/web-shell/client/hooks/useBackgroundTasks.ts
+++ b/packages/web-shell/client/hooks/useBackgroundTasks.ts
@@ -1,6 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 import type { DaemonSessionTaskStatus } from '@qwen-code/sdk/daemon';
-import { useActions } from '@qwen-code/webui/daemon-react-sdk';
+import {
+  useActions,
+  useDaemonSessionOwnerGuard,
+} from '@qwen-code/webui/daemon-react-sdk';
 import { TASKS_STATUS_ACTIVE_EVENT } from '../components/messages/TasksStatusMessage';
 import { isSessionDisconnectedError } from '../utils/sessionErrors';
 
@@ -20,32 +23,30 @@ export function useBackgroundTasks(
   refreshTrigger = 0,
 ): DaemonSessionTaskStatus[] {
   const actions = useActions();
+  const ownerGuard = useDaemonSessionOwnerGuard();
+  const ownerRef = useRef(ownerGuard.capture());
+  if (!ownerRef.current?.isCurrent()) ownerRef.current = ownerGuard.capture();
+  const owner = ownerRef.current;
   const [tasks, setTasks] = useState<DaemonSessionTaskStatus[]>([]);
+  const tasksOwnerRef = useRef(owner);
   const [pollingActive, setPollingActive] = useState(false);
   const [tasksPanelActive, setTasksPanelActive] = useState(false);
   const emptyPollsRef = useRef(0);
-  const tasksRefreshInFlightRef = useRef<{
-    sessionId: string;
-    request: object;
-  } | null>(null);
+  const tasksRefreshInFlightRef = useRef<typeof owner | null>(null);
 
   useEffect(() => {
+    tasksOwnerRef.current = owner;
     setTasks([]);
     setPollingActive(false);
     emptyPollsRef.current = 0;
-  }, [connected, sessionId]);
+  }, [connected, owner, sessionId]);
 
   useEffect(() => {
-    if (!connected || !sessionId || !taskActivityKey) return;
+    if (!connected || !sessionId || (!taskActivityKey && refreshTrigger === 0))
+      return;
     emptyPollsRef.current = 0;
     setPollingActive(true);
-  }, [connected, sessionId, taskActivityKey]);
-
-  useEffect(() => {
-    if (!connected || !sessionId || refreshTrigger === 0) return;
-    emptyPollsRef.current = 0;
-    setPollingActive(true);
-  }, [connected, refreshTrigger, sessionId]);
+  }, [connected, owner, refreshTrigger, sessionId, taskActivityKey]);
 
   useEffect(() => {
     if (tasksPanelActive) return;
@@ -53,13 +54,17 @@ export function useBackgroundTasks(
 
     let disposed = false;
     const refresh = () => {
-      if (tasksRefreshInFlightRef.current?.sessionId === sessionId) return;
-      const request = {};
-      tasksRefreshInFlightRef.current = { sessionId, request };
+      if (tasksRefreshInFlightRef.current === owner) return;
+      tasksRefreshInFlightRef.current = owner;
       actions
         .getTasks({ silent: true })
         .then((snapshot) => {
-          if (disposed || snapshot.sessionId !== sessionId) return;
+          if (
+            disposed ||
+            !owner.isCurrent() ||
+            snapshot.sessionId !== sessionId
+          )
+            return;
           setTasks(snapshot.tasks);
           if (snapshot.tasks.length === 0) {
             emptyPollsRef.current += 1;
@@ -74,7 +79,7 @@ export function useBackgroundTasks(
           }
         })
         .catch((error: unknown) => {
-          if (disposed) return;
+          if (disposed || !owner.isCurrent()) return;
           if (isSessionDisconnectedError(error)) {
             setPollingActive(false);
             return;
@@ -82,7 +87,7 @@ export function useBackgroundTasks(
           console.warn('[web-shell] failed to refresh tasks:', error);
         })
         .finally(() => {
-          if (tasksRefreshInFlightRef.current?.request === request) {
+          if (tasksRefreshInFlightRef.current === owner) {
             tasksRefreshInFlightRef.current = null;
           }
         });
@@ -94,7 +99,7 @@ export function useBackgroundTasks(
       disposed = true;
       clearInterval(id);
     };
-  }, [actions, connected, pollingActive, sessionId, tasksPanelActive]);
+  }, [actions, connected, owner, pollingActive, sessionId, tasksPanelActive]);
 
   const tasksRef = useRef(tasks);
   tasksRef.current = tasks;
@@ -113,5 +118,5 @@ export function useBackgroundTasks(
       window.removeEventListener(TASKS_STATUS_ACTIVE_EVENT, onTasksPanelActive);
   }, []);
 
-  return tasks;
+  return tasksOwnerRef.current === owner ? tasks : [];
 }

--- a/packages/web-shell/client/hooks/useQueuedPrompts.dom.test.tsx
+++ b/packages/web-shell/client/hooks/useQueuedPrompts.dom.test.tsx
@@ -110,6 +110,7 @@ function mount(
       connected,
       writeBlocked: blocked,
       sessionId: activeSessionId,
+      workspaceCwd: '/workspace',
       clientId: 'client-1',
       canMutateMidTurn,
       // This suite pins the legacy local-fallback lifecycle.

--- a/packages/web-shell/client/hooks/useQueuedPrompts.dom.test.tsx
+++ b/packages/web-shell/client/hooks/useQueuedPrompts.dom.test.tsx
@@ -182,12 +182,12 @@ afterEach(() => {
 });
 
 describe('useQueuedPrompts default mid-turn insertion', () => {
-  it('clears queued work when a same-id attachment is replaced', () => {
+  it('restores an unaccepted mid-turn prompt when its owner is replaced', () => {
     const { actions } = createActions();
     vi.mocked(actions.enqueueMidTurnMessage).mockReturnValue(
       new Promise(() => undefined),
     );
-    const { render } = mount('responding', actions);
+    const { editor, render } = mount('responding', actions);
 
     act(() => latest.enqueuePrompt('belongs to the source attachment'));
     expect(latest.queuedPrompts).toHaveLength(1);
@@ -195,6 +195,9 @@ describe('useQueuedPrompts default mid-turn insertion', () => {
     render('responding', 'session-1', true);
 
     expect(latest.queuedPrompts).toEqual([]);
+    expect(editor.setText).toHaveBeenCalledWith(
+      'belongs to the source attachment',
+    );
     const signal = vi.mocked(actions.enqueueMidTurnMessage).mock.calls[0]?.[1]
       ?.signal;
     expect(signal?.aborted).toBe(true);
@@ -984,6 +987,87 @@ describe('useQueuedPrompts default mid-turn insertion', () => {
     expect(latest.queuedPrompts).toEqual([]);
     expect(editor.setText).toHaveBeenCalledWith('修改我');
     expect(editor.focus).toHaveBeenCalled();
+  });
+
+  it('restores an edited prompt after a same-id attachment replacement', async () => {
+    const { actions } = createActions();
+    const removal = deferred<{ removed: boolean }>();
+    vi.mocked(actions.enqueueMidTurnMessage).mockResolvedValue({
+      accepted: true,
+      messageId: 'mid-edit',
+    });
+    vi.mocked(actions.removeMidTurnMessage).mockReturnValue(removal.promise);
+    const { editor, render } = mount('responding', actions);
+
+    act(() => latest.enqueuePrompt('修改后保留'));
+    await act(async () => {});
+    let editPromise!: Promise<void>;
+    act(() => {
+      editPromise = latest.editQueuedPrompt(1);
+    });
+    render('responding', 'session-1', true);
+    await act(async () => {
+      removal.resolve({ removed: true });
+      await editPromise;
+    });
+
+    expect(editor.setText).toHaveBeenCalledWith('修改后保留');
+    expect(editor.setText).toHaveBeenCalledOnce();
+    expect(editor.focus).toHaveBeenCalled();
+  });
+
+  it('restores an edited prompt when switching to a different session', async () => {
+    const { actions } = createActions();
+    const removal = deferred<{ removed: boolean }>();
+    vi.mocked(actions.enqueueMidTurnMessage).mockResolvedValue({
+      accepted: true,
+      messageId: 'mid-cross-session-edit',
+    });
+    vi.mocked(actions.removeMidTurnMessage).mockReturnValue(removal.promise);
+    const { editor, render } = mount('responding', actions);
+
+    act(() => latest.enqueuePrompt('切换后保留'));
+    await act(async () => {});
+    let editPromise!: Promise<void>;
+    act(() => {
+      editPromise = latest.editQueuedPrompt(1);
+    });
+    render('responding', 'session-2', true);
+    await act(async () => {
+      removal.resolve({ removed: true });
+      await editPromise;
+    });
+
+    expect(editor.setText).toHaveBeenCalledWith('切换后保留');
+    expect(editor.setText).toHaveBeenCalledOnce();
+    expect(latest.queuedPrompts).toEqual([]);
+  });
+
+  it('does not restore an edited prompt when cross-session removal loses', async () => {
+    const { actions } = createActions();
+    const removal = deferred<{ removed: boolean }>();
+    vi.mocked(actions.enqueueMidTurnMessage).mockResolvedValue({
+      accepted: true,
+      messageId: 'mid-cross-session-edit-lost',
+    });
+    vi.mocked(actions.removeMidTurnMessage).mockReturnValue(removal.promise);
+    const { editor, render } = mount('responding', actions);
+
+    act(() => latest.enqueuePrompt('仍在服务端'));
+    await act(async () => {});
+    let editPromise!: Promise<void>;
+    act(() => {
+      editPromise = latest.editQueuedPrompt(1);
+    });
+    render('responding', 'session-2', true);
+    expect(editor.setText).not.toHaveBeenCalled();
+    await act(async () => {
+      removal.resolve({ removed: false });
+      await editPromise;
+    });
+
+    expect(editor.setText).not.toHaveBeenCalled();
+    expect(latest.queuedPrompts).toEqual([]);
   });
 
   it('keeps the row when removal loses the race with drain or idle', async () => {

--- a/packages/web-shell/client/hooks/useQueuedPrompts.dom.test.tsx
+++ b/packages/web-shell/client/hooks/useQueuedPrompts.dom.test.tsx
@@ -37,6 +37,7 @@ const sdk = vi.hoisted(() => ({
     originatorClientId?: string;
   }>,
   consume: vi.fn(),
+  ownerVersion: 0,
 }));
 
 vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
@@ -48,6 +49,12 @@ vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
   useDaemonMidTurnInjected: () => ({
     batches: sdk.batches,
     consume: sdk.consume,
+  }),
+  useDaemonSessionOwnerGuard: () => ({
+    capture: () => {
+      const ownerVersion = sdk.ownerVersion;
+      return { isCurrent: () => sdk.ownerVersion === ownerVersion };
+    },
   }),
 }));
 
@@ -75,6 +82,7 @@ function mount(
   sessionActions: DaemonSessionActions,
   canMutateMidTurn = true,
   connected = false,
+  writeBlocked = false,
 ) {
   const editor = {
     getText: vi.fn(() => ''),
@@ -92,12 +100,15 @@ function mount(
   function Harness({
     state,
     activeSessionId,
+    blocked,
   }: {
     state: typeof streamingState;
     activeSessionId: string;
+    blocked: boolean;
   }) {
     latest = useQueuedPrompts({
       connected,
+      writeBlocked: blocked,
       sessionId: activeSessionId,
       clientId: 'client-1',
       canMutateMidTurn,
@@ -114,13 +125,24 @@ function mount(
   }
 
   let activeSessionId = 'session-1';
+  let blocked = writeBlocked;
   const render = (
     state: typeof streamingState,
     nextSessionId = activeSessionId,
+    replaceOwner = false,
+    nextWriteBlocked = blocked,
   ) => {
+    if (replaceOwner) sdk.ownerVersion += 1;
     activeSessionId = nextSessionId;
+    blocked = nextWriteBlocked;
     act(() =>
-      root.render(<Harness state={state} activeSessionId={activeSessionId} />),
+      root.render(
+        <Harness
+          state={state}
+          activeSessionId={activeSessionId}
+          blocked={blocked}
+        />,
+      ),
     );
   };
   render(streamingState);
@@ -151,6 +173,7 @@ beforeEach(() => {
   sdk.batches = [];
   sdk.pendingEvents = [];
   sdk.consume.mockReset();
+  sdk.ownerVersion = 0;
 });
 
 afterEach(() => {
@@ -159,6 +182,24 @@ afterEach(() => {
 });
 
 describe('useQueuedPrompts default mid-turn insertion', () => {
+  it('clears queued work when a same-id attachment is replaced', () => {
+    const { actions } = createActions();
+    vi.mocked(actions.enqueueMidTurnMessage).mockReturnValue(
+      new Promise(() => undefined),
+    );
+    const { render } = mount('responding', actions);
+
+    act(() => latest.enqueuePrompt('belongs to the source attachment'));
+    expect(latest.queuedPrompts).toHaveLength(1);
+
+    render('responding', 'session-1', true);
+
+    expect(latest.queuedPrompts).toEqual([]);
+    const signal = vi.mocked(actions.enqueueMidTurnMessage).mock.calls[0]?.[1]
+      ?.signal;
+    expect(signal?.aborted).toBe(true);
+  });
+
   it('queues and submits an image-only prompt without using mid-turn text insertion', () => {
     const { actions } = createActions();
     mount('responding', actions);
@@ -515,6 +556,24 @@ describe('useQueuedPrompts default mid-turn insertion', () => {
     expect(store.appendLocalUserMessage).not.toHaveBeenCalled();
   });
 
+  it('fences an old submit before the replacement owner rerenders', async () => {
+    const { actions, pendingSubmit } = createActions();
+    const { render, store } = mount('responding', actions);
+
+    act(() =>
+      latest.enqueuePrompt('', [{ data: 'b2xk', media_type: 'image/png' }]),
+    );
+    sdk.ownerVersion += 1;
+    await act(async () => {
+      pendingSubmit.resolve({ promptId: 'old-server-prompt' });
+      await Promise.resolve();
+    });
+
+    expect(store.appendLocalUserMessage).not.toHaveBeenCalled();
+    render('responding', 'session-1');
+    expect(latest.queuedPrompts).toEqual([]);
+  });
+
   it('ignores an old refresh after an S1 to S2 to S1 owner change', async () => {
     const { actions } = createActions();
     const oldRefresh = deferred<{
@@ -802,6 +861,26 @@ describe('useQueuedPrompts default mid-turn insertion', () => {
     expect(latest.queuedPrompts).toMatchObject([
       { text: '下一步', serverState: 'submitting' },
     ]);
+  });
+
+  it('freezes mid-turn fallback while a session switch is preparing', async () => {
+    const { actions } = createActions();
+    const admission = deferred<{ accepted: boolean }>();
+    vi.mocked(actions.enqueueMidTurnMessage).mockReturnValue(admission.promise);
+    const { render } = mount('responding', actions);
+
+    act(() => latest.enqueuePrompt('留在当前会话'));
+    render('responding', 'session-1', false, true);
+    await act(async () => admission.resolve({ accepted: false }));
+    render('idle', 'session-1', false, true);
+
+    expect(actions.submitPrompt).not.toHaveBeenCalled();
+    expect(latest.queuedPrompts).toMatchObject([
+      { text: '留在当前会话', midTurnState: 'submitting' },
+    ]);
+
+    render('idle', 'session-1', false, false);
+    expect(actions.submitPrompt).toHaveBeenCalledOnce();
   });
 
   it('falls back once when the running turn ends before injection', async () => {

--- a/packages/web-shell/client/hooks/useQueuedPrompts.midTurnReconcile.test.tsx
+++ b/packages/web-shell/client/hooks/useQueuedPrompts.midTurnReconcile.test.tsx
@@ -35,6 +35,7 @@ const sdkMock = vi.hoisted(() => {
     }>,
     consumeInjected: vi.fn(),
     pendingEvents: [] as Array<Record<string, unknown>>,
+    ownerVersion: 0,
     pendingEventListeners,
     publishPendingEvents: (events: Array<Record<string, unknown>>) => {
       mock.pendingEvents = events;
@@ -57,6 +58,12 @@ vi.mock('@qwen-code/webui/daemon-react-sdk', async () => {
     useDaemonMidTurnInjected: () => ({
       batches: sdkMock.injectedBatches,
       consume: sdkMock.consumeInjected,
+    }),
+    useDaemonSessionOwnerGuard: () => ({
+      capture: () => {
+        const version = sdkMock.ownerVersion;
+        return { isCurrent: () => sdkMock.ownerVersion === version };
+      },
     }),
     subscribePendingPromptEvents: (listener: () => void) => {
       sdkMock.pendingEventListeners.add(listener);
@@ -83,7 +90,9 @@ const CLIENT_ID = 'client-self';
 
 interface HarnessOptions {
   connected?: boolean;
+  writeBlocked?: boolean;
   sessionId?: string;
+  workspaceCwd?: string;
   clientId?: string;
   canMutateMidTurn?: boolean;
   canQueryMidTurn?: boolean;
@@ -115,7 +124,9 @@ function createHarness() {
   function TestComponent(opts: HarnessOptions) {
     latest = useQueuedPrompts({
       connected: opts.connected ?? true,
+      writeBlocked: opts.writeBlocked ?? false,
       sessionId: opts.sessionId ?? 'session-a',
+      workspaceCwd: opts.workspaceCwd ?? '/workspace',
       clientId: opts.clientId ?? CLIENT_ID,
       canMutateMidTurn: opts.canMutateMidTurn ?? true,
       canQueryMidTurn: opts.canQueryMidTurn ?? true,
@@ -165,6 +176,7 @@ function createHarness() {
 describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_query)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    sdkMock.ownerVersion = 0;
     sdkMock.actions.enqueueMidTurnMessage.mockImplementation(
       (_message: string, opts?: { messageId?: string }) =>
         Promise.resolve({ accepted: true, messageId: opts?.messageId }),
@@ -620,7 +632,7 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
     }
   });
 
-  it('reports an admission failure after the user switches sessions', async () => {
+  it('does not report an admission failure after the user switches sessions', async () => {
     let rejectAdmission: ((error: Error) => void) | undefined;
     sdkMock.actions.enqueueMidTurnMessage.mockReturnValueOnce(
       new Promise((_resolve, reject) => {
@@ -638,7 +650,7 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
         rejectAdmission?.(new Error('daemon unavailable'));
       });
 
-      expect(harness.reportError).toHaveBeenCalledTimes(1);
+      expect(harness.reportError).not.toHaveBeenCalled();
       expect(harness.editor.setText).not.toHaveBeenCalled();
       expect(sdkMock.actions.submitPrompt).not.toHaveBeenCalled();
     } finally {
@@ -874,6 +886,249 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
       await harness.render({ streamingState: 'responding', connected: false });
       await harness.render({ streamingState: 'responding', connected: true });
       expect(harness.result().queuedPrompts).toHaveLength(1);
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('preserves a stable-id admission across same-session owner replacement', async () => {
+    sdkMock.actions.enqueueMidTurnMessage.mockReturnValue(
+      new Promise(() => {}),
+    );
+    const harness = createHarness();
+    try {
+      await harness.render({ streamingState: 'responding' });
+      await act(async () => {
+        harness.result().enqueuePrompt('survive reattach');
+      });
+      expect(harness.result().queuedPrompts).toEqual([]);
+
+      sdkMock.ownerVersion += 1;
+      await harness.render({ streamingState: 'responding' });
+
+      expect(harness.result().queuedPrompts).toEqual([
+        expect.objectContaining({
+          sessionId: 'session-a',
+          text: 'survive reattach',
+          admissionOutcome: 'unknown',
+          payloadCompleteness: 'complete',
+        }),
+      ]);
+      expect(harness.editor.setText).not.toHaveBeenCalled();
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('preserves an ambiguous stable-id admission across later reattachment', async () => {
+    let rejectAdmission: ((error: Error) => void) | undefined;
+    sdkMock.actions.enqueueMidTurnMessage.mockReturnValue(
+      new Promise((_resolve, reject) => {
+        rejectAdmission = reject;
+      }),
+    );
+    const harness = createHarness();
+    try {
+      await harness.render({ streamingState: 'responding' });
+      sdkMock.actions.getMidTurnMessages.mockResolvedValue(undefined);
+      await act(async () => {
+        harness.result().enqueuePrompt('ambiguous input');
+        rejectAdmission?.(new Error('response lost'));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(harness.result().queuedPrompts).toEqual([
+        expect.objectContaining({
+          text: 'ambiguous input',
+          admissionOutcome: 'unknown',
+        }),
+      ]);
+
+      sdkMock.ownerVersion += 1;
+      await harness.render({ streamingState: 'responding' });
+
+      expect(harness.result().queuedPrompts).toEqual([
+        expect.objectContaining({
+          text: 'ambiguous input',
+          admissionOutcome: 'unknown',
+        }),
+      ]);
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('does not resurrect an admission after authoritative settlement', async () => {
+    let rejectAdmission: ((error: Error) => void) | undefined;
+    sdkMock.actions.enqueueMidTurnMessage.mockReturnValue(
+      new Promise((_resolve, reject) => {
+        rejectAdmission = reject;
+      }),
+    );
+    const harness = createHarness();
+    try {
+      await harness.render({ streamingState: 'responding' });
+      sdkMock.actions.getMidTurnMessages.mockResolvedValue(undefined);
+      await act(async () => {
+        harness.result().enqueuePrompt('settled input');
+        rejectAdmission?.(new Error('response lost'));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      const messageId = harness.result().queuedPrompts[0]?.midTurnMessageId;
+      if (!messageId) throw new Error('missing stable message id');
+
+      sdkMock.actions.getMidTurnMessages.mockResolvedValue({
+        messages: [],
+        settledMessageIds: [messageId],
+        promotedMessageIds: [],
+      });
+      await harness.render({ streamingState: 'idle' });
+      expect(harness.result().queuedPrompts).toEqual([]);
+
+      sdkMock.ownerVersion += 1;
+      await harness.render({ streamingState: 'idle' });
+
+      expect(harness.result().queuedPrompts).toEqual([]);
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('does not carry a stable-id admission into another workspace', async () => {
+    sdkMock.actions.enqueueMidTurnMessage.mockReturnValue(
+      new Promise(() => {}),
+    );
+    const harness = createHarness();
+    try {
+      await harness.render({
+        streamingState: 'responding',
+        workspaceCwd: '/workspace-a',
+      });
+      await act(async () => {
+        harness.result().enqueuePrompt('workspace-a input');
+      });
+
+      await harness.render({
+        streamingState: 'responding',
+        workspaceCwd: '/workspace-b',
+      });
+
+      expect(harness.result().queuedPrompts).toEqual([]);
+      expect(harness.editor.setText).not.toHaveBeenCalled();
+
+      await harness.render({
+        streamingState: 'responding',
+        workspaceCwd: '/workspace-a',
+      });
+      expect(harness.result().queuedPrompts).toEqual([
+        expect.objectContaining({
+          text: 'workspace-a input',
+          admissionOutcome: 'unknown',
+        }),
+      ]);
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('restores a rejected stable-id admission after returning to its workspace', async () => {
+    let resolveAdmission:
+      | ((value: { accepted: boolean; messageId?: string }) => void)
+      | undefined;
+    sdkMock.actions.enqueueMidTurnMessage.mockReturnValue(
+      new Promise((resolve) => {
+        resolveAdmission = resolve;
+      }),
+    );
+    const harness = createHarness();
+    try {
+      await harness.render({
+        streamingState: 'responding',
+        workspaceCwd: '/workspace-a',
+      });
+      await act(async () => {
+        harness.result().enqueuePrompt('rejected in workspace-a');
+      });
+      await harness.render({
+        streamingState: 'responding',
+        workspaceCwd: '/workspace-b',
+      });
+      await act(async () => {
+        resolveAdmission?.({ accepted: false });
+        await Promise.resolve();
+      });
+
+      await harness.render({
+        streamingState: 'responding',
+        workspaceCwd: '/workspace-a',
+      });
+
+      expect(harness.result().queuedPrompts).toEqual([
+        expect.objectContaining({
+          text: 'rejected in workspace-a',
+          admissionOutcome: 'unknown',
+        }),
+      ]);
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('does not apply an old-owner reconcile after same-id reattachment', async () => {
+    const harness = createHarness();
+    try {
+      await harness.render({ streamingState: 'responding' });
+      let resolveSnapshot: ((value: unknown) => void) | undefined;
+      sdkMock.actions.getMidTurnMessages.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSnapshot = resolve;
+          }),
+      );
+      await harness.render({ streamingState: 'idle' });
+
+      sdkMock.ownerVersion += 1;
+      await harness.render({ streamingState: 'idle' });
+      resolveSnapshot?.({
+        messages: [{ messageId: 'stale', text: 'old owner payload' }],
+        settledMessageIds: [],
+        promotedMessageIds: [],
+      });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(harness.result().queuedPrompts).toEqual([]);
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('does not fall back after an idle reconciliation is blocked', async () => {
+    const harness = createHarness();
+    try {
+      await harness.render({ streamingState: 'responding' });
+      sdkMock.actions.getPendingPrompts.mockClear();
+      sdkMock.actions.getMidTurnMessages.mockImplementationOnce(
+        (opts?: { signal?: AbortSignal }) =>
+          new Promise((resolve) => {
+            opts?.signal?.addEventListener('abort', () => resolve(undefined), {
+              once: true,
+            });
+          }),
+      );
+
+      await harness.render({ streamingState: 'idle', writeBlocked: false });
+      await harness.render({ streamingState: 'idle', writeBlocked: true });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(sdkMock.actions.getPendingPrompts).not.toHaveBeenCalled();
+      expect(harness.result().queuedPrompts).toEqual([]);
     } finally {
       await harness.dispose();
     }

--- a/packages/web-shell/client/hooks/useQueuedPrompts.ts
+++ b/packages/web-shell/client/hooks/useQueuedPrompts.ts
@@ -8,7 +8,6 @@ import {
   useCallback,
   useEffect,
   useLayoutEffect,
-  useMemo,
   useRef,
   useState,
   useSyncExternalStore,
@@ -20,6 +19,7 @@ import {
   subscribePendingPromptEvents,
   subscribePendingPromptVersion,
   useDaemonMidTurnInjected,
+  useDaemonSessionOwnerGuard,
   type DaemonSessionActions,
   type DaemonStreamingState,
 } from '@qwen-code/webui/daemon-react-sdk';
@@ -43,6 +43,7 @@ interface RefBox<T> {
 
 interface UseQueuedPromptsArgs {
   connected: boolean;
+  writeBlocked?: boolean;
   sessionId?: string;
   clientId?: string;
   /**
@@ -149,6 +150,7 @@ export interface UseQueuedPromptsResult {
 
 export function useQueuedPrompts({
   connected,
+  writeBlocked = false,
   sessionId,
   clientId,
   canMutateMidTurn,
@@ -160,12 +162,30 @@ export function useQueuedPrompts({
   reportError,
   t,
 }: UseQueuedPromptsArgs): UseQueuedPromptsResult {
+  const writeBlockedRef = useRef(writeBlocked);
+  writeBlockedRef.current = writeBlocked;
+  const sessionOwnerGuard = useDaemonSessionOwnerGuard();
   const [queuedPrompts, setQueuedPrompts] = useState<QueuedPrompt[]>([]);
   const queuedPromptsRef = useRef<QueuedPrompt[]>([]);
-  const ownerTokenRef = useRef({ sessionId });
-  if (ownerTokenRef.current.sessionId !== sessionId) {
-    ownerTokenRef.current = { sessionId };
+  const ownerTokenRef = useRef({
+    sessionId,
+    snapshot: sessionOwnerGuard.capture(),
+  });
+  if (
+    ownerTokenRef.current.sessionId !== sessionId ||
+    !ownerTokenRef.current.snapshot.isCurrent()
+  ) {
+    ownerTokenRef.current = {
+      sessionId,
+      snapshot: sessionOwnerGuard.capture(),
+    };
   }
+  const ownerToken = ownerTokenRef.current;
+  const isCurrentOwnerTokenRef = useRef(
+    (token: typeof ownerToken) =>
+      ownerTokenRef.current === token && token.snapshot.isCurrent(),
+  );
+  const queuedPromptsOwnerRef = useRef(ownerToken);
   const nextQueuedPromptIdRef = useRef(1);
   const latestSessionIdRef = useRef(sessionId);
   const midTurnEnqueueAbortRef = useRef<AbortController | null>(null);
@@ -204,16 +224,16 @@ export function useQueuedPrompts({
   }, [streamingIdle]);
   latestStreamingStateRef.current = streamingState;
 
-  const queuedTexts = useMemo(
-    () => queuedPrompts.map((prompt) => prompt.text),
-    [queuedPrompts],
-  );
+  const visibleQueuedPrompts =
+    queuedPromptsOwnerRef.current === ownerToken ? queuedPrompts : [];
+  const queuedTexts = visibleQueuedPrompts.map((prompt) => prompt.text);
 
   useEffect(() => {
     queuedPromptsRef.current = queuedPrompts;
   }, [queuedPrompts]);
 
   useEffect(() => {
+    queuedPromptsOwnerRef.current = ownerToken;
     queuedPromptsRef.current = [];
     setQueuedPrompts([]);
     completionCallbacksRef.current = new Map();
@@ -232,7 +252,7 @@ export function useQueuedPrompts({
     initialRefreshSessionIdRef.current = undefined;
     midTurnEnqueueAbortRef.current?.abort();
     midTurnEnqueueAbortRef.current = null;
-  }, [sessionId]);
+  }, [ownerToken]);
 
   const settleCompletionCallback = useCallback(
     (promptId: string, onComplete: () => void) => {
@@ -347,7 +367,7 @@ export function useQueuedPrompts({
         });
         if (requestSeq !== refreshRequestSeqRef.current) return 'superseded';
         if (
-          ownerTokenRef.current !== ownerToken ||
+          !isCurrentOwnerTokenRef.current(ownerToken) ||
           latestSessionIdRef.current !== targetSessionId
         ) {
           return 'skipped';
@@ -540,7 +560,7 @@ export function useQueuedPrompts({
       expectedOwnerToken = ownerTokenRef.current,
     ): boolean => {
       if (
-        ownerTokenRef.current !== expectedOwnerToken ||
+        !isCurrentOwnerTokenRef.current(expectedOwnerToken) ||
         (targetSessionId !== undefined &&
           latestSessionIdRef.current !== targetSessionId)
       ) {
@@ -798,7 +818,7 @@ export function useQueuedPrompts({
         .then((result) => {
           submitAbortControllersRef.current.delete(submitAbort);
           if (
-            ownerTokenRef.current !== ownerToken ||
+            !isCurrentOwnerTokenRef.current(ownerToken) ||
             latestSessionIdRef.current !== targetSessionId
           ) {
             return;
@@ -920,7 +940,7 @@ export function useQueuedPrompts({
         .catch((error: unknown) => {
           submitAbortControllersRef.current.delete(submitAbort);
           if (
-            ownerTokenRef.current !== ownerToken ||
+            !isCurrentOwnerTokenRef.current(ownerToken) ||
             latestSessionIdRef.current !== targetSessionId
           ) {
             return;
@@ -966,6 +986,7 @@ export function useQueuedPrompts({
 
   const fallbackToPendingPrompt = useCallback(
     (id: number) => {
+      if (writeBlockedRef.current) return;
       const current = queuedPromptsRef.current;
       const index = current.findIndex(
         (prompt) => prompt.id === id && prompt.midTurnState !== undefined,
@@ -1142,7 +1163,7 @@ export function useQueuedPrompts({
           signal: abort.signal,
         })
         .then((result) => {
-          if (ownerTokenRef.current !== ownerToken) return;
+          if (!isCurrentOwnerTokenRef.current(ownerToken)) return;
           const current = queuedPromptsRef.current;
           const index = current.findIndex((item) => item.id === prompt.id);
           if (index === -1) return;
@@ -1220,9 +1241,12 @@ export function useQueuedPrompts({
   ]);
 
   useEffect(() => {
-    if (streamingState !== 'idle') return;
-    midTurnEnqueueAbortRef.current?.abort();
-    midTurnEnqueueAbortRef.current = null;
+    if (streamingState !== 'idle' || writeBlocked) return;
+    const ctrl = midTurnEnqueueAbortRef.current;
+    if (ctrl) {
+      ctrl.abort();
+      midTurnEnqueueAbortRef.current = null;
+    }
     for (const prompt of queuedPromptsRef.current) {
       if (!prompt.midTurnFailedAction) continue;
       const next = queuedPromptsRef.current.filter(
@@ -1262,6 +1286,7 @@ export function useQueuedPrompts({
     };
   }, [
     streamingState,
+    writeBlocked,
     canQueryMidTurn,
     fallbackToPendingPrompt,
     restoreQueuedPromptsToEditor,
@@ -1327,7 +1352,7 @@ export function useQueuedPrompts({
             sessionId: targetSessionId,
           },
         );
-        if (ownerTokenRef.current !== ownerToken) return false;
+        if (!isCurrentOwnerTokenRef.current(ownerToken)) return false;
         removingPromptIds.delete(target.serverPromptId);
         if (!result.removed) {
           setQueuedPromptFlags(target.id, {
@@ -1335,7 +1360,7 @@ export function useQueuedPrompts({
             isRemoving: false,
           });
           await refreshPendingPrompts(targetSessionId);
-          if (ownerTokenRef.current !== ownerToken) return false;
+          if (!isCurrentOwnerTokenRef.current(ownerToken)) return false;
           reportError(
             new Error('Prompt could not be removed from queue'),
             fallback,
@@ -1344,7 +1369,7 @@ export function useQueuedPrompts({
         }
         completionCallbacksRef.current.delete(target.serverPromptId);
         const refreshResult = await refreshPendingPrompts(targetSessionId);
-        if (ownerTokenRef.current !== ownerToken) return false;
+        if (!isCurrentOwnerTokenRef.current(ownerToken)) return false;
         if (refreshResult === 'failed') {
           setQueuedPromptFlags(target.id, {
             isEditing: false,
@@ -1357,14 +1382,14 @@ export function useQueuedPrompts({
         }
         return true;
       } catch (error) {
-        if (ownerTokenRef.current !== ownerToken) return false;
+        if (!isCurrentOwnerTokenRef.current(ownerToken)) return false;
         removingPromptIds.delete(target.serverPromptId);
         setQueuedPromptFlags(target.id, {
           isEditing: false,
           isRemoving: false,
         });
         const refreshResult = await refreshPendingPrompts(targetSessionId);
-        if (ownerTokenRef.current !== ownerToken) return false;
+        if (!isCurrentOwnerTokenRef.current(ownerToken)) return false;
         if (refreshResult !== 'refreshed') {
           restoreQueuedPrompts([target]);
         }
@@ -1408,7 +1433,7 @@ export function useQueuedPrompts({
           target.midTurnMessageId,
           { sessionId: target.sessionId },
         );
-        if (ownerTokenRef.current !== ownerToken) return false;
+        if (!isCurrentOwnerTokenRef.current(ownerToken)) return false;
         const current = queuedPromptsRef.current;
         const latest = current.find((prompt) => prompt.id === target.id);
         if (!latest) return result.removed;
@@ -1456,7 +1481,7 @@ export function useQueuedPrompts({
         setQueuedPrompts(next);
         return true;
       } catch (error) {
-        if (ownerTokenRef.current !== ownerToken) return false;
+        if (!isCurrentOwnerTokenRef.current(ownerToken)) return false;
         const latest = queuedPromptsRef.current.find(
           (prompt) => prompt.id === target.id,
         );
@@ -1558,7 +1583,7 @@ export function useQueuedPrompts({
       ) {
         return false;
       }
-      if (ownerTokenRef.current !== ownerToken) return false;
+      if (!isCurrentOwnerTokenRef.current(ownerToken)) return false;
       if (target.midTurnMessageId) {
         completionCallbacksRef.current.delete(target.midTurnMessageId);
       }
@@ -1797,7 +1822,7 @@ export function useQueuedPrompts({
       );
 
       if (
-        ownerTokenRef.current !== clearOwnerToken ||
+        !isCurrentOwnerTokenRef.current(clearOwnerToken) ||
         latestSessionIdRef.current !== clearSessionId
       ) {
         return;
@@ -1831,7 +1856,7 @@ export function useQueuedPrompts({
   }, [refreshPendingPrompts, reportError, store, t, sessionActions]);
 
   return {
-    queuedPrompts,
+    queuedPrompts: visibleQueuedPrompts,
     queuedTexts,
     enqueuePrompt,
     removeQueuedPrompt,

--- a/packages/web-shell/client/hooks/useQueuedPrompts.ts
+++ b/packages/web-shell/client/hooks/useQueuedPrompts.ts
@@ -45,6 +45,7 @@ interface UseQueuedPromptsArgs {
   connected: boolean;
   writeBlocked?: boolean;
   sessionId?: string;
+  workspaceCwd?: string;
   clientId?: string;
   /**
    * Whether the daemon advertises `session_mid_turn_message_mutation`. Gates the
@@ -152,6 +153,7 @@ export function useQueuedPrompts({
   connected,
   writeBlocked = false,
   sessionId,
+  workspaceCwd,
   clientId,
   canMutateMidTurn,
   canQueryMidTurn,
@@ -169,14 +171,17 @@ export function useQueuedPrompts({
   const queuedPromptsRef = useRef<QueuedPrompt[]>([]);
   const ownerTokenRef = useRef({
     sessionId,
+    workspaceCwd,
     snapshot: sessionOwnerGuard.capture(),
   });
   if (
     ownerTokenRef.current.sessionId !== sessionId ||
+    ownerTokenRef.current.workspaceCwd !== workspaceCwd ||
     !ownerTokenRef.current.snapshot.isCurrent()
   ) {
     ownerTokenRef.current = {
       sessionId,
+      workspaceCwd,
       snapshot: sessionOwnerGuard.capture(),
     };
   }
@@ -188,6 +193,7 @@ export function useQueuedPrompts({
   const queuedPromptsOwnerRef = useRef(ownerToken);
   const nextQueuedPromptIdRef = useRef(1);
   const latestSessionIdRef = useRef(sessionId);
+  const latestWorkspaceCwdRef = useRef(workspaceCwd);
   const midTurnEnqueueAbortRef = useRef<AbortController | null>(null);
   const submitAbortControllersRef = useRef<Set<AbortController>>(new Set());
   const removingServerPromptIdsRef = useRef<Set<string>>(new Set());
@@ -195,6 +201,9 @@ export function useQueuedPrompts({
   const completionCallbacksRef = useRef<Map<string, () => void>>(new Map());
   const completedPromptIdsRef = useRef<Set<string>>(new Set());
   const completedPromptIdOrderRef = useRef<string[]>([]);
+  const pendingMidTurnAdmissionsRef = useRef<
+    Map<string, { prompt: QueuedPrompt; workspaceCwd?: string }>
+  >(new Map());
   const appendedBeforeResponsePromptIdsRef = useRef<Set<string>>(new Set());
   const removedBeforeResponsePromptIdsRef = useRef<Set<string>>(new Set());
   const latestStreamingStateRef = useRef(streamingState);
@@ -218,6 +227,7 @@ export function useQueuedPrompts({
   }, []);
 
   latestSessionIdRef.current = sessionId;
+  latestWorkspaceCwdRef.current = workspaceCwd;
   const streamingIdle = streamingState === 'idle';
   useLayoutEffect(() => {
     midTurnReconcileSeqRef.current += 1;
@@ -373,10 +383,17 @@ export function useQueuedPrompts({
     ): Set<string> => {
       const settledIds = new Set(snapshot.settledMessageIds);
       const promotedIds = new Set(snapshot.promotedMessageIds);
+      for (const message of snapshot.messages) {
+        pendingMidTurnAdmissionsRef.current.delete(message.messageId);
+      }
       for (const messageId of settledIds) {
+        pendingMidTurnAdmissionsRef.current.delete(messageId);
         const callback = completionCallbacksRef.current.get(messageId);
         completionCallbacksRef.current.delete(messageId);
         callback?.();
+      }
+      for (const messageId of promotedIds) {
+        pendingMidTurnAdmissionsRef.current.delete(messageId);
       }
       const waitingIds = new Set(
         snapshot.messages.map((message) => message.messageId),
@@ -482,7 +499,11 @@ export function useQueuedPrompts({
       opts?: { signal?: AbortSignal; seq?: number },
     ): Promise<DaemonMidTurnMessagesResult | undefined> => {
       const expectedSeq = opts?.seq ?? ++midTurnReconcileSeqRef.current;
+      const expectedOwnerToken = ownerTokenRef.current;
       const isCurrent = () =>
+        !opts?.signal?.aborted &&
+        !writeBlockedRef.current &&
+        isCurrentOwnerTokenRef.current(expectedOwnerToken) &&
         latestSessionIdRef.current === targetSessionId &&
         expectedSeq === midTurnReconcileSeqRef.current;
       if (!isCurrent()) return undefined;
@@ -601,6 +622,21 @@ export function useQueuedPrompts({
 
   useEffect(() => {
     restoredPromptIdsRef.current = new Set();
+    const retainedAdmissions = [
+      ...pendingMidTurnAdmissionsRef.current.entries(),
+    ].filter(
+      ([, entry]) =>
+        entry.prompt.sessionId === sessionId &&
+        entry.workspaceCwd === workspaceCwd,
+    );
+    const retainedAdmissionIds = new Set(
+      retainedAdmissions.map(([messageId]) => messageId),
+    );
+    const retainedCompletionCallbacks = new Map(
+      [...completionCallbacksRef.current.entries()].filter(([promptId]) =>
+        retainedAdmissionIds.has(promptId),
+      ),
+    );
     const interruptedPrompts = queuedPromptsRef.current.filter(
       (prompt) =>
         prompt.midTurnState === 'submitting' ||
@@ -610,9 +646,10 @@ export function useQueuedPrompts({
       restoreQueuedPromptsToEditorRef.current(interruptedPrompts);
     }
     queuedPromptsOwnerRef.current = ownerToken;
-    queuedPromptsRef.current = [];
-    setQueuedPrompts([]);
-    completionCallbacksRef.current = new Map();
+    const retainedPrompts = retainedAdmissions.map(([, entry]) => entry.prompt);
+    queuedPromptsRef.current = retainedPrompts;
+    setQueuedPrompts(retainedPrompts);
+    completionCallbacksRef.current = retainedCompletionCallbacks;
     completedPromptIdsRef.current = new Set();
     completedPromptIdOrderRef.current = [];
     appendedBeforeResponsePromptIdsRef.current = new Set();
@@ -627,7 +664,7 @@ export function useQueuedPrompts({
     initialRefreshSessionIdRef.current = undefined;
     midTurnEnqueueAbortRef.current?.abort();
     midTurnEnqueueAbortRef.current = null;
-  }, [ownerToken]);
+  }, [ownerToken, sessionId, workspaceCwd]);
 
   const appendLocalQueuedPrompt = useCallback(
     (prompt: QueuedPrompt, promptId: string) => {
@@ -684,6 +721,7 @@ export function useQueuedPrompts({
     sessionId,
     streamingState,
     canQueryMidTurn,
+    ownerToken,
     refreshPendingPrompts,
     reconcileMidTurnMessages,
   ]);
@@ -701,6 +739,7 @@ export function useQueuedPrompts({
       handled.push(event);
       const promptId = event.data.promptId;
       if (!promptId) continue;
+      pendingMidTurnAdmissionsRef.current.delete(promptId);
       if (event.type === 'pending_prompt_started') {
         if (removingServerPromptIdsRef.current.has(promptId)) {
           continue;
@@ -1031,6 +1070,7 @@ export function useQueuedPrompts({
       const trimmed = text.trim();
       if (!trimmed && (images?.length ?? 0) === 0) return true;
       const targetSessionId = latestSessionIdRef.current;
+      const targetWorkspaceCwd = latestWorkspaceCwdRef.current;
       const ownerToken = ownerTokenRef.current;
       const shouldInsertMidTurn =
         latestStreamingStateRef.current !== 'idle' &&
@@ -1048,6 +1088,19 @@ export function useQueuedPrompts({
           : undefined;
 
       if (shouldInsertMidTurn && canQueryMidTurn && midTurnMessageId) {
+        const pendingAdmission: QueuedPrompt = {
+          id: nextQueuedPromptIdRef.current++,
+          sessionId: targetSessionId,
+          text: trimmed,
+          midTurnMessageId,
+          admissionOutcome: 'unknown',
+          payloadCompleteness: 'complete',
+          payloadAvailable: true,
+        };
+        pendingMidTurnAdmissionsRef.current.set(midTurnMessageId, {
+          prompt: pendingAdmission,
+          workspaceCwd: targetWorkspaceCwd,
+        });
         if (onComplete) {
           settleCompletionCallback(midTurnMessageId, onComplete);
         }
@@ -1056,20 +1109,25 @@ export function useQueuedPrompts({
           .then(async (result) => {
             if (!result.accepted) {
               completionCallbacksRef.current.delete(midTurnMessageId);
-              if (latestSessionIdRef.current === targetSessionId) {
-                restoreQueuedPromptsToEditor(
-                  [
-                    {
-                      id: nextQueuedPromptIdRef.current++,
-                      sessionId: targetSessionId,
-                      text: trimmed,
-                      images: images ? [...images] : undefined,
-                      payloadCompleteness: 'complete',
-                    },
-                  ],
-                  targetSessionId,
-                );
+              if (
+                latestSessionIdRef.current !== targetSessionId ||
+                latestWorkspaceCwdRef.current !== targetWorkspaceCwd
+              ) {
+                return;
               }
+              const pendingAdmissionStillOwned =
+                pendingMidTurnAdmissionsRef.current.delete(midTurnMessageId);
+              if (!pendingAdmissionStillOwned) return;
+              const next = queuedPromptsRef.current.filter(
+                (prompt) => prompt.midTurnMessageId !== midTurnMessageId,
+              );
+              queuedPromptsRef.current = next;
+              setQueuedPrompts(next);
+              restoreQueuedPromptsToEditor(
+                [pendingAdmission],
+                targetSessionId,
+                true,
+              );
               reportError(
                 new Error('Daemon rejected mid-turn message'),
                 t('queue.queueFailed'),
@@ -1078,21 +1136,26 @@ export function useQueuedPrompts({
             }
             if (
               latestSessionIdRef.current === targetSessionId &&
+              latestWorkspaceCwdRef.current === targetWorkspaceCwd &&
               targetSessionId
             ) {
               await reconcileMidTurnMessages(targetSessionId);
             }
+            pendingMidTurnAdmissionsRef.current.delete(midTurnMessageId);
           })
           .catch(async (error: unknown) => {
             if (
               latestSessionIdRef.current !== targetSessionId ||
+              latestWorkspaceCwdRef.current !== targetWorkspaceCwd ||
               !targetSessionId
             ) {
-              reportError(error, t('queue.queueFailed'));
               return;
             }
             const snapshot = await reconcileMidTurnMessages(targetSessionId);
             if (!snapshot) {
+              if (!pendingMidTurnAdmissionsRef.current.has(midTurnMessageId)) {
+                return;
+              }
               if (
                 !queuedPromptsRef.current.some(
                   (prompt) =>
@@ -1118,13 +1181,15 @@ export function useQueuedPrompts({
               reportError(error, t('queue.admissionUnknown'));
               return;
             }
+            const pendingAdmissionStillOwned =
+              pendingMidTurnAdmissionsRef.current.delete(midTurnMessageId);
             const known =
               snapshot.messages.some(
                 (message) => message.messageId === midTurnMessageId,
               ) ||
               snapshot.settledMessageIds.includes(midTurnMessageId) ||
               snapshot.promotedMessageIds.includes(midTurnMessageId);
-            if (known) return;
+            if (known || !pendingAdmissionStillOwned) return;
             completionCallbacksRef.current.delete(midTurnMessageId);
             restoreQueuedPromptsToEditor(
               [
@@ -1218,6 +1283,7 @@ export function useQueuedPrompts({
     for (const batch of midTurnInjectedBatches) {
       if (batch.sessionId !== sessionId) continue;
       for (const messageId of batch.messageIds ?? []) {
+        pendingMidTurnAdmissionsRef.current.delete(messageId);
         const callback = completionCallbacksRef.current.get(messageId);
         completionCallbacksRef.current.delete(messageId);
         callback?.();
@@ -1596,6 +1662,7 @@ export function useQueuedPrompts({
       if (!isCurrentOwnerTokenRef.current(ownerToken)) return false;
       if (target.midTurnMessageId) {
         completionCallbacksRef.current.delete(target.midTurnMessageId);
+        pendingMidTurnAdmissionsRef.current.delete(target.midTurnMessageId);
       }
       const next = queuedPromptsRef.current.map((prompt) =>
         prompt.id === id

--- a/packages/web-shell/client/hooks/useQueuedPrompts.ts
+++ b/packages/web-shell/client/hooks/useQueuedPrompts.ts
@@ -232,28 +232,6 @@ export function useQueuedPrompts({
     queuedPromptsRef.current = queuedPrompts;
   }, [queuedPrompts]);
 
-  useEffect(() => {
-    queuedPromptsOwnerRef.current = ownerToken;
-    queuedPromptsRef.current = [];
-    setQueuedPrompts([]);
-    completionCallbacksRef.current = new Map();
-    completedPromptIdsRef.current = new Set();
-    completedPromptIdOrderRef.current = [];
-    appendedBeforeResponsePromptIdsRef.current = new Set();
-    removedBeforeResponsePromptIdsRef.current = new Set();
-    for (const controller of submitAbortControllersRef.current) {
-      controller.abort();
-    }
-    submitAbortControllersRef.current.clear();
-    removingServerPromptIdsRef.current = new Set();
-    displayedServerPromptIdsRef.current = new Set();
-    restoredPromptIdsRef.current = new Set();
-    pendingStartedByPromptIdRef.current = new Map();
-    initialRefreshSessionIdRef.current = undefined;
-    midTurnEnqueueAbortRef.current?.abort();
-    midTurnEnqueueAbortRef.current = null;
-  }, [ownerToken]);
-
   const settleCompletionCallback = useCallback(
     (promptId: string, onComplete: () => void) => {
       if (completedPromptIdsRef.current.delete(promptId)) {
@@ -618,6 +596,38 @@ export function useQueuedPrompts({
     },
     [editorRef],
   );
+  const restoreQueuedPromptsToEditorRef = useRef(restoreQueuedPromptsToEditor);
+  restoreQueuedPromptsToEditorRef.current = restoreQueuedPromptsToEditor;
+
+  useEffect(() => {
+    restoredPromptIdsRef.current = new Set();
+    const interruptedPrompts = queuedPromptsRef.current.filter(
+      (prompt) =>
+        prompt.midTurnState === 'submitting' ||
+        prompt.midTurnFailedAction === 'edit',
+    );
+    if (interruptedPrompts.length > 0) {
+      restoreQueuedPromptsToEditorRef.current(interruptedPrompts);
+    }
+    queuedPromptsOwnerRef.current = ownerToken;
+    queuedPromptsRef.current = [];
+    setQueuedPrompts([]);
+    completionCallbacksRef.current = new Map();
+    completedPromptIdsRef.current = new Set();
+    completedPromptIdOrderRef.current = [];
+    appendedBeforeResponsePromptIdsRef.current = new Set();
+    removedBeforeResponsePromptIdsRef.current = new Set();
+    for (const controller of submitAbortControllersRef.current) {
+      controller.abort();
+    }
+    submitAbortControllersRef.current.clear();
+    removingServerPromptIdsRef.current = new Set();
+    displayedServerPromptIdsRef.current = new Set();
+    pendingStartedByPromptIdRef.current = new Map();
+    initialRefreshSessionIdRef.current = undefined;
+    midTurnEnqueueAbortRef.current?.abort();
+    midTurnEnqueueAbortRef.current = null;
+  }, [ownerToken]);
 
   const appendLocalQueuedPrompt = useCallback(
     (prompt: QueuedPrompt, promptId: string) => {
@@ -1352,8 +1362,8 @@ export function useQueuedPrompts({
             sessionId: targetSessionId,
           },
         );
-        if (!isCurrentOwnerTokenRef.current(ownerToken)) return false;
         removingPromptIds.delete(target.serverPromptId);
+        if (!isCurrentOwnerTokenRef.current(ownerToken)) return result.removed;
         if (!result.removed) {
           setQueuedPromptFlags(target.id, {
             isEditing: false,
@@ -1369,7 +1379,7 @@ export function useQueuedPrompts({
         }
         completionCallbacksRef.current.delete(target.serverPromptId);
         const refreshResult = await refreshPendingPrompts(targetSessionId);
-        if (!isCurrentOwnerTokenRef.current(ownerToken)) return false;
+        if (!isCurrentOwnerTokenRef.current(ownerToken)) return true;
         if (refreshResult === 'failed') {
           setQueuedPromptFlags(target.id, {
             isEditing: false,
@@ -1433,7 +1443,7 @@ export function useQueuedPrompts({
           target.midTurnMessageId,
           { sessionId: target.sessionId },
         );
-        if (!isCurrentOwnerTokenRef.current(ownerToken)) return false;
+        if (!isCurrentOwnerTokenRef.current(ownerToken)) return result.removed;
         const current = queuedPromptsRef.current;
         const latest = current.find((prompt) => prompt.id === target.id);
         if (!latest) return result.removed;
@@ -1617,7 +1627,6 @@ export function useQueuedPrompts({
 
   const editQueuedPrompt = useCallback(
     async (id: number) => {
-      const editOwnerToken = ownerTokenRef.current;
       const target = queuedPromptsRef.current.find((p) => p.id === id);
       if (!target || target.serverState === 'submitting') return;
       if (
@@ -1634,12 +1643,7 @@ export function useQueuedPrompts({
           t('queue.editFailed'),
         );
         if (removed) {
-          restoreQueuedPromptsToEditor(
-            [target],
-            target.sessionId,
-            false,
-            editOwnerToken,
-          );
+          restoreQueuedPromptsToEditor([target]);
         }
         return;
       }
@@ -1650,12 +1654,7 @@ export function useQueuedPrompts({
           t('queue.editFailed'),
         );
         if (!removed) return;
-        restoreQueuedPromptsToEditor(
-          [target],
-          target.sessionId,
-          false,
-          editOwnerToken,
-        );
+        restoreQueuedPromptsToEditor([target]);
         return;
       }
       const popped = popQueuedPromptForEdit(id);
@@ -1698,7 +1697,6 @@ export function useQueuedPrompts({
       return true;
     }
     if (target.serverState !== 'queued') return false;
-    const editOwnerToken = ownerTokenRef.current;
     void (async () => {
       const removed = await removeServerPromptForAction(
         target,
@@ -1706,12 +1704,7 @@ export function useQueuedPrompts({
         t('queue.editFailed'),
       );
       if (removed) {
-        restoreQueuedPromptsToEditor(
-          [target],
-          target.sessionId,
-          false,
-          editOwnerToken,
-        );
+        restoreQueuedPromptsToEditor([target]);
       }
     })().catch((error: unknown) => {
       reportError(error, t('queue.editFailed'));

--- a/packages/web-shell/client/hooks/useSessionArtifacts.test.tsx
+++ b/packages/web-shell/client/hooks/useSessionArtifacts.test.tsx
@@ -23,6 +23,8 @@ interface Deferred<T> {
 }
 
 const sdkMock = vi.hoisted(() => ({
+  ownerVersion: 0,
+  ownerGuard: { capture: vi.fn() },
   actions: {
     loadArtifacts: vi.fn(),
   },
@@ -39,6 +41,7 @@ vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
   useActions: () => sdkMock.actions,
   useConnection: () => sdkMock.connection,
   usePromptStatus: () => sdkMock.promptStatus,
+  useDaemonSessionOwnerGuard: () => sdkMock.ownerGuard,
   useWorkspaceEventSignals: () => ({
     artifactsVersion: sdkMock.artifactsVersion,
   }),
@@ -101,6 +104,11 @@ beforeEach(() => {
   };
   sdkMock.promptStatus = 'idle';
   sdkMock.artifactsVersion = 0;
+  sdkMock.ownerVersion = 0;
+  sdkMock.ownerGuard.capture.mockImplementation(() => {
+    const version = sdkMock.ownerVersion;
+    return { isCurrent: () => sdkMock.ownerVersion === version };
+  });
   sdkMock.actions.loadArtifacts.mockReset();
 });
 
@@ -137,6 +145,7 @@ describe('useSessionArtifacts', () => {
       sessionId: 'session-b',
       capabilities: { features: ['session_artifacts'] },
     };
+    sdkMock.ownerVersion += 1;
     await rerenderHookHost();
 
     expect(latestState?.loading).toBe(true);
@@ -178,6 +187,32 @@ describe('useSessionArtifacts', () => {
     });
     expect(latestState?.artifacts.map((item) => item.id)).toEqual([
       'refreshed-artifact',
+    ]);
+  });
+
+  it('loads a same-id replacement without waiting for the old owner', async () => {
+    const oldLoad = deferred<{ artifacts: DaemonSessionArtifact[] }>();
+    sdkMock.actions.loadArtifacts
+      .mockReturnValueOnce(oldLoad.promise)
+      .mockResolvedValueOnce({ artifacts: [artifact('replacement')] });
+
+    await renderHookHost();
+    expect(sdkMock.actions.loadArtifacts).toHaveBeenCalledOnce();
+
+    sdkMock.ownerVersion += 1;
+    await rerenderHookHost();
+
+    expect(sdkMock.actions.loadArtifacts).toHaveBeenCalledTimes(2);
+    expect(latestState?.artifacts.map((item) => item.id)).toEqual([
+      'replacement',
+    ]);
+
+    await act(async () => {
+      oldLoad.resolve({ artifacts: [artifact('stale')] });
+      await oldLoad.promise;
+    });
+    expect(latestState?.artifacts.map((item) => item.id)).toEqual([
+      'replacement',
     ]);
   });
 });

--- a/packages/web-shell/client/hooks/useSessionArtifacts.ts
+++ b/packages/web-shell/client/hooks/useSessionArtifacts.ts
@@ -3,6 +3,7 @@ import {
   useActions,
   useConnection,
   usePromptStatus,
+  useDaemonSessionOwnerGuard,
   useWorkspaceEventSignals,
 } from '@qwen-code/webui/daemon-react-sdk';
 import type { DaemonSessionArtifact } from '@qwen-code/sdk/daemon';
@@ -20,6 +21,10 @@ export interface SessionArtifactsState {
 export function useSessionArtifacts(): SessionArtifactsState {
   const actions = useActions();
   const connection = useConnection();
+  const ownerGuard = useDaemonSessionOwnerGuard();
+  const ownerRef = useRef(ownerGuard.capture());
+  if (!ownerRef.current?.isCurrent()) ownerRef.current = ownerGuard.capture();
+  const owner = ownerRef.current;
   const promptStatus = usePromptStatus();
   const workspaceEventSignals = useWorkspaceEventSignals();
   const artifactsVersion = workspaceEventSignals?.artifactsVersion;
@@ -30,58 +35,37 @@ export function useSessionArtifacts(): SessionArtifactsState {
   const sessionId = connection.sessionId;
   const [artifacts, setArtifacts] = useState<DaemonSessionArtifact[]>([]);
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const requestIdRef = useRef(0);
-  const loadedSessionIdRef = useRef<string | undefined>(undefined);
+  const loadedOwnerRef = useRef<typeof owner | undefined>(undefined);
+  const loadingOwnerRef = useRef<typeof owner | undefined>(undefined);
   const previousPromptStatusRef = useRef(promptStatus);
   const previousArtifactsVersionRef = useRef(artifactsVersion);
 
   const refresh = useCallback(async () => {
-    const requestId = requestIdRef.current + 1;
-    requestIdRef.current = requestId;
-    if (!sessionId) {
-      loadedSessionIdRef.current = undefined;
+    const requestId = ++requestIdRef.current;
+    if (!sessionId || !isConnected || !supportsArtifacts) {
+      loadedOwnerRef.current = undefined;
+      loadingOwnerRef.current = undefined;
       setArtifacts([]);
-      setError(null);
       setLoading(false);
       return;
     }
-    if (!isConnected) {
-      loadedSessionIdRef.current = undefined;
-      setArtifacts([]);
-      setError(null);
-      setLoading(false);
-      return;
-    }
-    if (!supportsArtifacts) {
-      loadedSessionIdRef.current = undefined;
-      setArtifacts([]);
-      setError(null);
-      setLoading(false);
-      return;
-    }
-    if (
-      loadedSessionIdRef.current !== undefined &&
-      loadedSessionIdRef.current !== sessionId
-    ) {
-      setArtifacts([]);
-    }
+    if (loadedOwnerRef.current !== owner) setArtifacts([]);
+    loadingOwnerRef.current = owner;
     setLoading(true);
     try {
       const result = await actions.loadArtifacts();
-      if (requestIdRef.current !== requestId) return;
-      loadedSessionIdRef.current = sessionId;
+      if (requestIdRef.current !== requestId || !owner.isCurrent()) return;
+      loadedOwnerRef.current = owner;
       setArtifacts(result.artifacts);
-      setError(null);
     } catch {
-      if (requestIdRef.current !== requestId) return;
-      setError(null);
+      // The artifacts panel treats a failed refresh as an empty error state.
     } finally {
       if (requestIdRef.current === requestId) {
         setLoading(false);
       }
     }
-  }, [actions, isConnected, sessionId, supportsArtifacts]);
+  }, [actions, isConnected, owner, sessionId, supportsArtifacts]);
   const refreshRef = useRef(refresh);
   refreshRef.current = refresh;
 
@@ -110,9 +94,22 @@ export function useSessionArtifacts(): SessionArtifactsState {
   }, [artifactsVersion]);
 
   const artifactById = useMemo(
-    () => new Map(artifacts.map((artifact) => [artifact.id, artifact])),
-    [artifacts],
+    () =>
+      new Map(
+        (loadedOwnerRef.current === owner ? artifacts : []).map((artifact) => [
+          artifact.id,
+          artifact,
+        ]),
+      ),
+    [artifacts, owner],
   );
 
-  return { artifacts, artifactById, loading, error, refresh };
+  const visibleArtifacts = loadedOwnerRef.current === owner ? artifacts : [];
+  return {
+    artifacts: visibleArtifacts,
+    artifactById,
+    loading: loading && loadingOwnerRef.current === owner,
+    error: null,
+    refresh,
+  };
 }

--- a/packages/web-shell/client/index.test.tsx
+++ b/packages/web-shell/client/index.test.tsx
@@ -10,6 +10,7 @@ let workspaceShouldThrow = false;
 const sessionProviderProps: Array<Record<string, unknown>> = [];
 const appProps: Array<Record<string, unknown>> = [];
 let workspaceCapabilities: {
+  features: string[];
   workspaceCwd?: string;
   workspaces?: Array<{
     id: string;
@@ -18,6 +19,7 @@ let workspaceCapabilities: {
     trusted?: boolean;
   }>;
 } = {
+  features: [],
   workspaceCwd: '/workspace',
   workspaces: [{ id: 'primary', cwd: '/workspace', primary: true }],
 };
@@ -44,6 +46,7 @@ vi.mock('@qwen-code/webui/daemon-react-sdk', async () => {
       refreshCapabilities,
     }),
     useWorkspaceActions: () => ({ addWorkspace }),
+    useConnection: () => ({ status: 'idle' }),
   };
 });
 vi.mock('./App', async () => {
@@ -92,6 +95,7 @@ afterEach(() => {
   sessionProviderProps.length = 0;
   appProps.length = 0;
   workspaceCapabilities = {
+    features: [],
     workspaceCwd: '/workspace',
     workspaces: [{ id: 'primary', cwd: '/workspace', primary: true }],
   };
@@ -144,6 +148,7 @@ describe('WebShellWithProviders top-level boundary', () => {
 
   it('selects a registered workspace by path without locking the UI', () => {
     workspaceCapabilities = {
+      features: [],
       workspaces: [
         { id: 'primary', cwd: '/workspace', primary: true },
         { id: 'secondary', cwd: '/work/secondary', primary: false },
@@ -166,6 +171,7 @@ describe('WebShellWithProviders top-level boundary', () => {
 
   it('initializes an unlocked workspace selector from workspace id', () => {
     workspaceCapabilities = {
+      features: [],
       workspaces: [
         { id: 'primary', cwd: '/workspace', primary: true },
         { id: 'secondary', cwd: '/work/secondary', primary: false },
@@ -195,6 +201,7 @@ describe('WebShellWithProviders top-level boundary', () => {
 
   it('locks directly to an already registered workspace path', () => {
     workspaceCapabilities = {
+      features: [],
       workspaces: [
         { id: 'primary', cwd: '/workspace', primary: true },
         { id: 'secondary', cwd: '/work/secondary', primary: false },
@@ -225,7 +232,7 @@ describe('WebShellWithProviders top-level boundary', () => {
   });
 
   it('recognizes the primary path when single-workspace capabilities omit workspaces', () => {
-    workspaceCapabilities = { workspaceCwd: '/workspace' };
+    workspaceCapabilities = { features: [], workspaceCwd: '/workspace' };
 
     render(<WebShellWithProviders lockWorkspaceCwd="/workspace" />);
 
@@ -243,7 +250,7 @@ describe('WebShellWithProviders top-level boundary', () => {
   });
 
   it('selects the primary path without locking when workspaces are omitted', () => {
-    workspaceCapabilities = { workspaceCwd: '/workspace' };
+    workspaceCapabilities = { features: [], workspaceCwd: '/workspace' };
 
     render(<WebShellWithProviders workspaceCwd="/workspace" />);
 

--- a/packages/webui/README.md
+++ b/packages/webui/README.md
@@ -247,16 +247,17 @@ Do NOT nest multiple `<DaemonSessionProvider>` for the same session — that cre
 
 ### Session hooks
 
-| Hook                      | Returns                                                                                                             |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `useTranscriptBlocks()`   | `readonly DaemonTranscriptBlock[]` (raw blocks)                                                                     |
-| `useTranscriptState()`    | Full `DaemonTranscriptState` (blocks + metadata)                                                                    |
-| `useActions()`            | `{ sendPrompt, cancel, setModel, setApprovalMode, respondToPermission, loadSession, newSession, ... }`              |
-| `useConnection()`         | `{ status, sessionId, currentModel, currentMode, commands, skills, models, tokenCount, tokenUsage, contextWindow }` |
-| `useStreamingState()`     | `'idle' \| 'waiting' \| 'responding' \| 'thinking'`                                                                 |
-| `usePromptStatus()`       | `'idle' \| 'waiting' \| 'streaming'`                                                                                |
-| `usePendingPermissions()` | Unresolved permission blocks                                                                                        |
-| `useActiveTodoList()`     | Latest todo list, only when it still has active items                                                               |
+| Hook                           | Returns                                                                                                 |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| `useTranscriptBlocks()`        | `readonly DaemonTranscriptBlock[]` (raw blocks)                                                         |
+| `useTranscriptState()`         | Full `DaemonTranscriptState` (blocks + metadata)                                                        |
+| `useActions()`                 | `{ sendPrompt, cancel, setModel, setApprovalMode, respondToPermission, loadSession, newSession, ... }`  |
+| `useConnection()`              | Connection metadata, including optional `sessionTransition` state for transactional cross-session loads |
+| `useDaemonSessionOwnerGuard()` | Captures the current attachment identity so stale async UI continuations can be ignored                 |
+| `useStreamingState()`          | `'idle' \| 'waiting' \| 'responding' \| 'thinking'`                                                     |
+| `usePromptStatus()`            | `'idle' \| 'waiting' \| 'streaming'`                                                                    |
+| `usePendingPermissions()`      | Unresolved permission blocks                                                                            |
+| `useActiveTodoList()`          | Latest todo list, only when it still has active items                                                   |
 
 ### Workspace hooks
 
@@ -281,18 +282,19 @@ All resource hooks accept `{ autoLoad?: boolean, enabled?: boolean }` and return
 
 **`DaemonSessionProviderProps`:**
 
-| Prop                  | Type      | Default   | Description                                                                                              |
-| --------------------- | --------- | --------- | -------------------------------------------------------------------------------------------------------- |
-| `baseUrl`             | `string?` | inherited | Daemon HTTP base URL (inherited from `DaemonWorkspaceProvider` when nested; required in standalone mode) |
-| `token`               | `string?` | inherited | Bearer token (inherited from `DaemonWorkspaceProvider` when nested)                                      |
-| `workspaceCwd`        | `string?` | —         | Override workspace path (uses capabilities if omitted)                                                   |
-| `initialSessionId`    | `string?` | —         | Restore a specific session on mount                                                                      |
-| `clientId`            | `string?` | —         | Override stable client ID (auto-generated if omitted)                                                    |
-| `autoConnect`         | `boolean` | `true`    | Connect on mount                                                                                         |
-| `autoReconnect`       | `boolean` | `true`    | Auto-reconnect on disconnect                                                                             |
-| `reconnectDelayMs`    | `number`  | `1000`    | Initial reconnect backoff                                                                                |
-| `maxReconnectDelayMs` | `number`  | `10000`   | Max reconnect backoff                                                                                    |
-| `suppressOwnUserEcho` | `boolean` | `true`    | Suppress own user message echoes                                                                         |
+| Prop                        | Type               | Default   | Description                                                                                              |
+| --------------------------- | ------------------ | --------- | -------------------------------------------------------------------------------------------------------- |
+| `baseUrl`                   | `string?`          | inherited | Daemon HTTP base URL (inherited from `DaemonWorkspaceProvider` when nested; required in standalone mode) |
+| `token`                     | `string?`          | inherited | Bearer token (inherited from `DaemonWorkspaceProvider` when nested)                                      |
+| `workspaceCwd`              | `string?`          | —         | Override workspace path (uses capabilities if omitted)                                                   |
+| `sessionId`                 | `string?`          | —         | Restore a specific session and control later session transitions                                         |
+| `clientId`                  | `string?`          | —         | Override stable client ID (auto-generated if omitted)                                                    |
+| `autoConnect`               | `boolean`          | `true`    | Connect on mount                                                                                         |
+| `autoReconnect`             | `boolean`          | `true`    | Auto-reconnect on disconnect                                                                             |
+| `reconnectDelayMs`          | `number`           | `1000`    | Initial reconnect backoff                                                                                |
+| `maxReconnectDelayMs`       | `number`           | `10000`   | Max reconnect backoff                                                                                    |
+| `suppressOwnUserEcho`       | `boolean`          | `true`    | Suppress own user message echoes                                                                         |
+| `onSessionTransitionCommit` | `(target) => void` | —         | Runs synchronously after a transactional target becomes the owner and before the load promise resolves   |
 
 **`DaemonWorkspaceProviderProps`:**
 

--- a/packages/webui/src/daemon-react-sdk.ts
+++ b/packages/webui/src/daemon-react-sdk.ts
@@ -46,6 +46,8 @@ export { useDaemonActions as useActions } from './daemon/index.js';
 /** Connection status, capabilities, and model info. */
 export { useDaemonConnection as useConnection } from './daemon/index.js';
 
+export { useDaemonSessionOwnerGuard } from './daemon/session/DaemonSessionProvider.js';
+
 /** Current session metadata (id, model, approval mode). */
 export { useDaemonSession as useSession } from './daemon/index.js';
 
@@ -242,6 +244,11 @@ export type {
   /** Result of non-blocking `submitPrompt()`: the daemon-assigned promptId. */
   SubmitPromptResult,
 } from './daemon/index.js';
+export type {
+  DaemonSessionOwnerGuard,
+  DaemonSessionOwnerSnapshot,
+  DaemonSessionTransition,
+} from './daemon/session/types.js';
 
 // ── Types: Todos ─────────────────────────────────────────────────
 

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -6534,6 +6534,105 @@ describe('DaemonSessionProvider', () => {
     }
   });
 
+  it('clears a source passive-assistant timer before transactional commit', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => new Response(null, { status: 204 })),
+      );
+      sdkMocks.capabilities.mockResolvedValue({
+        workspaceCwd: '/mock-workspace',
+        features: ['client_identity'],
+      });
+      const source = createMockSession({
+        sessionId: 'session-a',
+        clientId: 'client-a',
+        events: async function* passiveSourceEvents(
+          opts: { signal?: AbortSignal } = {},
+        ) {
+          yield {
+            id: 1,
+            v: 1,
+            type: 'session_update',
+            data: {
+              update: {
+                sessionUpdate: 'agent_message_chunk',
+                content: { type: 'text', text: 'source partial' },
+              },
+            },
+          };
+          await new Promise<void>((resolve) =>
+            opts.signal?.addEventListener('abort', () => resolve(), {
+              once: true,
+            }),
+          );
+        },
+      });
+      const target = createMockSession({
+        sessionId: 'session-b',
+        clientId: 'client-b',
+        hasActivePrompt: true,
+        replaySnapshot: {
+          compactedReplay: [
+            {
+              id: 2,
+              v: 1,
+              type: 'session_update',
+              data: {
+                update: {
+                  sessionUpdate: 'agent_message_chunk',
+                  content: { type: 'text', text: 'target partial' },
+                },
+              },
+            },
+          ],
+          liveJournal: [],
+        },
+      });
+      sdkMocks.sessions.push(source, target);
+      let actions: DaemonSessionActions | undefined;
+      let blocks: readonly DaemonTranscriptBlock[] = [];
+      let streamingState: ReturnType<typeof useDaemonStreamingState> = 'idle';
+
+      function Harness() {
+        actions = useDaemonActions();
+        blocks = useDaemonTranscriptBlocks();
+        streamingState = useDaemonStreamingState();
+        return null;
+      }
+
+      await renderWithProvider(<Harness />, { autoConnect: true });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+        await flushPromises();
+      });
+      expect(blocks).toMatchObject([
+        { kind: 'assistant', text: 'source partial', streaming: true },
+      ]);
+
+      await act(async () => {
+        await requireActions(actions).loadSession('session-b');
+        await flushPromises();
+      });
+      expect(blocks).toMatchObject([
+        { kind: 'assistant', text: 'target partial', streaming: true },
+      ]);
+      expect(streamingState).toBe('responding');
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3_000);
+        await flushPromises();
+      });
+      expect(blocks).toMatchObject([
+        { kind: 'assistant', text: 'target partial', streaming: true },
+      ]);
+      expect(streamingState).toBe('responding');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('finishes replayed assistant streaming when replay completes', async () => {
     vi.useFakeTimers();
     try {
@@ -7676,7 +7775,7 @@ describe('DaemonSessionProvider', () => {
     expect(loadCalls[0]?.[3]).toBe('client-b');
   });
 
-  it('keeps cross-session restore blocked until every branch settles', async () => {
+  it('rejects a concurrent branch and opens the first branch', async () => {
     sdkMocks.capabilities.mockResolvedValue({
       v: 1,
       mode: 'http-bridge',
@@ -7688,28 +7787,23 @@ describe('DaemonSessionProvider', () => {
       sessionId: 'session-a',
       clientId: 'client-a',
     });
-    const secondBranchSession = createMockSession({
-      sessionId: 'session-c',
-      clientId: 'client-c',
+    const branchedSession = createMockSession({
+      sessionId: 'session-b',
+      clientId: 'client-b',
     });
     const firstBranch = createDeferred<{
       sessionId: string;
       displayName: string;
       clientId: string;
     }>();
-    const secondBranch = createDeferred<{
-      sessionId: string;
-      displayName: string;
-      clientId: string;
-    }>();
-    sdkMocks.branchSession
-      .mockReturnValueOnce(firstBranch.promise)
-      .mockReturnValueOnce(secondBranch.promise);
-    sdkMocks.sessions.push(sourceSession, secondBranchSession);
+    sdkMocks.branchSession.mockReturnValueOnce(firstBranch.promise);
+    sdkMocks.sessions.push(sourceSession, branchedSession);
     let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
 
     function Harness() {
       actions = useDaemonActions();
+      connection = useDaemonConnection();
       return null;
     }
 
@@ -7720,12 +7814,16 @@ describe('DaemonSessionProvider', () => {
     sdkMocks.MockDaemonSessionClient.load.mockClear();
 
     let first!: Promise<{ sessionId: string; displayName: string }>;
-    let second!: Promise<{ sessionId: string; displayName: string }>;
+    let second!: Promise<unknown>;
     await act(async () => {
       first = requireActions(actions).branchSession('First');
-      second = requireActions(actions).branchSession('Second');
+      second = requireActions(actions)
+        .branchSession('Second')
+        .catch((error: unknown) => error);
       await flushPromises();
     });
+    await expect(second).resolves.toMatchObject({ name: 'InvalidStateError' });
+    expect(sdkMocks.branchSession).toHaveBeenCalledOnce();
     let firstResult: { sessionId: string; displayName: string } | undefined;
     await act(async () => {
       firstBranch.resolve({
@@ -7740,43 +7838,16 @@ describe('DaemonSessionProvider', () => {
       sessionId: 'session-b',
       displayName: 'First',
     });
-    expect(sdkMocks.detachSession).toHaveBeenCalledWith(
-      'session-b',
-      'client-b',
-    );
-
-    let blockedResult: unknown;
-    await act(async () => {
-      blockedResult = await requireActions(actions)
-        .loadSession('session-d')
-        .catch((error: unknown) => error);
-      await flushPromises();
-    });
-    expect(blockedResult).toMatchObject({
-      name: 'InvalidStateError',
-    });
-    expect(sdkMocks.MockDaemonSessionClient.load).not.toHaveBeenCalled();
-
-    let secondResult: { sessionId: string; displayName: string } | undefined;
-    await act(async () => {
-      secondBranch.resolve({
-        sessionId: 'session-c',
-        displayName: 'Second',
-        clientId: 'client-c',
-      });
-      secondResult = await second;
-      await wait(5);
-      await flushPromises();
-    });
-    expect(secondResult).toEqual({
-      sessionId: 'session-c',
-      displayName: 'Second',
-    });
-
     expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledOnce();
     expect(sdkMocks.MockDaemonSessionClient.load.mock.calls[0]?.[1]).toBe(
-      'session-c',
+      'session-b',
     );
+    expect(connection).toMatchObject({
+      status: 'connected',
+      sessionId: 'session-b',
+      clientId: 'client-b',
+      sessionTransition: undefined,
+    });
   });
 
   it('exposes daemon capabilities on the connection state', async () => {

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -24,6 +24,7 @@ import {
   useDaemonActions,
   useDaemonConnection,
   useDaemonSessionNotices,
+  useDaemonSessionOwnerGuard,
   useDaemonPendingPermissions,
   useDaemonPromptStatus,
   useDaemonStreamingState,
@@ -46,6 +47,12 @@ import {
   clearSidechannelMidTurnInjected,
   getSidechannelMidTurnInjected,
 } from '../midTurnInjectedSidechannel.js';
+import {
+  clearSidechannelFollowupSuggestion,
+  getSidechannelFollowupSuggestion,
+  publishSidechannelFollowupSuggestion,
+  subscribeSidechannelFollowupSuggestion,
+} from '../followupSidechannel.js';
 import { persistStableClientId } from './clientLifecycle.js';
 
 interface MockSession {
@@ -109,6 +116,7 @@ interface MockClient {
   workspaceProviders: () => Promise<unknown>;
   listWorkspaceSessions: () => Promise<unknown[]>;
   closeSession: () => Promise<void>;
+  detachSession: (sessionId: string, clientId?: string) => Promise<void>;
   setSessionApprovalMode: () => Promise<{ mode: string }>;
   workspaceMcp: () => Promise<unknown>;
   workspaceMcpTools: () => Promise<unknown>;
@@ -162,6 +170,7 @@ const sdkMocks = vi.hoisted(() => {
   const workspaceProviders = vi.fn();
   const listWorkspaceSessions = vi.fn();
   const closeSession = vi.fn();
+  const detachSession = vi.fn();
   const setSessionApprovalMode = vi.fn();
   const workspaceMcp = vi.fn();
   const workspaceMcpTools = vi.fn();
@@ -196,6 +205,7 @@ const sdkMocks = vi.hoisted(() => {
     workspaceProviders = workspaceProviders;
     listWorkspaceSessions = listWorkspaceSessions;
     closeSession = closeSession;
+    detachSession = detachSession;
     setSessionApprovalMode = setSessionApprovalMode;
     workspaceMcp = workspaceMcp;
     workspaceMcpTools = workspaceMcpTools;
@@ -255,6 +265,7 @@ const sdkMocks = vi.hoisted(() => {
     workspaceByCwd,
     MockDaemonClient,
     MockDaemonSessionClient,
+    detachSession,
     workspaceMcpTools,
     getPendingPrompts,
     removePendingPrompt,
@@ -279,6 +290,8 @@ const sdkMocks = vi.hoisted(() => {
       listWorkspaceSessions.mockResolvedValue([]);
       closeSession.mockReset();
       closeSession.mockResolvedValue(undefined);
+      detachSession.mockReset();
+      detachSession.mockResolvedValue(undefined);
       setSessionApprovalMode.mockReset();
       setSessionApprovalMode.mockResolvedValue({ mode: 'default' });
       workspaceMcp.mockReset();
@@ -401,17 +414,20 @@ describe('DaemonSessionProvider', () => {
     sdkMocks.reset();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    vi.useRealTimers();
     if (root) {
-      act(() => {
+      await act(async () => {
         root?.unmount();
       });
+      await flushPromises();
       root = null;
     }
     if (container) {
       container.remove();
       container = null;
     }
+    clearSidechannelFollowupSuggestion();
     vi.unstubAllGlobals();
   });
 
@@ -7263,6 +7279,10 @@ describe('DaemonSessionProvider', () => {
   });
 
   it('retries a session switch while the target session is closing', async () => {
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
     const firstSession = createMockSession({ sessionId: 'session-a' });
     const secondSession = createMockSession({ sessionId: 'session-b' });
     sdkMocks.sessions.push(firstSession);
@@ -7313,6 +7333,14 @@ describe('DaemonSessionProvider', () => {
         await flushPromises();
       });
       expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(1);
+      expect(connection).toMatchObject({
+        status: 'connected',
+        sessionId: 'session-a',
+        sessionTransition: {
+          phase: 'preparing',
+          targetSessionId: 'session-b',
+        },
+      });
 
       await act(async () => {
         await vi.advanceTimersByTimeAsync(10);
@@ -7336,6 +7364,85 @@ describe('DaemonSessionProvider', () => {
         missingSession: false,
       });
       expect(notices).toEqual([]);
+    } finally {
+      random.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('retains legacy closing-session retries without client identity', async () => {
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: [],
+    });
+    sdkMocks.sessions.push(createMockSession({ sessionId: 'session-a' }));
+    let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      sessionId: 'session-a',
+      reconnectDelayMs: 10,
+      maxReconnectDelayMs: 100,
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    const closingError = new DaemonHttpError(
+      404,
+      {
+        error:
+          'No session with id "session-b". The session is closing; retry after close completes',
+        sessionId: 'session-b',
+      },
+      'POST /session/:id/load: No session with id "session-b". The session is closing; retry after close completes',
+    );
+    sdkMocks.MockDaemonSessionClient.load
+      .mockRejectedValueOnce(closingError)
+      .mockRejectedValueOnce(closingError);
+    sdkMocks.sessions.push(createMockSession({ sessionId: 'session-b' }));
+
+    const random = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    vi.useFakeTimers();
+    try {
+      let switched: Promise<void> | undefined;
+      act(() => {
+        switched = requireActions(actions).loadSession('session-b');
+      });
+      if (!switched) throw new Error('Session switch was not started');
+      await act(async () => {
+        await flushPromises();
+      });
+      expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10);
+        await flushPromises();
+      });
+      expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20);
+        await flushPromises();
+      });
+      expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(3);
+
+      await act(async () => {
+        await expect(switched).resolves.toBeUndefined();
+        await flushPromises();
+      });
+      expect(connection).toMatchObject({
+        status: 'connected',
+        sessionId: 'session-b',
+        missingSession: false,
+      });
     } finally {
       random.mockRestore();
       vi.useRealTimers();
@@ -7379,6 +7486,10 @@ describe('DaemonSessionProvider', () => {
   });
 
   it('does not retry a closing session after a newer switch', async () => {
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
     sdkMocks.sessions.push(createMockSession({ sessionId: 'session-a' }));
     let actions: DaemonSessionActions | undefined;
 
@@ -7412,13 +7523,92 @@ describe('DaemonSessionProvider', () => {
 
     vi.useFakeTimers();
     try {
-      const loadB = requireActions(actions)
-        .loadSession('session-b')
-        .catch(() => undefined);
+      let loadB: Promise<void | undefined> | undefined;
+      act(() => {
+        loadB = requireActions(actions)
+          .loadSession('session-b')
+          .catch(() => undefined);
+      });
+      if (!loadB) throw new Error('Session switch was not started');
       await act(async () => {
         await flushPromises();
       });
-      const loadC = requireActions(actions).loadSession('session-c');
+      let loadC: Promise<void> | undefined;
+      act(() => {
+        loadC = requireActions(actions).loadSession('session-c');
+      });
+      if (!loadC) throw new Error('Newer session switch was not started');
+      await act(async () => {
+        await flushPromises();
+      });
+      await expect(loadC).resolves.toBeUndefined();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(50);
+        await flushPromises();
+      });
+      await loadB;
+
+      expect(
+        sdkMocks.MockDaemonSessionClient.load.mock.calls.map((call) => call[1]),
+      ).toEqual(['session-b', 'session-c']);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops legacy closing-session retries after a newer switch', async () => {
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: [],
+    });
+    sdkMocks.sessions.push(createMockSession({ sessionId: 'session-a' }));
+    let actions: DaemonSessionActions | undefined;
+
+    function Harness() {
+      actions = useDaemonActions();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      sessionId: 'session-a',
+      reconnectDelayMs: 50,
+      maxReconnectDelayMs: 50,
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    sdkMocks.MockDaemonSessionClient.load.mockRejectedValueOnce(
+      new DaemonHttpError(
+        404,
+        {
+          error:
+            'No session with id "session-b". The session is closing; retry after close completes',
+          sessionId: 'session-b',
+        },
+        'POST /session/:id/load: No session with id "session-b". The session is closing; retry after close completes',
+      ),
+    );
+    sdkMocks.sessions.push(createMockSession({ sessionId: 'session-c' }));
+
+    vi.useFakeTimers();
+    try {
+      let loadB: Promise<void | undefined> | undefined;
+      act(() => {
+        loadB = requireActions(actions)
+          .loadSession('session-b')
+          .catch(() => undefined);
+      });
+      if (!loadB) throw new Error('Session switch was not started');
+      await act(async () => {
+        await flushPromises();
+      });
+      let loadC: Promise<void> | undefined;
+      act(() => {
+        loadC = requireActions(actions).loadSession('session-c');
+      });
+      if (!loadC) throw new Error('Newer session switch was not started');
       await act(async () => {
         await flushPromises();
       });
@@ -7484,6 +7674,109 @@ describe('DaemonSessionProvider', () => {
     const loadCalls = sdkMocks.MockDaemonSessionClient.load.mock.calls;
     expect(loadCalls[0]?.[1]).toBe('session-b');
     expect(loadCalls[0]?.[3]).toBe('client-b');
+  });
+
+  it('keeps cross-session restore blocked until every branch settles', async () => {
+    sdkMocks.capabilities.mockResolvedValue({
+      v: 1,
+      mode: 'http-bridge',
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+      modelServices: [],
+    });
+    const sourceSession = createMockSession({
+      sessionId: 'session-a',
+      clientId: 'client-a',
+    });
+    const secondBranchSession = createMockSession({
+      sessionId: 'session-c',
+      clientId: 'client-c',
+    });
+    const firstBranch = createDeferred<{
+      sessionId: string;
+      displayName: string;
+      clientId: string;
+    }>();
+    const secondBranch = createDeferred<{
+      sessionId: string;
+      displayName: string;
+      clientId: string;
+    }>();
+    sdkMocks.branchSession
+      .mockReturnValueOnce(firstBranch.promise)
+      .mockReturnValueOnce(secondBranch.promise);
+    sdkMocks.sessions.push(sourceSession, secondBranchSession);
+    let actions: DaemonSessionActions | undefined;
+
+    function Harness() {
+      actions = useDaemonActions();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    await act(async () => {
+      await flushPromises();
+    });
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+
+    let first!: Promise<{ sessionId: string; displayName: string }>;
+    let second!: Promise<{ sessionId: string; displayName: string }>;
+    await act(async () => {
+      first = requireActions(actions).branchSession('First');
+      second = requireActions(actions).branchSession('Second');
+      await flushPromises();
+    });
+    let firstResult: { sessionId: string; displayName: string } | undefined;
+    await act(async () => {
+      firstBranch.resolve({
+        sessionId: 'session-b',
+        displayName: 'First',
+        clientId: 'client-b',
+      });
+      firstResult = await first;
+      await flushPromises();
+    });
+    expect(firstResult).toEqual({
+      sessionId: 'session-b',
+      displayName: 'First',
+    });
+    expect(sdkMocks.detachSession).toHaveBeenCalledWith(
+      'session-b',
+      'client-b',
+    );
+
+    let blockedResult: unknown;
+    await act(async () => {
+      blockedResult = await requireActions(actions)
+        .loadSession('session-d')
+        .catch((error: unknown) => error);
+      await flushPromises();
+    });
+    expect(blockedResult).toMatchObject({
+      name: 'InvalidStateError',
+    });
+    expect(sdkMocks.MockDaemonSessionClient.load).not.toHaveBeenCalled();
+
+    let secondResult: { sessionId: string; displayName: string } | undefined;
+    await act(async () => {
+      secondBranch.resolve({
+        sessionId: 'session-c',
+        displayName: 'Second',
+        clientId: 'client-c',
+      });
+      secondResult = await second;
+      await wait(5);
+      await flushPromises();
+    });
+    expect(secondResult).toEqual({
+      sessionId: 'session-c',
+      displayName: 'Second',
+    });
+
+    expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledOnce();
+    expect(sdkMocks.MockDaemonSessionClient.load.mock.calls[0]?.[1]).toBe(
+      'session-c',
+    );
   });
 
   it('exposes daemon capabilities on the connection state', async () => {
@@ -8426,6 +8719,1634 @@ describe('DaemonSessionProvider', () => {
     ]);
   });
 
+  it('preserves the current session while a transactional target fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    const sourceEvent = createDeferred<DaemonEvent>();
+    const sourceStarted = createDeferred<void>();
+    const currentSession = createMockSession({
+      sessionId: 'session-a',
+      clientId: 'client-a',
+      replaySnapshot: createTextReplaySnapshot('old transcript'),
+      events: async function* sourceEvents(
+        opts: { signal?: AbortSignal } = {},
+      ) {
+        sourceStarted.resolve();
+        const event = await sourceEvent.promise;
+        if (opts.signal?.aborted) return;
+        yield event;
+        await new Promise<void>((resolve) =>
+          opts.signal?.addEventListener('abort', () => resolve(), {
+            once: true,
+          }),
+        );
+      },
+    });
+    sdkMocks.sessions.push(currentSession);
+    const target = createDeferred<MockSession>();
+    let actions: DaemonSessionActions | undefined;
+    let blocks: readonly DaemonTranscriptBlock[] = [];
+    let connection: DaemonConnectionState | undefined;
+
+    function Harness() {
+      actions = useDaemonActions();
+      blocks = useDaemonTranscriptBlocks();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    await sourceStarted.promise;
+    sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(
+      async () => target.promise,
+    );
+    let load!: Promise<void>;
+    act(() => {
+      load = requireActions(actions).loadSession('session-b');
+    });
+    const outcome = load.catch((error: unknown) => error);
+    await act(async () => flushPromises());
+
+    expect(connection).toMatchObject({
+      status: 'connected',
+      sessionId: 'session-a',
+      clientId: 'client-a',
+      sessionTransition: {
+        phase: 'preparing',
+        targetSessionId: 'session-b',
+        targetClientId: expect.any(String),
+      },
+    });
+    expect(blocks).toMatchObject([
+      { kind: 'assistant', text: 'old transcript' },
+    ]);
+    expect(currentSession.detach).not.toHaveBeenCalled();
+    await act(async () => {
+      await expect(requireActions(actions).cancel()).resolves.toBeUndefined();
+      await expect(
+        requireActions(actions).sendPrompt('must not target A'),
+      ).rejects.toThrow('A session switch is still preparing');
+    });
+    expect(currentSession.cancel).toHaveBeenCalledOnce();
+    expect(currentSession.prompt).not.toHaveBeenCalled();
+
+    sourceEvent.resolve({
+      id: 3,
+      v: 1,
+      type: 'session_update',
+      data: {
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: ' still live' },
+        },
+      },
+    });
+    await act(async () => {
+      await flushPromises();
+      await flushTranscriptDispatch();
+    });
+    expect(
+      blocks.map((block) => ('text' in block ? block.text : undefined)),
+    ).toEqual(['old transcript', ' still live']);
+
+    await act(async () => {
+      target.reject(new Error('target load failed'));
+      await flushPromises();
+    });
+    await expect(outcome).resolves.toMatchObject({
+      message: 'target load failed',
+    });
+    expect(connection).toMatchObject({
+      status: 'connected',
+      sessionId: 'session-a',
+      clientId: 'client-a',
+      sessionTransition: {
+        phase: 'failed',
+        targetClientId: expect.any(String),
+      },
+    });
+    expect(
+      blocks.map((block) => ('text' in block ? block.text : undefined)),
+    ).toEqual(['old transcript', ' still live']);
+  });
+
+  it('does not adopt a target restored under stale provider configuration', async () => {
+    const detachFetch = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(null, { status: 204 }),
+    );
+    vi.stubGlobal('fetch', detachFetch);
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    const source = createMockSession({
+      sessionId: 'session-a',
+      clientId: 'client-a',
+    });
+    const reloadedSource = createMockSession({
+      sessionId: 'session-a',
+      clientId: 'client-a-reloaded',
+    });
+    const target = createDeferred<MockSession>();
+    sdkMocks.sessions.push(source);
+    let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      maxBlocks: 1_024,
+      sessionId: 'session-a',
+    });
+    sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(
+      async () => target.promise,
+    );
+    let transition!: Promise<void>;
+    act(() => {
+      transition = requireActions(actions).loadSession('session-b');
+    });
+    const outcome = transition.catch((error: unknown) => error);
+    await act(async () => flushPromises());
+
+    sdkMocks.sessions.push(reloadedSource);
+    await act(async () => {
+      root?.render(
+        <DaemonSessionProvider
+          baseUrl="http://127.0.0.1:4170"
+          autoConnect
+          maxBlocks={2_048}
+          sessionId="session-a"
+        >
+          <Harness />
+        </DaemonSessionProvider>,
+      );
+      await flushPromises();
+    });
+    await expect(outcome).resolves.toMatchObject({ name: 'AbortError' });
+
+    const freshTarget = createMockSession({
+      sessionId: 'session-b',
+      clientId: 'client-b-fresh',
+    });
+    sdkMocks.sessions.push(freshTarget);
+    let retry!: Promise<void>;
+    act(() => {
+      retry = requireActions(actions).loadSession('session-b');
+    });
+    await act(async () => {
+      target.resolve(
+        createMockSession({
+          sessionId: 'session-b',
+          clientId: 'client-b-stale',
+        }),
+      );
+      await retry;
+      await flushPromises();
+    });
+    expect(connection).toMatchObject({
+      sessionId: 'session-b',
+      clientId: 'client-b-fresh',
+    });
+    expect(detachFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/session/session-b/detach'),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'X-Qwen-Client-Id': 'client-b-stale',
+        }),
+      }),
+    );
+    expect(
+      detachFetch.mock.calls.filter(([input]) =>
+        String(input).includes('/session/session-b/detach'),
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('does not commit a ready target after a real unmount', async () => {
+    const detachFetch = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(null, { status: 204 }),
+    );
+    vi.stubGlobal('fetch', detachFetch);
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    sdkMocks.sessions.push(
+      createMockSession({ sessionId: 'session-a', clientId: 'client-a' }),
+    );
+    const target = createDeferred<MockSession>();
+    let actions: DaemonSessionActions | undefined;
+
+    function Harness() {
+      actions = useDaemonActions();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(
+      () => target.promise,
+    );
+    let transition!: Promise<void>;
+    act(() => {
+      transition = requireActions(actions).loadSession('session-b');
+    });
+    const outcome = transition.catch((error: unknown) => error);
+    await act(async () => flushPromises());
+
+    act(() => {
+      target.resolve(
+        createMockSession({ sessionId: 'session-b', clientId: 'client-b' }),
+      );
+      root?.unmount();
+      root = null;
+    });
+    await act(async () => flushPromises());
+
+    await expect(outcome).resolves.toMatchObject({ name: 'AbortError' });
+    expect(detachFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/session/session-b/detach'),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'X-Qwen-Client-Id': 'client-b',
+        }),
+      }),
+    );
+    expect(
+      detachFetch.mock.calls.filter(([input]) =>
+        String(input).includes('/session/session-b/detach'),
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('retires a committed target when unmounted before its runner starts', async () => {
+    const detachFetch = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(null, { status: 204 }),
+    );
+    vi.stubGlobal('fetch', detachFetch);
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    sdkMocks.sessions.push(
+      createMockSession({ sessionId: 'session-a', clientId: 'client-a' }),
+    );
+    const target = createDeferred<MockSession>();
+    let actions: DaemonSessionActions | undefined;
+
+    function Harness() {
+      actions = useDaemonActions();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(
+      () => target.promise,
+    );
+    let transition!: Promise<void>;
+    act(() => {
+      transition = requireActions(actions).loadSession('session-b');
+    });
+    await act(async () => flushPromises());
+
+    await act(async () => {
+      target.resolve(
+        createMockSession({ sessionId: 'session-b', clientId: 'client-b' }),
+      );
+      await transition;
+      root?.unmount();
+      root = null;
+    });
+    await flushPromises();
+
+    expect(detachFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/session/session-b/detach'),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'X-Qwen-Client-Id': 'client-b',
+        }),
+      }),
+    );
+    expect(
+      detachFetch.mock.calls.filter(([input]) =>
+        String(input).includes('/session/session-b/detach'),
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('does not duplicate the initial controlled load when workspace is set', async () => {
+    sdkMocks.sessions.push(
+      createMockSession({ sessionId: 'session-a', clientId: 'client-a' }),
+    );
+
+    await renderWithProvider(null, {
+      autoConnect: true,
+      sessionId: 'session-a',
+      workspaceCwd: '/mock-workspace',
+    });
+
+    expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledOnce();
+  });
+
+  it('unblocks source actions after timeout while the raw restore settles', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    const source = createMockSession({
+      sessionId: 'session-a',
+      clientId: 'client-a',
+    });
+    sdkMocks.sessions.push(source);
+    const target = createDeferred<MockSession>();
+    let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(
+      async () => target.promise,
+    );
+    vi.useFakeTimers();
+    let outcome!: Promise<unknown>;
+    act(() => {
+      outcome = requireActions(actions)
+        .loadSession('session-b')
+        .catch((error: unknown) => error);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(75_000);
+    });
+
+    await act(async () => {
+      await expect(outcome).resolves.toMatchObject({
+        message: 'Session transition timed out',
+      });
+    });
+    await act(async () => {
+      await expect(
+        requireActions(actions).setModel('source-model'),
+      ).resolves.toEqual({ modelId: 'source-model' });
+    });
+    expect(connection).toMatchObject({
+      sessionId: 'session-a',
+      sessionTransition: { phase: 'failed' },
+    });
+
+    const retriedTarget = createMockSession({
+      sessionId: 'session-b',
+      clientId: 'client-b',
+    });
+    sdkMocks.MockDaemonSessionClient.load.mockResolvedValueOnce(retriedTarget);
+    let retry!: Promise<void>;
+    act(() => {
+      retry = requireActions(actions).loadSession('session-b');
+    });
+    await act(async () => {
+      target.reject(new Error('old request expired'));
+      await flushPromises();
+      await retry;
+    });
+    expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(2);
+    expect(connection?.sessionId).toBe('session-b');
+  });
+
+  it('adopts a late raw result when the same target is requested again', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    sdkMocks.sessions.push(
+      createMockSession({ sessionId: 'session-a', clientId: 'client-a' }),
+    );
+    const target = createDeferred<MockSession>();
+    let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(
+      async () => target.promise,
+    );
+    vi.useFakeTimers();
+    let first!: Promise<unknown>;
+    act(() => {
+      first = requireActions(actions)
+        .loadSession('session-b')
+        .catch((error: unknown) => error);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(75_000);
+    });
+    await expect(first).resolves.toMatchObject({
+      message: 'Session transition timed out',
+    });
+
+    let retry!: Promise<void>;
+    act(() => {
+      retry = requireActions(actions).loadSession('session-b');
+    });
+    await act(async () => {
+      target.resolve(
+        createMockSession({ sessionId: 'session-b', clientId: 'client-b' }),
+      );
+      await retry;
+      await flushPromises();
+    });
+
+    expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledOnce();
+    expect(connection).toMatchObject({
+      status: 'connected',
+      sessionId: 'session-b',
+      clientId: 'client-b',
+    });
+  });
+
+  it('commits a transactional target before resolving its public promise', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const detachFetch = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(null, { status: 204 }),
+    );
+    vi.stubGlobal('fetch', detachFetch);
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity', 'session_transcript_pagination'],
+    });
+    let sourceEventSignal: AbortSignal | undefined;
+    const currentSession = createMockSession({
+      sessionId: 'session-a',
+      clientId: 'client-a',
+      replaySnapshot: createTextReplaySnapshot('old transcript'),
+      events: async function* sourceEvents(
+        opts: { signal?: AbortSignal } = {},
+      ) {
+        sourceEventSignal = opts.signal;
+        await new Promise<void>((resolve) =>
+          opts.signal?.addEventListener('abort', () => resolve(), {
+            once: true,
+          }),
+        );
+        if (!opts.signal?.aborted) {
+          yield { id: 3, v: 1, type: 'debug', data: {} };
+        }
+      },
+    });
+    sdkMocks.sessions.push(currentSession);
+    const target = createDeferred<MockSession>();
+    let actions: DaemonSessionActions | undefined;
+    let blocks: readonly DaemonTranscriptBlock[] = [];
+    let connection: DaemonConnectionState | undefined;
+    let transcriptStore: DaemonTranscriptStore | undefined;
+    let history: ReturnType<typeof useDaemonTranscriptHistory> | undefined;
+    let ownerGuard: ReturnType<typeof useDaemonSessionOwnerGuard> | undefined;
+    let committedSessionId: string | undefined;
+
+    function Harness() {
+      actions = useDaemonActions();
+      blocks = useDaemonTranscriptBlocks();
+      connection = useDaemonConnection();
+      transcriptStore = useDaemonTranscriptStore();
+      history = useDaemonTranscriptHistory();
+      ownerGuard = useDaemonSessionOwnerGuard();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      onSessionTransitionCommit: (target) => {
+        committedSessionId = target.sessionId;
+        throw new Error('observer failed');
+      },
+    });
+    sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(
+      async () => target.promise,
+    );
+    const sourceOwner = ownerGuard?.capture();
+    let visibleAtResolve: {
+      sessionId?: string;
+      text?: string;
+      sourceIsCurrent?: boolean;
+      targetIsCurrent?: boolean;
+    } = {};
+    let load!: Promise<void>;
+    act(() => {
+      load = requireActions(actions)
+        .loadSession('session-b', { workspaceCwd: '/target-workspace' })
+        .then(() => {
+          const snapshot = transcriptStore?.getSnapshot();
+          visibleAtResolve = {
+            sessionId: committedSessionId,
+            text:
+              snapshot?.blocks[0]?.kind === 'assistant'
+                ? snapshot.blocks[0].text
+                : undefined,
+            sourceIsCurrent: sourceOwner?.isCurrent(),
+            targetIsCurrent: ownerGuard?.capture().isCurrent(),
+          };
+        });
+    });
+    await act(async () => {
+      target.resolve(
+        createMockSession({
+          sessionId: 'session-b',
+          clientId: 'client-b',
+          workspaceCwd: '/target-workspace',
+          historyHasMore: true,
+          replaySnapshot: {
+            compactedReplay: [
+              {
+                v: 1,
+                type: 'history_truncated',
+                data: {
+                  reason: 'replay_window_exceeded',
+                  fullTranscriptAvailable: true,
+                  recordId: 'record-b',
+                },
+              },
+              ...createTextReplaySnapshot('new transcript').compactedReplay,
+            ],
+            liveJournal: [],
+          },
+        }),
+      );
+      await load;
+      await flushPromises();
+    });
+
+    expect(visibleAtResolve).toEqual({
+      sessionId: 'session-b',
+      text: 'new transcript',
+      sourceIsCurrent: false,
+      targetIsCurrent: true,
+    });
+    expect(connection).toMatchObject({
+      status: 'connected',
+      sessionId: 'session-b',
+      clientId: 'client-b',
+      workspaceCwd: '/target-workspace',
+      sessionTransition: undefined,
+    });
+    expect(blocks).toMatchObject([
+      { kind: 'assistant', text: 'new transcript' },
+    ]);
+    expect(history?.hasMore).toBe(true);
+    expect(sourceEventSignal?.aborted).toBe(true);
+    expect(detachFetch).toHaveBeenCalledOnce();
+    const [detachInput, detachInit] = detachFetch.mock.calls[0] ?? [];
+    expect(new URL(String(detachInput)).pathname).toContain(
+      '/session/session-a/detach',
+    );
+    expect(new Headers(detachInit?.headers).get('X-Qwen-Client-Id')).toBe(
+      'client-a',
+    );
+  });
+
+  it('retires a stale candidate through its original endpoint', async () => {
+    const detachFetch = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(null, { status: 204 }),
+    );
+    vi.stubGlobal('fetch', detachFetch);
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    sdkMocks.sessions.push(
+      createMockSession({ sessionId: 'session-a', clientId: 'client-a' }),
+    );
+    const target = createDeferred<MockSession>();
+    let actions: DaemonSessionActions | undefined;
+    function Harness() {
+      actions = useDaemonActions();
+      return null;
+    }
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(
+      async () => target.promise,
+    );
+    let outcome!: Promise<unknown>;
+    act(() => {
+      outcome = requireActions(actions)
+        .loadSession('session-b')
+        .catch((error: unknown) => error);
+    });
+    sdkMocks.sessions.push(
+      createMockSession({ sessionId: 'session-a', clientId: 'client-a-2' }),
+    );
+
+    await act(async () => {
+      root?.render(
+        <DaemonSessionProvider baseUrl="http://127.0.0.1:4171" autoConnect>
+          <Harness />
+        </DaemonSessionProvider>,
+      );
+      await flushPromises();
+    });
+    await act(async () => {
+      target.resolve(
+        createMockSession({ sessionId: 'session-b', clientId: 'client-b' }),
+      );
+      await flushPromises();
+    });
+
+    await expect(outcome).resolves.toMatchObject({ name: 'AbortError' });
+    const candidateDetach = detachFetch.mock.calls.find(
+      ([, init]) =>
+        new Headers(init?.headers).get('X-Qwen-Client-Id') === 'client-b',
+    );
+    expect(candidateDetach).toBeDefined();
+    expect(new URL(String(candidateDetach?.[0])).origin).toBe(
+      'http://127.0.0.1:4170',
+    );
+    expect(
+      new Headers(candidateDetach?.[1]?.headers).get('X-Qwen-Client-Id'),
+    ).toBe('client-b');
+  });
+
+  it('stages a large target replay in bounded reducer batches', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    sdkMocks.sessions.push(
+      createMockSession({ sessionId: 'session-a', clientId: 'client-a' }),
+    );
+    const sdk = await import('@qwen-code/sdk/daemon');
+    const createStore = sdk.createDaemonTranscriptStore;
+    const batchSizes: number[] = [];
+    const createStoreSpy = vi
+      .spyOn(sdk, 'createDaemonTranscriptStore')
+      .mockImplementation((seed) => {
+        const next = createStore(seed);
+        const dispatch = next.dispatch.bind(next);
+        next.dispatch = (events) => {
+          batchSizes.push(Array.isArray(events) ? events.length : 1);
+          return dispatch(events);
+        };
+        return next;
+      });
+    let actions: DaemonSessionActions | undefined;
+    function Harness() {
+      actions = useDaemonActions();
+      return null;
+    }
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    batchSizes.length = 0;
+    const compactedReplay = Object.freeze(
+      Array.from(
+        { length: 513 },
+        (_, index): DaemonEvent => ({
+          id: index + 1,
+          v: 1,
+          type: 'session_update',
+          data: {
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              content: { type: 'text', text: `${index} ` },
+            },
+          },
+        }),
+      ),
+    );
+    sdkMocks.MockDaemonSessionClient.load.mockResolvedValueOnce(
+      createMockSession({
+        sessionId: 'session-b',
+        clientId: 'client-b',
+        replaySnapshot: {
+          compactedReplay: compactedReplay as DaemonEvent[],
+          liveJournal: [],
+        },
+      }),
+    );
+
+    await act(async () => {
+      await requireActions(actions).loadSession('session-b');
+      await flushPromises();
+    });
+
+    expect(batchSizes).toEqual([512, 1]);
+    createStoreSpy.mockRestore();
+  });
+
+  it('preserves a transactional replay that exceeds the configured block cap', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity', 'session_transcript_pagination'],
+    });
+    sdkMocks.sessions.push(
+      createMockSession({ sessionId: 'session-a', clientId: 'client-a' }),
+    );
+    let actions: DaemonSessionActions | undefined;
+    let blocks: readonly DaemonTranscriptBlock[] = [];
+    function Harness() {
+      actions = useDaemonActions();
+      blocks = useDaemonTranscriptBlocks();
+      return null;
+    }
+    await renderWithProvider(<Harness />, { autoConnect: true, maxBlocks: 1 });
+    sdkMocks.MockDaemonSessionClient.load.mockResolvedValueOnce(
+      createMockSession({
+        sessionId: 'session-b',
+        clientId: 'client-b',
+        replaySnapshot: {
+          compactedReplay: [
+            {
+              id: 1,
+              v: 1,
+              type: 'session_update',
+              data: {
+                update: {
+                  sessionUpdate: 'user_message_chunk',
+                  content: { type: 'text', text: 'target prompt' },
+                },
+              },
+            },
+            {
+              id: 2,
+              v: 1,
+              type: 'session_update',
+              data: {
+                update: {
+                  sessionUpdate: 'agent_message_chunk',
+                  content: { type: 'text', text: 'target answer' },
+                },
+              },
+            },
+          ],
+          liveJournal: [],
+        },
+      }),
+    );
+
+    await act(async () => {
+      await requireActions(actions).loadSession('session-b');
+      await flushPromises();
+    });
+
+    expect(blocks).toMatchObject([
+      { kind: 'user', text: 'target prompt' },
+      { kind: 'assistant', text: 'target answer' },
+    ]);
+  });
+
+  it('replaces the source follow-up with the last staged target suggestion', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/work/a',
+      features: ['client_identity'],
+    });
+    sdkMocks.sessions.push(
+      createMockSession({
+        sessionId: 'session-a',
+        clientId: 'client-a',
+        workspaceCwd: '/work/a',
+      }),
+    );
+    let actions: DaemonSessionActions | undefined;
+    let ownerGuard: ReturnType<typeof useDaemonSessionOwnerGuard> | undefined;
+    function Harness() {
+      actions = useDaemonActions();
+      ownerGuard = useDaemonSessionOwnerGuard();
+      return null;
+    }
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    const sourceOwner = ownerGuard?.capture();
+    const sourceCurrentWhenPublished: boolean[] = [];
+    const unsubscribe = subscribeSidechannelFollowupSuggestion(() => {
+      sourceCurrentWhenPublished.push(sourceOwner?.isCurrent() ?? true);
+    });
+    publishSidechannelFollowupSuggestion({
+      sessionId: 'session-a',
+      promptId: 'prompt-a',
+      suggestion: 'stale suggestion',
+    });
+    sdkMocks.MockDaemonSessionClient.load.mockResolvedValueOnce(
+      createMockSession({
+        sessionId: 'session-a',
+        clientId: 'client-b',
+        workspaceCwd: '/work/b',
+        replaySnapshot: {
+          compactedReplay: [
+            {
+              v: 1,
+              type: 'followup_suggestion',
+              data: {
+                sessionId: 'session-a',
+                promptId: 'prompt-b1',
+                suggestion: 'older target suggestion',
+              },
+            },
+            {
+              v: 1,
+              type: 'followup_suggestion',
+              data: {
+                sessionId: 'session-a',
+                promptId: 'prompt-b2',
+                suggestion: 'latest target suggestion',
+              },
+            },
+          ],
+          liveJournal: [],
+        },
+      }),
+    );
+
+    await act(async () => {
+      await requireActions(actions).loadSession('session-a', {
+        workspaceCwd: '/work/b',
+      });
+      await flushPromises();
+    });
+
+    expect(getSidechannelFollowupSuggestion()).toEqual({
+      sessionId: 'session-a',
+      promptId: 'prompt-b2',
+      suggestion: 'latest target suggestion',
+    });
+    expect(sourceCurrentWhenPublished.slice(1)).toEqual([false, false]);
+    unsubscribe();
+    clearSidechannelFollowupSuggestion();
+  });
+
+  it('keeps a transition started synchronously by the commit observer', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    const sourceStarted = createDeferred<void>();
+    sdkMocks.sessions.push(
+      createMockSession({
+        sessionId: 'session-a',
+        clientId: 'client-a',
+        events: async function* sourceEvents(
+          options: { signal?: AbortSignal } = {},
+        ) {
+          sourceStarted.resolve();
+          yield* [];
+          await new Promise<void>((resolve) =>
+            options.signal?.addEventListener('abort', () => resolve(), {
+              once: true,
+            }),
+          );
+        },
+      }),
+    );
+    const targetB = createDeferred<MockSession>();
+    const targetC = createMockSession({
+      sessionId: 'session-c',
+      clientId: 'client-c',
+    });
+    let actions: DaemonSessionActions | undefined;
+    let nestedLoad: Promise<void> | undefined;
+    let connection: DaemonConnectionState | undefined;
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      onSessionTransitionCommit: (target) => {
+        if (target.sessionId === 'session-b') {
+          nestedLoad = requireActions(actions).loadSession('session-c');
+        }
+      },
+    });
+    await sourceStarted.promise;
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    sdkMocks.MockDaemonSessionClient.load
+      .mockImplementationOnce(async () => targetB.promise)
+      .mockResolvedValueOnce(targetC);
+    let firstLoad!: Promise<void>;
+    act(() => {
+      firstLoad = requireActions(actions).loadSession('session-b');
+    });
+    await act(async () => {
+      targetB.resolve(
+        createMockSession({ sessionId: 'session-b', clientId: 'client-b' }),
+      );
+      await firstLoad;
+      await nestedLoad;
+      await flushPromises();
+    });
+
+    expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(2);
+    expect(connection).toMatchObject({
+      status: 'connected',
+      sessionId: 'session-c',
+      clientId: 'client-c',
+    });
+  });
+
+  it('keeps a notice dismissed by a later staged replay event', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    sdkMocks.sessions.push(
+      createMockSession({ sessionId: 'session-a', clientId: 'client-a' }),
+    );
+    const target = createDeferred<MockSession>();
+    let actions: DaemonSessionActions | undefined;
+    let notices: readonly DaemonSessionNotice[] = [];
+
+    function Harness() {
+      actions = useDaemonActions();
+      notices = useDaemonSessionNotices().notices;
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(
+      async () => target.promise,
+    );
+    let load!: Promise<void>;
+    await act(async () => {
+      load = requireActions(actions).loadSession('session-b');
+      await flushPromises();
+    });
+
+    await act(async () => {
+      target.resolve(
+        createMockSession({
+          sessionId: 'session-b',
+          clientId: 'client-b',
+          replaySnapshot: {
+            compactedReplay: [],
+            liveJournal: [
+              {
+                id: 1,
+                v: 1,
+                type: 'session_recording_degraded',
+                data: { sessionId: 'session-b', reason: 'write_failed' },
+              },
+              {
+                id: 2,
+                v: 1,
+                type: 'session_snapshot',
+                data: { sessionId: 'session-b', recordingDegraded: false },
+              },
+            ],
+          },
+        }),
+      );
+      await load;
+      await flushPromises();
+    });
+
+    expect(notices).toEqual([]);
+  });
+
+  it('restores a staged notice that reappears after dismissal', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    sdkMocks.sessions.push(
+      createMockSession({ sessionId: 'session-a', clientId: 'client-a' }),
+    );
+    let actions: DaemonSessionActions | undefined;
+    let notices: readonly DaemonSessionNotice[] = [];
+
+    function Harness() {
+      actions = useDaemonActions();
+      notices = useDaemonSessionNotices().notices;
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    sdkMocks.MockDaemonSessionClient.load.mockResolvedValueOnce(
+      createMockSession({
+        sessionId: 'session-b',
+        clientId: 'client-b',
+        replaySnapshot: {
+          compactedReplay: [],
+          liveJournal: [
+            {
+              id: 1,
+              v: 1,
+              type: 'session_recording_degraded',
+              data: { sessionId: 'session-b', reason: 'write_failed' },
+            },
+            {
+              id: 2,
+              v: 1,
+              type: 'session_snapshot',
+              data: { sessionId: 'session-b', recordingDegraded: false },
+            },
+            {
+              id: 3,
+              v: 1,
+              type: 'session_snapshot',
+              data: { sessionId: 'session-b', recordingDegraded: true },
+            },
+          ],
+        },
+      }),
+    );
+
+    await act(async () => {
+      await requireActions(actions).loadSession('session-b');
+      await flushPromises();
+    });
+
+    expect(notices).toHaveLength(1);
+    expect(notices[0]?.id).toBe('daemon.session_recording_degraded:session-b');
+  });
+
+  it('replays a later snapshot reload after a prepared target commits', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    sdkMocks.sessions.push(
+      createMockSession({ sessionId: 'session-a', clientId: 'client-a' }),
+    );
+    const requestResync = createDeferred<void>();
+    const target = createMockSession({
+      sessionId: 'session-b',
+      clientId: 'client-b',
+      replaySnapshot: createTextReplaySnapshot('target transcript'),
+      events: async function* resyncEvents() {
+        await requestResync.promise;
+        yield {
+          id: 3,
+          v: 1,
+          type: 'state_resync_required',
+          data: { reason: 'ring_evicted' },
+        };
+      },
+    });
+    let actions: DaemonSessionActions | undefined;
+    let blocks: readonly DaemonTranscriptBlock[] = [];
+    function Harness() {
+      actions = useDaemonActions();
+      blocks = useDaemonTranscriptBlocks();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      reconnectDelayMs: 1,
+      maxReconnectDelayMs: 1,
+    });
+    sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(
+      async () => target,
+    );
+    await act(async () => {
+      await requireActions(actions).loadSession('session-b');
+      await flushPromises();
+    });
+    sdkMocks.sessions.push(
+      createMockSession({
+        sessionId: 'session-b',
+        clientId: 'client-b',
+        replaySnapshot: createTextReplaySnapshot('reloaded transcript'),
+      }),
+    );
+    await act(async () => {
+      requestResync.resolve();
+      await flushPromises();
+    });
+    await act(async () => {
+      await vi.waitFor(() =>
+        expect(blocks).toMatchObject([
+          { kind: 'assistant', text: 'reloaded transcript' },
+        ]),
+      );
+    });
+    expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(3);
+    expect(sdkMocks.sessions).toHaveLength(0);
+  });
+
+  it('carries a target live-journal repair episode into its runner', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    sdkMocks.sessions.push(
+      createMockSession({ sessionId: 'session-a', clientId: 'client-a' }),
+    );
+    const releaseTerminal = createDeferred<void>();
+    const marker: DaemonEvent = {
+      id: 2,
+      v: 1,
+      type: 'history_truncated',
+      promptId: 'prompt-b',
+      data: {
+        reason: 'replay_window_exceeded',
+        scope: 'live_journal',
+        truncatedEvents: 4,
+        retainedEvents: 2,
+        maxBytes: 1024,
+        maxEvents: 2,
+        fullTranscriptAvailable: true,
+      },
+    };
+    const target = createMockSession({
+      sessionId: 'session-b',
+      clientId: 'client-b',
+      lastEventId: 3,
+      replaySnapshot: {
+        compactedReplay: [],
+        liveJournal: [
+          marker,
+          {
+            id: 3,
+            v: 1,
+            type: 'session_update',
+            promptId: 'prompt-b',
+            data: {
+              update: {
+                sessionUpdate: 'agent_message_chunk',
+                content: { type: 'text', text: 'partial' },
+              },
+            },
+          },
+        ],
+      },
+      events: async function* terminalEvents() {
+        await releaseTerminal.promise;
+        yield {
+          id: 4,
+          v: 1,
+          type: 'turn_complete',
+          promptId: 'prompt-b',
+          data: { promptId: 'prompt-b', stopReason: 'end_turn' },
+        };
+      },
+    });
+    let actions: DaemonSessionActions | undefined;
+    function Harness() {
+      actions = useDaemonActions();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(
+      async () => target,
+    );
+    await act(async () => {
+      await requireActions(actions).loadSession('session-b');
+      await flushPromises();
+    });
+    sdkMocks.sessions.push(
+      createMockSession({
+        sessionId: 'session-b',
+        clientId: 'client-b',
+        replaySnapshot: {
+          compactedReplay: [
+            {
+              id: 1,
+              v: 1,
+              type: 'session_update',
+              promptId: 'prompt-b',
+              data: {
+                update: {
+                  sessionUpdate: 'user_message_chunk',
+                  content: { type: 'text', text: 'prompt' },
+                },
+              },
+            },
+            {
+              id: 4,
+              v: 1,
+              type: 'turn_complete',
+              promptId: 'prompt-b',
+              data: { promptId: 'prompt-b', stopReason: 'end_turn' },
+            },
+          ],
+          liveJournal: [],
+        },
+      }),
+    );
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    await act(async () => {
+      releaseTerminal.resolve();
+      await flushPromises();
+    });
+    await vi.waitFor(() =>
+      expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledOnce(),
+    );
+  });
+
+  it('coalesces load and resume for the same transactional target', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    sdkMocks.sessions.push(
+      createMockSession({ sessionId: 'session-a', clientId: 'client-a' }),
+    );
+    const target = createDeferred<MockSession>();
+    let actions: DaemonSessionActions | undefined;
+
+    function Harness() {
+      actions = useDaemonActions();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    sdkMocks.MockDaemonSessionClient.load.mockImplementation(
+      async () => target.promise,
+    );
+    let first!: Promise<void>;
+    let second!: Promise<void>;
+    act(() => {
+      first = requireActions(actions).loadSession('session-b');
+      second = requireActions(actions).resumeSession('session-b');
+    });
+    await act(async () => flushPromises());
+    expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      target.resolve(
+        createMockSession({ sessionId: 'session-b', clientId: 'client-b' }),
+      );
+      await Promise.all([first, second]);
+      await flushPromises();
+    });
+  });
+
+  it('rejects a malformed modern target without replacing the source', async () => {
+    const detachFetch = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(null, { status: 204 }),
+    );
+    vi.stubGlobal('fetch', detachFetch);
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    sdkMocks.sessions.push(
+      createMockSession({ sessionId: 'session-a', clientId: 'client-a' }),
+    );
+    let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(async () =>
+      createMockSession({ sessionId: 'session-b', clientId: '' }),
+    );
+    await act(async () => {
+      await expect(
+        requireActions(actions).loadSession('session-b'),
+      ).rejects.toThrow('invalid owner identity');
+      await flushPromises();
+    });
+
+    expect(connection).toMatchObject({
+      sessionId: 'session-a',
+      clientId: 'client-a',
+      sessionTransition: { phase: 'failed' },
+    });
+    expect(detachFetch).toHaveBeenCalledOnce();
+  });
+
+  it('fails closed when a modern source has no client identity', async () => {
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    sdkMocks.sessions.push(
+      createMockSession({ sessionId: 'session-a', clientId: '' }),
+    );
+    let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    await act(async () => {
+      await expect(
+        requireActions(actions).loadSession('session-b'),
+      ).rejects.toThrow('current session has no clientId');
+      await flushPromises();
+    });
+
+    expect(sdkMocks.MockDaemonSessionClient.load).not.toHaveBeenCalled();
+    expect(connection).toMatchObject({
+      status: 'connected',
+      sessionId: 'session-a',
+      sessionTransition: { phase: 'failed' },
+    });
+  });
+
+  it('runs only the latest queued transactional restore', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    sdkMocks.sessions.push(
+      createMockSession({ sessionId: 'session-a', clientId: 'client-a' }),
+    );
+    const targetB = createDeferred<MockSession>();
+    const targetD = createDeferred<MockSession>();
+    let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+    let activeRestores = 0;
+    let maxActiveRestores = 0;
+
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    sdkMocks.MockDaemonSessionClient.load.mockImplementation(
+      async (_client, sessionId) => {
+        activeRestores += 1;
+        maxActiveRestores = Math.max(maxActiveRestores, activeRestores);
+        try {
+          if (sessionId === 'session-b') return await targetB.promise;
+          if (sessionId === 'session-d') return await targetD.promise;
+          throw new Error(`Unexpected restore for ${sessionId}`);
+        } finally {
+          activeRestores -= 1;
+        }
+      },
+    );
+    let loadB!: Promise<unknown>;
+    let loadC!: Promise<unknown>;
+    let loadD!: Promise<void>;
+    act(() => {
+      loadB = requireActions(actions)
+        .loadSession('session-b')
+        .catch((error: unknown) => error);
+      loadC = requireActions(actions)
+        .loadSession('session-c')
+        .catch((error: unknown) => error);
+      loadD = requireActions(actions).loadSession('session-d');
+    });
+    await act(async () => flushPromises());
+    expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      targetB.resolve(
+        createMockSession({ sessionId: 'session-b', clientId: 'client-b' }),
+      );
+      await flushPromises();
+    });
+    expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(2);
+    expect(sdkMocks.MockDaemonSessionClient.load.mock.calls[1]?.[1]).toBe(
+      'session-d',
+    );
+
+    await act(async () => {
+      targetD.resolve(
+        createMockSession({ sessionId: 'session-d', clientId: 'client-d' }),
+      );
+      await loadD;
+      await flushPromises();
+    });
+    await expect(loadB).resolves.toMatchObject({ name: 'AbortError' });
+    await expect(loadC).resolves.toMatchObject({ name: 'AbortError' });
+    expect(maxActiveRestores).toBe(1);
+    expect(connection).toMatchObject({
+      status: 'connected',
+      sessionId: 'session-d',
+      clientId: 'client-d',
+    });
+  });
+
+  it('preserves A when a controlled transactional target fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    sdkMocks.sessions.push(
+      createMockSession({
+        sessionId: 'session-a',
+        clientId: 'client-a',
+        replaySnapshot: createTextReplaySnapshot('old transcript'),
+      }),
+    );
+    const target = createDeferred<MockSession>();
+    let blocks: readonly DaemonTranscriptBlock[] = [];
+    let connection: DaemonConnectionState | undefined;
+
+    function Harness() {
+      blocks = useDaemonTranscriptBlocks();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      sessionId: 'session-a',
+    });
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(
+      async () => target.promise,
+    );
+    act(() => {
+      root?.render(
+        <DaemonSessionProvider
+          baseUrl="http://127.0.0.1:4170"
+          autoConnect
+          sessionId="session-b"
+        >
+          <Harness />
+        </DaemonSessionProvider>,
+      );
+    });
+    await act(async () => flushPromises());
+    expect(connection).toMatchObject({
+      status: 'connected',
+      sessionId: 'session-a',
+      clientId: 'client-a',
+      sessionTransition: { phase: 'preparing' },
+    });
+
+    await act(async () => {
+      target.reject(new Error('controlled target failed'));
+      await flushPromises();
+    });
+    expect(connection).toMatchObject({
+      status: 'connected',
+      sessionId: 'session-a',
+      clientId: 'client-a',
+      sessionTransition: { phase: 'failed' },
+    });
+    expect(blocks).toMatchObject([
+      { kind: 'assistant', text: 'old transcript' },
+    ]);
+    expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      root?.render(
+        <DaemonSessionProvider
+          baseUrl="http://127.0.0.1:4170"
+          autoConnect
+          sessionId="session-a"
+        >
+          <Harness />
+        </DaemonSessionProvider>,
+      );
+      await flushPromises();
+    });
+    expect(connection?.sessionTransition).toBeUndefined();
+  });
+
+  it('cancels a pending controlled target when props return to A', async () => {
+    const detachFetch = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(null, { status: 204 }),
+    );
+    vi.stubGlobal('fetch', detachFetch);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    sdkMocks.sessions.push(
+      createMockSession({ sessionId: 'session-a', clientId: 'client-a' }),
+    );
+    const target = createDeferred<MockSession>();
+    let connection: DaemonConnectionState | undefined;
+    function Harness() {
+      connection = useDaemonConnection();
+      return null;
+    }
+    const renderControlled = (sessionId: string) =>
+      root?.render(
+        <DaemonSessionProvider
+          baseUrl="http://127.0.0.1:4170"
+          autoConnect
+          sessionId={sessionId}
+        >
+          <Harness />
+        </DaemonSessionProvider>,
+      );
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      sessionId: 'session-a',
+    });
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(
+      async () => target.promise,
+    );
+    await act(async () => {
+      renderControlled('session-b');
+      await flushPromises();
+    });
+    expect(connection?.sessionTransition?.targetSessionId).toBe('session-b');
+
+    await act(async () => {
+      renderControlled('session-a');
+      await flushPromises();
+    });
+    expect(connection).toMatchObject({
+      status: 'connected',
+      sessionId: 'session-a',
+      clientId: 'client-a',
+    });
+    expect(connection?.sessionTransition).toBeUndefined();
+
+    await act(async () => {
+      target.resolve(
+        createMockSession({ sessionId: 'session-b', clientId: 'client-b' }),
+      );
+      await flushPromises();
+    });
+    expect(connection).toMatchObject({
+      status: 'connected',
+      sessionId: 'session-a',
+      clientId: 'client-a',
+    });
+    expect(detachFetch).toHaveBeenCalledOnce();
+  });
+
   it('loads controlled sessionId changes', async () => {
     const nextSession = createDeferred<MockSession>();
     sdkMocks.sessions.push(
@@ -8780,10 +10701,9 @@ describe('DaemonSessionProvider', () => {
   });
 
   it('does not clear a deferred session created after an empty controlled render', async () => {
-    sdkMocks.sessions.push(
-      createMockSession({ sessionId: 'created-session' }),
-      createMockSession({ sessionId: 'created-session' }),
-    );
+    const created = createMockSession({ sessionId: 'created-session' });
+    const attached = createMockSession({ sessionId: 'created-session' });
+    sdkMocks.sessions.push(created, attached);
     let actions: DaemonSessionActions | undefined;
     let connection: DaemonConnectionState | undefined;
 
@@ -8805,6 +10725,23 @@ describe('DaemonSessionProvider', () => {
 
     expect(connection).toMatchObject({ sessionId: 'created-session' });
     expect(sdkMocks.MockDaemonSessionClient.createOrAttach).toHaveBeenCalled();
+
+    act(() => {
+      root?.render(
+        <DaemonSessionProvider
+          baseUrl="http://127.0.0.1:4170"
+          autoConnect
+          workspaceCwd="/next-workspace"
+        >
+          <Harness />
+        </DaemonSessionProvider>,
+      );
+    });
+    await act(async () => flushPromises());
+
+    expect(connection).toMatchObject({ sessionId: 'created-session' });
+    expect(created.detach).not.toHaveBeenCalled();
+    expect(attached.detach).not.toHaveBeenCalled();
   });
 
   it('does not retry a failed controlled session load until the host changes it', async () => {

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -25,7 +25,9 @@ import {
   matchTurnEvent,
   normalizeDaemonEvent,
   type CreateSessionRequest,
+  type DaemonCapabilities,
   type DaemonEvent,
+  type DaemonFollowupSuggestionData,
   type DaemonSseConnectReason,
   type DaemonTranscriptBlock,
   type DaemonTranscriptState,
@@ -36,6 +38,7 @@ import {
 import {
   createDaemonSessionActions,
   getPromptSettledKey,
+  normalizeWorkspaceIdentity,
   resolveSessionRestoreTimeouts,
 } from './actions.js';
 import {
@@ -76,6 +79,7 @@ import {
   type TimerRef,
 } from '../timing.js';
 import {
+  clearSidechannelFollowupSuggestion,
   parseSidechannelFollowupSuggestion,
   publishSidechannelFollowupSuggestion,
 } from '../followupSidechannel.js';
@@ -101,6 +105,7 @@ import type {
   DaemonSessionContextValue,
   DaemonSessionNotice,
   DaemonSessionProviderProps,
+  DaemonSessionOwnerGuard,
   DaemonWorkspaceEventSignals,
   PendingSessionLoad,
   SettledPrompt,
@@ -155,10 +160,307 @@ interface TranscriptHistoryMaterialization {
   toolBlockByCallId: Record<string, string>;
   permissionBlockByRequestId: Record<string, string>;
 }
-
+type TranscriptHistoryState = Omit<DaemonTranscriptHistory, 'loadMore'> & {
+  sessionId?: string;
+  beforeRecordId?: string;
+  cursor?: string;
+};
+interface SessionRunnerControl {
+  session?: DaemonSessionClient;
+  flush(): void;
+  stop(): void;
+}
+interface StagedCrossSession {
+  session: DaemonSessionClient;
+  capabilities: DaemonCapabilities;
+  connection: DaemonConnectionState;
+  transcript: DaemonTranscriptState;
+  history: TranscriptHistoryState;
+  signals: DaemonWorkspaceEventSignals;
+  notices: SessionNoticeInput[];
+  dismissNoticeIds: Set<string>;
+  followupSuggestion?: DaemonFollowupSuggestionData;
+  midTurnEvents: DaemonEvent[];
+  pendingPromptEvents: DaemonEvent[];
+  repair?: LiveJournalRepairEpisode;
+}
+interface CrossSessionTarget {
+  sessionId: string;
+  workspaceCwd?: string;
+  targetClientId?: string;
+  mode: 'load' | 'resume';
+  origin: 'action' | 'controlled';
+}
+interface CrossSessionIntent extends CrossSessionTarget {
+  key: string;
+  source: DaemonSessionClient;
+  baseUrl: string;
+  token?: string;
+  lifecycle: number;
+  environmentGeneration: number;
+  deadlineAt?: number;
+  timeout?: ReturnType<typeof setTimeout>;
+  retryAttempt?: number;
+  promise: Promise<void>;
+  resolve(): void;
+  reject(error: unknown): void;
+}
 const SESSION_TRANSCRIPT_PAGINATION_FEATURE = 'session_transcript_pagination';
+const CLIENT_IDENTITY_FEATURE = 'client_identity';
 const WORKSPACE_ACP_PREHEAT_FEATURE = 'workspace_acp_preheat';
 const WORKSPACE_ACP_STATUS_FEATURE = 'workspace_acp_status';
+const STAGING_BATCH_SIZE = 512;
+function crossSessionKey(
+  sessionId: string,
+  workspaceCwd: string | undefined,
+): string {
+  return `${sessionId}\0${normalizeWorkspaceIdentity(workspaceCwd)}`;
+}
+function transitionState(
+  target: CrossSessionTarget,
+  phase: 'queued' | 'preparing' | 'failed',
+  error?: NonNullable<DaemonConnectionState['sessionTransition']>['error'],
+): NonNullable<DaemonConnectionState['sessionTransition']> {
+  return {
+    phase,
+    operation: target.mode,
+    origin: target.origin,
+    targetSessionId: target.sessionId,
+    targetWorkspaceCwd: target.workspaceCwd,
+    targetClientId: target.targetClientId,
+    ...(error ? { error } : {}),
+  };
+}
+function settleCrossSessionIntent(
+  intent: CrossSessionIntent,
+  error?: unknown,
+): void {
+  if (intent.timeout !== undefined) clearTimeout(intent.timeout);
+  if (error === undefined) intent.resolve();
+  else intent.reject(error);
+}
+function findFirstPersistedRecordId(
+  session: DaemonSessionClient,
+): string | undefined {
+  for (const type of ['session_update', 'history_truncated'] as const) {
+    for (const events of [
+      session.replaySnapshot.compactedReplay,
+      session.replaySnapshot.liveJournal,
+    ]) {
+      for (const event of events) {
+        if (event.type !== type) continue;
+        const id = getPersistedReplayRecordId(event);
+        if (id !== undefined) return id;
+      }
+    }
+  }
+  return session.historyAnchorRecordId;
+}
+
+function stageCrossSession(input: {
+  session: DaemonSessionClient;
+  capabilities: DaemonCapabilities;
+  maxBlocks: number;
+  subagentTranscriptMode: 'full' | 'summary';
+  eventOptions: { suppressOwnUserEcho: boolean; includeRawEvent: boolean };
+}): StagedCrossSession {
+  const { session, capabilities, maxBlocks, subagentTranscriptMode } = input;
+  const notices: SessionNoticeInput[] = [];
+  const dismissNoticeIds = new Set<string>();
+  let noticeId = 0;
+  const addStagedNotice: AddDaemonSessionNotice = (notice) => {
+    const stagedNotice = {
+      ...notice,
+      id: notice.id ?? `staged-daemon-notice-${++noticeId}`,
+      createdAt: notice.createdAt ?? Date.now(),
+    };
+    const existingIndex = notices.findIndex(
+      (existing) => existing.id === stagedNotice.id,
+    );
+    if (!dismissNoticeIds.delete(stagedNotice.id) && existingIndex >= 0)
+      return stagedNotice;
+    if (existingIndex >= 0) notices.splice(existingIndex, 1);
+    notices.push(stagedNotice);
+    if (notices.length > 50) notices.shift();
+    return stagedNotice;
+  };
+  let connection: DaemonConnectionState = {
+    status: 'connected',
+    sessionId: session.sessionId,
+    ...(session.clientId ? { clientId: session.clientId } : {}),
+    workspaceCwd: session.workspaceCwd,
+    displayName: getSessionDisplayName(session.state),
+    capabilities,
+    catchingUp: session.lastEventId !== undefined ? true : undefined,
+  };
+  const updateConnection: Dispatch<SetStateAction<DaemonConnectionState>> = (
+    update,
+  ) => {
+    connection = typeof update === 'function' ? update(connection) : update;
+  };
+  let signals = { ...INITIAL_WORKSPACE_EVENT_SIGNALS };
+  const updateSignals: Dispatch<SetStateAction<DaemonWorkspaceEventSignals>> = (
+    update,
+  ) => {
+    signals = typeof update === 'function' ? update(signals) : update;
+  };
+  const shadow = createDaemonTranscriptStore({
+    maxBlocks: Number.MAX_SAFE_INTEGER,
+    retainSubagentBlocks: subagentTranscriptMode === 'full',
+  });
+  let transcriptBatch: DaemonUiEvent[] = [];
+  const repairTarget = findLiveJournalRepairTarget(
+    session.sessionId,
+    session.replaySnapshot.liveJournal,
+    session.lastEventId,
+    session.replayDegraded === true,
+  );
+  let repairCheckpoint: DaemonTranscriptState | undefined;
+  const midTurnEvents: DaemonEvent[] = [];
+  const pendingPromptEvents: DaemonEvent[] = [];
+  let followupSuggestion: DaemonFollowupSuggestionData | undefined;
+  const observedSnapshotEventIds = new Set<number>();
+  const flush = () => {
+    if (transcriptBatch.length === 0) return;
+    shadow.dispatch(transcriptBatch);
+    transcriptBatch = [];
+  };
+  const enqueueTranscript = (events: readonly DaemonUiEvent[]) => {
+    for (const uiEvent of events) {
+      transcriptBatch.push(uiEvent);
+      if (transcriptBatch.length === STAGING_BATCH_SIZE) flush();
+    }
+  };
+  const firstPersistedRecordId = findFirstPersistedRecordId(session);
+  const replayWasTruncated =
+    session.replaySnapshot.compactedReplay.some(
+      hasFullTranscriptBeforeReplay,
+    ) || session.replaySnapshot.liveJournal.some(hasFullTranscriptBeforeReplay);
+  const historyHasMore =
+    capabilities.features.includes(SESSION_TRANSCRIPT_PAGINATION_FEATURE) &&
+    (session.historyHasMore || replayWasTruncated) &&
+    firstPersistedRecordId !== undefined;
+  const replayOpts = {
+    ...input.eventOptions,
+    suppressOwnUserEcho: false,
+  };
+  const consume = (event: DaemonEvent) => {
+    try {
+      const normalized = normalizeAndFilterEvent(
+        event,
+        session.clientId,
+        replayOpts,
+        updateConnection,
+        { suppressLog: true },
+      );
+      bumpWorkspaceEventSignals(normalized, updateSignals);
+      let transcript = filterDaemonUiEventsForTranscript(
+        event,
+        normalized,
+        addStagedNotice,
+        (id) => dismissNoticeIds.add(id),
+        { hideHistoryTruncation: historyHasMore, suppressLogs: true },
+      );
+      if (subagentTranscriptMode === 'summary') {
+        transcript = projectMainTranscriptEvents(transcript);
+      }
+      enqueueTranscript(transcript);
+      if (event.type === 'turn_complete') {
+        enqueueTranscript([
+          assistantDoneFromTurnEvent(
+            event,
+            (event.data as DaemonTurnCompleteData | undefined)?.stopReason ??
+              'end_turn',
+          ),
+        ]);
+      } else if (event.type === 'turn_error') {
+        enqueueTranscript([assistantDoneFromTurnEvent(event, 'error')]);
+      }
+      if (parseSidechannelMidTurnInjected(event)) {
+        midTurnEvents.push(event);
+        if (midTurnEvents.length > 64) midTurnEvents.shift();
+      }
+      followupSuggestion =
+        parseSidechannelFollowupSuggestion(event) ?? followupSuggestion;
+      if (isPendingPromptEvent(event)) {
+        pendingPromptEvents.push(event);
+        if (pendingPromptEvents.length > 200) pendingPromptEvents.shift();
+      }
+    } catch (error) {
+      addStagedNotice({
+        severity: 'warning',
+        category: 'protocol',
+        operation: 'normalize_event',
+        code: 'daemon.replay_event_malformed',
+        message: 'Skipped malformed replay event',
+        debugMessage: error instanceof Error ? error.message : String(error),
+        recoverable: true,
+      });
+    }
+  };
+  for (const event of session.replaySnapshot.compactedReplay) consume(event);
+  for (const event of session.replaySnapshot.liveJournal) {
+    if (event.id !== undefined) observedSnapshotEventIds.add(event.id);
+    if (event === repairTarget?.marker) {
+      flush();
+      repairCheckpoint = shadow.getSnapshot();
+    }
+    consume(event);
+  }
+  flush();
+  const replayTokenUsage =
+    getReplayTokenUsage(session.replaySnapshot.liveJournal) ??
+    getReplayTokenUsage(session.replaySnapshot.compactedReplay);
+  connection = {
+    ...connection,
+    status: 'connected',
+    displayName: getSessionDisplayName(session.state),
+    tokenUsage: replayTokenUsage,
+    tokenCount: getTokenCountFromUsage(replayTokenUsage) ?? 0,
+    error: undefined,
+    errorStatus: undefined,
+    missingSession: false,
+    sessionTransition: undefined,
+  };
+  const transcript = shadow.getSnapshot();
+  const replayExceededCapacity = transcript.blocks.length > maxBlocks;
+  transcript.maxBlocks = Math.max(maxBlocks, transcript.blocks.length);
+  if (repairCheckpoint) repairCheckpoint.maxBlocks = transcript.maxBlocks;
+  const repair =
+    repairTarget && repairCheckpoint
+      ? {
+          sessionId: session.sessionId,
+          target: repairTarget,
+          checkpoint: repairCheckpoint,
+          observedSnapshotEventIds,
+          snapshotLastEventId: session.lastEventId ?? 0,
+          lastObservedEventId: session.lastEventId ?? 0,
+          terminalSeen: false,
+          attempted: false,
+        }
+      : undefined;
+  return {
+    session,
+    capabilities,
+    connection,
+    transcript,
+    history: {
+      sessionId: session.sessionId,
+      beforeRecordId: firstPersistedRecordId,
+      hasMore: historyHasMore && !replayExceededCapacity,
+      loading: false,
+      capacityReached: historyHasMore && replayExceededCapacity,
+      paginationError: false,
+    },
+    signals,
+    notices,
+    dismissNoticeIds,
+    ...(followupSuggestion ? { followupSuggestion } : {}),
+    midTurnEvents,
+    pendingPromptEvents,
+    ...(repair ? { repair } : {}),
+  };
+}
 
 function assistantDoneFromTurnEvent(
   event: DaemonEvent,
@@ -426,6 +728,9 @@ const DaemonSessionNoticesContext = createContext<
 const DaemonWorkspaceEventSignalsContext = createContext<
   DaemonWorkspaceEventSignals | undefined
 >(undefined);
+const DaemonSessionOwnerGuardContext = createContext<
+  DaemonSessionOwnerGuard | undefined
+>(undefined);
 /**
  * Subset of TERMINAL_SESSION_HTTP_STATUSES that represent **credential
  * failures** (vs session-not-found 404/410). Auth failures should NOT enter
@@ -492,12 +797,40 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
     heartbeatIntervalMs = 30_000,
     heartbeatFailureThreshold = 3,
     loadWarnings,
+    onSessionTransitionCommit,
     children,
   } = props;
   const workspace = useOptionalDaemonWorkspace();
   const resolvedBaseUrl = baseUrl ?? workspace?.baseUrl;
   const resolvedToken = token ?? workspace?.token;
   const resolvedWorkspaceCwd = workspaceCwd ?? workspace?.workspaceCwd;
+  const environmentRef = useRef({
+    baseUrl: resolvedBaseUrl,
+    token: resolvedToken,
+    client: workspace?.client,
+    clientId,
+    maxBlocks,
+    subagentTranscriptMode,
+    generation: 0,
+  });
+  if (
+    environmentRef.current.baseUrl !== resolvedBaseUrl ||
+    environmentRef.current.token !== resolvedToken ||
+    environmentRef.current.client !== workspace?.client ||
+    environmentRef.current.clientId !== clientId ||
+    environmentRef.current.maxBlocks !== maxBlocks ||
+    environmentRef.current.subagentTranscriptMode !== subagentTranscriptMode
+  ) {
+    environmentRef.current = {
+      baseUrl: resolvedBaseUrl,
+      token: resolvedToken,
+      client: workspace?.client,
+      clientId,
+      maxBlocks,
+      subagentTranscriptMode,
+      generation: environmentRef.current.generation + 1,
+    };
+  }
   const workspaceClientRef = useRef(workspace?.client);
   workspaceClientRef.current = workspace?.client;
   const workspaceCapabilitiesRef = useRef(workspace?.capabilities);
@@ -512,12 +845,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
   // sessionId prop changes are handled by the controlled-session effect below.
   const shouldDeferInitialSessionCreation =
     initialRestoreSessionId === undefined;
-  const resolvedWorkspaceCwdRef = useRef(resolvedWorkspaceCwd);
-  resolvedWorkspaceCwdRef.current = resolvedWorkspaceCwd;
   const activeWorkspaceCwdRef = useRef(resolvedWorkspaceCwd);
-  if (resolvedWorkspaceCwd) {
-    activeWorkspaceCwdRef.current = resolvedWorkspaceCwd;
-  }
 
   const store = useMemo(
     () =>
@@ -528,26 +856,32 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
     [maxBlocks, subagentTranscriptMode],
   );
   const sessionRef = useRef<DaemonSessionClient | undefined>(undefined);
-  const transcriptHistoryRef = useRef<{
-    sessionId?: string;
-    beforeRecordId?: string;
-    cursor?: string;
-    hasMore: boolean;
-    loading: boolean;
-    capacityReached: boolean;
-    paginationError: boolean;
-  }>({
+  const runnerControlRef = useRef<SessionRunnerControl | undefined>(undefined);
+  const preparedRunnerRef = useRef<StagedCrossSession | undefined>(undefined);
+  const desiredTransitionRef = useRef<CrossSessionIntent | undefined>(
+    undefined,
+  );
+  if (
+    !sessionRef.current &&
+    !desiredTransitionRef.current &&
+    resolvedWorkspaceCwd
+  ) {
+    activeWorkspaceCwdRef.current = resolvedWorkspaceCwd;
+  }
+  const rawTransitionRef = useRef<CrossSessionIntent | undefined>(undefined);
+  const pumpTransitionRef = useRef<() => void>(() => undefined);
+  const lifecycleRef = useRef(0);
+  const sourceBoundOperationCountRef = useRef(0);
+  const cancelTransitionRef = useRef<(reason: string) => void>(() => undefined);
+  const controlledTransitionOriginRef = useRef(false);
+  const transcriptHistoryRef = useRef<TranscriptHistoryState>({
     hasMore: false,
     loading: false,
     capacityReached: false,
     paginationError: false,
   });
-  const [transcriptHistoryState, setTranscriptHistoryState] = useState({
-    hasMore: false,
-    loading: false,
-    capacityReached: false,
-    paginationError: false,
-  });
+  const [transcriptHistoryState, setTranscriptHistoryState] =
+    useState<TranscriptHistoryState>(transcriptHistoryRef.current);
   const eventStreamRef = useRef<
     | {
         sessionId: string;
@@ -616,9 +950,19 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
   const [connection, setConnection] = useState<DaemonConnectionState>({
     status: autoConnect ? 'connecting' : 'idle',
     ...(initialRestoreSessionId ? { sessionId: initialRestoreSessionId } : {}),
+    ...(resolvedWorkspaceCwd ? { workspaceCwd: resolvedWorkspaceCwd } : {}),
   });
   const connectionRef = useRef(connection);
   connectionRef.current = connection;
+  const setConnectionSynchronous = useCallback(
+    (update: SetStateAction<DaemonConnectionState>) => {
+      const next =
+        typeof update === 'function' ? update(connectionRef.current) : update;
+      connectionRef.current = next;
+      setConnection(next);
+    },
+    [],
+  );
   useEffect(() => {
     if (!workspace?.capabilities) return;
     setConnection((current) =>
@@ -660,14 +1004,31 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
     useState<DaemonWorkspaceEventSignals>(INITIAL_WORKSPACE_EVENT_SIGNALS);
   const hasCurrentSessionActivePromptRef = useRef<() => boolean>(() => false);
   const mountedRef = useRef(false);
+  const mountGenerationRef = useRef(0);
 
   useEffect(() => {
+    const generation = ++mountGenerationRef.current;
+    const mountGeneration = mountGenerationRef;
     mountedRef.current = true;
     return () => {
       mountedRef.current = false;
-      liveJournalRepairRef.current?.controller?.abort();
-      liveJournalRepairRef.current = undefined;
-      tryLiveJournalRepairRef.current = undefined;
+      queueMicrotask(() => {
+        if (mountedRef.current || mountGeneration.current !== generation) {
+          return;
+        }
+        lifecycleRef.current += 1;
+        const intent = desiredTransitionRef.current;
+        desiredTransitionRef.current = undefined;
+        if (intent) {
+          if (intent.timeout !== undefined) clearTimeout(intent.timeout);
+          intent.reject(
+            new DOMException('Session transition interrupted', 'AbortError'),
+          );
+        }
+        liveJournalRepairRef.current?.controller?.abort();
+        liveJournalRepairRef.current = undefined;
+        tryLiveJournalRepairRef.current = undefined;
+      });
     };
   }, []);
 
@@ -762,6 +1123,12 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
       cancelTranscriptFlush();
       pendingTranscriptEvents = [];
     };
+    const runnerControl: SessionRunnerControl = {
+      session: runnerSession,
+      flush: flushTranscriptSync,
+      stop: () => abort.abort(),
+    };
+    runnerControlRef.current = runnerControl;
     const tryLiveJournalRepair = () => {
       if (disposed || abort.signal.aborted) return;
       const repair = liveJournalRepairRef.current;
@@ -770,6 +1137,8 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
         repair.attempted ||
         !repair.terminalSeen ||
         pendingSessionLoadRef.current ||
+        desiredTransitionRef.current ||
+        rawTransitionRef.current ||
         transcriptHistoryRef.current.loading ||
         sessionRef.current?.sessionId !== repair.sessionId ||
         hasCurrentSessionActivePromptRef.current()
@@ -806,10 +1175,17 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
       const client =
         workspaceClientRef.current ??
         new DaemonClient({ baseUrl: resolvedBaseUrl!, token: resolvedToken });
-      let session: DaemonSessionClient | undefined;
+      let prepared =
+        preparedRunnerRef.current?.session === sessionRef.current
+          ? preparedRunnerRef.current
+          : undefined;
+      if (preparedRunnerRef.current === prepared) {
+        preparedRunnerRef.current = undefined;
+      }
+      let session: DaemonSessionClient | undefined = prepared?.session;
       let capabilities:
         | Awaited<ReturnType<DaemonClient['capabilities']>>
-        | undefined;
+        | undefined = prepared?.capabilities;
       let reconnectSessionId = restoreSessionId;
       let shouldCreateFreshSession =
         !manualSessionClearRef.current &&
@@ -923,7 +1299,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
               caps.features.includes('client_heartbeat');
             const effectWorkspaceCwd =
               restoreWorkspaceCwd ??
-              resolvedWorkspaceCwdRef.current ??
+              activeWorkspaceCwdRef.current ??
               caps.workspaceCwd;
             activeWorkspaceCwdRef.current = effectWorkspaceCwd;
             const capabilityFeatures = Array.isArray(caps.features)
@@ -1307,6 +1683,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
 
           const activeSession = session;
           runnerSession = activeSession;
+          runnerControl.session = activeSession;
           // Prompt activity is session state returned by /load. Surface it
           // immediately so a refreshed page shows the running state without
           // waiting for auxiliary data such as providers, commands, or context.
@@ -1354,7 +1731,11 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           // The deferred store.reset() runs here — in the same synchronous
           // block as store.dispatch() — so the queueMicrotask notification
           // only fires once with the fully-populated state.
-          const { compactedReplay, liveJournal } = activeSession.replaySnapshot;
+          const preparedHandoff = prepared !== undefined;
+          const { compactedReplay, liveJournal } = preparedHandoff
+            ? { compactedReplay: [], liveJournal: [] }
+            : activeSession.replaySnapshot;
+          prepared = undefined;
           const replayEvents = [...compactedReplay, ...liveJournal];
           const markerStillVisible =
             repairingEpisode?.markerBlockId !== undefined &&
@@ -1387,15 +1768,17 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           const replayHistoryWasTruncated = replayEvents.some(
             hasFullTranscriptBeforeReplay,
           );
-          const historyHasMore = repairingEpisode
+          const historyHasMore = preparedHandoff
             ? transcriptHistoryRef.current.hasMore
-            : Array.isArray(capabilities?.features) &&
-              capabilities.features.includes(
-                SESSION_TRANSCRIPT_PAGINATION_FEATURE,
-              ) &&
-              (activeSession.historyHasMore || replayHistoryWasTruncated) &&
-              firstPersistedRecordId !== undefined;
-          if (!repairingEpisode) {
+            : repairingEpisode
+              ? transcriptHistoryRef.current.hasMore
+              : Array.isArray(capabilities?.features) &&
+                capabilities.features.includes(
+                  SESSION_TRANSCRIPT_PAGINATION_FEATURE,
+                ) &&
+                (activeSession.historyHasMore || replayHistoryWasTruncated) &&
+                firstPersistedRecordId !== undefined;
+          if (!repairingEpisode && !preparedHandoff) {
             transcriptHistoryRef.current = {
               sessionId: activeSession.sessionId,
               ...(firstPersistedRecordId !== undefined
@@ -1885,6 +2268,9 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           let sawEvent = false;
           let resyncRequested = false;
           const requestEpochResetReload = () => {
+            cancelTransitionRef.current(
+              'Session transition cancelled by state resync',
+            );
             // An epoch reset means the daemon/EventBus timeline was rebuilt.
             // The current SSE cursor and any restored/local prompt activity may
             // describe the old epoch, so do a full /load and let
@@ -2187,6 +2573,9 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                     ? (event.data as Record<string, unknown>).reason
                     : undefined;
                 if (reason !== 'epoch_reset') {
+                  cancelTransitionRef.current(
+                    'Session transition cancelled by state resync',
+                  );
                   // Resync asks us to rebuild transcript state, but it is not a
                   // prompt terminal signal. Keep loading alive for local/restored
                   // prompts until turn_complete, turn_error, or prompt_cancelled.
@@ -2371,20 +2760,11 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
             error instanceof Error ? error.message : String(error);
           const errorStatus = extractHttpStatus(error);
           const pendingLoad = pendingSessionLoadRef.current;
-          const errorBody =
-            error instanceof DaemonHttpError && isRecord(error.body)
-              ? error.body
-              : undefined;
           if (
             autoReconnect &&
             loadingRequestedSession &&
             pendingLoad?.sessionId === restoreSessionId &&
-            error instanceof DaemonHttpError &&
-            error.status === 404 &&
-            typeof errorBody?.['error'] === 'string' &&
-            errorBody['error'].endsWith(
-              'The session is closing; retry after close completes',
-            )
+            isClosingSessionLoadError(error)
           ) {
             reconnectAttempt += 1;
             const reconnectConfig = reconnectConfigRef.current;
@@ -2569,16 +2949,18 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
     void run();
     return () => {
       const session = runnerSession;
+      if (desiredTransitionRef.current && sessionRef.current === session) {
+        cancelTransitionRef.current('Session runner restarted');
+      }
+      if (runnerControlRef.current === runnerControl) {
+        runnerControlRef.current = undefined;
+      }
       disposed = true;
       abort.abort();
       const ownsCurrentSession =
         session !== undefined && sessionRef.current === session;
       const ownsEmptyState =
         session === undefined && sessionRef.current === undefined;
-      const keepSessionForNextEffect =
-        ownsCurrentSession &&
-        session === skipNextCleanupDetachSessionRef.current;
-      const isUnmounting = !mountedRef.current;
       if (ownsCurrentSession || ownsEmptyState) {
         // A same-attachment effect restart must flush events already yielded by
         // the SSE client, because its resume cursor has advanced past them.
@@ -2588,41 +2970,62 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
         // runner's pending macrotask append its buffered events to that owner.
         clearPendingTranscriptEvents();
       }
-      if (ownsCurrentSession && (!keepSessionForNextEffect || isUnmounting)) {
-        hasCurrentSessionActivePromptRef.current = () => false;
-        setPromptStatus('idle');
-        clearPassiveAssistantDoneTimer(passiveAssistantDoneTimerRef);
-      }
-      if (
-        effectPendingSessionLoad !== undefined &&
-        pendingSessionLoadRef.current === effectPendingSessionLoad &&
-        (ownsCurrentSession || ownsEmptyState) &&
-        (!keepSessionForNextEffect || isUnmounting)
-      ) {
-        if (pendingSessionLoadRef.current.timeout !== undefined) {
-          clearTimeout(pendingSessionLoadRef.current.timeout);
+      const releaseOwnedSession = (unmounting: boolean) => {
+        const ownedSession = unmounting ? sessionRef.current : session;
+        const stillOwnsSession =
+          ownedSession !== undefined && sessionRef.current === ownedSession;
+        const stillOwnsEmptyState =
+          session === undefined && sessionRef.current === undefined;
+        if (!stillOwnsSession && !stillOwnsEmptyState) return;
+        const keepSessionForNextEffect =
+          !unmounting &&
+          stillOwnsSession &&
+          ownedSession === skipNextCleanupDetachSessionRef.current;
+        if (keepSessionForNextEffect) return;
+        if (stillOwnsSession) {
+          hasCurrentSessionActivePromptRef.current = () => false;
+          setPromptStatus('idle');
+          clearPassiveAssistantDoneTimer(passiveAssistantDoneTimerRef);
         }
-        pendingSessionLoadRef.current.reject(
-          new DOMException('Session load interrupted by cleanup', 'AbortError'),
-        );
-        pendingSessionLoadRef.current = undefined;
-      }
-      if (
-        ownsCurrentSession &&
-        (!keepSessionForNextEffect || isUnmounting) &&
-        session.clientId
-      ) {
-        void detachDaemonClient({
-          baseUrl: resolvedBaseUrl!,
-          token: resolvedToken,
-          sessionId: session.sessionId,
-          clientId: session.clientId,
-        }).catch((err) =>
-          console.warn('[DaemonSessionProvider] detach failed:', err),
-        );
-      }
-      if (ownsCurrentSession && (!keepSessionForNextEffect || isUnmounting)) {
-        sessionRef.current = undefined;
+        const pendingLoad = pendingSessionLoadRef.current;
+        if (
+          pendingLoad &&
+          (unmounting || pendingLoad === effectPendingSessionLoad) &&
+          (stillOwnsEmptyState ||
+            (stillOwnsSession &&
+              ownedSession.sessionId === pendingLoad.sessionId))
+        ) {
+          if (pendingLoad.timeout !== undefined) {
+            clearTimeout(pendingLoad.timeout);
+          }
+          pendingLoad.reject(
+            new DOMException(
+              'Session load interrupted by cleanup',
+              'AbortError',
+            ),
+          );
+          pendingSessionLoadRef.current = undefined;
+        }
+        if (stillOwnsSession) {
+          if (ownedSession.clientId) {
+            void detachDaemonClient({
+              baseUrl: resolvedBaseUrl!,
+              token: resolvedToken,
+              sessionId: ownedSession.sessionId,
+              clientId: ownedSession.clientId,
+            }).catch((err) =>
+              console.warn('[DaemonSessionProvider] detach failed:', err),
+            );
+          }
+          sessionRef.current = undefined;
+        }
+      };
+      if (!mountedRef.current) {
+        queueMicrotask(() => {
+          if (!mountedRef.current) releaseOwnedSession(true);
+        });
+      } else {
+        releaseOwnedSession(false);
       }
     };
   }, [
@@ -2630,7 +3033,6 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
     autoReconnect,
     resolvedBaseUrl,
     resolvedToken,
-    workspaceCwd,
     modelServiceId,
     sessionScope,
     maxQueued,
@@ -2795,6 +3197,477 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
     heartbeatIntervalMs,
   ]);
 
+  const publishCrossSessionFailure = useCallback(
+    (target: CrossSessionTarget, error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      const status = extractHttpStatus(error);
+      const code =
+        error instanceof DaemonHttpError &&
+        isRecord(error.body) &&
+        typeof error.body['code'] === 'string'
+          ? error.body['code']
+          : undefined;
+      setConnectionSynchronous((current) => ({
+        ...current,
+        sessionTransition: transitionState(target, 'failed', {
+          message,
+          ...(code !== undefined ? { code } : {}),
+          ...(status !== undefined ? { status } : {}),
+        }),
+      }));
+      addNotice({
+        severity: 'warning',
+        category: 'connection',
+        operation: target.mode === 'resume' ? 'resume_session' : 'load_session',
+        code: 'daemon.session_transition.failed',
+        message: `Could not open session ${target.sessionId}. The current session is still active.`,
+        debugMessage: message,
+        recoverable: true,
+      });
+    },
+    [addNotice, setConnectionSynchronous],
+  );
+
+  const exposeCrossSessionFailure = useCallback(
+    (intent: CrossSessionIntent, error: unknown) => {
+      if (desiredTransitionRef.current !== intent) return;
+      desiredTransitionRef.current = undefined;
+      if (mountedRef.current) publishCrossSessionFailure(intent, error);
+      settleCrossSessionIntent(intent, error);
+    },
+    [publishCrossSessionFailure],
+  );
+
+  const retireAttachment = useCallback(
+    (session: DaemonSessionClient, intent: CrossSessionIntent) => {
+      const clientId = session.clientId || intent.targetClientId;
+      if (!clientId) return;
+      void detachDaemonClient({
+        baseUrl: intent.baseUrl,
+        token: intent.token,
+        sessionId: session.sessionId || intent.sessionId,
+        clientId,
+      }).catch((error: unknown) => {
+        console.warn('[DaemonSessionProvider] detach failed:', error);
+      });
+    },
+    [],
+  );
+
+  const commitCrossSession = useCallback(
+    (intent: CrossSessionIntent, staged: StagedCrossSession): boolean => {
+      if (
+        !mountedRef.current ||
+        desiredTransitionRef.current !== intent ||
+        intent.lifecycle !== lifecycleRef.current ||
+        intent.environmentGeneration !== environmentRef.current.generation ||
+        (intent.deadlineAt !== undefined && Date.now() >= intent.deadlineAt)
+      ) {
+        return false;
+      }
+      const current = sessionRef.current;
+      if (
+        current !== undefined &&
+        (!current.clientId ||
+          current.sessionId !== intent.source.sessionId ||
+          normalizeWorkspaceIdentity(current.workspaceCwd) !==
+            normalizeWorkspaceIdentity(intent.source.workspaceCwd))
+      ) {
+        return false;
+      }
+      const sourceToRetire = current ?? intent.source;
+      if (intent.timeout !== undefined) clearTimeout(intent.timeout);
+      if (runnerControlRef.current?.session === sourceToRetire) {
+        runnerControlRef.current.flush();
+        runnerControlRef.current.stop();
+      }
+      store.reset(staged.transcript);
+      transcriptHistoryRef.current = staged.history;
+      setTranscriptHistoryState({
+        hasMore: staged.history.hasMore,
+        loading: false,
+        capacityReached: staged.history.capacityReached,
+        paginationError: false,
+      });
+      sessionRef.current = staged.session;
+      lastSessionIdRef.current = staged.session.sessionId;
+      activeWorkspaceCwdRef.current = staged.session.workspaceCwd;
+      clientIdRef.current = staged.session.clientId;
+      persistStableClientId(staged.session.clientId!, staged.session.sessionId);
+      setConnectionSynchronous(staged.connection);
+      desiredTransitionRef.current = undefined;
+      try {
+        onSessionTransitionCommit?.({
+          sessionId: staged.session.sessionId,
+          workspaceCwd: staged.session.workspaceCwd,
+        });
+      } catch (error) {
+        console.warn('[DaemonSessionProvider] commit observer failed:', error);
+      }
+      clearSidechannelFollowupSuggestion();
+      if (staged.followupSuggestion) {
+        publishSidechannelFollowupSuggestion(staged.followupSuggestion);
+      }
+      clearNotices();
+      for (const notice of staged.notices) addNotice(notice);
+      for (const id of staged.dismissNoticeIds) dismissNotice(id);
+      setWorkspaceEventSignals((currentSignals) => ({
+        memoryVersion:
+          currentSignals.memoryVersion + staged.signals.memoryVersion,
+        agentsVersion:
+          currentSignals.agentsVersion + staged.signals.agentsVersion,
+        toolsVersion: currentSignals.toolsVersion + staged.signals.toolsVersion,
+        settingsVersion:
+          currentSignals.settingsVersion + staged.signals.settingsVersion,
+        mcpVersion: currentSignals.mcpVersion + staged.signals.mcpVersion,
+        extensionsVersion:
+          currentSignals.extensionsVersion + staged.signals.extensionsVersion,
+        artifactsVersion:
+          currentSignals.artifactsVersion + staged.signals.artifactsVersion,
+        initVersion: currentSignals.initVersion + staged.signals.initVersion,
+        authVersion: currentSignals.authVersion + staged.signals.authVersion,
+        ...(staged.signals.lastExtensionChange
+          ? { lastExtensionChange: staged.signals.lastExtensionChange }
+          : {}),
+      }));
+      for (const event of staged.midTurnEvents) {
+        const injected = parseSidechannelMidTurnInjected(event);
+        if (injected) publishSidechannelMidTurnInjected(injected);
+      }
+      for (const event of staged.pendingPromptEvents) {
+        publishPendingPromptEvent(event);
+      }
+      const active = activePromptsRef.current.get(sourceToRetire.sessionId);
+      active?.controller.abort(
+        new DOMException(
+          'Session switch interrupted prompt wait',
+          'AbortError',
+        ),
+      );
+      activePromptsRef.current.delete(sourceToRetire.sessionId);
+      settledPromptsRef.current.clear();
+      hasCurrentSessionActivePromptRef.current = () =>
+        staged.session.hasActivePrompt === true;
+      setPromptStatus(staged.session.hasActivePrompt ? 'streaming' : 'idle');
+      liveJournalRepairRef.current?.controller?.abort();
+      liveJournalRepairRef.current = staged.repair;
+      preparedRunnerRef.current = staged;
+      manualSessionClearRef.current = false;
+      setRestoreMode(intent.mode);
+      setRestoreSessionId(staged.session.sessionId);
+      setRestoreWorkspaceCwd(staged.session.workspaceCwd);
+      setRestoreSessionNonce((nonce) => nonce + 1);
+      settleCrossSessionIntent(intent);
+      retireAttachment(sourceToRetire, intent);
+      return true;
+    },
+    [
+      addNotice,
+      clearNotices,
+      dismissNotice,
+      onSessionTransitionCommit,
+      retireAttachment,
+      setConnectionSynchronous,
+      store,
+    ],
+  );
+
+  const pumpCrossSessionTransition = useCallback(() => {
+    if (rawTransitionRef.current) return;
+    const intent = desiredTransitionRef.current;
+    if (!intent) return;
+    if (
+      intent.lifecycle !== lifecycleRef.current ||
+      intent.environmentGeneration !== environmentRef.current.generation
+    ) {
+      exposeCrossSessionFailure(
+        intent,
+        new DOMException(
+          'Session transition environment changed',
+          'AbortError',
+        ),
+      );
+      return;
+    }
+    if (intent.deadlineAt !== undefined && Date.now() >= intent.deadlineAt) {
+      exposeCrossSessionFailure(
+        intent,
+        new Error('Session transition timed out before restore started'),
+      );
+      return;
+    }
+    const capabilities =
+      workspaceCapabilitiesRef.current ?? connectionRef.current.capabilities;
+    if (!capabilities?.features.includes(CLIENT_IDENTITY_FEATURE)) return;
+    const requestClientId = getStableClientId(clientId, intent.sessionId);
+    intent.targetClientId = requestClientId;
+    rawTransitionRef.current = intent;
+    setConnectionSynchronous((current) => ({
+      ...current,
+      sessionTransition: transitionState(intent, 'preparing'),
+    }));
+    const client =
+      workspaceClientRef.current ??
+      new DaemonClient({ baseUrl: resolvedBaseUrl!, token: resolvedToken });
+    const remaining =
+      intent.deadlineAt === undefined
+        ? undefined
+        : Math.max(1, intent.deadlineAt - Date.now());
+    const requestBudget =
+      resolveSessionRestoreTimeouts(capabilities).requestTimeoutMs;
+    const timeoutMs =
+      requestBudget === 0
+        ? (remaining ?? 0)
+        : remaining === undefined
+          ? requestBudget
+          : Math.min(requestBudget, remaining);
+    const restore =
+      intent.mode === 'resume'
+        ? DaemonSessionClient.resume
+        : DaemonSessionClient.load;
+    let retryScheduled = false;
+    void restore(
+      client,
+      intent.sessionId,
+      {
+        workspaceCwd: intent.workspaceCwd,
+        timeoutMs,
+        ...(intent.mode === 'load' &&
+        historyPageSizeRef.current !== undefined &&
+        capabilities.features.includes(SESSION_TRANSCRIPT_PAGINATION_FEATURE)
+          ? { historyPageSize: historyPageSizeRef.current }
+          : {}),
+      },
+      requestClientId,
+    )
+      .then((candidate) => {
+        const latest = desiredTransitionRef.current;
+        if (
+          !candidate.clientId ||
+          candidate.sessionId !== intent.sessionId ||
+          normalizeWorkspaceIdentity(candidate.workspaceCwd) !==
+            normalizeWorkspaceIdentity(intent.workspaceCwd)
+        ) {
+          retireAttachment(candidate, intent);
+          if (latest === intent) {
+            exposeCrossSessionFailure(
+              latest,
+              new Error('Session restore returned an invalid owner identity'),
+            );
+          }
+          return;
+        }
+        if (
+          latest?.key !== intent.key ||
+          latest?.environmentGeneration !== intent.environmentGeneration
+        ) {
+          retireAttachment(candidate, intent);
+          return;
+        }
+        let staged: StagedCrossSession;
+        try {
+          staged = stageCrossSession({
+            session: candidate,
+            capabilities,
+            maxBlocks,
+            subagentTranscriptMode: subagentTranscriptModeRef.current,
+            eventOptions: eventOptionsRef.current,
+          });
+        } catch (error) {
+          retireAttachment(candidate, intent);
+          exposeCrossSessionFailure(latest, error);
+          return;
+        }
+        if (!commitCrossSession(latest, staged)) {
+          retireAttachment(candidate, intent);
+          exposeCrossSessionFailure(
+            latest,
+            new DOMException(
+              'Session transition became stale before commit',
+              'AbortError',
+            ),
+          );
+        }
+      })
+      .catch((error: unknown) => {
+        const latest = desiredTransitionRef.current;
+        if (
+          autoReconnect &&
+          latest === intent &&
+          isClosingSessionLoadError(error)
+        ) {
+          retryScheduled = true;
+          intent.retryAttempt = (intent.retryAttempt ?? 0) + 1;
+          const reconnectConfig = reconnectConfigRef.current;
+          setTimeout(
+            pumpTransitionRef.current,
+            getReconnectDelayMs(
+              intent.retryAttempt,
+              reconnectConfig.reconnectDelayMs,
+              reconnectConfig.maxReconnectDelayMs,
+            ),
+          );
+        } else if (latest === intent) {
+          exposeCrossSessionFailure(latest, error);
+        }
+      })
+      .finally(() => {
+        if (rawTransitionRef.current === intent) {
+          rawTransitionRef.current = undefined;
+        }
+        if (!retryScheduled) pumpTransitionRef.current();
+      });
+  }, [
+    autoReconnect,
+    clientId,
+    commitCrossSession,
+    exposeCrossSessionFailure,
+    maxBlocks,
+    resolvedBaseUrl,
+    resolvedToken,
+    retireAttachment,
+    setConnectionSynchronous,
+  ]);
+  pumpTransitionRef.current = pumpCrossSessionTransition;
+
+  const cancelCrossSessionTransition = useCallback(
+    (reason: string) => {
+      lifecycleRef.current += 1;
+      const intent = desiredTransitionRef.current;
+      desiredTransitionRef.current = undefined;
+      if (intent) {
+        settleCrossSessionIntent(
+          intent,
+          new DOMException(reason, 'AbortError'),
+        );
+      }
+      setConnectionSynchronous((current) => {
+        if (!current.sessionTransition) return current;
+        const next = { ...current };
+        delete next.sessionTransition;
+        return next;
+      });
+    },
+    [setConnectionSynchronous],
+  );
+  cancelTransitionRef.current = cancelCrossSessionTransition;
+
+  const beginCrossSessionTransition = useCallback(
+    (
+      request: CrossSessionTarget,
+      startLegacy: () => Promise<void>,
+    ): Promise<void> => {
+      const capabilities =
+        workspaceCapabilitiesRef.current ?? connectionRef.current.capabilities;
+      const rejectPreflight = (error: Error) => {
+        publishCrossSessionFailure(request, error);
+        return Promise.reject(error);
+      };
+      if (!capabilities) {
+        return rejectPreflight(
+          new Error(
+            'Daemon capabilities are unavailable; current session was preserved',
+          ),
+        );
+      }
+      if (!capabilities.features.includes(CLIENT_IDENTITY_FEATURE)) {
+        return startLegacy();
+      }
+      if (!resolvedBaseUrl) {
+        return rejectPreflight(
+          new Error(
+            'Daemon endpoint is unavailable; current session was preserved',
+          ),
+        );
+      }
+      const source = sessionRef.current;
+      if (!source?.clientId) {
+        return rejectPreflight(
+          new Error(
+            'The daemon advertises client identity but the current session has no clientId',
+          ),
+        );
+      }
+      if (sourceBoundOperationCountRef.current > 0) {
+        return rejectPreflight(
+          new DOMException(
+            'Another session operation is already in progress',
+            'InvalidStateError',
+          ),
+        );
+      }
+      if (pendingSessionLoadRef.current) {
+        return rejectPreflight(
+          new DOMException(
+            'Another session restore is already in progress',
+            'InvalidStateError',
+          ),
+        );
+      }
+      const key = crossSessionKey(request.sessionId, request.workspaceCwd);
+      const current = desiredTransitionRef.current;
+      if (current?.key === key) return current.promise;
+      if (current) {
+        settleCrossSessionIntent(
+          current,
+          new DOMException(
+            'Session transition superseded by a newer request',
+            'AbortError',
+          ),
+        );
+      }
+      let resolve!: () => void;
+      let reject!: (error: unknown) => void;
+      const promise = new Promise<void>((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+      const timeouts = resolveSessionRestoreTimeouts(capabilities);
+      const deadlineAt =
+        timeouts.watchdogTimeoutMs === undefined
+          ? undefined
+          : Date.now() + timeouts.watchdogTimeoutMs;
+      const intent: CrossSessionIntent = {
+        key,
+        ...request,
+        source,
+        baseUrl: resolvedBaseUrl,
+        token: resolvedToken,
+        lifecycle: lifecycleRef.current,
+        environmentGeneration: environmentRef.current.generation,
+        ...(deadlineAt !== undefined ? { deadlineAt } : {}),
+        promise,
+        resolve,
+        reject,
+      };
+      if (timeouts.watchdogTimeoutMs !== undefined) {
+        intent.timeout = setTimeout(() => {
+          exposeCrossSessionFailure(
+            intent,
+            new Error('Session transition timed out'),
+          );
+        }, timeouts.watchdogTimeoutMs);
+      }
+      desiredTransitionRef.current = intent;
+      setConnectionSynchronous((connectionState) => ({
+        ...connectionState,
+        sessionTransition: transitionState(
+          request,
+          rawTransitionRef.current ? 'queued' : 'preparing',
+        ),
+      }));
+      pumpTransitionRef.current();
+      return promise;
+    },
+    [
+      exposeCrossSessionFailure,
+      publishCrossSessionFailure,
+      resolvedBaseUrl,
+      resolvedToken,
+      setConnectionSynchronous,
+    ],
+  );
+
   const actions = useMemo<DaemonSessionActions>(
     () =>
       createDaemonSessionActions({
@@ -2878,6 +3751,17 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
         setRestoreSessionNonce,
         setAttachSessionNonce,
         setNewSessionNonce,
+        beginCrossSessionTransition,
+        cancelCrossSessionTransition,
+        isCrossSessionTransitionPending: () =>
+          desiredTransitionRef.current !== undefined,
+        setSourceBoundOperationInFlight: (inFlight) =>
+          (sourceBoundOperationCountRef.current += inFlight ? 1 : -1),
+        getTransitionOrigin: () => {
+          const controlled = controlledTransitionOriginRef.current;
+          controlledTransitionOriginRef.current = false;
+          return controlled ? 'controlled' : 'action';
+        },
         clearLiveJournalRepair: () => {
           liveJournalRepairRef.current?.controller?.abort();
           liveJournalRepairRef.current = undefined;
@@ -2885,6 +3769,8 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
       }),
     [
       addNotice,
+      beginCrossSessionTransition,
+      cancelCrossSessionTransition,
       clientId,
       resolvedBaseUrl,
       resolvedToken,
@@ -3102,16 +3988,60 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
   const lastHandledSessionIdRef = useRef<
     string | undefined | typeof UNHANDLED_SESSION
   >(UNHANDLED_SESSION);
+  const lastHandledWorkspaceRef = useRef<string | undefined>(undefined);
 
   useEffect(() => {
-    if (lastHandledSessionIdRef.current === sessionId) return;
+    const targetWorkspaceCwd =
+      resolvedWorkspaceCwd ?? connectionRef.current.workspaceCwd;
+    const previousSessionId = lastHandledSessionIdRef.current;
+    if (
+      lastHandledSessionIdRef.current === sessionId &&
+      normalizeWorkspaceIdentity(lastHandledWorkspaceRef.current) ===
+        normalizeWorkspaceIdentity(targetWorkspaceCwd)
+    ) {
+      return;
+    }
     lastHandledSessionIdRef.current = sessionId;
+    lastHandledWorkspaceRef.current = targetWorkspaceCwd;
+
+    if (sessionId === undefined && previousSessionId === undefined) return;
+
+    const pending = desiredTransitionRef.current;
+    if (
+      pending &&
+      (pending.sessionId !== sessionId ||
+        normalizeWorkspaceIdentity(pending.workspaceCwd) !==
+          normalizeWorkspaceIdentity(targetWorkspaceCwd))
+    ) {
+      cancelTransitionRef.current(
+        'Session transition cancelled by controlled target change',
+      );
+    }
 
     const currentSessionId = connectionRef.current.sessionId;
-    if (sessionId === currentSessionId) return;
+    if (
+      sessionId === currentSessionId &&
+      normalizeWorkspaceIdentity(targetWorkspaceCwd) ===
+        normalizeWorkspaceIdentity(connectionRef.current.workspaceCwd)
+    ) {
+      if (connectionRef.current.sessionTransition?.phase === 'failed') {
+        setConnectionSynchronous((current) => {
+          if (current.sessionTransition?.phase !== 'failed') return current;
+          const next = { ...current };
+          delete next.sessionTransition;
+          return next;
+        });
+      }
+      return;
+    }
 
+    if (sessionId) controlledTransitionOriginRef.current = true;
     const request = sessionId
-      ? actions.loadSession(sessionId)
+      ? actions.loadSession(sessionId, {
+          ...(targetWorkspaceCwd !== undefined
+            ? { workspaceCwd: targetWorkspaceCwd }
+            : {}),
+        })
       : currentSessionId
         ? actions.clearSession()
         : undefined;
@@ -3124,7 +4054,17 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
         error,
       );
     });
-  }, [actions, sessionId]);
+  }, [actions, resolvedWorkspaceCwd, sessionId, setConnectionSynchronous]);
+
+  const ownerGuardValue = useMemo<DaemonSessionOwnerGuard>(
+    () => ({
+      capture: () => {
+        const session = sessionRef.current;
+        return { isCurrent: () => sessionRef.current === session };
+      },
+    }),
+    [],
+  );
 
   return (
     <DaemonStoreContext.Provider value={store}>
@@ -3135,11 +4075,15 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
               value={workspaceEventSignals}
             >
               <DaemonActionsContext.Provider value={actions}>
-                <DaemonTranscriptHistoryContext.Provider
-                  value={transcriptHistoryValue}
+                <DaemonSessionOwnerGuardContext.Provider
+                  value={ownerGuardValue}
                 >
-                  {children}
-                </DaemonTranscriptHistoryContext.Provider>
+                  <DaemonTranscriptHistoryContext.Provider
+                    value={transcriptHistoryValue}
+                  >
+                    {children}
+                  </DaemonTranscriptHistoryContext.Provider>
+                </DaemonSessionOwnerGuardContext.Provider>
               </DaemonActionsContext.Provider>
             </DaemonWorkspaceEventSignalsContext.Provider>
           </DaemonSessionNoticesContext.Provider>
@@ -3298,6 +4242,7 @@ function filterDaemonUiEventsForTranscript(
   behavior: {
     hideHistoryTruncation?: boolean;
     suppressSideEffects?: boolean;
+    suppressLogs?: boolean;
   } = {},
 ): DaemonUiEvent[] {
   if (behavior.hideHistoryTruncation && isHistoricalReplayMarker(sourceEvent)) {
@@ -3328,7 +4273,10 @@ function filterDaemonUiEventsForTranscript(
     const notice = addNotice(
       daemonErrorEventToNotice(sourceEvent, event as DaemonUiErrorEvent),
     );
-    if (notice.category === 'protocol' || notice.category === 'connection') {
+    if (
+      !behavior.suppressLogs &&
+      (notice.category === 'protocol' || notice.category === 'connection')
+    ) {
       console.warn('[DaemonSessionProvider] daemon notice:', notice);
     }
   }
@@ -3492,6 +4440,16 @@ export function useDaemonActions(): DaemonSessionActions {
 
 export function useOptionalDaemonActions(): DaemonSessionActions | undefined {
   return useContext(DaemonActionsContext);
+}
+
+export function useDaemonSessionOwnerGuard(): DaemonSessionOwnerGuard {
+  const guard = useContext(DaemonSessionOwnerGuardContext);
+  if (!guard) {
+    throw new Error(
+      'useDaemonSessionOwnerGuard must be used within DaemonSessionProvider',
+    );
+  }
+  return guard;
 }
 
 export function useDaemonWorkspaceEventSignals():
@@ -3766,4 +4724,15 @@ function isTerminalSessionHttpError(error: unknown): boolean {
 function isAuthFailureHttpError(error: unknown): boolean {
   const status = extractHttpStatus(error);
   return status !== undefined && AUTH_FAILURE_HTTP_STATUSES.has(status);
+}
+
+function isClosingSessionLoadError(error: unknown): boolean {
+  if (!(error instanceof DaemonHttpError) || error.status !== 404) return false;
+  const body = isRecord(error.body) ? error.body : undefined;
+  return (
+    typeof body?.['error'] === 'string' &&
+    body['error'].endsWith(
+      'The session is closing; retry after close completes',
+    )
+  );
 }

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -3348,6 +3348,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
       settledPromptsRef.current.clear();
       hasCurrentSessionActivePromptRef.current = () =>
         staged.session.hasActivePrompt === true;
+      clearPassiveAssistantDoneTimer(passiveAssistantDoneTimerRef);
       setPromptStatus(staged.session.hasActivePrompt ? 'streaming' : 'idle');
       liveJournalRepairRef.current?.controller?.abort();
       liveJournalRepairRef.current = staged.repair;
@@ -3755,6 +3756,8 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
         cancelCrossSessionTransition,
         isCrossSessionTransitionPending: () =>
           desiredTransitionRef.current !== undefined,
+        isSourceBoundOperationInFlight: () =>
+          sourceBoundOperationCountRef.current > 0,
         setSourceBoundOperationInFlight: (inFlight) =>
           (sourceBoundOperationCountRef.current += inFlight ? 1 : -1),
         getTransitionOrigin: () => {

--- a/packages/webui/src/daemon/session/actions.test.ts
+++ b/packages/webui/src/daemon/session/actions.test.ts
@@ -606,6 +606,28 @@ describe('createDaemonSessionActions', () => {
     expect(beginCrossSessionTransition).toHaveBeenCalledOnce();
   });
 
+  it('does not restart the current session while a target switch is preparing', async () => {
+    const source = createMockSession('session-a', 'client-a');
+    const beginCrossSessionTransition = vi.fn(async () => undefined);
+    const { actions, pendingSessionLoadRef } = createActionsHarness({
+      beginCrossSessionTransition,
+      isCrossSessionTransitionPending: () => true,
+      connection: {
+        status: 'connected',
+        sessionId: 'session-a',
+        workspaceCwd: '/workspace',
+      },
+      session: source,
+    });
+
+    await expect(actions.loadSession('session-a')).rejects.toMatchObject({
+      name: 'InvalidStateError',
+    });
+    expect(beginCrossSessionTransition).not.toHaveBeenCalled();
+    expect(pendingSessionLoadRef.current).toBeUndefined();
+    expect(source.detach).not.toHaveBeenCalled();
+  });
+
   it('consumes the controlled origin when a switch uses the legacy path', () => {
     const getTransitionOrigin = vi.fn(() => 'controlled' as const);
     const { actions, pendingSessionLoadRef } = createActionsHarness({
@@ -1307,6 +1329,7 @@ function createActionsHarness(
     setRestoreWorkspaceCwd?: ReturnType<typeof vi.fn>;
     setSourceBoundOperationInFlight?: ReturnType<typeof vi.fn>;
     isSourceBoundOperationInFlight?: () => boolean;
+    isCrossSessionTransitionPending?: () => boolean;
     setPromptStatus?: ReturnType<typeof vi.fn>;
     hasSessionActivePrompt?: () => boolean;
   } = {},
@@ -1360,6 +1383,7 @@ function createActionsHarness(
     addNotice: opts.addNotice ?? vi.fn(),
     clearLiveJournalRepair: opts.clearLiveJournalRepair,
     beginCrossSessionTransition: opts.beginCrossSessionTransition,
+    isCrossSessionTransitionPending: opts.isCrossSessionTransitionPending,
     isSourceBoundOperationInFlight: opts.isSourceBoundOperationInFlight,
     getTransitionOrigin: opts.getTransitionOrigin,
     setSourceBoundOperationInFlight: opts.setSourceBoundOperationInFlight,

--- a/packages/webui/src/daemon/session/actions.test.ts
+++ b/packages/webui/src/daemon/session/actions.test.ts
@@ -168,34 +168,32 @@ describe('resolveSessionRestoreTimeouts', () => {
 });
 
 describe('createDaemonSessionActions', () => {
-  it('tracks concurrent source-bound branch requests independently', async () => {
+  it('rejects a concurrent source-bound branch request', async () => {
     const source = createMockSession('session-a', 'client-a');
     const first = createDeferred<{
       sessionId: string;
       displayName: string;
       clientId: string;
     }>();
-    const second = createDeferred<{
-      sessionId: string;
-      displayName: string;
-      clientId: string;
-    }>();
-    source.client.branchSession
-      .mockReturnValueOnce(first.promise)
-      .mockReturnValueOnce(second.promise);
-    const setSourceBoundOperationInFlight = vi.fn();
+    source.client.branchSession.mockReturnValueOnce(first.promise);
+    let sourceBoundOperationCount = 0;
+    const setSourceBoundOperationInFlight = vi.fn((inFlight: boolean) => {
+      sourceBoundOperationCount += inFlight ? 1 : -1;
+    });
     const { actions } = createActionsHarness({
       beginCrossSessionTransition: vi.fn(async () => undefined),
+      isSourceBoundOperationInFlight: () => sourceBoundOperationCount > 0,
       session: source,
       setSourceBoundOperationInFlight,
     });
 
     const firstBranch = actions.branchSession('First');
     const secondBranch = actions.branchSession('Second');
-    expect(setSourceBoundOperationInFlight.mock.calls).toEqual([
-      [true],
-      [true],
-    ]);
+    await expect(secondBranch).rejects.toMatchObject({
+      name: 'InvalidStateError',
+    });
+    expect(source.client.branchSession).toHaveBeenCalledOnce();
+    expect(setSourceBoundOperationInFlight.mock.calls).toEqual([[true]]);
 
     first.resolve({
       sessionId: 'session-b',
@@ -208,25 +206,43 @@ describe('createDaemonSessionActions', () => {
     });
     expect(setSourceBoundOperationInFlight.mock.calls).toEqual([
       [true],
-      [true],
       [false],
     ]);
+  });
 
-    second.resolve({
-      sessionId: 'session-c',
-      displayName: 'Second',
-      clientId: 'client-c',
+  it('does not open a branch that resolves after its source is cleared', async () => {
+    const source = createMockSession('session-a', 'client-a');
+    const branched = createDeferred<{
+      sessionId: string;
+      displayName: string;
+      clientId: string;
+    }>();
+    source.client.branchSession.mockReturnValueOnce(branched.promise);
+    const beginCrossSessionTransition = vi.fn(async () => undefined);
+    const { actions, sessionRef } = createActionsHarness({
+      beginCrossSessionTransition,
+      session: source,
     });
-    await expect(secondBranch).resolves.toEqual({
-      sessionId: 'session-c',
-      displayName: 'Second',
+
+    const pending = actions.branchSession('Late branch');
+    await actions.clearSession();
+    branched.resolve({
+      sessionId: 'session-b',
+      displayName: 'Late branch',
+      clientId: 'client-b',
     });
-    expect(setSourceBoundOperationInFlight.mock.calls).toEqual([
-      [true],
-      [true],
-      [false],
-      [false],
-    ]);
+
+    await expect(pending).resolves.toEqual({
+      sessionId: 'session-b',
+      displayName: 'Late branch',
+    });
+    await Promise.resolve();
+    expect(sessionRef.current).toBeUndefined();
+    expect(beginCrossSessionTransition).not.toHaveBeenCalled();
+    expect(source.client.detachSession).toHaveBeenCalledWith(
+      'session-b',
+      'client-b',
+    );
   });
 
   it('creates from the active session client when the connection matches', async () => {
@@ -1023,9 +1039,52 @@ describe('createDaemonSessionActions', () => {
     await expect(actions.getMidTurnMessages()).resolves.toBeUndefined();
   });
 
-  it('does not append prompt completion from a replaced same-id attachment', async () => {
+  it('settles a prompt after a same-logical attachment replacement', async () => {
     const source = createMockSession('session-a', 'client-a');
     const target = createMockSession('session-a', 'client-b');
+    const admitted = createDeferred<{ promptId: string }>();
+    source.submitPrompt.mockReturnValueOnce(admitted.promise);
+    const { actions, sessionRef, store } = createActionsHarness({
+      session: source,
+    });
+
+    const pending = actions.sendPrompt('hello');
+    sessionRef.current = target as unknown as DaemonSessionClient;
+    admitted.reject(new DOMException('source retired', 'AbortError'));
+
+    await expect(pending).resolves.toEqual({ stopReason: 'cancelled' });
+    expect(store.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'assistant.done' }),
+    );
+  });
+
+  it('keeps a replacement active prompt streaming when the old attachment aborts', async () => {
+    const source = createMockSession('session-a', 'client-a');
+    const target = createMockSession('session-a', 'client-b');
+    const admitted = createDeferred<{ promptId: string }>();
+    source.submitPrompt.mockReturnValueOnce(admitted.promise);
+    const setPromptStatus = vi.fn();
+    const { actions, sessionRef, store } = createActionsHarness({
+      hasSessionActivePrompt: () => true,
+      session: source,
+      setPromptStatus,
+    });
+
+    const pending = actions.sendPrompt('hello');
+    sessionRef.current = target as unknown as DaemonSessionClient;
+    admitted.reject(new DOMException('source retired', 'AbortError'));
+
+    await expect(pending).resolves.toEqual({ stopReason: 'cancelled' });
+    expect(store.dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'assistant.done' }),
+    );
+    expect(setPromptStatus).not.toHaveBeenCalledWith('idle');
+  });
+
+  it('does not settle a prompt after a different-workspace replacement', async () => {
+    const source = createMockSession('session-a', 'client-a');
+    const target = createMockSession('session-a', 'client-b');
+    target.workspaceCwd = '/other-workspace';
     const admitted = createDeferred<{ promptId: string }>();
     source.submitPrompt.mockReturnValueOnce(admitted.promise);
     const { actions, sessionRef, store } = createActionsHarness({
@@ -1040,6 +1099,52 @@ describe('createDaemonSessionActions', () => {
     expect(store.dispatch).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: 'assistant.done' }),
     );
+  });
+
+  it('settles cancel after a same-logical attachment replacement', async () => {
+    const source = createMockSession('session-a', 'client-a');
+    const target = createMockSession('session-a', 'client-b');
+    const cancelled = createDeferred<undefined>();
+    source.cancel.mockReturnValueOnce(cancelled.promise);
+    const setPromptStatus = vi.fn();
+    const { actions, sessionRef } = createActionsHarness({
+      activePrompts: new Map([
+        ['session-a', { controller: new AbortController() } as ActivePrompt],
+      ]),
+      session: source,
+      setPromptStatus,
+    });
+
+    const pending = actions.cancel();
+    sessionRef.current = target as unknown as DaemonSessionClient;
+    cancelled.resolve(undefined);
+
+    await expect(pending).resolves.toBeUndefined();
+    expect(setPromptStatus).toHaveBeenLastCalledWith('idle');
+  });
+
+  it('reports a shell failure after a same-logical attachment replacement', async () => {
+    const source = createMockSession('session-a', 'client-a');
+    const target = createMockSession('session-a', 'client-b');
+    const shell = createDeferred<never>();
+    source.shellCommand.mockReturnValueOnce(shell.promise);
+    const addNotice = vi.fn((notice) => notice);
+    const setPromptStatus = vi.fn();
+    const { actions, sessionRef } = createActionsHarness({
+      addNotice,
+      session: source,
+      setPromptStatus,
+    });
+
+    const pending = actions.sendShellCommand('echo hello');
+    sessionRef.current = target as unknown as DaemonSessionClient;
+    shell.reject(new Error('shell failed'));
+
+    await expect(pending).rejects.toThrow('shell failed');
+    expect(addNotice).toHaveBeenCalledWith(
+      expect.objectContaining({ operation: 'send_shell_command' }),
+    );
+    expect(setPromptStatus).toHaveBeenLastCalledWith('idle');
   });
 
   it('does not apply a late model update to a replacement attachment', async () => {
@@ -1201,6 +1306,9 @@ function createActionsHarness(
     setRestoreSessionId?: ReturnType<typeof vi.fn>;
     setRestoreWorkspaceCwd?: ReturnType<typeof vi.fn>;
     setSourceBoundOperationInFlight?: ReturnType<typeof vi.fn>;
+    isSourceBoundOperationInFlight?: () => boolean;
+    setPromptStatus?: ReturnType<typeof vi.fn>;
+    hasSessionActivePrompt?: () => boolean;
   } = {},
 ) {
   let connection: DaemonConnectionState = opts.connection ?? {
@@ -1246,18 +1354,19 @@ function createActionsHarness(
           ) as unknown as DaemonSessionClient,
       )) as () => Promise<DaemonSessionClient>,
     getConnection: () => connection,
-    hasSessionActivePrompt: () => false,
+    hasSessionActivePrompt: opts.hasSessionActivePrompt ?? (() => false),
     resetCurrentSessionActivePrompt: vi.fn(),
     restartEventStream: opts.restartEventStream ?? vi.fn(),
     addNotice: opts.addNotice ?? vi.fn(),
     clearLiveJournalRepair: opts.clearLiveJournalRepair,
     beginCrossSessionTransition: opts.beginCrossSessionTransition,
+    isSourceBoundOperationInFlight: opts.isSourceBoundOperationInFlight,
     getTransitionOrigin: opts.getTransitionOrigin,
     setSourceBoundOperationInFlight: opts.setSourceBoundOperationInFlight,
     setConnection: (update) => {
       connection = typeof update === 'function' ? update(connection) : update;
     },
-    setPromptStatus: vi.fn(),
+    setPromptStatus: opts.setPromptStatus ?? vi.fn(),
     setRestoreSessionId: opts.setRestoreSessionId ?? vi.fn(),
     setRestoreWorkspaceCwd: opts.setRestoreWorkspaceCwd ?? vi.fn(),
     setRestoreMode: vi.fn(),
@@ -1287,6 +1396,7 @@ function createMockSession(
     client: {
       createOrAttachSession: vi.fn(),
       branchSession: vi.fn(),
+      detachSession: vi.fn(async () => undefined),
       setSessionApprovalMode: vi.fn(async () => ({
         sessionId,
         mode: 'default',
@@ -1300,6 +1410,7 @@ function createMockSession(
     context: vi.fn(async () => contextStatus(sessionId)),
     detach: vi.fn(async () => undefined),
     setModel: vi.fn(async () => ({})),
+    shellCommand: vi.fn(async () => ({})),
     submitPrompt: vi.fn(async () => ({ promptId: 'prompt-1' })),
     supportedCommands: vi.fn(async () => supportedCommandsStatus(sessionId)),
     tasks: vi.fn(async () => ({ v: 1 as const, sessionId, tasks: [] })),

--- a/packages/webui/src/daemon/session/actions.test.ts
+++ b/packages/webui/src/daemon/session/actions.test.ts
@@ -168,6 +168,67 @@ describe('resolveSessionRestoreTimeouts', () => {
 });
 
 describe('createDaemonSessionActions', () => {
+  it('tracks concurrent source-bound branch requests independently', async () => {
+    const source = createMockSession('session-a', 'client-a');
+    const first = createDeferred<{
+      sessionId: string;
+      displayName: string;
+      clientId: string;
+    }>();
+    const second = createDeferred<{
+      sessionId: string;
+      displayName: string;
+      clientId: string;
+    }>();
+    source.client.branchSession
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const setSourceBoundOperationInFlight = vi.fn();
+    const { actions } = createActionsHarness({
+      beginCrossSessionTransition: vi.fn(async () => undefined),
+      session: source,
+      setSourceBoundOperationInFlight,
+    });
+
+    const firstBranch = actions.branchSession('First');
+    const secondBranch = actions.branchSession('Second');
+    expect(setSourceBoundOperationInFlight.mock.calls).toEqual([
+      [true],
+      [true],
+    ]);
+
+    first.resolve({
+      sessionId: 'session-b',
+      displayName: 'First',
+      clientId: 'client-b',
+    });
+    await expect(firstBranch).resolves.toEqual({
+      sessionId: 'session-b',
+      displayName: 'First',
+    });
+    expect(setSourceBoundOperationInFlight.mock.calls).toEqual([
+      [true],
+      [true],
+      [false],
+    ]);
+
+    second.resolve({
+      sessionId: 'session-c',
+      displayName: 'Second',
+      clientId: 'client-c',
+    });
+    await expect(secondBranch).resolves.toEqual({
+      sessionId: 'session-c',
+      displayName: 'Second',
+    });
+    expect(setSourceBoundOperationInFlight.mock.calls).toEqual([
+      [true],
+      [true],
+      [false],
+      [false],
+    ]);
+  });
+
   it('creates from the active session client when the connection matches', async () => {
     const existingSession = createMockSession('session-a');
     const nextSession = createMockSession('session-b');
@@ -511,6 +572,38 @@ describe('createDaemonSessionActions', () => {
       .catch(() => undefined);
 
     expect(setRestoreWorkspaceCwd).toHaveBeenCalledWith('/workspace/secondary');
+  });
+
+  it('does not collapse the filesystem root into an unknown workspace', async () => {
+    const beginCrossSessionTransition = vi.fn(async () => undefined);
+    const { actions } = createActionsHarness({
+      beginCrossSessionTransition,
+      connection: { status: 'connected' },
+      session: {
+        ...createMockSession('session-a'),
+        workspaceCwd: '/',
+      },
+    });
+
+    await actions.loadSession('session-a');
+
+    expect(beginCrossSessionTransition).toHaveBeenCalledOnce();
+  });
+
+  it('consumes the controlled origin when a switch uses the legacy path', () => {
+    const getTransitionOrigin = vi.fn(() => 'controlled' as const);
+    const { actions, pendingSessionLoadRef } = createActionsHarness({
+      getTransitionOrigin,
+    });
+
+    void actions.loadSession('session-b').catch(() => undefined);
+
+    expect(getTransitionOrigin).toHaveBeenCalledOnce();
+    clearTimeout(pendingSessionLoadRef.current?.timeout);
+    pendingSessionLoadRef.current?.reject(
+      new DOMException('Test cleanup', 'AbortError'),
+    );
+    pendingSessionLoadRef.current = undefined;
   });
 
   it('clears transcript loading when a session switch fails', async () => {
@@ -930,6 +1023,25 @@ describe('createDaemonSessionActions', () => {
     await expect(actions.getMidTurnMessages()).resolves.toBeUndefined();
   });
 
+  it('does not append prompt completion from a replaced same-id attachment', async () => {
+    const source = createMockSession('session-a', 'client-a');
+    const target = createMockSession('session-a', 'client-b');
+    const admitted = createDeferred<{ promptId: string }>();
+    source.submitPrompt.mockReturnValueOnce(admitted.promise);
+    const { actions, sessionRef, store } = createActionsHarness({
+      session: source,
+    });
+
+    const pending = actions.sendPrompt('hello');
+    sessionRef.current = target as unknown as DaemonSessionClient;
+    admitted.reject(new DOMException('source retired', 'AbortError'));
+
+    await expect(pending).resolves.toEqual({ stopReason: 'cancelled' });
+    expect(store.dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'assistant.done' }),
+    );
+  });
+
   it('does not apply a late model update to a replacement attachment', async () => {
     const source = createMockSession('session-a', 'client-a');
     const target = createMockSession('session-a', 'client-b');
@@ -1076,9 +1188,11 @@ function createActionsHarness(
   opts: {
     activePrompts?: Map<string, ActivePrompt>;
     addNotice?: ReturnType<typeof vi.fn>;
+    beginCrossSessionTransition?: ReturnType<typeof vi.fn>;
     clearLiveJournalRepair?: ReturnType<typeof vi.fn>;
     connection?: DaemonConnectionState;
     createDetachedSession?: ReturnType<typeof vi.fn>;
+    getTransitionOrigin?: () => 'action' | 'controlled';
     manualSessionClearRef?: { current: boolean };
     pendingSessionLoadRef?: { current: PendingSessionLoad | undefined };
     restartEventStream?: ReturnType<typeof vi.fn>;
@@ -1086,6 +1200,7 @@ function createActionsHarness(
     setAttachSessionNonce?: ReturnType<typeof vi.fn>;
     setRestoreSessionId?: ReturnType<typeof vi.fn>;
     setRestoreWorkspaceCwd?: ReturnType<typeof vi.fn>;
+    setSourceBoundOperationInFlight?: ReturnType<typeof vi.fn>;
   } = {},
 ) {
   let connection: DaemonConnectionState = opts.connection ?? {
@@ -1136,6 +1251,9 @@ function createActionsHarness(
     restartEventStream: opts.restartEventStream ?? vi.fn(),
     addNotice: opts.addNotice ?? vi.fn(),
     clearLiveJournalRepair: opts.clearLiveJournalRepair,
+    beginCrossSessionTransition: opts.beginCrossSessionTransition,
+    getTransitionOrigin: opts.getTransitionOrigin,
+    setSourceBoundOperationInFlight: opts.setSourceBoundOperationInFlight,
     setConnection: (update) => {
       connection = typeof update === 'function' ? update(connection) : update;
     },
@@ -1168,6 +1286,7 @@ function createMockSession(
     clientId,
     client: {
       createOrAttachSession: vi.fn(),
+      branchSession: vi.fn(),
       setSessionApprovalMode: vi.fn(async () => ({
         sessionId,
         mode: 'default',

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -130,6 +130,7 @@ export interface CreateDaemonSessionActionsArgs {
   ) => Promise<void>;
   cancelCrossSessionTransition?: (reason: string) => void;
   isCrossSessionTransitionPending?: () => boolean;
+  isSourceBoundOperationInFlight?: () => boolean;
   setSourceBoundOperationInFlight?: (inFlight: boolean) => void;
   getTransitionOrigin?: () => 'action' | 'controlled';
 }
@@ -198,6 +199,7 @@ export function createDaemonSessionActions({
   beginCrossSessionTransition,
   cancelCrossSessionTransition = () => undefined,
   isCrossSessionTransitionPending = () => false,
+  isSourceBoundOperationInFlight = () => false,
   setSourceBoundOperationInFlight = () => undefined,
   getTransitionOrigin = () => 'action',
 }: CreateDaemonSessionActionsArgs): DaemonSessionActions {
@@ -205,12 +207,28 @@ export function createDaemonSessionActions({
   let noticeOwner = sessionRef.current;
 
   function requireStableSession(): void {
-    if (!isCrossSessionTransitionPending()) return;
-    throw new DOMException(
-      'A session switch is still preparing',
-      'InvalidStateError',
-    );
+    if (isCrossSessionTransitionPending()) {
+      throw new DOMException(
+        'A session switch is still preparing',
+        'InvalidStateError',
+      );
+    }
+    if (isSourceBoundOperationInFlight()) {
+      throw new DOMException(
+        'Another session operation is still in progress',
+        'InvalidStateError',
+      );
+    }
   }
+
+  const isCurrentLogicalSession = (session: DaemonSessionClient) => {
+    const current = sessionRef.current;
+    return (
+      current?.sessionId === session.sessionId &&
+      normalizeWorkspaceIdentity(current.workspaceCwd) ===
+        normalizeWorkspaceIdentity(session.workspaceCwd)
+    );
+  };
 
   const ignoreStaleNotice: AddDaemonSessionNotice = (notice) => ({
     ...notice,
@@ -223,6 +241,11 @@ export function createDaemonSessionActions({
     noticeOwner = session;
     return addNotice;
   };
+  const noticeForLogicalSession = (session: DaemonSessionClient) =>
+    isCurrentLogicalSession(session) ? addNotice : ignoreStaleNotice;
+  const shouldSettlePromptForSession = (session: DaemonSessionClient) =>
+    sessionRef.current === session ||
+    (isCurrentLogicalSession(session) && !hasSessionActivePrompt());
 
   function clearActiveSessionState() {
     clearLiveJournalRepair();
@@ -540,7 +563,7 @@ export function createDaemonSessionActions({
         );
       } catch (error) {
         if (isAbortError(error)) {
-          if (sessionRef.current === session) {
+          if (shouldSettlePromptForSession(session)) {
             store.dispatch({ type: 'assistant.done', reason: 'cancelled' });
           }
           return { stopReason: 'cancelled' };
@@ -548,11 +571,11 @@ export function createDaemonSessionActions({
         if (isDaemonTurnError(error)) {
           throw error;
         }
-        if (sessionRef.current === session) {
+        if (shouldSettlePromptForSession(session)) {
           store.dispatch({ type: 'assistant.done', reason: 'error' });
         }
         throw dispatchActionError(
-          noticeForSession(session),
+          noticeForLogicalSession(session),
           'Prompt failed',
           error,
           'send_prompt',
@@ -562,7 +585,7 @@ export function createDaemonSessionActions({
         if (active?.controller === ctrl) {
           activePromptsRef.current.delete(sessionId);
         }
-        if (sessionRef.current === session && !hasSessionActivePrompt()) {
+        if (isCurrentLogicalSession(session) && !hasSessionActivePrompt()) {
           setPromptStatus('idle');
         }
       }
@@ -657,7 +680,7 @@ export function createDaemonSessionActions({
         await withActionTimeout(session.cancel(), 'Cancel timed out');
       } catch (error) {
         throw dispatchActionError(
-          noticeForSession(session),
+          noticeForLogicalSession(session),
           'Cancel failed',
           error,
           'cancel_prompt',
@@ -670,7 +693,7 @@ export function createDaemonSessionActions({
         ) {
           activePromptsRef.current.delete(session.sessionId);
         }
-        if (sessionRef.current === session && !hasSessionActivePrompt()) {
+        if (isCurrentLogicalSession(session) && !hasSessionActivePrompt()) {
           setPromptStatus('idle');
         }
       }
@@ -1362,7 +1385,7 @@ export function createDaemonSessionActions({
         return await session.shellCommand(command, ctrl.signal);
       } catch (error) {
         throw dispatchActionError(
-          noticeForSession(session),
+          noticeForLogicalSession(session),
           'Shell command failed',
           error,
           'send_shell_command',
@@ -1371,7 +1394,7 @@ export function createDaemonSessionActions({
         if (activePromptsRef.current.get(shellKey)?.controller === ctrl) {
           activePromptsRef.current.delete(shellKey);
         }
-        if (sessionRef.current === session && !hasSessionActivePrompt()) {
+        if (isCurrentLogicalSession(session) && !hasSessionActivePrompt()) {
           setPromptStatus('idle');
         }
       }
@@ -1525,6 +1548,15 @@ export function createDaemonSessionActions({
           branchRequest,
           'Branch session timed out',
         );
+        if (!isCurrentLogicalSession(session)) {
+          void session.client
+            .detachSession(result.sessionId, result.clientId)
+            .catch(() => undefined);
+          return {
+            sessionId: result.sessionId,
+            displayName: result.displayName,
+          };
+        }
         persistStableClientId(result.clientId, result.sessionId);
         void startSessionSwitch(result.sessionId, 'load').catch(
           (switchError: unknown) => {

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -83,7 +83,9 @@ export function resolveSessionRestoreTimeouts(
 function clearPendingLoadTimeout(load: PendingSessionLoad): void {
   if (load.timeout !== undefined) clearTimeout(load.timeout);
 }
-
+export function normalizeWorkspaceIdentity(value: string | undefined): string {
+  return value ? value.replace(/\\/g, '/').replace(/\/+$/, '') || '/' : '';
+}
 export interface CreateDaemonSessionActionsArgs {
   store: DaemonTranscriptStore;
   sessionRef: RefBox<DaemonSessionClient | undefined>;
@@ -117,8 +119,20 @@ export interface CreateDaemonSessionActionsArgs {
   setAttachSessionNonce: Dispatch<SetStateAction<number>>;
   setNewSessionNonce: Dispatch<SetStateAction<number>>;
   clearLiveJournalRepair?: () => void;
+  beginCrossSessionTransition?: (
+    request: {
+      sessionId: string;
+      mode: 'load' | 'resume';
+      workspaceCwd?: string;
+      origin: 'action' | 'controlled';
+    },
+    startLegacy: () => Promise<void>,
+  ) => Promise<void>;
+  cancelCrossSessionTransition?: (reason: string) => void;
+  isCrossSessionTransitionPending?: () => boolean;
+  setSourceBoundOperationInFlight?: (inFlight: boolean) => void;
+  getTransitionOrigin?: () => 'action' | 'controlled';
 }
-
 export function getConnectionAfterSessionClear(
   current: DaemonConnectionState,
   clearedSessionId: string | undefined,
@@ -154,7 +168,6 @@ export function getConnectionAfterSessionClear(
     missingSession: false,
   };
 }
-
 export function createDaemonSessionActions({
   store,
   sessionRef,
@@ -182,12 +195,39 @@ export function createDaemonSessionActions({
   setAttachSessionNonce,
   setNewSessionNonce,
   clearLiveJournalRepair = () => undefined,
+  beginCrossSessionTransition,
+  cancelCrossSessionTransition = () => undefined,
+  isCrossSessionTransitionPending = () => false,
+  setSourceBoundOperationInFlight = () => undefined,
+  getTransitionOrigin = () => 'action',
 }: CreateDaemonSessionActionsArgs): DaemonSessionActions {
   const silentHardFailureNoticeKeys = new Set<string>();
+  let noticeOwner = sessionRef.current;
+
+  function requireStableSession(): void {
+    if (!isCrossSessionTransitionPending()) return;
+    throw new DOMException(
+      'A session switch is still preparing',
+      'InvalidStateError',
+    );
+  }
+
+  const ignoreStaleNotice: AddDaemonSessionNotice = (notice) => ({
+    ...notice,
+    id: notice.id ?? 'stale-session-notice',
+    createdAt: notice.createdAt ?? 0,
+  });
+  const noticeForSession = (session: DaemonSessionClient) => {
+    if (sessionRef.current !== session) return ignoreStaleNotice;
+    if (noticeOwner !== session) silentHardFailureNoticeKeys.clear();
+    noticeOwner = session;
+    return addNotice;
+  };
 
   function clearActiveSessionState() {
     clearLiveJournalRepair();
     silentHardFailureNoticeKeys.clear();
+    noticeOwner = undefined;
     for (const [, active] of activePromptsRef.current) {
       active.controller.abort();
     }
@@ -289,7 +329,7 @@ export function createDaemonSessionActions({
     return loadPromise;
   }
 
-  function startSessionSwitch(
+  function startLegacySessionSwitch(
     sessionId: string,
     mode: 'load' | 'resume',
     workspaceCwd?: string,
@@ -381,8 +421,57 @@ export function createDaemonSessionActions({
     });
   }
 
+  function startSessionSwitch(
+    sessionId: string,
+    mode: 'load' | 'resume',
+    workspaceCwd?: string,
+    signal?: AbortSignal,
+    replaySource?: PendingSessionLoad['replaySource'],
+  ): Promise<void> {
+    if (signal?.aborted) {
+      return Promise.reject(
+        new DOMException('Session load cancelled', 'AbortError'),
+      );
+    }
+    const origin = getTransitionOrigin();
+    const startLegacy = () =>
+      startLegacySessionSwitch(
+        sessionId,
+        mode,
+        workspaceCwd,
+        signal,
+        replaySource,
+      );
+    const current = sessionRef.current;
+    const targetWorkspace = workspaceCwd ?? getConnection().workspaceCwd;
+    const crossLogicalTarget =
+      current !== undefined &&
+      (current.sessionId !== sessionId ||
+        normalizeWorkspaceIdentity(current.workspaceCwd) !==
+          normalizeWorkspaceIdentity(targetWorkspace));
+    if (
+      !crossLogicalTarget ||
+      replaySource !== undefined ||
+      !beginCrossSessionTransition
+    ) {
+      return startLegacy();
+    }
+    return beginCrossSessionTransition(
+      {
+        sessionId,
+        mode,
+        ...(targetWorkspace !== undefined
+          ? { workspaceCwd: targetWorkspace }
+          : {}),
+        origin,
+      },
+      startLegacy,
+    );
+  }
+
   return {
     async sendPrompt(text, options) {
+      requireStableSession();
       const session = requireSessionForAction(
         addNotice,
         sessionRef.current,
@@ -451,7 +540,7 @@ export function createDaemonSessionActions({
         );
       } catch (error) {
         if (isAbortError(error)) {
-          if (sessionRef.current?.sessionId === sessionId) {
+          if (sessionRef.current === session) {
             store.dispatch({ type: 'assistant.done', reason: 'cancelled' });
           }
           return { stopReason: 'cancelled' };
@@ -459,11 +548,11 @@ export function createDaemonSessionActions({
         if (isDaemonTurnError(error)) {
           throw error;
         }
-        if (sessionRef.current?.sessionId === sessionId) {
+        if (sessionRef.current === session) {
           store.dispatch({ type: 'assistant.done', reason: 'error' });
         }
         throw dispatchActionError(
-          addNotice,
+          noticeForSession(session),
           'Prompt failed',
           error,
           'send_prompt',
@@ -473,16 +562,14 @@ export function createDaemonSessionActions({
         if (active?.controller === ctrl) {
           activePromptsRef.current.delete(sessionId);
         }
-        if (
-          sessionRef.current?.sessionId === sessionId &&
-          !hasSessionActivePrompt()
-        ) {
+        if (sessionRef.current === session && !hasSessionActivePrompt()) {
           setPromptStatus('idle');
         }
       }
     },
 
     async submitPrompt(text, options) {
+      requireStableSession();
       const session = requireSessionForAction(
         addNotice,
         sessionRef.current,
@@ -532,7 +619,7 @@ export function createDaemonSessionActions({
             '[submitPrompt] removePendingPrompt failed after abort',
             err,
           );
-          addNotice({
+          noticeForSession(session)({
             severity: 'error',
             category: 'user_action',
             operation: 'send_prompt',
@@ -570,7 +657,7 @@ export function createDaemonSessionActions({
         await withActionTimeout(session.cancel(), 'Cancel timed out');
       } catch (error) {
         throw dispatchActionError(
-          addNotice,
+          noticeForSession(session),
           'Cancel failed',
           error,
           'cancel_prompt',
@@ -583,16 +670,14 @@ export function createDaemonSessionActions({
         ) {
           activePromptsRef.current.delete(session.sessionId);
         }
-        if (
-          sessionRef.current?.sessionId === session.sessionId &&
-          !hasSessionActivePrompt()
-        ) {
+        if (sessionRef.current === session && !hasSessionActivePrompt()) {
           setPromptStatus('idle');
         }
       }
     },
 
     async setModel(modelId) {
+      requireStableSession();
       const session = requireSessionForAction(
         addNotice,
         sessionRef.current,
@@ -610,7 +695,7 @@ export function createDaemonSessionActions({
         return result;
       } catch (error) {
         throw dispatchActionError(
-          addNotice,
+          noticeForSession(session),
           'Set model failed',
           error,
           'switch_model',
@@ -619,6 +704,7 @@ export function createDaemonSessionActions({
     },
 
     async setApprovalMode(mode, opts) {
+      requireStableSession();
       const session = requireSessionForAction(
         addNotice,
         sessionRef.current,
@@ -642,7 +728,7 @@ export function createDaemonSessionActions({
         return result;
       } catch (error) {
         throw dispatchActionError(
-          addNotice,
+          noticeForSession(session),
           'Set approval mode failed',
           error,
           'set_approval_mode',
@@ -664,7 +750,7 @@ export function createDaemonSessionActions({
         );
       } catch (error) {
         throw dispatchActionError(
-          addNotice,
+          noticeForSession(session),
           'Permission response failed',
           error,
           'submit_permission',
@@ -696,7 +782,7 @@ export function createDaemonSessionActions({
         );
       } catch (error) {
         throw dispatchActionError(
-          addNotice,
+          noticeForSession(session),
           'Permission response failed',
           error,
           'submit_permission',
@@ -720,7 +806,7 @@ export function createDaemonSessionActions({
         );
       } catch (error) {
         throw dispatchActionError(
-          addNotice,
+          noticeForSession(session),
           'List sessions failed',
           error,
           'list_sessions',
@@ -733,6 +819,7 @@ export function createDaemonSessionActions({
     },
 
     async reloadSession(signal, options) {
+      requireStableSession();
       const session = requireSessionForAction(
         addNotice,
         sessionRef.current,
@@ -759,6 +846,7 @@ export function createDaemonSessionActions({
       worktree?: { slug?: string };
       branch?: { name: string };
     }) {
+      requireStableSession();
       try {
         manualSessionClearRef.current = false;
         // Fold the initial approval mode into the create request so the daemon
@@ -844,6 +932,7 @@ export function createDaemonSessionActions({
     },
 
     async attachSession() {
+      requireStableSession();
       const session = requireSessionForAction(
         addNotice,
         sessionRef.current,
@@ -856,6 +945,7 @@ export function createDaemonSessionActions({
     },
 
     async clearSession() {
+      cancelCrossSessionTransition('Session transition cancelled by clear');
       const session = sessionRef.current;
       manualSessionClearRef.current = true;
       clearActiveSessionState();
@@ -873,6 +963,9 @@ export function createDaemonSessionActions({
     },
 
     async newSession() {
+      cancelCrossSessionTransition(
+        'Session transition cancelled by new session',
+      );
       manualSessionClearRef.current = false;
       clearActiveSessionState();
       setConnection((current) => ({
@@ -886,6 +979,11 @@ export function createDaemonSessionActions({
 
     async releaseSession(sessionId) {
       try {
+        if (sessionRef.current?.sessionId === sessionId) {
+          cancelCrossSessionTransition(
+            'Session transition cancelled by release',
+          );
+        }
         const session = requireSessionForAction(
           addNotice,
           sessionRef.current,
@@ -907,6 +1005,7 @@ export function createDaemonSessionActions({
     },
 
     async closeSession() {
+      cancelCrossSessionTransition('Session transition cancelled by close');
       const session = requireSessionForAction(
         addNotice,
         sessionRef.current,
@@ -917,7 +1016,7 @@ export function createDaemonSessionActions({
         await withActionTimeout(session.close(), 'Close session timed out');
       } catch (error) {
         throw dispatchActionError(
-          addNotice,
+          noticeForSession(session),
           'Close session failed',
           error,
           'close_session',
@@ -947,8 +1046,9 @@ export function createDaemonSessionActions({
           }));
         }
       } catch (error) {
+        if (sessionRef.current !== session) return;
         throw dispatchActionError(
-          addNotice,
+          noticeForSession(session),
           'Refresh commands failed',
           error,
           'refresh_commands',
@@ -981,7 +1081,7 @@ export function createDaemonSessionActions({
         return context;
       } catch (error) {
         throw dispatchActionError(
-          addNotice,
+          noticeForSession(session),
           'Load context failed',
           error,
           'load_context',
@@ -1003,7 +1103,7 @@ export function createDaemonSessionActions({
         );
       } catch (error) {
         throw dispatchActionError(
-          addNotice,
+          noticeForSession(session),
           'Load context usage failed',
           error,
           'load_context_usage',
@@ -1012,6 +1112,7 @@ export function createDaemonSessionActions({
     },
 
     async renameSession(displayName) {
+      requireStableSession();
       const session = requireSessionForAction(
         addNotice,
         sessionRef.current,
@@ -1025,7 +1126,7 @@ export function createDaemonSessionActions({
         );
       } catch (error) {
         throw dispatchActionError(
-          addNotice,
+          noticeForSession(session),
           'Rename session failed',
           error,
           'rename_session',
@@ -1034,6 +1135,7 @@ export function createDaemonSessionActions({
     },
 
     async recapSession(): Promise<DaemonSessionRecapResult> {
+      requireStableSession();
       const session = requireSessionForAction(
         addNotice,
         sessionRef.current,
@@ -1047,7 +1149,7 @@ export function createDaemonSessionActions({
         );
       } catch (error) {
         throw dispatchActionError(
-          addNotice,
+          noticeForSession(session),
           'Recap session failed',
           error,
           'recap_session',
@@ -1059,6 +1161,7 @@ export function createDaemonSessionActions({
       prompt: string,
       opts?: { signal?: AbortSignal },
     ): AsyncGenerator<DaemonSessionGenerationEvent> {
+      requireStableSession();
       const session = requireSessionForAction(
         addNotice,
         sessionRef.current,
@@ -1084,7 +1187,7 @@ export function createDaemonSessionActions({
         );
       } catch (error) {
         throw dispatchActionError(
-          addNotice,
+          noticeForSession(session),
           'Load rewind snapshots failed',
           error,
           'rewind_snapshots',
@@ -1096,6 +1199,7 @@ export function createDaemonSessionActions({
       promptId: string,
       opts?: { rewindFiles?: boolean },
     ): Promise<DaemonRewindResult> {
+      requireStableSession();
       const session = requireSessionForAction(
         addNotice,
         sessionRef.current,
@@ -1109,7 +1213,7 @@ export function createDaemonSessionActions({
         );
       } catch (error) {
         throw dispatchActionError(
-          addNotice,
+          noticeForSession(session),
           'Rewind session failed',
           error,
           'rewind_session',
@@ -1121,6 +1225,7 @@ export function createDaemonSessionActions({
       question: string,
       opts?: { signal?: AbortSignal },
     ): Promise<DaemonSessionBtwResult> {
+      requireStableSession();
       const session = requireSessionForAction(
         addNotice,
         sessionRef.current,
@@ -1137,7 +1242,7 @@ export function createDaemonSessionActions({
           throw error;
         }
         throw dispatchActionError(
-          addNotice,
+          noticeForSession(session),
           'Side question failed',
           error,
           'btw_session',
@@ -1149,6 +1254,7 @@ export function createDaemonSessionActions({
       message: string,
       opts?: { signal?: AbortSignal; messageId?: string },
     ): Promise<DaemonMidTurnMessageResult> {
+      if (isCrossSessionTransitionPending()) return { accepted: false };
       // Calls without an id are the old-daemon compatibility path and fall back
       // locally. With a stable id, transport failure is ambiguous (the POST may
       // already have committed), so let the caller reconcile instead of
@@ -1241,6 +1347,7 @@ export function createDaemonSessionActions({
     },
 
     async sendShellCommand(command: string) {
+      requireStableSession();
       const session = requireSessionForAction(
         addNotice,
         sessionRef.current,
@@ -1255,7 +1362,7 @@ export function createDaemonSessionActions({
         return await session.shellCommand(command, ctrl.signal);
       } catch (error) {
         throw dispatchActionError(
-          addNotice,
+          noticeForSession(session),
           'Shell command failed',
           error,
           'send_shell_command',
@@ -1264,10 +1371,7 @@ export function createDaemonSessionActions({
         if (activePromptsRef.current.get(shellKey)?.controller === ctrl) {
           activePromptsRef.current.delete(shellKey);
         }
-        if (
-          sessionRef.current?.sessionId === session.sessionId &&
-          !hasSessionActivePrompt()
-        ) {
+        if (sessionRef.current === session && !hasSessionActivePrompt()) {
           setPromptStatus('idle');
         }
       }
@@ -1289,7 +1393,7 @@ export function createDaemonSessionActions({
           throw error;
         }
         throw dispatchActionError(
-          addNotice,
+          noticeForSession(session),
           'Get tasks failed',
           error,
           'load_tasks',
@@ -1317,7 +1421,7 @@ export function createDaemonSessionActions({
         );
       } catch (error) {
         throw dispatchActionError(
-          addNotice,
+          noticeForSession(session),
           'Cancel task failed',
           error,
           'cancel_task',
@@ -1326,6 +1430,7 @@ export function createDaemonSessionActions({
     },
 
     async clearGoal() {
+      requireStableSession();
       const session = requireSessionForAction(
         addNotice,
         sessionRef.current,
@@ -1339,7 +1444,7 @@ export function createDaemonSessionActions({
         );
       } catch (error) {
         throw dispatchActionError(
-          addNotice,
+          noticeForSession(session),
           'Clear goal failed',
           error,
           'clear_goal',
@@ -1358,7 +1463,7 @@ export function createDaemonSessionActions({
         return await withActionTimeout(session.stats(), 'Load stats timed out');
       } catch (error) {
         throw dispatchActionError(
-          addNotice,
+          noticeForSession(session),
           'Load stats failed',
           error,
           'load_stats',
@@ -1389,7 +1494,7 @@ export function createDaemonSessionActions({
         );
       } catch (error) {
         throw dispatchActionError(
-          addNotice,
+          noticeForSession(session),
           'Global permission response failed',
           error,
           'submit_permission',
@@ -1398,6 +1503,7 @@ export function createDaemonSessionActions({
     },
 
     async branchSession(name?: string) {
+      requireStableSession();
       const session = requireSessionForAction(
         addNotice,
         sessionRef.current,
@@ -1405,17 +1511,26 @@ export function createDaemonSessionActions({
         'branch_session',
       );
       try {
+        setSourceBoundOperationInFlight(true);
+        const branchRequest = session.client.branchSession(
+          session.sessionId,
+          { name },
+          session.clientId,
+        );
+        void branchRequest.then(
+          () => setSourceBoundOperationInFlight(false),
+          () => setSourceBoundOperationInFlight(false),
+        );
         const result = await withActionTimeout(
-          session.client.branchSession(
-            session.sessionId,
-            { name },
-            session.clientId,
-          ),
+          branchRequest,
           'Branch session timed out',
         );
         persistStableClientId(result.clientId, result.sessionId);
         void startSessionSwitch(result.sessionId, 'load').catch(
           (switchError: unknown) => {
+            void session.client
+              .detachSession(result.sessionId, result.clientId)
+              .catch(() => undefined);
             if (isAbortError(switchError)) return;
             dispatchActionError(
               addNotice,
@@ -1440,6 +1555,7 @@ export function createDaemonSessionActions({
     },
 
     async forkSession(directive: string): Promise<DaemonForkSessionResult> {
+      requireStableSession();
       const session = requireSessionForAction(
         addNotice,
         sessionRef.current,
@@ -1453,7 +1569,7 @@ export function createDaemonSessionActions({
         );
       } catch (error) {
         throw dispatchActionError(
-          addNotice,
+          noticeForSession(session),
           'Fork session failed',
           error,
           'fork_session',

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -473,6 +473,18 @@ export function createDaemonSessionActions({
         normalizeWorkspaceIdentity(current.workspaceCwd) !==
           normalizeWorkspaceIdentity(targetWorkspace));
     if (
+      !crossLogicalTarget &&
+      replaySource === undefined &&
+      isCrossSessionTransitionPending()
+    ) {
+      return Promise.reject(
+        new DOMException(
+          'A session switch is still preparing',
+          'InvalidStateError',
+        ),
+      );
+    }
+    if (
       !crossLogicalTarget ||
       replaySource !== undefined ||
       !beginCrossSessionTransition

--- a/packages/webui/src/daemon/session/types.ts
+++ b/packages/webui/src/daemon/session/types.ts
@@ -51,6 +51,25 @@ export type DaemonConnectionStatus =
   | 'disconnected'
   | 'error';
 
+export interface DaemonSessionTransition {
+  phase: 'queued' | 'preparing' | 'failed';
+  operation: 'load' | 'resume';
+  origin: 'action' | 'controlled';
+  targetSessionId: string;
+  targetWorkspaceCwd?: string;
+  targetClientId?: string;
+  error?: {
+    message: string;
+    code?: string;
+    status?: number;
+  };
+}
+export interface DaemonSessionOwnerSnapshot {
+  isCurrent(): boolean;
+}
+export interface DaemonSessionOwnerGuard {
+  capture(): DaemonSessionOwnerSnapshot;
+}
 export interface DaemonConnectionState {
   status: DaemonConnectionStatus;
   sessionId?: string;
@@ -94,6 +113,7 @@ export interface DaemonConnectionState {
   errorStatus?: number;
   /** True only when the server confirmed the current session is missing. */
   missingSession?: boolean;
+  sessionTransition?: DaemonSessionTransition;
 }
 
 export interface DaemonTokenUsage {
@@ -152,6 +172,10 @@ export interface DaemonSessionProviderProps {
     /** Warning shown when session context metadata cannot be loaded. */
     context?: string;
   };
+  onSessionTransitionCommit?: (target: {
+    sessionId: string;
+    workspaceCwd?: string;
+  }) => void;
   /** React children rendered inside the daemon session contexts. */
   children: ReactNode;
 }


### PR DESCRIPTION
## What this PR does

This PR makes modern WebUI load/resume switches to a different logical session transactional. The current session remains the visible owner while the target restores and is replayed into an isolated, bounded staging store; only a fully staged target that still wins the lifecycle/deadline arbitration is committed. Failed, timed-out, superseded, malformed, or stale targets are discarded and detached best-effort without clearing the current transcript, stopping its event stream, or replacing its connection state.

The restore coordinator permits one ordinary restore RPC at a time, coalesces identical targets, retains only the latest queued target, and fences late results by exact attachment and environment identity. Commit installs the target transcript, session/client/workspace references, connection state, staged notices and side channels in one synchronous ownership handoff before the public load promise resolves, then starts the prepared target runner without issuing a second restore.

The main WebShell provider now stays mounted across modern controlled session/workspace changes. Navigation paths share transactional ownership fences and write gates, preserve source metadata while a target is pending or fails, hide stale metadata on the first committed target frame, and delay the scheduled-run catch-up timeout until restore has committed. Daemons that explicitly lack `client_identity` keep the existing keyed, detach-first compatibility behavior; unknown capabilities and malformed modern ownership fail closed.

## Why it's needed

Before this change, selecting another session immediately detached the current session, aborted its event stream, cleared its transcript, and published the target as loading before the target restore had succeeded. A large-session timeout or other restore failure therefore left the user on an empty/error target and stopped the conversation that had been usable. PR #8691 made restore deadlines safe and observable, and PR #8833 fenced late attachment work; this PR adds the missing client-side transaction boundary for ordinary and controlled cross-session load/resume.

## Reviewer Test Plan

### How to verify

Start with session A connected and containing a visible transcript, then delay the completed response for loading session B. Confirm that A stays connected, retains its transcript, continues receiving live events, and still accepts existing control operations while B is pending. Release B and confirm that the first committed state consistently contains B's session, client, workspace, and replay, with A detached only after commit.

Repeat with B returning a structured HTTP 504 and with B being superseded by later targets. Confirm that A remains usable after failure, only one ordinary restore is in flight, an intermediate queued target is never sent, and a late result cannot replace the latest owner. For a controlled workspace target, confirm that unresolved/failed workspace resolution keeps A mounted and rolls the host back once without a retry loop.

The focused regression suites cover WebUI restore arbitration, pure staging, attachment cleanup, controlled transitions, WebShell owner fences, navigation, queued prompts, background tasks, and artifacts. The real-daemon integration test exercises delayed-success and structured-504 scenarios through `qwen serve`.

### Evidence (Before & After)

Before: deterministic baseline runs on pre-change `main` showed action-driven and controlled switches detach A, abort A's stream, clear its transcript, and expose B/loading before B settled; a rejected B left an empty B/error state. A same-workspace controlled target also remounted the session provider.

After: the real-daemon integration test completed B's restore but withheld the response for about five seconds. During that gate A remained connected, accepted a control request, and received a new live event; releasing the response atomically installed B. A structured B restore 504 preserved A and surfaced `session_restore_timeout` with HTTP status 504. Focused verification passed 279 WebUI action/provider tests and 418 affected WebShell tests; repository build, typecheck, bundle, and focused ESLint also passed.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS Darwin 25.4.0 arm64, Node.js v22.22.3, npm 10.9.8. Real-daemon integration used `QWEN_SANDBOX=false` with the built `qwen serve` bundle and a mock ACP child.

## Risk & Scope

- Main risk or tradeoff: This is a cross-package WebUI/WebShell ownership change at the repository's 1,000+ production-line advisory threshold (9 production files, raw net +1,500), so restore arbitration, React lifecycle handoff, and host navigation deserve maintainer review. Staging temporarily holds A's store and B's replay, and best-effort detach failure can retain an invisible client reference until the existing reaper runs.
- Not validated / out of scope: Same-logical-session reload, clientId-only handoff, epoch/ring resync and live-journal repair transactions are reserved for PR3c; branch creation/adoption and its timeout contract are reserved for PR3d. JSONL streaming/selective restore, checkpointing, a global attachment scheduler, SDK self-heal, and an 80 MiB CI timing threshold are also out of scope. Windows and Linux were not tested locally.
- Breaking changes / migration notes: No daemon, REST, ACP, or WebSocket protocol changes and no migration are required. The connection state and provider expose additive optional transition/owner hooks. Daemons known not to support `client_identity` retain the prior destructive switching behavior.

## Linked Issues

Refs #8678

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 将现代 WebUI 中切换到不同逻辑会话的 load/resume 改为事务化。目标会话恢复并在隔离、有界的 staging store 中重放期间，当前会话仍然是可见 owner；只有完成全部 staging 且仍通过生命周期/截止时间仲裁的目标才会提交。失败、超时、被替换、格式错误或过期的目标会被丢弃并尽力 detach，不会清空当前 transcript、停止其事件流或替换其连接状态。

restore coordinator 同时只允许一个普通 restore RPC，合并相同目标，只保留最新排队目标，并使用精确 attachment 与环境 identity 隔离迟到结果。commit 在公开 load promise resolve 前，通过一次同步 ownership handoff 安装目标 transcript、session/client/workspace 引用、connection state、已 staging 的 notices 和 side channels，然后直接启动准备好的目标 runner，不会再次发起 restore。

现代受控 session/workspace 变化期间，主 WebShell provider 现在保持挂载。各导航入口共享事务化 ownership fence 和写入 gate，目标 pending 或失败时保留源会话 metadata，目标提交的第一帧隐藏过期 metadata，并将 scheduled-run 的 catch-up timeout 延后到 restore commit 之后。明确缺少 `client_identity` 的 daemon 继续使用现有 keyed、detach-first 兼容行为；capability 未知和现代 ownership 格式错误则 fail-closed。

## 为什么需要

变更前，选择另一个会话会在目标 restore 成功之前立即 detach 当前会话、终止其事件流、清空 transcript，并把目标发布为 loading。因此大型会话超时或其他 restore 失败会让用户停留在空白/错误目标，同时停止原本可用的会话。PR #8691 已使 restore deadline 安全且可观测，PR #8833 已隔离迟到 attachment 工作；本 PR 补上普通及受控跨会话 load/resume 所缺少的客户端事务边界。

## Reviewer 测试计划

### 如何验证

先连接 session A 并确保存在可见 transcript，然后延迟 session B 已完成 load 的响应。确认 B pending 期间 A 仍保持 connected、保留 transcript、继续接收实时事件，并且现有控制操作仍能使用。释放 B 后，确认第一个 committed 状态中的 session、client、workspace 和 replay 全部一致属于 B，并且 A 只在 commit 后才 detach。

再让 B 返回结构化 HTTP 504，并让 B 被后续目标替换。确认失败后 A 仍可用、同时只有一个普通 restore 在运行、中间排队目标不会发送、迟到结果不能替换最新 owner。对于受控 workspace 目标，确认 workspace 解析未完成或失败时 A 保持挂载，host 只回滚一次且不会形成重试循环。

focused regression suites 覆盖 WebUI restore 仲裁、pure staging、attachment 清理、受控切换，以及 WebShell owner fence、导航、queued prompts、background tasks 和 artifacts。真实 daemon integration test 通过 `qwen serve` 覆盖 delayed-success 与结构化 504 场景。

### 证据（变更前后）

变更前：在变更前 `main` 上的确定性 baseline 运行表明，action-driven 和 controlled 切换会在 B settle 前 detach A、终止 A 的 stream、清空 transcript 并显示 B/loading；B reject 后停留在空白 B/error 状态。同 workspace 的受控目标还会 remount session provider。

变更后：真实 daemon integration test 完成了 B restore，但将 response 暂停约五秒。在 gate 期间 A 保持 connected、接受 control request 并收到新的 live event；释放 response 后原子安装 B。B 的结构化 restore 504 保留 A，并显示 `session_restore_timeout` 与 HTTP 504。focused verification 通过 279 个 WebUI action/provider 测试和 418 个受影响 WebShell 测试；仓库 build、typecheck、bundle 与 focused ESLint 也全部通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS Darwin 25.4.0 arm64，Node.js v22.22.3，npm 10.9.8。真实 daemon integration 使用 `QWEN_SANDBOX=false`、已构建的 `qwen serve` bundle 和 mock ACP child。

## 风险与范围

- 主要风险或取舍：这是跨 WebUI/WebShell package 的 ownership 变更，达到仓库 1,000+ 生产行 advisory 阈值（9 个生产文件，原始净增 +1,500），因此 restore 仲裁、React lifecycle handoff 与 host navigation 需要 maintainer review。staging 会短暂同时持有 A store 与 B replay；best-effort detach 失败可能使不可见 client reference 保留到现有 reaper 执行。
- 未验证/范围外：same-logical-session reload、clientId-only handoff、epoch/ring resync 与 live-journal repair transaction 留给 PR3c；branch creation/adoption 及其 timeout contract 留给 PR3d。JSONL streaming/selective restore、checkpoint、全局 attachment scheduler、SDK self-heal 和 80 MiB CI 时延阈值也不在本 PR 范围内。Windows 与 Linux 未在本地测试。
- Breaking change / 迁移说明：不修改 daemon、REST、ACP 或 WebSocket 协议，不需要迁移。connection state 与 provider 仅增加可选 transition/owner hooks。明确不支持 `client_identity` 的 daemon 保留原有 destructive switching 行为。

## 关联 Issue

Refs #8678

</details>
