### PR TITLE
fix(webui): allow retry after session load timeout

### DIFF
--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -8086,6 +8086,54 @@ describe('DaemonSessionProvider', () => {
     expect(blocks).toEqual([]);
   });
 
+  it('does not attach a session after its load watchdog expires', async () => {
+    const firstSession = createMockSession({ sessionId: 'session-a' });
+    const lateSession = createMockSession({ sessionId: 'session-b' });
+    const lateLoad = createDeferred<MockSession>();
+    sdkMocks.sessions.push(firstSession);
+    let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      sessionId: 'session-a',
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+    sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(
+      async () => lateLoad.promise,
+    );
+
+    vi.useFakeTimers();
+    try {
+      const loadPromise = requireActions(actions).loadSession('session-b');
+      const rejection = expect(loadPromise).rejects.toThrow(
+        'Session load timed out',
+      );
+      await act(async () => {
+        await flushPromises();
+        await vi.advanceTimersByTimeAsync(75_000);
+      });
+      await rejection;
+      expect(connection).toMatchObject({ sessionId: undefined });
+
+      lateLoad.resolve(lateSession);
+      await act(async () => {
+        await flushPromises();
+      });
+      expect(connection).toMatchObject({ sessionId: undefined });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('surfaces a restore 504 without treating the session as missing', async () => {
     sdkMocks.MockDaemonSessionClient.load.mockRejectedValueOnce(
       new DaemonHttpError(

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -8114,14 +8114,14 @@ describe('DaemonSessionProvider', () => {
     vi.useFakeTimers();
     try {
       const loadPromise = requireActions(actions).loadSession('session-b');
-      const rejection = expect(loadPromise).rejects.toThrow(
-        'Session load timed out',
-      );
+      const rejection = loadPromise.catch((error: unknown) => error);
       await act(async () => {
         await flushPromises();
         await vi.advanceTimersByTimeAsync(75_000);
       });
-      await rejection;
+      const loadError = await rejection;
+      expect(loadError).toBeInstanceOf(Error);
+      expect((loadError as Error).message).toContain('Session load timed out');
       expect(connection).toMatchObject({ sessionId: undefined });
 
       lateLoad.resolve(lateSession);

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -811,7 +811,10 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
         | Awaited<ReturnType<DaemonClient['capabilities']>>
         | undefined;
       let reconnectSessionId = restoreSessionId;
-      let shouldCreateFreshSession = !restoreSessionId && newSessionNonce > 0;
+      let shouldCreateFreshSession =
+        !manualSessionClearRef.current &&
+        !restoreSessionId &&
+        newSessionNonce > 0;
       let reconnectAttempt = 0;
       let nextSseConnectReason: DaemonSseConnectReason | undefined;
       let skipMetadataRefresh = false;

--- a/packages/webui/src/daemon/session/actions.test.ts
+++ b/packages/webui/src/daemon/session/actions.test.ts
@@ -517,9 +517,13 @@ describe('createDaemonSessionActions', () => {
     vi.useFakeTimers();
     try {
       const existingSession = createMockSession('session-a');
+      const manualSessionClearRef = { current: false };
+      const setRestoreSessionId = vi.fn();
       const { actions, getConnection } = createActionsHarness({
         connection: { status: 'connected', sessionId: 'session-a' },
+        manualSessionClearRef,
         session: existingSession,
+        setRestoreSessionId,
       });
 
       const loadPromise = actions.loadSession('session-b');
@@ -545,6 +549,8 @@ describe('createDaemonSessionActions', () => {
         loadingTranscript: undefined,
         catchingUp: undefined,
       });
+      expect(manualSessionClearRef.current).toBe(true);
+      expect(setRestoreSessionId).toHaveBeenLastCalledWith(undefined);
     } finally {
       vi.useRealTimers();
     }
@@ -1024,6 +1030,7 @@ function createActionsHarness(
     restartEventStream?: ReturnType<typeof vi.fn>;
     session?: ReturnType<typeof createMockSession>;
     setAttachSessionNonce?: ReturnType<typeof vi.fn>;
+    setRestoreSessionId?: ReturnType<typeof vi.fn>;
     setRestoreWorkspaceCwd?: ReturnType<typeof vi.fn>;
   } = {},
 ) {
@@ -1079,7 +1086,7 @@ function createActionsHarness(
       connection = typeof update === 'function' ? update(connection) : update;
     },
     setPromptStatus: vi.fn(),
-    setRestoreSessionId: vi.fn(),
+    setRestoreSessionId: opts.setRestoreSessionId ?? vi.fn(),
     setRestoreWorkspaceCwd: opts.setRestoreWorkspaceCwd ?? vi.fn(),
     setRestoreMode: vi.fn(),
     setRestoreSessionNonce: vi.fn(),

--- a/packages/webui/src/daemon/session/actions.test.ts
+++ b/packages/webui/src/daemon/session/actions.test.ts
@@ -541,7 +541,7 @@ describe('createDaemonSessionActions', () => {
       await expect(loadPromise).rejects.toThrow('Session load timed out');
       expect(getConnection()).toMatchObject({
         status: 'disconnected',
-        sessionId: 'session-b',
+        sessionId: undefined,
         loadingTranscript: undefined,
         catchingUp: undefined,
       });

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -257,6 +257,7 @@ export function createDaemonSessionActions({
                     return {
                       ...getConnectionAfterSessionClear(current, sessionId),
                       status: 'disconnected',
+                      sessionId: undefined,
                     };
                   });
                 }

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -250,6 +250,7 @@ export function createDaemonSessionActions({
                       ? {
                           ...current,
                           status: 'disconnected',
+                          sessionId: undefined,
                           loadingTranscript: undefined,
                           catchingUp: undefined,
                         }

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -246,18 +246,19 @@ export function createDaemonSessionActions({
                 if (sessionRef.current?.sessionId !== sessionId) {
                   manualSessionClearRef.current = true;
                   setRestoreSessionId(undefined);
-                  setConnection((current) =>
-                    current.status === 'connecting' &&
-                    current.sessionId === sessionId
-                      ? {
-                          ...current,
-                          status: 'disconnected',
-                          sessionId: undefined,
-                          loadingTranscript: undefined,
-                          catchingUp: undefined,
-                        }
-                      : current,
-                  );
+                  setRestoreWorkspaceCwd(undefined);
+                  setConnection((current) => {
+                    if (
+                      current.status !== 'connecting' ||
+                      current.sessionId !== sessionId
+                    ) {
+                      return current;
+                    }
+                    return {
+                      ...getConnectionAfterSessionClear(current, sessionId),
+                      status: 'disconnected',
+                    };
+                  });
                 }
                 reject(
                   dispatchActionError(

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -244,6 +244,8 @@ export function createDaemonSessionActions({
               if (pendingSessionLoadRef.current?.id === loadId) {
                 pendingSessionLoadRef.current = undefined;
                 if (sessionRef.current?.sessionId !== sessionId) {
+                  manualSessionClearRef.current = true;
+                  setRestoreSessionId(undefined);
                   setConnection((current) =>
                     current.status === 'connecting' &&
                     current.sessionId === sessionId


### PR DESCRIPTION
## What this PR does

Clears the never-attached target session identity when a session-switch watchdog expires. The disconnected state no longer treats that timed-out target as the current session, so selecting it again starts a new load normally.

## Why it's needed

PR #8864 added watchdog settlement for a session switch that keeps receiving the transient closing response. The timeout changed the connection to `disconnected` but retained the target session ID. The Web Shell sidebar derives its current selection from that ID, so clicking the same target again returned early instead of retrying the load.

This is the bounded follow-up identified after #8864 merged. The broader transactional switching work in #8882 avoids publishing a pending target in its modern path, while this patch keeps the existing watchdog and legacy fallback path recoverable.

## Reviewer Test Plan

### How to verify

Start from session A and load session B without allowing B to attach. Advance the load watchdog to its deadline and confirm the load rejects, the connection settles as disconnected without a session ID, and selecting session B again follows the normal load path. Confirm that reloading the attached session and superseding a pending load still keep their existing guards.

### Evidence (Before & After)

Before: the watchdog test settled as `{ status: 'disconnected', sessionId: 'session-b' }`, causing the sidebar to treat session B as already selected.

After: the same test settles as `{ status: 'disconnected', sessionId: undefined }`; the sidebar derives no current session identity and can load session B again. The focused action suite passes 51/51 tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS, Node.js v22.22.0, npm 10.9.4. Verified with the focused WebUI action suite, WebUI typecheck/build, focused ESLint, Prettier, and `git diff --check`.

## Risk & Scope

- Main risk or tradeoff: the target identity is cleared only when the same pending load still owns the watchdog and no matching session has attached.
- Not validated / out of scope: transactional cross-session ownership and staging in #8882; no provider or protocol behavior changes.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #8864. Related to #8882.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

当会话切换的 watchdog 到期时，清除从未完成附着的目标会话 identity。断开状态不再把超时目标视为当前会话，因此再次选择该会话会正常发起新的加载。

## 为什么需要

PR #8864 为持续收到临时 closing 响应的会话切换增加了 watchdog 结算。超时会把连接切换为 `disconnected`，但仍保留目标 session ID。Web Shell 侧边栏从该 ID 派生当前选择，因此再次点击同一个目标时会提前返回，而不会重试加载。

这是 #8864 合并后确认的有限 follow-up。#8882 中更广泛的事务化切换在现代路径上不会发布 pending 目标；本补丁则确保现有 watchdog 与 legacy fallback 路径仍可恢复。

## Reviewer 测试计划

### 如何验证

从 session A 开始加载 session B，但不允许 B 完成附着。将加载 watchdog 推进到截止时间，确认加载被拒绝、连接进入不带 session ID 的 disconnected 状态，并且再次选择 session B 会进入正常加载路径。同时确认重载已附着会话和替换 pending load 的既有守卫保持不变。

### 证据（修改前后）

修改前：watchdog 测试最终得到 `{ status: 'disconnected', sessionId: 'session-b' }`，导致侧边栏把 session B 当作已选择。

修改后：同一测试最终得到 `{ status: 'disconnected', sessionId: undefined }`；侧边栏不再派生出当前 session identity，可以重新加载 session B。聚焦 action 测试共 51/51 通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS、Node.js v22.22.0、npm 10.9.4。已验证 WebUI 聚焦 action 测试、WebUI typecheck/build、聚焦 ESLint、Prettier 和 `git diff --check`。

## 风险与范围

- 主要风险或取舍：仅当同一个 pending load 仍持有 watchdog 且没有匹配会话完成附着时，才清除目标 identity。
- 未验证 / 范围外：#8882 中的事务化跨会话 ownership 与 staging；本 PR 不修改 provider 或协议行为。
- Breaking change / 迁移说明：无。

## 关联 Issue

#8864 的 follow-up；与 #8882 相关。

</details>
