### PR TITLE
fix(ci): stream autofix agent progress

### DIFF
--- a/.qwen/skills/autofix/scripts/run-agent.mjs
+++ b/.qwen/skills/autofix/scripts/run-agent.mjs
@@ -177,6 +177,19 @@ function isLoopGuardOutput(output) {
   );
 }
 
+function streamResultOutput(event) {
+  if (!event || event.type !== 'result') return '';
+  return [event.error?.message, event.result]
+    .filter((value) => typeof value === 'string')
+    .join('\n');
+}
+
+function isLoopGuardResult(event) {
+  return (
+    event?.is_error === true && isLoopGuardOutput(streamResultOutput(event))
+  );
+}
+
 function killQwen(child, signal) {
   try {
     process.kill(-child.pid, signal);
@@ -191,8 +204,9 @@ function runQwen(options, prompt) {
     flags: 'w',
   });
   log.on('error', () => {});
-  let outputTail = '';
-  let loopDetected = false;
+  let diagnosticTail = '';
+  let stdoutCarry = '';
+  let terminalResult;
   let settled = false;
   let timedOut = false;
   let idleTimedOut = false;
@@ -224,18 +238,44 @@ function runQwen(options, prompt) {
       },
     );
 
+    const appendDiagnostic = (text) => {
+      diagnosticTail = (diagnosticTail + text).slice(-20_000);
+    };
+
+    const consumeStreamJson = (text, final = false) => {
+      stdoutCarry += text;
+      const lines = stdoutCarry.split('\n');
+      stdoutCarry = final ? '' : (lines.pop() ?? '');
+      if (final && lines.at(-1) === '') lines.pop();
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const event = JSON.parse(line);
+          if (event?.type === 'result') terminalResult = event;
+        } catch {
+          appendDiagnostic(`${line}\n`);
+        }
+      }
+    };
+
     const finish = (result) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
       clearTimeout(killTimer);
       clearInterval(idleTimer);
-      const apiErrorInfo = recoverableApiError(outputTail);
+      consumeStreamJson('', true);
+      const terminalOutput = streamResultOutput(terminalResult);
+      const apiErrorInfo = recoverableApiError(
+        result.status === 0
+          ? terminalOutput
+          : `${diagnosticTail}\n${terminalOutput}`,
+      );
       const payload = {
         ...result,
         timedOut,
         idleTimedOut,
-        loopDetected: loopDetected || isLoopGuardOutput(outputTail),
+        loopDetected: isLoopGuardResult(terminalResult),
         // A RECOVERABLE model error means qwen never evaluated the feedback —
         // the workflow retries it rather than advancing the watermark.
         apiError: apiErrorInfo.error,
@@ -249,7 +289,7 @@ function runQwen(options, prompt) {
       }
     };
 
-    const record = (chunk, stream) => {
+    const record = (chunk, stream, source) => {
       lastOutputAt = Date.now();
       const text = chunk.toString('utf8');
       if (!sandboxName) {
@@ -268,14 +308,17 @@ function runQwen(options, prompt) {
           }
         }
       }
-      outputTail = (outputTail + text).slice(-20_000);
-      if (!loopDetected && isLoopGuardOutput(outputTail)) loopDetected = true;
+      if (source === 'stdout') {
+        consumeStreamJson(text);
+      } else {
+        appendDiagnostic(text);
+      }
       log.write(chunk);
       stream.write(chunk);
     };
 
-    child.stdout.on('data', (chunk) => record(chunk, process.stdout));
-    child.stderr.on('data', (chunk) => record(chunk, process.stderr));
+    child.stdout.on('data', (chunk) => record(chunk, process.stdout, 'stdout'));
+    child.stderr.on('data', (chunk) => record(chunk, process.stderr, 'stderr'));
     child.on('error', (error) => finish({ error, status: null, signal: null }));
     child.on('close', (status, signal) =>
       finish({ error: null, status, signal }),
@@ -511,9 +554,7 @@ if (spec.exclusiveOutput && presentOutputs.length > 1) {
   writeFailure(options.workdir, message);
   fail(message);
 }
-const ok = spec.anyOutput
-  ? missingOutputs.length < spec.outputs.length
-  : missingOutputs.length === 0;
+const ok = hasOutputVerdict;
 if (!ok) {
   const message = `Autofix agent finished without required output file(s): ${missingOutputs.join(', ')}.`;
   writeFailure(options.workdir, message);

--- a/.qwen/skills/autofix/scripts/run-agent.mjs
+++ b/.qwen/skills/autofix/scripts/run-agent.mjs
@@ -38,6 +38,7 @@ const QWEN_IDLE_TIMEOUT_MS =
   Number.isFinite(parsedIdleTimeoutMs) && parsedIdleTimeoutMs > 0
     ? parsedIdleTimeoutMs
     : 20 * 60 * 1000;
+const MAX_STREAM_JSON_LINE_LENGTH = 1024 * 1024;
 const specs = {
   'assess-candidates': {
     inputs: ['candidates.json'],
@@ -206,6 +207,7 @@ function runQwen(options, prompt) {
   log.on('error', () => {});
   let diagnosticTail = '';
   let stdoutCarry = '';
+  let discardingOversizedStdoutLine = false;
   let terminalResult;
   let settled = false;
   let timedOut = false;
@@ -242,19 +244,49 @@ function runQwen(options, prompt) {
       diagnosticTail = (diagnosticTail + text).slice(-20_000);
     };
 
-    const consumeStreamJson = (text, final = false) => {
-      stdoutCarry += text;
-      const lines = stdoutCarry.split('\n');
-      stdoutCarry = final ? '' : (lines.pop() ?? '');
-      if (final && lines.at(-1) === '') lines.pop();
-      for (const line of lines) {
-        if (!line.trim()) continue;
-        try {
-          const event = JSON.parse(line);
-          if (event?.type === 'result') terminalResult = event;
-        } catch {
-          appendDiagnostic(`${line}\n`);
+    const consumeStreamJsonLine = (line, terminated) => {
+      if (!line.trim()) return;
+      try {
+        const event = JSON.parse(line);
+        lastOutputAt = Date.now();
+        if (event?.type === 'result') terminalResult = event;
+        if (event?.type !== 'stream_event') {
+          process.stdout.write(`${line}${terminated ? '\n' : ''}`);
         }
+      } catch {
+        appendDiagnostic(`${line}${terminated ? '\n' : ''}`);
+        process.stdout.write(`${line}${terminated ? '\n' : ''}`);
+      }
+    };
+
+    const consumeStreamJson = (text, final = false) => {
+      const parts = text.split('\n');
+      for (const [index, part] of parts.entries()) {
+        const terminated = index < parts.length - 1;
+        if (!discardingOversizedStdoutLine) {
+          const remaining = MAX_STREAM_JSON_LINE_LENGTH - stdoutCarry.length;
+          if (part.length <= remaining) {
+            stdoutCarry += part;
+          } else {
+            appendDiagnostic(`${stdoutCarry}${part.slice(0, remaining)}`);
+            stdoutCarry = '';
+            discardingOversizedStdoutLine = true;
+          }
+        }
+        if (terminated) {
+          if (!discardingOversizedStdoutLine) {
+            consumeStreamJsonLine(stdoutCarry, true);
+          }
+          stdoutCarry = '';
+          discardingOversizedStdoutLine = false;
+        }
+      }
+      if (final) {
+        if (!discardingOversizedStdoutLine) {
+          consumeStreamJsonLine(stdoutCarry, false);
+        }
+        stdoutCarry = '';
+        discardingOversizedStdoutLine = false;
       }
     };
 
@@ -290,7 +322,6 @@ function runQwen(options, prompt) {
     };
 
     const record = (chunk, stream, source) => {
-      lastOutputAt = Date.now();
       const text = chunk.toString('utf8');
       if (!sandboxName) {
         lineCarry += text;
@@ -311,10 +342,11 @@ function runQwen(options, prompt) {
       if (source === 'stdout') {
         consumeStreamJson(text);
       } else {
+        lastOutputAt = Date.now();
         appendDiagnostic(text);
+        stream.write(chunk);
       }
       log.write(chunk);
-      stream.write(chunk);
     };
 
     child.stdout.on('data', (chunk) => record(chunk, process.stdout, 'stdout'));

--- a/.qwen/skills/autofix/scripts/run-agent.mjs
+++ b/.qwen/skills/autofix/scripts/run-agent.mjs
@@ -39,6 +39,8 @@ const QWEN_IDLE_TIMEOUT_MS =
     ? parsedIdleTimeoutMs
     : 20 * 60 * 1000;
 const MAX_STREAM_JSON_LINE_LENGTH = 1024 * 1024;
+const OVERSIZED_STREAM_JSON_LINE_NOTICE =
+  '[run-agent] dropped oversized stream-json line; full bytes in agent.log\n';
 const specs = {
   'assess-candidates': {
     inputs: ['candidates.json'],
@@ -268,13 +270,14 @@ function runQwen(options, prompt) {
           if (part.length <= remaining) {
             stdoutCarry += part;
           } else {
-            appendDiagnostic(`${stdoutCarry}${part.slice(0, remaining)}`);
             stdoutCarry = '';
             discardingOversizedStdoutLine = true;
           }
         }
         if (terminated) {
-          if (!discardingOversizedStdoutLine) {
+          if (discardingOversizedStdoutLine) {
+            process.stdout.write(OVERSIZED_STREAM_JSON_LINE_NOTICE);
+          } else {
             consumeStreamJsonLine(stdoutCarry, true);
           }
           stdoutCarry = '';
@@ -282,7 +285,9 @@ function runQwen(options, prompt) {
         }
       }
       if (final) {
-        if (!discardingOversizedStdoutLine) {
+        if (discardingOversizedStdoutLine) {
+          process.stdout.write(OVERSIZED_STREAM_JSON_LINE_NOTICE);
+        } else {
           consumeStreamJsonLine(stdoutCarry, false);
         }
         stdoutCarry = '';

--- a/.qwen/skills/autofix/scripts/run-agent.mjs
+++ b/.qwen/skills/autofix/scripts/run-agent.mjs
@@ -406,7 +406,24 @@ const result = await runQwen(options, prompt);
 // timeout) so the leak warning and the removal itself settle before this
 // process exits and the next step inspects the host.
 if (result.sandboxRemoval) await result.sandboxRemoval;
-if (result.error || result.signal || result.status !== 0) {
+const missingOutputs = missing(options.workdir, spec.outputs);
+const presentOutputs = spec.outputs.filter(
+  (name) => !missingOutputs.includes(name),
+);
+const hasOutputVerdict = spec.anyOutput
+  ? presentOutputs.length > 0
+  : missingOutputs.length === 0;
+const apiErrorWithoutVerdict =
+  result.status === 0 &&
+  result.apiError &&
+  !hasOutputVerdict &&
+  !existsSync(file(options.workdir, 'failure.md'));
+if (
+  result.error ||
+  result.signal ||
+  result.status !== 0 ||
+  apiErrorWithoutVerdict
+) {
   const detail = result.error
     ? result.error.message
     : result.idleTimedOut
@@ -415,7 +432,9 @@ if (result.error || result.signal || result.status !== 0) {
         ? `timeout (${QWEN_TIMEOUT_MS}ms)`
         : result.signal
           ? `signal ${result.signal}`
-          : `status ${String(result.status)}`;
+          : apiErrorWithoutVerdict
+            ? 'recoverable API error without an agent verdict'
+            : `status ${String(result.status)}`;
   if (!existsSync(file(options.workdir, 'failure.md'))) {
     if (result.loopDetected) {
       writeFailure(
@@ -474,7 +493,7 @@ if (result.error || result.signal || result.status !== 0) {
       `Qwen failed during ${options.mode}: ${detail}; preserving agent-written failure.md.`,
     );
   }
-  process.exit(result.status ?? 1);
+  process.exit(result.status === 0 ? 1 : (result.status ?? 1));
 }
 
 if (existsSync(file(options.workdir, 'failure.md'))) {
@@ -487,10 +506,6 @@ if (existsSync(file(options.workdir, 'failure.md'))) {
   process.exit(0);
 }
 
-const missingOutputs = missing(options.workdir, spec.outputs);
-const presentOutputs = spec.outputs.filter(
-  (name) => !missingOutputs.includes(name),
-);
 if (spec.exclusiveOutput && presentOutputs.length > 1) {
   const message = `Autofix agent wrote mutually exclusive output files: ${presentOutputs.join(', ')}.`;
   writeFailure(options.workdir, message);

--- a/.qwen/skills/autofix/scripts/run-agent.mjs
+++ b/.qwen/skills/autofix/scripts/run-agent.mjs
@@ -22,10 +22,11 @@ const QWEN_TIMEOUT_MS = Number(process.env.QWEN_TIMEOUT_MS) || 50 * 60 * 1000;
 // Idle watchdog: a wedged sandbox produces NOTHING — four observed hangs
 // (#8663 x2, #8761 r3, #8763 r4) each printed their last byte at docker
 // container entry and then sat silent for the whole absolute budget,
-// burning 2 hours per round for zero work. Legitimate runs are never that
-// quiet: the longest silence the fleet tolerates elsewhere is the review
-// pipeline's 10-minute stream-idle window for thinking phases on ~1M-token
-// contexts, so twice that is the default. Distinct from QWEN_TIMEOUT_MS so
+// burning 2 hours per round for zero work. Streamed agent events keep active
+// runs observable; the longest silence the fleet tolerates elsewhere is the
+// review pipeline's 10-minute stream-idle window for thinking phases on
+// ~1M-token contexts, so twice that is the default. Distinct from
+// QWEN_TIMEOUT_MS so
 // the failure comment says which limit fired; a leg whose absolute budget is
 // shorter than this window (the review workflow's 18-minute repair pass)
 // always reaches the absolute timer first.
@@ -207,10 +208,21 @@ function runQwen(options, prompt) {
   let sandboxRemoval = null;
 
   return new Promise((resolve) => {
-    const child = spawn(options.qwenBin, ['--yolo', '--prompt', prompt], {
-      stdio: ['inherit', 'pipe', 'pipe'],
-      detached: true,
-    });
+    const child = spawn(
+      options.qwenBin,
+      [
+        '--yolo',
+        '--output-format',
+        'stream-json',
+        '--include-partial-messages',
+        '--prompt',
+        prompt,
+      ],
+      {
+        stdio: ['inherit', 'pipe', 'pipe'],
+        detached: true,
+      },
+    );
 
     const finish = (result) => {
       if (settled) return;

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -10828,6 +10828,29 @@ exit 1
     });
   });
 
+  it('flags a recoverable stream-json API error even when qwen exits zero', () => {
+    withRunnerDir((dir) => {
+      writeFileSync(join(dir, 'feedback.md'), 'feedback\n');
+      const stub = writeQwenStub(dir, [
+        "process.stdout.write('[API Error: 429 quota exceeded]\\n');",
+        'process.exit(0);',
+      ]);
+
+      const result = runAddressReview(dir, stub);
+
+      expect(result.status).not.toBe(0);
+      expect(readFileSync(join(dir, 'failure.md'), 'utf8')).toContain(
+        '[API Error: 429 quota exceeded]',
+      );
+      expect(readFileSync(join(dir, 'agent-api-error'), 'utf8')).toContain(
+        '429 quota exceeded',
+      );
+      expect(
+        readFileSync(join(dir, 'agent-api-error-kind'), 'utf8').trim(),
+      ).toBe('transient');
+    });
+  });
+
   it('does not flag a non-API subprocess failure for retry', () => {
     withRunnerDir((dir) => {
       writeFileSync(join(dir, 'feedback.md'), 'feedback\n');

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -10876,6 +10876,39 @@ exit 1
     });
   });
 
+  it('classifies split and unterminated stream-json result lines', () => {
+    for (const [name, writes] of [
+      [
+        'split',
+        [
+          "const line = qwenResultLine({ result: '[API Error: 429 quota exceeded]' });",
+          'process.stdout.write(line.slice(0, 20));',
+          'process.stdout.write(line.slice(20));',
+        ],
+      ],
+      [
+        'unterminated',
+        [
+          "process.stdout.write(qwenResultLine({ result: '[API Error: 429 quota exceeded]' }).trimEnd());",
+        ],
+      ],
+    ]) {
+      withRunnerDir((dir) => {
+        writeFileSync(join(dir, 'feedback.md'), 'feedback\n');
+        const stub = writeWorkdirStub(dir, [
+          "const qwenResultLine = (value) => `${JSON.stringify({ type: 'result', subtype: 'success', is_error: false, ...value })}\\n`;",
+          ...writes,
+          'process.exit(0);',
+        ]);
+
+        const result = runAddressReview(dir, stub);
+
+        expect(result.status, name).not.toBe(0);
+        expect(existsSync(join(dir, 'agent-api-error')), name).toBe(true);
+      });
+    }
+  });
+
   it('ignores API-error markers from streamed tool results', () => {
     withRunnerDir((dir) => {
       writeFileSync(join(dir, 'feedback.md'), 'feedback\n');
@@ -12000,8 +12033,12 @@ describe('run-agent idle watchdog', () => {
       );
       return {
         status: res.status,
+        stdout: res.stdout,
         failure: existsSync(join(workdir, 'failure.md'))
           ? readFileSync(join(workdir, 'failure.md'), 'utf8')
+          : '',
+        agentLog: existsSync(join(workdir, 'agent.log'))
+          ? readFileSync(join(workdir, 'agent.log'), 'utf8')
           : '',
         timeoutSentinel: existsSync(join(workdir, 'agent-timeout'))
           ? readFileSync(join(workdir, 'agent-timeout'), 'utf8')
@@ -12029,17 +12066,16 @@ describe('run-agent idle watchdog', () => {
     expect(r.timeoutSentinel).toContain('idle-timeout (no output for 1200ms');
   });
 
-  it('never fires while the agent keeps talking, however slowly', () => {
+  it('never fires while the agent emits protocol events, however slowly', () => {
     // Output every 400ms with a 1500ms idle window: an absolute-timer
     // regression disguised as an idle watchdog would kill this run.
     const r = runAgent({
       stub: [
         '#!/bin/bash',
-        'for i in $(seq 1 8); do echo "tick $i"; sleep 0.4; done',
+        'for i in $(seq 1 8); do echo "{\\"type\\":\\"progress\\",\\"step\\":$i}"; sleep 0.4; done',
         // The mode's output contract: a real run ends by writing its
         // summary, and the script fails a run that produced neither output.
         'echo summary > "${AGENT_WORKDIR}/address-summary.md"',
-        'echo done',
         'exit 0',
       ].join('\n'),
       idleMs: 1500,
@@ -12066,6 +12102,23 @@ describe('run-agent idle watchdog', () => {
     expect(r.failure).toBe('');
   });
 
+  it('does not treat an unterminated stdout byte stream as progress', () => {
+    const r = runAgent({
+      stub: [
+        '#!/bin/bash',
+        'for i in $(seq 1 20); do printf x; sleep 0.2; done',
+        'echo summary > "${AGENT_WORKDIR}/address-summary.md"',
+        'exit 0',
+      ].join('\n'),
+      idleMs: 700,
+      timeoutMs: 2400,
+    });
+
+    expect(r.status).not.toBe(0);
+    expect(r.failure).toContain('idle-timeout (no output for 700ms');
+    expect(r.failure).not.toContain('timeout (2400ms)');
+  });
+
   it('requests streamed partial progress so active headless work refreshes the watchdog', () => {
     const r = runAgent({
       stub: [
@@ -12082,6 +12135,43 @@ describe('run-agent idle watchdog', () => {
     });
     expect(r.status).toBe(0);
     expect(r.failure).toBe('');
+  });
+
+  it('keeps partial events in the artifact without flooding step output', () => {
+    const payload = 'x'.repeat(10_000);
+    const streamEvent = JSON.stringify({
+      type: 'stream_event',
+      event: { type: 'input_json_delta', partial_json: payload },
+    });
+    const r = runAgent({
+      stub: [
+        '#!/bin/bash',
+        `printf '%s\\n' '${streamEvent}'`,
+        'echo summary > "${AGENT_WORKDIR}/address-summary.md"',
+        'exit 0',
+      ].join('\n'),
+      idleMs: 1500,
+    });
+
+    expect(r.status).toBe(0);
+    expect(r.stdout).not.toContain(payload);
+    expect(r.agentLog).toContain(payload);
+  });
+
+  it('bounds an unterminated stdout line while retaining the artifact', () => {
+    const r = runAgent({
+      stub: [
+        '#!/bin/bash',
+        "head -c 2097152 /dev/zero | tr '\\0' x",
+        'echo summary > "${AGENT_WORKDIR}/address-summary.md"',
+        'exit 0',
+      ].join('\n'),
+      idleMs: 1500,
+    });
+
+    expect(r.status).toBe(0);
+    expect(r.stdout.length).toBeLessThan(10_000);
+    expect(r.agentLog.length).toBe(2_097_152);
   });
 
   it('ignores a non-positive or non-numeric QWEN_IDLE_TIMEOUT_MS instead of arming it', () => {

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -11824,10 +11824,9 @@ describe('run-agent idle watchdog', () => {
   // last byte at docker container entry and then sat SILENT for the whole
   // 2-hour absolute budget — four different runners, two image versions, so
   // the watchdog lives in the runner script, not the environment. A wedged
-  // sandbox produces nothing; a legitimate run is never silent for 20
-  // minutes (the fleet's longest tolerated quiet is the review pipeline's
-  // 10-minute stream-idle window). These tests execute the REAL script with
-  // a stub agent whose only difference is whether it keeps talking.
+  // sandbox produces nothing; stream-json makes active headless work emit
+  // progress before its final result. These tests execute the REAL script
+  // with a stub agent whose only difference is whether it keeps talking.
   const runAgent = ({ stub, idleMs, timeoutMs = 60_000 }) => {
     const dir = mkdtempSync(join(tmpdir(), 'agent-idle-'));
     try {
@@ -11923,6 +11922,24 @@ describe('run-agent idle watchdog', () => {
         'for i in $(seq 1 8); do echo "tick $i" >&2; sleep 0.4; done',
         'echo summary > "${AGENT_WORKDIR}/address-summary.md"',
         'echo done',
+        'exit 0',
+      ].join('\n'),
+      idleMs: 1500,
+    });
+    expect(r.status).toBe(0);
+    expect(r.failure).toBe('');
+  });
+
+  it('requests streamed partial progress so active headless work refreshes the watchdog', () => {
+    const r = runAgent({
+      stub: [
+        '#!/bin/bash',
+        'if [[ " $* " == *" --output-format stream-json "* && " $* " == *" --include-partial-messages "* ]]; then',
+        '    for i in $(seq 1 8); do echo "{\\"type\\":\\"progress\\",\\"step\\":$i}"; sleep 0.4; done',
+        'else',
+        '    sleep 4',
+        'fi',
+        'echo summary > "${AGENT_WORKDIR}/address-summary.md"',
         'exit 0',
       ].join('\n'),
       idleMs: 1500,

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -283,6 +283,16 @@ function writeWorkdirStub(dir, lines) {
   ]);
 }
 
+function qwenResultLine({ result, errorMessage, isError = false }) {
+  return `${JSON.stringify({
+    type: 'result',
+    subtype: isError ? 'error_during_execution' : 'success',
+    is_error: isError,
+    ...(result === undefined ? {} : { result }),
+    ...(errorMessage === undefined ? {} : { error: { message: errorMessage } }),
+  })}\n`;
+}
+
 function runAutofixRunner(args) {
   return spawnSync(process.execPath, [autofixRunnerScriptPath, ...args], {
     encoding: 'utf8',
@@ -10712,7 +10722,12 @@ exit 1
     withRunnerDir((dir) => {
       writeFileSync(join(dir, 'feedback.md'), 'feedback\n');
       const stub = writeQwenStub(dir, [
-        "process.stderr.write('turn_tool_call_cap: too many tool calls\\n');",
+        `process.stdout.write(${JSON.stringify(
+          qwenResultLine({
+            errorMessage: 'turn_tool_call_cap: too many tool calls',
+            isError: true,
+          }),
+        )});`,
         'process.exit(1);',
       ]);
 
@@ -10744,7 +10759,12 @@ exit 1
     withRunnerDir((dir) => {
       writeFileSync(join(dir, 'feedback.md'), 'feedback\n');
       const stub = writeQwenStub(dir, [
-        "process.stderr.write('Loop detection halted the run\\n');",
+        `process.stdout.write(${JSON.stringify(
+          qwenResultLine({
+            errorMessage: 'Loop detection halted the run',
+            isError: true,
+          }),
+        )});`,
         "process.stdout.write('x'.repeat(21_000));",
         'process.exit(1);',
       ]);
@@ -10832,7 +10852,9 @@ exit 1
     withRunnerDir((dir) => {
       writeFileSync(join(dir, 'feedback.md'), 'feedback\n');
       const stub = writeQwenStub(dir, [
-        "process.stdout.write('[API Error: 429 quota exceeded]\\n');",
+        `process.stdout.write(${JSON.stringify(
+          qwenResultLine({ result: '[API Error: 429 quota exceeded]' }),
+        )});`,
         'process.exit(0);',
       ]);
 
@@ -10842,12 +10864,98 @@ exit 1
       expect(readFileSync(join(dir, 'failure.md'), 'utf8')).toContain(
         '[API Error: 429 quota exceeded]',
       );
+      expect(readFileSync(join(dir, 'failure.md'), 'utf8')).toContain(
+        'recoverable API error without an agent verdict',
+      );
       expect(readFileSync(join(dir, 'agent-api-error'), 'utf8')).toContain(
         '429 quota exceeded',
       );
       expect(
         readFileSync(join(dir, 'agent-api-error-kind'), 'utf8').trim(),
       ).toBe('transient');
+    });
+  });
+
+  it('ignores API-error markers from streamed tool results', () => {
+    withRunnerDir((dir) => {
+      writeFileSync(join(dir, 'feedback.md'), 'feedback\n');
+      const toolResult = `${JSON.stringify({
+        type: 'user',
+        message: {
+          content: [
+            {
+              type: 'tool_result',
+              content: '[API Error: 429 quota exceeded]',
+            },
+          ],
+        },
+      })}\n`;
+      const stub = writeQwenStub(dir, [
+        `process.stdout.write(${JSON.stringify(toolResult)});`,
+        'process.exit(0);',
+      ]);
+
+      const result = runAddressReview(dir, stub);
+
+      expect(result.status).not.toBe(0);
+      expect(existsSync(join(dir, 'agent-api-error'))).toBe(false);
+      expect(readFileSync(join(dir, 'failure.md'), 'utf8')).toContain(
+        'finished without required output file(s)',
+      );
+    });
+  });
+
+  it('ignores loop-guard markers from streamed tool results', () => {
+    withRunnerDir((dir) => {
+      writeFileSync(join(dir, 'feedback.md'), 'feedback\n');
+      const toolResult = `${JSON.stringify({
+        type: 'user',
+        message: {
+          content: [
+            {
+              type: 'tool_result',
+              content: 'turn_tool_call_cap Loop detection halted the run',
+            },
+          ],
+        },
+      })}\n`;
+      const stub = writeQwenStub(dir, [
+        `process.stdout.write(${JSON.stringify(toolResult)});`,
+        `process.stdout.write(${JSON.stringify(
+          qwenResultLine({
+            errorMessage: '[API Error: 429 quota exceeded]',
+            isError: true,
+          }),
+        )});`,
+        'process.exit(1);',
+      ]);
+
+      const result = runAddressReview(dir, stub);
+
+      expect(result.status).not.toBe(0);
+      expect(existsSync(join(dir, 'handoff.md'))).toBe(false);
+      expect(readFileSync(join(dir, 'agent-api-error'), 'utf8')).toContain(
+        '429 quota exceeded',
+      );
+    });
+  });
+
+  it('keeps a recovered exit-zero run with a verdict out of the API-error retry path', () => {
+    withRunnerDir((dir) => {
+      writeFileSync(join(dir, 'feedback.md'), 'feedback\n');
+      const stub = writeWorkdirStub(dir, [
+        `process.stdout.write(${JSON.stringify(
+          qwenResultLine({ result: '[API Error: 429 quota exceeded]' }),
+        )});`,
+        "writeFileSync(`${workdir}/address-summary.md`, 'summary\\n');",
+        'process.exit(0);',
+      ]);
+
+      const result = runAddressReview(dir, stub);
+
+      expect(result.status).toBe(0);
+      expect(existsSync(join(dir, 'failure.md'))).toBe(false);
+      expect(existsSync(join(dir, 'agent-api-error'))).toBe(false);
     });
   });
 
@@ -10886,7 +10994,12 @@ exit 1
     withRunnerDir((dir) => {
       writeFileSync(join(dir, 'feedback.md'), 'feedback\n');
       const stub = writeQwenStub(dir, [
-        "process.stderr.write('Loop detection halted the run\\n');",
+        `process.stdout.write(${JSON.stringify(
+          qwenResultLine({
+            errorMessage: 'Loop detection halted the run',
+            isError: true,
+          }),
+        )});`,
         "process.stdout.write('[API Error: 503 upstream overloaded]\\n');",
         'process.exit(1);',
       ]);

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -10755,7 +10755,7 @@ exit 1
     );
   });
 
-  it('detects loop guard output before it falls out of the log tail', () => {
+  it('detects the terminal loop result despite later log output', () => {
     withRunnerDir((dir) => {
       writeFileSync(join(dir, 'feedback.md'), 'feedback\n');
       const stub = writeQwenStub(dir, [
@@ -10765,6 +10765,7 @@ exit 1
             isError: true,
           }),
         )});`,
+        // Trailing output must not replace the already parsed terminal result.
         "process.stdout.write('x'.repeat(21_000));",
         'process.exit(1);',
       ]);
@@ -10935,6 +10936,66 @@ exit 1
       expect(readFileSync(join(dir, 'failure.md'), 'utf8')).toContain(
         'finished without required output file(s)',
       );
+    });
+  });
+
+  it('drops oversized stdout lines from API-error diagnostics', () => {
+    withRunnerDir((dir) => {
+      writeFileSync(join(dir, 'feedback.md'), 'feedback\n');
+      const oversizedToolResult = `${JSON.stringify({
+        type: 'user',
+        message: {
+          content: [
+            {
+              type: 'tool_result',
+              content:
+                'x'.repeat(1_045_000) +
+                '[API Error: 429 quota exceeded]' +
+                'x'.repeat(55_000),
+            },
+          ],
+        },
+      })}\n`;
+      const stub = writeQwenStub(dir, [
+        `process.stdout.write(${JSON.stringify(oversizedToolResult)}, () => process.exit(1));`,
+      ]);
+
+      const result = runAddressReview(dir, stub);
+
+      expect(result.status).not.toBe(0);
+      expect(existsSync(join(dir, 'agent-api-error'))).toBe(false);
+      expect(readFileSync(join(dir, 'failure.md'), 'utf8')).toContain(
+        'status 1',
+      );
+      expect(result.stdout).toContain(
+        'dropped oversized stream-json line; full bytes in agent.log',
+      );
+    });
+  });
+
+  it('resumes parsing after a terminated oversized stdout line', () => {
+    withRunnerDir((dir) => {
+      writeFileSync(join(dir, 'feedback.md'), 'feedback\n');
+      const loopResult = qwenResultLine({
+        errorMessage: 'Loop detection halted the run',
+        isError: true,
+      });
+      const stub = writeQwenStub(dir, [
+        `process.stdout.write('x'.repeat(1_100_000) + '\\n' + ${JSON.stringify(
+          loopResult,
+        )});`,
+        'process.exitCode = 1;',
+      ]);
+
+      const result = runAddressReview(dir, stub);
+
+      expect(result.status).not.toBe(0);
+      expect(readFileSync(join(dir, 'handoff.md'), 'utf8')).toContain(
+        'human should take over',
+      );
+      expect(
+        result.stdout.match(/dropped oversized stream-json line/g),
+      ).toHaveLength(1);
     });
   });
 
@@ -12124,7 +12185,7 @@ describe('run-agent idle watchdog', () => {
       stub: [
         '#!/bin/bash',
         'if [[ " $* " == *" --output-format stream-json "* && " $* " == *" --include-partial-messages "* ]]; then',
-        '    for i in $(seq 1 8); do echo "{\\"type\\":\\"progress\\",\\"step\\":$i}"; sleep 0.4; done',
+        '    for i in $(seq 1 8); do echo "{\\"type\\":\\"stream_event\\",\\"event\\":{\\"type\\":\\"input_json_delta\\",\\"partial_json\\":\\"x\\"}}"; sleep 0.4; done',
         'else',
         '    sleep 4',
         'fi',


### PR DESCRIPTION
## What this PR does

AutoFix now asks the headless Qwen process to emit streamed partial progress. The existing idle watchdog can therefore distinguish active tool work from a sandbox that stopped producing output. A regression test requires both stream JSON output and partial messages before treating a long-running headless task as active.

## Why it's needed

The default text output buffers non-interactive agent events until the final result. AutoFix was using stdout and stderr as its liveness signal, so productive rounds could modify source and tests for 20 minutes without emitting a chunk and then be killed as a silent sandbox. Six managed PRs recently reached the cumulative timeout breaker after this failure pattern.

## Reviewer Test Plan

### How to verify

Run the AutoFix workflow contract test and confirm that a headless stub emitting partial stream events remains alive beyond the idle window, while a genuinely silent stub is still terminated and reported as an idle timeout. Removing either streaming flag should make the new regression fail.

### Evidence (Before & After)

N/A (non-UI workflow behavior). Before the fix, the regression exited 1 after the 1.5-second idle window. With both streaming flags, the same regression exits 0 after approximately 4 seconds. The focused watchdog group passes 5/5 and sandbox cleanup passes 3/3. The complete workflow file reached 150/150 passing assertions twice; the local Vitest worker then reported an unrelated `onTaskUpdate` RPC timeout and returned exit 1.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Node.js 22, local workflow contract tests with a stubbed Qwen executable.

## Risk & Scope

- Main risk or tradeoff: AutoFix logs contain more structured progress events and may be larger during tool-heavy rounds.
- Not validated / out of scope: a live ECS sandbox run and re-arming PRs that already reached the cumulative timeout breaker.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

AutoFix 现在会要求无头 Qwen 进程输出流式 partial progress。现有 idle watchdog 因而能够区分仍在执行工具工作的 agent 与已经停止输出的 sandbox。新增回归测试要求 stream JSON 输出和 partial messages 两个条件同时存在，才把长时间运行的无头任务视为活跃。

## 为什么需要

默认 text 输出会把非交互 agent 事件缓冲到最终结果才写出。AutoFix 原先把 stdout 和 stderr 作为存活信号，因此即使某轮已经持续修改源码和测试，也可能 20 分钟没有输出 chunk，随后被误杀并报告为 silent sandbox。最近有 6 个托管 PR 因相同模式触发累计超时熔断。

## Reviewer 测试计划

### 如何验证

运行 AutoFix workflow 合约测试，确认持续发出 partial stream event 的无头 stub 在超过 idle window 后仍能完成，同时真正静默的 stub 仍会被终止并报告 idle timeout。删除任意一个流式参数都应让新增回归失败。

### 修复前后证据

N/A（非 UI workflow 行为）。修复前，回归测试在 1.5 秒 idle window 后以状态 1 退出；同时启用两个流式参数后，同一回归约 4 秒后以状态 0 退出。聚焦 watchdog 分组 5/5 通过，sandbox cleanup 3/3 通过。完整 workflow 文件两次都达到 150/150 断言通过，但本地 Vitest worker 随后报告无关的 `onTaskUpdate` RPC timeout 并返回状态 1。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

Node.js 22，本地 workflow 合约测试，使用 stub Qwen 可执行文件。

## 风险与范围

- 主要风险或取舍：AutoFix 日志会包含更多结构化进度事件，在工具调用密集的轮次中日志可能更大。
- 未验证 / 范围外：真实 ECS sandbox 运行，以及重新激活已经触发累计超时熔断的 PR。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

N/A

</details>
