### PR TITLE
fix(autofix): hold autofix rounds while review-pr is in flight

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -308,6 +308,7 @@ jobs:
       takeover_cmd: '${{ steps.decide.outputs.takeover_cmd }}'
       retry_pr: '${{ steps.decide.outputs.retry_pr }}'
       cmd_pr: '${{ steps.decide.outputs.cmd_pr }}'
+      review_sender: '${{ github.event.review.user.login }}'
     steps:
       - name: 'Decide phases'
         id: 'decide'
@@ -2003,6 +2004,7 @@ jobs:
           FORCED_PR: '${{ needs.route.outputs.pr_number }}'
           DRY_RUN: '${{ needs.route.outputs.dry_run }}'
           EVENT_NAME: '${{ github.event_name }}'
+          REVIEW_SENDER: '${{ needs.route.outputs.review_sender }}'
           DISPATCH_SOURCE: "${{ github.event_name == 'workflow_dispatch' && inputs.source || '' }}"
         run: |-
           # Every lane that reaches this scan is supposed to hold the PAT:
@@ -2398,6 +2400,16 @@ jobs:
             fi
           fi
 
+          # Review-workflow id, resolved ONCE per scan for the review-in-flight
+          # gate below (#8888): during qwen-code-pr-review.yml's 10-minute
+          # delay-automatic-review wait the review-pr JOB (and thus its
+          # check-run in statusCheckRollup) does not exist yet, so the rollup
+          # alone misses a just-triggered review; the runs API sees the run
+          # by head SHA before its job starts. Empty on lookup failure — the
+          # gate then degrades to the rollup check only (fail-open, like
+          # BUSY_PRS).
+          REVIEW_WF_ID="$(gh api "repos/${REPO}/actions/workflows/qwen-code-pr-review.yml" --jq '.id' 2> /dev/null || echo '')"
+
           # PRs whose review-address is already RUNNING OR QUEUED in any live
           # autofix run must not be re-targeted. Schedule/dispatch runs execute
           # against main's SHA, so their matrix jobs never appear in the PR's
@@ -2605,6 +2617,84 @@ jobs:
             if [[ "${HAS_PENDING_CHECKS}" == "true" ]]; then
               echo "⏳ #${PR}: active checks in flight; skipping until they finish (only checks stuck >${PENDING_STALE_MIN}m past their start are treated as dead and ignored)"
               fleet_row "${PR}" 'waiting' 'active checks in flight'
+              continue
+            fi
+            # Review-in-flight gate (#8888): NON_BLOCKING_CHECKS keeps an
+            # in-flight review-pr from blocking the FEEDBACK gate (its
+            # conclusion carries nothing the loop acts on — #7416), but every
+            # head mutation this scan can make (a stale-base update-branch
+            # below, an address push later) is a synchronize event that
+            # cancels the in-flight review via qwen-code-pr-review.yml's
+            # cancel-in-progress, discarding up to ~3h of review work — the
+            # self-reinforcing cancellation loop of #8830 (three killed runs
+            # in one PR, two by merge-main). Its findings are also the very
+            # feedback the next round should batch with, so deferring the
+            # WHOLE round until the review lands loses nothing: the watermark
+            # is not advanced on a skip, so the feedback stays visible. This
+            # is deliberately SEPARATE from HAS_PENDING_CHECKS rather than a
+            # NON_BLOCKING_CHECKS revert: that gate ages checks out after
+            # PENDING_STALE_MIN and would also re-block on the review's
+            # conclusion, reintroducing #7416's median-49-minute wait.
+            REVIEW_PR_LIVE="$(jq -r '
+              [ .[]
+                | select((((.status // .state // "") | IN("QUEUED", "IN_PROGRESS", "PENDING", "WAITING", "REQUESTED")) and ((.name // "") == "review-pr"))) ]
+              | length > 0
+            ' <<< "${CHECKS_JSON}")"
+            if [[ "${REVIEW_PR_LIVE}" != "true" && -n "${REVIEW_WF_ID}" && -n "${PR_HEAD_OID}" ]]; then
+              # Delay-window fallback: a review run parked BEFORE its job
+              # starts (the 10-minute environment wait) has no review-pr
+              # check-run yet, but a push now would still cancel it via
+              # synchronize. The runs API sees it by head SHA in every
+              # not-yet-running status GitHub reports (queued, waiting,
+              # pending — all three observed live on #8888). One read per
+              # candidate, and only when the rollup showed nothing live.
+              if gh api "repos/${REPO}/actions/runs?head_sha=${PR_HEAD_OID}&per_page=50" \
+                --jq ".workflow_runs[] | select(.workflow_id == ${REVIEW_WF_ID}) | .status" 2> /dev/null \
+                | grep -qE '^(queued|waiting|pending)$'; then
+                REVIEW_PR_LIVE="true"
+              fi
+            fi
+            if [[ "${REVIEW_PR_LIVE}" == "true" ]]; then
+              echo "🔍 #${PR}: review-pr in flight on this head — holding this round so the push cannot cancel it (#8888)"
+              fleet_row "${PR}" 'review-in-flight' 'review-pr live on head; round deferred'
+              # Ack-on-defer (#8888): a real-time human review routed this
+              # scan straight here, but the gate holds every mutation — from
+              # the human's seat the bot read their review and then did
+              # nothing. Say so once per in-flight review (the marker embeds
+              # the review-pr check's startedAt, so a NEW review re-arms the
+              # ack). The feedback itself needs no ack: the watermark is not
+              # advanced on this skip, so the next scan after the review
+              # lands still sees and addresses it. Cron scans stay silent —
+              # nothing arrived in them that a human is waiting on, and the
+              # fleet table already shows the deferral.
+              if [[ "${EVENT_NAME}" == 'pull_request_review' && "${DRY_RUN}" != "true" && "${REVIEW_SENDER}" != "${REVIEW_BOT}" ]]; then
+                REVIEW_STARTED_AT="$(jq -r '
+                  [ .[]
+                    | select((((.status // .state // "") | IN("QUEUED", "IN_PROGRESS", "PENDING", "WAITING", "REQUESTED")) and ((.name // "") == "review-pr")))
+                    | (.startedAt // "")
+                    | select(. != "") ] | first // ""' <<< "${CHECKS_JSON}")"
+                # An empty key (a queued check with no startedAt yet) would
+                # make the marker match EVERY future deferral — skip the ack
+                # this scan rather than arm a permanently-dead dedup.
+                if [[ -z "${REVIEW_STARTED_AT}" ]]; then
+                  echo "🕐 #${PR}: deferred-review ack skipped: live review-pr check has no startedAt yet (queued); a later scan acks once it starts"
+                else
+                  DEFER_ACKS="$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate --jq '.[].body' 2> /dev/null || true)"
+                  if grep -qF "<!-- autofix-review-deferred ${REVIEW_STARTED_AT} -->" <<< "${DEFER_ACKS}"; then
+                    echo "🕐 #${PR}: deferred-review ack already posted for this review run"
+                  else
+                    if [[ -z "${SCAN_BOT_ACTOR:-}" ]]; then
+                      SCAN_BOT_ACTOR="$(gh api user --jq '.login' 2> /dev/null || echo 'unknown')"
+                    fi
+                    if [[ "${SCAN_BOT_ACTOR}" != "${AUTOFIX_BOT}" ]]; then
+                      echo "::warning::#${PR}: deferred-review ack skipped: PAT authenticates as '${SCAN_BOT_ACTOR}', expected ${AUTOFIX_BOT}"
+                    else
+                      gh pr comment "${PR}" --repo "${REPO}" --body "$(printf '🕐 Review received — an automatic review of the current head is still running, so this round is held until it lands (a push now would cancel it and discard its work, #8888). Your feedback stays queued and is addressed in the next round.\n\n<details>\n<summary>中文说明</summary>\n\n🕐 已收到评审 —— 当前 head 上仍有一轮自动 review 在运行，本轮暂缓（现在推送会取消该 review 并丢弃其工作，#8888）。反馈保持排队，将在下一轮一并处理。\n\n</details>\n\n<!-- autofix-review-deferred %s -->' "${REVIEW_STARTED_AT}")" > /dev/null 2>&1 \
+                        || echo "::warning::#${PR}: deferred-review ack failed — the dedup marker is NOT posted (a later scan may ack again)"
+                    fi
+                  fi
+                fi
+              fi
               continue
             fi
             # Pre-first-eval floor: the PR's IMMUTABLE creation time. Feedback

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2640,6 +2640,7 @@ jobs:
                 | select((((.status // .state // "") | IN("QUEUED", "IN_PROGRESS", "PENDING", "WAITING", "REQUESTED")) and ((.name // "") == "review-pr") and ((.workflowName // "") == "🧐 Qwen Pull Request Review"))) ]
               | length > 0
             ' <<< "${CHECKS_JSON}")"
+            REVIEW_RUN_STARTED_AT=""
             if [[ "${REVIEW_PR_LIVE}" != "true" && -n "${REVIEW_WF_ID}" && -n "${PR_HEAD_OID}" && -n "${BRANCH}" ]]; then
               # Delay-window fallback: a review run parked BEFORE its job
               # starts (the 10-minute environment wait) has no review-pr
@@ -2648,13 +2649,15 @@ jobs:
               # explicit-trigger review runs by PR/head identity. One paginated
               # read per candidate, and only when the rollup showed nothing live.
               REVIEW_RUNS_JSON="$(gh api --paginate "repos/${REPO}/actions/workflows/${REVIEW_WF_ID}/runs?per_page=100" 2> /dev/null || printf '{"workflow_runs":[]}')"
-              if jq -e --arg wf "${REVIEW_WF_ID}" --arg pr "${PR}" --arg head "${PR_HEAD_OID}" --arg branch "${BRANCH}" '
+              REVIEW_RUN_STARTED_AT="$(jq -r --arg wf "${REVIEW_WF_ID}" --arg pr "${PR}" --arg head "${PR_HEAD_OID}" --arg branch "${BRANCH}" '
                 [ .workflow_runs[]?
                   | select((.workflow_id | tostring) == $wf)
                   | select((.status // "") | IN("queued", "waiting", "pending", "requested", "in_progress"))
-                  | select(((.head_sha // "") == $head) or ((.head_branch // "") == $branch) or any(.pull_requests[]?; (.number | tostring) == $pr)) ]
-                | length > 0
-              ' <<< "${REVIEW_RUNS_JSON}" > /dev/null; then
+                  | select(((.head_sha // "") == $head) or ((.head_branch // "") == $branch) or any(.pull_requests[]?; (.number | tostring) == $pr))
+                  | (.run_started_at // .created_at // "") ]
+                | map(select(. != "")) | sort | last // ""
+              ' <<< "${REVIEW_RUNS_JSON}")"
+              if [[ -n "${REVIEW_RUN_STARTED_AT}" ]]; then
                 REVIEW_PR_LIVE="true"
               fi
             fi
@@ -2677,6 +2680,7 @@ jobs:
                     | select((((.status // .state // "") | IN("QUEUED", "IN_PROGRESS", "PENDING", "WAITING", "REQUESTED")) and ((.name // "") == "review-pr") and ((.workflowName // "") == "🧐 Qwen Pull Request Review")))
                     | (.startedAt // "")
                     | select(. != "") ] | first // ""' <<< "${CHECKS_JSON}")"
+                [[ -z "${REVIEW_STARTED_AT}" ]] && REVIEW_STARTED_AT="${REVIEW_RUN_STARTED_AT}"
                 # An empty key (a queued check with no startedAt yet) would
                 # make the marker match EVERY future deferral — skip the ack
                 # this scan rather than arm a permanently-dead dedup.

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2409,6 +2409,11 @@ jobs:
           # gate then degrades to the rollup check only (fail-open, like
           # BUSY_PRS).
           REVIEW_WF_ID="$(gh api "repos/${REPO}/actions/workflows/qwen-code-pr-review.yml" --jq '.id' 2> /dev/null || echo '')"
+          REVIEW_RUNS_JSON='{"workflow_runs":[]}'
+          if [[ -n "${REVIEW_WF_ID}" ]] \
+            && ! REVIEW_RUNS_JSON="$(gh api "repos/${REPO}/actions/workflows/${REVIEW_WF_ID}/runs?per_page=100" 2> /dev/null)"; then
+            REVIEW_RUNS_JSON='{"workflow_runs":[]}'
+          fi
 
           # PRs whose review-address is already RUNNING OR QUEUED in any live
           # autofix run must not be re-targeted. Schedule/dispatch runs execute
@@ -2641,22 +2646,22 @@ jobs:
               | length > 0
             ' <<< "${CHECKS_JSON}")"
             REVIEW_RUN_STARTED_AT=""
-            if [[ "${REVIEW_PR_LIVE}" != "true" && -n "${REVIEW_WF_ID}" && -n "${PR_HEAD_OID}" && -n "${BRANCH}" ]]; then
+            if [[ "${REVIEW_PR_LIVE}" != "true" && -n "${REVIEW_WF_ID}" && -n "${PR_HEAD_OID}" ]]; then
               # Delay-window fallback: a review run parked BEFORE its job
               # starts (the 10-minute environment wait) has no review-pr
               # check-run yet, but a push now would still cancel it via
               # synchronize. Only pull_request_target runs are cancelable —
               # comment/review-triggered runs use per-run concurrency groups
               # that a synchronize never cancels, so holding the round for
-              # one would defer autofix for nothing (R2-1). One paginated
-              # read per candidate, and only when the rollup showed nothing live.
-              REVIEW_RUNS_JSON="$(gh api --paginate "repos/${REPO}/actions/workflows/${REVIEW_WF_ID}/runs?per_page=100" 2> /dev/null || printf '{"workflow_runs":[]}')"
-              REVIEW_RUN_STARTED_AT="$(jq -r --arg wf "${REVIEW_WF_ID}" --arg pr "${PR}" --arg head "${PR_HEAD_OID}" --arg branch "${BRANCH}" '
+              # one would defer autofix for nothing (R2-1). The scan fetched
+              # the newest run page once above; match by immutable head SHA or
+              # PR number, never by fork-controlled bare branch name.
+              REVIEW_RUN_STARTED_AT="$(jq -r --arg wf "${REVIEW_WF_ID}" --arg pr "${PR}" --arg head "${PR_HEAD_OID}" '
                 [ .workflow_runs[]?
                   | select((.workflow_id | tostring) == $wf)
                   | select((.event // "") == "pull_request_target")
                   | select((.status // "") | IN("queued", "waiting", "pending", "requested", "in_progress"))
-                  | select(((.head_sha // "") == $head) or ((.head_branch // "") == $branch) or any(.pull_requests[]?; (.number | tostring) == $pr))
+                  | select(((.head_sha // "") == $head) or any(.pull_requests[]?; (.number | tostring) == $pr))
                   | (.run_started_at // .created_at // "") ]
                 | map(select(. != "")) | sort | last // ""
               ' <<< "${REVIEW_RUNS_JSON}")"

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2645,13 +2645,16 @@ jobs:
               # Delay-window fallback: a review run parked BEFORE its job
               # starts (the 10-minute environment wait) has no review-pr
               # check-run yet, but a push now would still cancel it via
-              # synchronize. The runs API catches both pull_request_target and
-              # explicit-trigger review runs by PR/head identity. One paginated
+              # synchronize. Only pull_request_target runs are cancelable —
+              # comment/review-triggered runs use per-run concurrency groups
+              # that a synchronize never cancels, so holding the round for
+              # one would defer autofix for nothing (R2-1). One paginated
               # read per candidate, and only when the rollup showed nothing live.
               REVIEW_RUNS_JSON="$(gh api --paginate "repos/${REPO}/actions/workflows/${REVIEW_WF_ID}/runs?per_page=100" 2> /dev/null || printf '{"workflow_runs":[]}')"
               REVIEW_RUN_STARTED_AT="$(jq -r --arg wf "${REVIEW_WF_ID}" --arg pr "${PR}" --arg head "${PR_HEAD_OID}" --arg branch "${BRANCH}" '
                 [ .workflow_runs[]?
                   | select((.workflow_id | tostring) == $wf)
+                  | select((.event // "") == "pull_request_target")
                   | select((.status // "") | IN("queued", "waiting", "pending", "requested", "in_progress"))
                   | select(((.head_sha // "") == $head) or ((.head_branch // "") == $branch) or any(.pull_requests[]?; (.number | tostring) == $pr))
                   | (.run_started_at // .created_at // "") ]

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2559,6 +2559,52 @@ jobs:
             CHECKS_JSON="$(jq -c '.statusCheckRollup // []' <<< "${PR_META}")"
             PR_HEAD_OID="$(jq -r '.headRefOid // ""' <<< "${PR_META}")"
 
+            # Review-in-flight gate (#8888): NON_BLOCKING_CHECKS keeps an
+            # in-flight review-pr from blocking the FEEDBACK gate (its
+            # conclusion carries nothing the loop acts on — #7416), but every
+            # head mutation this scan can make (a stale-base update-branch,
+            # infra rerun, or address push later) is a synchronize event that
+            # cancels the in-flight review via qwen-code-pr-review.yml's
+            # cancel-in-progress, discarding up to ~3h of review work — the
+            # self-reinforcing cancellation loop of #8830 (three killed runs
+            # in one PR, two by merge-main). Its findings are also the very
+            # feedback the next round should batch with, so deferring the
+            # WHOLE round until the review lands loses nothing: the watermark
+            # is not advanced on a skip, so the feedback stays visible. This
+            # is deliberately SEPARATE from HAS_PENDING_CHECKS rather than a
+            # NON_BLOCKING_CHECKS revert: that gate ages checks out after
+            # PENDING_STALE_MIN and would also re-block on the review's
+            # conclusion, reintroducing #7416's median-49-minute wait.
+            REVIEW_PR_LIVE="$(jq -r '
+              [ .[]
+                | select((((.status // .state // "") | IN("QUEUED", "IN_PROGRESS", "PENDING", "WAITING", "REQUESTED")) and ((.name // "") == "review-pr") and ((.workflowName // "") == "🧐 Qwen Pull Request Review"))) ]
+              | length > 0
+            ' <<< "${CHECKS_JSON}")"
+            REVIEW_RUN_STARTED_AT=""
+            if [[ "${REVIEW_PR_LIVE}" != "true" && -n "${REVIEW_WF_ID}" && -n "${PR_HEAD_OID}" ]]; then
+              # Delay-window fallback: a review run parked BEFORE its job
+              # starts (the 10-minute environment wait) has no review-pr
+              # check-run yet, but a push now would still cancel it via
+              # synchronize. Only pull_request_target runs are cancelable —
+              # comment/review-triggered runs use per-run concurrency groups
+              # that a synchronize never cancels, so holding the round for
+              # one would defer autofix for nothing (R2-1). The scan fetched
+              # the newest run page once above; match by immutable head SHA or
+              # PR number, never by fork-controlled bare branch name.
+              REVIEW_RUN_STARTED_AT="$(jq -r --arg wf "${REVIEW_WF_ID}" --arg pr "${PR}" --arg head "${PR_HEAD_OID}" '
+                [ .workflow_runs[]?
+                  | select((.workflow_id | tostring) == $wf)
+                  | select((.event // "") == "pull_request_target")
+                  | select((.status // "") | IN("queued", "waiting", "pending", "requested", "in_progress"))
+                  | select(((.head_sha // "") == $head) or any(.pull_requests[]?; (.number | tostring) == $pr))
+                  | (.run_started_at // .created_at // "") ]
+                | map(select(. != "")) | sort | last // ""
+              ' <<< "${REVIEW_RUNS_JSON}")"
+              if [[ -n "${REVIEW_RUN_STARTED_AT}" ]]; then
+                REVIEW_PR_LIVE="true"
+              fi
+            fi
+
             # Auto-rerun a check that died on INFRASTRUCTURE, not the code (see
             # INFRA_FAILURE_SIGNATURES). Only reached when the PR has a FAILED
             # check; then, for each, we read its annotations and — if they carry
@@ -2568,7 +2614,7 @@ jobs:
             # marker needed; the attempt counter is the guard, and after a rerun
             # the attempt increments so the next scan skips it. Any API failure
             # here is fail-safe: it just means no rerun.
-            if [[ -n "${PR_HEAD_OID}" ]] && jq -e 'any(.[]; ((.conclusion // .state // "") | IN("FAILURE","FAILED","ERROR","TIMED_OUT","ACTION_REQUIRED")) and (((.workflowName // "") != "Qwen Autofix") or ((.name // "") | startswith("review-address"))))' <<< "${CHECKS_JSON}" > /dev/null 2>&1; then
+            if [[ -n "${PR_HEAD_OID}" && "${REVIEW_PR_LIVE}" != "true" ]] && jq -e 'any(.[]; ((.conclusion // .state // "") | IN("FAILURE","FAILED","ERROR","TIMED_OUT","ACTION_REQUIRED")) and (((.workflowName // "") != "Qwen Autofix") or ((.name // "") | startswith("review-address"))))' <<< "${CHECKS_JSON}" > /dev/null 2>&1; then
               RERAN_INFRA=false
               # Failed check-runs on this head, with their run id and annotation
               # count — fetched once. External statuses (no check-run) are absent
@@ -2623,51 +2669,6 @@ jobs:
               echo "⏳ #${PR}: active checks in flight; skipping until they finish (only checks stuck >${PENDING_STALE_MIN}m past their start are treated as dead and ignored)"
               fleet_row "${PR}" 'waiting' 'active checks in flight'
               continue
-            fi
-            # Review-in-flight gate (#8888): NON_BLOCKING_CHECKS keeps an
-            # in-flight review-pr from blocking the FEEDBACK gate (its
-            # conclusion carries nothing the loop acts on — #7416), but every
-            # head mutation this scan can make (a stale-base update-branch
-            # below, an address push later) is a synchronize event that
-            # cancels the in-flight review via qwen-code-pr-review.yml's
-            # cancel-in-progress, discarding up to ~3h of review work — the
-            # self-reinforcing cancellation loop of #8830 (three killed runs
-            # in one PR, two by merge-main). Its findings are also the very
-            # feedback the next round should batch with, so deferring the
-            # WHOLE round until the review lands loses nothing: the watermark
-            # is not advanced on a skip, so the feedback stays visible. This
-            # is deliberately SEPARATE from HAS_PENDING_CHECKS rather than a
-            # NON_BLOCKING_CHECKS revert: that gate ages checks out after
-            # PENDING_STALE_MIN and would also re-block on the review's
-            # conclusion, reintroducing #7416's median-49-minute wait.
-            REVIEW_PR_LIVE="$(jq -r '
-              [ .[]
-                | select((((.status // .state // "") | IN("QUEUED", "IN_PROGRESS", "PENDING", "WAITING", "REQUESTED")) and ((.name // "") == "review-pr") and ((.workflowName // "") == "🧐 Qwen Pull Request Review"))) ]
-              | length > 0
-            ' <<< "${CHECKS_JSON}")"
-            REVIEW_RUN_STARTED_AT=""
-            if [[ "${REVIEW_PR_LIVE}" != "true" && -n "${REVIEW_WF_ID}" && -n "${PR_HEAD_OID}" ]]; then
-              # Delay-window fallback: a review run parked BEFORE its job
-              # starts (the 10-minute environment wait) has no review-pr
-              # check-run yet, but a push now would still cancel it via
-              # synchronize. Only pull_request_target runs are cancelable —
-              # comment/review-triggered runs use per-run concurrency groups
-              # that a synchronize never cancels, so holding the round for
-              # one would defer autofix for nothing (R2-1). The scan fetched
-              # the newest run page once above; match by immutable head SHA or
-              # PR number, never by fork-controlled bare branch name.
-              REVIEW_RUN_STARTED_AT="$(jq -r --arg wf "${REVIEW_WF_ID}" --arg pr "${PR}" --arg head "${PR_HEAD_OID}" '
-                [ .workflow_runs[]?
-                  | select((.workflow_id | tostring) == $wf)
-                  | select((.event // "") == "pull_request_target")
-                  | select((.status // "") | IN("queued", "waiting", "pending", "requested", "in_progress"))
-                  | select(((.head_sha // "") == $head) or any(.pull_requests[]?; (.number | tostring) == $pr))
-                  | (.run_started_at // .created_at // "") ]
-                | map(select(. != "")) | sort | last // ""
-              ' <<< "${REVIEW_RUNS_JSON}")"
-              if [[ -n "${REVIEW_RUN_STARTED_AT}" ]]; then
-                REVIEW_PR_LIVE="true"
-              fi
             fi
             if [[ "${REVIEW_PR_LIVE}" == "true" ]]; then
               echo "🔍 #${PR}: review-pr in flight on this head — holding this round so the push cannot cancel it (#8888)"

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2637,20 +2637,24 @@ jobs:
             # conclusion, reintroducing #7416's median-49-minute wait.
             REVIEW_PR_LIVE="$(jq -r '
               [ .[]
-                | select((((.status // .state // "") | IN("QUEUED", "IN_PROGRESS", "PENDING", "WAITING", "REQUESTED")) and ((.name // "") == "review-pr"))) ]
+                | select((((.status // .state // "") | IN("QUEUED", "IN_PROGRESS", "PENDING", "WAITING", "REQUESTED")) and ((.name // "") == "review-pr") and ((.workflowName // "") == "🧐 Qwen Pull Request Review"))) ]
               | length > 0
             ' <<< "${CHECKS_JSON}")"
-            if [[ "${REVIEW_PR_LIVE}" != "true" && -n "${REVIEW_WF_ID}" && -n "${PR_HEAD_OID}" ]]; then
+            if [[ "${REVIEW_PR_LIVE}" != "true" && -n "${REVIEW_WF_ID}" && -n "${PR_HEAD_OID}" && -n "${BRANCH}" ]]; then
               # Delay-window fallback: a review run parked BEFORE its job
               # starts (the 10-minute environment wait) has no review-pr
               # check-run yet, but a push now would still cancel it via
-              # synchronize. The runs API sees it by head SHA in every
-              # not-yet-running status GitHub reports (queued, waiting,
-              # pending — all three observed live on #8888). One read per
-              # candidate, and only when the rollup showed nothing live.
-              if gh api "repos/${REPO}/actions/runs?head_sha=${PR_HEAD_OID}&per_page=50" \
-                --jq ".workflow_runs[] | select(.workflow_id == ${REVIEW_WF_ID}) | .status" 2> /dev/null \
-                | grep -qE '^(queued|waiting|pending)$'; then
+              # synchronize. The runs API catches both pull_request_target and
+              # explicit-trigger review runs by PR/head identity. One paginated
+              # read per candidate, and only when the rollup showed nothing live.
+              REVIEW_RUNS_JSON="$(gh api --paginate "repos/${REPO}/actions/workflows/${REVIEW_WF_ID}/runs?per_page=100" 2> /dev/null || printf '{"workflow_runs":[]}')"
+              if jq -e --arg wf "${REVIEW_WF_ID}" --arg pr "${PR}" --arg head "${PR_HEAD_OID}" --arg branch "${BRANCH}" '
+                [ .workflow_runs[]?
+                  | select((.workflow_id | tostring) == $wf)
+                  | select((.status // "") | IN("queued", "waiting", "pending", "requested", "in_progress"))
+                  | select(((.head_sha // "") == $head) or ((.head_branch // "") == $branch) or any(.pull_requests[]?; (.number | tostring) == $pr)) ]
+                | length > 0
+              ' <<< "${REVIEW_RUNS_JSON}" > /dev/null; then
                 REVIEW_PR_LIVE="true"
               fi
             fi
@@ -2670,7 +2674,7 @@ jobs:
               if [[ "${EVENT_NAME}" == 'pull_request_review' && "${DRY_RUN}" != "true" && "${REVIEW_SENDER}" != "${REVIEW_BOT}" ]]; then
                 REVIEW_STARTED_AT="$(jq -r '
                   [ .[]
-                    | select((((.status // .state // "") | IN("QUEUED", "IN_PROGRESS", "PENDING", "WAITING", "REQUESTED")) and ((.name // "") == "review-pr")))
+                    | select((((.status // .state // "") | IN("QUEUED", "IN_PROGRESS", "PENDING", "WAITING", "REQUESTED")) and ((.name // "") == "review-pr") and ((.workflowName // "") == "🧐 Qwen Pull Request Review")))
                     | (.startedAt // "")
                     | select(. != "") ] | first // ""' <<< "${CHECKS_JSON}")"
                 # An empty key (a queued check with no startedAt yet) would
@@ -2679,7 +2683,8 @@ jobs:
                 if [[ -z "${REVIEW_STARTED_AT}" ]]; then
                   echo "🕐 #${PR}: deferred-review ack skipped: live review-pr check has no startedAt yet (queued); a later scan acks once it starts"
                 else
-                  DEFER_ACKS="$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate --jq '.[].body' 2> /dev/null || true)"
+                  DEFER_ACKS="$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
+                    | jq -r --arg ab "${AUTOFIX_BOT}" '.[] | select((.user.login // "") == $ab) | .body // ""' 2> /dev/null || true)"
                   if grep -qF "<!-- autofix-review-deferred ${REVIEW_STARTED_AT} -->" <<< "${DEFER_ACKS}"; then
                     echo "🕐 #${PR}: deferred-review ack already posted for this review run"
                   else
@@ -2689,13 +2694,12 @@ jobs:
                     if [[ "${SCAN_BOT_ACTOR}" != "${AUTOFIX_BOT}" ]]; then
                       echo "::warning::#${PR}: deferred-review ack skipped: PAT authenticates as '${SCAN_BOT_ACTOR}', expected ${AUTOFIX_BOT}"
                     else
-                      gh pr comment "${PR}" --repo "${REPO}" --body "$(printf '🕐 Review received — an automatic review of the current head is still running, so this round is held until it lands (a push now would cancel it and discard its work, #8888). Your feedback stays queued and is addressed in the next round.\n\n<details>\n<summary>中文说明</summary>\n\n🕐 已收到评审 —— 当前 head 上仍有一轮自动 review 在运行，本轮暂缓（现在推送会取消该 review 并丢弃其工作，#8888）。反馈保持排队，将在下一轮一并处理。\n\n</details>\n\n<!-- autofix-review-deferred %s -->' "${REVIEW_STARTED_AT}")" > /dev/null 2>&1 \
+                      gh pr comment "${PR}" --repo "${REPO}" --body "$(printf '🕐 Review received — an automatic review of the current head is still running, so this round is held until it lands (a push now would cancel it and discard its work, #8888). Your feedback stays queued for the next eligible round.\n\n<details>\n<summary>中文说明</summary>\n\n🕐 已收到评审 —— 当前 head 上仍有一轮自动 review 在运行，本轮暂缓（现在推送会取消该 review 并丢弃其工作，#8888）。反馈保持排队，等待下一次可运行的轮次处理。\n\n</details>\n\n<!-- autofix-review-deferred %s -->' "${REVIEW_STARTED_AT}")" > /dev/null 2>&1 \
                         || echo "::warning::#${PR}: deferred-review ack failed — the dedup marker is NOT posted (a later scan may ack again)"
                     fi
                   fi
                 fi
               fi
-              continue
             fi
             # Pre-first-eval floor: the PR's IMMUTABLE creation time. Feedback
             # cannot predate the PR, and unlike the head commit date this never
@@ -2994,6 +2998,9 @@ jobs:
                   fi
                 fi
               fi
+              continue
+            fi
+            if [[ "${REVIEW_PR_LIVE}" == "true" ]]; then
               continue
             fi
             # Auto-update a PR that is red ONLY because of a stale base (see the

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -488,7 +488,11 @@ describe('qwen-autofix workflow', () => {
         const sel = seg.slice(0, 400);
         return (
           !/startswith\("review-address"\)/.test(sel) &&
-          !/!= "Qwen Autofix"/.test(sel)
+          !/!= "Qwen Autofix"/.test(sel) &&
+          // The review-in-flight gate (#8888) selects BY NAME for the LLM
+          // review check — a liveness probe, not a feedback selector, so it
+          // needs neither the review-address carve-out nor the workflow guard.
+          !/== "review-pr"/.test(sel)
         );
       });
     expect(guardlessSelectors).toEqual([]);
@@ -588,6 +592,88 @@ describe('qwen-autofix workflow', () => {
     expect(run([llm, build])).toBe('true');
     // Unchanged: the branch-mutating sibling in the same workflow still blocks.
     expect(run([{ ...llm, name: 'resolve-pr' }])).toBe('true');
+  });
+
+  it('holds a round while review-pr is in flight on the head (#8888)', () => {
+    // Every head mutation the scan can make (a stale-base update-branch, an
+    // address push) is a synchronize event that cancels the in-flight review
+    // via qwen-code-pr-review.yml's cancel-in-progress, discarding up to ~3h
+    // of review work — the self-reinforcing cancellation loop of PR #8830.
+    // The gate skips the PR entirely while review-pr is live on its head; the
+    // watermark is not advanced on the skip, so the feedback stays visible.
+    // It is deliberately separate from HAS_PENDING_CHECKS (no aging out, no
+    // NON_BLOCKING_CHECKS revert — that would re-block on the conclusion and
+    // reintroduce #7416's wait).
+    expect(reviewScanJob).toContain('REVIEW_PR_LIVE=');
+    expect(reviewScanJob).toContain(
+      'review-pr in flight on this head — holding this round',
+    );
+    expect(reviewScanJob).toContain('fleet_row "${PR}" \'review-in-flight\'');
+    // The gate must sit BEFORE the stale-base update (a merge-main is exactly
+    // the push that killed two reviews on #8830) and the feedback dispatch.
+    expect(reviewScanJob.indexOf('REVIEW_PR_LIVE=')).toBeLessThan(
+      reviewScanJob.indexOf('Auto-update a PR that is red ONLY'),
+    );
+    expect(reviewScanJob.indexOf('REVIEW_PR_LIVE=')).toBeLessThan(
+      reviewScanJob.indexOf('N_FAILED_CHECKS='),
+    );
+
+    // Replay the REAL extracted liveness filter over rollup fixtures.
+    const filter = reviewScanJob.match(
+      /REVIEW_PR_LIVE="\$\(jq -r[\s\S]*?<<< "\$\{CHECKS_JSON\}"\)"/,
+    )?.[0];
+    expect(filter).toBeTruthy();
+    const run = (checks) =>
+      execFileSync(
+        'bash',
+        [
+          '-c',
+          `CHECKS_JSON='${JSON.stringify(checks)}'\n${filter}\nprintf '%s' "$REVIEW_PR_LIVE"`,
+        ],
+        { env: { ...process.env }, encoding: 'utf8' },
+      );
+    const started = '2026-08-10T10:05:49Z';
+    // A live review-pr blocks — in every pending-ish status the rollup uses.
+    for (const status of [
+      'QUEUED',
+      'IN_PROGRESS',
+      'PENDING',
+      'WAITING',
+      'REQUESTED',
+    ]) {
+      expect(run([{ name: 'review-pr', status, startedAt: started }])).toBe(
+        'true',
+      );
+    }
+    // A concluded review does NOT block (that would reintroduce #7416's wait).
+    expect(
+      run([{ name: 'review-pr', status: 'COMPLETED', conclusion: 'SUCCESS' }]),
+    ).toBe('false');
+    // Other checks in flight are this gate's business as usual — not live.
+    expect(
+      run([{ name: 'Test (ubuntu-latest, Node 22.x)', status: 'IN_PROGRESS' }]),
+    ).toBe('false');
+
+    // Delay-window fallback: during the review workflow's 10-minute delay the
+    // review-pr check-run does not exist yet, so the rollup alone misses it;
+    // the scan falls back to queued runs of the review workflow by head SHA.
+    expect(reviewScanJob).toContain('REVIEW_WF_ID=');
+    expect(reviewScanJob).toContain('actions/runs?head_sha=${PR_HEAD_OID}');
+    expect(reviewScanJob).toContain("grep -qE '^(queued|waiting|pending)$'");
+
+    // Ack-on-defer: a real-time HUMAN review that the gate defers gets one
+    // visible acknowledgment per in-flight review run (marker keyed on the
+    // review-pr check's startedAt); the review bot's own findings never ack.
+    expect(reviewScanJob).toContain('"${REVIEW_SENDER}" != "${REVIEW_BOT}"');
+    expect(reviewScanJob).toContain('autofix-review-deferred');
+    expect(workflow).toContain(
+      "review_sender: '${{ github.event.review.user.login }}'",
+    );
+    // An empty startedAt must skip the ack, not arm an always-matching marker.
+    expect(reviewScanJob).toContain('select(. != "") ] | first // ""');
+    expect(reviewScanJob).toContain(
+      'has no startedAt yet (queued); a later scan acks once it starts',
+    );
   });
 
   it('auto-updates a PR red only from a stale base, gated on green-on-main', () => {
@@ -2678,14 +2764,16 @@ describe('qwen-autofix workflow', () => {
     // forces a deliberate test update, however it is spaced or line-wrapped:
     // bump this count AND pipe the new site through the normalizer (bumping
     // the count below too) — bumping this pin alone leaves toBe(9) green.
-    expect(workflow.split('--paginate').length - 1).toBe(14);
+    expect(workflow.split('--paginate').length - 1).toBe(15);
     // scan ic + pr-events + ic re-fetch + scan rv/rc + prepare rv/rc/ic +
     // report COMMENTS_JSON fallback = nine normalized fetch sites. The
     // blocked-takeover status lookup is deliberately NOT among them: like the
     // sibling STATUS_ID read, it consumes the page stream inline via
     // `--jq ... | .id` into `tail -1` and never lands in a WORKDIR json file,
     // so piping it through `jq -s 'add // []'` would wrap the id stream in an
-    // array and break the tail-1 consumer.
+    // array and break the tail-1 consumer. The #8888 deferred-review ack
+    // dedup is the same class: `--jq '.[].body'` feeds a grep, never a
+    // WORKDIR file, so it bumps the total pin but not the normalizer count.
     expect(workflow.split("jq -s 'add // []'").length - 1).toBe(9);
     // Empty-input semantics: a total gh failure feeds the fallback an EMPTY
     // stream, where the normalizer filter must yield '[]' and not 'null' —

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -617,6 +617,9 @@ describe('qwen-autofix workflow', () => {
     expect(reviewScanJob.indexOf('REVIEW_PR_LIVE=')).toBeLessThan(
       reviewScanJob.indexOf('N_FAILED_CHECKS='),
     );
+    expect(
+      reviewScanJob.lastIndexOf('if [[ "${REVIEW_PR_LIVE}" == "true" ]]'),
+    ).toBeGreaterThan(reviewScanJob.indexOf('if [[ "${ROUND}" -ge'));
 
     // Replay the REAL extracted liveness filter over rollup fixtures.
     const filter = reviewScanJob.match(
@@ -641,13 +644,36 @@ describe('qwen-autofix workflow', () => {
       'WAITING',
       'REQUESTED',
     ]) {
-      expect(run([{ name: 'review-pr', status, startedAt: started }])).toBe(
-        'true',
-      );
+      expect(
+        run([
+          {
+            name: 'review-pr',
+            workflowName: '🧐 Qwen Pull Request Review',
+            status,
+            startedAt: started,
+          },
+        ]),
+      ).toBe('true');
     }
+    expect(
+      run([
+        {
+          name: 'review-pr',
+          workflowName: 'Other',
+          status: 'IN_PROGRESS',
+        },
+      ]),
+    ).toBe('false');
     // A concluded review does NOT block (that would reintroduce #7416's wait).
     expect(
-      run([{ name: 'review-pr', status: 'COMPLETED', conclusion: 'SUCCESS' }]),
+      run([
+        {
+          name: 'review-pr',
+          workflowName: '🧐 Qwen Pull Request Review',
+          status: 'COMPLETED',
+          conclusion: 'SUCCESS',
+        },
+      ]),
     ).toBe('false');
     // Other checks in flight are this gate's business as usual — not live.
     expect(
@@ -658,14 +684,24 @@ describe('qwen-autofix workflow', () => {
     // review-pr check-run does not exist yet, so the rollup alone misses it;
     // the scan falls back to queued runs of the review workflow by head SHA.
     expect(reviewScanJob).toContain('REVIEW_WF_ID=');
-    expect(reviewScanJob).toContain('actions/runs?head_sha=${PR_HEAD_OID}');
-    expect(reviewScanJob).toContain("grep -qE '^(queued|waiting|pending)$'");
+    expect(reviewScanJob).toContain(
+      'actions/workflows/${REVIEW_WF_ID}/runs?per_page=100',
+    );
+    expect(reviewScanJob).toContain('gh api --paginate');
+    expect(reviewScanJob).toContain(
+      'IN("queued", "waiting", "pending", "requested", "in_progress")',
+    );
+    expect(reviewScanJob).not.toContain(
+      "grep -qE '^(queued|waiting|pending)$'",
+    );
+    expect(reviewScanJob).toContain('any(.pull_requests[]?');
 
     // Ack-on-defer: a real-time HUMAN review that the gate defers gets one
     // visible acknowledgment per in-flight review run (marker keyed on the
     // review-pr check's startedAt); the review bot's own findings never ack.
     expect(reviewScanJob).toContain('"${REVIEW_SENDER}" != "${REVIEW_BOT}"');
     expect(reviewScanJob).toContain('autofix-review-deferred');
+    expect(reviewScanJob).toContain('select((.user.login // "") == $ab)');
     expect(workflow).toContain(
       "review_sender: '${{ github.event.review.user.login }}'",
     );

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -697,6 +697,65 @@ describe('qwen-autofix workflow', () => {
     expect(reviewScanJob).toContain('REVIEW_RUN_STARTED_AT=');
     expect(reviewScanJob).toContain('.run_started_at // .created_at');
     expect(reviewScanJob).toContain('any(.pull_requests[]?');
+    expect(reviewScanJob).toContain(
+      'select((.event // "") == "pull_request_target")',
+    );
+
+    // Replay the REAL runs-API fallback filter over fixtures (R1-8): the
+    // toContain pins above would still pass if the jq body were dead.
+    const runsFilter = reviewScanJob.match(
+      /REVIEW_RUN_STARTED_AT="\$\(jq -r[\s\S]*?<<< "\$\{REVIEW_RUNS_JSON\}"\)"/,
+    )?.[0];
+    expect(runsFilter).toBeTruthy();
+    const runRuns = (runs) =>
+      execFileSync(
+        'bash',
+        [
+          '-c',
+          `REVIEW_WF_ID='77' PR='42' PR_HEAD_OID='abc123' BRANCH='feat/x'\nREVIEW_RUNS_JSON='${JSON.stringify(runs)}'\n${runsFilter}\nprintf '%s' "$REVIEW_RUN_STARTED_AT"`,
+        ],
+        { env: { ...process.env }, encoding: 'utf8' },
+      );
+    const runs = (...overrides) => ({
+      workflow_runs: overrides.map((o) => ({
+        workflow_id: 77,
+        event: 'pull_request_target',
+        status: 'in_progress',
+        head_sha: 'abc123',
+        head_branch: 'feat/x',
+        run_started_at: '2026-08-13T01:00:00Z',
+        pull_requests: [],
+        ...o,
+      })),
+    });
+    // A live automatic review on the head blocks — every pending-ish status
+    // the runs API uses, including requested/in_progress (R2-2).
+    for (const status of [
+      'queued',
+      'waiting',
+      'pending',
+      'requested',
+      'in_progress',
+    ]) {
+      expect(runRuns(runs({ status }))).toBe('2026-08-13T01:00:00Z');
+    }
+    // An explicit-trigger run is NOT cancelable by synchronize — no hold (R2-1).
+    expect(runRuns(runs({ event: 'issue_comment' }))).toBe('');
+    // A run of another workflow id never blocks (R2-1 binding).
+    expect(runRuns(runs({ workflow_id: 99 }))).toBe('');
+    // A concluded run does not block.
+    expect(runRuns(runs({ status: 'completed' }))).toBe('');
+    // Matching also works via pull_requests association, not only head SHA.
+    expect(
+      runRuns(
+        runs({
+          head_sha: 'other',
+          head_branch: 'other',
+          pull_requests: [{ number: 42 }],
+        }),
+      ),
+    ).toBe('2026-08-13T01:00:00Z');
+
 
     // Ack-on-defer: a real-time HUMAN review that the gate defers gets one
     // visible acknowledgment per in-flight review run (marker keyed on the
@@ -2805,7 +2864,7 @@ describe('qwen-autofix workflow', () => {
     // forces a deliberate test update, however it is spaced or line-wrapped:
     // bump this count AND pipe the new site through the normalizer (bumping
     // the count below too) — bumping this pin alone leaves toBe(9) green.
-    expect(workflow.split('--paginate').length - 1).toBe(15);
+    expect(workflow.split('--paginate').length - 1).toBe(16);
     // scan ic + pr-events + ic re-fetch + scan rv/rc + prepare rv/rc/ic +
     // report COMMENTS_JSON fallback = nine normalized fetch sites. The
     // blocked-takeover status lookup is deliberately NOT among them: like the

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -546,6 +546,9 @@ describe('qwen-autofix workflow', () => {
       '.github/workflows/qwen-code-pr-review.yml',
       'utf8',
     );
+    expect(reviewWorkflow.split('\n')[0]).toBe(
+      "name: '🧐 Qwen Pull Request Review'",
+    );
     for (const name of nonBlocking) {
       expect(reviewWorkflow).toContain(`\n  ${name}:\n`);
     }
@@ -611,6 +614,9 @@ describe('qwen-autofix workflow', () => {
     expect(reviewScanJob).toContain('fleet_row "${PR}" \'review-in-flight\'');
     // The gate must sit BEFORE the stale-base update (a merge-main is exactly
     // the push that killed two reviews on #8830) and the feedback dispatch.
+    expect(reviewScanJob.indexOf('REVIEW_PR_LIVE=')).toBeLessThan(
+      reviewScanJob.indexOf('Auto-rerun a check that died on INFRASTRUCTURE'),
+    );
     expect(reviewScanJob.indexOf('REVIEW_PR_LIVE=')).toBeLessThan(
       reviewScanJob.indexOf('Auto-update a PR that is red ONLY'),
     );
@@ -1223,6 +1229,7 @@ describe('qwen-autofix workflow', () => {
       rerunOk = true,
       crName = 'E2E',
       wfName = 'CI',
+      reviewLive = false,
     }) => {
       const dir = mkdtempSync(join(tmpdir(), 'infra-'));
       const bin = join(dir, 'bin');
@@ -1269,6 +1276,7 @@ describe('qwen-autofix workflow', () => {
             PR: '1',
             PR_META: JSON.stringify({ headRefOid: 'headSHA' }),
             PR_HEAD_OID: 'headSHA',
+            REVIEW_PR_LIVE: reviewLive ? 'true' : 'false',
             CHECKS_JSON: JSON.stringify(checks),
             INFRA_FAILURE_SIGNATURES: INFRA_SIGNATURES,
             PATH: `${bin}:${process.env.PATH}`,
@@ -1302,6 +1310,16 @@ describe('qwen-autofix workflow', () => {
       run({
         checks: [FAIL],
         annotations: 'Expected 1 argument but got 2 — src/foo.ts:10',
+      }),
+    ).toEqual({ reran: false, continued: false });
+    // A live review-pr must win: rerunning review-address can push and cancel
+    // that review, so the infra recovery waits for the next scan.
+    expect(
+      run({
+        checks: [FAIL],
+        annotations:
+          'The self-hosted runner lost communication with the server',
+        reviewLive: true,
       }),
     ).toEqual({ reran: false, continued: false });
     // Already reran once (attempt 2) and still infra-failing → persistent, do

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -687,7 +687,9 @@ describe('qwen-autofix workflow', () => {
     expect(reviewScanJob).toContain(
       'actions/workflows/${REVIEW_WF_ID}/runs?per_page=100',
     );
-    expect(reviewScanJob).toContain('gh api --paginate');
+    expect(reviewScanJob).not.toContain(
+      'REVIEW_RUNS_JSON="$(gh api --paginate',
+    );
     expect(reviewScanJob).toContain(
       'IN("queued", "waiting", "pending", "requested", "in_progress")',
     );
@@ -712,7 +714,7 @@ describe('qwen-autofix workflow', () => {
         'bash',
         [
           '-c',
-          `REVIEW_WF_ID='77' PR='42' PR_HEAD_OID='abc123' BRANCH='feat/x'\nREVIEW_RUNS_JSON='${JSON.stringify(runs)}'\n${runsFilter}\nprintf '%s' "$REVIEW_RUN_STARTED_AT"`,
+          `REVIEW_WF_ID='77' PR='42' PR_HEAD_OID='abc123'\nREVIEW_RUNS_JSON='${JSON.stringify(runs)}'\n${runsFilter}\nprintf '%s' "$REVIEW_RUN_STARTED_AT"`,
         ],
         { env: { ...process.env }, encoding: 'utf8' },
       );
@@ -745,6 +747,26 @@ describe('qwen-autofix workflow', () => {
     expect(runRuns(runs({ workflow_id: 99 }))).toBe('');
     // A concluded run does not block.
     expect(runRuns(runs({ status: 'completed' }))).toBe('');
+    // A fork-controlled bare branch name alone is not identity.
+    expect(
+      runRuns(
+        runs({
+          head_sha: 'other',
+          head_branch: 'feat/x',
+          pull_requests: [],
+        }),
+      ),
+    ).toBe('');
+    // Immutable head SHA alone is still enough.
+    expect(
+      runRuns(
+        runs({
+          head_sha: 'abc123',
+          head_branch: 'other',
+          pull_requests: [],
+        }),
+      ),
+    ).toBe('2026-08-13T01:00:00Z');
     // Matching also works via pull_requests association, not only head SHA.
     expect(
       runRuns(
@@ -755,7 +777,6 @@ describe('qwen-autofix workflow', () => {
         }),
       ),
     ).toBe('2026-08-13T01:00:00Z');
-
 
     // Ack-on-defer: a real-time HUMAN review that the gate defers gets one
     // visible acknowledgment per in-flight review run (marker keyed on the
@@ -2864,7 +2885,7 @@ describe('qwen-autofix workflow', () => {
     // forces a deliberate test update, however it is spaced or line-wrapped:
     // bump this count AND pipe the new site through the normalizer (bumping
     // the count below too) — bumping this pin alone leaves toBe(9) green.
-    expect(workflow.split('--paginate').length - 1).toBe(16);
+    expect(workflow.split('--paginate').length - 1).toBe(15);
     // scan ic + pr-events + ic re-fetch + scan rv/rc + prepare rv/rc/ic +
     // report COMMENTS_JSON fallback = nine normalized fetch sites. The
     // blocked-takeover status lookup is deliberately NOT among them: like the

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -694,6 +694,8 @@ describe('qwen-autofix workflow', () => {
     expect(reviewScanJob).not.toContain(
       "grep -qE '^(queued|waiting|pending)$'",
     );
+    expect(reviewScanJob).toContain('REVIEW_RUN_STARTED_AT=');
+    expect(reviewScanJob).toContain('.run_started_at // .created_at');
     expect(reviewScanJob).toContain('any(.pull_requests[]?');
 
     // Ack-on-defer: a real-time HUMAN review that the gate defers gets one
@@ -702,6 +704,9 @@ describe('qwen-autofix workflow', () => {
     expect(reviewScanJob).toContain('"${REVIEW_SENDER}" != "${REVIEW_BOT}"');
     expect(reviewScanJob).toContain('autofix-review-deferred');
     expect(reviewScanJob).toContain('select((.user.login // "") == $ab)');
+    expect(reviewScanJob).toContain(
+      '[[ -z "${REVIEW_STARTED_AT}" ]] && REVIEW_STARTED_AT="${REVIEW_RUN_STARTED_AT}"',
+    );
     expect(workflow).toContain(
       "review_sender: '${{ github.event.review.user.login }}'",
     );


### PR DESCRIPTION
## What this PR does

The autofix fleet scan now holds a managed PR's whole round whenever an automatic review of that PR's current head is still in flight: it skips both the stale-base branch update and the fix dispatch for that PR until the review lands, and the next scan picks the PR back up. Because the review's own findings are exactly the feedback the next round should batch with, and the skip does not advance the feedback watermark, nothing is dropped by waiting. When a human review is what triggered the held scan, the bot posts one acknowledgment comment per in-flight review run so the human sees their feedback was received and is queued, instead of watching the bot read their review and then go silent. The review workflow itself is untouched.

## Why it's needed

On bot-authored PRs the autofix loop and the automatic review cancel each other. Every head mutation the scan makes — a fix push, or a merge-main via branch update — is a synchronize event, and the review workflow cancels its in-progress run on synchronize. The scan was deliberately allowed to act while a review runs (the review check is exempted from the pending-checks gate so its duration does not hide the PR), so on an active PR the two interleave: a review starts, a scan pushes mid-flight, the review dies with up to hours of work discarded, a new review starts, and the cycle repeats. PR #8830 showed the pattern in full: seven commits in ~9.5 hours, the review cancelled and restarted at least six times, two of the kills caused by merge-main pushes alone, and a concurrency cost ledger of 83 API calls and ~8.7M input tokens for one two-file PR. This change removes the interleaving at its source: while a review is in flight on a head, the scan does not mutate that head. The gate also covers the review workflow's 10-minute delay window, where the review run already exists (queued/waiting/pending) but its check does not appear in the status rollup yet, by falling back to a runs-API lookup by head SHA.

## Reviewer Test Plan

### How to verify

- Run the workflow test file: `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-autofix-workflow.test.js`. The new case replays the extracted liveness filter over rollup fixtures (live review-pr in every pending-ish status blocks; a concluded review does not; other checks do not), pins the gate's position ahead of the stale-base update and the feedback dispatch, and pins the ack guards (human-only sender, per-review-run marker, empty-startedAt skip). The existing non-blocking-check test still passes unchanged, confirming the #7416 behavior (a concluded review never re-blocks the scan) is preserved.
- After merge, observe the next bot PR: expect `review-in-flight` rows in the fleet scan table instead of cancelled review runs, zero review-pr cancellations attributable to autofix pushes, and at most one ack comment per review run when a human review arrives mid-flight.

### Evidence (Before & After)

N/A (CI workflow change; behavior is observable in fleet scan logs and review-run history after merge — see PR #8830 run history for the before-state).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅    |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Unit/workflow tests only (`vitest`), plus YAML parse, extracted-script `bash -n`, actionlint (structure; full shellcheck deferred to CI), and jq replays of the new filters against synthetic rollups.

## Risk & Scope

- Main risk or tradeoff: human feedback that arrives while a review is in flight is addressed only after that review lands (acknowledged immediately by comment, fixed in the next round). Worst case the wait is one review duration; previously the same push would have discarded the review's work entirely.
- Not validated / out of scope: live fleet behavior until merged and observed; the review workflow's cancel-on-synchronize semantics are deliberately unchanged (a human push still restarts the review immediately); incremental/delta review remains the long-term direction, tracked separately.
- Breaking changes / migration notes: none; the change is additive gating inside the autofix scan plus one new route output.

## Linked Issues

Fixes #8888

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

Autofix 舰队扫描现在会在某个托管 PR 的当前 head 上仍有自动 review 在运行时，暂缓该 PR 的整轮处理：既不做 stale-base 分支更新，也不派发修复，等 review 落地后由下一次扫描接手。由于 review 自身产出的 findings 正是下一轮应当一并处理的反馈，且跳过不会推进反馈水位线，等待不会丢任何东西。当暂缓这次扫描的触发源是人类 review 时，bot 会按"每个在飞的 review run 一条"的频率发确认评论，让人类看到反馈已收到、已排队，而不是看到 bot 读了 review 之后毫无动静。review workflow 本身一行未动。

## 为什么需要

在 bot 创建的 PR 上，autofix 循环和自动 review 会互相取消。扫描对 head 的每一次变更——修复 push、或 update-branch 式的 merge main——都是一个 synchronize 事件，而 review workflow 在 synchronize 上取消正在运行的 review。扫描此前被刻意允许在 review 运行期间行动（review 检查被豁免出 pending-checks 门控，避免它的时长把 PR 藏起来），于是在活跃 PR 上两者互相穿插：review 启动 → 扫描中途 push → review 带着几小时的工作被杀 → 新 review 启动 → 循环往复。PR #8830 完整展示了这个模式：约 9.5 小时内 7 个 commit，review 被取消重启至少 6 次，其中两次是 merge-main push 单独造成的，一个两文件 PR 的 concurrency 账本高达 83 次 API 调用、约 870 万输入 token。本改动从源头消除穿插：head 上有 review 在飞时，扫描不变更该 head。门控还覆盖了 review workflow 的 10 分钟延迟窗口——此时 review run 已存在（queued/waiting/pending）但其 check 尚未出现在状态 rollup 中——通过按 head SHA 查 runs API 回退兜底。

## 评审验证计划

### 如何验证

- 运行 workflow 测试文件：`npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-autofix-workflow.test.js`。新用例会在 rollup 夹具上回放提取出的存活过滤器（各种 pending 状态的在飞 review-pr 都阻塞；已完成的 review 不阻塞；其他检查不阻塞），钉住门控位于 stale-base 更新与反馈派发之前的位置，并钉住 ack 的守卫（仅限人类发送者、按 review run 去重的 marker、空 startedAt 跳过）。既有的 non-blocking-check 测试原样通过，确认 #7416 的行为（已完成的 review 不会重新阻塞扫描）被保留。
- 合入后观察下一个 bot PR：预期舰队扫描表里出现 `review-in-flight` 行而不是被取消的 review run，autofix push 造成的 review-pr 取消归零，人类 review 在 review 运行中到达时每个 review run 至多一条确认评论。

### 前后证据

N/A（CI workflow 改动；行为在合入后可通过舰队扫描日志与 review run 历史观察——before 状态见 PR #8830 的运行历史）。

### 测试环境

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅    |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### 环境（可选）

仅单元/workflow 测试（`vitest`），另有 YAML 解析、提取脚本的 `bash -n`、actionlint（结构检查；完整 shellcheck 交给 CI）以及新过滤器在合成 rollup 上的 jq 回放。

## 风险与范围

- 主要风险或取舍：review 在飞期间到达的人类反馈，要等该 review 落地后才处理（评论即时确认，修复放到下一轮）。最坏等待时长为一轮 review 的时长；而此前同样的 push 会把 review 的工作整个丢弃。
- 未验证 / 超出范围：合入并观察之前的真实舰队行为；review workflow 的 synchronize 取消语义刻意不改（人类 push 仍会立即重启 review）；增量/delta review 是长期方向，另行跟踪。
- 破坏性变更 / 迁移说明：无；改动是 autofix 扫描内部的增量门控，外加 route 的一个新输出。

## 关联 Issue

Fixes #8888

</details>
