### PR TITLE
fix(cli): probe microphone permission on recording start, not voice warmup

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -118,6 +118,7 @@ const STARTUP_PROFILE_FINALIZE_CAP_MS = 35_000;
 import { useHistory } from './hooks/useHistoryManager.js';
 import { useMemoryMonitor } from './hooks/useMemoryMonitor.js';
 import { useWakeRepaint } from './hooks/use-wake-repaint.js';
+import type { MicrophonePermission } from './hooks/use-voice-input.js';
 import { useThemeCommand } from './hooks/useThemeCommand.js';
 import { useFeedbackDialog } from './hooks/useFeedbackDialog.js';
 import { useAuthCommand } from './auth/useAuth.js';
@@ -847,6 +848,11 @@ export const AppContainer = (props: AppContainerProps) => {
 
   // Layout measurements
   const mainControlsRef = useRef<DOMElement>(null);
+  // Dedup for the voice mic-permission notice. Held here rather than in
+  // Composer because dialogs (tool approvals, auth, settings) swap Composer
+  // out of the layout; a ref held there would reset on each swap and the
+  // notice would repeat on the next recording.
+  const voiceMicWarnedStatusRef = useRef<MicrophonePermission | null>(null);
   const lastTitleRef = useRef<string | null>(null);
   const [startupWarnings, setStartupWarnings] = useState(
     () => props.startupWarnings || [],
@@ -4374,6 +4380,7 @@ export const AppContainer = (props: AppContainerProps) => {
       terminalWidth,
       terminalHeight,
       mainControlsRef,
+      voiceMicWarnedStatusRef,
       currentIDE,
       startupIdeConnectionStatus,
       updateInfo,
@@ -4518,6 +4525,7 @@ export const AppContainer = (props: AppContainerProps) => {
       terminalWidth,
       terminalHeight,
       mainControlsRef,
+      voiceMicWarnedStatusRef,
       currentIDE,
       startupIdeConnectionStatus,
       updateInfo,

--- a/packages/cli/src/ui/components/Composer.test.tsx
+++ b/packages/cli/src/ui/components/Composer.test.tsx
@@ -8,6 +8,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render } from 'ink-testing-library';
 import { Text } from 'ink';
 import { Composer } from './Composer.js';
+import { InputPrompt } from './InputPrompt.js';
 import { UIStateContext, type UIState } from '../contexts/UIStateContext.js';
 import {
   UIActionsContext,
@@ -75,7 +76,7 @@ vi.mock('./ShellModeIndicator.js', () => ({
 }));
 
 vi.mock('./InputPrompt.js', () => ({
-  InputPrompt: () => <Text>InputPrompt</Text>,
+  InputPrompt: vi.fn(() => <Text>InputPrompt</Text>),
   calculatePromptWidths: vi.fn(() => ({
     inputWidth: 80,
     suggestionsWidth: 40,
@@ -146,6 +147,7 @@ const createMockUIState = (overrides: Partial<UIState> = {}): UIState =>
     taskStartStreamingChars: 0,
     responseCandidateTokens: 0,
     streamingResponseLengthRef: { current: 0 },
+    voiceMicWarnedStatusRef: { current: null },
     isReceivingContent: false,
     pendingGeminiHistoryItems: [],
     terminalWidth: 80,
@@ -175,21 +177,26 @@ const createMockConfig = (overrides = {}) => ({
 });
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
+const composerElement = (
+  uiState: UIState,
+  config = createMockConfig(),
+  uiActions = createMockUIActions(),
+) => (
+  <ConfigContext.Provider value={config as any}>
+    <UIStateContext.Provider value={uiState}>
+      <UIActionsContext.Provider value={uiActions}>
+        <Composer />
+      </UIActionsContext.Provider>
+    </UIStateContext.Provider>
+  </ConfigContext.Provider>
+);
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
 const renderComposer = (
   uiState: UIState,
   config = createMockConfig(),
   uiActions = createMockUIActions(),
-) =>
-  render(
-    <ConfigContext.Provider value={config as any}>
-      <UIStateContext.Provider value={uiState}>
-        <UIActionsContext.Provider value={uiActions}>
-          <Composer />
-        </UIActionsContext.Provider>
-      </UIStateContext.Provider>
-    </ConfigContext.Provider>,
-  );
-/* eslint-enable @typescript-eslint/no-explicit-any */
+) => render(composerElement(uiState, config, uiActions));
 
 describe('Composer', () => {
   describe('Footer Display', () => {
@@ -430,6 +437,37 @@ describe('Composer', () => {
       const { lastFrame } = renderComposer(uiState);
 
       expect(lastFrame()).not.toContain('InputPrompt');
+    });
+
+    it('forwards the session voice permission ref across input-active toggles', () => {
+      const mockedInputPrompt = vi.mocked(InputPrompt);
+      mockedInputPrompt.mockClear();
+      const voiceMicWarnedStatusRef = { current: null };
+      const config = createMockConfig();
+      const uiActions = createMockUIActions();
+      const activeState = createMockUIState({ voiceMicWarnedStatusRef });
+      const inactiveState = createMockUIState({
+        voiceMicWarnedStatusRef,
+        isInputActive: false,
+      });
+
+      const { rerender } = render(
+        composerElement(activeState, config, uiActions),
+      );
+      expect(mockedInputPrompt).toHaveBeenCalled();
+      expect(
+        mockedInputPrompt.mock.calls.at(-1)![0].voiceMicWarnedStatusRef,
+      ).toBe(voiceMicWarnedStatusRef);
+
+      // Input goes inactive (InputPrompt unmounts), then active again — the
+      // remounted InputPrompt must receive the same ref object, not a new one.
+      rerender(composerElement(inactiveState, config, uiActions));
+      mockedInputPrompt.mockClear();
+      rerender(composerElement(activeState, config, uiActions));
+      expect(mockedInputPrompt).toHaveBeenCalled();
+      expect(
+        mockedInputPrompt.mock.calls.at(-1)![0].voiceMicWarnedStatusRef,
+      ).toBe(voiceMicWarnedStatusRef);
     });
 
     // Note: AutoAcceptIndicator and ShellModeIndicator are now rendered inside Footer component

--- a/packages/cli/src/ui/components/Composer.tsx
+++ b/packages/cli/src/ui/components/Composer.tsx
@@ -8,7 +8,6 @@ import { Box, Text, useIsScreenReaderEnabled } from 'ink';
 import { useCallback, useRef, useState } from 'react';
 import { LoadingIndicator } from './LoadingIndicator.js';
 import { InputPrompt } from './InputPrompt.js';
-import type { MicrophonePermission } from '../hooks/use-voice-input.js';
 import { Footer } from './Footer.js';
 import { QueuedMessageDisplay } from './QueuedMessageDisplay.js';
 import { KeyboardShortcuts } from './KeyboardShortcuts.js';
@@ -63,9 +62,6 @@ export const Composer = () => {
   // narrow signal.
   const [showSuggestions, setShowSuggestions] = useState(false);
   const clipboardUnavailableShownRef = useRef(false);
-  // Held here rather than in InputPrompt so the microphone-permission notice
-  // is shown once per run instead of again on every InputPrompt remount.
-  const voiceMicWarnedStatusRef = useRef<MicrophonePermission | null>(null);
 
   // Broad signal — any input-area Tab consumer. Forwarded to AppContainer
   // via UIActionsContext so useAutoAcceptIndicator's `shouldBlockTab` can
@@ -146,7 +142,7 @@ export const Composer = () => {
           promptSuggestion={uiState.promptSuggestion}
           onPromptSuggestionDismiss={uiState.abortPromptSuggestion}
           clipboardUnavailableShownRef={clipboardUnavailableShownRef}
-          voiceMicWarnedStatusRef={voiceMicWarnedStatusRef}
+          voiceMicWarnedStatusRef={uiState.voiceMicWarnedStatusRef}
         />
       )}
 

--- a/packages/cli/src/ui/components/Composer.tsx
+++ b/packages/cli/src/ui/components/Composer.tsx
@@ -8,6 +8,7 @@ import { Box, Text, useIsScreenReaderEnabled } from 'ink';
 import { useCallback, useRef, useState } from 'react';
 import { LoadingIndicator } from './LoadingIndicator.js';
 import { InputPrompt } from './InputPrompt.js';
+import type { MicrophonePermission } from '../hooks/use-voice-input.js';
 import { Footer } from './Footer.js';
 import { QueuedMessageDisplay } from './QueuedMessageDisplay.js';
 import { KeyboardShortcuts } from './KeyboardShortcuts.js';
@@ -62,6 +63,9 @@ export const Composer = () => {
   // narrow signal.
   const [showSuggestions, setShowSuggestions] = useState(false);
   const clipboardUnavailableShownRef = useRef(false);
+  // Held here rather than in InputPrompt so the microphone-permission notice
+  // is shown once per run instead of again on every InputPrompt remount.
+  const voiceMicWarnedStatusRef = useRef<MicrophonePermission | null>(null);
 
   // Broad signal — any input-area Tab consumer. Forwarded to AppContainer
   // via UIActionsContext so useAutoAcceptIndicator's `shouldBlockTab` can
@@ -142,6 +146,7 @@ export const Composer = () => {
           promptSuggestion={uiState.promptSuggestion}
           onPromptSuggestionDismiss={uiState.abortPromptSuggestion}
           clipboardUnavailableShownRef={clipboardUnavailableShownRef}
+          voiceMicWarnedStatusRef={voiceMicWarnedStatusRef}
         />
       )}
 

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -32,6 +32,8 @@ import { useInputHistory } from '../hooks/useInputHistory.js';
 import type { UseReverseSearchCompletionReturn } from '../hooks/useReverseSearchCompletion.js';
 import { useReverseSearchCompletion } from '../hooks/useReverseSearchCompletion.js';
 import { useVoiceInput } from '../hooks/use-voice-input.js';
+import type { MicrophonePermission } from '../hooks/use-voice-input.js';
+import { createVoiceRecorder } from '../voice/voice-recorder.js';
 import * as clipboardUtils from '../utils/clipboardUtils.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
 import stripAnsi from 'strip-ansi';
@@ -66,6 +68,9 @@ vi.mock('../hooks/useCommandCompletion.js');
 vi.mock('../hooks/useInputHistory.js');
 vi.mock('../hooks/useReverseSearchCompletion.js');
 vi.mock('../hooks/use-voice-input.js');
+vi.mock('../voice/voice-recorder.js', () => ({
+  createVoiceRecorder: vi.fn(),
+}));
 vi.mock('../utils/clipboardUtils.js');
 vi.mock('../../services/prompt-stash.js');
 vi.mock('../contexts/UIStateContext.js', () => ({
@@ -646,6 +651,198 @@ describe('InputPrompt', () => {
     });
     expect(props.buffer.handleInput).not.toHaveBeenCalled();
     unmount();
+  });
+
+  describe('voice microphone permission', () => {
+    const setupRecorder = (status: MicrophonePermission) => {
+      const addItem = vi.fn();
+      mockedUseUIState.mockReturnValue({
+        isFeedbackDialogOpen: false,
+        messageQueue: [],
+        pendingGeminiHistoryItems: [],
+        historyManager: { addItem },
+      } as unknown as ReturnType<typeof useUIState>);
+      const microphoneStatus = vi.fn().mockResolvedValue(status);
+      vi.mocked(createVoiceRecorder).mockReturnValue({
+        start: vi.fn(),
+        stop: vi.fn(),
+        warmup: vi.fn(),
+        microphoneStatus,
+      } as unknown as ReturnType<typeof createVoiceRecorder>);
+      return { addItem, microphoneStatus };
+    };
+
+    const setupRecorderWith = (
+      microphoneStatus: (() => Promise<MicrophonePermission>) | undefined,
+    ) => {
+      const addItem = vi.fn();
+      mockedUseUIState.mockReturnValue({
+        isFeedbackDialogOpen: false,
+        messageQueue: [],
+        pendingGeminiHistoryItems: [],
+        historyManager: { addItem },
+      } as unknown as ReturnType<typeof useUIState>);
+      vi.mocked(createVoiceRecorder).mockReturnValue({
+        start: vi.fn(),
+        stop: vi.fn(),
+        warmup: vi.fn(),
+        microphoneStatus,
+      } as unknown as ReturnType<typeof createVoiceRecorder>);
+      return { addItem };
+    };
+
+    const lastVoiceArgs = () =>
+      mockedUseVoiceInput.mock.calls.at(-1)![0] as Parameters<
+        typeof useVoiceInput
+      >[0];
+
+    it('does not probe or warn about microphone permission during warmup', async () => {
+      const { addItem, microphoneStatus } = setupRecorder('prompt');
+      const { unmount } = renderWithProviders(<InputPrompt {...props} />);
+
+      await act(async () => {
+        await lastVoiceArgs().warmup?.();
+      });
+
+      expect(microphoneStatus).not.toHaveBeenCalled();
+      expect(addItem).not.toHaveBeenCalled();
+      unmount();
+    });
+
+    it('warns about a pending permission when a recording starts', async () => {
+      const { addItem, microphoneStatus } = setupRecorder('prompt');
+      const { unmount } = renderWithProviders(<InputPrompt {...props} />);
+
+      await act(async () => {
+        lastVoiceArgs().checkMicrophonePermission?.();
+      });
+
+      await waitFor(() => {
+        expect(addItem).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'info',
+            text: expect.stringContaining('needs microphone access'),
+          }),
+          expect.any(Number),
+        );
+      });
+      expect(microphoneStatus).toHaveBeenCalledTimes(1);
+      unmount();
+    });
+
+    it('reports a denied permission as an error when a recording starts', async () => {
+      const { addItem } = setupRecorder('denied');
+      const { unmount } = renderWithProviders(<InputPrompt {...props} />);
+
+      await act(async () => {
+        lastVoiceArgs().checkMicrophonePermission?.();
+      });
+
+      await waitFor(() => {
+        expect(addItem).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'error',
+            text: expect.stringContaining('Microphone access is denied.'),
+          }),
+          expect.any(Number),
+        );
+      });
+      unmount();
+    });
+
+    it('warns only once for repeated recordings with the same status', async () => {
+      const { addItem } = setupRecorder('prompt');
+      const { unmount } = renderWithProviders(<InputPrompt {...props} />);
+
+      await act(async () => {
+        lastVoiceArgs().checkMicrophonePermission?.();
+      });
+      await waitFor(() => {
+        expect(addItem).toHaveBeenCalledTimes(1);
+      });
+
+      await act(async () => {
+        lastVoiceArgs().checkMicrophonePermission?.();
+      });
+      await act(async () => {});
+
+      expect(addItem).toHaveBeenCalledTimes(1);
+      unmount();
+    });
+
+    it('warns only once across remounts when a session ref is supplied', async () => {
+      const { addItem } = setupRecorder('prompt');
+      const voiceMicWarnedStatusRef = { current: null };
+
+      const first = renderWithProviders(
+        <InputPrompt
+          {...props}
+          voiceMicWarnedStatusRef={voiceMicWarnedStatusRef}
+        />,
+      );
+      await act(async () => {
+        lastVoiceArgs().checkMicrophonePermission?.();
+      });
+      await waitFor(() => {
+        expect(addItem).toHaveBeenCalledTimes(1);
+      });
+      first.unmount();
+
+      const second = renderWithProviders(
+        <InputPrompt
+          {...props}
+          voiceMicWarnedStatusRef={voiceMicWarnedStatusRef}
+        />,
+      );
+      await act(async () => {
+        lastVoiceArgs().checkMicrophonePermission?.();
+      });
+      await act(async () => {});
+
+      expect(addItem).toHaveBeenCalledTimes(1);
+      second.unmount();
+    });
+
+    it('stays quiet when the recorder cannot report permission', async () => {
+      const { addItem } = setupRecorderWith(undefined);
+      const { unmount } = renderWithProviders(<InputPrompt {...props} />);
+
+      await act(async () => {
+        lastVoiceArgs().checkMicrophonePermission?.();
+      });
+      await act(async () => {});
+
+      expect(addItem).not.toHaveBeenCalled();
+      unmount();
+    });
+
+    it('stays quiet when the permission probe rejects', async () => {
+      const { addItem } = setupRecorderWith(() =>
+        Promise.reject(new Error('TCC query failed')),
+      );
+      const { unmount } = renderWithProviders(<InputPrompt {...props} />);
+
+      await act(async () => {
+        lastVoiceArgs().checkMicrophonePermission?.();
+      });
+      await act(async () => {});
+
+      expect(addItem).not.toHaveBeenCalled();
+      unmount();
+    });
+
+    it('stays quiet when permission is already granted', async () => {
+      const { addItem } = setupRecorder('granted');
+      const { unmount } = renderWithProviders(<InputPrompt {...props} />);
+
+      await act(async () => {
+        lastVoiceArgs().checkMicrophonePermission?.();
+      });
+      await act(async () => {});
+
+      expect(addItem).not.toHaveBeenCalled();
+      unmount();
+    });
   });
 
   it('lets non-voice keys fall through while voice recording is active', async () => {

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -655,20 +655,8 @@ describe('InputPrompt', () => {
 
   describe('voice microphone permission', () => {
     const setupRecorder = (status: MicrophonePermission) => {
-      const addItem = vi.fn();
-      mockedUseUIState.mockReturnValue({
-        isFeedbackDialogOpen: false,
-        messageQueue: [],
-        pendingGeminiHistoryItems: [],
-        historyManager: { addItem },
-      } as unknown as ReturnType<typeof useUIState>);
       const microphoneStatus = vi.fn().mockResolvedValue(status);
-      vi.mocked(createVoiceRecorder).mockReturnValue({
-        start: vi.fn(),
-        stop: vi.fn(),
-        warmup: vi.fn(),
-        microphoneStatus,
-      } as unknown as ReturnType<typeof createVoiceRecorder>);
+      const { addItem } = setupRecorderWith(microphoneStatus);
       return { addItem, microphoneStatus };
     };
 
@@ -767,6 +755,37 @@ describe('InputPrompt', () => {
       await act(async () => {});
 
       expect(addItem).toHaveBeenCalledTimes(1);
+      unmount();
+    });
+
+    it('warns again when the permission status changes between recordings', async () => {
+      const { addItem, microphoneStatus } = setupRecorder('prompt');
+      const { unmount } = renderWithProviders(<InputPrompt {...props} />);
+
+      await act(async () => {
+        lastVoiceArgs().checkMicrophonePermission?.();
+      });
+      await waitFor(() => {
+        expect(addItem).toHaveBeenCalledTimes(1);
+      });
+
+      // The user dismisses or denies the OS dialog: the next probe reports
+      // 'denied', which must re-warn — as an error — despite the earlier
+      // 'prompt' notice.
+      microphoneStatus.mockResolvedValue('denied');
+      await act(async () => {
+        lastVoiceArgs().checkMicrophonePermission?.();
+      });
+      await waitFor(() => {
+        expect(addItem).toHaveBeenCalledTimes(2);
+      });
+      expect(addItem).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          text: expect.stringContaining('Microphone access is denied'),
+        }),
+        expect.any(Number),
+      );
       unmount();
     });
 

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -73,6 +73,7 @@ import type { RenderLineOptions } from './BaseTextInput.js';
 import { getApprovalModePromptStyle } from './approvalModeVisuals.js';
 import {
   useVoiceInput,
+  type MicrophonePermission,
   type VoiceTranscriber,
 } from '../hooks/use-voice-input.js';
 import { createVoiceRecorder } from '../voice/voice-recorder.js';
@@ -215,6 +216,8 @@ export interface InputPromptProps {
   /** Called when prompt suggestion is dismissed (user typed) */
   onPromptSuggestionDismiss?: () => void;
   clipboardUnavailableShownRef?: React.MutableRefObject<boolean>;
+  /** Session-scoped so the microphone notice survives InputPrompt remounts. */
+  voiceMicWarnedStatusRef?: React.MutableRefObject<MicrophonePermission | null>;
 }
 
 // Re-export from shared utils for backwards compatibility
@@ -249,6 +252,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   promptSuggestion,
   onPromptSuggestionDismiss,
   clipboardUnavailableShownRef: sessionClipboardUnavailableShownRef,
+  voiceMicWarnedStatusRef: sessionVoiceMicWarnedStatusRef,
 }) => {
   const isShellFocused = useShellFocusState();
   const uiState = useUIState();
@@ -451,7 +455,13 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       refineVoiceTranscript(config, raw, signal),
     [config],
   );
-  const voiceMicWarnedStatusRef = useRef<string | null>(null);
+  const localVoiceMicWarnedStatusRef = useRef<MicrophonePermission | null>(
+    null,
+  );
+  // Falls back to a local ref only when no session-scoped ref is supplied; the
+  // session ref keeps the notice to once per run across InputPrompt remounts.
+  const voiceMicWarnedStatusRef =
+    sessionVoiceMicWarnedStatusRef ?? localVoiceMicWarnedStatusRef;
   const voiceRecorderRef = useRef<ReturnType<
     typeof createVoiceRecorder
   > | null>(null);
@@ -462,6 +472,11 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   const warmupVoice = useCallback(() => {
     const recorder = getVoiceRecorder();
     void Promise.resolve(recorder.warmup?.()).catch(() => {});
+  }, [getVoiceRecorder]);
+  // Runs when a recording starts, not on warmup: users who never dictate
+  // should not be told about microphone access on every startup.
+  const checkVoiceMicPermission = useCallback(() => {
+    const recorder = getVoiceRecorder();
     void Promise.resolve(recorder.microphoneStatus?.())
       .then((status) => {
         if (voiceMicWarnedStatusRef.current === status) {
@@ -495,7 +510,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         }
       })
       .catch(() => {});
-  }, [getVoiceRecorder, uiState.historyManager]);
+  }, [getVoiceRecorder, uiState.historyManager, voiceMicWarnedStatusRef]);
   const voiceStreaming = voiceModel ? isStreamingVoiceModel(voiceModel) : false;
   const openVoiceStreamSession = useCallback(
     (callbacks: {
@@ -541,6 +556,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     refine: voiceRefineEnabled ? refineVoice : undefined,
     onSubmit: (text) => voiceSubmitRef.current(text),
     warmup: warmupVoice,
+    checkMicrophonePermission: checkVoiceMicPermission,
     streaming: voiceStreaming,
     openStream: voiceStreaming ? openVoiceStreamSession : undefined,
   });

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -39,6 +39,7 @@ import { type HelpTab } from './UIActionsContext.js';
 import { type RestartReason } from '../hooks/useIdeTrustListener.js';
 import { type ProviderUpdateRequest } from '../hooks/useProviderUpdates.js';
 import { type ArenaDialogType } from '../hooks/useArenaCommand.js';
+import type { MicrophonePermission } from '../hooks/use-voice-input.js';
 import type { StatusLinePresetConfig } from '../statusLinePresets.js';
 import type { StartupIdeConnectionStatus } from '../../utils/events.js';
 
@@ -171,6 +172,7 @@ export interface UIState {
   terminalWidth: number;
   terminalHeight: number;
   mainControlsRef: React.MutableRefObject<DOMElement | null>;
+  voiceMicWarnedStatusRef: React.MutableRefObject<MicrophonePermission | null>;
   currentIDE: IdeInfo | null;
   startupIdeConnectionStatus: StartupIdeConnectionStatus;
   updateInfo: UpdateObject | null;

--- a/packages/cli/src/ui/hooks/use-voice-input.test.ts
+++ b/packages/cli/src/ui/hooks/use-voice-input.test.ts
@@ -82,6 +82,38 @@ describe('use-voice-input', () => {
     expect(warmup).not.toHaveBeenCalled();
   });
 
+  it('does not check microphone permission until a recording starts', async () => {
+    buffer = createBuffer();
+    const checkMicrophonePermission = vi.fn();
+    const recorder = {
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue({
+        data: new Uint8Array([1]),
+        mimeType: 'audio/wav',
+      }),
+    };
+    const { result } = renderHook(() =>
+      useVoiceInput({
+        enabled: true,
+        mode: 'tap',
+        voiceModel: 'qwen3-asr-flash',
+        buffer,
+        createRecorder: vi.fn(() => recorder),
+        transcribe: vi.fn().mockResolvedValue(''),
+        warmup: vi.fn(),
+        checkMicrophonePermission,
+      }),
+    );
+
+    expect(checkMicrophonePermission).not.toHaveBeenCalled();
+
+    await act(async () => {
+      expect(result.current.handleKeypress(voiceKey)).toBe(true);
+    });
+
+    expect(checkMicrophonePermission).toHaveBeenCalledTimes(1);
+  });
+
   it('does not intercept Space when voice input is disabled', () => {
     buffer = createBuffer();
     const { result } = renderHook(() =>

--- a/packages/cli/src/ui/hooks/use-voice-input.ts
+++ b/packages/cli/src/ui/hooks/use-voice-input.ts
@@ -91,6 +91,12 @@ interface UseVoiceInputArgs {
   onSubmit?: (text: string) => void;
   /** Pre-load the recorder backend when voice turns on (avoids cold-start race). */
   warmup?: () => void | Promise<void>;
+  /**
+   * Probe the OS microphone permission and surface a notice when it is not
+   * granted. Called when a recording actually starts, so users who never
+   * dictate are not told about microphone access on every startup.
+   */
+  checkMicrophonePermission?: () => void;
   /** Enable live streaming transcription (requires openStream + a drain-capable recorder). */
   streaming?: boolean;
   /** Open a streaming session; the hook pumps drained PCM into it while recording. */
@@ -165,6 +171,7 @@ export function useVoiceInput({
   refine,
   onSubmit,
   warmup,
+  checkMicrophonePermission,
   streaming,
   openStream,
 }: UseVoiceInputArgs): UseVoiceInputReturn {
@@ -287,6 +294,10 @@ export function useVoiceInput({
 
   const startRecording = useCallback(
     (silenceDetection: boolean) => {
+      // Permission is probed here rather than during warmup: on macOS an
+      // undetermined TCC status is only worth reporting to someone who is
+      // actually trying to record.
+      checkMicrophonePermission?.();
       const recorder = createRecorder();
       const sessionId = ++sessionIdRef.current;
       recorderRef.current = recorder;
@@ -401,6 +412,7 @@ export function useVoiceInput({
       });
     },
     [
+      checkMicrophonePermission,
       clearPump,
       clearReleaseTimer,
       createRecorder,


### PR DESCRIPTION
## What this PR does

Voice warmup no longer asks the operating system about microphone permission. Preloading the recorder backend and probing the permission were the same step, so a session that had voice dictation configured queried the microphone the moment the input prompt appeared. Those two jobs are now separate: warmup only preloads the backend, and the permission probe runs when a recording actually starts.

The state that keeps the notice from repeating also moves. It used to live inside the input prompt component, so it was reset whenever that component remounted and the same notice could be appended again. It now lives in the app container, which stays mounted across dialog swaps and layout switches, and reaches the input prompt through the UI state — the route `mainControlsRef` already uses — as an optional prop with a local fallback.

## Why it's needed

On macOS an undetermined TCC status is reported as `prompt`, which is the normal state for anyone who has never dictated. Because the probe ran at warmup, every startup of a session with a voice model configured appended "Voice dictation needs microphone access" to the chat history — including for users who never press the voice key. A remount of the input prompt during startup reset the per-instance guard, so the notice frequently arrived twice.

After this change the notice reaches only someone who is trying to dictate, and it arrives once per run.

## Reviewer Test Plan

### How to verify

Configure a voice model so voice dictation is enabled, do not grant microphone access to the terminal (or reset it with `tccutil reset Microphone <terminal bundle id>`), and start the CLI on macOS.

- Expected before: the chat history contains "Voice dictation needs microphone access …" immediately at startup, often twice, without any interaction.
- Expected after: startup is quiet. The notice appears the first time you start a recording with the voice key, and only that first time — repeated recordings, and remounts of the input prompt, do not repeat it.

Automated coverage, run from the repo root:

```
npx vitest run --root packages/cli --coverage=false src/ui/components/InputPrompt.test.tsx src/ui/hooks/use-voice-input.test.ts src/ui/components/Composer.test.tsx src/ui/voice/voice-recorder.test.ts
```

New tests in `packages/cli/src/ui/components/InputPrompt.test.tsx` (`voice microphone permission`):

- does not probe or warn about microphone permission during warmup
- warns about a pending permission when a recording starts
- reports a denied permission as an error when a recording starts
- warns only once for repeated recordings with the same status
- warns only once across remounts when a session ref is supplied
- stays quiet when the recorder cannot report permission
- stays quiet when the permission probe rejects
- stays quiet when permission is already granted
- warns again when the permission status changes between recordings

And in `packages/cli/src/ui/hooks/use-voice-input.test.ts`: does not check microphone permission until a recording starts. In `packages/cli/src/ui/components/Composer.test.tsx`: forwards the session voice permission ref across input-active toggles.

### Evidence (Before & After)

The behavior change is a message that is absent rather than present, so the evidence is the same tests run against the old and the new source.

Before — new tests against the pre-change source (the three source files reverted to `main`, the tests kept):

```
 FAIL  src/ui/components/InputPrompt.test.tsx > InputPrompt > voice microphone permission > warns only once across remounts when a session ref is supplied
AssertionError: expected "spy" to be called 1 times, but got 0 times
 FAIL  src/ui/hooks/use-voice-input.test.ts > use-voice-input > does not check microphone permission until a recording starts
AssertionError: expected "spy" to be called 1 times, but got 0 times

 Test Files  2 failed (2)
      Tests  6 failed | 3 passed | 227 skipped (236)
```

After — the same command on this branch:

```
 ✓ src/ui/hooks/use-voice-input.test.ts (24 tests | 23 skipped) 15ms
 ✓ src/ui/components/InputPrompt.test.tsx (212 tests | 204 skipped) 1053ms

 Test Files  2 passed (2)
      Tests  9 passed | 227 skipped (236)
```

The suites for every file this change touches, unfiltered:

```
 Test Files  4 passed (4)
      Tests  264 passed (264)
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS is where the reported behavior occurs (the issue is labelled `scope/macos`) and is where this was verified. Windows and Linux were not run locally; the change is platform-independent TypeScript and CI covers those legs.

### Environment (optional)

macOS, Node 22, `npm run test:ci` in `packages/cli` plus the targeted suites above.

## Risk & Scope

- Main risk or tradeoff: someone whose microphone is already denied now learns about it at the moment they press the voice key rather than at startup. That is the intended trade — the notice is delivered when it is actionable instead of to everyone. The `denied` path still surfaces as an error item, unchanged.
- Not validated / out of scope: the native permission probe itself (`packages/audio-capture`) is untouched, as is the Web Shell and desktop voice path. No change to when or how warmup preloads the backend.
- Breaking changes / migration notes: none. The new `checkMicrophonePermission` hook argument and the `voiceMicWarnedStatusRef` prop are both optional, so callers that do not pass them keep working — with the notice falling back to once per component instance.

## Linked Issues

Fixes #8877

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

语音预热（warmup）不再向操作系统查询麦克风权限。以前预加载录音后端和探测权限是同一个步骤，因此只要会话配置了语音模型，输入框一出现就会去查询麦克风。现在这两件事被拆开：预热只负责预加载后端，权限探测则在真正开始录音时才执行。

用于避免重复提示的状态也上移了。它原先保存在输入框组件内部，组件重新挂载时会被重置，同一条提示可能再次被追加。现在它保存在 app container 中——它在对话框切换和布局切换期间始终保持挂载——并经由 UI state 传递到输入框（与 `mainControlsRef` 相同的路径），仍然是带本地兜底的可选 prop。

## 为什么需要

在 macOS 上，未决定（undetermined）的 TCC 状态会被报告为 `prompt`，而这正是从未使用过听写的用户的正常状态。由于探测发生在预热阶段，配置了语音模型的会话每次启动都会向聊天记录追加“Voice dictation needs microphone access”——即使用户从不按语音键。启动过程中输入框的一次重新挂载会重置每个实例的去重标记，因此该提示经常出现两次。

改动之后，只有真正尝试听写的用户才会看到该提示，并且每次运行只出现一次。

## 审阅者验证步骤

配置语音模型以启用语音听写，不要授予终端麦克风权限（或用 `tccutil reset Microphone <terminal bundle id>` 重置），然后在 macOS 上启动 CLI。

- 改动前的预期：无需任何交互，启动时聊天记录中就会出现“Voice dictation needs microphone access …”，而且常常出现两次。
- 改动后的预期：启动时不会有任何提示。第一次用语音键开始录音时才出现该提示，且仅出现这一次——重复录音以及输入框重新挂载都不会再次出现。

自动化覆盖，在仓库根目录执行：

```
npx vitest run --root packages/cli --coverage=false src/ui/components/InputPrompt.test.tsx src/ui/hooks/use-voice-input.test.ts src/ui/components/Composer.test.tsx src/ui/voice/voice-recorder.test.ts
```

`packages/cli/src/ui/components/InputPrompt.test.tsx` 中新增的测试（`voice microphone permission`）：

- 预热期间不探测、也不提示麦克风权限
- 开始录音时对待决权限给出提示
- 开始录音时把已拒绝的权限报告为错误
- 状态相同的重复录音只提示一次
- 提供会话级 ref 时，跨重新挂载也只提示一次
- 录音器无法报告权限时保持安静
- 权限探测被 reject 时保持安静
- 权限已授予时保持安静
- 两次录音之间权限状态发生变化时再次提示

以及 `packages/cli/src/ui/hooks/use-voice-input.test.ts` 中的：在开始录音之前不检查麦克风权限。`packages/cli/src/ui/components/Composer.test.tsx` 中的：跨输入激活切换转发同一个会话级权限 ref。

## 证据（前后对比）

这次的行为变化是“某条消息不再出现”，因此证据是同一批测试分别对旧代码和新代码运行的结果。

改动前——把三个源文件回退到 `main`、保留新测试：

```
 Test Files  2 failed (2)
      Tests  6 failed | 3 passed | 227 skipped (236)
```

改动后——本分支上执行同一条命令：

```
 Test Files  2 passed (2)
      Tests  9 passed | 227 skipped (236)
```

本次改动涉及的所有文件的测试：

```
 Test Files  4 passed (4)
      Tests  264 passed (264)
```

## 测试平台

macOS 已验证（该问题标记为 `scope/macos`，也正是在 macOS 上复现）。Windows 与 Linux 未在本地运行；改动是与平台无关的 TypeScript，由 CI 覆盖这两条腿。

## 风险与范围

- 主要权衡：麦克风已被拒绝的用户现在会在按下语音键时才得知，而不是在启动时。这是有意的取舍——提示在可操作的时刻送达，而不是发给所有人。`denied` 分支仍然作为错误项呈现，未作改动。
- 未验证 / 不在范围内：原生权限探测本身（`packages/audio-capture`）未改动，Web Shell 与桌面端语音路径同样未改动。预热预加载后端的时机与方式没有变化。
- 破坏性变更 / 迁移说明：无。新增的 `checkMicrophonePermission` hook 参数与 `voiceMicWarnedStatusRef` prop 都是可选的，不传的调用方行为不变——提示退化为每个组件实例一次。

## 关联 issue

Fixes #8877

</details>
