### PR TITLE
fix(web-shell): stabilize transcript history pagination

### DIFF
--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -4084,6 +4084,183 @@ describe('createAcpSessionBridge', () => {
     await bridge.shutdown();
   });
 
+  it('skips empty persisted pages when refreshing an attached load', async () => {
+    const handle = makeChannel({
+      loadSessionImpl: () => ({}),
+      extMethodImpl: (method, params) => {
+        if (method !== SERVE_STATUS_EXT_METHODS.sessionTranscript) {
+          throw new Error(`unexpected extMethod ${method}`);
+        }
+        if (params['cursor'] === undefined) {
+          return {
+            v: 1,
+            sessionId: params['sessionId'],
+            events: [],
+            nextCursor: 'older-page',
+            hasMore: true,
+          };
+        }
+        return {
+          v: 1,
+          sessionId: params['sessionId'],
+          events: [
+            {
+              v: 1,
+              type: 'session_update',
+              data: {
+                sessionUpdate: 'user_message_chunk',
+                content: { type: 'text', text: 'visible prompt' },
+              },
+            },
+          ],
+          hasMore: false,
+        };
+      },
+    });
+    const bridge = makeBridge({ channelFactory: async () => handle.channel });
+    const loaded = await bridge.loadSession({
+      sessionId: 'persisted-empty-latest-page',
+      workspaceCwd: WS_A,
+      historyReplay: 'response',
+      historyPageSize: 100,
+    });
+
+    const refreshed = await bridge.loadSession({
+      sessionId: loaded.sessionId,
+      workspaceCwd: WS_A,
+      clientId: loaded.clientId,
+      historyReplay: 'response',
+      historyPageSize: 100,
+    });
+
+    expect(handle.agent.extMethodCalls).toEqual([
+      {
+        method: SERVE_STATUS_EXT_METHODS.sessionTranscript,
+        params: {
+          cwd: WS_A,
+          sessionId: loaded.sessionId,
+          direction: 'backward',
+          limit: 100,
+        },
+      },
+      {
+        method: SERVE_STATUS_EXT_METHODS.sessionTranscript,
+        params: {
+          cwd: WS_A,
+          sessionId: loaded.sessionId,
+          cursor: 'older-page',
+          limit: 100,
+        },
+      },
+    ]);
+    expect(JSON.stringify(refreshed.compactedReplay)).toContain(
+      'visible prompt',
+    );
+
+    await bridge.shutdown();
+  });
+
+  it('falls back to live replay when an empty-page cursor repeats', async () => {
+    const handle = makeChannel({
+      loadSessionImpl: () => ({
+        _meta: {
+          'qwen.session.loadReplay': {
+            v: 1,
+            updates: [
+              {
+                sessionUpdate: 'user_message_chunk',
+                content: { type: 'text', text: 'live prompt' },
+              },
+            ],
+          },
+        },
+      }),
+      extMethodImpl: (method, params) => {
+        if (method !== SERVE_STATUS_EXT_METHODS.sessionTranscript) {
+          throw new Error(`unexpected extMethod ${method}`);
+        }
+        return {
+          v: 1,
+          sessionId: params['sessionId'],
+          events: [],
+          nextCursor: 'stuck-cursor',
+          hasMore: true,
+        };
+      },
+    });
+    const bridge = makeBridge({ channelFactory: async () => handle.channel });
+    const loaded = await bridge.loadSession({
+      sessionId: 'persisted-stuck-cursor',
+      workspaceCwd: WS_A,
+      historyReplay: 'response',
+      historyPageSize: 100,
+    });
+
+    const refreshed = await bridge.loadSession({
+      sessionId: loaded.sessionId,
+      workspaceCwd: WS_A,
+      clientId: loaded.clientId,
+      historyReplay: 'response',
+      historyPageSize: 100,
+    });
+
+    expect(handle.agent.extMethodCalls).toHaveLength(2);
+    expect(JSON.stringify(refreshed.compactedReplay)).toContain('live prompt');
+
+    await bridge.shutdown();
+  });
+
+  it('bounds empty persisted pages with unique cursors', async () => {
+    let cursor = 0;
+    const handle = makeChannel({
+      loadSessionImpl: () => ({
+        _meta: {
+          'qwen.session.loadReplay': {
+            v: 1,
+            updates: [
+              {
+                sessionUpdate: 'user_message_chunk',
+                content: { type: 'text', text: 'live prompt' },
+              },
+            ],
+          },
+        },
+      }),
+      extMethodImpl: (method, params) => {
+        if (method !== SERVE_STATUS_EXT_METHODS.sessionTranscript) {
+          throw new Error(`unexpected extMethod ${method}`);
+        }
+        return {
+          v: 1,
+          sessionId: params['sessionId'],
+          events: [],
+          nextCursor: `cursor-${cursor++}`,
+          hasMore: true,
+        };
+      },
+    });
+    const bridge = makeBridge({ channelFactory: async () => handle.channel });
+    const loaded = await bridge.loadSession({
+      sessionId: 'persisted-unique-empty-cursors',
+      workspaceCwd: WS_A,
+      historyReplay: 'response',
+      historyPageSize: 100,
+    });
+
+    const refreshed = await bridge.loadSession({
+      sessionId: loaded.sessionId,
+      workspaceCwd: WS_A,
+      clientId: loaded.clientId,
+      historyReplay: 'response',
+      historyPageSize: 100,
+    });
+
+    expect(handle.agent.extMethodCalls).toHaveLength(20);
+    expect(JSON.stringify(refreshed.compactedReplay)).toContain('live prompt');
+
+    await bridge.shutdown();
+  });
+
   it('propagates partial and replayError from a bounded refresh', async () => {
     const handle = makeChannel({
       loadSessionImpl: () => ({

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -1419,6 +1419,7 @@ const SESSION_GENERATION_TIMEOUT_MS = 65_000;
 const GENERATION_STREAM_QUEUE_CAPACITY = 128;
 const SESSION_BTW_TIMEOUT_MS = 60_000;
 const SESSION_TRANSCRIPT_TIMEOUT_MS = 60_000;
+const MAX_EMPTY_TRANSCRIPT_PAGES = 20;
 const SHELL_COMMAND_TIMEOUT_MS = 120_000;
 const MAX_SHELL_OUTPUT_FOR_HISTORY = 10_000;
 // Per-session cap on undrained mid-turn messages: a busy turn with no drain
@@ -4910,11 +4911,40 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     for (let attempt = 0; attempt < 2; attempt++) {
       try {
         const lastEventId = entry.events.lastEventId;
-        const page = await requestSessionTranscriptPage({
-          sessionId: entry.sessionId,
-          direction: 'backward',
-          limit: historyPageSize,
-        });
+        const seenCursors = new Set<string>();
+        let emptyPageCount = 0;
+        let cursor: string | undefined;
+        let page: BridgeSessionTranscriptPage;
+        do {
+          page = await requestSessionTranscriptPage({
+            sessionId: entry.sessionId,
+            ...(cursor ? { cursor } : { direction: 'backward' }),
+            limit: historyPageSize,
+          });
+          const nextCursor = page.nextCursor;
+          if (
+            page.events.length === 0 &&
+            page.hasMore &&
+            (nextCursor === undefined || seenCursors.has(nextCursor))
+          ) {
+            throw new Error('Transcript cursor did not advance');
+          }
+          if (
+            page.events.length === 0 &&
+            page.hasMore &&
+            ++emptyPageCount >= MAX_EMPTY_TRANSCRIPT_PAGES
+          ) {
+            throw new Error('Transcript empty-page limit exceeded');
+          }
+          cursor = nextCursor;
+          if (cursor !== undefined) seenCursors.add(cursor);
+        } while (
+          page.events.length === 0 &&
+          page.hasMore &&
+          cursor !== undefined &&
+          page.partial !== true &&
+          page.replayError === undefined
+        );
         if (
           byId.get(entry.sessionId) === entry &&
           !entry.promptActive &&

--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -17,6 +17,12 @@ import { WEB_SHELL_TRANSCRIPT_RELOAD_BLOCKS } from '../constants/sessions';
 import flashStyles from './MessageLocateFlash.module.css';
 import styles from './MessageList.module.css';
 
+const virtualizerTestState = vi.hoisted(() => ({
+  itemSizeCache: new Map<string | number, number>(),
+  resizeItem: vi.fn(),
+  renderItems: true,
+}));
+
 // Mock the App context and the heavy row children so this test exercises only
 // MessageList's own collapse + deferred-scroll logic, not the whole render tree.
 vi.mock('../App', async () => {
@@ -88,17 +94,20 @@ vi.mock('@tanstack/react-virtual', () => ({
     enabled: boolean;
     getItemKey: (index: number) => string | number;
   }) => {
-    const virtualItems = enabled
-      ? Array.from({ length: Math.min(count, 5) }, (_, index) => ({
-          key: getItemKey(index),
-          index,
-          start: index * 80,
-        }))
-      : [];
+    const virtualItems =
+      enabled && virtualizerTestState.renderItems
+        ? Array.from({ length: Math.min(count, 5) }, (_, index) => ({
+            key: getItemKey(index),
+            index,
+            start: index * 80,
+          }))
+        : [];
     return {
       getVirtualItems: () => virtualItems,
       getTotalSize: () => (enabled ? count * 80 : 0),
       measureElement: () => {},
+      resizeItem: virtualizerTestState.resizeItem,
+      itemSizeCache: virtualizerTestState.itemSizeCache,
       scrollToIndex: () => {},
     };
   },
@@ -151,6 +160,9 @@ afterEach(() => {
   }
   resizeObserverCallbacks.length = 0;
   resizeObserversFireOnObserve = true;
+  virtualizerTestState.itemSizeCache.clear();
+  virtualizerTestState.resizeItem.mockClear();
+  virtualizerTestState.renderItems = true;
   vi.useRealTimers();
   vi.restoreAllMocks();
 });
@@ -2141,6 +2153,40 @@ describe('MessageList — turn collapse (DOM)', () => {
     expect(onLoadOlderHistory).toHaveBeenCalledTimes(1);
   });
 
+  it('loads earlier history after a fast wheel reaches the top', async () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    const onLoadOlderHistory = vi.fn().mockResolvedValue(undefined);
+    const c = mount([userMsg('u1')], undefined, {
+      hasOlderHistory: true,
+      onLoadOlderHistory,
+    });
+    const list = c.querySelector(
+      '[data-web-shell-message-list]',
+    ) as HTMLElement;
+    await nextFrame();
+    Object.defineProperty(list, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: 200,
+    });
+
+    await act(async () => {
+      list.dispatchEvent(new WheelEvent('wheel', { deltaY: -500 }));
+      list.scrollTop = 0;
+      await Promise.resolve();
+    });
+    await nextFrame();
+
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(1);
+  });
+
   it('preserves the scroll anchor after prepending earlier history', async () => {
     let scrollHeight = 1200;
     let scrollTop = 40;
@@ -2182,9 +2228,218 @@ describe('MessageList — turn collapse (DOM)', () => {
       list.dispatchEvent(new Event('scroll'));
       await Promise.resolve();
     });
+    await nextFrame();
 
     expect(onLoadOlderHistory).toHaveBeenCalledTimes(1);
     expect(scrollTop).toBe(640);
+  });
+
+  it('drops a pending history anchor when the transcript changes', async () => {
+    resizeObserversFireOnObserve = false;
+    const rectSpy = mockMessageListWidth(1000);
+    let scrollHeight = 1200;
+    let scrollTop = 40;
+    const resolveLoads: Array<() => void> = [];
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    const onLoadOlderHistory = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveLoads.push(resolve);
+        }),
+    );
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container, transcriptRenderMode: 'interactive' });
+    const render = (messages: Message[]) =>
+      root.render(
+        <I18nProvider language="en">
+          <MessageList
+            messages={messages}
+            pendingApproval={null}
+            hasOlderHistory
+            onLoadOlderHistory={onLoadOlderHistory}
+          />
+        </I18nProvider>,
+      );
+
+    act(() => render([userMsg('old')]));
+    const list = container.querySelector(
+      '[data-web-shell-message-list]',
+    ) as HTMLElement;
+    Object.defineProperty(list, 'scrollTop', {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = value;
+      },
+    });
+    Object.defineProperty(list, 'scrollTo', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    act(() => {
+      list.dispatchEvent(new WheelEvent('wheel', { deltaY: -1 }));
+      list.dispatchEvent(new Event('scroll'));
+    });
+    await Promise.resolve();
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(1);
+
+    scrollHeight = 1300;
+    act(() => render([userMsg('old'), asstMsg('streaming')]));
+    await nextFrame();
+    expect(scrollTop).toBe(40);
+
+    act(() => {
+      list.dispatchEvent(new WheelEvent('wheel', { deltaY: -1 }));
+    });
+    await nextFrame();
+
+    scrollHeight = 1800;
+    act(() => render([userMsg('new')]));
+    await nextFrame();
+
+    expect(scrollTop).toBe(40);
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(1);
+    act(() => {
+      list.dispatchEvent(new WheelEvent('wheel', { deltaY: -1 }));
+      list.dispatchEvent(new Event('scroll'));
+    });
+    await Promise.resolve();
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(2);
+
+    await act(async () => resolveLoads[0]?.());
+    await nextFrame();
+    act(() => {
+      list.dispatchEvent(new WheelEvent('wheel', { deltaY: -1 }));
+      list.dispatchEvent(new Event('scroll'));
+    });
+    await Promise.resolve();
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(2);
+
+    await act(async () => resolveLoads[1]?.());
+    await nextFrame();
+    rectSpy.mockRestore();
+  });
+
+  it('releases pagination when a virtual anchor never mounts', async () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    const messages = simpleTurns(110);
+    const onLoadOlderHistory = vi.fn().mockResolvedValue(undefined);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container, transcriptRenderMode: 'interactive' });
+    const render = (nextMessages: Message[]) =>
+      root.render(
+        <I18nProvider language="en">
+          <MessageList
+            messages={nextMessages}
+            pendingApproval={null}
+            hasOlderHistory
+            onLoadOlderHistory={onLoadOlderHistory}
+          />
+        </I18nProvider>,
+      );
+
+    virtualizerTestState.renderItems = false;
+    act(() => render(messages));
+    const list = container.querySelector(
+      '[data-web-shell-message-list]',
+    ) as HTMLElement;
+    Object.defineProperty(list, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+    act(() => {
+      list.dispatchEvent(new Event('scroll'));
+    });
+    for (let frame = 0; frame < 32; frame++) await nextFrame();
+    expect(onLoadOlderHistory).not.toHaveBeenCalled();
+
+    virtualizerTestState.renderItems = true;
+    act(() => render([...messages]));
+    await nextFrame();
+    expect(
+      container.querySelectorAll('[data-message-row-key]').length,
+    ).toBeGreaterThan(0);
+    list.scrollTop = 0;
+    act(() => {
+      list.dispatchEvent(new WheelEvent('wheel', { deltaY: -1 }));
+      list.dispatchEvent(new Event('scroll'));
+    });
+    await nextFrame();
+    await nextFrame();
+
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it('measures newly prepended virtual rows before they can overlap the anchor', async () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    const currentMessages = simpleTurns(110);
+    const earlierMessages = simpleTurns(3).map((message) => ({
+      ...message,
+      id: `earlier-${message.id}`,
+    }));
+    const onLoadOlderHistory = vi.fn().mockResolvedValue(undefined);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container, transcriptRenderMode: 'interactive' });
+    const render = (messages: Message[]) =>
+      root.render(
+        <I18nProvider language="en">
+          <MessageList
+            messages={messages}
+            pendingApproval={null}
+            hasOlderHistory
+            onLoadOlderHistory={onLoadOlderHistory}
+          />
+        </I18nProvider>,
+      );
+
+    act(() => render(currentMessages));
+    const list = container.querySelector(
+      '[data-web-shell-message-list]',
+    ) as HTMLElement;
+    Object.defineProperty(list, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+    await act(async () => {
+      list.dispatchEvent(new Event('scroll'));
+      await Promise.resolve();
+    });
+    await nextFrame();
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(1);
+
+    virtualizerTestState.resizeItem.mockClear();
+    act(() => render([...earlierMessages, ...currentMessages]));
+
+    expect(virtualizerTestState.resizeItem).toHaveBeenCalled();
   });
 
   it('loads earlier history when the transcript does not overflow', async () => {
@@ -2242,6 +2497,7 @@ describe('MessageList — turn collapse (DOM)', () => {
       await Promise.resolve();
     });
     expect(onLoadOlderHistory).toHaveBeenCalledTimes(1);
+    await nextFrame();
 
     await act(async () => {
       render(true);
@@ -2266,6 +2522,7 @@ describe('MessageList — turn collapse (DOM)', () => {
       list.dispatchEvent(new WheelEvent('wheel', { deltaY: -1 }));
       await Promise.resolve();
     });
+    await nextFrame();
 
     expect(onLoadOlderHistory).toHaveBeenCalledTimes(2);
   });
@@ -2306,6 +2563,7 @@ describe('MessageList — turn collapse (DOM)', () => {
       list.dispatchEvent(new WheelEvent('wheel', { deltaY: -1 }));
       await Promise.resolve();
     });
+    await nextFrame();
 
     expect(onLoadOlderHistory).toHaveBeenCalledTimes(2);
   });
@@ -2804,6 +3062,40 @@ describe('MessageList — turn collapse (DOM)', () => {
     await nextFrame();
 
     expect(onCanScrollToBottomChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('pauses bottom follow for a small upward wheel during scroll cooldown', async () => {
+    let scrollTop = 600;
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollTop', {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = Math.max(0, Math.min(value, 600));
+      },
+    });
+    const onCanScrollToBottomChange = vi.fn();
+    const container = mount([asstMsg('a1')], undefined, {
+      isResponding: true,
+      onCanScrollToBottomChange,
+    });
+    const list = container.firstElementChild as HTMLElement;
+
+    act(() => {
+      list.dispatchEvent(new WheelEvent('wheel', { deltaY: -8 }));
+      list.scrollTop = 592;
+      list.dispatchEvent(new Event('scroll', { bubbles: true }));
+    });
+    await nextFrame();
+
+    expect(onCanScrollToBottomChange).toHaveBeenLastCalledWith(true);
   });
 
   it('reports no scroll-to-bottom affordance when the list has no scrollbar', async () => {

--- a/packages/web-shell/client/components/MessageList.module.css
+++ b/packages/web-shell/client/components/MessageList.module.css
@@ -183,11 +183,11 @@
   max-width: 100%;
 }
 .turnStatusRow {
-  margin-bottom: 4px;
+  padding-bottom: 4px;
 }
 
 .turnAnswerRow {
-  margin-top: 10px;
+  padding-top: 10px;
 }
 
 .turnContentRow {

--- a/packages/web-shell/client/components/MessageList.test.ts
+++ b/packages/web-shell/client/components/MessageList.test.ts
@@ -13,6 +13,7 @@ import {
   getTurnIdByDisplayIndex,
   groupParallelAgents,
   pinActiveParallelAgentsToTurnEnd,
+  shouldAdjustVirtualScrollPosition,
   shouldUseVirtualScroll,
   VIRTUAL_SCROLL_THRESHOLD,
   type DisplayItem,
@@ -1028,6 +1029,13 @@ describe('shouldUseVirtualScroll', () => {
   });
 });
 
+describe('shouldAdjustVirtualScrollPosition', () => {
+  it('adjusts only for rows fully above the viewport', () => {
+    expect(shouldAdjustVirtualScrollPosition(900, 1_000)).toBe(true);
+    expect(shouldAdjustVirtualScrollPosition(1_100, 1_000)).toBe(false);
+  });
+});
+
 describe('findDisplayItemIndex', () => {
   it('finds a row by message id', () => {
     const items = groupParallelAgents([
@@ -1919,6 +1927,42 @@ describe('applyTurnCollapse', () => {
       hiddenCount: 1,
       toolCallCount: 2,
     });
+  });
+
+  it('collapses a failed turn after a newer turn starts', () => {
+    const items = groupParallelAgents([
+      makeUserMessage('u1'),
+      makeMultiToolGroup('g1'),
+      {
+        id: 's1',
+        role: 'system',
+        content: 'The turn failed.',
+        variant: 'error',
+        source: 'turn_error',
+      },
+      makeUserMessage('u2'),
+      makeMultiToolGroup('g2'),
+      makeAssistantMessage('a2'),
+    ]);
+
+    const out = collapseItems(items);
+
+    expect(collapseOf(out, 'u1')?.collapsed).toBe(true);
+  });
+
+  it('collapses a turn with no final answer after a newer turn starts', () => {
+    const items = groupParallelAgents([
+      makeUserMessage('u1'),
+      makeMultiToolGroup('g1'),
+      makeAssistantMessage('interim'),
+      makeMultiToolGroup('g2'),
+      makeUserMessage('u2'),
+      makeAssistantMessage('a2'),
+    ]);
+
+    const out = collapseItems(items);
+
+    expect(collapseOf(out, 'u1')?.collapsed).toBe(true);
   });
 
   it('folds thinking separately from the final answer', () => {

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -1561,7 +1561,8 @@ export function applyTurnCollapse(
     const head = items[start] as Extract<DisplayItem, { type: 'message' }>;
     const turnId = head.message.id;
     const promptTs = head.message.timestamp;
-    const isActiveTurn = k === userIdxs.length - 1 && isResponding;
+    const isLastTurn = k === userIdxs.length - 1;
+    const isActiveTurn = isLastTurn && isResponding;
     const hasActiveAgent = turnHasActiveAgent(items, start, end);
     const hasAutomaticallyExpandedAgent = turnHasAutomaticallyExpandedAgent(
       items,
@@ -1570,7 +1571,7 @@ export function applyTurnCollapse(
       automaticallyExpandedAgentKeys,
     );
     const awaitsBackgroundSummary =
-      k === userIdxs.length - 1 &&
+      isLastTurn &&
       backgroundSummaryGraceActive &&
       turnAwaitsBackgroundSummary(items, start, end);
     const hasPendingApproval = turnOwnsCallId(
@@ -1660,8 +1661,8 @@ export function applyTurnCollapse(
     }
 
     // A turn with foldable steps gets a chevron and defaults to expanded while
-    // streaming, while a subagent is still active, when the turn errored, or
-    // when there is no final answer; otherwise it collapses once complete. A
+    // streaming, while a subagent is still active, or when the latest turn is
+    // incomplete; otherwise it collapses once a newer turn starts. A
     // step-less turn (e.g. a plain "hi" reply) has nothing to fold, so it stays
     // expanded and shows a chevron-less metrics line. An explicit user toggle
     // always wins.
@@ -1670,8 +1671,7 @@ export function applyTurnCollapse(
       hasActiveAgent ||
       hasAutomaticallyExpandedAgent ||
       awaitsBackgroundSummary ||
-      hasTurnError ||
-      answerIdx < 0;
+      ((hasTurnError || answerIdx < 0) && isLastTurn);
     const expanded =
       hiddenCount === 0
         ? true
@@ -1823,7 +1823,8 @@ const ESTIMATE_MESSAGE = 80;
 const ESTIMATE_TURN_COLLAPSE = 32;
 const ESTIMATE_TAIL = 240;
 const FOLLOW_BOTTOM_THRESHOLD_PX = 30;
-const LOAD_OLDER_HISTORY_THRESHOLD_PX = 48;
+const LOAD_OLDER_HISTORY_THRESHOLD_PX = 160;
+const OLDER_HISTORY_ANCHOR_WAIT_FRAMES = 30;
 export const VIRTUAL_SCROLL_THRESHOLD = 200;
 const SESSION_TIMELINE_MIN_VISIBLE_ENTRIES = 4;
 
@@ -1832,6 +1833,13 @@ export function shouldUseVirtualScroll(
   threshold = VIRTUAL_SCROLL_THRESHOLD,
 ): boolean {
   return totalCount > threshold;
+}
+
+export function shouldAdjustVirtualScrollPosition(
+  itemEnd: number,
+  scrollOffset: number,
+): boolean {
+  return itemEnd <= scrollOffset;
 }
 
 function formatDuration(ms: number): string {
@@ -2731,6 +2739,7 @@ export const MessageList = memo(
     const userScrollIntentUntil = useRef(0);
     const lastScrollTop = useRef(0);
     const olderHistoryLoadInFlight = useRef(false);
+    const olderHistoryLoadGeneration = useRef(0);
     const scrollCooldown = useRef(false);
     const scrollCooldownCount = useRef(0);
     const pendingBottomFollowAfterCooldown = useRef(false);
@@ -2757,6 +2766,10 @@ export const MessageList = memo(
     catchingUpRef.current = catchingUp;
     const containerRef = useRef<HTMLDivElement>(null);
     const olderHistoryRetryBlocked = useRef(false);
+    const olderHistoryAnchorFrame = useRef<number | undefined>(undefined);
+    const olderHistoryAnchorWaitFrame = useRef<number | undefined>(undefined);
+    const olderHistoryTopCheckFrame = useRef<number | undefined>(undefined);
+    const pendingOlderHistoryTopLoad = useRef<number | undefined>(undefined);
     const reloadTranscriptTimer = useRef<number | undefined>(undefined);
     const reloadTranscriptAbort = useRef<AbortController | undefined>(
       undefined,
@@ -2779,23 +2792,19 @@ export const MessageList = memo(
     const [olderHistoryAnchor, setOlderHistoryAnchor] = useState<{
       scrollHeight: number;
       scrollTop: number;
+      messageCount: number;
+      virtual: boolean;
+      settled: boolean;
+      generation: number;
+      rowKey?: string;
+      rowTop?: number;
     } | null>(null);
+    const restoringOlderHistoryRef = useRef(false);
+    restoringOlderHistoryRef.current = olderHistoryAnchor?.virtual === true;
     const [
       suppressOlderHistoryLoadingStatus,
       setSuppressOlderHistoryLoadingStatus,
     ] = useState(false);
-
-    useLayoutEffect(() => {
-      if (!olderHistoryAnchor) return;
-      const current = containerRef.current;
-      if (current) {
-        current.scrollTop =
-          olderHistoryAnchor.scrollTop +
-          Math.max(0, current.scrollHeight - olderHistoryAnchor.scrollHeight);
-      }
-      olderHistoryLoadInFlight.current = false;
-      setOlderHistoryAnchor(null);
-    }, [olderHistoryAnchor]);
 
     useEffect(() => {
       if (!hasOlderHistory) {
@@ -2897,6 +2906,15 @@ export const MessageList = memo(
       mergedMessages,
       automaticallyExpandedAgentKeys,
     ]);
+    const visibleItemsRef = useRef(visibleItems);
+    visibleItemsRef.current = visibleItems;
+    const hasVisibleRowKey = useCallback(
+      (key: string) =>
+        visibleItemsRef.current.some(
+          (item) => String(getDisplayItemVirtualKey(item)) === key,
+        ),
+      [],
+    );
     const visibleTurnIdByDisplayIndex = useMemo(
       () => getTurnIdByDisplayIndex(visibleItems),
       [visibleItems],
@@ -3118,6 +3136,15 @@ export const MessageList = memo(
         if (pendingOverflowFrame.current !== undefined) {
           window.cancelAnimationFrame(pendingOverflowFrame.current);
         }
+        if (olderHistoryAnchorFrame.current !== undefined) {
+          window.cancelAnimationFrame(olderHistoryAnchorFrame.current);
+        }
+        if (olderHistoryAnchorWaitFrame.current !== undefined) {
+          window.cancelAnimationFrame(olderHistoryAnchorWaitFrame.current);
+        }
+        if (olderHistoryTopCheckFrame.current !== undefined) {
+          window.cancelAnimationFrame(olderHistoryTopCheckFrame.current);
+        }
         cancelTranscriptReload();
         if (transcriptBottomScrollFrame.current !== undefined) {
           window.cancelAnimationFrame(transcriptBottomScrollFrame.current);
@@ -3338,9 +3365,120 @@ export const MessageList = memo(
         return ESTIMATE_MESSAGE;
       },
       overscan: 20,
+      anchorTo: 'end',
       useFlushSync: false,
       useAnimationFrameWithResizeObserver: true,
+      directDomUpdates: true,
     });
+    virtualizer.shouldAdjustScrollPositionOnItemSizeChange = (
+      item,
+      _delta,
+      instance,
+    ) =>
+      shouldAdjustVirtualScrollPosition(
+        item.end,
+        containerRef.current?.scrollTop ?? instance.scrollOffset ?? 0,
+      );
+    const measureVirtualRow = useCallback(
+      (node: HTMLDivElement | null) => {
+        virtualizer.measureElement(node);
+        if (!node || !restoringOlderHistoryRef.current) return;
+        const index = Number(node.dataset.index);
+        if (
+          Number.isFinite(index) &&
+          !virtualizer.itemSizeCache.has(getItemKey(index))
+        ) {
+          virtualizer.resizeItem(index, node.offsetHeight);
+        }
+      },
+      [getItemKey, virtualizer],
+    );
+    useLayoutEffect(() => {
+      if (!olderHistoryAnchor) return;
+      const current = containerRef.current;
+      if (
+        olderHistoryAnchor.rowKey &&
+        !hasVisibleRowKey(olderHistoryAnchor.rowKey)
+      ) {
+        if (
+          olderHistoryAnchor.generation === olderHistoryLoadGeneration.current
+        ) {
+          olderHistoryLoadGeneration.current += 1;
+        }
+        olderHistoryLoadInFlight.current = false;
+        pendingOlderHistoryTopLoad.current = undefined;
+        setSuppressOlderHistoryLoadingStatus(false);
+        setOlderHistoryAnchor(null);
+        return;
+      }
+      if (!olderHistoryAnchor.settled) return;
+      if (!current) {
+        olderHistoryLoadInFlight.current = false;
+        setOlderHistoryAnchor(null);
+        return;
+      }
+      const unchanged = olderHistoryAnchor.virtual
+        ? mergedMessages.length === olderHistoryAnchor.messageCount
+        : current.scrollHeight === olderHistoryAnchor.scrollHeight;
+      if (unchanged) {
+        if (olderHistoryAnchorFrame.current !== undefined) return;
+        olderHistoryAnchorFrame.current = requestAnimationFrame(() => {
+          olderHistoryAnchorFrame.current = undefined;
+          if (
+            olderHistoryAnchor.generation !== olderHistoryLoadGeneration.current
+          ) {
+            return;
+          }
+          olderHistoryLoadInFlight.current = false;
+          setOlderHistoryAnchor((anchor) =>
+            anchor === olderHistoryAnchor ? null : anchor,
+          );
+        });
+        return;
+      }
+      if (olderHistoryAnchorFrame.current !== undefined) {
+        cancelAnimationFrame(olderHistoryAnchorFrame.current);
+        olderHistoryAnchorFrame.current = undefined;
+      }
+      olderHistoryAnchorFrame.current = requestAnimationFrame(() => {
+        olderHistoryAnchorFrame.current = undefined;
+        if (
+          olderHistoryAnchor.generation !== olderHistoryLoadGeneration.current
+        ) {
+          return;
+        }
+        if (
+          olderHistoryAnchor.rowKey &&
+          !hasVisibleRowKey(olderHistoryAnchor.rowKey)
+        ) {
+          olderHistoryLoadInFlight.current = false;
+          setOlderHistoryAnchor(null);
+          return;
+        }
+        const anchorRow = olderHistoryAnchor.rowKey
+          ? Array.from(
+              current.querySelectorAll<HTMLElement>('[data-message-row-key]'),
+            ).find(
+              (row) => row.dataset.messageRowKey === olderHistoryAnchor.rowKey,
+            )
+          : undefined;
+        if (anchorRow && olderHistoryAnchor.rowTop !== undefined) {
+          current.scrollTop +=
+            anchorRow.getBoundingClientRect().top - olderHistoryAnchor.rowTop;
+        } else {
+          current.scrollTop =
+            olderHistoryAnchor.scrollTop +
+            Math.max(0, current.scrollHeight - olderHistoryAnchor.scrollHeight);
+        }
+        olderHistoryLoadInFlight.current = false;
+        setOlderHistoryAnchor(null);
+      });
+    }, [
+      hasVisibleRowKey,
+      mergedMessages.length,
+      olderHistoryAnchor,
+      visibleItems,
+    ]);
     const virtualItems = virtualizer.getVirtualItems();
     const totalVirtualSize = virtualizer.getTotalSize();
     const sessionTimelineRangeState = useRef<{
@@ -3604,29 +3742,156 @@ export const MessageList = memo(
         }
         olderHistoryRetryBlocked.current = false;
         olderHistoryLoadInFlight.current = true;
-        setSuppressOlderHistoryLoadingStatus(!allowRetry);
+        const generation = ++olderHistoryLoadGeneration.current;
+        setSuppressOlderHistoryLoadingStatus(!force);
+        let virtualAnchor:
+          | {
+              rowKey: string;
+              rowTop: number;
+            }
+          | undefined;
+        if (useVirtualScroll) {
+          const firstMessageKey = String(getItemKey(headerOffset));
+          let remainingFrames = OLDER_HISTORY_ANCHOR_WAIT_FRAMES;
+          virtualAnchor = await new Promise<
+            | {
+                rowKey: string;
+                rowTop: number;
+              }
+            | undefined
+          >((resolve) => {
+            const waitForTopRange = () => {
+              olderHistoryAnchorWaitFrame.current = undefined;
+              if (
+                generation !== olderHistoryLoadGeneration.current ||
+                containerRef.current !== el ||
+                !hasVisibleRowKey(firstMessageKey) ||
+                remainingFrames-- <= 0
+              ) {
+                resolve(undefined);
+                return;
+              }
+              const firstMessageRow = Array.from(
+                el.querySelectorAll<HTMLElement>('[data-message-row-key]'),
+              ).find((row) => row.dataset.messageRowKey === firstMessageKey);
+              if (firstMessageRow) {
+                resolve({
+                  rowKey: firstMessageKey,
+                  rowTop: firstMessageRow.getBoundingClientRect().top,
+                });
+              } else {
+                olderHistoryAnchorWaitFrame.current =
+                  requestAnimationFrame(waitForTopRange);
+              }
+            };
+            olderHistoryAnchorWaitFrame.current =
+              requestAnimationFrame(waitForTopRange);
+          });
+          if (!virtualAnchor) {
+            if (generation === olderHistoryLoadGeneration.current) {
+              olderHistoryLoadInFlight.current = false;
+              pendingOlderHistoryTopLoad.current = undefined;
+              setSuppressOlderHistoryLoadingStatus(false);
+            }
+            return;
+          }
+        }
         const previousHeight = el.scrollHeight;
         const previousTop = el.scrollTop;
+        const viewportTop = el.getBoundingClientRect().top;
+        const anchorRow = virtualAnchor
+          ? undefined
+          : Array.from(
+              el.querySelectorAll<HTMLElement>('[data-message-row-key]'),
+            ).find((row) => {
+              const key = row.dataset.messageRowKey;
+              return (
+                key !== undefined &&
+                key.startsWith('msg:') &&
+                row.getBoundingClientRect().bottom > viewportTop
+              );
+            });
         followPausedByUserRef.current = true;
+        setOlderHistoryAnchor({
+          scrollHeight: previousHeight,
+          scrollTop: previousTop,
+          messageCount: mergedMessages.length,
+          virtual: useVirtualScroll,
+          settled: false,
+          generation,
+          ...(virtualAnchor ??
+            (anchorRow
+              ? {
+                  rowKey: anchorRow.dataset.messageRowKey,
+                  rowTop: anchorRow.getBoundingClientRect().top,
+                }
+              : {})),
+        });
         try {
           await onLoadOlderHistory(force ? { force: true } : undefined);
-          setOlderHistoryAnchor({
-            scrollHeight: previousHeight,
-            scrollTop: previousTop,
-          });
+          if (generation === olderHistoryLoadGeneration.current) {
+            setOlderHistoryAnchor((anchor) =>
+              anchor?.generation === generation
+                ? { ...anchor, settled: true }
+                : anchor,
+            );
+          }
         } catch {
-          olderHistoryRetryBlocked.current = true;
-          olderHistoryLoadInFlight.current = false;
+          if (generation === olderHistoryLoadGeneration.current) {
+            olderHistoryRetryBlocked.current = true;
+            olderHistoryLoadInFlight.current = false;
+            setOlderHistoryAnchor(null);
+          }
         } finally {
-          setSuppressOlderHistoryLoadingStatus(false);
+          if (generation === olderHistoryLoadGeneration.current) {
+            setSuppressOlderHistoryLoadingStatus(false);
+          }
         }
       },
-      [loadingOlderHistory, onLoadOlderHistory, historyPaginationError],
+      [
+        loadingOlderHistory,
+        onLoadOlderHistory,
+        historyPaginationError,
+        getItemKey,
+        hasVisibleRowKey,
+        headerOffset,
+        mergedMessages.length,
+        useVirtualScroll,
+      ],
     );
 
     const retryOlderHistory = useCallback(() => {
       void loadOlderHistory(true, true);
     }, [loadOlderHistory]);
+
+    useEffect(() => {
+      const pendingGeneration = pendingOlderHistoryTopLoad.current;
+      if (
+        pendingGeneration === undefined ||
+        loadingOlderHistory ||
+        olderHistoryAnchor ||
+        olderHistoryLoadInFlight.current
+      ) {
+        return;
+      }
+      pendingOlderHistoryTopLoad.current = undefined;
+      if (
+        !hasOlderHistory ||
+        pendingGeneration !== olderHistoryLoadGeneration.current
+      ) {
+        return;
+      }
+      const el = getScrollElement();
+      if (el && el.scrollTop <= LOAD_OLDER_HISTORY_THRESHOLD_PX) {
+        void loadOlderHistory(true);
+      }
+    }, [
+      getScrollElement,
+      hasOlderHistory,
+      loadOlderHistory,
+      loadingOlderHistory,
+      olderHistoryAnchor,
+    ]);
 
     // Rules 2 & 3: detect scroll direction to toggle follow mode.
     // Runs synchronously in the scroll handler — no rAF needed since
@@ -3638,20 +3903,9 @@ export const MessageList = memo(
       if (hasOlderHistory && curr <= LOAD_OLDER_HISTORY_THRESHOLD_PX) {
         void loadOlderHistory(true);
       }
-      if (scrollCooldown.current) {
-        const userScrolledUp =
-          curr < lastScrollTop.current - 1 &&
-          Date.now() <= userScrollIntentUntil.current &&
-          el.scrollHeight - curr - el.clientHeight >=
-            FOLLOW_BOTTOM_THRESHOLD_PX;
+      const hasUserScrollIntent = Date.now() <= userScrollIntentUntil.current;
+      if (scrollCooldown.current && !hasUserScrollIntent) {
         lastScrollTop.current = curr;
-        if (userScrolledUp) {
-          cancelTranscriptReload();
-          followPausedByUserRef.current = true;
-          pendingBottomFollowAfterCooldown.current = false;
-          setShouldFollow(false);
-          scheduleSessionTimelineRangeUpdate();
-        }
         return;
       }
       scheduleSessionTimelineRangeUpdate();
@@ -3665,14 +3919,13 @@ export const MessageList = memo(
         // Container resizes can clamp scrollTop downward while the viewport is
         // still at the tail. Treat that as follow mode, not a manual scroll-up.
         const isNearBottom = distanceFromBottom < FOLLOW_BOTTOM_THRESHOLD_PX;
-        const hasUserScrollIntent = Date.now() <= userScrollIntentUntil.current;
-        if (isNearBottom) {
-          followPausedByUserRef.current = false;
-          setShouldFollow(true);
-        } else if (hasUserScrollIntent) {
+        if (hasUserScrollIntent) {
           cancelTranscriptReload();
           followPausedByUserRef.current = true;
           setShouldFollow(false);
+        } else if (isNearBottom) {
+          followPausedByUserRef.current = false;
+          setShouldFollow(true);
         } else if (!followPausedByUserRef.current) {
           cancelTranscriptReload();
           setShouldFollow(false);
@@ -3750,22 +4003,32 @@ export const MessageList = memo(
     useEffect(() => {
       const el = getScrollElement();
       if (!el) return;
-      const retryOlderHistoryAtTop = () => {
-        if (
-          olderHistoryRetryBlocked.current &&
-          el.scrollTop <= LOAD_OLDER_HISTORY_THRESHOLD_PX
-        ) {
-          void loadOlderHistory(true);
+      const loadOlderHistoryAtTop = () => {
+        olderHistoryTopCheckFrame.current = undefined;
+        if (el.scrollTop > LOAD_OLDER_HISTORY_THRESHOLD_PX) return;
+        if (loadingOlderHistory || olderHistoryLoadInFlight.current) {
+          pendingOlderHistoryTopLoad.current =
+            olderHistoryLoadGeneration.current;
+          return;
         }
+        void loadOlderHistory(true);
+      };
+      const scheduleOlderHistoryTopCheck = () => {
+        if (olderHistoryTopCheckFrame.current !== undefined) {
+          cancelAnimationFrame(olderHistoryTopCheckFrame.current);
+        }
+        olderHistoryTopCheckFrame.current = requestAnimationFrame(
+          loadOlderHistoryAtTop,
+        );
       };
       const markFromWheel = (event: WheelEvent) => {
         markUserScrollIntent();
-        if (event.deltaY < 0) retryOlderHistoryAtTop();
+        if (event.deltaY < 0) scheduleOlderHistoryTopCheck();
       };
       const markFromTouch = () => {
         markUserScrollIntent();
-        retryOlderHistoryAtTop();
       };
+      const markFromTouchMove = () => scheduleOlderHistoryTopCheck();
       const markFromPointer = (event: PointerEvent) => {
         const rect = el.getBoundingClientRect();
         const scrollbarEdge = 20;
@@ -3792,7 +4055,7 @@ export const MessageList = memo(
             event.key === 'PageUp' ||
             event.key === 'Home'
           ) {
-            retryOlderHistoryAtTop();
+            scheduleOlderHistoryTopCheck();
           }
         }
       };
@@ -3800,15 +4063,26 @@ export const MessageList = memo(
       el.addEventListener('touchstart', markFromTouch, {
         passive: true,
       });
+      el.addEventListener('touchmove', markFromTouchMove, { passive: true });
       el.addEventListener('pointerdown', markFromPointer, { passive: true });
       el.addEventListener('keydown', markFromKey, { passive: true });
       return () => {
         el.removeEventListener('wheel', markFromWheel);
         el.removeEventListener('touchstart', markFromTouch);
+        el.removeEventListener('touchmove', markFromTouchMove);
         el.removeEventListener('pointerdown', markFromPointer);
         el.removeEventListener('keydown', markFromKey);
+        if (olderHistoryTopCheckFrame.current !== undefined) {
+          cancelAnimationFrame(olderHistoryTopCheckFrame.current);
+          olderHistoryTopCheckFrame.current = undefined;
+        }
       };
-    }, [getScrollElement, loadOlderHistory, markUserScrollIntent]);
+    }, [
+      getScrollElement,
+      loadOlderHistory,
+      loadingOlderHistory,
+      markUserScrollIntent,
+    ]);
 
     useEffect(() => {
       const el = getScrollElement();
@@ -4333,17 +4607,12 @@ export const MessageList = memo(
           onSelect={scrollToMessage}
         />
         {useVirtualScroll ? (
-          <div
-            className={styles.virtualSizer}
-            style={{
-              height: totalVirtualSize,
-            }}
-          >
+          <div ref={virtualizer.containerRef} className={styles.virtualSizer}>
             {virtualItems.map((virtualRow) => (
               <div
                 key={virtualRow.key}
                 data-index={virtualRow.index}
-                ref={virtualizer.measureElement}
+                ref={measureVirtualRow}
                 className={joinClassNames(
                   styles.virtualRow,
                   getRowClassName(
@@ -4357,7 +4626,6 @@ export const MessageList = memo(
                   top: 0,
                   left: 0,
                   right: 0,
-                  transform: `translateY(${virtualRow.start}px)`,
                 }}
               >
                 {renderVirtualItem(virtualRow.index)}


### PR DESCRIPTION
## What this PR does

This change stabilizes long Web Shell transcripts while users scroll upward through virtualized history. It preserves the visible message across prepended pages, measures newly mounted virtual rows before display, avoids fighting intentional upward scrolling while a response is streaming, and makes fast wheel, touch, and keyboard navigation reliably trigger pagination near the top.

It also keeps pagination state scoped to the active transcript, bounds virtual-anchor waiting, preserves consistent turn-output spacing after virtualization, and collapses incomplete or failed older turns once a newer turn exists while leaving the latest incomplete turn open for inspection.

Attached session refreshes now skip empty persisted transcript pages until a visible page is found. Repeated, missing, or excessively long empty-page cursor chains fall back to the live replay instead of returning an empty session or looping indefinitely.

## Why it's needed

Long sessions could visibly jump into newly loaded history, briefly render overlapping rows, or lose the reader's position during the first and second upward pagination. Fast scrolling could also reach the top without starting another page until the user moved down and up again. Separately, an attached session could appear empty when its newest persisted page contained no replayable events even though older pages contained the conversation.

## Reviewer Test Plan

### How to verify

1. Open a session long enough to enable virtual scrolling, expand several completed sections, scroll upward while the model is streaming, and cross at least two history page boundaries. The same visible message should remain anchored, with no overlapping or transient duplicate content.
2. From more than 160 px below the top, scroll upward quickly with a wheel or trackpad. Pagination should start after reaching the threshold without requiring a down-then-up retry.
3. Start loading earlier history, continue scrolling upward, then replace the transcript or switch sessions before the request settles. The old request must not restore, clear, or settle the new transcript's anchor, and a stale pending scroll intent must not paginate the new session.
4. Load an attached session whose newest persisted transcript page has no replayable events but an older page does. The visible older page should be returned. Repeated or continuously unique empty cursors should stop at the safety bound and use the live replay.
5. Confirm that the latest failed or answer-less turn stays expanded, then add a newer turn. The older incomplete turn should collapse. File-change output should retain the same vertical spacing before and after history pagination.

### Evidence (Before & After)

Before: upward pagination could move the viewport into the prepended page, briefly overlap old and current rows, miss fast top crossings, and return an empty attached session when the newest persisted page contained no visible replay events.

After: real-browser validation on macOS kept the viewport at the same visible content across repeated pagination without the recorded overlap flash. Automated coverage verifies anchor preservation, virtual-row measurement, fast top detection, stale-request isolation, bounded anchor waiting, turn-collapse behavior, and persisted empty-page recovery.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local Web Shell and daemon session on macOS, plus package-level Vitest and TypeScript checks.

## Risk & Scope

- Main risk or tradeoff: Scroll anchoring now coordinates virtual measurement and asynchronous pagination; generation guards, a 30-frame anchor budget, and a 20-empty-page transcript budget bound stale work.
- Not validated / out of scope: Browser-level automation on Windows and Linux; server-side pagination semantics and page size remain unchanged.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 的修改

本次修改提升了 Web Shell 长会话在向上浏览虚拟化历史记录时的稳定性。历史分页向前插入内容后会保持当前可见消息的位置，在展示前测量新挂载的虚拟行，模型流式输出期间不会与用户主动向上滚动争抢位置，并且快速滚轮、触摸和键盘操作到达顶部附近时都能可靠触发分页。

分页状态现在只作用于当前转录，虚拟锚点等待有明确上限，虚拟化后的 turn 输出间距保持一致；较早的异常或缺少最终回答的 turn 在出现新 turn 后会自动收起，而最新的不完整 turn 仍保持展开，便于用户检查。

刷新已附加会话时，会跳过没有可展示事件的持久化转录页，直到找到有内容的页面。对于重复、缺失或连续过长的空页 cursor 链，会回退到实时 replay，避免返回空会话或无限循环。

## 修改原因

长会话向上分页时可能直接跳进新加载的历史内容、短暂出现行重叠，或在第一次和第二次分页时丢失阅读位置。快速滚动到顶部后，有时还必须先向下再向上才能继续分页。另外，如果最新的持久化页没有可 replay 的事件，即使更早页面存在对话，已附加会话也可能显示为空。

## Reviewer 测试计划

### 验证方式

1. 打开足以启用虚拟滚动的长会话，展开多个“已处理”区域，在模型流式输出时向上滚动，并跨越至少两次历史分页。分页前后应保持同一条可见消息，不应出现重叠或瞬时重复内容。
2. 从距离顶部超过 160 px 的位置快速使用滚轮或触控板向上滚动。到达阈值后应直接触发分页，不需要先向下再向上重试。
3. 开始加载更早历史后继续向上滚动，并在请求完成前替换转录或切换会话。旧请求不得恢复、清理或结算新转录的锚点，旧会话遗留的滚动意图也不得触发新会话分页。
4. 加载一个最新持久化页没有可 replay 事件、但更早页面有内容的已附加会话。应返回更早的可见页面；重复 cursor 或持续产生不同空 cursor 时，应在安全边界停止并使用实时 replay。
5. 确认最新的异常或无最终回答 turn 保持展开，然后新增一个 turn。较早的不完整 turn 应收起；文件变更输出在历史分页前后应保持相同的垂直间距。

### 前后对比证据

修改前：向上分页可能把视口移动到新插入的历史页，短暂重叠旧内容与当前内容，快速到顶可能漏掉分页；最新持久化页没有可见 replay 事件时，已附加会话可能显示为空。

修改后：在 macOS 真机浏览器验证中，连续分页时视口保持在相同可见内容，录屏中出现的重叠闪动不再出现。自动化测试覆盖锚点保持、虚拟行测量、快速到顶检测、旧请求隔离、锚点等待边界、turn 收起规则和持久化空页恢复。

### 测试平台

|     系统     | 状态 |
| :----------: | :--: |
|  🍏 macOS    | ✅ 已测试 |
| 🪟 Windows   | ⚠️ 未测试 |
|  🐧 Linux    | ⚠️ 未测试 |

### 环境（可选）

macOS 本地 Web Shell 与 daemon 会话，以及包级 Vitest 和 TypeScript 检查。

## 风险与范围

- 主要风险或取舍：滚动锚定现在会协调虚拟测量与异步分页；generation 防护、30 帧锚点预算和 20 个空转录页预算会限制过期工作。
- 未验证或不在范围内：Windows 和 Linux 的浏览器级自动化；服务端分页语义和页大小保持不变。
- 破坏性修改或迁移说明：无。

## 关联 Issue

无

</details>
