### PR TITLE
fix(web-shell): improve subagent panel responsiveness

### DIFF
--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -201,6 +201,9 @@ const {
       Promise.resolve({ workspaceCwd: '/tmp/project' }),
     ),
     listWorkspaceSessions: vi.fn(() => Promise.resolve([])),
+    resolveSubagentSession: vi
+      .fn()
+      .mockRejectedValue(new Error('Subagent details unavailable')),
   };
   const settingsSetValue = vi.fn().mockResolvedValue(undefined);
   const mockCollectSystemInfo = vi.fn();
@@ -4290,6 +4293,10 @@ beforeEach(() => {
   });
   mockWorkspace.client.listWorkspaceSessions.mockReset();
   mockWorkspace.client.listWorkspaceSessions.mockResolvedValue([]);
+  mockWorkspace.client.resolveSubagentSession.mockReset();
+  mockWorkspace.client.resolveSubagentSession.mockRejectedValue(
+    new Error('Subagent details unavailable'),
+  );
   testState.prompt = 'hello';
   testState.inputAnnotations = undefined;
   testState.promptImages = undefined;
@@ -4444,6 +4451,7 @@ afterEach(() => {
   }
   vi.useRealTimers();
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe('App plan todos', () => {
@@ -7617,7 +7625,7 @@ describe('App session callbacks', () => {
     globalThis.ResizeObserver = originalResizeObserver;
   });
 
-  it('opens an out-of-band fork task in the right panel', () => {
+  it('loads an out-of-band fork after the right panel opens', async () => {
     testState.backgroundTasks = [
       {
         kind: 'agent',
@@ -7653,6 +7661,10 @@ describe('App session callbacks', () => {
     act(() => forkButton?.click());
 
     expect(
+      container.querySelector('[class*="artifactPanelDockNoOpenAnimation"]'),
+    ).toBeNull();
+    expect(mockWorkspace.client.resolveSubagentSession).not.toHaveBeenCalled();
+    expect(
       container.querySelector(
         '[data-testid="environment-panel"]:not([hidden])',
       ),
@@ -7660,6 +7672,97 @@ describe('App session callbacks', () => {
     expect(
       container.querySelector('button[title="Agent: Review current changes"]'),
     ).not.toBeNull();
+
+    const dock = container.querySelector<HTMLElement>(
+      '[class*="artifactPanelDock"]',
+    );
+    const panel = dock?.querySelector('aside');
+    await act(async () => {
+      panel?.dispatchEvent(new Event('animationend', { bubbles: true }));
+      await Promise.resolve();
+    });
+    expect(mockWorkspace.client.resolveSubagentSession).not.toHaveBeenCalled();
+
+    await act(async () => {
+      dock?.dispatchEvent(new Event('animationend', { bubbles: true }));
+      await Promise.resolve();
+    });
+    expect(
+      mockWorkspace.client.resolveSubagentSession,
+    ).toHaveBeenCalledExactlyOnceWith('session-1', 'fork-agent-1');
+  });
+
+  it('loads an out-of-band fork after the floating drawer opens with reduced motion', async () => {
+    vi.stubGlobal('CSS', { escape: (value: string) => value });
+    const setTimeoutSpy = vi.spyOn(window, 'setTimeout');
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query.includes('prefers-reduced-motion'),
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    });
+    testState.backgroundTasks = [
+      {
+        kind: 'agent',
+        id: 'fork-agent-1',
+        label: 'Review current changes',
+        description: 'Review current changes',
+        status: 'running',
+        startTime: 1,
+        runtimeMs: 10,
+        isBackgrounded: true,
+      },
+    ];
+    const { container } = renderApp();
+
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>(
+          'button[aria-label="Toggle environment information"]',
+        )
+        ?.click();
+    });
+    const subagentsButton = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('button[aria-expanded]'),
+    ).find((button) => button.textContent?.includes('Subagents'));
+    act(() => subagentsButton?.click());
+    const forkButton = Array.from(
+      container.querySelectorAll<HTMLButtonElement>(
+        '[data-testid="environment-panel"] ul button',
+      ),
+    ).find((button) => button.textContent?.includes('Review current changes'));
+
+    act(() => forkButton?.click());
+
+    expect(mockWorkspace.client.resolveSubagentSession).not.toHaveBeenCalled();
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 700);
+    const drawer = document.querySelector<HTMLElement>(
+      '[data-slot="drawer-content"]',
+    );
+    expect(drawer).not.toBeNull();
+    const dispatchAnimationEnd = (target: Element, animationName: string) => {
+      const event = new Event('animationend', { bubbles: true });
+      Object.defineProperty(event, 'animationName', { value: animationName });
+      target.dispatchEvent(event);
+    };
+
+    await act(async () => {
+      const panel = drawer?.querySelector('aside');
+      if (panel) dispatchAnimationEnd(panel, 'child-animation');
+      await Promise.resolve();
+    });
+    expect(mockWorkspace.client.resolveSubagentSession).not.toHaveBeenCalled();
+
+    await act(async () => {
+      if (drawer) dispatchAnimationEnd(drawer, 'slideFromRight');
+      await Promise.resolve();
+    });
+    expect(
+      mockWorkspace.client.resolveSubagentSession,
+    ).toHaveBeenCalledExactlyOnceWith('session-1', 'fork-agent-1');
   });
 
   it('updates the header when session metadata supplies a generated title', () => {

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -133,6 +133,7 @@ import {
   getScheduledTasksByTurn,
 } from './components/artifacts/turnOutputSelectors';
 import { useIsLargeScreen } from './hooks/useIsLargeScreen';
+import { usePrefersReducedMotion } from './hooks/usePrefersReducedMotion';
 import {
   clearSplitSessions,
   loadSplitSessions,
@@ -367,6 +368,7 @@ const TOAST_AUTO_DISMISS_MS = 5000;
 const DEFAULT_REVIEW_PANEL_WIDTH = 500;
 const MIN_ARTIFACT_PANEL_WIDTH = 320;
 const MIN_CHAT_PANE_WIDTH_WITH_ARTIFACT_PANEL = 500;
+const SUBAGENT_PANEL_ANIMATION_FALLBACK_MS = 700;
 const MIN_DOCKED_MESSAGE_AREA_WIDTH = 800;
 const DOCKED_ENVIRONMENT_PANEL_WIDTH = 332;
 // The docked fullscreen surface contains Tab itself instead of going through
@@ -1685,6 +1687,7 @@ export function App({
   // to be useful.
   const isLargeScreen = useIsLargeScreen();
   const canDockArtifactPanel = useIsLargeScreen('(min-width: 1001px)');
+  const prefersReducedMotion = usePrefersReducedMotion();
   // In split view the session sidebar competes with the panes for width. Below
   // this width it auto-collapses to its icon rail so the panes get the room, and
   // expands again once the window grows back. A wide split keeps the full
@@ -2492,6 +2495,8 @@ export function App({
     suppressArtifactDockOpenAnimation,
     setSuppressArtifactDockOpenAnimation,
   ] = useState(false);
+  const [waitForSubagentPanelAnimation, setWaitForSubagentPanelAnimation] =
+    useState(false);
   // In-tree portal target for the docked panel (display:contents keeps the
   // portaled wrapper a direct flex item of .appShell). Held in state so the
   // portal container exists before the wrapper renders.
@@ -3038,6 +3043,9 @@ export function App({
   );
   const openSubagentPanelForSession = useCallback(
     (tool: ACPToolCall, sessionId: string, workspaceCwd?: string) => {
+      if (!artifactPanelOpenRef.current) {
+        setWaitForSubagentPanelAnimation(true);
+      }
       const rawOutput =
         tool.rawOutput && typeof tool.rawOutput === 'object'
           ? (tool.rawOutput as Record<string, unknown>)
@@ -3782,6 +3790,25 @@ export function App({
   const mainViewRef = useRef(mainView);
   const useFloatingArtifactPanel =
     !canDockArtifactPanel || mainView === 'split';
+  const deferSubagentMount =
+    waitForSubagentPanelAnimation &&
+    artifactPanelOpen &&
+    !artifactPanelFullscreen &&
+    (useFloatingArtifactPanel ||
+      (!prefersReducedMotion && !suppressArtifactDockOpenAnimation));
+  useLayoutEffect(() => {
+    if (waitForSubagentPanelAnimation && !deferSubagentMount) {
+      setWaitForSubagentPanelAnimation(false);
+    }
+  }, [deferSubagentMount, waitForSubagentPanelAnimation]);
+  useEffect(() => {
+    if (!deferSubagentMount) return;
+    const timeout = window.setTimeout(
+      () => setWaitForSubagentPanelAnimation(false),
+      SUBAGENT_PANEL_ANIMATION_FALLBACK_MS,
+    );
+    return () => window.clearTimeout(timeout);
+  }, [deferSubagentMount]);
   const toggleArtifactPanelFullscreen = useCallback(() => {
     setArtifactPanelFullscreen((value) => !value);
     // Only the docked node replays its open animation on the fullscreen ->
@@ -9377,6 +9404,7 @@ export function App({
     onError: reportError,
     sessionWorkflowEnabled,
     onImageIngestionNotice: pushToast,
+    deferSubagentMount,
     onClose: closeArtifactPanel,
     fullscreen: artifactPanelFullscreen,
     onToggleFullscreen: toggleArtifactPanelFullscreen,
@@ -11119,6 +11147,11 @@ export function App({
                 }}
               >
                 <DrawerContent
+                  onAnimationEnd={(event) => {
+                    if (event.target === event.currentTarget) {
+                      setWaitForSubagentPanelAnimation(false);
+                    }
+                  }}
                   className={
                     artifactPanelFullscreen
                       ? 'data-[vaul-drawer-direction=right]:w-full data-[vaul-drawer-direction=right]:sm:max-w-none data-[vaul-drawer-direction=right]:rounded-none data-[vaul-drawer-direction=right]:border-0 data-[vaul-drawer-direction=right]:pt-[env(safe-area-inset-top)] data-[vaul-drawer-direction=right]:pr-[env(safe-area-inset-right)] data-[vaul-drawer-direction=right]:pb-[env(safe-area-inset-bottom)] data-[vaul-drawer-direction=right]:pl-[env(safe-area-inset-left)]'
@@ -11170,6 +11203,11 @@ export function App({
                   ref={artifactPanelFullscreenSurfaceRef}
                   tabIndex={-1}
                   onKeyDown={handleArtifactPanelSurfaceKeyDown}
+                  onAnimationEnd={(event) => {
+                    if (event.target === event.currentTarget) {
+                      setWaitForSubagentPanelAnimation(false);
+                    }
+                  }}
                   {...(artifactPanelFullscreen
                     ? { role: 'dialog' as const, 'aria-label': 'Right panel' }
                     : {})}

--- a/packages/web-shell/client/build-artifact.test.ts
+++ b/packages/web-shell/client/build-artifact.test.ts
@@ -198,6 +198,30 @@ describe('build artifact — package boundary', () => {
     expect(conflictingLayers).toEqual([]);
   });
 
+  it('removes the transcript width cap from fullscreen panels', () => {
+    let fullscreenRule: Rule | undefined;
+    postcss.parse(readInjectedCss()).walkRules((rule) => {
+      if (
+        rule.selector.includes('panelFullscreen') &&
+        rule.nodes.some(
+          (node) =>
+            node.type === 'decl' &&
+            node.prop === '--chat-content-width' &&
+            node.value === '100%',
+        )
+      ) {
+        fullscreenRule = rule;
+      }
+    });
+
+    expect(fullscreenRule).toBeDefined();
+    expect(fullscreenRule?.selector).toMatch(
+      /\._panelFullscreen_[A-Za-z0-9_]+$/,
+    );
+    expect(fullscreenRule?.selector).not.toContain('panelDrawer');
+    expect(fullscreenRule?.selector).not.toContain(':not(');
+  });
+
   it('prefixes global CSS registrations and animations', () => {
     const unscoped: string[] = [];
     postcss.parse(readInjectedCss()).walkAtRules((atRule) => {

--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -114,12 +114,15 @@ type MessageListHandle = import('./MessageList').MessageListHandle;
 // jsdom provides neither ResizeObserver (MessageList's resize guard) nor a real
 // scrollIntoView (the non-virtual scroll path) — stub both.
 const resizeObserverCallbacks: ResizeObserverCallback[] = [];
+let resizeObserversFireOnObserve = true;
 class ResizeObserverStub {
   constructor(private readonly callback: ResizeObserverCallback) {
     resizeObserverCallbacks.push(callback);
   }
   observe() {
-    this.callback([], this as unknown as ResizeObserver);
+    if (resizeObserversFireOnObserve) {
+      this.callback([], this as unknown as ResizeObserver);
+    }
   }
   unobserve() {}
   disconnect() {}
@@ -147,7 +150,9 @@ afterEach(() => {
     container.remove();
   }
   resizeObserverCallbacks.length = 0;
+  resizeObserversFireOnObserve = true;
   vi.useRealTimers();
+  vi.restoreAllMocks();
 });
 
 type UserMessage = Extract<Message, { role: 'user' }>;
@@ -2630,6 +2635,99 @@ describe('MessageList — turn collapse (DOM)', () => {
     expect(scrollTo).not.toHaveBeenCalled();
   });
 
+  it('finishes cooldown following unless the user scrolls up', () => {
+    resizeObserversFireOnObserve = false;
+    let scrollHeight = 1200;
+    let scrollTop = 0;
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollTop', {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = Math.max(0, Math.min(value, scrollHeight - 600));
+      },
+    });
+    const frames = new Map<number, FrameRequestCallback>();
+    let nextFrameId = 0;
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      nextFrameId += 1;
+      frames.set(nextFrameId, callback);
+      return nextFrameId;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((frameId) => {
+      frames.delete(frameId);
+    });
+    const messages = [userMsg('u1'), thinkingMsg('t1')];
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const ref = createRef<MessageListHandle>();
+    mounted.push({ root, container, transcriptRenderMode: 'interactive' });
+
+    renderInto(root, messages, ref, {
+      catchingUp: true,
+      isResponding: true,
+    });
+    renderInto(root, messages, ref, {
+      catchingUp: false,
+      isResponding: true,
+    });
+    expect(scrollTop).toBe(600);
+
+    scrollHeight = 1800;
+    renderInto(
+      root,
+      [userMsg('u1'), { ...thinkingMsg('t1'), content: 'thinking more' }],
+      ref,
+      {
+        catchingUp: false,
+        isResponding: true,
+      },
+    );
+    expect(scrollTop).toBe(600);
+
+    act(() => {
+      const pendingFrames = [...frames.values()];
+      frames.clear();
+      pendingFrames.forEach((callback) => callback(0));
+    });
+    expect(scrollTop).toBe(1200);
+
+    frames.clear();
+    act(() => ref.current?.scrollToBottom('auto'));
+    scrollHeight = 2400;
+    renderInto(
+      root,
+      [userMsg('u1'), { ...thinkingMsg('t1'), content: 'thinking even more' }],
+      ref,
+      {
+        catchingUp: false,
+        isResponding: true,
+      },
+    );
+    const list = container.querySelector('[data-web-shell-message-list]');
+    act(() => {
+      list?.dispatchEvent(
+        new WheelEvent('wheel', { bubbles: true, deltaY: -10 }),
+      );
+      scrollTop = 900;
+      list?.dispatchEvent(new Event('scroll', { bubbles: true }));
+    });
+    act(() => {
+      const pendingFrames = [...frames.values()];
+      frames.clear();
+      pendingFrames.forEach((callback) => callback(0));
+    });
+    expect(scrollTop).toBe(900);
+  });
+
   it('does not treat a user_shell row as a new chat prompt', () => {
     const scrollTo = vi.fn();
     Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
@@ -2777,6 +2875,7 @@ describe('MessageList — turn collapse (DOM)', () => {
     await nextFrame();
     await nextFrame();
 
+    expect(scrollTop).toBe(600);
     expect(onCanScrollToBottomChange).toHaveBeenLastCalledWith(false);
   });
 

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -2733,6 +2733,7 @@ export const MessageList = memo(
     const olderHistoryLoadInFlight = useRef(false);
     const scrollCooldown = useRef(false);
     const scrollCooldownCount = useRef(0);
+    const pendingBottomFollowAfterCooldown = useRef(false);
     const sessionTimelineFrame = useRef<number | null>(null);
     const lastReportedCanScrollToBottom = useRef<boolean | null>(null);
     const didTrackLastUserMsgRef = useRef(false);
@@ -3272,6 +3273,7 @@ export const MessageList = memo(
         const el = getScrollElement();
         if (!el) return;
         if (el.scrollHeight <= el.clientHeight) return;
+        pendingBottomFollowAfterCooldown.current = false;
         scrollCooldownCount.current += 1;
         const gen = scrollCooldownCount.current;
         scrollCooldown.current = true;
@@ -3284,9 +3286,21 @@ export const MessageList = memo(
         lastScrollTop.current = Math.max(0, el.scrollHeight - el.clientHeight);
         reportCanScrollToBottom();
         const releaseCooldown = () => {
-          if (scrollCooldownCount.current === gen) {
-            scrollCooldown.current = false;
-          }
+          if (scrollCooldownCount.current !== gen) return;
+          scrollCooldown.current = false;
+          if (!pendingBottomFollowAfterCooldown.current) return;
+          pendingBottomFollowAfterCooldown.current = false;
+          if (catchingUpRef.current || followPausedByUserRef.current) return;
+          const current = getScrollElement();
+          if (!current || current.scrollHeight <= current.clientHeight) return;
+          setShouldFollow(true);
+          current.scrollTop = current.scrollHeight;
+          scheduleScrollOverflowReport();
+          lastScrollTop.current = Math.max(
+            0,
+            current.scrollHeight - current.clientHeight,
+          );
+          reportCanScrollToBottom();
         };
         if (behavior === 'smooth') {
           setTimeout(releaseCooldown, 350);
@@ -3294,7 +3308,12 @@ export const MessageList = memo(
           requestAnimationFrame(releaseCooldown);
         }
       },
-      [getScrollElement, reportCanScrollToBottom, scheduleScrollOverflowReport],
+      [
+        getScrollElement,
+        reportCanScrollToBottom,
+        scheduleScrollOverflowReport,
+        setShouldFollow,
+      ],
     );
 
     const resumeBottomFollow = useCallback(
@@ -3620,7 +3639,19 @@ export const MessageList = memo(
         void loadOlderHistory(true);
       }
       if (scrollCooldown.current) {
+        const userScrolledUp =
+          curr < lastScrollTop.current - 1 &&
+          Date.now() <= userScrollIntentUntil.current &&
+          el.scrollHeight - curr - el.clientHeight >=
+            FOLLOW_BOTTOM_THRESHOLD_PX;
         lastScrollTop.current = curr;
+        if (userScrolledUp) {
+          cancelTranscriptReload();
+          followPausedByUserRef.current = true;
+          pendingBottomFollowAfterCooldown.current = false;
+          setShouldFollow(false);
+          scheduleSessionTimelineRangeUpdate();
+        }
         return;
       }
       scheduleSessionTimelineRangeUpdate();
@@ -3785,6 +3816,9 @@ export const MessageList = memo(
       const observer = new ResizeObserver(() => {
         scheduleScrollOverflowReport();
         loadOlderHistoryIfUnderfilled();
+        if (catchingUpRef.current || followPausedByUserRef.current) return;
+        setShouldFollow(true);
+        scrollToBottom();
       });
       observer.observe(el);
       for (const child of Array.from(el.children)) {
@@ -3811,6 +3845,8 @@ export const MessageList = memo(
       getScrollElement,
       loadOlderHistoryIfUnderfilled,
       scheduleScrollOverflowReport,
+      scrollToBottom,
+      setShouldFollow,
     ]);
 
     // Clear screen (e.g. /clear) → reset to follow mode, drop stale per-turn
@@ -3819,6 +3855,7 @@ export const MessageList = memo(
     useEffect(() => {
       if (messages.length === 0) {
         followPausedByUserRef.current = false;
+        pendingBottomFollowAfterCooldown.current = false;
         setShouldFollow(true);
         pendingScrollRef.current = null;
         setCollapseOverrides((prev) => (prev.size ? new Map() : prev));
@@ -4212,7 +4249,12 @@ export const MessageList = memo(
     useLayoutEffect(() => {
       if (catchingUp) return;
       const isNewUserMessage = pendingNewUserSmoothScroll.current;
-      if (scrollCooldown.current && !isNewUserMessage) return;
+      if (scrollCooldown.current && !isNewUserMessage) {
+        if (!followPausedByUserRef.current) {
+          pendingBottomFollowAfterCooldown.current = true;
+        }
+        return;
+      }
       // Preserve the new-prompt scroll even if a previous disclosure resize is
       // still settling; it targets the latest virtualizer size from this render.
       if (pendingFollowRecheck.current && !isNewUserMessage) return;

--- a/packages/web-shell/client/components/artifacts/ArtifactPanel.module.css
+++ b/packages/web-shell/client/components/artifacts/ArtifactPanel.module.css
@@ -16,6 +16,10 @@
   width: 100%;
 }
 
+.panelFullscreen {
+  --chat-content-width: 100%;
+}
+
 .header {
   flex: 0 0 auto;
   display: flex;
@@ -183,6 +187,10 @@
 }
 
 .addButton {
+  border-color: transparent;
+}
+
+.fullscreenButton {
   border-color: transparent;
 }
 

--- a/packages/web-shell/client/components/artifacts/ArtifactPanel.tsx
+++ b/packages/web-shell/client/components/artifacts/ArtifactPanel.tsx
@@ -252,6 +252,7 @@ interface ArtifactPanelProps {
   onError?: (error: unknown, fallback: string) => void;
   sessionWorkflowEnabled?: boolean;
   onImageIngestionNotice?: (tone: 'warning' | 'error', message: string) => void;
+  deferSubagentMount?: boolean;
   onClose: () => void;
   variant?: 'docked' | 'drawer';
   fullscreen?: boolean;
@@ -287,6 +288,7 @@ export function ArtifactPanel({
   onError,
   sessionWorkflowEnabled,
   onImageIngestionNotice,
+  deferSubagentMount = false,
   onClose,
   variant = 'docked',
   fullscreen = false,
@@ -466,7 +468,7 @@ export function ArtifactPanel({
           {onToggleFullscreen && (
             <button
               type="button"
-              className={`${styles.iconButton} ${fullscreen ? styles.iconButtonActive : ''}`}
+              className={`${styles.iconButton} ${styles.fullscreenButton} ${fullscreen ? styles.iconButtonActive : ''}`}
               onClick={onToggleFullscreen}
               aria-label={t(
                 fullscreen ? 'common.exitFullscreen' : 'common.fullscreen',
@@ -678,15 +680,17 @@ export function ArtifactPanel({
             error={error}
           />
         ) : activeTab.kind === 'subagent' ? (
-          <SubagentDetail
-            sessionId={activeTab.sessionId}
-            rootToolCallId={activeTab.rootToolCallId}
-            initialRootTool={activeTab.rootTool}
-            workspaceCwd={activeTab.workspaceCwd ?? workspaceCwd}
-            onRightPanelOpen={onNestedRightPanelOpen}
-            onArtifactsChange={onNestedArtifactsChange}
-            onError={onError}
-          />
+          deferSubagentMount ? null : (
+            <SubagentDetail
+              sessionId={activeTab.sessionId}
+              rootToolCallId={activeTab.rootToolCallId}
+              initialRootTool={activeTab.rootTool}
+              workspaceCwd={activeTab.workspaceCwd ?? workspaceCwd}
+              onRightPanelOpen={onNestedRightPanelOpen}
+              onArtifactsChange={onNestedArtifactsChange}
+              onError={onError}
+            />
+          )
         ) : activeTab.kind === 'monitor' ? (
           <MonitorTaskDetail
             key={activeTab.id}

--- a/packages/web-shell/client/components/artifacts/SubagentDetail.integration.test.tsx
+++ b/packages/web-shell/client/components/artifacts/SubagentDetail.integration.test.tsx
@@ -7,17 +7,22 @@ import type { ACPToolCall, Message } from '../../adapters/types';
 import { I18nProvider } from '../../i18n';
 
 const {
+  animationFrameBlocks,
   connection,
+  messagesFromBlocks,
   workspaceActions,
   workspaceClient,
   latestMessageListProps,
   messages,
 } = vi.hoisted(() => ({
+  animationFrameBlocks: [{ id: 'frame-block' }],
   connection: {
     sessionId: 'subagent-session',
     workspaceCwd: '/work/project',
     loadingTranscript: false,
+    catchingUp: true,
   },
+  messagesFromBlocks: vi.fn(),
   workspaceActions: {
     readFile: vi.fn(),
   },
@@ -54,7 +59,14 @@ vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
 }));
 
 vi.mock('../../hooks/useMessages', () => ({
-  useMessages: () => messages,
+  useMessagesFromBlocks: (translator: unknown, blocks: readonly unknown[]) => {
+    messagesFromBlocks(translator, blocks);
+    return messages;
+  },
+}));
+
+vi.mock('../../hooks/useAnimationFrameTranscriptBlocks', () => ({
+  useAnimationFrameTranscriptBlocks: () => animationFrameBlocks,
 }));
 
 vi.mock('../../hooks/useSessionArtifacts', () => ({
@@ -81,13 +93,14 @@ afterEach(() => {
   container = null;
   root = null;
   latestMessageListProps.current = undefined;
+  messagesFromBlocks.mockClear();
   workspaceClient.resolveSubagentSession.mockReset();
 });
 
 it('opens subagent and fork transcript outputs in source-scoped panel tabs', async () => {
   workspaceClient.resolveSubagentSession.mockResolvedValue({
     sessionId: 'subagent-session',
-    status: 'completed',
+    status: 'running',
   });
   const onRightPanelOpen = vi.fn();
   container = document.createElement('div');
@@ -101,8 +114,11 @@ it('opens subagent and fork transcript outputs in source-scoped panel tabs', asy
           sessionId="parent-session"
           rootToolCallId="agent-1"
           initialRootTool={
-            (messages[0] as Extract<Message, { role: 'tool_group' }>)
-              .tools[0] as ACPToolCall
+            {
+              ...(messages[0] as Extract<Message, { role: 'tool_group' }>)
+                .tools[0],
+              startTime: 40_000,
+            } as ACPToolCall
           }
           workspaceCwd="/work/project"
           onRightPanelOpen={onRightPanelOpen}
@@ -113,9 +129,15 @@ it('opens subagent and fork transcript outputs in source-scoped panel tabs', asy
   });
 
   expect(latestMessageListProps.current).toMatchObject({
+    activeTurnStartedAt: 40_000,
+    catchingUp: true,
     turnFileChanges: expect.any(Map),
     turnArtifacts: expect.any(Map),
   });
+  expect(messagesFromBlocks).toHaveBeenCalledWith(
+    expect.any(Function),
+    animationFrameBlocks,
+  );
 
   const openOutput = latestMessageListProps.current?.[
     'onTurnOutputOpen'

--- a/packages/web-shell/client/components/artifacts/SubagentDetail.module.css
+++ b/packages/web-shell/client/components/artifacts/SubagentDetail.module.css
@@ -1,6 +1,8 @@
 .detail {
   display: flex;
   flex-direction: column;
+  height: 100%;
+  min-height: 0;
   min-width: 0;
 }
 

--- a/packages/web-shell/client/components/artifacts/SubagentDetail.tsx
+++ b/packages/web-shell/client/components/artifacts/SubagentDetail.tsx
@@ -6,7 +6,8 @@ import {
 } from '@qwen-code/webui/daemon-react-sdk';
 import type { DaemonSessionArtifact } from '@qwen-code/sdk/daemon';
 import type { ACPToolCall, Message } from '../../adapters/types';
-import { useMessages } from '../../hooks/useMessages';
+import { useAnimationFrameTranscriptBlocks } from '../../hooks/useAnimationFrameTranscriptBlocks';
+import { useMessagesFromBlocks } from '../../hooks/useMessages';
 import { useSessionArtifacts } from '../../hooks/useSessionArtifacts';
 import { useI18n } from '../../i18n';
 import { MessageList } from '../MessageList';
@@ -142,7 +143,8 @@ function SubagentDetailContent({
 }) {
   const { t } = useI18n();
   const connection = useConnection();
-  const messages = useMessages(t);
+  const blocks = useAnimationFrameTranscriptBlocks();
+  const messages = useMessagesFromBlocks(t, blocks);
   const { artifacts } = useSessionArtifacts();
   const artifactsByTurn = useMemo(
     () =>
@@ -241,7 +243,9 @@ function SubagentDetailContent({
           messages={messages}
           pendingApproval={null}
           loadingTranscript={connection.loadingTranscript}
+          catchingUp={connection.catchingUp}
           isResponding={isRunning}
+          activeTurnStartedAt={isRunning ? rootTool.startTime : undefined}
           workspaceCwd={connection.workspaceCwd || ''}
           hideSessionTimeline
           hideFirstUserMessage
@@ -280,7 +284,8 @@ export function SubagentDetail({
   const { t } = useI18n();
   const workspace = useWorkspace();
   const parentConnection = useConnection();
-  const parentMessages = useMessages(t);
+  const parentBlocks = useAnimationFrameTranscriptBlocks();
+  const parentMessages = useMessagesFromBlocks(t, parentBlocks);
   const rootTool =
     (parentConnection.sessionId === sessionId
       ? findSubagentRootTool(parentMessages, rootToolCallId)

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -3764,6 +3764,24 @@ describe('DaemonSessionProvider', () => {
   });
 
   it('injects replay snapshot on initial session load', async () => {
+    const sdk = await import('@qwen-code/sdk/daemon');
+    const realCreateStore = sdk.createDaemonTranscriptStore;
+    const replayDispatchBatchSizes: number[] = [];
+    const createStoreSpy = vi
+      .spyOn(sdk, 'createDaemonTranscriptStore')
+      .mockImplementation((seed) => {
+        const store = realCreateStore(seed);
+        if (seed?.maxBlocks === Number.MAX_SAFE_INTEGER) {
+          const realDispatch = store.dispatch.bind(store);
+          store.dispatch = (event) => {
+            replayDispatchBatchSizes.push(
+              Array.isArray(event) ? event.length : 1,
+            );
+            return realDispatch(event);
+          };
+        }
+        return store;
+      });
     const session = createMockSession({
       replaySnapshot: {
         compactedReplay: [
@@ -3808,6 +3826,8 @@ describe('DaemonSessionProvider', () => {
     expect(blocks).toMatchObject([
       { kind: 'assistant', text: 'initial replay', streaming: false },
     ]);
+    expect(replayDispatchBatchSizes).toEqual([2]);
+    createStoreSpy.mockRestore();
   });
 
   it.each([

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -1571,11 +1571,17 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                     },
               );
               let nextCheckpoint: DaemonTranscriptState | undefined;
-              for (const [index, group] of eventGroups.entries()) {
-                if (index === markerIndex) {
-                  nextCheckpoint = replayStore.getSnapshot();
+              if (markerIndex < 0 && repairingEpisode === undefined) {
+                // Ordinary replay needs no intermediate checkpoint. Dispatch
+                // once so rebuilding a long transcript stays O(B), not O(E×B).
+                replayStore.dispatch(allUiEvents);
+              } else {
+                for (const [index, group] of eventGroups.entries()) {
+                  if (index === markerIndex) {
+                    nextCheckpoint = replayStore.getSnapshot();
+                  }
+                  replayStore.dispatch(group.transcript);
                 }
-                replayStore.dispatch(group.transcript);
               }
               const replayState = replayStore.getSnapshot();
               replayExceededCapacity =


### PR DESCRIPTION
## What this PR does

Improves the Web Shell background-task panel by waiting for its opening animation before loading subagent details, preserving the root task's real elapsed time, batching replay updates, and keeping streaming output pinned to the bottom unless the user has intentionally scrolled up. The right panel now expands fully in fullscreen mode, and its fullscreen toolbar button stays visually plain until hover or selection.

## Why it's needed

Opening a background task could stutter because transcript work competed with the panel animation. Once open, the elapsed timer restarted from zero, live output did not reliably remain visible, fullscreen still constrained the subagent content width, and the fullscreen control looked active even in its default state.

## Reviewer Test Plan

### How to verify

Open a session containing a running background task and click it from the transcript. Confirm the panel animation remains smooth and the detail content begins loading only after the animation completes. Confirm the running duration reflects the original task start time, live output follows the bottom as content streams, and manually scrolling upward pauses that follow behavior. Toggle the right panel to fullscreen and confirm the subagent transcript uses the full available width. Confirm the fullscreen icon has no default border/background, gains the standard accent background on hover, and remains accented while fullscreen is selected.

### Evidence (Before & After)

Before: opening the subagent detail could stutter, its timer restarted, streaming output could remain below the viewport, fullscreen retained a chat-width cap, and the fullscreen button showed a default outlined surface.

After: verified in a local Chromium session that detail loading starts after the drawer animation, the transcript reaches zero distance from the bottom during streaming, deliberate wheel scrolling remains fixed, elapsed time remains anchored to the root task, fullscreen removes the transcript width cap, and the toolbar states match adjacent icon buttons.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Local Web Shell development server and Chromium, plus focused Vitest suites and production package build.

## Risk & Scope

- Main risk or tradeoff: subagent detail rendering is intentionally delayed until the opening transition completes, with a bounded fallback when no animation event is delivered.
- Not validated / out of scope: Windows and Linux browser behavior; unrelated inline subagent tool output.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 此 PR 的改动

改进 Web Shell 后台任务面板：等待打开动画结束后再加载 subagent 详情，保留根任务真实开始时间，对历史回放更新进行批处理，并在用户没有主动向上滚动时让流式输出持续跟随底部。右侧面板全屏后会使用完整宽度，全屏工具栏按钮默认保持无背景、无边框，仅在 hover 或选中时显示状态。

## 为什么需要

打开后台任务时，文字记录处理会与面板动画竞争资源，从而产生卡顿。打开后，耗时会从零重新开始，实时输出不能稳定保持在可视区域，全屏状态仍会限制 subagent 内容宽度，并且全屏按钮在默认状态下看起来像已经被选中。

## Reviewer 测试计划

### 如何验证

打开一个包含运行中后台任务的会话，并从消息记录中点击该任务。确认面板动画流畅，详情内容只在动画结束后开始加载；运行时间反映任务最初的开始时间；内容持续输出时视图跟随底部，而手动向上滚动后不会被强制拉回。将右侧面板切换为全屏，确认 subagent 消息记录使用全部可用宽度。确认全屏图标默认没有边框和背景，hover 时出现与其他按钮一致的强调背景，并在全屏选中状态下保持强调背景。

### 前后对比证据

改动前：打开 subagent 详情可能卡顿，计时重新开始，流式输出可能停留在视口下方，全屏仍保留消息宽度限制，并且全屏按钮默认显示带轮廓的底框。

改动后：已在本地 Chromium 会话中验证，详情加载发生在抽屉动画结束之后；流式输出时消息记录与底部距离为零；主动滚轮上移后位置保持不变；计时以根任务为起点；全屏会移除消息宽度限制；工具栏状态与相邻图标按钮一致。

### 测试平台

|     系统     | 状态 |
| :----------: | :--: |
|  🍏 macOS    |  ✅  |
| 🪟 Windows   | N/A  |
|  🐧 Linux    | N/A  |

### 环境（可选）

本地 Web Shell 开发服务器与 Chromium，以及针对性的 Vitest 测试和生产包构建。

## 风险与范围

- 主要风险或权衡：subagent 详情渲染会有意等待打开动画结束；如果未收到动画事件，会通过有上限的兜底计时继续加载。
- 未验证或不在范围内：Windows 与 Linux 浏览器行为；无关的内嵌 subagent 工具输出。
- 破坏性改动或迁移说明：无。

## 关联 Issue

N/A

</details>
