### PR TITLE
fix(ci): restore Live Host release mirroring

### DIFF
--- a/.github/workflows/live-host-release.yml
+++ b/.github/workflows/live-host-release.yml
@@ -38,6 +38,7 @@ on:
         type: 'boolean'
 
 permissions:
+  actions: 'read'
   contents: 'read'
 
 concurrency:
@@ -357,3 +358,6 @@ jobs:
     with:
       version: '${{ needs.prepare.outputs.version }}'
       source: 'artifact'
+    secrets:
+      ALIYUN_OSS_ACCESS_KEY_ID: '${{ secrets.ALIYUN_OSS_ACCESS_KEY_ID }}'
+      ALIYUN_OSS_ACCESS_KEY_SECRET: '${{ secrets.ALIYUN_OSS_ACCESS_KEY_SECRET }}'

--- a/.github/workflows/sync-live-host-to-oss.yml
+++ b/.github/workflows/sync-live-host-to-oss.yml
@@ -9,6 +9,11 @@ on:
       source:
         required: true
         type: 'string'
+    secrets:
+      ALIYUN_OSS_ACCESS_KEY_ID:
+        required: true
+      ALIYUN_OSS_ACCESS_KEY_SECRET:
+        required: true
   workflow_dispatch:
     inputs:
       version:

--- a/scripts/tests/live-host-oss-workflow.test.js
+++ b/scripts/tests/live-host-oss-workflow.test.js
@@ -18,6 +18,12 @@ const syncWorkflow = readFileSync(
 );
 
 describe('Live Host OSS mirror workflow', () => {
+  it('grants the reusable mirror workflow its required token permissions', () => {
+    expect(releaseWorkflow).toContain(
+      "permissions:\n  actions: 'read'\n  contents: 'read'",
+    );
+  });
+
   it('runs only after a stable Live Host release or a manual re-run', () => {
     expect(syncWorkflow).not.toContain('pull_request:');
     expect(syncWorkflow).not.toContain('dry_run');
@@ -28,6 +34,19 @@ describe('Live Host OSS mirror workflow', () => {
     );
     expect(syncOss).toContain("- 'publish'");
     expect(syncOss).toContain("source: 'artifact'");
+    expect(syncOss).not.toContain('secrets: inherit');
+    expect(syncOss).toContain(
+      "ALIYUN_OSS_ACCESS_KEY_ID: '${{ secrets.ALIYUN_OSS_ACCESS_KEY_ID }}'",
+    );
+    expect(syncOss).toContain(
+      "ALIYUN_OSS_ACCESS_KEY_SECRET: '${{ secrets.ALIYUN_OSS_ACCESS_KEY_SECRET }}'",
+    );
+    expect(syncWorkflow).toContain(
+      'ALIYUN_OSS_ACCESS_KEY_ID:\n        required: true',
+    );
+    expect(syncWorkflow).toContain(
+      'ALIYUN_OSS_ACCESS_KEY_SECRET:\n        required: true',
+    );
   });
 
   it('uploads and verifies one release without an OSS state machine', () => {


### PR DESCRIPTION
## What this PR does

Restores the independent Qwen Live Host release workflow's ability to call its stable Aliyun OSS mirror. The caller now grants the read permission required by the reusable workflow and passes only the two OSS credentials that the mirror consumes.

## Why it's needed

The first release run after the OSS mirror integration failed before creating any jobs because a reusable workflow cannot elevate token permissions beyond its caller. Even after that permission issue, the mirror would not receive repository-level OSS credentials unless they were explicitly passed. Together these defects prevented the published Live Host feed from reaching OSS.

## Reviewer Test Plan

### How to verify

Trigger the Qwen Live Host release workflow with version 0.1.1, dry run enabled, and draft enabled. The prepare and macOS build jobs should pass, both architecture packages and the manifest should be uploaded as one artifact, and publishing plus OSS mirroring should remain skipped. Confirm that the reusable mirror receives only the two OSS credentials and does not inherit unrelated repository secrets. The production mirror can be checked by comparing the OSS latest manifest with the GitHub stable feed and verifying both versioned ZIPs return successfully.

### Evidence (Before & After)

Before: [run 31453757026](https://github.com/QwenLM/qwen-code/actions/runs/31453757026) ended in `startup_failure` with zero jobs. After: [run 31465970784](https://github.com/QwenLM/qwen-code/actions/runs/31465970784) completed the final-commit dry run, including Live Host tests, arm64/x64 packaging, manifest verification, and artifact upload. [Run 31465210321](https://github.com/QwenLM/qwen-code/actions/runs/31465210321) completed a production mirror of the existing stable v0.1.0 release, including credential setup, upload, public download, checksum verification, stable-feed comparison, and latest-manifest verification.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

GitHub-hosted macOS runner for Live Host build/package validation and GitHub-hosted Ubuntu runner with the `production-release` environment for the OSS mirror.

## Risk & Scope

- Main risk or tradeoff: The top-level workflow gains read-only access to Actions artifacts; the reusable mirror receives only the two existing OSS credentials.
- Not validated / out of scope: A new signed and notarized version was not published from the feature branch because production releases are intentionally restricted to `main`. The unchanged signing/notarization path previously published stable v0.1.0 successfully and all currently configured credential names were audited.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 此 PR 的作用

恢复独立 Qwen Live Host 发布工作流调用稳定版阿里云 OSS 镜像的能力。调用方现在授予可复用工作流所需的读取权限，并且只传递镜像实际使用的两项 OSS 凭据。

## 为什么需要

OSS 镜像集成后的首次发布运行在创建任何 job 之前失败，因为可复用工作流不能把 token 权限提升到调用方之上。即使修复该权限，若调用方不显式传递仓库级 OSS 凭据，镜像仍无法获得它们。这两个问题共同阻止已发布的 Live Host feed 到达 OSS。

## Reviewer Test Plan

### 如何验证

使用版本 0.1.1、启用 dry run 和 draft 触发 Qwen Live Host 发布工作流。prepare 和 macOS build 应通过，两种架构包和 manifest 应作为一个 artifact 上传，发布及 OSS 镜像应保持跳过。确认可复用镜像只接收两项 OSS 凭据，并未继承无关的仓库 secret。生产镜像可通过比较 OSS latest manifest 与 GitHub stable feed，并验证两个版本化 ZIP 均可成功访问来检查。

### 证据（Before & After）

Before：[run 31453757026](https://github.com/QwenLM/qwen-code/actions/runs/31453757026) 以 `startup_failure` 结束且没有任何 job。After：[run 31465970784](https://github.com/QwenLM/qwen-code/actions/runs/31465970784) 在最终 commit 上完成 dry run，包括 Live Host 测试、arm64/x64 打包、manifest 校验和 artifact 上传。[Run 31465210321](https://github.com/QwenLM/qwen-code/actions/runs/31465210321) 完成既有稳定版 v0.1.0 的生产 OSS 镜像，包括凭据配置、上传、公网下载、checksum 校验、stable feed 对比和 latest manifest 校验。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  |  ✅  |

### 环境（可选）

Live Host 构建/打包验证使用 GitHub 托管 macOS runner；OSS 镜像使用 GitHub 托管 Ubuntu runner 和 `production-release` 环境。

## 风险与范围

- 主要风险或权衡：顶层工作流获得 Actions artifact 的只读权限；可复用镜像只接收现有的两项 OSS 凭据。
- 未验证 / 不在范围内：未从功能分支发布新的签名、公证版本，因为生产发布按设计仅允许从 `main` 执行。未改动的签名/公证路径此前已成功发布稳定版 v0.1.0，并已审计当前配置的所有凭据名称。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

N/A

</details>
