### PR TITLE
fix(web-shell): show line-change stats for large edited files

### DIFF
--- a/packages/web-shell/client/components/artifacts/turnOutputSelectors.test.ts
+++ b/packages/web-shell/client/components/artifacts/turnOutputSelectors.test.ts
@@ -221,7 +221,7 @@ describe('turnOutputSelectors', () => {
     ]);
   });
 
-  it('omits stats for large full-content diffs', () => {
+  it('shows stats for large full-content diffs', () => {
     const oldContent = Array.from({ length: 1001 }, (_, index) => `${index}`)
       .join('\n')
       .concat('\n');
@@ -245,11 +245,50 @@ describe('turnOutputSelectors', () => {
     ];
 
     const change = getFileChangesByTurn(messages, new Map()).get('u1')?.[0];
-    expect(change?.additions).toBeUndefined();
-    expect(change?.deletions).toBeUndefined();
+    expect(change).toMatchObject({
+      additions: 1001,
+      deletions: 1001,
+    });
     expect(change?.diffs).toEqual([
       { oldText: oldContent, newText: newContent, fullContent: true },
     ]);
+  });
+
+  it('shows accurate stats for a large file with a small edit', () => {
+    const oldContent = Array.from(
+      { length: 2000 },
+      (_, index) => `line ${index}`,
+    )
+      .join('\n')
+      .concat('\n');
+    const newContent = [
+      ...oldContent.split('\n').slice(0, 1000),
+      'inserted line',
+      ...oldContent.split('\n').slice(1000, -1),
+    ]
+      .join('\n')
+      .concat('\n');
+    const messages = [
+      userMessage('u1', 'edit large file'),
+      toolGroup('tg1', [
+        {
+          callId: 'edit-1',
+          toolName: 'edit',
+          status: 'completed',
+          args: { file_path: 'src/app.ts' },
+          rawOutput: {
+            originalContent: oldContent,
+            newContent,
+          },
+        },
+      ]),
+    ];
+
+    const change = getFileChangesByTurn(messages, new Map()).get('u1')?.[0];
+    expect(change).toMatchObject({
+      additions: 1,
+      deletions: 0,
+    });
   });
 
   it('omits stats for unrelated partial diffs', () => {

--- a/packages/web-shell/client/components/artifacts/turnOutputSelectors.ts
+++ b/packages/web-shell/client/components/artifacts/turnOutputSelectors.ts
@@ -6,8 +6,6 @@ import type {
 } from './TurnOutputs';
 import { isSamePath, normalizePath } from './artifactUtils';
 
-const MAX_LINE_STAT_COMPARISONS = 1_000_000;
-
 function getToolCallIds(tool: ACPToolCall): string[] {
   const ids = new Set<string>();
   if (tool.callId) ids.add(tool.callId);
@@ -461,13 +459,25 @@ function getFinalFullContentDiff(diffs: TurnOutputFileChange['diffs']) {
   return finalDiff?.fullContent ? finalDiff : undefined;
 }
 
+// Counts changed lines as a multiset difference rather than an exact LCS
+// alignment: O(n+m) is fast enough for any file size (a 1000-line LCS is
+// already ~1M comparisons), and for display stats it only miscounts when
+// identical lines move to a different position.
 function countChangedLines(oldText: string, newText: string) {
   const oldLines = splitDiffLines(oldText);
   const newLines = splitDiffLines(newText);
-  if (oldLines.length * newLines.length > MAX_LINE_STAT_COMPARISONS) {
-    return undefined;
+  const oldLineCounts = new Map<string, number>();
+  for (const line of oldLines) {
+    oldLineCounts.set(line, (oldLineCounts.get(line) ?? 0) + 1);
   }
-  const commonLines = countLongestCommonSubsequence(oldLines, newLines);
+  let commonLines = 0;
+  for (const line of newLines) {
+    const count = oldLineCounts.get(line) ?? 0;
+    if (count > 0) {
+      commonLines++;
+      oldLineCounts.set(line, count - 1);
+    }
+  }
   return {
     additions: newLines.length - commonLines,
     deletions: oldLines.length - commonLines,
@@ -477,24 +487,6 @@ function countChangedLines(oldText: string, newText: string) {
 function splitDiffLines(text: string) {
   if (!text) return [];
   return text.replace(/\r?\n$/, '').split(/\r\n|\r|\n/);
-}
-
-function countLongestCommonSubsequence(left: string[], right: string[]) {
-  const previous = new Array(right.length + 1).fill(0);
-  const current = new Array(right.length + 1).fill(0);
-  for (const leftLine of left) {
-    for (let index = 0; index < right.length; index++) {
-      current[index + 1] =
-        leftLine === right[index]
-          ? previous[index] + 1
-          : Math.max(previous[index + 1], current[index]);
-    }
-    for (let index = 0; index < current.length; index++) {
-      previous[index] = current[index];
-    }
-    current.fill(0);
-  }
-  return previous[right.length] ?? 0;
 }
 
 function isSameWorkspacePath(


### PR DESCRIPTION
## What this PR does

The "Edited N files" list in the Web Shell turn outputs computes each file's +N/-M change counts from a full-content diff. The computation used an exact longest-common-subsequence (LCS) comparison with a 1,000,000-comparison cap; any full-content diff over roughly 1,000 lines hit the cap and silently produced no stats, so large edited files appeared in the list without any change counts while small files showed them. This PR replaces the exact LCS with a linear-time multiset comparison (count lines present in both sides), so stats are computed for files of any size and the cap is removed.

## Why it's needed

Edited files are most often the large source files, yet those were exactly the ones whose +N/-M counts never showed up. With the O(n+m) multiset comparison the counts appear for every edited file; the only accuracy tradeoff is that identical lines moved between positions count as unchanged, which is acceptable for display stats.

## Reviewer Test Plan

### How to verify

1. In a Web Shell session, edit a file larger than ~1000 lines (e.g. add a small change to `ToolGroup.tsx`) together with a small file, then check the "Edited N files" list on the turn outputs card — both files now show +N/-M counts (previously the large file showed none).
2. Run the unit tests: `cd packages/web-shell && npx vitest run client/components/artifacts/turnOutputSelectors.test.ts` — includes a new case "shows accurate stats for a large file with a small edit" (2000-line file, one inserted line → +1/-0) and the updated "shows stats for large full-content diffs" (1001 lines, all changed → +1001/-1001).

### Evidence (Before & After)

Before: large edited files (e.g. `ToolGroup.tsx`, ~1700 lines) showed no +N/-M in the edited-files list, while a small file (e.g. `ToolChrome.module.css`) showed +7 -0.
After: the same large file shows its counts (a small edit reports approximately +23/-9 instead of nothing).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Local macOS workspace; unit tests only (`turnOutputSelectors.test.ts`, 21 tests pass; artifacts suite 147 tests pass; ESLint clean on changed files).

## Risk & Scope

- Main risk or tradeoff: the multiset approximation undercounts when identical lines move between positions (a moved code block reads as +0/-0); the exact LCS previously reported those as deletions+additions. Acceptable for display stats, documented in a code comment.
- Not validated / out of scope: incremental (non-full-content) diffs still omit stats — an existing design for repeated partial diffs, unchanged here.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 的改动

Web Shell turn outputs 的"已编辑 N 个文件"列表中，每个文件的 +N/-M 变更行数来自全文对比计算。原实现使用精确的最长公共子序列（LCS）比较，并设有 100 万次比较的上限：任何超过约 1000 行的全文 diff 都会触发上限而静默不产生统计数据，导致大文件在列表中不显示变更行数，而小文件正常显示。本 PR 将精确 LCS 替换为线性时间的多重集合比较（统计两侧共同出现的行数），任意大小的文件都能计算行数，并移除了上限。

## 为什么需要

被编辑的文件往往正是大型源码文件，而这些文件恰恰是 +N/-M 计数从来不显示的那批。改为 O(n+m) 多重集合比较后，每个编辑文件都会显示计数；唯一的精度取舍是"移动到其他位置的相同行"会计为未变更，这对展示用途可以接受。

## Reviewer 测试计划

### 验证方式

1. 在 Web Shell 会话中同时编辑一个大文件（约 1000 行以上，如给 `ToolGroup.tsx` 加一处小改动）和一个小文件，查看 turn outputs 卡片上的"已编辑 N 个文件"列表 —— 两个文件现在都会显示 +N/-M（之前大文件什么都不显示）。
2. 运行单元测试：`cd packages/web-shell && npx vitest run client/components/artifacts/turnOutputSelectors.test.ts` —— 包含新增用例 "shows accurate stats for a large file with a small edit"（2000 行文件插入 1 行 → +1/-0）以及更新后的 "shows stats for large full-content diffs"（1001 行全部变更 → +1001/-1001）。

### 前后对比证据

改动前：大文件（如 `ToolGroup.tsx`，约 1700 行）在已编辑文件列表中不显示 +N/-M，而小文件（如 `ToolChrome.module.css`）显示 +7 -0。
改动后：同一大文件会显示计数（小改动约显示 +23/-9 而非什么都不显示）。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  N/A |
|  🐧 Linux  |  N/A |

### 环境（可选）

本地 macOS 仓库；仅单元测试（`turnOutputSelectors.test.ts` 21 项通过；artifacts 套件 147 项通过；改动文件 ESLint 通过）。

## 风险与范围

- 主要风险或取舍：多重集合近似在"相同行移动到其他位置"时会低估（整块移动的代码会计为 +0/-0）；精确 LCS 此前会计为删除+新增。对展示用途可接受，已在代码注释中说明。
- 未验证/不在范围内：增量（非全文）diff 仍不显示统计 —— 这是重复增量 diff 的既有设计，本次未改动。
- 破坏性变更/迁移说明：无。

## 关联 Issue

N/A

</details>