### PR TITLE
feat(web-shell): preview uploaded images in the right panel

### DIFF
--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -860,6 +860,16 @@ const DEFAULT_ENVIRONMENT_PANEL_ITEMS: readonly WebShellEnvironmentPanelItem[] =
   ['environment', 'subagents', 'backgroundTasks'];
 const BOTTOM_PANEL_GAP_PX = 6;
 const BOTTOM_PANEL_FALLBACK_INSET_PX = 40;
+
+// One preview tab per image, keyed by its content, so opening several images
+// keeps a tab each while re-clicking the same image just focuses its tab.
+function imageTabId(src: string): string {
+  let hash = 0;
+  for (let i = 0; i < src.length; i++) {
+    hash = (hash * 31 + src.charCodeAt(i)) | 0;
+  }
+  return `image:${hash.toString(36)}`;
+}
 type ChatWidthMode = `${typeof DEFAULT_CHAT_MAX_WIDTH}` | 'wide';
 
 const CHAT_WIDTH_STORAGE_KEY = 'qwen-code-web-shell-chat-width';
@@ -3002,6 +3012,28 @@ export function App({
     },
     [getDefaultReviewPanelWidth],
   );
+  const openImagePanel = useCallback(
+    (src: string, alt?: string) => {
+      const tab: ArtifactPanelTab = {
+        id: imageTabId(src),
+        kind: 'image',
+        title: t('turnOutputs.imagePreview'),
+        src,
+        ...(alt ? { alt } : {}),
+      };
+      setArtifactPanelTabs((tabs) =>
+        tabs.some((item) => item.id === tab.id)
+          ? tabs.map((item) => (item.id === tab.id ? tab : item))
+          : [tab, ...tabs],
+      );
+      setActiveArtifactPanelTabId(tab.id);
+      setArtifactPanelWidth((width) =>
+        artifactPanelOpenRef.current ? width : getDefaultReviewPanelWidth(),
+      );
+      setArtifactPanelOpen(true);
+    },
+    [getDefaultReviewPanelWidth, t],
+  );
   const openShellPanel = useCallback(
     (
       task: DaemonSessionShellTaskStatus,
@@ -3143,6 +3175,10 @@ export function App({
         );
         return;
       }
+      if (request.kind === 'image') {
+        openImagePanel(request.src, request.alt);
+        return;
+      }
       if (request.kind === 'subagent') {
         openSubagentPanelForSession(
           request.tool,
@@ -3198,6 +3234,7 @@ export function App({
       onRightPanelOpen,
       openReviewPanel,
       openScheduledTaskPanel,
+      openImagePanel,
       openSubagentPanelForSession,
     ],
   );
@@ -10601,6 +10638,7 @@ export function App({
                                     : undefined
                                 }
                                 onTurnOutputOpen={handleTurnOutputOpen}
+                                onImagePreview={openImagePanel}
                                 onReviewChanges={openReviewPanel}
                                 onOpenArtifact={openArtifactPanel}
                                 onOpenScheduledTask={openScheduledTaskPanel}
@@ -10893,6 +10931,7 @@ export function App({
                             handleComposerAttachmentsChange
                           }
                           onImageIngestionNotice={pushToast}
+                          onImagePreview={openImagePanel}
                           onCycleMode={handleCycleMode}
                           onToggleShortcuts={handleToggleShortcuts}
                           onCancel={handleCancel}

--- a/packages/web-shell/client/components/ChatEditor.module.css
+++ b/packages/web-shell/client/components/ChatEditor.module.css
@@ -1811,28 +1811,41 @@
 
 .imageRemove {
   position: absolute;
-  top: 0;
-  right: 0;
+  top: 2px;
+  right: 2px;
   width: 16px;
   height: 16px;
-  font-size: 12px;
-  line-height: 16px;
-  text-align: center;
-  background: rgba(0, 0, 0, 0.7);
-  color: var(--error-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
   border: none;
   cursor: pointer;
-  border-radius: 0 0 0 4px;
+  border-radius: 50%;
+  padding: 0;
+  opacity: 0;
+  transition:
+    opacity 0.15s ease,
+    background 0.15s ease;
+}
+
+.imageRemove svg {
+  display: block;
+}
+
+.imageThumb:hover .imageRemove:not(:disabled),
+.imageRemove:focus-visible {
+  opacity: 1;
 }
 
 .imageRemove:not(:disabled):hover {
-  background: var(--error-color);
-  color: var(--chat-editor-text-primary);
+  background: rgba(0, 0, 0, 0.8);
 }
 
 .imageRemove:disabled {
   cursor: default;
-  opacity: 0.55;
+  opacity: 0;
 }
 
 .searchPanel {

--- a/packages/web-shell/client/components/ChatEditor.test.tsx
+++ b/packages/web-shell/client/components/ChatEditor.test.tsx
@@ -269,6 +269,7 @@ function renderChatEditor(props: {
   onSelectMode?: (mode: string) => void;
   onSelectModel?: (model: string) => void;
   onAttachmentsChange?: (hasAttachments: boolean) => void;
+  onImagePreview?: (src: string, alt?: string) => void;
   tokenCount?: number;
   contextWindow?: number;
   onShowContextUsage?: () => void;
@@ -668,6 +669,18 @@ describe('ChatEditor attachment reporting', () => {
       'disabled',
       true,
     );
+  });
+
+  it('opens the image preview when a pasted image is clicked', () => {
+    const onImagePreview = vi.fn();
+    const container = renderChatEditor({
+      pastedImages: [{ data: 'abc', media_type: 'image/png' }],
+      onImagePreview,
+    });
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    act(() => img!.click());
+    expect(onImagePreview).toHaveBeenCalledWith('data:image/png;base64,abc');
   });
 });
 

--- a/packages/web-shell/client/components/ChatEditor.tsx
+++ b/packages/web-shell/client/components/ChatEditor.tsx
@@ -211,6 +211,8 @@ interface ChatEditorProps {
   voiceTarget?: VoiceWorkspaceTarget;
   voiceStatusRevision?: VoiceStatusRevision;
   onImageIngestionNotice?: (tone: 'warning' | 'error', message: string) => void;
+  /** Click a pasted image in the composer to preview it in the right panel. */
+  onImagePreview?: (src: string, alt?: string) => void;
 }
 
 const CHAT_EDITOR_THEME = {
@@ -1257,6 +1259,7 @@ export const ChatEditor = memo(
       voiceTarget,
       voiceStatusRevision,
       onImageIngestionNotice,
+      onImagePreview,
     } = props;
 
     const {
@@ -2065,26 +2068,48 @@ export const ChatEditor = memo(
                 )}
                 {core.pastedImages.length > 0 && (
                   <div className={styles.images}>
-                    {core.pastedImages.map((img, i) => (
-                      <div key={i} className={styles.imageThumb}>
-                        <img
-                          src={`data:${img.media_type};base64,${img.data}`}
-                          alt=""
-                        />
-                        <button
-                          type="button"
-                          className={styles.imageRemove}
-                          disabled={disabled}
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            if (disabled) return;
-                            core.removeImage(i);
-                          }}
-                        >
-                          ×
-                        </button>
-                      </div>
-                    ))}
+                    {core.pastedImages.map((img, i) => {
+                      const src = `data:${img.media_type};base64,${img.data}`;
+                      return (
+                        <div key={i} className={styles.imageThumb}>
+                          <img
+                            src={src}
+                            alt=""
+                            onClick={
+                              onImagePreview
+                                ? () => onImagePreview(src)
+                                : undefined
+                            }
+                          />
+                          <button
+                            type="button"
+                            className={styles.imageRemove}
+                            disabled={disabled}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              if (disabled) return;
+                              core.removeImage(i);
+                            }}
+                            aria-label="Remove image"
+                          >
+                            <svg
+                              width="8"
+                              height="8"
+                              viewBox="0 0 10 10"
+                              fill="none"
+                              aria-hidden="true"
+                            >
+                              <path
+                                d="M2 2l6 6M8 2l-6 6"
+                                stroke="currentColor"
+                                strokeWidth="1.5"
+                                strokeLinecap="round"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                      );
+                    })}
                   </div>
                 )}
               </div>

--- a/packages/web-shell/client/components/ChatPane.tsx
+++ b/packages/web-shell/client/components/ChatPane.tsx
@@ -643,6 +643,21 @@ export function ChatPane({
     [connection.sessionId, onRightPanelOpen],
   );
 
+  const handleImagePreview = useCallback(
+    (src: string, alt?: string) => {
+      if (!connection.sessionId) return;
+      handleRightPanelOpen({
+        id: 'image',
+        kind: 'image',
+        title: t('turnOutputs.imagePreview'),
+        turnId: connection.sessionId,
+        src,
+        ...(alt ? { alt } : {}),
+      });
+    },
+    [connection.sessionId, handleRightPanelOpen, t],
+  );
+
   // Composer wiring, all scoped to THIS pane's own DaemonSession context. The
   // slash menu lists the session's daemon commands — they run server-side when
   // submitted (via sendPrompt), so e.g. `/clear` clears this pane's session, not
@@ -907,6 +922,7 @@ export function ChatPane({
                   : undefined
               }
               onTurnOutputOpen={handleRightPanelOpen}
+              onImagePreview={handleImagePreview}
               onError={reportError}
               generateContent={
                 connection.capabilities?.features.includes('session_generation')
@@ -1004,6 +1020,7 @@ export function ChatPane({
           onDismissFollowup={onDismissFollowup}
           onImageIngestionNotice={onImageIngestionNotice}
           sessionId={connection.sessionId}
+          onImagePreview={handleImagePreview}
           atWorkspaceCwd={paneWorkspaceCwd}
           placeholderText={t('splitView.composerPlaceholder')}
           animatePlaceholder={false}

--- a/packages/web-shell/client/components/MessageItem.tsx
+++ b/packages/web-shell/client/components/MessageItem.tsx
@@ -28,6 +28,8 @@ interface MessageItemProps {
   pendingApproval?: PermissionRequest | null;
   /** Run /context detail, exactly like typing it (context-usage panels). */
   onShowContextDetail?: () => void;
+  /** Click an uploaded image in a user message to preview it in the right panel. */
+  onImagePreview?: (src: string, alt?: string) => void;
   workspaceCwd?: string;
   isLatest?: boolean;
   showRetryHint?: boolean;
@@ -46,6 +48,7 @@ export const MessageItem = memo(function MessageItem({
   message,
   pendingApproval,
   onShowContextDetail,
+  onImagePreview,
   workspaceCwd,
   isLatest = false,
   showRetryHint = false,
@@ -71,6 +74,7 @@ export const MessageItem = memo(function MessageItem({
             isLocateFlashing={isLocateFlashing}
             sendFailed={sendFailed}
             onRetrySend={onRetrySend}
+            onImagePreview={onImagePreview}
           />
         );
       case 'assistant':
@@ -264,6 +268,7 @@ function areMessageItemPropsEqual(
 ): boolean {
   if (prev.pendingApproval?.id !== next.pendingApproval?.id) return false;
   if (prev.onShowContextDetail !== next.onShowContextDetail) return false;
+  if (prev.onImagePreview !== next.onImagePreview) return false;
   if (prev.workspaceCwd !== next.workspaceCwd) return false;
   if (prev.isLatest !== next.isLatest) return false;
   if (prev.showRetryHint !== next.showRetryHint) return false;

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -64,6 +64,8 @@ interface MessageListProps {
   pendingApproval: PermissionRequest | null;
   /** Run /context detail, exactly like typing it (context-usage panels). */
   onShowContextDetail?: () => void;
+  /** Click an uploaded image in a user message to preview it in the right panel. */
+  onImagePreview?: (src: string, alt?: string) => void;
   loadingTranscript?: boolean;
   catchingUp?: boolean;
   hasOlderHistory?: boolean;
@@ -2439,6 +2441,7 @@ export const MessageList = memo(
       messages,
       pendingApproval,
       onShowContextDetail,
+      onImagePreview,
       loadingTranscript,
       catchingUp,
       hasOlderHistory = false,
@@ -4425,6 +4428,7 @@ export const MessageList = memo(
               message={displayItem.message}
               pendingApproval={pendingApproval}
               onShowContextDetail={onShowContextDetail}
+              onImagePreview={onImagePreview}
               workspaceCwd={workspaceCwd}
               isLatest={isLatest}
               showRetryHint={showRetryHint}
@@ -4482,6 +4486,7 @@ export const MessageList = memo(
         transcriptRenderMode,
         handleAutomaticAgentExpansionChange,
         onShowContextDetail,
+        onImagePreview,
         generateContent,
         headerOffset,
         visibleItems,

--- a/packages/web-shell/client/components/artifacts/ArtifactPanel.test.tsx
+++ b/packages/web-shell/client/components/artifacts/ArtifactPanel.test.tsx
@@ -2110,3 +2110,59 @@ describe('ArtifactPanel fullscreen toggle', () => {
     ).toBeNull();
   });
 });
+
+describe('ArtifactPanel image preview tabs', () => {
+  it('renders one preview tab per image and shows the active image', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+
+    act(() =>
+      root.render(
+        <I18nProvider language="en">
+          <ArtifactPanel
+            artifacts={[]}
+            tabs={[
+              {
+                id: 'image:a',
+                kind: 'image',
+                title: 'Image Preview',
+                src: 'data:image/png;base64,aWFh',
+                alt: 'Uploaded image 1',
+              },
+              {
+                id: 'image:b',
+                kind: 'image',
+                title: 'Image Preview',
+                src: 'data:image/png;base64,iWJi',
+              },
+            ]}
+            activeTabId="image:a"
+            reviewChanges={[]}
+            selectedReviewPath={null}
+            onSelectTab={() => {}}
+            onCloseTab={() => {}}
+            onOpenFilePreview={() => {}}
+            onClose={() => {}}
+          />
+        </I18nProvider>,
+      ),
+    );
+
+    expect(container.querySelectorAll('[role="tab"]')).toHaveLength(2);
+    const preview = container.querySelector(
+      'img[class*="imagePreview"]',
+    ) as HTMLImageElement;
+    expect(preview).not.toBeNull();
+    expect(preview.getAttribute('src')).toBe('data:image/png;base64,aWFh');
+    expect(preview.getAttribute('alt')).toBe('Uploaded image 1');
+
+    const download = container.querySelector(
+      'a[class*="imageDownloadButton"]',
+    ) as HTMLAnchorElement;
+    expect(download).not.toBeNull();
+    expect(download.getAttribute('href')).toBe('data:image/png;base64,aWFh');
+    expect(download.getAttribute('download')).toBe('image.png');
+  });
+});

--- a/packages/web-shell/client/components/artifacts/ArtifactPanel.tsx
+++ b/packages/web-shell/client/components/artifacts/ArtifactPanel.tsx
@@ -15,6 +15,7 @@ import { DownloadIcon } from 'lucide-react';
 import {
   ChevronRightIcon,
   CirclePlusIcon,
+  ImageIcon,
   Maximize2Icon,
   MessageCirclePlusIcon,
   Minimize2Icon,
@@ -146,6 +147,13 @@ export type ArtifactPanelTab =
     }
   | {
       id: string;
+      kind: 'image';
+      title: string;
+      src: string;
+      alt?: string;
+    }
+  | {
+      id: string;
       kind: 'subagent';
       title: string;
       sessionId: string;
@@ -194,6 +202,12 @@ function isWorkspaceScopedTab(
     tab.kind === 'artifact' ||
     tab.kind === 'scheduled_task'
   );
+}
+
+function imageDownloadName(src: string): string {
+  const match = src.match(/^data:image\/([a-z0-9+.+-]+)/i);
+  const ext = (match?.[1] ?? 'png').split('+')[0].toLowerCase();
+  return `image.${ext}`;
 }
 
 export interface SideTaskListItem {
@@ -397,6 +411,11 @@ export function ArtifactPanel({
                       />
                     ) : tab.kind === 'side_task' ? (
                       <MessageCirclePlusIcon
+                        className={styles.tabIconSvg}
+                        strokeWidth={1.6}
+                      />
+                    ) : tab.kind === 'image' ? (
+                      <ImageIcon
                         className={styles.tabIconSvg}
                         strokeWidth={1.6}
                       />
@@ -724,6 +743,23 @@ export function ArtifactPanel({
             sessionWorkflowEnabled={sessionWorkflowEnabled}
             onImageIngestionNotice={onImageIngestionNotice}
           />
+        ) : activeTab.kind === 'image' ? (
+          <div className={styles.imagePreviewWrap}>
+            <img
+              src={activeTab.src}
+              alt={activeTab.alt ?? activeTab.title}
+              className={styles.imagePreview}
+            />
+            <a
+              className={styles.imageDownloadButton}
+              href={activeTab.src}
+              download={imageDownloadName(activeTab.src)}
+              aria-label={t('common.download')}
+              title={t('common.download')}
+            >
+              <DownloadIcon size={16} strokeWidth={1.8} />
+            </a>
+          </div>
         ) : (
           <ScheduledTaskDetail
             key={activeTab.id}

--- a/packages/web-shell/client/components/artifacts/TurnOutputs.tsx
+++ b/packages/web-shell/client/components/artifacts/TurnOutputs.tsx
@@ -78,6 +78,14 @@ export type TurnOutputOpenRequest = (
       workspaceId?: string;
     }
   | {
+      id: 'image';
+      kind: 'image';
+      title: string;
+      turnId: string;
+      src: string;
+      alt?: string;
+    }
+  | {
       id: string;
       kind: 'artifact';
       title: string;

--- a/packages/web-shell/client/components/messages/UserMessage.module.css
+++ b/packages/web-shell/client/components/messages/UserMessage.module.css
@@ -255,3 +255,12 @@
   object-fit: contain;
   border: 1px solid var(--border);
 }
+
+.chatImageThumbInteractive {
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+.chatImageThumbInteractive:hover {
+  opacity: 0.85;
+}

--- a/packages/web-shell/client/components/messages/UserMessage.test.tsx
+++ b/packages/web-shell/client/components/messages/UserMessage.test.tsx
@@ -339,6 +339,23 @@ describe('UserMessage', () => {
     expect(img!.getAttribute('src')).toBe('data:image/png;base64,abc');
   });
 
+  it('opens the image preview on click', () => {
+    const onImagePreview = vi.fn();
+    const container = render(
+      <UserMessage
+        content=""
+        images={[{ data: 'abc', mimeType: 'image/png' }]}
+        onImagePreview={onImagePreview}
+      />,
+    );
+    const img = container.querySelector('img')!;
+    act(() => img.click());
+    expect(onImagePreview).toHaveBeenCalledWith(
+      'data:image/png;base64,abc',
+      expect.any(String),
+    );
+  });
+
   it('renders BMP images through the shared safe-source policy', () => {
     const container = render(
       <UserMessage

--- a/packages/web-shell/client/components/messages/UserMessage.tsx
+++ b/packages/web-shell/client/components/messages/UserMessage.tsx
@@ -48,6 +48,8 @@ interface UserMessageProps {
   isLocateFlashing?: boolean;
   sendFailed?: boolean;
   onRetrySend?: () => void;
+  /** Click an uploaded image to preview it in the right panel. */
+  onImagePreview?: (src: string, alt?: string) => void;
 }
 
 function DefaultUserMessageContent({
@@ -100,6 +102,7 @@ export const UserMessage = memo(function UserMessage({
   isLocateFlashing = false,
   sendFailed = false,
   onRetrySend,
+  onImagePreview,
 }: UserMessageProps) {
   const { t } = useI18n();
   const {
@@ -208,7 +211,20 @@ export const UserMessage = memo(function UserMessage({
                       key={index}
                       src={src}
                       alt={t('user.uploadedImage', { index: index + 1 })}
-                      className={styles.chatImageThumb}
+                      className={`${styles.chatImageThumb}${
+                        onImagePreview
+                          ? ` ${styles.chatImageThumbInteractive}`
+                          : ''
+                      }`}
+                      onClick={
+                        onImagePreview
+                          ? () =>
+                              onImagePreview(
+                                src,
+                                t('user.uploadedImage', { index: index + 1 }),
+                              )
+                          : undefined
+                      }
                       onLoad={measureOverflow}
                     />
                   );

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -1136,6 +1136,7 @@ const EN: Messages = {
     "Checked in this task's own session before each run. The prompt only runs in a fresh session when the check says yes — otherwise the run is skipped.",
   'scheduledTasks.condition.cardPrefix': 'If:',
   'turnOutputs.filesEdited': (v) => `Edited ${v?.count ?? 0} files`,
+  'turnOutputs.imagePreview': 'Image Preview',
   'turnOutputs.viewChanges': 'View changes',
   // Key keeps its historical `review` name; the label moved to "Changes" when
   // the code-review result view (`codeReview.*`) took over the word.
@@ -3916,6 +3917,7 @@ const ZH: Messages = {
     '每次触发前，先在本任务自己的会话中检查该条件。只有判定为"是"，才会新建会话执行命令；否则跳过本次运行。',
   'scheduledTasks.condition.cardPrefix': '若：',
   'turnOutputs.filesEdited': (v) => `已编辑 ${v?.count ?? 0} 个文件`,
+  'turnOutputs.imagePreview': '图片预览',
   'turnOutputs.viewChanges': '查看更改',
   // 与英文键同理：键名保留历史 `review`，标签改为“文件更改”，
   // 代码审查结果视图使用 `codeReview.*`，请勿“修正”此不一致。


### PR DESCRIPTION
## What this PR does

Adds image preview to the Web Shell. Clicking an uploaded image in a user message, or a pasted image in the composer, opens it in the right-hand artifact panel as a dedicated image tab. Each distinct image opens its own tab (re-clicking the same image focuses the existing tab instead of duplicating it). The preview reuses the workspace image artifact layout, so hovering the preview reveals a download button in the top-right, and the downloaded file name is derived from the image MIME type. The composer's image remove button is restyled from an always-visible heavy red cross to a small round icon that fades in on hover.

## Why it's needed

Uploaded and pasted images could only be seen as small thumbnails; there was no way to view them full size or download them from the transcript. This makes image attachments inspectable and retrievable, and softens the composer's remove affordance.

## Reviewer Test Plan

### How to verify

1. Paste or attach an image in the composer, then click the thumbnail — the right panel opens an "Image Preview" tab showing the full image; hover the preview and a download button appears top-right, and clicking it downloads the image (file name like `image.png`).
2. Send a message with one or more images, then click an image in the message bubble — the same preview opens.
3. Click two different images — two tabs appear; re-click the first image and its tab is focused rather than duplicated.
4. In the composer, hover a pasted image — the small round remove button fades in; clicking it removes the image (sending with only images and no text still works).
5. Unit tests: `cd packages/web-shell && npx vitest run client/App.test.tsx client/components/ChatEditor.test.tsx client/components/messages/UserMessage.test.tsx client/components/artifacts/ArtifactPanel.test.tsx`.

### Evidence (Before & After)

Before: images appeared only as small thumbnails with no preview, no download, and a heavy always-visible remove cross.
After: clicking any image opens a full preview tab in the right panel with a hover download button; the remove button is a subtle hover-revealed round icon.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Local macOS workspace; unit tests only (App 356, ChatEditor 42, UserMessage, ArtifactPanel 44 — all pass; ESLint clean on changed files).

## Risk & Scope

- Main risk or tradeoff: the image tab id is a 32-bit content hash of the data URL; collision risk is negligible at realistic image counts. Preview is a read-only affordance and does not touch the submit/send path.
- Not validated / out of scope: keyboard-operable image preview (the thumbnails are mouse-click only) and touch-device discovery of the hover remove button.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 的改动

为 Web Shell 增加图片预览。点击用户消息中的上传图片，或输入框中粘贴的图片，会在右侧 artifact 面板以独立的 image tab 打开。每张不同的图片打开各自的 tab（重复点击同一张图片会聚焦已有 tab 而非重复打开）。预览复用工作区图片 artifact 的布局，因此鼠标悬停预览区会在右上角显示下载按钮，下载文件名按图片 MIME 类型生成。输入框的图片移除按钮从常驻的粗重红色叉号，改为悬停时淡入的小圆形图标。

## 为什么需要

上传和粘贴的图片此前只能以小缩略图查看，无法看全尺寸，也无法从 transcript 下载。本 PR 让图片附件可以查看和下载，同时弱化了输入框的移除按钮。

## Reviewer 测试计划

### 验证方式

1. 在输入框粘贴或附加一张图片，点击缩略图 —— 右侧面板打开"图片预览" tab 显示完整图片；悬停预览区右上角出现下载按钮，点击可下载（文件名如 `image.png`）。
2. 发送一条带图片的消息，点击消息气泡里的图片 —— 打开同样的预览。
3. 点击两张不同的图片 —— 出现两个 tab；再点第一张图片，聚焦其 tab 而非重复打开。
4. 在输入框悬停一张粘贴的图片 —— 小圆形移除按钮淡入；点击移除该图片（只有图片没有文字时仍可发送）。
5. 单元测试：`cd packages/web-shell && npx vitest run client/App.test.tsx client/components/ChatEditor.test.tsx client/components/messages/UserMessage.test.tsx client/components/artifacts/ArtifactPanel.test.tsx`。

### 前后对比证据

改动前：图片仅以小缩略图显示，无预览、无下载，移除按钮是常驻的粗重红叉。
改动后：点击任意图片在右侧面板打开全尺寸预览 tab，带悬停下载按钮；移除按钮是悬停淡入的小圆形图标。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  N/A |
|  🐧 Linux  |  N/A |

### 环境（可选）

本地 macOS 仓库；仅单元测试（App 356、ChatEditor 42、UserMessage、ArtifactPanel 44 —— 全部通过；改动文件 ESLint 通过）。

## 风险与范围

- 主要风险或取舍：image tab 的 id 是 data URL 的 32 位内容哈希，实际图片数量下碰撞风险可忽略。预览是只读功能，不影响提交/发送链路。
- 未验证/不在范围内：图片预览的键盘可操作（缩略图仅支持鼠标点击），以及触摸设备上悬停移除按钮的可发现性。
- 破坏性变更/迁移说明：无。

## 关联 Issue

N/A

</details>
