### PR TITLE
fix(web-shell): Enforce prompt-safe session navigation

### DIFF
--- a/docs/design/2026-08-11-prompt-safe-session-navigation.md
+++ b/docs/design/2026-08-11-prompt-safe-session-navigation.md
@@ -1,0 +1,39 @@
+# Prompt-safe session navigation
+
+## Contract
+
+Session navigation may load, resume, or detach session attachments, refresh
+heartbeats, and issue read-only requests. Navigation must not create execution
+side effects: it must not send `cancel`, admit a new prompt, continue a prior
+prompt, or inject a mid-turn message. An explicit user Stop remains allowed to
+send one cancellation while a transition is preparing.
+
+The WebShell therefore blocks prompt writes as soon as a desired target is
+pending or the daemon transition enters `queued` or `preparing`. A prompt that
+is awaiting an asynchronous host admission hook rechecks this gate before any
+composer commit, follow-up clear, session allocation, send, or enqueue. If the
+gate closes while the hook is pending, the draft and retry state remain owned
+by the source composer.
+
+## Queued prompts
+
+An accepted daemon queued prompt is never reposted automatically. When an
+admission outcome is uncertain, local cleanup may remove the pending row and
+restore its payload to the editor once; it must not infer safety from prompt
+text or use text hashes for deduplication.
+
+## Rapid switching
+
+The transactional provider keeps at most one raw restore in flight. An
+A-to-B-to-A-to-B sequence may adopt a successful result for the latest
+equivalent B target. If the older B restore fails or times out, the latest B
+intent may start one serial replacement restore. Superseded targets never
+commit and their attachments are detached best-effort.
+
+## Compatibility
+
+Modern daemons that advertise `client_identity` preserve the committed source
+until the target is staged and committed. Legacy daemons retain destructive
+switching for compatibility; they guarantee only that navigation does not
+actively cancel or replay prompts, not that the source remains visible during
+restore.

--- a/docs/design/2026-08-11-prompt-safe-session-navigation.md
+++ b/docs/design/2026-08-11-prompt-safe-session-navigation.md
@@ -10,10 +10,11 @@ send one cancellation while a transition is preparing.
 
 The WebShell therefore blocks prompt writes as soon as a desired target is
 pending or the daemon transition enters `queued` or `preparing`. A prompt that
-is awaiting an asynchronous host admission hook rechecks this gate before any
-composer commit, follow-up clear, session allocation, send, or enqueue. If the
-gate closes while the hook is pending, the draft and retry state remain owned
-by the source composer.
+is awaiting an asynchronous host admission hook records the write-gate
+generation and rechecks it before any composer commit, follow-up clear, session
+allocation, send, or enqueue. If the gate closes at any point while the hook is
+pending, the draft and retry state remain owned by the source composer even if
+navigation completes or fails before the hook returns.
 
 ## Queued prompts
 

--- a/integration-tests/cli/qwen-serve-webui-session-switching.test.ts
+++ b/integration-tests/cli/qwen-serve-webui-session-switching.test.ts
@@ -35,6 +35,7 @@ let DaemonSessionProvider: typeof import('@qwen-code/webui/daemon-react-sdk').Da
 let useActions: typeof import('@qwen-code/webui/daemon-react-sdk').useActions;
 let useConnection: typeof import('@qwen-code/webui/daemon-react-sdk').useConnection;
 let useTranscriptBlocks: typeof import('@qwen-code/webui/daemon-react-sdk').useTranscriptBlocks;
+let restoreSessionRequestRecorder: (() => void) | undefined;
 const originalGlobalDescriptors = new Map(
   ['window', 'document', 'navigator', 'IS_REACT_ACT_ENVIRONMENT'].map(
     (key) => [key, Object.getOwnPropertyDescriptor(globalThis, key)] as const,
@@ -75,6 +76,8 @@ afterAll(() => {
 });
 
 afterEach(async () => {
+  restoreSessionRequestRecorder?.();
+  restoreSessionRequestRecorder = undefined;
   if (root) {
     await act(async () => root?.unmount());
     root = undefined;
@@ -107,7 +110,7 @@ function installSessionRequestRecorder(
   const requests: RecordedSessionRequest[] = [];
   let recording = true;
   globalThis.fetch = async (input, init) => {
-    const request = input instanceof Request ? input : new Request(input, init);
+    const request = new Request(input, init);
     const url = new URL(request.url);
     const match = url.pathname.match(/^\/session\/([^/]+)\//);
     if (recording) {
@@ -120,12 +123,18 @@ function installSessionRequestRecorder(
     }
     return respond?.(request) ?? originalFetch(request);
   };
+  const stop = () => {
+    if (!recording) return;
+    recording = false;
+    globalThis.fetch = originalFetch;
+    if (restoreSessionRequestRecorder === stop) {
+      restoreSessionRequestRecorder = undefined;
+    }
+  };
+  restoreSessionRequestRecorder = stop;
   return {
     requests,
-    stop() {
-      recording = false;
-      globalThis.fetch = originalFetch;
-    },
+    stop,
   };
 }
 
@@ -333,19 +342,21 @@ describe('qwen serve WebUI transactional session switching', () => {
     state: Awaited<ReturnType<typeof setupActiveSource>>,
   ) {
     state.recorder.stop();
-    await act(async () => {
-      await activeDaemon?.client
-        .cancel(state.source.sessionId)
-        .catch(() => undefined);
-    });
-    if (root) {
-      await act(async () => root?.unmount());
-      root = undefined;
+    try {
+      await act(async () => {
+        await state.getActions().cancel();
+        await state.promptOutcome;
+      });
+    } finally {
+      if (root) {
+        await act(async () => root?.unmount());
+        root = undefined;
+      }
+      state.container.remove();
+      await activeDaemon?.dispose();
+      activeDaemon = undefined;
+      fs.rmSync(state.workspace, { recursive: true, force: true });
     }
-    state.container.remove();
-    await activeDaemon?.dispose();
-    activeDaemon = undefined;
-    fs.rmSync(state.workspace, { recursive: true, force: true });
   }
 
   function executionRequests(requests: readonly RecordedSessionRequest[]) {

--- a/integration-tests/cli/qwen-serve-webui-session-switching.test.ts
+++ b/integration-tests/cli/qwen-serve-webui-session-switching.test.ts
@@ -93,6 +93,42 @@ function deferred<T = void>() {
   return { promise, resolve, reject };
 }
 
+interface RecordedSessionRequest {
+  method: string;
+  pathname: string;
+  sessionId: string | undefined;
+  clientId: string | undefined;
+}
+
+function installSessionRequestRecorder(
+  respond?: (request: Request) => Response | undefined,
+) {
+  const originalFetch = globalThis.fetch;
+  const requests: RecordedSessionRequest[] = [];
+  let recording = true;
+  globalThis.fetch = async (input, init) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    const url = new URL(request.url);
+    const match = url.pathname.match(/^\/session\/([^/]+)\//);
+    if (recording) {
+      requests.push({
+        method: request.method,
+        pathname: url.pathname,
+        sessionId: match?.[1] ? decodeURIComponent(match[1]) : undefined,
+        clientId: request.headers.get('X-Qwen-Client-Id') ?? undefined,
+      });
+    }
+    return respond?.(request) ?? originalFetch(request);
+  };
+  return {
+    requests,
+    stop() {
+      recording = false;
+      globalThis.fetch = originalFetch;
+    },
+  };
+}
+
 async function waitFor(
   condition: () => boolean,
   description: string,
@@ -179,6 +215,231 @@ describe('qwen serve WebUI transactional session switching', () => {
       getBlocks: () => blocks,
     };
   }
+
+  async function setupActiveSource(options?: { targetLoadTimeout?: boolean }) {
+    const workspace = makeTempWorkspace('webui-session-switching-active');
+    activeDaemon = await spawnDaemon({
+      workspaceCwd: workspace,
+      env: {
+        QWEN_CLI_ENTRY: MOCK_AGENT_PATH,
+        MOCK_ACP_MODE: 'hang',
+      },
+    });
+    const source = await activeDaemon.client.createOrAttachSession({
+      sessionScope: 'thread',
+    });
+    const target = await activeDaemon.client.createOrAttachSession({
+      sessionScope: 'thread',
+    });
+    const resolvedWorkspace = source.workspaceCwd ?? workspace;
+    const recorder = installSessionRequestRecorder((request) => {
+      if (
+        options?.targetLoadTimeout === true &&
+        request.method === 'POST' &&
+        new URL(request.url).pathname.endsWith(
+          `/session/${encodeURIComponent(target.sessionId)}/load`,
+        )
+      ) {
+        return new Response(
+          JSON.stringify({
+            code: 'session_restore_timeout',
+            error: 'Session restore timed out',
+            retryable: true,
+          }),
+          {
+            status: 504,
+            headers: {
+              'Content-Type': 'application/json',
+              'Retry-After': '5',
+            },
+          },
+        );
+      }
+      return undefined;
+    });
+    let actions: ReturnType<typeof useActions> | undefined;
+    let connection: ReturnType<typeof useConnection> | undefined;
+    function Harness() {
+      actions = useActions();
+      connection = useConnection();
+      return null;
+    }
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(
+        createElement(
+          DaemonSessionProvider,
+          {
+            autoConnect: true,
+            baseUrl: activeDaemon!.base,
+            token: activeDaemon!.token,
+            sessionId: source.sessionId,
+            workspaceCwd: resolvedWorkspace,
+          },
+          createElement(Harness),
+        ),
+      );
+    });
+    await waitFor(
+      () =>
+        connection?.status === 'connected' &&
+        connection.sessionId === source.sessionId &&
+        connection.capabilities?.features.includes('client_identity') === true,
+      'active source bootstrap',
+    );
+    const admitted = deferred();
+    let promptSettled = false;
+    let promptOutcome!: Promise<unknown>;
+    act(() => {
+      promptOutcome = actions!
+        .sendPrompt('source remains active', {
+          onAdmitted: () => admitted.resolve(),
+        })
+        .then(
+          (result) => {
+            promptSettled = true;
+            return result;
+          },
+          (error: unknown) => {
+            promptSettled = true;
+            return error;
+          },
+        );
+    });
+    await admitted.promise;
+    expect(
+      (await activeDaemon.client.sessionStatus(source.sessionId))
+        .hasActivePrompt,
+    ).toBe(true);
+    return {
+      workspace: resolvedWorkspace,
+      source,
+      target,
+      recorder,
+      container,
+      promptOutcome,
+      isPromptSettled: () => promptSettled,
+      getActions: () => {
+        if (!actions) throw new Error('session actions unavailable');
+        return actions;
+      },
+      getConnection: () => connection,
+    };
+  }
+
+  async function cleanupActiveSource(
+    state: Awaited<ReturnType<typeof setupActiveSource>>,
+  ) {
+    state.recorder.stop();
+    await act(async () => {
+      await activeDaemon?.client
+        .cancel(state.source.sessionId)
+        .catch(() => undefined);
+    });
+    if (root) {
+      await act(async () => root?.unmount());
+      root = undefined;
+    }
+    state.container.remove();
+    await activeDaemon?.dispose();
+    activeDaemon = undefined;
+    fs.rmSync(state.workspace, { recursive: true, force: true });
+  }
+
+  function executionRequests(requests: readonly RecordedSessionRequest[]) {
+    return requests.filter(
+      (request) =>
+        request.method === 'POST' &&
+        /\/(?:prompt|cancel|continue|mid-turn-message)$/.test(request.pathname),
+    );
+  }
+
+  it('keeps an active source running across A to B to A navigation', async () => {
+    const state = await setupActiveSource();
+    try {
+      await act(async () => {
+        await state.getActions().loadSession(state.target.sessionId, {
+          workspaceCwd: state.workspace,
+        });
+      });
+      await expect(state.promptOutcome).resolves.toEqual({
+        stopReason: 'cancelled',
+      });
+      expect(state.getConnection()).toMatchObject({
+        status: 'connected',
+        sessionId: state.target.sessionId,
+      });
+      expect(
+        (await activeDaemon!.client.sessionStatus(state.source.sessionId))
+          .hasActivePrompt,
+      ).toBe(true);
+
+      await act(async () => {
+        await state.getActions().loadSession(state.source.sessionId, {
+          workspaceCwd: state.workspace,
+        });
+      });
+      expect(state.getConnection()).toMatchObject({
+        status: 'connected',
+        sessionId: state.source.sessionId,
+      });
+      expect(
+        (await activeDaemon!.client.sessionStatus(state.source.sessionId))
+          .hasActivePrompt,
+      ).toBe(true);
+      expect(executionRequests(state.recorder.requests)).toEqual([
+        expect.objectContaining({
+          pathname: `/session/${state.source.sessionId}/prompt`,
+          sessionId: state.source.sessionId,
+        }),
+      ]);
+    } finally {
+      await cleanupActiveSource(state);
+    }
+  }, 30_000);
+
+  it('keeps an active source and its waiter after a target 504', async () => {
+    const state = await setupActiveSource({ targetLoadTimeout: true });
+    try {
+      let restoreError: unknown;
+      await act(async () => {
+        try {
+          await state.getActions().loadSession(state.target.sessionId, {
+            workspaceCwd: state.workspace,
+          });
+        } catch (error) {
+          restoreError = error;
+        }
+      });
+      expect(restoreError).toMatchObject({
+        status: 504,
+        body: {
+          code: 'session_restore_timeout',
+          retryable: true,
+        },
+      });
+      expect(state.getConnection()).toMatchObject({
+        status: 'connected',
+        sessionId: state.source.sessionId,
+        sessionTransition: { phase: 'failed' },
+      });
+      expect(state.isPromptSettled()).toBe(false);
+      expect(
+        (await activeDaemon!.client.sessionStatus(state.source.sessionId))
+          .hasActivePrompt,
+      ).toBe(true);
+      expect(executionRequests(state.recorder.requests)).toEqual([
+        expect.objectContaining({
+          pathname: `/session/${state.source.sessionId}/prompt`,
+          sessionId: state.source.sessionId,
+        }),
+      ]);
+    } finally {
+      await cleanupActiveSource(state);
+    }
+  }, 30_000);
 
   it('keeps the source usable until a completed target response is released', async () => {
     const originalFetch = globalThis.fetch;

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -10263,7 +10263,7 @@ describe('App session callbacks', () => {
     expect(testState.latestChatEditorProps?.isPreparing).toBe(false);
   });
 
-  it('cancels an approved direct submission when a session transition starts', async () => {
+  it('cancels an approved direct submission after a session transition', async () => {
     let approve: (() => void) | undefined;
     const onSubmitBefore = vi.fn(
       () =>
@@ -10287,6 +10287,13 @@ describe('App session callbacks', () => {
     act(() => {
       rerender({
         desiredSessionTargetPending: true,
+        onSubmitBefore,
+        onSessionChange,
+      });
+    });
+    act(() => {
+      rerender({
+        desiredSessionTargetPending: false,
         onSubmitBefore,
         onSessionChange,
       });
@@ -11277,6 +11284,53 @@ describe('App session callbacks', () => {
     );
   });
 
+  it('restores a turn-error retry after navigation completes during admission', async () => {
+    let approveRetry: (() => void) | undefined;
+    let admissionCount = 0;
+    const onSubmitBefore = vi.fn(() => {
+      admissionCount += 1;
+      if (admissionCount === 1) return Promise.resolve();
+      return new Promise<void>((resolve) => {
+        approveRetry = resolve;
+      });
+    });
+    const { container, rerender } = renderApp({ onSubmitBefore });
+    await flush();
+
+    testState.prompt = 'first';
+    await clickSubmit(container);
+    act(() => {
+      testState.blocks = [
+        { kind: 'error', source: 'turn_error', id: 'turn-error-1' },
+      ];
+      rerender({ onSubmitBefore });
+    });
+    expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
+
+    mockSessionActions.sendPrompt.mockClear();
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+        ?.click();
+    });
+    expect(onSubmitBefore).toHaveBeenCalledTimes(2);
+    expect(mockSessionActions.sendPrompt).not.toHaveBeenCalled();
+
+    act(() => {
+      rerender({ desiredSessionTargetPending: true, onSubmitBefore });
+    });
+    act(() => {
+      rerender({ desiredSessionTargetPending: false, onSubmitBefore });
+    });
+    await act(async () => {
+      approveRetry?.();
+      await Promise.resolve();
+    });
+
+    expect(mockSessionActions.sendPrompt).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
+  });
+
   it('allows manual retry after a model stream interrupted turn error', async () => {
     const retrySend = deferred<void>();
     const { container, rerender } = renderApp();
@@ -11590,7 +11644,7 @@ describe('App session callbacks', () => {
     expect(editorClear).not.toHaveBeenCalled();
   });
 
-  it('cancels an approved queued submission when a session transition starts', async () => {
+  it('cancels an approved queued submission after a session transition', async () => {
     let approve: (() => void) | undefined;
     const onSubmitBefore = vi.fn(
       () =>
@@ -11615,6 +11669,13 @@ describe('App session callbacks', () => {
     act(() => {
       rerender({
         desiredSessionTargetPending: true,
+        onSubmitBefore,
+        onSessionChange,
+      });
+    });
+    act(() => {
+      rerender({
+        desiredSessionTargetPending: false,
         onSubmitBefore,
         onSessionChange,
       });
@@ -15565,6 +15626,63 @@ describe('App prompt send failure retry', () => {
 
     expect(
       document.querySelector('[data-testid="failed-prompt-retry"]')
+        ?.textContent,
+    ).toBe('u1');
+  });
+
+  it('restores a failed-prompt retry after navigation completes during admission', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    let approveRetry: (() => void) | undefined;
+    let admissionCount = 0;
+    const onSubmitBefore = vi.fn(() => {
+      admissionCount += 1;
+      if (admissionCount === 1) return Promise.resolve();
+      return new Promise<void>((resolve) => {
+        approveRetry = resolve;
+      });
+    });
+    const firstSend = deferred<void>();
+    mockSessionActions.sendPrompt.mockImplementationOnce(() => {
+      testState.blocks = [{ id: 'u1', kind: 'user' }];
+      return firstSend.promise;
+    });
+    const { container, rerender } = renderApp({ onSubmitBefore });
+    await flush();
+
+    act(() => {
+      testState.latestChatEditorProps?.onSubmit('hello');
+    });
+    testState.messages = [{ id: 'u1', role: 'user', content: 'hello' }];
+    await act(async () => {
+      firstSend.reject(new DaemonHttpError(413, {}, 'Prompt too large'));
+      await Promise.resolve();
+    });
+    expect(
+      container.querySelector('[data-testid="failed-prompt-retry"]'),
+    ).not.toBeNull();
+
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="failed-prompt-retry"]')
+        ?.click();
+    });
+    expect(onSubmitBefore).toHaveBeenCalledTimes(2);
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      rerender({ desiredSessionTargetPending: true, onSubmitBefore });
+    });
+    act(() => {
+      rerender({ desiredSessionTargetPending: false, onSubmitBefore });
+    });
+    await act(async () => {
+      approveRetry?.();
+      await Promise.resolve();
+    });
+
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(1);
+    expect(
+      container.querySelector('[data-testid="failed-prompt-retry"]')
         ?.textContent,
     ).toBe('u1');
   });

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -10263,6 +10263,48 @@ describe('App session callbacks', () => {
     expect(testState.latestChatEditorProps?.isPreparing).toBe(false);
   });
 
+  it('cancels an approved direct submission when a session transition starts', async () => {
+    let approve: (() => void) | undefined;
+    const onSubmitBefore = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          approve = resolve;
+        }),
+    );
+    const onSessionChange = vi.fn();
+    const { container, rerender } = renderApp({
+      onSubmitBefore,
+      onSessionChange,
+    });
+    await flush();
+
+    await clickSubmit(container);
+    expect(onSubmitBefore).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      prompt: 'hello',
+    });
+
+    act(() => {
+      rerender({
+        desiredSessionTargetPending: true,
+        onSubmitBefore,
+        onSessionChange,
+      });
+    });
+    await act(async () => {
+      approve?.();
+      await Promise.resolve();
+    });
+
+    expect(mockSessionActions.sendPrompt).not.toHaveBeenCalled();
+    expect(editorCommit).not.toHaveBeenCalled();
+    expect(editorClear).not.toHaveBeenCalled();
+    expect(onSessionChange).not.toHaveBeenCalled();
+    expect(mockFollowup.clear).not.toHaveBeenCalled();
+    expect(testState.prompt).toBe('hello');
+    expect(testState.latestChatEditorProps?.isPreparing).toBe(false);
+  });
+
   it('cancels an approved new-task submission after its target workspace changes', async () => {
     let approve: (() => void) | undefined;
     const onSubmitBefore = vi.fn(
@@ -11546,6 +11588,47 @@ describe('App session callbacks', () => {
     expect(rawEnqueuePrompt).not.toHaveBeenCalled();
     expect(editorCommit).not.toHaveBeenCalled();
     expect(editorClear).not.toHaveBeenCalled();
+  });
+
+  it('cancels an approved queued submission when a session transition starts', async () => {
+    let approve: (() => void) | undefined;
+    const onSubmitBefore = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          approve = resolve;
+        }),
+    );
+    const onSessionChange = vi.fn();
+    const { container, rerender } = renderApp({
+      onSubmitBefore,
+      onSessionChange,
+    });
+    await flush();
+
+    act(() => {
+      testState.streamingState = 'responding';
+      rerender({ onSubmitBefore, onSessionChange });
+    });
+    testState.prompt = 'queued';
+    await clickSubmit(container);
+
+    act(() => {
+      rerender({
+        desiredSessionTargetPending: true,
+        onSubmitBefore,
+        onSessionChange,
+      });
+    });
+    await act(async () => {
+      approve?.();
+      await Promise.resolve();
+    });
+
+    expect(rawEnqueuePrompt).not.toHaveBeenCalled();
+    expect(editorCommit).not.toHaveBeenCalled();
+    expect(editorClear).not.toHaveBeenCalled();
+    expect(onSessionChange).not.toHaveBeenCalled();
+    expect(testState.prompt).toBe('queued');
   });
 
   it('cancels queued submissions when onSubmitBefore rejects', async () => {

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -4979,6 +4979,7 @@ export function App({
           return;
         }
         if (
+          sessionWriteBlockedRef.current ||
           connectionRef.current.sessionId !== sourceSessionId ||
           getComposerWorkspaceCwd() !== sourceWorkspaceCwd ||
           composerSourceVersionRef.current !== sourceVersion
@@ -5425,6 +5426,7 @@ export function App({
           })
           .then(() => {
             if (
+              sessionWriteBlockedRef.current ||
               connectionRef.current.sessionId !== sourceSessionId ||
               getComposerWorkspaceCwd() !== sourceWorkspaceCwd ||
               composerSourceVersionRef.current !== sourceVersion

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -1891,6 +1891,10 @@ export function App({
     connection.sessionTransition?.phase === 'queued' ||
     connection.sessionTransition?.phase === 'preparing';
   const sessionWriteBlockedRef = useRef(sessionWriteBlocked);
+  const sessionWriteBlockGenerationRef = useRef(0);
+  if (sessionWriteBlocked && !sessionWriteBlockedRef.current) {
+    sessionWriteBlockGenerationRef.current += 1;
+  }
   sessionWriteBlockedRef.current = sessionWriteBlocked;
   const sessionOwnerGuard = useDaemonSessionOwnerGuard();
   const transcriptHistory = useTranscriptHistory();
@@ -4918,6 +4922,7 @@ export function App({
         commitComposerAccepted?: ComposerSubmitCommit;
         onAdmissionStarted?: (sessionId: string | undefined) => void;
         onAdmitted?: () => void;
+        onCancelledBeforeAdmission?: () => void;
         onOptimisticUserMessage?: (message: OptimisticUserMessage) => void;
         ownerRef?: { current: DaemonSessionOwnerSnapshot };
       },
@@ -4947,6 +4952,7 @@ export function App({
           previousLastSubmittedSourceVersion;
         retriedTurnErrorIdRef.current = previousRetriedTurnErrorId;
         setShowRetryHint(previousShowRetryHint);
+        opts?.onCancelledBeforeAdmission?.();
       };
       if (!opts?.retry && isUserPrompt) {
         lastSubmittedPromptRef.current = text;
@@ -4962,6 +4968,7 @@ export function App({
         const sourceSessionId = connectionRef.current.sessionId;
         const sourceWorkspaceCwd = getComposerWorkspaceCwd();
         const sourceVersion = composerSourceVersionRef.current;
+        const writeBlockGeneration = sessionWriteBlockGenerationRef.current;
         setIsPreparingPrompt(true);
         try {
           await onSubmitBeforeRef.current({
@@ -4980,6 +4987,7 @@ export function App({
         }
         if (
           sessionWriteBlockedRef.current ||
+          sessionWriteBlockGenerationRef.current !== writeBlockGeneration ||
           connectionRef.current.sessionId !== sourceSessionId ||
           getComposerWorkspaceCwd() !== sourceWorkspaceCwd ||
           composerSourceVersionRef.current !== sourceVersion
@@ -5325,6 +5333,15 @@ export function App({
             : current,
         );
       },
+      onCancelledBeforeAdmission: () => {
+        if (!retryOwnerIsCurrent()) return;
+        if (
+          getLatestUserBlockId(store.getSnapshot().blocks) === failed.messageId
+        ) {
+          updateFailedPrompt(failed);
+        }
+        setFailedPromptRetry(null);
+      },
     })
       .catch((error: unknown) => {
         if (!retryOwnerIsCurrent()) return;
@@ -5419,6 +5436,7 @@ export function App({
         const sourceSessionId = connectionRef.current.sessionId;
         const sourceWorkspaceCwd = getComposerWorkspaceCwd();
         const sourceVersion = composerSourceVersionRef.current;
+        const writeBlockGeneration = sessionWriteBlockGenerationRef.current;
         onSubmitBeforeRef
           .current({
             sessionId: sourceSessionId,
@@ -5427,6 +5445,7 @@ export function App({
           .then(() => {
             if (
               sessionWriteBlockedRef.current ||
+              sessionWriteBlockGenerationRef.current !== writeBlockGeneration ||
               connectionRef.current.sessionId !== sourceSessionId ||
               getComposerWorkspaceCwd() !== sourceWorkspaceCwd ||
               composerSourceVersionRef.current !== sourceVersion
@@ -9013,6 +9032,8 @@ export function App({
       const retryText = lastSubmittedPromptRef.current;
       const retryImages = lastSubmittedImagesRef.current;
       const retryInputAnnotations = lastSubmittedInputAnnotationsRef.current;
+      const previousRetriedTurnErrorId = retriedTurnErrorIdRef.current;
+      const previousShowRetryHint = showRetryHintRef.current;
       const retryOwnerIsCurrent = () =>
         composerSourceVersionRef.current === retrySourceVersion &&
         connectionRef.current.sessionId === retrySessionId &&
@@ -9044,6 +9065,12 @@ export function App({
               ? { ...current, admitted: true }
               : current,
           );
+        },
+        onCancelledBeforeAdmission: () => {
+          if (!retryOwnerIsCurrent()) return;
+          retriedTurnErrorIdRef.current = previousRetriedTurnErrorId;
+          setShowRetryHint(previousShowRetryHint);
+          setFailedPromptRetry(null);
         },
       })
         .catch((error: unknown) => {

--- a/packages/web-shell/client/components/WorkspaceSessionProvider.test.tsx
+++ b/packages/web-shell/client/components/WorkspaceSessionProvider.test.tsx
@@ -154,6 +154,34 @@ describe('WorkspaceSessionProvider transactional targets', () => {
     expect(onSessionIdChange).toHaveBeenCalledWith('session-b', 'b', '/work/b');
   });
 
+  it('keeps one modern provider and updates the write gate during rapid props', async () => {
+    const onSessionIdChange = await renderTarget('session-a', '/work/a');
+
+    await renderTarget('session-b', '/work/b', onSessionIdChange);
+    expect(mocks.appProps.at(-1)).toMatchObject({
+      desiredSessionTargetPending: true,
+    });
+
+    await renderTarget('session-a', '/work/a', onSessionIdChange);
+    expect(mocks.providerMounts).toBe(1);
+    expect(mocks.providerUnmounts).toBe(0);
+    expect(mocks.providerProps.at(-1)).toMatchObject({
+      sessionId: 'session-a',
+      workspaceCwd: '/work/a',
+    });
+    expect(mocks.appProps.at(-1)).toMatchObject({
+      desiredSessionTargetPending: false,
+      initialSelectedWorkspaceCwd: '/work/a',
+    });
+
+    await renderTarget('session-b', '/work/b', onSessionIdChange);
+    expect(mocks.providerMounts).toBe(1);
+    expect(mocks.providerUnmounts).toBe(0);
+    expect(mocks.appProps.at(-1)).toMatchObject({
+      desiredSessionTargetPending: true,
+    });
+  });
+
   it('does not feed stale host props back after an action-driven commit', async () => {
     const onSessionIdChange = await renderTarget('session-a', '/work/a');
 

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -10418,6 +10418,70 @@ describe('DaemonSessionProvider', () => {
     expect(detachFetch).toHaveBeenCalledOnce();
   });
 
+  it('adopts one running B restore across controlled A to B to A to B', async () => {
+    const detachFetch = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(null, { status: 204 }),
+    );
+    vi.stubGlobal('fetch', detachFetch);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    sdkMocks.sessions.push(
+      createMockSession({ sessionId: 'session-a', clientId: 'client-a' }),
+    );
+    const target = createDeferred<MockSession>();
+    let connection: DaemonConnectionState | undefined;
+    function Harness() {
+      connection = useDaemonConnection();
+      return null;
+    }
+    const renderControlled = (sessionId: string) =>
+      root?.render(
+        <DaemonSessionProvider
+          baseUrl="http://127.0.0.1:4170"
+          autoConnect
+          sessionId={sessionId}
+        >
+          <Harness />
+        </DaemonSessionProvider>,
+      );
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      sessionId: 'session-a',
+    });
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(
+      async () => target.promise,
+    );
+
+    await act(async () => {
+      renderControlled('session-b');
+      await flushPromises();
+      renderControlled('session-a');
+      await flushPromises();
+      renderControlled('session-b');
+      await flushPromises();
+    });
+    expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      target.resolve(
+        createMockSession({ sessionId: 'session-b', clientId: 'client-b' }),
+      );
+      await flushPromises();
+    });
+    expect(connection).toMatchObject({
+      status: 'connected',
+      sessionId: 'session-b',
+      clientId: 'client-b',
+    });
+    expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledOnce();
+  });
+
   it('loads controlled sessionId changes', async () => {
     const nextSession = createDeferred<MockSession>();
     sdkMocks.sessions.push(

--- a/packages/webui/src/daemon/session/actions.test.ts
+++ b/packages/webui/src/daemon/session/actions.test.ts
@@ -416,6 +416,8 @@ describe('createDaemonSessionActions', () => {
     void actions.loadSession('session-b').catch(() => undefined);
 
     expect(existingSession.detach).toHaveBeenCalledOnce();
+    expect(existingSession.cancel).not.toHaveBeenCalled();
+    expect(existingSession.submitPrompt).not.toHaveBeenCalled();
     expect(sessionRef.current).toBeUndefined();
     expect(getConnection()).toMatchObject({
       status: 'connecting',


### PR DESCRIPTION
## What this PR does

This PR makes direct and queued prompt submission recheck the session write gate after an asynchronous host admission hook returns. If navigation entered a queued or preparing transition while that hook was pending, submission now stops before clearing follow-up state, committing the composer, allocating a session, sending a prompt, or enqueueing a prompt, so the source draft remains available.

It also documents the prompt-safe navigation contract and adds focused unit and real-daemon coverage for rapid A/B switching, legacy compatibility, source preservation, target restore failures, and the absence of navigation-generated execution requests.

## Why it's needed

Transactional switching from #8882 intentionally keeps the committed source session visible while a target is preparing. That means the source session ID, workspace, and composer version can all remain unchanged even though writes are already blocked. A prompt whose host admission hook started just before navigation could therefore pass the existing stale-owner checks, commit or clear the composer, and only then be rejected by the lower session action, losing the user's draft.

## Reviewer Test Plan

### How to verify

Provide a deferred `onSubmitBefore` hook, submit once in both idle and responding states, start a session transition before resolving the hook, and confirm that neither send nor enqueue runs and that the composer and follow-up state remain intact.

With a real daemon, start a hanging prompt in session A, navigate A to B to A, and confirm that A remains active with only its original prompt admission. Repeat with B returning a structured 504 and confirm that A and its local completion waiter remain intact. In both cases, the request ledger should contain no navigation-generated cancel, continuation, prompt replay, or mid-turn message.

### Evidence (Before & After)

Before: the two focused race regressions each failed because direct submission called `sendPrompt` once and queued submission called `rawEnqueuePrompt` once after the transition write gate had closed.

After: both focused regressions pass; the WebUI provider/action files pass 297 tests; the real-daemon session-switching file passes all 4 tests; each active-source request ledger contains exactly one source prompt and no navigation-generated execution request.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS 26.4.1, Node.js 22.22.3, npm 10.9.8, real daemon with sandbox disabled and the mock ACP agent in hanging mode.

## Risk & Scope

- Main risk or tradeoff: A submission approved after navigation starts is intentionally not admitted; its draft is preserved so the user can submit it after the transition settles.
- Not validated / out of scope: Windows and Linux were not run locally. Same-session reload, branch/fork, client-ID-only handoff, live-journal repair, and DataWorks host behavior are unchanged. Legacy daemons retain destructive visibility semantics while navigation remains free of active cancel or prompt replay.
- Breaking changes / migration notes: None. No public SDK, REST, ACP, CORS, or daemon behavior changes are introduced.

## Linked Issues

Refs #8923

<details>
<summary>中文说明</summary>

## 此 PR 的作用

此 PR 在异步宿主准入 hook 返回后，为直接 prompt 和 queued prompt 再次检查会话写入 gate。如果 hook 等待期间导航已经进入 queued 或 preparing transition，提交会在清理 follow-up、提交 composer、创建会话、发送 prompt 或加入队列之前停止，从而保留源会话草稿。

同时补充 prompt-safe 导航契约文档，以及快速 A/B 切换、legacy 兼容、源会话保留、目标恢复失败和导航不产生执行请求的定向单测与真实 daemon 测试。

## 为什么需要

#8882 的事务式切换会在目标准备期间继续显示已提交的源会话，因此即使写入已经被阻止，源 session ID、workspace 和 composer version 仍可能全部不变。如果 prompt 的宿主准入 hook 恰好在导航前开始，原有的 stale-owner 检查就可能全部通过，先提交或清空 composer，再被下层 session action 拒绝，造成用户草稿丢失。

## Reviewer 测试计划

### 如何验证

提供一个延迟完成的 `onSubmitBefore` hook，分别在 idle 和 responding 状态提交一次，在 hook 完成前启动会话切换，然后确认 send/enqueue 均未执行，composer 和 follow-up 状态保持不变。

使用真实 daemon，在会话 A 中启动一个持续挂起的 prompt，然后执行 A 到 B 再回 A，确认 A 始终 active 且只有最初一次 prompt 准入。再让 B 返回结构化 504，确认 A 及其本地 completion waiter 均被保留。两种情况下，请求账本都不应出现导航产生的 cancel、continuation、prompt 重投或 mid-turn message。

### 证据（修改前后）

修改前：两条定向竞态回归测试均失败，因为 transition write gate 关闭后，直接提交仍调用了一次 `sendPrompt`，queued 提交仍调用了一次 `rawEnqueuePrompt`。

修改后：两条定向回归测试通过；WebUI provider/action 文件共 297 条测试通过；真实 daemon session-switching 文件 4 条测试全部通过；每个 active-source 请求账本都只有一次源 prompt，且没有导航产生的执行请求。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS 26.4.1、Node.js 22.22.3、npm 10.9.8；关闭 sandbox 的真实 daemon，并使用 hang 模式的 mock ACP agent。

## 风险与范围

- 主要风险或取舍：导航开始后才获批的提交不会被准入；其草稿会被保留，用户可在 transition 结束后重新提交。
- 未验证 / 范围外：本地未运行 Windows 和 Linux。same-session reload、branch/fork、仅 client ID handoff、live-journal repair 和 DataWorks 宿主行为均不变。legacy daemon 仍保留破坏性可见性语义，但导航不会主动 cancel 或重投 prompt。
- 破坏性变更 / 迁移说明：无。没有引入 SDK、REST、ACP、CORS 或 daemon 行为变更。

## 关联 Issue

Refs #8923

</details>
