### PR TITLE
chore(serve): Log session continuation admissions

### DIFF
--- a/docs/developers/daemon/08-session-lifecycle.md
+++ b/docs/developers/daemon/08-session-lifecycle.md
@@ -57,6 +57,8 @@ Under `sessionScope: 'thread'`, each thread can mint a distinct session. The cal
 
 `X-Qwen-Client-Id` is **optional** but **strongly recommended**. The daemon does not generate one on the caller's behalf — clients pick their own and reuse it across requests so the daemon can attribute votes, audit events, and detect reconnects.
 
+Each independent controller should use a distinct, stable ID. The WebUI generates IDs with a `webui_` prefix by default. A host and an embedded WebShell should share an ID only when they intentionally act as one logical controller; once shared, daemon logs cannot distinguish which one originated a request.
+
 Validation rules:
 
 - Charset: `[A-Za-z0-9._:-]`.

--- a/docs/developers/daemon/19-observability.md
+++ b/docs/developers/daemon/19-observability.md
@@ -229,7 +229,7 @@ flowchart TD
 ## Caveats and known limits
 
 - **DaemonLogger file logs are structured** and can be filtered by `route`, `sessionId`, and `clientId`. `QWEN_SERVE_DEBUG` stderr logs remain unstructured text.
-- **Accepted prompt, continuation, and cancellation mutations have lifecycle logs.** `prompt enqueued`, `continuation enqueued`, and `cancel sent` include `sessionId`, `promptId` when applicable, and `clientId`; prompt content is not logged. Use a distinct stable client ID for each independent controller. Controllers that intentionally share an ID are indistinguishable in these records.
+- **Accepted prompt, continuation, and cancellation mutations have lifecycle logs.** `prompt enqueued`, `continuation enqueued`, and `cancel sent` include `sessionId`, `promptId` when applicable, and `clientId` when supplied; prompt content is not logged. Use a distinct stable client ID for each independent controller. Controllers that intentionally share an ID are indistinguishable in these records.
 - **DaemonLogger retention is size based, not age based.** The active file and four archives are bounded per family; live fallback owners are never deleted.
 - **Access summaries are intentional loss accounting.** A WARN `access logs suppressed` represents individual access records omitted from both stderr and file; it does not indicate dropped HTTP requests.
 - **External logrotate must not mutate the active family.** Use a shipper that reads/copies and reopens the stable pathname after replacement.

--- a/docs/developers/daemon/19-observability.md
+++ b/docs/developers/daemon/19-observability.md
@@ -229,6 +229,7 @@ flowchart TD
 ## Caveats and known limits
 
 - **DaemonLogger file logs are structured** and can be filtered by `route`, `sessionId`, and `clientId`. `QWEN_SERVE_DEBUG` stderr logs remain unstructured text.
+- **Accepted prompt, continuation, and cancellation mutations have lifecycle logs.** `prompt enqueued`, `continuation enqueued`, and `cancel sent` include `sessionId`, `promptId` when applicable, and `clientId`; prompt content is not logged. Use a distinct stable client ID for each independent controller. Controllers that intentionally share an ID are indistinguishable in these records.
 - **DaemonLogger retention is size based, not age based.** The active file and four archives are bounded per family; live fallback owners are never deleted.
 - **Access summaries are intentional loss accounting.** A WARN `access logs suppressed` represents individual access records omitted from both stderr and file; it does not indicate dropped HTTP requests.
 - **External logrotate must not mutate the active family.** Use a shipper that reads/copies and reopens the stable pathname after replacement.

--- a/packages/cli/src/serve/routes/session.ts
+++ b/packages/cli/src/serve/routes/session.ts
@@ -3251,12 +3251,18 @@ export function registerSessionRoutes(
         const clientId = parseClientIdHeader(req, res);
         if (clientId === null) return;
         const promptId = crypto.randomUUID();
-        res.status(200).json(
-          await runtime.bridge.continueSession(sessionId, {
-            ...(clientId !== undefined ? { clientId } : {}),
+        const result = await runtime.bridge.continueSession(sessionId, {
+          ...(clientId !== undefined ? { clientId } : {}),
+          promptId,
+        });
+        if (daemonLog && result.accepted) {
+          daemonLog.info('continuation enqueued', {
+            sessionId,
             promptId,
-          }),
-        );
+            clientId,
+          });
+        }
+        res.status(200).json(result);
       },
     ),
   );

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -9075,11 +9075,18 @@ describe('createServeApp', () => {
       });
       const promptId = bridge.continueSessionContexts[0]?.promptId;
       expect(typeof promptId).toBe('string');
-      expect(daemonLog.info).toHaveBeenCalledWith('continuation enqueued', {
-        sessionId: 's-1',
-        promptId,
-        clientId: 'client-xyz',
-      });
+      expect(
+        vi
+          .mocked(daemonLog.info)
+          .mock.calls.filter(
+            ([message]) => message === 'continuation enqueued',
+          ),
+      ).toEqual([
+        [
+          'continuation enqueued',
+          { sessionId: 's-1', promptId, clientId: 'client-xyz' },
+        ],
+      ]);
       expect(
         JSON.stringify(vi.mocked(daemonLog.info).mock.calls),
       ).not.toContain('must not appear in logs');
@@ -9102,10 +9109,11 @@ describe('createServeApp', () => {
 
       expect(res.status).toBe(200);
       expect(res.body).toEqual({ accepted: false, interruption: 'none' });
-      expect(daemonLog.info).not.toHaveBeenCalledWith(
-        'continuation enqueued',
-        expect.anything(),
-      );
+      expect(
+        vi
+          .mocked(daemonLog.info)
+          .mock.calls.some(([message]) => message === 'continuation enqueued'),
+      ).toBe(false);
     });
 
     it('maps session continue bridge errors', async () => {
@@ -9129,10 +9137,11 @@ describe('createServeApp', () => {
 
       expect(res.status).toBe(404);
       expect(res.body.sessionId).toBe('missing');
-      expect(daemonLog.info).not.toHaveBeenCalledWith(
-        'continuation enqueued',
-        expect.anything(),
-      );
+      expect(
+        vi
+          .mocked(daemonLog.info)
+          .mock.calls.some(([message]) => message === 'continuation enqueued'),
+      ).toBe(false);
     });
   });
 

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -9051,18 +9051,20 @@ describe('createServeApp', () => {
           interruption: 'interrupted_prompt',
         }),
       });
+      const daemonLog = fakeDaemonLog();
       const tokenOpts: ServeOptions = { ...baseOpts, token: 'secret' };
       const app = createServeApp(
         { ...tokenOpts, workspace: WS_BOUND },
         undefined,
-        { bridge },
+        { bridge, daemonLog },
       );
 
       const res = await request(app)
         .post('/session/s-1/continue')
         .set('Host', `127.0.0.1:${tokenOpts.port}`)
         .set('Authorization', 'Bearer secret')
-        .set('X-Qwen-Client-Id', 'client-xyz');
+        .set('X-Qwen-Client-Id', 'client-xyz')
+        .send({ prompt: 'must not appear in logs' });
 
       expect(res.status).toBe(200);
       // The originator + a generated promptId must reach the bridge so the
@@ -9071,7 +9073,39 @@ describe('createServeApp', () => {
       expect(bridge.continueSessionContexts[0]).toMatchObject({
         clientId: 'client-xyz',
       });
-      expect(typeof bridge.continueSessionContexts[0]?.promptId).toBe('string');
+      const promptId = bridge.continueSessionContexts[0]?.promptId;
+      expect(typeof promptId).toBe('string');
+      expect(daemonLog.info).toHaveBeenCalledWith('continuation enqueued', {
+        sessionId: 's-1',
+        promptId,
+        clientId: 'client-xyz',
+      });
+      expect(
+        JSON.stringify(vi.mocked(daemonLog.info).mock.calls),
+      ).not.toContain('must not appear in logs');
+    });
+
+    it('does not log a continuation that was not accepted', async () => {
+      const bridge = fakeBridge();
+      const daemonLog = fakeDaemonLog();
+      const tokenOpts: ServeOptions = { ...baseOpts, token: 'secret' };
+      const app = createServeApp(
+        { ...tokenOpts, workspace: WS_BOUND },
+        undefined,
+        { bridge, daemonLog },
+      );
+
+      const res = await request(app)
+        .post('/session/s-1/continue')
+        .set('Host', `127.0.0.1:${tokenOpts.port}`)
+        .set('Authorization', 'Bearer secret');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ accepted: false, interruption: 'none' });
+      expect(daemonLog.info).not.toHaveBeenCalledWith(
+        'continuation enqueued',
+        expect.anything(),
+      );
     });
 
     it('maps session continue bridge errors', async () => {
@@ -9080,11 +9114,12 @@ describe('createServeApp', () => {
           throw new SessionNotFoundError(sessionId);
         },
       });
+      const daemonLog = fakeDaemonLog();
       const tokenOpts: ServeOptions = { ...baseOpts, token: 'secret' };
       const app = createServeApp(
         { ...tokenOpts, workspace: WS_BOUND },
         undefined,
-        { bridge },
+        { bridge, daemonLog },
       );
 
       const res = await request(app)
@@ -9094,6 +9129,10 @@ describe('createServeApp', () => {
 
       expect(res.status).toBe(404);
       expect(res.body.sessionId).toBe('missing');
+      expect(daemonLog.info).not.toHaveBeenCalledWith(
+        'continuation enqueued',
+        expect.anything(),
+      );
     });
   });
 


### PR DESCRIPTION
## What this PR does

This PR adds a structured `continuation enqueued` lifecycle record after the daemon has accepted a session continuation. The record contains only `sessionId`, the generated `promptId`, and `clientId` when the request supplies one; rejected and failed continuation attempts are not reported as enqueued, and prompt content is never included.

It also documents the client identity contract for multi-controller integrations: each independent controller should use a distinct stable ID, WebUI-generated IDs use the `webui_` prefix, and a host should share an ID with an embedded WebShell only when both intentionally act as one logical controller.

## Why it's needed

Prompt submission and cancellation already have admission lifecycle records, but continuation did not. That gap made it difficult to determine whether a continuation was actually admitted and which controller initiated it while investigating session-navigation behavior under #8923. The new record closes that observability gap without changing the REST, ACP, SDK, cancellation, prompt queue, continuation, or detach contracts.

## Reviewer Test Plan

### How to verify

Send a continuation that the bridge accepts and confirm the daemon emits exactly one `continuation enqueued` record containing the session ID, generated prompt ID, and client ID, with no request content. Then return `accepted: false` and throw a mapped bridge error; neither path should emit the admission record. Run the focused serve route tests and confirm all four continuation cases pass, then run the repository build, typecheck, lint, and bundle checks.

### Evidence (Before & After)

N/A — this is a daemon observability and documentation change with no user-interface output.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS 26.4.1, Node.js 22.22.3, npm 10.9.8, sandbox disabled for local repository checks.

## Risk & Scope

- Main risk or tradeoff: Each accepted continuation produces one additional info-level structured log record; the fields are identifiers only and do not include prompt content.
- Not validated / out of scope: Windows and Linux were not tested locally. This PR does not change host controllers, session navigation, public protocol fields, CORS, SDK types, or daemon mutation semantics.
- Breaking changes / migration notes: None.

## Linked Issues

Refs #8923

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 在 daemon 接受会话 continuation 后新增结构化的 `continuation enqueued` 生命周期记录。记录只包含 `sessionId`、生成的 `promptId`，以及请求提供时的 `clientId`；被拒绝或失败的 continuation 不会被记录为 enqueued，也绝不会记录 prompt 内容。

同时补充多控制器集成的客户端身份约定：每个独立控制器应使用不同且稳定的 ID，WebUI 生成的 ID 使用 `webui_` 前缀；只有宿主与内嵌 WebShell 有意作为同一个逻辑控制器时，二者才应共享 ID。

## 为什么需要

Prompt 提交和取消已经有准入生命周期记录，但 continuation 没有。排查 #8923 下的会话导航行为时，这一缺口导致难以判断 continuation 是否真正被准入，以及由哪个控制器发起。新增记录在不改变 REST、ACP、SDK、取消、prompt 队列、continuation 或 detach 契约的前提下补齐了可观测性。

## Reviewer 测试计划

### 如何验证

发送一个被 bridge 接受的 continuation，确认 daemon 只产生一条 `continuation enqueued` 记录，包含会话 ID、生成的 prompt ID 和客户端 ID，且不包含请求内容。随后让 bridge 返回 `accepted: false`，再抛出一个会被映射的错误；这两条路径都不应产生准入记录。运行定向 serve 路由测试并确认四个 continuation 场景全部通过，再运行仓库 build、typecheck、lint 和 bundle 检查。

### 证据（修复前后）

N/A——这是 daemon 可观测性和文档变更，没有用户界面输出。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS 26.4.1、Node.js 22.22.3、npm 10.9.8；本地仓库检查未启用 sandbox。

## 风险与范围

- 主要风险或取舍：每个被接受的 continuation 会新增一条 info 级结构化日志；字段仅为标识符，不包含 prompt 内容。
- 未验证 / 范围外：未在本地测试 Windows 和 Linux。本 PR 不修改宿主控制器、会话导航、公共协议字段、CORS、SDK 类型或 daemon mutation 语义。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Refs #8923

</details>
