### PR TITLE
test(web-shell): prevent nested session render loop

### DIFF
--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -423,7 +423,14 @@ vi.mock('@qwen-code/webui/daemon-react-sdk', () => {
   };
   return {
     DAEMON_APPROVAL_MODES: ['default', 'plan', 'auto-edit', 'auto', 'yolo'],
-    DaemonSessionProvider: ({ children }: { children: ReactNode }) => children,
+    // This harness only models the parent session connection.
+    DaemonSessionProvider: ({
+      children,
+      clientId,
+    }: {
+      children: ReactNode;
+      clientId?: string;
+    }) => (clientId?.startsWith('side-task:') ? null : children),
     useActions: () => mockSessionActions,
     useConnection: () => mockConnection,
     useDaemonSessionOwnerGuard: () => ownerGuard,


### PR DESCRIPTION
## What this PR does

Limits the Web Shell app test harness's mocked daemon session provider to the parent session it actually models. Nested side-task providers no longer reuse the parent mocked connection.

## Why it's needed

When the side-task creation test resolves the nested session, the shared parent connection causes an infinite React update loop. The test process eventually exhausts its heap, which makes the Web Shell CI job fail.

## Reviewer Test Plan

### How to verify

Run the side-task creation test and the complete app test file with coverage. Confirm that the side task test completes and all 382 app tests pass without exhausting the Node.js heap.

### Evidence (Before & After)

Before: the nested side-task session repeatedly rendered with the parent mocked connection until Vitest ran out of memory.

After: the focused side-task test passes, and the complete app test file passes 382/382 with coverage.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

Node.js 22.14.0, Vitest 3.2.4.

## Risk & Scope

- Main risk or tradeoff: The mock intentionally does not render nested side-task providers; those providers require a separate connection model that this app-level harness does not provide.
- Not validated / out of scope: Full repository build is currently blocked in this clean worktree because installing with lifecycle scripts disabled omits the repository's customized Ink types. The affected Web Shell app tests were run directly.
- Breaking changes / migration notes: None; test-only change.

## Linked Issues

Related to #8872.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

将 Web Shell 应用测试桩中的 daemon session provider 限制为它实际模拟的父会话。嵌套 side-task provider 不再复用父会话的 mock 连接。

## 为什么需要

side-task 创建测试解析嵌套会话后，共用的父会话连接会触发 React 无限更新循环，最终耗尽测试进程堆内存，导致 Web Shell CI 失败。

## Reviewer 测试计划

### 如何验证

运行 side-task 创建测试以及带 coverage 的完整应用测试文件，确认 side-task 测试正常结束，并且全部 382 个应用测试通过，不再耗尽 Node.js 堆内存。

### 前后证据

修复前：嵌套 side-task 会话使用父会话 mock 连接持续重复渲染，直到 Vitest 内存溢出。

修复后：目标 side-task 测试通过，带 coverage 的完整应用测试文件 382/382 通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

Node.js 22.14.0，Vitest 3.2.4。

## 风险与范围

- 主要风险或取舍：该 mock 有意不渲染嵌套 side-task provider；这些 provider 需要当前应用级测试桩未提供的独立连接模型。
- 未验证/范围外：此干净 worktree 使用禁用生命周期脚本的方式安装依赖，因此缺少仓库定制的 Ink 类型，全仓构建目前受阻；受影响的 Web Shell 应用测试已单独运行。
- 破坏性变更/迁移说明：无，仅修改测试。

## 关联问题

与 #8872 相关。

</details>
