### PR TITLE
fix(desktop): strip Windows verbatim prefix from runtime spawn paths

### DIFF
--- a/packages/desktop-shell/src-tauri/src/runtime.rs
+++ b/packages/desktop-shell/src-tauri/src/runtime.rs
@@ -162,16 +162,26 @@ impl RuntimeLayout {
                 .join("runtime")
                 .join("qwen-code")
         };
-        let node = if cfg!(windows) {
-            root.join("node").join("node.exe")
-        } else {
-            root.join("node").join("bin").join("node")
-        };
-        let entry = root.join("lib").join("cli-entry.js");
+        let (node, entry) = layout_from_root(root);
         require_file(&node, "Node.js runtime")?;
         require_file(&entry, "Qwen Code runtime entry")?;
         Ok(Self { node, entry })
     }
+}
+
+fn layout_from_root(root: PathBuf) -> (PathBuf, PathBuf) {
+    let node = if cfg!(windows) {
+        root.join("node").join("node.exe")
+    } else {
+        root.join("node").join("bin").join("node")
+    };
+    let entry = root.join("lib").join("cli-entry.js");
+    // Tauri's resource_dir() returns `\\?\` verbatim paths on Windows, and
+    // Node's entry-script resolution cannot handle that prefix (#8929).
+    (
+        dunce::simplified(&node).to_path_buf(),
+        dunce::simplified(&entry).to_path_buf(),
+    )
 }
 
 fn require_file(path: &Path, description: &str) -> Result<(), String> {
@@ -532,6 +542,8 @@ mod tests {
     };
     #[cfg(unix)]
     use super::{stop_runtime_handle, wait_for_listening};
+    #[cfg(windows)]
+    use super::layout_from_root;
     use std::path::Path;
     #[cfg(windows)]
     use std::path::PathBuf;
@@ -584,6 +596,22 @@ mod tests {
             .expect("cleanup long workspace");
         let error = result.expect_err("reject long workspace");
         assert!(error.contains("unsupported Windows extended-length form"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn runtime_layout_strips_windows_verbatim_prefix() {
+        let root = PathBuf::from(r"\\?\C:\Users\user\AppData\Local\Qwen Code Desktop")
+            .join("runtime")
+            .join("qwen-code");
+        let (node, entry) = layout_from_root(root);
+        for path in [node, entry] {
+            let path = path.to_string_lossy();
+            assert!(
+                !path.starts_with("\\\\?\\"),
+                "runtime path keeps the verbatim prefix: {path}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What this PR does

When the desktop shell spawns the bundled Node runtime on Windows, it now strips the `\\?\` extended-length ("verbatim") prefix from the Node executable path and the CLI entry-script path before handing them to the spawn. The workspace path was already covered by #8619; this closes the same class of bug for the remaining two spawn arguments. A Windows-gated regression test asserts neither runtime spawn path keeps the prefix.

## Why it's needed

Fixes #8929. On Windows, Tauri's resource-directory resolution returns verbatim `\\?\` paths, and the launcher passed them through to the spawn unchanged. Node's entry-script resolution (`resolveMainPath` → `realpathSync`) cannot handle that prefix and dies with `EISDIR: lstat 'C:'` before the daemon prints its listening URL — the app cannot start at all, regardless of which workspace is chosen. The reporter captured the actual spawn command via WMI and showed the prefix on the program path, the entry-script path, and the workspace value; the first two are what trigger the crash, so the workspace fix from #8619 alone is not sufficient. The reporter's workaround — pointing the runtime-directory environment variable at a plain path — confirms the runtime paths as the cause.

## Reviewer Test Plan

### How to verify

- `cargo test --manifest-path src-tauri/Cargo.toml` in `packages/desktop-shell` passes (37 tests locally on macOS); the new Windows-gated test runs on the `windows-2022` leg of the `desktop_shell` CI job.
- On a packaged Windows build: start the app and confirm the runtime comes up; the spawned command line no longer contains `\\?\` for the Node executable or the entry script.

### Evidence (Before & After)

N/A — startup-crash fix in the Tauri launcher; no UI change. Before: "Bundled runtime closed stdout before reporting its listening URL" with an `EISDIR` stack on every start attempt (see #8929). After: runtime starts as it does with the reporter's plain-path workaround.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`cargo test` / `cargo clippy --tests` on the desktop crate; no bundled runtime needed.

## Risk & Scope

- Main risk or tradeoff: `dunce::simplified` keeps the verbatim form when a simplified path would be unsafe (e.g. over 260 characters), so in that edge case behavior is unchanged from today rather than broken.
- Not validated / out of scope: end-to-end startup on a packaged Windows build — the Windows CI test covers the path logic; a release build should be smoke-tested before the next Desktop release.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #8929. Related: #8615 / #8619 (workspace-path half of the same verbatim-path bug class).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

桌面端外壳在 Windows 上拉起内置 Node 运行时之前，现在会先剥离 Node 可执行文件路径和 CLI 入口脚本路径上的 `\\?\` 扩展长度（"verbatim"）前缀。workspace 路径此前已由 #8619 覆盖；本 PR 补齐了剩余两个 spawn 参数上的同类问题。并新增了一个仅在 Windows 上运行的回归测试，断言两个运行时 spawn 路径都不再保留该前缀。

## 为什么需要

修复 #8929。在 Windows 上，Tauri 的资源目录解析返回 verbatim `\\?\` 路径，而启动器原样将其传给了 spawn。Node 的入口脚本解析（`resolveMainPath` → `realpathSync`）无法处理该前缀，会在守护进程打印监听 URL 之前以 `EISDIR: lstat 'C:'` 崩溃 —— 无论选择哪个 workspace，应用都完全无法启动。报告者通过 WMI 抓到了真实的 spawn 命令，显示程序路径、入口脚本路径和 workspace 值上都带有该前缀；其中前两个才是触发崩溃的原因，因此仅有 #8619 的 workspace 修复并不够。报告者的临时方案 —— 将运行时目录环境变量指向普通路径 —— 也印证了运行时路径正是问题根源。

## 评审者测试计划

### 如何验证

- 在 `packages/desktop-shell` 下运行 `cargo test --manifest-path src-tauri/Cargo.toml` 通过（本地 macOS 37 个测试全过）；新增的 Windows 门控测试会在 `desktop_shell` CI 任务的 `windows-2022` 分支上运行。
- 在打包后的 Windows 构建上：启动应用并确认运行时正常拉起；spawn 出的命令行中 Node 可执行文件和入口脚本不再包含 `\\?\`。

### 证据（前后对比）

N/A —— Tauri 启动器中的启动崩溃修复，无 UI 变化。修复前：每次启动都报 "Bundled runtime closed stdout before reporting its listening URL" 并附 `EISDIR` 堆栈（见 #8929）。修复后：运行时如报告者用普通路径 workaround 时一样正常启动。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

对桌面 crate 运行 `cargo test` / `cargo clippy --tests`；不需要内置运行时。

## 风险与范围

- 主要风险或权衡：当简化后的路径不安全时（例如超过 260 字符），`dunce::simplified` 会保留 verbatim 形式，因此该边缘情况下行为与现状一致，而不会被改坏。
- 未验证 / 超出范围：打包后 Windows 构建的端到端启动 —— Windows CI 测试覆盖了路径逻辑；下一个 Desktop 版本发布前应对 release 构建做一次冒烟测试。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

修复 #8929。相关：#8615 / #8619（同一 verbatim 路径问题中 workspace 路径的那一半）。

</details>
