### PR TITLE
fix(vscode): preserve Windows file links in session exports

### DIFF
--- a/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.test.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.test.ts
@@ -522,235 +522,855 @@ describe('SessionMessageHandler', () => {
     const agentManager = {
       isConnected: true,
       currentSessionId: 'session-1',
-      rewindSessionßx¶‰žËkºwµçH[ØÚÔ›ØÙ\ÜÒ[XYÙP]XÚY[Ë›[ØÚÔ™\ÛÛ™Y˜[YJÂˆ›Ü›X]Y^ˆ	ÙY]Y›Û\	Ëˆ\Ü^U^ˆ	ÙY]Y›Û\	ËˆØ]™Y[XYÙPÛÝ[ˆˆ›Û\[XYÙ\Îˆ×KˆJNÂ‚ˆÛÛœÝ\ÝÜžP™Y›Ü™T™]Ú[™HÞÈ›ÛNˆ	Ý\Ù\‰Ë\ÎˆÞÈ^ˆ	Ùš\œÝ	ÈWHWNÂˆÛÛœÝÜšYÚ[˜[ÛÛ™\œØ][ÛˆHÂˆYˆ	ÜÙ\ÜÚ[Û‹LIËˆ]Nˆ	Ñ^\Ý[™ÈÙ\ÜÚ[Û‰ËˆY\ÜØYÙ\ÎˆÂˆÈ›ÛNˆ	Ý\Ù\‰È\ÈÛÛœÝÛÛ[ˆ	Ùš\œÝ	Ë[Y\Ý[\ˆHKˆÈ›ÛNˆ	Ø\ÜÚ\Ý[	È\ÈÛÛœÝÛÛ[ˆ	Ùš\œÝ™\IË[Y\Ý[\ˆˆKˆÈ›ÛNˆ	Ý\Ù\‰È\ÈÛÛœÝÛÛ[ˆ	ÜÙXÛÛ™	Ë[Y\Ý[\ˆÈKˆKˆÜ™X]Y]ˆKˆ\]Y]ˆËˆNÂˆÛÛœÝYÙ[X[˜YÙ\ˆHÂˆ\ÐÛÛ›™XÝYˆYKˆÝ\œ™[Ù\ÜÚ[Û’Yˆ	ÜÙ\ÜÚ[Û‹LIËˆ™]Ú[™Ù\ÜÚ[ÛŽˆšK™›Š
-K›[ØÚÔ™\ÛÛ™Y˜[YJÈ\ÝÜžP™Y›Ü™T™]Ú[™JKˆ™\ÝÜ™TÙ\ÜÚ[Û’\ÝÜžNˆšK™›Š
-K›[ØÚÔ™\ÛÛ™Y˜[YJ[™Yš[™Y
-KˆÙ[™Y\ÜØYÙNˆšK™›Š
-KˆNÂˆÛÛœÝÛÛ™\œØ][Û”ÝÜ™HHÂˆÜ™X]PÛÛ™\œØ][ÛŽˆšK™›Š
-KˆÙ]ÛÛ™\œØ][ÛŽˆšK™›Š
-K›[ØÚÔ™\ÛÛ™Y˜[YJÜšYÚ[˜[ÛÛ™\œØ][ÛŠKˆYY\ÜØYÙNˆšK™›Š
-K›[ØÚÔ™Z™XÝY˜[YJ™]È\œ›ÜŠ	ÜÝÜ˜YÙH˜Z[Y	ÊJKˆ™\XÙSY\ÜØYÙ\ÎˆšK™›Š
-K›[ØÚÔ™\ÛÛ™Y˜[YJYJKˆ[˜Ø]Qœ›ÛU\Ù\•\›ŽˆšK™›Š
-K›[ØÚÔ™\ÛÛ™Y˜[YJYJKˆNÂˆÛÛœÝÙ[™ÕÙX•šY]ÈHšK™›Š
-NÂ‚ˆÛÛœÝ[™\ˆH™]ÈÙ\ÜÚ[Û“Y\ÜØYÙR[™\ŠˆYÙ[X[˜YÙ\ˆ\È™]™\‹ˆÛÛ™\œØ][Û”ÝÜ™H\È™]™\‹ˆ	ÜÙ\ÜÚ[Û‹LIËˆÙ[™ÕÙX•šY]Ëˆ
-NÂ‚ˆ]ØZ][™\‹š[™JÂˆ\Nˆ	ÙY]Y\ÜØYÙIËˆ]NˆÂˆ^ˆ	ÙY]Y›Û\	Ëˆ\™Ù]\›’[™^ˆKˆKˆJNÂ‚ˆ^XÝ
-YÙ[X[˜YÙ\‹œ™\ÝÜ™TÙ\ÜÚ[Û’\ÝÜžJKÒ]™P™Y[Ø[YÚ]
-ˆ\ÝÜžP™Y›Ü™T™]Ú[™ˆ
-NÂˆ^XÝ
-ÛÛ™\œØ][Û”ÝÜ™Kœ™\XÙSY\ÜØYÙ\ÊKÒ]™P™Y[Ø[YÚ]
-ˆ	ÜÙ\ÜÚ[Û‹LIËˆÜšYÚ[˜[ÛÛ™\œØ][Û‹›Y\ÜØYÙ\Ëˆ
-NÂˆ^XÝ
-YÙ[X[˜YÙ\‹œÙ[™Y\ÜØYÙJK››ÝÒ]™P™Y[Ø[Y
+      rewindSession: vi.fn().mockResolvedValue({
+        historyBeforeRewind: [{ role: 'user', parts: [{ text: 'first' }] }],
+      }),
+      restoreSessionHistory: vi.fn().mockResolvedValue(undefined),
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+    };
+    const conversationStore = {
+      createConversation: vi.fn(),
+      getConversation: vi.fn().mockResolvedValue({
+        id: 'session-1',
+        title: 'Existing session',
+        messages: [
+          { role: 'user', content: 'first', timestamp: 1 },
+          { role: 'assistant', content: 'first reply', timestamp: 2 },
+          { role: 'user', content: 'second', timestamp: 3 },
+        ],
+        createdAt: 1,
+        updatedAt: 3,
+      }),
+      addMessage: vi.fn(),
+      replaceMessages: vi.fn().mockResolvedValue(true),
+      truncateFromUserTurn: vi.fn().mockResolvedValue(true),
+    };
+    const sendToWebView = vi.fn();
 
-NÂˆ^XÝ
-Ù[™ÕÙX•šY]ÊKÒ]™P™Y[Ø[YÚ]
-Âˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙNˆ	ÜÝÜ˜YÙH˜Z[Y	ÈKˆJNÂˆJNÂ‚ˆ]
-	Ü™Z™XÝÈY]ÝX›Z\ÜÚ[ÛœÈÚ][˜[Y\™Ù]\›ˆ[™^\ÉË\Þ[˜È
+    const handler = new SessionMessageHandler(
+      agentManager as never,
+      conversationStore as never,
+      'session-1',
+      sendToWebView,
+    );
 
-HOˆÂˆÛÛœÝYÙ[X[˜YÙ\ˆHÂˆ\ÐÛÛ›™XÝYˆYKˆÝ\œ™[Ù\ÜÚ[Û’Yˆ	ÜÙ\ÜÚ[Û‹LIËˆ™]Ú[™Ù\ÜÚ[ÛŽˆšK™›Š
-Kˆ™\ÝÜ™TÙ\ÜÚ[Û’\ÝÜžNˆšK™›Š
-KˆÙ[™Y\ÜØYÙNˆšK™›Š
-KˆNÂˆÛÛœÝÛÛ™\œØ][Û”ÝÜ™HHÂˆÜ™X]PÛÛ™\œØ][ÛŽˆšK™›Š
-KˆÙ]ÛÛ™\œØ][ÛŽˆšK™›Š
-KˆYY\ÜØYÙNˆšK™›Š
-Kˆ™\XÙSY\ÜØYÙ\ÎˆšK™›Š
-Kˆ[˜Ø]Qœ›ÛU\Ù\•\›ŽˆšK™›Š
-KˆNÂˆÛÛœÝÙ[™ÕÙX•šY]ÈHšK™›Š
-NÂ‚ˆÛÛœÝ[™\ˆH™]ÈÙ\ÜÚ[Û“Y\ÜØYÙR[™\ŠˆYÙ[X[˜YÙ\ˆ\È™]™\‹ˆÛÛ™\œØ][Û”ÝÜ™H\È™]™\‹ˆ	ÜÙ\ÜÚ[Û‹LIËˆÙ[™ÕÙX•šY]Ëˆ
-NÂ‚ˆ]ØZ][™\‹š[™JÂˆ\Nˆ	ÙY]Y\ÜØYÙIËˆ]NˆÂˆ^ˆ	ÙY]Y›Û\	Ëˆ\™Ù]\›’[™^ˆLKˆKˆJNÂ‚ˆ^XÝ
-YÙ[X[˜YÙ\‹œ™]Ú[™Ù\ÜÚ[ÛŠK››ÝÒ]™P™Y[Ø[Y
+    await handler.handle({
+      type: 'editMessage',
+      data: {
+        text: 'edited prompt',
+        targetTurnIndex: 1,
+      },
+    });
 
-NÂˆ^XÝ
-YÙ[X[˜YÙ\‹œÙ[™Y\ÜØYÙJK››ÝÒ]™P™Y[Ø[Y
+    expect(agentManager.rewindSession).toHaveBeenCalledWith(1);
+    expect(conversationStore.truncateFromUserTurn).toHaveBeenCalledWith(
+      'session-1',
+      1,
+    );
+    expect(sendToWebView).toHaveBeenCalledWith({
+      type: 'conversationRewound',
+      data: { targetTurnIndex: 1 },
+    });
+    expect(agentManager.sendMessage).toHaveBeenCalledWith([
+      { type: 'text', text: 'edited prompt' },
+    ]);
+    expect(
+      conversationStore.truncateFromUserTurn.mock.invocationCallOrder[0],
+    ).toBeLessThan(agentManager.rewindSession.mock.invocationCallOrder[0]);
+    expect(agentManager.rewindSession.mock.invocationCallOrder[0]).toBeLessThan(
+      agentManager.sendMessage.mock.invocationCallOrder[0],
+    );
+  });
 
-NÂˆ^XÝ
-ÛÛ™\œØ][Û”ÝÜ™K[˜Ø]Qœ›ÛU\Ù\•\›ŠK››ÝÒ]™P™Y[Ø[Y
+  it('restores the edited conversation snapshot when replacement send fails', async () => {
+    mockProcessImageAttachments.mockResolvedValue({
+      formattedText: 'edited prompt',
+      displayText: 'edited prompt',
+      savedImageCount: 0,
+      promptImages: [],
+    });
 
-NÂˆ^XÝ
-Ù[™ÕÙX•šY]ÊKÒ]™P™Y[Ø[YÚ]
-Âˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙNˆ	Ò[˜[YY\ÜØYÙHY]\™Ù]‰ÈKˆJNÂˆJNÂ‚ˆ]
-	ÚÙY\ÈÝ\œ™[ÛÛ™\œØ][Û’Y[YÛ™YÚ]H\˜Ú]™YÙ\ÜÚ[Û’YÚ[ˆÙ\ÜÚ[Û‹ÛØY˜[È˜XÚÈÈH™]ÈPÔÙ\ÜÚ[Û‰Ë\Þ[˜È
+    const originalConversation = {
+      id: 'session-1',
+      title: 'Existing session',
+      messages: [
+        { role: 'user' as const, content: 'first', timestamp: 1 },
+        { role: 'assistant' as const, content: 'first reply', timestamp: 2 },
+        { role: 'user' as const, content: 'second', timestamp: 3 },
+        { role: 'assistant' as const, content: 'second reply', timestamp: 4 },
+      ],
+      createdAt: 1,
+      updatedAt: 4,
+    };
+    const agentManager = {
+      isConnected: true,
+      currentSessionId: 'session-1',
+      rewindSession: vi.fn().mockResolvedValue({
+        historyBeforeRewind: [{ role: 'user', parts: [{ text: 'first' }] }],
+      }),
+      restoreSessionHistory: vi.fn().mockResolvedValue(undefined),
+      sendMessage: vi.fn().mockRejectedValue(new Error('send failed')),
+    };
+    const conversationStore = {
+      createConversation: vi.fn(),
+      getConversation: vi.fn().mockResolvedValue(originalConversation),
+      addMessage: vi.fn(),
+      replaceMessages: vi.fn().mockResolvedValue(true),
+      truncateFromUserTurn: vi.fn().mockResolvedValue(true),
+    };
+    const sendToWebView = vi.fn();
 
-HOˆÂˆÛÛœÝ\˜Ú]™YÙ\ÜÚ[Û’YH	Ø\˜Ú]™Y\Ù\ÜÚ[Û‰ÎÂˆÛÛœÝYÙ[X[˜YÙ\ˆHÂˆ\ÐÛÛ›™XÝYˆYKˆÝ\œ™[Ù\ÜÚ[Û’Yˆ	ÛÛXXÜ\Ù\ÜÚ[Û‰ËˆÙ]Ù\ÜÚ[Û“\ÝˆšBˆ™›Š
-Bˆ›[ØÚÔ™\ÛÛ™Y˜[YJÞÈYˆ\˜Ú]™YÙ\ÜÚ[Û’YÝÙˆ	ËÝÛÜšÜÜXÙIÈWJKˆØYÙ\ÜÚ[Û•šXPXÜˆšBˆ™›Š
-Bˆ›[ØÚÔ™Z™XÝY˜[YJ™]È\œ›ÜŠ	ÜÙ\ÜÚ[Ûˆ›Ý›Ý[™ÛˆÙ\™\‰ÊJKˆÙ]Ù\ÜÚ[Û“Y\ÜØYÙ\ÎˆšK™›Š
-K›[ØÚÔ™\ÛÛ™Y˜[YJ×JKˆÜ™X]S™]ÔÙ\ÜÚ[ÛŽˆšK™›Š
-K›[ØÚÔ™\ÛÛ™Y˜[YJ	Û™]ËXXÜ\Ù\ÜÚ[Û‰ÊKˆNÂˆÛÛœÝÛÛ™\œØ][Û”ÝÜ™HHÂˆÜ™X]PÛÛ™\œØ][ÛŽˆšK™›Š
-KˆÙ]ÛÛ™\œØ][ÛŽˆšK™›Š
-KˆYY\ÜØYÙNˆšK™›Š
-KˆNÂˆÛÛœÝÙ[™ÕÙX•šY]ÈHšK™›Š
-NÂ‚ˆÛÛœÝ[™\ˆH™]ÈÙ\ÜÚ[Û“Y\ÜØYÙR[™\ŠˆYÙ[X[˜YÙ\ˆ\È™]™\‹ˆÛÛ™\œØ][Û”ÝÜ™H\È™]™\‹ˆ[ˆÙ[™ÕÙX•šY]Ëˆ
-NÂ‚ˆ]ØZ][™\‹š[™JÂˆ\Nˆ	ÜÝÚ]Ú]Ù[”Ù\ÜÚ[Û‰Ëˆ]NˆÈÙ\ÜÚ[Û’Yˆ\˜Ú]™YÙ\ÜÚ[Û’YKˆJNÂ‚ˆËÈ˜XÚÙ[™]˜XÚÙYÝ\œ™[Ù\ÜÚ[Ûˆ]\ÝX]ÚHÙ\ÜÚ[Û’YHÙXšY]ÈÙY\ËˆËÈÝ\Ú\ÙH™[˜[YKÙ[]KÝ]K]\]H›ÝÜÈÚ[\™Ù]HÜ›Û™ÈÙ\ÜÚ[Û‚ˆËÈ\š[™ÈH˜[˜XÚÈÚ[™ÝÈ
-ÙYHˆÌÌLÈ™]šY]ÊK‚ˆ^XÝ
-[™\‹™Ù]Ý\œ™[ÛÛ™\œØ][Û’Y
+    const handler = new SessionMessageHandler(
+      agentManager as never,
+      conversationStore as never,
+      'session-1',
+      sendToWebView,
+    );
 
-JKÐ™J\˜Ú]™YÙ\ÜÚ[Û’Y
-NÂˆ^XÝ
-YÙ[X[˜YÙ\‹˜Ü™X]S™]ÔÙ\ÜÚ[ÛŠKÒ]™P™Y[Ø[Y
+    await handler.handle({
+      type: 'editMessage',
+      data: {
+        text: 'edited prompt',
+        targetTurnIndex: 1,
+      },
+    });
 
-NÂˆ^XÝ
-Ù[™ÕÙX•šY]ÊKÒ]™P™Y[Ø[YÚ]
-ˆ^XÝ›Øš™XÝÛÛZ[š[™ÊÂˆ\Nˆ	Ü]Ù[”Ù\ÜÚ[Û”ÝÚ]ÚY	Ëˆ]Nˆ^XÝ›Øš™XÝÛÛZ[š[™ÊÈÙ\ÜÚ[Û’Yˆ\˜Ú]™YÙ\ÜÚ[Û’YJKˆJKˆ
-NÂˆJNÂ‚ˆ]
-	Ù›Ü˜Ù\ÈHœ™\ÚPÔÙ\ÜÚ[ÛˆÚ[ˆHÙXšY]È™\]Y\ÝÈH™]ÈÙ\ÜÚ[Û‰Ë\Þ[˜È
+    expect(agentManager.restoreSessionHistory).toHaveBeenCalledWith([
+      { role: 'user', parts: [{ text: 'first' }] },
+    ]);
+    expect(conversationStore.replaceMessages).toHaveBeenCalledWith(
+      'session-1',
+      originalConversation.messages,
+    );
+    expect(sendToWebView).toHaveBeenCalledWith({
+      type: 'conversationLoaded',
+      data: originalConversation,
+    });
+    expect(sendToWebView).toHaveBeenCalledWith({
+      type: 'error',
+      data: { message: 'send failed' },
+    });
+  });
 
-HOˆÂˆÛÛœÝYÙ[X[˜YÙ\ˆHÂˆ\ÐÛÛ›™XÝYˆYKˆÝ\œ™[Ù\ÜÚ[Û’Yˆ	ÜÙ\ÜÚ[Û‹LIËˆÜ™X]S™]ÔÙ\ÜÚ[ÛŽˆšK™›Š
-K›[ØÚÔ™\ÛÛ™Y˜[YJ	ÜÙ\ÜÚ[Û‹L‰ÊKˆNÂˆÛÛœÝÛÛ™\œØ][Û”ÝÜ™HHÂˆÜ™X]PÛÛ™\œØ][ÛŽˆšK™›Š
-KˆÙ]ÛÛ™\œØ][ÛŽˆšK™›Š
-KˆYY\ÜØYÙNˆšK™›Š
-KˆNÂˆÛÛœÝÙ[™ÕÙX•šY]ÈHšK™›Š
-NÂ‚ˆÛÛœÝ[™\ˆH™]ÈÙ\ÜÚ[Û“Y\ÜØYÙR[™\ŠˆYÙ[X[˜YÙ\ˆ\È™]™\‹ˆÛÛ™\œØ][Û”ÝÜ™H\È™]™\‹ˆ	ØÛÛ™\œØ][Û‹LIËˆÙ[™ÕÙX•šY]Ëˆ
-NÂ‚ˆ]ØZ][™\‹š[™JÂˆ\Nˆ	Û™]Ô]Ù[”Ù\ÜÚ[Û‰ËˆJNÂ‚ˆ^XÝ
-[™\‹™Ù]Ý\œ™[ÛÛ™\œØ][Û’Y
+  it('continues edits with ACP-only rewind when no local snapshot exists', async () => {
+    mockProcessImageAttachments.mockResolvedValue({
+      formattedText: 'edited prompt',
+      displayText: 'edited prompt',
+      savedImageCount: 0,
+      promptImages: [],
+    });
 
-JKÐ™S[
+    const agentManager = {
+      isConnected: true,
+      currentSessionId: 'session-1',
+      rewindSession: vi.fn().mockResolvedValue({
+        historyBeforeRewind: [{ role: 'user', parts: [{ text: 'first' }] }],
+      }),
+      restoreSessionHistory: vi.fn(),
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+      getSessionMessages: vi.fn().mockResolvedValue([]),
+    };
+    const conversationStore = {
+      createConversation: vi.fn(),
+      getConversation: vi.fn().mockResolvedValue(null),
+      addMessage: vi.fn(),
+      replaceMessages: vi.fn(),
+      truncateFromUserTurn: vi.fn(),
+      upsertConversation: vi.fn(),
+    };
+    const sendToWebView = vi.fn();
 
-NÂˆ^XÝ
-YÙ[X[˜YÙ\‹˜Ü™X]S™]ÔÙ\ÜÚ[ÛŠKÒ]™P™Y[Ø[YÚ]
-	ËÝÛÜšÜÜXÙIËÂˆ›Ü˜ÙS™]ÎˆYKˆJNÂˆ^XÝ
-Ù[™ÕÙX•šY]ÊKÒ]™P™Y[Ø[YÚ]
-Âˆ\Nˆ	ØÛÛ™\œØ][ÛÛX\™Y	Ëˆ]NˆßKˆJNÂˆJNÂ‚ˆ]
-	Ú[\˜Ù\ÈÙ^Ü[[™\Ù\ÈH”ÐÛÙH^Ü›ÝÈ[œÝXYÙˆÙ[™[™ÈH›Û\	Ë\Þ[˜È
+    const handler = new SessionMessageHandler(
+      agentManager as never,
+      conversationStore as never,
+      'session-1',
+      sendToWebView,
+    );
 
-HOˆÂˆÛÛœÝYÙ[X[˜YÙ\ˆHÂˆ\ÐÛÛ›™XÝYˆYKˆÝ\œ™[Ù\ÜÚ[Û’Yˆ	ÜÙ\ÜÚ[Û‹LIËˆÙ]Ù\ÜÚ[Û“\ÝˆšBˆ™›Š
-Bˆ›[ØÚÔ™\ÛÛ™Y˜[YJÞÈÙ\ÜÚ[Û’Yˆ	ÜÙ\ÜÚ[Û‹LIËÝÙˆ	ËÝÛÜšÜÜXÙIÈWJKˆÙ[™Y\ÜØYÙNˆšK™›Š
-KˆNÂˆÛÛœÝÛÛ™\œØ][Û”ÝÜ™HHÂˆÜ™X]PÛÛ™\œØ][ÛŽˆšK™›Š
-KˆÙ]ÛÛ™\œØ][ÛŽˆšK™›Š
-KˆYY\ÜØYÙNˆšK™›Š
-KˆNÂˆÛÛœÝÙ[™ÕÙX•šY]ÈHšK™›Š
-NÂ‚ˆÛÛœÝ[™\ˆH™]ÈÙ\ÜÚ[Û“Y\ÜØYÙR[™\ŠˆYÙ[X[˜YÙ\ˆ\È™]™\‹ˆÛÛ™\œØ][Û”ÝÜ™H\È™]™\‹ˆ	ÜÙ\ÜÚ[Û‹LIËˆÙ[™ÕÙX•šY]Ëˆ
-NÂ‚ˆ]ØZ][™\‹š[™JÂˆ\Nˆ	ÜÙ[™Y\ÜØYÙIËˆ]NˆÂˆ^ˆ	ËÙ^Ü[	ËˆKˆJNÂ‚ˆ^XÝ
-[ØÚÑ^ÜÙ\ÜÚ[Û•Ñš[JKÒ]™P™Y[Ø[YÚ]
-ÂˆÙ\ÜÚ[Û’Yˆ	ÜÙ\ÜÚ[Û‹LIËˆÝÙˆ	ËÝÛÜšÜÜXÙIËˆ›Ü›X]ˆ	Ú[	ËˆJNÂˆ^XÝ
-ÛÛ™\œØ][Û”ÝÜ™K˜YY\ÜØYÙJK››ÝÒ]™P™Y[Ø[Y
+    await handler.handle({
+      type: 'editMessage',
+      data: {
+        text: 'edited prompt',
+        targetTurnIndex: 1,
+      },
+    });
 
-NÂˆ^XÝ
-YÙ[X[˜YÙ\‹œÙ[™Y\ÜØYÙJK››ÝÒ]™P™Y[Ø[Y
+    expect(conversationStore.truncateFromUserTurn).not.toHaveBeenCalled();
+    expect(agentManager.rewindSession).toHaveBeenCalledWith(1);
+    expect(sendToWebView).toHaveBeenCalledWith({
+      type: 'conversationRewound',
+      data: { targetTurnIndex: 1 },
+    });
+    expect(agentManager.sendMessage).toHaveBeenCalledWith([
+      { type: 'text', text: 'edited prompt' },
+    ]);
+    expect(sendToWebView).not.toHaveBeenCalledWith({
+      type: 'sessionTitleUpdated',
+      data: {
+        sessionId: 'session-1',
+        title: 'edited prompt',
+      },
+    });
+    expect(sendToWebView).not.toHaveBeenCalledWith({
+      type: 'error',
+      data: expect.objectContaining({
+        message: 'Failed to capture conversation state before editing.',
+      }),
+    });
+  });
 
-NÂˆ^XÝ
-Ù[™ÕÙX•šY]ÊKÒ]™P™Y[Ø[YÚ]
-Âˆ\Nˆ	ÛY\ÜØYÙIËˆ]Nˆ^XÝ›Øš™XÝÛÛZ[š[™ÊÂˆ›ÛNˆ	Ø\ÜÚ\Ý[	ËˆÛÛ[‚ˆ	ÔÙ\ÜÚ[Ûˆ^ÜYÈSˆÙ^Üš[Jš[N‹ËËÝÛÜšÜÜXÙKÙ^Üš[
-IËˆJKˆJNÂˆJNÂ‚ˆ]
-	Ü™Y™\œÈHXÝ]™HPÔÙ\ÜÚ[ÛˆYÝ™\ˆHØØ[ÛÛ™\œØ][ÛˆYÚ[ˆ^Ü[™ÉË\Þ[˜È
+  it('recovers a missing edit snapshot from persisted session messages', async () => {
+    mockProcessImageAttachments.mockResolvedValue({
+      formattedText: 'edited prompt',
+      displayText: 'edited prompt',
+      savedImageCount: 0,
+      promptImages: [],
+    });
 
-HOˆÂˆÛÛœÝYÙ[X[˜YÙ\ˆHÂˆ\ÐÛÛ›™XÝYˆYKˆÝ\œ™[Ù\ÜÚ[Û’Yˆ	ÜÙ\ÜÚ[Û‹LIËˆÙ]Ù\ÜÚ[Û“\ÝˆšBˆ™›Š
-Bˆ›[ØÚÔ™\ÛÛ™Y˜[YJÞÈÙ\ÜÚ[Û’Yˆ	ÜÙ\ÜÚ[Û‹LIËÝÙˆ	ËÝÛÜšÜÜXÙIÈWJKˆÙ[™Y\ÜØYÙNˆšK™›Š
-KˆNÂˆÛÛœÝÛÛ™\œØ][Û”ÝÜ™HHÂˆÜ™X]PÛÛ™\œØ][ÛŽˆšK™›Š
-KˆÙ]ÛÛ™\œØ][ÛŽˆšK™›Š
-KˆYY\ÜØYÙNˆšK™›Š
-KˆNÂˆÛÛœÝÙ[™ÕÙX•šY]ÈHšK™›Š
-NÂ‚ˆÛÛœÝ[™\ˆH™]ÈÙ\ÜÚ[Û“Y\ÜØYÙR[™\ŠˆYÙ[X[˜YÙ\ˆ\È™]™\‹ˆÛÛ™\œØ][Û”ÝÜ™H\È™]™\‹ˆ	ØÛÛ—ÛØØ[ÌLŒÉËˆÙ[™ÕÙX•šY]Ëˆ
-NÂ‚ˆ]ØZ][™\‹š[™JÂˆ\Nˆ	ÜÙ[™Y\ÜØYÙIËˆ]NˆÂˆ^ˆ	ËÙ^Ü[	ËˆKˆJNÂ‚ˆ^XÝ
-[ØÚÑ^ÜÙ\ÜÚ[Û•Ñš[JKÒ]™P™Y[Ø[YÚ]
-ÂˆÙ\ÜÚ[Û’Yˆ	ÜÙ\ÜÚ[Û‹LIËˆÝÙˆ	ËÝÛÜšÜÜXÙIËˆ›Ü›X]ˆ	Ú[	ËˆJNÂˆ^XÝ
-YÙ[X[˜YÙ\‹œÙ[™Y\ÜØYÙJK››ÝÒ]™P™Y[Ø[Y
+    const persistedMessages = [
+      { role: 'user' as const, content: 'first', timestamp: 1 },
+      { role: 'assistant' as const, content: 'first reply', timestamp: 2 },
+      { role: 'user' as const, content: 'second', timestamp: 3 },
+    ];
+    const agentManager = {
+      isConnected: true,
+      currentSessionId: 'session-1',
+      rewindSession: vi.fn().mockResolvedValue({
+        historyBeforeRewind: [{ role: 'user', parts: [{ text: 'first' }] }],
+      }),
+      restoreSessionHistory: vi.fn().mockResolvedValue(undefined),
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+      getSessionMessages: vi.fn().mockResolvedValue(persistedMessages),
+    };
+    const conversationStore = {
+      createConversation: vi.fn(),
+      getConversation: vi.fn().mockResolvedValue(null),
+      addMessage: vi.fn(),
+      replaceMessages: vi.fn(),
+      truncateFromUserTurn: vi.fn().mockResolvedValue(true),
+      upsertConversation: vi.fn().mockResolvedValue(undefined),
+    };
+    const sendToWebView = vi.fn();
 
-NÂˆJNÂ‚ˆ]
-	Ü™\ÜÈ˜\™HÙ^Ü\ÈHZ\ÜÚ[™ÈÝX˜ÛÛ[X[™[œÝXYÙˆ^Ü[™ÉË\Þ[˜È
+    const handler = new SessionMessageHandler(
+      agentManager as never,
+      conversationStore as never,
+      'session-1',
+      sendToWebView,
+    );
 
-HOˆÂˆÛÛœÝYÙ[X[˜YÙ\ˆHÂˆ\ÐÛÛ›™XÝYˆYKˆÝ\œ™[Ù\ÜÚ[Û’Yˆ	ÜÙ\ÜÚ[Û‹LIËˆÙ]Ù\ÜÚ[Û“\ÝˆšK™›Š
-KˆÙ[™Y\ÜØYÙNˆšK™›Š
-KˆNÂˆÛÛœÝÛÛ™\œØ][Û”ÝÜ™HHÂˆÜ™X]PÛÛ™\œØ][ÛŽˆšK™›Š
-KˆÙ]ÛÛ™\œØ][ÛŽˆšK™›Š
-KˆYY\ÜØYÙNˆšK™›Š
-KˆNÂˆÛÛœÝÙ[™ÕÙX•šY]ÈHšK™›Š
-NÂ‚ˆÛÛœÝ[™\ˆH™]ÈÙ\ÜÚ[Û“Y\ÜØYÙR[™\ŠˆYÙ[X[˜YÙ\ˆ\È™]™\‹ˆÛÛ™\œØ][Û”ÝÜ™H\È™]™\‹ˆ	ÜÙ\ÜÚ[Û‹LIËˆÙ[™ÕÙX•šY]Ëˆ
-NÂ‚ˆ]ØZ][™\‹š[™JÂˆ\Nˆ	ÜÙ[™Y\ÜØYÙIËˆ]NˆÂˆ^ˆ	ËÙ^Ü	ËˆKˆJNÂ‚ˆ^XÝ
-[ØÚÑ^ÜÙ\ÜÚ[Û•Ñš[JK››ÝÒ]™P™Y[Ø[Y
+    await handler.handle({
+      type: 'editMessage',
+      data: {
+        text: 'edited prompt',
+        targetTurnIndex: 1,
+      },
+    });
 
-NÂˆ^XÝ
-Ù[™ÕÙX•šY]ÊKÒ]™P™Y[Ø[YÚ]
-Âˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙNˆÛÛ[X[™	ËÙ^Ü	È™\]Z\™\ÈHÝX˜ÛÛ[X[™ˆˆKˆJNÂˆ^XÝ
-YÙ[X[˜YÙ\‹œÙ[™Y\ÜØYÙJK››ÝÒ]™P™Y[Ø[Y
+    expect(agentManager.getSessionMessages).toHaveBeenCalledWith('session-1');
+    expect(conversationStore.upsertConversation).toHaveBeenCalledWith({
+      id: 'session-1',
+      title: 'first',
+      messages: persistedMessages,
+      createdAt: 1,
+      updatedAt: 3,
+    });
+    expect(conversationStore.truncateFromUserTurn).toHaveBeenCalledWith(
+      'session-1',
+      1,
+    );
+    expect(agentManager.rewindSession).toHaveBeenCalledWith(1);
+    expect(agentManager.sendMessage).toHaveBeenCalledWith([
+      { type: 'text', text: 'edited prompt' },
+    ]);
+    expect(sendToWebView).not.toHaveBeenCalledWith({
+      type: 'error',
+      data: { message: 'Failed to capture conversation state before editing.' },
+    });
+  });
 
-NÂˆJNÂ‚ˆ]
-	Ü™\ÜÈ^Ü˜Z[\™\È˜XÚÈÈH\Ù\‰Ë\Þ[˜È
+  it('restores the edited conversation snapshot when ACP rewind fails', async () => {
+    mockProcessImageAttachments.mockResolvedValue({
+      formattedText: 'edited prompt',
+      displayText: 'edited prompt',
+      savedImageCount: 0,
+      promptImages: [],
+    });
 
-HOˆÂˆ[ØÚÑ^ÜÙ\ÜÚ[Û•Ñš[K›[ØÚÔ™Z™XÝY˜[YJ™]È\œ›ÜŠ	Ù\ÚÈ[	ÊJNÂ‚ˆÛÛœÝYÙ[X[˜YÙ\ˆHÂˆ\ÐÛÛ›™XÝYˆYKˆÝ\œ™[Ù\ÜÚ[Û’Yˆ	ÜÙ\ÜÚ[Û‹LIËˆÙ]Ù\ÜÚ[Û“\ÝˆšBˆ™›Š
-Bˆ›[ØÚÔ™\ÛÛ™Y˜[YJÞÈÙ\ÜÚ[Û’Yˆ	ÜÙ\ÜÚ[Û‹LIËÝÙˆ	ËÝÛÜšÜÜXÙIÈWJKˆÙ[™Y\ÜØYÙNˆšK™›Š
-KˆNÂˆÛÛœÝÛÛ™\œØ][Û”ÝÜ™HHÂˆÜ™X]PÛÛ™\œØ][ÛŽˆšK™›Š
-KˆÙ]ÛÛ™\œØ][ÛŽˆšK™›Š
-KˆYY\ÜØYÙNˆšK™›Š
-KˆNÂˆÛÛœÝÙ[™ÕÙX•šY]ÈHšK™›Š
-NÂ‚ˆÛÛœÝ[™\ˆH™]ÈÙ\ÜÚ[Û“Y\ÜØYÙR[™\ŠˆYÙ[X[˜YÙ\ˆ\È™]™\‹ˆÛÛ™\œØ][Û”ÝÜ™H\È™]™\‹ˆ	ÜÙ\ÜÚ[Û‹LIËˆÙ[™ÕÙX•šY]Ëˆ
-NÂ‚ˆ]ØZ][™\‹š[™JÂˆ\Nˆ	ÜÙ[™Y\ÜØYÙIËˆ]NˆÂˆ^ˆ	ËÙ^ÜY	ËˆKˆJNÂ‚ˆ^XÝ
-Ù[™ÕÙX•šY]ÊKÒ]™P™Y[Ø[YÚ]
-Âˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙNˆ	Ñ˜Z[YÈ^ÜÙ\ÜÚ[ÛŽˆ\ÚÈ[	ÈKˆJNÂˆ^XÝ
-YÙ[X[˜YÙ\‹œÙ[™Y\ÜØYÙJK››ÝÒ]™P™Y[Ø[Y
+    const originalConversation = {
+      id: 'session-1',
+      title: 'Existing session',
+      messages: [
+        { role: 'user' as const, content: 'first', timestamp: 1 },
+        { role: 'assistant' as const, content: 'first reply', timestamp: 2 },
+        { role: 'user' as const, content: 'second', timestamp: 3 },
+      ],
+      createdAt: 1,
+      updatedAt: 3,
+    };
+    const agentManager = {
+      isConnected: true,
+      currentSessionId: 'session-1',
+      rewindSession: vi.fn().mockRejectedValue(new Error('rewind failed')),
+      restoreSessionHistory: vi.fn(),
+      sendMessage: vi.fn(),
+    };
+    const conversationStore = {
+      createConversation: vi.fn(),
+      getConversation: vi.fn().mockResolvedValue(originalConversation),
+      addMessage: vi.fn(),
+      replaceMessages: vi.fn().mockResolvedValue(true),
+      truncateFromUserTurn: vi.fn().mockResolvedValue(true),
+    };
+    const sendToWebView = vi.fn();
 
-NÂˆJNÂ‚ˆ]
-	Ù[˜ÛÙ\È^ÜYš[H[šÜÈ™Y›Ü™H™[™\š[™ÈX\šÙÝÛ‰Ë\Þ[˜È
+    const handler = new SessionMessageHandler(
+      agentManager as never,
+      conversationStore as never,
+      'session-1',
+      sendToWebView,
+    );
 
-HOˆÂˆ[ØÚÑ^ÜÙ\ÜÚ[Û•Ñš[K›[ØÚÔ™\ÛÛ™Y˜[YJÂˆš[[˜[YNˆ	Ù^ÜJKš[	Ëˆ\šNˆÈœÔ]ˆ	ËÝÛÜšÜÜXÙKÙ^ÜJKš[	ÈKˆJNÂ‚ˆÛÛœÝYÙ[X[˜YÙ\ˆHÂˆ\ÐÛÛ›™XÝYˆYKˆÝ\œ™[Ù\ÜÚ[Û’Yˆ	ÜÙ\ÜÚ[Û‹LIËˆÙ]Ù\ÜÚ[Û“\ÝˆšBˆ™›Š
-Bˆ›[ØÚÔ™\ÛÛ™Y˜[YJÞÈÙ\ÜÚ[Û’Yˆ	ÜÙ\ÜÚ[Û‹LIËÝÙˆ	ËÝÛÜšÜÜXÙIÈWJKˆÙ[™Y\ÜØYÙNˆšK™›Š
-KˆNÂˆÛÛœÝÛÛ™\œØ][Û”ÝÜ™HHÂˆÜ™X]PÛÛ™\œØ][ÛŽˆšK™›Š
-KˆÙ]ÛÛ™\œØ][ÛŽˆšK™›Š
-KˆYY\ÜØYÙNˆšK™›Š
-KˆNÂˆÛÛœÝÙ[™ÕÙX•šY]ÈHšK™›Š
-NÂ‚ˆÛÛœÝ[™\ˆH™]ÈÙ\ÜÚ[Û“Y\ÜØYÙR[™\ŠˆYÙ[X[˜YÙ\ˆ\È™]™\‹ˆÛÛ™\œØ][Û”ÝÜ™H\È™]™\‹ˆ	ÜÙ\ÜÚ[Û‹LIËˆÙ[™ÕÙX•šY]Ëˆ
-NÂ‚ˆ]ØZ][™\‹š[™JÂˆ\Nˆ	ÜÙ[™Y\ÜØYÙIËˆ]NˆÂˆ^ˆ	ËÙ^Ü[	ËˆKˆJNÂ‚ˆ^XÝ
-Ù[™ÕÙX•šY]ÊKÒ]™P™Y[Ø[YÚ]
-Âˆ\Nˆ	ÛY\ÜØYÙIËˆ]Nˆ^XÝ›Øš™XÝÛÛZ[š[™ÊÂˆ›ÛNˆ	Ø\ÜÚ\Ý[	ËˆÛÛ[‚ˆ	ÔÙ\ÜÚ[Ûˆ^ÜYÈSˆÙ^ÜJKš[Jš[N‹ËËÝÛÜšÜÜXÙKÙ^Ü	LŒILŽKš[
-IËˆJKˆJNÂˆJNÂ‚ˆ\ØÜšX™J	Ú[™TÙ][Ù[8 %\ØÛÛ[YY[Ù[Y™[œÚ]™H˜[Y][Ûˆ
-\ÜÝYHÌÍÍJIË
+    await handler.handle({
+      type: 'editMessage',
+      data: {
+        text: 'edited prompt',
+        targetTurnIndex: 1,
+      },
+    });
 
-HOˆÂˆ]
-	Ü™Z™XÝÈH›Û‹\[[YH]Ù[ˆÐ]][Ù[[™Ý\™˜XÙ\È[ˆ\œ›Ü‰Ë\Þ[˜È
+    expect(agentManager.restoreSessionHistory).not.toHaveBeenCalled();
+    expect(conversationStore.replaceMessages).toHaveBeenCalledWith(
+      'session-1',
+      originalConversation.messages,
+    );
+    expect(agentManager.sendMessage).not.toHaveBeenCalled();
+    expect(sendToWebView).toHaveBeenCalledWith({
+      type: 'error',
+      data: { message: 'rewind failed' },
+    });
+  });
 
-HOˆÂˆÛÛœÝÙ][Ù[œ›ÛUZHHšK™›Š
-NÂˆÛÛœÝYÙ[X[˜YÙ\ˆHÂˆ\ÐÛÛ›™XÝYˆYKˆÝ\œ™[Ù\ÜÚ[Û’Yˆ	ÜÙ\ÜÚ[Û‹LIËˆÙ][Ù[œ›ÛUZKˆNÂˆÛÛœÝÙ[™ÕÙX•šY]ÈHšK™›Š
-NÂˆÛÛœÝ[™\ˆH™]ÈÙ\ÜÚ[Û“Y\ÜØYÙR[™\ŠˆYÙ[X[˜YÙ\ˆ\È™]™\‹ˆßH\È™]™\‹ˆ[ˆÙ[™ÕÙX•šY]Ëˆ
-NÂ‚ˆ]ØZ][™\‹š[™JÂˆ\Nˆ	ÜÙ][Ù[	Ëˆ]NˆÈ[Ù[Yˆ	Ü]Ù[ŒËXÛÙ\‹\\Ê]Ù[‹[Ø]]
-IÈKˆJNÂ‚ˆ^XÝ
-Ù][Ù[œ›ÛUZJK››ÝÒ]™P™Y[Ø[Y
+  it('restores store and ACP history when saving the edited user message fails', async () => {
+    mockProcessImageAttachments.mockResolvedValue({
+      formattedText: 'edited prompt',
+      displayText: 'edited prompt',
+      savedImageCount: 0,
+      promptImages: [],
+    });
 
-NÂˆ^XÝ
-[ØÚÔÚÝÑ\œ›Ü“Y\ÜØYÙJKÒ]™P™Y[Ø[YÚ]
-ˆ^XÝœÝš[™ÐÛÛZ[š[™Êˆ	Ô]Ù[ˆÐ]]œ™YHY\ˆØ\È\ØÛÛ[YYÛˆŒ‹LLMIËˆ
-Kˆ
-NÂˆ^XÝ
-Ù[™ÕÙX•šY]ÊKÒ]™P™Y[Ø[YÚ]
-Âˆ\Nˆ	Ù\œ›Ü‰Ëˆ]Nˆ^XÝ›Øš™XÝÛÛZ[š[™ÊÂˆY\ÜØYÙNˆ^XÝœÝš[™ÐÛÛZ[š[™Ê	Ù\ØÛÛ[YY	ÊKˆJKˆJNÂˆJNÂ‚ˆ]
-	Ø[ÝÜÈH[[YH]Ù[ˆÐ]]Û˜\ÚÝÈ\ÜÈ›ÝYÚ	Ë\Þ[˜È
+    const historyBeforeRewind = [{ role: 'user', parts: [{ text: 'first' }] }];
+    const originalConversation = {
+      id: 'session-1',
+      title: 'Existing session',
+      messages: [
+        { role: 'user' as const, content: 'first', timestamp: 1 },
+        { role: 'assistant' as const, content: 'first reply', timestamp: 2 },
+        { role: 'user' as const, content: 'second', timestamp: 3 },
+      ],
+      createdAt: 1,
+      updatedAt: 3,
+    };
+    const agentManager = {
+      isConnected: true,
+      currentSessionId: 'session-1',
+      rewindSession: vi.fn().mockResolvedValue({ historyBeforeRewind }),
+      restoreSessionHistory: vi.fn().mockResolvedValue(undefined),
+      sendMessage: vi.fn(),
+    };
+    const conversationStore = {
+      createConversation: vi.fn(),
+      getConversation: vi.fn().mockResolvedValue(originalConversation),
+      addMessage: vi.fn().mockRejectedValue(new Error('storage failed')),
+      replaceMessages: vi.fn().mockResolvedValue(true),
+      truncateFromUserTurn: vi.fn().mockResolvedValue(true),
+    };
+    const sendToWebView = vi.fn();
 
-HOˆÂˆÛÛœÝÙ][Ù[œ›ÛUZHHšK™›Š
-K›[ØÚÔ™\ÛÛ™Y˜[YJ[™Yš[™Y
-NÂˆÛÛœÝYÙ[X[˜YÙ\ˆHÂˆ\ÐÛÛ›™XÝYˆYKˆÝ\œ™[Ù\ÜÚ[Û’Yˆ	ÜÙ\ÜÚ[Û‹LIËˆÙ][Ù[œ›ÛUZKˆNÂˆÛÛœÝÙ[™ÕÙX•šY]ÈHšK™›Š
-NÂˆÛÛœÝ[™\ˆH™]ÈÙ\ÜÚ[Û“Y\ÜØYÙR[™\ŠˆYÙ[X[˜YÙ\ˆ\È™]™\‹ˆßH\È™]™\‹ˆ[ˆÙ[™ÕÙX•šY]Ëˆ
-NÂ‚ˆ]ØZ][™\‹š[™JÂˆ\Nˆ	ÜÙ][Ù[	Ëˆ]NˆÂˆ[Ù[Yˆ	É[[Y_]Ù[‹[Ø]]]Ù[ŒËXÛÙ\‹\\Ê]Ù[‹[Ø]]
-IËˆKˆJNÂ‚ˆ^XÝ
-Ù][Ù[œ›ÛUZJKÒ]™P™Y[Ø[YÚ]
-ˆ	É[[Y_]Ù[‹[Ø]]]Ù[ŒËXÛÙ\‹\\Ê]Ù[‹[Ø]]
-IËˆ
-NÂˆ^XÝ
-[ØÚÔÚÝÑ\œ›Ü“Y\ÜØYÙJK››ÝÒ]™P™Y[Ø[Y
+    const handler = new SessionMessageHandler(
+      agentManager as never,
+      conversationStore as never,
+      'session-1',
+      sendToWebView,
+    );
 
-NÂˆJNÂ‚ˆ]
-	Ü\ÜÙ\È›ÝYÚÝ\‹\›ÝšY\ˆ[Ù[È
-™YÜ™\ÜÚ[Ûˆ8 %›È˜[ÙHÜÚ]]™\ÊIË\Þ[˜È
+    await handler.handle({
+      type: 'editMessage',
+      data: {
+        text: 'edited prompt',
+        targetTurnIndex: 1,
+      },
+    });
 
-HOˆÂˆÛÛœÝÙ][Ù[œ›ÛUZHHšK™›Š
-K›[ØÚÔ™\ÛÛ™Y˜[YJ[™Yš[™Y
-NÂˆÛÛœÝYÙ[X[˜YÙ\ˆHÂˆ\ÐÛÛ›™XÝYˆYKˆÝ\œ™[Ù\ÜÚ[Û’Yˆ	ÜÙ\ÜÚ[Û‹LIËˆÙ][Ù[œ›ÛUZKˆNÂˆÛÛœÝÙ[™ÕÙX•šY]ÈHšK™›Š
-NÂˆÛÛœÝ[™\ˆH™]ÈÙ\ÜÚ[Û“Y\ÜØYÙR[™\ŠˆYÙ[X[˜YÙ\ˆ\È™]™\‹ˆßH\È™]™\‹ˆ[ˆÙ[™ÕÙX•šY]Ëˆ
-NÂ‚ˆ]ØZ][™\‹š[™JÂˆ\Nˆ	ÜÙ][Ù[	Ëˆ]NˆÈ[Ù[Yˆ	ÙÜM
-Ü[˜ZJIÈKˆJNÂ‚ˆ^XÝ
-Ù][Ù[œ›ÛUZJKÒ]™P™Y[Ø[YÚ]
-	ÙÜM
-Ü[˜ZJIÊNÂˆ^XÝ
-[ØÚÔÚÝÑ\œ›Ü“Y\ÜØYÙJK››ÝÒ]™P™Y[Ø[Y
+    expect(agentManager.restoreSessionHistory).toHaveBeenCalledWith(
+      historyBeforeRewind,
+    );
+    expect(conversationStore.replaceMessages).toHaveBeenCalledWith(
+      'session-1',
+      originalConversation.messages,
+    );
+    expect(agentManager.sendMessage).not.toHaveBeenCalled();
+    expect(sendToWebView).toHaveBeenCalledWith({
+      type: 'error',
+      data: { message: 'storage failed' },
+    });
+  });
 
-NÂˆJNÂˆJNÂˆ]
-	Ü™\Ù\™\ÈHš]™K[]\ˆÛÛÛˆ[ˆÚ[™ÝÜÈ^ÜYš[H[šÜÉË\Þ[˜È
+  it('rejects edit submissions with invalid target turn indexes', async () => {
+    const agentManager = {
+      isConnected: true,
+      currentSessionId: 'session-1',
+      rewindSession: vi.fn(),
+      restoreSessionHistory: vi.fn(),
+      sendMessage: vi.fn(),
+    };
+    const conversationStore = {
+      createConversation: vi.fn(),
+      getConversation: vi.fn(),
+      addMessage: vi.fn(),
+      replaceMessages: vi.fn(),
+      truncateFromUserTurn: vi.fn(),
+    };
+    const sendToWebView = vi.fn();
 
-HOˆÂˆ[ØÚÑ^ÜÙ\ÜÚ[Û•Ñš[K›[ØÚÔ™\ÛÛ™Y˜[YJÂˆš[[˜[YNˆ	Ùš[K›Y	Ëˆ\šNˆÈœÔ]ˆ	Ñ—\ZØXÚ˜Wš[K›Y	ÈKˆJNÂ‚ˆÛÛœÝYÙ[X[˜YÙ\ˆHÂˆ\ÐÛÛ›™XÝYˆYKˆÝ\œ™[Ù\ÜÚ[Û’Yˆ	ÜÙ\ÜÚ[Û‹LIËˆÙ]Ù\ÜÚ[Û“\ÝˆšBˆ™›Š
-Bˆ›[ØÚÔ™\ÛÛ™Y˜[YJÞÈÙ\ÜÚ[Û’Yˆ	ÜÙ\ÜÚ[Û‹LIËÝÙˆ	ËÝÛÜšÜÜXÙIÈWJKˆÙ[™Y\ÜØYÙNˆšK™›Š
-KˆNÂˆÛÛœÝÛÛ™\œØ][Û”ÝÜ™HHÂˆÜ™X]PÛÛ™\œØ][ÛŽˆšK™›Š
-KˆÙ]ÛÛ™\œØ][ÛŽˆšK™›Š
-KˆYY\ÜØYÙNˆšK™›Š
-KˆNÂˆÛÛœÝÙ[™ÕÙX•šY]ÈHšK™›Š
-NÂ‚ˆÛÛœÝ[™\ˆH™]ÈÙ\ÜÚ[Û“Y\ÜØYÙR[™\ŠˆYÙ[X[˜YÙ\ˆ\È™]™\‹ˆÛÛ™\œØ][Û”ÝÜ™H\È™]™\‹ˆ	ÜÙ\ÜÚ[Û‹LIËˆÙ[™ÕÙX•šY]Ëˆ
-NÂ‚ˆ]ØZ][™\‹š[™JÂˆ\Nˆ	ÜÙ[™Y\ÜØYÙIËˆ]NˆÂˆ^ˆ	ËÙ^ÜY	ËˆKˆJNÂ‚ˆ^XÝ
-Ù[™ÕÙX•šY]ÊKÒ]™P™Y[Ø[YÚ]
-Âˆ\Nˆ	ÛY\ÜØYÙIËˆ]Nˆ^XÝ›Øš™XÝÛÛZ[š[™ÊÂˆ›ÛNˆ	Ø\ÜÚ\Ý[	ËˆÛÛ[‚ˆ	ÔÙ\ÜÚ[Ûˆ^ÜYÈQˆÙš[K›YJš[N‹ËËÑ‹Ø\ZØXÚ˜KÙš[K›Y
-IËˆJKˆJNÂˆJNÂŸJNÂ
+    const handler = new SessionMessageHandler(
+      agentManager as never,
+      conversationStore as never,
+      'session-1',
+      sendToWebView,
+    );
+
+    await handler.handle({
+      type: 'editMessage',
+      data: {
+        text: 'edited prompt',
+        targetTurnIndex: -1,
+      },
+    });
+
+    expect(agentManager.rewindSession).not.toHaveBeenCalled();
+    expect(agentManager.sendMessage).not.toHaveBeenCalled();
+    expect(conversationStore.truncateFromUserTurn).not.toHaveBeenCalled();
+    expect(sendToWebView).toHaveBeenCalledWith({
+      type: 'error',
+      data: { message: 'Invalid message edit target.' },
+    });
+  });
+
+  it('keeps currentConversationId aligned with the archived sessionId when session/load falls back to a new ACP session', async () => {
+    const archivedSessionId = 'archived-session';
+    const agentManager = {
+      isConnected: true,
+      currentSessionId: 'old-acp-session',
+      getSessionList: vi
+        .fn()
+        .mockResolvedValue([{ id: archivedSessionId, cwd: '/workspace' }]),
+      loadSessionViaAcp: vi
+        .fn()
+        .mockRejectedValue(new Error('session not found on server')),
+      getSessionMessages: vi.fn().mockResolvedValue([]),
+      createNewSession: vi.fn().mockResolvedValue('new-acp-session'),
+    };
+    const conversationStore = {
+      createConversation: vi.fn(),
+      getConversation: vi.fn(),
+      addMessage: vi.fn(),
+    };
+    const sendToWebView = vi.fn();
+
+    const handler = new SessionMessageHandler(
+      agentManager as never,
+      conversationStore as never,
+      null,
+      sendToWebView,
+    );
+
+    await handler.handle({
+      type: 'switchQwenSession',
+      data: { sessionId: archivedSessionId },
+    });
+
+    // Backend-tracked current session must match the sessionId the webview sees,
+    // otherwise rename/delete/title-update flows will target the wrong session
+    // during the fallback window (see PR #3093 review).
+    expect(handler.getCurrentConversationId()).toBe(archivedSessionId);
+    expect(agentManager.createNewSession).toHaveBeenCalled();
+    expect(sendToWebView).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'qwenSessionSwitched',
+        data: expect.objectContaining({ sessionId: archivedSessionId }),
+      }),
+    );
+  });
+
+  it('forces a fresh ACP session when the webview requests a new session', async () => {
+    const agentManager = {
+      isConnected: true,
+      currentSessionId: 'session-1',
+      createNewSession: vi.fn().mockResolvedValue('session-2'),
+    };
+    const conversationStore = {
+      createConversation: vi.fn(),
+      getConversation: vi.fn(),
+      addMessage: vi.fn(),
+    };
+    const sendToWebView = vi.fn();
+
+    const handler = new SessionMessageHandler(
+      agentManager as never,
+      conversationStore as never,
+      'conversation-1',
+      sendToWebView,
+    );
+
+    await handler.handle({
+      type: 'newQwenSession',
+    });
+
+    expect(handler.getCurrentConversationId()).toBeNull();
+    expect(agentManager.createNewSession).toHaveBeenCalledWith('/workspace', {
+      forceNew: true,
+    });
+    expect(sendToWebView).toHaveBeenCalledWith({
+      type: 'conversationCleared',
+      data: {},
+    });
+  });
+
+  it('intercepts /export html and uses the VSCode export flow instead of sending a prompt', async () => {
+    const agentManager = {
+      isConnected: true,
+      currentSessionId: 'session-1',
+      getSessionList: vi
+        .fn()
+        .mockResolvedValue([{ sessionId: 'session-1', cwd: '/workspace' }]),
+      sendMessage: vi.fn(),
+    };
+    const conversationStore = {
+      createConversation: vi.fn(),
+      getConversation: vi.fn(),
+      addMessage: vi.fn(),
+    };
+    const sendToWebView = vi.fn();
+
+    const handler = new SessionMessageHandler(
+      agentManager as never,
+      conversationStore as never,
+      'session-1',
+      sendToWebView,
+    );
+
+    await handler.handle({
+      type: 'sendMessage',
+      data: {
+        text: '/export html',
+      },
+    });
+
+    expect(mockExportSessionToFile).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      cwd: '/workspace',
+      format: 'html',
+    });
+    expect(conversationStore.addMessage).not.toHaveBeenCalled();
+    expect(agentManager.sendMessage).not.toHaveBeenCalled();
+    expect(sendToWebView).toHaveBeenCalledWith({
+      type: 'message',
+      data: expect.objectContaining({
+        role: 'assistant',
+        content:
+          'Session exported to HTML: [export.html](file:///workspace/export.html)',
+      }),
+    });
+  });
+
+  it('prefers the active ACP session id over the local conversation id when exporting', async () => {
+    const agentManager = {
+      isConnected: true,
+      currentSessionId: 'session-1',
+      getSessionList: vi
+        .fn()
+        .mockResolvedValue([{ sessionId: 'session-1', cwd: '/workspace' }]),
+      sendMessage: vi.fn(),
+    };
+    const conversationStore = {
+      createConversation: vi.fn(),
+      getConversation: vi.fn(),
+      addMessage: vi.fn(),
+    };
+    const sendToWebView = vi.fn();
+
+    const handler = new SessionMessageHandler(
+      agentManager as never,
+      conversationStore as never,
+      'conv_local_123',
+      sendToWebView,
+    );
+
+    await handler.handle({
+      type: 'sendMessage',
+      data: {
+        text: '/export html',
+      },
+    });
+
+    expect(mockExportSessionToFile).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      cwd: '/workspace',
+      format: 'html',
+    });
+    expect(agentManager.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('reports bare /export as a missing subcommand instead of exporting', async () => {
+    const agentManager = {
+      isConnected: true,
+      currentSessionId: 'session-1',
+      getSessionList: vi.fn(),
+      sendMessage: vi.fn(),
+    };
+    const conversationStore = {
+      createConversation: vi.fn(),
+      getConversation: vi.fn(),
+      addMessage: vi.fn(),
+    };
+    const sendToWebView = vi.fn();
+
+    const handler = new SessionMessageHandler(
+      agentManager as never,
+      conversationStore as never,
+      'session-1',
+      sendToWebView,
+    );
+
+    await handler.handle({
+      type: 'sendMessage',
+      data: {
+        text: '/export',
+      },
+    });
+
+    expect(mockExportSessionToFile).not.toHaveBeenCalled();
+    expect(sendToWebView).toHaveBeenCalledWith({
+      type: 'error',
+      data: { message: "Command '/export' requires a subcommand." },
+    });
+    expect(agentManager.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('reports export failures back to the user', async () => {
+    mockExportSessionToFile.mockRejectedValue(new Error('disk full'));
+
+    const agentManager = {
+      isConnected: true,
+      currentSessionId: 'session-1',
+      getSessionList: vi
+        .fn()
+        .mockResolvedValue([{ sessionId: 'session-1', cwd: '/workspace' }]),
+      sendMessage: vi.fn(),
+    };
+    const conversationStore = {
+      createConversation: vi.fn(),
+      getConversation: vi.fn(),
+      addMessage: vi.fn(),
+    };
+    const sendToWebView = vi.fn();
+
+    const handler = new SessionMessageHandler(
+      agentManager as never,
+      conversationStore as never,
+      'session-1',
+      sendToWebView,
+    );
+
+    await handler.handle({
+      type: 'sendMessage',
+      data: {
+        text: '/export md',
+      },
+    });
+
+    expect(sendToWebView).toHaveBeenCalledWith({
+      type: 'error',
+      data: { message: 'Failed to export session: disk full' },
+    });
+    expect(agentManager.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('encodes exported file links before rendering markdown', async () => {
+    mockExportSessionToFile.mockResolvedValue({
+      filename: 'export a).html',
+      uri: { fsPath: '/workspace/export a).html' },
+    });
+
+    const agentManager = {
+      isConnected: true,
+      currentSessionId: 'session-1',
+      getSessionList: vi
+        .fn()
+        .mockResolvedValue([{ sessionId: 'session-1', cwd: '/workspace' }]),
+      sendMessage: vi.fn(),
+    };
+    const conversationStore = {
+      createConversation: vi.fn(),
+      getConversation: vi.fn(),
+      addMessage: vi.fn(),
+    };
+    const sendToWebView = vi.fn();
+
+    const handler = new SessionMessageHandler(
+      agentManager as never,
+      conversationStore as never,
+      'session-1',
+      sendToWebView,
+    );
+
+    await handler.handle({
+      type: 'sendMessage',
+      data: {
+        text: '/export html',
+      },
+    });
+
+    expect(sendToWebView).toHaveBeenCalledWith({
+      type: 'message',
+      data: expect.objectContaining({
+        role: 'assistant',
+        content:
+          'Session exported to HTML: [export a).html](file:///workspace/export%20a%29.html)',
+      }),
+    });
+  });
+
+  describe('handleSetModel â€” discontinued model defensive validation (Issue #3745)', () => {
+    it('rejects a non-runtime Qwen OAuth model and surfaces an error', async () => {
+      const setModelFromUi = vi.fn();
+      const agentManager = {
+        isConnected: true,
+        currentSessionId: 'session-1',
+        setModelFromUi,
+      };
+      const sendToWebView = vi.fn();
+      const handler = new SessionMessageHandler(
+        agentManager as never,
+        {} as never,
+        null,
+        sendToWebView,
+      );
+
+      await handler.handle({
+        type: 'setModel',
+        data: { modelId: 'qwen3-coder-plus(qwen-oauth)' },
+      });
+
+      expect(setModelFromUi).not.toHaveBeenCalled();
+      expect(mockShowErrorMessage).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Qwen OAuth free tier was discontinued on 2026-04-15',
+        ),
+      );
+      expect(sendToWebView).toHaveBeenCalledWith({
+        type: 'error',
+        data: expect.objectContaining({
+          message: expect.stringContaining('discontinued'),
+        }),
+      });
+    });
+
+    it('allows a runtime Qwen OAuth snapshot to pass through', async () => {
+      const setModelFromUi = vi.fn().mockResolvedValue(undefined);
+      const agentManager = {
+        isConnected: true,
+        currentSessionId: 'session-1',
+        setModelFromUi,
+      };
+      const sendToWebView = vi.fn();
+      const handler = new SessionMessageHandler(
+        agentManager as never,
+        {} as never,
+        null,
+        sendToWebView,
+      );
+
+      await handler.handle({
+        type: 'setModel',
+        data: {
+          modelId: '$runtime|qwen-oauth|qwen3-coder-plus(qwen-oauth)',
+        },
+      });
+
+      expect(setModelFromUi).toHaveBeenCalledWith(
+        '$runtime|qwen-oauth|qwen3-coder-plus(qwen-oauth)',
+      );
+      expect(mockShowErrorMessage).not.toHaveBeenCalled();
+    });
+
+    it('passes through other-provider models (regression â€” no false positives)', async () => {
+      const setModelFromUi = vi.fn().mockResolvedValue(undefined);
+      const agentManager = {
+        isConnected: true,
+        currentSessionId: 'session-1',
+        setModelFromUi,
+      };
+      const sendToWebView = vi.fn();
+      const handler = new SessionMessageHandler(
+        agentManager as never,
+        {} as never,
+        null,
+        sendToWebView,
+      );
+
+      await handler.handle({
+        type: 'setModel',
+        data: { modelId: 'gpt-4(openai)' },
+      });
+
+      expect(setModelFromUi).toHaveBeenCalledWith('gpt-4(openai)');
+      expect(mockShowErrorMessage).not.toHaveBeenCalled();
+    });
+  });
+  it('preserves the drive-letter colon in Windows exported file links', async () => {
+    mockExportSessionToFile.mockResolvedValue({
+      filename: 'file.md',
+      uri: { fsPath: 'D:\\aplikacja\\file.md' },
+    });
+
+    const agentManager = {
+      isConnected: true,
+      currentSessionId: 'session-1',
+      getSessionList: vi
+        .fn()
+        .mockResolvedValue([{ sessionId: 'session-1', cwd: '/workspace' }]),
+      sendMessage: vi.fn(),
+    };
+    const conversationStore = {
+      createConversation: vi.fn(),
+      getConversation: vi.fn(),
+      addMessage: vi.fn(),
+    };
+    const sendToWebView = vi.fn();
+
+    const handler = new SessionMessageHandler(
+      agentManager as never,
+      conversationStore as never,
+      'session-1',
+      sendToWebView,
+    );
+
+    await handler.handle({
+      type: 'sendMessage',
+      data: {
+        text: '/export md',
+      },
+    });
+
+    expect(sendToWebView).toHaveBeenCalledWith({
+      type: 'message',
+      data: expect.objectContaining({
+        role: 'assistant',
+        content:
+          'Session exported to MD: [file.md](file:///D:/aplikacja/file.md)',
+      }),
+    });
+  });
+});

--- a/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.test.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.test.ts
@@ -41,6 +41,22 @@ vi.mock('vscode', () => ({
   },
 }));
 
+vi.mock('node:url', async () => {
+  const actual = await vi.importActual<typeof import('node:url')>('node:url');
+  return {
+    ...actual,
+    pathToFileURL: (filePath: string) => {
+      if (
+        process.platform !== 'win32' &&
+        filePath === 'D:\\aplikacja\\file.md'
+      ) {
+        return actual.pathToFileURL(filePath, { windows: true });
+      }
+      return actual.pathToFileURL(filePath);
+    },
+  };
+});
+
 vi.mock('../utils/imageHandler.js', async (importOriginal) => {
   const actual =
     await importOriginal<typeof import('../utils/imageHandler.js')>();
@@ -1314,6 +1330,50 @@ describe('SessionMessageHandler', () => {
 
       expect(setModelFromUi).toHaveBeenCalledWith('gpt-4(openai)');
       expect(mockShowErrorMessage).not.toHaveBeenCalled();
+    });
+  });
+  it('preserves the drive-letter colon in Windows exported file links', async () => {
+    mockExportSessionToFile.mockResolvedValue({
+      filename: 'file.md',
+      uri: { fsPath: 'D:\\aplikacja\\file.md' },
+    });
+
+    const agentManager = {
+      isConnected: true,
+      currentSessionId: 'session-1',
+      getSessionList: vi
+        .fn()
+        .mockResolvedValue([{ sessionId: 'session-1', cwd: '/workspace' }]),
+      sendMessage: vi.fn(),
+    };
+    const conversationStore = {
+      createConversation: vi.fn(),
+      getConversation: vi.fn(),
+      addMessage: vi.fn(),
+    };
+    const sendToWebView = vi.fn();
+
+    const handler = new SessionMessageHandler(
+      agentManager as never,
+      conversationStore as never,
+      'session-1',
+      sendToWebView,
+    );
+
+    await handler.handle({
+      type: 'sendMessage',
+      data: {
+        text: '/export md',
+      },
+    });
+
+    expect(sendToWebView).toHaveBeenCalledWith({
+      type: 'message',
+      data: expect.objectContaining({
+        role: 'assistant',
+        content:
+          'Session exported to MD: [file.md](file:///D:/aplikacja/file.md)',
+      }),
     });
   });
 });

--- a/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.test.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.test.ts
@@ -46,10 +46,7 @@ vi.mock('node:url', async () => {
   return {
     ...actual,
     pathToFileURL: (filePath: string) => {
-      if (
-        process.platform !== 'win32' &&
-        filePath === 'D:\\aplikacja\\file.md'
-      ) {
+      if (process.platform !== 'win32' && /^[a-zA-Z]:\\/.test(filePath)) {
         return actual.pathToFileURL(filePath, { windows: true });
       }
       return actual.pathToFileURL(filePath);
@@ -525,855 +522,235 @@ describe('SessionMessageHandler', () => {
     const agentManager = {
       isConnected: true,
       currentSessionId: 'session-1',
-      rewindSession: vi.fn().mockResolvedValue({
-        historyBeforeRewind: [{ role: 'user', parts: [{ text: 'first' }] }],
-      }),
-      restoreSessionHistory: vi.fn().mockResolvedValue(undefined),
-      sendMessage: vi.fn().mockResolvedValue(undefined),
-    };
-    const conversationStore = {
-      createConversation: vi.fn(),
-      getConversation: vi.fn().mockResolvedValue({
-        id: 'session-1',
-        title: 'Existing session',
-        messages: [
-          { role: 'user', content: 'first', timestamp: 1 },
-          { role: 'assistant', content: 'first reply', timestamp: 2 },
-          { role: 'user', content: 'second', timestamp: 3 },
-        ],
-        createdAt: 1,
-        updatedAt: 3,
-      }),
-      addMessage: vi.fn(),
-      replaceMessages: vi.fn().mockResolvedValue(true),
-      truncateFromUserTurn: vi.fn().mockResolvedValue(true),
-    };
-    const sendToWebView = vi.fn();
-
-    const handler = new SessionMessageHandler(
-      agentManager as never,
-      conversationStore as never,
-      'session-1',
-      sendToWebView,
-    );
-
-    await handler.handle({
-      type: 'editMessage',
-      data: {
-        text: 'edited prompt',
-        targetTurnIndex: 1,
-      },
-    });
-
-    expect(agentManager.rewindSession).toHaveBeenCalledWith(1);
-    expect(conversationStore.truncateFromUserTurn).toHaveBeenCalledWith(
-      'session-1',
-      1,
-    );
-    expect(sendToWebView).toHaveBeenCalledWith({
-      type: 'conversationRewound',
-      data: { targetTurnIndex: 1 },
-    });
-    expect(agentManager.sendMessage).toHaveBeenCalledWith([
-      { type: 'text', text: 'edited prompt' },
-    ]);
-    expect(
-      conversationStore.truncateFromUserTurn.mock.invocationCallOrder[0],
-    ).toBeLessThan(agentManager.rewindSession.mock.invocationCallOrder[0]);
-    expect(agentManager.rewindSession.mock.invocationCallOrder[0]).toBeLessThan(
-      agentManager.sendMessage.mock.invocationCallOrder[0],
-    );
-  });
-
-  it('restores the edited conversation snapshot when replacement send fails', async () => {
-    mockProcessImageAttachments.mockResolvedValue({
-      formattedText: 'edited prompt',
-      displayText: 'edited prompt',
-      savedImageCount: 0,
-      promptImages: [],
-    });
-
-    const originalConversation = {
-      id: 'session-1',
-      title: 'Existing session',
-      messages: [
-        { role: 'user' as const, content: 'first', timestamp: 1 },
-        { role: 'assistant' as const, content: 'first reply', timestamp: 2 },
-        { role: 'user' as const, content: 'second', timestamp: 3 },
-        { role: 'assistant' as const, content: 'second reply', timestamp: 4 },
-      ],
-      createdAt: 1,
-      updatedAt: 4,
-    };
-    const agentManager = {
-      isConnected: true,
-      currentSessionId: 'session-1',
-      rewindSession: vi.fn().mockResolvedValue({
-        historyBeforeRewind: [{ role: 'user', parts: [{ text: 'first' }] }],
-      }),
-      restoreSessionHistory: vi.fn().mockResolvedValue(undefined),
-      sendMessage: vi.fn().mockRejectedValue(new Error('send failed')),
-    };
-    const conversationStore = {
-      createConversation: vi.fn(),
-      getConversation: vi.fn().mockResolvedValue(originalConversation),
-      addMessage: vi.fn(),
-      replaceMessages: vi.fn().mockResolvedValue(true),
-      truncateFromUserTurn: vi.fn().mockResolvedValue(true),
-    };
-    const sendToWebView = vi.fn();
-
-    const handler = new SessionMessageHandler(
-      agentManager as never,
-      conversationStore as never,
-      'session-1',
-      sendToWebView,
-    );
-
-    await handler.handle({
-      type: 'editMessage',
-      data: {
-        text: 'edited prompt',
-        targetTurnIndex: 1,
-      },
-    });
-
-    expect(agentManager.restoreSessionHistory).toHaveBeenCalledWith([
-      { role: 'user', parts: [{ text: 'first' }] },
-    ]);
-    expect(conversationStore.replaceMessages).toHaveBeenCalledWith(
-      'session-1',
-      originalConversation.messages,
-    );
-    expect(sendToWebView).toHaveBeenCalledWith({
-      type: 'conversationLoaded',
-      data: originalConversation,
-    });
-    expect(sendToWebView).toHaveBeenCalledWith({
-      type: 'error',
-      data: { message: 'send failed' },
-    });
-  });
-
-  it('continues edits with ACP-only rewind when no local snapshot exists', async () => {
-    mockProcessImageAttachments.mockResolvedValue({
-      formattedText: 'edited prompt',
-      displayText: 'edited prompt',
-      savedImageCount: 0,
-      promptImages: [],
-    });
-
-    const agentManager = {
-      isConnected: true,
-      currentSessionId: 'session-1',
-      rewindSession: vi.fn().mockResolvedValue({
-        historyBeforeRewind: [{ role: 'user', parts: [{ text: 'first' }] }],
-      }),
-      restoreSessionHistory: vi.fn(),
-      sendMessage: vi.fn().mockResolvedValue(undefined),
-      getSessionMessages: vi.fn().mockResolvedValue([]),
-    };
-    const conversationStore = {
-      createConversation: vi.fn(),
-      getConversation: vi.fn().mockResolvedValue(null),
-      addMessage: vi.fn(),
-      replaceMessages: vi.fn(),
-      truncateFromUserTurn: vi.fn(),
-      upsertConversation: vi.fn(),
-    };
-    const sendToWebView = vi.fn();
-
-    const handler = new SessionMessageHandler(
-      agentManager as never,
-      conversationStore as never,
-      'session-1',
-      sendToWebView,
-    );
-
-    await handler.handle({
-      type: 'editMessage',
-      data: {
-        text: 'edited prompt',
-        targetTurnIndex: 1,
-      },
-    });
-
-    expect(conversationStore.truncateFromUserTurn).not.toHaveBeenCalled();
-    expect(agentManager.rewindSession).toHaveBeenCalledWith(1);
-    expect(sendToWebView).toHaveBeenCalledWith({
-      type: 'conversationRewound',
-      data: { targetTurnIndex: 1 },
-    });
-    expect(agentManager.sendMessage).toHaveBeenCalledWith([
-      { type: 'text', text: 'edited prompt' },
-    ]);
-    expect(sendToWebView).not.toHaveBeenCalledWith({
-      type: 'sessionTitleUpdated',
-      data: {
-        sessionId: 'session-1',
-        title: 'edited prompt',
-      },
-    });
-    expect(sendToWebView).not.toHaveBeenCalledWith({
-      type: 'error',
-      data: expect.objectContaining({
-        message: 'Failed to capture conversation state before editing.',
-      }),
-    });
-  });
-
-  it('recovers a missing edit snapshot from persisted session messages', async () => {
-    mockProcessImageAttachments.mockResolvedValue({
-      formattedText: 'edited prompt',
-      displayText: 'edited prompt',
-      savedImageCount: 0,
-      promptImages: [],
-    });
-
-    const persistedMessages = [
-      { role: 'user' as const, content: 'first', timestamp: 1 },
-      { role: 'assistant' as const, content: 'first reply', timestamp: 2 },
-      { role: 'user' as const, content: 'second', timestamp: 3 },
-    ];
-    const agentManager = {
-      isConnected: true,
-      currentSessionId: 'session-1',
-      rewindSession: vi.fn().mockResolvedValue({
-        historyBeforeRewind: [{ role: 'user', parts: [{ text: 'first' }] }],
-      }),
-      restoreSessionHistory: vi.fn().mockResolvedValue(undefined),
-      sendMessage: vi.fn().mockResolvedValue(undefined),
-      getSessionMessages: vi.fn().mockResolvedValue(persistedMessages),
-    };
-    const conversationStore = {
-      createConversation: vi.fn(),
-      getConversation: vi.fn().mockResolvedValue(null),
-      addMessage: vi.fn(),
-      replaceMessages: vi.fn(),
-      truncateFromUserTurn: vi.fn().mockResolvedValue(true),
-      upsertConversation: vi.fn().mockResolvedValue(undefined),
-    };
-    const sendToWebView = vi.fn();
-
-    const handler = new SessionMessageHandler(
-      agentManager as never,
-      conversationStore as never,
-      'session-1',
-      sendToWebView,
-    );
-
-    await handler.handle({
-      type: 'editMessage',
-      data: {
-        text: 'edited prompt',
-        targetTurnIndex: 1,
-      },
-    });
-
-    expect(agentManager.getSessionMessages).toHaveBeenCalledWith('session-1');
-    expect(conversationStore.upsertConversation).toHaveBeenCalledWith({
-      id: 'session-1',
-      title: 'first',
-      messages: persistedMessages,
-      createdAt: 1,
-      updatedAt: 3,
-    });
-    expect(conversationStore.truncateFromUserTurn).toHaveBeenCalledWith(
-      'session-1',
-      1,
-    );
-    expect(agentManager.rewindSession).toHaveBeenCalledWith(1);
-    expect(agentManager.sendMessage).toHaveBeenCalledWith([
-      { type: 'text', text: 'edited prompt' },
-    ]);
-    expect(sendToWebView).not.toHaveBeenCalledWith({
-      type: 'error',
-      data: { message: 'Failed to capture conversation state before editing.' },
-    });
-  });
-
-  it('restores the edited conversation snapshot when ACP rewind fails', async () => {
-    mockProcessImageAttachments.mockResolvedValue({
-      formattedText: 'edited prompt',
-      displayText: 'edited prompt',
-      savedImageCount: 0,
-      promptImages: [],
-    });
-
-    const originalConversation = {
-      id: 'session-1',
-      title: 'Existing session',
-      messages: [
-        { role: 'user' as const, content: 'first', timestamp: 1 },
-        { role: 'assistant' as const, content: 'first reply', timestamp: 2 },
-        { role: 'user' as const, content: 'second', timestamp: 3 },
-      ],
-      createdAt: 1,
-      updatedAt: 3,
-    };
-    const agentManager = {
-      isConnected: true,
-      currentSessionId: 'session-1',
-      rewindSession: vi.fn().mockRejectedValue(new Error('rewind failed')),
-      restoreSessionHistory: vi.fn(),
-      sendMessage: vi.fn(),
-    };
-    const conversationStore = {
-      createConversation: vi.fn(),
-      getConversation: vi.fn().mockResolvedValue(originalConversation),
-      addMessage: vi.fn(),
-      replaceMessages: vi.fn().mockResolvedValue(true),
-      truncateFromUserTurn: vi.fn().mockResolvedValue(true),
-    };
-    const sendToWebView = vi.fn();
-
-    const handler = new SessionMessageHandler(
-      agentManager as never,
-      conversationStore as never,
-      'session-1',
-      sendToWebView,
-    );
-
-    await handler.handle({
-      type: 'editMessage',
-      data: {
-        text: 'edited prompt',
-        targetTurnIndex: 1,
-      },
-    });
-
-    expect(agentManager.restoreSessionHistory).not.toHaveBeenCalled();
-    expect(conversationStore.replaceMessages).toHaveBeenCalledWith(
-      'session-1',
-      originalConversation.messages,
-    );
-    expect(agentManager.sendMessage).not.toHaveBeenCalled();
-    expect(sendToWebView).toHaveBeenCalledWith({
-      type: 'error',
-      data: { message: 'rewind failed' },
-    });
-  });
-
-  it('restores store and ACP history when saving the edited user message fails', async () => {
-    mockProcessImageAttachments.mockResolvedValue({
-      formattedText: 'edited prompt',
-      displayText: 'edited prompt',
-      savedImageCount: 0,
-      promptImages: [],
-    });
-
-    const historyBeforeRewind = [{ role: 'user', parts: [{ text: 'first' }] }];
-    const originalConversation = {
-      id: 'session-1',
-      title: 'Existing session',
-      messages: [
-        { role: 'user' as const, content: 'first', timestamp: 1 },
-        { role: 'assistant' as const, content: 'first reply', timestamp: 2 },
-        { role: 'user' as const, content: 'second', timestamp: 3 },
-      ],
-      createdAt: 1,
-      updatedAt: 3,
-    };
-    const agentManager = {
-      isConnected: true,
-      currentSessionId: 'session-1',
-      rewindSession: vi.fn().mockResolvedValue({ historyBeforeRewind }),
-      restoreSessionHistory: vi.fn().mockResolvedValue(undefined),
-      sendMessage: vi.fn(),
-    };
-    const conversationStore = {
-      createConversation: vi.fn(),
-      getConversation: vi.fn().mockResolvedValue(originalConversation),
-      addMessage: vi.fn().mockRejectedValue(new Error('storage failed')),
-      replaceMessages: vi.fn().mockResolvedValue(true),
-      truncateFromUserTurn: vi.fn().mockResolvedValue(true),
-    };
-    const sendToWebView = vi.fn();
-
-    const handler = new SessionMessageHandler(
-      agentManager as never,
-      conversationStore as never,
-      'session-1',
-      sendToWebView,
-    );
-
-    await handler.handle({
-      type: 'editMessage',
-      data: {
-        text: 'edited prompt',
-        targetTurnIndex: 1,
-      },
-    });
-
-    expect(agentManager.restoreSessionHistory).toHaveBeenCalledWith(
-      historyBeforeRewind,
-    );
-    expect(conversationStore.replaceMessages).toHaveBeenCalledWith(
-      'session-1',
-      originalConversation.messages,
-    );
-    expect(agentManager.sendMessage).not.toHaveBeenCalled();
-    expect(sendToWebView).toHaveBeenCalledWith({
-      type: 'error',
-      data: { message: 'storage failed' },
-    });
-  });
-
-  it('rejects edit submissions with invalid target turn indexes', async () => {
-    const agentManager = {
-      isConnected: true,
-      currentSessionId: 'session-1',
-      rewindSession: vi.fn(),
-      restoreSessionHistory: vi.fn(),
-      sendMessage: vi.fn(),
-    };
-    const conversationStore = {
-      createConversation: vi.fn(),
-      getConversation: vi.fn(),
-      addMessage: vi.fn(),
-      replaceMessages: vi.fn(),
-      truncateFromUserTurn: vi.fn(),
-    };
-    const sendToWebView = vi.fn();
-
-    const handler = new SessionMessageHandler(
-      agentManager as never,
-      conversationStore as never,
-      'session-1',
-      sendToWebView,
-    );
-
-    await handler.handle({
-      type: 'editMessage',
-      data: {
-        text: 'edited prompt',
-        targetTurnIndex: -1,
-      },
-    });
-
-    expect(agentManager.rewindSession).not.toHaveBeenCalled();
-    expect(agentManager.sendMessage).not.toHaveBeenCalled();
-    expect(conversationStore.truncateFromUserTurn).not.toHaveBeenCalled();
-    expect(sendToWebView).toHaveBeenCalledWith({
-      type: 'error',
-      data: { message: 'Invalid message edit target.' },
-    });
-  });
-
-  it('keeps currentConversationId aligned with the archived sessionId when session/load falls back to a new ACP session', async () => {
-    const archivedSessionId = 'archived-session';
-    const agentManager = {
-      isConnected: true,
-      currentSessionId: 'old-acp-session',
-      getSessionList: vi
-        .fn()
-        .mockResolvedValue([{ id: archivedSessionId, cwd: '/workspace' }]),
-      loadSessionViaAcp: vi
-        .fn()
-        .mockRejectedValue(new Error('session not found on server')),
-      getSessionMessages: vi.fn().mockResolvedValue([]),
-      createNewSession: vi.fn().mockResolvedValue('new-acp-session'),
-    };
-    const conversationStore = {
-      createConversation: vi.fn(),
-      getConversation: vi.fn(),
-      addMessage: vi.fn(),
-    };
-    const sendToWebView = vi.fn();
-
-    const handler = new SessionMessageHandler(
-      agentManager as never,
-      conversationStore as never,
-      null,
-      sendToWebView,
-    );
-
-    await handler.handle({
-      type: 'switchQwenSession',
-      data: { sessionId: archivedSessionId },
-    });
-
-    // Backend-tracked current session must match the sessionId the webview sees,
-    // otherwise rename/delete/title-update flows will target the wrong session
-    // during the fallback window (see PR #3093 review).
-    expect(handler.getCurrentConversationId()).toBe(archivedSessionId);
-    expect(agentManager.createNewSession).toHaveBeenCalled();
-    expect(sendToWebView).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'qwenSessionSwitched',
-        data: expect.objectContaining({ sessionId: archivedSessionId }),
-      }),
-    );
-  });
-
-  it('forces a fresh ACP session when the webview requests a new session', async () => {
-    const agentManager = {
-      isConnected: true,
-      currentSessionId: 'session-1',
-      createNewSession: vi.fn().mockResolvedValue('session-2'),
-    };
-    const conversationStore = {
-      createConversation: vi.fn(),
-      getConversation: vi.fn(),
-      addMessage: vi.fn(),
-    };
-    const sendToWebView = vi.fn();
-
-    const handler = new SessionMessageHandler(
-      agentManager as never,
-      conversationStore as never,
-      'conversation-1',
-      sendToWebView,
-    );
-
-    await handler.handle({
-      type: 'newQwenSession',
-    });
-
-    expect(handler.getCurrentConversationId()).toBeNull();
-    expect(agentManager.createNewSession).toHaveBeenCalledWith('/workspace', {
-      forceNew: true,
-    });
-    expect(sendToWebView).toHaveBeenCalledWith({
-      type: 'conversationCleared',
-      data: {},
-    });
-  });
-
-  it('intercepts /export html and uses the VSCode export flow instead of sending a prompt', async () => {
-    const agentManager = {
-      isConnected: true,
-      currentSessionId: 'session-1',
-      getSessionList: vi
-        .fn()
-        .mockResolvedValue([{ sessionId: 'session-1', cwd: '/workspace' }]),
-      sendMessage: vi.fn(),
-    };
-    const conversationStore = {
-      createConversation: vi.fn(),
-      getConversation: vi.fn(),
-      addMessage: vi.fn(),
-    };
-    const sendToWebView = vi.fn();
-
-    const handler = new SessionMessageHandler(
-      agentManager as never,
-      conversationStore as never,
-      'session-1',
-      sendToWebView,
-    );
-
-    await handler.handle({
-      type: 'sendMessage',
-      data: {
-        text: '/export html',
-      },
-    });
-
-    expect(mockExportSessionToFile).toHaveBeenCalledWith({
-      sessionId: 'session-1',
-      cwd: '/workspace',
-      format: 'html',
-    });
-    expect(conversationStore.addMessage).not.toHaveBeenCalled();
-    expect(agentManager.sendMessage).not.toHaveBeenCalled();
-    expect(sendToWebView).toHaveBeenCalledWith({
-      type: 'message',
-      data: expect.objectContaining({
-        role: 'assistant',
-        content:
-          'Session exported to HTML: [export.html](file:///workspace/export.html)',
-      }),
-    });
-  });
-
-  it('prefers the active ACP session id over the local conversation id when exporting', async () => {
-    const agentManager = {
-      isConnected: true,
-      currentSessionId: 'session-1',
-      getSessionList: vi
-        .fn()
-        .mockResolvedValue([{ sessionId: 'session-1', cwd: '/workspace' }]),
-      sendMessage: vi.fn(),
-    };
-    const conversationStore = {
-      createConversation: vi.fn(),
-      getConversation: vi.fn(),
-      addMessage: vi.fn(),
-    };
-    const sendToWebView = vi.fn();
-
-    const handler = new SessionMessageHandler(
-      agentManager as never,
-      conversationStore as never,
-      'conv_local_123',
-      sendToWebView,
-    );
-
-    await handler.handle({
-      type: 'sendMessage',
-      data: {
-        text: '/export html',
-      },
-    });
-
-    expect(mockExportSessionToFile).toHaveBeenCalledWith({
-      sessionId: 'session-1',
-      cwd: '/workspace',
-      format: 'html',
-    });
-    expect(agentManager.sendMessage).not.toHaveBeenCalled();
-  });
-
-  it('reports bare /export as a missing subcommand instead of exporting', async () => {
-    const agentManager = {
-      isConnected: true,
-      currentSessionId: 'session-1',
-      getSessionList: vi.fn(),
-      sendMessage: vi.fn(),
-    };
-    const conversationStore = {
-      createConversation: vi.fn(),
-      getConversation: vi.fn(),
-      addMessage: vi.fn(),
-    };
-    const sendToWebView = vi.fn();
-
-    const handler = new SessionMessageHandler(
-      agentManager as never,
-      conversationStore as never,
-      'session-1',
-      sendToWebView,
-    );
-
-    await handler.handle({
-      type: 'sendMessage',
-      data: {
-        text: '/export',
-      },
-    });
-
-    expect(mockExportSessionToFile).not.toHaveBeenCalled();
-    expect(sendToWebView).toHaveBeenCalledWith({
-      type: 'error',
-      data: { message: "Command '/export' requires a subcommand." },
-    });
-    expect(agentManager.sendMessage).not.toHaveBeenCalled();
-  });
-
-  it('reports export failures back to the user', async () => {
-    mockExportSessionToFile.mockRejectedValue(new Error('disk full'));
-
-    const agentManager = {
-      isConnected: true,
-      currentSessionId: 'session-1',
-      getSessionList: vi
-        .fn()
-        .mockResolvedValue([{ sessionId: 'session-1', cwd: '/workspace' }]),
-      sendMessage: vi.fn(),
-    };
-    const conversationStore = {
-      createConversation: vi.fn(),
-      getConversation: vi.fn(),
-      addMessage: vi.fn(),
-    };
-    const sendToWebView = vi.fn();
-
-    const handler = new SessionMessageHandler(
-      agentManager as never,
-      conversationStore as never,
-      'session-1',
-      sendToWebView,
-    );
-
-    await handler.handle({
-      type: 'sendMessage',
-      data: {
-        text: '/export md',
-      },
-    });
-
-    expect(sendToWebView).toHaveBeenCalledWith({
-      type: 'error',
-      data: { message: 'Failed to export session: disk full' },
-    });
-    expect(agentManager.sendMessage).not.toHaveBeenCalled();
-  });
-
-  it('encodes exported file links before rendering markdown', async () => {
-    mockExportSessionToFile.mockResolvedValue({
-      filename: 'export (#1).html',
-      uri: { fsPath: '/workspace/export (#1).html' },
-    });
-
-    const agentManager = {
-      isConnected: true,
-      currentSessionId: 'session-1',
-      getSessionList: vi
-        .fn()
-        .mockResolvedValue([{ sessionId: 'session-1', cwd: '/workspace' }]),
-      sendMessage: vi.fn(),
-    };
-    const conversationStore = {
-      createConversation: vi.fn(),
-      getConversation: vi.fn(),
-      addMessage: vi.fn(),
-    };
-    const sendToWebView = vi.fn();
-
-    const handler = new SessionMessageHandler(
-      agentManager as never,
-      conversationStore as never,
-      'session-1',
-      sendToWebView,
-    );
-
-    await handler.handle({
-      type: 'sendMessage',
-      data: {
-        text: '/export html',
-      },
-    });
-
-    expect(sendToWebView).toHaveBeenCalledWith({
-      type: 'message',
-      data: expect.objectContaining({
-        role: 'assistant',
-        content:
-          'Session exported to HTML: [export (#1).html](file:///workspace/export%20(%231).html)',
-      }),
-    });
-  });
-
-  describe('handleSetModel вЂ” discontinued model defensive validation (Issue #3745)', () => {
-    it('rejects a non-runtime Qwen OAuth model and surfaces an error', async () => {
-      const setModelFromUi = vi.fn();
-      const agentManager = {
-        isConnected: true,
-        currentSessionId: 'session-1',
-        setModelFromUi,
-      };
-      const sendToWebView = vi.fn();
-      const handler = new SessionMessageHandler(
-        agentManager as never,
-        {} as never,
-        null,
-        sendToWebView,
-      );
-
-      await handler.handle({
-        type: 'setModel',
-        data: { modelId: 'qwen3-coder-plus(qwen-oauth)' },
-      });
-
-      expect(setModelFromUi).not.toHaveBeenCalled();
-      expect(mockShowErrorMessage).toHaveBeenCalledWith(
-        expect.stringContaining(
-          'Qwen OAuth free tier was discontinued on 2026-04-15',
-        ),
-      );
-      expect(sendToWebView).toHaveBeenCalledWith({
-        type: 'error',
-        data: expect.objectContaining({
-          message: expect.stringContaining('discontinued'),
-        }),
-      });
-    });
-
-    it('allows a runtime Qwen OAuth snapshot to pass through', async () => {
-      const setModelFromUi = vi.fn().mockResolvedValue(undefined);
-      const agentManager = {
-        isConnected: true,
-        currentSessionId: 'session-1',
-        setModelFromUi,
-      };
-      const sendToWebView = vi.fn();
-      const handler = new SessionMessageHandler(
-        agentManager as never,
-        {} as never,
-        null,
-        sendToWebView,
-      );
-
-      await handler.handle({
-        type: 'setModel',
-        data: {
-          modelId: '$runtime|qwen-oauth|qwen3-coder-plus(qwen-oauth)',
-        },
-      });
-
-      expect(setModelFromUi).toHaveBeenCalledWith(
-        '$runtime|qwen-oauth|qwen3-coder-plus(qwen-oauth)',
-      );
-      expect(mockShowErrorMessage).not.toHaveBeenCalled();
-    });
-
-    it('passes through other-provider models (regression вЂ” no false positives)', async () => {
-      const setModelFromUi = vi.fn().mockResolvedValue(undefined);
-      const agentManager = {
-        isConnected: true,
-        currentSessionId: 'session-1',
-        setModelFromUi,
-      };
-      const sendToWebView = vi.fn();
-      const handler = new SessionMessageHandler(
-        agentManager as never,
-        {} as never,
-        null,
-        sendToWebView,
-      );
-
-      await handler.handle({
-        type: 'setModel',
-        data: { modelId: 'gpt-4(openai)' },
-      });
-
-      expect(setModelFromUi).toHaveBeenCalledWith('gpt-4(openai)');
-      expect(mockShowErrorMessage).not.toHaveBeenCalled();
-    });
-  });
-  it('preserves the drive-letter colon in Windows exported file links', async () => {
-    mockExportSessionToFile.mockResolvedValue({
-      filename: 'file.md',
-      uri: { fsPath: 'D:\\aplikacja\\file.md' },
-    });
-
-    const agentManager = {
-      isConnected: true,
-      currentSessionId: 'session-1',
-      getSessionList: vi
-        .fn()
-        .mockResolvedValue([{ sessionId: 'session-1', cwd: '/workspace' }]),
-      sendMessage: vi.fn(),
-    };
-    const conversationStore = {
-      createConversation: vi.fn(),
-      getConversation: vi.fn(),
-      addMessage: vi.fn(),
-    };
-    const sendToWebView = vi.fn();
-
-    const handler = new SessionMessageHandler(
-      agentManager as never,
-      conversationStore as never,
-      'session-1',
-      sendToWebView,
-    );
-
-    await handler.handle({
-      type: 'sendMessage',
-      data: {
-        text: '/export md',
-      },
-    });
-
-    expect(sendToWebView).toHaveBeenCalledWith({
-      type: 'message',
-      data: expect.objectContaining({
-        role: 'assistant',
-        content:
-          'Session exported to MD: [file.md](file:///D:/aplikacja/file.md)',
-      }),
-    });
-  });
-});
+      rewindSessionЯќx¶‰ћЛkєwµзH[ШЪФ›ШЩ\ЬТ[XYЩP]XЪY[ќЛ›[ШЪФ™\ЫЫ™Y[YJВ€›Ь›X]Y^€	ЩY]Y›Ы\	Л€\Ь^U^€	ЩY]Y›Ы\	Л€Ш]™Y[XYЩPЫЭ[ќ€€›Ы\[XYЩ\О€ЧK€JNВ‚€ЫЫњЭ\ЭЬћP™Y›Ь™T™]Ъ[™HЮИ›ЫN€	Э\Щ\‰Л\ќО€ЮИ^€	Щљ\њЭ	ИWHWNВ€ЫЫњЭЬљYЪ[[ЫЫќ™\њШ][Ы€HВ€Y€	ЬЩ\ЬЪ[Ы‹LIЛ€]N€	С^\Э[™ИЩ\ЬЪ[Ы‰Л€Y\ЬШYЩ\О€В€И›ЫN€	Э\Щ\‰И\ИЫЫњЭЫЫќ[ќ€	Щљ\њЭ	Л[Y\Э[\€HK€И›ЫN€	Ш\ЬЪ\Э[ќ	И\ИЫЫњЭЫЫќ[ќ€	Щљ\њЭ™\IЛ[Y\Э[\€€K€И›ЫN€	Э\Щ\‰И\ИЫЫњЭЫЫќ[ќ€	ЬЩXЫЫ™	Л[Y\Э[\€ИK€K€Ь™X]Y]€K€\]Y]€Л€NВ€ЫЫњЭYЩ[ќX[YЩ\€HВ€\РЫЫ›™XЭY€ќYK€Э\њ™[ќЩ\ЬЪ[Ы’Y€	ЬЩ\ЬЪ[Ы‹LIЛ€™]Ъ[™Щ\ЬЪ[ЫЋ€љK™›Љ
+K›[ШЪФ™\ЫЫ™Y[YJИ\ЭЬћP™Y›Ь™T™]Ъ[™JK€™\ЭЬ™TЩ\ЬЪ[Ы’\ЭЬћN€љK™›Љ
+K›[ШЪФ™\ЫЫ™Y[YJ[™Yљ[™Y
+K€Щ[™Y\ЬШYЩN€љK™›Љ
+K€NВ€ЫЫњЭЫЫќ™\њШ][Ы”ЭЬ™HHВ€Ь™X]PЫЫќ™\њШ][ЫЋ€љK™›Љ
+K€Щ]ЫЫќ™\њШ][ЫЋ€љK™›Љ
+K›[ШЪФ™\ЫЫ™Y[YJЬљYЪ[[ЫЫќ™\њШ][ЫЉK€YY\ЬШYЩN€љK™›Љ
+K›[ШЪФ™Z™XЭY[YJ™]И\њ›ЬЉ	ЬЭЬYЩHZ[Y	КJK€™\XЩSY\ЬШYЩ\О€љK™›Љ
+K›[ШЪФ™\ЫЫ™Y[YJќYJK€ќ[Ш]Qњ›ЫU\Щ\•\›Ћ€љK™›Љ
+K›[ШЪФ™\ЫЫ™Y[YJќYJK€NВ€ЫЫњЭЩ[™ХЩX•љY]ИHљK™›Љ
+NВ‚€ЫЫњЭ[™\€H™]ИЩ\ЬЪ[Ы“Y\ЬШYЩR[™\Љ€YЩ[ќX[YЩ\€\И™]™\‹€ЫЫќ™\њШ][Ы”ЭЬ™H\И™]™\‹€	ЬЩ\ЬЪ[Ы‹LIЛ€Щ[™ХЩX•љY]Л€
+NВ‚€]ШZ][™\‹љ[™JВ€\N€	ЩY]Y\ЬШYЩIЛ€]N€В€^€	ЩY]Y›Ы\	Л€\™Щ]\›’[™^€K€K€JNВ‚€^XЭ
+YЩ[ќX[YЩ\‹њ™\ЭЬ™TЩ\ЬЪ[Ы’\ЭЬћJKќТ]™P™Y[ђШ[YЪ]
+€\ЭЬћP™Y›Ь™T™]Ъ[™€
+NВ€^XЭ
+ЫЫќ™\њШ][Ы”ЭЬ™Kњ™\XЩSY\ЬШYЩ\КKќТ]™P™Y[ђШ[YЪ]
+€	ЬЩ\ЬЪ[Ы‹LIЛ€ЬљYЪ[[ЫЫќ™\њШ][Ы‹›Y\ЬШYЩ\Л€
+NВ€^XЭ
+YЩ[ќX[YЩ\‹њЩ[™Y\ЬШYЩJK››ЭќТ]™P™Y[ђШ[Y
+
+NВ€^XЭ
+Щ[™ХЩX•љY]КKќТ]™P™Y[ђШ[YЪ]
+В€\N€	Щ\њ›Ь‰Л€]N€ИY\ЬШYЩN€	ЬЭЬYЩHZ[Y	ИK€JNВ€JNВ‚€]
+	Ь™Z™XЭИY]ЭX›Z\ЬЪ[ЫњИЪ][ќ[Y\™Щ]\›€[™^\ЙЛ\Ю[И
+
+HO€В€ЫЫњЭYЩ[ќX[YЩ\€HВ€\РЫЫ›™XЭY€ќYK€Э\њ™[ќЩ\ЬЪ[Ы’Y€	ЬЩ\ЬЪ[Ы‹LIЛ€™]Ъ[™Щ\ЬЪ[ЫЋ€љK™›Љ
+K€™\ЭЬ™TЩ\ЬЪ[Ы’\ЭЬћN€љK™›Љ
+K€Щ[™Y\ЬШYЩN€љK™›Љ
+K€NВ€ЫЫњЭЫЫќ™\њШ][Ы”ЭЬ™HHВ€Ь™X]PЫЫќ™\њШ][ЫЋ€љK™›Љ
+K€Щ]ЫЫќ™\њШ][ЫЋ€љK™›Љ
+K€YY\ЬШYЩN€љK™›Љ
+K€™\XЩSY\ЬШYЩ\О€љK™›Љ
+K€ќ[Ш]Qњ›ЫU\Щ\•\›Ћ€љK™›Љ
+K€NВ€ЫЫњЭЩ[™ХЩX•љY]ИHљK™›Љ
+NВ‚€ЫЫњЭ[™\€H™]ИЩ\ЬЪ[Ы“Y\ЬШYЩR[™\Љ€YЩ[ќX[YЩ\€\И™]™\‹€ЫЫќ™\њШ][Ы”ЭЬ™H\И™]™\‹€	ЬЩ\ЬЪ[Ы‹LIЛ€Щ[™ХЩX•љY]Л€
+NВ‚€]ШZ][™\‹љ[™JВ€\N€	ЩY]Y\ЬШYЩIЛ€]N€В€^€	ЩY]Y›Ы\	Л€\™Щ]\›’[™^€LK€K€JNВ‚€^XЭ
+YЩ[ќX[YЩ\‹њ™]Ъ[™Щ\ЬЪ[ЫЉK››ЭќТ]™P™Y[ђШ[Y
+
+NВ€^XЭ
+YЩ[ќX[YЩ\‹њЩ[™Y\ЬШYЩJK››ЭќТ]™P™Y[ђШ[Y
+
+NВ€^XЭ
+ЫЫќ™\њШ][Ы”ЭЬ™Kќќ[Ш]Qњ›ЫU\Щ\•\›ЉK››ЭќТ]™P™Y[ђШ[Y
+
+NВ€^XЭ
+Щ[™ХЩX•љY]КKќТ]™P™Y[ђШ[YЪ]
+В€\N€	Щ\њ›Ь‰Л€]N€ИY\ЬШYЩN€	Т[ќ[YY\ЬШYЩHY]\™Щ]‰ИK€JNВ€JNВ‚€]
+	ЪЩY\ИЭ\њ™[ќЫЫќ™\њШ][Ы’Y[YЫ™YЪ]H\Ъ]™YЩ\ЬЪ[Ы’YЪ[€Щ\ЬЪ[Ы‹ЫШY[ИXЪИИH™]ИPФЩ\ЬЪ[Ы‰Л\Ю[И
+
+HO€В€ЫЫњЭ\Ъ]™YЩ\ЬЪ[Ы’YH	Ш\Ъ]™Y\Щ\ЬЪ[Ы‰ОВ€ЫЫњЭYЩ[ќX[YЩ\€HВ€\РЫЫ›™XЭY€ќYK€Э\њ™[ќЩ\ЬЪ[Ы’Y€	ЫЫXXЬ\Щ\ЬЪ[Ы‰Л€Щ]Щ\ЬЪ[Ы“\Э€љB€™›Љ
+B€›[ШЪФ™\ЫЫ™Y[YJЮИY€\Ъ]™YЩ\ЬЪ[Ы’YЭЩ€	ЛЭЫЬљЬЬXЩIИWJK€ШYЩ\ЬЪ[Ы•љXPXЬ€љB€™›Љ
+B€›[ШЪФ™Z™XЭY[YJ™]И\њ›ЬЉ	ЬЩ\ЬЪ[Ы€›Э›Э[™Ы€Щ\ќ™\‰КJK€Щ]Щ\ЬЪ[Ы“Y\ЬШYЩ\О€љK™›Љ
+K›[ШЪФ™\ЫЫ™Y[YJЧJK€Ь™X]S™]ФЩ\ЬЪ[ЫЋ€љK™›Љ
+K›[ШЪФ™\ЫЫ™Y[YJ	Ы™]ЛXXЬ\Щ\ЬЪ[Ы‰КK€NВ€ЫЫњЭЫЫќ™\њШ][Ы”ЭЬ™HHВ€Ь™X]PЫЫќ™\њШ][ЫЋ€љK™›Љ
+K€Щ]ЫЫќ™\њШ][ЫЋ€љK™›Љ
+K€YY\ЬШYЩN€љK™›Љ
+K€NВ€ЫЫњЭЩ[™ХЩX•љY]ИHљK™›Љ
+NВ‚€ЫЫњЭ[™\€H™]ИЩ\ЬЪ[Ы“Y\ЬШYЩR[™\Љ€YЩ[ќX[YЩ\€\И™]™\‹€ЫЫќ™\њШ][Ы”ЭЬ™H\И™]™\‹€ќ[€Щ[™ХЩX•љY]Л€
+NВ‚€]ШZ][™\‹љ[™JВ€\N€	ЬЭЪ]Ъ]Щ[”Щ\ЬЪ[Ы‰Л€]N€ИЩ\ЬЪ[Ы’Y€\Ъ]™YЩ\ЬЪ[Ы’YK€JNВ‚€ЛИXЪЩ[™]XЪЩYЭ\њ™[ќЩ\ЬЪ[Ы€]\ЭX]ЪHЩ\ЬЪ[Ы’YHЩXќљY]ИЩY\Л€ЛИЭ\ќЪ\ЩH™[[YKЩ[]KЭ]K]\]H›ЭЬИЪ[\™Щ]HЬ›Ы™ИЩ\ЬЪ[Ы‚€ЛИ\љ[™ИH[XЪИЪ[™ЭИ
+ЩYH€ММLИ™]љY]КK‚€^XЭ
+[™\‹™Щ]Э\њ™[ќЫЫќ™\њШ][Ы’Y
+
+JKќР™J\Ъ]™YЩ\ЬЪ[Ы’Y
+NВ€^XЭ
+YЩ[ќX[YЩ\‹Ь™X]S™]ФЩ\ЬЪ[ЫЉKќТ]™P™Y[ђШ[Y
+
+NВ€^XЭ
+Щ[™ХЩX•љY]КKќТ]™P™Y[ђШ[YЪ]
+€^XЭ›Шљ™XЭЫЫќZ[љ[™КВ€\N€	Ь]Щ[”Щ\ЬЪ[Ы”ЭЪ]ЪY	Л€]N€^XЭ›Шљ™XЭЫЫќZ[љ[™КИЩ\ЬЪ[Ы’Y€\Ъ]™YЩ\ЬЪ[Ы’YJK€JK€
+NВ€JNВ‚€]
+	Щ›ЬЩ\ИHњ™\ЪPФЩ\ЬЪ[Ы€Ъ[€HЩXќљY]И™\]Y\ЭИH™]ИЩ\ЬЪ[Ы‰Л\Ю[И
+
+HO€В€ЫЫњЭYЩ[ќX[YЩ\€HВ€\РЫЫ›™XЭY€ќYK€Э\њ™[ќЩ\ЬЪ[Ы’Y€	ЬЩ\ЬЪ[Ы‹LIЛ€Ь™X]S™]ФЩ\ЬЪ[ЫЋ€љK™›Љ
+K›[ШЪФ™\ЫЫ™Y[YJ	ЬЩ\ЬЪ[Ы‹L‰КK€NВ€ЫЫњЭЫЫќ™\њШ][Ы”ЭЬ™HHВ€Ь™X]PЫЫќ™\њШ][ЫЋ€љK™›Љ
+K€Щ]ЫЫќ™\њШ][ЫЋ€љK™›Љ
+K€YY\ЬШYЩN€љK™›Љ
+K€NВ€ЫЫњЭЩ[™ХЩX•љY]ИHљK™›Љ
+NВ‚€ЫЫњЭ[™\€H™]ИЩ\ЬЪ[Ы“Y\ЬШYЩR[™\Љ€YЩ[ќX[YЩ\€\И™]™\‹€ЫЫќ™\њШ][Ы”ЭЬ™H\И™]™\‹€	ШЫЫќ™\њШ][Ы‹LIЛ€Щ[™ХЩX•љY]Л€
+NВ‚€]ШZ][™\‹љ[™JВ€\N€	Ы™]Ф]Щ[”Щ\ЬЪ[Ы‰Л€JNВ‚€^XЭ
+[™\‹™Щ]Э\њ™[ќЫЫќ™\њШ][Ы’Y
+
+JKќР™Sќ[
+
+NВ€^XЭ
+YЩ[ќX[YЩ\‹Ь™X]S™]ФЩ\ЬЪ[ЫЉKќТ]™P™Y[ђШ[YЪ]
+	ЛЭЫЬљЬЬXЩIЛВ€›ЬЩS™]О€ќYK€JNВ€^XЭ
+Щ[™ХЩX•љY]КKќТ]™P™Y[ђШ[YЪ]
+В€\N€	ШЫЫќ™\њШ][ЫђЫX\™Y	Л€]N€ЯK€JNВ€JNВ‚€]
+	Ъ[ќ\Щ\ИЩ^Ьќ[[™\Щ\ИH”РЫЩH^Ьќ›ЭИ[њЭXYЩ€Щ[™[™ИH›Ы\	Л\Ю[И
+
+HO€В€ЫЫњЭYЩ[ќX[YЩ\€HВ€\РЫЫ›™XЭY€ќYK€Э\њ™[ќЩ\ЬЪ[Ы’Y€	ЬЩ\ЬЪ[Ы‹LIЛ€Щ]Щ\ЬЪ[Ы“\Э€љB€™›Љ
+B€›[ШЪФ™\ЫЫ™Y[YJЮИЩ\ЬЪ[Ы’Y€	ЬЩ\ЬЪ[Ы‹LIЛЭЩ€	ЛЭЫЬљЬЬXЩIИWJK€Щ[™Y\ЬШYЩN€љK™›Љ
+K€NВ€ЫЫњЭЫЫќ™\њШ][Ы”ЭЬ™HHВ€Ь™X]PЫЫќ™\њШ][ЫЋ€љK™›Љ
+K€Щ]ЫЫќ™\њШ][ЫЋ€љK™›Љ
+K€YY\ЬШYЩN€љK™›Љ
+K€NВ€ЫЫњЭЩ[™ХЩX•љY]ИHљK™›Љ
+NВ‚€ЫЫњЭ[™\€H™]ИЩ\ЬЪ[Ы“Y\ЬШYЩR[™\Љ€YЩ[ќX[YЩ\€\И™]™\‹€ЫЫќ™\њШ][Ы”ЭЬ™H\И™]™\‹€	ЬЩ\ЬЪ[Ы‹LIЛ€Щ[™ХЩX•љY]Л€
+NВ‚€]ШZ][™\‹љ[™JВ€\N€	ЬЩ[™Y\ЬШYЩIЛ€]N€В€^€	ЛЩ^Ьќ[	Л€K€JNВ‚€^XЭ
+[ШЪС^ЬќЩ\ЬЪ[Ы•Сљ[JKќТ]™P™Y[ђШ[YЪ]
+В€Щ\ЬЪ[Ы’Y€	ЬЩ\ЬЪ[Ы‹LIЛ€ЭЩ€	ЛЭЫЬљЬЬXЩIЛ€›Ь›X]€	Ъ[	Л€JNВ€^XЭ
+ЫЫќ™\њШ][Ы”ЭЬ™KYY\ЬШYЩJK››ЭќТ]™P™Y[ђШ[Y
+
+NВ€^XЭ
+YЩ[ќX[YЩ\‹њЩ[™Y\ЬШYЩJK››ЭќТ]™P™Y[ђШ[Y
+
+NВ€^XЭ
+Щ[™ХЩX•љY]КKќТ]™P™Y[ђШ[YЪ]
+В€\N€	ЫY\ЬШYЩIЛ€]N€^XЭ›Шљ™XЭЫЫќZ[љ[™КВ€›ЫN€	Ш\ЬЪ\Э[ќ	Л€ЫЫќ[ќ‚€	ФЩ\ЬЪ[Ы€^ЬќYИS€Щ^Ьќљ[Jљ[N‹ЛЛЭЫЬљЬЬXЩKЩ^Ьќљ[
+IЛ€JK€JNВ€JNВ‚€]
+	Ь™Y™\њИHXЭ]™HPФЩ\ЬЪ[Ы€YЭ™\€HШШ[ЫЫќ™\њШ][Ы€YЪ[€^Ьќ[™ЙЛ\Ю[И
+
+HO€В€ЫЫњЭYЩ[ќX[YЩ\€HВ€\РЫЫ›™XЭY€ќYK€Э\њ™[ќЩ\ЬЪ[Ы’Y€	ЬЩ\ЬЪ[Ы‹LIЛ€Щ]Щ\ЬЪ[Ы“\Э€љB€™›Љ
+B€›[ШЪФ™\ЫЫ™Y[YJЮИЩ\ЬЪ[Ы’Y€	ЬЩ\ЬЪ[Ы‹LIЛЭЩ€	ЛЭЫЬљЬЬXЩIИWJK€Щ[™Y\ЬШYЩN€љK™›Љ
+K€NВ€ЫЫњЭЫЫќ™\њШ][Ы”ЭЬ™HHВ€Ь™X]PЫЫќ™\њШ][ЫЋ€љK™›Љ
+K€Щ]ЫЫќ™\њШ][ЫЋ€љK™›Љ
+K€YY\ЬШYЩN€љK™›Љ
+K€NВ€ЫЫњЭЩ[™ХЩX•љY]ИHљK™›Љ
+NВ‚€ЫЫњЭ[™\€H™]ИЩ\ЬЪ[Ы“Y\ЬШYЩR[™\Љ€YЩ[ќX[YЩ\€\И™]™\‹€ЫЫќ™\њШ][Ы”ЭЬ™H\И™]™\‹€	ШЫЫќ—ЫШШ[МLЊЙЛ€Щ[™ХЩX•љY]Л€
+NВ‚€]ШZ][™\‹љ[™JВ€\N€	ЬЩ[™Y\ЬШYЩIЛ€]N€В€^€	ЛЩ^Ьќ[	Л€K€JNВ‚€^XЭ
+[ШЪС^ЬќЩ\ЬЪ[Ы•Сљ[JKќТ]™P™Y[ђШ[YЪ]
+В€Щ\ЬЪ[Ы’Y€	ЬЩ\ЬЪ[Ы‹LIЛ€ЭЩ€	ЛЭЫЬљЬЬXЩIЛ€›Ь›X]€	Ъ[	Л€JNВ€^XЭ
+YЩ[ќX[YЩ\‹њЩ[™Y\ЬШYЩJK››ЭќТ]™P™Y[ђШ[Y
+
+NВ€JNВ‚€]
+	Ь™\ЬќИ\™HЩ^Ьќ\ИHZ\ЬЪ[™ИЭXЫЫ[X[™[њЭXYЩ€^Ьќ[™ЙЛ\Ю[И
+
+HO€В€ЫЫњЭYЩ[ќX[YЩ\€HВ€\РЫЫ›™XЭY€ќYK€Э\њ™[ќЩ\ЬЪ[Ы’Y€	ЬЩ\ЬЪ[Ы‹LIЛ€Щ]Щ\ЬЪ[Ы“\Э€љK™›Љ
+K€Щ[™Y\ЬШYЩN€љK™›Љ
+K€NВ€ЫЫњЭЫЫќ™\њШ][Ы”ЭЬ™HHВ€Ь™X]PЫЫќ™\њШ][ЫЋ€љK™›Љ
+K€Щ]ЫЫќ™\њШ][ЫЋ€љK™›Љ
+K€YY\ЬШYЩN€љK™›Љ
+K€NВ€ЫЫњЭЩ[™ХЩX•љY]ИHљK™›Љ
+NВ‚€ЫЫњЭ[™\€H™]ИЩ\ЬЪ[Ы“Y\ЬШYЩR[™\Љ€YЩ[ќX[YЩ\€\И™]™\‹€ЫЫќ™\њШ][Ы”ЭЬ™H\И™]™\‹€	ЬЩ\ЬЪ[Ы‹LIЛ€Щ[™ХЩX•љY]Л€
+NВ‚€]ШZ][™\‹љ[™JВ€\N€	ЬЩ[™Y\ЬШYЩIЛ€]N€В€^€	ЛЩ^Ьќ	Л€K€JNВ‚€^XЭ
+[ШЪС^ЬќЩ\ЬЪ[Ы•Сљ[JK››ЭќТ]™P™Y[ђШ[Y
+
+NВ€^XЭ
+Щ[™ХЩX•љY]КKќТ]™P™Y[ђШ[YЪ]
+В€\N€	Щ\њ›Ь‰Л€]N€ИY\ЬШYЩN€ђЫЫ[X[™	ЛЩ^Ьќ	И™\]Z\™\ИHЭXЫЫ[X[™€€K€JNВ€^XЭ
+YЩ[ќX[YЩ\‹њЩ[™Y\ЬШYЩJK››ЭќТ]™P™Y[ђШ[Y
+
+NВ€JNВ‚€]
+	Ь™\ЬќИ^ЬќZ[\™\ИXЪИИH\Щ\‰Л\Ю[И
+
+HO€В€[ШЪС^ЬќЩ\ЬЪ[Ы•Сљ[K›[ШЪФ™Z™XЭY[YJ™]И\њ›ЬЉ	Щ\ЪИќ[	КJNВ‚€ЫЫњЭYЩ[ќX[YЩ\€HВ€\РЫЫ›™XЭY€ќYK€Э\њ™[ќЩ\ЬЪ[Ы’Y€	ЬЩ\ЬЪ[Ы‹LIЛ€Щ]Щ\ЬЪ[Ы“\Э€љB€™›Љ
+B€›[ШЪФ™\ЫЫ™Y[YJЮИЩ\ЬЪ[Ы’Y€	ЬЩ\ЬЪ[Ы‹LIЛЭЩ€	ЛЭЫЬљЬЬXЩIИWJK€Щ[™Y\ЬШYЩN€љK™›Љ
+K€NВ€ЫЫњЭЫЫќ™\њШ][Ы”ЭЬ™HHВ€Ь™X]PЫЫќ™\њШ][ЫЋ€љK™›Љ
+K€Щ]ЫЫќ™\њШ][ЫЋ€љK™›Љ
+K€YY\ЬШYЩN€љK™›Љ
+K€NВ€ЫЫњЭЩ[™ХЩX•љY]ИHљK™›Љ
+NВ‚€ЫЫњЭ[™\€H™]ИЩ\ЬЪ[Ы“Y\ЬШYЩR[™\Љ€YЩ[ќX[YЩ\€\И™]™\‹€ЫЫќ™\њШ][Ы”ЭЬ™H\И™]™\‹€	ЬЩ\ЬЪ[Ы‹LIЛ€Щ[™ХЩX•љY]Л€
+NВ‚€]ШZ][™\‹љ[™JВ€\N€	ЬЩ[™Y\ЬШYЩIЛ€]N€В€^€	ЛЩ^ЬќY	Л€K€JNВ‚€^XЭ
+Щ[™ХЩX•љY]КKќТ]™P™Y[ђШ[YЪ]
+В€\N€	Щ\њ›Ь‰Л€]N€ИY\ЬШYЩN€	СZ[YИ^ЬќЩ\ЬЪ[ЫЋ€\ЪИќ[	ИK€JNВ€^XЭ
+YЩ[ќX[YЩ\‹њЩ[™Y\ЬШYЩJK››ЭќТ]™P™Y[ђШ[Y
+
+NВ€JNВ‚€]
+	Щ[ЫЩ\И^ЬќYљ[H[љЬИ™Y›Ь™H™[™\љ[™ИX\љЩЭЫ‰Л\Ю[И
+
+HO€В€[ШЪС^ЬќЩ\ЬЪ[Ы•Сљ[K›[ШЪФ™\ЫЫ™Y[YJВ€љ[[[YN€	Щ^ЬќJKљ[	Л€\љN€ИњФ]€	ЛЭЫЬљЬЬXЩKЩ^ЬќJKљ[	ИK€JNВ‚€ЫЫњЭYЩ[ќX[YЩ\€HВ€\РЫЫ›™XЭY€ќYK€Э\њ™[ќЩ\ЬЪ[Ы’Y€	ЬЩ\ЬЪ[Ы‹LIЛ€Щ]Щ\ЬЪ[Ы“\Э€љB€™›Љ
+B€›[ШЪФ™\ЫЫ™Y[YJЮИЩ\ЬЪ[Ы’Y€	ЬЩ\ЬЪ[Ы‹LIЛЭЩ€	ЛЭЫЬљЬЬXЩIИWJK€Щ[™Y\ЬШYЩN€љK™›Љ
+K€NВ€ЫЫњЭЫЫќ™\њШ][Ы”ЭЬ™HHВ€Ь™X]PЫЫќ™\њШ][ЫЋ€љK™›Љ
+K€Щ]ЫЫќ™\њШ][ЫЋ€љK™›Љ
+K€YY\ЬШYЩN€љK™›Љ
+K€NВ€ЫЫњЭЩ[™ХЩX•љY]ИHљK™›Љ
+NВ‚€ЫЫњЭ[™\€H™]ИЩ\ЬЪ[Ы“Y\ЬШYЩR[™\Љ€YЩ[ќX[YЩ\€\И™]™\‹€ЫЫќ™\њШ][Ы”ЭЬ™H\И™]™\‹€	ЬЩ\ЬЪ[Ы‹LIЛ€Щ[™ХЩX•љY]Л€
+NВ‚€]ШZ][™\‹љ[™JВ€\N€	ЬЩ[™Y\ЬШYЩIЛ€]N€В€^€	ЛЩ^Ьќ[	Л€K€JNВ‚€^XЭ
+Щ[™ХЩX•љY]КKќТ]™P™Y[ђШ[YЪ]
+В€\N€	ЫY\ЬШYЩIЛ€]N€^XЭ›Шљ™XЭЫЫќZ[љ[™КВ€›ЫN€	Ш\ЬЪ\Э[ќ	Л€ЫЫќ[ќ‚€	ФЩ\ЬЪ[Ы€^ЬќYИS€Щ^ЬќJKљ[Jљ[N‹ЛЛЭЫЬљЬЬXЩKЩ^Ьќ	LЊILЋKљ[
+IЛ€JK€JNВ€JNВ‚€\ШЬљX™J	Ъ[™TЩ][Щ[8 %\ШЫЫќ[ќYY[Щ[Y™[њЪ]™H[Y][Ы€
+\ЬЭYHМННJIЛ
+
+HO€В€]
+	Ь™Z™XЭИH›Ы‹\ќ[ќ[YH]Щ[€Р]][Щ[[™Э\™XЩ\И[€\њ›Ь‰Л\Ю[И
+
+HO€В€ЫЫњЭЩ][Щ[њ›ЫUZHHљK™›Љ
+NВ€ЫЫњЭYЩ[ќX[YЩ\€HВ€\РЫЫ›™XЭY€ќYK€Э\њ™[ќЩ\ЬЪ[Ы’Y€	ЬЩ\ЬЪ[Ы‹LIЛ€Щ][Щ[њ›ЫUZK€NВ€ЫЫњЭЩ[™ХЩX•љY]ИHљK™›Љ
+NВ€ЫЫњЭ[™\€H™]ИЩ\ЬЪ[Ы“Y\ЬШYЩR[™\Љ€YЩ[ќX[YЩ\€\И™]™\‹€ЯH\И™]™\‹€ќ[€Щ[™ХЩX•љY]Л€
+NВ‚€]ШZ][™\‹љ[™JВ€\N€	ЬЩ][Щ[	Л€]N€И[Щ[Y€	Ь]Щ[ЊЛXЫЩ\‹\\К]Щ[‹[Ш]]
+IИK€JNВ‚€^XЭ
+Щ][Щ[њ›ЫUZJK››ЭќТ]™P™Y[ђШ[Y
+
+NВ€^XЭ
+[ШЪФЪЭС\њ›Ь“Y\ЬШYЩJKќТ]™P™Y[ђШ[YЪ]
+€^XЭњЭљ[™РЫЫќZ[љ[™К€	Ф]Щ[€Р]]њ™YHY\€Ш\И\ШЫЫќ[ќYYЫ€ЊЌ‹LLMIЛ€
+K€
+NВ€^XЭ
+Щ[™ХЩX•љY]КKќТ]™P™Y[ђШ[YЪ]
+В€\N€	Щ\њ›Ь‰Л€]N€^XЭ›Шљ™XЭЫЫќZ[љ[™КВ€Y\ЬШYЩN€^XЭњЭљ[™РЫЫќZ[љ[™К	Щ\ШЫЫќ[ќYY	КK€JK€JNВ€JNВ‚€]
+	Ш[ЭЬИHќ[ќ[YH]Щ[€Р]]Ы\ЪЭИ\ЬИ›ЭYЪ	Л\Ю[И
+
+HO€В€ЫЫњЭЩ][Щ[њ›ЫUZHHљK™›Љ
+K›[ШЪФ™\ЫЫ™Y[YJ[™Yљ[™Y
+NВ€ЫЫњЭYЩ[ќX[YЩ\€HВ€\РЫЫ›™XЭY€ќYK€Э\њ™[ќЩ\ЬЪ[Ы’Y€	ЬЩ\ЬЪ[Ы‹LIЛ€Щ][Щ[њ›ЫUZK€NВ€ЫЫњЭЩ[™ХЩX•љY]ИHљK™›Љ
+NВ€ЫЫњЭ[™\€H™]ИЩ\ЬЪ[Ы“Y\ЬШYЩR[™\Љ€YЩ[ќX[YЩ\€\И™]™\‹€ЯH\И™]™\‹€ќ[€Щ[™ХЩX•љY]Л€
+NВ‚€]ШZ][™\‹љ[™JВ€\N€	ЬЩ][Щ[	Л€]N€В€[Щ[Y€	Йќ[ќ[Y_]Щ[‹[Ш]]]Щ[ЊЛXЫЩ\‹\\К]Щ[‹[Ш]]
+IЛ€K€JNВ‚€^XЭ
+Щ][Щ[њ›ЫUZJKќТ]™P™Y[ђШ[YЪ]
+€	Йќ[ќ[Y_]Щ[‹[Ш]]]Щ[ЊЛXЫЩ\‹\\К]Щ[‹[Ш]]
+IЛ€
+NВ€^XЭ
+[ШЪФЪЭС\њ›Ь“Y\ЬШYЩJK››ЭќТ]™P™Y[ђШ[Y
+
+NВ€JNВ‚€]
+	Ь\ЬЩ\И›ЭYЪЭ\‹\›ЭљY\€[Щ[И
+™YЬ™\ЬЪ[Ы€8 %›И[ЩHЬЪ]]™\КIЛ\Ю[И
+
+HO€В€ЫЫњЭЩ][Щ[њ›ЫUZHHљK™›Љ
+K›[ШЪФ™\ЫЫ™Y[YJ[™Yљ[™Y
+NВ€ЫЫњЭYЩ[ќX[YЩ\€HВ€\РЫЫ›™XЭY€ќYK€Э\њ™[ќЩ\ЬЪ[Ы’Y€	ЬЩ\ЬЪ[Ы‹LIЛ€Щ][Щ[њ›ЫUZK€NВ€ЫЫњЭЩ[™ХЩX•љY]ИHљK™›Љ
+NВ€ЫЫњЭ[™\€H™]ИЩ\ЬЪ[Ы“Y\ЬШYЩR[™\Љ€YЩ[ќX[YЩ\€\И™]™\‹€ЯH\И™]™\‹€ќ[€Щ[™ХЩX•љY]Л€
+NВ‚€]ШZ][™\‹љ[™JВ€\N€	ЬЩ][Щ[	Л€]N€И[Щ[Y€	ЩЬM
+Ь[ZJIИK€JNВ‚€^XЭ
+Щ][Щ[њ›ЫUZJKќТ]™P™Y[ђШ[YЪ]
+	ЩЬM
+Ь[ZJIКNВ€^XЭ
+[ШЪФЪЭС\њ›Ь“Y\ЬШYЩJK››ЭќТ]™P™Y[ђШ[Y
+
+NВ€JNВ€JNВ€]
+	Ь™\Щ\ќ™\ИHљ]™K[]\€ЫЫЫ€[€Ъ[™ЭЬИ^ЬќYљ[H[љЬЙЛ\Ю[И
+
+HO€В€[ШЪС^ЬќЩ\ЬЪ[Ы•Сљ[K›[ШЪФ™\ЫЫ™Y[YJВ€љ[[[YN€	Щљ[K›Y	Л€\љN€ИњФ]€	С—\ZШXЪWљ[K›Y	ИK€JNВ‚€ЫЫњЭYЩ[ќX[YЩ\€HВ€\РЫЫ›™XЭY€ќYK€Э\њ™[ќЩ\ЬЪ[Ы’Y€	ЬЩ\ЬЪ[Ы‹LIЛ€Щ]Щ\ЬЪ[Ы“\Э€љB€™›Љ
+B€›[ШЪФ™\ЫЫ™Y[YJЮИЩ\ЬЪ[Ы’Y€	ЬЩ\ЬЪ[Ы‹LIЛЭЩ€	ЛЭЫЬљЬЬXЩIИWJK€Щ[™Y\ЬШYЩN€љK™›Љ
+K€NВ€ЫЫњЭЫЫќ™\њШ][Ы”ЭЬ™HHВ€Ь™X]PЫЫќ™\њШ][ЫЋ€љK™›Љ
+K€Щ]ЫЫќ™\њШ][ЫЋ€љK™›Љ
+K€YY\ЬШYЩN€љK™›Љ
+K€NВ€ЫЫњЭЩ[™ХЩX•љY]ИHљK™›Љ
+NВ‚€ЫЫњЭ[™\€H™]ИЩ\ЬЪ[Ы“Y\ЬШYЩR[™\Љ€YЩ[ќX[YЩ\€\И™]™\‹€ЫЫќ™\њШ][Ы”ЭЬ™H\И™]™\‹€	ЬЩ\ЬЪ[Ы‹LIЛ€Щ[™ХЩX•љY]Л€
+NВ‚€]ШZ][™\‹љ[™JВ€\N€	ЬЩ[™Y\ЬШYЩIЛ€]N€В€^€	ЛЩ^ЬќY	Л€K€JNВ‚€^XЭ
+Щ[™ХЩX•љY]КKќТ]™P™Y[ђШ[YЪ]
+В€\N€	ЫY\ЬШYЩIЛ€]N€^XЭ›Шљ™XЭЫЫќZ[љ[™КВ€›ЫN€	Ш\ЬЪ\Э[ќ	Л€ЫЫќ[ќ‚€	ФЩ\ЬЪ[Ы€^ЬќYИQ€Щљ[K›YJљ[N‹ЛЛС‹Ш\ZШXЪKЩљ[K›Y
+IЛ€JK€JNВ€JNВџJNВ

--- a/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.test.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.test.ts
@@ -1199,8 +1199,8 @@ describe('SessionMessageHandler', () => {
 
   it('encodes exported file links before rendering markdown', async () => {
     mockExportSessionToFile.mockResolvedValue({
-      filename: 'export a).html',
-      uri: { fsPath: '/workspace/export a).html' },
+      filename: 'export (#1).html',
+      uri: { fsPath: '/workspace/export (#1).html' },
     });
 
     const agentManager = {
@@ -1237,7 +1237,7 @@ describe('SessionMessageHandler', () => {
       data: expect.objectContaining({
         role: 'assistant',
         content:
-          'Session exported to HTML: [export a).html](file:///workspace/export%20a%29.html)',
+          'Session exported to HTML: [export (#1).html](file:///workspace/export%20%28%231%29.html)',
       }),
     });
   });

--- a/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.ts
@@ -6,6 +6,7 @@
 
 import { logger } from '../../utils/logger.js';
 import * as vscode from 'vscode';
+import { pathToFileURL } from 'node:url';
 import { BaseMessageHandler } from './BaseMessageHandler.js';
 import type { ChatMessage } from '../../services/qwenAgentManager.js';
 import type { Conversation } from '../../services/conversationStore.js';
@@ -36,7 +37,7 @@ function formatExportSuccessMessage(
   filename: string,
   filePath: string,
 ): string {
-  const markdownLinkPath = vscode.Uri.file(filePath).toString();
+  const markdownLinkPath = pathToFileURL(filePath).href;
   return `Session exported to ${formatLabel}: [${filename}](${markdownLinkPath})`;
 }
 

--- a/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.ts
@@ -510,124 +510,1095 @@ export class SessionMessageHandler extends BaseMessageHandler {
     // Guard: do not process empty or whitespace-only messages.
     // This prevents ghost user-message bubbles when slash-command completions
     // or model-selector interactions clear the input but still trigger a submit.
-    const trimmedText = stripZeroWidthSpï^{¶‰žËkºwµç_HØ]Ú
-ØY\œ›ÜŠHÂˆÙÙÙ\‹Ø\›Šˆ	ÖÔÙ\ÜÚ[Û“Y\ÜØYÙR[™\—HÙ\ÜÚ[Û‹ÛØY˜Z[Y\Ú[™È˜[˜XÚÎ‰ËˆØY\œ›Ü‹ˆ
-NÂ‚ˆËÈÚXÚÈ›Üˆ]][XØ][Û‹ÜÙ\ÜÚ[Ûˆ^\˜][Ûˆ\œ›ÜœÂˆYˆ
-\ËœÚÝ[›Û\]]
-ØY\œ›ÜŠJHÂˆËÈÚÝÈH[Ü™H\Ù\‹YœšY[™H\œ›ÜˆY\ÜØYÙH›Üˆ^\™YÙ\ÜÚ[ÛœÂˆ]ØZ]\Ëœ›Û\]]
-ˆ	Ö[Ý\ˆÙ\ÜÚ[Ûˆ\È^\™YÜˆ\È[˜[YˆX\ÙHÛÛ™šYÝ\™H[Ý\ˆ›ÝšY\ˆÈÝÚ]ÚÙ\ÜÚ[ÛœË‰Ëˆ
-NÂ‚ˆËÈÙ[™HÜXÚYšXÈ\œ›ÜˆÈHÙXšY]È›Üˆ™]\ˆRH[™[™Âˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	ÜÙ\ÜÚ[Û‘^\™Y	Ëˆ]NˆÈY\ÜØYÙNˆ	ÔÙ\ÜÚ[Ûˆ^\™YˆX\ÙH]][XØ]HYØZ[‹‰ÈKˆJNÂˆ™]\›ŽÂˆB‚ˆËÈ˜[˜XÚÎˆÜ™X]H™]ÈÙ\ÜÚ[Û‚ˆÛÛœÝY\ÜØYÙ\ÈH]ØZ]\Ë˜YÙ[X[˜YÙ\‹™Ù]Ù\ÜÚ[Û“Y\ÜØYÙ\ÊÙ\ÜÚ[Û’Y
-NÂ‚ˆËÈYˆÙH\™HÛÛ›™XÝYžHÈÜ™X]HHœ™\ÚPÔÙ\ÜÚ[ÛˆÛÈ\Ù\ˆØ[ˆ[\˜XÝˆYˆ
-\Ë˜YÙ[X[˜YÙ\‹š\ÐÛÛ›™XÝY
-HÂˆžHÂˆ]ØZ]\Ë˜YÙ[X[˜YÙ\‹˜Ü™X]S™]ÔÙ\ÜÚ[ÛŠÛÜšÚ[™Ñ\‹Âˆ›Ü˜ÙS™]ÎˆYKˆJNÂ‚ˆËÈÙY\HšY]ÙYÙ\ÜÚ[ÛˆY[]H[YÛ™YÚ]Ú]HÙXšY]ÈÙY\ÂˆËÈ
-H\˜Ú]™YÙ\ÜÚ[Û’Y
-KˆH]™HPÔÙ\ÜÚ[Ûˆ]™\ÈÛ‚ˆËÈYÙ[X[˜YÙ\‹˜Ý\œ™[Ù\ÜÚ[Û’YÈHÞ[˜Ë[Û‹Yš\œÝ[Y\ÜØYÙH]ˆËÈ
-ÙYHÝ™X[Q[™[™\ŠHÚ[›\›ÝÚY\ÈÈHPÔYÛ˜ÙBˆËÈH\Ù\ˆXÝX[HÙ[™ÈHY\ÜØYÙKˆÙ][™ÈÝ\œ™[ÛÛ™\œØ][Û’YˆËÈÈH™]ÈPÔY\™HÛÝ[\Þ[˜ÈH˜XÚÙ[™œ›ÛHHÙXšY]ÂˆËÈ[™Ø]\ÙH™[˜[YKÙ[]KÝ]K]\]H›ÝÜÈÈ\™Ù]HÜ›Û™ÂˆËÈÙ\ÜÚ[Ûˆ\š[™ÈH˜[˜XÚÈÚ[™ÝË‚ˆ\Ë\]PÝ\œ™[ÛÛ™\œØ][Û’Y
-Ù\ÜÚ[Û’Y
-NÂ‚ˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ü]Ù[”Ù\ÜÚ[Û”ÝÚ]ÚY	Ëˆ]NˆÈÙ\ÜÚ[Û’YY\ÜØYÙ\ËÙ\ÜÚ[ÛŽˆÙ\ÜÚ[Û‘]Z[ÈKˆJNÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	ÜÙ\ÜÚ[Û“ØYÛÛ\]IËˆ]NˆÈÙ\ÜÚ[Û’YKˆJNÂ‚ˆËÈÛ›HÚÝÈHØXÚHØ\›š[™ÈYˆÙHXÝX[H™[˜XÚÈÈØØ[ØXÚBˆËÈ[™Y‰ÝÝXØÙ\ÜÙ[HØYšXHPÔˆËÈÚXÚÈYˆÙH[H™[˜XÚÈžHÚXÚÚ[™ÈYˆØY\œ›Üˆ\È›Ý[Ý[™Yš[™YˆËÈ[™Yˆ]	ÜÈ›ÝHÝXØÙ\ÜÙ[™\ÜÛœÙH]ÛÚÜÈZÙH[ˆ\œ›Ü‚ˆYˆ
-ˆØY\œ›Üˆ	‰‚ˆ\[ÙˆØY\œ›ÜˆOOH	ÛØš™XÝ	È	‰‚ˆJ	Ü™\Ý[	È[ˆØY\œ›ÜŠBˆ
-HÂˆœØÛÙKÚ[™ÝËœÚÝÕØ\›š[™ÓY\ÜØYÙJˆ	ÔÙ\ÜÚ[Ûˆ™\ÝÜ™Yœ›ÛHØØ[ØXÚKˆÛÛYHÛÛ^X^H™H[˜ÛÛ\]K‰Ëˆ
-NÂˆBˆHØ]Ú
-Ü™X]Q\œ›ÜŠHÂˆÙÙÙ\‹™\œ›ÜŠˆ	ÖÔÙ\ÜÚ[Û“Y\ÜØYÙR[™\—H˜Z[YÈÜ™X]HÙ\ÜÚ[ÛŽ‰ËˆÜ™X]Q\œ›Ü‹ˆ
-NÂ‚ˆËÈÚXÚÈ›Üˆ]][XØ][Û‹ÜÙ\ÜÚ[Ûˆ^\˜][Ûˆ\œ›ÜœÈ[ˆÙ\ÜÚ[ÛˆÜ™X][Û‚ˆYˆ
-\ËœÚÝ[›Û\]]
-Ü™X]Q\œ›ÜŠJHÂˆËÈÚÝÈH[Ü™H\Ù\‹YœšY[™H\œ›ÜˆY\ÜØYÙH›Üˆ^\™YÙ\ÜÚ[ÛœÂˆ]ØZ]\Ëœ›Û\]]
-ˆ	Ö[Ý\ˆÙ\ÜÚ[Ûˆ\È^\™YÜˆ\È[˜[YˆX\ÙHÛÛ™šYÝ\™H[Ý\ˆ›ÝšY\ˆÈÝÚ]ÚÙ\ÜÚ[ÛœË‰Ëˆ
-NÂ‚ˆËÈÙ[™HÜXÚYšXÈ\œ›ÜˆÈHÙXšY]È›Üˆ™]\ˆRH[™[™Âˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	ÜÙ\ÜÚ[Û‘^\™Y	Ëˆ]NˆÂˆY\ÜØYÙNˆ	ÔÙ\ÜÚ[Ûˆ^\™YˆX\ÙH]][XØ]HYØZ[‹‰ËˆKˆJNÂˆ™]\›ŽÂˆB‚ˆ›ÝÈÜ™X]Q\œ›ÜŽÂˆBˆH[ÙHÂˆËÈÙ™›[™HšY]ÈÛ›Bˆ\Ë\]PÝ\œ™[ÛÛ™\œØ][Û’Y
-Ù\ÜÚ[Û’Y
-NÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ü]Ù[”Ù\ÜÚ[Û”ÝÚ]ÚY	Ëˆ]NˆÈÙ\ÜÚ[Û’YY\ÜØYÙ\ËÙ\ÜÚ[ÛŽˆÙ\ÜÚ[Û‘]Z[ÈKˆJNÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	ÜÙ\ÜÚ[Û“ØYÛÛ\]IËˆ]NˆÈÙ\ÜÚ[Û’YKˆJNÂˆœØÛÙKÚ[™ÝËœÚÝÕØ\›š[™ÓY\ÜØYÙJˆ	ÔÚÝÚ[™ÈØXÚYÙ\ÜÚ[ÛˆÛÛ[ˆÛÛ™šYÝ\™H[Ý\ˆ›ÝšY\ˆÈ[\˜XÝÚ]HRK‰Ëˆ
-NÂˆBˆBˆHØ]Ú
-\œ›ÜŠHÂˆÙÙÙ\‹™\œ›ÜŠ	ÖÔÙ\ÜÚ[Û“Y\ÜØYÙR[™\—H˜Z[YÈÝÚ]ÚÙ\ÜÚ[ÛŽ‰Ë\œ›ÜŠNÂ‚ˆËÈØY™[HÛÛ™\\œ›ÜˆÈÝš[™ÂˆÛÛœÝ\œ›Ü“\ÙÈH\Ë™Ù]\œ›Ü“Y\ÜØYÙJ\œ›ÜŠNÂˆËÈÚXÚÈ›Üˆ]][XØ][Û‹ÜÙ\ÜÚ[Ûˆ^\˜][Ûˆ\œ›ÜœÂˆYˆ
-\ËœÚÝ[›Û\]]
-\œ›ÜŠJHÂˆËÈÚÝÈH[Ü™H\Ù\‹YœšY[™H\œ›ÜˆY\ÜØYÙH›Üˆ^\™YÙ\ÜÚ[ÛœÂˆ]ØZ]\Ëœ›Û\]]
-ˆ	Ö[Ý\ˆÙ\ÜÚ[Ûˆ\È^\™YÜˆ\È[˜[YˆX\ÙHÛÛ™šYÝ\™H[Ý\ˆ›ÝšY\ˆÈÝÚ]ÚÙ\ÜÚ[ÛœË‰Ëˆ
-NÂ‚ˆËÈÙ[™HÜXÚYšXÈ\œ›ÜˆÈHÙXšY]È›Üˆ™]\ˆRH[™[™Âˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	ÜÙ\ÜÚ[Û‘^\™Y	Ëˆ]NˆÈY\ÜØYÙNˆ	ÔÙ\ÜÚ[Ûˆ^\™YˆX\ÙH]][XØ]HYØZ[‹‰ÈKˆJNÂˆH[ÙHÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙNˆ˜Z[YÈÝÚ]ÚÙ\ÜÚ[ÛŽˆ	Ù\œ›Ü“\ÙßXKˆJNÂˆBˆBˆB‚ˆÊŠ‚ˆ
-ˆ[™HÙ]]Ù[ˆÙ\ÜÚ[ÛœÈ™\]Y\Ýˆ
-‹Âˆš]˜]H\Þ[˜È[™QÙ]]Ù[”Ù\ÜÚ[ÛœÊˆÝ\œÛÜÎˆ[X™\‹ˆÚ^™OÎˆ[X™\‹ˆ
-Nˆ›ÛZ\ÙO›ÚYˆÂˆžHÂˆËÈYÙYÚ[ˆÜÜÚX›NÈ˜[È˜XÚÈÈ[\ÝYˆPÔ›ÝÝ\ÜYˆÛÛœÝYÙHH]ØZ]\Ë˜YÙ[X[˜YÙ\‹™Ù]Ù\ÜÚ[Û“\ÝYÙY
-ÂˆÝ\œÛÜ‹ˆÚ^™KˆJNÂˆÛÛœÝ\[™H\[ÙˆÝ\œÛÜˆOOH	Û[X™\‰ÎÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ü]Ù[”Ù\ÜÚ[Û“\Ý	Ëˆ]NˆÂˆÙ\ÜÚ[ÛœÎˆYÙKœÙ\ÜÚ[ÛœËˆ™^Ý\œÛÜŽˆYÙK›™^Ý\œÛÜ‹ˆ\Ó[Ü™NˆYÙKš\Ó[Ü™Kˆ\[™ˆKˆJNÂˆHØ]Ú
-\œ›ÜŠHÂˆÙÙÙ\‹™\œ›ÜŠ	ÖÔÙ\ÜÚ[Û“Y\ÜØYÙR[™\—H˜Z[YÈÙ]Ù\ÜÚ[ÛœÎ‰Ë\œ›ÜŠNÂ‚ˆËÈØY™[HÛÛ™\\œ›ÜˆÈÝš[™ÂˆÛÛœÝ\œ›Ü“\ÙÈH\Ë™Ù]\œ›Ü“Y\ÜØYÙJ\œ›ÜŠNÂˆËÈÚXÚÈ›Üˆ]][XØ][Û‹ÜÙ\ÜÚ[Ûˆ^\˜][Ûˆ\œ›ÜœÂˆYˆ
-\ËœÚÝ[›Û\]]
-\œ›ÜŠJHÂˆËÈÚÝÈH[Ü™H\Ù\‹YœšY[™H\œ›ÜˆY\ÜØYÙH›Üˆ^\™YÙ\ÜÚ[ÛœÂˆ]ØZ]\Ëœ›Û\]]
-ˆ	Ö[Ý\ˆÙ\ÜÚ[Ûˆ\È^\™YÜˆ\È[˜[YˆX\ÙHÛÛ™šYÝ\™H[Ý\ˆ›ÝšY\ˆÈšY]ÈÙ\ÜÚ[ÛœË‰Ëˆ
-NÂ‚ˆËÈÙ[™HÜXÚYšXÈ\œ›ÜˆÈHÙXšY]È›Üˆ™]\ˆRH[™[™Âˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	ÜÙ\ÜÚ[Û‘^\™Y	Ëˆ]NˆÈY\ÜØYÙNˆ	ÔÙ\ÜÚ[Ûˆ^\™YˆX\ÙH]][XØ]HYØZ[‹‰ÈKˆJNÂˆH[ÙHÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙNˆ˜Z[YÈÙ]Ù\ÜÚ[ÛœÎˆ	Ù\œ›Ü“\ÙßXKˆJNÂˆBˆBˆB‚ˆÊŠ‚ˆ
-ˆ[™HØ[˜Ù[Ý™X[Z[™È™\]Y\Ýˆ
-‹Âˆš]˜]H\Þ[˜È[™PØ[˜Ù[Ý™X[Z[™Ê
-Nˆ›ÛZ\ÙO›ÚYˆÂˆžHÂˆÙÙÙ\‹›ÙÊ	ÖÔÙ\ÜÚ[Û“Y\ÜØYÙR[™\—HØ[˜Ù[[™ÈÝ™X[Z[™Ë‹‹‰ÊNÂ‚ˆËÈØ[˜Ù[HÝ\œ™[Ý™X[Z[™ÈÜ\˜][Ûˆ[ˆHYÙ[X[˜YÙ\‚ˆ]ØZ]\Ë˜YÙ[X[˜YÙ\‹˜Ø[˜Ù[Ý\œ™[›Û\
+    const trimmedText = stripZeroWidthSpaces(text).trim();
+    const hasAttachments = (attachments?.length ?? 0) > 0;
+    if (!trimmedText && !hasAttachments) {
+      logger.warn('[SessionMessageHandler] Ignoring empty message');
+      return;
+    }
 
-NÂ‚ˆËÈ\ÙHÙ[™Ý™X[Q[™È[˜ÛYH™\]Y\ÝY›Üˆ›Ü\ˆÛÜœ™[][Û‚ˆ\ËœÙ[™Ý™X[Q[™
-	Ý\Ù\—ØØ[˜Ù[Y	ÊNÂ‚ˆÙÙÙ\‹›ÙÊ	ÖÔÙ\ÜÚ[Û“Y\ÜØYÙR[™\—HÝ™X[Z[™ÈØ[˜Ù[YÝXØÙ\ÜÙ[IÊNÂˆHØ]Ú
-Ù\œ›ÜŠHÂˆÙÙÙ\‹›ÙÊ	ÖÔÙ\ÜÚ[Û“Y\ÜØYÙR[™\—HÝ™X[Z[™ÈØ[˜Ù[Y
-[\œ\Y
-IÊNÂ‚ˆËÈ\ÙHÙ[™Ý™X[Q[™
-Ú]\XØ]HÝX\™
-HÈ[˜ÛYH™\]Y\ÝYˆ\ËœÙ[™Ý™X[Q[™
-	Ý\Ù\—ØØ[˜Ù[Y	ÊNÂˆBˆB‚ˆÊŠ‚ˆ
-ˆ[™H™\Ý[YHÙ\ÜÚ[Ûˆ™\]Y\Ýˆ
-‹Âˆš]˜]H\Þ[˜È[™T™\Ý[YTÙ\ÜÚ[ÛŠÙ\ÜÚ[Û’YˆÝš[™ÊNˆ›ÛZ\ÙO›ÚYˆÂˆžHÂˆËÈYˆ›ÝÛÛ›™XÝYÙ™™\ˆÈ]][XØ]HÜˆšY]ÈÙ™›[™BˆYˆ
-]\Ë˜YÙ[X[˜YÙ\‹š\ÐÛÛ›™XÝY
-HÂˆÛÛœÝÚÚXÙHH]ØZ]\Ëœ›Û\]]Ü“Ù™›[™Jˆ	Ö[ÝH\™H›Ý]][XØ]YˆÛÛ™šYÝ\™H[Ý\ˆ›ÝšY\ˆÈ[H™\ÝÜ™H\ÈÙ\ÜÚ[Û‹ÜˆšY]È]Ù™›[™K‰Ëˆ
-NÂ‚ˆYˆ
-ÚÚXÙHOOH	ÛÙ™›[™IÊHÂˆÛÛœÝY\ÜØYÙ\ÈBˆ]ØZ]\Ë˜YÙ[X[˜YÙ\‹™Ù]Ù\ÜÚ[Û“Y\ÜØYÙ\ÊÙ\ÜÚ[Û’Y
-NÂˆ\Ë\]PÝ\œ™[ÛÛ™\œØ][Û’Y
-Ù\ÜÚ[Û’Y
-NÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ü]Ù[”Ù\ÜÚ[Û”ÝÚ]ÚY	Ëˆ]NˆÈÙ\ÜÚ[Û’YY\ÜØYÙ\ÈKˆJNÂˆœØÛÙKÚ[™ÝËœÚÝÒ[™›Ü›X][Û“Y\ÜØYÙJˆ	ÔÚÝÚ[™ÈØXÚYÙ\ÜÚ[ÛˆÛÛ[ˆÛÛ™šYÝ\™H[Ý\ˆ›ÝšY\ˆÈ[\˜XÝÚ]HRK‰Ëˆ
-NÂˆ™]\›ŽÂˆH[ÙHYˆ
-ÚÚXÙHOOH	Ø]]	ÊHÂˆ™]\›ŽÂˆBˆB‚ˆËÈžHPÔØYš\œÝˆžHÂˆËÈ™KXÛX\ˆRHÛÈ™\^YY\]\È\[™Y\Ø\™Âˆ\Ë\]PÝ\œ™[ÛÛ™\œØ][Û’Y
-Ù\ÜÚ[Û’Y
-NÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ü]Ù[”Ù\ÜÚ[Û”ÝÚ]ÚY	Ëˆ]NˆÈÙ\ÜÚ[Û’YY\ÜØYÙ\Îˆ×HKˆJNÂ‚ˆ]ØZ]\Ë˜YÙ[X[˜YÙ\‹›ØYÙ\ÜÚ[Û•šXPXÜ
-Ù\ÜÚ[Û’Y
-NÂ‚ˆËÈ™\Ù]]H›YÈÚ[ˆ™\Ý[Z[™ÈÙ\ÜÚ[ÛœÂˆ\Ëš\Õ]TÙ]H˜[ÙNÂ‚ˆËÈÝXØÙ\ÜÙ[HØYYÙ\ÜÚ[Û‹™]\›ˆX\›HÈ]›ÚY˜[˜XÚÈÙÚXÂˆ]ØZ]\Ëš[™QÙ]]Ù[”Ù\ÜÚ[ÛœÊ
-NÂˆ™]\›ŽÂˆHØ]Ú
-XÜ\œ›ÜŠHÂˆËÈÚXÚÈ›Üˆ]][XØ][Û‹ÜÙ\ÜÚ[Ûˆ^\˜][Ûˆ\œ›ÜœÂˆYˆ
-\ËœÚÝ[›Û\]]
-XÜ\œ›ÜŠJHÂˆËÈÚÝÈH[Ü™H\Ù\‹YœšY[™H\œ›ÜˆY\ÜØYÙH›Üˆ^\™YÙ\ÜÚ[ÛœÂˆ]ØZ]\Ëœ›Û\]]
-ˆ	Ö[Ý\ˆÙ\ÜÚ[Ûˆ\È^\™YÜˆ\È[˜[YˆX\ÙHÛÛ™šYÝ\™H[Ý\ˆ›ÝšY\ˆÈ™\Ý[YHÙ\ÜÚ[ÛœË‰Ëˆ
-NÂ‚ˆËÈÙ[™HÜXÚYšXÈ\œ›ÜˆÈHÙXšY]È›Üˆ™]\ˆRH[™[™Âˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	ÜÙ\ÜÚ[Û‘^\™Y	Ëˆ]NˆÈY\ÜØYÙNˆ	ÔÙ\ÜÚ[Ûˆ^\™YˆX\ÙH]][XØ]HYØZ[‹‰ÈKˆJNÂˆ™]\›ŽÂˆBˆB‚ˆ]ØZ]\Ëš[™QÙ]]Ù[”Ù\ÜÚ[ÛœÊ
-NÂˆHØ]Ú
-\œ›ÜŠHÂˆÙÙÙ\‹™\œ›ÜŠ	ÖÔÙ\ÜÚ[Û“Y\ÜØYÙR[™\—H˜Z[YÈ™\Ý[YHÙ\ÜÚ[ÛŽ‰Ë\œ›ÜŠNÂ‚ˆËÈØY™[HÛÛ™\\œ›ÜˆÈÝš[™ÂˆÛÛœÝ\œ›Ü“\ÙÈH\Ë™Ù]\œ›Ü“Y\ÜØYÙJ\œ›ÜŠNÂˆËÈÚXÚÈ›Üˆ]][XØ][Û‹ÜÙ\ÜÚ[Ûˆ^\˜][Ûˆ\œ›ÜœÂˆYˆ
-\ËœÚÝ[›Û\]]
-\œ›ÜŠJHÂˆËÈÚÝÈH[Ü™H\Ù\‹YœšY[™H\œ›ÜˆY\ÜØYÙH›Üˆ^\™YÙ\ÜÚ[ÛœÂˆ]ØZ]\Ëœ›Û\]]
-ˆ	Ö[Ý\ˆÙ\ÜÚ[Ûˆ\È^\™YÜˆ\È[˜[YˆX\ÙHÛÛ™šYÝ\™H[Ý\ˆ›ÝšY\ˆÈ™\Ý[YHÙ\ÜÚ[ÛœË‰Ëˆ
-NÂ‚ˆËÈÙ[™HÜXÚYšXÈ\œ›ÜˆÈHÙXšY]È›Üˆ™]\ˆRH[™[™Âˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	ÜÙ\ÜÚ[Û‘^\™Y	Ëˆ]NˆÈY\ÜØYÙNˆ	ÔÙ\ÜÚ[Ûˆ^\™YˆX\ÙH]][XØ]HYØZ[‹‰ÈKˆJNÂˆH[ÙHÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙNˆ˜Z[YÈ™\Ý[YHÙ\ÜÚ[ÛŽˆ	Ù\œ›Ü“\ÙßXKˆJNÂˆBˆBˆB‚ˆÊŠ‚ˆ
-ˆ[™H[]HÙ\ÜÚ[Ûˆ™\]Y\Ýˆ
-‹Âˆš]˜]H\Þ[˜È[™Q[]T]Ù[”Ù\ÜÚ[ÛŠÙ\ÜÚ[Û’YˆÝš[™ÊNˆ›ÛZ\ÙO›ÚYˆÂˆžHÂˆYˆ
-ˆÙ\ÜÚ[Û’YOOH\Ë˜Ý\œ™[ÛÛ™\œØ][Û’YˆÙ\ÜÚ[Û’YOOH\Ë˜YÙ[X[˜YÙ\‹˜Ý\œ™[Ù\ÜÚ[Û’Yˆ
-HÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙNˆ	ÐØ[››Ý[]HHÝ\œ™[XÝ]™HÙ\ÜÚ[Û‹‰ÈKˆJNÂˆ™]\›ŽÂˆB‚ˆÛÛœÝÝXØÙ\ÜÈH]ØZ]\Ë˜YÙ[X[˜YÙ\‹™[]TÙ\ÜÚ[ÛŠÙ\ÜÚ[Û’Y
-NÂˆYˆ
-ÝXØÙ\ÜÊHÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	ÜÙ\ÜÚ[Û‘[]Y	Ëˆ]NˆÈÙ\ÜÚ[Û’YKˆJNÂˆH[ÙHÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙNˆ	Ñ˜Z[YÈ[]HÙ\ÜÚ[Û‹‰ÈKˆJNÂˆBˆHØ]Ú
-\œ›ÜŠHÂˆÛÛœÝ\œ›Ü“\ÙÈH\Ë™Ù]\œ›Ü“Y\ÜØYÙJ\œ›ÜŠNÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙNˆ˜Z[YÈ[]HÙ\ÜÚ[ÛŽˆ	Ù\œ›Ü“\ÙßXKˆJNÂˆBˆB‚ˆÊŠ‚ˆ
-ˆ[™H™[˜[YHÙ\ÜÚ[Ûˆ™\]Y\Ýˆ
-‹Âˆš]˜]H\Þ[˜È[™T™[˜[YT]Ù[”Ù\ÜÚ[ÛŠˆÙ\ÜÚ[Û’YˆÝš[™Ëˆ]NˆÝš[™Ëˆ
-Nˆ›ÛZ\ÙO›ÚYˆÂˆžHÂˆÛÛœÝš[[YY]HH]Kš[J
-Kœ™\XÙJÖ×——JËÙË	È	ÊNÂˆYˆ
-]š[[YY]JHÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙNˆ	ÔX\ÙH›ÝšYHH˜[YK‰ÈKˆJNÂˆ™]\›ŽÂˆBˆËÈX]Ú\ÈÑTÔÒSÓ—ÕUWÓPVÓS‘Õœ›ÛH]Ù[‹XÛÙKÜ]Ù[‹XÛÙKXÛÜ™KÜÙ\ÜÚ[Û”Ù\šXÙBˆYˆ
-š[[YY]K›[™ÝˆŒ
-HÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙNˆ	Ó˜[YH\ÈÛÈÛ™ËˆX^[][HŒÚ\˜XÝ\œË‰ÈKˆJNÂˆ™]\›ŽÂˆB‚ˆÛÛœÝÝXØÙ\ÜÈH]ØZ]\Ë˜YÙ[X[˜YÙ\‹œ™[˜[YTÙ\ÜÚ[ÛŠˆÙ\ÜÚ[Û’Yˆš[[YY]Kˆ
-NÂˆYˆ
-ÝXØÙ\ÜÊHÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	ÜÙ\ÜÚ[Û”™[˜[YY	Ëˆ]NˆÈÙ\ÜÚ[Û’Y]Nˆš[[YY]HKˆJNÂˆYˆ
-Ù\ÜÚ[Û’YOOH\Ë˜Ý\œ™[ÛÛ™\œØ][Û’Y
-HÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	ÜÙ\ÜÚ[Û•]U\]Y	Ëˆ]NˆÈÙ\ÜÚ[Û’Y]Nˆš[[YY]HKˆJNÂˆBˆH[ÙHÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙNˆ	Ñ˜Z[YÈ™[˜[YHÙ\ÜÚ[Û‹‰ÈKˆJNÂˆBˆHØ]Ú
-\œ›ÜŠHÂˆÛÛœÝ\œ›Ü“\ÙÈH\Ë™Ù]\œ›Ü“Y\ÜØYÙJ\œ›ÜŠNÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙNˆ˜Z[YÈ™[˜[YHÙ\ÜÚ[ÛŽˆ	Ù\œ›Ü“\ÙßXKˆJNÂˆBˆB‚ˆÊŠ‚ˆ
-ˆÙ]\›Ý˜[[ÙHšXHYÙ[
-PÔÙ\ÜÚ[Û‹ÜÙ]Û[ÙJBˆ
-‹Âˆš]˜]H\Þ[˜È[™TÙ]\›Ý˜[[ÙJ]OÎˆÂˆ[ÙRYÎˆ\›Ý˜[[ÙU˜[YNÂˆJNˆ›ÛZ\ÙO›ÚYˆÂˆžHÂˆÛÛœÝ[ÙRYH]OË›[ÙRY	ÙY˜][	ÎÂˆ]ØZ]\Ë˜YÙ[X[˜YÙ\‹œÙ]\›Ý˜[[ÙQœ›ÛUZJ[ÙRY
-NÂˆËÈ›È^XÚ]™\ÜÛœÙH™YYYÈÙX•šY]È\Ý[œÈ›Üˆ[ÙPÚ[™ÙYˆHØ]Ú
-\œ›ÜŠHÂˆÙÙÙ\‹™\œ›ÜŠ	ÖÔÙ\ÜÚ[Û“Y\ÜØYÙR[™\—H˜Z[YÈÙ][ÙN‰Ë\œ›ÜŠNÂˆÛÛœÝ\œ›Ü“\ÙÈH\Ë™Ù]\œ›Ü“Y\ÜØYÙJ\œ›ÜŠNÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙNˆ˜Z[YÈÙ][ÙNˆ	Ù\œ›Ü“\ÙßXKˆJNÂˆBˆB‚ˆÊŠ‚ˆ
-ˆÙ][Ù[šXHYÙ[
-PÔÙ\ÜÚ[Û‹ÜÙ]Û[Ù[
-Bˆ
-ˆ\Ü^\È”ÐÛÙH˜]]™H›ÝYšXØ][ÛœÈÛˆÝXØÙ\ÜÈÜˆ˜Z[\™K‚ˆ
-‹Âˆš]˜]H\Þ[˜È[™TÙ][Ù[
-]OÎˆÈ[Ù[YÎˆÝš[™ÈJNˆ›ÛZ\ÙO›ÚYˆÂˆžHÂˆÛÛœÝ[Ù[YH]OË›[Ù[YÂˆYˆ
-[[Ù[Y
-HÂˆ›ÝÈ™]È\œ›ÜŠ	Ó[Ù[Q\È™\]Z\™Y	ÊNÂˆBˆËÈY™[œÚ]™HÝX\™ˆ™Y\ÙH›Û‹\[[YH]Ù[ˆÐ]][Ù[È[ˆØ\ÙHHRBˆËÈ\Èž\\ÜÙY
-›ÙÜ˜[[X]XÈØ[Ý[HÙXšY]Ë™\ÝÜ™YÙ\ÜÚ[ÛŠK‚ˆYˆ
-\Ñ\ØÛÛ[YY[Ù[
-[Ù[Y
-JHÂˆÙÙÙ\‹Ø\›Šˆ	ÖÔÙ\ÜÚ[Û“Y\ÜØYÙR[™\—H™Z™XÝY\ØÛÛ[YY[Ù[	Ëˆ[Ù[Yˆ
-NÂˆÛÛœÝY\ÜØYÙHH˜Z[YÈÝÚ]Ú[Ù[ˆ	ÑTÐÓÓ•S•QQÓQTÔÐQÑTË˜›ØÚÙY\œ›ÜŸXÂˆœØÛÙKÚ[™ÝËœÚÝÑ\œ›Ü“Y\ÜØYÙJY\ÜØYÙJNÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙHKˆJNÂˆ™]\›ŽÂˆBˆ]ØZ]\Ë˜YÙ[X[˜YÙ\‹œÙ][Ù[œ›ÛUZJ[Ù[Y
-NÂˆ›ÚYœØÛÙKÚ[™ÝËœÚÝÒ[™›Ü›X][Û“Y\ÜØYÙJˆ[Ù[ÝÚ]ÚYÎˆ	Û[Ù[YXˆ
-NÂˆHØ]Ú
-\œ›ÜŠHÂˆÛÛœÝ\œ›Ü“\ÙÈH\Ë™Ù]\œ›Ü“Y\ÜØYÙJ\œ›ÜŠNÂˆÙÙÙ\‹™\œ›ÜŠ	ÖÔÙ\ÜÚ[Û“Y\ÜØYÙR[™\—H˜Z[YÈÙ][Ù[‰Ë\œ›ÜŠNÂˆœØÛÙKÚ[™ÝËœÚÝÑ\œ›Ü“Y\ÜØYÙJ˜Z[YÈÝÚ]Ú[Ù[ˆ	Ù\œ›Ü“\ÙßX
-NÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙNˆ˜Z[YÈÙ][Ù[ˆ	Ù\œ›Ü“\ÙßXKˆJNÂˆBˆBŸB
+    try {
+      const exportFormat = parseExportSlashCommand(trimmedText);
+      if (exportFormat) {
+        await this.handleExportCommand(exportFormat);
+        return;
+      }
+    } catch (error) {
+      const errorMsg = this.getErrorMessage(error);
+      this.sendToWebView({
+        type: 'error',
+        data: { message: errorMsg },
+      });
+      return;
+    }
+
+    let displayText = trimmedText ? text : '';
+    let promptText = text;
+    if (context && context.length > 0) {
+      const contextParts = context
+        .map((ctx) => {
+          if (ctx.startLine && ctx.endLine) {
+            return `${ctx.value}#${ctx.startLine}${ctx.startLine !== ctx.endLine ? `-${ctx.endLine}` : ''}`;
+          }
+          return ctx.value;
+        })
+        .join('\n');
+
+      promptText = `${contextParts}\n\n${text}`;
+    }
+
+    const {
+      formattedText,
+      displayText: updatedDisplayText,
+      savedImageCount,
+      promptImages,
+    } = await processImageAttachments(promptText, attachments);
+    for (const ctx of context ?? []) {
+      const mimeType = ctx.isImage
+        ? getDisplayableImageMimeType(ctx.value)
+        : undefined;
+      if (mimeType) {
+        promptImages.push({
+          path: ctx.value,
+          name: ctx.name,
+          mimeType,
+        });
+      }
+    }
+    promptText = formattedText;
+    displayText = updatedDisplayText;
+
+    if (hasAttachments && !trimmedText && savedImageCount === 0) {
+      const errorMsg =
+        'Failed to attach the pasted image. Nothing was sent. Please paste the image again.';
+      logger.warn('[SessionMessageHandler]', errorMsg);
+      vscode.window.showErrorMessage(errorMsg);
+      this.sendToWebView({
+        type: 'error',
+        data: { message: errorMsg },
+      });
+      return;
+    }
+
+    // Ensure we have an active conversation
+    if (!this.currentConversationId) {
+      logger.log(
+        '[SessionMessageHandler] No active conversation, creating one...',
+      );
+      try {
+        const newConv = await this.conversationStore.createConversation();
+        this.updateCurrentConversationId(newConv.id);
+        this.sendToWebView({
+          type: 'conversationLoaded',
+          data: newConv,
+        });
+      } catch (error) {
+        const errorMsg = `Failed to create conversation: ${this.getErrorMessage(error)}`;
+        logger.error('[SessionMessageHandler]', errorMsg);
+        vscode.window.showErrorMessage(errorMsg);
+        this.sendToWebView({
+          type: 'error',
+          data: { message: errorMsg },
+        });
+        return;
+      }
+    }
+
+    if (!this.currentConversationId) {
+      const errorMsg =
+        'Failed to create conversation. Please restart the extension.';
+      logger.error('[SessionMessageHandler]', errorMsg);
+      vscode.window.showErrorMessage(errorMsg);
+      this.sendToWebView({
+        type: 'error',
+        data: { message: errorMsg },
+      });
+      return;
+    }
+
+    let editRestoreSnapshot: Conversation | null = null;
+    let editStoreMutationApplied = false;
+    let editAcpMutationApplied = false;
+    let editAcpHistorySnapshot: unknown[] | null = null;
+
+    if (editTargetTurnIndex !== undefined) {
+      if (!Number.isInteger(editTargetTurnIndex) || editTargetTurnIndex < 0) {
+        const errorMsg = 'Invalid message edit target.';
+        logger.error('[SessionMessageHandler]', errorMsg, editTargetTurnIndex);
+        this.sendToWebView({
+          type: 'error',
+          data: { message: errorMsg },
+        });
+        return;
+      }
+
+      if (!this.agentManager.isConnected) {
+        await this.promptAuth(
+          'You need to configure your provider to use Qwen Code.',
+        );
+        return;
+      }
+
+      if (!this.agentManager.currentSessionId) {
+        try {
+          const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+          const workingDir = workspaceFolder?.uri.fsPath || process.cwd();
+          await this.agentManager.createNewSession(workingDir);
+        } catch (createErr) {
+          logger.error(
+            '[SessionMessageHandler] Failed to create session before editing message:',
+            createErr,
+          );
+          const errorMsg = this.getErrorMessage(createErr);
+          if (this.shouldPromptAuth(createErr)) {
+            await this.promptAuth(
+              'Your session has expired or is invalid. Please configure your provider to continue using Qwen Code.',
+            );
+            return;
+          }
+          vscode.window.showErrorMessage(
+            `Failed to create session: ${errorMsg}`,
+          );
+          return;
+        }
+      }
+
+      try {
+        editRestoreSnapshot = await this.captureConversationSnapshot(
+          this.currentConversationId,
+        );
+      } catch (error) {
+        logger.error(
+          '[SessionMessageHandler] Failed to capture edit restore snapshot:',
+          error,
+        );
+        const errorMsg = this.getErrorMessage(error);
+        vscode.window.showErrorMessage(`Failed to edit message: ${errorMsg}`);
+        this.sendToWebView({
+          type: 'error',
+          data: { message: errorMsg },
+        });
+        return;
+      }
+
+      if (!editRestoreSnapshot) {
+        logger.warn(
+          '[SessionMessageHandler] Local conversation snapshot missing before edit; continuing with ACP rewind only.',
+        );
+      }
+
+      try {
+        if (editRestoreSnapshot) {
+          const truncated = await this.conversationStore.truncateFromUserTurn(
+            this.currentConversationId,
+            editTargetTurnIndex,
+          );
+          if (!truncated) {
+            throw new Error('Conversation not found for edit target.');
+          }
+          editStoreMutationApplied = true;
+        }
+
+        const rewindResult =
+          await this.agentManager.rewindSession(editTargetTurnIndex);
+        editAcpHistorySnapshot = rewindResult?.historyBeforeRewind ?? null;
+        editAcpMutationApplied = true;
+
+        this.sendToWebView({
+          type: 'conversationRewound',
+          data: { targetTurnIndex: editTargetTurnIndex },
+        });
+      } catch (error) {
+        if (editAcpMutationApplied && editAcpHistorySnapshot) {
+          try {
+            await this.agentManager.restoreSessionHistory(
+              editAcpHistorySnapshot,
+            );
+          } catch (restoreError) {
+            logger.warn(
+              '[SessionMessageHandler] Failed to restore ACP history after rewind failure:',
+              restoreError,
+            );
+          }
+        }
+        if (editStoreMutationApplied) {
+          await this.restoreConversationSnapshot(editRestoreSnapshot);
+        }
+        const errorMsg = this.getErrorMessage(error);
+        logger.error(
+          '[SessionMessageHandler] Failed to rewind session:',
+          error,
+        );
+        vscode.window.showErrorMessage(`Failed to edit message: ${errorMsg}`);
+        this.sendToWebView({
+          type: 'error',
+          data: { message: errorMsg },
+        });
+        return;
+      }
+    }
+
+    // Check if this is the first message
+    let isFirstMessage = false;
+    if (editTargetTurnIndex !== undefined) {
+      isFirstMessage = editTargetTurnIndex === 0;
+    } else {
+      try {
+        const conversation = await this.conversationStore.getConversation(
+          this.currentConversationId,
+        );
+        isFirstMessage = !conversation || conversation.messages.length === 0;
+      } catch (error) {
+        logger.error(
+          '[SessionMessageHandler] Failed to check conversation:',
+          error,
+        );
+      }
+    }
+
+    // Generate title for first message, but only if it hasn't been set yet
+    if (isFirstMessage && !this.isTitleSet) {
+      this.sendToWebView({
+        type: 'sessionTitleUpdated',
+        data: {
+          sessionId: this.currentConversationId,
+          title: displayText,
+        },
+      });
+      this.isTitleSet = true; // Mark title as set
+    }
+
+    // Save user message
+    const userMessage: ChatMessage = {
+      role: 'user',
+      content: displayText,
+      timestamp: Date.now(),
+    };
+
+    try {
+      await this.conversationStore.addMessage(
+        this.currentConversationId,
+        userMessage,
+      );
+    } catch (error) {
+      logger.error(
+        '[SessionMessageHandler] Failed to save user message:',
+        error,
+      );
+
+      if (editAcpMutationApplied && editAcpHistorySnapshot) {
+        try {
+          await this.agentManager.restoreSessionHistory(editAcpHistorySnapshot);
+        } catch (restoreError) {
+          logger.warn(
+            '[SessionMessageHandler] Failed to restore ACP history after user message save failure:',
+            restoreError,
+          );
+        }
+      }
+
+      if (editStoreMutationApplied) {
+        await this.restoreConversationSnapshot(editRestoreSnapshot);
+      }
+
+      const errorMsg = this.getErrorMessage(error);
+      vscode.window.showErrorMessage(`Failed to edit message: ${errorMsg}`);
+      this.sendToWebView({
+        type: 'error',
+        data: { message: errorMsg },
+      });
+      return;
+    }
+
+    this.sendToWebView({
+      type: 'message',
+      data: { ...userMessage, fileContext },
+    });
+
+    // Check if agent is connected
+    if (!this.agentManager.isConnected) {
+      logger.warn('[SessionMessageHandler] Agent not connected');
+
+      // Show non-modal notification with Configure button
+      await this.promptAuth(
+        'You need to configure your provider to use Qwen Code.',
+      );
+      return;
+    }
+
+    // Ensure an ACP session exists before sending prompt
+    if (!this.agentManager.currentSessionId) {
+      try {
+        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+        const workingDir = workspaceFolder?.uri.fsPath || process.cwd();
+        await this.agentManager.createNewSession(workingDir);
+      } catch (createErr) {
+        logger.error(
+          '[SessionMessageHandler] Failed to create session before sending message:',
+          createErr,
+        );
+        const errorMsg = this.getErrorMessage(createErr);
+        if (this.shouldPromptAuth(createErr)) {
+          await this.promptAuth(
+            'Your session has expired or is invalid. Please configure your provider to continue using Qwen Code.',
+          );
+          return;
+        }
+        vscode.window.showErrorMessage(`Failed to create session: ${errorMsg}`);
+        return;
+      }
+    }
+
+    // Send to agent
+    //
+    // Generate a unique requestId so the webview can correlate
+    // streamStart/streamEnd and discard stale events.
+    this.requestCounter += 1;
+    this.currentRequestId = `req-${this.requestCounter}-${Date.now()}`;
+    this.streamEndSent = false;
+
+    // Capture locally so that if a newer handleSendMessage() overwrites
+    // the shared fields while we are awaiting, our sendStreamEnd calls
+    // will detect the mismatch and silently no-op instead of emitting
+    // a streamEnd tagged with the newer request's ID.
+    const myRequestId = this.currentRequestId;
+
+    try {
+      this.resetStreamContent();
+
+      this.sendToWebView({
+        type: 'streamStart',
+        data: {
+          timestamp: Date.now(),
+          requestId: myRequestId,
+        },
+      });
+
+      await this.agentManager.sendMessage(
+        buildPromptBlocks(promptText, promptImages),
+      );
+
+      // Save assistant message
+      if (this.currentStreamContent && this.currentConversationId) {
+        const assistantMessage: ChatMessage = {
+          role: 'assistant',
+          content: this.currentStreamContent,
+          timestamp: Date.now(),
+        };
+        await this.conversationStore.addMessage(
+          this.currentConversationId,
+          assistantMessage,
+        );
+      }
+
+      this.sendStreamEnd(undefined, myRequestId);
+
+      // After first message, sync ACP session ID to webview for session list highlighting
+      const acpSessionId = this.agentManager.currentSessionId;
+      if (acpSessionId && acpSessionId !== this.currentConversationId) {
+        const previousConversationId = this.currentConversationId;
+        if (previousConversationId) {
+          const renamed = await this.conversationStore.renameConversationId(
+            previousConversationId,
+            acpSessionId,
+          );
+          if (!renamed) {
+            logger.warn(
+              '[SessionMessageHandler] Failed to align conversation store with ACP session id:',
+              previousConversationId,
+              acpSessionId,
+            );
+            return;
+          }
+        }
+        this.updateCurrentConversationId(acpSessionId);
+        this.sendToWebView({
+          type: 'sessionTitleUpdated',
+          data: {
+            sessionId: acpSessionId,
+            title:
+              displayText.substring(0, 50) +
+              (displayText.length > 50 ? '...' : ''),
+          },
+        });
+      }
+    } catch (error) {
+      logger.error('[SessionMessageHandler] Error sending message:', error);
+
+      if (editAcpMutationApplied && editAcpHistorySnapshot) {
+        try {
+          await this.agentManager.restoreSessionHistory(editAcpHistorySnapshot);
+        } catch (restoreError) {
+          logger.warn(
+            '[SessionMessageHandler] Failed to restore ACP history after send failure:',
+            restoreError,
+          );
+        }
+      }
+
+      if (editStoreMutationApplied) {
+        await this.restoreConversationSnapshot(editRestoreSnapshot);
+      }
+
+      const err = error as unknown as Error;
+      // Safely convert error to string
+      const errorMsg = this.getErrorMessage(error);
+      const lower = errorMsg.toLowerCase();
+
+      // Suppress user-cancelled/aborted errors (ESC/Stop button)
+      const isAbortLike =
+        (err && (err as Error).name === 'AbortError') ||
+        lower.includes('abort') ||
+        lower.includes('aborted') ||
+        lower.includes('request was aborted') ||
+        lower.includes('canceled') ||
+        lower.includes('cancelled') ||
+        lower.includes('user_cancelled');
+
+      if (isAbortLike) {
+        // Do not show VS Code error popup for intentional cancellations.
+        // Ensure the webview knows the stream ended due to user action.
+        this.sendStreamEnd('user_cancelled', myRequestId);
+        return;
+      }
+      // Check for session not found error and handle it appropriately
+      if (
+        errorMsg.includes('Session not found') ||
+        this.shouldPromptAuth(error)
+      ) {
+        // Show a more user-friendly error message for expired sessions
+        await this.promptAuth(
+          'Your session has expired or is invalid. Please configure your provider to continue using Qwen Code.',
+        );
+
+        // Send a specific error to the webview for better UI handling
+        this.sendToWebView({
+          type: 'sessionExpired',
+          data: { message: 'Session expired. Please authenticate again.' },
+        });
+        this.sendStreamEnd('session_expired', myRequestId);
+      } else {
+        const isTimeoutError =
+          lower.includes('timeout') || lower.includes('timed out');
+        if (isTimeoutError) {
+          // Note: session_prompt no longer has a timeout, so this should rarely occur
+          // This path may still be hit for other methods (initialize, etc.) or network-level timeouts
+          logger.warn(
+            '[SessionMessageHandler] Request timed out; suppressing popup',
+          );
+
+          const timeoutMessage: ChatMessage = {
+            role: 'assistant',
+            content:
+              'Request timed out. This may be due to a network issue. Please try again.',
+            timestamp: Date.now(),
+          };
+
+          // Send a timeout message to the WebView
+          this.sendToWebView({
+            type: 'message',
+            data: timeoutMessage,
+          });
+          this.sendStreamEnd('timeout', myRequestId);
+        } else {
+          // Handling of Non-Timeout Errors
+          vscode.window.showErrorMessage(`Error sending message: ${errorMsg}`);
+          this.sendToWebView({
+            type: 'error',
+            data: { message: errorMsg },
+          });
+          this.sendStreamEnd('error', myRequestId);
+        }
+      }
+    }
+  }
+
+  /**
+   * Handle new Qwen session request
+   */
+  private async handleNewQwenSession(): Promise<void> {
+    try {
+      logger.log('[SessionMessageHandler] Creating new Qwen session...');
+
+      // Ensure connection (auth) before creating a new session
+      if (!this.agentManager.isConnected) {
+        const proceeded = await this.promptAuth(
+          'You need to configure your provider before creating a new session.',
+        );
+        if (!proceeded) {
+          return;
+        }
+      }
+
+      const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+      const workingDir = workspaceFolder?.uri.fsPath || process.cwd();
+
+      await this.agentManager.createNewSession(workingDir, { forceNew: true });
+      this.updateCurrentConversationId(null);
+
+      this.sendToWebView({
+        type: 'conversationCleared',
+        data: {},
+      });
+
+      // Reset title flag when creating a new session
+      this.isTitleSet = false;
+    } catch (error) {
+      logger.error(
+        '[SessionMessageHandler] Failed to create new session:',
+        error,
+      );
+
+      // Safely convert error to string
+      const errorMsg = this.getErrorMessage(error);
+      // Check for authentication/session expiration errors
+      if (this.shouldPromptAuth(error)) {
+        // Show a more user-friendly error message for expired sessions
+        await this.promptAuth(
+          'Your session has expired or is invalid. Please configure your provider to create a new session.',
+        );
+
+        // Send a specific error to the webview for better UI handling
+        this.sendToWebView({
+          type: 'sessionExpired',
+          data: { message: 'Session expired. Please authenticate again.' },
+        });
+      } else {
+        this.sendToWebView({
+          type: 'error',
+          data: { message: `Failed to create new session: ${errorMsg}` },
+        });
+      }
+    }
+  }
+
+  /**
+   * Handle switch Qwen session request
+   */
+  private async handleSwitchQwenSession(sessionId: string): Promise<void> {
+    try {
+      logger.log('[SessionMessageHandler] Switching to session:', sessionId);
+
+      // If not connected yet, offer to authenticate or view offline
+      if (!this.agentManager.isConnected) {
+        const choice = await this.promptAuthOrOffline(
+          'You are not authenticated. Configure your provider to fully restore this session, or view it offline.',
+        );
+
+        if (choice === 'offline') {
+          // Show messages from local cache only
+          const messages =
+            await this.agentManager.getSessionMessages(sessionId);
+          this.updateCurrentConversationId(sessionId);
+          this.sendToWebView({
+            type: 'qwenSessionSwitched',
+            data: { sessionId, messages },
+          });
+          this.sendToWebView({
+            type: 'sessionLoadComplete',
+            data: { sessionId },
+          });
+          vscode.window.showInformationMessage(
+            'Showing cached session content. Configure your provider to interact with the AI.',
+          );
+          return;
+        } else if (choice !== 'auth') {
+          // User dismissed; clear loading state
+          this.sendToWebView({
+            type: 'sessionLoadComplete',
+            data: { sessionId },
+          });
+          return;
+        }
+      }
+
+      // Get session details (includes cwd and filePath when using ACP)
+      let sessionDetails: Record<string, unknown> | null = null;
+      try {
+        const allSessions = await this.agentManager.getSessionList();
+        sessionDetails =
+          allSessions.find(
+            (s: { id?: string; sessionId?: string }) =>
+              s.id === sessionId || s.sessionId === sessionId,
+          ) || null;
+      } catch (err) {
+        logger.log(
+          '[SessionMessageHandler] Could not get session details:',
+          err,
+        );
+      }
+
+      const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+      const workingDir = workspaceFolder?.uri.fsPath || process.cwd();
+
+      // Try to load session via ACP (now we should be connected)
+      try {
+        // Set current id and clear UI first so replayed updates append afterwards
+        this.updateCurrentConversationId(sessionId);
+        this.sendToWebView({
+          type: 'qwenSessionSwitched',
+          data: { sessionId, messages: [], session: sessionDetails },
+        });
+
+        const loadResponse = await this.agentManager.loadSessionViaAcp(
+          sessionId,
+          (sessionDetails?.cwd as string | undefined) || undefined,
+        );
+        logger.log(
+          '[SessionMessageHandler] session/load succeeded (per ACP spec result is null; actual history comes via session/update):',
+          loadResponse,
+        );
+
+        // Reset title flag when switching sessions
+        this.isTitleSet = false;
+
+        // Notify webview that session history has finished loading
+        this.sendToWebView({
+          type: 'sessionLoadComplete',
+          data: { sessionId },
+        });
+
+        // Successfully loaded session, return early to avoid fallback logic
+        return;
+      } catch (loadError) {
+        logger.warn(
+          '[SessionMessageHandler] session/load failed, using fallback:',
+          loadError,
+        );
+
+        // Check for authentication/session expiration errors
+        if (this.shouldPromptAuth(loadError)) {
+          // Show a more user-friendly error message for expired sessions
+          await this.promptAuth(
+            'Your session has expired or is invalid. Please configure your provider to switch sessions.',
+          );
+
+          // Send a specific error to the webview for better UI handling
+          this.sendToWebView({
+            type: 'sessionExpired',
+            data: { message: 'Session expired. Please authenticate again.' },
+          });
+          return;
+        }
+
+        // Fallback: create new session
+        const messages = await this.agentManager.getSessionMessages(sessionId);
+
+        // If we are connected, try to create a fresh ACP session so user can interact
+        if (this.agentManager.isConnected) {
+          try {
+            await this.agentManager.createNewSession(workingDir, {
+              forceNew: true,
+            });
+
+            // Keep the viewed session identity aligned with what the webview sees
+            // (the archived sessionId). The live ACP session lives on
+            // agentManager.currentSessionId; the sync-on-first-message path
+            // (see streamEnd handler) will flip both sides to the ACP id once
+            // the user actually sends a message. Setting currentConversationId
+            // to the new ACP id here would desync the backend from the webview
+            // and cause rename/delete/title-update flows to target the wrong
+            // session during the fallback window.
+            this.updateCurrentConversationId(sessionId);
+
+            this.sendToWebView({
+              type: 'qwenSessionSwitched',
+              data: { sessionId, messages, session: sessionDetails },
+            });
+            this.sendToWebView({
+              type: 'sessionLoadComplete',
+              data: { sessionId },
+            });
+
+            // Only show the cache warning if we actually fell back to local cache
+            // and didn't successfully load via ACP
+            // Check if we truly fell back by checking if loadError is not null/undefined
+            // and if it's not a successful response that looks like an error
+            if (
+              loadError &&
+              typeof loadError === 'object' &&
+              !('result' in loadError)
+            ) {
+              vscode.window.showWarningMessage(
+                'Session restored from local cache. Some context may be incomplete.',
+              );
+            }
+          } catch (createError) {
+            logger.error(
+              '[SessionMessageHandler] Failed to create session:',
+              createError,
+            );
+
+            // Check for authentication/session expiration errors in session creation
+            if (this.shouldPromptAuth(createError)) {
+              // Show a more user-friendly error message for expired sessions
+              await this.promptAuth(
+                'Your session has expired or is invalid. Please configure your provider to switch sessions.',
+              );
+
+              // Send a specific error to the webview for better UI handling
+              this.sendToWebView({
+                type: 'sessionExpired',
+                data: {
+                  message: 'Session expired. Please authenticate again.',
+                },
+              });
+              return;
+            }
+
+            throw createError;
+          }
+        } else {
+          // Offline view only
+          this.updateCurrentConversationId(sessionId);
+          this.sendToWebView({
+            type: 'qwenSessionSwitched',
+            data: { sessionId, messages, session: sessionDetails },
+          });
+          this.sendToWebView({
+            type: 'sessionLoadComplete',
+            data: { sessionId },
+          });
+          vscode.window.showWarningMessage(
+            'Showing cached session content. Configure your provider to interact with the AI.',
+          );
+        }
+      }
+    } catch (error) {
+      logger.error('[SessionMessageHandler] Failed to switch session:', error);
+
+      // Safely convert error to string
+      const errorMsg = this.getErrorMessage(error);
+      // Check for authentication/session expiration errors
+      if (this.shouldPromptAuth(error)) {
+        // Show a more user-friendly error message for expired sessions
+        await this.promptAuth(
+          'Your session has expired or is invalid. Please configure your provider to switch sessions.',
+        );
+
+        // Send a specific error to the webview for better UI handling
+        this.sendToWebView({
+          type: 'sessionExpired',
+          data: { message: 'Session expired. Please authenticate again.' },
+        });
+      } else {
+        this.sendToWebView({
+          type: 'error',
+          data: { message: `Failed to switch session: ${errorMsg}` },
+        });
+      }
+    }
+  }
+
+  /**
+   * Handle get Qwen sessions request
+   */
+  private async handleGetQwenSessions(
+    cursor?: number,
+    size?: number,
+  ): Promise<void> {
+    try {
+      // Paged when possible; falls back to full list if ACP not supported
+      const page = await this.agentManager.getSessionListPaged({
+        cursor,
+        size,
+      });
+      const append = typeof cursor === 'number';
+      this.sendToWebView({
+        type: 'qwenSessionList',
+        data: {
+          sessions: page.sessions,
+          nextCursor: page.nextCursor,
+          hasMore: page.hasMore,
+          append,
+        },
+      });
+    } catch (error) {
+      logger.error('[SessionMessageHandler] Failed to get sessions:', error);
+
+      // Safely convert error to string
+      const errorMsg = this.getErrorMessage(error);
+      // Check for authentication/session expiration errors
+      if (this.shouldPromptAuth(error)) {
+        // Show a more user-friendly error message for expired sessions
+        await this.promptAuth(
+          'Your session has expired or is invalid. Please configure your provider to view sessions.',
+        );
+
+        // Send a specific error to the webview for better UI handling
+        this.sendToWebView({
+          type: 'sessionExpired',
+          data: { message: 'Session expired. Please authenticate again.' },
+        });
+      } else {
+        this.sendToWebView({
+          type: 'error',
+          data: { message: `Failed to get sessions: ${errorMsg}` },
+        });
+      }
+    }
+  }
+
+  /**
+   * Handle cancel streaming request
+   */
+  private async handleCancelStreaming(): Promise<void> {
+    try {
+      logger.log('[SessionMessageHandler] Canceling streaming...');
+
+      // Cancel the current streaming operation in the agent manager
+      await this.agentManager.cancelCurrentPrompt();
+
+      // Use sendStreamEnd to include requestId for proper correlation
+      this.sendStreamEnd('user_cancelled');
+
+      logger.log('[SessionMessageHandler] Streaming cancelled successfully');
+    } catch (_error) {
+      logger.log('[SessionMessageHandler] Streaming cancelled (interrupted)');
+
+      // Use sendStreamEnd (with duplicate guard) to include requestId
+      this.sendStreamEnd('user_cancelled');
+    }
+  }
+
+  /**
+   * Handle resume session request
+   */
+  private async handleResumeSession(sessionId: string): Promise<void> {
+    try {
+      // If not connected, offer to authenticate or view offline
+      if (!this.agentManager.isConnected) {
+        const choice = await this.promptAuthOrOffline(
+          'You are not authenticated. Configure your provider to fully restore this session, or view it offline.',
+        );
+
+        if (choice === 'offline') {
+          const messages =
+            await this.agentManager.getSessionMessages(sessionId);
+          this.updateCurrentConversationId(sessionId);
+          this.sendToWebView({
+            type: 'qwenSessionSwitched',
+            data: { sessionId, messages },
+          });
+          vscode.window.showInformationMessage(
+            'Showing cached session content. Configure your provider to interact with the AI.',
+          );
+          return;
+        } else if (choice !== 'auth') {
+          return;
+        }
+      }
+
+      // Try ACP load first
+      try {
+        // Pre-clear UI so replayed updates append afterwards
+        this.updateCurrentConversationId(sessionId);
+        this.sendToWebView({
+          type: 'qwenSessionSwitched',
+          data: { sessionId, messages: [] },
+        });
+
+        await this.agentManager.loadSessionViaAcp(sessionId);
+
+        // Reset title flag when resuming sessions
+        this.isTitleSet = false;
+
+        // Successfully loaded session, return early to avoid fallback logic
+        await this.handleGetQwenSessions();
+        return;
+      } catch (acpError) {
+        // Check for authentication/session expiration errors
+        if (this.shouldPromptAuth(acpError)) {
+          // Show a more user-friendly error message for expired sessions
+          await this.promptAuth(
+            'Your session has expired or is invalid. Please configure your provider to resume sessions.',
+          );
+
+          // Send a specific error to the webview for better UI handling
+          this.sendToWebView({
+            type: 'sessionExpired',
+            data: { message: 'Session expired. Please authenticate again.' },
+          });
+          return;
+        }
+      }
+
+      await this.handleGetQwenSessions();
+    } catch (error) {
+      logger.error('[SessionMessageHandler] Failed to resume session:', error);
+
+      // Safely convert error to string
+      const errorMsg = this.getErrorMessage(error);
+      // Check for authentication/session expiration errors
+      if (this.shouldPromptAuth(error)) {
+        // Show a more user-friendly error message for expired sessions
+        await this.promptAuth(
+          'Your session has expired or is invalid. Please configure your provider to resume sessions.',
+        );
+
+        // Send a specific error to the webview for better UI handling
+        this.sendToWebView({
+          type: 'sessionExpired',
+          data: { message: 'Session expired. Please authenticate again.' },
+        });
+      } else {
+        this.sendToWebView({
+          type: 'error',
+          data: { message: `Failed to resume session: ${errorMsg}` },
+        });
+      }
+    }
+  }
+
+  /**
+   * Handle delete session request
+   */
+  private async handleDeleteQwenSession(sessionId: string): Promise<void> {
+    try {
+      if (
+        sessionId === this.currentConversationId ||
+        sessionId === this.agentManager.currentSessionId
+      ) {
+        this.sendToWebView({
+          type: 'error',
+          data: { message: 'Cannot delete the current active session.' },
+        });
+        return;
+      }
+
+      const success = await this.agentManager.deleteSession(sessionId);
+      if (success) {
+        this.sendToWebView({
+          type: 'sessionDeleted',
+          data: { sessionId },
+        });
+      } else {
+        this.sendToWebView({
+          type: 'error',
+          data: { message: 'Failed to delete session.' },
+        });
+      }
+    } catch (error) {
+      const errorMsg = this.getErrorMessage(error);
+      this.sendToWebView({
+        type: 'error',
+        data: { message: `Failed to delete session: ${errorMsg}` },
+      });
+    }
+  }
+
+  /**
+   * Handle rename session request
+   */
+  private async handleRenameQwenSession(
+    sessionId: string,
+    title: string,
+  ): Promise<void> {
+    try {
+      const trimmedTitle = title.trim().replace(/[\r\n]+/g, ' ');
+      if (!trimmedTitle) {
+        this.sendToWebView({
+          type: 'error',
+          data: { message: 'Please provide a name.' },
+        });
+        return;
+      }
+      // Matches SESSION_TITLE_MAX_LENGTH from @qwen-code/qwen-code-core/sessionService
+      if (trimmedTitle.length > 200) {
+        this.sendToWebView({
+          type: 'error',
+          data: { message: 'Name is too long. Maximum 200 characters.' },
+        });
+        return;
+      }
+
+      const success = await this.agentManager.renameSession(
+        sessionId,
+        trimmedTitle,
+      );
+      if (success) {
+        this.sendToWebView({
+          type: 'sessionRenamed',
+          data: { sessionId, title: trimmedTitle },
+        });
+        if (sessionId === this.currentConversationId) {
+          this.sendToWebView({
+            type: 'sessionTitleUpdated',
+            data: { sessionId, title: trimmedTitle },
+          });
+        }
+      } else {
+        this.sendToWebView({
+          type: 'error',
+          data: { message: 'Failed to rename session.' },
+        });
+      }
+    } catch (error) {
+      const errorMsg = this.getErrorMessage(error);
+      this.sendToWebView({
+        type: 'error',
+        data: { message: `Failed to rename session: ${errorMsg}` },
+      });
+    }
+  }
+
+  /**
+   * Set approval mode via agent (ACP session/set_mode)
+   */
+  private async handleSetApprovalMode(data?: {
+    modeId?: ApprovalModeValue;
+  }): Promise<void> {
+    try {
+      const modeId = data?.modeId || 'default';
+      await this.agentManager.setApprovalModeFromUi(modeId);
+      // No explicit response needed; WebView listens for modeChanged
+    } catch (error) {
+      logger.error('[SessionMessageHandler] Failed to set mode:', error);
+      const errorMsg = this.getErrorMessage(error);
+      this.sendToWebView({
+        type: 'error',
+        data: { message: `Failed to set mode: ${errorMsg}` },
+      });
+    }
+  }
+
+  /**
+   * Set model via agent (ACP session/set_model)
+   * Displays VSCode native notifications on success or failure.
+   */
+  private async handleSetModel(data?: { modelId?: string }): Promise<void> {
+    try {
+      const modelId = data?.modelId;
+      if (!modelId) {
+        throw new Error('Model ID is required');
+      }
+      // Defensive guard: refuse non-runtime Qwen OAuth models in case the UI
+      // is bypassed (programmatic call, stale webview, restored session).
+      if (isDiscontinuedModel(modelId)) {
+        logger.warn(
+          '[SessionMessageHandler] Rejected discontinued model',
+          modelId,
+        );
+        const message = `Failed to switch model: ${DISCONTINUED_MESSAGES.blockedError}`;
+        vscode.window.showErrorMessage(message);
+        this.sendToWebView({
+          type: 'error',
+          data: { message },
+        });
+        return;
+      }
+      await this.agentManager.setModelFromUi(modelId);
+      void vscode.window.showInformationMessage(
+        `Model switched to: ${modelId}`,
+      );
+    } catch (error) {
+      const errorMsg = this.getErrorMessage(error);
+      logger.error('[SessionMessageHandler] Failed to set model:', error);
+      vscode.window.showErrorMessage(`Failed to switch model: ${errorMsg}`);
+      this.sendToWebView({
+        type: 'error',
+        data: { message: `Failed to set model: ${errorMsg}` },
+      });
+    }
+  }
+}

--- a/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.ts
@@ -37,7 +37,9 @@ function formatExportSuccessMessage(
   filename: string,
   filePath: string,
 ): string {
-  const markdownLinkPath = pathToFileURL(filePath).href;
+  const markdownLinkPath = pathToFileURL(filePath)
+    .href.replace(/\(/g, '%28')
+    .replace(/\)/g, '%29');
   return `Session exported to ${formatLabel}: [${filename}](${markdownLinkPath})`;
 }
 
@@ -508,1095 +510,124 @@ export class SessionMessageHandler extends BaseMessageHandler {
     // Guard: do not process empty or whitespace-only messages.
     // This prevents ghost user-message bubbles when slash-command completions
     // or model-selector interactions clear the input but still trigger a submit.
-    const trimmedText = stripZeroWidthSpaces(text).trim();
-    const hasAttachments = (attachments?.length ?? 0) > 0;
-    if (!trimmedText && !hasAttachments) {
-      logger.warn('[SessionMessageHandler] Ignoring empty message');
-      return;
-    }
-
-    try {
-      const exportFormat = parseExportSlashCommand(trimmedText);
-      if (exportFormat) {
-        await this.handleExportCommand(exportFormat);
-        return;
-      }
-    } catch (error) {
-      const errorMsg = this.getErrorMessage(error);
-      this.sendToWebView({
-        type: 'error',
-        data: { message: errorMsg },
-      });
-      return;
-    }
-
-    let displayText = trimmedText ? text : '';
-    let promptText = text;
-    if (context && context.length > 0) {
-      const contextParts = context
-        .map((ctx) => {
-          if (ctx.startLine && ctx.endLine) {
-            return `${ctx.value}#${ctx.startLine}${ctx.startLine !== ctx.endLine ? `-${ctx.endLine}` : ''}`;
-          }
-          return ctx.value;
-        })
-        .join('\n');
-
-      promptText = `${contextParts}\n\n${text}`;
-    }
-
-    const {
-      formattedText,
-      displayText: updatedDisplayText,
-      savedImageCount,
-      promptImages,
-    } = await processImageAttachments(promptText, attachments);
-    for (const ctx of context ?? []) {
-      const mimeType = ctx.isImage
-        ? getDisplayableImageMimeType(ctx.value)
-        : undefined;
-      if (mimeType) {
-        promptImages.push({
-          path: ctx.value,
-          name: ctx.name,
-          mimeType,
-        });
-      }
-    }
-    promptText = formattedText;
-    displayText = updatedDisplayText;
-
-    if (hasAttachments && !trimmedText && savedImageCount === 0) {
-      const errorMsg =
-        'Failed to attach the pasted image. Nothing was sent. Please paste the image again.';
-      logger.warn('[SessionMessageHandler]', errorMsg);
-      vscode.window.showErrorMessage(errorMsg);
-      this.sendToWebView({
-        type: 'error',
-        data: { message: errorMsg },
-      });
-      return;
-    }
-
-    // Ensure we have an active conversation
-    if (!this.currentConversationId) {
-      logger.log(
-        '[SessionMessageHandler] No active conversation, creating one...',
-      );
-      try {
-        const newConv = await this.conversationStore.createConversation();
-        this.updateCurrentConversationId(newConv.id);
-        this.sendToWebView({
-          type: 'conversationLoaded',
-          data: newConv,
-        });
-      } catch (error) {
-        const errorMsg = `Failed to create conversation: ${this.getErrorMessage(error)}`;
-        logger.error('[SessionMessageHandler]', errorMsg);
-        vscode.window.showErrorMessage(errorMsg);
-        this.sendToWebView({
-          type: 'error',
-          data: { message: errorMsg },
-        });
-        return;
-      }
-    }
-
-    if (!this.currentConversationId) {
-      const errorMsg =
-        'Failed to create conversation. Please restart the extension.';
-      logger.error('[SessionMessageHandler]', errorMsg);
-      vscode.window.showErrorMessage(errorMsg);
-      this.sendToWebView({
-        type: 'error',
-        data: { message: errorMsg },
-      });
-      return;
-    }
-
-    let editRestoreSnapshot: Conversation | null = null;
-    let editStoreMutationApplied = false;
-    let editAcpMutationApplied = false;
-    let editAcpHistorySnapshot: unknown[] | null = null;
-
-    if (editTargetTurnIndex !== undefined) {
-      if (!Number.isInteger(editTargetTurnIndex) || editTargetTurnIndex < 0) {
-        const errorMsg = 'Invalid message edit target.';
-        logger.error('[SessionMessageHandler]', errorMsg, editTargetTurnIndex);
-        this.sendToWebView({
-          type: 'error',
-          data: { message: errorMsg },
-        });
-        return;
-      }
-
-      if (!this.agentManager.isConnected) {
-        await this.promptAuth(
-          'You need to configure your provider to use Qwen Code.',
-        );
-        return;
-      }
-
-      if (!this.agentManager.currentSessionId) {
-        try {
-          const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-          const workingDir = workspaceFolder?.uri.fsPath || process.cwd();
-          await this.agentManager.createNewSession(workingDir);
-        } catch (createErr) {
-          logger.error(
-            '[SessionMessageHandler] Failed to create session before editing message:',
-            createErr,
-          );
-          const errorMsg = this.getErrorMessage(createErr);
-          if (this.shouldPromptAuth(createErr)) {
-            await this.promptAuth(
-              'Your session has expired or is invalid. Please configure your provider to continue using Qwen Code.',
-            );
-            return;
-          }
-          vscode.window.showErrorMessage(
-            `Failed to create session: ${errorMsg}`,
-          );
-          return;
-        }
-      }
-
-      try {
-        editRestoreSnapshot = await this.captureConversationSnapshot(
-          this.currentConversationId,
-        );
-      } catch (error) {
-        logger.error(
-          '[SessionMessageHandler] Failed to capture edit restore snapshot:',
-          error,
-        );
-        const errorMsg = this.getErrorMessage(error);
-        vscode.window.showErrorMessage(`Failed to edit message: ${errorMsg}`);
-        this.sendToWebView({
-          type: 'error',
-          data: { message: errorMsg },
-        });
-        return;
-      }
-
-      if (!editRestoreSnapshot) {
-        logger.warn(
-          '[SessionMessageHandler] Local conversation snapshot missing before edit; continuing with ACP rewind only.',
-        );
-      }
-
-      try {
-        if (editRestoreSnapshot) {
-          const truncated = await this.conversationStore.truncateFromUserTurn(
-            this.currentConversationId,
-            editTargetTurnIndex,
-          );
-          if (!truncated) {
-            throw new Error('Conversation not found for edit target.');
-          }
-          editStoreMutationApplied = true;
-        }
-
-        const rewindResult =
-          await this.agentManager.rewindSession(editTargetTurnIndex);
-        editAcpHistorySnapshot = rewindResult?.historyBeforeRewind ?? null;
-        editAcpMutationApplied = true;
-
-        this.sendToWebView({
-          type: 'conversationRewound',
-          data: { targetTurnIndex: editTargetTurnIndex },
-        });
-      } catch (error) {
-        if (editAcpMutationApplied && editAcpHistorySnapshot) {
-          try {
-            await this.agentManager.restoreSessionHistory(
-              editAcpHistorySnapshot,
-            );
-          } catch (restoreError) {
-            logger.warn(
-              '[SessionMessageHandler] Failed to restore ACP history after rewind failure:',
-              restoreError,
-            );
-          }
-        }
-        if (editStoreMutationApplied) {
-          await this.restoreConversationSnapshot(editRestoreSnapshot);
-        }
-        const errorMsg = this.getErrorMessage(error);
-        logger.error(
-          '[SessionMessageHandler] Failed to rewind session:',
-          error,
-        );
-        vscode.window.showErrorMessage(`Failed to edit message: ${errorMsg}`);
-        this.sendToWebView({
-          type: 'error',
-          data: { message: errorMsg },
-        });
-        return;
-      }
-    }
-
-    // Check if this is the first message
-    let isFirstMessage = false;
-    if (editTargetTurnIndex !== undefined) {
-      isFirstMessage = editTargetTurnIndex === 0;
-    } else {
-      try {
-        const conversation = await this.conversationStore.getConversation(
-          this.currentConversationId,
-        );
-        isFirstMessage = !conversation || conversation.messages.length === 0;
-      } catch (error) {
-        logger.error(
-          '[SessionMessageHandler] Failed to check conversation:',
-          error,
-        );
-      }
-    }
-
-    // Generate title for first message, but only if it hasn't been set yet
-    if (isFirstMessage && !this.isTitleSet) {
-      this.sendToWebView({
-        type: 'sessionTitleUpdated',
-        data: {
-          sessionId: this.currentConversationId,
-          title: displayText,
-        },
-      });
-      this.isTitleSet = true; // Mark title as set
-    }
-
-    // Save user message
-    const userMessage: ChatMessage = {
-      role: 'user',
-      content: displayText,
-      timestamp: Date.now(),
-    };
-
-    try {
-      await this.conversationStore.addMessage(
-        this.currentConversationId,
-        userMessage,
-      );
-    } catch (error) {
-      logger.error(
-        '[SessionMessageHandler] Failed to save user message:',
-        error,
-      );
-
-      if (editAcpMutationApplied && editAcpHistorySnapshot) {
-        try {
-          await this.agentManager.restoreSessionHistory(editAcpHistorySnapshot);
-        } catch (restoreError) {
-          logger.warn(
-            '[SessionMessageHandler] Failed to restore ACP history after user message save failure:',
-            restoreError,
-          );
-        }
-      }
-
-      if (editStoreMutationApplied) {
-        await this.restoreConversationSnapshot(editRestoreSnapshot);
-      }
-
-      const errorMsg = this.getErrorMessage(error);
-      vscode.window.showErrorMessage(`Failed to edit message: ${errorMsg}`);
-      this.sendToWebView({
-        type: 'error',
-        data: { message: errorMsg },
-      });
-      return;
-    }
-
-    this.sendToWebView({
-      type: 'message',
-      data: { ...userMessage, fileContext },
-    });
-
-    // Check if agent is connected
-    if (!this.agentManager.isConnected) {
-      logger.warn('[SessionMessageHandler] Agent not connected');
-
-      // Show non-modal notification with Configure button
-      await this.promptAuth(
-        'You need to configure your provider to use Qwen Code.',
-      );
-      return;
-    }
-
-    // Ensure an ACP session exists before sending prompt
-    if (!this.agentManager.currentSessionId) {
-      try {
-        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-        const workingDir = workspaceFolder?.uri.fsPath || process.cwd();
-        await this.agentManager.createNewSession(workingDir);
-      } catch (createErr) {
-        logger.error(
-          '[SessionMessageHandler] Failed to create session before sending message:',
-          createErr,
-        );
-        const errorMsg = this.getErrorMessage(createErr);
-        if (this.shouldPromptAuth(createErr)) {
-          await this.promptAuth(
-            'Your session has expired or is invalid. Please configure your provider to continue using Qwen Code.',
-          );
-          return;
-        }
-        vscode.window.showErrorMessage(`Failed to create session: ${errorMsg}`);
-        return;
-      }
-    }
-
-    // Send to agent
-    //
-    // Generate a unique requestId so the webview can correlate
-    // streamStart/streamEnd and discard stale events.
-    this.requestCounter += 1;
-    this.currentRequestId = `req-${this.requestCounter}-${Date.now()}`;
-    this.streamEndSent = false;
-
-    // Capture locally so that if a newer handleSendMessage() overwrites
-    // the shared fields while we are awaiting, our sendStreamEnd calls
-    // will detect the mismatch and silently no-op instead of emitting
-    // a streamEnd tagged with the newer request's ID.
-    const myRequestId = this.currentRequestId;
-
-    try {
-      this.resetStreamContent();
-
-      this.sendToWebView({
-        type: 'streamStart',
-        data: {
-          timestamp: Date.now(),
-          requestId: myRequestId,
-        },
-      });
-
-      await this.agentManager.sendMessage(
-        buildPromptBlocks(promptText, promptImages),
-      );
-
-      // Save assistant message
-      if (this.currentStreamContent && this.currentConversationId) {
-        const assistantMessage: ChatMessage = {
-          role: 'assistant',
-          content: this.currentStreamContent,
-          timestamp: Date.now(),
-        };
-        await this.conversationStore.addMessage(
-          this.currentConversationId,
-          assistantMessage,
-        );
-      }
-
-      this.sendStreamEnd(undefined, myRequestId);
-
-      // After first message, sync ACP session ID to webview for session list highlighting
-      const acpSessionId = this.agentManager.currentSessionId;
-      if (acpSessionId && acpSessionId !== this.currentConversationId) {
-        const previousConversationId = this.currentConversationId;
-        if (previousConversationId) {
-          const renamed = await this.conversationStore.renameConversationId(
-            previousConversationId,
-            acpSessionId,
-          );
-          if (!renamed) {
-            logger.warn(
-              '[SessionMessageHandler] Failed to align conversation store with ACP session id:',
-              previousConversationId,
-              acpSessionId,
-            );
-            return;
-          }
-        }
-        this.updateCurrentConversationId(acpSessionId);
-        this.sendToWebView({
-          type: 'sessionTitleUpdated',
-          data: {
-            sessionId: acpSessionId,
-            title:
-              displayText.substring(0, 50) +
-              (displayText.length > 50 ? '...' : ''),
-          },
-        });
-      }
-    } catch (error) {
-      logger.error('[SessionMessageHandler] Error sending message:', error);
-
-      if (editAcpMutationApplied && editAcpHistorySnapshot) {
-        try {
-          await this.agentManager.restoreSessionHistory(editAcpHistorySnapshot);
-        } catch (restoreError) {
-          logger.warn(
-            '[SessionMessageHandler] Failed to restore ACP history after send failure:',
-            restoreError,
-          );
-        }
-      }
-
-      if (editStoreMutationApplied) {
-        await this.restoreConversationSnapshot(editRestoreSnapshot);
-      }
-
-      const err = error as unknown as Error;
-      // Safely convert error to string
-      const errorMsg = this.getErrorMessage(error);
-      const lower = errorMsg.toLowerCase();
-
-      // Suppress user-cancelled/aborted errors (ESC/Stop button)
-      const isAbortLike =
-        (err && (err as Error).name === 'AbortError') ||
-        lower.includes('abort') ||
-        lower.includes('aborted') ||
-        lower.includes('request was aborted') ||
-        lower.includes('canceled') ||
-        lower.includes('cancelled') ||
-        lower.includes('user_cancelled');
-
-      if (isAbortLike) {
-        // Do not show VS Code error popup for intentional cancellations.
-        // Ensure the webview knows the stream ended due to user action.
-        this.sendStreamEnd('user_cancelled', myRequestId);
-        return;
-      }
-      // Check for session not found error and handle it appropriately
-      if (
-        errorMsg.includes('Session not found') ||
-        this.shouldPromptAuth(error)
-      ) {
-        // Show a more user-friendly error message for expired sessions
-        await this.promptAuth(
-          'Your session has expired or is invalid. Please configure your provider to continue using Qwen Code.',
-        );
-
-        // Send a specific error to the webview for better UI handling
-        this.sendToWebView({
-          type: 'sessionExpired',
-          data: { message: 'Session expired. Please authenticate again.' },
-        });
-        this.sendStreamEnd('session_expired', myRequestId);
-      } else {
-        const isTimeoutError =
-          lower.includes('timeout') || lower.includes('timed out');
-        if (isTimeoutError) {
-          // Note: session_prompt no longer has a timeout, so this should rarely occur
-          // This path may still be hit for other methods (initialize, etc.) or network-level timeouts
-          logger.warn(
-            '[SessionMessageHandler] Request timed out; suppressing popup',
-          );
-
-          const timeoutMessage: ChatMessage = {
-            role: 'assistant',
-            content:
-              'Request timed out. This may be due to a network issue. Please try again.',
-            timestamp: Date.now(),
-          };
-
-          // Send a timeout message to the WebView
-          this.sendToWebView({
-            type: 'message',
-            data: timeoutMessage,
-          });
-          this.sendStreamEnd('timeout', myRequestId);
-        } else {
-          // Handling of Non-Timeout Errors
-          vscode.window.showErrorMessage(`Error sending message: ${errorMsg}`);
-          this.sendToWebView({
-            type: 'error',
-            data: { message: errorMsg },
-          });
-          this.sendStreamEnd('error', myRequestId);
-        }
-      }
-    }
-  }
-
-  /**
-   * Handle new Qwen session request
-   */
-  private async handleNewQwenSession(): Promise<void> {
-    try {
-      logger.log('[SessionMessageHandler] Creating new Qwen session...');
-
-      // Ensure connection (auth) before creating a new session
-      if (!this.agentManager.isConnected) {
-        const proceeded = await this.promptAuth(
-          'You need to configure your provider before creating a new session.',
-        );
-        if (!proceeded) {
-          return;
-        }
-      }
-
-      const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-      const workingDir = workspaceFolder?.uri.fsPath || process.cwd();
-
-      await this.agentManager.createNewSession(workingDir, { forceNew: true });
-      this.updateCurrentConversationId(null);
-
-      this.sendToWebView({
-        type: 'conversationCleared',
-        data: {},
-      });
-
-      // Reset title flag when creating a new session
-      this.isTitleSet = false;
-    } catch (error) {
-      logger.error(
-        '[SessionMessageHandler] Failed to create new session:',
-        error,
-      );
-
-      // Safely convert error to string
-      const errorMsg = this.getErrorMessage(error);
-      // Check for authentication/session expiration errors
-      if (this.shouldPromptAuth(error)) {
-        // Show a more user-friendly error message for expired sessions
-        await this.promptAuth(
-          'Your session has expired or is invalid. Please configure your provider to create a new session.',
-        );
-
-        // Send a specific error to the webview for better UI handling
-        this.sendToWebView({
-          type: 'sessionExpired',
-          data: { message: 'Session expired. Please authenticate again.' },
-        });
-      } else {
-        this.sendToWebView({
-          type: 'error',
-          data: { message: `Failed to create new session: ${errorMsg}` },
-        });
-      }
-    }
-  }
-
-  /**
-   * Handle switch Qwen session request
-   */
-  private async handleSwitchQwenSession(sessionId: string): Promise<void> {
-    try {
-      logger.log('[SessionMessageHandler] Switching to session:', sessionId);
-
-      // If not connected yet, offer to authenticate or view offline
-      if (!this.agentManager.isConnected) {
-        const choice = await this.promptAuthOrOffline(
-          'You are not authenticated. Configure your provider to fully restore this session, or view it offline.',
-        );
-
-        if (choice === 'offline') {
-          // Show messages from local cache only
-          const messages =
-            await this.agentManager.getSessionMessages(sessionId);
-          this.updateCurrentConversationId(sessionId);
-          this.sendToWebView({
-            type: 'qwenSessionSwitched',
-            data: { sessionId, messages },
-          });
-          this.sendToWebView({
-            type: 'sessionLoadComplete',
-            data: { sessionId },
-          });
-          vscode.window.showInformationMessage(
-            'Showing cached session content. Configure your provider to interact with the AI.',
-          );
-          return;
-        } else if (choice !== 'auth') {
-          // User dismissed; clear loading state
-          this.sendToWebView({
-            type: 'sessionLoadComplete',
-            data: { sessionId },
-          });
-          return;
-        }
-      }
-
-      // Get session details (includes cwd and filePath when using ACP)
-      let sessionDetails: Record<string, unknown> | null = null;
-      try {
-        const allSessions = await this.agentManager.getSessionList();
-        sessionDetails =
-          allSessions.find(
-            (s: { id?: string; sessionId?: string }) =>
-              s.id === sessionId || s.sessionId === sessionId,
-          ) || null;
-      } catch (err) {
-        logger.log(
-          '[SessionMessageHandler] Could not get session details:',
-          err,
-        );
-      }
-
-      const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-      const workingDir = workspaceFolder?.uri.fsPath || process.cwd();
-
-      // Try to load session via ACP (now we should be connected)
-      try {
-        // Set current id and clear UI first so replayed updates append afterwards
-        this.updateCurrentConversationId(sessionId);
-        this.sendToWebView({
-          type: 'qwenSessionSwitched',
-          data: { sessionId, messages: [], session: sessionDetails },
-        });
-
-        const loadResponse = await this.agentManager.loadSessionViaAcp(
-          sessionId,
-          (sessionDetails?.cwd as string | undefined) || undefined,
-        );
-        logger.log(
-          '[SessionMessageHandler] session/load succeeded (per ACP spec result is null; actual history comes via session/update):',
-          loadResponse,
-        );
-
-        // Reset title flag when switching sessions
-        this.isTitleSet = false;
-
-        // Notify webview that session history has finished loading
-        this.sendToWebView({
-          type: 'sessionLoadComplete',
-          data: { sessionId },
-        });
-
-        // Successfully loaded session, return early to avoid fallback logic
-        return;
-      } catch (loadError) {
-        logger.warn(
-          '[SessionMessageHandler] session/load failed, using fallback:',
-          loadError,
-        );
-
-        // Check for authentication/session expiration errors
-        if (this.shouldPromptAuth(loadError)) {
-          // Show a more user-friendly error message for expired sessions
-          await this.promptAuth(
-            'Your session has expired or is invalid. Please configure your provider to switch sessions.',
-          );
-
-          // Send a specific error to the webview for better UI handling
-          this.sendToWebView({
-            type: 'sessionExpired',
-            data: { message: 'Session expired. Please authenticate again.' },
-          });
-          return;
-        }
-
-        // Fallback: create new session
-        const messages = await this.agentManager.getSessionMessages(sessionId);
-
-        // If we are connected, try to create a fresh ACP session so user can interact
-        if (this.agentManager.isConnected) {
-          try {
-            await this.agentManager.createNewSession(workingDir, {
-              forceNew: true,
-            });
-
-            // Keep the viewed session identity aligned with what the webview sees
-            // (the archived sessionId). The live ACP session lives on
-            // agentManager.currentSessionId; the sync-on-first-message path
-            // (see streamEnd handler) will flip both sides to the ACP id once
-            // the user actually sends a message. Setting currentConversationId
-            // to the new ACP id here would desync the backend from the webview
-            // and cause rename/delete/title-update flows to target the wrong
-            // session during the fallback window.
-            this.updateCurrentConversationId(sessionId);
-
-            this.sendToWebView({
-              type: 'qwenSessionSwitched',
-              data: { sessionId, messages, session: sessionDetails },
-            });
-            this.sendToWebView({
-              type: 'sessionLoadComplete',
-              data: { sessionId },
-            });
-
-            // Only show the cache warning if we actually fell back to local cache
-            // and didn't successfully load via ACP
-            // Check if we truly fell back by checking if loadError is not null/undefined
-            // and if it's not a successful response that looks like an error
-            if (
-              loadError &&
-              typeof loadError === 'object' &&
-              !('result' in loadError)
-            ) {
-              vscode.window.showWarningMessage(
-                'Session restored from local cache. Some context may be incomplete.',
-              );
-            }
-          } catch (createError) {
-            logger.error(
-              '[SessionMessageHandler] Failed to create session:',
-              createError,
-            );
-
-            // Check for authentication/session expiration errors in session creation
-            if (this.shouldPromptAuth(createError)) {
-              // Show a more user-friendly error message for expired sessions
-              await this.promptAuth(
-                'Your session has expired or is invalid. Please configure your provider to switch sessions.',
-              );
-
-              // Send a specific error to the webview for better UI handling
-              this.sendToWebView({
-                type: 'sessionExpired',
-                data: {
-                  message: 'Session expired. Please authenticate again.',
-                },
-              });
-              return;
-            }
-
-            throw createError;
-          }
-        } else {
-          // Offline view only
-          this.updateCurrentConversationId(sessionId);
-          this.sendToWebView({
-            type: 'qwenSessionSwitched',
-            data: { sessionId, messages, session: sessionDetails },
-          });
-          this.sendToWebView({
-            type: 'sessionLoadComplete',
-            data: { sessionId },
-          });
-          vscode.window.showWarningMessage(
-            'Showing cached session content. Configure your provider to interact with the AI.',
-          );
-        }
-      }
-    } catch (error) {
-      logger.error('[SessionMessageHandler] Failed to switch session:', error);
-
-      // Safely convert error to string
-      const errorMsg = this.getErrorMessage(error);
-      // Check for authentication/session expiration errors
-      if (this.shouldPromptAuth(error)) {
-        // Show a more user-friendly error message for expired sessions
-        await this.promptAuth(
-          'Your session has expired or is invalid. Please configure your provider to switch sessions.',
-        );
-
-        // Send a specific error to the webview for better UI handling
-        this.sendToWebView({
-          type: 'sessionExpired',
-          data: { message: 'Session expired. Please authenticate again.' },
-        });
-      } else {
-        this.sendToWebView({
-          type: 'error',
-          data: { message: `Failed to switch session: ${errorMsg}` },
-        });
-      }
-    }
-  }
-
-  /**
-   * Handle get Qwen sessions request
-   */
-  private async handleGetQwenSessions(
-    cursor?: number,
-    size?: number,
-  ): Promise<void> {
-    try {
-      // Paged when possible; falls back to full list if ACP not supported
-      const page = await this.agentManager.getSessionListPaged({
-        cursor,
-        size,
-      });
-      const append = typeof cursor === 'number';
-      this.sendToWebView({
-        type: 'qwenSessionList',
-        data: {
-          sessions: page.sessions,
-          nextCursor: page.nextCursor,
-          hasMore: page.hasMore,
-          append,
-        },
-      });
-    } catch (error) {
-      logger.error('[SessionMessageHandler] Failed to get sessions:', error);
-
-      // Safely convert error to string
-      const errorMsg = this.getErrorMessage(error);
-      // Check for authentication/session expiration errors
-      if (this.shouldPromptAuth(error)) {
-        // Show a more user-friendly error message for expired sessions
-        await this.promptAuth(
-          'Your session has expired or is invalid. Please configure your provider to view sessions.',
-        );
-
-        // Send a specific error to the webview for better UI handling
-        this.sendToWebView({
-          type: 'sessionExpired',
-          data: { message: 'Session expired. Please authenticate again.' },
-        });
-      } else {
-        this.sendToWebView({
-          type: 'error',
-          data: { message: `Failed to get sessions: ${errorMsg}` },
-        });
-      }
-    }
-  }
-
-  /**
-   * Handle cancel streaming request
-   */
-  private async handleCancelStreaming(): Promise<void> {
-    try {
-      logger.log('[SessionMessageHandler] Canceling streaming...');
-
-      // Cancel the current streaming operation in the agent manager
-      await this.agentManager.cancelCurrentPrompt();
-
-      // Use sendStreamEnd to include requestId for proper correlation
-      this.sendStreamEnd('user_cancelled');
-
-      logger.log('[SessionMessageHandler] Streaming cancelled successfully');
-    } catch (_error) {
-      logger.log('[SessionMessageHandler] Streaming cancelled (interrupted)');
-
-      // Use sendStreamEnd (with duplicate guard) to include requestId
-      this.sendStreamEnd('user_cancelled');
-    }
-  }
-
-  /**
-   * Handle resume session request
-   */
-  private async handleResumeSession(sessionId: string): Promise<void> {
-    try {
-      // If not connected, offer to authenticate or view offline
-      if (!this.agentManager.isConnected) {
-        const choice = await this.promptAuthOrOffline(
-          'You are not authenticated. Configure your provider to fully restore this session, or view it offline.',
-        );
-
-        if (choice === 'offline') {
-          const messages =
-            await this.agentManager.getSessionMessages(sessionId);
-          this.updateCurrentConversationId(sessionId);
-          this.sendToWebView({
-            type: 'qwenSessionSwitched',
-            data: { sessionId, messages },
-          });
-          vscode.window.showInformationMessage(
-            'Showing cached session content. Configure your provider to interact with the AI.',
-          );
-          return;
-        } else if (choice !== 'auth') {
-          return;
-        }
-      }
-
-      // Try ACP load first
-      try {
-        // Pre-clear UI so replayed updates append afterwards
-        this.updateCurrentConversationId(sessionId);
-        this.sendToWebView({
-          type: 'qwenSessionSwitched',
-          data: { sessionId, messages: [] },
-        });
-
-        await this.agentManager.loadSessionViaAcp(sessionId);
-
-        // Reset title flag when resuming sessions
-        this.isTitleSet = false;
-
-        // Successfully loaded session, return early to avoid fallback logic
-        await this.handleGetQwenSessions();
-        return;
-      } catch (acpError) {
-        // Check for authentication/session expiration errors
-        if (this.shouldPromptAuth(acpError)) {
-          // Show a more user-friendly error message for expired sessions
-          await this.promptAuth(
-            'Your session has expired or is invalid. Please configure your provider to resume sessions.',
-          );
-
-          // Send a specific error to the webview for better UI handling
-          this.sendToWebView({
-            type: 'sessionExpired',
-            data: { message: 'Session expired. Please authenticate again.' },
-          });
-          return;
-        }
-      }
-
-      await this.handleGetQwenSessions();
-    } catch (error) {
-      logger.error('[SessionMessageHandler] Failed to resume session:', error);
-
-      // Safely convert error to string
-      const errorMsg = this.getErrorMessage(error);
-      // Check for authentication/session expiration errors
-      if (this.shouldPromptAuth(error)) {
-        // Show a more user-friendly error message for expired sessions
-        await this.promptAuth(
-          'Your session has expired or is invalid. Please configure your provider to resume sessions.',
-        );
-
-        // Send a specific error to the webview for better UI handling
-        this.sendToWebView({
-          type: 'sessionExpired',
-          data: { message: 'Session expired. Please authenticate again.' },
-        });
-      } else {
-        this.sendToWebView({
-          type: 'error',
-          data: { message: `Failed to resume session: ${errorMsg}` },
-        });
-      }
-    }
-  }
-
-  /**
-   * Handle delete session request
-   */
-  private async handleDeleteQwenSession(sessionId: string): Promise<void> {
-    try {
-      if (
-        sessionId === this.currentConversationId ||
-        sessionId === this.agentManager.currentSessionId
-      ) {
-        this.sendToWebView({
-          type: 'error',
-          data: { message: 'Cannot delete the current active session.' },
-        });
-        return;
-      }
-
-      const success = await this.agentManager.deleteSession(sessionId);
-      if (success) {
-        this.sendToWebView({
-          type: 'sessionDeleted',
-          data: { sessionId },
-        });
-      } else {
-        this.sendToWebView({
-          type: 'error',
-          data: { message: 'Failed to delete session.' },
-        });
-      }
-    } catch (error) {
-      const errorMsg = this.getErrorMessage(error);
-      this.sendToWebView({
-        type: 'error',
-        data: { message: `Failed to delete session: ${errorMsg}` },
-      });
-    }
-  }
-
-  /**
-   * Handle rename session request
-   */
-  private async handleRenameQwenSession(
-    sessionId: string,
-    title: string,
-  ): Promise<void> {
-    try {
-      const trimmedTitle = title.trim().replace(/[\r\n]+/g, ' ');
-      if (!trimmedTitle) {
-        this.sendToWebView({
-          type: 'error',
-          data: { message: 'Please provide a name.' },
-        });
-        return;
-      }
-      // Matches SESSION_TITLE_MAX_LENGTH from @qwen-code/qwen-code-core/sessionService
-      if (trimmedTitle.length > 200) {
-        this.sendToWebView({
-          type: 'error',
-          data: { message: 'Name is too long. Maximum 200 characters.' },
-        });
-        return;
-      }
-
-      const success = await this.agentManager.renameSession(
-        sessionId,
-        trimmedTitle,
-      );
-      if (success) {
-        this.sendToWebView({
-          type: 'sessionRenamed',
-          data: { sessionId, title: trimmedTitle },
-        });
-        if (sessionId === this.currentConversationId) {
-          this.sendToWebView({
-            type: 'sessionTitleUpdated',
-            data: { sessionId, title: trimmedTitle },
-          });
-        }
-      } else {
-        this.sendToWebView({
-          type: 'error',
-          data: { message: 'Failed to rename session.' },
-        });
-      }
-    } catch (error) {
-      const errorMsg = this.getErrorMessage(error);
-      this.sendToWebView({
-        type: 'error',
-        data: { message: `Failed to rename session: ${errorMsg}` },
-      });
-    }
-  }
-
-  /**
-   * Set approval mode via agent (ACP session/set_mode)
-   */
-  private async handleSetApprovalMode(data?: {
-    modeId?: ApprovalModeValue;
-  }): Promise<void> {
-    try {
-      const modeId = data?.modeId || 'default';
-      await this.agentManager.setApprovalModeFromUi(modeId);
-      // No explicit response needed; WebView listens for modeChanged
-    } catch (error) {
-      logger.error('[SessionMessageHandler] Failed to set mode:', error);
-      const errorMsg = this.getErrorMessage(error);
-      this.sendToWebView({
-        type: 'error',
-        data: { message: `Failed to set mode: ${errorMsg}` },
-      });
-    }
-  }
-
-  /**
-   * Set model via agent (ACP session/set_model)
-   * Displays VSCode native notifications on success or failure.
-   */
-  private async handleSetModel(data?: { modelId?: string }): Promise<void> {
-    try {
-      const modelId = data?.modelId;
-      if (!modelId) {
-        throw new Error('Model ID is required');
-      }
-      // Defensive guard: refuse non-runtime Qwen OAuth models in case the UI
-      // is bypassed (programmatic call, stale webview, restored session).
-      if (isDiscontinuedModel(modelId)) {
-        logger.warn(
-          '[SessionMessageHandler] Rejected discontinued model',
-          modelId,
-        );
-        const message = `Failed to switch model: ${DISCONTINUED_MESSAGES.blockedError}`;
-        vscode.window.showErrorMessage(message);
-        this.sendToWebView({
-          type: 'error',
-          data: { message },
-        });
-        return;
-      }
-      await this.agentManager.setModelFromUi(modelId);
-      void vscode.window.showInformationMessage(
-        `Model switched to: ${modelId}`,
-      );
-    } catch (error) {
-      const errorMsg = this.getErrorMessage(error);
-      logger.error('[SessionMessageHandler] Failed to set model:', error);
-      vscode.window.showErrorMessage(`Failed to switch model: ${errorMsg}`);
-      this.sendToWebView({
-        type: 'error',
-        data: { message: `Failed to set model: ${errorMsg}` },
-      });
-    }
-  }
-}
+    const trimmedText = stripZeroWidthSpï^{¶‰Ëkºwµç_HØ]Ú
+ØY\œ›ÜŠHÂˆÙÙÙ\‹Ø\›Šˆ	ÖÔÙ\ÜÚ[Û“Y\ÜØYÙR[™\—HÙ\ÜÚ[Û‹ÛØY˜Z[Y\Ú[™È˜[˜XÚÎ‰ËˆØY\œ›Ü‹ˆ
+NÂ‚ˆËÈÚXÚÈ›Üˆ]][XØ][Û‹ÜÙ\ÜÚ[Ûˆ^\˜][Ûˆ\œ›ÜœÂˆYˆ
+\ËœÚİ[›Û\]]
+ØY\œ›ÜŠJHÂˆËÈÚİÈH[Ü™H\Ù\‹YœšY[™H\œ›ÜˆY\ÜØYÙH›Üˆ^\™YÙ\ÜÚ[ÛœÂˆ]ØZ]\Ëœ›Û\]]
+ˆ	Ö[İ\ˆÙ\ÜÚ[Ûˆ\È^\™YÜˆ\È[˜[YˆX\ÙHÛÛ™šYİ\™H[İ\ˆ›İšY\ˆÈİÚ]ÚÙ\ÜÚ[ÛœË‰Ëˆ
+NÂ‚ˆËÈÙ[™HÜXÚYšXÈ\œ›ÜˆÈHÙXšY]È›Üˆ™]\ˆRH[™[™Âˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	ÜÙ\ÜÚ[Û‘^\™Y	Ëˆ]NˆÈY\ÜØYÙNˆ	ÔÙ\ÜÚ[Ûˆ^\™YˆX\ÙH]][XØ]HYØZ[‹‰ÈKˆJNÂˆ™]\›ÂˆB‚ˆËÈ˜[˜XÚÎˆÜ™X]H™]ÈÙ\ÜÚ[Û‚ˆÛÛœİY\ÜØYÙ\ÈH]ØZ]\Ë˜YÙ[X[˜YÙ\‹™Ù]Ù\ÜÚ[Û“Y\ÜØYÙ\ÊÙ\ÜÚ[Û’Y
+NÂ‚ˆËÈYˆÙH\™HÛÛ›™XİYHÈÜ™X]HHœ™\ÚPÔÙ\ÜÚ[ÛˆÛÈ\Ù\ˆØ[ˆ[\˜XİˆYˆ
+\Ë˜YÙ[X[˜YÙ\‹š\ĞÛÛ›™XİY
+HÂˆHÂˆ]ØZ]\Ë˜YÙ[X[˜YÙ\‹˜Ü™X]S™]ÔÙ\ÜÚ[ÛŠÛÜšÚ[™Ñ\‹Âˆ›Ü˜ÙS™]ÎˆYKˆJNÂ‚ˆËÈÙY\HšY]ÙYÙ\ÜÚ[ÛˆY[]H[YÛ™YÚ]Ú]HÙXšY]ÈÙY\ÂˆËÈ
+H\˜Ú]™YÙ\ÜÚ[Û’Y
+KˆH]™HPÔÙ\ÜÚ[Ûˆ]™\ÈÛ‚ˆËÈYÙ[X[˜YÙ\‹˜İ\œ™[Ù\ÜÚ[Û’YÈHŞ[˜Ë[Û‹Yš\œİ[Y\ÜØYÙH]ˆËÈ
+ÙYHİ™X[Q[™[™\ŠHÚ[›\›İÚY\ÈÈHPÔYÛ˜ÙBˆËÈH\Ù\ˆXİX[HÙ[™ÈHY\ÜØYÙKˆÙ][™Èİ\œ™[ÛÛ™\œØ][Û’YˆËÈÈH™]ÈPÔY\™HÛİ[\Ş[˜ÈH˜XÚÙ[™œ›ÛHHÙXšY]ÂˆËÈ[™Ø]\ÙH™[˜[YKÙ[]Kİ]K]\]H›İÜÈÈ\™Ù]HÜ›Û™ÂˆËÈÙ\ÜÚ[Ûˆ\š[™ÈH˜[˜XÚÈÚ[™İË‚ˆ\Ë\]Pİ\œ™[ÛÛ™\œØ][Û’Y
+Ù\ÜÚ[Û’Y
+NÂ‚ˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ü]Ù[”Ù\ÜÚ[Û”İÚ]ÚY	Ëˆ]NˆÈÙ\ÜÚ[Û’YY\ÜØYÙ\ËÙ\ÜÚ[ÛˆÙ\ÜÚ[Û‘]Z[ÈKˆJNÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	ÜÙ\ÜÚ[Û“ØYÛÛ\]IËˆ]NˆÈÙ\ÜÚ[Û’YKˆJNÂ‚ˆËÈÛ›HÚİÈHØXÚHØ\›š[™ÈYˆÙHXİX[H™[˜XÚÈÈØØ[ØXÚBˆËÈ[™Y‰İİXØÙ\ÜÙ[HØYšXHPÔˆËÈÚXÚÈYˆÙH[H™[˜XÚÈHÚXÚÚ[™ÈYˆØY\œ›Üˆ\È›İ[İ[™Yš[™YˆËÈ[™Yˆ]	ÜÈ›İHİXØÙ\ÜÙ[™\ÜÛœÙH]ÛÚÜÈZÙH[ˆ\œ›Ü‚ˆYˆ
+ˆØY\œ›Üˆ	‰‚ˆ\[ÙˆØY\œ›ÜˆOOH	ÛØš™Xİ	È	‰‚ˆJ	Ü™\İ[	È[ˆØY\œ›ÜŠBˆ
+HÂˆœØÛÙKÚ[™İËœÚİÕØ\›š[™ÓY\ÜØYÙJˆ	ÔÙ\ÜÚ[Ûˆ™\İÜ™Yœ›ÛHØØ[ØXÚKˆÛÛYHÛÛ^X^H™H[˜ÛÛ\]K‰Ëˆ
+NÂˆBˆHØ]Ú
+Ü™X]Q\œ›ÜŠHÂˆÙÙÙ\‹™\œ›ÜŠˆ	ÖÔÙ\ÜÚ[Û“Y\ÜØYÙR[™\—H˜Z[YÈÜ™X]HÙ\ÜÚ[Û‰ËˆÜ™X]Q\œ›Ü‹ˆ
+NÂ‚ˆËÈÚXÚÈ›Üˆ]][XØ][Û‹ÜÙ\ÜÚ[Ûˆ^\˜][Ûˆ\œ›ÜœÈ[ˆÙ\ÜÚ[ÛˆÜ™X][Û‚ˆYˆ
+\ËœÚİ[›Û\]]
+Ü™X]Q\œ›ÜŠJHÂˆËÈÚİÈH[Ü™H\Ù\‹YœšY[™H\œ›ÜˆY\ÜØYÙH›Üˆ^\™YÙ\ÜÚ[ÛœÂˆ]ØZ]\Ëœ›Û\]]
+ˆ	Ö[İ\ˆÙ\ÜÚ[Ûˆ\È^\™YÜˆ\È[˜[YˆX\ÙHÛÛ™šYİ\™H[İ\ˆ›İšY\ˆÈİÚ]ÚÙ\ÜÚ[ÛœË‰Ëˆ
+NÂ‚ˆËÈÙ[™HÜXÚYšXÈ\œ›ÜˆÈHÙXšY]È›Üˆ™]\ˆRH[™[™Âˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	ÜÙ\ÜÚ[Û‘^\™Y	Ëˆ]NˆÂˆY\ÜØYÙNˆ	ÔÙ\ÜÚ[Ûˆ^\™YˆX\ÙH]][XØ]HYØZ[‹‰ËˆKˆJNÂˆ™]\›ÂˆB‚ˆ›İÈÜ™X]Q\œ›ÜÂˆBˆH[ÙHÂˆËÈÙ™›[™HšY]ÈÛ›Bˆ\Ë\]Pİ\œ™[ÛÛ™\œØ][Û’Y
+Ù\ÜÚ[Û’Y
+NÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ü]Ù[”Ù\ÜÚ[Û”İÚ]ÚY	Ëˆ]NˆÈÙ\ÜÚ[Û’YY\ÜØYÙ\ËÙ\ÜÚ[ÛˆÙ\ÜÚ[Û‘]Z[ÈKˆJNÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	ÜÙ\ÜÚ[Û“ØYÛÛ\]IËˆ]NˆÈÙ\ÜÚ[Û’YKˆJNÂˆœØÛÙKÚ[™İËœÚİÕØ\›š[™ÓY\ÜØYÙJˆ	ÔÚİÚ[™ÈØXÚYÙ\ÜÚ[ÛˆÛÛ[ˆÛÛ™šYİ\™H[İ\ˆ›İšY\ˆÈ[\˜XİÚ]HRK‰Ëˆ
+NÂˆBˆBˆHØ]Ú
+\œ›ÜŠHÂˆÙÙÙ\‹™\œ›ÜŠ	ÖÔÙ\ÜÚ[Û“Y\ÜØYÙR[™\—H˜Z[YÈİÚ]ÚÙ\ÜÚ[Û‰Ë\œ›ÜŠNÂ‚ˆËÈØY™[HÛÛ™\\œ›ÜˆÈİš[™ÂˆÛÛœİ\œ›Ü“\ÙÈH\Ë™Ù]\œ›Ü“Y\ÜØYÙJ\œ›ÜŠNÂˆËÈÚXÚÈ›Üˆ]][XØ][Û‹ÜÙ\ÜÚ[Ûˆ^\˜][Ûˆ\œ›ÜœÂˆYˆ
+\ËœÚİ[›Û\]]
+\œ›ÜŠJHÂˆËÈÚİÈH[Ü™H\Ù\‹YœšY[™H\œ›ÜˆY\ÜØYÙH›Üˆ^\™YÙ\ÜÚ[ÛœÂˆ]ØZ]\Ëœ›Û\]]
+ˆ	Ö[İ\ˆÙ\ÜÚ[Ûˆ\È^\™YÜˆ\È[˜[YˆX\ÙHÛÛ™šYİ\™H[İ\ˆ›İšY\ˆÈİÚ]ÚÙ\ÜÚ[ÛœË‰Ëˆ
+NÂ‚ˆËÈÙ[™HÜXÚYšXÈ\œ›ÜˆÈHÙXšY]È›Üˆ™]\ˆRH[™[™Âˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	ÜÙ\ÜÚ[Û‘^\™Y	Ëˆ]NˆÈY\ÜØYÙNˆ	ÔÙ\ÜÚ[Ûˆ^\™YˆX\ÙH]][XØ]HYØZ[‹‰ÈKˆJNÂˆH[ÙHÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙNˆ˜Z[YÈİÚ]ÚÙ\ÜÚ[Ûˆ	Ù\œ›Ü“\ÙßXKˆJNÂˆBˆBˆB‚ˆÊŠ‚ˆ
+ˆ[™HÙ]]Ù[ˆÙ\ÜÚ[ÛœÈ™\]Y\İˆ
+‹Âˆš]˜]H\Ş[˜È[™QÙ]]Ù[”Ù\ÜÚ[ÛœÊˆİ\œÛÜÎˆ[X™\‹ˆÚ^™OÎˆ[X™\‹ˆ
+Nˆ›ÛZ\ÙO›ÚYˆÂˆHÂˆËÈYÙYÚ[ˆÜÜÚX›NÈ˜[È˜XÚÈÈ[\İYˆPÔ›İİ\ÜYˆÛÛœİYÙHH]ØZ]\Ë˜YÙ[X[˜YÙ\‹™Ù]Ù\ÜÚ[Û“\İYÙY
+Âˆİ\œÛÜ‹ˆÚ^™KˆJNÂˆÛÛœİ\[™H\[Ùˆİ\œÛÜˆOOH	Û[X™\‰ÎÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ü]Ù[”Ù\ÜÚ[Û“\İ	Ëˆ]NˆÂˆÙ\ÜÚ[ÛœÎˆYÙKœÙ\ÜÚ[ÛœËˆ™^İ\œÛÜˆYÙK›™^İ\œÛÜ‹ˆ\Ó[Ü™NˆYÙKš\Ó[Ü™Kˆ\[™ˆKˆJNÂˆHØ]Ú
+\œ›ÜŠHÂˆÙÙÙ\‹™\œ›ÜŠ	ÖÔÙ\ÜÚ[Û“Y\ÜØYÙR[™\—H˜Z[YÈÙ]Ù\ÜÚ[ÛœÎ‰Ë\œ›ÜŠNÂ‚ˆËÈØY™[HÛÛ™\\œ›ÜˆÈİš[™ÂˆÛÛœİ\œ›Ü“\ÙÈH\Ë™Ù]\œ›Ü“Y\ÜØYÙJ\œ›ÜŠNÂˆËÈÚXÚÈ›Üˆ]][XØ][Û‹ÜÙ\ÜÚ[Ûˆ^\˜][Ûˆ\œ›ÜœÂˆYˆ
+\ËœÚİ[›Û\]]
+\œ›ÜŠJHÂˆËÈÚİÈH[Ü™H\Ù\‹YœšY[™H\œ›ÜˆY\ÜØYÙH›Üˆ^\™YÙ\ÜÚ[ÛœÂˆ]ØZ]\Ëœ›Û\]]
+ˆ	Ö[İ\ˆÙ\ÜÚ[Ûˆ\È^\™YÜˆ\È[˜[YˆX\ÙHÛÛ™šYİ\™H[İ\ˆ›İšY\ˆÈšY]ÈÙ\ÜÚ[ÛœË‰Ëˆ
+NÂ‚ˆËÈÙ[™HÜXÚYšXÈ\œ›ÜˆÈHÙXšY]È›Üˆ™]\ˆRH[™[™Âˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	ÜÙ\ÜÚ[Û‘^\™Y	Ëˆ]NˆÈY\ÜØYÙNˆ	ÔÙ\ÜÚ[Ûˆ^\™YˆX\ÙH]][XØ]HYØZ[‹‰ÈKˆJNÂˆH[ÙHÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙNˆ˜Z[YÈÙ]Ù\ÜÚ[ÛœÎˆ	Ù\œ›Ü“\ÙßXKˆJNÂˆBˆBˆB‚ˆÊŠ‚ˆ
+ˆ[™HØ[˜Ù[İ™X[Z[™È™\]Y\İˆ
+‹Âˆš]˜]H\Ş[˜È[™PØ[˜Ù[İ™X[Z[™Ê
+Nˆ›ÛZ\ÙO›ÚYˆÂˆHÂˆÙÙÙ\‹›ÙÊ	ÖÔÙ\ÜÚ[Û“Y\ÜØYÙR[™\—HØ[˜Ù[[™Èİ™X[Z[™Ë‹‹‰ÊNÂ‚ˆËÈØ[˜Ù[Hİ\œ™[İ™X[Z[™ÈÜ\˜][Ûˆ[ˆHYÙ[X[˜YÙ\‚ˆ]ØZ]\Ë˜YÙ[X[˜YÙ\‹˜Ø[˜Ù[İ\œ™[›Û\
+
+NÂ‚ˆËÈ\ÙHÙ[™İ™X[Q[™È[˜ÛYH™\]Y\İY›Üˆ›Ü\ˆÛÜœ™[][Û‚ˆ\ËœÙ[™İ™X[Q[™
+	İ\Ù\—ØØ[˜Ù[Y	ÊNÂ‚ˆÙÙÙ\‹›ÙÊ	ÖÔÙ\ÜÚ[Û“Y\ÜØYÙR[™\—Hİ™X[Z[™ÈØ[˜Ù[YİXØÙ\ÜÙ[IÊNÂˆHØ]Ú
+Ù\œ›ÜŠHÂˆÙÙÙ\‹›ÙÊ	ÖÔÙ\ÜÚ[Û“Y\ÜØYÙR[™\—Hİ™X[Z[™ÈØ[˜Ù[Y
+[\œ\Y
+IÊNÂ‚ˆËÈ\ÙHÙ[™İ™X[Q[™
+Ú]\XØ]HİX\™
+HÈ[˜ÛYH™\]Y\İYˆ\ËœÙ[™İ™X[Q[™
+	İ\Ù\—ØØ[˜Ù[Y	ÊNÂˆBˆB‚ˆÊŠ‚ˆ
+ˆ[™H™\İ[YHÙ\ÜÚ[Ûˆ™\]Y\İˆ
+‹Âˆš]˜]H\Ş[˜È[™T™\İ[YTÙ\ÜÚ[ÛŠÙ\ÜÚ[Û’Yˆİš[™ÊNˆ›ÛZ\ÙO›ÚYˆÂˆHÂˆËÈYˆ›İÛÛ›™XİYÙ™™\ˆÈ]][XØ]HÜˆšY]ÈÙ™›[™BˆYˆ
+]\Ë˜YÙ[X[˜YÙ\‹š\ĞÛÛ›™XİY
+HÂˆÛÛœİÚÚXÙHH]ØZ]\Ëœ›Û\]]Ü“Ù™›[™Jˆ	Ö[İH\™H›İ]][XØ]YˆÛÛ™šYİ\™H[İ\ˆ›İšY\ˆÈ[H™\İÜ™H\ÈÙ\ÜÚ[Û‹ÜˆšY]È]Ù™›[™K‰Ëˆ
+NÂ‚ˆYˆ
+ÚÚXÙHOOH	ÛÙ™›[™IÊHÂˆÛÛœİY\ÜØYÙ\ÈBˆ]ØZ]\Ë˜YÙ[X[˜YÙ\‹™Ù]Ù\ÜÚ[Û“Y\ÜØYÙ\ÊÙ\ÜÚ[Û’Y
+NÂˆ\Ë\]Pİ\œ™[ÛÛ™\œØ][Û’Y
+Ù\ÜÚ[Û’Y
+NÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ü]Ù[”Ù\ÜÚ[Û”İÚ]ÚY	Ëˆ]NˆÈÙ\ÜÚ[Û’YY\ÜØYÙ\ÈKˆJNÂˆœØÛÙKÚ[™İËœÚİÒ[™›Ü›X][Û“Y\ÜØYÙJˆ	ÔÚİÚ[™ÈØXÚYÙ\ÜÚ[ÛˆÛÛ[ˆÛÛ™šYİ\™H[İ\ˆ›İšY\ˆÈ[\˜XİÚ]HRK‰Ëˆ
+NÂˆ™]\›ÂˆH[ÙHYˆ
+ÚÚXÙHOOH	Ø]]	ÊHÂˆ™]\›ÂˆBˆB‚ˆËÈHPÔØYš\œİˆHÂˆËÈ™KXÛX\ˆRHÛÈ™\^YY\]\È\[™Y\Ø\™Âˆ\Ë\]Pİ\œ™[ÛÛ™\œØ][Û’Y
+Ù\ÜÚ[Û’Y
+NÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ü]Ù[”Ù\ÜÚ[Û”İÚ]ÚY	Ëˆ]NˆÈÙ\ÜÚ[Û’YY\ÜØYÙ\Îˆ×HKˆJNÂ‚ˆ]ØZ]\Ë˜YÙ[X[˜YÙ\‹›ØYÙ\ÜÚ[Û•šXPXÜ
+Ù\ÜÚ[Û’Y
+NÂ‚ˆËÈ™\Ù]]H›YÈÚ[ˆ™\İ[Z[™ÈÙ\ÜÚ[ÛœÂˆ\Ëš\Õ]TÙ]H˜[ÙNÂ‚ˆËÈİXØÙ\ÜÙ[HØYYÙ\ÜÚ[Û‹™]\›ˆX\›HÈ]›ÚY˜[˜XÚÈÙÚXÂˆ]ØZ]\Ëš[™QÙ]]Ù[”Ù\ÜÚ[ÛœÊ
+NÂˆ™]\›ÂˆHØ]Ú
+XÜ\œ›ÜŠHÂˆËÈÚXÚÈ›Üˆ]][XØ][Û‹ÜÙ\ÜÚ[Ûˆ^\˜][Ûˆ\œ›ÜœÂˆYˆ
+\ËœÚİ[›Û\]]
+XÜ\œ›ÜŠJHÂˆËÈÚİÈH[Ü™H\Ù\‹YœšY[™H\œ›ÜˆY\ÜØYÙH›Üˆ^\™YÙ\ÜÚ[ÛœÂˆ]ØZ]\Ëœ›Û\]]
+ˆ	Ö[İ\ˆÙ\ÜÚ[Ûˆ\È^\™YÜˆ\È[˜[YˆX\ÙHÛÛ™šYİ\™H[İ\ˆ›İšY\ˆÈ™\İ[YHÙ\ÜÚ[ÛœË‰Ëˆ
+NÂ‚ˆËÈÙ[™HÜXÚYšXÈ\œ›ÜˆÈHÙXšY]È›Üˆ™]\ˆRH[™[™Âˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	ÜÙ\ÜÚ[Û‘^\™Y	Ëˆ]NˆÈY\ÜØYÙNˆ	ÔÙ\ÜÚ[Ûˆ^\™YˆX\ÙH]][XØ]HYØZ[‹‰ÈKˆJNÂˆ™]\›ÂˆBˆB‚ˆ]ØZ]\Ëš[™QÙ]]Ù[”Ù\ÜÚ[ÛœÊ
+NÂˆHØ]Ú
+\œ›ÜŠHÂˆÙÙÙ\‹™\œ›ÜŠ	ÖÔÙ\ÜÚ[Û“Y\ÜØYÙR[™\—H˜Z[YÈ™\İ[YHÙ\ÜÚ[Û‰Ë\œ›ÜŠNÂ‚ˆËÈØY™[HÛÛ™\\œ›ÜˆÈİš[™ÂˆÛÛœİ\œ›Ü“\ÙÈH\Ë™Ù]\œ›Ü“Y\ÜØYÙJ\œ›ÜŠNÂˆËÈÚXÚÈ›Üˆ]][XØ][Û‹ÜÙ\ÜÚ[Ûˆ^\˜][Ûˆ\œ›ÜœÂˆYˆ
+\ËœÚİ[›Û\]]
+\œ›ÜŠJHÂˆËÈÚİÈH[Ü™H\Ù\‹YœšY[™H\œ›ÜˆY\ÜØYÙH›Üˆ^\™YÙ\ÜÚ[ÛœÂˆ]ØZ]\Ëœ›Û\]]
+ˆ	Ö[İ\ˆÙ\ÜÚ[Ûˆ\È^\™YÜˆ\È[˜[YˆX\ÙHÛÛ™šYİ\™H[İ\ˆ›İšY\ˆÈ™\İ[YHÙ\ÜÚ[ÛœË‰Ëˆ
+NÂ‚ˆËÈÙ[™HÜXÚYšXÈ\œ›ÜˆÈHÙXšY]È›Üˆ™]\ˆRH[™[™Âˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	ÜÙ\ÜÚ[Û‘^\™Y	Ëˆ]NˆÈY\ÜØYÙNˆ	ÔÙ\ÜÚ[Ûˆ^\™YˆX\ÙH]][XØ]HYØZ[‹‰ÈKˆJNÂˆH[ÙHÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙNˆ˜Z[YÈ™\İ[YHÙ\ÜÚ[Ûˆ	Ù\œ›Ü“\ÙßXKˆJNÂˆBˆBˆB‚ˆÊŠ‚ˆ
+ˆ[™H[]HÙ\ÜÚ[Ûˆ™\]Y\İˆ
+‹Âˆš]˜]H\Ş[˜È[™Q[]T]Ù[”Ù\ÜÚ[ÛŠÙ\ÜÚ[Û’Yˆİš[™ÊNˆ›ÛZ\ÙO›ÚYˆÂˆHÂˆYˆ
+ˆÙ\ÜÚ[Û’YOOH\Ë˜İ\œ™[ÛÛ™\œØ][Û’YˆÙ\ÜÚ[Û’YOOH\Ë˜YÙ[X[˜YÙ\‹˜İ\œ™[Ù\ÜÚ[Û’Yˆ
+HÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙNˆ	ĞØ[››İ[]HHİ\œ™[Xİ]™HÙ\ÜÚ[Û‹‰ÈKˆJNÂˆ™]\›ÂˆB‚ˆÛÛœİİXØÙ\ÜÈH]ØZ]\Ë˜YÙ[X[˜YÙ\‹™[]TÙ\ÜÚ[ÛŠÙ\ÜÚ[Û’Y
+NÂˆYˆ
+İXØÙ\ÜÊHÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	ÜÙ\ÜÚ[Û‘[]Y	Ëˆ]NˆÈÙ\ÜÚ[Û’YKˆJNÂˆH[ÙHÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙNˆ	Ñ˜Z[YÈ[]HÙ\ÜÚ[Û‹‰ÈKˆJNÂˆBˆHØ]Ú
+\œ›ÜŠHÂˆÛÛœİ\œ›Ü“\ÙÈH\Ë™Ù]\œ›Ü“Y\ÜØYÙJ\œ›ÜŠNÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙNˆ˜Z[YÈ[]HÙ\ÜÚ[Ûˆ	Ù\œ›Ü“\ÙßXKˆJNÂˆBˆB‚ˆÊŠ‚ˆ
+ˆ[™H™[˜[YHÙ\ÜÚ[Ûˆ™\]Y\İˆ
+‹Âˆš]˜]H\Ş[˜È[™T™[˜[YT]Ù[”Ù\ÜÚ[ÛŠˆÙ\ÜÚ[Û’Yˆİš[™Ëˆ]Nˆİš[™Ëˆ
+Nˆ›ÛZ\ÙO›ÚYˆÂˆHÂˆÛÛœİš[[YY]HH]Kš[J
+Kœ™\XÙJÖ×——JËÙË	È	ÊNÂˆYˆ
+]š[[YY]JHÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙNˆ	ÔX\ÙH›İšYHH˜[YK‰ÈKˆJNÂˆ™]\›ÂˆBˆËÈX]Ú\ÈÑTÔÒSÓ—ÕUWÓPVÓS‘Õœ›ÛH]Ù[‹XÛÙKÜ]Ù[‹XÛÙKXÛÜ™KÜÙ\ÜÚ[Û”Ù\šXÙBˆYˆ
+š[[YY]K›[™İˆŒ
+HÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙNˆ	Ó˜[YH\ÈÛÈÛ™ËˆX^[][HŒÚ\˜Xİ\œË‰ÈKˆJNÂˆ™]\›ÂˆB‚ˆÛÛœİİXØÙ\ÜÈH]ØZ]\Ë˜YÙ[X[˜YÙ\‹œ™[˜[YTÙ\ÜÚ[ÛŠˆÙ\ÜÚ[Û’Yˆš[[YY]Kˆ
+NÂˆYˆ
+İXØÙ\ÜÊHÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	ÜÙ\ÜÚ[Û”™[˜[YY	Ëˆ]NˆÈÙ\ÜÚ[Û’Y]Nˆš[[YY]HKˆJNÂˆYˆ
+Ù\ÜÚ[Û’YOOH\Ë˜İ\œ™[ÛÛ™\œØ][Û’Y
+HÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	ÜÙ\ÜÚ[Û•]U\]Y	Ëˆ]NˆÈÙ\ÜÚ[Û’Y]Nˆš[[YY]HKˆJNÂˆBˆH[ÙHÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙNˆ	Ñ˜Z[YÈ™[˜[YHÙ\ÜÚ[Û‹‰ÈKˆJNÂˆBˆHØ]Ú
+\œ›ÜŠHÂˆÛÛœİ\œ›Ü“\ÙÈH\Ë™Ù]\œ›Ü“Y\ÜØYÙJ\œ›ÜŠNÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙNˆ˜Z[YÈ™[˜[YHÙ\ÜÚ[Ûˆ	Ù\œ›Ü“\ÙßXKˆJNÂˆBˆB‚ˆÊŠ‚ˆ
+ˆÙ]\›İ˜[[ÙHšXHYÙ[
+PÔÙ\ÜÚ[Û‹ÜÙ]Û[ÙJBˆ
+‹Âˆš]˜]H\Ş[˜È[™TÙ]\›İ˜[[ÙJ]OÎˆÂˆ[ÙRYÎˆ\›İ˜[[ÙU˜[YNÂˆJNˆ›ÛZ\ÙO›ÚYˆÂˆHÂˆÛÛœİ[ÙRYH]OË›[ÙRY	ÙY˜][	ÎÂˆ]ØZ]\Ë˜YÙ[X[˜YÙ\‹œÙ]\›İ˜[[ÙQœ›ÛUZJ[ÙRY
+NÂˆËÈ›È^XÚ]™\ÜÛœÙH™YYYÈÙX•šY]È\İ[œÈ›Üˆ[ÙPÚ[™ÙYˆHØ]Ú
+\œ›ÜŠHÂˆÙÙÙ\‹™\œ›ÜŠ	ÖÔÙ\ÜÚ[Û“Y\ÜØYÙR[™\—H˜Z[YÈÙ][ÙN‰Ë\œ›ÜŠNÂˆÛÛœİ\œ›Ü“\ÙÈH\Ë™Ù]\œ›Ü“Y\ÜØYÙJ\œ›ÜŠNÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙNˆ˜Z[YÈÙ][ÙNˆ	Ù\œ›Ü“\ÙßXKˆJNÂˆBˆB‚ˆÊŠ‚ˆ
+ˆÙ][Ù[šXHYÙ[
+PÔÙ\ÜÚ[Û‹ÜÙ]Û[Ù[
+Bˆ
+ˆ\Ü^\È”ĞÛÙH˜]]™H›İYšXØ][ÛœÈÛˆİXØÙ\ÜÈÜˆ˜Z[\™K‚ˆ
+‹Âˆš]˜]H\Ş[˜È[™TÙ][Ù[
+]OÎˆÈ[Ù[YÎˆİš[™ÈJNˆ›ÛZ\ÙO›ÚYˆÂˆHÂˆÛÛœİ[Ù[YH]OË›[Ù[YÂˆYˆ
+[[Ù[Y
+HÂˆ›İÈ™]È\œ›ÜŠ	Ó[Ù[Q\È™\]Z\™Y	ÊNÂˆBˆËÈY™[œÚ]™HİX\™ˆ™Y\ÙH›Û‹\[[YH]Ù[ˆĞ]][Ù[È[ˆØ\ÙHHRBˆËÈ\È\\ÜÙY
+›ÙÜ˜[[X]XÈØ[İ[HÙXšY]Ë™\İÜ™YÙ\ÜÚ[ÛŠK‚ˆYˆ
+\Ñ\ØÛÛ[YY[Ù[
+[Ù[Y
+JHÂˆÙÙÙ\‹Ø\›Šˆ	ÖÔÙ\ÜÚ[Û“Y\ÜØYÙR[™\—H™Z™XİY\ØÛÛ[YY[Ù[	Ëˆ[Ù[Yˆ
+NÂˆÛÛœİY\ÜØYÙHH˜Z[YÈİÚ]Ú[Ù[ˆ	ÑTĞÓÓ•S•QQÓQTÔĞQÑTË˜›ØÚÙY\œ›ÜŸXÂˆœØÛÙKÚ[™İËœÚİÑ\œ›Ü“Y\ÜØYÙJY\ÜØYÙJNÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙHKˆJNÂˆ™]\›ÂˆBˆ]ØZ]\Ë˜YÙ[X[˜YÙ\‹œÙ][Ù[œ›ÛUZJ[Ù[Y
+NÂˆ›ÚYœØÛÙKÚ[™İËœÚİÒ[™›Ü›X][Û“Y\ÜØYÙJˆ[Ù[İÚ]ÚYÎˆ	Û[Ù[YXˆ
+NÂˆHØ]Ú
+\œ›ÜŠHÂˆÛÛœİ\œ›Ü“\ÙÈH\Ë™Ù]\œ›Ü“Y\ÜØYÙJ\œ›ÜŠNÂˆÙÙÙ\‹™\œ›ÜŠ	ÖÔÙ\ÜÚ[Û“Y\ÜØYÙR[™\—H˜Z[YÈÙ][Ù[‰Ë\œ›ÜŠNÂˆœØÛÙKÚ[™İËœÚİÑ\œ›Ü“Y\ÜØYÙJ˜Z[YÈİÚ]Ú[Ù[ˆ	Ù\œ›Ü“\ÙßX
+NÂˆ\ËœÙ[™ÕÙX•šY]ÊÂˆ\Nˆ	Ù\œ›Ü‰Ëˆ]NˆÈY\ÜØYÙNˆ˜Z[YÈÙ][Ù[ˆ	Ù\œ›Ü“\ÙßXKˆJNÂˆBˆBŸB

--- a/packages/webui/src/components/messages/MarkdownRenderer/MarkdownRenderer.test.tsx
+++ b/packages/webui/src/components/messages/MarkdownRenderer/MarkdownRenderer.test.tsx
@@ -15,8 +15,8 @@ let container: HTMLDivElement | null = null;
 
 function renderMarkdown(
   content: string,
-  onFileClick = vi.fn(),
-  enableFileLinks = false,
+  onFileClick: ((filePath: string) => void) | null = vi.fn(),
+  enableFileLinks = true,
 ) {
   container = document.createElement('div');
   document.body.appendChild(container);
@@ -26,7 +26,7 @@ function renderMarkdown(
     root?.render(
       <MarkdownRenderer
         content={content}
-        onFileClick={onFileClick}
+        onFileClick={onFileClick ?? undefined}
         enableFileLinks={enableFileLinks}
       />,
     );
@@ -48,6 +48,8 @@ describe('MarkdownRenderer explicit file links', () => {
   it('opens markdown file links with decoded absolute paths', () => {
     const { onFileClick } = renderMarkdown(
       'Saved: [export.html](/tmp/my%20dir/export.html)',
+      vi.fn(),
+      false,
     );
 
     const anchor = container?.querySelector('a');
@@ -63,8 +65,6 @@ describe('MarkdownRenderer explicit file links', () => {
   it('opens Windows file URI links through the file click handler', () => {
     const { onFileClick } = renderMarkdown(
       'Saved: [export.md](file:///C:/Users/Me/My%20Exports/export.md)',
-      vi.fn(),
-      true,
     );
 
     const anchor = container?.querySelector('a');
@@ -105,16 +105,61 @@ describe('MarkdownRenderer explicit file links', () => {
     expect(onFileClick).toHaveBeenCalledWith('/tmp/exports/export.md');
   });
 
-  it('opens UNC file URI links without treating the server as a local path', () => {
-    const { onFileClick } = renderMarkdown(
-      'Saved: [file.md](file://server/share/file.md)',
-    );
+  it.each([
+    [
+      'localhost',
+      'file://localhost/tmp/exports/export.md',
+      '/tmp/exports/export.md',
+    ],
+    [
+      'uppercase POSIX',
+      'FILE:///tmp/exports/export.md',
+      '/tmp/exports/export.md',
+    ],
+    [
+      'uppercase localhost',
+      'FiLe://LOCALHOST/tmp/exports/export.md',
+      '/tmp/exports/export.md',
+    ],
+  ])('normalizes %s as a local file URI', (_label, href, expectedPath) => {
+    const { onFileClick } = renderMarkdown('Saved: [export.md](' + href + ')');
     const anchor = container?.querySelector('a');
     expect(anchor).toBeTruthy();
-    anchor?.dispatchEvent(
-      new MouseEvent('click', { bubbles: true, cancelable: true }),
-    );
-    expect(onFileClick).toHaveBeenCalledWith('//server/share/file.md');
+    expect(anchor?.classList.contains('file-path-link')).toBe(false);
+
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+    anchor?.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(onFileClick).toHaveBeenCalledWith(expectedPath);
+  });
+  it.each([
+    ['remote server', 'file://server/share/file.md'],
+    ['attacker authority', 'file://attacker.example/share/file.md'],
+    ['lookalike localhost authority', 'file://localhost.evil/share/file.md'],
+    ['empty authority UNC', 'file:////server/share/file.md'],
+    ['empty authority UNC with extra slash', 'file://///server/share/file.md'],
+    ['encoded slash UNC', 'file:///%2F%2Fserver/share/file.md'],
+    ['encoded backslash UNC', 'file:///%5C%5Cserver/share/file.md'],
+  ])('rejects %s file URI links on the default path', (_label, href) => {
+    const { onFileClick } = renderMarkdown('[open](' + href + ')');
+
+    // Rejected file URIs must remain inert after both markdown rendering and
+    // the default processFilePaths pass.
+    expect(container?.querySelector('a.file-path-link')).toBeNull();
+    expect(container?.querySelector('a[href^="file:"]')).toBeNull();
+    expect(onFileClick).not.toHaveBeenCalled();
+  });
+  it('prevents local file URI navigation without a click handler', () => {
+    renderMarkdown('[export.md](file:///tmp/export.md)', null);
+    const anchor = container?.querySelector('a');
+    expect(anchor).toBeTruthy();
+    const event = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+    });
+    anchor?.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
   });
 
   it('converts file URI line fragments without decoding literal path hashes', () => {
@@ -134,12 +179,14 @@ describe('MarkdownRenderer explicit file links', () => {
   });
 
   it('does not turn file URI images into live local images', () => {
-    renderMarkdown('![private](file:///tmp/private.png)', vi.fn(), true);
+    renderMarkdown('![private](file:///tmp/private.png)');
     expect(container?.querySelector('img[src^="file:"]')).toBeNull();
   });
 
   it('preserves safe links while rejecting javascript links', () => {
-    renderMarkdown('[docs](https://example.com/a.md)');
+    renderMarkdown(
+      '[docs](https://example.com/a.md) [bad](javascript:alert%281%29)',
+    );
     expect(
       container?.querySelector('a[href="https://example.com/a.md"]'),
     ).toBeTruthy();

--- a/packages/webui/src/components/messages/MarkdownRenderer/MarkdownRenderer.test.tsx
+++ b/packages/webui/src/components/messages/MarkdownRenderer/MarkdownRenderer.test.tsx
@@ -60,6 +60,23 @@ describe('MarkdownRenderer explicit file links', () => {
     expect(onFileClick).toHaveBeenCalledWith('/tmp/my dir/export.html');
   });
 
+  it('opens Windows file URI links through the file click handler', () => {
+    const { onFileClick } = renderMarkdown(
+      'Saved: [export.md](file:///C:/Users/Me/My%20Exports/export.md)',
+    );
+
+    const anchor = container?.querySelector('a');
+    expect(anchor).toBeTruthy();
+
+    anchor?.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, cancelable: true }),
+    );
+
+    expect(onFileClick).toHaveBeenCalledWith(
+      'C:/Users/Me/My Exports/export.md',
+    );
+  });
+
   it('converts markdown file links with line fragments into vscode paths', () => {
     const { onFileClick } = renderMarkdown('[app.ts](/tmp/src/app.ts#L12)');
 

--- a/packages/webui/src/components/messages/MarkdownRenderer/MarkdownRenderer.test.tsx
+++ b/packages/webui/src/components/messages/MarkdownRenderer/MarkdownRenderer.test.tsx
@@ -63,15 +63,18 @@ describe('MarkdownRenderer explicit file links', () => {
   it('opens Windows file URI links through the file click handler', () => {
     const { onFileClick } = renderMarkdown(
       'Saved: [export.md](file:///C:/Users/Me/My%20Exports/export.md)',
+      vi.fn(),
+      true,
     );
 
     const anchor = container?.querySelector('a');
     expect(anchor).toBeTruthy();
 
-    anchor?.dispatchEvent(
-      new MouseEvent('click', { bubbles: true, cancelable: true }),
-    );
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+    anchor?.dispatchEvent(event);
 
+    expect(event.defaultPrevented).toBe(true);
+    expect(anchor?.classList.contains('file-path-link')).toBe(false);
     expect(onFileClick).toHaveBeenCalledWith(
       'C:/Users/Me/My Exports/export.md',
     );
@@ -88,5 +91,58 @@ describe('MarkdownRenderer explicit file links', () => {
     );
 
     expect(onFileClick).toHaveBeenCalledWith('/tmp/src/app.ts:12');
+  });
+
+  it('opens POSIX file URI links with absolute filesystem paths', () => {
+    const { onFileClick } = renderMarkdown(
+      'Saved: [export.md](file:///tmp/exports/export.md)',
+    );
+    const anchor = container?.querySelector('a');
+    expect(anchor).toBeTruthy();
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+    anchor?.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+    expect(onFileClick).toHaveBeenCalledWith('/tmp/exports/export.md');
+  });
+
+  it('opens UNC file URI links without treating the server as a local path', () => {
+    const { onFileClick } = renderMarkdown(
+      'Saved: [file.md](file://server/share/file.md)',
+    );
+    const anchor = container?.querySelector('a');
+    expect(anchor).toBeTruthy();
+    anchor?.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, cancelable: true }),
+    );
+    expect(onFileClick).toHaveBeenCalledWith('//server/share/file.md');
+  });
+
+  it('converts file URI line fragments without decoding literal path hashes', () => {
+    const { onFileClick } = renderMarkdown(
+      '[app.ts](file:///tmp/src/app.ts#L12) [hash.md](file:///tmp/hash%23name.md)',
+    );
+    const anchors = container?.querySelectorAll('a');
+    expect(anchors).toHaveLength(2);
+    anchors?.[0]?.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, cancelable: true }),
+    );
+    anchors?.[1]?.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, cancelable: true }),
+    );
+    expect(onFileClick).toHaveBeenNthCalledWith(1, '/tmp/src/app.ts:12');
+    expect(onFileClick).toHaveBeenNthCalledWith(2, '/tmp/hash#name.md');
+  });
+
+  it('does not turn file URI images into live local images', () => {
+    renderMarkdown('![private](file:///tmp/private.png)', vi.fn(), true);
+    expect(container?.querySelector('img[src^="file:"]')).toBeNull();
+  });
+
+  it('preserves safe links while rejecting javascript links', () => {
+    renderMarkdown('[docs](https://example.com/a.md)');
+    expect(
+      container?.querySelector('a[href="https://example.com/a.md"]'),
+    ).toBeTruthy();
+    expect(container?.querySelector('a[href^="javascript:"]')).toBeNull();
   });
 });

--- a/packages/webui/src/components/messages/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/packages/webui/src/components/messages/MarkdownRenderer/MarkdownRenderer.tsx
@@ -34,6 +34,27 @@ const KNOWN_FILE_EXTENSIONS =
   /\.(tsx?|jsx?|css|scss|json|md|py|java|go|rs|c|cpp|h|hpp|sh|ya?ml|toml|xml|html|vue|svelte)$/i;
 
 const FILE_URI_PATTERN = /^file:\/\//i;
+const FILE_URI_TEXT_PATTERN = /file:\/\//i;
+const EXTERNAL_LINK_PATTERN = /^(?:https?|mailto|ftp|data):/i;
+
+const splitLineFragment = (
+  raw: string,
+): { filePath: string; line?: number } => {
+  const hashIndex = raw.indexOf('#');
+  if (hashIndex < 0) {
+    return { filePath: raw };
+  }
+
+  const fragment = raw.slice(hashIndex + 1);
+  const lineMatch = fragment.match(/^L?(\d+)(?:-\d+)?$/i);
+  return {
+    filePath: raw.slice(0, hashIndex),
+    line: lineMatch ? parseInt(lineMatch[1], 10) : undefined,
+  };
+};
+
+const appendLineNumber = (filePath: string, line?: number): string =>
+  line === undefined ? filePath : filePath + ':' + line;
 
 const safeDecodePath = (value: string): string => {
   try {
@@ -43,39 +64,69 @@ const safeDecodePath = (value: string): string => {
   }
 };
 
+type ParsedLocalFileUri = {
+  filePath: string;
+  line?: number;
+};
+
+const parseAllowedLocalFileUri = (
+  raw: string,
+): ParsedLocalFileUri | undefined => {
+  if (!FILE_URI_PATTERN.test(raw)) {
+    return undefined;
+  }
+
+  const { filePath: rawUri, line } = splitLineFragment(raw);
+  let uri: URL;
+  try {
+    uri = new URL(rawUri);
+  } catch {
+    return undefined;
+  }
+
+  if (uri.protocol.toLowerCase() !== 'file:') {
+    return undefined;
+  }
+
+  const hostname = uri.hostname.toLowerCase();
+  if (hostname !== '' && hostname !== 'localhost') {
+    return undefined;
+  }
+
+  const decodedPath = safeDecodePath(uri.pathname).replace(/\\/g, '/');
+  const encodedNetworkPath = uri.pathname
+    .replace(/%2f/gi, '/')
+    .replace(/%5c/gi, '\\')
+    .replace(/\\/g, '/');
+
+  // An empty authority can still carry a UNC-like pathname (file:////server).
+  if (decodedPath.startsWith('//') || encodedNetworkPath.startsWith('//')) {
+    return undefined;
+  }
+
+  const filePath =
+    decodedPath.length > 1 && /^[a-zA-Z]:\//.test(decodedPath.slice(1))
+      ? decodedPath.slice(1)
+      : decodedPath;
+
+  return { filePath, line };
+};
+
+const isAllowedLocalFileUri = (url: string): boolean =>
+  parseAllowedLocalFileUri(url) !== undefined;
+
+const shouldSkipFilePathUpgrade = (href: string): boolean =>
+  EXTERNAL_LINK_PATTERN.test(href) || FILE_URI_PATTERN.test(href);
+
 const normalizeExplicitFileLink = (raw: string): string => {
-  const fragmentIndex = raw.indexOf('#');
-  const rawPath = fragmentIndex >= 0 ? raw.slice(0, fragmentIndex) : raw;
-  const fragment = fragmentIndex >= 0 ? raw.slice(fragmentIndex + 1) : '';
+  const parsed = parseAllowedLocalFileUri(raw);
+  if (parsed) {
+    return appendLineNumber(parsed.filePath, parsed.line);
+  }
+
+  const { filePath: rawPath, line } = splitLineFragment(raw);
   const decodedPath = safeDecodePath(rawPath).replace(/\\/g, '/');
-
-  // file:// URIs encode path characters separately from line fragments.
-  if (FILE_URI_PATTERN.test(decodedPath)) {
-    const uriPath = decodedPath.replace(FILE_URI_PATTERN, '');
-    let filePath: string;
-    if (uriPath.startsWith('/')) {
-      filePath = uriPath.slice(1);
-      if (!/^[a-zA-Z]:/.test(filePath)) {
-        filePath = '/' + filePath;
-      }
-    } else {
-      // Preserve the authority component for UNC paths.
-      filePath = `//${uriPath}`;
-    }
-    const lineMatch = fragment.match(/^L?(\d+)(?:-\d+)?$/i);
-    return lineMatch ? `${filePath}:${parseInt(lineMatch[1], 10)}` : filePath;
-  }
-
-  if (!fragment) {
-    return decodedPath;
-  }
-
-  const lineMatch = fragment.match(/^L?(\d+)(?:-\d+)?$/i);
-  if (lineMatch) {
-    return `${decodedPath}:${parseInt(lineMatch[1], 10)}`;
-  }
-
-  return decodedPath;
+  return appendLineNumber(decodedPath, line);
 };
 
 /**
@@ -103,7 +154,9 @@ const createMarkdownInstance = (): MarkdownIt => {
 
   const defaultValidateLink = md.validateLink;
   md.validateLink = (url: string): boolean =>
-    FILE_URI_PATTERN.test(url) || defaultValidateLink(url);
+    FILE_URI_PATTERN.test(url)
+      ? isAllowedLocalFileUri(url)
+      : defaultValidateLink(url);
 
   return md;
 };
@@ -153,19 +206,11 @@ export const MarkdownRenderer: FC<MarkdownRendererProps> = ({
     const normalizePathAndLine = (
       raw: string,
     ): { displayText: string; dataPath: string } => {
-      const displayText = raw;
-      let base = raw;
-      const hashIndex = raw.indexOf('#');
-      if (hashIndex >= 0) {
-        const frag = raw.slice(hashIndex + 1);
-        const m = frag.match(/^L?(\d+)(?:-\d+)?$/i);
-        if (m) {
-          const line = parseInt(m[1], 10);
-          base = raw.slice(0, hashIndex);
-          return { displayText, dataPath: `${base}:${line}` };
-        }
-      }
-      return { displayText, dataPath: base };
+      const { filePath, line } = splitLineFragment(raw);
+      return {
+        displayText: raw,
+        dataPath: line === undefined ? raw : appendLineNumber(filePath, line),
+      };
     };
 
     const makeLink = (text: string) => {
@@ -229,10 +274,7 @@ export const MarkdownRenderer: FC<MarkdownRendererProps> = ({
         }
       }
 
-      if (
-        /^(https?|mailto|ftp|data):/i.test(href) ||
-        FILE_URI_PATTERN.test(href)
-      ) {
+      if (shouldSkipFilePathUpgrade(href)) {
         return;
       }
 
@@ -280,6 +322,15 @@ export const MarkdownRenderer: FC<MarkdownRendererProps> = ({
         const next = child.nextSibling;
         if (child.nodeType === Node.TEXT_NODE) {
           const text = child.nodeValue || '';
+
+          // MarkdownIt emits rejected file URIs as text. Keep them inert so
+          // path linkification cannot turn a later slash segment into a
+          // file-path-link.
+          if (FILE_URI_TEXT_PATTERN.test(text)) {
+            child = next;
+            continue;
+          }
+
           union.lastIndex = 0;
           const hasMatch = union.test(text);
           union.lastIndex = 0;
@@ -327,7 +378,10 @@ export const MarkdownRenderer: FC<MarkdownRendererProps> = ({
   };
 
   const removeFileUriImages = (html: string): string => {
-    if (typeof document === 'undefined') {
+    if (
+      typeof document === 'undefined' ||
+      !html.toLowerCase().includes('file:')
+    ) {
       return html;
     }
 
@@ -382,7 +436,7 @@ export const MarkdownRenderer: FC<MarkdownRendererProps> = ({
       }
 
       // Handle explicit markdown links (file:// URIs and normal file-path hrefs).
-      // file:// URIs come from trusted system-generated content (e.g. /export).
+      // Every file:// link is intercepted so the browser never navigates to it.
       // Normal file-path links (absolute or with known extensions) are also
       // supported so that intentional markdown links remain clickable even
       // when enableFileLinks is false.
@@ -394,20 +448,18 @@ export const MarkdownRenderer: FC<MarkdownRendererProps> = ({
 
       const href = anyAnchor.getAttribute('href') || '';
 
-      // Handle file:// URI links (e.g. from /export success messages).
-      if (FILE_URI_PATTERN.test(href) && onFileClick) {
-        const candidate = normalizeExplicitFileLink(href);
+      // Only local file:/// URIs may reach the host file-open handler.
+      if (FILE_URI_PATTERN.test(href)) {
         e.preventDefault();
         e.stopPropagation();
-        onFileClick(candidate);
+        if (isAllowedLocalFileUri(href)) {
+          onFileClick?.(normalizeExplicitFileLink(href));
+        }
         return;
       }
 
       // Skip external links — let browser handle them normally
-      if (
-        /^(https?|mailto|ftp|data):/i.test(href) ||
-        FILE_URI_PATTERN.test(href)
-      ) {
+      if (shouldSkipFilePathUpgrade(href)) {
         return;
       }
 

--- a/packages/webui/src/components/messages/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/packages/webui/src/components/messages/MarkdownRenderer/MarkdownRenderer.tsx
@@ -33,6 +33,8 @@ const FILE_PATH_WITH_LINES_REGEX =
 const KNOWN_FILE_EXTENSIONS =
   /\.(tsx?|jsx?|css|scss|json|md|py|java|go|rs|c|cpp|h|hpp|sh|ya?ml|toml|xml|html|vue|svelte)$/i;
 
+const FILE_URI_PATTERN = /^file:\/\//i;
+
 const safeDecodePath = (value: string): string => {
   try {
     return decodeURIComponent(value);
@@ -42,35 +44,38 @@ const safeDecodePath = (value: string): string => {
 };
 
 const normalizeExplicitFileLink = (raw: string): string => {
-  const decoded = safeDecodePath(raw).replace(/\\/g, '/');
+  const fragmentIndex = raw.indexOf('#');
+  const rawPath = fragmentIndex >= 0 ? raw.slice(0, fragmentIndex) : raw;
+  const fragment = fragmentIndex >= 0 ? raw.slice(fragmentIndex + 1) : '';
+  const decodedPath = safeDecodePath(rawPath).replace(/\\/g, '/');
 
-  // file:// URIs (e.g. from vscode.Uri.file().toString()) encode special
-  // characters like # as %23 in the path component. After decoding the
-  // full URI we can strip the scheme and return the filesystem path
-  // directly — no fragment splitting needed, because any # in the
-  // decoded result is a literal filename character, not an anchor.
-  if (/^file:\/\//i.test(decoded)) {
-    let filePath = decoded.replace(/^file:\/\/\//i, '');
-    // On Unix the path should start with /
-    if (!/^[a-zA-Z]:/.test(filePath) && !filePath.startsWith('/')) {
-      filePath = '/' + filePath;
+  // file:// URIs encode path characters separately from line fragments.
+  if (FILE_URI_PATTERN.test(decodedPath)) {
+    const uriPath = decodedPath.replace(FILE_URI_PATTERN, '');
+    let filePath: string;
+    if (uriPath.startsWith('/')) {
+      filePath = uriPath.slice(1);
+      if (!/^[a-zA-Z]:/.test(filePath)) {
+        filePath = '/' + filePath;
+      }
+    } else {
+      // Preserve the authority component for UNC paths.
+      filePath = `//${uriPath}`;
     }
-    return filePath;
+    const lineMatch = fragment.match(/^L?(\d+)(?:-\d+)?$/i);
+    return lineMatch ? `${filePath}:${parseInt(lineMatch[1], 10)}` : filePath;
   }
 
-  const hashIndex = decoded.indexOf('#');
-  if (hashIndex < 0) {
-    return decoded;
+  if (!fragment) {
+    return decodedPath;
   }
 
-  const base = decoded.slice(0, hashIndex);
-  const fragment = decoded.slice(hashIndex + 1);
   const lineMatch = fragment.match(/^L?(\d+)(?:-\d+)?$/i);
   if (lineMatch) {
-    return `${base}:${parseInt(lineMatch[1], 10)}`;
+    return `${decodedPath}:${parseInt(lineMatch[1], 10)}`;
   }
 
-  return base;
+  return decodedPath;
 };
 
 /**
@@ -98,7 +103,7 @@ const createMarkdownInstance = (): MarkdownIt => {
 
   const defaultValidateLink = md.validateLink;
   md.validateLink = (url: string): boolean =>
-    /^file:\/\//i.test(url) || defaultValidateLink(url);
+    FILE_URI_PATTERN.test(url) || defaultValidateLink(url);
 
   return md;
 };
@@ -224,7 +229,10 @@ export const MarkdownRenderer: FC<MarkdownRendererProps> = ({
         }
       }
 
-      if (/^(https?|mailto|ftp|data):/i.test(href)) {
+      if (
+        /^(https?|mailto|ftp|data):/i.test(href) ||
+        FILE_URI_PATTERN.test(href)
+      ) {
         return;
       }
 
@@ -318,12 +326,27 @@ export const MarkdownRenderer: FC<MarkdownRendererProps> = ({
     return container.innerHTML;
   };
 
+  const removeFileUriImages = (html: string): string => {
+    if (typeof document === 'undefined') {
+      return html;
+    }
+
+    const container = document.createElement('div');
+    container.innerHTML = html;
+    for (const image of Array.from(container.querySelectorAll('img'))) {
+      if (FILE_URI_PATTERN.test(image.getAttribute('src') || '')) {
+        image.replaceWith(document.createTextNode(image.alt));
+      }
+    }
+    return container.innerHTML;
+  };
+
   /**
    * Render markdown content to HTML (memoized)
    */
   const renderedHtml = useMemo(() => {
     try {
-      let html = md.render(content);
+      let html = removeFileUriImages(md.render(content));
 
       if (enableFileLinks) {
         html = processFilePaths(html);
@@ -372,7 +395,7 @@ export const MarkdownRenderer: FC<MarkdownRendererProps> = ({
       const href = anyAnchor.getAttribute('href') || '';
 
       // Handle file:// URI links (e.g. from /export success messages).
-      if (/^file:\/\//i.test(href) && onFileClick) {
+      if (FILE_URI_PATTERN.test(href) && onFileClick) {
         const candidate = normalizeExplicitFileLink(href);
         e.preventDefault();
         e.stopPropagation();
@@ -381,7 +404,10 @@ export const MarkdownRenderer: FC<MarkdownRendererProps> = ({
       }
 
       // Skip external links — let browser handle them normally
-      if (/^(https?|mailto|ftp|data):/i.test(href)) {
+      if (
+        /^(https?|mailto|ftp|data):/i.test(href) ||
+        FILE_URI_PATTERN.test(href)
+      ) {
         return;
       }
 

--- a/packages/webui/src/components/messages/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/packages/webui/src/components/messages/MarkdownRenderer/MarkdownRenderer.tsx
@@ -87,14 +87,21 @@ const escapeHtml = (unsafe: string): string =>
 /**
  * Create a cached MarkdownIt instance
  */
-const createMarkdownInstance = (): MarkdownIt =>
-  new MarkdownIt({
+const createMarkdownInstance = (): MarkdownIt => {
+  const md = new MarkdownIt({
     html: false, // Disable HTML for security
     xhtmlOut: false,
     breaks: true,
     linkify: true,
     typographer: true,
   } as MarkdownItOptions);
+
+  const defaultValidateLink = md.validateLink;
+  md.validateLink = (url: string): boolean =>
+    /^file:\/\//i.test(url) || defaultValidateLink(url);
+
+  return md;
+};
 
 /**
  * MarkdownRenderer component - renders markdown content with enhanced features


### PR DESCRIPTION


**Before recording (compressed `before.mp4`):**

https://github.com/user-attachments/assets/35af438e-35ba-4372-91a5-b0e5e1effc82



**After recording (compressed `after.mp4`):**

https://github.com/user-attachments/assets/148fe0a6-b68d-4876-84ec-2328ffad5ea3

## What this PR does

Preserve Windows drive-letter paths in session export links and allow the Web UI Markdown renderer to open `file://` links through the existing file click handler.

## Why it's needed

On Windows, session export links could encode a drive-letter path incorrectly and be rejected by Markdown rendering, causing a click to open the browser and return HTTP 502 instead of opening the exported file in VS Code.

## Reviewer Test Plan

### How to verify

1. On Windows, start a Qwen Code Companion conversation and run `/export md`.
2. Click the generated Markdown export link.
3. Confirm that the exported `.md` file opens in VS Code, with no browser navigation or HTTP 502.
4. Confirm that HTML, JSON, and JSONL export links still work.
5. Local validation: `npm run clean`, `npm ci`, `npm run format`, `npm run lint:ci`, `npm run build`, and `npm run typecheck` passed when run separately.

### Evidence (Before & After)

Before: clicking the Windows Markdown export link opened the browser and showed HTTP 502; the compressed `before.mp4` recording is attached above. After: clicking the same link opens the exported Markdown file in VS Code without browser navigation or HTTP 502; the compressed `after.mp4` recording is attached above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | ✅ |
|  🐧 Linux  | N/A |

### Environment

Windows 11, VS Code Qwen Code Companion 0.21.9, workspace opened through GitHub Codespaces.

## Risk & Scope

- Main risk or tradeoff: `file://` links are explicitly allowed by the Markdown renderer so the existing local-file click handler can process Windows paths.
- Not validated / out of scope: Manual UI verification on macOS/Linux; the full root `test:ci` run reached `@qwen-code/external-context` (172 tests passed) but ended without an aggregate summary or exit code, so the full-suite result is inconclusive.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #8644

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

保留会话导出链接中的 Windows 盘符路径，并允许 Web UI Markdown 渲染器通过现有的文件点击处理器打开 `file://` 链接。

## 为什么需要它

在 Windows 上，会话导出链接可能错误地编码盘符，随后被 Markdown 渲染器拒绝，导致点击链接后跳转到浏览器并返回 HTTP 502，而不是在 VS Code 中打开导出的文件。

## 审阅者测试计划

### 如何验证

1. 在 Windows 上启动 Qwen Code Companion 会话并运行 `/export md`。
2. 点击生成的 Markdown 导出链接。
3. 确认导出的 `.md` 文件在 VS Code 中打开，且不会跳转浏览器或出现 HTTP 502。
4. 确认 HTML、JSON 和 JSONL 导出链接仍然正常。
5. 本地验证：分别运行的 `npm run clean`、`npm ci`、`npm run format`、`npm run lint:ci`、`npm run build` 和 `npm run typecheck` 均通过。

### 证据（修复前与修复后）

修复前：点击 Windows Markdown 导出链接会打开浏览器并显示 HTTP 502；压缩后的 `before.mp4` 录屏已附在上方。修复后：点击同一链接会在 VS Code 中打开导出的 Markdown 文件，不会跳转浏览器或出现 HTTP 502；压缩后的 `after.mp4` 录屏已附在上方。

### 已测试平台

| 操作系统 | 状态 |
| :------: | :--: |
| 🍏 macOS | N/A |
| 🪟 Windows | ✅ |
| 🐧 Linux | N/A |

### 环境

Windows 11、VS Code Qwen Code Companion 0.21.9，工作区通过 GitHub Codespaces 打开。

## 风险与范围

- 主要风险或权衡：Markdown 渲染器显式允许 `file://` 链接，使现有的本地文件点击处理器能够处理 Windows 路径。
- 未验证/不在范围内：未在 macOS/Linux 上进行手动 UI 验证；远端 root `test:ci` 已运行到 `@qwen-code/external-context`（172 个测试通过），但日志没有最终汇总或退出码，因此全量结果尚不确定。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Fixes #8644

</details>