### PR TITLE
feat(serve): Propagate session list cancellation

### DIFF
--- a/docs/design/session-list-persisted-catalog-cache.md
+++ b/docs/design/session-list-persisted-catalog-cache.md
@@ -8,7 +8,11 @@ Organized and metadata-filtered session lists must load the complete persisted s
 
 The daemon keeps a process-local catalog snapshot keyed by the resolved session runtime root, the exact workspace identity, and active versus archived state. Query, group, source, cursor, trust, and live-merge options are intentionally excluded because they do not change persisted catalog contents.
 
-The first request installs an in-flight Promise before starting the loader. Concurrent requests for the same generation await that Promise. A successful catalog, including worktree sidecars, remains available for two seconds from scan completion. Organization and every live bridge field are merged after lookup on every request. Default numeric pagination and the separate session-info counter do not use the catalog cache.
+The first request installs an in-flight load before starting the loader. Concurrent requests for the same generation attach independent waiter promises to that load. A successful catalog, including worktree sidecars, remains available for two seconds from scan completion. Organization and every live bridge field are merged after lookup on every request. Default numeric pagination and the separate session-info counter do not use the catalog cache.
+
+Each physical load owns an `AbortController`; caller signals attach only to their waiter and are never combined directly with the loader signal. Cancelling one waiter rejects only that caller with its original reason. Settlement is first-wins: after the physical load outcome is accepted, a later caller abort cannot replace that result. When the last waiter cancels first, the cache aborts the physical load and synchronously detaches it from the slot, allowing a new request to start a replacement scan immediately. A detached load that ignores cancellation may still settle its existing promise, but identity and generation checks prevent it from installing a snapshot or changing the replacement load.
+
+The core persisted scan checks cancellation around directory enumeration, sorting, JSONL reads, runtime membership reads, sidecar reads, and synchronous title extraction. When a signal is present, directory stat enumeration yields to the event loop every 128 entries so an HTTP disconnect can be observed; callers that do not pass a signal retain the original non-yielding path. REST request disconnects and ACP connection destruction cancel their own waiters. LiveTask callers do not pass a signal and remain non-cancellable waiters.
 
 Each scope has a generation. Explicit metadata, close, delete, archive, and unarchive operations invalidate the affected states. An invalidated in-flight load may finish for requests that already joined it, but its generation cannot repopulate the cache. Failures are never cached and there is no stale-on-error fallback.
 
@@ -24,8 +28,8 @@ The cache is not a filesystem transaction. Unknown writers can update a file aft
 
 ## Observability
 
-Request spans distinguish physical scans, cache hits, and single-flight waiters before awaiting the shared Promise, so failures retain their cache status. Successful lookups also record archive state, query kind, summary count, scan pages, truncation, and either leader scan duration or cache age. Paths, session identifiers, titles, and source identifiers are never attached.
+Request spans distinguish physical scans, cache hits, and single-flight waiters before awaiting the shared load, so failures retain their cache status. Successful lookups also record archive state, query kind, summary count, scan pages, truncation, and either the physical scan duration for scan/single-flight waiters or cache age for cache hits. Paths, session identifiers, titles, and source identifiers are never attached.
 
 ## Out of scope
 
-This change does not alter public protocols, Web Shell polling, the session-info scan, cross-workspace scan scheduling, core filesystem APIs, or daemon timeout policy. The outer lifecycle timeout fix remains necessary for a single slow cold scan.
+This change does not alter public protocols, Web Shell polling, the session-info scan, cross-workspace scan scheduling, or daemon timeout policy. It does not add per-request ACP cancellation, fixed scan deadlines, asynchronous directory enumeration, concurrent stat calls, worker threads, or cancellation for CLI resume and picker callers.

--- a/packages/cli/src/serve/acp-http/dispatch.ts
+++ b/packages/cli/src/serve/acp-http/dispatch.ts
@@ -1986,20 +1986,33 @@ export class AcpDispatcher {
           if ('error' in parsedSource) {
             throw new AcpParamError(parsedSource.error);
           }
-          const result = await listWorkspaceSessionsForResponse(
-            this.bridge,
-            workspaceCwd,
-            {
-              cursor,
-              size: metaSize,
-              archiveState,
-              view,
-              group,
-              parentSessionId,
-              ...parsedSource,
-            },
-            { runtimeBaseDir: this.sessionRuntimeBaseDir },
-          );
+          let result: Awaited<
+            ReturnType<typeof listWorkspaceSessionsForResponse>
+          >;
+          try {
+            conn.abortSignal.throwIfAborted();
+            result = await listWorkspaceSessionsForResponse(
+              this.bridge,
+              workspaceCwd,
+              {
+                cursor,
+                size: metaSize,
+                archiveState,
+                view,
+                group,
+                parentSessionId,
+                ...parsedSource,
+              },
+              {
+                runtimeBaseDir: this.sessionRuntimeBaseDir,
+                signal: conn.abortSignal,
+              },
+            );
+            conn.abortSignal.throwIfAborted();
+          } catch (error) {
+            if (conn.abortSignal.aborted) return;
+            throw error;
+          }
           this.replyConn(conn, id, {
             sessions: result.sessions.map((s) => ({
               sessionId: s.sessionId,

--- a/packages/cli/src/serve/acp-http/transport.test.ts
+++ b/packages/cli/src/serve/acp-http/transport.test.ts
@@ -3257,6 +3257,66 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
     });
   });
 
+  it('cancels session/list without buffering an error when the connection is destroyed', async () => {
+    let loadSignal: AbortSignal | undefined;
+    const listSessionsSpy = vi
+      .spyOn(SessionService.prototype, 'listSessions')
+      .mockImplementation(async (options) => {
+        const signal = options?.signal;
+        expect(signal).toBeDefined();
+        loadSignal = signal;
+        await new Promise<void>((_resolve, reject) => {
+          if (signal?.aborted) {
+            reject(signal.reason);
+            return;
+          }
+          signal?.addEventListener('abort', () => reject(signal.reason), {
+            once: true,
+          });
+        });
+        return { items: [], nextCursor: undefined, hasMore: false };
+      });
+
+    try {
+      const connId = await initialize();
+      const conn = acpHandle?.registry.get(connId);
+      expect(conn).toBeDefined();
+      const bufferedBefore = conn!.getDiagnostic().bufferedConnectionFrames;
+      const logCallsBefore = stdioMocks.writeStderrLine.mock.calls.length;
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 130,
+        method: 'session/list',
+        params: { workspaceCwd: TEST_WORKSPACE, view: 'organized' },
+      });
+      await waitUntil(() => loadSignal !== undefined);
+
+      const deleted = await fetch(`${base}/acp`, {
+        method: 'DELETE',
+        headers: { 'acp-connection-id': connId },
+      });
+      expect(deleted.status).toBe(202);
+      await waitUntil(() => loadSignal?.aborted === true);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(conn!.abortSignal.aborted).toBe(true);
+      expect(conn!.getDiagnostic().bufferedConnectionFrames).toBe(
+        bufferedBefore,
+      );
+      const cancellationLogs = stdioMocks.writeStderrLine.mock.calls
+        .slice(logCallsBefore)
+        .flat();
+      expect(
+        cancellationLogs.some(
+          (line) =>
+            typeof line === 'string' && line.includes('/acp dispatch error'),
+        ),
+      ).toBe(false);
+    } finally {
+      listSessionsSpy.mockRestore();
+    }
+  });
+
   it('_qwen/sessions/archive rejects invalid batch params', async () => {
     const connId = await initialize();
     const connStream = await openStream(connId);

--- a/packages/cli/src/serve/acp-http/transport.test.ts
+++ b/packages/cli/src/serve/acp-http/transport.test.ts
@@ -3317,6 +3317,76 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
     }
   });
 
+  it('keeps a shared session/list scan alive when one connection is destroyed', async () => {
+    let loadSignal: AbortSignal | undefined;
+    let resolveScan!: (value: {
+      items: [];
+      nextCursor: undefined;
+      hasMore: false;
+    }) => void;
+    let rejectScan!: (reason?: unknown) => void;
+    const scan = new Promise<{
+      items: [];
+      nextCursor: undefined;
+      hasMore: false;
+    }>((resolve, reject) => {
+      resolveScan = resolve;
+      rejectScan = reject;
+    });
+    const listSessionsSpy = vi
+      .spyOn(SessionService.prototype, 'listSessions')
+      .mockImplementation(async (options) => {
+        const signal = options?.signal;
+        expect(signal).toBeDefined();
+        loadSignal = signal;
+        signal?.addEventListener('abort', () => rejectScan(signal.reason), {
+          once: true,
+        });
+        return scan;
+      });
+
+    try {
+      const firstConnId = await initialize();
+      const secondConnId = await initialize();
+      const secondStream = await openStream(secondConnId);
+      const secondFrame = takeFrames(secondStream, 1);
+      await Promise.all([
+        post(firstConnId, {
+          jsonrpc: '2.0',
+          id: 131,
+          method: 'session/list',
+          params: { workspaceCwd: TEST_WORKSPACE, view: 'organized' },
+        }),
+        post(secondConnId, {
+          jsonrpc: '2.0',
+          id: 132,
+          method: 'session/list',
+          params: { workspaceCwd: TEST_WORKSPACE, view: 'organized' },
+        }),
+      ]);
+      await waitUntil(() => loadSignal !== undefined);
+      expect(listSessionsSpy).toHaveBeenCalledTimes(1);
+
+      const deleted = await fetch(`${base}/acp`, {
+        method: 'DELETE',
+        headers: { 'acp-connection-id': firstConnId },
+      });
+      expect(deleted.status).toBe(202);
+      expect(loadSignal?.aborted).toBe(false);
+
+      resolveScan({ items: [], nextCursor: undefined, hasMore: false });
+      await expect(secondFrame).resolves.toEqual([
+        expect.objectContaining({
+          id: 132,
+          result: expect.objectContaining({ sessions: [] }),
+        }),
+      ]);
+    } finally {
+      resolveScan({ items: [], nextCursor: undefined, hasMore: false });
+      listSessionsSpy.mockRestore();
+    }
+  });
+
   it('_qwen/sessions/archive rejects invalid batch params', async () => {
     const connId = await initialize();
     const connStream = await openStream(connId);

--- a/packages/cli/src/serve/routes/session.ts
+++ b/packages/cli/src/serve/routes/session.ts
@@ -787,16 +787,22 @@ export function registerSessionRoutes(
     return runtime;
   };
 
-  const hasActivePersistedSessions = async (runtime: WorkspaceRuntime) => {
+  const hasActivePersistedSessions = async (
+    runtime: WorkspaceRuntime,
+    signal: AbortSignal,
+  ) => {
     try {
       const page = await createWorkspaceRuntimeSessionService(
         runtime,
       ).listSessions({
         archiveState: 'active',
         size: 1,
+        signal,
       });
+      signal.throwIfAborted();
       return page.items.length > 0;
     } catch {
+      signal.throwIfAborted();
       return false;
     }
   };
@@ -4371,53 +4377,82 @@ export function registerSessionRoutes(
           ...(parentSessionId !== undefined ? { parentSessionId } : {}),
           ...parsedSource,
         };
-        // Organized/archived views always need the persisted store: organized
-        // cursors are opaque (non-numeric) and archived-only workspaces have no
-        // active persisted sessions, so the live-only fallback would drop them.
-        // Metadata filters gather the whole workspace
-        // (persisted + live) to filter completely and paginates with an opaque
-        // activity cursor, so the numeric-cursor live fallback can't serve it.
-        const usePersisted =
-          readOnlySecondary ||
-          runtime.primary ||
-          view === 'organized' ||
-          archiveState === 'archived' ||
-          parentSessionId !== undefined ||
-          parsedSource.sourceType !== undefined ||
-          (cursor !== undefined && cursor !== ''
-            ? isNumericSessionCursor(cursor)
-            : await hasActivePersistedSessions(runtime));
-        // The live path only reads cursor/size; persisted-only options
-        // (organized view or archived state) would be silently dropped there.
-        // usePersisted already routes those to the persisted path — assert it so
-        // a future option added to validation but not to that gate fails loudly.
-        if (
-          !usePersisted &&
-          (view !== undefined ||
+        const controller = new AbortController();
+        const onRequestAborted = () => {
+          controller.abort(new DOMException('Request aborted', 'AbortError'));
+        };
+        const onResponseClosed = () => {
+          if (!res.writableEnded) {
+            controller.abort(new DOMException('Response closed', 'AbortError'));
+          }
+        };
+        req.once('aborted', onRequestAborted);
+        res.once('close', onResponseClosed);
+        if (req.aborted || res.destroyed) onRequestAborted();
+        try {
+          // Organized/archived views always need the persisted store: organized
+          // cursors are opaque (non-numeric) and archived-only workspaces have no
+          // active persisted sessions, so the live-only fallback would drop them.
+          // Metadata filters gather the whole workspace
+          // (persisted + live) to filter completely and paginates with an opaque
+          // activity cursor, so the numeric-cursor live fallback can't serve it.
+          const usePersisted =
+            readOnlySecondary ||
+            runtime.primary ||
+            view === 'organized' ||
             archiveState === 'archived' ||
             parentSessionId !== undefined ||
-            parsedSource.sourceType !== undefined)
-        ) {
-          throw new Error(
-            'session list live path received persisted-only options',
-          );
+            parsedSource.sourceType !== undefined ||
+            (cursor !== undefined && cursor !== ''
+              ? isNumericSessionCursor(cursor)
+              : await hasActivePersistedSessions(runtime, controller.signal));
+          // The live path only reads cursor/size; persisted-only options
+          // (organized view or archived state) would be silently dropped there.
+          // usePersisted already routes those to the persisted path — assert it so
+          // a future option added to validation but not to that gate fails loudly.
+          if (
+            !usePersisted &&
+            (view !== undefined ||
+              archiveState === 'archived' ||
+              parentSessionId !== undefined ||
+              parsedSource.sourceType !== undefined)
+          ) {
+            throw new Error(
+              'session list live path received persisted-only options',
+            );
+          }
+          const result = usePersisted
+            ? await runWorkspaceInspectionWithLogPolicy(runtime, () =>
+                listWorkspaceSessionsForResponse(runtime.bridge, key, options, {
+                  mergeLive: !readOnlySecondary,
+                  runtimeBaseDir: runtime.sessionRuntimeBaseDir,
+                  signal: controller.signal,
+                }),
+              )
+            : listLiveWorkspaceSessionsForResponse(
+                runtime.bridge,
+                key,
+                options,
+              );
+          controller.signal.throwIfAborted();
+          if (res.destroyed) return;
+          res.status(200).json({
+            sessions: result.sessions,
+            ...(result.nextCursor != null
+              ? { nextCursor: result.nextCursor }
+              : {}),
+            ...(result.liveMergeFailed ? { liveMergeFailed: true } : {}),
+            ...(result.truncated ? { truncated: true } : {}),
+          });
+        } catch (err) {
+          if (controller.signal.aborted || res.destroyed) {
+            return;
+          }
+          throw err;
+        } finally {
+          req.off('aborted', onRequestAborted);
+          res.off('close', onResponseClosed);
         }
-        const result = usePersisted
-          ? await runWorkspaceInspectionWithLogPolicy(runtime, () =>
-              listWorkspaceSessionsForResponse(runtime.bridge, key, options, {
-                mergeLive: !readOnlySecondary,
-                runtimeBaseDir: runtime.sessionRuntimeBaseDir,
-              }),
-            )
-          : listLiveWorkspaceSessionsForResponse(runtime.bridge, key, options);
-        res.status(200).json({
-          sessions: result.sessions,
-          ...(result.nextCursor != null
-            ? { nextCursor: result.nextCursor }
-            : {}),
-          ...(result.liveMergeFailed ? { liveMergeFailed: true } : {}),
-          ...(result.truncated ? { truncated: true } : {}),
-        });
       } catch (err) {
         if (err instanceof InvalidCursorError) {
           res.status(400).json({

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -191,7 +191,9 @@ import { getActiveSseCount } from './routes/sse-events.js';
 // `mockWt.impl` to control instance behaviour.
 const mockWt = vi.hoisted(() => ({
   impl: undefined as (() => Record<string, unknown>) | undefined,
-  readSidecar: undefined as (() => Promise<unknown>) | undefined,
+  readSidecar: undefined as
+    | ((...args: unknown[]) => Promise<unknown>)
+    | undefined,
   realpath: undefined as ((p: string) => string) | undefined,
 }));
 const mockTmpdir = vi.hoisted(() => ({
@@ -223,7 +225,7 @@ vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
     ...original,
     readWorktreeSession: (...args: unknown[]) =>
       mockWt.readSidecar
-        ? mockWt.readSidecar()
+        ? mockWt.readSidecar(...args)
         : (original.readWorktreeSession as (...a: unknown[]) => unknown)(
             ...args,
           ),
@@ -12997,6 +12999,7 @@ describe('createServeApp', () => {
         });
         catalogRequest.abort();
         await vi.waitFor(() => expect(preflightSignal?.aborted).toBe(true));
+        expect(secondaryBridge.listCalls).toEqual([]);
       } finally {
         listSessionsSpy.mockRestore();
       }
@@ -13735,6 +13738,64 @@ describe('createServeApp', () => {
       }
     });
 
+    it('propagates catalog cancellation through worktree enrichment', async () => {
+      const sessionId = '550e8400-e29b-41d4-a716-446655440016';
+      const controller = new AbortController();
+      const reason = new Error('cancelled during worktree enrichment');
+      let sidecarSignal: AbortSignal | undefined;
+      const listSessionsSpy = vi
+        .spyOn(SessionService.prototype, 'listSessions')
+        .mockResolvedValue({
+          items: [
+            {
+              sessionId,
+              cwd: WS_BOUND,
+              startTime: '2026-05-17T12:00:00.000Z',
+              mtime: Date.parse('2026-05-17T12:00:00.000Z'),
+              prompt: 'persisted prompt',
+              filePath: `/tmp/${sessionId}.jsonl`,
+            },
+          ],
+          nextCursor: undefined,
+          hasMore: false,
+        });
+      mockWt.readSidecar = async (_filePath: unknown, options: unknown) => {
+        sidecarSignal = (options as { signal?: AbortSignal }).signal;
+        await new Promise<void>((_resolve, reject) => {
+          sidecarSignal?.addEventListener(
+            'abort',
+            () => reject(sidecarSignal?.reason),
+            { once: true },
+          );
+        });
+        return null;
+      };
+
+      try {
+        const result = listWorkspaceSessionsForResponse(
+          fakeBridge(),
+          WS_BOUND,
+          { view: 'organized' },
+          {
+            runtimeBaseDir: path.join(runtimeDir, 'cancel-sidecar'),
+            signal: controller.signal,
+          },
+        );
+        await vi.waitFor(() =>
+          expect(sidecarSignal).toBeInstanceOf(AbortSignal),
+        );
+        expect(sidecarSignal).not.toBe(controller.signal);
+
+        controller.abort(reason);
+
+        await expect(result).rejects.toBe(reason);
+        expect(sidecarSignal?.aborted).toBe(true);
+      } finally {
+        listSessionsSpy.mockRestore();
+        mockWt.readSidecar = undefined;
+      }
+    });
+
     it('propagates cancellation through numeric pagination', async () => {
       const controller = new AbortController();
       const reason = new Error('numeric request disconnected');
@@ -13792,7 +13853,45 @@ describe('createServeApp', () => {
       }
     });
 
-    it('keeps a shared REST catalog scan alive when only one request disconnects', async () => {
+    it('aborts a REST catalog scan when its last request disconnects', async () => {
+      const workspaceCwd = path.join(WS_BOUND, 'rest-cancel-last-waiter');
+      let loadSignal: AbortSignal | undefined;
+      const listSessionsSpy = vi
+        .spyOn(SessionService.prototype, 'listSessions')
+        .mockImplementation(async (options) => {
+          loadSignal = options.signal;
+          await new Promise<void>((_resolve, reject) => {
+            options.signal?.addEventListener(
+              'abort',
+              () => reject(options.signal?.reason),
+              { once: true },
+            );
+          });
+          return { items: [], nextCursor: undefined, hasMore: false };
+        });
+      const app = createServeApp(
+        { ...baseOpts, workspace: workspaceCwd },
+        undefined,
+        { bridge: fakeBridge(), boundWorkspace: workspaceCwd },
+      );
+      const catalogRequest = request(app)
+        .get(
+          `/workspace/${encodeURIComponent(workspaceCwd)}/sessions?view=organized`,
+        )
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
+      catalogRequest.end(() => undefined);
+
+      try {
+        await vi.waitFor(() => expect(loadSignal).toBeDefined());
+        catalogRequest.abort();
+        await vi.waitFor(() => expect(loadSignal?.aborted).toBe(true));
+        expect(listSessionsSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        listSessionsSpy.mockRestore();
+      }
+    });
+
+    it('keeps a shared REST catalog scan alive until every request disconnects', async () => {
       const workspaceCwd = path.join(WS_BOUND, 'rest-cancel-waiter');
       const scan = deferred<{
         items: SessionListItem[];
@@ -13816,14 +13915,10 @@ describe('createServeApp', () => {
         .get(url)
         .set('Host', `127.0.0.1:${baseOpts.port}`);
       firstRequest.end(() => undefined);
-      const secondResponse = new Promise<request.Response>((resolve, reject) =>
-        request(app)
-          .get(url)
-          .set('Host', `127.0.0.1:${baseOpts.port}`)
-          .end((error, response) =>
-            error ? reject(error) : resolve(response),
-          ),
-      );
+      const secondRequest = request(app)
+        .get(url)
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
+      secondRequest.end(() => undefined);
 
       try {
         await vi.waitFor(() => expect(loadSignal).toBeDefined());
@@ -13831,8 +13926,8 @@ describe('createServeApp', () => {
         await new Promise<void>((resolve) => setImmediate(resolve));
         expect(loadSignal?.aborted).toBe(false);
 
-        scan.resolve({ items: [], nextCursor: undefined, hasMore: false });
-        await expect(secondResponse).resolves.toMatchObject({ status: 200 });
+        secondRequest.abort();
+        await vi.waitFor(() => expect(loadSignal?.aborted).toBe(true));
         expect(listSessionsSpy).toHaveBeenCalledTimes(1);
       } finally {
         scan.resolve({ items: [], nextCursor: undefined, hasMore: false });
@@ -14084,16 +14179,24 @@ describe('createServeApp', () => {
           'single_flight',
         );
 
+        await Promise.all([
+          listWorkspaceSessionsForResponse(
+            fakeBridge(),
+            WS_BOUND,
+            { sourceType: 'default' },
+            { runtimeBaseDir: runtimeDir },
+          ),
+          listWorkspaceSessionsForResponse(
+            fakeBridge(),
+            WS_BOUND,
+            { parentSessionId: 'missing-parent' },
+            { runtimeBaseDir: runtimeDir },
+          ),
+        ]);
         await listWorkspaceSessionsForResponse(
           fakeBridge(),
           WS_BOUND,
           { sourceType: 'default' },
-          { runtimeBaseDir: runtimeDir },
-        );
-        await listWorkspaceSessionsForResponse(
-          fakeBridge(),
-          WS_BOUND,
-          { parentSessionId: 'missing-parent' },
           { runtimeBaseDir: runtimeDir },
         );
         expect(setAttribute).toHaveBeenCalledWith(
@@ -14128,6 +14231,12 @@ describe('createServeApp', () => {
           'qwen-code.daemon.session_list.scan_duration_ms',
           expect.any(Number),
         );
+        expect(
+          setAttribute.mock.calls.filter(
+            ([name]) =>
+              name === 'qwen-code.daemon.session_list.scan_duration_ms',
+          ),
+        ).toHaveLength(2);
       } finally {
         getSpanSpy.mockRestore();
         listSessionsSpy.mockRestore();

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -12946,6 +12946,62 @@ describe('createServeApp', () => {
       expect(secondaryBridge.listCalls).toEqual([WS_DIFFERENT]);
     });
 
+    it('cancels the trusted-secondary persisted preflight when the request disconnects', async () => {
+      const primaryBridge = fakeBridge();
+      const secondaryBridge = fakeBridge();
+      const registry = createWorkspaceRegistry([
+        makeWorkspaceRuntimeForTest({
+          workspaceId: 'preflight-primary',
+          workspaceCwd: WS_BOUND,
+          primary: true,
+          bridge: primaryBridge,
+        }),
+        makeWorkspaceRuntimeForTest({
+          workspaceId: 'preflight-secondary',
+          workspaceCwd: WS_DIFFERENT,
+          primary: false,
+          trusted: true,
+          bridge: secondaryBridge,
+        }),
+      ]);
+      let preflightSignal: AbortSignal | undefined;
+      const listSessionsSpy = vi
+        .spyOn(SessionService.prototype, 'listSessions')
+        .mockImplementation(async (options) => {
+          preflightSignal = options.signal;
+          await new Promise<void>((_resolve, reject) => {
+            options.signal?.addEventListener(
+              'abort',
+              () => reject(options.signal?.reason),
+              { once: true },
+            );
+          });
+          return { items: [], nextCursor: undefined, hasMore: false };
+        });
+      const app = createServeApp(
+        { ...baseOpts, workspace: WS_BOUND },
+        undefined,
+        { workspaceRegistry: registry },
+      );
+      const catalogRequest = request(app)
+        .get('/workspaces/preflight-secondary/sessions')
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
+      catalogRequest.end(() => undefined);
+
+      try {
+        await vi.waitFor(() => expect(preflightSignal).toBeDefined());
+        expect(listSessionsSpy).toHaveBeenCalledWith({
+          archiveState: 'active',
+          size: 1,
+          signal: preflightSignal,
+        });
+        catalogRequest.abort();
+        await vi.waitFor(() => expect(preflightSignal?.aborted).toBe(true));
+      } finally {
+        listSessionsSpy.mockRestore();
+      }
+    });
+
     it('includes persisted sessions from the CLI session store', async () => {
       const storedOnlyId = '550e8400-e29b-41d4-a716-446655440000';
       const liveAndStoredId = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
@@ -13564,6 +13620,223 @@ describe('createServeApp', () => {
       } finally {
         listSessionsSpy.mockRestore();
         mockWt.readSidecar = undefined;
+      }
+    });
+
+    it('cancels one organized waiter without aborting the shared catalog scan', async () => {
+      const scan = deferred<{
+        items: SessionListItem[];
+        nextCursor: undefined;
+        hasMore: false;
+      }>();
+      let loadSignal: AbortSignal | undefined;
+      const listSessionsSpy = vi
+        .spyOn(SessionService.prototype, 'listSessions')
+        .mockImplementation(async (options) => {
+          loadSignal = options.signal;
+          return scan.promise;
+        });
+      const controller = new AbortController();
+      const reason = new Error('first REST waiter disconnected');
+      const readOptions = {
+        runtimeBaseDir: path.join(runtimeDir, 'cancel-one-waiter'),
+      };
+
+      try {
+        const leader = listWorkspaceSessionsForResponse(
+          fakeBridge(),
+          WS_BOUND,
+          { view: 'organized' },
+          { ...readOptions, signal: controller.signal },
+        );
+        const follower = listWorkspaceSessionsForResponse(
+          fakeBridge(),
+          WS_BOUND,
+          { sourceType: 'default' },
+          readOptions,
+        );
+        await vi.waitFor(() => expect(loadSignal).toBeDefined());
+
+        controller.abort(reason);
+        await expect(leader).rejects.toBe(reason);
+        expect(loadSignal).not.toBe(controller.signal);
+        expect(loadSignal?.aborted).toBe(false);
+
+        scan.resolve({ items: [], nextCursor: undefined, hasMore: false });
+        await expect(follower).resolves.toMatchObject({ sessions: [] });
+        expect(listSessionsSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        scan.resolve({ items: [], nextCursor: undefined, hasMore: false });
+        listSessionsSpy.mockRestore();
+      }
+    });
+
+    it('aborts and detaches a catalog scan after its last waiter cancels', async () => {
+      let firstLoadSignal: AbortSignal | undefined;
+      let invocation = 0;
+      const listSessionsSpy = vi
+        .spyOn(SessionService.prototype, 'listSessions')
+        .mockImplementation(async (options) => {
+          invocation += 1;
+          if (invocation > 1) {
+            return { items: [], nextCursor: undefined, hasMore: false };
+          }
+          firstLoadSignal = options.signal;
+          await new Promise<void>((_resolve, reject) => {
+            options.signal?.addEventListener(
+              'abort',
+              () => reject(options.signal?.reason),
+              { once: true },
+            );
+          });
+          return { items: [], nextCursor: undefined, hasMore: false };
+        });
+      const firstController = new AbortController();
+      const secondController = new AbortController();
+      const firstReason = new Error('first waiter disconnected');
+      const secondReason = new Error('last waiter disconnected');
+      const readOptions = {
+        runtimeBaseDir: path.join(runtimeDir, 'cancel-all-waiters'),
+      };
+
+      try {
+        const first = listWorkspaceSessionsForResponse(
+          fakeBridge(),
+          WS_BOUND,
+          { view: 'organized' },
+          { ...readOptions, signal: firstController.signal },
+        );
+        const second = listWorkspaceSessionsForResponse(
+          fakeBridge(),
+          WS_BOUND,
+          { sourceType: 'default' },
+          { ...readOptions, signal: secondController.signal },
+        );
+        await vi.waitFor(() => expect(firstLoadSignal).toBeDefined());
+
+        firstController.abort(firstReason);
+        await expect(first).rejects.toBe(firstReason);
+        expect(firstLoadSignal?.aborted).toBe(false);
+        secondController.abort(secondReason);
+        await expect(second).rejects.toBe(secondReason);
+        expect(firstLoadSignal?.aborted).toBe(true);
+
+        await expect(
+          listWorkspaceSessionsForResponse(
+            fakeBridge(),
+            WS_BOUND,
+            { view: 'organized' },
+            readOptions,
+          ),
+        ).resolves.toMatchObject({ sessions: [] });
+        expect(listSessionsSpy).toHaveBeenCalledTimes(2);
+      } finally {
+        listSessionsSpy.mockRestore();
+      }
+    });
+
+    it('propagates cancellation through numeric pagination', async () => {
+      const controller = new AbortController();
+      const reason = new Error('numeric request disconnected');
+      const listSessionsSpy = vi
+        .spyOn(SessionService.prototype, 'listSessions')
+        .mockImplementation(async (options) => {
+          expect(options.signal).toBe(controller.signal);
+          controller.abort(reason);
+          options.signal?.throwIfAborted();
+          return { items: [], nextCursor: undefined, hasMore: false };
+        });
+
+      try {
+        await expect(
+          listWorkspaceSessionsForResponse(fakeBridge(), WS_BOUND, undefined, {
+            runtimeBaseDir: runtimeDir,
+            signal: controller.signal,
+          }),
+        ).rejects.toBe(reason);
+      } finally {
+        listSessionsSpy.mockRestore();
+      }
+    });
+
+    it('does not start an organized catalog lookup after organization loading is cancelled', async () => {
+      const controller = new AbortController();
+      const reason = new Error('cancelled after organization read');
+      const readSnapshotSpy = vi
+        .spyOn(qwenCore.SessionOrganizationService.prototype, 'readSnapshot')
+        .mockImplementation(async () => {
+          controller.abort(reason);
+          return { groups: [], sessions: new Map() };
+        });
+      const listSessionsSpy = vi.spyOn(
+        SessionService.prototype,
+        'listSessions',
+      );
+
+      try {
+        await expect(
+          listWorkspaceSessionsForResponse(
+            fakeBridge(),
+            WS_BOUND,
+            { view: 'organized' },
+            {
+              runtimeBaseDir: path.join(runtimeDir, 'cancel-organization'),
+              signal: controller.signal,
+            },
+          ),
+        ).rejects.toBe(reason);
+        expect(listSessionsSpy).not.toHaveBeenCalled();
+      } finally {
+        readSnapshotSpy.mockRestore();
+        listSessionsSpy.mockRestore();
+      }
+    });
+
+    it('keeps a shared REST catalog scan alive when only one request disconnects', async () => {
+      const workspaceCwd = path.join(WS_BOUND, 'rest-cancel-waiter');
+      const scan = deferred<{
+        items: SessionListItem[];
+        nextCursor: undefined;
+        hasMore: false;
+      }>();
+      let loadSignal: AbortSignal | undefined;
+      const listSessionsSpy = vi
+        .spyOn(SessionService.prototype, 'listSessions')
+        .mockImplementation(async (options) => {
+          loadSignal = options.signal;
+          return scan.promise;
+        });
+      const app = createServeApp(
+        { ...baseOpts, workspace: workspaceCwd },
+        undefined,
+        { bridge: fakeBridge(), boundWorkspace: workspaceCwd },
+      );
+      const url = `/workspace/${encodeURIComponent(workspaceCwd)}/sessions?view=organized`;
+      const firstRequest = request(app)
+        .get(url)
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
+      firstRequest.end(() => undefined);
+      const secondResponse = new Promise<request.Response>((resolve, reject) =>
+        request(app)
+          .get(url)
+          .set('Host', `127.0.0.1:${baseOpts.port}`)
+          .end((error, response) =>
+            error ? reject(error) : resolve(response),
+          ),
+      );
+
+      try {
+        await vi.waitFor(() => expect(loadSignal).toBeDefined());
+        firstRequest.abort();
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        expect(loadSignal?.aborted).toBe(false);
+
+        scan.resolve({ items: [], nextCursor: undefined, hasMore: false });
+        await expect(secondResponse).resolves.toMatchObject({ status: 200 });
+        expect(listSessionsSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        scan.resolve({ items: [], nextCursor: undefined, hasMore: false });
+        listSessionsSpy.mockRestore();
       }
     });
 

--- a/packages/cli/src/serve/server/persisted-session-list-cache.test.ts
+++ b/packages/cli/src/serve/server/persisted-session-list-cache.test.ts
@@ -68,13 +68,193 @@ describe('PersistedSessionListCache', () => {
       'single_flight',
     ]);
     for (const lookup of lookups.slice(1)) {
-      expect(lookup.promise).toBe(lookups[0]!.promise);
+      expect(lookup.promise).not.toBe(lookups[0]!.promise);
     }
     expect(loader).not.toHaveBeenCalled();
     load.resolve(snapshot());
     await expect(
       Promise.all(lookups.map((lookup) => lookup.promise)),
     ).resolves.toHaveLength(5);
+    expect(loader).toHaveBeenCalledTimes(1);
+    cache.clear();
+  });
+
+  it('cancels one waiter without aborting the shared load', async () => {
+    const cache = new PersistedSessionListCache(2_000, 50_000);
+    const load = deferred<PersistedSessionListSnapshot>();
+    let loadSignal: AbortSignal | undefined;
+    const loader = vi.fn((signal: AbortSignal) => {
+      loadSignal = signal;
+      return load.promise;
+    });
+    const leaderController = new AbortController();
+    const reason = new Error('leader disconnected');
+    const leader = cache.lookup(SCOPE, loader, {
+      signal: leaderController.signal,
+    });
+    const follower = cache.lookup(SCOPE, loader);
+
+    await Promise.resolve();
+    leaderController.abort(reason);
+    await expect(leader.promise).rejects.toBe(reason);
+    expect(loadSignal?.aborted).toBe(false);
+
+    load.resolve(snapshot());
+    await expect(follower.promise).resolves.toEqual(snapshot());
+    expect(cache.lookup(SCOPE, loader).status).toBe('cache_hit');
+    cache.clear();
+  });
+
+  it('preserves a null caller abort reason', async () => {
+    const cache = new PersistedSessionListCache(2_000, 50_000);
+    const controller = new AbortController();
+    const lookup = cache.lookup(SCOPE, async () => snapshot(), {
+      signal: controller.signal,
+    });
+
+    controller.abort(null);
+
+    await expect(lookup.promise).rejects.toBeNull();
+    cache.clear();
+  });
+
+  it('keeps the load result when it settles before caller cancellation', async () => {
+    const cache = new PersistedSessionListCache(2_000, 50_000);
+    const load = deferred<PersistedSessionListSnapshot>();
+    const controller = new AbortController();
+    const reason = new Error('late caller cancellation');
+    const completed = snapshot();
+    const sessions = completed.sessions;
+    Object.defineProperty(completed, 'sessions', {
+      get() {
+        controller.abort(reason);
+        return sessions;
+      },
+    });
+    const lookup = cache.lookup(SCOPE, () => load.promise, {
+      signal: controller.signal,
+    });
+
+    load.resolve(completed);
+
+    await expect(lookup.promise).resolves.toBe(completed);
+    expect(controller.signal.aborted).toBe(true);
+    cache.clear();
+  });
+
+  it('does not start a load when its only waiter cancels before the loader microtask', async () => {
+    const cache = new PersistedSessionListCache(2_000, 50_000);
+    const controller = new AbortController();
+    const reason = new Error('cancel before start');
+    const loader = vi.fn(async () => snapshot());
+    const lookup = cache.lookup(SCOPE, loader, {
+      signal: controller.signal,
+    });
+
+    controller.abort(reason);
+    await expect(lookup.promise).rejects.toBe(reason);
+    await Promise.resolve();
+    expect(loader).not.toHaveBeenCalled();
+
+    const retry = cache.lookup(SCOPE, loader);
+    expect(retry.status).toBe('scan');
+    await retry.promise;
+    cache.clear();
+  });
+
+  it('detaches an aborted load so a new scan can start immediately', async () => {
+    const cache = new PersistedSessionListCache(2_000, 50_000);
+    const oldLoad = deferred<PersistedSessionListSnapshot>();
+    const newLoad = deferred<PersistedSessionListSnapshot>();
+    let oldLoadSignal: AbortSignal | undefined;
+    const loader = vi
+      .fn<(signal: AbortSignal) => Promise<PersistedSessionListSnapshot>>()
+      .mockImplementationOnce((signal) => {
+        oldLoadSignal = signal;
+        return oldLoad.promise;
+      })
+      .mockImplementationOnce(() => newLoad.promise);
+    const controller = new AbortController();
+    const reason = new Error('last waiter disconnected');
+    const oldLookup = cache.lookup(SCOPE, loader, {
+      signal: controller.signal,
+    });
+    await Promise.resolve();
+
+    controller.abort(reason);
+    await expect(oldLookup.promise).rejects.toBe(reason);
+    expect(oldLoadSignal?.aborted).toBe(true);
+    const newLookup = cache.lookup(SCOPE, loader);
+    expect(newLookup.status).toBe('scan');
+    await Promise.resolve();
+    expect(loader).toHaveBeenCalledTimes(2);
+
+    oldLoad.resolve(snapshot(1));
+    await Promise.resolve();
+    expect(cache.lookup(SCOPE, loader).status).toBe('single_flight');
+    newLoad.resolve(snapshot(2));
+    await newLookup.promise;
+    expect(cache.lookup(SCOPE, loader).status).toBe('cache_hit');
+    cache.clear();
+  });
+
+  it('does not let a detached load rejection clear its replacement', async () => {
+    const cache = new PersistedSessionListCache(2_000, 50_000);
+    const oldLoad = deferred<PersistedSessionListSnapshot>();
+    const newLoad = deferred<PersistedSessionListSnapshot>();
+    const loader = vi
+      .fn<(signal: AbortSignal) => Promise<PersistedSessionListSnapshot>>()
+      .mockImplementationOnce(() => oldLoad.promise)
+      .mockImplementationOnce(() => newLoad.promise);
+    const controller = new AbortController();
+    const reason = new Error('old waiter gone');
+    const oldLookup = cache.lookup(SCOPE, loader, {
+      signal: controller.signal,
+    });
+    await Promise.resolve();
+
+    controller.abort(reason);
+    await expect(oldLookup.promise).rejects.toBe(reason);
+    const newLookup = cache.lookup(SCOPE, loader);
+    await Promise.resolve();
+    oldLoad.reject(new Error('late old failure'));
+    await Promise.resolve();
+    expect(cache.lookup(SCOPE, loader).status).toBe('single_flight');
+
+    newLoad.resolve(snapshot());
+    await newLookup.promise;
+    cache.clear();
+  });
+
+  it('rejects an already-aborted caller without creating a slot or load', async () => {
+    const cache = new PersistedSessionListCache(2_000, 50_000);
+    const controller = new AbortController();
+    const reason = new Error('already gone');
+    controller.abort(reason);
+    const loader = vi.fn(async () => snapshot());
+
+    expect(() =>
+      cache.lookup(SCOPE, loader, { signal: controller.signal }),
+    ).toThrow(reason);
+    expect(loader).not.toHaveBeenCalled();
+    const lookup = cache.lookup(SCOPE, loader);
+    expect(lookup.status).toBe('scan');
+    await lookup.promise;
+    cache.clear();
+  });
+
+  it('honors cancellation before delivering a cache hit', async () => {
+    const cache = new PersistedSessionListCache(2_000, 50_000);
+    const loader = vi.fn(async () => snapshot());
+    await cache.lookup(SCOPE, loader).promise;
+    const controller = new AbortController();
+    const reason = new Error('cache-hit caller disconnected');
+    const lookup = cache.lookup(SCOPE, loader, {
+      signal: controller.signal,
+    });
+
+    controller.abort(reason);
+    await expect(lookup.promise).rejects.toBe(reason);
     expect(loader).toHaveBeenCalledTimes(1);
     cache.clear();
   });
@@ -153,13 +333,19 @@ describe('PersistedSessionListCache', () => {
     const cache = new PersistedSessionListCache(2_000, 50_000);
     const oldLoad = deferred<PersistedSessionListSnapshot>();
     const newLoad = deferred<PersistedSessionListSnapshot>();
+    let oldLoadSignal: AbortSignal | undefined;
     const loader = vi
-      .fn<() => Promise<PersistedSessionListSnapshot>>()
-      .mockImplementationOnce(() => oldLoad.promise)
+      .fn<(signal: AbortSignal) => Promise<PersistedSessionListSnapshot>>()
+      .mockImplementationOnce((signal) => {
+        oldLoadSignal = signal;
+        return oldLoad.promise;
+      })
       .mockImplementationOnce(() => newLoad.promise);
 
     const oldLookup = cache.lookup(SCOPE, loader);
+    await Promise.resolve();
     cache.invalidate(SCOPE);
+    expect(oldLoadSignal?.aborted).toBe(false);
     const newLookup = cache.lookup(SCOPE, loader);
     expect(newLookup.status).toBe('scan');
     oldLoad.resolve(snapshot(1));

--- a/packages/cli/src/serve/server/persisted-session-list-cache.ts
+++ b/packages/cli/src/serve/server/persisted-session-list-cache.ts
@@ -40,7 +40,10 @@ interface CachedSnapshot {
 
 interface InFlightLoad {
   generation: number;
+  controller: AbortController;
   promise: Promise<PersistedSessionListSnapshot>;
+  waiterCount: number;
+  settled: boolean;
 }
 
 interface CacheSlot {
@@ -60,8 +63,10 @@ export class PersistedSessionListCache {
 
   lookup(
     scope: PersistedSessionListScope,
-    loader: () => Promise<PersistedSessionListSnapshot>,
+    loader: (signal: AbortSignal) => Promise<PersistedSessionListSnapshot>,
+    options: { signal?: AbortSignal } = {},
   ): PersistedSessionListLookup {
+    options.signal?.throwIfAborted();
     const key = this.key(scope);
     let slot = this.slots.get(key);
     if (!slot) {
@@ -73,9 +78,13 @@ export class PersistedSessionListCache {
     if (slot.value) {
       const cacheAgeMs = Math.max(0, now - slot.value.completedAt);
       if (cacheAgeMs < this.ttlMs) {
+        const snapshot = slot.value.snapshot;
         return {
           status: 'cache_hit',
-          promise: Promise.resolve(slot.value.snapshot),
+          promise: Promise.resolve().then(() => {
+            options.signal?.throwIfAborted();
+            return snapshot;
+          }),
           cacheAgeMs,
         };
       }
@@ -84,24 +93,38 @@ export class PersistedSessionListCache {
 
     if (
       slot.inFlight !== undefined &&
-      slot.inFlight.generation === slot.generation
+      slot.inFlight.generation === slot.generation &&
+      !slot.inFlight.controller.signal.aborted
     ) {
       return {
         status: 'single_flight',
-        promise: slot.inFlight.promise,
+        promise: this.attachWaiter(key, slot, slot.inFlight, options.signal),
       };
     }
 
     const generation = slot.generation;
+    const controller = new AbortController();
+    const load: InFlightLoad = {
+      generation,
+      controller,
+      promise: undefined as unknown as Promise<PersistedSessionListSnapshot>,
+      waiterCount: 0,
+      settled: false,
+    };
     const managed = Promise.resolve()
-      .then(loader)
+      .then(() => {
+        controller.signal.throwIfAborted();
+        return loader(controller.signal);
+      })
       .then(
         (snapshot) => {
+          load.settled = true;
           const current = this.slots.get(key);
-          if (current === slot && current.inFlight?.promise === managed) {
+          if (current === slot && current.inFlight === load) {
             current.inFlight = undefined;
             if (
               current.generation === generation &&
+              !controller.signal.aborted &&
               snapshot.sessions.length <= this.maxRetainedSummaries
             ) {
               this.installValue(key, current, snapshot);
@@ -112,17 +135,22 @@ export class PersistedSessionListCache {
           return snapshot;
         },
         (error: unknown) => {
+          load.settled = true;
           const current = this.slots.get(key);
-          if (current === slot && current.inFlight?.promise === managed) {
+          if (current === slot && current.inFlight === load) {
             current.inFlight = undefined;
             if (current.value === undefined) this.slots.delete(key);
           }
           throw error;
         },
       );
-    slot.inFlight = { generation, promise: managed };
+    load.promise = managed;
+    slot.inFlight = load;
 
-    return { status: 'scan', promise: managed };
+    return {
+      status: 'scan',
+      promise: this.attachWaiter(key, slot, load, options.signal),
+    };
   }
 
   invalidate(scope: PersistedSessionListScope): void {
@@ -192,6 +220,46 @@ export class PersistedSessionListCache {
     clearTimeout(value.expiryTimer);
     this.retainedSummaries -= value.snapshot.sessions.length;
     slot.value = undefined;
+  }
+
+  private attachWaiter(
+    key: string,
+    slot: CacheSlot,
+    load: InFlightLoad,
+    signal?: AbortSignal,
+  ): Promise<PersistedSessionListSnapshot> {
+    load.waiterCount += 1;
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      const settle = (finish: () => void) => {
+        if (settled) return;
+        settled = true;
+        signal?.removeEventListener('abort', onAbort);
+        load.waiterCount -= 1;
+        if (load.waiterCount === 0 && !load.settled) {
+          load.controller.abort(
+            new DOMException('No active session list waiters', 'AbortError'),
+          );
+          const current = this.slots.get(key);
+          if (current === slot && current.inFlight === load) {
+            current.inFlight = undefined;
+            if (current.value === undefined) this.slots.delete(key);
+          }
+        }
+        finish();
+      };
+      const onAbort = () => {
+        if (load.settled) return;
+        settle(() => reject(signal?.reason));
+      };
+
+      signal?.addEventListener('abort', onAbort, { once: true });
+      if (signal?.aborted) onAbort();
+      void load.promise.then(
+        (snapshot) => settle(() => resolve(snapshot)),
+        (error: unknown) => settle(() => reject(error)),
+      );
+    });
   }
 
   private key(scope: PersistedSessionListScope): string {

--- a/packages/cli/src/serve/server/session-list.ts
+++ b/packages/cli/src/serve/server/session-list.ts
@@ -86,11 +86,14 @@ export interface ListWorkspaceSessionsReadOptions {
   mergeLive?: boolean;
   /** Runtime root owned by the selected managed workspace. */
   runtimeBaseDir?: string;
+  /** Aborts this caller's wait without cancelling other shared waiters. */
+  signal?: AbortSignal;
 }
 
 interface ResolvedListWorkspaceSessionsReadOptions {
   mergeLive?: boolean;
   runtimeBaseDir: string;
+  signal?: AbortSignal;
 }
 
 export interface InvalidateWorkspaceSessionListCacheOptions {
@@ -318,15 +321,24 @@ async function enrichWorktreeSidecars(
   bySessionId: Map<string, BridgeSessionSummary>,
   sessionService: SessionService,
   archiveState: SessionArchiveState = 'active',
+  signal?: AbortSignal,
 ): Promise<void> {
   for (const [sessionId, summary] of bySessionId) {
+    signal?.throwIfAborted();
     if (summary.worktree) continue;
-    const sidecar = await readWorktreeSession(
-      sessionService.getWorktreeSessionPathForArchiveState(
+    let sidecar: Awaited<ReturnType<typeof readWorktreeSession>>;
+    try {
+      const sidecarPath = sessionService.getWorktreeSessionPathForArchiveState(
         sessionId,
         archiveState,
-      ),
-    ).catch(() => null);
+      );
+      sidecar = signal
+        ? await readWorktreeSession(sidecarPath, { signal })
+        : await readWorktreeSession(sidecarPath);
+    } catch {
+      signal?.throwIfAborted();
+      sidecar = null;
+    }
     if (sidecar) {
       bySessionId.set(sessionId, {
         ...summary,
@@ -409,8 +421,10 @@ function clonePersistedSummary(
 async function loadAllPersistedSummaries(
   sessionService: SessionService,
   archiveState: SessionArchiveState,
+  signal: AbortSignal,
 ): Promise<PersistedSessionListSnapshot> {
   const scanStartedAt = performance.now();
+  signal.throwIfAborted();
   // Organized view needs global pin/group ordering before pagination; v1 keeps
   // the storage API unchanged and performs that merge in memory.
   const sessions: BridgeSessionSummary[] = [];
@@ -423,7 +437,9 @@ async function loadAllPersistedSummaries(
       cursor,
       size: 10_000,
       archiveState,
+      signal,
     });
+    signal.throwIfAborted();
     const remaining = MAX_ORGANIZED_SESSIONS - sessions.length;
     sessions.push(...page.items.slice(0, remaining).map(toSummary));
     cursor = page.nextCursor;
@@ -444,7 +460,13 @@ async function loadAllPersistedSummaries(
   const bySessionId = new Map(
     sessions.map((session) => [session.sessionId, session]),
   );
-  await enrichWorktreeSidecars(bySessionId, sessionService, archiveState);
+  await enrichWorktreeSidecars(
+    bySessionId,
+    sessionService,
+    archiveState,
+    signal,
+  );
+  signal.throwIfAborted();
   return {
     sessions: [...bySessionId.values()],
     truncated,
@@ -459,10 +481,13 @@ async function listAllPersistedSummaries(
   archiveState: SessionArchiveState,
   runtimeBaseDir: string,
   queryKind: 'organized' | 'metadata',
+  signal?: AbortSignal,
 ): Promise<PersistedSessionListSnapshot> {
   const lookup = persistedSessionListCache.lookup(
     { runtimeBaseDir, workspaceCwd, archiveState },
-    () => loadAllPersistedSummaries(sessionService, archiveState),
+    (loadSignal) =>
+      loadAllPersistedSummaries(sessionService, archiveState, loadSignal),
+    { signal },
   );
   addDaemonRequestAttribute(
     'qwen-code.daemon.session_list.cache_status',
@@ -484,6 +509,7 @@ async function listAllPersistedSummaries(
   }
 
   const snapshot = await lookup.promise;
+  signal?.throwIfAborted();
   addDaemonRequestAttribute(
     'qwen-code.daemon.session_list.persisted_sessions',
     snapshot.sessions.length,
@@ -496,7 +522,7 @@ async function listAllPersistedSummaries(
     'qwen-code.daemon.session_list.truncated',
     snapshot.truncated,
   );
-  if (lookup.status === 'scan') {
+  if (lookup.status !== 'cache_hit') {
     addDaemonRequestAttribute(
       'qwen-code.daemon.session_list.scan_duration_ms',
       snapshot.scanDurationMs,
@@ -593,7 +619,9 @@ async function listOrganizedWorkspaceSessionsForResponse(
   const archiveState = options.archiveState ?? 'active';
   const sessionService = new SessionService(workspaceCwd);
   const organizationService = createSessionOrganizationService(workspaceCwd);
+  readOptions.signal?.throwIfAborted();
   const snapshot = await organizationService.readSnapshot();
+  readOptions.signal?.throwIfAborted();
   const knownGroupIds = new Set(snapshot.groups.map((group) => group.id));
   const group = options.group ?? 'all';
   if (
@@ -627,7 +655,9 @@ async function listOrganizedWorkspaceSessionsForResponse(
     archiveState,
     readOptions.runtimeBaseDir,
     'organized',
+    readOptions.signal,
   );
+  readOptions.signal?.throwIfAborted();
   for (const session of persisted.sessions) {
     bySessionId.set(
       session.sessionId,
@@ -666,7 +696,11 @@ async function listOrganizedWorkspaceSessionsForResponse(
           // `sessionExists` flipped to true, silently dropping the live
           // session from the response instead of merging it.
           !persisted.truncated ||
-          !(await sessionService.sessionExists(live.sessionId))
+          !(await (readOptions.signal
+            ? sessionService.sessionExists(live.sessionId, {
+                signal: readOptions.signal,
+              })
+            : sessionService.sessionExists(live.sessionId)))
         ) {
           bySessionId.set(
             live.sessionId,
@@ -684,6 +718,7 @@ async function listOrganizedWorkspaceSessionsForResponse(
         }
       }
     } catch (error) {
+      readOptions.signal?.throwIfAborted();
       liveMergeFailed = true;
       writeStderrLine(
         `qwen serve: organized session list live merge failed; using persisted sessions only: ${
@@ -705,6 +740,7 @@ async function listOrganizedWorkspaceSessionsForResponse(
     // both fields even though the UI keeps them mutually exclusive).
     return session.color == null && session.groupId === group;
   });
+  readOptions.signal?.throwIfAborted();
   const activityTimeById = new Map(
     filtered.map((session) => [
       session.sessionId,
@@ -712,6 +748,7 @@ async function listOrganizedWorkspaceSessionsForResponse(
     ]),
   );
   filtered.sort((a, b) => compareOrganizedSessions(activityTimeById, a, b));
+  readOptions.signal?.throwIfAborted();
   const afterCursor =
     cursorKey === undefined
       ? filtered
@@ -762,7 +799,9 @@ async function listWorkspaceSessionsByMetadataForResponse(
     archiveState,
     readOptions.runtimeBaseDir,
     'metadata',
+    readOptions.signal,
   );
+  readOptions.signal?.throwIfAborted();
   for (const session of persisted.sessions) {
     bySessionId.set(session.sessionId, clonePersistedSummary(session));
   }
@@ -783,7 +822,11 @@ async function listWorkspaceSessionsByMetadataForResponse(
           // already covers every persisted session, so skip the racy
           // re-check when nothing was truncated.
           !persisted.truncated ||
-          !(await sessionService.sessionExists(live.sessionId))
+          !(await (readOptions.signal
+            ? sessionService.sessionExists(live.sessionId, {
+                signal: readOptions.signal,
+              })
+            : sessionService.sessionExists(live.sessionId)))
         ) {
           bySessionId.set(live.sessionId, {
             ...live,
@@ -795,6 +838,7 @@ async function listWorkspaceSessionsByMetadataForResponse(
         }
       }
     } catch (error) {
+      readOptions.signal?.throwIfAborted();
       liveMergeFailed = true;
       writeStderrLine(
         `qwen serve: session metadata filter live merge failed; using persisted sessions only: ${
@@ -817,6 +861,7 @@ async function listWorkspaceSessionsByMetadataForResponse(
         getLiveSessionCursorKey(b),
       ),
     );
+  readOptions.signal?.throwIfAborted();
   const cursorKey =
     options.cursor !== undefined && options.cursor !== ''
       ? parseMetadataSessionCursor(options.cursor, {
@@ -857,18 +902,26 @@ export async function listWorkspaceSessionsForResponse(
   options?: ListWorkspaceSessionsOptions,
   readOptions: ListWorkspaceSessionsReadOptions = {},
 ): Promise<ListWorkspaceSessionsResult> {
+  readOptions.signal?.throwIfAborted();
   const runtimeBaseDir = new Storage(
     workspaceCwd,
     readOptions.runtimeBaseDir,
   ).getRuntimeBaseDir();
-  return Storage.runWithResolvedRuntimeBaseDir(runtimeBaseDir, () =>
-    listWorkspaceSessionsForResponseInRuntime(bridge, workspaceCwd, options, {
-      ...(readOptions.mergeLive !== undefined
-        ? { mergeLive: readOptions.mergeLive }
-        : {}),
-      runtimeBaseDir,
-    }),
+  const result = await Storage.runWithResolvedRuntimeBaseDir(
+    runtimeBaseDir,
+    () =>
+      listWorkspaceSessionsForResponseInRuntime(bridge, workspaceCwd, options, {
+        ...(readOptions.mergeLive !== undefined
+          ? { mergeLive: readOptions.mergeLive }
+          : {}),
+        ...(readOptions.signal !== undefined
+          ? { signal: readOptions.signal }
+          : {}),
+        runtimeBaseDir,
+      }),
   );
+  readOptions.signal?.throwIfAborted();
+  return result;
 }
 
 async function listWorkspaceSessionsForResponseInRuntime(
@@ -877,6 +930,7 @@ async function listWorkspaceSessionsForResponseInRuntime(
   options: ListWorkspaceSessionsOptions | undefined,
   readOptions: ResolvedListWorkspaceSessionsReadOptions,
 ): Promise<ListWorkspaceSessionsResult> {
+  readOptions.signal?.throwIfAborted();
   const rawSize = options?.size;
   const requestedSize =
     typeof rawSize === 'number' && Number.isSafeInteger(rawSize)
@@ -930,14 +984,22 @@ async function listWorkspaceSessionsForResponseInRuntime(
     cursor: numericCursor,
     size: pageSize,
     archiveState,
+    ...(readOptions.signal ? { signal: readOptions.signal } : {}),
   });
+  readOptions.signal?.throwIfAborted();
   const bySessionId = new Map<string, BridgeSessionSummary>();
 
   for (const item of persisted.items) {
     bySessionId.set(item.sessionId, toSummary(item));
   }
 
-  await enrichWorktreeSidecars(bySessionId, sessionService, archiveState);
+  await enrichWorktreeSidecars(
+    bySessionId,
+    sessionService,
+    archiveState,
+    readOptions.signal,
+  );
+  readOptions.signal?.throwIfAborted();
 
   if (archiveState === 'archived' || readOptions.mergeLive === false) {
     const sessions = [...bySessionId.values()];
@@ -961,7 +1023,11 @@ async function listWorkspaceSessionsForResponseInRuntime(
       // silently dropping the live session from the response instead of
       // merging it.
       (persisted.nextCursor == null ||
-        !(await sessionService.sessionExists(live.sessionId)))
+        !(await (readOptions.signal
+          ? sessionService.sessionExists(live.sessionId, {
+              signal: readOptions.signal,
+            })
+          : sessionService.sessionExists(live.sessionId))))
     ) {
       bySessionId.set(live.sessionId, {
         ...live,
@@ -978,6 +1044,7 @@ async function listWorkspaceSessionsForResponseInRuntime(
     const bTime = Date.parse(b.updatedAt ?? b.createdAt);
     return bTime - aTime;
   });
+  readOptions.signal?.throwIfAborted();
 
   const nextCursor =
     persisted.nextCursor != null ? String(persisted.nextCursor) : undefined;

--- a/packages/core/src/services/sessionService.test.ts
+++ b/packages/core/src/services/sessionService.test.ts
@@ -156,6 +156,43 @@ describe('SessionService', () => {
       expect(result.nextCursor).toBeUndefined();
     });
 
+    it('yields after 128 directory entries and stops statting after cancellation', async () => {
+      const fileNames = Array.from(
+        { length: 129 },
+        (_, index) => `${index.toString(16).padStart(32, '0')}.jsonl`,
+      );
+      readdirSyncSpy.mockReturnValue(
+        fileNames as unknown as Array<fs.Dirent<Buffer>>,
+      );
+      const controller = new AbortController();
+      const reason = Object.assign(new Error('catalog request disconnected'), {
+        code: 'ENOENT',
+      });
+      setImmediate(() => controller.abort(reason));
+
+      await expect(
+        sessionService.listSessions({ signal: controller.signal }),
+      ).rejects.toBe(reason);
+      expect(statSyncSpy).toHaveBeenCalledTimes(128);
+      expect(jsonl.readLines).not.toHaveBeenCalled();
+    });
+
+    it('does not yield during directory enumeration without a signal', async () => {
+      const fileNames = Array.from(
+        { length: 129 },
+        (_, index) => `${index.toString(16).padStart(32, '0')}.jsonl`,
+      );
+      readdirSyncSpy.mockReturnValue(
+        fileNames as unknown as Array<fs.Dirent<Buffer>>,
+      );
+      const setImmediateSpy = vi.spyOn(globalThis, 'setImmediate');
+
+      await sessionService.listSessions({ size: 0 });
+
+      expect(statSyncSpy).toHaveBeenCalledTimes(129);
+      expect(setImmediateSpy).not.toHaveBeenCalled();
+    });
+
     it('should return empty list when chats directory does not exist', async () => {
       const error = new Error('ENOENT') as NodeJS.ErrnoException;
       error.code = 'ENOENT';
@@ -2329,6 +2366,40 @@ describe('SessionService', () => {
       );
 
       expect(exists).toBe(false);
+    });
+
+    it('does not convert cancellation into a missing session', async () => {
+      const controller = new AbortController();
+      const reason = new Error('existence check cancelled');
+      vi.mocked(jsonl.readLines).mockImplementation(
+        async (_filePath, _count, options) => {
+          controller.abort(reason);
+          options?.signal?.throwIfAborted();
+          return [];
+        },
+      );
+
+      await expect(
+        sessionService.sessionExists(sessionIdA, {
+          signal: controller.signal,
+        }),
+      ).rejects.toBe(reason);
+      expect(jsonl.readLines).toHaveBeenCalledWith(expect.any(String), 1, {
+        signal: controller.signal,
+      });
+    });
+
+    it('observes cancellation after the project-membership await', async () => {
+      vi.mocked(jsonl.readLines).mockResolvedValue([recordA1]);
+      const controller = new AbortController();
+      const reason = new Error('cancelled after membership resolved');
+
+      const exists = sessionService.sessionExists(sessionIdA, {
+        signal: controller.signal,
+      });
+      queueMicrotask(() => controller.abort(reason));
+
+      await expect(exists).rejects.toBe(reason);
     });
 
     it('should return false for session from different project', async () => {

--- a/packages/core/src/services/sessionService.test.ts
+++ b/packages/core/src/services/sessionService.test.ts
@@ -193,6 +193,70 @@ describe('SessionService', () => {
       expect(setImmediateSpy).not.toHaveBeenCalled();
     });
 
+    it('passes cancellation to the per-file JSONL read', async () => {
+      readdirSyncSpy.mockReturnValue([
+        `${sessionIdA}.jsonl`,
+      ] as unknown as Array<fs.Dirent<Buffer>>);
+      const controller = new AbortController();
+      const reason = new Error('cancelled during session JSONL read');
+      let readSignal: AbortSignal | undefined;
+      vi.mocked(jsonl.readLines).mockImplementation(
+        async (_filePath, _count, options) => {
+          readSignal = options?.signal;
+          await new Promise<void>((_resolve, reject) => {
+            readSignal?.addEventListener(
+              'abort',
+              () => reject(readSignal?.reason),
+              { once: true },
+            );
+          });
+          return [];
+        },
+      );
+
+      const result = sessionService.listSessions({
+        signal: controller.signal,
+      });
+      await vi.waitFor(() => expect(readSignal).toBe(controller.signal));
+      controller.abort(reason);
+
+      await expect(result).rejects.toBe(reason);
+      expect(jsonl.readLines).toHaveBeenCalledWith(
+        expect.stringContaining(`${sessionIdA}.jsonl`),
+        expect.any(Number),
+        { signal: controller.signal },
+      );
+    });
+
+    it('passes cancellation through migrated-session membership reads', async () => {
+      readdirSyncSpy.mockReturnValue([
+        `${sessionIdA}.jsonl`,
+      ] as unknown as Array<fs.Dirent<Buffer>>);
+      const migratedRecord = { ...recordA1, cwd: '/old/project' };
+      vi.mocked(jsonl.readLines).mockResolvedValue([migratedRecord]);
+      vi.mocked(getProjectHash).mockImplementation((cwd: string) =>
+        cwd === '/test/project/root'
+          ? 'test-project-hash'
+          : 'other-project-hash',
+      );
+      vi.mocked(readRuntimeStatus).mockResolvedValue({
+        schemaVersion: 1,
+        pid: 123,
+        sessionId: sessionIdA,
+        workDir: '/test/project/root',
+        hostname: 'host',
+        startedAt: 1,
+        qwenVersion: null,
+      });
+      const controller = new AbortController();
+
+      await sessionService.listSessions({ signal: controller.signal });
+
+      expect(readRuntimeStatus).toHaveBeenCalledWith(expect.any(String), {
+        signal: controller.signal,
+      });
+    });
+
     it('should return empty list when chats directory does not exist', async () => {
       const error = new Error('ENOENT') as NodeJS.ErrnoException;
       error.code = 'ENOENT';
@@ -2400,6 +2464,48 @@ describe('SessionService', () => {
       queueMicrotask(() => controller.abort(reason));
 
       await expect(exists).rejects.toBe(reason);
+    });
+
+    it('passes cancellation to migrated-session runtime status reads', async () => {
+      const migratedRecord: ChatRecord = {
+        ...recordA1,
+        cwd: '/old/project',
+      };
+      vi.mocked(jsonl.readLines).mockResolvedValue([migratedRecord]);
+      vi.mocked(getProjectHash).mockImplementation((cwd: string) =>
+        cwd === '/test/project/root'
+          ? 'test-project-hash'
+          : 'other-project-hash',
+      );
+      const controller = new AbortController();
+      const reason = new Error('cancelled during runtime status read');
+      let runtimeStatusSignal: AbortSignal | undefined;
+      vi.mocked(readRuntimeStatus).mockImplementation(
+        async (_filePath, options) => {
+          runtimeStatusSignal = options?.signal;
+          await new Promise<void>((_resolve, reject) => {
+            runtimeStatusSignal?.addEventListener(
+              'abort',
+              () => reject(runtimeStatusSignal?.reason),
+              { once: true },
+            );
+          });
+          return null;
+        },
+      );
+
+      const exists = sessionService.sessionExists(sessionIdA, {
+        signal: controller.signal,
+      });
+      await vi.waitFor(() =>
+        expect(runtimeStatusSignal).toBe(controller.signal),
+      );
+      controller.abort(reason);
+
+      await expect(exists).rejects.toBe(reason);
+      expect(readRuntimeStatus).toHaveBeenCalledWith(expect.any(String), {
+        signal: controller.signal,
+      });
     });
 
     it('should return false for session from different project', async () => {

--- a/packages/core/src/services/sessionService.ts
+++ b/packages/core/src/services/sessionService.ts
@@ -127,6 +127,8 @@ export interface ListSessionsOptions {
    * @default 'active'
    */
   archiveState?: SessionArchiveState;
+  /** Aborts an in-progress catalog scan. */
+  signal?: AbortSignal;
 }
 
 /**
@@ -240,6 +242,7 @@ export interface ResumedSessionData {
  * This is a safety limit to prevent performance issues with very large chat directories.
  */
 const MAX_FILES_TO_PROCESS = 10000;
+const SESSION_LIST_CANCEL_YIELD_INTERVAL = 128;
 
 /**
  * Maximum character length for a session custom title.
@@ -402,7 +405,9 @@ export class SessionService {
   private async sessionBelongsToCurrentProject(
     sessionId: string,
     recordCwd: string,
+    signal?: AbortSignal,
   ): Promise<boolean> {
+    signal?.throwIfAborted();
     if (getProjectHash(recordCwd) === this.projectHash) {
       return true;
     }
@@ -425,9 +430,11 @@ export class SessionService {
       }
     }
 
-    const status = await readRuntimeStatus(
-      this.storage.getRuntimeStatusPath(sessionId),
-    );
+    const runtimeStatusPath = this.storage.getRuntimeStatusPath(sessionId);
+    const status = signal
+      ? await readRuntimeStatus(runtimeStatusPath, { signal })
+      : await readRuntimeStatus(runtimeStatusPath);
+    signal?.throwIfAborted();
     return (
       status?.sessionId === sessionId &&
       getProjectHash(status.workDir) === this.projectHash
@@ -970,35 +977,44 @@ export class SessionService {
   async listSessions(
     options: ListSessionsOptions = {},
   ): Promise<ListSessionsResult> {
-    const { cursor, size = 20, archiveState = 'active' } = options;
+    const { cursor, size = 20, archiveState = 'active', signal } = options;
     const chatsDir = this.getChatsDirForState(archiveState);
     const isArchived = archiveState === 'archived';
+    signal?.throwIfAborted();
 
     // Get all valid session files (matching UUID pattern) with their stats
     let files: Array<{ name: string; mtime: number }> = [];
     try {
       const fileNames = fs.readdirSync(chatsDir);
-      for (const name of fileNames) {
-        // Only process files matching session file pattern
-        if (!SESSION_FILE_PATTERN.test(name)) continue;
-        const filePath = path.join(chatsDir, name);
-        try {
-          const stats = fs.statSync(filePath);
-          files.push({ name, mtime: stats.mtimeMs });
-        } catch {
-          // Skip files we can't stat
-          continue;
+      signal?.throwIfAborted();
+      for (const [index, name] of fileNames.entries()) {
+        if (SESSION_FILE_PATTERN.test(name)) {
+          const filePath = path.join(chatsDir, name);
+          try {
+            const stats = fs.statSync(filePath);
+            files.push({ name, mtime: stats.mtimeMs });
+          } catch {
+            // Skip files we can't stat
+          }
+        }
+        if (signal && (index + 1) % SESSION_LIST_CANCEL_YIELD_INTERVAL === 0) {
+          signal.throwIfAborted();
+          await new Promise<void>((resolve) => setImmediate(resolve));
+          signal.throwIfAborted();
         }
       }
     } catch (error) {
+      signal?.throwIfAborted();
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
         return { items: [], hasMore: false };
       }
       throw error;
     }
+    signal?.throwIfAborted();
 
     // Sort by mtime descending (most recent first)
     files.sort((a, b) => b.mtime - a.mtime);
+    signal?.throwIfAborted();
 
     // Apply cursor filter (items with mtime < cursor)
     if (cursor !== undefined) {
@@ -1021,6 +1037,7 @@ export class SessionService {
     const tailBuffer = Buffer.alloc(LITE_READ_BUF_SIZE);
 
     for (const file of files) {
+      signal?.throwIfAborted();
       // Safety limit to prevent performance issues
       if (filesProcessed >= MAX_FILES_TO_PROCESS) {
         hasMoreFiles = true;
@@ -1037,10 +1054,12 @@ export class SessionService {
       lastProcessedMtime = file.mtime;
 
       const filePath = path.join(chatsDir, file.name);
-      const records = await jsonl.readLines<ChatRecord>(
-        filePath,
-        MAX_PROMPT_SCAN_LINES,
-      );
+      const records = signal
+        ? await jsonl.readLines<ChatRecord>(filePath, MAX_PROMPT_SCAN_LINES, {
+            signal,
+          })
+        : await jsonl.readLines<ChatRecord>(filePath, MAX_PROMPT_SCAN_LINES);
+      signal?.throwIfAborted();
 
       if (records.length === 0) continue;
       const firstRecord = records[0];
@@ -1049,6 +1068,7 @@ export class SessionService {
         !(await this.sessionBelongsToCurrentProject(
           firstRecord.sessionId,
           firstRecord.cwd,
+          signal,
         ))
       ) {
         continue;
@@ -1056,7 +1076,9 @@ export class SessionService {
 
       const prompt = this.extractFirstPromptFromRecords(records);
 
+      signal?.throwIfAborted();
       const titleInfo = this.readSessionTitleInfoFromFile(filePath, tailBuffer);
+      signal?.throwIfAborted();
       const source = this.extractCreationMetadataFromRecords(records);
       items.push({
         sessionId: firstRecord.sessionId,
@@ -1078,6 +1100,7 @@ export class SessionService {
         isArchived,
       });
     }
+    signal?.throwIfAborted();
 
     // Determine next cursor (mtime of last processed file)
     // Only set if there are more files to process
@@ -2104,7 +2127,11 @@ export class SessionService {
    * @remarks Only checks active sessions. Use `getSessionLocation()` or
    * `sessionExistsInAnyState()` for archive-aware lookups.
    */
-  async sessionExists(sessionId: string): Promise<boolean> {
+  async sessionExists(
+    sessionId: string,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<boolean> {
+    options.signal?.throwIfAborted();
     if (!SESSION_FILE_PATTERN.test(`${sessionId}.jsonl`)) {
       return false;
     }
@@ -2112,12 +2139,22 @@ export class SessionService {
     const filePath = path.join(chatsDir, `${sessionId}.jsonl`);
 
     try {
-      const records = await jsonl.readLines<ChatRecord>(filePath, 1);
+      const records = options.signal
+        ? await jsonl.readLines<ChatRecord>(filePath, 1, options)
+        : await jsonl.readLines<ChatRecord>(filePath, 1);
+      options.signal?.throwIfAborted();
       if (records.length === 0) {
         return false;
       }
-      return this.sessionBelongsToCurrentProject(sessionId, records[0].cwd);
+      const belongsToCurrentProject = await this.sessionBelongsToCurrentProject(
+        sessionId,
+        records[0].cwd,
+        options.signal,
+      );
+      options.signal?.throwIfAborted();
+      return belongsToCurrentProject;
     } catch {
+      options.signal?.throwIfAborted();
       return false;
     }
   }

--- a/packages/core/src/services/worktreeSessionService.test.ts
+++ b/packages/core/src/services/worktreeSessionService.test.ts
@@ -41,6 +41,16 @@ afterEach(async () => {
 });
 
 describe('readWorktreeSession', () => {
+  it('propagates the caller abort reason', async () => {
+    const controller = new AbortController();
+    const reason = new Error('worktree sidecar read cancelled');
+    controller.abort(reason);
+
+    await expect(
+      readWorktreeSession(filePath, { signal: controller.signal }),
+    ).rejects.toBe(reason);
+  });
+
   it('returns null when file does not exist', async () => {
     expect(await readWorktreeSession(filePath)).toBeNull();
   });

--- a/packages/core/src/services/worktreeSessionService.test.ts
+++ b/packages/core/src/services/worktreeSessionService.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -19,6 +19,16 @@ import {
 import { Storage } from '../config/storage.js';
 import { writeRuntimeStatus } from '../utils/runtimeStatus.js';
 
+const fsMocks = vi.hoisted(() => ({
+  readFile: vi.fn<typeof import('node:fs/promises').readFile>(),
+}));
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  fsMocks.readFile.mockImplementation(actual.readFile);
+  return { ...actual, readFile: fsMocks.readFile };
+});
+
 const sample: WorktreeSession = {
   slug: 'my-feature',
   worktreePath: '/repo/.qwen/worktrees/my-feature',
@@ -32,6 +42,7 @@ let tmpDir: string;
 let filePath: string;
 
 beforeEach(async () => {
+  fsMocks.readFile.mockClear();
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wt-session-test-'));
   filePath = path.join(tmpDir, 'test.worktree.json');
 });
@@ -49,6 +60,19 @@ describe('readWorktreeSession', () => {
     await expect(
       readWorktreeSession(filePath, { signal: controller.signal }),
     ).rejects.toBe(reason);
+  });
+
+  it('passes the caller signal to the file read', async () => {
+    await fs.writeFile(filePath, JSON.stringify(sample), 'utf-8');
+    const controller = new AbortController();
+
+    await expect(
+      readWorktreeSession(filePath, { signal: controller.signal }),
+    ).resolves.toEqual(sample);
+    expect(fsMocks.readFile).toHaveBeenLastCalledWith(filePath, {
+      encoding: 'utf-8',
+      signal: controller.signal,
+    });
   });
 
   it('returns null when file does not exist', async () => {

--- a/packages/core/src/services/worktreeSessionService.ts
+++ b/packages/core/src/services/worktreeSessionService.ts
@@ -95,20 +95,30 @@ function isValidWorktreeSession(value: unknown): value is WorktreeSession {
  */
 export async function readWorktreeSession(
   filePath: string,
+  options: { signal?: AbortSignal } = {},
 ): Promise<WorktreeSession | null> {
   let raw: string;
   try {
-    raw = await fs.readFile(filePath, 'utf-8');
+    options.signal?.throwIfAborted();
+    raw = options.signal
+      ? await fs.readFile(filePath, {
+          encoding: 'utf-8',
+          signal: options.signal,
+        })
+      : await fs.readFile(filePath, 'utf-8');
   } catch (error) {
+    options.signal?.throwIfAborted();
     if (isNodeError(error) && error.code === 'ENOENT') return null;
     throw error;
   }
+  options.signal?.throwIfAborted();
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
   } catch {
     return null;
   }
+  options.signal?.throwIfAborted();
   if (!isValidWorktreeSession(parsed)) return null;
   return parsed;
 }

--- a/packages/core/src/utils/jsonl-utils.test.ts
+++ b/packages/core/src/utils/jsonl-utils.test.ts
@@ -261,6 +261,48 @@ describe('read() / readLines() with malformed lines', () => {
 });
 
 describe('reader resource cleanup', () => {
+  it('propagates the caller abort reason from readLines', async () => {
+    const file = tmpFile(
+      Array.from({ length: 1_000 }, (_, index) => `{"i":${index}}`).join('\n'),
+    );
+    const controller = new AbortController();
+    const reason = new Error('jsonl scan cancelled');
+    const readPromise = readLines<{ i: number }>(file, 1_000, {
+      signal: controller.signal,
+    });
+
+    controller.abort(reason);
+
+    await expect(readPromise).rejects.toBe(reason);
+  });
+
+  it('observes cancellation while readLines is closing its stream', async () => {
+    const file = tmpFile('{"i":1}\n{"i":2}\n');
+    const controller = new AbortController();
+    const reason = new Error('cancelled during stream cleanup');
+    let capturedStream: fs.ReadStream | undefined;
+    const originalCreateReadStream = fs.createReadStream.bind(fs);
+    const spy = vi
+      .spyOn(fs, 'createReadStream')
+      .mockImplementation((...args: Parameters<typeof fs.createReadStream>) => {
+        const stream = originalCreateReadStream(...args);
+        capturedStream = stream;
+        return stream;
+      });
+
+    try {
+      const readPromise = readLines<{ i: number }>(file, 1, {
+        signal: controller.signal,
+      });
+      expect(capturedStream).toBeDefined();
+      capturedStream!.once('close', () => controller.abort(reason));
+
+      await expect(readPromise).rejects.toBe(reason);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
   it('closes the file stream after readLines stops at the requested limit', async () => {
     const file = tmpFile('{"i":1}\n{"i":2}\n{"i":3}\n');
 

--- a/packages/core/src/utils/jsonl-utils.test.ts
+++ b/packages/core/src/utils/jsonl-utils.test.ts
@@ -267,13 +267,25 @@ describe('reader resource cleanup', () => {
     );
     const controller = new AbortController();
     const reason = new Error('jsonl scan cancelled');
-    const readPromise = readLines<{ i: number }>(file, 1_000, {
-      signal: controller.signal,
-    });
+    const originalCreateReadStream = fs.createReadStream.bind(fs);
+    const spy = vi
+      .spyOn(fs, 'createReadStream')
+      .mockImplementation((...args: Parameters<typeof fs.createReadStream>) =>
+        originalCreateReadStream(...args),
+      );
 
-    controller.abort(reason);
+    try {
+      const readPromise = readLines<{ i: number }>(file, 1_000, {
+        signal: controller.signal,
+      });
+      expect(spy).toHaveBeenCalledWith(file, { signal: controller.signal });
 
-    await expect(readPromise).rejects.toBe(reason);
+      controller.abort(reason);
+
+      await expect(readPromise).rejects.toBe(reason);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it('observes cancellation while readLines is closing its stream', async () => {

--- a/packages/core/src/utils/jsonl-utils.ts
+++ b/packages/core/src/utils/jsonl-utils.ts
@@ -35,6 +35,10 @@ type JsonlReadOptions = {
   throwOnNonEnoentError?: boolean;
 };
 
+type JsonlReadLinesOptions = {
+  signal?: AbortSignal;
+};
+
 /**
  * A map of file paths to mutexes for preventing concurrent writes.
  */
@@ -171,11 +175,15 @@ async function closeLineReader(
 export async function readLines<T = unknown>(
   filePath: string,
   count: number,
+  options: JsonlReadLinesOptions = {},
 ): Promise<T[]> {
   let fileStream: fs.ReadStream | undefined;
   let rl: readline.Interface | undefined;
   try {
-    fileStream = fs.createReadStream(filePath);
+    options.signal?.throwIfAborted();
+    fileStream = options.signal
+      ? fs.createReadStream(filePath, { signal: options.signal })
+      : fs.createReadStream(filePath);
     rl = readline.createInterface({
       input: fileStream,
       crlfDelay: Infinity,
@@ -192,8 +200,10 @@ export async function readLines<T = unknown>(
       }
     }
 
+    options.signal?.throwIfAborted();
     return results;
   } catch (error) {
+    options.signal?.throwIfAborted();
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
       debugLogger.error(
         `Error reading first ${count} lines from ${filePath}:`,
@@ -203,6 +213,7 @@ export async function readLines<T = unknown>(
     return [];
   } finally {
     await closeLineReader(rl, fileStream);
+    options.signal?.throwIfAborted();
   }
 }
 

--- a/packages/core/src/utils/runtimeStatus.test.ts
+++ b/packages/core/src/utils/runtimeStatus.test.ts
@@ -108,6 +108,16 @@ describe('writeRuntimeStatus', () => {
 });
 
 describe('readRuntimeStatus', () => {
+  it('propagates the caller abort reason', async () => {
+    const controller = new AbortController();
+    const reason = new Error('runtime status read cancelled');
+    controller.abort(reason);
+
+    await expect(
+      readRuntimeStatus(targetPath(), { signal: controller.signal }),
+    ).rejects.toBe(reason);
+  });
+
   it('round-trips a written record', async () => {
     await writeRuntimeStatus(targetPath(), {
       sessionId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',

--- a/packages/core/src/utils/runtimeStatus.test.ts
+++ b/packages/core/src/utils/runtimeStatus.test.ts
@@ -7,7 +7,7 @@
 import { mkdtemp, readFile, rm, writeFile, readdir } from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   RUNTIME_STATUS_SCHEMA_VERSION,
   clearRuntimeStatus,
@@ -15,9 +15,20 @@ import {
   writeRuntimeStatus,
 } from './runtimeStatus.js';
 
+const fsMocks = vi.hoisted(() => ({
+  readFile: vi.fn<typeof import('node:fs/promises').readFile>(),
+}));
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  fsMocks.readFile.mockImplementation(actual.readFile);
+  return { ...actual, readFile: fsMocks.readFile };
+});
+
 let tmpDir: string;
 
 beforeEach(async () => {
+  fsMocks.readFile.mockClear();
   tmpDir = await mkdtemp(path.join(os.tmpdir(), 'qwen-runtime-status-'));
 });
 
@@ -116,6 +127,22 @@ describe('readRuntimeStatus', () => {
     await expect(
       readRuntimeStatus(targetPath(), { signal: controller.signal }),
     ).rejects.toBe(reason);
+  });
+
+  it('passes the caller signal to the file read', async () => {
+    await writeRuntimeStatus(targetPath(), {
+      sessionId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      workDir: '/some/where',
+      pid: 99,
+    });
+    const controller = new AbortController();
+
+    await readRuntimeStatus(targetPath(), { signal: controller.signal });
+
+    expect(fsMocks.readFile).toHaveBeenLastCalledWith(targetPath(), {
+      encoding: 'utf-8',
+      signal: controller.signal,
+    });
   });
 
   it('round-trips a written record', async () => {

--- a/packages/core/src/utils/runtimeStatus.ts
+++ b/packages/core/src/utils/runtimeStatus.ts
@@ -120,13 +120,22 @@ export async function writeRuntimeStatus(
  */
 export async function readRuntimeStatus(
   filePath: string,
+  options: { signal?: AbortSignal } = {},
 ): Promise<RuntimeStatus | null> {
   let raw: string;
   try {
-    raw = await fs.readFile(filePath, 'utf-8');
+    options.signal?.throwIfAborted();
+    raw = options.signal
+      ? await fs.readFile(filePath, {
+          encoding: 'utf-8',
+          signal: options.signal,
+        })
+      : await fs.readFile(filePath, 'utf-8');
   } catch {
+    options.signal?.throwIfAborted();
     return null;
   }
+  options.signal?.throwIfAborted();
 
   let data: unknown;
   try {
@@ -134,6 +143,7 @@ export async function readRuntimeStatus(
   } catch {
     return null;
   }
+  options.signal?.throwIfAborted();
 
   if (data === null || typeof data !== 'object' || Array.isArray(data)) {
     return null;


### PR DESCRIPTION
## What this PR does

This PR propagates request cancellation through daemon Session List reads while preserving the persisted catalog cache introduced by #8892. Shared organized and metadata scans now track independent waiters: cancelling one REST or ACP caller leaves other REST, ACP, and LiveTask waiters running, while cancelling the last waiter aborts and detaches the physical scan so a replacement request can start immediately. Cancellation also reaches numeric pagination, JSONL reads, runtime-status and worktree-sidecar enrichment, persisted-existence checks, and the cooperative directory scan.

## Why it's needed

Disconnected Session List clients previously left expensive persisted-session scans running to completion, which could waste daemon resources and delay later catalog work. Directly wiring a caller signal to the shared loader would instead let one client cancel every consumer, so the cache needs waiter-aware cancellation ownership and late-load isolation.

## Reviewer Test Plan

### How to verify

Start two identical organized Session List requests and disconnect one; the remaining request should return the complete catalog from one physical scan. Disconnect every cancellable waiter; the physical scan should abort, and the next request should start a fresh scan before the following request hits the existing two-second TTL. Verify numeric pagination, trusted-secondary persisted preflight, ACP connection destruction, and cancellation during JSONL, runtime-status, worktree-sidecar, and project-membership reads return no partial data, HTTP 500, ACP error frame, or cancellation error log.

### Evidence (Before & After)

N/A — daemon-internal behavior with unchanged REST and ACP response schemas.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS local Node.js 22-compatible workspace; isolated `qwen serve` E2E with 1,200 persisted sessions and package-level Vitest coverage.

## Risk & Scope

- Main risk or tradeoff: Cancellation adds cooperative checkpoints and per-waiter bookkeeping around an existing single-flight cache; tests cover settlement races, last-waiter abort, replacement-load identity, late old-load completion, and no-signal behavior.
- Not validated / out of scope: Windows and Linux E2E, fixed scan deadlines, asynchronous directory enumeration, concurrent stat calls, worker threads, request-id ACP cancellation, Web Shell GET cancellation, and cancellation for CLI resume or picker callers.
- Breaking changes / migration notes: None; REST, ACP, TypeScript SDK, cache scope, TTL, capacity, invalidation, runtime routing, and trust semantics remain unchanged.

## Linked Issues

References #8892.

<details>
<summary>中文说明</summary>

## 此 PR 的作用

此 PR 在保留 #8892 引入的持久化目录缓存基础上，将请求取消传播到 daemon Session List 读取。共享的 organized 和 metadata 扫描现在跟踪独立 waiter：取消单个 REST 或 ACP 调用方不会影响其他 REST、ACP 或 LiveTask waiter；最后一个 waiter 取消时会中止并同步脱离物理扫描，使替代请求可以立即启动。取消还会传播到数字分页、JSONL 读取、runtime status 与 worktree sidecar 补充、持久化存在性检查以及协作式目录扫描。

## 为什么需要

Session List 客户端断开后，昂贵的持久化会话扫描此前仍会运行到结束，浪费 daemon 资源并可能延迟后续目录工作。若将调用方 signal 直接连接到共享 loader，单个客户端又会取消所有消费者，因此缓存需要 waiter 感知的取消所有权和晚到 load 隔离。

## Reviewer 测试计划

### 如何验证

启动两个相同的 organized Session List 请求并断开其中一个；剩余请求应通过一次物理扫描返回完整目录。断开所有可取消 waiter 后，物理扫描应中止，下一请求应启动新的扫描，随后请求命中现有两秒 TTL。验证数字分页、可信 secondary 的 persisted preflight、ACP connection destroy，以及 JSONL、runtime status、worktree sidecar 和项目归属读取期间的取消都不会返回部分数据、HTTP 500、ACP error frame 或取消错误日志。

### 证据（Before & After）

N/A — daemon 内部行为，REST 和 ACP 响应 schema 未变化。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|     🍏 macOS      | ✅ 已测试 |
|    🪟 Windows     | ⚠️ 未测试 |
|     🐧 Linux      | ⚠️ 未测试 |

### 环境（可选）

macOS 本地 Node.js 22 兼容工作区；使用 1,200 个持久化 session 的隔离 `qwen serve` E2E，并运行了包级 Vitest。

## 风险与范围

- 主要风险或权衡：取消功能在现有 single-flight cache 周围增加协作检查点和按 waiter 计数；测试覆盖 settle 竞态、最后 waiter 中止、replacement load identity、旧 load 晚到完成以及无 signal 路径。
- 未验证 / 范围外：Windows 与 Linux E2E、固定扫描期限、异步目录枚举、并发 stat、worker thread、ACP request-id 取消、Web Shell GET 取消，以及 CLI resume 或 picker 调用方取消。
- 破坏性变更 / 迁移说明：无；REST、ACP、TypeScript SDK、cache scope、TTL、capacity、invalidation、runtime routing 与 trust 语义均保持不变。

## 关联 Issue

参考 #8892。

</details>
