### PR TITLE
fix(web-shell): Harden prompt admission ownership

### DIFF
--- a/docs/design/2026-08-11-prompt-safe-session-navigation.md
+++ b/docs/design/2026-08-11-prompt-safe-session-navigation.md
@@ -9,12 +9,35 @@ prompt, or inject a mid-turn message. An explicit user Stop remains allowed to
 send one cancellation while a transition is preparing.
 
 The WebShell therefore blocks prompt writes as soon as a desired target is
-pending or the daemon transition enters `queued` or `preparing`. A prompt that
-is awaiting an asynchronous host admission hook records the write-gate
-generation and rechecks it before any composer commit, follow-up clear, session
-allocation, send, or enqueue. If the gate closes at any point while the hook is
-pending, the draft and retry state remain owned by the source composer even if
-navigation completes or fails before the hook returns.
+pending or the daemon transition enters `queued` or `preparing`. Every prompt
+records its owner and the write-gate generation before asynchronous host
+admission, session preparation, or a prompt prerequisite such as switching to
+plan mode, then rechecks them before any composer commit, follow-up clear, send,
+or enqueue.
+Any prompt that joins an existing lazy-session preparation likewise defers its
+composer commit until the shared preparation passes the same check.
+It invalidates the continuation when its App instance unmounts. If the gate
+closes at any point while admission or preparation is pending, the draft and
+retry state remain owned by the source composer even if navigation completes
+or fails before the continuation returns. A cancelled retry is consumed only
+after navigation settles and its source session becomes current again. A retry
+whose workspace is known may settle across an attachment replacement of the
+same logical session. A retry captured before its workspace is known may be
+restored only while the captured live owner remains current, or after that same
+owner supplies its workspace. An owner change discards it; transcript block IDs
+are local to a reducer and cannot establish identity across transcript
+replacement. Failed-message restoration therefore requires the same in-memory
+block or stable persisted source-record identities. Rehydration is allowed only
+when the preceding message has equivalent identity, including an empty
+transcript with no preceding message.
+Accepting a newer prompt refreshes the retry owner before its send begins, so a
+replacement attachment cannot leave its eventual failure tied to a stale live
+owner. If navigation resets the transcript after a locally rejected prompt,
+the local user message may be restored only when the preceding user-message
+anchor still matches. Turn-error retries likewise require the same block or a
+stable prompt/event identity after transcript replacement. A missing or changed
+identity fails closed instead of offering a retry for a potentially different
+transcript.
 
 ## Queued prompts
 

--- a/docs/design/2026-08-11-prompt-safe-session-navigation.md
+++ b/docs/design/2026-08-11-prompt-safe-session-navigation.md
@@ -21,6 +21,8 @@ closes at any point while admission or preparation is pending, the draft and
 retry state remain owned by the source composer even if navigation completes
 or fails before the continuation returns. A cancelled retry is consumed only
 after navigation settles and its source session becomes current again. A retry
+started later supersedes an older retry of the same kind even when their
+asynchronous admission callbacks settle out of order. A retry
 whose workspace is known may settle across an attachment replacement of the
 same logical session. A retry captured before its workspace is known may be
 restored only while the captured live owner remains current, or after that same

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -323,6 +323,8 @@ const {
           answer?: string;
           isPending?: boolean;
         }>;
+        showRetryHint?: boolean;
+        onRetryClick?: () => void;
         failedPromptMessageId?: string;
         onRetryFailedPrompt?: () => void;
         isResponding?: boolean;
@@ -4489,6 +4491,7 @@ beforeEach(() => {
   editorFocus.mockClear();
   editorRestoreInputAnnotations.mockClear();
   editorInsertText.mockClear();
+  mockStore.appendLocalUserMessage.mockReset();
   settingsReload.mockClear();
   settingsReload.mockResolvedValue(undefined);
   settingsSetValue.mockReset();
@@ -10319,6 +10322,26 @@ describe('App session callbacks', () => {
     expect(testState.latestChatEditorProps?.isPreparing).toBe(false);
   });
 
+  it('does not commit an approved submission after the App unmounts', async () => {
+    const approval = deferred<void>();
+    const onSubmitBefore = vi.fn(() => approval.promise);
+    const { container, unmount } = renderApp({ onSubmitBefore });
+    await flush();
+
+    await clickSubmit(container);
+    expect(onSubmitBefore).toHaveBeenCalledOnce();
+    unmount();
+    await act(async () => {
+      approval.resolve();
+      await approval.promise;
+    });
+
+    expect(mockSessionActions.sendPrompt).not.toHaveBeenCalled();
+    expect(editorCommit).not.toHaveBeenCalled();
+    expect(editorClear).not.toHaveBeenCalled();
+    expect(mockFollowup.clear).not.toHaveBeenCalled();
+  });
+
   it('cancels an approved new-task submission after its target workspace changes', async () => {
     let approve: (() => void) | undefined;
     const onSubmitBefore = vi.fn(
@@ -11062,6 +11085,7 @@ describe('App session callbacks', () => {
     const callbackFinished = deferred<void>();
     mockSessionActions.createSession.mockImplementation(async () => {
       mockConnection.sessionId = 'session-created';
+      mockConnection.workspaceCwd = '/workspace';
       return { sessionId: 'session-created' };
     });
     const onSessionCreated = vi.fn(async () => {
@@ -11093,6 +11117,244 @@ describe('App session callbacks', () => {
     expect(mockSessionActions.attachSession).toHaveBeenCalledOnce();
   });
 
+  it('cancels an approved submission when navigation occurs during session preparation', async () => {
+    mockConnection.sessionId = undefined;
+    const callbackStarted = deferred<void>();
+    const callbackFinished = deferred<void>();
+    mockSessionActions.createSession.mockImplementation(async () => {
+      mockConnection.sessionId = 'session-created';
+      return { sessionId: 'session-created' };
+    });
+    const onSessionCreated = vi.fn(async () => {
+      callbackStarted.resolve();
+      await callbackFinished.promise;
+    });
+    const onSubmitBefore = vi.fn().mockResolvedValue(undefined);
+    const onSessionChange = vi.fn();
+    const { rerender } = renderApp({
+      onSessionChange,
+      onSessionCreated,
+      onSubmitBefore,
+    });
+    await flush();
+
+    act(() => {
+      testState.latestChatEditorProps?.onSubmit('first');
+    });
+    await callbackStarted.promise;
+    act(() => {
+      rerender({
+        desiredSessionTargetPending: true,
+        onSessionChange,
+        onSessionCreated,
+        onSubmitBefore,
+      });
+    });
+    act(() => {
+      rerender({
+        desiredSessionTargetPending: false,
+        onSessionChange,
+        onSessionCreated,
+        onSubmitBefore,
+      });
+    });
+    await act(async () => {
+      callbackFinished.resolve();
+      await callbackFinished.promise;
+    });
+    await flush();
+
+    expect(mockSessionActions.attachSession).toHaveBeenCalledOnce();
+    expect(mockSessionActions.sendPrompt).not.toHaveBeenCalled();
+    expect(editorCommit).not.toHaveBeenCalled();
+    expect(editorClear).not.toHaveBeenCalled();
+    expect(mockFollowup.clear).not.toHaveBeenCalled();
+    expect(onSessionChange).not.toHaveBeenCalled();
+    expect(testState.prompt).toBe('hello');
+  });
+
+  it('cancels a default submission when navigation occurs during session preparation', async () => {
+    mockConnection.sessionId = undefined;
+    const callbackStarted = deferred<void>();
+    const callbackFinished = deferred<void>();
+    mockSessionActions.createSession.mockImplementation(async () => {
+      mockConnection.sessionId = 'session-created';
+      mockConnection.workspaceCwd = '/workspace';
+      testState.ownerVersion += 1;
+      return { sessionId: 'session-created' };
+    });
+    const onSessionCreated = vi.fn(async () => {
+      callbackStarted.resolve();
+      await callbackFinished.promise;
+    });
+    const onSessionChange = vi.fn();
+    const { rerender } = renderApp({ onSessionChange, onSessionCreated });
+    await flush();
+
+    act(() => {
+      testState.latestChatEditorProps?.onSubmit('first');
+    });
+    await callbackStarted.promise;
+    const secondCommit = vi.fn();
+    let secondAccepted: boolean | void;
+    act(() => {
+      secondAccepted = testState.latestChatEditorProps?.onSubmit(
+        'second',
+        undefined,
+        secondCommit,
+      );
+      if (secondAccepted !== false) secondCommit();
+    });
+    expect(secondAccepted).toBe(false);
+    expect(secondCommit).not.toHaveBeenCalled();
+    act(() => {
+      rerender({
+        desiredSessionTargetPending: true,
+        onSessionChange,
+        onSessionCreated,
+      });
+    });
+    act(() => {
+      rerender({
+        desiredSessionTargetPending: false,
+        onSessionChange,
+        onSessionCreated,
+      });
+    });
+    await act(async () => {
+      callbackFinished.resolve();
+      await callbackFinished.promise;
+    });
+    await flush();
+
+    expect(mockSessionActions.attachSession).toHaveBeenCalledOnce();
+    expect(mockSessionActions.sendPrompt).not.toHaveBeenCalled();
+    expect(editorCommit).not.toHaveBeenCalled();
+    expect(secondCommit).not.toHaveBeenCalled();
+    expect(editorClear).not.toHaveBeenCalled();
+    expect(mockFollowup.clear).not.toHaveBeenCalled();
+    expect(onSessionChange).not.toHaveBeenCalled();
+    expect(testState.prompt).toBe('hello');
+  });
+
+  it('keeps the first prompt retryable through its lazy session commit', async () => {
+    mockConnection.sessionId = undefined;
+    const callbackStarted = deferred<void>();
+    const callbackFinished = deferred<void>();
+    mockSessionActions.createSession.mockImplementation(async () => {
+      mockConnection.sessionId = 'session-created';
+      mockConnection.workspaceCwd = '/workspace';
+      testState.ownerVersion += 1;
+      return { sessionId: 'session-created' };
+    });
+    const onSessionCreated = vi.fn(async () => {
+      callbackStarted.resolve();
+      await callbackFinished.promise;
+    });
+    const onSubmitBefore = vi.fn().mockResolvedValue(undefined);
+    const { container, rerender } = renderApp({
+      onSessionCreated,
+      onSubmitBefore,
+    });
+    await flush();
+
+    act(() => {
+      testState.latestChatEditorProps?.onSubmit('first');
+    });
+    await callbackStarted.promise;
+    rerender({ onSessionCreated, onSubmitBefore });
+    await act(async () => {
+      callbackFinished.resolve();
+      await callbackFinished.promise;
+    });
+    await vi.waitFor(() => {
+      expect(mockSessionActions.sendPrompt).toHaveBeenCalledOnce();
+    });
+
+    act(() => {
+      testState.blocks = [
+        { kind: 'error', source: 'turn_error', id: 'turn-error-created' },
+      ];
+      rerender({ onSessionCreated, onSubmitBefore });
+    });
+    expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+        ?.click();
+      await Promise.resolve();
+    });
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(2);
+    expect(mockSessionActions.sendPrompt).toHaveBeenLastCalledWith(
+      'first',
+      expect.objectContaining({ retry: true }),
+    );
+  });
+
+  it('refreshes unknown-workspace retry ownership after accepting a prompt', async () => {
+    mockConnection.workspaceCwd = undefined;
+    const retrySend = deferred<void>();
+    let retryAdmitted: (() => void) | undefined;
+    mockSessionActions.sendPrompt
+      .mockResolvedValueOnce(undefined)
+      .mockImplementationOnce(
+        (
+          _text: string,
+          options?: {
+            onAdmitted?: () => void;
+          },
+        ) => {
+          retryAdmitted = options?.onAdmitted;
+          return retrySend.promise;
+        },
+      );
+    const { container, rerender } = renderApp();
+    await flush();
+
+    act(() => {
+      testState.ownerVersion += 1;
+      rerender();
+    });
+    testState.prompt = 'after reconnect';
+    await clickSubmit(container);
+    act(() => {
+      testState.blocks = [
+        { kind: 'error', source: 'turn_error', id: 'turn-error-reconnect' },
+      ];
+      rerender();
+    });
+    await flush();
+    expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+        ?.click();
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => {
+      expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(2);
+    });
+    expect(retryAdmitted).toBeTypeOf('function');
+    act(() => retryAdmitted?.());
+    await act(async () => {
+      retrySend.resolve();
+      await retrySend.promise;
+      testState.streamingState = 'idle';
+      rerender();
+      await Promise.resolve();
+    });
+    act(() => {
+      testState.streamingState = 'responding';
+      rerender();
+    });
+
+    expect(testState.latestMessageListProps?.isResponding).toBe(true);
+    expect(
+      container.querySelector('[data-testid="streaming-status"]'),
+    ).not.toBeNull();
+  });
+
   it('commits the first prompt after creating its session', async () => {
     mockConnection.sessionId = undefined;
     mockSessionActions.createSession.mockImplementation(async () => {
@@ -11116,6 +11378,7 @@ describe('App session callbacks', () => {
     await vi.waitFor(() => {
       expect(mockSessionActions.sendPrompt).toHaveBeenCalled();
     });
+    expect(mockFollowup.clear).toHaveBeenCalledOnce();
     expect(commitAccepted).toHaveBeenCalledOnce();
     expect(sessionCatalogController.sessionCreated).toHaveBeenCalledWith(
       '/workspace',
@@ -11175,7 +11438,7 @@ describe('App session callbacks', () => {
     mockSessionActions.createSession.mockImplementation(
       () => creationFinished.promise,
     );
-    const { rerender } = renderApp();
+    const { container, rerender } = renderApp();
     await flush();
 
     act(() => {
@@ -11184,8 +11447,14 @@ describe('App session callbacks', () => {
     await vi.waitFor(() => {
       expect(mockSessionActions.createSession).toHaveBeenCalledOnce();
     });
-    mockConnection.sessionId = 'session-selected';
-    rerender();
+    act(() => {
+      mockConnection.sessionId = 'session-selected';
+      testState.blocks = [
+        { kind: 'error', source: 'turn_error', id: 'selected-error' },
+      ];
+      rerender();
+    });
+    expect(container.querySelector('[data-testid="retry"]')).toBeNull();
     await act(async () => {
       testState.latestChatEditorProps?.onSubmit('second');
       await vi.waitFor(() => {
@@ -11230,6 +11499,7 @@ describe('App session callbacks', () => {
     await flush();
 
     expect(mockSessionActions.sendPrompt).not.toHaveBeenCalled();
+    expect(mockFollowup.clear).not.toHaveBeenCalled();
     await act(async () => {
       testState.latestChatEditorProps?.onSubmit('third');
       await vi.waitFor(() => {
@@ -11239,6 +11509,7 @@ describe('App session callbacks', () => {
         expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(1);
       });
     });
+    expect(mockFollowup.clear).toHaveBeenCalledOnce();
   });
 
   it('cancels direct submissions when onSubmitBefore rejects and preserves retry state', async () => {
@@ -11291,7 +11562,62 @@ describe('App session callbacks', () => {
     );
   });
 
-  it('restores a turn-error retry after navigation completes during admission', async () => {
+  it('hides a turn-error retry while a newer prompt awaits admission', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const rejectedAdmission = deferred<void>();
+    const approvedAdmission = deferred<void>();
+    let admissionCount = 0;
+    const onSubmitBefore = vi.fn(() => {
+      admissionCount += 1;
+      if (admissionCount === 1) return Promise.resolve();
+      if (admissionCount === 2) return rejectedAdmission.promise;
+      return approvedAdmission.promise;
+    });
+    const { container, rerender } = renderApp({ onSubmitBefore });
+    await flush();
+
+    testState.prompt = 'first';
+    await clickSubmit(container);
+    act(() => {
+      testState.blocks = [
+        {
+          kind: 'error',
+          source: 'turn_error',
+          id: 'turn-error-1',
+        },
+      ];
+      rerender({ onSubmitBefore });
+    });
+    expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
+
+    testState.prompt = 'newer';
+    await clickSubmit(container);
+    expect(testState.latestChatEditorProps?.isPreparing).toBe(true);
+    expect(container.querySelector('[data-testid="retry"]')).toBeNull();
+
+    await act(async () => {
+      rejectedAdmission.reject(new Error('rejected'));
+      await Promise.resolve();
+    });
+    await flush();
+    expect(testState.latestChatEditorProps?.isPreparing).toBe(false);
+    expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledOnce();
+
+    await clickSubmit(container);
+    expect(container.querySelector('[data-testid="retry"]')).toBeNull();
+    await act(async () => {
+      approvedAdmission.resolve();
+      await approvedAdmission.promise;
+    });
+    await vi.waitFor(() => {
+      expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(2);
+    });
+    expect(testState.latestChatEditorProps?.isPreparing).toBe(false);
+    expect(container.querySelector('[data-testid="retry"]')).toBeNull();
+  });
+
+  it('restores a turn-error retry after switching away during admission', async () => {
     let approveRetry: (() => void) | undefined;
     let admissionCount = 0;
     const onSubmitBefore = vi.fn(() => {
@@ -11308,7 +11634,12 @@ describe('App session callbacks', () => {
     await clickSubmit(container);
     act(() => {
       testState.blocks = [
-        { kind: 'error', source: 'turn_error', id: 'turn-error-1' },
+        {
+          kind: 'error',
+          source: 'turn_error',
+          id: 'turn-error-1',
+          promptId: 'prompt-first',
+        },
       ];
       rerender({ onSubmitBefore });
     });
@@ -11326,16 +11657,309 @@ describe('App session callbacks', () => {
     act(() => {
       rerender({ desiredSessionTargetPending: true, onSubmitBefore });
     });
+    const allowBPrompt = vi.fn().mockResolvedValue(undefined);
     act(() => {
-      rerender({ desiredSessionTargetPending: false, onSubmitBefore });
+      mockConnection.sessionId = 'session-2';
+      mockConnection.workspaceCwd = '/tmp/project-2';
+      testState.blocks = [];
+      testState.ownerVersion += 1;
+      rerender({
+        desiredSessionTargetPending: false,
+        onSubmitBefore: allowBPrompt,
+      });
     });
+    testState.prompt = 'second';
+    await clickSubmit(container);
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledOnce();
+    expect(mockSessionActions.sendPrompt).toHaveBeenLastCalledWith(
+      'second',
+      expect.objectContaining({ retry: undefined }),
+    );
     await act(async () => {
       approveRetry?.();
       await Promise.resolve();
     });
 
-    expect(mockSessionActions.sendPrompt).not.toHaveBeenCalled();
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledOnce();
+    expect(container.querySelector('[data-testid="retry"]')).toBeNull();
+
+    act(() => {
+      testState.blocks = [
+        { kind: 'error', source: 'turn_error', id: 'turn-error-2' },
+      ];
+      rerender({ onSubmitBefore: allowBPrompt });
+    });
     expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+        ?.click();
+      await Promise.resolve();
+    });
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(2);
+    expect(mockSessionActions.sendPrompt).toHaveBeenLastCalledWith(
+      'second',
+      expect.objectContaining({
+        optimisticUserMessage: false,
+        retry: true,
+      }),
+    );
+
+    act(() => {
+      mockConnection.sessionId = 'session-1';
+      mockConnection.workspaceCwd = '/tmp/project';
+      testState.blocks = [
+        {
+          kind: 'error',
+          source: 'turn_error',
+          id: 'turn-error-1',
+          promptId: 'prompt-first',
+        },
+      ];
+      testState.ownerVersion += 1;
+      rerender({ onSubmitBefore });
+    });
+    await flush();
+
+    expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
+    const allowRetry = vi.fn().mockResolvedValue(undefined);
+    rerender({ onSubmitBefore: allowRetry });
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+        ?.click();
+      await Promise.resolve();
+    });
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(3);
+    expect(mockSessionActions.sendPrompt).toHaveBeenLastCalledWith(
+      'first',
+      expect.objectContaining({
+        optimisticUserMessage: false,
+        retry: true,
+      }),
+    );
+  });
+
+  it('defers retry restoration until navigation commits', async () => {
+    const retryApproval = deferred<void>();
+    let admissionCount = 0;
+    const onSubmitBefore = vi.fn(() => {
+      admissionCount += 1;
+      return admissionCount === 1 ? Promise.resolve() : retryApproval.promise;
+    });
+    const { container, rerender } = renderApp({ onSubmitBefore });
+    await flush();
+
+    testState.prompt = 'first';
+    await clickSubmit(container);
+    act(() => {
+      testState.blocks = [
+        {
+          kind: 'error',
+          source: 'turn_error',
+          id: 'turn-error-1',
+          promptId: 'prompt-first',
+        },
+      ];
+      rerender({ onSubmitBefore });
+    });
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+        ?.click();
+      rerender({ desiredSessionTargetPending: true, onSubmitBefore });
+    });
+    await act(async () => {
+      retryApproval.resolve();
+      await retryApproval.promise;
+    });
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('[data-testid="retry"]')).toBeNull();
+    act(() => {
+      mockConnection.sessionId = 'session-1';
+      mockConnection.workspaceCwd = '/tmp/project-2';
+      testState.blocks = [
+        { kind: 'error', source: 'turn_error', id: 'turn-error-2' },
+      ];
+      testState.ownerVersion += 1;
+      rerender({ desiredSessionTargetPending: false, onSubmitBefore });
+    });
+    act(() => {
+      mockConnection.sessionId = 'session-1';
+      mockConnection.workspaceCwd = '/tmp/project';
+      testState.blocks = [
+        {
+          kind: 'error',
+          source: 'turn_error',
+          id: 'turn-error-1',
+          promptId: 'prompt-first',
+        },
+      ];
+      testState.ownerVersion += 1;
+      rerender({ onSubmitBefore });
+    });
+    await flush();
+
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
+  });
+
+  it('waits for the source transcript before restoring a cancelled retry', async () => {
+    let approveRetry: (() => void) | undefined;
+    let admissionCount = 0;
+    const onSubmitBefore = vi.fn(() => {
+      admissionCount += 1;
+      if (admissionCount === 1) return Promise.resolve();
+      return new Promise<void>((resolve) => {
+        approveRetry = resolve;
+      });
+    });
+    const { container, rerender } = renderApp({ onSubmitBefore });
+    await flush();
+
+    testState.prompt = 'first';
+    await clickSubmit(container);
+    act(() => {
+      testState.blocks = [
+        {
+          kind: 'error',
+          source: 'turn_error',
+          id: 'turn-error-1',
+          promptId: 'prompt-first',
+        },
+      ];
+      rerender({ onSubmitBefore });
+    });
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+        ?.click();
+      rerender({ desiredSessionTargetPending: true, onSubmitBefore });
+    });
+    act(() => {
+      mockConnection.sessionId = 'session-2';
+      mockConnection.workspaceCwd = '/tmp/project-2';
+      testState.blocks = [];
+      testState.ownerVersion += 1;
+      rerender({ desiredSessionTargetPending: false, onSubmitBefore });
+    });
+    act(() => {
+      mockConnection.sessionId = 'session-1';
+      mockConnection.workspaceCwd = '/tmp/project';
+      mockConnection.loadingTranscript = true;
+      testState.ownerVersion += 1;
+      rerender({ onSubmitBefore });
+    });
+    await act(async () => {
+      approveRetry?.();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-testid="retry"]')).toBeNull();
+
+    act(() => {
+      mockConnection.loadingTranscript = false;
+      testState.blocks = [
+        {
+          kind: 'error',
+          source: 'turn_error',
+          id: 'turn-error-1',
+          promptId: 'prompt-first',
+        },
+      ];
+      rerender({ onSubmitBefore });
+    });
+    await flush();
+
+    expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
+  });
+
+  it('does not restore a stale turn-error retry after the source advances', async () => {
+    let approveRetry: (() => void) | undefined;
+    let admissionCount = 0;
+    const onSubmitBefore = vi.fn(() => {
+      admissionCount += 1;
+      if (admissionCount === 1) return Promise.resolve();
+      return new Promise<void>((resolve) => {
+        approveRetry = resolve;
+      });
+    });
+    const { container, rerender } = renderApp({ onSubmitBefore });
+    await flush();
+
+    testState.prompt = 'first';
+    await clickSubmit(container);
+    act(() => {
+      testState.blocks = [
+        {
+          kind: 'error',
+          source: 'turn_error',
+          id: 'turn-error-1',
+          eventId: 100,
+          promptId: 'prompt-old',
+        },
+      ];
+      rerender({ onSubmitBefore });
+    });
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+        ?.click();
+    });
+
+    act(() => {
+      rerender({ desiredSessionTargetPending: true, onSubmitBefore });
+    });
+    act(() => {
+      mockConnection.sessionId = 'session-2';
+      mockConnection.workspaceCwd = '/tmp/project-2';
+      testState.blocks = [];
+      testState.ownerVersion += 1;
+      rerender({ desiredSessionTargetPending: false, onSubmitBefore });
+    });
+
+    const allowNewerPrompt = vi.fn().mockResolvedValue(undefined);
+    act(() => {
+      mockConnection.sessionId = 'session-1';
+      mockConnection.workspaceCwd = '/tmp/project';
+      testState.blocks = [];
+      testState.ownerVersion += 1;
+      rerender({ onSubmitBefore: allowNewerPrompt });
+    });
+    testState.prompt = 'newer';
+    await clickSubmit(container);
+    act(() => {
+      testState.blocks = [
+        { kind: 'user', id: 'newer-user' },
+        {
+          kind: 'error',
+          source: 'turn_error',
+          id: 'turn-error-1',
+          eventId: 200,
+          promptId: 'prompt-new',
+        },
+      ];
+      rerender({ onSubmitBefore: allowNewerPrompt });
+    });
+    expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
+
+    await act(async () => {
+      approveRetry?.();
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+        ?.click();
+      await Promise.resolve();
+    });
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(3);
+    expect(mockSessionActions.sendPrompt).toHaveBeenLastCalledWith(
+      'newer',
+      expect.objectContaining({ retry: true }),
+    );
   });
 
   it('allows manual retry after a model stream interrupted turn error', async () => {
@@ -11448,6 +12072,61 @@ describe('App session callbacks', () => {
     act(() => unblockedRetry?.click());
     await flush();
     expect(mockSessionActions.sendPrompt).toHaveBeenCalledOnce();
+  });
+
+  it('settles a rejected turn-error retry after workspace enrichment', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const retrySend = deferred<void>();
+    mockConnection.sessionId = 'session-late';
+    mockConnection.workspaceCwd = undefined;
+    const { container, rerender } = renderApp();
+    await flush();
+
+    testState.prompt = 'recover this stream';
+    await clickSubmit(container);
+    mockSessionActions.sendPrompt.mockClear();
+    act(() => {
+      testState.blocks = [
+        {
+          kind: 'error',
+          source: 'turn_error',
+          id: 'turn-error-workspace-enrichment',
+          errorKind: 'model_stream_interrupted',
+          text: 'terminated',
+        },
+      ];
+      rerender();
+    });
+    mockSessionActions.sendPrompt.mockReturnValueOnce(retrySend.promise);
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+        ?.click();
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => {
+      expect(mockSessionActions.sendPrompt).toHaveBeenCalledOnce();
+    });
+    act(() => {
+      mockConnection.workspaceCwd = '/tmp/project';
+      rerender();
+    });
+    await act(async () => {
+      retrySend.reject(new DaemonHttpError(413, {}, 'Retry rejected'));
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(error).toHaveBeenCalled();
+    act(() => {
+      testState.streamingState = 'responding';
+      rerender();
+    });
+    expect(
+      container.querySelector('[data-testid="streaming-status"]'),
+    ).not.toBeNull();
+    expect(testState.latestMessageListProps?.isResponding).toBe(true);
   });
 
   it('does not settle a turn-error retry into a different workspace', async () => {
@@ -11618,7 +12297,7 @@ describe('App session callbacks', () => {
     expect(editorClear).not.toHaveBeenCalled();
   });
 
-  it('cancels an approved queued submission after the session changes', async () => {
+  it('cancels an approved queued submission after an A-to-B-to-A owner cycle', async () => {
     let approve: (() => void) | undefined;
     const onSubmitBefore = vi.fn(
       () =>
@@ -11639,6 +12318,13 @@ describe('App session callbacks', () => {
     act(() => {
       mockConnection.sessionId = 'session-2';
       mockConnection.workspaceCwd = '/tmp/project-2';
+      testState.ownerVersion += 1;
+      rerender({ onSubmitBefore });
+    });
+    act(() => {
+      mockConnection.sessionId = 'session-1';
+      mockConnection.workspaceCwd = '/tmp/project';
+      testState.ownerVersion += 1;
       rerender({ onSubmitBefore });
     });
     await act(async () => {
@@ -11697,6 +12383,30 @@ describe('App session callbacks', () => {
     expect(editorClear).not.toHaveBeenCalled();
     expect(onSessionChange).not.toHaveBeenCalled();
     expect(testState.prompt).toBe('queued');
+  });
+
+  it('does not enqueue an approved queued submission after the App unmounts', async () => {
+    const approval = deferred<void>();
+    const onSubmitBefore = vi.fn(() => approval.promise);
+    const { container, rerender, unmount } = renderApp({ onSubmitBefore });
+    await flush();
+
+    act(() => {
+      testState.streamingState = 'responding';
+      rerender({ onSubmitBefore });
+    });
+    testState.prompt = 'queued';
+    await clickSubmit(container);
+    expect(onSubmitBefore).toHaveBeenCalledOnce();
+    unmount();
+    await act(async () => {
+      approval.resolve();
+      await approval.promise;
+    });
+
+    expect(rawEnqueuePrompt).not.toHaveBeenCalled();
+    expect(editorCommit).not.toHaveBeenCalled();
+    expect(editorClear).not.toHaveBeenCalled();
   });
 
   it('cancels queued submissions when onSubmitBefore rejects', async () => {
@@ -12052,6 +12762,32 @@ describe('App session callbacks', () => {
     expect(testState.latestChatEditorProps?.isPreparing).toBe(false);
   });
 
+  it('does not send a deferred plan prompt after an interrupted navigation', async () => {
+    const approval = deferred<void>();
+    mockSessionActions.setApprovalMode.mockReturnValueOnce(approval.promise);
+    const { container, rerender } = renderApp();
+    await flush();
+
+    testState.prompt = '/plan explain the migration';
+    await clickSubmit(container);
+    expect(mockSessionActions.setApprovalMode).toHaveBeenCalledWith('plan');
+
+    act(() => {
+      rerender({ desiredSessionTargetPending: true });
+    });
+    act(() => {
+      rerender({ desiredSessionTargetPending: false });
+    });
+    await act(async () => {
+      approval.resolve();
+      await approval.promise;
+    });
+
+    expect(mockSessionActions.sendPrompt).not.toHaveBeenCalled();
+    expect(testState.prompt).toBe('/plan explain the migration');
+    expect(testState.latestChatEditorProps?.isPreparing).toBe(false);
+  });
+
   it('clears deferred plan preparation after a same-session reattach', async () => {
     const approval = deferred<void>();
     mockSessionActions.setApprovalMode.mockReturnValueOnce(approval.promise);
@@ -12208,6 +12944,573 @@ describe('App session callbacks', () => {
         sessionId: 'session-late',
       }),
     );
+  });
+
+  it('keeps retry state when the active workspace becomes available mid-turn', async () => {
+    mockConnection.sessionId = 'session-late';
+    mockConnection.workspaceCwd = undefined;
+    const { container, rerender } = renderApp();
+    await flush();
+
+    testState.prompt = 'first';
+    await clickSubmit(container);
+    act(() => {
+      testState.streamingState = 'responding';
+      rerender();
+    });
+    act(() => {
+      mockConnection.workspaceCwd = '/tmp/project';
+      rerender();
+    });
+    act(() => {
+      testState.blocks = [
+        { kind: 'error', source: 'turn_error', id: 'turn-error-1' },
+      ];
+      testState.streamingState = 'idle';
+      rerender();
+    });
+    await flush();
+
+    expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+        ?.click();
+    });
+    await flush();
+
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(2);
+    expect(mockSessionActions.sendPrompt).toHaveBeenLastCalledWith(
+      'first',
+      expect.objectContaining({
+        optimisticUserMessage: false,
+        retry: true,
+      }),
+    );
+  });
+
+  it('restores a pending retry when the active workspace becomes available', async () => {
+    let approveRetry: (() => void) | undefined;
+    let admissionCount = 0;
+    const onSubmitBefore = vi.fn(() => {
+      admissionCount += 1;
+      if (admissionCount === 1) return Promise.resolve();
+      return new Promise<void>((resolve) => {
+        approveRetry = resolve;
+      });
+    });
+    mockConnection.sessionId = 'session-late';
+    mockConnection.workspaceCwd = undefined;
+    const { container, rerender } = renderApp({ onSubmitBefore });
+    await flush();
+
+    testState.prompt = 'first';
+    await clickSubmit(container);
+    act(() => {
+      testState.blocks = [
+        { kind: 'error', source: 'turn_error', id: 'turn-error-1' },
+      ];
+      rerender({ onSubmitBefore });
+    });
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+        ?.click();
+    });
+    act(() => {
+      mockConnection.workspaceCwd = '/tmp/project';
+      rerender({ onSubmitBefore });
+    });
+    await act(async () => {
+      approveRetry?.();
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
+  });
+
+  it('migrates a cached retry when the active workspace becomes available', async () => {
+    const retryApproval = deferred<void>();
+    let admissionCount = 0;
+    const onSubmitBefore = vi.fn(() => {
+      admissionCount += 1;
+      return admissionCount === 1 ? Promise.resolve() : retryApproval.promise;
+    });
+    mockConnection.sessionId = 'session-late';
+    mockConnection.workspaceCwd = undefined;
+    const { container, rerender } = renderApp({ onSubmitBefore });
+    await flush();
+
+    testState.prompt = 'first';
+    await clickSubmit(container);
+    act(() => {
+      testState.blocks = [
+        { kind: 'error', source: 'turn_error', id: 'turn-error-1' },
+      ];
+      rerender({ onSubmitBefore });
+    });
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+        ?.click();
+      rerender({ desiredSessionTargetPending: true, onSubmitBefore });
+    });
+    await act(async () => {
+      retryApproval.resolve();
+      await retryApproval.promise;
+    });
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('[data-testid="retry"]')).toBeNull();
+
+    act(() => {
+      mockConnection.workspaceCwd = '/tmp/project';
+      rerender({ desiredSessionTargetPending: true, onSubmitBefore });
+    });
+    act(() => {
+      rerender({ desiredSessionTargetPending: false, onSubmitBefore });
+    });
+    await flush();
+
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
+  });
+
+  it('clears retry state when a new owner supplies the workspace', async () => {
+    mockConnection.sessionId = 'session-late';
+    mockConnection.workspaceCwd = undefined;
+    const { container, rerender } = renderApp();
+    await flush();
+
+    testState.prompt = 'first';
+    await clickSubmit(container);
+    act(() => {
+      testState.blocks = [
+        { kind: 'error', source: 'turn_error', id: 'turn-error-1' },
+      ];
+      rerender();
+    });
+    expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
+
+    act(() => {
+      testState.ownerVersion += 1;
+      mockConnection.workspaceCwd = '/tmp/project-2';
+      rerender();
+    });
+    await flush();
+
+    expect(container.querySelector('[data-testid="retry"]')).toBeNull();
+  });
+
+  it('prefers the active retry when its workspace becomes available', async () => {
+    const oldRetryApproval = deferred<void>();
+    const activeRetryApproval = deferred<void>();
+    let admissionCount = 0;
+    const onSubmitBefore = vi.fn(() => {
+      admissionCount += 1;
+      if (admissionCount === 2) return oldRetryApproval.promise;
+      if (admissionCount === 4) return activeRetryApproval.promise;
+      return Promise.resolve();
+    });
+    const oldError = {
+      kind: 'error',
+      source: 'turn_error',
+      id: 'turn-error-1',
+      eventId: 100,
+      promptId: 'prompt-old',
+    } as const;
+    const activeError = {
+      kind: 'error',
+      source: 'turn_error',
+      id: 'turn-error-2',
+      eventId: 200,
+      promptId: 'prompt-active',
+    } as const;
+    const { container, rerender } = renderApp({ onSubmitBefore });
+    await flush();
+
+    testState.prompt = 'first';
+    await clickSubmit(container);
+    act(() => {
+      testState.blocks = [oldError];
+      rerender({ onSubmitBefore });
+    });
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+        ?.click();
+      rerender({ desiredSessionTargetPending: true, onSubmitBefore });
+    });
+    await act(async () => {
+      oldRetryApproval.resolve();
+      await oldRetryApproval.promise;
+    });
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledOnce();
+
+    act(() => {
+      testState.ownerVersion += 1;
+      mockConnection.workspaceCwd = undefined;
+      testState.blocks = [];
+      rerender({ desiredSessionTargetPending: false, onSubmitBefore });
+    });
+    testState.prompt = 'second';
+    await clickSubmit(container);
+    act(() => {
+      testState.blocks = [activeError];
+      rerender({ onSubmitBefore });
+    });
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+        ?.click();
+      rerender({ desiredSessionTargetPending: true, onSubmitBefore });
+    });
+    await act(async () => {
+      activeRetryApproval.resolve();
+      await activeRetryApproval.promise;
+    });
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      mockConnection.workspaceCwd = '/tmp/project';
+      rerender({ desiredSessionTargetPending: true, onSubmitBefore });
+    });
+    act(() => {
+      rerender({ desiredSessionTargetPending: false, onSubmitBefore });
+    });
+    await flush();
+
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(2);
+    expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+        ?.click();
+      await Promise.resolve();
+    });
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(3);
+    expect(mockSessionActions.sendPrompt).toHaveBeenLastCalledWith(
+      'second',
+      expect.objectContaining({ retry: true }),
+    );
+  });
+
+  it('drops a known-workspace retry when a replacement reuses its local error id', async () => {
+    const { container, rerender } = renderApp();
+    await flush();
+
+    testState.prompt = 'first';
+    await clickSubmit(container);
+    act(() => {
+      testState.blocks = [
+        { kind: 'error', source: 'turn_error', id: 'turn-error-1' },
+      ];
+      rerender();
+    });
+    expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
+    const retry = testState.latestMessageListProps?.onRetryClick;
+
+    act(() => {
+      testState.ownerVersion += 1;
+      testState.blocks = [
+        { kind: 'error', source: 'turn_error', id: 'turn-error-1' },
+      ];
+      retry?.();
+      rerender();
+    });
+    await flush();
+
+    expect(container.querySelector('[data-testid="retry"]')).toBeNull();
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops an uncertain retry response after a known-workspace transcript replacement', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const retrySend = deferred<void>();
+    mockSessionActions.sendPrompt
+      .mockResolvedValueOnce(undefined)
+      .mockReturnValueOnce(retrySend.promise);
+    const { container, rerender } = renderApp();
+    await flush();
+
+    testState.prompt = 'first';
+    await clickSubmit(container);
+    act(() => {
+      testState.blocks = [
+        { kind: 'error', source: 'turn_error', id: 'turn-error-1' },
+      ];
+      rerender();
+    });
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+        ?.click();
+    });
+    await vi.waitFor(() => {
+      expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(2);
+    });
+    const retryOptions = mockSessionActions.sendPrompt.mock.calls[1]?.[1];
+
+    act(() => {
+      retryOptions?.onAdmissionStarted?.();
+      testState.ownerVersion += 1;
+      testState.blocks = [
+        { kind: 'error', source: 'turn_error', id: 'turn-error-1' },
+      ];
+      rerender();
+    });
+    await act(async () => {
+      retrySend.reject(new Error('response lost'));
+      await Promise.resolve();
+    });
+
+    expect(
+      container.querySelector('[data-testid="prompt-admission-unknown"]'),
+    ).toBeNull();
+    expect(warn).not.toHaveBeenCalledWith(
+      '[WebShell] post-turn retry admission outcome is unknown',
+      expect.anything(),
+    );
+  });
+
+  it('keeps a known-workspace retry across a stable error replay', async () => {
+    const firstError = {
+      kind: 'error',
+      source: 'turn_error',
+      id: 'turn-error-1',
+      promptId: 'prompt-1',
+    } as const;
+    const replayedError = {
+      kind: 'error',
+      source: 'turn_error',
+      id: 'turn-error-2',
+      promptId: 'prompt-1',
+    } as const;
+    const { container, rerender } = renderApp();
+    await flush();
+
+    testState.prompt = 'first';
+    await clickSubmit(container);
+    act(() => {
+      testState.blocks = [firstError];
+      rerender();
+    });
+    expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
+
+    act(() => {
+      testState.ownerVersion += 1;
+      testState.blocks = [replayedError];
+      rerender();
+    });
+    await flush();
+    expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+        ?.click();
+    });
+    await flush();
+
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(2);
+    expect(mockSessionActions.sendPrompt).toHaveBeenLastCalledWith(
+      'first',
+      expect.objectContaining({ retry: true }),
+    );
+  });
+
+  it('does not expose a duplicate retry when a stable replay passes through an empty transcript', async () => {
+    const retrySend = deferred<void>();
+    mockSessionActions.sendPrompt
+      .mockResolvedValueOnce(undefined)
+      .mockReturnValueOnce(retrySend.promise);
+    const { container, rerender } = renderApp();
+    await flush();
+
+    testState.prompt = 'first';
+    await clickSubmit(container);
+    act(() => {
+      testState.blocks = [
+        {
+          kind: 'error',
+          source: 'turn_error',
+          id: 'turn-error-1',
+          promptId: 'prompt-1',
+        },
+      ];
+      rerender();
+    });
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+        ?.click();
+    });
+    await vi.waitFor(() => {
+      expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(2);
+    });
+
+    act(() => {
+      testState.ownerVersion += 1;
+      testState.blocks = [];
+      rerender();
+    });
+    await flush();
+    act(() => {
+      testState.blocks = [
+        {
+          kind: 'error',
+          source: 'turn_error',
+          id: 'turn-error-2',
+          promptId: 'prompt-1',
+        },
+      ];
+      rerender();
+    });
+    await flush();
+
+    expect(container.querySelector('[data-testid="retry"]')).toBeNull();
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      retrySend.resolve();
+      await retrySend.promise;
+    });
+  });
+
+  it('drops a visible workspace-unknown retry after its attachment is replaced', async () => {
+    mockConnection.sessionId = 'session-1';
+    mockConnection.workspaceCwd = undefined;
+    const { container, rerender } = renderApp();
+    await flush();
+
+    testState.prompt = 'first';
+    await clickSubmit(container);
+    act(() => {
+      testState.blocks = [
+        { kind: 'error', source: 'turn_error', id: 'turn-error-1' },
+      ];
+      rerender();
+    });
+    expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
+    const retry = testState.latestMessageListProps?.onRetryClick;
+
+    act(() => {
+      testState.ownerVersion += 1;
+      rerender();
+    });
+    expect(container.querySelector('[data-testid="retry"]')).toBeNull();
+    act(() => retry?.());
+    await flush();
+
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let an in-flight workspace-unknown retry suppress a replacement attachment', async () => {
+    mockConnection.sessionId = 'session-1';
+    mockConnection.workspaceCwd = undefined;
+    const retrySend = deferred<void>();
+    let retryAdmitted: (() => void) | undefined;
+    mockSessionActions.sendPrompt
+      .mockResolvedValueOnce(undefined)
+      .mockImplementationOnce(
+        (
+          _text: string,
+          options?: {
+            onAdmitted?: () => void;
+          },
+        ) => {
+          retryAdmitted = options?.onAdmitted;
+          return retrySend.promise;
+        },
+      );
+    const { container, rerender } = renderApp();
+    await flush();
+
+    testState.prompt = 'first';
+    await clickSubmit(container);
+    act(() => {
+      testState.blocks = [
+        { kind: 'error', source: 'turn_error', id: 'turn-error-1' },
+      ];
+      rerender();
+    });
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+        ?.click();
+    });
+    await vi.waitFor(() => {
+      expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(2);
+    });
+
+    await act(async () => {
+      testState.ownerVersion += 1;
+      testState.streamingState = 'responding';
+      rerender();
+      retryAdmitted?.();
+      retrySend.resolve();
+      await retrySend.promise;
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(testState.latestMessageListProps?.isResponding).toBe(true);
+  });
+
+  it('drops a workspace-unknown retry when its owner changes', async () => {
+    const retryApproval = deferred<void>();
+    let admissionCount = 0;
+    const onSubmitBefore = vi.fn(() => {
+      admissionCount += 1;
+      return admissionCount === 1 ? Promise.resolve() : retryApproval.promise;
+    });
+    mockConnection.sessionId = 'session-1';
+    mockConnection.workspaceCwd = undefined;
+    const { container, rerender } = renderApp({ onSubmitBefore });
+    await flush();
+
+    testState.prompt = 'first';
+    await clickSubmit(container);
+    act(() => {
+      testState.blocks = [
+        { kind: 'error', source: 'turn_error', id: 'turn-error-1' },
+      ];
+      rerender({ onSubmitBefore });
+    });
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+        ?.click();
+      rerender({ desiredSessionTargetPending: true, onSubmitBefore });
+    });
+    await act(async () => {
+      retryApproval.resolve();
+      await retryApproval.promise;
+    });
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('[data-testid="retry"]')).toBeNull();
+    act(() => {
+      mockConnection.sessionId = 'session-1';
+      mockConnection.workspaceCwd = '/tmp/project-2';
+      testState.blocks = [
+        { kind: 'error', source: 'turn_error', id: 'turn-error-1' },
+      ];
+      testState.ownerVersion += 1;
+      rerender({ desiredSessionTargetPending: false, onSubmitBefore });
+    });
+    expect(container.querySelector('[data-testid="retry"]')).toBeNull();
+    act(() => {
+      mockConnection.sessionId = 'session-1';
+      mockConnection.workspaceCwd = '/tmp/project';
+      testState.blocks = [
+        { kind: 'error', source: 'turn_error', id: 'turn-error-1' },
+      ];
+      testState.ownerVersion += 1;
+      rerender({ onSubmitBefore });
+    });
+    await flush();
+
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('[data-testid="retry"]')).toBeNull();
   });
 
   it('auto-closes an open Settings/Status panel when a tool approval becomes pending', async () => {
@@ -15597,11 +16900,549 @@ describe('App prompt send failure retry', () => {
     );
   });
 
+  it('keeps a failed-prompt retry when its workspace becomes available', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockConnection.sessionId = 'session-late';
+    mockConnection.workspaceCwd = undefined;
+    const firstSend = deferred<void>();
+    mockSessionActions.sendPrompt.mockImplementationOnce(() => {
+      testState.blocks = [{ id: 'u1', kind: 'user' }];
+      return firstSend.promise;
+    });
+    const { container, rerender } = renderApp();
+    await flush();
+
+    act(() => {
+      testState.latestChatEditorProps?.onSubmit('hello');
+    });
+    testState.messages = [{ id: 'u1', role: 'user', content: 'hello' }];
+    await act(async () => {
+      firstSend.reject(new DaemonHttpError(413, {}, 'Prompt too large'));
+      await Promise.resolve();
+    });
+    expect(
+      container.querySelector('[data-testid="failed-prompt-retry"]'),
+    ).not.toBeNull();
+
+    act(() => {
+      mockConnection.workspaceCwd = '/tmp/project';
+      rerender();
+    });
+    await flush();
+
+    expect(
+      container.querySelector('[data-testid="failed-prompt-retry"]')
+        ?.textContent,
+    ).toBe('u1');
+  });
+
+  it('restores a pending failed-prompt retry after workspace enrichment', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const retryApproval = deferred<void>();
+    let admissionCount = 0;
+    const onSubmitBefore = vi.fn(() => {
+      admissionCount += 1;
+      return admissionCount === 2 ? retryApproval.promise : Promise.resolve();
+    });
+    mockConnection.sessionId = 'session-late';
+    mockConnection.workspaceCwd = undefined;
+    const firstSend = deferred<void>();
+    mockSessionActions.sendPrompt.mockImplementationOnce(() => {
+      testState.blocks = [{ id: 'u1', kind: 'user' }];
+      return firstSend.promise;
+    });
+    const { container, rerender } = renderApp({ onSubmitBefore });
+    await flush();
+
+    act(() => {
+      testState.latestChatEditorProps?.onSubmit('hello');
+    });
+    testState.messages = [{ id: 'u1', role: 'user', content: 'hello' }];
+    await act(async () => {
+      firstSend.reject(new DaemonHttpError(413, {}, 'Prompt too large'));
+      await Promise.resolve();
+    });
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="failed-prompt-retry"]')
+        ?.click();
+      mockConnection.workspaceCwd = '/tmp/project';
+      rerender({ onSubmitBefore });
+    });
+    await act(async () => {
+      retryApproval.resolve();
+      await retryApproval.promise;
+    });
+    await flush();
+
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(1);
+    expect(
+      container.querySelector('[data-testid="failed-prompt-retry"]')
+        ?.textContent,
+    ).toBe('u1');
+  });
+
+  it('restores a rejected failed-prompt retry after workspace enrichment', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockConnection.sessionId = 'session-late';
+    mockConnection.workspaceCwd = undefined;
+    const firstSend = deferred<void>();
+    const retrySend = deferred<void>();
+    mockSessionActions.sendPrompt
+      .mockImplementationOnce(() => {
+        testState.blocks = [{ id: 'u1', kind: 'user' }];
+        return firstSend.promise;
+      })
+      .mockImplementationOnce(() => retrySend.promise);
+    const { container, rerender } = renderApp();
+    await flush();
+
+    act(() => {
+      testState.latestChatEditorProps?.onSubmit('hello');
+    });
+    testState.messages = [{ id: 'u1', role: 'user', content: 'hello' }];
+    await act(async () => {
+      firstSend.reject(new DaemonHttpError(413, {}, 'Prompt too large'));
+      await Promise.resolve();
+    });
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="failed-prompt-retry"]')
+        ?.click();
+    });
+    await vi.waitFor(() => {
+      expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(2);
+    });
+    act(() => {
+      mockConnection.workspaceCwd = '/tmp/project';
+      rerender();
+    });
+    await act(async () => {
+      retrySend.reject(new DaemonHttpError(413, {}, 'Prompt too large'));
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(
+      container.querySelector('[data-testid="failed-prompt-retry"]')
+        ?.textContent,
+    ).toBe('u1');
+  });
+
+  it('rehydrates a rejected failed-prompt retry after attachment reset', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const firstSend = deferred<void>();
+    const retrySend = deferred<void>();
+    const originalAnchor = {
+      id: 'user-1',
+      kind: 'user',
+      text: 'original anchor',
+      sourceRecordIds: ['record-anchor'],
+    };
+    testState.blocks = [originalAnchor];
+    testState.messages = [
+      { id: 'user-1', role: 'user', content: 'original anchor' },
+    ];
+    mockStore.appendLocalUserMessage.mockImplementationOnce(() => {
+      testState.blocks = [
+        ...testState.blocks,
+        { id: 'user-3', kind: 'user', text: 'hello' },
+      ];
+      testState.messages = [
+        ...testState.messages,
+        { id: 'user-3', role: 'user', content: 'hello' },
+      ];
+    });
+    mockSessionActions.sendPrompt
+      .mockImplementationOnce(() => {
+        testState.blocks = [
+          originalAnchor,
+          { id: 'user-2', kind: 'user', text: 'hello' },
+        ];
+        return firstSend.promise;
+      })
+      .mockImplementationOnce(() => retrySend.promise);
+    const { container, rerender } = renderApp();
+    await flush();
+
+    act(() => {
+      testState.latestChatEditorProps?.onSubmit('hello');
+    });
+    testState.messages = [
+      { id: 'user-1', role: 'user', content: 'original anchor' },
+      { id: 'user-2', role: 'user', content: 'hello' },
+    ];
+    await act(async () => {
+      firstSend.reject(new DaemonHttpError(413, {}, 'Prompt too large'));
+      await Promise.resolve();
+    });
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="failed-prompt-retry"]')
+        ?.click();
+    });
+    await vi.waitFor(() => {
+      expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(2);
+    });
+
+    act(() => {
+      testState.ownerVersion += 1;
+      testState.blocks = [
+        {
+          id: 'user-9',
+          kind: 'user',
+          text: 'original anchor',
+          sourceRecordIds: ['record-anchor'],
+        },
+      ];
+      testState.messages = [
+        { id: 'user-9', role: 'user', content: 'original anchor' },
+      ];
+      rerender();
+    });
+    await act(async () => {
+      retrySend.reject(new DaemonHttpError(413, {}, 'Prompt too large'));
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => {
+      expect(mockStore.appendLocalUserMessage).toHaveBeenCalledWith(
+        'hello',
+        undefined,
+        undefined,
+      );
+    });
+    act(() => {
+      testState.blocks = [...testState.blocks];
+      testState.messages = [...testState.messages];
+      rerender();
+    });
+    await flush();
+
+    expect(
+      container.querySelector('[data-testid="failed-prompt-retry"]')
+        ?.textContent,
+    ).toBe('user-3');
+  });
+
+  it('drops a known-workspace failed retry when a replacement reuses its local user id', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const firstSend = deferred<void>();
+    mockSessionActions.sendPrompt.mockImplementationOnce(() => {
+      testState.blocks = [{ id: 'user-1', kind: 'user', text: 'hello' }];
+      return firstSend.promise;
+    });
+    const { container, rerender } = renderApp();
+    await flush();
+
+    act(() => {
+      testState.latestChatEditorProps?.onSubmit('hello');
+    });
+    testState.messages = [{ id: 'user-1', role: 'user', content: 'hello' }];
+    await act(async () => {
+      firstSend.reject(new DaemonHttpError(413, {}, 'Prompt too large'));
+      await Promise.resolve();
+    });
+    expect(
+      container.querySelector('[data-testid="failed-prompt-retry"]'),
+    ).not.toBeNull();
+    const retry = testState.latestMessageListProps?.onRetryFailedPrompt;
+
+    act(() => {
+      testState.ownerVersion += 1;
+      testState.blocks = [
+        { id: 'user-1', kind: 'user', text: 'replacement prompt' },
+      ];
+      testState.messages = [
+        { id: 'user-1', role: 'user', content: 'replacement prompt' },
+      ];
+      retry?.();
+      rerender();
+    });
+    await flush();
+
+    expect(
+      container.querySelector('[data-testid="failed-prompt-retry"]'),
+    ).toBeNull();
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops an uncertain failed retry response after a known-workspace transcript replacement', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const firstSend = deferred<void>();
+    const retrySend = deferred<void>();
+    mockSessionActions.sendPrompt
+      .mockImplementationOnce(() => {
+        testState.blocks = [{ id: 'user-1', kind: 'user', text: 'first' }];
+        return firstSend.promise;
+      })
+      .mockReturnValueOnce(retrySend.promise);
+    const { container, rerender } = renderApp();
+    await flush();
+
+    testState.prompt = 'first';
+    await clickSubmit(container);
+    testState.messages = [{ id: 'user-1', role: 'user', content: 'first' }];
+    await act(async () => {
+      firstSend.reject(new DaemonHttpError(413, {}, 'Prompt too large'));
+      await Promise.resolve();
+    });
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="failed-prompt-retry"]')
+        ?.click();
+    });
+    await vi.waitFor(() => {
+      expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(2);
+    });
+    const retryOptions = mockSessionActions.sendPrompt.mock.calls[1]?.[1];
+
+    act(() => {
+      retryOptions?.onAdmissionStarted?.();
+      testState.ownerVersion += 1;
+      testState.blocks = [{ id: 'user-1', kind: 'user', text: 'replacement' }];
+      testState.messages = [
+        { id: 'user-1', role: 'user', content: 'replacement' },
+      ];
+      rerender();
+    });
+    await act(async () => {
+      retrySend.reject(new Error('response lost'));
+      await Promise.resolve();
+    });
+
+    expect(
+      container.querySelector('[data-testid="prompt-admission-unknown"]'),
+    ).toBeNull();
+    expect(warn).not.toHaveBeenCalledWith(
+      '[WebShell] prompt retry admission outcome is unknown',
+      expect.anything(),
+    );
+  });
+
+  it('drops a visible workspace-unknown failed retry after its attachment is replaced', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockConnection.sessionId = 'session-late';
+    mockConnection.workspaceCwd = undefined;
+    const firstSend = deferred<void>();
+    mockSessionActions.sendPrompt.mockImplementationOnce(() => {
+      testState.blocks = [{ id: 'user-1', kind: 'user' }];
+      return firstSend.promise;
+    });
+    const { container, rerender } = renderApp();
+    await flush();
+
+    act(() => {
+      testState.latestChatEditorProps?.onSubmit('hello');
+    });
+    testState.messages = [{ id: 'user-1', role: 'user', content: 'hello' }];
+    await act(async () => {
+      firstSend.reject(new DaemonHttpError(413, {}, 'Prompt too large'));
+      await Promise.resolve();
+    });
+    expect(
+      container.querySelector('[data-testid="failed-prompt-retry"]'),
+    ).not.toBeNull();
+    const retry = testState.latestMessageListProps?.onRetryFailedPrompt;
+
+    act(() => {
+      testState.ownerVersion += 1;
+      rerender();
+    });
+    expect(
+      container.querySelector('[data-testid="failed-prompt-retry"]'),
+    ).toBeNull();
+    act(() => retry?.());
+    await flush();
+
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let an in-flight workspace-unknown failed retry suppress a replacement attachment', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockConnection.sessionId = 'session-late';
+    mockConnection.workspaceCwd = undefined;
+    const firstSend = deferred<void>();
+    const retrySend = deferred<void>();
+    let retryAdmitted: (() => void) | undefined;
+    mockSessionActions.sendPrompt
+      .mockImplementationOnce(() => {
+        testState.blocks = [{ id: 'user-1', kind: 'user' }];
+        return firstSend.promise;
+      })
+      .mockImplementationOnce(
+        (
+          _text: string,
+          options?: {
+            onAdmitted?: () => void;
+          },
+        ) => {
+          retryAdmitted = options?.onAdmitted;
+          return retrySend.promise;
+        },
+      );
+    const { container, rerender } = renderApp();
+    await flush();
+
+    act(() => {
+      testState.latestChatEditorProps?.onSubmit('hello');
+    });
+    testState.messages = [{ id: 'user-1', role: 'user', content: 'hello' }];
+    await act(async () => {
+      firstSend.reject(new DaemonHttpError(413, {}, 'Prompt too large'));
+      await Promise.resolve();
+    });
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="failed-prompt-retry"]')
+        ?.click();
+    });
+    await vi.waitFor(() => {
+      expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(2);
+    });
+
+    act(() => {
+      testState.ownerVersion += 1;
+      testState.streamingState = 'responding';
+      rerender();
+    });
+    act(() => retryAdmitted?.());
+    await act(async () => {
+      retrySend.resolve();
+      await retrySend.promise;
+    });
+    act(() => rerender());
+
+    expect(testState.latestMessageListProps?.isResponding).toBe(true);
+  });
+
+  it('does not revive an old workspace-unknown failure when a replacement reuses its local id', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockConnection.sessionId = 'session-late';
+    mockConnection.workspaceCwd = undefined;
+    const firstSend = deferred<void>();
+    const replacementSend = deferred<void>();
+    mockSessionActions.sendPrompt
+      .mockImplementationOnce(() => {
+        testState.blocks = [{ id: 'user-1', kind: 'user' }];
+        return firstSend.promise;
+      })
+      .mockImplementationOnce(() => {
+        testState.blocks = [{ id: 'user-1', kind: 'user' }];
+        return replacementSend.promise;
+      });
+    const { container, rerender } = renderApp();
+    await flush();
+
+    testState.prompt = 'old';
+    await clickSubmit(container);
+    testState.messages = [{ id: 'user-1', role: 'user', content: 'old' }];
+    await act(async () => {
+      firstSend.reject(new DaemonHttpError(413, {}, 'Prompt too large'));
+      await Promise.resolve();
+    });
+    expect(
+      container.querySelector('[data-testid="failed-prompt-retry"]'),
+    ).not.toBeNull();
+
+    act(() => {
+      testState.ownerVersion += 1;
+      testState.blocks = [];
+      testState.messages = [];
+      rerender();
+    });
+    expect(
+      container.querySelector('[data-testid="failed-prompt-retry"]'),
+    ).toBeNull();
+
+    testState.prompt = 'new';
+    await clickSubmit(container);
+    act(() => {
+      testState.messages = [{ id: 'user-1', role: 'user', content: 'new' }];
+      rerender();
+    });
+
+    expect(
+      container.querySelector('[data-testid="failed-prompt-retry"]'),
+    ).toBeNull();
+    await act(async () => {
+      replacementSend.resolve();
+      await replacementSend.promise;
+    });
+  });
+
+  it('drops a workspace-unknown failed-prompt retry when its owner changes', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const retryApproval = deferred<void>();
+    let admissionCount = 0;
+    const onSubmitBefore = vi.fn(() => {
+      admissionCount += 1;
+      return admissionCount === 2 ? retryApproval.promise : Promise.resolve();
+    });
+    mockConnection.sessionId = 'session-late';
+    mockConnection.workspaceCwd = undefined;
+    const firstSend = deferred<void>();
+    mockSessionActions.sendPrompt.mockImplementationOnce(() => {
+      testState.blocks = [{ id: 'user-1', kind: 'user' }];
+      return firstSend.promise;
+    });
+    const { container, rerender } = renderApp({ onSubmitBefore });
+    await flush();
+
+    act(() => {
+      testState.latestChatEditorProps?.onSubmit('hello');
+    });
+    testState.messages = [{ id: 'user-1', role: 'user', content: 'hello' }];
+    await act(async () => {
+      firstSend.reject(new DaemonHttpError(413, {}, 'Prompt too large'));
+      await Promise.resolve();
+    });
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="failed-prompt-retry"]')
+        ?.click();
+      rerender({ desiredSessionTargetPending: true, onSubmitBefore });
+    });
+    act(() => {
+      mockConnection.workspaceCwd = '/tmp/project-2';
+      testState.blocks = [{ id: 'user-1', kind: 'user' }];
+      testState.messages = [
+        { id: 'user-1', role: 'user', content: 'other owner' },
+      ];
+      testState.ownerVersion += 1;
+      rerender({ desiredSessionTargetPending: false, onSubmitBefore });
+    });
+    await act(async () => {
+      retryApproval.resolve();
+      await retryApproval.promise;
+    });
+
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(1);
+    expect(
+      container.querySelector('[data-testid="failed-prompt-retry"]'),
+    ).toBeNull();
+    act(() => {
+      mockConnection.workspaceCwd = '/tmp/project';
+      testState.blocks = [{ id: 'user-1', kind: 'user' }];
+      testState.messages = [{ id: 'user-1', role: 'user', content: 'hello' }];
+      testState.ownerVersion += 1;
+      rerender({ onSubmitBefore });
+    });
+    await flush();
+
+    expect(
+      container.querySelector('[data-testid="failed-prompt-retry"]'),
+    ).toBeNull();
+  });
+
   it('tracks the first failed message with the lazily allocated session id', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
     mockConnection.sessionId = undefined;
     mockSessionActions.createSession.mockResolvedValueOnce({
       sessionId: 'session-created',
+    });
+    mockSessionActions.attachSession.mockImplementationOnce(async () => {
+      testState.ownerVersion += 1;
     });
     const firstSend = deferred<void>();
     mockSessionActions.sendPrompt.mockImplementationOnce(() => {
@@ -15637,7 +17478,7 @@ describe('App prompt send failure retry', () => {
     ).toBe('u1');
   });
 
-  it('restores a failed-prompt retry after navigation completes during admission', async () => {
+  it('restores a failed-prompt retry after an empty transcript returns', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
     let approveRetry: (() => void) | undefined;
     let admissionCount = 0;
@@ -15649,8 +17490,12 @@ describe('App prompt send failure retry', () => {
       });
     });
     const firstSend = deferred<void>();
+    mockStore.appendLocalUserMessage.mockImplementationOnce(() => {
+      testState.blocks = [{ id: 'user-1', kind: 'user', text: 'hello' }];
+      testState.messages = [{ id: 'user-1', role: 'user', content: 'hello' }];
+    });
     mockSessionActions.sendPrompt.mockImplementationOnce(() => {
-      testState.blocks = [{ id: 'u1', kind: 'user' }];
+      testState.blocks = [{ id: 'user-1', kind: 'user', text: 'hello' }];
       return firstSend.promise;
     });
     const { container, rerender } = renderApp({ onSubmitBefore });
@@ -15659,7 +17504,101 @@ describe('App prompt send failure retry', () => {
     act(() => {
       testState.latestChatEditorProps?.onSubmit('hello');
     });
-    testState.messages = [{ id: 'u1', role: 'user', content: 'hello' }];
+    testState.messages = [{ id: 'user-1', role: 'user', content: 'hello' }];
+    await act(async () => {
+      firstSend.reject(new DaemonHttpError(413, {}, 'Prompt too large'));
+      await Promise.resolve();
+    });
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="failed-prompt-retry"]')
+        ?.click();
+      rerender({ desiredSessionTargetPending: true, onSubmitBefore });
+    });
+    act(() => {
+      mockConnection.workspaceCwd = '/tmp/project-2';
+      testState.blocks = [];
+      testState.messages = [];
+      testState.ownerVersion += 1;
+      rerender({ desiredSessionTargetPending: false, onSubmitBefore });
+    });
+    await act(async () => {
+      approveRetry?.();
+      await Promise.resolve();
+    });
+
+    act(() => {
+      mockConnection.workspaceCwd = '/tmp/project';
+      testState.blocks = [];
+      testState.messages = [];
+      testState.ownerVersion += 1;
+      rerender({ onSubmitBefore });
+    });
+    act(() => {
+      rerender({ onSubmitBefore });
+    });
+    await flush();
+
+    expect(mockStore.appendLocalUserMessage).toHaveBeenCalledWith(
+      'hello',
+      undefined,
+      undefined,
+    );
+    expect(
+      container.querySelector('[data-testid="failed-prompt-retry"]')
+        ?.textContent,
+    ).toBe('user-1');
+  });
+
+  it('restores a failed-prompt retry after switching away during admission', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    let approveRetry: (() => void) | undefined;
+    let admissionCount = 0;
+    const onSubmitBefore = vi.fn(() => {
+      admissionCount += 1;
+      if (admissionCount === 1) return Promise.resolve();
+      return new Promise<void>((resolve) => {
+        approveRetry = resolve;
+      });
+    });
+    const firstSend = deferred<void>();
+    const originalAnchor = {
+      id: 'user-2',
+      kind: 'user',
+      text: 'original anchor',
+      sourceRecordIds: ['record-anchor'],
+    };
+    testState.blocks = [originalAnchor];
+    testState.messages = [
+      { id: 'user-2', role: 'user', content: 'original anchor' },
+    ];
+    mockStore.appendLocalUserMessage.mockImplementationOnce(() => {
+      testState.blocks = [
+        ...testState.blocks,
+        { id: 'user-10', kind: 'user', text: 'hello' },
+      ];
+      testState.messages = [
+        ...testState.messages,
+        { id: 'user-10', role: 'user', content: 'hello' },
+      ];
+    });
+    mockSessionActions.sendPrompt.mockImplementationOnce(() => {
+      testState.blocks = [
+        originalAnchor,
+        { id: 'user-3', kind: 'user', text: 'hello' },
+      ];
+      return firstSend.promise;
+    });
+    const { container, rerender } = renderApp({ onSubmitBefore });
+    await flush();
+
+    act(() => {
+      testState.latestChatEditorProps?.onSubmit('hello');
+    });
+    testState.messages = [
+      { id: 'user-2', role: 'user', content: 'original anchor' },
+      { id: 'user-3', role: 'user', content: 'hello' },
+    ];
     await act(async () => {
       firstSend.reject(new DaemonHttpError(413, {}, 'Prompt too large'));
       await Promise.resolve();
@@ -15676,10 +17615,21 @@ describe('App prompt send failure retry', () => {
     expect(onSubmitBefore).toHaveBeenCalledTimes(2);
     expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(1);
 
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="load-session"]')
+        ?.click();
+      await Promise.resolve();
+    });
     act(() => {
       rerender({ desiredSessionTargetPending: true, onSubmitBefore });
     });
     act(() => {
+      mockConnection.sessionId = 'session-1';
+      mockConnection.workspaceCwd = '/tmp/project-2';
+      testState.blocks = [];
+      testState.messages = [];
+      testState.ownerVersion += 1;
       rerender({ desiredSessionTargetPending: false, onSubmitBefore });
     });
     await act(async () => {
@@ -15689,9 +17639,135 @@ describe('App prompt send failure retry', () => {
 
     expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(1);
     expect(
+      container.querySelector('[data-testid="failed-prompt-retry"]'),
+    ).toBeNull();
+
+    act(() => {
+      mockConnection.sessionId = 'session-1';
+      mockConnection.workspaceCwd = '/tmp/project';
+      testState.blocks = [
+        {
+          id: 'user-1',
+          kind: 'user',
+          text: 'original anchor',
+          sourceRecordIds: ['record-anchor'],
+        },
+      ];
+      testState.messages = [
+        { id: 'user-1', role: 'user', content: 'original anchor' },
+      ];
+      testState.ownerVersion += 1;
+      rerender({ onSubmitBefore });
+    });
+    expect(mockStore.appendLocalUserMessage).toHaveBeenCalledWith(
+      'hello',
+      undefined,
+      undefined,
+    );
+    act(() => {
+      rerender({ onSubmitBefore });
+    });
+    await flush();
+
+    expect(
       container.querySelector('[data-testid="failed-prompt-retry"]')
         ?.textContent,
-    ).toBe('u1');
+    ).toBe('user-10');
+    const allowRetry = vi.fn().mockResolvedValue(undefined);
+    rerender({ onSubmitBefore: allowRetry });
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="failed-prompt-retry"]')
+        ?.click();
+      await Promise.resolve();
+    });
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(2);
+    expect(mockSessionActions.sendPrompt).toHaveBeenLastCalledWith(
+      'hello',
+      expect.objectContaining({ optimisticUserMessage: false }),
+    );
+  });
+
+  it('drops a cancelled failed-prompt retry when its transcript anchor changes', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    let approveRetry: (() => void) | undefined;
+    let admissionCount = 0;
+    const onSubmitBefore = vi.fn(() => {
+      admissionCount += 1;
+      if (admissionCount === 1) return Promise.resolve();
+      return new Promise<void>((resolve) => {
+        approveRetry = resolve;
+      });
+    });
+    const firstSend = deferred<void>();
+    const originalAnchor = {
+      id: 'user-1',
+      kind: 'user',
+      text: 'original anchor',
+    };
+    testState.blocks = [originalAnchor];
+    testState.messages = [
+      { id: 'user-1', role: 'user', content: 'original anchor' },
+    ];
+    mockSessionActions.sendPrompt.mockImplementationOnce(() => {
+      testState.blocks = [
+        originalAnchor,
+        { id: 'user-2', kind: 'user', text: 'hello' },
+      ];
+      return firstSend.promise;
+    });
+    const { container, rerender } = renderApp({ onSubmitBefore });
+    await flush();
+
+    act(() => {
+      testState.latestChatEditorProps?.onSubmit('hello');
+    });
+    testState.messages = [
+      { id: 'user-1', role: 'user', content: 'original anchor' },
+      { id: 'user-2', role: 'user', content: 'hello' },
+    ];
+    await act(async () => {
+      firstSend.reject(new DaemonHttpError(413, {}, 'Prompt too large'));
+      await Promise.resolve();
+    });
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="failed-prompt-retry"]')
+        ?.click();
+      rerender({ desiredSessionTargetPending: true, onSubmitBefore });
+    });
+    act(() => {
+      mockConnection.workspaceCwd = '/tmp/project-2';
+      testState.blocks = [];
+      testState.messages = [];
+      testState.ownerVersion += 1;
+      rerender({ desiredSessionTargetPending: false, onSubmitBefore });
+    });
+    await act(async () => {
+      approveRetry?.();
+      await Promise.resolve();
+    });
+
+    act(() => {
+      mockConnection.workspaceCwd = '/tmp/project';
+      testState.blocks = [
+        { id: 'user-1', kind: 'user', text: 'replacement anchor' },
+        { id: 'user-2', kind: 'user', text: 'unrelated message' },
+      ];
+      testState.messages = [
+        { id: 'user-1', role: 'user', content: 'replacement anchor' },
+        { id: 'user-2', role: 'user', content: 'unrelated message' },
+      ];
+      testState.ownerVersion += 1;
+      rerender({ onSubmitBefore });
+    });
+    await flush();
+
+    expect(mockStore.appendLocalUserMessage).not.toHaveBeenCalled();
+    expect(
+      container.querySelector('[data-testid="failed-prompt-retry"]'),
+    ).toBeNull();
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledOnce();
   });
 
   it('restores the retry action when resending fails again', async () => {
@@ -15764,9 +17840,21 @@ describe('App prompt send failure retry', () => {
     const firstSend = deferred<void>();
     const retrySend = deferred<void>();
     let retryAdmitted: (() => void) | undefined;
+    const originalUser = {
+      id: 'u1',
+      kind: 'user',
+      text: 'hello',
+      sourceRecordIds: ['record-1'],
+    } as const;
+    const replayedUser = {
+      id: 'u2',
+      kind: 'user',
+      text: 'hello',
+      sourceRecordIds: ['record-1'],
+    } as const;
     mockSessionActions.sendPrompt
       .mockImplementationOnce(() => {
-        testState.blocks = [{ id: 'u1', kind: 'user' }];
+        testState.blocks = [originalUser];
         return firstSend.promise;
       })
       .mockImplementationOnce(
@@ -15791,15 +17879,33 @@ describe('App prompt send failure retry', () => {
       firstSend.reject(new DaemonHttpError(413, {}, 'Prompt too large'));
       await Promise.resolve();
     });
-    act(() =>
-      container
-        .querySelector<HTMLButtonElement>('[data-testid="failed-prompt-retry"]')
-        ?.click(),
-    );
-
+    await flush();
+    expect(
+      container.querySelector('[data-testid="failed-prompt-retry"]'),
+    ).not.toBeNull();
     act(() => {
       testState.ownerVersion += 1;
+      testState.blocks = [replayedUser];
+      testState.messages = [{ id: 'u2', role: 'user', content: 'hello' }];
       rerender();
+    });
+    await flush();
+    expect(
+      container.querySelector('[data-testid="failed-prompt-retry"]')
+        ?.textContent,
+    ).toBe('u2');
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="failed-prompt-retry"]')
+        ?.click();
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => {
+      expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(2);
+    });
+    expect(retryAdmitted).toBeTypeOf('function');
+
+    act(() => {
       retryAdmitted?.();
     });
     await act(async () => {

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -489,7 +489,10 @@ vi.mock('@qwen-code/sdk/daemon', () => ({
     }
   },
   DAEMON_GOAL_STATUS_SENTINEL_PREFIX: 'qwen-goal-status:',
-  isDaemonTurnError: () => false,
+  isDaemonTurnError: (error: unknown) =>
+    typeof error === 'object' &&
+    error !== null &&
+    (error as { _daemonTurnError?: unknown })._daemonTurnError === true,
 }));
 
 vi.mock('./hooks/useMessages', () => ({
@@ -11242,8 +11245,6 @@ describe('App session callbacks', () => {
     const callbackStarted = deferred<void>();
     const callbackFinished = deferred<void>();
     mockSessionActions.createSession.mockImplementation(async () => {
-      mockConnection.sessionId = 'session-created';
-      mockConnection.workspaceCwd = '/workspace';
       testState.ownerVersion += 1;
       return { sessionId: 'session-created' };
     });
@@ -11270,6 +11271,12 @@ describe('App session callbacks', () => {
     await vi.waitFor(() => {
       expect(mockSessionActions.sendPrompt).toHaveBeenCalledOnce();
     });
+    act(() => {
+      mockConnection.sessionId = 'session-created';
+      mockConnection.workspaceCwd = '/workspace';
+      rerender({ onSessionCreated, onSubmitBefore });
+    });
+    await flush();
 
     act(() => {
       testState.blocks = [
@@ -11962,6 +11969,117 @@ describe('App session callbacks', () => {
     );
   });
 
+  it('preserves the newer cancelled retry when admissions settle out of order', async () => {
+    const oldRetryApproval = deferred<void>();
+    const newerRetryApproval = deferred<void>();
+    let admissionCount = 0;
+    const onSubmitBefore = vi.fn(() => {
+      admissionCount += 1;
+      if (admissionCount === 2) return oldRetryApproval.promise;
+      if (admissionCount === 4) return newerRetryApproval.promise;
+      return Promise.resolve();
+    });
+    const oldError = {
+      kind: 'error',
+      source: 'turn_error',
+      id: 'turn-error-old',
+      promptId: 'prompt-old',
+    } as const;
+    const newerError = {
+      kind: 'error',
+      source: 'turn_error',
+      id: 'turn-error-newer',
+      promptId: 'prompt-newer',
+    } as const;
+    const { container, rerender } = renderApp({ onSubmitBefore });
+    await flush();
+
+    testState.prompt = 'first';
+    await clickSubmit(container);
+    act(() => {
+      testState.blocks = [oldError];
+      rerender({ onSubmitBefore });
+    });
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+        ?.click();
+    });
+    expect(onSubmitBefore).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      rerender({ desiredSessionTargetPending: true, onSubmitBefore });
+    });
+    act(() => {
+      mockConnection.sessionId = 'session-2';
+      mockConnection.workspaceCwd = '/tmp/project-2';
+      testState.blocks = [];
+      testState.ownerVersion += 1;
+      rerender({ desiredSessionTargetPending: false, onSubmitBefore });
+    });
+    act(() => {
+      mockConnection.sessionId = 'session-1';
+      mockConnection.workspaceCwd = '/tmp/project';
+      testState.blocks = [];
+      testState.ownerVersion += 1;
+      rerender({ onSubmitBefore });
+    });
+
+    testState.prompt = 'newer';
+    await clickSubmit(container);
+    act(() => {
+      testState.blocks = [newerError];
+      rerender({ onSubmitBefore });
+    });
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+        ?.click();
+    });
+    expect(onSubmitBefore).toHaveBeenCalledTimes(4);
+
+    act(() => {
+      rerender({ desiredSessionTargetPending: true, onSubmitBefore });
+    });
+    act(() => {
+      mockConnection.sessionId = 'session-2';
+      mockConnection.workspaceCwd = '/tmp/project-2';
+      testState.blocks = [];
+      testState.ownerVersion += 1;
+      rerender({ desiredSessionTargetPending: false, onSubmitBefore });
+    });
+    await act(async () => {
+      newerRetryApproval.resolve();
+      await newerRetryApproval.promise;
+    });
+    await act(async () => {
+      oldRetryApproval.resolve();
+      await oldRetryApproval.promise;
+    });
+
+    act(() => {
+      mockConnection.sessionId = 'session-1';
+      mockConnection.workspaceCwd = '/tmp/project';
+      testState.blocks = [newerError];
+      testState.ownerVersion += 1;
+      rerender({ onSubmitBefore });
+    });
+    await flush();
+
+    expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+        ?.click();
+      await Promise.resolve();
+    });
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(3);
+    expect(mockSessionActions.sendPrompt).toHaveBeenLastCalledWith(
+      'newer',
+      expect.objectContaining({ retry: true }),
+    );
+  });
+
   it('allows manual retry after a model stream interrupted turn error', async () => {
     const retrySend = deferred<void>();
     const { container, rerender } = renderApp();
@@ -12032,6 +12150,139 @@ describe('App session callbacks', () => {
       rerender();
       await Promise.resolve();
     });
+  });
+
+  it.each([
+    ['a fresh prompt id', 'prompt-2'],
+    ['a reused prompt id', 'prompt-1'],
+  ])(
+    'reoffers a turn-error retry when the retried turn fails with %s',
+    async (_label, nextPromptId) => {
+      const retrySend = deferred<void>();
+      mockSessionActions.sendPrompt
+        .mockResolvedValueOnce(undefined)
+        .mockReturnValueOnce(retrySend.promise)
+        .mockResolvedValueOnce(undefined);
+      const { container, rerender } = renderApp();
+      await flush();
+
+      testState.prompt = 'recover this stream';
+      await clickSubmit(container);
+      act(() => {
+        testState.blocks = [
+          {
+            kind: 'error',
+            source: 'turn_error',
+            id: 'turn-error-1',
+            promptId: 'prompt-1',
+          },
+        ];
+        rerender();
+      });
+      act(() => {
+        container
+          .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+          ?.click();
+      });
+      await vi.waitFor(() => {
+        expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(2);
+      });
+      const retryOptions = mockSessionActions.sendPrompt.mock.calls[1]?.[1];
+
+      act(() => {
+        retryOptions?.onAdmissionStarted?.();
+        retryOptions?.onAdmitted?.();
+      });
+      await act(async () => {
+        retrySend.reject(
+          Object.assign(new Error('retried turn failed'), {
+            _daemonTurnError: true,
+          }),
+        );
+        await Promise.resolve();
+      });
+      expect(container.querySelector('[data-testid="retry"]')).toBeNull();
+      act(() => {
+        testState.blocks = [
+          {
+            kind: 'error',
+            source: 'turn_error',
+            id: 'turn-error-1',
+            promptId: 'prompt-1',
+          },
+          {
+            kind: 'error',
+            source: 'turn_error',
+            id: 'turn-error-2',
+            promptId: nextPromptId,
+          },
+        ];
+        rerender();
+      });
+      await flush();
+
+      expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
+      act(() => {
+        container
+          .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+          ?.click();
+      });
+      await flush();
+      expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(3);
+      expect(mockSessionActions.sendPrompt).toHaveBeenLastCalledWith(
+        'recover this stream',
+        expect.objectContaining({ retry: true }),
+      );
+    },
+  );
+
+  it('restores a turn-error retry when resend fails before admission starts', async () => {
+    const { container, rerender } = renderApp();
+    await flush();
+
+    testState.prompt = 'recover this stream';
+    await clickSubmit(container);
+    act(() => {
+      testState.blocks = [
+        { kind: 'error', source: 'turn_error', id: 'turn-error-network' },
+      ];
+      rerender();
+    });
+    mockSessionActions.sendPrompt.mockRejectedValueOnce(
+      new TypeError('network unavailable'),
+    );
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+        ?.click();
+    });
+    await flush();
+
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(2);
+    expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
+  });
+
+  it('keeps a turn-error retry visible through background notifications', async () => {
+    const { container, rerender } = renderApp();
+    await flush();
+
+    testState.prompt = 'recover this stream';
+    await clickSubmit(container);
+    act(() => {
+      testState.blocks = [
+        { kind: 'error', source: 'turn_error', id: 'turn-error-background' },
+        {
+          id: 'background-1',
+          kind: 'user',
+          text: 'Background task completed',
+          meta: { source: 'background_notification' },
+        },
+      ];
+      rerender();
+    });
+
+    expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
   });
 
   it('preserves the turn-error retry while session writes are blocked', async () => {
@@ -16900,6 +17151,90 @@ describe('App prompt send failure retry', () => {
     );
   });
 
+  it('keeps a failed-prompt retry visible through background notifications', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const firstSend = deferred<void>();
+    mockSessionActions.sendPrompt.mockImplementationOnce(() => {
+      testState.blocks = [{ id: 'u1', kind: 'user', text: 'hello' }];
+      return firstSend.promise;
+    });
+    const { container, rerender } = renderApp();
+    await flush();
+
+    act(() => {
+      testState.latestChatEditorProps?.onSubmit('hello');
+    });
+    testState.messages = [{ id: 'u1', role: 'user', content: 'hello' }];
+    await act(async () => {
+      firstSend.reject(new DaemonHttpError(413, {}, 'Prompt too large'));
+      await Promise.resolve();
+    });
+    expect(
+      container.querySelector('[data-testid="failed-prompt-retry"]'),
+    ).not.toBeNull();
+
+    act(() => {
+      testState.blocks = [
+        { id: 'u1', kind: 'user', text: 'hello' },
+        {
+          id: 'background-1',
+          kind: 'user',
+          text: 'Background task completed',
+          meta: { source: 'background_notification' },
+        },
+      ];
+      testState.messages = [
+        { id: 'u1', role: 'user', content: 'hello' },
+        {
+          id: 'background-1',
+          role: 'system',
+          content: 'Background task completed',
+          source: 'background_notification',
+        },
+      ];
+      rerender();
+    });
+    await flush();
+
+    expect(
+      container.querySelector('[data-testid="failed-prompt-retry"]')
+        ?.textContent,
+    ).toBe('u1');
+  });
+
+  it('keeps a failed-prompt retry when its optimistic block is cloned', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const firstSend = deferred<void>();
+    const optimisticUser = { id: 'u1', kind: 'user', text: 'hello' } as const;
+    mockSessionActions.sendPrompt.mockImplementationOnce(() => {
+      testState.blocks = [optimisticUser];
+      return firstSend.promise;
+    });
+    const { container, rerender } = renderApp();
+    await flush();
+
+    act(() => {
+      testState.latestChatEditorProps?.onSubmit('hello');
+    });
+    act(() => {
+      testState.blocks = [{ ...optimisticUser, text: 'hello echoed' }];
+      testState.messages = [
+        { id: 'u1', role: 'user', content: 'hello echoed' },
+      ];
+      rerender();
+    });
+    await act(async () => {
+      firstSend.reject(new DaemonHttpError(413, {}, 'Prompt too large'));
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(
+      container.querySelector('[data-testid="failed-prompt-retry"]')
+        ?.textContent,
+    ).toBe('u1');
+  });
+
   it('keeps a failed-prompt retry when its workspace becomes available', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
     mockConnection.sessionId = 'session-late';
@@ -17686,6 +18021,80 @@ describe('App prompt send failure retry', () => {
       'hello',
       expect.objectContaining({ optimisticUserMessage: false }),
     );
+  });
+
+  it('restores a failed-prompt retry onto the replayed stable user record', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    let approveRetry: (() => void) | undefined;
+    let admissionCount = 0;
+    const onSubmitBefore = vi.fn(() => {
+      admissionCount += 1;
+      if (admissionCount === 1) return Promise.resolve();
+      return new Promise<void>((resolve) => {
+        approveRetry = resolve;
+      });
+    });
+    const firstSend = deferred<void>();
+    const failedUser = {
+      id: 'user-2',
+      kind: 'user',
+      text: 'hello',
+      sourceRecordIds: ['record-failed'],
+    } as const;
+    mockSessionActions.sendPrompt.mockImplementationOnce(() => {
+      testState.blocks = [failedUser];
+      return firstSend.promise;
+    });
+    const { container, rerender } = renderApp({ onSubmitBefore });
+    await flush();
+
+    act(() => {
+      testState.latestChatEditorProps?.onSubmit('hello');
+    });
+    testState.messages = [{ id: 'user-2', role: 'user', content: 'hello' }];
+    await act(async () => {
+      firstSend.reject(new DaemonHttpError(413, {}, 'Prompt too large'));
+      await Promise.resolve();
+    });
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="failed-prompt-retry"]')
+        ?.click();
+      rerender({ desiredSessionTargetPending: true, onSubmitBefore });
+    });
+    act(() => {
+      mockConnection.workspaceCwd = '/tmp/project-2';
+      testState.blocks = [];
+      testState.messages = [];
+      testState.ownerVersion += 1;
+      rerender({ desiredSessionTargetPending: false, onSubmitBefore });
+    });
+    await act(async () => {
+      approveRetry?.();
+      await Promise.resolve();
+    });
+    act(() => {
+      mockConnection.workspaceCwd = '/tmp/project';
+      testState.blocks = [
+        {
+          id: 'user-9',
+          kind: 'user',
+          text: 'rewritten display text',
+          sourceRecordIds: ['record-failed'],
+        },
+      ];
+      testState.messages = [
+        { id: 'user-9', role: 'user', content: 'rewritten display text' },
+      ];
+      testState.ownerVersion += 1;
+      rerender({ onSubmitBefore });
+    });
+    await flush();
+
+    expect(
+      container.querySelector('[data-testid="failed-prompt-retry"]')
+        ?.textContent,
+    ).toBe('user-9');
   });
 
   it('drops a cancelled failed-prompt retry when its transcript anchor changes', async () => {

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -497,14 +497,28 @@ interface SendPromptOptionsWithRetry {
 interface OptimisticUserMessage {
   sessionId: string;
   messageId: string;
+  identity: TranscriptUserMessageIdentity;
+  previousIdentity?: TranscriptUserMessageIdentity;
+  owner: CancelledRetryOwner;
 }
 
 interface FailedPrompt {
   sessionId: string;
   messageId: string;
+  identity: TranscriptUserMessageIdentity;
+  previousIdentity?: TranscriptUserMessageIdentity;
   text: string;
   images?: PromptImage[];
   inputAnnotations?: DaemonInputAnnotation[];
+  owner: CancelledRetryOwner;
+}
+
+interface TranscriptUserMessageIdentity {
+  block: DaemonTranscriptBlock;
+}
+
+interface TranscriptTurnErrorIdentity {
+  block: DaemonTranscriptBlock;
 }
 
 interface FailedPromptRetry {
@@ -513,6 +527,57 @@ interface FailedPromptRetry {
   startedAt: number;
   admitted: boolean;
   settled: boolean;
+  owner: CancelledRetryOwner;
+  transcriptIdentity:
+    | { kind: 'failed-prompt'; identity: TranscriptUserMessageIdentity }
+    | { kind: 'turn-error'; identity: TranscriptTurnErrorIdentity };
+}
+
+type CancelledRetryState =
+  | {
+      kind: 'failed-prompt';
+      failed: FailedPrompt;
+    }
+  | {
+      kind: 'turn-error';
+      errorId: string;
+      identity: TranscriptTurnErrorIdentity;
+      text: string;
+      images?: PromptImage[];
+      inputAnnotations?: DaemonInputAnnotation[];
+      previousRetriedTurnErrorId: string | null;
+      previousShowRetryHint: boolean;
+    };
+
+type CancelledRetryRestoreResult = 'restored' | 'pending' | 'invalid';
+
+interface CancelledRetryOwner {
+  sessionId?: string;
+  workspaceCwd?: string;
+  sessionKey?: string;
+  sourceVersion: number;
+  snapshot: DaemonSessionOwnerSnapshot;
+}
+
+function retryOwnerMatchesCurrent(
+  owner: CancelledRetryOwner,
+  sessionId: string | undefined,
+  workspaceCwd: string | undefined,
+  sourceVersion: number,
+): boolean {
+  const workspaceMatches =
+    (owner.workspaceCwd !== undefined && owner.workspaceCwd === workspaceCwd) ||
+    owner.snapshot.isCurrent();
+  return (
+    owner.sessionId === sessionId &&
+    owner.sourceVersion === sourceVersion &&
+    workspaceMatches
+  );
+}
+
+interface CancelledRetryEntry {
+  owner?: CancelledRetryOwner;
+  state: CancelledRetryState;
 }
 
 interface UnknownPromptAdmission {
@@ -527,11 +592,108 @@ interface UnknownPromptAdmission {
 function getLatestUserBlockId(
   blocks: readonly DaemonTranscriptBlock[],
 ): string | undefined {
+  return getLatestUserBlock(blocks)?.id;
+}
+
+function getLatestUserBlock(
+  blocks: readonly DaemonTranscriptBlock[],
+): DaemonTranscriptBlock | undefined {
   for (let index = blocks.length - 1; index >= 0; index -= 1) {
     const block = blocks[index];
-    if (block?.kind === 'user') return block.id;
+    if (block?.kind === 'user') return block;
   }
   return undefined;
+}
+
+function matchesUserMessageIdentity(
+  block: DaemonTranscriptBlock | undefined,
+  identity: TranscriptUserMessageIdentity | undefined,
+): boolean {
+  if (!identity) return block === undefined;
+  if (!block || block.kind !== 'user' || identity.block.kind !== 'user') {
+    return false;
+  }
+  if (block === identity.block) return true;
+  const expectedRecords = identity.block.sourceRecordIds;
+  const currentRecords = block.sourceRecordIds;
+  return (
+    expectedRecords !== undefined &&
+    expectedRecords.length > 0 &&
+    currentRecords !== undefined &&
+    currentRecords.length === expectedRecords.length &&
+    currentRecords.every((record, index) => record === expectedRecords[index])
+  );
+}
+
+function findUserMessageByIdentity(
+  blocks: readonly DaemonTranscriptBlock[],
+  identity: TranscriptUserMessageIdentity,
+): DaemonTranscriptBlock | undefined {
+  for (let index = blocks.length - 1; index >= 0; index -= 1) {
+    const block = blocks[index];
+    if (block?.kind === 'user' && matchesUserMessageIdentity(block, identity)) {
+      return block;
+    }
+  }
+  return undefined;
+}
+
+function getLogicalSessionKey(
+  sessionId: string | undefined,
+  workspaceCwd: string | undefined,
+): string | undefined {
+  return sessionId ? `${workspaceCwd ?? ''}\0${sessionId}` : undefined;
+}
+
+function getRetryableTurnError(
+  blocks: readonly DaemonTranscriptBlock[],
+): DaemonTranscriptBlock | undefined {
+  for (let i = blocks.length - 1; i >= 0; i--) {
+    const block = blocks[i];
+    if (block?.kind === 'user') break;
+    if (block?.kind === 'error' && block.source === 'turn_error') {
+      return block;
+    }
+    if (block?.kind !== 'debug') break;
+  }
+  return undefined;
+}
+
+function matchesTurnErrorIdentity(
+  block: DaemonTranscriptBlock | undefined,
+  identity: TranscriptTurnErrorIdentity,
+): boolean {
+  if (
+    !block ||
+    block.kind !== 'error' ||
+    block.source !== 'turn_error' ||
+    identity.block.kind !== 'error' ||
+    identity.block.source !== 'turn_error'
+  ) {
+    return false;
+  }
+  if (block === identity.block) return true;
+  const expectedPromptId = identity.block.promptId;
+  if (expectedPromptId) return block.promptId === expectedPromptId;
+  return (
+    identity.block.eventId !== undefined &&
+    block.eventId === identity.block.eventId
+  );
+}
+
+function retryTranscriptIdentityMatches(
+  blocks: readonly DaemonTranscriptBlock[],
+  transcriptIdentity: FailedPromptRetry['transcriptIdentity'],
+): boolean {
+  return transcriptIdentity.kind === 'failed-prompt'
+    ? matchesUserMessageIdentity(
+        getLatestUserBlock(blocks),
+        transcriptIdentity.identity,
+      )
+    : matchesTurnErrorIdentity(
+        getRetryableTurnError(blocks),
+        transcriptIdentity.identity,
+      );
 }
 
 type GoalStatusTranscriptBlock = DaemonTranscriptBlock & {
@@ -1883,9 +2045,10 @@ export function App({
   const store = useTranscriptStore();
   const blocks = useAnimationFrameTranscriptBlocks();
   const connection = useConnection();
-  const logicalSessionKey = connection.sessionId
-    ? `${connection.workspaceCwd ?? ''}\0${connection.sessionId}`
-    : undefined;
+  const logicalSessionKey = getLogicalSessionKey(
+    connection.sessionId,
+    connection.workspaceCwd,
+  );
   const sessionWriteBlocked =
     desiredSessionTargetPending ||
     connection.sessionTransition?.phase === 'queued' ||
@@ -1896,6 +2059,13 @@ export function App({
     sessionWriteBlockGenerationRef.current += 1;
   }
   sessionWriteBlockedRef.current = sessionWriteBlocked;
+  const appMountedRef = useRef(true);
+  useLayoutEffect(() => {
+    appMountedRef.current = true;
+    return () => {
+      appMountedRef.current = false;
+    };
+  }, []);
   const sessionOwnerGuard = useDaemonSessionOwnerGuard();
   const transcriptHistory = useTranscriptHistory();
   const workspace = useWorkspace();
@@ -2281,6 +2451,10 @@ export function App({
   const failedPromptRef = useRef<FailedPrompt | null>(failedPrompt);
   const [failedPromptRetry, setFailedPromptRetry] =
     useState<FailedPromptRetry | null>(null);
+  const cancelledRetryStatesRef = useRef(
+    new Map<string, CancelledRetryEntry[]>(),
+  );
+  const [cancelledRetryRevision, setCancelledRetryRevision] = useState(0);
   const [unknownPromptAdmission, setUnknownPromptAdmission] =
     useState<UnknownPromptAdmission | null>(null);
   const unknownPromptAdmissionRef = useRef<UnknownPromptAdmission | null>(null);
@@ -2295,11 +2469,40 @@ export function App({
     failedPromptRef.current = next;
     setFailedPrompt(next);
   }, []);
+  const failedPromptOwnerRef = useRef<{
+    sessionId?: string;
+    workspaceCwd?: string;
+    snapshot: DaemonSessionOwnerSnapshot;
+  }>({
+    sessionId: connection.sessionId,
+    workspaceCwd: connection.workspaceCwd,
+    snapshot: sessionOwnerGuard.capture(),
+  });
   useLayoutEffect(() => {
+    const previousOwner = failedPromptOwnerRef.current;
+    failedPromptOwnerRef.current = {
+      sessionId: connection.sessionId,
+      workspaceCwd: connection.workspaceCwd,
+      snapshot: sessionOwnerGuard.capture(),
+    };
+    if (
+      previousOwner.sessionId === connection.sessionId &&
+      previousOwner.workspaceCwd === undefined &&
+      connection.workspaceCwd !== undefined &&
+      previousOwner.snapshot.isCurrent()
+    ) {
+      return;
+    }
     updateFailedPrompt(null);
     setFailedPromptRetry(null);
     updateUnknownPromptAdmission(null);
-  }, [logicalSessionKey, updateFailedPrompt, updateUnknownPromptAdmission]);
+  }, [
+    connection.sessionId,
+    connection.workspaceCwd,
+    sessionOwnerGuard,
+    updateFailedPrompt,
+    updateUnknownPromptAdmission,
+  ]);
   const [recapMessage, setRecapMessage] = useState<LocalAnchoredMessage | null>(
     null,
   );
@@ -2342,19 +2545,46 @@ export function App({
   useEffect(() => {
     const failed = failedPromptRef.current;
     if (!failed) return;
-    const failedIndex = displayMessages.findIndex(
-      (message) => message.id === failed.messageId,
+    const currentFailedBlock = findUserMessageByIdentity(
+      store.getSnapshot().blocks,
+      failed.identity,
     );
+    const failedBlock = findUserMessageByIdentity(blocks, failed.identity);
+    if (failed.sessionId !== connection.sessionId || !currentFailedBlock) {
+      updateFailedPrompt(null);
+      return;
+    }
+    if (!failedBlock) return;
+    const failedIndex = displayMessages.findIndex(
+      (message) => message.id === failedBlock.id,
+    );
+    if (failedIndex < 0) return;
     if (
-      failed.sessionId !== connection.sessionId ||
-      failedIndex < 0 ||
       displayMessages
         .slice(failedIndex + 1)
         .some((message) => message.role === 'user')
     ) {
       updateFailedPrompt(null);
+      return;
     }
-  }, [connection.sessionId, displayMessages, failedPrompt, updateFailedPrompt]);
+    if (
+      failed.messageId !== failedBlock.id ||
+      failed.identity.block !== failedBlock
+    ) {
+      updateFailedPrompt({
+        ...failed,
+        messageId: failedBlock.id,
+        identity: { block: failedBlock },
+      });
+    }
+  }, [
+    blocks,
+    connection.sessionId,
+    displayMessages,
+    failedPrompt,
+    store,
+    updateFailedPrompt,
+  ]);
   useEffect(() => {
     const unknown = unknownPromptAdmissionRef.current;
     if (unknown && unknown.sessionId !== connection.sessionId) {
@@ -3766,18 +3996,31 @@ export function App({
   const [isStartingNewSessionSuggestion, setIsStartingNewSessionSuggestion] =
     useState(false);
   const streamingState = useStreamingState();
+  const failedPromptRetryIsCurrent = Boolean(
+    failedPromptRetry &&
+      retryOwnerMatchesCurrent(
+        failedPromptRetry.owner,
+        connection.sessionId,
+        connection.workspaceCwd,
+        composerSourceVersionRef.current,
+      ) &&
+      retryTranscriptIdentityMatches(
+        blocks,
+        failedPromptRetry.transcriptIdentity,
+      ),
+  );
   useEffect(() => {
     if (
       failedPromptRetry &&
-      (failedPromptRetry.sessionId !== connection.sessionId ||
+      (!failedPromptRetryIsCurrent ||
         (streamingState === 'idle' && failedPromptRetry.settled))
     ) {
       setFailedPromptRetry(null);
     }
-  }, [connection.sessionId, failedPromptRetry, streamingState]);
+  }, [failedPromptRetry, failedPromptRetryIsCurrent, streamingState]);
   const suppressFailedPromptRetryStreaming = Boolean(
     failedPromptRetry &&
-      failedPromptRetry.sessionId === connection.sessionId &&
+      failedPromptRetryIsCurrent &&
       (!failedPromptRetry.admitted || failedPromptRetry.settled),
   );
   const streamingStateRef = useRef<DaemonStreamingState>(streamingState);
@@ -3820,10 +4063,219 @@ export function App({
     composerSourceVersionRef.current,
   );
   const retryableTurnErrorIdRef = useRef<string | null>(null);
+  const retryableTurnErrorIdentityRef = useRef<
+    TranscriptTurnErrorIdentity | undefined
+  >(undefined);
   const retriedTurnErrorIdRef = useRef<string | null>(null);
   const [showRetryHint, setShowRetryHint] = useState(false);
   const showRetryHintRef = useRef(showRetryHint);
   showRetryHintRef.current = showRetryHint;
+  const retryOwnerRef = useRef<CancelledRetryOwner>({
+    sessionId: connection.sessionId,
+    workspaceCwd: connection.workspaceCwd,
+    sessionKey: logicalSessionKey,
+    sourceVersion: composerSourceVersionRef.current,
+    snapshot: sessionOwnerGuard.capture(),
+  });
+  useLayoutEffect(() => {
+    const previousOwner = retryOwnerRef.current;
+    const currentSnapshot = sessionOwnerGuard.capture();
+    const workspaceBecameKnown =
+      previousOwner.sessionId !== undefined &&
+      previousOwner.sessionId === connection.sessionId &&
+      previousOwner.workspaceCwd === undefined &&
+      connection.workspaceCwd !== undefined &&
+      previousOwner.snapshot.isCurrent();
+    if (workspaceBecameKnown && logicalSessionKey) {
+      const previousSessionKey = previousOwner.sessionKey;
+      previousOwner.workspaceCwd = connection.workspaceCwd;
+      previousOwner.sessionKey = logicalSessionKey;
+      previousOwner.snapshot = currentSnapshot;
+      const previousStates =
+        previousSessionKey !== undefined
+          ? cancelledRetryStatesRef.current.get(previousSessionKey)
+          : undefined;
+      if (
+        previousSessionKey &&
+        previousStates &&
+        previousSessionKey !== logicalSessionKey
+      ) {
+        const currentStates =
+          cancelledRetryStatesRef.current.get(logicalSessionKey) ?? [];
+        cancelledRetryStatesRef.current.set(logicalSessionKey, [
+          ...currentStates.filter(
+            (current) =>
+              !previousStates.some(
+                (previous) => previous.state.kind === current.state.kind,
+              ),
+          ),
+          ...previousStates.map((previous) => ({ state: previous.state })),
+        ]);
+        cancelledRetryStatesRef.current.delete(previousSessionKey);
+      }
+      return;
+    }
+    if (previousOwner.workspaceCwd === undefined && previousOwner.sessionKey) {
+      cancelledRetryStatesRef.current.delete(previousOwner.sessionKey);
+    }
+    retryOwnerRef.current = {
+      sessionId: connection.sessionId,
+      workspaceCwd: connection.workspaceCwd,
+      sessionKey: logicalSessionKey,
+      sourceVersion: composerSourceVersionRef.current,
+      snapshot: currentSnapshot,
+    };
+    lastSubmittedPromptRef.current = '';
+    lastSubmittedImagesRef.current = undefined;
+    lastSubmittedInputAnnotationsRef.current = undefined;
+    lastSubmittedSourceVersionRef.current = -1;
+    retryableTurnErrorIdRef.current = null;
+    retryableTurnErrorIdentityRef.current = undefined;
+    retriedTurnErrorIdRef.current = null;
+    setShowRetryHint(false);
+  }, [
+    connection.sessionId,
+    connection.workspaceCwd,
+    logicalSessionKey,
+    sessionOwnerGuard,
+  ]);
+  const applyCancelledRetryState = useCallback(
+    (state: CancelledRetryState): CancelledRetryRestoreResult => {
+      const currentBlocks = store.getSnapshot().blocks;
+      if (state.kind === 'failed-prompt') {
+        let failed = state.failed;
+        const latestUserMessage = getLatestUserBlock(currentBlocks);
+        if (!matchesUserMessageIdentity(latestUserMessage, failed.identity)) {
+          if (
+            !matchesUserMessageIdentity(
+              latestUserMessage,
+              failed.previousIdentity,
+            )
+          ) {
+            return 'invalid';
+          }
+          store.appendLocalUserMessage(
+            failed.text,
+            failed.images?.map((image) => ({
+              data: image.data,
+              mimeType: image.media_type,
+            })),
+            failed.inputAnnotations?.length
+              ? { inputAnnotations: failed.inputAnnotations }
+              : undefined,
+          );
+          const rehydratedMessage = getLatestUserBlock(
+            store.getSnapshot().blocks,
+          );
+          if (!rehydratedMessage || rehydratedMessage === latestUserMessage) {
+            return 'invalid';
+          }
+          failed = {
+            ...failed,
+            messageId: rehydratedMessage.id,
+            identity: { block: rehydratedMessage },
+          };
+          state.failed = failed;
+        }
+        if (
+          !displayMessages.some((message) => message.id === failed.messageId)
+        ) {
+          return 'pending';
+        }
+        failed = {
+          ...failed,
+          owner: retryOwnerRef.current,
+        };
+        state.failed = failed;
+        updateFailedPrompt(failed);
+        setFailedPromptRetry(null);
+        return 'restored';
+      }
+      const currentTurnError = getRetryableTurnError(currentBlocks);
+      if (!matchesTurnErrorIdentity(currentTurnError, state.identity)) {
+        return 'invalid';
+      }
+      const renderedTurnError = getRetryableTurnError(blocks);
+      if (
+        !renderedTurnError ||
+        !matchesTurnErrorIdentity(renderedTurnError, state.identity)
+      ) {
+        return 'pending';
+      }
+      lastSubmittedPromptRef.current = state.text;
+      lastSubmittedImagesRef.current = state.images;
+      lastSubmittedInputAnnotationsRef.current = state.inputAnnotations;
+      lastSubmittedSourceVersionRef.current = composerSourceVersionRef.current;
+      retryableTurnErrorIdRef.current = renderedTurnError.id;
+      retryableTurnErrorIdentityRef.current = { block: renderedTurnError };
+      retriedTurnErrorIdRef.current = state.previousRetriedTurnErrorId;
+      setShowRetryHint(state.previousShowRetryHint);
+      setFailedPromptRetry(null);
+      return 'restored';
+    },
+    [blocks, displayMessages, store, updateFailedPrompt],
+  );
+  const restoreOrDeferCancelledRetry = useCallback(
+    (owner: CancelledRetryOwner, state: CancelledRetryState) => {
+      const resolvedSessionKey = owner.sessionKey;
+      if (
+        !resolvedSessionKey ||
+        (owner.workspaceCwd === undefined && !owner.snapshot.isCurrent())
+      ) {
+        return;
+      }
+      const states = [
+        ...(
+          cancelledRetryStatesRef.current.get(resolvedSessionKey) ?? []
+        ).filter((current) => current.state.kind !== state.kind),
+        {
+          ...(owner.workspaceCwd === undefined ? { owner } : {}),
+          state,
+        },
+      ];
+      cancelledRetryStatesRef.current.set(resolvedSessionKey, states);
+      if (appMountedRef.current) {
+        setCancelledRetryRevision((current) => current + 1);
+      }
+    },
+    [],
+  );
+  useLayoutEffect(() => {
+    if (
+      !logicalSessionKey ||
+      sessionWriteBlocked ||
+      connection.loadingTranscript ||
+      connection.catchingUp
+    ) {
+      return;
+    }
+    const exactStates =
+      cancelledRetryStatesRef.current.get(logicalSessionKey) ?? [];
+    const pendingExactStates: CancelledRetryEntry[] = [];
+    for (const entry of exactStates) {
+      if (entry.owner && !entry.owner.snapshot.isCurrent()) {
+        continue;
+      }
+      if (applyCancelledRetryState(entry.state) === 'pending') {
+        pendingExactStates.push(entry);
+      }
+    }
+    if (pendingExactStates.length > 0) {
+      cancelledRetryStatesRef.current.set(
+        logicalSessionKey,
+        pendingExactStates,
+      );
+    } else {
+      cancelledRetryStatesRef.current.delete(logicalSessionKey);
+    }
+  }, [
+    applyCancelledRetryState,
+    cancelledRetryRevision,
+    connection.catchingUp,
+    connection.loadingTranscript,
+    logicalSessionKey,
+    sessionWriteBlocked,
+  ]);
   const connected = connection.status === 'connected';
   const workspaceEventSignals = useWorkspaceEventSignals();
   const [loadedSkills, setLoadedSkills] = useState<SkillInfo[]>([]);
@@ -4722,9 +5174,22 @@ export function App({
     setCurrentMode(modeId);
   }, []);
   const [isPreparingPrompt, setIsPreparingPrompt] = useState(false);
+  const promptPreparationOwnerRef = useRef<symbol | null>(null);
+  const beginPromptPreparation = useCallback(() => {
+    const owner = Symbol('prompt-preparation');
+    promptPreparationOwnerRef.current = owner;
+    setIsPreparingPrompt(true);
+    return owner;
+  }, []);
+  const finishPromptPreparation = useCallback((owner: symbol | undefined) => {
+    if (!owner || promptPreparationOwnerRef.current !== owner) return;
+    promptPreparationOwnerRef.current = null;
+    setIsPreparingPrompt(false);
+  }, []);
   const planPreparationTokenRef = useRef(0);
   useLayoutEffect(() => {
     planPreparationTokenRef.current += 1;
+    promptPreparationOwnerRef.current = null;
     setIsPreparingPrompt(false);
   }, [logicalSessionKey]);
   const createSessionPromiseRef = useRef<Promise<string | undefined> | null>(
@@ -4898,6 +5363,16 @@ export function App({
       workspacesRef.current.find((entry) => entry.primary)?.cwd
     );
   }, [lockedWorkspaceCwd]);
+  const retryOwnerIsCurrent = useCallback(
+    (owner: CancelledRetryOwner) =>
+      retryOwnerMatchesCurrent(
+        owner,
+        connectionRef.current.sessionId,
+        getComposerWorkspaceCwd(),
+        composerSourceVersionRef.current,
+      ),
+    [getComposerWorkspaceCwd],
+  );
   const dispatchSessionChange = useCallback(
     (event: SessionChangeEvent) => {
       onSessionChange?.(event);
@@ -4934,48 +5409,62 @@ export function App({
         );
       }
       const isUserPrompt = !text.trimStart().startsWith('/');
-      const previousLastSubmittedPrompt = lastSubmittedPromptRef.current;
-      const previousLastSubmittedImages = lastSubmittedImagesRef.current;
-      const previousLastSubmittedInputAnnotations =
-        lastSubmittedInputAnnotationsRef.current;
-      const previousLastSubmittedSourceVersion =
-        lastSubmittedSourceVersionRef.current;
-      const previousRetriedTurnErrorId = retriedTurnErrorIdRef.current;
-      const previousShowRetryHint = showRetryHintRef.current;
+      let promptPreparationOwner: symbol | undefined;
+      const startPreparing = () => {
+        promptPreparationOwner ??= beginPromptPreparation();
+      };
+      const finishPreparing = () => {
+        finishPromptPreparation(promptPreparationOwner);
+      };
       const restoreCancelledSubmitState = () => {
-        setIsPreparingPrompt(false);
-        lastSubmittedPromptRef.current = previousLastSubmittedPrompt;
-        lastSubmittedImagesRef.current = previousLastSubmittedImages;
-        lastSubmittedInputAnnotationsRef.current =
-          previousLastSubmittedInputAnnotations;
-        lastSubmittedSourceVersionRef.current =
-          previousLastSubmittedSourceVersion;
-        retriedTurnErrorIdRef.current = previousRetriedTurnErrorId;
-        setShowRetryHint(previousShowRetryHint);
+        finishPreparing();
         opts?.onCancelledBeforeAdmission?.();
       };
-      if (!opts?.retry && isUserPrompt) {
-        lastSubmittedPromptRef.current = text;
-        lastSubmittedImagesRef.current = images;
-        lastSubmittedInputAnnotationsRef.current = opts?.inputAnnotations;
-        lastSubmittedSourceVersionRef.current =
-          composerSourceVersionRef.current;
-        retriedTurnErrorIdRef.current = null;
-      }
-      setShowRetryHint(false);
       const shouldShowPreparing = !connectionRef.current.sessionId;
-      if (onSubmitBeforeRef.current) {
-        const sourceSessionId = connectionRef.current.sessionId;
-        const sourceWorkspaceCwd = getComposerWorkspaceCwd();
-        const sourceVersion = composerSourceVersionRef.current;
-        const writeBlockGeneration = sessionWriteBlockGenerationRef.current;
-        setIsPreparingPrompt(true);
+      const submitBefore = onSubmitBeforeRef.current;
+      const admissionSource = {
+        owner: sessionOwnerGuard.capture(),
+        sessionId: connectionRef.current.sessionId,
+        workspaceCwd: getComposerWorkspaceCwd(),
+        sourceVersion: composerSourceVersionRef.current,
+        writeBlockGeneration: sessionWriteBlockGenerationRef.current,
+      };
+      const admissionOwnerIsCurrent = (allocatedSessionId?: string) => {
+        if (!appMountedRef.current) return false;
+        const currentSessionId = connectionRef.current.sessionId;
+        const sessionMatches =
+          currentSessionId === admissionSource.sessionId ||
+          (admissionSource.sessionId === undefined &&
+            (currentSessionId === undefined ||
+              (allocatedSessionId !== undefined &&
+                currentSessionId === allocatedSessionId)));
+        const ownAllocationSucceeded =
+          admissionSource.sessionId === undefined &&
+          allocatedSessionId !== undefined &&
+          (currentSessionId === undefined ||
+            currentSessionId === allocatedSessionId);
+        return (
+          (admissionSource.owner.isCurrent() || ownAllocationSucceeded) &&
+          sessionMatches &&
+          (ownAllocationSucceeded ||
+            getComposerWorkspaceCwd() === admissionSource.workspaceCwd) &&
+          composerSourceVersionRef.current === admissionSource.sourceVersion
+        );
+      };
+      const admissionSourceIsCurrent = (allocatedSessionId?: string) =>
+        admissionOwnerIsCurrent(allocatedSessionId) &&
+        !sessionWriteBlockedRef.current &&
+        sessionWriteBlockGenerationRef.current ===
+          admissionSource.writeBlockGeneration;
+      if (submitBefore) {
+        startPreparing();
         try {
-          await onSubmitBeforeRef.current({
-            sessionId: sourceSessionId,
+          await submitBefore({
+            sessionId: admissionSource.sessionId,
             prompt: text,
           });
         } catch (err) {
+          if (!appMountedRef.current) return;
           console.warn(
             '[web-shell] onSubmitBefore rejected, prompt cancelled',
             err,
@@ -4985,40 +5474,28 @@ export function App({
           restoreCancelledSubmitState();
           return;
         }
-        if (
-          sessionWriteBlockedRef.current ||
-          sessionWriteBlockGenerationRef.current !== writeBlockGeneration ||
-          connectionRef.current.sessionId !== sourceSessionId ||
-          getComposerWorkspaceCwd() !== sourceWorkspaceCwd ||
-          composerSourceVersionRef.current !== sourceVersion
-        ) {
+        if (!appMountedRef.current) return;
+        if (!admissionSourceIsCurrent()) {
           restoreCancelledSubmitState();
           return;
         }
-        // Only reset if session already exists; otherwise keep true and let
-        // ensureSessionForPrompt's finally block handle it.
-        if (!shouldShowPreparing) {
-          setIsPreparingPrompt(false);
-        }
       }
-      if (!onSubmitBeforeRef.current && shouldShowPreparing) {
-        setIsPreparingPrompt(true);
+      if (!submitBefore && shouldShowPreparing) {
+        startPreparing();
       }
-      clearFollowup();
       const existingSessionWorkspaceCwd = getComposerWorkspaceCwd();
       let allocatedSessionId: string | undefined;
       try {
         allocatedSessionId = await ensureSessionForPrompt();
-        if (opts?.ownerRef) opts.ownerRef.current = sessionOwnerGuard.capture();
       } finally {
-        if (shouldShowPreparing) {
-          setIsPreparingPrompt(false);
+        if (appMountedRef.current && shouldShowPreparing) {
+          finishPreparing();
         }
       }
-      if (opts?.commitComposerAccepted) {
-        opts.commitComposerAccepted();
-      } else if (opts?.clearComposerOnPromptStart) {
-        editorRef.current?.clear();
+      if (!appMountedRef.current) return;
+      if (!admissionSourceIsCurrent(allocatedSessionId)) {
+        restoreCancelledSubmitState();
+        return;
       }
       const sessionIdAfterEnsure =
         connectionRef.current.sessionId ?? allocatedSessionId;
@@ -5028,6 +5505,39 @@ export function App({
           ? allocatedOwner.workspaceCwd
           : undefined
         : existingSessionWorkspaceCwd;
+      if (
+        !opts?.retry &&
+        opts?.optimisticUserMessage !== false &&
+        isUserPrompt
+      ) {
+        lastSubmittedPromptRef.current = text;
+        lastSubmittedImagesRef.current = images;
+        lastSubmittedInputAnnotationsRef.current = opts?.inputAnnotations;
+        lastSubmittedSourceVersionRef.current =
+          composerSourceVersionRef.current;
+        retryableTurnErrorIdRef.current = null;
+        retryableTurnErrorIdentityRef.current = undefined;
+        retriedTurnErrorIdRef.current = null;
+        retryOwnerRef.current = {
+          sessionId: sessionIdAfterEnsure,
+          workspaceCwd: promptWorkspaceCwd,
+          sessionKey: getLogicalSessionKey(
+            sessionIdAfterEnsure,
+            promptWorkspaceCwd,
+          ),
+          sourceVersion: composerSourceVersionRef.current,
+          snapshot: sessionOwnerGuard.capture(),
+        };
+      }
+      setShowRetryHint(false);
+      finishPreparing();
+      if (opts?.ownerRef) opts.ownerRef.current = sessionOwnerGuard.capture();
+      clearFollowup();
+      if (opts?.commitComposerAccepted) {
+        opts.commitComposerAccepted();
+      } else if (opts?.clearComposerOnPromptStart) {
+        editorRef.current?.clear();
+      }
       let admissionStarted = false;
       let admitted = false;
       const promptOptions: SendPromptOptionsWithRetry = {
@@ -5060,8 +5570,8 @@ export function App({
           queued: false,
         });
       }
-      const previousUserMessageId = opts?.onOptimisticUserMessage
-        ? getLatestUserBlockId(store.getSnapshot().blocks)
+      const previousUserMessage = opts?.onOptimisticUserMessage
+        ? getLatestUserBlock(store.getSnapshot().blocks)
         : undefined;
       const resultPromise = (
         sessionActions.sendPrompt as (
@@ -5074,11 +5584,16 @@ export function App({
         opts?.optimisticUserMessage !== false &&
         opts?.onOptimisticUserMessage
       ) {
-        const messageId = getLatestUserBlockId(store.getSnapshot().blocks);
-        if (messageId && messageId !== previousUserMessageId) {
+        const message = getLatestUserBlock(store.getSnapshot().blocks);
+        if (message && message !== previousUserMessage) {
           opts.onOptimisticUserMessage({
             sessionId: sessionIdAfterEnsure,
-            messageId,
+            messageId: message.id,
+            identity: { block: message },
+            owner: retryOwnerRef.current,
+            ...(previousUserMessage
+              ? { previousIdentity: { block: previousUserMessage } }
+              : {}),
           });
         }
       }
@@ -5097,8 +5612,10 @@ export function App({
       }
     },
     [
+      beginPromptPreparation,
       clearFollowup,
       ensureSessionForPrompt,
+      finishPromptPreparation,
       getComposerWorkspaceCwd,
       sessionCatalogController,
       sessionActions,
@@ -5292,28 +5809,56 @@ export function App({
     [pushToast],
   );
   const handleFailedPromptRetry = useCallback(() => {
-    const failed = failedPromptRef.current;
+    if (sessionWriteBlockedRef.current || promptPreparationOwnerRef.current) {
+      return;
+    }
+    let failed = failedPromptRef.current;
     if (!failed || failed.sessionId !== connectionRef.current.sessionId) {
       updateFailedPrompt(null);
       return;
     }
-    const retryOwner = {
-      sourceVersion: composerSourceVersionRef.current,
-      sessionId: connectionRef.current.sessionId,
-      workspaceCwd: getComposerWorkspaceCwd(),
-    };
-    const retryOwnerIsCurrent = () =>
-      composerSourceVersionRef.current === retryOwner.sourceVersion &&
-      connectionRef.current.sessionId === retryOwner.sessionId &&
-      getComposerWorkspaceCwd() === retryOwner.workspaceCwd;
+    const retryOwner = failed.owner;
+    if (!retryOwnerIsCurrent(retryOwner)) {
+      updateFailedPrompt(null);
+      return;
+    }
+    const currentFailedBlock = getLatestUserBlock(store.getSnapshot().blocks);
+    if (
+      !currentFailedBlock ||
+      !matchesUserMessageIdentity(currentFailedBlock, failed.identity)
+    ) {
+      updateFailedPrompt(null);
+      return;
+    }
+    if (
+      currentFailedBlock !== failed.identity.block ||
+      currentFailedBlock.id !== failed.messageId
+    ) {
+      failed = {
+        ...failed,
+        messageId: currentFailedBlock.id,
+        identity: { block: currentFailedBlock },
+      };
+    }
     updateFailedPrompt(null);
     const retryStartedAt = Date.now();
+    const retryTranscriptIdentity: FailedPromptRetry['transcriptIdentity'] = {
+      kind: 'failed-prompt',
+      identity: failed.identity,
+    };
+    const retryTranscriptIsCurrent = () =>
+      retryTranscriptIdentityMatches(
+        store.getSnapshot().blocks,
+        retryTranscriptIdentity,
+      );
     setFailedPromptRetry({
       sessionId: failed.sessionId,
       messageId: failed.messageId,
       startedAt: retryStartedAt,
       admitted: false,
       settled: false,
+      owner: retryOwner,
+      transcriptIdentity: retryTranscriptIdentity,
     });
     let admitted = false;
     let admissionStarted = false;
@@ -5325,28 +5870,27 @@ export function App({
       },
       onAdmitted: () => {
         admitted = true;
-        if (!retryOwnerIsCurrent()) return;
+        if (!retryOwnerIsCurrent(retryOwner)) return;
         setFailedPromptRetry((current) =>
-          current?.sessionId === failed.sessionId &&
-          current.messageId === failed.messageId
-            ? { ...current, admitted: true }
+          current?.transcriptIdentity === retryTranscriptIdentity
+            ? retryTranscriptIsCurrent()
+              ? { ...current, admitted: true }
+              : null
             : current,
         );
       },
       onCancelledBeforeAdmission: () => {
-        if (!retryOwnerIsCurrent()) return;
-        if (
-          getLatestUserBlockId(store.getSnapshot().blocks) === failed.messageId
-        ) {
-          updateFailedPrompt(failed);
-        }
-        setFailedPromptRetry(null);
+        restoreOrDeferCancelledRetry(retryOwner, {
+          kind: 'failed-prompt',
+          failed,
+        });
       },
     })
       .catch((error: unknown) => {
-        if (!retryOwnerIsCurrent()) return;
+        if (!retryOwnerIsCurrent(retryOwner)) return;
         const definitelyRejected = isDefinitelyRejectedPromptAdmission(error);
         if (admissionStarted && !admitted && !definitelyRejected) {
+          if (!retryTranscriptIsCurrent()) return;
           updateUnknownPromptAdmission({
             sessionId: failed.sessionId,
             messageId: failed.messageId,
@@ -5362,28 +5906,31 @@ export function App({
           );
           return;
         }
-        if (
-          !admitted &&
-          connectionRef.current.sessionId === failed.sessionId &&
-          getLatestUserBlockId(store.getSnapshot().blocks) === failed.messageId
-        ) {
-          updateFailedPrompt(failed);
+        if (!admitted) {
+          restoreOrDeferCancelledRetry(retryOwner, {
+            kind: 'failed-prompt',
+            failed,
+          });
         }
-        reportError(error, 'Failed to resend message');
+        if (retryTranscriptIsCurrent()) {
+          reportError(error, 'Failed to resend message');
+        }
       })
       .finally(() => {
-        if (!retryOwnerIsCurrent()) return;
+        if (!retryOwnerIsCurrent(retryOwner)) return;
         setFailedPromptRetry((current) =>
-          current?.sessionId === failed.sessionId &&
-          current.messageId === failed.messageId
-            ? { ...current, settled: true }
+          current?.transcriptIdentity === retryTranscriptIdentity
+            ? retryTranscriptIsCurrent()
+              ? { ...current, settled: true }
+              : null
             : current,
         );
       });
   }, [
-    getComposerWorkspaceCwd,
     pushToast,
     reportError,
+    restoreOrDeferCancelledRetry,
+    retryOwnerIsCurrent,
     sendPrompt,
     store,
     t,
@@ -5433,6 +5980,7 @@ export function App({
       inputAnnotations?: DaemonInputAnnotation[],
     ) => {
       if (onSubmitBeforeRef.current) {
+        const sourceOwner = sessionOwnerGuard.capture();
         const sourceSessionId = connectionRef.current.sessionId;
         const sourceWorkspaceCwd = getComposerWorkspaceCwd();
         const sourceVersion = composerSourceVersionRef.current;
@@ -5444,6 +5992,8 @@ export function App({
           })
           .then(() => {
             if (
+              !appMountedRef.current ||
+              !sourceOwner.isCurrent() ||
               sessionWriteBlockedRef.current ||
               sessionWriteBlockGenerationRef.current !== writeBlockGeneration ||
               connectionRef.current.sessionId !== sourceSessionId ||
@@ -5508,7 +6058,12 @@ export function App({
       }
       return result;
     },
-    [getComposerWorkspaceCwd, rawEnqueuePrompt, sessionCatalogController],
+    [
+      getComposerWorkspaceCwd,
+      rawEnqueuePrompt,
+      sessionCatalogController,
+      sessionOwnerGuard,
+    ],
   );
 
   useEffect(() => {
@@ -6393,27 +6948,43 @@ export function App({
   ]);
 
   useEffect(() => {
-    let retryableTurnErrorId: string | null = null;
-    for (let i = blocks.length - 1; i >= 0; i--) {
-      const block = blocks[i];
-      if (block?.kind === 'user') break;
-      if (block?.kind === 'error' && block.source === 'turn_error') {
-        retryableTurnErrorId = block.id;
-        break;
-      }
-      if (block?.kind !== 'debug') break;
+    const retryableTurnError = getRetryableTurnError(blocks);
+    const previousIdentity = retryableTurnErrorIdentityRef.current;
+    const identityMatches =
+      previousIdentity === undefined ||
+      (retryableTurnError !== undefined &&
+        matchesTurnErrorIdentity(retryableTurnError, previousIdentity));
+    if (
+      retryableTurnError &&
+      previousIdentity &&
+      identityMatches &&
+      retriedTurnErrorIdRef.current !== null
+    ) {
+      retriedTurnErrorIdRef.current = retryableTurnError.id;
     }
     const canRetry =
       connected &&
-      retryableTurnErrorId !== null &&
-      retryableTurnErrorId !== retriedTurnErrorIdRef.current &&
+      retryableTurnError !== undefined &&
+      identityMatches &&
+      retryableTurnError.id !== retriedTurnErrorIdRef.current &&
+      failedPromptRetry === null &&
       lastSubmittedSourceVersionRef.current ===
         composerSourceVersionRef.current &&
       (lastSubmittedPromptRef.current.length > 0 ||
         (lastSubmittedImagesRef.current?.length ?? 0) > 0);
-    retryableTurnErrorIdRef.current = canRetry ? retryableTurnErrorId : null;
+    if (retryableTurnError && previousIdentity && !identityMatches) {
+      lastSubmittedPromptRef.current = '';
+      lastSubmittedImagesRef.current = undefined;
+      lastSubmittedInputAnnotationsRef.current = undefined;
+      lastSubmittedSourceVersionRef.current = -1;
+      retryableTurnErrorIdentityRef.current = undefined;
+      retriedTurnErrorIdRef.current = null;
+    } else if (canRetry) {
+      retryableTurnErrorIdentityRef.current = { block: retryableTurnError };
+    }
+    retryableTurnErrorIdRef.current = canRetry ? retryableTurnError.id : null;
     setShowRetryHint(canRetry);
-  }, [blocks, connected]);
+  }, [blocks, connected, failedPromptRetry]);
 
   useEffect(() => {
     onStreamingStateChange?.(streamingState);
@@ -7706,7 +8277,9 @@ export function App({
       const sendToDaemon = opts?.sendToDaemon ?? true;
       const sendGoalPrompt = () => {
         const owner = { current: sessionOwnerGuard.capture() };
-        const deferComposerCommit = Boolean(onSubmitBeforeRef.current);
+        const deferComposerCommit =
+          Boolean(onSubmitBeforeRef.current) ||
+          createSessionPromiseRef.current !== null;
         const clearComposerOnPromptStart =
           !connectionRef.current.sessionId || deferComposerCommit;
         sendPrompt(text, images, {
@@ -7827,7 +8400,9 @@ export function App({
             (connectionRef.current.sessionId === admissionOwner.sessionId &&
               getComposerWorkspaceCwd() === admissionOwner.workspaceCwd));
         const { trackSendFailure = false, ...sendOptions } = opts ?? {};
-        const deferComposerCommit = Boolean(onSubmitBeforeRef.current);
+        const deferComposerCommit =
+          Boolean(onSubmitBeforeRef.current) ||
+          createSessionPromiseRef.current !== null;
         const clearComposerOnPromptStart =
           !connectionRef.current.sessionId || deferComposerCommit;
         let optimisticUserMessage: OptimisticUserMessage | undefined;
@@ -7887,12 +8462,16 @@ export function App({
             !admitted &&
             failedMessage &&
             failedMessage.sessionId === connectionRef.current.sessionId &&
-            store
-              .getSnapshot()
-              .blocks.some(
-                (block) =>
-                  block.kind === 'user' && block.id === failedMessage.messageId,
-              )
+            matchesUserMessageIdentity(
+              store
+                .getSnapshot()
+                .blocks.find(
+                  (block) =>
+                    block.kind === 'user' &&
+                    block.id === failedMessage.messageId,
+                ),
+              failedMessage.identity,
+            )
           ) {
             updateFailedPrompt({
               ...failedMessage,
@@ -8048,7 +8627,9 @@ export function App({
               const owner = { current: sessionOwnerGuard.capture() };
               handleLanguageChange(nextLanguage);
               if (!promptBlocked) {
-                const deferComposerCommit = Boolean(onSubmitBeforeRef.current);
+                const deferComposerCommit =
+                  Boolean(onSubmitBeforeRef.current) ||
+                  createSessionPromiseRef.current !== null;
                 const clearComposerOnPromptStart =
                   !connectionRef.current.sessionId || deferComposerCommit;
                 sendPrompt(`/language ui ${nextLanguage}`, undefined, {
@@ -8230,14 +8811,22 @@ export function App({
             const planPreparationToken = prompt
               ? ++planPreparationTokenRef.current
               : undefined;
-            if (prompt) setIsPreparingPrompt(true);
+            const planPromptPreparationOwner = prompt
+              ? beginPromptPreparation()
+              : undefined;
             const owner = sessionOwnerGuard.capture();
+            const writeBlockGeneration = sessionWriteBlockGenerationRef.current;
             sessionActions
               .setApprovalMode('plan')
               .then(() => {
                 if (!owner.isCurrent()) return;
                 setPendingMode('plan');
-                if (prompt) {
+                if (
+                  prompt &&
+                  !sessionWriteBlockedRef.current &&
+                  sessionWriteBlockGenerationRef.current ===
+                    writeBlockGeneration
+                ) {
                   return sendPrompt(prompt, images, {
                     clearComposerOnPromptStart: true,
                     inputAnnotations: metadata?.inputAnnotations,
@@ -8255,7 +8844,7 @@ export function App({
                   prompt &&
                   planPreparationTokenRef.current === planPreparationToken
                 ) {
-                  setIsPreparingPrompt(false);
+                  finishPromptPreparation(planPromptPreparationOwner);
                 }
               });
             return prompt ? false : true;
@@ -8774,17 +9363,18 @@ export function App({
           return true;
         }
         const needsSession = !connectionRef.current.sessionId;
+        let shellPromptPreparationOwner: symbol | undefined;
         if (needsSession) {
           if (shellSubmitInFlightRef.current) return false;
           shellSubmitInFlightRef.current = true;
-          setIsPreparingPrompt(true);
+          shellPromptPreparationOwner = beginPromptPreparation();
         }
         let sessionCreated = false;
         const generationAtSubmit = drainGenerationRef.current;
         void ensureSessionForPrompt()
           .finally(() => {
             if (needsSession) {
-              setIsPreparingPrompt(false);
+              finishPromptPreparation(shellPromptPreparationOwner);
               shellSubmitInFlightRef.current = false;
             }
           })
@@ -8842,6 +9432,7 @@ export function App({
       }
     },
     [
+      beginPromptPreparation,
       sendPrompt,
       sessionActions,
       sessionOwnerGuard,
@@ -8857,6 +9448,7 @@ export function App({
       openGoals,
       createNewSession,
       ensureSessionForPrompt,
+      finishPromptPreparation,
       getComposerWorkspaceCwd,
       sessionCatalogController,
       gitDiffWorkspaceCwd,
@@ -9015,37 +9607,70 @@ export function App({
   );
 
   const handleRetry = useCallback(() => {
-    if (sessionWriteBlockedRef.current) return;
+    if (sessionWriteBlockedRef.current || promptPreparationOwnerRef.current) {
+      return;
+    }
     if (
       showRetryHintRef.current &&
       connected &&
       streamingStateRef.current === 'idle' &&
       retryableTurnErrorIdRef.current &&
+      retryableTurnErrorIdentityRef.current &&
       connectionRef.current.sessionId &&
       (lastSubmittedPromptRef.current ||
         (lastSubmittedImagesRef.current?.length ?? 0) > 0)
     ) {
-      const retryErrorId = retryableTurnErrorIdRef.current;
+      const savedRetryErrorIdentity = retryableTurnErrorIdentityRef.current;
+      const currentRetryError = getRetryableTurnError(
+        store.getSnapshot().blocks,
+      );
+      if (
+        !savedRetryErrorIdentity ||
+        !currentRetryError ||
+        !matchesTurnErrorIdentity(currentRetryError, savedRetryErrorIdentity)
+      ) {
+        lastSubmittedPromptRef.current = '';
+        lastSubmittedImagesRef.current = undefined;
+        lastSubmittedInputAnnotationsRef.current = undefined;
+        lastSubmittedSourceVersionRef.current = -1;
+        retryableTurnErrorIdRef.current = null;
+        retryableTurnErrorIdentityRef.current = undefined;
+        retriedTurnErrorIdRef.current = null;
+        setShowRetryHint(false);
+        return;
+      }
+      const retryErrorId = currentRetryError.id;
+      const retryErrorIdentity = { block: currentRetryError };
       const retrySessionId = connectionRef.current.sessionId;
-      const retryWorkspaceCwd = getComposerWorkspaceCwd();
-      const retrySourceVersion = composerSourceVersionRef.current;
       const retryText = lastSubmittedPromptRef.current;
       const retryImages = lastSubmittedImagesRef.current;
       const retryInputAnnotations = lastSubmittedInputAnnotationsRef.current;
       const previousRetriedTurnErrorId = retriedTurnErrorIdRef.current;
       const previousShowRetryHint = showRetryHintRef.current;
-      const retryOwnerIsCurrent = () =>
-        composerSourceVersionRef.current === retrySourceVersion &&
-        connectionRef.current.sessionId === retrySessionId &&
-        getComposerWorkspaceCwd() === retryWorkspaceCwd;
+      const retryOwner = retryOwnerRef.current;
+      if (!retryOwnerIsCurrent(retryOwner)) {
+        setShowRetryHint(false);
+        return;
+      }
       retriedTurnErrorIdRef.current = retryErrorId;
       setShowRetryHint(false);
+      const retryTranscriptIdentity: FailedPromptRetry['transcriptIdentity'] = {
+        kind: 'turn-error',
+        identity: retryErrorIdentity,
+      };
+      const retryTranscriptIsCurrent = () =>
+        retryTranscriptIdentityMatches(
+          store.getSnapshot().blocks,
+          retryTranscriptIdentity,
+        );
       setFailedPromptRetry({
         sessionId: retrySessionId,
         messageId: retryErrorId,
         startedAt: Date.now(),
         admitted: false,
         settled: false,
+        owner: retryOwner,
+        transcriptIdentity: retryTranscriptIdentity,
       });
       let admissionStarted = false;
       let admitted = false;
@@ -9058,25 +9683,33 @@ export function App({
         },
         onAdmitted: () => {
           admitted = true;
-          if (!retryOwnerIsCurrent()) return;
+          if (!retryOwnerIsCurrent(retryOwner)) return;
           setFailedPromptRetry((current) =>
-            current?.sessionId === retrySessionId &&
-            current.messageId === retryErrorId
-              ? { ...current, admitted: true }
+            current?.transcriptIdentity === retryTranscriptIdentity
+              ? retryTranscriptIsCurrent()
+                ? { ...current, admitted: true }
+                : null
               : current,
           );
         },
         onCancelledBeforeAdmission: () => {
-          if (!retryOwnerIsCurrent()) return;
-          retriedTurnErrorIdRef.current = previousRetriedTurnErrorId;
-          setShowRetryHint(previousShowRetryHint);
-          setFailedPromptRetry(null);
+          restoreOrDeferCancelledRetry(retryOwner, {
+            kind: 'turn-error',
+            errorId: retryErrorId,
+            identity: retryErrorIdentity,
+            text: retryText,
+            images: retryImages,
+            inputAnnotations: retryInputAnnotations,
+            previousRetriedTurnErrorId,
+            previousShowRetryHint,
+          });
         },
       })
         .catch((error: unknown) => {
-          if (!retryOwnerIsCurrent()) return;
+          if (!retryOwnerIsCurrent(retryOwner)) return;
           const definitelyRejected = isDefinitelyRejectedPromptAdmission(error);
           if (admissionStarted && !admitted && !definitelyRejected) {
+            if (!retryTranscriptIsCurrent()) return;
             updateUnknownPromptAdmission({
               sessionId: retrySessionId,
               messageId: retryErrorId,
@@ -9092,14 +9725,17 @@ export function App({
             );
             return;
           }
-          reportError(error, 'Failed to retry prompt');
+          if (retryTranscriptIsCurrent()) {
+            reportError(error, 'Failed to retry prompt');
+          }
         })
         .finally(() => {
-          if (!retryOwnerIsCurrent()) return;
+          if (!retryOwnerIsCurrent(retryOwner)) return;
           setFailedPromptRetry((current) =>
-            current?.sessionId === retrySessionId &&
-            current.messageId === retryErrorId
-              ? { ...current, settled: true }
+            current?.transcriptIdentity === retryTranscriptIdentity
+              ? retryTranscriptIsCurrent()
+                ? { ...current, settled: true }
+                : null
               : current,
           );
         });
@@ -9108,9 +9744,10 @@ export function App({
     }
   }, [
     connected,
-    getComposerWorkspaceCwd,
     pushToast,
     reportError,
+    restoreOrDeferCancelledRetry,
+    retryOwnerIsCurrent,
     sendPrompt,
     store,
     t,
@@ -9300,6 +9937,25 @@ export function App({
       pendingApproval: pendingApproval !== null,
       isPreparingPrompt,
     });
+  const retryableTurnErrorIdentity = retryableTurnErrorIdentityRef.current;
+  const showCurrentRetryHint = Boolean(
+    showRetryHint &&
+      !isPreparingPrompt &&
+      retryableTurnErrorIdentity &&
+      matchesTurnErrorIdentity(
+        getRetryableTurnError(blocks),
+        retryableTurnErrorIdentity,
+      ) &&
+      retryOwnerIsCurrent(retryOwnerRef.current),
+  );
+  const latestUserBlock = getLatestUserBlock(blocks);
+  const visibleFailedPromptBlock =
+    failedPrompt &&
+    latestUserBlock &&
+    matchesUserMessageIdentity(latestUserBlock, failedPrompt.identity) &&
+    retryOwnerIsCurrent(failedPrompt.owner)
+      ? latestUserBlock
+      : undefined;
   const composerPlaceholderInputState = {
     catchingUp: Boolean(connection.catchingUp),
     isPreparingPrompt,
@@ -11116,10 +11772,12 @@ export function App({
                                 hideSessionTimeline={
                                   effectiveChatWidthMode === 'wide'
                                 }
-                                showRetryHint={showRetryHint}
+                                showRetryHint={showCurrentRetryHint}
                                 onRetryClick={handleRetry}
                                 failedPromptMessageId={
-                                  failedPrompt?.messageId
+                                  isPreparingPrompt
+                                    ? undefined
+                                    : visibleFailedPromptBlock?.id
                                 }
                                 onRetryFailedPrompt={handleFailedPromptRetry}
                                 onBranchSession={handleBranchCurrentSession}

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -536,10 +536,12 @@ interface FailedPromptRetry {
 type CancelledRetryState =
   | {
       kind: 'failed-prompt';
+      attemptId: number;
       failed: FailedPrompt;
     }
   | {
       kind: 'turn-error';
+      attemptId: number;
       errorId: string;
       identity: TranscriptTurnErrorIdentity;
       text: string;
@@ -580,6 +582,27 @@ interface CancelledRetryEntry {
   state: CancelledRetryState;
 }
 
+function mergeCancelledRetryEntries(
+  current: readonly CancelledRetryEntry[],
+  incoming: readonly CancelledRetryEntry[],
+): CancelledRetryEntry[] {
+  return incoming.reduce<CancelledRetryEntry[]>(
+    (merged, candidate) => {
+      const existing = merged.find(
+        (entry) => entry.state.kind === candidate.state.kind,
+      );
+      if (existing && existing.state.attemptId >= candidate.state.attemptId) {
+        return merged;
+      }
+      return [
+        ...merged.filter((entry) => entry.state.kind !== candidate.state.kind),
+        candidate,
+      ];
+    },
+    [...current],
+  );
+}
+
 interface UnknownPromptAdmission {
   sessionId: string;
   messageId?: string;
@@ -600,7 +623,12 @@ function getLatestUserBlock(
 ): DaemonTranscriptBlock | undefined {
   for (let index = blocks.length - 1; index >= 0; index -= 1) {
     const block = blocks[index];
-    if (block?.kind === 'user') return block;
+    if (
+      block?.kind === 'user' &&
+      block.meta?.['source'] !== 'background_notification'
+    ) {
+      return block;
+    }
   }
   return undefined;
 }
@@ -608,12 +636,14 @@ function getLatestUserBlock(
 function matchesUserMessageIdentity(
   block: DaemonTranscriptBlock | undefined,
   identity: TranscriptUserMessageIdentity | undefined,
+  allowLocalId = false,
 ): boolean {
   if (!identity) return block === undefined;
   if (!block || block.kind !== 'user' || identity.block.kind !== 'user') {
     return false;
   }
   if (block === identity.block) return true;
+  if (allowLocalId && block.id === identity.block.id) return true;
   const expectedRecords = identity.block.sourceRecordIds;
   const currentRecords = block.sourceRecordIds;
   return (
@@ -628,10 +658,15 @@ function matchesUserMessageIdentity(
 function findUserMessageByIdentity(
   blocks: readonly DaemonTranscriptBlock[],
   identity: TranscriptUserMessageIdentity,
+  allowLocalId = false,
 ): DaemonTranscriptBlock | undefined {
   for (let index = blocks.length - 1; index >= 0; index -= 1) {
     const block = blocks[index];
-    if (block?.kind === 'user' && matchesUserMessageIdentity(block, identity)) {
+    if (
+      block?.kind === 'user' &&
+      block.meta?.['source'] !== 'background_notification' &&
+      matchesUserMessageIdentity(block, identity, allowLocalId)
+    ) {
       return block;
     }
   }
@@ -650,7 +685,10 @@ function getRetryableTurnError(
 ): DaemonTranscriptBlock | undefined {
   for (let i = blocks.length - 1; i >= 0; i--) {
     const block = blocks[i];
-    if (block?.kind === 'user') break;
+    if (block?.kind === 'user') {
+      if (block.meta?.['source'] === 'background_notification') continue;
+      break;
+    }
     if (block?.kind === 'error' && block.source === 'turn_error') {
       return block;
     }
@@ -684,11 +722,13 @@ function matchesTurnErrorIdentity(
 function retryTranscriptIdentityMatches(
   blocks: readonly DaemonTranscriptBlock[],
   transcriptIdentity: FailedPromptRetry['transcriptIdentity'],
+  allowLocalUserId = false,
 ): boolean {
   return transcriptIdentity.kind === 'failed-prompt'
     ? matchesUserMessageIdentity(
         getLatestUserBlock(blocks),
         transcriptIdentity.identity,
+        allowLocalUserId,
       )
     : matchesTurnErrorIdentity(
         getRetryableTurnError(blocks),
@@ -2454,6 +2494,7 @@ export function App({
   const cancelledRetryStatesRef = useRef(
     new Map<string, CancelledRetryEntry[]>(),
   );
+  const cancelledRetryAttemptRef = useRef(0);
   const [cancelledRetryRevision, setCancelledRetryRevision] = useState(0);
   const [unknownPromptAdmission, setUnknownPromptAdmission] =
     useState<UnknownPromptAdmission | null>(null);
@@ -2548,8 +2589,13 @@ export function App({
     const currentFailedBlock = findUserMessageByIdentity(
       store.getSnapshot().blocks,
       failed.identity,
+      failed.owner.snapshot.isCurrent(),
     );
-    const failedBlock = findUserMessageByIdentity(blocks, failed.identity);
+    const failedBlock = findUserMessageByIdentity(
+      blocks,
+      failed.identity,
+      failed.owner.snapshot.isCurrent(),
+    );
     if (failed.sessionId !== connection.sessionId || !currentFailedBlock) {
       updateFailedPrompt(null);
       return;
@@ -4067,9 +4113,59 @@ export function App({
     TranscriptTurnErrorIdentity | undefined
   >(undefined);
   const retriedTurnErrorIdRef = useRef<string | null>(null);
+  const failedTurnErrorRetryRef = useRef<{
+    errorId: string;
+    text: string;
+    images?: PromptImage[];
+    inputAnnotations?: DaemonInputAnnotation[];
+    owner: CancelledRetryOwner;
+  } | null>(null);
   const [showRetryHint, setShowRetryHint] = useState(false);
   const showRetryHintRef = useRef(showRetryHint);
   showRetryHintRef.current = showRetryHint;
+  const rearmFailedTurnErrorRetry = useCallback(
+    (
+      retryableTurnError: DaemonTranscriptBlock,
+      currentBlocks: readonly DaemonTranscriptBlock[],
+    ) => {
+      const failedRetry = failedTurnErrorRetryRef.current;
+      if (!failedRetry || retryableTurnError.id === failedRetry.errorId) {
+        return;
+      }
+      if (
+        !retryOwnerMatchesCurrent(
+          failedRetry.owner,
+          connectionRef.current.sessionId,
+          connectionRef.current.workspaceCwd,
+          composerSourceVersionRef.current,
+        )
+      ) {
+        failedTurnErrorRetryRef.current = null;
+        return;
+      }
+      if (
+        !currentBlocks.some(
+          (block) =>
+            block.kind === 'error' &&
+            block.source === 'turn_error' &&
+            block.id === failedRetry.errorId,
+        )
+      ) {
+        failedTurnErrorRetryRef.current = null;
+        return;
+      }
+      lastSubmittedPromptRef.current = failedRetry.text;
+      lastSubmittedImagesRef.current = failedRetry.images;
+      lastSubmittedInputAnnotationsRef.current = failedRetry.inputAnnotations;
+      lastSubmittedSourceVersionRef.current = composerSourceVersionRef.current;
+      retryableTurnErrorIdRef.current = retryableTurnError.id;
+      retryableTurnErrorIdentityRef.current = { block: retryableTurnError };
+      retriedTurnErrorIdRef.current = null;
+      failedTurnErrorRetryRef.current = null;
+      setShowRetryHint(true);
+    },
+    [],
+  );
   const retryOwnerRef = useRef<CancelledRetryOwner>({
     sessionId: connection.sessionId,
     workspaceCwd: connection.workspaceCwd,
@@ -4102,17 +4198,25 @@ export function App({
       ) {
         const currentStates =
           cancelledRetryStatesRef.current.get(logicalSessionKey) ?? [];
-        cancelledRetryStatesRef.current.set(logicalSessionKey, [
-          ...currentStates.filter(
-            (current) =>
-              !previousStates.some(
-                (previous) => previous.state.kind === current.state.kind,
-              ),
+        cancelledRetryStatesRef.current.set(
+          logicalSessionKey,
+          mergeCancelledRetryEntries(
+            currentStates,
+            previousStates.map((previous) => ({ state: previous.state })),
           ),
-          ...previousStates.map((previous) => ({ state: previous.state })),
-        ]);
+        );
         cancelledRetryStatesRef.current.delete(previousSessionKey);
       }
+      return;
+    }
+    if (
+      retryOwnerMatchesCurrent(
+        previousOwner,
+        connection.sessionId,
+        connection.workspaceCwd,
+        composerSourceVersionRef.current,
+      )
+    ) {
       return;
     }
     if (previousOwner.workspaceCwd === undefined && previousOwner.sessionKey) {
@@ -4132,6 +4236,7 @@ export function App({
     retryableTurnErrorIdRef.current = null;
     retryableTurnErrorIdentityRef.current = undefined;
     retriedTurnErrorIdRef.current = null;
+    failedTurnErrorRetryRef.current = null;
     setShowRetryHint(false);
   }, [
     connection.sessionId,
@@ -4174,6 +4279,17 @@ export function App({
             ...failed,
             messageId: rehydratedMessage.id,
             identity: { block: rehydratedMessage },
+          };
+          state.failed = failed;
+        } else if (
+          latestUserMessage &&
+          (latestUserMessage.id !== failed.messageId ||
+            latestUserMessage !== failed.identity.block)
+        ) {
+          failed = {
+            ...failed,
+            messageId: latestUserMessage.id,
+            identity: { block: latestUserMessage },
           };
           state.failed = failed;
         }
@@ -4224,15 +4340,15 @@ export function App({
       ) {
         return;
       }
-      const states = [
-        ...(
-          cancelledRetryStatesRef.current.get(resolvedSessionKey) ?? []
-        ).filter((current) => current.state.kind !== state.kind),
-        {
-          ...(owner.workspaceCwd === undefined ? { owner } : {}),
-          state,
-        },
-      ];
+      const states = mergeCancelledRetryEntries(
+        cancelledRetryStatesRef.current.get(resolvedSessionKey) ?? [],
+        [
+          {
+            ...(owner.workspaceCwd === undefined ? { owner } : {}),
+            state,
+          },
+        ],
+      );
       cancelledRetryStatesRef.current.set(resolvedSessionKey, states);
       if (appMountedRef.current) {
         setCancelledRetryRevision((current) => current + 1);
@@ -5518,6 +5634,7 @@ export function App({
         retryableTurnErrorIdRef.current = null;
         retryableTurnErrorIdentityRef.current = undefined;
         retriedTurnErrorIdRef.current = null;
+        failedTurnErrorRetryRef.current = null;
         retryOwnerRef.current = {
           sessionId: sessionIdAfterEnsure,
           workspaceCwd: promptWorkspaceCwd,
@@ -5825,7 +5942,11 @@ export function App({
     const currentFailedBlock = getLatestUserBlock(store.getSnapshot().blocks);
     if (
       !currentFailedBlock ||
-      !matchesUserMessageIdentity(currentFailedBlock, failed.identity)
+      !matchesUserMessageIdentity(
+        currentFailedBlock,
+        failed.identity,
+        retryOwner.snapshot.isCurrent(),
+      )
     ) {
       updateFailedPrompt(null);
       return;
@@ -5842,6 +5963,7 @@ export function App({
     }
     updateFailedPrompt(null);
     const retryStartedAt = Date.now();
+    const retryAttemptId = ++cancelledRetryAttemptRef.current;
     const retryTranscriptIdentity: FailedPromptRetry['transcriptIdentity'] = {
       kind: 'failed-prompt',
       identity: failed.identity,
@@ -5850,6 +5972,7 @@ export function App({
       retryTranscriptIdentityMatches(
         store.getSnapshot().blocks,
         retryTranscriptIdentity,
+        retryOwner.snapshot.isCurrent(),
       );
     setFailedPromptRetry({
       sessionId: failed.sessionId,
@@ -5882,6 +6005,7 @@ export function App({
       onCancelledBeforeAdmission: () => {
         restoreOrDeferCancelledRetry(retryOwner, {
           kind: 'failed-prompt',
+          attemptId: retryAttemptId,
           failed,
         });
       },
@@ -5909,6 +6033,7 @@ export function App({
         if (!admitted) {
           restoreOrDeferCancelledRetry(retryOwner, {
             kind: 'failed-prompt',
+            attemptId: retryAttemptId,
             failed,
           });
         }
@@ -6949,6 +7074,9 @@ export function App({
 
   useEffect(() => {
     const retryableTurnError = getRetryableTurnError(blocks);
+    if (retryableTurnError) {
+      rearmFailedTurnErrorRetry(retryableTurnError, blocks);
+    }
     const previousIdentity = retryableTurnErrorIdentityRef.current;
     const identityMatches =
       previousIdentity === undefined ||
@@ -6979,12 +7107,13 @@ export function App({
       lastSubmittedSourceVersionRef.current = -1;
       retryableTurnErrorIdentityRef.current = undefined;
       retriedTurnErrorIdRef.current = null;
+      failedTurnErrorRetryRef.current = null;
     } else if (canRetry) {
       retryableTurnErrorIdentityRef.current = { block: retryableTurnError };
     }
     retryableTurnErrorIdRef.current = canRetry ? retryableTurnError.id : null;
     setShowRetryHint(canRetry);
-  }, [blocks, connected, failedPromptRetry]);
+  }, [blocks, connected, failedPromptRetry, rearmFailedTurnErrorRetry]);
 
   useEffect(() => {
     onStreamingStateChange?.(streamingState);
@@ -8471,6 +8600,7 @@ export function App({
                     block.id === failedMessage.messageId,
                 ),
               failedMessage.identity,
+              failedMessage.owner.snapshot.isCurrent(),
             )
           ) {
             updateFailedPrompt({
@@ -9647,6 +9777,7 @@ export function App({
       const retryInputAnnotations = lastSubmittedInputAnnotationsRef.current;
       const previousRetriedTurnErrorId = retriedTurnErrorIdRef.current;
       const previousShowRetryHint = showRetryHintRef.current;
+      const retryAttemptId = ++cancelledRetryAttemptRef.current;
       const retryOwner = retryOwnerRef.current;
       if (!retryOwnerIsCurrent(retryOwner)) {
         setShowRetryHint(false);
@@ -9695,6 +9826,7 @@ export function App({
         onCancelledBeforeAdmission: () => {
           restoreOrDeferCancelledRetry(retryOwner, {
             kind: 'turn-error',
+            attemptId: retryAttemptId,
             errorId: retryErrorId,
             identity: retryErrorIdentity,
             text: retryText,
@@ -9725,6 +9857,37 @@ export function App({
             );
             return;
           }
+          if (!admitted) {
+            restoreOrDeferCancelledRetry(retryOwner, {
+              kind: 'turn-error',
+              attemptId: retryAttemptId,
+              errorId: retryErrorId,
+              identity: retryErrorIdentity,
+              text: retryText,
+              images: retryImages,
+              inputAnnotations: retryInputAnnotations,
+              previousRetriedTurnErrorId,
+              previousShowRetryHint,
+            });
+          }
+          if (isDaemonTurnError(error)) {
+            failedTurnErrorRetryRef.current = {
+              errorId: retryErrorId,
+              text: retryText,
+              images: retryImages,
+              inputAnnotations: retryInputAnnotations,
+              owner: retryOwner,
+            };
+            const nextTurnError = getRetryableTurnError(
+              store.getSnapshot().blocks,
+            );
+            if (nextTurnError) {
+              rearmFailedTurnErrorRetry(
+                nextTurnError,
+                store.getSnapshot().blocks,
+              );
+            }
+          }
           if (retryTranscriptIsCurrent()) {
             reportError(error, 'Failed to retry prompt');
           }
@@ -9746,6 +9909,7 @@ export function App({
     connected,
     pushToast,
     reportError,
+    rearmFailedTurnErrorRetry,
     restoreOrDeferCancelledRetry,
     retryOwnerIsCurrent,
     sendPrompt,
@@ -9952,7 +10116,11 @@ export function App({
   const visibleFailedPromptBlock =
     failedPrompt &&
     latestUserBlock &&
-    matchesUserMessageIdentity(latestUserBlock, failedPrompt.identity) &&
+    matchesUserMessageIdentity(
+      latestUserBlock,
+      failedPrompt.identity,
+      failedPrompt.owner.snapshot.isCurrent(),
+    ) &&
     retryOwnerIsCurrent(failedPrompt.owner)
       ? latestUserBlock
       : undefined;


### PR DESCRIPTION
## What this PR does

This PR hardens WebShell prompt ownership across session navigation. Direct and queued submissions now revalidate the App lifetime, logical session owner, composer source, and write-gate generation after asynchronous host admission and lazy session preparation, before clearing follow-ups, committing the composer, sending, or enqueueing.

Cancelled failed-prompt and turn-error retries are retained for their logical source session and restored only after navigation settles. Restoration uses persisted user-record identities or stable prompt/event identities instead of reducer-local block IDs, supports same-owner workspace enrichment and stable transcript replay, and fails closed when an attachment or transcript belongs to a different owner. The prompt-safe navigation design contract is updated to document these guarantees.

## Why it's needed

#8882 preserves the source session while a target restore is prepared, but asynchronous WebShell continuations could still outlive a navigation transition. A host admission hook or shared lazy-session preparation could return after A→B or A→B→A and commit a stale draft, clear follow-up state, enqueue work, or lose the source retry. Transcript reducers also reuse local block IDs, so using those IDs across attachment replacement could expose a retry for the wrong payload.

The new checks keep stale continuations side-effect free, preserve source-owned draft and retry state, and ensure a retry is offered only when the current transcript has a stable identity match.

## Reviewer Test Plan

### How to verify

Use a delayed `onSubmitBefore` hook in session A, begin a direct or queued submission, navigate A→B→A while the hook or lazy session preparation is pending, and then release it. Confirm no stale send or enqueue occurs, the composer and follow-up remain intact, and a valid source retry becomes available only after A is current and navigation has settled.

Repeat with a failed-prompt retry and a turn-error retry while replacing the session attachment. Confirm a stable persisted replay retains exactly one retry, while a new transcript that only reuses the same reducer-local ID exposes no retry and cannot resend the old payload. With a hanging real daemon turn, navigate A→B→A and confirm A remains active and the request ledger contains no navigation-generated cancel, prompt replay, continuation, or mid-turn mutation.

### Evidence (Before & After)

Before: focused regressions reproduced a direct send and queued enqueue after the navigation gate changed, and mutation tests reproduced hidden valid retries or stale retry UI after attachment/source-version changes.

After: the full WebShell App suite passes 422/422; the real-daemon session-switching suite passes 5/5 on the latest main; targeted mutation checks fail when the owner, generation, or transcript-identity guards are removed and pass with this change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS, Node.js 22.22.3, npm 10.9.8, local WebShell Vitest, and the bundled real-daemon integration harness with `QWEN_SANDBOX=false`.

## Risk & Scope

- Main risk or tradeoff: Prompt and retry lifecycle bookkeeping in the WebShell App is more explicit; focused owner/identity mutation tests, the full App suite, and real-daemon navigation tests cover the affected paths.
- Not validated / out of scope: Windows and Linux were not tested locally. DataWorks host-controller behavior, daemon prompt/cancel semantics, public REST/ACP/SDK interfaces, branch/fork navigation, and legacy source visibility remain out of scope.
- Breaking changes / migration notes: None. No public protocol, SDK type, header, or persisted-data migration is introduced.

## Linked Issues

Refs #8923

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 加固了 WebShell 在会话导航期间的 prompt 所有权。直接提交和排队提交在异步宿主准入及懒会话准备完成后、清除 follow-up、提交 composer、发送或入队之前，会重新校验 App 生命周期、逻辑会话 owner、composer source 和 write-gate generation。

被取消的 failed-prompt 与 turn-error retry 会保留在其逻辑源会话中，并且只在导航结束后恢复。恢复逻辑使用持久化 user record identity 或稳定的 prompt/event identity，而不是 reducer 局部 block ID；它支持同 owner 的 workspace 补全和稳定 transcript replay，并在 attachment 或 transcript 属于不同 owner 时 fail closed。Prompt-safe 导航设计契约也同步记录了这些保证。

## 为什么需要

#8882 在目标 restore 准备期间保留源会话，但异步 WebShell continuation 仍可能晚于导航 transition 返回。宿主准入 hook 或共享懒会话准备可能在 A→B 或 A→B→A 之后继续提交旧 draft、清除 follow-up 状态、将任务入队，或者丢失源会话 retry。Transcript reducer 还会复用局部 block ID，因此跨 attachment replacement 使用这些 ID 可能为错误 payload 暴露 retry。

新的校验让过期 continuation 不产生副作用，保留源会话拥有的 draft 和 retry 状态，并且只在当前 transcript 具备稳定 identity 匹配时提供 retry。

## Reviewer 测试计划

### 如何验证

在会话 A 中使用延迟的 `onSubmitBefore` hook，开始一次直接提交或排队提交，在 hook 或懒会话准备仍 pending 时执行 A→B→A，然后释放它。确认不会发生过期 send 或 enqueue，composer 和 follow-up 保持不变，并且有效的源会话 retry 只会在 A 成为当前会话且导航结束后恢复。

分别对 failed-prompt retry 和 turn-error retry 重复 attachment replacement。确认具有稳定持久 identity 的 replay 只保留一个 retry，而仅复用相同 reducer 局部 ID 的新 transcript 不显示 retry，也不能重发旧 payload。使用挂起真实 daemon turn 时执行 A→B→A，确认 A 仍保持 active，并且请求账本中没有导航生成的 cancel、prompt replay、continuation 或 mid-turn mutation。

### 证据（修改前与修改后）

修改前：聚焦回归测试复现了导航 gate 变化后的直接 send 和 queued enqueue；mutation 测试也复现了 attachment/source-version 变化后有效 retry 被隐藏或过期 retry UI 被保留的问题。

修改后：完整 WebShell App 测试 422/422 通过；基于最新 main 的真实 daemon 会话切换测试 5/5 通过；移除 owner、generation 或 transcript-identity guard 时，定向 mutation 测试会失败，保留本次修复时则通过。

### 已测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS、Node.js 22.22.3、npm 10.9.8、本地 WebShell Vitest，以及设置 `QWEN_SANDBOX=false` 的 bundle 真实 daemon 集成测试环境。

## 风险与范围

- 主要风险或取舍：WebShell App 中的 prompt 与 retry 生命周期记账更显式；定向 owner/identity mutation 测试、完整 App 测试和真实 daemon 导航测试覆盖了受影响路径。
- 未验证 / 范围外：未在本地测试 Windows 和 Linux。DataWorks 宿主控制器行为、daemon prompt/cancel 语义、公开 REST/ACP/SDK 接口、branch/fork 导航以及 legacy 源会话可见性不在本次范围。
- 破坏性变更 / 迁移说明：无。不新增公开协议、SDK 类型、header 或持久化数据迁移。

## 关联 Issue

Refs #8923

</details>
