### PR TITLE
fix(ci): seed the dist-rebuild warning on every retryable A/B exit

### DIFF
--- a/.github/scripts/run-autofix-review-verification.sh
+++ b/.github/scripts/run-autofix-review-verification.sh
@@ -156,12 +156,12 @@ baseline_also_fails() {
   # Every retryable exit below hands the tree to the repair agent with
   # dist/ REBUILT FROM BASELINE SOURCES (the restore checkout brings back
   # tracked files only) — the mirror of the dist confound that exempted
-  # typecheck from the A/B. The note seeds the repair feedback so the
-  # agent rebuilds before it trusts any dist-consuming check. The
+  # typecheck from the A/B. seed_dist_note seeds the repair feedback so
+  # the agent rebuilds before it trusts any dist-consuming check. The
   # pre-existing exit is the exception: no repair runs for it, so the
   # note stays out of its document.
   if [[ "${rc}" -ne 1 ]]; then
-    echo "⚠️ the baseline leg rebuilt dist/ from baseline sources — run npm run build before typecheck/tests" >> "${GATE_LOG}"
+    seed_dist_note
     echo "🔁 baseline is green — the failure belongs to this round" \
       | tee -a "${GATE_LOG}"
     return 1
@@ -188,11 +188,13 @@ baseline_also_fails() {
   # (sig_head was extracted before the detach.)
   sig_base="$(fail_signature "${ab_log}")" || true
   new_in_round="$(comm -23 <(printf '%s\n' "${sig_head}") <(printf '%s\n' "${sig_base}"))" || {
-    echo "⚠️ the baseline leg rebuilt dist/ from baseline sources — run npm run build before typecheck/tests" >> "${GATE_LOG}"
+    seed_dist_note
+    echo "🔁 signature comparison failed — fail-closed, charged to the round" \
+      | tee -a "${GATE_LOG}"
     return 1
   }
   if [[ -z "${sig_head}" || -z "${sig_base}" ]] || [[ -n "${new_in_round}" ]]; then
-    echo "⚠️ the baseline leg rebuilt dist/ from baseline sources — run npm run build before typecheck/tests" >> "${GATE_LOG}"
+    seed_dist_note
     echo "🔁 baseline fails for a DIFFERENT reason — charged to the round" \
       | tee -a "${GATE_LOG}"
     return 1
@@ -216,6 +218,12 @@ fail_signature() {
   # to the round) — widening needs their position formats normalized first.
   grep -oE "[^ '\"]+\([0-9]+,[0-9]+\): error TS[0-9]+.*" "${1}" 2> /dev/null \
     | sed -E 's/\([0-9]+,[0-9]+\)//' | sort -u
+}
+# The one emit point for the dist-rebuild steering note — every retryable
+# exit of baseline_also_fails after the baseline leg calls this, so the
+# guidance cannot drift across exits.
+seed_dist_note() {
+  echo "⚠️ the baseline leg rebuilt dist/ from baseline sources — run npm run build before typecheck/tests" >> "${GATE_LOG}"
 }
 run_check() {
   # pipefail makes the pipeline carry the command's status, not tee's. The

--- a/.github/scripts/run-autofix-review-verification.sh
+++ b/.github/scripts/run-autofix-review-verification.sh
@@ -153,12 +153,14 @@ baseline_also_fails() {
     } > "${WORKDIR}/gate-rejection.md" || true
     exit 1
   fi
+  # Every retryable exit below hands the tree to the repair agent with
+  # dist/ REBUILT FROM BASELINE SOURCES (the restore checkout brings back
+  # tracked files only) — the mirror of the dist confound that exempted
+  # typecheck from the A/B. The note seeds the repair feedback so the
+  # agent rebuilds before it trusts any dist-consuming check. The
+  # pre-existing exit is the exception: no repair runs for it, so the
+  # note stays out of its document.
   if [[ "${rc}" -ne 1 ]]; then
-    # Both retryable exits below hand the tree to the repair agent with
-    # dist/ REBUILT FROM BASELINE SOURCES (the restore checkout brings back
-    # tracked files only) — the mirror of the dist confound that exempted
-    # typecheck from the A/B. The note seeds the repair feedback so the
-    # agent rebuilds before it trusts any dist-consuming check.
     echo "⚠️ the baseline leg rebuilt dist/ from baseline sources — run npm run build before typecheck/tests" >> "${GATE_LOG}"
     echo "🔁 baseline is green — the failure belongs to this round" \
       | tee -a "${GATE_LOG}"
@@ -185,9 +187,12 @@ baseline_also_fails() {
   # verdict-less gate crash.
   # (sig_head was extracted before the detach.)
   sig_base="$(fail_signature "${ab_log}")" || true
-  new_in_round="$(comm -23 <(printf '%s\n' "${sig_head}") <(printf '%s\n' "${sig_base}"))" ||
+  new_in_round="$(comm -23 <(printf '%s\n' "${sig_head}") <(printf '%s\n' "${sig_base}"))" || {
+    echo "⚠️ the baseline leg rebuilt dist/ from baseline sources — run npm run build before typecheck/tests" >> "${GATE_LOG}"
     return 1
+  }
   if [[ -z "${sig_head}" || -z "${sig_base}" ]] || [[ -n "${new_in_round}" ]]; then
+    echo "⚠️ the baseline leg rebuilt dist/ from baseline sources — run npm run build before typecheck/tests" >> "${GATE_LOG}"
     echo "🔁 baseline fails for a DIFFERENT reason — charged to the round" \
       | tee -a "${GATE_LOG}"
     return 1

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -11581,6 +11581,7 @@ describe('review verification gate: baseline A/B on deterministic rejection', ()
     restoreClash = false,
     hugeFail = false,
     noIdentity = false,
+    baselineNoIdentity = false,
     trackedDirt = false,
     commFail = false,
   }) => {
@@ -11662,6 +11663,11 @@ describe('review verification gate: baseline A/B on deterministic rejection', ()
           '      echo "stub build FAILED at $head"',
           '      if [[ "${NO_IDENTITY:-}" == "1" ]]; then',
           // vite/esbuild shape: a red build with no tsc diagnostic at all.
+          '        echo "error during build: something exploded"; exit 1',
+          '      fi',
+          '      if [[ "$head" == "${BASELINE_SHA:-}" && "${BASELINE_NO_IDENTITY:-}" == "1" ]]; then',
+          // Same shape restricted to the baseline leg — the head keeps its
+          // tsc identity while the baseline loses its.
           '        echo "error during build: something exploded"; exit 1',
           '      fi',
           '      if [[ "$head" == "${BASELINE_SHA:-}" && "${TRACKED_DIRT:-}" == "1" ]]; then',
@@ -11749,6 +11755,7 @@ describe('review verification gate: baseline A/B on deterministic rejection', ()
             EXTRA_BASELINE_DIAG: extraBaselineDiag ? '1' : '',
             RESTORE_CLASH: restoreClash ? '1' : '',
             NO_IDENTITY: noIdentity ? '1' : '',
+            BASELINE_NO_IDENTITY: baselineNoIdentity ? '1' : '',
             TRACKED_DIRT: trackedDirt ? '1' : '',
             SCHEMA_FAIL: schemaFail ? '1' : '',
             TYPECHECK_FAIL: typecheckFail ? '1' : '',
@@ -11949,6 +11956,23 @@ describe('review verification gate: baseline A/B on deterministic rejection', ()
     expect(r.stdout).toContain('DIFFERENT reason');
     // The same repair handoff as the green path — the dist/ warning must
     // seed this rejection too.
+    expect(r.rejection).toContain('run npm run build before typecheck/tests');
+  });
+
+  it('charges the round when the baseline fails without a failure identity', () => {
+    // Mirror of the head-side noIdentity shape on the other leg: the
+    // baseline crashes vite/esbuild-style with no tsc diagnostic, so its
+    // signature is empty and identity cannot be established — fail
+    // closed and charge the round, with the same repair handoff (and
+    // dist/ note) as the sibling retryable exits.
+    const r = runGate({
+      failAt: ['feature', 'origin/feature'],
+      baselineNoIdentity: true,
+    });
+    expect(r.status).toBe(1);
+    expect(r.outputs).toContain('retryable=true');
+    expect(r.outputs).not.toContain('preexisting=true');
+    expect(r.stdout).toContain('DIFFERENT reason');
     expect(r.rejection).toContain('run npm run build before typecheck/tests');
   });
 

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -11582,6 +11582,7 @@ describe('review verification gate: baseline A/B on deterministic rejection', ()
     hugeFail = false,
     noIdentity = false,
     trackedDirt = false,
+    commFail = false,
   }) => {
     const dir = mkdtempSync(join(tmpdir(), 'gate-ab-'));
     try {
@@ -11698,6 +11699,13 @@ describe('review verification gate: baseline A/B on deterministic rejection', ()
         ].join('\n'),
       );
       chmodSync(join(bin, 'npm'), 0o755);
+      if (commFail) {
+        // Shadows the system comm via PATH precedence: the signature
+        // comparison itself fails (the SIGPIPE-under-pipefail class), so
+        // the gate takes its fail-closed retryable exit.
+        writeFileSync(join(bin, 'comm'), '#!/bin/bash\nexit 1\n');
+        chmodSync(join(bin, 'comm'), 0o755);
+      }
       const rt = join(dir, 'rt');
       mkdirSync(rt);
       writeFileSync(
@@ -11795,6 +11803,11 @@ describe('review verification gate: baseline A/B on deterministic rejection', ()
     // The baseline leg's own transcript is the ONLY proof behind the
     // verdict — it must reach the rejection document.
     expect(r.rejection).toContain(`stub build FAILED at ${r.baselineSha}`);
+    // No repair runs for a pre-existing failure — the dist/ steering note
+    // is for the repair agent and stays out of this document.
+    expect(r.rejection).not.toContain(
+      'run npm run build before typecheck/tests',
+    );
     expect(r.headAfter).toBe('feature');
   });
 
@@ -11934,6 +11947,25 @@ describe('review verification gate: baseline A/B on deterministic rejection', ()
     expect(r.outputs).toContain('retryable=true');
     expect(r.outputs).not.toContain('preexisting=true');
     expect(r.stdout).toContain('DIFFERENT reason');
+    // The same repair handoff as the green path — the dist/ warning must
+    // seed this rejection too.
+    expect(r.rejection).toContain('run npm run build before typecheck/tests');
+  });
+
+  it('seeds the dist-rebuild warning when the signature comparison itself fails', () => {
+    // comm failing (SIGPIPE under pipefail, an infrastructure hiccup)
+    // takes the same retryable handoff as the green/different-signature
+    // exits — without the note the repair agent trusts baseline-built
+    // dist/ and chases phantom dist-consuming failures.
+    const r = runGate({
+      failAt: ['feature', 'origin/feature'],
+      commFail: true,
+    });
+    expect(r.status).toBe(1);
+    expect(r.outputs).toContain('retryable=true');
+    expect(r.outputs).not.toContain('preexisting=true');
+    expect(r.rejection).toContain('run npm run build before typecheck/tests');
+    expect(r.headAfter).toBe('feature');
   });
 
   it('keeps the green path intact', () => {

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -11965,6 +11965,10 @@ describe('review verification gate: baseline A/B on deterministic rejection', ()
     expect(r.outputs).toContain('retryable=true');
     expect(r.outputs).not.toContain('preexisting=true');
     expect(r.rejection).toContain('run npm run build before typecheck/tests');
+    // Like its sibling exits, this one names its verdict — an oncall must
+    // distinguish "the comparison itself failed" from "baseline is green"
+    // without re-running the A/B.
+    expect(r.rejection).toContain('signature comparison failed');
     expect(r.headAfter).toBe('feature');
   });
 


### PR DESCRIPTION
## What this PR does

When the review-address verify gate rejects a fix as retryable, it warns the repair agent that the baseline A/B leg rebuilt `dist/` from baseline sources, so the agent rebuilds before trusting any dist-consuming check. That warning only reached the green-baseline rejection; this PR seeds it on the two remaining retryable exits — the failure-signature comparison erroring, and the baseline failing for a different reason — and pins the coverage with tests.

## Why it's needed

Every retryable exit hands the repair agent a tree whose `dist/` was rebuilt from baseline sources (the restore checkout brings back tracked files only). Without the warning, the repair agent can trust or test against stale baseline artifacts and burn its budget on phantom dist-consuming failures. #8765's post-close round-3 review flagged the comparison-failure exit as Critical; that PR closed as subsumed by #8878, and the port kept the warning on the green exit only — the different-reason exit had the note on #8765's branch but lost it in the port. Both gaps are live on main today.

## Reviewer Test Plan

### How to verify

Run the gate's executable harness: `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-autofix-workflow.test.js -t 'baseline A/B'` — 18 tests, all passing. Three assertions carry the change: the different-reason test now expects the warning in the rejection document, a new test stubs `comm` to fail and expects the same, and the pre-existing test pins the warning OUT of its document (no repair runs for that verdict). Mutation-tested, 3 of 3 caught: dropping either added echo fails its test, and leaking the note into the pre-existing document fails the negative assertion.

### Evidence (Before & After)

N/A (CI workflow script, not user-visible)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only (real-git fixture harness under `scripts/tests`).

## Risk & Scope

- Main risk or tradeoff: the warning line is duplicated at three exits rather than routed through a helper — matches the style the gate already used and keeps each exit self-contained.
- Not validated / out of scope: a live CI run of the workflow itself (the harness executes the real script in a fixture repo).
- Breaking changes / migration notes: none.

## Linked Issues

References #8765 (post-close round-3 review finding, Critical) and #8878.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当 review-address 的 verify gate 以可重试为由拒绝修复时，它会警告 repair agent：baseline A/B 分支已经用 baseline 源码重建了 `dist/`，agent 在信任任何消费 dist 的检查前必须先重新构建。此前这个警告只出现在 baseline 全绿的拒绝路径上；本 PR 把它补到另外两个可重试出口——失败签名比较本身出错、以及 baseline 因不同原因失败——并用测试固定了这些覆盖。

## 为什么需要

每一个可重试出口交给 repair agent 的工作树里，`dist/` 都是用 baseline 源码重建的（恢复 checkout 只带回受跟踪文件）。缺少警告时，repair agent 可能信任或基于陈旧的 baseline 产物做测试，把预算烧在假性的 dist 消费失败上。#8765 关闭后的第 3 轮 review 把比较失败出口标为 Critical；该 PR 以被 #8878 涵盖而关闭，而移植只保留了 baseline 全绿出口的警告——不同原因失败出口在 #8765 分支上原本有这条提示，移植时丢了。这两个缺口今天都活在 main 上。

## Reviewer 测试计划

### 如何验证

运行 gate 的可执行测试台：`npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-autofix-workflow.test.js -t 'baseline A/B'`——18 个测试全部通过。三处断言承载本次改动：不同原因失败测试现在断言拒绝文档包含警告；新增测试 stub `comm` 使其失败并做同样断言；pre-existing 测试反向断言警告不出现在其文档中（该判定不会触发 repair）。已做变异测试，3/3 被捕获：删掉任一新增 echo 会让对应测试失败；把警告泄漏进 pre-existing 文档会触发反向断言失败。

### 证据（Before & After）

N/A（CI 工作流脚本，非用户可见）

### 测试平台

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

仅单元测试（`scripts/tests` 下的真实 git fixture 测试台）。

## 风险与范围

- 主要风险或取舍：警告在三个出口各复制一行而非通过 helper 统一——与 gate 既有风格一致，且让每个出口自包含。
- 未验证 / 范围外：工作流本身的实时 CI 运行（测试台在 fixture 仓库中执行真实脚本）。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

关联 #8765（关闭后第 3 轮 review 的 Critical 发现）与 #8878。

</details>
