### PR TITLE
test DSW EAS prerelease pipeline

### DIFF
--- a/.github/scripts/dsw-swe-verified/dispatch-release-benchmark.sh
+++ b/.github/scripts/dsw-swe-verified/dispatch-release-benchmark.sh
@@ -21,6 +21,8 @@ model_name="${OPENAI_MODEL:-qwen3.7-max}"
 dataset_revision="2"
 max_attempts="${BENCHMARK_MAX_ATTEMPTS:-4}"
 retry_backoff_seconds="${BENCHMARK_RETRY_BACKOFF_SECONDS:-60}"
+execution_backend="${BENCHMARK_EXECUTION_BACKEND:-harbor}"
+eas_template_manifest="${EAS_TEMPLATE_MANIFEST:-${pool_root}/deploy/eas/templates.json}"
 output_root="${GITHUB_WORKSPACE:-$(pwd)}/benchmark-output"
 
 if [[ ! "${INSTANCE_LIMIT}" =~ ^[0-9]+$ ]] || (( INSTANCE_LIMIT < 1 || INSTANCE_LIMIT > 500 )); then
@@ -35,29 +37,41 @@ if [[ ! "${retry_backoff_seconds}" =~ ^[0-9]+$ ]]; then
   echo "BENCHMARK_RETRY_BACKOFF_SECONDS must be a non-negative integer" >&2
   exit 2
 fi
-for required_path in "${pool_bin}" "${python_bin}" "${dataset_root}" "${agent_cache_prepare}"; do
+if [[ "${execution_backend}" != "harbor" && "${execution_backend}" != "eas" && "${execution_backend}" != "eas-smoke" ]]; then
+  echo "BENCHMARK_EXECUTION_BACKEND must be harbor, eas, or eas-smoke" >&2
+  exit 2
+fi
+required_paths=("${pool_bin}" "${python_bin}" "${dataset_root}")
+if [[ "${execution_backend}" == "harbor" ]]; then
+  required_paths+=("${agent_cache_prepare}")
+elif [[ "${execution_backend}" == "eas" || "${execution_backend}" == "eas-smoke" ]]; then
+  required_paths+=("${eas_template_manifest}")
+fi
+for required_path in "${required_paths[@]}"; do
   if [[ ! -e "${required_path}" ]]; then
     echo "Required DSW resource is missing: ${required_path}" >&2
     exit 2
   fi
 done
-agent_cache_dirs=(
-  "${agent_cache_root}"
-  "${agent_cache_root}/node"
-  "${agent_cache_root}/nvm"
-  "${agent_cache_root}/npm"
-  "${agent_cache_root}/qwen-code"
-)
-for cache_dir in "${agent_cache_dirs[@]}"; do
-  if [[ ! -d "${cache_dir}" ]]; then
-    echo "::error::Benchmark cache directory is missing: ${cache_dir}" >&2
-    exit 2
-  fi
-  if [[ ! -w "${cache_dir}" ]]; then
-    echo "::error::Benchmark cache directory is not writable by $(id -un): ${cache_dir}" >&2
-    exit 2
-  fi
-done
+if [[ "${execution_backend}" == "harbor" ]]; then
+  agent_cache_dirs=(
+    "${agent_cache_root}"
+    "${agent_cache_root}/node"
+    "${agent_cache_root}/nvm"
+    "${agent_cache_root}/npm"
+    "${agent_cache_root}/qwen-code"
+  )
+  for cache_dir in "${agent_cache_dirs[@]}"; do
+    if [[ ! -d "${cache_dir}" ]]; then
+      echo "::error::Benchmark cache directory is missing: ${cache_dir}" >&2
+      exit 2
+    fi
+    if [[ ! -w "${cache_dir}" ]]; then
+      echo "::error::Benchmark cache directory is not writable by $(id -un): ${cache_dir}" >&2
+      exit 2
+    fi
+  done
+fi
 
 mkdir -p "${output_root}"
 manifest_path="${output_root}/manifest.json"
@@ -75,14 +89,20 @@ fi
 # Cache the exact published Qwen Code version and its Node/npm runtime before
 # tasks become claimable. This normally takes seconds on a warm DSW cache and
 # does not wait for the benchmark itself.
-qwen_version="${QWEN_REF#v}"
-"${python_bin}" "${agent_cache_prepare}" \
-  --cache-root "${agent_cache_root}" \
-  --node-version "${QWEN_BENCHMARK_NODE_VERSION:-v22.23.1}" \
-  --nvm-version "${QWEN_BENCHMARK_NVM_VERSION:-v0.40.2}" \
-  --qwen-version "${qwen_version}" \
-  --npm-registry "${NPM_CONFIG_REGISTRY:-https://registry.npmjs.org}" \
-  > "${output_root}/agent-cache-manifest-path.txt"
+if [[ "${execution_backend}" == "harbor" ]]; then
+  qwen_version="${QWEN_REF#v}"
+  "${python_bin}" "${agent_cache_prepare}" \
+    --cache-root "${agent_cache_root}" \
+    --node-version "${QWEN_BENCHMARK_NODE_VERSION:-v22.23.1}" \
+    --nvm-version "${QWEN_BENCHMARK_NVM_VERSION:-v0.40.2}" \
+    --qwen-version "${qwen_version}" \
+    --npm-registry "${NPM_CONFIG_REGISTRY:-https://registry.npmjs.org}" \
+    > "${output_root}/agent-cache-manifest-path.txt"
+elif [[ "${execution_backend}" == "eas" || "${execution_backend}" == "eas-smoke" ]]; then
+  "${pool_bin}" validate-eas-templates \
+    --task-manifest "${manifest_path}" \
+    --template-manifest "${eas_template_manifest}" >/dev/null
+fi
 
 export BENCHMARK_POOL_DATABASE_URL="${database_url}"
 "${pool_bin}" init-db >/dev/null
@@ -130,6 +150,7 @@ jq -n \
   --arg release_tag "${RELEASE_TAG}" \
   --arg qwen_ref "${QWEN_REF}" \
   --arg qwen_commit "${QWEN_COMMIT}" \
+  --arg execution_backend "${execution_backend}" \
   --argjson expected_instances "${INSTANCE_LIMIT}" \
   '{
     status: $status,
@@ -137,6 +158,7 @@ jq -n \
     release_tag: $release_tag,
     qwen_ref: $qwen_ref,
     qwen_commit: $qwen_commit,
+    execution_backend: $execution_backend,
     expected_instances: $expected_instances
   }' > "${output_root}/dispatch-receipt.json"
 

--- a/.github/scripts/dsw-swe-verified/dispatch-release-benchmark.sh
+++ b/.github/scripts/dsw-swe-verified/dispatch-release-benchmark.sh
@@ -17,11 +17,19 @@ dataset_root="${SWE_VERIFIED_DATASET_ROOT:-${pool_root}/datasets/swe-bench-verif
 agent_cache_root="${QWEN_BENCHMARK_CACHE_ROOT:-/mnt/workspace/qwen-benchmark-cache}"
 agent_cache_prepare="${pool_root}/service/deploy/prepare-agent-cache.py"
 database_url="${BENCHMARK_POOL_DATABASE_URL:-postgresql://qwen_benchmark@127.0.0.1:55432/qwen_benchmark_dsw_release_v1}"
+execution_backend="${BENCHMARK_EXECUTION_BACKEND:-harbor}"
+model_env_file="${MODEL_ENV_FILE:-/mnt/workspace/qwen-benchmark-eas-poc/config/model.env}"
+if [[ "${execution_backend}" == "eas" && -s "${model_env_file}" ]]; then
+  set -a
+  # This file contains only OPENAI_BASE_URL and OPENAI_MODEL; the API key is
+  # deliberately stored in a separate 0600 file consumed by the Executor.
+  source "${model_env_file}"
+  set +a
+fi
 model_name="${OPENAI_MODEL:-qwen3.7-max}"
 dataset_revision="2"
 max_attempts="${BENCHMARK_MAX_ATTEMPTS:-4}"
 retry_backoff_seconds="${BENCHMARK_RETRY_BACKOFF_SECONDS:-60}"
-execution_backend="${BENCHMARK_EXECUTION_BACKEND:-harbor}"
 eas_template_manifest="${EAS_TEMPLATE_MANIFEST:-${pool_root}/deploy/eas/templates.json}"
 output_root="${GITHUB_WORKSPACE:-$(pwd)}/benchmark-output"
 

--- a/.github/scripts/dsw-swe-verified/dispatch-release-benchmark.sh
+++ b/.github/scripts/dsw-swe-verified/dispatch-release-benchmark.sh
@@ -33,6 +33,10 @@ retry_backoff_seconds="${BENCHMARK_RETRY_BACKOFF_SECONDS:-60}"
 eas_template_manifest="${EAS_TEMPLATE_MANIFEST:-${pool_root}/deploy/eas/templates.json}"
 acr_image_manifest="${ACR_IMAGE_MANIFEST:-/mnt/workspace/qwen-benchmark-eas-poc/state/acr-manifest-c104f840.json}"
 acr_image_state_dir="${ACR_IMAGE_STATE_DIR:-/mnt/data/qwen-benchmark/acr-prewarm/c104f840/state}"
+eas_agent_cache_prepare="${EAS_AGENT_CACHE_PREPARE:-/mnt/workspace/qwen-benchmark-eas-poc/deploy/prepare-eas-agent-cache.py}"
+eas_runtime_uploader="${EAS_RUNTIME_UPLOADER:-/mnt/workspace/qwen-benchmark-eas-poc/deploy/acr-upload-runtime-artifact.py}"
+eas_node_bin="${EAS_NODE_BIN:-/mnt/workspace/qwen-benchmark-cache/node/runtime/bin}"
+eas_docker_config="${EAS_DOCKER_CONFIG:-/mnt/workspace/.docker/config.json}"
 output_root="${GITHUB_WORKSPACE:-$(pwd)}/benchmark-output"
 
 if [[ ! "${INSTANCE_LIMIT}" =~ ^[0-9]+$ ]] || (( INSTANCE_LIMIT < 1 || INSTANCE_LIMIT > 500 )); then
@@ -57,7 +61,15 @@ if [[ "${execution_backend}" == "harbor" ]]; then
 elif [[ "${execution_backend}" == "eas-smoke" ]]; then
   required_paths+=("${eas_template_manifest}")
 elif [[ "${execution_backend}" == "eas-harbor" ]]; then
-  required_paths+=("${acr_image_manifest}" "${acr_image_state_dir}")
+  required_paths+=(
+    "${acr_image_manifest}"
+    "${acr_image_state_dir}"
+    "${eas_agent_cache_prepare}"
+    "${eas_runtime_uploader}"
+    "${eas_node_bin}/node"
+    "${eas_node_bin}/npm"
+    "${eas_docker_config}"
+  )
 fi
 for required_path in "${required_paths[@]}"; do
   if [[ ! -e "${required_path}" ]]; then
@@ -101,8 +113,8 @@ fi
 # Cache the exact published Qwen Code version and its Node/npm runtime before
 # tasks become claimable. This normally takes seconds on a warm DSW cache and
 # does not wait for the benchmark itself.
+qwen_version="${QWEN_REF#v}"
 if [[ "${execution_backend}" == "harbor" ]]; then
-  qwen_version="${QWEN_REF#v}"
   "${python_bin}" "${agent_cache_prepare}" \
     --cache-root "${agent_cache_root}" \
     --node-version "${QWEN_BENCHMARK_NODE_VERSION:-v22.23.1}" \
@@ -114,6 +126,14 @@ elif [[ "${execution_backend}" == "eas-smoke" ]]; then
   "${pool_bin}" validate-eas-templates \
     --task-manifest "${manifest_path}" \
     --template-manifest "${eas_template_manifest}" >/dev/null
+elif [[ "${execution_backend}" == "eas-harbor" ]]; then
+  "${python_bin}" "${eas_agent_cache_prepare}" \
+    --version "${qwen_version}" \
+    --node-bin "${eas_node_bin}" \
+    --docker-config "${eas_docker_config}" \
+    --uploader "${eas_runtime_uploader}" \
+    --output-root "/mnt/workspace/qwen-benchmark-eas-poc/cache/agent-releases" \
+    > "${output_root}/eas-agent-cache.json"
 fi
 
 export BENCHMARK_POOL_DATABASE_URL="${database_url}"

--- a/.github/scripts/dsw-swe-verified/dispatch-release-benchmark.sh
+++ b/.github/scripts/dsw-swe-verified/dispatch-release-benchmark.sh
@@ -19,7 +19,7 @@ agent_cache_prepare="${pool_root}/service/deploy/prepare-agent-cache.py"
 database_url="${BENCHMARK_POOL_DATABASE_URL:-postgresql://qwen_benchmark@127.0.0.1:55432/qwen_benchmark_dsw_release_v1}"
 execution_backend="${BENCHMARK_EXECUTION_BACKEND:-harbor}"
 model_env_file="${MODEL_ENV_FILE:-/mnt/workspace/qwen-benchmark-eas-poc/config/model.env}"
-if [[ "${execution_backend}" == "eas" && -s "${model_env_file}" ]]; then
+if [[ "${execution_backend}" == "eas-harbor" && -s "${model_env_file}" ]]; then
   set -a
   # This file contains only OPENAI_BASE_URL and OPENAI_MODEL; the API key is
   # deliberately stored in a separate 0600 file consumed by the Executor.
@@ -31,6 +31,8 @@ dataset_revision="2"
 max_attempts="${BENCHMARK_MAX_ATTEMPTS:-4}"
 retry_backoff_seconds="${BENCHMARK_RETRY_BACKOFF_SECONDS:-60}"
 eas_template_manifest="${EAS_TEMPLATE_MANIFEST:-${pool_root}/deploy/eas/templates.json}"
+acr_image_manifest="${ACR_IMAGE_MANIFEST:-/mnt/workspace/qwen-benchmark-eas-poc/state/acr-manifest-c104f840.json}"
+acr_image_state_dir="${ACR_IMAGE_STATE_DIR:-/mnt/data/qwen-benchmark/acr-prewarm/c104f840/state}"
 output_root="${GITHUB_WORKSPACE:-$(pwd)}/benchmark-output"
 
 if [[ ! "${INSTANCE_LIMIT}" =~ ^[0-9]+$ ]] || (( INSTANCE_LIMIT < 1 || INSTANCE_LIMIT > 500 )); then
@@ -45,15 +47,17 @@ if [[ ! "${retry_backoff_seconds}" =~ ^[0-9]+$ ]]; then
   echo "BENCHMARK_RETRY_BACKOFF_SECONDS must be a non-negative integer" >&2
   exit 2
 fi
-if [[ "${execution_backend}" != "harbor" && "${execution_backend}" != "eas" && "${execution_backend}" != "eas-smoke" ]]; then
-  echo "BENCHMARK_EXECUTION_BACKEND must be harbor, eas, or eas-smoke" >&2
+if [[ "${execution_backend}" != "harbor" && "${execution_backend}" != "eas-harbor" && "${execution_backend}" != "eas-smoke" ]]; then
+  echo "BENCHMARK_EXECUTION_BACKEND must be harbor, eas-harbor, or eas-smoke" >&2
   exit 2
 fi
 required_paths=("${pool_bin}" "${python_bin}" "${dataset_root}")
 if [[ "${execution_backend}" == "harbor" ]]; then
   required_paths+=("${agent_cache_prepare}")
-elif [[ "${execution_backend}" == "eas" || "${execution_backend}" == "eas-smoke" ]]; then
+elif [[ "${execution_backend}" == "eas-smoke" ]]; then
   required_paths+=("${eas_template_manifest}")
+elif [[ "${execution_backend}" == "eas-harbor" ]]; then
+  required_paths+=("${acr_image_manifest}" "${acr_image_state_dir}")
 fi
 for required_path in "${required_paths[@]}"; do
   if [[ ! -e "${required_path}" ]]; then
@@ -106,7 +110,7 @@ if [[ "${execution_backend}" == "harbor" ]]; then
     --qwen-version "${qwen_version}" \
     --npm-registry "${NPM_CONFIG_REGISTRY:-https://registry.npmjs.org}" \
     > "${output_root}/agent-cache-manifest-path.txt"
-elif [[ "${execution_backend}" == "eas" || "${execution_backend}" == "eas-smoke" ]]; then
+elif [[ "${execution_backend}" == "eas-smoke" ]]; then
   "${pool_bin}" validate-eas-templates \
     --task-manifest "${manifest_path}" \
     --template-manifest "${eas_template_manifest}" >/dev/null
@@ -114,24 +118,32 @@ fi
 
 export BENCHMARK_POOL_DATABASE_URL="${database_url}"
 "${pool_bin}" init-db >/dev/null
+submit_args=(
+  --idempotency-key "${BENCHMARK_IDEMPOTENCY_KEY}"
+  --suite "dsw_release_swe_verified_v1"
+  --dataset "swe-bench/swe-bench-verified"
+  --dataset-revision "${dataset_revision}"
+  --task-prefix "swe-bench/"
+  --qwen-ref "${QWEN_REF}"
+  --qwen-commit "${QWEN_COMMIT}"
+  --model "${model_name}"
+  --manifest "${manifest_path}"
+  --max-attempts "${max_attempts}"
+  --retry-backoff-seconds "${retry_backoff_seconds}"
+  --infra-failure-threshold 0
+  --repository "${GITHUB_REPOSITORY}"
+  --release-id "${RELEASE_ID}"
+  --release-tag "${RELEASE_TAG}"
+  --github-run-url "${GITHUB_RUN_URL:-}"
+)
+if [[ "${execution_backend}" == "eas-harbor" ]]; then
+  submit_args+=(
+    --acr-manifest "${acr_image_manifest}"
+    --acr-state-dir "${acr_image_state_dir}"
+  )
+fi
 submit_json="$(
-  "${pool_bin}" submit \
-    --idempotency-key "${BENCHMARK_IDEMPOTENCY_KEY}" \
-    --suite "dsw_release_swe_verified_v1" \
-    --dataset "swe-bench/swe-bench-verified" \
-    --dataset-revision "${dataset_revision}" \
-    --task-prefix "swe-bench/" \
-    --qwen-ref "${QWEN_REF}" \
-    --qwen-commit "${QWEN_COMMIT}" \
-    --model "${model_name}" \
-    --manifest "${manifest_path}" \
-    --max-attempts "${max_attempts}" \
-    --retry-backoff-seconds "${retry_backoff_seconds}" \
-    --infra-failure-threshold 0 \
-    --repository "${GITHUB_REPOSITORY}" \
-    --release-id "${RELEASE_ID}" \
-    --release-tag "${RELEASE_TAG}" \
-    --github-run-url "${GITHUB_RUN_URL:-}"
+  "${pool_bin}" submit "${submit_args[@]}"
 )"
 run_id="$(
   "${python_bin}" -c '

--- a/.github/workflows/dsw-swe-verified-release.yml
+++ b/.github/workflows/dsw-swe-verified-release.yml
@@ -27,6 +27,14 @@ on:
         required: false
         default: 'sympy__sympy-20590'
         type: 'string'
+      execution_backend:
+        description: 'Execution backend; eas-smoke validates infrastructure only'
+        required: true
+        default: 'eas-smoke'
+        type: 'choice'
+        options:
+          - 'eas-smoke'
+          - 'eas'
 
 permissions:
   contents: 'read'
@@ -43,6 +51,9 @@ jobs:
     runs-on: 'ubuntu-latest'
     outputs:
       should_run: '${{ steps.gate.outputs.should_run }}'
+      execution_backend: '${{ steps.gate.outputs.execution_backend }}'
+      instance_limit: '${{ steps.gate.outputs.instance_limit }}'
+      instance_id: '${{ steps.gate.outputs.instance_id }}'
     steps:
       - name: 'Check release version'
         id: 'gate'
@@ -52,12 +63,28 @@ jobs:
           RELEASE_PRERELEASE: '${{ github.event.release.prerelease || false }}'
         run: |-
           should_run='false'
+          execution_backend='eas'
+          instance_limit='500'
+          instance_id=''
           if [[ "${EVENT_NAME}" == 'workflow_dispatch' ]]; then
             should_run='true'
+            execution_backend='${{ inputs.execution_backend }}'
+            instance_limit='${{ inputs.instance_limit }}'
+            instance_id='${{ inputs.instance_id }}'
+          elif [[ "${RELEASE_PRERELEASE}" == 'true' && "${RELEASE_TAG}" =~ ^dsw-eas-smoke-[0-9A-Za-z._-]+$ ]]; then
+            should_run='true'
+            execution_backend='eas-smoke'
+            instance_limit='1'
+            instance_id='astropy__astropy-12907'
           elif [[ "${RELEASE_PRERELEASE}" == 'false' && "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.0$ ]]; then
             should_run='true'
           fi
-          echo "should_run=${should_run}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "should_run=${should_run}"
+            echo "execution_backend=${execution_backend}"
+            echo "instance_limit=${instance_limit}"
+            echo "instance_id=${instance_id}"
+          } >> "${GITHUB_OUTPUT}"
           if [[ "${should_run}" == 'false' ]]; then
             echo "::notice::Skipping benchmark for ${RELEASE_TAG:-non-release event}"
           fi
@@ -66,15 +93,22 @@ jobs:
     name: 'Dispatch SWE-bench Verified to DSW'
     needs: 'release_gate'
     if: '${{ needs.release_gate.outputs.should_run == ''true'' }}'
-    runs-on: ['self-hosted', 'Linux', 'X64', 'qwen-benchmark-dsw']
+    runs-on: ['self-hosted', 'Linux', 'X64', 'qwen-benchmark-dsw-hk-eas']
     timeout-minutes: 15
     env:
       RELEASE_TAG: '${{ github.event_name == ''release'' && github.event.release.tag_name || inputs.release_tag }}'
       QWEN_REF: '${{ github.event_name == ''release'' && github.event.release.tag_name || inputs.qwen_release_tag || inputs.release_tag }}'
-      INSTANCE_LIMIT: '${{ github.event_name == ''release'' && ''500'' || inputs.instance_limit }}'
-      BENCHMARK_INSTANCE_ID: '${{ (github.event_name != ''release'' && inputs.instance_limit == ''1'') && inputs.instance_id || '''' }}'
+      INSTANCE_LIMIT: '${{ needs.release_gate.outputs.instance_limit }}'
+      BENCHMARK_INSTANCE_ID: '${{ needs.release_gate.outputs.instance_id }}'
       BENCHMARK_IDEMPOTENCY_KEY: 'dsw-release-v1-${{ github.run_id }}'
       GITHUB_RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+      BENCHMARK_EXECUTION_BACKEND: '${{ needs.release_gate.outputs.execution_backend }}'
+      DSW_POOL_ROOT: '/mnt/workspace/qwen-benchmark-acr-prewarm'
+      POOL_BIN: '/mnt/workspace/qwen-benchmark-eas-poc/venv/bin/qwen-benchmark-pool'
+      POOL_PYTHON: '/mnt/workspace/qwen-benchmark-eas-poc/venv/bin/python'
+      SWE_VERIFIED_DATASET_ROOT: '/mnt/workspace/qwen-benchmark-acr-prewarm/datasets/swe-bench-verified'
+      EAS_TEMPLATE_MANIFEST: '/mnt/workspace/qwen-benchmark-acr-prewarm/deploy/eas/templates.json'
+      BENCHMARK_POOL_DATABASE_URL: 'postgresql://postgres@/qwen_benchmark_eas?host=/mnt/dynamic/qwen-benchmark-pg/run&port=55432'
 
     steps:
       - name: 'Checkout pipeline'

--- a/.github/workflows/dsw-swe-verified-release.yml
+++ b/.github/workflows/dsw-swe-verified-release.yml
@@ -34,7 +34,7 @@ on:
         type: 'choice'
         options:
           - 'eas-smoke'
-          - 'eas'
+          - 'eas-harbor'
 
 permissions:
   contents: 'read'
@@ -63,7 +63,7 @@ jobs:
           RELEASE_PRERELEASE: '${{ github.event.release.prerelease || false }}'
         run: |-
           should_run='false'
-          execution_backend='eas'
+          execution_backend='eas-harbor'
           instance_limit='500'
           instance_id=''
           if [[ "${EVENT_NAME}" == 'workflow_dispatch' ]]; then
@@ -78,7 +78,7 @@ jobs:
             instance_id='astropy__astropy-12907'
           elif [[ "${RELEASE_PRERELEASE}" == 'true' && "${RELEASE_TAG}" =~ ^dsw-eas-full-[0-9A-Za-z._-]+$ ]]; then
             should_run='true'
-            execution_backend='eas'
+            execution_backend='eas-harbor'
             instance_limit='500'
             instance_id=''
           elif [[ "${RELEASE_PRERELEASE}" == 'false' && "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.0$ ]]; then
@@ -111,9 +111,12 @@ jobs:
       DSW_POOL_ROOT: '/mnt/workspace/qwen-benchmark-acr-prewarm'
       POOL_BIN: '/mnt/workspace/qwen-benchmark-eas-poc/venv/bin/qwen-benchmark-pool'
       POOL_PYTHON: '/mnt/workspace/qwen-benchmark-eas-poc/venv/bin/python'
+      PYTHONPATH: '/mnt/workspace/qwen-benchmark-eas-poc'
       SWE_VERIFIED_DATASET_ROOT: '/mnt/workspace/qwen-benchmark-acr-prewarm/datasets/swe-bench-verified'
       EAS_TEMPLATE_MANIFEST: '/mnt/workspace/qwen-benchmark-acr-prewarm/deploy/eas/templates.json'
-      BENCHMARK_POOL_DATABASE_URL: 'postgresql://postgres@/qwen_benchmark_eas?host=/mnt/dynamic/qwen-benchmark-pg/run&port=55432'
+      ACR_IMAGE_MANIFEST: '/mnt/workspace/qwen-benchmark-eas-poc/state/acr-manifest-c104f840.json'
+      ACR_IMAGE_STATE_DIR: '/mnt/data/qwen-benchmark/acr-prewarm/c104f840/state'
+      BENCHMARK_POOL_DATABASE_URL: 'postgresql://postgres@/qwen_benchmark_eas_long_pool?host=/mnt/dynamic/qwen-benchmark-pg/run&port=55432'
 
     steps:
       - name: 'Checkout pipeline'

--- a/.github/workflows/dsw-swe-verified-release.yml
+++ b/.github/workflows/dsw-swe-verified-release.yml
@@ -76,6 +76,11 @@ jobs:
             execution_backend='eas-smoke'
             instance_limit='1'
             instance_id='astropy__astropy-12907'
+          elif [[ "${RELEASE_PRERELEASE}" == 'true' && "${RELEASE_TAG}" =~ ^dsw-eas-full-[0-9A-Za-z._-]+$ ]]; then
+            should_run='true'
+            execution_backend='eas'
+            instance_limit='500'
+            instance_id=''
           elif [[ "${RELEASE_PRERELEASE}" == 'false' && "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.0$ ]]; then
             should_run='true'
           fi

--- a/.github/workflows/dsw-swe-verified-release.yml
+++ b/.github/workflows/dsw-swe-verified-release.yml
@@ -70,7 +70,9 @@ jobs:
             should_run='true'
             execution_backend='${{ inputs.execution_backend }}'
             instance_limit='${{ inputs.instance_limit }}'
-            instance_id='${{ inputs.instance_id }}'
+            if [[ "${instance_limit}" == '1' ]]; then
+              instance_id='${{ inputs.instance_id }}'
+            fi
           elif [[ "${RELEASE_PRERELEASE}" == 'true' && "${RELEASE_TAG}" =~ ^dsw-eas-smoke-[0-9A-Za-z._-]+$ ]]; then
             should_run='true'
             execution_backend='eas-smoke'


### PR DESCRIPTION
## Summary

- route the release benchmark to the dedicated Hong Kong DSW self-hosted runner
- add EAS and EAS infrastructure-smoke execution backends
- allow only `dsw-eas-smoke-*` prereleases to start the one-case non-scoreable smoke path
- validate that selected cases have immutable EAS Template mappings before PG submission

## Architecture

`prerelease -> GitHub Actions -> DSW runner -> PostgreSQL -> Coordinator -> up to 10 Executors -> EAS Sandbox -> OSS/PG`

The prerelease smoke is intentionally non-scoreable. Production `vX.Y.0` behavior remains unchanged.

## Validation

- manifest tests: 6/6
- workflow YAML parse, `bash -n`, and `git diff --check`
- prerelease: https://github.com/QwenLM/qwen-code/releases/tag/dsw-eas-smoke-20260812-281542bfdc
- automatic `release.published` Action: https://github.com/QwenLM/qwen-code/actions/runs/31555674505
- Pool run: `pool-9440458ad4c84929`
- DSW Runner dispatched one task to Executor `eas-hk-6`
- PostgreSQL run/task/attempt/event reached a unique terminal state
- OSS contains `result.json` and `trajectory.json`
- Sandbox was destroyed; no orphan remained
- result is explicitly `score_publishable=false`; no SWE score is claimed
