### PR TITLE
feat(web-shell): improve compact tool activity

### DIFF
--- a/docs/design/compact-mode/compact-mode-design.md
+++ b/docs/design/compact-mode/compact-mode-design.md
@@ -1,5 +1,8 @@
 # Compact Mode Design: Competitive Analysis & Optimization
 
+> Historical design. The current Web Shell behavior is documented in
+> [Web Shell compact mode and tool progress](../web-shell-thinking-and-tool-progress.md).
+
 > Ctrl+O compact/verbose mode toggle — competitive analysis with Claude Code, current implementation review, and optimization recommendations.
 >
 > User documentation: [Settings — ui.compactMode](../../users/configuration/settings.md).

--- a/docs/design/web-shell-thinking-and-tool-progress.md
+++ b/docs/design/web-shell-thinking-and-tool-progress.md
@@ -6,7 +6,7 @@ Update the existing Web Shell compact mode to hide transcript thinking without c
 
 ## Design
 
-`App` keeps the existing `Ctrl+O` compact-mode shortcut, context, Help terminology, and `ui.compactMode` workspace-setting write. Compact mode no longer switches message bodies to their old condensed cards. Instead, `MessageList` removes thinking rows only from its rendered item list, leaving the transcript and model behavior unchanged.
+`App` keeps the existing `Ctrl+O` compact-mode shortcut, context, Help terminology, and `ui.compactMode` workspace setting. The setting restores compact mode when the Web Shell loads and is updated when the shortcut toggles the mode. Compact mode no longer switches message bodies to their old condensed cards. Instead, `MessageList` removes thinking rows only from its rendered item list, leaving the transcript and model behavior unchanged.
 
 In compact mode, regular tool groups separated only by hidden thinking are merged within the same activity sequence. Outside compact mode, visible thinking preserves the original interleaved transcript order. User, assistant, system, plan, approval, agent, todo, and question UI boundaries remain separate. Running tool summaries are derived from all active foreground tools and reuse the existing tool descriptions. Completed summaries remain unchanged and appear only after no tool is active. Expanded tool rows reuse the existing tool-kind icons.
 

--- a/docs/design/web-shell-thinking-and-tool-progress.md
+++ b/docs/design/web-shell-thinking-and-tool-progress.md
@@ -1,0 +1,17 @@
+# Web Shell compact mode and tool progress
+
+## Goal
+
+Update the existing Web Shell compact mode to hide transcript thinking without changing model behavior and make parallel tool summaries describe every active foreground tool until all tools finish.
+
+## Design
+
+`App` keeps the existing `Ctrl+O` compact-mode shortcut, context, Help terminology, and `ui.compactMode` workspace-setting write. Compact mode no longer switches message bodies to their old condensed cards. Instead, `MessageList` removes thinking rows only from its rendered item list, leaving the transcript and model behavior unchanged.
+
+In compact mode, regular tool groups separated only by hidden thinking are merged within the same activity sequence. Outside compact mode, visible thinking preserves the original interleaved transcript order. User, assistant, system, plan, approval, agent, todo, and question UI boundaries remain separate. Running tool summaries are derived from all active foreground tools and reuse the existing tool descriptions. Completed summaries remain unchanged and appear only after no tool is active. Expanded tool rows reuse the existing tool-kind icons.
+
+Expanded tool rows show locally observed elapsed time while a tool is active and omit it after the tool finishes. Collapsed summaries do not show elapsed time.
+
+## Compatibility
+
+The existing compact-mode concept and persistence path remain unchanged. No new setting, URL parameter, public transcript prop, or `localStorage` key is introduced. The read-only `WebShellTranscript` remains outside compact mode.

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -4613,6 +4613,40 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+describe('App compact mode', () => {
+  async function toggleCompactMode() {
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          bubbles: true,
+          cancelable: true,
+          ctrlKey: true,
+          key: 'o',
+        }),
+      );
+      await Promise.resolve();
+    });
+  }
+
+  it('uses Ctrl+O and persists the existing workspace setting', async () => {
+    renderApp();
+    await toggleCompactMode();
+
+    expect(settingsSetValue).toHaveBeenCalledWith(
+      'workspace',
+      'ui.compactMode',
+      true,
+    );
+
+    await toggleCompactMode();
+    expect(settingsSetValue).toHaveBeenLastCalledWith(
+      'workspace',
+      'ui.compactMode',
+      false,
+    );
+  });
+});
+
 describe('App plan todos', () => {
   it('gates the exit-plan workflow on the experimental setting', async () => {
     const approvedEntries = [

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -4645,6 +4645,29 @@ describe('App compact mode', () => {
       false,
     );
   });
+
+  it('restores compact mode from the workspace setting', async () => {
+    testState.settings = [
+      {
+        key: 'ui.compactMode',
+        type: 'boolean',
+        label: 'Compact mode',
+        category: 'UI',
+        requiresRestart: false,
+        default: false,
+        values: { effective: true, workspace: true },
+      },
+    ];
+    renderApp();
+
+    await toggleCompactMode();
+
+    expect(settingsSetValue).toHaveBeenCalledWith(
+      'workspace',
+      'ui.compactMode',
+      false,
+    );
+  });
 });
 
 describe('App plan todos', () => {

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -5862,6 +5862,9 @@ export function App({
   const languageSetting = workspaceSettings.find(
     (setting) => setting.key === LANGUAGE_SETTING_KEY,
   );
+  const compactModeSetting = workspaceSettings.find(
+    (setting) => setting.key === COMPACT_MODE_SETTING_KEY,
+  );
   const currentVoiceModel = (() => {
     const value = readScopedModelSetting(
       targetedWorkspaceSettings,
@@ -6124,6 +6127,11 @@ export function App({
   const [compactMode, setCompactMode] = useState(false);
   const compactModeRef = useRef(compactMode);
   compactModeRef.current = compactMode;
+
+  useEffect(() => {
+    const value = compactModeSetting?.values.effective;
+    if (typeof value === 'boolean') setCompactMode(value);
+  }, [compactModeSetting?.values.effective]);
 
   useEffect(() => {
     if (providedTheme) {

--- a/packages/web-shell/client/adapters/transcriptToMessages.test.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.test.ts
@@ -118,6 +118,7 @@ function toolBlock(
     details: overrides.details,
     parentToolCallId: overrides.parentToolCallId,
     subagentType: overrides.subagentType,
+    serverTimestamp: overrides.serverTimestamp,
     clientReceivedAt: createdAt,
     createdAt,
     updatedAt: overrides.updatedAt ?? createdAt,
@@ -247,7 +248,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
       expect(messages).toHaveLength(2);
       expect(messages[0]).toMatchObject({
         role: 'tool_group',
-        tools: [{ callId: 'agent-call', status: expectedStatus, endTime: 2 }],
+        tools: [{ callId: 'agent-call', status: expectedStatus }],
       });
       expect(messages[1]).toMatchObject({
         role: 'system',
@@ -300,7 +301,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
     expect(messages).toHaveLength(2);
     expect(messages[0]).toMatchObject({
       role: 'tool_group',
-      tools: [{ callId: 'agent-call', status: 'completed', endTime: 2 }],
+      tools: [{ callId: 'agent-call', status: 'completed' }],
     });
     expect(messages[1]).toMatchObject({
       role: 'system',
@@ -312,6 +313,81 @@ describe('transcriptBlocksToDaemonMessages', () => {
         toolUseId: 'agent-call',
       },
     });
+  });
+
+  it('omits timing for a completed background agent', () => {
+    const messages = transcriptBlocksToDaemonMessages([
+      toolBlock('agent-block', 'agent-call', 'completed', 100_000, {
+        toolName: 'agent',
+        rawInput: { run_in_background: true },
+        rawOutput: { type: 'task_execution', status: 'background' },
+        serverTimestamp: 5_000,
+      }),
+      textBlock(
+        'agent-terminal',
+        'user',
+        'background agent finished',
+        200_000,
+        false,
+        {
+          serverTimestamp: 15_000,
+          meta: {
+            source: 'background_notification',
+            qwenDiscreteMessage: true,
+            backgroundTask: {
+              kind: 'agent',
+              status: 'completed',
+              taskId: 'agent-task',
+              toolUseId: 'agent-call',
+            },
+          },
+        },
+      ),
+    ]);
+
+    const tool =
+      messages[0]?.role === 'tool_group' ? messages[0].tools[0] : undefined;
+    expect(tool).not.toHaveProperty('startTime');
+    expect(tool).not.toHaveProperty('endTime');
+  });
+
+  it('does not apply timing from a non-terminal background notification', () => {
+    const messages = transcriptBlocksToDaemonMessages([
+      toolBlock('agent-block', 'agent-call', 'completed', 100_000, {
+        toolName: 'agent',
+        rawInput: { run_in_background: true },
+        rawOutput: { type: 'task_execution', status: 'background' },
+        serverTimestamp: 5_000,
+      }),
+      textBlock(
+        'agent-running',
+        'user',
+        'background agent running',
+        200_000,
+        false,
+        {
+          serverTimestamp: 15_000,
+          meta: {
+            source: 'background_notification',
+            qwenDiscreteMessage: true,
+            backgroundTask: {
+              kind: 'agent',
+              status: 'running',
+              taskId: 'agent-task',
+              toolUseId: 'agent-call',
+            },
+          },
+        },
+      ),
+    ]);
+
+    expect(messages[0]).toMatchObject({
+      role: 'tool_group',
+      tools: [{ callId: 'agent-call', status: 'pending', startTime: 100_000 }],
+    });
+    if (messages[0]?.role === 'tool_group') {
+      expect(messages[0].tools[0]).not.toHaveProperty('endTime');
+    }
   });
 
   it('does not apply a non-agent background notification to an agent tool', () => {
@@ -1072,7 +1148,6 @@ describe('transcriptBlocksToDaemonMessages', () => {
           {
             callId: 'agent-1',
             status: 'completed',
-            endTime: 35,
             rawOutput: {
               status: 'cancelled',
               reason: 'Agent was cancelled by user',
@@ -1089,7 +1164,6 @@ describe('transcriptBlocksToDaemonMessages', () => {
             callId: 'agent-2',
             status: 'completed',
             title: 'Agent: second done',
-            endTime: 45,
             rawOutput: { result: 'second result' },
           },
         ],
@@ -1630,7 +1704,6 @@ describe('transcriptBlocksToDaemonMessages', () => {
       title: 'Shell complete',
       status: 'completed',
       rawOutput: 'output text',
-      endTime: 4,
     });
   });
 
@@ -1854,7 +1927,6 @@ describe('transcriptBlocksToDaemonMessages', () => {
         {
           callId: 'agent-1',
           status: 'completed',
-          endTime: 30,
           rawOutput: {
             status: 'cancelled',
             reason: 'Agent was cancelled by user',
@@ -2003,6 +2075,105 @@ describe('transcriptBlocksToDaemonMessages', () => {
         ],
       },
     ]);
+  });
+
+  it('keeps completed timing hidden after merging a permission placeholder', () => {
+    const messages = transcriptBlocksToDaemonMessages([
+      {
+        id: 'perm-1',
+        kind: 'permission',
+        requestId: 'req-1',
+        sessionId: 'sess-1',
+        title: 'Allow shell?',
+        options: [{ optionId: 'proceed_once', label: 'Allow', raw: {} }],
+        toolCall: {
+          toolCallId: 'tc-1',
+          kind: 'execute',
+          toolName: 'run_shell_command',
+          rawInput: { command: 'ls' },
+        },
+        preview: { kind: 'generic' as const },
+        clientReceivedAt: 1_000,
+        createdAt: 1_000,
+        updatedAt: 2_000,
+        resolved: 'selected:proceed_once',
+      },
+      toolBlock('tool-1', 'tc-1', 'completed', 3_000, {
+        toolName: 'run_shell_command',
+        updatedAt: 13_000,
+        serverTimestamp: 5_000,
+      }),
+    ]);
+
+    const tool =
+      messages[0]?.role === 'tool_group' ? messages[0].tools[0] : undefined;
+    expect(tool).not.toHaveProperty('startTime');
+    expect(tool).not.toHaveProperty('endTime');
+  });
+
+  it('keeps completed timing hidden when the tool precedes the permission', () => {
+    const messages = transcriptBlocksToDaemonMessages([
+      toolBlock('tool-1', 'tc-1', 'completed', 3_000, {
+        toolName: 'run_shell_command',
+        updatedAt: 13_000,
+        serverTimestamp: 5_000,
+      }),
+      {
+        id: 'perm-1',
+        kind: 'permission',
+        requestId: 'req-1',
+        sessionId: 'sess-1',
+        title: 'Allow shell?',
+        options: [{ optionId: 'proceed_once', label: 'Allow', raw: {} }],
+        toolCall: {
+          toolCallId: 'tc-1',
+          kind: 'execute',
+          toolName: 'run_shell_command',
+          rawInput: { command: 'ls' },
+        },
+        preview: { kind: 'generic' as const },
+        clientReceivedAt: 110_000,
+        createdAt: 110_000,
+        updatedAt: 111_000,
+        resolved: 'selected:proceed_once',
+      },
+    ]);
+
+    const tool =
+      messages[0]?.role === 'tool_group' ? messages[0].tools[0] : undefined;
+    expect(tool).not.toHaveProperty('startTime');
+    expect(tool).not.toHaveProperty('endTime');
+  });
+
+  it('clears running timing when a permission is rejected', () => {
+    const messages = transcriptBlocksToDaemonMessages([
+      toolBlock('tool-1', 'tc-1', 'in_progress', 1_000, {
+        toolName: 'ReadFile',
+      }),
+      {
+        id: 'perm-1',
+        kind: 'permission',
+        requestId: 'req-1',
+        sessionId: 'sess-1',
+        title: 'Denied read',
+        options: [{ optionId: 'cancel', label: 'Deny', raw: {} }],
+        toolCall: {
+          toolCallId: 'tc-1',
+          toolName: 'ReadFile',
+        },
+        preview: { kind: 'generic' as const },
+        clientReceivedAt: 2_000,
+        createdAt: 2_000,
+        updatedAt: 2_000,
+        resolved: 'selected:cancel',
+      },
+    ]);
+
+    const tool =
+      messages[0]?.role === 'tool_group' ? messages[0].tools[0] : undefined;
+    expect(tool).toMatchObject({ callId: 'tc-1', status: 'failed' });
+    expect(tool).not.toHaveProperty('startTime');
+    expect(tool).not.toHaveProperty('endTime');
   });
 
   it('uses text content as raw output when a tool has no raw output', () => {
@@ -2568,7 +2739,6 @@ describe('transcriptBlocksToDaemonMessages', () => {
         callId: 'mcp-1',
         status: 'completed',
         rawOutput: '{"approved":true}',
-        endTime: 3,
       });
     },
   );
@@ -2610,7 +2780,6 @@ describe('transcriptBlocksToDaemonMessages', () => {
       expect(agentGroup.tools[0]).toMatchObject({
         callId: 'agent-1',
         status: 'failed',
-        endTime: 3,
       });
     }
     // Third: second thinking, fourth: response (not absorbed into agent subContent)
@@ -2650,7 +2819,6 @@ describe('transcriptBlocksToDaemonMessages', () => {
     expect(agent).toMatchObject({
       callId: 'agent-1',
       status: 'failed',
-      endTime: 2,
     });
   });
 
@@ -2897,6 +3065,46 @@ describe('transcriptBlocksToDaemonMessages', () => {
     ]);
   });
 
+  it('keeps the local observation start for an unstamped running tool', () => {
+    const messages = transcriptBlocksToDaemonMessages([
+      toolBlock('tool-1', 'call-1', 'in_progress', 100_000, {
+        updatedAt: 106_000,
+      }),
+    ]);
+
+    expect(messages[0]).toMatchObject({
+      role: 'tool_group',
+      tools: [{ startTime: 100_000 }],
+    });
+  });
+
+  it('omits a synthetic offline start for an unfinished tool', () => {
+    const messages = transcriptBlocksToDaemonMessages([
+      toolBlock('tool-1', 'call-1', 'in_progress', 0, {
+        serverTimestamp: 1_000,
+      }),
+    ]);
+
+    const tool =
+      messages[0]?.role === 'tool_group' ? messages[0].tools[0] : undefined;
+    expect(tool).not.toHaveProperty('startTime');
+    expect(tool).not.toHaveProperty('endTime');
+  });
+
+  it('omits timing for a completed tool', () => {
+    const messages = transcriptBlocksToDaemonMessages([
+      toolBlock('tool-1', 'call-1', 'completed', 100_000, {
+        serverTimestamp: 1_000,
+        updatedAt: 106_000,
+      }),
+    ]);
+
+    const tool =
+      messages[0]?.role === 'tool_group' ? messages[0].tools[0] : undefined;
+    expect(tool).not.toHaveProperty('startTime');
+    expect(tool).not.toHaveProperty('endTime');
+  });
+
   it('handles nested subagent via parentToolCallId', () => {
     const messages = transcriptBlocksToDaemonMessages([
       toolBlock('parent-start', 'parent-1', 'in_progress', 10, {
@@ -3138,7 +3346,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
     const tool =
       messages[0].role === 'tool_group' ? messages[0].tools[0] : undefined;
     expect(tool?.status).toBe('completed');
-    expect(tool?.endTime).toBe(25);
+    expect(tool?.endTime).toBeUndefined();
     expect(tool?.rawOutput).toBeUndefined();
   });
 
@@ -3255,7 +3463,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
       messages[0].role === 'tool_group' ? messages[0].tools[0] : undefined;
     expect(tool?.title).toBe('Agent: work done');
     expect(tool?.status).toBe('completed');
-    expect(tool?.endTime).toBe(25);
+    expect(tool?.endTime).toBeUndefined();
     expect(tool?.rawOutput).toEqual({
       type: 'task_execution',
       totalTokens: 500,
@@ -3374,7 +3582,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
     const agentTool =
       messages[0].role === 'tool_group' ? messages[0].tools[0] : undefined;
     expect(agentTool?.status).toBe('failed');
-    expect(agentTool?.endTime).toBe(25);
+    expect(agentTool?.endTime).toBeUndefined();
     expect(agentTool?.subContent).toBe('Looking into it');
     expect(messages[1]).toMatchObject({
       role: 'assistant',
@@ -3405,7 +3613,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
     expect(tools?.[1]?.status).toBe('pending');
     expect(tools?.[2]?.status).toBe('failed');
     expect(tool4?.status).toBe('completed');
-    expect(tool4?.endTime).toBe(5);
+    expect(tool4?.endTime).toBeUndefined();
   });
 
   it('parented blocks after completed subAgent remain nested', () => {

--- a/packages/web-shell/client/adapters/transcriptToMessages.test.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.test.ts
@@ -118,7 +118,6 @@ function toolBlock(
     details: overrides.details,
     parentToolCallId: overrides.parentToolCallId,
     subagentType: overrides.subagentType,
-    serverTimestamp: overrides.serverTimestamp,
     clientReceivedAt: createdAt,
     createdAt,
     updatedAt: overrides.updatedAt ?? createdAt,
@@ -248,7 +247,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
       expect(messages).toHaveLength(2);
       expect(messages[0]).toMatchObject({
         role: 'tool_group',
-        tools: [{ callId: 'agent-call', status: expectedStatus }],
+        tools: [{ callId: 'agent-call', status: expectedStatus, endTime: 2 }],
       });
       expect(messages[1]).toMatchObject({
         role: 'system',
@@ -301,7 +300,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
     expect(messages).toHaveLength(2);
     expect(messages[0]).toMatchObject({
       role: 'tool_group',
-      tools: [{ callId: 'agent-call', status: 'completed' }],
+      tools: [{ callId: 'agent-call', status: 'completed', endTime: 2 }],
     });
     expect(messages[1]).toMatchObject({
       role: 'system',
@@ -313,81 +312,6 @@ describe('transcriptBlocksToDaemonMessages', () => {
         toolUseId: 'agent-call',
       },
     });
-  });
-
-  it('omits timing for a completed background agent', () => {
-    const messages = transcriptBlocksToDaemonMessages([
-      toolBlock('agent-block', 'agent-call', 'completed', 100_000, {
-        toolName: 'agent',
-        rawInput: { run_in_background: true },
-        rawOutput: { type: 'task_execution', status: 'background' },
-        serverTimestamp: 5_000,
-      }),
-      textBlock(
-        'agent-terminal',
-        'user',
-        'background agent finished',
-        200_000,
-        false,
-        {
-          serverTimestamp: 15_000,
-          meta: {
-            source: 'background_notification',
-            qwenDiscreteMessage: true,
-            backgroundTask: {
-              kind: 'agent',
-              status: 'completed',
-              taskId: 'agent-task',
-              toolUseId: 'agent-call',
-            },
-          },
-        },
-      ),
-    ]);
-
-    const tool =
-      messages[0]?.role === 'tool_group' ? messages[0].tools[0] : undefined;
-    expect(tool).not.toHaveProperty('startTime');
-    expect(tool).not.toHaveProperty('endTime');
-  });
-
-  it('does not apply timing from a non-terminal background notification', () => {
-    const messages = transcriptBlocksToDaemonMessages([
-      toolBlock('agent-block', 'agent-call', 'completed', 100_000, {
-        toolName: 'agent',
-        rawInput: { run_in_background: true },
-        rawOutput: { type: 'task_execution', status: 'background' },
-        serverTimestamp: 5_000,
-      }),
-      textBlock(
-        'agent-running',
-        'user',
-        'background agent running',
-        200_000,
-        false,
-        {
-          serverTimestamp: 15_000,
-          meta: {
-            source: 'background_notification',
-            qwenDiscreteMessage: true,
-            backgroundTask: {
-              kind: 'agent',
-              status: 'running',
-              taskId: 'agent-task',
-              toolUseId: 'agent-call',
-            },
-          },
-        },
-      ),
-    ]);
-
-    expect(messages[0]).toMatchObject({
-      role: 'tool_group',
-      tools: [{ callId: 'agent-call', status: 'pending', startTime: 100_000 }],
-    });
-    if (messages[0]?.role === 'tool_group') {
-      expect(messages[0].tools[0]).not.toHaveProperty('endTime');
-    }
   });
 
   it('does not apply a non-agent background notification to an agent tool', () => {
@@ -1148,6 +1072,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
           {
             callId: 'agent-1',
             status: 'completed',
+            endTime: 35,
             rawOutput: {
               status: 'cancelled',
               reason: 'Agent was cancelled by user',
@@ -1164,6 +1089,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
             callId: 'agent-2',
             status: 'completed',
             title: 'Agent: second done',
+            endTime: 45,
             rawOutput: { result: 'second result' },
           },
         ],
@@ -1704,6 +1630,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
       title: 'Shell complete',
       status: 'completed',
       rawOutput: 'output text',
+      endTime: 4,
     });
   });
 
@@ -1927,6 +1854,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
         {
           callId: 'agent-1',
           status: 'completed',
+          endTime: 30,
           rawOutput: {
             status: 'cancelled',
             reason: 'Agent was cancelled by user',
@@ -2075,105 +2003,6 @@ describe('transcriptBlocksToDaemonMessages', () => {
         ],
       },
     ]);
-  });
-
-  it('keeps completed timing hidden after merging a permission placeholder', () => {
-    const messages = transcriptBlocksToDaemonMessages([
-      {
-        id: 'perm-1',
-        kind: 'permission',
-        requestId: 'req-1',
-        sessionId: 'sess-1',
-        title: 'Allow shell?',
-        options: [{ optionId: 'proceed_once', label: 'Allow', raw: {} }],
-        toolCall: {
-          toolCallId: 'tc-1',
-          kind: 'execute',
-          toolName: 'run_shell_command',
-          rawInput: { command: 'ls' },
-        },
-        preview: { kind: 'generic' as const },
-        clientReceivedAt: 1_000,
-        createdAt: 1_000,
-        updatedAt: 2_000,
-        resolved: 'selected:proceed_once',
-      },
-      toolBlock('tool-1', 'tc-1', 'completed', 3_000, {
-        toolName: 'run_shell_command',
-        updatedAt: 13_000,
-        serverTimestamp: 5_000,
-      }),
-    ]);
-
-    const tool =
-      messages[0]?.role === 'tool_group' ? messages[0].tools[0] : undefined;
-    expect(tool).not.toHaveProperty('startTime');
-    expect(tool).not.toHaveProperty('endTime');
-  });
-
-  it('keeps completed timing hidden when the tool precedes the permission', () => {
-    const messages = transcriptBlocksToDaemonMessages([
-      toolBlock('tool-1', 'tc-1', 'completed', 3_000, {
-        toolName: 'run_shell_command',
-        updatedAt: 13_000,
-        serverTimestamp: 5_000,
-      }),
-      {
-        id: 'perm-1',
-        kind: 'permission',
-        requestId: 'req-1',
-        sessionId: 'sess-1',
-        title: 'Allow shell?',
-        options: [{ optionId: 'proceed_once', label: 'Allow', raw: {} }],
-        toolCall: {
-          toolCallId: 'tc-1',
-          kind: 'execute',
-          toolName: 'run_shell_command',
-          rawInput: { command: 'ls' },
-        },
-        preview: { kind: 'generic' as const },
-        clientReceivedAt: 110_000,
-        createdAt: 110_000,
-        updatedAt: 111_000,
-        resolved: 'selected:proceed_once',
-      },
-    ]);
-
-    const tool =
-      messages[0]?.role === 'tool_group' ? messages[0].tools[0] : undefined;
-    expect(tool).not.toHaveProperty('startTime');
-    expect(tool).not.toHaveProperty('endTime');
-  });
-
-  it('clears running timing when a permission is rejected', () => {
-    const messages = transcriptBlocksToDaemonMessages([
-      toolBlock('tool-1', 'tc-1', 'in_progress', 1_000, {
-        toolName: 'ReadFile',
-      }),
-      {
-        id: 'perm-1',
-        kind: 'permission',
-        requestId: 'req-1',
-        sessionId: 'sess-1',
-        title: 'Denied read',
-        options: [{ optionId: 'cancel', label: 'Deny', raw: {} }],
-        toolCall: {
-          toolCallId: 'tc-1',
-          toolName: 'ReadFile',
-        },
-        preview: { kind: 'generic' as const },
-        clientReceivedAt: 2_000,
-        createdAt: 2_000,
-        updatedAt: 2_000,
-        resolved: 'selected:cancel',
-      },
-    ]);
-
-    const tool =
-      messages[0]?.role === 'tool_group' ? messages[0].tools[0] : undefined;
-    expect(tool).toMatchObject({ callId: 'tc-1', status: 'failed' });
-    expect(tool).not.toHaveProperty('startTime');
-    expect(tool).not.toHaveProperty('endTime');
   });
 
   it('uses text content as raw output when a tool has no raw output', () => {
@@ -2739,6 +2568,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
         callId: 'mcp-1',
         status: 'completed',
         rawOutput: '{"approved":true}',
+        endTime: 3,
       });
     },
   );
@@ -2780,6 +2610,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
       expect(agentGroup.tools[0]).toMatchObject({
         callId: 'agent-1',
         status: 'failed',
+        endTime: 3,
       });
     }
     // Third: second thinking, fourth: response (not absorbed into agent subContent)
@@ -2819,6 +2650,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
     expect(agent).toMatchObject({
       callId: 'agent-1',
       status: 'failed',
+      endTime: 2,
     });
   });
 
@@ -3065,46 +2897,6 @@ describe('transcriptBlocksToDaemonMessages', () => {
     ]);
   });
 
-  it('keeps the local observation start for an unstamped running tool', () => {
-    const messages = transcriptBlocksToDaemonMessages([
-      toolBlock('tool-1', 'call-1', 'in_progress', 100_000, {
-        updatedAt: 106_000,
-      }),
-    ]);
-
-    expect(messages[0]).toMatchObject({
-      role: 'tool_group',
-      tools: [{ startTime: 100_000 }],
-    });
-  });
-
-  it('omits a synthetic offline start for an unfinished tool', () => {
-    const messages = transcriptBlocksToDaemonMessages([
-      toolBlock('tool-1', 'call-1', 'in_progress', 0, {
-        serverTimestamp: 1_000,
-      }),
-    ]);
-
-    const tool =
-      messages[0]?.role === 'tool_group' ? messages[0].tools[0] : undefined;
-    expect(tool).not.toHaveProperty('startTime');
-    expect(tool).not.toHaveProperty('endTime');
-  });
-
-  it('omits timing for a completed tool', () => {
-    const messages = transcriptBlocksToDaemonMessages([
-      toolBlock('tool-1', 'call-1', 'completed', 100_000, {
-        serverTimestamp: 1_000,
-        updatedAt: 106_000,
-      }),
-    ]);
-
-    const tool =
-      messages[0]?.role === 'tool_group' ? messages[0].tools[0] : undefined;
-    expect(tool).not.toHaveProperty('startTime');
-    expect(tool).not.toHaveProperty('endTime');
-  });
-
   it('handles nested subagent via parentToolCallId', () => {
     const messages = transcriptBlocksToDaemonMessages([
       toolBlock('parent-start', 'parent-1', 'in_progress', 10, {
@@ -3346,7 +3138,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
     const tool =
       messages[0].role === 'tool_group' ? messages[0].tools[0] : undefined;
     expect(tool?.status).toBe('completed');
-    expect(tool?.endTime).toBeUndefined();
+    expect(tool?.endTime).toBe(25);
     expect(tool?.rawOutput).toBeUndefined();
   });
 
@@ -3463,7 +3255,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
       messages[0].role === 'tool_group' ? messages[0].tools[0] : undefined;
     expect(tool?.title).toBe('Agent: work done');
     expect(tool?.status).toBe('completed');
-    expect(tool?.endTime).toBeUndefined();
+    expect(tool?.endTime).toBe(25);
     expect(tool?.rawOutput).toEqual({
       type: 'task_execution',
       totalTokens: 500,
@@ -3582,7 +3374,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
     const agentTool =
       messages[0].role === 'tool_group' ? messages[0].tools[0] : undefined;
     expect(agentTool?.status).toBe('failed');
-    expect(agentTool?.endTime).toBeUndefined();
+    expect(agentTool?.endTime).toBe(25);
     expect(agentTool?.subContent).toBe('Looking into it');
     expect(messages[1]).toMatchObject({
       role: 'assistant',
@@ -3613,7 +3405,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
     expect(tools?.[1]?.status).toBe('pending');
     expect(tools?.[2]?.status).toBe('failed');
     expect(tool4?.status).toBe('completed');
-    expect(tool4?.endTime).toBeUndefined();
+    expect(tool4?.endTime).toBe(5);
   });
 
   it('parented blocks after completed subAgent remain nested', () => {

--- a/packages/web-shell/client/adapters/transcriptToMessages.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.ts
@@ -54,14 +54,7 @@ interface TranscriptMessageOptions {
 
 interface BackgroundAgentTaskUpdate {
   status: string;
-}
-
-function getToolTiming(
-  block: DaemonToolTranscriptBlock,
-  complete: boolean,
-): { startTime?: number } {
-  if (complete) return {};
-  return block.clientReceivedAt === 0 ? {} : { startTime: block.createdAt };
+  endTime: number;
 }
 
 function collectBackgroundAgentTaskUpdates(
@@ -81,7 +74,10 @@ function collectBackgroundAgentTaskUpdates(
     const toolUseId = getString(task, 'toolUseId');
     const status = getString(task, 'status');
     if (task?.['kind'] !== 'agent' || !toolUseId || !status) continue;
-    updates.set(toolUseId, { status });
+    updates.set(toolUseId, {
+      status,
+      endTime: block.serverTimestamp ?? block.clientReceivedAt,
+    });
   }
   return updates;
 }
@@ -94,23 +90,22 @@ function applyBackgroundAgentTaskUpdate(
   switch (update.status) {
     case 'completed':
       tool.status = 'completed';
+      tool.endTime = update.endTime;
       break;
     case 'failed':
       tool.status = 'failed';
+      tool.endTime = update.endTime;
       break;
     case 'cancelled':
     case 'canceled':
       tool.status = 'completed';
+      tool.endTime = update.endTime;
       tool.rawOutput = {
         ...(getRecord(tool.rawOutput) ?? {}),
         status: 'cancelled',
       };
       break;
-    default:
-      return;
   }
-  delete tool.startTime;
-  delete tool.endTime;
 }
 
 function isIgnoredWebShellStatus(text: string): boolean {
@@ -569,10 +564,6 @@ export function transcriptBlocksToDaemonMessages(
 
         if (existingTool) {
           mergeToolCall(existingTool, toolCall);
-          if (isTerminalToolStatus(toolCall.status)) {
-            delete existingTool.startTime;
-            delete existingTool.endTime;
-          }
           break;
         }
 
@@ -666,32 +657,26 @@ export function transcriptBlocksToDaemonMessages(
         if (existingPermission) {
           const previousStatus = existingPermission.status;
           const previousEndTime = existingPermission.endTime;
-          const approved = isApprovedPermissionResolution(permBlock.resolved);
           permissionToolCall.toolName = existingPermission.toolName;
-          permissionToolCall.status = approved
-            ? isSubAgentPermission
-              ? permissionToolCall.status
-              : 'in_progress'
-            : 'failed';
-          // Do not replace the tool's observed start with the permission block's time.
-          permissionToolCall.startTime = undefined;
+          if (permBlock.resolved) {
+            if (isApprovedPermissionResolution(permBlock.resolved)) {
+              permissionToolCall.status = isSubAgentPermission
+                ? permissionToolCall.status
+                : 'in_progress';
+            } else {
+              permissionToolCall.status = 'failed';
+              permissionToolCall.endTime = permBlock.updatedAt;
+            }
+          }
           mergeToolCall(existingPermission, permissionToolCall);
           if (
             isTerminalToolStatus(previousStatus) ||
-            (isSubAgentPermission && approved)
+            (permBlock.resolved &&
+              isSubAgentPermission &&
+              isApprovedPermissionResolution(permBlock.resolved))
           ) {
             existingPermission.status = previousStatus;
-            if (previousEndTime !== undefined) {
-              existingPermission.endTime = previousEndTime;
-            } else {
-              delete existingPermission.endTime;
-            }
-            if (isTerminalToolStatus(previousStatus)) {
-              delete existingPermission.startTime;
-            }
-          } else if (!approved) {
-            delete existingPermission.startTime;
-            delete existingPermission.endTime;
+            existingPermission.endTime = previousEndTime;
           }
           break;
         }
@@ -718,7 +703,7 @@ export function transcriptBlocksToDaemonMessages(
             needsNewContentMessage = true;
           } else {
             permissionToolCall.status = 'failed';
-            delete permissionToolCall.startTime;
+            permissionToolCall.endTime = permBlock.updatedAt;
             appendToolCallMessage(
               messages,
               block.id,
@@ -910,8 +895,7 @@ function mergeToolCall(
   target.toolName = source.toolName ?? target.toolName;
   target.kind = source.kind ?? target.kind;
   target.content = source.content ?? target.content;
-  if (source.startTime !== undefined) target.startTime = source.startTime;
-  if (source.endTime !== undefined) target.endTime = source.endTime;
+  target.endTime = source.endTime ?? target.endTime;
   target.rawOutput = source.rawOutput ?? target.rawOutput;
   target.args = source.args ?? target.args;
   target.locations = source.locations ?? target.locations;
@@ -1013,7 +997,6 @@ function daemonToolBlockToToolCall(
     block.status === 'failed' ||
     block.status === 'cancelled' ||
     block.status === 'canceled';
-  const timing = getToolTiming(block, isComplete && !isBackgroundAgent);
 
   return {
     callId: block.toolCallId,
@@ -1027,7 +1010,8 @@ function daemonToolBlockToToolCall(
     rawOutput,
     args: block.rawInput as Record<string, unknown> | undefined,
     parentToolCallId: block.parentToolCallId,
-    ...timing,
+    startTime: block.createdAt,
+    endTime: isComplete && !isBackgroundAgent ? block.updatedAt : undefined,
     ...(content ? { content } : {}),
   };
 }

--- a/packages/web-shell/client/adapters/transcriptToMessages.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.ts
@@ -54,7 +54,14 @@ interface TranscriptMessageOptions {
 
 interface BackgroundAgentTaskUpdate {
   status: string;
-  endTime: number;
+}
+
+function getToolTiming(
+  block: DaemonToolTranscriptBlock,
+  complete: boolean,
+): { startTime?: number } {
+  if (complete) return {};
+  return block.clientReceivedAt === 0 ? {} : { startTime: block.createdAt };
 }
 
 function collectBackgroundAgentTaskUpdates(
@@ -74,10 +81,7 @@ function collectBackgroundAgentTaskUpdates(
     const toolUseId = getString(task, 'toolUseId');
     const status = getString(task, 'status');
     if (task?.['kind'] !== 'agent' || !toolUseId || !status) continue;
-    updates.set(toolUseId, {
-      status,
-      endTime: block.serverTimestamp ?? block.clientReceivedAt,
-    });
+    updates.set(toolUseId, { status });
   }
   return updates;
 }
@@ -90,22 +94,23 @@ function applyBackgroundAgentTaskUpdate(
   switch (update.status) {
     case 'completed':
       tool.status = 'completed';
-      tool.endTime = update.endTime;
       break;
     case 'failed':
       tool.status = 'failed';
-      tool.endTime = update.endTime;
       break;
     case 'cancelled':
     case 'canceled':
       tool.status = 'completed';
-      tool.endTime = update.endTime;
       tool.rawOutput = {
         ...(getRecord(tool.rawOutput) ?? {}),
         status: 'cancelled',
       };
       break;
+    default:
+      return;
   }
+  delete tool.startTime;
+  delete tool.endTime;
 }
 
 function isIgnoredWebShellStatus(text: string): boolean {
@@ -564,6 +569,10 @@ export function transcriptBlocksToDaemonMessages(
 
         if (existingTool) {
           mergeToolCall(existingTool, toolCall);
+          if (isTerminalToolStatus(toolCall.status)) {
+            delete existingTool.startTime;
+            delete existingTool.endTime;
+          }
           break;
         }
 
@@ -657,26 +666,32 @@ export function transcriptBlocksToDaemonMessages(
         if (existingPermission) {
           const previousStatus = existingPermission.status;
           const previousEndTime = existingPermission.endTime;
+          const approved = isApprovedPermissionResolution(permBlock.resolved);
           permissionToolCall.toolName = existingPermission.toolName;
-          if (permBlock.resolved) {
-            if (isApprovedPermissionResolution(permBlock.resolved)) {
-              permissionToolCall.status = isSubAgentPermission
-                ? permissionToolCall.status
-                : 'in_progress';
-            } else {
-              permissionToolCall.status = 'failed';
-              permissionToolCall.endTime = permBlock.updatedAt;
-            }
-          }
+          permissionToolCall.status = approved
+            ? isSubAgentPermission
+              ? permissionToolCall.status
+              : 'in_progress'
+            : 'failed';
+          // Do not replace the tool's observed start with the permission block's time.
+          permissionToolCall.startTime = undefined;
           mergeToolCall(existingPermission, permissionToolCall);
           if (
             isTerminalToolStatus(previousStatus) ||
-            (permBlock.resolved &&
-              isSubAgentPermission &&
-              isApprovedPermissionResolution(permBlock.resolved))
+            (isSubAgentPermission && approved)
           ) {
             existingPermission.status = previousStatus;
-            existingPermission.endTime = previousEndTime;
+            if (previousEndTime !== undefined) {
+              existingPermission.endTime = previousEndTime;
+            } else {
+              delete existingPermission.endTime;
+            }
+            if (isTerminalToolStatus(previousStatus)) {
+              delete existingPermission.startTime;
+            }
+          } else if (!approved) {
+            delete existingPermission.startTime;
+            delete existingPermission.endTime;
           }
           break;
         }
@@ -703,7 +718,7 @@ export function transcriptBlocksToDaemonMessages(
             needsNewContentMessage = true;
           } else {
             permissionToolCall.status = 'failed';
-            permissionToolCall.endTime = permBlock.updatedAt;
+            delete permissionToolCall.startTime;
             appendToolCallMessage(
               messages,
               block.id,
@@ -895,7 +910,8 @@ function mergeToolCall(
   target.toolName = source.toolName ?? target.toolName;
   target.kind = source.kind ?? target.kind;
   target.content = source.content ?? target.content;
-  target.endTime = source.endTime ?? target.endTime;
+  if (source.startTime !== undefined) target.startTime = source.startTime;
+  if (source.endTime !== undefined) target.endTime = source.endTime;
   target.rawOutput = source.rawOutput ?? target.rawOutput;
   target.args = source.args ?? target.args;
   target.locations = source.locations ?? target.locations;
@@ -997,6 +1013,7 @@ function daemonToolBlockToToolCall(
     block.status === 'failed' ||
     block.status === 'cancelled' ||
     block.status === 'canceled';
+  const timing = getToolTiming(block, isComplete && !isBackgroundAgent);
 
   return {
     callId: block.toolCallId,
@@ -1010,8 +1027,7 @@ function daemonToolBlockToToolCall(
     rawOutput,
     args: block.rawInput as Record<string, unknown> | undefined,
     parentToolCallId: block.parentToolCallId,
-    startTime: block.createdAt,
-    endTime: isComplete && !isBackgroundAgent ? block.updatedAt : undefined,
+    ...timing,
     ...(content ? { content } : {}),
   };
 }

--- a/packages/web-shell/client/components/MessageItem.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageItem.dom.test.tsx
@@ -10,6 +10,11 @@ import {
 } from '../customization';
 import type { Message } from '../adapters/types';
 
+vi.mock('../App', async () => {
+  const { createContext } = await import('react');
+  return { CompactModeContext: createContext(false) };
+});
+
 // Stub the message body components so MessageItem's own wiring — not the bodies
 // — is under test. UserMessage/AssistantMessage throw on a sentinel so we can
 // drive the message-level ErrorBoundary (the real one, imported below); the
@@ -18,8 +23,18 @@ import type { Message } from '../adapters/types';
 vi.mock('./MessageTimestamp', async () => {
   const React = await import('react');
   return {
-    MessageTimestamp: ({ children }: { children: React.ReactNode }) =>
-      React.createElement('div', null, children),
+    MessageTimestamp: ({
+      children,
+      toolGroupSpacing,
+    }: {
+      children: React.ReactNode;
+      toolGroupSpacing?: boolean;
+    }) =>
+      React.createElement(
+        'div',
+        { 'data-tool-group-spacing': String(toolGroupSpacing === true) },
+        children,
+      ),
     formatTimestamp: () => '',
   };
 });
@@ -73,6 +88,7 @@ vi.mock('./InsightProgress', () => ({ InsightProgress: () => null }));
 vi.mock('./InsightReady', () => ({ InsightReady: () => null }));
 
 const { MessageItem } = await import('./MessageItem');
+const { CompactModeContext } = await import('../App');
 
 (
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -112,6 +128,12 @@ const assistantMsg = (id: string, content: string): Message =>
   ({ id, role: 'assistant', content, timestamp: 0 }) as Message;
 const thinkingMsg = (id: string, content: string): Message =>
   ({ id, role: 'thinking', content, timestamp: 0 }) as Message;
+const toolMsg = (id: string): Message => ({
+  id,
+  role: 'tool_group',
+  tools: [],
+  timestamp: 0,
+});
 
 function item(message: Message) {
   return <MessageItem message={message} />;
@@ -192,6 +214,50 @@ describe('MessageItem selectable wrapper', () => {
     // The message body renders inside the wrapper, so the CSS descendant
     // selector `[data-user-selectable] *` still re-enables selection.
     expect(wrapper.querySelector('[data-testid="user-ok"]')).not.toBeNull();
+  });
+});
+
+describe('MessageItem tool group spacing', () => {
+  it('uses larger row spacing only in compact mode', () => {
+    const compact = render(
+      <I18nProvider language="en">
+        <CompactModeContext.Provider value={true}>
+          {item(toolMsg('compact'))}
+        </CompactModeContext.Provider>
+      </I18nProvider>,
+    );
+    const regular = render(
+      <I18nProvider language="en">
+        <CompactModeContext.Provider value={false}>
+          {item(toolMsg('regular'))}
+        </CompactModeContext.Provider>
+      </I18nProvider>,
+    );
+    const compactAssistant = render(
+      <I18nProvider language="en">
+        <CompactModeContext.Provider value={true}>
+          {item(assistantMsg('assistant', 'answer'))}
+        </CompactModeContext.Provider>
+      </I18nProvider>,
+    );
+    const defaultTool = render(
+      <I18nProvider language="en">{item(toolMsg('default'))}</I18nProvider>,
+    );
+
+    expect(
+      compact.firstElementChild?.getAttribute('data-tool-group-spacing'),
+    ).toBe('true');
+    expect(
+      regular.firstElementChild?.getAttribute('data-tool-group-spacing'),
+    ).toBe('false');
+    expect(
+      compactAssistant.firstElementChild?.getAttribute(
+        'data-tool-group-spacing',
+      ),
+    ).toBe('false');
+    expect(
+      defaultTool.firstElementChild?.getAttribute('data-tool-group-spacing'),
+    ).toBe('false');
   });
 });
 

--- a/packages/web-shell/client/components/MessageItem.tsx
+++ b/packages/web-shell/client/components/MessageItem.tsx
@@ -1,10 +1,11 @@
-import { memo, type ReactElement } from 'react';
+import { memo, useContext, type ReactElement } from 'react';
 import type {
   ACPToolCall,
   Message,
   PermissionRequest,
   TodoItem,
 } from '../adapters/types';
+import { CompactModeContext } from '../App';
 import type { WebShellAssistantTurnFooterRenderInfo } from '../customization';
 import { useI18n } from '../i18n';
 import { ErrorBoundary } from './ErrorBoundary';
@@ -63,6 +64,7 @@ export const MessageItem = memo(function MessageItem({
   generateContent,
 }: MessageItemProps) {
   const { t } = useI18n();
+  const compactMode = useContext(CompactModeContext);
   const body = ((): ReactElement | null => {
     switch (message.role) {
       case 'user':
@@ -227,6 +229,7 @@ export const MessageItem = memo(function MessageItem({
     <MessageTimestamp
       timestamp={message.timestamp}
       chatMode={message.role === 'user'}
+      toolGroupSpacing={message.role === 'tool_group' && compactMode}
       copyText={message.role === 'user' ? message.content : undefined}
       copyTitle={t('common.copy')}
     >

--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -627,6 +627,30 @@ describe('MessageList — compact mode', () => {
       ).not.toBeNull();
     },
   );
+
+  it.each([
+    ['TodoWrite', standaloneToolMsg('special', 'TodoWrite')],
+    ['AskUserQuestion', standaloneToolMsg('special', 'AskUserQuestion')],
+    ['agent', agentMsg('special')],
+  ])('does not merge a leading %s group with later tools', (_name, special) => {
+    const container = mount(
+      [special, thinkingMsg('t1'), toolMsg('g2')],
+      undefined,
+      {
+        compactMode: true,
+        customization: { collapseCompletedTurns: false },
+      },
+    );
+
+    expect(
+      container.querySelector('[data-testid="msg-special"]'),
+    ).not.toBeNull();
+    expect(
+      container
+        .querySelector('[data-testid="msg-g2"]')
+        ?.getAttribute('data-tool-ids'),
+    ).toBe('call-g2');
+  });
 });
 
 describe('MessageList — turn collapse (DOM)', () => {

--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -59,6 +59,11 @@ vi.mock('./MessageItem', async () => {
           'data-assistant-actions': String(Boolean(showAssistantActions)),
           'data-locate-flashing': isLocateFlashing ? 'true' : undefined,
           'data-send-failed': sendFailed ? 'true' : undefined,
+          'data-timestamp': message.timestamp,
+          'data-tool-ids':
+            message.role === 'tool_group'
+              ? message.tools.map((tool) => tool.callId).join(',')
+              : undefined,
         },
         sendFailed
           ? React.createElement(
@@ -114,6 +119,7 @@ vi.mock('@tanstack/react-virtual', () => ({
 }));
 
 const { MessageList } = await import('./MessageList');
+const { CompactModeContext } = await import('../App');
 type MessageListHandle = import('./MessageList').MessageListHandle;
 
 (
@@ -152,6 +158,7 @@ const mounted: Array<{
   root: Root;
   container: HTMLElement;
   transcriptRenderMode: TranscriptRenderMode;
+  compactMode: boolean;
 }> = [];
 afterEach(() => {
   for (const { root, container } of mounted.splice(0)) {
@@ -203,6 +210,11 @@ const agentMsg = (id: string): ToolGroupMessage => ({
       args: { subagent_type: 'explore', run_in_background: true },
     },
   ],
+});
+const standaloneToolMsg = (id: string, toolName: string): ToolGroupMessage => ({
+  id,
+  role: 'tool_group',
+  tools: [{ callId: `call-${id}`, toolName, status: 'completed' }],
 });
 const asstMsg = (id: string): AssistantMessage => ({
   id,
@@ -294,6 +306,7 @@ function mount(
     includeSubagentToolUsageInMetrics?: boolean;
     onCanScrollToBottomChange?: (canScrollToBottom: boolean) => void;
     customization?: WebShellCustomization;
+    compactMode?: boolean;
     failedPromptMessageId?: string;
     onRetryFailedPrompt?: () => void;
   } = {},
@@ -305,35 +318,37 @@ function mount(
     root.render(
       <I18nProvider language="en">
         <WebShellCustomizationProvider value={opts.customization ?? {}}>
-          <TranscriptRenderModeProvider
-            value={opts.transcriptRenderMode ?? 'interactive'}
-          >
-            <MessageList
-              ref={ref}
-              messages={messages}
-              pendingApproval={null}
-              hideSessionTimeline={opts.hideSessionTimeline}
-              loadingTranscript={opts.loadingTranscript}
-              catchingUp={opts.catchingUp}
-              hasOlderHistory={opts.hasOlderHistory}
-              loadingOlderHistory={opts.loadingOlderHistory}
-              historyCapacityReached={opts.historyCapacityReached}
-              historyPaginationError={opts.historyPaginationError}
-              onLoadOlderHistory={opts.onLoadOlderHistory}
-              transcriptBlockCount={opts.transcriptBlockCount}
-              transcriptActivity={opts.transcriptActivity}
-              onReloadTranscript={opts.onReloadTranscript}
-              isResponding={opts.isResponding}
-              hideFirstUserMessage={opts.hideFirstUserMessage}
-              firstTurnMetrics={opts.firstTurnMetrics}
-              includeSubagentToolUsageInMetrics={
-                opts.includeSubagentToolUsageInMetrics
-              }
-              onCanScrollToBottomChange={opts.onCanScrollToBottomChange}
-              failedPromptMessageId={opts.failedPromptMessageId}
-              onRetryFailedPrompt={opts.onRetryFailedPrompt}
-            />
-          </TranscriptRenderModeProvider>
+          <CompactModeContext.Provider value={opts.compactMode ?? false}>
+            <TranscriptRenderModeProvider
+              value={opts.transcriptRenderMode ?? 'interactive'}
+            >
+              <MessageList
+                ref={ref}
+                messages={messages}
+                pendingApproval={null}
+                hideSessionTimeline={opts.hideSessionTimeline}
+                loadingTranscript={opts.loadingTranscript}
+                catchingUp={opts.catchingUp}
+                hasOlderHistory={opts.hasOlderHistory}
+                loadingOlderHistory={opts.loadingOlderHistory}
+                historyCapacityReached={opts.historyCapacityReached}
+                historyPaginationError={opts.historyPaginationError}
+                onLoadOlderHistory={opts.onLoadOlderHistory}
+                transcriptBlockCount={opts.transcriptBlockCount}
+                transcriptActivity={opts.transcriptActivity}
+                onReloadTranscript={opts.onReloadTranscript}
+                isResponding={opts.isResponding}
+                hideFirstUserMessage={opts.hideFirstUserMessage}
+                firstTurnMetrics={opts.firstTurnMetrics}
+                includeSubagentToolUsageInMetrics={
+                  opts.includeSubagentToolUsageInMetrics
+                }
+                onCanScrollToBottomChange={opts.onCanScrollToBottomChange}
+                failedPromptMessageId={opts.failedPromptMessageId}
+                onRetryFailedPrompt={opts.onRetryFailedPrompt}
+              />
+            </TranscriptRenderModeProvider>
+          </CompactModeContext.Provider>
         </WebShellCustomizationProvider>
       </I18nProvider>,
     );
@@ -342,6 +357,7 @@ function mount(
     root,
     container,
     transcriptRenderMode: opts.transcriptRenderMode ?? 'interactive',
+    compactMode: opts.compactMode ?? false,
   });
   return container;
 }
@@ -361,15 +377,17 @@ function rerenderMessages(
     entry.root.render(
       <I18nProvider language="en">
         <WebShellCustomizationProvider value={{}}>
-          <TranscriptRenderModeProvider value={entry.transcriptRenderMode}>
-            <MessageList
-              messages={messages}
-              pendingApproval={null}
-              loadingTranscript={opts.loadingTranscript}
-              catchingUp={opts.catchingUp}
-              isResponding={opts.isResponding}
-            />
-          </TranscriptRenderModeProvider>
+          <CompactModeContext.Provider value={entry.compactMode}>
+            <TranscriptRenderModeProvider value={entry.transcriptRenderMode}>
+              <MessageList
+                messages={messages}
+                pendingApproval={null}
+                loadingTranscript={opts.loadingTranscript}
+                catchingUp={opts.catchingUp}
+                isResponding={opts.isResponding}
+              />
+            </TranscriptRenderModeProvider>
+          </CompactModeContext.Provider>
         </WebShellCustomizationProvider>
       </I18nProvider>,
     );
@@ -485,6 +503,130 @@ describe('MessageList — failed prompt retry', () => {
     );
     expect(onRetry).toHaveBeenCalledTimes(1);
   });
+});
+
+describe('MessageList — compact mode', () => {
+  it('hides thinking rows without removing surrounding transcript content', () => {
+    const container = mount(
+      [userMsg('u1'), thinkingMsg('t1'), asstMsg('a1')],
+      undefined,
+      {
+        compactMode: true,
+        customization: { collapseCompletedTurns: false },
+      },
+    );
+
+    expect(container.querySelector('[data-testid="msg-u1"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="msg-t1"]')).toBeNull();
+    expect(container.querySelector('[data-testid="msg-a1"]')).not.toBeNull();
+
+    rerenderMessages(container, [
+      userMsg('u1'),
+      thinkingMsg('t1'),
+      thinkingMsg('t2'),
+      asstMsg('a1'),
+    ]);
+    expect(container.querySelector('[data-testid="msg-t2"]')).toBeNull();
+  });
+
+  it('merges tool groups separated only by hidden thinking', () => {
+    const container = mount(
+      [
+        userMsg('u1'),
+        { ...toolMsg('g1'), timestamp: 1_000 },
+        thinkingMsg('t1'),
+        { ...toolMsg('g2'), timestamp: 2_000 },
+        asstMsg('a1'),
+        userMsg('u2'),
+        toolMsg('g3'),
+      ],
+      undefined,
+      {
+        compactMode: true,
+        customization: { collapseCompletedTurns: false },
+      },
+    );
+
+    expect(container.querySelector('[data-testid="msg-g1"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="msg-g2"]')).toBeNull();
+    expect(
+      container
+        .querySelector('[data-testid="msg-g1"]')
+        ?.getAttribute('data-timestamp'),
+    ).toBe('1000');
+    expect(
+      container
+        .querySelector('[data-testid="msg-g1"]')
+        ?.getAttribute('data-tool-ids'),
+    ).toBe('call-g1,call-g2');
+    expect(container.querySelector('[data-testid="msg-a1"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="msg-g3"]')).not.toBeNull();
+  });
+
+  it('keeps visible thinking and tool groups in transcript order', () => {
+    const container = mount(
+      [
+        userMsg('u1'),
+        toolMsg('g1'),
+        thinkingMsg('t1'),
+        toolMsg('g2'),
+        asstMsg('a1'),
+      ],
+      undefined,
+      { customization: { collapseCompletedTurns: false } },
+    );
+
+    expect(container.querySelector('[data-testid="msg-t1"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="msg-g1"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="msg-g2"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="msg-a1"]')).not.toBeNull();
+    expect(
+      Array.from(container.querySelectorAll('[data-testid^="msg-"]')).map(
+        (element) => element.getAttribute('data-testid'),
+      ),
+    ).toEqual(['msg-u1', 'msg-g1', 'msg-t1', 'msg-g2', 'msg-a1']);
+  });
+
+  it('keeps agent groups on their parallel-agent path', () => {
+    const container = mount(
+      [
+        userMsg('u1'),
+        agentMsg('agent-1'),
+        thinkingMsg('t1'),
+        agentMsg('agent-2'),
+      ],
+      undefined,
+      {
+        compactMode: true,
+        customization: { collapseCompletedTurns: false },
+      },
+    );
+
+    expect(parallelAgentsSummary(container)).not.toBeNull();
+  });
+
+  it.each(['TodoWrite', 'AskUserQuestion'])(
+    'keeps %s groups separate across hidden thinking',
+    (toolName) => {
+      const container = mount(
+        [
+          toolMsg('g1'),
+          thinkingMsg('t1'),
+          standaloneToolMsg('special', toolName),
+        ],
+        undefined,
+        {
+          compactMode: true,
+          customization: { collapseCompletedTurns: false },
+        },
+      );
+
+      expect(container.querySelector('[data-testid="msg-g1"]')).not.toBeNull();
+      expect(
+        container.querySelector('[data-testid="msg-special"]'),
+      ).not.toBeNull();
+    },
+  );
 });
 
 describe('MessageList — turn collapse (DOM)', () => {

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -46,9 +46,11 @@ import {
 import { ParallelAgentsGroup } from './messages/tools/ParallelAgentsGroup';
 import { useSharedNow } from '../hooks/useSharedNow';
 import {
+  isAskUserQuestionToolName,
   isActiveToolStatus,
   toolContainsCallId,
 } from './messages/toolFormatting';
+import { isTodoWriteToolName } from '../utils/todos';
 import turnCollapseStyles from './TurnCollapseRow.module.css';
 import flashStyles from './MessageLocateFlash.module.css';
 import styles from './MessageList.module.css';
@@ -262,8 +264,19 @@ function isForceExpandGroup(
 }
 
 function isHiddenInCompactMode(msg: Message): boolean {
-  if (msg.role === 'thinking') return true;
-  return false;
+  return msg.role === 'thinking';
+}
+
+function isStandaloneToolGroup(msg: Message): boolean {
+  return (
+    msg.role === 'tool_group' &&
+    msg.tools.some(
+      (tool) =>
+        isSubAgentToolCall(tool) ||
+        isTodoWriteToolName(tool.toolName) ||
+        isAskUserQuestionToolName(tool.toolName),
+    )
+  );
 }
 
 function mergeCompactToolGroups(
@@ -276,7 +289,11 @@ function mergeCompactToolGroups(
   while (i < messages.length) {
     const msg = messages[i];
 
-    if (msg.role !== 'tool_group' || isForceExpandGroup(msg, pendingApproval)) {
+    if (
+      msg.role !== 'tool_group' ||
+      isForceExpandGroup(msg, pendingApproval) ||
+      isStandaloneToolGroup(msg)
+    ) {
       if (!isHiddenInCompactMode(msg)) {
         result.push(msg);
       }
@@ -298,7 +315,8 @@ function mergeCompactToolGroups(
 
       if (
         next.role === 'tool_group' &&
-        !isForceExpandGroup(next, pendingApproval)
+        !isForceExpandGroup(next, pendingApproval) &&
+        !isStandaloneToolGroup(next)
       ) {
         mergeableGroups.push(next);
         lastMergedIdx = j;
@@ -322,6 +340,7 @@ function mergeCompactToolGroups(
       id: mergeableGroups[0].id,
       role: 'tool_group',
       tools: mergedTools,
+      timestamp: mergeableGroups[0].timestamp,
     });
     i = lastMergedIdx + 1;
   }
@@ -2487,6 +2506,7 @@ export const MessageList = memo(
     const { t } = useI18n();
     const transcriptRenderMode = useTranscriptRenderMode();
     const compactMode = useContext(CompactModeContext);
+    const { collapseCompletedTurns } = useWebShellCustomization();
     const mergedMessages = useMemo(
       () =>
         compactMode
@@ -2727,7 +2747,6 @@ export const MessageList = memo(
     // (collapsed once complete). `displayItems` stays the full, pre-collapse
     // list — used only to locate rows hidden inside a collapsed turn — while
     // `visibleItems` is what actually renders.
-    const { collapseCompletedTurns } = useWebShellCustomization();
     const collapseEnabled = collapseCompletedTurns ?? true;
     const [collapseOverrides, setCollapseOverrides] = useState<
       ReadonlyMap<string, boolean>

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -2506,7 +2506,6 @@ export const MessageList = memo(
     const { t } = useI18n();
     const transcriptRenderMode = useTranscriptRenderMode();
     const compactMode = useContext(CompactModeContext);
-    const { collapseCompletedTurns } = useWebShellCustomization();
     const mergedMessages = useMemo(
       () =>
         compactMode
@@ -2747,6 +2746,7 @@ export const MessageList = memo(
     // (collapsed once complete). `displayItems` stays the full, pre-collapse
     // list — used only to locate rows hidden inside a collapsed turn — while
     // `visibleItems` is what actually renders.
+    const { collapseCompletedTurns } = useWebShellCustomization();
     const collapseEnabled = collapseCompletedTurns ?? true;
     const [collapseOverrides, setCollapseOverrides] = useState<
       ReadonlyMap<string, boolean>

--- a/packages/web-shell/client/components/MessageTimestamp.module.css
+++ b/packages/web-shell/client/components/MessageTimestamp.module.css
@@ -3,6 +3,10 @@
   padding: 5px 0;
 }
 
+.toolGroupSpacing {
+  padding: 8px 0;
+}
+
 /*
  * Anchored inside the message's top-right corner rather than floating above
  * it: the message list (`.list`) is `overflow-y: auto`, so a tooltip spilling

--- a/packages/web-shell/client/components/MessageTimestamp.test.tsx
+++ b/packages/web-shell/client/components/MessageTimestamp.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { act, type ReactNode } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { MessageTimestamp, formatTimestamp } from './MessageTimestamp';
+import styles from './MessageTimestamp.module.css';
 
 (
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -65,7 +66,7 @@ describe('MessageTimestamp', () => {
     expect(container.textContent).toContain('body');
   });
 
-  it('renders children unchanged with no tooltip when timestamp is undefined', () => {
+  it('renders no wrapper when timestamp is undefined', () => {
     const container = render(
       <MessageTimestamp>
         <div data-testid="child">body</div>
@@ -73,10 +74,28 @@ describe('MessageTimestamp', () => {
     );
 
     expect(container.querySelector('span[aria-hidden="true"]')).toBeNull();
-    // No wrapper element is introduced: the child stays a direct child of the
-    // mount container, so message spacing/structure is untouched.
     const child = container.querySelector('[data-testid="child"]');
     expect(child).not.toBeNull();
     expect(child?.parentElement).toBe(container);
+  });
+
+  it('uses larger spacing only when requested for a tool group', () => {
+    const defaultRow = render(
+      <MessageTimestamp>
+        <div>default</div>
+      </MessageTimestamp>,
+    );
+    const toolRow = render(
+      <MessageTimestamp toolGroupSpacing>
+        <div>tool</div>
+      </MessageTimestamp>,
+    );
+
+    expect(defaultRow.firstElementChild?.classList).not.toContain(
+      styles.toolGroupSpacing,
+    );
+    expect(toolRow.firstElementChild?.classList).toContain(
+      styles.toolGroupSpacing,
+    );
   });
 });

--- a/packages/web-shell/client/components/MessageTimestamp.tsx
+++ b/packages/web-shell/client/components/MessageTimestamp.tsx
@@ -7,19 +7,21 @@ interface MessageTimestampProps {
   children: ReactNode;
   /** When true, show the timestamp permanently at bottom-right instead of hover tooltip. */
   chatMode?: boolean;
+  /** Use the larger vertical rhythm for tool summaries in thinking-hidden mode. */
+  toolGroupSpacing?: boolean;
   copyText?: string;
   copyTitle?: string;
 }
 
 /**
  * Wraps a rendered history message and reveals its wall-clock time as a
- * CSS-only tooltip on hover. When the message carries no timestamp the
- * children render unchanged, so no empty wrapper is introduced.
+ * CSS-only tooltip on hover.
  */
 export function MessageTimestamp({
   timestamp,
   children,
   chatMode = false,
+  toolGroupSpacing = false,
   copyText,
   copyTitle = 'Copy',
 }: MessageTimestampProps) {
@@ -34,7 +36,7 @@ export function MessageTimestamp({
       })
       .catch(() => {});
   }, [copyText]);
-  if (timestamp === undefined && !copyText) {
+  if (timestamp === undefined && !copyText && !toolGroupSpacing) {
     return <>{children}</>;
   }
   const copyButton = copyText ? (
@@ -48,16 +50,21 @@ export function MessageTimestamp({
       {copied ? <CheckIcon /> : <CopyIcon />}
     </button>
   ) : null;
+  const rowClassName = chatMode
+    ? styles.chatRow
+    : toolGroupSpacing
+      ? `${styles.row} ${styles.toolGroupSpacing}`
+      : styles.row;
   if (timestamp === undefined) {
     return (
-      <div className={chatMode ? styles.chatRow : styles.row}>
+      <div className={rowClassName}>
         {children}
         {copyButton}
       </div>
     );
   }
   return (
-    <div className={chatMode ? styles.chatRow : styles.row}>
+    <div className={rowClassName}>
       {children}
       {chatMode ? (
         <span className={styles.chatActions}>

--- a/packages/web-shell/client/components/dialogs/HelpDialog.test.tsx
+++ b/packages/web-shell/client/components/dialogs/HelpDialog.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it } from 'vitest';
+import { I18nProvider, type WebShellLanguage } from '../../i18n';
+import { HelpDialog } from './HelpDialog';
+
+const containers: HTMLDivElement[] = [];
+
+afterEach(() => {
+  for (const container of containers.splice(0)) container.remove();
+});
+
+describe('HelpDialog shortcuts', () => {
+  it.each([
+    ['en', 'Toggle compact mode'],
+    ['zh-CN', '切换紧凑模式'],
+  ] as const)('documents Ctrl+O in %s', (language, description) => {
+    const container = document.createElement('div');
+    containers.push(container);
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <I18nProvider language={language as WebShellLanguage}>
+          <HelpDialog commands={[]} />
+        </I18nProvider>,
+      );
+    });
+
+    expect(container.textContent).toContain('Ctrl+O');
+    expect(container.textContent).toContain(description);
+    act(() => root.unmount());
+  });
+});

--- a/packages/web-shell/client/components/dialogs/HelpDialog.tsx
+++ b/packages/web-shell/client/components/dialogs/HelpDialog.tsx
@@ -84,6 +84,7 @@ const GENERAL_SHORTCUTS: Array<[string, string]> = [
   ['Esc', 'help.shortcut.cancel'],
   ['Ctrl+J', 'help.shortcut.newline'],
   ['Ctrl+L', 'help.shortcut.clear'],
+  ['Ctrl+O', 'help.shortcut.compact'],
   ['Ctrl+Y', 'help.shortcut.retry'],
   ['Shift+Tab', 'help.shortcut.approvals'],
   ['Alt+Left/Right', 'help.shortcut.altWords'],

--- a/packages/web-shell/client/components/messages/ToolGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.test.tsx
@@ -753,6 +753,7 @@ describe('tool row rendering', () => {
     );
 
     expect(container.textContent).toContain('5s');
+    expect(container.textContent).toContain('1.2k tokens');
     if (reason) expect(container.textContent).toContain(reason);
   });
 

--- a/packages/web-shell/client/components/messages/ToolGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.test.tsx
@@ -13,7 +13,6 @@ import { MonitorDetailsProvider } from '../../monitorDetailsContext';
 vi.mock('../../App', async () => {
   const { createContext } = await import('react');
   return {
-    CompactModeContext: createContext(false),
     TodoTimelineContext: createContext(new Map()),
     TodoDetailContext: createContext(new Map()),
   };
@@ -98,7 +97,7 @@ function renderToolGroup(
 
 const t = (key: string, values?: Record<string, string | number>): string => {
   if (key === 'toolGroup.running') {
-    return `Running ${values?.name ?? 'tool'}${values?.duration ? ` ${values.duration}` : ''}${
+    return `Running ${values?.name ?? 'tool'}${
       Number(values?.count ?? 0) > 1 ? ` · ${values?.count ?? 0} tools` : ''
     }`;
   }
@@ -184,6 +183,78 @@ describe('tool group summary logic', () => {
     ];
 
     expect(formatToolGroupSummary(tools, t)).toBe('Running ReadFile · 2 tools');
+  });
+
+  it('describes every active foreground tool until all tools finish', () => {
+    const tools = [
+      makeTool({
+        callId: 'read',
+        toolName: 'ReadFile',
+        status: 'in_progress',
+        args: { file_path: 'package.json' },
+      }),
+      makeTool({
+        callId: 'search',
+        toolName: 'grep',
+        status: 'pending',
+        args: { pattern: 'ToolGroup' },
+      }),
+      makeTool({ callId: 'done', status: 'completed' }),
+    ];
+
+    const summary = formatToolGroupSummary(tools, t);
+    expect(summary).toContain('ReadFile package.json');
+    expect(summary).toContain('ToolGroup');
+    expect(summary).toContain('3 tools');
+  });
+
+  it('keeps workspace-relative paths in multi-tool summaries', () => {
+    const tools = [
+      makeTool({
+        callId: 'first',
+        toolName: 'ReadFile',
+        status: 'in_progress',
+        args: { file_path: '/workspace/src/index.ts' },
+      }),
+      makeTool({
+        callId: 'second',
+        toolName: 'ReadFile',
+        status: 'pending',
+        args: { file_path: '/workspace/test/index.ts' },
+      }),
+    ];
+
+    expect(formatToolGroupSummary(tools, t, '/workspace')).toBe(
+      'Running ReadFile src/index.ts · ReadFile test/index.ts · 2 tools',
+    );
+  });
+
+  it('excludes a running background agent from a multi-tool summary', () => {
+    const tools = [
+      makeTool({
+        callId: 'agent',
+        toolName: 'agent',
+        status: 'in_progress',
+        args: { run_in_background: true },
+      }),
+      makeTool({
+        callId: 'read',
+        toolName: 'ReadFile',
+        status: 'in_progress',
+        args: { file_path: 'package.json' },
+      }),
+      makeTool({
+        callId: 'search',
+        toolName: 'grep',
+        status: 'pending',
+        args: { pattern: 'ToolGroup' },
+      }),
+    ];
+
+    const summary = formatToolGroupSummary(tools, t);
+    expect(summary).toBe(
+      "Running ReadFile package.json · Grep 'ToolGroup' in path './' · 3 tools",
+    );
   });
 
   it('localizes active tool names in running summaries', () => {
@@ -537,6 +608,96 @@ describe('tool kind logic', () => {
 });
 
 describe('tool row rendering', () => {
+  it('renders the aggregate summary for a multi-tool group', () => {
+    const container = renderToolGroup([
+      makeTool({
+        callId: 'read',
+        toolName: 'ReadFile',
+        status: 'in_progress',
+        args: { file_path: 'package.json' },
+      }),
+      makeTool({
+        callId: 'search',
+        toolName: 'grep',
+        status: 'pending',
+        args: { pattern: 'ToolGroup' },
+      }),
+    ]);
+
+    expect(container.querySelector('button')?.textContent).toContain(
+      'package.json',
+    );
+    expect(container.querySelector('button')?.textContent).toContain(
+      'ToolGroup',
+    );
+  });
+
+  it('does not show elapsed time in a running summary', () => {
+    const container = renderToolGroup([
+      makeTool({ status: 'in_progress', startTime: 1_000 }),
+      makeTool({ callId: 'done', status: 'completed' }),
+    ]);
+
+    expect(container.querySelector('button')?.textContent).not.toMatch(
+      /\d+[sm]/,
+    );
+  });
+
+  it('keeps elapsed time updating in a running tool row', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(6_000);
+
+    try {
+      const container = renderToolLine(
+        makeTool({
+          toolName: 'ReadFile',
+          status: 'in_progress',
+          startTime: 1_000,
+        }),
+      );
+      expect(container.textContent).toContain('5s');
+
+      act(() => {
+        vi.advanceTimersByTime(1_000);
+      });
+      expect(container.textContent).toContain('6s');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not show elapsed time after a tool completes', () => {
+    const container = renderToolLine(
+      makeTool({
+        toolName: 'ReadFile',
+        status: 'completed',
+        startTime: 1_000,
+        endTime: 6_000,
+      }),
+    );
+
+    expect(container.textContent).not.toContain('5s');
+  });
+
+  it('shows a tool-kind icon on every expanded group row', () => {
+    const container = renderToolGroup([
+      makeTool({ callId: 'read', toolName: 'ReadFile' }),
+      makeTool({ callId: 'edit', toolName: 'edit' }),
+    ]);
+    const summary = container.querySelector('button');
+    act(() => summary?.click());
+
+    const rows = container.querySelectorAll(
+      '[class*="chatSummaryGroup"] [class*="lineMain"]',
+    );
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(
+        row.querySelector('svg[class*="chatSummaryToolIcon"]'),
+      ).not.toBeNull();
+    }
+  });
+
   it('shows failed status in the collapsed chat summary', () => {
     const container = renderToolGroup([
       makeTool({ toolName: 'Shell', status: 'failed' }),

--- a/packages/web-shell/client/components/messages/ToolGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.test.tsx
@@ -674,13 +674,19 @@ describe('tool row rendering', () => {
     vi.setSystemTime(6_000);
 
     try {
-      const container = renderToolGroup([
-        makeTool({
-          toolName: 'ReadFile',
-          status: 'in_progress',
-          startTime: 1_000,
-        }),
-      ]);
+      const container = renderToolGroup(
+        [
+          makeTool({
+            toolName: 'ReadFile',
+            status: 'in_progress',
+            startTime: 1_000,
+          }),
+        ],
+        {
+          renderToolHeaderExtra: (info) =>
+            info.elapsed ? <span>custom {info.elapsed}</span> : null,
+        },
+      );
       const summary = container.querySelector('button');
       expect(summary?.textContent).not.toContain('5s');
 
@@ -689,12 +695,12 @@ describe('tool row rendering', () => {
         '[class*="chatSummaryContentClip"]',
       );
       expect(content?.className).not.toContain('chatSummaryContentCollapsed');
-      expect(content?.textContent).toContain('5s');
+      expect(content?.textContent).toContain('custom 5s');
 
       act(() => {
         vi.advanceTimersByTime(1_000);
       });
-      expect(content?.textContent).toContain('6s');
+      expect(content?.textContent).toContain('custom 6s');
     } finally {
       vi.useRealTimers();
     }
@@ -726,6 +732,28 @@ describe('tool row rendering', () => {
     );
 
     expect(container.textContent).toContain('5s');
+  });
+
+  it.each([
+    ['completed', undefined],
+    ['failed', 'Agent process failed'],
+  ] as const)('shows meta for a %s agent', (status, reason) => {
+    const container = renderToolLine(
+      makeTool({
+        toolName: 'Task',
+        status,
+        startTime: 1_000,
+        endTime: 6_000,
+        rawOutput: {
+          type: 'task_execution',
+          executionSummary: { outputTokens: 1_200 },
+          reason,
+        },
+      }),
+    );
+
+    expect(container.textContent).toContain('5s');
+    if (reason) expect(container.textContent).toContain(reason);
   });
 
   it('shows a tool-kind icon on every expanded group row', () => {

--- a/packages/web-shell/client/components/messages/ToolGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.test.tsx
@@ -60,6 +60,7 @@ function makeTool(overrides: Partial<ACPToolCall> = {}): ACPToolCall {
 function renderToolLine(
   tool: ACPToolCall,
   props: Partial<Parameters<typeof ToolLine>[0]> = {},
+  customization = {},
 ): HTMLElement {
   const container = document.createElement('div');
   document.body.appendChild(container);
@@ -67,7 +68,9 @@ function renderToolLine(
   act(() => {
     root.render(
       <I18nProvider language="en">
-        <ToolLine tool={tool} {...props} />
+        <WebShellCustomizationProvider value={customization}>
+          <ToolLine tool={tool} {...props} />
+        </WebShellCustomizationProvider>
       </I18nProvider>,
     );
   });
@@ -97,9 +100,9 @@ function renderToolGroup(
 
 const t = (key: string, values?: Record<string, string | number>): string => {
   if (key === 'toolGroup.running') {
-    return `Running ${values?.name ?? 'tool'}${
-      Number(values?.count ?? 0) > 1 ? ` · ${values?.count ?? 0} tools` : ''
-    }`;
+    return Number(values?.count ?? 0) > 1
+      ? `Running ${values?.count ?? 0} tools: ${values?.name ?? 'tool'}`
+      : `Running ${values?.name ?? 'tool'}`;
   }
   if (key === 'toolGroup.summary') {
     return `Ran ${values?.count ?? 0} tool${values?.count === 1 ? '' : 's'}`;
@@ -149,7 +152,7 @@ describe('tool group summary logic', () => {
 
     expect(hasActiveAgents(tools)).toBe(true);
     expect(getActiveTool(tools).callId).toBe('active');
-    expect(formatToolGroupSummary(tools, t)).toBe('Running ReadFile · 2 tools');
+    expect(formatToolGroupSummary(tools, t)).toBe('Running ReadFile');
   });
 
   it('uses a static summary when only background agents remain active', () => {
@@ -182,7 +185,7 @@ describe('tool group summary logic', () => {
       }),
     ];
 
-    expect(formatToolGroupSummary(tools, t)).toBe('Running ReadFile · 2 tools');
+    expect(formatToolGroupSummary(tools, t)).toBe('Running ReadFile');
   });
 
   it('describes every active foreground tool until all tools finish', () => {
@@ -205,7 +208,7 @@ describe('tool group summary logic', () => {
     const summary = formatToolGroupSummary(tools, t);
     expect(summary).toContain('ReadFile package.json');
     expect(summary).toContain('ToolGroup');
-    expect(summary).toContain('3 tools');
+    expect(summary).toContain('Running 2 tools:');
   });
 
   it('keeps workspace-relative paths in multi-tool summaries', () => {
@@ -225,7 +228,7 @@ describe('tool group summary logic', () => {
     ];
 
     expect(formatToolGroupSummary(tools, t, '/workspace')).toBe(
-      'Running ReadFile src/index.ts · ReadFile test/index.ts · 2 tools',
+      'Running 2 tools: ReadFile src/index.ts · ReadFile test/index.ts',
     );
   });
 
@@ -253,7 +256,7 @@ describe('tool group summary logic', () => {
 
     const summary = formatToolGroupSummary(tools, t);
     expect(summary).toBe(
-      "Running ReadFile package.json · Grep 'ToolGroup' in path './' · 3 tools",
+      "Running 2 tools: ReadFile package.json · Grep 'ToolGroup' in path './'",
     );
   });
 
@@ -666,6 +669,37 @@ describe('tool row rendering', () => {
     }
   });
 
+  it('shows live elapsed time after expanding a single-tool group', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(6_000);
+
+    try {
+      const container = renderToolGroup([
+        makeTool({
+          toolName: 'ReadFile',
+          status: 'in_progress',
+          startTime: 1_000,
+        }),
+      ]);
+      const summary = container.querySelector('button');
+      expect(summary?.textContent).not.toContain('5s');
+
+      act(() => summary?.click());
+      const content = container.querySelector(
+        '[class*="chatSummaryContentClip"]',
+      );
+      expect(content?.className).not.toContain('chatSummaryContentCollapsed');
+      expect(content?.textContent).toContain('5s');
+
+      act(() => {
+        vi.advanceTimersByTime(1_000);
+      });
+      expect(content?.textContent).toContain('6s');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('does not show elapsed time after a tool completes', () => {
     const container = renderToolLine(
       makeTool({
@@ -677,6 +711,21 @@ describe('tool row rendering', () => {
     );
 
     expect(container.textContent).not.toContain('5s');
+  });
+
+  it('keeps completed elapsed data available to custom header renderers', () => {
+    const container = renderToolLine(
+      makeTool({
+        toolName: 'ReadFile',
+        status: 'completed',
+        startTime: 1_000,
+        endTime: 6_000,
+      }),
+      {},
+      { renderToolHeaderExtra: (info) => <span>{info.elapsed}</span> },
+    );
+
+    expect(container.textContent).toContain('5s');
   });
 
   it('shows a tool-kind icon on every expanded group row', () => {

--- a/packages/web-shell/client/components/messages/ToolGroup.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.tsx
@@ -567,7 +567,7 @@ function ToolHeaderExtra({ info }: { info: ToolHeaderExtraRenderInfo }) {
   return (
     <DefaultToolHeaderExtra
       description={info.description}
-      elapsed={info.elapsed}
+      elapsed={isActiveToolStatus(info.tool.status) ? info.elapsed : ''}
     />
   );
 }
@@ -612,7 +612,7 @@ export function formatToolGroupSummary(
     );
     return t('toolGroup.running', {
       name: activeSummaries.join(' · '),
-      count: tools.length,
+      count: foregroundActiveTools.length,
     });
   }
 
@@ -1243,9 +1243,7 @@ export const ToolLine = memo(function ToolLine({
   const elapsed =
     isShellToolName(tool.toolName) || isWebFetchToolName(tool.toolName)
       ? ''
-      : isRunningTool
-        ? formatElapsed(tool.startTime, now)
-        : '';
+      : formatElapsed(tool.startTime, isRunningTool ? now : tool.endTime);
 
   const name = tool.toolName.toLowerCase();
   const opensMonitorDetails =
@@ -1304,6 +1302,11 @@ export const ToolLine = memo(function ToolLine({
 
   return (
     <div className={styles.line}>
+      {hideHeader && isRunningTool && elapsed && (
+        <div className={styles.lineMain}>
+          <span className={styles.lineElapsed}>{elapsed}</span>
+        </div>
+      )}
       {!hideHeader && (
         <div
           className={`${styles.lineMain} ${interactive ? styles.lineExpandable : ''}`}
@@ -1492,7 +1495,7 @@ export const ToolGroup = memo(function ToolGroup({
     singleMonitor && monitorDetailsAvailable && !monitorDetailsUnavailable,
   );
   const opensToolDetails = opensSubagentDetails || opensMonitorDetails;
-  const summaryIconTool = activeTool ?? tools[0];
+  const summaryIconTool = hasRunningTool ? (activeTool ?? tools[0]) : tools[0];
   const hasApprovalTool =
     pendingApproval?.toolCallId &&
     tools.some((t) => toolContainsCallId(t, pendingApproval.toolCallId!));

--- a/packages/web-shell/client/components/messages/ToolGroup.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.tsx
@@ -1106,7 +1106,11 @@ export const ToolLine = memo(function ToolLine({
     isAgent &&
     toolContainsCallId(tool, approval.toolCallId);
   const isRunningTool = isActiveToolStatus(tool.status);
-  const now = useSharedNow(isRunningTool);
+  const showsLiveElapsed =
+    isRunningTool &&
+    !isShellToolName(tool.toolName) &&
+    !isWebFetchToolName(tool.toolName);
+  const now = useSharedNow(showsLiveElapsed);
 
   // Collapse a regular tool to its one-line summary once it completes
   // successfully — unless the user explicitly toggled this row, in which case

--- a/packages/web-shell/client/components/messages/ToolGroup.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.tsx
@@ -567,7 +567,11 @@ function ToolHeaderExtra({ info }: { info: ToolHeaderExtraRenderInfo }) {
   return (
     <DefaultToolHeaderExtra
       description={info.description}
-      elapsed={isActiveToolStatus(info.tool.status) ? info.elapsed : ''}
+      elapsed={
+        info.kind === 'agent' || isActiveToolStatus(info.tool.status)
+          ? info.elapsed
+          : ''
+      }
     />
   );
 }
@@ -1304,7 +1308,16 @@ export const ToolLine = memo(function ToolLine({
     <div className={styles.line}>
       {hideHeader && isRunningTool && elapsed && (
         <div className={styles.lineMain}>
-          <span className={styles.lineElapsed}>{elapsed}</span>
+          <ToolHeaderExtra
+            info={{
+              kind: getToolHeaderKind(tool),
+              tool,
+              displayName,
+              description: '',
+              elapsed,
+              workspaceCwd,
+            }}
+          />
         </div>
       )}
       {!hideHeader && (

--- a/packages/web-shell/client/components/messages/ToolGroup.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.tsx
@@ -35,7 +35,6 @@ import { Markdown } from './Markdown';
 import {
   formatDurationMs,
   formatElapsed,
-  formatLiveElapsed,
   localizeToolDisplayName,
   StatusIcon,
   truncateText,
@@ -61,7 +60,7 @@ import {
 } from './toolFormatting';
 import { useI18n } from '../../i18n';
 import { useTranscriptRenderMode } from '../../transcriptRenderMode';
-import { CompactModeContext, TodoTimelineContext } from '../../App';
+import { TodoTimelineContext } from '../../App';
 import {
   type ToolHeaderExtraRenderInfo,
   type ToolHeaderKind,
@@ -590,24 +589,30 @@ export function getActiveTool(tools: ACPToolCall[]): ACPToolCall {
 export function formatToolGroupSummary(
   tools: ACPToolCall[],
   t: ReturnType<typeof useI18n>['t'],
-  duration?: string,
+  workspaceCwd?: string,
 ): string {
   if (hasActiveAgents(tools)) {
-    const foregroundActiveTool = tools.find(
+    const foregroundActiveTools = tools.filter(
       (tool) =>
         isActiveToolStatus(tool.status) && !isBackgroundSubAgentToolCall(tool),
     );
-    const activeTool = foregroundActiveTool ?? getActiveTool(tools);
-    if (isAskUserQuestionToolName(activeTool.toolName)) {
-      return t('toolGroup.summary.provideInformation');
-    }
-    if (!foregroundActiveTool && isBackgroundSubAgentToolCall(activeTool)) {
+    if (foregroundActiveTools.length === 0) {
       return t('subagent.background');
     }
+    if (
+      foregroundActiveTools.length === 1 &&
+      isAskUserQuestionToolName(foregroundActiveTools[0].toolName)
+    ) {
+      return t('toolGroup.summary.provideInformation');
+    }
+    const activeSummaries = foregroundActiveTools.map((tool) =>
+      isAskUserQuestionToolName(tool.toolName)
+        ? t('toolGroup.summary.provideInformation')
+        : formatSingleToolSummary(tool, t, workspaceCwd),
+    );
     return t('toolGroup.running', {
-      name: localizeToolDisplayName(activeTool.toolName, t),
+      name: activeSummaries.join(' · '),
       count: tools.length,
-      duration: duration ?? '',
     });
   }
 
@@ -665,11 +670,9 @@ function getSingleToolSummaryInfo(
 
 function SingleToolSummary({
   tool,
-  runningDuration,
   workspaceCwd,
 }: {
   tool: ACPToolCall;
-  runningDuration?: string;
   workspaceCwd?: string;
 }) {
   const { t } = useI18n();
@@ -687,7 +690,6 @@ function SingleToolSummary({
       <>
         {runningPrefix && <span>{runningPrefix} </span>}
         {formatSingleToolSummary(tool, t, workspaceCwd)}
-        {runningDuration && <span> {runningDuration}</span>}
       </>
     );
   }
@@ -703,7 +705,6 @@ function SingleToolSummary({
         )}
         <ToolHeaderExtra info={info} />
       </span>
-      {runningDuration && <span> {runningDuration}</span>}
     </>
   );
 }
@@ -959,61 +960,6 @@ export function isWebFetchToolName(toolName: string): boolean {
   return name === 'web_fetch' || name === 'webfetch' || name === 'fetch';
 }
 
-const getCompactDisplayStatus = getAgentDisplayStatus;
-
-function CompactToolGroup({
-  tools,
-  workspaceCwd,
-  isLocateFlashing = false,
-}: {
-  tools: ACPToolCall[];
-  workspaceCwd?: string;
-  isLocateFlashing?: boolean;
-}) {
-  const { t } = useI18n();
-  const activeTool = getActiveTool(tools);
-  const displayName = localizeToolDisplayName(activeTool.toolName, t);
-  const overallStatus = getCompactDisplayStatus(activeTool);
-  const description = getToolDescription(activeTool, workspaceCwd);
-  const elapsed =
-    (isActiveToolStatus(activeTool.status) &&
-      isBackgroundSubAgentToolCall(activeTool)) ||
-    isShellToolName(activeTool.toolName) ||
-    isWebFetchToolName(activeTool.toolName)
-      ? ''
-      : formatElapsed(activeTool.startTime, activeTool.endTime);
-
-  return (
-    <div
-      className={`${styles.compactGroup}${
-        isLocateFlashing ? ` ${flashStyles.flash}` : ''
-      }`}
-    >
-      <div className={styles.compactHeader}>
-        <StatusIcon status={overallStatus} />
-        <span className={styles.lineName}>{displayName}</span>
-        {tools.length > 1 && (
-          <span className={styles.compactCount}>
-            {'× '}
-            {tools.length}
-          </span>
-        )}
-        <ToolHeaderExtra
-          info={{
-            kind: getToolHeaderKind(activeTool),
-            tool: activeTool,
-            displayName,
-            description,
-            elapsed,
-            workspaceCwd,
-          }}
-        />
-      </div>
-      <div className={styles.compactHint}>{t('compact.hint')}</div>
-    </div>
-  );
-}
-
 function areToolLinePropsEqual(
   prev: ToolLineProps,
   next: ToolLineProps,
@@ -1128,14 +1074,13 @@ export const ToolLine = memo(function ToolLine({
 }: ToolLineProps) {
   const { t } = useI18n();
   const transcriptRenderMode = useTranscriptRenderMode();
-  const compactMode = useContext(CompactModeContext);
   const subagentDetails = useSubagentDetails();
   const monitorDetails = useMonitorDetails();
   const monitorDetailsAvailable = monitorDetails !== undefined;
   const [monitorDetailsUnavailable, setMonitorDetailsUnavailable] =
     useState(false);
   const [expanded, setExpanded] = useState(
-    () => forceExpanded || (!compactMode && shouldAutoExpand(tool)),
+    () => forceExpanded || shouldAutoExpand(tool),
   );
   const monitorDetailsRequestRef = useRef<object | null>(null);
   // Set once the user explicitly toggles this row, so auto-collapse-on-
@@ -1144,22 +1089,14 @@ export const ToolLine = memo(function ToolLine({
 
   useEffect(
     () => {
-      setExpanded(
-        forceExpanded || (compactMode ? false : shouldAutoExpand(tool)),
-      );
+      setExpanded(forceExpanded || shouldAutoExpand(tool));
       setMonitorDetailsUnavailable(false);
       monitorDetailsRequestRef.current = null;
-      // A new tool identity (or compact-mode toggle) resets the manual latch.
+      // A new tool identity resets the manual latch.
       userToggledRef.current = false;
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      compactMode,
-      forceExpanded,
-      monitorDetailsAvailable,
-      tool.callId,
-      tool.toolName,
-    ],
+    [forceExpanded, monitorDetailsAvailable, tool.callId, tool.toolName],
   );
   const isAgent = isSubAgentToolCall(tool);
   const hasApproval = approval && approval.toolCallId === tool.callId;
@@ -1168,8 +1105,8 @@ export const ToolLine = memo(function ToolLine({
     approval?.toolCallId &&
     isAgent &&
     toolContainsCallId(tool, approval.toolCallId);
-  const isRunningAgent = isAgent && tool.status === 'in_progress';
-  const now = useSharedNow(isRunningAgent);
+  const isRunningTool = isActiveToolStatus(tool.status);
+  const now = useSharedNow(isRunningTool);
 
   // Collapse a regular tool to its one-line summary once it completes
   // successfully — unless the user explicitly toggled this row, in which case
@@ -1302,7 +1239,9 @@ export const ToolLine = memo(function ToolLine({
   const elapsed =
     isShellToolName(tool.toolName) || isWebFetchToolName(tool.toolName)
       ? ''
-      : formatElapsed(tool.startTime, tool.endTime);
+      : isRunningTool
+        ? formatElapsed(tool.startTime, now)
+        : '';
 
   const name = tool.toolName.toLowerCase();
   const opensMonitorDetails =
@@ -1405,6 +1344,7 @@ export const ToolLine = memo(function ToolLine({
               : undefined
           }
         >
+          <ToolSummaryIcon tool={tool} />
           <StatusIcon status={tool.status} />
           <span className={styles.lineName}>{displayName}</span>
           {isTodo && hasTodoList && (
@@ -1517,7 +1457,6 @@ export const ToolGroup = memo(function ToolGroup({
   isLocateFlashing = false,
 }: ToolGroupProps) {
   const { t } = useI18n();
-  const compactMode = useContext(CompactModeContext);
   const subagentDetails = useSubagentDetails();
   const monitorDetails = useMonitorDetails();
   const monitorDetailsAvailable = monitorDetails !== undefined;
@@ -1527,7 +1466,11 @@ export const ToolGroup = memo(function ToolGroup({
   const monitorDetailsRequestRef = useRef<object | null>(null);
   const hasRunningTool = hasActiveAgents(tools);
   const hasFailedTool = tools.some((tool) => tool.status === 'failed');
-  const activeTool = tools.length > 0 ? getActiveTool(tools) : undefined;
+  const activeTool =
+    tools.find(
+      (tool) =>
+        isActiveToolStatus(tool.status) && !isBackgroundSubAgentToolCall(tool),
+    ) ?? (tools.length > 0 ? getActiveTool(tools) : undefined);
   const singleTool = tools.length === 1 ? tools[0] : undefined;
   const singleSubagent =
     singleTool && isSubAgentToolCall(singleTool) ? singleTool : undefined;
@@ -1545,22 +1488,10 @@ export const ToolGroup = memo(function ToolGroup({
     singleMonitor && monitorDetailsAvailable && !monitorDetailsUnavailable,
   );
   const opensToolDetails = opensSubagentDetails || opensMonitorDetails;
-  const summaryIconTool = tools[0] ?? activeTool;
-  const liveStartedAtRef = useRef(Date.now());
-  const summaryNow = useSharedNow(animateSummary);
+  const summaryIconTool = activeTool ?? tools[0];
   const hasApprovalTool =
     pendingApproval?.toolCallId &&
     tools.some((t) => toolContainsCallId(t, pendingApproval.toolCallId!));
-  const showCompact = compactMode && !hasApprovalTool;
-  const runningDuration = animateSummary
-    ? formatLiveElapsed(summaryNow - liveStartedAtRef.current)
-    : undefined;
-
-  useEffect(() => {
-    if (!animateSummary) return;
-    liveStartedAtRef.current = Date.now();
-  }, [animateSummary, activeTool?.callId]);
-
   useEffect(() => {
     setMonitorDetailsUnavailable(false);
     setChatExpanded(false);
@@ -1578,16 +1509,6 @@ export const ToolGroup = memo(function ToolGroup({
       },
     );
   };
-
-  if (showCompact) {
-    return (
-      <CompactToolGroup
-        tools={tools}
-        workspaceCwd={workspaceCwd}
-        isLocateFlashing={isLocateFlashing}
-      />
-    );
-  }
 
   if (!hasApprovalTool) {
     return (
@@ -1633,11 +1554,10 @@ export const ToolGroup = memo(function ToolGroup({
             {singleTool ? (
               <SingleToolSummary
                 tool={singleTool}
-                runningDuration={runningDuration}
                 workspaceCwd={workspaceCwd}
               />
             ) : (
-              formatToolGroupSummary(tools, t, runningDuration)
+              formatToolGroupSummary(tools, t, workspaceCwd)
             )}
           </span>
           <span

--- a/packages/web-shell/client/components/messages/UserShellMessage.module.css
+++ b/packages/web-shell/client/components/messages/UserShellMessage.module.css
@@ -13,11 +13,6 @@
   max-height: 200px;
 }
 
-.compact {
-  overflow: hidden;
-  max-height: none;
-}
-
 .header {
   display: flex;
   align-items: center;
@@ -57,10 +52,4 @@
   line-height: 1.45;
   overflow-x: auto;
   white-space: pre-wrap;
-}
-
-.compactHint {
-  color: var(--muted-foreground);
-  font-size: 12px;
-  line-height: 1.35;
 }

--- a/packages/web-shell/client/components/messages/UserShellMessage.tsx
+++ b/packages/web-shell/client/components/messages/UserShellMessage.tsx
@@ -1,5 +1,4 @@
-import { memo, useContext } from 'react';
-import { CompactModeContext } from '../../App';
+import { memo } from 'react';
 import { useI18n } from '../../i18n';
 import styles from './UserShellMessage.module.css';
 
@@ -12,25 +11,16 @@ export const UserShellMessage = memo(function UserShellMessage({
   command,
   output,
 }: UserShellMessageProps) {
-  const compactMode = useContext(CompactModeContext);
   const { t } = useI18n();
 
   return (
-    <div
-      className={
-        compactMode ? `${styles.message} ${styles.compact}` : styles.message
-      }
-    >
+    <div className={styles.message}>
       <div className={styles.header}>
         <span className={styles.status}>✓</span>
         <span className={styles.name}>{t('shell.command')}</span>
         {command && <span className={styles.command}>{command}</span>}
       </div>
-      {compactMode ? (
-        <div className={styles.compactHint}>{t('compact.hint')}</div>
-      ) : (
-        output && <pre className={styles.output}>{output}</pre>
-      )}
+      {output && <pre className={styles.output}>{output}</pre>}
     </div>
   );
 });

--- a/packages/web-shell/client/components/messages/tools/SubAgentPanel.test.tsx
+++ b/packages/web-shell/client/components/messages/tools/SubAgentPanel.test.tsx
@@ -6,12 +6,15 @@ import { I18nProvider } from '../../../i18n';
 import type { ACPToolCall } from '../../../adapters/types';
 import { formatTimestamp } from '../../MessageTimestamp';
 
-// SubAgentPanel pulls in ToolGroup, which imports App only for
-// CompactModeContext; loading the real App module would drag the whole
-// application graph into this unit test.
+// SubAgentPanel pulls in ToolGroup, which imports App for TodoTimelineContext;
+// loading the real App module would drag the whole application graph into this
+// unit test.
 vi.mock('../../../App', async () => {
   const { createContext } = await import('react');
-  return { CompactModeContext: createContext(false) };
+  return {
+    TodoTimelineContext: createContext(new Map()),
+    TodoDetailContext: createContext(new Map()),
+  };
 });
 
 const { SubAgentPanel } = await import('./SubAgentPanel');

--- a/packages/web-shell/client/components/messages/tools/ToolChrome.module.css
+++ b/packages/web-shell/client/components/messages/tools/ToolChrome.module.css
@@ -41,13 +41,15 @@
 }
 
 .chatSummary:hover,
-.chatSummary:focus-visible {
+.chatSummary:focus-visible,
+.chatSummary[aria-expanded='true'] {
   color: var(--primary);
   outline: none;
 }
 
 .chatSummary:hover .chatSummaryTextActive,
-.chatSummary:focus-visible .chatSummaryTextActive {
+.chatSummary:focus-visible .chatSummaryTextActive,
+.chatSummary[aria-expanded='true'] .chatSummaryTextActive {
   background-image: none;
   -webkit-text-fill-color: currentColor;
 }
@@ -70,6 +72,7 @@
   width: 14px;
   height: 14px;
   display: block;
+  flex-shrink: 0;
 }
 
 .chatSummaryText {
@@ -426,33 +429,4 @@
 
 .expandedCardBody .todoBody {
   padding: 0;
-}
-
-.compactGroup {
-  margin-bottom: 12px;
-  padding: 8px 14px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-}
-
-.compactHeader {
-  display: flex;
-  align-items: baseline;
-  gap: 8px;
-  min-width: 0;
-  color: var(--muted-foreground);
-  font-size: 13px;
-  font-weight: 400;
-}
-
-.compactCount {
-  color: var(--muted-foreground);
-  font-size: 13px;
-  flex-shrink: 0;
-}
-
-.compactHint {
-  font-size: 12px;
-  color: var(--muted-foreground);
-  margin-top: 4px;
 }

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -2489,9 +2489,9 @@ const EN: Messages = {
   'toolGroup.summary.otherTools': (v) =>
     `Called ${v?.count ?? 0} other tool${v?.count === 1 ? '' : 's'}`,
   'toolGroup.running': (v) =>
-    `Running ${v?.name ?? 'tool'}${
-      Number(v?.count ?? 0) > 1 ? ` · ${v?.count ?? 0} tools` : ''
-    }`,
+    Number(v?.count ?? 0) > 1
+      ? `Running ${v?.count ?? 0} tools: ${v?.name ?? 'tool'}`
+      : `Running ${v?.name ?? 'tool'}`,
   'toolGroup.runningPrefix': 'Running',
   'thinking.expand': 'Expand thinking',
   'thinking.collapse': 'Collapse thinking',
@@ -5185,9 +5185,9 @@ const ZH: Messages = {
   'toolGroup.summary.askedQuestions': (v) => `已询问 ${v?.count ?? 0} 个问题`,
   'toolGroup.summary.otherTools': (v) => `调用了 ${v?.count ?? 0} 个工具`,
   'toolGroup.running': (v) =>
-    `正在执行 ${v?.name ?? '工具'}${
-      Number(v?.count ?? 0) > 1 ? ` · 共 ${v?.count ?? 0} 个工具` : ''
-    }`,
+    Number(v?.count ?? 0) > 1
+      ? `正在执行 ${v?.count ?? 0} 个工具：${v?.name ?? '工具'}`
+      : `正在执行 ${v?.name ?? '工具'}`,
   'toolGroup.runningPrefix': '正在执行',
   'thinking.expand': '展开思考',
   'thinking.collapse': '收起思考',

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -1460,7 +1460,6 @@ const EN: Messages = {
   'shell.command': 'Shell Command',
   'compact.enabled': 'Compact mode enabled',
   'compact.disabled': 'Compact mode disabled',
-  'compact.hint': 'Press Ctrl+O to show full tool output',
   'compact.saveFailed': 'Failed to save compact mode',
   'help.subcommands': 'subcommands',
   'help.tab.commands': 'Built-in commands',
@@ -2490,7 +2489,7 @@ const EN: Messages = {
   'toolGroup.summary.otherTools': (v) =>
     `Called ${v?.count ?? 0} other tool${v?.count === 1 ? '' : 's'}`,
   'toolGroup.running': (v) =>
-    `Running ${v?.name ?? 'tool'}${v?.duration ? ` ${v.duration}` : ''}${
+    `Running ${v?.name ?? 'tool'}${
       Number(v?.count ?? 0) > 1 ? ` · ${v?.count ?? 0} tools` : ''
     }`,
   'toolGroup.runningPrefix': 'Running',
@@ -4237,7 +4236,6 @@ const ZH: Messages = {
   'shell.command': 'Shell 命令',
   'compact.enabled': '紧凑模式已开启',
   'compact.disabled': '紧凑模式已关闭',
-  'compact.hint': '按 Ctrl+O 显示完整工具输出',
   'compact.saveFailed': '保存紧凑模式失败',
   'help.subcommands': '子命令',
   'help.tab.commands': '内置命令',
@@ -5187,7 +5185,7 @@ const ZH: Messages = {
   'toolGroup.summary.askedQuestions': (v) => `已询问 ${v?.count ?? 0} 个问题`,
   'toolGroup.summary.otherTools': (v) => `调用了 ${v?.count ?? 0} 个工具`,
   'toolGroup.running': (v) =>
-    `正在执行 ${v?.name ?? '工具'}${v?.duration ? ` ${v.duration}` : ''}${
+    `正在执行 ${v?.name ?? '工具'}${
       Number(v?.count ?? 0) > 1 ? ` · 共 ${v?.count ?? 0} 个工具` : ''
     }`,
   'toolGroup.runningPrefix': '正在执行',


### PR DESCRIPTION
## What this PR does

This updates the existing Web Shell compact mode so Ctrl+O hides thinking rows while preserving the standard expandable tool UI. Regular tool activity separated only by hidden thinking is presented as one group, while agent, todo, question, approval, assistant, and user boundaries stay separate.

Running groups describe every active foreground tool and use the existing tool descriptions and tool-kind icons. Collapsed summaries do not show elapsed time; expanded tool rows show live elapsed time only while the tool is active and omit it after completion.

The existing compact-mode setting and persistence behavior are retained. Shell output keeps its existing presentation, and no new setting or browser-storage key is introduced.

## Why it's needed

Compact mode previously replaced tool content with a separate condensed presentation, which hid useful progress and output. Keeping the normal tool UI while removing thinking rows makes compact transcripts easier to scan without losing tool details or changing transcript data and model behavior.

## Reviewer Test Plan

### How to verify

Start a Web Shell session containing thinking, multiple foreground tools, shell output, agents, todos, questions, and approvals. Toggle compact mode with Ctrl+O and confirm that thinking rows disappear, ordinary tool activity separated only by thinking is grouped, the protected boundaries remain separate, and toggling again restores the full transcript order.

While a regular tool is active, expand its row and confirm that elapsed time increases. Confirm that no elapsed time appears in the collapsed group summary or after the tool completes. Confirm that running summaries describe all active foreground tools.

Refresh after enabling compact mode and confirm that the existing workspace preference restores the mode. Toggle it off and confirm that the preference is updated.

### Evidence (Before & After)

Before: compact mode replaced tool and shell content with condensed cards and did not provide the intended thinking-hidden transcript view.

After: compact mode hides thinking rows while retaining expandable tool details, normal shell output, meaningful activity summaries, and protected transcript boundaries. Automated DOM and unit coverage verifies these states; no screenshot was captured.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Verified with 694 focused Web Shell tests, an additional 183 adapter/tool tests after the final review fix, Web Shell type checking, ESLint, Prettier, and the repository pre-commit checks.

## Risk & Scope

- Main risk or tradeoff: compact-mode grouping changes the rendered activity sequence, so special tool and permission boundaries are explicitly excluded from merging.
- Not validated / out of scope: interactive browser E2E and local Windows/Linux runs; thinking-duration behavior and transcript timing semantics are unchanged.
- Breaking changes / migration notes: none; the existing shortcut and workspace preference continue to be used.

## Linked Issues

Supersedes #8872.

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本 PR 更新了现有的 Web Shell 紧凑模式：按 Ctrl+O 后隐藏思考行，同时保留标准的可展开工具界面。仅被隐藏思考隔开的普通工具活动会合并展示为一组，而代理、待办、提问、审批、助手消息和用户消息边界仍保持独立。

运行中的工具组会描述所有活跃的前台工具，并沿用现有的工具描述和工具类型图标。折叠摘要不显示耗时；展开的工具行仅在工具活跃时显示持续增长的耗时，工具完成后不再显示。

现有紧凑模式的设置和持久化行为保持不变。Shell 输出继续使用原有展示方式，不新增设置或浏览器存储键。

## 为什么需要

紧凑模式此前会把工具内容替换为单独的精简展示，从而隐藏有用的进度和输出。现在保留正常工具界面并隐藏思考行，可以让紧凑记录更易浏览，同时不丢失工具详情，也不改变记录数据和模型行为。

## Reviewer 测试计划

### 验证方式

启动一个包含思考、多个前台工具、Shell 输出、代理、待办、提问和审批的 Web Shell 会话。按 Ctrl+O 切换紧凑模式，确认思考行消失，仅被思考隔开的普通工具活动被归组，受保护的边界仍保持独立；再次切换后应恢复完整记录顺序。

普通工具运行时展开其工具行，确认耗时持续增加。确认折叠的工具组摘要不显示耗时，工具完成后也不显示耗时。确认运行摘要会描述所有活跃的前台工具。

启用紧凑模式后刷新，确认现有工作区偏好能够恢复该模式。关闭紧凑模式后，确认偏好设置同步更新。

### 证据（改动前后）

改动前：紧凑模式会把工具和 Shell 内容替换为精简卡片，无法提供预期的隐藏思考记录视图。

改动后：紧凑模式隐藏思考行，同时保留可展开的工具详情、正常 Shell 输出、有意义的活动摘要以及受保护的记录边界。自动化 DOM 和单元测试覆盖了这些状态；本次未截图。

### 测试平台

|     系统     | 状态 |
| :----------: | :--: |
|  🍏 macOS    |  ✅  |
| 🪟 Windows   |  ⚠️  |
|  🐧 Linux    |  ⚠️  |

### 环境（可选）

已通过 694 个聚焦 Web Shell 测试；最终审查修正后又运行了 183 个适配器/工具测试；同时通过 Web Shell 类型检查、ESLint、Prettier 和仓库 pre-commit 检查。

## 风险与范围

- 主要风险或取舍：紧凑模式归组会改变活动序列的渲染方式，因此特殊工具和审批边界被明确排除在合并之外。
- 未验证/范围外：交互式浏览器 E2E、Windows/Linux 本地运行；思考耗时行为和记录计时语义保持不变。
- 破坏性改动/迁移说明：无；继续使用现有快捷键和工作区偏好。

## 关联问题

替代 #8872。

</details>
