### PR TITLE
test(acp-bridge): request response-mode replay in the transport-failure test

### DIFF
--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -8432,6 +8432,12 @@ describe('createAcpSessionBridge', () => {
     const replayAttach = bridge.loadSession({
       sessionId: first.sessionId,
       workspaceCwd: WS_A,
+      // historyPageSize only takes effect in response-mode replay (#8933);
+      // without historyReplay the request silently degrades to 'stream',
+      // no transcript page is ever requested, and the waitFor below times
+      // out. This test predates that gating (logical merge conflict — both
+      // PRs were green on their own branches).
+      historyReplay: 'response',
       historyPageSize: 10,
       clientId: 'rejected-load-client',
     });


### PR DESCRIPTION
## Problem

`createAcpSessionBridge > transport failure marks the channel dying before process exit` (added in #8947) fails **deterministically** on merged main — first observed breaking an unrelated PR's CI (#8981, `Test (ubuntu-latest, Node 22.x)`), and reproducible locally on `origin/main` 3/3:

```
× transport failure marks the channel dying before process exit 1081ms
  → expected [] to deep equally contain ObjectContaining{…}   (bridge.test.ts:8439)
```

## Root cause: a logical merge conflict, not a flake

- #8933 (`962dc8eadc`, merged 2026-08-12 01:20) gated `historyPageSize` behind response-mode replay: in `restoreSession`, `historyPageSize` now only takes effect when `historyReplay === 'response'`; otherwise the request degrades to `'stream'` and the bounded transcript refresh (`refreshedReplayFieldsFor` → `requestSessionTranscriptPage`) is never entered.
- #8947's branch **does not contain #8933** (verified: `962dc8eadc` is not an ancestor of its head `e2c6af25`). Its new test calls `loadSession({ historyPageSize: 10 })` without `historyReplay`, which triggered the transcript page request under pre-#8933 semantics.
- Each PR was green on its own branch; the combination is red: on merged main the request silently degrades to stream replay, no `sessionTranscript` ext call ever happens, and the `vi.waitFor` on `extMethodCalls` times out at its 1s default. Instrumented replay confirms the mechanism: `historyReplay=stream historyPageSize=undefined`, replay contains a single `session_update`, no `history_truncated` marker, so the anchor-backfill path does not fire either.

## Fix

Pass `historyReplay: 'response'` in the test's `loadSession` call, restoring the intended scenario under post-#8933 semantics: the transcript page request hangs against the fake agent, the transport failure rejects it, `refreshedReplayFieldsFor` falls back to the in-memory replay, and the second `assertAttachableSessionEntry` maps the torn-down session to `SessionNotFoundError` — exactly what the test asserts. One test-file change, no production code touched.

## Verification

- The failing test now passes 3/3 in the environment where it previously failed 3/3.
- Full `packages/acp-bridge` suite: 26 files, **1277 passed** (previously 1 failed / 1276 passed in CI run 31565801863).

<details>
<summary>中文说明</summary>

## 问题

`createAcpSessionBridge > transport failure marks the channel dying before process exit`（#8947 新增）在合并后的 main 上**确定性失败**——最先打红了无关 PR（#8981）的 CI（`Test (ubuntu-latest, Node 22.x)`），并可在本地 `origin/main` 上 3/3 复现：

```
× transport failure marks the channel dying before process exit 1081ms
  → expected [] to deep equally contain ObjectContaining{…}   (bridge.test.ts:8439)
```

## 根因：逻辑合并冲突，不是 flake

- #8933（`962dc8eadc`，2026-08-12 01:20 合入）为 `historyPageSize` 增加了 response 模式门控：`restoreSession` 中 `historyPageSize` 仅在 `historyReplay === 'response'` 时生效；否则请求降级为 `'stream'`，有界 transcript 刷新（`refreshedReplayFieldsFor` → `requestSessionTranscriptPage`）根本不会进入。
- #8947 的分支**不包含 #8933**（已验证：`962dc8eadc` 不是其 head `e2c6af25` 的祖先）。其新测试调用 `loadSession({ historyPageSize: 10 })` 且未传 `historyReplay`，在 #8933 之前的语义下会触发 transcript 分页请求。
- 两个 PR 在各自分支上都是绿的；合并后组合变红：在 main 上请求被静默降级为 stream 回放，`sessionTranscript` ext 调用永不发生，`extMethodCalls` 上的 `vi.waitFor` 在默认 1 秒后超时。插桩回放证实了这一机制：`historyReplay=stream historyPageSize=undefined`，回放仅含一条 `session_update`，无 `history_truncated` 标记，锚点回填路径同样不会触发。

## 修复

在测试的 `loadSession` 调用中补上 `historyReplay: 'response'`，在 #8933 之后的语义下恢复测试预期场景：transcript 分页请求挂在 fake agent 上，transport failure 将其拒绝，`refreshedReplayFieldsFor` 回退到内存回放，随后第二个 `assertAttachableSessionEntry` 把已拆除的会话映射为 `SessionNotFoundError`——与测试断言完全一致。仅改动一个测试文件，不触碰生产代码。

## 验证

- 该测试在此前 3/3 失败的环境中现在 3/3 通过。
- `packages/acp-bridge` 全套：26 个文件，**1277 全部通过**（CI run 31565801863 中此前为 1 失败 / 1276 通过）。

</details>
