### PR TITLE
fix(serve): restore the transport-failure bridge test's transcript fetch shape

### DIFF
--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -8432,6 +8432,10 @@ describe('createAcpSessionBridge', () => {
     const replayAttach = bridge.loadSession({
       sessionId: first.sessionId,
       workspaceCwd: WS_A,
+      // historyPageSize only takes effect under response replay (#8933 kept
+      // the restore request shapes distinct); without this the transcript
+      // fetch never happens and the wait below spins on an empty call list.
+      historyReplay: 'response',
       historyPageSize: 10,
       clientId: 'rejected-load-client',
     });


### PR DESCRIPTION
## What this PR does

The bridge test added by #8947 ("transport failure marks the channel dying before process exit") attaches with `historyPageSize: 10` but without `historyReplay: 'response'`. #8933, merged a few hours earlier, made `historyPageSize` a no-op outside response replay, so the transcript fetch the test waits for never happens and the wait spins on an empty ext-method call list. This one-line fix passes the response-replay shape so the test exercises the transcript path again, as it did when #8947's CI ran.

## Why it's needed

The two PRs crossed without conflict markers: #8947's CI ran against a base without #8933's request-shape gate and passed; after both merged, main fails this test deterministically (reproduced 3/3 locally), blocking every PR cut from the new main (e.g. runs 31566076525, 31566817858, 31566722008, 31566021116 all fail on the identical signature).

## Reviewer Test Plan

### How to verify

Run `cd packages/acp-bridge && npx vitest run src/bridge.test.ts -t "transport failure marks the channel dying before process exit"` — before this change it fails deterministically with `expected [] to deep equally contain ObjectContaining{ method: 'qwen/status/session/transcript' }`; after, it passes in ~200ms. The full bridge suite passes (568/568).

### Evidence (Before & After)

N/A (test-only change, no user-visible behavior).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows | ⚠️ (covered by CI) |
|  🐧 Linux  | ⚠️ (covered by CI) |

### Environment (optional)

N/A — unit tests only.

## Risk & Scope

- Main risk or tradeoff: none identified — test-only change restoring the request shape the test was written against; all 37 other `historyPageSize` call sites already pass `historyReplay: 'response'`.
- Not validated / out of scope: whether the daemon should reject (rather than ignore) a `historyPageSize` without response replay — a possible follow-up so this class of silent no-op cannot recur.
- Breaking changes / migration notes: none.

## Linked Issues

Unblocks main CI after the #8947 × #8933 semantic merge conflict.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

#8947 新增的 bridge 用例（"transport failure marks the channel dying before process exit"）attach 时带了 `historyPageSize: 10` 但没带 `historyReplay: 'response'`。早几个小时合入的 #8933 已把 `historyPageSize` 在 response replay 之外变成空操作，于是测试等待的 transcript 拉取根本不会发生，等待在空的 ext-method 调用列表上空转。本 PR 用一行修复补上 response replay 形态，让测试重新走到 transcript 路径——与 #8947 CI 运行时的行为一致。

## 为什么需要

两个 PR 交错合入且没有文本冲突标记：#8947 的 CI 跑在不含 #8933 请求形态门控的基线上所以通过了；两者都合入后，main 上该用例确定性失败（本地 3/3 复现），阻塞了所有基于新 main 的 PR（如 run 31566076525、31566817858、31566722008、31566021116 全部挂在同一签名）。

## 评审验证计划

### 如何验证

运行 `cd packages/acp-bridge && npx vitest run src/bridge.test.ts -t "transport failure marks the channel dying before process exit"`——改动前确定性失败于 `expected [] to deep equally contain ObjectContaining{ method: 'qwen/status/session/transcript' }`；改动后约 200ms 通过。完整 bridge 套件通过（568/568）。

### 前后对比证据

N/A（纯测试变更，无用户可见行为）。

### 测试环境

macOS 已本地验证；Windows/Linux 由 CI 覆盖。

### 环境说明

N/A——仅单元测试。

## 风险与范围

- 主要风险或权衡：未发现——纯测试变更，恢复该用例编写时的请求形态；其余 37 处 `historyPageSize` 调用点均已携带 `historyReplay: 'response'`。
- 未验证 / 超出范围：daemon 是否应当拒绝（而非静默忽略）不带 response replay 的 `historyPageSize`——可作为后续跟进，避免这类静默空操作再次发生。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

解除 #8947 与 #8933 语义合并冲突导致的 main CI 阻塞。

</details>
