### PR TITLE
fix(cli): prevent input border overflow on resize

### DIFF
--- a/packages/cli/src/ui/components/BaseTextInput.test.tsx
+++ b/packages/cli/src/ui/components/BaseTextInput.test.tsx
@@ -186,11 +186,13 @@ describe('BaseTextInput', () => {
   });
 
   it.each([
-    { columns: 11, label: 'session' },
-    { columns: 12, label: '会话标题' },
+    { columns: 11, label: 'session', expectedLabel: 'sessi…' },
+    { columns: 12, label: '会话标题', expectedLabel: '会话标…' },
+    { columns: 20, label: 'session', expectedLabel: 'session' },
+    { columns: 4, label: 'session', expectedLabel: '' },
   ])(
     'keeps the top border within $columns columns for "$label"',
-    ({ columns, label }) => {
+    ({ columns, label, expectedLabel }) => {
       const originalDescriptor = Object.getOwnPropertyDescriptor(
         process.stdout,
         'columns',
@@ -211,6 +213,11 @@ describe('BaseTextInput', () => {
         const topBorderLine = lastFrame()?.split('\n')[0] ?? '';
 
         expect(stringWidth(topBorderLine)).toBe(columns);
+        if (expectedLabel) {
+          expect(topBorderLine).toContain(` ${expectedLabel} `);
+        } else {
+          expect(topBorderLine).toBe('─'.repeat(columns));
+        }
       } finally {
         if (originalDescriptor) {
           Object.defineProperty(process.stdout, 'columns', originalDescriptor);

--- a/packages/cli/src/ui/components/BaseTextInput.test.tsx
+++ b/packages/cli/src/ui/components/BaseTextInput.test.tsx
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from 'ink-testing-library';
 import type { DOMElement } from 'ink';
+import stringWidth from 'string-width';
 import {
   BaseTextInput,
   defaultRenderLine,
@@ -183,6 +184,42 @@ describe('BaseTextInput', () => {
       }),
     ).toEqual({ x: 29, y: 20 });
   });
+
+  it.each([
+    { columns: 11, label: 'session' },
+    { columns: 12, label: '会话标题' },
+  ])(
+    'keeps the top border within $columns columns for "$label"',
+    ({ columns, label }) => {
+      const originalDescriptor = Object.getOwnPropertyDescriptor(
+        process.stdout,
+        'columns',
+      );
+      Object.defineProperty(process.stdout, 'columns', {
+        configurable: true,
+        value: columns,
+      });
+
+      try {
+        const { lastFrame } = render(
+          <BaseTextInput
+            buffer={createBuffer()}
+            onSubmit={vi.fn()}
+            topRightLabel={label}
+          />,
+        );
+        const topBorderLine = lastFrame()?.split('\n')[0] ?? '';
+
+        expect(stringWidth(topBorderLine)).toBe(columns);
+      } finally {
+        if (originalDescriptor) {
+          Object.defineProperty(process.stdout, 'columns', originalDescriptor);
+        } else {
+          Reflect.deleteProperty(process.stdout, 'columns');
+        }
+      }
+    },
+  );
 });
 
 describe('getAbsolutePosition', () => {

--- a/packages/cli/src/ui/components/BaseTextInput.tsx
+++ b/packages/cli/src/ui/components/BaseTextInput.tsx
@@ -28,7 +28,7 @@ import type { Key } from '../hooks/useKeypress.js';
 import { useKeypress } from '../hooks/useKeypress.js';
 import { keyMatchers, Command } from '../keyMatchers.js';
 import stringWidth from 'string-width';
-import { cpSlice, cpLen } from '../utils/textUtils.js';
+import { cpSlice, cpLen, truncateToWidth } from '../utils/textUtils.js';
 import { theme } from '../semantic-colors.js';
 import { renderSoftwareCursor } from '../utils/software-cursor.js';
 
@@ -340,11 +340,14 @@ export const BaseTextInput = ({
 
   const columns = process.stdout.columns || 80;
   // Build the top border line: ─────── label ──
-  // Label takes: 1 space + text + 1 space + 2 trailing dashes = label.length + 4
-  const labelWidth = topRightLabel ? stringWidth(topRightLabel) + 4 : 0;
-  const dashCount = Math.max(1, columns - labelWidth);
-  const topBorderLine = topRightLabel
-    ? `${'─'.repeat(dashCount)} ${topRightLabel} ${'─'.repeat(2)}`
+  // Label takes 1 leading space, the text, 1 trailing space, and 2 dashes.
+  const renderedLabel = topRightLabel
+    ? truncateToWidth(topRightLabel, columns - 5)
+    : '';
+  const labelWidth = renderedLabel ? stringWidth(renderedLabel) + 4 : 0;
+  const dashCount = columns - labelWidth;
+  const topBorderLine = renderedLabel
+    ? `${'─'.repeat(dashCount)} ${renderedLabel} ${'─'.repeat(2)}`
     : '─'.repeat(columns);
 
   return (

--- a/packages/cli/src/ui/components/BaseTextInput.tsx
+++ b/packages/cli/src/ui/components/BaseTextInput.tsx
@@ -32,6 +32,9 @@ import { cpSlice, cpLen, truncateToWidth } from '../utils/textUtils.js';
 import { theme } from '../semantic-colors.js';
 import { renderSoftwareCursor } from '../utils/software-cursor.js';
 
+const TOP_BORDER_LABEL_DECORATION_WIDTH = 4;
+const TOP_BORDER_MIN_LEADING_DASHES = 1;
+
 // ─── Types ──────────────────────────────────────────────────
 
 export interface RenderLineOptions {
@@ -340,11 +343,15 @@ export const BaseTextInput = ({
 
   const columns = process.stdout.columns || 80;
   // Build the top border line: ─────── label ──
-  // Label takes 1 leading space, the text, 1 trailing space, and 2 dashes.
+  // Reserve the label decoration and at least one leading dash.
+  const labelBudget =
+    columns - TOP_BORDER_LABEL_DECORATION_WIDTH - TOP_BORDER_MIN_LEADING_DASHES;
   const renderedLabel = topRightLabel
-    ? truncateToWidth(topRightLabel, columns - 5)
+    ? truncateToWidth(topRightLabel, labelBudget)
     : '';
-  const labelWidth = renderedLabel ? stringWidth(renderedLabel) + 4 : 0;
+  const labelWidth = renderedLabel
+    ? stringWidth(renderedLabel) + TOP_BORDER_LABEL_DECORATION_WIDTH
+    : 0;
   const dashCount = columns - labelWidth;
   const topBorderLine = renderedLabel
     ? `${'─'.repeat(dashCount)} ${renderedLabel} ${'─'.repeat(2)}`


### PR DESCRIPTION
## What this PR does

Constrains the labelled input-box top border to the current terminal width. When a session title cannot fit, it is truncated by terminal display width with an ellipsis while preserving the surrounding border; at extremely narrow widths, the label is hidden and the border remains width-safe.

## Why it's needed

During terminal resize, the previous border arithmetic always kept at least one leading dash without first bounding the label. At the exact boundary where the label and decorations filled the viewport, the resulting row was one cell too wide, so the final dash could wrap and make the input box jitter down by one row.

## Reviewer Test Plan

### How to verify

1. Start an interactive session, run `/rename session`, and resize the terminal to 11 columns. Confirm the top border remains a single row and reads `─ sessi… ──`.
2. Expand the terminal and confirm the full session title returns without truncation.
3. Run `cd packages/cli && node ../../node_modules/vitest/vitest.mjs run src/ui/components/BaseTextInput.test.tsx --maxWorkers=1`; all 14 tests should pass, including ASCII and CJK width boundaries.
4. Run `npm run typecheck` and `npm run build` from the CLI package; both should pass.

### Evidence (Before & After)

| Viewport | Before | After |
| --- | --- | --- |
| 11 columns, ASCII title | `─ session ──` — 12 cells | `─ sessi… ──` — 11 cells |
| 12 columns, CJK title | `─ 会话标题 ──` — 13 cells | `─ 会话标… ──` — 12 cells |

A real PTY run on macOS resumed the `session` conversation at 11 columns and rendered `─ sessi… ──` on one row with no stray border fragment.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22, local source checkout, an 11x30 PTY, safe and bare modes, and an isolated temporary Qwen home. No model request was sent.

The repository preflight was also executed. Formatting, lint, builds, and typechecks passed; the exhaustive test stage returned non-zero in unrelated existing concurrency, bundle-drift, UI timing, and proxy-environment tests. The focused regression suite passed after those failures were isolated and rerun.

## Risk & Scope

- Main risk or tradeoff: Long titles truncate slightly earlier at narrow widths so the border always retains one leading dash and two trailing dashes; below six columns, the title is hidden.
- Not validated / out of scope: Manual resize testing on Windows and Linux, and the separate footer-pill overflow risk noted in the issue discussion.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #8849

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

将带标题的输入框上边框严格限制在当前终端宽度内。当会话标题放不下时，按终端显示宽度截断并添加省略号，同时保留两侧边框；终端极窄时隐藏标题，确保边框始终不会溢出。

## 为什么需要

终端缩放过程中，原先的边框计算会强制至少保留一个左侧横线，却没有先限制标题宽度。当标题与装饰恰好占满视口时，最终构造出的整行会多出一格，末尾横线可能自动换行，从而导致输入框向下抖动一行。

## Reviewer 测试计划

### 如何验证

1. 启动交互会话，执行 `/rename session`，把终端缩到 11 列。确认上边框保持单行并显示为 `─ sessi… ──`。
2. 扩宽终端，确认完整会话标题恢复显示，不再截断。
3. 在 CLI 包中运行 `cd packages/cli && node ../../node_modules/vitest/vitest.mjs run src/ui/components/BaseTextInput.test.tsx --maxWorkers=1`；14 个测试应全部通过，其中包括 ASCII 与 CJK 宽度边界。
4. 在 CLI 包中运行 `npm run typecheck` 和 `npm run build`；两者都应通过。

### 前后证据

| 视口 | 修复前 | 修复后 |
| --- | --- | --- |
| 11 列，ASCII 标题 | `─ session ──` — 12 格 | `─ sessi… ──` — 11 格 |
| 12 列，CJK 标题 | `─ 会话标题 ──` — 13 格 | `─ 会话标… ──` — 12 格 |

在 macOS 真实 PTY 中，以 11 列恢复名为 `session` 的会话后，上边框稳定地在一行内显示为 `─ sessi… ──`，没有出现游离的边框碎片。

### 已测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|    🍏 macOS      |  ✅  |
|    🪟 Windows    |  ⚠️  |
|     🐧 Linux     |  ⚠️  |

### 环境（可选）

Node.js 22、本地源码、11x30 PTY、safe 与 bare 模式，以及隔离的临时 Qwen 主目录。未发送任何模型请求。

同时执行了仓库 preflight。格式化、lint、构建和类型检查均通过；全量测试阶段仅在与本改动无关的既有并发、bundle 漂移、UI 时序和代理环境测试中以非零状态结束。隔离并复跑这些失败后，本次修复的定向回归测试通过。

## 风险与范围

- 主要风险或取舍：窄终端下长标题会略早截断，以便边框始终保留一个左侧横线和两个右侧横线；不足 6 列时隐藏标题。
- 未验证 / 不在范围内：Windows 与 Linux 的手动缩放测试，以及 issue 讨论中提到的独立 Footer pill 溢出风险。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #8849

</details>
