### PR TITLE
docs(agents): drop mandatory /review step from the general workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,11 +206,6 @@ npm run preflight  # Full check: clean → install → format → lint → build
    exit on a pass that found something. If five passes bring no convergence,
    say so instead of declaring done. Scale to the diff: one clean, careful
    pass suffices for a trivial change.
-5. **Code review** — run `/review` when available. Triage each comment:
-   valid / false positive / overthinking. Fixes go back through steps 3-4.
-   Here, `/review` means the Codex code-review workflow, not Qwen Review or
-   the `qwen-review` plugin. Do not invoke Qwen Review unless the user
-   explicitly requests it by name.
 
 ### Feature development
 


### PR DESCRIPTION
## What this PR does

Removes the unconditional code-review step from the general development workflow that agents working in this repository follow. The workflow no longer instructs agents to run `/review` on their own initiative; running a review is now something the user explicitly asks for.

## Why it's needed

The removed step told agents to run `/review` whenever it was available, so any routine request that ended in a commit — "implement this and commit it", or even just "commit these changes" — launched the full multi-agent review pipeline (roughly ten parallel review agents plus a verification pass at the default medium effort) before anything shipped. That burns large amounts of tokens on every commit, especially on thinking-enabled models, even though a review was never asked for. On-demand review stays fully available through the `/review` skill, and the project-specific review rules section is untouched because the skill loads it only when a review actually runs.

## Reviewer Test Plan

### How to verify

Guidance-text-only change with no code paths involved. Read the diff and confirm the remaining workflow steps still read coherently — the self-audit step's reference to "step 3" still resolves, and nothing else in the guidance references the removed step. Optionally ask an agent in this repo to commit a small change and confirm it no longer launches `/review` unprompted.

### Evidence (Before & After)

N/A (guidance text change, no UI)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

N/A

## Risk & Scope

- Main risk or tradeoff: agents no longer get an automatic review pass as part of the standard workflow; reviews become opt-in, which is the intended behavior.
- Not validated / out of scope: the `/feat-dev` and `/bugfix` skill workflows still include their own code-review steps — those are explicit opt-in workflows and were left as is.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

移除了本仓库中 agent 遵循的通用开发工作流里那条无条件的代码审查步骤。工作流不再指示 agent 主动运行 `/review`；审查改为用户明确要求时才执行。

## 为什么需要

被移除的步骤要求 agent 在 `/review` 可用时就运行它，导致任何以提交收尾的常规请求——"实现这个并提交"、甚至只是"提交这些改动"——都会在提交前拉起完整的多 agent 审查流水线（默认 medium 档位下约十个并行审查 agent 加一轮验证）。这在每次提交时都消耗大量 token，在开启思考的模型上尤其明显，而审查其实并不是用户所要求的。按需审查仍然完全可用（通过 `/review` skill），项目专属的审查规则段落保持不变，因为该段落只在审查实际运行时由 skill 加载。

## 审阅者测试计划

### 如何验证

纯指引文本改动，不涉及任何代码路径。阅读 diff，确认剩余的工作流步骤读起来连贯——自审步骤对"step 3"的引用仍然有效，且指引中没有其他地方引用被移除的步骤。也可以在本仓库让 agent 提交一个小改动，确认它不再未经要求就拉起 `/review`。

### 证据（前后对比）

N/A（指引文本改动，无 UI）

### 测试环境

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### 环境（可选）

N/A

## 风险与范围

- 主要风险或权衡：agent 在标准工作流中不再有自动审查这一步；审查变为按需触发，这正是预期行为。
- 未验证 / 超出范围：`/feat-dev` 和 `/bugfix` skill 工作流仍保留各自的代码审查步骤——它们是显式选择进入的工作流，本次未改动。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

N/A

</details>

Generated with Qwen Code
