### PR TITLE
fix(cli): Bound headless tool result content

### DIFF
--- a/docs/design/2026-08-12-headless-tool-result-text-projection.md
+++ b/docs/design/2026-08-12-headless-tool-result-text-projection.md
@@ -1,0 +1,51 @@
+# Headless Tool-Result Text Projection
+
+## Summary
+
+Headless JSON transports currently serialize the complete semantic display
+string selected for `tool_result.content`. A large tool display therefore
+creates a large JSON array entry or JSONL event even when the model-facing tool
+response and producer artifact are already bounded separately.
+
+This change applies a fixed display-transport projection after semantic
+selection and before the shared JSON adapter emits or retains the result.
+
+## Contract
+
+For textual `tool_result.content` created by the built-in JSON adapters:
+
+```text
+UTF8_BYTES(JSON.stringify(content)) <= 65,536
+```
+
+Oversized strings use a deterministic preview containing approximately 20%
+of the available source budget from the head and 80% from the tail. The
+transport marker counts toward the budget. JSON escaping, control characters,
+Unicode, paired surrogates, and lone surrogates use the same accounting as
+native JSON serialization.
+
+The projection is independent of output format, covering JSON, stream-JSON,
+persistent stream-JSON and SDK sessions, subagent results, internal Text-mode
+retention, and Dual Output through one adapter boundary.
+
+## Boundaries
+
+Projection occurs only after the adapter selects the semantic display value.
+It does not modify the tool response, model-facing response parts, canonical
+recording, or producer artifact. Existing display footers may survive in the
+tail, but internal `persistedOutputFiles` metadata is not inspected or added
+to the wire.
+
+The shared implementation contains only JSON-string byte accounting and
+single-string preview selection. ACP keeps its own multi-block allocation,
+A2UI exemption, and field-specific behavior while reusing those primitives.
+
+Dual Output increments its protocol version from 1 to 2 because existing
+consumers can observe bounded previews in a previously unbounded field. Event
+types and SDK schemas are unchanged.
+
+## Non-goals
+
+This is not a universal event, JSONL frame, accumulated session, tool-input,
+partial-message, replay-container, or backpressure limit. It does not change
+artifact ownership or lifecycle and introduces no configuration or disk I/O.

--- a/docs/users/features/dual-output.md
+++ b/docs/users/features/dual-output.md
@@ -256,6 +256,11 @@ Events are emitted as JSON Lines (one object per line). The schema is the same
 one used by the non-interactive `--output-format=stream-json` mode, with
 `includePartialMessages` always enabled.
 
+Protocol version 2 bounds textual `tool_result.content` values to 65,536 UTF-8
+bytes after JSON string serialization. Oversized values become deterministic
+head/tail previews; the event type and field schema are unchanged. This is a
+field limit, not a universal JSONL frame-size limit.
+
 The first event on the channel is always `system` / `session_start`, emitted
 when the bridge is constructed. Use it to correlate the channel with a
 session id before any other event arrives.

--- a/docs/users/features/headless.md
+++ b/docs/users/features/headless.md
@@ -215,6 +215,14 @@ Output (streaming as events occur):
 
 When combined with `--include-partial-messages`, additional stream events are emitted in real-time (message_start, content_block_delta, etc.) for real-time UI updates.
 
+For JSON and stream-JSON output, textual `tool_result.content` values are
+bounded to 65,536 UTF-8 bytes after JSON string serialization. Oversized
+values are emitted as deterministic head/tail previews. The same bound applies
+to persistent stream-JSON sessions, SDK transports, subagent tool results, and
+Dual Output. Text mode still prints only the final response, while retaining
+only the bounded preview internally. This limit does not cap an entire JSON
+session, JSONL event, tool input, or partial message.
+
 ```bash
 qwen -p "Write a Python script" --output-format stream-json --include-partial-messages
 ```

--- a/packages/cli/src/acp-integration/session/acp-tool-result-text-projection.test.ts
+++ b/packages/cli/src/acp-integration/session/acp-tool-result-text-projection.test.ts
@@ -10,7 +10,6 @@ import { describe, expect, it } from 'vitest';
 import {
   ACP_TOOL_RESULT_TEXT_JSON_BYTE_BUDGET,
   ACP_TOOL_RESULT_TEXT_TRUNCATION_MARKER,
-  jsonStringJsonByteLength,
   projectAcpToolResultUpdate,
 } from './acp-tool-result-text-projection.js';
 
@@ -50,53 +49,6 @@ function jsonBytes(value: unknown): number {
 }
 
 describe('ACP tool-result text projection', () => {
-  it('matches native JSON string byte accounting for Unicode and escapes', () => {
-    const samples = [
-      '',
-      'plain ASCII',
-      '"\\\n\b\f\r\t',
-      '\0\u0001\u001f',
-      '汉字',
-      '😀',
-      '\ud83d\ude00',
-      '\ud800',
-      '\udc00',
-      '\u2028\u2029',
-      '\u007f\u0080\u07ff\u0800',
-    ];
-    for (const sample of samples) {
-      expect(jsonStringJsonByteLength(sample)).toBe(jsonBytes(sample));
-    }
-  });
-
-  it('matches native JSON byte accounting under fixed-seed fuzzing', () => {
-    const atoms = [
-      'a',
-      '"',
-      '\\',
-      '\n',
-      '\0',
-      '汉',
-      '😀',
-      '\ud800',
-      '\udc00',
-      '\u2028',
-    ];
-    let state = 0x5eed1234;
-    const random = () => {
-      state = (Math.imul(state, 1_664_525) + 1_013_904_223) >>> 0;
-      return state;
-    };
-    for (let sampleIndex = 0; sampleIndex < 250; sampleIndex++) {
-      const length = random() % 200;
-      let value = '';
-      for (let index = 0; index < length; index++) {
-        value += atoms[random() % atoms.length];
-      }
-      expect(jsonStringJsonByteLength(value)).toBe(jsonBytes(value));
-    }
-  });
-
   it.each([65_535, 65_536, 65_537])(
     'enforces the rawOutput boundary at %i JSON bytes',
     (targetBytes) => {

--- a/packages/cli/src/acp-integration/session/acp-tool-result-text-projection.ts
+++ b/packages/cli/src/acp-integration/session/acp-tool-result-text-projection.ts
@@ -7,6 +7,12 @@
 import { Buffer } from 'node:buffer';
 import type { SessionUpdate } from '@agentclientprotocol/sdk';
 import { isA2uiToolMeta } from '@qwen-code/acp-bridge/bridgeClient';
+import {
+  JSON_STRING_DELIMITER_BYTES,
+  jsonStringJsonByteLength,
+  jsonStringPayloadByteLength,
+  truncateJsonStringPayload,
+} from '../../utils/json-string-byte-projection.js';
 
 export const ACP_TOOL_RESULT_TEXT_JSON_BYTE_BUDGET = 65_536;
 export const ACP_TOOL_RESULT_TEXT_TRUNCATION_MARKER =
@@ -26,7 +32,6 @@ const EMPTY_TEXT_BLOCK_JSON_BYTES = Buffer.byteLength(
   'utf8',
 );
 const JSON_ARRAY_SEPARATOR_BYTES = 1;
-const JSON_STRING_DELIMITER_BYTES = 2;
 const TRUNCATION_MARKER_PAYLOAD_BYTES =
   jsonStringJsonByteLength(ACP_TOOL_RESULT_TEXT_TRUNCATION_MARKER) -
   JSON_STRING_DELIMITER_BYTES;
@@ -79,111 +84,6 @@ function canonicalTextBlocks(
     }
   }
   return value as CanonicalTextContentBlock[];
-}
-
-function jsonPayloadBytesAt(value: string, index: number): number {
-  const code = value.charCodeAt(index);
-  if (code === 0x22 || code === 0x5c) return 2;
-  if (code <= 0x1f) {
-    return code === 0x08 ||
-      code === 0x09 ||
-      code === 0x0a ||
-      code === 0x0c ||
-      code === 0x0d
-      ? 2
-      : 6;
-  }
-  if (code <= 0x7f) return 1;
-  if (code <= 0x7ff) return 2;
-  if (code >= 0xd800 && code <= 0xdbff) {
-    const next = value.charCodeAt(index + 1);
-    return next >= 0xdc00 && next <= 0xdfff ? 4 : 6;
-  }
-  if (code >= 0xdc00 && code <= 0xdfff) return 6;
-  return 3;
-}
-
-function jsonPayloadWidthAt(value: string, index: number): number {
-  const code = value.charCodeAt(index);
-  if (code < 0xd800 || code > 0xdbff) return 1;
-  const next = value.charCodeAt(index + 1);
-  return next >= 0xdc00 && next <= 0xdfff ? 2 : 1;
-}
-
-function jsonStringPayloadByteLength(
-  value: string,
-  stopAfterBytes = Number.POSITIVE_INFINITY,
-): number {
-  let bytes = 0;
-  for (let index = 0; index < value.length; ) {
-    bytes += jsonPayloadBytesAt(value, index);
-    if (bytes > stopAfterBytes) return bytes;
-    index += jsonPayloadWidthAt(value, index);
-  }
-  return bytes;
-}
-
-export function jsonStringJsonByteLength(value: string): number {
-  return JSON_STRING_DELIMITER_BYTES + jsonStringPayloadByteLength(value);
-}
-
-function jsonPayloadWidthBefore(value: string, end: number): number {
-  const last = value.charCodeAt(end - 1);
-  if (last >= 0xdc00 && last <= 0xdfff && end >= 2) {
-    const previous = value.charCodeAt(end - 2);
-    if (previous >= 0xd800 && previous <= 0xdbff) return 2;
-  }
-  return 1;
-}
-
-function selectPrefix(value: string, budget: number): number {
-  let end = 0;
-  let bytes = 0;
-  while (end < value.length) {
-    const partBytes = jsonPayloadBytesAt(value, end);
-    if (bytes + partBytes > budget) break;
-    bytes += partBytes;
-    end += jsonPayloadWidthAt(value, end);
-  }
-  return end;
-}
-
-function selectSuffix(value: string, budget: number): number {
-  let start = value.length;
-  let bytes = 0;
-  while (start > 0) {
-    const partWidth = jsonPayloadWidthBefore(value, start);
-    const partBytes = jsonPayloadBytesAt(value, start - partWidth);
-    if (bytes + partBytes > budget) break;
-    bytes += partBytes;
-    start -= partWidth;
-  }
-  return start;
-}
-
-function copyString(value: string): string {
-  return value.split('').join('');
-}
-
-function truncateStringPayload(
-  value: string,
-  originalPayloadBytes: number,
-  payloadBudget: number,
-): string {
-  if (originalPayloadBytes <= payloadBudget) return value;
-  if (payloadBudget < TRUNCATION_MARKER_PAYLOAD_BYTES) {
-    return copyString(value.slice(0, selectPrefix(value, payloadBudget)));
-  }
-  const sourceBudget = payloadBudget - TRUNCATION_MARKER_PAYLOAD_BYTES;
-  const headBudget = Math.floor(sourceBudget * 0.2);
-  const tailBudget = sourceBudget - headBudget;
-  const headEnd = selectPrefix(value, headBudget);
-  const tailStart = selectSuffix(value, tailBudget);
-  return (
-    copyString(value.slice(0, headEnd)) +
-    ACP_TOOL_RESULT_TEXT_TRUNCATION_MARKER +
-    copyString(value.slice(tailStart))
-  );
 }
 
 function contentSkeletonBytes(blockCount: number): number {
@@ -321,10 +221,11 @@ function projectContent(
   const projected = original.map((block, index) => {
     if (payloadBytes[index] <= allocations[index]) return block;
     return createTextBlock(
-      truncateStringPayload(
+      truncateJsonStringPayload(
         block.content.text,
         payloadBytes[index],
         allocations[index],
+        ACP_TOOL_RESULT_TEXT_TRUNCATION_MARKER,
       ),
     );
   });
@@ -338,7 +239,12 @@ function projectRawOutput(value: string): string {
     ACP_TOOL_RESULT_TEXT_JSON_BYTE_BUDGET - JSON_STRING_DELIMITER_BYTES;
   const payloadBytes = jsonStringPayloadByteLength(value, payloadBudget);
   if (payloadBytes <= payloadBudget) return value;
-  const projected = truncateStringPayload(value, payloadBytes, payloadBudget);
+  const projected = truncateJsonStringPayload(
+    value,
+    payloadBytes,
+    payloadBudget,
+    ACP_TOOL_RESULT_TEXT_TRUNCATION_MARKER,
+  );
   return jsonByteLength(projected) <= ACP_TOOL_RESULT_TEXT_JSON_BYTE_BUDGET
     ? projected
     : ACP_TOOL_RESULT_TEXT_TRUNCATION_MARKER;

--- a/packages/cli/src/dualOutput/DualOutputBridge.test.ts
+++ b/packages/cli/src/dualOutput/DualOutputBridge.test.ts
@@ -5,11 +5,16 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Buffer } from 'node:buffer';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { execSync } from 'node:child_process';
 import type { Config } from '@qwen-code/qwen-code-core';
+import {
+  HEADLESS_TOOL_RESULT_TEXT_JSON_BYTE_BUDGET,
+  HEADLESS_TOOL_RESULT_TEXT_TRUNCATION_MARKER,
+} from '../nonInteractive/io/headless-tool-result-text-projection.js';
 import {
   DualOutputBridge,
   DUAL_OUTPUT_PROTOCOL_VERSION,
@@ -165,6 +170,43 @@ describe('DualOutputBridge', () => {
       expect(data['version']).toBe('1.2.3');
       expect(data['protocol_version']).toBe(DUAL_OUTPUT_PROTOCOL_VERSION);
       expect(data['supported_events']).toEqual([...SUPPORTED_EVENTS]);
+      expect(DUAL_OUTPUT_PROTOCOL_VERSION).toBe(2);
+    });
+
+    it('writes bounded tool result content to the sidecar file', async () => {
+      bridge = new DualOutputBridge(config, { filePath: target });
+      const display = 'HEAD-' + 'x'.repeat(100_000) + '-TAIL';
+
+      bridge.emitToolResult(
+        {
+          callId: 'tool-large',
+          name: 'test_tool',
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'prompt-1',
+        },
+        {
+          callId: 'tool-large',
+          responseParts: [],
+          resultDisplay: display,
+          error: undefined,
+          errorType: undefined,
+        },
+      );
+      await bridge.shutdown();
+
+      const user = readJsonl(target).find((line) => line['type'] === 'user');
+      const content = (
+        user as {
+          message: { content: Array<{ content: string }> };
+        }
+      ).message.content[0].content;
+
+      expect(
+        Buffer.byteLength(JSON.stringify(content), 'utf8'),
+      ).toBeLessThanOrEqual(HEADLESS_TOOL_RESULT_TEXT_JSON_BYTE_BUDGET);
+      expect(content).toContain(HEADLESS_TOOL_RESULT_TEXT_TRUNCATION_MARKER);
+      expect(content).not.toBe(display);
     });
 
     it('emits session_end on shutdown for a clean termination signal', async () => {

--- a/packages/cli/src/dualOutput/DualOutputBridge.ts
+++ b/packages/cli/src/dualOutput/DualOutputBridge.ts
@@ -51,8 +51,9 @@ export const SUPPORTED_EVENTS = [
  *
  * History:
  *   1 — initial release (session_start, session_end, full stream-json).
+ *   2 — textual tool_result content is bounded for transport.
  */
-export const DUAL_OUTPUT_PROTOCOL_VERSION = 1;
+export const DUAL_OUTPUT_PROTOCOL_VERSION = 2;
 
 /**
  * Maximum bytes buffered in the Node.js WriteStream before the bridge

--- a/packages/cli/src/nonInteractive/io/BaseJsonOutputAdapter.test.ts
+++ b/packages/cli/src/nonInteractive/io/BaseJsonOutputAdapter.test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Buffer } from 'node:buffer';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   GeminiEventType,
@@ -28,6 +29,10 @@ import {
   extractTextFromBlocks,
   createExtendedUsage,
 } from './BaseJsonOutputAdapter.js';
+import {
+  HEADLESS_TOOL_RESULT_TEXT_JSON_BYTE_BUDGET,
+  HEADLESS_TOOL_RESULT_TEXT_TRUNCATION_MARKER,
+} from './headless-tool-result-text-projection.js';
 
 /**
  * Test implementation of BaseJsonOutputAdapter for unit testing.
@@ -1060,6 +1065,164 @@ describe('BaseJsonOutputAdapter', () => {
       if (message.type === 'user') {
         expect(message.parent_tool_use_id).toBe('parent-tool-1');
       }
+    });
+
+    const persistedOutputCases: Array<[string, string[] | undefined]> = [
+      ['unhandled', undefined],
+      ['handled without artifact', []],
+      ['reusable artifact', ['/tmp/private-output.txt']],
+    ];
+    it.each(persistedOutputCases)(
+      'bounds %s tool display without mutating or serializing persistence metadata',
+      (_name, persistedOutputFiles) => {
+        const display = 'HEAD-' + 'x'.repeat(100_000) + '-TAIL';
+        const request = {
+          callId: 'tool-large',
+          name: 'test_tool',
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'prompt-1',
+        };
+        const response = {
+          callId: 'tool-large',
+          responseParts: [],
+          resultDisplay: display,
+          error: undefined,
+          errorType: undefined,
+          persistedOutputFiles,
+        };
+
+        adapter.emitToolResult(request, response, 'parent-tool-1');
+
+        const message = adapter.emittedMessages[0];
+        expect(message).toMatchObject({
+          type: 'user',
+          parent_tool_use_id: 'parent-tool-1',
+        });
+        if (message.type !== 'user') throw new Error('Expected user message');
+        const block = message.message.content[0];
+        if (
+          typeof block !== 'object' ||
+          block === null ||
+          block.type !== 'tool_result' ||
+          typeof block.content !== 'string'
+        ) {
+          throw new Error('Expected textual tool result');
+        }
+
+        expect(
+          Buffer.byteLength(JSON.stringify(block.content), 'utf8'),
+        ).toBeLessThanOrEqual(HEADLESS_TOOL_RESULT_TEXT_JSON_BYTE_BUDGET);
+        expect(block.content).toContain(
+          HEADLESS_TOOL_RESULT_TEXT_TRUNCATION_MARKER,
+        );
+        expect(block.content.startsWith('HEAD-')).toBe(true);
+        expect(block.content.endsWith('-TAIL')).toBe(true);
+        expect(JSON.stringify(block)).not.toContain('/tmp/private-output.txt');
+        expect(response.resultDisplay).toBe(display);
+        expect(response.persistedOutputFiles).toBe(persistedOutputFiles);
+      },
+    );
+
+    it('keeps content omitted when semantic selection yields no text', () => {
+      const request = {
+        callId: 'tool-empty',
+        name: 'test_tool',
+        args: {},
+        isClientInitiated: false,
+        prompt_id: 'prompt-1',
+      };
+
+      adapter.emitToolResult(request, {
+        callId: 'tool-empty',
+        responseParts: [],
+        resultDisplay: undefined,
+        error: undefined,
+        errorType: undefined,
+      });
+
+      const message = adapter.emittedMessages[0];
+      if (message.type !== 'user') throw new Error('Expected user message');
+      const block = message.message.content[0];
+      if (
+        typeof block !== 'object' ||
+        block === null ||
+        block.type !== 'tool_result'
+      ) {
+        throw new Error('Expected tool result');
+      }
+      expect(Object.hasOwn(block, 'content')).toBe(false);
+    });
+
+    it.each([
+      {
+        name: 'responseParts fallback',
+        response: {
+          responseParts: [
+            {
+              functionResponse: {
+                response: {
+                  output: 'HEAD-' + 'p'.repeat(100_000) + '-TAIL',
+                },
+              },
+            },
+          ],
+          resultDisplay: undefined,
+          error: undefined,
+        },
+      },
+      {
+        name: 'top-level error',
+        response: {
+          responseParts: [],
+          resultDisplay: 'ignored display',
+          error: new Error('HEAD-' + 'e'.repeat(100_000) + '-TAIL'),
+        },
+      },
+      {
+        name: 'vision bridge notice',
+        response: {
+          responseParts: [],
+          resultDisplay: 'HEAD-' + 'v'.repeat(100_000) + '-TAIL',
+          visionBridgeNotice: 'Vision disclosure',
+          error: undefined,
+        },
+      },
+    ])('projects oversized $name after semantic selection', ({ response }) => {
+      adapter.emitToolResult(
+        {
+          callId: 'tool-semantic',
+          name: 'test_tool',
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'prompt-1',
+        },
+        {
+          callId: 'tool-semantic',
+          errorType: undefined,
+          ...response,
+        },
+      );
+
+      const message = adapter.emittedMessages[0];
+      if (message.type !== 'user') throw new Error('Expected user message');
+      const block = message.message.content[0];
+      if (
+        typeof block !== 'object' ||
+        block === null ||
+        block.type !== 'tool_result' ||
+        typeof block.content !== 'string'
+      ) {
+        throw new Error('Expected textual tool result');
+      }
+
+      expect(
+        Buffer.byteLength(JSON.stringify(block.content), 'utf8'),
+      ).toBeLessThanOrEqual(HEADLESS_TOOL_RESULT_TEXT_JSON_BYTE_BUDGET);
+      expect(block.content).toContain(
+        HEADLESS_TOOL_RESULT_TEXT_TRUNCATION_MARKER,
+      );
+      expect(block.content.endsWith('-TAIL')).toBe(true);
     });
   });
 

--- a/packages/cli/src/nonInteractive/io/BaseJsonOutputAdapter.ts
+++ b/packages/cli/src/nonInteractive/io/BaseJsonOutputAdapter.ts
@@ -42,6 +42,7 @@ import type {
   Usage,
 } from '../types.js';
 import { functionResponsePartsToString } from '../../utils/nonInteractiveHelpers.js';
+import { projectHeadlessToolResultContent } from './headless-tool-result-text-projection.js';
 
 /**
  * Internal state for managing a single message context (main agent or subagent).
@@ -1059,7 +1060,7 @@ export abstract class BaseJsonOutputAdapter {
     };
     const content = toolResultContent(response);
     if (content !== undefined) {
-      block.content = content;
+      block.content = projectHeadlessToolResultContent(content);
     }
 
     const message: CLIUserMessage = {

--- a/packages/cli/src/nonInteractive/io/JsonOutputAdapter.test.ts
+++ b/packages/cli/src/nonInteractive/io/JsonOutputAdapter.test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Buffer } from 'node:buffer';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type {
   Config,
@@ -12,6 +13,10 @@ import type {
 import { GeminiEventType, OutputFormat } from '@qwen-code/qwen-code-core';
 import type { Part } from '@google/genai';
 import { JsonOutputAdapter } from './JsonOutputAdapter.js';
+import {
+  HEADLESS_TOOL_RESULT_TEXT_JSON_BYTE_BUDGET,
+  HEADLESS_TOOL_RESULT_TEXT_TRUNCATION_MARKER,
+} from './headless-tool-result-text-projection.js';
 
 function createMockConfig(): Config {
   return {
@@ -774,6 +779,97 @@ describe('JsonOutputAdapter', () => {
         is_error?: boolean;
       };
       expect(block.is_error).toBe(true);
+    });
+
+    it('serializes a bounded tool result in JSON output', () => {
+      const display = 'HEAD-' + 'x'.repeat(100_000) + '-TAIL';
+      adapter.emitToolResult(
+        {
+          callId: 'tool-large',
+          name: 'test_tool',
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'prompt-1',
+        },
+        {
+          callId: 'tool-large',
+          responseParts: [],
+          resultDisplay: display,
+          error: undefined,
+          errorType: undefined,
+        },
+      );
+      adapter.emitResult({
+        isError: false,
+        durationMs: 1000,
+        apiDurationMs: 800,
+        numTurns: 1,
+      });
+
+      const parsed = JSON.parse(stdoutWriteSpy.mock.calls[0][0] as string);
+      const user = parsed.find(
+        (message: { type?: string }) => message.type === 'user',
+      );
+      const content = user.message.content[0].content as string;
+
+      expect(
+        Buffer.byteLength(JSON.stringify(content), 'utf8'),
+      ).toBeLessThanOrEqual(HEADLESS_TOOL_RESULT_TEXT_JSON_BYTE_BUDGET);
+      expect(content).toContain(HEADLESS_TOOL_RESULT_TEXT_TRUNCATION_MARKER);
+      expect(content).not.toBe(display);
+    });
+
+    it('retains only the bounded preview while text output stays unchanged', () => {
+      mockConfig = {
+        ...createMockConfig(),
+        getOutputFormat: vi.fn().mockReturnValue(OutputFormat.TEXT),
+      } as unknown as Config;
+      adapter = new JsonOutputAdapter(mockConfig);
+      const display = 'HEAD-' + 'x'.repeat(100_000) + '-TAIL';
+      adapter.emitToolResult(
+        {
+          callId: 'tool-large',
+          name: 'test_tool',
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'prompt-1',
+        },
+        {
+          callId: 'tool-large',
+          responseParts: [],
+          resultDisplay: display,
+          error: undefined,
+          errorType: undefined,
+        },
+      );
+      adapter.startAssistantMessage();
+      adapter.processEvent({ type: GeminiEventType.Content, value: 'done' });
+      adapter.finalizeAssistantMessage();
+
+      const storedMessages = (
+        adapter as unknown as {
+          messages: Array<{
+            type: string;
+            message?: { content?: Array<{ content?: string }> };
+          }>;
+        }
+      ).messages;
+      const user = storedMessages.find((message) => message.type === 'user');
+      const content = user?.message?.content?.[0]?.content;
+
+      expect(typeof content).toBe('string');
+      expect(
+        Buffer.byteLength(JSON.stringify(content), 'utf8'),
+      ).toBeLessThanOrEqual(HEADLESS_TOOL_RESULT_TEXT_JSON_BYTE_BUDGET);
+      expect(content).not.toBe(display);
+
+      adapter.emitResult({
+        isError: false,
+        durationMs: 1000,
+        apiDurationMs: 800,
+        numTurns: 1,
+      });
+      expect(stdoutWriteSpy).toHaveBeenCalledWith('done\n');
     });
   });
 

--- a/packages/cli/src/nonInteractive/io/StreamJsonOutputAdapter.test.ts
+++ b/packages/cli/src/nonInteractive/io/StreamJsonOutputAdapter.test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Buffer } from 'node:buffer';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type {
   Config,
@@ -13,6 +14,10 @@ import type {
 import { GeminiEventType } from '@qwen-code/qwen-code-core';
 import type { Part } from '@google/genai';
 import { StreamJsonOutputAdapter } from './StreamJsonOutputAdapter.js';
+import {
+  HEADLESS_TOOL_RESULT_TEXT_JSON_BYTE_BUDGET,
+  HEADLESS_TOOL_RESULT_TEXT_TRUNCATION_MARKER,
+} from './headless-tool-result-text-projection.js';
 
 function createMockConfig(): Config {
   return {
@@ -1069,6 +1074,38 @@ describe('StreamJsonOutputAdapter', () => {
 
       const block = parsed.message.content[0];
       expect(block.is_error).toBe(true);
+    });
+
+    it('emits a parseable line with bounded tool result content', () => {
+      stdoutWriteSpy.mockClear();
+      const display = 'HEAD-' + 'x'.repeat(100_000) + '-TAIL';
+      adapter.emitToolResult(
+        {
+          callId: 'tool-large',
+          name: 'test_tool',
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'prompt-1',
+        },
+        {
+          callId: 'tool-large',
+          responseParts: [],
+          resultDisplay: display,
+          error: undefined,
+          errorType: undefined,
+        },
+      );
+
+      const output = stdoutWriteSpy.mock.calls[0][0] as string;
+      const parsed = JSON.parse(output);
+      const content = parsed.message.content[0].content as string;
+
+      expect(output.endsWith('\n')).toBe(true);
+      expect(
+        Buffer.byteLength(JSON.stringify(content), 'utf8'),
+      ).toBeLessThanOrEqual(HEADLESS_TOOL_RESULT_TEXT_JSON_BYTE_BUDGET);
+      expect(content).toContain(HEADLESS_TOOL_RESULT_TEXT_TRUNCATION_MARKER);
+      expect(content).not.toBe(display);
     });
   });
 

--- a/packages/cli/src/nonInteractive/io/headless-tool-result-text-projection.ts
+++ b/packages/cli/src/nonInteractive/io/headless-tool-result-text-projection.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { projectJsonStringToByteBudget } from '../../utils/json-string-byte-projection.js';
+
+export const HEADLESS_TOOL_RESULT_TEXT_JSON_BYTE_BUDGET = 65_536;
+export const HEADLESS_TOOL_RESULT_TEXT_TRUNCATION_MARKER =
+  '\n[... truncated for Headless transport ...]\n';
+
+export function projectHeadlessToolResultContent(value: string): string {
+  return projectJsonStringToByteBudget(
+    value,
+    HEADLESS_TOOL_RESULT_TEXT_JSON_BYTE_BUDGET,
+    HEADLESS_TOOL_RESULT_TEXT_TRUNCATION_MARKER,
+  );
+}

--- a/packages/cli/src/utils/json-string-byte-projection.test.ts
+++ b/packages/cli/src/utils/json-string-byte-projection.test.ts
@@ -1,0 +1,138 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Buffer } from 'node:buffer';
+import { describe, expect, it } from 'vitest';
+import {
+  jsonStringJsonByteLength,
+  projectJsonStringToByteBudget,
+} from './json-string-byte-projection.js';
+
+const BUDGET = 65_536;
+const MARKER = '\n[... truncated for test transport ...]\n';
+
+function jsonBytes(value: string): number {
+  return Buffer.byteLength(JSON.stringify(value), 'utf8');
+}
+
+describe('JSON string byte projection', () => {
+  it('matches native JSON string byte accounting for Unicode and escapes', () => {
+    const samples = [
+      '',
+      'plain ASCII',
+      '"\\\n\b\f\r\t',
+      '\0\u0001\u001f',
+      '汉字',
+      '😀',
+      '\ud800',
+      '\udc00',
+      '\u2028\u2029',
+      '\u007f\u0080\u07ff\u0800',
+    ];
+
+    for (const sample of samples) {
+      expect(jsonStringJsonByteLength(sample)).toBe(jsonBytes(sample));
+    }
+  });
+
+  it('matches native JSON byte accounting under fixed-seed fuzzing', () => {
+    const atoms = [
+      'a',
+      '"',
+      '\\',
+      '\n',
+      '\0',
+      '汉',
+      '😀',
+      '\ud800',
+      '\udc00',
+      '\u2028',
+    ];
+    let state = 0x5eed1234;
+    const random = () => {
+      state = (Math.imul(state, 1_664_525) + 1_013_904_223) >>> 0;
+      return state;
+    };
+
+    for (let sampleIndex = 0; sampleIndex < 250; sampleIndex++) {
+      const length = random() % 200;
+      let value = '';
+      for (let index = 0; index < length; index++) {
+        value += atoms[random() % atoms.length];
+      }
+      expect(jsonStringJsonByteLength(value)).toBe(jsonBytes(value));
+    }
+  });
+
+  it.each([65_535, 65_536, 65_537])(
+    'enforces the JSON string boundary at %i bytes',
+    (targetBytes) => {
+      const value = 'x'.repeat(targetBytes - 2);
+      const projected = projectJsonStringToByteBudget(value, BUDGET, MARKER);
+
+      expect(jsonBytes(projected)).toBeLessThanOrEqual(BUDGET);
+      expect(projected === value).toBe(targetBytes <= BUDGET);
+    },
+  );
+
+  it.each([
+    ['CJK', '汉'.repeat(100_000)],
+    ['JSON escapes', '"\\\n\0'.repeat(30_000)],
+    ['lone high surrogate', '\ud800'.repeat(100_000)],
+    ['lone low surrogate', '\udc00'.repeat(100_000)],
+  ])(
+    'projects oversized %s strings within the exact budget',
+    (_name, value) => {
+      const projected = projectJsonStringToByteBudget(value, BUDGET, MARKER);
+
+      expect(jsonBytes(projected)).toBeLessThanOrEqual(BUDGET);
+      expect(projected).toContain(MARKER);
+      expect(projected).not.toBe(value);
+    },
+  );
+
+  it('keeps an approximately 20/80 head and tail preview', () => {
+    const value =
+      'HEAD-' + 'h'.repeat(200_000) + '-' + 't'.repeat(200_000) + '-TAIL';
+    const projected = projectJsonStringToByteBudget(value, BUDGET, MARKER);
+    const [head, tail] = projected.split(MARKER);
+
+    expect(projected.startsWith('HEAD-')).toBe(true);
+    expect(projected.endsWith('-TAIL')).toBe(true);
+    expect(tail.length).toBeGreaterThan(head.length * 3.9);
+    expect(tail.length).toBeLessThan(head.length * 4.1);
+  });
+
+  it.each(['-tail', '-tail!!'])(
+    'never splits valid surrogate pairs with suffix alignment %s',
+    (suffix) => {
+      const value = 'head-' + '😀'.repeat(100_000) + suffix;
+      const projected = projectJsonStringToByteBudget(value, BUDGET, MARKER);
+
+      expect(projected).not.toMatch(/[\ud800-\udbff](?![\udc00-\udfff])/u);
+      expect(projected).not.toMatch(/(?<![\ud800-\udbff])[\udc00-\udfff]/u);
+      expect(projected.endsWith(suffix)).toBe(true);
+      expect(jsonBytes(projected)).toBeLessThanOrEqual(BUDGET);
+    },
+  );
+
+  it('accounts for the marker and handles a budget smaller than the marker', () => {
+    const value = 'abcdef';
+    const projected = projectJsonStringToByteBudget(value, 5, MARKER);
+
+    expect(projected).toBe('abc');
+    expect(jsonBytes(projected)).toBe(5);
+  });
+
+  it('is idempotent and leaves small strings unchanged', () => {
+    const small = 'small';
+    const large = 'head-' + 'x'.repeat(100_000) + '-tail';
+    const once = projectJsonStringToByteBudget(large, BUDGET, MARKER);
+
+    expect(projectJsonStringToByteBudget(small, BUDGET, MARKER)).toBe(small);
+    expect(projectJsonStringToByteBudget(once, BUDGET, MARKER)).toBe(once);
+  });
+});

--- a/packages/cli/src/utils/json-string-byte-projection.ts
+++ b/packages/cli/src/utils/json-string-byte-projection.ts
@@ -1,0 +1,146 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Buffer } from 'node:buffer';
+
+export const JSON_STRING_DELIMITER_BYTES = 2;
+
+function jsonPayloadBytesAt(value: string, index: number): number {
+  const code = value.charCodeAt(index);
+  if (code === 0x22 || code === 0x5c) return 2;
+  if (code <= 0x1f) {
+    return code === 0x08 ||
+      code === 0x09 ||
+      code === 0x0a ||
+      code === 0x0c ||
+      code === 0x0d
+      ? 2
+      : 6;
+  }
+  if (code <= 0x7f) return 1;
+  if (code <= 0x7ff) return 2;
+  if (code >= 0xd800 && code <= 0xdbff) {
+    const next = value.charCodeAt(index + 1);
+    return next >= 0xdc00 && next <= 0xdfff ? 4 : 6;
+  }
+  if (code >= 0xdc00 && code <= 0xdfff) return 6;
+  return 3;
+}
+
+function jsonPayloadWidthAt(value: string, index: number): number {
+  const code = value.charCodeAt(index);
+  if (code < 0xd800 || code > 0xdbff) return 1;
+  const next = value.charCodeAt(index + 1);
+  return next >= 0xdc00 && next <= 0xdfff ? 2 : 1;
+}
+
+export function jsonStringPayloadByteLength(
+  value: string,
+  stopAfterBytes = Number.POSITIVE_INFINITY,
+): number {
+  let bytes = 0;
+  for (let index = 0; index < value.length; ) {
+    bytes += jsonPayloadBytesAt(value, index);
+    if (bytes > stopAfterBytes) return bytes;
+    index += jsonPayloadWidthAt(value, index);
+  }
+  return bytes;
+}
+
+export function jsonStringJsonByteLength(value: string): number {
+  return JSON_STRING_DELIMITER_BYTES + jsonStringPayloadByteLength(value);
+}
+
+function jsonPayloadWidthBefore(value: string, end: number): number {
+  const last = value.charCodeAt(end - 1);
+  if (last >= 0xdc00 && last <= 0xdfff && end >= 2) {
+    const previous = value.charCodeAt(end - 2);
+    if (previous >= 0xd800 && previous <= 0xdbff) return 2;
+  }
+  return 1;
+}
+
+function selectPrefix(value: string, budget: number): number {
+  let end = 0;
+  let bytes = 0;
+  while (end < value.length) {
+    const partBytes = jsonPayloadBytesAt(value, end);
+    if (bytes + partBytes > budget) break;
+    bytes += partBytes;
+    end += jsonPayloadWidthAt(value, end);
+  }
+  return end;
+}
+
+function selectSuffix(value: string, budget: number): number {
+  let start = value.length;
+  let bytes = 0;
+  while (start > 0) {
+    const partWidth = jsonPayloadWidthBefore(value, start);
+    const partBytes = jsonPayloadBytesAt(value, start - partWidth);
+    if (bytes + partBytes > budget) break;
+    bytes += partBytes;
+    start -= partWidth;
+  }
+  return start;
+}
+
+function copyString(value: string): string {
+  return value.split('').join('');
+}
+
+export function truncateJsonStringPayload(
+  value: string,
+  originalPayloadBytes: number,
+  payloadBudget: number,
+  marker: string,
+): string {
+  if (originalPayloadBytes <= payloadBudget) return value;
+  const markerPayloadBytes = jsonStringPayloadByteLength(marker);
+  if (payloadBudget < markerPayloadBytes) {
+    return copyString(value.slice(0, selectPrefix(value, payloadBudget)));
+  }
+  const sourceBudget = payloadBudget - markerPayloadBytes;
+  const headBudget = Math.floor(sourceBudget * 0.2);
+  const tailBudget = sourceBudget - headBudget;
+  const headEnd = selectPrefix(value, headBudget);
+  const tailStart = selectSuffix(value, tailBudget);
+  return (
+    copyString(value.slice(0, headEnd)) +
+    marker +
+    copyString(value.slice(tailStart))
+  );
+}
+
+export function projectJsonStringToByteBudget(
+  value: string,
+  jsonByteBudget: number,
+  marker: string,
+): string {
+  const payloadBudget = Math.max(
+    0,
+    jsonByteBudget - JSON_STRING_DELIMITER_BYTES,
+  );
+  const payloadBytes = jsonStringPayloadByteLength(value, payloadBudget);
+  if (payloadBytes <= payloadBudget) return value;
+
+  const projected = truncateJsonStringPayload(
+    value,
+    payloadBytes,
+    payloadBudget,
+    marker,
+  );
+  if (Buffer.byteLength(JSON.stringify(projected), 'utf8') <= jsonByteBudget) {
+    return projected;
+  }
+
+  const fallback = copyString(
+    marker.slice(0, selectPrefix(marker, payloadBudget)),
+  );
+  return Buffer.byteLength(JSON.stringify(fallback), 'utf8') <= jsonByteBudget
+    ? fallback
+    : '';
+}


### PR DESCRIPTION
## What this PR does

This PR bounds textual `tool_result.content` emitted or retained by the built-in Headless JSON adapters to 65,536 UTF-8 bytes after JSON string serialization. Oversized displays become deterministic 20/80 head-tail previews with a transport marker, while semantic selection, model-facing responses, canonical recordings, and producer artifacts remain unchanged.

The projection is applied once at the shared adapter boundary, so it covers JSON, stream-JSON, persistent stream-JSON and SDK sessions, subagent results, Text-mode retention, and Dual Output. The JSON-string byte scanner and surrogate-safe truncation primitive are shared with ACP without moving ACP multi-block allocation or A2UI behavior. Dual Output protocol version is incremented from 1 to 2 because consumers can observe bounded previews in a previously unbounded field.

## Why it's needed

A large tool display was serialized in full into every Headless `tool_result` event. A deterministic 499,999-byte fake-MCP result produced roughly 500 KB JSON and JSONL output and was retained internally even when Text mode printed only the final answer. This created avoidable wire amplification and memory retention across CLI, SDK, subagent, and Dual Output paths.

The fixed field-level contract keeps those transports bounded without changing the tool-result schema or pretending to impose a universal frame, session, input, or backpressure limit.

## Reviewer Test Plan

### How to verify

- Run the focused CLI tests for the shared JSON-string projector, ACP regression coverage, the base adapter, JSON output, stream-JSON output, and Dual Output. All 268 focused tests should pass.
- Run `npm run build && npm run typecheck`. Both commands should complete successfully.
- Use a deterministic fake MCP tool that returns 499,999 ASCII bytes. Confirm that JSON, stream-JSON, persistent stream-JSON/SDK transport, subagent, and Dual Output preserve one marker plus both the head and tail while `UTF8_BYTES(JSON.stringify(tool_result.content))` stays at or below 65,536.
- Confirm default Text output still contains only the final answer and that the producer artifact remains byte-for-byte identical to the original tool result.

### Evidence (Before & After)

| Path | Before | After |
| --- | --- | --- |
| JSON | 504,795-byte stdout; 499,999-byte content | 70,331-byte stdout; content serializes to exactly 65,536 bytes |
| stream-JSON | 504,066-byte stdout; 500,267-byte maximum event | 69,603-byte stdout; 65,802-byte maximum event; content serializes to exactly 65,536 bytes |
| Persistent stream-JSON / SDK transport | 504,122-byte stdout; complete content | 69,657-byte stdout; 65,802-byte maximum event; content serializes to exactly 65,536 bytes |
| Subagent adapter | 500,923-byte wire | 66,458-byte wire; parent tool-use id preserved; content serializes to exactly 65,536 bytes |
| Dual Output bridge | 500,892-byte sidecar wire | 66,428-byte sidecar wire; protocol version 2; content serializes to exactly 65,536 bytes |
| Text | `done\n` only | `done\n` only; retained tool-result preview is bounded |
| Producer artifact | 499,999 bytes, SHA-256 `7e103f713fbc419ed41705f9e303cbc3d6260b38ee9d2edb4a3b4ecdad8c58b1` | Same size and SHA-256 |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 26.4.1 arm64, Node.js v24.12.0, npm 10.9.8, local no-sandbox fake-MCP fixture.

## Risk & Scope

- Main risk or tradeoff: consumers no longer receive complete oversized textual tool displays on the Headless wire and must treat marked content as a preview.
- Not validated / out of scope: the Python SDK wrapper and a complete TUI session were not run directly; their underlying persistent stream-JSON transport and the actual Dual Output bridge class were verified. This PR does not cap complete JSONL frames, accumulated sessions, tool inputs, partial messages, replay containers, or backpressure.
- Breaking changes / migration notes: Headless field types and SDK schemas are unchanged. Dual Output consumers should accept protocol version 2 and recognize that oversized textual `tool_result.content` can be a bounded preview.

## Linked Issues

Related to #8447

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 将内置 Headless JSON adapter 发射或保留的文本 `tool_result.content` 限制为 JSON 字符串序列化后最多 65,536 个 UTF-8 字节。超限展示会转换为确定性的 20/80 头尾预览并带上传输截断标记，同时保持语义选择、面向模型的响应、规范化记录和生产者 artifact 不变。

投影只在共享 adapter 边界应用一次，因此统一覆盖 JSON、stream-JSON、持久 stream-JSON 与 SDK session、subagent 结果、Text 模式内部保留以及 Dual Output。JSON 字符串字节扫描器与 surrogate-safe 截断原语和 ACP 共享，但 ACP 的多 block 分配与 A2UI 行为仍保留在原边界内。由于消费者能够观察到此前无限制字段现在会变为有界预览，Dual Output 协议版本从 1 升级到 2。

## 为什么需要

此前大型工具展示会完整序列化到每个 Headless `tool_result` 事件中。一个确定性的 fake-MCP 工具返回 499,999 字节时，会产生约 500 KB 的 JSON 和 JSONL 输出；即使 Text 模式只打印最终答案，也会在内部保留完整内容。这会在 CLI、SDK、subagent 和 Dual Output 路径中造成不必要的 wire 放大和内存保留。

固定的字段级契约能够约束这些传输，同时不改变 tool-result schema，也不会宣称对完整 frame、session、输入或 backpressure 施加通用限制。

## Reviewer 测试计划

### 如何验证

- 运行共享 JSON 字符串 projector、ACP 回归覆盖、基础 adapter、JSON 输出、stream-JSON 输出和 Dual Output 的定向 CLI 测试。全部 268 个定向测试应通过。
- 运行 `npm run build && npm run typecheck`，两个命令都应成功完成。
- 使用返回 499,999 个 ASCII 字节的确定性 fake MCP 工具。确认 JSON、stream-JSON、持久 stream-JSON/SDK transport、subagent 和 Dual Output 都只保留一个 marker 及头尾内容，并且 `UTF8_BYTES(JSON.stringify(tool_result.content))` 不超过 65,536。
- 确认默认 Text 输出仍只包含最终答案，同时生产者 artifact 与原始工具结果逐字节一致。

### 证据（Before & After）

| 路径 | Before | After |
| --- | --- | --- |
| JSON | stdout 504,795 字节；content 499,999 字节 | stdout 70,331 字节；content 序列化后恰好 65,536 字节 |
| stream-JSON | stdout 504,066 字节；最大事件 500,267 字节 | stdout 69,603 字节；最大事件 65,802 字节；content 序列化后恰好 65,536 字节 |
| 持久 stream-JSON / SDK transport | stdout 504,122 字节；完整 content | stdout 69,657 字节；最大事件 65,802 字节；content 序列化后恰好 65,536 字节 |
| Subagent adapter | wire 500,923 字节 | wire 66,458 字节；parent tool-use id 保持不变；content 序列化后恰好 65,536 字节 |
| Dual Output bridge | sidecar wire 500,892 字节 | sidecar wire 66,428 字节；协议版本 2；content 序列化后恰好 65,536 字节 |
| Text | 仅 `done\n` | 仍仅 `done\n`；内部保留的 tool-result 预览有界 |
| 生产者 artifact | 499,999 字节，SHA-256 `7e103f713fbc419ed41705f9e303cbc3d6260b38ee9d2edb4a3b4ecdad8c58b1` | 大小和 SHA-256 相同 |

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

macOS 26.4.1 arm64、Node.js v24.12.0、npm 10.9.8、本地无 sandbox 的 fake-MCP fixture。

## 风险与范围

- 主要风险或取舍：消费者不再从 Headless wire 收到完整的超大文本工具展示，必须将带标记的内容视为预览。
- 未验证 / 范围外：未直接运行 Python SDK wrapper 和完整 TUI session；已验证它们底层的持久 stream-JSON transport 和实际 Dual Output bridge class。本 PR 不限制完整 JSONL frame、累积 session、tool input、partial message、replay container 或 backpressure。
- Breaking changes / 迁移说明：Headless 字段类型与 SDK schema 不变。Dual Output 消费者应接受协议版本 2，并识别超大的文本 `tool_result.content` 可能是有界预览。

## 关联 Issue

Related to #8447

</details>