### PR TITLE
fix(review): close the inline-quotation gap and harden the layer gate

### DIFF
--- a/packages/cli/src/commands/review/lib/audit-layers.test.ts
+++ b/packages/cli/src/commands/review/lib/audit-layers.test.ts
@@ -171,6 +171,11 @@ describe('parseLayerReceipts', () => {
         ].join('\n'),
       ),
     ]).toEqual(['scope-propagation']);
+    // A receipt after a `>` BLOCKQUOTE counts too — the close-depth decrement
+    // must return to 0, or every later inline would be skipped as still-quoted.
+    expect([
+      ...parseLayerReceipts('> quoted\n\nLayer walked: toctou — real'),
+    ]).toEqual(['toctou']);
   });
 
   it('does not credit a marker hidden in an INLINE construct — the R4-1 residual, closed', () => {
@@ -185,21 +190,37 @@ describe('parseLayerReceipts', () => {
       '[x\nLayer walked: toctou]: /url', // link-reference continuation
       '![Layer walked: toctou](/u)', // image alt — an attribute, never prose
       'Layer walked: `toctou` — styled id', // id inside a code span, dropped
-      // A dropped inline node BREAKS the line, so a marker cannot stitch across
-      // it into an id GitHub renders as one token. Both render two things, not a
-      // receipt: "Layer walked: xtoctou" and "Layer walked: ⟨img⟩toctou".
+      // A dropped inline node becomes a non-whitespace sentinel, so a marker
+      // never stitches across it into an id GitHub renders as one token. Both
+      // render two things: "Layer walked: xtoctou" and "Layer walked: ⟨img⟩toctou".
       'Layer walked: `x`toctou', // code span splits marker from id
       'Layer walked: ![a](/u)toctou', // image splits marker from id
+      // The sentinel is not a line break either, so an inline node BEFORE a marker
+      // leaves it mid-line — exactly where GitHub renders it — not floated to a
+      // fresh line start. GitHub shows "x Layer walked: toctou", never a receipt.
+      '`x` Layer walked: toctou', // code span before the marker
+      // A hard break (two trailing spaces) IS a visible line break, so it splits
+      // an inline-`<br>` marker from its id — GitHub shows the id on its own line.
+      'Layer walked:  \ntoctou',
+      // Raw-text elements (`<script>`, `<style>`, `<textarea>`, `<title>`,
+      // `<template>`, `<noscript>`): markdown-it exposes their inner text as a
+      // child, but GitHub renders it only inline/escaped, never as a line-leading
+      // receipt. The sentinel keeps the marker mid-line, matching that render.
+      'x <script>Layer walked: toctou</script>',
+      'x <style>Layer walked: toctou</style>',
+      'x <textarea>Layer walked: toctou</textarea>',
+      'x <title>Layer walked: toctou</title>',
+      'x <template>Layer walked: toctou</template>',
+      'x <noscript>Layer walked: toctou</noscript>',
+      '<script>Layer walked: toctou</script>', // even with no prefix
     ];
     for (const q of hidden) expect(parseLayerReceipts(q).size).toBe(0);
-    // A link's VISIBLE text is prose and still counts.
+    // A link's VISIBLE text is prose and still counts, and a hard break BEFORE a
+    // whole marker leaves the marker at the start of its own visible line.
     expect([
       ...parseLayerReceipts('[Layer walked: toctou](/u) — real'),
     ]).toEqual(['toctou']);
-    // A code span BEFORE a whole marker leaves the marker as visible prose
-    // ("x Layer walked: toctou"), so it stays a real receipt — the break only
-    // stops fragments STITCHING, it does not invent a quotation.
-    expect([...parseLayerReceipts('`x` Layer walked: toctou')]).toEqual([
+    expect([...parseLayerReceipts('x  \nLayer walked: toctou')]).toEqual([
       'toctou',
     ]);
   });

--- a/packages/cli/src/commands/review/lib/audit-layers.test.ts
+++ b/packages/cli/src/commands/review/lib/audit-layers.test.ts
@@ -173,6 +173,24 @@ describe('parseLayerReceipts', () => {
     ]).toEqual(['scope-propagation']);
   });
 
+  it('does not credit a marker hidden in an INLINE construct — the R4-1 residual, closed', () => {
+    // Reading the rendered prose (not source lines) drops a marker GitHub shows
+    // as nothing or as monospace/attribute text — the inline families a block-only
+    // pass leaked. Each verified against markdown-it, GitHub's own family.
+    const hidden = [
+      '`x\nLayer walked: toctou`', // multi-line inline code span
+      '<!-- Layer walked: toctou -->', // HTML comment
+      '<a title="Layer walked: toctou">t</a>', // tag attribute value
+      '[t](/u "Layer walked: toctou")', // link title
+      '[x\nLayer walked: toctou]: /url', // link-reference continuation
+    ];
+    for (const q of hidden) expect(parseLayerReceipts(q).size).toBe(0);
+    // A link's VISIBLE text is prose and still counts.
+    expect([
+      ...parseLayerReceipts('[Layer walked: toctou](/u) — real'),
+    ]).toEqual(['toctou']);
+  });
+
   it('requires the colon — a colon-less shape is not a receipt', () => {
     // Relaxing the mandatory colon would let colon-less parrot prose parse as a
     // receipt, and that is the credit/release direction.

--- a/packages/cli/src/commands/review/lib/audit-layers.test.ts
+++ b/packages/cli/src/commands/review/lib/audit-layers.test.ts
@@ -258,6 +258,18 @@ describe('parseLayerReceipts', () => {
       'Layer walked: lexing.extra', // id then `.` then more of the word
       'Layer walked: toctou.,x', // chained punctuation then word
       'Layer walked: toctou.<b>x</b>', // punctuation then a dropped node
+      // A CONNECTOR (`\p{Pc}`) joins with no word break (UAX#29), so even a lone
+      // trailing one renders one word — not a receipt.
+      'Layer walked: toctou_', // trailing low line
+      'Layer walked: expansion_', // a real layer id, connector-joined
+      'Layer walked: toctou&#8255;', // U+203F undertie
+      // FORM FEED (U+000C) is JS `\s` but CSS does not collapse it to a space, so
+      // GitHub renders it verbatim — a glued phrase or a wedged id, never a receipt.
+      'Layer&#12;walked: toctou', // FF glues the phrase
+      'Layer walked: toctou&#12;x', // FF wedges the id
+      // A bidi control REORDERS the visible text, so the logical marker is not what
+      // a human reads — mapped to the opaque sentinel, which breaks the match.
+      '&#8238;Layer walked: toctou', // U+202E right-to-left override, line-leading
     ];
     for (const q of hidden) expect(parseLayerReceipts(q).size).toBe(0);
     // Trailing PUNCTUATION with nothing stuck after it is a real boundary — the id
@@ -290,8 +302,19 @@ describe('parseLayerReceipts', () => {
     // But NOT a `<br-…>` custom element or `<brfoo>` — GitHub strips the
     // non-allowlisted tag, leaving no break, so the marker stays mid-line. The
     // break test must not fabricate a receipt from these (a dropped `\b` would).
-    for (const notBr of ['<br-foo>', '<brfoo>', '<BR-FOO>', '<br->']) {
-      expect(parseLayerReceipts(`x${notBr}Layer walked: toctou`).size).toBe(0);
+    // A NON-ASCII space after `br` is not tag whitespace in the HTML grammar, so
+    // GitHub does not parse the tag at all — it must not count as a break either.
+    const notBr = [
+      '<br-foo>',
+      '<brfoo>',
+      '<BR-FOO>',
+      '<br->',
+      '<br\u00A0>', // no-break space — not ASCII tag whitespace
+      '<br\u2000>', // en quad
+      '<br\u3000>', // ideographic space
+    ];
+    for (const t of notBr) {
+      expect(parseLayerReceipts(`x${t}Layer walked: toctou`).size).toBe(0);
     }
     // A paragraph-LEADING entity newline collapses to a space GitHub renders at
     // paragraph start, so the marker stays a visible receipt.
@@ -332,18 +355,26 @@ describe('parseLayerReceipts', () => {
     for (const q of [
       'Layer&#32;walked: toctou', // entity space separator
       '&#76;ayer walked: toctou', // entity-encoded leading `L`
+      '&#76;ayer w&#97;lked: toctou', // BOTH words entity-encoded — isolates the entity clause
       'Layer&nbsp;walked: toctou', // named entity → visible nbsp space
       // The two words split by inline markup that the reconstructed prose rejoins:
       // the raw view has no adjacent "layer walked", but the render does — the
-      // split can even fall MID-word, so the prefilter cannot require either whole
-      // word to survive it (only that both are not wholly absent).
+      // split can even fall MID-word in BOTH words at once, so the prefilter must
+      // strip the markup delimiters before testing, not require either word whole.
       'Layer *walked*: toctou', // emphasis boundary between the words
       'Layer [walked: toctou](/u)', // link boundary between the words
       'La*yer* walked: toctou', // emphasis MID-word in "layer"
       'Layer wal*ked*: toctou', // emphasis MID-word in "walked"
+      'La*yer* wal*ked*: toctou', // BOTH words split mid-word
     ]) {
       expect([...parseLayerReceipts(q)]).toEqual(['toctou']);
     }
+    // A variation selector (U+FE0F) is folded only by `\p{Variation_Selector}` —
+    // not `\p{Cf}` — so this fold-dependent carve-out (VS just before a real break)
+    // discriminates that member: dropping it would reject a genuine receipt.
+    expect([
+      ...parseLayerReceipts('Layer walked: toctou&#65039;  \nmore'),
+    ]).toEqual(['toctou']);
     // The combining grapheme joiner (U+034F) — the one enumerated non-`\p{Cf}`
     // member of the fold class — renders as nothing, so a marker wearing it is a
     // real receipt. Pin it: dropping U+034F from the class silently loses this.

--- a/packages/cli/src/commands/review/lib/audit-layers.test.ts
+++ b/packages/cli/src/commands/review/lib/audit-layers.test.ts
@@ -213,6 +213,21 @@ describe('parseLayerReceipts', () => {
       'x <template>Layer walked: toctou</template>',
       'x <noscript>Layer walked: toctou</noscript>',
       '<script>Layer walked: toctou</script>', // even with no prefix
+      // A numeric entity decoding to a newline lands as a raw \n INSIDE a text
+      // child (markdown-it decodes at parse time); GitHub collapses that LF to a
+      // space, so it must not forge a line start. Mid-line here → not a receipt.
+      'x&#10;Layer walked: toctou',
+      'x&#x0A;Layer walked: toctou',
+      // Two more R4-1 origin families: a terminated multi-line LRD title and an
+      // image TITLE attribute — both live in attributes, never in visible prose.
+      '[x]: /url "a\nLayer walked: toctou\nb"',
+      '![x](/u "Layer walked: toctou")',
+      // Trailing stitch — the mirror of the leading cases: a dropped inline node
+      // touching the END of the id stitches the visible token into a longer word
+      // GitHub renders as one (`toctoux`, `toctou-x`), so it is not a receipt.
+      'Layer walked: toctou`x`', // code span after the id
+      'Layer walked: toctou<b>x</b>', // inline HTML after the id
+      'Layer walked: toctou![a](/u)', // image after the id
     ];
     for (const q of hidden) expect(parseLayerReceipts(q).size).toBe(0);
     // A link's VISIBLE text is prose and still counts, and a hard break BEFORE a
@@ -221,6 +236,16 @@ describe('parseLayerReceipts', () => {
       ...parseLayerReceipts('[Layer walked: toctou](/u) — real'),
     ]).toEqual(['toctou']);
     expect([...parseLayerReceipts('x  \nLayer walked: toctou')]).toEqual([
+      'toctou',
+    ]);
+    // A `<br>` IS a visible line break on GitHub, so a marker after it starts its
+    // own line — a real receipt (the entity LF above collapses; a `<br>` does not).
+    expect([...parseLayerReceipts('x<br>Layer walked: toctou')]).toEqual([
+      'toctou',
+    ]);
+    // A paragraph-LEADING entity newline collapses to a space GitHub renders at
+    // paragraph start, so the marker stays a visible receipt.
+    expect([...parseLayerReceipts('&#10;Layer walked: toctou')]).toEqual([
       'toctou',
     ]);
   });

--- a/packages/cli/src/commands/review/lib/audit-layers.test.ts
+++ b/packages/cli/src/commands/review/lib/audit-layers.test.ts
@@ -235,6 +235,17 @@ describe('parseLayerReceipts', () => {
       'Layer walked: toctou&#8203;x', // U+200B zero-width space
       'Layer walked: toctou&#173;x', // U+00AD soft hyphen
       'Layer walked: toctou&#8288;`x`', // U+2060 word joiner + code span
+      'Layer walked: toctou&#8294;x', // U+2066 bidi isolate — `\p{Cf}`, not an enum gap
+      'Layer walked: toctou&#65039;x', // U+FE0F variation selector
+      'Layer walked: toctou&#6157;x', // U+180D Mongolian free variation selector
+      // A VISIBLE word constituent stitched onto the id (letter, digit, connector,
+      // combining mark) also renders one word GitHub never reads as a receipt —
+      // and needs no entity to reach: pure ASCII `toctou_x` leaks without the guard.
+      'Layer walked: toctou_x — note', // underscore (connector punctuation)
+      'Layer walked: toctoué', // trailing letter
+      'Layer walked: toctou&#65400;', // fullwidth `x` (letter)
+      'Layer walked: toctou&#1635;', // Arabic-Indic digit three
+      'Layer walked: toctou&#769;x', // U+0301 combining acute on the id
     ];
     for (const q of hidden) expect(parseLayerReceipts(q).size).toBe(0);
     // A link's VISIBLE text is prose and still counts, and a hard break BEFORE a
@@ -247,8 +258,9 @@ describe('parseLayerReceipts', () => {
     ]);
     // A `<br>` IS a visible line break on GitHub, so a marker after it starts its
     // own line — a real receipt (the entity LF above collapses; a `<br>` does not).
-    // Pin the regex's tolerances (`\/?`, case) so a regression cannot drop them.
-    for (const br of ['<br>', '<br/>', '<BR>', '<br >']) {
+    // Pin the regex's tolerances (`\/?`, case, attributes) so a regression cannot
+    // drop them — GitHub strips a `<br>`'s attributes but keeps the break.
+    for (const br of ['<br>', '<br/>', '<BR>', '<br >', '<br class="a">']) {
       expect([...parseLayerReceipts(`x${br}Layer walked: toctou`)]).toEqual([
         'toctou',
       ]);
@@ -293,6 +305,10 @@ describe('parseLayerReceipts', () => {
       'Layer&#32;walked: toctou', // entity space separator
       '&#76;ayer walked: toctou', // entity-encoded leading `L`
       'Layer&nbsp;walked: toctou', // named entity → visible nbsp space
+      // The two words split by inline markup that the reconstructed prose rejoins:
+      // the raw view has no adjacent "layer walked", but the render does.
+      'Layer *walked*: toctou', // emphasis boundary
+      'Layer [walked: toctou](/u)', // link boundary
     ]) {
       expect([...parseLayerReceipts(q)]).toEqual(['toctou']);
     }

--- a/packages/cli/src/commands/review/lib/audit-layers.test.ts
+++ b/packages/cli/src/commands/review/lib/audit-layers.test.ts
@@ -183,12 +183,44 @@ describe('parseLayerReceipts', () => {
       '<a title="Layer walked: toctou">t</a>', // tag attribute value
       '[t](/u "Layer walked: toctou")', // link title
       '[x\nLayer walked: toctou]: /url', // link-reference continuation
+      '![Layer walked: toctou](/u)', // image alt — an attribute, never prose
+      'Layer walked: `toctou` — styled id', // id inside a code span, dropped
+      // A dropped inline node BREAKS the line, so a marker cannot stitch across
+      // it into an id GitHub renders as one token. Both render two things, not a
+      // receipt: "Layer walked: xtoctou" and "Layer walked: ⟨img⟩toctou".
+      'Layer walked: `x`toctou', // code span splits marker from id
+      'Layer walked: ![a](/u)toctou', // image splits marker from id
     ];
     for (const q of hidden) expect(parseLayerReceipts(q).size).toBe(0);
     // A link's VISIBLE text is prose and still counts.
     expect([
       ...parseLayerReceipts('[Layer walked: toctou](/u) — real'),
     ]).toEqual(['toctou']);
+    // A code span BEFORE a whole marker leaves the marker as visible prose
+    // ("x Layer walked: toctou"), so it stays a real receipt — the break only
+    // stops fragments STITCHING, it does not invent a quotation.
+    expect([...parseLayerReceipts('`x` Layer walked: toctou')]).toEqual([
+      'toctou',
+    ]);
+  });
+
+  it('credits a marker rendered as VISIBLE prose in any block, not just a paragraph', () => {
+    // The source-line scanner this replaced anchored on the raw line and so was
+    // blind to a marker GitHub renders as visible prose inside a heading, a table
+    // cell, or via an HTML entity. Reading the rendered token stream corrects
+    // that: each of these IS a real, visible receipt, so it counts. (Corroboration
+    // — identity + territory read — is the separate gate against parroted ones.)
+    const visible = [
+      '## Layer walked: toctou', // ATX heading text
+      '| Layer walked: toctou | x |\n| --- | --- |', // table cell
+      'Layer walked: &#x74;octou', // entity id, decoded to `toctou` by the render
+    ];
+    for (const q of visible)
+      expect([...parseLayerReceipts(q)]).toEqual(['toctou']);
+    // The interior of a multi-line HTML open tag is raw markup, never prose.
+    expect(
+      parseLayerReceipts('<a\n    Layer walked: toctou\n    >x</a>').size,
+    ).toBe(0);
   });
 
   it('requires the colon — a colon-less shape is not a receipt', () => {
@@ -294,6 +326,20 @@ describe('inferLayersFromProse', () => {
       '> export -f is imported by a child shell',
     ].join('\n');
     expect(inferLayersFromProse(quoted).size).toBe(0);
+  });
+
+  it('shares the receipt parser quotation view — an inline-code signal is dropped', () => {
+    // Moving to the token authority made an inline code span quoted for this
+    // estimate too. The only difference between these two is the backticks, so a
+    // signal named in a code span infers nothing where the bare token infers a
+    // layer. That can UNDER-count a layer the auditor did name — but that only
+    // owes MORE (fail-safe), acceptable for a non-authoritative guess.
+    expect(
+      inferLayersFromProse('the guard mishandles set -a expansion').size,
+    ).toBeGreaterThan(0);
+    expect(
+      inferLayersFromProse('the guard mishandles `set -a` expansion').size,
+    ).toBe(0);
   });
 });
 

--- a/packages/cli/src/commands/review/lib/audit-layers.test.ts
+++ b/packages/cli/src/commands/review/lib/audit-layers.test.ts
@@ -228,6 +228,13 @@ describe('parseLayerReceipts', () => {
       'Layer walked: toctou`x`', // code span after the id
       'Layer walked: toctou<b>x</b>', // inline HTML after the id
       'Layer walked: toctou![a](/u)', // image after the id
+      // An INVISIBLE code point (zero-width space, soft hyphen, word joiner)
+      // wedged between the id and the text after it renders as one stitched word
+      // on GitHub (`toctoux`), so it is not a receipt — the sentinel-only guard
+      // would miss these; folding them out of the prose view catches them.
+      'Layer walked: toctou&#8203;x', // U+200B zero-width space
+      'Layer walked: toctou&#173;x', // U+00AD soft hyphen
+      'Layer walked: toctou&#8288;`x`', // U+2060 word joiner + code span
     ];
     for (const q of hidden) expect(parseLayerReceipts(q).size).toBe(0);
     // A link's VISIBLE text is prose and still counts, and a hard break BEFORE a
@@ -240,14 +247,55 @@ describe('parseLayerReceipts', () => {
     ]);
     // A `<br>` IS a visible line break on GitHub, so a marker after it starts its
     // own line — a real receipt (the entity LF above collapses; a `<br>` does not).
-    expect([...parseLayerReceipts('x<br>Layer walked: toctou')]).toEqual([
-      'toctou',
-    ]);
+    // Pin the regex's tolerances (`\/?`, case) so a regression cannot drop them.
+    for (const br of ['<br>', '<br/>', '<BR>', '<br >']) {
+      expect([...parseLayerReceipts(`x${br}Layer walked: toctou`)]).toEqual([
+        'toctou',
+      ]);
+    }
     // A paragraph-LEADING entity newline collapses to a space GitHub renders at
     // paragraph start, so the marker stays a visible receipt.
     expect([...parseLayerReceipts('&#10;Layer walked: toctou')]).toEqual([
       'toctou',
     ]);
+    // Carve-out: an invisible wedge sitting just before a REAL break still leaves
+    // a clean line-leading receipt — folding it out keeps that credited.
+    expect([
+      ...parseLayerReceipts('Layer walked: toctou&#8203;  \nmore'),
+    ]).toEqual(['toctou']);
+  });
+
+  it('folds invisible format characters out of the entity-decoded prose view', () => {
+    // markdown-it decodes numeric entities at parse time, so a code point JS `\s`
+    // matches but GitHub renders as NOTHING (U+2028/U+2029 line separators, VT,
+    // BOM) would glue `layer<x>walked` into a phrase the anchored regex matches
+    // yet GitHub shows fused (`layerwalked`). The plain first receipt passes the
+    // prefilter (any parroted return carries one); only the glued second must drop.
+    for (const cp of ['&#8232;', '&#8233;', '&#11;', '&#65279;']) {
+      expect([
+        ...parseLayerReceipts(
+          `Layer walked: lexing — ok\nlayer${cp}walked: toctou`,
+        ),
+      ]).toEqual(['lexing']);
+    }
+    // The fold target for an entity newline must be a SPACE, not empty — else it
+    // stitches `Lay`+`er walked` into a line-leading receipt GitHub never renders
+    // (it shows `Lay er walked`). A plain marker carries the input past the prefilter.
+    expect([
+      ...parseLayerReceipts(
+        'Layer walked: lexing — real\nLay&#10;er walked: toctou',
+      ),
+    ]).toEqual(['lexing']);
+    // The prefilter reads RAW text; an entity that only DECODES into the marker
+    // phrase must not be vetoed before the parser sees the rendered prose. Each of
+    // these renders `Layer walked: toctou` on GitHub, so each is a real receipt.
+    for (const q of [
+      'Layer&#32;walked: toctou', // entity space separator
+      '&#76;ayer walked: toctou', // entity-encoded leading `L`
+      'Layer&nbsp;walked: toctou', // named entity → visible nbsp space
+    ]) {
+      expect([...parseLayerReceipts(q)]).toEqual(['toctou']);
+    }
   });
 
   it('credits a marker rendered as VISIBLE prose in any block, not just a paragraph', () => {

--- a/packages/cli/src/commands/review/lib/audit-layers.test.ts
+++ b/packages/cli/src/commands/review/lib/audit-layers.test.ts
@@ -246,8 +246,30 @@ describe('parseLayerReceipts', () => {
       'Layer walked: toctou&#65400;', // fullwidth `x` (letter)
       'Layer walked: toctou&#1635;', // Arabic-Indic digit three
       'Layer walked: toctou&#769;x', // U+0301 combining acute on the id
+      // Punctuation or a symbol stitched between the id and more word content also
+      // renders one joined token GitHub never reads as a receipt — pure ASCII, no
+      // entity needed. A trailing dash the id class does not swallow (U+2010, not
+      // ASCII `-`) is the same shape.
+      'Layer walked: toctou.x', // period
+      'Layer walked: toctou/x', // slash
+      'Layer walked: toctou)x', // close paren
+      'Layer walked: toctou$x', // currency symbol
+      'Layer walked: toctou&#8208;x', // U+2010 hyphen (a `\p{Pd}` dash)
+      'Layer walked: lexing.extra', // id then `.` then more of the word
+      'Layer walked: toctou.,x', // chained punctuation then word
+      'Layer walked: toctou.<b>x</b>', // punctuation then a dropped node
     ];
     for (const q of hidden) expect(parseLayerReceipts(q).size).toBe(0);
+    // Trailing PUNCTUATION with nothing stuck after it is a real boundary — the id
+    // still ends its visible word — so these stay credited.
+    for (const q of [
+      'Layer walked: toctou', // end of line
+      'Layer walked: toctou.', // sentence period
+      'Layer walked: toctou,', // comma
+      'Layer walked: toctou. note', // period then a space
+    ]) {
+      expect([...parseLayerReceipts(q)]).toEqual(['toctou']);
+    }
     // A link's VISIBLE text is prose and still counts, and a hard break BEFORE a
     // whole marker leaves the marker at the start of its own visible line.
     expect([
@@ -264,6 +286,12 @@ describe('parseLayerReceipts', () => {
       expect([...parseLayerReceipts(`x${br}Layer walked: toctou`)]).toEqual([
         'toctou',
       ]);
+    }
+    // But NOT a `<br-…>` custom element or `<brfoo>` — GitHub strips the
+    // non-allowlisted tag, leaving no break, so the marker stays mid-line. The
+    // break test must not fabricate a receipt from these (a dropped `\b` would).
+    for (const notBr of ['<br-foo>', '<brfoo>', '<BR-FOO>', '<br->']) {
+      expect(parseLayerReceipts(`x${notBr}Layer walked: toctou`).size).toBe(0);
     }
     // A paragraph-LEADING entity newline collapses to a space GitHub renders at
     // paragraph start, so the marker stays a visible receipt.
@@ -306,12 +334,24 @@ describe('parseLayerReceipts', () => {
       '&#76;ayer walked: toctou', // entity-encoded leading `L`
       'Layer&nbsp;walked: toctou', // named entity → visible nbsp space
       // The two words split by inline markup that the reconstructed prose rejoins:
-      // the raw view has no adjacent "layer walked", but the render does.
-      'Layer *walked*: toctou', // emphasis boundary
-      'Layer [walked: toctou](/u)', // link boundary
+      // the raw view has no adjacent "layer walked", but the render does — the
+      // split can even fall MID-word, so the prefilter cannot require either whole
+      // word to survive it (only that both are not wholly absent).
+      'Layer *walked*: toctou', // emphasis boundary between the words
+      'Layer [walked: toctou](/u)', // link boundary between the words
+      'La*yer* walked: toctou', // emphasis MID-word in "layer"
+      'Layer wal*ked*: toctou', // emphasis MID-word in "walked"
     ]) {
       expect([...parseLayerReceipts(q)]).toEqual(['toctou']);
     }
+    // The combining grapheme joiner (U+034F) — the one enumerated non-`\p{Cf}`
+    // member of the fold class — renders as nothing, so a marker wearing it is a
+    // real receipt. Pin it: dropping U+034F from the class silently loses this.
+    expect([
+      ...parseLayerReceipts(
+        'Layer walked: lexing — real\nLayer walked&#847;: toctou',
+      ),
+    ]).toEqual(['lexing', 'toctou']);
   });
 
   it('credits a marker rendered as VISIBLE prose in any block, not just a paragraph', () => {

--- a/packages/cli/src/commands/review/lib/audit-layers.ts
+++ b/packages/cli/src/commands/review/lib/audit-layers.ts
@@ -208,22 +208,30 @@ const LAYER_HINT_RE = /layer\s+walked/i;
  */
 const MD = new MarkdownIt({ html: true });
 
+// Stands in for a dropped inline node (code span, inline HTML, image) in the
+// reconstructed prose. A single NON-whitespace, non-marker code point (U+0000):
+// unlike a newline it does not FORGE a line start, and unlike an empty string it
+// does not let the text on either side STITCH — the receipt regex's leading
+// anchor (`^\s*…`) and its id class (`[\s*_~\`]*[a-z]`) both reject it, so a
+// marker only ever begins a reconstructed line when it truly begins a visible one.
+const DROPPED_INLINE = '\u0000';
+
 /**
  * The lines an auditor is USING, not quoting — the VISIBLE PROSE markdown-it
  * renders, reconstructed from its token stream. A quoted block (a fenced or
  * indented code block, an HTML block, or anything inside a blockquote) yields
  * nothing; a prose block (paragraph, heading, list item) yields its text nodes
- * and line breaks, with inline code spans, raw HTML (tags, comments, attribute
- * values) and the title/alt attributes of links and images dropped — GitHub
- * renders those as nothing or as monospace/attribute text, never as a receipt.
+ * and visible line breaks, with inline code spans, raw HTML (tags, comments,
+ * attribute values, raw-text elements) and the title/alt attributes of links and
+ * images reduced to a non-line-starting sentinel — GitHub renders those as
+ * nothing, as monospace, or inline/escaped, never as a line-leading receipt.
  *
  * Reading the rendered prose, not the source lines, is what closes the divergence
  * outright: a block-only pass still leaked a marker hidden in an INLINE construct
  * — a multi-line inline code span, an HTML comment or attribute, a link title, a
  * link-reference continuation — as a live receipt, and enumerating those one by
  * one just opens the next. A parser throw (unconstructed in practice) falls back
- * to the raw lines; the receipt regex's no-leading-backtick rule still guards the
- * common inline span there.
+ * to the raw source lines, where the anchored receipt regex still holds.
  */
 function* usedLines(finalText: string): Generator<string> {
   const src = finalText.replace(/\r\n?/g, '\n');
@@ -239,25 +247,30 @@ function* usedLines(finalText: string): Generator<string> {
     if (t.type === 'blockquote_open') blockquoteDepth++;
     else if (t.type === 'blockquote_close') blockquoteDepth--;
     else if (t.type === 'inline' && blockquoteDepth === 0) {
-      // The visible prose of this inline. `text` is prose; `code_inline` (a code
-      // span), `html_inline` (raw tags, comments, attributes) and an `image` (its
-      // alt/title live in attributes, never in a text child) are quoted or
-      // non-prose and BREAK the line — a dropped node must not let the text on
-      // either side stitch into a marker GitHub never renders as one receipt
-      // (`` `x` Layer walked: X `` renders two things, not a receipt). Emphasis
-      // and link open/close nodes are deliberately NOT breaks: their visible text
-      // children flow through as prose (a link's visible text is a real receipt).
+      // The visible prose of this inline, reconstructed the way GitHub lays it
+      // out. `text` is prose. A soft/hard break is a real visible line break, so
+      // it splits the line. Every OTHER inline node — a code span, inline HTML (a
+      // raw tag, a comment, or a raw-text element like `<script>`/`<title>` whose
+      // inner text markdown-it exposes as a child but GitHub shows only inline or
+      // escaped), or an image — does NOT start a new visible line on GitHub, so it
+      // must not start one here: it is replaced by `DROPPED_INLINE`, a
+      // non-whitespace sentinel that neither forges a line start (`x <script>Layer
+      // walked: id` stays one line, marker mid-line → rejected, as GitHub renders
+      // it) nor lets fragments stitch (`Layer walked: <x>id` → the id capture
+      // stops at the sentinel). Emphasis and link open/close nodes are NEITHER:
+      // their visible text children flow through as prose (a link's visible text
+      // is a real receipt).
       let prose = '';
       for (const c of t.children ?? []) {
         if (c.type === 'text') prose += c.content;
+        else if (c.type === 'softbreak' || c.type === 'hardbreak')
+          prose += '\n';
         else if (
-          c.type === 'softbreak' ||
-          c.type === 'hardbreak' ||
           c.type === 'code_inline' ||
           c.type === 'html_inline' ||
           c.type === 'image'
         )
-          prose += '\n';
+          prose += DROPPED_INLINE;
       }
       yield* prose.split('\n');
     }

--- a/packages/cli/src/commands/review/lib/audit-layers.ts
+++ b/packages/cli/src/commands/review/lib/audit-layers.ts
@@ -196,6 +196,17 @@ const LAYER_RECEIPT_LINE_RE =
   /^[ \t]*(?:[-*+]|\d+[.)])?[ \t]*[*_~]{0,3}layer\s+walked[*_~]{0,3}[ \t]*[:：][\s*_~`]*([a-z][a-z0-9-]*)/i;
 
 /**
+ * Tests the text immediately AFTER a captured id: an optional run of trailing
+ * punctuation/symbols followed by any non-space, non-punctuation code point means
+ * the id is STITCHED to more of a visible word GitHub renders as one token (a
+ * letter/digit/mark/connector — `toctou_x`, `toctoué` — or a punctuation-then-more
+ * run — `toctou.x`, `toctou‐x` — or the dropped-node sentinel — `` toctou`x` ``).
+ * A clean receipt has nothing but trailing punctuation before the next space:
+ * `toctou`, `toctou.`, `toctou — note` all pass.
+ */
+const TRAILING_STITCH = /^[\p{P}\p{S}]*[^\s\p{P}\p{S}]/u;
+
+/**
  * The one CommonMark tokenizer this module uses. A hand-rolled fence/blockquote
  * scanner diverged from the spec round after round — a second parser is a
  * divergence hunt, and this skill's own lesson is that the oracle must come from
@@ -287,7 +298,11 @@ function* usedLines(finalText: string): Generator<string> {
           prose += '\n';
         else if (
           c.type === 'html_inline' &&
-          /^<br\b[^>]*\/?>$/i.test(c.content)
+          // A real GitHub break: `<br>`, self-closing, or with attributes — but
+          // NOT a `<br-…>` custom element (a hyphen keeps the tag name going, and
+          // GitHub strips the non-allowlisted tag, leaving no break). After `br`
+          // the tag must END, or continue with whitespace/slash then attributes.
+          /^<br(?:[\s/][^>]*)?>$/i.test(c.content)
         )
           prose += '\n';
         else if (
@@ -317,11 +332,13 @@ export function parseLayerReceipts(
 ): Set<string> {
   const ids = new Set<string>();
   // Cheap pre-filter. It reads RAW text but the parser reads DECODED, markup-joined
-  // prose, so it must not veto a marker whose two words are split by inline markup
-  // (`Layer *walked*`) or whose letters are entity-encoded (`Layer&#32;walked`).
-  // Skip only when both words are absent AND no entity could decode into them.
+  // prose, so it must not veto a marker whose words are split by inline markup —
+  // even MID-word (`La*yer* walked`, `Layer wal*ked*`) — or entity-encoded
+  // (`Layer&#32;walked`). Skip only when BOTH words are absent AND no entity could
+  // decode into them; a single surviving word (or any entity) runs the full parse.
   if (
-    (!/layer/i.test(finalText) || !/walked/i.test(finalText)) &&
+    !/layer/i.test(finalText) &&
+    !/walked/i.test(finalText) &&
     !/&[#a-z]/i.test(finalText)
   )
     return ids;
@@ -329,15 +346,16 @@ export function parseLayerReceipts(
   for (const line of usedLines(finalText)) {
     const m = LAYER_RECEIPT_LINE_RE.exec(line);
     if (!m) continue;
-    // Trailing stitch: the id capture is un-anchored at its end, so any character
-    // that stitches onto the id disqualifies the receipt — GitHub renders one word
-    // (`toctoux`, `toctou_x`, `toctoué`), never a receipt. Two guards: the dropped
-    // node sentinel, and any word constituent (letter, number, combining mark, or
-    // connector) — the mirror of the leading-stitch guard. A break, space, dash or
-    // other punctuation after the id is a real boundary and stays credited.
-    const after = m[0].length;
-    if (line.charCodeAt(after) === DROPPED_INLINE.charCodeAt(0)) continue;
-    if (/^[\p{L}\p{N}\p{M}\p{Pc}]/u.test(line.slice(after))) continue;
+    // Trailing stitch: the id capture is un-anchored at its end, so anything that
+    // renders JOINED to the id disqualifies the receipt — GitHub shows one token
+    // (`toctoux`, `toctou_x`, `toctou.x`, `toctou‐x`, `toctou` + a dropped node),
+    // never a receipt. A clean receipt's id ends its visible word: the run up to
+    // the next space must be nothing but trailing PUNCTUATION/symbols (`toctou`,
+    // `toctou.`, `toctou — note`). So reject when that run holds any non-space,
+    // non-punctuation code point — a letter, digit, mark, connector, OR the
+    // dropped-node sentinel — after an optional punctuation prefix. This one rule
+    // is the mirror of the leading-stitch guard and subsumes the sentinel check.
+    if (TRAILING_STITCH.test(line.slice(m[0].length))) continue;
     const id = m[1].toLowerCase();
     if (known.has(id)) ids.add(id);
   }

--- a/packages/cli/src/commands/review/lib/audit-layers.ts
+++ b/packages/cli/src/commands/review/lib/audit-layers.ts
@@ -213,6 +213,18 @@ const MD = new MarkdownIt({ html: true });
  * code, an HTML block, or the span of a blockquote — from the block tokens'
  * `.map` line ranges. A parser throw quotes nothing (an unreadable return still
  * has its inline spans guarded by the receipt regex's no-leading-backtick rule).
+ *
+ * KNOWN RESIDUAL — this masks BLOCK-level quotation only. A marker hidden in an
+ * INLINE construct GitHub renders invisibly — a multi-line inline code span, an
+ * HTML comment or tag attribute value, a link/image title, a link-reference
+ * continuation line — sits on a line no block token covers, so it can still parse
+ * as a receipt. The exposure is bounded: releasing on it needs a corroborated
+ * (identity- and territory-checked) auditor to deliberately obfuscate its own
+ * receipts, an adversarial input, not a normal miss, and only under that input.
+ * The definitive close is to compute USED text from RENDERED visible content
+ * rather than source lines (enumerating inline constructs one by one just opens
+ * the next); deferred as a follow-up rather than reopened as another hand-rolled
+ * hunt.
  */
 function quotedLines(text: string): Set<number> {
   const quoted = new Set<number>();

--- a/packages/cli/src/commands/review/lib/audit-layers.ts
+++ b/packages/cli/src/commands/review/lib/audit-layers.ts
@@ -197,14 +197,15 @@ const LAYER_RECEIPT_LINE_RE =
 
 /**
  * Tests the text immediately AFTER a captured id: an optional run of trailing
- * punctuation/symbols followed by any non-space, non-punctuation code point means
- * the id is STITCHED to more of a visible word GitHub renders as one token (a
- * letter/digit/mark/connector — `toctou_x`, `toctoué` — or a punctuation-then-more
- * run — `toctou.x`, `toctou‐x` — or the dropped-node sentinel — `` toctou`x` ``).
- * A clean receipt has nothing but trailing punctuation before the next space:
- * `toctou`, `toctou.`, `toctou — note` all pass.
+ * punctuation/symbols followed by either a non-space, non-punctuation code point
+ * OR a CONNECTOR (`\p{Pc}`) means the id is STITCHED to more of a visible word
+ * GitHub renders as one token (a letter/digit/mark — `toctou_x`, `toctoué` — a
+ * punctuation-then-more run — `toctou.x`, `toctou‐x` — the dropped-node sentinel
+ * — `` toctou`x` `` — or a lone connector, which UAX#29 joins with no word break:
+ * `toctou_` renders one word). A clean receipt has nothing but non-connector
+ * trailing punctuation before the next space: `toctou`, `toctou.`, `toctou — note`.
  */
-const TRAILING_STITCH = /^[\p{P}\p{S}]*[^\s\p{P}\p{S}]/u;
+const TRAILING_STITCH = /^[\p{P}\p{S}]*(?:[^\s\p{P}\p{S}]|\p{Pc})/u;
 
 /**
  * The one CommonMark tokenizer this module uses. A hand-rolled fence/blockquote
@@ -224,21 +225,31 @@ const MD = new MarkdownIt({ html: true });
 // marker only ever begins a reconstructed line when it truly begins a visible one.
 const DROPPED_INLINE = '\u0000';
 
-// Code points GitHub renders as NOTHING: every format character (`\p{Cf}` —
-// zero-width spaces/joiners, bidi controls AND isolates, BOM, soft hyphen, …)
-// and variation selector, plus VT, the combining grapheme joiner, and the line/
-// paragraph separators (which are not `\p{Cf}`). A Unicode PROPERTY class, not a
-// hand-enumerated one, so it cannot silently MISS a member the way a list does —
-// enumerating them by hand is what left the bidi isolates open. Same family the
-// sanitizer's `PROMPT_UNSAFE_INVISIBLES` (channels/base) guards, the same drift-
-// proof way. markdown-it decodes numeric entities at parse time, so any of these
-// can land in a text child (`&#8203;`, `&#8294;`). Left in the prose view they
-// would glue a marker phrase GitHub shows fused (`layerwalked`) or wedge
-// invisibly between an id and the text after it; deleted from the text view so
-// the reconstruction is what a human sees (a wedge just before a REAL break still
-// leaves a clean line-leading receipt).
+// Directionality controls REORDER visible text rather than hide it, so deleting
+// them would make the reconstruction the LOGICAL text, not what a human sees
+// (`<RLO>Layer walked: toctou` displays reversed — never a readable receipt). Map
+// them to the dropped-node sentinel instead: opaque, so they break a match right
+// where they disrupt the visible reading. `\p{Bidi_Control}` is the whole family
+// (LRM/RLM/ALM, embeddings/overrides U+202A–202E, isolates U+2066–2069),
+// property-defined so it cannot drift.
+const BIDI_CONTROL = /\p{Bidi_Control}/gu;
+
+// Code points GitHub renders as NOTHING (truly invisible, not reordering): every
+// non-bidi format character (`\p{Cf}` — zero-width spaces/joiners, BOM, soft
+// hyphen, …) and variation selector, plus VT, FORM FEED (CSS does not collapse it
+// to a space), the combining grapheme joiner, and the line/paragraph separators
+// (not `\p{Cf}`). A Unicode PROPERTY class, not a hand-enumerated one, so it
+// cannot silently MISS a member the way a list does — enumerating by hand is what
+// left the bidi isolates open. Same family the sanitizer's `PROMPT_UNSAFE_INVISIBLES`
+// (channels/base) guards, the same drift-proof way. markdown-it decodes numeric
+// entities at parse time, so any of these can land in a text child (`&#8203;`,
+// `&#12;`). Left in the prose view they would glue a marker phrase GitHub shows
+// fused (`layerwalked`) or wedge invisibly between an id and following text;
+// deleted so the reconstruction is what a human sees (a wedge just before a REAL
+// break still leaves a clean receipt). Bidi controls are `\p{Cf}` too, but the
+// sentinel map above already replaced them.
 const INVISIBLE_FORMAT =
-  /[\p{Cf}\p{Variation_Selector}\u000B\u034F\u2028\u2029]/gu; // eslint-disable-line no-control-regex, no-misleading-character-class
+  /[\p{Cf}\p{Variation_Selector}\u000B\u034F\u000C\u2028\u2029]/gu; // eslint-disable-line no-control-regex, no-misleading-character-class
 
 /**
  * The lines an auditor is USING, not quoting — the VISIBLE PROSE markdown-it
@@ -293,6 +304,7 @@ function* usedLines(finalText: string): Generator<string> {
         if (c.type === 'text')
           prose += c.content
             .replace(/[\r\n]+/g, ' ')
+            .replace(BIDI_CONTROL, DROPPED_INLINE)
             .replace(INVISIBLE_FORMAT, '');
         else if (c.type === 'softbreak' || c.type === 'hardbreak')
           prose += '\n';
@@ -302,7 +314,7 @@ function* usedLines(finalText: string): Generator<string> {
           // NOT a `<br-…>` custom element (a hyphen keeps the tag name going, and
           // GitHub strips the non-allowlisted tag, leaving no break). After `br`
           // the tag must END, or continue with whitespace/slash then attributes.
-          /^<br(?:[\s/][^>]*)?>$/i.test(c.content)
+          /^<br(?:[ \t\n\f\r/][^>]*)?>$/i.test(c.content)
         )
           prose += '\n';
         else if (
@@ -333,12 +345,14 @@ export function parseLayerReceipts(
   const ids = new Set<string>();
   // Cheap pre-filter. It reads RAW text but the parser reads DECODED, markup-joined
   // prose, so it must not veto a marker whose words are split by inline markup —
-  // even MID-word (`La*yer* walked`, `Layer wal*ked*`) — or entity-encoded
-  // (`Layer&#32;walked`). Skip only when BOTH words are absent AND no entity could
-  // decode into them; a single surviving word (or any entity) runs the full parse.
+  // even MID-word, and even when BOTH words are (`La*yer* wal*ked*`) — or are
+  // entity-encoded (`Layer&#32;walked`). Strip the inline-markup delimiters first,
+  // then skip only when BOTH words are absent from that AND no entity could decode
+  // into them; a single surviving word (or any entity) runs the full parse.
+  const bare = finalText.replace(/[*_~`[\]()]/g, '');
   if (
-    !/layer/i.test(finalText) &&
-    !/walked/i.test(finalText) &&
+    !/layer/i.test(bare) &&
+    !/walked/i.test(bare) &&
     !/&[#a-z]/i.test(finalText)
   )
     return ids;

--- a/packages/cli/src/commands/review/lib/audit-layers.ts
+++ b/packages/cli/src/commands/review/lib/audit-layers.ts
@@ -239,15 +239,24 @@ function* usedLines(finalText: string): Generator<string> {
     if (t.type === 'blockquote_open') blockquoteDepth++;
     else if (t.type === 'blockquote_close') blockquoteDepth--;
     else if (t.type === 'inline' && blockquoteDepth === 0) {
-      // The visible prose of this inline: text and line breaks only. `code_inline`
-      // (a code span) and `html_inline` (raw tags, comments, attributes) are
-      // quoted or invisible; a link/image title and alt live in attributes, never
-      // in a text child, so they drop out for free. A link/image's VISIBLE text IS
-      // a text child and is kept — it renders as prose.
+      // The visible prose of this inline. `text` is prose; `code_inline` (a code
+      // span), `html_inline` (raw tags, comments, attributes) and an `image` (its
+      // alt/title live in attributes, never in a text child) are quoted or
+      // non-prose and BREAK the line — a dropped node must not let the text on
+      // either side stitch into a marker GitHub never renders as one receipt
+      // (`` `x` Layer walked: X `` renders two things, not a receipt). Emphasis
+      // and link open/close nodes are deliberately NOT breaks: their visible text
+      // children flow through as prose (a link's visible text is a real receipt).
       let prose = '';
       for (const c of t.children ?? []) {
         if (c.type === 'text') prose += c.content;
-        else if (c.type === 'softbreak' || c.type === 'hardbreak')
+        else if (
+          c.type === 'softbreak' ||
+          c.type === 'hardbreak' ||
+          c.type === 'code_inline' ||
+          c.type === 'html_inline' ||
+          c.type === 'image'
+        )
           prose += '\n';
       }
       yield* prose.split('\n');
@@ -290,9 +299,12 @@ export function inferLayersFromProse(
   finalText: string,
   taxonomy: readonly DefectLayer[] = SHELL_MODEL_LAYERS,
 ): Set<string> {
-  // Over the USED lines only — the estimate must not credit a layer from a
-  // signal that lives in quoted code or a blockquote, the same invariant the
-  // structured parser enforces.
+  // Over the USED lines only, sharing the receipt parser's quotation view: a
+  // signal in a fenced/indented block, a blockquote, OR an inline code span is
+  // dropped. For a receipt that is exactly right (a quoted marker is not a
+  // receipt); for this estimate it can UNDER-count a layer an auditor named in
+  // backticks (`` `set -a` ``), but that only infers FEWER layers → owes more →
+  // the over-cap (fail-safe) direction, acceptable for a non-authoritative guess.
   const lower = [...usedLines(finalText)].join('\n').toLowerCase();
   const ids = new Set<string>();
   for (const layer of taxonomy) {

--- a/packages/cli/src/commands/review/lib/audit-layers.ts
+++ b/packages/cli/src/commands/review/lib/audit-layers.ts
@@ -216,6 +216,18 @@ const MD = new MarkdownIt({ html: true });
 // marker only ever begins a reconstructed line when it truly begins a visible one.
 const DROPPED_INLINE = '\u0000';
 
+// Code points GitHub renders as NOTHING: zero-width, format, and bidi controls,
+// the line/paragraph separators, VT, and BOM. markdown-it decodes numeric
+// entities at parse time, so any of these can land inside a text child
+// (`&#8203;`, `&#8232;`). JS `\s` matches some and none render, so left in the
+// prose view they would glue a marker phrase GitHub shows fused (`layerwalked`)
+// or wedge invisibly between an id and the text after it — either way crediting a
+// receipt that never renders. Deleted from the text view so the reconstruction is
+// what a human sees; a wedge sitting just before a REAL break still leaves a clean
+// line-leading receipt (which a post-id guard on these characters would not).
+const INVISIBLE_FORMAT =
+  /[\u000B\u00AD\u034F\u061C\u180E\u200B-\u200F\u2028\u2029\u202A-\u202E\u2060-\u2064\u206A-\u206F\uFEFF]/g; // eslint-disable-line no-control-regex, no-misleading-character-class
+
 /**
  * The lines an auditor is USING, not quoting — the VISIBLE PROSE markdown-it
  * renders, reconstructed from its token stream. A quoted block (a fenced or
@@ -266,7 +278,10 @@ function* usedLines(finalText: string): Generator<string> {
       // is a real receipt).
       let prose = '';
       for (const c of t.children ?? []) {
-        if (c.type === 'text') prose += c.content.replace(/[\r\n]+/g, ' ');
+        if (c.type === 'text')
+          prose += c.content
+            .replace(/[\r\n]+/g, ' ')
+            .replace(INVISIBLE_FORMAT, '');
         else if (c.type === 'softbreak' || c.type === 'hardbreak')
           prose += '\n';
         else if (c.type === 'html_inline' && /^<br\s*\/?>$/i.test(c.content))
@@ -297,7 +312,10 @@ export function parseLayerReceipts(
   taxonomy: readonly DefectLayer[] = SHELL_MODEL_LAYERS,
 ): Set<string> {
   const ids = new Set<string>();
-  if (!LAYER_HINT_RE.test(finalText)) return ids;
+  // The prefilter reads RAW text but the parser now reads entity-DECODED prose,
+  // so an entity that decodes into the marker phrase (`Layer&#32;walked`) must
+  // not be vetoed here: skip the fast path only when no entity could decode.
+  if (!LAYER_HINT_RE.test(finalText) && !/&[#a-z]/i.test(finalText)) return ids;
   const known = new Set(taxonomy.map((l) => l.id));
   for (const line of usedLines(finalText)) {
     const m = LAYER_RECEIPT_LINE_RE.exec(line);
@@ -307,7 +325,7 @@ export function parseLayerReceipts(
     // the visible token `toctoux` back to the known prefix `toctou`. GitHub
     // renders one stitched word, not a receipt, so a sentinel immediately after
     // the id disqualifies it — the mirror of the leading-stitch guard.
-    if (line.charCodeAt(m[0].length) === 0) continue;
+    if (line.charCodeAt(m[0].length) === DROPPED_INLINE.charCodeAt(0)) continue;
     const id = m[1].toLowerCase();
     if (known.has(id)) ids.add(id);
   }

--- a/packages/cli/src/commands/review/lib/audit-layers.ts
+++ b/packages/cli/src/commands/review/lib/audit-layers.ts
@@ -248,22 +248,28 @@ function* usedLines(finalText: string): Generator<string> {
     else if (t.type === 'blockquote_close') blockquoteDepth--;
     else if (t.type === 'inline' && blockquoteDepth === 0) {
       // The visible prose of this inline, reconstructed the way GitHub lays it
-      // out. `text` is prose. A soft/hard break is a real visible line break, so
-      // it splits the line. Every OTHER inline node — a code span, inline HTML (a
-      // raw tag, a comment, or a raw-text element like `<script>`/`<title>` whose
-      // inner text markdown-it exposes as a child but GitHub shows only inline or
-      // escaped), or an image — does NOT start a new visible line on GitHub, so it
-      // must not start one here: it is replaced by `DROPPED_INLINE`, a
-      // non-whitespace sentinel that neither forges a line start (`x <script>Layer
-      // walked: id` stays one line, marker mid-line → rejected, as GitHub renders
-      // it) nor lets fragments stitch (`Layer walked: <x>id` → the id capture
-      // stops at the sentinel). Emphasis and link open/close nodes are NEITHER:
-      // their visible text children flow through as prose (a link's visible text
+      // out. A visible line break — a soft/hard break, or a `<br>` tag, which
+      // GitHub renders as one — splits the line. Every OTHER inline node — a code
+      // span, other inline HTML (a raw tag, a comment, or a raw-text element like
+      // `<script>`/`<title>` whose inner text markdown-it exposes as a child but
+      // GitHub shows only inline or escaped), or an image — does NOT start a new
+      // visible line on GitHub, so it must not start one here: it is replaced by
+      // `DROPPED_INLINE`, a non-whitespace sentinel that neither forges a line
+      // start (`x <script>Layer walked: id` stays one line, marker mid-line →
+      // rejected, as GitHub renders it) nor lets fragments stitch (`Layer walked:
+      // <x>id` → the id capture stops at the sentinel). `text` is prose, except a
+      // raw newline in it can only come from a decoded numeric entity (`&#10;`) —
+      // a real source break is a `softbreak`/`hardbreak` TOKEN, never text — and
+      // GitHub collapses that entity LF to whitespace, so it must not split a line
+      // either. Emphasis and link open/close nodes are NEITHER a break nor a
+      // sentinel: their visible text children flow through (a link's visible text
       // is a real receipt).
       let prose = '';
       for (const c of t.children ?? []) {
-        if (c.type === 'text') prose += c.content;
+        if (c.type === 'text') prose += c.content.replace(/[\r\n]+/g, ' ');
         else if (c.type === 'softbreak' || c.type === 'hardbreak')
+          prose += '\n';
+        else if (c.type === 'html_inline' && /^<br\s*\/?>$/i.test(c.content))
           prose += '\n';
         else if (
           c.type === 'code_inline' ||
@@ -296,6 +302,12 @@ export function parseLayerReceipts(
   for (const line of usedLines(finalText)) {
     const m = LAYER_RECEIPT_LINE_RE.exec(line);
     if (!m) continue;
+    // Trailing stitch: the id capture is un-anchored at its end, so a dropped
+    // inline node touching the id (`Layer walked: toctou` + `` `x` ``) truncates
+    // the visible token `toctoux` back to the known prefix `toctou`. GitHub
+    // renders one stitched word, not a receipt, so a sentinel immediately after
+    // the id disqualifies it — the mirror of the leading-stitch guard.
+    if (line.charCodeAt(m[0].length) === 0) continue;
     const id = m[1].toLowerCase();
     if (known.has(id)) ids.add(id);
   }

--- a/packages/cli/src/commands/review/lib/audit-layers.ts
+++ b/packages/cli/src/commands/review/lib/audit-layers.ts
@@ -199,67 +199,61 @@ const LAYER_RECEIPT_LINE_RE =
 const LAYER_HINT_RE = /layer\s+walked/i;
 
 /**
- * The one CommonMark tokenizer this module uses to LOCATE quoted regions. A
- * hand-rolled fence/blockquote scanner diverged from the spec round after round
- * — a second parser is a divergence hunt, and this skill's own lesson is that the
- * oracle must come from the authority the code is modelling, not a self-consistent
- * re-implementation. So it defers to `markdown-it`, the parser GitHub's own family
- * uses. `html: true` so a raw-HTML block registers as a quoted block too.
+ * The one CommonMark tokenizer this module uses. A hand-rolled fence/blockquote
+ * scanner diverged from the spec round after round — a second parser is a
+ * divergence hunt, and this skill's own lesson is that the oracle must come from
+ * the authority the code is modelling. So it defers to `markdown-it`, the parser
+ * GitHub's own family uses, and reads receipts from the prose it RENDERS (see
+ * `usedLines`). `html: true` so raw HTML is tokenized — and thus excluded — too.
  */
 const MD = new MarkdownIt({ html: true });
 
 /**
- * The 0-based source line indices inside a QUOTED block — fenced or indented
- * code, an HTML block, or the span of a blockquote — from the block tokens'
- * `.map` line ranges. A parser throw quotes nothing (an unreadable return still
- * has its inline spans guarded by the receipt regex's no-leading-backtick rule).
+ * The lines an auditor is USING, not quoting — the VISIBLE PROSE markdown-it
+ * renders, reconstructed from its token stream. A quoted block (a fenced or
+ * indented code block, an HTML block, or anything inside a blockquote) yields
+ * nothing; a prose block (paragraph, heading, list item) yields its text nodes
+ * and line breaks, with inline code spans, raw HTML (tags, comments, attribute
+ * values) and the title/alt attributes of links and images dropped — GitHub
+ * renders those as nothing or as monospace/attribute text, never as a receipt.
  *
- * KNOWN RESIDUAL — this masks BLOCK-level quotation only. A marker hidden in an
- * INLINE construct GitHub renders invisibly — a multi-line inline code span, an
- * HTML comment or tag attribute value, a link/image title, a link-reference
- * continuation line — sits on a line no block token covers, so it can still parse
- * as a receipt. The exposure is bounded: releasing on it needs a corroborated
- * (identity- and territory-checked) auditor to deliberately obfuscate its own
- * receipts, an adversarial input, not a normal miss, and only under that input.
- * The definitive close is to compute USED text from RENDERED visible content
- * rather than source lines (enumerating inline constructs one by one just opens
- * the next); deferred as a follow-up rather than reopened as another hand-rolled
- * hunt.
- */
-function quotedLines(text: string): Set<number> {
-  const quoted = new Set<number>();
-  let tokens: ReturnType<typeof MD.parse>;
-  try {
-    tokens = MD.parse(text, {});
-  } catch {
-    return quoted;
-  }
-  for (const t of tokens) {
-    if (
-      t.map &&
-      (t.type === 'fence' ||
-        t.type === 'code_block' ||
-        t.type === 'html_block' ||
-        t.type === 'blockquote_open')
-    ) {
-      for (let i = t.map[0]; i < t.map[1]; i++) quoted.add(i);
-    }
-  }
-  return quoted;
-}
-
-/**
- * The lines an auditor is USING, not quoting: every line outside a quoted block
- * (`quotedLines`). Shared by the receipt parser and the opt-in prose estimate so
- * neither credits a layer from quoted text — the module's "a return that QUOTES
- * the marker is not USING it" invariant, deferred to the authoritative parser.
+ * Reading the rendered prose, not the source lines, is what closes the divergence
+ * outright: a block-only pass still leaked a marker hidden in an INLINE construct
+ * — a multi-line inline code span, an HTML comment or attribute, a link title, a
+ * link-reference continuation — as a live receipt, and enumerating those one by
+ * one just opens the next. A parser throw (unconstructed in practice) falls back
+ * to the raw lines; the receipt regex's no-leading-backtick rule still guards the
+ * common inline span there.
  */
 function* usedLines(finalText: string): Generator<string> {
   const src = finalText.replace(/\r\n?/g, '\n');
-  const quoted = quotedLines(src);
-  const lines = src.split('\n');
-  for (let i = 0; i < lines.length; i++) {
-    if (!quoted.has(i)) yield lines[i];
+  let tokens: ReturnType<typeof MD.parse>;
+  try {
+    tokens = MD.parse(src, {});
+  } catch {
+    yield* src.split('\n');
+    return;
+  }
+  let blockquoteDepth = 0;
+  for (const t of tokens) {
+    if (t.type === 'blockquote_open') blockquoteDepth++;
+    else if (t.type === 'blockquote_close') blockquoteDepth--;
+    else if (t.type === 'inline' && blockquoteDepth === 0) {
+      // The visible prose of this inline: text and line breaks only. `code_inline`
+      // (a code span) and `html_inline` (raw tags, comments, attributes) are
+      // quoted or invisible; a link/image title and alt live in attributes, never
+      // in a text child, so they drop out for free. A link/image's VISIBLE text IS
+      // a text child and is kept — it renders as prose.
+      let prose = '';
+      for (const c of t.children ?? []) {
+        if (c.type === 'text') prose += c.content;
+        else if (c.type === 'softbreak' || c.type === 'hardbreak')
+          prose += '\n';
+      }
+      yield* prose.split('\n');
+    }
+    // fence, code_block, html_block, and any inline inside a blockquote yield
+    // nothing — they are quoted.
   }
 }
 

--- a/packages/cli/src/commands/review/lib/audit-layers.ts
+++ b/packages/cli/src/commands/review/lib/audit-layers.ts
@@ -195,9 +195,6 @@ export function renderShellLayerBriefList(
 const LAYER_RECEIPT_LINE_RE =
   /^[ \t]*(?:[-*+]|\d+[.)])?[ \t]*[*_~]{0,3}layer\s+walked[*_~]{0,3}[ \t]*[:：][\s*_~`]*([a-z][a-z0-9-]*)/i;
 
-/** Cheap pre-filter so the line walk skips returns with no marker at all. */
-const LAYER_HINT_RE = /layer\s+walked/i;
-
 /**
  * The one CommonMark tokenizer this module uses. A hand-rolled fence/blockquote
  * scanner diverged from the spec round after round — a second parser is a
@@ -216,17 +213,21 @@ const MD = new MarkdownIt({ html: true });
 // marker only ever begins a reconstructed line when it truly begins a visible one.
 const DROPPED_INLINE = '\u0000';
 
-// Code points GitHub renders as NOTHING: zero-width, format, and bidi controls,
-// the line/paragraph separators, VT, and BOM. markdown-it decodes numeric
-// entities at parse time, so any of these can land inside a text child
-// (`&#8203;`, `&#8232;`). JS `\s` matches some and none render, so left in the
-// prose view they would glue a marker phrase GitHub shows fused (`layerwalked`)
-// or wedge invisibly between an id and the text after it — either way crediting a
-// receipt that never renders. Deleted from the text view so the reconstruction is
-// what a human sees; a wedge sitting just before a REAL break still leaves a clean
-// line-leading receipt (which a post-id guard on these characters would not).
+// Code points GitHub renders as NOTHING: every format character (`\p{Cf}` —
+// zero-width spaces/joiners, bidi controls AND isolates, BOM, soft hyphen, …)
+// and variation selector, plus VT, the combining grapheme joiner, and the line/
+// paragraph separators (which are not `\p{Cf}`). A Unicode PROPERTY class, not a
+// hand-enumerated one, so it cannot silently MISS a member the way a list does —
+// enumerating them by hand is what left the bidi isolates open. Same family the
+// sanitizer's `PROMPT_UNSAFE_INVISIBLES` (channels/base) guards, the same drift-
+// proof way. markdown-it decodes numeric entities at parse time, so any of these
+// can land in a text child (`&#8203;`, `&#8294;`). Left in the prose view they
+// would glue a marker phrase GitHub shows fused (`layerwalked`) or wedge
+// invisibly between an id and the text after it; deleted from the text view so
+// the reconstruction is what a human sees (a wedge just before a REAL break still
+// leaves a clean line-leading receipt).
 const INVISIBLE_FORMAT =
-  /[\u000B\u00AD\u034F\u061C\u180E\u200B-\u200F\u2028\u2029\u202A-\u202E\u2060-\u2064\u206A-\u206F\uFEFF]/g; // eslint-disable-line no-control-regex, no-misleading-character-class
+  /[\p{Cf}\p{Variation_Selector}\u000B\u034F\u2028\u2029]/gu; // eslint-disable-line no-control-regex, no-misleading-character-class
 
 /**
  * The lines an auditor is USING, not quoting — the VISIBLE PROSE markdown-it
@@ -284,7 +285,10 @@ function* usedLines(finalText: string): Generator<string> {
             .replace(INVISIBLE_FORMAT, '');
         else if (c.type === 'softbreak' || c.type === 'hardbreak')
           prose += '\n';
-        else if (c.type === 'html_inline' && /^<br\s*\/?>$/i.test(c.content))
+        else if (
+          c.type === 'html_inline' &&
+          /^<br\b[^>]*\/?>$/i.test(c.content)
+        )
           prose += '\n';
         else if (
           c.type === 'code_inline' ||
@@ -312,20 +316,28 @@ export function parseLayerReceipts(
   taxonomy: readonly DefectLayer[] = SHELL_MODEL_LAYERS,
 ): Set<string> {
   const ids = new Set<string>();
-  // The prefilter reads RAW text but the parser now reads entity-DECODED prose,
-  // so an entity that decodes into the marker phrase (`Layer&#32;walked`) must
-  // not be vetoed here: skip the fast path only when no entity could decode.
-  if (!LAYER_HINT_RE.test(finalText) && !/&[#a-z]/i.test(finalText)) return ids;
+  // Cheap pre-filter. It reads RAW text but the parser reads DECODED, markup-joined
+  // prose, so it must not veto a marker whose two words are split by inline markup
+  // (`Layer *walked*`) or whose letters are entity-encoded (`Layer&#32;walked`).
+  // Skip only when both words are absent AND no entity could decode into them.
+  if (
+    (!/layer/i.test(finalText) || !/walked/i.test(finalText)) &&
+    !/&[#a-z]/i.test(finalText)
+  )
+    return ids;
   const known = new Set(taxonomy.map((l) => l.id));
   for (const line of usedLines(finalText)) {
     const m = LAYER_RECEIPT_LINE_RE.exec(line);
     if (!m) continue;
-    // Trailing stitch: the id capture is un-anchored at its end, so a dropped
-    // inline node touching the id (`Layer walked: toctou` + `` `x` ``) truncates
-    // the visible token `toctoux` back to the known prefix `toctou`. GitHub
-    // renders one stitched word, not a receipt, so a sentinel immediately after
-    // the id disqualifies it — the mirror of the leading-stitch guard.
-    if (line.charCodeAt(m[0].length) === DROPPED_INLINE.charCodeAt(0)) continue;
+    // Trailing stitch: the id capture is un-anchored at its end, so any character
+    // that stitches onto the id disqualifies the receipt — GitHub renders one word
+    // (`toctoux`, `toctou_x`, `toctoué`), never a receipt. Two guards: the dropped
+    // node sentinel, and any word constituent (letter, number, combining mark, or
+    // connector) — the mirror of the leading-stitch guard. A break, space, dash or
+    // other punctuation after the id is a real boundary and stays credited.
+    const after = m[0].length;
+    if (line.charCodeAt(after) === DROPPED_INLINE.charCodeAt(0)) continue;
+    if (/^[\p{L}\p{N}\p{M}\p{Pc}]/u.test(line.slice(after))) continue;
     const id = m[1].toLowerCase();
     if (known.has(id)) ids.add(id);
   }

--- a/packages/cli/src/commands/review/lib/layer-audit-gate.ts
+++ b/packages/cli/src/commands/review/lib/layer-audit-gate.ts
@@ -144,10 +144,12 @@ export function layerAuditGate(
     return { unreviewed: [] };
   }
 
-  // Typed, not inferred: a future reshape of `repositoryContextOf` that renamed
-  // or dropped `domains` would otherwise silently disable the gate on every
-  // modeled-system diff, caught only at runtime. The annotation makes it a
-  // compile error.
+  // Typed, not inferred: the annotation pins the declared type regardless of how
+  // the assignment's control flow is later restructured (or if
+  // `repositoryContextOf` starts returning `any`), so `context.domains` stays
+  // checked against `RepositoryContext` at compile time. (An evolving `let`
+  // already narrows to the return type today, so this is belt-and-braces, not the
+  // sole guard.)
   let context: RepositoryContext | null;
   try {
     context = repositoryContextOf(plan as { repositoryContext?: unknown });

--- a/packages/cli/src/commands/review/lib/layer-audit-gate.ts
+++ b/packages/cli/src/commands/review/lib/layer-audit-gate.ts
@@ -57,7 +57,10 @@
 import { statSync, readFileSync } from 'node:fs';
 import { readTranscripts } from './transcripts.js';
 import { bakedRanges, openedTheTerritory } from './retirement.js';
-import { repositoryContextOf } from './repository-context.js';
+import {
+  repositoryContextOf,
+  type RepositoryContext,
+} from './repository-context.js';
 import { MODELED_SYSTEM_DOMAIN, owedLayerDimensions } from './audit-layers.js';
 
 /**
@@ -141,7 +144,11 @@ export function layerAuditGate(
     return { unreviewed: [] };
   }
 
-  let context;
+  // Typed, not inferred: a future reshape of `repositoryContextOf` that renamed
+  // or dropped `domains` would otherwise silently disable the gate on every
+  // modeled-system diff, caught only at runtime. The annotation makes it a
+  // compile error.
+  let context: RepositoryContext | null;
   try {
     context = repositoryContextOf(plan as { repositoryContext?: unknown });
   } catch {
@@ -153,6 +160,13 @@ export function layerAuditGate(
     return { unreviewed: [] };
   }
 
+  // Corroboration needs the diff path: `readTranscripts` populates
+  // `diffToolCalls`/`diffReads` only when given it, so a plan WITHOUT
+  // `diffPathAbsolute` fails every auditor's corroboration and owes all six
+  // layers. That is fail-safe (over-caps, never releases), and the gate arms only
+  // on a manifest read from a pr-worktree base where the path is present — but the
+  // dependency is real, not incidental: a plan shape that dropped it would defeat
+  // corroboration silently, so it is stated here.
   const diffPathValue = (plan as { diffPathAbsolute?: unknown })
     ?.diffPathAbsolute;
   const diffPath =


### PR DESCRIPTION
## What this PR does

Follow-ups to #8956 (modeled-system defect-layer reverse-audit coverage), from that PR's review after it merged:

- **Close the inline-level quotation gap.** The merged PR swapped a hand-rolled fence scanner for the authoritative CommonMark parser, but read receipts from source lines and masked only BLOCK-level quotation — so a `Layer walked:` marker hidden in an INLINE construct that GitHub renders as nothing or as monospace/attribute text (a multi-line inline code span, an HTML comment or tag attribute value, a link/image title, a link-reference continuation) still credited as a live receipt and could release the Approve cap on layers nobody walked. Read receipts from the VISIBLE PROSE the parser renders instead — walk its tokens, skip quoted blocks, and reconstruct each prose block's text nodes and line breaks, so inline code, raw HTML, and link/image title/alt attributes drop out for free (a link's visible text is kept — it renders as prose). Enumerating inline constructs one by one just opens the next; reading what renders closes them all at once. Verified against the parser GitHub's own family uses.
- **Type the gate's repository context** as a concrete type instead of letting it infer, so a future reshape of the context reader that renamed or dropped the domain field fails at compile time rather than silently disabling the gate on every modeled-system diff.
- **Document that corroboration depends on the plan's diff path** — without it every auditor fails the diff-read check and all layers are owed, which is fail-safe (it only over-withholds an Approve, never releases one) but a real dependency worth stating.

## Why it's needed

#8956 merged; these address its review comments. The inline-quotation item is judged on its facts — probe-verified against the real renderer, in the release direction the gate exists to prevent, and not requiring an adversarial input (a normal auditor quoting a receipt example or using HTML can hit it) — so it is fixed here, not deferred. The other two are compile-time and documentation hardening.

## Reviewer Test Plan

### How to verify

Run the `qwen review` unit suites (`audit-layers`, `layer-audit-gate`). The receipt parser now has a regression per inline family (inline code span, HTML comment, attribute, link title, link-reference continuation) asserting the hidden marker does not count, plus controls (plain prose and link visible text still count). The context typing is compile-time (`tsc`). Confirm the gate still caps a modeled-system diff with an unwalked layer and stays inert on any diff the manifest does not mark.

### Evidence (Before & After)

N/A — a parser/robustness change with unit coverage; no UI.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

## Risk & Scope

- Main risk or tradeoff: the receipt parser now reconstructs prose from the parser's token stream rather than scanning source lines. It biases the same way as before — a marker it cannot see as prose is not counted, which can only over-withhold an Approve, never release one.
- Not validated / out of scope: none outstanding for this change. (One pre-existing, unrelated test failure — `manifest-repository-context.committed.test.ts`, a repo-state bound — reproduces on `main` and is not touched here.)
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #8956.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

对 #8956(modeled-system 缺陷分层反向审计覆盖)合并后、其评审意见的跟进:

- **关闭行内层引用漏洞。** 合并的 PR 已把手写围栏扫描换成权威 CommonMark 解析器,但仍按源码行读回执、只挡**块级**引用——于是藏在**行内**构造里、被 GitHub 渲染成空/等宽/属性文本的 `Layer walked:` 标记(多行 inline code、HTML 注释/属性、链接/图片 title、LRD 续行)仍被算成有效回执,可能在无人走查的层上放行 Approve。改为从解析器**渲染出的可见 prose** 读回执——遍历 token、跳过引用块、重建每个正文块的 text 节点与换行,inline code、原始 HTML、链接/图片 title/alt 属性自动落选(链接的**可见文字**保留,它渲染为正文)。逐个枚举行内构造只会敞开下一个;读"渲染结果"一次全关。已对 GitHub 同款解析器验证。
- **给 gate 的 repository context 加具体类型**,而非任其推断:日后 context reader 重命名/删除 domain 字段会在编译期报错,而非静默禁用 gate。
- **文档化佐证对 diff path 的依赖**——缺失时所有 auditor 佐证失败、欠全部层,fail-safe(只会多扣 Approve、绝不放行),但确是真实依赖。

## 为什么需要

#8956 已合并;此处处理其评审意见。行内引用一项**按事实**判定——对真实渲染器实测、方向是 gate 要防的放行、且触发不必恶意(正常 auditor 引用回执示例或用 HTML 即可撞上)——故在此修复,不再推迟。另两项为编译期与文档加固。

## Reviewer Test Plan

### 如何验证

运行 `qwen review` 单测(`audit-layers`、`layer-audit-gate`)。回执解析器现对每个行内 family(inline code、HTML 注释、属性、链接 title、LRD 续行)各有一条回归,断言藏起来的标记不计入,并有对照(正文与链接可见文字仍计入)。类型注解为编译期(`tsc`)。确认 gate 仍对"有未走查层的 modeled-system diff"扣 Approve,对 manifest 未标记的 diff 保持惰性。

### Evidence(Before & After)

N/A —— 带单测覆盖的解析器/稳健性改动,无 UI。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

## 风险与范围

- 主要风险或取舍:回执解析器现从 token 流重建 prose,而非扫源码行。偏向与此前一致——看不成 prose 的标记不计入,只会多扣 Approve、绝不放行。
- 未验证 / 不在范围内:本改动无遗留项。(有一处**预先存在、无关**的测试失败——`manifest-repository-context.committed.test.ts`,一个仓库状态 bound,在 `main` 上同样复现,本 PR 未触及。)
- Breaking changes / migration notes:无。

## Linked Issues

Follow-up to #8956。

</details>
