### PR TITLE
chore(review): narrow automatic bundled skill context

### DIFF
--- a/.qwen/review-context.json
+++ b/.qwen/review-context.json
@@ -21,7 +21,10 @@
     },
     {
       "paths": ["packages/core/src/skills/**"],
-      "relatedPaths": ["packages/core/src/skills/**"],
+      "relatedPaths": [
+        "packages/core/src/skills/*.ts",
+        "packages/core/src/skills/bundled/*/SKILL.md"
+      ],
       "domains": ["core-skills"]
     },
     {

--- a/packages/cli/src/commands/review/lib/manifest-repository-context.committed.test.ts
+++ b/packages/cli/src/commands/review/lib/manifest-repository-context.committed.test.ts
@@ -217,17 +217,32 @@ describe('committed review context manifest', () => {
   });
 
   it('stays under the resolved-file bound when every rule co-matches', () => {
-    const probes = expectedManifest.rules.flatMap((rule) =>
-      rule.paths.map(probeFor),
-    );
+    const probes = expectedManifest.rules.map((rule) => {
+      const wildcardPattern = rule.paths.find((pattern) =>
+        /[?*]/.test(pattern),
+      );
+      expect(
+        wildcardPattern,
+        'every rule needs a synthetic wildcard probe for the union test',
+      ).toBeDefined();
+      const probe = probeFor(wildcardPattern as string);
+      expect(
+        existsSync(join(repoRoot, probe)),
+        'union probes must not be real changed files excluded from relatedPaths',
+      ).toBe(false);
+      return probe;
+    });
     const context = provideForRepo(probes);
     expect(context).not.toBeNull();
 
-    // At this revision the real provider resolves 115/128 files, leaving 13
-    // slots. The manifest grammar has no negation globs, and hooks/** is the
-    // fastest-growing remaining group, so this bound is the deliberate alarm
-    // for future rebalancing rather than permission to truncate the result.
-    expect(context?.relatedPaths).toHaveLength(115);
+    // The reviewed tree resolved 115/128 files, leaving 13 slots. Do not pin
+    // that exact count: the real provider intentionally scans the working tree,
+    // so harmless untracked files and normal source growth can change it. The
+    // synthetic, nonexistent changed paths above prevent changed-file exclusion
+    // from understating the union. The manifest grammar has no negation globs,
+    // and hooks/** is the fastest-growing remaining group, so this bound is the
+    // deliberate alarm for future rebalancing rather than permission to
+    // truncate the result.
     expect(context?.relatedPaths.length).toBeLessThanOrEqual(MAX_ARRAY_ITEMS);
   });
 

--- a/packages/cli/src/commands/review/lib/manifest-repository-context.committed.test.ts
+++ b/packages/cli/src/commands/review/lib/manifest-repository-context.committed.test.ts
@@ -47,7 +47,10 @@ const expectedManifest = {
     },
     {
       paths: ['packages/core/src/skills/**'],
-      relatedPaths: ['packages/core/src/skills/**'],
+      relatedPaths: [
+        'packages/core/src/skills/*.ts',
+        'packages/core/src/skills/bundled/*/SKILL.md',
+      ],
       domains: ['core-skills'],
     },
     {
@@ -95,7 +98,8 @@ const expectedManifest = {
 
 const relatedPathSentinels: Readonly<Record<string, string>> = {
   'packages/core/src/config/**': 'packages/core/src/config/config.ts',
-  'packages/core/src/skills/**':
+  'packages/core/src/skills/*.ts': 'packages/core/src/skills/skill-manager.ts',
+  'packages/core/src/skills/bundled/*/SKILL.md':
     'packages/core/src/skills/bundled/review/SKILL.md',
   'packages/web-shell/client/adapters/**':
     'packages/web-shell/client/adapters/types.ts',

--- a/packages/cli/src/commands/review/lib/manifest-repository-context.committed.test.ts
+++ b/packages/cli/src/commands/review/lib/manifest-repository-context.committed.test.ts
@@ -23,7 +23,8 @@ const repoRoot = resolve(
 );
 
 const MANIFEST_RELATIVE_PATH = '.qwen/review-context.json';
-const BUNDLED_SKILLS_ROOT = 'packages/core/src/skills/bundled';
+const SKILLS_ROOT = 'packages/core/src/skills';
+const BUNDLED_SKILLS_ROOT = `${SKILLS_ROOT}/bundled`;
 
 const expectedManifest = {
   version: 1,
@@ -255,6 +256,12 @@ describe('committed review context manifest', () => {
       expect(existsSync(join(repoRoot, sentinel))).toBe(true);
     }
 
+    const topLevelSources = readdirSync(join(repoRoot, SKILLS_ROOT), {
+      withFileTypes: true,
+    })
+      .filter((entry) => entry.isFile() && entry.name.endsWith('.ts'))
+      .map((entry) => `${SKILLS_ROOT}/${entry.name}`)
+      .sort();
     const bundledFiles = listFilesRecursively(BUNDLED_SKILLS_ROOT);
     const entrypoints = bundledFiles.filter((path) =>
       /^packages\/core\/src\/skills\/bundled\/[^/]+\/SKILL\.md$/.test(path),
@@ -262,8 +269,12 @@ describe('committed review context manifest', () => {
     const nestedFiles = bundledFiles.filter(
       (path) => !entrypoints.includes(path),
     );
+    expect(topLevelSources.length).toBeGreaterThan(1);
     expect(entrypoints.length).toBeGreaterThan(0);
     expect(nestedFiles).toEqual(expect.arrayContaining(nestedSentinels));
+    for (const source of topLevelSources) {
+      expect(context?.relatedPaths).toContain(source);
+    }
     for (const entrypoint of entrypoints) {
       expect(context?.relatedPaths).toContain(entrypoint);
     }

--- a/packages/cli/src/commands/review/lib/manifest-repository-context.committed.test.ts
+++ b/packages/cli/src/commands/review/lib/manifest-repository-context.committed.test.ts
@@ -196,9 +196,10 @@ describe('committed review context manifest', () => {
   });
 
   it('keeps nested bundled-skill material out of automatic related context', () => {
-    const context = provideForRepo([
-      'packages/core/src/skills/bundled/dataviz/scripts/validate_palette.js',
-    ]);
+    const changedPath =
+      'packages/core/src/skills/bundled/dataviz/synthetic-change.txt';
+    expect(existsSync(join(repoRoot, changedPath))).toBe(false);
+    const context = provideForRepo([changedPath]);
 
     expect(context).not.toBeNull();
     expect(context?.domains).toContain('core-skills');

--- a/packages/cli/src/commands/review/lib/manifest-repository-context.committed.test.ts
+++ b/packages/cli/src/commands/review/lib/manifest-repository-context.committed.test.ts
@@ -6,12 +6,12 @@
 
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
-import { dirname, join, relative, resolve } from 'node:path';
+import { dirname, join, relative, resolve, win32 } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { manifestRepositoryContextProvider } from './manifest-repository-context.js';
 import { MAX_ARRAY_ITEMS } from './repository-context.js';
-import { allFiles } from './test-utils.js';
+import { allFiles, toRepositoryPath } from './test-utils.js';
 
 const repoRoot = resolve(
   dirname(fileURLToPath(import.meta.url)),
@@ -251,7 +251,7 @@ describe('committed review context manifest', () => {
       .map((entry) => `${SKILLS_ROOT}/${entry.name}`)
       .sort();
     const bundledFiles = [...allFiles(join(repoRoot, BUNDLED_SKILLS_ROOT))]
-      .map((path) => relative(repoRoot, path))
+      .map((path) => toRepositoryPath(relative(repoRoot, path)))
       .sort();
     const entrypoints = bundledFiles.filter((path) =>
       /^packages\/core\/src\/skills\/bundled\/[^/]+\/SKILL\.md$/.test(path),
@@ -271,6 +271,17 @@ describe('committed review context manifest', () => {
     for (const nestedFile of nestedFiles) {
       expect(context?.relatedPaths).not.toContain(nestedFile);
     }
+  });
+
+  it('normalizes Windows file-walk results before repository matching', () => {
+    const windowsPath = win32.relative(
+      'C:\\repo',
+      'C:\\repo\\packages\\core\\src\\skills\\bundled\\review\\SKILL.md',
+    );
+
+    expect(toRepositoryPath(windowsPath, win32.sep)).toBe(
+      'packages/core/src/skills/bundled/review/SKILL.md',
+    );
   });
 
   it('stays under the resolved-file bound when every rule co-matches', () => {

--- a/packages/cli/src/commands/review/lib/manifest-repository-context.committed.test.ts
+++ b/packages/cli/src/commands/review/lib/manifest-repository-context.committed.test.ts
@@ -6,11 +6,12 @@
 
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { manifestRepositoryContextProvider } from './manifest-repository-context.js';
 import { MAX_ARRAY_ITEMS } from './repository-context.js';
+import { allFiles } from './test-utils.js';
 
 const repoRoot = resolve(
   dirname(fileURLToPath(import.meta.url)),
@@ -160,21 +161,6 @@ function probeFor(pattern: string): string {
     .join('/');
 }
 
-function listFilesRecursively(relativeDirectory: string): string[] {
-  const files: string[] = [];
-  for (const entry of readdirSync(join(repoRoot, relativeDirectory), {
-    withFileTypes: true,
-  })) {
-    const relativePath = `${relativeDirectory}/${entry.name}`;
-    if (entry.isDirectory()) {
-      files.push(...listFilesRecursively(relativePath));
-    } else if (entry.isFile()) {
-      files.push(relativePath);
-    }
-  }
-  return files.sort();
-}
-
 function inGitWorktree(): boolean {
   try {
     execFileSync('git', ['rev-parse', '--is-inside-work-tree'], {
@@ -206,6 +192,8 @@ describe('committed review context manifest', () => {
   it('matches every paths pattern through the real provider', () => {
     const patterns = [
       ...expectedManifest.rules.flatMap((rule) => rule.paths),
+      // No committed paths pattern uses a single-star segment; keep one
+      // synthetic probe so that branch of probeFor and the matcher stay covered.
       'packages/core/src/synthetic/*.json',
     ];
     for (const pattern of patterns) {
@@ -262,7 +250,9 @@ describe('committed review context manifest', () => {
       .filter((entry) => entry.isFile() && entry.name.endsWith('.ts'))
       .map((entry) => `${SKILLS_ROOT}/${entry.name}`)
       .sort();
-    const bundledFiles = listFilesRecursively(BUNDLED_SKILLS_ROOT);
+    const bundledFiles = [...allFiles(join(repoRoot, BUNDLED_SKILLS_ROOT))]
+      .map((path) => relative(repoRoot, path))
+      .sort();
     const entrypoints = bundledFiles.filter((path) =>
       /^packages\/core\/src\/skills\/bundled\/[^/]+\/SKILL\.md$/.test(path),
     );

--- a/packages/cli/src/commands/review/lib/manifest-repository-context.committed.test.ts
+++ b/packages/cli/src/commands/review/lib/manifest-repository-context.committed.test.ts
@@ -52,8 +52,8 @@ const expectedManifest = {
       paths: ['packages/core/src/skills/**'],
       // Keep every bundled skill entrypoint, but deliberately leave nested
       // implementations, tests, references, and scripts to the changed-file
-      // diff. Including bundled/*/** makes the all-rule union 129 files and
-      // violates the 128-item repository-context wire contract.
+      // diff. Keeping the whole subtree is unnecessary automatic context and
+      // leaves less room under the 128-item repository-context wire contract.
       relatedPaths: [
         'packages/core/src/skills/*.ts',
         'packages/core/src/skills/bundled/*/SKILL.md',
@@ -299,14 +299,13 @@ describe('committed review context manifest', () => {
     const context = provideForRepo(probes);
     expect(context).not.toBeNull();
 
-    // The reviewed tree resolved 115/128 files, leaving 13 slots. Do not pin
+    // The reviewed tree resolved 93/128 files, leaving 35 slots. Do not pin
     // that exact count: the real provider intentionally scans the working tree,
     // so harmless untracked files and normal source growth can change it. The
     // synthetic, nonexistent changed paths above prevent changed-file exclusion
     // from understating the union. The manifest grammar has no negation globs,
-    // and hooks/** is the fastest-growing remaining group, so this bound is the
-    // deliberate alarm for future rebalancing rather than permission to
-    // truncate the result.
+    // so this bound is the deliberate alarm for future rebalancing rather than
+    // permission to truncate the result.
     expect(context?.relatedPaths.length).toBeLessThanOrEqual(MAX_ARRAY_ITEMS);
   });
 

--- a/packages/cli/src/commands/review/lib/manifest-repository-context.committed.test.ts
+++ b/packages/cli/src/commands/review/lib/manifest-repository-context.committed.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
@@ -23,6 +23,7 @@ const repoRoot = resolve(
 );
 
 const MANIFEST_RELATIVE_PATH = '.qwen/review-context.json';
+const BUNDLED_SKILLS_ROOT = 'packages/core/src/skills/bundled';
 
 const expectedManifest = {
   version: 1,
@@ -133,11 +134,44 @@ function provideForRepo(changedPaths: string[]) {
   });
 }
 
+function provideForPattern(pattern: string, changedPath: string) {
+  const manifest = {
+    version: 1,
+    label: 'Pattern probe',
+    rules: [{ paths: [pattern], domains: ['pattern-probe'] }],
+  };
+  return manifestRepositoryContextProvider.provide({
+    worktree: repoRoot,
+    changedPaths: [changedPath],
+    readIdentityFile: (relativePath) =>
+      relativePath === MANIFEST_RELATIVE_PATH ? JSON.stringify(manifest) : null,
+  });
+}
+
 function probeFor(pattern: string): string {
-  const wildcard = pattern.search(/[?*]/);
-  if (wildcard === -1) return pattern;
-  const slash = pattern.lastIndexOf('/', wildcard);
-  return `${pattern.slice(0, slash)}/probe.txt`;
+  return pattern
+    .split('/')
+    .map((segment) =>
+      segment === '**'
+        ? '__qwen_review_probe__'
+        : segment.replaceAll('*', 'probe').replaceAll('?', 'q'),
+    )
+    .join('/');
+}
+
+function listFilesRecursively(relativeDirectory: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(join(repoRoot, relativeDirectory), {
+    withFileTypes: true,
+  })) {
+    const relativePath = `${relativeDirectory}/${entry.name}`;
+    if (entry.isDirectory()) {
+      files.push(...listFilesRecursively(relativePath));
+    } else if (entry.isFile()) {
+      files.push(relativePath);
+    }
+  }
+  return files.sort();
 }
 
 function inGitWorktree(): boolean {
@@ -169,10 +203,15 @@ describe('committed review context manifest', () => {
   });
 
   it('matches every paths pattern through the real provider', () => {
-    for (const rule of expectedManifest.rules) {
-      for (const pattern of rule.paths) {
-        expect(provideForRepo([probeFor(pattern)])).not.toBeNull();
-      }
+    const patterns = [
+      ...expectedManifest.rules.flatMap((rule) => rule.paths),
+      'packages/core/src/synthetic/*.json',
+    ];
+    for (const pattern of patterns) {
+      const probe = probeFor(pattern);
+      expect(provideForPattern(pattern, probe)?.domains).toEqual([
+        'pattern-probe',
+      ]);
     }
   });
 
@@ -203,35 +242,56 @@ describe('committed review context manifest', () => {
 
     expect(context).not.toBeNull();
     expect(context?.domains).toContain('core-skills');
-    expect(context?.relatedPaths).toContain(
-      'packages/core/src/skills/bundled/dataviz/SKILL.md',
-    );
-    expect(context?.relatedPaths).not.toContain(
+
+    const nestedSentinels = [
       'packages/core/src/skills/bundled/dataviz/references/palette.md',
-    );
-    expect(context?.relatedPaths).not.toContain(
       'packages/core/src/skills/bundled/dataviz/scripts/validate_palette.js',
-    );
-    expect(context?.relatedPaths).not.toContain(
+      'packages/core/src/skills/bundled/dataviz/scripts/validate_palette.test.js',
       'packages/core/src/skills/bundled/loop/autonomous-loop.ts',
+      'packages/core/src/skills/bundled/loop/autonomous-loop.test.ts',
+      'packages/core/src/skills/bundled/review/DESIGN.md',
+    ];
+    for (const sentinel of nestedSentinels) {
+      expect(existsSync(join(repoRoot, sentinel))).toBe(true);
+    }
+
+    const bundledFiles = listFilesRecursively(BUNDLED_SKILLS_ROOT);
+    const entrypoints = bundledFiles.filter((path) =>
+      /^packages\/core\/src\/skills\/bundled\/[^/]+\/SKILL\.md$/.test(path),
     );
+    const nestedFiles = bundledFiles.filter(
+      (path) => !entrypoints.includes(path),
+    );
+    expect(entrypoints.length).toBeGreaterThan(0);
+    expect(nestedFiles).toEqual(expect.arrayContaining(nestedSentinels));
+    for (const entrypoint of entrypoints) {
+      expect(context?.relatedPaths).toContain(entrypoint);
+    }
+    for (const nestedFile of nestedFiles) {
+      expect(context?.relatedPaths).not.toContain(nestedFile);
+    }
   });
 
   it('stays under the resolved-file bound when every rule co-matches', () => {
-    const probes = expectedManifest.rules.map((rule) => {
-      const wildcardPattern = rule.paths.find((pattern) =>
+    const probes = expectedManifest.rules.flatMap((rule) => {
+      const wildcardPatterns = rule.paths.filter((pattern) =>
         /[?*]/.test(pattern),
       );
       expect(
-        wildcardPattern,
+        wildcardPatterns.length,
         'every rule needs a synthetic wildcard probe for the union test',
-      ).toBeDefined();
-      const probe = probeFor(wildcardPattern as string);
-      expect(
-        existsSync(join(repoRoot, probe)),
-        'union probes must not be real changed files excluded from relatedPaths',
-      ).toBe(false);
-      return probe;
+      ).toBeGreaterThan(0);
+      return wildcardPatterns.map((pattern) => {
+        const probe = probeFor(pattern);
+        expect(
+          existsSync(join(repoRoot, probe)),
+          'union probes must not be real changed files excluded from relatedPaths',
+        ).toBe(false);
+        expect(provideForPattern(pattern, probe)?.domains).toEqual([
+          'pattern-probe',
+        ]);
+        return probe;
+      });
     });
     const context = provideForRepo(probes);
     expect(context).not.toBeNull();

--- a/packages/cli/src/commands/review/lib/manifest-repository-context.committed.test.ts
+++ b/packages/cli/src/commands/review/lib/manifest-repository-context.committed.test.ts
@@ -47,6 +47,10 @@ const expectedManifest = {
     },
     {
       paths: ['packages/core/src/skills/**'],
+      // Keep every bundled skill entrypoint, but deliberately leave nested
+      // implementations, tests, references, and scripts to the changed-file
+      // diff. Including bundled/*/** makes the all-rule union 129 files and
+      // violates the 128-item repository-context wire contract.
       relatedPaths: [
         'packages/core/src/skills/*.ts',
         'packages/core/src/skills/bundled/*/SKILL.md',
@@ -191,12 +195,39 @@ describe('committed review context manifest', () => {
     }
   });
 
+  it('keeps nested bundled-skill material out of automatic related context', () => {
+    const context = provideForRepo([
+      'packages/core/src/skills/bundled/dataviz/scripts/validate_palette.js',
+    ]);
+
+    expect(context).not.toBeNull();
+    expect(context?.domains).toContain('core-skills');
+    expect(context?.relatedPaths).toContain(
+      'packages/core/src/skills/bundled/dataviz/SKILL.md',
+    );
+    expect(context?.relatedPaths).not.toContain(
+      'packages/core/src/skills/bundled/dataviz/references/palette.md',
+    );
+    expect(context?.relatedPaths).not.toContain(
+      'packages/core/src/skills/bundled/dataviz/scripts/validate_palette.js',
+    );
+    expect(context?.relatedPaths).not.toContain(
+      'packages/core/src/skills/bundled/loop/autonomous-loop.ts',
+    );
+  });
+
   it('stays under the resolved-file bound when every rule co-matches', () => {
     const probes = expectedManifest.rules.flatMap((rule) =>
       rule.paths.map(probeFor),
     );
     const context = provideForRepo(probes);
     expect(context).not.toBeNull();
+
+    // At this revision the real provider resolves 115/128 files, leaving 13
+    // slots. The manifest grammar has no negation globs, and hooks/** is the
+    // fastest-growing remaining group, so this bound is the deliberate alarm
+    // for future rebalancing rather than permission to truncate the result.
+    expect(context?.relatedPaths).toHaveLength(115);
     expect(context?.relatedPaths.length).toBeLessThanOrEqual(MAX_ARRAY_ITEMS);
   });
 

--- a/packages/cli/src/commands/review/lib/review-digest-covers-only-bundled.test.ts
+++ b/packages/cli/src/commands/review/lib/review-digest-covers-only-bundled.test.ts
@@ -21,13 +21,7 @@
 // sparse or partial clone fails this test without anything being wrong.
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import {
-  mkdtempSync,
-  readFileSync,
-  readdirSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import {
   basename,
@@ -44,6 +38,7 @@ import {
   NOT_BUNDLED_FILE,
   NOT_BUNDLED_RE,
 } from './stale-bundle.js';
+import { allFiles } from './test-utils.js';
 
 const repoRoot = resolve(
   import.meta.dirname,
@@ -62,15 +57,6 @@ const reviewDir = join(
   'commands',
   'review',
 );
-
-/** Every file under `dir`, tests and fixtures included. */
-function* allFiles(dir: string): Generator<string> {
-  for (const e of readdirSync(dir, { withFileTypes: true })) {
-    const full = join(dir, e.name);
-    if (e.isDirectory()) yield* allFiles(full);
-    else if (e.isFile()) yield full;
-  }
-}
 
 /**
  * Whether a static `import`/`export … from` clause is a statement-level

--- a/packages/cli/src/commands/review/lib/test-utils.ts
+++ b/packages/cli/src/commands/review/lib/test-utils.ts
@@ -4,11 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { PARSE_ARGS_REPORT } from './paths.js';
 import { DIGEST_FILE } from './stale-bundle.js';
+
+/** Every regular directory entry under `dir`; symlinks are not followed. */
+export function* allFiles(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) yield* allFiles(full);
+    else if (entry.isFile()) yield full;
+  }
+}
 
 /** Seed the report `parse-args` tees, so the effort fallback has something to read. */
 export function seedParseArgs(dir: string, effort: unknown): void {

--- a/packages/cli/src/commands/review/lib/test-utils.ts
+++ b/packages/cli/src/commands/review/lib/test-utils.ts
@@ -5,7 +5,7 @@
  */
 
 import { mkdirSync, readdirSync, writeFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, sep } from 'node:path';
 import { tmpdir } from 'node:os';
 import { PARSE_ARGS_REPORT } from './paths.js';
 import { DIGEST_FILE } from './stale-bundle.js';
@@ -17,6 +17,16 @@ export function* allFiles(dir: string): Generator<string> {
     if (entry.isDirectory()) yield* allFiles(full);
     else if (entry.isFile()) yield full;
   }
+}
+
+/** Normalize a host-native filesystem path for repository path matching. */
+export function toRepositoryPath(
+  filePath: string,
+  pathSeparator = sep,
+): string {
+  return pathSeparator === '/'
+    ? filePath
+    : filePath.split(pathSeparator).join('/');
 }
 
 /** Seed the report `parse-args` tees, so the effort fallback has something to read. */


### PR DESCRIPTION
## What this PR does

This PR further narrows the repository review manifest's automatic core-skills context from the entire skills subtree to the top-level TypeScript implementation/tests plus every bundled skill's `SKILL.md`. It also strengthens the committed manifest-policy tests so each glob is exercised through the real provider, every current top-level skill source and bundled entrypoint is covered, nested bundled material is excluded, Windows path normalization is pinned, and the combined related-path set stays within the 128-file wire contract.

## Why it's needed

#9028 fixed the immediate main-branch overflow by removing Web Shell E2E paths that breached the resolved-file bound. On current `main`, the all-rules provider probe now resolves 107 of 128 allowed related paths. This PR is a separate follow-up that reduces the same probe to 93 paths, leaving 35 slots of headroom, while retaining the shared skill loader/manager/types context and every bundled skill entrypoint. Keeping nested bundled references, scripts, and implementation details in automatic context is unnecessary because changed files still appear in the review diff and a reviewer can request additional repository context explicitly.

## Reviewer Test Plan

### How to verify

1. On current `main`, run the committed all-rules provider probe and confirm it resolves 107 related paths after #9028.
2. On this branch, run:

```bash
cd packages/cli
npx vitest run src/commands/review/lib/manifest-repository-context.committed.test.ts src/commands/review/lib/manifest-repository-context.test.ts src/commands/review/lib/review-digest-covers-only-bundled.test.ts
```

Expected: 3 files / 73 tests pass. The real-provider union probe resolves 93 related paths, including every top-level `packages/core/src/skills/*.ts` file and every `packages/core/src/skills/bundled/*/SKILL.md`, while excluding nested bundled references, scripts, and implementation files.

3. Run `npm run typecheck --workspace @qwen-code/qwen-code`, focused ESLint and Prettier checks for the four changed files, and `git diff --check`. Expected: all pass.

### Evidence (Before & After)

N/A — this is a non-UI repository review-policy change. Current `main` after #9028 resolves 107/128 related paths in the all-rules probe; this branch resolves 93/128 and leaves 35 slots. The regression deliberately checks the protocol ceiling rather than pinning an exact working-tree-sensitive count. It also verifies rule membership exhaustively: all current top-level skill TypeScript sources and all bundled `SKILL.md` entrypoints are included, nested bundled files are excluded, and host-native Windows paths are normalized before matching.

### Tested on

|     OS     |        Status         |
| :--------: | :-------------------: |
|  🍏 macOS  |       ✅ tested        |
| 🪟 Windows | ⚠️ path behavior covered by regression test |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

macOS arm64, Node.js v26.5.0, npm 11.17.0. The branch is synchronized with `main` at `abfd44369860b53aff1b0607ff983be6a0a98bfa`.

## Risk & Scope

- Main risk or tradeoff: nested bundled-skill reference documents, scripts, and implementation details are no longer attached automatically as related paths. Changed files remain in the review diff, and the shared top-level skill implementation/tests plus every bundled `SKILL.md` remain available automatically.
- Not validated / out of scope: changing the 128-file wire limit, silently truncating oversized manifests, redesigning repository-context selection, or manually exercising Linux. CI covers the supported Node lane.
- Breaking changes / migration notes: none. This only narrows this repository's committed review metadata.

## Linked Issues

Follow-up to #9028. Related to #8654 and the tree growth introduced by #8804.

<details>
<summary>中文说明</summary>

## 此 PR 做了什么

此 PR 进一步将仓库 review manifest 自动附加的 core-skills 上下文从整个 skills 子树收窄为顶层 TypeScript 实现/测试文件，以及每个 bundled skill 的 `SKILL.md`。同时加强已提交的 manifest 策略测试：所有 glob 都会通过真实 provider 验证，覆盖当前全部顶层 skill 源文件和 bundled 入口文件，排除嵌套 bundled 内容，固定 Windows 路径归一化行为，并确保合并后的关联路径总数始终满足 128 文件的 wire contract。

## 为什么需要

#9028 已经通过移除导致 resolved-file 上限溢出的 Web Shell E2E 路径，修复了主分支当时的直接失败。当前 `main` 的全规则 provider 探针会解析出 107/128 个关联路径。本 PR 是独立的后续收窄：同一探针会降到 93 个路径，留下 35 个位置余量，同时保留共享的 skill loader/manager/types 上下文和每个 bundled skill 的入口文件。嵌套的 bundled 参考资料、脚本和实现细节无需全部自动附加，因为发生改动的文件仍会出现在 review diff 中，Reviewer 也可以按需请求额外仓库上下文。

## Reviewer 测试计划

### 如何验证

1. 在当前 `main` 上运行已提交的全规则 provider 探针，确认 #9028 合入后会解析出 107 个关联路径。
2. 在本分支运行：

```bash
cd packages/cli
npx vitest run src/commands/review/lib/manifest-repository-context.committed.test.ts src/commands/review/lib/manifest-repository-context.test.ts src/commands/review/lib/review-digest-covers-only-bundled.test.ts
```

预期：3 个文件 / 73 个测试全部通过。真实 provider 的规则并集探针会解析出 93 个关联路径，其中包含所有顶层 `packages/core/src/skills/*.ts` 文件和所有 `packages/core/src/skills/bundled/*/SKILL.md`，并排除嵌套的 bundled 参考资料、脚本和实现文件。

3. 运行 `npm run typecheck --workspace @qwen-code/qwen-code`、针对四个改动文件的 ESLint 和 Prettier 检查，以及 `git diff --check`。预期：全部通过。

### 证据（修改前与修改后）

N/A —— 这是非 UI 的仓库 review 策略变更。#9028 合入后的当前 `main` 在全规则探针中解析出 107/128 个关联路径；本分支解析出 93/128 个，并留下 35 个位置。回归测试有意守住协议上限，而不固定容易受工作树影响的精确数量；同时会穷举验证规则成员：包含当前全部顶层 skill TypeScript 源文件和所有 bundled `SKILL.md` 入口，排除嵌套 bundled 文件，并在匹配前归一化宿主 Windows 路径。

### 测试平台

|     系统     |          状态          |
| :----------: | :--------------------: |
|  🍏 macOS    |       ✅ 已测试         |
| 🪟 Windows   | ⚠️ 路径行为由回归测试覆盖 |
|  🐧 Linux    | ⚠️ 未进行本地测试      |

### 环境（可选）

macOS arm64、Node.js v26.5.0、npm 11.17.0。本分支已同步到 `main` 的 `abfd44369860b53aff1b0607ff983be6a0a98bfa`。

## 风险与范围

- 主要风险或取舍：嵌套的 bundled-skill 参考文档、脚本和实现细节不再自动作为关联路径附加。发生改动的文件仍会出现在 review diff 中；共享的 skills 顶层实现/测试文件和每个 bundled `SKILL.md` 仍会自动提供。
- 未验证/范围外：修改 128 文件 wire 上限、静默截断过大的 manifest、重新设计 repository-context 选择逻辑，或在本地手工验证 Linux。CI 会覆盖支持的 Node lane。
- 破坏性变更/迁移说明：无。这里只收窄本仓库已提交的 review metadata。

## 关联 Issue

#9028 的后续改进。关联 #8654，以及 #8804 引入的文件树增长。

</details>
