### PR TITLE
fix(review): drop the web-shell e2e related-paths that breach the resolved-file bound

### DIFF
--- a/.qwen/review-context.json
+++ b/.qwen/review-context.json
@@ -35,9 +35,6 @@
       "relatedPaths": [
         "packages/web-shell/client/adapters/**",
         "packages/web-shell/client/completions/**",
-        "packages/web-shell/client/e2e/*",
-        "packages/web-shell/client/e2e/utils/*",
-        "packages/web-shell/client/e2e/visuals/*",
         "packages/web-shell/client/hooks/**"
       ]
     },

--- a/packages/cli/src/commands/review/lib/manifest-repository-context.committed.test.ts
+++ b/packages/cli/src/commands/review/lib/manifest-repository-context.committed.test.ts
@@ -61,9 +61,6 @@ const expectedManifest = {
       relatedPaths: [
         'packages/web-shell/client/adapters/**',
         'packages/web-shell/client/completions/**',
-        'packages/web-shell/client/e2e/*',
-        'packages/web-shell/client/e2e/utils/*',
-        'packages/web-shell/client/e2e/visuals/*',
         'packages/web-shell/client/hooks/**',
       ],
     },
@@ -101,12 +98,6 @@ const relatedPathSentinels: Readonly<Record<string, string>> = {
     'packages/web-shell/client/adapters/types.ts',
   'packages/web-shell/client/completions/**':
     'packages/web-shell/client/completions/slashCompletion.ts',
-  'packages/web-shell/client/e2e/*':
-    'packages/web-shell/client/e2e/web-shell.smoke.spec.ts',
-  'packages/web-shell/client/e2e/utils/*':
-    'packages/web-shell/client/e2e/utils/mockDaemon.ts',
-  'packages/web-shell/client/e2e/visuals/*':
-    'packages/web-shell/client/e2e/visuals/constants.ts',
   'packages/web-shell/client/hooks/**':
     'packages/web-shell/client/hooks/useMessages.ts',
 };


### PR DESCRIPTION
## What this PR does

Drops the three web-shell `e2e` entries (`e2e/*`, `e2e/utils/*`, `e2e/visuals/*`) from the committed review-context manifest's `relatedPaths`, and updates the committed-manifest expectation and its sentinel map to match.

`relatedPaths` exist to surface related **source** a reviewer should read as context. The web-shell client rule already lists the client's source subsystems (`adapters/**`, `completions/**`, `hooks/**`); the three `e2e` entries pulled in the client's **Playwright + visual-regression test harness** — test scaffolding, not source context.

## Why it's needed

The committed review-context manifest test `stays under the resolved-file bound when every rule co-matches` fails on `main`:

```
manifest-repository-context.committed.test.ts
  → repository context manifest relatedPaths exceeds limit
  at expandRelatedPaths (manifest-repository-context.ts:522)
```

When every rule co-matches, `expandRelatedPaths` resolves the **union of all `relatedPaths` globs against the worktree**, and that fail-closed set crossed `MAX_ARRAY_ITEMS` (128) as the repository grew — **129 resolved files**, so the guard throws and the `Test (ubuntu-latest, Node 22.x)` job goes red (also breaking the nightly release quality job, issue #9029). The union had been sitting at exactly 128 for the last ~50 commits and just tipped.

Dropping the e2e block restores the manifest to **107 resolved files (~21 of headroom)** with every *source* `relatedPath` intact. This follows the expansion guard's own documented remedy — *"narrow the globs' reach"* — rather than raising the shared 128 wire bound.

## Reviewer Test Plan

### How to verify

- `manifest-repository-context.committed.test.ts` — 5/5 pass (was 1 failing).
- Full `manifest-repository-context*` suite — 64 pass, 1 skipped.
- `tsc` / `eslint` / `prettier` clean.

### Evidence (Before & After)

| | resolved files (worst case) |
|---|---|
| before | 129 → throws |
| after | 107 |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ |
| 🪟 Windows | ⚠️ |
|  🐧 Linux  | ✅ |

(Manifest/test-only change; verified on Linux locally and via the ubuntu CI job. macOS/Windows not separately run — no platform-specific code touched.)

## Risk & Scope

- Main risk or tradeoff: the related-context set for a web-shell client change shrinks by the e2e test tree; e2e coverage remains surfaced via `recommendedTests: ['web-shell']`. No production behavior changes for an ordinary review.
- Not validated / out of scope: raising the shared 128 wire bound (deliberately not done).
- Breaking changes / migration notes: none.

## Linked Issues

References #9029 (nightly release quality failure on main).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

从 committed review-context manifest 的 `relatedPaths` 中删掉三条 web-shell `e2e` 项（`e2e/*`、`e2e/utils/*`、`e2e/visuals/*`），并同步更新 committed manifest 的期望值与 sentinel 映射。

`relatedPaths` 的用途是给评审者补充"应当一并阅读的相关**源码**"。web-shell client 规则已经列出了该客户端的源码子系统（`adapters/**`、`completions/**`、`hooks/**`）；三条 `e2e` 项拉进来的是客户端的 **Playwright + 视觉回归测试脚手架**——属于测试脚手架而非源码上下文。

## 为什么需要

`main` 上 committed manifest 测试 `stays under the resolved-file bound when every rule co-matches` 一直失败：所有规则同时命中时，`expandRelatedPaths` 会把全部 `relatedPaths` glob **对 worktree 展开**，随着仓库变大，这个 fail-closed 集合越过了 `MAX_ARRAY_ITEMS`（128）——展开出 **129 个文件**，守卫抛错，`Test (ubuntu-latest, Node 22.x)` 变红（也打红了 nightly 发布的 quality job，见 #9029）。这个并集在最近约 50 个提交里一直卡在 128，刚刚越线。

删掉 e2e 块后，manifest 展开回到 **107 个文件（约 21 的余量）**，所有*源码*类 `relatedPath` 原样保留。这遵循了展开守卫注释本身给出的补救方向——*"narrow the globs' reach"*，而不是抬高与 wire 校验共享的 128 上限。

## Reviewer 测试计划

### 如何验证

- `manifest-repository-context.committed.test.ts` —— 5/5 通过（原先 1 个失败）。
- 完整 `manifest-repository-context*` 套件 —— 64 通过，1 跳过。
- `tsc` / `eslint` / `prettier` 均干净。

### 证据（Before & After）

| | 解析文件数（最坏情况） |
|---|---|
| 之前 | 129 → 抛错 |
| 之后 | 107 |

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ |
| 🪟 Windows | ⚠️ |
|  🐧 Linux  | ✅ |

（仅 manifest/测试改动；Linux 本地与 ubuntu CI job 已验证，macOS/Windows 未单独跑——不涉及平台相关代码。）

## 风险与范围

- 主要风险或权衡：web-shell client 改动的相关上下文集合少了 e2e 测试树；e2e 覆盖仍通过 `recommendedTests: ['web-shell']` 体现。普通评审的产物行为不变。
- 未验证 / 超出范围：抬高共享的 128 wire 上限（刻意不做）。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

References #9029（main 上 nightly 发布 quality 失败）。
</details>
