### PR TITLE
fix(review): drop the web-shell e2e related-paths that breach the resolved-file bound

### DIFF
--- a/.qwen/review-context.json
+++ b/.qwen/review-context.json
@@ -35,9 +35,6 @@
       "relatedPaths": [
         "packages/web-shell/client/adapters/**",
         "packages/web-shell/client/completions/**",
-        "packages/web-shell/client/e2e/*",
-        "packages/web-shell/client/e2e/utils/*",
-        "packages/web-shell/client/e2e/visuals/*",
         "packages/web-shell/client/hooks/**"
       ]
     },

--- a/packages/cli/src/commands/review/lib/manifest-repository-context.committed.test.ts
+++ b/packages/cli/src/commands/review/lib/manifest-repository-context.committed.test.ts
@@ -61,9 +61,6 @@ const expectedManifest = {
       relatedPaths: [
         'packages/web-shell/client/adapters/**',
         'packages/web-shell/client/completions/**',
-        'packages/web-shell/client/e2e/*',
-        'packages/web-shell/client/e2e/utils/*',
-        'packages/web-shell/client/e2e/visuals/*',
         'packages/web-shell/client/hooks/**',
       ],
     },
@@ -101,12 +98,6 @@ const relatedPathSentinels: Readonly<Record<string, string>> = {
     'packages/web-shell/client/adapters/types.ts',
   'packages/web-shell/client/completions/**':
     'packages/web-shell/client/completions/slashCompletion.ts',
-  'packages/web-shell/client/e2e/*':
-    'packages/web-shell/client/e2e/web-shell.smoke.spec.ts',
-  'packages/web-shell/client/e2e/utils/*':
-    'packages/web-shell/client/e2e/utils/mockDaemon.ts',
-  'packages/web-shell/client/e2e/visuals/*':
-    'packages/web-shell/client/e2e/visuals/constants.ts',
   'packages/web-shell/client/hooks/**':
     'packages/web-shell/client/hooks/useMessages.ts',
 };


### PR DESCRIPTION
## What this PR does

Drops the three web-shell `e2e` entries (`e2e/*`, `e2e/utils/*`, `e2e/visuals/*`) from the committed review-context manifest's `relatedPaths`, and updates the committed-manifest expectation and its sentinel map to match. 2 files, 12 deletions, no production code.

## Why it's needed

The nightly release quality job (issue #9029, run 31653483600) fails on `Test (ubuntu-latest, Node 22.x)`:

```
manifest-repository-context.committed.test.ts
  × stays under the resolved-file bound when every rule co-matches
  → repository context manifest relatedPaths exceeds limit
```

With every rule co-matching, `expandRelatedPaths` resolves the union of all `relatedPaths` globs against the worktree; as the repository grew that union crossed `MAX_ARRAY_ITEMS` (128) at 129 files (config 12 + skills 43 + adapters 9 + completions 2 + e2e 22 + hooks 41), so the fail-closed guard throws. The e2e entries pulled the Playwright/visual-regression test harness into related **source** context; e2e coverage remains surfaced via `recommendedTests: ['web-shell']`. Dropping them restores 107 resolved files (~21 headroom) with every source `relatedPath` intact — the expansion guard's own documented remedy (*narrow the globs' reach*) instead of raising the shared 128 wire bound.

Note: #9028 (wenshao) takes the identical approach; the two are parallel fixes and either may land — the other should then be closed. This PR exists so the release fix does not depend on a single PR's merge queue.

## Reviewer Test Plan

### How to verify

- `npx vitest run packages/cli/src/commands/review/lib/manifest-repository-context.committed.test.ts` — the previously failing test passes (5/5).
- Union check: resolving the remaining globs against the repo yields 107 files ≤ 128.

### Evidence (Before & After)

| | resolved files (worst case) |
|---|---|
| before | 129 → throws |
| after | 107 |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ |
| 🪟 Windows | ⚠️ |
|  🐧 Linux  | ✅ |

(Manifest/test-only change; Linux verified locally, CI covers the rest.)

## Risk & Scope

- Main risk or tradeoff: the related-context set for a web-shell client change shrinks by the e2e test tree; no production behavior change for an ordinary review.
- Not validated / out of scope: raising the shared 128 wire bound (deliberately not done).
- Breaking changes / migration notes: none.

## Linked Issues

References #9029 (nightly release quality failure). Parallel to #9028.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

从 committed review-context manifest 的 `relatedPaths` 删除三条 web-shell `e2e` 项（`e2e/*`、`e2e/utils/*`、`e2e/visuals/*`），同步更新 committed 测试的期望与 sentinel 映射。2 个文件，删 12 行，不碰生产代码。

## 为什么需要

nightly 发布 quality job（#9029，run 31653483600）挂在 `Test (ubuntu-latest, Node 22.x)`：所有规则同时命中时 `expandRelatedPaths` 对 worktree 展开全部 `relatedPaths` glob，并集随仓库增长越过 `MAX_ARRAY_ITEMS`（128）到 129 个文件（config 12 + skills 43 + adapters 9 + completions 2 + e2e 22 + hooks 41），fail-closed 守卫抛错。e2e 项拉入的是 Playwright/视觉回归测试脚手架而非源码上下文；e2e 覆盖仍由 `recommendedTests: ['web-shell']` 体现。删除后回到 107 个文件（约 21 余量），源码类 `relatedPath` 全部保留——遵循守卫注释自身的补救方向（收窄 glob），而非抬高共享 wire 上限。

说明：#9028（wenshao）是同思路的并行修复，二者任一合入后另一个关闭；本 PR 保证发布修复不依赖单个 PR 的合并节奏。

## Reviewer 测试计划

### 如何验证

- `npx vitest run packages/cli/src/commands/review/lib/manifest-repository-context.committed.test.ts` —— 原先失败的测试通过（5/5）。
- 并集校验：剩余 glob 对仓库解析为 107 个文件 ≤ 128。

### 证据（Before & After）

| | 解析文件数（最坏情况） |
|---|---|
| 之前 | 129 → 抛错 |
| 之后 | 107 |

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ |
| 🪟 Windows | ⚠️ |
|  🐧 Linux  | ✅ |

（仅 manifest/测试改动；Linux 本地已验证，其余靠 CI。）

## 风险与范围

- 主要风险或权衡：web-shell client 改动的相关上下文少 e2e 测试树；普通评审行为不变。
- 未验证 / 超出范围：抬高 128 wire 上限（刻意不做）。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

References #9029。与 #9028 并行。
</details>
