### PR TITLE
fix(web-shell): preserve standalone session target

### DIFF
--- a/packages/web-shell/client/main.test.tsx
+++ b/packages/web-shell/client/main.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { act, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WebShellProps } from './App';
+
+interface CapturedWorkspaceSessionProps {
+  sessionId?: string;
+  workspaceId?: string;
+  webShellProps: WebShellProps;
+}
+
+const testState = vi.hoisted(() => ({
+  props: undefined as CapturedWorkspaceSessionProps | undefined,
+}));
+
+vi.mock('react-dom/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('react-dom/client')>()),
+  default: { createRoot: () => ({ render: vi.fn() }) },
+}));
+vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
+  DaemonWorkspaceProvider: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock('./components/WorkspaceSessionProvider', () => ({
+  WorkspaceSessionProvider: (props: CapturedWorkspaceSessionProps) => {
+    testState.props = props;
+    return null;
+  },
+}));
+vi.mock('./config/daemon', () => ({
+  getDaemonBaseUrl: () => '',
+  getDaemonToken: () => 'token',
+  removeDaemonTokenFromUrl: vi.fn(),
+  waitForDaemonTokenMessage: vi.fn(),
+}));
+
+import { StandaloneApp } from './main';
+
+describe('StandaloneApp', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    testState.props = undefined;
+    window.history.replaceState(null, '', '/');
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('keeps the controlled session target in sync with URL changes', () => {
+    act(() => root.render(<StandaloneApp daemonToken="token" />));
+
+    act(() => {
+      testState.props?.webShellProps.onSessionIdChange?.(
+        'session-created',
+        'workspace-1',
+      );
+    });
+
+    expect(testState.props).toMatchObject({
+      sessionId: 'session-created',
+      workspaceId: 'workspace-1',
+    });
+    expect(window.location.pathname).toBe('/session/session-created');
+    expect(new URLSearchParams(window.location.search).get('workspace')).toBe(
+      'workspace-1',
+    );
+  });
+});

--- a/packages/web-shell/client/main.tsx
+++ b/packages/web-shell/client/main.tsx
@@ -111,13 +111,15 @@ function replaceStandaloneSessionUrl(
   window.history.replaceState(null, '', url);
 }
 
-function StandaloneApp({ daemonToken }: { daemonToken?: string }) {
+export function StandaloneApp({ daemonToken }: { daemonToken?: string }) {
   const [theme, setTheme] = useState<WebShellTheme>(() => getInitialTheme());
   const [language, setLanguage] = useState<WebShellLanguage>(() =>
     getInitialLanguage(),
   );
-  const [sessionId] = useState<string | undefined>(() => getSessionIdFromUrl());
-  const [workspaceId] = useState<string | undefined>(() =>
+  const [sessionId, setSessionId] = useState<string | undefined>(() =>
+    getSessionIdFromUrl(),
+  );
+  const [workspaceId, setWorkspaceId] = useState<string | undefined>(() =>
     getWorkspaceIdFromUrl(),
   );
   const baseUrl = DAEMON_BASE_URL || window.location.origin;
@@ -144,6 +146,8 @@ function StandaloneApp({ daemonToken }: { daemonToken?: string }) {
   }, []);
   const handleSessionIdChange = useCallback(
     (nextSessionId?: string, nextWorkspaceId?: string) => {
+      setSessionId(nextSessionId);
+      setWorkspaceId(nextWorkspaceId);
       replaceStandaloneSessionUrl(nextSessionId, nextWorkspaceId);
     },
     [],


### PR DESCRIPTION
## What this PR does

Keeps the standalone Web Shell's controlled session and workspace targets synchronized when the active session changes. It also adds a regression test covering both the React props and URL update.

## Why it's needed

The standalone entry previously updated only the browser URL after lazily creating a session. Because replacing browser history does not update React state, a later reconciliation could still receive the previous undefined target, detach the newly created session, and leave an empty session without submitting the first prompt.

## Reviewer Test Plan

### How to verify

Open the standalone Web Shell without a session in the URL, submit the first prompt, and confirm that the URL changes to the created session while the prompt is accepted by that same session. Confirm that subsequent rerenders keep the created session selected.

### Evidence (Before & After)

Before: the daemon log could show session creation followed by detach without a prompt request, leaving an empty session. After: manual verification showed session creation followed by POST to the created session's prompt route, and the regression test confirms the new session and workspace remain in the rendered provider props and URL.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Standalone daemon development mode with the Web Shell served by Vite.

## Risk & Scope

- Main risk or tradeoff: limited to the standalone browser entry's local session and workspace state synchronization.
- Not validated / out of scope: custom hosts that do not write onSessionIdChange values back to their own controlled props.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 的改动

在当前会话变化时，同步 standalone Web Shell 受控的会话与工作区目标，并新增回归测试，同时覆盖 React 属性和 URL 更新。

## 为什么需要

standalone 入口在懒创建会话后原本只更新浏览器 URL。替换浏览器历史不会更新 React state，因此后续协调仍可能收到之前的 undefined 目标，断开刚创建的会话，最终留下没有提交首条 prompt 的空会话。

## Reviewer 测试计划

### 验证方式

打开 URL 中不带 session 的 standalone Web Shell，提交首条 prompt，确认 URL 更新为新建会话，并且 prompt 被同一会话接收。确认后续重新渲染仍保持选中新建会话。

### 前后对比证据

修复前：daemon 日志可能只出现会话创建和随后的 detach，没有 prompt 请求，从而留下空会话。修复后：手工验证显示会话创建后向该会话的 prompt 路由发起了 POST；回归测试确认新会话和工作区同时保留在渲染后的 Provider 属性及 URL 中。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

standalone daemon 开发模式，Web Shell 由 Vite 提供服务。

## 风险与范围

- 主要风险或权衡：仅影响 standalone 浏览器入口本地的会话与工作区状态同步。
- 未验证或不在范围内：没有把 onSessionIdChange 返回值写回自身受控属性的自定义宿主。
- 破坏性变更或迁移说明：无。

## 关联 Issue

无

</details>
