### PR TITLE
feat(core): Add privacy-safe tool-result boundary diagnostics

### DIFF
--- a/docs/design/2026-08-13-privacy-safe-tool-result-boundary-diagnostics.md
+++ b/docs/design/2026-08-13-privacy-safe-tool-result-boundary-diagnostics.md
@@ -1,0 +1,62 @@
+# Privacy-Safe Tool-Result Boundary Diagnostics
+
+## Summary
+
+Add opt-in debug-log events that explain where an oversized tool-result representation changes between production, model finalization, session recording, ACP or Headless projection, and the actual writer. The events contain only sizes, process-local HMACs, mutation state, and privacy-safe artifact state/kinds. Diagnostic failures remain isolated from tool execution and transport behavior.
+
+## Scope
+
+The implementation covers every built-in tool-result route:
+
+- `CoreToolScheduler` records raw producer input and its terminal output for interactive, Headless, and agent executions, so scheduler-side persistence, truncation, hooks, and display compaction are attributable before finalization.
+- ACP and speculative execution invoke tools directly, so those runtimes record the same producer boundary after `execute()` settles.
+- `finalizeToolResponses()` covers interactive, Headless, ACP, agent, and speculative model-facing aggregation.
+- `ChatRecordingService.recordToolResult()` is the shared recorder boundary.
+- ACP live and replay delivery are observed immediately before and after textual projection.
+- Headless JSON, stream-json, persistent SDK transport, subagent, Text retention, and DualOutput are observed at their shared adapter projection. JSON and stream-json writers provide exact emitted frame sizes; Text has no tool-result wire frame.
+- The ACP NDJSON hook provides the serialized payload byte count; the diagnostic adds the single newline byte written by that transport.
+
+Custom adapters and prebuilt custom `tool_result` messages remain outside the built-in Headless route. Generic frame limits, backpressure, replay aggregate limits, and artifact lifecycle remain tracked separately.
+
+## Event Contract
+
+Diagnostics run only when `QWEN_DEBUG_LOG_FILE` is enabled and a debug-log session is active. An event is eligible only when at least one textual representation exceeds 65,536 JSON UTF-8 bytes or the observed boundary changed a representation.
+
+Each event records:
+
+- boundary stage and representation kind;
+- JavaScript code units, raw UTF-8 bytes, and exact JSON-string UTF-8 bytes;
+- a process-local HMAC-SHA-256 for each textual slot;
+- HMACs for available session, prompt, tool-call, and tool-name identifiers;
+- mutation state plus one artifact summary per tool call, containing producer-persistence state (`undecided`, `none`, or `reusable`) and deduplicated kind enums only;
+- exact serialized frame bytes at ACP and Headless writer boundaries.
+
+The HMAC key is generated randomly once per process. Every string is hashed independently with an eight-byte byte-length prefix followed by its UTF-16LE code units; values are never concatenated before hashing. Hashing code units preserves distinctions between valid Unicode and lone-surrogate JavaScript strings while keeping equal values comparable inside one process without creating stable cross-process content fingerprints.
+
+No event contains output text, prompts, artifact paths, artifact titles or URLs, session IDs, prompt IDs, tool-call IDs, tool names, arguments, or filesystem paths. Structured rich displays are not recursively inspected: the Phase 2 byte contract applies only to the textual model, display, ACP content/raw, and Headless content representations. Artifact summaries use the existing kind enum plus `unknown`; reusable persistence files contribute the safe `file` kind. Batch writer events keep summaries in the same order as their tool-call identifiers instead of collapsing mixed states or kinds.
+
+## Failure and Rate-Limit Behavior
+
+The observer performs its enablement check before scanning or hashing values. All observation, hashing, classification, and logging code is wrapped in a failure boundary; exceptions are swallowed and never alter the value or write path.
+
+A process-wide limiter emits at most 50 eligible events per 60-second window. Additional eligible events increment a suppressed counter. The first eligible event in a later window reports the accumulated count, then resets it.
+
+The existing `qwen serve` large-pipe-frame observer remains the only daemon attribution mechanism for frames at or above 256 KiB. These diagnostics correlate representations and exact writer sizes but do not emit production telemetry or replace large-frame attribution.
+
+## Implementation Shape
+
+A small Core utility owns event eligibility, exact JSON-string byte accounting, HMAC generation, artifact-state classification, rate limiting, and debug-log output. It accepts textual values lazily so disabled diagnostics do not traverse tool results.
+
+Core call sites add observations at scheduler producer input/output, the speculative producer route, finalizer input/output, and recorder input/output. ACP adds its direct producer observation. Recorder-only diagnostic metadata is stripped before the transcript record is constructed.
+
+A CLI-internal helper owns ACP and Headless projection correlation. It records projection input/output and associates eligible projected objects plus their safe artifact summaries with the later writer through weak references. Subagent progress carries only this closed-enum summary, only while diagnostics are enabled; raw persistence paths and structured artifacts never enter that event path. Eligibility includes both changed projections and oversized unchanged exemptions such as A2UI. This avoids marker parsing and avoids any schema or wire metadata change.
+
+## Compatibility
+
+The change is diagnostic-only when disabled and does not modify tool results, projections, transcripts, schemas, ACP messages, Headless messages, SDK types, or protocol versions. Debug log files gain new JSON-shaped lines only when explicitly enabled. HMACs intentionally change after every process restart.
+
+## Verification
+
+Focused tests cover exact JSON byte accounting (including escapes and Unicode), HMAC equality and mutation mismatch, identifier redaction, artifact tri-state/kinds, mixed batch artifact summaries, enablement, rate limiting, suppressed counts, failure isolation, Core boundary integration, ACP live/replay projection, ACP NDJSON byte counts, Headless JSON/stream-json writer byte counts, and Text retention without a tool-result wire event.
+
+A deterministic fake-MCP exercise records before/after evidence for a 499,999-byte result across Headless JSON, stream-json, persistent stream-json/SDK transport, Text, and ACP where feasible. It verifies exact logged writer bytes, process-local HMAC correlation, absence of fixture text and identifiers in the log, unchanged producer artifact size/hash, and unchanged user-visible output.

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -232,6 +232,13 @@ vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => ({
   ),
   initializeTelemetry: vi.fn().mockResolvedValue(undefined),
   addDaemonRequestAttribute: mockAddDaemonRequestAttribute,
+  observeToolResultBoundary: vi.fn(() => false),
+  toolResultArtifactState: (
+    await importOriginal<typeof import('@qwen-code/qwen-code-core')>()
+  ).toolResultArtifactState,
+  toolResultPartDiagnosticValues: (
+    await importOriginal<typeof import('@qwen-code/qwen-code-core')>()
+  ).toolResultPartDiagnosticValues,
   preloadContentGenerator: mockPreloadContentGenerator,
   createDebugLogger: () => mockDebugLogger,
   extractDaemonTraceContext: mockExtractDaemonTraceContext,

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -177,6 +177,7 @@ import {
   ACP_EVENT_LOOP_STALL_RESTART_MS,
   CHANNEL_PROMPT_META_KEY,
 } from '@qwen-code/channel-base';
+import { observeAcpToolResultWire } from '../utils/tool-result-boundary-diagnostics.js';
 import { Readable, Writable } from 'node:stream';
 import { normalizeDisabledToolList } from '../config/normalizeDisabledTools.js';
 import { pipeline } from 'node:stream/promises';
@@ -3257,7 +3258,10 @@ export async function runAcpAgent(
     let initializeRequestId: string | number | null | undefined;
     const pendingNewSessionRequestIds = new Set<string | number | null>();
     const stream = ndJsonStream(stdout, stdin, {
-      onMessageObserved: ({ direction, message }) => {
+      onMessageObserved: ({ direction, bytes, message }) => {
+        if (direction === 'sent') {
+          observeAcpToolResultWire(message, bytes);
+        }
         if (
           direction === 'received' &&
           'id' in message &&

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -22515,6 +22515,9 @@ describe('Session', () => {
       const logToolCallSpy = vi
         .spyOn(core, 'logToolCall')
         .mockImplementation(() => {});
+      const boundarySpy = vi
+        .spyOn(core, 'observeToolResultBoundary')
+        .mockReturnValue(false);
       const messageBus = {
         request: vi
           .fn()
@@ -22533,9 +22536,18 @@ describe('Session', () => {
       mockConfig.getMessageBus = vi.fn().mockReturnValue(messageBus);
       mockConfig.getDisableAllHooks = vi.fn().mockReturnValue(false);
       mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.YOLO);
+      const artifacts = [
+        {
+          kind: 'link' as const,
+          title: 'Completed report',
+          url: 'https://example.com/report',
+        },
+      ];
       const execute = vi.fn().mockResolvedValue({
         llmContent: 'completed',
         returnDisplay: 'completed',
+        artifacts,
+        persistedOutputFiles: ['/private/post-stop-output.txt'],
       });
       mockToolRegistry.getTool.mockReturnValue(
         mockAllowedTool('post_stop_tool', execute),
@@ -22566,8 +22578,28 @@ describe('Session', () => {
           status: 'error',
           executionStatus: 'success',
           errorType: core.ToolErrorType.EXECUTION_DENIED,
+          resultDisplay: undefined,
+          artifacts,
+          persistedOutputFiles: ['/private/post-stop-output.txt'],
         }),
       );
+      expect(mockClient.sessionUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          update: expect.objectContaining({
+            toolCallId: 'post_stop_call',
+            _meta: expect.objectContaining({ artifacts }),
+          }),
+        }),
+      );
+      const producerObservations = boundarySpy.mock.calls.filter(
+        ([observation]) =>
+          observation.stage === 'producer' &&
+          observation.toolCallId === 'post_stop_call',
+      );
+      expect(producerObservations).toHaveLength(1);
+      expect(producerObservations[0][0].artifacts).toEqual([
+        { state: 'reusable', kinds: ['file', 'link'] },
+      ]);
     });
 
     it('records postprocessing failure after successful execution', async () => {
@@ -23041,9 +23073,18 @@ describe('Session', () => {
       mockConfig.getMessageBus = vi.fn().mockReturnValue(messageBus);
       mockConfig.getDisableAllHooks = vi.fn().mockReturnValue(false);
       mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.YOLO);
+      const artifacts = [
+        {
+          kind: 'file' as const,
+          title: 'Cancelled report',
+          workspacePath: 'reports/cancelled.txt',
+        },
+      ];
       const execute = vi.fn().mockResolvedValue({
         llmContent: 'completed',
         returnDisplay: 'completed',
+        artifacts,
+        persistedOutputFiles: ['/private/post-cancel-output.txt'],
       });
       mockToolRegistry.getTool.mockReturnValue(
         mockAllowedTool('post_hook_tool', execute),
@@ -23082,6 +23123,17 @@ describe('Session', () => {
           executionStatus: 'success',
           error: undefined,
           errorType: undefined,
+          resultDisplay: undefined,
+          artifacts,
+          persistedOutputFiles: ['/private/post-cancel-output.txt'],
+        }),
+      );
+      expect(mockClient.sessionUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          update: expect.objectContaining({
+            toolCallId: 'post_hook_cancel_call',
+            _meta: expect.objectContaining({ artifacts }),
+          }),
         }),
       );
     });

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -22742,6 +22742,9 @@ describe('Session', () => {
       const logToolCallSpy = vi
         .spyOn(core, 'logToolCall')
         .mockImplementation(() => {});
+      const boundarySpy = vi
+        .spyOn(core, 'observeToolResultBoundary')
+        .mockReturnValue(false);
       vi.mocked(mockClient.sessionUpdate).mockRejectedValue(
         new Error('ACP update unavailable'),
       );
@@ -22792,6 +22795,16 @@ describe('Session', () => {
           status: 'error',
           executionStatus: 'error',
           errorType: core.ToolErrorType.UNHANDLED_EXCEPTION,
+        }),
+      );
+      expect(boundarySpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stage: 'producer',
+          sessionId: 'test-session-id',
+          promptId: 'prompt-hook-fail',
+          toolCallId: 'hook_fail_call',
+          toolName: 'failing_tool',
+          values: expect.any(Function),
         }),
       );
     });

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -22809,6 +22809,44 @@ describe('Session', () => {
       );
     });
 
+    it('observes a producer error when a settled tool result is malformed', async () => {
+      const boundarySpy = vi
+        .spyOn(core, 'observeToolResultBoundary')
+        .mockReturnValue(false);
+      mockConfig.getDisableAllHooks = vi.fn().mockReturnValue(true);
+      mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.YOLO);
+      mockToolRegistry.getTool.mockReturnValue(
+        mockAllowedTool('malformed_tool', vi.fn().mockResolvedValue(null)),
+      );
+
+      await (session as unknown as ToolCallInternals).runToolCalls(
+        new AbortController().signal,
+        'prompt-malformed-result',
+        [
+          {
+            id: 'malformed_result_call',
+            name: 'malformed_tool',
+            args: {},
+          },
+        ],
+      );
+
+      const producerObservations = boundarySpy.mock.calls.filter(
+        ([observation]) =>
+          observation.stage === 'producer' &&
+          observation.toolCallId === 'malformed_result_call',
+      );
+      expect(producerObservations).toHaveLength(1);
+      expect(producerObservations[0][0]).toEqual(
+        expect.objectContaining({
+          sessionId: 'test-session-id',
+          promptId: 'prompt-malformed-result',
+          toolName: 'malformed_tool',
+          values: expect.any(Function),
+        }),
+      );
+    });
+
     it('classifies postprocessing failures independently from a settled soft error', async () => {
       const logToolCallSpy = vi
         .spyOn(core, 'logToolCall')

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -22879,6 +22879,56 @@ describe('Session', () => {
       );
     });
 
+    it('ignores throwing optional metadata on a successful tool result', async () => {
+      const toolResult = {
+        llmContent: 'completed',
+        returnDisplay: 'completed',
+      } as core.ToolResult;
+      Object.defineProperties(toolResult, {
+        artifacts: {
+          get: () => {
+            throw new Error('artifacts unavailable');
+          },
+        },
+        persistedOutputFiles: {
+          get: () => {
+            throw new Error('persisted output unavailable');
+          },
+        },
+      });
+      mockConfig.getDisableAllHooks = vi.fn().mockReturnValue(true);
+      mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.YOLO);
+      mockToolRegistry.getTool.mockReturnValue(
+        mockAllowedTool(
+          'throwing_metadata_tool',
+          vi.fn().mockResolvedValue(toolResult),
+        ),
+      );
+
+      const result = await (
+        session as unknown as ToolCallInternals
+      ).runToolCalls(new AbortController().signal, 'prompt-metadata', [
+        {
+          id: 'throwing_metadata_call',
+          name: 'throwing_metadata_tool',
+          args: {},
+        },
+      ]);
+
+      expect(result.parts[0].functionResponse?.response).toEqual({
+        output: 'completed',
+      });
+      expect(mockChatRecordingService.recordToolResult).toHaveBeenCalledWith(
+        result.parts,
+        expect.objectContaining({
+          callId: 'throwing_metadata_call',
+          status: 'success',
+          artifacts: undefined,
+          persistedOutputFiles: undefined,
+        }),
+      );
+    });
+
     it('classifies postprocessing failures independently from a settled soft error', async () => {
       const logToolCallSpy = vi
         .spyOn(core, 'logToolCall')

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -9038,7 +9038,7 @@ export class Session implements SessionContext {
         opts.status,
         opts.errorType,
       );
-      if (executeAttempted && !executeReturned && !producerObserved) {
+      if (executeAttempted && !producerObserved) {
         observeToolResultBoundary({
           stage: 'producer',
           sessionId: this.sessionId,

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -181,6 +181,9 @@ import {
   splitImageParts,
   approxBase64Bytes,
   runWithRuntimeContentGenerator,
+  observeToolResultBoundary,
+  toolResultBoundaryArtifact,
+  toolResultPartDiagnosticValues,
   getInvocationContext,
   runWithInvocationContext,
   truncateNotificationLabel,
@@ -299,6 +302,7 @@ import type {
 } from './types.js';
 import { HistoryReplayer } from './history-replayer.js';
 import { projectAcpToolResultUpdate } from './acp-tool-result-text-projection.js';
+import { observeAcpToolResultProjection } from '../../utils/tool-result-boundary-diagnostics.js';
 import { ToolCallEmitter } from './emitters/tool-call-emitter.js';
 import { ToolCallPreparationTracker } from './tool-call-preparation-tracker.js';
 import { PlanEmitter } from './emitters/PlanEmitter.js';
@@ -5748,9 +5752,11 @@ export class Session implements SessionContext {
   }
 
   async sendUpdate(update: SessionUpdate): Promise<void> {
+    const projectedUpdate = projectAcpToolResultUpdate(update);
+    observeAcpToolResultProjection(update, projectedUpdate, this.sessionId);
     const params: SessionNotification = {
       sessionId: this.sessionId,
-      update: projectAcpToolResultUpdate(update),
+      update: projectedUpdate,
     };
 
     if (update.sessionUpdate === 'plan') {
@@ -8310,12 +8316,18 @@ export class Session implements SessionContext {
           toolName: record.toolName,
           responseParts: record.responseParts,
           persistedOutputFiles: record.persistedOutputFiles,
+          artifacts: record.metadata.artifacts,
         })),
+        new Map(orderedRecords.map((record) => [record.callId, promptId])),
       );
       orderedRecords.forEach((record, index) => {
         this.config
           .getChatRecordingService()
-          ?.recordToolResult(finalized[index].responseParts, record.metadata);
+          ?.recordToolResult(finalized[index].responseParts, {
+            ...record.metadata,
+            persistedOutputFiles: finalized[index].persistedOutputFiles,
+            artifacts: finalized[index].artifacts,
+          });
       });
       return {
         ...result,
@@ -8461,6 +8473,8 @@ export class Session implements SessionContext {
             resultDisplay: response.resultDisplay,
             error: response.error,
             success: false,
+            artifacts: response.artifacts,
+            persistedOutputFiles: response.persistedOutputFiles,
           });
         }
       } catch (emitError) {
@@ -8482,6 +8496,7 @@ export class Session implements SessionContext {
           resultDisplay: response.resultDisplay,
           error: response.error,
           errorType: response.errorType,
+          artifacts: response.artifacts,
         },
       });
     };
@@ -10350,6 +10365,31 @@ export class Session implements SessionContext {
             sleepInhibitorHandle.release();
           }
 
+          observeToolResultBoundary({
+            stage: 'producer',
+            sessionId: this.sessionId,
+            promptId,
+            toolCallId: callId,
+            toolName,
+            artifacts: [
+              toolResultBoundaryArtifact(
+                toolResult.persistedOutputFiles,
+                toolResult.artifacts,
+              ),
+            ],
+            values: () => [
+              ...toolResultPartDiagnosticValues(toolResult.llmContent),
+              ...(typeof toolResult.returnDisplay === 'string'
+                ? [
+                    {
+                      representation: 'display' as const,
+                      value: toolResult.returnDisplay,
+                    },
+                  ]
+                : []),
+            ],
+          });
+
           // Clean up event listeners
           cleanupAgentToolResources();
 
@@ -10594,6 +10634,7 @@ export class Session implements SessionContext {
                 error: responseError,
                 success: succeeded,
                 artifacts: toolResult.artifacts,
+                persistedOutputFiles: toolResult.persistedOutputFiles,
               });
             } catch (emitError) {
               debugLogger.debug(
@@ -10649,6 +10690,7 @@ export class Session implements SessionContext {
               ...(visionBridgeNotice !== undefined
                 ? { visionBridgeNotice }
                 : {}),
+              artifacts: toolResult.artifacts,
               error:
                 status === 'error' && toolResult.error
                   ? new Error(toolResult.error.message)

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -9015,7 +9015,10 @@ export class Session implements SessionContext {
         executionStatus: ToolExecutionStatus;
         recordInvalidToolParams?: boolean;
         stopAfterPermissionCancel?: boolean;
-        settledResult?: ToolResult;
+        settledMetadata?: {
+          artifacts?: ToolArtifact[];
+          persistedOutputFiles?: string[];
+        };
       },
     ) => {
       executionStatus = opts.executionStatus;
@@ -9030,7 +9033,7 @@ export class Session implements SessionContext {
       );
       if (toolName !== ToolNames.TODO_WRITE) {
         try {
-          if (opts.settledResult) {
+          if (opts.settledMetadata) {
             await this.toolCallEmitter.emitResult({
               callId,
               toolName,
@@ -9038,8 +9041,8 @@ export class Session implements SessionContext {
               message: errorParts,
               error,
               success: false,
-              artifacts: opts.settledResult.artifacts,
-              persistedOutputFiles: opts.settledResult.persistedOutputFiles,
+              artifacts: opts.settledMetadata.artifacts,
+              persistedOutputFiles: opts.settledMetadata.persistedOutputFiles,
             });
           } else {
             await this.toolCallEmitter.emitError(callId, toolName, error);
@@ -9059,10 +9062,10 @@ export class Session implements SessionContext {
           toolCallId: callId,
           toolName,
           artifacts: [
-            opts.settledResult
+            opts.settledMetadata
               ? toolResultBoundaryArtifact(
-                  opts.settledResult.persistedOutputFiles,
-                  opts.settledResult.artifacts,
+                  opts.settledMetadata.persistedOutputFiles,
+                  opts.settledMetadata.artifacts,
                 )
               : toolResultBoundaryArtifact([], []),
           ],
@@ -9074,7 +9077,7 @@ export class Session implements SessionContext {
         callId,
         toolName,
         responseParts: errorParts,
-        persistedOutputFiles: opts.settledResult?.persistedOutputFiles,
+        persistedOutputFiles: opts.settledMetadata?.persistedOutputFiles,
         policyToolName: guardContext.policyToolName,
         toolType,
         executionErrorType:
@@ -9086,7 +9089,7 @@ export class Session implements SessionContext {
           status: opts.status,
           executionStatus,
           resultDisplay: undefined,
-          artifacts: opts.settledResult?.artifacts,
+          artifacts: opts.settledMetadata?.artifacts,
           error: opts.status === 'error' ? error : undefined,
           errorType: opts.status === 'error' ? opts.errorType : undefined,
         },
@@ -10303,6 +10306,8 @@ export class Session implements SessionContext {
                   },
                 }
               : undefined;
+          let settledArtifacts: ToolArtifact[] | undefined;
+          let settledPersistedOutputFiles: string[] | undefined;
           const sleepInhibitorHandle = acquireSleepInhibitor(
             this.config,
             `Qwen Code is executing tool ${toolName}`,
@@ -10334,6 +10339,16 @@ export class Session implements SessionContext {
                 onToolProgress,
               );
               executeReturned = true;
+              try {
+                settledArtifacts = toolResult.artifacts;
+              } catch {
+                // Optional result metadata must not affect execution.
+              }
+              try {
+                settledPersistedOutputFiles = toolResult.persistedOutputFiles;
+              } catch {
+                // Optional result metadata must not affect execution.
+              }
               parentAbortedAtExecutionSettle = activeToolAbortSignal.aborted;
               isExecutionTimeout =
                 toolResult.error?.type === ToolErrorType.EXECUTION_TIMEOUT;
@@ -10402,31 +10417,35 @@ export class Session implements SessionContext {
             sleepInhibitorHandle.release();
           }
 
-          observeToolResultBoundary({
-            stage: 'producer',
-            sessionId: this.sessionId,
-            promptId,
-            toolCallId: callId,
-            toolName,
-            artifacts: [
-              toolResultBoundaryArtifact(
-                toolResult.persistedOutputFiles,
-                toolResult.artifacts,
-              ),
-            ],
-            values: () => [
-              ...toolResultPartDiagnosticValues(toolResult.llmContent),
-              ...(typeof toolResult.returnDisplay === 'string'
-                ? [
-                    {
-                      representation: 'display' as const,
-                      value: toolResult.returnDisplay,
-                    },
-                  ]
-                : []),
-            ],
-          });
           producerObserved = true;
+          try {
+            observeToolResultBoundary({
+              stage: 'producer',
+              sessionId: this.sessionId,
+              promptId,
+              toolCallId: callId,
+              toolName,
+              artifacts: [
+                toolResultBoundaryArtifact(
+                  settledPersistedOutputFiles,
+                  settledArtifacts,
+                ),
+              ],
+              values: () => [
+                ...toolResultPartDiagnosticValues(toolResult.llmContent),
+                ...(typeof toolResult.returnDisplay === 'string'
+                  ? [
+                      {
+                        representation: 'display' as const,
+                        value: toolResult.returnDisplay,
+                      },
+                    ]
+                  : []),
+              ],
+            });
+          } catch {
+            // Diagnostics must not affect tool execution.
+          }
 
           // Clean up event listeners
           cleanupAgentToolResources();
@@ -10519,7 +10538,10 @@ export class Session implements SessionContext {
                   status: 'cancelled',
                   errorType: undefined,
                   executionStatus,
-                  settledResult: toolResult,
+                  settledMetadata: {
+                    artifacts: settledArtifacts,
+                    persistedOutputFiles: settledPersistedOutputFiles,
+                  },
                 },
               );
             }
@@ -10537,7 +10559,10 @@ export class Session implements SessionContext {
                 status: 'error',
                 errorType: ToolErrorType.EXECUTION_DENIED,
                 executionStatus,
-                settledResult: toolResult,
+                settledMetadata: {
+                  artifacts: settledArtifacts,
+                  persistedOutputFiles: settledPersistedOutputFiles,
+                },
               });
             }
 
@@ -10673,8 +10698,8 @@ export class Session implements SessionContext {
                 resultDisplay: toolResult.returnDisplay,
                 error: responseError,
                 success: succeeded,
-                artifacts: toolResult.artifacts,
-                persistedOutputFiles: toolResult.persistedOutputFiles,
+                artifacts: settledArtifacts,
+                persistedOutputFiles: settledPersistedOutputFiles,
               });
             } catch (emitError) {
               debugLogger.debug(
@@ -10717,7 +10742,7 @@ export class Session implements SessionContext {
             callId,
             toolName,
             responseParts,
-            persistedOutputFiles: toolResult.persistedOutputFiles,
+            persistedOutputFiles: settledPersistedOutputFiles,
             policyToolName,
             toolType,
             executionErrorType:
@@ -10730,7 +10755,7 @@ export class Session implements SessionContext {
               ...(visionBridgeNotice !== undefined
                 ? { visionBridgeNotice }
                 : {}),
-              artifacts: toolResult.artifacts,
+              artifacts: settledArtifacts,
               error:
                 status === 'error' && toolResult.error
                   ? new Error(toolResult.error.message)

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -9015,15 +9015,35 @@ export class Session implements SessionContext {
         executionStatus: ToolExecutionStatus;
         recordInvalidToolParams?: boolean;
         stopAfterPermissionCancel?: boolean;
+        settledResult?: ToolResult;
       },
     ) => {
       executionStatus = opts.executionStatus;
       terminalStatus = opts.status;
       spanError = opts.status === 'error' ? error.message : undefined;
       cleanupAgentToolResources();
+      const errorParts = errorResponse(
+        error,
+        toolName,
+        opts.status,
+        opts.errorType,
+      );
       if (toolName !== ToolNames.TODO_WRITE) {
         try {
-          await this.toolCallEmitter.emitError(callId, toolName, error);
+          if (opts.settledResult) {
+            await this.toolCallEmitter.emitResult({
+              callId,
+              toolName,
+              args,
+              message: errorParts,
+              error,
+              success: false,
+              artifacts: opts.settledResult.artifacts,
+              persistedOutputFiles: opts.settledResult.persistedOutputFiles,
+            });
+          } else {
+            await this.toolCallEmitter.emitError(callId, toolName, error);
+          }
         } catch (emitError) {
           debugLogger.debug(
             '[Session.runTool] Failed to emit terminal tool update',
@@ -9031,13 +9051,6 @@ export class Session implements SessionContext {
           );
         }
       }
-
-      const errorParts = errorResponse(
-        error,
-        toolName,
-        opts.status,
-        opts.errorType,
-      );
       if (executeAttempted && !producerObserved) {
         observeToolResultBoundary({
           stage: 'producer',
@@ -9045,7 +9058,14 @@ export class Session implements SessionContext {
           promptId,
           toolCallId: callId,
           toolName,
-          artifacts: [toolResultBoundaryArtifact(undefined, undefined)],
+          artifacts: [
+            opts.settledResult
+              ? toolResultBoundaryArtifact(
+                  opts.settledResult.persistedOutputFiles,
+                  opts.settledResult.artifacts,
+                )
+              : toolResultBoundaryArtifact([], []),
+          ],
           values: () => toolResultPartDiagnosticValues(errorParts),
         });
         producerObserved = true;
@@ -9054,6 +9074,7 @@ export class Session implements SessionContext {
         callId,
         toolName,
         responseParts: errorParts,
+        persistedOutputFiles: opts.settledResult?.persistedOutputFiles,
         policyToolName: guardContext.policyToolName,
         toolType,
         executionErrorType:
@@ -9065,6 +9086,7 @@ export class Session implements SessionContext {
           status: opts.status,
           executionStatus,
           resultDisplay: undefined,
+          artifacts: opts.settledResult?.artifacts,
           error: opts.status === 'error' ? error : undefined,
           errorType: opts.status === 'error' ? opts.errorType : undefined,
         },
@@ -10497,6 +10519,7 @@ export class Session implements SessionContext {
                   status: 'cancelled',
                   errorType: undefined,
                   executionStatus,
+                  settledResult: toolResult,
                 },
               );
             }
@@ -10514,6 +10537,7 @@ export class Session implements SessionContext {
                 status: 'error',
                 errorType: ToolErrorType.EXECUTION_DENIED,
                 executionStatus,
+                settledResult: toolResult,
               });
             }
 

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -8916,6 +8916,8 @@ export class Session implements SessionContext {
     let executionStatus: ToolExecutionStatus = 'not_started';
     let executionErrorType: ToolErrorType | undefined;
     let executeReturned = false;
+    let executeAttempted = false;
+    let producerObserved = false;
     let terminalStatus: 'success' | 'error' | 'cancelled' | undefined;
     let toolType: 'native' | 'mcp' = 'native';
     let mcpServerName: string | undefined = undefined;
@@ -9036,6 +9038,18 @@ export class Session implements SessionContext {
         opts.status,
         opts.errorType,
       );
+      if (executeAttempted && !executeReturned && !producerObserved) {
+        observeToolResultBoundary({
+          stage: 'producer',
+          sessionId: this.sessionId,
+          promptId,
+          toolCallId: callId,
+          toolName,
+          artifacts: [toolResultBoundaryArtifact(undefined, undefined)],
+          values: () => toolResultPartDiagnosticValues(errorParts),
+        });
+        producerObserved = true;
+      }
       queueToolResultRecord?.(fc, {
         callId,
         toolName,
@@ -10291,6 +10305,7 @@ export class Session implements SessionContext {
             // Set the attempted outcome immediately before calling execute so
             // synchronous throws are classified as execution failures.
             executionStatus = 'error';
+            executeAttempted = true;
             try {
               toolResult = await invocation.execute(
                 activeToolAbortSignal,
@@ -10389,6 +10404,7 @@ export class Session implements SessionContext {
                 : []),
             ],
           });
+          producerObserved = true;
 
           // Clean up event listeners
           cleanupAgentToolResources();

--- a/packages/cli/src/acp-integration/session/SubAgentTracker.ts
+++ b/packages/cli/src/acp-integration/session/SubAgentTracker.ts
@@ -186,6 +186,7 @@ export class SubAgentTracker {
           success: event.success,
           message: event.responseParts ?? [],
           resultDisplay: event.resultDisplay,
+          boundaryArtifact: event.boundaryArtifact,
           args: state?.args,
           subagentMeta: this.subagentMeta,
         })

--- a/packages/cli/src/acp-integration/session/emitters/tool-call-emitter.test.ts
+++ b/packages/cli/src/acp-integration/session/emitters/tool-call-emitter.test.ts
@@ -12,6 +12,7 @@ import type {
   SubagentMeta,
 } from '../types.js';
 import type {
+  AgentResultDisplay,
   Config,
   ToolRegistry,
   AnyDeclarativeTool,
@@ -1011,6 +1012,49 @@ describe('ToolCallEmitter', () => {
         expect(call._meta).toEqual({
           toolName: 'test_tool',
           provenance: 'builtin',
+        });
+      });
+
+      it('should omit diagnostic artifact summaries from rawOutput', async () => {
+        const resultDisplay: AgentResultDisplay = {
+          type: 'task_execution',
+          subagentName: 'test-agent',
+          taskDescription: 'Test task',
+          taskPrompt: 'Test prompt',
+          status: 'completed',
+          toolCalls: [
+            {
+              callId: 'child-call',
+              name: 'read_file',
+              status: 'success',
+              resultDisplay: 'done',
+              boundaryArtifact: { state: 'reusable', kinds: ['file'] },
+            },
+          ],
+        };
+
+        await emitter.emitResult({
+          toolName: 'task',
+          callId: 'parent-call',
+          success: true,
+          message: [],
+          resultDisplay,
+        });
+
+        expect(sendUpdateSpy.mock.calls[0][0].rawOutput).toEqual({
+          ...resultDisplay,
+          toolCalls: [
+            {
+              callId: 'child-call',
+              name: 'read_file',
+              status: 'success',
+              resultDisplay: 'done',
+            },
+          ],
+        });
+        expect(resultDisplay.toolCalls?.[0].boundaryArtifact).toEqual({
+          state: 'reusable',
+          kinds: ['file'],
         });
       });
     });

--- a/packages/cli/src/acp-integration/session/emitters/tool-call-emitter.ts
+++ b/packages/cli/src/acp-integration/session/emitters/tool-call-emitter.ts
@@ -22,6 +22,7 @@ import type {
 import {
   formatVisionBridgeNoticeDisplay,
   isVisionBridgeNoticeDisplay,
+  toolResultBoundaryArtifact,
   ToolNames,
   Kind,
 } from '@qwen-code/qwen-code-core';
@@ -30,6 +31,7 @@ import {
   createTranscriptToolCallStartUpdate,
 } from '@qwen-code/acp-bridge/transcriptReplay';
 import { sanitizeTerminalText } from '../../../ui/utils/textUtils.js';
+import { associateAcpToolResultArtifact } from '../../../utils/tool-result-boundary-diagnostics.js';
 
 const KIND_MAP: Record<Kind, ToolKind> = {
   [Kind.Read]: 'read',
@@ -187,24 +189,31 @@ export class ToolCallEmitter extends BaseEmitter {
       params.toolName,
       params.subagentMeta,
     );
-    await this.sendUpdate(
-      createTranscriptToolCallResultUpdate({
-        toolName: params.toolName,
-        callId: params.callId,
-        success: params.success,
-        message: params.message,
-        resultDisplay: params.resultDisplay,
-        errorMessage: params.error?.message,
-        artifacts: params.artifacts,
-        contentPrefix: buildToolResultContentPrefix(params.resultDisplay),
-        timestamp: params.timestamp,
-        extra: {
-          ...params.subagentMeta,
-          provenance: provenance.provenance,
-          ...(provenance.serverId ? { serverId: provenance.serverId } : {}),
-        },
-      }),
+    const update = createTranscriptToolCallResultUpdate({
+      toolName: params.toolName,
+      callId: params.callId,
+      success: params.success,
+      message: params.message,
+      resultDisplay: params.resultDisplay,
+      errorMessage: params.error?.message,
+      artifacts: params.artifacts,
+      contentPrefix: buildToolResultContentPrefix(params.resultDisplay),
+      timestamp: params.timestamp,
+      extra: {
+        ...params.subagentMeta,
+        provenance: provenance.provenance,
+        ...(provenance.serverId ? { serverId: provenance.serverId } : {}),
+      },
+    });
+    associateAcpToolResultArtifact(
+      update,
+      params.boundaryArtifact ??
+        toolResultBoundaryArtifact(
+          params.persistedOutputFiles,
+          params.artifacts,
+        ),
     );
+    await this.sendUpdate(update);
   }
 
   /**

--- a/packages/cli/src/acp-integration/session/emitters/tool-call-emitter.ts
+++ b/packages/cli/src/acp-integration/session/emitters/tool-call-emitter.ts
@@ -53,6 +53,36 @@ const KIND_MAP: Record<Kind, ToolKind> = {
   [Kind.Other]: 'other',
 };
 
+function stripBoundaryArtifactsFromRawOutput(resultDisplay: unknown): unknown {
+  if (
+    typeof resultDisplay !== 'object' ||
+    resultDisplay === null ||
+    !('type' in resultDisplay) ||
+    resultDisplay.type !== 'task_execution' ||
+    !('toolCalls' in resultDisplay) ||
+    !Array.isArray(resultDisplay.toolCalls)
+  ) {
+    return resultDisplay;
+  }
+
+  let changed = false;
+  const toolCalls = resultDisplay.toolCalls.map((toolCall) => {
+    if (
+      typeof toolCall !== 'object' ||
+      toolCall === null ||
+      !('boundaryArtifact' in toolCall)
+    ) {
+      return toolCall;
+    }
+    const rawOutputToolCall: Record<string, unknown> = { ...toolCall };
+    delete rawOutputToolCall['boundaryArtifact'];
+    changed = true;
+    return rawOutputToolCall;
+  });
+
+  return changed ? { ...resultDisplay, toolCalls } : resultDisplay;
+}
+
 /**
  * Unified tool call event emitter.
  *
@@ -194,7 +224,7 @@ export class ToolCallEmitter extends BaseEmitter {
       callId: params.callId,
       success: params.success,
       message: params.message,
-      resultDisplay: params.resultDisplay,
+      resultDisplay: stripBoundaryArtifactsFromRawOutput(params.resultDisplay),
       errorMessage: params.error?.message,
       artifacts: params.artifacts,
       contentPrefix: buildToolResultContentPrefix(params.resultDisplay),

--- a/packages/cli/src/acp-integration/session/history-replay-page.test.ts
+++ b/packages/cli/src/acp-integration/session/history-replay-page.test.ts
@@ -24,6 +24,17 @@ import {
   replayTranscriptRecordPage,
 } from './history-replay-page.js';
 
+const observeAcpProjectionMock = vi.hoisted(() => vi.fn());
+vi.mock(
+  '../../utils/tool-result-boundary-diagnostics.js',
+  async (original) => ({
+    ...(await original<
+      typeof import('../../utils/tool-result-boundary-diagnostics.js')
+    >()),
+    observeAcpToolResultProjection: observeAcpProjectionMock,
+  }),
+);
+
 const SESSION_ID = '550e8400-e29b-41d4-a716-446655440000';
 const TIMESTAMP = '2026-07-12T00:00:00.000Z';
 const GOAL_STATE: GoalSnapshotV2 = {
@@ -227,6 +238,7 @@ describe('history replay page', () => {
   });
 
   it('lifts record timestamps for bulk replay callers', async () => {
+    observeAcpProjectionMock.mockClear();
     const result = await collectHistoryReplayUpdates({
       sessionId: SESSION_ID,
       records: [userRecord()],
@@ -239,6 +251,11 @@ describe('history replay page', () => {
         timestamp: Date.parse(TIMESTAMP),
       }),
     ]);
+    const deliveredUpdate = result.updates[0];
+    const projectionCall = observeAcpProjectionMock.mock.calls.find(
+      ([, , sessionId]) => sessionId === SESSION_ID,
+    );
+    expect(projectionCall?.[3]).toBe(deliveredUpdate);
   });
 
   it('fails incrementally before collecting an update above the count limit', async () => {

--- a/packages/cli/src/acp-integration/session/history-replay-page.ts
+++ b/packages/cli/src/acp-integration/session/history-replay-page.ts
@@ -202,11 +202,12 @@ function replayContext(
           _meta: { ...meta, 'qwen.session.recordId': activeRecordId },
         } as unknown as SessionUpdate;
       })();
+      const deliveredUpdate = liftSessionUpdateTimestamp(updateWithRecordId);
       observeAcpToolResultProjection(
         update,
         projectedUpdate,
         sessionId,
-        updateWithRecordId,
+        deliveredUpdate,
       );
       if (limits) {
         const updateCount = updates.length + 1;
@@ -220,7 +221,7 @@ function replayContext(
         }
         serializedUpdateBytes +=
           (updates.length === 0 ? 0 : 1) +
-          Buffer.byteLength(JSON.stringify(updateWithRecordId), 'utf8');
+          Buffer.byteLength(JSON.stringify(deliveredUpdate), 'utf8');
         if (serializedUpdateBytes > limits.maxBytes) {
           throw new HistoryReplayLimitError(
             sessionId,
@@ -230,7 +231,7 @@ function replayContext(
           );
         }
       }
-      updates.push(updateWithRecordId);
+      updates.push(deliveredUpdate);
     },
     setActiveRecordId: (recordId: string | null) => {
       activeRecordId = recordId;
@@ -280,22 +281,24 @@ export async function collectHistoryReplayUpdates({
       updates.length,
       error,
     );
-    return { updates: liftSessionUpdateTimestamps(updates), replayError };
+    return { updates, replayError };
   }
-  return { updates: liftSessionUpdateTimestamps(updates) };
+  return { updates };
+}
+
+function liftSessionUpdateTimestamp(update: SessionUpdate): SessionUpdate {
+  const record = update as Record<string, unknown>;
+  const meta = record['_meta'];
+  const timestamp = isObjectRecord(meta) ? meta['timestamp'] : undefined;
+  return typeof timestamp === 'number' || typeof timestamp === 'string'
+    ? ({ ...record, timestamp } as unknown as SessionUpdate)
+    : update;
 }
 
 export function liftSessionUpdateTimestamps(
   updates: SessionUpdate[],
 ): SessionUpdate[] {
-  return updates.map((update) => {
-    const record = update as Record<string, unknown>;
-    const meta = record['_meta'];
-    const timestamp = isObjectRecord(meta) ? meta['timestamp'] : undefined;
-    return typeof timestamp === 'number' || typeof timestamp === 'string'
-      ? ({ ...record, timestamp } as unknown as SessionUpdate)
-      : update;
-  });
+  return updates.map(liftSessionUpdateTimestamp);
 }
 
 export interface ReplayedTranscriptPage {
@@ -361,7 +364,7 @@ export async function replayTranscriptRecordPage({
       : undefined;
 
   return {
-    updates: liftSessionUpdateTimestamps(updates),
+    updates,
     ...(nextCursor ? { nextCursor } : {}),
     hasMore: replayError === undefined && page.hasMore,
     startTime: page.startTime,

--- a/packages/cli/src/acp-integration/session/history-replay-page.ts
+++ b/packages/cli/src/acp-integration/session/history-replay-page.ts
@@ -295,12 +295,6 @@ function liftSessionUpdateTimestamp(update: SessionUpdate): SessionUpdate {
     : update;
 }
 
-export function liftSessionUpdateTimestamps(
-  updates: SessionUpdate[],
-): SessionUpdate[] {
-  return updates.map(liftSessionUpdateTimestamp);
-}
-
 export interface ReplayedTranscriptPage {
   updates: SessionUpdate[];
   nextCursor?: string;

--- a/packages/cli/src/acp-integration/session/history-replay-page.ts
+++ b/packages/cli/src/acp-integration/session/history-replay-page.ts
@@ -19,6 +19,7 @@ import type { SessionUpdate } from '@agentclientprotocol/sdk';
 import type { TranscriptReplayStateV1 } from '@qwen-code/acp-bridge/transcriptReplay';
 import { Buffer } from 'node:buffer';
 import { projectAcpToolResultUpdate } from './acp-tool-result-text-projection.js';
+import { observeAcpToolResultProjection } from '../../utils/tool-result-boundary-diagnostics.js';
 import { HistoryReplayer } from './history-replayer.js';
 import type { PendingReplayToolCall } from './history-replayer.js';
 import type { CumulativeUsage, SessionEmitterContext } from './types.js';
@@ -201,6 +202,12 @@ function replayContext(
           _meta: { ...meta, 'qwen.session.recordId': activeRecordId },
         } as unknown as SessionUpdate;
       })();
+      observeAcpToolResultProjection(
+        update,
+        projectedUpdate,
+        sessionId,
+        updateWithRecordId,
+      );
       if (limits) {
         const updateCount = updates.length + 1;
         if (updateCount > limits.maxUpdates) {

--- a/packages/cli/src/acp-integration/session/history-replayer.test.ts
+++ b/packages/cli/src/acp-integration/session/history-replayer.test.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Deliberately NOT mocked: `writeStderrLineSafe` is the thing under test in
@@ -16,6 +19,7 @@ import {
   MISSING_TOOL_RESULT_MESSAGE,
 } from './history-replayer.js';
 import type { SessionContext } from './types.js';
+import { ChatRecordingService } from '@qwen-code/qwen-code-core';
 import type {
   Config,
   ChatRecord,
@@ -877,23 +881,64 @@ describe('HistoryReplayer', () => {
       });
     });
 
-    it('should replay structured artifacts from stored tool results', async () => {
-      const record = createToolResultRecord('read_file', 'File contents here');
+    it('should replay structured artifacts persisted by the recorder', async () => {
+      const projectDir = mkdtempSync(join(tmpdir(), 'qwen-history-replay-'));
+      const sessionId = 'recorded-session';
       const artifacts = [
         {
+          kind: 'link' as const,
           title: 'Replay artifact',
           url: 'https://example.com/replayed',
         },
       ];
-      record.toolCallResult!.artifacts = artifacts;
-
-      await replayer.replay([record]);
-
-      expect(sentUpdates()[0]).toMatchObject({
-        _meta: {
+      try {
+        const recorder = new ChatRecordingService(
+          {
+            getSessionId: () => sessionId,
+            getProjectRoot: () => projectDir,
+            getCliVersion: () => '1.0.0',
+            getResumedSessionData: () => undefined,
+            storage: { getProjectDir: () => projectDir },
+          } as unknown as Config,
+          undefined,
+          false,
+        );
+        const responseParts = [
+          {
+            functionResponse: {
+              name: 'read_file',
+              response: { result: 'ok' },
+            },
+          },
+        ];
+        recorder.recordToolResult(responseParts, {
+          callId: 'call-123',
+          status: 'success',
+          resultDisplay: 'File contents here',
+          responseParts,
+          persistedOutputFiles: ['/private/tool-result.txt'],
           artifacts,
-        },
-      });
+        });
+        await recorder.flush();
+
+        const jsonl = readFileSync(
+          join(projectDir, 'chats', `${sessionId}.jsonl`),
+          'utf8',
+        );
+        expect(jsonl).not.toContain('/private/tool-result.txt');
+        const storedRecord = JSON.parse(jsonl.trim()) as ChatRecord;
+        expect(storedRecord.toolCallResult?.artifacts).toEqual(artifacts);
+
+        await replayer.replay([storedRecord]);
+
+        expect(sentUpdates()[0]).toMatchObject({
+          _meta: {
+            artifacts,
+          },
+        });
+      } finally {
+        rmSync(projectDir, { recursive: true, force: true });
+      }
     });
 
     it('should emit failed status for tool results with errors', async () => {

--- a/packages/cli/src/acp-integration/session/types.ts
+++ b/packages/cli/src/acp-integration/session/types.ts
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Config, ToolArtifact } from '@qwen-code/qwen-code-core';
+import type {
+  Config,
+  ToolArtifact,
+  ToolResultBoundaryArtifact,
+} from '@qwen-code/qwen-code-core';
 import type { Part } from '@google/genai';
 import type {
   SessionUpdate,
@@ -123,6 +127,8 @@ export interface ToolCallResultParams {
   error?: Error;
   /** Structured artifacts produced by the tool result. */
   artifacts?: ToolArtifact[];
+  persistedOutputFiles?: string[];
+  boundaryArtifact?: ToolResultBoundaryArtifact;
   /** Original args (fallback for TodoWriteTool todos extraction) */
   args?: Record<string, unknown>;
   /** Optional subagent metadata */

--- a/packages/cli/src/nonInteractive/io/BaseJsonOutputAdapter.ts
+++ b/packages/cli/src/nonInteractive/io/BaseJsonOutputAdapter.ts
@@ -21,6 +21,7 @@ import {
   isVisionBridgeNoticeDisplay,
   ToolErrorType,
   parseAndFormatApiError,
+  toolResultBoundaryArtifact,
 } from '@qwen-code/qwen-code-core';
 import type { Part, GenerateContentResponseUsageMetadata } from '@google/genai';
 import type {
@@ -43,6 +44,7 @@ import type {
 } from '../types.js';
 import { functionResponsePartsToString } from '../../utils/nonInteractiveHelpers.js';
 import { projectHeadlessToolResultContent } from './headless-tool-result-text-projection.js';
+import { observeHeadlessToolResultProjection } from '../../utils/tool-result-boundary-diagnostics.js';
 
 /**
  * Internal state for managing a single message context (main agent or subagent).
@@ -1059,8 +1061,10 @@ export abstract class BaseJsonOutputAdapter {
       is_error: hasError,
     };
     const content = toolResultContent(response);
+    let projectedContent: string | undefined;
     if (content !== undefined) {
-      block.content = projectHeadlessToolResultContent(content);
+      projectedContent = projectHeadlessToolResultContent(content);
+      block.content = projectedContent;
     }
 
     const message: CLIUserMessage = {
@@ -1073,6 +1077,19 @@ export abstract class BaseJsonOutputAdapter {
         content: [block],
       },
     };
+    if (content !== undefined && projectedContent !== undefined) {
+      observeHeadlessToolResultProjection(
+        message,
+        content,
+        projectedContent,
+        request.callId,
+        response.boundaryArtifact ??
+          toolResultBoundaryArtifact(
+            response.persistedOutputFiles,
+            response.artifacts,
+          ),
+      );
+    }
     this.emitMessageImpl(message);
   }
 

--- a/packages/cli/src/nonInteractive/io/JsonOutputAdapter.ts
+++ b/packages/cli/src/nonInteractive/io/JsonOutputAdapter.ts
@@ -11,6 +11,7 @@ import {
   type JsonOutputAdapterInterface,
   type ResultOptions,
 } from './BaseJsonOutputAdapter.js';
+import { observeHeadlessJsonToolResultWire } from '../../utils/tool-result-boundary-diagnostics.js';
 
 /**
  * JSON output adapter that collects all messages and emits them
@@ -74,7 +75,9 @@ export class JsonOutputAdapter
     } else {
       // Emit the entire messages array as JSON (includes all main agent + subagent messages)
       const json = JSON.stringify(this.messages);
-      process.stdout.write(`${json}\n`);
+      const frame = `${json}\n`;
+      observeHeadlessJsonToolResultWire(this.messages, frame);
+      process.stdout.write(frame);
     }
   }
 

--- a/packages/cli/src/nonInteractive/io/StreamJsonOutputAdapter.ts
+++ b/packages/cli/src/nonInteractive/io/StreamJsonOutputAdapter.ts
@@ -29,6 +29,7 @@ import {
   type ResultOptions,
   type JsonOutputAdapterInterface,
 } from './BaseJsonOutputAdapter.js';
+import { observeHeadlessToolResultWire } from '../../utils/tool-result-boundary-diagnostics.js';
 
 /**
  * Stream JSON output adapter that emits messages immediately
@@ -67,7 +68,11 @@ export class StreamJsonOutputAdapter
     }
 
     // Emit messages immediately in stream mode
-    this.outputStream.write(`${JSON.stringify(message)}\n`);
+    const frame = `${JSON.stringify(message)}\n`;
+    if ('session_id' in message) {
+      observeHeadlessToolResultWire(message as CLIMessage, frame);
+    }
+    this.outputStream.write(frame);
   }
 
   /**

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -2198,7 +2198,14 @@ export async function runNonInteractive(
             toolName: request.name,
             responseParts: response.responseParts,
             persistedOutputFiles: response.persistedOutputFiles,
+            artifacts: response.artifacts,
           })),
+          new Map(
+            orderedResponses.map(({ request }) => [
+              request.callId,
+              request.prompt_id,
+            ]),
+          ),
         );
 
         const chatRecordingService = config.getChatRecordingService?.();
@@ -2213,6 +2220,8 @@ export async function runNonInteractive(
               statusByResponse.get(response) ??
               (response.error ? 'error' : 'success'),
             resultDisplay: response.resultDisplay,
+            persistedOutputFiles: finalized[index].persistedOutputFiles,
+            artifacts: finalized[index].artifacts,
             error: response.error,
             errorType: response.errorType,
             executionStatus: response.executionStatus,

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -3633,7 +3633,20 @@ export const useGeminiStream = (
                   toolName: request.name,
                   responseParts: response.responseParts,
                   persistedOutputFiles: response.persistedOutputFiles,
+                  artifacts: response.artifacts,
                 }),
+              ),
+              new Map(
+                immediateDuplicateToolResponses.responses.flatMap(
+                  ({ request }) => {
+                    const promptId =
+                      request.prompt_id ??
+                      immediateDuplicateToolResponses.promptId;
+                    return promptId
+                      ? [[request.callId, promptId] as const]
+                      : [];
+                  },
+                ),
               ),
             );
             const responseParts = finalized.flatMap(
@@ -3648,6 +3661,8 @@ export const useGeminiStream = (
                     callId: request.callId,
                     status: response.error ? 'error' : 'success',
                     resultDisplay: response.resultDisplay,
+                    persistedOutputFiles: finalized[index].persistedOutputFiles,
+                    artifacts: finalized[index].artifacts,
                     error: response.error,
                     errorType: response.errorType,
                     executionStatus: response.executionStatus,
@@ -4392,7 +4407,15 @@ export const useGeminiStream = (
           toolName: request.name,
           responseParts: response.responseParts,
           persistedOutputFiles: response.persistedOutputFiles,
+          artifacts: response.artifacts,
         })),
+        new Map(
+          orderedResponses.flatMap(({ request }) =>
+            request.prompt_id
+              ? [[request.callId, request.prompt_id] as const]
+              : [],
+          ),
+        ),
       );
       const responsesToSend = finalizedResponses.flatMap(
         (entry) => entry.responseParts,
@@ -4405,6 +4428,9 @@ export const useGeminiStream = (
             callId: request.callId,
             status,
             resultDisplay: response.resultDisplay,
+            persistedOutputFiles:
+              finalizedResponses[index].persistedOutputFiles,
+            artifacts: finalizedResponses[index].artifacts,
             error: response.error,
             errorType: response.errorType,
             executionStatus: response.executionStatus,

--- a/packages/cli/src/utils/nonInteractiveHelpers.test.ts
+++ b/packages/cli/src/utils/nonInteractiveHelpers.test.ts
@@ -783,6 +783,7 @@ describe('createAgentToolProgressHandler', () => {
           args: { arg1: 'value1' },
           status: 'success',
           responseParts,
+          boundaryArtifact: { state: 'reusable', kinds: ['file'] },
         },
       ],
     };
@@ -807,6 +808,7 @@ describe('createAgentToolProgressHandler', () => {
       expect.objectContaining({
         callId: 'tool-1',
         responseParts,
+        boundaryArtifact: { state: 'reusable', kinds: ['file'] },
       }),
       'parent-tool-id',
     );

--- a/packages/cli/src/utils/nonInteractiveHelpers.ts
+++ b/packages/cli/src/utils/nonInteractiveHelpers.ts
@@ -360,6 +360,7 @@ export function createAgentToolProgressHandler(
       toolCall.status === 'failed' ? ToolErrorType.EXECUTION_FAILED : undefined,
     resultDisplay: toolCall.resultDisplay,
     responseParts: toolCall.responseParts || [],
+    boundaryArtifact: toolCall.boundaryArtifact,
   });
 
   /**

--- a/packages/cli/src/utils/tool-result-boundary-diagnostics.test.ts
+++ b/packages/cli/src/utils/tool-result-boundary-diagnostics.test.ts
@@ -1,0 +1,343 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionUpdate } from '@agentclientprotocol/sdk';
+import { LOAD_REPLAY_META_KEY } from '@qwen-code/acp-bridge/bridgeTypes';
+import type { ToolResultBoundaryObservation } from '@qwen-code/qwen-code-core';
+import type { CLIUserMessage } from '../nonInteractive/types.js';
+
+const { mockObserveBoundary } = vi.hoisted(() => ({
+  mockObserveBoundary: vi.fn(
+    (_observation: ToolResultBoundaryObservation) => true,
+  ),
+}));
+
+vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@qwen-code/qwen-code-core')>()),
+  observeToolResultBoundary: mockObserveBoundary,
+}));
+
+import {
+  associateAcpToolResultArtifact,
+  observeAcpToolResultProjection,
+  observeAcpToolResultWire,
+  observeHeadlessJsonToolResultWire,
+  observeHeadlessToolResultProjection,
+  observeHeadlessToolResultWire,
+} from './tool-result-boundary-diagnostics.js';
+
+function acpUpdate(text: string, toolCallId = 'call-secret'): SessionUpdate {
+  return {
+    sessionUpdate: 'tool_call_update',
+    toolCallId,
+    content: [
+      {
+        type: 'content',
+        content: { type: 'text', text },
+      },
+    ],
+    rawOutput: text,
+  };
+}
+
+function headlessMessage(
+  content: string,
+  toolCallId = 'call-secret',
+): CLIUserMessage {
+  return {
+    type: 'user',
+    session_id: 'session-secret',
+    parent_tool_use_id: null,
+    message: {
+      role: 'user',
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: toolCallId,
+          content,
+        },
+      ],
+    },
+  };
+}
+
+describe('CLI tool-result boundary diagnostics', () => {
+  beforeEach(() => {
+    mockObserveBoundary.mockReset().mockReturnValue(true);
+  });
+
+  it('correlates ACP projection with the exact direct NDJSON writer frame', () => {
+    const input = acpUpdate('original');
+    const output = acpUpdate('projected');
+    associateAcpToolResultArtifact(input, {
+      state: 'reusable',
+      kinds: ['file', 'image'],
+    });
+
+    observeAcpToolResultProjection(input, output, 'session-secret');
+    observeAcpToolResultWire(
+      {
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: { sessionId: 'session-secret', update: output },
+      },
+      1_234,
+    );
+
+    expect(mockObserveBoundary).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        stage: 'acp_projection_input',
+        mutated: true,
+        sessionId: 'session-secret',
+        toolCallId: 'call-secret',
+        artifacts: [{ state: 'reusable', kinds: ['file', 'image'] }],
+        values: expect.any(Function),
+      }),
+    );
+    const projectionValues = mockObserveBoundary.mock.calls[0]?.[0].values;
+    expect(
+      typeof projectionValues === 'function'
+        ? projectionValues()
+        : projectionValues,
+    ).toEqual([
+      { representation: 'acp_content', value: 'original' },
+      { representation: 'acp_raw_output', value: 'original' },
+    ]);
+    expect(mockObserveBoundary).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        stage: 'acp_wire',
+        wireUtf8Bytes: 1_235,
+        artifacts: [{ state: 'reusable', kinds: ['file', 'image'] }],
+        values: expect.any(Function),
+      }),
+    );
+    const wireValues = mockObserveBoundary.mock.calls.at(-1)?.[0]?.values;
+    expect(
+      typeof wireValues === 'function' ? wireValues() : wireValues,
+    ).toEqual([
+      { representation: 'acp_content', value: 'projected' },
+      { representation: 'acp_raw_output', value: 'projected' },
+    ]);
+  });
+
+  it('correlates the delivered replay clone inside a bulk response', () => {
+    const input = acpUpdate('original');
+    const projected = acpUpdate('projected');
+    const delivered = {
+      ...projected,
+      _meta: { 'qwen.session.recordId': 'record-secret' },
+    } as SessionUpdate;
+    associateAcpToolResultArtifact(input, {
+      state: 'none',
+      kinds: ['link'],
+    });
+    observeAcpToolResultProjection(
+      input,
+      projected,
+      'session-secret',
+      delivered,
+    );
+
+    observeAcpToolResultWire(
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          _meta: {
+            [LOAD_REPLAY_META_KEY]: { v: 1, updates: [delivered] },
+          },
+        },
+      },
+      2_000,
+    );
+
+    expect(mockObserveBoundary).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        stage: 'acp_wire',
+        wireUtf8Bytes: 2_001,
+        artifacts: [{ state: 'none', kinds: ['link'] }],
+      }),
+    );
+  });
+
+  it('preserves per-call artifact summaries in bulk ACP responses', () => {
+    const firstInput = acpUpdate('first-original', 'first-call');
+    const firstProjected = acpUpdate('first-projected', 'first-call');
+    const firstDelivered = { ...firstProjected };
+    const secondInput = acpUpdate('second-original', 'second-call');
+    const secondProjected = acpUpdate('second-projected', 'second-call');
+    const secondDelivered = { ...secondProjected };
+
+    associateAcpToolResultArtifact(firstInput, {
+      state: 'reusable',
+      kinds: ['file'],
+    });
+    observeAcpToolResultProjection(
+      firstInput,
+      firstProjected,
+      'session-secret',
+      firstDelivered,
+    );
+    associateAcpToolResultArtifact(secondInput, {
+      state: 'none',
+      kinds: ['image'],
+    });
+    observeAcpToolResultProjection(
+      secondInput,
+      secondProjected,
+      'session-secret',
+      secondDelivered,
+    );
+
+    observeAcpToolResultWire(
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          _meta: {
+            [LOAD_REPLAY_META_KEY]: {
+              v: 1,
+              updates: [firstDelivered, secondDelivered],
+            },
+          },
+        },
+      },
+      3_000,
+    );
+
+    expect(mockObserveBoundary).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        stage: 'acp_wire',
+        toolCallId: undefined,
+        toolCallIds: ['first-call', 'second-call'],
+        wireUtf8Bytes: 3_001,
+        artifacts: [
+          { state: 'reusable', kinds: ['file'] },
+          { state: 'none', kinds: ['image'] },
+        ],
+      }),
+    );
+  });
+
+  it('correlates Headless projection with its writer frame', () => {
+    const message = headlessMessage('projected');
+    observeHeadlessToolResultProjection(
+      message,
+      'original',
+      'projected',
+      'call-secret',
+      { state: 'reusable', kinds: ['file'] },
+    );
+    observeHeadlessToolResultWire(message, 'x'.repeat(777));
+
+    expect(mockObserveBoundary).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        stage: 'headless_projection_input',
+        mutated: true,
+        artifacts: [{ state: 'reusable', kinds: ['file'] }],
+        values: [{ representation: 'headless_content', value: 'original' }],
+      }),
+    );
+    expect(mockObserveBoundary).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        stage: 'headless_wire',
+        sessionId: 'session-secret',
+        toolCallId: 'call-secret',
+        wireUtf8Bytes: 777,
+        artifacts: [{ state: 'reusable', kinds: ['file'] }],
+        values: [{ representation: 'headless_content', value: 'projected' }],
+      }),
+    );
+  });
+
+  it('logs one exact wire event for a batch JSON frame', () => {
+    const first = headlessMessage('first-projected', 'first-call');
+    const second = headlessMessage('second-projected', 'second-call');
+    observeHeadlessToolResultProjection(
+      first,
+      'first-original',
+      'first-projected',
+      'first-call',
+      { state: 'reusable', kinds: ['file'] },
+    );
+    observeHeadlessToolResultProjection(
+      second,
+      'second-original',
+      'second-projected',
+      'second-call',
+      { state: 'none', kinds: ['image'] },
+    );
+
+    observeHeadlessJsonToolResultWire([first, second], 'x'.repeat(999));
+
+    expect(mockObserveBoundary).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        stage: 'headless_wire',
+        toolCallId: undefined,
+        toolCallIds: ['first-call', 'second-call'],
+        wireUtf8Bytes: 999,
+        artifacts: [
+          { state: 'reusable', kinds: ['file'] },
+          { state: 'none', kinds: ['image'] },
+        ],
+        values: [
+          {
+            representation: 'headless_content',
+            value: 'first-projected',
+          },
+          {
+            representation: 'headless_content',
+            value: 'second-projected',
+          },
+        ],
+      }),
+    );
+  });
+
+  it('does not retain objects when neither projection event is eligible', () => {
+    mockObserveBoundary.mockReturnValue(false);
+    const output = acpUpdate('small');
+    observeAcpToolResultProjection(output, output, 'session-secret');
+    mockObserveBoundary.mockClear();
+
+    observeAcpToolResultWire(
+      {
+        method: 'session/update',
+        params: { update: output },
+      },
+      10,
+    );
+
+    expect(mockObserveBoundary).not.toHaveBeenCalled();
+  });
+
+  it('swallows observer failures at projection boundaries', () => {
+    mockObserveBoundary.mockImplementation(() => {
+      throw new Error('diagnostic failure');
+    });
+    const message = headlessMessage('projected');
+
+    expect(() =>
+      observeHeadlessToolResultProjection(
+        message,
+        'original',
+        'projected',
+        'call-secret',
+        { state: 'undecided', kinds: [] },
+      ),
+    ).not.toThrow();
+    expect(() =>
+      observeAcpToolResultProjection(
+        acpUpdate('original'),
+        acpUpdate('projected'),
+        'session-secret',
+      ),
+    ).not.toThrow();
+  });
+});

--- a/packages/cli/src/utils/tool-result-boundary-diagnostics.test.ts
+++ b/packages/cli/src/utils/tool-result-boundary-diagnostics.test.ts
@@ -99,6 +99,16 @@ describe('CLI tool-result boundary diagnostics', () => {
         values: expect.any(Function),
       }),
     );
+    expect(mockObserveBoundary).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        stage: 'acp_projection_output',
+        mutated: true,
+        sessionId: 'session-secret',
+        toolCallId: 'call-secret',
+        artifacts: [{ state: 'reusable', kinds: ['file', 'image'] }],
+      }),
+    );
     const projectionValues = mockObserveBoundary.mock.calls[0]?.[0].values;
     expect(
       typeof projectionValues === 'function'
@@ -161,6 +171,36 @@ describe('CLI tool-result boundary diagnostics', () => {
         stage: 'acp_wire',
         wireUtf8Bytes: 2_001,
         artifacts: [{ state: 'none', kinds: ['link'] }],
+      }),
+    );
+  });
+
+  it('correlates paged replay events with the ACP writer frame', () => {
+    const input = acpUpdate('original');
+    const projected = acpUpdate('projected');
+    const delivered = { ...projected, timestamp: 123 };
+    observeAcpToolResultProjection(
+      input,
+      projected,
+      'session-secret',
+      delivered,
+    );
+
+    observeAcpToolResultWire(
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          events: [{ v: 1, type: 'session_update', data: delivered }],
+        },
+      },
+      2_500,
+    );
+
+    expect(mockObserveBoundary).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        stage: 'acp_wire',
+        wireUtf8Bytes: 2_501,
       }),
     );
   });
@@ -242,6 +282,15 @@ describe('CLI tool-result boundary diagnostics', () => {
         mutated: true,
         artifacts: [{ state: 'reusable', kinds: ['file'] }],
         values: [{ representation: 'headless_content', value: 'original' }],
+      }),
+    );
+    expect(mockObserveBoundary).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        stage: 'headless_projection_output',
+        mutated: true,
+        artifacts: [{ state: 'reusable', kinds: ['file'] }],
+        values: [{ representation: 'headless_content', value: 'projected' }],
       }),
     );
     expect(mockObserveBoundary).toHaveBeenLastCalledWith(

--- a/packages/cli/src/utils/tool-result-boundary-diagnostics.test.ts
+++ b/packages/cli/src/utils/tool-result-boundary-diagnostics.test.ts
@@ -409,6 +409,23 @@ describe('CLI tool-result boundary diagnostics', () => {
     );
   });
 
+  it('does not observe the same replay-delivered ACP update twice', () => {
+    mockObserveBoundary.mockReturnValue(true);
+    const update = acpUpdate('large');
+
+    observeAcpToolResultProjection(update, update, 'session-secret');
+    expect(mockObserveBoundary).toHaveBeenCalledTimes(2);
+
+    observeAcpToolResultProjection(update, update, 'session-secret');
+    expect(mockObserveBoundary).toHaveBeenCalledTimes(2);
+
+    observeAcpToolResultWire(
+      { method: 'session/update', params: { update } },
+      20,
+    );
+    expect(mockObserveBoundary).toHaveBeenCalledTimes(3);
+  });
+
   it('swallows observer failures at projection boundaries', () => {
     mockObserveBoundary.mockImplementation(() => {
       throw new Error('diagnostic failure');

--- a/packages/cli/src/utils/tool-result-boundary-diagnostics.test.ts
+++ b/packages/cli/src/utils/tool-result-boundary-diagnostics.test.ts
@@ -121,6 +121,9 @@ describe('CLI tool-result boundary diagnostics', () => {
     expect(mockObserveBoundary).toHaveBeenLastCalledWith(
       expect.objectContaining({
         stage: 'acp_wire',
+        sessionId: 'session-secret',
+        toolCallId: 'call-secret',
+        mutated: true,
         wireUtf8Bytes: 1_235,
         artifacts: [{ state: 'reusable', kinds: ['file', 'image'] }],
         values: expect.any(Function),
@@ -242,7 +245,11 @@ describe('CLI tool-result boundary diagnostics', () => {
           _meta: {
             [LOAD_REPLAY_META_KEY]: {
               v: 1,
-              updates: [firstDelivered, secondDelivered],
+              updates: [
+                { sessionUpdate: 'plan', entries: [] },
+                firstDelivered,
+                secondDelivered,
+              ],
             },
           },
         },
@@ -273,7 +280,8 @@ describe('CLI tool-result boundary diagnostics', () => {
       'call-secret',
       { state: 'reusable', kinds: ['file'] },
     );
-    observeHeadlessToolResultWire(message, 'x'.repeat(777));
+    const frame = '汉😀';
+    observeHeadlessToolResultWire(message, frame);
 
     expect(mockObserveBoundary).toHaveBeenNthCalledWith(
       1,
@@ -298,7 +306,8 @@ describe('CLI tool-result boundary diagnostics', () => {
         stage: 'headless_wire',
         sessionId: 'session-secret',
         toolCallId: 'call-secret',
-        wireUtf8Bytes: 777,
+        mutated: true,
+        wireUtf8Bytes: Buffer.byteLength(frame, 'utf8'),
         artifacts: [{ state: 'reusable', kinds: ['file'] }],
         values: [{ representation: 'headless_content', value: 'projected' }],
       }),
@@ -323,7 +332,10 @@ describe('CLI tool-result boundary diagnostics', () => {
       { state: 'none', kinds: ['image'] },
     );
 
-    observeHeadlessJsonToolResultWire([first, second], 'x'.repeat(999));
+    observeHeadlessJsonToolResultWire(
+      [headlessMessage('uncorrelated'), first, second],
+      'x'.repeat(999),
+    );
 
     expect(mockObserveBoundary).toHaveBeenLastCalledWith(
       expect.objectContaining({
@@ -353,6 +365,14 @@ describe('CLI tool-result boundary diagnostics', () => {
     mockObserveBoundary.mockReturnValue(false);
     const output = acpUpdate('small');
     observeAcpToolResultProjection(output, output, 'session-secret');
+    expect(mockObserveBoundary).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ mutated: false }),
+    );
+    expect(mockObserveBoundary).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ mutated: false }),
+    );
     mockObserveBoundary.mockClear();
 
     observeAcpToolResultWire(
@@ -387,6 +407,39 @@ describe('CLI tool-result boundary diagnostics', () => {
         acpUpdate('projected'),
         'session-secret',
       ),
+    ).not.toThrow();
+  });
+
+  it('swallows observer failures at writer boundaries', () => {
+    const acpInput = acpUpdate('original');
+    const acpOutput = acpUpdate('projected');
+    const headless = headlessMessage('projected');
+    observeAcpToolResultProjection(acpInput, acpOutput, 'session-secret');
+    observeHeadlessToolResultProjection(
+      headless,
+      'original',
+      'projected',
+      'call-secret',
+      { state: 'undecided', kinds: [] },
+    );
+    mockObserveBoundary.mockImplementation(() => {
+      throw new Error('diagnostic failure');
+    });
+
+    expect(() =>
+      observeAcpToolResultWire(
+        {
+          method: 'session/update',
+          params: { sessionId: 'session-secret', update: acpOutput },
+        },
+        10,
+      ),
+    ).not.toThrow();
+    expect(() =>
+      observeHeadlessToolResultWire(headless, 'frame'),
+    ).not.toThrow();
+    expect(() =>
+      observeHeadlessJsonToolResultWire([headless], 'frame'),
     ).not.toThrow();
   });
 });

--- a/packages/cli/src/utils/tool-result-boundary-diagnostics.test.ts
+++ b/packages/cli/src/utils/tool-result-boundary-diagnostics.test.ts
@@ -203,6 +203,7 @@ describe('CLI tool-result boundary diagnostics', () => {
     expect(mockObserveBoundary).toHaveBeenLastCalledWith(
       expect.objectContaining({
         stage: 'acp_wire',
+        sessionId: 'session-secret',
         wireUtf8Bytes: 2_501,
       }),
     );
@@ -260,6 +261,7 @@ describe('CLI tool-result boundary diagnostics', () => {
     expect(mockObserveBoundary).toHaveBeenLastCalledWith(
       expect.objectContaining({
         stage: 'acp_wire',
+        sessionId: 'session-secret',
         toolCallId: undefined,
         toolCallIds: ['first-call', 'second-call'],
         wireUtf8Bytes: 3_001,
@@ -384,6 +386,27 @@ describe('CLI tool-result boundary diagnostics', () => {
     );
 
     expect(mockObserveBoundary).not.toHaveBeenCalled();
+  });
+
+  it('correlates eligible unmutated ACP updates with the writer', () => {
+    mockObserveBoundary.mockReturnValue(true);
+    const update = acpUpdate('large');
+    observeAcpToolResultProjection(update, update, 'session-secret');
+    mockObserveBoundary.mockClear();
+
+    observeAcpToolResultWire(
+      { method: 'session/update', params: { update } },
+      20,
+    );
+
+    expect(mockObserveBoundary).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: 'acp_wire',
+        sessionId: 'session-secret',
+        mutated: false,
+        wireUtf8Bytes: 21,
+      }),
+    );
   });
 
   it('swallows observer failures at projection boundaries', () => {

--- a/packages/cli/src/utils/tool-result-boundary-diagnostics.ts
+++ b/packages/cli/src/utils/tool-result-boundary-diagnostics.ts
@@ -1,0 +1,280 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { SessionUpdate } from '@agentclientprotocol/sdk';
+import { LOAD_REPLAY_META_KEY } from '@qwen-code/acp-bridge/bridgeTypes';
+import {
+  observeToolResultBoundary,
+  type ToolResultBoundaryArtifact,
+  type ToolResultBoundaryValue,
+} from '@qwen-code/qwen-code-core';
+import type { CLIMessage, ToolResultBlock } from '../nonInteractive/types.js';
+
+interface ProjectedToolResult {
+  mutated: boolean;
+  artifact: ToolResultBoundaryArtifact;
+}
+
+const acpUpdateArtifacts = new WeakMap<object, ToolResultBoundaryArtifact>();
+const projectedAcpUpdates = new WeakMap<object, ProjectedToolResult>();
+const projectedHeadlessMessages = new WeakMap<object, ProjectedToolResult>();
+
+export function associateAcpToolResultArtifact(
+  update: SessionUpdate,
+  artifact: ToolResultBoundaryArtifact,
+): void {
+  if (isObject(update)) acpUpdateArtifacts.set(update, artifact);
+}
+
+export function observeAcpToolResultProjection(
+  input: SessionUpdate,
+  output: SessionUpdate,
+  sessionId: string,
+  wireUpdate: SessionUpdate = output,
+): void {
+  try {
+    const mutated = input !== output;
+    const artifact = acpUpdateArtifacts.get(input) ?? {
+      state: 'undecided',
+      kinds: [],
+    };
+    const common = { sessionId, toolCallId: toolCallId(input) };
+    const inputEligible = observeToolResultBoundary({
+      stage: 'acp_projection_input',
+      ...common,
+      mutated,
+      artifacts: [artifact],
+      values: () => acpToolResultValues(input),
+    });
+    const outputEligible = observeToolResultBoundary({
+      stage: 'acp_projection_output',
+      ...common,
+      mutated,
+      artifacts: [artifact],
+      values: () => acpToolResultValues(output),
+    });
+    if ((inputEligible || outputEligible) && isObject(wireUpdate)) {
+      projectedAcpUpdates.set(wireUpdate, { mutated, artifact });
+    }
+  } catch {
+    // Diagnostics must not affect projection or delivery.
+  }
+}
+
+export function observeAcpToolResultWire(
+  message: unknown,
+  payloadUtf8Bytes: number,
+): void {
+  try {
+    const record = asRecord(message);
+    if (!record) return;
+    const updates = acpWireUpdates(record).flatMap((update) => {
+      const projection = projectedAcpUpdates.get(update);
+      return projection ? [{ update, projection }] : [];
+    });
+    if (updates.length === 0) return;
+    const params = asRecord(record['params']);
+    const toolCallIds = updates.flatMap(({ update }) => {
+      const id = toolCallId(update);
+      return id === undefined ? [] : [id];
+    });
+    observeToolResultBoundary({
+      stage: 'acp_wire',
+      sessionId:
+        typeof params?.['sessionId'] === 'string'
+          ? params['sessionId']
+          : undefined,
+      toolCallId:
+        updates.length === 1 ? toolCallId(updates[0].update) : undefined,
+      ...(updates.length > 1 ? { toolCallIds } : {}),
+      wireUtf8Bytes: payloadUtf8Bytes + 1,
+      mutated: updates.some(({ projection }) => projection.mutated),
+      artifacts: updates.map(({ projection }) => projection.artifact),
+      values: () =>
+        updates.flatMap(({ update }) =>
+          acpToolResultValues(update as unknown as SessionUpdate),
+        ),
+    });
+    for (const { update } of updates) projectedAcpUpdates.delete(update);
+  } catch {
+    // Diagnostics must not affect the writer hook.
+  }
+}
+
+export function observeHeadlessToolResultProjection(
+  message: CLIMessage,
+  inputContent: string,
+  outputContent: string,
+  toolCallId: string,
+  artifact: ToolResultBoundaryArtifact,
+): void {
+  try {
+    const mutated = inputContent !== outputContent;
+    const inputEligible = observeToolResultBoundary({
+      stage: 'headless_projection_input',
+      sessionId: message.session_id,
+      toolCallId,
+      mutated,
+      artifacts: [artifact],
+      values: [{ representation: 'headless_content', value: inputContent }],
+    });
+    const outputEligible = observeToolResultBoundary({
+      stage: 'headless_projection_output',
+      sessionId: message.session_id,
+      toolCallId,
+      mutated,
+      artifacts: [artifact],
+      values: [{ representation: 'headless_content', value: outputContent }],
+    });
+    if (inputEligible || outputEligible) {
+      projectedHeadlessMessages.set(message, { mutated, artifact });
+    }
+  } catch {
+    // Diagnostics must not affect projection or delivery.
+  }
+}
+
+export function observeHeadlessToolResultWire(
+  message: CLIMessage,
+  frame: string,
+): void {
+  try {
+    if (!projectedHeadlessMessages.has(message)) return;
+    const projection = projectedHeadlessMessages.get(message)!;
+    const toolResults = headlessToolResults(message);
+    const values = toolResults.flatMap(toolResultValues);
+    observeToolResultBoundary({
+      stage: 'headless_wire',
+      sessionId: message.session_id,
+      toolCallId:
+        toolResults.length === 1 &&
+        typeof toolResults[0].tool_use_id === 'string'
+          ? toolResults[0].tool_use_id
+          : undefined,
+      ...(toolResults.length > 1
+        ? {
+            toolCallIds: toolResults.map(
+              (toolResult) => toolResult.tool_use_id,
+            ),
+          }
+        : {}),
+      wireUtf8Bytes: Buffer.byteLength(frame, 'utf8'),
+      mutated: projection.mutated,
+      artifacts: [projection.artifact],
+      values,
+    });
+    projectedHeadlessMessages.delete(message);
+  } catch {
+    // Diagnostics must not affect the writer.
+  }
+}
+
+export function observeHeadlessJsonToolResultWire(
+  messages: readonly CLIMessage[],
+  frame: string,
+): void {
+  try {
+    const observedMessages = messages.filter((message) =>
+      projectedHeadlessMessages.has(message),
+    );
+    if (observedMessages.length === 0) return;
+    const toolResults = observedMessages.flatMap(headlessToolResults);
+    const values = toolResults.flatMap(toolResultValues);
+    observeToolResultBoundary({
+      stage: 'headless_wire',
+      sessionId:
+        new Set(observedMessages.map((message) => message.session_id)).size ===
+        1
+          ? observedMessages[0].session_id
+          : undefined,
+      toolCallId:
+        toolResults.length === 1 ? toolResults[0].tool_use_id : undefined,
+      ...(toolResults.length > 1
+        ? {
+            toolCallIds: toolResults.map(
+              (toolResult) => toolResult.tool_use_id,
+            ),
+          }
+        : {}),
+      wireUtf8Bytes: Buffer.byteLength(frame, 'utf8'),
+      mutated: observedMessages.some(
+        (message) => projectedHeadlessMessages.get(message)?.mutated === true,
+      ),
+      artifacts: observedMessages.map(
+        (message) => projectedHeadlessMessages.get(message)!.artifact,
+      ),
+      values,
+    });
+    for (const message of observedMessages) {
+      projectedHeadlessMessages.delete(message);
+    }
+  } catch {
+    // Diagnostics must not affect the writer.
+  }
+}
+
+function acpToolResultValues(update: SessionUpdate): ToolResultBoundaryValue[] {
+  const record = update as unknown as Record<string, unknown>;
+  if (record['sessionUpdate'] !== 'tool_call_update') return [];
+  const values: ToolResultBoundaryValue[] = [];
+  const content = record['content'];
+  if (Array.isArray(content)) {
+    for (const block of content) {
+      const text = asRecord(asRecord(block)?.['content'])?.['text'];
+      if (typeof text === 'string') {
+        values.push({ representation: 'acp_content', value: text });
+      }
+    }
+  }
+  if (typeof record['rawOutput'] === 'string') {
+    values.push({
+      representation: 'acp_raw_output',
+      value: record['rawOutput'],
+    });
+  }
+  return values;
+}
+
+function toolCallId(value: unknown): string | undefined {
+  const id = asRecord(value)?.['toolCallId'];
+  return typeof id === 'string' ? id : undefined;
+}
+
+function acpWireUpdates(message: Record<string, unknown>): object[] {
+  if (message['method'] === 'session/update') {
+    const update = asRecord(asRecord(message['params'])?.['update']);
+    return update ? [update] : [];
+  }
+  const result = asRecord(message['result']);
+  const replay = asRecord(asRecord(result?.['_meta'])?.[LOAD_REPLAY_META_KEY]);
+  const candidates = replay?.['updates'] ?? result?.['updates'];
+  return Array.isArray(candidates) ? candidates.filter(isObject) : [];
+}
+
+function headlessToolResults(message: CLIMessage): ToolResultBlock[] {
+  if (message.type !== 'user' || !Array.isArray(message.message.content)) {
+    return [];
+  }
+  return message.message.content.flatMap((block) =>
+    block.type === 'tool_result' ? [block] : [],
+  );
+}
+
+function toolResultValues(
+  toolResult: ToolResultBlock,
+): ToolResultBoundaryValue[] {
+  return typeof toolResult.content === 'string'
+    ? [{ representation: 'headless_content', value: toolResult.content }]
+    : [];
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return isObject(value) ? (value as Record<string, unknown>) : undefined;
+}
+
+function isObject(value: unknown): value is object {
+  return typeof value === 'object' && value !== null;
+}

--- a/packages/cli/src/utils/tool-result-boundary-diagnostics.ts
+++ b/packages/cli/src/utils/tool-result-boundary-diagnostics.ts
@@ -37,6 +37,7 @@ export function observeAcpToolResultProjection(
   wireUpdate: SessionUpdate = output,
 ): void {
   try {
+    if (isObject(wireUpdate) && projectedAcpUpdates.has(wireUpdate)) return;
     const mutated = input !== output;
     const artifact = acpUpdateArtifacts.get(input) ?? {
       state: 'undecided',

--- a/packages/cli/src/utils/tool-result-boundary-diagnostics.ts
+++ b/packages/cli/src/utils/tool-result-boundary-diagnostics.ts
@@ -251,7 +251,14 @@ function acpWireUpdates(message: Record<string, unknown>): object[] {
   const result = asRecord(message['result']);
   const replay = asRecord(asRecord(result?.['_meta'])?.[LOAD_REPLAY_META_KEY]);
   const candidates = replay?.['updates'] ?? result?.['updates'];
-  return Array.isArray(candidates) ? candidates.filter(isObject) : [];
+  if (Array.isArray(candidates)) return candidates.filter(isObject);
+  const events = result?.['events'];
+  return Array.isArray(events)
+    ? events.flatMap((event) => {
+        const update = asRecord(event)?.['data'];
+        return isObject(update) ? [update] : [];
+      })
+    : [];
 }
 
 function headlessToolResults(message: CLIMessage): ToolResultBlock[] {

--- a/packages/cli/src/utils/tool-result-boundary-diagnostics.ts
+++ b/packages/cli/src/utils/tool-result-boundary-diagnostics.ts
@@ -16,6 +16,7 @@ import type { CLIMessage, ToolResultBlock } from '../nonInteractive/types.js';
 interface ProjectedToolResult {
   mutated: boolean;
   artifact: ToolResultBoundaryArtifact;
+  sessionId: string;
 }
 
 const acpUpdateArtifacts = new WeakMap<object, ToolResultBoundaryArtifact>();
@@ -57,7 +58,7 @@ export function observeAcpToolResultProjection(
       values: () => acpToolResultValues(output),
     });
     if ((inputEligible || outputEligible) && isObject(wireUpdate)) {
-      projectedAcpUpdates.set(wireUpdate, { mutated, artifact });
+      projectedAcpUpdates.set(wireUpdate, { mutated, artifact, sessionId });
     }
   } catch {
     // Diagnostics must not affect projection or delivery.
@@ -77,6 +78,9 @@ export function observeAcpToolResultWire(
     });
     if (updates.length === 0) return;
     const params = asRecord(record['params']);
+    const projectionSessionIds = new Set(
+      updates.map(({ projection }) => projection.sessionId),
+    );
     const toolCallIds = updates.flatMap(({ update }) => {
       const id = toolCallId(update);
       return id === undefined ? [] : [id];
@@ -86,7 +90,9 @@ export function observeAcpToolResultWire(
       sessionId:
         typeof params?.['sessionId'] === 'string'
           ? params['sessionId']
-          : undefined,
+          : projectionSessionIds.size === 1
+            ? projectionSessionIds.values().next().value
+            : undefined,
       toolCallId:
         updates.length === 1 ? toolCallId(updates[0].update) : undefined,
       ...(updates.length > 1 ? { toolCallIds } : {}),
@@ -130,7 +136,11 @@ export function observeHeadlessToolResultProjection(
       values: [{ representation: 'headless_content', value: outputContent }],
     });
     if (inputEligible || outputEligible) {
-      projectedHeadlessMessages.set(message, { mutated, artifact });
+      projectedHeadlessMessages.set(message, {
+        mutated,
+        artifact,
+        sessionId: message.session_id,
+      });
     }
   } catch {
     // Diagnostics must not affect projection or delivery.

--- a/packages/core/src/agents/runtime/agent-core.test.ts
+++ b/packages/core/src/agents/runtime/agent-core.test.ts
@@ -51,6 +51,20 @@ import {
 } from '../../utils/invocation-context.js';
 import { GeminiChat } from '../../core/geminiChat.js';
 import { ContextState } from './agent-headless.js';
+import type { ToolResultBoundaryObservation } from '../../utils/tool-result-boundary-diagnostics.js';
+
+const boundaryObserveMock = vi.hoisted(() =>
+  vi.fn((_observation: ToolResultBoundaryObservation) => false),
+);
+vi.mock(
+  '../../utils/tool-result-boundary-diagnostics.js',
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import('../../utils/tool-result-boundary-diagnostics.js')
+    >()),
+    observeToolResultBoundary: boundaryObserveMock,
+  }),
+);
 
 describe('AgentCore.createChat manual plan-exit notice ownership', () => {
   it('enables notices only for interactive agent chats', async () => {
@@ -702,6 +716,7 @@ describe('AgentCore.prepareTools', () => {
   it.each([ToolNames.ENTER_PLAN_MODE, ToolNames.EXIT_PLAN_MODE])(
     'returns a dedicated message when filtered %s is called directly',
     async (toolName) => {
+      boundaryObserveMock.mockClear();
       const { core } = buildAgentForTools(undefined, []);
 
       const result = await runWithAgentContext('test-subagent', () =>
@@ -727,6 +742,13 @@ describe('AgentCore.prepareTools', () => {
       expect(response?.error).toContain('not available inside subagents');
       expect(response?.error).toContain('return your plan');
       expect(response?.error).not.toContain('not found');
+      const producerObservations = boundaryObserveMock.mock.calls
+        .map(([observation]) => observation)
+        .filter((observation) => observation.stage === 'producer');
+      expect(producerObservations).toHaveLength(1);
+      expect(producerObservations[0].artifacts).toEqual([
+        { state: 'none', kinds: [] },
+      ]);
     },
   );
 

--- a/packages/core/src/agents/runtime/agent-core.ts
+++ b/packages/core/src/agents/runtime/agent-core.ts
@@ -50,6 +50,7 @@ import {
 import type {
   ToolConfirmationOutcome,
   ToolCallConfirmationDetails,
+  ToolArtifact,
   ToolResultDisplay,
 } from '../../tools/tools.js';
 import { isShellProgressData } from '../../tools/tools.js';
@@ -58,6 +59,10 @@ import {
   finalizeToolResponses,
   type ToolResponseBudgetEntry,
 } from '../../utils/tool-response-finalizer.js';
+import {
+  isToolResultBoundaryDiagnosticsEnabled,
+  toolResultBoundaryArtifact,
+} from '../../utils/tool-result-boundary-diagnostics.js';
 import { FinishReason } from '../../core/genai-compat.js';
 import type {
   Content,
@@ -1524,6 +1529,7 @@ export class AgentCore {
         toolName: string;
         responseParts: Part[];
         persistedOutputFiles?: string[];
+        artifacts?: ToolArtifact[];
         durationMs?: number;
       }
     >();
@@ -1719,6 +1725,14 @@ export class AgentCore {
             error: errorMessage,
             responseParts: call.response.responseParts,
             resultDisplay: call.response.resultDisplay,
+            ...(isToolResultBoundaryDiagnosticsEnabled()
+              ? {
+                  boundaryArtifact: toolResultBoundaryArtifact(
+                    call.response.persistedOutputFiles,
+                    call.response.artifacts,
+                  ),
+                }
+              : {}),
             durationMs: duration,
             timestamp: Date.now(),
           } as AgentToolResultEvent);
@@ -1739,6 +1753,7 @@ export class AgentCore {
             toolName,
             responseParts: call.response.responseParts,
             persistedOutputFiles: call.response.persistedOutputFiles,
+            artifacts: call.response.artifacts,
             durationMs: duration,
           });
         }
@@ -1970,6 +1985,7 @@ export class AgentCore {
             toolName: response.toolName,
             responseParts: response.responseParts,
             persistedOutputFiles: response.persistedOutputFiles,
+            artifacts: response.artifacts,
           },
         ];
       });
@@ -1988,6 +2004,7 @@ export class AgentCore {
     const finalizedResponses = await finalizeToolResponses(
       this.runtimeContext,
       orderedResponses,
+      new Map(orderedResponses.map((response) => [response.callId, promptId])),
     );
     const toolResponseParts = finalizedResponses.flatMap(
       (response) => response.responseParts,

--- a/packages/core/src/agents/runtime/agent-core.ts
+++ b/packages/core/src/agents/runtime/agent-core.ts
@@ -61,7 +61,9 @@ import {
 } from '../../utils/tool-response-finalizer.js';
 import {
   isToolResultBoundaryDiagnosticsEnabled,
+  observeToolResultBoundary,
   toolResultBoundaryArtifact,
+  toolResultPartDiagnosticValues,
 } from '../../utils/tool-result-boundary-diagnostics.js';
 import { FinishReason } from '../../core/genai-compat.js';
 import type {
@@ -1403,6 +1405,25 @@ export class AgentCore {
 
   // ─── Tool Execution ───────────────────────────────────────
 
+  private observeSyntheticToolResultProducer(params: {
+    callId: string;
+    name: string;
+    responseParts: Part[];
+  }): void {
+    try {
+      observeToolResultBoundary({
+        stage: 'producer',
+        sessionId: this.runtimeContext.getSessionId?.(),
+        toolCallId: params.callId,
+        toolName: params.name,
+        artifacts: [toolResultBoundaryArtifact([], [])],
+        values: () => toolResultPartDiagnosticValues(params.responseParts),
+      });
+    } catch {
+      // Diagnostics must not affect agent execution.
+    }
+  }
+
   private emitSyntheticToolError(params: {
     callId: string;
     name: string;
@@ -1424,6 +1445,8 @@ export class AgentCore {
       timestamp: Date.now(),
     } as AgentToolCallEvent);
 
+    this.observeSyntheticToolResultProducer(params);
+
     this.eventEmitter?.emit(AgentEventType.TOOL_RESULT, {
       subagentId: this.subagentId,
       round: params.currentRound,
@@ -1433,6 +1456,9 @@ export class AgentCore {
       error: params.errorMessage,
       responseParts: params.responseParts,
       resultDisplay: params.resultDisplay,
+      ...(isToolResultBoundaryDiagnosticsEnabled()
+        ? { boundaryArtifact: toolResultBoundaryArtifact([], []) }
+        : {}),
       durationMs: params.durationMs ?? 0,
       timestamp: Date.now(),
     } as AgentToolResultEvent);
@@ -1684,6 +1710,7 @@ export class AgentCore {
     const executionStartedEmitted = new Set<string>();
     const scheduler = new CoreToolScheduler({
       config: this.runtimeContext,
+      shouldObserveProducer: (callId) => !emittedCallIds.has(callId),
       outputUpdateHandler: (callId, outputChunk) => {
         // Shell liveness heartbeats have no subagent consumer; broadcasting
         // one would overwrite the live output view kept in liveOutputs.
@@ -1935,6 +1962,12 @@ export class AgentCore {
           ];
           this.recordToolCallStats(req.name, false, 0, errorMessage);
 
+          this.observeSyntheticToolResultProducer({
+            callId: req.callId,
+            name: req.name,
+            responseParts,
+          });
+
           this.eventEmitter?.emit(AgentEventType.TOOL_RESULT, {
             subagentId: this.subagentId,
             round: currentRound,
@@ -1944,6 +1977,9 @@ export class AgentCore {
             error: errorMessage,
             responseParts,
             resultDisplay: errorMessage,
+            ...(isToolResultBoundaryDiagnosticsEnabled()
+              ? { boundaryArtifact: toolResultBoundaryArtifact([], []) }
+              : {}),
             durationMs: 0,
             timestamp: Date.now(),
           } as AgentToolResultEvent);

--- a/packages/core/src/agents/runtime/agent-events.ts
+++ b/packages/core/src/agents/runtime/agent-events.ts
@@ -17,6 +17,7 @@ import { EventEmitter } from 'events';
 import type {
   ToolCallConfirmationDetails,
   ToolConfirmationOutcome,
+  ToolResultBoundaryArtifact,
   ToolResultDisplay,
 } from '../../tools/tools.js';
 import type { Part, GenerateContentResponseUsageMetadata } from '@google/genai';
@@ -136,6 +137,7 @@ export interface AgentToolResultEvent {
   resultDisplay?: ToolResultDisplay;
   /** Path to the temp file where oversized output was saved. */
   outputFile?: string;
+  boundaryArtifact?: ToolResultBoundaryArtifact;
   durationMs?: number;
   timestamp: number;
 }

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -92,6 +92,7 @@ import {
   promptIdContext,
   todoWorkChainContext,
 } from '../utils/promptIdContext.js';
+import type { ToolResultBoundaryObservation } from '../utils/tool-result-boundary-diagnostics.js';
 
 type ToolSpanRecord = {
   name: string;
@@ -138,6 +139,19 @@ const { mockAcquireSleepInhibitor, mockSleepInhibitorRelease } = vi.hoisted(
 );
 
 const debugLoggerWarnSpy = vi.hoisted(() => vi.fn());
+const boundaryObserveMock = vi.hoisted(() =>
+  vi.fn((_observation: ToolResultBoundaryObservation) => false),
+);
+
+vi.mock(
+  '../utils/tool-result-boundary-diagnostics.js',
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import('../utils/tool-result-boundary-diagnostics.js')
+    >()),
+    observeToolResultBoundary: boundaryObserveMock,
+  }),
+);
 const debugLoggerInfoSpy = vi.hoisted(() => vi.fn());
 const runSideQueryMock = vi.hoisted(() => vi.fn());
 const mockTelemetrySdkState = vi.hoisted(() => ({ initialized: false }));
@@ -624,6 +638,7 @@ async function waitForStatus(
 describe('CoreToolScheduler', () => {
   beforeEach(() => {
     debugLoggerInfoSpy.mockClear();
+    boundaryObserveMock.mockClear();
     runSideQueryMock.mockReset();
     modifyWithEditorOverride.value = undefined;
   });
@@ -10529,6 +10544,10 @@ describe('CoreToolScheduler Plan shell routing', () => {
 });
 
 describe('CoreToolScheduler telemetry spans', () => {
+  beforeEach(() => {
+    boundaryObserveMock.mockClear();
+  });
+
   afterEach(() => {
     shouldThrowToolSpanSetAttribute.value = false;
     shouldThrowToolSpanSetStatus.value = false;
@@ -11409,6 +11428,35 @@ describe('CoreToolScheduler telemetry spans', () => {
       'Tool execution failed with exception',
       'tool_exception',
     );
+  });
+
+  it('observes a settled producer when post-processing throws', async () => {
+    const resultFilePaths: string[] = [];
+    Object.defineProperty(resultFilePaths, Symbol.iterator, {
+      value: () => {
+        throw new Error('post-processing failed');
+      },
+    });
+    const readTool = new MockTool({
+      name: ToolNames.READ_FILE,
+      execute: vi.fn().mockResolvedValue({
+        llmContent: 'settled result',
+        returnDisplay: 'settled result',
+        resultFilePaths,
+      }),
+    });
+
+    const { completedCalls } = await runSingleTool({
+      tools: [readTool],
+      toolName: ToolNames.READ_FILE,
+    });
+
+    expect(completedCalls[0].status).toBe('error');
+    expect(
+      boundaryObserveMock.mock.calls
+        .map(([observation]) => observation.stage)
+        .filter((stage) => stage.startsWith('producer_')),
+    ).toEqual(['producer_input', 'producer_output']);
   });
 
   it('preserves original tool exceptions when the failure hook rejects', async () => {

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -4547,6 +4547,17 @@ describe('CoreToolScheduler', () => {
       String(functionResponse?.response?.['output']).length,
     );
     expect(completed.response.visionBridgeNotice).toContain('qwen3-vl-plus');
+    const producerObservations = boundaryObserveMock.mock.calls
+      .map(([observation]) => observation)
+      .filter((observation) => observation.stage.startsWith('producer_'));
+    expect(producerObservations).toHaveLength(2);
+    for (const observation of producerObservations) {
+      expect(
+        typeof observation.mutated === 'function'
+          ? observation.mutated()
+          : observation.mutated,
+      ).toBe(true);
+    }
     expect(functionResponse).not.toHaveProperty('parts');
     expect(runSideQueryMock).toHaveBeenCalledWith(
       expect.anything(),
@@ -11457,6 +11468,50 @@ describe('CoreToolScheduler telemetry spans', () => {
         .map(([observation]) => observation.stage)
         .filter((stage) => stage.startsWith('producer_')),
     ).toEqual(['producer_input', 'producer_output']);
+  });
+
+  it('does not treat routine multi-part response wrapping as a producer mutation', async () => {
+    await runSingleTool({
+      execute: vi.fn().mockResolvedValue({
+        llmContent: [{ text: 'alpha' }, { text: 'beta' }],
+      }),
+    });
+
+    const observations = boundaryObserveMock.mock.calls
+      .map(([observation]) => observation)
+      .filter((observation) => observation.stage.startsWith('producer_'));
+    expect(observations).toHaveLength(2);
+    for (const observation of observations) {
+      expect(
+        typeof observation.mutated === 'function'
+          ? observation.mutated()
+          : observation.mutated,
+      ).toBe(false);
+    }
+  });
+
+  it('does not treat routine media response wrapping as a producer mutation', async () => {
+    await runSingleTool({
+      execute: vi.fn().mockResolvedValue({
+        llmContent: [
+          {
+            inlineData: { mimeType: 'image/png', data: 'aGVsbG8=' },
+          },
+        ],
+      }),
+    });
+
+    const observations = boundaryObserveMock.mock.calls
+      .map(([observation]) => observation)
+      .filter((observation) => observation.stage.startsWith('producer_'));
+    expect(observations).toHaveLength(2);
+    for (const observation of observations) {
+      expect(
+        typeof observation.mutated === 'function'
+          ? observation.mutated()
+          : observation.mutated,
+      ).toBe(false);
+    }
   });
 
   it('preserves original tool exceptions when the failure hook rejects', async () => {

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -11598,6 +11598,41 @@ describe('CoreToolScheduler telemetry spans', () => {
     ).toHaveLength(0);
   });
 
+  it('preserves a successful result when the producer owner predicate throws', async () => {
+    const { completedCalls } = await runSingleTool({
+      shouldObserveProducer: () => {
+        throw new Error('owner predicate failed');
+      },
+    });
+
+    expect(completedCalls[0].status).toBe('success');
+    expect(
+      boundaryObserveMock.mock.calls.filter(
+        ([observation]) => observation.stage === 'producer',
+      ),
+    ).toHaveLength(0);
+  });
+
+  it('preserves an execution error when the producer owner predicate throws', async () => {
+    const { completedCalls } = await runSingleTool({
+      execute: vi.fn().mockRejectedValue(new Error('tool failed')),
+      shouldObserveProducer: () => {
+        throw new Error('owner predicate failed');
+      },
+    });
+
+    const completedCall = completedCalls[0];
+    expect(completedCall.status).toBe('error');
+    if (completedCall.status === 'error') {
+      expect(completedCall.response.error?.message).toBe('tool failed');
+    }
+    expect(
+      boundaryObserveMock.mock.calls.filter(
+        ([observation]) => observation.stage === 'producer',
+      ),
+    ).toHaveLength(0);
+  });
+
   it('observes a settled producer when post-processing throws', async () => {
     const resultFilePaths: string[] = [];
     Object.defineProperty(resultFilePaths, Symbol.iterator, {

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -1153,6 +1153,43 @@ describe('CoreToolScheduler', () => {
     ).toBe(0);
   });
 
+  it('does not observe the budget-exempt plan reminder in the scheduler pass', async () => {
+    const reminder = getPlanModeSystemReminder(false);
+    const enterTool = new MockTool({
+      name: ToolNames.ENTER_PLAN_MODE,
+      maxOutputChars: Number.POSITIVE_INFINITY,
+      execute: vi.fn().mockResolvedValue({
+        llmContent: reminder,
+        returnDisplay: 'Entered plan mode.',
+      }),
+    });
+    const { scheduler, onAllToolCallsComplete } =
+      createSchedulerForLegacyToolTests({
+        toolsByName: new Map([[ToolNames.ENTER_PLAN_MODE, enterTool]]),
+        toolOutputBatchBudget: 1,
+      });
+
+    await scheduler.schedule(
+      [
+        {
+          callId: 'enter-plan-only',
+          name: ToolNames.ENTER_PLAN_MODE,
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'prompt-plan-only',
+        },
+      ],
+      new AbortController().signal,
+    );
+    await vi.waitFor(() => expect(onAllToolCallsComplete).toHaveBeenCalled());
+
+    expect(
+      boundaryObserveMock.mock.calls
+        .map(([observation]) => observation.stage)
+        .filter((stage) => stage.startsWith('finalizer_')),
+    ).toEqual([]);
+  });
+
   it('keeps siblings suppressed when enter_plan_mode itself fails', async () => {
     const enterExecute = vi.fn().mockResolvedValue({
       llmContent: 'Failed to enter plan mode: transition failed',
@@ -2815,6 +2852,22 @@ describe('CoreToolScheduler', () => {
         ([, result]) => result.executionStatus === 'success',
       ),
     ).toBe(true);
+    const finalizerObservations = boundaryObserveMock.mock.calls
+      .map(([observation]) => observation)
+      .filter((observation) => observation.stage.startsWith('finalizer_'));
+    expect(finalizerObservations).toHaveLength(4);
+    expect(
+      finalizerObservations.map((observation) => [
+        observation.toolCallId,
+        observation.stage,
+        observation.mutated,
+      ]),
+    ).toEqual([
+      ['big', 'finalizer_input', true],
+      ['small', 'finalizer_input', false],
+      ['big', 'finalizer_output', true],
+      ['small', 'finalizer_output', false],
+    ]);
   });
 
   it('hard-caps a batch whose producer outputs already carry truncation markers', async () => {

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -142,6 +142,7 @@ const debugLoggerWarnSpy = vi.hoisted(() => vi.fn());
 const boundaryObserveMock = vi.hoisted(() =>
   vi.fn((_observation: ToolResultBoundaryObservation) => false),
 );
+const boundaryDiagnosticsEnabled = vi.hoisted(() => ({ value: false }));
 
 vi.mock(
   '../utils/tool-result-boundary-diagnostics.js',
@@ -149,6 +150,8 @@ vi.mock(
     ...(await importOriginal<
       typeof import('../utils/tool-result-boundary-diagnostics.js')
     >()),
+    isToolResultBoundaryDiagnosticsEnabled: () =>
+      boundaryDiagnosticsEnabled.value,
     observeToolResultBoundary: boundaryObserveMock,
   }),
 );
@@ -639,6 +642,7 @@ describe('CoreToolScheduler', () => {
   beforeEach(() => {
     debugLoggerInfoSpy.mockClear();
     boundaryObserveMock.mockClear();
+    boundaryDiagnosticsEnabled.value = false;
     runSideQueryMock.mockReset();
     modifyWithEditorOverride.value = undefined;
   });
@@ -1153,7 +1157,8 @@ describe('CoreToolScheduler', () => {
     ).toBe(0);
   });
 
-  it('does not observe the budget-exempt plan reminder in the scheduler pass', async () => {
+  it('marks the budget-exempt plan reminder unchanged in the scheduler pass', async () => {
+    boundaryDiagnosticsEnabled.value = true;
     const reminder = getPlanModeSystemReminder(false);
     const enterTool = new MockTool({
       name: ToolNames.ENTER_PLAN_MODE,
@@ -1185,10 +1190,58 @@ describe('CoreToolScheduler', () => {
 
     expect(
       boundaryObserveMock.mock.calls
-        .map(([observation]) => observation.stage)
-        .filter((stage) => stage.startsWith('finalizer_')),
-    ).toEqual([]);
+        .map(([observation]) => observation)
+        .filter((observation) => observation.stage.startsWith('finalizer_'))
+        .map((observation) => [observation.stage, observation.mutated]),
+    ).toEqual([
+      ['finalizer_input', false],
+      ['finalizer_output', false],
+    ]);
   });
+
+  it.each([200_000, Number.POSITIVE_INFINITY])(
+    'observes oversized output that remains within the batch budget (%s)',
+    async (toolOutputBatchBudget) => {
+      boundaryDiagnosticsEnabled.value = true;
+      const largeOutput = 'a'.repeat(70_000);
+      const tool = new MockTool({
+        name: 'largeWithinBudget',
+        execute: vi.fn().mockResolvedValue({
+          llmContent: largeOutput,
+          returnDisplay: 'large output',
+        }),
+      });
+      const { scheduler, onAllToolCallsComplete } =
+        createSchedulerForLegacyToolTests({
+          toolsByName: new Map([['largeWithinBudget', tool]]),
+          toolOutputBatchBudget,
+        });
+
+      await scheduler.schedule(
+        [
+          {
+            callId: 'large-within-budget',
+            name: 'largeWithinBudget',
+            args: {},
+            isClientInitiated: false,
+            prompt_id: 'prompt-large-within-budget',
+          },
+        ],
+        new AbortController().signal,
+      );
+      await vi.waitFor(() => expect(onAllToolCallsComplete).toHaveBeenCalled());
+
+      expect(
+        boundaryObserveMock.mock.calls
+          .map(([observation]) => observation)
+          .filter((observation) => observation.stage.startsWith('finalizer_'))
+          .map((observation) => [observation.stage, observation.mutated]),
+      ).toEqual([
+        ['finalizer_input', false],
+        ['finalizer_output', false],
+      ]);
+    },
+  );
 
   it('keeps siblings suppressed when enter_plan_mode itself fails', async () => {
     const enterExecute = vi.fn().mockResolvedValue({
@@ -2588,6 +2641,17 @@ describe('CoreToolScheduler', () => {
       ]);
       expect(completedCall.response.resultDisplay).toBe('completed');
     }
+    const producerObservations = boundaryObserveMock.mock.calls
+      .map(([observation]) => observation)
+      .filter((observation) => observation.stage.startsWith('producer_'));
+    expect(producerObservations).toHaveLength(2);
+    const inputValues = producerObservations[0].values;
+    expect(
+      typeof inputValues === 'function' ? inputValues() : inputValues,
+    ).toEqual([
+      { representation: 'model_text', value: '' },
+      { representation: 'display', value: 'completed' },
+    ]);
   });
 
   it('applies the per-tool budget for a tool invoked via a legacy alias', async () => {
@@ -2767,6 +2831,7 @@ describe('CoreToolScheduler', () => {
   });
 
   it('deterministically bounds tool outputs when a batch exceeds the budget', async () => {
+    boundaryDiagnosticsEnabled.value = true;
     // Both outputs are individually under the single-result threshold (25k),
     // so PR-A truncation leaves them alone; only their SUM (12k) exceeds the
     // per-message batch budget (10k). The small result fits intact and the

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -11,6 +11,7 @@ import type {
   AnyDeclarativeTool,
   ChatRecordingService,
   Config,
+  FileDiff,
   ToolCallConfirmationDetails,
   ToolCallRequestInfo,
   ToolConfirmationPayload,
@@ -10711,6 +10712,7 @@ describe('CoreToolScheduler telemetry spans', () => {
     includeSensitiveSpanAttributes?: boolean;
     sensitiveSpanAttributeMaxLength?: number;
     onToolCallsUpdate?: ReturnType<typeof vi.fn>;
+    shouldObserveProducer?: (callId: string) => boolean;
   }): {
     scheduler: CoreToolScheduler;
     onAllToolCallsComplete: ReturnType<typeof vi.fn>;
@@ -10792,6 +10794,7 @@ describe('CoreToolScheduler telemetry spans', () => {
       config: mockConfig,
       onAllToolCallsComplete,
       onToolCallsUpdate,
+      shouldObserveProducer: options.shouldObserveProducer,
       getPreferredEditor: () => 'vscode',
       onEditorClose: vi.fn(),
     });
@@ -10821,6 +10824,7 @@ describe('CoreToolScheduler telemetry spans', () => {
       providerCallId?: string;
       tools?: AnyDeclarativeTool[];
       toolName?: string;
+      shouldObserveProducer?: (callId: string) => boolean;
     } = {},
   ): Promise<{
     spanRecord: ToolSpanRecord;
@@ -11390,6 +11394,7 @@ describe('CoreToolScheduler telemetry spans', () => {
             hookSpecificOutput: {
               artifacts: [
                 {
+                  kind: 'link',
                   title: 'Hook report',
                   workspacePath: 'reports/hook.html',
                 },
@@ -11407,6 +11412,7 @@ describe('CoreToolScheduler telemetry spans', () => {
         returnDisplay: 'ok',
         artifacts: [
           {
+            kind: 'file',
             title: 'Tool report',
             workspacePath: 'reports/tool.html',
           },
@@ -11419,14 +11425,27 @@ describe('CoreToolScheduler telemetry spans', () => {
     if (completedCall.status === 'success') {
       expect(completedCall.response.artifacts).toEqual([
         {
+          kind: 'file',
           title: 'Tool report',
           workspacePath: 'reports/tool.html',
         },
         {
+          kind: 'link',
           title: 'Hook report',
           workspacePath: 'reports/hook.html',
         },
       ]);
+    }
+    const producerObservations = boundaryObserveMock.mock.calls
+      .map(([observation]) => observation)
+      .filter((observation) => observation.stage.startsWith('producer_'));
+    expect(producerObservations).toHaveLength(2);
+    for (const observation of producerObservations) {
+      expect(
+        typeof observation.mutated === 'function'
+          ? observation.mutated()
+          : observation.mutated,
+      ).toBe(true);
     }
   });
 
@@ -11557,6 +11576,26 @@ describe('CoreToolScheduler telemetry spans', () => {
       'Tool execution failed with exception',
       'tool_exception',
     );
+    const producerObservations = boundaryObserveMock.mock.calls
+      .map(([observation]) => observation)
+      .filter((observation) => observation.stage === 'producer');
+    expect(producerObservations).toHaveLength(1);
+    expect(producerObservations[0].artifacts).toEqual([
+      { state: 'none', kinds: [] },
+    ]);
+  });
+
+  it('lets an outer owner suppress a scheduler producer observation', async () => {
+    await runSingleTool({
+      execute: vi.fn().mockRejectedValue(new Error('externally owned')),
+      shouldObserveProducer: () => false,
+    });
+
+    expect(
+      boundaryObserveMock.mock.calls.filter(
+        ([observation]) => observation.stage === 'producer',
+      ),
+    ).toHaveLength(0);
   });
 
   it('observes a settled producer when post-processing throws', async () => {
@@ -11629,6 +11668,86 @@ describe('CoreToolScheduler telemetry spans', () => {
           ? observation.mutated()
           : observation.mutated,
       ).toBe(false);
+    }
+  });
+
+  it('does not treat a supported function response as a producer mutation', async () => {
+    await runSingleTool({
+      execute: vi.fn().mockResolvedValue({
+        llmContent: [
+          {
+            functionResponse: {
+              id: 'span-call',
+              name: 'mockTool',
+              response: { output: 'complete' },
+            },
+          },
+        ],
+      }),
+    });
+
+    const observations = boundaryObserveMock.mock.calls
+      .map(([observation]) => observation)
+      .filter((observation) => observation.stage.startsWith('producer_'));
+    expect(observations).toHaveLength(2);
+    for (const observation of observations) {
+      expect(
+        typeof observation.mutated === 'function'
+          ? observation.mutated()
+          : observation.mutated,
+      ).toBe(false);
+    }
+  });
+
+  it('treats dropped structured parts as a producer mutation', async () => {
+    await runSingleTool({
+      execute: vi.fn().mockResolvedValue({
+        llmContent: [
+          {
+            functionCall: { name: 'nested_call', args: { value: 1 } },
+          },
+        ],
+      }),
+    });
+
+    const observations = boundaryObserveMock.mock.calls
+      .map(([observation]) => observation)
+      .filter((observation) => observation.stage.startsWith('producer_'));
+    expect(observations).toHaveLength(2);
+    for (const observation of observations) {
+      expect(
+        typeof observation.mutated === 'function'
+          ? observation.mutated()
+          : observation.mutated,
+      ).toBe(true);
+    }
+  });
+
+  it('treats structured display compaction as a producer mutation', async () => {
+    const oversized = 'x'.repeat(MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS + 100);
+    const returnDisplay: FileDiff = {
+      fileName: 'large.txt',
+      fileDiff: oversized,
+      originalContent: oversized,
+      newContent: oversized,
+    };
+    await runSingleTool({
+      execute: vi.fn().mockResolvedValue({
+        llmContent: 'updated',
+        returnDisplay,
+      }),
+    });
+
+    const observations = boundaryObserveMock.mock.calls
+      .map(([observation]) => observation)
+      .filter((observation) => observation.stage.startsWith('producer_'));
+    expect(observations).toHaveLength(2);
+    for (const observation of observations) {
+      expect(
+        typeof observation.mutated === 'function'
+          ? observation.mutated()
+          : observation.mutated,
+      ).toBe(true);
     }
   });
 

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -1320,17 +1320,19 @@ function partitionToolCalls(calls: ScheduledToolCall[]): ToolBatch[] {
   return partitionByConcurrencySafety(calls, isConcurrencySafe);
 }
 
-function toolResultBoundaryValuesEqual(
-  left: readonly ToolResultBoundaryValue[],
-  right: readonly ToolResultBoundaryValue[],
+function producerTextEqual(
+  input: PartListUnion,
+  output: PartListUnion,
 ): boolean {
+  const diagnosticText = (value: PartListUnion) =>
+    toolResultPartDiagnosticValues(value)
+      .map((slot) => slot.value)
+      .join('\n');
+  const inputText = diagnosticText(input);
+  const outputText = diagnosticText(output);
   return (
-    left.length === right.length &&
-    left.every(
-      (value, index) =>
-        value.representation === right[index].representation &&
-        value.value === right[index].value,
-    )
+    inputText === outputText ||
+    (inputText === '' && outputText === TOOL_SUCCEEDED_OUTPUT)
   );
 }
 
@@ -4804,10 +4806,16 @@ export class CoreToolScheduler {
             ]);
           let mutated: boolean | undefined;
           const isMutated = () =>
-            (mutated ??= !toolResultBoundaryValuesEqual(
-              getProducerInputValues(),
-              getProducerOutputValues(),
-            ));
+            (mutated ??=
+              !producerTextEqual(
+                toolResult.llmContent,
+                response.responseParts,
+              ) ||
+              (typeof toolResult.returnDisplay === 'string' ||
+              typeof response.resultDisplay === 'string'
+                ? toolResult.returnDisplay !== response.resultDisplay
+                : false) ||
+              typeof response.visionBridgeNotice === 'string');
           const observation = {
             sessionId: this.config.getSessionId(),
             promptId: scheduledCall.request.prompt_id,
@@ -6046,6 +6054,7 @@ export class CoreToolScheduler {
           call.request.prompt_id,
         ]),
       ),
+      false,
     );
 
     return completedCalls.map((call, index) => ({

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -62,6 +62,7 @@ import type {
   PartListUnion,
 } from '@google/genai';
 import { fileURLToPath } from 'node:url';
+import { isDeepStrictEqual } from 'node:util';
 import { ToolNames, canonicalToolName } from '../tools/tool-names.js';
 import { PLAN_EXIT_APPROVED_LLM_CONTENT_PREFIXES } from '../tools/exitPlanMode.js';
 import { approvedPlanRedactionText } from './geminiChat.js';
@@ -1214,6 +1215,8 @@ interface CoreToolSchedulerOptions {
    */
   chatRecordingService?: ChatRecordingService;
   onToolResultFullTurnModel?: (model: string) => boolean;
+  /** Lets an outer owner suppress a scheduler result it already emitted. */
+  shouldObserveProducer?: (callId: string) => boolean;
 }
 
 // ─── Tool Concurrency Helpers ────────────────────────────────
@@ -1321,19 +1324,58 @@ function partitionToolCalls(calls: ScheduledToolCall[]): ToolBatch[] {
   return partitionByConcurrencySafety(calls, isConcurrencySafe);
 }
 
-function producerTextEqual(
+function producerInputDropsStructuredContent(
+  input: PartListUnion | null | undefined,
+): boolean {
+  if (input === null || input === undefined || typeof input === 'string') {
+    return false;
+  }
+
+  const contentToProcess =
+    Array.isArray(input) && input.length === 1 ? input[0] : input;
+  if (typeof contentToProcess === 'string') return false;
+
+  const hasOnlyKeys = (part: Part, ...keys: string[]) =>
+    Object.entries(part).every(
+      ([key, value]) => value === undefined || keys.includes(key),
+    );
+  if (Array.isArray(contentToProcess)) {
+    return contentToProcess.some((part) => {
+      if (typeof part === 'string') return false;
+      if (part.text !== undefined) return !hasOnlyKeys(part, 'text');
+      if (part.inlineData !== undefined) {
+        return !hasOnlyKeys(part, 'inlineData');
+      }
+      if (part.fileData !== undefined) return !hasOnlyKeys(part, 'fileData');
+      return true;
+    });
+  }
+
+  if (contentToProcess.functionResponse !== undefined) {
+    return Boolean(contentToProcess.functionResponse.response?.['content']);
+  }
+  if (
+    contentToProcess.inlineData !== undefined ||
+    contentToProcess.fileData !== undefined
+  ) {
+    return !hasOnlyKeys(contentToProcess, 'inlineData', 'fileData');
+  }
+  if (contentToProcess.text !== undefined) {
+    return !hasOnlyKeys(contentToProcess, 'text');
+  }
+  return true;
+}
+
+function producerContentEqual(
+  toolName: string,
+  callId: string,
   input: PartListUnion | null | undefined,
   output: PartListUnion,
 ): boolean {
-  const diagnosticText = (value: PartListUnion | null | undefined) =>
-    toolResultPartDiagnosticValues(value)
-      .map((slot) => slot.value)
-      .join('\n');
-  const inputText = diagnosticText(input);
-  const outputText = diagnosticText(output);
-  return (
-    inputText === outputText ||
-    (inputText === '' && outputText === TOOL_SUCCEEDED_OUTPUT)
+  if (producerInputDropsStructuredContent(input)) return false;
+  return isDeepStrictEqual(
+    convertToFunctionResponse(toolName, callId, input ?? ''),
+    output,
   );
 }
 
@@ -1348,6 +1390,7 @@ export class CoreToolScheduler {
   private onEditorClose: () => void;
   private chatRecordingService?: ChatRecordingService;
   private onToolResultFullTurnModel?: (model: string) => boolean;
+  private shouldObserveProducer: (callId: string) => boolean;
   private isFinalizingToolCalls = false;
   private postToolBatchEnabledForBatch = false;
   private postToolBatchSpanCallId: string | undefined;
@@ -1417,6 +1460,7 @@ export class CoreToolScheduler {
     this.onEditorClose = options.onEditorClose;
     this.chatRecordingService = options.chatRecordingService;
     this.onToolResultFullTurnModel = options.onToolResultFullTurnModel;
+    this.shouldObserveProducer = options.shouldObserveProducer ?? (() => true);
   }
 
   private get memoryMonitor(): MemoryPressureMonitor | undefined {
@@ -4410,6 +4454,41 @@ export class CoreToolScheduler {
     // Get MessageBus for hook execution
     const messageBus = this.config.getMessageBus() as MessageBus | undefined;
     const hooksEnabled = !this.config.getDisableAllHooks();
+    let producerObserved = false;
+    const observeSyntheticProducer = (
+      response: CoreToolCallResponseInfo,
+    ): void => {
+      if (producerObserved || !this.shouldObserveProducer(callId)) return;
+      producerObserved = true;
+      try {
+        observeToolResultBoundary({
+          stage: 'producer',
+          sessionId: this.config.getSessionId(),
+          promptId: scheduledCall.request.prompt_id,
+          toolCallId: callId,
+          toolName: canonicalName,
+          artifacts: [
+            toolResultBoundaryArtifact(
+              response.persistedOutputFiles ?? [],
+              response.artifacts ?? [],
+            ),
+          ],
+          values: () => [
+            ...toolResultPartDiagnosticValues(response.responseParts),
+            ...(typeof response.resultDisplay === 'string'
+              ? [
+                  {
+                    representation: 'display' as const,
+                    value: response.resultDisplay,
+                  },
+                ]
+              : []),
+          ],
+        });
+      } catch {
+        // Diagnostics must not affect tool execution.
+      }
+    };
 
     // PreToolUse Hook — skipped on a post-'ask' re-execution (the hook
     // already ran and the user already confirmed; re-firing would loop).
@@ -4485,6 +4564,7 @@ export class CoreToolScheduler {
           ToolErrorType.EXECUTION_DENIED,
           'not_started',
         );
+        observeSyntheticProducer(errorResponse);
         this.setStatusInternal(callId, 'error', errorResponse);
         setToolSpanFailure(
           span,
@@ -4509,15 +4589,13 @@ export class CoreToolScheduler {
         },
       );
       if (signal.aborted) {
-        this.setStatusInternal(
-          callId,
-          'cancelled',
-          createCancelledResponse(
-            scheduledCall.request,
-            'Tool call cancelled before execution.',
-            'not_started',
-          ),
+        const cancelledResponse = createCancelledResponse(
+          scheduledCall.request,
+          'Tool call cancelled before execution.',
+          'not_started',
         );
+        observeSyntheticProducer(cancelledResponse);
+        this.setStatusInternal(callId, 'cancelled', cancelledResponse);
         if (this.toolSpans.has(callId)) {
           setToolSpanCancelled(span);
         }
@@ -4530,6 +4608,7 @@ export class CoreToolScheduler {
           ToolErrorType.EXECUTION_DENIED,
           'not_started',
         );
+        observeSyntheticProducer(errorResponse);
         this.setStatusInternal(callId, 'error', errorResponse);
         setToolSpanFailure(
           span,
@@ -4550,15 +4629,13 @@ export class CoreToolScheduler {
         currentCall.status !== 'error' &&
         currentCall.status !== 'cancelled'
       ) {
-        this.setStatusInternal(
-          callId,
-          'cancelled',
-          createCancelledResponse(
-            scheduledCall.request,
-            'Tool call cancelled before execution.',
-            'not_started',
-          ),
+        const cancelledResponse = createCancelledResponse(
+          scheduledCall.request,
+          'Tool call cancelled before execution.',
+          'not_started',
         );
+        observeSyntheticProducer(cancelledResponse);
+        this.setStatusInternal(callId, 'cancelled', cancelledResponse);
         if (this.toolSpans.has(callId)) {
           setToolSpanCancelled(span);
         }
@@ -4607,7 +4684,8 @@ export class CoreToolScheduler {
     let executionStatus: ToolExecutionStatus = 'not_started';
     let executionSettled = false;
     let execSpan: Span | undefined;
-    let observeProducerOutput = (_response: CoreToolCallResponseInfo) => {};
+    let producerToolResult: ToolResult | null | undefined;
+    let observeProducerOutput = observeSyntheticProducer;
     try {
       let promise: Promise<ToolResult>;
 
@@ -4769,21 +4847,24 @@ export class CoreToolScheduler {
       } else {
         toolResult = await promise;
       }
-      let producerInputValues: ToolResultBoundaryValue[] | undefined;
-      const getProducerInputValues = () =>
-        (producerInputValues ??= [
-          ...toolResultPartDiagnosticValues(toolResult.llmContent),
-          ...(typeof toolResult.returnDisplay === 'string'
-            ? [
-                {
-                  representation: 'display' as const,
-                  value: toolResult.returnDisplay,
-                },
-              ]
-            : []),
-        ]);
+      producerToolResult = toolResult;
       observeProducerOutput = (response: CoreToolCallResponseInfo) => {
+        if (producerObserved || !this.shouldObserveProducer(callId)) return;
+        producerObserved = true;
         try {
+          let producerInputValues: ToolResultBoundaryValue[] | undefined;
+          const getProducerInputValues = () =>
+            (producerInputValues ??= [
+              ...toolResultPartDiagnosticValues(producerToolResult?.llmContent),
+              ...(typeof producerToolResult?.returnDisplay === 'string'
+                ? [
+                    {
+                      representation: 'display' as const,
+                      value: producerToolResult.returnDisplay,
+                    },
+                  ]
+                : []),
+            ]);
           let producerOutputValues: ToolResultBoundaryValue[] | undefined;
           const getProducerOutputValues = () =>
             (producerOutputValues ??= [
@@ -4805,17 +4886,29 @@ export class CoreToolScheduler {
                   ]
                 : []),
             ]);
+          const inputArtifact = toolResultBoundaryArtifact(
+            producerToolResult?.persistedOutputFiles,
+            producerToolResult?.artifacts,
+          );
+          const outputArtifact = toolResultBoundaryArtifact(
+            response.persistedOutputFiles,
+            response.artifacts,
+          );
           let mutated: boolean | undefined;
           const isMutated = () =>
             (mutated ??=
-              !producerTextEqual(
-                toolResult.llmContent,
+              producerToolResult == null ||
+              !producerContentEqual(
+                toolName,
+                callId,
+                producerToolResult.llmContent,
                 response.responseParts,
               ) ||
-              (typeof toolResult.returnDisplay === 'string' ||
-              typeof response.resultDisplay === 'string'
-                ? toolResult.returnDisplay !== response.resultDisplay
-                : false) ||
+              !isDeepStrictEqual(
+                producerToolResult.returnDisplay,
+                response.resultDisplay,
+              ) ||
+              !isDeepStrictEqual(inputArtifact, outputArtifact) ||
               typeof response.visionBridgeNotice === 'string');
           const observation = {
             sessionId: this.config.getSessionId(),
@@ -4827,23 +4920,13 @@ export class CoreToolScheduler {
           observeToolResultBoundary({
             ...observation,
             stage: 'producer_input',
-            artifacts: [
-              toolResultBoundaryArtifact(
-                toolResult.persistedOutputFiles,
-                toolResult.artifacts,
-              ),
-            ],
+            artifacts: [inputArtifact],
             values: getProducerInputValues,
           });
           observeToolResultBoundary({
             ...observation,
             stage: 'producer_output',
-            artifacts: [
-              toolResultBoundaryArtifact(
-                response.persistedOutputFiles,
-                response.artifacts,
-              ),
-            ],
+            artifacts: [outputArtifact],
             values: getProducerOutputValues,
           });
         } catch {

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -44,6 +44,7 @@ import {
 } from '../utils/truncation.js';
 import {
   finalizeToolResponses,
+  toolResponseBudgetedTextLength,
   toolResponseTextLength,
 } from '../utils/tool-response-finalizer.js';
 import {
@@ -6038,6 +6039,16 @@ export class CoreToolScheduler {
     const budget =
       this.config.getToolOutputBatchBudget?.() ?? Number.POSITIVE_INFINITY;
     if (!Number.isFinite(budget) || budget <= 0) return completedCalls;
+    const exceedsBudget =
+      completedCalls.reduce(
+        (total, call) =>
+          total +
+          toolResponseBudgetedTextLength(
+            call.response.responseParts,
+            call.request.name,
+          ),
+        0,
+      ) > budget;
 
     const finalized = await finalizeToolResponses(
       this.config,
@@ -6054,7 +6065,7 @@ export class CoreToolScheduler {
           call.request.prompt_id,
         ]),
       ),
-      false,
+      exceedsBudget,
     );
 
     return completedCalls.map((call, index) => ({

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -44,7 +44,6 @@ import {
 } from '../utils/truncation.js';
 import {
   finalizeToolResponses,
-  toolResponseBudgetedTextLength,
   toolResponseTextLength,
 } from '../utils/tool-response-finalizer.js';
 import {
@@ -78,6 +77,7 @@ import {
   todoWorkChainContext,
 } from '../utils/promptIdContext.js';
 import {
+  isToolResultBoundaryDiagnosticsEnabled,
   observeToolResultBoundary,
   toolResultBoundaryArtifact,
   toolResultPartDiagnosticValues,
@@ -1322,10 +1322,10 @@ function partitionToolCalls(calls: ScheduledToolCall[]): ToolBatch[] {
 }
 
 function producerTextEqual(
-  input: PartListUnion,
+  input: PartListUnion | null | undefined,
   output: PartListUnion,
 ): boolean {
-  const diagnosticText = (value: PartListUnion) =>
+  const diagnosticText = (value: PartListUnion | null | undefined) =>
     toolResultPartDiagnosticValues(value)
       .map((slot) => slot.value)
       .join('\n');
@@ -5860,7 +5860,11 @@ export class CoreToolScheduler {
       }
       try {
         const batchBudget = this.config.getToolOutputBatchBudget?.();
-        if (batchBudget !== undefined && Number.isFinite(batchBudget)) {
+        if (
+          messageBus &&
+          batchBudget !== undefined &&
+          Number.isFinite(batchBudget)
+        ) {
           completedCalls = await this.applyBatchOutputBudget(completedCalls);
         }
 
@@ -6038,18 +6042,13 @@ export class CoreToolScheduler {
   ): Promise<CompletedToolCall[]> {
     const budget =
       this.config.getToolOutputBatchBudget?.() ?? Number.POSITIVE_INFINITY;
-    if (!Number.isFinite(budget) || budget <= 0) return completedCalls;
-    const exceedsBudget =
-      completedCalls.reduce(
-        (total, call) =>
-          total +
-          toolResponseBudgetedTextLength(
-            call.response.responseParts,
-            call.request.name,
-          ),
-        0,
-      ) > budget;
-
+    const observeFinalizerBoundary = isToolResultBoundaryDiagnosticsEnabled();
+    if (
+      (!Number.isFinite(budget) || budget <= 0) &&
+      !observeFinalizerBoundary
+    ) {
+      return completedCalls;
+    }
     const finalized = await finalizeToolResponses(
       this.config,
       completedCalls.map((call) => ({
@@ -6065,7 +6064,8 @@ export class CoreToolScheduler {
           call.request.prompt_id,
         ]),
       ),
-      exceedsBudget,
+      observeFinalizerBoundary,
+      observeFinalizerBoundary,
     );
 
     return completedCalls.map((call, index) => ({

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -76,6 +76,12 @@ import {
   promptIdContext,
   todoWorkChainContext,
 } from '../utils/promptIdContext.js';
+import {
+  observeToolResultBoundary,
+  toolResultBoundaryArtifact,
+  toolResultPartDiagnosticValues,
+  type ToolResultBoundaryValue,
+} from '../utils/tool-result-boundary-diagnostics.js';
 import { unescapePath, PATH_ARG_KEYS } from '../utils/paths.js';
 import type { MemoryPressureMonitor } from '../services/memoryPressureMonitor.js';
 import { CONCURRENCY_SAFE_KINDS, isShellProgressData } from '../tools/tools.js';
@@ -1312,6 +1318,20 @@ export function partitionByConcurrencySafety<T>(
 
 function partitionToolCalls(calls: ScheduledToolCall[]): ToolBatch[] {
   return partitionByConcurrencySafety(calls, isConcurrencySafe);
+}
+
+function toolResultBoundaryValuesEqual(
+  left: readonly ToolResultBoundaryValue[],
+  right: readonly ToolResultBoundaryValue[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every(
+      (value, index) =>
+        value.representation === right[index].representation &&
+        value.value === right[index].value,
+    )
+  );
 }
 
 export class CoreToolScheduler {
@@ -4584,6 +4604,7 @@ export class CoreToolScheduler {
     let executionStatus: ToolExecutionStatus = 'not_started';
     let executionSettled = false;
     let execSpan: Span | undefined;
+    let observeProducerOutput = (_response: CoreToolCallResponseInfo) => {};
     try {
       let promise: Promise<ToolResult>;
 
@@ -4745,6 +4766,81 @@ export class CoreToolScheduler {
       } else {
         toolResult = await promise;
       }
+      let producerInputValues: ToolResultBoundaryValue[] | undefined;
+      const getProducerInputValues = () =>
+        (producerInputValues ??= [
+          ...toolResultPartDiagnosticValues(toolResult.llmContent),
+          ...(typeof toolResult.returnDisplay === 'string'
+            ? [
+                {
+                  representation: 'display' as const,
+                  value: toolResult.returnDisplay,
+                },
+              ]
+            : []),
+        ]);
+      observeProducerOutput = (response: CoreToolCallResponseInfo) => {
+        try {
+          let producerOutputValues: ToolResultBoundaryValue[] | undefined;
+          const getProducerOutputValues = () =>
+            (producerOutputValues ??= [
+              ...toolResultPartDiagnosticValues(response.responseParts),
+              ...(typeof response.resultDisplay === 'string'
+                ? [
+                    {
+                      representation: 'display' as const,
+                      value: response.resultDisplay,
+                    },
+                  ]
+                : []),
+              ...(typeof response.visionBridgeNotice === 'string'
+                ? [
+                    {
+                      representation: 'display' as const,
+                      value: response.visionBridgeNotice,
+                    },
+                  ]
+                : []),
+            ]);
+          let mutated: boolean | undefined;
+          const isMutated = () =>
+            (mutated ??= !toolResultBoundaryValuesEqual(
+              getProducerInputValues(),
+              getProducerOutputValues(),
+            ));
+          const observation = {
+            sessionId: this.config.getSessionId(),
+            promptId: scheduledCall.request.prompt_id,
+            toolCallId: callId,
+            toolName: canonicalName,
+            mutated: isMutated,
+          };
+          observeToolResultBoundary({
+            ...observation,
+            stage: 'producer_input',
+            artifacts: [
+              toolResultBoundaryArtifact(
+                toolResult.persistedOutputFiles,
+                toolResult.artifacts,
+              ),
+            ],
+            values: getProducerInputValues,
+          });
+          observeToolResultBoundary({
+            ...observation,
+            stage: 'producer_output',
+            artifacts: [
+              toolResultBoundaryArtifact(
+                response.persistedOutputFiles,
+                response.artifacts,
+              ),
+            ],
+            values: getProducerOutputValues,
+          });
+        } catch {
+          // Diagnostics must not affect tool execution.
+        }
+      };
       // A tool that observes signal.aborted and resolves with a normal
       // ToolResult (no .error field) would otherwise close the execution
       // sub-span as success while the parent tool span ends as cancelled.
@@ -4818,17 +4914,15 @@ export class CoreToolScheduler {
           }
           failureHookArtifacts = failureHookResult.artifacts;
         }
-        this.setStatusInternal(
-          callId,
-          'cancelled',
-          createCancelledResponse(
-            scheduledCall.request,
-            cancelMessage,
-            executionStatus,
-            failureHookArtifacts,
-            toolResult.persistedOutputFiles,
-          ),
+        const cancelledResponse = createCancelledResponse(
+          scheduledCall.request,
+          cancelMessage,
+          executionStatus,
+          failureHookArtifacts,
+          toolResult.persistedOutputFiles,
         );
+        observeProducerOutput(cancelledResponse);
+        this.setStatusInternal(callId, 'cancelled', cancelledResponse);
         setToolSpanCancelled(span);
         return; // Both code paths should return here
       }
@@ -4843,19 +4937,17 @@ export class CoreToolScheduler {
         if (!signal.aborted || (isTimeout && parentAbortedAtExecutionSettle)) {
           return false;
         }
-        this.setStatusInternal(
-          callId,
-          'cancelled',
-          createCancelledResponse(
-            scheduledCall.request,
-            // Reached only after `execute()` settled with a result.
-            TOOL_CANCELLED_AFTER_COMPLETION_MESSAGE,
-            executionStatus,
-            artifacts,
-            preserved?.persistedOutputFiles,
-            preserved?.visionBridgeNotice,
-          ),
+        const cancelledResponse = createCancelledResponse(
+          scheduledCall.request,
+          // Reached only after `execute()` settled with a result.
+          TOOL_CANCELLED_AFTER_COMPLETION_MESSAGE,
+          executionStatus,
+          artifacts,
+          preserved?.persistedOutputFiles,
+          preserved?.visionBridgeNotice,
         );
+        observeProducerOutput(cancelledResponse);
+        this.setStatusInternal(callId, 'cancelled', cancelledResponse);
         setToolSpanCancelled(span);
         return true;
       };
@@ -4953,6 +5045,7 @@ export class CoreToolScheduler {
             if (persistedOutputFiles !== undefined) {
               errorResponse.persistedOutputFiles = persistedOutputFiles;
             }
+            observeProducerOutput(errorResponse);
             this.setStatusInternal(callId, 'error', errorResponse);
             setToolSpanFailure(
               span,
@@ -5311,6 +5404,7 @@ export class CoreToolScheduler {
         ) {
           return;
         }
+        observeProducerOutput(successResponse);
         this.setStatusInternal(callId, 'success', successResponse);
         // Mirrors setToolSpanFailure/setToolSpanCancelled — every tool span
         // ends with an explicit `success` attribute so backends can filter
@@ -5422,7 +5516,7 @@ export class CoreToolScheduler {
           ) {
             return;
           }
-          this.setStatusInternal(callId, 'error', {
+          const timeoutResponse: CoreToolCallResponseInfo = {
             callId,
             responseParts,
             resultDisplay: this.compactResultDisplayForInteractiveHistory(
@@ -5442,7 +5536,9 @@ export class CoreToolScheduler {
               ? { visionBridgeNotice: processedImages.visionBridgeNotice }
               : {}),
             ...(artifacts.length > 0 ? { artifacts } : {}),
-          });
+          };
+          observeProducerOutput(timeoutResponse);
+          this.setStatusInternal(callId, 'error', timeoutResponse);
           setToolSpanFailure(
             span,
             TOOL_FAILURE_KIND_TIMEOUT,
@@ -5550,6 +5646,7 @@ export class CoreToolScheduler {
         ) {
           return;
         }
+        observeProducerOutput(errorResponse);
         this.setStatusInternal(callId, 'error', errorResponse);
         setToolSpanFailure(
           span,
@@ -5638,16 +5735,14 @@ export class CoreToolScheduler {
           }
           failureHookArtifacts = failureHookResult.artifacts;
         }
-        this.setStatusInternal(
-          callId,
-          'cancelled',
-          createCancelledResponse(
-            scheduledCall.request,
-            cancelMessage,
-            executionStatus,
-            failureHookArtifacts,
-          ),
+        const cancelledResponse = createCancelledResponse(
+          scheduledCall.request,
+          cancelMessage,
+          executionStatus,
+          failureHookArtifacts,
         );
+        observeProducerOutput(cancelledResponse);
+        this.setStatusInternal(callId, 'cancelled', cancelledResponse);
         setToolSpanCancelled(span);
         return;
       } else {
@@ -5683,36 +5778,32 @@ export class CoreToolScheduler {
           failureHookArtifacts = failureHookResult.artifacts;
         }
         if (signal.aborted && !executionTimedOut) {
-          this.setStatusInternal(
-            callId,
-            'cancelled',
-            createCancelledResponse(
-              scheduledCall.request,
-              // The abort landed while the failure hook was running; the
-              // tool's own outcome is still what `executionThrew` says.
-              executionThrew
-                ? TOOL_CANCELLED_BEFORE_COMPLETION_MESSAGE
-                : TOOL_CANCELLED_AFTER_COMPLETION_MESSAGE,
-              executionStatus,
-              failureHookArtifacts,
-            ),
+          const cancelledResponse = createCancelledResponse(
+            scheduledCall.request,
+            // The abort landed while the failure hook was running; the
+            // tool's own outcome is still what `executionThrew` says.
+            executionThrew
+              ? TOOL_CANCELLED_BEFORE_COMPLETION_MESSAGE
+              : TOOL_CANCELLED_AFTER_COMPLETION_MESSAGE,
+            executionStatus,
+            failureHookArtifacts,
           );
+          observeProducerOutput(cancelledResponse);
+          this.setStatusInternal(callId, 'cancelled', cancelledResponse);
           setToolSpanCancelled(span);
           return;
         }
-        this.setStatusInternal(
-          callId,
-          'error',
-          createErrorResponse(
-            scheduledCall.request,
-            executionError instanceof Error
-              ? new Error(exceptionErrorMessage)
-              : new Error(String(executionError)),
-            exceptionErrorType,
-            executionStatus,
-            failureHookArtifacts,
-          ),
+        const errorResponse = createErrorResponse(
+          scheduledCall.request,
+          executionError instanceof Error
+            ? new Error(exceptionErrorMessage)
+            : new Error(String(executionError)),
+          exceptionErrorType,
+          executionStatus,
+          failureHookArtifacts,
         );
+        observeProducerOutput(errorResponse);
+        this.setStatusInternal(callId, 'error', errorResponse);
         setToolSpanFailure(
           span,
           TOOL_FAILURE_KIND_TOOL_EXCEPTION,
@@ -5947,7 +6038,14 @@ export class CoreToolScheduler {
         toolName: call.request.name,
         responseParts: call.response.responseParts,
         persistedOutputFiles: call.response.persistedOutputFiles,
+        artifacts: call.response.artifacts,
       })),
+      new Map(
+        completedCalls.map((call) => [
+          call.request.callId,
+          call.request.prompt_id,
+        ]),
+      ),
     );
 
     return completedCalls.map((call, index) => ({
@@ -5970,6 +6068,8 @@ export class CoreToolScheduler {
         status: call.status,
         executionStatus: call.response.executionStatus,
         resultDisplay: call.response.resultDisplay,
+        persistedOutputFiles: call.response.persistedOutputFiles,
+        artifacts: call.response.artifacts,
         ...(call.response.visionBridgeNotice !== undefined
           ? { visionBridgeNotice: call.response.visionBridgeNotice }
           : {}),

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -4458,9 +4458,9 @@ export class CoreToolScheduler {
     const observeSyntheticProducer = (
       response: CoreToolCallResponseInfo,
     ): void => {
-      if (producerObserved || !this.shouldObserveProducer(callId)) return;
-      producerObserved = true;
       try {
+        if (producerObserved || !this.shouldObserveProducer(callId)) return;
+        producerObserved = true;
         observeToolResultBoundary({
           stage: 'producer',
           sessionId: this.config.getSessionId(),
@@ -4849,9 +4849,9 @@ export class CoreToolScheduler {
       }
       producerToolResult = toolResult;
       observeProducerOutput = (response: CoreToolCallResponseInfo) => {
-        if (producerObserved || !this.shouldObserveProducer(callId)) return;
-        producerObserved = true;
         try {
+          if (producerObserved || !this.shouldObserveProducer(callId)) return;
+          producerObserved = true;
           let producerInputValues: ToolResultBoundaryValue[] | undefined;
           const getProducerInputValues = () =>
             (producerInputValues ??= [

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -17,6 +17,7 @@ import { FinishReason } from './genai-compat.js';
 import type {
   ToolCallConfirmationDetails,
   ToolArtifact,
+  ToolResultBoundaryArtifact,
   ToolResult,
   ToolResultDisplay,
 } from '../tools/tools.js';
@@ -158,6 +159,7 @@ export interface ToolCallResponseInfo {
   terminateTurn?: boolean;
   visionBridgeNotice?: string;
   artifacts?: ToolArtifact[];
+  boundaryArtifact?: ToolResultBoundaryArtifact;
 }
 
 function normalizeRequestParts(req: PartListUnion): Part[] {

--- a/packages/core/src/followup/speculation.test.ts
+++ b/packages/core/src/followup/speculation.test.ts
@@ -258,6 +258,83 @@ describe('startSpeculation', () => {
     await abortSpeculation(state);
   });
 
+  it('ignores throwing optional metadata on a speculative result', async () => {
+    const result = { llmContent: 'file contents' } as {
+      llmContent: string;
+      artifacts?: never;
+      persistedOutputFiles?: never;
+    };
+    Object.defineProperties(result, {
+      artifacts: {
+        get: () => {
+          throw new Error('artifacts unavailable');
+        },
+      },
+      persistedOutputFiles: {
+        get: () => {
+          throw new Error('persisted output unavailable');
+        },
+      },
+    });
+    const toolRegistry = {
+      ensureTool: vi.fn().mockResolvedValue({
+        build: vi.fn().mockReturnValue({
+          execute: vi.fn().mockResolvedValue(result),
+        }),
+      }),
+    };
+    const config = {
+      getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
+      getCwd: vi.fn().mockReturnValue(process.cwd()),
+      getFastModel: vi.fn().mockReturnValue(undefined),
+      getToolRegistry: vi.fn().mockReturnValue(toolRegistry),
+    } as unknown as Config;
+
+    forkedAgentMocks.runForkedAgent.mockResolvedValue({
+      jsonResult: { suggestion: '' },
+    });
+    forkedAgentMocks.sendMessageStream.mockImplementation(async function* () {
+      if (forkedAgentMocks.sendMessageStream.mock.calls.length === 1) {
+        yield {
+          type: 'chunk',
+          value: {
+            candidates: [
+              {
+                content: {
+                  parts: [
+                    {
+                      functionCall: {
+                        id: 'call-speculation-metadata',
+                        name: 'read_file',
+                        args: { path: 'a.ts' },
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        };
+      }
+    });
+
+    const state = await startSpeculation(config, 'read a.ts');
+    await vi.waitFor(() => expect(state.status).toBe('completed'));
+
+    expect(state.messages[2].parts?.[0].functionResponse?.response).toEqual({
+      output: 'file contents',
+    });
+    expect(boundaryMocks.observe).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: 'producer',
+        toolCallId: 'call-speculation-metadata',
+        artifacts: [{ state: 'undecided', kinds: [] }],
+      }),
+    );
+
+    await abortSpeculation(state);
+  });
+
   it('preserves generated tool call ids in paired responses', async () => {
     const execute = vi.fn().mockResolvedValue({
       llmContent: 'file contents',

--- a/packages/core/src/followup/speculation.test.ts
+++ b/packages/core/src/followup/speculation.test.ts
@@ -12,13 +12,14 @@ import {
 } from './speculation.js';
 import type { Content } from '@google/genai';
 import { ApprovalMode, type Config } from '../config/config.js';
+import type { ToolResultBoundaryObservation } from '../utils/tool-result-boundary-diagnostics.js';
 
 const forkedAgentMocks = vi.hoisted(() => ({
   runForkedAgent: vi.fn(),
   sendMessageStream: vi.fn(),
 }));
 const boundaryMocks = vi.hoisted(() => ({
-  observe: vi.fn(() => false),
+  observe: vi.fn((_observation: ToolResultBoundaryObservation) => false),
 }));
 
 vi.mock(
@@ -188,6 +189,71 @@ describe('startSpeculation', () => {
         values: expect.any(Function),
       }),
     );
+
+    await abortSpeculation(state);
+  });
+
+  it('observes rejected speculative executions as terminal producers', async () => {
+    const execute = vi.fn().mockRejectedValue(new Error('execution failed'));
+    const toolRegistry = {
+      ensureTool: vi.fn().mockResolvedValue({
+        build: vi.fn().mockReturnValue({ execute }),
+      }),
+    };
+    const config = {
+      getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
+      getCwd: vi.fn().mockReturnValue(process.cwd()),
+      getFastModel: vi.fn().mockReturnValue(undefined),
+      getToolRegistry: vi.fn().mockReturnValue(toolRegistry),
+    } as unknown as Config;
+
+    forkedAgentMocks.runForkedAgent.mockResolvedValue({
+      jsonResult: { suggestion: '' },
+    });
+    forkedAgentMocks.sendMessageStream.mockImplementation(async function* () {
+      if (forkedAgentMocks.sendMessageStream.mock.calls.length === 1) {
+        yield {
+          type: 'chunk',
+          value: {
+            candidates: [
+              {
+                content: {
+                  parts: [
+                    {
+                      functionCall: {
+                        id: 'call-speculation-reject',
+                        name: 'read_file',
+                        args: { path: 'a.ts' },
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        };
+      }
+    });
+
+    const state = await startSpeculation(config, 'read a.ts');
+    await vi.waitFor(() => expect(state.status).toBe('completed'));
+
+    const producerObservations = boundaryMocks.observe.mock.calls
+      .map(([observation]) => observation)
+      .filter(
+        (observation) =>
+          observation.stage === 'producer' &&
+          observation.toolCallId === 'call-speculation-reject',
+      );
+    expect(producerObservations).toHaveLength(1);
+    expect(producerObservations[0]).toEqual(
+      expect.objectContaining({
+        artifacts: [{ state: 'none', kinds: [] }],
+      }),
+    );
+    expect(state.messages[2].parts?.[0].functionResponse?.response).toEqual({
+      error: 'execution failed',
+    });
 
     await abortSpeculation(state);
   });

--- a/packages/core/src/followup/speculation.test.ts
+++ b/packages/core/src/followup/speculation.test.ts
@@ -17,6 +17,19 @@ const forkedAgentMocks = vi.hoisted(() => ({
   runForkedAgent: vi.fn(),
   sendMessageStream: vi.fn(),
 }));
+const boundaryMocks = vi.hoisted(() => ({
+  observe: vi.fn(() => false),
+}));
+
+vi.mock(
+  '../utils/tool-result-boundary-diagnostics.js',
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import('../utils/tool-result-boundary-diagnostics.js')
+    >()),
+    observeToolResultBoundary: boundaryMocks.observe,
+  }),
+);
 
 vi.mock('../utils/forkedAgent.js', () => ({
   getCacheSafeParams: vi.fn(() => ({
@@ -167,6 +180,14 @@ describe('startSpeculation', () => {
       signal: expect.any(AbortSignal),
     });
     expect(execute).toHaveBeenCalledOnce();
+    expect(boundaryMocks.observe).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: 'producer',
+        toolCallId: 'call-speculation-guard-allow',
+        toolName: 'read_file',
+        values: expect.any(Function),
+      }),
+    );
 
     await abortSpeculation(state);
   });

--- a/packages/core/src/followup/speculation.ts
+++ b/packages/core/src/followup/speculation.ts
@@ -41,6 +41,11 @@ import {
   finalizeToolResponses,
   type ToolResponseBudgetEntry,
 } from '../utils/tool-response-finalizer.js';
+import {
+  observeToolResultBoundary,
+  toolResultBoundaryArtifact,
+  toolResultPartDiagnosticValues,
+} from '../utils/tool-result-boundary-diagnostics.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -370,6 +375,34 @@ async function runSpeculativeLoop(
           );
           state.toolUseCount++;
 
+          try {
+            observeToolResultBoundary({
+              stage: 'producer',
+              sessionId: config.getSessionId?.(),
+              toolCallId: persistenceCallId,
+              toolName: name,
+              artifacts: [
+                toolResultBoundaryArtifact(
+                  result.persistedOutputFiles,
+                  result.artifacts,
+                ),
+              ],
+              values: () => [
+                ...toolResultPartDiagnosticValues(result.llmContent),
+                ...(typeof result.returnDisplay === 'string'
+                  ? [
+                      {
+                        representation: 'display' as const,
+                        value: result.returnDisplay,
+                      },
+                    ]
+                  : []),
+              ],
+            });
+          } catch {
+            // Diagnostics must not affect speculative execution.
+          }
+
           const convertedResponseParts = result.error
             ? convertToFunctionErrorResponse(
                 name,
@@ -397,6 +430,7 @@ async function runSpeculativeLoop(
             toolName: name,
             responseParts,
             persistedOutputFiles: result.persistedOutputFiles,
+            artifacts: result.artifacts,
           });
         } catch (error: unknown) {
           const responsePart: Part = {

--- a/packages/core/src/followup/speculation.ts
+++ b/packages/core/src/followup/speculation.ts
@@ -56,6 +56,34 @@ const debugLogger = createDebugLogger('SPECULATION');
 const MAX_SPECULATION_TURNS = 20;
 const MAX_SPECULATION_MESSAGES = 100;
 
+function observeSpeculationProducer(params: {
+  config: Config;
+  callId: string;
+  toolName: string;
+  persistedOutputFiles?: string[];
+  artifacts?: ReadonlyArray<{ kind?: unknown }>;
+  knownNone?: boolean;
+  values: () => ReturnType<typeof toolResultPartDiagnosticValues>;
+}): void {
+  try {
+    observeToolResultBoundary({
+      stage: 'producer',
+      sessionId: params.config.getSessionId?.(),
+      toolCallId: params.callId,
+      toolName: params.toolName,
+      artifacts: [
+        toolResultBoundaryArtifact(
+          params.knownNone ? [] : params.persistedOutputFiles,
+          params.artifacts,
+        ),
+      ],
+      values: params.values,
+    });
+  } catch {
+    // Diagnostics must not affect speculative execution.
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -299,6 +327,22 @@ async function runSpeculativeLoop(
         const args = (fc.args ?? {}) as Record<string, unknown>;
         const persistenceCallId =
           id ?? `${name}-${state.id}-${turn}-${responseEntries.length}`;
+        let producerObserved = false;
+        const observeProducer = (
+          params: Omit<
+            Parameters<typeof observeSpeculationProducer>[0],
+            'config' | 'callId' | 'toolName'
+          >,
+        ) => {
+          if (producerObserved) return;
+          producerObserved = true;
+          observeSpeculationProducer({
+            ...params,
+            config,
+            callId: persistenceCallId,
+            toolName: name,
+          });
+        };
         const gate = await evaluateToolCall(
           name,
           args,
@@ -335,6 +379,10 @@ async function runSpeculativeLoop(
                 response: { error: `Tool '${name}' not found` },
               },
             };
+            observeProducer({
+              knownNone: true,
+              values: () => toolResultPartDiagnosticValues(responsePart),
+            });
             functionResponses.push(responsePart);
             responseEntries.push({
               callId: persistenceCallId,
@@ -375,33 +423,21 @@ async function runSpeculativeLoop(
           );
           state.toolUseCount++;
 
-          try {
-            observeToolResultBoundary({
-              stage: 'producer',
-              sessionId: config.getSessionId?.(),
-              toolCallId: persistenceCallId,
-              toolName: name,
-              artifacts: [
-                toolResultBoundaryArtifact(
-                  result.persistedOutputFiles,
-                  result.artifacts,
-                ),
-              ],
-              values: () => [
-                ...toolResultPartDiagnosticValues(result.llmContent),
-                ...(typeof result.returnDisplay === 'string'
-                  ? [
-                      {
-                        representation: 'display' as const,
-                        value: result.returnDisplay,
-                      },
-                    ]
-                  : []),
-              ],
-            });
-          } catch {
-            // Diagnostics must not affect speculative execution.
-          }
+          observeProducer({
+            persistedOutputFiles: result.persistedOutputFiles,
+            artifacts: result.artifacts,
+            values: () => [
+              ...toolResultPartDiagnosticValues(result.llmContent),
+              ...(typeof result.returnDisplay === 'string'
+                ? [
+                    {
+                      representation: 'display' as const,
+                      value: result.returnDisplay,
+                    },
+                  ]
+                : []),
+            ],
+          });
 
           const convertedResponseParts = result.error
             ? convertToFunctionErrorResponse(
@@ -445,6 +481,10 @@ async function runSpeculativeLoop(
               },
             },
           };
+          observeProducer({
+            knownNone: true,
+            values: () => toolResultPartDiagnosticValues(responsePart),
+          });
           functionResponses.push(responsePart);
           responseEntries.push({
             callId: persistenceCallId,

--- a/packages/core/src/followup/speculation.ts
+++ b/packages/core/src/followup/speculation.ts
@@ -18,6 +18,7 @@
 import type { Content, Part } from '@google/genai';
 import type { Config } from '../config/config.js';
 import type { GeminiClient } from '../core/client.js';
+import type { ToolArtifact } from '../tools/tools.js';
 import { StreamEventType } from '../core/geminiChat.js';
 import {
   convertToFunctionErrorResponse,
@@ -422,10 +423,22 @@ async function runSpeculativeLoop(
             state.abortController!.signal,
           );
           state.toolUseCount++;
+          let resultArtifacts: ToolArtifact[] | undefined;
+          let resultPersistedOutputFiles: string[] | undefined;
+          try {
+            resultArtifacts = result.artifacts;
+          } catch {
+            // Optional result metadata must not affect execution.
+          }
+          try {
+            resultPersistedOutputFiles = result.persistedOutputFiles;
+          } catch {
+            // Optional result metadata must not affect execution.
+          }
 
           observeProducer({
-            persistedOutputFiles: result.persistedOutputFiles,
-            artifacts: result.artifacts,
+            persistedOutputFiles: resultPersistedOutputFiles,
+            artifacts: resultArtifacts,
             values: () => [
               ...toolResultPartDiagnosticValues(result.llmContent),
               ...(typeof result.returnDisplay === 'string'
@@ -465,8 +478,8 @@ async function runSpeculativeLoop(
             callId: persistenceCallId,
             toolName: name,
             responseParts,
-            persistedOutputFiles: result.persistedOutputFiles,
-            artifacts: result.artifacts,
+            persistedOutputFiles: resultPersistedOutputFiles,
+            artifacts: resultArtifacts,
           });
         } catch (error: unknown) {
           const responsePart: Part = {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -586,6 +586,7 @@ export * from './utils/pathReader.js';
 export * from './utils/paths.js';
 export * from './utils/projectSummary.js';
 export * from './utils/promptIdContext.js';
+export * from './utils/tool-result-boundary-diagnostics.js';
 export * from './utils/proxyUtils.js';
 export * from './utils/quotaErrorDetection.js';
 export * from './utils/rateLimit.js';

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -33,6 +33,7 @@ import type {
   GoalStateRecordPayloadV2,
   GoalTurnPermit,
 } from '../goals/goal-protocol.js';
+import type { ToolResultBoundaryObservation } from '../utils/tool-result-boundary-diagnostics.js';
 
 vi.mock('node:path');
 vi.mock('node:child_process');
@@ -46,6 +47,19 @@ vi.mock('node:crypto', () => ({
 }));
 vi.mock('../utils/jsonl-utils.js');
 
+const boundaryObserveMock = vi.hoisted(() =>
+  vi.fn((_observation: ToolResultBoundaryObservation) => false),
+);
+vi.mock(
+  '../utils/tool-result-boundary-diagnostics.js',
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import('../utils/tool-result-boundary-diagnostics.js')
+    >()),
+    observeToolResultBoundary: boundaryObserveMock,
+  }),
+);
+
 describe('ChatRecordingService', () => {
   let chatRecordingService: ChatRecordingService;
   let mockConfig: Config;
@@ -55,6 +69,7 @@ describe('ChatRecordingService', () => {
 
   beforeEach(() => {
     uuidCounter = 0;
+    boundaryObserveMock.mockClear();
 
     mockConfig = {
       getSessionId: vi.fn().mockReturnValue('test-session-id'),
@@ -1369,6 +1384,14 @@ describe('ChatRecordingService', () => {
       expect(
         (record.toolCallResult?.resultDisplay as FileDiff).truncatedForSession,
       ).toBeUndefined();
+      const inputObservation = boundaryObserveMock.mock.calls.find(
+        ([observation]) => observation.stage === 'recorder_input',
+      )?.[0];
+      expect(
+        typeof inputObservation?.mutated === 'function'
+          ? inputObservation.mutated()
+          : inputObservation?.mutated,
+      ).toBe(false);
     });
 
     it('compacts large resultDisplay metadata before recording', async () => {
@@ -1523,6 +1546,14 @@ describe('ChatRecordingService', () => {
       expect(resultDisplay.originalContent).toBe(largeOriginal);
       expect(resultDisplay.newContent).toBe(largeNew);
       expect(resultDisplay.truncatedForSession).toBeUndefined();
+      const inputObservation = boundaryObserveMock.mock.calls.find(
+        ([observation]) => observation.stage === 'recorder_input',
+      )?.[0];
+      expect(
+        typeof inputObservation?.mutated === 'function'
+          ? inputObservation.mutated()
+          : inputObservation?.mutated,
+      ).toBe(true);
     });
 
     it('should continue stripping nested tool calls from task execution results', async () => {
@@ -1569,6 +1600,14 @@ describe('ChatRecordingService', () => {
         type: 'task_execution',
         toolCalls: [],
       });
+      const inputObservation = boundaryObserveMock.mock.calls.find(
+        ([observation]) => observation.stage === 'recorder_input',
+      )?.[0];
+      expect(
+        typeof inputObservation?.mutated === 'function'
+          ? inputObservation.mutated()
+          : inputObservation?.mutated,
+      ).toBe(true);
     });
 
     it('should chain tool result correctly with parentUuid', async () => {

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -1308,7 +1308,7 @@ describe('ChatRecordingService', () => {
       expect(record.toolCallResult?.callId).toBe('call-1');
     });
 
-    it('uses persistence metadata only for diagnostics', async () => {
+    it('preserves replayable artifacts without diagnostic metadata', async () => {
       const toolResultParts: Part[] = [
         {
           functionResponse: {
@@ -1319,25 +1319,35 @@ describe('ChatRecordingService', () => {
         },
       ];
 
+      const artifacts = [
+        {
+          kind: 'link' as const,
+          title: 'Replay artifact',
+          url: 'https://example.com/replayed',
+        },
+      ];
       chatRecordingService.recordToolResult(toolResultParts, {
         callId: 'call-1',
         status: 'success',
         persistedOutputFiles: ['/private/tool-result.txt'],
-        artifacts: [
-          {
-            kind: 'link',
-            title: 'private artifact',
-            url: 'https://private.example/result',
-          },
-        ],
+        artifacts,
+        boundaryArtifact: { state: 'reusable', kinds: ['link'] },
       });
       await chatRecordingService.flush();
 
       const record = vi.mocked(jsonl.writeLine).mock.calls[0][1] as ChatRecord;
       expect(record.toolCallResult).not.toHaveProperty('persistedOutputFiles');
-      expect(record.toolCallResult).not.toHaveProperty('artifacts');
+      expect(record.toolCallResult).not.toHaveProperty('boundaryArtifact');
+      expect(
+        JSON.parse(JSON.stringify(record)).toolCallResult.artifacts,
+      ).toEqual(artifacts);
       expect(JSON.stringify(record)).not.toContain('/private/tool-result.txt');
-      expect(JSON.stringify(record)).not.toContain('private.example');
+      expect(boundaryObserveMock).toHaveBeenCalledTimes(2);
+      for (const [observation] of boundaryObserveMock.mock.calls) {
+        expect(observation.artifacts).toEqual([
+          { state: 'reusable', kinds: ['file', 'link'] },
+        ]);
+      }
     });
 
     it('should keep small file diff resultDisplay unchanged', async () => {

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -1293,6 +1293,38 @@ describe('ChatRecordingService', () => {
       expect(record.toolCallResult?.callId).toBe('call-1');
     });
 
+    it('uses persistence metadata only for diagnostics', async () => {
+      const toolResultParts: Part[] = [
+        {
+          functionResponse: {
+            id: 'call-1',
+            name: 'shell',
+            response: { output: 'result' },
+          },
+        },
+      ];
+
+      chatRecordingService.recordToolResult(toolResultParts, {
+        callId: 'call-1',
+        status: 'success',
+        persistedOutputFiles: ['/private/tool-result.txt'],
+        artifacts: [
+          {
+            kind: 'link',
+            title: 'private artifact',
+            url: 'https://private.example/result',
+          },
+        ],
+      });
+      await chatRecordingService.flush();
+
+      const record = vi.mocked(jsonl.writeLine).mock.calls[0][1] as ChatRecord;
+      expect(record.toolCallResult).not.toHaveProperty('persistedOutputFiles');
+      expect(record.toolCallResult).not.toHaveProperty('artifacts');
+      expect(JSON.stringify(record)).not.toContain('/private/tool-result.txt');
+      expect(JSON.stringify(record)).not.toContain('private.example');
+    });
+
     it('should keep small file diff resultDisplay unchanged', async () => {
       const toolResultParts: Part[] = [
         {

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -1734,7 +1734,7 @@ export class ChatRecordingService {
       if (toolCallResult) {
         const recordableToolCallResult = { ...toolCallResult };
         delete recordableToolCallResult.persistedOutputFiles;
-        delete recordableToolCallResult.artifacts;
+        delete recordableToolCallResult.boundaryArtifact;
         recordingToolCallResult = sanitizeToolCallResultForRecording(
           recordableToolCallResult,
         );

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -18,6 +18,11 @@ import { createModelContent, createUserContent } from '../core/genai-compat.js';
 import * as jsonl from '../utils/jsonl-utils.js';
 import { getGitBranch } from '../utils/gitUtils.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
+import {
+  observeToolResultBoundary,
+  toolResultBoundaryArtifact,
+  toolResultPartDiagnosticValues,
+} from '../utils/tool-result-boundary-diagnostics.js';
 import { compactToolResultDisplayForRecording } from '../utils/toolResultDisplayCompaction.js';
 import type { AttributionSnapshot } from './commitAttribution.js';
 import { tryGenerateSessionTitle } from './sessionTitle.js';
@@ -1703,6 +1708,66 @@ export class ChatRecordingService {
     options?: RecordToolResultOptions,
   ): void {
     try {
+      const persistedOutputFiles = toolCallResult?.persistedOutputFiles;
+      const artifacts = [
+        toolResultBoundaryArtifact(
+          persistedOutputFiles,
+          toolCallResult?.artifacts,
+        ),
+      ];
+      const inputDisplay = toolCallResult?.resultDisplay;
+      const inputValues = () => [
+        ...toolResultPartDiagnosticValues(message),
+        ...(typeof inputDisplay === 'string'
+          ? [
+              {
+                representation: 'display' as const,
+                value: inputDisplay,
+              },
+            ]
+          : []),
+      ];
+      let recordingToolCallResult:
+        | (Partial<ToolCallResponseInfo> & { status: Status })
+        | undefined;
+      if (toolCallResult) {
+        const recordableToolCallResult = { ...toolCallResult };
+        delete recordableToolCallResult.persistedOutputFiles;
+        delete recordableToolCallResult.artifacts;
+        recordingToolCallResult = sanitizeToolCallResultForRecording(
+          recordableToolCallResult,
+        );
+      }
+      const outputDisplay = recordingToolCallResult?.resultDisplay;
+      const mutated =
+        typeof inputDisplay === 'string' && inputDisplay !== outputDisplay;
+      observeToolResultBoundary({
+        stage: 'recorder_input',
+        sessionId: this.getSessionId(),
+        toolCallId: toolCallResult?.callId,
+        artifacts,
+        mutated,
+        values: inputValues,
+      });
+      observeToolResultBoundary({
+        stage: 'recorder_output',
+        sessionId: this.getSessionId(),
+        toolCallId: toolCallResult?.callId,
+        artifacts,
+        mutated,
+        values: () => [
+          ...toolResultPartDiagnosticValues(message),
+          ...(typeof outputDisplay === 'string'
+            ? [
+                {
+                  representation: 'display' as const,
+                  value: outputDisplay,
+                },
+              ]
+            : []),
+        ],
+      });
+
       const record: ChatRecord = {
         ...this.createBaseRecord('tool_result'),
         ...(options?.goalContext
@@ -1712,10 +1777,7 @@ export class ChatRecordingService {
         message: createUserContent(message),
       };
 
-      if (toolCallResult) {
-        const recordingToolCallResult =
-          sanitizeToolCallResultForRecording(toolCallResult);
-
+      if (recordingToolCallResult) {
         // special case for task executions - we don't want to record the tool calls
         if (
           typeof recordingToolCallResult.resultDisplay === 'object' &&

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -8,6 +8,7 @@ import { type Config } from '../config/config.js';
 import path from 'node:path';
 import fs from 'node:fs';
 import { randomUUID } from 'node:crypto';
+import { isDeepStrictEqual } from 'node:util';
 import type {
   PartListUnion,
   Content,
@@ -1737,10 +1738,24 @@ export class ChatRecordingService {
         recordingToolCallResult = sanitizeToolCallResultForRecording(
           recordableToolCallResult,
         );
+        if (
+          typeof recordingToolCallResult.resultDisplay === 'object' &&
+          recordingToolCallResult.resultDisplay !== null &&
+          'type' in recordingToolCallResult.resultDisplay &&
+          recordingToolCallResult.resultDisplay.type === 'task_execution'
+        ) {
+          const taskResult =
+            recordingToolCallResult.resultDisplay as AgentResultDisplay;
+          recordingToolCallResult = {
+            ...recordingToolCallResult,
+            resultDisplay: { ...taskResult, toolCalls: [] },
+          };
+        }
       }
       const outputDisplay = recordingToolCallResult?.resultDisplay;
-      const mutated =
-        typeof inputDisplay === 'string' && inputDisplay !== outputDisplay;
+      let displayMutated: boolean | undefined;
+      const mutated = () =>
+        (displayMutated ??= !isDeepStrictEqual(inputDisplay, outputDisplay));
       observeToolResultBoundary({
         stage: 'recorder_input',
         sessionId: this.getSessionId(),
@@ -1778,25 +1793,7 @@ export class ChatRecordingService {
       };
 
       if (recordingToolCallResult) {
-        // special case for task executions - we don't want to record the tool calls
-        if (
-          typeof recordingToolCallResult.resultDisplay === 'object' &&
-          recordingToolCallResult.resultDisplay !== null &&
-          'type' in recordingToolCallResult.resultDisplay &&
-          recordingToolCallResult.resultDisplay.type === 'task_execution'
-        ) {
-          const taskResult =
-            recordingToolCallResult.resultDisplay as AgentResultDisplay;
-          record.toolCallResult = {
-            ...recordingToolCallResult,
-            resultDisplay: {
-              ...taskResult,
-              toolCalls: [],
-            },
-          };
-        } else {
-          record.toolCallResult = recordingToolCallResult;
-        }
+        record.toolCallResult = recordingToolCallResult;
       }
 
       this.appendRecord(record);

--- a/packages/core/src/tools/agent/agent.test.ts
+++ b/packages/core/src/tools/agent/agent.test.ts
@@ -5265,6 +5265,7 @@ describe('AgentTool', () => {
           name: 'read_file',
           success: true,
           responseParts,
+          boundaryArtifact: { state: 'reusable', kinds: ['file'] },
           timestamp: Date.now(),
         } satisfies AgentToolResultEvent);
       });
@@ -5284,6 +5285,10 @@ describe('AgentTool', () => {
       );
       expect(toolCall?.args).toEqual({ path: '/test.ts' });
       expect(toolCall?.responseParts).toBe(responseParts);
+      expect(toolCall?.boundaryArtifact).toEqual({
+        state: 'reusable',
+        kinds: ['file'],
+      });
     });
 
     it('omits subagent protocol payloads from interactive display state', async () => {
@@ -5310,6 +5315,7 @@ describe('AgentTool', () => {
           success: true,
           responseParts,
           resultDisplay: 'Rendered result',
+          boundaryArtifact: { state: 'reusable', kinds: ['file'] },
           timestamp: Date.now(),
         } satisfies AgentToolResultEvent);
       });
@@ -5331,6 +5337,7 @@ describe('AgentTool', () => {
       expect(toolCall?.resultDisplay).toBe('Rendered result');
       expect(toolCall).not.toHaveProperty('args');
       expect(toolCall).not.toHaveProperty('responseParts');
+      expect(toolCall).not.toHaveProperty('boundaryArtifact');
     });
 
     it('should clear pendingConfirmation when TOOL_RESULT arrives for the pending tool (IDE accept path)', async () => {

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -1528,6 +1528,9 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
           ...(typeof event.resultDisplay === 'string'
             ? { resultDisplay: event.resultDisplay }
             : {}),
+          ...(preserveProtocolPayloads && event.boundaryArtifact
+            ? { boundaryArtifact: event.boundaryArtifact }
+            : {}),
         };
 
         // When a tool result arrives for the tool that had a pending

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -466,6 +466,13 @@ export type ToolArtifactKind =
   | 'notebook'
   | 'other';
 
+export type ToolResultArtifactState = 'undecided' | 'none' | 'reusable';
+
+export interface ToolResultBoundaryArtifact {
+  state: ToolResultArtifactState;
+  kinds: Array<ToolArtifactKind | 'unknown'>;
+}
+
 export type ToolArtifactStorage =
   | 'workspace'
   | 'external_url'
@@ -659,6 +666,7 @@ export interface AgentResultDisplay {
     result?: string;
     resultDisplay?: string;
     responseParts?: Part[];
+    boundaryArtifact?: ToolResultBoundaryArtifact;
     description?: string;
   }>;
 }

--- a/packages/core/src/utils/tool-response-finalizer.test.ts
+++ b/packages/core/src/utils/tool-response-finalizer.test.ts
@@ -68,6 +68,7 @@ function config(budget: number): Config {
 describe('tool response finalization', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    boundaryObserveMock.mockReset();
     persist.mockImplementation(async (callId, _toolName, content) => ({
       content,
       outputFile: `/tmp/${callId}.txt`,
@@ -170,6 +171,93 @@ describe('tool response finalization', () => {
     await finalizeToolResponses(config(100), entries, undefined, false);
 
     expect(boundaryObserveMock).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates an unchanged scheduler-owned entry in an outer batch', async () => {
+    boundaryObserveMock.mockReturnValue(true);
+    const owned = entry('owned', [
+      {
+        functionResponse: {
+          id: 'owned',
+          name: 'shell',
+          response: { output: 'a'.repeat(70_000) },
+        },
+      },
+    ]);
+    const promptIds = new Map([
+      ['owned', 'prompt-owned'],
+      ['synthetic', 'prompt-synthetic'],
+    ]);
+    const schedulerFinalized = await finalizeToolResponses(
+      config(200_000),
+      [owned],
+      promptIds,
+      true,
+      true,
+    );
+    boundaryObserveMock.mockClear();
+
+    await finalizeToolResponses(
+      config(200_000),
+      [
+        ...schedulerFinalized,
+        entry('synthetic', [
+          {
+            functionResponse: {
+              id: 'synthetic',
+              name: 'shell',
+              response: { output: 'synthetic error' },
+            },
+          },
+        ]),
+      ],
+      promptIds,
+    );
+
+    expect(
+      boundaryObserveMock.mock.calls.map(([observation]) => [
+        observation.toolCallId,
+        observation.stage,
+      ]),
+    ).toEqual([
+      ['synthetic', 'finalizer_input'],
+      ['synthetic', 'finalizer_output'],
+    ]);
+  });
+
+  it('observes an outer mutation of a scheduler-owned entry', async () => {
+    boundaryObserveMock.mockReturnValue(true);
+    const promptIds = new Map([['owned', 'prompt-owned']]);
+    const schedulerFinalized = await finalizeToolResponses(
+      config(200_000),
+      [
+        entry('owned', [
+          {
+            functionResponse: {
+              id: 'owned',
+              name: 'shell',
+              response: { output: 'a'.repeat(70_000) },
+            },
+          },
+        ]),
+      ],
+      promptIds,
+      true,
+      true,
+    );
+    boundaryObserveMock.mockClear();
+
+    await finalizeToolResponses(config(10_000), schedulerFinalized, promptIds);
+
+    expect(
+      boundaryObserveMock.mock.calls.map(([observation]) => [
+        observation.stage,
+        observation.mutated,
+      ]),
+    ).toEqual([
+      ['finalizer_input', true],
+      ['finalizer_output', true],
+    ]);
   });
 
   it.each([false, true])(

--- a/packages/core/src/utils/tool-response-finalizer.test.ts
+++ b/packages/core/src/utils/tool-response-finalizer.test.ts
@@ -115,6 +115,45 @@ describe('tool response finalization', () => {
     );
   });
 
+  it('marks only persisted over-budget entries as mutated', async () => {
+    const entries = [
+      entry('large', [
+        {
+          functionResponse: {
+            id: 'large',
+            name: 'shell',
+            response: { output: 'x'.repeat(1000) },
+          },
+        },
+      ]),
+      entry('small', [
+        {
+          functionResponse: {
+            id: 'small',
+            name: 'shell',
+            response: { output: 'ok' },
+          },
+        },
+      ]),
+    ];
+
+    await finalizeToolResponses(config(100), entries);
+
+    const observations = boundaryObserveMock.mock.calls.map(
+      ([observation]) => observation,
+    );
+    expect(
+      observations
+        .filter((observation) => observation.toolCallId === 'large')
+        .map((observation) => observation.mutated),
+    ).toEqual([true, true]);
+    expect(
+      observations
+        .filter((observation) => observation.toolCallId === 'small')
+        .map((observation) => observation.mutated),
+    ).toEqual([false, false]);
+  });
+
   it('can suppress intermediate boundary observations', async () => {
     const entries = [
       entry('small', [

--- a/packages/core/src/utils/tool-response-finalizer.test.ts
+++ b/packages/core/src/utils/tool-response-finalizer.test.ts
@@ -88,11 +88,31 @@ describe('tool response finalization', () => {
       ]),
     ];
 
-    await expect(finalizeToolResponses(config(100), entries)).resolves.toBe(
-      entries,
-    );
+    await expect(
+      finalizeToolResponses(
+        config(100),
+        entries,
+        new Map([['small', 'prompt-small']]),
+      ),
+    ).resolves.toBe(entries);
     expect(persist).not.toHaveBeenCalled();
     expect(debugLogger.info).not.toHaveBeenCalled();
+    expect(boundaryObserveMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        stage: 'finalizer_input',
+        promptId: 'prompt-small',
+        mutated: false,
+      }),
+    );
+    expect(boundaryObserveMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        stage: 'finalizer_output',
+        promptId: 'prompt-small',
+        mutated: false,
+      }),
+    );
   });
 
   it('can suppress intermediate boundary observations', async () => {

--- a/packages/core/src/utils/tool-response-finalizer.test.ts
+++ b/packages/core/src/utils/tool-response-finalizer.test.ts
@@ -23,9 +23,17 @@ const debugLogger = vi.hoisted(() => ({
   warn: vi.fn(),
   error: vi.fn(),
 }));
+const boundaryObserveMock = vi.hoisted(() => vi.fn());
 
 vi.mock('./debugLogger.js', () => ({
   createDebugLogger: () => debugLogger,
+}));
+
+vi.mock('./tool-result-boundary-diagnostics.js', async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import('./tool-result-boundary-diagnostics.js')
+  >()),
+  observeToolResultBoundary: boundaryObserveMock,
 }));
 
 vi.mock('./truncation.js', async (importOriginal) => {
@@ -85,6 +93,24 @@ describe('tool response finalization', () => {
     );
     expect(persist).not.toHaveBeenCalled();
     expect(debugLogger.info).not.toHaveBeenCalled();
+  });
+
+  it('can suppress intermediate boundary observations', async () => {
+    const entries = [
+      entry('small', [
+        {
+          functionResponse: {
+            id: 'small',
+            name: 'shell',
+            response: { output: 'small output' },
+          },
+        },
+      ]),
+    ];
+
+    await finalizeToolResponses(config(100), entries, undefined, false);
+
+    expect(boundaryObserveMock).not.toHaveBeenCalled();
   });
 
   it.each([false, true])(

--- a/packages/core/src/utils/tool-response-finalizer.ts
+++ b/packages/core/src/utils/tool-response-finalizer.ts
@@ -6,8 +6,15 @@
 
 import type { Part } from '@google/genai';
 import type { Config } from '../config/config.js';
+import type { ToolArtifact } from '../tools/tools.js';
 import { getPlanModeLifecyclePrefix } from '../core/plan-mode-entry-policy.js';
 import { createDebugLogger } from './debugLogger.js';
+import {
+  observeToolResultBoundary,
+  toolResultBoundaryArtifact,
+  toolResultPartDiagnosticValues,
+  type ToolResultBoundaryStage,
+} from './tool-result-boundary-diagnostics.js';
 import {
   normalizeToolResultCallId,
   persistAndTruncateToolResult,
@@ -20,6 +27,41 @@ export interface ToolResponseBudgetEntry {
   toolName: string;
   responseParts: Part[];
   persistedOutputFiles?: string[];
+  artifacts?: ToolArtifact[];
+}
+
+function observeFinalizerEntries(
+  config: Config,
+  stage: Extract<
+    ToolResultBoundaryStage,
+    'finalizer_input' | 'finalizer_output'
+  >,
+  entries: ToolResponseBudgetEntry[],
+  mutatedEntryIndexes: ReadonlySet<number>,
+  promptIds?: ReadonlyMap<string, string>,
+): void {
+  for (let index = 0; index < entries.length; index++) {
+    const entry = entries[index];
+    try {
+      observeToolResultBoundary({
+        stage,
+        sessionId: config.getSessionId?.(),
+        promptId: promptIds?.get(entry.callId),
+        toolCallId: entry.callId,
+        toolName: entry.toolName,
+        mutated: mutatedEntryIndexes.has(index),
+        artifacts: [
+          toolResultBoundaryArtifact(
+            entry.persistedOutputFiles,
+            entry.artifacts,
+          ),
+        ],
+        values: () => toolResultPartDiagnosticValues(entry.responseParts),
+      });
+    } catch {
+      // Diagnostics must not affect response finalization.
+    }
+  }
 }
 
 type TextSlot = {
@@ -255,14 +297,49 @@ export function enforceFunctionResponseBudget(
 export async function finalizeToolResponses(
   config: Config,
   entries: ToolResponseBudgetEntry[],
+  promptIds?: ReadonlyMap<string, string>,
 ): Promise<ToolResponseBudgetEntry[]> {
   const budget =
     config.getToolOutputBatchBudget?.() ?? Number.POSITIVE_INFINITY;
-  if (!Number.isFinite(budget) || budget <= 0) return entries;
+  if (!Number.isFinite(budget) || budget <= 0) {
+    const unchanged = new Set<number>();
+    observeFinalizerEntries(
+      config,
+      'finalizer_input',
+      entries,
+      unchanged,
+      promptIds,
+    );
+    observeFinalizerEntries(
+      config,
+      'finalizer_output',
+      entries,
+      unchanged,
+      promptIds,
+    );
+    return entries;
+  }
 
   const slots = collectTextSlots(entries);
   const total = slots.reduce((sum, slot) => sum + slot.text.length, 0);
-  if (total <= budget) return entries;
+  if (total <= budget) {
+    const unchanged = new Set<number>();
+    observeFinalizerEntries(
+      config,
+      'finalizer_input',
+      entries,
+      unchanged,
+      promptIds,
+    );
+    observeFinalizerEntries(
+      config,
+      'finalizer_output',
+      entries,
+      unchanged,
+      promptIds,
+    );
+    return entries;
+  }
 
   const allocations = allocateTextBudget(
     slots.map((slot) => slot.text.length),
@@ -274,6 +351,14 @@ export async function finalizeToolResponses(
       entriesToPersist.add(slots[index].entryIndex);
     }
   }
+
+  observeFinalizerEntries(
+    config,
+    'finalizer_input',
+    entries,
+    entriesToPersist,
+    promptIds,
+  );
 
   const withPersistence = [...entries];
   const normalizedCallIds = entries.map((entry) =>
@@ -339,6 +424,13 @@ export async function finalizeToolResponses(
   }
 
   const finalized = replaceTextSlots(withPersistence, slots, allocations);
+  observeFinalizerEntries(
+    config,
+    'finalizer_output',
+    finalized,
+    entriesToPersist,
+    promptIds,
+  );
   const finalizedTotal = collectTextSlots(finalized).reduce(
     (sum, slot) => sum + slot.text.length,
     0,

--- a/packages/core/src/utils/tool-response-finalizer.ts
+++ b/packages/core/src/utils/tool-response-finalizer.ts
@@ -268,10 +268,25 @@ function replaceTextSlots(
 }
 
 export function toolResponseTextLength(parts: Part[]): number {
+  return toolResponseTextLengthForBudget(parts, false);
+}
+
+export function toolResponseBudgetedTextLength(
+  parts: Part[],
+  toolName: string,
+): number {
+  return toolResponseTextLengthForBudget(parts, true, toolName);
+}
+
+function toolResponseTextLengthForBudget(
+  parts: Part[],
+  excludeBudgetExemptOutput: boolean,
+  toolName = '',
+): number {
   return collectTextSlots(
-    [{ callId: '', toolName: '', responseParts: parts }],
+    [{ callId: '', toolName, responseParts: parts }],
     true,
-    false,
+    excludeBudgetExemptOutput,
   ).reduce((total, slot) => total + slot.text.length, 0);
 }
 
@@ -300,49 +315,35 @@ export async function finalizeToolResponses(
   promptIds?: ReadonlyMap<string, string>,
   observeBoundary = true,
 ): Promise<ToolResponseBudgetEntry[]> {
+  const observeUnchangedEntries = () => {
+    if (!observeBoundary) return;
+    const unchanged = new Set<number>();
+    observeFinalizerEntries(
+      config,
+      'finalizer_input',
+      entries,
+      unchanged,
+      promptIds,
+    );
+    observeFinalizerEntries(
+      config,
+      'finalizer_output',
+      entries,
+      unchanged,
+      promptIds,
+    );
+  };
   const budget =
     config.getToolOutputBatchBudget?.() ?? Number.POSITIVE_INFINITY;
   if (!Number.isFinite(budget) || budget <= 0) {
-    const unchanged = new Set<number>();
-    if (observeBoundary)
-      observeFinalizerEntries(
-        config,
-        'finalizer_input',
-        entries,
-        unchanged,
-        promptIds,
-      );
-    if (observeBoundary)
-      observeFinalizerEntries(
-        config,
-        'finalizer_output',
-        entries,
-        unchanged,
-        promptIds,
-      );
+    observeUnchangedEntries();
     return entries;
   }
 
   const slots = collectTextSlots(entries);
   const total = slots.reduce((sum, slot) => sum + slot.text.length, 0);
   if (total <= budget) {
-    const unchanged = new Set<number>();
-    if (observeBoundary)
-      observeFinalizerEntries(
-        config,
-        'finalizer_input',
-        entries,
-        unchanged,
-        promptIds,
-      );
-    if (observeBoundary)
-      observeFinalizerEntries(
-        config,
-        'finalizer_output',
-        entries,
-        unchanged,
-        promptIds,
-      );
+    observeUnchangedEntries();
     return entries;
   }
 

--- a/packages/core/src/utils/tool-response-finalizer.ts
+++ b/packages/core/src/utils/tool-response-finalizer.ts
@@ -30,6 +30,31 @@ export interface ToolResponseBudgetEntry {
   artifacts?: ToolArtifact[];
 }
 
+const associatedFinalizerResponses = new WeakSet<Part[]>();
+
+function consumeAssociatedFinalizerEntries(
+  entries: ToolResponseBudgetEntry[],
+): Set<number> {
+  const associated = new Set<number>();
+  for (let index = 0; index < entries.length; index++) {
+    const responseParts = entries[index].responseParts;
+    if (associatedFinalizerResponses.has(responseParts)) {
+      associated.add(index);
+      associatedFinalizerResponses.delete(responseParts);
+    }
+  }
+  return associated;
+}
+
+function associateFinalizerEntries(
+  entries: ToolResponseBudgetEntry[],
+  indexes: ReadonlySet<number>,
+): void {
+  for (const index of indexes) {
+    associatedFinalizerResponses.add(entries[index].responseParts);
+  }
+}
+
 function observeFinalizerEntries(
   config: Config,
   stage: Extract<
@@ -39,8 +64,10 @@ function observeFinalizerEntries(
   entries: ToolResponseBudgetEntry[],
   mutatedEntryIndexes: ReadonlySet<number>,
   promptIds?: ReadonlyMap<string, string>,
+  entryIndexes?: ReadonlySet<number>,
 ): void {
   for (let index = 0; index < entries.length; index++) {
+    if (entryIndexes && !entryIndexes.has(index)) continue;
     const entry = entries[index];
     try {
       observeToolResultBoundary({
@@ -268,25 +295,10 @@ function replaceTextSlots(
 }
 
 export function toolResponseTextLength(parts: Part[]): number {
-  return toolResponseTextLengthForBudget(parts, false);
-}
-
-export function toolResponseBudgetedTextLength(
-  parts: Part[],
-  toolName: string,
-): number {
-  return toolResponseTextLengthForBudget(parts, true, toolName);
-}
-
-function toolResponseTextLengthForBudget(
-  parts: Part[],
-  excludeBudgetExemptOutput: boolean,
-  toolName = '',
-): number {
   return collectTextSlots(
-    [{ callId: '', toolName, responseParts: parts }],
+    [{ callId: '', toolName: '', responseParts: parts }],
     true,
-    excludeBudgetExemptOutput,
+    false,
   ).reduce((total, slot) => total + slot.text.length, 0);
 }
 
@@ -314,16 +326,31 @@ export async function finalizeToolResponses(
   entries: ToolResponseBudgetEntry[],
   promptIds?: ReadonlyMap<string, string>,
   observeBoundary = true,
+  associateBoundary = false,
 ): Promise<ToolResponseBudgetEntry[]> {
+  const shouldAssociateBoundary = observeBoundary && associateBoundary;
+  const associatedEntryIndexes = observeBoundary
+    ? consumeAssociatedFinalizerEntries(entries)
+    : new Set<number>();
+  const observationIndexes = (mutatedEntryIndexes: ReadonlySet<number>) =>
+    new Set(
+      entries.flatMap((_, index) =>
+        mutatedEntryIndexes.has(index) || !associatedEntryIndexes.has(index)
+          ? [index]
+          : [],
+      ),
+    );
   const observeUnchangedEntries = () => {
     if (!observeBoundary) return;
     const unchanged = new Set<number>();
+    const indexes = observationIndexes(unchanged);
     observeFinalizerEntries(
       config,
       'finalizer_input',
       entries,
       unchanged,
       promptIds,
+      indexes,
     );
     observeFinalizerEntries(
       config,
@@ -331,12 +358,15 @@ export async function finalizeToolResponses(
       entries,
       unchanged,
       promptIds,
+      indexes,
     );
   };
   const budget =
     config.getToolOutputBatchBudget?.() ?? Number.POSITIVE_INFINITY;
   if (!Number.isFinite(budget) || budget <= 0) {
     observeUnchangedEntries();
+    if (shouldAssociateBoundary)
+      associateFinalizerEntries(entries, new Set(entries.keys()));
     return entries;
   }
 
@@ -344,6 +374,8 @@ export async function finalizeToolResponses(
   const total = slots.reduce((sum, slot) => sum + slot.text.length, 0);
   if (total <= budget) {
     observeUnchangedEntries();
+    if (shouldAssociateBoundary)
+      associateFinalizerEntries(entries, new Set(entries.keys()));
     return entries;
   }
 
@@ -358,6 +390,7 @@ export async function finalizeToolResponses(
     }
   }
 
+  const indexes = observationIndexes(entriesToPersist);
   if (observeBoundary)
     observeFinalizerEntries(
       config,
@@ -365,6 +398,7 @@ export async function finalizeToolResponses(
       entries,
       entriesToPersist,
       promptIds,
+      indexes,
     );
 
   const withPersistence = [...entries];
@@ -438,7 +472,11 @@ export async function finalizeToolResponses(
       finalized,
       entriesToPersist,
       promptIds,
+      indexes,
     );
+  if (shouldAssociateBoundary) {
+    associateFinalizerEntries(finalized, new Set(finalized.keys()));
+  }
   const finalizedTotal = collectTextSlots(finalized).reduce(
     (sum, slot) => sum + slot.text.length,
     0,

--- a/packages/core/src/utils/tool-response-finalizer.ts
+++ b/packages/core/src/utils/tool-response-finalizer.ts
@@ -298,25 +298,28 @@ export async function finalizeToolResponses(
   config: Config,
   entries: ToolResponseBudgetEntry[],
   promptIds?: ReadonlyMap<string, string>,
+  observeBoundary = true,
 ): Promise<ToolResponseBudgetEntry[]> {
   const budget =
     config.getToolOutputBatchBudget?.() ?? Number.POSITIVE_INFINITY;
   if (!Number.isFinite(budget) || budget <= 0) {
     const unchanged = new Set<number>();
-    observeFinalizerEntries(
-      config,
-      'finalizer_input',
-      entries,
-      unchanged,
-      promptIds,
-    );
-    observeFinalizerEntries(
-      config,
-      'finalizer_output',
-      entries,
-      unchanged,
-      promptIds,
-    );
+    if (observeBoundary)
+      observeFinalizerEntries(
+        config,
+        'finalizer_input',
+        entries,
+        unchanged,
+        promptIds,
+      );
+    if (observeBoundary)
+      observeFinalizerEntries(
+        config,
+        'finalizer_output',
+        entries,
+        unchanged,
+        promptIds,
+      );
     return entries;
   }
 
@@ -324,20 +327,22 @@ export async function finalizeToolResponses(
   const total = slots.reduce((sum, slot) => sum + slot.text.length, 0);
   if (total <= budget) {
     const unchanged = new Set<number>();
-    observeFinalizerEntries(
-      config,
-      'finalizer_input',
-      entries,
-      unchanged,
-      promptIds,
-    );
-    observeFinalizerEntries(
-      config,
-      'finalizer_output',
-      entries,
-      unchanged,
-      promptIds,
-    );
+    if (observeBoundary)
+      observeFinalizerEntries(
+        config,
+        'finalizer_input',
+        entries,
+        unchanged,
+        promptIds,
+      );
+    if (observeBoundary)
+      observeFinalizerEntries(
+        config,
+        'finalizer_output',
+        entries,
+        unchanged,
+        promptIds,
+      );
     return entries;
   }
 
@@ -352,13 +357,14 @@ export async function finalizeToolResponses(
     }
   }
 
-  observeFinalizerEntries(
-    config,
-    'finalizer_input',
-    entries,
-    entriesToPersist,
-    promptIds,
-  );
+  if (observeBoundary)
+    observeFinalizerEntries(
+      config,
+      'finalizer_input',
+      entries,
+      entriesToPersist,
+      promptIds,
+    );
 
   const withPersistence = [...entries];
   const normalizedCallIds = entries.map((entry) =>
@@ -424,13 +430,14 @@ export async function finalizeToolResponses(
   }
 
   const finalized = replaceTextSlots(withPersistence, slots, allocations);
-  observeFinalizerEntries(
-    config,
-    'finalizer_output',
-    finalized,
-    entriesToPersist,
-    promptIds,
-  );
+  if (observeBoundary)
+    observeFinalizerEntries(
+      config,
+      'finalizer_output',
+      finalized,
+      entriesToPersist,
+      promptIds,
+    );
   const finalizedTotal = collectTextSlots(finalized).reduce(
     (sum, slot) => sum + slot.text.length,
     0,

--- a/packages/core/src/utils/tool-result-boundary-diagnostics.test.ts
+++ b/packages/core/src/utils/tool-result-boundary-diagnostics.test.ts
@@ -45,6 +45,7 @@ describe('tool-result boundary diagnostics', () => {
         toolCallId: 'secret-tool-call-id',
         toolCallIds: ['secret-tool-call-id-2'],
         toolName: 'secret-tool-name',
+        wireUtf8Bytes: 12_345,
       }),
     ).toBe(true);
 
@@ -60,6 +61,7 @@ describe('tool-result boundary diagnostics', () => {
       toolCallHmacSha256: expect.stringMatching(/^[0-9a-f]{64}$/),
       toolCallHmacSha256s: [expect.stringMatching(/^[0-9a-f]{64}$/)],
       toolNameHmacSha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+      wireUtf8Bytes: 12_345,
     });
     expect(eventValues(event)[0]).toMatchObject({
       representation: 'display',
@@ -79,6 +81,7 @@ describe('tool-result boundary diagnostics', () => {
     ]) {
       expect(line).not.toContain(raw);
     }
+    expect(line).not.toContain(JSON.stringify(secret).slice(1, -1));
   });
 
   it('normalizes untrusted artifact summaries at the log sink', () => {
@@ -106,6 +109,15 @@ describe('tool-result boundary diagnostics', () => {
       artifacts: [{ state: 'undecided', kinds: ['file', 'unknown'] }],
     });
     expect(line).not.toContain('/private/secret');
+
+    observe({
+      stage: 'producer',
+      values: [{ representation: 'display', value: 'eligible' }],
+      artifacts: [{ state: 'none', kinds: [] }],
+    });
+    expect(parseEvent(debug.mock.calls[1][0] as string)).toMatchObject({
+      artifacts: [{ state: 'none', kinds: [] }],
+    });
   });
 
   it('keeps unchanged HMACs equal and changes the first mutated value', () => {
@@ -139,6 +151,7 @@ describe('tool-result boundary diagnostics', () => {
     );
     expect(hashes[0]).toBe(hashes[1]);
     expect(hashes[2]).not.toBe(hashes[1]);
+    expect(parseEvent(debug.mock.calls[0][0] as string)['mutated']).toBe(true);
   });
 
   it('hashes legacy and canonical tool names identically', () => {
@@ -183,6 +196,46 @@ describe('tool-result boundary diagnostics', () => {
 
     const values = eventValues(parseEvent(debug.mock.calls[0][0] as string));
     expect(values[0]['hmacSha256']).not.toBe(values[1]['hmacSha256']);
+    expect(values.map((value) => value['slot'])).toEqual([0, 1]);
+  });
+
+  it('reuses its lazily generated HMAC key across events', () => {
+    const debug = vi.fn();
+    const observe = createToolResultBoundaryObserver({
+      enabled: () => true,
+      logger: { debug, isEnabled: () => true },
+      thresholdBytes: 0,
+    });
+    const observation = {
+      stage: 'producer' as const,
+      sessionId: 'same-session',
+      values: [{ representation: 'display' as const, value: 'eligible' }],
+    };
+
+    observe(observation);
+    observe(observation);
+
+    expect(
+      parseEvent(debug.mock.calls[0][0] as string)['sessionHmacSha256'],
+    ).toBe(parseEvent(debug.mock.calls[1][0] as string)['sessionHmacSha256']);
+  });
+
+  it('executes enabled value and mutation thunks', () => {
+    const debug = vi.fn();
+    const values = vi.fn(() => [
+      { representation: 'display' as const, value: 'small' },
+    ]);
+    const mutated = vi.fn(() => true);
+    const observe = createToolResultBoundaryObserver({
+      enabled: () => true,
+      hmacKey: Buffer.alloc(32, 6),
+      logger: { debug, isEnabled: () => true },
+    });
+
+    expect(observe({ stage: 'producer', mutated, values })).toBe(true);
+    expect(values).toHaveBeenCalledOnce();
+    expect(mutated).toHaveBeenCalledOnce();
+    expect(parseEvent(debug.mock.calls[0][0] as string)['mutated']).toBe(true);
   });
 
   it('matches native JSON byte accounting under fixed-seed fuzzing', () => {
@@ -302,6 +355,26 @@ describe('tool-result boundary diagnostics', () => {
     ).toMatchObject({ jsonUtf8Bytes: 65_537 });
   });
 
+  it('emits when any value exceeds the threshold', () => {
+    const debug = vi.fn();
+    const observe = createToolResultBoundaryObserver({
+      enabled: () => true,
+      hmacKey: Buffer.alloc(32, 4),
+      logger: { debug, isEnabled: () => true },
+    });
+
+    expect(
+      observe({
+        stage: 'producer',
+        values: [
+          { representation: 'display', value: 'a'.repeat(65_535) },
+          { representation: 'display', value: 'small' },
+        ],
+      }),
+    ).toBe(true);
+    expect(debug).toHaveBeenCalledOnce();
+  });
+
   it('rate-limits eligible events and reports the suppressed count', () => {
     let currentTime = 0;
     const debug = vi.fn();
@@ -328,6 +401,11 @@ describe('tool-result boundary diagnostics', () => {
     expect(parseEvent(debug.mock.calls[1][0] as string)).toMatchObject({
       suppressedCount: 1,
     });
+    currentTime = 200;
+    expect(observe(observation)).toBe(true);
+    expect(parseEvent(debug.mock.calls[2][0] as string)).not.toHaveProperty(
+      'suppressedCount',
+    );
   });
 
   it('starts a new rate-limit window when the clock moves backward', () => {

--- a/packages/core/src/utils/tool-result-boundary-diagnostics.test.ts
+++ b/packages/core/src/utils/tool-result-boundary-diagnostics.test.ts
@@ -577,5 +577,11 @@ describe('tool-result boundary diagnostics', () => {
       { representation: 'model_text', value: 'plain' },
       { representation: 'model_text', value: 'top' },
     ]);
+    expect(toolResultPartDiagnosticValues(undefined)).toEqual([
+      { representation: 'model_text', value: '' },
+    ]);
+    expect(toolResultPartDiagnosticValues(null)).toEqual([
+      { representation: 'model_text', value: '' },
+    ]);
   });
 });

--- a/packages/core/src/utils/tool-result-boundary-diagnostics.test.ts
+++ b/packages/core/src/utils/tool-result-boundary-diagnostics.test.ts
@@ -1,0 +1,384 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Buffer } from 'node:buffer';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createToolResultBoundaryObserver,
+  toolResultBoundaryArtifact,
+  toolResultArtifactState,
+  toolResultPartDiagnosticValues,
+  TOOL_RESULT_BOUNDARY_EVENT_NAME,
+} from './tool-result-boundary-diagnostics.js';
+
+function parseEvent(line: string): Record<string, unknown> {
+  return JSON.parse(
+    line.slice(`${TOOL_RESULT_BOUNDARY_EVENT_NAME} `.length),
+  ) as Record<string, unknown>;
+}
+
+function eventValues(event: Record<string, unknown>) {
+  return event['values'] as Array<Record<string, unknown>>;
+}
+
+describe('tool-result boundary diagnostics', () => {
+  it('records exact sizes and process-local HMACs without raw values or identifiers', () => {
+    const debug = vi.fn();
+    const observe = createToolResultBoundaryObserver({
+      enabled: () => true,
+      hmacKey: Buffer.alloc(32, 7),
+      logger: { debug, isEnabled: () => true },
+      thresholdBytes: 0,
+    });
+    const secret = 'secret "汉😀\ud800" output';
+
+    expect(
+      observe({
+        stage: 'producer',
+        values: [{ representation: 'display', value: secret }],
+        artifacts: [{ state: 'reusable', kinds: ['file', 'image'] }],
+        sessionId: 'secret-session-id',
+        promptId: 'secret-prompt-id',
+        toolCallId: 'secret-tool-call-id',
+        toolCallIds: ['secret-tool-call-id-2'],
+        toolName: 'secret-tool-name',
+      }),
+    ).toBe(true);
+
+    const line = debug.mock.calls[0][0] as string;
+    const event = parseEvent(line);
+    expect(event).toMatchObject({
+      eventName: TOOL_RESULT_BOUNDARY_EVENT_NAME,
+      stage: 'producer',
+      mutated: false,
+      artifacts: [{ state: 'reusable', kinds: ['file', 'image'] }],
+      sessionHmacSha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+      promptHmacSha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+      toolCallHmacSha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+      toolCallHmacSha256s: [expect.stringMatching(/^[0-9a-f]{64}$/)],
+      toolNameHmacSha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+    });
+    expect(eventValues(event)[0]).toMatchObject({
+      representation: 'display',
+      slot: 0,
+      codeUnits: secret.length,
+      rawUtf8Bytes: Buffer.byteLength(secret, 'utf8'),
+      jsonUtf8Bytes: Buffer.byteLength(JSON.stringify(secret), 'utf8'),
+      hmacSha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+    });
+    for (const raw of [
+      secret,
+      'secret-session-id',
+      'secret-prompt-id',
+      'secret-tool-call-id',
+      'secret-tool-call-id-2',
+      'secret-tool-name',
+    ]) {
+      expect(line).not.toContain(raw);
+    }
+  });
+
+  it('normalizes untrusted artifact summaries at the log sink', () => {
+    const debug = vi.fn();
+    const observe = createToolResultBoundaryObserver({
+      enabled: () => true,
+      hmacKey: Buffer.alloc(32, 8),
+      logger: { debug, isEnabled: () => true },
+      thresholdBytes: 0,
+    });
+
+    observe({
+      stage: 'producer',
+      values: [{ representation: 'display', value: 'eligible' }],
+      artifacts: [
+        {
+          state: '/private/secret-state',
+          kinds: ['file', '/private/secret-kind'],
+        },
+      ] as unknown as Parameters<typeof observe>[0]['artifacts'],
+    });
+
+    const line = debug.mock.calls[0][0] as string;
+    expect(parseEvent(line)).toMatchObject({
+      artifacts: [{ state: 'undecided', kinds: ['file', 'unknown'] }],
+    });
+    expect(line).not.toContain('/private/secret');
+  });
+
+  it('keeps unchanged HMACs equal and changes the first mutated value', () => {
+    const debug = vi.fn();
+    const observe = createToolResultBoundaryObserver({
+      enabled: () => true,
+      hmacKey: Buffer.alloc(32, 9),
+      logger: { debug, isEnabled: () => true },
+      thresholdBytes: 0,
+    });
+
+    observe({
+      stage: 'finalizer_input',
+      mutated: true,
+      values: [{ representation: 'model_text', value: 'same-value' }],
+    });
+    observe({
+      stage: 'finalizer_output',
+      mutated: true,
+      values: [{ representation: 'model_text', value: 'same-value' }],
+    });
+    observe({
+      stage: 'headless_projection_output',
+      mutated: true,
+      values: [{ representation: 'headless_content', value: 'changed-value' }],
+    });
+
+    const hashes = debug.mock.calls.map(
+      ([line]) =>
+        eventValues(parseEvent(line as string))[0]['hmacSha256'] as string,
+    );
+    expect(hashes[0]).toBe(hashes[1]);
+    expect(hashes[2]).not.toBe(hashes[1]);
+  });
+
+  it('hashes distinct lone-surrogate code units differently', () => {
+    const debug = vi.fn();
+    const observe = createToolResultBoundaryObserver({
+      enabled: () => true,
+      hmacKey: Buffer.alloc(32, 3),
+      logger: { debug, isEnabled: () => true },
+      thresholdBytes: 0,
+    });
+
+    observe({
+      stage: 'producer',
+      values: [
+        { representation: 'display', value: '\ud800' },
+        { representation: 'display', value: '\udc00' },
+      ],
+    });
+
+    const values = eventValues(parseEvent(debug.mock.calls[0][0] as string));
+    expect(values[0]['hmacSha256']).not.toBe(values[1]['hmacSha256']);
+  });
+
+  it('matches native JSON byte accounting under fixed-seed fuzzing', () => {
+    const debug = vi.fn();
+    const observe = createToolResultBoundaryObserver({
+      enabled: () => true,
+      hmacKey: Buffer.alloc(32, 1),
+      logLimit: 500,
+      logger: { debug, isEnabled: () => true },
+      thresholdBytes: 0,
+    });
+    const atoms = ['a', '"', '\\', '\n', '\0', '汉', '😀', '\ud800', '\udc00'];
+    let state = 0x5eed1234;
+    const random = () => {
+      state = (Math.imul(state, 1_664_525) + 1_013_904_223) >>> 0;
+      return state;
+    };
+
+    for (let sampleIndex = 0; sampleIndex < 250; sampleIndex++) {
+      let value = '';
+      const length = 1 + (random() % 100);
+      for (let index = 0; index < length; index++) {
+        value += atoms[random() % atoms.length];
+      }
+      observe({
+        stage: 'producer',
+        values: [{ representation: 'model_text', value }],
+      });
+      const summary = eventValues(
+        parseEvent(debug.mock.calls.at(-1)?.[0] as string),
+      )[0];
+      expect(summary['jsonUtf8Bytes']).toBe(
+        Buffer.byteLength(JSON.stringify(value), 'utf8'),
+      );
+    }
+  });
+
+  it('is lazy and silent while disabled or below the threshold', () => {
+    const disabledValues = vi.fn(() => [
+      { representation: 'display' as const, value: 'secret' },
+    ]);
+    const disabledMutation = vi.fn(() => true);
+    const disabledDebug = vi.fn();
+    const disabled = createToolResultBoundaryObserver({
+      enabled: () => false,
+      logger: { debug: disabledDebug, isEnabled: () => true },
+    });
+    expect(
+      disabled({
+        stage: 'producer',
+        mutated: disabledMutation,
+        values: disabledValues,
+      }),
+    ).toBe(false);
+    expect(disabledValues).not.toHaveBeenCalled();
+    expect(disabledMutation).not.toHaveBeenCalled();
+    expect(disabledDebug).not.toHaveBeenCalled();
+
+    const belowDebug = vi.fn();
+    const below = createToolResultBoundaryObserver({
+      enabled: () => true,
+      logger: { debug: belowDebug, isEnabled: () => true },
+      thresholdBytes: 100,
+    });
+    expect(
+      below({
+        stage: 'producer',
+        values: [{ representation: 'display', value: 'small' }],
+      }),
+    ).toBe(false);
+    expect(belowDebug).not.toHaveBeenCalled();
+  });
+
+  it('emits only above the 65,536-byte JSON-string threshold', () => {
+    const debug = vi.fn();
+    const observe = createToolResultBoundaryObserver({
+      enabled: () => true,
+      hmacKey: Buffer.alloc(32, 4),
+      logger: { debug, isEnabled: () => true },
+    });
+
+    for (const [valueLength, expected] of [
+      [65_533, false],
+      [65_534, false],
+      [65_535, true],
+    ] as const) {
+      expect(
+        observe({
+          stage: 'producer',
+          values: [
+            { representation: 'display', value: 'a'.repeat(valueLength) },
+          ],
+        }),
+      ).toBe(expected);
+    }
+    expect(debug).toHaveBeenCalledTimes(1);
+    expect(
+      eventValues(parseEvent(debug.mock.calls[0][0] as string))[0],
+    ).toMatchObject({ jsonUtf8Bytes: 65_537 });
+  });
+
+  it('rate-limits eligible events and reports the suppressed count', () => {
+    let currentTime = 0;
+    const debug = vi.fn();
+    const observe = createToolResultBoundaryObserver({
+      enabled: () => true,
+      hmacKey: Buffer.alloc(32, 5),
+      logLimit: 1,
+      logger: { debug, isEnabled: () => true },
+      now: () => currentTime,
+      thresholdBytes: 0,
+      windowMs: 100,
+    });
+    const observation = {
+      stage: 'producer' as const,
+      values: [{ representation: 'display' as const, value: 'large' }],
+    };
+
+    expect(observe(observation)).toBe(true);
+    expect(observe(observation)).toBe(true);
+    expect(debug).toHaveBeenCalledTimes(1);
+    currentTime = 100;
+    expect(observe(observation)).toBe(true);
+    expect(debug).toHaveBeenCalledTimes(2);
+    expect(parseEvent(debug.mock.calls[1][0] as string)).toMatchObject({
+      suppressedCount: 1,
+    });
+  });
+
+  it('swallows diagnostic failures', () => {
+    const throwingLogger = {
+      debug: () => {
+        throw new Error('log failed');
+      },
+      isEnabled: () => true,
+    };
+    const observe = createToolResultBoundaryObserver({
+      enabled: () => true,
+      logger: throwingLogger,
+      thresholdBytes: 0,
+    });
+
+    expect(() =>
+      observe({
+        stage: 'producer',
+        values: () => {
+          throw new Error('scan failed');
+        },
+      }),
+    ).not.toThrow();
+    expect(() =>
+      observe({
+        stage: 'producer',
+        values: [{ representation: 'display', value: 'eligible' }],
+      }),
+    ).not.toThrow();
+  });
+
+  it('classifies artifact tri-state and kinds without paths', () => {
+    expect(toolResultArtifactState(undefined)).toBe('undecided');
+    expect(toolResultArtifactState([])).toBe('none');
+    expect(toolResultArtifactState(['/private/result.txt'])).toBe('reusable');
+    expect(
+      toolResultBoundaryArtifact(
+        ['/private/result.txt'],
+        [
+          { kind: 'image' },
+          { kind: 'image' },
+          {},
+          { kind: '/private/secret-kind' },
+        ],
+      ),
+    ).toEqual({
+      state: 'reusable',
+      kinds: ['file', 'image', 'unknown'],
+    });
+    expect(
+      JSON.stringify(
+        toolResultBoundaryArtifact(
+          ['/private/result.txt'],
+          [{ kind: '/private/secret-kind' }],
+        ),
+      ),
+    ).not.toContain('/private/result.txt');
+    expect(
+      JSON.stringify(
+        toolResultBoundaryArtifact(
+          ['/private/result.txt'],
+          [{ kind: '/private/secret-kind' }],
+        ),
+      ),
+    ).not.toContain('/private/secret-kind');
+    expect(
+      toolResultBoundaryArtifact(
+        undefined,
+        new Proxy([], {
+          get() {
+            throw new Error('untrusted artifact metadata');
+          },
+        }),
+      ),
+    ).toEqual({ state: 'undecided', kinds: [] });
+  });
+
+  it('extracts model text slots', () => {
+    expect(
+      toolResultPartDiagnosticValues([
+        { text: 'top' },
+        {
+          functionResponse: {
+            name: 'tool',
+            response: { output: 'output', error: 'error' },
+          },
+        },
+      ]),
+    ).toEqual([
+      { representation: 'model_text', value: 'top' },
+      { representation: 'model_text', value: 'output' },
+      { representation: 'model_text', value: 'error' },
+    ]);
+  });
+});

--- a/packages/core/src/utils/tool-result-boundary-diagnostics.test.ts
+++ b/packages/core/src/utils/tool-result-boundary-diagnostics.test.ts
@@ -154,6 +154,27 @@ describe('tool-result boundary diagnostics', () => {
     expect(parseEvent(debug.mock.calls[0][0] as string)['mutated']).toBe(true);
   });
 
+  it('hashes equal values identically across representations', () => {
+    const debug = vi.fn();
+    const observe = createToolResultBoundaryObserver({
+      enabled: () => true,
+      hmacKey: Buffer.alloc(32, 2),
+      logger: { debug, isEnabled: () => true },
+      thresholdBytes: 0,
+    });
+
+    observe({
+      stage: 'producer',
+      values: [
+        { representation: 'model_text', value: 'same-value' },
+        { representation: 'display', value: 'same-value' },
+      ],
+    });
+
+    const values = eventValues(parseEvent(debug.mock.calls[0][0] as string));
+    expect(values[0]['hmacSha256']).toBe(values[1]['hmacSha256']);
+  });
+
   it('hashes legacy and canonical tool names identically', () => {
     const debug = vi.fn();
     const observe = createToolResultBoundaryObserver({
@@ -394,18 +415,33 @@ describe('tool-result boundary diagnostics', () => {
 
     expect(observe(observation)).toBe(true);
     expect(observe(observation)).toBe(true);
+    expect(observe(observation)).toBe(true);
     expect(debug).toHaveBeenCalledTimes(1);
     currentTime = 100;
     expect(observe(observation)).toBe(true);
     expect(debug).toHaveBeenCalledTimes(2);
     expect(parseEvent(debug.mock.calls[1][0] as string)).toMatchObject({
-      suppressedCount: 1,
+      suppressedCount: 2,
     });
     currentTime = 200;
     expect(observe(observation)).toBe(true);
     expect(parseEvent(debug.mock.calls[2][0] as string)).not.toHaveProperty(
       'suppressedCount',
     );
+  });
+
+  it('skips value measurement for rate-limited mutated events', () => {
+    const values = vi.fn(() => [
+      { representation: 'display' as const, value: 'secret' },
+    ]);
+    const observe = createToolResultBoundaryObserver({
+      enabled: () => true,
+      logLimit: 0,
+      logger: { debug: vi.fn(), isEnabled: () => true },
+    });
+
+    expect(observe({ stage: 'producer', mutated: true, values })).toBe(true);
+    expect(values).not.toHaveBeenCalled();
   });
 
   it('starts a new rate-limit window when the clock moves backward', () => {

--- a/packages/core/src/utils/tool-result-boundary-diagnostics.test.ts
+++ b/packages/core/src/utils/tool-result-boundary-diagnostics.test.ts
@@ -141,6 +141,29 @@ describe('tool-result boundary diagnostics', () => {
     expect(hashes[2]).not.toBe(hashes[1]);
   });
 
+  it('hashes legacy and canonical tool names identically', () => {
+    const debug = vi.fn();
+    const observe = createToolResultBoundaryObserver({
+      enabled: () => true,
+      hmacKey: Buffer.alloc(32, 4),
+      logger: { debug, isEnabled: () => true },
+      thresholdBytes: 0,
+    });
+
+    for (const toolName of ['task', 'agent']) {
+      observe({
+        stage: 'producer',
+        toolName,
+        values: [{ representation: 'display', value: 'eligible' }],
+      });
+    }
+
+    const hashes = debug.mock.calls.map(
+      ([line]) => parseEvent(line as string)['toolNameHmacSha256'],
+    );
+    expect(hashes[0]).toBe(hashes[1]);
+  });
+
   it('hashes distinct lone-surrogate code units differently', () => {
     const debug = vi.fn();
     const observe = createToolResultBoundaryObserver({
@@ -171,7 +194,25 @@ describe('tool-result boundary diagnostics', () => {
       logger: { debug, isEnabled: () => true },
       thresholdBytes: 0,
     });
-    const atoms = ['a', '"', '\\', '\n', '\0', '汉', '😀', '\ud800', '\udc00'];
+    const atoms = [
+      'a',
+      '"',
+      '\\',
+      '\b',
+      '\t',
+      '\n',
+      '\f',
+      '\r',
+      '\0',
+      '\x1f',
+      '\x7f',
+      'é',
+      '\u07ff',
+      '汉',
+      '😀',
+      '\ud800',
+      '\udc00',
+    ];
     let state = 0x5eed1234;
     const random = () => {
       state = (Math.imul(state, 1_664_525) + 1_013_904_223) >>> 0;
@@ -289,6 +330,33 @@ describe('tool-result boundary diagnostics', () => {
     });
   });
 
+  it('starts a new rate-limit window when the clock moves backward', () => {
+    let currentTime = 100;
+    const debug = vi.fn();
+    const observe = createToolResultBoundaryObserver({
+      enabled: () => true,
+      hmacKey: Buffer.alloc(32, 5),
+      logLimit: 1,
+      logger: { debug, isEnabled: () => true },
+      now: () => currentTime,
+      thresholdBytes: 0,
+      windowMs: 100,
+    });
+    const observation = {
+      stage: 'producer' as const,
+      values: [{ representation: 'display' as const, value: 'large' }],
+    };
+
+    expect(observe(observation)).toBe(true);
+    expect(observe(observation)).toBe(true);
+    currentTime = 50;
+    expect(observe(observation)).toBe(true);
+    expect(debug).toHaveBeenCalledTimes(2);
+    expect(parseEvent(debug.mock.calls[1][0] as string)).toMatchObject({
+      suppressedCount: 1,
+    });
+  });
+
   it('swallows diagnostic failures', () => {
     const throwingLogger = {
       debug: () => {
@@ -362,6 +430,14 @@ describe('tool-result boundary diagnostics', () => {
         }),
       ),
     ).toEqual({ state: 'undecided', kinds: [] });
+    expect(toolResultBoundaryArtifact(undefined, [{ kind: 'image' }])).toEqual({
+      state: 'undecided',
+      kinds: ['image'],
+    });
+    expect(toolResultBoundaryArtifact([], [{ kind: 'image' }])).toEqual({
+      state: 'none',
+      kinds: ['image'],
+    });
   });
 
   it('extracts model text slots', () => {
@@ -379,6 +455,13 @@ describe('tool-result boundary diagnostics', () => {
       { representation: 'model_text', value: 'top' },
       { representation: 'model_text', value: 'output' },
       { representation: 'model_text', value: 'error' },
+    ]);
+    expect(toolResultPartDiagnosticValues('plain')).toEqual([
+      { representation: 'model_text', value: 'plain' },
+    ]);
+    expect(toolResultPartDiagnosticValues(['plain', { text: 'top' }])).toEqual([
+      { representation: 'model_text', value: 'plain' },
+      { representation: 'model_text', value: 'top' },
     ]);
   });
 });

--- a/packages/core/src/utils/tool-result-boundary-diagnostics.ts
+++ b/packages/core/src/utils/tool-result-boundary-diagnostics.ts
@@ -215,20 +215,10 @@ export function createToolResultBoundaryObserver(
   return (observation) => {
     try {
       if (!enabled()) return false;
-      const values =
-        typeof observation.values === 'function'
-          ? observation.values()
-          : observation.values;
-      const measuredValues = measureValues(values);
       const mutated =
         typeof observation.mutated === 'function'
           ? observation.mutated()
           : observation.mutated === true;
-      const oversized = measuredValues.some(
-        (summary) => summary.jsonUtf8Bytes > thresholdBytes,
-      );
-      if (!mutated && !oversized) return false;
-
       const currentTime = now();
       if (
         currentTime < windowStartedAt ||
@@ -237,17 +227,38 @@ export function createToolResultBoundaryObserver(
         windowStartedAt = currentTime;
         emittedInWindow = 0;
       }
+      if (mutated && emittedInWindow >= logLimit) {
+        suppressedCount++;
+        return true;
+      }
+
+      const values =
+        typeof observation.values === 'function'
+          ? observation.values()
+          : observation.values;
+      const oversized =
+        !mutated &&
+        values.some(({ value }) =>
+          jsonStringExceedsByteLength(value, thresholdBytes),
+        );
+      if (!mutated && !oversized) return false;
       if (emittedInWindow >= logLimit) {
         suppressedCount++;
         return true;
       }
 
+      const measuredValues = measureValues(values);
       hmacKey ??= randomBytes(32);
       const activeHmacKey = hmacKey;
-      const summaries = measuredValues.map(({ value, ...summary }) => ({
-        ...summary,
-        hmacSha256: hmacString(value, activeHmacKey),
-      }));
+      const valueHmacs = new Map<string, string>();
+      const summaries = measuredValues.map(({ value, ...summary }) => {
+        let hmacSha256 = valueHmacs.get(value);
+        if (hmacSha256 === undefined) {
+          hmacSha256 = hmacString(value, activeHmacKey);
+          valueHmacs.set(value, hmacSha256);
+        }
+        return { ...summary, hmacSha256 };
+      });
 
       const event: ToolResultBoundaryEvent = {
         eventName: TOOL_RESULT_BOUNDARY_EVENT_NAME,
@@ -335,15 +346,26 @@ function measureValues(
   values: readonly ToolResultBoundaryValue[],
 ): MeasuredToolResultBoundaryValue[] {
   const slots = new Map<ToolResultRepresentation, number>();
+  const measurements = new Map<
+    string,
+    Pick<
+      MeasuredToolResultBoundaryValue,
+      'codeUnits' | 'rawUtf8Bytes' | 'jsonUtf8Bytes'
+    >
+  >();
   return values.map(({ representation, value }) => {
     const slot = slots.get(representation) ?? 0;
     slots.set(representation, slot + 1);
-    return {
-      representation,
-      slot,
+    const measurement = measurements.get(value) ?? {
       codeUnits: value.length,
       rawUtf8Bytes: Buffer.byteLength(value, 'utf8'),
       jsonUtf8Bytes: jsonStringByteLength(value),
+    };
+    measurements.set(value, measurement);
+    return {
+      representation,
+      slot,
+      ...measurement,
       value,
     };
   });
@@ -372,9 +394,16 @@ function hmacString(value: string, hmacKey: Uint8Array): string {
     .digest('hex');
 }
 
-function jsonStringByteLength(value: string): number {
+function jsonStringByteLength(
+  value: string,
+  stopAfterBytes = Number.POSITIVE_INFINITY,
+): number {
   let bytes = 2;
-  for (let index = 0; index < value.length; index++) {
+  for (
+    let index = 0;
+    index < value.length && bytes <= stopAfterBytes;
+    index++
+  ) {
     const code = value.charCodeAt(index);
     if (code === 0x22 || code === 0x5c) {
       bytes += 2;
@@ -406,4 +435,11 @@ function jsonStringByteLength(value: string): number {
     }
   }
   return bytes;
+}
+
+function jsonStringExceedsByteLength(
+  value: string,
+  threshold: number,
+): boolean {
+  return jsonStringByteLength(value, threshold) > threshold;
 }

--- a/packages/core/src/utils/tool-result-boundary-diagnostics.ts
+++ b/packages/core/src/utils/tool-result-boundary-diagnostics.ts
@@ -1,0 +1,401 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Buffer } from 'node:buffer';
+import { createHmac, randomBytes } from 'node:crypto';
+import type { Part, PartListUnion } from '@google/genai';
+import {
+  createDebugLogger,
+  isDebugLogFileEnabled,
+  type DebugLogger,
+} from './debugLogger.js';
+import { promptIdContext } from './promptIdContext.js';
+import { sessionIdContext } from './sessionIdContext.js';
+import type {
+  ToolArtifactKind,
+  ToolResultArtifactState,
+  ToolResultBoundaryArtifact,
+} from '../tools/tools.js';
+
+export const TOOL_RESULT_BOUNDARY_EVENT_NAME = 'qwen-code.tool_result.boundary';
+export const TOOL_RESULT_BOUNDARY_JSON_BYTE_THRESHOLD = 65_536;
+export const TOOL_RESULT_BOUNDARY_LOG_LIMIT = 50;
+export const TOOL_RESULT_BOUNDARY_LOG_WINDOW_MS = 60_000;
+
+export type ToolResultBoundaryStage =
+  | 'producer'
+  | 'producer_input'
+  | 'producer_output'
+  | 'finalizer_input'
+  | 'finalizer_output'
+  | 'recorder_input'
+  | 'recorder_output'
+  | 'acp_projection_input'
+  | 'acp_projection_output'
+  | 'acp_wire'
+  | 'headless_projection_input'
+  | 'headless_projection_output'
+  | 'headless_wire';
+
+export type ToolResultRepresentation =
+  | 'model_text'
+  | 'display'
+  | 'acp_content'
+  | 'acp_raw_output'
+  | 'headless_content';
+
+export type ToolResultBoundaryArtifactKind = ToolArtifactKind | 'unknown';
+
+export interface ToolResultBoundaryValue {
+  representation: ToolResultRepresentation;
+  value: string;
+}
+
+export interface ToolResultBoundaryObservation {
+  stage: ToolResultBoundaryStage;
+  values:
+    | readonly ToolResultBoundaryValue[]
+    | (() => readonly ToolResultBoundaryValue[]);
+  mutated?: boolean | (() => boolean);
+  artifacts?: readonly ToolResultBoundaryArtifact[];
+  sessionId?: string;
+  promptId?: string;
+  toolCallId?: string;
+  toolCallIds?: readonly string[];
+  toolName?: string;
+  wireUtf8Bytes?: number;
+}
+
+interface ToolResultBoundaryValueSummary {
+  representation: ToolResultRepresentation;
+  slot: number;
+  codeUnits: number;
+  rawUtf8Bytes: number;
+  jsonUtf8Bytes: number;
+  hmacSha256: string;
+}
+
+type MeasuredToolResultBoundaryValue = Omit<
+  ToolResultBoundaryValueSummary,
+  'hmacSha256'
+> & { value: string };
+
+interface ToolResultBoundaryEvent {
+  eventName: typeof TOOL_RESULT_BOUNDARY_EVENT_NAME;
+  stage: ToolResultBoundaryStage;
+  mutated: boolean;
+  values: ToolResultBoundaryValueSummary[];
+  artifacts?: ToolResultBoundaryArtifact[];
+  sessionHmacSha256?: string;
+  promptHmacSha256?: string;
+  toolCallHmacSha256?: string;
+  toolCallHmacSha256s?: string[];
+  toolNameHmacSha256?: string;
+  wireUtf8Bytes?: number;
+  suppressedCount?: number;
+}
+
+export interface ToolResultBoundaryObserverOptions {
+  enabled?: () => boolean;
+  hmacKey?: Uint8Array;
+  logLimit?: number;
+  logger?: Pick<DebugLogger, 'debug' | 'isEnabled'>;
+  now?: () => number;
+  thresholdBytes?: number;
+  windowMs?: number;
+}
+
+const boundaryLogger = createDebugLogger('TOOL_RESULT_BOUNDARY');
+const artifactKinds = new Set<ToolArtifactKind>([
+  'file',
+  'link',
+  'html',
+  'image',
+  'video',
+  'audio',
+  'pdf',
+  'notebook',
+  'other',
+]);
+
+export function isToolResultBoundaryDiagnosticsEnabled(): boolean {
+  try {
+    return isDebugLogFileEnabled() && boundaryLogger.isEnabled();
+  } catch {
+    return false;
+  }
+}
+
+export function toolResultArtifactState(
+  persistedOutputFiles: readonly string[] | undefined,
+): ToolResultArtifactState {
+  if (persistedOutputFiles === undefined) return 'undecided';
+  return persistedOutputFiles.length === 0 ? 'none' : 'reusable';
+}
+
+export function toolResultBoundaryArtifact(
+  persistedOutputFiles: readonly string[] | undefined,
+  artifacts: ReadonlyArray<{ kind?: unknown }> | undefined,
+): ToolResultBoundaryArtifact {
+  try {
+    const kinds = new Set<ToolResultBoundaryArtifactKind>();
+    if (persistedOutputFiles && persistedOutputFiles.length > 0) {
+      kinds.add('file');
+    }
+    for (const artifact of artifacts ?? []) {
+      const kind = artifact.kind;
+      kinds.add(
+        typeof kind === 'string' && artifactKinds.has(kind as ToolArtifactKind)
+          ? (kind as ToolArtifactKind)
+          : 'unknown',
+      );
+    }
+    return {
+      state: toolResultArtifactState(persistedOutputFiles),
+      kinds: [...kinds],
+    };
+  } catch {
+    return { state: 'undecided', kinds: [] };
+  }
+}
+
+export function toolResultPartDiagnosticValues(
+  value: PartListUnion,
+  representation: ToolResultRepresentation = 'model_text',
+): ToolResultBoundaryValue[] {
+  const values: ToolResultBoundaryValue[] = [];
+  const parts = Array.isArray(value) ? value : [value];
+  for (const candidate of parts) {
+    if (typeof candidate === 'string') {
+      values.push({ representation, value: candidate });
+      continue;
+    }
+    const part = candidate as Part;
+    if (typeof part.text === 'string') {
+      values.push({ representation, value: part.text });
+    }
+    const response = part.functionResponse?.response;
+    const output = response?.['output'];
+    const error = response?.['error'];
+    if (typeof output === 'string') {
+      values.push({ representation, value: output });
+    }
+    if (typeof error === 'string') {
+      values.push({ representation, value: error });
+    }
+  }
+  return values;
+}
+
+export function createToolResultBoundaryObserver(
+  options: ToolResultBoundaryObserverOptions = {},
+): (observation: ToolResultBoundaryObservation) => boolean {
+  const logger = options.logger ?? boundaryLogger;
+  const enabled =
+    options.enabled ??
+    (logger === boundaryLogger
+      ? isToolResultBoundaryDiagnosticsEnabled
+      : () => isDebugLogFileEnabled() && logger.isEnabled());
+  let hmacKey = options.hmacKey ? Buffer.from(options.hmacKey) : undefined;
+  const thresholdBytes =
+    options.thresholdBytes ?? TOOL_RESULT_BOUNDARY_JSON_BYTE_THRESHOLD;
+  const logLimit = options.logLimit ?? TOOL_RESULT_BOUNDARY_LOG_LIMIT;
+  const windowMs = options.windowMs ?? TOOL_RESULT_BOUNDARY_LOG_WINDOW_MS;
+  const now = options.now ?? Date.now;
+  let windowStartedAt = now();
+  let emittedInWindow = 0;
+  let suppressedCount = 0;
+
+  return (observation) => {
+    try {
+      if (!enabled()) return false;
+      const values =
+        typeof observation.values === 'function'
+          ? observation.values()
+          : observation.values;
+      const measuredValues = measureValues(values);
+      const mutated =
+        typeof observation.mutated === 'function'
+          ? observation.mutated()
+          : observation.mutated === true;
+      const oversized = measuredValues.some(
+        (summary) => summary.jsonUtf8Bytes > thresholdBytes,
+      );
+      if (!mutated && !oversized) return false;
+
+      const currentTime = now();
+      if (currentTime - windowStartedAt >= windowMs) {
+        windowStartedAt = currentTime;
+        emittedInWindow = 0;
+      }
+      if (emittedInWindow >= logLimit) {
+        suppressedCount++;
+        return true;
+      }
+
+      hmacKey ??= randomBytes(32);
+      const activeHmacKey = hmacKey;
+      const summaries = measuredValues.map(({ value, ...summary }) => ({
+        ...summary,
+        hmacSha256: hmacString(value, activeHmacKey),
+      }));
+
+      const event: ToolResultBoundaryEvent = {
+        eventName: TOOL_RESULT_BOUNDARY_EVENT_NAME,
+        stage: observation.stage,
+        mutated,
+        values: summaries,
+        ...(observation.artifacts !== undefined
+          ? {
+              artifacts: observation.artifacts.map((artifact) => ({
+                state:
+                  artifact.state === 'none' || artifact.state === 'reusable'
+                    ? artifact.state
+                    : 'undecided',
+                kinds: [
+                  ...new Set(
+                    artifact.kinds.map((kind) =>
+                      kind === 'unknown' || artifactKinds.has(kind)
+                        ? kind
+                        : 'unknown',
+                    ),
+                  ),
+                ],
+              })),
+            }
+          : {}),
+        ...hmacIdentifier(
+          'sessionHmacSha256',
+          observation.sessionId,
+          activeHmacKey,
+        ),
+        ...hmacIdentifier(
+          'promptHmacSha256',
+          observation.promptId,
+          activeHmacKey,
+        ),
+        ...hmacIdentifier(
+          'toolCallHmacSha256',
+          observation.toolCallId,
+          activeHmacKey,
+        ),
+        ...(observation.toolCallIds !== undefined
+          ? {
+              toolCallHmacSha256s: observation.toolCallIds.map((id) =>
+                hmacString(id, activeHmacKey),
+              ),
+            }
+          : {}),
+        ...hmacIdentifier(
+          'toolNameHmacSha256',
+          observation.toolName,
+          activeHmacKey,
+        ),
+        ...(observation.wireUtf8Bytes !== undefined
+          ? { wireUtf8Bytes: observation.wireUtf8Bytes }
+          : {}),
+        ...(suppressedCount > 0 ? { suppressedCount } : {}),
+      };
+      suppressedCount = 0;
+      emittedInWindow++;
+      logger.debug(
+        `${TOOL_RESULT_BOUNDARY_EVENT_NAME} ${JSON.stringify(event)}`,
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  };
+}
+
+const observeBoundary = createToolResultBoundaryObserver();
+
+export function observeToolResultBoundary(
+  observation: ToolResultBoundaryObservation,
+): boolean {
+  return observeBoundary({
+    ...observation,
+    sessionId: observation.sessionId ?? sessionIdContext.getStore(),
+    promptId: observation.promptId ?? promptIdContext.getStore(),
+  });
+}
+
+function measureValues(
+  values: readonly ToolResultBoundaryValue[],
+): MeasuredToolResultBoundaryValue[] {
+  const slots = new Map<ToolResultRepresentation, number>();
+  return values.map(({ representation, value }) => {
+    const slot = slots.get(representation) ?? 0;
+    slots.set(representation, slot + 1);
+    return {
+      representation,
+      slot,
+      codeUnits: value.length,
+      rawUtf8Bytes: Buffer.byteLength(value, 'utf8'),
+      jsonUtf8Bytes: jsonStringByteLength(value),
+      value,
+    };
+  });
+}
+
+function hmacIdentifier<K extends keyof ToolResultBoundaryEvent>(
+  key: K,
+  value: string | undefined,
+  hmacKey: Uint8Array,
+): Partial<Pick<ToolResultBoundaryEvent, K>> {
+  return value === undefined
+    ? {}
+    : ({ [key]: hmacString(value, hmacKey) } as Pick<
+        ToolResultBoundaryEvent,
+        K
+      >);
+}
+
+function hmacString(value: string, hmacKey: Uint8Array): string {
+  const byteLength = value.length * 2;
+  const prefix = Buffer.alloc(8);
+  prefix.writeBigUInt64BE(BigInt(byteLength));
+  return createHmac('sha256', hmacKey)
+    .update(prefix)
+    .update(value, 'utf16le')
+    .digest('hex');
+}
+
+function jsonStringByteLength(value: string): number {
+  let bytes = 2;
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index);
+    if (code === 0x22 || code === 0x5c) {
+      bytes += 2;
+    } else if (code <= 0x1f) {
+      bytes +=
+        code === 0x08 ||
+        code === 0x09 ||
+        code === 0x0a ||
+        code === 0x0c ||
+        code === 0x0d
+          ? 2
+          : 6;
+    } else if (code <= 0x7f) {
+      bytes += 1;
+    } else if (code <= 0x7ff) {
+      bytes += 2;
+    } else if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        bytes += 4;
+        index++;
+      } else {
+        bytes += 6;
+      }
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      bytes += 6;
+    } else {
+      bytes += 3;
+    }
+  }
+  return bytes;
+}

--- a/packages/core/src/utils/tool-result-boundary-diagnostics.ts
+++ b/packages/core/src/utils/tool-result-boundary-diagnostics.ts
@@ -168,27 +168,26 @@ export function toolResultBoundaryArtifact(
 
 export function toolResultPartDiagnosticValues(
   value: PartListUnion,
-  representation: ToolResultRepresentation = 'model_text',
 ): ToolResultBoundaryValue[] {
   const values: ToolResultBoundaryValue[] = [];
   const parts = Array.isArray(value) ? value : [value];
   for (const candidate of parts) {
     if (typeof candidate === 'string') {
-      values.push({ representation, value: candidate });
+      values.push({ representation: 'model_text', value: candidate });
       continue;
     }
     const part = candidate as Part;
     if (typeof part.text === 'string') {
-      values.push({ representation, value: part.text });
+      values.push({ representation: 'model_text', value: part.text });
     }
     const response = part.functionResponse?.response;
     const output = response?.['output'];
     const error = response?.['error'];
     if (typeof output === 'string') {
-      values.push({ representation, value: output });
+      values.push({ representation: 'model_text', value: output });
     }
     if (typeof error === 'string') {
-      values.push({ representation, value: error });
+      values.push({ representation: 'model_text', value: error });
     }
   }
   return values;

--- a/packages/core/src/utils/tool-result-boundary-diagnostics.ts
+++ b/packages/core/src/utils/tool-result-boundary-diagnostics.ts
@@ -167,10 +167,10 @@ export function toolResultBoundaryArtifact(
 }
 
 export function toolResultPartDiagnosticValues(
-  value: PartListUnion,
+  value: PartListUnion | null | undefined,
 ): ToolResultBoundaryValue[] {
   const values: ToolResultBoundaryValue[] = [];
-  const parts = Array.isArray(value) ? value : [value];
+  const parts = Array.isArray(value) ? value : [value ?? ''];
   for (const candidate of parts) {
     if (typeof candidate === 'string') {
       values.push({ representation: 'model_text', value: candidate });

--- a/packages/core/src/utils/tool-result-boundary-diagnostics.ts
+++ b/packages/core/src/utils/tool-result-boundary-diagnostics.ts
@@ -19,6 +19,7 @@ import type {
   ToolResultArtifactState,
   ToolResultBoundaryArtifact,
 } from '../tools/tools.js';
+import { canonicalToolName } from '../tools/tool-names.js';
 
 export const TOOL_RESULT_BOUNDARY_EVENT_NAME = 'qwen-code.tool_result.boundary';
 export const TOOL_RESULT_BOUNDARY_JSON_BYTE_THRESHOLD = 65_536;
@@ -109,17 +110,20 @@ export interface ToolResultBoundaryObserverOptions {
 }
 
 const boundaryLogger = createDebugLogger('TOOL_RESULT_BOUNDARY');
-const artifactKinds = new Set<ToolArtifactKind>([
-  'file',
-  'link',
-  'html',
-  'image',
-  'video',
-  'audio',
-  'pdf',
-  'notebook',
-  'other',
-]);
+const artifactKindRecord = {
+  file: true,
+  link: true,
+  html: true,
+  image: true,
+  video: true,
+  audio: true,
+  pdf: true,
+  notebook: true,
+  other: true,
+} satisfies Record<ToolArtifactKind, true>;
+const artifactKinds = new Set<ToolArtifactKind>(
+  Object.keys(artifactKindRecord) as ToolArtifactKind[],
+);
 
 export function isToolResultBoundaryDiagnosticsEnabled(): boolean {
   try {
@@ -227,7 +231,10 @@ export function createToolResultBoundaryObserver(
       if (!mutated && !oversized) return false;
 
       const currentTime = now();
-      if (currentTime - windowStartedAt >= windowMs) {
+      if (
+        currentTime < windowStartedAt ||
+        currentTime - windowStartedAt >= windowMs
+      ) {
         windowStartedAt = currentTime;
         emittedInWindow = 0;
       }
@@ -291,7 +298,9 @@ export function createToolResultBoundaryObserver(
           : {}),
         ...hmacIdentifier(
           'toolNameHmacSha256',
-          observation.toolName,
+          observation.toolName === undefined
+            ? undefined
+            : canonicalToolName(observation.toolName),
           activeHmacKey,
         ),
         ...(observation.wireUtf8Bytes !== undefined


### PR DESCRIPTION
<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item on one long line.
-->

## What this PR does

This PR adds opt-in, privacy-safe debug events that correlate oversized or mutated tool-result representations across producer, model finalization, session recording, ACP and Headless projection, and the actual transport writer. Each event records exact size measurements, process-local HMAC-SHA-256 values, mutation state, and a closed artifact state/kind summary without recording result text, paths, prompts, or raw identifiers.

The correlation covers built-in interactive, Headless JSON/stream-json, persistent SDK transport, ACP live/replay, subagent, and speculative execution paths. Aggregate writer events preserve one artifact summary per tool call in call order, while weak associations keep diagnostic metadata out of ACP and Headless wire schemas. Diagnostics remain disabled unless file debug logging is active, are capped at 50 eligible events per minute, and swallow all diagnostic failures.

## Why it's needed

Large tool results can be persisted, finalized, recorded, projected, or serialized at different boundaries. Existing logs could show that a large frame occurred but could not safely identify the first boundary that changed a representation. These events make that transition observable without exposing sensitive tool output or stable cross-process fingerprints, completing the diagnostics contract tracked by #8448.

## Reviewer Test Plan

### How to verify

1. Enable `QWEN_DEBUG_LOG_FILE` and run a deterministic tool that returns an oversized text result through Headless JSON, stream-json, and ACP. Confirm boundary events appear only for oversized or mutated representations, equal values retain the same HMAC within the process, and the first changed representation produces the first HMAC mismatch.
2. Compare each writer event's byte count with the captured JSON or NDJSON frame and confirm they match exactly, including the transport newline where applicable.
3. Inspect the new event lines and confirm they contain only sizes, HMACs, mutation state, and closed artifact state/kind enums. Result text, prompts, raw session/prompt/tool-call IDs, tool names, artifact paths, titles, and URLs must be absent.
4. Repeat with debug-file logging disabled. Confirm no boundary event is emitted and tool-result wire output plus producer artifacts remain byte-identical.
5. Exercise a multi-tool aggregate and confirm tool-call HMACs and artifact summaries remain slot-aligned instead of collapsing mixed states.

### Evidence (Before & After)

Before: the deterministic 499,999-byte fixture completed with the expected bounded transport previews and intact producer artifact, but the debug log contained no tool-result boundary events, so the first mutating boundary could not be identified.

After: Headless JSON recorded a 71,252-byte writer buffer exactly matching stdout, with `tool_result.content` at exactly 65,536 JSON UTF-8 bytes. Stream-json recorded a 65,800-byte target frame, and ACP recorded a 131,349-byte target frame; both matched the captured NDJSON bytes. The producer artifact remained 499,999 bytes with SHA-256 `0004a69109d580ed184c0772fd37b888f02e7f5bcd05a18a7a8288bee395adeb`. Debug-on and debug-off runs produced identical target wire bytes, and all new boundary events were free of fixture text, prompts, raw identifiers, tool names, and artifact paths. This is a non-UI diagnostic change; screenshots are N/A.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS 26.4.1, Node.js 24.12.0, npm 10.9.8, local unsandboxed CLI with deterministic OpenAI and MCP fixtures.

## Risk & Scope

- Main risk or tradeoff: When explicitly enabled, diagnostics scan and HMAC eligible large strings; lazy enablement, a 50-events-per-minute limit, process-random keys, and failure isolation bound the cost and privacy exposure.
- Not validated / out of scope: A fully model-driven nested-subagent E2E was not run; that route is covered by cross-package unit tests and static consumer tracing. Generic frame limits, backpressure, custom adapters, and artifact lifecycle changes remain out of scope.
- Breaking changes / migration notes: None. Tool results, transcripts, ACP/Headless schemas, SDK types, and protocol versions are unchanged.

## Linked Issues

Closes #8448

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 新增了按需启用、隐私安全的调试事件，用于关联 tool result 在 producer、模型终结、会话录制、ACP 与 Headless 投影以及实际传输 writer 各边界上的超大或变异表示。每条事件记录精确的大小指标、进程内 HMAC-SHA-256、变异状态以及闭合集合的 artifact 状态/类型摘要，但不会记录结果正文、路径、提示词或原始标识符。

关联范围覆盖内置交互模式、Headless JSON/stream-json、持久 SDK transport、ACP live/replay、subagent 和 speculative execution 路径。聚合 writer 事件按 tool call 顺序保留逐项 artifact 摘要，弱关联机制保证诊断元数据不会进入 ACP 或 Headless wire schema。只有文件调试日志处于启用状态时诊断才会运行，每分钟最多记录 50 条 eligible 事件，并吞掉所有诊断异常。

## 为什么需要它

大型 tool result 可能在持久化、终结、录制、投影或序列化等不同边界发生变化。现有日志只能显示发生了大帧，无法在不泄露内容的前提下定位第一个改变表示的边界。这些事件可以在不暴露敏感工具输出、也不创建跨进程稳定指纹的情况下观察该变化，完成 #8448 跟踪的诊断契约。

## Reviewer 测试计划

### 如何验证

1. 启用 `QWEN_DEBUG_LOG_FILE`，通过 Headless JSON、stream-json 和 ACP 运行一个返回超大文本的确定性工具。确认只为超大或已变异表示生成边界事件；相同值在同一进程内保持相同 HMAC；第一个发生变化的表示产生第一个 HMAC 不匹配。
2. 将每条 writer 事件的字节数与捕获的 JSON 或 NDJSON frame 对比，确认完全一致，并在适用时包含传输换行符。
3. 检查新增事件行，确认其只包含大小、HMAC、变异状态和闭合集合的 artifact 状态/类型枚举。不得包含结果正文、提示词、原始 session/prompt/tool-call ID、工具名、artifact 路径、标题或 URL。
4. 关闭文件调试日志后重复运行。确认不生成边界事件，并且 tool-result wire 输出和 producer artifact 在字节层面完全一致。
5. 运行多工具聚合场景，确认 tool-call HMAC 和 artifact 摘要保持槽位对齐，不会折叠混合状态。

### 证据（Before & After）

Before：确定性的 499,999 字节 fixture 会生成预期的有界传输预览，producer artifact 也保持完整，但调试日志中没有 tool-result 边界事件，因此无法定位第一个发生变异的边界。

After：Headless JSON 记录的 writer buffer 为 71,252 字节，与 stdout 精确一致，且 `tool_result.content` 恰好为 65,536 JSON UTF-8 字节。stream-json 记录的目标 frame 为 65,800 字节，ACP 记录的目标 frame 为 131,349 字节，均与捕获的 NDJSON 字节完全一致。producer artifact 仍为 499,999 字节，SHA-256 为 `0004a69109d580ed184c0772fd37b888f02e7f5bcd05a18a7a8288bee395adeb`。启用和关闭调试诊断时目标 wire 字节完全相同，所有新增边界事件均不包含 fixture 正文、提示词、原始标识符、工具名或 artifact 路径。这是非 UI 诊断变更，截图不适用。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS 26.4.1、Node.js 24.12.0、npm 10.9.8、本地无 sandbox CLI，以及确定性的 OpenAI 和 MCP fixture。

## 风险与范围

- 主要风险或权衡：显式启用后，诊断会扫描并对 eligible 的大字符串计算 HMAC；惰性启用、每分钟 50 条事件限制、进程随机密钥和故障隔离共同限制了成本与隐私暴露。
- 未验证 / 范围外：未运行完全由模型驱动的嵌套 subagent E2E；该路径由跨包单测和静态消费者追踪覆盖。通用 frame 限制、backpressure、自定义 adapter 和 artifact 生命周期变更仍不在本 PR 范围内。
- 破坏性变更 / 迁移说明：无。Tool result、transcript、ACP/Headless schema、SDK 类型和协议版本均未改变。

## 关联 Issue

Closes #8448

</details>
