### PR TITLE
fix(webui): Make resync and repair transactional

### DIFF
--- a/docs/design/2026-08-12-transactional-webui-resync-and-repair.md
+++ b/docs/design/2026-08-12-transactional-webui-resync-and-repair.md
@@ -1,0 +1,128 @@
+# Transactional WebUI resync and live-journal repair
+
+## Problem
+
+The WebUI rebuilds a session after an event epoch reset or replay-ring gap by
+clearing the visible transcript and replacing the current attachment before a
+fresh load succeeds. Live-journal repair uses the same destructive reload path.
+A slow or failed load can therefore hide a still-useful transcript, reopen a
+known-gapped attachment for writes, or lose the healthy source stream used by
+repair.
+
+## Scope
+
+This change makes event-gap resync and live-journal repair transactional for
+modern daemons that advertise `client_identity`. It reuses the provider-local
+restore coordinator used by cross-session switching and same-session refresh.
+Selective transcript reading, branch adoption, durable checkpoints, and daemon
+wire formats remain separate work.
+
+Daemons that explicitly lack client identity retain the legacy recovery path.
+Unknown capabilities or malformed ownership fail closed. No feature flag or
+second restore coordinator is introduced.
+
+## Resync episode
+
+A `state_resync_required` frame creates a provider-local recovery episode tied
+to the exact source attachment, normalized workspace, committed client id,
+lifecycle, environment, and one absolute restore deadline. The episode is a
+safety lock rather than a request: superseding or failing one restore intent
+does not make the gapped source writable again.
+
+The runner flushes every legal event before the sentinel, leaves the retained
+transcript visible, and parks the source stream without clearing its session or
+prompt state. All sentinel reasons use the same authoritative full-load path;
+the reason is diagnostic and a replacement epoch may equal or differ from the
+source epoch.
+
+Recovery always requests response replay with no history page size and reuses
+the committed client id. It waits for already-started source-bound requests,
+shell work, and prompt admission to settle, but an admitted prompt may continue
+while the snapshot is prepared. If prompt admission self-heals the source
+registration before recovery starts, the episode adopts that new committed
+client id; the identity is fixed once the load request begins. A candidate must
+have the exact owner identity, a complete non-degraded replay, a concrete epoch,
+and a valid watermark. When the epoch is unchanged, a known gap reason must
+advance beyond the final processed source cursor; other recovery reasons cannot
+move behind it. Cursors from different epochs are not compared.
+
+The replay is built in an unsubscribed shadow store. Commit synchronously swaps
+the transcript, history owner, session handle, connection state, cursor, and
+prompt ownership, then starts the prepared runner. The old registration is
+detached once afterward. Source and candidate may use the same logical client
+id, so cleanup is tracked by attachment object and registration reference, not
+by comparing client-id strings.
+
+If automatic recovery cannot finish, the old transcript and attachment remain
+visible but read-only. A same-session reload starts a new authoritative recovery
+attempt; successful navigation to another session or an explicit lifecycle
+operation ends the episode. A failed close or release resumes recovery instead
+of silently leaving the safety lock without an active attempt. The old cursor
+is never resumed after a real gap.
+
+## Prompt and side-effect consistency
+
+Replay reconstruction and local prompt-promise settlement are separate. Replay
+already materializes terminal `assistant.done` state, so a matching local waiter
+is resolved or rejected without dispatching another transcript terminal. An
+idle candidate without a terminal for a bound local prompt is rejected; an
+active candidate carries the waiter into the replacement runner. If replay
+settles that local prompt while the candidate reports another active prompt,
+the successor remains owned by the replacement runner until its terminal.
+
+Historical replay does not republish notices, pending-prompt events, mid-turn
+injection events, or workspace-change counters. After commit, one reconciliation
+pulse refreshes workspace resources and pending/mid-turn snapshots, while only
+the latest follow-up suggestion is restored. Extension change details are
+cleared so a historical extension toast cannot reappear.
+
+## Live-journal repair
+
+Repair keeps its existing marker, checkpoint, and target-turn suffix rules but
+uses the same coordinator. The healthy source runner remains live while a full
+candidate snapshot is prepared. A bounded same-epoch source-tail capture closes
+the interval after the candidate watermark. If the load response arrives before
+the source SSE reaches that watermark, preparation waits within the existing
+deadline instead of treating delivery lag as corruption. The deadline starts
+when repair is queued, including when the source runner has not reached
+`replay_complete`. Commit atomically replaces the marker with the complete
+suffix plus captured tail and advances the candidate cursor to the final
+processed source event.
+
+The captured tail is reduced after the candidate snapshot, so newer title and
+token-usage updates remain authoritative through commit and runner startup.
+
+Repair replay and tail events have already been observed, so their external
+side effects are not emitted again. Repair attempts once. Failure retires the
+candidate and capture and continues the healthy source; a resync sentinel takes
+priority and converts the session to the persistent read-only episode.
+
+## Scheduling and failure behavior
+
+Resync shares one deadline across at most three requests. Only structured
+pre-attachment conditions are automatically retried: `session_closing`, an
+ordinary `restore_in_progress`, and a retryable quarantined ACP channel. Network
+outcome, restore timeout, abandoned-cleanup fences, generic HTTP failures, and
+candidate-integrity failures do not retry automatically because the server may
+already have registered an attachment that the client cannot identify safely.
+
+The WebUI connection exposes a recovery-required bit and a recovery transition
+origin. The main WebShell and split panes block every session mutation while a
+recovery is preparing or a gap remains unresolved. Read-only inspection,
+navigation, and explicit clear/new/close/release paths remain available.
+Controlled navigation rolls back host state only for controlled transition
+failures, never for an internal recovery failure.
+
+## Verification
+
+Provider tests cover every resync reason, legal-prefix flushing, replay
+integrity, prompt settlement, retries, supersede and lifecycle races, exact
+registration cleanup, side-effect reconciliation, and repair capture/commit.
+WebShell tests cover both layouts and provider-level mutation defenses.
+
+A real-daemon JSDOM test pauses an SSE reconnect, advances a three-event ring
+past the retained cursor, and observes a genuine `ring_evicted` sentinel. It
+then delays the recovery load to prove that the source transcript stays visible
+and read-only until atomic commit. The existing real-daemon live-journal test
+delays the repair load and verifies that the healthy source remains attached and
+the repaired turn appears once.

--- a/docs/plans/2026-08-12-transactional-webui-resync-and-repair.md
+++ b/docs/plans/2026-08-12-transactional-webui-resync-and-repair.md
@@ -1,0 +1,43 @@
+# Transactional WebUI resync and live-journal repair implementation
+
+## Scope
+
+Implement Issue #8678 PR3c-B on top of the existing WebUI restore coordinator.
+The change is limited to WebUI/WebShell behavior, tests, and documentation. It
+does not change daemon wire formats, SDK restore schemas, selective transcript
+reading, or durable checkpoints.
+
+## Implementation sequence
+
+1. Extend the existing restore intent with recovery purposes and keep a resync
+   safety episode outside any individual intent.
+2. Park a gapped runner, retain its transcript, and prepare an authoritative
+   same-session full load with its committed client identity, refreshing that
+   identity if a pending prompt admission self-heals it before request start.
+3. Reconstruct recovery replay in a shadow store, validate ownership,
+   completeness, epoch/watermark, prompt evidence, lifecycle, and deadline,
+   then atomically replace the source attachment.
+4. Separate prompt-promise settlement from transcript terminal publication and
+   replace historical replay side effects with one post-commit reconciliation.
+5. Move live-journal repair onto the same coordinator while retaining its
+   checkpoint, target suffix, and bounded source-tail capture; tail metadata
+   and usage must override the older candidate snapshot through runner startup.
+6. Apply one mutation-blocking rule to the main WebShell, split panes, queued
+   prompts, and provider action boundaries.
+7. Preserve the explicit legacy-daemon fallback; fail closed when a modern
+   daemon cannot provide an owned client attachment.
+
+## Verification
+
+- Run focused WebUI provider and WebShell layout/action tests.
+- Run real-daemon ring-eviction and live-journal repair integration tests.
+- Run formatting, lint, build, bundle, and typecheck.
+- Audit the final diff until two consecutive passes find no new actionable
+  issue, then run the available Codex review workflow.
+
+## Delivery
+
+Ship the design, implementation, and test evidence as one Draft PR titled
+`fix(webui): Make resync and repair transactional`, referencing Issue #8678.
+The rollback is a revert of the complete PR; no feature flag or alternate
+coordinator is retained.

--- a/integration-tests/cli/qwen-serve-webui-live-journal-recovery.test.ts
+++ b/integration-tests/cli/qwen-serve-webui-live-journal-recovery.test.ts
@@ -29,6 +29,8 @@ let root: Root | undefined;
 let dom: JSDOM;
 let createRoot: typeof import('react-dom/client').createRoot;
 let DaemonSessionProvider: typeof import('@qwen-code/webui/daemon-react-sdk').DaemonSessionProvider;
+let useActions: typeof import('@qwen-code/webui/daemon-react-sdk').useActions;
+let useConnection: typeof import('@qwen-code/webui/daemon-react-sdk').useConnection;
 let useTranscriptBlocks: typeof import('@qwen-code/webui/daemon-react-sdk').useTranscriptBlocks;
 const originalGlobalDescriptors = new Map(
   ['window', 'document', 'navigator', 'IS_REACT_ACT_ENVIRONMENT'].map(
@@ -57,9 +59,8 @@ beforeAll(async () => {
     value: true,
   });
   ({ createRoot } = await import('react-dom/client'));
-  ({ DaemonSessionProvider, useTranscriptBlocks } = await import(
-    '@qwen-code/webui/daemon-react-sdk'
-  ));
+  ({ DaemonSessionProvider, useActions, useConnection, useTranscriptBlocks } =
+    await import('@qwen-code/webui/daemon-react-sdk'));
 });
 
 afterAll(() => {
@@ -88,14 +89,22 @@ function eventText(event: DaemonEvent): string | undefined {
     ?.content?.text;
 }
 
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 async function waitFor(
-  condition: () => boolean,
+  condition: () => boolean | Promise<boolean>,
   description: string,
   timeoutMs = 5_000,
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (condition()) return;
+    if (await condition()) return;
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 20));
     });
@@ -103,21 +112,50 @@ async function waitFor(
   throw new Error(`Timed out waiting for ${description}`);
 }
 
+async function waitForPromise<T>(
+  promise: Promise<T>,
+  description: string,
+  timeoutMs = 5_000,
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(`Timed out waiting for ${description}`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+}
+
 describe('qwen serve WebUI live journal recovery', () => {
   it('repairs once after terminal without another model request', async () => {
     const workspace = makeTempWorkspace('webui-live-journal-recovery');
     const originalFetch = globalThis.fetch;
     const requestPaths: string[] = [];
+    const repairLoadReady = deferred();
+    const releaseRepairLoad = deferred();
+    let loadRequestCount = 0;
     try {
       globalThis.fetch = async (input, init) => {
-        const url =
-          typeof input === 'string'
-            ? input
-            : input instanceof URL
-              ? input.href
-              : input.url;
-        requestPaths.push(new URL(url, 'http://localhost').pathname);
-        return await originalFetch(input, init);
+        const request =
+          input instanceof Request ? input : new Request(input, init);
+        const pathname = new URL(request.url, 'http://localhost').pathname;
+        requestPaths.push(pathname);
+        const response = await originalFetch(request);
+        if (request.method === 'POST' && pathname.endsWith('/load')) {
+          loadRequestCount += 1;
+          if (loadRequestCount === 2) {
+            repairLoadReady.resolve();
+            await releaseRepairLoad.promise;
+          }
+        }
+        return response;
       };
       activeDaemon = await spawnDaemon({
         workspaceCwd: workspace,
@@ -126,7 +164,7 @@ describe('qwen serve WebUI live journal recovery', () => {
           QWEN_CLI_ENTRY: MOCK_AGENT_PATH,
           MOCK_ACP_MODE: 'echo',
           MOCK_ACP_EMIT_CHUNKS: '20',
-          MOCK_ACP_PROMPT_DELAY_MS: '1500',
+          MOCK_ACP_PROMPT_DELAY_MS: '5000',
         },
       });
       const created = await activeDaemon.client.createOrAttachSession({
@@ -144,12 +182,22 @@ describe('qwen serve WebUI live journal recovery', () => {
       const prompt = activeDaemon.client.prompt(created.sessionId, {
         prompt: [{ type: 'text', text: 'repair this turn in WebUI' }],
       });
+      void prompt.catch(() => undefined);
       await sawLastChunk;
+      expect(
+        (await activeDaemon.client.daemonStatus('full')).full?.sessions.find(
+          (session) => session.sessionId === created.sessionId,
+        )?.hasActivePrompt,
+      ).toBe(true);
       observerAbort.abort();
 
       let blocks: readonly DaemonTranscriptBlock[] = [];
+      let actions: ReturnType<typeof useActions> | undefined;
+      let connection: ReturnType<typeof useConnection> | undefined;
       function Harness() {
         blocks = useTranscriptBlocks();
+        actions = useActions();
+        connection = useConnection();
         return null;
       }
       const container = document.createElement('div');
@@ -158,7 +206,6 @@ describe('qwen serve WebUI live journal recovery', () => {
       await act(async () => {
         root?.render(
           // `children` is the one required prop on DaemonSessionProviderProps,
-          // and a trailing createElement argument does not satisfy it — the
           // call only type checks with children in the props object. The lint
           // rule guards JSX readability, which does not apply in this .ts file
           // where createElement is already being called by hand.
@@ -181,9 +228,36 @@ describe('qwen serve WebUI live journal recovery', () => {
           ),
         'visible live journal marker',
       );
+      const baseline = (
+        await activeDaemon.client.daemonStatus('full')
+      ).full?.sessions.find(
+        (session) => session.sessionId === created.sessionId,
+      );
+      expect(baseline).toBeDefined();
       await act(async () => {
         await prompt;
       });
+      await waitForPromise(repairLoadReady.promise, 'held repair load');
+      expect(
+        blocks.some(
+          (block) => 'source' in block && block.source === 'history_truncated',
+        ),
+      ).toBe(true);
+      expect(connection).toMatchObject({
+        status: 'connected',
+        sessionId: created.sessionId,
+        sessionTransition: { origin: 'recovery', phase: 'preparing' },
+      });
+      if (!actions) throw new Error('session actions unavailable');
+      await expect(
+        actions.sendPrompt('blocked while repair is preparing'),
+      ).rejects.toThrow('read-only until recovery completes');
+      expect(
+        (await activeDaemon.client.daemonStatus('full')).full?.sessions.find(
+          (session) => session.sessionId === created.sessionId,
+        )?.subscriberCount,
+      ).toBe(1);
+      releaseRepairLoad.resolve();
       await waitFor(
         () =>
           JSON.stringify(blocks).includes('chunk-0') &&
@@ -202,8 +276,20 @@ describe('qwen serve WebUI live journal recovery', () => {
         requestPaths.filter((pathname) => pathname.endsWith('/prompt')),
       ).toHaveLength(1);
       expect(JSON.stringify(blocks).match(/chunk-0/g)).toHaveLength(1);
+      await waitFor(async () => {
+        const session = (
+          await activeDaemon!.client.daemonStatus('full')
+        ).full?.sessions.find((entry) => entry.sessionId === created.sessionId);
+        return (
+          session !== undefined &&
+          session.clientCount === baseline?.clientCount &&
+          session.attachCount === baseline?.attachCount &&
+          session.subscriberCount === 1
+        );
+      }, 'repair attachment ledger to stabilize');
     } finally {
       globalThis.fetch = originalFetch;
+      releaseRepairLoad.resolve();
       if (root) {
         await act(async () => root?.unmount());
         root = undefined;

--- a/integration-tests/cli/qwen-serve-webui-state-resync.test.ts
+++ b/integration-tests/cli/qwen-serve-webui-state-resync.test.ts
@@ -1,0 +1,363 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { act, createElement } from 'react';
+import type { Root } from 'react-dom/client';
+import { JSDOM } from 'jsdom';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import type { DaemonTranscriptBlock } from '@qwen-code/sdk/daemon';
+import {
+  makeTempWorkspace,
+  spawnDaemon,
+  type SpawnedDaemon,
+} from './_daemon-harness.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MOCK_AGENT_PATH = path.resolve(
+  __dirname,
+  '../fixtures/mock-acp-child/agent.mjs',
+);
+const CLIENT_ID = 'webui-state-resync-client';
+
+let activeDaemon: SpawnedDaemon | undefined;
+let activeWorkspace: string | undefined;
+let root: Root | undefined;
+let dom: JSDOM;
+let createRoot: typeof import('react-dom/client').createRoot;
+let DaemonSessionProvider: typeof import('@qwen-code/webui/daemon-react-sdk').DaemonSessionProvider;
+let useActions: typeof import('@qwen-code/webui/daemon-react-sdk').useActions;
+let useConnection: typeof import('@qwen-code/webui/daemon-react-sdk').useConnection;
+let useTranscriptBlocks: typeof import('@qwen-code/webui/daemon-react-sdk').useTranscriptBlocks;
+const originalGlobalDescriptors = new Map(
+  ['window', 'document', 'navigator', 'IS_REACT_ACT_ENVIRONMENT'].map(
+    (key) => [key, Object.getOwnPropertyDescriptor(globalThis, key)] as const,
+  ),
+);
+
+beforeAll(async () => {
+  dom = new JSDOM('<!doctype html><html><body></body></html>', {
+    url: 'http://localhost',
+  });
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: dom.window,
+  });
+  Object.defineProperty(globalThis, 'document', {
+    configurable: true,
+    value: dom.window.document,
+  });
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: dom.window.navigator,
+  });
+  Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+    configurable: true,
+    value: true,
+  });
+  ({ createRoot } = await import('react-dom/client'));
+  ({ DaemonSessionProvider, useActions, useConnection, useTranscriptBlocks } =
+    await import('@qwen-code/webui/daemon-react-sdk'));
+});
+
+afterAll(() => {
+  dom.window.close();
+  for (const [key, descriptor] of originalGlobalDescriptors) {
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else Reflect.deleteProperty(globalThis, key);
+  }
+});
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => root?.unmount());
+    root = undefined;
+  }
+  await activeDaemon?.dispose();
+  activeDaemon = undefined;
+  if (activeWorkspace) {
+    fs.rmSync(activeWorkspace, { recursive: true, force: true });
+    activeWorkspace = undefined;
+  }
+});
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+async function waitFor(
+  condition: () => boolean | Promise<boolean>,
+  description: string,
+  timeoutMs = 10_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await condition()) return;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+  }
+  throw new Error(`Timed out waiting for ${description}`);
+}
+
+async function waitForPromise<T>(
+  promise: Promise<T>,
+  description: string,
+  timeoutMs = 10_000,
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(`Timed out waiting for ${description}`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+}
+
+describe('qwen serve WebUI transactional state resync', () => {
+  it('keeps the source visible until an authoritative ring-eviction reload commits', async () => {
+    const workspace = makeTempWorkspace('webui-state-resync');
+    activeWorkspace = workspace;
+    activeDaemon = await spawnDaemon({
+      workspaceCwd: workspace,
+      extraArgs: ['--event-ring-size', '3'],
+      env: {
+        QWEN_CLI_ENTRY: MOCK_AGENT_PATH,
+        MOCK_ACP_MODE: 'echo',
+        MOCK_ACP_EMIT_CHUNKS: '20',
+      },
+    });
+    const created = await activeDaemon.client.createOrAttachSession(
+      { sessionScope: 'thread' },
+      CLIENT_ID,
+    );
+    const stableClientId = created.clientId ?? CLIENT_ID;
+    await activeDaemon.client.promptNonBlocking(
+      created.sessionId,
+      { prompt: [{ type: 'text', text: 'seed transcript' }] },
+      undefined,
+      stableClientId,
+    );
+    await waitFor(async () => {
+      const status = await activeDaemon!.client.daemonStatus('full');
+      return (
+        status.full?.sessions.some(
+          (session) =>
+            session.sessionId === created.sessionId &&
+            session.hasActivePrompt === false,
+        ) === true
+      );
+    }, 'seed prompt to finish');
+
+    const originalFetch = globalThis.fetch;
+    const firstSseController = new AbortController();
+    const firstSseReady = deferred();
+    const reconnectReady = deferred<number>();
+    const releaseReconnect = deferred();
+    const recoveryLoadReady = deferred();
+    const releaseRecoveryLoad = deferred();
+    let eventRequestCount = 0;
+    let loadRequestCount = 0;
+    let recoveryLoadBody: Record<string, unknown> | undefined;
+
+    try {
+      globalThis.fetch = async (input, init) => {
+        const request =
+          input instanceof Request ? input : new Request(input, init);
+        const url = new URL(request.url);
+        if (
+          request.method === 'GET' &&
+          url.pathname.endsWith(
+            `/session/${encodeURIComponent(created.sessionId)}/events`,
+          )
+        ) {
+          eventRequestCount += 1;
+          if (eventRequestCount === 1) {
+            const response = await originalFetch(
+              new Request(request, {
+                signal: AbortSignal.any([
+                  request.signal,
+                  firstSseController.signal,
+                ]),
+              }),
+            );
+            firstSseReady.resolve();
+            return response;
+          }
+          if (url.searchParams.get('connectReason') === 'transport_error') {
+            const rawCursor = request.headers.get('Last-Event-ID');
+            const cursor = rawCursor === null ? NaN : Number(rawCursor);
+            if (
+              rawCursor === null ||
+              rawCursor.length === 0 ||
+              !Number.isSafeInteger(cursor) ||
+              cursor < 0
+            ) {
+              throw new Error('Provider reconnect omitted Last-Event-ID');
+            }
+            reconnectReady.resolve(cursor);
+            await releaseReconnect.promise;
+          }
+        }
+        if (
+          request.method === 'POST' &&
+          url.pathname.endsWith(
+            `/session/${encodeURIComponent(created.sessionId)}/load`,
+          )
+        ) {
+          loadRequestCount += 1;
+          const body = (await request.clone().json()) as Record<
+            string,
+            unknown
+          >;
+          const response = await originalFetch(request);
+          if (loadRequestCount === 2) {
+            recoveryLoadBody = body;
+            recoveryLoadReady.resolve();
+            await releaseRecoveryLoad.promise;
+          }
+          return response;
+        }
+        return await originalFetch(request);
+      };
+
+      let actions: ReturnType<typeof useActions> | undefined;
+      let connection: ReturnType<typeof useConnection> | undefined;
+      let blocks: readonly DaemonTranscriptBlock[] = [];
+      function Harness() {
+        actions = useActions();
+        connection = useConnection();
+        blocks = useTranscriptBlocks();
+        return null;
+      }
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      root = createRoot(container);
+      await act(async () => {
+        root?.render(
+          // eslint-disable-next-line react/no-children-prop
+          createElement(DaemonSessionProvider, {
+            autoConnect: true,
+            baseUrl: activeDaemon!.base,
+            token: activeDaemon!.token,
+            sessionId: created.sessionId,
+            workspaceCwd: created.workspaceCwd,
+            clientId: stableClientId,
+            historyPageSize: 100,
+            children: createElement(Harness),
+          }),
+        );
+      });
+      await waitForPromise(firstSseReady.promise, 'initial SSE response');
+      await waitFor(
+        () =>
+          connection?.status === 'connected' &&
+          JSON.stringify(blocks).includes('seed transcript'),
+        'initial WebUI attachment',
+      );
+      const baseline = (
+        await activeDaemon.client.daemonStatus('full')
+      ).full?.sessions.find(
+        (session) => session.sessionId === created.sessionId,
+      );
+      expect(baseline).toBeDefined();
+
+      firstSseController.abort();
+      const reconnectCursor = await waitForPromise(
+        reconnectReady.promise,
+        'held transport reconnect',
+      );
+      await activeDaemon.client.promptNonBlocking(
+        created.sessionId,
+        { prompt: [{ type: 'text', text: 'gap during reconnect' }] },
+        undefined,
+        stableClientId,
+      );
+      await waitFor(async () => {
+        const status = await activeDaemon!.client.daemonStatus('full');
+        const session = status.full?.sessions.find(
+          (entry) => entry.sessionId === created.sessionId,
+        );
+        return (
+          session?.hasActivePrompt === false &&
+          session.lastEventId >= reconnectCursor + 4
+        );
+      }, 'event ring to advance beyond the held cursor');
+
+      const resyncLogOffset = activeDaemon.stderrBuf.value.length;
+      releaseReconnect.resolve();
+      await waitForPromise(
+        recoveryLoadReady.promise,
+        'held recovery load response',
+      );
+      expect(recoveryLoadBody).not.toHaveProperty('historyPageSize');
+      expect(JSON.stringify(blocks)).toContain('seed transcript');
+      expect(JSON.stringify(blocks)).not.toContain('gap during reconnect');
+      expect(connection).toMatchObject({
+        status: 'connected',
+        sessionId: created.sessionId,
+        sessionRecoveryRequired: true,
+        sessionTransition: { origin: 'recovery', phase: 'preparing' },
+      });
+      if (!actions) throw new Error('session actions unavailable');
+      await expect(
+        actions.sendPrompt('blocked while recovering'),
+      ).rejects.toThrow('read-only until recovery completes');
+
+      releaseRecoveryLoad.resolve();
+      await waitFor(
+        () =>
+          connection?.sessionRecoveryRequired !== true &&
+          connection?.sessionTransition === undefined &&
+          JSON.stringify(blocks).includes('seed transcript') &&
+          JSON.stringify(blocks).includes('gap during reconnect'),
+        'atomic state recovery',
+      );
+      expect(
+        JSON.stringify(blocks).match(/gap during reconnect/g),
+      ).toHaveLength(1);
+      expect(JSON.stringify(blocks).match(/chunk-0/g)).toHaveLength(2);
+      expect(JSON.stringify(blocks).match(/chunk-19/g)).toHaveLength(2);
+      const currentActions = actions;
+      if (!currentActions) throw new Error('session actions unavailable');
+      await act(async () => {
+        await currentActions.sendPrompt('after recovery');
+      });
+      await waitFor(async () => {
+        const status = await activeDaemon!.client.daemonStatus('full');
+        const session = status.full?.sessions.find(
+          (entry) => entry.sessionId === created.sessionId,
+        );
+        return (
+          session?.hasActivePrompt === false &&
+          session.clientCount === baseline?.clientCount &&
+          session.attachCount === baseline?.attachCount &&
+          session.subscriberCount === baseline?.subscriberCount
+        );
+      }, 'replacement runner and attachment ledger to stabilize');
+      expect(activeDaemon.stderrBuf.value.slice(resyncLogOffset)).toContain(
+        'ring_evicted',
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      releaseReconnect.resolve();
+      releaseRecoveryLoad.resolve();
+    }
+  }, 60_000);
+});

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -44,6 +44,14 @@ type MockConnection = {
   error?: string;
   errorStatus?: number;
   missingSession?: boolean;
+  sessionRecoveryRequired?: true;
+  sessionTransition?: {
+    phase: 'queued' | 'preparing' | 'failed';
+    operation: 'load' | 'resume';
+    origin: 'action' | 'controlled' | 'recovery';
+    targetSessionId: string;
+    targetWorkspaceCwd?: string;
+  };
   gitBranch?: string;
   gitStatus?: DaemonWorkspaceGitStatus;
   voiceTarget?: VoiceWorkspaceTarget;
@@ -4413,6 +4421,8 @@ beforeEach(() => {
   mockConnection.skills = [];
   mockConnection.loadingTranscript = false;
   mockConnection.catchingUp = false;
+  mockConnection.sessionRecoveryRequired = undefined;
+  mockConnection.sessionTransition = undefined;
   mockConnection.capabilities = {
     qwenCodeVersion: '1.2.3',
     features: [],
@@ -10038,6 +10048,24 @@ describe('App session callbacks', () => {
     });
     await act(async () => new Promise((resolve) => setTimeout(resolve, 0)));
     expect(editorFocus).toHaveBeenCalledOnce();
+  });
+
+  it('keeps the main composer read-only after recovery preparation fails', async () => {
+    mockConnection.sessionRecoveryRequired = true;
+    mockConnection.sessionTransition = {
+      phase: 'failed',
+      operation: 'load',
+      origin: 'recovery',
+      targetSessionId: 'session-1',
+    };
+    renderApp();
+    await flush();
+
+    expect(testState.latestChatEditorProps?.disabled).toBe(true);
+    expect(testState.latestChatEditorProps?.onCancel).toBeUndefined();
+    expect(testState.latestChatEditorProps?.onSubmit('blocked')).toBe(false);
+    expect(mockSessionActions.sendPrompt).not.toHaveBeenCalled();
+    expect(mockSessionActions.cancel).not.toHaveBeenCalled();
   });
 
   it('opens a Live session in its owning Conversations workspace', async () => {

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -229,6 +229,7 @@ import {
 import { appendOrDeferLocalUserMessage } from './utils/localCommandQueue';
 import { QueuedPromptDisplay } from './components/QueuedPromptDisplay';
 import { useQueuedPrompts } from './hooks/useQueuedPrompts';
+import { isSessionMutationBlocked } from './utils/sessionMutationBlock';
 import { useNewSessionSuggestion } from './hooks/useNewSessionSuggestion';
 import {
   TasksStatusMessage,
@@ -2089,10 +2090,10 @@ export function App({
     connection.sessionId,
     connection.workspaceCwd,
   );
-  const sessionWriteBlocked =
-    desiredSessionTargetPending ||
-    connection.sessionTransition?.phase === 'queued' ||
-    connection.sessionTransition?.phase === 'preparing';
+  const sessionWriteBlocked = isSessionMutationBlocked(
+    connection,
+    desiredSessionTargetPending,
+  );
   const sessionWriteBlockedRef = useRef(sessionWriteBlocked);
   const sessionWriteBlockGenerationRef = useRef(0);
   if (sessionWriteBlocked && !sessionWriteBlockedRef.current) {
@@ -9665,6 +9666,7 @@ export function App({
   );
 
   const handleCancel = useCallback(() => {
+    if (sessionWriteBlockedRef.current) return;
     const owner = sessionOwnerGuard.capture();
     const dropped = queuedShellCommandsRef.current.length;
     queuedShellCommandsRef.current = [];
@@ -12292,7 +12294,9 @@ export function App({
                           onImagePreview={openImagePanel}
                           onCycleMode={handleCycleMode}
                           onToggleShortcuts={handleToggleShortcuts}
-                          onCancel={handleCancel}
+                          onCancel={
+                            sessionWriteBlocked ? undefined : handleCancel
+                          }
                           isRunning={streamingState !== 'idle'}
                           isPreparing={
                             isPreparingPrompt || isStartingNewSessionSuggestion

--- a/packages/web-shell/client/components/ChatPane.test.tsx
+++ b/packages/web-shell/client/components/ChatPane.test.tsx
@@ -794,6 +794,23 @@ describe('ChatPane', () => {
     expect(enqueuePrompt).not.toHaveBeenCalled();
   });
 
+  it('keeps a recovering split pane read-only', () => {
+    connectionState.sessionRecoveryRequired = true;
+    connectionState.sessionTransition = {
+      phase: 'failed',
+      operation: 'load',
+      origin: 'recovery',
+      targetSessionId: 'sess-1',
+    };
+    render();
+
+    expect(latestChatEditorProps.disabled).toBe(true);
+    expect(latestChatEditorProps.onCancel).toBeUndefined();
+    expect(latestOnSubmit?.('must stay local')).toBe(false);
+    expect(sendPrompt).not.toHaveBeenCalled();
+    expect(enqueuePrompt).not.toHaveBeenCalled();
+  });
+
   it('lets the host handle a slash command', () => {
     const onSlashCommand = vi.fn(() => true);
     render({ onSlashCommand });

--- a/packages/web-shell/client/components/ChatPane.tsx
+++ b/packages/web-shell/client/components/ChatPane.tsx
@@ -48,6 +48,7 @@ import type {
   EditorHandle,
 } from '../hooks/useComposerCore';
 import { useQueuedPrompts } from '../hooks/useQueuedPrompts';
+import { isSessionMutationBlocked } from '../utils/sessionMutationBlock';
 import { isAskUserPermission } from '../utils/askUserPermission';
 import { isDaemonApprovalMode } from '../utils/sessionPreparation';
 import { isVisibleComposerModel } from '../utils/composerModels';
@@ -495,6 +496,7 @@ export function ChatPane({
     [voiceTarget, voiceUserRevision, voiceWorkspaceRevisions],
   );
   const isResponding = streamingState !== 'idle';
+  const sessionWriteBlocked = isSessionMutationBlocked(connection);
   const artifactsByTurn = useMemo(
     () =>
       getArtifactsByTurn(messages, artifacts, connection.workspaceCwd || ''),
@@ -537,6 +539,7 @@ export function ChatPane({
     discardUnknownQueuedPrompt,
   } = useQueuedPrompts({
     connected: connection.status === 'connected',
+    writeBlocked: sessionWriteBlocked,
     sessionId: connection.sessionId,
     workspaceCwd: connection.workspaceCwd,
     clientId: connection.clientId,
@@ -571,6 +574,7 @@ export function ChatPane({
     ): boolean => {
       const trimmed = text.trim();
       if (!trimmed && (images?.length ?? 0) === 0) return false;
+      if (sessionWriteBlocked) return false;
       if (admissionPayloadLocked) return false;
       if (
         trimmed &&
@@ -667,6 +671,7 @@ export function ChatPane({
     [
       actions,
       admissionPayloadLocked,
+      sessionWriteBlocked,
       catalogOwnerCwd,
       clearFollowup,
       connection.sessionId,
@@ -1077,7 +1082,7 @@ export function ChatPane({
         <ChatEditor
           ref={editorRef}
           onSubmit={handleSubmit}
-          onCancel={handleCancel}
+          onCancel={sessionWriteBlocked ? undefined : handleCancel}
           isRunning={isResponding}
           commands={commands}
           queuedMessages={queuedTexts}
@@ -1096,7 +1101,9 @@ export function ChatPane({
           reasoning={connection.reasoning}
           onSelectReasoningEffort={handleSelectReasoningEffort}
           dialogOpen={approvalActive}
-          disabled={approvalActive || admissionPayloadLocked}
+          disabled={
+            approvalActive || admissionPayloadLocked || sessionWriteBlocked
+          }
           voiceTarget={hidden ? undefined : voiceTarget}
           voiceStatusRevision={voiceStatusRevision}
           followupState={followupState}
@@ -1111,7 +1118,9 @@ export function ChatPane({
         />
         {CustomComposerFooter && (
           <CustomComposerFooter
-            disabled={approvalActive || admissionPayloadLocked}
+            disabled={
+              approvalActive || admissionPayloadLocked || sessionWriteBlocked
+            }
             isRunning={isResponding}
             currentMode={connection.currentMode ?? 'default'}
             currentModel={connection.currentModel ?? ''}

--- a/packages/web-shell/client/components/WorkspaceSessionProvider.test.tsx
+++ b/packages/web-shell/client/components/WorkspaceSessionProvider.test.tsx
@@ -294,6 +294,28 @@ describe('WorkspaceSessionProvider transactional targets', () => {
     });
   });
 
+  it('does not roll a controlled target back for an internal recovery failure', async () => {
+    const onSessionIdChange = await renderTarget('session-a', '/work/a');
+    onSessionIdChange.mockClear();
+    mocks.connection = {
+      status: 'connected',
+      sessionId: 'session-b',
+      workspaceCwd: '/work/b',
+      sessionRecoveryRequired: true,
+      sessionTransition: {
+        phase: 'failed',
+        operation: 'load',
+        origin: 'recovery',
+        targetSessionId: 'session-b',
+        targetWorkspaceCwd: '/work/b',
+      },
+    };
+
+    await renderTarget('session-b', '/work/b', onSessionIdChange);
+
+    expect(onSessionIdChange).not.toHaveBeenCalled();
+  });
+
   it('rolls back a primary-workspace target when workspace props are omitted', async () => {
     const onSessionIdChange = vi.fn();
     await act(async () => {

--- a/packages/web-shell/client/components/WorkspaceSessionProvider.tsx
+++ b/packages/web-shell/client/components/WorkspaceSessionProvider.tsx
@@ -209,6 +209,7 @@ export function WorkspaceSessionProvider({
       const transition = connection.sessionTransition;
       if (
         transition?.phase === 'failed' &&
+        transition.origin === 'controlled' &&
         transition.targetSessionId === effectiveSessionId &&
         transition.targetWorkspaceCwd === desiredWorkspace?.cwd &&
         failureLatchRef.current !== desiredKey

--- a/packages/web-shell/client/hooks/useQueuedPrompts.dom.test.tsx
+++ b/packages/web-shell/client/hooks/useQueuedPrompts.dom.test.tsx
@@ -1246,6 +1246,79 @@ describe('useQueuedPrompts default mid-turn insertion', () => {
     expect(actions.enqueueMidTurnMessage).not.toHaveBeenCalled();
   });
 
+  it('keeps queue admission decisions inert while session writes are blocked', async () => {
+    const { actions, pendingSubmit } = createActions();
+    const { editor, render } = mount('responding', actions);
+    vi.mocked(actions.enqueueMidTurnMessage).mockResolvedValue({
+      accepted: false,
+    });
+
+    act(() => latest.enqueuePrompt('', [{ data: 'eA==', media_type: 'x' }]));
+    await act(async () => {
+      pendingSubmit.reject(new TypeError('response lost'));
+      await Promise.resolve();
+    });
+    const before = latest.queuedPrompts;
+    render('responding', 'session-1', false, true);
+
+    act(() => {
+      expect(latest.enqueuePrompt('blocked prompt')).toBe(false);
+      expect(latest.restoreUnknownQueuedPrompt(1)).toBe(false);
+      expect(latest.discardUnknownQueuedPrompt(1)).toBe(false);
+      expect(latest.editLastQueuedPrompt()).toBe(false);
+    });
+
+    expect(latest.queuedPrompts).toEqual(before);
+    expect(actions.submitPrompt).toHaveBeenCalledOnce();
+    expect(actions.removePendingPrompt).not.toHaveBeenCalled();
+    expect(actions.removeMidTurnMessage).not.toHaveBeenCalled();
+    expect(editor.setText).not.toHaveBeenCalled();
+  });
+
+  it.each(['remove', 'edit', 'clear'] as const)(
+    'keeps an admitted server row inert when %s is blocked',
+    async (operation) => {
+      const { actions, pendingSubmit } = createActions();
+      const { editor, render, store } = mount('responding', actions);
+
+      act(() =>
+        latest.enqueuePrompt('', [{ data: 'eA==', media_type: 'image/png' }]),
+      );
+      await act(async () => {
+        pendingSubmit.resolve({ promptId: 'server-queued' });
+        await Promise.resolve();
+      });
+      expect(latest.queuedPrompts).toMatchObject([
+        {
+          id: 1,
+          serverPromptId: 'server-queued',
+          serverState: 'queued',
+        },
+      ]);
+      const before = latest.queuedPrompts;
+      vi.mocked(actions.removePendingPrompt).mockClear();
+      editor.setText.mockClear();
+      editor.restoreImages.mockClear();
+      store.appendLocalUserMessage.mockClear();
+      render('responding', 'session-1', false, true);
+
+      if (operation === 'edit') {
+        await act(async () => latest.editQueuedPrompt(1));
+      } else {
+        act(() => {
+          if (operation === 'remove') latest.removeQueuedPrompt(1);
+          else expect(latest.clearQueuedPrompts()).toBe(false);
+        });
+      }
+
+      expect(latest.queuedPrompts).toEqual(before);
+      expect(actions.removePendingPrompt).not.toHaveBeenCalled();
+      expect(editor.setText).not.toHaveBeenCalled();
+      expect(editor.restoreImages).not.toHaveBeenCalled();
+      expect(store.appendLocalUserMessage).not.toHaveBeenCalled();
+    },
+  );
+
   it('retains mid-turn rows and marks in-flight admissions unknown on clear', async () => {
     const { actions } = createActions();
     vi.mocked(actions.enqueueMidTurnMessage).mockResolvedValue({

--- a/packages/web-shell/client/hooks/useQueuedPrompts.ts
+++ b/packages/web-shell/client/hooks/useQueuedPrompts.ts
@@ -1067,6 +1067,7 @@ export function useQueuedPrompts({
       inputAnnotations?: DaemonInputAnnotation[],
       onAdmitted?: () => void,
     ) => {
+      if (writeBlockedRef.current) return false;
       const trimmed = text.trim();
       if (!trimmed && (images?.length ?? 0) === 0) return true;
       const targetSessionId = latestSessionIdRef.current;
@@ -1605,6 +1606,7 @@ export function useQueuedPrompts({
 
   const removeQueuedPrompt = useCallback(
     (id: number) => {
+      if (writeBlockedRef.current) return;
       const target = queuedPromptsRef.current.find((p) => p.id === id);
       if (target?.admissionOutcome === 'unknown') return;
       if (
@@ -1640,6 +1642,7 @@ export function useQueuedPrompts({
 
   const resolveUnknownQueuedPrompt = useCallback(
     (id: number, restore: boolean): boolean => {
+      if (writeBlockedRef.current) return false;
       const ownerToken = ownerTokenRef.current;
       const target = queuedPromptsRef.current.find(
         (prompt) => prompt.id === id,
@@ -1694,6 +1697,7 @@ export function useQueuedPrompts({
 
   const editQueuedPrompt = useCallback(
     async (id: number) => {
+      if (writeBlockedRef.current) return;
       const target = queuedPromptsRef.current.find((p) => p.id === id);
       if (!target || target.serverState === 'submitting') return;
       if (
@@ -1738,6 +1742,7 @@ export function useQueuedPrompts({
   );
 
   const editLastQueuedPrompt = useCallback((): boolean => {
+    if (writeBlockedRef.current) return false;
     const current = queuedPromptsRef.current;
     if (current.length === 0) return false;
     const target = current[current.length - 1];
@@ -1787,6 +1792,7 @@ export function useQueuedPrompts({
   ]);
 
   const clearQueuedPrompts = useCallback((): boolean => {
+    if (writeBlockedRef.current) return false;
     if (queuedPromptsRef.current.length === 0) return false;
     const clearOwnerToken = ownerTokenRef.current;
     const clearSessionId = latestSessionIdRef.current;

--- a/packages/web-shell/client/utils/sessionMutationBlock.test.ts
+++ b/packages/web-shell/client/utils/sessionMutationBlock.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { DaemonConnectionState } from '@qwen-code/webui/daemon-react-sdk';
+import { isSessionMutationBlocked } from './sessionMutationBlock';
+
+describe('isSessionMutationBlocked', () => {
+  const connected: DaemonConnectionState = { status: 'connected' };
+
+  it('blocks pending targets, recovery locks, and active transitions', () => {
+    expect(isSessionMutationBlocked(connected, true)).toBe(true);
+    expect(
+      isSessionMutationBlocked({
+        ...connected,
+        sessionRecoveryRequired: true,
+      }),
+    ).toBe(true);
+    for (const phase of ['queued', 'preparing'] as const) {
+      expect(
+        isSessionMutationBlocked({
+          ...connected,
+          sessionTransition: {
+            phase,
+            operation: 'load',
+            origin: 'recovery',
+            targetSessionId: 'session-a',
+          },
+        }),
+      ).toBe(true);
+    }
+  });
+
+  it('does not block an ordinary failed transition without a recovery lock', () => {
+    expect(
+      isSessionMutationBlocked({
+        ...connected,
+        sessionTransition: {
+          phase: 'failed',
+          operation: 'load',
+          origin: 'action',
+          targetSessionId: 'session-b',
+        },
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/web-shell/client/utils/sessionMutationBlock.ts
+++ b/packages/web-shell/client/utils/sessionMutationBlock.ts
@@ -1,0 +1,13 @@
+import type { DaemonConnectionState } from '@qwen-code/webui/daemon-react-sdk';
+
+export function isSessionMutationBlocked(
+  connection: DaemonConnectionState,
+  desiredTargetPending = false,
+): boolean {
+  return (
+    desiredTargetPending ||
+    connection.sessionRecoveryRequired === true ||
+    connection.sessionTransition?.phase === 'queued' ||
+    connection.sessionTransition?.phase === 'preparing'
+  );
+}

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -4816,7 +4816,7 @@ describe('DaemonSessionProvider', () => {
   it('uses a bounded full-snapshot fallback after the marker block is trimmed', async () => {
     sdkMocks.capabilities.mockResolvedValue({
       workspaceCwd: '/mock-workspace',
-      features: ['session_transcript_pagination'],
+      features: ['client_identity', 'session_transcript_pagination'],
     });
     sdkMocks.getSessionTranscriptPage
       .mockResolvedValueOnce({
@@ -4908,6 +4908,7 @@ describe('DaemonSessionProvider', () => {
       events: async function* trimMarkerThenFinish(
         options: { signal?: AbortSignal } = {},
       ) {
+        yield { v: 1, type: 'replay_complete', data: {} };
         await toolGate.promise;
         if (options.signal?.aborted) return;
         yield toolEvent;
@@ -5031,6 +5032,7 @@ describe('DaemonSessionProvider', () => {
     'missing terminal',
     'degraded',
     'network error',
+    'closing session',
     'auth error',
     'missing session',
     'server error',
@@ -5105,6 +5107,9 @@ describe('DaemonSessionProvider', () => {
             );
             return;
           }
+          if (invalidCase === 'closing session') {
+            yield { v: 1, type: 'replay_complete', data: {} };
+          }
           await terminalGate.promise;
           if (options.signal?.aborted) return;
           yield terminalEvent;
@@ -5146,6 +5151,13 @@ describe('DaemonSessionProvider', () => {
       let notices: readonly DaemonSessionNotice[] = [];
       let connection: DaemonConnectionState | undefined;
 
+      if (invalidCase === 'closing session') {
+        sdkMocks.capabilities.mockResolvedValue({
+          workspaceCwd: '/mock-workspace',
+          features: ['client_identity'],
+        });
+      }
+
       function Harness() {
         blocks = useDaemonTranscriptBlocks();
         notices = useDaemonSessionNotices().notices;
@@ -5157,6 +5169,14 @@ describe('DaemonSessionProvider', () => {
       if (invalidCase === 'network error') {
         sdkMocks.MockDaemonSessionClient.load.mockRejectedValueOnce(
           new Error('repair load unavailable'),
+        );
+      } else if (invalidCase === 'closing session') {
+        sdkMocks.MockDaemonSessionClient.load.mockRejectedValueOnce(
+          new DaemonHttpError(
+            404,
+            { code: 'session_closing' },
+            'Session is closing',
+          ),
         );
       } else if (invalidCase === 'auth error') {
         sdkMocks.MockDaemonSessionClient.load.mockRejectedValueOnce(
@@ -5187,7 +5207,11 @@ describe('DaemonSessionProvider', () => {
             ),
           ).toBe(true),
         );
-        if (invalidCase !== 'auth error' && invalidCase !== 'missing session') {
+        if (
+          invalidCase !== 'closing session' &&
+          invalidCase !== 'auth error' &&
+          invalidCase !== 'missing session'
+        ) {
           await vi.waitFor(() =>
             expect(JSON.stringify(blocks)).toContain('old SSE resumed'),
           );
@@ -5202,6 +5226,7 @@ describe('DaemonSessionProvider', () => {
       ).toHaveLength(1);
       if (
         invalidCase === 'network error' ||
+        invalidCase === 'closing session' ||
         invalidCase === 'auth error' ||
         invalidCase === 'missing session' ||
         invalidCase === 'server error'
@@ -5222,6 +5247,13 @@ describe('DaemonSessionProvider', () => {
           sessionId: undefined,
           missingSession: true,
         });
+      } else if (invalidCase === 'closing session') {
+        expect(connection).toMatchObject({
+          status: 'connected',
+          sessionId: session.sessionId,
+        });
+        expect(connection?.sessionRecoveryRequired).toBeUndefined();
+        expect(connection?.sessionTransition).toBeUndefined();
       }
     },
   );
@@ -6681,6 +6713,100 @@ describe('DaemonSessionProvider', () => {
     }
   });
 
+  it('clears a parked passive-assistant timer before resync commit', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => new Response(null, { status: 204 })),
+      );
+      sdkMocks.capabilities.mockResolvedValue({
+        workspaceCwd: '/mock-workspace',
+        features: ['client_identity'],
+      });
+      const candidateStarted = createDeferred<void>();
+      const source = createMockSession({
+        sessionId: 'session-passive-resync',
+        clientId: 'client-stable',
+        lastEventId: 2,
+        events: async function* passiveResyncEvents() {
+          yield {
+            id: 3,
+            v: 1,
+            type: 'session_update',
+            promptId: 'observer-prompt',
+            data: {
+              update: {
+                sessionUpdate: 'agent_message_chunk',
+                content: { type: 'text', text: 'source partial' },
+              },
+            },
+          } satisfies DaemonEvent;
+          yield {
+            v: 1,
+            type: 'state_resync_required',
+            data: { reason: 'ring_evicted' },
+          } satisfies DaemonEvent;
+        },
+      });
+      const candidate = createMockSession({
+        sessionId: source.sessionId,
+        clientId: source.clientId,
+        hasActivePrompt: true,
+        lastEventId: 4,
+        replaySnapshot: {
+          compactedReplay: [
+            {
+              id: 4,
+              v: 1,
+              type: 'session_update',
+              promptId: 'observer-prompt',
+              data: {
+                update: {
+                  sessionUpdate: 'agent_message_chunk',
+                  content: { type: 'text', text: 'recovered partial' },
+                },
+              },
+            },
+          ],
+          liveJournal: [],
+        },
+        events: createPendingEvents(candidateStarted),
+      });
+      sdkMocks.sessions.push(source, candidate);
+      let blocks: readonly DaemonTranscriptBlock[] = [];
+      let streamingState: ReturnType<typeof useDaemonStreamingState> = 'idle';
+
+      function Harness() {
+        blocks = useDaemonTranscriptBlocks();
+        streamingState = useDaemonStreamingState();
+        return null;
+      }
+
+      await renderWithProvider(<Harness />, { autoConnect: true });
+      await act(async () => {
+        await candidateStarted.promise;
+        await vi.advanceTimersByTimeAsync(0);
+        await flushPromises();
+      });
+      expect(blocks).toMatchObject([
+        { kind: 'assistant', text: 'recovered partial', streaming: true },
+      ]);
+      expect(streamingState).toBe('responding');
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3_000);
+        await flushPromises();
+      });
+      expect(blocks).toMatchObject([
+        { kind: 'assistant', text: 'recovered partial', streaming: true },
+      ]);
+      expect(streamingState).toBe('responding');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('finishes replayed assistant streaming when replay completes', async () => {
     vi.useFakeTimers();
     try {
@@ -7162,11 +7288,7 @@ describe('DaemonSessionProvider', () => {
       return null;
     }
 
-    await renderWithProvider(<Harness />, {
-      autoConnect: true,
-      sessionId: 'session-a',
-      clientId: 'client-a',
-    });
+    await renderWithProvider(<Harness />, { autoConnect: true });
     await act(async () => {
       await streamStarted.promise;
       await flushPromises();
@@ -10036,6 +10158,7 @@ describe('DaemonSessionProvider', () => {
       createMockSession({
         sessionId: 'session-b',
         clientId: 'client-b',
+        lastEventId: 2,
         replaySnapshot: createTextReplaySnapshot('reloaded transcript'),
       }),
     );
@@ -10054,19 +10177,20 @@ describe('DaemonSessionProvider', () => {
     expect(sdkMocks.sessions).toHaveLength(0);
   });
 
-  it('carries a target live-journal repair episode into its runner', async () => {
+  it('starts a carried live-journal repair when replay already has its terminal', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn(async () => new Response(null, { status: 204 })),
     );
     sdkMocks.capabilities.mockResolvedValue({
       workspaceCwd: '/mock-workspace',
-      features: ['client_identity'],
+      features: ['client_identity', 'session_transcript_pagination'],
     });
     sdkMocks.sessions.push(
       createMockSession({ sessionId: 'session-a', clientId: 'client-a' }),
     );
-    const releaseTerminal = createDeferred<void>();
+    const releaseSourceCatchup = createDeferred<void>();
+    const sourceCatchupProcessed = createDeferred<void>();
     const marker: DaemonEvent = {
       id: 2,
       v: 1,
@@ -10080,12 +10204,14 @@ describe('DaemonSessionProvider', () => {
         maxBytes: 1024,
         maxEvents: 2,
         fullTranscriptAvailable: true,
+        recordId: 'record-before-repair',
       },
     };
     const target = createMockSession({
       sessionId: 'session-b',
       clientId: 'client-b',
-      lastEventId: 3,
+      historyHasMore: true,
+      lastEventId: 4,
       replaySnapshot: {
         compactedReplay: [],
         liveJournal: [
@@ -10102,28 +10228,80 @@ describe('DaemonSessionProvider', () => {
               },
             },
           },
+          {
+            id: 4,
+            v: 1,
+            type: 'turn_complete',
+            promptId: 'prompt-b',
+            data: { promptId: 'prompt-b', stopReason: 'end_turn' },
+          },
         ],
       },
-      events: async function* terminalEvents() {
-        await releaseTerminal.promise;
+      events: async function* terminalEvents(opts = {}) {
+        yield { v: 1, type: 'replay_complete', data: {} };
+        await releaseSourceCatchup.promise;
         yield {
-          id: 4,
+          id: 5,
           v: 1,
-          type: 'turn_complete',
+          type: 'session_update',
           promptId: 'prompt-b',
-          data: { promptId: 'prompt-b', stopReason: 'end_turn' },
-        };
+          data: {
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              content: { type: 'text', text: '' },
+              _meta: { usage: { inputTokens: 321, totalTokens: 654 } },
+            },
+          },
+        } satisfies DaemonEvent;
+        yield {
+          id: 6,
+          v: 1,
+          type: 'session_metadata_updated',
+          data: {
+            sessionId: 'session-b',
+            displayName: 'Updated while repair loaded',
+          },
+        } satisfies DaemonEvent;
+        sourceCatchupProcessed.resolve();
+        await new Promise<void>((resolve) =>
+          opts.signal?.addEventListener('abort', () => resolve(), {
+            once: true,
+          }),
+        );
       },
     });
     let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+    let history: ReturnType<typeof useDaemonTranscriptHistory> | undefined;
+    let promptStatus: ReturnType<typeof useDaemonPromptStatus> = 'idle';
+    let streamingState: ReturnType<typeof useDaemonStreamingState> = 'idle';
     function Harness() {
       actions = useDaemonActions();
+      connection = useDaemonConnection();
+      history = useDaemonTranscriptHistory();
+      promptStatus = useDaemonPromptStatus();
+      streamingState = useDaemonStreamingState();
       return null;
     }
 
-    await renderWithProvider(<Harness />, { autoConnect: true });
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      historyPageSize: 25,
+    });
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    const repairLoad = createDeferred<MockSession>();
     sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(
-      async () => target,
+      async (client) => {
+        target.client = client as MockClient;
+        return target;
+      },
+    );
+    sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(
+      async (client) => {
+        const repaired = await repairLoad.promise;
+        repaired.client = client as MockClient;
+        return repaired;
+      },
     );
     await act(async () => {
       await requireActions(actions).loadSession('session-b');
@@ -10133,6 +10311,8 @@ describe('DaemonSessionProvider', () => {
       createMockSession({
         sessionId: 'session-b',
         clientId: 'client-b',
+        lastEventId: 4,
+        state: { displayName: 'Stale candidate title' },
         replaySnapshot: {
           compactedReplay: [
             {
@@ -10159,14 +10339,194 @@ describe('DaemonSessionProvider', () => {
         },
       }),
     );
-    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    await vi.waitFor(() =>
+      expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(2),
+    );
+    sdkMocks.getSessionTranscriptPage.mockResolvedValueOnce({
+      v: 1,
+      sessionId: target.sessionId,
+      events: [],
+      nextCursor: 'cursor-after-repair-checkpoint',
+      hasMore: true,
+    });
+    await act(async () => history?.loadMore());
+    expect(sdkMocks.getSessionTranscriptPage).toHaveBeenNthCalledWith(
+      1,
+      target.sessionId,
+      {
+        beforeRecordId: 'record-before-repair',
+        limit: 25,
+        clientId: target.clientId,
+      },
+    );
+    await expect(requireActions(actions).cancel()).rejects.toThrow(
+      'read-only until recovery completes',
+    );
+    await expect(
+      requireActions(actions).submitPermission('request', 'allow'),
+    ).rejects.toThrow('read-only until recovery completes');
     await act(async () => {
-      releaseTerminal.resolve();
+      releaseSourceCatchup.resolve();
+      await sourceCatchupProcessed.promise;
       await flushPromises();
     });
-    await vi.waitFor(() =>
-      expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledOnce(),
+    await vi.waitFor(() => {
+      expect(connection?.displayName).toBe('Updated while repair loaded');
+      expect(connection?.tokenUsage).toEqual({
+        inputTokens: 321,
+        totalTokens: 654,
+      });
+    });
+    await expect(requireActions(actions).cancel()).rejects.toThrow(
+      'read-only until recovery completes',
     );
+    await act(async () => {
+      repairLoad.resolve(sdkMocks.sessions.shift()!);
+      await flushPromises();
+    });
+    expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(2);
+    await vi.waitFor(() =>
+      expect(connection?.sessionTransition).toBeUndefined(),
+    );
+    expect(connection?.displayName).toBe('Updated while repair loaded');
+    expect(connection?.tokenUsage).toEqual({
+      inputTokens: 321,
+      totalTokens: 654,
+    });
+    expect({ promptStatus, streamingState }).toEqual({
+      promptStatus: 'idle',
+      streamingState: 'idle',
+    });
+    sdkMocks.getSessionTranscriptPage.mockResolvedValueOnce({
+      v: 1,
+      sessionId: target.sessionId,
+      events: [],
+      hasMore: false,
+    });
+    await act(async () => history?.loadMore());
+    expect(sdkMocks.getSessionTranscriptPage).toHaveBeenNthCalledWith(
+      2,
+      target.sessionId,
+      {
+        cursor: 'cursor-after-repair-checkpoint',
+        limit: 25,
+        clientId: target.clientId,
+      },
+    );
+  });
+
+  it('times out a carried repair before the source runner becomes ready', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity', 'session_transcript_pagination'],
+      limits: { sessionRestoreTimeoutMs: 2_147_483_647 },
+    });
+    sdkMocks.sessions.push(
+      createMockSession({ sessionId: 'session-a', clientId: 'client-a' }),
+    );
+    const releaseReplayComplete = createDeferred<void>();
+    const target = createMockSession({
+      sessionId: 'session-b',
+      clientId: 'client-b',
+      historyHasMore: true,
+      lastEventId: 4,
+      replaySnapshot: {
+        compactedReplay: [],
+        liveJournal: [
+          {
+            id: 2,
+            v: 1,
+            type: 'history_truncated',
+            promptId: 'prompt-b',
+            data: {
+              reason: 'replay_window_exceeded',
+              scope: 'live_journal',
+              truncatedEvents: 4,
+              retainedEvents: 2,
+              maxBytes: 1024,
+              maxEvents: 2,
+              fullTranscriptAvailable: true,
+              recordId: 'record-before-repair',
+            },
+          },
+          {
+            id: 3,
+            v: 1,
+            type: 'session_update',
+            promptId: 'prompt-b',
+            data: {
+              update: {
+                sessionUpdate: 'agent_message_chunk',
+                content: { type: 'text', text: 'partial' },
+              },
+            },
+          },
+          {
+            id: 4,
+            v: 1,
+            type: 'turn_complete',
+            promptId: 'prompt-b',
+            data: { promptId: 'prompt-b', stopReason: 'end_turn' },
+          },
+        ],
+      },
+      events: async function* delayedReplayComplete(opts = {}) {
+        await releaseReplayComplete.promise;
+        yield { v: 1, type: 'replay_complete', data: {} };
+        await new Promise<void>((resolve) =>
+          opts.signal?.addEventListener('abort', () => resolve(), {
+            once: true,
+          }),
+        );
+      },
+    });
+    let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      historyPageSize: 25,
+    });
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    sdkMocks.MockDaemonSessionClient.load.mockResolvedValueOnce(target);
+    vi.useFakeTimers();
+    try {
+      await act(async () => {
+        await requireActions(actions).loadSession('session-b');
+        await flushPromises();
+      });
+      expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledOnce();
+      expect(connection).toMatchObject({
+        sessionId: 'session-b',
+        sessionTransition: { origin: 'recovery', phase: 'queued' },
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(75_001);
+        await flushPromises();
+      });
+      expect(connection?.sessionTransition).toBeUndefined();
+      expect(connection?.sessionRecoveryRequired).toBeUndefined();
+      await act(async () => {
+        await expect(
+          requireActions(actions).setModel('model-after-repair-timeout'),
+        ).resolves.toEqual({ modelId: 'model-after-repair-timeout' });
+      });
+      expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledOnce();
+    } finally {
+      releaseReplayComplete.resolve();
+      await act(async () => flushPromises());
+      vi.useRealTimers();
+    }
   });
 
   it('restores a standalone transactional resume through session/resume', async () => {
@@ -12229,6 +12589,14 @@ describe('DaemonSessionProvider', () => {
   });
 
   it('settles active prompts from replay snapshot after ring eviction', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
     const ringEvicted = createDeferred<void>();
     const reloaded = createDeferred<void>();
     const firstSession = createMockSession({
@@ -12253,6 +12621,7 @@ describe('DaemonSessionProvider', () => {
     });
     const reloadedSession = createMockSession({
       sessionId: 'session-ring-active-prompt',
+      lastEventId: 13,
       replaySnapshot: {
         compactedReplay: [
           {
@@ -12343,6 +12712,14 @@ describe('DaemonSessionProvider', () => {
   });
 
   it('rejects active prompts from replay turn_error after ring eviction', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
     const ringEvicted = createDeferred<void>();
     const reloaded = createDeferred<void>();
     const firstSession = createMockSession({
@@ -12367,6 +12744,7 @@ describe('DaemonSessionProvider', () => {
     });
     const reloadedSession = createMockSession({
       sessionId: 'session-ring-active-error',
+      lastEventId: 13,
       replaySnapshot: {
         compactedReplay: [
           {
@@ -15841,7 +16219,7 @@ describe('DaemonSessionProvider', () => {
     expect(new Headers(init?.headers).get('X-Qwen-Client-Id')).toBe('client-a');
   });
 
-  it('keeps the committed clientId for a later recovery request', async () => {
+  it('keeps the committed clientId for a later full recovery load', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn(async () => new Response(null, { status: 204 })),
@@ -15919,18 +16297,150 @@ describe('DaemonSessionProvider', () => {
         replaySnapshot: createTextReplaySnapshot('resynced transcript'),
       }),
     );
-    const resumeCallsBeforeResync =
-      sdkMocks.MockDaemonSessionClient.resume.mock.calls.length;
+    const loadCallsBeforeResync =
+      sdkMocks.MockDaemonSessionClient.load.mock.calls.length;
     await act(async () => {
       requestResync.resolve();
       await flushPromises();
     });
     await vi.waitFor(() =>
-      expect(sdkMocks.MockDaemonSessionClient.resume).toHaveBeenCalledTimes(
-        resumeCallsBeforeResync + 1,
+      expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(
+        loadCallsBeforeResync + 1,
       ),
     );
-    expect(sdkMocks.MockDaemonSessionClient.resume.mock.calls.at(-1)?.[3]).toBe(
+    expect(sdkMocks.MockDaemonSessionClient.load.mock.calls.at(-1)?.[3]).toBe(
+      'client-b',
+    );
+  });
+
+  it('replays a controlled clientId rebind after recovery commits', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    const requestResync = createDeferred<void>();
+    const source = createMockSession({
+      sessionId: 'session-a',
+      clientId: 'client-a',
+      lastEventId: 2,
+      events: async function* sourceEvents(opts = {}) {
+        yield { v: 1, type: 'replay_complete', data: {} };
+        await requestResync.promise;
+        yield {
+          id: 3,
+          v: 1,
+          type: 'state_resync_required',
+          data: { reason: 'ring_evicted' },
+        };
+        await new Promise<void>((resolve) =>
+          opts.signal?.addEventListener('abort', () => resolve(), {
+            once: true,
+          }),
+        );
+      },
+    });
+    sdkMocks.sessions.push(source);
+    let connection: DaemonConnectionState | undefined;
+    function Harness() {
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      sessionId: 'session-a',
+      clientId: 'client-a',
+    });
+    await vi.waitFor(() =>
+      expect(connection).toMatchObject({
+        status: 'connected',
+        sessionId: 'session-a',
+        clientId: 'client-a',
+      }),
+    );
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    const recoveryCandidate = createMockSession({
+      sessionId: 'session-a',
+      clientId: 'client-a',
+      eventEpoch: source.eventEpoch,
+      lastEventId: 4,
+      events: async function* recoveryEvents(opts = {}) {
+        yield { v: 1, type: 'replay_complete', data: {} };
+        await new Promise<void>((resolve) =>
+          opts.signal?.addEventListener('abort', () => resolve(), {
+            once: true,
+          }),
+        );
+      },
+    });
+    const recoveryReady = createDeferred<void>();
+    sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(async () => {
+      await recoveryReady.promise;
+      return recoveryCandidate;
+    });
+    sdkMocks.MockDaemonSessionClient.resume.mockResolvedValueOnce(
+      createMockSession({
+        sessionId: 'session-a',
+        clientId: 'client-b',
+        lastEventId: 4,
+      }),
+    );
+    await act(async () => {
+      requestResync.resolve();
+      await flushPromises();
+    });
+    expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledOnce();
+    await act(async () => {
+      root?.render(
+        <DaemonSessionProvider
+          baseUrl="http://127.0.0.1:4170"
+          autoConnect
+          sessionId="session-a"
+          clientId="client-b"
+        >
+          <Harness />
+        </DaemonSessionProvider>,
+      );
+      await flushPromises();
+    });
+    expect(connection?.sessionRecoveryRequired).toBe(true);
+    const controlledRebind = createDeferred<MockSession>();
+    sdkMocks.MockDaemonSessionClient.resume.mockImplementationOnce(
+      async () => controlledRebind.promise,
+    );
+    await act(async () => {
+      recoveryReady.resolve();
+      await flushPromises();
+    });
+    await vi.waitFor(() =>
+      expect(sdkMocks.MockDaemonSessionClient.resume).toHaveBeenCalledOnce(),
+    );
+    await act(async () => {
+      controlledRebind.resolve(
+        createMockSession({
+          sessionId: 'session-a',
+          clientId: 'client-b',
+          lastEventId: 4,
+        }),
+      );
+      await flushPromises();
+    });
+    await vi.waitFor(() =>
+      expect(connection).toMatchObject({
+        sessionId: 'session-a',
+        clientId: 'client-b',
+      }),
+    );
+    expect(
+      sdkMocks.MockDaemonSessionClient.load.mock.calls.every(
+        (call) => call[3] === 'client-a',
+      ),
+    ).toBe(true);
+    expect(sdkMocks.MockDaemonSessionClient.resume.mock.calls[0]?.[3]).toBe(
       'client-b',
     );
   });
@@ -16079,6 +16589,1427 @@ describe('DaemonSessionProvider', () => {
     expect(sdkMocks.MockDaemonSessionClient.load.mock.calls[0]?.[3]).toBe(
       'client-b',
     );
+  });
+
+  it.each(['epoch_reset', 'ring_evicted', 'future_reason'])(
+    'preserves the source while transactional %s recovery is preparing',
+    async (reason) => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => new Response(null, { status: 204 })),
+      );
+      sdkMocks.capabilities.mockResolvedValue({
+        workspaceCwd: '/mock-workspace',
+        features: ['client_identity', 'session_transcript_pagination'],
+      });
+      const emitResync = createDeferred<void>();
+      const recovery = createDeferred<MockSession>();
+      const source = createMockSession({
+        sessionId: 'session-transactional-resync',
+        clientId: 'client-stable',
+        lastEventId: 2,
+        replaySnapshot: createTextReplaySnapshot('source transcript'),
+        events: async function* resyncEvents() {
+          await emitResync.promise;
+          yield {
+            v: 1,
+            type: 'state_resync_required',
+            data: { reason },
+          } satisfies DaemonEvent;
+        },
+      });
+      sdkMocks.sessions.push(source);
+      let actions: DaemonSessionActions | undefined;
+      let blocks: readonly DaemonTranscriptBlock[] = [];
+      let connection: DaemonConnectionState | undefined;
+      function Harness() {
+        actions = useDaemonActions();
+        blocks = useDaemonTranscriptBlocks();
+        connection = useDaemonConnection();
+        return null;
+      }
+
+      await renderWithProvider(<Harness />, {
+        autoConnect: true,
+        historyPageSize: 25,
+      });
+      sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(
+        async () => recovery.promise,
+      );
+      await act(async () => {
+        emitResync.resolve();
+        await vi.waitFor(() =>
+          expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(
+            2,
+          ),
+        );
+      });
+
+      expect(blocks).toMatchObject([
+        { kind: 'assistant', text: 'source transcript' },
+      ]);
+      expect(connection).toMatchObject({
+        status: 'connected',
+        sessionId: source.sessionId,
+        clientId: 'client-stable',
+        sessionRecoveryRequired: true,
+        sessionTransition: { origin: 'recovery', phase: 'preparing' },
+      });
+      expect(sdkMocks.MockDaemonSessionClient.load.mock.calls[1]?.[2]).toEqual(
+        expect.not.objectContaining({ historyPageSize: expect.anything() }),
+      );
+      expect(sdkMocks.MockDaemonSessionClient.load.mock.calls[1]?.[3]).toBe(
+        'client-stable',
+      );
+      await expect(
+        requireActions(actions).sendShellCommand('echo blocked'),
+      ).rejects.toThrow('read-only until recovery completes');
+    },
+  );
+
+  it('keeps one owner for a local prompt that remains active after resync', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    const emitResync = createDeferred<void>();
+    const emitTerminal = createDeferred<void>();
+    const source = createMockSession({
+      sessionId: 'session-resync-active-prompt',
+      clientId: 'client-stable',
+      lastEventId: 2,
+      submitPrompt: vi.fn(async () => ({
+        promptId: 'prompt-local',
+        lastEventId: 2,
+      })),
+      events: async function* resyncEvents() {
+        await emitResync.promise;
+        yield {
+          v: 1,
+          type: 'state_resync_required',
+          data: { reason: 'ring_evicted' },
+        } satisfies DaemonEvent;
+      },
+    });
+    const candidate = createMockSession({
+      sessionId: source.sessionId,
+      clientId: source.clientId,
+      hasActivePrompt: true,
+      lastEventId: 3,
+      replaySnapshot: {
+        compactedReplay: [
+          {
+            id: 3,
+            v: 1,
+            type: 'session_update',
+            promptId: 'prompt-local',
+            data: {
+              update: {
+                sessionUpdate: 'agent_message_chunk',
+                content: { type: 'text', text: 'prompt still running' },
+              },
+            },
+          },
+        ],
+        liveJournal: [],
+      },
+      events: async function* candidateEvents() {
+        yield { v: 1, type: 'replay_complete', data: {} };
+        await emitTerminal.promise;
+        yield {
+          id: 4,
+          v: 1,
+          type: 'turn_complete',
+          promptId: 'prompt-local',
+          data: { promptId: 'prompt-local', stopReason: 'end_turn' },
+        } satisfies DaemonEvent;
+      },
+    });
+    sdkMocks.sessions.push(source, candidate);
+    let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+    let promptStatus: ReturnType<typeof useDaemonPromptStatus> = 'idle';
+    let streamingState: ReturnType<typeof useDaemonStreamingState> = 'idle';
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      promptStatus = useDaemonPromptStatus();
+      streamingState = useDaemonStreamingState();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    let prompt!: Promise<unknown>;
+    await act(async () => {
+      prompt = requireActions(actions).sendPrompt('keep running');
+      await vi.waitFor(() =>
+        expect(source.submitPrompt).toHaveBeenCalledOnce(),
+      );
+      emitResync.resolve();
+      await vi.waitFor(() =>
+        expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(2),
+      );
+      await vi.waitFor(() =>
+        expect(connection?.sessionRecoveryRequired).toBeUndefined(),
+      );
+    });
+    await act(async () => {
+      emitTerminal.resolve();
+      await expect(prompt).resolves.toEqual({ stopReason: 'end_turn' });
+      await flushPromises();
+    });
+    await vi.waitFor(() =>
+      expect({ promptStatus, streamingState }).toEqual({
+        promptStatus: 'idle',
+        streamingState: 'idle',
+      }),
+    );
+  });
+
+  it('keeps a successor prompt active after replay settles the local prompt', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    const emitResync = createDeferred<void>();
+    const emitSuccessorTerminal = createDeferred<void>();
+    const source = createMockSession({
+      sessionId: 'session-resync-successor-prompt',
+      clientId: 'client-stable',
+      lastEventId: 2,
+      submitPrompt: vi.fn(async () => ({
+        promptId: 'prompt-local',
+        lastEventId: 2,
+      })),
+      events: async function* resyncEvents() {
+        await emitResync.promise;
+        yield {
+          v: 1,
+          type: 'state_resync_required',
+          data: { reason: 'ring_evicted' },
+        } satisfies DaemonEvent;
+      },
+    });
+    const candidate = createMockSession({
+      sessionId: source.sessionId,
+      clientId: source.clientId,
+      hasActivePrompt: true,
+      lastEventId: 5,
+      replaySnapshot: {
+        compactedReplay: [
+          {
+            id: 3,
+            v: 1,
+            type: 'turn_complete',
+            promptId: 'prompt-local',
+            data: { promptId: 'prompt-local', stopReason: 'end_turn' },
+          },
+          {
+            id: 4,
+            v: 1,
+            type: 'session_update',
+            promptId: 'prompt-successor',
+            data: {
+              update: {
+                sessionUpdate: 'user_message_chunk',
+                content: { type: 'text', text: 'successor prompt' },
+              },
+            },
+          },
+          {
+            id: 5,
+            v: 1,
+            type: 'session_update',
+            promptId: 'prompt-successor',
+            data: {
+              update: {
+                sessionUpdate: 'agent_message_chunk',
+                content: { type: 'text', text: 'successor running' },
+              },
+            },
+          },
+        ],
+        liveJournal: [],
+      },
+      events: async function* candidateEvents() {
+        yield { v: 1, type: 'replay_complete', data: {} };
+        await emitSuccessorTerminal.promise;
+        yield {
+          id: 6,
+          v: 1,
+          type: 'turn_complete',
+          promptId: 'prompt-successor',
+          data: { promptId: 'prompt-successor', stopReason: 'end_turn' },
+        } satisfies DaemonEvent;
+      },
+    });
+    sdkMocks.sessions.push(source, candidate);
+    let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+    let promptStatus: ReturnType<typeof useDaemonPromptStatus> = 'idle';
+    let streamingState: ReturnType<typeof useDaemonStreamingState> = 'idle';
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      promptStatus = useDaemonPromptStatus();
+      streamingState = useDaemonStreamingState();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    let localPrompt!: Promise<unknown>;
+    await act(async () => {
+      localPrompt = requireActions(actions).sendPrompt('local prompt');
+      await vi.waitFor(() =>
+        expect(source.submitPrompt).toHaveBeenCalledOnce(),
+      );
+      emitResync.resolve();
+      await vi.waitFor(() =>
+        expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(2),
+      );
+      await vi.waitFor(() =>
+        expect(connection?.sessionRecoveryRequired).toBeUndefined(),
+      );
+      await expect(localPrompt).resolves.toEqual({ stopReason: 'end_turn' });
+    });
+    expect({ promptStatus, streamingState }).toEqual({
+      promptStatus: 'streaming',
+      streamingState: 'responding',
+    });
+    await act(async () => {
+      emitSuccessorTerminal.resolve();
+      await flushPromises();
+    });
+    await vi.waitFor(() =>
+      expect({ promptStatus, streamingState }).toEqual({
+        promptStatus: 'idle',
+        streamingState: 'idle',
+      }),
+    );
+  });
+
+  it('fails closed when a modern attachment has no client identity', async () => {
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    const emitResync = createDeferred<void>();
+    const source = createMockSession({
+      sessionId: 'session-resync-without-owner',
+      replaySnapshot: createTextReplaySnapshot('retained transcript'),
+      events: async function* resyncEvents() {
+        await emitResync.promise;
+        yield {
+          v: 1,
+          type: 'state_resync_required',
+          data: { reason: 'ring_evicted' },
+        } satisfies DaemonEvent;
+      },
+    });
+    delete (source as Partial<MockSession>).clientId;
+    sdkMocks.sessions.push(source);
+    let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+    let blocks: readonly DaemonTranscriptBlock[] = [];
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      blocks = useDaemonTranscriptBlocks();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    await act(async () => {
+      emitResync.resolve();
+      await flushPromises();
+    });
+
+    expect(sdkMocks.MockDaemonSessionClient.load).not.toHaveBeenCalled();
+    expect(blocks).toMatchObject([
+      { kind: 'assistant', text: 'retained transcript' },
+    ]);
+    expect(connection).toMatchObject({
+      status: 'connected',
+      sessionRecoveryRequired: true,
+      sessionTransition: { origin: 'recovery', phase: 'failed' },
+    });
+    await expect(requireActions(actions).sendPrompt('blocked')).rejects.toThrow(
+      'read-only until recovery completes',
+    );
+
+    sdkMocks.sessions.push(
+      createMockSession({
+        sessionId: source.sessionId,
+        clientId: 'replacement-client',
+        replaySnapshot: createTextReplaySnapshot('replacement transcript'),
+      }),
+    );
+    act(() => {
+      root?.render(
+        <DaemonSessionProvider
+          baseUrl="http://127.0.0.1:4170"
+          autoConnect
+          sessionId={source.sessionId}
+          maxBlocks={4096}
+        >
+          <Harness />
+        </DaemonSessionProvider>,
+      );
+    });
+    await act(async () => flushPromises());
+    await vi.waitFor(() =>
+      expect(connection).toMatchObject({
+        status: 'connected',
+        sessionId: source.sessionId,
+        clientId: 'replacement-client',
+      }),
+    );
+    expect(connection?.sessionRecoveryRequired).toBeUndefined();
+    expect(connection?.sessionTransition).toBeUndefined();
+  });
+
+  it('flushes the valid prefix and ignores events after a resync sentinel', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    const emitResync = createDeferred<void>();
+    const recovery = createDeferred<MockSession>();
+    sdkMocks.sessions.push(
+      createMockSession({
+        sessionId: 'session-resync-prefix',
+        clientId: 'client-stable',
+        lastEventId: 2,
+        replaySnapshot: createTextReplaySnapshot('snapshot prefix'),
+        events: async function* resyncEvents() {
+          await emitResync.promise;
+          yield {
+            id: 3,
+            v: 1,
+            type: 'session_update',
+            data: {
+              update: {
+                sessionUpdate: 'agent_message_chunk',
+                content: { type: 'text', text: ' valid prefix' },
+              },
+            },
+          } satisfies DaemonEvent;
+          yield {
+            v: 1,
+            type: 'state_resync_required',
+            data: { reason: 'ring_evicted' },
+          } satisfies DaemonEvent;
+          yield {
+            id: 5,
+            v: 1,
+            type: 'session_update',
+            data: {
+              update: {
+                sessionUpdate: 'agent_message_chunk',
+                content: { type: 'text', text: ' stale suffix' },
+              },
+            },
+          } satisfies DaemonEvent;
+        },
+      }),
+    );
+    let blocks: readonly DaemonTranscriptBlock[] = [];
+    function Harness() {
+      blocks = useDaemonTranscriptBlocks();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(
+      async () => recovery.promise,
+    );
+    await act(async () => {
+      emitResync.resolve();
+      await vi.waitFor(() =>
+        expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(2),
+      );
+      await flushTranscriptDispatch();
+    });
+
+    expect(JSON.stringify(blocks)).toContain('snapshot prefix');
+    expect(JSON.stringify(blocks)).toContain(' valid prefix');
+    expect(JSON.stringify(blocks)).not.toContain('stale suffix');
+  });
+
+  it('resumes a recovery lock after a superseding navigation fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    const emitResync = createDeferred<void>();
+    const firstRecovery = createDeferred<MockSession>();
+    const resumedRecovery = createDeferred<MockSession>();
+    const source = createMockSession({
+      sessionId: 'session-resync-navigation',
+      clientId: 'client-stable',
+      lastEventId: 2,
+      replaySnapshot: createTextReplaySnapshot('source transcript'),
+      events: async function* resyncEvents() {
+        await emitResync.promise;
+        yield {
+          v: 1,
+          type: 'state_resync_required',
+          data: { reason: 'ring_evicted' },
+        } satisfies DaemonEvent;
+      },
+    });
+    sdkMocks.sessions.push(source);
+    let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+    let blocks: readonly DaemonTranscriptBlock[] = [];
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      blocks = useDaemonTranscriptBlocks();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(
+      async () => firstRecovery.promise,
+    );
+    await act(async () => {
+      emitResync.resolve();
+      await flushPromises();
+    });
+    await vi.waitFor(() =>
+      expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledOnce(),
+    );
+
+    let navigationOutcome!: Promise<unknown>;
+    act(() => {
+      navigationOutcome = requireActions(actions)
+        .loadSession('session-b', { workspaceCwd: '/mock-workspace' })
+        .catch((error: unknown) => error);
+    });
+    sdkMocks.MockDaemonSessionClient.load
+      .mockRejectedValueOnce(new Error('target failed'))
+      .mockImplementationOnce(async () => resumedRecovery.promise);
+    await act(async () => {
+      firstRecovery.resolve(
+        createMockSession({
+          sessionId: source.sessionId,
+          clientId: source.clientId,
+          lastEventId: 2,
+          replaySnapshot: createTextReplaySnapshot('stale candidate'),
+        }),
+      );
+      await flushPromises();
+    });
+    expect(await navigationOutcome).toBeInstanceOf(Error);
+    await vi.waitFor(() =>
+      expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(3),
+    );
+    expect(connection?.sessionRecoveryRequired).toBe(true);
+    expect(blocks).toMatchObject([
+      { kind: 'assistant', text: 'source transcript' },
+    ]);
+    await expect(requireActions(actions).sendPrompt('blocked')).rejects.toThrow(
+      'read-only until recovery completes',
+    );
+
+    await act(async () => {
+      resumedRecovery.resolve(
+        createMockSession({
+          sessionId: source.sessionId,
+          clientId: source.clientId,
+          lastEventId: 3,
+          replaySnapshot: createTextReplaySnapshot('recovered transcript'),
+        }),
+      );
+      await flushPromises();
+    });
+    expect(connection?.sessionId).toBe(source.sessionId);
+    expect(connection?.sessionRecoveryRequired).toBeUndefined();
+    expect(blocks).toMatchObject([
+      { kind: 'assistant', text: 'recovered transcript' },
+    ]);
+  });
+
+  it.each([
+    {
+      caseName: 'a pre-gap watermark',
+      lastEventId: 2,
+      replaySnapshot: createTextReplaySnapshot('stale transcript'),
+    },
+    {
+      caseName: 'another resync sentinel',
+      lastEventId: 3,
+      replaySnapshot: {
+        compactedReplay: [
+          {
+            v: 1 as const,
+            type: 'state_resync_required' as const,
+            data: { reason: 'ring_evicted' },
+          },
+        ],
+        liveJournal: [],
+      },
+    },
+  ])('rejects a recovery snapshot with $caseName', async (candidateState) => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    const emitResync = createDeferred<void>();
+    const source = createMockSession({
+      sessionId: 'session-nested-resync',
+      clientId: 'client-stable',
+      lastEventId: 2,
+      replaySnapshot: createTextReplaySnapshot('retained transcript'),
+      events: async function* resyncEvents() {
+        await emitResync.promise;
+        yield {
+          v: 1,
+          type: 'state_resync_required',
+          data: { reason: 'ring_evicted' },
+        } satisfies DaemonEvent;
+      },
+    });
+    sdkMocks.sessions.push(source);
+    let connection: DaemonConnectionState | undefined;
+    let blocks: readonly DaemonTranscriptBlock[] = [];
+    function Harness() {
+      connection = useDaemonConnection();
+      blocks = useDaemonTranscriptBlocks();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    sdkMocks.MockDaemonSessionClient.load.mockResolvedValueOnce(
+      createMockSession({
+        sessionId: source.sessionId,
+        clientId: source.clientId,
+        lastEventId: candidateState.lastEventId,
+        replaySnapshot: candidateState.replaySnapshot,
+      }),
+    );
+    await act(async () => {
+      emitResync.resolve();
+      await flushPromises();
+    });
+    await vi.waitFor(() =>
+      expect(connection?.sessionTransition).toMatchObject({
+        origin: 'recovery',
+        phase: 'failed',
+      }),
+    );
+
+    expect(connection?.sessionRecoveryRequired).toBe(true);
+    expect(blocks).toMatchObject([
+      { kind: 'assistant', text: 'retained transcript' },
+    ]);
+  });
+
+  it('keeps a failed recovery read-only until an authoritative reload succeeds', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    const emitResync = createDeferred<void>();
+    const close = vi.fn(async () => undefined);
+    const source = createMockSession({
+      sessionId: 'session-resync-retry',
+      clientId: 'client-stable',
+      lastEventId: 2,
+      replaySnapshot: createTextReplaySnapshot('source transcript'),
+      close,
+      events: async function* resyncEvents() {
+        await emitResync.promise;
+        yield {
+          v: 1,
+          type: 'state_resync_required',
+          data: { reason: 'ring_evicted' },
+        } satisfies DaemonEvent;
+      },
+    });
+    sdkMocks.sessions.push(source);
+    let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+    let blocks: readonly DaemonTranscriptBlock[] = [];
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      blocks = useDaemonTranscriptBlocks();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      autoReconnect: false,
+    });
+    sdkMocks.MockDaemonSessionClient.load.mockRejectedValueOnce(
+      new Error('unknown recovery outcome'),
+    );
+    await act(async () => {
+      emitResync.resolve();
+      await flushPromises();
+    });
+    await vi.waitFor(() =>
+      expect(connection?.sessionTransition).toMatchObject({
+        origin: 'recovery',
+        phase: 'failed',
+      }),
+    );
+
+    expect(connection?.sessionRecoveryRequired).toBe(true);
+    expect(blocks).toMatchObject([
+      { kind: 'assistant', text: 'source transcript' },
+    ]);
+    await expect(requireActions(actions).sendPrompt('blocked')).rejects.toThrow(
+      'read-only until recovery completes',
+    );
+    close.mockRejectedValueOnce(new Error('close failed'));
+    const resumedRecovery = createDeferred<MockSession>();
+    sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(
+      async () => resumedRecovery.promise,
+    );
+    await expect(requireActions(actions).closeSession()).rejects.toThrow(
+      'close failed',
+    );
+    await vi.waitFor(() =>
+      expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(3),
+    );
+    expect(connection?.sessionRecoveryRequired).toBe(true);
+    await expect(
+      requireActions(actions).sendPrompt('still blocked'),
+    ).rejects.toThrow('read-only until recovery completes');
+
+    await act(async () => {
+      resumedRecovery.resolve(
+        createMockSession({
+          sessionId: source.sessionId,
+          clientId: 'client-stable',
+          lastEventId: 3,
+          replaySnapshot: createTextReplaySnapshot('recovered transcript'),
+        }),
+      );
+      await flushPromises();
+    });
+    await vi.waitFor(() =>
+      expect(connection?.sessionRecoveryRequired).toBeUndefined(),
+    );
+    expect(sdkMocks.MockDaemonSessionClient.resume).not.toHaveBeenCalled();
+    expect(connection?.sessionRecoveryRequired).toBeUndefined();
+    expect(connection?.sessionTransition).toBeUndefined();
+    expect(blocks).toMatchObject([
+      { kind: 'assistant', text: 'recovered transcript' },
+    ]);
+  });
+
+  it('clears a parked recovery session after close succeeds', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    const emitResync = createDeferred<void>();
+    const recovery = createDeferred<MockSession>();
+    const source = createMockSession({
+      sessionId: 'session-resync-close',
+      clientId: 'client-stable',
+      lastEventId: 2,
+      replaySnapshot: createTextReplaySnapshot('source transcript'),
+      events: async function* resyncEvents() {
+        await emitResync.promise;
+        yield {
+          v: 1,
+          type: 'state_resync_required',
+          data: { reason: 'ring_evicted' },
+        } satisfies DaemonEvent;
+      },
+    });
+    sdkMocks.sessions.push(source);
+    let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(
+      async () => recovery.promise,
+    );
+    await act(async () => {
+      emitResync.resolve();
+      await flushPromises();
+    });
+    await vi.waitFor(() =>
+      expect(connection?.sessionRecoveryRequired).toBe(true),
+    );
+    await act(async () => {
+      await requireActions(actions).closeSession();
+      await flushPromises();
+    });
+
+    expect(source.close).toHaveBeenCalledOnce();
+    expect(connection?.sessionId).toBeUndefined();
+    expect(connection?.sessionRecoveryRequired).toBeUndefined();
+    expect(connection?.sessionTransition).toBeUndefined();
+  });
+
+  it('waits for an in-flight shell command before starting recovery', async () => {
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    const emitResync = createDeferred<void>();
+    const shellRequest = createDeferred<unknown>();
+    const source = createMockSession({
+      sessionId: 'session-resync-shell',
+      clientId: 'client-stable',
+      lastEventId: 2,
+      shellCommand: vi.fn(() => shellRequest.promise),
+      events: async function* resyncEvents() {
+        await emitResync.promise;
+        yield {
+          v: 1,
+          type: 'state_resync_required',
+          data: { reason: 'ring_evicted' },
+        } satisfies DaemonEvent;
+      },
+    });
+    sdkMocks.sessions.push(source);
+    let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    sdkMocks.MockDaemonSessionClient.load.mockResolvedValueOnce(
+      createMockSession({
+        sessionId: source.sessionId,
+        clientId: source.clientId,
+        lastEventId: 3,
+        replaySnapshot: createTextReplaySnapshot('recovered transcript'),
+      }),
+    );
+    let shellOutcome!: Promise<unknown>;
+    act(() => {
+      shellOutcome = requireActions(actions).sendShellCommand('sleep 1');
+    });
+    await act(async () => flushPromises());
+    expect(source.shellCommand).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      emitResync.resolve();
+      await flushPromises();
+    });
+    expect(connection).toMatchObject({
+      sessionRecoveryRequired: true,
+      sessionTransition: { origin: 'recovery', phase: 'queued' },
+    });
+    expect(sdkMocks.MockDaemonSessionClient.load).not.toHaveBeenCalled();
+
+    await act(async () => {
+      shellRequest.resolve(undefined);
+      await shellOutcome;
+      await flushPromises();
+    });
+    await vi.waitFor(() =>
+      expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledOnce(),
+    );
+    expect(connection?.sessionRecoveryRequired).toBeUndefined();
+    expect(connection?.sessionTransition).toBeUndefined();
+  });
+
+  it('waits for an in-flight source-bound create before starting recovery', async () => {
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    const emitResync = createDeferred<void>();
+    const created = createDeferred<MockSession>();
+    const source = createMockSession({
+      sessionId: 'session-resync-create',
+      clientId: 'client-stable',
+      lastEventId: 2,
+      events: async function* resyncEvents() {
+        await emitResync.promise;
+        yield {
+          v: 1,
+          type: 'state_resync_required',
+          data: { reason: 'ring_evicted' },
+        } satisfies DaemonEvent;
+      },
+    });
+    sdkMocks.sessions.push(source);
+    let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    const sourceClient = source.client;
+    if (!sourceClient) throw new Error('source client is required');
+    sourceClient.createOrAttachSession = vi.fn(() => created.promise);
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    sdkMocks.MockDaemonSessionClient.load.mockResolvedValueOnce(
+      createMockSession({
+        sessionId: source.sessionId,
+        clientId: source.clientId,
+        lastEventId: 3,
+        replaySnapshot: createTextReplaySnapshot('recovered transcript'),
+      }),
+    );
+    let createOutcome!: ReturnType<DaemonSessionActions['createSession']>;
+    act(() => {
+      createOutcome = requireActions(actions).createSession();
+    });
+    await act(async () => flushPromises());
+    expect(sourceClient.createOrAttachSession).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      emitResync.resolve();
+      await flushPromises();
+    });
+    expect(connection).toMatchObject({
+      sessionRecoveryRequired: true,
+      sessionTransition: { origin: 'recovery', phase: 'queued' },
+    });
+    expect(sdkMocks.MockDaemonSessionClient.load).not.toHaveBeenCalled();
+
+    await act(async () => {
+      created.resolve(
+        createMockSession({
+          sessionId: 'detached-created-session',
+          clientId: 'detached-created-client',
+        }),
+      );
+      await createOutcome;
+      await flushPromises();
+    });
+    await vi.waitFor(() =>
+      expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledOnce(),
+    );
+    expect(connection?.sessionRecoveryRequired).toBeUndefined();
+    expect(connection?.sessionTransition).toBeUndefined();
+  });
+
+  it('refreshes a healed recovery owner after a deadline expires during admission', async () => {
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    const emitResync = createDeferred<void>();
+    const admission = createDeferred<NonBlockingPromptAccepted>();
+    const source = createMockSession({
+      sessionId: 'session-resync-admission-deadline',
+      clientId: 'client-stable',
+      lastEventId: 2,
+      replaySnapshot: createTextReplaySnapshot('source transcript'),
+      submitPrompt: vi.fn(() => admission.promise),
+      events: async function* resyncEvents() {
+        await emitResync.promise;
+        yield {
+          v: 1,
+          type: 'state_resync_required',
+          data: { reason: 'ring_evicted' },
+        } satisfies DaemonEvent;
+      },
+    });
+    sdkMocks.sessions.push(source);
+    let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    let promptOutcome!: Promise<unknown>;
+    act(() => {
+      promptOutcome = requireActions(actions)
+        .sendPrompt('held admission')
+        .catch((error: unknown) => error);
+    });
+    await act(async () => flushPromises());
+    expect(source.submitPrompt).toHaveBeenCalledOnce();
+
+    vi.useFakeTimers();
+    try {
+      await act(async () => {
+        emitResync.resolve();
+        await flushPromises();
+      });
+      expect(connection).toMatchObject({
+        sessionRecoveryRequired: true,
+        sessionTransition: { origin: 'recovery', phase: 'queued' },
+      });
+      expect(sdkMocks.MockDaemonSessionClient.load).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(75_001);
+        await flushPromises();
+      });
+      expect(connection).toMatchObject({
+        sessionRecoveryRequired: true,
+        sessionTransition: { origin: 'recovery', phase: 'failed' },
+      });
+      expect(sdkMocks.MockDaemonSessionClient.load).not.toHaveBeenCalled();
+
+      await act(async () => {
+        source.clientId = 'client-healed';
+        admission.reject(new Error('admission stopped'));
+        await promptOutcome;
+      });
+      sdkMocks.MockDaemonSessionClient.load.mockResolvedValueOnce(
+        createMockSession({
+          sessionId: source.sessionId,
+          clientId: 'client-healed',
+          lastEventId: 3,
+          replaySnapshot: createTextReplaySnapshot('recovered transcript'),
+        }),
+      );
+      let retry!: Promise<void>;
+      act(() => {
+        retry = requireActions(actions).loadSession(source.sessionId);
+      });
+      await act(async () => {
+        await retry;
+        await flushPromises();
+      });
+      expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledOnce();
+      expect(sdkMocks.MockDaemonSessionClient.load.mock.calls[0]?.[3]).toBe(
+        'client-healed',
+      );
+      expect(connection?.clientId).toBe('client-healed');
+      expect(connection?.sessionRecoveryRequired).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('rejects a recovery snapshot when staging crosses the shared deadline', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    const emitResync = createDeferred<void>();
+    const source = createMockSession({
+      sessionId: 'session-resync-staging-deadline',
+      clientId: 'client-stable',
+      lastEventId: 2,
+      replaySnapshot: createTextReplaySnapshot('source transcript'),
+      events: async function* resyncEvents() {
+        await emitResync.promise;
+        yield {
+          v: 1,
+          type: 'state_resync_required',
+          data: { reason: 'ring_evicted' },
+        } satisfies DaemonEvent;
+      },
+    });
+    sdkMocks.sessions.push(source);
+    let connection: DaemonConnectionState | undefined;
+    let blocks: readonly DaemonTranscriptBlock[] = [];
+    function Harness() {
+      connection = useDaemonConnection();
+      blocks = useDaemonTranscriptBlocks();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    let now = 1_000;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now);
+    const stagedData = {
+      update: {
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: 'expired replacement' },
+      },
+    };
+    const crossingEvent = {
+      id: 2,
+      v: 1,
+      type: 'session_update',
+    } as DaemonEvent;
+    Object.defineProperty(crossingEvent, 'data', {
+      configurable: true,
+      get() {
+        now = 76_001;
+        return stagedData;
+      },
+    });
+    sdkMocks.MockDaemonSessionClient.load.mockResolvedValueOnce(
+      createMockSession({
+        sessionId: source.sessionId,
+        clientId: source.clientId,
+        lastEventId: 2,
+        replaySnapshot: {
+          compactedReplay: [crossingEvent],
+          liveJournal: [],
+        },
+      }),
+    );
+    try {
+      await act(async () => {
+        emitResync.resolve();
+        await flushPromises();
+      });
+      await vi.waitFor(() =>
+        expect(connection).toMatchObject({
+          sessionRecoveryRequired: true,
+          sessionTransition: { origin: 'recovery', phase: 'failed' },
+        }),
+      );
+      expect(blocks).toMatchObject([
+        { kind: 'assistant', text: 'source transcript' },
+      ]);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('waits for queued prompt admission before starting recovery', async () => {
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    const emitResync = createDeferred<void>();
+    const admission = createDeferred<NonBlockingPromptAccepted>();
+    const source = createMockSession({
+      sessionId: 'session-resync-queued-admission',
+      clientId: 'client-stable',
+      lastEventId: 2,
+      replaySnapshot: createTextReplaySnapshot('source transcript'),
+      submitPrompt: vi.fn(() => admission.promise),
+      events: async function* resyncEvents() {
+        await emitResync.promise;
+        yield {
+          v: 1,
+          type: 'state_resync_required',
+          data: { reason: 'ring_evicted' },
+        } satisfies DaemonEvent;
+      },
+    });
+    sdkMocks.sessions.push(source);
+    let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    sdkMocks.MockDaemonSessionClient.load.mockResolvedValueOnce(
+      createMockSession({
+        sessionId: source.sessionId,
+        clientId: 'client-healed',
+        lastEventId: 3,
+        replaySnapshot: createTextReplaySnapshot('recovered transcript'),
+      }),
+    );
+    let admissionOutcome!: Promise<unknown>;
+    act(() => {
+      admissionOutcome = requireActions(actions).submitPrompt('queued prompt');
+    });
+    await act(async () => flushPromises());
+    expect(source.submitPrompt).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      emitResync.resolve();
+      await flushPromises();
+    });
+    expect(connection).toMatchObject({
+      sessionRecoveryRequired: true,
+      sessionTransition: { origin: 'recovery', phase: 'queued' },
+    });
+    expect(sdkMocks.MockDaemonSessionClient.load).not.toHaveBeenCalled();
+
+    await act(async () => {
+      source.clientId = 'client-healed';
+      admission.resolve({ promptId: 'queued-prompt', lastEventId: 2 });
+      await admissionOutcome;
+      await flushPromises();
+    });
+    await vi.waitFor(() =>
+      expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledOnce(),
+    );
+    expect(sdkMocks.MockDaemonSessionClient.load.mock.calls[0]?.[3]).toBe(
+      'client-healed',
+    );
+    expect(connection?.clientId).toBe('client-healed');
+    expect(connection?.sessionRecoveryRequired).toBeUndefined();
+  });
+
+  it('starts queued recovery after an in-flight cancel settles', async () => {
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    const emitResync = createDeferred<void>();
+    const cancelRequest = createDeferred<void>();
+    const source = createMockSession({
+      sessionId: 'session-resync-during-cancel',
+      clientId: 'client-stable',
+      lastEventId: 2,
+      cancel: vi.fn(() => cancelRequest.promise),
+      submitPrompt: vi.fn(async () => ({
+        promptId: 'prompt-cancelled',
+        lastEventId: 2,
+      })),
+      events: async function* resyncDuringCancelEvents() {
+        await emitResync.promise;
+        yield {
+          v: 1,
+          type: 'state_resync_required',
+          data: { reason: 'ring_evicted' },
+        } satisfies DaemonEvent;
+      },
+    });
+    const candidate = createMockSession({
+      sessionId: source.sessionId,
+      clientId: source.clientId,
+      lastEventId: 3,
+      replaySnapshot: createTextReplaySnapshot('recovered after cancel'),
+    });
+    sdkMocks.sessions.push(source, candidate);
+    let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    let prompt!: Promise<unknown>;
+    await act(async () => {
+      prompt = requireActions(actions).sendPrompt('cancel before resync');
+      await vi.waitFor(() =>
+        expect(source.submitPrompt).toHaveBeenCalledOnce(),
+      );
+    });
+    let cancel!: Promise<void>;
+    act(() => {
+      cancel = requireActions(actions).cancel();
+    });
+    await act(async () => flushPromises());
+    expect(source.cancel).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      emitResync.resolve();
+      await flushPromises();
+    });
+    expect(connection).toMatchObject({
+      sessionRecoveryRequired: true,
+      sessionTransition: { origin: 'recovery', phase: 'queued' },
+    });
+    expect(sdkMocks.MockDaemonSessionClient.load).not.toHaveBeenCalled();
+
+    await act(async () => {
+      cancelRequest.resolve();
+      await cancel;
+      await prompt;
+      await flushPromises();
+    });
+    await vi.waitFor(() =>
+      expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledOnce(),
+    );
+    expect(connection?.sessionRecoveryRequired).toBeUndefined();
+    expect(connection?.sessionTransition).toBeUndefined();
+  });
+
+  it('retries only a structured incomplete recovery within the shared deadline', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    const emitResync = createDeferred<void>();
+    const source = createMockSession({
+      sessionId: 'session-resync-structured-retry',
+      clientId: 'client-stable',
+      lastEventId: 2,
+      replaySnapshot: createTextReplaySnapshot('source transcript'),
+      events: async function* resyncEvents() {
+        await emitResync.promise;
+        yield {
+          v: 1,
+          type: 'state_resync_required',
+          data: { reason: 'ring_evicted' },
+        } satisfies DaemonEvent;
+      },
+    });
+    sdkMocks.sessions.push(source);
+    let connection: DaemonConnectionState | undefined;
+    function Harness() {
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      autoReconnect: true,
+    });
+    sdkMocks.MockDaemonSessionClient.load.mockClear();
+    sdkMocks.MockDaemonSessionClient.load
+      .mockRejectedValueOnce(
+        new DaemonHttpError(
+          409,
+          {
+            code: 'restore_in_progress',
+            retryable: true,
+            retryAfterSeconds: 0.001,
+          },
+          'Restore is in progress',
+        ),
+      )
+      .mockRejectedValueOnce(
+        new DaemonHttpError(
+          409,
+          {
+            code: 'restore_in_progress',
+            retryable: true,
+            retryAfterSeconds: 0.001,
+          },
+          'Restore is still in progress',
+        ),
+      )
+      .mockResolvedValueOnce(
+        createMockSession({
+          sessionId: source.sessionId,
+          clientId: 'client-stable',
+          lastEventId: 3,
+          replaySnapshot: createTextReplaySnapshot('recovered transcript'),
+        }),
+      );
+    vi.useFakeTimers();
+    try {
+      await act(async () => {
+        emitResync.resolve();
+        await flushPromises();
+      });
+      expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledOnce();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+        await flushPromises();
+      });
+
+      expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(2);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+        await flushPromises();
+      });
+
+      expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledTimes(3);
+      expect(connection).toMatchObject({
+        status: 'connected',
+        sessionId: source.sessionId,
+      });
+      expect(connection?.sessionRecoveryRequired).toBeUndefined();
+      expect(connection?.sessionTransition).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('retires a recovery lock after a terminal authorization failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 })),
+    );
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['client_identity'],
+    });
+    const emitResync = createDeferred<void>();
+    sdkMocks.sessions.push(
+      createMockSession({
+        sessionId: 'session-resync-auth-failure',
+        clientId: 'client-stable',
+        lastEventId: 2,
+        replaySnapshot: createTextReplaySnapshot('source transcript'),
+        events: async function* resyncEvents() {
+          await emitResync.promise;
+          yield {
+            v: 1,
+            type: 'state_resync_required',
+            data: { reason: 'epoch_reset' },
+          } satisfies DaemonEvent;
+        },
+      }),
+    );
+    let connection: DaemonConnectionState | undefined;
+    function Harness() {
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    sdkMocks.MockDaemonSessionClient.load.mockRejectedValueOnce(
+      new DaemonHttpError(403, undefined, 'Forbidden'),
+    );
+    await act(async () => {
+      emitResync.resolve();
+      await flushPromises();
+    });
+    await vi.waitFor(() =>
+      expect(connection).toMatchObject({
+        status: 'error',
+        sessionId: undefined,
+        errorStatus: 403,
+      }),
+    );
+    expect(connection?.sessionRecoveryRequired).toBeUndefined();
+    expect(connection?.sessionTransition).toBeUndefined();
   });
 
   async function renderWithProvider(

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -89,6 +89,7 @@ import {
   publishSidechannelMidTurnInjected,
 } from '../midTurnInjectedSidechannel.js';
 import {
+  bumpPendingPromptVersion,
   isPendingPromptEvent,
   publishPendingPromptEvent,
 } from '../pendingPromptVersion.js';
@@ -195,6 +196,8 @@ interface SameSessionCapture {
 interface PreparedRunnerHandoff {
   session: DaemonSessionClient;
   capabilities: DaemonCapabilities;
+  preserveStagedDisplayName?: true;
+  preserveStagedTokenUsage?: true;
 }
 interface StagedCrossSession {
   session: DaemonSessionClient;
@@ -208,14 +211,17 @@ interface StagedCrossSession {
   followupSuggestion?: DaemonFollowupSuggestionData;
   midTurnEvents: DaemonEvent[];
   pendingPromptEvents: DaemonEvent[];
+  promptTerminals: Map<string, DaemonEvent>;
   repair?: LiveJournalRepairEpisode;
 }
+type TransitionPurpose = 'ordinary' | 'resync' | 'live_repair';
 interface CrossSessionTarget {
   sessionId: string;
   workspaceCwd?: string;
   targetClientId?: string;
   mode: 'load' | 'resume';
-  origin: 'action' | 'controlled';
+  origin: 'action' | 'controlled' | 'recovery';
+  purpose?: TransitionPurpose;
   sameLogical?: boolean;
   signal?: AbortSignal;
 }
@@ -241,6 +247,19 @@ interface CrossSessionIntent extends CrossSessionTarget {
   resolve(): void;
   reject(error: unknown): void;
 }
+interface ResyncEpisode {
+  source: DaemonSessionClient;
+  sessionId: string;
+  workspaceCwd?: string;
+  clientId: string;
+  sourceEpoch?: string;
+  sourceCursor?: number;
+  reason: string;
+  lifecycle: number;
+  environmentGeneration: number;
+  deadlineAt: number;
+  attemptCount: number;
+}
 const SESSION_TRANSCRIPT_PAGINATION_FEATURE = 'session_transcript_pagination';
 const CLIENT_IDENTITY_FEATURE = 'client_identity';
 const WORKSPACE_ACP_PREHEAT_FEATURE = 'workspace_acp_preheat';
@@ -254,6 +273,7 @@ function crossSessionKey(
   mode: CrossSessionTarget['mode'],
   historyPageSize: number | undefined,
   clientId: string | undefined,
+  purpose: TransitionPurpose = 'ordinary',
 ): string {
   const replayShape =
     mode === 'resume'
@@ -261,7 +281,7 @@ function crossSessionKey(
       : historyPageSize === undefined
         ? 'load:all'
         : `load:recent:${historyPageSize}`;
-  return `${sessionId}\0${normalizeWorkspaceIdentity(workspaceCwd)}\0${replayShape}\0${clientId ?? ''}`;
+  return `${sessionId}\0${normalizeWorkspaceIdentity(workspaceCwd)}\0${replayShape}\0${clientId ?? ''}\0${purpose}`;
 }
 function transitionState(
   target: CrossSessionTarget,
@@ -313,8 +333,13 @@ function stageCrossSession(input: {
   subagentTranscriptMode: 'full' | 'summary';
   eventOptions: { suppressOwnUserEcho: boolean; includeRawEvent: boolean };
   additionalEvents?: readonly DaemonEvent[];
+  purpose?: TransitionPurpose;
+  repairEpisode?: LiveJournalRepairEpisode;
+  repairMarkerVisible?: boolean;
 }): StagedCrossSession {
   const { session, capabilities, maxBlocks, subagentTranscriptMode } = input;
+  const purpose = input.purpose ?? 'ordinary';
+  const publishReplaySideEffects = purpose === 'ordinary';
   const notices: SessionNoticeInput[] = [];
   const dismissNoticeIds = new Set<string>();
   let noticeId = 0;
@@ -354,20 +379,41 @@ function stageCrossSession(input: {
   ) => {
     signals = typeof update === 'function' ? update(signals) : update;
   };
-  const shadow = createDaemonTranscriptStore({
-    maxBlocks: Number.MAX_SAFE_INTEGER,
-    retainSubagentBlocks: subagentTranscriptMode === 'full',
-  });
-  let transcriptBatch: DaemonUiEvent[] = [];
-  const repairTarget = findLiveJournalRepairTarget(
-    session.sessionId,
-    session.replaySnapshot.liveJournal,
-    session.lastEventId,
-    session.replayDegraded === true,
+  const repairMarkerVisible =
+    purpose === 'live_repair' &&
+    input.repairEpisode?.markerBlockId !== undefined &&
+    input.repairMarkerVisible === true;
+  const replayMaxBlocks =
+    purpose === 'live_repair'
+      ? repairMarkerVisible && input.repairEpisode
+        ? input.repairEpisode.checkpoint.maxBlocks
+        : maxBlocks
+      : Number.MAX_SAFE_INTEGER;
+  const shadow = createDaemonTranscriptStore(
+    repairMarkerVisible && input.repairEpisode
+      ? {
+          ...input.repairEpisode.checkpoint,
+          maxBlocks: replayMaxBlocks,
+        }
+      : {
+          maxBlocks: replayMaxBlocks,
+          retainSubagentBlocks: subagentTranscriptMode === 'full',
+        },
   );
+  let transcriptBatch: DaemonUiEvent[] = [];
+  const repairTarget =
+    purpose === 'live_repair'
+      ? undefined
+      : findLiveJournalRepairTarget(
+          session.sessionId,
+          session.replaySnapshot.liveJournal,
+          session.lastEventId,
+          session.replayDegraded === true,
+        );
   let repairCheckpoint: DaemonTranscriptState | undefined;
   const midTurnEvents: DaemonEvent[] = [];
   const pendingPromptEvents: DaemonEvent[] = [];
+  const promptTerminals = new Map<string, DaemonEvent>();
   let followupSuggestion: DaemonFollowupSuggestionData | undefined;
   const observedSnapshotEventIds = new Set<number>();
   const flush = () => {
@@ -403,7 +449,9 @@ function stageCrossSession(input: {
         updateConnection,
         { suppressLog: true },
       );
-      bumpWorkspaceEventSignals(normalized, updateSignals);
+      if (publishReplaySideEffects) {
+        bumpWorkspaceEventSignals(normalized, updateSignals);
+      }
       let transcript = filterDaemonUiEventsForTranscript(
         event,
         normalized,
@@ -426,13 +474,20 @@ function stageCrossSession(input: {
       } else if (event.type === 'turn_error') {
         enqueueTranscript([assistantDoneFromTurnEvent(event, 'error')]);
       }
-      if (parseSidechannelMidTurnInjected(event)) {
+      const promptId = eventPromptId(event);
+      if (
+        promptId &&
+        (event.type === 'turn_complete' || event.type === 'turn_error')
+      ) {
+        promptTerminals.set(promptId, event);
+      }
+      if (publishReplaySideEffects && parseSidechannelMidTurnInjected(event)) {
         midTurnEvents.push(event);
         if (midTurnEvents.length > 64) midTurnEvents.shift();
       }
       followupSuggestion =
         parseSidechannelFollowupSuggestion(event) ?? followupSuggestion;
-      if (isPendingPromptEvent(event)) {
+      if (publishReplaySideEffects && isPendingPromptEvent(event)) {
         pendingPromptEvents.push(event);
         if (pendingPromptEvents.length > 200) pendingPromptEvents.shift();
       }
@@ -448,8 +503,23 @@ function stageCrossSession(input: {
       });
     }
   };
-  for (const event of session.replaySnapshot.compactedReplay) consume(event);
-  for (const event of session.replaySnapshot.liveJournal) {
+  const repairSuffix = input.repairEpisode
+    ? findLiveJournalRepairSuffix(
+        [
+          ...session.replaySnapshot.compactedReplay,
+          ...session.replaySnapshot.liveJournal,
+        ],
+        input.repairEpisode.target.promptId,
+      )
+    : undefined;
+  const compactedReplay = repairMarkerVisible
+    ? []
+    : session.replaySnapshot.compactedReplay;
+  const liveJournal = repairMarkerVisible
+    ? (repairSuffix?.events ?? [])
+    : session.replaySnapshot.liveJournal;
+  for (const event of compactedReplay) consume(event);
+  for (const event of liveJournal) {
     if (event.id !== undefined) observedSnapshotEventIds.add(event.id);
     if (event === repairTarget?.marker) {
       flush();
@@ -457,8 +527,6 @@ function stageCrossSession(input: {
     }
     consume(event);
   }
-  for (const event of input.additionalEvents ?? []) consume(event);
-  flush();
   const replayTokenUsage =
     getReplayTokenUsage(session.replaySnapshot.liveJournal) ??
     getReplayTokenUsage(session.replaySnapshot.compactedReplay);
@@ -473,9 +541,29 @@ function stageCrossSession(input: {
     missingSession: false,
     sessionTransition: undefined,
   };
+  for (const event of input.additionalEvents ?? []) consume(event);
+  flush();
+  connection = {
+    ...connection,
+    status: 'connected',
+    error: undefined,
+    errorStatus: undefined,
+    missingSession: false,
+    sessionTransition: undefined,
+  };
   const transcript = shadow.getSnapshot();
+  const repairMarkerBlock = transcript.blocks.find(
+    (block) =>
+      block.kind === 'status' &&
+      block.source === 'history_truncated' &&
+      isRecord(block.data) &&
+      block.data['scope'] === 'live_journal',
+  );
   const replayExceededCapacity = transcript.blocks.length > maxBlocks;
-  transcript.maxBlocks = Math.max(maxBlocks, transcript.blocks.length);
+  transcript.maxBlocks =
+    purpose === 'live_repair'
+      ? replayMaxBlocks
+      : Math.max(maxBlocks, transcript.blocks.length);
   if (repairCheckpoint) repairCheckpoint.maxBlocks = transcript.maxBlocks;
   const repair =
     repairTarget && repairCheckpoint
@@ -483,10 +571,11 @@ function stageCrossSession(input: {
           sessionId: session.sessionId,
           target: repairTarget,
           checkpoint: repairCheckpoint,
+          ...(repairMarkerBlock ? { markerBlockId: repairMarkerBlock.id } : {}),
           observedSnapshotEventIds,
           snapshotLastEventId: session.lastEventId ?? 0,
           lastObservedEventId: session.lastEventId ?? 0,
-          terminalSeen: false,
+          terminalSeen: promptTerminals.has(repairTarget.promptId),
           attempted: false,
         }
       : undefined;
@@ -509,6 +598,7 @@ function stageCrossSession(input: {
     ...(followupSuggestion ? { followupSuggestion } : {}),
     midTurnEvents,
     pendingPromptEvents,
+    promptTerminals,
     ...(repair ? { repair } : {}),
   };
 }
@@ -924,14 +1014,36 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
   }
   const rawTransitionRef = useRef<CrossSessionIntent | undefined>(undefined);
   const pumpTransitionRef = useRef<() => void>(() => undefined);
+  const resyncEpisodeRef = useRef<ResyncEpisode | undefined>(undefined);
+  const beginResyncRef = useRef<
+    (
+      source: DaemonSessionClient,
+      reason: string,
+      sourceEpoch: string | undefined,
+      sourceCursor: number | undefined,
+    ) => void
+  >(() => undefined);
+  const beginLiveRepairRef = useRef<
+    (episode: LiveJournalRepairEpisode) => void
+  >(() => undefined);
+  const resumeResyncRef = useRef<() => void>(() => undefined);
   const lifecycleRef = useRef(0);
   const sourceBoundOperationCountRef = useRef(0);
   const sessionConfigGenerationRef = useRef(
     new WeakMap<DaemonSessionClient, number>(),
   );
+  const promptAdmissionCountsRef = useRef(
+    new WeakMap<DaemonSessionClient, number>(),
+  );
   const controlledRetryPendingRef = useRef(false);
+  const controlledClientRebindRef = useRef<string | undefined>(undefined);
   const cancelTransitionRef = useRef<(reason: string) => void>(() => undefined);
   const controlledTransitionOriginRef = useRef(false);
+  const lastHandledSessionIdRef = useRef<
+    string | undefined | typeof UNHANDLED_SESSION
+  >(UNHANDLED_SESSION);
+  const lastHandledWorkspaceRef = useRef<string | undefined>(undefined);
+  const lastHandledClientIdRef = useRef<string | undefined>(undefined);
   const transcriptHistoryRef = useRef<TranscriptHistoryState>({
     hasMore: false,
     loading: false,
@@ -983,11 +1095,13 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
   const historyPageSizeRef = useRef(historyPageSize);
   const subagentTranscriptModeRef = useRef(subagentTranscriptMode);
   const clientIdRef = useRef<string | undefined>(getStableClientId(clientId));
+  const controlledClientIdRef = useRef(clientId);
   eventOptionsRef.current = { suppressOwnUserEcho, includeRawEvent };
   reconnectConfigRef.current = { reconnectDelayMs, maxReconnectDelayMs };
   loadWarningsRef.current = loadWarnings;
   historyPageSizeRef.current = historyPageSize;
   subagentTranscriptModeRef.current = subagentTranscriptMode;
+  controlledClientIdRef.current = clientId;
   const modelServiceId = createSessionRequest?.modelServiceId;
   const sessionScope = createSessionRequest?.sessionScope;
   const createSessionRequestRef = useRef(createSessionRequest);
@@ -1090,6 +1204,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           return;
         }
         cancelTransitionRef.current('Session transition interrupted');
+        resyncEpisodeRef.current = undefined;
         liveJournalRepairRef.current?.controller?.abort();
         liveJournalRepairRef.current = undefined;
         tryLiveJournalRepairRef.current = undefined;
@@ -1266,6 +1381,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
     const tryLiveJournalRepair = () => {
       if (disposed || abort.signal.aborted) return;
       const repair = liveJournalRepairRef.current;
+      const currentSession = sessionRef.current;
       if (
         !repair ||
         repair.attempted ||
@@ -1273,37 +1389,20 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
         pendingSessionLoadRef.current ||
         desiredTransitionRef.current ||
         rawTransitionRef.current ||
+        sourceBoundOperationCountRef.current > 0 ||
+        (currentSession !== undefined &&
+          (promptAdmissionCountsRef.current.get(currentSession) ?? 0) > 0) ||
         transcriptHistoryRef.current.loading ||
-        sessionRef.current?.sessionId !== repair.sessionId ||
+        currentSession?.sessionId !== repair.sessionId ||
         hasCurrentSessionActivePromptRef.current()
       ) {
         return;
       }
-      const reload = repairReloadRef.current;
-      if (!reload) return;
       repair.attempted = true;
-      const controller = new AbortController();
-      repair.controller = controller;
-      void reload(controller.signal, { replaySource: 'memory' }).catch(
-        (error: unknown) => {
-          if (liveJournalRepairRef.current !== repair) return;
-          addNotice({
-            id: `daemon.live_journal_repair.failed:${repair.target.signature}`,
-            severity: 'warning',
-            category: 'connection',
-            operation: 'load_session',
-            code: 'daemon.live_journal_repair.failed',
-            message:
-              'Could not restore the complete turn. The retained replay remains visible.',
-            debugMessage:
-              error instanceof Error ? error.message : String(error),
-            recoverable: true,
-          });
-          liveJournalRepairRef.current = undefined;
-        },
-      );
+      beginLiveRepairRef.current(repair);
     };
     tryLiveJournalRepairRef.current = tryLiveJournalRepair;
+    queueMicrotask(tryLiveJournalRepair);
 
     const run = async () => {
       const client =
@@ -1317,6 +1416,10 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
         preparedRunnerRef.current = undefined;
       }
       let session: DaemonSessionClient | undefined = prepared?.session;
+      const preserveStagedDisplayName =
+        prepared?.preserveStagedDisplayName === true;
+      const preserveStagedTokenUsage =
+        prepared?.preserveStagedTokenUsage === true;
       let capabilities:
         | Awaited<ReturnType<DaemonClient['capabilities']>>
         | undefined = prepared?.capabilities;
@@ -2208,19 +2311,22 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
               ? { clientId: activeSession.clientId }
               : {}),
             workspaceCwd: activeSession.workspaceCwd,
-            displayName:
-              getSessionDisplayName(activeSession.state) ??
-              (current.sessionId === activeSession.sessionId
-                ? current.displayName
-                : undefined),
-            tokenUsage:
-              replayTokenUsage !== undefined
+            displayName: preserveStagedDisplayName
+              ? current.displayName
+              : (getSessionDisplayName(activeSession.state) ??
+                (current.sessionId === activeSession.sessionId
+                  ? current.displayName
+                  : undefined)),
+            tokenUsage: preserveStagedTokenUsage
+              ? current.tokenUsage
+              : replayTokenUsage !== undefined
                 ? replayTokenUsage
                 : current.sessionId === activeSession.sessionId
                   ? current.tokenUsage
                   : undefined,
-            tokenCount:
-              replayTokenCount !== undefined
+            tokenCount: preserveStagedTokenUsage
+              ? current.tokenCount
+              : replayTokenCount !== undefined
                 ? replayTokenCount
                 : current.sessionId === activeSession.sessionId
                   ? (current.tokenCount ?? 0)
@@ -2371,9 +2477,10 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                       current.reasoning?.effort,
                     )
                   : current.reasoning,
-              displayName:
-                getSessionDisplayName(activeSession.state) ??
-                current.displayName,
+              displayName: preserveStagedDisplayName
+                ? current.displayName
+                : (getSessionDisplayName(activeSession.state) ??
+                  current.displayName),
               contextWindow: configSnapshotCurrent
                 ? (sessionContextWindow ?? current.contextWindow)
                 : current.contextWindow,
@@ -2432,42 +2539,151 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           }
           let sawEvent = false;
           let resyncRequested = false;
-          const requestEpochResetReload = () => {
+          const requestStateResync = (reason: string) => {
             cancelTransitionRef.current(
               'Session transition cancelled by state resync',
             );
-            // An epoch reset means the daemon/EventBus timeline was rebuilt.
-            // The current SSE cursor and any restored/local prompt activity may
-            // describe the old epoch, so do a full /load and let
-            // hasActivePrompt from that fresh snapshot become authoritative.
-            const active = activePromptsRef.current.get(
-              activeSession.sessionId,
-            );
-            active?.controller.abort();
-            activePromptsRef.current.delete(activeSession.sessionId);
-            if (restoredActivePrompt) {
-              settleRestoredActivePrompt();
+            liveJournalRepairRef.current?.controller?.abort();
+            liveJournalRepairRef.current = undefined;
+            capabilities ??=
+              workspaceCapabilitiesRef.current ??
+              sessionCapabilitiesRef.current ??
+              connectionRef.current.capabilities;
+            if (capabilities === undefined) {
+              flushTranscriptSync();
+              clearPassiveAssistantDoneTimer(passiveAssistantDoneTimerRef);
+              resyncRequested = true;
+              if (activeSession.clientId) {
+                resyncEpisodeRef.current = {
+                  source: activeSession,
+                  sessionId: activeSession.sessionId,
+                  workspaceCwd: activeSession.workspaceCwd,
+                  clientId: activeSession.clientId,
+                  sourceEpoch: runnerEventEpoch,
+                  sourceCursor: processedEventId,
+                  reason,
+                  lifecycle: lifecycleRef.current,
+                  environmentGeneration: environmentRef.current.generation,
+                  deadlineAt: Date.now() + 75_000,
+                  attemptCount: 0,
+                };
+              }
+              setConnectionSynchronous((current) => ({
+                ...current,
+                status: 'connected',
+                sessionRecoveryRequired: true,
+                sessionTransition: transitionState(
+                  {
+                    sessionId: activeSession.sessionId,
+                    workspaceCwd: activeSession.workspaceCwd,
+                    mode: 'load',
+                    origin: 'recovery',
+                    purpose: 'resync',
+                    sameLogical: true,
+                  },
+                  'failed',
+                  {
+                    message:
+                      'Transactional recovery capability could not be verified',
+                  },
+                ),
+              }));
+              addNotice({
+                severity: 'warning',
+                category: 'connection',
+                operation: 'load_session',
+                code: 'daemon.session_resync.capability_unknown',
+                message:
+                  'This session cannot be resynchronized safely because daemon capabilities are unavailable. Clear it before continuing.',
+                recoverable: true,
+              });
+              return;
             }
+            const supportsClientIdentity = capabilities.features.includes(
+              CLIENT_IDENTITY_FEATURE,
+            );
+            if (!supportsClientIdentity) {
+              if (reason === 'epoch_reset') {
+                const active = activePromptsRef.current.get(
+                  activeSession.sessionId,
+                );
+                active?.controller.abort();
+                activePromptsRef.current.delete(activeSession.sessionId);
+                if (restoredActivePrompt) settleRestoredActivePrompt();
+                clearPassiveAssistantDoneTimer(passiveAssistantDoneTimerRef);
+                setPromptStatus('idle');
+              } else if (!hasSessionActivePrompt()) {
+                clearPassiveAssistantDoneTimer(passiveAssistantDoneTimerRef);
+                setPromptStatus('idle');
+              }
+              clearPendingTranscriptEvents();
+              store.reset();
+              activeSession.setLastEventId(0);
+              reconnectSessionId = activeSession.sessionId;
+              nextSseConnectReason = 'state_resync';
+              session = undefined;
+              sessionRef.current = undefined;
+              hasCurrentSessionActivePromptRef.current = () => false;
+              setConnection((current) => ({
+                ...current,
+                status: 'connecting',
+                error: undefined,
+                errorStatus: resolveConnectionErrorStatus(
+                  undefined,
+                  current.errorStatus,
+                ),
+              }));
+              resyncRequested = true;
+              return;
+            }
+            flushTranscriptSync();
             clearPassiveAssistantDoneTimer(passiveAssistantDoneTimerRef);
-            setPromptStatus('idle');
-            clearPendingTranscriptEvents();
-            store.reset();
-            activeSession.setLastEventId(0);
-            reconnectSessionId = activeSession.sessionId;
             resyncRequested = true;
-            nextSseConnectReason = 'state_resync';
-            session = undefined;
-            sessionRef.current = undefined;
-            hasCurrentSessionActivePromptRef.current = () => false;
-            setConnection((current) => ({
+            if (!activeSession.clientId) {
+              setConnectionSynchronous((current) => ({
+                ...current,
+                status: 'connected',
+                sessionRecoveryRequired: true,
+                sessionTransition: transitionState(
+                  {
+                    sessionId: activeSession.sessionId,
+                    workspaceCwd: activeSession.workspaceCwd,
+                    mode: 'load',
+                    origin: 'recovery',
+                    purpose: 'resync',
+                    sameLogical: true,
+                  },
+                  'failed',
+                  {
+                    message:
+                      'Transactional recovery requires an owned client attachment',
+                  },
+                ),
+              }));
+              addNotice({
+                severity: 'warning',
+                category: 'connection',
+                operation: 'load_session',
+                code: 'daemon.session_resync.client_identity_missing',
+                message:
+                  'This session cannot be resynchronized safely. Clear it before opening another session.',
+                recoverable: true,
+              });
+              return;
+            }
+            setConnectionSynchronous((current) => ({
               ...current,
-              status: 'connecting',
+              status: 'connected',
+              sessionRecoveryRequired: true,
               error: undefined,
-              errorStatus: resolveConnectionErrorStatus(
-                undefined,
-                current.errorStatus,
-              ),
+              errorStatus: undefined,
             }));
+            beginResyncRef.current(
+              activeSession,
+              reason,
+              runnerEventEpoch,
+              processedEventId,
+            );
           };
           const eventStreamController = new AbortController();
           eventStream = {
@@ -2509,6 +2725,16 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                 currentRepair.lastObservedEventId,
                 event.id,
               );
+            }
+            if (event.type === 'state_resync_required') {
+              const reason =
+                typeof event.data === 'object' && event.data !== null
+                  ? (event.data as Record<string, unknown>).reason
+                  : undefined;
+              requestStateResync(
+                typeof reason === 'string' ? reason : 'unknown',
+              );
+              break;
             }
             try {
               try {
@@ -2559,16 +2785,6 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                   subagentTranscriptModeRef.current === 'summary'
                     ? projectMainTranscriptEvents(uiEvents)
                     : uiEvents;
-                if (event.type === 'state_resync_required') {
-                  const reason =
-                    typeof event.data === 'object' && event.data !== null
-                      ? (event.data as Record<string, unknown>).reason
-                      : undefined;
-                  if (reason === 'epoch_reset') {
-                    requestEpochResetReload();
-                    break;
-                  }
-                }
                 bumpWorkspaceEventSignals(uiEvents, setWorkspaceEventSignals);
                 if (uiEvents.length > 0) {
                   const hasGenerationSignal =
@@ -2679,7 +2895,20 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                       store.clearAwaitingResync();
                     }
                     runnerReady = true;
+                    if (
+                      controlledClientRebindRef.current ===
+                      activeSession.sessionId
+                    ) {
+                      controlledClientRebindRef.current = undefined;
+                      if (
+                        controlledClientIdRef.current !== undefined &&
+                        controlledClientIdRef.current !== activeSession.clientId
+                      ) {
+                        setControlledRetryNonce((nonce) => nonce + 1);
+                      }
+                    }
                     queueMicrotask(pumpTransitionRef.current);
+                    queueMicrotask(tryLiveJournalRepair);
                     if (!hasSessionActivePrompt()) {
                       clearPassiveAssistantDoneTimer(
                         passiveAssistantDoneTimerRef,
@@ -2757,60 +2986,9 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                   eventPromptId(event) === pendingRepair.target.promptId
                 ) {
                   pendingRepair.terminalSeen = true;
-                  queueMicrotask(tryLiveJournalRepair);
+                  tryLiveJournalRepair();
                 } else if (pendingRepair?.terminalSeen) {
                   queueMicrotask(tryLiveJournalRepair);
-                }
-                // ── state_resync_required handling ──────────────────────
-                // Resyncs are transcript recovery signals, not prompt terminal
-                // signals. For epoch_reset and ring_evicted we reload the session
-                // snapshot; the fresh /load response is the source of truth for
-                // hasActivePrompt and transcript replay.
-                if (event.type === 'state_resync_required') {
-                  const reason =
-                    typeof event.data === 'object' && event.data !== null
-                      ? (event.data as Record<string, unknown>).reason
-                      : undefined;
-                  if (reason !== 'epoch_reset') {
-                    cancelTransitionRef.current(
-                      'Session transition cancelled by state resync',
-                    );
-                    // Resync asks us to rebuild transcript state, but it is not a
-                    // prompt terminal signal. Keep loading alive for local/restored
-                    // prompts until turn_complete, turn_error, or prompt_cancelled.
-                    if (!hasSessionActivePrompt()) {
-                      setPromptStatus('idle');
-                      clearPassiveAssistantDoneTimer(
-                        passiveAssistantDoneTimerRef,
-                      );
-                    }
-                    clearPendingTranscriptEvents();
-                    store.reset();
-                    // Ring eviction means the SSE replay window has a real gap.
-                    // Resetting and continuing on the same stream can only replay
-                    // the surviving tail; reload the session snapshot instead so
-                    // compactedReplay/liveJournal rebuild the bounded replay
-                    // window.
-                    console.warn(
-                      '[DaemonSessionProvider] ring eviction detected, reloading session (sessionId=%s)',
-                      activeSession.sessionId,
-                    );
-                    resyncRequested = true;
-                    nextSseConnectReason = 'state_resync';
-                    session = undefined;
-                    sessionRef.current = undefined;
-                    hasCurrentSessionActivePromptRef.current = () => false;
-                    setConnection((current) => ({
-                      ...current,
-                      status: 'connecting',
-                      error: undefined,
-                      errorStatus: resolveConnectionErrorStatus(
-                        undefined,
-                        current.errorStatus,
-                      ),
-                    }));
-                    break;
-                  }
                 }
                 // session_closed with reason 'client_close' means the
                 // user explicitly deleted the session. Stop the
@@ -2871,6 +3049,13 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           runnerReady = false;
           const restartRequested = eventStream.restartRequested;
           clearEventStream();
+          if (
+            resyncRequested &&
+            (capabilities === undefined ||
+              capabilities.features.includes(CLIENT_IDENTITY_FEATURE))
+          ) {
+            return;
+          }
           if (restartRequested) {
             nextSseConnectReason = 'prompt_restart';
             reconnectAttempt = 0;
@@ -3213,6 +3398,24 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           pendingSessionLoadRef.current = undefined;
         }
         if (stillOwnsSession) {
+          if (
+            resyncEpisodeRef.current?.source === ownedSession ||
+            (connectionRef.current.sessionRecoveryRequired === true &&
+              connectionRef.current.sessionId === ownedSession.sessionId)
+          ) {
+            cancelTransitionRef.current(
+              'Session recovery interrupted by environment replacement',
+            );
+            resyncEpisodeRef.current = undefined;
+            setConnectionSynchronous((current) => {
+              const next = { ...current };
+              delete next.sessionRecoveryRequired;
+              if (next.sessionTransition?.origin === 'recovery') {
+                delete next.sessionTransition;
+              }
+              return next;
+            });
+          }
           if (ownedSession.clientId) {
             void detachDaemonClient({
               baseUrl: resolvedBaseUrl!,
@@ -3345,6 +3548,12 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           const missingSession = isMissingSessionHttpStatus(errorStatus);
           if (authFailure || missingSession) {
             const deadSessionId = session.sessionId;
+            if (resyncEpisodeRef.current?.source === session) {
+              cancelTransitionRef.current(
+                'Session recovery stopped after a terminal heartbeat failure',
+              );
+              resyncEpisodeRef.current = undefined;
+            }
             if (missingSession) {
               console.warn(
                 '[DaemonSessionProvider] heartbeat detected missing session (sessionId=%s, status=%d)',
@@ -3370,27 +3579,35 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
               sessionRef.current = undefined;
             }
           }
-          setConnection((current) =>
-            current.sessionId === session.sessionId
-              ? {
-                  ...current,
-                  status: authFailure ? 'error' : 'disconnected',
-                  error: effectiveMessage,
-                  errorStatus: resolveConnectionErrorStatus(
-                    errorStatus,
-                    current.errorStatus,
-                  ),
-                  missingSession,
-                  ...(authFailure || missingSession
-                    ? {
-                        sessionId: undefined,
-                        loadingTranscript: undefined,
-                        catchingUp: undefined,
-                      }
-                    : {}),
-                }
-              : current,
-          );
+          setConnection((current) => {
+            if (current.sessionId !== session.sessionId) return current;
+            const next = {
+              ...current,
+              status: authFailure
+                ? ('error' as const)
+                : ('disconnected' as const),
+              error: effectiveMessage,
+              errorStatus: resolveConnectionErrorStatus(
+                errorStatus,
+                current.errorStatus,
+              ),
+              missingSession,
+              ...(authFailure || missingSession
+                ? {
+                    sessionId: undefined,
+                    loadingTranscript: undefined,
+                    catchingUp: undefined,
+                  }
+                : {}),
+            };
+            if (authFailure || missingSession) {
+              delete next.sessionRecoveryRequired;
+              if (next.sessionTransition?.origin === 'recovery') {
+                delete next.sessionTransition;
+              }
+            }
+            return next;
+          });
         });
     }, heartbeatIntervalMs);
     return () => {
@@ -3414,8 +3631,80 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
         typeof error.body['code'] === 'string'
           ? error.body['code']
           : undefined;
+      const recoveryReason =
+        target.purpose === 'resync'
+          ? resyncEpisodeRef.current?.reason
+          : undefined;
+      if (target.purpose === 'live_repair') {
+        setConnectionSynchronous((current) => {
+          const next = { ...current };
+          delete next.sessionTransition;
+          return next;
+        });
+        const repair = liveJournalRepairRef.current;
+        if (repair) {
+          addNotice({
+            id: `daemon.live_journal_repair.failed:${repair.target.signature}`,
+            severity: 'warning',
+            category: 'connection',
+            operation: 'load_session',
+            code: 'daemon.live_journal_repair.failed',
+            message:
+              'Could not restore the complete turn. The retained replay remains visible.',
+            debugMessage: message,
+            recoverable: true,
+          });
+        }
+        liveJournalRepairRef.current = undefined;
+        return;
+      }
+      if (target.purpose === 'resync' && isTerminalRecoveryFailure(error)) {
+        const source = resyncEpisodeRef.current?.source;
+        resyncEpisodeRef.current = undefined;
+        if (source && sessionRef.current === source) {
+          const active = activePromptsRef.current.get(source.sessionId);
+          active?.controller.abort();
+          activePromptsRef.current.delete(source.sessionId);
+          runnerControlRef.current?.stop();
+          sessionRef.current = undefined;
+          hasCurrentSessionActivePromptRef.current = () => false;
+          clearPassiveAssistantDoneTimer(passiveAssistantDoneTimerRef);
+          setPromptStatus('idle');
+          if (source.clientId && resolvedBaseUrl) {
+            void detachDaemonClient({
+              baseUrl: resolvedBaseUrl,
+              token: resolvedToken,
+              sessionId: source.sessionId,
+              clientId: source.clientId,
+            }).catch((detachError) =>
+              console.warn(
+                '[DaemonSessionProvider] terminal recovery detach failed:',
+                detachError,
+              ),
+            );
+          }
+        }
+        setConnectionSynchronous((current) => {
+          const next = {
+            ...current,
+            status: 'error' as const,
+            sessionId: undefined,
+            clientId: undefined,
+            error: message,
+            errorStatus: status,
+            missingSession: status === 404 || status === 410,
+          };
+          delete next.sessionRecoveryRequired;
+          delete next.sessionTransition;
+          return next;
+        });
+        return;
+      }
       setConnectionSynchronous((current) => ({
         ...current,
+        ...(target.purpose === 'resync'
+          ? { sessionRecoveryRequired: true as const }
+          : {}),
         sessionTransition: transitionState(target, 'failed', {
           message,
           ...(code !== undefined ? { code } : {}),
@@ -3426,15 +3715,23 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
         severity: 'warning',
         category: 'connection',
         operation: target.mode === 'resume' ? 'resume_session' : 'load_session',
-        code: 'daemon.session_transition.failed',
-        message: target.sameLogical
-          ? `Could not refresh session ${target.sessionId}. The current attachment is still active.`
-          : `Could not open session ${target.sessionId}. The current session is still active.`,
-        debugMessage: message,
+        code:
+          target.purpose === 'resync'
+            ? 'daemon.session_resync.failed'
+            : 'daemon.session_transition.failed',
+        message:
+          target.purpose === 'resync'
+            ? `Could not resynchronize session ${target.sessionId}. The retained transcript is read-only; reload it or open another session.`
+            : target.sameLogical
+              ? `Could not refresh session ${target.sessionId}. The current attachment is still active.`
+              : `Could not open session ${target.sessionId}. The current session is still active.`,
+        debugMessage: recoveryReason
+          ? `${message} (resync reason: ${recoveryReason})`
+          : message,
         recoverable: true,
       });
     },
-    [addNotice, setConnectionSynchronous],
+    [addNotice, resolvedBaseUrl, resolvedToken, setConnectionSynchronous],
   );
 
   const retireAttachment = useCallback(
@@ -3481,6 +3778,13 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
       desiredTransitionRef.current = undefined;
       if (mountedRef.current) publishCrossSessionFailure(intent, error);
       settleCrossSessionIntent(intent, error);
+      if (
+        intent.purpose !== 'resync' &&
+        intent.purpose !== 'live_repair' &&
+        resyncEpisodeRef.current?.source === sessionRef.current
+      ) {
+        queueMicrotask(resumeResyncRef.current);
+      }
     },
     [cleanupTransitionArtifacts, publishCrossSessionFailure],
   );
@@ -3489,10 +3793,19 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
     (intent: CrossSessionIntent, capabilities: DaemonCapabilities) => {
       if (intent.deadlineStarted) return;
       intent.deadlineStarted = true;
-      const timeoutMs =
+      const configuredTimeout =
         resolveSessionRestoreTimeouts(capabilities).watchdogTimeoutMs;
-      if (timeoutMs === undefined) return;
-      intent.deadlineAt = Date.now() + timeoutMs;
+      const timeoutMs =
+        configuredTimeout ??
+        (intent.purpose === 'resync' || intent.purpose === 'live_repair'
+          ? 75_000
+          : undefined);
+      const deadlineAt =
+        intent.deadlineAt ??
+        (timeoutMs === undefined ? undefined : Date.now() + timeoutMs);
+      if (deadlineAt === undefined) return;
+      intent.deadlineAt = deadlineAt;
+      const remaining = Math.max(1, deadlineAt - Date.now());
       intent.timeout = setTimeout(() => {
         exposeCrossSessionFailure(
           intent,
@@ -3501,7 +3814,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
             preserveInFlightCapture: rawTransitionRef.current === intent,
           },
         );
-      }, timeoutMs);
+      }, remaining);
     },
     [exposeCrossSessionFailure],
   );
@@ -3542,6 +3855,9 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
         paginationError: false,
       });
       sessionRef.current = staged.session;
+      if (resyncEpisodeRef.current?.source === sourceToRetire) {
+        resyncEpisodeRef.current = undefined;
+      }
       lastSessionIdRef.current = staged.session.sessionId;
       activeWorkspaceCwdRef.current = staged.session.workspaceCwd;
       clientIdRef.current = staged.session.clientId;
@@ -3797,6 +4113,289 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
     [maxBlocks, retireAttachment, setConnectionSynchronous, store],
   );
 
+  const commitRecovery = useCallback(
+    (
+      intent: CrossSessionIntent,
+      candidate: DaemonSessionClient,
+      capabilities: DaemonCapabilities,
+      capture: SameSessionCapture | undefined,
+    ): boolean => {
+      const source = intent.source;
+      const control = runnerControlRef.current;
+      const snapshot = control?.snapshot();
+      const episode = resyncEpisodeRef.current;
+      const isResync = intent.purpose === 'resync';
+      const pendingControlledClientId =
+        isResync && controlledClientIdRef.current !== episode?.clientId
+          ? controlledClientIdRef.current
+          : undefined;
+      const repair = liveJournalRepairRef.current;
+      const watermark = candidate.lastEventId;
+      if (
+        !mountedRef.current ||
+        desiredTransitionRef.current !== intent ||
+        sessionRef.current !== source ||
+        source.clientId !== intent.sourceClientId ||
+        !candidate.clientId ||
+        candidate.clientId !== intent.sourceClientId ||
+        candidate.sessionId !== source.sessionId ||
+        normalizeWorkspaceIdentity(candidate.workspaceCwd) !==
+          normalizeWorkspaceIdentity(source.workspaceCwd) ||
+        candidate.eventEpoch === undefined ||
+        watermark === undefined ||
+        !Number.isSafeInteger(watermark) ||
+        watermark < 0 ||
+        candidate.replayPartial ||
+        candidate.replayError !== undefined ||
+        candidate.replayDegraded ||
+        !candidate.replaySnapshotComplete ||
+        (intent.deadlineAt !== undefined && Date.now() >= intent.deadlineAt)
+      ) {
+        return false;
+      }
+      if (isResync) {
+        const requiresWatermarkAdvance =
+          episode?.reason === 'ring_evicted' ||
+          episode?.reason === 'seeded_replay_not_in_ring' ||
+          episode?.reason === 'replay_budget_exceeded';
+        if (
+          !episode ||
+          episode.source !== source ||
+          episode.sessionId !== source.sessionId ||
+          normalizeWorkspaceIdentity(episode.workspaceCwd) !==
+            normalizeWorkspaceIdentity(source.workspaceCwd) ||
+          episode.clientId !== intent.sourceClientId ||
+          episode.lifecycle !== intent.lifecycle ||
+          episode.environmentGeneration !== intent.environmentGeneration ||
+          (episode.sourceEpoch === candidate.eventEpoch &&
+            episode.sourceCursor !== undefined &&
+            (requiresWatermarkAdvance
+              ? watermark <= episode.sourceCursor
+              : watermark < episode.sourceCursor))
+        ) {
+          return false;
+        }
+      } else if (
+        !repair ||
+        !capture ||
+        capture.invalidReason ||
+        snapshot?.session !== source ||
+        snapshot.clientId !== intent.sourceClientId ||
+        snapshot.eventEpoch !== candidate.eventEpoch ||
+        !snapshot.ready ||
+        snapshot.activeTurn ||
+        snapshot.processedEventId === undefined ||
+        watermark < capture.startEventId ||
+        snapshot.processedEventId < watermark
+      ) {
+        return false;
+      }
+
+      const active = activePromptsRef.current.get(source.sessionId);
+      const tail =
+        intent.purpose === 'live_repair' &&
+        capture &&
+        snapshot?.processedEventId
+          ? capture.events.filter(
+              (event) =>
+                event.id !== undefined &&
+                event.id > watermark &&
+                event.id <= snapshot.processedEventId!,
+            )
+          : [];
+      if (
+        [
+          ...candidate.replaySnapshot.compactedReplay,
+          ...candidate.replaySnapshot.liveJournal,
+          ...tail,
+        ].some((event) => event.type === 'state_resync_required')
+      ) {
+        return false;
+      }
+      if (snapshot?.processedEventId !== undefined && !isResync) {
+        candidate.setLastEventId(snapshot.processedEventId);
+      }
+      const repairMarkerVisible = Boolean(
+        repair?.markerBlockId &&
+          store
+            .getSnapshot()
+            .blocks.some((block) => block.id === repair.markerBlockId),
+      );
+      let staged: StagedCrossSession;
+      try {
+        staged = stageCrossSession({
+          session: candidate,
+          capabilities,
+          maxBlocks,
+          subagentTranscriptMode: subagentTranscriptModeRef.current,
+          eventOptions: eventOptionsRef.current,
+          purpose: intent.purpose,
+          ...(repair ? { repairEpisode: repair } : {}),
+          ...(repairMarkerVisible ? { repairMarkerVisible: true } : {}),
+          additionalEvents: tail,
+        });
+      } catch {
+        return false;
+      }
+      if (
+        staged.notices.some(
+          (notice) => notice.code === 'daemon.replay_event_malformed',
+        ) ||
+        staged.transcript.awaitingResync ||
+        (intent.purpose === 'live_repair' &&
+          !staged.promptTerminals.has(repair!.target.promptId))
+      ) {
+        return false;
+      }
+      const terminal = active?.promptId
+        ? staged.promptTerminals.get(active.promptId)
+        : undefined;
+      if (
+        isResync &&
+        active?.promptId &&
+        !candidate.hasActivePrompt &&
+        !terminal
+      ) {
+        return false;
+      }
+      const finalSnapshot = control?.snapshot();
+      if (
+        (intent.deadlineAt !== undefined && Date.now() >= intent.deadlineAt) ||
+        (intent.purpose === 'live_repair' &&
+          (finalSnapshot?.session !== source ||
+            finalSnapshot.clientId !== intent.sourceClientId ||
+            finalSnapshot.eventEpoch !== candidate.eventEpoch ||
+            finalSnapshot.processedEventId !== snapshot?.processedEventId ||
+            !finalSnapshot.ready ||
+            finalSnapshot.activeTurn))
+      ) {
+        return false;
+      }
+
+      if (control && control.capture === capture) control.capture = undefined;
+      control?.flush();
+      control?.stop();
+      store.reset(staged.transcript);
+      const nextHistory = isResync
+        ? staged.history
+        : repairMarkerVisible
+          ? {
+              ...transcriptHistoryRef.current,
+              loading: false,
+              paginationError: false,
+            }
+          : {
+              ...transcriptHistoryRef.current,
+              sessionId: candidate.sessionId,
+              beforeRecordId:
+                staged.history.beforeRecordId ??
+                transcriptHistoryRef.current.beforeRecordId,
+              cursor: staged.history.cursor,
+              loading: false,
+              paginationError: false,
+            };
+      transcriptHistoryRef.current = nextHistory;
+      setTranscriptHistoryState({
+        hasMore: nextHistory.hasMore,
+        loading: false,
+        capacityReached: nextHistory.capacityReached,
+        paginationError: false,
+      });
+      sessionRef.current = candidate;
+      lastSessionIdRef.current = candidate.sessionId;
+      activeWorkspaceCwdRef.current = candidate.workspaceCwd;
+      clientIdRef.current = candidate.clientId;
+      persistStableClientId(candidate.clientId, candidate.sessionId);
+      setConnectionSynchronous((current) => {
+        const next = {
+          ...current,
+          ...staged.connection,
+          capabilities,
+        };
+        delete next.sessionRecoveryRequired;
+        delete next.sessionTransition;
+        return next;
+      });
+      desiredTransitionRef.current = undefined;
+      resyncEpisodeRef.current = undefined;
+      let hasActivePromptAfterCommit = candidate.hasActivePrompt === true;
+      if (terminal) {
+        settleActivePromptFromTurnEvent(
+          activePromptsRef.current,
+          settledPromptsRef.current,
+          source.sessionId,
+          terminal,
+          store,
+          setPromptStatus,
+          passiveAssistantDoneTimerRef,
+          { requireBoundPromptId: true, dispatchTranscript: false },
+        );
+      }
+      if (
+        candidate.hasActivePrompt &&
+        (intent.purpose === 'live_repair' ||
+          (active !== undefined && terminal === undefined))
+      ) {
+        settledRestoredActivePromptSessionsRef.current.add(candidate);
+      }
+      if (intent.purpose === 'live_repair') {
+        hasActivePromptAfterCommit = false;
+      }
+      hasCurrentSessionActivePromptRef.current = () =>
+        hasActivePromptAfterCommit;
+      setPromptStatus(hasActivePromptAfterCommit ? 'streaming' : 'idle');
+      if (isResync) {
+        clearSidechannelFollowupSuggestion();
+        if (staged.followupSuggestion) {
+          publishSidechannelFollowupSuggestion(staged.followupSuggestion);
+        }
+        setWorkspaceEventSignals((current) => ({
+          memoryVersion: current.memoryVersion + 1,
+          agentsVersion: current.agentsVersion + 1,
+          toolsVersion: current.toolsVersion + 1,
+          settingsVersion: current.settingsVersion + 1,
+          mcpVersion: current.mcpVersion + 1,
+          extensionsVersion: current.extensionsVersion + 1,
+          artifactsVersion: current.artifactsVersion + 1,
+          initVersion: current.initVersion + 1,
+          authVersion: current.authVersion + 1,
+        }));
+        bumpPendingPromptVersion();
+      }
+      liveJournalRepairRef.current = staged.repair;
+      preparedRunnerRef.current = {
+        session: candidate,
+        capabilities,
+        ...(tail.some(
+          (event) =>
+            event.type === 'session_metadata_updated' &&
+            isRecord(event.data) &&
+            Object.prototype.hasOwnProperty.call(event.data, 'displayName'),
+        )
+          ? { preserveStagedDisplayName: true }
+          : {}),
+        ...(getReplayTokenUsage(tail) !== undefined
+          ? { preserveStagedTokenUsage: true }
+          : {}),
+      };
+      manualSessionClearRef.current = false;
+      setRestoreMode('load');
+      setRestoreSessionId(candidate.sessionId);
+      setRestoreWorkspaceCwd(candidate.workspaceCwd);
+      setRestoreSessionNonce((nonce) => nonce + 1);
+      settleCrossSessionIntent(intent);
+      retireAttachment(source, intent);
+      if (
+        pendingControlledClientId !== undefined &&
+        pendingControlledClientId !== candidate.clientId
+      ) {
+        controlledClientRebindRef.current = candidate.sessionId;
+      }
+      return true;
+    },
+    [maxBlocks, retireAttachment, setConnectionSynchronous, store],
+  );
+
   const pumpCrossSessionTransition = useCallback(() => {
     const intent = desiredTransitionRef.current;
     if (!intent) return;
@@ -3828,6 +4427,43 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
       sessionCapabilitiesRef.current ??
       connectionRef.current.capabilities;
     if (!capabilities?.features.includes(CLIENT_IDENTITY_FEATURE)) return;
+
+    const recoveryIntent =
+      intent.purpose === 'resync' || intent.purpose === 'live_repair';
+    if (recoveryIntent && intent.candidate) {
+      const candidate = intent.candidate;
+      if (intent.purpose === 'live_repair') {
+        const snapshot = runnerControlRef.current?.snapshot();
+        if (
+          intent.capture !== undefined &&
+          intent.capture.invalidReason === undefined &&
+          snapshot?.session === intent.source &&
+          snapshot.clientId === intent.sourceClientId &&
+          snapshot.eventEpoch === candidate.eventEpoch &&
+          (!snapshot.ready ||
+            snapshot.activeTurn ||
+            snapshot.processedEventId === undefined ||
+            (candidate.lastEventId !== undefined &&
+              snapshot.processedEventId < candidate.lastEventId))
+        ) {
+          return;
+        }
+      }
+      if (
+        !commitRecovery(
+          intent,
+          candidate,
+          intent.candidateCapabilities ?? capabilities,
+          intent.capture,
+        )
+      ) {
+        exposeCrossSessionFailure(
+          intent,
+          new Error('Session recovery failed integrity validation'),
+        );
+      }
+      return;
+    }
 
     if (intent.sameLogical && intent.candidate) {
       const candidate = intent.candidate;
@@ -3886,7 +4522,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
     }
 
     if (rawTransitionRef.current) return;
-    if (intent.sameLogical) {
+    if (intent.sameLogical && !recoveryIntent) {
       const snapshot = runnerControlRef.current?.snapshot();
       if (
         snapshot?.session !== intent.source ||
@@ -3929,6 +4565,86 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
         runnerControlRef.current!.capture = capture;
       }
       armTransitionDeadline(intent, capabilities);
+    } else if (intent.purpose === 'live_repair') {
+      const snapshot = runnerControlRef.current?.snapshot();
+      if (
+        snapshot?.session !== intent.source ||
+        snapshot.clientId !== intent.sourceClientId ||
+        snapshot.eventEpoch === undefined ||
+        snapshot.processedEventId === undefined ||
+        !snapshot.ready ||
+        snapshot.activeTurn
+      ) {
+        setConnectionSynchronous((current) => ({
+          ...current,
+          sessionTransition: transitionState(intent, 'queued'),
+        }));
+        return;
+      }
+      const capture: SameSessionCapture = {
+        source: intent.source,
+        sourceClientId: intent.sourceClientId,
+        eventEpoch: snapshot.eventEpoch,
+        startEventId: snapshot.processedEventId,
+        lastCapturedEventId: snapshot.processedEventId,
+        bytes: 0,
+        events: [],
+      };
+      intent.capture = capture;
+      runnerControlRef.current!.capture = capture;
+      armTransitionDeadline(intent, capabilities);
+    } else if (intent.purpose === 'resync') {
+      const active = activePromptsRef.current.get(intent.sessionId);
+      if (
+        sourceBoundOperationCountRef.current > 0 ||
+        (promptAdmissionCountsRef.current.get(intent.source) ?? 0) > 0 ||
+        activePromptsRef.current.has(`${intent.sessionId}:shell`) ||
+        (active !== undefined && active.promptId === undefined)
+      ) {
+        setConnectionSynchronous((current) => ({
+          ...current,
+          sessionTransition: transitionState(intent, 'queued'),
+        }));
+        return;
+      }
+      const refreshedClientId = intent.source.clientId;
+      if (!refreshedClientId) {
+        exposeCrossSessionFailure(
+          intent,
+          new Error('Session recovery client identity is unavailable'),
+        );
+        return;
+      }
+      const episode = resyncEpisodeRef.current;
+      if (episode?.source !== intent.source) {
+        exposeCrossSessionFailure(
+          intent,
+          new Error('Session recovery owner changed unexpectedly'),
+        );
+        return;
+      }
+      episode.clientId = refreshedClientId;
+      if (refreshedClientId !== intent.sourceClientId) {
+        intent.sourceClientId = refreshedClientId;
+        intent.targetClientId = refreshedClientId;
+        intent.key = crossSessionKey(
+          intent.sessionId,
+          intent.workspaceCwd,
+          intent.mode,
+          intent.effectiveHistoryPageSize,
+          refreshedClientId,
+          intent.purpose,
+        );
+      }
+      clientIdRef.current = refreshedClientId;
+      persistStableClientId(refreshedClientId, intent.sessionId);
+      setConnectionSynchronous((current) =>
+        current.sessionId === intent.sessionId &&
+        current.clientId !== refreshedClientId
+          ? { ...current, clientId: refreshedClientId }
+          : current,
+      );
+      armTransitionDeadline(intent, capabilities);
     }
     const requestClientId = intent.targetClientId;
     if (!requestClientId) {
@@ -3938,7 +4654,29 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
       );
       return;
     }
+    if (
+      intent.purpose === 'resync' &&
+      resyncEpisodeRef.current?.source === intent.source &&
+      resyncEpisodeRef.current.attemptCount >= 3
+    ) {
+      exposeCrossSessionFailure(
+        intent,
+        new Error('Session recovery retry limit exhausted'),
+      );
+      return;
+    }
     rawTransitionRef.current = intent;
+    if (intent.purpose === 'resync') {
+      const episode = resyncEpisodeRef.current;
+      const attemptCount =
+        episode?.source === intent.source
+          ? episode.attemptCount + 1
+          : (intent.retryAttempt ?? 0) + 1;
+      if (episode?.source === intent.source) {
+        episode.attemptCount = attemptCount;
+      }
+      intent.retryAttempt = attemptCount;
+    }
     setConnectionSynchronous((current) => ({
       ...current,
       sessionTransition: transitionState(intent, 'preparing'),
@@ -3995,6 +4733,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
         }
         if (
           intent.sameLogical &&
+          (intent.purpose ?? 'ordinary') === 'ordinary' &&
           (candidate.eventEpoch === undefined ||
             candidate.eventEpoch !== intent.capture?.eventEpoch ||
             candidate.lastEventId === undefined ||
@@ -4018,6 +4757,26 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           return;
         }
         if (
+          (intent.purpose === 'resync' || intent.purpose === 'live_repair') &&
+          (candidate.eventEpoch === undefined ||
+            candidate.lastEventId === undefined ||
+            !Number.isSafeInteger(candidate.lastEventId) ||
+            candidate.lastEventId < 0 ||
+            candidate.replayPartial ||
+            candidate.replayError !== undefined ||
+            candidate.replayDegraded ||
+            !candidate.replaySnapshotComplete)
+        ) {
+          retireAttachment(candidate, intent);
+          if (latest === intent) {
+            exposeCrossSessionFailure(
+              latest,
+              new Error('Session recovery returned an incomplete snapshot'),
+            );
+          }
+          return;
+        }
+        if (
           intent.resultSuperseded === true ||
           latest?.key !== intent.key ||
           latest.lifecycle !== intent.lifecycle ||
@@ -4030,6 +4789,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           latest.capture = intent.capture;
           latest.candidate = candidate;
           latest.candidateCapabilities = capabilities;
+          queueMicrotask(pumpTransitionRef.current);
           return;
         }
         let staged: StagedCrossSession;
@@ -4062,6 +4822,33 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
         if (
           autoReconnect &&
           latest === intent &&
+          intent.purpose === 'resync' &&
+          (intent.retryAttempt ?? 1) < 3 &&
+          isStructuredRecoveryRetryable(error)
+        ) {
+          retryScheduled = true;
+          const retryAfterMs = getRecoveryRetryDelayMs(
+            error,
+            intent.retryAttempt ?? 1,
+            reconnectConfigRef.current,
+          );
+          const remaining =
+            intent.deadlineAt === undefined
+              ? retryAfterMs + 1
+              : intent.deadlineAt - Date.now();
+          if (retryAfterMs < remaining) {
+            setTimeout(pumpTransitionRef.current, retryAfterMs);
+          } else {
+            retryScheduled = false;
+            exposeCrossSessionFailure(
+              latest,
+              new Error('Session recovery deadline expired'),
+            );
+          }
+        } else if (
+          autoReconnect &&
+          latest === intent &&
+          (intent.purpose ?? 'ordinary') === 'ordinary' &&
           isClosingSessionLoadError(error)
         ) {
           retryScheduled = true;
@@ -4098,6 +4885,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
     armTransitionDeadline,
     autoReconnect,
     commitCrossSession,
+    commitRecovery,
     commitSameSession,
     exposeCrossSessionFailure,
     maxBlocks,
@@ -4138,6 +4926,21 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
       request: CrossSessionTarget,
       startLegacy: () => Promise<void>,
     ): Promise<void> => {
+      const recoveryEpisode = resyncEpisodeRef.current;
+      let manualRecoveryRetry = false;
+      if (
+        request.sameLogical &&
+        recoveryEpisode?.source === sessionRef.current &&
+        request.purpose === undefined
+      ) {
+        request = {
+          ...request,
+          mode: 'load',
+          origin: 'recovery',
+          purpose: 'resync',
+        };
+        manualRecoveryRetry = true;
+      }
       const capabilities =
         workspaceCapabilitiesRef.current ??
         sessionCapabilitiesRef.current ??
@@ -4153,7 +4956,18 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           ),
         );
       }
-      if (sourceBoundOperationCountRef.current > 0) {
+      if (manualRecoveryRetry && recoveryEpisode) {
+        const watchdog =
+          resolveSessionRestoreTimeouts(capabilities).watchdogTimeoutMs ??
+          75_000;
+        recoveryEpisode.lifecycle = lifecycleRef.current;
+        recoveryEpisode.deadlineAt = Date.now() + watchdog;
+        recoveryEpisode.attemptCount = 0;
+      }
+      if (
+        sourceBoundOperationCountRef.current > 0 &&
+        (request.purpose ?? 'ordinary') === 'ordinary'
+      ) {
         return rejectPreflight(
           new DOMException(
             'Another session operation is already in progress',
@@ -4197,6 +5011,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
         );
       }
       const effectiveHistoryPageSize =
+        (request.purpose ?? 'ordinary') === 'ordinary' &&
         request.mode === 'load' &&
         historyPageSizeRef.current !== undefined &&
         capabilities.features.includes(SESSION_TRANSCRIPT_PAGINATION_FEATURE)
@@ -4208,6 +5023,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
         request.mode,
         effectiveHistoryPageSize,
         undefined,
+        request.purpose,
       );
       const raw = rawTransitionRef.current;
       const rawShape = raw
@@ -4217,22 +5033,26 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
             raw.mode,
             raw.effectiveHistoryPageSize,
             undefined,
+            raw.purpose,
           )
         : undefined;
       const targetClientId =
-        clientId ??
-        (request.sameLogical
+        request.purpose === 'resync' || request.purpose === 'live_repair'
           ? source.clientId
-          : rawShape === requestShape
-            ? raw?.targetClientId
-            : undefined) ??
-        getStableClientId(undefined, request.sessionId);
+          : (clientId ??
+            (request.sameLogical
+              ? source.clientId
+              : rawShape === requestShape
+                ? raw?.targetClientId
+                : undefined) ??
+            getStableClientId(undefined, request.sessionId));
       const key = crossSessionKey(
         request.sessionId,
         request.workspaceCwd,
         request.mode,
         effectiveHistoryPageSize,
         targetClientId,
+        request.purpose,
       );
       if (raw && raw.key !== key) raw.resultSuperseded = true;
       const current = desiredTransitionRef.current;
@@ -4274,13 +5094,20 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
         environmentGeneration: environmentRef.current.generation,
         sourceClientId: source.clientId,
         targetClientId,
+        ...(request.purpose === 'resync' && recoveryEpisode
+          ? { deadlineAt: recoveryEpisode.deadlineAt }
+          : {}),
         promise,
         resolve,
         reject,
       };
       desiredTransitionRef.current = intent;
       const adoptingRaw = rawTransitionRef.current?.key === key;
-      if (request.sameLogical && adoptingRaw) {
+      if (
+        request.purpose === 'resync' ||
+        request.purpose === 'live_repair' ||
+        (request.sameLogical && adoptingRaw)
+      ) {
         armTransitionDeadline(intent, capabilities);
       }
       if (request.signal) {
@@ -4336,6 +5163,103 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
       setConnectionSynchronous,
     ],
   );
+
+  const startRecoveryTransition = useCallback(
+    (purpose: 'resync' | 'live_repair') => {
+      const source = sessionRef.current;
+      if (!source) return;
+      const episode = resyncEpisodeRef.current;
+      if (purpose === 'resync' && episode?.source === source) {
+        episode.lifecycle = lifecycleRef.current;
+      }
+      const transition = beginCrossSessionTransition(
+        {
+          sessionId: source.sessionId,
+          mode: 'load',
+          workspaceCwd: source.workspaceCwd,
+          origin: 'recovery',
+          purpose,
+          sameLogical: true,
+        },
+        () => Promise.reject(new Error('Transactional recovery unavailable')),
+      );
+      const intent = desiredTransitionRef.current;
+      if (purpose === 'resync' && intent?.purpose === 'resync' && episode) {
+        intent.deadlineAt = episode.deadlineAt;
+      }
+      void transition.catch(() => undefined);
+    },
+    [beginCrossSessionTransition],
+  );
+  resumeResyncRef.current = () => {
+    const episode = resyncEpisodeRef.current;
+    if (!episode || sessionRef.current !== episode.source) return;
+    startRecoveryTransition('resync');
+  };
+  beginResyncRef.current = (source, reason, sourceEpoch, sourceCursor) => {
+    const capabilities = connectionRef.current.capabilities;
+    const watchdog =
+      resolveSessionRestoreTimeouts(capabilities).watchdogTimeoutMs;
+    const deadlineAt = Date.now() + (watchdog ?? 75_000);
+    resyncEpisodeRef.current = {
+      source,
+      sessionId: source.sessionId,
+      workspaceCwd: source.workspaceCwd,
+      clientId: source.clientId!,
+      sourceEpoch,
+      sourceCursor,
+      reason,
+      lifecycle: lifecycleRef.current,
+      environmentGeneration: environmentRef.current.generation,
+      deadlineAt,
+      attemptCount: 0,
+    };
+    startRecoveryTransition('resync');
+  };
+  beginLiveRepairRef.current = (episode) => {
+    liveJournalRepairRef.current = episode;
+    const capabilities = connectionRef.current.capabilities;
+    if (capabilities === undefined) {
+      addNotice({
+        id: `daemon.live_journal_repair.failed:${episode.target.signature}`,
+        severity: 'warning',
+        category: 'connection',
+        operation: 'load_session',
+        code: 'daemon.live_journal_repair.failed',
+        message:
+          'Could not restore the complete turn because daemon capabilities are unavailable. The retained replay remains visible.',
+        recoverable: true,
+      });
+      liveJournalRepairRef.current = undefined;
+      return;
+    }
+    if (!capabilities.features.includes(CLIENT_IDENTITY_FEATURE)) {
+      const reload = repairReloadRef.current;
+      if (!reload) return;
+      const controller = new AbortController();
+      episode.controller = controller;
+      void reload(controller.signal, { replaySource: 'memory' }).catch(
+        (error: unknown) => {
+          if (liveJournalRepairRef.current !== episode) return;
+          addNotice({
+            id: `daemon.live_journal_repair.failed:${episode.target.signature}`,
+            severity: 'warning',
+            category: 'connection',
+            operation: 'load_session',
+            code: 'daemon.live_journal_repair.failed',
+            message:
+              'Could not restore the complete turn. The retained replay remains visible.',
+            debugMessage:
+              error instanceof Error ? error.message : String(error),
+            recoverable: true,
+          });
+          liveJournalRepairRef.current = undefined;
+        },
+      );
+      return;
+    }
+    startRecoveryTransition('live_repair');
+  };
 
   const actions = useMemo<DaemonSessionActions>(
     () =>
@@ -4445,6 +5369,12 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
               }
             });
           }
+          if (!inFlight && sourceBoundOperationCountRef.current === 0) {
+            queueMicrotask(() => {
+              pumpTransitionRef.current();
+              tryLiveJournalRepairRef.current?.();
+            });
+          }
         },
         sessionConfigGeneration: sessionConfigGenerationRef.current,
         getTransitionOrigin: () => {
@@ -4456,6 +5386,48 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           liveJournalRepairRef.current?.controller?.abort();
           liveJournalRepairRef.current = undefined;
         },
+        isSessionRecoveryLocked: () => {
+          const episode = resyncEpisodeRef.current;
+          const transition = desiredTransitionRef.current;
+          return (
+            (episode !== undefined && episode.source === sessionRef.current) ||
+            (transition?.origin === 'recovery' &&
+              transition.source === sessionRef.current) ||
+            connectionRef.current.sessionRecoveryRequired === true
+          );
+        },
+        clearSessionRecovery: () => {
+          resyncEpisodeRef.current = undefined;
+          setConnectionSynchronous((current) => {
+            if (
+              current.sessionRecoveryRequired !== true &&
+              current.sessionTransition?.origin !== 'recovery'
+            ) {
+              return current;
+            }
+            const next = { ...current };
+            delete next.sessionRecoveryRequired;
+            if (next.sessionTransition?.origin === 'recovery') {
+              delete next.sessionTransition;
+            }
+            return next;
+          });
+        },
+        resumeSessionRecovery: () => queueMicrotask(resumeResyncRef.current),
+        onPromptAdmissionSettled: () =>
+          queueMicrotask(pumpTransitionRef.current),
+        setPromptAdmissionInFlight: (session, inFlight) => {
+          const current = promptAdmissionCountsRef.current.get(session) ?? 0;
+          const next = current + (inFlight ? 1 : -1);
+          if (next > 0) promptAdmissionCountsRef.current.set(session, next);
+          else promptAdmissionCountsRef.current.delete(session);
+          if (!inFlight && next <= 0) {
+            queueMicrotask(() => {
+              pumpTransitionRef.current();
+              tryLiveJournalRepairRef.current?.();
+            });
+          }
+        },
       }),
     [
       addNotice,
@@ -4465,6 +5437,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
       resolvedBaseUrl,
       resolvedToken,
       restartEventStreamOnPrompt,
+      setConnectionSynchronous,
       store,
     ],
   );
@@ -4675,16 +5648,41 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
       loadMore: loadMoreTranscript,
     };
   }, [connection.sessionId, loadMoreTranscript, transcriptHistoryState]);
-  const lastHandledSessionIdRef = useRef<
-    string | undefined | typeof UNHANDLED_SESSION
-  >(UNHANDLED_SESSION);
-  const lastHandledWorkspaceRef = useRef<string | undefined>(undefined);
-  const lastHandledClientIdRef = useRef<string | undefined>(undefined);
-
   useEffect(() => {
     const targetWorkspaceCwd =
       resolvedWorkspaceCwd ?? connectionRef.current.workspaceCwd;
     const previousSessionId = lastHandledSessionIdRef.current;
+    const currentSession = sessionRef.current;
+    const recoveryEpisode = resyncEpisodeRef.current;
+    if (
+      recoveryEpisode !== undefined &&
+      currentSession !== undefined &&
+      recoveryEpisode.source === currentSession &&
+      connectionRef.current.sessionRecoveryRequired === true &&
+      sessionId === currentSession.sessionId &&
+      normalizeWorkspaceIdentity(targetWorkspaceCwd) ===
+        normalizeWorkspaceIdentity(currentSession.workspaceCwd)
+    ) {
+      if (clientId !== undefined && clientId !== recoveryEpisode.clientId) {
+        return;
+      }
+    }
+    if (
+      currentSession !== undefined &&
+      sessionId === currentSession.sessionId &&
+      normalizeWorkspaceIdentity(targetWorkspaceCwd) ===
+        normalizeWorkspaceIdentity(currentSession.workspaceCwd)
+    ) {
+      if (clientId === undefined || clientId === currentSession.clientId) {
+        controlledClientRebindRef.current = undefined;
+      } else {
+        const runner = runnerControlRef.current?.snapshot();
+        if (runner?.session !== currentSession || !runner.ready) {
+          controlledClientRebindRef.current = currentSession.sessionId;
+          return;
+        }
+      }
+    }
     if (
       lastHandledSessionIdRef.current === sessionId &&
       normalizeWorkspaceIdentity(lastHandledWorkspaceRef.current) ===
@@ -4718,7 +5716,6 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
     }
 
     const currentSessionId = connectionRef.current.sessionId;
-    const currentSession = sessionRef.current;
     const sameLogicalTarget =
       sessionId === currentSessionId &&
       normalizeWorkspaceIdentity(targetWorkspaceCwd) ===
@@ -4737,7 +5734,10 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
       (controlledCapabilities === undefined ||
         controlledCapabilities.features.includes(CLIENT_IDENTITY_FEATURE));
     if (sameLogicalTarget && !needsTransactionalClientRebind) {
-      if (connectionRef.current.sessionTransition?.phase === 'failed') {
+      if (
+        connectionRef.current.sessionTransition?.phase === 'failed' &&
+        connectionRef.current.sessionTransition.origin !== 'recovery'
+      ) {
         setConnectionSynchronous((current) => {
           if (current.sessionTransition?.phase !== 'failed') return current;
           const next = { ...current };
@@ -4817,10 +5817,10 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
 
 /**
  * Settle the session's active prompt from a `turn_complete` / `turn_error`
- * event. Dispatches `assistant.done` directly on `store`, so callers that have
- * buffered (batched) transcript events must flush them first
- * (`flushTranscriptSync()`) — otherwise `assistant.done` is applied ahead of
- * the turn's still-buffered transcript content.
+ * event. By default it dispatches `assistant.done` directly on `store`, so
+ * callers with buffered transcript events must flush them first. Recovery
+ * staging can suppress that dispatch after its shadow replay materializes the
+ * terminal.
  */
 function settleActivePromptFromTurnEvent(
   activePrompts: Map<string, ActivePrompt>,
@@ -4830,7 +5830,10 @@ function settleActivePromptFromTurnEvent(
   store: DaemonTranscriptStore,
   setPromptStatus: Dispatch<SetStateAction<DaemonPromptStatus>>,
   passiveAssistantDoneTimerRef: TimerRef,
-  opts: { requireBoundPromptId?: boolean } = {},
+  opts: {
+    requireBoundPromptId?: boolean;
+    dispatchTranscript?: boolean;
+  } = {},
 ): boolean {
   if (event.type !== 'turn_complete' && event.type !== 'turn_error') {
     return false;
@@ -4851,7 +5854,9 @@ function settleActivePromptFromTurnEvent(
   try {
     const result = matchTurnEvent(event, promptId);
     if (!result) return false;
-    store.dispatch(assistantDoneFromTurnEvent(event, result.stopReason));
+    if (opts.dispatchTranscript !== false) {
+      store.dispatch(assistantDoneFromTurnEvent(event, result.stopReason));
+    }
     setPromptStatus('idle');
     if (active.resolve) {
       activePrompts.delete(sessionId);
@@ -4864,7 +5869,9 @@ function settleActivePromptFromTurnEvent(
       });
     }
   } catch (error) {
-    store.dispatch(assistantDoneFromTurnEvent(event, 'error'));
+    if (opts.dispatchTranscript !== false) {
+      store.dispatch(assistantDoneFromTurnEvent(event, 'error'));
+    }
     setPromptStatus('idle');
     if (active.reject) {
       activePrompts.delete(sessionId);
@@ -5465,5 +6472,59 @@ function isClosingSessionLoadError(
       body['error'].endsWith(
         'The session is closing; retry after close completes',
       ))
+  );
+}
+
+function isStructuredRecoveryRetryable(error: unknown): boolean {
+  if (!(error instanceof DaemonHttpError) || !isRecord(error.body)) {
+    return false;
+  }
+  const code = error.body['code'];
+  if (error.status === 404) return code === 'session_closing';
+  if (error.status === 409) {
+    return (
+      code === 'restore_in_progress' &&
+      error.body['reason'] !== 'awaiting_abandoned_cleanup' &&
+      error.body['retryable'] === true
+    );
+  }
+  return (
+    error.status === 503 &&
+    code === 'acp_channel_unavailable' &&
+    error.body['retryable'] === true
+  );
+}
+
+function getRecoveryRetryDelayMs(
+  error: unknown,
+  attempt: number,
+  reconnect: { reconnectDelayMs: number; maxReconnectDelayMs: number },
+): number {
+  if (error instanceof DaemonHttpError && isRecord(error.body)) {
+    const seconds = error.body['retryAfterSeconds'];
+    if (
+      typeof seconds === 'number' &&
+      Number.isFinite(seconds) &&
+      seconds > 0
+    ) {
+      return Math.ceil(seconds * 1000);
+    }
+    if (error.status === 409) return 5000;
+  }
+  return getReconnectDelayMs(
+    attempt,
+    reconnect.reconnectDelayMs,
+    reconnect.maxReconnectDelayMs,
+  );
+}
+
+function isTerminalRecoveryFailure(error: unknown): boolean {
+  const status = extractHttpStatus(error);
+  if (status === 401 || status === 403 || status === 410) return true;
+  if (status !== 404) return false;
+  return !(
+    error instanceof DaemonHttpError &&
+    isRecord(error.body) &&
+    error.body['code'] === 'session_closing'
   );
 }

--- a/packages/webui/src/daemon/session/actions.test.ts
+++ b/packages/webui/src/daemon/session/actions.test.ts
@@ -1151,6 +1151,38 @@ describe('createDaemonSessionActions', () => {
     expect(pendingSessionLoadRef.current).toBeUndefined();
   });
 
+  it('resumes recovery when closing the current session fails', async () => {
+    const session = createMockSession('session-a');
+    session.close.mockRejectedValue(new Error('close failed'));
+    const resumeSessionRecovery = vi.fn();
+    const { actions } = createActionsHarness({
+      isSessionRecoveryLocked: () => true,
+      resumeSessionRecovery,
+      session,
+    });
+
+    await expect(actions.closeSession()).rejects.toThrow('close failed');
+
+    expect(resumeSessionRecovery).toHaveBeenCalledOnce();
+  });
+
+  it('resumes recovery when releasing the current session fails', async () => {
+    const session = createMockSession('session-a');
+    session.client.closeSession.mockRejectedValue(new Error('release failed'));
+    const resumeSessionRecovery = vi.fn();
+    const { actions } = createActionsHarness({
+      isSessionRecoveryLocked: () => true,
+      resumeSessionRecovery,
+      session,
+    });
+
+    await expect(actions.releaseSession('session-a')).rejects.toThrow(
+      'release failed',
+    );
+
+    expect(resumeSessionRecovery).toHaveBeenCalledOnce();
+  });
+
   it('restarts the event stream after prompt admission', async () => {
     const restartEventStream = vi.fn();
     const onAdmissionStarted = vi.fn();
@@ -1656,6 +1688,7 @@ function createActionsHarness(
     activePrompts?: Map<string, ActivePrompt>;
     addNotice?: ReturnType<typeof vi.fn>;
     beginCrossSessionTransition?: ReturnType<typeof vi.fn>;
+    cancelCrossSessionTransition?: ReturnType<typeof vi.fn>;
     clearLiveJournalRepair?: ReturnType<typeof vi.fn>;
     connection?: DaemonConnectionState;
     createDetachedSession?: ReturnType<typeof vi.fn>;
@@ -1672,6 +1705,8 @@ function createActionsHarness(
     isSourceBoundOperationInFlight?: () => boolean;
     isCrossSessionTransitionPending?: () => boolean;
     isDifferentLogicalTransitionPending?: () => boolean;
+    isSessionRecoveryLocked?: () => boolean;
+    resumeSessionRecovery?: ReturnType<typeof vi.fn>;
     setPromptStatus?: ReturnType<typeof vi.fn>;
     hasSessionActivePrompt?: () => boolean;
   } = {},
@@ -1725,10 +1760,13 @@ function createActionsHarness(
     addNotice: opts.addNotice ?? vi.fn(),
     clearLiveJournalRepair: opts.clearLiveJournalRepair,
     beginCrossSessionTransition: opts.beginCrossSessionTransition,
+    cancelCrossSessionTransition: opts.cancelCrossSessionTransition,
     isCrossSessionTransitionPending: opts.isCrossSessionTransitionPending,
     isDifferentLogicalTransitionPending:
       opts.isDifferentLogicalTransitionPending,
     isSourceBoundOperationInFlight: opts.isSourceBoundOperationInFlight,
+    isSessionRecoveryLocked: opts.isSessionRecoveryLocked,
+    resumeSessionRecovery: opts.resumeSessionRecovery,
     getTransitionOrigin: opts.getTransitionOrigin,
     setSourceBoundOperationInFlight: opts.setSourceBoundOperationInFlight,
     sessionConfigGeneration: opts.sessionConfigGeneration,
@@ -1778,6 +1816,7 @@ function createMockSession(
     cancel: vi.fn(async () => undefined),
     context: vi.fn(async () => contextStatus(sessionId)),
     detach: vi.fn(async () => undefined),
+    close: vi.fn(async () => undefined),
     setModel: vi.fn(async () => ({})),
     setConfigOption: vi.fn(
       async (): Promise<{ configOptions: unknown[] }> => ({

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -128,7 +128,7 @@ export interface CreateDaemonSessionActionsArgs {
       sessionId: string;
       mode: 'load' | 'resume';
       workspaceCwd?: string;
-      origin: 'action' | 'controlled';
+      origin: 'action' | 'controlled' | 'recovery';
       sameLogical?: boolean;
       signal?: AbortSignal;
     },
@@ -141,6 +141,14 @@ export interface CreateDaemonSessionActionsArgs {
   setSourceBoundOperationInFlight?: (inFlight: boolean) => void;
   sessionConfigGeneration?: WeakMap<DaemonSessionClient, number>;
   getTransitionOrigin?: () => 'action' | 'controlled';
+  isSessionRecoveryLocked?: () => boolean;
+  clearSessionRecovery?: () => void;
+  resumeSessionRecovery?: () => void;
+  onPromptAdmissionSettled?: () => void;
+  setPromptAdmissionInFlight?: (
+    session: DaemonSessionClient,
+    inFlight: boolean,
+  ) => void;
 }
 export function getConnectionAfterSessionClear(
   current: DaemonConnectionState,
@@ -213,6 +221,11 @@ export function createDaemonSessionActions({
   setSourceBoundOperationInFlight = () => undefined,
   sessionConfigGeneration = new WeakMap(),
   getTransitionOrigin = () => 'action',
+  isSessionRecoveryLocked = () => false,
+  clearSessionRecovery = () => undefined,
+  resumeSessionRecovery = () => undefined,
+  onPromptAdmissionSettled = () => undefined,
+  setPromptAdmissionInFlight = () => undefined,
 }: CreateDaemonSessionActionsArgs): DaemonSessionActions {
   const silentHardFailureNoticeKeys = new Set<string>();
   let noticeOwner = sessionRef.current;
@@ -220,8 +233,20 @@ export function createDaemonSessionActions({
   let appliedReasoningActionToken = 0;
   let modelMutationGeneration = 0;
 
-  function requireStableSession(): void {
-    if (isCrossSessionTransitionPending()) {
+  function requireStableSession(options?: {
+    allowDuringRecovery?: boolean;
+  }): void {
+    const recoveryLocked = isSessionRecoveryLocked();
+    if (recoveryLocked && !options?.allowDuringRecovery) {
+      throw new DOMException(
+        'The session is read-only until recovery completes',
+        'InvalidStateError',
+      );
+    }
+    if (
+      isCrossSessionTransitionPending() &&
+      !(options?.allowDuringRecovery && recoveryLocked)
+    ) {
       throw new DOMException(
         'A session switch is still preparing',
         'InvalidStateError',
@@ -257,6 +282,14 @@ export function createDaemonSessionActions({
       (sessionConfigGeneration.get(session) ?? 0) + 1,
     );
     setSourceBoundOperationInFlight(false);
+  }
+
+  function requireRecoveryWritable(): void {
+    if (!isSessionRecoveryLocked()) return;
+    throw new DOMException(
+      'The session is read-only until recovery completes',
+      'InvalidStateError',
+    );
   }
 
   const isCurrentLogicalSession = (session: DaemonSessionClient) => {
@@ -312,6 +345,17 @@ export function createDaemonSessionActions({
     store.reset();
     setRestoreSessionId(undefined);
     setRestoreWorkspaceCwd(undefined);
+  }
+
+  function clearClosedRecoverySession(session: DaemonSessionClient) {
+    if (sessionRef.current !== session || !isSessionRecoveryLocked()) return;
+    clearSessionRecovery();
+    manualSessionClearRef.current = true;
+    clearActiveSessionState();
+    sessionRef.current = undefined;
+    setConnection((current) =>
+      getConnectionAfterSessionClear(current, session.sessionId),
+    );
   }
 
   function startPendingSessionLoad(
@@ -616,14 +660,17 @@ export function createDaemonSessionActions({
         // The prompt is admitted to the session here — signal it before we wait
         // out the (possibly long) turn, so an admission-only caller can proceed.
         options?.onAdmitted?.();
-        return await waitForAcceptedPromptCompletion(
+        const completion = waitForAcceptedPromptCompletion(
           activePromptsRef.current,
           settledPromptsRef.current,
           sessionId,
           ctrl,
           accepted.promptId,
         );
+        onPromptAdmissionSettled();
+        return await completion;
       } catch (error) {
+        onPromptAdmissionSettled();
         if (isAbortError(error)) {
           if (shouldSettlePromptForSession(session)) {
             store.dispatch({ type: 'assistant.done', reason: 'cancelled' });
@@ -690,39 +737,47 @@ export function createDaemonSessionActions({
       if (options?.retry) {
         promptRequest['retry'] = true;
       }
-      const accepted = await session.submitPrompt(
-        promptRequest as Parameters<typeof session.submitPrompt>[0],
-      );
-      if (options?.signal?.aborted) {
-        try {
-          const removal = await session.removePendingPrompt(accepted.promptId);
-          if (removal.removed) {
-            return { promptId: accepted.promptId, removedAfterAbort: true };
-          }
-        } catch (err) {
-          console.warn(
-            '[submitPrompt] removePendingPrompt failed after abort',
-            err,
-          );
-          noticeForSession(session)({
-            severity: 'error',
-            category: 'user_action',
-            operation: 'send_prompt',
-            code: 'daemon.send_prompt.pending_cleanup_failed',
-            message:
-              'Prompt was accepted after cancellation but could not be removed from the queue.',
-            debugMessage: err instanceof Error ? err.message : String(err),
-            recoverable: true,
-          });
-        }
-        throw (
-          options.signal.reason ?? new DOMException('Aborted', 'AbortError')
+      setPromptAdmissionInFlight(session, true);
+      try {
+        const accepted = await session.submitPrompt(
+          promptRequest as Parameters<typeof session.submitPrompt>[0],
         );
+        if (options?.signal?.aborted) {
+          try {
+            const removal = await session.removePendingPrompt(
+              accepted.promptId,
+            );
+            if (removal.removed) {
+              return { promptId: accepted.promptId, removedAfterAbort: true };
+            }
+          } catch (err) {
+            console.warn(
+              '[submitPrompt] removePendingPrompt failed after abort',
+              err,
+            );
+            noticeForSession(session)({
+              severity: 'error',
+              category: 'user_action',
+              operation: 'send_prompt',
+              code: 'daemon.send_prompt.pending_cleanup_failed',
+              message:
+                'Prompt was accepted after cancellation but could not be removed from the queue.',
+              debugMessage: err instanceof Error ? err.message : String(err),
+              recoverable: true,
+            });
+          }
+          throw (
+            options.signal.reason ?? new DOMException('Aborted', 'AbortError')
+          );
+        }
+        return { promptId: accepted.promptId };
+      } finally {
+        setPromptAdmissionInFlight(session, false);
       }
-      return { promptId: accepted.promptId };
     },
 
     async cancel() {
+      requireRecoveryWritable();
       const session = requireSessionForAction(
         addNotice,
         sessionRef.current,
@@ -755,6 +810,7 @@ export function createDaemonSessionActions({
         ) {
           activePromptsRef.current.delete(session.sessionId);
         }
+        onPromptAdmissionSettled();
         if (isCurrentLogicalSession(session) && !hasSessionActivePrompt()) {
           setPromptStatus('idle');
         }
@@ -926,6 +982,7 @@ export function createDaemonSessionActions({
     },
 
     async respondToPermission(requestId, response) {
+      requireRecoveryWritable();
       const session = requireSessionForAction(
         addNotice,
         sessionRef.current,
@@ -948,6 +1005,7 @@ export function createDaemonSessionActions({
     },
 
     async submitPermission(requestId, optionId, answers) {
+      requireRecoveryWritable();
       const session = requireSessionForAction(
         addNotice,
         sessionRef.current,
@@ -1035,7 +1093,7 @@ export function createDaemonSessionActions({
       worktree?: { slug?: string };
       branch?: { name: string };
     }) {
-      requireStableSession();
+      requireStableSession({ allowDuringRecovery: true });
       let rawCreateStarted = false;
       let rawCreateSettled = false;
       let retireLateResult = false;
@@ -1175,6 +1233,7 @@ export function createDaemonSessionActions({
 
     async clearSession() {
       cancelCrossSessionTransition('Session transition cancelled by clear');
+      clearSessionRecovery();
       const session = sessionRef.current;
       manualSessionClearRef.current = true;
       clearActiveSessionState();
@@ -1195,6 +1254,7 @@ export function createDaemonSessionActions({
       cancelCrossSessionTransition(
         'Session transition cancelled by new session',
       );
+      clearSessionRecovery();
       manualSessionClearRef.current = false;
       clearActiveSessionState();
       setConnection((current) => ({
@@ -1207,8 +1267,9 @@ export function createDaemonSessionActions({
     },
 
     async releaseSession(sessionId) {
+      const releasingCurrent = sessionRef.current?.sessionId === sessionId;
       try {
-        if (sessionRef.current?.sessionId === sessionId) {
+        if (releasingCurrent) {
           cancelCrossSessionTransition(
             'Session transition cancelled by release',
           );
@@ -1223,7 +1284,11 @@ export function createDaemonSessionActions({
           session.client.closeSession(sessionId),
           'Release session timed out',
         );
+        if (releasingCurrent) clearClosedRecoverySession(session);
       } catch (error) {
+        if (releasingCurrent && isSessionRecoveryLocked()) {
+          resumeSessionRecovery();
+        }
         throw dispatchActionError(
           addNotice,
           'Release session failed',
@@ -1243,7 +1308,11 @@ export function createDaemonSessionActions({
       );
       try {
         await withActionTimeout(session.close(), 'Close session timed out');
+        clearClosedRecoverySession(session);
       } catch (error) {
+        if (sessionRef.current === session && isSessionRecoveryLocked()) {
+          resumeSessionRecovery();
+        }
         throw dispatchActionError(
           noticeForSession(session),
           'Close session failed',
@@ -1495,7 +1564,9 @@ export function createDaemonSessionActions({
       message: string,
       opts?: { signal?: AbortSignal; messageId?: string },
     ): Promise<DaemonMidTurnMessageResult> {
-      if (isCrossSessionTransitionPending()) return { accepted: false };
+      if (isCrossSessionTransitionPending() || isSessionRecoveryLocked()) {
+        return { accepted: false };
+      }
       // Calls without an id are the old-daemon compatibility path and fall back
       // locally. With a stable id, transport failure is ambiguous (the POST may
       // already have committed), so let the caller reconcile instead of
@@ -1525,6 +1596,7 @@ export function createDaemonSessionActions({
       messageId: string,
       opts,
     ): Promise<DaemonRemoveMidTurnMessageResult> {
+      requireRecoveryWritable();
       const session = sessionRef.current;
       if (!session) return { removed: false };
       if (opts?.sessionId && session.sessionId !== opts.sessionId) {
@@ -1576,6 +1648,7 @@ export function createDaemonSessionActions({
     },
 
     async removePendingPrompt(promptId: string, opts) {
+      requireRecoveryWritable();
       const session = sessionRef.current;
       if (!session) return { removed: false };
       if (opts?.sessionId && session.sessionId !== opts.sessionId) {
@@ -1612,6 +1685,7 @@ export function createDaemonSessionActions({
         if (activePromptsRef.current.get(shellKey)?.controller === ctrl) {
           activePromptsRef.current.delete(shellKey);
         }
+        onPromptAdmissionSettled();
         if (isCurrentLogicalSession(session) && !hasSessionActivePrompt()) {
           setPromptStatus('idle');
         }
@@ -1649,6 +1723,7 @@ export function createDaemonSessionActions({
     },
 
     async cancelTask(taskId: string, kind: DaemonSessionTaskStatus['kind']) {
+      requireRecoveryWritable();
       const session = requireSessionForAction(
         addNotice,
         sessionRef.current,
@@ -1722,6 +1797,7 @@ export function createDaemonSessionActions({
       requestId: string,
       response: PermissionResponse,
     ): Promise<boolean> {
+      requireRecoveryWritable();
       const session = requireSessionForAction(
         addNotice,
         sessionRef.current,

--- a/packages/webui/src/daemon/session/types.ts
+++ b/packages/webui/src/daemon/session/types.ts
@@ -54,7 +54,7 @@ export type DaemonConnectionStatus =
 export interface DaemonSessionTransition {
   phase: 'queued' | 'preparing' | 'failed';
   operation: 'load' | 'resume';
-  origin: 'action' | 'controlled';
+  origin: 'action' | 'controlled' | 'recovery';
   targetSessionId: string;
   targetWorkspaceCwd?: string;
   targetClientId?: string;
@@ -114,6 +114,8 @@ export interface DaemonConnectionState {
   errorStatus?: number;
   /** True only when the server confirmed the current session is missing. */
   missingSession?: boolean;
+  /** The retained session has a known event gap and is read-only until resynced. */
+  sessionRecoveryRequired?: true;
   sessionTransition?: DaemonSessionTransition;
 }
 


### PR DESCRIPTION
<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item on one long line.
-->

## What this PR does

This PR makes authoritative WebUI state resync and live-journal repair transactional. When the daemon reports an event epoch or replay-ring gap, the provider parks the known-gapped source stream but keeps its last valid transcript and attachment visible in a persistent read-only recovery state while a complete replacement snapshot is restored off-screen. The candidate reuses the committed stable client ID, is checked for session/workspace ownership, replay completeness, epoch and watermark integrity, prompt-terminal consistency, and lifecycle freshness, then replaces the source atomically; stale source and candidate registration references are retired exactly once.

The existing provider-local restore coordinator now arbitrates ordinary switching, same-session recovery, and live-journal repair instead of introducing another loader. Replay reconstruction is separated from local prompt-promise settlement so restored terminal state does not append a duplicate assistant terminal. Historical replay does not republish notices, workspace events, or pending/mid-turn events; a single post-commit reconciliation refreshes authoritative side-channel state.

Live-journal repair now stages a full snapshot while the healthy source SSE remains attached, captures a bounded same-epoch source tail, and atomically replaces the truncation marker with the repaired suffix plus that tail. The WebShell main view, split panes, queued-prompt workflow, and provider action layer consistently block session mutations while recovery is preparing or a real gap remains unresolved. No daemon, ACP, REST, or SDK wire schema changes are introduced.

The transactional recovery design and implementation plan are included. Selective transcript restore, branch adoption, durable checkpoints, and other Issue #8678 slices remain independent work.

## Why it's needed

The previous resync path cleared the transcript, session reference, cursor, and source stream before the replacement load succeeded. A delayed or failed restore could therefore hide the last valid conversation and later make a known-gapped owner writable again. Live-journal repair used the same destructive reload path and interrupted an otherwise healthy source stream.

Keeping the committed owner visible but read-only until a fully validated candidate commits avoids empty or mixed-owner UI states, preserves prompt and attachment ownership, and makes recovery failures safely retryable. Transactional repair similarly prevents a temporary marker from destroying a healthy live view.

## Reviewer Test Plan

### How to verify

Force a replay-ring gap for a modern daemon that advertises `client_identity`, then delay the authoritative full-load response. Confirm that the existing transcript remains visible, the request omits `historyPageSize`, and prompts, queue edits, model/mode changes, shell, cancel, permission, task, Goal, and other session mutations are rejected while read-only inspection and navigation remain available. Release the response and confirm that the complete snapshot appears in one commit, the recovery lock clears, subsequent prompts work, and source/candidate attachment counts return to baseline.

Repeat with a structured retryable failure and with a permanent or integrity failure. Only pre-attachment `session_closing`, ordinary `restore_in_progress`, and retryable `acp_channel_unavailable` conditions should retry within the shared deadline; unknown network outcomes, timeouts, abandoned cleanup, generic HTTP failures, and invalid candidates should leave the retained owner read-only until explicit reload, navigation, or lifecycle cleanup.

For live-journal repair, delay the completed repair load after a truncation marker appears. Confirm that the marker and source stream remain present and writes are blocked during staging. Release the response and verify that the complete turn replaces the marker atomically, the concurrently captured source tail is preserved, no historical side effect or transcript terminal is duplicated, and attachment counts return to baseline.

Automated verification completed on the final implementation: 366/366 focused WebUI tests, 574/574 affected WebShell tests, 2/2 deterministic real-daemon integration tests, focused Prettier and ESLint checks, `npm run build`, `npm run typecheck`, and `npm run bundle`. Two consecutive broad clean diff audits and a final Codex review found no actionable correctness issue.

### Evidence (Before & After)

Before: on `state_resync_required`, the production provider reset the visible store and current session before issuing `/load`; holding that load produced an empty transcript. Live-journal repair also re-entered the destructive reload path and stopped the healthy source stream.

After: a deterministic real-daemon test uses a three-event ring, intentionally pauses the Provider reconnect, advances the daemon beyond the retained cursor, and observes a genuine `ring_evicted` recovery. While the recovery `/load` is held, the seed transcript remains visible, the gap turn is not partially exposed, the session is read-only, and the request is authoritative `load/all`. Releasing it commits the seed and gap turns exactly once, preserves chunk and terminal counts, accepts a subsequent prompt, and restores the client/attach/subscriber ledger to baseline. A second real-daemon test holds live-journal repair and proves the marker and sole source subscriber remain installed until the complete `chunk-0` through `chunk-19` turn commits once.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS, Node.js v22.22.3, Vitest production-provider/JSDOM harness, and the repository real-daemon integration harness with sandbox disabled.

## Risk & Scope

- Main risk or tradeoff: Recovery scheduling, prompt ownership, and attachment handoff are concurrency-sensitive, and staging temporarily holds the visible transcript together with a full candidate replay. The implementation contains this with one existing coordinator, a single absolute deadline, identity/generation fences, bounded repair-tail capture, and reference-counted cleanup. Because this is a cross-package WebUI/WebShell behavioral change with a substantial production diff, maintainer review is explicitly requested.
- Not validated / out of scope: Selective JSONL restore, branch creation/adoption, durable checkpoints, daemon protocol changes, large-session restore performance, and a process-wide attachment scheduler are out of scope. Real daemon coverage deterministically exercises `ring_evicted`; epoch-reset transport behavior remains covered at the EventBus and Provider unit layers. Windows and Linux were not tested locally.
- Breaking changes / migration notes: No wire or persisted-data migration. Modern transactional recovery requires an explicit `client_identity` capability and concrete client IDs; daemons that explicitly lack the feature retain legacy behavior, while missing or malformed modern ownership fails closed. There is no feature flag; operational rollback is a revert of this vertical slice.

## Linked Issues

Refs #8678

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 将 WebUI 的权威状态 resync 和 live-journal repair 改为事务化执行。当 daemon 报告 event epoch 或 replay ring 缺口时，Provider 会 park 已知存在缺口的 source stream，但保留其最后一段合法 transcript 和 attachment，以持久只读恢复状态继续显示，同时在屏幕外恢复完整替换快照。Candidate 复用已提交的 stable client ID，并校验 session/workspace ownership、replay 完整性、epoch 与 watermark、prompt terminal 一致性及 lifecycle freshness，之后才原子替换 source；stale source 和 candidate 的 registration reference 各自只退役一次。

现有 Provider-local restore coordinator 现在统一仲裁普通切换、同会话恢复和 live-journal repair，不引入另一套 loader。Replay 重建与本地 prompt promise 结算被拆开，恢复出的 terminal state 不会再追加重复的 assistant terminal。历史 replay 不会重新发布 notice、workspace event 或 pending/mid-turn event；提交后只执行一次 reconciliation 来刷新权威 side-channel 状态。

Live-journal repair 现在会在健康 source SSE 保持 attached 的同时 staging 完整快照，捕获同 epoch 的有界 source tail，并将 truncation marker、修复 suffix 和 tail 原子替换。WebShell 主视图、split pane、queued-prompt workflow 和 Provider action 层在恢复准备期间或真实缺口尚未解除时一致阻断 session mutation。本 PR 不修改 daemon、ACP、REST 或 SDK wire schema。

本 PR 同时包含事务恢复设计与实施计划。Selective transcript restore、branch adoption、durable checkpoint 以及 Issue #8678 的其他切片继续作为独立工作。

## 为什么需要它

此前的 resync 路径会在替换 load 成功前清空 transcript、session reference、cursor 和 source stream。延迟或失败的 restore 因而可能隐藏最后一段合法对话，并在之后把已知存在缺口的 owner 重新开放写入。Live-journal repair 也复用了同一破坏性 reload 路径，会中断原本健康的 source stream。

在完整校验的 candidate 提交前保持 committed owner 可见但只读，可以避免空白或混合 owner 的 UI 状态，保留 prompt 与 attachment ownership，并让恢复失败能够安全重试。事务化 repair 同样避免临时 marker 破坏健康的 live view。

## Reviewer 测试计划

### 如何验证

对声明 `client_identity` 的现代 daemon 制造 replay-ring 缺口，然后延迟权威 full-load response。确认现有 transcript 始终可见，请求不包含 `historyPageSize`，且 prompt、queue edit、model/mode change、shell、cancel、permission、task、Goal 及其他 session mutation 被拒绝；只读查看和导航仍可使用。释放响应后，确认完整快照一次性提交、恢复锁清除、后续 prompt 可用，并且 source/candidate 的 attachment count 回到基线。

分别使用结构化可重试错误和永久或完整性错误重复验证。只有 attachment 建立前的 `session_closing`、普通 `restore_in_progress` 和可重试 `acp_channel_unavailable` 才能在共享 deadline 内重试；未知 network outcome、timeout、abandoned cleanup、通用 HTTP failure 和非法 candidate 必须让保留 owner 持续只读，直到显式 reload、导航或 lifecycle cleanup。

对于 live-journal repair，在 truncation marker 出现后延迟已完成的 repair load。确认 staging 期间 marker 与 source stream 持续存在，写操作被阻断。释放响应后验证完整 turn 原子替换 marker，并发捕获的 source tail 得到保留，历史 side effect 和 transcript terminal 不会重复，attachment count 回到基线。

最终实现已完成自动化验证：366/366 个 focused WebUI 测试、574/574 个受影响 WebShell 测试、2/2 个确定性真实 daemon 集成测试、focused Prettier 与 ESLint 检查、`npm run build`、`npm run typecheck` 和 `npm run bundle`。连续两轮全面 clean diff 审计及最终 Codex review 均未发现可行动的正确性问题。

### 证据（修改前与修改后）

修改前：收到 `state_resync_required` 时，production Provider 会在发起 `/load` 前重置可见 store 和当前 session；hold 该 load 会得到空白 transcript。Live-journal repair 同样会重新进入破坏性 reload 路径并停止健康的 source stream。

修改后：确定性真实 daemon 测试使用三事件 ring，主动暂停 Provider reconnect，让 daemon 推进超过保留 cursor，并观察到真实 `ring_evicted` 恢复。Hold 恢复 `/load` 期间，seed transcript 始终可见，gap turn 不会部分暴露，session 处于只读状态，请求是权威 `load/all`。释放后，seed 和 gap turn 各提交一次，chunk 与 terminal 数量正确，后续 prompt 可用，client/attach/subscriber ledger 回到基线。第二个真实 daemon 测试 hold live-journal repair，证明 marker 和唯一 source subscriber 会持续安装，直到完整的 `chunk-0` 至 `chunk-19` turn 只提交一次。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS、Node.js v22.22.3、Vitest production-provider/JSDOM harness，以及关闭 sandbox 的仓库真实 daemon integration harness。

## 风险与范围

- 主要风险或权衡：恢复调度、prompt ownership 和 attachment handoff 对并发敏感，staging 期间会短暂同时持有可见 transcript 和完整 candidate replay。实现通过复用单一 coordinator、单个绝对 deadline、identity/generation fence、有界 repair-tail capture 和引用计数清理来控制风险。由于这是跨 WebUI/WebShell package 的行为变更且 production diff 较大，明确请求 maintainer review。
- 未验证/范围外：selective JSONL restore、branch creation/adoption、durable checkpoint、daemon 协议变更、大型会话 restore 性能和 process-wide attachment scheduler 不在本 PR 范围内。真实 daemon 覆盖确定性验证 `ring_evicted`；epoch-reset transport behavior 保留在 EventBus 与 Provider unit 层覆盖。Windows 和 Linux 未在本地测试。
- 破坏性变更/迁移说明：没有 wire 或 persisted-data migration。现代事务恢复要求明确的 `client_identity` capability 和具体 client ID；明确缺少该 feature 的 daemon 保留 legacy behavior，缺失或格式错误的现代 ownership 则 fail closed。不增加 feature flag；线上回滚方式是 revert 整个 vertical slice。

## 关联 Issue

Refs #8678

</details>
