### PR TITLE
test(webui): drain the batched transcript dispatch with two timer hops

### DIFF
--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -16237,7 +16237,16 @@ async function flushPromises(): Promise<void> {
 // SSE events coalesces into one reducer pass. Stay-alive mock generators never
 // end the consumer loop (which would flush synchronously), so tests that assert
 // transcript state mid-stream drain the batched dispatch here.
+// Two chained timer hops, not one: the dispatch timer and this helper's first
+// timer are registered from concurrently-draining microtask chains, so their
+// registration order is unspecified, and Node drains microtasks between timer
+// callbacks — a single hop registered first would resume the test (and its
+// assertions) before the dispatch timer ever fires. The dispatch timer is
+// always registered during the microtask drain that precedes the first hop's
+// callback, so the second hop — registered after that callback — is
+// guaranteed to fire after the dispatch has run.
 async function flushTranscriptDispatch(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
   await new Promise((resolve) => setTimeout(resolve, 0));
   await Promise.resolve();
   await Promise.resolve();


### PR DESCRIPTION
## What this PR does

Fixes the flaky `DaemonSessionProvider` test `keeps the current attachment live while a same-session load fails`, which failed the Release Quality Checks on `main` (run [31665796236](https://github.com/QwenLM/qwen-code/actions/runs/31665796236/job/94340231638)) with `expected [ 'A transcript' ] to deeply equal [ 'A transcript', ' still live' ]`. The test helper `flushTranscriptDispatch` now awaits two chained `setTimeout(0)` hops instead of one before test assertions read the transcript.

## Why it's needed

The provider batches transcript events onto a single `setTimeout(0)` macrotask. The helper also waited exactly one `setTimeout(0)` hop. Those two timers are registered from two concurrently-draining microtask chains — the event-consumer chain (mock generator resume → `for await` → `enqueueTranscriptEvents`) and the test chain (`flushPromises()` → `flushTranscriptDispatch()`) — so their registration order is unspecified. Instrumenting `setTimeout` in the failing runs shows the helper's timer registering **before** the dispatch timer; since Node drains the microtask queue between timer callbacks, the helper's single hop resumed the test and ran the assertion before the dispatch timer ever fired, so the streamed `' still live'` block was missing. Whether a given run passed depended on whether `await act(...)`'s exit path happened to cross one more macrotask (letting the dispatch timer slip in), which is why the failure was intermittent (~10% locally) rather than deterministic.

Two chained hops close the window structurally: the dispatch timer is always registered during the microtask drain that precedes the first hop's callback, so the second hop — registered after that callback — is guaranteed to fire after the dispatch has run, regardless of which chain registered its timer first. This is a test-only change; the provider's macrotask batching is intentional (it coalesces event bursts into one reducer pass) and is untouched.

## Reviewer Test Plan

### How to verify

Repro is a plain repetition loop in `packages/webui` (no load or stress needed); the fix is judged by the same loop going clean. Baseline vs fixed on the same machine, same code, with the 9-line helper change as the only variable:

| Scenario | Before (single hop) | After (two hops) |
| --- | --- | --- |
| `vitest run … -t 'keeps the current attachment live'` loop | 6/60 failed (~10%) | **0/100 failed** |
| Full `DaemonSessionProvider.test.tsx`, Node 24.18.1 | 1/15 failed | **0/15 failed** |
| Full `DaemonSessionProvider.test.tsx`, Node 22.23.2 (CI's version) | 3/15 failed | **0/15 failed** |

Every baseline failure is the exact CI assertion (`expected [ 'A transcript' ] to deeply equal [ 'A transcript', ' still live' ]`). The Node 22 leg rules out the Node `22.23.1 → 22.23.2` bump between the passing and failing Release runs as the cause — both versions reproduce the flake before the fix.

All 10 existing `flushTranscriptDispatch()` call sites in the file want "drain the batched dispatch", so strengthening the drain is safe for all of them — including the two absence assertions (`not.toContain('stale output')`, `not.toEqual(...)`), which the extra hop only makes stricter. The full-file loops above cover them.

### Evidence (Before & After)

N/A — test-timing change; the before/after failure rates above are the evidence.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only: `vitest run` in `packages/webui`, Node 24.18.1 and Node 22.23.2 (the version the failing CI job used).

## Risk & Scope

- Main risk or tradeoff: each helper call now takes one extra macrotask hop, marginally slowing the 10 call sites; the drain becomes strictly stronger, never weaker.
- Not validated / out of scope: the provider's dispatch batching itself is untouched; no product code changes.
- Breaking changes / migration notes: none.

## Linked Issues

The flaky test was introduced with the same-session refresh coverage in #8939 (and extended in #8990); the failing run was Release run 31665796236 on `main`.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修复 `DaemonSessionProvider` 的 flaky 测试 `keeps the current attachment live while a same-session load fails`。它在 `main` 的 Release Quality Checks(run [31665796236](https://github.com/QwenLM/qwen-code/actions/runs/31665796236/job/94340231638))中以 `expected [ 'A transcript' ] to deeply equal [ 'A transcript', ' still live' ]` 失败。测试助手 `flushTranscriptDispatch` 现在在断言读取 transcript 之前等待**两跳**链式 `setTimeout(0)`,而不是一跳。

## 为什么需要

provider 把 transcript 事件批量派发挂在单个 `setTimeout(0)` 宏任务上,而助手也只等恰好一跳 `setTimeout(0)`。这两个计时器分别从两条并行清空的微任务链注册——事件消费链(mock 生成器恢复 → `for await` → `enqueueTranscriptEvents`)和测试链(`flushPromises()` → `flushTranscriptDispatch()`)——注册顺序不受保证。对失败运行插桩 `setTimeout` 显示助手的计时器**先于**派发计时器注册;由于 Node 在相邻计时器回调之间会清空微任务队列,助手的单跳直接把测试推进到断言,派发计时器根本没来得及触发,流式增量块 `' still live'` 自然缺失。某次运行是否通过,取决于 `await act(...)` 的退出路径是否恰好多跨一个宏任务(让派发计时器插进来),因此故障呈间歇性(本地约 10%)而非确定性。

两跳链式等待在结构上关闭了这个窗口:派发计时器必定在首跳回调之前的微任务清空阶段注册,因此第二跳——注册于首跳回调之后——无论两条链谁先注册计时器,都保证在派发完成之后才触发。这是纯测试改动;provider 的宏任务批量派发是有意设计(把事件突发合并为一次 reducer 执行),不做改动。

## Reviewer Test Plan

### 如何验证

复现只需在 `packages/webui` 里做普通重复循环(无需负载或压力);修复以同一循环跑干净为判据。同机同码 A/B,唯一变量是这 9 行助手改动:

| 场景 | 修复前(单跳) | 修复后(两跳) |
| --- | --- | --- |
| `vitest run … -t 'keeps the current attachment live'` 循环 | 6/60 失败(约 10%) | **0/100 失败** |
| 整文件 `DaemonSessionProvider.test.tsx`,Node 24.18.1 | 1/15 失败 | **0/15 失败** |
| 整文件 `DaemonSessionProvider.test.tsx`,Node 22.23.2(CI 版本) | 3/15 失败 | **0/15 失败** |

每次基线失败都是与 CI 完全相同的断言(`expected [ 'A transcript' ] to deeply equal [ 'A transcript', ' still live' ]`)。Node 22 一组排除了通过/失败两次 Release run 之间 Node `22.23.1 → 22.23.2` 升级作为原因——修复前两个版本都能复现。

文件内现有 10 处 `flushTranscriptDispatch()` 调用点的意图都是"排空批量派发",加强排空对所有调用点都安全——包括两处"排除型"断言(`not.toContain('stale output')`、`not.toEqual(...)`),额外一跳只会让它们更严格。上面的整文件循环覆盖了它们。

### 证据(Before & After)

N/A——测试时序改动;上面的修复前后失败率即证据。

### 测试环境

仅单元测试:`packages/webui` 下 `vitest run`,Node 24.18.1 与 Node 22.23.2(失败 CI job 使用的版本)。

## 风险与范围

- 主要风险或权衡:每次助手调用多一跳宏任务,10 处调用点略微变慢;排空只会更强,不会更弱。
- 未验证/超出范围:provider 的派发批量机制本身未动;无产品代码改动。
- 破坏性变更/迁移说明:无。

## 关联 Issue

该 flaky 测试随 #8939 的同会话刷新覆盖引入(#8990 有扩展);失败运行为 `main` 上的 Release run 31665796236。

</details>
