### PR TITLE
fix(desktop): hide the Windows runtime terminal and align reduced-motion startup

### DIFF
--- a/packages/acp-bridge/src/spawnChannel.test.ts
+++ b/packages/acp-bridge/src/spawnChannel.test.ts
@@ -131,8 +131,9 @@ describe('createSpawnChannelFactory env policy', () => {
     });
 
     const spawnOptions = mockSpawn.mock.calls[0]?.[2] as
-      | { env?: NodeJS.ProcessEnv }
+      | { env?: NodeJS.ProcessEnv; windowsHide?: boolean }
       | undefined;
+    expect(spawnOptions?.windowsHide).toBe(true);
     expect(spawnOptions?.env).not.toHaveProperty('QWEN_CODE_SIMPLE');
     expect(spawnOptions?.env).not.toHaveProperty('QWEN_SERVER_TOKEN');
     expect(spawnOptions?.env).not.toHaveProperty(

--- a/packages/acp-bridge/src/spawnChannel.ts
+++ b/packages/acp-bridge/src/spawnChannel.ts
@@ -474,6 +474,7 @@ export function createSpawnChannelFactory(
         {
           cwd: workspaceCwd,
           stdio: ['pipe', 'pipe', 'pipe'],
+          windowsHide: true,
           env: childEnv,
         },
       );

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -127,6 +127,7 @@ const mockProcessKill = vi
 // to avoid PATH/CWD binary planting. Compute the expected path the same way so
 // assertions stay in sync across platforms (SystemRoot is unset off Windows).
 const TASKKILL = `${process.env['SystemRoot'] || 'C:\\Windows'}\\System32\\taskkill.exe`;
+const HIDDEN_WINDOW = { windowsHide: true };
 const CHCP = `${process.env['SystemRoot'] || 'C:\\Windows'}\\System32\\chcp.com`;
 
 const shellExecutionConfig = {
@@ -1411,29 +1412,27 @@ describe('ShellExecutionService', () => {
       expect(result.aborted).toBe(true);
       // Cancel tree-kills (/t) SYNCHRONOUSLY (spawnSync) so taskkill enumerates
       // the tree before ptyProcess.kill() fires ClosePseudoConsole. See #5873.
-      expect(mockSpawnSync).toHaveBeenCalledWith(TASKKILL, [
-        '/f',
-        '/t',
-        '/pid',
-        String(mockPtyProcess.pid),
-      ]);
+      expect(mockSpawnSync).toHaveBeenCalledWith(
+        TASKKILL,
+        ['/f', '/t', '/pid', String(mockPtyProcess.pid)],
+        HIDDEN_WINDOW,
+      );
       // The finalizer reap (async cpSpawn via windowsKillPid) must ALSO
       // tree-kill on cancel — positively asserted so removing the reap or
       // forcing cancelKillDispatched=false fails here, not just trivially via
       // the negative check below. See #5873.
-      expect(mockCpSpawn).toHaveBeenCalledWith(TASKKILL, [
-        '/f',
-        '/t',
-        '/pid',
-        String(mockPtyProcess.pid),
-      ]);
+      expect(mockCpSpawn).toHaveBeenCalledWith(
+        TASKKILL,
+        ['/f', '/t', '/pid', String(mockPtyProcess.pid)],
+        HIDDEN_WINDOW,
+      );
       // ...and it must never downgrade to a shell-only (/f without /t) kill
       // that could leave the abandoned descendant tree behind. See #5873.
-      expect(mockCpSpawn).not.toHaveBeenCalledWith(TASKKILL, [
-        '/f',
-        '/pid',
-        String(mockPtyProcess.pid),
-      ]);
+      expect(mockCpSpawn).not.toHaveBeenCalledWith(
+        TASKKILL,
+        ['/f', '/pid', String(mockPtyProcess.pid)],
+        HIDDEN_WINDOW,
+      );
       // ...and still calls ptyProcess.kill() so that if taskkill cannot launch,
       // the ConPTY host is torn down and onExit fires (the cancel can't hang).
       // See #5873.
@@ -1457,17 +1456,16 @@ describe('ShellExecutionService', () => {
       expect(result.exitCode).toBe(0);
       // Reap kills only the shell pid — no /t — so a child the command
       // intentionally detached (e.g. Start-Process) survives. See #5873.
-      expect(mockCpSpawn).toHaveBeenCalledWith(TASKKILL, [
-        '/f',
-        '/pid',
-        String(mockPtyProcess.pid),
-      ]);
-      expect(mockCpSpawn).not.toHaveBeenCalledWith(TASKKILL, [
-        '/f',
-        '/t',
-        '/pid',
-        String(mockPtyProcess.pid),
-      ]);
+      expect(mockCpSpawn).toHaveBeenCalledWith(
+        TASKKILL,
+        ['/f', '/pid', String(mockPtyProcess.pid)],
+        HIDDEN_WINDOW,
+      );
+      expect(mockCpSpawn).not.toHaveBeenCalledWith(
+        TASKKILL,
+        ['/f', '/t', '/pid', String(mockPtyProcess.pid)],
+        HIDDEN_WINDOW,
+      );
     });
 
     it('normal completion on win32 swallows a taskkill launch error (no crash)', async () => {
@@ -1514,6 +1512,7 @@ describe('ShellExecutionService', () => {
         expect(mockCpSpawn).not.toHaveBeenCalledWith(
           TASKKILL,
           expect.anything(),
+          HIDDEN_WINDOW,
         );
       } finally {
         // clearAllMocks() resets calls but not implementations — restore the
@@ -1529,7 +1528,11 @@ describe('ShellExecutionService', () => {
       });
 
       expect(result.exitCode).toBe(0);
-      expect(mockCpSpawn).not.toHaveBeenCalledWith(TASKKILL, expect.anything());
+      expect(mockCpSpawn).not.toHaveBeenCalledWith(
+        TASKKILL,
+        expect.anything(),
+        HIDDEN_WINDOW,
+      );
     });
 
     it('exit cleanup on win32 tree-kills via taskkill and tears down the host', () => {
@@ -1546,12 +1549,11 @@ describe('ShellExecutionService', () => {
       ShellExecutionService.cleanup();
       ShellExecutionService['activePtys'].delete(pid);
 
-      expect(mockSpawnSync).toHaveBeenCalledWith(TASKKILL, [
-        '/f',
-        '/t',
-        '/pid',
-        String(pid),
-      ]);
+      expect(mockSpawnSync).toHaveBeenCalledWith(
+        TASKKILL,
+        ['/f', '/t', '/pid', String(pid)],
+        HIDDEN_WINDOW,
+      );
       // The ConPTY host is torn down unconditionally, alongside the tree-kill.
       expect(mockPtyProcess.kill).toHaveBeenCalled();
     });
@@ -1622,17 +1624,17 @@ describe('ShellExecutionService', () => {
 
         expect(result.aborted).toBe(true);
         // performCancelKill's sync tree-kill still runs...
-        expect(mockSpawnSync).toHaveBeenCalledWith(TASKKILL, [
-          '/f',
-          '/t',
-          '/pid',
-          String(mockPtyProcess.pid),
-        ]);
+        expect(mockSpawnSync).toHaveBeenCalledWith(
+          TASKKILL,
+          ['/f', '/t', '/pid', String(mockPtyProcess.pid)],
+          HIDDEN_WINDOW,
+        );
         // ...but the finalizer reap is skipped (isPtyActive false via ESRCH),
         // so no async taskkill fires there.
         expect(mockCpSpawn).not.toHaveBeenCalledWith(
           TASKKILL,
           expect.anything(),
+          HIDDEN_WINDOW,
         );
       } finally {
         mockProcessKill.mockImplementation(() => true);
@@ -1670,12 +1672,11 @@ describe('ShellExecutionService', () => {
 
       // Pins killChildProcesses on the absolute System32 path — a regression to
       // the bare 'taskkill' name reopens the binary-planting hole. See #5873.
-      expect(mockSpawnSync).toHaveBeenCalledWith(TASKKILL, [
-        '/f',
-        '/t',
-        '/pid',
-        String(childPid),
-      ]);
+      expect(mockSpawnSync).toHaveBeenCalledWith(
+        TASKKILL,
+        ['/f', '/t', '/pid', String(childPid)],
+        HIDDEN_WINDOW,
+      );
     });
 
     it('win32 taskkill is invoked by absolute System32 path, not the bare name', async () => {
@@ -1713,17 +1714,16 @@ describe('ShellExecutionService', () => {
       );
 
       expect(result.exitCode).toBe(0);
-      expect(mockCpSpawn).toHaveBeenCalledWith(TASKKILL, [
-        '/f',
-        '/pid',
-        String(mockPtyProcess.pid),
-      ]);
-      expect(mockCpSpawn).not.toHaveBeenCalledWith(TASKKILL, [
-        '/f',
-        '/t',
-        '/pid',
-        String(mockPtyProcess.pid),
-      ]);
+      expect(mockCpSpawn).toHaveBeenCalledWith(
+        TASKKILL,
+        ['/f', '/pid', String(mockPtyProcess.pid)],
+        HIDDEN_WINDOW,
+      );
+      expect(mockCpSpawn).not.toHaveBeenCalledWith(
+        TASKKILL,
+        ['/f', '/t', '/pid', String(mockPtyProcess.pid)],
+        HIDDEN_WINDOW,
+      );
     });
 
     it('win32 promoted shell reaps its lingering pwsh on natural exit (shell-pid-only)', async () => {
@@ -1754,17 +1754,16 @@ describe('ShellExecutionService', () => {
       postPromoteExitHandler({ exitCode: 0, signal: undefined });
 
       expect(settleCalls).toHaveLength(1);
-      expect(mockCpSpawn).toHaveBeenCalledWith(TASKKILL, [
-        '/f',
-        '/pid',
-        String(mockPtyProcess.pid),
-      ]);
-      expect(mockCpSpawn).not.toHaveBeenCalledWith(TASKKILL, [
-        '/f',
-        '/t',
-        '/pid',
-        String(mockPtyProcess.pid),
-      ]);
+      expect(mockCpSpawn).toHaveBeenCalledWith(
+        TASKKILL,
+        ['/f', '/pid', String(mockPtyProcess.pid)],
+        HIDDEN_WINDOW,
+      );
+      expect(mockCpSpawn).not.toHaveBeenCalledWith(
+        TASKKILL,
+        ['/f', '/t', '/pid', String(mockPtyProcess.pid)],
+        HIDDEN_WINDOW,
+      );
     });
 
     it('win32 promoted shell reaps on natural exit even with onData only (no onSettle)', async () => {
@@ -1790,11 +1789,11 @@ describe('ShellExecutionService', () => {
         onExitRegistrations[onExitRegistrations.length - 1][0];
       postPromoteExitHandler({ exitCode: 0, signal: undefined });
 
-      expect(mockCpSpawn).toHaveBeenCalledWith(TASKKILL, [
-        '/f',
-        '/pid',
-        String(mockPtyProcess.pid),
-      ]);
+      expect(mockCpSpawn).toHaveBeenCalledWith(
+        TASKKILL,
+        ['/f', '/pid', String(mockPtyProcess.pid)],
+        HIDDEN_WINDOW,
+      );
     });
 
     it('win32 promoted shell skips the post-settle reap when the pty already exited', async () => {
@@ -1834,6 +1833,7 @@ describe('ShellExecutionService', () => {
         expect(mockCpSpawn).not.toHaveBeenCalledWith(
           TASKKILL,
           expect.anything(),
+          HIDDEN_WINDOW,
         );
       } finally {
         mockProcessKill.mockImplementation(() => true);
@@ -2632,12 +2632,11 @@ describe('ShellExecutionService child_process fallback', () => {
               expectedSignal,
             );
           } else {
-            expect(mockCpSpawn).toHaveBeenCalledWith(expectedCommand, [
-              '/f',
-              '/t',
-              '/pid',
-              String(mockChildProcess.pid),
-            ]);
+            expect(mockCpSpawn).toHaveBeenCalledWith(
+              expectedCommand,
+              ['/f', '/t', '/pid', String(mockChildProcess.pid)],
+              HIDDEN_WINDOW,
+            );
           }
         });
       },

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -550,6 +550,7 @@ interface ProcessCleanupStrategy {
 // workspace or on PATH could run from these cleanup paths with the CLI's
 // environment — arbitrary code execution out of a benign teardown. See #5873.
 const WINDOWS_TASKKILL = `${process.env['SystemRoot'] || 'C:\\Windows'}\\System32\\taskkill.exe`;
+const WINDOWS_TASKKILL_OPTIONS = { windowsHide: true } as const;
 
 const windowsKillPid = (pid: number, tree: boolean): void => {
   try {
@@ -558,7 +559,7 @@ const windowsKillPid = (pid: number, tree: boolean): void => {
     const args = tree
       ? ['/f', '/t', '/pid', pid.toString()]
       : ['/f', '/pid', pid.toString()];
-    const killer = cpSpawn(WINDOWS_TASKKILL, args);
+    const killer = cpSpawn(WINDOWS_TASKKILL, args, WINDOWS_TASKKILL_OPTIONS);
     // Log (don't crash on) a failed launch: silently swallowing it would let
     // the #5873 pwsh leak quietly return with no diagnostic trail under
     // enterprise lockdown / EMFILE / antivirus interception.
@@ -597,7 +598,11 @@ const windowsStrategy: ProcessCleanupStrategy = {
       // before the process dies (and a sync stderr write would be exit-time
       // noise). The unconditional ptyProcess.kill() below is the mitigation;
       // the runtime reap paths (windowsKillPid), which DO flush, keep logging.
-      spawnSync(WINDOWS_TASKKILL, ['/f', '/t', '/pid', pid.toString()]);
+      spawnSync(
+        WINDOWS_TASKKILL,
+        ['/f', '/t', '/pid', pid.toString()],
+        WINDOWS_TASKKILL_OPTIONS,
+      );
     } catch {
       // ignore
     }
@@ -621,7 +626,7 @@ const windowsStrategy: ProcessCleanupStrategy = {
         }
         // No logging — like killPty, this runs only from the 'exit' handler
         // where an async debug write can't flush before the process dies.
-        spawnSync(WINDOWS_TASKKILL, args);
+        spawnSync(WINDOWS_TASKKILL, args, WINDOWS_TASKKILL_OPTIONS);
       } catch {
         // ignore
       }
@@ -1332,12 +1337,11 @@ export class ShellExecutionService {
         const performCancelKill = async (): Promise<void> => {
           if (!child.pid || exited) return;
           if (isWindows) {
-            const killer = cpSpawn(WINDOWS_TASKKILL, [
-              '/f',
-              '/t',
-              '/pid',
-              child.pid.toString(),
-            ]);
+            const killer = cpSpawn(
+              WINDOWS_TASKKILL,
+              ['/f', '/t', '/pid', child.pid.toString()],
+              WINDOWS_TASKKILL_OPTIONS,
+            );
             // taskkill can fail two ways, and either would otherwise hang the
             // cancel (the abort waits for a child exit that never comes), so
             // fall back to killing the child directly in both:
@@ -2312,12 +2316,11 @@ export class ShellExecutionService {
             // cancel path). ptyProcess.kill() alone doesn't tree-kill under
             // ConPTY (microsoft/node-pty#333).
             try {
-              const r = spawnSync(WINDOWS_TASKKILL, [
-                '/f',
-                '/t',
-                '/pid',
-                ptyProcess.pid.toString(),
-              ]);
+              const r = spawnSync(
+                WINDOWS_TASKKILL,
+                ['/f', '/t', '/pid', ptyProcess.pid.toString()],
+                WINDOWS_TASKKILL_OPTIONS,
+              );
               if (r.error || (typeof r.status === 'number' && r.status !== 0)) {
                 debugLogger.warn(
                   `performCancelKill: taskkill failed for pid ${ptyProcess.pid}: ${r.error?.message ?? `exit ${r.status}`}`,

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -3099,12 +3099,13 @@ export class ShellToolInvocation extends BaseToolInvocation<
       if (pid !== undefined) {
         if (os.platform() === 'win32') {
           try {
-            const taskkillChild = childProcess.spawn('taskkill', [
-              '/pid',
-              String(pid),
-              '/f',
-              '/t',
-            ]);
+            const taskkillChild = childProcess.spawn(
+              'taskkill',
+              ['/pid', String(pid), '/f', '/t'],
+              // The desktop runtime daemon has no console; without this
+              // flag each console-app child allocates a visible window.
+              { windowsHide: true },
+            );
             taskkillChild.on('error', () => {
               /* swallow — already in error path */
             });
@@ -3249,12 +3250,13 @@ export class ShellToolInvocation extends BaseToolInvocation<
       if (pid !== undefined) {
         if (os.platform() === 'win32') {
           try {
-            const taskkillChild = childProcess.spawn('taskkill', [
-              '/pid',
-              String(pid),
-              '/f',
-              '/t',
-            ]);
+            const taskkillChild = childProcess.spawn(
+              'taskkill',
+              ['/pid', String(pid), '/f', '/t'],
+              // The desktop runtime daemon has no console; without this
+              // flag each console-app child allocates a visible window.
+              { windowsHide: true },
+            );
             // Without an 'error' listener on the spawned ChildProcess,
             // a taskkill spawn failure (binary missing, permission
             // denied, etc.) would emit 'error' with no listener — which
@@ -3812,7 +3814,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
       const child = childProcess.execFile(
         'git',
         args,
-        { cwd, timeout: 2000 },
+        { cwd, timeout: 2000, windowsHide: true },
         (error, stdout) => {
           if (error) {
             resolve(0);
@@ -3840,7 +3842,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
       const child = childProcess.execFile(
         'git',
         ['rev-parse', 'HEAD'],
-        { cwd, timeout: 2000 },
+        { cwd, timeout: 2000, windowsHide: true },
         (error, stdout) => {
           if (error) {
             resolve(null);
@@ -3874,6 +3876,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
       const stdout = childProcess.execFileSync('git', ['rev-parse', 'HEAD'], {
         cwd,
         timeout: 2000,
+        windowsHide: true,
         // Discard stderr noise (e.g. "fatal: not a git repository") —
         // the catch-or-empty-output path already covers failure.
         stdio: ['ignore', 'pipe', 'ignore'],
@@ -4108,6 +4111,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
             .execFileSync('git', ['show', `${postHead}:${rel}`], {
               cwd,
               timeout: 2000,
+              windowsHide: true,
               stdio: ['ignore', 'pipe', 'ignore'],
               maxBuffer: 16 * 1024 * 1024,
             })
@@ -4193,7 +4197,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
         const child = childProcess.execFile(
           notesCommand.command,
           notesCommand.args,
-          { cwd, timeout: 5000 },
+          { cwd, timeout: 5000, windowsHide: true },
           (error, stdout, stderr) => {
             const merged = (stdout || '') + (stderr || '');
             if (error) {

--- a/packages/desktop-shell/bootstrap/index.html
+++ b/packages/desktop-shell/bootstrap/index.html
@@ -127,21 +127,15 @@
         body[data-state='starting'] .mark {
           animation: none;
         }
-        /* The visible status text stacks under the logo; center both so they
-           share the same horizontal center as the animated logo-only view. */
-        body[data-state='starting'] .shell {
-          display: flex;
-          flex-direction: column;
-          align-items: center;
+        body[data-state='starting'] .brand {
+          justify-content: center;
         }
         body[data-state='starting'] .status {
           position: static;
           width: auto;
           height: auto;
           margin: 18px 0 0;
-          padding: 0;
           overflow: visible;
-          border: 0;
           clip: auto;
           clip-path: none;
           white-space: normal;

--- a/packages/desktop-shell/bootstrap/index.html
+++ b/packages/desktop-shell/bootstrap/index.html
@@ -127,12 +127,21 @@
         body[data-state='starting'] .mark {
           animation: none;
         }
+        /* The visible status text stacks under the logo; center both so they
+           share the same horizontal center as the animated logo-only view. */
+        body[data-state='starting'] .shell {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+        }
         body[data-state='starting'] .status {
           position: static;
           width: auto;
           height: auto;
           margin: 18px 0 0;
+          padding: 0;
           overflow: visible;
+          border: 0;
           clip: auto;
           clip-path: none;
           white-space: normal;

--- a/packages/desktop-shell/scripts/test-release.js
+++ b/packages/desktop-shell/scripts/test-release.js
@@ -68,11 +68,23 @@ async function testBootstrapWorkspaceVisibility() {
     'The bootstrap splash mark must ship with the frontendDist directory.',
   );
   assert.doesNotMatch(bootstrapHtml, /class="mark">Q</);
-  assert.match(
-    bootstrapHtml,
-    /@media \(prefers-reduced-motion: reduce\) \{\s*body\[data-state='starting'\] \.mark \{[^}]*\}\s*body\[data-state='starting'\] \.brand \{[^}]*justify-content: center;[^}]*\}\s*body\[data-state='starting'\] \.status \{[^}]*text-align: center;[^}]*\}/,
-    'The reduced-motion startup view must keep the logo and status text on the same horizontal center.',
+  const reducedMotionBlock = bootstrapHtml.match(
+    /@media \(prefers-reduced-motion: reduce\) \{([\s\S]*?)(?:@media|<\/style>)/,
   );
+  assert.ok(
+    reducedMotionBlock,
+    'The bootstrap splash must keep a reduced-motion media block.',
+  );
+  for (const centeringRule of [
+    /body\[data-state='starting'\] \.brand \{[^}]*justify-content: center;[^}]*\}/,
+    /body\[data-state='starting'\] \.status \{[^}]*text-align: center;[^}]*\}/,
+  ]) {
+    assert.match(
+      reducedMotionBlock[1],
+      centeringRule,
+      'The reduced-motion startup view must keep the logo and status text on the same horizontal center.',
+    );
+  }
   const primary = await createBootstrapHarness();
   const { body, commands, element, listeners, resolveBootstrapState } = primary;
 

--- a/packages/desktop-shell/scripts/test-release.js
+++ b/packages/desktop-shell/scripts/test-release.js
@@ -85,6 +85,15 @@ async function testBootstrapWorkspaceVisibility() {
       'The reduced-motion startup view must keep the logo and status text on the same horizontal center.',
     );
   }
+  const runtimeSource = fs.readFileSync(
+    path.join(packageDir, 'src-tauri', 'src', 'runtime.rs'),
+    'utf8',
+  );
+  assert.match(
+    runtimeSource,
+    /let mut child = spawn_runtime_group\(&mut command\)/,
+    'DesktopRuntime::start must spawn the runtime through the hidden-console helper.',
+  );
   const primary = await createBootstrapHarness();
   const { body, commands, element, listeners, resolveBootstrapState } = primary;
 

--- a/packages/desktop-shell/scripts/test-release.js
+++ b/packages/desktop-shell/scripts/test-release.js
@@ -70,7 +70,7 @@ async function testBootstrapWorkspaceVisibility() {
   assert.doesNotMatch(bootstrapHtml, /class="mark">Q</);
   assert.match(
     bootstrapHtml,
-    /@media \(prefers-reduced-motion: reduce\) \{[\s\S]*body\[data-state='starting'\] \.shell \{[\s\S]*?display: flex;[\s\S]*?flex-direction: column;[\s\S]*?align-items: center;/,
+    /@media \(prefers-reduced-motion: reduce\) \{\s*body\[data-state='starting'\] \.mark \{[^}]*\}\s*body\[data-state='starting'\] \.brand \{[^}]*justify-content: center;[^}]*\}\s*body\[data-state='starting'\] \.status \{[^}]*text-align: center;[^}]*\}/,
     'The reduced-motion startup view must keep the logo and status text on the same horizontal center.',
   );
   const primary = await createBootstrapHarness();

--- a/packages/desktop-shell/scripts/test-release.js
+++ b/packages/desktop-shell/scripts/test-release.js
@@ -68,6 +68,11 @@ async function testBootstrapWorkspaceVisibility() {
     'The bootstrap splash mark must ship with the frontendDist directory.',
   );
   assert.doesNotMatch(bootstrapHtml, /class="mark">Q</);
+  assert.match(
+    bootstrapHtml,
+    /@media \(prefers-reduced-motion: reduce\) \{[\s\S]*body\[data-state='starting'\] \.shell \{[\s\S]*?display: flex;[\s\S]*?flex-direction: column;[\s\S]*?align-items: center;/,
+    'The reduced-motion startup view must keep the logo and status text on the same horizontal center.',
+  );
   const primary = await createBootstrapHarness();
   const { body, commands, element, listeners, resolveBootstrapState } = primary;
 

--- a/packages/desktop-shell/src-tauri/src/local_control.rs
+++ b/packages/desktop-shell/src-tauri/src/local_control.rs
@@ -633,13 +633,19 @@ fn start_sleep_inhibitor() -> Option<Child> {
     #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
     return None;
 
-    Command::new(command.0)
+    let mut child_command = Command::new(command.0);
+    child_command
         .args(command.1)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .ok()
+        .stderr(Stdio::null());
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+        child_command.creation_flags(CREATE_NO_WINDOW);
+    }
+    child_command.spawn().ok()
 }
 
 fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {

--- a/packages/desktop-shell/src-tauri/src/runtime.rs
+++ b/packages/desktop-shell/src-tauri/src/runtime.rs
@@ -62,8 +62,7 @@ impl DesktopRuntime {
             .env("QWEN_CODE_DESKTOP", "1")
             .env("QWEN_SERVER_TOKEN", &token);
 
-        let mut child = command
-            .group_spawn()
+        let mut child = spawn_runtime_group(&mut command)
             .map_err(|error| format!("Failed to start bundled Qwen Code runtime: {error}"))?;
         let Some(stdout) = child.inner().stdout.take() else {
             stop_runtime_child(&mut child);
@@ -139,6 +138,23 @@ impl Drop for DesktopRuntime {
     fn drop(&mut self) {
         self.stop();
     }
+}
+
+// Spawns the runtime child in its own process group. On Windows the bundled
+// Node.js binary is a console application, so creating it from the desktop
+// (a GUI application) without `CREATE_NO_WINDOW` allocates a visible terminal
+// window for it, and closing that window stops the runtime (#9043). The flag
+// must be set through the group builder: `group_spawn` replaces the command's
+// creation flags with the builder's own.
+#[cfg(windows)]
+fn spawn_runtime_group(command: &mut Command) -> std::io::Result<GroupChild> {
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
+    command.group().creation_flags(CREATE_NO_WINDOW).spawn()
+}
+
+#[cfg(not(windows))]
+fn spawn_runtime_group(command: &mut Command) -> std::io::Result<GroupChild> {
+    command.group_spawn()
 }
 
 struct RuntimeLayout {
@@ -543,7 +559,7 @@ mod tests {
     #[cfg(unix)]
     use super::{stop_runtime_handle, wait_for_listening};
     #[cfg(windows)]
-    use super::layout_from_root;
+    use super::{layout_from_root, spawn_runtime_group};
     use std::path::Path;
     #[cfg(windows)]
     use std::path::PathBuf;
@@ -596,6 +612,40 @@ mod tests {
             .expect("cleanup long workspace");
         let error = result.expect_err("reject long workspace");
         assert!(error.contains("unsupported Windows extended-length form"));
+    }
+
+    // The bundled runtime is a console application, so it must be created
+    // with `CREATE_NO_WINDOW`: the probe child reports its own attached
+    // console window, and there must be none (#9043).
+    #[cfg(windows)]
+    #[test]
+    fn runtime_child_gets_no_windows_console() {
+        let probe = concat!(
+            "Add-Type -Namespace QwenDesktop -Name ConsoleProbe",
+            " -MemberDefinition '[DllImport(\"kernel32.dll\")]",
+            " public static extern IntPtr GetConsoleWindow();';",
+            " [QwenDesktop.ConsoleProbe]::GetConsoleWindow().ToInt64()",
+        );
+        let mut command = std::process::Command::new("powershell.exe");
+        command
+            .args(["-NoProfile", "-NonInteractive", "-Command", probe])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+        let output = spawn_runtime_group(&mut command)
+            .expect("spawn hidden runtime child")
+            .wait_with_output()
+            .expect("collect hidden runtime child output");
+        assert!(
+            output.status.success(),
+            "console probe child failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            "0",
+            "the runtime child must not receive a console window"
+        );
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
## What this PR does

This fixes both startup problems from #9043 in Qwen Code Desktop (the Tauri shell in `packages/desktop-shell`). First, the bundled runtime child is now spawned with `CREATE_NO_WINDOW` on Windows, so starting, restarting, or recovering the runtime no longer opens a visible Windows Terminal/console window, and closing unrelated windows can no longer kill the runtime. Second, the bootstrap view's reduced-motion fallback (used when Windows animation effects are disabled) now stacks the logo and the "Starting Qwen Code" status in one centered column and drops the leftover status-card chrome, so both share the same horizontal center as the simplified normal-motion startup view from #8988.

## Why it's needed

The desktop app is a GUI-subsystem Windows process, but the bundled runtime (`node.exe` running `qwen serve`) is a console application. Creating a console child without `CREATE_NO_WINDOW` makes Windows allocate a visible console window for it; closing that window terminates the runtime, and Desktop then reports `Qwen Code stopped: exit code: 1`. The spawn uses `command_group::CommandGroup::group_spawn()`, which replaces any creation flags set directly on the `Command` with the group builder's own flags ORed with `CREATE_SUSPENDED`, so the flag must be passed through the builder (`command.group().creation_flags(...).spawn()`) — this is the exact pattern the crate documents for hiding console windows. The reduced-motion branch of the startup view was left behind when #8988 simplified the normal loading screen: the logo stayed left-aligned in the shell while the newly visible status text sat centered inside a wider card, so the two did not share a horizontal center.

## Reviewer Test Plan

### How to verify

On Windows, build or install the Desktop app and launch it with the default workspace: no separate terminal/console window should appear while the bundled runtime starts, and the app should reach the Web Shell. Trigger a runtime failure and use Retry, or choose another workspace — both restart paths go through the same spawn helper, so no console window should appear there either. With Windows animation effects disabled (Settings > Accessibility > Visual effects, or OS-level `prefers-reduced-motion`), the startup view should show the logo with "Starting Qwen Code" directly beneath it, both on the same horizontal center, with no leftover status-card border or padding. In CI, `cargo test` for `packages/desktop-shell/src-tauri` runs on `windows-2022` and includes the new `runtime_child_gets_no_windows_console` test, which spawns a child through the same helper and asserts the child has no attached console window (`GetConsoleWindow() == 0`). Locally, `node scripts/test-release.js` passes, including the new assertion guarding the reduced-motion centering rules, and `prettier --check` is clean for the changed files.

### Evidence (Before & After)

Before: the issue screenshots in #9043 show the visible Windows Terminal window for the runtime and the misaligned reduced-motion logo/status. After: no local Windows machine was available to produce matching screenshots; the behavior is covered by the new Windows CI test for the hidden console and the bootstrap release check for the centering, and needs a visual confirmation on a Windows build.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Linux: `node scripts/test-release.js` (desktop release/bootstrap regression checks) and Prettier on the changed files. Rust compile/tests were not run locally (no Rust toolchain or WebKitGTK headers in this environment); the desktop-shell CI job runs `cargo test` on ubuntu-22.04 and windows-2022.

## Risk & Scope

- Main risk or tradeoff: On Windows the group spawn now passes `CREATE_NO_WINDOW` through the command-group builder; the crate still applies its job-object grouping and `CREATE_SUSPENDED` + thread resume, so kill-on-stop and process-group behavior are unchanged. Other platforms keep `group_spawn()` exactly as before.
- Not validated / out of scope: No packaged Windows build was produced here, so the visual result needs confirmation on a Windows release build. The Local Control sleep-inhibitor also spawns `powershell.exe` on Windows without `CREATE_NO_WINDOW`; that is a separate code path not reported in #9043 and is left unchanged.
- Breaking changes / migration notes: None; the change only affects how the existing runtime child is created on Windows and bootstrap CSS in the reduced-motion starting state.

## Linked Issues

Fixes #9043

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修复 #9043 中 Qwen Code Desktop（`packages/desktop-shell` 的 Tauri 外壳）的两个启动问题。第一，Windows 上捆绑运行时子进程现在带 `CREATE_NO_WINDOW` 标志启动，启动、重启或恢复运行时不会再弹出可见的 Windows Terminal/控制台窗口，关闭无关窗口也不会再杀死运行时。第二，启动视图的减弱动效回退分支（Windows 关闭动画效果时使用）现在把 logo 和 "Starting Qwen Code" 状态堆叠在同一列并整体居中，同时去掉了残留的状态卡片边框和内边距，使两者与 #8988 简化后的常规启动视图保持同一水平中心。

## 为什么需要

桌面应用是 GUI 子系统的 Windows 进程，而捆绑运行时（运行 `qwen serve` 的 `node.exe`）是控制台应用。创建控制台子进程时不带 `CREATE_NO_WINDOW`，Windows 会为它分配一个可见的控制台窗口；关闭该窗口会终止运行时，Desktop 随后报 `Qwen Code stopped: exit code: 1`。启动代码使用 `command_group::CommandGroup::group_spawn()`，它会用 group builder 自身的标志（或上 `CREATE_SUSPENDED`）覆盖直接设置在 `Command` 上的创建标志，所以标志必须通过 builder 传入（`command.group().creation_flags(...).spawn()`）——这正是该 crate 文档中隐藏控制台窗口的推荐写法。减弱动效分支在 #8988 简化常规加载界面时被遗漏：logo 仍在外壳中左对齐，而新出现的状态文字居中在更宽的卡片里，两者没有共享同一水平中心。

## 评审测试计划

### 如何验证

在 Windows 上构建或安装 Desktop 应用并用默认工作区启动：运行时启动期间不应出现单独的终端/控制台窗口，应用应能进入 Web Shell。触发一次运行时失败并使用 Retry，或选择其他工作区——两条重启路径都走同一个启动辅助函数，同样不应出现控制台窗口。在 Windows 关闭动画效果（设置 > 辅助功能 > 视觉效果，或系统级 `prefers-reduced-motion`）时，启动视图应显示 logo，其正下方为 "Starting Qwen Code"，两者处于同一水平中心，且没有残留的状态卡片边框或内边距。CI 中 `packages/desktop-shell/src-tauri` 的 `cargo test` 在 `windows-2022` 上运行，包含新增的 `runtime_child_gets_no_windows_console` 测试：它通过同一辅助函数启动子进程，并断言子进程没有附加的控制台窗口（`GetConsoleWindow() == 0`）。本地 `node scripts/test-release.js` 通过（含新增的减弱动效居中规则断言），改动文件的 `prettier --check` 也通过。

### 证据（修改前后）

修改前：#9043 的截图展示了可见的 Windows Terminal 窗口和未对齐的减弱动效 logo/状态。修改后：本地没有 Windows 机器可以产出对应截图；行为由新增的 Windows CI 测试（隐藏控制台）和 bootstrap 发布检查（居中规则）覆盖，需要在 Windows 构建上做一次视觉确认。

### 测试环境

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### 环境（可选）

Linux：`node scripts/test-release.js`（桌面发布/bootstrap 回归检查）以及对改动文件的 Prettier 检查。本地未运行 Rust 编译/测试（该环境没有 Rust 工具链和 WebKitGTK 头文件）；desktop-shell 的 CI 任务会在 ubuntu-22.04 和 windows-2022 上运行 `cargo test`。

## 风险与范围

- 主要风险或权衡：Windows 上的 group 启动现在通过 command-group builder 传入 `CREATE_NO_WINDOW`；该 crate 仍然应用其 job object 分组和 `CREATE_SUSPENDED` + 线程恢复，因此停止时杀进程和进程组行为不变。其他平台完全保持原来的 `group_spawn()`。
- 未验证 / 超出范围：本地未产出打包后的 Windows 构建，视觉效果需要在 Windows 发布构建上确认。Local Control 的睡眠抑制在 Windows 上也会不带 `CREATE_NO_WINDOW` 启动 `powershell.exe`；那是 #9043 未报告的独立代码路径，本次不改动。
- 破坏性变更 / 迁移说明：无；改动只影响 Windows 上现有运行时子进程的创建方式和减弱动效启动状态下的 bootstrap CSS。

## 关联 Issue

Fixes #9043

</details>