### PR TITLE
fix(web-shell): render a single archive action in the session toolbar

### DIFF
--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -3115,7 +3115,7 @@ export function WebShellSidebar({
       const showPin = canOrganizeSession(session, 'pin');
       const showArchive =
         sessionActionItems.has('archive') && canMutateSessionArchive(session);
-      const showReadOnlyArchive = readOnly && showArchive;
+      const showReadOnlyArchive = readOnly && showArchive && !showPin;
       const showSharedArchive = showArchive && !showReadOnlyArchive;
       const showRename = sessionActionItems.has('rename') && mutableScope;
       const activeExportScope = getActiveExportScope(session);

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -3115,6 +3115,12 @@ export function WebShellSidebar({
       const showPin = canOrganizeSession(session, 'pin');
       const showArchive =
         sessionActionItems.has('archive') && canMutateSessionArchive(session);
+      // Read-only rows render their own dedicated archive control above.
+      // The shared action block below must not contribute a second archive
+      // action for the same row (it would render a duplicate button whenever
+      // a read-only row still shows pin, e.g. restricted secondary
+      // workspaces with qualified REST + organization enabled).
+      const archiveOwnedByReadOnlyBlock = readOnly && showArchive;
       const showRename = sessionActionItems.has('rename') && mutableScope;
       const activeExportScope = getActiveExportScope(session);
       const showExport =
@@ -3322,7 +3328,9 @@ export function WebShellSidebar({
                                 ? t('sidebar.archiveCurrentDisabled')
                                 : t('sidebar.archive'),
                               visible:
-                                showArchive && inlineActionItems.has('archive'),
+                                showArchive &&
+                                !archiveOwnedByReadOnlyBlock &&
+                                inlineActionItems.has('archive'),
                               onClick: () => handleArchive(session),
                             },
                             {
@@ -3394,7 +3402,9 @@ export function WebShellSidebar({
                             ));
                         })()}
                         {(showPin && !inlineActionItems.has('pin')) ||
-                        (showArchive && !inlineActionItems.has('archive')) ||
+                        (showArchive &&
+                          !archiveOwnedByReadOnlyBlock &&
+                          !inlineActionItems.has('archive')) ||
                         sessionActionItems.has('details') ||
                         (showRename && !inlineActionItems.has('rename')) ||
                         canOrganizeSession(session, 'group') ||
@@ -3437,6 +3447,7 @@ export function WebShellSidebar({
                                   </DropdownMenuItem>
                                 )}
                                 {showArchive &&
+                                  !archiveOwnedByReadOnlyBlock &&
                                   !inlineActionItems.has('archive') && (
                                     <DropdownMenuItem
                                       disabled={busy || isCurrent}

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -3115,12 +3115,8 @@ export function WebShellSidebar({
       const showPin = canOrganizeSession(session, 'pin');
       const showArchive =
         sessionActionItems.has('archive') && canMutateSessionArchive(session);
-      // Read-only rows render their own dedicated archive control above.
-      // The shared action block below must not contribute a second archive
-      // action for the same row (it would render a duplicate button whenever
-      // a read-only row still shows pin, e.g. restricted secondary
-      // workspaces with qualified REST + organization enabled).
-      const archiveOwnedByReadOnlyBlock = readOnly && showArchive;
+      const showReadOnlyArchive = readOnly && showArchive;
+      const showSharedArchive = showArchive && !showReadOnlyArchive;
       const showRename = sessionActionItems.has('rename') && mutableScope;
       const activeExportScope = getActiveExportScope(session);
       const showExport =
@@ -3225,7 +3221,7 @@ export function WebShellSidebar({
                     ) : !attentionLabel ? (
                       <span className={styles.sessionTime}>{time}</span>
                     ) : null}
-                    {readOnly && showArchive && (
+                    {showReadOnlyArchive && (
                       <div
                         className={styles.sessionActions}
                         onClick={(event) => event.stopPropagation()}
@@ -3328,8 +3324,7 @@ export function WebShellSidebar({
                                 ? t('sidebar.archiveCurrentDisabled')
                                 : t('sidebar.archive'),
                               visible:
-                                showArchive &&
-                                !archiveOwnedByReadOnlyBlock &&
+                                showSharedArchive &&
                                 inlineActionItems.has('archive'),
                               onClick: () => handleArchive(session),
                             },
@@ -3402,8 +3397,7 @@ export function WebShellSidebar({
                             ));
                         })()}
                         {(showPin && !inlineActionItems.has('pin')) ||
-                        (showArchive &&
-                          !archiveOwnedByReadOnlyBlock &&
+                        (showSharedArchive &&
                           !inlineActionItems.has('archive')) ||
                         sessionActionItems.has('details') ||
                         (showRename && !inlineActionItems.has('rename')) ||
@@ -3446,8 +3440,7 @@ export function WebShellSidebar({
                                       : t('sidebar.pin')}
                                   </DropdownMenuItem>
                                 )}
-                                {showArchive &&
-                                  !archiveOwnedByReadOnlyBlock &&
+                                {showSharedArchive &&
                                   !inlineActionItems.has('archive') && (
                                     <DropdownMenuItem
                                       disabled={busy || isCurrent}

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
@@ -4398,7 +4398,7 @@ describe('WebShellSidebar session toolbar archive action dedupe', () => {
   // that used to render two archive actions.
   async function pinnedSecondaryCatalog(
     cwd: string,
-    options?: { archiveState?: string; group?: string },
+    options?: { group?: string },
   ): Promise<DaemonSessionSummary[]> {
     return cwd === '/tmp/other' && options?.group === 'pinned'
       ? [
@@ -4436,28 +4436,15 @@ describe('WebShellSidebar session toolbar archive action dedupe', () => {
   }
 
   async function countArchiveMenuItemsInRow(label: string): Promise<number> {
-    const triggers = Array.from(
-      sessionRow(label).querySelectorAll<HTMLButtonElement>(
-        'button[aria-label="More actions"]',
-      ),
-    );
-    let archiveItems = 0;
-    for (const trigger of triggers) {
-      await act(async () => {
-        click(trigger);
-        await Promise.resolve();
-      });
-      archiveItems += Array.from(
-        document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
-      ).filter((item) => item.textContent?.includes('Archive')).length;
-      await act(async () => {
-        document.body.dispatchEvent(
-          new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
-        );
-        await Promise.resolve();
-      });
-    }
-    return archiveItems;
+    const trigger = sessionAction(label);
+    expect(trigger).toBeDefined();
+    await act(async () => {
+      click(trigger!);
+      await Promise.resolve();
+    });
+    return Array.from(
+      document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+    ).filter((item) => item.textContent?.includes('Archive')).length;
   }
 
   it('keeps one inline archive action when ownership changes', async () => {
@@ -4466,14 +4453,37 @@ describe('WebShellSidebar session toolbar archive action dedupe', () => {
 
     renderSidebar();
     await settle();
-
     expect(inlineSessionAction('Pinned secondary', 'Unpin')).toBeDefined();
     expect(archiveButtonsInRow('Pinned secondary')).toHaveLength(1);
+    expect(
+      sessionRow('Pinned secondary').querySelectorAll(
+        '[class*="sessionActions"]',
+      ),
+    ).toHaveLength(1);
+  });
 
-    renderSidebar({ lockedWorkspaceCwd: '/tmp/other' });
-    await settle();
-    expect(inlineSessionAction('Pinned secondary', 'Unpin')).toBeDefined();
-    expect(archiveButtonsInRow('Pinned secondary')).toHaveLength(1);
+  it('keeps archive when the read-only cluster is the sole owner', async () => {
+    useWorkspaceSessionCatalog(async (cwd, options) =>
+      cwd === '/tmp/other' && options?.archiveState === 'active'
+        ? [
+            {
+              sessionId: 'secondary-only',
+              workspaceCwd: cwd,
+              displayName: 'Secondary only',
+            },
+          ]
+        : [],
+    );
+    renderSidebar({
+      sessionActions: { items: ['archive'], inlineItems: ['archive'] },
+    });
+    await expandWorkspace('other');
+    expect(archiveButtonsInRow('Secondary only')).toHaveLength(1);
+    expect(
+      sessionRow('Secondary only').querySelectorAll(
+        '[class*="sessionActions"]',
+      ),
+    ).toHaveLength(1);
   });
 
   it('keeps exactly one archive menu item when archive is dropdown-only', async () => {
@@ -4481,7 +4491,7 @@ describe('WebShellSidebar session toolbar archive action dedupe', () => {
     useWorkspaceSessionCatalog(pinnedSecondaryCatalog);
 
     renderSidebar({
-      sessionActions: { items: ['pin', 'archive'], inlineItems: ['pin'] },
+      sessionActions: { inlineItems: ['pin'] },
     });
     await settle();
 

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
@@ -4460,7 +4460,7 @@ describe('WebShellSidebar session toolbar archive action dedupe', () => {
     return archiveItems;
   }
 
-  it('renders exactly one archive action on a read-only row that also shows pin', async () => {
+  it('keeps one inline archive action when ownership changes', async () => {
     enableOrganization();
     useWorkspaceSessionCatalog(pinnedSecondaryCatalog);
 
@@ -4469,31 +4469,7 @@ describe('WebShellSidebar session toolbar archive action dedupe', () => {
 
     expect(inlineSessionAction('Pinned secondary', 'Unpin')).toBeDefined();
     expect(archiveButtonsInRow('Pinned secondary')).toHaveLength(1);
-  });
 
-  it('keeps exactly one archive action across pin toggle and workspace lock transitions', async () => {
-    enableOrganization();
-    useWorkspaceSessionCatalog(pinnedSecondaryCatalog);
-
-    renderSidebar();
-    await settle();
-    expect(archiveButtonsInRow('Pinned secondary')).toHaveLength(1);
-
-    // Pin state transition on the read-only row.
-    const unpin = inlineSessionAction('Pinned secondary', 'Unpin');
-    expect(unpin).toBeDefined();
-    await act(async () => {
-      click(unpin!);
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-    expect(updateSessionOrganization).toHaveBeenCalledWith('pinned-secondary', {
-      isPinned: false,
-    });
-    expect(archiveButtonsInRow('Pinned secondary')).toHaveLength(1);
-
-    // Locking the workspace flips the row out of read-only scope; the
-    // archive action must still render exactly once.
     renderSidebar({ lockedWorkspaceCwd: '/tmp/other' });
     await settle();
     expect(inlineSessionAction('Pinned secondary', 'Unpin')).toBeDefined();
@@ -4504,10 +4480,17 @@ describe('WebShellSidebar session toolbar archive action dedupe', () => {
     enableOrganization();
     useWorkspaceSessionCatalog(pinnedSecondaryCatalog);
 
-    renderSidebar({ sessionActions: { inlineItems: ['pin'] } });
+    renderSidebar({
+      sessionActions: { items: ['pin', 'archive'], inlineItems: ['pin'] },
+    });
     await settle();
 
     expect(archiveButtonsInRow('Pinned secondary')).toHaveLength(0);
+    expect(
+      sessionRow('Pinned secondary').querySelectorAll(
+        'button[aria-label="More actions"]',
+      ),
+    ).toHaveLength(1);
     expect(await countArchiveMenuItemsInRow('Pinned secondary')).toBe(1);
   });
 });

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
@@ -4382,3 +4382,132 @@ describe('WebShellSidebar archived session export', () => {
     expect(URL.revokeObjectURL).toHaveBeenCalledTimes(2);
   });
 });
+
+describe('WebShellSidebar session toolbar archive action dedupe', () => {
+  function enableOrganization(): void {
+    connection.capabilities = {
+      ...capabilities,
+      features: [...capabilities.features, 'session_organization'],
+    };
+    workspace.capabilities = connection.capabilities;
+  }
+
+  // Sessions from a trusted secondary workspace resolve to the
+  // "restricted" scope: read-only rows that may still show pin and
+  // archive when the qualified REST core is enabled — the exact state
+  // that used to render two archive actions.
+  async function pinnedSecondaryCatalog(
+    cwd: string,
+    options?: { archiveState?: string; group?: string },
+  ): Promise<DaemonSessionSummary[]> {
+    return cwd === '/tmp/other' && options?.group === 'pinned'
+      ? [
+          {
+            sessionId: 'pinned-secondary',
+            workspaceCwd: cwd,
+            displayName: 'Pinned secondary',
+            isPinned: true,
+          },
+        ]
+      : [];
+  }
+
+  function sessionRow(label: string): HTMLElement {
+    const row = Array.from(
+      container.querySelectorAll<HTMLElement>('[class*="sessionRow"]'),
+    ).find((candidate) => candidate.textContent?.includes(label));
+    expect(row).toBeDefined();
+    return row!;
+  }
+
+  function archiveButtonsInRow(label: string): HTMLButtonElement[] {
+    return Array.from(
+      sessionRow(label).querySelectorAll<HTMLButtonElement>(
+        'button[aria-label="Archive"]',
+      ),
+    );
+  }
+
+  async function settle(): Promise<void> {
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  async function countArchiveMenuItemsInRow(label: string): Promise<number> {
+    const triggers = Array.from(
+      sessionRow(label).querySelectorAll<HTMLButtonElement>(
+        'button[aria-label="More actions"]',
+      ),
+    );
+    let archiveItems = 0;
+    for (const trigger of triggers) {
+      await act(async () => {
+        click(trigger);
+        await Promise.resolve();
+      });
+      archiveItems += Array.from(
+        document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+      ).filter((item) => item.textContent?.includes('Archive')).length;
+      await act(async () => {
+        document.body.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+        );
+        await Promise.resolve();
+      });
+    }
+    return archiveItems;
+  }
+
+  it('renders exactly one archive action on a read-only row that also shows pin', async () => {
+    enableOrganization();
+    useWorkspaceSessionCatalog(pinnedSecondaryCatalog);
+
+    renderSidebar();
+    await settle();
+
+    expect(inlineSessionAction('Pinned secondary', 'Unpin')).toBeDefined();
+    expect(archiveButtonsInRow('Pinned secondary')).toHaveLength(1);
+  });
+
+  it('keeps exactly one archive action across pin toggle and workspace lock transitions', async () => {
+    enableOrganization();
+    useWorkspaceSessionCatalog(pinnedSecondaryCatalog);
+
+    renderSidebar();
+    await settle();
+    expect(archiveButtonsInRow('Pinned secondary')).toHaveLength(1);
+
+    // Pin state transition on the read-only row.
+    const unpin = inlineSessionAction('Pinned secondary', 'Unpin');
+    expect(unpin).toBeDefined();
+    await act(async () => {
+      click(unpin!);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(updateSessionOrganization).toHaveBeenCalledWith('pinned-secondary', {
+      isPinned: false,
+    });
+    expect(archiveButtonsInRow('Pinned secondary')).toHaveLength(1);
+
+    // Locking the workspace flips the row out of read-only scope; the
+    // archive action must still render exactly once.
+    renderSidebar({ lockedWorkspaceCwd: '/tmp/other' });
+    await settle();
+    expect(inlineSessionAction('Pinned secondary', 'Unpin')).toBeDefined();
+    expect(archiveButtonsInRow('Pinned secondary')).toHaveLength(1);
+  });
+
+  it('keeps exactly one archive menu item when archive is dropdown-only', async () => {
+    enableOrganization();
+    useWorkspaceSessionCatalog(pinnedSecondaryCatalog);
+
+    renderSidebar({ sessionActions: { inlineItems: ['pin'] } });
+    await settle();
+
+    expect(archiveButtonsInRow('Pinned secondary')).toHaveLength(0);
+    expect(await countArchiveMenuItemsInRow('Pinned secondary')).toBe(1);
+  });
+});


### PR DESCRIPTION
## What this PR does

Session toolbar rows in the web-shell sidebar compose hover actions from a read-only archive block and a shared action block. This PR keeps exactly one archive action visible for restricted secondary workspace rows: rows that also show pin keep archive in the shared action overlay so the archive button remains pointer-accessible, while read-only rows without shared actions keep the dedicated archive owner. Pin and every other action keep their existing behavior, and rows that are not read-only are unchanged.

## Why it's needed

Fixes the intermittent duplicate archive button reported in #9059. When a session resolves to a restricted secondary workspace while `workspace_qualified_rest_core` and `session_organization` capabilities are enabled, the row is read-only (`readOnly === true`) but still shows pin (`showPin === true`) and archive (`showArchive === true`). The earlier fix removed the duplicate archive entry but still rendered two absolutely positioned overlays in the same meta slot, which could leave the surviving archive control under the shared overlay. The latest code avoids that overlap for pinned read-only rows and keeps the single archive action reachable.

## Reviewer Test Plan

### How to verify

1. Connect to a daemon that advertises `session_archive`, `workspace_qualified_rest_core`, and `session_organization`, with a trusted secondary workspace that has a pinned session shown in the sidebar. Hovering that session row should show exactly one archive action and it should remain clickable beside pin.
2. Run the regression tests: `cd packages/web-shell && npx vitest run --config vitest.config.ts client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx -t "archive action dedupe"`. The focused tests cover the pinned read-only row, the read-only sole-owner row, and the dropdown-only archive configuration.

### Evidence (Before & After)

Before: the #9059 state could render duplicate archive actions, and the first follow-up could leave two action overlays competing in the same meta slot. After: the latest focused test run on head `a838f0477f4e7adfbb90d945c8cd324a07aabdf6` passed 3 tests and skipped the unrelated 68 tests in the file.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Linux: `cd packages/web-shell && npx vitest run --config vitest.config.ts client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx -t "archive action dedupe"` passed 3/3 focused tests on the latest head.

## Risk & Scope

- Main risk or tradeoff: Archive ownership now depends on whether the read-only row also has shared actions such as pin, avoiding duplicate overlays while preserving a dedicated archive owner when no shared actions render.
- Not validated / out of scope: no visual/E2E run on packaged desktop apps; archived-row actions (Restore) and non-read-only rows are unchanged.
- Breaking changes / migration notes: none; rendering-only change, no API/config changes.

## Linked Issues

Fixes #9059

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

web-shell 侧边栏会话工具栏由只读归档区块和共享操作区块组合悬浮操作。本 PR 确保受限次级工作区行只显示一个归档操作：同时显示 pin 的只读行把 archive 保留在共享操作 overlay 中，使归档按钮仍可点击；没有共享操作的只读行继续由专用归档区块负责。Pin 和其它操作行为保持不变，非只读行不变。

## 为什么需要

修复 #9059 报告的偶发重复归档按钮。当会话归属于受限的次级工作区，且守护进程开启 `workspace_qualified_rest_core` 与 `session_organization` 能力时，该行是只读的，但仍会显示 pin 和 archive。此前修复移除了重复 archive 项，但仍可能在同一个 meta slot 中渲染两个绝对定位 overlay，导致保留下来的 archive 控件被共享 overlay 盖住。最新代码避免 pinned read-only 行的 overlay 重叠，并保持唯一 archive 操作可点击。

## 评审测试计划

### 如何验证

1. 连接一个声明了 `session_archive`、`workspace_qualified_rest_core`、`session_organization` 能力的守护进程，并有一个可信次级工作区的 pinned session 显示在侧边栏。悬浮该行时应只有一个 archive 操作，并且它应在 pin 旁边可点击。
2. 运行回归测试：`cd packages/web-shell && npx vitest run --config vitest.config.ts client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx -t "archive action dedupe"`。聚焦测试覆盖 pinned read-only 行、只读 sole-owner 行，以及仅下拉 archive 配置。

### 证据（修改前后）

修改前：#9059 状态可能渲染重复 archive 操作，第一次后续修复还可能让两个 action overlay 竞争同一个 meta slot。修改后：在最新 head `a838f0477f4e7adfbb90d945c8cd324a07aabdf6` 上，聚焦测试 3 个通过，文件内无关 68 个测试跳过。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### 环境（可选）

Linux：`cd packages/web-shell && npx vitest run --config vitest.config.ts client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx -t "archive action dedupe"` 在最新 head 上通过 3/3 个聚焦测试。

## 风险与范围

- 主要风险或权衡：归档操作 ownership 现在取决于只读行是否也有 pin 等共享操作，从而避免重复 overlay，同时在没有共享操作时保留专用归档 owner。
- 未验证 / 超出范围：未在打包桌面应用上做视觉/E2E；归档行操作（Restore）和非只读行不变。
- 破坏性变更 / 迁移说明：无；纯渲染改动，无 API/配置变化。

## 关联 Issue

Fixes #9059

</details>
