### PR TITLE
fix(desktop): reserve scrollbar gutter so sidebar project rows don't jitter

### DIFF
--- a/packages/desktop/apps/electron/src/renderer/components/app-shell/WorkspaceProjectTree.tsx
+++ b/packages/desktop/apps/electron/src/renderer/components/app-shell/WorkspaceProjectTree.tsx
@@ -928,7 +928,7 @@ export function WorkspaceProjectTree({
         </DialogContent>
       </Dialog>
 
-      <div className="min-h-0 flex-1 overflow-y-auto pb-3 mask-fade-bottom">
+      <div className="min-h-0 flex-1 overflow-y-auto pb-3 mask-fade-bottom scrollbar-stable">
         <div className="flex shrink-0 items-center justify-between px-3 pb-2 pt-1">
           <span className="text-[12px] font-semibold text-muted-foreground">
             {t("sidebar.projects", "Workspaces")}

--- a/packages/desktop/apps/electron/src/renderer/index.css
+++ b/packages/desktop/apps/electron/src/renderer/index.css
@@ -532,6 +532,12 @@ html[data-font="inter"] {
     height: 4px;
   }
 
+  /* Reserve scrollbar space so content does not shift when the scrollbar
+     appears or disappears */
+  .scrollbar-stable {
+    scrollbar-gutter: stable;
+  }
+
   /* Hide scrollbar but keep scrolling */
   .scrollbar-hide {
     -ms-overflow-style: none;


### PR DESCRIPTION
## What this PR does

Reserves the scrollbar gutter for the scrollable project list in the desktop app's left sidebar. It adds a small `.scrollbar-stable` utility (`scrollbar-gutter: stable`) to the Electron renderer stylesheet, next to the existing `.scrollbar-hide` / `.panel-scroll` scrollbar utilities, and applies it only to the sidebar's project list scroll container. No other scroll behavior changes.

## Why it's needed

Fixes #8985. In the desktop sidebar, the project list is the scroll container (the `min-h-0 flex-1 overflow-y-auto ...` div in `WorkspaceProjectTree`), and the renderer styles scrollbars as classic 8px webkit scrollbars (`::-webkit-scrollbar { width: 8px }` in `index.css`). Expanding a project until the list overflows makes the scrollbar appear, which consumes 8px of layout width and shifts every project row/icon to the left; collapsing makes it disappear and shifts everything back. Reserving the gutter up front keeps the content width stable whether or not the scrollbar is visible. The web-shell sidebar already uses the same fix (`scrollbar-gutter: stable` on `.sessionList` in `WebShellSidebar.module.css`); this brings the desktop sidebar to parity.

## Reviewer Test Plan

### How to verify

1. Run the desktop (Electron) app with several projects in the left sidebar.
2. Expand a project whose session list makes the project list taller than the visible sidebar area.
3. Before this fix: the scrollbar appears and all rows/icons jump ~8px left; collapsing jumps them back. After this fix: rows/icons stay at a fixed horizontal position in both states; the gutter is reserved at all times.

Expected: no horizontal shift of project rows/icons when expanding or collapsing projects.

### Evidence (Before & After)

This box is headless, so the Electron GUI can't be exercised here for screenshots; the video in the issue shows the before behavior. The change is a single CSS property scoped to the one scrolling container — the exact pattern already proven on the web-shell `.sessionList`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Code-level verification only (headless Linux, no display available); CI covers lint/typecheck/tests.

## Risk & Scope

- Main risk or tradeoff: the gutter (8px) is reserved even when the list does not overflow, so the project list is permanently 8px narrower — the standard `scrollbar-gutter: stable` tradeoff, identical to the web-shell sidebar today.
- Not validated / out of scope: no visual screenshots (headless environment); other scroll containers (chat display, panels, menus) are untouched.
- Breaking changes / migration notes: none — CSS-only addition; the new `.scrollbar-stable` class is inert unless applied.

## Linked Issues

Fixes #8985

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

为桌面端左侧边栏中可滚动的项目列表预留滚动条占位（scrollbar gutter）。在 Electron 渲染进程的全局样式中新增一个小的 `.scrollbar-stable` 工具类（`scrollbar-gutter: stable`），放在已有的 `.scrollbar-hide` / `.panel-scroll` 滚动条工具类旁边，并且只应用在侧边栏项目列表的滚动容器上，不改变任何其他滚动行为。

## 为什么需要

修复 #8985。桌面端侧边栏中，项目列表本身就是滚动容器（`WorkspaceProjectTree` 中的 `min-h-0 flex-1 overflow-y-auto ...` div），而渲染进程把滚动条样式化为 8px 的经典 webkit 滚动条（`index.css` 中 `::-webkit-scrollbar { width: 8px }`）。展开某个项目使列表超出可视区域时，滚动条出现并占用 8px 布局宽度，导致所有项目行/图标整体左移；收起后滚动条消失又移回来。提前预留滚动条空间后，无论滚动条是否可见，内容宽度都保持稳定。web-shell 侧边栏已经用了同样的修复方式（`WebShellSidebar.module.css` 的 `.sessionList` 上的 `scrollbar-gutter: stable`），本 PR 让桌面端侧边栏与其保持一致。

## 评审测试计划

### 如何验证

1. 运行桌面端（Electron）应用，左侧边栏中有若干项目。
2. 展开一个会话较多的项目，使项目列表总高度超过侧边栏可视区域。
3. 修复前：滚动条出现，所有行/图标左移约 8px，收起后右移回来。修复后：展开/收起两种状态下图标和文字都保持固定水平位置，滚动条占位始终被预留。

预期：展开/收起项目时项目行/图标不再发生水平位移。

### 证据（修改前后）

本环境无图形界面，无法运行 Electron GUI 截图；issue 中的视频即为修复前表现。本次改动是只作用于该滚动容器的单条 CSS 属性，与 web-shell `.sessionList` 上已验证的同款修复完全一致。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ 未测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

仅代码级验证（无显示器的 Linux 环境）；lint/类型检查/测试由 CI 覆盖。

## 风险与范围

- 主要风险或权衡：即使列表没有溢出也会预留 8px 占位，项目列表内容区永久窄 8px——这是 `scrollbar-gutter: stable` 的标准权衡，与 web-shell 侧边栏现状一致。
- 未验证 / 不在范围内：无图形环境，未截图；其他滚动容器（聊天区、面板、菜单）不受影响。
- 破坏性变更 / 迁移说明：无——纯 CSS 新增，`.scrollbar-stable` 类在未使用时不产生任何效果。

## 关联 Issue

Fixes #8985

</details>
