### PR TITLE
fix(core): Preserve OTel session ownership in daemons

### DIFF
--- a/docs/design/telemetry-session-ownership.md
+++ b/docs/design/telemetry-session-ownership.md
@@ -1,0 +1,37 @@
+# Telemetry session ownership
+
+## Problem
+
+The CLI initializes telemetry once per process. That process-global session is
+safe for an interactive CLI, but a daemon can host multiple sessions. Native
+LLM spans created outside an interaction currently fall back to the bootstrap
+session, even though `LoggingContentGenerator` owns the `Config` for the
+session that issued the request. API log spans use that `Config`, so one model
+request can be split across two sessions.
+
+## Ownership
+
+An existing native logical parent owns its descendants. Without one, the
+`Config` owned by `LoggingContentGenerator` is authoritative. The resolved
+session is carried in an OpenTelemetry `Context` so automatic HTTP spans and
+log records created during the request inherit the same identity.
+
+Session resolution uses this order:
+
+1. Native interaction, subagent, or tool parent.
+2. Explicit session from the owning `Config`.
+3. Session stored in the active OpenTelemetry `Context`.
+4. The existing per-request session `AsyncLocalStorage`.
+5. The process-global session, for single-session compatibility.
+
+The OpenTelemetry context key is private and is not baggage, so it is not
+serialized onto outbound requests. A streaming request snapshots its resolved
+session when the LLM span starts, uses the same snapshot for API log records,
+and reactivates that context for every stream iteration. A later `Config`
+session change therefore cannot split an in-flight request across sessions.
+
+## Boundaries
+
+This change fixes session ownership only. It does not add AgentLoop entry or
+step spans, turn or react-round attributes, resource-level session identity,
+or any wire, storage, or daemon API changes.

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts
@@ -23,6 +23,7 @@ import {
   logApiError,
 } from '../../telemetry/loggers.js';
 import { isTelemetrySdkInitialized } from '../../telemetry/index.js';
+import { startLLMRequestSpanWithContext } from '../../telemetry/session-tracing.js';
 import { OpenAILogger } from '../../utils/openaiLogger.js';
 import type OpenAI from 'openai';
 import { APIUserAbortError } from 'openai';
@@ -62,6 +63,7 @@ const loggingSpanNamesWithSetStatusFailure = vi.hoisted(
 );
 const loggingSpanAttributeFailures = vi.hoisted(() => new Set<string>());
 const loggingSpanAttributeSetAttempts = vi.hoisted((): string[] => []);
+const startLLMRequestSpanWithContextMock = vi.hoisted(() => vi.fn());
 const genAiExchangeState = vi.hoisted(
   (): {
     controllers: Array<{ finalize: ReturnType<typeof vi.fn> }>;
@@ -144,79 +146,21 @@ vi.mock('../../telemetry/gen-ai-request.js', () => ({
   }),
 }));
 
+vi.mock('../../telemetry/session-tracing.js', () => ({
+  startLLMRequestSpanWithContext: startLLMRequestSpanWithContextMock,
+}));
+
 vi.mock('../../telemetry/index.js', () => {
   const isTelemetrySdkInitialized = vi.fn(() => true);
-  function createSpan(
-    name: string,
-    attributes: Record<string, string | number | boolean>,
-  ) {
-    const record = {
-      name,
-      attributes: { ...attributes } as Record<
-        string,
-        string | number | boolean
-      >,
-      statuses: [] as Array<{ code: number; message?: string }>,
-      ended: false,
-    };
-    loggingSpanRecords.push(record);
-    return {
-      __spanName: name,
-      setStatus(status: { code: number; message?: string }) {
-        if (loggingSpanNamesWithSetStatusFailure.has(name)) {
-          throw new Error('set-status-fail');
-        }
-        record.statuses.push(status);
-      },
-      setAttribute(key: string, value: string | number | boolean) {
-        loggingSpanAttributeSetAttempts.push(key);
-        if (loggingSpanAttributeFailures.has(key)) {
-          throw new Error('set-attribute-fail');
-        }
-        record.attributes[key] = value;
-      },
-      setAttributes(attrs: Record<string, string | number | boolean>) {
-        Object.assign(record.attributes, attrs);
-      },
-      end() {
-        record.ended = true;
-      },
-      spanContext: () => ({
-        traceId: 'a'.repeat(32),
-        spanId: 'b'.repeat(16),
-        traceFlags: 1,
-      }),
-    };
-  }
 
   return {
-    startLLMRequestSpan: vi.fn(
-      (
-        model: string,
-        promptId: string,
-        options?: {
-          operationName?: string;
-          providerName?: string;
-          outputType?: string;
-        },
-      ) =>
-        createSpan('qwen-code.llm_request', {
-          model,
-          prompt_id: promptId,
-          ...(options?.operationName
-            ? { 'gen_ai.operation.name': options.operationName }
-            : {}),
-          ...(options?.providerName
-            ? { 'gen_ai.provider.name': options.providerName }
-            : {}),
-          ...(options?.outputType
-            ? { 'gen_ai.output.type': options.outputType }
-            : {}),
-        }),
-    ),
     endLLMRequestSpan: vi.fn(
       (
-        span: ReturnType<typeof createSpan>,
+        span: {
+          __spanName: string;
+          setStatus: (status: { code: number; message?: string }) => void;
+          end: () => void;
+        },
         metadata?: {
           success: boolean;
           inputTokens?: number;
@@ -289,6 +233,68 @@ vi.mock('../../utils/openaiLogger.js', () => ({
   })),
 }));
 
+function createOwnedLlmSpan(
+  model: string,
+  promptId: string,
+  options?: {
+    operationName?: string;
+    providerName?: string;
+    outputType?: string;
+    sessionId?: string;
+    userId?: string;
+  },
+) {
+  const name = 'qwen-code.llm_request';
+  const record = {
+    name,
+    attributes: {
+      model,
+      prompt_id: promptId,
+      ...(options?.operationName
+        ? { 'gen_ai.operation.name': options.operationName }
+        : {}),
+      ...(options?.providerName
+        ? { 'gen_ai.provider.name': options.providerName }
+        : {}),
+      ...(options?.outputType
+        ? { 'gen_ai.output.type': options.outputType }
+        : {}),
+      ...(options?.sessionId ? { 'session.id': options.sessionId } : {}),
+      ...(options?.userId ? { 'gen_ai.user.id': options.userId } : {}),
+    } as Record<string, string | number | boolean>,
+    statuses: [] as Array<{ code: number; message?: string }>,
+    ended: false,
+  };
+  loggingSpanRecords.push(record);
+  return {
+    __spanName: name,
+    setStatus(status: { code: number; message?: string }) {
+      if (loggingSpanNamesWithSetStatusFailure.has(name)) {
+        throw new Error('set-status-fail');
+      }
+      record.statuses.push(status);
+    },
+    setAttribute(key: string, value: string | number | boolean) {
+      loggingSpanAttributeSetAttempts.push(key);
+      if (loggingSpanAttributeFailures.has(key)) {
+        throw new Error('set-attribute-fail');
+      }
+      record.attributes[key] = value;
+    },
+    setAttributes(attrs: Record<string, string | number | boolean>) {
+      Object.assign(record.attributes, attrs);
+    },
+    end() {
+      record.ended = true;
+    },
+    spanContext: () => ({
+      traceId: 'a'.repeat(32),
+      spanId: 'b'.repeat(16),
+      traceFlags: 1,
+    }),
+  };
+}
+
 const realConvertGeminiRequestToOpenAI =
   OpenAIContentConverter.convertGeminiRequestToOpenAI;
 const convertGeminiRequestToOpenAISpy = vi
@@ -322,6 +328,9 @@ const createConfig = (overrides: Record<string, unknown> = {}): Config => {
     getTelemetrySensitiveSpanAttributeMaxLength: () =>
       (configContent['sensitiveSpanAttributeMaxLength'] as number) ??
       1024 * 1024,
+    getSessionId: () =>
+      (configContent['sessionId'] as string | undefined) ?? 'test-session',
+    getTelemetryUserId: () => configContent['userId'] as string | undefined,
   } as Config;
 };
 
@@ -389,6 +398,19 @@ describe('LoggingContentGenerator', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(isTelemetrySdkInitialized).mockReturnValue(true);
+    vi.mocked(startLLMRequestSpanWithContext).mockImplementation(
+      (model, promptId, options) => {
+        const span = createOwnedLlmSpan(model, promptId, options);
+        return {
+          span: span as never,
+          context: {
+            label: span.__spanName,
+            span,
+            getValue: () => options?.sessionId,
+          } as never,
+        };
+      },
+    );
     activeOtelContext.current = 'root';
     loggingSpanRecords.length = 0;
     loggingSpanNamesWithSetStatusFailure.clear();
@@ -402,6 +424,154 @@ describe('LoggingContentGenerator', () => {
     convertGeminiRequestToOpenAISpy.mockClear();
     convertGeminiToolsToOpenAISpy.mockClear();
     convertGeminiResponseToOpenAISpy.mockClear();
+  });
+
+  it('passes the owning config identity to a standalone LLM span', async () => {
+    const wrapped = createWrappedGenerator(
+      vi
+        .fn()
+        .mockResolvedValue(
+          createResponse('resp-owner', 'test-model', [{ text: 'ok' }]),
+        ),
+      vi.fn(),
+    );
+    const generator = new LoggingContentGenerator(
+      wrapped,
+      createConfig({ sessionId: 'owner-session', userId: 'owner-user' }),
+      {
+        model: 'test-model',
+        authType: AuthType.USE_OPENAI,
+      },
+    );
+
+    await generator.generateContent(
+      {
+        model: 'test-model',
+        contents: [{ role: 'user', parts: [{ text: 'hello' }] }],
+      },
+      'owner-prompt',
+    );
+
+    expect(startLLMRequestSpanWithContext).toHaveBeenCalledWith(
+      'test-model',
+      'owner-prompt',
+      expect.objectContaining({
+        sessionId: 'owner-session',
+        userId: 'owner-user',
+      }),
+    );
+  });
+
+  it('uses the final logical-parent session for API logs', async () => {
+    const wrapped = createWrappedGenerator(
+      vi
+        .fn()
+        .mockResolvedValue(
+          createResponse('resp-parent', 'test-model', [{ text: 'ok' }]),
+        ),
+      vi.fn(),
+    );
+    vi.mocked(startLLMRequestSpanWithContext).mockImplementationOnce(
+      (model, promptId, options) => {
+        const span = createOwnedLlmSpan(model, promptId, {
+          ...options,
+          sessionId: 'parent-session',
+        });
+        return {
+          span: span as never,
+          context: {
+            label: span.__spanName,
+            span,
+            getValue: () => 'parent-session',
+          } as never,
+        };
+      },
+    );
+    const generator = new LoggingContentGenerator(
+      wrapped,
+      createConfig({ sessionId: 'different-owner' }),
+      {
+        model: 'test-model',
+        authType: AuthType.USE_OPENAI,
+      },
+    );
+
+    await generator.generateContent(
+      {
+        model: 'test-model',
+        contents: [{ role: 'user', parts: [{ text: 'hello' }] }],
+      },
+      'parent-prompt',
+    );
+
+    expect(logApiRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'parent-session',
+    );
+    expect(logApiResponse).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'parent-session',
+    );
+  });
+
+  it('snapshots the owning identity before stream iteration', async () => {
+    const iterationContexts: string[] = [];
+    const responseLogContexts: string[] = [];
+    vi.mocked(logApiResponse).mockImplementationOnce(() => {
+      responseLogContexts.push(activeOtelContext.current);
+    });
+    const wrapped = createWrappedGenerator(
+      vi.fn(),
+      vi.fn().mockImplementation(async () =>
+        (async function* () {
+          iterationContexts.push(activeOtelContext.current);
+          yield createResponse('resp-stream', 'test-model', [{ text: 'ok' }]);
+        })(),
+      ),
+    );
+    let activeSessionId = 'stream-session-B';
+    const config = createConfig({ userId: 'stream-user' });
+    vi.spyOn(config, 'getSessionId').mockImplementation(() => activeSessionId);
+    const generator = new LoggingContentGenerator(wrapped, config, {
+      model: 'test-model',
+      authType: AuthType.USE_OPENAI,
+    });
+
+    const stream = await generator.generateContentStream(
+      {
+        model: 'test-model',
+        contents: [{ role: 'user', parts: [{ text: 'hello' }] }],
+      },
+      'stream-owner-prompt',
+    );
+    activeSessionId = 'stream-session-C';
+    for await (const _chunk of stream) {
+      // Drain the stream so all logging and span finalization paths execute.
+    }
+
+    expect(startLLMRequestSpanWithContext).toHaveBeenCalledWith(
+      'test-model',
+      'stream-owner-prompt',
+      expect.objectContaining({
+        sessionId: 'stream-session-B',
+        userId: 'stream-user',
+      }),
+    );
+    expect(iterationContexts).toEqual(['qwen-code.llm_request']);
+    expect(responseLogContexts).toEqual(['qwen-code.llm_request']);
+    expect(logApiRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'stream-session-B',
+    );
+    expect(logApiResponse).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'stream-session-B',
+    );
+    expect(activeOtelContext.current).toBe('root');
   });
 
   it('logs request/response, normalizes thought parts, and logs OpenAI interaction', async () => {

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
@@ -20,7 +20,7 @@ import {
   type FinishReason,
 } from '@google/genai';
 import type OpenAI from 'openai';
-import { context, trace, type Context, type Span } from '@opentelemetry/api';
+import { context, type Context, type Span } from '@opentelemetry/api';
 import {
   ApiRequestEvent,
   ApiResponseEvent,
@@ -52,10 +52,11 @@ import {
   isAbortError,
 } from '../../utils/errors.js';
 import {
-  startLLMRequestSpan,
   endLLMRequestSpan,
   areSensitiveSpanAttributesEnabled,
 } from '../../telemetry/index.js';
+import { startLLMRequestSpanWithContext } from '../../telemetry/session-tracing.js';
+import { getSessionIdFromContext } from '../../telemetry/session-context.js';
 import {
   API_CALL_ABORTED_SPAN_STATUS_MESSAGE,
   API_CALL_FAILED_SPAN_STATUS_MESSAGE,
@@ -97,6 +98,26 @@ function snapshotRetryMetadata(): {
     attempt: ctx?.attempt ?? 1,
     requestSetupMs: ctx?.requestSetupMs,
     retryTotalDelayMs: ctx?.retryTotalDelayMs,
+  };
+}
+
+function bindAsyncGeneratorToContext<TYield, TReturn, TNext>(
+  stream: AsyncGenerator<TYield, TReturn, TNext>,
+  scopedContext: Context,
+): AsyncGenerator<TYield, TReturn, TNext> {
+  // An async generator starts executing on next(), after context.with() around
+  // its construction has already returned. Bind every protocol operation so
+  // provider iteration and wrapper-side telemetry retain the request context.
+  return {
+    next: (...args: [] | [TNext]) =>
+      context.with(scopedContext, () => stream.next(...args)),
+    return: (value: TReturn | PromiseLike<TReturn>) =>
+      context.with(scopedContext, () => stream.return(value)),
+    throw: (error: unknown) =>
+      context.with(scopedContext, () => stream.throw(error)),
+    [Symbol.asyncIterator]() {
+      return this;
+    },
   };
 }
 
@@ -188,6 +209,7 @@ export class LoggingContentGenerator implements ContentGenerator {
     contents: Content[],
     model: string,
     promptId: string,
+    sessionId: string,
   ): void {
     const requestText = JSON.stringify(contents);
     logApiRequest(
@@ -198,6 +220,7 @@ export class LoggingContentGenerator implements ContentGenerator {
         requestText,
         subagentNameContext.getStore(),
       ),
+      sessionId,
     );
   }
 
@@ -206,6 +229,7 @@ export class LoggingContentGenerator implements ContentGenerator {
     durationMs: number,
     model: string,
     prompt_id: string,
+    sessionId: string,
     usageMetadata?: GenerateContentResponseUsageMetadata,
     responseText?: string,
     ttftMs?: number,
@@ -223,6 +247,7 @@ export class LoggingContentGenerator implements ContentGenerator {
         subagentNameContext.getStore(),
         ttftMs,
       ),
+      sessionId,
     );
   }
 
@@ -232,6 +257,7 @@ export class LoggingContentGenerator implements ContentGenerator {
     error: unknown,
     model: string,
     prompt_id: string,
+    sessionId: string,
   ): void {
     const errorMessage = getErrorMessage(error);
     const errorType = getErrorType(error);
@@ -254,6 +280,7 @@ export class LoggingContentGenerator implements ContentGenerator {
         statusCode: errorStatus,
         subagentName: subagentNameContext.getStore(),
       }),
+      sessionId,
     );
   }
 
@@ -263,6 +290,7 @@ export class LoggingContentGenerator implements ContentGenerator {
     error: unknown,
     model: string,
     prompt_id: string,
+    sessionId: string,
     abortSignal?: AbortSignal,
   ): void {
     // A user cancel is not an API error, so skip the api_error event entirely —
@@ -275,7 +303,14 @@ export class LoggingContentGenerator implements ContentGenerator {
       return;
     }
     try {
-      this._logApiError(responseId, durationMs, error, model, prompt_id);
+      this._logApiError(
+        responseId,
+        durationMs,
+        error,
+        model,
+        prompt_id,
+        sessionId,
+      );
     } catch (loggingError) {
       debugLogger.warn('Failed to log API error:', loggingError);
     }
@@ -286,6 +321,7 @@ export class LoggingContentGenerator implements ContentGenerator {
     durationMs: number,
     model: string,
     prompt_id: string,
+    sessionId: string,
     usageMetadata?: GenerateContentResponseUsageMetadata,
     responseText?: string,
     ttftMs?: number,
@@ -296,6 +332,7 @@ export class LoggingContentGenerator implements ContentGenerator {
         durationMs,
         model,
         prompt_id,
+        sessionId,
         usageMetadata,
         responseText,
         ttftMs,
@@ -313,25 +350,28 @@ export class LoggingContentGenerator implements ContentGenerator {
     // await. ALS frame from `retryWithBackoff` is guaranteed to be active here.
     const retrySnapshot = snapshotRetryMetadata();
 
-    const llmSpan = startLLMRequestSpan(req.model, userPromptId, {
-      operationName: this.genAiOperationName,
-      providerName: this.genAiProviderName,
-      outputType: resolveGenAiOutputType(this.generatorAuthType, req.config),
-    });
+    const ownerSessionId = this.config.getSessionId();
+    const ownerUserId = this.config.getTelemetryUserId();
+    const { span: llmSpan, context: llmContext } =
+      startLLMRequestSpanWithContext(req.model, userPromptId, {
+        operationName: this.genAiOperationName,
+        providerName: this.genAiProviderName,
+        outputType: resolveGenAiOutputType(this.generatorAuthType, req.config),
+        sessionId: ownerSessionId,
+        userId: ownerUserId,
+      });
+    const requestSessionId =
+      getSessionIdFromContext(llmContext) ?? ownerSessionId;
     // Capture span context so the API call and logging activate it via
     // context.with(). Without this, nested OTel spans (HTTP instrumentation,
     // log-bridge spans) parent to session root instead of llm_request.
     const isInternal = isInternalPromptId(userPromptId);
-    const exchange = createGenAiExchange(
-      trace.setSpan(context.active(), llmSpan),
-      llmSpan,
-      {
-        captureContent:
-          !isInternal && this.shouldCollectSensitiveSpanAttributes(),
-        sensitiveAttributeMaxLength:
-          this.config.getTelemetrySensitiveSpanAttributeMaxLength(),
-      },
-    );
+    const exchange = createGenAiExchange(llmContext, llmSpan, {
+      captureContent:
+        !isInternal && this.shouldCollectSensitiveSpanAttributes(),
+      sensitiveAttributeMaxLength:
+        this.config.getTelemetrySensitiveSpanAttributeMaxLength(),
+    });
     const spanContext = exchange.context;
 
     const startTime = Date.now();
@@ -347,6 +387,7 @@ export class LoggingContentGenerator implements ContentGenerator {
             this.toContents(req.contents),
             req.model,
             userPromptId,
+            requestSessionId,
           );
         }
         const result = await session.wrap(() =>
@@ -361,6 +402,7 @@ export class LoggingContentGenerator implements ContentGenerator {
           durationMs,
           result.modelVersion || req.model,
           userPromptId,
+          requestSessionId,
           result.usageMetadata,
           responseText,
         );
@@ -419,6 +461,7 @@ export class LoggingContentGenerator implements ContentGenerator {
           error,
           req.model,
           userPromptId,
+          requestSessionId,
           req.config?.abortSignal,
         );
         try {
@@ -449,11 +492,18 @@ export class LoggingContentGenerator implements ContentGenerator {
     // endLLMRequestSpan callsites (success / error / idle-timeout / abort).
     const retrySnapshot = snapshotRetryMetadata();
 
-    const llmSpan = startLLMRequestSpan(req.model, userPromptId, {
-      operationName: this.genAiOperationName,
-      providerName: this.genAiProviderName,
-      outputType: resolveGenAiOutputType(this.generatorAuthType, req.config),
-    });
+    const ownerSessionId = this.config.getSessionId();
+    const ownerUserId = this.config.getTelemetryUserId();
+    const { span: llmSpan, context: llmContext } =
+      startLLMRequestSpanWithContext(req.model, userPromptId, {
+        operationName: this.genAiOperationName,
+        providerName: this.genAiProviderName,
+        outputType: resolveGenAiOutputType(this.generatorAuthType, req.config),
+        sessionId: ownerSessionId,
+        userId: ownerUserId,
+      });
+    const requestSessionId =
+      getSessionIdFromContext(llmContext) ?? ownerSessionId;
     try {
       llmSpan.setAttribute('gen_ai.request.stream', true);
     } catch {
@@ -463,16 +513,12 @@ export class LoggingContentGenerator implements ContentGenerator {
     // Capture the span context so the stream wrapper can activate it
     // during iteration — not just during generator creation.
     const isInternal = isInternalPromptId(userPromptId);
-    const exchange = createGenAiExchange(
-      trace.setSpan(context.active(), llmSpan),
-      llmSpan,
-      {
-        captureContent:
-          !isInternal && this.shouldCollectSensitiveSpanAttributes(),
-        sensitiveAttributeMaxLength:
-          this.config.getTelemetrySensitiveSpanAttributeMaxLength(),
-      },
-    );
+    const exchange = createGenAiExchange(llmContext, llmSpan, {
+      captureContent:
+        !isInternal && this.shouldCollectSensitiveSpanAttributes(),
+      sensitiveAttributeMaxLength:
+        this.config.getTelemetrySensitiveSpanAttributeMaxLength(),
+    });
     const spanContext = exchange.context;
 
     const startTime = Date.now();
@@ -493,6 +539,7 @@ export class LoggingContentGenerator implements ContentGenerator {
             this.toContents(req.contents),
             req.model,
             userPromptId,
+            requestSessionId,
           );
         }
         return session.wrap(async () => {
@@ -514,6 +561,7 @@ export class LoggingContentGenerator implements ContentGenerator {
           error,
           req.model,
           userPromptId,
+          requestSessionId,
           req.config?.abortSignal,
         ),
       );
@@ -552,20 +600,21 @@ export class LoggingContentGenerator implements ContentGenerator {
         })
       : undefined;
 
-    return context.with(spanContext, () =>
+    return bindAsyncGeneratorToContext(
       this.loggingStreamWrapper(
         stream,
         startTime,
         requestIssuedAtMs,
         userPromptId,
         req.model,
+        requestSessionId,
         openaiRequestPromise,
         llmSpan,
-        spanContext,
         req.config?.abortSignal,
         retrySnapshot,
         exchange.controller,
       ),
+      spanContext,
     );
   }
 
@@ -597,11 +646,11 @@ export class LoggingContentGenerator implements ContentGenerator {
     requestIssuedAtMs: number,
     userPromptId: string,
     model: string,
+    sessionId: string,
     openaiRequestPromise?: Promise<
       OpenAI.Chat.ChatCompletionCreateParams | undefined
     >,
     span?: Span,
-    spanContext?: Context,
     abortSignal?: AbortSignal,
     // Phase 4b — snapshot of retry context captured BEFORE the stream wrapper
     // returned, when the ALS frame from `retryWithBackoff` was still active.
@@ -650,12 +699,6 @@ export class LoggingContentGenerator implements ContentGenerator {
     // again (the helper would no-op, but more importantly we skip the
     // redundant work and avoid resetting the timer further).
     let spanEndedByTimeout = false;
-
-    // Helper to run code within the span context during iteration.
-    // This ensures debug log lines emitted during stream processing
-    // see the stream span as the active span.
-    const runInSpan = <T>(fn: () => T): T =>
-      spanContext ? context.with(spanContext, fn) : fn();
 
     // Idle timeout: if no chunks arrive for this duration the consumer has
     // likely abandoned the generator without calling .return(). Close the
@@ -789,25 +832,22 @@ export class LoggingContentGenerator implements ContentGenerator {
       // the timeout signal and a parallel "success" record would be confusing
       // during incident response.
       if (!spanEndedByTimeout) {
-        runInSpan(() =>
-          this.safelyLogApiResponse(
-            firstResponseId,
-            durationMs,
-            firstModelVersion || model,
-            userPromptId,
-            lastUsageMetadata,
-            streamResponseText,
-            ttftMs,
-          ),
+        this.safelyLogApiResponse(
+          firstResponseId,
+          durationMs,
+          firstModelVersion || model,
+          userPromptId,
+          sessionId,
+          lastUsageMetadata,
+          streamResponseText,
+          ttftMs,
         );
         const openaiRequest = await openaiRequestPromise;
-        await runInSpan(() =>
-          this.safelyLogOpenAIInteraction(
-            openaiRequest,
-            consolidatedResponse,
-            undefined,
-            userPromptId,
-          ),
+        await this.safelyLogOpenAIInteraction(
+          openaiRequest,
+          consolidatedResponse,
+          undefined,
+          userPromptId,
         );
       }
     } catch (error) {
@@ -820,24 +860,21 @@ export class LoggingContentGenerator implements ContentGenerator {
       // + api_error log — just on the error branch.
       if (!spanEndedByTimeout) {
         const durationMs = Date.now() - startTime;
-        runInSpan(() =>
-          this.safelyLogApiError(
-            firstResponseId,
-            durationMs,
-            error,
-            firstModelVersion || model,
-            userPromptId,
-            abortSignal,
-          ),
+        this.safelyLogApiError(
+          firstResponseId,
+          durationMs,
+          error,
+          firstModelVersion || model,
+          userPromptId,
+          sessionId,
+          abortSignal,
         );
         const openaiRequest = await openaiRequestPromise;
-        await runInSpan(() =>
-          this.safelyLogOpenAIInteraction(
-            openaiRequest,
-            undefined,
-            error,
-            userPromptId,
-          ),
+        await this.safelyLogOpenAIInteraction(
+          openaiRequest,
+          undefined,
+          error,
+          userPromptId,
         );
       }
       throw error;

--- a/packages/core/src/telemetry/daemon-tracing.test.ts
+++ b/packages/core/src/telemetry/daemon-tracing.test.ts
@@ -32,6 +32,7 @@ import {
   withDaemonSpan,
   withDaemonRequestSpan,
 } from './daemon-tracing.js';
+import { getSessionIdFromContext } from './session-context.js';
 
 describe('daemon-tracing', () => {
   afterEach(() => {
@@ -195,6 +196,37 @@ describe('daemon-tracing', () => {
       expect.any(Function),
     );
     expect(span.end).toHaveBeenCalledOnce();
+  });
+
+  it('binds an explicit daemon session to the callback context', async () => {
+    const span = {
+      setStatus: vi.fn(),
+      end: vi.fn(),
+    } as unknown as Span;
+    vi.spyOn(trace, 'getTracer').mockReturnValue({
+      startActiveSpan: vi.fn(
+        async (
+          _name: string,
+          _options: unknown,
+          fn: (span: Span) => Promise<string>,
+        ) => await fn(span),
+      ),
+    } as unknown as Tracer);
+    let scopedSessionId: string | undefined;
+    vi.spyOn(otelContext, 'with').mockImplementation(
+      (ctx, fn: () => Promise<string>) => {
+        scopedSessionId = getSessionIdFromContext(ctx);
+        return fn();
+      },
+    );
+
+    await withDaemonSpan(
+      'daemon-session',
+      { 'session.id': 'daemon-session-B' },
+      async () => 'ok',
+    );
+
+    expect(scopedSessionId).toBe('daemon-session-B');
   });
 
   it('strips reserved metadata when no active daemon span exists', () => {

--- a/packages/core/src/telemetry/daemon-tracing.ts
+++ b/packages/core/src/telemetry/daemon-tracing.ts
@@ -23,6 +23,7 @@ import {
   formatTraceparent,
   getActiveSpanTraceContext,
 } from './trace-context.js';
+import { setSessionIdOnContext } from './session-context.js';
 
 export const DAEMON_TRACEPARENT_META_KEY = 'qwen.telemetry.traceparent';
 export const DAEMON_TRACESTATE_META_KEY = 'qwen.telemetry.tracestate';
@@ -102,18 +103,25 @@ export async function withDaemonSpan<T>(
     ...(options.startTime ? { startTime: options.startTime } : {}),
   };
   const run = async (span: Span): Promise<T> => {
-    try {
-      const result = await fn(span);
-      if (autoOkOnSuccess) {
-        span.setStatus({ code: SpanStatusCode.OK });
+    const sessionId = attributes['session.id'];
+    const scopedContext = setSessionIdOnContext(
+      otelContext.active(),
+      typeof sessionId === 'string' ? sessionId : undefined,
+    );
+    return await otelContext.with(scopedContext, async () => {
+      try {
+        const result = await fn(span);
+        if (autoOkOnSuccess) {
+          span.setStatus({ code: SpanStatusCode.OK });
+        }
+        return result;
+      } catch (error) {
+        recordDaemonError(span, error);
+        throw error;
+      } finally {
+        span.end();
       }
-      return result;
-    } catch (error) {
-      recordDaemonError(span, error);
-      throw error;
-    } finally {
-      span.end();
-    }
+    });
   };
   return options.parentContext
     ? await tracer.startActiveSpan(

--- a/packages/core/src/telemetry/log-to-span-processor.test.ts
+++ b/packages/core/src/telemetry/log-to-span-processor.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
+  ROOT_CONTEXT,
   SpanKind,
   SpanStatusCode,
   TraceFlags,
@@ -15,12 +16,15 @@ import {
 import { LogToSpanProcessor } from './log-to-span-processor.js';
 import type { ReadableLogRecord } from '@opentelemetry/sdk-logs';
 import type { SpanExporter } from '@opentelemetry/sdk-trace-base';
+import { sessionIdContext } from '../utils/sessionIdContext.js';
 
 let mockCurrentSessionId: string | undefined = undefined;
+let mockScopedSessionId: string | undefined = undefined;
 let mockIsInNativeSubagentSpan = false;
 
 vi.mock('./session-context.js', () => ({
   getCurrentSessionId: () => mockCurrentSessionId,
+  getSessionIdFromContext: () => mockScopedSessionId,
 }));
 
 vi.mock('./session-tracing.js', () => ({
@@ -46,6 +50,8 @@ describe('LogToSpanProcessor', () => {
   beforeEach(() => {
     exportedSpans = [];
     mockCurrentSessionId = undefined;
+    mockScopedSessionId = undefined;
+    mockIsInNativeSubagentSpan = false;
     mockExporter = {
       export: vi.fn((spans, cb) => {
         exportedSpans.push(...spans);
@@ -774,10 +780,51 @@ describe('LogToSpanProcessor', () => {
     expect(exportedSpans[0].spanContext().traceId).toBe(
       deriveTraceId('session-from-context'),
     );
+    expect(exportedSpans[0].attributes['session.id']).toBe(
+      'session-from-context',
+    );
+  });
+
+  it('prefers and stamps the scoped OTel session over the global fallback', async () => {
+    mockCurrentSessionId = 'stale-session';
+    mockScopedSessionId = 'scoped-session';
+    const logRecord = {
+      body: 'scoped event',
+      hrTime: [1000, 0] as [number, number],
+      attributes: {},
+    } as unknown as ReadableLogRecord;
+
+    processor.onEmit(logRecord, ROOT_CONTEXT);
+    await processor.forceFlush();
+
+    const { deriveTraceId } = await import('./trace-id-utils.js');
+    expect(exportedSpans[0].attributes['session.id']).toBe('scoped-session');
+    expect(exportedSpans[0].spanContext().traceId).toBe(
+      deriveTraceId('scoped-session'),
+    );
+  });
+
+  it('uses the per-request session before the global fallback', async () => {
+    mockCurrentSessionId = 'stale-session';
+    const logRecord = {
+      body: 'request-scoped event',
+      hrTime: [1000, 0] as [number, number],
+      attributes: {},
+    } as unknown as ReadableLogRecord;
+
+    sessionIdContext.run('request-session', () => processor.onEmit(logRecord));
+    await processor.forceFlush();
+
+    const { deriveTraceId } = await import('./trace-id-utils.js');
+    expect(exportedSpans[0].attributes['session.id']).toBe('request-session');
+    expect(exportedSpans[0].spanContext().traceId).toBe(
+      deriveTraceId('request-session'),
+    );
   });
 
   it('prefers log record session.id over getCurrentSessionId', async () => {
     mockCurrentSessionId = 'stale-session';
+    mockScopedSessionId = 'wrong-scoped-session';
     const logRecord = {
       body: 'event with session attr',
       hrTime: [1000, 0] as [number, number],
@@ -791,6 +838,7 @@ describe('LogToSpanProcessor', () => {
     expect(exportedSpans[0].spanContext().traceId).toBe(
       deriveTraceId('fresh-session'),
     );
+    expect(exportedSpans[0].attributes['session.id']).toBe('fresh-session');
   });
 
   describe('bridge skip-list (#3731 Phase 3)', () => {

--- a/packages/core/src/telemetry/log-to-span-processor.ts
+++ b/packages/core/src/telemetry/log-to-span-processor.ts
@@ -9,6 +9,7 @@ import {
   SpanKind,
   SpanStatusCode,
   TraceFlags,
+  type Context,
   type HrTime,
   type SpanContext,
 } from '@opentelemetry/api';
@@ -32,8 +33,12 @@ import {
   randomHexString,
   randomSpanId,
 } from './trace-id-utils.js';
-import { getCurrentSessionId } from './session-context.js';
+import {
+  getCurrentSessionId,
+  getSessionIdFromContext,
+} from './session-context.js';
 import { isInNativeSubagentSpan } from './session-tracing.js';
+import { sessionIdContext } from '../utils/sessionIdContext.js';
 
 /**
  * LogRecord event names that have native span coverage when emitted
@@ -147,7 +152,7 @@ export class LogToSpanProcessor implements LogRecordProcessor {
     this.flushTimer.unref();
   }
 
-  onEmit(logRecord: ReadableLogRecord): void {
+  onEmit(logRecord: ReadableLogRecord, emitContext?: Context): void {
     if (this.isShutdown) {
       return;
     }
@@ -208,12 +213,17 @@ export class LogToSpanProcessor implements LogRecordProcessor {
     // Prefer a real active span context when OTel logs provide one, preserving
     // direct parentage. Otherwise derive traceId from session.id so all events
     // in one session appear under a single trace.  Fall back to
-    // getCurrentSessionId() when the log record has no session.id attribute
-    // (e.g. after a session change via /clear or /resume).
+    // the scoped session when the log record has no session.id attribute.
+    // The process-global value remains the last compatibility fallback.
     const parentSpanContext = getValidParentSpanContext(logRecord.spanContext);
-    // || (not ??) so empty-string session.id also falls through to the fallback
+    const explicitSessionId = logRecord.attributes?.['session.id'];
     const sessionId =
-      logRecord.attributes?.['session.id'] || getCurrentSessionId();
+      (typeof explicitSessionId === 'string' && explicitSessionId
+        ? explicitSessionId
+        : undefined) ??
+      (emitContext ? getSessionIdFromContext(emitContext) : undefined) ??
+      (sessionIdContext.getStore() || getCurrentSessionId());
+    if (sessionId) attributes['session.id'] = sessionId;
     let traceId: string;
     if (parentSpanContext) {
       traceId = parentSpanContext.traceId;

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -743,6 +743,25 @@ describe('loggers', () => {
       ).toHaveBeenCalledWith(mockConfig, event);
     });
 
+    it('uses the request session snapshot when provided', () => {
+      const event = new ApiResponseEvent(
+        'test-response-id',
+        'test-model',
+        100,
+        'prompt-id',
+      );
+
+      logApiResponse(mockConfig, event, 'request-session-id');
+
+      expect(mockLogger.emit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attributes: expect.objectContaining({
+            'session.id': 'request-session-id',
+          }),
+        }),
+      );
+    });
+
     it.each([
       'prompt_suggestion',
       'forked_query',
@@ -843,6 +862,29 @@ describe('loggers', () => {
       logApiResponse(configWithRecording, event);
 
       expect(mockRecordUiTelemetryEvent).toHaveBeenCalled();
+    });
+
+    it('uses the request session snapshot when provided', () => {
+      const event = new ApiErrorEvent({
+        model: 'test-model',
+        durationMs: 100,
+        promptId: 'user_query',
+        errorMessage: 'test error',
+      });
+
+      logApiError(
+        makeFakeConfig({ sessionId: 'current-session-id' }),
+        event,
+        'request-session-id',
+      );
+
+      expect(mockLogger.emit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attributes: expect.objectContaining({
+            'session.id': 'request-session-id',
+          }),
+        }),
+      );
     });
 
     it('suppresses chatRecordingService writes inside hidden runs', () => {
@@ -990,6 +1032,20 @@ describe('loggers', () => {
           prompt_id: 'prompt-id-6',
         },
       });
+    });
+
+    it('uses the request session snapshot when provided', () => {
+      const event = new ApiRequestEvent('test-model', 'prompt-id');
+
+      logApiRequest(mockConfig, event, 'request-session-id');
+
+      expect(mockLogger.emit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attributes: expect.objectContaining({
+            'session.id': 'request-session-id',
+          }),
+        }),
+      );
     });
   });
 

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -426,13 +426,18 @@ export function logFileOperation(
   });
 }
 
-export function logApiRequest(config: Config, event: ApiRequestEvent): void {
+export function logApiRequest(
+  config: Config,
+  event: ApiRequestEvent,
+  sessionId?: string,
+): void {
   // QwenLogger.getInstance(config)?.logApiRequestEvent(event);
   if (!isTelemetrySdkInitialized()) return;
 
   const attributes: LogAttributes = {
     ...getCommonAttributes(config),
     ...event,
+    ...(sessionId ? { 'session.id': sessionId } : {}),
     'event.name': EVENT_API_REQUEST,
     'event.timestamp': new Date().toISOString(),
   };
@@ -513,7 +518,11 @@ export function logRipgrepRuntimeRecovery(
   logger.emit(logRecord);
 }
 
-export function logApiError(config: Config, event: ApiErrorEvent): void {
+export function logApiError(
+  config: Config,
+  event: ApiErrorEvent,
+  sessionId?: string,
+): void {
   const uiEvent = {
     ...event,
     'event.name': EVENT_API_ERROR,
@@ -532,6 +541,7 @@ export function logApiError(config: Config, event: ApiErrorEvent): void {
   const attributes: LogAttributes = {
     ...getCommonAttributes(config),
     ...event,
+    ...(sessionId ? { 'session.id': sessionId } : {}),
     'event.name': EVENT_API_ERROR,
     'event.timestamp': new Date().toISOString(),
     ['error.message']: event.error_message,
@@ -585,7 +595,11 @@ export function logApiCancel(config: Config, event: ApiCancelEvent): void {
   logger.emit(logRecord);
 }
 
-export function logApiResponse(config: Config, event: ApiResponseEvent): void {
+export function logApiResponse(
+  config: Config,
+  event: ApiResponseEvent,
+  sessionId?: string,
+): void {
   const uiEvent = {
     ...event,
     'event.name': EVENT_API_RESPONSE,
@@ -603,6 +617,7 @@ export function logApiResponse(config: Config, event: ApiResponseEvent): void {
   const attributes: LogAttributes = {
     ...getCommonAttributes(config),
     ...event,
+    ...(sessionId ? { 'session.id': sessionId } : {}),
     'event.name': EVENT_API_RESPONSE,
     'event.timestamp': new Date().toISOString(),
   };

--- a/packages/core/src/telemetry/sdk-impl.ts
+++ b/packages/core/src/telemetry/sdk-impl.ts
@@ -48,8 +48,12 @@ import {
 } from './file-exporters.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import type { LogToSpanProcessor } from './log-to-span-processor.js';
-import { getCurrentSessionId } from './session-context.js';
+import {
+  getCurrentSessionId,
+  getSessionIdFromContext,
+} from './session-context.js';
 import { resolveHttpOtlpUrl } from './otlp-urls.js';
+import { sessionIdContext } from '../utils/sessionIdContext.js';
 
 /**
  * `TextMapPropagator` that emits nothing. Installed when
@@ -124,10 +128,13 @@ function validateUrl(url: string | undefined): string | undefined {
 }
 
 class SessionIdSpanProcessor implements SpanProcessor {
-  onStart(span: SdkSpan): void {
+  onStart(span: SdkSpan, parentContext: Context): void {
     try {
-      if ((span as unknown as ReadableSpan).attributes?.['session.id']) return;
-      const sessionId = getCurrentSessionId();
+      const existingSessionId = span.attributes['session.id'];
+      if (typeof existingSessionId === 'string' && existingSessionId) return;
+      const sessionId =
+        getSessionIdFromContext(parentContext) ??
+        (sessionIdContext.getStore() || getCurrentSessionId());
       if (sessionId) {
         span.setAttribute('session.id', sessionId);
       }

--- a/packages/core/src/telemetry/sdk.test.ts
+++ b/packages/core/src/telemetry/sdk.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { diag } from '@opentelemetry/api';
+import { diag, ROOT_CONTEXT } from '@opentelemetry/api';
 import type { Config } from '../config/config.js';
 import {
   initializeTelemetry,
@@ -67,12 +67,17 @@ vi.mock('./tracer.js', () => ({
 }));
 
 import { LogToSpanProcessor } from './log-to-span-processor.js';
-import { getCurrentSessionId, setSessionContext } from './session-context.js';
+import {
+  getCurrentSessionId,
+  getSessionIdFromContext,
+  setSessionContext,
+} from './session-context.js';
 import { setShellTracePropagation } from './trace-context.js';
 import { createSessionRootContext } from './tracer.js';
 import { emitSessionEnd, emitSessionStart } from './session-events.js';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici';
+import { sessionIdContext } from '../utils/sessionIdContext.js';
 
 describe('resolveHttpOtlpUrl', () => {
   it('appends signal path to base collector URL', () => {
@@ -138,6 +143,8 @@ describe('Telemetry SDK', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getCurrentSessionId).mockReturnValue(undefined);
+    vi.mocked(getSessionIdFromContext).mockReturnValue(undefined);
     mockConfig = {
       getTelemetryEnabled: () => true,
       getTelemetryOtlpEndpoint: () => 'http://localhost:4317',
@@ -160,7 +167,67 @@ describe('Telemetry SDK', () => {
   });
 
   afterEach(async () => {
+    vi.mocked(getCurrentSessionId).mockReturnValue(undefined);
     await shutdownTelemetry();
+  });
+
+  async function getSessionIdSpanProcessor() {
+    await initializeTelemetry(mockConfig);
+    const constructorCall = vi.mocked(NodeSDK).mock.calls[0]![0]! as {
+      spanProcessors?: Array<{
+        onStart: (span: unknown, parentContext: unknown) => void;
+      }>;
+    };
+    return constructorCall.spanProcessors![0]!;
+  }
+
+  function createSessionSpan(attributes: Record<string, unknown> = {}) {
+    return {
+      attributes,
+      setAttribute: vi.fn((key: string, value: unknown) => {
+        attributes[key] = value;
+      }),
+    };
+  }
+
+  it('stamps automatic spans from scoped context before the global session', async () => {
+    vi.mocked(getSessionIdFromContext).mockReturnValue('scoped-session');
+    vi.mocked(getCurrentSessionId).mockReturnValue('stale-session');
+    const processor = await getSessionIdSpanProcessor();
+    const span = createSessionSpan();
+
+    processor.onStart(span, ROOT_CONTEXT);
+
+    expect(span.setAttribute).toHaveBeenCalledWith(
+      'session.id',
+      'scoped-session',
+    );
+  });
+
+  it('does not overwrite an explicit automatic-span session', async () => {
+    vi.mocked(getSessionIdFromContext).mockReturnValue('scoped-session');
+    const processor = await getSessionIdSpanProcessor();
+    const span = createSessionSpan({ 'session.id': 'explicit-session' });
+
+    processor.onStart(span, ROOT_CONTEXT);
+
+    expect(span.setAttribute).not.toHaveBeenCalled();
+  });
+
+  it('uses the per-request session before the global session', async () => {
+    vi.mocked(getSessionIdFromContext).mockReturnValue(undefined);
+    vi.mocked(getCurrentSessionId).mockReturnValue('stale-session');
+    const processor = await getSessionIdSpanProcessor();
+    const span = createSessionSpan();
+
+    sessionIdContext.run('request-session', () =>
+      processor.onStart(span, ROOT_CONTEXT),
+    );
+
+    expect(span.setAttribute).toHaveBeenCalledWith(
+      'session.id',
+      'request-session',
+    );
   });
 
   it('should use gRPC exporters when protocol is grpc', async () => {

--- a/packages/core/src/telemetry/session-context.test.ts
+++ b/packages/core/src/telemetry/session-context.test.ts
@@ -10,6 +10,8 @@ import {
   getSessionContext,
   setSessionContext,
   getCurrentSessionId,
+  getSessionIdFromContext,
+  setSessionIdOnContext,
 } from './session-context.js';
 
 describe('session-context', () => {
@@ -44,6 +46,23 @@ describe('session-context', () => {
     setSessionContext(undefined);
 
     expect(getSessionContext()).toBeUndefined();
+  });
+});
+
+describe('scoped session context', () => {
+  it('returns a new context carrying the session id', () => {
+    const scoped = setSessionIdOnContext(ROOT_CONTEXT, 'session-scoped');
+
+    expect(scoped).not.toBe(ROOT_CONTEXT);
+    expect(getSessionIdFromContext(scoped)).toBe('session-scoped');
+    expect(getSessionIdFromContext(ROOT_CONTEXT)).toBeUndefined();
+  });
+
+  it('ignores an empty session id', () => {
+    const scoped = setSessionIdOnContext(ROOT_CONTEXT, '');
+
+    expect(scoped).toBe(ROOT_CONTEXT);
+    expect(getSessionIdFromContext(scoped)).toBeUndefined();
   });
 });
 

--- a/packages/core/src/telemetry/session-context.ts
+++ b/packages/core/src/telemetry/session-context.ts
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Context } from '@opentelemetry/api';
+import { createContextKey, type Context } from '@opentelemetry/api';
+
+const sessionIdContextKey = createContextKey('qwen-code.telemetry.session-id');
 
 let sessionRootContext: Context | undefined;
 let currentSessionId: string | undefined;
@@ -23,9 +25,22 @@ export function getSessionContext(): Context | undefined {
 
 /**
  * Returns the most recent session ID passed to setSessionContext.
- * Used by LogToSpanProcessor as a fallback to derive the correct traceId
- * when a log record has no session.id attribute (e.g. after /clear or /resume).
+ * This remains the final compatibility fallback for single-session telemetry
+ * paths that have no explicit owner or scoped context.
  */
 export function getCurrentSessionId(): string | undefined {
   return currentSessionId;
+}
+
+export function setSessionIdOnContext(
+  ctx: Context,
+  sessionId: string | undefined,
+): Context {
+  if (!sessionId) return ctx;
+  return ctx.setValue(sessionIdContextKey, sessionId);
+}
+
+export function getSessionIdFromContext(ctx: Context): string | undefined {
+  const sessionId = ctx.getValue(sessionIdContextKey);
+  return typeof sessionId === 'string' && sessionId ? sessionId : undefined;
 }

--- a/packages/core/src/telemetry/session-tracing.test.ts
+++ b/packages/core/src/telemetry/session-tracing.test.ts
@@ -5,7 +5,13 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { ROOT_CONTEXT, SpanStatusCode } from '@opentelemetry/api';
+import {
+  context as otelContext,
+  createContextKey,
+  ROOT_CONTEXT,
+  SpanStatusCode,
+  trace,
+} from '@opentelemetry/api';
 
 const mockState = vi.hoisted(() => ({
   sdkInitialized: true,
@@ -18,6 +24,7 @@ const mockState = vi.hoisted(() => ({
   // span and `trace.getSpan()` reports it. Lets tests exercise the
   // active-OTel-span fallback in resolveParentContext (#4212).
   activeOtelSpan: undefined as unknown,
+  activeOtelContext: undefined as unknown,
 }));
 
 const mockMetrics = vi.hoisted(() => ({
@@ -62,6 +69,30 @@ vi.mock('@opentelemetry/api', async () => {
     await vi.importActual<typeof import('@opentelemetry/api')>(
       '@opentelemetry/api',
     );
+
+  function createMockContext(
+    properties: Record<string, unknown> = {},
+    values: Map<unknown, unknown> = new Map(),
+    inheritedContext?: { getValue: (key: unknown) => unknown },
+  ) {
+    const mockContext = {
+      ...properties,
+      getValue: (key: unknown) =>
+        values.has(key) ? values.get(key) : inheritedContext?.getValue(key),
+      setValue: (key: unknown, value: unknown) => {
+        const nextValues = new Map(values);
+        nextValues.set(key, value);
+        return createMockContext(properties, nextValues, inheritedContext);
+      },
+      deleteValue: (key: unknown) => {
+        const nextValues = new Map(values);
+        nextValues.delete(key);
+        return createMockContext(properties, nextValues, inheritedContext);
+      },
+    };
+    Object.defineProperty(mockContext, '__contextValues', { value: values });
+    return mockContext;
+  }
 
   function createMockSpan(
     name: string,
@@ -138,21 +169,40 @@ vi.mock('@opentelemetry/api', async () => {
     SpanStatusCode: actual.SpanStatusCode,
     trace: {
       getTracer: () => mockTracer,
-      setSpan: (ctx: unknown, _span: unknown) => ({
-        ...(ctx as object),
-        __parentSpan: _span,
-      }),
+      setSpan: (ctx: unknown, _span: unknown) =>
+        createMockContext(
+          {
+            ...(ctx as object),
+            __parentSpan: _span,
+          },
+          typeof ctx === 'object' && ctx !== null && '__contextValues' in ctx
+            ? ((ctx as { __contextValues: Map<unknown, unknown> })
+                .__contextValues as Map<unknown, unknown>)
+            : new Map(),
+          typeof ctx === 'object' &&
+            ctx !== null &&
+            'getValue' in ctx &&
+            typeof ctx.getValue === 'function'
+            ? (ctx as { getValue: (key: unknown) => unknown })
+            : undefined,
+        ),
       getSpan: (ctx: unknown) =>
-        typeof ctx === 'object' && ctx !== null && '__activeSpan' in ctx
-          ? (ctx as { __activeSpan: unknown }).__activeSpan
+        typeof ctx === 'object' && ctx !== null
+          ? '__parentSpan' in ctx
+            ? (ctx as { __parentSpan: unknown }).__parentSpan
+            : '__activeSpan' in ctx
+              ? (ctx as { __activeSpan: unknown }).__activeSpan
+              : undefined
           : undefined,
       wrapSpanContext: actual.trace.wrapSpanContext,
     },
     context: {
-      active: () =>
-        mockState.activeOtelSpan
-          ? { __activeSpan: mockState.activeOtelSpan }
-          : {},
+      active: () => {
+        if (mockState.activeOtelContext) return mockState.activeOtelContext;
+        return mockState.activeOtelSpan
+          ? createMockContext({ __activeSpan: mockState.activeOtelSpan })
+          : createMockContext();
+      },
       with: <T>(_ctx: unknown, fn: () => T): T => fn(),
     },
   };
@@ -164,6 +214,7 @@ import {
   endInteractionSpan,
   withInteractionSpan,
   startLLMRequestSpan,
+  startLLMRequestSpanWithContext,
   endLLMRequestSpan,
   startToolSpan,
   endToolSpan,
@@ -182,7 +233,12 @@ import {
   runTTLSweepForTesting,
   truncateSpanError,
 } from './session-tracing.js';
-import { setSessionContext } from './session-context.js';
+import {
+  getSessionIdFromContext,
+  setSessionContext,
+  setSessionIdOnContext,
+} from './session-context.js';
+import { sessionIdContext } from '../utils/sessionIdContext.js';
 
 function createMockConfig(
   overrides: Partial<{
@@ -208,6 +264,7 @@ describe('session-tracing', () => {
     mockState.throwOnSetStatus = false;
     mockState.throwOnStartSpan = false;
     mockState.activeOtelSpan = undefined;
+    mockState.activeOtelContext = undefined;
   });
 
   afterEach(() => {
@@ -249,17 +306,22 @@ describe('session-tracing', () => {
     });
 
     it('runs scoped interaction spans without mutating the global interaction context', async () => {
+      const contextWithSpy = vi.spyOn(otelContext, 'with');
       const config = createMockConfig({
         sessionId: 'scoped-session',
         userId: 'scoped-user',
       });
+      const parentContext = ROOT_CONTEXT.setValue(
+        createContextKey('daemon-parent'),
+        'daemon',
+      );
       const result = await withInteractionSpan(
         config,
         {
           promptId: 'prompt-scoped',
           model: 'test-model',
           messageType: 'acp_prompt',
-          parentContext: { parent: 'daemon' } as never,
+          parentContext,
         },
         async () => 'done',
       );
@@ -267,7 +329,7 @@ describe('session-tracing', () => {
       expect(result).toBe('done');
       expect(mockSpans).toHaveLength(1);
       expect(mockSpans[0]!.name).toBe('qwen-code.interaction');
-      expect(mockSpans[0]!.parentContext).toEqual({ parent: 'daemon' });
+      expect(mockSpans[0]!.parentContext).toBe(parentContext);
       expect(mockSpans[0]!.attributes['session.id']).toBe('scoped-session');
       expect(mockSpans[0]!.attributes['gen_ai.user.id']).toBe('scoped-user');
       expect(mockSpans[0]!.attributes['qwen-code.message_type']).toBe(
@@ -275,6 +337,9 @@ describe('session-tracing', () => {
       );
       expect(mockSpans[0]!.ended).toBe(true);
       expect(mockSpans[0]!.statuses.at(-1)?.code).toBe(SpanStatusCode.OK);
+      expect(getSessionIdFromContext(contextWithSpy.mock.calls[0]![0])).toBe(
+        'scoped-session',
+      );
     });
 
     it('marks the interaction span ERROR when getResultStatus returns "error"', async () => {
@@ -438,6 +503,16 @@ describe('session-tracing', () => {
   });
 
   describe('LLM request spans', () => {
+    it('preserves the no-op span context when telemetry is disabled', () => {
+      mockState.sdkInitialized = false;
+
+      const { span, context } = startLLMRequestSpanWithContext('m', 'p', {
+        sessionId: 'owner-session',
+      });
+
+      expect(trace.getSpan(context)).toBe(span);
+    });
+
     it('creates and ends an LLM request span', () => {
       const span = startLLMRequestSpan('test-model', 'prompt-llm');
 
@@ -496,6 +571,137 @@ describe('session-tracing', () => {
       expect(mockSpans[0]!.attributes['llm_request.context']).toBe(
         'standalone',
       );
+    });
+
+    it('uses the owning config identity instead of a stale global session', () => {
+      setSessionContext(undefined, 'bootstrap-session');
+
+      const { span, context } = startLLMRequestSpanWithContext('m', 'p', {
+        sessionId: 'owner-session',
+        userId: 'owner-user',
+      });
+
+      expect(mockSpans[0]!.attributes).toMatchObject({
+        'session.id': 'owner-session',
+        'gen_ai.conversation.id': 'owner-session',
+        'gen_ai.user.id': 'owner-user',
+      });
+      expect(getSessionIdFromContext(context)).toBe('owner-session');
+      endLLMRequestSpan(span, { success: true });
+    });
+
+    it('keeps the logical parent identity ahead of an explicit owner', () => {
+      startInteractionSpan(
+        createMockConfig({
+          sessionId: 'parent-session',
+          userId: 'parent-user',
+        }),
+        { promptId: 'p', model: 'm', messageType: 'userQuery' },
+      );
+
+      const { span, context } = startLLMRequestSpanWithContext('m', 'p', {
+        sessionId: 'different-owner',
+        userId: 'different-user',
+      });
+
+      const record = mockSpans.find(
+        (candidate) => candidate.name === 'qwen-code.llm_request',
+      );
+      expect(record?.attributes['session.id']).toBe('parent-session');
+      expect(record?.attributes['gen_ai.conversation.id']).toBe(
+        'parent-session',
+      );
+      expect(record?.attributes['gen_ai.user.id']).toBe('parent-user');
+      expect(getSessionIdFromContext(context)).toBe('parent-session');
+      endLLMRequestSpan(span, { success: true });
+      endInteractionSpan('ok');
+    });
+
+    it('keeps the logical tool identity ahead of an explicit owner', () => {
+      const contextWithSpy = vi.spyOn(otelContext, 'with');
+      startInteractionSpan(
+        createMockConfig({
+          sessionId: 'parent-session',
+          userId: 'parent-user',
+        }),
+        { promptId: 'p', model: 'm', messageType: 'userQuery' },
+      );
+      const toolSpan = startToolSpan('agent');
+
+      runInToolSpanContext(toolSpan, () => {
+        const { span, context } = startLLMRequestSpanWithContext('m', 'p', {
+          sessionId: 'different-owner',
+          userId: 'different-user',
+        });
+        const record = mockSpans.find(
+          (candidate) => candidate.name === 'qwen-code.llm_request',
+        );
+        expect(record?.attributes['session.id']).toBe('parent-session');
+        expect(record?.attributes['gen_ai.user.id']).toBe('parent-user');
+        expect(getSessionIdFromContext(context)).toBe('parent-session');
+        endLLMRequestSpan(span, { success: true });
+      });
+
+      endToolSpan(toolSpan, { success: true });
+      endInteractionSpan('ok');
+      expect(getSessionIdFromContext(contextWithSpy.mock.calls[0]![0])).toBe(
+        'parent-session',
+      );
+    });
+
+    it('uses the per-request session context before the global fallback', () => {
+      setSessionContext(undefined, 'bootstrap-session');
+
+      const span = sessionIdContext.run('request-session', () =>
+        startLLMRequestSpan('m', 'p'),
+      );
+
+      expect(mockSpans[0]!.attributes['session.id']).toBe('request-session');
+      endLLMRequestSpan(span, { success: true });
+    });
+
+    it('uses the scoped OTel session before per-request and global fallbacks', () => {
+      setSessionContext(undefined, 'bootstrap-session');
+      mockState.activeOtelContext = setSessionIdOnContext(
+        ROOT_CONTEXT,
+        'otel-session',
+      );
+
+      const span = sessionIdContext.run('request-session', () =>
+        startLLMRequestSpan('m', 'p'),
+      );
+
+      expect(mockSpans[0]!.attributes['session.id']).toBe('otel-session');
+      endLLMRequestSpan(span, { success: true });
+    });
+
+    it('keeps standalone owner contexts isolated', async () => {
+      setSessionContext(undefined, 'bootstrap-session');
+
+      const sessionIds = ['session-A', 'session-B'];
+      const started = await Promise.all(
+        sessionIds.map(async (sessionId) =>
+          startLLMRequestSpanWithContext('m', `prompt-${sessionId}`, {
+            sessionId,
+          }),
+        ),
+      );
+
+      for (const [index, sessionId] of sessionIds.entries()) {
+        const record = mockSpans.find(
+          (candidate) =>
+            candidate.attributes['qwen-code.prompt_id'] ===
+            `prompt-${sessionId}`,
+        );
+        expect(record?.attributes['session.id']).toBe(sessionId);
+        expect(record?.attributes['gen_ai.conversation.id']).toBe(sessionId);
+        expect(getSessionIdFromContext(started[index]!.context)).toBe(
+          sessionId,
+        );
+      }
+      for (const { span } of started) {
+        endLLMRequestSpan(span, { success: true });
+      }
     });
 
     it('LLM request span re-parents to active OTel span when no interaction is set (#4212)', () => {
@@ -1208,6 +1414,24 @@ describe('session-tracing', () => {
   });
 
   describe('session.id derives from the owning session, not the process-global (#4602 review)', () => {
+    it('keeps a nested tool on its logical tool session', () => {
+      setSessionContext(undefined, 'bootstrap-session');
+      const outerTool = sessionIdContext.run('tool-session', () =>
+        startToolSpan('outer'),
+      );
+
+      runInToolSpanContext(outerTool, () => {
+        const nestedTool = startToolSpan('nested');
+        const nestedRecord = mockSpans.find(
+          (candidate) => candidate.attributes['gen_ai.tool.name'] === 'nested',
+        );
+        expect(nestedRecord?.attributes['session.id']).toBe('tool-session');
+        endToolSpan(nestedTool, { success: true });
+      });
+
+      endToolSpan(outerTool, { success: true });
+    });
+
     it('stamps a tool span with the interaction session.id even when the process-global belongs to another session', () => {
       // Daemon scenario: telemetry init left the process-global pointing at
       // session B, but the active interaction belongs to session A.
@@ -2225,6 +2449,30 @@ describe('session-tracing', () => {
       sessionId: 'session-uuid',
     } as const;
 
+    it('keeps the logical parent session ahead of the explicit owner', () => {
+      startInteractionSpan(createMockConfig({ sessionId: 'parent-session' }), {
+        promptId: 'p',
+        model: 'm',
+        messageType: 'userQuery',
+      });
+
+      const span = startSubagentSpan({
+        ...baseOpts,
+        sessionId: 'different-owner',
+        invocationKind: 'foreground',
+      });
+      const record = mockSpans.find(
+        (candidate) => candidate.name === 'qwen-code.subagent',
+      );
+      expect(record?.attributes['session.id']).toBe('parent-session');
+      expect(record?.attributes['gen_ai.conversation.id']).toBe(
+        'parent-session',
+      );
+
+      endSubagentSpan(span, { status: 'completed' });
+      endInteractionSpan('ok');
+    });
+
     it('foreground invocation creates a child span (no root flag, no links)', () => {
       const span = startSubagentSpan({
         ...baseOpts,
@@ -2248,6 +2496,7 @@ describe('session-tracing', () => {
       expect(record!.attributes['gen_ai.operation.name']).toBe('invoke_agent');
       expect(record!.attributes['gen_ai.provider.name']).toBeUndefined();
       expect(record!.attributes['gen_ai.conversation.id']).toBe('session-uuid');
+      expect(record!.attributes['session.id']).toBe('session-uuid');
       // Vendor concept attrs.
       expect(record!.attributes['qwen-code.subagent.invocation_kind']).toBe(
         'foreground',
@@ -2488,16 +2737,16 @@ describe('session-tracing', () => {
     });
 
     it('runInSubagentSpanContext wraps fn in context.with', async () => {
-      // Our mocked context.with just runs fn (line 119). The behavioral
-      // assertion is "fn was called and its result returned"; the parent-
-      // context behavior is covered by the integration test in
-      // agent.test.ts where real OTel context propagation matters.
+      const contextWithSpy = vi.spyOn(otelContext, 'with');
       const span = startSubagentSpan({
         ...baseOpts,
         invocationKind: 'foreground',
       });
       const result = await runInSubagentSpanContext(span, async () => 42);
       expect(result).toBe(42);
+      expect(getSessionIdFromContext(contextWithSpy.mock.calls[0]![0])).toBe(
+        'session-uuid',
+      );
       endSubagentSpan(span, { status: 'completed' });
     });
 

--- a/packages/core/src/telemetry/session-tracing.ts
+++ b/packages/core/src/telemetry/session-tracing.ts
@@ -30,9 +30,15 @@ import {
 } from './constants.js';
 import { ApiRequestPhase, recordApiRequestBreakdown } from './metrics.js';
 import { isTelemetrySdkInitialized } from './sdk.js';
-import { getCurrentSessionId, setSessionContext } from './session-context.js';
+import {
+  getCurrentSessionId,
+  getSessionIdFromContext,
+  setSessionContext,
+  setSessionIdOnContext,
+} from './session-context.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import type { ToolExecutionStatus } from '../core/turn.js';
+import { sessionIdContext } from '../utils/sessionIdContext.js';
 
 const debugLogger = createDebugLogger('SESSION_TRACING');
 
@@ -54,6 +60,8 @@ export interface StartLLMRequestSpanOptions {
   operationName?: 'chat' | 'generate_content';
   providerName?: string;
   outputType?: 'text' | 'json' | 'image' | 'speech';
+  sessionId?: string;
+  userId?: string;
 }
 
 export interface LLMRequestMetadata {
@@ -212,8 +220,8 @@ export function isInNativeSubagentSpan(): boolean {
 
 /**
  * Resolve the session.id for a child span (llm_request / tool / tool.execution)
- * from the per-session value carried on the parent span context, falling back
- * to the process-global getCurrentSessionId() only when no parent is present.
+ * from the logical parent, an explicit owner, or the active per-request
+ * contexts. The process-global value is only the final compatibility fallback.
  *
  * A daemon hosts many sessions in one process, but getCurrentSessionId() is a
  * single module-global set at telemetry init — so reading it directly would
@@ -226,22 +234,28 @@ export function isInNativeSubagentSpan(): boolean {
  */
 function resolveSessionId(
   parentCtx: SpanContext | undefined,
+  explicitSessionId?: string,
+  activeContext: Context = otelContext.active(),
 ): string | undefined {
   const fromParent = parentCtx?.attributes?.['session.id'];
-  return typeof fromParent === 'string' && fromParent
-    ? fromParent
-    : getCurrentSessionId();
+  if (typeof fromParent === 'string' && fromParent) return fromParent;
+  if (explicitSessionId) return explicitSessionId;
+  return (
+    getSessionIdFromContext(activeContext) ??
+    (sessionIdContext.getStore() || getCurrentSessionId())
+  );
 }
 
 function resolveGenAiUserId(
   parentCtx: Pick<SpanContext, 'attributes'> | undefined,
   promptId?: string,
+  explicitUserId?: string,
 ): string | undefined {
   const logicalParent =
     parentCtx ??
     (promptId ? interactionIdentityByPromptId.get(promptId) : undefined);
   const value = logicalParent?.attributes['gen_ai.user.id'];
-  return typeof value === 'string' && value ? value : undefined;
+  return typeof value === 'string' && value ? value : explicitUserId;
 }
 
 const activeSpans = new Map<string, WeakRef<SpanContext>>();
@@ -531,9 +545,10 @@ export async function withInteractionSpan<T>(
   ensureCleanupInterval();
   interactionSequence++;
 
+  const sessionId = config.getSessionId();
   const userId = config.getTelemetryUserId();
   const attributes: Attributes = {
-    'session.id': config.getSessionId(),
+    'session.id': sessionId,
     ...(userId ? { 'gen_ai.user.id': userId } : {}),
     'qwen-code.prompt_id': options.promptId,
     'qwen-code.message_type': options.messageType,
@@ -569,7 +584,10 @@ export async function withInteractionSpan<T>(
     interactionIdentityByPromptId.delete(options.promptId);
   }
 
-  const activeContext = trace.setSpan(parentContext, span);
+  const activeContext = trace.setSpan(
+    setSessionIdOnContext(parentContext, sessionId),
+    span,
+  );
   return await otelContext.with(activeContext, async () =>
     interactionContext.run(spanContextObj, async () => {
       let terminalStatus: InteractionStatus = 'ok';
@@ -624,21 +642,44 @@ export function startLLMRequestSpan(
   promptId: string,
   options?: StartLLMRequestSpanOptions,
 ): Span {
+  return startLLMRequestSpanWithContext(model, promptId, options).span;
+}
+
+export function startLLMRequestSpanWithContext(
+  model: string,
+  promptId: string,
+  options?: StartLLMRequestSpanOptions,
+): { span: Span; context: Context } {
   if (!isTelemetrySdkInitialized()) {
-    return NOOP_SPAN;
+    return {
+      span: NOOP_SPAN,
+      context: trace.setSpan(otelContext.active(), NOOP_SPAN),
+    };
   }
 
   // Prefer subagentContext over interactionContext so LLM spans inside a
   // foreground subagent nest under the subagent span instead of escaping
   // back to the outer interaction. wenshao @ #4410.
   const parentCtx = subagentContext.getStore() ?? interactionContext.getStore();
+  const identityParentCtx =
+    subagentContext.getStore() ??
+    toolContext.getStore() ??
+    interactionContext.getStore();
   // resolveParentContext() also re-parents to the active OTel span when
   // present, so a side-query LLM call nested inside a tool span still
   // attaches to the tool span instead of becoming a separate trace root.
   const ctx = resolveParentContext(parentCtx);
 
-  const sessionId = resolveSessionId(parentCtx);
-  const userId = resolveGenAiUserId(parentCtx, promptId);
+  const sessionId = resolveSessionId(
+    identityParentCtx,
+    options?.sessionId,
+    ctx,
+  );
+  const userId = resolveGenAiUserId(
+    identityParentCtx,
+    promptId,
+    options?.userId,
+  );
   const attributes: Attributes = {
     ...(sessionId ? { 'session.id': sessionId } : {}),
     ...(sessionId ? { 'gen_ai.conversation.id': sessionId } : {}),
@@ -662,10 +703,11 @@ export function startLLMRequestSpan(
       : {}),
   };
 
+  const sessionContext = setSessionIdOnContext(ctx, sessionId);
   const span = getTracer().startSpan(
     SPAN_LLM_REQUEST,
     { kind: SpanKind.INTERNAL, attributes },
-    ctx,
+    sessionContext,
   );
 
   const spanId = getSpanId(span);
@@ -678,7 +720,10 @@ export function startLLMRequestSpan(
   activeSpans.set(spanId, new WeakRef(spanContextObj));
   strongSpans.set(spanId, spanContextObj);
 
-  return span;
+  return {
+    span,
+    context: trace.setSpan(sessionContext, span),
+  };
 }
 
 export function endLLMRequestSpan(
@@ -890,12 +935,16 @@ export function startToolSpan(
     // for rationale; wenshao @ #4410).
     const parentCtx =
       subagentContext.getStore() ?? interactionContext.getStore();
+    const identityParentCtx =
+      subagentContext.getStore() ??
+      toolContext.getStore() ??
+      interactionContext.getStore();
     // Same fallback as startLLMRequestSpan: prefer active OTel span for
     // tools-inside-tools cases before becoming a trace root.
     const ctx = resolveParentContext(parentCtx);
 
-    const sessionId = resolveSessionId(parentCtx);
-    const userId = resolveGenAiUserId(parentCtx, promptId);
+    const sessionId = resolveSessionId(identityParentCtx);
+    const userId = resolveGenAiUserId(identityParentCtx, promptId);
     const attributes: Attributes = {
       ...(sessionId ? { 'session.id': sessionId } : {}),
       ...attrs,
@@ -956,7 +1005,11 @@ export function runInToolSpanContext<T>(span: Span, fn: () => T): T {
   const spanId = getSpanId(span);
   const spanCtx = activeSpans.get(spanId)?.deref();
   if (!spanCtx) return fn();
-  const otelCtxWithSpan = trace.setSpan(otelContext.active(), span);
+  const sessionId = resolveSessionId(spanCtx);
+  const otelCtxWithSpan = trace.setSpan(
+    setSessionIdOnContext(otelContext.active(), sessionId),
+    span,
+  );
   return toolContext.run(spanCtx, () => otelContext.with(otelCtxWithSpan, fn));
 }
 
@@ -1497,7 +1550,7 @@ export interface StartSubagentSpanOptions {
   depth: number;
   /** Parent's request id (for cross-trace correlation with parent prompt). */
   invokingRequestId?: string;
-  /** Session id used as `gen_ai.conversation.id`. */
+  /** Session identity used by native and GenAI attributes. */
   sessionId: string;
   /** Model override, if this subagent runs on a different model than parent. */
   modelOverride?: string;
@@ -1550,12 +1603,15 @@ export function startSubagentSpan(opts: StartSubagentSpanOptions): Span {
     subagentContext.getStore() ??
     toolContext.getStore() ??
     interactionContext.getStore();
+  const sessionId =
+    resolveSessionId(parentCtx, opts.sessionId) ?? opts.sessionId;
   const userId = resolveGenAiUserId(parentCtx);
   const attributes: Attributes = {
     // Spec-aligned (OTel GenAI Agent Spans, Development status).
     'gen_ai.operation.name': 'invoke_agent',
     'gen_ai.agent.name': opts.subagentName,
-    'gen_ai.conversation.id': opts.sessionId,
+    'gen_ai.conversation.id': sessionId,
+    'session.id': sessionId,
     ...(userId ? { 'gen_ai.user.id': userId } : {}),
 
     // Vendor identity and lifecycle. The per-invocation ID stays private;
@@ -1671,7 +1727,11 @@ export function runInSubagentSpanContext<T>(
   // of the subagent. The subagent's own inner tools will re-set
   // toolContext via runInToolSpanContext, so inner-tool parenting stays
   // correct. wenshao @ #4410.
-  const otelCtxWithSpan = trace.setSpan(otelContext.active(), span);
+  const sessionId = resolveSessionId(spanCtx);
+  const otelCtxWithSpan = trace.setSpan(
+    setSessionIdOnContext(otelContext.active(), sessionId),
+    span,
+  );
   return subagentContext.run(spanCtx, () =>
     toolContext.run(undefined, () => otelContext.with(otelCtxWithSpan, fn)),
   );


### PR DESCRIPTION
## What this PR does

This PR gives every model request an immutable, request-scoped OpenTelemetry session identity. Logical interaction, tool, or subagent parents remain authoritative; standalone requests use the session owned by their content generator; scoped OpenTelemetry context, request-local context, and the process-global CLI session provide progressively weaker fallbacks. The resolved identity is shared by the native LLM span, instrumented HTTP children, and API log records, including throughout asynchronous stream iteration.

Automatic spans and log-to-span bridging now consult the scoped identity before legacy fallbacks without overwriting explicit session attributes. Interaction, tool, subagent, and daemon callback contexts carry their owning session, while the existing process-global identity remains available for single-session CLI compatibility.

## Why it's needed

A daemon or ACP child can host multiple sessions in one process, but telemetry initialization records only one process-global session. Standalone model operations such as generation and forked queries could therefore emit a native LLM span under the bootstrap session while their API logs used the actual live session. AgentLoop then grouped one model request into two conversations, inflated a synthetic bootstrap conversation, and made real conversations appear shorter.

## Reviewer Test Plan

### How to verify

Start one source-mode daemon, create two thread sessions, and run concurrent streaming generation for both sessions plus a forked query and a normal prompt. For each operation, confirm that the native LLM span has `session.id == gen_ai.conversation.id`, each provider HTTP span is a child of that LLM span with the same session, API request/response/error records use the same LLM trace and session, and the daemon request span uses the routed session. No selected record should contain the daemon bootstrap session.

Also verify that changing a mutable session configuration after a stream is created does not change the session attached to later stream response/error logs, and that a single-session interactive CLI retains its existing global fallback behavior.

### Evidence (Before & After)

N/A (non-UI telemetry fix). Before the fix, reproduced daemon traces showed standalone native LLM spans under the ACP bootstrap session while same-trace API records belonged to the routed session. After the fix, source-mode E2E runs with overlapping A/B streams, a B forked query, a B prompt, and a third session created while B was streaming showed matching ownership across all native LLM, HTTP, API-log, and daemon surfaces with no bootstrap/global ID.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS, Node.js 26.0.0, source-mode daemon/ACP with an isolated temporary home and OpenTelemetry file exporter. Seven focused test files passed with 461 tests; core lint, typecheck, and build passed; a clean dependency install also completed the repository build and bundle.

## Risk & Scope

- Main risk or tradeoff: The change touches core telemetry context propagation, so an incorrect precedence rule could misattribute automatically instrumented spans; focused priority, concurrency, error-path, and live daemon tests cover those boundaries.
- Not validated / out of scope: AgentLoop ENTRY/STEP modeling, turn/react-round attributes, historical telemetry repair, Windows/Linux source E2E, and the existing current-source TUI dependency issue are out of scope.
- Breaking changes / migration notes: None. There is no wire, daemon API, persistence, resource, or data migration change; the process-global session remains the last compatibility fallback.

## Linked Issues

Fixes #9078

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 为每次模型请求建立不可变的请求级 OpenTelemetry 会话身份。已有 interaction、tool 或 subagent 逻辑父级仍是最高权威；standalone 请求使用其内容生成器实际拥有的会话；scoped OpenTelemetry Context、请求级 Context 和进程全局 CLI 会话依次作为更弱的回退。最终身份由 native LLM span、自动 HTTP 子 span 和 API 日志共同使用，并覆盖异步流的完整迭代过程。

自动 span 和 log-to-span bridge 现在会在旧兼容回退前读取 scoped 身份，同时不会覆盖显式 session 属性。interaction、tool、subagent 和 daemon 回调 Context 都携带自身 owning session；现有进程全局身份继续保留，用于单会话 CLI 兼容。

## 为什么需要

一个 daemon 或 ACP child 可以在同一进程承载多个会话，但 telemetry 初始化只记录一个进程全局 session。generation、forked query 等 standalone 模型操作因此可能把 native LLM span 归到 bootstrap session，而 API 日志却使用真实 live session。AgentLoop 会把同一次模型请求拆到两个会话中，膨胀一个虚假的 bootstrap 会话，并让真实会话显得更短。

## Reviewer 测试计划

### 如何验证

启动一个源码模式 daemon，创建两个 thread session，并为两个 session 并发执行流式 generation，再执行 forked query 和普通 prompt。逐个操作确认 native LLM span 满足 `session.id == gen_ai.conversation.id`，provider HTTP span 是对应 LLM span 的直接子级且 session 相同，API request/response/error 记录使用同一个 LLM trace 和 session，daemon request span 使用路由选中的 session。所有选中记录都不应出现 daemon bootstrap session。

同时验证：流创建后修改可变 session 配置不会改变后续流式 response/error 日志的 session；单会话交互 CLI 继续保持现有全局回退行为。

### 证据（修复前后）

N/A（非 UI telemetry 修复）。修复前，daemon 复现 trace 显示 standalone native LLM span 使用 ACP bootstrap session，而同 trace 的 API 记录属于路由选中的 session。修复后，源码 E2E 覆盖相互重叠的 A/B 流、B 的 forked query、B 的普通 prompt，以及 B 流中创建第三个 session；所有 native LLM、HTTP、API 日志和 daemon 记录的归属一致，未出现 bootstrap/global ID。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

macOS、Node.js 26.0.0、隔离临时 home 与 OpenTelemetry file exporter 的源码模式 daemon/ACP。7 个定向测试文件共 461 项通过；core lint、typecheck、build 通过；全新依赖安装也成功完成仓库 build 和 bundle。

## 风险与范围

- 主要风险或权衡：变更涉及 core telemetry Context 传播，错误的优先级可能导致自动 instrumentation span 归属错误；定向测试已覆盖优先级、并发、错误路径和真实 daemon 边界。
- 未验证 / 范围外：AgentLoop ENTRY/STEP 建模、turn/react-round 属性、历史数据修复、Windows/Linux 源码 E2E，以及现有当前源码 TUI 依赖问题均不在本次范围。
- 破坏性变更 / 迁移说明：无。没有 wire、daemon API、持久化、Resource 或数据迁移变化；进程全局 session 继续作为最后的兼容回退。

## 关联 Issue

Fixes #9078（合并时自动关闭）

</details>
