### PR TITLE
fix(desktop): bridge Electron users on Windows and Linux

### DIFF
--- a/.github/scripts/create-electron-bridge-manifest.mjs
+++ b/.github/scripts/create-electron-bridge-manifest.mjs
@@ -6,12 +6,21 @@ import path from 'node:path';
 
 const options = parseArguments(process.argv.slice(2));
 const assets = fs.readdirSync(options.assets).sort();
-const names = [
-  'Qwen-Code-Desktop-arm64.zip',
-  'Qwen-Code-Desktop-x64.zip',
-  'Qwen-Code-Desktop-arm64.dmg',
-  'Qwen-Code-Desktop-x64.dmg',
-];
+const patterns = {
+  macos: [
+    /-arm64\.zip$/i,
+    /-x64\.zip$/i,
+    /-arm64\.dmg$/i,
+    /-x64\.dmg$/i,
+  ],
+  windows: [/-setup\.exe$/i],
+  linux: [/\.AppImage$/i],
+};
+const selectedPatterns = patterns[options.platform];
+if (!selectedPatterns) {
+  throw new Error(`Invalid --platform: ${options.platform}`);
+}
+const names = selectedPatterns.map((pattern) => selectArtifact(assets, pattern));
 const artifacts = names.map((name) => readArtifact(assets, name));
 const primary = artifacts[0];
 
@@ -29,10 +38,17 @@ const lines = [
 ];
 fs.writeFileSync(options.output, `${lines.join('\n')}\n`);
 
-function readArtifact(assets, name) {
-  if (!assets.includes(name)) {
-    throw new Error(`Missing Electron bridge artifact: ${name}`);
+function selectArtifact(assets, pattern) {
+  const matches = assets.filter((asset) => pattern.test(asset));
+  if (matches.length !== 1) {
+    throw new Error(
+      `Expected one Electron bridge artifact matching ${pattern}, found ${matches.length}: ${matches.join(', ')}`,
+    );
   }
+  return matches[0];
+}
+
+function readArtifact(assets, name) {
   const file = path.join(options.assets, name);
   return {
     name,
@@ -52,7 +68,7 @@ function parseArguments(args) {
     if (!name || value === undefined) throw new Error('Invalid arguments.');
     values[name] = value;
   }
-  for (const required of ['assets', 'version', 'output']) {
+  for (const required of ['assets', 'platform', 'version', 'output']) {
     if (!values[required]) throw new Error(`Missing --${required}`);
   }
   if (

--- a/.github/scripts/create-electron-bridge-manifest.mjs
+++ b/.github/scripts/create-electron-bridge-manifest.mjs
@@ -38,6 +38,7 @@ const lines = [
 ];
 fs.writeFileSync(options.output, `${lines.join('\n')}\n`);
 
+// Keep the selection regexes in sync with create-desktop-update-manifest.mjs.
 function selectArtifact(assets, pattern) {
   const matches = assets.filter((asset) => pattern.test(asset));
   if (matches.length !== 1) {

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -664,6 +664,10 @@ jobs:
             fi
             newest="$(printf '%s\n%s\n' "$RELEASE_VERSION" "$current" | sort -V | tail -n 1)"
             if [ "$current" != "$RELEASE_VERSION" ] && [ "$newest" = "$current" ]; then
+              if [ "$ELECTRON_BRIDGE" = 'true' ]; then
+                echo "::error::Electron bridge $RELEASE_VERSION cannot replace newer stable feed $current."
+                exit 1
+              fi
               echo "::notice::Desktop $RELEASE_VERSION will not replace newer stable feed $current."
               exit 0
             fi

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -15,7 +15,7 @@ on:
         default: 'main'
         type: 'string'
       electron_bridge:
-        description: 'Publish the one-time macOS Electron-to-Tauri update bridge.'
+        description: 'Publish the one-time Electron-to-Tauri update bridge for macOS, Windows, and Linux.'
         required: true
         default: false
         type: 'boolean'
@@ -581,10 +581,15 @@ jobs:
             --version "$RELEASE_VERSION" \
             --output desktop-latest.json
           if [ "$ELECTRON_BRIDGE" = 'true' ]; then
-            node ../.github/scripts/create-electron-bridge-manifest.mjs \
-              --assets . \
-              --version "$RELEASE_VERSION" \
-              --output latest-mac.yml
+            for manifest in macos:latest-mac.yml windows:latest.yml linux:latest-linux.yml; do
+              platform="${manifest%%:*}"
+              output="${manifest#*:}"
+              node ../.github/scripts/create-electron-bridge-manifest.mjs \
+                --assets . \
+                --platform "$platform" \
+                --version "$RELEASE_VERSION" \
+                --output "$output"
+            done
           fi
           sha256sum -- * > SHA256SUMS.txt
 
@@ -629,12 +634,23 @@ jobs:
           set -euo pipefail
           feed_assets=(release-assets/desktop-latest.json)
           if [ "$ELECTRON_BRIDGE" = 'true' ]; then
+            shopt -s nullglob
+            windows_installers=(release-assets/*-setup.exe)
+            linux_appimages=(release-assets/*.AppImage)
+            if [ "${#windows_installers[@]}" -ne 1 ] || [ "${#linux_appimages[@]}" -ne 1 ]; then
+              echo '::error::The Electron bridge requires one Windows installer and one Linux AppImage.'
+              exit 1
+            fi
             feed_assets+=(
               release-assets/latest-mac.yml
+              release-assets/latest.yml
+              release-assets/latest-linux.yml
               release-assets/Qwen-Code-Desktop-arm64.zip
               release-assets/Qwen-Code-Desktop-x64.zip
               release-assets/Qwen-Code-Desktop-arm64.dmg
               release-assets/Qwen-Code-Desktop-x64.dmg
+              "${windows_installers[0]}"
+              "${linux_appimages[0]}"
             )
           fi
           if gh release view "$FEED_TAG" >/dev/null 2>&1; then

--- a/docs/design/desktop-electron-to-tauri-update-bridge.md
+++ b/docs/design/desktop-electron-to-tauri-update-bridge.md
@@ -2,65 +2,21 @@
 
 ## Context
 
-The last published desktop release, `desktop-v0.0.5`, is an Electron app named `Qwen Code Desktop` with bundle identifier `com.alibaba.qwen-code`. Its macOS updater reads `latest-mac.yml` from the fixed `desktop-latest` release and installs a ZIP archive.
-
-The new desktop shell is a Tauri app. It currently uses a different product name and bundle identifier and publishes `desktop-latest.json`, so the existing Electron app cannot discover or replace it.
-
-## Goals
-
-- Let signed macOS Electron `0.0.5` installations update directly to the first stable Tauri release.
-- Preserve the existing macOS application identity so the updater replaces the installed app bundle.
-- Keep Tauri's signed updater feed for all releases after the migration.
-- Make the bridge opt-in and one-time; later releases must not need Electron build tooling.
-
-## Non-goals
-
-- Migrating Electron settings, sessions, or workspace state. The Tauri app may ask for a workspace on first launch.
-- Bridging Windows or Linux Electron installations.
-- Generating Electron differential blockmaps. Electron updater falls back to the checksum-verified full ZIP.
+The legacy Electron desktop reads `latest-mac.yml`, `latest.yml`, or `latest-linux.yml` from the fixed `desktop-latest` release. The Tauri desktop reads `desktop-latest.json` from the same release. A stable release can therefore expose both update formats over the same Tauri installers without building Electron again.
 
 ## Compatibility contract
 
-The Tauri bundle uses the legacy macOS identity:
+The Tauri bundle keeps the legacy product name and application identifier. With `electron_bridge` enabled, the release workflow publishes:
 
-- product name: `Qwen Code Desktop`
-- bundle identifier: `com.alibaba.qwen-code`
-- artifact prefix: `Qwen-Code-Desktop`
-- signing identity: the existing Developer ID Application certificate
+- `latest-mac.yml` plus ZIP and DMG payloads for Apple Silicon and Intel;
+- `latest.yml` plus the x64 NSIS installer for Windows;
+- `latest-linux.yml` plus the x64 AppImage for Linux;
+- `desktop-latest.json` for Tauri clients on all platforms.
 
-The bridge release must be newer than `0.0.5`. It publishes two updater views over the same signed app bundles:
+The macOS ZIPs are created from the signed and notarized Tauri app. Windows removes the matching per-user Electron installation through its registered uninstaller before Tauri writes files, preserving user data and avoiding duplicate uninstall entries. Linux AppImage updates replace the current AppImage directly.
 
-1. `latest-mac.yml` points legacy Electron clients at `Qwen-Code-Desktop-arm64.zip` or `Qwen-Code-Desktop-x64.zip`.
-2. `desktop-latest.json` points Tauri clients at the signed Tauri updater archives.
+## Release usage
 
-The ZIP is created from the already signed and notarized `.app`; it is not rebuilt by Electron tooling.
+Run `Desktop Release` for the next stable version with `electron_bridge=true`, `dry_run=false`, `draft=false`, and `prerelease=false`. The bridge is one-time: the fixed `desktop-latest` release retains the three Electron manifests and payloads when later Tauri-only releases update `desktop-latest.json`.
 
-## Release flow
-
-`Desktop Release` gains an `electron_bridge` input, disabled by default.
-
-- All macOS builds continue to produce the Tauri app, DMG, updater archive, and updater signature.
-- When `electron_bridge` is enabled, each macOS build also creates a legacy-compatible ZIP.
-- The publish job generates `latest-mac.yml` from the two ZIPs and two DMGs.
-- A stable bridge release uploads the legacy metadata and payloads to `desktop-latest` together with `desktop-latest.json`.
-- Later stable releases leave `electron_bridge` disabled. Updating `desktop-latest.json` does not remove the bridge files, so Electron installations that return later can still cross to Tauri.
-
-Draft and prerelease runs may build and publish bridge artifacts for inspection, but they never update the stable feed.
-
-## Signing credentials
-
-The repository already stores the Electron-era Apple certificate and App Store Connect API key under `MAC_CSC_*` and `APPLE_NOTARY_*` secret names. The workflow accepts those names as fallbacks for the newer Tauri names, so the Developer ID identity remains unchanged.
-
-Tauri updater artifacts additionally require `TAURI_SIGNING_PRIVATE_KEY`; `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` is only needed for an encrypted private key. The private key must match the public key in the Tauri configuration before the first published Tauri release.
-
-## Validation
-
-Automated release-helper tests verify:
-
-- the legacy application identity,
-- exact bridge artifact selection,
-- SHA-512 and size values in `latest-mac.yml`,
-- failure when a required bridge artifact is missing,
-- existing Tauri updater manifest and version synchronization behavior.
-
-Before the stable release, install the signed `desktop-v0.0.5` arm64 and x64 builds, point them at an isolated bridge feed, and verify both `0.0.5 -> Tauri bridge` and `Tauri bridge -> newer Tauri` updates.
+Before publishing, verify each signed legacy client can install the bridge and that the resulting Tauri app can then update to a newer Tauri release. Do not remove the bridge assets from `desktop-latest` while legacy Electron installations remain supported.

--- a/packages/desktop-shell/README.md
+++ b/packages/desktop-shell/README.md
@@ -65,6 +65,6 @@ cargo test --manifest-path src-tauri/Cargo.toml
 
 The `Desktop Release` workflow builds signed updater artifacts when `dry_run` is disabled. Published releases require the Tauri updater private key. macOS releases also require Apple signing and notarization credentials.
 
-The first stable Tauri release may set `electron_bridge=true` to publish the macOS ZIPs and `latest-mac.yml` consumed by Electron `0.0.5`. Leave the input disabled for later releases; the fixed `desktop-latest` release retains the bridge assets while `desktop-latest.json` advances independently.
+The first stable Tauri release may set `electron_bridge=true` to publish the macOS ZIPs and DMGs, Windows NSIS installer, Linux AppImage, and their Electron `0.0.5` manifests. Leave the input disabled for later releases; the fixed `desktop-latest` release retains the bridge assets while `desktop-latest.json` advances independently.
 
 The macOS workflow accepts either the Tauri-era `APPLE_*` certificate and notarization secrets or the existing `MAC_CSC_*` and `APPLE_NOTARY_*` secrets. `TAURI_SIGNING_PRIVATE_KEY` must match the public key in `src-tauri/tauri.conf.json`.

--- a/packages/desktop-shell/scripts/test-release.js
+++ b/packages/desktop-shell/scripts/test-release.js
@@ -214,6 +214,10 @@ function testLegacyApplicationIdentity() {
   );
   assert.match(
     migrationHook,
+    /\$\{AndIf\} \$\{FileExists\} "\$R0\\Uninstall Qwen Code Desktop\.exe"/,
+  );
+  assert.match(
+    migrationHook,
     /ExecWait '"\$R0\\Uninstall Qwen Code Desktop\.exe" \/currentuser \/S --updated _\?=\$R0'/,
   );
   assert.match(migrationHook, /\$\{If\} \$R2 != 0\s*\n\s*Abort/);

--- a/packages/desktop-shell/scripts/test-release.js
+++ b/packages/desktop-shell/scripts/test-release.js
@@ -198,6 +198,22 @@ function testLegacyApplicationIdentity() {
   );
   assert.equal(config.productName, 'Qwen Code Desktop');
   assert.equal(config.identifier, 'com.alibaba.qwen-code');
+  assert.equal(
+    config.bundle.windows.nsis.installerHooks,
+    'windows/electron-migration.nsh',
+  );
+  const migrationHook = fs.readFileSync(
+    path.join(packageDir, 'src-tauri', 'windows', 'electron-migration.nsh'),
+    'utf8',
+  );
+  assert.match(
+    migrationHook,
+    /Software\\821b18a9-7c63-5bb4-9e20-51ba63d5ecc3/,
+  );
+  assert.match(
+    migrationHook,
+    /ExecWait '\"\$R0\\Uninstall Qwen Code Desktop\.exe\" \/currentuser \/S --updated _\?=\$R0'/,
+  );
 }
 
 function testElectronBridgeWorkflow() {
@@ -207,6 +223,11 @@ function testElectronBridgeWorkflow() {
   );
   assert.match(workflow, /^ {6}electron_bridge:$/m);
   assert.match(workflow, /create-electron-bridge-manifest\.mjs/);
+  assert.match(workflow, /macos:latest-mac\.yml/);
+  assert.match(workflow, /windows:latest\.yml/);
+  assert.match(workflow, /linux:latest-linux\.yml/);
+  assert.match(workflow, /windows_installers=\(release-assets\/\*-setup\.exe\)/);
+  assert.match(workflow, /linux_appimages=\(release-assets\/\*\.AppImage\)/);
   for (const artifact of [
     'Qwen-Code-Desktop-arm64.zip',
     'Qwen-Code-Desktop-x64.zip',
@@ -824,23 +845,53 @@ function testElectronBridgeManifest(directory) {
   for (const artifact of artifacts) {
     fs.writeFileSync(path.join(assets, artifact), `contents:${artifact}`);
   }
-  const output = path.join(directory, 'latest-mac.yml');
-  execFileSync(process.execPath, [
-    electronBridgeScript,
-    '--assets',
-    assets,
-    '--version',
-    '0.1.0',
-    '--output',
-    output,
-  ]);
-  const manifest = fs.readFileSync(output, 'utf8');
-  assert.match(manifest, /^version: 0\.1\.0$/m);
-  assert.match(
-    manifest,
-    /^releaseDate: '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z'$/m,
+  artifacts.push(
+    'Qwen-Code-Desktop_0.1.0_x64-setup.exe',
+    'Qwen-Code-Desktop_0.1.0_amd64.AppImage',
   );
-  for (const artifact of artifacts) {
+  for (const artifact of artifacts.slice(4)) {
+    fs.writeFileSync(path.join(assets, artifact), `contents:${artifact}`);
+  }
+  const macOutput = path.join(directory, 'latest-mac.yml');
+  for (const [platform, filename, selected] of [
+    ['macos', 'latest-mac.yml', artifacts.slice(0, 4)],
+    ['windows', 'latest.yml', artifacts.slice(4, 5)],
+    ['linux', 'latest-linux.yml', artifacts.slice(5, 6)],
+  ]) {
+    const output = path.join(directory, filename);
+    execFileSync(process.execPath, [
+      electronBridgeScript,
+      '--assets',
+      assets,
+      '--platform',
+      platform,
+      '--version',
+      '0.1.0',
+      '--output',
+      output,
+    ]);
+    const manifest = fs.readFileSync(output, 'utf8');
+    assert.match(manifest, /^version: 0\.1\.0$/m);
+    assert.match(
+      manifest,
+      /^releaseDate: '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z'$/m,
+    );
+    for (const artifact of selected) {
+      const contents = fs.readFileSync(path.join(assets, artifact));
+      const sha512 = crypto
+        .createHash('sha512')
+        .update(contents)
+        .digest('base64');
+      assert.ok(manifest.includes(`url: ${artifact}`));
+      assert.ok(manifest.includes(`sha512: ${sha512}`));
+      assert.ok(manifest.includes(`size: ${contents.length}`));
+    }
+  }
+  const manifest = fs.readFileSync(
+    path.join(directory, 'latest-mac.yml'),
+    'utf8',
+  );
+  for (const artifact of artifacts.slice(0, 4)) {
     const contents = fs.readFileSync(path.join(assets, artifact));
     const sha512 = crypto
       .createHash('sha512')
@@ -872,15 +923,17 @@ function testElectronBridgeManifest(directory) {
       electronBridgeScript,
       '--assets',
       assets,
+      '--platform',
+      'macos',
       '--version',
       '0.1.0',
       '--output',
-      output,
+      macOutput,
     ],
     { encoding: 'utf8' },
   );
   assert.notEqual(failure.status, 0);
-  assert.match(failure.stderr, /Missing Electron bridge artifact/);
+  assert.match(failure.stderr, /Expected one Electron bridge artifact/);
 
   const invalidVersion = spawnSync(
     process.execPath,
@@ -888,10 +941,12 @@ function testElectronBridgeManifest(directory) {
       electronBridgeScript,
       '--assets',
       assets,
+      '--platform',
+      'macos',
       '--version',
       '0.1',
       '--output',
-      output,
+      macOutput,
     ],
     { encoding: 'utf8' },
   );
@@ -900,7 +955,15 @@ function testElectronBridgeManifest(directory) {
 
   const missingOutput = spawnSync(
     process.execPath,
-    [electronBridgeScript, '--assets', assets, '--version', '0.1.0'],
+    [
+      electronBridgeScript,
+      '--assets',
+      assets,
+      '--platform',
+      'macos',
+      '--version',
+      '0.1.0',
+    ],
     { encoding: 'utf8' },
   );
   assert.notEqual(missingOutput.status, 0);

--- a/packages/desktop-shell/scripts/test-release.js
+++ b/packages/desktop-shell/scripts/test-release.js
@@ -212,7 +212,7 @@ function testLegacyApplicationIdentity() {
   );
   assert.match(
     migrationHook,
-    /ExecWait '\"\$R0\\Uninstall Qwen Code Desktop\.exe\" \/currentuser \/S --updated _\?=\$R0'/,
+    /ExecWait '"\$R0\\Uninstall Qwen Code Desktop\.exe" \/currentuser \/S --updated _\?=\$R0'/,
   );
 }
 

--- a/packages/desktop-shell/scripts/test-release.js
+++ b/packages/desktop-shell/scripts/test-release.js
@@ -206,14 +206,17 @@ function testLegacyApplicationIdentity() {
     path.join(packageDir, 'src-tauri', 'windows', 'electron-migration.nsh'),
     'utf8',
   );
+  assert.match(migrationHook, /Software\\821b18a9-7c63-5bb4-9e20-51ba63d5ecc3/);
+  assert.match(migrationHook, /!macro NSIS_HOOK_PREINSTALL/);
   assert.match(
     migrationHook,
-    /Software\\821b18a9-7c63-5bb4-9e20-51ba63d5ecc3/,
+    /StrCpy \$R1 \$R1 17\s*\n\s*\$\{If\} \$R0 != ""\s*\n\s*\$\{AndIf\} \$R1 == "Qwen Code Desktop"/,
   );
   assert.match(
     migrationHook,
     /ExecWait '"\$R0\\Uninstall Qwen Code Desktop\.exe" \/currentuser \/S --updated _\?=\$R0'/,
   );
+  assert.match(migrationHook, /\$\{If\} \$R2 != 0\s*\n\s*Abort/);
 }
 
 function testElectronBridgeWorkflow() {
@@ -226,8 +229,19 @@ function testElectronBridgeWorkflow() {
   assert.match(workflow, /macos:latest-mac\.yml/);
   assert.match(workflow, /windows:latest\.yml/);
   assert.match(workflow, /linux:latest-linux\.yml/);
-  assert.match(workflow, /windows_installers=\(release-assets\/\*-setup\.exe\)/);
+  assert.match(
+    workflow,
+    /windows_installers=\(release-assets\/\*-setup\.exe\)/,
+  );
   assert.match(workflow, /linux_appimages=\(release-assets\/\*\.AppImage\)/);
+  assert.match(workflow, /^\s+release-assets\/latest\.yml$/m);
+  assert.match(workflow, /^\s+release-assets\/latest-linux\.yml$/m);
+  assert.match(workflow, /^\s+"\$\{windows_installers\[0\]\}"$/m);
+  assert.match(workflow, /^\s+"\$\{linux_appimages\[0\]\}"$/m);
+  assert.match(
+    workflow,
+    /if \[ "\$ELECTRON_BRIDGE" = 'true' \]; then\s+echo "::error::Electron bridge \$RELEASE_VERSION cannot replace newer stable feed \$current\."\s+exit 1/,
+  );
   for (const artifact of [
     'Qwen-Code-Desktop-arm64.zip',
     'Qwen-Code-Desktop-x64.zip',
@@ -882,39 +896,49 @@ function testElectronBridgeManifest(directory) {
         .createHash('sha512')
         .update(contents)
         .digest('base64');
-      assert.ok(manifest.includes(`url: ${artifact}`));
-      assert.ok(manifest.includes(`sha512: ${sha512}`));
-      assert.ok(manifest.includes(`size: ${contents.length}`));
+      assert.match(
+        manifest,
+        new RegExp(
+          `^  - url: ${artifact.replaceAll('.', '\\.')}\\n    sha512: ${sha512.replaceAll('+', '\\+')}\\n    size: ${contents.length}$`,
+          'm',
+        ),
+      );
+      if (artifact === selected[0]) {
+        assert.match(
+          manifest,
+          new RegExp(`^path: ${artifact.replaceAll('.', '\\.')}$`, 'm'),
+        );
+        assert.match(
+          manifest,
+          new RegExp(`^sha512: ${sha512.replaceAll('+', '\\+')}$`, 'm'),
+        );
+      }
     }
+    assert.equal((manifest.match(/^  - url:/gm) ?? []).length, selected.length);
   }
-  const manifest = fs.readFileSync(
-    path.join(directory, 'latest-mac.yml'),
-    'utf8',
+  const duplicateWindowsArtifact = path.join(
+    assets,
+    'Qwen-Code-Desktop_0.1.0_arm64-setup.exe',
   );
-  for (const artifact of artifacts.slice(0, 4)) {
-    const contents = fs.readFileSync(path.join(assets, artifact));
-    const sha512 = crypto
-      .createHash('sha512')
-      .update(contents)
-      .digest('base64');
-    assert.match(
-      manifest,
-      new RegExp(
-        `^  - url: ${artifact.replaceAll('.', '\\.')}\\n    sha512: ${sha512.replaceAll('+', '\\+')}\\n    size: ${contents.length}$`,
-        'm',
-      ),
-    );
-  }
-  const arm64Contents = fs.readFileSync(path.join(assets, artifacts[0]));
-  const arm64Sha512 = crypto
-    .createHash('sha512')
-    .update(arm64Contents)
-    .digest('base64');
-  assert.match(manifest, /^path: Qwen-Code-Desktop-arm64\.zip$/m);
-  assert.match(
-    manifest,
-    new RegExp(`^sha512: ${arm64Sha512.replaceAll('+', '\\+')}$`, 'm'),
+  fs.writeFileSync(duplicateWindowsArtifact, 'duplicate');
+  const ambiguousWindows = spawnSync(
+    process.execPath,
+    [
+      electronBridgeScript,
+      '--assets',
+      assets,
+      '--platform',
+      'windows',
+      '--version',
+      '0.1.0',
+      '--output',
+      path.join(directory, 'ambiguous-windows.yml'),
+    ],
+    { encoding: 'utf8' },
   );
+  assert.notEqual(ambiguousWindows.status, 0);
+  assert.match(ambiguousWindows.stderr, /found 2/);
+  fs.rmSync(duplicateWindowsArtifact);
 
   fs.rmSync(path.join(assets, artifacts[1]));
   const failure = spawnSync(

--- a/packages/desktop-shell/scripts/test-release.js
+++ b/packages/desktop-shell/scripts/test-release.js
@@ -914,7 +914,10 @@ function testElectronBridgeManifest(directory) {
         );
       }
     }
-    assert.equal((manifest.match(/^  - url:/gm) ?? []).length, selected.length);
+    assert.equal(
+      (manifest.match(/^ {2}- url:/gm) ?? []).length,
+      selected.length,
+    );
   }
   const duplicateWindowsArtifact = path.join(
     assets,

--- a/packages/desktop-shell/src-tauri/tauri.conf.json
+++ b/packages/desktop-shell/src-tauri/tauri.conf.json
@@ -51,7 +51,8 @@
       },
       "nsis": {
         "installMode": "currentUser",
-        "installerIcon": "icons/icon.ico"
+        "installerIcon": "icons/icon.ico",
+        "installerHooks": "windows/electron-migration.nsh"
       }
     }
   },

--- a/packages/desktop-shell/src-tauri/windows/electron-migration.nsh
+++ b/packages/desktop-shell/src-tauri/windows/electron-migration.nsh
@@ -7,6 +7,7 @@
   StrCpy $R1 $R1 17
   ${If} $R0 != ""
   ${AndIf} $R1 == "Qwen Code Desktop"
+  ${AndIf} ${FileExists} "$R0\Uninstall Qwen Code Desktop.exe"
     ExecWait '"$R0\Uninstall Qwen Code Desktop.exe" /currentuser /S --updated _?=$R0' $R2
     ${If} $R2 != 0
       Abort "Could not remove the previous Qwen Code Desktop installation."

--- a/packages/desktop-shell/src-tauri/windows/electron-migration.nsh
+++ b/packages/desktop-shell/src-tauri/windows/electron-migration.nsh
@@ -4,6 +4,7 @@
 !macro NSIS_HOOK_PREINSTALL
   ReadRegStr $R0 HKCU "${ELECTRON_INSTALL_KEY}" "InstallLocation"
   ReadRegStr $R1 HKCU "${ELECTRON_UNINSTALL_KEY}" "DisplayName"
+  StrCpy $R1 $R1 17
   ${If} $R0 != ""
   ${AndIf} $R1 == "Qwen Code Desktop"
     ExecWait '"$R0\Uninstall Qwen Code Desktop.exe" /currentuser /S --updated _?=$R0' $R2

--- a/packages/desktop-shell/src-tauri/windows/electron-migration.nsh
+++ b/packages/desktop-shell/src-tauri/windows/electron-migration.nsh
@@ -1,0 +1,14 @@
+!define ELECTRON_INSTALL_KEY "Software\821b18a9-7c63-5bb4-9e20-51ba63d5ecc3"
+!define ELECTRON_UNINSTALL_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\821b18a9-7c63-5bb4-9e20-51ba63d5ecc3"
+
+!macro NSIS_HOOK_PREINSTALL
+  ReadRegStr $R0 HKCU "${ELECTRON_INSTALL_KEY}" "InstallLocation"
+  ReadRegStr $R1 HKCU "${ELECTRON_UNINSTALL_KEY}" "DisplayName"
+  ${If} $R0 != ""
+  ${AndIf} $R1 == "Qwen Code Desktop"
+    ExecWait '"$R0\Uninstall Qwen Code Desktop.exe" /currentuser /S --updated _?=$R0' $R2
+    ${If} $R2 != 0
+      Abort "Could not remove the previous Qwen Code Desktop installation."
+    ${EndIf}
+  ${EndIf}
+!macroend


### PR DESCRIPTION
## What this PR does

This PR extends the existing one-time Electron-to-Tauri update bridge from macOS to Windows and Linux. A bridge release now publishes the legacy Electron manifests and the matching Tauri installer payloads for all three supported platforms while retaining the normal Tauri updater feed.

On Windows, the Tauri installer recognizes the matching per-user Electron installation and runs its registered uninstaller in update mode before copying Tauri files. This preserves user data and avoids leaving a second uninstall entry that could later remove the new installation. The release documentation now describes the cross-platform contract and operator flow.

## Why it's needed

The live `desktop-latest` release currently serves Tauri `0.2.1`, but `latest.yml` and `latest-linux.yml` still advertise Electron `0.0.5`. Windows and Linux users installed from the Electron release therefore cannot discover the Tauri desktop through their existing updater. This closes that gap while reusing the release artifacts and bridge mechanism already proven on macOS.

## Reviewer Test Plan

### How to verify

1. Run the desktop release contract check and confirm it generates checksum-verified Electron manifests for macOS ZIP/DMG, Windows NSIS, and Linux AppImage fixtures, including the missing-artifact failure path.
2. Inspect a stable release dry run with `electron_bridge=true` and confirm the fixed `desktop-latest` feed receives `latest-mac.yml`, `latest.yml`, `latest-linux.yml`, their matching payloads, and `desktop-latest.json`.
3. On a disposable Windows VM with Electron `0.0.5`, install a signed bridge build and confirm Electron is removed without deleting user data, only one Qwen Code Desktop uninstall entry remains, and the Tauri app can update again through its JSON feed.
4. Repeat the update hop with the published Electron AppImage on Linux and both Electron ZIP variants on macOS.

### Evidence (Before & After)

N/A — release infrastructure and installer migration only; no UI change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ release-contract checks |
| 🪟 Windows | ⚠️ signed installer rehearsal required before release |
|  🐧 Linux  | ⚠️ published AppImage rehearsal required before release |

### Environment (optional)

macOS arm64, Node.js 22.22.0. `npm run test:release --prefix packages/desktop-shell`, `actionlint .github/workflows/desktop-release.yml`, and `git diff --check` passed.

## Risk & Scope

- Main risk or tradeoff: The Windows migration uses the stable Electron application ID and uninstall filename contract; the signed release must still be rehearsed on a disposable VM before publication.
- Not validated / out of scope: Settings/session schema migration and real signed Electron → Tauri → newer Tauri installation on Windows and Linux.
- Breaking changes / migration notes: Run the next stable release once with `electron_bridge=true`; later Tauri-only releases leave the fixed Electron bridge assets intact.

## Linked Issues

Resolves #9074

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 将现有的一次性 Electron → Tauri 更新桥接从 macOS 扩展到 Windows 和 Linux。桥接版本现在会为三个受支持平台发布旧 Electron 更新器可识别的清单及相应的 Tauri 安装包，同时保留正常的 Tauri 更新源。

在 Windows 上，Tauri 安装器会识别同一应用的当前用户 Electron 安装，并在复制 Tauri 文件前以更新模式运行其已注册的卸载程序。这样既保留用户数据，也避免遗留第二个卸载项，防止以后卸载旧项时误删新安装。发布文档现在也声明了跨平台兼容契约和操作方式。

## 为什么需要

线上 `desktop-latest` Release 当前已经提供 Tauri `0.2.1`，但 `latest.yml` 和 `latest-linux.yml` 仍然发布 Electron `0.0.5`。因此从 Electron 版本安装的 Windows 和 Linux 用户无法通过现有更新器发现 Tauri 桌面端。这个改动复用已经在 macOS 验证过的发布资产和桥接机制，补齐这一缺口。

## Reviewer 测试计划

### 如何验证

1. 运行桌面发布契约检查，确认它能针对 macOS ZIP/DMG、Windows NSIS 和 Linux AppImage fixture 生成带校验的 Electron 清单，并覆盖缺少资产时的失败路径。
2. 使用 `electron_bridge=true` 检查稳定版 dry run，确认固定 `desktop-latest` feed 收到 `latest-mac.yml`、`latest.yml`、`latest-linux.yml`、对应载荷以及 `desktop-latest.json`。
3. 在安装 Electron `0.0.5` 的一次性 Windows 虚拟机中安装已签名桥接版，确认 Electron 被移除但用户数据保留、系统中只剩一个 Qwen Code Desktop 卸载项，且 Tauri 应用之后可以继续通过 JSON feed 更新。
4. 使用已发布的 Electron AppImage 在 Linux 重复升级，并在 macOS 对两个 Electron ZIP 架构重复验证。

### 证据（Before & After）

N/A——仅涉及发布基础设施和安装器迁移，没有 UI 变化。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | ✅ 发布契约检查 |
| 🪟 Windows | ⚠️ 发布前需完成签名安装器演练 |
|  🐧 Linux  | ⚠️ 发布前需完成已发布 AppImage 演练 |

### 环境（可选）

macOS arm64，Node.js 22.22.0。`npm run test:release --prefix packages/desktop-shell`、`actionlint .github/workflows/desktop-release.yml` 和 `git diff --check` 均通过。

## 风险与范围

- 主要风险或取舍：Windows 迁移依赖稳定的 Electron application ID 与卸载文件名契约；正式发布前仍需在一次性虚拟机中演练已签名版本。
- 未验证 / 范围外：设置/会话 schema 迁移，以及 Windows、Linux 上真实签名的 Electron → Tauri → 更新 Tauri 安装链路。
- 破坏性变更 / 迁移说明：下一个稳定版使用 `electron_bridge=true` 执行一次；后续仅发布 Tauri 的版本会保留固定 Electron 桥接资产。

## 关联 Issue

Resolves #9074

</details>
