### PR TITLE
feat(omni): S6 governance — object-store GC with byte budget, JSONL trajectory export

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -4769,3 +4769,53 @@ describe('loadCliConfig skills.directories', () => {
     expect(config.getCustomSkillDirs()).toEqual([]);
   });
 });
+
+describe('loadCliConfig omni settings key validation', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.argv = ['node', 'script.js'];
+  });
+
+  it('accepts known nested omni keys (storage, memory, processing maps)', async () => {
+    const argv = await parseArguments();
+    const settings: Settings = {
+      omni: {
+        storage: { retentionDays: 7, maxTotalBytes: 1024 * 1024 * 1024 },
+        memory: { recall: { mode: 'active' } },
+        processing: {
+          // Free-form map: policy names are user-defined — the walk must
+          // stop at map nodes instead of rejecting every name.
+          fixedPolicies: {
+            'my-policy': { priority: 10, toolName: 'omni_extract_audio' },
+          },
+        },
+      },
+    } as Settings;
+
+    await expect(loadCliConfig(settings, argv)).resolves.toBeDefined();
+  });
+
+  it('rejects an unknown key directly under omni', async () => {
+    const argv = await parseArguments();
+    const settings = {
+      omni: { storag: { retentionDays: 7 } },
+    } as unknown as Settings;
+
+    await expect(loadCliConfig(settings, argv)).rejects.toThrow(
+      /unknown key\(s\) under "omni".*"storag"/s,
+    );
+  });
+
+  it('rejects an unknown NESTED key with its full path', async () => {
+    // The deletion-controlling knobs live at omni.storage.* — a typo
+    // there must fail loud instead of leaving the GC on defaults.
+    const argv = await parseArguments();
+    const settings = {
+      omni: { storage: { retentionDay: 7 } },
+    } as unknown as Settings;
+
+    await expect(loadCliConfig(settings, argv)).rejects.toThrow(
+      /unknown key\(s\) under "omni\.storage".*"retentionDay"/s,
+    );
+  });
+});

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -1499,20 +1499,46 @@ function assertKnownOmniSettingKeys(settings: Settings): void {
   const schemaOmni = getSettingsSchema()['omni'] as
     | { properties?: Record<string, unknown> }
     | undefined;
-  const allowed = new Set(Object.keys(schemaOmni?.properties ?? {}));
   // No schema properties resolved (unexpected): stay silent rather than
   // rejecting every valid key.
-  if (allowed.size === 0) return;
-  const unknown = Object.keys(omni).filter((key) => !allowed.has(key));
-  if (unknown.length > 0) {
-    throw new Error(
-      `Invalid settings: unknown key(s) under "omni": ` +
-        `${unknown.map((k) => `"${k}"`).join(', ')}. ` +
-        `Allowed: ${[...allowed].sort().join(', ')}. ` +
-        `An unrecognized omni section would be silently ignored, leaving ` +
-        `the session running with defaults instead of your configuration.`,
-    );
-  }
+  if (Object.keys(schemaOmni?.properties ?? {}).length === 0) return;
+
+  // Walk nested object settings too: the deletion-controlling knobs live
+  // at `omni.storage.*`, and a typo there would silently leave the GC on
+  // defaults. Free-form map nodes (fixedPolicies, policyTools — schema
+  // nodes without `properties`) stop the walk: their keys are
+  // user-defined.
+  const walk = (
+    value: unknown,
+    schemaNode: { properties?: Record<string, unknown> } | undefined,
+    label: string,
+  ): void => {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+      return;
+    }
+    const props = schemaNode?.properties;
+    if (!props || Object.keys(props).length === 0) return;
+    const allowed = new Set(Object.keys(props));
+    const unknown = Object.keys(value).filter((key) => !allowed.has(key));
+    if (unknown.length > 0) {
+      throw new Error(
+        `Invalid settings: unknown key(s) under "${label}": ` +
+          `${unknown.map((k) => `"${k}"`).join(', ')}. ` +
+          `Allowed: ${[...allowed].sort().join(', ')}. ` +
+          `An unrecognized ${label} entry would be silently ignored, ` +
+          `leaving the session running with defaults instead of your ` +
+          `configuration.`,
+      );
+    }
+    for (const [key, child] of Object.entries(value)) {
+      walk(
+        child,
+        props[key] as { properties?: Record<string, unknown> } | undefined,
+        `${label}.${key}`,
+      );
+    }
+  };
+  walk(omni, schemaOmni, 'omni');
 }
 
 export async function loadCliConfig(

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -2256,6 +2256,8 @@ export async function loadCliConfig(
     omniQuarantineRetentionDays:
       settings.omni?.storage?.quarantine?.retentionDays,
     omniQuarantineMaxBytes: settings.omni?.storage?.quarantine?.maxBytes,
+    omniStorageRetentionDays: settings.omni?.storage?.retentionDays,
+    omniStorageMaxTotalBytes: settings.omni?.storage?.maxTotalBytes,
     omniMemory: settings.omni?.memory as Record<string, unknown> | undefined,
     // CDP tunnel (Plan C, #5626): with the tunnel on, browser automation goes
     // through the CDP tunnel (far lighter than the OS-level computer-use

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -3992,6 +3992,39 @@ const SETTINGS_SCHEMA = {
         description: 'Managed storage settings under .qwen/omni/.',
         showInDialog: false,
         properties: {
+          retentionDays: {
+            type: 'integer',
+            label: 'Object Retention (days)',
+            category: 'Experimental',
+            requiresRestart: true,
+            default: 14,
+            description:
+              'Days an object in .qwen/omni/objects/ that no memory ' +
+              'record references survives before garbage collection may ' +
+              'remove it. Referenced objects are never removed. Must be ' +
+              'at least 1; non-positive values fall back to the default.',
+            showInDialog: false,
+            jsonSchemaOverride: { type: 'integer', minimum: 1, default: 14 },
+          },
+          maxTotalBytes: {
+            type: 'integer',
+            label: 'Object Store Max Bytes',
+            category: 'Experimental',
+            requiresRestart: true,
+            default: 21474836480,
+            description:
+              'Soft byte budget for .qwen/omni/objects/. Over budget, ' +
+              'garbage collection removes the oldest unreferenced ' +
+              'objects regardless of age; if only referenced objects ' +
+              'remain it warns and suspends new policy derivations ' +
+              'instead of deleting them. Defaults to 20 GiB.',
+            showInDialog: false,
+            jsonSchemaOverride: {
+              type: 'integer',
+              minimum: 1,
+              default: 21474836480,
+            },
+          },
           quarantine: {
             type: 'object',
             label: 'Omni Quarantine',

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -623,6 +623,51 @@ describe('Server Config (config.ts)', () => {
     );
   });
 
+  describe('omni storage GC getters (settings → sweep knobs)', () => {
+    it('passes through valid settings', () => {
+      const config = new Config({
+        ...baseParams,
+        omniStorageRetentionDays: 3,
+        omniStorageMaxTotalBytes: 1024,
+      });
+      expect(config.getOmniStorageRetentionDays()).toBe(3);
+      expect(config.getOmniStorageMaxTotalBytes()).toBe(1024);
+    });
+
+    it.each([
+      ['unset', undefined],
+      ['zero', 0],
+      ['negative', -1],
+      ['NaN', Number.NaN],
+      ['Infinity', Number.POSITIVE_INFINITY],
+      // Sub-day retention would gut the multi-process grace window the
+      // GC's safety argument leans on — the schema promises minimum 1.
+      ['sub-day', 0.5],
+    ])('retentionDays falls back to 14 on a %s setting', (_label, bad) => {
+      const config = new Config({
+        ...baseParams,
+        omniStorageRetentionDays: bad,
+      });
+      expect(config.getOmniStorageRetentionDays()).toBe(14);
+    });
+
+    it.each([
+      ['unset', undefined],
+      ['zero', 0],
+      ['negative', -1],
+      ['NaN', Number.NaN],
+      ['Infinity', Number.POSITIVE_INFINITY],
+    ])('maxTotalBytes falls back to 20 GiB on a %s setting', (_label, bad) => {
+      const config = new Config({
+        ...baseParams,
+        omniStorageMaxTotalBytes: bad,
+      });
+      expect(config.getOmniStorageMaxTotalBytes()).toBe(
+        20 * 1024 * 1024 * 1024,
+      );
+    });
+  });
+
   describe('getMemoryAgentTimeoutMinutes', () => {
     it('returns undefined when unset', () => {
       expect(

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -6554,11 +6554,12 @@ export class Config {
   }
 
   getOmniStorageRetentionDays(): number {
-    // Zero/negative/NaN would make the GC treat every unreferenced object
-    // as expired — fall back to the default instead (same fail-safe stance
-    // as the quarantine accessors above).
+    // Zero/negative/NaN/sub-day values would gut the retention grace the
+    // GC's multi-process argument leans on — fall back to the default
+    // instead (the schema promises `minimum: 1`; enforce it here too,
+    // since settings loading never validates jsonSchemaOverride).
     const days = this.omniStorageRetentionDays;
-    return typeof days === 'number' && Number.isFinite(days) && days > 0
+    return typeof days === 'number' && Number.isFinite(days) && days >= 1
       ? days
       : 14;
   }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1131,6 +1131,12 @@ export interface ConfigParameters {
   omniQuarantineRetentionDays?: number;
   /** `omni.storage.quarantine.maxBytes` (default 5 GiB). */
   omniQuarantineMaxBytes?: number;
+  /** `omni.storage.retentionDays` — days an unreferenced object survives
+   * before GC may sweep it (default 14). */
+  omniStorageRetentionDays?: number;
+  /** `omni.storage.maxTotalBytes` — soft byte budget for the object
+   * store (default 20 GiB). */
+  omniStorageMaxTotalBytes?: number;
   /** Raw `omni.memory` settings (collection/recall). Normalized at
    * startup; invalid configuration aborts startup. */
   omniMemory?: Record<string, unknown>;
@@ -1970,6 +1976,8 @@ export class Config {
   private readonly omniTransportGuardPolicies?: Record<string, unknown>;
   private readonly omniProcessingLimits?: Record<string, unknown>;
   private readonly omniQuarantineRetentionDays?: number;
+  private readonly omniStorageRetentionDays?: number;
+  private readonly omniStorageMaxTotalBytes?: number;
   private readonly omniQuarantineMaxBytes?: number;
   private readonly omniMemory?: Record<string, unknown>;
   /** Normalized `omni.processing` view; set once during initialize()
@@ -2269,6 +2277,8 @@ export class Config {
     this.omniProcessingLimits = params.omniProcessingLimits;
     this.omniQuarantineRetentionDays = params.omniQuarantineRetentionDays;
     this.omniQuarantineMaxBytes = params.omniQuarantineMaxBytes;
+    this.omniStorageRetentionDays = params.omniStorageRetentionDays;
+    this.omniStorageMaxTotalBytes = params.omniStorageMaxTotalBytes;
     this.omniMemory = params.omniMemory;
     this.workflowsEnabled = params.workflowsEnabled ?? false;
     this.skipWorkflowUsageWarning = params.skipWorkflowUsageWarning ?? false;
@@ -6541,6 +6551,23 @@ export class Config {
     return typeof bytes === 'number' && Number.isFinite(bytes) && bytes > 0
       ? bytes
       : 5 * 1024 * 1024 * 1024;
+  }
+
+  getOmniStorageRetentionDays(): number {
+    // Zero/negative/NaN would make the GC treat every unreferenced object
+    // as expired — fall back to the default instead (same fail-safe stance
+    // as the quarantine accessors above).
+    const days = this.omniStorageRetentionDays;
+    return typeof days === 'number' && Number.isFinite(days) && days > 0
+      ? days
+      : 14;
+  }
+
+  getOmniStorageMaxTotalBytes(): number {
+    const bytes = this.omniStorageMaxTotalBytes;
+    return typeof bytes === 'number' && Number.isFinite(bytes) && bytes > 0
+      ? bytes
+      : 20 * 1024 * 1024 * 1024;
   }
 
   resolveImageGenerationModel(

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -2955,6 +2955,12 @@ export class GeminiClient {
             systemReminders.push(
               formatOmniMemorySideQueryReminder(omniRecall.result),
             );
+            // The user record was persisted before this reminder existed —
+            // record the payload so the transcript (and the trajectory
+            // exporter) shows what memory the model was actually given.
+            this.config
+              .getChatRecordingService()
+              ?.recordOmniRecallReminder(omniRecall.result);
           } else if (omniRecall?.reason) {
             // A degraded passive recall is invisible by construction: the
             // turn proceeds normally, just without the memory it was

--- a/packages/core/src/omni/disclosure.ts
+++ b/packages/core/src/omni/disclosure.ts
@@ -19,12 +19,58 @@
  * this prefix to keep the disclosure adjacent to its media part. */
 export const OMNI_DISCLOSURE_TEXT_PREFIX = '【媒体降质】';
 
+/**
+ * The annotation grammar separates the display name from the payload with
+ * a full-width colon — but a display name (a basename) may itself contain
+ * one. Writers escape the name so a reader can split at the first
+ * UNESCAPED separator instead of guessing; names without the separator
+ * pass through unchanged, so the model-visible text is identical in the
+ * common case.
+ */
+export function escapeAnnotationName(name: string): string {
+  return name.replaceAll('\\', '\\\\').replaceAll('：', '\\：');
+}
+
+/** Inverse of {@link escapeAnnotationName}. */
+export function unescapeAnnotationName(escaped: string): string {
+  return escaped.replace(/\\([\s\S])/g, '$1');
+}
+
+/**
+ * Split an annotation body `<escaped-name>：<payload>` at the first
+ * unescaped separator. Returns undefined when no unescaped separator
+ * exists (not an annotation body).
+ */
+export function splitAnnotationBody(
+  body: string,
+): { name: string; payload: string } | undefined {
+  let escaped = false;
+  for (let i = 0; i < body.length; i++) {
+    const ch = body[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (ch === '：') {
+      return {
+        name: unescapeAnnotationName(body.slice(0, i)),
+        payload: body.slice(i + 1),
+      };
+    }
+  }
+  return undefined;
+}
+
 /** Model-facing disclosure text for one degraded resource. */
 export function formatDisclosureText(
   displayName: string,
   disclosure: string,
 ): string {
-  return `${OMNI_DISCLOSURE_TEXT_PREFIX}${displayName}：${disclosure}`;
+  return `${OMNI_DISCLOSURE_TEXT_PREFIX}${escapeAnnotationName(displayName)}：${disclosure}`;
 }
 
 /** Whether a text is a disclosure emitted by {@link formatDisclosureText}. */
@@ -42,7 +88,7 @@ export function formatOmissionText(
   displayName: string,
   reason: string,
 ): string {
-  return `${OMNI_OMISSION_TEXT_PREFIX}${displayName}：${reason}`;
+  return `${OMNI_OMISSION_TEXT_PREFIX}${escapeAnnotationName(displayName)}：${reason}`;
 }
 
 /** Marks a text Part as a media transcript: a text derivative (upstream P
@@ -56,7 +102,7 @@ export function formatTranscriptText(
   displayName: string,
   transcript: string,
 ): string {
-  return `${OMNI_TRANSCRIPT_TEXT_PREFIX}${displayName}：${transcript}`;
+  return `${OMNI_TRANSCRIPT_TEXT_PREFIX}${escapeAnnotationName(displayName)}：${transcript}`;
 }
 
 /** Marks a text Part as a session resource-handle annotation: the opaque
@@ -71,7 +117,7 @@ export function formatResourceHandleText(
   displayName: string,
   resourceId: string,
 ): string {
-  return `${OMNI_RESOURCE_HANDLE_TEXT_PREFIX}${displayName}：${resourceId}`;
+  return `${OMNI_RESOURCE_HANDLE_TEXT_PREFIX}${escapeAnnotationName(displayName)}：${resourceId}`;
 }
 
 /** Extract the resourceId from a handle annotation emitted by

--- a/packages/core/src/omni/export.test.ts
+++ b/packages/core/src/omni/export.test.ts
@@ -1,0 +1,279 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { MediaMemoryService } from '../services/media-memory/index.js';
+import {
+  formatDisclosureText,
+  formatOmissionText,
+  formatResourceHandleText,
+} from './disclosure.js';
+import {
+  exportOmniTrajectory,
+  serializeOmniTrajectory,
+  writeOmniTrajectoryJsonl,
+  type OmniTrajectoryExecutionRecord,
+  type OmniTrajectoryFileRecord,
+  type OmniTrajectoryTurnRecord,
+} from './export.js';
+
+describe('exportOmniTrajectory', () => {
+  let tmpDir: string;
+  let omniRootDir: string;
+  let transcriptPath: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'omni-export-'));
+    omniRootDir = path.join(tmpDir, 'omni');
+    await fs.mkdir(omniRootDir, { recursive: true });
+    transcriptPath = path.join(tmpDir, 'session.jsonl');
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  function transcriptLine(record: Record<string, unknown>): string {
+    return JSON.stringify({ sessionId: 's-1', ...record });
+  }
+
+  async function writeTranscript(lines: string[]): Promise<void> {
+    await fs.writeFile(transcriptPath, lines.join('\n') + '\n', 'utf8');
+  }
+
+  /** Seed memory with one user file and one policy execution over it. */
+  async function seedMemory(): Promise<void> {
+    const memory = new MediaMemoryService(omniRootDir);
+    const source = (await memory.recordFileRecognized({
+      fileRef: '/movies/film.mkv',
+      sha256: 'a'.repeat(64),
+      mediaType: 'video',
+      metadata: { durationMs: 5000 },
+      sizeBytes: 100,
+      mimeType: 'video/x-matroska',
+      origin: 'user',
+      source: { protocol: 'local', locator: 'film.mkv' },
+      recognition: {
+        ingestionConfigHash: '',
+        detectorVersion: 'omni-sniff-ffprobe/1',
+        probeStatus: 'complete',
+      },
+    }))!;
+    await memory.commitPolicySucceeded({
+      invocationId: 'call-42',
+      source,
+      executionOrigin: { kind: 'model' },
+      toolName: 'omni_extract_keyframes',
+      finalArguments: { count: 8 },
+      omniConfigHash: 'fp-' + '1'.repeat(61),
+      startedAt: '2026-08-13T00:00:00.000Z',
+      completedAt: '2026-08-13T00:00:09.000Z',
+      outputs: [
+        {
+          kind: 'media',
+          objectPath: path.join(
+            omniRootDir,
+            'objects',
+            'sha256',
+            'bb',
+            `${'b'.repeat(64)}.jpg`,
+          ),
+          sha256: 'b'.repeat(64),
+          mediaType: 'image',
+          metadata: { width: 1280, height: 694 },
+          sizeBytes: 5,
+          mimeType: 'image/jpeg',
+          role: 'keyframe',
+          disclosure: 'sampled 8 frames',
+        },
+      ],
+    });
+  }
+
+  it('assembles turns with media annotations and joins by identity keys', async () => {
+    await seedMemory();
+    await writeTranscript([
+      transcriptLine({
+        type: 'user',
+        timestamp: '2026-08-13T00:00:00.000Z',
+        message: {
+          parts: [
+            { text: '分析这部电影 @film.mkv' },
+            { text: formatResourceHandleText('film.mkv', 'media-1-ab') },
+            { text: formatDisclosureText('film.mkv', '原 1080p → 480p') },
+          ],
+        },
+      }),
+      transcriptLine({
+        type: 'assistant',
+        message: {
+          parts: [
+            { text: '我先抽取关键帧。' },
+            {
+              functionCall: {
+                id: 'call-42',
+                name: 'omni_extract_keyframes',
+                args: {
+                  resourceId: 'media-1-ab',
+                  count: 8,
+                  inputPath: '/secret/abs/path.mkv',
+                  outputDir: '/secret/out',
+                },
+              },
+            },
+          ],
+        },
+      }),
+    ]);
+
+    const records = await exportOmniTrajectory({ omniRootDir, transcriptPath });
+
+    const turn = records.find((r) => r.kind === 'turn') as
+      | OmniTrajectoryTurnRecord
+      | undefined;
+    expect(turn).toBeDefined();
+    expect(turn!.request.text).toContain('分析这部电影');
+    expect(turn!.request.media).toEqual([
+      {
+        name: 'film.mkv',
+        resourceId: 'media-1-ab',
+        disclosures: ['原 1080p → 480p'],
+        transcripts: [],
+      },
+    ]);
+    // Reserved runtime keys are stripped from tool args — the transcript
+    // side must not re-leak the paths memory's finalArguments excludes.
+    expect(turn!.response.toolCalls).toEqual([
+      {
+        callId: 'call-42',
+        name: 'omni_extract_keyframes',
+        args: { resourceId: 'media-1-ab', count: 8 },
+      },
+    ]);
+
+    const execution = records.find((r) => r.kind === 'execution') as
+      | OmniTrajectoryExecutionRecord
+      | undefined;
+    expect(execution).toBeDefined();
+    // The join contract: turn.toolCalls[].callId ↔ execution.invocationId.
+    expect(execution!.invocationId).toBe('call-42');
+    expect(execution!.omniConfigHash).toBe('fp-' + '1'.repeat(61));
+    expect(execution!.outputs).toEqual([
+      {
+        kind: 'derived_media',
+        role: 'keyframe',
+        sha256: 'b'.repeat(64),
+        mimeType: 'image/jpeg',
+        sizeBytes: 5,
+        disclosure: 'sampled 8 frames',
+      },
+    ]);
+
+    const files = records.filter(
+      (r): r is OmniTrajectoryFileRecord => r.kind === 'file',
+    );
+    // Source + derivative, each with its durable identity.
+    expect(files.map((f) => f.sha256).sort()).toEqual([
+      'a'.repeat(64),
+      'b'.repeat(64),
+    ]);
+    const sourceFile = files.find((f) => f.origin === 'user')!;
+    expect(sourceFile.source).toEqual({
+      protocol: 'local',
+      locator: 'film.mkv',
+    });
+  });
+
+  it('captures omissions and extracts an injected passive recall', async () => {
+    await writeTranscript([
+      transcriptLine({
+        type: 'user',
+        message: {
+          parts: [
+            {
+              text:
+                '<system-reminder>\n【媒体记忆】Recalled media memory…\n' +
+                '{"status":"partial","entries":[{"entryId":"e-1"}]}\n' +
+                '</system-reminder>continue please',
+            },
+            { text: formatOmissionText('huge.mkv', 'video exceeds limit') },
+          ],
+        },
+      }),
+      transcriptLine({
+        type: 'assistant',
+        message: { parts: [{ text: '好的。' }] },
+      }),
+    ]);
+
+    const records = await exportOmniTrajectory({ omniRootDir, transcriptPath });
+    const turn = records[0] as OmniTrajectoryTurnRecord;
+
+    expect(turn.request.recall).toEqual({
+      status: 'partial',
+      entries: [{ entryId: 'e-1' }],
+    });
+    // The reminder wrapper is NOT part of the user's request prose.
+    expect(turn.request.text).toBe('continue please');
+    expect(turn.request.media).toEqual([
+      {
+        name: 'huge.mkv',
+        disclosures: [],
+        omitted: 'video exceeds limit',
+        transcripts: [],
+      },
+    ]);
+  });
+
+  it('degrades to transcript-only output when memory is unreadable', async () => {
+    await fs.writeFile(path.join(omniRootDir, 'memory.json'), '{broken');
+    await writeTranscript([
+      transcriptLine({
+        type: 'user',
+        message: { parts: [{ text: 'hello' }] },
+      }),
+    ]);
+
+    const records = await exportOmniTrajectory({ omniRootDir, transcriptPath });
+
+    expect(records).toHaveLength(1);
+    expect(records[0]!.kind).toBe('turn');
+  });
+
+  it('re-exports byte-identically and writes parseable JSONL', async () => {
+    await seedMemory();
+    await writeTranscript([
+      transcriptLine({
+        type: 'user',
+        message: { parts: [{ text: 'q' }] },
+      }),
+    ]);
+
+    const a = serializeOmniTrajectory(
+      await exportOmniTrajectory({ omniRootDir, transcriptPath }),
+    );
+    const b = serializeOmniTrajectory(
+      await exportOmniTrajectory({ omniRootDir, transcriptPath }),
+    );
+    expect(a).toBe(b);
+
+    const outPath = path.join(tmpDir, 'out.jsonl');
+    const { records } = await writeOmniTrajectoryJsonl({
+      omniRootDir,
+      transcriptPath,
+      outPath,
+    });
+    const lines = (await fs.readFile(outPath, 'utf8'))
+      .split('\n')
+      .filter(Boolean);
+    expect(lines).toHaveLength(records);
+    // Every line parses on its own — the whole point of JSONL.
+    for (const line of lines) expect(() => JSON.parse(line)).not.toThrow();
+  });
+});

--- a/packages/core/src/omni/export.test.ts
+++ b/packages/core/src/omni/export.test.ts
@@ -13,6 +13,7 @@ import {
   formatDisclosureText,
   formatOmissionText,
   formatResourceHandleText,
+  formatTranscriptText,
 } from './disclosure.js';
 import {
   exportOmniTrajectory,
@@ -96,6 +97,26 @@ describe('exportOmniTrajectory', () => {
     });
   }
 
+  /** Seed a second, UNRELATED file — a session filter must not export it. */
+  async function seedUnrelatedMemory(): Promise<void> {
+    const memory = new MediaMemoryService(omniRootDir);
+    await memory.recordFileRecognized({
+      fileRef: '/other/unrelated.png',
+      sha256: 'c'.repeat(64),
+      mediaType: 'image',
+      metadata: { width: 8, height: 8 },
+      sizeBytes: 10,
+      mimeType: 'image/png',
+      origin: 'user',
+      source: { protocol: 'local', locator: 'unrelated.png' },
+      recognition: {
+        ingestionConfigHash: '',
+        detectorVersion: 'omni-sniff-ffprobe/1',
+        probeStatus: 'complete',
+      },
+    });
+  }
+
   it('assembles turns with media annotations and joins by identity keys', async () => {
     await seedMemory();
     await writeTranscript([
@@ -119,12 +140,9 @@ describe('exportOmniTrajectory', () => {
               functionCall: {
                 id: 'call-42',
                 name: 'omni_extract_keyframes',
-                args: {
-                  resourceId: 'media-1-ab',
-                  count: 8,
-                  inputPath: '/secret/abs/path.mkv',
-                  outputDir: '/secret/out',
-                },
+                // A gate-possible call shape: the model passes a handle,
+                // never inputPath+resourceId together.
+                args: { resourceId: 'media-1-ab', count: 8 },
               },
             },
           ],
@@ -138,7 +156,8 @@ describe('exportOmniTrajectory', () => {
       | OmniTrajectoryTurnRecord
       | undefined;
     expect(turn).toBeDefined();
-    expect(turn!.request.text).toContain('分析这部电影');
+    // Exact equality: annotation parts must not leak into request prose.
+    expect(turn!.request.text).toBe('分析这部电影 @film.mkv');
     expect(turn!.request.media).toEqual([
       {
         name: 'film.mkv',
@@ -147,8 +166,8 @@ describe('exportOmniTrajectory', () => {
         transcripts: [],
       },
     ]);
-    // Reserved runtime keys are stripped from tool args — the transcript
-    // side must not re-leak the paths memory's finalArguments excludes.
+    // The assistant's visible reply is captured alongside its calls.
+    expect(turn!.response.text).toBe('我先抽取关键帧。');
     expect(turn!.response.toolCalls).toEqual([
       {
         callId: 'call-42',
@@ -188,21 +207,72 @@ describe('exportOmniTrajectory', () => {
       protocol: 'local',
       locator: 'film.mkv',
     });
+    // The fixed-policy join: execution.sourceVersionId resolves to the
+    // source file's version, and the derivative carries its lineage.
+    expect(execution!.sourceVersionId).toBe(sourceFile.fileVersionId);
+    const derived = files.find((f) => f.sha256 === 'b'.repeat(64))!;
+    expect(derived.producedByExecutionId).toBe(execution!.executionId);
+    expect(derived.parentVersionId).toBe(sourceFile.fileVersionId);
   });
 
-  it('captures omissions and extracts an injected passive recall', async () => {
+  it('preserves model-emitted tool arguments verbatim (no scrubbing)', async () => {
+    // The gate explicitly permits a model-authored inputPath (exactly one
+    // of inputPath|resourceId); the recorded assistant turn predates the
+    // harness's runtime-key injection, so whatever is here IS what the
+    // model emitted and must survive the export unchanged.
+    await writeTranscript([
+      transcriptLine({
+        type: 'user',
+        message: { parts: [{ text: 'compress it' }] },
+      }),
+      transcriptLine({
+        type: 'assistant',
+        message: {
+          parts: [
+            {
+              functionCall: {
+                id: 'call-77',
+                name: 'omni_downsample_image',
+                args: { inputPath: '/data/photo.png', quality: 7 },
+              },
+            },
+          ],
+        },
+      }),
+    ]);
+
+    const records = await exportOmniTrajectory({ omniRootDir, transcriptPath });
+    const turn = records[0] as OmniTrajectoryTurnRecord;
+
+    expect(turn.response.toolCalls).toEqual([
+      {
+        callId: 'call-77',
+        name: 'omni_downsample_image',
+        args: { inputPath: '/data/photo.png', quality: 7 },
+      },
+    ]);
+  });
+
+  it('captures omissions, multi-line transcripts, and colon-bearing names', async () => {
     await writeTranscript([
       transcriptLine({
         type: 'user',
         message: {
           parts: [
-            {
-              text:
-                '<system-reminder>\n【媒体记忆】Recalled media memory…\n' +
-                '{"status":"partial","entries":[{"entryId":"e-1"}]}\n' +
-                '</system-reminder>continue please',
-            },
+            { text: 'continue please' },
             { text: formatOmissionText('huge.mkv', 'video exceeds limit') },
+            {
+              // Multi-line transcript payload must survive intact.
+              text: formatTranscriptText(
+                'talk.wav',
+                '[00:00-03:00] first segment\n[03:00-06:00] second segment',
+              ),
+            },
+            {
+              // A display name containing the separator (escaped by the
+              // builder) must round-trip without mis-splitting.
+              text: formatDisclosureText('报告：最终版.mkv', '原 1080p → 480p'),
+            },
           ],
         },
       }),
@@ -215,11 +285,6 @@ describe('exportOmniTrajectory', () => {
     const records = await exportOmniTrajectory({ omniRootDir, transcriptPath });
     const turn = records[0] as OmniTrajectoryTurnRecord;
 
-    expect(turn.request.recall).toEqual({
-      status: 'partial',
-      entries: [{ entryId: 'e-1' }],
-    });
-    // The reminder wrapper is NOT part of the user's request prose.
     expect(turn.request.text).toBe('continue please');
     expect(turn.request.media).toEqual([
       {
@@ -228,11 +293,278 @@ describe('exportOmniTrajectory', () => {
         omitted: 'video exceeds limit',
         transcripts: [],
       },
+      {
+        name: 'talk.wav',
+        disclosures: [],
+        transcripts: [
+          '[00:00-03:00] first segment\n[03:00-06:00] second segment',
+        ],
+      },
+      {
+        name: '报告：最终版.mkv',
+        disclosures: ['原 1080p → 480p'],
+        transcripts: [],
+      },
     ]);
   });
 
-  it('degrades to transcript-only output when memory is unreadable', async () => {
-    await fs.writeFile(path.join(omniRootDir, 'memory.json'), '{broken');
+  it('reads the recall payload from its system record, not from reminders', async () => {
+    const recall = { status: 'partial', entries: [{ entryId: 'e-1' }] };
+    await writeTranscript([
+      transcriptLine({
+        type: 'user',
+        message: {
+          parts: [
+            {
+              // A reminder QUOTING annotation grammar must be inert: the
+              // wrapper is stripped before annotation matching.
+              text:
+                '<system-reminder>\n【媒体资源】draft.png：media-3-9f2c\n' +
+                '</system-reminder>ask about the clip',
+            },
+          ],
+        },
+      }),
+      transcriptLine({
+        type: 'system',
+        subtype: 'omni_recall',
+        systemPayload: recall,
+      }),
+      transcriptLine({
+        type: 'assistant',
+        message: { parts: [{ text: 'answering from memory' }] },
+      }),
+    ]);
+
+    const records = await exportOmniTrajectory({ omniRootDir, transcriptPath });
+    const turn = records[0] as OmniTrajectoryTurnRecord;
+
+    expect(turn.request.recall).toEqual(recall);
+    expect(turn.request.text).toBe('ask about the clip');
+    // The quoted handle line was NOT harvested as a media annotation.
+    expect(turn.request.media).toEqual([]);
+  });
+
+  it('excludes thought parts from the exported response text', async () => {
+    await writeTranscript([
+      transcriptLine({
+        type: 'user',
+        message: { parts: [{ text: 'q' }] },
+      }),
+      transcriptLine({
+        type: 'assistant',
+        message: {
+          parts: [
+            { text: 'SECRET-CHAIN-OF-THOUGHT', thought: true },
+            { text: 'visible answer' },
+          ],
+        },
+      }),
+    ]);
+
+    const records = await exportOmniTrajectory({ omniRootDir, transcriptPath });
+    const turn = records[0] as OmniTrajectoryTurnRecord;
+
+    expect(turn.response.text).toBe('visible answer');
+  });
+
+  it('harvests annotations delivered inside tool_result records', async () => {
+    await writeTranscript([
+      transcriptLine({
+        type: 'user',
+        message: { parts: [{ text: 'grab the poster' }] },
+      }),
+      transcriptLine({
+        type: 'tool_result',
+        message: {
+          parts: [
+            { text: 'downloaded 1 file' },
+            { text: formatResourceHandleText('poster.png', 'media-2-cd') },
+            { text: formatDisclosureText('poster.png', '原 4096px → 768px') },
+          ],
+        },
+      }),
+      transcriptLine({
+        type: 'assistant',
+        message: { parts: [{ text: 'got it' }] },
+      }),
+    ]);
+
+    const records = await exportOmniTrajectory({ omniRootDir, transcriptPath });
+    const turn = records[0] as OmniTrajectoryTurnRecord;
+
+    expect(turn.request.media).toEqual([
+      {
+        name: 'poster.png',
+        resourceId: 'media-2-cd',
+        disclosures: ['原 4096px → 768px'],
+        transcripts: [],
+      },
+    ]);
+    // Tool output prose is not request text.
+    expect(turn.request.text).toBe('grab the poster');
+  });
+
+  it('splits multiple user records into distinct turns with isolated state', async () => {
+    await writeTranscript([
+      transcriptLine({
+        type: 'user',
+        message: {
+          parts: [
+            { text: 'first question' },
+            { text: formatResourceHandleText('a.mp4', 'media-1-aa') },
+          ],
+        },
+      }),
+      transcriptLine({
+        type: 'assistant',
+        message: { parts: [{ text: 'first answer' }] },
+      }),
+      transcriptLine({
+        type: 'user',
+        message: { parts: [{ text: 'second question' }] },
+      }),
+      transcriptLine({
+        type: 'assistant',
+        message: { parts: [{ text: 'second answer' }] },
+      }),
+    ]);
+
+    const records = await exportOmniTrajectory({ omniRootDir, transcriptPath });
+    const turns = records.filter(
+      (r): r is OmniTrajectoryTurnRecord => r.kind === 'turn',
+    );
+
+    expect(turns.map((t) => t.turnIndex)).toEqual([0, 1]);
+    expect(turns[0]!.request.media).toHaveLength(1);
+    // Per-turn media/toolCalls state does not bleed into the next turn.
+    expect(turns[1]!.request.media).toEqual([]);
+    expect(turns[1]!.response.text).toBe('second answer');
+  });
+
+  it('does not open a turn on a subtyped user record (cron/notification)', async () => {
+    await writeTranscript([
+      transcriptLine({
+        type: 'user',
+        subtype: 'cron',
+        message: { parts: [{ text: 'scheduled ping' }] },
+      }),
+      transcriptLine({
+        type: 'user',
+        message: { parts: [{ text: 'real question' }] },
+      }),
+    ]);
+
+    const records = await exportOmniTrajectory({ omniRootDir, transcriptPath });
+    const turns = records.filter(
+      (r): r is OmniTrajectoryTurnRecord => r.kind === 'turn',
+    );
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0]!.request.text).toBe('real question');
+  });
+
+  it('replays only the active parentUuid chain, skipping rewound branches', async () => {
+    await writeTranscript([
+      transcriptLine({
+        type: 'user',
+        uuid: 'u1',
+        parentUuid: null,
+        message: { parts: [{ text: 'q1' }] },
+      }),
+      transcriptLine({
+        type: 'assistant',
+        uuid: 'a1',
+        parentUuid: 'u1',
+        message: { parts: [{ text: 'answer 1' }] },
+      }),
+      // Abandoned by a rewind: still in the file, off the active chain.
+      transcriptLine({
+        type: 'user',
+        uuid: 'u2-dead',
+        parentUuid: 'a1',
+        message: { parts: [{ text: 'q2-ABANDONED' }] },
+      }),
+      transcriptLine({
+        type: 'assistant',
+        uuid: 'a2-dead',
+        parentUuid: 'u2-dead',
+        message: { parts: [{ text: 'answer 2 abandoned' }] },
+      }),
+      // The rewind re-rooted here.
+      transcriptLine({
+        type: 'user',
+        uuid: 'u2',
+        parentUuid: 'a1',
+        message: { parts: [{ text: 'q2-survivor' }] },
+      }),
+      transcriptLine({
+        type: 'assistant',
+        uuid: 'a2',
+        parentUuid: 'u2',
+        message: { parts: [{ text: 'answer 2' }] },
+      }),
+    ]);
+
+    const records = await exportOmniTrajectory({ omniRootDir, transcriptPath });
+    const turns = records.filter(
+      (r): r is OmniTrajectoryTurnRecord => r.kind === 'turn',
+    );
+
+    expect(turns.map((t) => t.request.text)).toEqual(['q1', 'q2-survivor']);
+    expect(turns.map((t) => t.response.text)).toEqual([
+      'answer 1',
+      'answer 2',
+    ]);
+  });
+
+  it('exports only memory records reachable from this session', async () => {
+    await seedMemory();
+    await seedUnrelatedMemory();
+    // A text-only transcript: nothing in memory is reachable.
+    await writeTranscript([
+      transcriptLine({
+        type: 'user',
+        message: { parts: [{ text: 'just a question, no media' }] },
+      }),
+    ]);
+
+    const records = await exportOmniTrajectory({ omniRootDir, transcriptPath });
+
+    expect(records.filter((r) => r.kind !== 'turn')).toEqual([]);
+
+    // A session that carried the film DOES pull the whole chain — but
+    // still not the unrelated file.
+    await writeTranscript([
+      transcriptLine({
+        type: 'user',
+        message: {
+          parts: [
+            { text: 'analyse' },
+            { text: formatResourceHandleText('film.mkv', 'media-1-ab') },
+          ],
+        },
+      }),
+    ]);
+    const withMedia = await exportOmniTrajectory({
+      omniRootDir,
+      transcriptPath,
+    });
+    const files = withMedia.filter(
+      (r): r is OmniTrajectoryFileRecord => r.kind === 'file',
+    );
+    expect(files.map((f) => f.sha256).sort()).toEqual([
+      'a'.repeat(64),
+      'b'.repeat(64),
+    ]);
+    expect(
+      withMedia.filter((r) => r.kind === 'execution'),
+    ).toHaveLength(1);
+  });
+
+  it('degrades to transcript-only WITHOUT touching a corrupt ledger', async () => {
+    const ledgerPath = path.join(omniRootDir, 'memory.json');
+    await fs.writeFile(ledgerPath, '{broken');
     await writeTranscript([
       transcriptLine({
         type: 'user',
@@ -244,6 +576,23 @@ describe('exportOmniTrajectory', () => {
 
     expect(records).toHaveLength(1);
     expect(records[0]!.kind).toBe('turn');
+    // Pure-reader contract: the live document is untouched — no
+    // corruption self-heal rename, no `.corrupt-*` backup that would
+    // silently block the GC for a whole retention window.
+    await expect(fs.readFile(ledgerPath, 'utf8')).resolves.toBe('{broken');
+    const siblings = await fs.readdir(omniRootDir);
+    expect(siblings.filter((n) => n.includes('.corrupt-'))).toEqual([]);
+  });
+
+  it('rejects an unreadable transcript instead of degrading', async () => {
+    // The documented asymmetry: memory degrades, transcript REJECTS —
+    // there is no trajectory without it.
+    await expect(
+      exportOmniTrajectory({
+        omniRootDir,
+        transcriptPath: path.join(tmpDir, 'missing.jsonl'),
+      }),
+    ).rejects.toThrow();
   });
 
   it('re-exports byte-identically and writes parseable JSONL', async () => {
@@ -251,7 +600,12 @@ describe('exportOmniTrajectory', () => {
     await writeTranscript([
       transcriptLine({
         type: 'user',
-        message: { parts: [{ text: 'q' }] },
+        message: {
+          parts: [
+            { text: 'q' },
+            { text: formatResourceHandleText('film.mkv', 'media-1-ab') },
+          ],
+        },
       }),
     ]);
 
@@ -263,7 +617,7 @@ describe('exportOmniTrajectory', () => {
     );
     expect(a).toBe(b);
 
-    const outPath = path.join(tmpDir, 'out.jsonl');
+    const outPath = path.join(tmpDir, 'nested', 'out.jsonl');
     const { records } = await writeOmniTrajectoryJsonl({
       omniRootDir,
       transcriptPath,
@@ -275,5 +629,26 @@ describe('exportOmniTrajectory', () => {
     expect(lines).toHaveLength(records);
     // Every line parses on its own — the whole point of JSONL.
     for (const line of lines) expect(() => JSON.parse(line)).not.toThrow();
+  });
+
+  it('refuses to write the trajectory over the source transcript', async () => {
+    await writeTranscript([
+      transcriptLine({
+        type: 'user',
+        message: { parts: [{ text: 'q' }] },
+      }),
+    ]);
+
+    await expect(
+      writeOmniTrajectoryJsonl({
+        omniRootDir,
+        transcriptPath,
+        outPath: transcriptPath,
+      }),
+    ).rejects.toThrow(/must differ/);
+    // The transcript is intact.
+    await expect(fs.readFile(transcriptPath, 'utf8')).resolves.toContain(
+      '"type":"user"',
+    );
   });
 });

--- a/packages/core/src/omni/export.ts
+++ b/packages/core/src/omni/export.ts
@@ -1,0 +1,512 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs/promises';
+import { createDebugLogger } from '../utils/debugLogger.js';
+import { MediaMemoryStore } from '../services/media-memory/store.js';
+import type { MediaMemorySnapshot } from '../services/media-memory/types.js';
+import {
+  OMNI_DISCLOSURE_TEXT_PREFIX,
+  OMNI_OMISSION_TEXT_PREFIX,
+  OMNI_TRANSCRIPT_TEXT_PREFIX,
+  OMNI_RESOURCE_HANDLE_TEXT_PREFIX,
+  parseResourceHandleText,
+} from './disclosure.js';
+
+const debugLogger = createDebugLogger('omni:export');
+
+/**
+ * Trajectory export (S6, issue #8190 / formerly #8196): one experiment
+ * session as training-consumable JSONL.
+ *
+ * The exporter is a pure READER over two artifacts that already exist —
+ * the session's chat-record JSONL and the project's `memory.json` — so it
+ * adds no collection points, cannot affect runtime behavior, and works on
+ * sessions recorded before it was written.
+ *
+ * ## Record kinds (the `kind` field of every line)
+ *
+ * - `turn` — one user request → model response cycle from the transcript:
+ *   the request text (system reminders stripped, an injected passive
+ *   recall extracted into `recall`), the media annotations the model saw
+ *   (handles, disclosures, omissions, transcripts), the assistant text
+ *   and its tool calls.
+ * - `execution` — one policy execution from memory, with full provenance
+ *   (arguments, config hash, source/output identities, reuse marker).
+ * - `file` — one file version from memory: the durable identity
+ *   (`fileVersionId`, `sha256`), modality, origin, and a source locator
+ *   REDUCED to its safe form (URLs and managed keys verbatim; local
+ *   locators are already basenames by construction — M §5.2's no-path
+ *   discipline is enforced at collection time, not here).
+ *
+ * ## The join contract (deliberately explicit, not implicit)
+ *
+ * Model/client-origin executions join `turn.response.toolCalls[].callId`
+ * ↔ `execution.invocationId` — both sides record the scheduler's callId.
+ * Fixed-policy executions have no transcript-side call (they run inside
+ * delivery); they join through identities instead:
+ * `execution.sourceVersionId` → `file.fileVersionId`, and a turn's media
+ * name matches `file.sourceLocator`'s display form. The exporter does NOT
+ * fabricate a turn↔fixed-policy edge from timestamps — a wrong edge in
+ * training data is worse than an explicit join key.
+ *
+ * Media bytes are never embedded; `sha256` is the pointer (fetch from
+ * `objects/` while retention lasts). Every `execution` line carries
+ * `omniConfigHash` so downstream can split trajectories by processing
+ * configuration instead of mixing distributions.
+ */
+
+// ─── Line shapes ──────────────────────────────────────────────────────────
+
+export interface OmniTrajectoryMediaAnnotation {
+  /** Display name from the annotation (basename or URL base). */
+  name: string;
+  /** Session handle, when a 【媒体资源】 annotation was present. */
+  resourceId?: string;
+  disclosures: string[];
+  /** Omission notice text, when the transport guard withheld the bytes. */
+  omitted?: string;
+  /** Transcript-protocol text delivered in place of (or beside) media. */
+  transcripts: string[];
+}
+
+export interface OmniTrajectoryTurnRecord {
+  kind: 'turn';
+  sessionId: string;
+  /** 0-based index over the session's user requests. */
+  turnIndex: number;
+  timestamp?: string;
+  request: {
+    text: string;
+    media: OmniTrajectoryMediaAnnotation[];
+    /** Parsed 【媒体记忆】 sideQuery injection, verbatim JSON when present. */
+    recall?: unknown;
+  };
+  response: {
+    text: string;
+    toolCalls: Array<{
+      callId?: string;
+      name: string;
+      /** Arguments minus reserved runtime keys (inputPath/outputDir) —
+       * the same exclusion memory applies to `finalArguments`. */
+      args?: Record<string, unknown>;
+    }>;
+  };
+}
+
+export interface OmniTrajectoryExecutionRecord {
+  kind: 'execution';
+  executionId: string;
+  /** Scheduler callId for model/client calls (the turn-side join key);
+   * a random invocation id for fixed-policy runs. */
+  invocationId: string;
+  executionOrigin: unknown;
+  toolName: string;
+  toolVersion?: string;
+  finalArguments: Record<string, unknown>;
+  omniConfigHash: string;
+  sourceVersionId: string;
+  rootFileId: string;
+  startedAt: string;
+  completedAt: string;
+  /** Present when this execution reused another's outputs (M §11.3). */
+  reusedExecutionId?: string;
+  outputs: Array<{
+    kind: string;
+    role?: string;
+    sha256?: string;
+    mimeType?: string;
+    sizeBytes?: number;
+    disclosure?: string;
+  }>;
+}
+
+export interface OmniTrajectoryFileRecord {
+  kind: 'file';
+  fileId: string;
+  fileVersionId: string;
+  rootFileId: string;
+  sha256: string;
+  mediaType: string;
+  origin: string;
+  sizeBytes: number;
+  mimeType: string;
+  source: { protocol: string; locator: string };
+  producedByExecutionId?: string;
+  parentVersionId?: string;
+  createdAt: string;
+}
+
+export type OmniTrajectoryRecord =
+  | OmniTrajectoryTurnRecord
+  | OmniTrajectoryExecutionRecord
+  | OmniTrajectoryFileRecord;
+
+// ─── Transcript side ──────────────────────────────────────────────────────
+
+/** Minimal structural view of one chat record (the exporter must not
+ * import the CLI's ChatRecord type — core cannot depend on cli). */
+interface TranscriptRecordView {
+  sessionId?: string;
+  type?: string;
+  subtype?: string;
+  timestamp?: string;
+  message?: { parts?: unknown[] };
+  toolCallResult?: unknown;
+}
+
+const RECALL_REMINDER_MARKER = '【媒体记忆】';
+
+function textOfPart(part: unknown): string | undefined {
+  if (typeof part === 'string') return part;
+  if (typeof part === 'object' && part !== null && 'text' in part) {
+    const text = (part as { text?: unknown }).text;
+    return typeof text === 'string' ? text : undefined;
+  }
+  return undefined;
+}
+
+function functionCallOfPart(
+  part: unknown,
+):
+  | { callId?: string; name: string; args?: Record<string, unknown> }
+  | undefined {
+  if (typeof part !== 'object' || part === null) return undefined;
+  const fc = (part as { functionCall?: unknown }).functionCall;
+  if (typeof fc !== 'object' || fc === null) return undefined;
+  const { id, name, args } = fc as {
+    id?: unknown;
+    name?: unknown;
+    args?: unknown;
+  };
+  if (typeof name !== 'string') return undefined;
+  const cleanArgs =
+    typeof args === 'object' && args !== null
+      ? { ...(args as Record<string, unknown>) }
+      : undefined;
+  if (cleanArgs) {
+    // Reserved runtime keys are per-invocation plumbing and may carry
+    // absolute paths — the same exclusion memory's finalArguments applies.
+    delete cleanArgs['inputPath'];
+    delete cleanArgs['outputDir'];
+  }
+  return {
+    ...(typeof id === 'string' ? { callId: id } : {}),
+    name,
+    ...(cleanArgs ? { args: cleanArgs } : {}),
+  };
+}
+
+/** Split an annotation line `【…】name：payload` into its parts. */
+function splitAnnotation(
+  text: string,
+  prefix: string,
+): { name: string; payload: string } | undefined {
+  if (!text.startsWith(prefix)) return undefined;
+  const rest = text.slice(prefix.length);
+  const sep = rest.indexOf('：');
+  if (sep < 0) return undefined;
+  return { name: rest.slice(0, sep), payload: rest.slice(sep + 1) };
+}
+
+/** Extract the recall reminder's JSON body, if this text part is one. */
+function parseRecallReminder(text: string): unknown | undefined {
+  if (!text.includes(RECALL_REMINDER_MARKER)) return undefined;
+  const start = text.indexOf('{');
+  const end = text.lastIndexOf('}');
+  if (start < 0 || end <= start) return undefined;
+  try {
+    return JSON.parse(text.slice(start, end + 1));
+  } catch {
+    return undefined;
+  }
+}
+
+function stripSystemReminders(text: string): string {
+  return text
+    .replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, '')
+    .trim();
+}
+
+interface TurnAccumulator {
+  turnIndex: number;
+  timestamp?: string;
+  requestTexts: string[];
+  media: Map<string, OmniTrajectoryMediaAnnotation>;
+  recall?: unknown;
+  responseTexts: string[];
+  toolCalls: OmniTrajectoryTurnRecord['response']['toolCalls'];
+}
+
+function mediaFor(
+  turn: TurnAccumulator,
+  name: string,
+): OmniTrajectoryMediaAnnotation {
+  let media = turn.media.get(name);
+  if (!media) {
+    media = { name, disclosures: [], transcripts: [] };
+    turn.media.set(name, media);
+  }
+  return media;
+}
+
+/** Consume one user-part text line into the accumulating turn. Returns
+ * true when the line was a media/recall annotation (not request prose). */
+function consumeAnnotationLine(turn: TurnAccumulator, line: string): boolean {
+  const handle = splitAnnotation(line, OMNI_RESOURCE_HANDLE_TEXT_PREFIX);
+  if (handle) {
+    const resourceId = parseResourceHandleText(line);
+    const media = mediaFor(turn, handle.name);
+    if (resourceId) media.resourceId = resourceId;
+    return true;
+  }
+  const disclosure = splitAnnotation(line, OMNI_DISCLOSURE_TEXT_PREFIX);
+  if (disclosure) {
+    mediaFor(turn, disclosure.name).disclosures.push(disclosure.payload);
+    return true;
+  }
+  const omission = splitAnnotation(line, OMNI_OMISSION_TEXT_PREFIX);
+  if (omission) {
+    mediaFor(turn, omission.name).omitted = omission.payload;
+    return true;
+  }
+  const transcript = splitAnnotation(line, OMNI_TRANSCRIPT_TEXT_PREFIX);
+  if (transcript) {
+    mediaFor(turn, transcript.name).transcripts.push(transcript.payload);
+    return true;
+  }
+  return false;
+}
+
+function finishTurn(
+  turn: TurnAccumulator,
+  sessionId: string,
+): OmniTrajectoryTurnRecord {
+  return {
+    kind: 'turn',
+    sessionId,
+    turnIndex: turn.turnIndex,
+    ...(turn.timestamp !== undefined ? { timestamp: turn.timestamp } : {}),
+    request: {
+      text: turn.requestTexts.join('\n'),
+      media: [...turn.media.values()],
+      ...(turn.recall !== undefined ? { recall: turn.recall } : {}),
+    },
+    response: {
+      text: turn.responseTexts.join('\n'),
+      toolCalls: turn.toolCalls,
+    },
+  };
+}
+
+function buildTurnRecords(
+  transcriptLines: TranscriptRecordView[],
+): OmniTrajectoryTurnRecord[] {
+  const turns: OmniTrajectoryTurnRecord[] = [];
+  let sessionId = '';
+  let current: TurnAccumulator | undefined;
+
+  for (const record of transcriptLines) {
+    if (typeof record.sessionId === 'string' && sessionId === '') {
+      sessionId = record.sessionId;
+    }
+    if (record.type === 'user' && record.subtype === undefined) {
+      if (current) turns.push(finishTurn(current, sessionId));
+      current = {
+        turnIndex: turns.length,
+        ...(record.timestamp !== undefined
+          ? { timestamp: record.timestamp }
+          : {}),
+        requestTexts: [],
+        media: new Map(),
+        responseTexts: [],
+        toolCalls: [],
+      };
+      for (const part of record.message?.parts ?? []) {
+        const text = textOfPart(part);
+        if (text === undefined) continue;
+        // A recall reminder may share its part with the user's own text
+        // (client.ts prepends reminders INTO the request parts) — extract
+        // the payload, then keep processing what remains of the part.
+        const recall = parseRecallReminder(text);
+        if (recall !== undefined) current.recall = recall;
+        const prose: string[] = [];
+        for (const line of text.split('\n')) {
+          if (!consumeAnnotationLine(current, line.trim())) prose.push(line);
+        }
+        const stripped = stripSystemReminders(prose.join('\n'));
+        if (stripped) current.requestTexts.push(stripped);
+      }
+      continue;
+    }
+    if (!current) continue;
+    if (record.type === 'assistant') {
+      for (const part of record.message?.parts ?? []) {
+        const text = textOfPart(part);
+        if (text !== undefined && text.trim()) {
+          current.responseTexts.push(text);
+          continue;
+        }
+        const call = functionCallOfPart(part);
+        if (call) current.toolCalls.push(call);
+      }
+    }
+  }
+  if (current) turns.push(finishTurn(current, sessionId));
+  return turns;
+}
+
+// ─── Memory side ──────────────────────────────────────────────────────────
+
+interface MemoryRecords {
+  files: OmniTrajectoryFileRecord[];
+  executions: OmniTrajectoryExecutionRecord[];
+}
+
+function buildMemoryRecords(snapshot: MediaMemorySnapshot): MemoryRecords {
+  const files: OmniTrajectoryFileRecord[] = [];
+  const executions: OmniTrajectoryExecutionRecord[] = [];
+  for (const version of Object.values(snapshot.versions)) {
+    const file = snapshot.files[version.fileId];
+    if (!file) continue;
+    files.push({
+      kind: 'file',
+      fileId: version.fileId,
+      fileVersionId: version.fileVersionId,
+      rootFileId: file.rootFileId,
+      sha256: version.sha256,
+      mediaType: version.mediaType,
+      origin: file.origin,
+      sizeBytes: version.sizeBytes,
+      mimeType: version.mimeType,
+      source: version.source,
+      ...(version.producedByExecutionId !== undefined
+        ? { producedByExecutionId: version.producedByExecutionId }
+        : {}),
+      ...(version.parentVersionId !== undefined
+        ? { parentVersionId: version.parentVersionId }
+        : {}),
+      createdAt: version.createdAt,
+    });
+  }
+  for (const execution of Object.values(snapshot.executions)) {
+    const outputs = execution.outputRefs.flatMap((entryId) => {
+      const entry = snapshot.entries[entryId];
+      if (!entry) return [];
+      return [
+        {
+          kind: entry.kind,
+          ...(entry.role !== undefined ? { role: entry.role } : {}),
+          ...(entry.artifactRef?.managedId?.startsWith('sha256/')
+            ? { sha256: entry.artifactRef.managedId.slice('sha256/'.length) }
+            : {}),
+          ...(entry.artifactRef?.mimeType !== undefined
+            ? { mimeType: entry.artifactRef.mimeType }
+            : {}),
+          ...(entry.artifactRef?.sizeBytes !== undefined
+            ? { sizeBytes: entry.artifactRef.sizeBytes }
+            : {}),
+          ...(entry.disclosure !== undefined
+            ? { disclosure: entry.disclosure }
+            : {}),
+        },
+      ];
+    });
+    executions.push({
+      kind: 'execution',
+      executionId: execution.executionId,
+      invocationId: execution.invocationId,
+      executionOrigin: execution.executionOrigin,
+      toolName: execution.toolName,
+      ...(execution.toolVersion !== undefined
+        ? { toolVersion: execution.toolVersion }
+        : {}),
+      finalArguments: execution.finalArguments,
+      omniConfigHash: execution.omniConfigHash,
+      sourceVersionId: execution.sourceVersionId,
+      rootFileId: execution.rootFileId,
+      startedAt: execution.startedAt,
+      completedAt: execution.completedAt,
+      ...(execution.reusedExecutionId !== undefined
+        ? { reusedExecutionId: execution.reusedExecutionId }
+        : {}),
+      outputs,
+    });
+  }
+  return { files, executions };
+}
+
+// ─── Entry points ─────────────────────────────────────────────────────────
+
+export interface ExportOmniTrajectoryOptions {
+  /** `.qwen/omni` root holding memory.json. */
+  omniRootDir: string;
+  /** Path to the session's chat-record JSONL. */
+  transcriptPath: string;
+}
+
+/**
+ * Build the trajectory records for one session. Turn records come first
+ * (transcript order), then file records, then execution records — a
+ * deterministic order so re-exports are byte-identical.
+ *
+ * An unreadable memory store degrades to transcript-only output with a
+ * debug note (the transcript half is still valid training signal); an
+ * unreadable transcript is an error — there is no trajectory without it.
+ */
+export async function exportOmniTrajectory(
+  options: ExportOmniTrajectoryOptions,
+): Promise<OmniTrajectoryRecord[]> {
+  const raw = await fs.readFile(options.transcriptPath, 'utf8');
+  const transcriptLines: TranscriptRecordView[] = [];
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      transcriptLines.push(JSON.parse(line) as TranscriptRecordView);
+    } catch {
+      // One corrupt transcript line loses that line, not the export.
+    }
+  }
+  const records: OmniTrajectoryRecord[] = buildTurnRecords(transcriptLines);
+
+  const store = new MediaMemoryStore(options.omniRootDir);
+  const empty: MemoryRecords = { files: [], executions: [] };
+  const memoryRecords = await store
+    .read<MemoryRecords>(empty, (snapshot) => buildMemoryRecords(snapshot))
+    .catch((err) => {
+      debugLogger.debug(
+        `trajectory export: memory unreadable, exporting transcript only: ` +
+          `${err instanceof Error ? err.message : err}`,
+      );
+      return empty;
+    });
+  // files before executions, each sorted by id — deterministic re-export.
+  records.push(
+    ...memoryRecords.files.sort((a, b) =>
+      a.fileVersionId.localeCompare(b.fileVersionId),
+    ),
+    ...memoryRecords.executions.sort((a, b) =>
+      a.executionId.localeCompare(b.executionId),
+    ),
+  );
+  return records;
+}
+
+/** Serialize to JSONL (one record per line, trailing newline). */
+export function serializeOmniTrajectory(
+  records: OmniTrajectoryRecord[],
+): string {
+  return records.map((r) => JSON.stringify(r)).join('\n') + '\n';
+}
+
+/** Convenience wrapper: export and write to a file. */
+export async function writeOmniTrajectoryJsonl(
+  options: ExportOmniTrajectoryOptions & { outPath: string },
+): Promise<{ records: number }> {
+  const records = await exportOmniTrajectory(options);
+  await fs.writeFile(options.outPath, serializeOmniTrajectory(records), 'utf8');
+  return { records: records.length };
+}

--- a/packages/core/src/omni/export.ts
+++ b/packages/core/src/omni/export.ts
@@ -5,8 +5,8 @@
  */
 
 import fs from 'node:fs/promises';
+import path from 'node:path';
 import { createDebugLogger } from '../utils/debugLogger.js';
-import { MediaMemoryStore } from '../services/media-memory/store.js';
 import type { MediaMemorySnapshot } from '../services/media-memory/types.js';
 import {
   OMNI_DISCLOSURE_TEXT_PREFIX,
@@ -14,6 +14,8 @@ import {
   OMNI_TRANSCRIPT_TEXT_PREFIX,
   OMNI_RESOURCE_HANDLE_TEXT_PREFIX,
   parseResourceHandleText,
+  splitAnnotationBody,
+  unescapeAnnotationName,
 } from './disclosure.js';
 
 const debugLogger = createDebugLogger('omni:export');
@@ -24,16 +26,21 @@ const debugLogger = createDebugLogger('omni:export');
  *
  * The exporter is a pure READER over two artifacts that already exist —
  * the session's chat-record JSONL and the project's `memory.json` — so it
- * adds no collection points, cannot affect runtime behavior, and works on
- * sessions recorded before it was written.
+ * adds no collection points and cannot affect runtime behavior. The
+ * memory ledger is read RAW (no store-side corruption self-heal: an
+ * export must never rename the live document); an unreadable ledger
+ * degrades the export to transcript-only records.
  *
  * ## Record kinds (the `kind` field of every line)
  *
  * - `turn` — one user request → model response cycle from the transcript:
- *   the request text (system reminders stripped, an injected passive
- *   recall extracted into `recall`), the media annotations the model saw
- *   (handles, disclosures, omissions, transcripts), the assistant text
- *   and its tool calls.
+ *   the request text (system reminders stripped), the media annotations
+ *   the model saw (handles, disclosures, omissions, transcripts —
+ *   harvested from user AND tool_result records), the recall payload the
+ *   sideQuery injected (recorded by the runtime since this exporter
+ *   shipped; older transcripts simply have no `recall`), the assistant's
+ *   VISIBLE text (thought parts are excluded) and its tool calls with
+ *   arguments preserved verbatim.
  * - `execution` — one policy execution from memory, with full provenance
  *   (arguments, config hash, source/output identities, reuse marker).
  * - `file` — one file version from memory: the durable identity
@@ -41,6 +48,25 @@ const debugLogger = createDebugLogger('omni:export');
  *   REDUCED to its safe form (URLs and managed keys verbatim; local
  *   locators are already basenames by construction — M §5.2's no-path
  *   discipline is enforced at collection time, not here).
+ *
+ * ## Session scope
+ *
+ * `memory.json` is project-wide; a single-session export includes only
+ * the records reachable from THIS session's transcript: executions whose
+ * `invocationId` matches a turn's tool callId, files whose display
+ * locator matches a media annotation, and everything reachable from
+ * those through the identity graph (source versions, produced
+ * derivatives, and the executions between them) — computed as a closure,
+ * so fixed-policy chains (extract-audio → transcribe) stay complete.
+ *
+ * ## Branches
+ *
+ * Chat records form a `parentUuid` chain and `/rewind` re-roots it,
+ * leaving abandoned records in the append-only file. The exporter
+ * replays only the ACTIVE chain (walked back from the final record) —
+ * a rewound branch must not export as a genuine turn. Records without
+ * uuids (hand-built fixtures, foreign transcripts) fall back to append
+ * order.
  *
  * ## The join contract (deliberately explicit, not implicit)
  *
@@ -60,15 +86,21 @@ const debugLogger = createDebugLogger('omni:export');
  *
  * ## What is and is not scrubbed
  *
- * The exporter strips exactly the harness-side surface the model never
- * saw: the reserved runtime keys (inputPath/outputDir) that the gate and
- * orchestrator inject into policy calls. Content the MODEL itself saw or
- * produced — a path the user typed into their prompt, a `file_path` the
- * model passed to write_file — is preserved verbatim: it IS the
- * trajectory, and scrubbing it would corrupt the training signal while
- * teaching nothing about the pipeline. Callers publishing exports off
- * the machine own that second category (measured on a real session: 147
- * records, zero pipeline-side leaks, 7 user/model-side absolute paths).
+ * Transcript-side content is preserved VERBATIM — the recorded assistant
+ * turn predates the gate's runtime-key injection, so its tool-call
+ * arguments are exactly what the model emitted (including an `inputPath`
+ * the model legitimately passed to an omni tool); scrubbing them would
+ * corrupt the training signal. The memory side excludes the reserved
+ * runtime keys (`inputPath`/`outputDir`/`resourceId`) from
+ * `finalArguments` at collection time — before this exporter ever runs.
+ * Callers publishing exports off the machine own user/model-authored
+ * absolute paths (they ARE the trajectory).
+ *
+ * ## Known limitation
+ *
+ * Non-text request parts (pasted images, inline blobs) contribute no
+ * annotation and are not represented in `turn.request` beyond any omni
+ * annotations delivered beside them.
  */
 
 // ─── Line shapes ──────────────────────────────────────────────────────────
@@ -94,7 +126,8 @@ export interface OmniTrajectoryTurnRecord {
   request: {
     text: string;
     media: OmniTrajectoryMediaAnnotation[];
-    /** Parsed 【媒体记忆】 sideQuery injection, verbatim JSON when present. */
+    /** The sideQuery recall payload the runtime injected (recorded as a
+     * system record at injection time), verbatim JSON when present. */
     recall?: unknown;
   };
   response: {
@@ -102,8 +135,7 @@ export interface OmniTrajectoryTurnRecord {
     toolCalls: Array<{
       callId?: string;
       name: string;
-      /** Arguments minus reserved runtime keys (inputPath/outputDir) —
-       * the same exclusion memory applies to `finalArguments`. */
+      /** Arguments exactly as the model emitted them. */
       args?: Record<string, unknown>;
     }>;
   };
@@ -166,11 +198,11 @@ interface TranscriptRecordView {
   type?: string;
   subtype?: string;
   timestamp?: string;
+  uuid?: string;
+  parentUuid?: string | null;
   message?: { parts?: unknown[] };
-  toolCallResult?: unknown;
+  systemPayload?: unknown;
 }
-
-const RECALL_REMINDER_MARKER = '【媒体记忆】';
 
 function textOfPart(part: unknown): string | undefined {
   if (typeof part === 'string') return part;
@@ -179,6 +211,14 @@ function textOfPart(part: unknown): string | undefined {
     return typeof text === 'string' ? text : undefined;
   }
   return undefined;
+}
+
+function isThoughtPart(part: unknown): boolean {
+  return (
+    typeof part === 'object' &&
+    part !== null &&
+    (part as { thought?: unknown }).thought === true
+  );
 }
 
 function functionCallOfPart(
@@ -195,46 +235,19 @@ function functionCallOfPart(
     args?: unknown;
   };
   if (typeof name !== 'string') return undefined;
+  // Arguments are preserved verbatim: the assistant turn is recorded
+  // BEFORE the gate injects runtime keys, so whatever is here is what
+  // the model itself emitted — scrubbing it would delete a legitimate
+  // model-authored `inputPath` and corrupt the call record.
   const cleanArgs =
     typeof args === 'object' && args !== null
       ? { ...(args as Record<string, unknown>) }
       : undefined;
-  if (cleanArgs) {
-    // Reserved runtime keys are per-invocation plumbing and may carry
-    // absolute paths — the same exclusion memory's finalArguments applies.
-    delete cleanArgs['inputPath'];
-    delete cleanArgs['outputDir'];
-  }
   return {
     ...(typeof id === 'string' ? { callId: id } : {}),
     name,
     ...(cleanArgs ? { args: cleanArgs } : {}),
   };
-}
-
-/** Split an annotation line `【…】name：payload` into its parts. */
-function splitAnnotation(
-  text: string,
-  prefix: string,
-): { name: string; payload: string } | undefined {
-  if (!text.startsWith(prefix)) return undefined;
-  const rest = text.slice(prefix.length);
-  const sep = rest.indexOf('：');
-  if (sep < 0) return undefined;
-  return { name: rest.slice(0, sep), payload: rest.slice(sep + 1) };
-}
-
-/** Extract the recall reminder's JSON body, if this text part is one. */
-function parseRecallReminder(text: string): unknown | undefined {
-  if (!text.includes(RECALL_REMINDER_MARKER)) return undefined;
-  const start = text.indexOf('{');
-  const end = text.lastIndexOf('}');
-  if (start < 0 || end <= start) return undefined;
-  try {
-    return JSON.parse(text.slice(start, end + 1));
-  } catch {
-    return undefined;
-  }
 }
 
 function stripSystemReminders(text: string): string {
@@ -265,32 +278,74 @@ function mediaFor(
   return media;
 }
 
-/** Consume one user-part text line into the accumulating turn. Returns
- * true when the line was a media/recall annotation (not request prose). */
-function consumeAnnotationLine(turn: TurnAccumulator, line: string): boolean {
-  const handle = splitAnnotation(line, OMNI_RESOURCE_HANDLE_TEXT_PREFIX);
-  if (handle) {
-    const resourceId = parseResourceHandleText(line);
-    const media = mediaFor(turn, handle.name);
-    if (resourceId) media.resourceId = resourceId;
+/**
+ * Consume one text PART as a media annotation if it is one. Writers emit
+ * each annotation as a standalone part (`formatDisclosureText` and
+ * friends produce the whole part text), so matching at part granularity
+ * keeps multi-line payloads intact and never harvests look-alike lines
+ * out of surrounding prose. Returns true when the part was an
+ * annotation.
+ */
+function consumeAnnotationPart(turn: TurnAccumulator, text: string): boolean {
+  if (text.startsWith(OMNI_RESOURCE_HANDLE_TEXT_PREFIX)) {
+    const resourceId = parseResourceHandleText(text);
+    if (!resourceId) return false;
+    // Name = body minus the end-anchored `：<resourceId>` (the id grammar
+    // is harness-minted, so this parse never guesses at the name).
+    const body = text.slice(OMNI_RESOURCE_HANDLE_TEXT_PREFIX.length);
+    const name = unescapeAnnotationName(
+      body.slice(0, body.length - resourceId.length - 1),
+    );
+    mediaFor(turn, name).resourceId = resourceId;
     return true;
   }
-  const disclosure = splitAnnotation(line, OMNI_DISCLOSURE_TEXT_PREFIX);
-  if (disclosure) {
-    mediaFor(turn, disclosure.name).disclosures.push(disclosure.payload);
-    return true;
-  }
-  const omission = splitAnnotation(line, OMNI_OMISSION_TEXT_PREFIX);
-  if (omission) {
-    mediaFor(turn, omission.name).omitted = omission.payload;
-    return true;
-  }
-  const transcript = splitAnnotation(line, OMNI_TRANSCRIPT_TEXT_PREFIX);
-  if (transcript) {
-    mediaFor(turn, transcript.name).transcripts.push(transcript.payload);
+  for (const [prefix, apply] of [
+    [
+      OMNI_DISCLOSURE_TEXT_PREFIX,
+      (m: OmniTrajectoryMediaAnnotation, payload: string) => {
+        m.disclosures.push(payload);
+      },
+    ],
+    [
+      OMNI_OMISSION_TEXT_PREFIX,
+      (m: OmniTrajectoryMediaAnnotation, payload: string) => {
+        m.omitted = payload;
+      },
+    ],
+    [
+      OMNI_TRANSCRIPT_TEXT_PREFIX,
+      (m: OmniTrajectoryMediaAnnotation, payload: string) => {
+        m.transcripts.push(payload);
+      },
+    ],
+  ] as const) {
+    if (!text.startsWith(prefix)) continue;
+    const split = splitAnnotationBody(text.slice(prefix.length));
+    if (!split) return false;
+    apply(mediaFor(turn, split.name), split.payload);
     return true;
   }
   return false;
+}
+
+/** Harvest media annotations (and request prose, when `collectProse`)
+ * from a record's text parts into the accumulating turn. */
+function consumeRecordParts(
+  turn: TurnAccumulator,
+  record: TranscriptRecordView,
+  collectProse: boolean,
+): void {
+  for (const part of record.message?.parts ?? []) {
+    const raw = textOfPart(part);
+    if (raw === undefined) continue;
+    // Reminders are harness plumbing, never annotation carriers — strip
+    // them BEFORE annotation matching so a reminder quoting an
+    // annotation line cannot be harvested as one.
+    const text = stripSystemReminders(raw);
+    if (!text) continue;
+    if (consumeAnnotationPart(turn, text)) continue;
+    if (collectProse) turn.requestTexts.push(text);
+  }
 }
 
 function finishTurn(
@@ -314,6 +369,44 @@ function finishTurn(
   };
 }
 
+/**
+ * Reduce the append-only record list to the ACTIVE parentUuid chain.
+ * `/rewind` re-roots the chain and leaves the abandoned records in the
+ * file — replaying them would export phantom turns. Records without
+ * uuids (fixtures, foreign transcripts) fall back to the full list.
+ */
+function activeChainRecords(
+  records: TranscriptRecordView[],
+): TranscriptRecordView[] {
+  const byUuid = new Map<string, TranscriptRecordView>();
+  for (const record of records) {
+    if (typeof record.uuid === 'string') byUuid.set(record.uuid, record);
+  }
+  if (byUuid.size === 0) return records;
+  let leaf: TranscriptRecordView | undefined;
+  for (let i = records.length - 1; i >= 0; i--) {
+    if (typeof records[i].uuid === 'string') {
+      leaf = records[i];
+      break;
+    }
+  }
+  if (!leaf) return records;
+  const active = new Set<string>();
+  let current: TranscriptRecordView | undefined = leaf;
+  while (current?.uuid && !active.has(current.uuid)) {
+    active.add(current.uuid);
+    current =
+      typeof current.parentUuid === 'string'
+        ? byUuid.get(current.parentUuid)
+        : undefined;
+  }
+  // Preserve file order; keep uuid-less records (defensive: they cannot
+  // be on a dead branch that rewind knows about).
+  return records.filter(
+    (r) => typeof r.uuid !== 'string' || active.has(r.uuid),
+  );
+}
+
 function buildTurnRecords(
   transcriptLines: TranscriptRecordView[],
 ): OmniTrajectoryTurnRecord[] {
@@ -321,7 +414,7 @@ function buildTurnRecords(
   let sessionId = '';
   let current: TurnAccumulator | undefined;
 
-  for (const record of transcriptLines) {
+  for (const record of activeChainRecords(transcriptLines)) {
     if (typeof record.sessionId === 'string' && sessionId === '') {
       sessionId = record.sessionId;
     }
@@ -337,26 +430,27 @@ function buildTurnRecords(
         responseTexts: [],
         toolCalls: [],
       };
-      for (const part of record.message?.parts ?? []) {
-        const text = textOfPart(part);
-        if (text === undefined) continue;
-        // A recall reminder may share its part with the user's own text
-        // (client.ts prepends reminders INTO the request parts) — extract
-        // the payload, then keep processing what remains of the part.
-        const recall = parseRecallReminder(text);
-        if (recall !== undefined) current.recall = recall;
-        const prose: string[] = [];
-        for (const line of text.split('\n')) {
-          if (!consumeAnnotationLine(current, line.trim())) prose.push(line);
-        }
-        const stripped = stripSystemReminders(prose.join('\n'));
-        if (stripped) current.requestTexts.push(stripped);
-      }
+      consumeRecordParts(current, record, true);
       continue;
     }
     if (!current) continue;
+    if (record.type === 'system' && record.subtype === 'omni_recall') {
+      current.recall = record.systemPayload;
+      continue;
+    }
+    if (record.type === 'tool_result') {
+      // Tool-delivered media carries its annotations in the tool_result
+      // record's parts — harvest them; tool output prose is NOT request
+      // text.
+      consumeRecordParts(current, record, false);
+      continue;
+    }
     if (record.type === 'assistant') {
       for (const part of record.message?.parts ?? []) {
+        // Thought parts are internal chain-of-thought the user never saw
+        // — exporting them as "the response" would mislabel the training
+        // signal.
+        if (isThoughtPart(part)) continue;
         const text = textOfPart(part);
         if (text !== undefined && text.trim()) {
           current.responseTexts.push(text);
@@ -378,77 +472,213 @@ interface MemoryRecords {
   executions: OmniTrajectoryExecutionRecord[];
 }
 
+/**
+ * Read the memory ledger WITHOUT the store's corruption self-heal. The
+ * store backs a corrupt document up (renaming the live file) and
+ * continues on empty — correct for recall, but an EXPORT must never
+ * mutate the thing it reads (and the backup would silently block the GC
+ * for a whole retention window). Any failure degrades to transcript-only
+ * output.
+ */
+async function readSnapshotRaw(
+  omniRootDir: string,
+): Promise<MediaMemorySnapshot | undefined> {
+  const filePath = path.join(omniRootDir, 'memory.json');
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, 'utf8');
+  } catch {
+    return undefined; // Missing ledger: a media-less project is normal.
+  }
+  try {
+    const parsed = JSON.parse(raw) as MediaMemorySnapshot;
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      [parsed.files, parsed.versions, parsed.executions, parsed.entries].some(
+        (c) => typeof c !== 'object' || c === null || Array.isArray(c),
+      )
+    ) {
+      throw new Error('unexpected snapshot shape');
+    }
+    return parsed;
+  } catch (err) {
+    debugLogger.debug(
+      `trajectory export: memory unreadable, exporting transcript only: ` +
+        `${err instanceof Error ? err.message : err}`,
+    );
+    return undefined;
+  }
+}
+
 function buildMemoryRecords(snapshot: MediaMemorySnapshot): MemoryRecords {
   const files: OmniTrajectoryFileRecord[] = [];
   const executions: OmniTrajectoryExecutionRecord[] = [];
   for (const version of Object.values(snapshot.versions)) {
-    const file = snapshot.files[version.fileId];
-    if (!file) continue;
-    files.push({
-      kind: 'file',
-      fileId: version.fileId,
-      fileVersionId: version.fileVersionId,
-      rootFileId: file.rootFileId,
-      sha256: version.sha256,
-      mediaType: version.mediaType,
-      origin: file.origin,
-      sizeBytes: version.sizeBytes,
-      mimeType: version.mimeType,
-      source: version.source,
-      ...(version.producedByExecutionId !== undefined
-        ? { producedByExecutionId: version.producedByExecutionId }
-        : {}),
-      ...(version.parentVersionId !== undefined
-        ? { parentVersionId: version.parentVersionId }
-        : {}),
-      createdAt: version.createdAt,
-    });
+    try {
+      const file = snapshot.files[version.fileId];
+      if (!file) continue;
+      files.push({
+        kind: 'file',
+        fileId: version.fileId,
+        fileVersionId: version.fileVersionId,
+        rootFileId: file.rootFileId,
+        sha256: version.sha256,
+        mediaType: version.mediaType,
+        origin: file.origin,
+        sizeBytes: version.sizeBytes,
+        mimeType: version.mimeType,
+        source: version.source,
+        ...(version.producedByExecutionId !== undefined
+          ? { producedByExecutionId: version.producedByExecutionId }
+          : {}),
+        ...(version.parentVersionId !== undefined
+          ? { parentVersionId: version.parentVersionId }
+          : {}),
+        createdAt: version.createdAt,
+      });
+    } catch {
+      // One malformed record loses that record, not the export.
+    }
   }
   for (const execution of Object.values(snapshot.executions)) {
-    const outputs = execution.outputRefs.flatMap((entryId) => {
-      const entry = snapshot.entries[entryId];
-      if (!entry) return [];
-      return [
-        {
-          kind: entry.kind,
-          ...(entry.role !== undefined ? { role: entry.role } : {}),
-          ...(entry.artifactRef?.managedId?.startsWith('sha256/')
-            ? { sha256: entry.artifactRef.managedId.slice('sha256/'.length) }
-            : {}),
-          ...(entry.artifactRef?.mimeType !== undefined
-            ? { mimeType: entry.artifactRef.mimeType }
-            : {}),
-          ...(entry.artifactRef?.sizeBytes !== undefined
-            ? { sizeBytes: entry.artifactRef.sizeBytes }
-            : {}),
-          ...(entry.disclosure !== undefined
-            ? { disclosure: entry.disclosure }
-            : {}),
-        },
-      ];
-    });
-    executions.push({
-      kind: 'execution',
-      executionId: execution.executionId,
-      invocationId: execution.invocationId,
-      executionOrigin: execution.executionOrigin,
-      toolName: execution.toolName,
-      ...(execution.toolVersion !== undefined
-        ? { toolVersion: execution.toolVersion }
-        : {}),
-      finalArguments: execution.finalArguments,
-      omniConfigHash: execution.omniConfigHash,
-      sourceVersionId: execution.sourceVersionId,
-      rootFileId: execution.rootFileId,
-      startedAt: execution.startedAt,
-      completedAt: execution.completedAt,
-      ...(execution.reusedExecutionId !== undefined
-        ? { reusedExecutionId: execution.reusedExecutionId }
-        : {}),
-      outputs,
-    });
+    try {
+      const outputs = execution.outputRefs.flatMap((entryId) => {
+        const entry = snapshot.entries[entryId];
+        if (!entry) return [];
+        return [
+          {
+            kind: entry.kind,
+            ...(entry.role !== undefined ? { role: entry.role } : {}),
+            ...(entry.artifactRef?.managedId?.startsWith('sha256/')
+              ? { sha256: entry.artifactRef.managedId.slice('sha256/'.length) }
+              : {}),
+            ...(entry.artifactRef?.mimeType !== undefined
+              ? { mimeType: entry.artifactRef.mimeType }
+              : {}),
+            ...(entry.artifactRef?.sizeBytes !== undefined
+              ? { sizeBytes: entry.artifactRef.sizeBytes }
+              : {}),
+            ...(entry.disclosure !== undefined
+              ? { disclosure: entry.disclosure }
+              : {}),
+          },
+        ];
+      });
+      executions.push({
+        kind: 'execution',
+        executionId: execution.executionId,
+        invocationId: execution.invocationId,
+        executionOrigin: execution.executionOrigin,
+        toolName: execution.toolName,
+        ...(execution.toolVersion !== undefined
+          ? { toolVersion: execution.toolVersion }
+          : {}),
+        finalArguments: execution.finalArguments,
+        omniConfigHash: execution.omniConfigHash,
+        sourceVersionId: execution.sourceVersionId,
+        rootFileId: execution.rootFileId,
+        startedAt: execution.startedAt,
+        completedAt: execution.completedAt,
+        ...(execution.reusedExecutionId !== undefined
+          ? { reusedExecutionId: execution.reusedExecutionId }
+          : {}),
+        outputs,
+      });
+    } catch {
+      // Same stance: skip the malformed execution.
+    }
   }
   return { files, executions };
+}
+
+/**
+ * Reduce project-wide memory records to the ones reachable from this
+ * session's transcript. Seeds: executions joined by callId, files whose
+ * display locator matches a media annotation name. Closure: an included
+ * execution pulls in its source version's file and every file it
+ * produced; an included file pulls in the executions that read it and
+ * the executions that produced its versions. Fixed-policy chains
+ * (extract-audio → transcribe) stay complete without timestamp guessing.
+ */
+function filterToSession(
+  memory: MemoryRecords,
+  turns: OmniTrajectoryTurnRecord[],
+): MemoryRecords {
+  const callIds = new Set<string>();
+  const mediaNames = new Set<string>();
+  for (const turn of turns) {
+    for (const call of turn.response.toolCalls) {
+      if (call.callId) callIds.add(call.callId);
+    }
+    for (const media of turn.request.media) mediaNames.add(media.name);
+  }
+
+  const filesByVersion = new Map(
+    memory.files.map((f) => [f.fileVersionId, f]),
+  );
+  const versionsByFile = new Map<string, OmniTrajectoryFileRecord[]>();
+  for (const f of memory.files) {
+    const list = versionsByFile.get(f.fileId) ?? [];
+    list.push(f);
+    versionsByFile.set(f.fileId, list);
+  }
+
+  const includedFiles = new Set<string>(); // fileId
+  const includedExecutions = new Set<string>(); // executionId
+
+  const includeFile = (fileId: string | undefined): boolean => {
+    if (!fileId || includedFiles.has(fileId)) return false;
+    if (!versionsByFile.has(fileId)) return false;
+    includedFiles.add(fileId);
+    return true;
+  };
+
+  // Seeds.
+  for (const f of memory.files) {
+    if (mediaNames.has(f.source.locator)) includeFile(f.fileId);
+  }
+  for (const e of memory.executions) {
+    if (callIds.has(e.invocationId)) includedExecutions.add(e.executionId);
+  }
+
+  // Closure to a fixed point.
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const e of memory.executions) {
+      const sourceFile = filesByVersion.get(e.sourceVersionId)?.fileId;
+      if (!includedExecutions.has(e.executionId)) {
+        // An execution joins when it read an included file.
+        if (sourceFile && includedFiles.has(sourceFile)) {
+          includedExecutions.add(e.executionId);
+          changed = true;
+        } else {
+          continue;
+        }
+      }
+      // An included execution pulls in its source file…
+      if (includeFile(sourceFile)) changed = true;
+    }
+    for (const f of memory.files) {
+      if (includedFiles.has(f.fileId)) continue;
+      // …and every file one of its versions produced.
+      if (
+        f.producedByExecutionId !== undefined &&
+        includedExecutions.has(f.producedByExecutionId)
+      ) {
+        includeFile(f.fileId);
+        changed = true;
+      }
+    }
+  }
+
+  return {
+    files: memory.files.filter((f) => includedFiles.has(f.fileId)),
+    executions: memory.executions.filter((e) =>
+      includedExecutions.has(e.executionId),
+    ),
+  };
 }
 
 // ─── Entry points ─────────────────────────────────────────────────────────
@@ -482,19 +712,13 @@ export async function exportOmniTrajectory(
       // One corrupt transcript line loses that line, not the export.
     }
   }
-  const records: OmniTrajectoryRecord[] = buildTurnRecords(transcriptLines);
+  const turns = buildTurnRecords(transcriptLines);
+  const records: OmniTrajectoryRecord[] = [...turns];
 
-  const store = new MediaMemoryStore(options.omniRootDir);
-  const empty: MemoryRecords = { files: [], executions: [] };
-  const memoryRecords = await store
-    .read<MemoryRecords>(empty, (snapshot) => buildMemoryRecords(snapshot))
-    .catch((err) => {
-      debugLogger.debug(
-        `trajectory export: memory unreadable, exporting transcript only: ` +
-          `${err instanceof Error ? err.message : err}`,
-      );
-      return empty;
-    });
+  const snapshot = await readSnapshotRaw(options.omniRootDir);
+  const memoryRecords = snapshot
+    ? filterToSession(buildMemoryRecords(snapshot), turns)
+    : { files: [], executions: [] };
   // files before executions, each sorted by id — deterministic re-export.
   records.push(
     ...memoryRecords.files.sort((a, b) =>
@@ -518,7 +742,17 @@ export function serializeOmniTrajectory(
 export async function writeOmniTrajectoryJsonl(
   options: ExportOmniTrajectoryOptions & { outPath: string },
 ): Promise<{ records: number }> {
+  const outPath = path.resolve(options.outPath);
+  if (outPath === path.resolve(options.transcriptPath)) {
+    // Writing the trajectory over the raw transcript would irreversibly
+    // destroy the non-reconstructible source this pipeline exists to
+    // capture.
+    throw new Error(
+      'trajectory outPath must differ from the transcript path',
+    );
+  }
   const records = await exportOmniTrajectory(options);
-  await fs.writeFile(options.outPath, serializeOmniTrajectory(records), 'utf8');
+  await fs.mkdir(path.dirname(outPath), { recursive: true });
+  await fs.writeFile(outPath, serializeOmniTrajectory(records), 'utf8');
   return { records: records.length };
 }

--- a/packages/core/src/omni/export.ts
+++ b/packages/core/src/omni/export.ts
@@ -57,6 +57,18 @@ const debugLogger = createDebugLogger('omni:export');
  * `objects/` while retention lasts). Every `execution` line carries
  * `omniConfigHash` so downstream can split trajectories by processing
  * configuration instead of mixing distributions.
+ *
+ * ## What is and is not scrubbed
+ *
+ * The exporter strips exactly the harness-side surface the model never
+ * saw: the reserved runtime keys (inputPath/outputDir) that the gate and
+ * orchestrator inject into policy calls. Content the MODEL itself saw or
+ * produced — a path the user typed into their prompt, a `file_path` the
+ * model passed to write_file — is preserved verbatim: it IS the
+ * trajectory, and scrubbing it would corrupt the training signal while
+ * teaching nothing about the pipeline. Callers publishing exports off
+ * the machine own that second category (measured on a real session: 147
+ * records, zero pipeline-side leaks, 7 user/model-side absolute paths).
  */
 
 // ─── Line shapes ──────────────────────────────────────────────────────────

--- a/packages/core/src/omni/gc.test.ts
+++ b/packages/core/src/omni/gc.test.ts
@@ -1,0 +1,295 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  MediaMemoryService,
+  MediaResourceRegistry,
+} from '../services/media-memory/index.js';
+import { MEDIA_MEMORY_FILE_NAME } from '../services/media-memory/store.js';
+import { OmniObjectStore } from './storage.js';
+import {
+  isOmniDerivationSuspended,
+  resetGcLatchForTests,
+  runOmniGcOnce,
+} from './gc.js';
+
+const DAY_MS = 24 * 3600_000;
+
+describe('runOmniGcOnce', () => {
+  let qwenDir: string;
+  let store: OmniObjectStore;
+  let memory: MediaMemoryService;
+
+  beforeEach(async () => {
+    resetGcLatchForTests();
+    qwenDir = await fs.mkdtemp(path.join(os.tmpdir(), 'omni-gc-'));
+    store = new OmniObjectStore(qwenDir);
+    memory = new MediaMemoryService(store.getOmniRootDir());
+    await fs.mkdir(store.getObjectsDir(), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(qwenDir, { recursive: true, force: true });
+  });
+
+  /** Materialize one object file with controllable age and size. */
+  async function writeObject(
+    sha256: string,
+    ageDays: number,
+    sizeBytes = 4,
+  ): Promise<string> {
+    const shardDir = path.join(store.getObjectsDir(), sha256.slice(0, 2));
+    await fs.mkdir(shardDir, { recursive: true });
+    const filePath = path.join(shardDir, `${sha256}.bin`);
+    await fs.writeFile(filePath, Buffer.alloc(sizeBytes, 1));
+    const mtime = new Date(Date.now() - ageDays * DAY_MS);
+    await fs.utimes(filePath, mtime, mtime);
+    return filePath;
+  }
+
+  /** Record a policy execution whose media output references `sha256`,
+   * making it a GC root through `entries[].artifactRef.managedId`. */
+  async function referenceViaEntry(sha256: string): Promise<void> {
+    const source = (await memory.recordFileRecognized({
+      fileRef: '/movies/film.mkv',
+      sha256: 'e'.repeat(64),
+      mediaType: 'video',
+      metadata: { durationMs: 1000 },
+      sizeBytes: 10,
+      mimeType: 'video/x-matroska',
+      origin: 'user',
+      source: { protocol: 'local', locator: 'film.mkv' },
+      recognition: {
+        ingestionConfigHash: '',
+        detectorVersion: 'omni-sniff-ffprobe/1',
+        probeStatus: 'complete',
+      },
+    }))!;
+    await memory.commitPolicySucceeded({
+      invocationId: 'aabbccdd00112233',
+      source,
+      executionOrigin: {
+        kind: 'fixed_policy',
+        policyId: 'p',
+        stage: 'preprocessing',
+      },
+      toolName: 'omni_downscale_video',
+      finalArguments: {},
+      omniConfigHash: 'fp-' + '0'.repeat(61),
+      startedAt: '2026-08-13T00:00:00.000Z',
+      completedAt: '2026-08-13T00:00:01.000Z',
+      outputs: [
+        {
+          kind: 'media',
+          objectPath: store.objectPathFor(sha256, '.bin'),
+          sha256,
+          mediaType: 'video',
+          metadata: { durationMs: 1000 },
+          sizeBytes: 4,
+          mimeType: 'video/mp4',
+        },
+      ],
+    });
+  }
+
+  function gcOptions(overrides?: Partial<Parameters<typeof runOmniGcOnce>[0]>) {
+    return {
+      store,
+      memoryService: memory,
+      retentionDays: 14,
+      maxTotalBytes: 1024 * 1024,
+      ...overrides,
+    };
+  }
+
+  it('sweeps an expired unreferenced object and keeps a referenced one', async () => {
+    const dead = 'a'.repeat(64);
+    const kept = 'b'.repeat(64);
+    const deadPath = await writeObject(dead, 30);
+    const keptPath = await writeObject(kept, 30);
+    await referenceViaEntry(kept);
+
+    const result = await runOmniGcOnce(gcOptions());
+
+    expect(result).toMatchObject({ ran: true, deletedObjects: 1 });
+    await expect(fs.access(deadPath)).rejects.toThrow();
+    await expect(fs.access(keptPath)).resolves.toBeUndefined();
+  });
+
+  it('keeps a young unreferenced object (retention grace)', async () => {
+    // The window is what makes "promoted, memory commit still in flight"
+    // and cross-process races safe — a fresh orphan must survive.
+    const young = 'c'.repeat(64);
+    const p = await writeObject(young, 2);
+
+    const result = await runOmniGcOnce(gcOptions());
+
+    expect(result.deletedObjects).toBe(0);
+    await expect(fs.access(p)).resolves.toBeUndefined();
+  });
+
+  it('treats a managed source locator as a root, not just artifactRefs', async () => {
+    // Tool/URL media anchor their file identity in the object store —
+    // their only reference is `versions[].source.locator`. A GC that only
+    // reads artifactRefs would delete exactly the objects whose store copy
+    // is the only copy.
+    const anchored = 'd'.repeat(64);
+    const p = await writeObject(anchored, 30);
+    await memory.recordFileRecognized({
+      fileRef: store.objectPathFor(anchored, '.bin'),
+      sha256: anchored,
+      mediaType: 'image',
+      metadata: { width: 8, height: 8 },
+      sizeBytes: 4,
+      mimeType: 'image/png',
+      origin: 'tool',
+      source: { protocol: 'managed', locator: `sha256/${anchored}` },
+      recognition: {
+        ingestionConfigHash: '',
+        detectorVersion: 'omni-sniff-ffprobe/1',
+        probeStatus: 'complete',
+      },
+    });
+
+    const result = await runOmniGcOnce(gcOptions());
+
+    expect(result.deletedObjects).toBe(0);
+    await expect(fs.access(p)).resolves.toBeUndefined();
+  });
+
+  it('protects objects the live session registry still points at', async () => {
+    const live = 'f'.repeat(64);
+    const p = await writeObject(live, 30);
+    const registry = new MediaResourceRegistry();
+    registry.bind({
+      fileId: 'f1',
+      fileVersionId: 'v1',
+      rootFileId: 'f1',
+      fileRef: store.objectPathFor(live, '.bin'),
+      mediaType: 'image',
+    });
+
+    const result = await runOmniGcOnce(gcOptions({ registry }));
+
+    expect(result.deletedObjects).toBe(0);
+    await expect(fs.access(p)).resolves.toBeUndefined();
+  });
+
+  it('deletes NOTHING when the memory snapshot is unreadable', async () => {
+    // Fail-closed hard rule: an unreadable ledger must never read as an
+    // empty one — that misread would sweep the entire store.
+    await writeObject('a'.repeat(64), 400);
+    await fs.writeFile(
+      path.join(store.getOmniRootDir(), MEDIA_MEMORY_FILE_NAME),
+      '{not json',
+    );
+
+    const result = await runOmniGcOnce(gcOptions());
+
+    expect(result.ran).toBe(false);
+    expect(result.deletedObjects).toBe(0);
+    await expect(
+      fs.access(
+        path.join(store.getObjectsDir(), 'aa', `${'a'.repeat(64)}.bin`),
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('over budget: deletes oldest unreferenced objects regardless of age', async () => {
+    const older = '1'.repeat(64);
+    const newer = '2'.repeat(64);
+    await writeObject(older, 5, 600); // younger than retention, but budget
+    await writeObject(newer, 1, 600);
+
+    const result = await runOmniGcOnce(gcOptions({ maxTotalBytes: 800 }));
+
+    // Oldest goes first; once within budget the newer one survives.
+    expect(result.deletedObjects).toBe(1);
+    await expect(
+      fs.access(path.join(store.getObjectsDir(), '11', `${older}.bin`)),
+    ).rejects.toThrow();
+    await expect(
+      fs.access(path.join(store.getObjectsDir(), '22', `${newer}.bin`)),
+    ).resolves.toBeUndefined();
+  });
+
+  it('over budget with only referenced objects: suspends derivations, deletes nothing', async () => {
+    const kept = 'b'.repeat(64);
+    await writeObject(kept, 30, 2048);
+    await referenceViaEntry(kept);
+    const root = store.getOmniRootDir();
+    expect(isOmniDerivationSuspended(root)).toBe(false);
+
+    const result = await runOmniGcOnce(gcOptions({ maxTotalBytes: 100 }));
+
+    expect(result.deletedObjects).toBe(0);
+    expect(result.derivationsSuspended).toBe(true);
+    expect(isOmniDerivationSuspended(root)).toBe(true);
+
+    // A later run under a raised budget clears the suspension.
+    resetGcLatchForTests();
+    const relaxed = await runOmniGcOnce(gcOptions({ maxTotalBytes: 10_000 }));
+    expect(relaxed.derivationsSuspended).toBe(false);
+    expect(isOmniDerivationSuspended(root)).toBe(false);
+  });
+
+  it('cascades a deletion into the upload and degradation caches', async () => {
+    const dead = 'a'.repeat(64);
+    await writeObject(dead, 30);
+    const uploadRemoved: string[] = [];
+    const degradedRemoved: string[] = [];
+    await runOmniGcOnce(
+      gcOptions({
+        uploadCache: {
+          removeBySha256: async (sha: string) => {
+            uploadRemoved.push(sha);
+          },
+        } as never,
+        degradationCache: {
+          removeByOriginalSha256: async (sha: string) => {
+            degradedRemoved.push(`orig:${sha}`);
+          },
+          removeByDegradedSha256: async (sha: string) => {
+            degradedRemoved.push(`deg:${sha}`);
+          },
+        } as never,
+      }),
+    );
+
+    expect(uploadRemoved).toEqual([dead]);
+    expect(degradedRemoved).toEqual([`orig:${dead}`, `deg:${dead}`]);
+  });
+
+  it('runs once per store root per process', async () => {
+    await writeObject('a'.repeat(64), 30);
+    const first = await runOmniGcOnce(gcOptions());
+    // Second call returns the SAME settled run — no re-sweep.
+    const again = await runOmniGcOnce(gcOptions());
+    expect(first.deletedObjects).toBe(1);
+    expect(again).toBe(first);
+  });
+
+  it('never descends into a symlinked shard', async () => {
+    // A link planted inside objects/ must not redirect the sweep at
+    // arbitrary external paths (same guard the recovery scan carries).
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'omni-gc-out-'));
+    const victim = path.join(outside, `${'9'.repeat(64)}.bin`);
+    await fs.writeFile(victim, 'x');
+    const old = new Date(Date.now() - 400 * DAY_MS);
+    await fs.utimes(victim, old, old);
+    await fs.symlink(outside, path.join(store.getObjectsDir(), '99'));
+
+    const result = await runOmniGcOnce(gcOptions());
+
+    expect(result.deletedObjects).toBe(0);
+    await expect(fs.access(victim)).resolves.toBeUndefined();
+    await fs.rm(outside, { recursive: true, force: true });
+  });
+});

--- a/packages/core/src/omni/gc.test.ts
+++ b/packages/core/src/omni/gc.test.ts
@@ -18,6 +18,7 @@ import {
   isOmniDerivationSuspended,
   resetGcLatchForTests,
   runOmniGcOnce,
+  settleOmniGc,
 } from './gc.js';
 
 const DAY_MS = 24 * 3600_000;
@@ -274,6 +275,25 @@ describe('runOmniGcOnce', () => {
     const again = await runOmniGcOnce(gcOptions());
     expect(first.deletedObjects).toBe(1);
     expect(again).toBe(first);
+  });
+
+  it('settleOmniGc waits out an in-flight sweep before the gate reads the flag', async () => {
+    // The startup wiring is fire-and-forget; the budget gate must not
+    // consult isOmniDerivationSuspended while the sweep is still running
+    // (observed E2E: the first derivation of a fresh process slipped past
+    // the budget because the verdict landed ~900ms later).
+    const kept = 'b'.repeat(64);
+    await writeObject(kept, 30, 2048);
+    await referenceViaEntry(kept);
+    const root = store.getOmniRootDir();
+
+    // Fire-and-forget, exactly like the index.ts wiring — no await.
+    void runOmniGcOnce(gcOptions({ maxTotalBytes: 100 }));
+    await settleOmniGc(root);
+
+    expect(isOmniDerivationSuspended(root)).toBe(true);
+    // A root with no pending run settles immediately.
+    await expect(settleOmniGc('/nonexistent')).resolves.toBeUndefined();
   });
 
   it('never descends into a symlinked shard', async () => {

--- a/packages/core/src/omni/gc.test.ts
+++ b/packages/core/src/omni/gc.test.ts
@@ -7,7 +7,7 @@
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   MediaMemoryService,
   MediaResourceRegistry,
@@ -15,6 +15,7 @@ import {
 import { MEDIA_MEMORY_FILE_NAME } from '../services/media-memory/store.js';
 import { OmniObjectStore } from './storage.js';
 import {
+  effectiveOmniStorageMaxTotalBytes,
   isOmniDerivationSuspended,
   resetGcLatchForTests,
   runOmniGcOnce,
@@ -214,9 +215,35 @@ describe('runOmniGcOnce', () => {
     await expect(fs.access(p)).resolves.toBeUndefined();
   });
 
-  it('deletes NOTHING when the memory snapshot is unreadable', async () => {
-    // Fail-closed hard rule: an unreadable ledger must never read as an
-    // empty one — that misread would sweep the entire store.
+  it('ignores a registry fileRef OUTSIDE the store, even with a matching name', async () => {
+    // The registry-root scope guard: a handle on a user file protects
+    // nothing — only locators inside objects/ count. A same-named file
+    // outside the store must not shield the store copy.
+    const sha = '6'.repeat(64);
+    const p = await writeObject(sha, 30);
+    const outside = path.join(qwenDir, `${sha}.bin`);
+    await fs.writeFile(outside, 'user copy');
+    const registry = new MediaResourceRegistry();
+    registry.bind({
+      fileId: 'f1',
+      fileVersionId: 'v1',
+      rootFileId: 'f1',
+      fileRef: outside,
+      mediaType: 'image',
+    });
+
+    const result = await runOmniGcOnce(gcOptions({ registry }));
+
+    expect(result.deletedObjects).toBe(1);
+    await expect(fs.access(p)).rejects.toThrow();
+    await expect(fs.access(outside)).resolves.toBeUndefined();
+  });
+
+  it('deletes NOTHING when the ledger was corrupt (recovery-backup guard)', async () => {
+    // A corrupt document does not read as null: the store SELF-HEALS it
+    // (rename to `.corrupt-<ts>`, continue on empty). What blocks this
+    // run is the corruption-recovery guard — an empty post-heal ledger
+    // must not read as "nothing is referenced".
     await writeObject('a'.repeat(64), 400);
     await fs.writeFile(
       path.join(store.getOmniRootDir(), MEDIA_MEMORY_FILE_NAME),
@@ -232,6 +259,53 @@ describe('runOmniGcOnce', () => {
         path.join(store.getObjectsDir(), 'aa', `${'a'.repeat(64)}.bin`),
       ),
     ).resolves.toBeUndefined();
+  });
+
+  it('deletes NOTHING when the root set is unknowable (refs === null)', async () => {
+    // Hard rule 1 proper: a service that cannot READ the ledger (EACCES,
+    // I/O error — distinct from corrupt-and-healed) reports null, and
+    // null must never be treated as an empty root set.
+    const p = await writeObject('a'.repeat(64), 400);
+    const unreadableService = {
+      collectManagedRefs: async () => null,
+    } as unknown as MediaMemoryService;
+
+    const result = await runOmniGcOnce(
+      gcOptions({ memoryService: unreadableService }),
+    );
+
+    expect(result.ran).toBe(false);
+    expect(result.deletedObjects).toBe(0);
+    await expect(fs.access(p)).resolves.toBeUndefined();
+  });
+
+  it('roots an entry artifactRef on its own (no version locator for it)', async () => {
+    // `entries[].artifactRef.managedId` must be an independent root: a
+    // hand-written ledger references the object ONLY through an entry —
+    // no version record backs it up (the service's own commit would
+    // double-root, masking a regression in this branch).
+    const sha = '8'.repeat(64);
+    const p = await writeObject(sha, 30);
+    await fs.writeFile(
+      path.join(store.getOmniRootDir(), MEDIA_MEMORY_FILE_NAME),
+      JSON.stringify({
+        schemaVersion: 1,
+        files: {},
+        versions: {},
+        executions: {},
+        entries: {
+          'e-1': {
+            kind: 'derived_media',
+            artifactRef: { storage: 'managed', managedId: `sha256/${sha}` },
+          },
+        },
+      }),
+    );
+
+    const result = await runOmniGcOnce(gcOptions());
+
+    expect(result.deletedObjects).toBe(0);
+    await expect(fs.access(p)).resolves.toBeUndefined();
   });
 
   it('over budget: deletes oldest unreferenced objects regardless of age', async () => {
@@ -318,8 +392,11 @@ describe('runOmniGcOnce', () => {
     expect(result.derivationsSuspended).toBe(true);
     expect(isOmniDerivationSuspended(root)).toBe(true);
 
-    // A later run under a raised budget clears the suspension.
-    resetGcLatchForTests();
+    // A later run under a raised budget clears the suspension. Re-arm
+    // ONLY the run latch — the flag must stand until the relaxed sweep
+    // itself clears it, or this assertion proves nothing.
+    resetGcLatchForTests({ keepSuspension: true });
+    expect(isOmniDerivationSuspended(root)).toBe(true);
     const relaxed = await runOmniGcOnce(gcOptions({ maxTotalBytes: 10_000 }));
     expect(relaxed.derivationsSuspended).toBe(false);
     expect(isOmniDerivationSuspended(root)).toBe(false);
@@ -327,13 +404,21 @@ describe('runOmniGcOnce', () => {
 
   it('cascades a deletion into the upload and degradation caches', async () => {
     const dead = 'a'.repeat(64);
-    await writeObject(dead, 30);
+    const deadPath = await writeObject(dead, 30);
     const uploadRemoved: string[] = [];
     const degradedRemoved: string[] = [];
+    let bytesGoneAtCascade: boolean | undefined;
     await runOmniGcOnce(
       gcOptions({
         uploadCache: {
           removeBySha256: async (sha: string) => {
+            // Load-bearing ORDER: the bytes must be gone before the
+            // cache entry — the reverse could re-serve a deleted object
+            // from cache.
+            bytesGoneAtCascade = await fs.access(deadPath).then(
+              () => false,
+              () => true,
+            );
             uploadRemoved.push(sha);
           },
         } as never,
@@ -350,6 +435,90 @@ describe('runOmniGcOnce', () => {
 
     expect(uploadRemoved).toEqual([dead]);
     expect(degradedRemoved).toEqual([`orig:${dead}`, `deg:${dead}`]);
+    expect(bytesGoneAtCascade).toBe(true);
+  });
+
+  it('accounts a failed rm as a survivor (budget keeps its bytes)', async () => {
+    const stuck = 'a'.repeat(64);
+    const p = await writeObject(stuck, 30, 600);
+    const rmSpy = vi
+      .spyOn(fs, 'rm')
+      .mockRejectedValue(new Error('EPERM: operation not permitted'));
+    try {
+      const result = await runOmniGcOnce(gcOptions({ maxTotalBytes: 100 }));
+
+      // Nothing was deleted, nothing was double-counted, and the
+      // undeletable bytes still count against the budget.
+      expect(result.ran).toBe(true);
+      expect(result.deletedObjects).toBe(0);
+      expect(result.deletedBytes).toBe(0);
+      expect(result.remainingBytes).toBe(600);
+      expect(result.derivationsSuspended).toBe(true);
+    } finally {
+      rmSpy.mockRestore();
+    }
+    await expect(fs.access(p)).resolves.toBeUndefined();
+  });
+
+  it('keys the latch and the suspension per store root', async () => {
+    // Two roots in ONE process: each gets its own sweep and its own
+    // suspension verdict — the Map/Set keying is what this pins.
+    const otherQwenDir = await fs.mkdtemp(path.join(os.tmpdir(), 'omni-gc2-'));
+    try {
+      const otherStore = new OmniObjectStore(otherQwenDir);
+      const otherMemory = new MediaMemoryService(otherStore.getOmniRootDir());
+      await fs.mkdir(otherStore.getObjectsDir(), { recursive: true });
+
+      // Root A: over budget with only referenced bytes → suspended.
+      const kept = 'b'.repeat(64);
+      await writeObject(kept, 30, 2048);
+      await referenceViaEntry(kept);
+      const first = await runOmniGcOnce(gcOptions({ maxTotalBytes: 100 }));
+
+      // Root B: one expired orphan, comfortable budget → swept, clean.
+      const orphan = 'a'.repeat(64);
+      const shard = path.join(otherStore.getObjectsDir(), orphan.slice(0, 2));
+      await fs.mkdir(shard, { recursive: true });
+      const orphanPath = path.join(shard, `${orphan}.bin`);
+      await fs.writeFile(orphanPath, Buffer.alloc(4, 1));
+      const old = new Date(Date.now() - 30 * 24 * 3600_000);
+      await fs.utimes(orphanPath, old, old);
+      const second = await runOmniGcOnce({
+        store: otherStore,
+        memoryService: otherMemory,
+        retentionDays: 14,
+        maxTotalBytes: 1024 * 1024,
+      });
+
+      // Distinct runs, not the first root's settled result.
+      expect(second).not.toBe(first);
+      expect(second.deletedObjects).toBe(1);
+      expect(isOmniDerivationSuspended(store.getOmniRootDir())).toBe(true);
+      expect(isOmniDerivationSuspended(otherStore.getOmniRootDir())).toBe(
+        false,
+      );
+    } finally {
+      await fs.rm(otherQwenDir, { recursive: true, force: true });
+    }
+  });
+
+  it('effectiveOmniStorageMaxTotalBytes floors the budget at 10× the media limit', () => {
+    const configFor = (budget: number, singleMedia?: number) =>
+      ({
+        getOmniStorageMaxTotalBytes: () => budget,
+        getOmniMaxUploadFileBytes: () => singleMedia,
+      }) as never;
+
+    // Below the floor: clamped up (storage design §7 — the budget must
+    // hold at least ten normal uploads or it reads as a broken pipeline).
+    expect(effectiveOmniStorageMaxTotalBytes(configFor(1000, 500))).toBe(5000);
+    // At or above the floor: honored verbatim.
+    expect(effectiveOmniStorageMaxTotalBytes(configFor(5000, 500))).toBe(5000);
+    expect(effectiveOmniStorageMaxTotalBytes(configFor(9999, 500))).toBe(9999);
+    // No explicit media limit: the guard default (1 GiB) drives the floor.
+    expect(effectiveOmniStorageMaxTotalBytes(configFor(1000))).toBe(
+      10 * 1024 * 1024 * 1024,
+    );
   });
 
   it('runs once per store root per process', async () => {

--- a/packages/core/src/omni/gc.test.ts
+++ b/packages/core/src/omni/gc.test.ts
@@ -367,9 +367,12 @@ describe('runOmniGcOnce', () => {
         maxTotalBytes: 100,
         uploadCache: {
           // Fires while `first` is being deleted — before `second`'s turn.
+          // A +10s timestamp keeps the assertion immune to filesystems
+          // that truncate mtime to whole seconds (observed on the CI
+          // runner: touch-with-now floored below the sweep start).
           removeBySha256: async () => {
-            const now = new Date();
-            await fs.utimes(secondPath, now, now);
+            const future = new Date(Date.now() + 10_000);
+            await fs.utimes(secondPath, future, future);
           },
         } as never,
       }),

--- a/packages/core/src/omni/gc.test.ts
+++ b/packages/core/src/omni/gc.test.ts
@@ -165,6 +165,37 @@ describe('runOmniGcOnce', () => {
     await expect(fs.access(p)).resolves.toBeUndefined();
   });
 
+  it('roots a URL-origin version through its in-store fileRef', async () => {
+    // URL media keep the ORIGINAL URL as source.locator (protocol 'url'),
+    // but their staging download is deleted the turn it lands — the store
+    // copy named by fileRef is the only persistent bytes. A root set that
+    // only reads managed locators would delete exactly those objects
+    // while the ledger still vouches for them (hard rule 2).
+    const urlAnchored = '5'.repeat(64);
+    const p = await writeObject(urlAnchored, 30);
+    await memory.recordFileRecognized({
+      fileRef: store.objectPathFor(urlAnchored, '.bin'),
+      sha256: urlAnchored,
+      mediaType: 'video',
+      metadata: { durationMs: 1000 },
+      sizeBytes: 4,
+      mimeType: 'video/mp4',
+      origin: 'user',
+      source: { protocol: 'url', locator: 'https://example.com/clip.mp4' },
+      recognition: {
+        ingestionConfigHash: '',
+        detectorVersion: 'omni-sniff-ffprobe/1',
+        probeStatus: 'complete',
+      },
+    });
+
+    // Both passes must keep it: pass 1 (expired) and pass 2 (budget).
+    const result = await runOmniGcOnce(gcOptions({ maxTotalBytes: 1 }));
+
+    expect(result.deletedObjects).toBe(0);
+    await expect(fs.access(p)).resolves.toBeUndefined();
+  });
+
   it('protects objects the live session registry still points at', async () => {
     const live = 'f'.repeat(64);
     const p = await writeObject(live, 30);
@@ -219,6 +250,59 @@ describe('runOmniGcOnce', () => {
     await expect(
       fs.access(path.join(store.getObjectsDir(), '22', `${newer}.bin`)),
     ).resolves.toBeUndefined();
+  });
+
+  it('budget pass spares an object the FRESH ledger references (stale-snapshot race)', async () => {
+    // The initial root snapshot goes stale while the sweep runs; a commit
+    // landing in that gap must not lose its object. The budget pass
+    // re-reads the ledger right before deleting — simulate the race with
+    // a service whose second read knows the new reference.
+    const contested = '7'.repeat(64);
+    const p = await writeObject(contested, 5, 600);
+    let reads = 0;
+    const racingService = {
+      collectManagedRefs: async () =>
+        ++reads === 1 ? new Set<string>() : new Set([contested]),
+    } as unknown as MediaMemoryService;
+
+    const result = await runOmniGcOnce(
+      gcOptions({ memoryService: racingService, maxTotalBytes: 100 }),
+    );
+
+    expect(reads).toBeGreaterThanOrEqual(2);
+    expect(result.deletedObjects).toBe(0);
+    await expect(fs.access(p)).resolves.toBeUndefined();
+    // Still over budget with (now-)referenced bytes only → suspended.
+    expect(result.derivationsSuspended).toBe(true);
+  });
+
+  it('budget pass skips an object whose mtime was touched during the sweep', async () => {
+    // putFile's dedup touch precedes every new commit; an object touched
+    // after the sweep began signals an in-flight reference. The delete
+    // loop re-stats each candidate — the touched one must survive even
+    // though the budget still wants its bytes. (`first` is expired and
+    // goes in pass 1; young `second` is only reachable by the budget
+    // pass, whose cascade-triggered touch must spare it.)
+    const first = '3'.repeat(64);
+    const second = '4'.repeat(64);
+    await writeObject(first, 30, 600);
+    const secondPath = await writeObject(second, 5, 600);
+
+    const result = await runOmniGcOnce(
+      gcOptions({
+        maxTotalBytes: 100,
+        uploadCache: {
+          // Fires while `first` is being deleted — before `second`'s turn.
+          removeBySha256: async () => {
+            const now = new Date();
+            await fs.utimes(secondPath, now, now);
+          },
+        } as never,
+      }),
+    );
+
+    expect(result.deletedObjects).toBe(1);
+    await expect(fs.access(secondPath)).resolves.toBeUndefined();
   });
 
   it('over budget with only referenced objects: suspends derivations, deletes nothing', async () => {

--- a/packages/core/src/omni/gc.ts
+++ b/packages/core/src/omni/gc.ts
@@ -1,0 +1,361 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { createDebugLogger } from '../utils/debugLogger.js';
+import type { MediaMemoryService } from '../services/media-memory/service.js';
+import type { MediaResourceRegistry } from '../services/media-memory/registry.js';
+import type { OmniObjectStore } from './storage.js';
+import type { OmniUploadCache } from './upload-cache.js';
+import type { OmniDegradationCache } from './policy/degradation-cache.js';
+import { MEDIA_MEMORY_FILE_NAME } from '../services/media-memory/store.js';
+
+const debugLogger = createDebugLogger('omni:gc');
+
+/**
+ * Mark-and-sweep GC over the content-addressed object store (storage
+ * design §6.2). The design's two hard rules shape everything here:
+ *
+ * 1. **An unreadable ledger deletes nothing.** The root set comes from the
+ *    memory snapshot; if that snapshot cannot be read, the GC has no way
+ *    to tell "unreferenced" from "unknown" and skips the run entirely.
+ * 2. **A referenced object is never deleted, even over budget.** Deleting
+ *    it would leave memory records pointing at nothing — recall would
+ *    report `artifact_unavailable` for artifacts the user paid for and the
+ *    ledger still vouches for. Budget pressure is answered by suspending
+ *    NEW derivations (policy design §8.4's budget-stop semantics), never
+ *    by rewriting history.
+ *
+ * Sweep order is oldest-first so the budget pass converges on the objects
+ * least likely to be re-used. Every deletion cascades into the upload
+ * cache and the degradation cache — a cache hit must never point at bytes
+ * that are gone (same invariant the recovery scan's corrupt-object path
+ * already enforces).
+ *
+ * Multi-process safety leans on the same argument as startup recovery:
+ * deletion requires BOTH "no reference in the snapshot" and "older than
+ * the retention window", so another process's just-promoted object (whose
+ * memory commit may still be in flight) survives on age alone. The
+ * once-per-root latch is process-local by design; two processes GCing the
+ * same store can only disagree toward "delete less".
+ */
+
+/** Object-file shape inside a shard: `<64-hex>.<extension>`. Anything else
+ * (promotion temps, strays) belongs to the recovery scan, not the GC. */
+const OBJECT_NAME_RE = /^([0-9a-f]{64})\.[A-Za-z0-9][A-Za-z0-9.]*$/;
+
+export interface OmniGcOptions {
+  store: OmniObjectStore;
+  memoryService: MediaMemoryService;
+  /** Live session bindings — roots alongside the snapshot (a resource
+   * delivered this turn may be bound before its memory commit lands). */
+  registry?: MediaResourceRegistry;
+  uploadCache?: OmniUploadCache;
+  degradationCache?: OmniDegradationCache;
+  /** Days an unreferenced object survives after promotion. */
+  retentionDays: number;
+  /** Soft byte budget for objects/; over-budget triggers oldest-first
+   * deletion of unreferenced objects regardless of age. */
+  maxTotalBytes: number;
+  /** Test seam: "now" in epoch ms. */
+  nowMs?: number;
+}
+
+export interface OmniGcResult {
+  /** False when the run was skipped (unreadable snapshot / latch). */
+  ran: boolean;
+  deletedObjects: number;
+  deletedBytes: number;
+  /** Bytes remaining in objects/ after the sweep. */
+  remainingBytes: number;
+  /** True when the store is still over budget with only referenced
+   * objects left — new derivations are suspended until a later run
+   * clears it. */
+  derivationsSuspended: boolean;
+}
+
+const SKIPPED: OmniGcResult = {
+  ran: false,
+  deletedObjects: 0,
+  deletedBytes: 0,
+  remainingBytes: 0,
+  derivationsSuspended: false,
+};
+
+/** One GC per store root per process lifetime (same latch pattern as
+ * startup recovery); the suspension flag lives beside it so the
+ * orchestrator can consult it without holding a GC reference. */
+const gcOnce = new Map<string, Promise<OmniGcResult>>();
+const suspendedRoots = new Set<string>();
+
+/** Test-only: allow re-running GC within one process. */
+export function resetGcLatchForTests(): void {
+  gcOnce.clear();
+  suspendedRoots.clear();
+}
+
+/**
+ * Whether new policy derivations are suspended for this store (storage
+ * design §6.2: over budget with only referenced objects left). Consulted
+ * by the orchestrator before executing a policy tool; reuse and cache
+ * hits stay allowed — they produce no new bytes.
+ */
+export function isOmniDerivationSuspended(omniRootDir: string): boolean {
+  return suspendedRoots.has(path.resolve(omniRootDir));
+}
+
+/** Real-directory guard (lstat, symlinks rejected) — the sweep deletes
+ * files under every directory it descends into, and a symlinked shard
+ * would redirect those deletions outside the store. Same rationale as
+ * the recovery scan's guard. */
+async function isRealDirectory(p: string): Promise<boolean> {
+  try {
+    return (await fs.lstat(p)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+interface ObjectStat {
+  sha256: string;
+  filePath: string;
+  mtimeMs: number;
+  sizeBytes: number;
+}
+
+async function listObjects(objectsDir: string): Promise<ObjectStat[]> {
+  const out: ObjectStat[] = [];
+  if (!(await isRealDirectory(objectsDir))) return out;
+  let shards: string[];
+  try {
+    shards = await fs.readdir(objectsDir);
+  } catch {
+    return out;
+  }
+  for (const shard of shards) {
+    const shardDir = path.join(objectsDir, shard);
+    if (!(await isRealDirectory(shardDir))) continue;
+    let names: string[];
+    try {
+      names = await fs.readdir(shardDir);
+    } catch {
+      continue;
+    }
+    for (const name of names) {
+      const match = OBJECT_NAME_RE.exec(name);
+      if (!match) continue;
+      const filePath = path.join(shardDir, name);
+      try {
+        const st = await fs.lstat(filePath);
+        if (!st.isFile()) continue;
+        out.push({
+          sha256: match[1],
+          filePath,
+          mtimeMs: st.mtimeMs,
+          sizeBytes: st.size,
+        });
+      } catch {
+        // Raced away; nothing to account for.
+      }
+    }
+  }
+  return out;
+}
+
+async function deleteObject(
+  object: ObjectStat,
+  options: OmniGcOptions,
+): Promise<boolean> {
+  try {
+    await fs.rm(object.filePath, { force: true });
+  } catch (err) {
+    debugLogger.debug(
+      `gc: failed to delete ${object.sha256}: ${err instanceof Error ? err.message : err}`,
+    );
+    return false;
+  }
+  // Cascade AFTER the bytes are gone: a cache entry pointing at a missing
+  // object degrades to a miss (both caches already tolerate that), while
+  // the reverse order could re-serve a deleted object from cache.
+  try {
+    await options.uploadCache?.removeBySha256(object.sha256);
+  } catch {
+    // Cache hygiene is best-effort; a stale entry degrades to a miss.
+  }
+  try {
+    await options.degradationCache?.removeByOriginalSha256(object.sha256);
+    await options.degradationCache?.removeByDegradedSha256(object.sha256);
+  } catch {
+    // Same best-effort stance.
+  }
+  debugLogger.debug(
+    `gc: deleted unreferenced object ${object.sha256} (${object.sizeBytes} bytes)`,
+  );
+  return true;
+}
+
+/**
+ * Run the GC once per store root per process. Runs AFTER startup
+ * recovery (the recovery scan owns staging/downloads/quarantine and
+ * temp-file hygiene; the GC owns only committed objects).
+ */
+export function runOmniGcOnce(options: OmniGcOptions): Promise<OmniGcResult> {
+  const rootKey = path.resolve(options.store.getOmniRootDir());
+  const existing = gcOnce.get(rootKey);
+  if (existing) return existing;
+  const run = sweep(options, rootKey).catch((err) => {
+    debugLogger.debug(
+      `gc: run failed, skipped: ${err instanceof Error ? err.message : err}`,
+    );
+    return SKIPPED;
+  });
+  gcOnce.set(rootKey, run);
+  return run;
+}
+
+/**
+ * Whether the memory ledger was recently lost to corruption. The store's
+ * own recovery (C8) backs a corrupt document up as
+ * `memory.json.corrupt-<ts>` and continues on an EMPTY snapshot — correct
+ * for recall (degrade to a miss, start a fresh ledger), catastrophic if
+ * the GC trusted it: an empty ledger reads as "nothing is referenced" and
+ * the sweep would erase the entire store off one corruption event. A
+ * fresh backup therefore blocks the run; once the newest backup is older
+ * than the retention window, the empty ledger has stood long enough to be
+ * the real state of the world.
+ */
+async function recentlyRecoveredFromCorruption(
+  omniRootDir: string,
+  retentionDays: number,
+  nowMs: number,
+): Promise<boolean> {
+  const prefix = `${MEDIA_MEMORY_FILE_NAME}.corrupt-`;
+  let names: string[];
+  try {
+    names = await fs.readdir(omniRootDir);
+  } catch {
+    return false;
+  }
+  const cutoff = nowMs - retentionDays * 24 * 3600_000;
+  for (const name of names) {
+    if (!name.startsWith(prefix)) continue;
+    const stamp = Number(name.slice(prefix.length));
+    if (Number.isFinite(stamp) && stamp >= cutoff) return true;
+    try {
+      const st = await fs.lstat(path.join(omniRootDir, name));
+      if (st.mtimeMs >= cutoff) return true;
+    } catch {
+      // Unreadable backup: treat as recent (fail-closed).
+      return true;
+    }
+  }
+  return false;
+}
+
+async function sweep(
+  options: OmniGcOptions,
+  rootKey: string,
+): Promise<OmniGcResult> {
+  const nowMsForGuard = options.nowMs ?? Date.now();
+  const refs = await options.memoryService.collectManagedRefs();
+  if (refs === null) {
+    // Hard rule 1: roots unknown → delete nothing, and leave any prior
+    // suspension in place (we cannot prove the pressure is gone either).
+    debugLogger.debug('gc: memory snapshot unreadable, skipping run');
+    return SKIPPED;
+  }
+  // Reading the snapshot above may itself have just performed the
+  // corruption recovery — the backup check must come AFTER it.
+  if (
+    await recentlyRecoveredFromCorruption(
+      options.store.getOmniRootDir(),
+      options.retentionDays,
+      nowMsForGuard,
+    )
+  ) {
+    debugLogger.debug(
+      'gc: memory ledger recently recovered from corruption, skipping run',
+    );
+    return SKIPPED;
+  }
+  // Live session handles count as roots too. Only locators inside the
+  // object store matter here — a handle on a user file protects nothing
+  // (GC never touches paths outside objects/ in the first place).
+  const objectsDir = options.store.getObjectsDir();
+  for (const fileRef of options.registry?.activeFileRefs() ?? []) {
+    const name = path.basename(fileRef);
+    const match = OBJECT_NAME_RE.exec(name);
+    if (match && fileRef.startsWith(objectsDir)) refs.add(match[1]);
+  }
+
+  const nowMs = options.nowMs ?? Date.now();
+  const cutoffMs = nowMs - options.retentionDays * 24 * 3600_000;
+  const objects = await listObjects(objectsDir);
+
+  let deletedObjects = 0;
+  let deletedBytes = 0;
+  const survivors: ObjectStat[] = [];
+
+  // Pass 1: expired and unreferenced.
+  for (const object of objects) {
+    if (refs.has(object.sha256) || object.mtimeMs >= cutoffMs) {
+      survivors.push(object);
+      continue;
+    }
+    if (await deleteObject(object, options)) {
+      deletedObjects += 1;
+      deletedBytes += object.sizeBytes;
+    } else {
+      survivors.push(object);
+    }
+  }
+
+  // Pass 2: budget. Oldest unreferenced objects go regardless of age;
+  // referenced objects are untouchable (hard rule 2).
+  let remainingBytes = survivors.reduce((sum, o) => sum + o.sizeBytes, 0);
+  if (remainingBytes > options.maxTotalBytes) {
+    const unreferenced = survivors
+      .filter((o) => !refs.has(o.sha256))
+      .sort((a, b) => a.mtimeMs - b.mtimeMs);
+    for (const object of unreferenced) {
+      if (remainingBytes <= options.maxTotalBytes) break;
+      if (await deleteObject(object, options)) {
+        deletedObjects += 1;
+        deletedBytes += object.sizeBytes;
+        remainingBytes -= object.sizeBytes;
+      }
+    }
+  }
+
+  const derivationsSuspended = remainingBytes > options.maxTotalBytes;
+  if (derivationsSuspended) {
+    suspendedRoots.add(rootKey);
+    debugLogger.warn(
+      `omni object store over budget with only referenced objects left ` +
+        `(${remainingBytes} > ${options.maxTotalBytes} bytes); new policy ` +
+        `derivations are suspended for this session. Raise ` +
+        `omni.storage.maxTotalBytes or delete memory records you no ` +
+        `longer need.`,
+    );
+  } else {
+    suspendedRoots.delete(rootKey);
+  }
+
+  if (deletedObjects > 0) {
+    debugLogger.debug(
+      `gc: removed ${deletedObjects} object(s) / ${deletedBytes} bytes; ` +
+        `${remainingBytes} bytes remain`,
+    );
+  }
+  return {
+    ran: true,
+    deletedObjects,
+    deletedBytes,
+    remainingBytes,
+    derivationsSuspended,
+  };
+}

--- a/packages/core/src/omni/gc.ts
+++ b/packages/core/src/omni/gc.ts
@@ -36,12 +36,19 @@ const debugLogger = createDebugLogger('omni:gc');
  * that are gone (same invariant the recovery scan's corrupt-object path
  * already enforces).
  *
- * Multi-process safety leans on the same argument as startup recovery:
- * deletion requires BOTH "no reference in the snapshot" and "older than
- * the retention window", so another process's just-promoted object (whose
- * memory commit may still be in flight) survives on age alone. The
- * once-per-root latch is process-local by design; two processes GCing the
- * same store can only disagree toward "delete less".
+ * Multi-process safety is layered. New BYTES are covered by the
+ * retention window (deletion in pass 1 requires BOTH "no reference in
+ * the snapshot" and "older than the window", so another process's
+ * just-promoted object survives on age alone — same argument as startup
+ * recovery). New REFERENCES to old bytes are covered by touch-on-dedup:
+ * every reference is preceded by a `putFile` whose dedup hit refreshes
+ * the object's mtime before the commit lands, and both passes re-stat a
+ * candidate at delete time (the budget pass — where age protects
+ * nothing — additionally re-reads the ledger for a fresh root set).
+ * The residual window is the moment between the re-stat and the rm,
+ * down from the whole sweep duration. The once-per-root latch is
+ * process-local by design; two processes GCing the same store can only
+ * disagree toward "delete less".
  */
 
 /** Object-file shape inside a shard: `<64-hex>.<extension>`. Anything else
@@ -315,9 +322,31 @@ async function sweep(
   let deletedBytes = 0;
   const survivors: ObjectStat[] = [];
 
+  /** Freshness re-check at delete time. The root snapshot and the object
+   * listing are minutes-stale by the time a candidate is deleted, and a
+   * concurrent commit can reference OLD bytes in that gap (its putFile
+   * dedup-touch refreshes the object's mtime BEFORE the commit lands —
+   * ordering invariant). Re-statting narrows the race from "whole sweep
+   * duration" to the moment between this stat and the rm. */
+  const touchedSinceListing = async (
+    object: ObjectStat,
+    freshCutoffMs: number,
+  ): Promise<boolean> => {
+    try {
+      return (await fs.lstat(object.filePath)).mtimeMs >= freshCutoffMs;
+    } catch {
+      // Raced away — nothing left to delete either.
+      return true;
+    }
+  };
+
   // Pass 1: expired and unreferenced.
   for (const object of objects) {
     if (refs.has(object.sha256) || object.mtimeMs >= cutoffMs) {
+      survivors.push(object);
+      continue;
+    }
+    if (await touchedSinceListing(object, cutoffMs)) {
       survivors.push(object);
       continue;
     }
@@ -330,18 +359,31 @@ async function sweep(
   }
 
   // Pass 2: budget. Oldest unreferenced objects go regardless of age;
-  // referenced objects are untouchable (hard rule 2).
+  // referenced objects are untouchable (hard rule 2). Because age no
+  // longer protects anything here, the pass re-reads the ledger for a
+  // FRESH root set and skips objects touched since the sweep began —
+  // both signals catch a commit that landed while pass 1 ran.
   let remainingBytes = survivors.reduce((sum, o) => sum + o.sizeBytes, 0);
   if (remainingBytes > options.maxTotalBytes) {
-    const unreferenced = survivors
-      .filter((o) => !refs.has(o.sha256))
-      .sort((a, b) => a.mtimeMs - b.mtimeMs);
-    for (const object of unreferenced) {
-      if (remainingBytes <= options.maxTotalBytes) break;
-      if (await deleteObject(object, options)) {
-        deletedObjects += 1;
-        deletedBytes += object.sizeBytes;
-        remainingBytes -= object.sizeBytes;
+    const freshRefs = await options.memoryService.collectManagedRefs();
+    if (freshRefs === null) {
+      // Ledger became unreadable mid-run: fail closed — delete nothing
+      // more. The store is still over budget, so suspension holds.
+      debugLogger.debug(
+        'gc: ledger unreadable at budget pass, skipping budget deletions',
+      );
+    } else {
+      const unreferenced = survivors
+        .filter((o) => !refs.has(o.sha256) && !freshRefs.has(o.sha256))
+        .sort((a, b) => a.mtimeMs - b.mtimeMs);
+      for (const object of unreferenced) {
+        if (remainingBytes <= options.maxTotalBytes) break;
+        if (await touchedSinceListing(object, nowMs)) continue;
+        if (await deleteObject(object, options)) {
+          deletedObjects += 1;
+          deletedBytes += object.sizeBytes;
+          remainingBytes -= object.sizeBytes;
+        }
       }
     }
   }
@@ -354,7 +396,8 @@ async function sweep(
         `(${remainingBytes} > ${options.maxTotalBytes} bytes); new policy ` +
         `derivations are suspended for this session. Raise ` +
         `omni.storage.maxTotalBytes or delete memory records you no ` +
-        `longer need.`,
+        `longer need — either change takes effect at the next session ` +
+        `start (the GC runs once per process).`,
     );
   } else {
     suspendedRoots.delete(rootKey);

--- a/packages/core/src/omni/gc.ts
+++ b/packages/core/src/omni/gc.ts
@@ -7,11 +7,13 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { createDebugLogger } from '../utils/debugLogger.js';
+import type { Config } from '../config/config.js';
 import type { MediaMemoryService } from '../services/media-memory/service.js';
 import type { MediaResourceRegistry } from '../services/media-memory/registry.js';
 import type { OmniObjectStore } from './storage.js';
 import type { OmniUploadCache } from './upload-cache.js';
 import type { OmniDegradationCache } from './policy/degradation-cache.js';
+import { effectiveMaxUploadFileBytes } from './guard.js';
 import { MEDIA_MEMORY_FILE_NAME } from '../services/media-memory/store.js';
 
 const debugLogger = createDebugLogger('omni:gc');
@@ -99,10 +101,37 @@ const SKIPPED: OmniGcResult = {
 const gcOnce = new Map<string, Promise<OmniGcResult>>();
 const suspendedRoots = new Set<string>();
 
-/** Test-only: allow re-running GC within one process. */
-export function resetGcLatchForTests(): void {
+/** Test-only: allow re-running GC within one process. Pass
+ * `keepSuspension` to re-arm the run latch while leaving the suspension
+ * flag standing — the only way to prove a later run actually CLEARS it
+ * (a full reset would make that assertion vacuous). */
+export function resetGcLatchForTests(options?: {
+  keepSuspension?: boolean;
+}): void {
   gcOnce.clear();
-  suspendedRoots.clear();
+  if (!options?.keepSuspension) suspendedRoots.clear();
+}
+
+/**
+ * Effective byte budget for the sweep (storage design §7): never below
+ * 10× the transport guard's single-media ceiling. A budget smaller than
+ * a handful of normal uploads cannot hold legitimate experiment
+ * artifacts — the first referenced object would tip it into permanent
+ * derivation suspension, which reads as a broken pipeline rather than a
+ * configuration mistake.
+ */
+export function effectiveOmniStorageMaxTotalBytes(config: Config): number {
+  const configured = config.getOmniStorageMaxTotalBytes();
+  const floor = 10 * effectiveMaxUploadFileBytes(config);
+  if (configured < floor) {
+    debugLogger.warn(
+      `omni.storage.maxTotalBytes (${configured}) is below 10× the ` +
+        `transport guard's single-media limit; using ${floor} bytes ` +
+        `instead (the budget must hold at least ten normal uploads).`,
+    );
+    return floor;
+  }
+  return configured;
 }
 
 /**

--- a/packages/core/src/omni/gc.ts
+++ b/packages/core/src/omni/gc.ts
@@ -108,6 +108,21 @@ export function isOmniDerivationSuspended(omniRootDir: string): boolean {
   return suspendedRoots.has(path.resolve(omniRootDir));
 }
 
+/**
+ * Await this process's in-flight GC for a store root, if one was started.
+ * The startup wiring runs the GC fire-and-forget so delivery is never
+ * blocked on a sweep — but the budget gate MUST NOT be consulted while
+ * the sweep that sets the suspension flag is still running, or the first
+ * derivation of every fresh process races past the budget (observed in
+ * E2E: one headless run wrote new derivatives before the over-budget
+ * verdict landed ~900ms later). Awaiting the settled run costs nothing
+ * when the GC already finished and never rejects (runOmniGcOnce catches).
+ */
+export async function settleOmniGc(omniRootDir: string): Promise<void> {
+  const existing = gcOnce.get(path.resolve(omniRootDir));
+  if (existing) await existing;
+}
+
 /** Real-directory guard (lstat, symlinks rejected) — the sweep deletes
  * files under every directory it descends into, and a symlinked shard
  * would redirect those deletions outside the store. Same rationale as

--- a/packages/core/src/omni/index.ts
+++ b/packages/core/src/omni/index.ts
@@ -37,6 +37,7 @@ import {
   DEFAULT_UPLOAD_CACHE_TTL_HOURS,
 } from './upload-cache.js';
 import { runStartupRecoveryOnce } from './recovery.js';
+import { runOmniGcOnce } from './gc.js';
 import { OmniDegradationCache } from './policy/degradation-cache.js';
 import {
   formatDisclosureText,
@@ -479,6 +480,24 @@ export async function processMediaForOmniDelivery(
         maxInlineTextBytes: memoryConfig.collection.maxInlineTextBytes,
       })
     : undefined;
+  // GC (storage design §6.2), asynchronously after recovery so the first
+  // delivery is never blocked on a sweep. Memory IS the root set, so the
+  // GC only exists where memory does — without it every object would read
+  // as unreferenced and the sweep would empty the store on age alone.
+  if (memoryService) {
+    void runOmniGcOnce({
+      store,
+      memoryService,
+      registry: (
+        config as OmniMediaRegistryView
+      ).getOmniMediaResourceRegistry?.(),
+      uploadCache,
+      degradationCache: new OmniDegradationCache(store.getOmniRootDir()),
+      retentionDays: config.getOmniStorageRetentionDays?.() ?? 14,
+      maxTotalBytes:
+        config.getOmniStorageMaxTotalBytes?.() ?? 20 * 1024 * 1024 * 1024,
+    });
+  }
   // Session resource registry (M §5.2): every memory-known resource this
   // delivery puts in front of the model gets an opaque session handle,
   // making it addressable by recall without ever exposing a path.

--- a/packages/core/src/omni/index.ts
+++ b/packages/core/src/omni/index.ts
@@ -1193,3 +1193,15 @@ export function effectiveMaxDownloadFileBytes(config: Config): number {
 // is how the ACP agent's static closure acquired iconv-lite's 550 KB of
 // encoding tables (scripts/check-serve-fast-path-bundle.js caught it).
 export { reanchorRememberedMedia } from './memory-recall.js';
+
+// Trajectory export (S6): a pure reader over transcript + memory.json,
+// exposed through the omni door for the wrapper script and E2E tests.
+export {
+  exportOmniTrajectory,
+  serializeOmniTrajectory,
+  writeOmniTrajectoryJsonl,
+  type OmniTrajectoryRecord,
+  type OmniTrajectoryTurnRecord,
+  type OmniTrajectoryExecutionRecord,
+  type OmniTrajectoryFileRecord,
+} from './export.js';

--- a/packages/core/src/omni/index.ts
+++ b/packages/core/src/omni/index.ts
@@ -37,7 +37,7 @@ import {
   DEFAULT_UPLOAD_CACHE_TTL_HOURS,
 } from './upload-cache.js';
 import { runStartupRecoveryOnce } from './recovery.js';
-import { runOmniGcOnce } from './gc.js';
+import { effectiveOmniStorageMaxTotalBytes, runOmniGcOnce } from './gc.js';
 import { OmniDegradationCache } from './policy/degradation-cache.js';
 import {
   formatDisclosureText,
@@ -494,8 +494,12 @@ export async function processMediaForOmniDelivery(
       uploadCache,
       degradationCache: new OmniDegradationCache(store.getOmniRootDir()),
       retentionDays: config.getOmniStorageRetentionDays?.() ?? 14,
+      // Floor-clamped: a budget below 10× the single-media limit cannot
+      // hold normal artifacts and would read as permanent suspension.
       maxTotalBytes:
-        config.getOmniStorageMaxTotalBytes?.() ?? 20 * 1024 * 1024 * 1024,
+        typeof config.getOmniStorageMaxTotalBytes === 'function'
+          ? effectiveOmniStorageMaxTotalBytes(config)
+          : 20 * 1024 * 1024 * 1024,
     });
   }
   // Session resource registry (M §5.2): every memory-known resource this

--- a/packages/core/src/omni/policy/model-call-collection.test.ts
+++ b/packages/core/src/omni/policy/model-call-collection.test.ts
@@ -7,7 +7,7 @@
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Config } from '../../config/config.js';
 import type { PolicyArtifactBatch } from '../../core/turn.js';
 import type { MediaPolicyToolDescriptor } from '../../tools/tools.js';
@@ -18,6 +18,18 @@ import {
 } from '../../services/media-memory/index.js';
 import { OmniObjectStore } from '../storage.js';
 import { collectModelPolicyCall } from './model-call-collection.js';
+
+// The content sniff stays REAL (magic bytes, in-process) — only the
+// ffprobe SUBPROCESS is stubbed. Under CI load the real ffprobe hit its
+// 15s kill timer and the collection silently skipped per D12, reading
+// as "0 executions" (observed twice on the hk runners). Probing adds
+// nothing this suite asserts; the subprocess only adds a load
+// dependency.
+vi.mock('../ffmpeg.js', () => ({
+  probeMediaMetadata: vi
+    .fn()
+    .mockResolvedValue({ width: 1, height: 1 } as never),
+}));
 
 /** A 1x1 JPEG — recognizeMediaFile sniffs real bytes, so the artifact has
  * to be a genuine image. */

--- a/packages/core/src/omni/policy/orchestrator.ts
+++ b/packages/core/src/omni/policy/orchestrator.ts
@@ -32,6 +32,7 @@ import {
   computePolicyFingerprint,
   OmniDegradationCache,
 } from './degradation-cache.js';
+import { isOmniDerivationSuspended } from '../gc.js';
 import { DEFAULT_OMNI_PROCESSING_LIMITS } from './config.js';
 import { resolvePolicyToolSettings } from './tools/media-policy-tool.js';
 import type {
@@ -875,6 +876,22 @@ async function executePolicy(
     // (GC, manual deletion) or its bytes no longer match the entry. Drop
     // every entry pointing at it and re-transcode.
     await cache.removeByDegradedSha256(hit.degradedSha256);
+  }
+
+  // Budget-stop (storage design §6.2 / policy design §8.4): when the GC
+  // found the store over budget with only referenced objects left, no NEW
+  // bytes may be derived. Reuse and cache hits stay allowed — both paths
+  // above return before this point and produce nothing new. Fail the
+  // policy rather than silently skip: a policy that was configured to run
+  // and didn't must say why (its failure routes through the existing
+  // required/optional semantics).
+  if (isOmniDerivationSuspended(store.getOmniRootDir())) {
+    throw new Error(
+      `omni object store is over its byte budget with only ` +
+        `memory-referenced objects left; new policy derivations are ` +
+        `suspended. Raise omni.storage.maxTotalBytes or delete memory ` +
+        `records you no longer need.`,
+    );
   }
 
   const invocationId = randomBytes(8).toString('hex');

--- a/packages/core/src/omni/policy/orchestrator.ts
+++ b/packages/core/src/omni/policy/orchestrator.ts
@@ -32,7 +32,7 @@ import {
   computePolicyFingerprint,
   OmniDegradationCache,
 } from './degradation-cache.js';
-import { isOmniDerivationSuspended } from '../gc.js';
+import { isOmniDerivationSuspended, settleOmniGc } from '../gc.js';
 import { DEFAULT_OMNI_PROCESSING_LIMITS } from './config.js';
 import { resolvePolicyToolSettings } from './tools/media-policy-tool.js';
 import type {
@@ -884,7 +884,10 @@ async function executePolicy(
   // above return before this point and produce nothing new. Fail the
   // policy rather than silently skip: a policy that was configured to run
   // and didn't must say why (its failure routes through the existing
-  // required/optional semantics).
+  // required/optional semantics). The startup GC is fire-and-forget, so
+  // settle it first — otherwise the first derivation of a fresh process
+  // races past the flag before the sweep can raise it.
+  await settleOmniGc(store.getOmniRootDir());
   if (isOmniDerivationSuspended(store.getOmniRootDir())) {
     throw new Error(
       `omni object store is over its byte budget with only ` +

--- a/packages/core/src/omni/policy/orchestrator.ts
+++ b/packages/core/src/omni/policy/orchestrator.ts
@@ -893,7 +893,8 @@ async function executePolicy(
       `omni object store is over its byte budget with only ` +
         `memory-referenced objects left; new policy derivations are ` +
         `suspended. Raise omni.storage.maxTotalBytes or delete memory ` +
-        `records you no longer need.`,
+        `records you no longer need, then start a new session — the ` +
+        `budget is re-evaluated once per process.`,
     );
   }
 

--- a/packages/core/src/omni/storage.test.ts
+++ b/packages/core/src/omni/storage.test.ts
@@ -70,6 +70,23 @@ describe('OmniObjectStore', () => {
     expect(objectFiles).toEqual([path.basename(first.objectPath)]);
   });
 
+  it('a dedup hit refreshes the object mtime (touch-on-reference)', async () => {
+    // Every new memory reference is preceded by a putFile of the same
+    // bytes; the dedup touch re-arms the GC retention grace so a
+    // concurrent sweep whose snapshot predates the commit cannot delete
+    // freshly re-referenced old bytes on age.
+    const a = await makeSource('old-bytes');
+    const { objectPath } = await store.putFile(a.sourcePath, a.sha256, '.bin');
+    const old = new Date(Date.now() - 30 * 24 * 3600_000);
+    await fs.utimes(objectPath, old, old);
+
+    const second = await store.putFile(a.sourcePath, a.sha256, '.bin');
+
+    expect(second.deduped).toBe(true);
+    const st = await fs.lstat(objectPath);
+    expect(st.mtimeMs).toBeGreaterThan(Date.now() - 60_000);
+  });
+
   it('writes a self-ignoring .gitignore once', async () => {
     const { sourcePath, sha256 } = await makeSource('x');
     await store.putFile(sourcePath, sha256, '.mp4');

--- a/packages/core/src/omni/storage.ts
+++ b/packages/core/src/omni/storage.ts
@@ -288,6 +288,15 @@ export class OmniObjectStore {
       if (existing.isFile() && !existing.isSymbolicLink()) {
         const existingHash = await hashFileSha256(objectPath, signal);
         if (existingHash === sha256) {
+          // Touch-on-reference: every new memory reference is preceded by
+          // this call (ordering invariant: promote before commit), so
+          // refreshing mtime here re-arms the GC retention grace for OLD
+          // bytes gaining a NEW reference. Without it, a GC whose root
+          // snapshot predates the upcoming commit would still see the
+          // object as an expired orphan and delete it. Best-effort: a
+          // failed touch weakens the race window but never the promotion.
+          const now = new Date();
+          await fs.utimes(objectPath, now, now).catch(() => {});
           return { objectPath, deduped: true };
         }
       }

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -290,6 +290,7 @@ export interface ChatRecord {
     | 'custom_title'
     | 'parent_session'
     | 'session_source'
+    | 'omni_recall'
     | 'rewind'
     | 'agent_bootstrap'
     | 'agent_launch_prompt'
@@ -1613,6 +1614,28 @@ export class ChatRecordingService {
       this.appendRecord(record);
     } catch (error) {
       debugLogger.error('Error saving slash command record:', error);
+    }
+  }
+
+  /**
+   * Records the omni passive media-memory recall payload injected into the
+   * model-bound request (memory design M §9.3, D10 sideQuery mode). The
+   * reminder is assembled AFTER the user record is persisted, so without
+   * this record the transcript would never show what memory the model was
+   * given — the trajectory exporter reads it back as `turn.recall`.
+   */
+  recordOmniRecallReminder(payload: unknown): void {
+    try {
+      const record: ChatRecord = {
+        ...this.createBaseRecord('system'),
+        type: 'system',
+        subtype: 'omni_recall',
+        systemPayload: payload as ChatRecord['systemPayload'],
+      };
+
+      this.appendRecord(record);
+    } catch (error) {
+      debugLogger.error('Error saving omni recall record:', error);
     }
   }
 

--- a/packages/core/src/services/media-memory/registry.ts
+++ b/packages/core/src/services/media-memory/registry.ts
@@ -82,6 +82,18 @@ export class MediaResourceRegistry {
     }
     return undefined;
   }
+
+  /** Every locator this session currently has a handle for. GC treats
+   * these as roots alongside the memory snapshot: a resource delivered
+   * THIS turn may be bound here before its memory commit lands, and the
+   * sweep must not win that race. */
+  activeFileRefs(): string[] {
+    const refs = new Set<string>();
+    for (const binding of this.byVersionId.values()) {
+      refs.add(binding.fileRef);
+    }
+    return [...refs];
+  }
 }
 
 /** Structural view of the Config accessor (same pattern as

--- a/packages/core/src/services/media-memory/service.ts
+++ b/packages/core/src/services/media-memory/service.ts
@@ -405,6 +405,53 @@ export class MediaMemoryService {
   }
 
   /**
+   * The GC root set (storage design §6.2): every object hash any memory
+   * record still references. Two distinct reference kinds exist and BOTH
+   * count — `entries[].artifactRef.managedId` (policy outputs) and
+   * managed-protocol `versions[].source.locator` (tool/URL media anchor
+   * their file identity in the object store because their local file is
+   * deleted the turn it lands, so the store copy is the only one).
+   *
+   * Returns null when the store exists but cannot be read — the caller
+   * must treat that as "roots unknown" and delete NOTHING (fail-closed:
+   * an unreadable ledger must never read as an empty one). A store that
+   * has never been written returns an empty set: nothing was ever
+   * recorded, so nothing is referenced.
+   */
+  async collectManagedRefs(): Promise<Set<string> | null> {
+    const UNREADABLE = null;
+    try {
+      return await this.store.read<Set<string> | null>(
+        UNREADABLE,
+        (snapshot) => {
+          const refs = new Set<string>();
+          const add = (locator: string | undefined) => {
+            if (locator?.startsWith('sha256/')) {
+              refs.add(locator.slice('sha256/'.length));
+            }
+          };
+          for (const entry of Object.values(snapshot.entries)) {
+            if (entry.artifactRef?.storage === 'managed') {
+              add(entry.artifactRef.managedId);
+            }
+          }
+          for (const version of Object.values(snapshot.versions)) {
+            if (version.source.protocol === 'managed') {
+              add(version.source.locator);
+            }
+          }
+          return refs;
+        },
+      );
+    } catch (err) {
+      debugLogger.debug(
+        `collectManagedRefs failed: ${err instanceof Error ? err.message : err}`,
+      );
+      return null;
+    }
+  }
+
+  /**
    * Read-side lookup for callers that hold bytes but no identity (the
    * reactive degradation ladder re-recognizes a stored object without
    * knowing which memory version it is). Returns the binding of the

--- a/packages/core/src/services/media-memory/service.ts
+++ b/packages/core/src/services/media-memory/service.ts
@@ -406,11 +406,16 @@ export class MediaMemoryService {
 
   /**
    * The GC root set (storage design §6.2): every object hash any memory
-   * record still references. Two distinct reference kinds exist and BOTH
-   * count — `entries[].artifactRef.managedId` (policy outputs) and
-   * managed-protocol `versions[].source.locator` (tool/URL media anchor
-   * their file identity in the object store because their local file is
-   * deleted the turn it lands, so the store copy is the only one).
+   * record still references. Three distinct reference kinds exist and ALL
+   * count — `entries[].artifactRef.managedId` (policy outputs),
+   * managed-protocol `versions[].source.locator` (tool media anchor
+   * their file identity in the object store), and versions of files
+   * whose `fileRef` points INTO the object store while their source
+   * keeps a different protocol (URL media: `source.locator` is the
+   * original URL, but the staging download is deleted the turn it
+   * lands, so the store copy named by the file's `fileRef` is the only
+   * persistent bytes). The last kind is rooted by content hash: each
+   * such version's bytes live in the store under its own sha256.
    *
    * Returns null when the store exists but cannot be read — the caller
    * must treat that as "roots unknown" and delete NOTHING (fail-closed:
@@ -420,6 +425,10 @@ export class MediaMemoryService {
    */
   async collectManagedRefs(): Promise<Set<string> | null> {
     const UNREADABLE = null;
+    // The store copy lives under `<omniRoot>/objects/` — matching on the
+    // objects prefix (not exact equality with objectPathFor) keeps this
+    // robust to extension differences.
+    const objectsPrefix = this.store.omniObjectsPrefix();
     try {
       return await this.store.read<Set<string> | null>(
         UNREADABLE,
@@ -438,6 +447,13 @@ export class MediaMemoryService {
           for (const version of Object.values(snapshot.versions)) {
             if (version.source.protocol === 'managed') {
               add(version.source.locator);
+            }
+            // A file anchored in the object store (URL/tool media whose
+            // staging copy is gone) roots every ledger-vouched version's
+            // bytes by content hash.
+            const file = snapshot.files[version.fileId];
+            if (file?.fileRef.startsWith(objectsPrefix)) {
+              refs.add(version.sha256);
             }
           }
           return refs;

--- a/packages/core/src/services/media-memory/store.ts
+++ b/packages/core/src/services/media-memory/store.ts
@@ -99,9 +99,21 @@ function pruneMalformedRecords(snapshot: MediaMemorySnapshot): void {
  */
 export class MediaMemoryStore {
   readonly filePath: string;
+  private readonly omniRootDir: string;
 
   constructor(omniRootDir: string) {
+    this.omniRootDir = omniRootDir;
     this.filePath = path.join(omniRootDir, MEDIA_MEMORY_FILE_NAME);
+  }
+
+  /**
+   * Prefix (with trailing separator) under which the omni object store
+   * keeps its content-addressed copies. A version whose `fileRef` starts
+   * with this prefix anchors its only persistent bytes in the store —
+   * the GC root collection matches on it.
+   */
+  omniObjectsPrefix(): string {
+    return path.join(this.omniRootDir, 'objects') + path.sep;
   }
 
   /**

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -3408,6 +3408,18 @@
           "description": "Managed storage settings under .qwen/omni/.",
           "type": "object",
           "properties": {
+            "retentionDays": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 14,
+              "description": "Days an object in .qwen/omni/objects/ that no memory record references survives before garbage collection may remove it. Referenced objects are never removed. Must be at least 1; non-positive values fall back to the default."
+            },
+            "maxTotalBytes": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 21474836480,
+              "description": "Soft byte budget for .qwen/omni/objects/. Over budget, garbage collection removes the oldest unreferenced objects regardless of age; if only referenced objects remain it warns and suspends new policy derivations instead of deleting them. Defaults to 20 GiB."
+            },
             "quarantine": {
               "description": "Retention for failed policy invocations moved to .qwen/omni/quarantine/ for diagnosis. Quarantined content is never recalled into recognition or delivery.",
               "type": "object",

--- a/scripts/export-omni-trajectory.js
+++ b/scripts/export-omni-trajectory.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Export one session's omni trajectory as training-consumable JSONL
+ * (S6, issue #8190). Thin wrapper over the core exporter — kept as a
+ * script instead of a CLI subcommand deliberately: the experiment branch
+ * does not grow command surface for a downstream-tooling concern.
+ *
+ * Usage:
+ *   node scripts/export-omni-trajectory.js \
+ *     --transcript <path/to/session.jsonl> \
+ *     --omni-root <project>/.qwen/omni \
+ *     --out <path/to/trajectory.jsonl>
+ *
+ * The transcript is a chat-record JSONL (found under
+ * `~/.qwen/tmp/<project_id>/chats/`); --omni-root holds memory.json.
+ */
+
+import path from 'node:path';
+import { writeOmniTrajectoryJsonl } from '@qwen-code/qwen-code-core/omni';
+
+function argValue(flag) {
+  const index = process.argv.indexOf(flag);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+const transcriptPath = argValue('--transcript');
+const omniRootDir = argValue('--omni-root');
+const outPath = argValue('--out');
+
+if (!transcriptPath || !omniRootDir || !outPath) {
+  console.error(
+    'usage: export-omni-trajectory.js --transcript <session.jsonl> ' +
+      '--omni-root <.qwen/omni> --out <trajectory.jsonl>',
+  );
+  process.exit(2);
+}
+
+const { records } = await writeOmniTrajectoryJsonl({
+  transcriptPath: path.resolve(transcriptPath),
+  omniRootDir: path.resolve(omniRootDir),
+  outPath: path.resolve(outPath),
+});
+console.log(`wrote ${records} record(s) to ${outPath}`);


### PR DESCRIPTION
## What this PR does

Implements the S6 governance slice of the omni experiment: a mark-and-sweep GC with a byte budget over the content-addressed object store, and a trajectory exporter that turns one session into training-consumable JSONL.

**A. GC + budget (`packages/core/src/omni/gc.ts`)**

- **Mark**: the root set is collected from the memory ledger (`entries[].artifactRef.managedId`, managed-protocol `versions[].source.locator`) plus the live session registry's `activeFileRefs()` — a resource delivered this turn is protected before its memory commit lands.
- **Sweep pass 1**: objects both unreferenced AND older than `omni.storage.retentionDays` (default 14) are deleted; the retention window doubles as the multi-process grace period (same argument startup recovery already relies on).
- **Sweep pass 2 (budget)**: over `omni.storage.maxTotalBytes` (default 20 GiB), unreferenced objects go oldest-first regardless of age. Referenced objects are never deleted — over budget with only referenced objects left, the GC warns and **suspends new policy derivations** instead of rewriting history; reuse and cache hits stay allowed (they produce no new bytes).
- **Fail-closed hard rules**: an unreadable ledger deletes nothing (roots unknown ≠ roots empty); a recent `memory.json.corrupt-*` recovery backup blocks the run (an empty post-recovery ledger must not read as "nothing is referenced"); symlinked shards are never descended into. Deletions cascade into the upload and degradation caches.
- Wired fire-and-forget into media-delivery init, after startup recovery; the orchestrator's budget gate awaits `settleOmniGc()` first — without it the first derivation of a fresh process races past the flag before the sweep can raise it (defect found by the real-API E2E run below, fixed in the last commit).

**D. JSONL trajectory export (`packages/core/src/omni/export.ts` + `scripts/export-omni-trajectory.js`)**

- Pure reader over two artifacts that already exist (the session's chat-record JSONL and `memory.json`) — no new collection points, works on sessions recorded before it was written.
- Three record kinds per line: `turn` (request text, media annotations the model saw — handles/disclosures/omissions/transcripts —, recall payload, response text + tool calls), `execution` (full provenance: arguments, config hash, source/output identities, reuse marker), `file` (durable identity chain).
- Explicit join contract: model/client executions join `toolCalls[].callId ↔ invocationId`; fixed-policy executions join through `sourceVersionId → fileVersionId` — no fabricated timestamp edges.
- Scrub boundary: exactly the harness-side surface the model never saw (reserved `inputPath`/`outputDir` runtime keys) is stripped; content the model saw or produced is preserved verbatim — it IS the trajectory.

**C. Whole-request limit measurement (documentation-only outcome)**

Probed mixed-media requests against the real DashScope API (counts scaled up to 32 videos / 200 images / 8 audios / 4v+20i+4a in one request): no mixed-request constraint below "per-media limit × N" exists. The only whole-request hard boundary is the 196 608-token input window (HTTP 400 `Range of input length should be [1, 196608]` at 64 videos), which the estimation/guard layers already model as token budget — so no new guard dimension was added, per the design doc's conditional.

## Why it's needed

S1–S5 left the storage lifecycle open-ended: `objects/` grows without bound (every degradation, keyframe set, and transcript lands there and nothing ever deletes), and a full experiment session's trajectory — the very thing the experiment exists to produce — could not be handed to a training pipeline without scraping logs. S6 closes issue #8190: bounded storage with explicit, safe reclamation semantics, and a machine-readable export of what the model saw and did.

## Reviewer Test Plan

### How to verify

Unit suites (all green):

```
cd packages/core
npx vitest run src/omni/ src/services/media-memory/   # 903 tests, 38 files
npx tsc --noEmit -p .
```

The 11 GC tests cover both hard rules, budget order, cache cascade, corruption-recovery guard, symlink guard, latch semantics, and the settle-before-gate race. Export tests cover record building, the join contract, and scrub behavior.

E2E acceptance ran against the real DashScope API with `qwen3.5-omni-plus` (`npm run build && npm run bundle`, `node dist/cli.js`), the four criteria from issue #8190:

| # | Criterion | Result |
| --- | --- | --- |
| 1 | Expired unreferenced objects GC'd, referenced kept | PASS — planted 30-day-old orphan deleted; equally old referenced object kept (roots from `artifactRef.managedId`); young orphan kept (retention grace); touch-on-use re-referencing observed and correct |
| 2 | Over budget with only referenced objects → warn + suspend, delete nothing referenced | PASS — `maxTotalBytes=1000` workspace: budget pass deleted the only unreferenced object regardless of age, zero referenced deletions; `[omni:gc]` warn emitted; all new derivations rejected INCLUDING the first of a fresh process (after the `settleOmniGc` race fix); reuse still served |
| 3 | Three-modality full chain + second-session reuse | PASS — video+image+audio session: 4 fresh executions (extract-audio, keyframes, 2× transcribe), all disclosure markers present, model answers all three modalities correctly; second session: zero new executions, byte-identical `oss://` URLs (upload-cache hits), 3 API calls total |
| 4 | JSONL export parsed by an independent script | PASS — 13 records/session (1 turn + 8 file + 4 execution); a zero-shared-code Python stdlib parser validated every line as JSON, all required fields per kind, both join contracts resolving, and the scrub boundary (`"inputPath"`/`"outputDir"` absent) |

Spot-checks worth doing in review:

1. **Fail-closed**: corrupt `memory.json` by hand → GC run reports `ran: false`, deletes nothing.
2. **Budget never touches referenced objects**: set a tiny `omni.storage.maxTotalBytes`, deliver media → derivation attempts fail with the suspension message; nothing referenced disappears from `objects/`.
3. **Settle-before-gate**: the orchestrator awaits `settleOmniGc()` before `isOmniDerivationSuspended` — remove the await and the new gc test fails.
4. **Export determinism**: run the export script twice on the same session → byte-identical output (files before executions, each sorted by id).

### Evidence (Before & After)

N/A (no TUI change). Behavioral before/after for the race fix: before, a fresh process's first derivation wrote 2 objects (~800 KB) past an over-budget store before the GC verdict landed ~900 ms later; after, the same scenario rejects every derivation and the leaked objects are reclaimed by the next budget sweep.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS, Node 22, real DashScope API (`qwen3.5-omni-plus`); E2E via headless `node dist/cli.js --approval-mode yolo --output-format json`.

## Risk & Scope

- Main risk or tradeoff: **this change deletes files from disk.** Mitigations are structural, not incidental: deletion requires BOTH "unreferenced in the ledger" AND "older than the retention window" (budget pass drops the age condition but never the reference condition); an unreadable ledger deletes nothing; a recent corruption-recovery backup blocks the run entirely; symlinked shards are never entered; the once-per-root latch means two processes can only disagree toward "delete less". Budget pressure suspends NEW derivations rather than deleting referenced history.
- Not validated / out of scope: Windows/Linux local runs (CI covers them); multi-process GC racing under sustained concurrent writes beyond the retention-window argument; total-byte upload boundaries above ~42 MB per request in the limit probe (single-media byte limits unchanged from the existing know-how); transport-guard degradation copies are not "derivations" and still land during suspension — they are unreferenced and reclaimed by the next budget sweep (documented observation, accepted).
- Breaking changes / migration notes: none. Two new settings (`omni.storage.retentionDays`, `omni.storage.maxTotalBytes`) with conservative defaults (14 days, 20 GiB); absent settings behave as before except that genuinely orphaned, expired objects now get reclaimed.

## Linked Issues

Closes #8190

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

实现 omni 实验的 S6 治理切片：对内容寻址对象存储做标记-清扫 GC（带字节预算），以及把一次会话导出为可供训练消费的 JSONL 轨迹导出器。

**A. GC + 预算（`packages/core/src/omni/gc.ts`）**

- **标记**：根集合来自 memory 账本（`entries[].artifactRef.managedId`、managed 协议的 `versions[].source.locator`）加上活跃会话注册表的 `activeFileRefs()`——本轮刚投递的资源在其 memory 提交落地前就受保护。
- **清扫第一遍**：同时满足"无引用"且"超过 `omni.storage.retentionDays`（默认 14 天）"的对象被删除；保留期窗口兼作多进程宽限期（与启动恢复同一套论证）。
- **清扫第二遍（预算）**：超过 `omni.storage.maxTotalBytes`（默认 20 GiB）时，无引用对象不论年龄按最旧优先删除。被引用对象永不删除——超预算且只剩被引用对象时，GC 告警并**挂起新的 policy 衍生**而不是改写历史；复用与缓存命中不产生新字节，仍然放行。
- **fail-closed 硬规则**：账本不可读则一个不删（根未知 ≠ 根为空）；近期存在 `memory.json.corrupt-*` 恢复备份则阻止本轮（恢复后的空账本不能被读成"无引用"）；不进入符号链接分片。删除级联到上传缓存与降质缓存。
- 以 fire-and-forget 方式挂接在媒体投递初始化、启动恢复之后；orchestrator 预算闸门先 `await settleOmniGc()`——否则新进程的首个衍生会在清扫升起标志前竞速穿过预算（该缺陷由下述真实 API E2E 发现，已在最后一个提交修复）。

**D. JSONL 轨迹导出（`packages/core/src/omni/export.ts` + `scripts/export-omni-trajectory.js`）**

- 纯读取两个已存在的产物（会话 chat-record JSONL 与 `memory.json`）——不新增采集点，对导出器写成之前录制的会话同样有效。
- 每行三种记录：`turn`（请求文本、模型看到的媒体注解——句柄/披露/省略/转写——、召回负载、应答文本与工具调用）、`execution`（完整溯源：参数、配置哈希、来源/产物身份、复用标记）、`file`（持久身份链）。
- 显式 join 契约：model/client 执行经 `toolCalls[].callId ↔ invocationId` 关联；fixed-policy 执行经 `sourceVersionId → fileVersionId` 关联——不用时间戳编造边。
- scrub 边界：只剥离模型从未见过的 harness 侧表面（保留运行时键 `inputPath`/`outputDir`）；模型看到或产出的内容逐字保留——那正是轨迹本身。

**C. 整请求限额实测（仅文档产出）**

用真实 DashScope API 探测混合媒体请求（放大到单请求 32 视频 / 200 图 / 8 音频 / 4v+20i+4a）：不存在低于"单媒体限制 × N"的混合请求约束。唯一整请求硬边界是 196608 token 输入窗口（64 视频触发 HTTP 400 `Range of input length should be [1, 196608]`），estimation/guard 层已按 token 预算建模——按设计文档的条件项，无需新增 guard 维度。

## 为什么需要

S1–S5 把存储生命周期留成了开放式：`objects/` 无界增长（每次降质、关键帧、转写都落盘且从不删除）；而完整实验会话的轨迹——实验存在的目的本身——无法不靠抓日志就交给训练管线。S6 关闭 issue #8190：有界存储 + 显式安全回收语义 + 模型所见所为的机器可读导出。

## 审阅者测试计划

### 如何验证

单测（全绿）：

```
cd packages/core
npx vitest run src/omni/ src/services/media-memory/   # 903 tests, 38 files
npx tsc --noEmit -p .
```

11 个 GC 测试覆盖两条硬规则、预算顺序、缓存级联、损坏恢复守卫、符号链接守卫、latch 语义、settle-before-gate 竞态。导出测试覆盖记录构建、join 契约与 scrub 行为。

E2E 验收用真实 DashScope API（`qwen3.5-omni-plus`）跑通 issue #8190 的四条标准：

| # | 标准 | 结果 |
| --- | --- | --- |
| 1 | 过期无引用对象被 GC、被引用保留 | PASS——植入的 30 天孤儿被删；同龄被引用对象保留；年轻孤儿保留（宽限）；touch-on-use 重新引用行为正确 |
| 2 | 超预算仅剩被引用 → 告警+挂起、零误删 | PASS——`maxTotalBytes=1000` 工作区：预算遍历不论年龄删除唯一无引用对象、被引用零删除；`[omni:gc]` 告警；所有新衍生被拒，包括新进程首个（settleOmniGc 竞态修复后）；复用仍放行 |
| 3 | 三模态全链路 + 二次会话复用 | PASS——视频+图片+音频会话：4 条新执行、披露标记齐全、模型三模态回答全对；第二会话：零新增执行、`oss://` URL 与首会话逐字节一致（上传缓存命中）、共 3 次 API 调用 |
| 4 | JSONL 导出可被独立脚本解析 | PASS——每会话 13 条记录（1 turn + 8 file + 4 execution）；零共享代码的 Python stdlib 解析器验证逐行 JSON、各 kind 必填字段、两条 join 契约、scrub 边界（不含 `"inputPath"`/`"outputDir"`） |

值得在评审中抽查的点：

1. **fail-closed**：手动损坏 `memory.json` → GC 返回 `ran: false`，一个不删。
2. **预算不碰被引用对象**：设极小 `maxTotalBytes` 后投递媒体 → 衍生尝试报挂起错误；`objects/` 中被引用对象一个不少。
3. **settle-before-gate**：orchestrator 在 `isOmniDerivationSuspended` 之前 `await settleOmniGc()`——去掉 await 则新增 gc 测试失败。
4. **导出确定性**：同一会话跑两次导出脚本 → 字节一致（file 在 execution 前，各按 id 排序）。

### 证据（Before & After）

N/A（无 TUI 变更）。竞态修复的行为对比：修复前，新进程首个衍生在 GC 判定落地前约 900ms 向超预算存储写入 2 个对象（约 800KB）；修复后同场景所有衍生被拒，泄漏对象由下轮预算清扫回收。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

macOS、Node 22、真实 DashScope API（`qwen3.5-omni-plus`）；E2E 用 headless `node dist/cli.js --approval-mode yolo --output-format json`。

## 风险与范围

- 主要风险/权衡：**该改动会从磁盘删除文件。**缓解是结构性的：删除同时要求"账本无引用"与"超过保留期"（预算遍历放弃年龄条件但绝不放弃引用条件）；账本不可读则一个不删；近期损坏恢复备份直接阻止本轮；不进入符号链接分片；once-per-root latch 使两进程只可能朝"少删"方向分歧。预算压力挂起新衍生而不是删除被引用历史。
- 未验证/范围外：Windows/Linux 本地跑（CI 覆盖）；保留期窗口论证之外的持续并发写多进程 GC 竞争；限额探测中单请求约 42MB 以上的总字节边界（单媒体字节上限沿用既有 know-how）；transport-guard 降质副本不是"衍生"、挂起期间仍会落盘——无引用，由下轮预算清扫回收（已记录的观察项，接受）。
- 破坏性变更/迁移说明：无。新增两个设置（`omni.storage.retentionDays`、`omni.storage.maxTotalBytes`），默认保守（14 天、20 GiB）；不配置时行为与之前一致，除了真正孤立且过期的对象现在会被回收。

## 关联 Issue

Closes #8190

</details>
