### PR TITLE
fix(review): harden the pipeline against four live-run failures

### DIFF
--- a/packages/cli/src/commands/review/agent-prompt.ts
+++ b/packages/cli/src/commands/review/agent-prompt.ts
@@ -435,8 +435,9 @@ function toolBudgetBlock(
       'unfinished check on its own line, exactly as `Budget gap: <the check>` — ' +
       'the coverage tool reads those lines, so the format is load-bearing. If ' +
       'nothing was cut short, write NO `Budget gap:` line at all — the format ' +
-      'is only for checks the ceiling stopped, and a "none" written in it is ' +
-      'parsed as a gap someone must rule on. The ' +
+      'is only for checks the ceiling stopped: a "none" put there is at best ' +
+      'filtered out, and any wording the filter does not recognize is ' +
+      'published in the review body as a phantom coverage gap. The ' +
       'budget never suppresses a finding: a candidate you can already name goes ' +
       'in your return regardless (at `Confidence: low` if the budget stopped ' +
       'you before verifying it).',

--- a/packages/cli/src/commands/review/agent-prompt.ts
+++ b/packages/cli/src/commands/review/agent-prompt.ts
@@ -433,7 +433,10 @@ function toolBudgetBlock(
       'counted in. It is a soft ceiling. At the ceiling: stop exploring, write ' +
       'your findings from the evidence already in hand, and disclose each ' +
       'unfinished check on its own line, exactly as `Budget gap: <the check>` — ' +
-      'the coverage tool reads those lines, so the format is load-bearing. The ' +
+      'the coverage tool reads those lines, so the format is load-bearing. If ' +
+      'nothing was cut short, write NO `Budget gap:` line at all — the format ' +
+      'is only for checks the ceiling stopped, and a "none" written in it is ' +
+      'parsed as a gap someone must rule on. The ' +
       'budget never suppresses a finding: a candidate you can already name goes ' +
       'in your return regardless (at `Confidence: low` if the budget stopped ' +
       'you before verifying it).',

--- a/packages/cli/src/commands/review/check-coverage.test.ts
+++ b/packages/cli/src/commands/review/check-coverage.test.ts
@@ -773,6 +773,29 @@ describe('budget-gap disclosures — guarded, parsed, never punished', () => {
     expect(r.ok).toBe(true);
   });
 
+  it("labels a non-chunk discloser by its brief codename, not the prompt's first line", () => {
+    // Launchers prepend context: twelve live finders shared one PR-summary
+    // first line, so every disclosure rendered the same truncated PR quote
+    // instead of a name. The codename line names the agent wherever it sits.
+    transcript(
+      '6c',
+      'PR #9045 modifies getAuthTypeFromEnv() to infer auth.\n\nYou are review agent `6c` — Agent 6c: Undirected audit.\n' +
+        wholeDiff(),
+      {
+        calls: 4,
+        text: 'Walked the diff.\nBudget gap: second-order callers of getAuthTypeFromEnv',
+      },
+    );
+
+    const r = coverageFromTranscripts(plan3a(), ENV);
+    expect(r.budgetGaps).toEqual([
+      {
+        agent: 'agent 6c',
+        gaps: ['second-order callers of getAuthTypeFromEnv'],
+      },
+    ]);
+  });
+
   it('a disclosure costs no coverage credit — the gate must not punish it', () => {
     // An earlier draft narrowed a disclosing agent's credit to its ranged
     // reads. `rangeOf` records only reads carrying a positive `limit`, so

--- a/packages/cli/src/commands/review/compose-review.test.ts
+++ b/packages/cli/src/commands/review/compose-review.test.ts
@@ -2397,15 +2397,25 @@ describe('coverage is recomputed, never accepted', () => {
   });
 
   it('collapses spaces after removing backticks from agent labels', () => {
-    transcript(
-      'p1',
-      `You are review agent \`security\` — inspect auth\n${DIFF}`,
-    );
+    transcript('p1', `Inspect the \`auth\` and \`session\` paths\n${DIFF}`);
     const r = composeReview({ planPath: plan(), env: ENV, modelId: MODEL });
 
     expect(r.body).toContain(
-      'Not reviewed: `"You are review agent security — inspect auth"`',
+      'Not reviewed: `"Inspect the auth and session paths"`',
     );
+  });
+
+  it('labels an agent by its brief codename wherever it sits in the prompt', () => {
+    // Launchers prepend context lines: twelve live finders shared one
+    // PR-summary first line, so every disclosure rendered the same truncated
+    // PR quote. The codename line wins over first-line prose.
+    transcript(
+      'p1',
+      `PR #9045 modifies getAuthTypeFromEnv().\nYou are review agent \`security\` — inspect auth\n${DIFF}`,
+    );
+    const r = composeReview({ planPath: plan(), env: ENV, modelId: MODEL });
+
+    expect(r.body).toContain('Not reviewed: `"agent security"`');
   });
 
   it('names a blind launch as itself, not as a whiff', () => {

--- a/packages/cli/src/commands/review/compose-review.ts
+++ b/packages/cli/src/commands/review/compose-review.ts
@@ -1750,11 +1750,14 @@ function composeReviewBody(
 /**
  * The public subject for an agent-derived disclosure label. A `chunk N`
  * label stays bare — the chunk collapse translates it into the author's
- * units. Any other label is the truncated first line of a launch prompt:
- * prose. Rendered bare it reads as a claim about the PR itself —
- * #8811's posted body carried "Not reviewed: This PR narrows the
- * daemon-marker check from a truthy tes..." — not as the name of the agent
- * that failed. Quoted, it reads as a name. The INTERNAL subject stays the
+ * units. Any other label is usually a parsed codename (`agent security`,
+ * `agent reverse-audit (round 2)` — coverage's `label()` prefers the
+ * identity line), falling back to the truncated first line of a launch
+ * prompt: prose. The quoting serves both: prose rendered bare reads as a
+ * claim about the PR itself — #8811's posted body carried "Not reviewed:
+ * This PR narrows the daemon-marker check from a truthy tes..." — and
+ * quoted, either shape reads as a name. Short codename labels pass
+ * `compressSummary`'s cap untouched. The INTERNAL subject stays the
  * unquoted label: the dedup and certification checks key on it.
  */
 function publicAgentSubject(label: string): string | undefined {

--- a/packages/cli/src/commands/review/cost-ledger.test.ts
+++ b/packages/cli/src/commands/review/cost-ledger.test.ts
@@ -1041,6 +1041,32 @@ describe('cost-ledger — the spend, from the records already on disk', () => {
     expect(text).toContain('agent verify (round 2) (×2):');
   });
 
+  it('labels from the FIRST line only — an identity quoted below never wins', () => {
+    // The two agent-identity entry points are not interchangeable here.
+    // cost-ledger feeds the first line alone because the text below can
+    // quote other agents' identity lines; a scan would label this row by
+    // the quote and fold two agents' costs into one. Switching `labelOf` to
+    // `labelFromLaunchPrompt` must fail this test.
+    const { plan, env, project } = fixture();
+    writeMainCall(project);
+    writeFileSync(
+      join(project, 'subagents', SESSION, 'agent-q0.jsonl'),
+      [
+        userRecord(
+          'Context: this launch was rewritten by the orchestrator.\n' +
+            'You are review agent `verify` — Verification (round 4).\n',
+        ),
+        event('2026-08-03T10:08:00Z', { input: 5_000, output: 60 }),
+      ].join('\n'),
+    );
+
+    const text = renderLedger(computeLedger(plan, env));
+    expect(text).not.toContain('agent verify (round 4)');
+    // The row keeps this transcript's own id — the caller's fallback — not a
+    // label lifted from the text below line one.
+    expect(text).toContain('q0:');
+  });
+
   it('reads the round from the identity line, never from folded findings', () => {
     const { plan, env, project } = fixture();
     writeMainCall(project);

--- a/packages/cli/src/commands/review/cost-ledger.ts
+++ b/packages/cli/src/commands/review/cost-ledger.ts
@@ -42,7 +42,7 @@ import {
   TranscriptsUnavailableError,
   textOf,
 } from './lib/transcripts.js';
-import { CHUNK_RE } from './lib/coverage.js';
+import { labelFromIdentityLine } from './lib/agent-identity.js';
 
 interface CostLedgerArgs {
   plan: string;
@@ -185,7 +185,8 @@ function labelOf(launch: string, fallback: string): string {
   // label it owns — the file id.
   const nl = launch.indexOf('\n');
   const identity = nl === -1 ? launch : launch.slice(0, nl);
-  if (!identity.startsWith('You are review agent `')) return fallback;
+  const parsed = labelFromIdentityLine(identity);
+  if (parsed === null) return fallback;
   // A reverse-audit chunk auditor shares its launch shape with the territory
   // finder; only its brief path carries the stage and the round — without
   // it, five audit rounds fold into one row and the ledger reports one agent
@@ -198,26 +199,10 @@ function labelOf(launch: string, fallback: string): string {
   if (auditChunk) {
     return `audit chunk ${auditChunk[1]} (round ${auditChunk[2]})`;
   }
-  const role = /^You are review agent `([^`]+)`/.exec(identity);
-  if (!role) return fallback;
-  const round = /\(round (\d+)\)/.exec(identity);
-  const chunk = CHUNK_RE.exec(role[1]);
-  // A chunk role is `chunk N of M`; prefixing it with "agent" would read as
-  // a malformed role, so resolve it through the same regex coverage uses.
-  if (chunk) return `chunk ${chunk[1]}`;
-  if (round) {
-    // Shards of one verify round carry the same label and fold; distinct
-    // rounds — verify and reverse-audit alike — are distinct rows.
-    return `agent ${role[1]} (round ${round[1]})`;
-  }
-  // An invariant role launches once PER heavy file. The role alone would
-  // fold those parallel runs into one (×N) row — the marker reserved for
-  // relaunches — and lose the per-file breakdown. The identity line names
-  // the owned file; the FULL path is the distinguisher, because a monorepo
-  // routinely holds same-basename files in different packages.
-  const file = /Your file: `([^`]+)`/.exec(identity);
-  if (file) return `agent ${role[1]} (${file[1]})`;
-  return `agent ${role[1]}`;
+  // The chunk / round / owned-file grammar lives in the shared parser
+  // (agent-identity.ts), alongside coverage's disclosure labels — one format,
+  // one parser, so the two readers cannot drift apart again.
+  return parsed;
 }
 
 function foldEvents(

--- a/packages/cli/src/commands/review/lib/agent-identity.test.ts
+++ b/packages/cli/src/commands/review/lib/agent-identity.test.ts
@@ -39,6 +39,28 @@ describe('labelFromIdentityLine', () => {
         'You are review agent `chunk 3 of 7` — the territory agent for lines 120-260 of the diff.',
       ),
     ).toBe('chunk 3');
+    // Both suffixes on one line (agent-prompt emits them independently):
+    // round wins — losing it folds two rounds of the same owned file into
+    // one cost-ledger row, the exact fold the round suffix prevents.
+    expect(
+      labelFromIdentityLine(
+        'You are review agent `invariant-a` — Whole-file invariants (round 2). Your file: `packages/cli/src/a.ts`.',
+      ),
+    ).toBe('agent invariant-a (round 2)');
+  });
+
+  it('tolerates a trailing carriage return — CRLF prompts must still parse', () => {
+    // Callers split on `\n` alone (cost-ledger slices at the first `\n`), so
+    // a CRLF-recorded prompt hands this parser a `\r`-terminated line; a
+    // parse that fails there falls back to first-line prose for EVERY agent.
+    expect(
+      labelFromIdentityLine('You are review agent `security` — inspect auth\r'),
+    ).toBe('agent security');
+    expect(
+      labelFromLaunchPrompt(
+        'context line\r\nYou are review agent `6c` — Undirected audit.\r\nbody\r\n',
+      ),
+    ).toBe('agent 6c');
   });
 
   it('returns null for anything that is not an identity line', () => {

--- a/packages/cli/src/commands/review/lib/agent-identity.test.ts
+++ b/packages/cli/src/commands/review/lib/agent-identity.test.ts
@@ -107,4 +107,23 @@ describe('labelFromLaunchPrompt', () => {
       labelFromLaunchPrompt('Security review of the whole diff.'),
     ).toBeNull();
   });
+
+  it('differs from the identity-line entry point on a quoted-below prompt', () => {
+    // The two entry points are NOT interchangeable, and each caller's choice
+    // is load-bearing. A CLI-built launch carries its identity on line one;
+    // anything below can QUOTE another agent's. Coverage scans (its launches
+    // arrive with orchestrator context prepended); cost-ledger refuses to,
+    // because a scan would label its row by the quote and fold two agents'
+    // costs into one. Consolidating both callers on either entry point must
+    // fail here.
+    const quotedBelow =
+      'Context: the orchestrator rewrote this launch.\n' +
+      'You are review agent `verify` — Verification (round 4).\n';
+
+    // Scanning finds the identity wherever it sits…
+    expect(labelFromLaunchPrompt(quotedBelow)).toBe('agent verify (round 4)');
+    // …while cost-ledger's feed — line one alone — refuses it, leaving the
+    // caller's own fallback (the transcript's file id) in place.
+    expect(labelFromIdentityLine(quotedBelow.split('\n')[0])).toBeNull();
+  });
 });

--- a/packages/cli/src/commands/review/lib/agent-identity.test.ts
+++ b/packages/cli/src/commands/review/lib/agent-identity.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// One parser for the identity line `agent-prompt` bakes into every launch —
+// shared by cost-ledger (row labels) and coverage (disclosure labels), which
+// previously each carried their own copy of this grammar.
+
+import { describe, expect, it } from 'vitest';
+import {
+  labelFromIdentityLine,
+  labelFromLaunchPrompt,
+} from './agent-identity.js';
+
+describe('labelFromIdentityLine', () => {
+  it('parses the role, keeping round and owned-file suffixes distinct', () => {
+    expect(
+      labelFromIdentityLine('You are review agent `security` — inspect auth'),
+    ).toBe('agent security');
+    // Rounds separate pipeline stages that share a role — reverse-audit
+    // rounds 1 and 2 must not fold into one indistinguishable label.
+    expect(
+      labelFromIdentityLine(
+        'You are review agent `reverse-audit` — Reverse audit agent (round 2).',
+      ),
+    ).toBe('agent reverse-audit (round 2)');
+    // An invariant role launches once per heavy file; the full path is the
+    // distinguisher (same-basename files exist across a monorepo).
+    expect(
+      labelFromIdentityLine(
+        'You are review agent `invariant-a` — Whole-file invariants. Your file: `packages/cli/src/a.ts`.',
+      ),
+    ).toBe('agent invariant-a (packages/cli/src/a.ts)');
+    // A chunk role labels as its chunk id, matching coverage's chunk labels.
+    expect(
+      labelFromIdentityLine(
+        'You are review agent `chunk 3 of 7` — the territory agent for lines 120-260 of the diff.',
+      ),
+    ).toBe('chunk 3');
+  });
+
+  it('returns null for anything that is not an identity line', () => {
+    expect(
+      labelFromIdentityLine('PR #9045 modifies getAuthTypeFromEnv().'),
+    ).toBeNull();
+    expect(labelFromIdentityLine('')).toBeNull();
+    // A mid-line mention is a quote, not an identity.
+    expect(
+      labelFromIdentityLine(
+        'as noted, You are review agent `security` was launched earlier',
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('labelFromLaunchPrompt', () => {
+  it('finds the identity line under a launcher-prepended context line', () => {
+    // Twelve live finders shared one PR-summary first line; a first-line-only
+    // read labelled every disclosure with the same truncated PR quote.
+    expect(
+      labelFromLaunchPrompt(
+        'PR #9045 (fixes issue #9025) modifies getAuthTypeFromEnv().\n\n' +
+          'You are review agent `6c` — Agent 6c: Undirected audit.\n' +
+          'Read your brief first.',
+      ),
+    ).toBe('agent 6c');
+  });
+
+  it("takes the agent's OWN line, which precedes anything quoted below it", () => {
+    // CLI-built launches put the identity on line one; quoted identity lines
+    // (a findings section citing another agent) sit below and must lose.
+    expect(
+      labelFromLaunchPrompt(
+        'You are review agent `verify` — Verification agent (round 2).\n' +
+          'Prior findings:\n' +
+          'You are review agent `security` — inspect auth\n',
+      ),
+    ).toBe('agent verify (round 2)');
+  });
+
+  it('returns null when no line is an identity line', () => {
+    expect(
+      labelFromLaunchPrompt('Security review of the whole diff.'),
+    ).toBeNull();
+  });
+});

--- a/packages/cli/src/commands/review/lib/agent-identity.ts
+++ b/packages/cli/src/commands/review/lib/agent-identity.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// The identity line `agent-prompt` bakes into every launch it builds —
+// `You are review agent `<role>` — <label>[ (round N)].[ Your file: `<path>`.]`
+// — and the ONE parser for it. Two independent copies existed (cost-ledger's
+// row labels and coverage's disclosure labels), which is how the format and
+// its readers drift apart: when the builder changes and a copy is missed,
+// that reader silently falls back to first-line prose.
+//
+// What each caller decides for itself is WHICH line to feed the parser.
+// cost-ledger trusts only the prompt's first line (the text below can QUOTE
+// other agents' identity lines, and a whole-launch match would hand the
+// quoted label to the agent carrying the quote); coverage scans for the
+// first line-anchored identity line, because orchestrators prepend context
+// lines to the launches they write (measured: twelve finders shared one
+// PR-summary first line, and every disclosure rendered the same PR quote).
+
+/** A role that IS a chunk assignment — `chunk 3 of 7` — labels as its id. */
+const CHUNK_ROLE_RE = /^chunk (\d+) of \d+$/;
+
+const IDENTITY_LINE_RE = /^You are review agent `([^`\n]+)`(.*)$/;
+
+/**
+ * The label for ONE identity line, or null when the line is not one.
+ *
+ * Precedence mirrors what each suffix distinguishes: a chunk role is its
+ * chunk id; a round suffix separates pipeline stages that share a role
+ * (verify round 1 vs 2); the owned-file suffix separates the per-heavy-file
+ * launches of an invariant role. Round wins over file when both appear —
+ * the same order cost-ledger's rows always used.
+ */
+export function labelFromIdentityLine(line: string): string | null {
+  const m = IDENTITY_LINE_RE.exec(line);
+  if (!m) return null;
+  const [, role, rest] = m;
+  const chunk = CHUNK_ROLE_RE.exec(role);
+  if (chunk) return `chunk ${chunk[1]}`;
+  const round = /\(round (\d+)\)/.exec(rest);
+  if (round) return `agent ${role} (round ${round[1]})`;
+  const file = /Your file: `([^`\n]+)`/.exec(rest);
+  if (file) return `agent ${role} (${file[1]})`;
+  return `agent ${role}`;
+}
+
+/**
+ * The first line-anchored identity line in a launch prompt, parsed. For a
+ * CLI-built launch the identity IS line one, so its own line always wins
+ * over anything quoted below it; a launcher-prepended context line is prose
+ * and never matches, so the agent's own line is still the first hit.
+ */
+export function labelFromLaunchPrompt(prompt: string): string | null {
+  for (const line of prompt.split('\n')) {
+    const label = labelFromIdentityLine(line);
+    if (label !== null) return label;
+  }
+  return null;
+}

--- a/packages/cli/src/commands/review/lib/agent-identity.ts
+++ b/packages/cli/src/commands/review/lib/agent-identity.ts
@@ -19,8 +19,15 @@
 // lines to the launches they write (measured: twelve finders shared one
 // PR-summary first line, and every disclosure rendered the same PR quote).
 
-/** A role that IS a chunk assignment — `chunk 3 of 7` — labels as its id. */
-const CHUNK_ROLE_RE = /^chunk (\d+) of \d+$/;
+/**
+ * A role that IS a chunk assignment — `chunk 3 of 7` — labels as its id.
+ * The shape matches coverage's `CHUNK_RE` (whitespace-tolerant,
+ * case-insensitive) so both readers resolve the same role the same way; a
+ * hand-edited `Chunk 3 of 7` used to resolve as a chunk owner in the posted
+ * body and a role agent in the ledger row. Anchored, because here the whole
+ * role slot is the candidate, not a substring of a prompt.
+ */
+const CHUNK_ROLE_RE = /^chunk\s+(\d+)\s+of\s+\d+$/i;
 
 const IDENTITY_LINE_RE = /^You are review agent `([^`\n]+)`(.*)$/;
 

--- a/packages/cli/src/commands/review/lib/agent-identity.ts
+++ b/packages/cli/src/commands/review/lib/agent-identity.ts
@@ -34,7 +34,12 @@ const IDENTITY_LINE_RE = /^You are review agent `([^`\n]+)`(.*)$/;
  * the same order cost-ledger's rows always used.
  */
 export function labelFromIdentityLine(line: string): string | null {
-  const m = IDENTITY_LINE_RE.exec(line);
+  // CRLF tolerance: callers hand over lines split on `\n` alone (and
+  // cost-ledger slices at the first `\n`), so a prompt recorded with CRLF
+  // endings leaves a trailing `\r` that `$` will not anchor past — every
+  // parse would fail and every label fall back to first-line prose, the
+  // exact defect the parser exists to end.
+  const m = IDENTITY_LINE_RE.exec(line.replace(/\r$/, ''));
   if (!m) return null;
   const [, role, rest] = m;
   const chunk = CHUNK_ROLE_RE.exec(role);
@@ -53,9 +58,9 @@ export function labelFromIdentityLine(line: string): string | null {
  * and never matches, so the agent's own line is still the first hit.
  */
 export function labelFromLaunchPrompt(prompt: string): string | null {
-  for (const line of prompt.split('\n')) {
-    const label = labelFromIdentityLine(line);
-    if (label !== null) return label;
-  }
-  return null;
+  // One multiline scan, not a split: this runs for every agent record of
+  // every coverage pass, and launcher-built prompts carry a diff-sized tail
+  // that a line-array materializes for nothing.
+  const m = /^You are review agent `[^`\n]+`[^\n]*/m.exec(prompt);
+  return m ? labelFromIdentityLine(m[0]) : null;
 }

--- a/packages/cli/src/commands/review/lib/budget.test.ts
+++ b/packages/cli/src/commands/review/lib/budget.test.ts
@@ -403,8 +403,9 @@ describe('budgetGapDisclosures — the one parser of the disclosure format', () 
       'none — all 5 Windows checks failed to start',
       'none — all planned checks completed except the Windows matrix',
       // The budget adverbial is end-anchored like its siblings: a clause
-      // continuing past it discloses skipped work.
+      // continuing past it discloses skipped work — in both branch forms.
       'none — all checks completed within budget, but the Windows matrix never ran',
+      'None (all checks completed within the tool-call budget, but the Windows matrix never ran)',
       '<integration tests on Windows> runner unavailable',
     ]) {
       expect(budgetGapDisclosures(`Budget gap: ${gap}`)).toEqual([gap]);

--- a/packages/cli/src/commands/review/lib/budget.test.ts
+++ b/packages/cli/src/commands/review/lib/budget.test.ts
@@ -340,6 +340,12 @@ describe('budgetGapDisclosures — the one parser of the disclosure format', () 
       'Budget gap: none — all checks my dimension defines were completed within budget.',
       'Budget gap: none — all planned checks done under the tool budget',
       'Budget gap: None (all checks completed within the tool-call budget)',
+      // One vocabulary across the idiom family: `below` in the completion
+      // tail, and the stayed idiom with the same qualifiers the tail takes.
+      'Budget gap: none — all checks completed below budget.',
+      'Budget gap: none — stayed inside budget.',
+      'Budget gap: none — stayed under the tool budget',
+      'Budget gap: none — stayed below the tool-call budget.',
     ]) {
       expect(budgetGapDisclosures(line)).toEqual([]);
     }

--- a/packages/cli/src/commands/review/lib/budget.test.ts
+++ b/packages/cli/src/commands/review/lib/budget.test.ts
@@ -332,6 +332,14 @@ describe('budgetGapDisclosures — the one parser of the disclosure format', () 
       'Budget gap: no gaps found',
       'Budget gap: none ( all checks completed)',
       'Budget gap:',
+      // The trailing budget adverbial after the completion word — three of
+      // these reached two posted bodies in one live round (2026-08-13,
+      // PRs #9013/#9045) because the completion word was not final.
+      'Budget gap: none — all checks above completed within budget.',
+      'Budget gap: none — all checks I started were completed within budget.',
+      'Budget gap: none — all checks my dimension defines were completed within budget.',
+      'Budget gap: none — all planned checks done under the tool budget',
+      'Budget gap: None (all checks completed within the tool-call budget)',
     ]) {
       expect(budgetGapDisclosures(line)).toEqual([]);
     }
@@ -388,6 +396,9 @@ describe('budgetGapDisclosures — the one parser of the disclosure format', () 
       'nothing — every check crashed',
       'none — all 5 Windows checks failed to start',
       'none — all planned checks completed except the Windows matrix',
+      // The budget adverbial is end-anchored like its siblings: a clause
+      // continuing past it discloses skipped work.
+      'none — all checks completed within budget, but the Windows matrix never ran',
       '<integration tests on Windows> runner unavailable',
     ]) {
       expect(budgetGapDisclosures(`Budget gap: ${gap}`)).toEqual([gap]);

--- a/packages/cli/src/commands/review/lib/budget.test.ts
+++ b/packages/cli/src/commands/review/lib/budget.test.ts
@@ -341,11 +341,14 @@ describe('budgetGapDisclosures — the one parser of the disclosure format', () 
       'Budget gap: none — all planned checks done under the tool budget',
       'Budget gap: None (all checks completed within the tool-call budget)',
       // One vocabulary across the idiom family: `below` in the completion
-      // tail, and the stayed idiom with the same qualifiers the tail takes.
+      // tail, and the stayed idiom with the same qualifiers the tail takes —
+      // including the space-separated `tool call` form the regex accepts.
       'Budget gap: none — all checks completed below budget.',
       'Budget gap: none — stayed inside budget.',
       'Budget gap: none — stayed under the tool budget',
       'Budget gap: none — stayed below the tool-call budget.',
+      'Budget gap: none — all checks completed within the tool call budget.',
+      'Budget gap: none — stayed within the tool call budget',
     ]) {
       expect(budgetGapDisclosures(line)).toEqual([]);
     }

--- a/packages/cli/src/commands/review/lib/budget.ts
+++ b/packages/cli/src/commands/review/lib/budget.ts
@@ -414,8 +414,33 @@ export const INLINE_BUDGET_GAP_RE =
  * spans are tempered (a per-character exception lookahead), which keeps
  * them linear too.
  */
-const PLACEHOLDER_GAP_RE =
-  /^(?:<[^>]*>$|[-—*_~`]+$|(?:none|n\/a|nothing|no (?:gaps?|checks?))\b(?:[.!…,;:\s]*$|\s+(?:skipped|found|to report)\b[.!…,;:\s]*$|\s*[-—–]\s*(?:stayed\s+(?:under|within|below|inside)\s+(?:the\s+)?(?:tool(?:[- ]call)?\s+)?budget\b[.!…,;:\s]*$|(?:all|every(?:thing)?|planned|further|no further)\b(?:(?!\b(?:but|except|excepting|excluding)\b).)*(?<!\b(?:none|nothing|no|zero|never|not)\s)\b(?:complete[ds]?|done|finished|covered)\b(?:\s+(?:within|under|inside|below)\s+(?:the\s+)?(?:tool(?:[- ]call)?\s+)?budget)?[.!…,;:\s]*$)|\s*\(\s*(?:all|every(?:thing)?)\b(?:(?!\b(?:but|except|excepting|excluding)\b)[^()])*(?<!\b(?:none|nothing|no|zero|never|not)\s)\b(?:complete[ds]?|done|finished|covered)\b(?:\s+(?:within|under|inside|below)\s+(?:the\s+)?(?:tool(?:[- ]call)?\s+)?budget)?[.!…,;:\s]*\)\s*$))/i;
+// The budget-position vocabulary, spelled ONCE for the whole idiom family:
+// the stayed idiom and both completion tails read the same words. As a
+// regex literal the family was hand-copied three times, and the copies had
+// already drifted twice in two review rounds (`below` missing from one
+// branch, the qualifiers from another).
+const BUDGET_QUALIFIED =
+  '(?:under|within|below|inside)\\s+(?:the\\s+)?(?:tool(?:[- ]call)?\\s+)?budget';
+const COMPLETION_TAIL = `(?:\\s+${BUDGET_QUALIFIED})?`;
+
+const PLACEHOLDER_GAP_RE = new RegExp(
+  '^(?:<[^>]*>$' +
+    '|[-—*_~`]+$' +
+    '|(?:none|n/a|nothing|no (?:gaps?|checks?))\\b(?:' +
+    '[.!…,;:\\s]*$' +
+    '|\\s+(?:skipped|found|to report)\\b[.!…,;:\\s]*$' +
+    `|\\s*[-—–]\\s*(?:stayed\\s+${BUDGET_QUALIFIED}\\b[.!…,;:\\s]*$` +
+    '|(?:all|every(?:thing)?|planned|further|no further)\\b' +
+    '(?:(?!\\b(?:but|except|excepting|excluding)\\b).)*' +
+    '(?<!\\b(?:none|nothing|no|zero|never|not)\\s)' +
+    `\\b(?:complete[ds]?|done|finished|covered)\\b${COMPLETION_TAIL}[.!…,;:\\s]*$)` +
+    '|\\s*\\(\\s*(?:all|every(?:thing)?)\\b' +
+    '(?:(?!\\b(?:but|except|excepting|excluding)\\b)[^()])*' +
+    '(?<!\\b(?:none|nothing|no|zero|never|not)\\s)' +
+    `\\b(?:complete[ds]?|done|finished|covered)\\b${COMPLETION_TAIL}[.!…,;:\\s]*\\)\\s*$` +
+    '))',
+  'i',
+);
 
 /** Keep an operator-facing NOTE readable; a gap names a check, not an essay. */
 const MAX_GAP_LENGTH = 160;

--- a/packages/cli/src/commands/review/lib/budget.ts
+++ b/packages/cli/src/commands/review/lib/budget.ts
@@ -389,8 +389,11 @@ export const INLINE_BUDGET_GAP_RE =
  *    `None.`, `no gaps`), and the non-answer idioms `nothing skipped`,
  *    `none found`, `nothing to report`;
  *  - the stayed-under-budget idiom, end-anchored like its siblings
- *    (`N/A - stayed under budget`); text continuing past `budget` keeps
- *    (`N/A - stayed under budget, but the Windows matrix never ran`);
+ *    (`N/A - stayed under budget`), with the same position words and
+ *    budget qualifiers as the completion tail below (`stayed inside the
+ *    tool-call budget`) — one vocabulary for one idiom family; text
+ *    continuing past `budget` keeps (`N/A - stayed under budget, but the
+ *    Windows matrix never ran`);
  *  - the completion idiom — token, dash, an "all done" head, then a
  *    completion word the text ENDS with (`none — all planned checks
  *    completed`), tolerating one trailing budget adverbial (`none — all
@@ -412,7 +415,7 @@ export const INLINE_BUDGET_GAP_RE =
  * them linear too.
  */
 const PLACEHOLDER_GAP_RE =
-  /^(?:<[^>]*>$|[-—*_~`]+$|(?:none|n\/a|nothing|no (?:gaps?|checks?))\b(?:[.!…,;:\s]*$|\s+(?:skipped|found|to report)\b[.!…,;:\s]*$|\s*[-—–]\s*(?:stayed\s+(?:under|within|below)\s+budget\b[.!…,;:\s]*$|(?:all|every(?:thing)?|planned|further|no further)\b(?:(?!\b(?:but|except|excepting|excluding)\b).)*(?<!\b(?:none|nothing|no|zero|never|not)\s)\b(?:complete[ds]?|done|finished|covered)\b(?:\s+(?:within|under|inside)\s+(?:the\s+)?(?:tool(?:[- ]call)?\s+)?budget)?[.!…,;:\s]*$)|\s*\(\s*(?:all|every(?:thing)?)\b(?:(?!\b(?:but|except|excepting|excluding)\b)[^()])*(?<!\b(?:none|nothing|no|zero|never|not)\s)\b(?:complete[ds]?|done|finished|covered)\b(?:\s+(?:within|under|inside)\s+(?:the\s+)?(?:tool(?:[- ]call)?\s+)?budget)?[.!…,;:\s]*\)\s*$))/i;
+  /^(?:<[^>]*>$|[-—*_~`]+$|(?:none|n\/a|nothing|no (?:gaps?|checks?))\b(?:[.!…,;:\s]*$|\s+(?:skipped|found|to report)\b[.!…,;:\s]*$|\s*[-—–]\s*(?:stayed\s+(?:under|within|below|inside)\s+(?:the\s+)?(?:tool(?:[- ]call)?\s+)?budget\b[.!…,;:\s]*$|(?:all|every(?:thing)?|planned|further|no further)\b(?:(?!\b(?:but|except|excepting|excluding)\b).)*(?<!\b(?:none|nothing|no|zero|never|not)\s)\b(?:complete[ds]?|done|finished|covered)\b(?:\s+(?:within|under|inside|below)\s+(?:the\s+)?(?:tool(?:[- ]call)?\s+)?budget)?[.!…,;:\s]*$)|\s*\(\s*(?:all|every(?:thing)?)\b(?:(?!\b(?:but|except|excepting|excluding)\b)[^()])*(?<!\b(?:none|nothing|no|zero|never|not)\s)\b(?:complete[ds]?|done|finished|covered)\b(?:\s+(?:within|under|inside|below)\s+(?:the\s+)?(?:tool(?:[- ]call)?\s+)?budget)?[.!…,;:\s]*\)\s*$))/i;
 
 /** Keep an operator-facing NOTE readable; a gap names a check, not an essay. */
 const MAX_GAP_LENGTH = 160;

--- a/packages/cli/src/commands/review/lib/budget.ts
+++ b/packages/cli/src/commands/review/lib/budget.ts
@@ -393,7 +393,10 @@ export const INLINE_BUDGET_GAP_RE =
  *    (`N/A - stayed under budget, but the Windows matrix never ran`);
  *  - the completion idiom — token, dash, an "all done" head, then a
  *    completion word the text ENDS with (`none — all planned checks
- *    completed`). The head alone is not completion (`none — all 5
+ *    completed`), tolerating one trailing budget adverbial (`none — all
+ *    checks above completed within budget` — three of these reached two
+ *    posted bodies in one live round because the completion word was not
+ *    final). The head alone is not completion (`none — all 5
  *    Windows checks failed to start` keeps), the completion word must be
  *    AFFIRMED (`none — all checks crashed, none completed` keeps), and
  *    the span must not cross an exception (`none — all but the Windows
@@ -409,7 +412,7 @@ export const INLINE_BUDGET_GAP_RE =
  * them linear too.
  */
 const PLACEHOLDER_GAP_RE =
-  /^(?:<[^>]*>$|[-—*_~`]+$|(?:none|n\/a|nothing|no (?:gaps?|checks?))\b(?:[.!…,;:\s]*$|\s+(?:skipped|found|to report)\b[.!…,;:\s]*$|\s*[-—–]\s*(?:stayed\s+(?:under|within|below)\s+budget\b[.!…,;:\s]*$|(?:all|every(?:thing)?|planned|further|no further)\b(?:(?!\b(?:but|except|excepting|excluding)\b).)*(?<!\b(?:none|nothing|no|zero|never|not)\s)\b(?:complete[ds]?|done|finished|covered)\b[.!…,;:\s]*$)|\s*\(\s*(?:all|every(?:thing)?)\b(?:(?!\b(?:but|except|excepting|excluding)\b)[^()])*(?<!\b(?:none|nothing|no|zero|never|not)\s)\b(?:complete[ds]?|done|finished|covered)\b[.!…,;:\s]*\)\s*$))/i;
+  /^(?:<[^>]*>$|[-—*_~`]+$|(?:none|n\/a|nothing|no (?:gaps?|checks?))\b(?:[.!…,;:\s]*$|\s+(?:skipped|found|to report)\b[.!…,;:\s]*$|\s*[-—–]\s*(?:stayed\s+(?:under|within|below)\s+budget\b[.!…,;:\s]*$|(?:all|every(?:thing)?|planned|further|no further)\b(?:(?!\b(?:but|except|excepting|excluding)\b).)*(?<!\b(?:none|nothing|no|zero|never|not)\s)\b(?:complete[ds]?|done|finished|covered)\b(?:\s+(?:within|under|inside)\s+(?:the\s+)?(?:tool(?:[- ]call)?\s+)?budget)?[.!…,;:\s]*$)|\s*\(\s*(?:all|every(?:thing)?)\b(?:(?!\b(?:but|except|excepting|excluding)\b)[^()])*(?<!\b(?:none|nothing|no|zero|never|not)\s)\b(?:complete[ds]?|done|finished|covered)\b(?:\s+(?:within|under|inside)\s+(?:the\s+)?(?:tool(?:[- ]call)?\s+)?budget)?[.!…,;:\s]*\)\s*$))/i;
 
 /** Keep an operator-facing NOTE readable; a gap names a check, not an essay. */
 const MAX_GAP_LENGTH = 160;

--- a/packages/cli/src/commands/review/lib/coverage.ts
+++ b/packages/cli/src/commands/review/lib/coverage.ts
@@ -71,6 +71,7 @@ import {
   type RosterPlan,
 } from './roster.js';
 import { BRIEFS } from './agent-briefs.js';
+import { labelFromLaunchPrompt } from './agent-identity.js';
 import { chunkIdsProblem } from './diff-plan.js';
 import { readBudgetStop } from './deadline.js';
 import { budgetGapDisclosures } from './budget.js';
@@ -358,13 +359,15 @@ function publicRoleLabelZh(req: RequiredAgent): string | undefined {
 /** Something a reader can act on. `agentName` is `general-purpose` for all of them. */
 function label(rec: AgentRecord, chunk: number | null): string {
   if (chunk !== null) return `chunk ${chunk}`;
-  // The brief's codename line names the agent wherever it sits: launchers
-  // prepend context lines, and a first-line-only read has labelled twelve
-  // finders with one shared PR-summary sentence — every disclosure then
-  // rendered the same truncated PR quote instead of a name a reader can act
-  // on. (The pattern is the brief opener `agent-prompt` writes.)
-  const codename = /You are review agent `([^`\n]+)`/.exec(rec.launchPrompt);
-  if (codename) return `agent ${codename[1]}`;
+  // The identity line names the agent wherever it sits: launchers prepend
+  // context lines, and a first-line-only read has labelled twelve finders
+  // with one shared PR-summary sentence — every disclosure then rendered
+  // the same truncated PR quote instead of a name a reader can act on. The
+  // parser is shared with cost-ledger's row labels, so the round and
+  // owned-file suffixes survive here too — two reverse-audit rounds must
+  // not fold into one indistinguishable disclosure line.
+  const identity = labelFromLaunchPrompt(rec.launchPrompt);
+  if (identity !== null) return identity;
   const first = rec.launchPrompt.split('\n')[0]?.trim() ?? '';
   if (first) return first.replace(/\s+/g, ' ');
   return rec.agentName || rec.agentId;

--- a/packages/cli/src/commands/review/lib/coverage.ts
+++ b/packages/cli/src/commands/review/lib/coverage.ts
@@ -358,6 +358,13 @@ function publicRoleLabelZh(req: RequiredAgent): string | undefined {
 /** Something a reader can act on. `agentName` is `general-purpose` for all of them. */
 function label(rec: AgentRecord, chunk: number | null): string {
   if (chunk !== null) return `chunk ${chunk}`;
+  // The brief's codename line names the agent wherever it sits: launchers
+  // prepend context lines, and a first-line-only read has labelled twelve
+  // finders with one shared PR-summary sentence — every disclosure then
+  // rendered the same truncated PR quote instead of a name a reader can act
+  // on. (The pattern is the brief opener `agent-prompt` writes.)
+  const codename = /You are review agent `([^`\n]+)`/.exec(rec.launchPrompt);
+  if (codename) return `agent ${codename[1]}`;
   const first = rec.launchPrompt.split('\n')[0]?.trim() ?? '';
   if (first) return first.replace(/\s+/g, ' ');
   return rec.agentName || rec.agentId;

--- a/packages/cli/src/commands/review/run-skill-parity.test.ts
+++ b/packages/cli/src/commands/review/run-skill-parity.test.ts
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// `review run` pins the artifacts it captures by exact filename, and those
+// names are the bundled skill's to choose: the skill writes
+// `--out .qwen/tmp/qwen-review-{target}-composed.json` in Step 6 and the
+// report stems in Step 8. `composedNameFor`/`reportPatternFor` are therefore
+// a SECOND copy of a template that lives in prose — and when the two drift,
+// every affected `review run` completes (and, with --comment, posts) while
+// the parent reports "no composed verdict was produced" and exits 1: the
+// exact live defect the pinning exists to end.
+//
+// So the skill is the oracle here, not a hand-typed literal: this reads the
+// templates out of SKILL.md and renders them for each target class. A skill
+// edit that changes a template fails HERE, next to the code that must follow
+// it, instead of silently in a review months later.
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { composedNameFor, reportPatternFor } from './run.js';
+
+const repoRoot = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  '..',
+  '..',
+  '..',
+);
+
+const SKILL_PATH = join(
+  repoRoot,
+  'packages/core/src/skills/bundled/review/SKILL.md',
+);
+
+/** The `{target}` token, rendered per class exactly as the skill defines it. */
+const TARGETS = {
+  pr: { cls: { kind: 'pr', number: '9014' } as const, token: 'pr-9014' },
+  file: { cls: { kind: 'file', base: 'foo.ts' } as const, token: 'foo.ts' },
+  local: { cls: { kind: 'local' } as const, token: 'local' },
+};
+
+describe('run pins match the bundled skill templates', () => {
+  const skill = existsSync(SKILL_PATH)
+    ? readFileSync(SKILL_PATH, 'utf8').replace(/\r\n/g, '\n')
+    : null;
+
+  // A sparse or partial checkout has no skill to read; the pins are still
+  // covered by run.test.ts's own cases. Failing here would report a checkout
+  // shape as a contract drift.
+  const itWithSkill = skill === null ? it.skip : it;
+
+  itWithSkill('composedNameFor renders Step 6’s --out template', () => {
+    // The template as the skill writes it, e.g.
+    //   --out .qwen/tmp/qwen-review-{target}-composed.json
+    const m =
+      /--out\s+\.qwen\/tmp\/(qwen-review-\{target\}-composed\.json)/.exec(
+        skill as string,
+      );
+    // A null here means SKILL.md no longer writes that `--out` line: update
+    // composedNameFor and this oracle together to the new template.
+    expect(m).not.toBeNull();
+
+    const template = (m as RegExpExecArray)[1];
+    for (const { cls, token } of Object.values(TARGETS)) {
+      expect(composedNameFor(cls)).toBe(template.replace('{target}', token));
+    }
+  });
+
+  itWithSkill('reportPatternFor accepts Step 8’s report stems', () => {
+    // The stems as the skill lists them, e.g.
+    //   `.qwen/reviews/<YYYY-MM-DD>-<HHMMSS>-pr-<number>.md`
+    const stems = [
+      ...(skill as string).matchAll(
+        /`\.qwen\/reviews\/<YYYY-MM-DD>-<HHMMSS>-([^`]+)\.md`/g,
+      ),
+    ].map((s) => s[1]);
+    // A miss here means Step 8 no longer lists those stems: update
+    // reportPatternFor and this oracle together to the new template.
+    expect(stems).toEqual(
+      expect.arrayContaining(['local', 'pr-<number>', '<filename>']),
+    );
+
+    const render = (stem: string): string =>
+      `2026-08-13-101010-${stem}.md`
+        .replace('pr-<number>', 'pr-9014')
+        .replace('<filename>', 'foo.ts');
+
+    expect(reportPatternFor(TARGETS.pr.cls).test(render('pr-<number>'))).toBe(
+      true,
+    );
+    expect(reportPatternFor(TARGETS.file.cls).test(render('<filename>'))).toBe(
+      true,
+    );
+    expect(reportPatternFor(TARGETS.local.cls).test(render('local'))).toBe(
+      true,
+    );
+    // And each class refuses the neighbouring classes' rendered stems — the
+    // cross-capture this pinning exists to prevent.
+    expect(reportPatternFor(TARGETS.pr.cls).test(render('local'))).toBe(false);
+    expect(
+      reportPatternFor(TARGETS.local.cls).test(render('pr-<number>')),
+    ).toBe(false);
+    expect(reportPatternFor(TARGETS.file.cls).test(render('local'))).toBe(
+      false,
+    );
+  });
+});

--- a/packages/cli/src/commands/review/run.test.ts
+++ b/packages/cli/src/commands/review/run.test.ts
@@ -50,6 +50,9 @@ const {
   exitCodeFor,
   killProcessGroup,
   runCommand,
+  prNumberFromTarget,
+  composedPatternFor,
+  reportPatternFor,
 } = await import('./run.js');
 const { REVIEW_TMP_DIR, REVIEWS_DIR } = await import('./lib/paths.js');
 // The real cleanup, not a mock: the regression test below must prove the parent
@@ -139,6 +142,47 @@ describe('newestArtifactSince', () => {
     expect(
       newestArtifactSince(join(dir, 'absent'), /composed/, Date.now()),
     ).toBeNull();
+  });
+});
+
+describe('target-pinned artifact patterns', () => {
+  it('extracts the PR number from a bare number and a PR URL', () => {
+    expect(prNumberFromTarget('9014')).toBe('9014');
+    expect(prNumberFromTarget('https://github.com/o/r/pull/9014')).toBe('9014');
+    expect(prNumberFromTarget('https://github.com/o/r/pull/9014/')).toBe(
+      '9014',
+    );
+    expect(prNumberFromTarget('src/foo.ts')).toBeNull();
+    expect(prNumberFromTarget(undefined)).toBeNull();
+  });
+
+  it('pins a PR run to its own composed artifact', () => {
+    // Two concurrent `review run`s share `.qwen/tmp`; the generic
+    // newest-composed scan republished the OTHER run's verdict on two of
+    // three live parallel reviews.
+    const p = composedPatternFor('9014');
+    expect(p.test('qwen-review-pr-9014-composed.json')).toBe(true);
+    expect(p.test('qwen-review-pr-9013-composed.json')).toBe(false);
+    expect(p.test('qwen-review-local-composed.json')).toBe(false);
+  });
+
+  it('keeps a local/file run away from PR-scoped artifacts', () => {
+    const p = composedPatternFor(null);
+    expect(p.test('qwen-review-local-composed.json')).toBe(true);
+    expect(p.test('qwen-review-pr-9013-composed.json')).toBe(false);
+  });
+
+  it('pins the saved report the same way', () => {
+    expect(reportPatternFor('9014').test('2026-08-13-071500-pr-9014.md')).toBe(
+      true,
+    );
+    expect(reportPatternFor('9014').test('2026-08-13-162336-pr-9013.md')).toBe(
+      false,
+    );
+    expect(reportPatternFor(null).test('review.md')).toBe(true);
+    expect(reportPatternFor(null).test('2026-08-13-1622-pr-9045.md')).toBe(
+      false,
+    );
   });
 });
 
@@ -351,6 +395,83 @@ describe('review run (handler)', () => {
     expect(result.event).toBe('APPROVE');
     expect(result.composedPath).toContain('qwen-review-local-composed.json');
     expect(process.exitCode).toBe(0);
+  });
+
+  it('ignores a concurrent run’s other-PR verdict and captures its own', async () => {
+    vi.useFakeTimers();
+    let child!: FakeChild;
+    spawnMock.mockImplementation(() => {
+      // A NEIGHBOUR review composes first — the shape that made two of three
+      // live parallel runs republish the wrong PR's verdict.
+      mkdirSync(REVIEW_TMP_DIR, { recursive: true });
+      writeFileSync(
+        join(REVIEW_TMP_DIR, 'qwen-review-pr-9013-composed.json'),
+        JSON.stringify({ event: 'APPROVE', verdictLine: 'Verdict: Approve' }),
+        'utf8',
+      );
+      child = new FakeChild();
+      return child;
+    });
+
+    const done = runHandler({ target: '9014' });
+    await vi.advanceTimersByTimeAsync(1_000);
+    // This run's own verdict lands later.
+    writeFileSync(
+      join(REVIEW_TMP_DIR, 'qwen-review-pr-9014-composed.json'),
+      JSON.stringify({
+        event: 'COMMENT',
+        verdictLine: 'Verdict: Comment',
+      }),
+      'utf8',
+    );
+    await vi.advanceTimersByTimeAsync(1_000);
+    child.emit('close', 0);
+    await done;
+
+    const result = JSON.parse(outs.join(''));
+    expect(result.completed).toBe(true);
+    expect(result.event).toBe('COMMENT');
+    expect(result.composedPath).toContain('qwen-review-pr-9014-composed.json');
+  });
+
+  it('republishes the newest recompose, not the first snapshot', async () => {
+    // A coverage re-check can recompose the verdict minutes after the first
+    // write (measured live); the first snapshot would republish a superseded
+    // verdict.
+    vi.useFakeTimers();
+    let child!: FakeChild;
+    spawnMock.mockImplementation(() => {
+      mkdirSync(REVIEW_TMP_DIR, { recursive: true });
+      const path = join(REVIEW_TMP_DIR, 'qwen-review-pr-7-composed.json');
+      writeFileSync(
+        path,
+        JSON.stringify({ event: 'APPROVE', verdictLine: 'Verdict: Approve' }),
+        'utf8',
+      );
+      utimesSync(path, Date.now() / 1000, Date.now() / 1000);
+      child = new FakeChild();
+      return child;
+    });
+
+    const done = runHandler({ target: '7' });
+    await vi.advanceTimersByTimeAsync(1_000);
+    const path = join(REVIEW_TMP_DIR, 'qwen-review-pr-7-composed.json');
+    writeFileSync(
+      path,
+      JSON.stringify({
+        event: 'REQUEST_CHANGES',
+        verdictLine: 'Verdict: Request changes',
+      }),
+      'utf8',
+    );
+    // A strictly newer mtime, independent of filesystem clock granularity.
+    utimesSync(path, Date.now() / 1000 + 60, Date.now() / 1000 + 60);
+    await vi.advanceTimersByTimeAsync(1_000);
+    child.emit('close', 0);
+    await done;
+
+    const result = JSON.parse(outs.join(''));
+    expect(result.event).toBe('REQUEST_CHANGES');
   });
 
   it('closes the child stdin so piped input cannot defeat slash detection', async () => {

--- a/packages/cli/src/commands/review/run.test.ts
+++ b/packages/cli/src/commands/review/run.test.ts
@@ -50,7 +50,7 @@ const {
   exitCodeFor,
   killProcessGroup,
   runCommand,
-  prNumberFromTarget,
+  classifyRunTarget,
   composedPatternFor,
   reportPatternFor,
 } = await import('./run.js');
@@ -127,15 +127,21 @@ describe('newestArtifactSince', () => {
     ).toBeNull();
   });
 
-  it('returns the newest matching artifact from this run', () => {
+  it('returns the newest matching artifact from this run, mtime attached', () => {
     const start = Date.now() - 10_000;
     file('qwen-review-local-composed.json', start + 1_000);
     const newer = file('qwen-review-pr-9-composed.json', start + 5_000);
     file('unrelated.json', start + 9_000);
 
-    expect(
-      newestArtifactSince(dir, /^qwen-review-.*composed\.json$/, start),
-    ).toBe(newer);
+    const best = newestArtifactSince(
+      dir,
+      /^qwen-review-.*composed\.json$/,
+      start,
+    );
+    expect(best?.path).toBe(newer);
+    // The mtime rides along so the capture poll never re-stats the path —
+    // a second stat races the child's Step 9 sweep.
+    expect(Math.abs((best?.mtime ?? 0) - (start + 5_000))).toBeLessThan(1_000);
   });
 
   it('returns null when the directory does not exist', () => {
@@ -146,60 +152,81 @@ describe('newestArtifactSince', () => {
 });
 
 describe('target-pinned artifact patterns', () => {
-  it('extracts the PR number from a bare number and a PR URL', () => {
-    expect(prNumberFromTarget('9014')).toBe('9014');
-    expect(prNumberFromTarget('https://github.com/o/r/pull/9014')).toBe('9014');
-    expect(prNumberFromTarget('https://github.com/o/r/pull/9014/')).toBe(
-      '9014',
-    );
-    expect(prNumberFromTarget('src/foo.ts')).toBeNull();
-    expect(prNumberFromTarget(undefined)).toBeNull();
-  });
-
   it('classifies exactly as the child parser does — no second classifier', () => {
     // The child names its artifacts after parse-args' verdict; a narrower
     // local regex pinned patterns the child never writes and reported a
     // completed (and posted) review as "no verdict was produced".
+    expect(classifyRunTarget('9014')).toEqual({ kind: 'pr', number: '9014' });
+    expect(classifyRunTarget('https://github.com/o/r/pull/9014')).toEqual({
+      kind: 'pr',
+      number: '9014',
+    });
     // GitHub's Files-changed tab hands out /pull/<n>/files URLs:
-    expect(prNumberFromTarget('https://github.com/o/r/pull/9014/files')).toBe(
-      '9014',
+    expect(classifyRunTarget('https://github.com/o/r/pull/9014/files')).toEqual(
+      { kind: 'pr', number: '9014' },
     );
     // The parser normalizes pure integers via Number(), and the child writes
     // `pr-42-…`, so the pin must be '42', never '0042':
-    expect(prNumberFromTarget('0042')).toBe('42');
-    // A path that merely contains /pull/<n> is a FILE target to the parser:
-    expect(prNumberFromTarget('docs/pull/42')).toBeNull();
+    expect(classifyRunTarget('0042')).toEqual({ kind: 'pr', number: '42' });
     // The scheme and path are case-insensitive to the parser:
-    expect(prNumberFromTarget('HTTPS://github.com/o/r/PULL/9014')).toBe('9014');
+    expect(classifyRunTarget('HTTPS://github.com/o/r/PULL/9014')).toEqual({
+      kind: 'pr',
+      number: '9014',
+    });
+    // A path that merely contains /pull/<n> is a FILE target to the parser,
+    // and the file identity is the basename (the skill's `{target}` token):
+    expect(classifyRunTarget('docs/pull/42')).toEqual({
+      kind: 'file',
+      base: '42',
+    });
+    expect(classifyRunTarget('src/foo.ts')).toEqual({
+      kind: 'file',
+      base: 'foo.ts',
+    });
+    expect(classifyRunTarget(undefined)).toEqual({ kind: 'local' });
   });
 
-  it('pins a PR run to its own composed artifact', () => {
+  it('pins each target class to its exact composed filename', () => {
     // Two concurrent `review run`s share `.qwen/tmp`; the generic
     // newest-composed scan republished the OTHER run's verdict on two of
-    // three live parallel reviews.
-    const p = composedPatternFor('9014');
-    expect(p.test('qwen-review-pr-9014-composed.json')).toBe(true);
-    expect(p.test('qwen-review-pr-9013-composed.json')).toBe(false);
-    expect(p.test('qwen-review-local-composed.json')).toBe(false);
+    // three live parallel reviews. Exact names, not shape heuristics.
+    const pr = composedPatternFor({ kind: 'pr', number: '9014' });
+    expect(pr.test('qwen-review-pr-9014-composed.json')).toBe(true);
+    expect(pr.test('qwen-review-pr-9013-composed.json')).toBe(false);
+    expect(pr.test('qwen-review-local-composed.json')).toBe(false);
+
+    const local = composedPatternFor({ kind: 'local' });
+    expect(local.test('qwen-review-local-composed.json')).toBe(true);
+    expect(local.test('qwen-review-pr-9013-composed.json')).toBe(false);
+    // A concurrent FILE run's artifact is not the local run's either:
+    expect(local.test('qwen-review-b.ts-composed.json')).toBe(false);
+
+    const file = composedPatternFor({ kind: 'file', base: 'b.ts' });
+    expect(file.test('qwen-review-b.ts-composed.json')).toBe(true);
+    expect(file.test('qwen-review-local-composed.json')).toBe(false);
+    // The dot is a literal, not a wildcard:
+    expect(file.test('qwen-review-bxts-composed.json')).toBe(false);
   });
 
-  it('keeps a local/file run away from PR-scoped artifacts', () => {
-    const p = composedPatternFor(null);
-    expect(p.test('qwen-review-local-composed.json')).toBe(true);
-    expect(p.test('qwen-review-pr-9013-composed.json')).toBe(false);
+  it('a pr-<digits>-named FILE target is not confused with a PR run', () => {
+    // A name-shape pin broke both directions here: the `(?!pr-\d+-)`
+    // lookahead rejected this file run's OWN artifact, and the PR branch's
+    // `.*` wildcard claimed it for `review run 42`.
+    const file = composedPatternFor({ kind: 'file', base: 'pr-42-notes.ts' });
+    expect(file.test('qwen-review-pr-42-notes.ts-composed.json')).toBe(true);
+
+    const pr = composedPatternFor({ kind: 'pr', number: '42' });
+    expect(pr.test('qwen-review-pr-42-notes.ts-composed.json')).toBe(false);
+    expect(pr.test('qwen-review-pr-42-composed.json')).toBe(true);
   });
 
-  it('pins the saved report the same way', () => {
-    expect(reportPatternFor('9014').test('2026-08-13-071500-pr-9014.md')).toBe(
-      true,
-    );
-    expect(reportPatternFor('9014').test('2026-08-13-162336-pr-9013.md')).toBe(
-      false,
-    );
-    expect(reportPatternFor(null).test('review.md')).toBe(true);
-    expect(reportPatternFor(null).test('2026-08-13-1622-pr-9045.md')).toBe(
-      false,
-    );
+  it('pins the saved report as far as its naming allows', () => {
+    const pr = reportPatternFor({ kind: 'pr', number: '9014' });
+    expect(pr.test('2026-08-13-071500-pr-9014.md')).toBe(true);
+    expect(pr.test('2026-08-13-162336-pr-9013.md')).toBe(false);
+    const local = reportPatternFor({ kind: 'local' });
+    expect(local.test('review.md')).toBe(true);
+    expect(local.test('2026-08-13-1622-pr-9045.md')).toBe(false);
   });
 });
 
@@ -426,6 +453,26 @@ describe('review run (handler)', () => {
         JSON.stringify({ event: 'APPROVE', verdictLine: 'Verdict: Approve' }),
         'utf8',
       );
+      // The neighbour's saved report exists too — and is newer than this
+      // run's own by the time the scan runs.
+      mkdirSync(REVIEWS_DIR, { recursive: true });
+      writeFileSync(
+        join(REVIEWS_DIR, '2026-08-13-071500-pr-9014.md'),
+        '# own report',
+        'utf8',
+      );
+      writeFileSync(
+        join(REVIEWS_DIR, '2026-08-13-162336-pr-9013.md'),
+        '# neighbour report',
+        'utf8',
+      );
+      // Force the neighbour's report strictly newer, so an unpinned
+      // newest-.md scan would deterministically pick the wrong one.
+      utimesSync(
+        join(REVIEWS_DIR, '2026-08-13-162336-pr-9013.md'),
+        Date.now() / 1000 + 60,
+        Date.now() / 1000 + 60,
+      );
       child = new FakeChild();
       return child;
     });
@@ -449,6 +496,9 @@ describe('review run (handler)', () => {
     expect(result.completed).toBe(true);
     expect(result.event).toBe('COMMENT');
     expect(result.composedPath).toContain('qwen-review-pr-9014-composed.json');
+    // The report scan is pinned the same way — the neighbour's newer report
+    // must not become this run's reportPath.
+    expect(result.reportPath).toContain('pr-9014.md');
   });
 
   it('republishes the newest recompose, not the first snapshot', async () => {

--- a/packages/cli/src/commands/review/run.test.ts
+++ b/packages/cli/src/commands/review/run.test.ts
@@ -183,6 +183,10 @@ describe('target-pinned artifact patterns', () => {
       kind: 'file',
       base: 'foo.ts',
     });
+    // A tab-completed trailing separator must not produce an empty basename
+    // (an empty base pins `qwen-review--composed.json`, which no child
+    // artifact can carry — every such run would report "no verdict").
+    expect(classifyRunTarget('src/')).toEqual({ kind: 'file', base: 'src' });
     expect(classifyRunTarget(undefined)).toEqual({ kind: 'local' });
   });
 
@@ -227,6 +231,15 @@ describe('target-pinned artifact patterns', () => {
     const local = reportPatternFor({ kind: 'local' });
     expect(local.test('review.md')).toBe(true);
     expect(local.test('2026-08-13-1622-pr-9045.md')).toBe(false);
+
+    // File reports carry the filename in the report stem's trailing slot.
+    const file = reportPatternFor({ kind: 'file', base: 'foo.ts' });
+    expect(file.test('2026-08-13-101010-foo.ts.md')).toBe(true);
+    expect(file.test('2026-08-13-101010-bar.ts.md')).toBe(false);
+    // A file literally named `pr-1234.md` claims its OWN report — the shape
+    // the local branch's PR exclusion would self-reject (`.md` not doubled).
+    const prNamed = reportPatternFor({ kind: 'file', base: 'pr-1234.md' });
+    expect(prNamed.test('2026-08-13-101010-pr-1234.md')).toBe(true);
   });
 });
 

--- a/packages/cli/src/commands/review/run.test.ts
+++ b/packages/cli/src/commands/review/run.test.ts
@@ -466,6 +466,14 @@ describe('review run (handler)', () => {
         JSON.stringify({ event: 'APPROVE', verdictLine: 'Verdict: Approve' }),
         'utf8',
       );
+      // Strictly NEWER than this run's own verdict, written below: with the
+      // neighbour older, an unpinned newest-composed scan would land on the
+      // right file anyway and the regression would pass this test.
+      utimesSync(
+        join(REVIEW_TMP_DIR, 'qwen-review-pr-9013-composed.json'),
+        Date.now() / 1000 + 60,
+        Date.now() / 1000 + 60,
+      );
       // The neighbour's saved report exists too — and is newer than this
       // run's own by the time the scan runs.
       mkdirSync(REVIEWS_DIR, { recursive: true });
@@ -552,6 +560,31 @@ describe('review run (handler)', () => {
 
     const result = JSON.parse(outs.join(''));
     expect(result.event).toBe('REQUEST_CHANGES');
+  });
+
+  it('names the artifact it waited for when no verdict appears', async () => {
+    // The pin is an exact-filename contract with the skill's naming
+    // template. When the two drift, Step 9 has already swept `.qwen/tmp` by
+    // the time anyone investigates — so the expectation has to be in the
+    // failure report itself, in both output modes.
+    armChild(0);
+    await runHandler({ target: '9014', json: false });
+
+    expect(outs.join('')).toContain(
+      'no composed verdict was produced (expected',
+    );
+    expect(outs.join('')).toContain('qwen-review-pr-9014-composed.json');
+    expect(process.exitCode).toBe(1);
+
+    outs.length = 0;
+    armChild(0);
+    await runHandler({ target: '9014' });
+
+    const result = JSON.parse(outs.join(''));
+    expect(result.completed).toBe(false);
+    expect(result.expectedComposedName).toBe(
+      'qwen-review-pr-9014-composed.json',
+    );
   });
 
   it('closes the child stdin so piped input cannot defeat slash detection', async () => {

--- a/packages/cli/src/commands/review/run.test.ts
+++ b/packages/cli/src/commands/review/run.test.ts
@@ -156,6 +156,23 @@ describe('target-pinned artifact patterns', () => {
     expect(prNumberFromTarget(undefined)).toBeNull();
   });
 
+  it('classifies exactly as the child parser does — no second classifier', () => {
+    // The child names its artifacts after parse-args' verdict; a narrower
+    // local regex pinned patterns the child never writes and reported a
+    // completed (and posted) review as "no verdict was produced".
+    // GitHub's Files-changed tab hands out /pull/<n>/files URLs:
+    expect(prNumberFromTarget('https://github.com/o/r/pull/9014/files')).toBe(
+      '9014',
+    );
+    // The parser normalizes pure integers via Number(), and the child writes
+    // `pr-42-…`, so the pin must be '42', never '0042':
+    expect(prNumberFromTarget('0042')).toBe('42');
+    // A path that merely contains /pull/<n> is a FILE target to the parser:
+    expect(prNumberFromTarget('docs/pull/42')).toBeNull();
+    // The scheme and path are case-insensitive to the parser:
+    expect(prNumberFromTarget('HTTPS://github.com/o/r/PULL/9014')).toBe('9014');
+  });
+
   it('pins a PR run to its own composed artifact', () => {
     // Two concurrent `review run`s share `.qwen/tmp`; the generic
     // newest-composed scan republished the OTHER run's verdict on two of

--- a/packages/cli/src/commands/review/run.ts
+++ b/packages/cli/src/commands/review/run.ts
@@ -80,8 +80,39 @@ export interface RunReviewResult {
   durationMs: number;
 }
 
-/** The composed verdict `compose-review` writes and Step 9 cleanup sweeps. */
-const COMPOSED_PATTERN = /^qwen-review-.*composed\.json$/;
+/**
+ * The PR number a `review run` target names, or null for local/file targets.
+ * Used to pin the artifact scan to THIS run's files: two concurrent
+ * `review run`s in one repo share `.qwen/tmp`, and a generic newest-composed
+ * scan has captured the OTHER run's verdict the moment it appeared (measured:
+ * two of three parallel PR reviews republished a neighbour's `composedPath`).
+ */
+export function prNumberFromTarget(target?: string): string | null {
+  if (!target) return null;
+  if (/^\d+$/.test(target)) return target;
+  const m = /\/pull\/(\d+)\/?(?:[?#]|$)/.exec(target);
+  return m ? m[1] : null;
+}
+
+/**
+ * The composed-verdict filenames this run can claim. A PR target owns exactly
+ * its own `qwen-review-pr-<n>-…composed.json`; a local/file target owns any
+ * composed artifact EXCEPT a PR-scoped one, so a concurrent PR review cannot
+ * be mistaken for the local run (the reverse direction is already covered by
+ * the PR pin).
+ */
+export function composedPatternFor(prNumber: string | null): RegExp {
+  return prNumber
+    ? new RegExp(`^qwen-review-pr-${prNumber}-.*composed\\.json$`)
+    : /^qwen-review-(?!pr-\d+-).*composed\.json$/;
+}
+
+/** Same pinning for the saved report under `.qwen/reviews/`. */
+export function reportPatternFor(prNumber: string | null): RegExp {
+  return prNumber
+    ? new RegExp(`-pr-${prNumber}\\.md$`)
+    : /^(?!.*-pr-\d+\.md$).*\.md$/;
+}
 
 // How often to poll for the composed verdict while the child runs. The verdict
 // sits on disk from Step 6 (compose-review) until Step 9 (cleanup) — a window
@@ -315,23 +346,31 @@ async function runReview(args: RunReviewArgs): Promise<void> {
   // every `.qwen/tmp/qwen-review-<target>-*` file — including it — before the
   // child exits. Reading it only AFTER `close` therefore sees nothing and
   // reports a review that completed as one that failed. Snapshot it the moment
-  // compose-review writes it: the first verdict newer than the run start is
-  // this run's, and caching it in memory survives the sweep.
+  // compose-review writes it, and keep re-reading while the child runs: a
+  // coverage re-check can legitimately recompose the verdict (measured: a live
+  // run rewrote its composed artifact twelve minutes after the first write),
+  // and the FIRST snapshot would republish the superseded one.
+  const prNumber = prNumberFromTarget(args.target);
+  const composedPattern = composedPatternFor(prNumber);
   let capturedPath: string | null = null;
   let capturedVerdict: ComposedVerdict | null = null;
+  let capturedMtime = -Infinity;
   const captureTimer = setInterval(() => {
-    if (capturedVerdict !== null) return;
-    const path = newestArtifactSince(
-      REVIEW_TMP_DIR,
-      COMPOSED_PATTERN,
-      cutoffMs,
-    );
+    const path = newestArtifactSince(REVIEW_TMP_DIR, composedPattern, cutoffMs);
     if (path === null) return;
+    let mtime: number;
+    try {
+      mtime = statSync(path).mtimeMs;
+    } catch {
+      return; // swept between scan and stat; keep the captured verdict
+    }
+    if (mtime <= capturedMtime) return;
     // A half-written file fails to parse; the next tick retries it.
     const verdict = readComposed(path);
     if (verdict !== null) {
       capturedPath = path;
       capturedVerdict = verdict;
+      capturedMtime = mtime;
     }
   }, COMPOSED_POLL_MS);
 
@@ -405,12 +444,16 @@ async function runReview(args: RunReviewArgs): Promise<void> {
   if (composed === null) {
     composedPath = newestArtifactSince(
       REVIEW_TMP_DIR,
-      COMPOSED_PATTERN,
+      composedPattern,
       cutoffMs,
     );
     composed = composedPath ? readComposed(composedPath) : null;
   }
-  const reportPath = newestArtifactSince(REVIEWS_DIR, /\.md$/, cutoffMs);
+  const reportPath = newestArtifactSince(
+    REVIEWS_DIR,
+    reportPatternFor(prNumber),
+    cutoffMs,
+  );
 
   const completed = composed !== null;
   const result: RunReviewResult = {

--- a/packages/cli/src/commands/review/run.ts
+++ b/packages/cli/src/commands/review/run.ts
@@ -81,53 +81,81 @@ export interface RunReviewResult {
 }
 
 /**
- * The PR number a `review run` target names, or null for local/file targets.
- * Used to pin the artifact scan to THIS run's files: two concurrent
- * `review run`s in one repo share `.qwen/tmp`, and a generic newest-composed
- * scan has captured the OTHER run's verdict the moment it appeared (measured:
- * two of three parallel PR reviews republished a neighbour's `composedPath`).
- *
- * Classified by the child's own parser, not a local regex: the child names
- * its artifacts after what `parse-args` decided, so any second classifier
- * here diverges exactly where the shapes get interesting — `/pull/9014/files`
- * (a PR to the parser, unmatched by a $-anchored regex), `0042` (the parser
- * writes `pr-42-`, a verbatim pin looks for `pr-0042-`), `docs/pull/42` (a
- * file path to the parser). A run whose pin disagrees with the child reports
- * a completed review as "no verdict was produced".
+ * What a `review run` target IS, in the child's own terms. Classified by the
+ * child's parser, not a local regex: the child names its artifacts after
+ * what `parse-args` decided, so any second classifier here diverges exactly
+ * where the shapes get interesting — `/pull/9014/files` (a PR to the parser,
+ * unmatched by a $-anchored regex), `0042` (the parser writes `pr-42-`, a
+ * verbatim pin looks for `pr-0042-`), `docs/pull/42` (a file path to the
+ * parser). A run whose pin disagrees with the child reports a completed
+ * review as "no verdict was produced".
  */
-export function prNumberFromTarget(target?: string): string | null {
-  if (!target) return null;
+export type RunTargetClass =
+  | { kind: 'pr'; number: string }
+  | { kind: 'file'; base: string }
+  | { kind: 'local' };
+
+export function classifyRunTarget(target?: string): RunTargetClass {
+  if (!target) return { kind: 'local' };
   const { target: t } = parseReviewArgs(target);
-  return t.type === 'pr-number' || t.type === 'pr-url'
-    ? String(t.number)
-    : null;
+  if (t.type === 'pr-number' || t.type === 'pr-url') {
+    return { kind: 'pr', number: String(t.number) };
+  }
+  if (t.type === 'file') {
+    // The skill's `{target}` token for a file review is the file's basename
+    // (`--target <filename>` in the capture step), so that is the identity
+    // the child's artifact names carry.
+    return { kind: 'file', base: t.path.split(/[\\/]/).pop() ?? t.path };
+  }
+  return { kind: 'local' };
+}
+
+const escapeRe = (s: string): string =>
+  s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * The one composed-verdict filename this run's target class produces, per
+ * the skill's literal `--out .qwen/tmp/qwen-review-{target}-composed.json`
+ * template: `pr-<n>` for a PR, the file's basename for a file review, the
+ * fixed token `local` for a bare run. Exact names, not shape heuristics —
+ * a name-shape pin (`(?!pr-\d+-)…`) rejected a file run's OWN artifact
+ * whenever the reviewed file was named `pr-<digits>-…`, and conversely let
+ * a PR pin claim that file run's artifact. Two concurrent `review run`s
+ * share `.qwen/tmp`, and the pre-pin newest-composed scan captured the
+ * OTHER run's verdict the moment it appeared (measured: two of three
+ * parallel PR reviews republished a neighbour's `composedPath`).
+ *
+ * Known residual race, accepted: the pin separates target IDENTITIES, not
+ * runs. Two concurrent runs of the SAME target (two bare runs, or the same
+ * PR twice) write the same filename, and whichever child composes last wins
+ * on disk for both parents — only a per-run nonce in the child's artifact
+ * names could key that apart, and the bundled skill, not this command,
+ * would have to mint it. Same-target collisions predate the pin; do not
+ * diagnose them as a pin failure.
+ */
+export function composedPatternFor(cls: RunTargetClass): RegExp {
+  switch (cls.kind) {
+    case 'pr':
+      return new RegExp(`^qwen-review-pr-${cls.number}-composed\\.json$`);
+    case 'file':
+      return new RegExp(`^qwen-review-${escapeRe(cls.base)}-composed\\.json$`);
+    case 'local':
+    default:
+      return /^qwen-review-local-composed\.json$/;
+  }
 }
 
 /**
- * The composed-verdict filenames this run can claim. A PR target owns exactly
- * its own `qwen-review-pr-<n>-…composed.json`; a local/file target owns any
- * composed artifact EXCEPT a PR-scoped one, so a concurrent PR review cannot
- * be mistaken for the local run (the reverse direction is already covered by
- * the PR pin).
- *
- * Known residual race, accepted: the pin separates target CLASSES, not runs.
- * Two concurrent no-target runs both write the one fixed filename
- * `qwen-review-local-composed.json`, and whichever child composes last wins
- * on disk for both parents — target identity cannot key that apart without
- * threading a per-run nonce into the child's artifact names, which the
- * bundled skill, not this command, would have to mint. Same-target
- * collisions predate the pin; do not diagnose them as a pin failure.
+ * The saved report under `.qwen/reviews/`, pinned as far as its naming
+ * allows. PR reports reliably end `-pr-<n>.md`; local/file report stems are
+ * model-chosen (three formats observed in one day), so those runs claim any
+ * report EXCEPT a PR-suffixed one — non-PR runs can still pool each other's
+ * reports in a concurrent window. The report is informational; the verdict
+ * (`composedPatternFor`) is what carries the exit code, and it is exact.
  */
-export function composedPatternFor(prNumber: string | null): RegExp {
-  return prNumber
-    ? new RegExp(`^qwen-review-pr-${prNumber}-.*composed\\.json$`)
-    : /^qwen-review-(?!pr-\d+-).*composed\.json$/;
-}
-
-/** Same pinning for the saved report under `.qwen/reviews/`. */
-export function reportPatternFor(prNumber: string | null): RegExp {
-  return prNumber
-    ? new RegExp(`-pr-${prNumber}\\.md$`)
+export function reportPatternFor(cls: RunTargetClass): RegExp {
+  return cls.kind === 'pr'
+    ? new RegExp(`-pr-${cls.number}\\.md$`)
     : /^(?!.*-pr-\d+\.md$).*\.md$/;
 }
 
@@ -179,13 +207,16 @@ export function buildReviewPrompt(args: {
  * `startMs`, or null. Pre-existing artifacts from earlier reviews in the same
  * repo must not be mistaken for this run's verdict — a stale composed JSON says
  * whatever the LAST review decided, which is exactly the wrong thing to
- * republish — so anything older than the run is invisible here.
+ * republish — so anything older than the run is invisible here. The mtime
+ * rides along with the path: the capture poll compares it against what it
+ * already holds, and re-statting the path here would race the child's Step 9
+ * sweep, which unlinks these files while the parent may still be polling.
  */
 export function newestArtifactSince(
   dir: string,
   pattern: RegExp,
   startMs: number,
-): string | null {
+): { path: string; mtime: number } | null {
   let best: { path: string; mtime: number } | null = null;
   let names: string[];
   try {
@@ -205,7 +236,7 @@ export function newestArtifactSince(
     if (mtime < startMs) continue;
     if (!best || mtime > best.mtime) best = { path, mtime };
   }
-  return best ? best.path : null;
+  return best;
 }
 
 /**
@@ -367,27 +398,20 @@ async function runReview(args: RunReviewArgs): Promise<void> {
   // coverage re-check can legitimately recompose the verdict (measured: a live
   // run rewrote its composed artifact twelve minutes after the first write),
   // and the FIRST snapshot would republish the superseded one.
-  const prNumber = prNumberFromTarget(args.target);
-  const composedPattern = composedPatternFor(prNumber);
+  const targetClass = classifyRunTarget(args.target);
+  const composedPattern = composedPatternFor(targetClass);
   let capturedPath: string | null = null;
   let capturedVerdict: ComposedVerdict | null = null;
   let capturedMtime = -Infinity;
   const captureTimer = setInterval(() => {
-    const path = newestArtifactSince(REVIEW_TMP_DIR, composedPattern, cutoffMs);
-    if (path === null) return;
-    let mtime: number;
-    try {
-      mtime = statSync(path).mtimeMs;
-    } catch {
-      return; // swept between scan and stat; keep the captured verdict
-    }
-    if (mtime <= capturedMtime) return;
+    const best = newestArtifactSince(REVIEW_TMP_DIR, composedPattern, cutoffMs);
+    if (best === null || best.mtime <= capturedMtime) return;
     // A half-written file fails to parse; the next tick retries it.
-    const verdict = readComposed(path);
+    const verdict = readComposed(best.path);
     if (verdict !== null) {
-      capturedPath = path;
+      capturedPath = best.path;
       capturedVerdict = verdict;
-      capturedMtime = mtime;
+      capturedMtime = best.mtime;
     }
   }, COMPOSED_POLL_MS);
 
@@ -459,18 +483,13 @@ async function runReview(args: RunReviewArgs): Promise<void> {
   let composedPath: string | null = capturedPath;
   let composed: ComposedVerdict | null = capturedVerdict;
   if (composed === null) {
-    composedPath = newestArtifactSince(
-      REVIEW_TMP_DIR,
-      composedPattern,
-      cutoffMs,
-    );
+    const best = newestArtifactSince(REVIEW_TMP_DIR, composedPattern, cutoffMs);
+    composedPath = best?.path ?? null;
     composed = composedPath ? readComposed(composedPath) : null;
   }
-  const reportPath = newestArtifactSince(
-    REVIEWS_DIR,
-    reportPatternFor(prNumber),
-    cutoffMs,
-  );
+  const reportPath =
+    newestArtifactSince(REVIEWS_DIR, reportPatternFor(targetClass), cutoffMs)
+      ?.path ?? null;
 
   const completed = composed !== null;
   const result: RunReviewResult = {

--- a/packages/cli/src/commands/review/run.ts
+++ b/packages/cli/src/commands/review/run.ts
@@ -104,8 +104,12 @@ export function classifyRunTarget(target?: string): RunTargetClass {
   if (t.type === 'file') {
     // The skill's `{target}` token for a file review is the file's basename
     // (`--target <filename>` in the capture step), so that is the identity
-    // the child's artifact names carry.
-    return { kind: 'file', base: t.path.split(/[\\/]/).pop() ?? t.path };
+    // the child's artifact names carry. Trailing separators are stripped
+    // first: a tab-completed `src/` classifies as a file target and reviews
+    // the directory, and a bare `.pop()` would return `''` — a pin
+    // (`qwen-review--composed.json`) no child artifact can ever carry.
+    const trimmed = t.path.replace(/[\\/]+$/, '');
+    return { kind: 'file', base: trimmed.split(/[\\/]/).pop() || trimmed };
   }
   return { kind: 'local' };
 }
@@ -125,13 +129,20 @@ const escapeRe = (s: string): string =>
  * OTHER run's verdict the moment it appeared (measured: two of three
  * parallel PR reviews republished a neighbour's `composedPath`).
  *
- * Known residual race, accepted: the pin separates target IDENTITIES, not
- * runs. Two concurrent runs of the SAME target (two bare runs, or the same
- * PR twice) write the same filename, and whichever child composes last wins
- * on disk for both parents — only a per-run nonce in the child's artifact
- * names could key that apart, and the bundled skill, not this command,
- * would have to mint it. Same-target collisions predate the pin; do not
- * diagnose them as a pin failure.
+ * Known residual races, accepted — the pin separates composed FILENAMES,
+ * which is as much identity as the child's naming carries; do not diagnose
+ * any of these as a pin failure:
+ *
+ *  - same target twice (two bare runs, or the same PR twice) — the same
+ *    filename, so whichever child composes last wins for both parents;
+ *  - two FILE targets with different paths but one basename (a monorepo's
+ *    two `index.ts`) — the child names by basename, so their filenames
+ *    collide the same way;
+ *  - a FILE target whose basename is literally `local` or `pr-<digits>` —
+ *    its filename is byte-identical to the local/PR pin.
+ *
+ * Only a per-run nonce in the child's artifact names could key these
+ * apart, and the bundled skill, not this command, would have to mint it.
  */
 export function composedPatternFor(cls: RunTargetClass): RegExp {
   switch (cls.kind) {
@@ -147,16 +158,31 @@ export function composedPatternFor(cls: RunTargetClass): RegExp {
 
 /**
  * The saved report under `.qwen/reviews/`, pinned as far as its naming
- * allows. PR reports reliably end `-pr-<n>.md`; local/file report stems are
- * model-chosen (three formats observed in one day), so those runs claim any
- * report EXCEPT a PR-suffixed one — non-PR runs can still pool each other's
- * reports in a concurrent window. The report is informational; the verdict
- * (`composedPatternFor`) is what carries the exit code, and it is exact.
+ * allows. PR reports reliably end `-pr-<n>.md`, and file reports carry the
+ * filename in the same slot (`<date>-<time>-<filename>.md`, the `.md` not
+ * doubled) — so a file target named `pr-1234.md` claims its OWN report
+ * instead of tripping the local branch's PR exclusion. Local report stems
+ * are model-chosen (three date formats observed in one day), so a bare run
+ * claims any report EXCEPT a PR-suffixed one — concurrent local runs can
+ * still pool reports, and a PR run cannot be told from a file run whose
+ * basename is `pr-<n>.md` by name alone. The report is informational; the
+ * verdict (`composedPatternFor`) is what carries the exit code, and it is
+ * exact.
  */
 export function reportPatternFor(cls: RunTargetClass): RegExp {
-  return cls.kind === 'pr'
-    ? new RegExp(`-pr-${cls.number}\\.md$`)
-    : /^(?!.*-pr-\d+\.md$).*\.md$/;
+  switch (cls.kind) {
+    case 'pr':
+      return new RegExp(`-pr-${cls.number}\\.md$`);
+    case 'file':
+      return new RegExp(
+        cls.base.toLowerCase().endsWith('.md')
+          ? `-${escapeRe(cls.base)}$`
+          : `-${escapeRe(cls.base)}\\.md$`,
+      );
+    case 'local':
+    default:
+      return /^(?!.*-pr-\d+\.md$).*\.md$/;
+  }
 }
 
 // How often to poll for the composed verdict while the child runs. The verdict

--- a/packages/cli/src/commands/review/run.ts
+++ b/packages/cli/src/commands/review/run.ts
@@ -73,6 +73,13 @@ export interface RunReviewResult {
   downgradedFrom: string | null;
   remediation: string[];
   composedPath: string | null;
+  /**
+   * The exact `.qwen/tmp` filename this run's target class pins — named in
+   * the result so a completed-but-uncaptured review (a naming drift between
+   * this pin and the skill's template) is diagnosable after Step 9 has
+   * swept the directory that would show the near-miss.
+   */
+  expectedComposedName: string;
   reportPath: string | null;
   childExitCode: number | null;
   childSignal: string | null;
@@ -144,16 +151,20 @@ const escapeRe = (s: string): string =>
  * Only a per-run nonce in the child's artifact names could key these
  * apart, and the bundled skill, not this command, would have to mint it.
  */
-export function composedPatternFor(cls: RunTargetClass): RegExp {
+export function composedNameFor(cls: RunTargetClass): string {
   switch (cls.kind) {
     case 'pr':
-      return new RegExp(`^qwen-review-pr-${cls.number}-composed\\.json$`);
+      return `qwen-review-pr-${cls.number}-composed.json`;
     case 'file':
-      return new RegExp(`^qwen-review-${escapeRe(cls.base)}-composed\\.json$`);
+      return `qwen-review-${cls.base}-composed.json`;
     case 'local':
     default:
-      return /^qwen-review-local-composed\.json$/;
+      return 'qwen-review-local-composed.json';
   }
+}
+
+export function composedPatternFor(cls: RunTargetClass): RegExp {
+  return new RegExp(`^${escapeRe(composedNameFor(cls))}$`);
 }
 
 /**
@@ -528,6 +539,7 @@ async function runReview(args: RunReviewArgs): Promise<void> {
     downgradedFrom: composed?.downgradedFrom ?? null,
     remediation: composed?.remediation ?? [],
     composedPath: composedPath ? resolve(composedPath) : null,
+    expectedComposedName: composedNameFor(targetClass),
     reportPath: reportPath ? resolve(reportPath) : null,
     childExitCode,
     childSignal,
@@ -548,10 +560,18 @@ async function runReview(args: RunReviewArgs): Promise<void> {
       writeStdoutLine(result.verdictLine ?? `Event: ${result.event}`);
       if (result.reportPath) writeStdoutLine(`Report: ${result.reportPath}`);
     } else {
+      // Name the expectation: the pin is an exact-filename contract with the
+      // skill's naming template, and by the time anyone investigates, Step 9
+      // has swept `.qwen/tmp` — the near-miss name is gone. A no-verdict
+      // report that does not say which file it was waiting for cannot be
+      // diagnosed as a naming drift.
       const detail =
         composedPath !== null
           ? `a composed verdict was found at ${resolve(composedPath)} but could not be parsed`
-          : 'no composed verdict was produced';
+          : `no composed verdict was produced (expected ${join(
+              REVIEW_TMP_DIR,
+              composedNameFor(targetClass),
+            )})`;
       writeStdoutLine(
         timedOut
           ? 'Review did not complete: timed out.'

--- a/packages/cli/src/commands/review/run.ts
+++ b/packages/cli/src/commands/review/run.ts
@@ -34,7 +34,7 @@ import {
   writeStderrLineSafe,
 } from '../../utils/stdioHelpers.js';
 import { REVIEW_TMP_DIR, REVIEWS_DIR } from './lib/paths.js';
-import { EFFORT_LEVELS } from './parse-args.js';
+import { EFFORT_LEVELS, parseReviewArgs } from './parse-args.js';
 
 export interface RunReviewArgs {
   target?: string;
@@ -86,12 +86,21 @@ export interface RunReviewResult {
  * `review run`s in one repo share `.qwen/tmp`, and a generic newest-composed
  * scan has captured the OTHER run's verdict the moment it appeared (measured:
  * two of three parallel PR reviews republished a neighbour's `composedPath`).
+ *
+ * Classified by the child's own parser, not a local regex: the child names
+ * its artifacts after what `parse-args` decided, so any second classifier
+ * here diverges exactly where the shapes get interesting — `/pull/9014/files`
+ * (a PR to the parser, unmatched by a $-anchored regex), `0042` (the parser
+ * writes `pr-42-`, a verbatim pin looks for `pr-0042-`), `docs/pull/42` (a
+ * file path to the parser). A run whose pin disagrees with the child reports
+ * a completed review as "no verdict was produced".
  */
 export function prNumberFromTarget(target?: string): string | null {
   if (!target) return null;
-  if (/^\d+$/.test(target)) return target;
-  const m = /\/pull\/(\d+)\/?(?:[?#]|$)/.exec(target);
-  return m ? m[1] : null;
+  const { target: t } = parseReviewArgs(target);
+  return t.type === 'pr-number' || t.type === 'pr-url'
+    ? String(t.number)
+    : null;
 }
 
 /**
@@ -100,6 +109,14 @@ export function prNumberFromTarget(target?: string): string | null {
  * composed artifact EXCEPT a PR-scoped one, so a concurrent PR review cannot
  * be mistaken for the local run (the reverse direction is already covered by
  * the PR pin).
+ *
+ * Known residual race, accepted: the pin separates target CLASSES, not runs.
+ * Two concurrent no-target runs both write the one fixed filename
+ * `qwen-review-local-composed.json`, and whichever child composes last wins
+ * on disk for both parents — target identity cannot key that apart without
+ * threading a per-run nonce into the child's artifact names, which the
+ * bundled skill, not this command, would have to mint. Same-target
+ * collisions predate the pin; do not diagnose them as a pin failure.
  */
 export function composedPatternFor(prNumber: string | null): RegExp {
   return prNumber

--- a/scripts/copy_bundle_assets.js
+++ b/scripts/copy_bundle_assets.js
@@ -17,7 +17,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { copyFileSync, existsSync, mkdirSync, statSync } from 'node:fs';
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import {
   dirname,
   join,
@@ -402,6 +409,22 @@ export function copyBundleAssets({ root = defaultRoot } = {}) {
   // cannot tell and neither can its reader. Compared, not trusted: the check
   // reads this and re-derives the digest from the tree.
   stampReviewSourceDigest(root, distDir);
+
+  // Make dist/cli.js directly executable: shellContextEnv blanks a
+  // QWEN_CODE_CLI whose entry a POSIX shell cannot exec (no shebang, or no
+  // execute bit), and the `"${QWEN_CODE_CLI:-qwen}"` fallback then silently
+  // runs whatever `qwen` the PATH resolves — a different install for every
+  // `review` subcommand of a session launched from this bundle. Measured on
+  // three live `review run`s: every agent-issued subcommand ran the machine's
+  // global install instead of the freshly bundled tree.
+  const cliEntry = join(distDir, 'cli.js');
+  if (existsSync(cliEntry)) {
+    const source = readFileSync(cliEntry, 'utf8');
+    if (!source.startsWith('#!')) {
+      writeFileSync(cliEntry, `#!/usr/bin/env node\n${source}`);
+    }
+    fs.chmodSync(cliEntry, 0o755);
+  }
 
   console.log('\n✅ All bundle assets copied to dist/');
 }

--- a/scripts/copy_bundle_assets.js
+++ b/scripts/copy_bundle_assets.js
@@ -421,8 +421,18 @@ export function copyBundleAssets({ root = defaultRoot } = {}) {
   if (existsSync(cliEntry)) {
     const source = readFileSync(cliEntry, 'utf8');
     if (!source.startsWith('#!')) {
+      // Preserve the bundle's write time across the rewrite. The digest stamp
+      // above reads this mtime as "when the bundle was built", and a bumped
+      // one certifies a bundle as newer than review sources edited before it
+      // — the staleness warning the skill's Step 0 stops on then never fires.
+      // (Only a standalone run of this script is exposed, since a full bundle
+      // stamps before reaching here, but that is a flow the gate contemplates.)
+      const { atime, mtime } = statSync(cliEntry);
       writeFileSync(cliEntry, `#!/usr/bin/env node\n${source}`);
+      fs.utimesSync(cliEntry, atime, mtime);
     }
+    // chmod does not touch mtime, so it stays outside the guard: a bundle
+    // that already carries a shebang may still arrive without the exec bit.
     fs.chmodSync(cliEntry, 0o755);
   }
 

--- a/scripts/tests/package-assets.test.js
+++ b/scripts/tests/package-assets.test.js
@@ -58,6 +58,12 @@ describe('package asset scripts', () => {
     // fires and a review silently measures the old behaviour.
     const builtAt = new Date(Date.now() - 60_000);
     utimesSync(cliEntry, builtAt, builtAt);
+    // Read back what the filesystem actually recorded. Comparing against the
+    // `Date` handed to `utimesSync` would re-pin libuv's double-seconds →
+    // `timespec` truncation (about half of all millisecond values land 1 ns
+    // low), which is not the invariant under test — only whether the rewrite
+    // moves the time the filesystem holds.
+    const builtMs = fs.statSync(cliEntry).mtimeMs;
     stubConsole();
 
     copyBundleAssets({ root: rootDir });
@@ -65,7 +71,7 @@ describe('package asset scripts', () => {
     const once = readFileSync(cliEntry, 'utf8');
     expect(once.startsWith('#!/usr/bin/env node\n')).toBe(true);
     expect(once).toContain('console.log("bundle");');
-    expect(fs.statSync(cliEntry).mtimeMs).toBe(builtAt.getTime());
+    expect(fs.statSync(cliEntry).mtimeMs).toBe(builtMs);
     if (process.platform !== 'win32') {
       // Windows has no POSIX exec bit for chmod to set; the shebang half
       // still holds there.

--- a/scripts/tests/package-assets.test.js
+++ b/scripts/tests/package-assets.test.js
@@ -41,6 +41,34 @@ describe('package asset scripts', () => {
     }
   });
 
+  it('emits an executable dist/cli.js — shebang plus the exec bit, once', () => {
+    // shellContextEnv blanks a QWEN_CODE_CLI a POSIX shell cannot exec (no
+    // shebang, or no exec bit), and `"${QWEN_CODE_CLI:-qwen}"` then silently
+    // runs whatever `qwen` the PATH resolves — a different install for every
+    // review subcommand of a session launched off the bundle (measured on
+    // three live runs). Deleting the block, dropping the chmod, or dropping
+    // the already-has-a-shebang guard must not stay green.
+    const rootDir = createFixtureRoot();
+    writeFile(rootDir, 'dist/cli.js', 'console.log("bundle");\n');
+    stubConsole();
+
+    copyBundleAssets({ root: rootDir });
+
+    const cliEntry = path.join(rootDir, 'dist', 'cli.js');
+    const once = readFileSync(cliEntry, 'utf8');
+    expect(once.startsWith('#!/usr/bin/env node\n')).toBe(true);
+    expect(once).toContain('console.log("bundle");');
+    if (process.platform !== 'win32') {
+      // Windows has no POSIX exec bit for chmod to set; the shebang half
+      // still holds there.
+      expect(fs.statSync(cliEntry).mode & 0o777).toBe(0o755);
+    }
+
+    // Re-running the bundle step must not stack a second shebang.
+    copyBundleAssets({ root: rootDir });
+    expect(readFileSync(cliEntry, 'utf8')).toBe(once);
+  });
+
   it('stamps the review source digest into dist', () => {
     // Nothing gated this call site: removing it left the whole scripts suite
     // green while `npm run bundle` silently stopped writing the stamp — and a

--- a/scripts/tests/package-assets.test.js
+++ b/scripts/tests/package-assets.test.js
@@ -50,23 +50,40 @@ describe('package asset scripts', () => {
     // the already-has-a-shebang guard must not stay green.
     const rootDir = createFixtureRoot();
     writeFile(rootDir, 'dist/cli.js', 'console.log("bundle");\n');
+    const cliEntry = path.join(rootDir, 'dist', 'cli.js');
+    // A build time in the past, so the rewrite's own clock cannot coincide
+    // with it: the digest stamp reads this mtime as "when the bundle was
+    // built", and a rewrite that bumps it certifies a bundle as newer than
+    // review sources edited before it — the staleness warning then never
+    // fires and a review silently measures the old behaviour.
+    const builtAt = new Date(Date.now() - 60_000);
+    utimesSync(cliEntry, builtAt, builtAt);
     stubConsole();
 
     copyBundleAssets({ root: rootDir });
 
-    const cliEntry = path.join(rootDir, 'dist', 'cli.js');
     const once = readFileSync(cliEntry, 'utf8');
     expect(once.startsWith('#!/usr/bin/env node\n')).toBe(true);
     expect(once).toContain('console.log("bundle");');
+    expect(fs.statSync(cliEntry).mtimeMs).toBe(builtAt.getTime());
     if (process.platform !== 'win32') {
       // Windows has no POSIX exec bit for chmod to set; the shebang half
       // still holds there.
       expect(fs.statSync(cliEntry).mode & 0o777).toBe(0o755);
     }
 
-    // Re-running the bundle step must not stack a second shebang.
+    // Re-running the bundle step must not stack a second shebang — and must
+    // still set the exec bit on a file that already carries one (an entry
+    // arriving with a shebang but mode 0644 is exactly the shape that blanks
+    // QWEN_CODE_CLI; demoting the chmod inside the shebang guard must fail).
+    if (process.platform !== 'win32') {
+      fs.chmodSync(cliEntry, 0o644);
+    }
     copyBundleAssets({ root: rootDir });
     expect(readFileSync(cliEntry, 'utf8')).toBe(once);
+    if (process.platform !== 'win32') {
+      expect(fs.statSync(cliEntry).mode & 0o777).toBe(0o755);
+    }
   });
 
   it('stamps the review source digest into dist', () => {


### PR DESCRIPTION
## What this PR does

Fixes four defects in the `/review` pipeline that were caught by running `qwen review run` end-to-end against three real open PRs (#9013, #9014, #9045) with qwen3.8-max, and pins each fix with regression tests. All four were observed live, not hypothesized.

1. **`review run` republished a concurrent run's verdict (`run.ts`).** The composed-verdict scan matched any `qwen-review-*composed.json` in the shared `.qwen/tmp` and took the newest, so with two reviews running in one repo, whichever composed first was captured by the other run. The scan (poll and post-exit fallback) is now pinned to the run's own target — a PR run only claims `qwen-review-pr-<n>-…composed.json` and `…-pr-<n>.md`, a local/file run refuses PR-scoped artifacts — and the poller keeps re-reading while the child runs, because one live review legitimately recomposed its verdict 12 minutes after the first write and the first-snapshot capture would have republished the superseded one.

2. **Placeholder budget gaps reached posted bodies (`lib/budget.ts`).** `PLACEHOLDER_GAP_RE` drops "nothing to disclose" non-answers, but its completion idiom required the completion word to end the text, so `none — all checks … completed within budget.` slipped through into public verdict bodies. The completion branches now tolerate one end-anchored budget adverbial (`within/under/inside (the) (tool[-call]) budget`); a clause continuing past it still keeps.

3. **Gap disclosures labelled by a PR quote instead of an agent name (`lib/coverage.ts`).** `label()` took the launch prompt's first line, and launchers prepend a context sentence — so all twelve finders of one run shared a single PR-summary first line and every budget-gap disclosure rendered as the same truncated PR quote. The brief's codename line (``You are review agent `6c` ``) is now matched anywhere in the prompt and wins; the first line remains the fallback.

4. **`dist/cli.js` was not executable, silently defeating QWEN_CODE_CLI (`scripts/copy_bundle_assets.js`).** `shellContextEnv` blanks a `QWEN_CODE_CLI` that a POSIX shell cannot exec (no shebang, or no execute bit) so `"${QWEN_CODE_CLI:-qwen}"` doesn't die on exit 126 — but the bundle step emitted `dist/cli.js` at mode 644 with no shebang, so the variable arrived blank in every shell of a session launched off the bundle and every `qwen review …` subcommand fell back to the PATH's global install. The bundle now emits `dist/cli.js` with `#!/usr/bin/env node` and mode 755.

## Why it's needed

A live round of three parallel `qwen review run`s produced concretely wrong outputs on all four paths: two of the three runs reported a neighbour PR's verdict as their own (one externally reported REQUEST_CHANGES for a review whose own saved report says Comment); three "none — …" placeholder lines were rendered into two public verdict bodies as coverage gaps; every gap disclosure in one run carried the same unreadable truncated PR quote as its agent label; and all subcommands of all three runs silently executed the machine's auto-updated global install instead of the tree they were launched from, which defeats the skill's entire version-skew defense for source-tree launches. Each of these misleads either a CI consumer of `review run --json`, a PR author reading the posted body, or a maintainer measuring a build.

## Reviewer Test Plan

### How to verify

Run the pinned regression suites — all four fixes have dedicated cases (concurrent-artifact isolation, recompose freshness, the live placeholder strings kept and dropped, the codename label, pattern pinning): `cd packages/cli && npx vitest run src/commands/review/run.test.ts src/commands/review/lib/budget.test.ts src/commands/review/check-coverage.test.ts` → 168 passed. For the bundle fix: `npm run build && npm run bundle`, then `head -c 2 dist/cli.js` prints `#!`, `ls -l dist/cli.js` shows mode 755, and `./dist/cli.js --version` execs directly. Optionally reproduce the concurrency bug on the base commit: start two `review run`s of different PRs in one repo and observe the later-starting run's `composedPath` point at whichever PR composes first; on this branch each run only ever claims its own `qwen-review-pr-<n>-…` artifacts.

### Evidence (Before & After)

Before (live run, base commit): `review run 9014 --json` returned `"event": "REQUEST_CHANGES", "composedPath": ".../qwen-review-pr-9013-composed.json"` while its own saved report concluded `Verdict: Comment`; the posted body of #9013 carried `Not explored to full depth (tool budget reached): …: none — all checks above completed within budget.`; the process table showed `fnm …/bin/qwen review build-test` resolving to `~/.qwen/updates/npm/…/0.21.11` (global install) inside a review launched from a freshly bundled tree whose `dist/cli.js` was `-rw-r--r--` with no shebang. After: the new unit tests pin each of these shapes (`composedPatternFor('9014')` rejects `qwen-review-pr-9013-composed.json`; `budgetGapDisclosures('Budget gap: none — all checks above completed within budget.')` returns `[]` while the same text with a trailing clause is kept; a prompt with a prepended context line labels as `agent 6c`), and the bundle emits `#!/usr/bin/env node` + mode 755, verified by direct exec and by the exact `shellContextEnv` usability predicate.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS (darwin 25.6), Node v24.18.1, npm 11.16.0; live-run evidence gathered with `node dist/cli.js review run <pr> --json` under tmux against dashscope qwen3.8-max.

## Risk & Scope

- Main risk or tradeoff: the local/file composed pattern now refuses PR-scoped artifacts, so a hypothetical run that reviews a local tree but names its composed artifact `qwen-review-pr-…` would no longer be picked up — no shipped path produces that shape. The placeholder-gap widening is end-anchored and negation-guarded, so a real gap that mentions budget mid-sentence still discloses; live keep-shapes are pinned in tests.
- Not validated / out of scope: the systemic issues the same live round surfaced (build-test whole-call budget guaranteeing an `unreviewed-dimension` cap on this repo, small-PR high-effort latency, headless progress opacity, model-improvised report filename stems) need design decisions and are deliberately not patched here.
- Breaking changes / migration notes: none. `dist/cli.js` gaining a shebang and the execute bit is additive; npm-published entry points are unaffected.

## Linked Issues

None — the defects were found by direct live-run observation against PRs #9013 / #9014 / #9045 (referenced for evidence only; this PR does not close them).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修复 `/review` 管线的四个缺陷。这些缺陷是用 `qwen review run` 对三个真实 open PR（#9013、#9014、#9045）配合 qwen3.8-max 做端到端实跑时抓到的，每个修复都配了回归测试。四个问题全部是现场实测观察到的，不是推测。

1. **`review run` 转发了并发运行的另一个 review 的 verdict（`run.ts`）。** composed verdict 扫描用 `qwen-review-*composed.json` 在共享的 `.qwen/tmp` 里取最新文件，同仓库两个 review 并发时，谁先 compose 就被对方捕获。现在扫描（轮询和退出后兜底）按本次运行的 target 钉死——PR 运行只认自己的 `qwen-review-pr-<n>-…composed.json` 和 `…-pr-<n>.md`，local/file 运行拒绝 PR 前缀的工件——且轮询在子进程运行期间持续读取最新版本，因为实测有一次 review 在首次写入 12 分钟后合法地二次 compose，只取首个快照会转发已被取代的 verdict。

2. **占位符 budget gap 进入了公开正文（`lib/budget.ts`）。** `PLACEHOLDER_GAP_RE` 负责丢弃"没有可披露内容"的非披露，但其 completion 习语要求 completion 词收尾，于是 `none — all checks … completed within budget.` 漏进了公开 verdict 正文。completion 分支现在容忍一个端锚定的 budget 状语（`within/under/inside (the) (tool[-call]) budget`）；后面还有从句的文本仍然保留为真披露。

3. **缺口披露的 agent 标签渲染成 PR 引文而非 agent 名（`lib/coverage.ts`）。** `label()` 只取 launch prompt 首行，而 launcher 会前置一句上下文——一次运行的 12 个 finder 共享同一句 PR 概述首行，所有 budget gap 披露都渲染成同一句截断的 PR 引文。现在在 prompt 全文中匹配 brief 的代号行（``You are review agent `6c` ``）并优先使用；首行仍作兜底。

4. **`dist/cli.js` 不可执行，静默击穿 QWEN_CODE_CLI（`scripts/copy_bundle_assets.js`）。** `shellContextEnv` 会把 POSIX shell 无法直接执行的 `QWEN_CODE_CLI`（无 shebang 或无执行位）置空，以免 `"${QWEN_CODE_CLI:-qwen}"` 死于 exit 126——但 bundle 步骤产出的 `dist/cli.js` 是 644 且无 shebang，于是从 bundle 启动的会话里每个 shell 拿到的该变量都是空的，所有 `qwen review …` 子命令都回落到 PATH 上的全局安装。现在 bundle 产出带 `#!/usr/bin/env node` 且 mode 755 的 `dist/cli.js`。

## 为什么需要

一轮三个并发 `qwen review run` 实跑在四条路径上都产出了具体的错误输出：三跑有二把邻居 PR 的 verdict 当成自己的对外报告（其中一个对外报 REQUEST_CHANGES，而它自己保存的报告结论是 Comment）；三条 "none — …" 占位行被渲染进两个公开 verdict 正文当作覆盖缺口；一次运行的所有缺口披露都挂着同一句不可读的截断 PR 引文当 agent 标签；三次运行的全部子命令都静默执行了机器上自动更新的全局安装而非启动它们的源码树，这使 skill 的整套防版本漂移体系对源码树启动完全失效。每一条都会误导 `review run --json` 的 CI 消费者、读公开正文的 PR 作者、或测量构建的维护者。

## Reviewer 测试计划

### 如何验证

跑钉死的回归套件——四个修复各有专门用例（并发工件隔离、二次 compose 取最新、实跑占位符原句的保留与丢弃、代号标签、模式钉死）：`cd packages/cli && npx vitest run src/commands/review/run.test.ts src/commands/review/lib/budget.test.ts src/commands/review/check-coverage.test.ts` → 168 通过。bundle 修复：`npm run build && npm run bundle` 后 `head -c 2 dist/cli.js` 输出 `#!`，`ls -l dist/cli.js` 显示 755，`./dist/cli.js --version` 可直接执行。可选：在 base 提交上复现并发 bug——同仓库启动两个不同 PR 的 `review run`，观察后启动的运行其 `composedPath` 指向先 compose 的那个 PR；本分支上每个运行只认自己的 `qwen-review-pr-<n>-…` 工件。

### 证据（Before & After）

Before（实跑，base 提交）：`review run 9014 --json` 返回 `"event": "REQUEST_CHANGES", "composedPath": ".../qwen-review-pr-9013-composed.json"`，而它自己保存的报告结论是 `Verdict: Comment`；#9013 的公开正文出现 `Not explored to full depth (tool budget reached): …: none — all checks above completed within budget.`；进程表显示从新 bundle 的源码树启动的 review 内部 `fnm …/bin/qwen review build-test` 解析到 `~/.qwen/updates/npm/…/0.21.11`（全局安装），彼时 `dist/cli.js` 是 `-rw-r--r--` 且无 shebang。After：新增单测钉死上述每种形态（`composedPatternFor('9014')` 拒绝 `qwen-review-pr-9013-composed.json`；`budgetGapDisclosures('Budget gap: none — all checks above completed within budget.')` 返回 `[]` 而同文本带后续从句时保留；带前置上下文行的 prompt 标签为 `agent 6c`），bundle 产出 `#!/usr/bin/env node` + 755，经直接执行和 `shellContextEnv` 的可用性判定原样验证。

### 已测试系统

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS（darwin 25.6）、Node v24.18.1、npm 11.16.0；实跑证据在 tmux 下用 `node dist/cli.js review run <pr> --json` 对 dashscope qwen3.8-max 采集。

## 风险与范围

- 主要风险或取舍：local/file 的 composed 模式现在拒绝 PR 前缀工件，假想中某个 review 本地树却把 composed 命名为 `qwen-review-pr-…` 的路径将不再被识别——现有代码没有会产生这种形态的路径。占位符放宽是端锚定且带否定守卫的，句中提及 budget 的真披露仍会保留；实跑的保留形态已入测试。
- 未验证/范围外：同一轮实跑暴露的系统性问题（build-test whole-call 预算在本仓库必然导致 `unreviewed-dimension` 封顶、小 PR 高档位延迟、headless 无进度、报告文件名由模型即兴命名）需要设计决策，本 PR 有意不修。
- 破坏性变更/迁移说明：无。`dist/cli.js` 增加 shebang 与执行位是增量性的；npm 发布的入口不受影响。

## 关联 Issue

无——缺陷由对 PR #9013 / #9014 / #9045 的直接实跑观察发现（仅作证据引用；本 PR 不关闭它们）。

</details>