### PR TITLE
ci(sdk-java): drop the shared Maven toolchains.xml before setup-java on self-hosted runners

### DIFF
--- a/.github/workflows/sdk-java.yml
+++ b/.github/workflows/sdk-java.yml
@@ -96,6 +96,17 @@ jobs:
             exit 1
           fi
 
+      # Runner instances on one self-hosted machine share $HOME and therefore
+      # ~/.m2/toolchains.xml. setup-java merges its JDK entry into that file
+      # with a non-atomic read-modify-write, so two concurrent jobs can tear
+      # it — and once torn, every later job on the machine fails Set up Java
+      # with "Cannot insert a text node as a child of a document node". The
+      # build never reads toolchains.xml (no maven-toolchains-plugin), so
+      # dropping it is free and setup-java rewrites it from scratch.
+      - name: 'Drop shared Maven toolchains.xml (self-hosted)'
+        if: "${{ runner.environment == 'self-hosted' }}"
+        run: 'rm -f "${HOME}/.m2/toolchains.xml"'
+
       - name: 'Set up Java'
         uses: 'actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654' # v5.2.0
         with:
@@ -178,6 +189,12 @@ jobs:
           if [[ "$(node -p 'process.versions.node.split(".")[0]')" != "22" ]]; then
             echo "::warning::Expected Node 22.x but found $(node -v); daemon E2E will run against the runner's Node."
           fi
+
+      # Same shared-$HOME hazard as the unit job above: drop the torn-prone
+      # toolchains.xml so a corrupt leftover cannot fail Set up Java.
+      - name: 'Drop shared Maven toolchains.xml (self-hosted)'
+        if: "${{ runner.environment == 'self-hosted' }}"
+        run: 'rm -f "${HOME}/.m2/toolchains.xml"'
 
       - name: 'Set up Java'
         uses: 'actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654' # v5.2.0


### PR DESCRIPTION
## What this PR does

Adds a self-hosted-only step before both `Set up Java` steps in the SDK Java workflow that deletes `~/.m2/toolchains.xml`, so a corrupt leftover copy of that file on a shared runner machine can never fail the job again. Hosted runners are untouched (the step is gated on `runner.environment == 'self-hosted'`), and `release-sdk-java.yml` runs on hosted `ubuntu-latest` only, so it does not need the step.

## Why it's needed

SDK Java jobs are currently hard-failing at `Set up Java` on one of the self-hosted HK machines with `The operation would yield an incorrect node tree. Cannot insert a text node as a child of a document node.` (e.g. run [31680689177](https://github.com/QwenLM/qwen-code/actions/runs/31680689177/job/94385216700) on PR #9057). The runner instances on one machine share `$HOME`, and therefore share `~/.m2/toolchains.xml`. `actions/setup-java` merges its JDK entry into that file with a non-atomic read-modify-write, so two concurrent jobs on the same machine can tear it — and once the file is torn, it stays torn: every later job scheduled onto any runner instance of that machine dies parsing it in `Set up Java`.

The corruption is machine-sticky, not flaky: the five most recent SDK Java failures all show the identical DOM error and all landed on `actions-runner-hk-…s6t-*` instances (7, 9, 12, 13, 23, 25 — one machine), while the interleaved successes landed on the healthy `…s6u-*` machine. Reruns are therefore scheduling roulette until someone hand-cleans the machine; this step makes the workflow self-heal instead, the same way the CI gate already sanitizes other shared-`$HOME` pollution (e.g. the global gitconfig incident).

Deleting the file is free: `setup-java` rewrites `toolchains.xml` from scratch after the delete, and nothing in the build reads it — `packages/sdk-java/qwencode/pom.xml` does not use `maven-toolchains-plugin` (`settings.xml` is not affected by this failure mode; `setup-java` overwrites it wholesale via its default `overwrite-settings: true`, with no merge parse). A concurrent-write tear can still, in the worst case, flake the one job that races the write, but it can no longer persist and take the whole machine out of rotation.

## Reviewer Test Plan

### How to verify

Confirm the diagnosis from the linked logs: the failing step is `Set up Java` right after `Creating toolchains.xml for JDK version 11 from temurin`, which is the merge path of `actions/setup-java`'s `toolchains.xml` handling; the five most recent failures ([31694105216](https://github.com/QwenLM/qwen-code/actions/runs/31694105216), [31690396556](https://github.com/QwenLM/qwen-code/actions/runs/31690396556), [31688406633](https://github.com/QwenLM/qwen-code/actions/runs/31688406633), [31687745478](https://github.com/QwenLM/qwen-code/actions/runs/31687745478), [31687573966](https://github.com/QwenLM/qwen-code/actions/runs/31687573966)) all carry the identical error on `…s6t-*` runners while successes ran on `…s6u-*`. Confirm the pom has no toolchains usage (`grep toolchain packages/sdk-java/qwencode/pom.xml` is empty), so deleting the file cannot affect the build. `actionlint` and `yamllint` pass on the changed workflow. This PR's own SDK Java run exercises the new step whenever it schedules onto a self-hosted runner; on the currently-poisoned machine it is expected to convert a guaranteed `Set up Java` failure into a pass.

### Evidence (Before & After)

N/A — CI workflow change; the before state is the linked failing runs.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

N/A — workflow-only change, validated with `actionlint` (with shellcheck) and `yamllint` locally.

## Risk & Scope

- Main risk or tradeoff: any other job on the machine that relied on a persistent `~/.m2/toolchains.xml` would lose entries between jobs — none does today (the only writer observed is `setup-java` itself, and this repo's builds never read the file).
- Not validated / out of scope: cleaning the already-corrupt file on the `…s6t` machine happens automatically the first time this workflow runs there; no manual runner intervention is scripted here. The narrow concurrent-tear window during simultaneous `setup-java` writes remains, but no longer persists.
- Breaking changes / migration notes: none.

## Linked Issues

Observed on PR #9057's SDK Java run 31680689177; same signature on runs 31694105216, 31690396556, 31688406633, 31687745478, 31687573966.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在 SDK Java workflow 的两个 `Set up Java` 步骤之前各加一个仅 self-hosted 生效的步骤,删除 `~/.m2/toolchains.xml`,使共享 runner 宿主机上残留的损坏文件不能再让 job 失败。hosted runner 不受影响(步骤以 `runner.environment == 'self-hosted'` 为条件),`release-sdk-java.yml` 只跑 hosted `ubuntu-latest`,无需此步骤。

## 为什么需要

SDK Java job 目前在某台 HK 自托管宿主机上于 `Set up Java` 阶段必挂,报 `The operation would yield an incorrect node tree. Cannot insert a text node as a child of a document node.`(如 PR #9057 的 run [31680689177](https://github.com/QwenLM/qwen-code/actions/runs/31680689177/job/94385216700))。同一台宿主机上的多个 runner 实例共享 `$HOME`,因此共享 `~/.m2/toolchains.xml`。`actions/setup-java` 用非原子的读-改-写把自己的 JDK 条目合并进该文件,同机并发的两个 job 可能把它写撕裂——而且一旦撕裂就持久存在:之后调度到这台机器任何 runner 实例的 job 都会在 `Set up Java` 解析它时死掉。

这个损坏是"机器粘性"的而非偶发:最近 5 个 SDK Java 失败全部是完全相同的 DOM 错误,全部落在 `actions-runner-hk-…s6t-*` 实例(7、9、12、13、23、25——同一台机器)上,而穿插其间的成功 run 都落在健康的 `…s6u-*` 机器上。在有人手工清理宿主机之前,重跑只是调度轮盘赌;本步骤让 workflow 自愈,与 CI 门此前对其他共享 `$HOME` 污染(如全局 gitconfig 事件)的 sanitize 处理同一路数。

删除该文件没有代价:`setup-java` 在删除后会从头重写 `toolchains.xml`,而构建本身不读它——`packages/sdk-java/qwencode/pom.xml` 不使用 `maven-toolchains-plugin`(`settings.xml` 不受此故障模式影响:`setup-java` 默认 `overwrite-settings: true` 整体覆盖写,不做合并解析)。并发写撕裂在最坏情况下仍可能让恰好撞上的那一个 job 偶发失败,但不会再持久化、不会把整台机器打出轮换。

## Reviewer Test Plan

### 如何验证

从链接日志确认诊断:失败步骤是 `Set up Java`,紧跟 `Creating toolchains.xml for JDK version 11 from temurin` 之后,即 `actions/setup-java` 的 `toolchains.xml` 合并路径;最近 5 个失败([31694105216](https://github.com/QwenLM/qwen-code/actions/runs/31694105216)、[31690396556](https://github.com/QwenLM/qwen-code/actions/runs/31690396556)、[31688406633](https://github.com/QwenLM/qwen-code/actions/runs/31688406633)、[31687745478](https://github.com/QwenLM/qwen-code/actions/runs/31687745478)、[31687573966](https://github.com/QwenLM/qwen-code/actions/runs/31687573966))错误完全一致且全在 `…s6t-*` runner,成功 run 都在 `…s6u-*`。确认 pom 不使用 toolchains(`grep toolchain packages/sdk-java/qwencode/pom.xml` 为空),删除文件不影响构建。改动的 workflow 通过 `actionlint` 与 `yamllint`。本 PR 自己的 SDK Java run 一旦调度到 self-hosted runner 即实际执行新步骤;在当前已中毒的机器上,预期把必挂的 `Set up Java` 变为通过。

### 证据(Before & After)

N/A——CI workflow 改动;before 状态即上面链接的失败 run。

### 测试环境

N/A——纯 workflow 改动,本地以 `actionlint`(含 shellcheck)与 `yamllint` 校验。

## 风险与范围

- 主要风险或权衡:如果这台机器上有其他 job 依赖持久化的 `~/.m2/toolchains.xml`,其条目会在 job 间丢失——目前没有(观察到的唯一写入者就是 `setup-java` 本身,且本仓库构建从不读该文件)。
- 未验证/超出范围:`…s6t` 机器上已损坏的文件将在本 workflow 首次跑到该机器时自动清掉,不需要额外的人工 runner 操作。`setup-java` 同时写入的窄撕裂窗口仍在,但不再持久化。
- 破坏性变更/迁移说明:无。

## 关联 Issue

在 PR #9057 的 SDK Java run 31680689177 观察到;run 31694105216、31690396556、31688406633、31687745478、31687573966 同一签名。

</details>
