### PR TITLE
feat(review): resume an interrupted PR review from its on-disk state

### DIFF
--- a/packages/cli/src/commands/review.test.ts
+++ b/packages/cli/src/commands/review.test.ts
@@ -68,6 +68,7 @@ describe('reviewCommand', () => {
       'test-efficacy',
       'test-plan',
       'findings',
+      'recover-findings',
       'publish-assets',
       'compose-review',
       'save-artifact',

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -13,6 +13,7 @@ import { parseArgsCommand } from './review/parse-args.js';
 import { matchRemoteCommand } from './review/match-remote.js';
 import { composeReviewCommand } from './review/compose-review.js';
 import { findingsCommand } from './review/findings.js';
+import { recoverFindingsCommand } from './review/recover-findings.js';
 import { fetchPrCommand } from './review/fetch-pr.js';
 import { captureLocalCommand } from './review/capture-local.js';
 import { planDiffCommand } from './review/plan-diff.js';
@@ -79,6 +80,7 @@ export const reviewCommand: CommandModule = {
       .command(testEfficacyCommand)
       .command(testPlanCommand)
       .command(findingsCommand)
+      .command(recoverFindingsCommand)
       .command(publishAssetsCommand)
       .command(composeReviewCommand)
       .command(saveArtifactCommand)
@@ -86,7 +88,7 @@ export const reviewCommand: CommandModule = {
       .command(cleanupCommand)
       .demandCommand(
         1,
-        'Specify a subcommand: run, parse-args, match-remote, meta, issue-context, fetch-diff, comment-body, fetch-pr, capture-local, plan-diff, repo-context, pr-context, comment-status, load-rules, agent-prompt, build-test, base-tree, test-delta, drive, mock-provider, extract-step, script-lint, resolve-anchors, check-coverage, cost-ledger, presubmit, test-efficacy, test-plan, findings, publish-assets, compose-review, save-artifact, submit, or cleanup.',
+        'Specify a subcommand: run, parse-args, match-remote, meta, issue-context, fetch-diff, comment-body, fetch-pr, capture-local, plan-diff, repo-context, pr-context, comment-status, load-rules, agent-prompt, build-test, base-tree, test-delta, drive, mock-provider, extract-step, script-lint, resolve-anchors, check-coverage, cost-ledger, presubmit, test-efficacy, test-plan, findings, recover-findings, publish-assets, compose-review, save-artifact, submit, or cleanup.',
       )
       .version(false),
   handler: () => {

--- a/packages/cli/src/commands/review/fetch-pr.test.ts
+++ b/packages/cli/src/commands/review/fetch-pr.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createHash } from 'node:crypto';
 import type { Argv, CommandModule } from 'yargs';
 import { resolve } from 'node:path';
 import {
@@ -25,10 +26,13 @@ import {
   reviewLeaseHeldByAnotherSession,
 } from '../../services/review-worktree-lease.js';
 import { classifyHeavy } from './lib/heavy.js';
-import { DEADLINE_ENV } from './lib/deadline.js';
+import { DEADLINE_ENV, hasReviewDeadline } from './lib/deadline.js';
 import type { MergeBaseResult } from './lib/merge-base.js';
 import { buildRoleBrief } from './agent-prompt.js';
-import { PARSE_ARGS_REPORT, worktreePath } from './lib/paths.js';
+import { PARSE_ARGS_REPORT, tmpFile, worktreePath } from './lib/paths.js';
+import { buildDiffPlan } from './lib/diff-plan.js';
+import { buildPlanReport } from './lib/report.js';
+import { operatorReviewSettings } from './lib/review-settings.js';
 import { makeDiff } from './lib/test-utils.js';
 
 describe('classifyHeavy', () => {
@@ -230,6 +234,7 @@ describe('fetchPrCommand builder', () => {
 // ---------------------------------------------------------------------------
 
 const producerMocks = vi.hoisted(() => ({
+  mkdirSync: vi.fn(),
   writeFileSync: vi.fn(),
   readFileSync: vi.fn((_path?: unknown): string => {
     throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
@@ -240,6 +245,12 @@ const producerMocks = vi.hoisted(() => ({
   refExists: vi.fn((..._refs: unknown[]): boolean => false),
   releaseWorktree: vi.fn(() => ({ existed: false, freed: true })),
   gitOpt: vi.fn((..._args: string[]): string | null => null),
+  statSync: vi.fn((path?: unknown): { mtimeMs: number } | undefined =>
+    String(path).endsWith('-fetch.json') ||
+    String(path).endsWith('fetch-report.json')
+      ? { mtimeMs: Date.parse('2026-08-13T00:00:00.000Z') }
+      : undefined,
+  ),
   gitRaw: vi.fn((..._args: string[]): Buffer => Buffer.from('')),
   resolveMergeBase: vi.fn(
     (..._args: unknown[]): MergeBaseResult => ({
@@ -260,14 +271,21 @@ vi.mock('node:fs', async (importOriginal) => {
     ...actual,
     default: {
       ...actual,
-      mkdirSync: vi.fn(),
+      mkdirSync: producerMocks.mkdirSync,
       readFileSync: producerMocks.readFileSync,
       writeFileSync: producerMocks.writeFileSync,
+      statSync: statSyncThroughMock,
     },
-    mkdirSync: vi.fn(),
+    mkdirSync: producerMocks.mkdirSync,
     readFileSync: producerMocks.readFileSync,
     writeFileSync: producerMocks.writeFileSync,
+    statSync: statSyncThroughMock,
   };
+  function statSyncThroughMock(path?: unknown, ...rest: unknown[]) {
+    const mocked = producerMocks.statSync(path);
+    if (mocked !== undefined) return mocked;
+    return (actual.statSync as (...a: unknown[]) => unknown)(path, ...rest);
+  }
 });
 
 vi.mock('node:child_process', async (importOriginal) => {
@@ -319,6 +337,7 @@ vi.mock('./lib/git.js', () => ({
     return { out, status: out === null ? 1 : 0 };
   },
   gitRaw: producerMocks.gitRaw,
+  gitWithInput: vi.fn((): string => ''),
   refExists: producerMocks.refExists,
   releaseWorktree: producerMocks.releaseWorktree,
 }));
@@ -330,9 +349,43 @@ vi.mock('./lib/merge-base.js', () => ({
 // The ledger append is the wiring under test here, not the ledger itself
 // (run-ledger.test.ts owns that): a silently unwritten ledger would make a
 // later --resume find no prior sessions and re-run everything.
-vi.mock('./lib/run-ledger.js', () => ({
-  appendRunSession: vi.fn(),
-}));
+vi.mock('./lib/run-ledger.js', async (importOriginal) => {
+  // Take RESUME_MAX from the real module: hardcoding it here made the
+  // production constant unfalsifiable — changing it shipped this suite green.
+  const actual = await importOriginal<typeof import('./lib/run-ledger.js')>();
+  return {
+    ...actual,
+    appendRunSession: vi.fn(),
+    priorSessionIds: vi.fn(() => []),
+    sessionEntryCount: vi.fn(() => 1),
+    ledgerResumeCount: vi.fn(() => 0),
+    readResumeMarker: vi.fn(() => ({
+      schemaVersion: 1,
+      resumes: [],
+      restarts: [],
+    })),
+    recordResume: vi.fn(),
+    recordRestart: vi.fn(),
+  };
+});
+
+// The budget-hygiene branch runs in these tests; unmocked it performs REAL
+// filesystem deletes against the hardcoded report path's record dir, and
+// nothing could observe whether it ran.
+vi.mock('./lib/deadline.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./lib/deadline.js')>();
+  // Spread the real module so `DEADLINE_ENV` and the real deadline/round-cap
+  // wiring the report-assembly suite exercises pass through; stub only the
+  // budget-hygiene calls the resume suite asserts on. `hasReviewDeadline`
+  // stays real — it reads `DEADLINE_ENV`, which is unset in the resume tests,
+  // so it returns false there anyway.
+  return {
+    ...actual,
+    readBudgetStop: vi.fn(() => null),
+    clearBudgetStop: vi.fn(),
+    clearRoundStamps: vi.fn(),
+  };
+});
 vi.mock('./lib/diff-plan.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./lib/diff-plan.js')>();
   producerMocks.actualBuildDiffPlan = actual.buildDiffPlan as (
@@ -375,6 +428,7 @@ describe('fetch-pr report assembly', () => {
         headRefName: 'feat/x',
         headRefOid: 'f00df00df00d',
         baseRefName: 'main',
+        baseRefOid: 'ba5e0f0ba5e0',
         additions: 1,
         deletions: 0,
         changedFiles: 1,
@@ -1038,6 +1092,23 @@ describe('fetch-pr report assembly', () => {
     expect(report.auditSince).toBe('2020-01-01T00:00:00.000Z');
   });
 
+  it('does not inherit an extended-year forgery that sorts before today', async () => {
+    // `'+275760-09-13…'` parses to the maximum Date yet sorts
+    // lexicographically BEFORE any `'2026-…'` string — a string-compared
+    // bound inherited exactly the far-future forgery it exists to reject,
+    // and cleanup's `comments?since=<far future>` audit then returned
+    // nothing. The bound compares numerically.
+    producerMocks.readFileSync.mockReturnValue(
+      JSON.stringify({
+        prNumber: '42',
+        auditSince: '+275760-09-13T00:00:00.000Z',
+        fetchedAt: '+275760-09-13T00:00:00.000Z',
+      }),
+    );
+    const report = await reportFor({});
+    expect(report.auditSince).toBe(report.fetchedAt);
+  });
+
   it('does not inherit a window from a DIFFERENT PR left at the same path', async () => {
     producerMocks.readFileSync.mockReturnValue(
       JSON.stringify({
@@ -1145,6 +1216,7 @@ describe('fetch-pr report assembly', () => {
         headRefName: 'feat/x',
         headRefOid: 'f00df00df00d',
         baseRefName: 'main',
+        baseRefOid: 'ba5e0f0ba5e0',
         additions: 400,
         deletions: 100,
         changedFiles: 9,
@@ -1734,6 +1806,7 @@ describe('fetch-pr report assembly', () => {
         headRefName: 'feat/x',
         headRefOid: 'f00df00df00d',
         baseRefName: 'main',
+        baseRefOid: 'ba5e0f0ba5e0',
         additions: 800,
         deletions: 100,
         changedFiles: 9,
@@ -2121,6 +2194,7 @@ describe('fetch-pr report assembly', () => {
         headRefName: 'feat/x',
         headRefOid: 'f00df00df00d',
         baseRefName: 'main',
+        baseRefOid: 'ba5e0f0ba5e0',
         additions: 400,
         deletions: 100,
         changedFiles: 9,
@@ -3670,12 +3744,20 @@ describe('fetch-pr diff identity (diffSha256)', () => {
         headRefName: 'feat/x',
         headRefOid: 'f00df00df00d',
         baseRefName: 'main',
+        baseRefOid: 'ba5e0f0ba5e0',
         additions: 1,
         deletions: 0,
         changedFiles: 1,
         isCrossRepository: false,
         body: '',
       }),
+    );
+    // Self-containment: one test here matches a `resume` filter, and the
+    // shared buildDiffPlan delegation is otherwise installed only by a
+    // preceding describe's beforeEach — a filtered run of this suite alone
+    // partitioned with an implementation-less mock and crashed the report.
+    producerMocks.buildDiffPlan.mockImplementation((...a: unknown[]) =>
+      producerMocks.actualBuildDiffPlan(...a),
     );
   });
 
@@ -3808,6 +3890,7 @@ describe('fetch-pr run-session ledger wiring', () => {
         headRefName: 'feat/x',
         headRefOid: 'f00df00df00d',
         baseRefName: 'main',
+        baseRefOid: 'ba5e0f0ba5e0',
         additions: 1,
         deletions: 0,
         changedFiles: 1,
@@ -3859,5 +3942,841 @@ describe('fetch-pr run-session ledger wiring', () => {
     const writeOrder =
       producerMocks.writeFileSync.mock.invocationCallOrder[writeIndex];
     expect(appendOrder).toBeGreaterThan(writeOrder);
+  });
+});
+
+// The plan payload a genuine capture of the resume fixtures' diff records:
+// the ruling re-plans the re-derived bytes under this invocation's context
+// and compares the report field for field, so the fixture must carry what a
+// real fetch-pr wrote — built through the same functions, with the line
+// count the gitRaw mock answers every `git show` with (the diff's own five
+// lines).
+function resumePlanFields(diffBytes: string): Record<string, unknown> {
+  return buildPlanReport(buildDiffPlan(diffBytes, 400), () => 5, {
+    operatorRoundCap: operatorReviewSettings().reverseAuditRounds,
+    hasDeadline: hasReviewDeadline(process.env),
+  }) as unknown as Record<string, unknown>;
+}
+
+describe('fetch-pr --resume', () => {
+  const OUT = '/tmp/fetch-report.json';
+  const DIFF_BYTES = 'diff --git a/f b/f\n--- a/f\n+++ b/f\n@@ -1 +1 @@\n+x\n';
+
+  function prevReport(over: Record<string, unknown> = {}): string {
+    return JSON.stringify({
+      prNumber: '42',
+      ownerRepo: 'acme/widgets',
+      host: null,
+      fetchedSha: 'f00df00df00d',
+      diffSha256: createHash('sha256')
+        .update(Buffer.from(DIFF_BYTES))
+        .digest('hex'),
+      worktreePath: '.qwen/tmp/review-pr-42',
+      diffPathAbsolute: resolve(tmpFile('pr-42', 'diff.txt')),
+      mergeBaseSha: 'baseb45eb45e',
+      baseRefName: 'main',
+      baseRefOid: 'ba5e0f0ba5e0',
+      headRefName: 'feat/x',
+      baseFetchFailed: false,
+      auditSince: '2026-08-12T00:00:00.000Z',
+      fetchedAt: '2026-08-13T00:00:00.000Z',
+      prDescriptionHasHan: false,
+      isCrossRepository: false,
+      diffStat: { files: 1, additions: 1, deletions: 0 },
+      ...resumePlanFields(DIFF_BYTES),
+      ...over,
+    });
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // The path-switched fs: the previous report and the diff exist; every
+    // other read (resume marker, session ledger) is ENOENT.
+    producerMocks.readFileSync.mockImplementation((path?: unknown) => {
+      if (path === OUT) return prevReport();
+      if (String(path).endsWith('qwen-review-pr-42-diff.txt')) {
+        return Buffer.from(DIFF_BYTES) as unknown as string;
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+    producerMocks.git.mockImplementation((...args: string[]) =>
+      args[0] === 'rev-parse' ? 'f00df00df00d' : '',
+    );
+    producerMocks.gh.mockReturnValue(
+      JSON.stringify({
+        headRefName: 'feat/x',
+        headRefOid: 'f00df00df00d',
+        baseRefName: 'main',
+        baseRefOid: 'ba5e0f0ba5e0',
+        additions: 1,
+        deletions: 0,
+        changedFiles: 1,
+        isCrossRepository: false,
+        body: '',
+        headRefOidOnly: undefined,
+      }),
+    );
+    const { gitOpt, gitRaw } = await import('./lib/git.js');
+    // `status --porcelain` → clean; `ls-files -v` → ordinary tags; the
+    // identity probes agree on ONE repository; rev-parse → the fetched SHA.
+    vi.mocked(gitOpt).mockImplementation((...args: string[]) => {
+      if (args.includes('--others')) return '';
+      if (args.includes('ls-tree')) return '';
+      if (args.includes('config')) return '';
+      if (args.includes('merge-base')) return 'baseb45eb45e';
+      if (args.includes('status')) return '';
+      if (args.includes('ls-files')) return 'H f.txt';
+      if (args.includes('--git-common-dir')) return '/repo/.git';
+      if (args.includes('--git-dir')) {
+        return '/repo/.git/worktrees/review-pr-42';
+      }
+      return 'f00df00df00d';
+    });
+    // The re-derivation terms: a resolvable merge-base and a `git diff`
+    // whose bytes match the recorded capture.
+    const { resolveMergeBase } = await import('./lib/merge-base.js');
+    vi.mocked(resolveMergeBase).mockImplementation(() => ({
+      sha: 'baseb45eb45e',
+      baseFetchFailed: false,
+    }));
+    vi.mocked(gitRaw).mockImplementation((...args: string[]) =>
+      args.includes('ls-tree') || args.includes('cat-file')
+        ? Buffer.from('')
+        : Buffer.from(DIFF_BYTES),
+    );
+    // clearAllMocks resets call history but NOT implementations; re-assert
+    // the ledger defaults so a mockReturnValue set by one test cannot leak
+    // into the next — the same discipline the fs mock above follows.
+    const {
+      priorSessionIds,
+      readResumeMarker,
+      ledgerResumeCount,
+      sessionEntryCount,
+    } = await import('./lib/run-ledger.js');
+    vi.mocked(priorSessionIds).mockImplementation(() => []);
+    vi.mocked(ledgerResumeCount).mockImplementation(() => 0);
+    vi.mocked(sessionEntryCount).mockImplementation(() => 1);
+    vi.mocked(readResumeMarker).mockImplementation(() => ({
+      schemaVersion: 1,
+      resumes: [],
+      restarts: [],
+    }));
+    // Self-containment: a filtered run of ONLY this suite never executes the
+    // preceding describes' beforeEach, which is the only place the shared
+    // buildDiffPlan delegation is installed — clearAllMocks does not
+    // reinstall it. A refused resume falls through to the fresh path and
+    // partitions the diff, so the suite owns the implementation it consumes.
+    producerMocks.buildDiffPlan.mockImplementation((...a: unknown[]) =>
+      producerMocks.actualBuildDiffPlan(...a),
+    );
+    // The cap's marker term excludes THIS session, so these tests need a
+    // current session id for it to exclude. The lease gate (#9205) demands
+    // BOTH ids before any step runs.
+    vi.stubEnv('QWEN_CODE_SESSION_ID', 'S-test');
+    vi.stubEnv('QWEN_CODE_PROMPT_ID', 'P-test');
+  });
+
+  async function run(extraArgs: Record<string, unknown> = {}) {
+    const handler = fetchPrCommand.handler;
+    if (!handler) throw new Error('fetch-pr handler missing');
+    await handler({
+      _: [],
+      $0: 'qwen',
+      pr_number: '42',
+      owner_repo: 'acme/widgets',
+      remote: 'origin',
+      out: OUT,
+      maxChunkLines: 400,
+      resume: true,
+      ...extraArgs,
+    } as unknown as Parameters<typeof handler>[0]);
+  }
+
+  function reportWritten(): boolean {
+    return producerMocks.writeFileSync.mock.calls.some(
+      ([path]) => path === OUT,
+    );
+  }
+
+  async function stdoutJsonLines(): Promise<Array<Record<string, unknown>>> {
+    const { writeStdoutLine } = await import('../../utils/stdioHelpers.js');
+    return vi
+      .mocked(writeStdoutLine)
+      .mock.calls.map((c) => String(c[0]))
+      .filter((l) => l.startsWith('{'))
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+  }
+
+  it('resumes without touching the report when every probe matches', async () => {
+    await run();
+    expect(reportWritten()).toBe(false);
+    const lines = await stdoutJsonLines();
+    expect(lines).toEqual([
+      {
+        resumed: true,
+        resumeAttempt: 1,
+        restartsSpent: 0,
+        effort: 'high',
+        out: OUT,
+      },
+    ]);
+    const { recordResume, appendRunSession } = await import(
+      './lib/run-ledger.js'
+    );
+    expect(vi.mocked(recordResume)).toHaveBeenCalledWith(OUT);
+    expect(vi.mocked(appendRunSession)).toHaveBeenCalledWith(OUT);
+  });
+
+  it('falls through to a fresh fetch when the head moved, and says so', async () => {
+    producerMocks.gh.mockImplementation((...args: string[]) => {
+      if (args.includes('headRefOid') && !args.includes('headRefName')) {
+        return JSON.stringify({ headRefOid: 'aaaa1111bbbb' });
+      }
+      return JSON.stringify({
+        headRefName: 'feat/x',
+        headRefOid: 'aaaa1111bbbb',
+        baseRefName: 'main',
+        baseRefOid: 'ba5e0f0ba5e0',
+        additions: 1,
+        deletions: 0,
+        changedFiles: 1,
+        isCrossRepository: false,
+        body: '',
+      });
+    });
+    await run();
+    expect(reportWritten()).toBe(true);
+    const lines = await stdoutJsonLines();
+    expect(lines).toEqual([{ resumed: false, resumeRefused: 'head-moved' }]);
+    // The once-per-review restart bound becomes a fact on disk here.
+    const { recordRestart } = await import('./lib/run-ledger.js');
+    expect(vi.mocked(recordRestart)).toHaveBeenCalledWith(
+      OUT,
+      expect.stringContaining('head-moved'),
+    );
+  });
+
+  it('falls through when the diff bytes changed — the content key', async () => {
+    producerMocks.readFileSync.mockImplementation((path?: unknown) => {
+      if (path === OUT) return prevReport();
+      if (String(path).endsWith('qwen-review-pr-42-diff.txt')) {
+        return Buffer.from('tampered') as unknown as string;
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+    await run();
+    expect(reportWritten()).toBe(true);
+    const lines = await stdoutJsonLines();
+    expect(lines).toEqual([
+      { resumed: false, resumeRefused: 'diff-hash-mismatch' },
+    ]);
+  });
+
+  it('falls through when there is no previous report at all', async () => {
+    producerMocks.readFileSync.mockImplementation(() => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+    await run();
+    expect(reportWritten()).toBe(true);
+    const lines = await stdoutJsonLines();
+    expect(lines).toEqual([{ resumed: false, resumeRefused: 'no-report' }]);
+  });
+
+  it('without --resume the flag path never runs', async () => {
+    await run({ resume: false });
+    expect(reportWritten()).toBe(true);
+    expect(await stdoutJsonLines()).toEqual([]);
+  });
+
+  it('surfaces the recorded restart count to the resumed session', async () => {
+    const { readResumeMarker } = await import('./lib/run-ledger.js');
+    vi.mocked(readResumeMarker).mockReturnValue({
+      schemaVersion: 1,
+      resumes: [],
+      restarts: [{ atMs: Date.now(), reason: 'head-moved aaa->bbb' }],
+    });
+    await run();
+    const lines = await stdoutJsonLines();
+    expect(lines[0]['restartsSpent']).toBe(1);
+  });
+
+  it('cross-caps the resume count on the session ledger — a deleted marker does not reset it', async () => {
+    // Marker reads empty (deleted), but the ledger names three sessions:
+    // the original plus two resumes — two entries past the original, so the
+    // cap must read as spent.
+    // Read UNGATED: the gated accessor cannot answer at ruling time, because
+    // the record that satisfies its gate is written only after the ruling.
+    const { ledgerResumeCount } = await import('./lib/run-ledger.js');
+    // The ruling passes the CURRENT session for exclusion; a deleted-marker
+    // attack arrives as a session the ledger does not name, so nothing is
+    // excluded and the full count bites.
+    vi.mocked(ledgerResumeCount).mockImplementation(() => 2);
+    await run();
+    expect(reportWritten()).toBe(true);
+    const lines = await stdoutJsonLines();
+    expect(lines).toEqual([{ resumed: false, resumeRefused: 'resume-cap' }]);
+  });
+
+  it('refuses the ORIGINAL session at the cap on the backstop path', async () => {
+    // Ledger [S0 (original), S1, S2], marker deleted — the exact backstop
+    // state the ledger term exists for — and S0 itself resumes again. The
+    // exclusion already removed S0's entry, so the count answers 2; the old
+    // unconditional minus one read 1 and admitted a third resume through
+    // the cap's own backstop.
+    const { ledgerResumeCount } = await import('./lib/run-ledger.js');
+    vi.mocked(ledgerResumeCount).mockImplementation(() => 2);
+    await run();
+    const lines = await stdoutJsonLines();
+    expect(lines).toEqual([{ resumed: false, resumeRefused: 'resume-cap' }]);
+  });
+
+  it('spends the resume budget from the ledger, not one early', async () => {
+    // The ledger's first entry is the original run's own session, not a
+    // resume — so [original, resume1] is ONE resume spent, and RESUME_MAX = 2
+    // still allows this one. Counting the first entry reads it as two and
+    // refuses a legitimate continuation; the three-session case cannot see
+    // the difference, because there both counts rule alike.
+    const { ledgerResumeCount } = await import('./lib/run-ledger.js');
+    vi.mocked(ledgerResumeCount).mockImplementation(() => 1);
+    await run();
+    const lines = await stdoutJsonLines();
+    expect(lines[0]).toMatchObject({ resumed: true });
+  });
+
+  it('a same-session retry at the cap is the SAME resume in both terms', async () => {
+    // Sessions S0/S1/S2 all inside the fence (a resume never rewrites the
+    // plan), marker [S1, S2], current session S2 retrying: the ledger term
+    // must exclude S2 too — counting it pushed the retry to the cap, and
+    // the fresh fall-through force-removed the worktree being resumed.
+    const { readResumeMarker, ledgerResumeCount } = await import(
+      './lib/run-ledger.js'
+    );
+    vi.mocked(ledgerResumeCount).mockImplementation((_p, opts) =>
+      opts?.excludeSessionId?.toLowerCase() === 's-test' ? 1 : 2,
+    );
+    vi.mocked(readResumeMarker).mockReturnValue({
+      schemaVersion: 1,
+      resumes: [
+        { sessionId: 'S-prev', atMs: Date.now() },
+        { sessionId: 'S-test', atMs: Date.now() },
+      ],
+      restarts: [],
+    });
+    await run();
+    const lines = await stdoutJsonLines();
+    expect(lines[0]).toMatchObject({ resumed: true });
+  });
+
+  it('does not count the CURRENT session against its own resume cap', async () => {
+    // A same-session retry of the last permitted resume is that same resume —
+    // `recordResume` dedupes on exactly this. Counting the session's own
+    // marker entry refused the retry as `resume-cap`, and the fall-through
+    // then force-removed the worktree and rewrote the plan, fencing out every
+    // attempt's evidence: a review restarted from zero by a retry.
+    const { readResumeMarker } = await import('./lib/run-ledger.js');
+    vi.mocked(readResumeMarker).mockReturnValue({
+      schemaVersion: 1,
+      resumes: [
+        { sessionId: 'S-prev', atMs: Date.now() },
+        { sessionId: 'S-test', atMs: Date.now() },
+      ],
+      restarts: [],
+    });
+    await run();
+    const lines = await stdoutJsonLines();
+    expect(lines[0]).toMatchObject({ resumed: true });
+  });
+
+  it('asks git for untracked files EXPLICITLY, immune to user config', async () => {
+    // `status.showUntrackedFiles=no` hides untracked residue from a bare
+    // `--porcelain`, and untracked files are the one dirty state no other
+    // probe can see.
+    await run();
+    const { gitOpt } = await import('./lib/git.js');
+    const statusCall = vi
+      .mocked(gitOpt)
+      .mock.calls.find((c) => c.includes('status') && c.includes('-C'));
+    expect(statusCall).toContain('--untracked-files=normal');
+  });
+
+  it('refuses on an explicit effort different from the recorded run', async () => {
+    producerMocks.readFileSync.mockImplementation((path?: unknown) => {
+      if (path === OUT) return prevReport({ effort: 'medium' });
+      if (String(path).endsWith('qwen-review-pr-42-diff.txt')) {
+        return Buffer.from(DIFF_BYTES) as unknown as string;
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+    await run({ effort: 'high' });
+    expect(reportWritten()).toBe(true);
+    const lines = await stdoutJsonLines();
+    expect(lines).toEqual([
+      { resumed: false, resumeRefused: 'effort-mismatch' },
+    ]);
+  });
+
+  it('resumes at the recorded effort when none is passed, and says so', async () => {
+    producerMocks.readFileSync.mockImplementation((path?: unknown) => {
+      if (path === OUT) return prevReport({ effort: 'medium' });
+      if (String(path).endsWith('qwen-review-pr-42-diff.txt')) {
+        return Buffer.from(DIFF_BYTES) as unknown as string;
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+    await run();
+    const lines = await stdoutJsonLines();
+    expect(lines[0]['resumed']).toBe(true);
+    expect(lines[0]['effort']).toBe('medium');
+  });
+
+  it('falls through when the worktree holds uncommitted changes', async () => {
+    // Right HEAD, right diff bytes, moved content: this pipeline's own probe
+    // and build/test agents mutate worktrees, and a death between an apply
+    // and its revert leaves exactly this.
+    const { gitOpt } = await import('./lib/git.js');
+    vi.mocked(gitOpt).mockImplementation((...args: string[]) => {
+      if (args.includes('--others')) return '';
+      if (args.includes('ls-tree')) return '';
+      if (args.includes('config')) return '';
+      if (args.includes('merge-base')) return 'baseb45eb45e';
+      if (args.includes('status')) return ' M packages/cli/src/x.ts';
+      if (args.includes('ls-files')) return 'H f.txt';
+      if (args.includes('--git-common-dir')) return '/repo/.git';
+      if (args.includes('--git-dir')) {
+        return '/repo/.git/worktrees/review-pr-42';
+      }
+      return 'f00df00df00d';
+    });
+    await run();
+    expect(reportWritten()).toBe(true);
+    const lines = await stdoutJsonLines();
+    expect(lines).toEqual([
+      { resumed: false, resumeRefused: 'worktree-dirty' },
+    ]);
+  });
+
+  it('falls through when the captured diff is gone', async () => {
+    producerMocks.readFileSync.mockImplementation((path?: unknown) => {
+      if (path === OUT) return prevReport();
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+    await run();
+    const lines = await stdoutJsonLines();
+    expect(lines).toEqual([
+      { resumed: false, resumeRefused: 'diff-unreadable' },
+    ]);
+  });
+
+  it('falls through when the worktree is not at the fetched SHA', async () => {
+    const { gitOpt } = await import('./lib/git.js');
+    vi.mocked(gitOpt).mockImplementation((...args: string[]) => {
+      if (args.includes('--others')) return '';
+      if (args.includes('ls-tree')) return '';
+      if (args.includes('config')) return '';
+      if (args.includes('merge-base')) return 'baseb45eb45e';
+      if (args.includes('status')) return '';
+      if (args.includes('ls-files')) return 'H f.txt';
+      if (args.includes('--git-common-dir')) return '/repo/.git';
+      if (args.includes('--git-dir')) {
+        return '/repo/.git/worktrees/review-pr-42';
+      }
+      return 'someothersha';
+    });
+    await run();
+    expect(reportWritten()).toBe(true);
+    const lines = await stdoutJsonLines();
+    expect(lines).toEqual([
+      { resumed: false, resumeRefused: 'worktree-sha-mismatch' },
+    ]);
+  });
+
+  // -- The report is attempt-1-writable: every field the resumed pipeline
+  // -- consumes is compared against a fact this run derives itself. Each
+  // -- test forges ONE field and expects the refusal that names it.
+
+  it('does NOT refuse ordinary ignored build artifacts — node_modules is expected', async () => {
+    // The residue probe respects `.gitignore` (`--exclude-standard`): a
+    // resume after `npm install` left node_modules must not read as tamper.
+    const { gitOpt } = await import('./lib/git.js');
+    vi.mocked(gitOpt).mockImplementation((...args: string[]) => {
+      // The unexcluded pathspec listing (planted .gitignore probe) and the
+      // exclude-standard residue listing both come back empty; node_modules
+      // is ignored, so exclude-standard omits it.
+      if (args.includes('--others')) return '';
+      if (args.includes('ls-tree')) return '';
+      if (args.includes('config')) return '';
+      if (args.includes('merge-base')) return 'baseb45eb45e';
+      if (args.includes('status')) return '';
+      if (args.includes('ls-files')) return 'H f.txt';
+      if (args.includes('--git-common-dir')) return '/repo/.git';
+      if (args.includes('--git-dir')) {
+        return '/repo/.git/worktrees/review-pr-42';
+      }
+      return 'f00df00df00d';
+    });
+    await run();
+    expect(reportWritten()).toBe(false);
+    expect(await stdoutJsonLines()).toEqual([
+      {
+        resumed: true,
+        resumeAttempt: 1,
+        restartsSpent: 0,
+        effort: 'high',
+        out: OUT,
+      },
+    ]);
+  });
+
+  it('keeps a round-cap stop and its stamps on a continuation', async () => {
+    // A round-cap stop is the trusted CLI's own record that the audit reached
+    // its round cap — not a stale time-budget stop — so the continuation
+    // keeps it and the stamps that price its rounds rather than clearing them.
+    const { readBudgetStop, clearBudgetStop, clearRoundStamps } = await import(
+      './lib/deadline.js'
+    );
+    vi.mocked(readBudgetStop).mockReturnValue({
+      cause: 'round-cap',
+      cap: 5,
+      entry: 'round cap',
+      entryZh: '轮数上限',
+      round: 5,
+      remainingSeconds: 0,
+      reserveSeconds: 0,
+      atMs: Date.now(),
+    });
+    await run();
+    expect(vi.mocked(clearBudgetStop)).not.toHaveBeenCalled();
+    expect(vi.mocked(clearRoundStamps)).not.toHaveBeenCalled();
+  });
+});
+
+describe('fetch-pr --resume bookkeeping is counted, not merely called', () => {
+  const OUT = '/tmp/fetch-report.json';
+  const DIFF_BYTES = 'diff --git a/f b/f\n--- a/f\n+++ b/f\n@@ -1 +1 @@\n+x\n';
+
+  function prevReport(over: Record<string, unknown> = {}): string {
+    return JSON.stringify({
+      prNumber: '42',
+      ownerRepo: 'acme/widgets',
+      host: null,
+      fetchedSha: 'f00df00df00d',
+      diffSha256: createHash('sha256')
+        .update(Buffer.from(DIFF_BYTES))
+        .digest('hex'),
+      worktreePath: '.qwen/tmp/review-pr-42',
+      diffPathAbsolute: resolve(tmpFile('pr-42', 'diff.txt')),
+      mergeBaseSha: 'baseb45eb45e',
+      baseRefName: 'main',
+      baseRefOid: 'ba5e0f0ba5e0',
+      headRefName: 'feat/x',
+      baseFetchFailed: false,
+      auditSince: '2026-08-12T00:00:00.000Z',
+      fetchedAt: '2026-08-13T00:00:00.000Z',
+      prDescriptionHasHan: false,
+      isCrossRepository: false,
+      diffStat: { files: 1, additions: 1, deletions: 0 },
+      ...resumePlanFields(DIFF_BYTES),
+      ...over,
+    });
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    producerMocks.readFileSync.mockImplementation((path?: unknown) => {
+      if (path === OUT) return prevReport();
+      if (String(path).endsWith('qwen-review-pr-42-diff.txt')) {
+        return Buffer.from(DIFF_BYTES) as unknown as string;
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+    producerMocks.git.mockImplementation((...args: string[]) =>
+      args[0] === 'rev-parse' ? 'f00df00df00d' : '',
+    );
+    producerMocks.gh.mockReturnValue(
+      JSON.stringify({
+        headRefName: 'feat/x',
+        headRefOid: 'f00df00df00d',
+        baseRefName: 'main',
+        baseRefOid: 'ba5e0f0ba5e0',
+        additions: 1,
+        deletions: 0,
+        changedFiles: 1,
+        isCrossRepository: false,
+        body: '',
+      }),
+    );
+    const { gitOpt } = await import('./lib/git.js');
+    // `status --porcelain` → clean; `ls-files -v` → ordinary tags; the
+    // identity probes agree on ONE repository; rev-parse → the fetched SHA.
+    vi.mocked(gitOpt).mockImplementation((...args: string[]) => {
+      if (args.includes('--others')) return '';
+      if (args.includes('ls-tree')) return '';
+      if (args.includes('config')) return '';
+      if (args.includes('merge-base')) return 'baseb45eb45e';
+      if (args.includes('status')) return '';
+      if (args.includes('ls-files')) return 'H f.txt';
+      if (args.includes('--git-common-dir')) return '/repo/.git';
+      if (args.includes('--git-dir')) {
+        return '/repo/.git/worktrees/review-pr-42';
+      }
+      return 'f00df00df00d';
+    });
+    const {
+      priorSessionIds,
+      readResumeMarker,
+      ledgerResumeCount,
+      sessionEntryCount,
+    } = await import('./lib/run-ledger.js');
+    vi.mocked(priorSessionIds).mockImplementation(() => []);
+    vi.mocked(ledgerResumeCount).mockImplementation(() => 0);
+    vi.mocked(sessionEntryCount).mockImplementation(() => 1);
+    vi.mocked(readResumeMarker).mockImplementation(() => ({
+      schemaVersion: 1,
+      resumes: [],
+      restarts: [],
+    }));
+    // Self-containment, the same reason as the first resume suite: these
+    // re-derivation probes and the partitioner are installed only by
+    // preceding describes' beforeEach in a full-file run; a filtered run of
+    // this suite must install them itself.
+    const { resolveMergeBase } = await import('./lib/merge-base.js');
+    vi.mocked(resolveMergeBase).mockImplementation(() => ({
+      sha: 'baseb45eb45e',
+      baseFetchFailed: false,
+    }));
+    const { gitRaw } = await import('./lib/git.js');
+    vi.mocked(gitRaw).mockImplementation((...args: string[]) =>
+      args.includes('ls-tree') || args.includes('cat-file')
+        ? Buffer.from('')
+        : Buffer.from(DIFF_BYTES),
+    );
+    producerMocks.buildDiffPlan.mockImplementation((...a: unknown[]) =>
+      producerMocks.actualBuildDiffPlan(...a),
+    );
+    // The cap's marker term excludes THIS session, so these tests need a
+    // current session id for it to exclude. The lease gate (#9205) demands
+    // BOTH ids before any step runs.
+    vi.stubEnv('QWEN_CODE_SESSION_ID', 'S-test');
+    vi.stubEnv('QWEN_CODE_PROMPT_ID', 'P-test');
+  });
+
+  async function run(extra: Record<string, unknown> = {}) {
+    const handler = fetchPrCommand.handler;
+    if (!handler) throw new Error('fetch-pr handler missing');
+    await handler({
+      _: [],
+      $0: 'qwen',
+      pr_number: '42',
+      owner_repo: 'acme/widgets',
+      remote: 'origin',
+      out: OUT,
+      maxChunkLines: 400,
+      resume: true,
+      ...extra,
+    } as unknown as Parameters<typeof handler>[0]);
+  }
+
+  it('writes the resume bookkeeping exactly once, and only on a continuation', async () => {
+    const { appendRunSession, recordResume, recordRestart } = await import(
+      './lib/run-ledger.js'
+    );
+    await run();
+    expect(vi.mocked(recordResume)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(appendRunSession)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(recordRestart)).not.toHaveBeenCalled();
+  });
+
+  it('records nothing when the resume is refused', async () => {
+    // Hoisting the bookkeeping above the ruling shipped green before this.
+    const { recordResume } = await import('./lib/run-ledger.js');
+    const { gitOpt } = await import('./lib/git.js');
+    vi.mocked(gitOpt).mockImplementation((...args: string[]) =>
+      args.includes('status') ? '' : 'someothersha',
+    );
+    await run();
+    expect(vi.mocked(recordResume)).not.toHaveBeenCalled();
+  });
+
+  it('records a restart ONLY for head movement, not for any refusal', async () => {
+    const { recordRestart } = await import('./lib/run-ledger.js');
+    const { gitOpt } = await import('./lib/git.js');
+    vi.mocked(gitOpt).mockImplementation((...args: string[]) =>
+      args.includes('status') ? ' M src/x.ts' : 'f00df00df00d',
+    );
+    await run();
+    expect(vi.mocked(recordRestart)).not.toHaveBeenCalled();
+  });
+
+  it('honours the marker term of the cap independently of the ledger', async () => {
+    const { readResumeMarker } = await import('./lib/run-ledger.js');
+    vi.mocked(readResumeMarker).mockReturnValue({
+      schemaVersion: 1,
+      resumes: [
+        { sessionId: 'A', atMs: 1 },
+        { sessionId: 'B', atMs: 2 },
+      ],
+      restarts: [],
+    });
+    await run();
+    const { writeStdoutLine } = await import('../../utils/stdioHelpers.js');
+    const lines = vi
+      .mocked(writeStdoutLine)
+      .mock.calls.map((c) => String(c[0]))
+      .filter((l) => l.startsWith('{'))
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+    expect(lines).toEqual([{ resumed: false, resumeRefused: 'resume-cap' }]);
+  });
+
+  it('numbers the attempt from the marker AFTER the write', async () => {
+    // recordResume deduplicates by session, so a second --resume in the same
+    // session is the same resume — not attempt 2.
+    const { readResumeMarker } = await import('./lib/run-ledger.js');
+    vi.mocked(readResumeMarker).mockReturnValue({
+      schemaVersion: 1,
+      resumes: [{ sessionId: 'S-current', atMs: 1 }],
+      restarts: [],
+    });
+    await run();
+    const { writeStdoutLine } = await import('../../utils/stdioHelpers.js');
+    const line = JSON.parse(
+      vi
+        .mocked(writeStdoutLine)
+        .mock.calls.map((c) => String(c[0]))
+        .filter((l) => l.startsWith('{'))[0],
+    ) as Record<string, unknown>;
+    expect(line['resumeAttempt']).toBe(1);
+  });
+
+  it('runs the budget hygiene on a continuation, and only there', async () => {
+    const { clearRoundStamps, clearBudgetStop, readBudgetStop } = await import(
+      './lib/deadline.js'
+    );
+    vi.mocked(readBudgetStop).mockReturnValue({
+      cause: 'time-budget',
+      entry: 'stopped',
+      entryZh: '停止',
+      round: 3,
+      remainingSeconds: 10,
+      reserveSeconds: 4800,
+      atMs: Date.now(),
+    });
+    await run();
+    expect(vi.mocked(clearRoundStamps)).toHaveBeenCalledWith(OUT);
+    expect(vi.mocked(clearBudgetStop)).toHaveBeenCalledWith(OUT);
+  });
+
+  it('keeps a round-cap stop across the resume', async () => {
+    // A round-cap stop is about rounds, not time — it is the interrupted
+    // attempt's genuine record that the audit reached its cap, so it survives
+    // the continuation untouched.
+    const { clearBudgetStop, readBudgetStop } = await import(
+      './lib/deadline.js'
+    );
+    vi.mocked(readBudgetStop).mockReturnValue({
+      cause: 'round-cap',
+      cap: 5,
+      entry: 'round cap',
+      entryZh: '轮数上限',
+      round: 5,
+      remainingSeconds: 900,
+      reserveSeconds: 1200,
+      atMs: Date.now(),
+    });
+    await run();
+    expect(vi.mocked(clearBudgetStop)).not.toHaveBeenCalled();
+  });
+
+  it('keeps a round-cap stop AND its stamps across TWO resumes', async () => {
+    // Real stamp files: a round-cap stop and the stamps that price its rounds
+    // must both survive every resume, or resume 2 reads an empty set and
+    // silently reprices the exhausted cap — the exact population RESUME_MAX
+    // exists for.
+    const actualDeadline =
+      await vi.importActual<typeof import('./lib/deadline.js')>(
+        './lib/deadline.js',
+      );
+    const realFs = await vi.importActual<typeof import('node:fs')>('node:fs');
+    const recordDir = `${OUT.replace(/\.json$/, '')}-prompts`;
+    const routeRecordDirToDisk = (): void => {
+      producerMocks.readFileSync.mockImplementation((path?: unknown) => {
+        if (String(path).startsWith(recordDir)) {
+          return realFs.readFileSync(String(path), 'utf8');
+        }
+        if (path === OUT) return prevReport();
+        if (String(path).endsWith('qwen-review-pr-42-diff.txt')) {
+          return Buffer.from(DIFF_BYTES) as unknown as string;
+        }
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      });
+      producerMocks.writeFileSync.mockImplementation(
+        (path: unknown, data: unknown) => {
+          if (String(path).startsWith(recordDir)) {
+            realFs.writeFileSync(String(path), String(data));
+          }
+        },
+      );
+      producerMocks.mkdirSync.mockImplementation((dir: unknown) => {
+        if (String(dir).startsWith(recordDir)) {
+          realFs.mkdirSync(String(dir), { recursive: true });
+        }
+      });
+    };
+    const { readBudgetStop, clearBudgetStop, clearRoundStamps } = await import(
+      './lib/deadline.js'
+    );
+    try {
+      routeRecordDirToDisk();
+      vi.mocked(readBudgetStop).mockImplementation(() =>
+        actualDeadline.readBudgetStop(OUT),
+      );
+      vi.mocked(clearBudgetStop).mockImplementation(() =>
+        actualDeadline.clearBudgetStop(OUT),
+      );
+      vi.mocked(clearRoundStamps).mockImplementation(() =>
+        actualDeadline.clearRoundStamps(OUT),
+      );
+      // Attempt 1 exhausted the round cap: stamps 1..2 and the stop marker.
+      const now = Date.now();
+      actualDeadline.stampRound(OUT, 1, now);
+      actualDeadline.stampRound(OUT, 2, now + 1000);
+      actualDeadline.writeRoundCapStop(OUT, 2, 2, now + 2000);
+
+      await run();
+      const stampsFile = `${recordDir}/budget-rounds.json`;
+      // Resume 1 kept the stop — and the stamps that price its rounds.
+      expect(actualDeadline.readBudgetStop(OUT)).not.toBeNull();
+      expect(realFs.existsSync(stampsFile)).toBe(true);
+
+      // The resumed run dies again — the exact population RESUME_MAX exists
+      // for — and resume 2 re-reads the same state.
+      await run();
+      expect(vi.mocked(clearBudgetStop)).not.toHaveBeenCalled();
+      expect(actualDeadline.readBudgetStop(OUT)).not.toBeNull();
+
+      const { writeStdoutLine } = await import('../../utils/stdioHelpers.js');
+      const lines = vi
+        .mocked(writeStdoutLine)
+        .mock.calls.map((c) => String(c[0]))
+        .filter((l) => l.startsWith('{'))
+        .map((l) => JSON.parse(l) as Record<string, unknown>);
+      expect(lines).toEqual([
+        {
+          resumed: true,
+          resumeAttempt: 1,
+          restartsSpent: 0,
+          effort: 'high',
+          out: OUT,
+        },
+        {
+          resumed: true,
+          resumeAttempt: 1,
+          restartsSpent: 0,
+          effort: 'high',
+          out: OUT,
+        },
+      ]);
+    } finally {
+      realFs.rmSync(recordDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/cli/src/commands/review/fetch-pr.ts
+++ b/packages/cli/src/commands/review/fetch-pr.ts
@@ -40,6 +40,7 @@ import {
 } from '../../services/review-worktree-lease.js';
 import { setGhHost } from './lib/gh.js';
 import { getPlatformReader } from './lib/platform/registry.js';
+import type { ReviewPlatformReader } from './lib/platform/types.js';
 import type { ReviewEffort } from './parse-args.js';
 import {
   git,
@@ -71,9 +72,26 @@ import {
 } from './lib/report.js';
 import { resolveMergeBase, type GitProbe } from './lib/merge-base.js';
 import { operatorReviewSettings } from './lib/review-settings.js';
-import { hasReviewDeadline } from './lib/deadline.js';
-import { appendRunSession } from './lib/run-ledger.js';
 import { SHA_RE } from './lib/ledger.js';
+import {
+  appendRunSession,
+  ledgerResumeCount,
+  readResumeMarker,
+  recordResume,
+  recordRestart,
+  RESUME_MAX,
+} from './lib/run-ledger.js';
+import {
+  assessResume,
+  type PreviousReport,
+  type ResumeRefusal,
+} from './lib/resume.js';
+import {
+  hasReviewDeadline,
+  readBudgetStop,
+  clearBudgetStop,
+  clearRoundStamps,
+} from './lib/deadline.js';
 import { certifierMatchesRound, roundModelIdFrom } from './lib/round-model.js';
 
 interface PrMetadata {
@@ -103,6 +121,15 @@ interface FetchPrArgs {
    * array and the recovery flow can produce one; `runFetchPr` normalizes.
    */
   since?: string | string[];
+  /**
+   * Continue the interrupted run at this plan path when its state still
+   * matches (worktree at `fetchedSha`, diff bytes unhashed-unchanged, live
+   * head unmoved): keep the worktree, do NOT rewrite the plan — its mtime is
+   * the run epoch every fence keys on — and re-announce the existing report.
+   * When the state does not match, fall through to a fresh fetch; the flag
+   * never fails a run that could start over.
+   */
+  resume?: boolean;
   /**
    * WHO certified the `--since` anchor: the `lastModelId` beside it in the
    * cache, or the `model` beside the marker's `sha`. Copied through verbatim
@@ -663,7 +690,8 @@ const gitProbe: GitProbe = {
       `+refs/heads/${ref}:refs/remotes/${remote}/${ref}`,
     ) !== null && refExists(`refs/remotes/${remote}/${ref}`),
   refExists,
-  mergeBase: (a, b) => gitOpt('merge-base', a, b),
+  mergeBase: (a, b) =>
+    gitOpt('-c', 'core.commitGraph=false', 'merge-base', a, b),
 };
 
 function tryRemove(action: () => void): void {
@@ -682,6 +710,144 @@ function cleanStale(prNumber: string): void {
       execFileSync('git', ['branch', '-D', ref], { stdio: 'pipe' }),
     );
   }
+}
+
+/** sha256 of a file's raw bytes, or null when it cannot be read. */
+function sha256OfFile(path: string): string | null {
+  try {
+    return createHash('sha256').update(readFileSync(path)).digest('hex');
+  } catch {
+    return null;
+  }
+}
+
+type ResumeOutcome =
+  | { resumed: true }
+  | { resumed: false; reason: ResumeRefusal; priorFetchedSha: string | null };
+
+/**
+ * The `--resume` fast path: rule on the interrupted attempt's state and, when
+ * it holds, continue it — every probe is a fact this command gathers itself
+ * (git, gh, file hashes, the CLI-written marker), never the orchestrator's
+ * account. On a continuation the plan file is NOT touched: its mtime is the
+ * run epoch that keeps the first attempt's records, stamps and transcripts
+ * inside every reader's fence.
+ */
+function tryResume(
+  args: FetchPrArgs,
+  wt: string,
+  platform: ReviewPlatformReader,
+): ResumeOutcome {
+  const { pr_number: prNumber, owner_repo: ownerRepo, out } = args;
+  let prev: PreviousReport | null = null;
+  try {
+    prev = JSON.parse(readFileSync(out, 'utf8')) as PreviousReport;
+  } catch {
+    prev = null;
+  }
+  // An unreachable forge reads as "unmoved": the worktree and diff hashes
+  // pin the content, and presubmit's headDrift re-checks before anything
+  // posts. Only the live head OID is needed — a moved head is the one
+  // upstream change resume refuses. The read goes through the same platform
+  // reader the fresh path uses, so an Aone clone resolves the same way.
+  let liveHeadSha: string | null = null;
+  try {
+    const oid = platform.getFetchMeta(Number(prNumber), ownerRepo).headRefOid;
+    liveHeadSha = typeof oid === 'string' && oid !== '' ? oid : null;
+  } catch {
+    liveHeadSha = null;
+  }
+  // The resume cap: how many times this review has already been resumed.
+  // Both counters are the CLI's own record; the marker is primary and the
+  // session ledger cross-caps it, minus the original run's own first entry.
+  const marker = readResumeMarker(out);
+  const currentSessionId = process.env['QWEN_CODE_SESSION_ID']?.trim();
+  const ledgerResumes = ledgerResumeCount(out, {
+    excludeSessionId: currentSessionId,
+  });
+  const currentKey = currentSessionId?.toLowerCase();
+  const markerResumes = marker.resumes.filter(
+    (r) => r.sessionId.toLowerCase() !== currentKey,
+  ).length;
+  // `--porcelain` prints nothing on a clean tree; a null (the command could
+  // not run) is treated as dirty. `--untracked-files=normal` explicitly, so
+  // a `status.showUntrackedFiles=no` tuning cannot hide residue that is not
+  // in the PR.
+  const status = gitOpt(
+    '-C',
+    wt,
+    'status',
+    '--porcelain',
+    '--untracked-files=normal',
+  );
+  const ruling = assessResume(prev, {
+    prNumber,
+    worktreeHeadSha: gitOpt('-C', wt, 'rev-parse', 'HEAD'),
+    worktreeClean: status === null ? null : status.trim() === '',
+    diffSha256OnDisk: sha256OfFile(tmpFile(`pr-${prNumber}`, 'diff.txt')),
+    liveHeadSha,
+    resumeCount: Math.max(markerResumes, ledgerResumes),
+    requestedEffort: args.effort ?? null,
+  });
+  if (!ruling.ok) {
+    return {
+      resumed: false,
+      reason: ruling.reason,
+      priorFetchedSha:
+        prev !== null && typeof prev.fetchedSha === 'string'
+          ? prev.fetchedSha
+          : null,
+    };
+  }
+
+  // Budget hygiene: the continuation runs under a fresh deadline, so a
+  // time-budget stop is the dead attempt's, not this run's, and is cleared.
+  // A round-cap stop is about rounds, not time — it is the trusted CLI's own
+  // record that the audit reached its round cap, so it stands, and the round
+  // stamps stay with it. Any other stop is cleared with the stamps: the span
+  // from the dead attempt's last stamp to the continuation's first admission
+  // spans the death gap and would price a round at hours; without the stamps
+  // the gate falls back to its conservative constant.
+  const stop = readBudgetStop(out);
+  const roundCapStands = stop !== null && stop.cause === 'round-cap';
+  if (stop !== null && !roundCapStands) {
+    clearBudgetStop(out);
+  }
+  if (!roundCapStands) {
+    clearRoundStamps(out);
+  }
+  appendRunSession(out);
+  recordResume(out);
+  // Read the marker back: `recordResume` deduplicates by session, so a
+  // second `--resume` in the SAME session is the same resume, and deriving
+  // the number from the pre-write count would announce attempt 2 for it.
+  const attempt = Math.max(1, readResumeMarker(out).resumes.length);
+  // `restartsSpent` is the resume marker's ONE consumer beyond idempotency:
+  // the resumed session initialises Step 7's once-per-review restart bound
+  // from it — without a reader here, the recorded restart would silently
+  // reset on every resume. `effort` names the level the continuation is
+  // pinned to (the plan's, deliberately untouched), so a continuation never
+  // silently runs at a level the caller did not expect.
+  const pinnedEffort =
+    prev !== null && typeof prev.effort === 'string' && prev.effort !== ''
+      ? prev.effort
+      : 'high';
+  writeStdoutLine(
+    JSON.stringify({
+      resumed: true,
+      resumeAttempt: attempt,
+      restartsSpent: marker.restarts.length,
+      effort: pinnedEffort,
+      out,
+    }),
+  );
+  writeStderrLine(
+    `Resumed PR #${prNumber} review (resume ${attempt} of ${RESUME_MAX}): ` +
+      `worktree, plan and the interrupted attempt's agent evidence are reused; ` +
+      `the report at ${out} is unchanged, and the run continues at its ` +
+      `recorded effort (${pinnedEffort}).`,
+  );
+  return { resumed: true };
 }
 
 async function runFetchPr(args: FetchPrArgs): Promise<void> {
@@ -790,6 +956,31 @@ async function runFetchPr(args: FetchPrArgs): Promise<void> {
     }
     const platform = getPlatformReader({ remoteUrl, host: args.host?.trim() });
     platform.ensureAuthenticated();
+
+    // A `--resume` rules before any destructive step: a continuation must
+    // reach neither the cleanup below (the worktree is the state being
+    // resumed) nor the plan write (its mtime is the run epoch). Platform
+    // detection above is non-destructive and gives the resume probe's forge
+    // read its auth. The lease already covers the resumed run — a
+    // continuation keeps working in this worktree after this command
+    // returns, and cleanup releases the lease with the rest. A refused
+    // resume falls through to the fresh path and announces why; head
+    // movement is recorded AFTER the fresh plan lands, so the marker entry
+    // postdates the new epoch.
+    let resumeRefusal: ResumeRefusal | null = null;
+    let priorFetchedSha: string | null = null;
+    if (args.resume) {
+      const outcome = tryResume(args, wt, platform);
+      if (outcome.resumed) return;
+      resumeRefusal = outcome.reason;
+      priorFetchedSha = outcome.priorFetchedSha;
+      writeStdoutLine(
+        JSON.stringify({ resumed: false, resumeRefused: outcome.reason }),
+      );
+      writeStderrLine(
+        `Cannot resume PR #${prNumber} (${outcome.reason}); starting a fresh review.`,
+      );
+    }
 
     // 1. Clean any stale worktree / branch from an earlier run.
     cleanStale(prNumber);
@@ -1372,8 +1563,12 @@ async function runFetchPr(args: FetchPrArgs): Promise<void> {
           // attempt, never forward. A corrupted far-future `auditSince`
           // (`"2099-…"`) is therefore rejected here — it would push the window
           // ahead of every real comment and silently report a clean audit.
-          // (ISO-8601 strings from `toISOString()` compare chronologically.)
-          prevSince < auditSince
+          // Compared NUMERICALLY: `toISOString()` output happens to sort
+          // chronologically, but a forged extended-year form
+          // (`"+275760-…"`) parses to the far future while sorting
+          // lexicographically BEFORE any `"2026-…"` string — a string
+          // comparison inherits exactly the forgery this bound rejects.
+          Date.parse(prevSince) < Date.parse(auditSince)
         ) {
           auditSince = prevSince;
         }
@@ -1491,6 +1686,14 @@ async function runFetchPr(args: FetchPrArgs): Promise<void> {
     // reads the ledger to find this attempt's transcripts. After the plan
     // write, so the entry sits inside the run-epoch fence it is read through.
     appendRunSession(out);
+    if (resumeRefusal === 'head-moved') {
+      // The once-per-review restart bound, now a fact on disk. Recorded after
+      // the plan write for the same fence reason as the session entry.
+      recordRestart(
+        out,
+        `head-moved ${priorFetchedSha?.slice(0, 7) ?? 'unknown'}->${fetchedSha.slice(0, 7)}`,
+      );
+    }
     writeStdoutLine(`Wrote fetch-pr report to ${out}`);
     if (diffPath) writeStdoutLine(`Wrote review diff to ${diffPath}`);
     // Surface diff stats to stderr so a human running the command interactively
@@ -1684,6 +1887,12 @@ export const fetchPrCommand: CommandModule = {
         default: DEFAULT_MAX_CHUNK_LINES,
         describe:
           'Target size, in diff lines, of each review chunk. A chunk boundary falls on a hunk boundary; a hunk larger than this is split only at a top-level declaration, never inside a function.',
+      })
+      .option('resume', {
+        type: 'boolean',
+        default: false,
+        describe:
+          'Continue an interrupted run of this PR when its on-disk state still matches (worktree at the fetched SHA, diff bytes unchanged, PR head unmoved): keep the worktree, leave the plan untouched, and print {"resumed":true}. Falls through to a normal fresh fetch — printing {"resumed":false,"resumeRefused":"<reason>"} — whenever the state does not match.',
       })
       .option('effort', {
         type: 'string',

--- a/packages/cli/src/commands/review/lib/coverage.ts
+++ b/packages/cli/src/commands/review/lib/coverage.ts
@@ -281,7 +281,7 @@ const DIGEST_WINDOW_MS = 5000;
 export const CHUNK_RE = /\bchunk\s+(\d+)\s+of\s+\d+\b/i;
 
 /** The chunk this agent owns, when it was launched to own one. */
-function assignedChunk(rec: AgentRecord): number | null {
+export function assignedChunk(rec: AgentRecord): number | null {
   const m = CHUNK_RE.exec(rec.launchPrompt);
   return m ? Number(m[1]) : null;
 }
@@ -295,7 +295,10 @@ function assignedChunk(rec: AgentRecord): number | null {
  * recoverable from the harness's own copy of its launch prompt, in either
  * topology, without the agent having to claim anything afterwards.
  */
-function pointedAt(prompt: string, plan: Plan): Array<[number, number]> {
+export function pointedAt(
+  prompt: string,
+  plan: { chunks: Array<{ id: number; startLine: number; endLine: number }> },
+): Array<[number, number]> {
   const out: Array<[number, number]> = [];
   const re = /offset\s*[=:]\s*(\d+)\s*,\s*limit\s*[=:]\s*(\d+)/gi;
   for (const m of prompt.matchAll(re)) {

--- a/packages/cli/src/commands/review/lib/deadline.test.ts
+++ b/packages/cli/src/commands/review/lib/deadline.test.ts
@@ -28,6 +28,7 @@ import {
   budgetStopEntry,
   budgetStopEntryZh,
   clearBudgetStop,
+  clearRoundStamps,
   expectedAdmissionSeconds,
   expectedRoundSeconds,
   readBudgetStop,
@@ -884,5 +885,32 @@ describe('verifyBudgetExhausted — the compose floor the verifier answers to', 
       composeFloorSeconds: DEFAULT_COMPOSE_FLOOR_SECONDS,
     });
     expect(msg).toContain('0 minute(s) remain');
+  });
+});
+
+describe('clearRoundStamps — the resume hygiene', () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  });
+  function plan(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'deadline-clear-'));
+    dirs.push(dir);
+    const p = join(dir, 'plan.json');
+    writeFileSync(p, '{}');
+    backdatePlan(p);
+    return p;
+  }
+
+  it('removes the stamps so the gate falls back to its constant', () => {
+    const p = plan();
+    stampRound(p, 1, NOW_MS - 2_400_000);
+    expect(expectedRoundSeconds(p, 2, NOW_MS)).toBe(2400);
+    clearRoundStamps(p);
+    expect(expectedRoundSeconds(p, 2, NOW_MS)).toBe(DEFAULT_ROUND_SECONDS);
+  });
+
+  it('is silent when there is nothing to remove', () => {
+    expect(() => clearRoundStamps(plan())).not.toThrow();
   });
 });

--- a/packages/cli/src/commands/review/lib/deadline.ts
+++ b/packages/cli/src/commands/review/lib/deadline.ts
@@ -726,6 +726,23 @@ export function clearBudgetStop(planPath: string): void {
 }
 
 /**
+ * Remove the admission stamps beside the prompt records. Called by the
+ * `--resume` path in `fetch-pr`: the span from the interrupted attempt's last
+ * stamp to the continuation's first admission contains the death gap and the
+ * retry backoff, which would price a "round" at hours and refuse round 1 of a
+ * fresh deadline. Without stamps the gate falls back to its conservative
+ * constant — the failure direction is an early stop with a disclosure, never
+ * a kill-before-compose. Errors are swallowed like `clearBudgetStop`'s.
+ */
+export function clearRoundStamps(planPath: string): void {
+  try {
+    rmSync(join(promptRecordDir(planPath), STAMPS_FILE), { force: true });
+  } catch {
+    // Best-effort: stale stamps only make the gate MORE conservative.
+  }
+}
+
+/**
  * The refusal, spelled as the termination rule it is. Printed to stderr by
  * `agent-prompt` alongside exit code 4; the disclosure sentence matches the
  * `budget-stop.json` marker byte for byte, so both channels cap the verdict

--- a/packages/cli/src/commands/review/lib/resume.test.ts
+++ b/packages/cli/src/commands/review/lib/resume.test.ts
@@ -1,0 +1,275 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// The resume ruling, check by check. Each test breaks exactly one link in
+// the chain and expects the ruling to name THAT link — the reason is what an
+// operator acts on, so a later check must not shadow an earlier one.
+//
+// Resume is a LOCAL convenience: the on-disk state was written by the trusted
+// CLI and the developer, so the ruling asks only whether that state is
+// genuinely UNCHANGED and resumable, never whether a field was forged.
+
+import { describe, it, expect } from 'vitest';
+import { assessResume, type ResumeProbes } from './resume.js';
+import { RESUME_MAX } from './run-ledger.js';
+
+const SHA = 'f00df00df00df00d';
+const DIFF_SHA = 'a'.repeat(64);
+
+const prev = () => ({
+  prNumber: '42',
+  fetchedSha: SHA,
+  diffSha256: DIFF_SHA,
+  effort: undefined as unknown,
+});
+
+const probes = (over: Partial<ResumeProbes> = {}): ResumeProbes => ({
+  prNumber: '42',
+  worktreeHeadSha: SHA,
+  worktreeClean: true,
+  diffSha256OnDisk: DIFF_SHA,
+  liveHeadSha: SHA,
+  resumeCount: 0,
+  requestedEffort: null,
+  ...over,
+});
+
+describe('assessResume — the empty-string shapes, named by the FIRST break', () => {
+  // A hand-edited or externally rewritten report is diagnosed by the artifact
+  // that is actually broken. The suites otherwise pass `undefined`/`null`,
+  // which take the `typeof` branches and leave these clauses free to be
+  // deleted.
+  it('an empty fetchedSha is a broken REPORT, not a moved worktree', () => {
+    expect(assessResume({ ...prev(), fetchedSha: '' }, probes())).toEqual({
+      ok: false,
+      reason: 'no-report',
+    });
+  });
+
+  it('an empty diffSha256 is a missing hash, not a mismatched one', () => {
+    expect(assessResume({ ...prev(), diffSha256: '' }, probes())).toEqual({
+      ok: false,
+      reason: 'no-diff-hash',
+    });
+  });
+
+  it('an empty recorded effort reads as the default, not as a mismatch', () => {
+    // Nothing recorded means nothing to disagree with, so an explicit `high`
+    // matches the default a resumed run inherits.
+    expect(
+      assessResume(
+        { ...prev(), effort: '' },
+        probes({ requestedEffort: 'high' }),
+      ),
+    ).toEqual({ ok: true });
+  });
+});
+
+describe('assessResume', () => {
+  it('resumes when every probe matches the previous report', () => {
+    expect(assessResume(prev(), probes())).toEqual({ ok: true });
+  });
+
+  it('refuses with no-report when there is nothing to resume', () => {
+    expect(assessResume(null, probes())).toEqual({
+      ok: false,
+      reason: 'no-report',
+    });
+  });
+
+  it('refuses with no-report when the report has no fetchedSha', () => {
+    expect(assessResume({ prNumber: '42' }, probes())).toEqual({
+      ok: false,
+      reason: 'no-report',
+    });
+  });
+
+  it("refuses with pr-mismatch on another PR's report at the same path", () => {
+    expect(assessResume({ ...prev(), prNumber: '999' }, probes())).toEqual({
+      ok: false,
+      reason: 'pr-mismatch',
+    });
+  });
+
+  it('refuses with effort-mismatch when an explicit effort differs', () => {
+    // A different effort is a request for different work; the fresh
+    // fall-through honors it instead of silently pinning the old level.
+    expect(
+      assessResume(
+        { ...prev(), effort: 'medium' },
+        probes({ requestedEffort: 'high' }),
+      ),
+    ).toEqual({ ok: false, reason: 'effort-mismatch' });
+  });
+
+  it('resumes when the explicit effort matches the recorded one', () => {
+    expect(
+      assessResume(
+        { ...prev(), effort: 'medium' },
+        probes({ requestedEffort: 'medium' }),
+      ),
+    ).toEqual({ ok: true });
+  });
+
+  it('reads a plan with no recorded effort as the default high', () => {
+    expect(assessResume(prev(), probes({ requestedEffort: 'high' }))).toEqual({
+      ok: true,
+    });
+    expect(assessResume(prev(), probes({ requestedEffort: 'medium' }))).toEqual(
+      { ok: false, reason: 'effort-mismatch' },
+    );
+  });
+
+  it('reads an invalid recorded effort as the default high', () => {
+    // Locally there is no forger to distinguish a corrupt level from an
+    // absent one — both simply select the default roster.
+    expect(
+      assessResume(
+        { ...prev(), effort: 'turbo' },
+        probes({ requestedEffort: 'high' }),
+      ),
+    ).toEqual({ ok: true });
+    expect(
+      assessResume(
+        { ...prev(), effort: 'turbo' },
+        probes({ requestedEffort: 'medium' }),
+      ),
+    ).toEqual({ ok: false, reason: 'effort-mismatch' });
+  });
+
+  it('never refuses on effort when none was passed', () => {
+    expect(assessResume({ ...prev(), effort: 'medium' }, probes())).toEqual({
+      ok: true,
+    });
+  });
+
+  it('refuses with no-diff-hash on a pre-diffSha256 report', () => {
+    expect(
+      assessResume({ ...prev(), diffSha256: undefined }, probes()),
+    ).toEqual({ ok: false, reason: 'no-diff-hash' });
+  });
+
+  it('refuses with no-diff-hash when the run captured no diff', () => {
+    expect(assessResume({ ...prev(), diffSha256: null }, probes())).toEqual({
+      ok: false,
+      reason: 'no-diff-hash',
+    });
+  });
+
+  it('refuses with worktree-gone when the worktree cannot answer rev-parse', () => {
+    expect(assessResume(prev(), probes({ worktreeHeadSha: null }))).toEqual({
+      ok: false,
+      reason: 'worktree-gone',
+    });
+  });
+
+  it('refuses with worktree-sha-mismatch when the worktree moved', () => {
+    expect(assessResume(prev(), probes({ worktreeHeadSha: 'other' }))).toEqual({
+      ok: false,
+      reason: 'worktree-sha-mismatch',
+    });
+  });
+
+  it('refuses with worktree-dirty on uncommitted changes at the right SHA', () => {
+    // This pipeline's own probe and build/test agents mutate worktrees; a
+    // death between an apply and its revert leaves exactly this state, and
+    // the HEAD SHA plus the diff hash both still match.
+    expect(assessResume(prev(), probes({ worktreeClean: false }))).toEqual({
+      ok: false,
+      reason: 'worktree-dirty',
+    });
+  });
+
+  it('treats an unrunnable cleanliness probe as dirty', () => {
+    expect(assessResume(prev(), probes({ worktreeClean: null }))).toEqual({
+      ok: false,
+      reason: 'worktree-dirty',
+    });
+  });
+
+  it('names a missing diff capture apart from a changed one', () => {
+    // Local state loss and upstream input change are different facts.
+    expect(assessResume(prev(), probes({ diffSha256OnDisk: null }))).toEqual({
+      ok: false,
+      reason: 'diff-unreadable',
+    });
+  });
+
+  it('refuses with diff-hash-mismatch when the diff bytes changed', () => {
+    // The content key: input that changed re-runs, by construction.
+    expect(
+      assessResume(prev(), probes({ diffSha256OnDisk: 'b'.repeat(64) })),
+    ).toEqual({ ok: false, reason: 'diff-hash-mismatch' });
+  });
+
+  it('refuses with head-moved when the live head advanced', () => {
+    expect(assessResume(prev(), probes({ liveHeadSha: 'newhead' }))).toEqual({
+      ok: false,
+      reason: 'head-moved',
+    });
+  });
+
+  it('does NOT refuse on an unreachable forge — the content checks pin it', () => {
+    expect(assessResume(prev(), probes({ liveHeadSha: null }))).toEqual({
+      ok: true,
+    });
+  });
+
+  it('refuses with resume-cap at the marker limit', () => {
+    expect(assessResume(prev(), probes({ resumeCount: RESUME_MAX }))).toEqual({
+      ok: false,
+      reason: 'resume-cap',
+    });
+  });
+
+  it('still resumes one short of the cap', () => {
+    expect(
+      assessResume(prev(), probes({ resumeCount: RESUME_MAX - 1 })),
+    ).toEqual({ ok: true });
+  });
+
+  it('reports the FIRST broken link when several are broken at once', () => {
+    // The reason is what an operator acts on, so a later check must not
+    // shadow an earlier one — a test that breaks exactly one link is by
+    // construction insensitive to that ordering.
+    expect(
+      assessResume(
+        prev(),
+        probes({
+          worktreeHeadSha: 'other',
+          worktreeClean: false,
+          diffSha256OnDisk: null,
+          liveHeadSha: 'moved',
+          resumeCount: 99,
+        }),
+      ),
+    ).toEqual({ ok: false, reason: 'worktree-sha-mismatch' });
+    expect(
+      assessResume(
+        prev(),
+        probes({
+          worktreeClean: false,
+          diffSha256OnDisk: null,
+          liveHeadSha: 'moved',
+          resumeCount: 99,
+        }),
+      ),
+    ).toEqual({ ok: false, reason: 'worktree-dirty' });
+    expect(
+      assessResume(
+        prev(),
+        probes({
+          diffSha256OnDisk: null,
+          liveHeadSha: 'moved',
+          resumeCount: 99,
+        }),
+      ),
+    ).toEqual({ ok: false, reason: 'diff-unreadable' });
+    expect(
+      assessResume(prev(), probes({ liveHeadSha: 'moved', resumeCount: 99 })),
+    ).toEqual({ ok: false, reason: 'head-moved' });
+  });
+});

--- a/packages/cli/src/commands/review/lib/resume.ts
+++ b/packages/cli/src/commands/review/lib/resume.ts
@@ -1,0 +1,152 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// May this run continue the interrupted one, or must it start over?
+//
+// The ruling is pure: `fetch-pr --resume` gathers the probes (git, gh, file
+// hashes, the resume marker) and this function only compares them. Every
+// check fails toward a FRESH run — resuming on stale state would continue a
+// review of code nobody is reviewing anymore, which is strictly worse than
+// re-fetching. The checkpoint key is content (the diff's sha256, the head
+// SHA), never a path or a timestamp: input that changed re-runs, by
+// construction rather than by invalidation logic.
+//
+// Resume is a LOCAL convenience: a developer whose `qwen review` was
+// interrupted re-runs it with `--resume`. The on-disk state was written by
+// the trusted CLI and the developer — there is no adversarial attempt-1 code
+// racing the same disk (CI does not resume; its trigger runs fresh), so the
+// ruling asks only whether the state is genuinely UNCHANGED and resumable,
+// not whether a report field was forged. Every check still fails toward a
+// FRESH run: resuming stale state reviews code nobody is reviewing anymore.
+
+import { EFFORT_LEVELS } from '../parse-args.js';
+import { RESUME_MAX } from './run-ledger.js';
+
+/** Why a resume was refused. Stable identifiers: the report carries one. */
+export type ResumeRefusal =
+  | 'no-report' // no previous fetch report at the plan path
+  | 'pr-mismatch' // the report on disk is another PR's
+  | 'effort-mismatch' // an explicit --effort differs from the recorded run's
+  | 'no-diff-hash' // the previous run predates diffSha256 (or captured no diff)
+  | 'worktree-gone' // the interrupted attempt's worktree no longer exists
+  | 'worktree-sha-mismatch' // the worktree is not checked out at fetchedSha
+  | 'worktree-dirty' // the worktree holds uncommitted changes
+  | 'diff-unreadable' // the captured diff is gone or cannot be read
+  | 'diff-hash-mismatch' // the diff file changed since it was captured
+  | 'head-moved' // the PR head advanced — the once-per-review restart case
+  | 'resume-cap'; // this review has already resumed RESUME_MAX times
+
+export type ResumeAssessment =
+  | { ok: true }
+  | { ok: false; reason: ResumeRefusal };
+
+/** What the previous fetch report claims. All fields as parsed, unvalidated. */
+export interface PreviousReport {
+  prNumber?: unknown;
+  fetchedSha?: unknown;
+  diffSha256?: unknown;
+  effort?: unknown;
+}
+
+/** What the world looks like now, probed by the caller. */
+export interface ResumeProbes {
+  /** The PR number this invocation was asked to review. */
+  prNumber: string;
+  /** `git -C <worktree> rev-parse HEAD`, or null when the worktree is gone. */
+  worktreeHeadSha: string | null;
+  /**
+   * `git status --porcelain` on the worktree reported no changes. A tree at
+   * the right HEAD can still hold uncommitted edits — this pipeline's own
+   * build/test agents mutate worktrees by design, and a death between an
+   * apply and its revert leaves exactly that. Resuming there would review
+   * code that is not in the PR. Null when the probe could not run, treated
+   * as dirty.
+   */
+  worktreeClean: boolean | null;
+  /** sha256 of the diff file's bytes on disk, or null when unreadable. */
+  diffSha256OnDisk: string | null;
+  /** The PR's live head OID from the forge, or null when unavailable. */
+  liveHeadSha: string | null;
+  /** How many times this review has already resumed. */
+  resumeCount: number;
+  /**
+   * The --effort this invocation was called with, or null. An EXPLICIT
+   * effort different from the recorded run's is a request for different
+   * work, not a continuation; absent effort keeps the recorded level.
+   */
+  requestedEffort: string | null;
+}
+
+/**
+ * The ruling. Checks are ordered from "there is nothing to resume" through
+ * "the state is not the state that was left" to "resuming is not allowed
+ * again" — so the reported reason names the FIRST fact that broke the chain.
+ */
+export function assessResume(
+  prev: PreviousReport | null,
+  probes: ResumeProbes,
+): ResumeAssessment {
+  if (
+    prev === null ||
+    typeof prev.fetchedSha !== 'string' ||
+    prev.fetchedSha === ''
+  ) {
+    return { ok: false, reason: 'no-report' };
+  }
+  if (prev.prNumber !== probes.prNumber) {
+    return { ok: false, reason: 'pr-mismatch' };
+  }
+  // A plan with no recorded effort ran the default (high) roster; an
+  // explicit effort that differs is a request for different work, not a
+  // continuation. (An invalid recorded level simply selects the default,
+  // like an absent one — locally there is no forger to distinguish.)
+  if (
+    probes.requestedEffort !== null &&
+    probes.requestedEffort !==
+      (typeof prev.effort === 'string' &&
+      prev.effort !== '' &&
+      EFFORT_LEVELS.has(prev.effort)
+        ? prev.effort
+        : 'high')
+  ) {
+    return { ok: false, reason: 'effort-mismatch' };
+  }
+  // A pre-diffSha256 report (or a run that captured no diff) has no content
+  // identity to verify against; a resume that cannot prove its input is
+  // unchanged does not happen.
+  if (typeof prev.diffSha256 !== 'string' || prev.diffSha256 === '') {
+    return { ok: false, reason: 'no-diff-hash' };
+  }
+  if (probes.worktreeHeadSha === null) {
+    return { ok: false, reason: 'worktree-gone' };
+  }
+  if (probes.worktreeHeadSha !== prev.fetchedSha) {
+    return { ok: false, reason: 'worktree-sha-mismatch' };
+  }
+  if (probes.worktreeClean !== true) {
+    return { ok: false, reason: 'worktree-dirty' };
+  }
+  // Absent local state and changed input are different facts: one says this
+  // run lost its own capture, the other says what it captured is no longer
+  // what it captured.
+  if (probes.diffSha256OnDisk === null) {
+    return { ok: false, reason: 'diff-unreadable' };
+  }
+  if (probes.diffSha256OnDisk !== prev.diffSha256) {
+    return { ok: false, reason: 'diff-hash-mismatch' };
+  }
+  // An unreachable forge is NOT a head-moved: it is indistinguishable from
+  // "unchanged", and the worktree/diff checks above already pin the content.
+  // presubmit's headDrift re-checks against the live head before anything is
+  // posted, so failing open here costs nothing that gate does not catch.
+  if (probes.liveHeadSha !== null && probes.liveHeadSha !== prev.fetchedSha) {
+    return { ok: false, reason: 'head-moved' };
+  }
+  if (probes.resumeCount >= RESUME_MAX) {
+    return { ok: false, reason: 'resume-cap' };
+  }
+  return { ok: true };
+}

--- a/packages/cli/src/commands/review/lib/run-ledger.test.ts
+++ b/packages/cli/src/commands/review/lib/run-ledger.test.ts
@@ -33,6 +33,7 @@ import {
   priorSessionEntries,
   priorSessionIds,
   sessionEntryCount,
+  ledgerResumeCount,
   runSessionsPath,
   readResumeMarker,
   recordResume,
@@ -125,6 +126,52 @@ describe('sessionEntryCount — the cap term the gate must not swallow', () => {
     appendRunSession(plan, envOf('S1'));
     appendRunSession(plan, envOf('../evil'));
     expect(sessionEntryCount(plan)).toBe(1);
+  });
+});
+
+describe('ledgerResumeCount — entries past the original, no double subtraction', () => {
+  // The ledger's first entry is the original run's own session, which is
+  // not a resume. The resuming session is excluded from the REMAINDER — and
+  // when it IS the original, the exclusion has already removed the first
+  // entry, so subtracting the original again counts one resume short: the
+  // exact backstop shape (a deleted marker, the original session resuming)
+  // passed a cap it had already exhausted.
+  const now = Date.now();
+
+  function threeSessions(): void {
+    appendRunSession(plan, envOf('S0'), now);
+    appendRunSession(plan, envOf('S1'), now + 1000);
+    appendRunSession(plan, envOf('S2'), now + 2000);
+  }
+
+  it('counts the resumes past the original session', () => {
+    threeSessions();
+    expect(ledgerResumeCount(plan)).toBe(2);
+  });
+
+  it('excludes the original resuming without subtracting it twice', () => {
+    threeSessions();
+    // S0 resumes again: the exclusion removes the first entry, leaving S1
+    // and S2 — two resumes, the cap already out. The double subtraction
+    // read 1 here and admitted a third resume.
+    expect(ledgerResumeCount(plan, { excludeSessionId: 'S0' })).toBe(2);
+  });
+
+  it('excludes a resuming session that is not the original', () => {
+    threeSessions();
+    // S1 retries its own resume: S2 is the only OTHER resume.
+    expect(ledgerResumeCount(plan, { excludeSessionId: 'S1' })).toBe(1);
+  });
+
+  it('is zero on a fresh ledger, whatever excludes', () => {
+    appendRunSession(plan, envOf('S0'), now);
+    expect(ledgerResumeCount(plan)).toBe(0);
+    expect(ledgerResumeCount(plan, { excludeSessionId: 'S0' })).toBe(0);
+    expect(ledgerResumeCount(plan, { excludeSessionId: 'S9' })).toBe(0);
+  });
+
+  it('is zero when there is no ledger at all', () => {
+    expect(ledgerResumeCount(plan, { excludeSessionId: 'S0' })).toBe(0);
   });
 });
 

--- a/packages/cli/src/commands/review/lib/run-ledger.ts
+++ b/packages/cli/src/commands/review/lib/run-ledger.ts
@@ -423,6 +423,26 @@ export function sessionEntryCount(
 }
 
 /**
+ * How many RESUMES this run's ledger records — the entries PAST the first.
+ * The ledger's first entry is the original run's own session, which is not
+ * a resume. `excludeSessionId` removes the resuming session's own entry
+ * from that remainder — and when the resuming session IS the original, the
+ * exclusion has already removed the first entry, so the original must not
+ * be subtracted AGAIN: the double subtraction undercounted the cap by one
+ * and admitted a resume past the cap through the exact backstop path
+ * (deleted marker, original session resuming) this term exists to hold.
+ */
+export function ledgerResumeCount(
+  planPath: string,
+  opts: { excludeSessionId?: string } = {},
+): number {
+  const past = readSessions(planPath).slice(1);
+  if (opts.excludeSessionId === undefined) return past.length;
+  const key = sessionPathKey(opts.excludeSessionId);
+  return past.filter((e) => sessionPathKey(e.sessionId) !== key).length;
+}
+
+/**
  * Session ids of EARLIER attempts of this same run — the current session
  * excluded, order preserved, deduplicated by the ledger's own append guard.
  * These are addresses for `subagents/<id>` lookups, nothing more.

--- a/packages/cli/src/commands/review/recover-findings.test.ts
+++ b/packages/cli/src/commands/review/recover-findings.test.ts
@@ -1,0 +1,969 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// The recovery command against the shapes real interrupted runs leave: a
+// certified agent in the dead session, an uncertified one, a transcript that
+// verbatim-matches two records (the injectivity refusal), and the findings
+// lists earlier rounds wrote. Fixtures are files in a real temp dir — the
+// same discipline as check-coverage.test.ts, whose pairing this reuses.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  chmodSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+  readFileSync,
+  mkdirSync,
+  utimesSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+import yargs from 'yargs';
+import type { Argv } from 'yargs';
+import { recoverFindings, recoverFindingsCommand } from './recover-findings.js';
+import {
+  promptRecordDir,
+  briefPath,
+  findingsFilePath,
+  recordPrompt,
+} from './lib/prompt-record.js';
+import { appendRunSession, recordResume } from './lib/run-ledger.js';
+
+let dir: string;
+let ENV: NodeJS.ProcessEnv;
+let plan: string;
+let DIFF: string;
+
+beforeEach(() => {
+  dir = realpathSync(mkdtempSync(join(tmpdir(), 'recover-')));
+  ENV = { QWEN_CODE_PROJECT_DIR: dir, QWEN_CODE_SESSION_ID: 'S1' };
+  mkdirSync(join(dir, 'subagents', 'S1'), { recursive: true });
+  mkdirSync(join(dir, 'subagents', 'S0'), { recursive: true });
+  plan = join(dir, 'plan.json');
+  DIFF = join(dir, 'diff.txt');
+  writeFileSync(
+    plan,
+    JSON.stringify({ diffPathAbsolute: DIFF, diffLines: 10, chunks: [] }),
+  );
+  const old = new Date(2020, 0, 1);
+  utimesSync(plan, old, old);
+  const recordDir = promptRecordDir(plan);
+  mkdirSync(recordDir, { recursive: true });
+  // Written by the real writers: the entries carry the plan mtime they are
+  // keyed on, and reading prior evidence at all requires this session's own
+  // recorded resume. The current attempt is stamped last, since each
+  // attempt's window closes when the next one opened.
+  const now = Date.now();
+  appendRunSession(plan, { QWEN_CODE_SESSION_ID: 'S0' }, now);
+  appendRunSession(plan, { QWEN_CODE_SESSION_ID: 'S1' }, now + 1500);
+  recordResume(plan, ENV, now + 1500);
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+/** A CLI-built prompt record plus its brief, under `key`. */
+function built(key: string): string {
+  const brief = briefPath(plan, key);
+  writeFileSync(brief, `The ${key} brief.`);
+  const prompt = `You are ${key}.\nread_file(file_path="${brief}")`;
+  recordPrompt(plan, key, prompt);
+  return prompt;
+}
+
+/** A harness transcript in `session`, launched with `launch`. */
+function transcript(
+  session: string,
+  id: string,
+  launch: string,
+  opts: {
+    opens?: string[];
+    finalText?: string;
+    /** Append one more tool call AFTER the text — the died-mid-work shape. */
+    trailingCall?: boolean;
+  } = {},
+): void {
+  const base = {
+    agentId: id,
+    agentName: 'general-purpose',
+    sessionId: session,
+  };
+  const lines = [
+    JSON.stringify({
+      ...base,
+      type: 'user',
+      message: { role: 'user', parts: [{ text: launch }] },
+    }),
+  ];
+  for (const path of opts.opens ?? []) {
+    lines.push(
+      JSON.stringify({
+        ...base,
+        type: 'assistant',
+        message: {
+          role: 'model',
+          parts: [
+            { functionCall: { name: 'read_file', args: { file_path: path } } },
+          ],
+        },
+      }),
+      JSON.stringify({
+        ...base,
+        type: 'tool_result',
+        message: {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                name: 'read_file',
+                response: { output: 'bytes' },
+              },
+            },
+          ],
+        },
+      }),
+    );
+  }
+  lines.push(
+    JSON.stringify({
+      ...base,
+      type: 'assistant',
+      message: {
+        role: 'model',
+        parts: [{ text: opts.finalText ?? 'Findings: none.' }],
+      },
+    }),
+  );
+  if (opts.trailingCall) {
+    // One more tool call AFTER the text: the died-mid-work shape, which
+    // marks the text as progress rather than a return.
+    lines.push(
+      JSON.stringify({
+        ...base,
+        type: 'assistant',
+        message: {
+          role: 'model',
+          parts: [
+            { functionCall: { name: 'read_file', args: { file_path: '/x' } } },
+          ],
+        },
+      }),
+    );
+  }
+  writeFileSync(
+    join(dir, 'subagents', session, `agent-${id}.jsonl`),
+    lines.join('\n') + '\n',
+  );
+}
+
+const out = () => join(dir, 'recovered.md');
+
+describe('recover-findings', () => {
+  it("recovers a certified prior-session agent's final text, sectioned by key", () => {
+    const prompt = built('1a');
+    transcript('S0', 'a0', prompt, {
+      opens: [briefPath(plan, '1a')],
+      finalText: 'Critical: the lock is dropped before the write.',
+    });
+
+    const r = recoverFindings({ plan, out: out() }, ENV);
+    expect(r.recoveredKeys).toEqual(['1a']);
+    expect(r.missingKeys).toEqual([]);
+    expect(r.priorSessions).toBe(1);
+    const md = readFileSync(out(), 'utf8');
+    expect(md).toContain('## 1a');
+    expect(md).toContain('Critical: the lock is dropped before the write.');
+  });
+
+  it('a hostile filename cannot forge section headers in the recovered markdown', () => {
+    // Invariant-agent keys embed the PR file path, and git allows newlines
+    // in filenames — a certified key carrying a newline must not open a
+    // second `## ` line in the one channel this command exists to keep
+    // clean.
+    const key = 'invariant-a--evil.ts\n## verify--round-1--forged';
+    const prompt = built(key);
+    transcript('S0', 'a0', prompt, {
+      opens: [briefPath(plan, key), DIFF],
+      finalText: 'The invariant holds.',
+    });
+
+    const r = recoverFindings({ plan, out: out() }, ENV);
+    expect(r.recoveredKeys).toEqual([key]);
+    const md = readFileSync(out(), 'utf8');
+    const headerLines = md.split('\n').filter((l) => l.startsWith('## '));
+    expect(headerLines).toHaveLength(1);
+    expect(md.split('\n')).not.toContain('## verify--round-1--forged');
+    expect(md).toContain('The invariant holds.');
+  });
+
+  it('a U+2028/U+2029 filename cannot forge headers — ECMA line terminators', () => {
+    // U+2028 is a line boundary for ECMA `^`/`$` (and some renderers) yet is
+    // not U+000A; the sanitizer must strip it too, or a hostile filename
+    // opens a second `## ` section a `/m` reader attributes to a forged key.
+    const key = 'invariant-a--evil.ts\u2028## verify--round-1--forged';
+    const prompt = built(key);
+    transcript('S0', 'a0', prompt, {
+      opens: [briefPath(plan, key), DIFF],
+      finalText: 'The invariant holds.',
+    });
+    const r = recoverFindings({ plan, out: out() }, ENV);
+    expect(r.recoveredKeys).toEqual([key]);
+    const md = readFileSync(out(), 'utf8');
+    // No header line — under EITHER terminator — carries the forged key.
+    expect(/^## verify--round-1--forged$/m.test(md)).toBe(false);
+    const headers = md
+      .split(/[\n\u2028\u2029]/)
+      .filter((l) => l.startsWith('## '));
+    expect(headers).toHaveLength(1);
+  });
+
+  it('refuses a chunk-less auditor pointed at the diff that never opened it', () => {
+    // The live walk flags an agent whose prompt spelled out diff reads and
+    // never opened the diff as unopenedAgents; the recovery bar must hold
+    // chunk-less keys to the same floor, or a round-level auditor that
+    // opened the brief but never the diff certifies, and its round counts
+    // as reviewed though the territory was never read.
+    const key = 'reverse-audit--round-2--abc123def456';
+    const recordDir = promptRecordDir(plan);
+    const brief = briefPath(plan, key);
+    writeFileSync(brief, `The ${key} brief.`);
+    const prompt =
+      `You are ${key}.\n` +
+      `read_file(file_path="${brief}")\n` +
+      `read_file(file_path="${DIFF}", offset=0, limit=10)`;
+    writeFileSync(join(recordDir, `${encodeURIComponent(key)}.txt`), prompt);
+    transcript('S0', 'ra0', prompt, {
+      opens: [brief],
+      finalText: 'Round 2 found nothing.',
+    });
+
+    const r = recoverFindings({ plan, out: out() }, ENV);
+    expect(r.recoveredKeys).toEqual([]);
+    expect(r.missingKeys).toEqual([key]);
+    expect(r.latestReverseAuditRound).toBeNull();
+  });
+
+  it('refuses the transcript that matches two records — injectivity', () => {
+    // One "agent" launched with both prompts concatenated verbatim-contains
+    // both records; crediting either would let one agent take a stack.
+    const p1 = built('1a');
+    const p2 = built('2');
+    transcript('S0', 'a0', `${p1}\n${p2}`, {
+      opens: [briefPath(plan, '1a'), briefPath(plan, '2')],
+      finalText: 'Covered both.',
+    });
+
+    const r = recoverFindings({ plan, out: out() }, ENV);
+    expect(r.recoveredKeys).toEqual([]);
+    expect(r.missingKeys).toEqual(['1a', '2']);
+    expect(readFileSync(out(), 'utf8')).not.toContain('Covered both.');
+  });
+
+  it('does not recover an agent that opened neither brief nor diff', () => {
+    const prompt = built('1a');
+    transcript('S0', 'a0', prompt, {
+      opens: [],
+      finalText: 'Confident prose, no evidence.',
+    });
+
+    const r = recoverFindings({ plan, out: out() }, ENV);
+    expect(r.recoveredKeys).toEqual([]);
+    expect(r.missingKeys).toEqual(['1a']);
+  });
+
+  it('picks the newest of two certified transcripts for one key', () => {
+    // A legitimate relaunch (the agent ran twice in the interrupted attempt)
+    // leaves two certified transcripts for one key. All writers here are
+    // trusted, so the newest by mtime is the attempt's latest word and wins.
+    const prompt = built('1a');
+    const older = briefPath(plan, '1a');
+    transcript('S0', 'a0', prompt, {
+      opens: [older],
+      finalText: 'First pass: nothing yet.',
+    });
+    const first = join(dir, 'subagents', 'S0', 'agent-a0.jsonl');
+    const old = new Date(2021, 0, 1);
+    utimesSync(first, old, old);
+    transcript('S0', 'a0b', prompt, {
+      opens: [older],
+      finalText: 'Second pass: Critical found.',
+    });
+
+    const r = recoverFindings({ plan, out: out() }, ENV);
+    expect(r.recoveredKeys).toEqual(['1a']);
+    expect(readFileSync(out(), 'utf8')).toContain(
+      'Second pass: Critical found.',
+    );
+    expect(readFileSync(out(), 'utf8')).not.toContain(
+      'First pass: nothing yet.',
+    );
+  });
+
+  it('enumerates the findings lists with their rounds, in-dir only', () => {
+    const recordDir = promptRecordDir(plan);
+    const key = 'reverse-audit--round-2--abc123def456';
+    const list = join(recordDir, `${encodeURIComponent(key)}.findings.md`);
+    writeFileSync(list, '- R1-1 …');
+    // The builder records a content digest beside every list it writes;
+    // recovery refuses a list without one (fail closed on authorship).
+    // Enumeration is corroborated: the file is listed because a CERTIFIED
+    // transcript's recorded prompt points at it (the brief and the list
+    // both read, so the bar clears).
+    const brief = briefPath(plan, key);
+    writeFileSync(brief, `The ${key} brief.`);
+    const prompt =
+      `You are ${key}.\n` +
+      `read_file(file_path="${list}")\n` +
+      `read_file(file_path="${brief}")`;
+    writeFileSync(join(recordDir, `${encodeURIComponent(key)}.txt`), prompt);
+    transcript('S0', 'ra2', prompt, {
+      opens: [brief, list],
+      finalText: 'Round 2: no new issues after a full walk.',
+    });
+    const r = recoverFindings({ plan, out: out() }, ENV);
+    expect(r.findingsFiles).toEqual([{ key, path: list, round: 2 }]);
+  });
+
+  it('reports the latest certified reverse-audit round', () => {
+    for (const round of [1, 2]) {
+      const key = `reverse-audit--round-${round}--abc123def456`;
+      const prompt = built(key);
+      transcript('S0', `ra${round}`, prompt, {
+        opens: [briefPath(plan, key)],
+        finalText: `Round ${round}: no new issues after a full territory walk.`,
+      });
+    }
+    const r = recoverFindings({ plan, out: out() }, ENV);
+    expect(r.latestReverseAuditRound).toBe(2);
+  });
+
+  it('recovers with the NEW session dir absent — the pre-launch state', () => {
+    // A resumed run calls this before launching any agent, so the current
+    // session's transcript dir does not exist yet. That must not read as an
+    // infrastructure failure.
+    const prompt = built('1a');
+    transcript('S0', 'a0', prompt, {
+      opens: [briefPath(plan, '1a')],
+      finalText: 'Recovered before any new launch.',
+    });
+    const freshEnv = { QWEN_CODE_PROJECT_DIR: dir, QWEN_CODE_SESSION_ID: 'S9' };
+    appendRunSession(plan, freshEnv, Date.now() + 1500);
+    recordResume(plan, freshEnv, Date.now() + 1500);
+    const r = recoverFindings({ plan, out: out() }, freshEnv);
+    expect(r.recoveredKeys).toEqual(['1a']);
+    expect(readFileSync(out(), 'utf8')).toContain(
+      'Recovered before any new launch.',
+    );
+  });
+
+  it('refuses an --out that would overwrite the plan', () => {
+    expect(() => recoverFindings({ plan, out: plan }, ENV)).toThrow(
+      /must not overwrite the plan/,
+    );
+  });
+
+  it('the CLI option contract: yargs-parsed flags drive the pure function', () => {
+    const prompt = built('1a');
+    transcript('S0', 'a0', prompt, {
+      opens: [briefPath(plan, '1a')],
+      finalText: 'Recovered through the parsed flags.',
+    });
+    const parsed = (recoverFindingsCommand.builder as (y: Argv) => Argv)(
+      yargs([]),
+    ).parseSync(['--plan', plan, '--out', out()]) as unknown as Parameters<
+      typeof recoverFindings
+    >[0];
+
+    const r = recoverFindings(parsed, ENV);
+    expect(r.recoveredKeys).toEqual(['1a']);
+    expect(readFileSync(out(), 'utf8')).toContain(
+      'Recovered through the parsed flags.',
+    );
+  });
+});
+
+describe('recover-findings — the guarantees, made falsifiable', () => {
+  it('refuses a launch that diverged from the recorded prompt', () => {
+    // The verbatim-delivery check is the core of the certification; no
+    // fixture diverged from it before, so dropping it shipped green.
+    const prompt = built('1a');
+    transcript('S0', 'a0', prompt.replace('You are', 'You were'), {
+      opens: [briefPath(plan, '1a')],
+      finalText: 'Rewritten launch, plausible prose.',
+    });
+    const r = recoverFindings({ plan, out: out() }, ENV);
+    expect(r.recoveredKeys).toEqual([]);
+    expect(r.missingKeys).toEqual(['1a']);
+  });
+
+  it('does not recover an agent whose final text is empty', () => {
+    const prompt = built('1a');
+    transcript('S0', 'a0', prompt, {
+      opens: [briefPath(plan, '1a')],
+      finalText: '   ',
+    });
+    expect(recoverFindings({ plan, out: out() }, ENV).recoveredKeys).toEqual(
+      [],
+    );
+  });
+
+  it('vetoes a return that declares a chunk uncoverable', () => {
+    // Production shape: a chunk agent's launch prompt carries its `chunk N
+    // of M` line — that line is how BOTH pipeline authorities assign the
+    // record, and the veto keys on the record's own assignment exactly as
+    // they do.
+    const recordDir = promptRecordDir(plan);
+    const brief = briefPath(plan, 'chunk-1');
+    writeFileSync(brief, 'The chunk-1 brief.');
+    const prompt =
+      `You are reviewing chunk 1 of 2.\n` + `read_file(file_path="${brief}")`;
+    writeFileSync(
+      join(recordDir, `${encodeURIComponent('chunk-1')}.txt`),
+      prompt,
+    );
+    transcript('S0', 'a0', prompt, {
+      opens: [brief],
+      finalText: 'Uncoverable: chunk 1 — a line exceeds the read limit',
+    });
+    const r = recoverFindings({ plan, out: out() }, ENV);
+    expect(r.recoveredKeys).toEqual([]);
+  });
+
+  it('refuses a CHUNK agent that opened its brief but never the diff', () => {
+    // Coverage requires `diffToolCalls > 0` of a chunk-assigned record. The
+    // recovery bar was `openedBrief || diffToolCalls > 0`, so this agent's
+    // plausible prose over zero diff lines was written into the recovery file
+    // and its key left `missingKeys` — the resumed run then never relaunches
+    // it.
+    const prompt = built('chunk-2');
+    transcript('S0', 'a0', prompt, {
+      opens: [briefPath(plan, 'chunk-2')],
+      finalText: 'No issues found in chunk 2.',
+    });
+    expect(recoverFindings({ plan, out: out() }, ENV).recoveredKeys).toEqual(
+      [],
+    );
+  });
+
+  it('refuses a NON-chunk agent that opened the diff but never its brief', () => {
+    // The mirror direction: a reverse-audit brief carries the method and the
+    // cumulative findings list, so an auditor that never opened it did not
+    // perform the audit however much of the diff it read.
+    const prompt = built('reverse-audit');
+    transcript('S0', 'a0', prompt, {
+      opens: [DIFF],
+      finalText: 'Audit complete; nothing further.',
+    });
+    expect(recoverFindings({ plan, out: out() }, ENV).recoveredKeys).toEqual(
+      [],
+    );
+  });
+
+  it('requires the findings list a verifier was told to read', () => {
+    // The floor the compose-time gate applies to the same key. Without it,
+    // recovery certifies a verifier that skipped the read and compose then
+    // rules the very same key `findings-unread`.
+    const key = 'verify';
+    const findings = findingsFilePath(plan, key);
+    writeFileSync(findings, '- **[Critical]** x.ts:1 — y');
+    // Production shape: the POINTER rides the recorded prompt (post-#8597),
+    // and the floor keys on that pointer — not on a path derived from the
+    // record key, which never matches for per-chunk reverse-audit keys.
+    const recordDir = promptRecordDir(plan);
+    const brief = briefPath(plan, key);
+    writeFileSync(brief, `The ${key} brief.`);
+    const prompt =
+      `You are ${key}.\n` +
+      `read_file(file_path="${findings}")\n` +
+      `read_file(file_path="${brief}")`;
+    writeFileSync(join(recordDir, `${encodeURIComponent(key)}.txt`), prompt);
+
+    transcript('S0', 'a0', prompt, {
+      opens: [briefPath(plan, key)],
+      finalText: 'Verified.',
+    });
+    expect(recoverFindings({ plan, out: out() }, ENV).recoveredKeys).toEqual(
+      [],
+    );
+
+    // ...and it recovers once the list was actually opened.
+    transcript('S0', 'a1', prompt, {
+      opens: [briefPath(plan, key), findings],
+      finalText: 'Verified, with the list read.',
+    });
+    expect(recoverFindings({ plan, out: out() }, ENV).recoveredKeys).toEqual([
+      key,
+    ]);
+  });
+
+  it('refuses a record whose text is progress, not a return', () => {
+    // finalText keeps the last non-empty assistant message, including
+    // narration between tool calls; handing a mid-flight-dead agent's
+    // narration to the resumed orchestrator as certified final text is the
+    // exact fabrication recovery exists to prevent.
+    const prompt = built('1a');
+    transcript('S0', 'a0', prompt, {
+      opens: [briefPath(plan, '1a')],
+      finalText: 'Reading the brief now…',
+      trailingCall: true,
+    });
+    expect(recoverFindings({ plan, out: out() }, ENV).recoveredKeys).toEqual(
+      [],
+    );
+  });
+
+  it('applies the findings floor to PER-CHUNK reverse-audit keys', () => {
+    // Their findings file is keyed WITHOUT the chunk, so a key-derived path
+    // never matches and the floor silently vanished for exactly these
+    // auditors — compose-time then ruled the same key `findings-unread`.
+    // The floor keys on the pointer the recorded prompt names.
+    const key = 'reverse-audit--chunk-3--round-1--abc123def456';
+    const roundList = findingsFilePath(
+      plan,
+      'reverse-audit--round-1--abc123def456',
+    );
+    writeFileSync(roundList, '- **[Critical]** x.ts:1 — y');
+    const recordDir = promptRecordDir(plan);
+    const brief = briefPath(plan, key);
+    writeFileSync(brief, 'The brief.');
+    // Production shape: NO `chunk N of M` line — the per-chunk audit prompt
+    // never carries one, and the key alone must supply the assignment.
+    const prompt =
+      `You are review agent \`${key}\`.\n` +
+      `read_file(file_path="${roundList}")\n` +
+      `read_file(file_path="${brief}")\n` +
+      `read_file(file_path="${DIFF}")`;
+    writeFileSync(join(recordDir, `${encodeURIComponent(key)}.txt`), prompt);
+
+    // Skips the round list → refused.
+    transcript('S0', 'a0', prompt, {
+      opens: [brief],
+      finalText: 'No issues found — re-walked chunk 3.',
+    });
+    expect(recoverFindings({ plan, out: out() }, ENV).recoveredKeys).toEqual(
+      [],
+    );
+
+    // Reads it (and the diff — the chunk branch's territory proof) →
+    // recovered.
+    transcript('S0', 'a1', prompt, {
+      opens: [brief, roundList, DIFF],
+      finalText: 'No issues found — re-walked chunk 3, list compared.',
+    });
+    expect(recoverFindings({ plan, out: out() }, ENV).recoveredKeys).toEqual([
+      key,
+    ]);
+  });
+
+  it('refuses a per-chunk auditor that never opened the diff', () => {
+    // The fifth divergence: with the key parsed chunk-less and no prose
+    // identity line, the bar dropped the diff-read requirement for exactly
+    // the auditors whose territory is a chunk — certifying a died-early
+    // auditor over territory nobody read, while the live walk flags the same
+    // record unopened.
+    const key = 'reverse-audit--chunk-4--round-1--abc123def456';
+    const roundList = findingsFilePath(
+      plan,
+      'reverse-audit--round-1--abc123def456',
+    );
+    writeFileSync(roundList, '- **[Critical]** x.ts:1 — y');
+    const recordDir = promptRecordDir(plan);
+    const brief = briefPath(plan, key);
+    writeFileSync(brief, 'The brief.');
+    const prompt =
+      `You are review agent \`${key}\`.\n` +
+      `read_file(file_path="${roundList}")\n` +
+      `read_file(file_path="${brief}")\n` +
+      `read_file(file_path="${DIFF}")`;
+    writeFileSync(join(recordDir, `${encodeURIComponent(key)}.txt`), prompt);
+
+    // Brief and list read, diff never opened — the died-early shape.
+    transcript('S0', 'a0', prompt, {
+      opens: [brief, roundList],
+      finalText: 'No issues found — re-walked chunk 4.',
+    });
+    expect(recoverFindings({ plan, out: out() }, ENV).recoveredKeys).toEqual(
+      [],
+    );
+  });
+
+  it('does not veto an auditor that QUOTES an uncoverable declaration', () => {
+    // The brief instructs verbatim quoting of the evidence, so a certified
+    // auditor's text legitimately contains the line. Applied raw, the veto
+    // matched the quotation, dropped the round from recovery, and regressed
+    // `latestReverseAuditRound` — restarting the audit loop a round early.
+    const key = 'reverse-audit--round-2--abc123def456';
+    const prompt = built(key);
+    transcript('S0', 'a0', prompt, {
+      opens: [briefPath(plan, key)],
+      finalText:
+        'Reviewed the round-1 declarations. One of them reads:\n' +
+        'Uncoverable: chunk 1 — a line exceeds the read limit\n' +
+        'That declaration is sound.',
+    });
+    const r = recoverFindings({ plan, out: out() }, ENV);
+    expect(r.recoveredKeys).toEqual([key]);
+    expect(r.latestReverseAuditRound).toBe(2);
+  });
+
+  it('a PER-CHUNK auditor quoting its own chunk declaration is still recovered', () => {
+    // The sixth divergence: the veto keyed on `chunkOfKey(key)` while both
+    // pipeline authorities key it on `assignedChunk(rec)` — null here, since
+    // the production per-chunk audit prompt carries no `chunk N of M` line.
+    // A certified auditor QUOTING its own chunk's declaration (the briefs
+    // mandate verbatim quoting) was dropped from recovery while coverage
+    // counted the same record as recovered work, and
+    // `latestReverseAuditRound` regressed a round.
+    const key = 'reverse-audit--chunk-3--round-1--abc123def456';
+    const roundList = findingsFilePath(
+      plan,
+      'reverse-audit--round-1--abc123def456',
+    );
+    writeFileSync(roundList, '- **[Critical]** x.ts:1 — y');
+    const recordDir = promptRecordDir(plan);
+    const brief = briefPath(plan, key);
+    writeFileSync(brief, 'The brief.');
+    const prompt =
+      `You are review agent \`${key}\`.\n` +
+      `read_file(file_path="${roundList}")\n` +
+      `read_file(file_path="${brief}")\n` +
+      `read_file(file_path="${DIFF}")`;
+    writeFileSync(join(recordDir, `${encodeURIComponent(key)}.txt`), prompt);
+    transcript('S0', 'a0', prompt, {
+      opens: [brief, roundList, DIFF],
+      finalText:
+        'Audited the round-1 evidence for chunk 3. It reads:\n' +
+        'Uncoverable: chunk 3 — a line exceeds the read limit\n' +
+        'The declaration is sound.',
+    });
+    const r = recoverFindings({ plan, out: out() }, ENV);
+    expect(r.recoveredKeys).toEqual([key]);
+    expect(r.latestReverseAuditRound).toBe(1);
+  });
+
+  it('a per-chunk VERIFY shard cannot skip the findings floor', () => {
+    // The seventh entrance: `verify--chunk-N--…` keys fell into the
+    // chunk-territory branch (`chunk !== null` and not reverse-audit) and
+    // were certified on a diff read alone — skipping the findings floor
+    // coverage's `deliveryOf` holds every verify key to. Only the bare
+    // chunk ROLE takes the territory-only branch now.
+    const key = 'verify--chunk-2--round-1--abc123def456';
+    const list = findingsFilePath(plan, 'verify--round-1--abc123def456');
+    writeFileSync(list, '- **[Critical]** x.ts:1 — y');
+    const recordDir = promptRecordDir(plan);
+    const brief = briefPath(plan, key);
+    writeFileSync(brief, 'The brief.');
+    const prompt =
+      `You are review agent \`${key}\`.\n` +
+      `read_file(file_path="${list}")\n` +
+      `read_file(file_path="${brief}")\n` +
+      `read_file(file_path="${DIFF}")`;
+    writeFileSync(join(recordDir, `${encodeURIComponent(key)}.txt`), prompt);
+
+    // Diff and brief opened, findings list skipped → refused.
+    transcript('S0', 'a0', prompt, {
+      opens: [brief, DIFF],
+      finalText: 'All verified.',
+    });
+    expect(recoverFindings({ plan, out: out() }, ENV).recoveredKeys).toEqual(
+      [],
+    );
+
+    // List read too → recovered.
+    transcript('S0', 'a1', prompt, {
+      opens: [brief, list, DIFF],
+      finalText: 'All verified, list compared.',
+    });
+    expect(recoverFindings({ plan, out: out() }, ENV).recoveredKeys).toEqual([
+      key,
+    ]);
+  });
+
+  it('certifies a NON-chunk agent that opened its brief AND the findings list only', () => {
+    // The positive counterpart of the refusals above: every other `opens:`
+    // fixture in this file opens a brief, so the diff-read side of the bar is
+    // exercised nowhere on the certifying path.
+    const key = 'invariant-a';
+    const prompt = built(key);
+    transcript('S0', 'a0', prompt, {
+      opens: [briefPath(plan, key), DIFF],
+      finalText: 'Invariant holds.',
+    });
+    expect(recoverFindings({ plan, out: out() }, ENV).recoveredKeys).toEqual([
+      key,
+    ]);
+  });
+
+  it('refuses only the AMBIGUOUS transcript, not the contested key itself', () => {
+    // The refusal is per-transcript by design: a transcript matching two keys
+    // proves neither. A competitor that matches exactly one key is innocent
+    // and still certifies — vetoing the whole key would drop finished work
+    // and, for a reverse-audit round, regress `latestReverseAuditRound`.
+    const promptA = built('1a');
+    const promptB = built('1b');
+    // One transcript launched with BOTH prompts concatenated matches both.
+    transcript('S0', 'ambig', `${promptA}\n${promptB}`, {
+      opens: [briefPath(plan, '1a'), briefPath(plan, '1b')],
+      finalText: 'Ambiguous.',
+    });
+    transcript('S0', 'clean', promptA, {
+      opens: [briefPath(plan, '1a')],
+      finalText: 'A clean single-key result.',
+    });
+
+    expect(recoverFindings({ plan, out: out() }, ENV).recoveredKeys).toEqual([
+      '1a',
+    ]);
+  });
+
+  it('normalizes both paths before refusing to overwrite the plan', () => {
+    // The guard is `resolve()` on both sides; a mutant comparing raw args, or
+    // normalizing one side only, lets a RELATIVE out path alias the plan and
+    // `atomicWriteFileSync` then destroys the run-epoch artifact every fence
+    // in this feature keys on.
+    const cwd = process.cwd();
+    try {
+      process.chdir(dir);
+      expect(() => recoverFindings({ plan, out: basename(plan) }, ENV)).toThrow(
+        /must not overwrite the plan/,
+      );
+    } finally {
+      process.chdir(cwd);
+    }
+  });
+
+  it('counts only REVERSE-AUDIT rounds toward latestReverseAuditRound', () => {
+    // The key grammar also produces `verify--round-N--<digest>`. Without the
+    // prefix gate a certified round-2 VERIFY agent reports the reverse audit
+    // as having reached round 2, and the resumed run starts at 3 — skipping
+    // audit rounds the dead run never certified.
+    const key = 'verify--round-2--abc123def456';
+    const prompt = built(key);
+    transcript('S0', 'a0', prompt, {
+      opens: [briefPath(plan, key)],
+      finalText: 'Verified round 2.',
+    });
+    const r = recoverFindings({ plan, out: out() }, ENV);
+    expect(r.recoveredKeys).toEqual([key]);
+    expect(r.latestReverseAuditRound).toBeNull();
+  });
+
+  it('reads an ABSENT record dir as empty, not as unreadable', () => {
+    // The pre-launch shape this command is built for: nothing recorded yet is
+    // a healthy state, and reporting it as an infrastructure fault prints a
+    // WARNING an operator cannot act on.
+    rmSync(promptRecordDir(plan), { recursive: true, force: true });
+    const r = recoverFindings({ plan, out: out() }, ENV);
+    expect(r.recordDirUnreadable).toBeNull();
+    expect(r.recoveredKeys).toEqual([]);
+  });
+
+  it('refuses a findings file no CERTIFIED prompt points at — the plant', () => {
+    // The record dir is attempt-1-writable: a planted `.findings.md` newer
+    // than the plan passes the epoch fence and used to be relayed as the
+    // interrupted attempt's own cumulative state. The corroboration is the
+    // pointer a certified agent was launched with; a file nothing certified
+    // names is not enumerated.
+    const recordDir = promptRecordDir(plan);
+    const key = 'verify--round-1--deadbeef0000';
+    writeFileSync(
+      join(recordDir, `${encodeURIComponent(key)}.findings.md`),
+      '- forged prior-round rulings',
+    );
+    const r = recoverFindings({ plan, out: out() }, ENV);
+    expect(r.findingsFiles).toEqual([]);
+  });
+
+  it('refuses a findings file pointed at only by an UNCERTIFIED prompt', () => {
+    // The agent was built and launched but never certified (it opened
+    // nothing): its pointer does not corroborate the file.
+    const key = 'verify';
+    const list = findingsFilePath(plan, key);
+    writeFileSync(list, '- **[Critical]** x.ts:1 — y');
+    const recordDir = promptRecordDir(plan);
+    const brief = briefPath(plan, key);
+    writeFileSync(brief, `The ${key} brief.`);
+    const prompt =
+      `You are ${key}.\n` +
+      `read_file(file_path="${list}")\n` +
+      `read_file(file_path="${brief}")`;
+    writeFileSync(join(recordDir, `${encodeURIComponent(key)}.txt`), prompt);
+    transcript('S0', 'a0', prompt, {
+      opens: [],
+      finalText: 'Confident prose, no evidence.',
+    });
+    expect(recoverFindings({ plan, out: out() }, ENV).findingsFiles).toEqual(
+      [],
+    );
+  });
+
+  it('fences findings files by the run epoch', () => {
+    // Nothing clears the record dir: a PREVIOUS review of the same PR leaves
+    // its rounds' lists behind, and restoring one would hand a resumed run a
+    // foreign attempt's state.
+    const recordDir = promptRecordDir(plan);
+    const key = 'reverse-audit--round-1--abc123def456';
+    const stale = join(recordDir, `${encodeURIComponent(key)}.findings.md`);
+    writeFileSync(stale, '- from a previous review');
+    const old = new Date(2019, 0, 1);
+    utimesSync(stale, old, old);
+    expect(recoverFindings({ plan, out: out() }, ENV).findingsFiles).toEqual(
+      [],
+    );
+  });
+
+  it('decodes a key whose file name is percent-encoded', () => {
+    const recordDir = promptRecordDir(plan);
+    const key = 'invariant-a--packages/cli/src/x.ts';
+    const list = join(recordDir, `${encodeURIComponent(key)}.findings.md`);
+    writeFileSync(list, '- entry');
+    const brief = briefPath(plan, key);
+    writeFileSync(brief, `The ${key} brief.`);
+    const prompt =
+      `You are ${key}.\n` +
+      `read_file(file_path="${list}")\n` +
+      `read_file(file_path="${brief}")`;
+    writeFileSync(join(recordDir, `${encodeURIComponent(key)}.txt`), prompt);
+    transcript('S0', 'inv', prompt, {
+      opens: [brief, list],
+      finalText: 'Invariant holds.',
+    });
+    const r = recoverFindings({ plan, out: out() }, ENV);
+    expect(r.findingsFiles.map((f) => f.key)).toEqual([key]);
+  });
+
+  it('reports the budget stop the interrupted attempt left standing', () => {
+    writeFileSync(
+      join(promptRecordDir(plan), 'budget-stop.json'),
+      JSON.stringify({
+        cause: 'round-cap',
+        cap: 5,
+        entry: 'the audit stopped at the round cap',
+        entryZh: '审计在轮数上限停止',
+        round: 5,
+        remainingSeconds: 900,
+        reserveSeconds: 1200,
+        atMs: Date.now(),
+      }),
+    );
+    const r = recoverFindings({ plan, out: out() }, ENV);
+    expect(r.budgetStop?.cause).toBe('round-cap');
+  });
+
+  it('counts only CERTIFIED rounds toward latestReverseAuditRound', () => {
+    const k1 = 'reverse-audit--round-1--abc123def456';
+    const k2 = 'reverse-audit--round-2--abc123def456';
+    const p1 = built(k1);
+    built(k2); // built, but its agent never opened anything
+    transcript('S0', 'ra1', p1, {
+      opens: [briefPath(plan, k1)],
+      finalText: 'Round 1: no new issues after a full walk.',
+    });
+    transcript('S0', 'ra2', `You are ${k2}.`, {
+      opens: [],
+      finalText: 'Round 2: nothing.',
+    });
+    expect(
+      recoverFindings({ plan, out: out() }, ENV).latestReverseAuditRound,
+    ).toBe(1);
+  });
+
+  it.skipIf(process.platform === 'win32' || process.getuid?.() === 0)(
+    'discloses an unreadable record dir instead of printing as empty',
+    () => {
+      // Guarded like every sibling chmod fixture in this suite: as uid 0 the
+      // permission bits are bypassed and the directory stays readable, and on
+      // Windows chmod on a directory only toggles the read-only attribute —
+      // in both cases `recordDirUnreadable` stays null and this fails on a
+      // required merge-queue leg for a reason that has nothing to do with the
+      // code.
+      const recordDir = promptRecordDir(plan);
+      chmodSync(recordDir, 0o000);
+      try {
+        const r = recoverFindings({ plan, out: out() }, ENV);
+        expect(r.recordDirUnreadable).not.toBeNull();
+      } finally {
+        chmodSync(recordDir, 0o755);
+      }
+    },
+  );
+
+  it('fences the built prompts by the run epoch — a retry owes only its own keys', () => {
+    // Nothing clears the record dir, and the CI retry re-runs the review at
+    // the SAME plan path: an unfenced read enumerated keys earlier attempts
+    // built, so `missingKeys` named obligations this run does not owe and a
+    // resumed orchestrator relaunched agents whose prompts it cannot build.
+    const recordDir = promptRecordDir(plan);
+    writeFileSync(
+      join(recordDir, `${encodeURIComponent('chunk-9')}.txt`),
+      'You are chunk-9.',
+    );
+    const stale = new Date(2019, 0, 1);
+    utimesSync(
+      join(recordDir, `${encodeURIComponent('chunk-9')}.txt`),
+      stale,
+      stale,
+    );
+    const prompt = built('1a');
+    transcript('S0', 'a0', prompt, {
+      opens: [briefPath(plan, '1a')],
+      finalText: 'Covered.',
+    });
+    const r = recoverFindings({ plan, out: out() }, ENV);
+    expect(r.missingKeys).toEqual([]);
+    expect(r.recoveredKeys).toEqual(['1a']);
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'refuses a SYMLINKED findings file — the read would follow it out',
+    () => {
+      // A symlink is not the file it points at: statSync fenced on the
+      // TARGET's mtime and the resumed orchestrator's read follows the link
+      // out of the record dir entirely. Only a regular file of the dir can
+      // be handed on.
+      const recordDir = promptRecordDir(plan);
+      const key = 'reverse-audit--round-2--abc123def456';
+      const list = join(recordDir, `${encodeURIComponent(key)}.findings.md`);
+      const outside = join(dir, 'outside-findings.md');
+      writeFileSync(outside, '- FORGED: real Criticals erased');
+      symlinkSync(outside, list);
+      const brief = briefPath(plan, key);
+      writeFileSync(brief, `The ${key} brief.`);
+      const prompt =
+        `You are ${key}.\n` +
+        `read_file(file_path="${list}")\n` +
+        `read_file(file_path="${brief}")`;
+      writeFileSync(join(recordDir, `${encodeURIComponent(key)}.txt`), prompt);
+      transcript('S0', 'ra2', prompt, {
+        opens: [brief, list],
+        finalText: 'Round 2: no new issues after a full walk.',
+      });
+      const r = recoverFindings({ plan, out: out() }, ENV);
+      expect(r.findingsFiles).toEqual([]);
+    },
+  );
+
+  it('exits 1 when the transcript infrastructure is missing entirely', () => {
+    // The handler takes no env argument, so it reads `process.env` — which is
+    // what makes this a real probe of the `TranscriptsUnavailableError` exit
+    // path rather than of the suite's own `ENV` object. Stubbed explicitly
+    // rather than relied upon: a developer running the suite from inside a
+    // qwen-code session inherits both variables, and the test would then
+    // silently exercise the success path instead.
+    vi.stubEnv('QWEN_CODE_PROJECT_DIR', '');
+    vi.stubEnv('QWEN_CODE_SESSION_ID', '');
+    const handler = recoverFindingsCommand.handler as (a: unknown) => void;
+    const saved = process.exitCode;
+    try {
+      handler({ plan, out: out() });
+      expect(process.exitCode).toBe(1);
+    } finally {
+      process.exitCode = saved;
+      vi.unstubAllEnvs();
+    }
+  });
+});

--- a/packages/cli/src/commands/review/recover-findings.ts
+++ b/packages/cli/src/commands/review/recover-findings.ts
@@ -1,0 +1,462 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Hand a resumed run the interrupted attempt's agent results, from the
+// harness's records — never from the orchestrator's memory of them.
+//
+// A review's findings normally live only in the orchestrator's context: each
+// agent returns inline, and no file carries the returns. A resumed run is a
+// NEW session, so that context is gone — but the harness's transcripts are
+// not, and each one ends with the agent's own final text. This command pairs
+// the CLI's prompt records with those transcripts (the same two-author proof
+// `check-coverage` runs on) and writes the certified agents' final texts to a
+// file the resumed orchestrator reads back.
+//
+// It is an assessment, not a gate: exit 0 with whatever could be recovered,
+// and `check-coverage` remains the authority on what is still owed. The one
+// hard failure is missing transcript infrastructure — a resume with no
+// evidence to read should say so rather than print an empty recovery.
+
+import {
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+} from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import type { CommandModule } from 'yargs';
+import { atomicWriteFileSync } from '@qwen-code/qwen-code-core';
+import { writeStdoutLine, writeStderrLine } from '../../utils/stdioHelpers.js';
+import {
+  readRunTranscripts,
+  TranscriptsUnavailableError,
+  type AgentRecord,
+} from './lib/transcripts.js';
+import {
+  promptRecordDir,
+  readRecordedPrompts,
+  deliveredVerbatimLines,
+  flattenPrompt,
+  promptLines,
+  briefPath,
+  findingsPointerOf,
+} from './lib/prompt-record.js';
+import { priorSessionIds } from './lib/run-ledger.js';
+import { assignedChunk, pointedAt } from './lib/coverage.js';
+import { readBudgetStop, type BudgetStop } from './lib/deadline.js';
+
+interface RecoverFindingsArgs {
+  plan: string;
+  out: string;
+}
+
+/** One findings list a prior round left on disk, named by its record key. */
+interface FindingsFileEntry {
+  key: string;
+  path: string;
+  /** The `--round-<k>` baked into the key, when the key carries one. */
+  round: number | null;
+}
+
+export interface RecoverFindingsResult {
+  schemaVersion: 1;
+  out: string;
+  /** Keys whose agent was certified and whose final text was recovered. */
+  recoveredKeys: string[];
+  /** Keys the CLI built a prompt for with no certifiable transcript. */
+  missingKeys: string[];
+  /**
+   * Every `.findings.md` in the record dir whose path a CERTIFIED
+   * transcript's recorded prompt points at — the model-state snapshots.
+   * The record dir is attempt-1-writable, and a planted list the mtime
+   * fence admits would otherwise be relayed as the interrupted attempt's
+   * own cumulative state; the pointer a certified agent was launched with
+   * is the authorship corroboration, and a file it names nowhere is not
+   * enumerated.
+   */
+  findingsFiles: FindingsFileEntry[];
+  /** Highest round among certified reverse-audit agents, null if none. */
+  latestReverseAuditRound: number | null;
+  /** The budget-stop marker still standing, if any (round-cap survives). */
+  budgetStop: BudgetStop | null;
+  /** How many earlier sessions the run ledger names. */
+  priorSessions: number;
+  /**
+   * The errno when the prompt-record directory could not be listed, else
+   * null. An empty recovery and an unreadable one must not print alike: the
+   * first says the interrupted attempt achieved nothing, the second says
+   * this run cannot tell.
+   */
+  recordDirUnreadable: string | null;
+}
+
+const ROUND_IN_KEY_RE = /--round-(\d+)(?:--|$)/;
+
+/**
+ * Certify one transcript against one built prompt — the same bar coverage
+ * holds a live launch to: the CLI-built prompt arrived verbatim, and the
+ * agent demonstrably opened its brief or the diff. Prose proves nothing.
+ */
+const UNCOVERABLE_RE = /^\s*Uncoverable:\s*chunk\s+(\d+)\b/im;
+
+/**
+ * Certify one transcript against one built prompt — the SAME bar the live
+ * pipeline holds a launch to, branch for branch.
+ *
+ * It used to be a re-implementation, and re-implementing a bar means drifting
+ * from it. `openedBrief || diffToolCalls > 0` certified three things the
+ * pipeline refuses: a chunk agent that opened its brief and never the diff
+ * (coverage requires the diff read for a chunk-assigned record), a
+ * verify/reverse-audit agent that opened the diff and never its brief (the
+ * brief carries the method and the cumulative findings list), and a verifier
+ * that skipped the findings-list read the compose-time gate requires of the
+ * same key. Each handed the resumed orchestrator uncertified prose labelled
+ * as certified.
+ */
+/**
+ * The chunk a KEY assigns: `chunk-13` → 13, and the per-chunk audit shapes —
+ * `reverse-audit--chunk-13--round-2--<digest>` — carry theirs in a `--chunk-N`
+ * segment. Parsing only the bare form left those keys chunk-less, and with
+ * the production launch prompt carrying no `chunk N of M` line either, the
+ * bar's diff-read requirement silently vanished for exactly the auditors
+ * whose territory is a chunk.
+ */
+function chunkOfKey(key: string): number | null {
+  const m = /^chunk-(\d+)$/.exec(key) ?? /--chunk-(\d+)(?:--|$)/.exec(key);
+  return m ? Number(m[1]) : null;
+}
+
+function meetsBar(
+  rec: AgentRecord,
+  planPath: string,
+  key: string,
+  builtPrompt: string,
+  plan: { chunks: Array<{ id: number; startLine: number; endLine: number }> },
+): boolean {
+  // RETURNED first, like every certification consumer: `finalText` keeps the
+  // last non-empty assistant text, which includes progress narrated between
+  // tool calls, and a mid-flight-dead agent's narration must not be handed
+  // to the resumed orchestrator as certified final text.
+  if (!rec.returned) return false;
+  // The DUTY chunk — the territory whose diff read the key demands — comes
+  // from the key, with the prompt as fallback: recovery is matching a record
+  // to a KEY the CLI built, which names the chunk directly.
+  const chunk = chunkOfKey(key) ?? assignedChunk(rec);
+  // The VETO chunk is the record's OWN assignment — `assignedChunk(rec)`,
+  // exactly as both pipeline authorities key it (coverage's walk and its
+  // `certifies()`). A per-chunk audit key names a chunk, but the production
+  // per-chunk audit prompt carries no `chunk N of M` line, and keying the
+  // veto on the KEY's chunk dropped a certified auditor whose final text
+  // QUOTED its own chunk's declaration (the briefs mandate verbatim
+  // quoting) — while coverage counted the same record as recovered work:
+  // two authorities of one pipeline answering oppositely about one
+  // transcript. `latestReverseAuditRound` regressed with the drop and the
+  // resumed run restarted a round the dead attempt had completed.
+  const own = assignedChunk(rec);
+  const declared = UNCOVERABLE_RE.exec(rec.finalText);
+  if (declared !== null && own !== null && Number(declared[1]) === own) {
+    return false;
+  }
+  // EVERY role opens its brief — the live walk gates `ok` on `unreadBriefs`
+  // for chunk agents too: the brief carries the severity bar, the finding
+  // format and the project's own rules, and a chunk agent that skipped it
+  // reviewed against rules it never saw.
+  const openedBrief = rec.successfulCallArgs.some((a) =>
+    a.includes(JSON.stringify(briefPath(planPath, key))),
+  );
+  if (!openedBrief) return false;
+  if (/^chunk-\d+$/.test(key)) {
+    // The chunk ROLE only — its proof of territory is the diff it opened,
+    // and its prompt names no findings list. Keyed on the exact bare form:
+    // `chunk !== null` also matched per-chunk VERIFY shards
+    // (`verify--chunk-N--…`), certifying them on a diff read alone and
+    // skipping the findings floor coverage's `deliveryOf` holds every
+    // verify key to.
+    return rec.diffToolCalls > 0;
+  }
+  // The chunk-less roles (whole-diff auditors) have no chunk floor, but the
+  // live walk still holds them to the reads their OWN prompt spelled out —
+  // pointed at diff lines and never opened the diff is `unopenedAgents`
+  // there. Mirrored here, or a round-level auditor that opened the brief
+  // and the findings list but never the diff certifies, its round counts
+  // as reviewed, and the territory is never relaunched.
+  const chunklessFloor =
+    pointedAt(builtPrompt, plan).length === 0 || rec.diffToolCalls > 0;
+  // The findings floor keys on the POINTER the recorded prompt names — not a
+  // path derived from the record key, which never matches for per-chunk
+  // reverse-audit keys (their findings file is keyed without the chunk).
+  // Deriving from the key made the floor silently vanish for exactly those
+  // auditors, and compose-time then ruled the same key `findings-unread`.
+  const pointer = findingsPointerOf(builtPrompt);
+  if (pointer === null) {
+    return chunk !== null ? rec.diffToolCalls > 0 : chunklessFloor;
+  }
+  const readList = rec.successfulReadFileArgs.some((a) =>
+    a.includes(JSON.stringify(pointer)),
+  );
+  if (!readList) return false;
+  return chunk !== null ? rec.diffToolCalls > 0 : chunklessFloor;
+}
+
+export function recoverFindings(
+  args: RecoverFindingsArgs,
+  env: NodeJS.ProcessEnv = process.env,
+): RecoverFindingsResult {
+  const planPath = args.plan;
+  const outPath = resolve(args.out);
+  if (outPath === resolve(planPath)) {
+    throw new Error('--out must not overwrite the plan');
+  }
+  let planRaw: unknown;
+  try {
+    planRaw = JSON.parse(readFileSync(planPath, 'utf8'));
+  } catch (err) {
+    throw new Error(
+      `could not read the plan report ${planPath}: ${(err as Error).message}`,
+    );
+  }
+  const plan = planRaw as { diffPathAbsolute?: unknown; chunks?: unknown };
+  const planChunks = {
+    chunks: (Array.isArray(plan.chunks) ? plan.chunks : []).filter(
+      (c): c is { id: number; startLine: number; endLine: number } =>
+        typeof c === 'object' &&
+        c !== null &&
+        typeof (c as { id?: unknown }).id === 'number' &&
+        typeof (c as { startLine?: unknown }).startLine === 'number' &&
+        typeof (c as { endLine?: unknown }).endLine === 'number',
+    ),
+  };
+  const diffPath =
+    typeof plan.diffPathAbsolute === 'string' && plan.diffPathAbsolute !== ''
+      ? plan.diffPathAbsolute
+      : undefined;
+  const sinceMs = statSync(planPath).mtimeMs;
+  // The plan mtime is this run's epoch. Nothing clears the record dir, and a
+  // resume re-runs the review at the SAME plan path, so an unfenced read
+  // would enumerate keys earlier runs of this PR built — `missingKeys` would
+  // name obligations this run does not owe. The trusted writers here (the
+  // CLI and the developer) never rewind that mtime, so the fence is a plain
+  // staleness cut, not an integrity check.
+  const built = readRecordedPrompts(planPath, sinceMs);
+  // The current session has launched nothing yet when this runs — that is
+  // the point of running it — so its missing transcript dir is the expected
+  // state, not the infrastructure failure it would be for check-coverage.
+  const records = readRunTranscripts(planPath, sinceMs, env, diffPath, {
+    currentDirOptional: true,
+  });
+
+  // Pair each transcript with the built prompts it delivered verbatim. The
+  // injectivity rule is retirement's: a transcript that matches MORE THAN ONE
+  // built prompt certifies none of them — "one agent taking a stack of
+  // chunks" must not resurface on the recovery path.
+  // Flatten each launch once and split each built prompt once: the pairing
+  // is N×M, and `wasDeliveredVerbatim` would otherwise redo both halves of
+  // that work on every pair (the helper family exists for exactly this).
+  const builtLines = new Map<string, string[]>();
+  for (const [key, prompt] of built) {
+    if (prompt.trim() === '') continue;
+    builtLines.set(key, promptLines(prompt));
+  }
+  const matchesOf = new Map<AgentRecord, string[]>();
+  for (const rec of records) {
+    const launch = flattenPrompt(rec.launchPrompt);
+    const keys: string[] = [];
+    for (const [key, lines] of builtLines) {
+      if (deliveredVerbatimLines(launch, lines)) keys.push(key);
+    }
+    matchesOf.set(rec, keys);
+  }
+
+  // Certified transcripts PER KEY. The injectivity rule is retirement's: a
+  // transcript that matched MORE THAN ONE built prompt (one agent taking a
+  // stack of chunks) certifies none of them. A legitimate relaunch can leave
+  // two certified transcripts for one key; the newest by mtime is the
+  // interrupted attempt's latest word, so it wins.
+  const recovered = new Map<string, AgentRecord>();
+  const recoveredMtime = new Map<string, number>();
+  for (const [rec, keys] of matchesOf) {
+    if (keys.length !== 1) continue; // unmatched, or the injectivity refusal
+    const key = keys[0];
+    if (!meetsBar(rec, planPath, key, built.get(key) ?? '', planChunks)) {
+      continue;
+    }
+    if (rec.finalText.trim() === '') continue;
+    const prior = recoveredMtime.get(key);
+    if (prior === undefined || rec.mtimeMs > prior) {
+      recovered.set(key, rec);
+      recoveredMtime.set(key, rec.mtimeMs);
+    }
+  }
+
+  const recoveredKeys = [...recovered.keys()].sort();
+  const missingKeys = [...built.keys()]
+    .filter((k) => built.get(k)?.trim() !== '' && !recovered.has(k))
+    .sort();
+
+  // The findings lists a CERTIFIED agent was actually pointed at: the
+  // pointer each recovered key's recorded prompt carries. The enumeration
+  // below admits only these — the record dir is attempt-1-writable, and a
+  // planted `.findings.md` the mtime fence admits is exactly the foreign
+  // state this corroboration keeps out.
+  const corroboratedFindings = new Set<string>();
+  for (const key of recoveredKeys) {
+    const pointer = findingsPointerOf(built.get(key) ?? '');
+    if (pointer !== null) corroboratedFindings.add(resolve(pointer));
+  }
+
+  // The findings lists earlier rounds wrote — the on-disk snapshots of the
+  // orchestrator's cumulative state. Enumerated from the record dir the CLI
+  // owns; names decode back to keys exactly (they were percent-encoded).
+  const recordDir = promptRecordDir(planPath);
+  const findingsFiles: FindingsFileEntry[] = [];
+  let names: string[] = [];
+  let recordDirUnreadable: string | null = null;
+  try {
+    names = readdirSync(recordDir).sort();
+  } catch (err) {
+    names = [];
+    // "Could not look" and "there was nothing" print identically otherwise:
+    // an empty recovery on a run whose records are unreachable would read as
+    // an interrupted attempt that had simply achieved nothing.
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code !== 'ENOENT') {
+      recordDirUnreadable = code ?? (err as Error).message;
+    }
+  }
+  for (const name of names) {
+    if (!name.endsWith('.findings.md')) continue;
+    let key: string;
+    try {
+      key = decodeURIComponent(name.slice(0, -'.findings.md'.length));
+    } catch {
+      continue;
+    }
+    const path = join(recordDir, name);
+    // lstat, never stat: a symlink is not the file it points at. `statSync`
+    // would fence on the TARGET's mtime — attacker-chosen — and the read
+    // the resumed orchestrator makes would follow the link out of the
+    // record dir entirely, `resolve()` being lexical. Only a regular file
+    // of this dir can be a findings list this run may hand on.
+    let st: ReturnType<typeof lstatSync>;
+    try {
+      st = lstatSync(path);
+    } catch {
+      continue;
+    }
+    if (!st.isFile()) continue;
+    // The run-epoch fence every reader here applies: nothing clears the
+    // record dir, so a PREVIOUS review of the same PR leaves its rounds'
+    // findings lists behind, and handing one to a resumed run would restore
+    // a foreign attempt's state as this one's.
+    if (st.mtimeMs < sinceMs) continue;
+    // The corroborated pointer proves a certified agent was POINTED at this
+    // path — the authorship link the enumeration needs. A file no certified
+    // prompt names is not this run's cumulative state and is left out.
+    if (!corroboratedFindings.has(resolve(path))) continue;
+    const m = ROUND_IN_KEY_RE.exec(key);
+    findingsFiles.push({
+      key,
+      path,
+      round: m ? Number(m[1]) : null,
+    });
+  }
+
+  let latestReverseAuditRound: number | null = null;
+  for (const key of recoveredKeys) {
+    if (!key.startsWith('reverse-audit')) continue;
+    const m = ROUND_IN_KEY_RE.exec(key);
+    if (!m) continue;
+    const round = Number(m[1]);
+    if (latestReverseAuditRound === null || round > latestReverseAuditRound) {
+      latestReverseAuditRound = round;
+    }
+  }
+
+  const sections: string[] = [
+    '# Recovered agent results',
+    '',
+    'Written by `qwen review recover-findings` from the harness transcripts',
+    "of the interrupted attempt. Each section is one certified agent's own",
+    'final text, verbatim. Findings in here still owe Step 4 verification',
+    'unless a findings list already carries them as verified.',
+    '',
+  ];
+  for (const key of recoveredKeys) {
+    const rec = recovered.get(key) as AgentRecord;
+    // Keys embed PR file paths (the invariant agents), and git allows
+    // newlines in filenames — a raw key would let a hostile path forge
+    // `## ` section boundaries in the one channel this command exists to
+    // keep clean. Control characters carry no finding text; a space
+    // cannot forge structure.
+    const header =
+      // eslint-disable-next-line no-control-regex -- control chars are exactly what must not reach the markdown
+      key.replace(/[\u0000-\u001f\u007f\u2028\u2029]+/g, ' ');
+    sections.push(`## ${header}`, '', rec.finalText.trim(), '');
+  }
+  // The sibling with the identical --plan/--out contract does this too. The
+  // recovered list can be the only surviving copy of an interrupted attempt's
+  // results, and a missing parent directory turned that into a raw ENOENT
+  // crash — in exactly the post-mortem context this command exists for.
+  mkdirSync(dirname(outPath), { recursive: true });
+  atomicWriteFileSync(outPath, sections.join('\n'), { noFollow: true });
+
+  return {
+    schemaVersion: 1,
+    out: outPath,
+    recoveredKeys,
+    missingKeys,
+    findingsFiles,
+    latestReverseAuditRound,
+    budgetStop: readBudgetStop(planPath),
+    recordDirUnreadable,
+    priorSessions: priorSessionIds(planPath, env).length,
+  };
+}
+
+export const recoverFindingsCommand: CommandModule = {
+  command: 'recover-findings',
+  describe:
+    'Recover the certified agent results of an interrupted review run from the harness transcripts, for a resumed run to read back',
+  builder: (yargs) =>
+    yargs
+      .option('plan', {
+        type: 'string',
+        demandOption: true,
+        describe: 'The plan report from Step 1 (fetch-pr output)',
+      })
+      .option('out', {
+        type: 'string',
+        demandOption: true,
+        describe:
+          'Where to write the recovered final texts (Markdown, one section per certified agent)',
+      })
+      .version(false),
+  handler: (argv) => {
+    try {
+      const result = recoverFindings(argv as unknown as RecoverFindingsArgs);
+      writeStdoutLine(JSON.stringify(result));
+      writeStderrLine(
+        `recover-findings: ${result.recoveredKeys.length} agent result(s) recovered, ` +
+          `${result.missingKeys.length} still owed; wrote ${result.out}`,
+      );
+      if (result.recordDirUnreadable !== null) {
+        writeStderrLine(
+          `WARNING: the prompt-record directory could not be read ` +
+            `(${result.recordDirUnreadable}); this recovery is a floor, not a ` +
+            `complete account of the interrupted attempt.`,
+        );
+      }
+    } catch (err) {
+      if (err instanceof TranscriptsUnavailableError) {
+        writeStderrLine(`recover-findings: ${err.message}`);
+        process.exitCode = 1;
+        return;
+      }
+      throw err;
+    }
+  },
+};


### PR DESCRIPTION
## What this PR does

Adds the resume capability itself, on top of the session-ledger groundwork. `fetch-pr` gains `--resume`: it rules on facts it gathers itself — the previous report parses and is this PR's, the worktree still sits at `fetchedSha`, the diff bytes on disk hash to the plan's `diffSha256` (content is the checkpoint key: changed input re-runs by construction), the live PR head has not moved, and the resume cap (2) is unspent — and on a pass it skips the stale-state sweep, reuses the worktree, and deliberately does not rewrite the plan, so its mtime keeps the first attempt's records, budget stamps and transcripts inside every reader's run-epoch fence. It prints one machine-readable stdout line either way: `{"resumed":true,...}` on a continuation, or `{"resumed":false,"resumeRefused":"<reason>"}` after falling through to a completely normal fresh fetch — the flag never fails a run that could start over. Budget hygiene on a continuation: a `time-budget` stop marker is the dead attempt's and is cleared (a `round-cap` stop is about rounds, not time, and stands), and the admission stamps are dropped because a span across the death gap would price a round at hours; the gate falls back to its conservative constant, whose failure direction is an early stop with a disclosure. A refusal for `head-moved` records the review's one head-movement restart on disk (the SKILL rule that previously lived only in transcript memory).

The new `recover-findings` subcommand hands the resumed session the interrupted attempt's results. A review's findings normally exist only in the orchestrator's context — each agent returns inline — and a resumed run is a new session, so that context is gone; but the harness transcripts are not, and each ends with the agent's own final text. The command certifies each transcript against the CLI's prompt records under the same bar coverage holds a live launch to (verbatim-delivered prompt, opened brief or diff, plus the retirement injectivity rule: a transcript matching two records certifies neither) and writes the certified final texts to a CLI-authored file the new orchestrator reads back, together with the on-disk per-round findings lists and the latest certified reverse-audit round. It runs before the new session has launched anything, so a missing current-session transcript directory is the expected pre-launch state there — env-less invocation still fails as the infrastructure fact it is.

## Why it's needed

Stacked on #9091 (second of three). The ledger lets readers see an earlier attempt's evidence; this PR adds the two decisions that make a retry an actual continuation: whether the on-disk state is still the state that was left (every check fails toward a fresh run — resuming on stale state would continue a review of code nobody is reviewing), and how the new orchestrator recovers the results the dead one held in context. The design mirrors a resume mechanism proven elsewhere: content hashes as checkpoint keys, strict precondition validation, and "unverifiable reads as absent" so fabrication can never mint credit.

## Reviewer Test Plan

### How to verify

Unit: `cd packages/cli && npx vitest run src/commands/review` — `lib/resume.test.ts` walks the full refusal matrix one broken link at a time (each test expects the FIRST failed check's reason, including "unreachable forge is not head-moved"), `fetch-pr.test.ts`'s `--resume` block covers the continuation (report file untouched, single `{"resumed":true}` line), the head-moved/diff-tampered/no-report fall-throughs, and flag-off inertness; `recover-findings.test.ts` covers certification, the injectivity refusal, newest-relaunch-wins, findings-file enumeration and the pre-launch missing-dir state; `lib/deadline.test.ts` covers `clearRoundStamps`.

End-to-end against the real bundle (no model needed): a local bare repo serving `refs/pull/42/head` as the forge, a stub `gh` on PATH, and the test playing the harness by writing transcripts. Attempt 1 ran real `fetch-pr` + `agent-prompt --roster`, "completed" 2 of 14 agents, and died; attempt 2 under a new session id ran `fetch-pr ... --resume` → `{"resumed":true,"resumeAttempt":1}` with the plan's mtime byte-identical, `recover-findings` recovered exactly the two certified final texts (the seeded Critical came back verbatim; 12 keys reported missing), and after the resumed session launched the remaining 12, `check-coverage` passed with `recoveredAgents: 2` and the continuity disclosure. Mutations all refused as designed: one byte appended to the diff → `diff-hash-mismatch` (and the fresh fall-through self-heals the diff), forged head → `head-moved` with the restart recorded in `resume.json`, marker pre-loaded with 2 resumes → `resume-cap`, a forged ledger entry naming a nonexistent session → no crash and no credit.

### Evidence (Before & After)

N/A — CLI subcommands; the E2E outputs above are the observable behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

vitest; E2E via `node dist/cli.js` (root bundle built from this source) against a local bare-repo forge with a stubbed `gh`.

## Risk & Scope

- Main risk or tradeoff: a model deleting `resume.json` weakens the resume cap — accepted and documented; the session ledger's entry count and the workflow's MAX_ATTEMPTS remain the hard bounds. Dropping budget stamps on resume trades round-cost memory for never pricing the death gap as a round.
- Not validated / out of scope: nothing invokes `--resume` yet — the `/review` grammar, `review run` flag and CI wiring are PR 3; local (non-PR) reviews have no resume path by design.
- Breaking changes / migration notes: none; without `--resume`, `fetch-pr` is byte-for-byte its previous behavior plus the PR-1 ledger append.

## Linked Issues

Stacked on #9091; the wiring PR follows.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在 session 台账地基之上加入续跑能力本体。`fetch-pr` 新增 `--resume`：它只依据自己采集的事实裁决——上一份报告可解析且属于本 PR、worktree 仍停在 `fetchedSha`、磁盘上的 diff 字节哈希等于 plan 的 `diffSha256`（内容即检查点键：输入变了就重跑，由构造保证）、PR 的线上 head 未移动、续跑上限（2 次）未用尽——通过则跳过陈旧状态清扫、复用 worktree，并且刻意不重写 plan，让其 mtime 把第一次尝试的记录、预算戳与 transcripts 全部留在各读取方的 run-epoch 栅栏之内。无论哪个分支都在 stdout 打印一行机器可读输出：续跑时为 `{"resumed":true,...}`，否则落回完全正常的全新抓取并打印 `{"resumed":false,"resumeRefused":"<原因>"}`——该 flag 绝不会让一个本可从头开始的运行失败。续跑时的预算卫生：`time-budget` 停止标记属于挂掉的那次尝试，予以清除（`round-cap` 停止关乎轮数而非时间，保留）；轮次准入戳被删除，因为跨越死亡间隙的时间跨度会把一轮定价成数小时——门禁回退到保守常数，其失败方向是提前停止并披露。因 `head-moved` 拒绝时，把本评审仅有一次的 head 移动重启记到磁盘（此前该规则只存在于 transcript 记忆里）。

新子命令 `recover-findings` 把中断尝试的成果交还给续跑 session。评审的 findings 通常只存在于编排者上下文中——每个 agent 内联返回——而续跑是新 session，那份上下文已经消失；但 harness transcripts 还在，每份末尾都是 agent 自己的最终文本。该命令按 coverage 对现场发射相同的门槛（逐字送达的 prompt、打开过 brief 或 diff，外加退休调度器的单射规则：一份 transcript 匹配两条记录则一条也不认证）对照 CLI 的 prompt 记录认证每份 transcript，把认证通过的最终文本写入一个由 CLI 撰写、新编排者读回的文件，连同磁盘上的各轮 findings 清单与最近一轮已认证的反向审计轮号。它在新 session 尚未发射任何 agent 之前运行，因此当前 session transcript 目录缺失是预期中的发射前状态——缺少环境变量的调用仍按基础设施故障失败。

## 为什么需要

堆叠于 #9091（三个之二）。台账让读取方看得见前一次尝试的证据；本 PR 补上让重试成为真正续跑的两个决定：磁盘状态是否仍是当时留下的状态（每项检查都朝全新运行方向失败——在陈旧状态上续跑等于继续评审一份没人在审的代码），以及新编排者如何恢复挂掉的那位保存在上下文里的成果。设计借鉴了一套已被验证的恢复机制：内容哈希做检查点键、严格的前置校验、以及「无法核验即视为不存在」，使伪造永远无法铸造采信。

## 审阅者验证方案

### 如何验证

单测：`cd packages/cli && npx vitest run src/commands/review`——`lib/resume.test.ts` 逐个打断链条走完整个拒绝矩阵（每个用例断言第一个失败检查的原因，含「联系不上 forge 不算 head-moved」）；`fetch-pr.test.ts` 的 `--resume` 块覆盖续跑（报告文件不动、单行 `{"resumed":true}`）、head-moved/diff 被篡改/无报告三种落回、以及不带 flag 时完全不生效；`recover-findings.test.ts` 覆盖认证、单射拒绝、最新重发射胜出、findings 文件枚举与发射前目录缺失态；`lib/deadline.test.ts` 覆盖 `clearRoundStamps`。

针对真实 bundle 的端到端（无需模型）：本地 bare 仓库以 `refs/pull/42/head` 充当 forge，PATH 上放 `gh` 桩，由测试扮演 harness 写 transcripts。第一次尝试真实运行 `fetch-pr` + `agent-prompt --roster`，「完成」14 个 agent 中的 2 个后死亡；第二次尝试换新 session id 运行 `fetch-pr ... --resume` → `{"resumed":true,"resumeAttempt":1}` 且 plan 的 mtime 逐字节不变，`recover-findings` 恰好恢复出两份已认证的最终文本（预埋的 Critical 原文返回；报告 12 个 key 缺失），续跑 session 补发其余 12 个后，`check-coverage` 以 `recoveredAgents: 2` 通过并携带续跑披露。变异全部按设计拒绝：diff 追加一个字节 → `diff-hash-mismatch`（落回的全新抓取自愈了 diff）、伪造 head → `head-moved` 且重启记入 `resume.json`、预置 2 次续跑的 marker → `resume-cap`、指向不存在 session 的伪造台账条目 → 不崩溃且零采信。

### 证据（前后对比）

N/A——CLI 子命令；上述端到端输出即可观察行为。

### 已测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

vitest；端到端经 `node dist/cli.js`（由本源码构建的根 bundle）对本地 bare 仓库 forge + `gh` 桩运行。

## 风险与范围

- 主要风险或取舍：模型删除 `resume.json` 会削弱续跑上限——已接受并记入文档；session 台账条目数与 workflow 的 MAX_ATTEMPTS 仍是硬上界。续跑时删除预算戳，以放弃轮成本记忆换取绝不把死亡间隙定价成一轮。
- 未验证 / 范围外：目前尚无任何入口调用 `--resume`——`/review` 文法、`review run` flag 与 CI 接线在 PR 3；本地（非 PR）评审按设计没有续跑路径。
- 破坏性变更 / 迁移说明：无；不带 `--resume` 时 `fetch-pr` 的行为与之前逐字节一致，仅多了 PR 1 的台账追加。

## 关联 Issue

堆叠于 #9091；接线 PR 随后。

</details>
