### PR TITLE
fix(core): bound the workflow meta evaluation

### DIFF
--- a/packages/core/src/agents/runtime/workflow-sandbox.test.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.test.ts
@@ -383,6 +383,99 @@ describe('extractAndStripMeta', () => {
     );
   });
 
+  it('bounds async meta continuations inside the vm timeout', () => {
+    const src = `export const meta = {
+      name: (async () => { await 0; while (true) {} })(),
+      description: 'd',
+    }
+    return 1`;
+    expect(() => extractAndStripMeta(src)).toThrow(
+      /failed to evaluate meta object literal/,
+    );
+  });
+
+  it('neutralizes rejected Promises when a later field times out', async () => {
+    const src = `export const meta = {
+      name: Promise.reject(new Error('dangling')),
+      description: (function () { while (true) {} })(),
+    }
+    return 1`;
+    expect(() => extractAndStripMeta(src)).toThrow(
+      /failed to evaluate meta object literal/,
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  });
+
+  it('neutralizes every rejected Promise before rejecting meta', async () => {
+    const src = `export const meta = {
+      name: 'x',
+      description: 'd',
+      first: Promise.reject(new Error('first')),
+      second: Promise.reject(new Error('second')),
+    }
+    return 1`;
+    expect(() => extractAndStripMeta(src)).toThrow(
+      /meta values must not be Promises/,
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  });
+
+  it('neutralizes rejected Promise subclasses without invoking their species', async () => {
+    const src = `export const meta = {
+      name: 'x',
+      description: 'd',
+      extra: (() => {
+        class MetaPromise extends Promise {
+          static get [Symbol.species]() { while (true) {} }
+        }
+        return MetaPromise.reject(new Error('subclass'));
+      })(),
+    }
+    return 1`;
+    expect(() => extractAndStripMeta(src)).toThrow(
+      /meta values must not be Promises/,
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  });
+
+  it('does not coerce vm-thrown values in the host realm', () => {
+    const src = `export const meta = {
+      name: (function () {
+        throw { toString() { while (true) {} } };
+      })(),
+      description: 'd',
+    }
+    return 1`;
+    expect(() => extractAndStripMeta(src)).toThrow(
+      /failed to evaluate meta object literal/,
+    );
+  });
+
+  it('uses captured vm intrinsics while copying meta', async () => {
+    const src = `export const meta = {
+      name: (Object.keys = () => ['name', 'description'], 'x'),
+      description: 'd',
+      hidden: Promise.reject(new Error('hidden')),
+    }
+    return 1`;
+    expect(() => extractAndStripMeta(src)).toThrow(
+      /meta values must not be Promises/,
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  });
+
+  it('does not depend on mutable Array methods while copying meta', () => {
+    const src = `export const meta = {
+      name: (Array.prototype.includes = () => false, 'x'),
+      description: 'd',
+    }
+    return 1`;
+    expect(extractAndStripMeta(src).meta).toEqual({
+      name: 'x',
+      description: 'd',
+    });
+  });
+
   // P4 Round 7 (wenshao): `phase('X'); phase('X')` previously yielded
   // `outcome.phases = ['X','X']` (sandbox unconditional push) while the
   // registry's onPhaseStarted deduped to `entry.phases = ['X']`. The

--- a/packages/core/src/agents/runtime/workflow-sandbox.test.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.test.ts
@@ -266,12 +266,9 @@ describe('extractAndStripMeta', () => {
     expect(() => extractAndStripMeta(src)).toThrow(/unbalanced/i);
   });
 
-  // The meta literal is model-authored source, and every caller evaluates it
-  // on a path where a wedged thread is unrecoverable: the tool-confirmation
-  // dialog (the user has not consented yet, so there is nothing to cancel)
-  // and saved-workflow enumeration (no run exists to abort). A synchronous
-  // IIFE that never returns must therefore surface as an ordinary malformed
-  // -meta error, not as a hang.
+  // Meta is evaluated at the top of sandbox.run() before its watchdog is
+  // armed. A synchronous IIFE that never returns must therefore surface as
+  // an ordinary malformed-meta error, not as a hang.
   it('a meta field that never returns times out instead of hanging', () => {
     const src = `export const meta = { name: (function () { while (true) {} })(), description: 'd' }\nreturn 1`;
     const startedAt = Date.now();
@@ -288,6 +285,39 @@ describe('extractAndStripMeta', () => {
     const src = `export const meta = { name: 'w', description: 'd', phases: [{ title: 'One' }] }\nreturn 1`;
     const { meta } = extractAndStripMeta(src);
     expect(meta).toEqual({
+      name: 'w',
+      description: 'd',
+      phases: [{ title: 'One' }],
+    });
+  });
+
+  it('bounds accessor execution while copying meta values', () => {
+    const src = `export const meta = {
+      get name() {
+        const until = Date.now() + 1_000;
+        while (Date.now() < until) {}
+        return 'late';
+      },
+      description: 'd',
+    }
+    return 1`;
+    const startedAt = Date.now();
+    expect(() => extractAndStripMeta(src)).toThrow(
+      /failed to evaluate meta object literal/,
+    );
+    expect(Date.now() - startedAt).toBeLessThan(5_000);
+  });
+
+  it('does not invoke a custom phases iterator in the host realm', () => {
+    const src = `export const meta = {
+      name: 'w',
+      description: 'd',
+      phases: Object.defineProperty([{ title: 'One' }], Symbol.iterator, {
+        value() { throw new Error('custom iterator invoked'); },
+      }),
+    }
+    return 1`;
+    expect(extractAndStripMeta(src).meta).toEqual({
       name: 'w',
       description: 'd',
       phases: [{ title: 'One' }],

--- a/packages/core/src/agents/runtime/workflow-sandbox.test.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.test.ts
@@ -266,6 +266,34 @@ describe('extractAndStripMeta', () => {
     expect(() => extractAndStripMeta(src)).toThrow(/unbalanced/i);
   });
 
+  // The meta literal is model-authored source, and every caller evaluates it
+  // on a path where a wedged thread is unrecoverable: the tool-confirmation
+  // dialog (the user has not consented yet, so there is nothing to cancel)
+  // and saved-workflow enumeration (no run exists to abort). A synchronous
+  // IIFE that never returns must therefore surface as an ordinary malformed
+  // -meta error, not as a hang.
+  it('a meta field that never returns times out instead of hanging', () => {
+    const src = `export const meta = { name: (function () { while (true) {} })(), description: 'd' }\nreturn 1`;
+    const startedAt = Date.now();
+    expect(() => extractAndStripMeta(src)).toThrow(
+      /failed to evaluate meta object literal/,
+    );
+    // Generous multiple of META_EVAL_TIMEOUT_MS (250ms): this asserts the
+    // timeout fired at all, not how precisely it fired, so it stays stable
+    // on a loaded CI runner.
+    expect(Date.now() - startedAt).toBeLessThan(5_000);
+  });
+
+  it('a well-formed meta literal is unaffected by the eval timeout', () => {
+    const src = `export const meta = { name: 'w', description: 'd', phases: [{ title: 'One' }] }\nreturn 1`;
+    const { meta } = extractAndStripMeta(src);
+    expect(meta).toEqual({
+      name: 'w',
+      description: 'd',
+      phases: [{ title: 'One' }],
+    });
+  });
+
   // P4a adversarial review (HIGH × 3 lenses): the docstring at
   // workflow-sandbox.ts:283-294 promises the returned meta is HOST-realm —
   // a per-field copy that defends against T1/T8/T14-style vm-realm escape

--- a/packages/core/src/agents/runtime/workflow-sandbox.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.ts
@@ -168,11 +168,10 @@ export interface WorkflowMeta {
  *      invocation time, not replayed during resume, so non-determinism in
  *      the meta literal (a `Date.now()` call in `meta.name`) does not
  *      break the resume contract that the script body honors.
- *   3. The vm result is walked field-by-field and copied into a new
- *      host-realm plain object. No JSON round-trip is needed because every
- *      contract field is a primitive — strings and arrays of plain
- *      objects with string fields — so prototype identity on the
- *      intermediate values is irrelevant.
+ *   3. The vm result is serialized in the bounded context, then parsed into
+ *      a new host-realm plain object. Every contract field is a primitive —
+ *      strings and arrays of plain objects with string fields — so the JSON
+ *      round-trip also severs vm-realm prototypes.
  *
  * Returns `{ stripped, meta: null }` when no meta declaration is present
  * (callers treat this as "no meta"). Throws when meta is present but
@@ -195,48 +194,98 @@ export function extractAndStripMeta(source: string): {
   // / `args` / workflow-sandbox bridge globals). The vm realm still
   // provides its own intrinsics, but that's intentional — see the
   // docstring above.
-  const metaContext = vm.createContext(Object.create(null));
+  const metaContext = vm.createContext(Object.create(null), {
+    microtaskMode: 'afterEvaluate',
+  });
+  let attachingPromiseHandler = false;
+  const stopTrackingPromises = promiseHooks.createHook({
+    init(promise) {
+      if (attachingPromiseHandler) return;
+      attachingPromiseHandler = true;
+      try {
+        // Promise#then consults @@species; hide a model-defined constructor
+        // while attaching the host rejection handler.
+        Object.defineProperty(promise, 'constructor', {
+          configurable: true,
+          value: Promise,
+        });
+        void Promise.prototype.then.call(promise, undefined, () => undefined);
+      } finally {
+        Reflect.deleteProperty(promise, 'constructor');
+        attachingPromiseHandler = false;
+      }
+    },
+  });
   let serialized: unknown;
+  let evaluationFailed = false;
   try {
     serialized = new vm.Script(
       `(() => {
+        const apply = Reflect.apply;
+        const arrayIsArray = Array.isArray;
+        const arrayPush = Array.prototype.push;
+        const jsonStringify = JSON.stringify;
+        const objectCreate = Object.create;
+        const objectKeys = Object.keys;
+        const weakSetAdd = WeakSet.prototype.add;
+        const weakSetDelete = WeakSet.prototype.delete;
+        const weakSetHas = WeakSet.prototype.has;
         const active = new WeakSet();
+        let hasThenable = false;
         function copy(value) {
-          if (value === null || ['string', 'number', 'boolean'].includes(typeof value)) {
+          const type = typeof value;
+          if (value === null || type === 'string' || type === 'number' || type === 'boolean') {
             return value;
           }
-          if (typeof value !== 'object') return undefined;
-          if (active.has(value)) return undefined;
-          active.add(value);
+          if (type !== 'object') return undefined;
+          if (apply(weakSetHas, active, [value])) return undefined;
+          apply(weakSetAdd, active, [value]);
           if (typeof value.then === 'function') {
-            try { value.catch(() => {}); } catch {}
-            throw new Error(
-              'extractAndStripMeta: meta values must not be Promises ' +
-              '(no async / dynamic import allowed in meta literal)',
-            );
+            hasThenable = true;
+            return undefined;
           }
-          if (Array.isArray(value)) {
+          if (arrayIsArray(value)) {
             const out = [];
-            for (let i = 0; i < value.length; i++) out.push(copy(value[i]));
-            active.delete(value);
+            for (let i = 0; i < value.length; i++) {
+              apply(arrayPush, out, [copy(value[i])]);
+            }
+            apply(weakSetDelete, active, [value]);
             return out;
           }
-          const out = Object.create(null);
-          for (const key of Object.keys(value)) out[key] = copy(value[key]);
-          active.delete(value);
+          const out = objectCreate(null);
+          const keys = objectKeys(value);
+          for (let i = 0; i < keys.length; i++) {
+            const key = keys[i];
+            out[key] = copy(value[key]);
+          }
+          apply(weakSetDelete, active, [value]);
           return out;
         }
-        return JSON.stringify(copy((${metaSource})));
+        const value = copy((${metaSource}));
+        return jsonStringify({ hasThenable, value });
       })()`,
     ).runInContext(metaContext, { timeout: META_EVAL_TIMEOUT_MS });
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
+  } catch {
+    evaluationFailed = true;
+  } finally {
+    stopTrackingPromises();
+  }
+  if (evaluationFailed) {
     throw new Error(
-      `extractAndStripMeta: failed to evaluate meta object literal: ${msg}`,
+      'extractAndStripMeta: failed to evaluate meta object literal',
     );
   }
-  const raw = JSON.parse(serialized as string) as unknown;
-  const meta = validateMeta(raw);
+  const result = JSON.parse(serialized as string) as {
+    hasThenable: boolean;
+    value: unknown;
+  };
+  if (result.hasThenable) {
+    throw new Error(
+      'extractAndStripMeta: meta values must not be Promises ' +
+        '(no async / dynamic import allowed in meta literal)',
+    );
+  }
+  const meta = validateMeta(result.value);
   return { stripped, meta };
 }
 
@@ -338,6 +387,7 @@ function isRegexContext(source: string, i: number): boolean {
 }
 
 import * as vm from 'node:vm';
+import { promiseHooks } from 'node:v8';
 import { createDebugLogger } from '../../utils/debugLogger.js';
 import type { WorkflowDispatchScheduler } from './workflow-dispatch-scheduler.js';
 

--- a/packages/core/src/agents/runtime/workflow-sandbox.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.ts
@@ -155,13 +155,14 @@ export interface WorkflowMeta {
  * Implementation:
  *   1. `findMetaBlockBounds` (shared with `stripExportMeta`) locates the
  *      object-literal source range via the brace-walker.
- *   2. The literal source is evaluated as `(${metaSource})` inside a fresh
+ *   2. The literal source is evaluated and copied inside a fresh
  *      vm context whose globalThis is a null-prototyped object — no
  *      bridge to the host realm, no access to host primitives like
  *      `process` / `require` / the workflow-sandbox bridge globals
- *      (`args` / `agent` / `phase` / `log` / etc.), and bounded by
- *      `META_EVAL_TIMEOUT_MS` so a field value that never returns cannot
- *      wedge the caller. The vm realm DOES
+ *      (`args` / `agent` / `phase` / `log` / etc.). Evaluation, accessor
+ *      reads, thenable rejection, and copying are all bounded by
+ *      `META_EVAL_TIMEOUT_MS`, so model-authored code cannot run later in
+ *      the host realm and wedge the caller. The vm realm DOES
  *      provide its own intrinsics (`Object`, `Array`, `Math`, `Date`,
  *      `JSON`, …) which is fine: meta extraction is a one-shot at tool-
  *      invocation time, not replayed during resume, so non-determinism in
@@ -195,77 +196,48 @@ export function extractAndStripMeta(source: string): {
   // provides its own intrinsics, but that's intentional — see the
   // docstring above.
   const metaContext = vm.createContext(Object.create(null));
-  let raw: unknown;
+  let serialized: unknown;
   try {
-    raw = new vm.Script(`(${metaSource})`).runInContext(metaContext, {
-      timeout: META_EVAL_TIMEOUT_MS,
-    });
+    serialized = new vm.Script(
+      `(() => {
+        const active = new WeakSet();
+        function copy(value) {
+          if (value === null || ['string', 'number', 'boolean'].includes(typeof value)) {
+            return value;
+          }
+          if (typeof value !== 'object') return undefined;
+          if (active.has(value)) return undefined;
+          active.add(value);
+          if (typeof value.then === 'function') {
+            try { value.catch(() => {}); } catch {}
+            throw new Error(
+              'extractAndStripMeta: meta values must not be Promises ' +
+              '(no async / dynamic import allowed in meta literal)',
+            );
+          }
+          if (Array.isArray(value)) {
+            const out = [];
+            for (let i = 0; i < value.length; i++) out.push(copy(value[i]));
+            active.delete(value);
+            return out;
+          }
+          const out = Object.create(null);
+          for (const key of Object.keys(value)) out[key] = copy(value[key]);
+          active.delete(value);
+          return out;
+        }
+        return JSON.stringify(copy((${metaSource})));
+      })()`,
+    ).runInContext(metaContext, { timeout: META_EVAL_TIMEOUT_MS });
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     throw new Error(
       `extractAndStripMeta: failed to evaluate meta object literal: ${msg}`,
     );
   }
-
-  // P4a R3 (wenshao): a Promise (e.g. `import('node:fs')`) used as a
-  // value in the meta literal would otherwise leave a dangling rejection
-  // behind — `runInContext` returns synchronously with the Promise scheduled
-  // to reject on the next tick, validateMeta drops the non-contract field
-  // silently, and the run completes successfully. Then Node's default
-  // `--unhandled-rejections=throw` terminates the host process, decoupled
-  // from the run that triggered it. Walk `raw`, neutralise any thenables
-  // with `.catch(() => {})` so the rejection is marked handled, and reject
-  // the meta literal up front.
-  rejectThenablesInMeta(raw);
-
+  const raw = JSON.parse(serialized as string) as unknown;
   const meta = validateMeta(raw);
   return { stripped, meta };
-}
-
-/**
- * Recursively scan a vm-eval'd value, marking any thenable as handled
- * (so its rejection cannot terminate the host on the next tick) and
- * throwing an explicit "meta values must not be Promises" so the
- * malformed meta is reported clearly.
- *
- * Recurses through plain objects and arrays — `phases[]` entries may
- * embed an `import()` below the top level.
- */
-function rejectThenablesInMeta(
-  value: unknown,
-  seen: WeakSet<object> = new WeakSet(),
-): void {
-  if (value === null || typeof value !== 'object') return;
-  // P4 Round 4 (wenshao): a cyclic meta literal built via spread of a
-  // self-referential object would otherwise overflow the call stack on
-  // this walk — the walker exists to reject Promises before they leave
-  // a dangling rejection, but the walk itself must terminate on any
-  // shape vm-eval can return. Track visited nodes in a WeakSet so cycles
-  // and shared subgraphs both early-return without re-walking.
-  if (seen.has(value as object)) return;
-  seen.add(value as object);
-  const maybeThen = (value as { then?: unknown }).then;
-  if (typeof maybeThen === 'function') {
-    // Mark handled so Node's unhandled-rejection trap does not later kill
-    // the process. `.catch` on a non-Promise thenable would synchronously
-    // throw if the implementation is non-standard, so swallow defensively.
-    try {
-      (value as Promise<unknown>).catch(() => {});
-    } catch {
-      /* non-standard thenable — already rejecting below */
-    }
-    throw new Error(
-      'extractAndStripMeta: meta values must not be Promises ' +
-        '(no async / dynamic import allowed in meta literal)',
-    );
-  }
-  if (Array.isArray(value)) {
-    for (const v of value) rejectThenablesInMeta(v, seen);
-    return;
-  }
-  for (const v of Object.values(value as Record<string, unknown>)) {
-    rejectThenablesInMeta(v, seen);
-  }
 }
 
 /**
@@ -389,8 +361,8 @@ const ARGS_MAX_DEPTH = 64;
 // loop that would otherwise wedge the calling thread with no way out.
 // Generous for a contract object whose fields are strings and small arrays;
 // tight enough that a wedge surfaces as a normal malformed-meta error.
-// Callers evaluate meta on interactive paths (tool confirmation, saved-workflow
-// enumeration), so this must never be unbounded.
+// Meta is evaluated at the top of sandbox.run() before the run's watchdog is
+// armed, so this must never be unbounded.
 const META_EVAL_TIMEOUT_MS = 250;
 
 /**

--- a/packages/core/src/agents/runtime/workflow-sandbox.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.ts
@@ -159,7 +159,9 @@ export interface WorkflowMeta {
  *      vm context whose globalThis is a null-prototyped object — no
  *      bridge to the host realm, no access to host primitives like
  *      `process` / `require` / the workflow-sandbox bridge globals
- *      (`args` / `agent` / `phase` / `log` / etc.). The vm realm DOES
+ *      (`args` / `agent` / `phase` / `log` / etc.), and bounded by
+ *      `META_EVAL_TIMEOUT_MS` so a field value that never returns cannot
+ *      wedge the caller. The vm realm DOES
  *      provide its own intrinsics (`Object`, `Array`, `Math`, `Date`,
  *      `JSON`, …) which is fine: meta extraction is a one-shot at tool-
  *      invocation time, not replayed during resume, so non-determinism in
@@ -195,7 +197,9 @@ export function extractAndStripMeta(source: string): {
   const metaContext = vm.createContext(Object.create(null));
   let raw: unknown;
   try {
-    raw = new vm.Script(`(${metaSource})`).runInContext(metaContext);
+    raw = new vm.Script(`(${metaSource})`).runInContext(metaContext, {
+      timeout: META_EVAL_TIMEOUT_MS,
+    });
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     throw new Error(
@@ -378,6 +382,16 @@ const MAX_PHASE_ENTRIES = 10_000;
 // Max nesting depth for args; defends against stack-overflow on deeply
 // nested model-authored input.
 const ARGS_MAX_DEPTH = 64;
+
+// Wall-clock bound on evaluating the `meta` object literal. The literal is
+// model-authored source, and an IIFE in a field value
+// (`{ name: (function(){ while(true){} })() }`) is a synchronous infinite
+// loop that would otherwise wedge the calling thread with no way out.
+// Generous for a contract object whose fields are strings and small arrays;
+// tight enough that a wedge surfaces as a normal malformed-meta error.
+// Callers evaluate meta on interactive paths (tool confirmation, saved-workflow
+// enumeration), so this must never be unbounded.
+const META_EVAL_TIMEOUT_MS = 250;
 
 /**
  * WorkflowAgentOpts — structured options for the `agent()` global.


### PR DESCRIPTION
## What this PR does

Bounds the vm evaluation of a workflow script's `meta` block with a 250ms timeout, so a field value that never returns surfaces as the ordinary malformed-meta error instead of wedging the process.

## Why it's needed

`extractAndStripMeta` evaluates the `export const meta = {...}` object literal inside a fresh vm realm to recover the workflow's name, description and phases. The realm is well fenced — null-prototyped `globalThis`, no host bridge, no `process` or `require` — but the evaluation itself is unbounded. A literal whose field value is a synchronous infinite loop, for example `{ name: (function () { while (true) {} })(), description: 'd' }`, never returns.

Because the loop is synchronous it blocks the event loop outright, so this is not merely a slow call: no timer fires, no signal handler runs, and nothing left in-process can cancel it. The meta literal is model-authored source, which makes an accidental non-terminating expression a realistic failure rather than only an adversarial one.

Today the blast radius is limited, because the only caller evaluates meta inside `sandbox.run` — after the user has already approved the run, and where a wedge at least corresponds to a run the user started. That is the part about to change. Two natural follow-ups both move this call somewhere a hang is unrecoverable: rendering the workflow's name and phases in the tool-confirmation dialog would hang the TUI *before* the user has consented to anything, and reading each saved workflow's description for the slash-command palette would hang startup with no run to abort. Bounding the evaluation first makes those paths safe to build on, and it is worth doing on its own merits regardless of whether they land.

250ms is generous for a contract object whose fields are strings and small arrays, and tight enough that a wedge is reported promptly. A timeout is thrown from the same `try` that already wraps the evaluation, so it degrades through the existing malformed-meta path with no new failure mode for callers to handle.

## Reviewer Test Plan

### How to verify

Run the sandbox suite: `cd packages/core && npx vitest run src/agents/runtime/workflow-sandbox.test.ts` — 150 passed. The full workflow runtime plus the Workflow tool: `npx vitest run src/agents/runtime/ src/tools/workflow/` — 621 passed, 6 skipped.

Two tests are added. The first asserts that a meta field containing a non-terminating IIFE throws the malformed-meta error and completes well inside a generous bound, rather than hanging; the second pins that a well-formed meta literal is unaffected by the timeout.

To see the pre-fix behaviour directly, run this against `main` — it never prints, because the synchronous loop blocks the event loop and even the watchdog timer cannot fire:

```
node -e 'const vm=require("vm"); setTimeout(()=>console.log("would print if the loop were escapable"),2000); new vm.Script("({ name: (function(){while(true){}})() })").runInContext(vm.createContext(Object.create(null)));'
```

### Evidence (Before & After)

N/A — no user-visible or TUI change. This is a robustness fix in the workflow sandbox.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ✅   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

Unit tests only, Node 22.23.0 on Linux.

## Risk & Scope

- Main risk or tradeoff: a meta literal that legitimately needs more than 250ms to evaluate would now be rejected. No such literal is plausible — the contract fields are strings and small arrays of `{ title }` objects, and the realm has no I/O to wait on — but the constant is named and commented so it is easy to revisit if one ever appears.
- Not validated / out of scope: this does not change the fence around the meta realm, the set of intrinsics it exposes, or anything about the script body's own execution. It also does not add a timeout to any other vm call.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

给 workflow 脚本 `meta` 块的 vm 求值加上 250ms 超时，这样一个永不返回的字段值会以常规的 meta 格式错误暴露出来，而不是把进程卡死。

## 为什么需要

`extractAndStripMeta` 会在一个全新的 vm realm 里对 `export const meta = {...}` 对象字面量求值，以取出 workflow 的 name、description 和 phases。这个 realm 的隔离做得很好——`globalThis` 是 null 原型、没有 host bridge、拿不到 `process` 和 `require`——但求值本身没有任何上界。如果某个字段值是一个同步死循环，例如 `{ name: (function () { while (true) {} })(), description: 'd' }`，它永远不会返回。

因为这个循环是同步的，它会直接阻塞事件循环，所以这不只是"调用变慢"：定时器不会触发，信号处理器不会运行，进程内没有任何东西能取消它。meta 字面量是模型编写的源码，因此一个意外写出的不终止表达式是现实中会发生的故障，而不仅仅是对抗性构造。

目前影响范围有限，因为唯一的调用方是在 `sandbox.run` 内部求值 meta 的——此时用户已经批准了这次运行，卡死至少还对应着一次用户主动发起的 run。而这一点即将改变。两个自然的后续改动都会把这个调用挪到"卡死即不可恢复"的位置：在工具确认对话框里渲染 workflow 的名称和阶段，会在用户**尚未**授权任何东西之前就把 TUI 卡死；为斜杠命令面板读取每个已保存 workflow 的描述，则会在没有任何 run 可中止的情况下卡死启动过程。先把求值加上边界，才能让这些路径可以安全地在其之上构建；而且即便那些改动最终没有落地，这个修复本身也是值得做的。

250ms 对一个字段只有字符串和小数组的契约对象来说很宽松，同时又足够紧，能让卡死被及时报告。超时异常从已经包裹求值的同一个 `try` 中抛出，因此它会走既有的 meta 格式错误路径降级，不会给调用方带来需要额外处理的新失败模式。

## 审阅者验证方案

### 如何验证

运行 sandbox 测试：`cd packages/core && npx vitest run src/agents/runtime/workflow-sandbox.test.ts`——150 项通过。完整的 workflow 运行时加 Workflow 工具：`npx vitest run src/agents/runtime/ src/tools/workflow/`——621 项通过、6 项跳过。

新增了两个测试。第一个断言：含有不终止 IIFE 的 meta 字段会抛出 meta 格式错误，并在一个宽松的时限内远早于超时完成，而不是卡住；第二个则固定住"格式正确的 meta 字面量不受该超时影响"这一行为。

想直接看到修复前的行为，可以在 `main` 上运行下面这行——它永远不会打印任何东西，因为同步循环阻塞了事件循环，连看门狗定时器都无法触发：

```
node -e 'const vm=require("vm"); setTimeout(()=>console.log("would print if the loop were escapable"),2000); new vm.Script("({ name: (function(){while(true){}})() })").runInContext(vm.createContext(Object.create(null)));'
```

### 证据（前后对比）

N/A——没有用户可见或 TUI 层面的变化。这是 workflow sandbox 内部的健壮性修复。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ✅   |

### 环境（可选）

仅单元测试，Linux 上的 Node 22.23.0。

## 风险与范围

- 主要风险或取舍：一个确实需要超过 250ms 才能求值完成的 meta 字面量现在会被拒绝。这种字面量在现实中不太可能出现——契约字段只有字符串和 `{ title }` 小对象数组，而且该 realm 里没有任何 I/O 可等待——但这个常量已经命名并加了注释，一旦真的出现也很容易调整。
- 未验证 / 不在范围内：本 PR 不改变 meta realm 的隔离边界、它暴露的 intrinsics 集合，也不改变脚本主体自身执行的任何行为。它同样没有给其他任何 vm 调用加超时。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
