### PR TITLE
fix(cli): close three review-comment gaps from the #9027 CI review

### DIFF
--- a/packages/cli/src/commands/review/lib/authorization.ts
+++ b/packages/cli/src/commands/review/lib/authorization.ts
@@ -110,11 +110,19 @@ export function reviewWriteAuthorization(req: WriteAuthorizationRequest): {
   } catch {
     // No args file means no arguments — which means no `--comment`. Fail
     // closed: a missing authorisation record is not an absent objection.
+    // The wording must not send a setting-driven operator to type a flag
+    // they never needed: with `review.comment` on, the real blocker is that
+    // no recorded invocation names a pull request to bind the write to, and
+    // a plain re-run of the review fixes that — typing `--comment` does not.
     return {
       ok: false,
       why:
-        `no review arguments were recorded at ${path}, so this run cannot ` +
-        'show that `--comment` was requested',
+        req.defaultComment === true
+          ? `no review arguments were recorded at ${path}, so no recorded ` +
+            'invocation names a pull request to bind this write to — re-run ' +
+            'the review naming the pull request'
+          : `no review arguments were recorded at ${path}, so this run ` +
+            'cannot show that `--comment` was requested',
     };
   }
 

--- a/packages/cli/src/commands/review/parse-args.test.ts
+++ b/packages/cli/src/commands/review/parse-args.test.ts
@@ -399,6 +399,20 @@ describe('parseReviewArgs — settings-provided defaults', () => {
     expect(got.warnings.some((w) => w.includes('review.comment'))).toBe(true);
   });
 
+  it('a flag-forced high names the flag in the forcing warning, not the setting', () => {
+    // The flag branch of the same ternary: with no setting enabled, the
+    // warning must not send the operator hunting a setting that is off.
+    const got = parseReviewArgs('6711 --comment --effort low');
+    expect(got.effort).toBe('high');
+    expect(got.effortSource).toBe('forced-by-comment');
+    expect(got.warnings).toContain(
+      '`--comment` requires a verified review; running at high effort.',
+    );
+    expect(
+      got.warnings.some((w) => w.includes('`review.comment` is enabled')),
+    ).toBe(false);
+  });
+
   it('the standing comment setting stays inert on a local target', () => {
     const got = parseReviewArgs('', { comment: true });
     expect(got.comment.effective).toBe(false);
@@ -569,6 +583,10 @@ describe('parseReviewArgs — repeated --effort warnings state what is actually 
     const invalidWarning = got.warnings.find((w) => w.includes('"typo"'));
     expect(invalidWarning).toContain('forces high effort');
     expect(invalidWarning).not.toContain('default');
+    // The flag drove the forcing — the resolution must name the flag, not a
+    // setting that is off (both branches contain 'forces high effort').
+    expect(invalidWarning).toContain('`--comment` forces high effort');
+    expect(invalidWarning).not.toContain('review.comment');
   });
 
   it('with no valid occurrence anywhere the warning still says the default applies', () => {

--- a/packages/cli/src/commands/review/publish-assets.test.ts
+++ b/packages/cli/src/commands/review/publish-assets.test.ts
@@ -48,8 +48,9 @@ vi.mock('../../utils/stdioHelpers.js', () => ({
 
 // The handler resolves `review.comment` through `operatorReviewSettings` —
 // pin the view it reads so the wiring leg below does not depend on the
-// running developer's settings.json. The refusal assertions call
-// runPublishAssets directly and never touch this mock.
+// running developer's settings.json. The direct refusal assertions call
+// runPublishAssets and never touch this mock; the handler-path tests below
+// do.
 const reviewSettingsMock = vi.hoisted(() =>
   vi.fn((): Record<string, unknown> => ({})),
 );
@@ -61,9 +62,10 @@ vi.mock('../../config/settings.js', async (importOriginal) => {
     // The production call carries `{ skipWorkspaceSettings: true }` — the
     // authorisation default resolves from operator scopes only. A caller that
     // forgets the flag reads the workspace-polluted view instead; the guards
-    // that redden are submit.test.ts's handler-level refusal test and
-    // review-settings.test.ts's direct assertion. This file's own refusals
-    // bypass the handler, so only the wiring leg below exercises the mock.
+    // that redden are submit.test.ts's handler-level refusal test,
+    // review-settings.test.ts's direct assertion, and this file's
+    // handler-level refusal test. The direct runPublishAssets refusals
+    // bypass the handler.
     loadSettings: vi.fn((...callArgs: unknown[]) => {
       const opts = callArgs[1] as
         | { skipWorkspaceSettings?: boolean }

--- a/packages/cli/src/commands/review/publish-assets.test.ts
+++ b/packages/cli/src/commands/review/publish-assets.test.ts
@@ -166,6 +166,25 @@ describe('publish-assets', () => {
     } as never);
   }
 
+  // The handler-path counterpart of run(): every handler-level leg calls
+  // this, so the yargs-facing argument shape lives in exactly one place and
+  // a one-leg-only edit (a renamed key silenced by the `as never` cast) is
+  // structurally impossible.
+  async function runHandler(
+    overrides: Record<string, unknown> = {},
+  ): Promise<void> {
+    await publishAssetsCommand.handler?.({
+      _: [],
+      $0: 'qwen',
+      pr: 8346,
+      files: [pngFile('a.png')],
+      out: join(dir, 'manifest.json'),
+      'user-authorized': false,
+      'skill-args': argsFile,
+      ...overrides,
+    } as never);
+  }
+
   it('refuses without a designated repo — exit 3, nothing written', () => {
     delete process.env['QWEN_REVIEW_ASSETS_REPO'];
     run({ files: [pngFile('a.png')] });
@@ -219,15 +238,7 @@ describe('publish-assets', () => {
     writeFileSync(argsFile, '8346\n'); // no --comment
     reviewSettingsMock.mockReturnValue({ comment: true });
     happyGh();
-    await publishAssetsCommand.handler?.({
-      _: [],
-      $0: 'qwen',
-      pr: 8346,
-      files: [pngFile('wired.png')],
-      out: join(dir, 'manifest.json'),
-      'user-authorized': false,
-      'skill-args': argsFile,
-    } as never);
+    await runHandler({ files: [pngFile('wired.png')] });
     expect(process.exitCode).toBeUndefined();
     expect(ghWithInputMock).toHaveBeenCalled();
   });
@@ -242,15 +253,7 @@ describe('publish-assets', () => {
     writeFileSync(argsFile, '8346\n'); // no --comment
     reviewSettingsMock.mockReturnValue({}); // setting off
     happyGh();
-    await publishAssetsCommand.handler?.({
-      _: [],
-      $0: 'qwen',
-      pr: 8346,
-      files: [pngFile('refused.png')],
-      out: join(dir, 'manifest.json'),
-      'user-authorized': false,
-      'skill-args': argsFile,
-    } as never);
+    await runHandler({ files: [pngFile('refused.png')] });
     expect(process.exitCode).toBe(3);
     expect(ghWithInputMock).not.toHaveBeenCalled();
     expect(ghMock).not.toHaveBeenCalled();

--- a/packages/cli/src/commands/review/publish-assets.test.ts
+++ b/packages/cli/src/commands/review/publish-assets.test.ts
@@ -230,6 +230,30 @@ describe('publish-assets', () => {
     expect(ghWithInputMock).toHaveBeenCalled();
   });
 
+  it('the handler refuses when neither flag nor setting authorises — the polluted view must not decide', async () => {
+    // The refusal counterpart of the wiring leg above: setting off, no
+    // `--comment` in the recorded arguments. If the handler's loadSettings
+    // call drops `skipWorkspaceSettings`, the workspace-polluted mock view
+    // answers comment:true and this refusal becomes a publish — the exact
+    // regression review-settings.ts documents (a repository-controlled
+    // .qwen/settings.json deciding to publish for every reviewer).
+    writeFileSync(argsFile, '8346\n'); // no --comment
+    reviewSettingsMock.mockReturnValue({}); // setting off
+    happyGh();
+    await publishAssetsCommand.handler?.({
+      _: [],
+      $0: 'qwen',
+      pr: 8346,
+      files: [pngFile('refused.png')],
+      out: join(dir, 'manifest.json'),
+      'user-authorized': false,
+      'skill-args': argsFile,
+    } as never);
+    expect(process.exitCode).toBe(3);
+    expect(ghWithInputMock).not.toHaveBeenCalled();
+    expect(ghMock).not.toHaveBeenCalled();
+  });
+
   it('publishes, writes a manifest with commit-pinned URLs', () => {
     happyGh();
     const f = pngFile('evidence.png');

--- a/packages/cli/src/commands/review/submit.test.ts
+++ b/packages/cli/src/commands/review/submit.test.ts
@@ -248,7 +248,7 @@ describe('authorization — URL-shaped host and repo binding at the submit call 
       skillArgs: missing,
       pr: 123,
       repo: 'o/r',
-    } as never;
+    };
 
     const bySetting = reviewWriteAuthorization({
       ...base,

--- a/packages/cli/src/commands/review/submit.test.ts
+++ b/packages/cli/src/commands/review/submit.test.ts
@@ -236,6 +236,34 @@ describe('authorization — URL-shaped host and repo binding at the submit call 
       '`--comment` was not in the review arguments',
     );
   });
+
+  it('a missing args file names the missing invocation, not a missing flag, when the setting authorises', () => {
+    // With `review.comment` on, telling the operator to re-run with
+    // `--comment` misdirects: the blocker is that no recorded invocation
+    // names a PR, and a plain re-run fixes it. Flag-driven operators keep
+    // the flag wording — for them the flag IS the missing piece.
+    const missing = join(dir, 'no-such-args.txt');
+    const base = {
+      userAuthorized: false,
+      skillArgs: missing,
+      pr: 123,
+      repo: 'o/r',
+    } as never;
+
+    const bySetting = reviewWriteAuthorization({
+      ...base,
+      defaultComment: true,
+    });
+    expect(bySetting.ok).toBe(false);
+    expect(bySetting.why).toContain(
+      'no recorded invocation names a pull request',
+    );
+    expect(bySetting.why).not.toContain('`--comment`');
+
+    const byFlag = reviewWriteAuthorization(base);
+    expect(byFlag.ok).toBe(false);
+    expect(byFlag.why).toContain('cannot show that `--comment` was requested');
+  });
 });
 
 describe('the posting gate', () => {

--- a/packages/cli/src/commands/review/submit.test.ts
+++ b/packages/cli/src/commands/review/submit.test.ts
@@ -400,6 +400,7 @@ describe('the posting gate', () => {
     );
     expect(advice()).not.toContain('Re-run with `--comment`');
     expect(advice()).toContain('invoked naming it');
+    expect(advice()).toContain('Nothing recorded authorises binding');
     writeStderrSpy.mockClear();
 
     // ...or a different PR than this submission targets.
@@ -410,6 +411,17 @@ describe('the posting gate', () => {
     );
     expect(advice()).not.toContain('Re-run with `--comment`');
     expect(advice()).toContain('invoked naming it');
+    writeStderrSpy.mockClear();
+
+    // Nothing recorded at all, with the setting authorising: the refusal
+    // names the missing invocation, and the advice preamble must not
+    // contradict it by presupposing recorded arguments exist.
+    runSubmit(args({ skillArgs: join(dir, 'advice-missing.txt') }), 'unknown', {
+      defaultComment: true,
+    });
+    expect(advice()).toContain('no recorded invocation names a pull request');
+    expect(advice()).toContain('Nothing recorded authorises binding');
+    expect(advice()).not.toContain('The recorded arguments');
     expect(ghMock).not.toHaveBeenCalled();
     expect(process.exitCode).toBe(3);
   });

--- a/packages/cli/src/commands/review/submit.test.ts
+++ b/packages/cli/src/commands/review/submit.test.ts
@@ -263,6 +263,19 @@ describe('authorization — URL-shaped host and repo binding at the submit call 
     const byFlag = reviewWriteAuthorization(base);
     expect(byFlag.ok).toBe(false);
     expect(byFlag.why).toContain('cannot show that `--comment` was requested');
+
+    // Both production callers pass a strict boolean (destructured default /
+    // the resolved setting), so pin the flag branch with the explicit false
+    // they actually send — a presence-check mutation of the ternary must not
+    // survive.
+    const byFlagExplicit = reviewWriteAuthorization({
+      ...base,
+      defaultComment: false,
+    });
+    expect(byFlagExplicit.ok).toBe(false);
+    expect(byFlagExplicit.why).toContain(
+      'cannot show that `--comment` was requested',
+    );
   });
 });
 

--- a/packages/cli/src/commands/review/submit.ts
+++ b/packages/cli/src/commands/review/submit.ts
@@ -432,18 +432,22 @@ export function runSubmit(
     // report, and the user can ask for them to be posted.
     // The advice must match the refusal class, or it misdirects the retry:
     // the gate refuses either because comment was never requested (its `why`
-    // carries `` `--comment` was ``) or because the recorded arguments do not
-    // bind this target. `--comment` cannot fix the second class — the flag
-    // stands in for nothing a target binding needs, and the `review.comment`
-    // setting already stood in for the flag on exactly those refusals — so
-    // advising it there buys the futile retry loop authorization.ts's refusal
-    // wording exists to prevent.
+    // carries `` `--comment` was ``) or because nothing recorded authorises
+    // this target — a binding miss, or no recorded arguments at all. The
+    // second arm's preamble stays neutral ("Nothing recorded…") because a
+    // setting-driven missing-args refusal lands here too, and "The recorded
+    // arguments do not bind" would contradict its `why` ("no review
+    // arguments were recorded"). `--comment` cannot fix the second class —
+    // the flag stands in for nothing a target binding needs, and the
+    // `review.comment` setting already stood in for the flag on exactly
+    // those refusals — so advising it there buys the futile retry loop
+    // authorization.ts's refusal wording exists to prevent.
     const advice = auth.why.includes('`--comment` was')
       ? `This is the correct outcome of a review the user did not ask to ` +
         `publish — report the findings in the terminal and stop. Re-run with ` +
         `\`--comment\`, or pass --user-authorized only after the user has ` +
         `asked, in a message they typed, for this review to be published.`
-      : `The recorded arguments do not bind this target — report the ` +
+      : `Nothing recorded authorises binding this target — report the ` +
         `findings in the terminal and stop. Posting to this pull request ` +
         `needs a review invoked naming it, or --user-authorized after the ` +
         `user has asked, in a message they typed, for this review to be ` +


### PR DESCRIPTION
## What this PR does

Follow-ups to three Suggestion-level findings from #9027's CI review, all landed on files that belonged to the now-merged #8994:

- **Regime-aware refusal wording.** When `review.comment` authorises the run and the args record is missing, the refusal no longer says "cannot show that `--comment` was requested" — the real blocker is that no recorded invocation names a pull request to bind the write to, and a plain re-run of the review fixes it, while typing `--comment` does not. Flag-driven operators keep the flag wording, and the refusal-advice selection routes the new message to the binding remedy.
- **A handler-path refusal test for the operator-scope invariant.** The publish-assets suite previously pinned the `skipWorkspaceSettings` flag only through a success case whose mock returned the same value as the polluted view. The new test runs the handler with the setting off and no `--comment` in the recorded arguments, expecting exit code 3 and no gh call; dropping the scope flag turns the refusal into a publish (mutation-verified).
- **Symmetric pins for the flag branch of the forcing ternaries.** A flag-forced high effort now has positive and negative assertions on both the forcing warning and the resolution text, so collapsing either ternary to the setting-only message reddens the suite (mutation-verified).

## Why it's needed

Each gap lets a specific misdirection or regression ship silently: an operator told to type a flag they never needed; a repository-controlled workspace settings file deciding to publish evidence for every reviewer; a warning that sends the operator hunting a setting that is off.

## Reviewer Test Plan

### How to verify

- Run the review command suites (`cd packages/cli && npx vitest run src/commands/review/submit.test.ts src/commands/review/publish-assets.test.ts src/commands/review/parse-args.test.ts`) — the new cases pin both regimes.
- To see the refusal wording directly: with `review.comment: true` in user settings and no recorded args, `qwen review submit` refuses naming the missing invocation rather than a missing flag.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

## Risk & Scope

- Main risk or tradeoff: none user-facing beyond refusal text; the only behavior change is wording in a refusal path and added test coverage.
- Not validated / out of scope: the R2-3 linearity-guard tightening from the same review was superseded by the bounded-strip version already on main.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to review findings on #9027 (files from #8994).

<details>
<summary>中文说明</summary>

本 PR 处理 #9027 CI review 的三条 Suggestion 级发现，涉及文件均来自已合并的 #8994：

- **拒绝措辞区分授权模式。**当 `review.comment` 设置授权运行而 args 记录缺失时，拒绝理由不再说"无法证明请求了 `--comment`"——真正的阻塞是没有任何记录了 PR 的调用可供绑定写入目标，重新运行评审即可解决，键入 `--comment` 并不能。旗标驱动的用户保留旗标措辞，拒绝建议的选择逻辑会把新文案路由到绑定类补救措施。
- **operator-scope 不变量的 handler 路径拒绝测试。**publish-assets 套件此前只通过一个 mock 返回值与污染视图相同的成功用例间接覆盖 `skipWorkspaceSettings` 旗标。新测试在设置关闭、args 无 `--comment` 时运行 handler，断言退出码 3 且未调用 gh；去掉该旗标会让拒绝变成发布（已变异验证）。
- **强制提级三元表达式旗标分支的对称断言。**旗标强制 high 时，强制警告和 resolution 文案都有正负断言，折叠任一三元表达式为仅设置分支文案都会使套件变红（已变异验证）。

动机：每个缺口都让一种具体的误导或回归悄悄上线——告诉运营者键入一个他们从未需要的旗标；仓库可控的 workspace 设置文件为每个评审者决定发布证据；警告让运营者去排查一个并未开启的设置。

验证：`cd packages/cli && npx vitest run src/commands/review/submit.test.ts src/commands/review/publish-assets.test.ts src/commands/review/parse-args.test.ts` 全绿；三条修复均做了变异验证（去掉被钉的机制后新测试变红）。

</details>
