### PR TITLE
feat(core): inject request metadata for alicloudapi.com gateways

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
@@ -246,6 +246,39 @@ describe('DashScopeOpenAICompatibleProvider', () => {
       expect(result).toBe(true);
     });
 
+    it('should return true for alicloudapi.com subdomain', () => {
+      const config = {
+        authType: AuthType.USE_OPENAI,
+        baseUrl: 'https://api-id.cn-hangzhou.alicloudapi.com/v1',
+      } as ContentGeneratorConfig;
+
+      const result =
+        DashScopeOpenAICompatibleProvider.isDashScopeProvider(config);
+      expect(result).toBe(true);
+    });
+
+    it('should return true for port-bearing alicloudapi.com URL', () => {
+      const config = {
+        authType: AuthType.USE_OPENAI,
+        baseUrl: 'https://gateway.alicloudapi.com:8443/v1',
+      } as ContentGeneratorConfig;
+
+      const result =
+        DashScopeOpenAICompatibleProvider.isDashScopeProvider(config);
+      expect(result).toBe(true);
+    });
+
+    it('should return false for bare alicloudapi.com domain', () => {
+      const config = {
+        authType: AuthType.USE_OPENAI,
+        baseUrl: 'https://alicloudapi.com/v1',
+      } as ContentGeneratorConfig;
+
+      const result =
+        DashScopeOpenAICompatibleProvider.isDashScopeProvider(config);
+      expect(result).toBe(false);
+    });
+
     it('should return false for bare alibaba-inc.com domain', () => {
       const config = {
         authType: AuthType.USE_OPENAI,
@@ -276,6 +309,8 @@ describe('DashScopeOpenAICompatibleProvider', () => {
         'https://aliyun-inc.com.evil.com/v1',
         'https://not-token-plan.cn-beijing.maas.aliyuncs.com/v1',
         'https://token-plan.cn-beijing.maas.aliyuncs.com.evil.com/v1',
+        'https://notalicloudapi.com/v1',
+        'https://alicloudapi.com.evil.com/v1',
       ];
 
       configs.forEach((baseUrl) => {

--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
@@ -17,6 +17,7 @@ import {
   DashScopeOpenAICompatibleProvider,
   selectDashScopeThinkingKnob,
 } from './dashscope.js';
+import { determineProvider } from '../index.js';
 import type { Config } from '../../../config/config.js';
 import type { ContentGeneratorConfig } from '../../contentGenerator.js';
 import { AuthType } from '../../contentGenerator.js';
@@ -255,6 +256,9 @@ describe('DashScopeOpenAICompatibleProvider', () => {
       const result =
         DashScopeOpenAICompatibleProvider.isDashScopeProvider(config);
       expect(result).toBe(true);
+      expect(mockDebugLogger.debug).toHaveBeenCalledWith(
+        'DashScope provider activated via alicloudapi origin: api-id.cn-hangzhou.alicloudapi.com',
+      );
     });
 
     it('should return true for port-bearing alicloudapi.com URL', () => {
@@ -472,6 +476,42 @@ describe('DashScopeOpenAICompatibleProvider', () => {
       const result =
         DashScopeOpenAICompatibleProvider.isDashScopeProvider(config);
       expect(result).toBe(true);
+    });
+  });
+
+  // Guards the full acceptance path end-to-end: an alicloudapi.com base URL
+  // must route through the DashScope provider so buildRequest injects the
+  // session-tracking metadata into the request body.
+  describe('determineProvider routing for alicloudapi.com', () => {
+    const alicloudapiConfig = {
+      authType: AuthType.USE_OPENAI,
+      baseUrl: 'https://api-id.cn-hangzhou.alicloudapi.com/v1',
+      model: 'qwen-max',
+    } as ContentGeneratorConfig;
+
+    it('routes alicloudapi.com base URLs to the DashScope provider', () => {
+      const routed = determineProvider(alicloudapiConfig, mockCliConfig);
+      expect(routed).toBeInstanceOf(DashScopeOpenAICompatibleProvider);
+    });
+
+    it('injects session-tracking metadata into the request body', () => {
+      const routed = determineProvider(
+        alicloudapiConfig,
+        mockCliConfig,
+      ) as DashScopeOpenAICompatibleProvider;
+
+      const result = routed.buildRequest(
+        {
+          model: 'qwen-max',
+          messages: [{ role: 'user', content: 'Hello!' }],
+        },
+        'test-prompt-id',
+      );
+
+      expect(result.metadata).toEqual({
+        sessionId: 'test-session-id',
+        promptId: 'test-prompt-id',
+      });
     });
   });
 

--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
@@ -252,6 +252,12 @@ export class DashScopeOpenAICompatibleProvider extends DefaultOpenAICompatiblePr
       );
     }
 
+    if (isAliCloudApiOrigin) {
+      debugLogger.debug(
+        `DashScope provider activated via alicloudapi origin: ${hostname}`,
+      );
+    }
+
     return (
       isDashscopeOrigin ||
       isTokenPlanOrigin ||

--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
@@ -170,6 +170,7 @@ export class DashScopeOpenAICompatibleProvider extends DefaultOpenAICompatiblePr
    * Covers the official regional hosts (DASHSCOPE_REGIONAL_HOSTS),
    * Token Plan endpoints under token-plan.<region>.maas.aliyuncs.com,
    * internal Alibaba domains (*.alibaba-inc.com, *.aliyun-inc.com),
+   * Alibaba Cloud API Gateway domains (*.alicloudapi.com),
    * and proxy matches.
    *
    * Note: any *.alibaba-inc.com / *.aliyun-inc.com host is treated as a
@@ -217,6 +218,11 @@ export class DashScopeOpenAICompatibleProvider extends DefaultOpenAICompatiblePr
       (hostname.endsWith('.alibaba-inc.com') ||
         hostname.endsWith('.aliyun-inc.com'));
 
+    // Alibaba Cloud API Gateway domains proxying to DashScope-compatible
+    // APIs. Covers *.alicloudapi.com.
+    const isAliCloudApiOrigin =
+      hostname !== null && hostname.endsWith('.alicloudapi.com');
+
     // Check if proxy is configured and matches
     const normalizedProxyUrl = DASHSCOPE_PROXY_BASE_URL?.endsWith('/')
       ? DASHSCOPE_PROXY_BASE_URL.slice(0, -1)
@@ -232,6 +238,7 @@ export class DashScopeOpenAICompatibleProvider extends DefaultOpenAICompatiblePr
       !isDashscopeOrigin &&
       !isTokenPlanOrigin &&
       !isInternalOrigin &&
+      !isAliCloudApiOrigin &&
       !isProxyMatch
     ) {
       debugLogger.debug(
@@ -246,7 +253,11 @@ export class DashScopeOpenAICompatibleProvider extends DefaultOpenAICompatiblePr
     }
 
     return (
-      isDashscopeOrigin || isTokenPlanOrigin || isInternalOrigin || isProxyMatch
+      isDashscopeOrigin ||
+      isTokenPlanOrigin ||
+      isInternalOrigin ||
+      isAliCloudApiOrigin ||
+      isProxyMatch
     );
   }
 


### PR DESCRIPTION
## What this PR does

Recognizes `*.alicloudapi.com` (Alibaba Cloud API Gateway) as a DashScope-compatible origin, so that model requests sent through such a gateway include the `metadata` field in the request body — `sessionId`, `promptId`, and `channel` when configured — exactly like requests to the official DashScope hosts and internal Alibaba domains already do.

## Why it's needed

qwen-code injects a request-body `metadata` field used for session tracing and log correlation only when the endpoint is recognized as DashScope-compatible. When the model API is accessed through an Alibaba Cloud API Gateway domain (`*.alicloudapi.com`), the provider falls back to the default OpenAI-compatible path, which omits `metadata`. This breaks session tracking and log correlation for those requests.

## Reviewer Test Plan

### How to verify

Run the focused provider tests:

```bash
cd packages/core && npx vitest run src/core/openaiContentGenerator/provider/dashscope.test.ts
```

Confirm the new `alicloudapi.com` cases pass: subdomain and port-bearing URLs are recognized, the bare domain and lookalike domains are rejected.

### Evidence (Before & After)

N/A — non-user-visible change (request-body field for a new domain).

Test output:

- `dashscope.test.ts`: 151 passed (5 new assertions for `alicloudapi.com`)
- `pipeline.test.ts`: 153 passed (unaffected)
- `tsc --noEmit` (core): clean
- `eslint` on the two changed files: clean

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

Unit tests only (`npm ci` in a clean worktree, Node v22).

## Risk & Scope

- Main risk or tradeoff: `*.alicloudapi.com` is a public gateway where arbitrary APIs can be deployed, so treating it as DashScope-compatible applies DashScope headers, cache control, and `metadata` to every request under that domain. This is the same trust posture already applied to `*.alibaba-inc.com` and `*.aliyun-inc.com`.
- Not validated / out of scope: the bare `alicloudapi.com` domain is deliberately not matched — gateway endpoints are subdomains, consistent with the existing bare-domain rejection for internal Alibaba domains.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #9101

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

将 `*.alicloudapi.com`（阿里云 API 网关）识别为 DashScope 兼容来源，使通过该网关发送的模型请求在请求体中携带 `metadata` 字段——包括 `sessionId`、`promptId` 以及（配置了时的）`channel`——与发送到 DashScope 官方主机和阿里内部域名时一致。

## 为什么需要

qwen-code 仅在端点被识别为 DashScope 兼容时，才会在请求体中注入用于会话追踪和日志关联的 `metadata` 字段。当模型 API 通过阿里云 API 网关域名（`*.alicloudapi.com`）访问时，provider 会回退到默认的 OpenAI 兼容路径，从而不携带 `metadata`，导致这些请求的会话追踪和日志关联中断。

## 评审验证方式

### 如何验证

运行聚焦的 provider 测试：

```bash
cd packages/core && npx vitest run src/core/openaiContentGenerator/provider/dashscope.test.ts
```

确认新增的 `alicloudapi.com` 用例通过：子域名和带端口 URL 被识别，裸域名和仿冒域名被拒绝。

### 证据（Before & After）

N/A —— 非用户可见改动（针对新域名的请求体字段）。

测试输出：

- `dashscope.test.ts`：151 通过（含 5 个 `alicloudapi.com` 新增断言）
- `pipeline.test.ts`：153 通过（无影响）
- `tsc --noEmit`（core）：通过
- 两个改动文件的 `eslint`：通过

### 测试环境

|     系统     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

仅单元测试（干净 worktree 中 `npm ci`，Node v22）。

## 风险与范围

- 主要风险或权衡：`*.alicloudapi.com` 是公开网关，任意 API 都可能部署其上，因此将其视为 DashScope 兼容会对该域名下的所有请求应用 DashScope 头、缓存控制和 `metadata`。这与已经应用于 `*.alibaba-inc.com` 和 `*.aliyun-inc.com` 的信任姿态一致。
- 未验证 / 超出范围：裸域名 `alicloudapi.com` 有意不匹配——网关端点是子域名，与现有对阿里内部裸域名的拒绝行为保持一致。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #9101

</details>
