### PR TITLE
test(desktop): pin sidebar scrollbar gutter

### DIFF
--- a/packages/desktop/apps/electron/src/renderer/components/app-shell/__tests__/WorkspaceProjectTree.scrollbar.test.ts
+++ b/packages/desktop/apps/electron/src/renderer/components/app-shell/__tests__/WorkspaceProjectTree.scrollbar.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'bun:test'
+
+const here = dirname(fileURLToPath(import.meta.url))
+
+describe('WorkspaceProjectTree scrollbar gutter', () => {
+  it('reserves scrollbar space on the project list scroll container', () => {
+    const component = readFileSync(
+      resolve(here, '../WorkspaceProjectTree.tsx'),
+      'utf8',
+    )
+    const css = readFileSync(resolve(here, '../../../index.css'), 'utf8')
+
+    expect(component).toContain('mask-fade-bottom scrollbar-stable')
+    expect(css).toContain('.scrollbar-stable')
+    expect(css).toContain('scrollbar-gutter: stable')
+  })
+})


### PR DESCRIPTION
## What this PR does

Adds a focused Bun regression test that pins the Electron workspace project list's stable scrollbar gutter behavior introduced in #9073.

## Why it's needed

The production fix from #9073 is already on main, but its follow-up regression test was pushed to the old branch after that PR merged and therefore did not land. This PR carries only that missing test.

## Reviewer Test Plan

### How to verify

Run `bun test src/renderer/components/app-shell/__tests__/WorkspaceProjectTree.scrollbar.test.ts` from `packages/desktop/apps/electron`. The test should pass and should fail if either the project list loses the `scrollbar-stable` class or the stable gutter CSS declaration is removed.

### Evidence (Before & After)

N/A — test-only change with no user-visible behavior change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Bun 1.3.14 on macOS; focused test passed with 1 test and 3 assertions.

## Risk & Scope

- Main risk or tradeoff: Minimal; the test reads the existing component and stylesheet source to pin the regression fix.
- Not validated / out of scope: No desktop UI behavior was changed or re-tested manually; Windows and Linux rely on CI.
- Breaking changes / migration notes: None.

## Linked Issues

Follow-up to #9073.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

新增一个聚焦的 Bun 回归测试，用于固定 #9073 引入的 Electron 工作区项目列表稳定滚动条占位行为。

## 为什么需要

#9073 的生产修复已经进入 main，但后续回归测试是在该 PR 合并后才推送到旧分支，因此没有随之落地。本 PR 只带回这一个缺失测试。

## Reviewer Test Plan

### 如何验证

在 `packages/desktop/apps/electron` 目录运行 `bun test src/renderer/components/app-shell/__tests__/WorkspaceProjectTree.scrollbar.test.ts`。测试应通过；如果项目列表移除 `scrollbar-stable` 类，或稳定滚动条占位的 CSS 声明被删除，测试应失败。

### 证据（前后对比）

不适用——仅测试变更，没有用户可见行为变化。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|     🍏 macOS      |  ✅  |
|    🪟 Windows     |  ⚠️  |
|     🐧 Linux      |  ⚠️  |

### 环境（可选）

macOS 上使用 Bun 1.3.14；聚焦测试通过，共 1 个测试、3 个断言。

## 风险与范围

- 主要风险或权衡：很小；测试读取现有组件和样式表源码，以固定该回归修复。
- 未验证 / 范围外：没有修改或手动复测桌面 UI 行为；Windows 和 Linux 依赖 CI。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

#9073 的后续补充。

</details>
